### PR TITLE
Fixes to CMake open source build system

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,8 +11,18 @@ list(PREPEND CMAKE_MODULE_PATH "${PROJECT_SOURCE_DIR}/velox/CMake")
 include(ResolveDependency)
 
 set(VELOX_BUILD_MINIMAL ON CACHE BOOL "Velox minimal build.")
+set(VELOX_DEPENDENCY_SOURCE
+  AUTO
+  CACHE
+  STRING
+  "Default dependency source: AUTO SYSTEM or BUNDLED."
+)
 
 message(STATUS "Build type: ${CMAKE_BUILD_TYPE}")
+
+# Ignore known compiler warnings.
+set(KNOWN_WARNINGS "-Wno-stringop-overread")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${KNOWN_WARNINGS}")
 message("FINAL CMAKE_CXX_FLAGS=${CMAKE_CXX_FLAGS}")
 
 include(CTest) # include after project() but before add_subdirectory()

--- a/dwio/alpha/common/CMakeLists.txt
+++ b/dwio/alpha/common/CMakeLists.txt
@@ -7,7 +7,6 @@ add_library(
   FixedBitArray.cpp
   Huffman.cpp
   MetricsLogger.cpp
-  StopWatch.cpp
   Types.cpp
   Varint.cpp)
 

--- a/dwio/alpha/common/tests/CMakeLists.txt
+++ b/dwio/alpha/common/tests/CMakeLists.txt
@@ -6,7 +6,6 @@ add_executable(
   FixedBitArrayTests.cpp
   HuffmanTests.cpp
   IndexMapTests.cpp
-  StopWatchTests.cpp
   VarintTests.cpp
   VectorTests.cpp)
 


### PR DESCRIPTION
Three fixes:
* Setting default dependency source as AUTO (tries to find locally, bundles if not found).
* Adds flag to ignore existing folly compiler warning.
* Removes StopWatch.cpp and its tests from CMake, since it relies on an internal library and is not used anywhere in Alpha today.

With this change, CMake builds successfully (though they only compile alpha/common today).