### PR TITLE
Force Makefile to resolve submodules

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,6 +33,13 @@ if(COMPILER_HAS_W_DEPRECATED_DECLARATIONS)
   string(APPEND CMAKE_CXX_FLAGS " -Wno-deprecated-declarations")
 endif()
 
+check_cxx_compiler_flag("-Wmaybe-uninitialized"
+                        COMPILER_HAS_W_MAYBE_UNINITIALIZED)
+if(COMPILER_HAS_W_MAYBE_UNINITIALIZED)
+  string(APPEND CMAKE_CXX_FLAGS " -Wno-maybe-uninitialized")
+endif()
+
+
 message("FINAL CMAKE_CXX_FLAGS=${CMAKE_CXX_FLAGS}")
 
 include(CTest) # include after project() but before add_subdirectory()
@@ -59,7 +66,6 @@ include_directories(SYSTEM velox)
 include_directories(SYSTEM velox/velox/external/xxhash)
 include_directories(SYSTEM ${CMAKE_BINARY_DIR}/_deps/xsimd-src/include/)
 
-# TODO - compile only Velox submodule and alpha/common
 add_subdirectory(velox)
 add_subdirectory(dwio/alpha/common)
 add_subdirectory(dwio/alpha/tablet)

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: all cmake build clean debug release unit
+.PHONY: all cmake build clean debug release unit submodules
 
 BUILD_BASE_DIR=_build
 BUILD_DIR=release
@@ -31,7 +31,11 @@ all: release			#: Build the release version
 clean:					#: Delete all build artifacts
 	rm -rf $(BUILD_BASE_DIR)
 
-cmake:					#: Use CMake to create a Makefile build system
+submodules:
+	git submodule sync --recursive
+	git submodule update --init --recursive
+
+cmake: submodules  #: Use CMake to create a Makefile build system
 	mkdir -p $(BUILD_BASE_DIR)/$(BUILD_DIR) && \
 	cmake -B \
 		"$(BUILD_BASE_DIR)/$(BUILD_DIR)" \


### PR DESCRIPTION
Adding rule to Makefile to automatically resolve submodules when compiling. Also adding logic to skip clang's "-Wmaybe-uninitialized" warning, triggered from within folly.