### PR TITLE
Use standard header name

### DIFF
--- a/dwio/nimble/common/Buffer.h
+++ b/dwio/nimble/common/Buffer.h
@@ -18,8 +18,8 @@
 #include "velox/buffer/Buffer.h"
 #include "velox/common/memory/Memory.h"
 
-#include <bits/unique_ptr.h>
 #include <cstring>
+#include <memory>
 #include <string_view>
 #include <vector>
 


### PR DESCRIPTION
Summary: `bits/unique_ptr.h` is not a standard header name. As we are migrating fbcode to libc++, this showed up as an error. Use standard <memory> header instead.

Differential Revision: D70754769


