### PR TITLE
refactor: Use KeepAlive instead of Executor*

### DIFF
--- a/dwio/nimble/tablet/tests/TabletTests.cpp
+++ b/dwio/nimble/tablet/tests/TabletTests.cpp
@@ -553,7 +553,7 @@ TEST(TabletTests, OptionalSections) {
 
   tabletWriter.close();
 
-  folly::CPUThreadPoolExecutor executor{5};
+  auto executor = std::make_shared<folly::CPUThreadPoolExecutor>(5);
   facebook::velox::dwio::common::ExecutorBarrier barrier{executor};
 
   for (auto useChaniedBuffers : {false, true}) {
@@ -914,7 +914,7 @@ TEST(TabletTests, ReferenceCountedCacheStressParallelDuplicates) {
     ++counter;
     return std::make_shared<int>(id);
   }};
-  folly::CPUThreadPoolExecutor executor(10);
+  auto executor = std::make_shared<folly::CPUThreadPoolExecutor>(10);
   velox::dwio::common::ExecutorBarrier barrier(executor);
   constexpr int kEntryIds = 100;
   constexpr int kEntryDuplicates = 10;
@@ -937,7 +937,7 @@ TEST(TabletTests, ReferenceCountedCacheStressParallelDuplicatesSaveEntries) {
     return std::make_shared<int>(id);
   }};
   folly::Synchronized<std::vector<std::shared_ptr<int>>> entries;
-  folly::CPUThreadPoolExecutor executor(10);
+  auto executor = std::make_shared<folly::CPUThreadPoolExecutor>(10);
   velox::dwio::common::ExecutorBarrier barrier(executor);
   constexpr int kEntryIds = 100;
   constexpr int kEntryDuplicates = 10;
@@ -960,7 +960,7 @@ TEST(TabletTests, ReferenceCountedCacheStress) {
     ++counter;
     return std::make_shared<int>(id);
   }};
-  folly::CPUThreadPoolExecutor executor(10);
+  auto executor = std::make_shared<folly::CPUThreadPoolExecutor>(10);
   velox::dwio::common::ExecutorBarrier barrier(executor);
   constexpr int kEntryIds = 100;
   constexpr int kEntryDuplicates = 10;
@@ -982,7 +982,7 @@ TEST(TabletTests, ReferenceCountedCacheStressSaveEntries) {
     return std::make_shared<int>(id);
   }};
   folly::Synchronized<std::vector<std::shared_ptr<int>>> entries;
-  folly::CPUThreadPoolExecutor executor(10);
+  auto executor = std::make_shared<folly::CPUThreadPoolExecutor>(10);
   velox::dwio::common::ExecutorBarrier barrier(executor);
   constexpr int kEntryIds = 100;
   constexpr int kEntryDuplicates = 10;


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebookincubator/velox/pull/11732

folly::Executor::KeepAlive is the recommended way of holding
references to executors as they ensure they are actually kept alive (block the
executor destructor). A shared_ptr or a naked pointer won't ensure the executor
is still available. Other functions from folly (like global pools) only provide
KeepAlive APIs.

Reviewed By: xiaoxmeng, sdruzkin

Differential Revision: D66724539


