### PR TITLE
Call unsafeResize in FlatMapReaders

### DIFF
--- a/dwio/alpha/velox/FieldReader.cpp
+++ b/dwio/alpha/velox/FieldReader.cpp
@@ -1701,7 +1701,7 @@ class StructFlatMapFieldReader : public FlatMapFieldReaderBase<T, hasNull> {
     ALPHA_ASSERT(scatterBitmap == nullptr, "unexpected scatterBitmap");
     auto vector = VectorInitializer<velox::RowVector>::initialize(
         &this->pool_, output, this->type_, rowCount);
-    vector->resize(rowCount);
+    vector->unsafeResize(rowCount);
     uint32_t nonNullCount = this->loadNulls(rowCount, vector);
 
     if (executor_) {


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebookincubator/velox/pull/8129

We need to call unsafeResize in the DWRF FlatMapReader.

Reviewed By: zzhao0

Differential Revision: D52339055


