### PR TITLE
feat(readers): Optionally disable row size tracking

### DIFF
--- a/dwio/nimble/velox/selective/ChunkedDecoder.h
+++ b/dwio/nimble/velox/selective/ChunkedDecoder.h
@@ -293,6 +293,8 @@ class ChunkedDecoder {
 
   std::unique_ptr<Encoding> encoding_;
   int64_t remainingValues_ = 0;
+  mutable std::optional<size_t> rowCountEstimate_{std::nullopt};
+  mutable std::optional<size_t> stringDataSizeEstimate_{std::nullopt};
 
   friend class ChunkedDecoderTestHelper;
 };

--- a/dwio/nimble/velox/selective/ColumnLoader.h
+++ b/dwio/nimble/velox/selective/ColumnLoader.h
@@ -1,0 +1,209 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "dwio/nimble/velox/selective/RowSizeTracker.h"
+#include "velox/dwio/common/ColumnLoader.h"
+#include "velox/dwio/common/SelectiveStructColumnReader.h"
+
+namespace facebook::nimble {
+
+class TrackedColumnLoader : public velox::dwio::common::ColumnLoader {
+ public:
+  TrackedColumnLoader(
+      velox::dwio::common::SelectiveStructColumnReaderBase* structReader,
+      velox::dwio::common::SelectiveColumnReader* fieldReader,
+      uint64_t version,
+      RowSizeTracker* rowSizeTracker = nullptr)
+      : velox::dwio::common::ColumnLoader{structReader, fieldReader, version},
+        typeWithId_{fieldReader->fileType()},
+        rowSizeTracker_{rowSizeTracker} {}
+
+ private:
+  void loadInternal(
+      velox::RowSet rows,
+      velox::ValueHook* hook,
+      velox::vector_size_t resultSize,
+      velox::VectorPtr* result) override {
+    velox::dwio::common::ColumnLoader::loadInternal(
+        rows, hook, resultSize, result);
+    if (result && rowSizeTracker_) {
+      updateRowSize(typeWithId_, resultSize, *result);
+    }
+  }
+
+  bool isFullyLoaded(const velox::VectorPtr& vector) const {
+    if (!vector || isLazyNotLoaded(*vector)) {
+      return false;
+    }
+
+    auto vectorType = vector->type();
+    switch (vectorType->kind()) {
+      case velox::TypeKind::BOOLEAN:
+      case velox::TypeKind::TINYINT:
+      case velox::TypeKind::SMALLINT:
+      case velox::TypeKind::INTEGER:
+      case velox::TypeKind::BIGINT:
+      case velox::TypeKind::HUGEINT:
+      case velox::TypeKind::REAL:
+      case velox::TypeKind::DOUBLE:
+      case velox::TypeKind::VARCHAR:
+      case velox::TypeKind::VARBINARY: {
+        return true;
+      }
+      case velox::TypeKind::ARRAY: {
+        if (vector->encoding() != velox::VectorEncoding::Simple::ARRAY) {
+          return true;
+        }
+        velox::DecodedVector decodedVector(*vector);
+        auto arrayVector = decodedVector.base()->as<velox::ArrayVector>();
+        return isFullyLoaded(arrayVector->elements());
+      }
+      case velox::TypeKind::MAP: {
+        if (vector->encoding() != velox::VectorEncoding::Simple::MAP) {
+          return true;
+        }
+        velox::DecodedVector decodedVector(*vector);
+        auto mapVector = decodedVector.base()->as<velox::MapVector>();
+        return isFullyLoaded(mapVector->mapKeys()) &&
+            isFullyLoaded(mapVector->mapValues());
+      }
+      case velox::TypeKind::ROW: {
+        if (vector->encoding() != velox::VectorEncoding::Simple::ROW) {
+          return true;
+        }
+        velox::DecodedVector decodedVector(*vector);
+        auto rowVector = decodedVector.base()->as<velox::RowVector>();
+        for (auto child : rowVector->children()) {
+          if (!isFullyLoaded(child)) {
+            return false;
+          }
+        }
+        return true;
+      }
+      default: {
+        VELOX_FAIL("Unsupported lazy field type " + vectorType->toString());
+      }
+    }
+  }
+
+  void updateRowSize(
+      const velox::dwio::common::TypeWithId& localTypeWithId,
+      velox::vector_size_t resultSize,
+      const velox::VectorPtr& vector) {
+    if (!vector || isLazyNotLoaded(*vector)) {
+      return;
+    }
+
+    auto vectorType = vector->type();
+
+    switch (vectorType->kind()) {
+      case velox::TypeKind::BOOLEAN:
+      case velox::TypeKind::TINYINT:
+      case velox::TypeKind::SMALLINT:
+      case velox::TypeKind::INTEGER:
+      case velox::TypeKind::BIGINT:
+      case velox::TypeKind::HUGEINT:
+      case velox::TypeKind::REAL:
+      case velox::TypeKind::DOUBLE:
+      case velox::TypeKind::VARCHAR:
+      case velox::TypeKind::VARBINARY: {
+        VLOG(1) << fmt::format(
+            "updating primitive type, node id {}, vector size {}, row count {}",
+            localTypeWithId.id(),
+            vector->retainedSize(),
+            resultSize);
+        rowSizeTracker_->update(
+            localTypeWithId.id(), vector->retainedSize(), resultSize);
+        break;
+      }
+      case velox::TypeKind::ARRAY: {
+        // Or we can subtract the retained sizes from the children retained
+        // sizes.
+        rowSizeTracker_->update(localTypeWithId.id(), 0, resultSize);
+        if (vector->encoding() != velox::VectorEncoding::Simple::ARRAY) {
+          if (isFullyLoaded(vector)) {
+            rowSizeTracker_->update(
+                localTypeWithId.id(), vector->retainedSize(), resultSize);
+          }
+          break;
+        }
+
+        auto arrayVector = vector->as<velox::ArrayVector>();
+        updateRowSize(
+            *localTypeWithId.childAt(0),
+            arrayVector->elements()->size(),
+            arrayVector->elements());
+        break;
+      }
+      case velox::TypeKind::MAP: {
+        rowSizeTracker_->update(localTypeWithId.id(), 0, resultSize);
+        if (vector->encoding() != velox::VectorEncoding::Simple::MAP) {
+          if (isFullyLoaded(vector)) {
+            rowSizeTracker_->update(
+                localTypeWithId.id(), vector->retainedSize(), resultSize);
+          }
+          break;
+        }
+
+        auto mapVector = vector->as<velox::MapVector>();
+        updateRowSize(
+            *localTypeWithId.childAt(0),
+            mapVector->mapKeys()->size(),
+            mapVector->mapKeys());
+        updateRowSize(
+            *localTypeWithId.childAt(1),
+            mapVector->mapValues()->size(),
+            mapVector->mapValues());
+        break;
+      }
+      case velox::TypeKind::ROW: {
+        if (vector->encoding() != velox::VectorEncoding::Simple::ROW ||
+            localTypeWithId.type()->kind() == velox::TypeKind::MAP) {
+          if (isFullyLoaded(vector)) {
+            rowSizeTracker_->update(
+                localTypeWithId.id(), vector->retainedSize(), resultSize);
+          }
+          break;
+        }
+
+        rowSizeTracker_->update(localTypeWithId.id(), 0, resultSize);
+        auto rowVector = vector->as<velox::RowVector>();
+
+        // Deal with schema evolution..
+        const auto childrenCount = std::min(
+            rowVector->childrenSize(),
+            static_cast<uint64_t>(localTypeWithId.size()));
+        for (auto i = 0; i < childrenCount; i++) {
+          updateRowSize(
+              *localTypeWithId.childAt(i),
+              rowVector->childAt(i)->size(),
+              rowVector->childAt(i));
+        }
+        break;
+      }
+      default: {
+        VELOX_FAIL("Unsupported lazy field type " + vectorType->toString());
+      }
+    }
+  }
+
+  const velox::dwio::common::TypeWithId& typeWithId_;
+  RowSizeTracker* rowSizeTracker_;
+};
+
+} // namespace facebook::nimble

--- a/dwio/nimble/velox/selective/NimbleData.h
+++ b/dwio/nimble/velox/selective/NimbleData.h
@@ -17,6 +17,7 @@
 #pragma once
 
 #include "dwio/nimble/velox/selective/ReaderBase.h"
+#include "dwio/nimble/velox/selective/RowSizeTracker.h"
 #include "velox/dwio/common/FormatData.h"
 
 namespace facebook::nimble {
@@ -108,10 +109,12 @@ class NimbleParams : public velox::dwio::common::FormatParams {
       velox::dwio::common::ColumnReaderStatistics& stats,
       const std::shared_ptr<const Type>& nimbleType,
       StripeStreams& streams,
+      RowSizeTracker* rowSizeTracker,
       bool preserveFlatMapsInMemory = false)
       : FormatParams(pool, stats),
         nimbleType_(nimbleType),
         streams_(streams),
+        rowSizeTracker_(rowSizeTracker),
         preserveFlatMapsInMemory_(preserveFlatMapsInMemory) {}
 
   std::unique_ptr<velox::dwio::common::FormatData> toFormatData(
@@ -120,7 +123,12 @@ class NimbleParams : public velox::dwio::common::FormatParams {
 
   NimbleParams makeChildParams(const std::shared_ptr<const Type>& type) {
     return NimbleParams(
-        pool(), runtimeStatistics(), type, streams_, preserveFlatMapsInMemory_);
+        pool(),
+        runtimeStatistics(),
+        type,
+        streams_,
+        rowSizeTracker_,
+        preserveFlatMapsInMemory_);
   }
 
   const std::shared_ptr<const Type>& nimbleType() const {
@@ -139,10 +147,15 @@ class NimbleParams : public velox::dwio::common::FormatParams {
     return preserveFlatMapsInMemory_;
   }
 
+  RowSizeTracker* rowSizeTracker() const {
+    return rowSizeTracker_;
+  }
+
  private:
   const std::shared_ptr<const Type> nimbleType_;
   StripeStreams& streams_;
   ChunkedDecoder* inMapDecoder_ = nullptr;
+  RowSizeTracker* rowSizeTracker_ = nullptr;
   bool preserveFlatMapsInMemory_ = false;
 };
 

--- a/dwio/nimble/velox/selective/RowSizeTracker.cpp
+++ b/dwio/nimble/velox/selective/RowSizeTracker.cpp
@@ -1,0 +1,122 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "dwio/nimble/velox/selective/RowSizeTracker.h"
+#include <algorithm>
+
+#include "velox/common/base/BitUtil.h"
+
+namespace facebook::nimble {
+
+/* explicit */ RowSizeTracker::RowSizeTracker(
+    const std::shared_ptr<const velox::dwio::common::TypeWithId>& typeWithId)
+    : typeWithId_{typeWithId} {
+  const auto totalNodes = typeWithId->maxId() + 1;
+  variableLengthNodes_.resize(totalNodes);
+  initFromSchema(*typeWithId->type(), 0, false);
+  cellSizes_.resize(totalNodes, std::nullopt);
+}
+
+size_t RowSizeTracker::initFromSchema(
+    const facebook::velox::Type& type,
+    size_t nodeId,
+    bool isParentVariableLength) {
+  size_t nextId = nodeId + 1;
+  if (type.isRow()) {
+    variableLengthNodes_.setValid(nodeId, isParentVariableLength);
+    for (const auto& child : type.asRow().children()) {
+      nextId = initFromSchema(*child, nextId, isParentVariableLength);
+    }
+    return nextId;
+  }
+
+  if (type.isArray()) {
+    auto& arrayType = type.asArray();
+    variableLengthNodes_.setValid(nodeId, true);
+    return initFromSchema(*arrayType.childAt(0), nextId, true);
+  }
+
+  if (type.isMap()) {
+    auto& mapType = type.asMap();
+    variableLengthNodes_.setValid(nodeId, true);
+    nextId = initFromSchema(*mapType.childAt(0), nextId, true);
+    return initFromSchema(*mapType.childAt(1), nextId, true);
+  }
+
+  if (type.isVarchar() || type.isVarbinary()) {
+    variableLengthNodes_.setValid(nodeId, true);
+    return nextId;
+  }
+
+  variableLengthNodes_.setValid(nodeId, isParentVariableLength);
+  return nextId;
+}
+
+void RowSizeTracker::update(
+    size_t nodeIdx,
+    size_t memoryFootprint,
+    velox::vector_size_t rowCount) {
+  if (rowCount <= 0) {
+    return;
+  }
+
+  auto& currentColumnMax = cellSizes_[nodeIdx];
+  auto updateValue = memoryFootprint / rowCount;
+  if (!currentColumnMax.has_value()) {
+    maxRowSize_ += updateValue;
+    currentColumnMax = updateValue;
+    return;
+  }
+
+  // The below logic handles each column's max row size independently.
+  // This allows us to tolerate out of order updates to different rows
+  // to some extent. The only remaining edge case is if the tracked row size
+  // is polled too early (before any subcolumns can materialize).
+  if (currentColumnMax < updateValue) {
+    maxRowSize_ = maxRowSize_ - currentColumnMax.value() + updateValue;
+    currentColumnMax = updateValue;
+  }
+}
+
+size_t RowSizeTracker::getCurrentMaxRowSize() const {
+  bool allVariableLengthMaterialized = true;
+  velox::bits::forEachBit(
+      variableLengthNodes_.allBits(),
+      0,
+      variableLengthNodes_.end(),
+      true,
+      [&](velox::vector_size_t col) {
+        allVariableLengthMaterialized = cellSizes_[col].has_value();
+        VLOG(1) << fmt::format(
+            "variable length col = {}, cell size: {}",
+            col,
+            cellSizes_[col].has_value() ? cellSizes_[col].value() : -1);
+      });
+
+  // TODO: handle the edge case where the tracked row size
+  // is polled too early (before a lot of primitive subcolumns can
+  // materialize). In this case we can either interpolate or supply some
+  // heuristics based on primitive types. This logic would be similar to the
+  // reader row size estimates logic to begin with. In a future iteration, we
+  // can combine the 2 sources of estimates.
+
+  // We return the same conservative estimate if we still have a lot of
+  // unmaterialized variable length columns.
+  return allVariableLengthMaterialized ? maxRowSize_
+                                       : std::max(1UL << 20, maxRowSize_);
+}
+
+} // namespace facebook::nimble

--- a/dwio/nimble/velox/selective/RowSizeTracker.h
+++ b/dwio/nimble/velox/selective/RowSizeTracker.h
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <memory>
+
+#include "velox/dwio/common/TypeWithId.h"
+#include "velox/type/Type.h"
+#include "velox/vector/SelectivityVector.h"
+
+namespace facebook::nimble {
+
+class RowSizeTracker {
+ public:
+  explicit RowSizeTracker(
+      const std::shared_ptr<const velox::dwio::common::TypeWithId>& typeWithId);
+
+  ~RowSizeTracker() = default;
+
+  void
+  update(size_t nodeIdx, size_t memoryFootprint, velox::vector_size_t rowCount);
+
+  size_t getCurrentMaxRowSize() const;
+
+ private:
+  // Populates cell sizes and marks variable length nodes.
+  // Returns the next node index (or the size of the current type subtree).
+  size_t initFromSchema(
+      const facebook::velox::Type& type,
+      size_t nodeId,
+      bool isParentVariableLength);
+
+  const std::shared_ptr<const velox::dwio::common::TypeWithId>& typeWithId_;
+  std::vector<std::optional<size_t>> cellSizes_;
+  // Avoid providing aggressive row sizes when we don't have any materialized
+  // variable length nodes.
+  velox::SelectivityVector variableLengthNodes_;
+  size_t maxRowSize_{0};
+
+  friend class RowSizeTrackerTest;
+};
+
+} // namespace facebook::nimble

--- a/dwio/nimble/velox/selective/SelectiveNimbleReader.cpp
+++ b/dwio/nimble/velox/selective/SelectiveNimbleReader.cpp
@@ -167,7 +167,7 @@ class SelectiveNimbleRowReader : public dwio::common::RowReader {
         columnReaderStatistics_,
         readerBase_->nimbleSchema(),
         streams_,
-        rowSizeTracker_.get(),
+        options_.trackRowSize() ? rowSizeTracker_.get() : nullptr,
         options_.preserveFlatMapsInMemory());
     columnReader_ = buildColumnReader(
         options_.requestedType() ? options_.requestedType()

--- a/dwio/nimble/velox/selective/SelectiveNimbleReader.cpp
+++ b/dwio/nimble/velox/selective/SelectiveNimbleReader.cpp
@@ -17,6 +17,7 @@
 #include "dwio/nimble/velox/selective/SelectiveNimbleReader.h"
 #include "dwio/nimble/velox/selective/ColumnReader.h"
 #include "dwio/nimble/velox/selective/ReaderBase.h"
+#include "dwio/nimble/velox/selective/RowSizeTracker.h"
 
 namespace facebook::nimble {
 namespace detail {
@@ -35,7 +36,11 @@ class SelectiveNimbleRowReader : public dwio::common::RowReader {
   SelectiveNimbleRowReader(
       const std::shared_ptr<ReaderBase>& readerBase,
       const dwio::common::RowReaderOptions& options)
-      : readerBase_(readerBase), options_(options), streams_(readerBase_) {
+      : readerBase_(readerBase),
+        options_(options),
+        streams_(readerBase_),
+        rowSizeTracker_{
+            std::make_unique<RowSizeTracker>(readerBase->fileSchemaWithId())} {
     initReadRange();
     if (options.eagerFirstStripeLoad()) {
       nextRowNumber();
@@ -127,7 +132,7 @@ class SelectiveNimbleRowReader : public dwio::common::RowReader {
     }
     size_t byteSize, rowCount;
     if (!columnReader_->estimateMaterializedSize(byteSize, rowCount)) {
-      return 1 << 20;
+      return rowSizeTracker_->getCurrentMaxRowSize();
     }
     return rowCount == 0 ? 0 : byteSize / rowCount;
   }
@@ -162,6 +167,7 @@ class SelectiveNimbleRowReader : public dwio::common::RowReader {
         columnReaderStatistics_,
         readerBase_->nimbleSchema(),
         streams_,
+        rowSizeTracker_.get(),
         options_.preserveFlatMapsInMemory());
     columnReader_ = buildColumnReader(
         options_.requestedType() ? options_.requestedType()
@@ -185,6 +191,7 @@ class SelectiveNimbleRowReader : public dwio::common::RowReader {
   int skippedStripes_ = 0;
   std::unique_ptr<dwio::common::SelectiveColumnReader> columnReader_;
   dwio::common::ColumnReaderStatistics columnReaderStatistics_;
+  std::unique_ptr<RowSizeTracker> rowSizeTracker_;
 };
 
 class SelectiveNimbleReader : public dwio::common::Reader {

--- a/dwio/nimble/velox/selective/tests/RowSizeTrackerTest.cpp
+++ b/dwio/nimble/velox/selective/tests/RowSizeTrackerTest.cpp
@@ -1,0 +1,153 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <gtest/gtest.h>
+
+#include "dwio/nimble/velox/selective/RowSizeTracker.h"
+#include "velox/vector/tests/utils/VectorTestBase.h"
+
+using namespace ::testing;
+using namespace facebook::velox;
+
+namespace facebook::nimble {
+
+class RowSizeTrackerTest : public velox::test::VectorTestBase, public Test {
+ protected:
+  static void SetUpTestCase() {
+    memory::MemoryManager::initialize(memory::MemoryManager::Options{});
+  }
+
+  void testInit(
+      velox::RowTypePtr schema,
+      std::vector<vector_size_t> variableLengthNodes) {
+    // Create the same TypeWithId as reference.
+    auto typeWithId = dwio::common::TypeWithId::create(schema);
+    RowSizeTracker tracker(dwio::common::TypeWithId::create(schema));
+
+    EXPECT_EQ(tracker.cellSizes_.size(), typeWithId->maxId() + 1);
+
+    velox::bits::forEachBit(
+        tracker.variableLengthNodes_.allBits(),
+        0,
+        tracker.variableLengthNodes_.end(),
+        true,
+        [&](velox::vector_size_t col) {
+          EXPECT_EQ(
+              1,
+              std::count(
+                  variableLengthNodes.begin(), variableLengthNodes.end(), col))
+              << fmt::format(
+                     "variable length col {} not correctly marked after initialization",
+                     col);
+        });
+  }
+};
+
+TEST_F(RowSizeTrackerTest, initialization) {
+  testInit(ROW({INTEGER(), VARCHAR()}), {2});
+  testInit(ROW({INTEGER(), ROW({VARCHAR(), DOUBLE()})}), {3});
+  testInit(ROW({ARRAY(INTEGER()), ROW({VARCHAR(), DOUBLE()})}), {1, 2, 4});
+  testInit(
+      ROW({ARRAY(INTEGER()), ROW({ROW({VARCHAR(), DOUBLE()}), VARCHAR()})}),
+      {1, 2, 5, 7});
+  testInit(
+      ROW(
+          {ARRAY(INTEGER()),
+           ROW(
+               {ROW({VARCHAR(), DOUBLE(), MAP(INTEGER(), ROW({REAL()}))}),
+                VARCHAR()})}),
+      {1, 2, 5, 7, 8, 9, 10, 11});
+}
+
+TEST_F(RowSizeTrackerTest, basicUpdates) {
+  auto schema = ROW({ARRAY(INTEGER()), ROW({VARCHAR(), DOUBLE()})});
+  RowSizeTracker tracker(dwio::common::TypeWithId::create(schema));
+  tracker.update(1, 2, 2);
+  tracker.update(2, 4, 2);
+  tracker.update(3, 8, 2);
+  tracker.update(4, 16, 2);
+  tracker.update(5, 32, 2);
+  EXPECT_EQ(tracker.getCurrentMaxRowSize(), 31);
+
+  tracker.update(2, 32, 4);
+  EXPECT_EQ(tracker.getCurrentMaxRowSize(), 37);
+  tracker.update(2, 4, 4);
+  EXPECT_EQ(tracker.getCurrentMaxRowSize(), 37);
+
+  tracker.update(4, 8, 2);
+  EXPECT_EQ(tracker.getCurrentMaxRowSize(), 37);
+}
+
+TEST_F(RowSizeTrackerTest, partialMarterialization) {
+  auto schema = ROW({ARRAY(INTEGER()), ROW({VARCHAR(), DOUBLE()})});
+  constexpr size_t kFallbackValue = 1UL << 20;
+  // Updating all variable length columns first
+  {
+    RowSizeTracker tracker(dwio::common::TypeWithId::create(schema));
+    tracker.update(1, 0, 2);
+    EXPECT_EQ(tracker.getCurrentMaxRowSize(), kFallbackValue);
+    tracker.update(2, 128, 2);
+    EXPECT_EQ(tracker.getCurrentMaxRowSize(), kFallbackValue);
+    tracker.update(4, 48, 2);
+    EXPECT_EQ(tracker.getCurrentMaxRowSize(), 88);
+    tracker.update(5, 32, 2);
+    EXPECT_EQ(tracker.getCurrentMaxRowSize(), 104);
+    tracker.update(3, 8, 2);
+    EXPECT_EQ(tracker.getCurrentMaxRowSize(), 108);
+  }
+  // Updating all variable length columns last
+  {
+    RowSizeTracker tracker(dwio::common::TypeWithId::create(schema));
+    tracker.update(5, 32, 2);
+    EXPECT_EQ(tracker.getCurrentMaxRowSize(), kFallbackValue);
+    tracker.update(3, 8, 2);
+    EXPECT_EQ(tracker.getCurrentMaxRowSize(), kFallbackValue);
+    tracker.update(1, 0, 2);
+    EXPECT_EQ(tracker.getCurrentMaxRowSize(), kFallbackValue);
+    tracker.update(2, 128, 2);
+    EXPECT_EQ(tracker.getCurrentMaxRowSize(), kFallbackValue);
+    tracker.update(4, 48, 2);
+    EXPECT_EQ(tracker.getCurrentMaxRowSize(), 108);
+  }
+  // Updating in traversal order
+  {
+    RowSizeTracker tracker(dwio::common::TypeWithId::create(schema));
+    tracker.update(1, 0, 2);
+    EXPECT_EQ(tracker.getCurrentMaxRowSize(), kFallbackValue);
+    tracker.update(2, 128, 2);
+    EXPECT_EQ(tracker.getCurrentMaxRowSize(), kFallbackValue);
+    tracker.update(3, 8, 2);
+    EXPECT_EQ(tracker.getCurrentMaxRowSize(), kFallbackValue);
+    tracker.update(4, 48, 2);
+    EXPECT_EQ(tracker.getCurrentMaxRowSize(), 92);
+    tracker.update(5, 32, 2);
+    EXPECT_EQ(tracker.getCurrentMaxRowSize(), 108);
+  }
+}
+
+TEST_F(RowSizeTrackerTest, oversizeRow) {
+  auto schema = ROW({ARRAY(INTEGER()), ROW({VARCHAR(), DOUBLE()})});
+  RowSizeTracker tracker(dwio::common::TypeWithId::create(schema));
+  constexpr size_t kFallbackValue = 1UL << 20;
+  EXPECT_EQ(tracker.getCurrentMaxRowSize(), kFallbackValue);
+  // One materialized node already surpassed the fallback value 1MB.
+  tracker.update(2, 4 * kFallbackValue, 2);
+  EXPECT_EQ(tracker.getCurrentMaxRowSize(), 2 * kFallbackValue);
+
+  tracker.update(4, 4 * kFallbackValue, 2);
+  EXPECT_EQ(tracker.getCurrentMaxRowSize(), 4 * kFallbackValue);
+}
+} // namespace facebook::nimble


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebookincubator/velox/pull/14648

Add a kill switch for row size tracking in case it has unexpected overhead for some data shapes. (Low concern IMO because the row size tracking would quickly increase the batch size and reduce its own overhead. If the end state batch size is still small, we should either way tune the batch memory budget.)

The session property wire up would be added in a presto PR separately.

Reviewed By: Yuhta

Differential Revision: D80978540


