### PR TITLE
refactor: Remove usage of folly::StringPiece in dwio

### DIFF
--- a/dwio/nimble/encodings/Encoding.h
+++ b/dwio/nimble/encodings/Encoding.h
@@ -525,13 +525,13 @@ void readWithVisitorFast(
 // ValueType is the type we store in values buffer of selective column reader.
 template <typename DataType>
 using ValueType = std::conditional_t<
-    std::is_same_v<DataType, folly::StringPiece>,
+    std::is_same_v<DataType, std::string_view>,
     velox::StringView,
     DataType>;
 
 template <typename V, typename DataType>
 ValueType<DataType> dataToValue(const V& visitor, DataType data) {
-  if constexpr (std::is_same_v<DataType, folly::StringPiece>) {
+  if constexpr (std::is_same_v<DataType, std::string_view>) {
     return visitor.reader().copyStringValueIfNeed(data);
   } else {
     return data;

--- a/dwio/nimble/encodings/EncodingUtils.h
+++ b/dwio/nimble/encodings/EncodingUtils.h
@@ -132,7 +132,7 @@ void callReadWithVisitor(
     V& visitor,
     ReadWithVisitorParams& params) {
   using T = typename V::DataType;
-  if constexpr (std::is_same_v<T, folly::StringPiece>) {
+  if constexpr (std::is_same_v<T, std::string_view>) {
     detail::encodingTypeDispatchString(encoding, [&](auto& typedEncoding) {
       typedEncoding.readWithVisitor(visitor, params);
     });

--- a/dwio/nimble/encodings/TrivialEncoding.h
+++ b/dwio/nimble/encodings/TrivialEncoding.h
@@ -332,7 +332,7 @@ void TrivialEncoding<std::string_view>::readWithVisitor(
       },
       [&] {
         auto len = *lengths++;
-        folly::StringPiece value(pos_, len);
+        std::string_view value(pos_, len);
         ++row_;
         pos_ += len;
         return value;

--- a/dwio/nimble/velox/selective/StringColumnReader.cpp
+++ b/dwio/nimble/velox/selective/StringColumnReader.cpp
@@ -32,7 +32,7 @@ void StringColumnReader::read(
     int64_t offset,
     const RowSet& rows,
     const uint64_t* incomingNulls) {
-  prepareRead<folly::StringPiece>(offset, rows, incomingNulls);
+  prepareRead<std::string_view>(offset, rows, incomingNulls);
   dwio::common::StringColumnReadWithVisitorHelper<false, false>(
       *this, rows)([&](auto visitor) { decoder_.readWithVisitor(visitor); });
   readOffset_ += rows.back() + 1;


### PR DESCRIPTION
Summary:
Intermediate step while migrating legacy folly::StringPiece usages to
std::string_view.

Part of https://github.com/facebookincubator/velox/issues/14456

Differential Revision: D85061784


