### PR TITLE
Transform Optimizations + Trainer Role

### DIFF
--- a/dwio/nimble/velox/VeloxWriter.cpp
+++ b/dwio/nimble/velox/VeloxWriter.cpp
@@ -471,8 +471,9 @@ VeloxWriter::VeloxWriter(
                [&sb = context_->schemaBuilder]() { return sb.getRoot(); },
                context_->options.featureReordering)}},
       root_{createRootField(*context_, schema_)},
-      spillConfig_{options.spillConfig} {
+      spillConfig_{context_->options.spillConfig} {
   NIMBLE_CHECK(file_, "File is null");
+
   if (context_->options.encodingLayoutTree.has_value()) {
     context_->flatmapFieldAddedEventHandler =
         [&](const TypeBuilder& flatmap,


### PR DESCRIPTION
Summary:
To better utilize our workers, I enabled the following:
1. Parallel encoding
2. Parallel stream reading
3. I/O decoupling

These increased our CPU utilization on workers from ~30% to ~85%, speeding up transforms by a lot.

In addition, created a new role to train encoding layouts for jobs (with enough items in them).
This trainer is not super robust right now, and will be improved in the future (for example, detect if it is stuck, and restert).
Not sure how much this is contributing to transform speed yet.

Differential Revision: D59125380
