### PR TITLE
Selective flat map column reader

### DIFF
--- a/dwio/nimble/encodings/ConstantEncoding.h
+++ b/dwio/nimble/encodings/ConstantEncoding.h
@@ -46,6 +46,9 @@ class ConstantEncoding final
   void skip(uint32_t rowCount) final;
   void materialize(uint32_t rowCount, void* buffer) final;
 
+  void materializeBoolsAsBits(uint32_t rowCount, uint64_t* buffer, int begin)
+      final;
+
   template <typename DecoderVisitor>
   void readWithVisitor(DecoderVisitor& visitor, ReadWithVisitorParams& params);
 
@@ -86,6 +89,22 @@ void ConstantEncoding<T>::materialize(uint32_t rowCount, void* buffer) {
   for (uint32_t i = 0; i < rowCount; ++i) {
     castBuffer[i] = value_;
   }
+}
+
+template <>
+inline void ConstantEncoding<bool>::materializeBoolsAsBits(
+    uint32_t rowCount,
+    uint64_t* buffer,
+    int begin) {
+  velox::bits::fillBits(buffer, begin, begin + rowCount, value_);
+}
+
+template <typename T>
+void ConstantEncoding<T>::materializeBoolsAsBits(
+    uint32_t /*rowCount*/,
+    uint64_t* /*buffer*/,
+    int /*begin*/) {
+  NIMBLE_UNREACHABLE("");
 }
 
 template <typename T>

--- a/dwio/nimble/encodings/Encoding.h
+++ b/dwio/nimble/encodings/Encoding.h
@@ -148,6 +148,14 @@ class Encoding {
       const bits::Bitmap* scatterBitmap = nullptr,
       uint32_t offset = 0) = 0;
 
+  // Read bool values to output buffer as bits.
+  virtual void materializeBoolsAsBits(
+      uint32_t /*rowCount*/,
+      uint64_t* /*buffer*/,
+      int /*begin*/) {
+    NIMBLE_NOT_IMPLEMENTED(typeid(*this).name());
+  }
+
   // Whether this encoding is nullable, i.e. contains any nulls. This property
   // modifies how engines need to interpret many of the function results, and a
   // number of functions are only callable if isNullable() returns true.

--- a/dwio/nimble/encodings/EncodingUtils.h
+++ b/dwio/nimble/encodings/EncodingUtils.h
@@ -79,6 +79,10 @@ auto encodingTypeDispatchVarint(Encoding& encoding, F f) {
       return f(static_cast<E<int64_t>&>(encoding));
     case DataType::Uint64:
       return f(static_cast<E<uint64_t>&>(encoding));
+    case DataType::Float:
+      return f(static_cast<E<float>&>(encoding));
+    case DataType::Double:
+      return f(static_cast<E<double>&>(encoding));
     default:
       NIMBLE_NOT_SUPPORTED(toString(encoding.dataType()));
   }

--- a/dwio/nimble/encodings/FixedBitWidthEncoding.h
+++ b/dwio/nimble/encodings/FixedBitWidthEncoding.h
@@ -143,8 +143,10 @@ template <typename V>
 void FixedBitWidthEncoding<T>::readWithVisitor(
     V& visitor,
     ReadWithVisitorParams& params) {
-  this->template readWithVisitorSlow<true>(
-      visitor, params, [&] { return baseline_ + fixedBitArray_.get(row_++); });
+  this->template readWithVisitorSlow<true>(visitor, params, [&] {
+    physicalType value = fixedBitArray_.get(row_++) + baseline_;
+    return value;
+  });
 }
 
 template <typename T>

--- a/dwio/nimble/encodings/RleEncoding.h
+++ b/dwio/nimble/encodings/RleEncoding.h
@@ -219,6 +219,9 @@ class RLEEncoding<bool> final
     return {reserved, 1};
   }
 
+  void materializeBoolsAsBits(uint32_t rowCount, uint64_t* buffer, int begin)
+      final;
+
  private:
   bool initialValue_;
   bool value_;

--- a/dwio/nimble/encodings/SparseBoolEncoding.h
+++ b/dwio/nimble/encodings/SparseBoolEncoding.h
@@ -59,6 +59,9 @@ class SparseBoolEncoding final : public TypedEncoding<bool, bool> {
   void skip(uint32_t rowCount) final;
   void materialize(uint32_t rowCount, void* buffer) final;
 
+  void materializeBoolsAsBits(uint32_t rowCount, uint64_t* buffer, int begin)
+      final;
+
   template <typename DecoderVisitor>
   void readWithVisitor(DecoderVisitor& visitor, ReadWithVisitorParams& params);
 

--- a/dwio/nimble/encodings/TrivialEncoding.cpp
+++ b/dwio/nimble/encodings/TrivialEncoding.cpp
@@ -206,6 +206,19 @@ void TrivialEncoding<bool>::materialize(uint32_t rowCount, void* buffer) {
   }
 }
 
+void TrivialEncoding<bool>::materializeBoolsAsBits(
+    uint32_t rowCount,
+    uint64_t* buffer,
+    int begin) {
+  velox::bits::copyBits(
+      reinterpret_cast<const uint64_t*>(bitmap_),
+      row_,
+      buffer,
+      begin,
+      rowCount);
+  row_ += rowCount;
+}
+
 std::string_view TrivialEncoding<bool>::encode(
     EncodingSelection<bool>& selection,
     std::span<const bool> values,

--- a/dwio/nimble/encodings/TrivialEncoding.h
+++ b/dwio/nimble/encodings/TrivialEncoding.h
@@ -143,6 +143,9 @@ class TrivialEncoding<bool> final : public TypedEncoding<bool, bool> {
   void skip(uint32_t rowCount) final;
   void materialize(uint32_t rowCount, void* buffer) final;
 
+  void materializeBoolsAsBits(uint32_t rowCount, uint64_t* buffer, int begin)
+      final;
+
   template <typename DecoderVisitor>
   void readWithVisitor(DecoderVisitor& visitor, ReadWithVisitorParams& params);
 


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebookincubator/velox/pull/9790

- Refactor existing DWRF selective flat map reader code for reusing
- Add Nimble selective flat map column reader
- Optimize `ChunkedBoolsDecoder::next` (showing up >15% CPU in query)
- Add `estimatedRowSize` using encoding information

Differential Revision: D57276011


