### PR TITLE
fix(vector)!: Remove size parameter from FlatVector::mutableValues

### DIFF
--- a/dwio/nimble/velox/FieldReader.cpp
+++ b/dwio/nimble/velox/FieldReader.cpp
@@ -106,7 +106,7 @@ struct VectorInitializer<velox::FlatVector<T>> {
     velox::BufferPtr nulls;
     if (vector) {
       nulls = vector->nulls();
-      values = vector->mutableValues(rowCount);
+      values = vector->mutableValues();
       resetIfNotWritable(output, nulls, values);
     }
     if (!values) {
@@ -454,7 +454,7 @@ class ScalarFieldReader final
           [&]() { return paddedNulls(vector, rowCount); },
           scatterBitmap);
 
-      auto target = vector->mutableValues(rowCount)->template asMutable<char>();
+      auto target = vector->mutableValues()->template asMutable<char>();
       std::fill(target, target + bits::bytesRequired(rowCount), 0);
       for (uint32_t i = 0; i < rowCount; ++i) {
         bits::maybeSetBit(i, target, buf[i]);
@@ -462,7 +462,7 @@ class ScalarFieldReader final
     } else {
       nonNullCount = decoder_->next(
           count,
-          vector->mutableValues(rowCount)->template asMutable<TRequested>(),
+          vector->mutableValues()->template asMutable<TRequested>(),
           [&]() { return paddedNulls(vector, rowCount); },
           scatterBitmap);
     }


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebookincubator/velox/pull/14012

Today FlatVector::mutableValues takes a size parameter and ensures the values Buffer in 
the FlatVector is sized to hold at least that many values.  If the Buffer is null, shared, or is a view, a new Buffer of that size is allocated.

This can result in the FlatVector ending up in an invalid state, if the size passed in is smaller
than the size of the Vector and a new Buffer is allocated.  In this case, if we call FlatVector::set, FlatVector::valueAt, or other functions that access the value at an index, this
can read or write off the end of the Buffer even for an index that seems valid based on the
size of the Vector.  All of our checks within FlatVector (or at least all that I saw in a cursory 
inspection) are based on the size of the Vector, not the size of the values Buffer.

This can be fixed by silently using the maximum of the size passed in or the size of the 
Vector. This is what BaseVector's mutableNulls does for example. I don't see any need for 
passing in a size greater than the size of the Vector, in particular I don't see any use cases 
for this in the existing calls to  mutableValues.

Therefore I've opted to simply remove the argument.

BREAKING CHANGE:
This change removes the size parameter from FlatVector::mutableValues.  Callers need to 
remove the argument from the function call and ensure they've sized the Vector 
appropriately before calling mutableValues.

Differential Revision: D77766602


