### PR TITLE
Open source CI fixes

### DIFF
--- a/.github/workflows/linux-build.yml
+++ b/.github/workflows/linux-build.yml
@@ -31,7 +31,7 @@ concurrency:
 jobs:
   ubuntu-release:
     runs-on: ubuntu-latest
-    if: ${{ github.repository == 'facebookexternal/nimble' }}
+    if: ${{ github.repository == 'facebookincubator/nimble' }}
     name: "Ubuntu Build"
     env:
       CCACHE_DIR: "${{ github.workspace }}/.ccache"

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ Nimble’s CMake build system is self-sufficient and able to either locate its
 main dependencies or compile them locally. In order to compile it, one can simply:
 
 ```shell
-$ git clone git@github.com:facebookexternal/nimble.git
+$ git clone git@github.com:facebookincubator/nimble.git
 $ cd nimble
 $ make
 ```

--- a/dwio/nimble/encodings/CMakeLists.txt
+++ b/dwio/nimble/encodings/CMakeLists.txt
@@ -26,4 +26,5 @@ add_library(
   TrivialEncoding.cpp
   ZstdCompressor.cpp)
 
-target_link_libraries(nimble_encodings Folly::folly absl::flat_hash_map)
+target_link_libraries(nimble_encodings Folly::folly absl::flat_hash_map
+                      protobuf::libprotobuf)

--- a/dwio/nimble/velox/CMakeLists.txt
+++ b/dwio/nimble/velox/CMakeLists.txt
@@ -28,14 +28,16 @@ target_link_libraries(nimble_velox_schema_builder nimble_velox_schema_reader
                       nimble_velox_schema nimble_common Folly::folly)
 
 add_library(nimble_velox_field_reader FieldReader.cpp)
-target_link_libraries(nimble_velox_field_reader nimble_velox_schema_reader
-                      nimble_common Folly::folly)
+target_link_libraries(
+  nimble_velox_field_reader nimble_velox_schema_reader nimble_common
+  Folly::folly absl::flat_hash_map protobuf::libprotobuf)
 
 add_library(nimble_velox_flatmap_layout_planner FlatMapLayoutPlanner.cpp)
 target_link_libraries(nimble_velox_flatmap_layout_planner
                       nimble_velox_schema_reader velox_file)
 
-add_library(nimble_velox_field_writer BufferGrowthPolicy.cpp FieldWriter.cpp)
+add_library(nimble_velox_field_writer BufferGrowthPolicy.cpp
+                                      DeduplicationUtils.cpp FieldWriter.cpp)
 target_link_libraries(nimble_velox_field_writer nimble_velox_schema
                       nimble_velox_schema_builder Folly::folly)
 
@@ -78,7 +80,6 @@ add_library(nimble_velox_reader ChunkedStream.cpp ChunkedStreamDecoder.cpp
                                 StreamLabels.cpp VeloxReader.cpp)
 target_link_libraries(
   nimble_velox_reader
-  nimble_velox_dwio_common
   nimble_velox_schema
   nimble_velox_schema_serialization
   nimble_velox_schema_fb

--- a/dwio/nimble/velox/tests/VeloxReaderTests.cpp
+++ b/dwio/nimble/velox/tests/VeloxReaderTests.cpp
@@ -4588,12 +4588,12 @@ TEST_F(VeloxReaderTests, EstimatedRowSizeComplex) {
           .keyType = type->kind(),
           .maxNumKVPerRow = numFeatures,
           .variantNumKV = false,
+          .seed = 1387939242,
           .hasNulls = hasNulls,
           // Use inline size for better control size estimate by utilizing
           // BaseVector::retainedSize()
           .stringLength = velox::StringView::kInlineSize,
           .stringVariableLength = false,
-          .seed = 1387939242,
       };
       VeloxMapGenerator generator(leafPool_.get(), generatorConfig);
       auto vector = generator.generateBatch(rowCount);


### PR DESCRIPTION
Fixing a series of issues with CI. The repo rename facebookexternal->facebookincubator broken jobs, and since then other error accumulated. This hopefully addresses all of them. 

Also advancing Velox's submodule.