### PR TITLE
Fix writer regression caused by memory reallocation in ensureNullsCapacity

### DIFF
--- a/dwio/nimble/velox/CMakeLists.txt
+++ b/dwio/nimble/velox/CMakeLists.txt
@@ -27,7 +27,7 @@ target_link_libraries(nimble_velox_schema_builder nimble_velox_schema_reader
 
 add_library(nimble_velox_stream_data StreamData.cpp)
 target_link_libraries(nimble_velox_stream_data nimble_velox_schema_builder
-                      nimble_common)
+                      nimble_common nimble_velox_buffer_growth_policy)
 
 add_library(nimble_velox_field_reader FieldReader.cpp)
 target_link_libraries(
@@ -37,11 +37,13 @@ target_link_libraries(
 add_library(nimble_velox_layout_planner LayoutPlanner.cpp)
 target_link_libraries(nimble_velox_layout_planner nimble_velox_schema_reader)
 
-add_library(nimble_velox_field_writer BufferGrowthPolicy.cpp
-                                      DeduplicationUtils.cpp FieldWriter.cpp)
+add_library(nimble_velox_buffer_growth_policy BufferGrowthPolicy.cpp)
+target_link_libraries(nimble_velox_buffer_growth_policy nimble_common)
+
+add_library(nimble_velox_field_writer DeduplicationUtils.cpp FieldWriter.cpp)
 target_link_libraries(
   nimble_velox_field_writer nimble_velox_schema nimble_velox_stream_data
-  nimble_velox_schema_builder Folly::folly)
+  nimble_velox_schema_builder nimble_velox_buffer_growth_policy Folly::folly)
 
 build_flatbuffers(
   "${CMAKE_CURRENT_SOURCE_DIR}/Schema.fbs"
@@ -108,6 +110,7 @@ add_library(
                       ChunkedStreamWriter.cpp VeloxWriterDefaultMetadataOSS.cpp)
 target_link_libraries(
   nimble_velox_writer
+  nimble_velox_buffer_growth_policy
   nimble_encodings
   nimble_common
   nimble_column_stats_utils

--- a/dwio/nimble/velox/StreamData.cpp
+++ b/dwio/nimble/velox/StreamData.cpp
@@ -18,10 +18,15 @@
 
 namespace facebook::nimble {
 
-void NullsStreamData::ensureNullsCapacity(bool mayHaveNulls, uint32_t size) {
+void NullsStreamData::ensureNullsCapacity(
+    bool mayHaveNulls,
+    uint32_t size,
+    InputBufferGrowthPolicy* growthPolicy) {
   if (mayHaveNulls || hasNulls_) {
     auto newSize = bufferedCount_ + size;
-    nonNulls_.reserve(newSize);
+    auto newCapacity = growthPolicy->getExtendedCapacity(
+        bufferedCount_ + size, nonNulls_.capacity());
+    nonNulls_.reserve(newCapacity);
     if (!hasNulls_) {
       hasNulls_ = true;
       std::fill(nonNulls_.data(), nonNulls_.data() + bufferedCount_, true);

--- a/dwio/nimble/velox/StreamData.h
+++ b/dwio/nimble/velox/StreamData.h
@@ -20,6 +20,7 @@
 #include <string_view>
 
 #include "dwio/nimble/common/Vector.h"
+#include "dwio/nimble/velox/BufferGrowthPolicy.h"
 #include "dwio/nimble/velox/SchemaBuilder.h"
 #include "velox/common/memory/Memory.h"
 
@@ -160,7 +161,10 @@ class NullsStreamData : public StreamData {
     }
   }
 
-  void ensureNullsCapacity(bool mayHaveNulls, uint32_t size);
+  void ensureNullsCapacity(
+      bool mayHaveNulls,
+      uint32_t size,
+      InputBufferGrowthPolicy* growthPolicy);
 
  protected:
   Vector<bool> nonNulls_;


### PR DESCRIPTION
Summary:
Fix up to 32x writer regression caused by memory reallocation of the exact size without growing
in ensureNullsCapacity by providing the grows policy. 

This regression was identified by DISCO runs on biggest tables and then narrowed by CPU profiling.

Differential Revision: D82172070


