### PR TITLE
Add test to do map->flatmap and then passthrough that same flatmap

### DIFF
--- a/dwio/nimble/velox/FieldWriter.cpp
+++ b/dwio/nimble/velox/FieldWriter.cpp
@@ -1369,6 +1369,8 @@ std::unique_ptr<FieldWriter> createArrayWithOffsetsFieldWriter(
 
 FieldWriterContext::LocalDecodedVector
 FieldWriterContext::getLocalDecodedVector() {
+  NIMBLE_DASSERT(vectorDecoderVisitor, "vectorDecoderVisitor is missing");
+  vectorDecoderVisitor();
   return LocalDecodedVector{*this};
 }
 

--- a/dwio/nimble/velox/FieldWriter.h
+++ b/dwio/nimble/velox/FieldWriter.h
@@ -39,13 +39,15 @@ struct FieldWriterContext {
 
   explicit FieldWriterContext(
       velox::memory::MemoryPool& memoryPool,
-      std::unique_ptr<velox::memory::MemoryReclaimer> reclaimer = nullptr)
+      std::unique_ptr<velox::memory::MemoryReclaimer> reclaimer = nullptr,
+      std::function<void(void)> vectorDecoderVisitor = []() {})
       : bufferMemoryPool{memoryPool.addLeafChild(
             "field_writer_buffer",
             true,
             std::move(reclaimer))},
         inputBufferGrowthPolicy{
-            DefaultInputBufferGrowthPolicy::withDefaultRanges()} {
+            DefaultInputBufferGrowthPolicy::withDefaultRanges()},
+        vectorDecoderVisitor(std::move(vectorDecoderVisitor)) {
     resetStringBuffer();
   }
 
@@ -64,6 +66,8 @@ struct FieldWriterContext {
 
   std::function<void(const TypeBuilder&)> typeAddedHandler =
       [](const TypeBuilder&) {};
+
+  std::function<void(void)> vectorDecoderVisitor;
 
   LocalDecodedVector getLocalDecodedVector();
   velox::SelectivityVector& getSelectivityVector(velox::vector_size_t size);

--- a/dwio/nimble/velox/VeloxWriter.cpp
+++ b/dwio/nimble/velox/VeloxWriter.cpp
@@ -64,7 +64,7 @@ class WriterContext : public FieldWriterContext {
   WriterContext(
       velox::memory::MemoryPool& memoryPool,
       VeloxWriterOptions options)
-      : FieldWriterContext{memoryPool, options.reclaimerFactory()},
+      : FieldWriterContext{memoryPool, options.reclaimerFactory(), options.vectorDecoderVisitor},
         options{std::move(options)},
         logger{this->options.metricsLogger} {
     flushPolicy = this->options.flushPolicyFactory();

--- a/dwio/nimble/velox/VeloxWriterOptions.h
+++ b/dwio/nimble/velox/VeloxWriterOptions.h
@@ -131,6 +131,11 @@ struct VeloxWriterOptions {
   std::shared_ptr<folly::Executor> encodingExecutor;
 
   bool enableChunking = false;
+
+  // This callback will be visited on access to getDecodedVector in order to
+  // monitor usage of decoded vectors vs. data that is passed-through in the
+  // writer. Default function is no-op since its used for tests only.
+  std::function<void(void)> vectorDecoderVisitor = []() {};
 };
 
 } // namespace facebook::nimble


### PR DESCRIPTION
Summary:
Test that creates a fuzz map, writes it to a nimble file with flatmap encoding turned on, then reads it back and writes the same vector again. Test ensures that the two paths 
map input ->flatmap vector to write
and
flatmap input->flatmap vector to write

have the same right side output

Reviewed By: helfman

Differential Revision: D62110004


