### PR TITLE
Reserve only Required Capacity During Compaction

### DIFF
--- a/dwio/nimble/velox/StreamChunker.h
+++ b/dwio/nimble/velox/StreamChunker.h
@@ -34,7 +34,8 @@ uint64_t getNewBufferCapacity(
     uint64_t requiredCapacityCount) {
   const auto maxChunkElementCount = maxChunkSize / sizeof(T);
   if (currentCapacityCount < maxChunkElementCount) {
-    return currentCapacityCount;
+    return std::max<uint64_t>(
+        currentCapacityCount * 0.5, requiredCapacityCount);
   }
   NIMBLE_DCHECK_LE(
       requiredCapacityCount,

--- a/dwio/nimble/velox/tests/StreamChunkerTests.cpp
+++ b/dwio/nimble/velox/tests/StreamChunkerTests.cpp
@@ -122,15 +122,26 @@ class StreamChunkerTestsBase : public ::testing::Test {
 
 TEST_F(StreamChunkerTestsBase, getNewBufferCapacityTest) {
   // currentCapacityCount  < maxChunkElementCount
+  // currentCapacityCount * 0.5 < requiredCapacityCount
   uint64_t maxChunkElementCount = 8;
   uint64_t currentCapacityCount = 4;
-  const uint64_t requiredCapacityCount = 2;
+  uint64_t requiredCapacityCount = 3;
   EXPECT_EQ(
       detail::getNewBufferCapacity<int32_t>(
           /*maxChunkSize=*/maxChunkElementCount * sizeof(int32_t),
           /*currentCapacityCount=*/currentCapacityCount,
           /*requiredCapacityCount=*/requiredCapacityCount),
-      currentCapacityCount);
+      requiredCapacityCount);
+
+  // currentCapacityCount  < maxChunkElementCount
+  // currentCapacityCount * 0.5 > requiredCapacityCount
+  requiredCapacityCount = 1;
+  EXPECT_EQ(
+      detail::getNewBufferCapacity<int32_t>(
+          /*maxChunkSize=*/maxChunkElementCount * sizeof(int32_t),
+          /*currentCapacityCount=*/currentCapacityCount,
+          /*requiredCapacityCount=*/requiredCapacityCount),
+      currentCapacityCount * 0.5);
 
   currentCapacityCount = 40;
   // currentCapacityCount  > maxChunkElementCount = 8 + (40 - 8) * 0.5 = 24


### PR DESCRIPTION
Summary: When implementing the stream chunker, we anticipated that stream buffers after chunking will end up growing to the size that previously triggered chunking. As a tradeoff between minimizing reallocations (for performance) and actually releasing memory (to relieve memory pressure), we heuristically decided to set the new buffer size to be maxChunkSize_ plus 50% of the difference between the current buffer capacity and maxChunkSize_. The problem with this is that when a majority of streams before chunking are less than maxChunkSize_, we never get to relieve memory pressure. We will be reverting this decision for now to see what the actual performance implications would be in DISCO experiments. Local tests indicate significant memory improvements for certain files.

Differential Revision: D87022554


