### PR TITLE
][be] Attach file path to VeloxExceptions thrown from DWRF reader ctor, Nimble tablet and file reader ctors

### DIFF
--- a/dwio/nimble/tablet/TabletReader.h
+++ b/dwio/nimble/tablet/TabletReader.h
@@ -296,6 +296,10 @@ class TabletReader {
     return file_->size();
   }
 
+  std::string fileName() const {
+    return file_->getName();
+  }
+
   uint32_t footerSize() const {
     return ps_.footerSize();
   }

--- a/dwio/nimble/velox/VeloxReader.cpp
+++ b/dwio/nimble/velox/VeloxReader.cpp
@@ -205,6 +205,16 @@ VeloxReader::VeloxReader(
       logger_{
           parameters_.metricsLogger ? parameters_.metricsLogger
                                     : std::make_shared<MetricsLogger>()} {
+  // Attach the path to VeloxException if an exception is thrown in the
+  // constructor.
+  auto exceptionContextMsg =
+      fmt::format("Reader path {}", tabletReader_->fileName());
+  velox::ExceptionContextSetter exceptionContext(
+      {[](velox::VeloxException::Type /*exceptionType*/, auto* debugString) {
+         return *static_cast<std::string*>(debugString);
+       },
+       &exceptionContextMsg});
+
   static_assert(std::is_same_v<velox::vector_size_t, int32_t>);
 
   if (!selector) {


### PR DESCRIPTION
Summary:
VeloxException has a mechanism to attach scope bound context to VeloxExceptions thrown out of scope. Let's leverage it to add the file path to exceptions thrown from:
* DWRF batch reader constructor
* Nimble tablet reader constructor
* Nimble batch file reader constructor

Later we can also add the file path to the reader::next method.

Differential Revision: D85173751


