### PR TITLE
Fix ASAN bug in nimble_dump after adding the column separator

### DIFF
--- a/dwio/nimble/tools/NimbleDumpLib.cpp
+++ b/dwio/nimble/tools/NimbleDumpLib.cpp
@@ -144,7 +144,7 @@ class TableFormatter {
       Alignment /* Horizontal Alignment */
       >>
       fields_;
-  const std::string& separator_;
+  const std::string separator_;
 };
 
 void traverseTablet(


### PR DESCRIPTION
Summary:
Fix ASAN issue binding reference member to stack allocated parameter for the table formatter.
```
==2953670==ERROR: AddressSanitizer: stack-use-after-scope on address 0x7fcec4ed86b0 at pc 0x0000045c4ea7 bp 0x7ffdcd084d30 sp 0x7ffdcd084d28

```

Differential Revision: D78944238


