### PR TITLE
Add alpha/velox to cmake build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,6 +20,7 @@ list(PREPEND CMAKE_MODULE_PATH "${PROJECT_SOURCE_DIR}/CMake"
 include(ResolveDependency)
 
 set(VELOX_BUILD_MINIMAL ON CACHE BOOL "Velox minimal build.")
+set(VELOX_BUILD_DWIO ON CACHE BOOL "Velox dwio build.")
 set(VELOX_DEPENDENCY_SOURCE
   AUTO
   CACHE
@@ -45,6 +46,18 @@ check_cxx_compiler_flag("-Wmaybe-uninitialized"
                         COMPILER_HAS_W_MAYBE_UNINITIALIZED)
 if(COMPILER_HAS_W_MAYBE_UNINITIALIZED)
   string(APPEND CMAKE_CXX_FLAGS " -Wno-maybe-uninitialized")
+endif()
+
+check_cxx_compiler_flag("-Wunknown-warning-option"
+                        COMPILER_HAS_W_UNKNOWN_WARNING_OPTION)
+if(COMPILER_HAS_W_UNKNOWN_WARNING_OPTION)
+  string(APPEND CMAKE_CXX_FLAGS " -Wno-unknown-warning-option")
+endif()
+
+check_cxx_compiler_flag("-Wnullability-completeness"
+                        COMPILER_HAS_W_NULLABILITY_COMPLETENESS)
+if(COMPILER_HAS_W_NULLABILITY_COMPLETENESS)
+  string(APPEND CMAKE_CXX_FLAGS " -Wno-nullability-completeness")
 endif()
 
 message("FINAL CMAKE_CXX_FLAGS=${CMAKE_CXX_FLAGS}")
@@ -81,3 +94,4 @@ add_subdirectory(dwio/alpha/common)
 add_subdirectory(dwio/alpha/tablet)
 add_subdirectory(dwio/alpha/tools)
 add_subdirectory(dwio/alpha/encodings)
+add_subdirectory(dwio/alpha/velox)

--- a/dwio/alpha/common/tests/CMakeLists.txt
+++ b/dwio/alpha/common/tests/CMakeLists.txt
@@ -1,3 +1,8 @@
+add_library(alpha_common_file_writer AlphaFileWriter.cpp)
+
+target_link_libraries(alpha_common_file_writer alpha_common alpha_velox_writer
+                      velox_vector)
+
 add_executable(
   alpha_common_tests
   BitEncoderTests.cpp

--- a/dwio/alpha/velox/CMakeLists.txt
+++ b/dwio/alpha/velox/CMakeLists.txt
@@ -1,0 +1,92 @@
+# TODO - fix linkage problems with tests.
+#add_subdirectory(tests)
+
+add_library(alpha_velox_common SchemaUtils.cpp)
+target_link_libraries(alpha_velox_common alpha_common velox_type)
+
+add_library(alpha_velox_schema SchemaTypes.cpp)
+target_link_libraries(alpha_velox_schema alpha_common Folly::folly)
+
+add_library(alpha_velox_schema_reader SchemaReader.cpp)
+target_link_libraries(alpha_velox_schema_reader alpha_velox_schema alpha_common Folly::folly)
+
+add_library(alpha_velox_schema_builder SchemaBuilder.cpp)
+target_link_libraries(
+  alpha_velox_schema_builder
+  alpha_velox_schema_reader
+  alpha_velox_schema
+  alpha_common
+  Folly::folly)
+
+add_library(alpha_velox_config Config.cpp)
+target_link_libraries(alpha_velox_config alpha_encodings alpha_common Folly::folly)
+
+add_library(alpha_velox_field_reader FieldReader.cpp)
+target_link_libraries(alpha_velox_field_reader alpha_velox_schema_reader
+                      alpha_common Folly::folly)  #velox_dwio_common Folly::folly)
+
+add_library(alpha_velox_flatmap_layout_planner FlatMapLayoutPlanner.cpp)
+target_link_libraries(alpha_velox_flatmap_layout_planner
+                      alpha_velox_schema_reader alpha_tablet velox_file)
+
+add_library(alpha_velox_field_writer BufferGrowthPolicy.cpp FieldWriter.cpp)
+target_link_libraries(alpha_velox_field_writer
+                      alpha_velox_schema alpha_velox_schema_builder Folly::folly)
+
+# Alpha code expects an upper case suffix to the generated file.
+list(PREPEND FLATBUFFERS_FLATC_SCHEMA_EXTRA_ARGS "--filename-suffix" "Generated")
+
+build_flatbuffers(
+  "${CMAKE_CURRENT_SOURCE_DIR}/Schema.fbs"
+  ""
+  alpha_velox_schema_schema_fb
+  ""
+  "${CMAKE_CURRENT_BINARY_DIR}"
+  ""
+  "")
+add_library(alpha_velox_schema_fb INTERFACE)
+target_include_directories(alpha_velox_schema_fb INTERFACE ${FLATBUFFERS_INCLUDE_DIR})
+add_dependencies(alpha_velox_schema_fb alpha_velox_schema_schema_fb)
+
+build_flatbuffers(
+  "${CMAKE_CURRENT_SOURCE_DIR}/Metadata.fbs"
+  ""
+  alpha_velox_metadata_schema_fb
+  ""
+  "${CMAKE_CURRENT_BINARY_DIR}"
+  ""
+  "")
+add_library(alpha_velox_metadata_fb INTERFACE)
+target_include_directories(alpha_velox_metadata_fb INTERFACE ${FLATBUFFERS_INCLUDE_DIR})
+add_dependencies(alpha_velox_metadata_fb alpha_velox_metadata_schema_fb)
+
+add_library(alpha_velox_schema_serialization SchemaSerialization.cpp)
+target_link_libraries(
+  alpha_velox_schema_serialization
+  alpha_velox_schema_reader
+  alpha_velox_schema_builder
+  alpha_velox_schema_fb)
+
+add_library(alpha_velox_deserializer Deserializer.cpp)
+target_link_libraries(alpha_velox_deserializer alpha_common
+                      alpha_velox_field_reader velox_vector velox_memory)
+
+add_library(alpha_velox_serializer Serializer.cpp)
+target_link_libraries(alpha_velox_serializer alpha_common
+                      alpha_velox_schema_builder velox_vector)
+
+add_library(alpha_velox_reader
+            StreamInputDecoder.cpp StreamLabels.cpp VeloxReader.cpp)
+target_link_libraries(
+  alpha_velox_reader
+  alpha_velox_schema
+  alpha_velox_schema_serialization
+  alpha_velox_schema_fb
+  alpha_velox_metadata_fb
+  alpha_common
+  Folly::folly)
+
+add_library(alpha_velox_writer EncodingLayoutTree.cpp FlushPolicy.cpp
+            VeloxWriter.cpp VeloxWriterOptions.cpp)
+target_link_libraries(alpha_velox_writer alpha_encodings alpha_common
+                      alpha_velox_metadata_fb Folly::folly)

--- a/dwio/alpha/velox/tests/CMakeLists.txt
+++ b/dwio/alpha/velox/tests/CMakeLists.txt
@@ -1,0 +1,42 @@
+add_library(alpha_velox_schema_utils SchemaUtils.cpp)
+target_link_libraries(
+  alpha_velox_schema_utils
+  alpha_velox_schema_fb
+  alpha_velox_schema_builder
+  alpha_velox_schema_reader
+  gtest
+  gtest_main)
+
+add_executable(
+  alpha_velox_tests
+  BufferGrowthPolicyTest.cpp
+  EncodingLayoutTreeTests.cpp
+  FlatMapLayoutPlannerTests.cpp
+  OrderedRangesTests.cpp
+  SchemaTests.cpp
+  SerializationTests.cpp
+  TypeTests.cpp
+  VeloxReaderTests.cpp
+  VeloxWriterTests.cpp)
+add_test(alpha_velox_tests alpha_velox_tests)
+
+target_link_libraries(
+  alpha_velox_tests
+  alpha_velox_common
+  alpha_velox_schema_utils
+  alpha_velox_reader
+  alpha_velox_writer
+  alpha_velox_serializer
+  alpha_velox_deserializer
+  alpha_velox_field_writer
+  alpha_velox_flatmap_layout_planner
+  alpha_common_file_writer
+  alpha_common
+  alpha_encodings
+  velox_vector
+  velox_vector_fuzzer
+  velox_dwio_common
+  gmock
+  gtest
+  gtest_main
+  Folly::folly)


### PR DESCRIPTION
Adding cmake files for compiling alpha/velox and tests under that folder. Tests are still disabled for now until other linkage problems are solved between Alpha and Velox.