### PR TITLE
Add support for setting feature reordering properties in Velox

### DIFF
--- a/dwio/nimble/velox/VeloxWriterOptions.h
+++ b/dwio/nimble/velox/VeloxWriterOptions.h
@@ -23,7 +23,11 @@
 #include "dwio/nimble/velox/FlushPolicy.h"
 #include "folly/container/F14Set.h"
 #include "velox/common/base/SpillConfig.h"
-#include "velox/type/Type.h"
+
+// Forward declaration to avoid circular dependency
+namespace facebook::nimble {
+class Config;
+}
 
 // Options used by Velox writer that affect the output file format
 
@@ -152,6 +156,11 @@ struct VeloxWriterOptions {
   // monitor usage of decoded vectors vs. data that is passed-through in the
   // writer. Default function is no-op since its used for tests only.
   std::function<void(void)> vectorDecoderVisitor = []() {};
+
+  // Raw nimble configuration object containing all serde parameters.
+  // This provides the nimble writer with access to raw config strings
+  // (like FEATURE_REORDERING) that need to be parsed internally by the writer.
+  std::shared_ptr<nimble::Config> rawConfig;
 };
 
 } // namespace facebook::nimble


### PR DESCRIPTION
Summary:

The feature reordering configuration flows through the complete Velox pipeline from serde parameters to NimbleWriterOptions, enabling storage optimizations for workloads with predictable map key access patterns.
This change implements feature reordering configuration support for Nimble writer to optimize storage and query performance for map columns with predictable access patterns.

**Solution:**
Added comprehensive feature reordering support through the existing serde parameter mechanism:

**Configuration Infrastructure:**
- Added `FEATURE_REORDERING` config entry to NimbleConfig for alpha.feature.reordering parameter
- Integrated with existing Velox writer pipeline through serde parameters

- Gracefully handles malformed configurations with warning logs and skipping them instead of throwing an error

**Dynamic Partition Support**: The updated architecture anticipates partition → [manifold_links] mappings where different partitions can have different feature ordering configs, prepares for the planned remodeled architecture where "config will be a few manifold links, each pointing to one or more blobs, with mapping of dynamic partition to manifold links"

Differential Revision: D83006952


