### PR TITLE
Fix Chunk Decoder for string types

### DIFF
--- a/dwio/nimble/velox/ChunkedStreamDecoder.cpp
+++ b/dwio/nimble/velox/ChunkedStreamDecoder.cpp
@@ -147,7 +147,8 @@ uint32_t ChunkedStreamDecoder::next(
       // string buffers of the Velox Vector. Later diff will change this logic
       // to directly copy the strings into the Velox string buffers directly.
       auto& buffer = stringBuffers_.emplace_back(&pool_);
-      bufferStringContent(buffer, output, nullsPtr, offset, rowsToRead);
+      bufferStringContent(
+          buffer, output, nullsPtr, offset, (endOffset - offset));
     }
 
     offset = endOffset;


### PR DESCRIPTION
Summary:
When a string stream is not chunked, the materialized data contains string_views pointing to the actual stream data.

Once a new chunk is leaded, the old stream data is disposed.
This means that the string_views no longer point to a valid memory.

For this reason, we have a buffering solution in the chunked decoder (only for the string case), where before we load the next chunk, we copy all the strings to a buffer managed by the chunked decoder.

Turns out this buffering logic had a bug, and it wasn't counting correctly all the strings to copy, if scattering and nulls are mixed together.

We didn't have string tests to cover this case.

As part of this change, I added string tests (which were failing very fast before the fix).

Differential Revision: D70021503


