### PR TITLE
Fix unreachable-break issue in dscp/gss/util/TierSpecInterpreter.cpp +5

### DIFF
--- a/dwio/nimble/encodings/EncodingLayoutCapture.cpp
+++ b/dwio/nimble/encodings/EncodingLayoutCapture.cpp
@@ -147,15 +147,12 @@ EncodingLayout EncodingLayoutCapture::capture(std::string_view encoding) {
       // For nullable encodings we only capture the data encoding part, so we
       // are "overwriting" the current captured node with the nested data node.
       return EncodingLayoutCapture::capture({pos, dataBytes});
-
-      break;
     }
     case EncodingType::Sentinel: {
       // For sentinel encodings we only capture the data encoding part, so we
       // are "overwriting" the current captured node with the nested data node.
       return EncodingLayoutCapture::capture(
           encoding.substr(kEncodingPrefixSize + 8));
-      break;
     }
   }
 


### PR DESCRIPTION
Summary:
LLVM has a warning `-Wunreachable-code-break` which identifies `break` statements that cannot be reached. These compromise readability, are misleading, and may identify bugs. This diff removes such statements.

Such statements once existed to prevent accidental fallthroughs in switch statements. However, this is no longer necessary in C++17 because `[[fallthrough]]` is used to indicate intentional fallthroughs and we raise compilation errors for fallthroughs that are not annotated with `[[fallthrough]]` using `-Wimplicit-fallthrough`.

For questions/comments, contact r-barnes.

 - If you approve of this diff, please use the "Accept & Ship" button :-)

Reviewed By: dtolnay

Differential Revision: D78276007


