### PR TITLE
Add cmake for dwio/alpha/encodings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,8 +22,17 @@ set(VELOX_DEPENDENCY_SOURCE
 message(STATUS "Build type: ${CMAKE_BUILD_TYPE}")
 
 # Ignore known compiler warnings.
-set(KNOWN_WARNINGS "-Wno-stringop-overread")
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${KNOWN_WARNINGS}")
+check_cxx_compiler_flag("-Wstringop-overread" COMPILER_HAS_W_STRINGOP_OVERREAD)
+if(COMPILER_HAS_W_STRINGOP_OVERREAD)
+  string(APPEND CMAKE_CXX_FLAGS " -Wno-stringop-overread")
+endif()
+
+check_cxx_compiler_flag("-Wdeprecated-declarations"
+                        COMPILER_HAS_W_DEPRECATED_DECLARATIONS)
+if(COMPILER_HAS_W_DEPRECATED_DECLARATIONS)
+  string(APPEND CMAKE_CXX_FLAGS " -Wno-deprecated-declarations")
+endif()
+
 message("FINAL CMAKE_CXX_FLAGS=${CMAKE_CXX_FLAGS}")
 
 include(CTest) # include after project() but before add_subdirectory()
@@ -54,3 +63,5 @@ include_directories(SYSTEM ${CMAKE_BINARY_DIR}/_deps/xsimd-src/include/)
 add_subdirectory(velox)
 add_subdirectory(dwio/alpha/common)
 add_subdirectory(dwio/alpha/tablet)
+add_subdirectory(dwio/alpha/tools)
+add_subdirectory(dwio/alpha/encodings)

--- a/dwio/alpha/encodings/CMakeLists.txt
+++ b/dwio/alpha/encodings/CMakeLists.txt
@@ -1,0 +1,15 @@
+add_subdirectory(tests)
+
+add_library(
+  alpha_encodings
+  Compression.cpp
+  Encoding.cpp
+  EncodingFactoryNew.cpp
+  EncodingLayout.cpp
+  EncodingLayoutCapture.cpp
+  RleEncoding.cpp
+  SparseBoolEncoding.cpp
+  Statistics.cpp
+  TrivialEncoding.cpp)
+
+target_link_libraries(alpha_encodings Folly::folly)

--- a/dwio/alpha/encodings/tests/CMakeLists.txt
+++ b/dwio/alpha/encodings/tests/CMakeLists.txt
@@ -1,0 +1,22 @@
+add_executable(
+  alpha_encodings_tests
+  ConstantEncodingTests.cpp
+  EncodingLayoutTests.cpp
+  EncodingSelectionTests.cpp
+  EncodingTestsNew.cpp
+  MainlyConstantEncodingTests.cpp
+  NullableEncodingTests.cpp
+  RleEncodingTests.cpp
+  SentinelEncodingTests.cpp
+  StatisticsTests.cpp)
+
+add_test(alpha_encodings_tests alpha_encodings_tests)
+
+target_link_libraries(
+  alpha_encodings_tests
+  alpha_encodings
+  alpha_common
+  alpha_tools_common
+  gtest
+  gtest_main
+  Folly::folly)

--- a/dwio/alpha/tools/CMakeLists.txt
+++ b/dwio/alpha/tools/CMakeLists.txt
@@ -1,0 +1,3 @@
+add_library(alpha_tools_common EncodingUtilities.cpp)
+
+target_link_libraries(alpha_tools_common alpha_common alpha_tablet)


### PR DESCRIPTION
Compiling encodings, tests, and a small library needed within alpha/tools. Also adding some flags to ignore existing compiler warning in library dependencies.