### PR TITLE
fix: Chance previous CHECK back to DCHECK

### DIFF
--- a/dwio/nimble/encodings/RleEncoding.h
+++ b/dwio/nimble/encodings/RleEncoding.h
@@ -300,7 +300,7 @@ vector_size_t RLEEncoding<T>::findNumInRun(
       std::min<vector_size_t>(this->copiesRemaining_, numRows - rowIndex);
   auto endOfRun = currentRow + this->copiesRemaining_;
   auto* it = std::lower_bound(begin, end, endOfRun);
-  NIMBLE_DCHECK(it >= begin);
+  NIMBLE_DCHECK(it > begin);
   return it - begin;
 }
 

--- a/dwio/nimble/tablet/TabletReader.cpp
+++ b/dwio/nimble/tablet/TabletReader.cpp
@@ -648,7 +648,7 @@ std::shared_ptr<StripeGroup> TabletReader::stripeGroup(
 
 std::span<const uint32_t> TabletReader::streamOffsets(
     const StripeIdentifier& stripe) const {
-  NIMBLE_CHECK_LT(stripe.stripeId(), stripeCount_, "Stripe is out of range.");
+  NIMBLE_DCHECK_LT(stripe.stripeId(), stripeCount_, "Stripe is out of range.");
   return stripe.stripeGroup()->streamOffsets(stripe.stripeId());
 }
 


### PR DESCRIPTION
Summary: change a few previously marked DCHECK before D86277634 back to DCHECK. This helps unblock S593756

Differential Revision: D87573410


