### PR TITLE
Make Reader Lifecycle Tests More Stable

### DIFF
--- a/dwio/nimble/velox/tests/VeloxReaderTests.cpp
+++ b/dwio/nimble/velox/tests/VeloxReaderTests.cpp
@@ -4965,9 +4965,13 @@ TEST_F(VeloxReaderTests, TestArrayFieldLifeCycle) {
         child = std::dynamic_pointer_cast<velox::ArrayVector>(
             result->as<velox::RowVector>()->childAt(0));
 
-        if (rawNulls && child->nulls().get()) {
-          EXPECT_EQ(rawNulls, child->nulls().get());
-        }
+        auto checkAndUpdateNulls = [&rawNulls](velox::BaseVector* vector) {
+          if (rawNulls && vector->nulls().get()) {
+            EXPECT_EQ(rawNulls, vector->nulls().get());
+          }
+          rawNulls = vector->nulls().get();
+        };
+        checkAndUpdateNulls(child.get());
         EXPECT_EQ(rawSizes, child->sizes().get());
         EXPECT_NE(offsets, child->offsets());
         EXPECT_EQ(elementsPtr, child->elements().get());
@@ -4982,9 +4986,7 @@ TEST_F(VeloxReaderTests, TestArrayFieldLifeCycle) {
         EXPECT_TRUE(reader->next(batchSize, result));
         child = std::dynamic_pointer_cast<velox::ArrayVector>(
             result->as<velox::RowVector>()->childAt(0));
-        if (rawNulls && child->nulls().get()) {
-          EXPECT_EQ(rawNulls, child->nulls().get());
-        }
+        checkAndUpdateNulls(child.get());
         EXPECT_EQ(rawSizes, child->sizes().get());
         EXPECT_EQ(rawOffsets, child->offsets().get());
         EXPECT_NE(elements, child->elements());
@@ -5034,9 +5036,13 @@ TEST_F(VeloxReaderTests, TestMapFieldLifeCycle) {
         child = std::dynamic_pointer_cast<velox::MapVector>(
             result->as<velox::RowVector>()->childAt(0));
 
-        if (rawNulls && child->nulls().get()) {
-          EXPECT_EQ(rawNulls, child->nulls().get());
-        }
+        auto checkAndUpdateNulls = [&rawNulls](velox::BaseVector* vector) {
+          if (rawNulls && vector->nulls().get()) {
+            EXPECT_EQ(rawNulls, vector->nulls().get());
+          }
+          rawNulls = vector->nulls().get();
+        };
+        checkAndUpdateNulls(child.get());
         EXPECT_NE(sizes, child->sizes());
         EXPECT_EQ(rawOffsets, child->offsets().get());
         EXPECT_EQ(keysPtr, child->mapKeys().get());
@@ -5051,9 +5057,7 @@ TEST_F(VeloxReaderTests, TestMapFieldLifeCycle) {
         EXPECT_TRUE(reader->next(batchSize, result));
         child = std::dynamic_pointer_cast<velox::MapVector>(
             result->as<velox::RowVector>()->childAt(0));
-        if (rawNulls && child->nulls().get()) {
-          EXPECT_EQ(rawNulls, child->nulls().get());
-        }
+        checkAndUpdateNulls(child.get());
         EXPECT_EQ(rawSizes, child->sizes().get());
         EXPECT_EQ(rawOffsets, child->offsets().get());
         EXPECT_NE(mapKeys, child->mapKeys());
@@ -5069,9 +5073,7 @@ TEST_F(VeloxReaderTests, TestMapFieldLifeCycle) {
         EXPECT_TRUE(reader->next(batchSize, result));
         child = std::dynamic_pointer_cast<velox::MapVector>(
             result->as<velox::RowVector>()->childAt(0));
-        if (rawNulls && child->nulls().get()) {
-          EXPECT_EQ(rawNulls, child->nulls().get());
-        }
+        checkAndUpdateNulls(child.get());
         EXPECT_EQ(rawSizes, child->sizes().get());
         EXPECT_EQ(rawOffsets, child->offsets().get());
         EXPECT_EQ(keysPtr, child->mapKeys().get());
@@ -5135,9 +5137,13 @@ TEST_F(VeloxReaderTests, TestFlatMapAsMapFieldLifeCycle) {
         child = std::dynamic_pointer_cast<velox::MapVector>(
             result->as<velox::RowVector>()->childAt(0));
 
-        if (rawNulls && child->nulls().get()) {
-          EXPECT_EQ(rawNulls, child->nulls().get());
-        }
+        auto checkAndUpdateNulls = [&rawNulls](velox::BaseVector* vector) {
+          if (rawNulls && vector->nulls().get()) {
+            EXPECT_EQ(rawNulls, vector->nulls().get());
+          }
+          rawNulls = vector->nulls().get();
+        };
+        checkAndUpdateNulls(child.get());
         EXPECT_NE(sizes, child->sizes());
         EXPECT_EQ(rawOffsets, child->offsets().get());
         EXPECT_EQ(keysPtr, child->mapKeys().get());
@@ -5151,9 +5157,7 @@ TEST_F(VeloxReaderTests, TestFlatMapAsMapFieldLifeCycle) {
         EXPECT_TRUE(reader->next(batchSize, result));
         child = std::dynamic_pointer_cast<velox::MapVector>(
             result->as<velox::RowVector>()->childAt(0));
-        if (rawNulls && child->nulls().get()) {
-          EXPECT_EQ(rawNulls, child->nulls().get());
-        }
+        checkAndUpdateNulls(child.get());
         EXPECT_EQ(rawSizes, child->sizes().get());
         EXPECT_EQ(rawOffsets, child->offsets().get());
         EXPECT_NE(mapKeys, child->mapKeys());
@@ -5225,6 +5229,7 @@ TEST_F(VeloxReaderTests, TestRowFieldLifeCycle) {
         if (rawNulls && child->nulls().get()) {
           EXPECT_EQ(rawNulls, child->nulls().get());
         }
+        rawNulls = child->nulls().get();
         EXPECT_NE(childAtIdx0, child->childAt(0));
         EXPECT_EQ(childPtrAtIdx1, child->childAt(1).get());
         EXPECT_EQ(childPtr, child.get());


### PR DESCRIPTION
Summary:
Our reader lifecycle tests ensure that internal Velox vectors and buffers are reused whenever possible, provided the caller does not hold references to these buffers. Specifically, these tests verify that the pointer remains the same before and after calling `next()`.

However, this pointer stability does not always apply to null buffers. The null buffer pointer may change depending on whether the data contains nulls. When the data has no nulls, the nulls vector is freed by resetting its smart pointer to `nullptr`. Currently, the tests incorrectly expect the nulls vector pointer to remain unchanged even after it has been freed.

This diff relaxes that test condition: it now only expects pointer reuse for the nulls vector when it exists and is actively used to represent null data. If the nulls vector is freed (i.e., when there are no nulls), the test no longer expects the pointer address to remain the same.

Differential Revision: D80510416


