### PR TITLE
Remove unused-variable in /fbcode/dwio/catalog/AuditLogger.cpp

### DIFF
--- a/dwio/nimble/encodings/tests/TestGenerator.cpp
+++ b/dwio/nimble/encodings/tests/TestGenerator.cpp
@@ -147,7 +147,6 @@ void writeFile(
     std::ofstream file{
         fmt::format("{}/{}.data", path, identifier),
         std::ios::out | std::ios::binary | std::ios::trunc};
-    auto count = data.size();
     for (const auto& value : data) {
       if constexpr (std::is_same_v<std::string_view, typename E::cppDataType>) {
         auto size = value.size();

--- a/dwio/nimble/tablet/tests/TabletTests.cpp
+++ b/dwio/nimble/tablet/tests/TabletTests.cpp
@@ -617,7 +617,7 @@ TEST(TabletTests, OptionalSectionsPreload) {
   LOG(INFO) << "seed: " << seed;
   std::mt19937 rng{seed};
 
-  for (const auto footerCompressionThreshold :
+  for ([[maybe_unused]] const auto footerCompressionThreshold :
        {0U, std::numeric_limits<uint32_t>::max()}) {
     auto pool = velox::memory::deprecatedAddDefaultLeafMemoryPool();
     std::string file;

--- a/dwio/nimble/velox/tests/TypeTests.cpp
+++ b/dwio/nimble/velox/tests/TypeTests.cpp
@@ -327,7 +327,6 @@ TEST_F(TypeTests, FlatMapFeatureSelection) {
 
     for (auto i = 0; i < batchSize; ++i) {
       for (auto j = 0; j < map->sizeAt(i); ++j) {
-        size_t idx = map->offsetAt(i) + j;
         if (!values->isNullAt(i)) {
           uniqueKeys.emplace(keys->valueAt(i));
         }


### PR DESCRIPTION
Summary:
[codemod] Remove unused-variable in {filename}


LLVM-15 has a warning `-Wunused-variable` which we treat as an error because it's so often diagnostic of a code issue. Unused variables can compromise readability or, worse, performance.

This diff either (a) removes an unused variable and, possibly, it's associated code or (b) qualifies the variable with `[[maybe_unused]]`.

#buildsonlynotests - Builds are sufficient to verify
 - If you approve of this diff, please use the "Accept & Ship" button :-)

Differential Revision: D65445300


