### PR TITLE
Fix a small typo in an error message left after alpha->nimble renaming

### DIFF
--- a/dwio/nimble/tablet/TabletReader.cpp
+++ b/dwio/nimble/tablet/TabletReader.cpp
@@ -201,8 +201,7 @@ Postscript Postscript::parse(std::string_view data) {
   const uint16_t magicNumber = *reinterpret_cast<const uint16_t*>(pos);
 
   NIMBLE_CHECK(
-      magicNumber == kMagicNumber,
-      "Magic number mismatch. Not an nimble file!");
+      magicNumber == kMagicNumber, "Magic number mismatch. Not a nimble file!");
 
   // Read and validate versions
   pos -= 4;


### PR DESCRIPTION
Summary: Fix small typo.

Differential Revision: D81417719


