### PR TITLE
Relax constraint on the number of vector fields in the struct writer

### DIFF
--- a/dwio/nimble/velox/FieldWriter.cpp
+++ b/dwio/nimble/velox/FieldWriter.cpp
@@ -397,7 +397,7 @@ class RowFieldWriter : public FieldWriter {
     uint64_t nullCount = 0;
 
     if (row) {
-      NIMBLE_CHECK_EQ(
+      NIMBLE_CHECK_LE(
           fields_.size(),
           row->childrenSize(),
           "Schema mismatch: expected {} fields, but got {} fields",
@@ -420,7 +420,7 @@ class RowFieldWriter : public FieldWriter {
       auto& decoded = decodingContext.decode(vector, ranges);
       row = decoded.base()->as<velox::RowVector>();
       NIMBLE_CHECK_NOT_NULL(row, "Unexpected vector type");
-      NIMBLE_CHECK_EQ(
+      NIMBLE_CHECK_LE(
           fields_.size(),
           row->childrenSize(),
           "Schema mismatch: expected {} fields, but got {} fields",


### PR DESCRIPTION
Summary: Relax RowVector field count constraint in the RowFieldWriter to allow writing RowVectors that have more fields (schema growth in FBETL) than the row type. The extra fields will be ignored by the writer.

Differential Revision: D87359972


