### PR TITLE
Disable colored output if not running in a terminal

### DIFF
--- a/dwio/nimble/tools/NimbleDumpLib.h
+++ b/dwio/nimble/tools/NimbleDumpLib.h
@@ -24,7 +24,10 @@ namespace facebook::nimble::tools {
 
 class NimbleDumpLib {
  public:
-  NimbleDumpLib(std::ostream& ostream, const std::string& file);
+  NimbleDumpLib(
+      std::ostream& ostream,
+      bool enableColors,
+      const std::string& file);
 
   void emitInfo();
   void emitSchema(bool collapseFlatMap = true);
@@ -55,5 +58,6 @@ class NimbleDumpLib {
   std::shared_ptr<velox::memory::MemoryPool> pool_;
   std::shared_ptr<velox::ReadFile> file_;
   std::ostream& ostream_;
+  bool enableColors_;
 };
 } // namespace facebook::nimble::tools


### PR DESCRIPTION
Summary:
Colored output is great for the terminal, but it is annoying when the output is piped into a file.

With this change, the tool detects if it is running in a (color supporting) terminal, and only then emits colors.

Reviewed By: sdruzkin

Differential Revision: D85069881


