### PR TITLE
Fix CQS signal facebook-unused-include-check in fbcode/dwio/nimble

### DIFF
--- a/dwio/nimble/tablet/TabletWriter.cpp
+++ b/dwio/nimble/tablet/TabletWriter.cpp
@@ -16,7 +16,6 @@
 
 #include "dwio/nimble/tablet/TabletWriter.h"
 
-#include "dwio/nimble/common/Buffer.h"
 #include "dwio/nimble/tablet/Compression.h"
 #include "dwio/nimble/tablet/Constants.h"
 


### PR DESCRIPTION
Reviewed By: sdruzkin

Differential Revision: D87423152


