### PR TITLE
Selective Nimble reader skeleton

### DIFF
--- a/dwio/nimble/encodings/ConstantEncoding.h
+++ b/dwio/nimble/encodings/ConstantEncoding.h
@@ -46,6 +46,9 @@ class ConstantEncoding final
   void skip(uint32_t rowCount) final;
   void materialize(uint32_t rowCount, void* buffer) final;
 
+  template <typename DecoderVisitor>
+  void readWithVisitor(DecoderVisitor& visitor, ReadWithVisitorParams& params);
+
   static std::string_view encode(
       EncodingSelection<physicalType>& selection,
       std::span<const physicalType> values,
@@ -83,6 +86,15 @@ void ConstantEncoding<T>::materialize(uint32_t rowCount, void* buffer) {
   for (uint32_t i = 0; i < rowCount; ++i) {
     castBuffer[i] = value_;
   }
+}
+
+template <typename T>
+template <typename V>
+void ConstantEncoding<T>::readWithVisitor(
+    V& visitor,
+    ReadWithVisitorParams& params) {
+  this->template readWithVisitorSlow<false>(
+      visitor, params, [&] { return value_; });
 }
 
 template <typename T>

--- a/dwio/nimble/encodings/EncodingUtils.h
+++ b/dwio/nimble/encodings/EncodingUtils.h
@@ -1,0 +1,169 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include "dwio/nimble/encodings/ConstantEncoding.h"
+#include "dwio/nimble/encodings/DictionaryEncoding.h"
+#include "dwio/nimble/encodings/FixedBitWidthEncoding.h"
+#include "dwio/nimble/encodings/MainlyConstantEncoding.h"
+#include "dwio/nimble/encodings/NullableEncoding.h"
+#include "dwio/nimble/encodings/RleEncoding.h"
+#include "dwio/nimble/encodings/SparseBoolEncoding.h"
+#include "dwio/nimble/encodings/TrivialEncoding.h"
+#include "dwio/nimble/encodings/VarintEncoding.h"
+
+namespace facebook::nimble {
+
+template <typename F>
+auto encodingTypeDispatch(Encoding& encoding, F&& f);
+
+template <typename DecoderVisitor>
+void callReadWithVisitor(
+    Encoding& encoding,
+    DecoderVisitor& visitor,
+    ReadWithVisitorParams& params);
+
+namespace detail {
+
+template <template <typename D> typename E, typename F>
+auto encodingTypeDispatchNumeric(Encoding& encoding, F f) {
+  switch (encoding.dataType()) {
+    case DataType::Int8:
+      return f(static_cast<E<int8_t>&>(encoding));
+    case DataType::Uint8:
+      return f(static_cast<E<uint8_t>&>(encoding));
+    case DataType::Int16:
+      return f(static_cast<E<int16_t>&>(encoding));
+    case DataType::Uint16:
+      return f(static_cast<E<uint16_t>&>(encoding));
+    case DataType::Int32:
+      return f(static_cast<E<int32_t>&>(encoding));
+    case DataType::Uint32:
+      return f(static_cast<E<uint32_t>&>(encoding));
+    case DataType::Int64:
+      return f(static_cast<E<int64_t>&>(encoding));
+    case DataType::Uint64:
+      return f(static_cast<E<uint64_t>&>(encoding));
+    case DataType::Float:
+      return f(static_cast<E<float>&>(encoding));
+    case DataType::Double:
+      return f(static_cast<E<double>&>(encoding));
+    case DataType::Bool:
+      return f(static_cast<E<bool>&>(encoding));
+    default:
+      NIMBLE_NOT_SUPPORTED(toString(encoding.dataType()));
+  }
+}
+
+template <template <typename D> typename E, typename F>
+auto encodingTypeDispatchVarint(Encoding& encoding, F f) {
+  switch (encoding.dataType()) {
+    case DataType::Int32:
+      return f(static_cast<E<int32_t>&>(encoding));
+    case DataType::Uint32:
+      return f(static_cast<E<uint32_t>&>(encoding));
+    case DataType::Int64:
+      return f(static_cast<E<int64_t>&>(encoding));
+    case DataType::Uint64:
+      return f(static_cast<E<uint64_t>&>(encoding));
+    default:
+      NIMBLE_NOT_SUPPORTED(toString(encoding.dataType()));
+  }
+}
+
+template <typename F>
+auto encodingTypeDispatchString(Encoding& encoding, F f) {
+  switch (encoding.encodingType()) {
+    case EncodingType::Trivial:
+      return f(static_cast<TrivialEncoding<std::string_view>&>(encoding));
+    case EncodingType::RLE:
+      return f(static_cast<RLEEncoding<std::string_view>&>(encoding));
+    case EncodingType::Dictionary:
+      return f(static_cast<DictionaryEncoding<std::string_view>&>(encoding));
+    case EncodingType::Nullable:
+      return f(static_cast<NullableEncoding<std::string_view>&>(encoding));
+    case EncodingType::Constant:
+      return f(static_cast<ConstantEncoding<std::string_view>&>(encoding));
+    case EncodingType::MainlyConstant:
+      return f(
+          static_cast<MainlyConstantEncoding<std::string_view>&>(encoding));
+    default:
+      NIMBLE_NOT_SUPPORTED(toString(encoding.encodingType()));
+  }
+}
+
+template <typename F>
+auto encodingTypeDispatchNonString(Encoding& encoding, F&& f) {
+  switch (encoding.encodingType()) {
+    case EncodingType::Trivial:
+      return detail::encodingTypeDispatchNumeric<TrivialEncoding>(
+          encoding, std::forward<F>(f));
+    case EncodingType::RLE:
+      return detail::encodingTypeDispatchNumeric<RLEEncoding>(
+          encoding, std::forward<F>(f));
+    case EncodingType::Dictionary:
+      return detail::encodingTypeDispatchNumeric<DictionaryEncoding>(
+          encoding, std::forward<F>(f));
+    case EncodingType::FixedBitWidth:
+      return detail::encodingTypeDispatchNumeric<FixedBitWidthEncoding>(
+          encoding, std::forward<F>(f));
+    case EncodingType::Nullable:
+      return detail::encodingTypeDispatchNumeric<NullableEncoding>(
+          encoding, std::forward<F>(f));
+    case EncodingType::SparseBool:
+      return f(static_cast<SparseBoolEncoding&>(encoding));
+    case EncodingType::Varint:
+      return detail::encodingTypeDispatchVarint<VarintEncoding>(
+          encoding, std::forward<F>(f));
+    case EncodingType::Constant:
+      return detail::encodingTypeDispatchNumeric<ConstantEncoding>(
+          encoding, std::forward<F>(f));
+    case EncodingType::MainlyConstant:
+      return detail::encodingTypeDispatchNumeric<MainlyConstantEncoding>(
+          encoding, std::forward<F>(f));
+    default:
+      NIMBLE_NOT_SUPPORTED(toString(encoding.encodingType()));
+  }
+}
+
+} // namespace detail
+
+template <typename F>
+auto encodingTypeDispatch(Encoding& encoding, F&& f) {
+  if (encoding.dataType() == DataType::String) {
+    return detail::encodingTypeDispatchString(encoding, std::forward<F>(f));
+  } else {
+    return detail::encodingTypeDispatchNonString(encoding, std::forward<F>(f));
+  }
+}
+
+template <typename V>
+void callReadWithVisitor(
+    Encoding& encoding,
+    V& visitor,
+    ReadWithVisitorParams& params) {
+  if constexpr (std::is_same_v<typename V::DataType, folly::StringPiece>) {
+    detail::encodingTypeDispatchString(encoding, [&](auto& typedEncoding) {
+      typedEncoding.readWithVisitor(visitor, params);
+    });
+  } else {
+    detail::encodingTypeDispatchNonString(encoding, [&](auto& typedEncoding) {
+      typedEncoding.readWithVisitor(visitor, params);
+    });
+  }
+}
+
+} // namespace facebook::nimble

--- a/dwio/nimble/encodings/FixedBitWidthEncoding.h
+++ b/dwio/nimble/encodings/FixedBitWidthEncoding.h
@@ -60,6 +60,9 @@ class FixedBitWidthEncoding final
   void skip(uint32_t rowCount) final;
   void materialize(uint32_t rowCount, void* buffer) final;
 
+  template <typename DecoderVisitor>
+  void readWithVisitor(DecoderVisitor& visitor, ReadWithVisitorParams& params);
+
   static std::string_view encode(
       EncodingSelection<physicalType>& selection,
       std::span<const physicalType> values,
@@ -133,6 +136,15 @@ void FixedBitWidthEncoding<T>::materialize(uint32_t rowCount, void* buffer) {
     }
   }
   row_ += rowCount;
+}
+
+template <typename T>
+template <typename V>
+void FixedBitWidthEncoding<T>::readWithVisitor(
+    V& visitor,
+    ReadWithVisitorParams& params) {
+  this->template readWithVisitorSlow<true>(
+      visitor, params, [&] { return baseline_ + fixedBitArray_.get(row_++); });
 }
 
 template <typename T>

--- a/dwio/nimble/encodings/RleEncoding.h
+++ b/dwio/nimble/encodings/RleEncoding.h
@@ -103,6 +103,18 @@ class RLEEncodingBase
     }
   }
 
+  template <typename DecoderVisitor>
+  void readWithVisitor(DecoderVisitor& visitor, ReadWithVisitorParams& params) {
+    this->template readWithVisitorSlow<true>(visitor, params, [&] {
+      if (copiesRemaining_ == 0) {
+        copiesRemaining_ = materializedRunLengths_.nextValue();
+        currentValue_ = nextValue();
+      }
+      --copiesRemaining_;
+      return currentValue_;
+    });
+  }
+
   static std::string_view encode(
       EncodingSelection<physicalType>& selection,
       std::span<const physicalType> values,


### PR DESCRIPTION
Summary:
The first diff for Nimble selective reader.  Contains:
- Reader class and factory implementation
- All primitive type column readers (no dictionary) and struct column reader
- `ChuckedDecoder` to accept visitor and apply it on multiple chunks
- Basic simple implementation of `readWithVisitor` for all testable encodings
- Unit tests and randomized unit tests covering all primitive types and struct

Differential Revision: D57162138


