### PR TITLE
rollout writers to MC based on namespace and/or table name

### DIFF
--- a/dwio/nimble/encodings/EncodingSelection.h
+++ b/dwio/nimble/encodings/EncodingSelection.h
@@ -77,6 +77,7 @@ struct MetaInternalCompressionParameters {
   int16_t compressionLevel = 0;
   int16_t decompressionLevel = 0;
   bool useVariableBitWidthCompressor = true;
+  bool useManagedCompression = false;
 };
 
 union CompressionParameters {
@@ -85,8 +86,8 @@ union CompressionParameters {
 };
 
 struct CompressionInformation {
-  CompressionType compressionType;
-  CompressionParameters parameters;
+  CompressionType compressionType{};
+  CompressionParameters parameters{};
 };
 
 class CompressionPolicy {

--- a/dwio/nimble/encodings/EncodingSelectionPolicy.h
+++ b/dwio/nimble/encodings/EncodingSelectionPolicy.h
@@ -105,6 +105,7 @@ struct CompressionOptions {
   uint32_t internalCompressionLevel = 4;
   uint32_t internalDecompressionLevel = 2;
   bool useVariableBitWidthCompressor = false;
+  bool metaInternalUseManagedCompressionForCompress = false;
 };
 
 // This is the manual encoding selection implementation.
@@ -207,6 +208,8 @@ class ManualEncodingSelectionPolicy : public EncodingSelectionPolicy<T> {
             compressionOptions_.internalDecompressionLevel;
         information.parameters.metaInternal.useVariableBitWidthCompressor =
             compressionOptions_.useVariableBitWidthCompressor;
+        information.parameters.metaInternal.useManagedCompression =
+            compressionOptions_.metaInternalUseManagedCompressionForCompress;
         return information;
 #else
         CompressionInformation information{
@@ -955,6 +958,8 @@ class ReplayedCompressionPolicy : public nimble::CompressionPolicy {
         compressionOptions_.internalDecompressionLevel;
     information.parameters.metaInternal.useVariableBitWidthCompressor =
         compressionOptions_.useVariableBitWidthCompressor;
+    information.parameters.metaInternal.useManagedCompression =
+        compressionOptions_.metaInternalUseManagedCompressionForCompress;
     return information;
   }
 


### PR DESCRIPTION
Summary: Add a ns and table name check in the `FileWriter` static constructor. This will pull from a rollout config in configerator . Also adds a temporary field to `CompressionOptions` and `MetaInternalCompressionParameters` to plumb this down to `MetaInternalCompressor`.

Differential Revision: D74692180


