### PR TITLE
Update copyright line

### DIFF
--- a/.github/workflows/linux-build.yml
+++ b/.github/workflows/linux-build.yml
@@ -1,4 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/.github/workflows/sanity_check.yml
+++ b/.github/workflows/sanity_check.yml
@@ -1,4 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/dwio/nimble/common/tests/CMakeLists.txt
+++ b/dwio/nimble/common/tests/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/dwio/nimble/encodings/tests/CMakeLists.txt
+++ b/dwio/nimble/encodings/tests/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/dwio/nimble/tablet/tests/CMakeLists.txt
+++ b/dwio/nimble/tablet/tests/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/dwio/nimble/tools/CMakeLists.txt
+++ b/dwio/nimble/tools/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/dwio/nimble/velox/tests/CMakeLists.txt
+++ b/dwio/nimble/velox/tests/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.


### PR DESCRIPTION
We still have "and its affiliates" in copyright lines:

    $ git grep 'and its affiliates'
    .github/workflows/linux-build.yml:# Copyright (c) Meta Platforms, Inc. and its affiliates.
    .github/workflows/sanity_check.yml:# Copyright (c) Meta Platforms, Inc. and its affiliates.
    Makefile:# Copyright (c) Meta Platforms, Inc. and its affiliates.
    dwio/nimble/common/tests/CMakeLists.txt:# Copyright (c) Meta Platforms, Inc. and its affiliates.
    dwio/nimble/encodings/tests/CMakeLists.txt:# Copyright (c) Meta Platforms, Inc. and its affiliates.
    dwio/nimble/tablet/tests/CMakeLists.txt:# Copyright (c) Meta Platforms, Inc. and its affiliates.
    dwio/nimble/tools/CMakeLists.txt:# Copyright (c) Meta Platforms, Inc. and its affiliates.
    dwio/nimble/velox/tests/CMakeLists.txt:# Copyright (c) Meta Platforms, Inc. and its affiliates.