### PR TITLE
Add CMake configuration for selective reader

### DIFF
--- a/dwio/nimble/velox/CMakeLists.txt
+++ b/dwio/nimble/velox/CMakeLists.txt
@@ -11,8 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-add_subdirectory(tests)
-
 add_library(nimble_velox_common SchemaUtils.cpp)
 target_link_libraries(nimble_velox_common nimble_common velox_type)
 
@@ -37,8 +35,7 @@ target_link_libraries(
   Folly::folly absl::flat_hash_map protobuf::libprotobuf)
 
 add_library(nimble_velox_layout_planner LayoutPlanner.cpp)
-target_link_libraries(nimble_velox_layout_planner nimble_velox_schema_reader
-                      velox_file)
+target_link_libraries(nimble_velox_layout_planner nimble_velox_schema_reader)
 
 add_library(nimble_velox_field_writer BufferGrowthPolicy.cpp
                                       DeduplicationUtils.cpp FieldWriter.cpp)
@@ -117,9 +114,15 @@ target_link_libraries(
   nimble_velox_writer
   nimble_encodings
   nimble_common
+  nimble_column_stats_utils
   nimble_tablet_writer
+  nimble_velox_field_writer
+  nimble_velox_layout_planner
   nimble_velox_metadata_fb
   nimble_velox_stats_fb
   raw_size_utils
   velox_dwio_common
   Folly::folly)
+
+add_subdirectory(selective)
+add_subdirectory(tests)

--- a/dwio/nimble/velox/selective/CMakeLists.txt
+++ b/dwio/nimble/velox/selective/CMakeLists.txt
@@ -1,0 +1,31 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+add_library(
+  nimble_velox_selective
+  ChunkedDecoder.cpp
+  ColumnReader.cpp
+  FlatMapColumnReader.cpp
+  IntegerColumnReader.cpp
+  NimbleData.cpp
+  ReaderBase.cpp
+  SelectiveNimbleReader.cpp
+  SelectiveNimbleReaderInitHookOSS.cpp
+  StringColumnReader.cpp
+  StructColumnReader.cpp
+  StructColumnReader.cpp
+  VariableLengthColumnReader.cpp)
+target_link_libraries(nimble_velox_selective nimble_velox_reader
+                      nimble_velox_writer nimble_velox_common)
+
+add_subdirectory(tests)

--- a/dwio/nimble/velox/selective/tests/CMakeLists.txt
+++ b/dwio/nimble/velox/selective/tests/CMakeLists.txt
@@ -1,0 +1,36 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+add_executable(
+  nimble_velox_selective_tests
+  ChunkedDecoderTest.cpp
+  # This requires VELOX_BUILD_TEST_UTILS=ON but it also requires
+  # VELOX_ENABLE_EXEC=ON. VELOX_ENABLE_EXEC is OFF by
+  # VELOX_BUILD_MINIMAL_WITH_DWIO=ON.
+  #
+  # E2EFilterTest.cpp
+  SelectiveNimbleReaderTest.cpp)
+add_test(nimble_velox_selective_tests nimble_velox_selective_tests)
+
+target_link_libraries(
+  nimble_velox_selective_tests
+  nimble_velox_selective
+  nimble_common_file_writer
+  velox_vector_test_lib
+  # See also the above VELOX_BUILD_TEST_UTILS=ON comment.
+  #
+  # velox_dwio_common_test_utils
+  gmock
+  gtest
+  gtest_main
+  Folly::folly)

--- a/dwio/nimble/velox/tests/CMakeLists.txt
+++ b/dwio/nimble/velox/tests/CMakeLists.txt
@@ -35,7 +35,6 @@ target_link_libraries(
   nimble_velox_schema_utils
   nimble_velox_reader
   nimble_velox_writer
-  nimble_velox_field_writer
   nimble_velox_layout_planner
   nimble_velox_stats_fb
   nimble_common_file_writer


### PR DESCRIPTION
Fixes #214

E2E test isn't disable for now because it requires Velox change.