### PR TITLE
Add optional_sections_metadata command to nimble_dump

### DIFF
--- a/dwio/nimble/tools/NimbleDump.cpp
+++ b/dwio/nimble/tools/NimbleDump.cpp
@@ -393,6 +393,30 @@ int main(int argc, char* argv[]) {
             "Don't print column names. Default is to include column names."
         );
   // clang-format on
+  app.addCommand(
+         "optional_sections_metadata",
+         "<file>",
+         "Print optional sections information",
+         "Prints optional sections information as referenced by the footer.",
+         [](const po::variables_map& options,
+            const std::vector<std::string>& /*args*/) {
+           nimble::tools::NimbleDumpLib{
+               std::cout, options["file"].as<std::string>()}
+               .emitOptionalSectionsMetadata(options["no_header"].as<bool>());
+         },
+         positionalArgs)
+      // clang-format off
+        .add_options()
+        (
+            "file",
+            po::value<std::string>()->required(),
+            "Nimble file path. Can be a local path or a Warm Storage path."
+        )(
+            "no_header,n",
+            po::bool_switch()->default_value(false),
+            "Don't print column names. Default is to include column names."
+        );
+  // clang-format on
 
   app.addAlias("i", "info");
   app.addAlias("b", "binary");

--- a/dwio/nimble/tools/NimbleDumpLib.h
+++ b/dwio/nimble/tools/NimbleDumpLib.h
@@ -49,6 +49,7 @@ class NimbleDumpLib {
   void emitFileLayout(bool noHeader);
   void emitStripesMetadata(bool noHeader);
   void emitStripeGroupsMetadata(bool noHeader);
+  void emitOptionalSectionsMetadata(bool noHeader);
 
  private:
   std::shared_ptr<velox::memory::MemoryPool> pool_;


### PR DESCRIPTION
Summary: Add a new nimble dump command that prints metadata for optional sections.

Differential Revision: D81453738


