### PR TITLE
Fix IOStats for Nimble

### DIFF
--- a/dwio/nimble/tablet/TabletReader.cpp
+++ b/dwio/nimble/tablet/TabletReader.cpp
@@ -33,16 +33,6 @@
 
 namespace facebook::nimble {
 
-DEFINE_bool(
-    nimble_disable_coalesce,
-    false,
-    "Disable read coalescing in Nimble reader.");
-
-DEFINE_uint64(
-    nimble_coalesce_max_distance,
-    1024 * 1024 * 1.25,
-    "Maximum read coalescing distance in Nimble reader. And gap smaller than this value will be coalesced.");
-
 // Here's the layout of the tablet:
 //
 // stripe 1 streams
@@ -59,6 +49,7 @@ DEFINE_uint64(
 // 2 bytes major version + 2 bytes minor version +
 // 4 bytes magic number.
 namespace {
+
 template <typename T>
 const T* asFlatBuffersRoot(std::string_view content) {
   return flatbuffers::GetRoot<T>(content.data());


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebookincubator/velox/pull/10216

IOStats are being calculated in different layers of the IO stacks.
Since Nimble and DWRF don't share parts of the stack, some IOStats calculation were not affecting Nimble.

Probably the right thing to do is to move all IOStats calculations to the bottom layers (WSFile, cache and SSD reads), where IO is actually performed (and these layers are shared beteen Nimble nad DWRF).
But it seems like that for this change, we need a design, clarifying what we actually want to track and how to track it.

Since we don't have the cycles to create this design right now, I opted for a simple solution, where I create a simple layer on the Nimble side, which will calculate these stats.

Reviewed By: Yuhta, sdruzkin

Differential Revision: D58559606
