### PR TITLE
Reduce default metadata compression threshold to 64kB

### DIFF
--- a/dwio/nimble/tablet/TabletWriter.h
+++ b/dwio/nimble/tablet/TabletWriter.h
@@ -34,7 +34,7 @@ class LayoutPlanner {
 };
 
 constexpr uint32_t kMetadataFlushThreshold = 8 * 1024 * 1024; // 8MB
-constexpr uint32_t kMetadataCompressionThreshold = 4 * 1024 * 1024; // 4MB
+constexpr uint32_t kMetadataCompressionThreshold = 64 * 1024; // 64kB
 
 struct TabletWriterOptions {
   std::unique_ptr<LayoutPlanner> layoutPlanner{nullptr};


### PR DESCRIPTION
Summary:
Reduce default metadata compression threshold from 4MB to 64kB to get smaller and fewer footer IOs in preparation of reducing the tail read size. 

Default compression level for metadata is Zstd 1.

Differential Revision: D81456032


