### PR TITLE
Remove unused private from dwio/nimble/velox/FieldWriter.cpp +1

### DIFF
--- a/dwio/nimble/velox/FieldWriter.cpp
+++ b/dwio/nimble/velox/FieldWriter.cpp
@@ -778,8 +778,7 @@ class FlatMapValueFieldWriter {
       FieldWriterContext& context,
       const StreamDescriptorBuilder& inMapDescriptor,
       std::unique_ptr<FieldWriter> valueField)
-      : inMapDescriptor_{inMapDescriptor},
-        valueField_{std::move(valueField)},
+      : valueField_{std::move(valueField)},
         inMapStream_{context.createContentStreamData<bool>(inMapDescriptor)} {}
 
   // Clear the ranges and extend the inMapBuffer
@@ -823,7 +822,6 @@ class FlatMapValueFieldWriter {
   }
 
  private:
-  const StreamDescriptorBuilder& inMapDescriptor_;
   std::unique_ptr<FieldWriter> valueField_;
   ContentStreamData<bool>& inMapStream_;
   OrderedRanges ranges_;


### PR DESCRIPTION
Summary:
`-Wunused-private-field` has identified an unused private field. This diff removes it.

If the code compiles, this is safe to land.

Reviewed By: dtolnay

Differential Revision: D71063936


