### PR TITLE
rollout JK knob for non-FBETL writers

### DIFF
--- a/dwio/nimble/encodings/EncodingSelection.h
+++ b/dwio/nimble/encodings/EncodingSelection.h
@@ -77,7 +77,7 @@ struct MetaInternalCompressionParameters {
   int16_t compressionLevel = 0;
   int16_t decompressionLevel = 0;
   bool useVariableBitWidthCompressor = true;
-  bool useManagedCompression = false;
+  int useManagedCompression = 2; // 0: disabled, 1: enabled, 2: unset
 };
 
 union CompressionParameters {

--- a/dwio/nimble/encodings/EncodingSelectionPolicy.h
+++ b/dwio/nimble/encodings/EncodingSelectionPolicy.h
@@ -105,7 +105,8 @@ struct CompressionOptions {
   uint32_t internalCompressionLevel = 4;
   uint32_t internalDecompressionLevel = 2;
   bool useVariableBitWidthCompressor = false;
-  bool metaInternalUseManagedCompressionForCompress = false;
+  int metaInternalUseManagedCompressionForCompress =
+      2; // 0: off, 1: on, 2: unset
 };
 
 // This is the manual encoding selection implementation.


### PR DESCRIPTION
Summary: This is a JK-backed knob to turn on managed compression for nimble writers who don't pass table/namespace info via `dwio/api/FileWriter.cpp`. It's backed by the `managed_compression/nimble_rollout:use_mc` fractional host rollout knob. It's a host-based rollout, which means the rollout is incremental and it can be quickly undone if things go wrong.

Reviewed By: HuamengJiang, felixhandte

Differential Revision: D81956730


