### PR TITLE
fix: Avoid decompress data when estimate row size

### DIFF
--- a/dwio/nimble/encodings/Compression.cpp
+++ b/dwio/nimble/encodings/Compression.cpp
@@ -73,4 +73,10 @@ ICompressor& getCompressor(CompressionType compressionType) {
       .uncompress(memoryPool, compressionType, data);
 }
 
+/* static */ std::optional<size_t> Compression::uncompressedSize(
+    CompressionType compressionType,
+    std::string_view data) {
+  return getCompressor(compressionType).uncompressedSize(data);
+}
+
 } // namespace facebook::nimble

--- a/dwio/nimble/encodings/Compression.h
+++ b/dwio/nimble/encodings/Compression.h
@@ -41,6 +41,9 @@ struct ICompressor {
       CompressionType compressionType,
       std::string_view data) = 0;
 
+  virtual std::optional<size_t> uncompressedSize(
+      std::string_view data) const = 0;
+
   virtual CompressionType compressionType() = 0;
 
   virtual ~ICompressor() = default;
@@ -57,6 +60,10 @@ class Compression {
 
   static Vector<char> uncompress(
       velox::memory::MemoryPool& memoryPool,
+      CompressionType compressionType,
+      std::string_view data);
+
+  static std::optional<size_t> uncompressedSize(
       CompressionType compressionType,
       std::string_view data);
 

--- a/dwio/nimble/encodings/ZstdCompressor.cpp
+++ b/dwio/nimble/encodings/ZstdCompressor.cpp
@@ -67,6 +67,12 @@ Vector<char> ZstdCompressor::uncompress(
   return buffer;
 }
 
+std::optional<size_t> ZstdCompressor::uncompressedSize(
+    std::string_view data) const {
+  auto* pos = data.data();
+  return encoding::readUint32(pos);
+}
+
 CompressionType ZstdCompressor::compressionType() {
   return CompressionType::Zstd;
 }

--- a/dwio/nimble/encodings/ZstdCompressor.h
+++ b/dwio/nimble/encodings/ZstdCompressor.h
@@ -34,6 +34,8 @@ class ZstdCompressor : public ICompressor {
       CompressionType compressionType,
       std::string_view data) override;
 
+  std::optional<size_t> uncompressedSize(std::string_view data) const override;
+
   CompressionType compressionType() override;
 };
 


### PR DESCRIPTION
Summary:
With some very low selectivity queries (more stripes than output rows),
Nimble still needs to load and decompress the data in order to do the row size
estimation.  The shall be addressed once we have column statistics metadata; in
the meantime we can avoid the decompression cost by just get the row count and decompressed
size instead of actual decompressing the data.  This brings us on par with same
query on DWRF.

Differential Revision: D74884140


