### PR TITLE
Make Nimble Vector allocate exact Velox Buffer size

### DIFF
--- a/dwio/nimble/common/Vector.h
+++ b/dwio/nimble/common/Vector.h
@@ -220,9 +220,12 @@ class Vector {
   // values.
   void reserve(uint64_t size) {
     if (size > capacity_) {
-      capacity_ = size;
       auto newData =
-          velox::AlignedBuffer::allocate<InnerType>(capacity_, memoryPool_);
+          velox::AlignedBuffer::allocateExact<InnerType>(size, memoryPool_);
+      // AlignedBuffer can allocate a bit more than requested for the alignment
+      // purpose, let's leverage that by using its true capacity.
+      capacity_ = newData->capacity() / sizeof(InnerType);
+      VELOX_CHECK_GE(capacity_, size);
       if (data_ != nullptr && size_ > 0) {
         std::move(
             dataRawPtr_,
@@ -282,8 +285,12 @@ class Vector {
   }
 
   inline void allocateBuffer() {
-    data_ = velox::AlignedBuffer::allocate<InnerType>(capacity_, memoryPool_);
+    data_ =
+        velox::AlignedBuffer::allocateExact<InnerType>(capacity_, memoryPool_);
     dataRawPtr_ = reinterpret_cast<T*>(data_->asMutable<InnerType>());
+    uint64_t newCapacity = data_->capacity() / sizeof(InnerType);
+    VELOX_CHECK_GE(newCapacity, capacity_);
+    capacity_ = newCapacity;
   }
 
   velox::memory::MemoryPool* memoryPool_;


### PR DESCRIPTION
Summary:
Significantly optimize memory consumption by making Nimble Vector allocate exact Velox Buffer size.

By default Velox AlignedBuffer allocates amount of memory which is a rounded up to the next closest power of two (kinda). For example when requested to allocate 65MB it will allocate 96MB, or when requested 520MB it will allocate 805MB. You can find exact numbers here https://github.com/facebookincubator/velox/pull/14825.

# Reader
Depending on stream sizes and data shapes this can lead to significant memory regressions in both reader and writer. With this improvement 
average reader memory consumption lowers by 13.66% (min 6.07%, max 23.80%); 
and peak memory consumption on average lowers by 28.65% (min 4.41%, max 44.99%). 
Reader CPU times improves by 2.71% on average (min -3.04%, max 10.91%).
Here are reader metrics captured for top tables: 
https://docs.google.com/spreadsheets/d/1Td883Mr0RGWvEbfvn8koRK1BTfpvM6Dt64hWvV5uNhs/edit?usp=sharing

# Writer
On the writer side the story is pretty much the same:
https://docs.google.com/spreadsheets/d/1EYFHZ7MYq36jh3Sk3ZxfumlVIgvKf8yjZp7nhGkcxxs/edit?gid=1561918147#gid=1561918147

Writer average memory reduced by avg 15.82% (min 1.86%, max 29.71%)
Writer max average memory reduced by avg 15.52% (min 1.21%, max 40.73%)
Writer peak memory reduced by avg 13.90% (min 5.59%, max 27.00%).

# Performance impact of allocating smaller blocks of memory
There is no negative impact of allocating exact memory size instead of larger chunks (e.g. resizing) because Nimble uses its own growth policy and does not take into actual buffer capacity.

Differential Revision: D82693528


