### PR TITLE
Remove unused-variable in dwio/nimble/velox/tests/VeloxWriterTests.cpp +3

### DIFF
--- a/dwio/nimble/velox/tests/VeloxWriterTests.cpp
+++ b/dwio/nimble/velox/tests/VeloxWriterTests.cpp
@@ -193,8 +193,6 @@ TEST_F(VeloxWriterTests, RootHasNulls) {
 }
 
 TEST_F(VeloxWriterTests, FeatureReorderingNonFlatmapColumn) {
-  const uint32_t batchSize = 10;
-
   velox::test::VectorMaker vectorMaker{leafPool_.get()};
   auto vector = vectorMaker.rowVector(
       {"map", "flatmap"},


### PR DESCRIPTION
Summary:
LLVM-15 has a warning `-Wunused-variable` which we treat as an error because it's so often diagnostic of a code issue. Unused variables can compromise readability or, worse, performance.

This diff either (a) removes an unused variable and, possibly, it's associated code or (b) qualifies the variable with `[[maybe_unused]]`.

#buildsonlynotests - Builds are sufficient

 - If you approve of this diff, please use the "Accept & Ship" button :-)

Differential Revision: D66330541


