### PR TITLE
Fix written file bytes bug in nimble writer

### DIFF
--- a/dwio/nimble/velox/VeloxWriter.cpp
+++ b/dwio/nimble/velox/VeloxWriter.cpp
@@ -535,6 +535,7 @@ bool VeloxWriter::write(const velox::VectorPtr& vector) {
     context_->memoryUsed = memoryUsed;
     context_->rowsInFile += size;
     context_->rowsInStripe += size;
+    context_->bytesWritten = file_->size();
 
     return tryWriteStripe();
   } catch (...) {


### PR DESCRIPTION
Summary: Nimble writer reports file bytes written at the end of the writer closing. This takes away the opportunity of presto coordinator dynamically scaling up writer tasks in the middle of the write, making scaled writer fail to work. This change made it work by moving the bytes reporting to every write call.

Reviewed By: zzhao0, feilong-liu, kletkavrubashku

Differential Revision: D79738851


