### PR TITLE
Use FlatMapLayoutPlanner as a default planner

### DIFF
--- a/dwio/nimble/velox/CMakeLists.txt
+++ b/dwio/nimble/velox/CMakeLists.txt
@@ -32,9 +32,9 @@ target_link_libraries(
   nimble_velox_field_reader nimble_velox_schema_reader nimble_common
   Folly::folly absl::flat_hash_map protobuf::libprotobuf)
 
-add_library(nimble_velox_flatmap_layout_planner FlatMapLayoutPlanner.cpp)
-target_link_libraries(nimble_velox_flatmap_layout_planner
-                      nimble_velox_schema_reader velox_file)
+add_library(nimble_velox_layout_planner LayoutPlanner.cpp)
+target_link_libraries(nimble_velox_layout_planner nimble_velox_schema_reader
+                      velox_file)
 
 add_library(nimble_velox_field_writer BufferGrowthPolicy.cpp
                                       DeduplicationUtils.cpp FieldWriter.cpp)

--- a/dwio/nimble/velox/LayoutPlanner.h
+++ b/dwio/nimble/velox/LayoutPlanner.h
@@ -20,11 +20,12 @@
 
 namespace facebook::nimble {
 
-class FlatMapLayoutPlanner : public LayoutPlanner {
+class DefaultLayoutPlanner : public LayoutPlanner {
  public:
-  FlatMapLayoutPlanner(
+  DefaultLayoutPlanner(
       std::function<std::shared_ptr<const TypeBuilder>()> typeResolver,
-      std::vector<std::tuple<size_t, std::vector<int64_t>>>
+      const std::optional<
+          std::vector<std::tuple<size_t, std::vector<int64_t>>>>&
           flatMapFeatureOrder);
 
   virtual std::vector<Stream> getLayout(std::vector<Stream>&& streams) override;

--- a/dwio/nimble/velox/VeloxWriter.cpp
+++ b/dwio/nimble/velox/VeloxWriter.cpp
@@ -28,8 +28,8 @@
 #include "dwio/nimble/velox/ChunkedStreamWriter.h"
 #include "dwio/nimble/velox/EncodingLayoutTree.h"
 #include "dwio/nimble/velox/FieldWriter.h"
-#include "dwio/nimble/velox/FlatMapLayoutPlanner.h"
 #include "dwio/nimble/velox/FlushPolicy.h"
+#include "dwio/nimble/velox/LayoutPlanner.h"
 #include "dwio/nimble/velox/MetadataGenerated.h"
 #include "dwio/nimble/velox/SchemaBuilder.h"
 #include "dwio/nimble/velox/SchemaSerialization.h"
@@ -467,11 +467,9 @@ VeloxWriter::VeloxWriter(
       writer_{
           *encodingMemoryPool_,
           file_.get(),
-          {.layoutPlanner = context_->options.featureReordering.has_value()
-               ? std::make_unique<FlatMapLayoutPlanner>(
-                     [&sb = context_->schemaBuilder]() { return sb.getRoot(); },
-                     context_->options.featureReordering.value())
-               : nullptr}},
+          {.layoutPlanner = std::make_unique<DefaultLayoutPlanner>(
+               [&sb = context_->schemaBuilder]() { return sb.getRoot(); },
+               context_->options.featureReordering)}},
       root_{createRootField(*context_, schema_)},
       spillConfig_{options.spillConfig} {
   NIMBLE_CHECK(file_, "File is null");

--- a/dwio/nimble/velox/tests/CMakeLists.txt
+++ b/dwio/nimble/velox/tests/CMakeLists.txt
@@ -20,7 +20,7 @@ add_executable(
   nimble_velox_tests
   BufferGrowthPolicyTest.cpp
   EncodingLayoutTreeTests.cpp
-  FlatMapLayoutPlannerTests.cpp
+  LayoutPlannerTests.cpp
   OrderedRangesTests.cpp
   SchemaTests.cpp
   TypeTests.cpp
@@ -35,7 +35,7 @@ target_link_libraries(
   nimble_velox_reader
   nimble_velox_writer
   nimble_velox_field_writer
-  nimble_velox_flatmap_layout_planner
+  nimble_velox_layout_planner
   nimble_common_file_writer
   nimble_common
   nimble_encodings


### PR DESCRIPTION
Summary:
Promote FlatMap layout planner to be a default layout planner.

Changes:
* rename FlatMapLayoutPlanner to DefaultLayoutPlanner
* rename tests
* always create the DefaultLayoutPlanner in the writer

Differential Revision: D58894881
