### PR TITLE
Add a new command to nimble_dump: stripes_metadata

### DIFF
--- a/dwio/nimble/tools/NimbleDump.cpp
+++ b/dwio/nimble/tools/NimbleDump.cpp
@@ -314,6 +314,31 @@ int main(int argc, char* argv[]) {
               );
   // clang-format on
 
+  app.addCommand(
+         "stripes_metadata",
+         "<file>",
+         "Print stripes metadata information",
+         "Prints stripes metadata information as referenced by the footer.",
+         [](const po::variables_map& options,
+            const std::vector<std::string>& /*args*/) {
+           nimble::tools::NimbleDumpLib{
+               std::cout, options["file"].as<std::string>()}
+               .emitStripesMetadata(options["no_header"].as<bool>());
+         },
+         positionalArgs)
+      // clang-format off
+        .add_options()
+        (
+            "file",
+            po::value<std::string>()->required(),
+            "Nimble file path. Can be a local path or a Warm Storage path."
+        )(
+            "no_header,n",
+            po::bool_switch()->default_value(false),
+            "Don't print column names. Default is to include column names."
+        );
+  // clang-format on
+
   app.addAlias("i", "info");
   app.addAlias("b", "binary");
   app.addAlias("c", "content");

--- a/dwio/nimble/tools/NimbleDumpLib.cpp
+++ b/dwio/nimble/tools/NimbleDumpLib.cpp
@@ -274,8 +274,8 @@ void NimbleDumpLib::emitInfo() {
   if (!stripesMetadata) {
     ostream_ << "0" << std::endl;
   } else {
-    ostream_ << commaSeparated(stripesMetadata.value().size()) << " ("
-             << stripesMetadata.value().compressionType() << ")" << std::endl;
+    ostream_ << commaSeparated(stripesMetadata->size()) << " ("
+             << stripesMetadata->compressionType() << ")" << std::endl;
   }
   auto stripeGroupsMetadata = tablet->stripeGroupsMetadata();
   ostream_ << "Stripe Groups Metadata Size: "
@@ -863,6 +863,27 @@ void NimbleDumpLib::emitLayout(bool noHeader, bool compressed) {
              std::string(node.name()),
              encodingLayout});
       });
+}
+
+void NimbleDumpLib::emitStripesMetadata(bool noHeader) {
+  TabletReader tabletReader{*pool_, file_.get()};
+  TableFormatter formatter(
+      ostream_,
+      {
+          {"Offset", 15, Alignment::Left},
+          {"Size", 15, Alignment::Left},
+          {"Compression Type", 18, Alignment::Left},
+      },
+      noHeader);
+  auto stripesMetadata = tabletReader.stripesMetadata();
+  if (!stripesMetadata) {
+    return;
+  }
+  formatter.writeRow({
+      commaSeparated(stripesMetadata->offset()),
+      commaSeparated(stripesMetadata->size()),
+      toString(stripesMetadata->compressionType()),
+  });
 }
 
 } // namespace facebook::nimble::tools

--- a/dwio/nimble/tools/NimbleDumpLib.h
+++ b/dwio/nimble/tools/NimbleDumpLib.h
@@ -43,6 +43,7 @@ class NimbleDumpLib {
       uint32_t streamId,
       uint32_t stripeId);
   void emitLayout(bool noHeader, bool compressed);
+  void emitStripesMetadata(bool noHeader);
 
  private:
   std::shared_ptr<velox::memory::MemoryPool> pool_;


### PR DESCRIPTION
Summary: `stripes_metadata` dumps the stripes metadata information as referenced by the footer: https://www.internalfb.com/code/fbsource/[3a9c4e4b1b7b7e7b22668f54ddc12f0ccfc904b4]/fbcode/dwio/nimble/tablet/Footer.fbs?lines=52

Differential Revision: D68031461


