### PR TITLE
Optimize readWithVisitor for TrivialEncoding and MainlyConstantEncoding

### DIFF
--- a/dwio/nimble/encodings/ConstantEncoding.h
+++ b/dwio/nimble/encodings/ConstantEncoding.h
@@ -112,8 +112,7 @@ template <typename V>
 void ConstantEncoding<T>::readWithVisitor(
     V& visitor,
     ReadWithVisitorParams& params) {
-  this->template readWithVisitorSlow<false>(
-      visitor, params, [&] { return value_; });
+  detail::readWithVisitorSlow(visitor, params, nullptr, [&] { return value_; });
 }
 
 template <typename T>

--- a/dwio/nimble/encodings/DictionaryEncoding.h
+++ b/dwio/nimble/encodings/DictionaryEncoding.h
@@ -190,7 +190,7 @@ void DictionaryEncoding<T>::readWithVisitor(
           &indicesHook));
   indicesVisitor.setRowIndex(startRowIndex);
   callReadWithVisitor(*indicesEncoding_, indicesVisitor, params);
-  this->template readWithVisitorSlow<false>(visitor, params, [&] {
+  detail::readWithVisitorSlow(visitor, params, nullptr, [&] {
     auto index = buffer_[visitor.rowIndex() - startRowIndex];
     return alphabet_[index];
   });

--- a/dwio/nimble/encodings/Encoding.cpp
+++ b/dwio/nimble/encodings/Encoding.cpp
@@ -20,17 +20,13 @@
 
 namespace facebook::nimble {
 
-EncodingType Encoding::encodingType() const {
-  return static_cast<EncodingType>(data_[kEncodingTypeOffset]);
-}
-
-DataType Encoding::dataType() const {
-  return static_cast<DataType>(data_[kDataTypeOffset]);
-}
-
-uint32_t Encoding::rowCount() const {
-  return *reinterpret_cast<const uint32_t*>(data_.data() + kRowCountOffset);
-}
+Encoding::Encoding(velox::memory::MemoryPool& memoryPool, std::string_view data)
+    : memoryPool_{memoryPool},
+      data_{data},
+      encodingType_{data_[kEncodingTypeOffset]},
+      dataType_{static_cast<DataType>(data_[kDataTypeOffset])},
+      rowCount_{
+          *reinterpret_cast<const uint32_t*>(data_.data() + kRowCountOffset)} {}
 
 /* static */ void Encoding::copyIOBuf(char* pos, const folly::IOBuf& buf) {
   [[maybe_unused]] size_t length = buf.computeChainDataLength();

--- a/dwio/nimble/encodings/FixedBitWidthEncoding.h
+++ b/dwio/nimble/encodings/FixedBitWidthEncoding.h
@@ -143,10 +143,14 @@ template <typename V>
 void FixedBitWidthEncoding<T>::readWithVisitor(
     V& visitor,
     ReadWithVisitorParams& params) {
-  this->template readWithVisitorSlow<true>(visitor, params, [&] {
-    physicalType value = fixedBitArray_.get(row_++) + baseline_;
-    return value;
-  });
+  detail::readWithVisitorSlow(
+      visitor,
+      params,
+      [&](auto toSkip) { skip(toSkip); },
+      [&] {
+        physicalType value = fixedBitArray_.get(row_++) + baseline_;
+        return value;
+      });
 }
 
 template <typename T>

--- a/dwio/nimble/encodings/SparseBoolEncoding.h
+++ b/dwio/nimble/encodings/SparseBoolEncoding.h
@@ -84,16 +84,20 @@ template <typename V>
 void SparseBoolEncoding::readWithVisitor(
     V& visitor,
     ReadWithVisitorParams& params) {
-  readWithVisitorSlow<true>(visitor, params, [&] {
-    while (nextIndex_ < row_) {
-      nextIndex_ = indices_.nextValue();
-    }
-    if (FOLLY_UNLIKELY(nextIndex_ == row_++)) {
-      nextIndex_ = indices_.nextValue();
-      return sparseValue_;
-    }
-    return !sparseValue_;
-  });
+  detail::readWithVisitorSlow(
+      visitor,
+      params,
+      [&](auto toSkip) { skip(toSkip); },
+      [&] {
+        while (nextIndex_ < row_) {
+          nextIndex_ = indices_.nextValue();
+        }
+        if (FOLLY_UNLIKELY(nextIndex_ == row_++)) {
+          nextIndex_ = indices_.nextValue();
+          return sparseValue_;
+        }
+        return !sparseValue_;
+      });
 }
 
 } // namespace facebook::nimble

--- a/dwio/nimble/encodings/VarintEncoding.h
+++ b/dwio/nimble/encodings/VarintEncoding.h
@@ -129,16 +129,20 @@ template <typename V>
 void VarintEncoding<T>::readWithVisitor(
     V& visitor,
     ReadWithVisitorParams& params) {
-  this->template readWithVisitorSlow<true>(visitor, params, [&] {
-    physicalType value;
-    if constexpr (isFourByteIntegralType<physicalType>()) {
-      value = varint::readVarint32(&pos_);
-    } else {
-      static_assert(sizeof(T) == 8);
-      value = varint::readVarint64(&pos_);
-    }
-    return baseline_ + value;
-  });
+  detail::readWithVisitorSlow(
+      visitor,
+      params,
+      [&](auto toSkip) { skip(toSkip); },
+      [&] {
+        physicalType value;
+        if constexpr (isFourByteIntegralType<physicalType>()) {
+          value = varint::readVarint32(&pos_);
+        } else {
+          static_assert(sizeof(T) == 8);
+          value = varint::readVarint64(&pos_);
+        }
+        return baseline_ + value;
+      });
 }
 
 template <typename T>


### PR DESCRIPTION
Summary:
- Fast path for `TrivialEncoding::readWithVisitor`
- Fast path for `MainlyConstantEncoding::readWithVisitor`
- Store `encodingType`, `dataType`, `rowCount` in `Encoding` object memory to reduce memory fetch on `data_`
- Use skip functor only in `readWithVisitorSlow` to avoid virtual call cost

Differential Revision: D58085138


