### PR TITLE
Add GitHub Actions workflow to release source archive

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,57 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: Release
+
+on:
+  push:
+    tags:
+      - '**'
+
+permissions:
+  contents: write
+  discussions: write
+
+jobs:
+  source:
+    name: Source
+    runs-on: ubuntu-latest
+    steps:
+      - name: "Checkout"
+        uses: actions/checkout@v5
+
+      - name: "Archive"
+        run: |
+          git archive ${GITHUB_REF_NAME} \
+            --prefix nimble-${GITHUB_REF_NAME}/ \
+            --output nimble-${GITHUB_REF_NAME}.tar.gz
+          sha256sum \
+            nimble-${GITHUB_REF_NAME}.tar.gz > \
+            nimble-${GITHUB_REF_NAME}.tar.gz.sha256
+          sha512sum \
+            nimble-${GITHUB_REF_NAME}.tar.gz > \
+            nimble-${GITHUB_REF_NAME}.tar.gz.sha512
+
+      - name: "Create GitHub Release"
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          version=${GITHUB_REF_NAME}
+          gh release create ${GITHUB_REF_NAME} \
+            --discussion-category Announcements \
+            --generate-notes \
+            --repo ${GITHUB_REPOSITORY} \
+            --title "Nimble ${version}" \
+            --verify-tag \
+            nimble-${GITHUB_REF_NAME}.tar.gz*


### PR DESCRIPTION
Fix #307

This generates `nimble-${TAG}.tar.gz{,.sha256,sha512}` and uploads to GitHub Release.

Example: https://github.com/kou/nimble/releases/tag/0.1.0

This also creates a GitHub Discussion automatically.

Example: https://github.com/kou/nimble/discussions/1

This assumes that we use `${VERSION}` not `v${VERSION}` as tag name. I like no `v` prefix tag name (because `v` is meaningless and we need additional work to extract version from tag name) but I can change the implementation to assume `v${VERSION}` tag name.

`nimble-${TAG}.tar.gz` doesn't include `velox/` submodule because I'll remove `velox/` in #215.