### PR TITLE
Add writer support for FlatMapVector

### DIFF
--- a/dwio/nimble/velox/FieldWriter.h
+++ b/dwio/nimble/velox/FieldWriter.h
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 #pragma once
 
 #include "dwio/nimble/common/Buffer.h"


### PR DESCRIPTION
Summary:
Enable nimble to write flat map vector if the target storage encoding
is flat map.

Reviewed By: zzhao0

Differential Revision: D80812487


