### PR TITLE
Introduce a flag that allows ignoring top level nulls in the writer

### DIFF
--- a/dwio/nimble/velox/FieldWriter.h
+++ b/dwio/nimble/velox/FieldWriter.h
@@ -134,6 +134,7 @@ struct FieldWriterContext {
   folly::F14FastSet<uint32_t> flatMapNodeIds;
   folly::F14FastSet<uint32_t> dictionaryArrayNodeIds;
   folly::F14FastSet<uint32_t> deduplicatedMapNodeIds;
+  bool ignoreTopLevelNulls{false};
 
   std::unique_ptr<InputBufferGrowthPolicy> inputBufferGrowthPolicy;
   InputBufferGrowthStats inputBufferGrowthStats;

--- a/dwio/nimble/velox/VeloxWriter.cpp
+++ b/dwio/nimble/velox/VeloxWriter.cpp
@@ -74,6 +74,7 @@ class WriterContext : public FieldWriterContext {
     if (!logger) {
       logger = std::make_shared<MetricsLogger>();
     }
+    ignoreTopLevelNulls = this->options.ignoreTopLevelNulls;
   }
 
   void nextStripe() {

--- a/dwio/nimble/velox/VeloxWriterOptions.h
+++ b/dwio/nimble/velox/VeloxWriterOptions.h
@@ -156,6 +156,9 @@ struct VeloxWriterOptions {
   // monitor usage of decoded vectors vs. data that is passed-through in the
   // writer. Default function is no-op since its used for tests only.
   std::function<void(void)> vectorDecoderVisitor = []() {};
+
+  // Whether writer should ignore the top level nulls in the input.
+  bool ignoreTopLevelNulls{false};
 };
 
 } // namespace facebook::nimble


### PR DESCRIPTION
Summary: Having top level nulls is not a valid use case in the context of data warehouse. Nimble writer accepts top level nulls and write them as is, which means downstream readers that tries to read from the file may encounter exceptions or produce wrong result. In contrast, DWRF writer ignores nulls and there still dependency that may produce vectors with top level nulls. Introduce flag that controls if nulls should be ignored for the root writer, so we can ensure a seamless migration.

Differential Revision: D86210058


