### PR TITLE
Add Raw Data Size Stat to Nimble Files

### DIFF
--- a/dwio/nimble/encodings/RleEncoding.h
+++ b/dwio/nimble/encodings/RleEncoding.h
@@ -174,7 +174,7 @@ class RLEEncodingBase
 
 } // namespace internal
 
-// Handles the numeric cases. Bools and strings are templated below.
+// Handles the numeric and string cases. Bools are templated below.
 // Data layout is:
 // RLEEncodingBase bytes
 // 4 * sizeof(physicalType) bytes: run values

--- a/dwio/nimble/encodings/tests/CMakeLists.txt
+++ b/dwio/nimble/encodings/tests/CMakeLists.txt
@@ -11,6 +11,9 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+add_library(nimble_encodings_tests_utils TestUtils.cpp)
+target_link_libraries(nimble_encodings_tests_utils nimble_encodings)
+
 add_executable(
   nimble_encodings_tests
   ConstantEncodingTests.cpp
@@ -27,6 +30,7 @@ add_test(nimble_encodings_tests nimble_encodings_tests)
 
 target_link_libraries(
   nimble_encodings_tests
+  nimble_encodings_tests_utils
   nimble_encodings
   nimble_common
   nimble_tools_common

--- a/dwio/nimble/encodings/tests/TestUtils.cpp
+++ b/dwio/nimble/encodings/tests/TestUtils.cpp
@@ -1,0 +1,138 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "dwio/nimble/encodings/tests/TestUtils.h"
+#include "dwio/nimble/encodings/EncodingUtils.h"
+
+namespace facebook::nimble::test {
+
+static constexpr int kRowCountOffset = 2;
+static constexpr int kPrefixSize = 6;
+static constexpr int kCompressionTypeSize = 1;
+
+uint64_t TestUtils::getRawDataSize(
+    velox::memory::MemoryPool& memoryPool,
+    std::string_view encodingStr) {
+  auto encoding = EncodingFactory::decode(memoryPool, encodingStr);
+  EncodingType encodingType = encoding->encodingType();
+  DataType dataType = encoding->dataType();
+  uint32_t rowCount = encoding->rowCount();
+
+  if (encodingType == EncodingType::Sentinel) {
+    NIMBLE_NOT_SUPPORTED("Sentinel encoding is not supported");
+  }
+
+  if (encodingType == EncodingType::Nullable) {
+    auto pos = encodingStr.data() + kPrefixSize;
+    auto nonNullsSize = encoding::readUint32(pos);
+    auto nonNullsCount = encoding::peek<uint32_t>(pos + kRowCountOffset);
+    // We do not count the bits indicating non-null, therefore we only
+    // include the size of the null bits and the non-null values.
+    return getRawDataSize(memoryPool, {pos, nonNullsSize}) +
+        (rowCount - nonNullsCount);
+  } else {
+    if (dataType != DataType::String) {
+      auto typeSize = nimble::detail::dataTypeSize(dataType);
+      auto result = typeSize * rowCount;
+      return result;
+    } else {
+      auto pos = encodingStr.data() + kPrefixSize; // Skip the prefix.
+      uint64_t result = 0;
+
+      switch (encodingType) {
+        case EncodingType::Trivial: {
+          pos += kCompressionTypeSize;
+          auto lengthsSize = encoding::readUint32(pos);
+          auto lengths =
+              EncodingFactory::decode(memoryPool, {pos, lengthsSize});
+          std::vector<uint32_t> buffer(rowCount);
+          lengths->materialize(rowCount, buffer.data());
+          result += std::accumulate(buffer.begin(), buffer.end(), 0u);
+          break;
+        }
+
+        case EncodingType::Constant: {
+          auto valueSize = encoding::readUint32(pos);
+          result += rowCount * valueSize;
+          break;
+        }
+
+        case EncodingType::MainlyConstant: {
+          auto isCommonSize = encoding::readUint32(pos);
+          pos += isCommonSize;
+          auto otherValuesSize = encoding::readUint32(pos);
+          auto otherValuesOffset = pos;
+          auto otherValuesCount =
+              encoding::peek<uint32_t>(pos + kRowCountOffset);
+          pos += otherValuesSize;
+          auto constantValueSize = encoding::readUint32(pos);
+          result += (rowCount - otherValuesCount) * constantValueSize;
+          result +=
+              getRawDataSize(memoryPool, {otherValuesOffset, otherValuesSize});
+          break;
+        }
+
+        case EncodingType::Dictionary: {
+          auto alphabetSize = encoding::readUint32(pos);
+          auto alphabetCount = encoding::peek<uint32_t>(pos + kRowCountOffset);
+          auto alphabet =
+              EncodingFactory::decode(memoryPool, {pos, alphabetSize});
+          std::vector<std::string_view> alphabetBuffer(alphabetCount);
+          alphabet->materialize(alphabetCount, alphabetBuffer.data());
+
+          pos += alphabetSize;
+          auto indicesSize = encodingStr.length() - (pos - encodingStr.data());
+          auto indices =
+              EncodingFactory::decode(memoryPool, {pos, indicesSize});
+          std::vector<uint32_t> indicesBuffer(rowCount);
+          indices->materialize(rowCount, indicesBuffer.data());
+          for (int i = 0; i < rowCount; ++i) {
+            result += alphabetBuffer[indicesBuffer[i]].size();
+          }
+          break;
+        }
+
+        case EncodingType::RLE: {
+          auto runLengthsSize = encoding::readUint32(pos);
+          auto runLengthsCount =
+              encoding::peek<uint32_t>(pos + kRowCountOffset);
+          auto runLengths =
+              EncodingFactory::decode(memoryPool, {pos, runLengthsSize});
+          std::vector<uint32_t> runLengthsBuffer(runLengthsCount);
+          runLengths->materialize(runLengthsCount, runLengthsBuffer.data());
+
+          pos += runLengthsSize;
+          auto runValuesSize =
+              encodingStr.length() - (pos - encodingStr.data());
+          auto runValues =
+              EncodingFactory::decode(memoryPool, {pos, runValuesSize});
+          std::vector<std::string_view> runValuesBuffer(runLengthsCount);
+          runValues->materialize(runLengthsCount, runValuesBuffer.data());
+
+          for (int i = 0; i < runLengthsCount; ++i) {
+            result += runLengthsBuffer[i] * runValuesBuffer[i].size();
+          }
+          break;
+        }
+
+        default:
+          NIMBLE_NOT_SUPPORTED("Encoding type does not support strings.");
+      }
+      return result;
+    }
+  }
+}
+} // namespace facebook::nimble::test

--- a/dwio/nimble/encodings/tests/TestUtils.h
+++ b/dwio/nimble/encodings/tests/TestUtils.h
@@ -16,7 +16,6 @@
 #pragma once
 
 #include "dwio/nimble/encodings/ConstantEncoding.h"
-#include "dwio/nimble/encodings/DeltaEncoding.h"
 #include "dwio/nimble/encodings/DictionaryEncoding.h"
 #include "dwio/nimble/encodings/Encoding.h"
 #include "dwio/nimble/encodings/EncodingFactory.h"
@@ -235,5 +234,12 @@ class Encoder {
         buffer.getMemoryPool(),
         encodeNullable(buffer, values, nulls, compressionType));
   }
+};
+
+class TestUtils {
+ public:
+  static uint64_t getRawDataSize(
+      velox::memory::MemoryPool& memoryPool,
+      std::string_view encodingStr);
 };
 } // namespace facebook::nimble::test

--- a/dwio/nimble/tablet/Constants.h
+++ b/dwio/nimble/tablet/Constants.h
@@ -31,5 +31,6 @@ constexpr uint32_t kPostscriptChecksumedSize = 5;
 
 constexpr std::string_view kSchemaSection = "columnar.schema";
 constexpr std::string_view kMetadataSection = "columnar.metadata";
+constexpr std::string_view kStatsSection = "columnar.stats";
 
 } // namespace facebook::nimble

--- a/dwio/nimble/velox/CMakeLists.txt
+++ b/dwio/nimble/velox/CMakeLists.txt
@@ -71,6 +71,19 @@ target_include_directories(nimble_velox_metadata_fb
                            INTERFACE ${FLATBUFFERS_INCLUDE_DIR})
 add_dependencies(nimble_velox_metadata_fb nimble_velox_metadata_schema_fb)
 
+build_flatbuffers(
+  "${CMAKE_CURRENT_SOURCE_DIR}/Stats.fbs"
+  ""
+  nimble_velox_stats_schema_fb
+  ""
+  "${CMAKE_CURRENT_BINARY_DIR}"
+  ""
+  "")
+add_library(nimble_velox_stats_fb INTERFACE)
+target_include_directories(nimble_velox_stats_fb
+                           INTERFACE ${FLATBUFFERS_INCLUDE_DIR})
+add_dependencies(nimble_velox_stats_fb nimble_velox_stats_schema_fb)
+
 add_library(nimble_velox_schema_serialization SchemaSerialization.cpp)
 target_link_libraries(
   nimble_velox_schema_serialization nimble_velox_schema_reader
@@ -98,5 +111,6 @@ target_link_libraries(
   nimble_common
   nimble_tablet_writer
   nimble_velox_metadata_fb
+  nimble_velox_stats_fb
   velox_dwio_common
   Folly::folly)

--- a/dwio/nimble/velox/tests/TestUtils.h
+++ b/dwio/nimble/velox/tests/TestUtils.h
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include "dwio/nimble/encodings/tests/TestUtils.h"
+#include "dwio/nimble/tablet/TabletReader.h"
+#include "dwio/nimble/velox/ChunkedStream.h"
+
+namespace facebook::nimble::test {
+// Calculate the raw Stream Size.
+inline std::uint64_t getRawStreamSize(
+    velox::memory::MemoryPool& pool,
+    nimble::TabletReader& tablet) {
+  // Calculate expected size by summing stream sizes.
+  uint64_t expected = 0;
+  for (auto i = 0; i < tablet.stripeCount(); ++i) {
+    auto stripeIdentifier = tablet.getStripeIdentifier(i);
+
+    auto numStreams = tablet.streamCount(stripeIdentifier);
+    std::vector<uint32_t> identifiers(numStreams);
+    std::iota(identifiers.begin(), identifiers.end(), 0);
+    auto streams = tablet.load(stripeIdentifier, identifiers);
+
+    // Skip nullStreams indicated by nullptr.
+    for (auto& stream : streams) {
+      if (stream == nullptr) {
+        continue;
+      }
+      nimble::InMemoryChunkedStream chunkedStream{pool, std::move(stream)};
+      while (chunkedStream.hasNext()) {
+        auto chunk = chunkedStream.nextChunk();
+        expected += TestUtils::getRawDataSize(pool, chunk);
+      }
+    }
+  }
+  return expected;
+}
+
+} // namespace facebook::nimble::test


### PR DESCRIPTION
Summary:
# Context
Knowing the size of the raw data being written is useful for identifying the cause of changes to file sizes after compressing and encoding when writing to files.

# Changes
- Adding the optional Stats section to Tablet
- Calculating the raw data size in bytes via running sum of memory used right before encoding and flushing, and writing this to tablet.
- Unit testing and fuzz testing

# Important Notes
- In `VeloxWriter.cpp` we have special handling for chunked null streams, which is why `materialize` is called before one of the rawSize stat calculations and not the other.
- `rawStripeSize` name updated for clarity and value is now as the name implies, which I can guarantee is correct because it calculated in the same way as raw file size.
  - Some investigation determined that rawStripeSize in stripe flush metrics is also currently not used anywhere.

Differential Revision: D60534808
