### PR TITLE
Add Method to Calculate Logical/Raw Stats for Flat/Constant Scalars Vectors

### DIFF
--- a/dwio/nimble/velox/CMakeLists.txt
+++ b/dwio/nimble/velox/CMakeLists.txt
@@ -119,3 +119,6 @@ target_link_libraries(
   nimble_velox_stats_fb
   velox_dwio_common
   Folly::folly)
+
+add_library(raw_size_utils RawSizeUtils.cpp)
+target_link_libraries(raw_size_utils velox_vector)

--- a/dwio/nimble/velox/RawSizeUtils.cpp
+++ b/dwio/nimble/velox/RawSizeUtils.cpp
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "dwio/nimble/velox/RawSizeUtils.h"
+
+namespace facebook::nimble {
+
+// Returns uint64_t bytes of raw data in the vector.
+uint64_t getRawSizeFromVector(const velox::VectorPtr& vector) {
+  VELOX_CHECK_NOT_NULL(vector, "vector is null");
+  const auto& typeKind = vector->typeKind();
+  switch (typeKind) {
+    case velox::TypeKind::BOOLEAN: {
+      return getRawSizeFromFixedWidthVector<bool>(vector);
+    }
+    case velox::TypeKind::TINYINT: {
+      return getRawSizeFromFixedWidthVector<int8_t>(vector);
+    }
+    case velox::TypeKind::SMALLINT: {
+      return getRawSizeFromFixedWidthVector<int16_t>(vector);
+    }
+    case velox::TypeKind::INTEGER: {
+      return getRawSizeFromFixedWidthVector<int32_t>(vector);
+    }
+    case velox::TypeKind::BIGINT: {
+      return getRawSizeFromFixedWidthVector<int64_t>(vector);
+    }
+    case velox::TypeKind::REAL: {
+      return getRawSizeFromFixedWidthVector<float>(vector);
+    }
+    case velox::TypeKind::DOUBLE: {
+      return getRawSizeFromFixedWidthVector<double>(vector);
+    }
+    case velox::TypeKind::VARCHAR:
+    case velox::TypeKind::VARBINARY: {
+      return getRawSizeFromStringVector<velox::StringView>(vector);
+    }
+    default: {
+      VELOX_FAIL("Unsupported type: {}", typeKind);
+    }
+  }
+}
+
+} // namespace facebook::nimble

--- a/dwio/nimble/velox/RawSizeUtils.h
+++ b/dwio/nimble/velox/RawSizeUtils.h
@@ -1,0 +1,109 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include "velox/vector/BaseVector.h"
+#include "velox/vector/ConstantVector.h"
+#include "velox/vector/FlatVector.h"
+
+namespace facebook::nimble {
+
+constexpr uint64_t NULL_SIZE = 1;
+
+template <typename T>
+uint64_t getRawSizeFromFixedWidthVector(const velox::VectorPtr& vector) {
+  VELOX_DCHECK(
+      (std::disjunction_v<
+          std::is_same<bool, T>,
+          std::is_same<int8_t, T>,
+          std::is_same<int16_t, T>,
+          std::is_same<int32_t, T>,
+          std::is_same<int64_t, T>,
+          std::is_same<float, T>,
+          std::is_same<double, T>>),
+      "Wrong vector type. Expected bool | int8_t | int16_t | int32_t | int64_t | float | double.");
+
+  const auto& encoding = vector->encoding();
+  switch (encoding) {
+    case velox::VectorEncoding::Simple::FLAT: {
+      auto* flatVector = vector->asFlatVector<T>();
+      VELOX_CHECK_NOT_NULL(flatVector, "vector is null");
+
+      const auto nullCount = velox::BaseVector::countNulls(
+          flatVector->nulls(), flatVector->size());
+
+      // Non null count * size in bytes + null count * null size
+      return ((flatVector->size() - nullCount) *
+              flatVector->type()->cppSizeInBytes()) +
+          (nullCount * NULL_SIZE);
+    }
+    case velox::VectorEncoding::Simple::CONSTANT: {
+      auto* constVector = vector->as<velox::ConstantVector<T>>();
+      VELOX_CHECK_NOT_NULL(constVector, "vector is null");
+
+      return constVector->mayHaveNulls()
+          ? NULL_SIZE * constVector->size()
+          : constVector->size() * constVector->type()->cppSizeInBytes();
+    }
+    default: {
+      VELOX_FAIL("Unsupported encoding: {}", encoding);
+    }
+  }
+}
+
+template <typename T>
+uint64_t getRawSizeFromStringVector(const velox::VectorPtr& vector) {
+  VELOX_DCHECK(
+      (std::is_same_v<velox::StringView, T>),
+      "Wrong vector type. Expected StringView.");
+
+  const auto& encoding = vector->encoding();
+  switch (encoding) {
+    case velox::VectorEncoding::Simple::FLAT: {
+      auto* flatVector = vector->as<velox::FlatVector<T>>();
+      VELOX_CHECK_NOT_NULL(flatVector, "vector is null");
+
+      const auto nullCount = velox::BaseVector::countNulls(
+          flatVector->nulls(), flatVector->size());
+
+      const velox::StringView* stringValues = flatVector->rawValues();
+      uint64_t rawSize = std::accumulate(
+          stringValues,
+          stringValues + flatVector->size(),
+          uint64_t(0),
+          [](uint64_t sum, const velox::StringView& str) {
+            return sum + str.size();
+          });
+
+      return rawSize + (nullCount * NULL_SIZE);
+    }
+    case velox::VectorEncoding::Simple::CONSTANT: {
+      auto* constVector = vector->as<velox::ConstantVector<T>>();
+      VELOX_CHECK_NOT_NULL(constVector, "vector is null");
+
+      return constVector->mayHaveNulls()
+          ? NULL_SIZE * constVector->size()
+          : constVector->value().size() * constVector->size();
+    }
+    default: {
+      VELOX_FAIL("Unsupported encoding: {}", encoding);
+    }
+  }
+}
+
+uint64_t getRawSizeFromVector(const velox::VectorPtr& vector);
+
+} // namespace facebook::nimble

--- a/dwio/nimble/velox/tests/CMakeLists.txt
+++ b/dwio/nimble/velox/tests/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -43,6 +43,18 @@ target_link_libraries(
   velox_vector_fuzzer
   velox_vector_test_lib
   gmock
+  gtest
+  gtest_main
+  Folly::folly)
+
+add_executable(raw_size_tests RawSizeTests.cpp)
+add_test(raw_size_tests raw_size_tests)
+
+target_link_libraries(
+  raw_size_tests
+  raw_size_utils
+  velox_vector
+  velox_vector_test_lib
   gtest
   gtest_main
   Folly::folly)

--- a/dwio/nimble/velox/tests/RawSizeTests.cpp
+++ b/dwio/nimble/velox/tests/RawSizeTests.cpp
@@ -1,0 +1,216 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include <gtest/gtest.h>
+
+#include "dwio/nimble/velox/RawSizeUtils.h"
+#include "velox/vector/tests/utils/VectorMaker.h"
+
+using namespace facebook;
+
+class RawSizeBaseTestFixture : public ::testing::Test {
+ protected:
+  static void SetUpTestSuite() {
+    velox::memory::MemoryManager::initialize({});
+  }
+
+  void SetUp() override {
+    pool_ = velox::memory::memoryManager()->addLeafPool();
+  }
+
+  std::shared_ptr<velox::memory::MemoryPool> pool_;
+};
+
+class RawSizeTestFixture : public RawSizeBaseTestFixture {};
+
+template <typename T>
+class RawSizeTypedTestFixture : public RawSizeBaseTestFixture {};
+
+TYPED_TEST_SUITE_P(RawSizeTypedTestFixture);
+
+TYPED_TEST_P(RawSizeTypedTestFixture, FlatVector) {
+  auto vectorMaker = velox::test::VectorMaker(this->pool_.get());
+  auto flatVector =
+      vectorMaker.flatVector<TypeParam>({0, 1, 0, 1, 0, 1, 0, 1, 0, 1});
+  auto rawSize = nimble::getRawSizeFromVector(flatVector);
+
+  ASSERT_EQ(sizeof(TypeParam) * 10, rawSize);
+}
+
+TYPED_TEST_P(RawSizeTypedTestFixture, FlatVectorSomeNull) {
+  auto vectorMaker = velox::test::VectorMaker(this->pool_.get());
+  auto flatVector = vectorMaker.flatVectorNullable<TypeParam>(
+      {0, 1, 0, 1, 0, 1, 0, std::nullopt, std::nullopt, std::nullopt});
+  auto rawSize = nimble::getRawSizeFromVector(flatVector);
+
+  ASSERT_EQ(sizeof(TypeParam) * 7 + nimble::NULL_SIZE * 3, rawSize);
+}
+
+TYPED_TEST_P(RawSizeTypedTestFixture, FlatVectorAllNull) {
+  auto vectorMaker = velox::test::VectorMaker(this->pool_.get());
+  auto flatVector = vectorMaker.flatVectorNullable<TypeParam>(
+      {std::nullopt,
+       std::nullopt,
+       std::nullopt,
+       std::nullopt,
+       std::nullopt,
+       std::nullopt,
+       std::nullopt,
+       std::nullopt,
+       std::nullopt,
+       std::nullopt});
+  auto rawSize = nimble::getRawSizeFromVector(flatVector);
+
+  ASSERT_EQ(nimble::NULL_SIZE * 10, rawSize);
+}
+
+TYPED_TEST_P(RawSizeTypedTestFixture, ConstVector) {
+  auto vectorMaker = velox::test::VectorMaker(this->pool_.get());
+  auto constVector = vectorMaker.constantVector<TypeParam>({0, 0, 0, 0, 0, 0});
+  auto rawSize = nimble::getRawSizeFromVector(constVector);
+
+  ASSERT_EQ(sizeof(TypeParam) * 6, rawSize);
+}
+
+TYPED_TEST_P(RawSizeTypedTestFixture, ConstVectorAllNull) {
+  auto vectorMaker = velox::test::VectorMaker(this->pool_.get());
+  auto constVector = vectorMaker.constantVector<TypeParam>(
+      {std::nullopt,
+       std::nullopt,
+       std::nullopt,
+       std::nullopt,
+       std::nullopt,
+       std::nullopt});
+  auto rawSize = nimble::getRawSizeFromVector(constVector);
+
+  ASSERT_EQ(nimble::NULL_SIZE * 6, rawSize);
+}
+
+REGISTER_TYPED_TEST_SUITE_P(
+    RawSizeTypedTestFixture,
+    FlatVector,
+    FlatVectorSomeNull,
+    FlatVectorAllNull,
+    ConstVector,
+    ConstVectorAllNull);
+
+using FixedWidthTypes =
+    ::testing::Types<bool, int8_t, int16_t, int32_t, int64_t, float, double>;
+
+INSTANTIATE_TYPED_TEST_SUITE_P(
+    RawSizeTestSuite,
+    RawSizeTypedTestFixture,
+    FixedWidthTypes);
+
+TEST_F(RawSizeTestFixture, FlatString) {
+  auto vectorMaker = velox::test::VectorMaker(pool_.get());
+  auto flatVector = vectorMaker.flatVector<velox::StringView>(
+      {"a", "bbbb", "ccccccccc", "dddddddddddddddd"}); // 1 4 9 16
+  auto rawSize = nimble::getRawSizeFromVector(flatVector);
+
+  ASSERT_EQ(30, rawSize);
+}
+
+TEST_F(RawSizeTestFixture, FlatStringSomeNull) {
+  auto vectorMaker = velox::test::VectorMaker(pool_.get());
+  auto flatVector = vectorMaker.flatVectorNullable<velox::StringView>(
+      {"a", "bbbb", std::nullopt, "dddddddddddddddd"}); // 1 4 16 + 1
+  auto rawSize = nimble::getRawSizeFromVector(flatVector);
+
+  ASSERT_EQ(22, rawSize);
+}
+
+TEST_F(RawSizeTestFixture, FlatStringAllNull) {
+  auto vectorMaker = velox::test::VectorMaker(pool_.get());
+  auto flatVector = vectorMaker.flatVectorNullable<velox::StringView>(
+      {std::nullopt, std::nullopt, std::nullopt, std::nullopt});
+  auto rawSize = nimble::getRawSizeFromVector(flatVector);
+
+  ASSERT_EQ(nimble::NULL_SIZE * 4, rawSize);
+}
+
+TEST_F(RawSizeTestFixture, FlatStringVarBinary) {
+  auto vectorMaker = velox::test::VectorMaker(pool_.get());
+  auto flatVector = vectorMaker.flatVector<velox::StringView>(
+      {"a", "bbbb", "ccccccccc", "dddddddddddddddd"},
+      velox::VARBINARY()); // 1 4 9 16
+  auto rawSize = nimble::getRawSizeFromVector(flatVector);
+
+  ASSERT_EQ(30, rawSize);
+}
+
+TEST_F(RawSizeTestFixture, FlatStringVarBinarySomeNull) {
+  auto vectorMaker = velox::test::VectorMaker(pool_.get());
+  auto flatVector = vectorMaker.flatVectorNullable<velox::StringView>(
+      {"a", "bbbb", std::nullopt, "dddddddddddddddd"},
+      velox::VARBINARY()); // 1 4 16 + 1
+  auto rawSize = nimble::getRawSizeFromVector(flatVector);
+
+  ASSERT_EQ(22, rawSize);
+}
+
+TEST_F(RawSizeTestFixture, FlatStringVarBinaryAllNull) {
+  auto vectorMaker = velox::test::VectorMaker(pool_.get());
+  auto flatVector = vectorMaker.flatVectorNullable<velox::StringView>(
+      {std::nullopt, std::nullopt, std::nullopt, std::nullopt},
+      velox::VARBINARY());
+  auto rawSize = nimble::getRawSizeFromVector(flatVector);
+
+  ASSERT_EQ(nimble::NULL_SIZE * 4, rawSize);
+}
+
+TEST_F(RawSizeTestFixture, ConstString) {
+  auto vectorMaker = velox::test::VectorMaker(this->pool_.get());
+  auto constVector = vectorMaker.constantVector<velox::StringView>(
+      {"foo", "foo", "foo", "foo"});
+  auto rawSize = nimble::getRawSizeFromVector(constVector);
+
+  ASSERT_EQ(3 * 4, rawSize);
+}
+
+TEST_F(RawSizeTestFixture, ConstStringAllNull) {
+  auto vectorMaker = velox::test::VectorMaker(this->pool_.get());
+  auto constVector = vectorMaker.constantVector<velox::StringView>(
+      {std::nullopt, std::nullopt, std::nullopt, std::nullopt});
+  auto rawSize = nimble::getRawSizeFromVector(constVector);
+
+  ASSERT_EQ(nimble::NULL_SIZE * 4, rawSize);
+}
+
+TEST_F(RawSizeTestFixture, ThrowOnDefaultType) {
+  auto unknownVector = facebook::velox::BaseVector::create(
+      facebook::velox::UNKNOWN(), 10, pool_.get());
+
+  EXPECT_THROW(
+      nimble::getRawSizeFromVector(unknownVector), velox::VeloxRuntimeError);
+}
+
+TEST_F(RawSizeTestFixture, ThrowOnDefaultEncodingFixedWidth) {
+  auto vectorMaker = velox::test::VectorMaker(pool_.get());
+  auto sequenceVector =
+      vectorMaker.sequenceVector<int8_t>({0, 1, 2, 3, 4, 5, 6, 7, 8, 9});
+
+  EXPECT_THROW(
+      nimble::getRawSizeFromVector(sequenceVector), velox::VeloxRuntimeError);
+}
+
+TEST_F(RawSizeTestFixture, ThrowOnDefaultEncodingVariableWidth) {
+  auto vectorMaker = velox::test::VectorMaker(pool_.get());
+  auto sequenceVector = vectorMaker.sequenceVector<velox::StringView>(
+      {"a", "bbbb", "ccccccccc", "dddddddddddddddd"});
+
+  EXPECT_THROW(
+      nimble::getRawSizeFromVector(sequenceVector), velox::VeloxRuntimeError);
+}


### PR DESCRIPTION
Summary:
Adding function that takes in a Velox Vector and returns the logical/raw sizing of the data.

Currently the function will support Flat and Constant encoding vectors for Scalar types.

Differential Revision: D69929415


