### PR TITLE
Optimize readWithVisitor for RleEncoding and NullableEncoding

### DIFF
--- a/dwio/nimble/encodings/EncodingUtils.h
+++ b/dwio/nimble/encodings/EncodingUtils.h
@@ -163,6 +163,8 @@ void callReadWithVisitor(
     detail::encodingTypeDispatchString(encoding, [&](auto& typedEncoding) {
       typedEncoding.readWithVisitor(visitor, params);
     });
+  } else if constexpr (std::is_same_v<typename V::DataType, velox::int128_t>) {
+    NIMBLE_NOT_SUPPORTED("Int128 is not supported in Nimble");
   } else {
     detail::encodingTypeDispatchNonString(encoding, [&](auto& typedEncoding) {
       typedEncoding.readWithVisitor(visitor, params);


### PR DESCRIPTION
Summary:
- Add fash path for `RleEncoding::readWithVisitor`
- Use `materializeBoolsAsBits` in `NullableEncoding::readWithVisitor`
- Merge `ChunkedBoolsDecoder` with `ChunkedDecoder`

Differential Revision: D57675525


