### PR TITLE
Free up memory held by previous stripe in batch reader

### DIFF
--- a/dwio/nimble/velox/VeloxReader.cpp
+++ b/dwio/nimble/velox/VeloxReader.cpp
@@ -308,6 +308,10 @@ void VeloxReader::loadNextStripe() {
     StripeLoadMetrics metrics;
     velox::CpuWallTiming timing{};
     {
+      // Free up any memory used by the previous stripe
+      rootReader_ = nullptr;
+      decoders_.clear();
+
       auto& unit = unitLoader_->getLoadedUnit(getUnitIndex(nextStripe_));
 
       velox::CpuWallTimer timer{timing};


### PR DESCRIPTION
Summary:
Batch reader was holding up to the previous stripe streams during a loading of the next stripe. This resulted in significant increase (50-400MB) in peak memory consumption when the reader was loading the next stripe. 

This change resets decoders from the previous stripe before loading the next stripe. It brings the batch reader almost on par with the reported peak memory with the selective reader.

Differential Revision: D81859545


