### PR TITLE
Add min compression size

### DIFF
--- a/dwio/nimble/common/Constants.h
+++ b/dwio/nimble/common/Constants.h
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+namespace facebook::nimble {
+
+// Attempt to compress a data stream only if the data size is equal or greater
+// than this threshold.
+// WARNING: These values have been derived experimentally.
+constexpr uint32_t kMetaInternalMinCompressionSize = 40;
+constexpr uint32_t kZstdMinCompressionSize = 25;
+
+} // namespace facebook::nimble

--- a/dwio/nimble/encodings/Compression.h
+++ b/dwio/nimble/encodings/Compression.h
@@ -88,7 +88,8 @@ class CompressionEncoder {
       int bitWidth = 0)
       : dataSize_{uncompressedBuffer.size()},
         compressionType_{CompressionType::Uncompressed} {
-    if (uncompressedBuffer.size() == 0 ||
+    if (dataSize_ == 0 ||
+        dataSize_ < compressionPolicy.compression().minCompressionSize ||
         compressionPolicy.compression().compressionType ==
             CompressionType::Uncompressed) {
       // No compression, just use the original buffer.
@@ -129,6 +130,7 @@ class CompressionEncoder {
         compressionType_{CompressionType::Uncompressed},
         encoder_{encoder} {
     if (uncompressedSize == 0 ||
+        uncompressedSize < compressionPolicy.compression().minCompressionSize ||
         compressionPolicy.compression().compressionType ==
             CompressionType::Uncompressed) {
       // No compression. Do not encode the data yet. It will be encoded later

--- a/dwio/nimble/encodings/EncodingSelection.h
+++ b/dwio/nimble/encodings/EncodingSelection.h
@@ -88,6 +88,7 @@ union CompressionParameters {
 struct CompressionInformation {
   CompressionType compressionType{};
   CompressionParameters parameters{};
+  uint64_t minCompressionSize = 0;
 };
 
 class CompressionPolicy {

--- a/dwio/nimble/encodings/tests/CompressionTests.cpp
+++ b/dwio/nimble/encodings/tests/CompressionTests.cpp
@@ -1,0 +1,178 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include <glog/logging.h>
+#include <gtest/gtest.h>
+#include "dwio/nimble/common/Buffer.h"
+#include "dwio/nimble/common/Constants.h"
+#include "dwio/nimble/common/EncodingType.h"
+#include "dwio/nimble/common/Types.h"
+#include "dwio/nimble/encodings/Encoding.h"
+#include "dwio/nimble/encodings/EncodingSelectionPolicy.h"
+#include "dwio/nimble/encodings/tests/TestUtils.h"
+
+#include <vector>
+
+using namespace facebook;
+using namespace facebook::nimble::test;
+
+namespace facebook::nimble::test {
+
+class TestCompressionPolicy : public nimble::CompressionPolicy {
+ public:
+  explicit TestCompressionPolicy(
+      nimble::CompressionType compressionType,
+      uint64_t minCompressionSize) {
+    EXPECT_TRUE(
+        compressionType == nimble::CompressionType::Zstd ||
+        compressionType == nimble::CompressionType::MetaInternal);
+
+    compressionInfo_ = {
+        .compressionType = compressionType,
+        .minCompressionSize = minCompressionSize};
+
+    compressionInfo_.parameters.zstd.compressionLevel = 3;
+    compressionInfo_.parameters.metaInternal.compressionLevel = 4;
+    compressionInfo_.parameters.metaInternal.decompressionLevel = 2;
+  }
+
+  nimble::CompressionInformation compression() const override {
+    return compressionInfo_;
+  }
+
+  virtual bool shouldAccept(
+      nimble::CompressionType /* compressionType */,
+      uint64_t /* uncompressedSize */,
+      uint64_t /* compressedSize */) const override {
+    return true;
+  }
+
+ private:
+  nimble::CompressionInformation compressionInfo_;
+};
+
+template <typename T>
+void assertMinCompressibleSizeMetaInternal(
+    const nimble::CompressionType compressionType,
+    const uint32_t expectedMinCompressibleBytes) {
+  const auto pool =
+      facebook::velox::memory::deprecatedAddDefaultLeafMemoryPool();
+  bool hitUncompressedBetter = false;
+  bool hitCompressedBetter = false;
+  const uint32_t itemSize = std::is_same<T, std::string>::value ? 1 : sizeof(T);
+
+  for (uint32_t i = 1; i < 100; ++i) {
+    const uint32_t uncompressedSize = itemSize * i;
+
+    // assumption is that the data with all bytes being equal is the best case
+    // for compression
+    std::vector<char> data(uncompressedSize);
+
+    TestCompressionPolicy compressionPolicy{compressionType, 0};
+    nimble::CompressionEncoder<T> compressionEncoder{
+        *pool,
+        compressionPolicy,
+        nimble::TypeTraits<T>::dataType,
+        {data.data(), uncompressedSize}};
+
+    // ZStd compressor returns uncompressed data if the input is too small,
+    // MetInternal returns compressed data even if the input is too small.
+    const bool expectCompressedBetter =
+        uncompressedSize >= expectedMinCompressibleBytes &&
+        compressionEncoder.compressionType() == compressionType;
+    const auto compressedSize = compressionEncoder.getSize();
+    EXPECT_TRUE(
+        compressionEncoder.compressionType() == compressionType ||
+        compressionEncoder.compressionType() == CompressionType::Uncompressed);
+
+    if (expectCompressedBetter) {
+      EXPECT_GT(uncompressedSize, compressedSize);
+      hitCompressedBetter = true;
+    } else {
+      EXPECT_LE(uncompressedSize, compressedSize);
+      hitUncompressedBetter = true;
+    }
+  }
+
+  EXPECT_TRUE(hitUncompressedBetter);
+  EXPECT_TRUE(hitCompressedBetter);
+}
+} // namespace facebook::nimble::test
+
+template <typename C>
+class CompressionTests : public ::testing::Test {};
+
+#define TYPES int8_t, int16_t, int32_t, int64_t, double, float, std::string
+using TestTypes = ::testing::Types<TYPES>;
+
+TYPED_TEST_CASE(CompressionTests, TestTypes);
+
+TYPED_TEST(CompressionTests, MinCompressibleSizeMetaInternal) {
+  using T = TypeParam;
+  assertMinCompressibleSizeMetaInternal<T>(
+      nimble::CompressionType::MetaInternal,
+      nimble::kMetaInternalMinCompressionSize);
+}
+
+TYPED_TEST(CompressionTests, MinCompressibleSizeZstd) {
+  using T = TypeParam;
+  assertMinCompressibleSizeMetaInternal<T>(
+      nimble::CompressionType::Zstd, nimble::kZstdMinCompressionSize);
+}
+
+TEST(CompressionTests, VerifyDefaultMinCompressionSize) {
+  nimble::CompressionOptions compressionOptions{};
+  EXPECT_EQ(
+      compressionOptions.internalMinCompressionSize,
+      nimble::kMetaInternalMinCompressionSize);
+  EXPECT_EQ(
+      compressionOptions.zstdMinCompressionSize,
+      nimble::kZstdMinCompressionSize);
+}
+
+TEST(CompressionTests, MinCompresssionSizeIsApplied) {
+  const auto pool =
+      facebook::velox::memory::deprecatedAddDefaultLeafMemoryPool();
+  const auto compressionType = nimble::CompressionType::MetaInternal;
+  const uint32_t uncompressedSize = 100;
+  char* data = new char[uncompressedSize];
+  std::memset(data, 0, uncompressedSize);
+
+  {
+    // make minCompressionSize slightly smaller than data to apply compression
+    TestCompressionPolicy policy{compressionType, uncompressedSize - 1};
+    nimble::CompressionEncoder<std::string> encoder{
+        *pool, policy, nimble::DataType::String, {data, uncompressedSize}};
+    EXPECT_EQ(encoder.compressionType(), compressionType);
+    EXPECT_GT(uncompressedSize, encoder.getSize());
+  }
+
+  {
+    // make minCompressionSize same as the data size to apply compression
+    TestCompressionPolicy policy{compressionType, uncompressedSize};
+    nimble::CompressionEncoder<std::string> encoder{
+        *pool, policy, nimble::DataType::String, {data, uncompressedSize}};
+    EXPECT_EQ(encoder.compressionType(), compressionType);
+    EXPECT_GT(uncompressedSize, encoder.getSize());
+  }
+
+  {
+    // make minCompressionSize slightly larger than data to skip compression
+    TestCompressionPolicy policy{compressionType, uncompressedSize + 1};
+    nimble::CompressionEncoder<std::string> encoder{
+        *pool, policy, nimble::DataType::String, {data, uncompressedSize}};
+    EXPECT_EQ(encoder.compressionType(), nimble::CompressionType::Uncompressed);
+  }
+}

--- a/dwio/nimble/encodings/tests/EncodingLayoutTests.cpp
+++ b/dwio/nimble/encodings/tests/EncodingLayoutTests.cpp
@@ -64,7 +64,8 @@ void testCapture(nimble::EncodingLayout expected, TCollection data) {
   auto encoding = nimble::EncodingFactory::encode<T>(
       std::make_unique<nimble::ReplayedEncodingSelectionPolicy<T>>(
           expected,
-          nimble::CompressionOptions{.compressionAcceptRatio = 100},
+          nimble::CompressionOptions{
+              .compressionAcceptRatio = 100, .internalMinCompressionSize = 0},
           encodingSelectionPolicyFactory),
       data,
       buffer);

--- a/dwio/nimble/velox/tests/VeloxWriterTests.cpp
+++ b/dwio/nimble/velox/tests/VeloxWriterTests.cpp
@@ -551,7 +551,8 @@ TEST_F(VeloxWriterTests, EncodingLayout) {
           .encodingLayoutTree = std::move(expected),
           // Boosting acceptance ratio by 100x to make sure it is always
           // accepted (even if compressed size if bigger than uncompressed size)
-          .compressionOptions = {.compressionAcceptRatio = 100},
+          .compressionOptions =
+              {.compressionAcceptRatio = 100, .internalMinCompressionSize = 0},
       });
 
   writer.write(vector);


### PR DESCRIPTION
Summary:
Add experimentally derived minimum stream compression size to:
1) avoid wasting time on trying to compress small streams - this will improve bottom line of the writer's perf
2) we can use it in the data encoders for encoding decisions (e.g. switch FBW to optimal bit width)
3) we can use it in the size estimation

I used a buffer of varied size filled with 0x00 to derive min data size where the compression kicks in. Find the results below. You can repro the results by debugging the new unit test.

Notice that ZStd has min compression size 25, but MetaInternal min compression size is 40. If MetaInternal's min stays at 40, then we can consider using zstd for small streams with size in-between 25-40 bytes.

Notice that Int64 has compressed size of 36 when the rest has size of 39. It means that the min size can be potentially changed to be type aware.

```
MetaInternal Defined Data Type
item count: 40, itemSize 1, uncompressedSize: 40, compressed size: 39, data type: String
item count: 40, itemSize 1, uncompressedSize: 40, compressed size: 39, data type: Int8
item count: 20, itemSize 2, uncompressedSize: 40, compressed size: 39, data type: Int16
item count: 10, itemSize 4, uncompressedSize: 40, compressed size: 39, data type: Int32
item count: 5, itemSize 8,  uncompressedSize: 40, compressed size: 36, data type: Int64
item count: 10, itemSize 4, uncompressedSize: 40, compressed size: 39, data type: Float
item count: 5, itemSize 8,  uncompressedSize: 40, compressed size: 39, data type: Double

MetaInternal Undefined Data Type
item count: 40, itemSize 1, uncompressedSize: 40, compressed size: 39, data type: String
item count: 5, itemSize 8,  uncompressedSize: 40, compressed size: 39, data type: Int64
item count: 10, itemSize 4, uncompressedSize: 40, compressed size: 39, data type: Int32
item count: 5, itemSize 8,  uncompressedSize: 40, compressed size: 39, data type: Double
item count: 40, itemSize 1, uncompressedSize: 40, compressed size: 39, data type: Int8
item count: 20, itemSize 2, uncompressedSize: 40, compressed size: 39, data type: Int16
item count: 10, itemSize 4, uncompressedSize: 40, compressed size: 39, data type: Float

ZStd
item count: 25, itemSize 1, uncompressedSize: 25, compressed size: 21, data type: String
item count: 25, itemSize 1, uncompressedSize: 25, compressed size: 21, data type: Int8
item count: 13, itemSize 2, uncompressedSize: 26, compressed size: 21, data type: Int16
item count: 7, itemSize 4,  uncompressedSize: 28, compressed size: 21, data type: Int32
item count: 4, itemSize 8,  uncompressedSize: 32, compressed size: 21, data type: Int64
item count: 4, itemSize 8,  uncompressedSize: 32, compressed size: 21, data type: Double
item count: 7, itemSize 4,  uncompressedSize: 28, compressed size: 21, data type: Float
```

For MetaInternal on compression levels 5-8 the lower bound goes from 40 to 39, on 9-10 it goes back to 40, on 11+ it goes down to 39. It follows zstd on the same levels.
```
$ zstd -b0e25i3 1.txt 
 0#1.txt             :        24 ->        18 (x1.333),   16.9 MB/s,  116.7 MB/s
 1#1.txt             :        24 ->        18 (x1.333),   17.0 MB/s,  117.0 MB/s
 2#1.txt             :        24 ->        18 (x1.333),   17.1 MB/s,  117.5 MB/s
 3#1.txt             :        24 ->        18 (x1.333),   17.0 MB/s,  117.1 MB/s
 4#1.txt             :        24 ->        18 (x1.333),   16.9 MB/s,  117.2 MB/s
 5#1.txt             :        24 ->        17 (x1.412),   16.2 MB/s,  117.4 MB/s
 6#1.txt             :        24 ->        17 (x1.412),   15.8 MB/s,  116.8 MB/s
 7#1.txt             :        24 ->        17 (x1.412),   15.7 MB/s,  117.5 MB/s
 8#1.txt             :        24 ->        17 (x1.412),   15.8 MB/s,  117.6 MB/s
 9#1.txt             :        24 ->        18 (x1.333),   15.9 MB/s,  117.3 MB/s
10#1.txt             :        24 ->        18 (x1.333),   15.8 MB/s,  116.7 MB/s
11#1.txt             :        24 ->        17 (x1.412),   10.9 MB/s,  116.8 MB/s
12#1.txt             :        24 ->        17 (x1.412),   7.58 MB/s,  116.8 MB/s
13#1.txt             :        24 ->        17 (x1.412),   5.69 MB/s,  116.9 MB/s
14#1.txt             :        24 ->        17 (x1.412),   5.79 MB/s,  117.0 MB/s
15#1.txt             :        24 ->        17 (x1.412),   5.77 MB/s,  116.5 MB/s
16#1.txt             :        24 ->        17 (x1.412),   3.61 MB/s,  115.7 MB/s
17#1.txt             :        24 ->        17 (x1.412),   3.63 MB/s,  116.8 MB/s
18#1.txt             :        24 ->        17 (x1.412),   3.64 MB/s,  116.9 MB/s
19#1.txt             :        24 ->        17 (x1.412),   3.58 MB/s,  115.6 MB/s
20#1.txt             :        24 ->        17 (x1.412),   3.60 MB/s,  116.1 MB/s
21#1.txt             :        24 ->        17 (x1.412),   3.63 MB/s,  117.3 MB/s
22#1.txt             :        24 ->        17 (x1.412),   3.63 MB/s,  116.1 MB/s
```

# Writer perf impact
I did not do any heavy benchmarking, but I rewrote a few flat map heavy files from four Ads tables. The writer CPU time seems to improve by 3-10% depending on the number of incompressible streams.

```
# page_write_cpu_time_ms:  before -> after
24344 -> 23713  3%
6926 -> 6626  5%
65666 -> 59578 10%
80218 -> 75853 5%
```

# File size impact
No impact.


# Flow
```
                                                                
 ┌──────────────────────────┐                                   
 │NimbleConfig SerDe        │                                   
 ├──────────────────────────┤                                   
 │zstdMinsCompressionSize   │                                   
 │internalMinCompressionSize│                                   
 │                          │                                   
 └───────────┬──────────────┘                                   
             │                                                  
             │                                                  
             │    Built by WriterOptionsBuilder                 
             │                                                  
             ▼                                                  
    ┌───────────────────┐        ┌───────────────────────────┐  
    │VeloxWriterOptions │        │CompressionOptions         │  
    ├───────────────────┤  has   ├───────────────────────────┤  
    │compressionOptions │───────►│zstdMinCompressionSize     │  
    │                   │        │internalMinCompressionSize │  
    │                   │        │                           │  
    └────────┬──────────┘        └───────────────────────────┘  
             │                                                  
             │  Built by AlwaysCompressPolicy.                  
             │  It decides compression type and min             
             │  size based on the compressin type.              
             │                                                  
             ▼                                                  
    ┌───────────────────┐        ┌─────────────────────┐        
    │CompressionPolicy  │        │CompressionInfo      │        
    ├───────────────────┤ has    ├─────────────────────┤        
    │compressionInfo    ├───────►│type                 │        
    │                   │        │minCompressionSize   │        
    └───────────────────┘        └─────────────────────┘        
                 ▲                                              
                 │                                              
                 └───                                           
               Used by the stream compressor                    
                                                                
                                                                
```

Reviewed By: HuamengJiang, Victor-C-Zhang

Differential Revision: D78620343


