### PR TITLE
Back out "Free up memory in DictionaryEncoding::encode faster"

### DIFF
--- a/dwio/nimble/encodings/DictionaryEncoding.h
+++ b/dwio/nimble/encodings/DictionaryEncoding.h
@@ -201,39 +201,35 @@ std::string_view DictionaryEncoding<T>::encode(
     std::span<const physicalType> values,
     Buffer& buffer) {
   const uint32_t valueCount = values.size();
-  Buffer tempBuffer{buffer.getMemoryPool()};
-  std::string_view serializedAlphabet;
-  std::string_view serializedIndices;
+  const uint32_t alphabetCount = selection.statistics().uniqueCounts().size();
 
-  // scope alphabet + indicies population to free up memory faster
-  {
-    const uint32_t alphabetCount = selection.statistics().uniqueCounts().size();
-    folly::F14FastMap<physicalType, uint32_t> alphabetMapping;
-    alphabetMapping.reserve(alphabetCount);
-    {
-      Vector<physicalType> alphabet{&buffer.getMemoryPool()};
-      alphabet.reserve(alphabetCount);
-      uint32_t index = 0;
-      for (const auto& pair : selection.statistics().uniqueCounts()) {
-        alphabet.push_back(pair.first);
-        alphabetMapping.emplace(pair.first, index++);
-      }
-      serializedAlphabet = selection.template encodeNested<physicalType>(
-          EncodingIdentifiers::Dictionary::Alphabet, {alphabet}, tempBuffer);
-    }
-
-    Vector<uint32_t> indices{&buffer.getMemoryPool()};
-    indices.reserve(valueCount);
-    for (const auto& value : values) {
-      auto it = alphabetMapping.find(value);
-      NIMBLE_DASSERT(
-          it != alphabetMapping.end(),
-          "Statistics corruption. Missing alphabet entry.");
-      indices.push_back(it->second);
-    }
-    serializedIndices = selection.template encodeNested<uint32_t>(
-        EncodingIdentifiers::Dictionary::Indices, {indices}, tempBuffer);
+  folly::F14FastMap<physicalType, uint32_t> alphabetMapping;
+  alphabetMapping.reserve(alphabetCount);
+  Vector<physicalType> alphabet{&buffer.getMemoryPool()};
+  alphabet.reserve(alphabetCount);
+  uint32_t index = 0;
+  for (const auto& pair : selection.statistics().uniqueCounts()) {
+    alphabet.push_back(pair.first);
+    alphabetMapping.emplace(pair.first, index++);
   }
+
+  Vector<uint32_t> indices{&buffer.getMemoryPool()};
+  indices.reserve(valueCount);
+  for (const auto& value : values) {
+    auto it = alphabetMapping.find(value);
+    NIMBLE_DASSERT(
+        it != alphabetMapping.end(),
+        "Statistics corruption. Missing alphabet entry.");
+    indices.push_back(it->second);
+  }
+
+  Buffer tempBuffer{buffer.getMemoryPool()};
+  std::string_view serializedAlphabet =
+      selection.template encodeNested<physicalType>(
+          EncodingIdentifiers::Dictionary::Alphabet, {alphabet}, tempBuffer);
+  std::string_view serializedIndices =
+      selection.template encodeNested<uint32_t>(
+          EncodingIdentifiers::Dictionary::Indices, {indices}, tempBuffer);
 
   const uint32_t encodingSize = Encoding::kPrefixSize + 4 +
       serializedAlphabet.size() + serializedIndices.size();


### PR DESCRIPTION
Summary:
The diff above will create a big memory bandwidth regression.
Nimble Buffers are not meant to be short lived.
Each buffer allocates a very big chunk of memory inside.


The proper fix (which was planned to be implemented as part of the compression fallback change) was to have two buffers to be used at the time of encodings.
One for temp memory, like this (which will be dicarded after all encodings are done), and one for holding the encoding results.

Reverting this change for now.

Differential Revision: D75824819


