### PR TITLE
Use pre-commit for clang-format

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,6 +15,10 @@
 # See https://pre-commit.com for more information
 
 repos:
+  - repo: https://github.com/pre-commit/mirrors-clang-format
+    rev: v18.1.3
+    hooks:
+      - id: clang-format
   - repo: https://github.com/BlankSpruce/gersemi
     rev: 0.22.2
     hooks:

--- a/scripts/format-check.py
+++ b/scripts/format-check.py
@@ -24,7 +24,6 @@ import util
 
 from util import attrdict
 
-EXTENSIONS = "cpp,h,inc,prolog"
 SCRIPTS = util.script_path()
 
 
@@ -41,27 +40,6 @@ def get_diff(file, formatted):
     return status, stdout, stderr
 
 
-class CppFormatter(str):
-    def diff(self, commit):
-        if commit == "":
-            return get_diff(self, util.run(f"clang-format --style=file {self}")[1])
-        else:
-            return util.run(
-                f"{SCRIPTS}/git-clang-format -q --extensions='{EXTENSIONS}' --diff --style=file {commit} {self}"
-            )
-
-    def fix(self, commit):
-        if commit == "":
-            return util.run(f"clang-format -i --style=file {self}")[0] == 0
-        else:
-            return (
-                util.run(
-                    f"{SCRIPTS}/git-clang-format -q --extensions='{EXTENSIONS}' --style=file {commit} {self}"
-                )[0]
-                == 0
-            )
-
-
 class PythonFormatter(str):
     def diff(self, commit):
         return util.run(f"black -q --diff {self}")
@@ -72,10 +50,6 @@ class PythonFormatter(str):
 
 format_file_types = OrderedDict(
     {
-        "*.cpp": attrdict({"formatter": CppFormatter}),
-        "*.h": attrdict({"formatter": CppFormatter}),
-        "*.inc": attrdict({"formatter": CppFormatter}),
-        "*.prolog": attrdict({"formatter": CppFormatter}),
         "*.py": attrdict({"formatter": PythonFormatter}),
     }
 )


### PR DESCRIPTION
Velox migrated to pre-commit:
* https://github.com/facebookincubator/velox/pull/13361

If we use pre-commit, pre-commit prepare pinned clang-format automatically.