### PR TITLE
Split header and data size in encoding size estimation

### DIFF
--- a/dwio/nimble/encodings/EncodingSelectionPolicy.h
+++ b/dwio/nimble/encodings/EncodingSelectionPolicy.h
@@ -172,10 +172,10 @@ class ManualEncodingSelectionPolicy : public EncodingSelectionPolicy<T> {
     // minimal cost.
     for (const auto& pair : readFactors_) {
       auto encodingType = pair.first;
-      auto size =
+      auto sizeEstimation =
           detail::EncodingSizeEstimation<T, FixedByteWidth>::estimateSize(
               encodingType, values.size(), statistics);
-      if (!size.has_value()) {
+      if (!sizeEstimation.has_value()) {
         NIMBLE_SELECTION_LOG(
             PURPLE << encodingType << " encoding is incompatible.");
         continue;
@@ -184,9 +184,10 @@ class ManualEncodingSelectionPolicy : public EncodingSelectionPolicy<T> {
       // We use read factor weights to raise/lower the favorability of each
       // encoding.
       auto readFactor = pair.second;
-      auto cost = size.value() * readFactor;
+      auto cost = sizeEstimation.value().cost(readFactor);
       NIMBLE_SELECTION_LOG(
-          YELLOW << "Encoding: " << encodingType << ", Size: " << size.value()
+          YELLOW << "Encoding: " << encodingType
+                 << ", Size: " << sizeEstimation.value().size()
                  << ", Factor: " << readFactor << ", Cost: " << cost);
       if (cost < minCost) {
         minCost = cost;


### PR DESCRIPTION
Summary: Split header and data size in encoding size estimation so that the read factor can only be applied to the compressible data. Current implementation give funky estimates for small sized data.

Differential Revision: D84458948


