### PR TITLE
Schema evolution support for reader value hooks

### DIFF
--- a/dwio/nimble/encodings/DictionaryEncoding.h
+++ b/dwio/nimble/encodings/DictionaryEncoding.h
@@ -137,19 +137,16 @@ class DictionaryIndicesHook : public velox::ValueHook {
     return false;
   }
 
-  void addValue(vector_size_t i, const void* value) final {
-    indices_[i - offset_] = *reinterpret_cast<const uint32_t*>(value);
+  void addValue(vector_size_t i, int64_t value) final {
+    indices_[i - offset_] = value;
   }
 
   void addValues(
       const vector_size_t* rows,
-      const void* values,
-      vector_size_t size,
-      uint8_t valueWidth) final {
-    NIMBLE_DASSERT(valueWidth == sizeof(uint32_t), "");
-    auto* indices = reinterpret_cast<const uint32_t*>(values);
+      const int32_t* values,
+      vector_size_t size) final {
     for (vector_size_t i = 0; i < size; ++i) {
-      indices_[rows[i] - offset_] = indices[i];
+      indices_[rows[i] - offset_] = values[i];
     }
   }
 

--- a/dwio/nimble/encodings/MainlyConstantEncoding.h
+++ b/dwio/nimble/encodings/MainlyConstantEncoding.h
@@ -301,8 +301,7 @@ void MainlyConstantEncoding<T>::bulkScan(
   visitor.setRowIndex(visitor.numRows());
   if constexpr (V::kHasHook) {
     NIMBLE_DASSERT(numValues == numNonNulls, "");
-    visitor.hook().addValues(
-        scatterRows, values, numNonNulls, sizeof(ValueType));
+    visitor.hook().addValues(scatterRows, values, numNonNulls);
   } else {
     visitor.addNumValues(V::kFilterOnly ? numHits : numValues);
   }

--- a/dwio/nimble/encodings/RleEncoding.h
+++ b/dwio/nimble/encodings/RleEncoding.h
@@ -377,8 +377,7 @@ void RLEEncoding<T>::bulkScan(
   }
   if constexpr (V::kHasHook) {
     NIMBLE_DASSERT(numValues == numNonNulls, "");
-    visitor.hook().addValues(
-        scatterRows, values, numNonNulls, sizeof(ValueType));
+    visitor.hook().addValues(scatterRows, values, numNonNulls);
   } else {
     visitor.addNumValues(V::kFilterOnly ? numHits : numValues);
   }


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebookincubator/velox/pull/10755

Currently reader value hook is not considering schema evolution at all, this change fix that.

Differential Revision: D61229494
