### PR TITLE
Fix traverseTablet in nimble_dump for empty files

### DIFF
--- a/dwio/nimble/tools/NimbleDumpLib.cpp
+++ b/dwio/nimble/tools/NimbleDumpLib.cpp
@@ -164,6 +164,10 @@ void traverseTablet(
         ChunkedStream& /*stream*/,
         uint32_t /*stripeId*/,
         uint32_t /* streamId*/)>& streamVisitor = nullptr) {
+  if (tabletReader.stripeCount() == 0) {
+    return;
+  }
+
   uint32_t startStripe = stripeIndex ? *stripeIndex : 0;
   uint32_t endStripe =
       stripeIndex ? *stripeIndex : tabletReader.stripeCount() - 1;


### PR DESCRIPTION
Summary:
traverseTablet fails when the file is empty / has no stripes.

```
[sdruzkin@devvm27220.prn0 ~/test]$ nd file_layout empty_file.nimble
Error: NimbleUserError
Error Source: USER
Error Code: INVALID_ARGUMENT
Error Message: Stripe is out of range.
Retryable: False
Location: getStripeIdentifier@fbcode/dwio/nimble/tablet/TabletReader.cpp:574
Expression: stripeIndex < stripeCount_
Stack Trace:
    @ 000000000505135f facebook::nimble::NimbleException::NimbleException(std::basic_string_view<char, std::char_traits<char> >, char const*, unsigned long, char const*, std::basic_string_view<char, std::char_traits<char> >, std::basic_string_view<char, std::char_traits<char> >, std::basic_string_view<char, std::char_traits<char> >, bool, facebook::velox::VeloxException::Type)
                       fbcode/dwio/nimble/common/Exceptions.h:108
    @ 00000000050601ac facebook::nimble::NimbleUserError::NimbleUserError(char const*, unsigned long, char const*, std::basic_string_view<char, std::char_traits<char> >, std::basic_string_view<char, std::char_traits<char> >, std::basic_string_view<char, std::char_traits<char> >, bool)
                       fbcode/dwio/nimble/common/Exceptions.h:280
    @ 00000000128ce4eb facebook::nimble::TabletReader::getStripeIdentifier(unsigned int) const
                       ./fbcode/dwio/nimble/tablet/TabletReader.cpp:574
    @ 0000000005059fdc std::_Function_handler<void (unsigned int), facebook::nimble::tools::NimbleDumpLib::emitFileLayout(bool)::$_0>::_M_invoke(std::_Any_data const&, unsigned int&&)
                       ./fbcode/dwio/nimble/tools/NimbleDumpLib.cpp:973
    @ 00000000050426f7 facebook::nimble::tools::(anonymous namespace)::traverseTablet(facebook::velox::memory::MemoryPool&, facebook::nimble::TabletReader const&, std::optional<int>, std::function<void (unsigned int)> const&, std::function<void (facebook::nimble::ChunkedStream&, unsigned int, unsigned int)> const&)
                       fbcode/third-party-buck/platform010/build/libgcc/include/c++/trunk/bits/std_function.h:584
    @ 0000000005058dca facebook::nimble::tools::NimbleDumpLib::emitFileLayout(bool)
                       ./fbcode/dwio/nimble/tools/NimbleDumpLib.cpp:972
    @ 000000000501c9ee std::_Function_handler<void (boost::program_options::variables_map const&, std::vector<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::allocator<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > > const&), main::$_1>::_M_invoke(std::_Any_data const&, boost::program_options::variables_map const&, std::vector<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::allocator<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > > const&)
                       ./fbcode/dwio/nimble/tools/NimbleDump.cpp:108
    @ 0000000012917ded folly::NestedCommandLineApp::doRun(std::vector<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::allocator<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > > const&)
                       fbcode/third-party-buck/platform010/build/libgcc/include/c++/trunk/bits/std_function.h:584
    @ 00000000129172d2 folly::NestedCommandLineApp::run(std::vector<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::allocator<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > > const&)
                       ./fbcode/folly/cli/NestedCommandLineApp.cpp:242
    @ 00000000129171af folly::NestedCommandLineApp::run(int, char const* const*)
                       ./fbcode/folly/cli/NestedCommandLineApp.cpp:236
    @ 000000000501981b main
                       ./fbcode/dwio/nimble/tools/NimbleDump.cpp:459
    @ 000000000002c656 __libc_start_call_main
                       /home/engshare/third-party2/glibc/2.34/src/glibc-2.34/csu/../sysdeps/nptl/libc_start_call_main.h:58
                       -> /home/engshare/third-party2/glibc/2.34/src/glibc-2.34/csu/../sysdeps/x86/libc-start.c
    @ 000000000002c717 __libc_start_main
                       /home/engshare/third-party2/glibc/2.34/src/glibc-2.34/csu/../csu/libc-start.c:409
                       -> /home/engshare/third-party2/glibc/2.34/src/glibc-2.34/csu/../sysdeps/x86/libc-start.c
    @ 000000000500c7e0 _start
                       /home/engshare/third-party2/glibc/2.34/src/glibc-2.34/csu/../sysdeps/x86_64/start.S:116
```

Differential Revision: D86345203


