### PR TITLE
Remove unused-variable in dwio/api/test/TestApi.cpp +3

### DIFF
--- a/dwio/nimble/encodings/tests/TestGenerator.cpp
+++ b/dwio/nimble/encodings/tests/TestGenerator.cpp
@@ -92,8 +92,6 @@ generateFixedBitWidthData(RNG&& rng, nimble::Buffer& buffer, int count) {
   auto bits = 4 * sizeof(T) - 1;
   physicalType mask = (1 << bits) - 1u;
   LOG(INFO) << nimble::bits::printBits(mask);
-  physicalType val =
-      (randomValue<physicalType>(std::forward<RNG>(rng), buffer)) & mask;
   for (int i = 0; i < count; ++i) {
     physicalType value =
         randomValue<physicalType>(std::forward<RNG>(rng), buffer) & mask;
@@ -171,7 +169,6 @@ void writeFile(
     std::ofstream file{
         fmt::format("{}/{}.nulls", path, identifier),
         std::ios::out | std::ios::binary | std::ios::trunc};
-    auto count = data.size();
     for (const auto& value : nulls.value()) {
       file.write(reinterpret_cast<const char*>(&value), sizeof(uint8_t));
     }


### PR DESCRIPTION
Summary:
LLVM-15 has a warning `-Wunused-variable` which we treat as an error because it's so often diagnostic of a code issue. Unused variables can compromise readability or, worse, performance.

This diff either (a) removes an unused variable and, possibly, it's associated code or (b) qualifies the variable with `[[maybe_unused]]`.

#buildsonlynotests - Builds are sufficient

 - If you approve of this diff, please use the "Accept & Ship" button :-)

Differential Revision: D66330367


