### PR TITLE
refactor: Rename velox casting utilities to camelCase convention

### DIFF
--- a/dwio/nimble/velox/tests/VeloxReaderTests.cpp
+++ b/dwio/nimble/velox/tests/VeloxReaderTests.cpp
@@ -3963,7 +3963,7 @@ class TestNimbleReaderFactory {
       const nimble::VeloxWriterOptions& writerOptions = {})
       : file_{std::make_unique<velox::InMemoryReadFile>(
             nimble::test::createNimbleFile(rootPool, vectors, writerOptions))},
-        type_{velox::checked_pointer_cast<const velox::RowType>(
+        type_{velox::checkedPointerCast<const velox::RowType>(
             vectors[0]->type())},
         pool_{&leafPool} {}
 


### PR DESCRIPTION
Summary:
Renamed three function templates in velox's casting utilities to follow the camelCase naming convention:
- `checked_pointer_cast` → `checkedPointerCast`
- `static_unique_pointer_cast` → `staticUniquePointerCast`
- `is_instance_of` → `isInstanceOf`

This change affects the function definitions in `/data/users/ericjjj/fbsource/fbcode/velox/common/Casts.h` and all call sites within the velox codebase and related projects that use velox namespaced functions.

Files updated:
- Function definitions in `velox/common/Casts.h`
- Velox core files: `core/PlanNode.cpp`, `exec/Exchange.cpp`, `exec/Task.cpp`, `common/memory/MemoryPool.cpp`, `tool/trace/TopNRowNumberReplayer.cpp`
- Test file: `velox/common/testutil/tests/CastsTest.cpp` - updated all test cases
- DataInfra/Sequence files that use `facebook::velox::` namespace prefix (8 files)

This refactoring improves consistency with velox's naming conventions while maintaining backward compatibility with external codebases that use their own implementations.

Differential Revision: D87806227


