### PR TITLE
remove writer rollout code

### DIFF
--- a/dwio/nimble/encodings/EncodingSelection.h
+++ b/dwio/nimble/encodings/EncodingSelection.h
@@ -102,7 +102,6 @@ struct MetaInternalCompressionParameters {
   int16_t compressionLevel = 0;
   int16_t decompressionLevel = 0;
   bool useVariableBitWidthCompressor = true;
-  int useManagedCompression = 2; // 0: disabled, 1: enabled, 2: unset
   MetaInternalCompressionKey compressionKey;
 };
 

--- a/dwio/nimble/encodings/EncodingSelectionPolicy.h
+++ b/dwio/nimble/encodings/EncodingSelectionPolicy.h
@@ -109,8 +109,6 @@ struct CompressionOptions {
   uint32_t internalCompressionLevel = 4;
   uint32_t internalDecompressionLevel = 2;
   bool useVariableBitWidthCompressor = false;
-  int metaInternalUseManagedCompressionForCompress =
-      2; // 0: off, 1: on, 2: unset
   MetaInternalCompressionKey metaInternalCompressionKey;
 };
 
@@ -218,8 +216,6 @@ class ManualEncodingSelectionPolicy : public EncodingSelectionPolicy<T> {
             compressionOptions_.internalDecompressionLevel;
         information.parameters.metaInternal.useVariableBitWidthCompressor =
             compressionOptions_.useVariableBitWidthCompressor;
-        information.parameters.metaInternal.useManagedCompression =
-            compressionOptions_.metaInternalUseManagedCompressionForCompress;
         information.parameters.metaInternal.compressionKey =
             compressionOptions_.metaInternalCompressionKey;
         return information;
@@ -568,8 +564,6 @@ class ReplayedCompressionPolicy : public nimble::CompressionPolicy {
         compressionOptions_.internalDecompressionLevel;
     information.parameters.metaInternal.useVariableBitWidthCompressor =
         compressionOptions_.useVariableBitWidthCompressor;
-    information.parameters.metaInternal.useManagedCompression =
-        compressionOptions_.metaInternalUseManagedCompressionForCompress;
     information.parameters.metaInternal.compressionKey =
         compressionOptions_.metaInternalCompressionKey;
     return information;

--- a/dwio/nimble/encodings/tests/CompressionTests.cpp
+++ b/dwio/nimble/encodings/tests/CompressionTests.cpp
@@ -44,8 +44,6 @@ class TestCompressionPolicy : public nimble::CompressionPolicy {
         .minCompressionSize = minCompressionSize};
 
     compressionInfo_.parameters.zstd.compressionLevel = 3;
-    // enum MCTernaryState : long { Unset = 2, Off = 0, On = 1 };
-    compressionInfo_.parameters.metaInternal.useManagedCompression = 0;
     compressionInfo_.parameters.metaInternal.compressionLevel = 4;
     compressionInfo_.parameters.metaInternal.decompressionLevel = 2;
   }
@@ -56,9 +54,9 @@ class TestCompressionPolicy : public nimble::CompressionPolicy {
 
   virtual bool shouldAccept(
       nimble::CompressionType /* compressionType */,
-      uint64_t /* uncompressedSize */,
-      uint64_t /* compressedSize */) const override {
-    return true;
+      uint64_t uncompressedSize,
+      uint64_t compressedSize) const override {
+    return compressedSize < uncompressedSize;
   }
 
  private:


### PR DESCRIPTION
Summary: The writers have been fully rolled out since Sept 24. All dashboards and anecdotal evidence point to no issues. Therefore we can remove the rollout code.

Reviewed By: sdruzkin

Differential Revision: D84201078


