### PR TITLE
Add thread local context information in exception

### DIFF
--- a/dwio/nimble/common/CMakeLists.txt
+++ b/dwio/nimble/common/CMakeLists.txt
@@ -16,4 +16,4 @@ add_subdirectory(tests)
 add_library(nimble_common Bits.cpp Checksum.cpp FixedBitArray.cpp
                           MetricsLogger.cpp Types.cpp Varint.cpp)
 
-target_link_libraries(nimble_common velox_memory Folly::folly)
+target_link_libraries(nimble_common velox_memory velox_exception Folly::folly)


### PR DESCRIPTION
Summary:
When running with Velox, the thread local context is not captured in
exception.  For example we are missing file path in the Prestissimo query error
20241216_142035_60655_zc54y.

Differential Revision: D67569514


