### PR TITLE
Fix shadow variable warning in VeloxReaderTests

### DIFF
--- a/dwio/nimble/velox/tests/VeloxReaderTests.cpp
+++ b/dwio/nimble/velox/tests/VeloxReaderTests.cpp
@@ -3478,9 +3478,9 @@ TEST_F(VeloxReaderTests, MapToFlatMapAndPassthrough) {
 
     // ensure result is all flatmaps
     auto rowVector = result->as<velox::RowVector>();
-    for (int i = 0; i < rowVector->childrenSize(); ++i) {
+    for (int childIdx = 0; childIdx < rowVector->childrenSize(); ++childIdx) {
       ASSERT_TRUE(
-          result->as<velox::RowVector>()->childAt(i)->type()->kind() ==
+          result->as<velox::RowVector>()->childAt(childIdx)->type()->kind() ==
           velox::TypeKind::ROW);
     }
     fullReadResult.push_back(std::move(result));


### PR DESCRIPTION
Summary:
## Instructions about RACER Diffs:
**This feature is still in BETA and we are continuously improving it. Your constructive feedback would help improving RACER and highly appreciated.** 

This diff was pre-created by Racer AI agent for your convenience on top of T229383202. How-to-code instruction is provided by oncall [Sky Jazayeri](https://www.internalfb.com/profile/view/1047504621). For questions or suggestions please post in [RACER Autonomous Codebase Management](https://fb.workplace.com/groups/742040101615185) group.



This diff fixes a 'Shadow Variable Warning' issue identified by Quality Insight from [Monetization codehub](https://fburl.com/quality/wmkbc0si).

- If you are happy with the changes, commandeer it if minor edits are needed. (**we encourage commandeer to get the diff credit**)
- If you are not happy with the changes, please comment on the diff with clear actions and send it back to the author. Racer will pick it up and re-generate.
- If you really feel the Racer is not helping with this change (alas, some complex changes are hard for AI) feel free to abandon this diff.

## Summary:
Fixed a shadow variable warning in VeloxReaderTests.cpp. The warning occurred because a local variable 'i' in an inner loop was shadowing another variable 'i' from an outer loop. Renamed the inner loop variable to 'childIdx' to be more descriptive and avoid the shadowing issue.
---
> Generated by [RACER](https://www.internalfb.com/wiki/RACER_(Risk-Aware_Code_Editing_and_Refactoring)/), powered by [Confucius](https://www.internalfb.com/wiki/Confucius/Analect/Shared_Analects/Confucius_Code_Assist_(CCA)/)
[Session](https://www.internalfb.com/confucius?session_id=81947aff-598b-11f0-90c0-5a11a9cbe287&tab=Chat), [Trace](https://www.internalfb.com/confucius?session_id=81947aff-598b-11f0-90c0-5a11a9cbe287&tab=Trace)

Reviewed By: sdruzkin

Differential Revision: D77534183


