### PR TITLE
Disable MC in the compression test

### DIFF
--- a/dwio/nimble/encodings/tests/CompressionTests.cpp
+++ b/dwio/nimble/encodings/tests/CompressionTests.cpp
@@ -44,6 +44,8 @@ class TestCompressionPolicy : public nimble::CompressionPolicy {
         .minCompressionSize = minCompressionSize};
 
     compressionInfo_.parameters.zstd.compressionLevel = 3;
+    // enum MCTernaryState : long { Unset = 2, Off = 0, On = 1 };
+    compressionInfo_.parameters.metaInternal.useManagedCompression = 0;
     compressionInfo_.parameters.metaInternal.compressionLevel = 4;
     compressionInfo_.parameters.metaInternal.decompressionLevel = 2;
   }


### PR DESCRIPTION
Summary:
As MacVincent discovered, the MC is getting enabled in opt mode, which changes the compression behavior. With enabled MC the minimal compression threshold for MetaInternal grows by additional 20 bytes.

For now let's just disable the MC in the test to force it to the old behavior, and let's re-evaluate the MC threshold separately to see whether we should raise it to 80-100 bytes or adjust to the new MC threshold.

Differential Revision: D83215102


