### PR TITLE
Reduce add_library()

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -147,6 +147,16 @@ include_directories(SYSTEM velox/velox/external/xxhash)
 include_directories(SYSTEM ${CMAKE_BINARY_DIR}/_deps/xsimd-src/include/)
 
 add_subdirectory(velox)
+
+add_library(nimble)
+set_target_properties(nimble PROPERTIES POSITION_INDEPENDENT_CODE ON)
+add_library(nimble_test)
+target_link_libraries(
+  nimble_test
+  PUBLIC nimble gmock gtest
+  INTERFACE gtest_main Folly::folly
+)
+
 add_subdirectory(dwio/nimble/common)
 add_subdirectory(dwio/nimble/tablet)
 add_subdirectory(dwio/nimble/tools)

--- a/dwio/nimble/common/CMakeLists.txt
+++ b/dwio/nimble/common/CMakeLists.txt
@@ -13,16 +13,17 @@
 # limitations under the License.
 add_subdirectory(tests)
 
-add_library(
-  nimble_common
-  Bits.cpp
-  Checksum.cpp
-  Exceptions.cpp
-  FixedBitArray.cpp
-  MetricsLogger.cpp
-  NimbleException.cpp
-  Types.cpp
-  Varint.cpp
+target_sources(
+  nimble
+  PRIVATE
+    Bits.cpp
+    Checksum.cpp
+    Exceptions.cpp
+    FixedBitArray.cpp
+    MetricsLogger.cpp
+    NimbleException.cpp
+    Types.cpp
+    Varint.cpp
 )
 
-target_link_libraries(nimble_common velox_memory velox_exception Folly::folly)
+target_link_libraries(nimble PRIVATE velox_memory velox_exception Folly::folly)

--- a/dwio/nimble/common/tests/CMakeLists.txt
+++ b/dwio/nimble/common/tests/CMakeLists.txt
@@ -11,14 +11,9 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-add_library(nimble_common_file_writer NimbleFileWriter.cpp)
+target_sources(nimble_test PRIVATE NimbleFileWriter.cpp)
 
-target_link_libraries(
-  nimble_common_file_writer
-  nimble_common
-  nimble_velox_writer
-  velox_vector
-)
+target_link_libraries(nimble_test PUBLIC velox_vector)
 
 add_executable(
   nimble_common_tests
@@ -32,11 +27,4 @@ add_executable(
 
 add_test(nimble_common_tests nimble_common_tests)
 
-target_link_libraries(
-  nimble_common_tests
-  nimble_common
-  gtest
-  gtest_main
-  glog::glog
-  Folly::folly
-)
+target_link_libraries(nimble_common_tests PRIVATE nimble_test glog::glog)

--- a/dwio/nimble/encodings/CMakeLists.txt
+++ b/dwio/nimble/encodings/CMakeLists.txt
@@ -13,23 +13,22 @@
 # limitations under the License.
 add_subdirectory(tests)
 
-add_library(
-  nimble_encodings
-  Compression.cpp
-  Encoding.cpp
-  EncodingFactory.cpp
-  EncodingLayout.cpp
-  EncodingLayoutCapture.cpp
-  RleEncoding.cpp
-  SparseBoolEncoding.cpp
-  Statistics.cpp
-  TrivialEncoding.cpp
-  ZstdCompressor.cpp
+target_sources(
+  nimble
+  PRIVATE
+    Compression.cpp
+    Encoding.cpp
+    EncodingFactory.cpp
+    EncodingLayout.cpp
+    EncodingLayoutCapture.cpp
+    RleEncoding.cpp
+    SparseBoolEncoding.cpp
+    Statistics.cpp
+    TrivialEncoding.cpp
+    ZstdCompressor.cpp
 )
 
 target_link_libraries(
-  nimble_encodings
-  Folly::folly
-  absl::flat_hash_map
-  protobuf::libprotobuf
+  nimble
+  PRIVATE Folly::folly absl::flat_hash_map protobuf::libprotobuf
 )

--- a/dwio/nimble/encodings/tests/CMakeLists.txt
+++ b/dwio/nimble/encodings/tests/CMakeLists.txt
@@ -11,8 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-add_library(nimble_encodings_tests_utils TestUtils.cpp)
-target_link_libraries(nimble_encodings_tests_utils nimble_encodings)
+target_sources(nimble_test PRIVATE TestUtils.cpp)
 
 add_executable(
   nimble_encodings_tests
@@ -29,13 +28,4 @@ add_executable(
 
 add_test(nimble_encodings_tests nimble_encodings_tests)
 
-target_link_libraries(
-  nimble_encodings_tests
-  nimble_encodings_tests_utils
-  nimble_encodings
-  nimble_common
-  nimble_tools_common
-  gtest
-  gtest_main
-  Folly::folly
-)
+target_link_libraries(nimble_encodings_tests nimble_test)

--- a/dwio/nimble/stats/CMakeLists.txt
+++ b/dwio/nimble/stats/CMakeLists.txt
@@ -11,12 +11,5 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-add_library(nimble_column_stats_utils ColumnStatsUtils.cpp)
-target_link_libraries(
-  nimble_column_stats_utils
-  nimble_velox_schema
-  nimble_velox_schema_builder
-  raw_size_utils
-  velox_dwio_common
-  velox_vector
-)
+target_sources(nimble PRIVATE ColumnStatsUtils.cpp)
+target_link_libraries(nimble PRIVATE velox_dwio_common velox_vector)

--- a/dwio/nimble/tablet/CMakeLists.txt
+++ b/dwio/nimble/tablet/CMakeLists.txt
@@ -29,11 +29,5 @@ target_include_directories(
 )
 add_dependencies(nimble_footer_fb nimble_footer_schema_fb)
 
-add_library(nimble_tablet_common Compression.cpp)
-target_link_libraries(nimble_tablet_common nimble_footer_fb Folly::folly)
-
-add_library(nimble_tablet_reader TabletReader.cpp)
-target_link_libraries(nimble_tablet_reader nimble_tablet_common)
-
-add_library(nimble_tablet_writer TabletWriter.cpp)
-target_link_libraries(nimble_tablet_writer nimble_tablet_common)
+target_sources(nimble PRIVATE Compression.cpp TabletReader.cpp TabletWriter.cpp)
+target_link_libraries(nimble PRIVATE nimble_footer_fb Folly::folly)

--- a/dwio/nimble/tablet/tests/CMakeLists.txt
+++ b/dwio/nimble/tablet/tests/CMakeLists.txt
@@ -11,20 +11,11 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-add_executable(nimble_tabletReader_tests TabletTests.cpp)
+add_executable(nimble_tablet_reader_tests TabletTests.cpp)
 
-add_test(nimble_tabletReader_tests nimble_tabletReader_tests)
+add_test(nimble_tablet_reader_tests nimble_tablet_reader_tests)
 
 target_link_libraries(
-  nimble_tabletReader_tests
-  nimble_tablet_reader
-  nimble_tablet_writer
-  nimble_common
-  velox_dwio_common
-  velox_memory
-  velox_file
-  gtest
-  gtest_main
-  glog::glog
-  Folly::folly
+  nimble_tablet_reader_tests
+  PRIVATE nimble_test velox_dwio_common velox_memory velox_file glog::glog
 )

--- a/dwio/nimble/tools/CMakeLists.txt
+++ b/dwio/nimble/tools/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -11,6 +11,4 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-add_library(nimble_tools_common EncodingUtilities.cpp)
-
-target_link_libraries(nimble_tools_common nimble_common)
+target_sources(nimble PRIVATE EncodingUtilities.cpp)

--- a/dwio/nimble/velox/CMakeLists.txt
+++ b/dwio/nimble/velox/CMakeLists.txt
@@ -11,61 +11,25 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-add_library(nimble_velox_common SchemaUtils.cpp)
-target_link_libraries(nimble_velox_common nimble_common velox_type)
 
-add_library(nimble_velox_schema SchemaTypes.cpp)
-target_link_libraries(nimble_velox_schema nimble_common Folly::folly)
-
-add_library(nimble_velox_schema_reader SchemaReader.cpp)
-target_link_libraries(
-  nimble_velox_schema_reader
-  nimble_velox_schema
-  nimble_common
-  Folly::folly
+target_sources(
+  nimble
+  PRIVATE
+    SchemaUtils.cpp
+    SchemaTypes.cpp
+    SchemaReader.cpp
+    SchemaBuilder.cpp
+    StreamData.cpp
+    FieldReader.cpp
+    LayoutPlanner.cpp
+    BufferGrowthPolicy.cpp
+    DeduplicationUtils.cpp
+    FieldWriter.cpp
 )
 
-add_library(nimble_velox_schema_builder SchemaBuilder.cpp)
 target_link_libraries(
-  nimble_velox_schema_builder
-  nimble_velox_schema_reader
-  nimble_velox_schema
-  nimble_common
-  Folly::folly
-)
-
-add_library(nimble_velox_stream_data StreamData.cpp)
-target_link_libraries(
-  nimble_velox_stream_data
-  nimble_velox_schema_builder
-  nimble_common
-)
-
-add_library(nimble_velox_field_reader FieldReader.cpp)
-target_link_libraries(
-  nimble_velox_field_reader
-  nimble_velox_schema_reader
-  nimble_common
-  Folly::folly
-  absl::flat_hash_map
-  protobuf::libprotobuf
-)
-
-add_library(nimble_velox_layout_planner LayoutPlanner.cpp)
-target_link_libraries(nimble_velox_layout_planner nimble_velox_schema_reader)
-
-add_library(
-  nimble_velox_field_writer
-  BufferGrowthPolicy.cpp
-  DeduplicationUtils.cpp
-  FieldWriter.cpp
-)
-target_link_libraries(
-  nimble_velox_field_writer
-  nimble_velox_schema
-  nimble_velox_stream_data
-  nimble_velox_schema_builder
-  Folly::folly
+  nimble
+  PRIVATE velox_type Folly::folly absl::flat_hash_map protobuf::libprotobuf
 )
 
 build_flatbuffers(
@@ -116,63 +80,27 @@ target_include_directories(
 )
 add_dependencies(nimble_velox_stats_fb nimble_velox_stats_schema_fb)
 
-add_library(nimble_velox_schema_serialization SchemaSerialization.cpp)
 target_link_libraries(
-  nimble_velox_schema_serialization
-  nimble_velox_schema_reader
-  nimble_velox_schema_builder
-  nimble_velox_schema_fb
+  nimble
+  PRIVATE nimble_velox_schema_fb nimble_velox_metadata_fb nimble_velox_stats_fb
 )
 
-add_library(
-  nimble_velox_reader
-  ChunkedStream.cpp
-  ChunkedStreamDecoder.cpp
-  StreamLabels.cpp
-  VeloxReader.cpp
-)
-target_link_libraries(
-  nimble_velox_reader
-  nimble_velox_schema
-  nimble_velox_schema_serialization
-  nimble_velox_schema_fb
-  nimble_velox_metadata_fb
-  nimble_velox_field_reader
-  nimble_tablet_reader
-  nimble_common
-  Folly::folly
-)
-
-add_library(raw_size_utils RawSizeUtils.cpp DecodedVectorManager.cpp)
-target_link_libraries(
-  raw_size_utils
-  nimble_common
-  velox_vector
-  velox_dwio_common
-)
-
-add_library(
-  nimble_velox_writer
-  EncodingLayoutTree.cpp
-  FlushPolicy.cpp
-  VeloxWriter.cpp
-  ChunkedStreamWriter.cpp
-  VeloxWriterDefaultMetadataOSS.cpp
-  StreamChunker.cpp
-)
-target_link_libraries(
-  nimble_velox_writer
-  nimble_encodings
-  nimble_common
-  nimble_column_stats_utils
-  nimble_tablet_writer
-  nimble_velox_field_writer
-  nimble_velox_layout_planner
-  nimble_velox_metadata_fb
-  nimble_velox_stats_fb
-  raw_size_utils
-  velox_dwio_common
-  Folly::folly
+target_sources(
+  nimble
+  PRIVATE
+    ChunkedStream.cpp
+    ChunkedStreamDecoder.cpp
+    SchemaSerialization.cpp
+    StreamLabels.cpp
+    VeloxReader.cpp
+    RawSizeUtils.cpp
+    DecodedVectorManager.cpp
+    EncodingLayoutTree.cpp
+    FlushPolicy.cpp
+    VeloxWriter.cpp
+    ChunkedStreamWriter.cpp
+    VeloxWriterDefaultMetadataOSS.cpp
+    StreamChunker.cpp
 )
 
 add_subdirectory(selective)

--- a/dwio/nimble/velox/selective/CMakeLists.txt
+++ b/dwio/nimble/velox/selective/CMakeLists.txt
@@ -11,27 +11,22 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-add_library(
-  nimble_velox_selective
-  ChunkedDecoder.cpp
-  ColumnReader.cpp
-  FlatMapColumnReader.cpp
-  IntegerColumnReader.cpp
-  NimbleData.cpp
-  ReaderBase.cpp
-  RowSizeTracker.cpp
-  SelectiveNimbleReader.cpp
-  SelectiveNimbleReaderInitHookOSS.cpp
-  StringColumnReader.cpp
-  StructColumnReader.cpp
-  StructColumnReader.cpp
-  VariableLengthColumnReader.cpp
-)
-target_link_libraries(
-  nimble_velox_selective
-  nimble_velox_reader
-  nimble_velox_writer
-  nimble_velox_common
+target_sources(
+  nimble
+  PRIVATE
+    ChunkedDecoder.cpp
+    ColumnReader.cpp
+    FlatMapColumnReader.cpp
+    IntegerColumnReader.cpp
+    NimbleData.cpp
+    ReaderBase.cpp
+    RowSizeTracker.cpp
+    SelectiveNimbleReader.cpp
+    SelectiveNimbleReaderInitHookOSS.cpp
+    StringColumnReader.cpp
+    StructColumnReader.cpp
+    StructColumnReader.cpp
+    VariableLengthColumnReader.cpp
 )
 
 add_subdirectory(tests)

--- a/dwio/nimble/velox/selective/tests/CMakeLists.txt
+++ b/dwio/nimble/velox/selective/tests/CMakeLists.txt
@@ -25,14 +25,12 @@ add_test(nimble_velox_selective_tests nimble_velox_selective_tests)
 
 target_link_libraries(
   nimble_velox_selective_tests
-  nimble_velox_selective
-  nimble_common_file_writer
-  velox_vector_test_lib
-  # See also the above VELOX_BUILD_TEST_UTILS=ON comment.
-  #
-  # velox_dwio_common_test_utils
-  gmock
-  gtest
-  gtest_main
-  Folly::folly
+  PRIVATE
+    nimble_test
+    velox_vector_test_lib
+    # See also the above VELOX_BUILD_TEST_UTILS=ON comment.
+    #
+    # velox_dwio_common_test_utils
+    gmock
+    gtest_main
 )

--- a/dwio/nimble/velox/tests/CMakeLists.txt
+++ b/dwio/nimble/velox/tests/CMakeLists.txt
@@ -11,15 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-add_library(nimble_velox_schema_utils SchemaUtils.cpp)
-target_link_libraries(
-  nimble_velox_schema_utils
-  nimble_velox_schema_fb
-  nimble_velox_schema_builder
-  nimble_velox_schema_reader
-  gtest
-  gtest_main
-)
+target_sources(nimble_test PRIVATE SchemaUtils.cpp)
 
 add_executable(
   nimble_velox_tests
@@ -37,25 +29,7 @@ add_test(nimble_velox_tests nimble_velox_tests)
 
 target_link_libraries(
   nimble_velox_tests
-  nimble_velox_common
-  nimble_velox_schema_utils
-  nimble_velox_reader
-  nimble_velox_writer
-  nimble_velox_layout_planner
-  nimble_velox_stats_fb
-  nimble_common_file_writer
-  nimble_common
-  nimble_encodings
-  nimble_encodings_tests_utils
-  velox_vector
-  velox_vector_fuzzer
-  velox_vector_test_lib
-  gmock
-  gtest
-  gtest_main
-  Folly::folly
-  raw_size_utils
-  nimble_column_stats_utils
+  PRIVATE nimble_test velox_vector velox_vector_fuzzer velox_vector_test_lib
 )
 
 add_executable(raw_size_tests RawSizeTests.cpp)
@@ -63,19 +37,9 @@ add_test(raw_size_tests raw_size_tests)
 
 target_link_libraries(
   raw_size_tests
-  raw_size_utils
-  velox_vector
-  velox_vector_test_lib
-  gtest
-  gtest_main
-  Folly::folly
+  PRIVATE nimble_test velox_vector velox_vector_test_lib
 )
 
 add_executable(raw_size_benchmark RawSizeBenchmark.cpp)
 
-target_link_libraries(
-  raw_size_benchmark
-  raw_size_utils
-  Folly::folly
-  Folly::follybenchmark
-)
+target_link_libraries(raw_size_benchmark PRIVATE nimble Folly::follybenchmark)


### PR DESCRIPTION
Fix #298

Reduce `add_library()`s to the following 2 `add_library()`s:

```cmake
add_library(nimble)
add_library(nimble_test)
```

`nimble` is for Nimble features. `nimble_test` is for test.

All non test files are sources of `nimble`.

`nimble_test` depends on `nimble` and test related dependencies such as `gtest_main`. Each test links to `nimble_test`. Each test doesn't need to link to `gtest_main` and so on.

This PR doesn't install `nimble`. I'll work on it in a separated PR.