### PR TITLE
Change nimble_dump streams data representation

### DIFF
--- a/dwio/nimble/tools/NimbleDumpLib.cpp
+++ b/dwio/nimble/tools/NimbleDumpLib.cpp
@@ -110,14 +110,16 @@ class TableFormatter {
           uint8_t /* Width */,
           Alignment /* Horizontal Alignment */
           >> fields,
-      bool noHeader = false)
-      : ostream_{ostream}, fields_{std::move(fields)} {
+      bool noHeader = false,
+      const std::string& separator = "\t")
+      : ostream_{ostream}, fields_{std::move(fields)}, separator_{separator} {
     if (!noHeader) {
       ostream << YELLOW;
       for (const auto& field : fields_) {
         ostream << (std::get<2>(field) == Alignment::Right ? std::right
                                                            : std::left)
-                << std::setw(std::get<1>(field) + 2) << std::get<0>(field);
+                << std::setw(std::get<1>(field)) << std::get<0>(field)
+                << ((&field != &fields_.back()) ? separator_ : "");
       }
       ostream << RESET_COLOR << std::endl;
     }
@@ -128,7 +130,8 @@ class TableFormatter {
     for (auto i = 0; i < values.size(); ++i) {
       ostream_ << (std::get<2>(fields_[i]) == Alignment::Right ? std::right
                                                                : std::left)
-               << std::setw(std::get<1>(fields_[i]) + 2) << values[i];
+               << std::setw(std::get<1>(fields_[i])) << values[i]
+               << (i != values.size() - 1 ? separator_ : "");
     }
     ostream_ << std::endl;
   }
@@ -141,6 +144,7 @@ class TableFormatter {
       Alignment /* Horizontal Alignment */
       >>
       fields_;
+  const std::string& separator_;
 };
 
 void traverseTablet(
@@ -469,14 +473,14 @@ void NimbleDumpLib::emitStreams(
   auto tabletReader = std::make_shared<TabletReader>(*pool_, file_.get());
 
   std::vector<std::tuple<std::string, uint8_t, Alignment>> fields;
-  fields.push_back({"Stripe Id", 11, Alignment::Left});
-  fields.push_back({"Stream Id", 11, Alignment::Left});
-  fields.push_back({"Stream Offset", 13, Alignment::Left});
-  fields.push_back({"Stream Size", 13, Alignment::Left});
+  fields.push_back({"Stripe Id", 9, Alignment::Left});
+  fields.push_back({"Stream Id", 9, Alignment::Left});
+  fields.push_back({"Stream Offset", 13, Alignment::Right});
+  fields.push_back({"Stream Length", 13, Alignment::Right});
   if (showStreamRawSize) {
-    fields.push_back({"Raw Stream Size", 16, Alignment::Left});
+    fields.push_back({"Raw Stream Size", 16, Alignment::Right});
   }
-  fields.push_back({"Item Count", 13, Alignment::Left});
+  fields.push_back({"Item Count", 13, Alignment::Right});
   if (showStreamLabels) {
     fields.push_back({"Stream Label", 16, Alignment::Left});
   }


### PR DESCRIPTION
Summary:
#### Make these numeric columns aligned to the right
* Stream Offset
* Stream Length
* Item Count

All numeric columns where values can be large and can be compared to each other should be aligned to the right to simplify comparison.

Before - notice how hard to visually compare the stream sizes:
```
Stripe Id    Stream Id    Stream Offset  Stream Size    Item Count     Type                            
....
0            8            45050          5223           8640           0:RLE<String,5218>[Lengths:FixedBitWidth<Uint32,759>{MetaInternal},Values:Trivial<String,4449>{MetaInternal}[Lengths:Constant<Uint32,10>]]
0            9            50273          2381           8640           0:Nullable<String,2376>[Data:Trivial<String,1938>{MetaInternal}[Lengths:Constant<Uint32,10>],Nulls:RLE<Bool,428>[Lengths:FixedBitWidth<Uint32,417>{MetaInternal}]]
0            10           52654          2467           8640           0:RLE<Uint32,2462>[Lengths:FixedBitWidth<Uint32,827>{MetaInternal},Values:FixedBitWidth<Uint32,1625>{MetaInternal}]
0            11           55121          159328         4065638        0:Trivial<Int32,159323>{MetaInternal}
0            12           214449         1800430        4065638        0:Trivial<Float,1800425>{MetaInternal}
0            13           2014879        1685           8640           0:RLE<Uint32,1680>[Lengths:FixedBitWidth<Uint32,776>{MetaInternal},Values:FixedBitWidth<Uint32,894>{MetaInternal}]
0            14           2016564        30583          928681         0:Trivial<Int32,30578>{MetaInternal}
0            15           2047147        90061          928681         0:Nullable<Uint32,90056>[Data:FixedBitWidth<Uint32,90000>{MetaInternal},Nulls:SparseBool<Bool,46>[Indices:Trivial<Uint32,39>{Uncompressed}]]
0            16           2137208        18478612       31493289       0:Trivial<Int64,18478607>{MetaInternal}
0            17           20615820       1476           8640           0:RLE<Uint32,1471>[Lengths:FixedBitWidth<Uint32,749>{MetaInternal},Values:FixedBitWidth<Uint32,712>{MetaInternal}]
0            18           20617296       7437           181218         0:Trivial<Int32,7432>{MetaInternal}
0            19           20624733       21904          181218         0:FixedBitWidth<Uint32,21899>{MetaInternal}
0            20           20646637       7207669        8794713        0:Trivial<Int64,7207664>{MetaInternal}
0            21           27854306       1988499        8794713        0:Trivial<Float,1988494>{MetaInternal}

```

After:
```
Stripe Id	Stream Id	Stream Offset	Stream Length	   Item Count	Type                          
....
0        	8        	        45050	         5223	         8640	0:RLE<String,5218>[Lengths:FixedBitWidth<Uint32,759>{MetaInternal},Values:Trivial<String,4449>{MetaInternal}[Lengths:Constant<Uint32,10>]]
0        	9        	        50273	         2381	         8640	0:Nullable<String,2376>[Data:Trivial<String,1938>{MetaInternal}[Lengths:Constant<Uint32,10>],Nulls:RLE<Bool,428>[Lengths:FixedBitWidth<Uint32,417>{MetaInternal}]]
0        	10       	        52654	         2467	         8640	0:RLE<Uint32,2462>[Lengths:FixedBitWidth<Uint32,827>{MetaInternal},Values:FixedBitWidth<Uint32,1625>{MetaInternal}]
0        	11       	        55121	       159328	      4065638	0:Trivial<Int32,159323>{MetaInternal}
0        	12       	       214449	      1800430	      4065638	0:Trivial<Float,1800425>{MetaInternal}
0        	13       	      2014879	         1685	         8640	0:RLE<Uint32,1680>[Lengths:FixedBitWidth<Uint32,776>{MetaInternal},Values:FixedBitWidth<Uint32,894>{MetaInternal}]
0        	14       	      2016564	        30583	       928681	0:Trivial<Int32,30578>{MetaInternal}
0        	15       	      2047147	        90061	       928681	0:Nullable<Uint32,90056>[Data:FixedBitWidth<Uint32,90000>{MetaInternal},Nulls:SparseBool<Bool,46>[Indices:Trivial<Uint32,39>{Uncompressed}]]
0        	16       	      2137208	     18478612	     31493289	0:Trivial<Int64,18478607>{MetaInternal}
0        	17       	     20615820	         1476	         8640	0:RLE<Uint32,1471>[Lengths:FixedBitWidth<Uint32,749>{MetaInternal},Values:FixedBitWidth<Uint32,712>{MetaInternal}]
0        	18       	     20617296	         7437	       181218	0:Trivial<Int32,7432>{MetaInternal}
0        	19       	     20624733	        21904	       181218	0:FixedBitWidth<Uint32,21899>{MetaInternal}
0        	20       	     20646637	      7207669	      8794713	0:Trivial<Int64,7207664>{MetaInternal}
0        	21       	     27854306	      1988499	      8794713	0:Trivial<Float,1988494>{MetaInternal}
```


#### Rework Formatting
 Rework table formatting by adding a column separator because the old implementation put two adjacent columns with right and left alignments without any separators.

Before - Notice how `Item Count` and `Type` values are bunched up together:
```
Stripe Id    Stream Id      Stream Offset  Stream Length     Item CountType                            
0            1                          0            420           86400:MainlyConstant<Double,415>[IsCommon:RLE<Bool,379>[Lengths:FixedBitWidth<Uint32,368>{MetaInternal}],OtherValues:Constant<Uint64,14>]
0            2                        420          10365           86400:RLE<Int64,10360>[Lengths:FixedBitWidth<Uint32,759>{MetaInternal},Values:Trivial<Uint64,9591>{MetaInternal}]
0            3                      10785           5044           86400:RLE<Int64,5039>[Lengths:FixedBitWidth<Uint32,779>{MetaInternal},Values:Trivial<Uint64,4250>{MetaInternal}]
```

After:
```
Stripe Id	Stream Id	Stream Offset	Stream Length	   Item Count	Type                          
0        	1        	            0	          420	         8640	0:MainlyConstant<Double,415>[IsCommon:RLE<Bool,379>[Lengths:FixedBitWidth<Uint32,368>{MetaInternal}],OtherValues:Constant<Uint64,14>]
0        	2        	          420	        10365	         8640	0:RLE<Int64,10360>[Lengths:FixedBitWidth<Uint32,759>{MetaInternal},Values:Trivial<Uint64,9591>{MetaInternal}]
0        	3        	        10785	         5044	         8640	0:RLE<Int64,5039>[Lengths:FixedBitWidth<Uint32,779>{MetaInternal},Values:Trivial<Uint64,4250>{MetaInternal}]
0        	4        	        15829	         9394	         8640	0:MainlyConstant<String,9389>[IsCommon:RLE<Bool,1007>[Lengths:FixedBitWidth<Uint32,996>{MetaInternal}],OtherValues:RLE<String,8346>[Lengths:FixedBitWidth<Uint32,23
```

Differential Revision: D78371778


