### PR TITLE
Allow nimble writer to work with leaf pool

### DIFF
--- a/dwio/nimble/velox/VeloxWriter.h
+++ b/dwio/nimble/velox/VeloxWriter.h
@@ -71,8 +71,8 @@ class VeloxWriter {
  private:
   std::shared_ptr<const velox::dwio::common::TypeWithId> schema_;
   std::unique_ptr<velox::WriteFile> file_;
-  std::shared_ptr<velox::memory::MemoryPool> writerMemoryPool_;
-  std::shared_ptr<velox::memory::MemoryPool> encodingMemoryPool_;
+  MemoryPoolHolder writerMemoryPool_;
+  MemoryPoolHolder encodingMemoryPool_;
   std::unique_ptr<detail::WriterContext> context_;
   TabletWriter writer_;
   std::unique_ptr<FieldWriter> root_;


### PR DESCRIPTION
Summary:
Nimble writer needs root pool because it will create agg pools to do memory accounting. However, this makes it harder for caller as most of the cases, caller doesn't know if a writer needs a leaf pool or not, hence have to know the implementation details to pass the right pool.

To make it worse, in Nimble serializer uses a root pool as well due to using Nimble writer. It's quite hard to wire up an agg pool there, and causes a lot of confusion different pools have to be wired up due to the encoding type and if it's encoding or decoding.

This diff addresses the problem by allowing Nimble to use a leaf pool. In the case when leaf pool is passed in, it will use it only for allocation without creating additional child pools.

Differential Revision: D74020754


