### PR TITLE
Encodings: Plumb DataType to Uncompress

### DIFF
--- a/dwio/nimble/encodings/Compression.cpp
+++ b/dwio/nimble/encodings/Compression.cpp
@@ -68,9 +68,10 @@ ICompressor& getCompressor(CompressionType compressionType) {
 /* static */ Vector<char> Compression::uncompress(
     velox::memory::MemoryPool& memoryPool,
     CompressionType compressionType,
+    DataType dataType,
     std::string_view data) {
   return getCompressor(compressionType)
-      .uncompress(memoryPool, compressionType, data);
+      .uncompress(memoryPool, compressionType, dataType, data);
 }
 
 /* static */ std::optional<size_t> Compression::uncompressedSize(

--- a/dwio/nimble/encodings/Compression.h
+++ b/dwio/nimble/encodings/Compression.h
@@ -39,6 +39,7 @@ struct ICompressor {
   virtual Vector<char> uncompress(
       velox::memory::MemoryPool& memoryPool,
       CompressionType compressionType,
+      DataType dataType,
       std::string_view data) = 0;
 
   virtual std::optional<size_t> uncompressedSize(
@@ -61,6 +62,7 @@ class Compression {
   static Vector<char> uncompress(
       velox::memory::MemoryPool& memoryPool,
       CompressionType compressionType,
+      DataType dataType,
       std::string_view data);
 
   static std::optional<size_t> uncompressedSize(

--- a/dwio/nimble/encodings/FixedBitWidthEncoding.h
+++ b/dwio/nimble/encodings/FixedBitWidthEncoding.h
@@ -98,6 +98,7 @@ FixedBitWidthEncoding<T>::FixedBitWidthEncoding(
     uncompressedData_ = Compression::uncompress(
         memoryPool,
         compressionType,
+        DataType::Undefined,
         {pos, static_cast<size_t>(data.end() - pos)});
     fixedBitArray_ = FixedBitArray{
         {uncompressedData_.data(), uncompressedData_.size()}, bitWidth_};

--- a/dwio/nimble/encodings/SparseBoolEncoding.cpp
+++ b/dwio/nimble/encodings/SparseBoolEncoding.cpp
@@ -20,7 +20,6 @@
 #include "dwio/nimble/common/Bits.h"
 #include "dwio/nimble/common/EncodingPrimitives.h"
 #include "dwio/nimble/common/Types.h"
-#include "dwio/nimble/encodings/Compression.h"
 #include "dwio/nimble/encodings/EncodingFactory.h"
 
 namespace facebook::nimble {

--- a/dwio/nimble/encodings/TrivialEncoding.cpp
+++ b/dwio/nimble/encodings/TrivialEncoding.cpp
@@ -37,6 +37,7 @@ TrivialEncoding<std::string_view>::TrivialEncoding(
     dataUncompressed_ = Compression::uncompress(
         memoryPool,
         dataCompressionType,
+        DataType::String,
         {blob_, static_cast<size_t>(data.end() - blob_)});
     blob_ = reinterpret_cast<const char*>(dataUncompressed_.data());
     uncompressedDataBytes_ = dataUncompressed_.size();
@@ -147,6 +148,7 @@ TrivialEncoding<bool>::TrivialEncoding(
     uncompressed_ = Compression::uncompress(
         memoryPool,
         compressionType,
+        DataType::Undefined,
         {bitmap_, static_cast<size_t>(data.end() - bitmap_)});
     bitmap_ = uncompressed_.data();
     NIMBLE_CHECK(

--- a/dwio/nimble/encodings/TrivialEncoding.h
+++ b/dwio/nimble/encodings/TrivialEncoding.h
@@ -186,6 +186,7 @@ TrivialEncoding<T>::TrivialEncoding(
     uncompressed_ = Compression::uncompress(
         memoryPool,
         compressionType,
+        TypeTraits<physicalType>::dataType,
         {data.data() + kDataOffset, data.size() - kDataOffset});
     values_ = reinterpret_cast<const T*>(uncompressed_.data());
     NIMBLE_CHECK(

--- a/dwio/nimble/encodings/ZstdCompressor.cpp
+++ b/dwio/nimble/encodings/ZstdCompressor.cpp
@@ -54,7 +54,8 @@ CompressionResult ZstdCompressor::compress(
 
 Vector<char> ZstdCompressor::uncompress(
     velox::memory::MemoryPool& memoryPool,
-    CompressionType compressionType,
+    const CompressionType compressionType,
+    const DataType /* dataType */,
     std::string_view data) {
   auto pos = data.data();
   const uint32_t uncompressedSize = encoding::readUint32(pos);

--- a/dwio/nimble/encodings/ZstdCompressor.h
+++ b/dwio/nimble/encodings/ZstdCompressor.h
@@ -32,6 +32,7 @@ class ZstdCompressor : public ICompressor {
   Vector<char> uncompress(
       velox::memory::MemoryPool& memoryPool,
       CompressionType compressionType,
+      DataType dataType,
       std::string_view data) override;
 
   std::optional<size_t> uncompressedSize(std::string_view data) const override;


### PR DESCRIPTION
Summary: We need it for an internal compressor.

Differential Revision: D75322977
