### PR TITLE
Fix incorrect nulls in multi-chunk sparse read

### DIFF
--- a/dwio/nimble/encodings/Encoding.h
+++ b/dwio/nimble/encodings/Encoding.h
@@ -470,6 +470,15 @@ void readWithVisitorFast(
           outerRows,
           chunkResultNulls,
           tailSkip);
+  if constexpr (kOutputNulls) {
+    if (auto remainderBitCount = numRows % 8) {
+      // `nonNullRowsFromSparse' resets the bits in last byte after `numRows'.
+      // We need to set them back to ensure rows in next chunk is not
+      // incorrectly nullified.
+      chunkResultNulls[(numRows - 1) / 8] |= static_cast<uint8_t>(-1)
+          << remainderBitCount;
+    }
+  }
   if (anyNulls) {
     visitor.setHasNulls();
   }


### PR DESCRIPTION
Summary:
When all these conditions are satisfied:
* The row set is sparse (a filter on another column filtered some rows out)
* In a multi-chunk read
* The field has nulls in a previous chunk in the same read call, and that chunk decoder has fast path
* It does not have nulls in next chunk

And when we write out result nulls for first chunks, if there is extra bits after in the last by after the last bit in the chunk, these bits are cleared to 0.  Since the next chunk does not write nulls, the 0s would be left there in result nulls and causing extra nulls in result.  Fix this by set the remaining bits to 1 in the last byte when we read previous chunk.

Differential Revision: D73993832


