### PR TITLE
Fix Broken Nimble OSS Build

### DIFF
--- a/dwio/nimble/tablet/tests/TabletTests.cpp
+++ b/dwio/nimble/tablet/tests/TabletTests.cpp
@@ -27,7 +27,6 @@
 #include "dwio/nimble/tablet/TabletWriter.h"
 #include "folly/FileUtil.h"
 #include "folly/Random.h"
-#include "folly/coro/Generator.h"
 #include "folly/executors/CPUThreadPoolExecutor.h"
 #include "velox/common/file/File.h"
 #include "velox/common/memory/Memory.h"


### PR DESCRIPTION
Summary: The OSS build for Nimble is currently broken. I traced the issue to a path change in a folly dependency D62684436. We update the CMakeLists.txt file with the right dependency for this change.

Differential Revision: D63798397


