### PR TITLE
Remove usage of velox::mapTypeKindToName()

### DIFF
--- a/dwio/nimble/velox/selective/ColumnReader.cpp
+++ b/dwio/nimble/velox/selective/ColumnReader.cpp
@@ -132,8 +132,7 @@ std::unique_ptr<dwio::common::SelectiveColumnReader> buildColumnReader(
             requestedType, fileType, params, scanSpec);
       }
     default:
-      VELOX_UNSUPPORTED(
-          "Unsupported type: {}", mapTypeKindToName(fileType->type()->kind()));
+      VELOX_UNSUPPORTED("Unsupported type: {}", fileType->type()->kind());
   }
 }
 


### PR DESCRIPTION
Summary: Remove usage of deprecated API velox::mapTypeKindToName().

Differential Revision: D84876899


