### PR TITLE
refactor: Move MemoryManagerOptions inside MemoryManager step0-nimble, explicitly specify object type

### DIFF
--- a/dwio/nimble/common/tests/VectorTests.cpp
+++ b/dwio/nimble/common/tests/VectorTests.cpp
@@ -216,7 +216,9 @@ TEST(VectorTests, BoolCopyCtr) {
 }
 
 TEST(VectorTests, MemoryCleanup) {
-  velox::memory::MemoryManager memoryManager{{.trackDefaultUsage = true}};
+  velox::memory::MemoryManagerOptions options;
+  options.trackDefaultUsage = true;
+  velox::memory::MemoryManager memoryManager{options};
   auto pool = memoryManager.addLeafPool();
   EXPECT_EQ(0, pool->usedBytes());
   {

--- a/dwio/nimble/velox/tests/DeduplicationUtilsTests.cpp
+++ b/dwio/nimble/velox/tests/DeduplicationUtilsTests.cpp
@@ -25,8 +25,9 @@ class DeduplicationUtilsTests : public ::testing::Test {
  protected:
   static void SetUpTestCase() {
     velox::memory::SharedArbitrator::registerFactory();
-    velox::memory::MemoryManager::testingSetInstance(
-        {.arbitratorKind = "SHARED"});
+    velox::memory::MemoryManagerOptions options;
+    options.arbitratorKind = "SHARED";
+    velox::memory::MemoryManager::testingSetInstance(options);
   }
 
   void SetUp() override {

--- a/dwio/nimble/velox/tests/RawSizeTests.cpp
+++ b/dwio/nimble/velox/tests/RawSizeTests.cpp
@@ -79,7 +79,8 @@ uint64_t getSize<velox::Timestamp>(velox::Timestamp /*value*/) {
 class RawSizeBaseTestFixture : public ::testing::Test {
  protected:
   static void SetUpTestSuite() {
-    velox::memory::MemoryManager::initialize({});
+    velox::memory::MemoryManager::initialize(
+        velox::memory::MemoryManagerOptions{});
   }
 
   void SetUp() override {

--- a/dwio/nimble/velox/tests/TypeTests.cpp
+++ b/dwio/nimble/velox/tests/TypeTests.cpp
@@ -28,7 +28,8 @@ using namespace facebook;
 class TypeTests : public ::testing::Test {
  protected:
   static void SetUpTestCase() {
-    velox::memory::MemoryManager::testingSetInstance({});
+    velox::memory::MemoryManager::testingSetInstance(
+        velox::memory::MemoryManagerOptions{});
   }
 
   void SetUp() override {

--- a/dwio/nimble/velox/tests/VeloxReaderTests.cpp
+++ b/dwio/nimble/velox/tests/VeloxReaderTests.cpp
@@ -401,7 +401,8 @@ size_t streamsReadCount(
 class VeloxReaderTests : public ::testing::Test {
  protected:
   static void SetUpTestCase() {
-    velox::memory::MemoryManager::testingSetInstance({});
+    velox::memory::MemoryManager::testingSetInstance(
+        velox::memory::MemoryManagerOptions{});
   }
 
   void SetUp() override {

--- a/dwio/nimble/velox/tests/VeloxWriterTests.cpp
+++ b/dwio/nimble/velox/tests/VeloxWriterTests.cpp
@@ -39,8 +39,9 @@ class VeloxWriterTests : public ::testing::Test {
  protected:
   static void SetUpTestCase() {
     velox::memory::SharedArbitrator::registerFactory();
-    velox::memory::MemoryManager::testingSetInstance(
-        {.arbitratorKind = "SHARED"});
+    velox::memory::MemoryManagerOptions options;
+    options.arbitratorKind = "SHARED";
+    velox::memory::MemoryManager::testingSetInstance(options);
   }
 
   void SetUp() override {


### PR DESCRIPTION
Summary: refactor: Move MemoryManagerOptions inside MemoryManager step0, explicitly specify object type

Differential Revision: D74211181


