### PR TITLE
Skip incompatible feature ordering configuration

### DIFF
--- a/dwio/nimble/velox/LayoutPlanner.cpp
+++ b/dwio/nimble/velox/LayoutPlanner.cpp
@@ -117,19 +117,21 @@ std::vector<Stream> DefaultLayoutPlanner::getLayout(
   orderedFlatMapOffsets.reserve(flatMapFeatureOrder_.size() * 3);
 
   for (const auto& flatMapFeatures : flatMapFeatureOrder_) {
-    NIMBLE_CHECK(
-        std::get<0>(flatMapFeatures) < root.childrenCount(),
-        fmt::format(
-            "Column ordinal {} for feature ordering is out of range. "
-            "Top-level row has {} columns.",
-            std::get<0>(flatMapFeatures),
-            root.childrenCount()));
+    if (std::get<0>(flatMapFeatures) >= root.childrenCount()) {
+      LOG(WARNING)
+          << "Column ordinal " << std::get<0>(flatMapFeatures)
+          << " for feature ordering is out of range. Top-level row has "
+          << root.childrenCount() << " columns.";
+      continue;
+    }
+
     auto& column = root.childAt(std::get<0>(flatMapFeatures));
-    NIMBLE_CHECK(
-        column.kind() == Kind::FlatMap,
-        fmt::format(
-            "Column '{}' for feature ordering is not a flat map.",
-            root.nameAt(std::get<0>(flatMapFeatures))));
+
+    if (column.kind() != Kind::FlatMap) {
+      LOG(WARNING) << "Column '" << root.nameAt(std::get<0>(flatMapFeatures))
+                   << "' for feature ordering is not a flat map.";
+      continue;
+    }
 
     auto& flatMap = column.asFlatMap();
 

--- a/dwio/nimble/velox/tests/VeloxWriterTests.cpp
+++ b/dwio/nimble/velox/tests/VeloxWriterTests.cpp
@@ -192,7 +192,9 @@ TEST_F(VeloxWriterTests, RootHasNulls) {
   }
 }
 
-TEST_F(VeloxWriterTests, FeatureReorderingNonFlatmapColumn) {
+TEST_F(
+    VeloxWriterTests,
+    FeatureReorderingNonFlatmapColumnIgnoresMismatchedConfig) {
   velox::test::VectorMaker vectorMaker{leafPool_.get()};
   auto vector = vectorMaker.rowVector(
       {"map", "flatmap"},
@@ -220,18 +222,8 @@ TEST_F(VeloxWriterTests, FeatureReorderingNonFlatmapColumn) {
        .featureReordering =
            std::vector<std::tuple<size_t, std::vector<int64_t>>>{
                {0, {1, 2}}, {1, {3, 4}}}});
-
-  try {
-    writer.write(vector);
-    writer.close();
-    FAIL();
-  } catch (const nimble::NimbleUserError& e) {
-    EXPECT_EQ("USER", e.errorSource());
-    EXPECT_EQ("INVALID_ARGUMENT", e.errorCode());
-    EXPECT_EQ(
-        "Column 'map' for feature ordering is not a flat map.",
-        e.errorMessage());
-  }
+  writer.write(vector);
+  writer.close();
 }
 
 namespace {


### PR DESCRIPTION
Summary: Skip incompatible feature ordering configuration to avoid writer failures in case of mismatch in the schema or flat map configuration.

Differential Revision: D68024263


