### PR TITLE
Updating cosco 2 h to include uncompressed file size.

### DIFF
--- a/dwio/nimble/velox/VeloxWriter.cpp
+++ b/dwio/nimble/velox/VeloxWriter.cpp
@@ -893,6 +893,7 @@ VeloxWriter::RunStats VeloxWriter::getRunStats() const {
   return RunStats{
       .bytesWritten = context_->bytesWritten,
       .stripeCount = folly::to<uint32_t>(context_->getStripeIndex()),
+      .rawSize = context_->rawSize,
       .rowsPerStripe = context_->rowsPerStripe,
       .flushCpuTimeUsec = context_->totalFlushTiming.cpuNanos / 1000,
       .flushWallTimeUsec = context_->totalFlushTiming.wallNanos / 1000,

--- a/dwio/nimble/velox/VeloxWriter.h
+++ b/dwio/nimble/velox/VeloxWriter.h
@@ -41,6 +41,7 @@ class VeloxWriter {
   struct RunStats {
     uint64_t bytesWritten;
     uint32_t stripeCount;
+    uint64_t rawSize;
     std::vector<uint64_t> rowsPerStripe;
     uint64_t flushCpuTimeUsec;
     uint64_t flushWallTimeUsec;


### PR DESCRIPTION
Summary: C2H flow had many stats but we needed to expose the uncompressed size.

Differential Revision: D78028228


