### PR TITLE
Fix unchecked decompression callsites

### DIFF
--- a/dwio/nimble/tools/NimbleDumpLib.cpp
+++ b/dwio/nimble/tools/NimbleDumpLib.cpp
@@ -838,7 +838,9 @@ void NimbleDumpLib::emitLayout(bool noHeader, bool compressed) {
   file_->pread(0, size, buffer.data());
   if (compressed) {
     std::string uncompressed;
-    strings::zstdDecompress(buffer, &uncompressed);
+    NIMBLE_CHECK(
+        strings::zstdDecompress(buffer, &uncompressed),
+        "Decompress failed during `emitLayout`");
     buffer = std::move(uncompressed);
   }
 


### PR DESCRIPTION
Summary:
***Why?***
It has been noticed that there were quite a few callsites where the return values of std compression and decompression functions of commons/string were being ignored. We plan to annotate those functions with nodiscard to avoid future cases and we are also providing more modern functions less prone to misuse.

In order to be able to annotate the existing functions with the nodiscard attribute, we first need to fix all callsites.

***Changes***
* In `EncodingDBUtilTest` use the new result based API and unwrapping by  throwing if an error occurs - that should be fine as this is code used in tests
* In `EncodingLayoutTrainerMain` use the new result based API but manually unwarp in case of failures - that allows us to be comptible with the exitsing failure mechnism and having a better error message compared to the legacy API
* In the rest of the production code, keep using the legacy code but ensure to wrap it in a NIMBLE_CHECK to be comptible with th rest of the error handling

***Results***
* Remove potential bugs especially with the decompression which could happen if there is some data corruption
* dwio is not a blocker anymore to annotate zstd compression functions in commons/string with no nodiscard

Differential Revision: D78984494


