### PR TITLE
Add file_layout command to nimble_dump

### DIFF
--- a/dwio/nimble/tools/NimbleDump.cpp
+++ b/dwio/nimble/tools/NimbleDump.cpp
@@ -74,6 +74,31 @@ int main(int argc, char* argv[]) {
           "Nimble file path. Can be a local path or a Warm Storage path.");
 
   app.addCommand(
+         "file_layout",
+         "<file>",
+         "Print overall layout of the file",
+         "Print overall layout of the file",
+         [](const po::variables_map& options,
+            const std::vector<std::string>& /*args*/) {
+           nimble::tools::NimbleDumpLib{
+               std::cout, options["file"].as<std::string>()}
+               .emitFileLayout(options["no_header"].as<bool>());
+         },
+         positionalArgs)
+      // clang-format off
+        .add_options()
+        (
+            "file",
+            po::value<std::string>()->required(),
+            "Nimble file path. Can be a local path or a Warm Storage path."
+        )(
+            "no_header,n",
+            po::bool_switch()->default_value(false),
+            "Don't print column names. Default is to include column names."
+        );
+  // clang-format on
+
+  app.addCommand(
          "schema",
          "<file>",
          "Print file schema",

--- a/dwio/nimble/tools/NimbleDumpLib.h
+++ b/dwio/nimble/tools/NimbleDumpLib.h
@@ -46,6 +46,7 @@ class NimbleDumpLib {
       uint32_t streamId,
       uint32_t stripeId);
   void emitLayout(bool noHeader, bool compressed);
+  void emitFileLayout(bool noHeader);
   void emitStripesMetadata(bool noHeader);
   void emitStripeGroupsMetadata(bool noHeader);
 


### PR DESCRIPTION
Summary: Add a separate command to print the overall layout of objects in the file.

Differential Revision: D81503738


