### PR TITLE
Fix ExceptionTests.Verify after enabling -Waddress flag

### DIFF
--- a/dwio/alpha/common/tests/ExceptionTests.cpp
+++ b/dwio/alpha/common/tests/ExceptionTests.cpp
@@ -144,7 +144,7 @@ TEST(ExceptionTests, Assert) {
 TEST(ExceptionTests, Verify) {
   try {
     ALPHA_VERIFY_EXTERNAL(
-        "a" == "b",
+        1 == 2,
         LocalFileSystem,
         alpha::error_code::NotSupported,
         true,
@@ -156,7 +156,7 @@ TEST(ExceptionTests, Verify) {
         __FILE__,
         "",
         "TestBody",
-        "\"a\" == \"b\"",
+        "1 == 2",
         "error message3",
         "EXTERNAL",
         "NOT_SUPPORTED",


### PR DESCRIPTION
Summary:
-Waddress is about to be enabled, and it will cause a compilation error:
```
fbcode/dwio/alpha/common/tests/ExceptionTests.cpp:147:13: error: result of comparison against a string literal is unspecified (use an explicit string comparison function instead) [-Werror,-Wstring-compare]
        "a" == "b",
        ~~~ ^
```

Differential Revision: D55153584


