### PR TITLE
Expose metadata compression threshold in writer options

### DIFF
--- a/dwio/nimble/tablet/TabletWriter.h
+++ b/dwio/nimble/tablet/TabletWriter.h
@@ -33,10 +33,13 @@ class LayoutPlanner {
   virtual ~LayoutPlanner() = default;
 };
 
+constexpr uint32_t kMetadataFlushThreshold = 8 * 1024 * 1024; // 8MB
+constexpr uint32_t kMetadataCompressionThreshold = 4 * 1024 * 1024; // 4MB
+
 struct TabletWriterOptions {
   std::unique_ptr<LayoutPlanner> layoutPlanner{nullptr};
-  uint32_t metadataFlushThreshold{8 * 1024 * 1024}; // 8Mb
-  uint32_t metadataCompressionThreshold{4 * 1024 * 1024}; // 4Mb
+  uint32_t metadataFlushThreshold{kMetadataFlushThreshold};
+  uint32_t metadataCompressionThreshold{kMetadataCompressionThreshold};
   ChecksumType checksumType{ChecksumType::XXH3_64};
 };
 

--- a/dwio/nimble/velox/VeloxWriter.cpp
+++ b/dwio/nimble/velox/VeloxWriter.cpp
@@ -469,7 +469,10 @@ VeloxWriter::VeloxWriter(
           file_.get(),
           {.layoutPlanner = std::make_unique<DefaultLayoutPlanner>(
                [&sb = context_->schemaBuilder]() { return sb.getRoot(); },
-               context_->options.featureReordering)}},
+               context_->options.featureReordering),
+           .metadataCompressionThreshold =
+               context_->options.metadataCompressionThreshold.value_or(
+                   kMetadataCompressionThreshold)}},
       root_{createRootField(*context_, schema_)},
       spillConfig_{context_->options.spillConfig} {
   NIMBLE_CHECK(file_, "File is null");

--- a/dwio/nimble/velox/VeloxWriterOptions.h
+++ b/dwio/nimble/velox/VeloxWriterOptions.h
@@ -88,6 +88,9 @@ struct VeloxWriterOptions {
   // ExactGrowthPolicy, as defined here: dwio/nimble/velox/BufferGrowthPolicy.h)
   bool lowMemoryMode = false;
 
+  // If present, metadata sections above this threshold size will be compressed.
+  std::optional<uint32_t> metadataCompressionThreshold;
+
   // When flushing data streams into chunks, streams with raw data size smaller
   // than this threshold will not be flushed.
   // Note: this threshold is ignored when it is time to flush a stripe.


### PR DESCRIPTION
Summary: Previously commandeered from helfman and used in benchmarks. If there are no concerns we can land this.

Reviewed By: helfman

Differential Revision: D52221618
