### PR TITLE
Hold shared reference on memory pool inside arbitrator

### DIFF
--- a/dwio/nimble/velox/tests/DeduplicationUtilsTests.cpp
+++ b/dwio/nimble/velox/tests/DeduplicationUtilsTests.cpp
@@ -20,6 +20,10 @@ class DeduplicationUtilsTests : public testing::Test {
     leafPool_ = rootPool_->addLeafChild("default_leaf");
   }
 
+  void TearDown() override {
+    rootPool_->unregisterArbitration();
+  }
+
   std::shared_ptr<velox::memory::MemoryPool> rootPool_;
   std::shared_ptr<velox::memory::MemoryPool> leafPool_;
 };

--- a/dwio/nimble/velox/tests/VeloxWriterTests.cpp
+++ b/dwio/nimble/velox/tests/VeloxWriterTests.cpp
@@ -49,6 +49,10 @@ class VeloxWriterTests : public testing::Test {
     leafPool_ = rootPool_->addLeafChild("default_leaf");
   }
 
+  void TearDown() override {
+    rootPool_->unregisterArbitration();
+  }
+
   std::shared_ptr<velox::memory::MemoryPool> rootPool_;
   std::shared_ptr<velox::memory::MemoryPool> leafPool_;
 };
@@ -315,6 +319,9 @@ class MockReclaimer : public velox::memory::MemoryReclaimer {
 TEST_F(VeloxWriterTests, MemoryReclaimPath) {
   auto rootPool = velox::memory::memoryManager()->addRootPool(
       "root", 4L << 20, velox::memory::MemoryReclaimer::create());
+  SCOPE_EXIT {
+    rootPool->unregisterArbitration();
+  };
   auto writerPool = rootPool->addAggregateChild(
       "writer", velox::memory::MemoryReclaimer::create());
 


### PR DESCRIPTION
Summary:
Let arbitrator hold a shared reference instead of weak pointer to avoid pointer upgrade
to ease the global arbitration implementation in followup

X-link: https://github.com/facebookincubator/velox/pull/10707

Differential Revision: D61067384

Pulled By: xiaoxmeng
