### PR TITLE
Add record separator to 'nimble_dump content' command

### DIFF
--- a/dwio/nimble/tools/NimbleDump.cpp
+++ b/dwio/nimble/tools/NimbleDump.cpp
@@ -221,7 +221,8 @@ int main(int argc, char* argv[]) {
                std::cout, options["file"].as<std::string>()}
                .emitContent(
                    options["stream"].as<uint32_t>(),
-                   getOptional<uint32_t>(options["stripe"]));
+                   getOptional<uint32_t>(options["stripe"]),
+                   options["separator"].as<std::string>());
          },
          positionalArgs)
       // clang-format off
@@ -239,6 +240,10 @@ int main(int argc, char* argv[]) {
                 po::value<uint32_t>(),
                 "Limit output to a single stripe with the provided stripe id. "
                 "Default is to output stream content across in all stripes."
+            )(
+                "separator",
+                po::value<std::string>()->default_value("\n"),
+                "Record separator. Default is \\n."
             );
   // clang-format on
 

--- a/dwio/nimble/tools/NimbleDumpLib.cpp
+++ b/dwio/nimble/tools/NimbleDumpLib.cpp
@@ -183,7 +183,8 @@ void printScalarData(
     std::ostream& ostream,
     velox::memory::MemoryPool& pool,
     Encoding& stream,
-    uint32_t rowCount) {
+    uint32_t rowCount,
+    const std::string& separator) {
   nimble::Vector<T> buffer(&pool);
   nimble::Vector<char> nulls(&pool);
   buffer.resize(rowCount);
@@ -202,19 +203,17 @@ void printScalarData(
     // and we should not use it. We should just read all values, ignoring the
     // nulls bitmap.
     for (uint32_t i = 0; i < rowCount; ++i) {
-      ostream << folly::to<std::string>(buffer[i])
-              << std::endl; // Have to use folly::to as Int8 was getting
-                            // converted to char.
+      // Have to use folly::to as Int8 was getting converted to char.
+      ostream << folly::to<std::string>(buffer[i]) << separator;
     }
   } else {
     for (uint32_t i = 0; i < rowCount; ++i) {
       assert(stream.isNullable());
       if (nimble::bits::getBit(i, nulls.data()) == 0) {
-        ostream << "NULL" << std::endl;
+        ostream << "NULL" << separator;
       } else {
-        ostream << folly::to<std::string>(buffer[i])
-                << std::endl; // Have to use folly::to as Int8 was getting
-                              // converted to char.
+        // Have to use folly::to as Int8 was getting converted to char.
+        ostream << folly::to<std::string>(buffer[i]) << separator;
       }
     }
   }
@@ -224,12 +223,13 @@ void printScalarType(
     std::ostream& ostream,
     velox::memory::MemoryPool& pool,
     Encoding& stream,
-    uint32_t rowCount) {
+    uint32_t rowCount,
+    const std::string& separator) {
   switch (stream.dataType()) {
-#define CASE(KIND, cppType)                                    \
-  case DataType::KIND: {                                       \
-    printScalarData<cppType>(ostream, pool, stream, rowCount); \
-    break;                                                     \
+#define CASE(KIND, cppType)                                               \
+  case DataType::KIND: {                                                  \
+    printScalarData<cppType>(ostream, pool, stream, rowCount, separator); \
+    break;                                                                \
   }
     CASE(Int8, int8_t);
     CASE(Uint8, uint8_t);
@@ -638,7 +638,8 @@ void NimbleDumpLib::emitHistogram(
 
 void NimbleDumpLib::emitContent(
     uint32_t streamId,
-    std::optional<uint32_t> stripeId) {
+    std::optional<uint32_t> stripeId,
+    const std::string& separator) {
   TabletReader tabletReader{*pool_, file_.get()};
 
   uint32_t maxStreamCount;
@@ -663,7 +664,8 @@ void NimbleDumpLib::emitContent(
         uint32_t totalRows = encoding->rowCount();
         while (totalRows > 0) {
           auto currentReadSize = std::min(kBufferSize, totalRows);
-          printScalarType(ostream_, *pool_, *encoding, currentReadSize);
+          printScalarType(
+              ostream_, *pool_, *encoding, currentReadSize, separator);
           totalRows -= currentReadSize;
         }
       }

--- a/dwio/nimble/tools/NimbleDumpLib.h
+++ b/dwio/nimble/tools/NimbleDumpLib.h
@@ -37,7 +37,10 @@ class NimbleDumpLib {
       std::optional<uint32_t> stripeId);
   void
   emitHistogram(bool topLevel, bool noHeader, std::optional<uint32_t> stripeId);
-  void emitContent(uint32_t streamId, std::optional<uint32_t> stripeId);
+  void emitContent(
+      uint32_t streamId,
+      std::optional<uint32_t> stripeId,
+      const std::string& separator);
   void emitBinary(
       std::function<std::unique_ptr<std::ostream>()> outputFactory,
       uint32_t streamId,


### PR DESCRIPTION
Summary: Allow setting the record separator when printing content of a stream.

Differential Revision: D77984868


