### PR TITLE
turn CompressionParameters into a struct

### DIFF
--- a/dwio/nimble/encodings/EncodingSelection.h
+++ b/dwio/nimble/encodings/EncodingSelection.h
@@ -80,9 +80,9 @@ struct MetaInternalCompressionParameters {
   int useManagedCompression = 2; // 0: disabled, 1: enabled, 2: unset
 };
 
-union CompressionParameters {
-  ZstdCompressionParameters zstd;
-  MetaInternalCompressionParameters metaInternal;
+struct CompressionParameters {
+  ZstdCompressionParameters zstd{};
+  MetaInternalCompressionParameters metaInternal{};
 };
 
 struct CompressionInformation {


### PR DESCRIPTION
Summary:
Because `CompressionParameters` is a union, the default initialization is to only initialize the zstd params portion. The result is that the `MetaInternalCompressionParameters` is not initialized properly in places where defaults are expected. This is the cause of the bug encountered in D83197927 and doubtless other small bugs here and there.

`CompressionParameters` was declared as a union in D40728763. I saw no reason given for this to be a union and not a struct. On the contrary, there are many use cases within the codebase where the union is treated like a struct, including in the test itself!
https://www.internalfb.com/code/fbsource/[23ec3ab74d6b6bd8bd228b1cdc9537b65e1dbc96]/fbcode/dwio/nimble/encodings/tests/CompressionTests.cpp?lines=46%2C49

Differential Revision: D83626048


