### PR TITLE
Prepare stats for optional Uniques

### DIFF
--- a/dwio/nimble/encodings/ConstantEncoding.h
+++ b/dwio/nimble/encodings/ConstantEncoding.h
@@ -124,7 +124,7 @@ std::string_view ConstantEncoding<T>::encode(
     NIMBLE_INCOMPATIBLE_ENCODING("ConstantEncoding cannot be empty.");
   }
 
-  if (selection.statistics().uniqueCounts().size() != 1) {
+  if (selection.statistics().uniqueCounts().value().size() != 1) {
     NIMBLE_INCOMPATIBLE_ENCODING("ConstantEncoding requires constant data.");
   }
 

--- a/dwio/nimble/encodings/DictionaryEncoding.h
+++ b/dwio/nimble/encodings/DictionaryEncoding.h
@@ -200,7 +200,8 @@ std::string_view DictionaryEncoding<T>::encode(
     std::span<const physicalType> values,
     Buffer& buffer) {
   const uint32_t valueCount = values.size();
-  const uint32_t alphabetCount = selection.statistics().uniqueCounts().size();
+  const uint32_t alphabetCount =
+      selection.statistics().uniqueCounts().value().size();
 
   folly::F14FastMap<physicalType, uint32_t> alphabetMapping;
   alphabetMapping.reserve(alphabetCount);

--- a/dwio/nimble/encodings/EncodingSelectionPolicy.h
+++ b/dwio/nimble/encodings/EncodingSelectionPolicy.h
@@ -323,7 +323,7 @@ struct EncodingPredictionModel {
     // TODO: Utilize more features within statistics for prediction.
     auto maxRepeat = statistics.maxRepeat();
     auto minRepeat = statistics.minRepeat();
-    auto unique = statistics.uniqueCounts().size();
+    auto unique = statistics.uniqueCounts().value().size();
     return maxRepeatParam * maxRepeat + minRepeatParam * minRepeat +
         uniqueParam * unique;
   }

--- a/dwio/nimble/encodings/MainlyConstantEncoding.h
+++ b/dwio/nimble/encodings/MainlyConstantEncoding.h
@@ -345,8 +345,8 @@ std::string_view MainlyConstantEncoding<T>::encode(
   }
 
   const auto commonElement = std::max_element(
-      selection.statistics().uniqueCounts().cbegin(),
-      selection.statistics().uniqueCounts().cend(),
+      selection.statistics().uniqueCounts().value().cbegin(),
+      selection.statistics().uniqueCounts().value().cend(),
       [](const auto& a, const auto& b) { return a.second < b.second; });
 
   const uint32_t entryCount = values.size();

--- a/dwio/nimble/encodings/SparseBoolEncoding.cpp
+++ b/dwio/nimble/encodings/SparseBoolEncoding.cpp
@@ -94,10 +94,11 @@ std::string_view SparseBoolEncoding::encode(
     std::span<const bool> values,
     Buffer& buffer) {
   // Decide the polarity of the encoding.
-  const uint32_t valueCount = values.size();
-  const uint32_t setCount = selection.statistics().uniqueCounts().at(true);
+  const uint64_t valueCount = values.size();
+  const uint64_t setCount =
+      selection.statistics().uniqueCounts().value().at(true);
   bool sparseValue;
-  uint32_t indexCount;
+  uint64_t indexCount;
   if (setCount > (valueCount >> 1)) {
     sparseValue = false;
     indexCount = valueCount - setCount;

--- a/dwio/nimble/encodings/Statistics.cpp
+++ b/dwio/nimble/encodings/Statistics.cpp
@@ -18,7 +18,6 @@
 
 #include <algorithm>
 #include <limits>
-#include <memory>
 #include <type_traits>
 
 namespace facebook::nimble {
@@ -128,7 +127,7 @@ void Statistics<T, InputType>::populateUniques() const {
       ++uniqueCounts[data_[i]];
     }
   }
-  uniqueCounts_.emplace(std::move(uniqueCounts));
+  uniqueCounts_.emplace(std::make_optional(std::move(uniqueCounts)));
 }
 
 template <typename T, typename InputType>
@@ -192,7 +191,8 @@ Statistics<T, InputType> Statistics<T, InputType>::create(
     statistics.max_ = T();
 
     statistics.bucketCounts_ = {};
-    statistics.uniqueCounts_ = {};
+    statistics.uniqueCounts_ = std::make_optional(
+        std::make_optional(UniqueValueCounts<T, InputType>()));
     return statistics;
   }
 

--- a/dwio/nimble/encodings/Statistics.h
+++ b/dwio/nimble/encodings/Statistics.h
@@ -16,7 +16,6 @@
 #pragma once
 
 #include <limits>
-#include <memory>
 #include <optional>
 #include <span>
 #include <type_traits>
@@ -179,7 +178,8 @@ class Statistics {
     return bucketCounts_.value();
   }
 
-  const UniqueValueCounts<T, InputType>& uniqueCounts() const noexcept {
+  const std::optional<UniqueValueCounts<T, InputType>>& uniqueCounts()
+      const noexcept {
     if (!uniqueCounts_.has_value()) {
       populateUniques();
     }
@@ -204,7 +204,8 @@ class Statistics {
   mutable std::optional<T> min_;
   mutable std::optional<T> max_;
   mutable std::optional<std::vector<uint64_t>> bucketCounts_;
-  mutable std::optional<UniqueValueCounts<T, InputType>> uniqueCounts_;
+  mutable std::optional<std::optional<UniqueValueCounts<T, InputType>>>
+      uniqueCounts_;
 };
 
 } // namespace facebook::nimble

--- a/dwio/nimble/encodings/tests/StatisticsTests.cpp
+++ b/dwio/nimble/encodings/tests/StatisticsTests.cpp
@@ -77,28 +77,28 @@ TYPED_TEST(StatisticsNumericTests, Create) {
   }
 
   auto statistics = T::create({data});
-  EXPECT_EQ(repeatSize, statistics.uniqueCounts().size());
+  EXPECT_EQ(repeatSize, statistics.uniqueCounts().value().size());
   EXPECT_EQ(minValue, statistics.min());
   EXPECT_EQ(minValue + repeatSize - 1, statistics.max());
   EXPECT_EQ(1, statistics.minRepeat());
   EXPECT_EQ(1, statistics.maxRepeat());
   EXPECT_EQ(dataSize, statistics.consecutiveRepeatCount());
 
-  for (const auto& pair : statistics.uniqueCounts()) {
+  for (const auto& pair : statistics.uniqueCounts().value()) {
     EXPECT_EQ(dataSize / repeatSize, pair.second);
   }
 
   // Repeating data (consecutive)
   std::sort(data.begin(), data.end());
   statistics = T::create({data});
-  EXPECT_EQ(repeatSize, statistics.uniqueCounts().size());
+  EXPECT_EQ(repeatSize, statistics.uniqueCounts().value().size());
   EXPECT_EQ(minValue, statistics.min());
   EXPECT_EQ(minValue + repeatSize - 1, statistics.max());
   EXPECT_EQ(dataSize / repeatSize, statistics.minRepeat());
   EXPECT_EQ(dataSize / repeatSize, statistics.maxRepeat());
   EXPECT_EQ(repeatSize, statistics.consecutiveRepeatCount());
 
-  for (const auto& pair : statistics.uniqueCounts()) {
+  for (const auto& pair : statistics.uniqueCounts().value()) {
     EXPECT_EQ(dataSize / repeatSize, pair.second);
   }
 
@@ -108,14 +108,14 @@ TYPED_TEST(StatisticsNumericTests, Create) {
   }
 
   statistics = T::create({data});
-  EXPECT_EQ(dataSize, statistics.uniqueCounts().size());
+  EXPECT_EQ(dataSize, statistics.uniqueCounts().value().size());
   EXPECT_EQ(minValue, statistics.min());
   EXPECT_EQ(minValue + dataSize - 1, statistics.max());
   EXPECT_EQ(1, statistics.minRepeat());
   EXPECT_EQ(1, statistics.maxRepeat());
   EXPECT_EQ(dataSize, statistics.consecutiveRepeatCount());
 
-  for (const auto& pair : statistics.uniqueCounts()) {
+  for (const auto& pair : statistics.uniqueCounts().value()) {
     EXPECT_EQ(1, pair.second);
   }
 
@@ -127,14 +127,14 @@ TYPED_TEST(StatisticsNumericTests, Create) {
         std::numeric_limits<ValueType>::lowest(),
         std::numeric_limits<ValueType>::max()};
     statistics = T::create({data});
-    EXPECT_EQ(4, statistics.uniqueCounts().size());
+    EXPECT_EQ(4, statistics.uniqueCounts().value().size());
     EXPECT_EQ(std::numeric_limits<ValueType>::lowest(), statistics.min());
     EXPECT_EQ(std::numeric_limits<ValueType>::max(), statistics.max());
     EXPECT_EQ(1, statistics.minRepeat());
     EXPECT_EQ(1, statistics.maxRepeat());
     EXPECT_EQ(4, statistics.consecutiveRepeatCount());
 
-    for (const auto& pair : statistics.uniqueCounts()) {
+    for (const auto& pair : statistics.uniqueCounts().value()) {
       EXPECT_EQ(1, pair.second);
     }
   } else {
@@ -143,14 +143,14 @@ TYPED_TEST(StatisticsNumericTests, Create) {
         1,
         std::numeric_limits<ValueType>::max()};
     statistics = T::create({data});
-    EXPECT_EQ(3, statistics.uniqueCounts().size());
+    EXPECT_EQ(3, statistics.uniqueCounts().value().size());
     EXPECT_EQ(std::numeric_limits<ValueType>::min(), statistics.min());
     EXPECT_EQ(std::numeric_limits<ValueType>::max(), statistics.max());
     EXPECT_EQ(1, statistics.minRepeat());
     EXPECT_EQ(1, statistics.maxRepeat());
     EXPECT_EQ(3, statistics.consecutiveRepeatCount());
 
-    for (const auto& pair : statistics.uniqueCounts()) {
+    for (const auto& pair : statistics.uniqueCounts().value()) {
       EXPECT_EQ(1, pair.second);
     }
   }
@@ -174,9 +174,10 @@ TYPED_TEST(StatisticsBoolTests, Create) {
   uint64_t expectedDistinctValuesCount = 0;
   expectedDistinctValuesCount += trueCount > 0 ? 1 : 0;
   expectedDistinctValuesCount += falseCount > 0 ? 1 : 0;
-  EXPECT_EQ(expectedDistinctValuesCount, statistics.uniqueCounts().size());
-  EXPECT_EQ(trueCount, statistics.uniqueCounts().at(true));
-  EXPECT_EQ(falseCount, statistics.uniqueCounts().at(false));
+  EXPECT_EQ(
+      expectedDistinctValuesCount, statistics.uniqueCounts().value().size());
+  EXPECT_EQ(trueCount, statistics.uniqueCounts().value().at(true));
+  EXPECT_EQ(falseCount, statistics.uniqueCounts().value().at(false));
   EXPECT_EQ(std::min(trueCount, falseCount), statistics.minRepeat());
   EXPECT_EQ(std::max(trueCount, falseCount), statistics.maxRepeat());
   EXPECT_EQ(2, statistics.consecutiveRepeatCount());
@@ -185,9 +186,10 @@ TYPED_TEST(StatisticsBoolTests, Create) {
 
   statistics =
       T::create(std::span<const bool>(data.get(), trueCount + falseCount));
-  EXPECT_EQ(expectedDistinctValuesCount, statistics.uniqueCounts().size());
-  EXPECT_EQ(trueCount, statistics.uniqueCounts().at(true));
-  EXPECT_EQ(falseCount, statistics.uniqueCounts().at(false));
+  EXPECT_EQ(
+      expectedDistinctValuesCount, statistics.uniqueCounts().value().size());
+  EXPECT_EQ(trueCount, statistics.uniqueCounts().value().at(true));
+  EXPECT_EQ(falseCount, statistics.uniqueCounts().value().at(false));
 }
 
 template <typename T>
@@ -213,7 +215,7 @@ void verifyString(
 
   T statistics = genStatisticsType(data);
 
-  EXPECT_EQ(uniqueStrings, statistics.uniqueCounts().size());
+  EXPECT_EQ(uniqueStrings, statistics.uniqueCounts().value().size());
   EXPECT_EQ(maxRepeat - uniqueStrings + 1, statistics.minRepeat());
   EXPECT_EQ(maxRepeat, statistics.maxRepeat());
   EXPECT_EQ(uniqueStrings, statistics.consecutiveRepeatCount());
@@ -224,9 +226,9 @@ void verifyString(
   EXPECT_EQ(std::string(1, 'a'), statistics.min());
 
   currentRepeat = maxRepeat;
-  for (auto i = 0; i < statistics.uniqueCounts().size(); ++i) {
+  for (auto i = 0; i < statistics.uniqueCounts().value().size(); ++i) {
     EXPECT_EQ(
-        statistics.uniqueCounts().at(std::string(i + 1, 'a' + i)),
+        statistics.uniqueCounts().value().at(std::string(i + 1, 'a' + i)),
         currentRepeat--);
   }
 
@@ -234,16 +236,16 @@ void verifyString(
 
   statistics = genStatisticsType(data);
 
-  EXPECT_EQ(uniqueStrings, statistics.uniqueCounts().size());
+  EXPECT_EQ(uniqueStrings, statistics.uniqueCounts().value().size());
   EXPECT_EQ(totalLength, statistics.totalStringsLength());
   EXPECT_EQ(
       std::string(uniqueStrings, 'a' + uniqueStrings - 1), statistics.max());
   EXPECT_EQ(std::string(1, 'a'), statistics.min());
 
-  currentRepeat = maxRepeat;
-  for (auto i = 0; i < statistics.uniqueCounts().size(); ++i) {
+  const auto uniqueCounts7 = statistics.uniqueCounts().value();
+  for (auto i = 0; i < statistics.uniqueCounts().value().size(); ++i) {
     EXPECT_EQ(
-        statistics.uniqueCounts().at(std::string(i + 1, 'a' + i)),
+        statistics.uniqueCounts().value().at(std::string(i + 1, 'a' + i)),
         currentRepeat--);
   }
 }
@@ -272,7 +274,7 @@ TYPED_TEST(StatisticsStringTests, Create) {
   T statistics =
       nimble::Statistics<std::string_view, std::string>::create(data);
 
-  EXPECT_EQ(uniqueStrings, statistics.uniqueCounts().size());
+  EXPECT_EQ(uniqueStrings, statistics.uniqueCounts().value().size());
   EXPECT_EQ(maxRepeat - uniqueStrings + 1, statistics.minRepeat());
   EXPECT_EQ(maxRepeat, statistics.maxRepeat());
   EXPECT_EQ(uniqueStrings, statistics.consecutiveRepeatCount());
@@ -283,9 +285,9 @@ TYPED_TEST(StatisticsStringTests, Create) {
   EXPECT_EQ(std::string(1, 'a'), statistics.min());
 
   currentRepeat = maxRepeat;
-  for (auto i = 0; i < statistics.uniqueCounts().size(); ++i) {
+  for (auto i = 0; i < statistics.uniqueCounts().value().size(); ++i) {
     EXPECT_EQ(
-        statistics.uniqueCounts().at(std::string(i + 1, 'a' + i)),
+        statistics.uniqueCounts().value().at(std::string(i + 1, 'a' + i)),
         currentRepeat--);
   }
 
@@ -294,16 +296,16 @@ TYPED_TEST(StatisticsStringTests, Create) {
   statistics =
       nimble::Statistics<std::string_view, std::string>::create({data});
 
-  EXPECT_EQ(uniqueStrings, statistics.uniqueCounts().size());
+  EXPECT_EQ(uniqueStrings, statistics.uniqueCounts().value().size());
   EXPECT_EQ(totalLength, statistics.totalStringsLength());
   EXPECT_EQ(
       std::string(uniqueStrings, 'a' + uniqueStrings - 1), statistics.max());
   EXPECT_EQ(std::string(1, 'a'), statistics.min());
 
   currentRepeat = maxRepeat;
-  for (auto i = 0; i < statistics.uniqueCounts().size(); ++i) {
+  for (auto i = 0; i < statistics.uniqueCounts().value().size(); ++i) {
     EXPECT_EQ(
-        statistics.uniqueCounts().at(std::string(i + 1, 'a' + i)),
+        statistics.uniqueCounts().value().at(std::string(i + 1, 'a' + i)),
         currentRepeat--);
   }
 }


### PR DESCRIPTION
Summary:
Prepare stats for optional Uniques by wrapping uniqueStats_ in additional std::optional. For now don't add any verification for missing uniques value in consumers assuming that for now it is going to always be present.

[Strobelight](https://fburl.com/scuba/strobelight_services/yoali6ap) shows that 93% of estimateSize is spent in estimateNumericSize. And this is where we will be putting a threshold next after collecting a bit of data.

Differential Revision: D85310781


