### PR TITLE
(fix): Correctly Update Nulls Capactity for Nullable Content Stream Data Without Nulls

### DIFF
--- a/dwio/nimble/velox/StreamChunker.h
+++ b/dwio/nimble/velox/StreamChunker.h
@@ -219,7 +219,7 @@ class ContentStreamChunker final : public StreamChunker {
     // Move and clear existing buffer
     auto tempData = std::move(currentData);
     streamData_->reset();
-    NIMBLE_CHECK(
+    NIMBLE_DCHECK(
         streamData_->empty(), "StreamData should be empty after reset");
 
     auto& mutableData = streamData_->mutableData();
@@ -241,6 +241,13 @@ class ContentStreamChunker final : public StreamChunker {
         mutableData.begin());
     dataElementOffset_ = 0;
     streamData_->extraMemory() = extraMemory_;
+
+    // Ensure nulls capacity for nullable content streams without nulls.
+    if (auto* nullableContentStreamData =
+            dynamic_cast<NullableContentStreamData<T>*>(streamData_)) {
+      nullableContentStreamData->ensureAdditionalNullsCapacity(
+          /*mayHaveNulls=*/false, static_cast<uint32_t>(remainingDataCount));
+    }
   }
 
   StreamDataT* const streamData_;


### PR DESCRIPTION
Summary: There are separate chunkers for `NullableContentStreamData` and  `ContentStreamData` streams. However, when a `NullableContentStreamData` stream does not have nulls, [it is treated](https://fburl.com/code/zrsw0dyl) as a `ContentStreamData` stream.  This serves as an optimization when returning `StreamDataView`s since non-nulls will not be materialized or copied. However, there are failures in Vader caused by this code path because in `ContentStreamData` we fail to reserve the needed capacity for null entries.  This diff fixes that.

Differential Revision: D87683568


