### PR TITLE
fix: Read lazy ROW value in flat map vector returning incorrect result

### DIFF
--- a/dwio/nimble/velox/selective/FlatMapColumnReader.cpp
+++ b/dwio/nimble/velox/selective/FlatMapColumnReader.cpp
@@ -340,6 +340,11 @@ class FlatMapAsMapColumnReader : public StructColumnReaderBase {
     flatMap_.getValues(rows, result);
   }
 
+  void setIsTopLevel() override {
+    // Children are not considered top level since this is materialized as MAP.
+    SelectiveColumnReader::setIsTopLevel();
+  }
+
   bool estimateMaterializedSize(size_t& byteSize, size_t& rowCount)
       const final {
     auto* nulls = formatData().template as<NimbleData>().nullsDecoder();


### PR DESCRIPTION
Summary:
When the following conditions are satisfied:
1. The flat map column has ROW as the map value (there is no prod data with this type; we discovered it using table evolution fuzzer)
2. The flat map column is read as ordinary map
3. The flat map column has a push down filter in the query
4. A second filter is evaluated and reducing the number of rows after flat map column

The children in the ROW map values would be read lazily; however the output row
set of the ROW column is not set correctly, because we consider its parent a MAP
column and its value should not be read lazily.  Fix this by not allowing the
MAP children to be read lazily in the flat map as map column readers.

Differential Revision: D81390639


