### PR TITLE
Create build system for alpha/common

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,40 @@
+cmake_minimum_required(VERSION 3.14)
+
+# Set the project name.
+project(Alpha)
+
+set(CMAKE_CXX_STANDARD 20)
+set(CMAKE_CXX_STANDARD_REQUIRED True)
+
+# Use ThirdPartyToolchain dependencies macros from Velox.
+list(PREPEND CMAKE_MODULE_PATH "${PROJECT_SOURCE_DIR}/velox/CMake")
+include(ResolveDependency)
+
+set(VELOX_BUILD_MINIMAL ON CACHE BOOL "Velox minimal build.")
+
+message(STATUS "Build type: ${CMAKE_BUILD_TYPE}")
+message("FINAL CMAKE_CXX_FLAGS=${CMAKE_CXX_FLAGS}")
+
+include(CTest) # include after project() but before add_subdirectory()
+
+set_source(gtest)
+resolve_dependency(gtest)
+
+set_source(glog)
+resolve_dependency(glog)
+
+set_source(gflags)
+resolve_dependency(gflags COMPONENTS shared)
+
+set_source(folly)
+resolve_dependency(folly)
+
+# Use xxhash and xsimd from Velox for now.
+include_directories(.)
+include_directories(SYSTEM velox)
+include_directories(SYSTEM velox/velox/external/xxhash)
+include_directories(SYSTEM ${CMAKE_BINARY_DIR}/_deps/xsimd-src/include/)
+
+# TODO - compile only Velox submodule and alpha/common
+add_subdirectory(velox)
+add_subdirectory(dwio/alpha/common)

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,60 @@
+.PHONY: all cmake build clean debug release unit
+
+BUILD_BASE_DIR=_build
+BUILD_DIR=release
+BUILD_TYPE=Release
+
+CMAKE_FLAGS := -DCMAKE_BUILD_TYPE=$(BUILD_TYPE)
+
+# Use Ninja if available. If Ninja is used, pass through parallelism control flags.
+USE_NINJA ?= 1
+ifeq ($(USE_NINJA), 1)
+ifneq ($(shell which ninja), )
+GENERATOR := -GNinja
+
+# Ninja makes compilers disable colored output by default.
+GENERATOR += -DVELOX_FORCE_COLORED_OUTPUT=ON
+endif
+endif
+
+ifndef USE_CCACHE
+ifneq ($(shell which ccache), )
+USE_CCACHE=-DCMAKE_CXX_COMPILER_LAUNCHER=ccache
+endif
+endif
+
+NUM_THREADS ?= $(shell getconf _NPROCESSORS_CONF 2>/dev/null || echo 1)
+CPU_TARGET ?= "avx"
+
+all: release			#: Build the release version
+
+clean:					#: Delete all build artifacts
+	rm -rf $(BUILD_BASE_DIR)
+
+cmake:					#: Use CMake to create a Makefile build system
+	mkdir -p $(BUILD_BASE_DIR)/$(BUILD_DIR) && \
+	cmake -B \
+		"$(BUILD_BASE_DIR)/$(BUILD_DIR)" \
+		${CMAKE_FLAGS} \
+		$(GENERATOR) \
+		$(USE_CCACHE) \
+		${EXTRA_CMAKE_FLAGS}
+
+build:					#: Build the software based in BUILD_DIR and BUILD_TYPE variables
+	cmake --build $(BUILD_BASE_DIR)/$(BUILD_DIR) -j $(NUM_THREADS)
+
+debug:					#: Build with debugging symbols
+	$(MAKE) cmake BUILD_DIR=debug BUILD_TYPE=Debug
+	$(MAKE) build BUILD_DIR=debug -j ${NUM_THREADS}
+
+release:				#: Build the release version
+	$(MAKE) cmake BUILD_DIR=release BUILD_TYPE=Release && \
+	$(MAKE) build BUILD_DIR=release
+
+unittest: debug			#: Build with debugging and run unit tests
+	cd $(BUILD_BASE_DIR)/debug && ctest -j ${NUM_THREADS} -VV --output-on-failure
+
+help:					#: Show the help messages
+	@cat $(firstword $(MAKEFILE_LIST)) | \
+	awk '/^[-a-z]+:/' | \
+	awk -F: '{ printf("%-20s   %s\n", $$1, $$NF) }'

--- a/dwio/alpha/common/CMakeLists.txt
+++ b/dwio/alpha/common/CMakeLists.txt
@@ -1,0 +1,14 @@
+add_subdirectory(tests)
+
+add_library(
+  alpha_common
+  Bits.cpp
+  Checksum.cpp
+  FixedBitArray.cpp
+  Huffman.cpp
+  MetricsLogger.cpp
+  StopWatch.cpp
+  Types.cpp
+  Varint.cpp)
+
+target_link_libraries(alpha_common velox_memory Folly::folly)

--- a/dwio/alpha/common/tests/CMakeLists.txt
+++ b/dwio/alpha/common/tests/CMakeLists.txt
@@ -1,0 +1,21 @@
+add_executable(
+  alpha_common_tests
+  BitEncoderTests.cpp
+  BitsTests.cpp
+  ExceptionTests.cpp
+  FixedBitArrayTests.cpp
+  HuffmanTests.cpp
+  IndexMapTests.cpp
+  StopWatchTests.cpp
+  VarintTests.cpp
+  VectorTests.cpp)
+
+add_test(alpha_common_tests alpha_common_tests)
+
+target_link_libraries(
+  alpha_common_tests
+  alpha_common
+  gtest
+  gtest_main
+  glog::glog
+  Folly::folly)


### PR DESCRIPTION
Adding a first sketch for an open source cmake-based build system for Alpha. For now it only compiles alpha/common, and requires a few internal dependencies to be commented out first.
In the next PRs I'll clean them up.