### PR TITLE
feat: Table evolution fuzzer

### DIFF
--- a/dwio/nimble/velox/tests/VeloxReaderTests.cpp
+++ b/dwio/nimble/velox/tests/VeloxReaderTests.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -82,6 +82,8 @@ struct VeloxMapGeneratorConfig {
   // If true, generated string field will have variable length, maxing at
   // 'stringLength'.
   bool stringVariableLength = true;
+
+  bool allowConstant = true;
 };
 
 // Generates a RowVector containing a set of feature MapVector with
@@ -140,6 +142,7 @@ class VeloxMapGenerator {
             .stringVariableLength = config_.stringVariableLength,
             .containerLength = 5,
             .containerVariableLength = true,
+            .allowConstantVector = config_.allowConstant,
         },
         leafPool_,
         config_.seed);
@@ -3499,7 +3502,7 @@ TEST_F(VeloxReaderTests, MapToFlatMapAndPassthrough) {
       << "Expected: " << type->toString()
       << ", actual: " << flatRootTypeFromSchema->toString();
 
-  // fullReadResult and nextExpected are interchangable at this point
+  // fullReadResult and nextExpected are interchangeable at this point
   for (auto i = 0; i < fullReadResult.size(); ++i) {
     velox::VectorPtr flatResult;
     auto& current = fullReadResult.at(i);
@@ -5674,6 +5677,7 @@ TEST_F(VeloxReaderTests, EstimatedRowSizeComplex) {
           // BaseVector::retainedSize()
           .stringLength = velox::StringView::kInlineSize,
           .stringVariableLength = false,
+          .allowConstant = false,
       };
       VeloxMapGenerator generator(leafPool_.get(), generatorConfig);
       auto vector = generator.generateBatch(rowCount);


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebookincubator/velox/pull/11872

Basic version of table evolution fuzzer.  Full design of the fuzzer can be found at https://docs.google.com/document/d/18jjNRknSxI99mgdL7eDMzkq65i-mi47Ukymi3JkXzUA/edit

Differential Revision: D67283632


