### PR TITLE
Use Ubuntu 22.04 for CI

### DIFF
--- a/.github/workflows/linux-build.yml
+++ b/.github/workflows/linux-build.yml
@@ -30,7 +30,7 @@ concurrency:
 
 jobs:
   ubuntu-release:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     if: ${{ github.repository == 'facebookincubator/nimble' }}
     name: "Ubuntu Build"
     env:


### PR DESCRIPTION
"ubuntu-latest" is "ubuntu-24.04" now.

Our CI worked with "ubuntu-22.04". For example:
https://github.com/facebookincubator/nimble/actions/runs/12754920533

But it doesn't work with "ubuntu-24.04": For example:

https://github.com/facebookincubator/nimble/actions/runs/13042775062/job/36387994477#step:5:694

```text
 [  2%] Building CXX object _deps/abseil-build/absl/time/CMakeFiles/absl_time_zone.dir/internal/cctz/src/time_zone_format.cc.o
In file included from /home/runner/work/nimble/nimble/nimble/_build/release/_deps/abseil-src/absl/time/internal/cctz/src/time_zone_fixed.cc:15:
In file included from /home/runner/work/nimble/nimble/nimble/_build/release/_deps/abseil-src/absl/time/internal/cctz/src/time_zone_fixed.h:18:
In file included from /usr/bin/../lib/gcc/x86_64-linux-gnu/14/../../../../include/c++/14/string:42:
In file included from /usr/bin/../lib/gcc/x86_64-linux-gnu/14/../../../../include/c++/14/bits/char_traits.h:57:
In file included from /usr/bin/../lib/gcc/x86_64-linux-gnu/14/../../../../include/c++/14/bits/stl_construct.h:61:
In file included from /usr/bin/../lib/gcc/x86_64-linux-gnu/14/../../../../include/c++/14/bits/stl_iterator_base_types.h:71:
/usr/bin/../lib/gcc/x86_64-linux-gnu/14/../../../../include/c++/14/bits/iterator_concepts.h:1013:13: error: no matching function for call to '__begin'
        = decltype(ranges::__access::__begin(std::declval<_Tp&>()));
                       ^~~~~~~~~~~~~~~~~~~~~~~~~
```

We should use "ubuntu-24.04" eventually but how about using "ubuntu-22.04" for now for green CI?