### PR TITLE
feat: Add priority based memory reclaim framework

### DIFF
--- a/dwio/nimble/velox/tests/VeloxWriterTests.cpp
+++ b/dwio/nimble/velox/tests/VeloxWriterTests.cpp
@@ -293,7 +293,7 @@ TEST_P(RawStripeSizeFlushPolicyTest, RawStripeSizeFlushPolicy) {
 namespace {
 class MockReclaimer : public velox::memory::MemoryReclaimer {
  public:
-  explicit MockReclaimer() {}
+  explicit MockReclaimer() : velox::memory::MemoryReclaimer(0) {}
   void setEnterArbitrationFunc(std::function<void()>&& func) {
     enterArbitrationFunc_ = func;
   }


### PR DESCRIPTION
Summary:
* Adds priority base reclaiming to memory reclaim framework. The priority determines which memory pool to reclaim first on the same level. This would help to make reclaim more application logic aware. 
* Make join node reclaim priority lower than others. This is because cost of reclaiming (spilling) on join node is high compared to other nodes.

X-link: https://github.com/facebookincubator/velox/pull/11598

Reviewed By: xiaoxmeng

Differential Revision: D66261340

Pulled By: tanjialiang


