### PR TITLE
Add cmake support for abseil

### DIFF
--- a/CMake/abseil.cmake
+++ b/CMake/abseil.cmake
@@ -1,0 +1,21 @@
+include_guard(GLOBAL)
+
+# TODO: these variables are named VELOX_* because we are piggy-backing on 
+# Velox's resolve dependency module for now. We should change and have 
+# our own in the future.
+set(VELOX_ABSEIL_VERSION 20240116.0)
+set(VELOX_ABSEIL_BUILD_SHA256_CHECKSUM
+    "338420448b140f0dfd1a1ea3c3ce71b3bc172071f24f4d9a57d59b45037da440")
+set(VELOX_ABSEIL_SOURCE_URL
+  "https://github.com/abseil/abseil-cpp/archive/refs/tags/${VELOX_ABSEIL_VERSION}.tar.gz")
+
+resolve_dependency_url(ABSEIL)
+
+message(STATUS "Building abseil from source")
+
+FetchContent_Declare(
+  abseil
+  URL ${VELOX_ABSEIL_SOURCE_URL}
+  URL_HASH ${VELOX_ABSEIL_BUILD_SHA256_CHECKSUM})
+
+FetchContent_MakeAvailable(abseil)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,6 +6,14 @@ project(Alpha)
 set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED True)
 
+# Sets new behavior for CMP0135, which controls how timestamps are extracted
+# when using ExternalProject_Add():
+# https://cmake.org/cmake/help/latest/policy/CMP0135.html
+if(POLICY CMP0135)
+  cmake_policy(SET CMP0135 NEW)
+  set(CMAKE_POLICY_DEFAULT_CMP0135 NEW)
+endif()
+
 # Use ThirdPartyToolchain dependencies macros from Velox.
 list(PREPEND CMAKE_MODULE_PATH "${PROJECT_SOURCE_DIR}/CMake"
      "${PROJECT_SOURCE_DIR}/velox/CMake")
@@ -39,7 +47,6 @@ if(COMPILER_HAS_W_MAYBE_UNINITIALIZED)
   string(APPEND CMAKE_CXX_FLAGS " -Wno-maybe-uninitialized")
 endif()
 
-
 message("FINAL CMAKE_CXX_FLAGS=${CMAKE_CXX_FLAGS}")
 
 include(CTest) # include after project() but before add_subdirectory()
@@ -59,6 +66,9 @@ resolve_dependency(gflags COMPONENTS shared)
 
 set_source(folly)
 resolve_dependency(folly)
+
+set_source(abseil)
+resolve_dependency(abseil)
 
 # Use xxhash and xsimd from Velox for now.
 include_directories(.)

--- a/dwio/alpha/encodings/CMakeLists.txt
+++ b/dwio/alpha/encodings/CMakeLists.txt
@@ -12,4 +12,4 @@ add_library(
   Statistics.cpp
   TrivialEncoding.cpp)
 
-target_link_libraries(alpha_encodings Folly::folly)
+target_link_libraries(alpha_encodings Folly::folly absl::flat_hash_map)


### PR DESCRIPTION
Adding resolve_dependency() module for abseil, and ensure it builds
dwio/alpha/encodings. Also adding a cmake policy override to omit cmake
warning.
