### PR TITLE
Add output size estimation in field readers

### DIFF
--- a/dwio/nimble/encodings/NullableEncoding.h
+++ b/dwio/nimble/encodings/NullableEncoding.h
@@ -51,6 +51,7 @@ class NullableEncoding final
 
   uint32_t nullCount() const final;
   bool isNullable() const final;
+  const Encoding* nonNulls() const;
 
   void reset() final;
   void skip(uint32_t rowCount) final;
@@ -109,6 +110,11 @@ NullableEncoding<T>::NullableEncoding(
 template <typename T>
 uint32_t NullableEncoding<T>::nullCount() const {
   return nulls_->rowCount() - nonNulls_->rowCount();
+}
+
+template <typename T>
+const Encoding* NullableEncoding<T>::nonNulls() const {
+  return nonNulls_.get();
 }
 
 template <typename T>

--- a/dwio/nimble/encodings/RleEncoding.h
+++ b/dwio/nimble/encodings/RleEncoding.h
@@ -144,7 +144,7 @@ class RLEEncodingBase
     return {reserved, encodingSize};
   }
 
-  const char* getValuesStart() {
+  const char* getValuesStart() const {
     return this->data_.data() + Encoding::kPrefixSize + 4 +
         *reinterpret_cast<const uint32_t*>(
                this->data_.data() + Encoding::kPrefixSize);

--- a/dwio/nimble/encodings/TrivialEncoding.cpp
+++ b/dwio/nimble/encodings/TrivialEncoding.cpp
@@ -39,8 +39,10 @@ TrivialEncoding<std::string_view>::TrivialEncoding(
         dataCompressionType,
         {blob_, static_cast<size_t>(data.end() - blob_)});
     blob_ = reinterpret_cast<const char*>(dataUncompressed_.data());
+    uncompressedDataBytes_ = dataUncompressed_.size();
+  } else {
+    uncompressedDataBytes_ = data.size() - std::distance(blob_, data.data());
   }
-
   pos_ = blob_;
 }
 
@@ -70,6 +72,10 @@ void TrivialEncoding<std::string_view>::materialize(
   }
   pos_ = pos;
   row_ += rowCount;
+}
+
+uint64_t TrivialEncoding<std::string_view>::uncompressedDataBytes() const {
+  return uncompressedDataBytes_;
 }
 
 std::string_view TrivialEncoding<std::string_view>::encode(

--- a/dwio/nimble/encodings/TrivialEncoding.h
+++ b/dwio/nimble/encodings/TrivialEncoding.h
@@ -100,6 +100,9 @@ class TrivialEncoding<std::string_view> final
   template <typename DecoderVisitor>
   void readWithVisitor(DecoderVisitor& visitor, ReadWithVisitorParams& params);
 
+  // Returns the total size of the characters payload in bytes
+  uint64_t uncompressedDataBytes() const;
+
   static std::string_view encode(
       EncodingSelection<std::string_view>& selection,
       std::span<const std::string_view> values,
@@ -111,6 +114,12 @@ class TrivialEncoding<std::string_view> final
   const char* pos_;
   std::unique_ptr<Encoding> lengths_;
   Vector<uint32_t> buffer_;
+
+  // The size of the uncompressed data in bytes.
+  //
+  // NOTE: This is not necessarily the size of 'dataUncompressed_' because the
+  // data could come as uncompressed.
+  uint64_t uncompressedDataBytes_;
   Vector<char> dataUncompressed_;
 };
 

--- a/dwio/nimble/velox/ChunkedStreamDecoder.h
+++ b/dwio/nimble/velox/ChunkedStreamDecoder.h
@@ -40,9 +40,13 @@ class ChunkedStreamDecoder : public Decoder {
 
   void reset() override;
 
- private:
   void ensureLoaded();
 
+  const Encoding* encoding() const override {
+    return encoding_.get();
+  }
+
+ private:
   velox::memory::MemoryPool& pool_;
   std::unique_ptr<ChunkedStream> stream_;
   std::unique_ptr<Encoding> encoding_;

--- a/dwio/nimble/velox/Decoder.h
+++ b/dwio/nimble/velox/Decoder.h
@@ -21,6 +21,8 @@
 
 namespace facebook::nimble {
 
+class Encoding;
+
 class Decoder {
  public:
   virtual ~Decoder() = default;
@@ -34,6 +36,8 @@ class Decoder {
   virtual void skip(uint32_t count) = 0;
 
   virtual void reset() = 0;
+
+  virtual const Encoding* encoding() const = 0;
 };
 
 } // namespace facebook::nimble

--- a/dwio/nimble/velox/FieldReader.h
+++ b/dwio/nimble/velox/FieldReader.h
@@ -63,6 +63,13 @@ class FieldReader {
 
   virtual ~FieldReader() = default;
 
+  // Estimation of the total output size of the current reading stripe in bytes.
+  // This method will throw NotSupported error for not yet supported encoding
+  // estimations.
+  //
+  // NOTE: This is not the estimation on the remaining rows, but the total rows.
+  virtual uint64_t estimatedTotalOutputSize() const = 0;
+
   // Place the next X rows of data into the passed in output vector.
   virtual void next(
       uint32_t count,


### PR DESCRIPTION
Summary:
The output size estimation estimates the flattened output row size of the currently loaded stripe by inspecting the encoding headers. 
For string type, this diff only deals with simple encodings (trivial). More encoding supports will come in followup changes.

Differential Revision: D56973690


