### PR TITLE
refactor: Move the metadata object definitions into common place to share with reader/writer/index

### DIFF
--- a/dwio/nimble/tablet/CMakeLists.txt
+++ b/dwio/nimble/tablet/CMakeLists.txt
@@ -29,7 +29,7 @@ target_include_directories(
 )
 add_dependencies(nimble_footer_fb nimble_footer_schema_fb)
 
-add_library(nimble_tablet_common Compression.cpp)
+add_library(nimble_tablet_common Compression.cpp, MetadataBuffer.cpp)
 target_link_libraries(nimble_tablet_common nimble_footer_fb Folly::folly)
 
 add_library(nimble_tablet_reader TabletReader.cpp)

--- a/dwio/nimble/tablet/MetadataBuffer.cpp
+++ b/dwio/nimble/tablet/MetadataBuffer.cpp
@@ -1,0 +1,94 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "dwio/nimble/tablet/MetadataBuffer.h"
+#include "dwio/nimble/tablet/Compression.h"
+#include "folly/io/Cursor.h"
+
+namespace facebook::nimble {
+
+namespace {
+
+folly::IOBuf
+cloneAndCoalesce(const folly::IOBuf& src, size_t offset, size_t size) {
+  folly::io::Cursor cursor(&src);
+  NIMBLE_CHECK_GE(cursor.totalLength(), offset, "Offset out of range");
+  cursor.skip(offset);
+  NIMBLE_CHECK_GE(cursor.totalLength(), size, "Size out of range");
+  folly::IOBuf result;
+  cursor.clone(result, size);
+  result.coalesceWithHeadroomTailroom(0, 0);
+  return result;
+}
+
+std::string_view toStringView(const folly::IOBuf& buf) {
+  return {reinterpret_cast<const char*>(buf.data()), buf.length()};
+}
+
+} // namespace
+
+MetadataBuffer::MetadataBuffer(
+    velox::memory::MemoryPool& pool,
+    std::string_view ref,
+    CompressionType type)
+    : buffer_{&pool} {
+  switch (type) {
+    case CompressionType::Uncompressed: {
+      buffer_.resize(ref.size());
+      std::copy(ref.cbegin(), ref.cend(), buffer_.begin());
+      break;
+    }
+    case CompressionType::Zstd: {
+      buffer_ = ZstdCompression::uncompress(pool, ref);
+      break;
+    }
+    default:
+      NIMBLE_UNREACHABLE("Unexpected stream compression type: {}", type);
+  }
+}
+
+MetadataBuffer::MetadataBuffer(
+    velox::memory::MemoryPool& pool,
+    const folly::IOBuf& iobuf,
+    size_t offset,
+    size_t length,
+    CompressionType type)
+    : buffer_{&pool} {
+  switch (type) {
+    case CompressionType::Uncompressed: {
+      buffer_.resize(length);
+      folly::io::Cursor cursor(&iobuf);
+      cursor.skip(offset);
+      cursor.pull(buffer_.data(), length);
+      break;
+    }
+    case CompressionType::Zstd: {
+      auto compressed = cloneAndCoalesce(iobuf, offset, length);
+      buffer_ = ZstdCompression::uncompress(pool, toStringView(compressed));
+      break;
+    }
+    default:
+      NIMBLE_UNREACHABLE("Unexpected stream compression type: {}", type);
+  }
+}
+
+MetadataBuffer::MetadataBuffer(
+    velox::memory::MemoryPool& pool,
+    const folly::IOBuf& iobuf,
+    CompressionType type)
+    : MetadataBuffer{pool, iobuf, 0, iobuf.computeChainDataLength(), type} {}
+
+} // namespace facebook::nimble

--- a/dwio/nimble/tablet/MetadataBuffer.h
+++ b/dwio/nimble/tablet/MetadataBuffer.h
@@ -1,0 +1,96 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <string_view>
+#include "dwio/nimble/common/Types.h"
+#include "dwio/nimble/common/Vector.h"
+#include "folly/io/IOBuf.h"
+
+namespace facebook::nimble {
+
+class MetadataBuffer {
+ public:
+  MetadataBuffer(
+      velox::memory::MemoryPool& pool,
+      std::string_view ref,
+      CompressionType type = CompressionType::Uncompressed);
+
+  MetadataBuffer(
+      velox::memory::MemoryPool& pool,
+      const folly::IOBuf& iobuf,
+      size_t offset,
+      size_t length,
+      CompressionType type = CompressionType::Uncompressed);
+
+  MetadataBuffer(
+      velox::memory::MemoryPool& pool,
+      const folly::IOBuf& iobuf,
+      CompressionType type = CompressionType::Uncompressed);
+
+  std::string_view content() const {
+    return {buffer_.data(), buffer_.size()};
+  }
+
+ private:
+  Vector<char> buffer_;
+};
+
+class Section {
+ public:
+  explicit Section(MetadataBuffer&& buffer) : buffer_{std::move(buffer)} {}
+
+  std::string_view content() const {
+    return buffer_.content();
+  }
+  explicit operator std::string_view() const {
+    return content();
+  }
+
+ private:
+  MetadataBuffer buffer_;
+};
+
+class MetadataSection {
+ public:
+  MetadataSection(
+      uint64_t offset,
+      uint32_t size,
+      CompressionType compressionType)
+      : offset_{offset}, size_{size}, compressionType_{compressionType} {}
+
+  MetadataSection()
+      : offset_{0}, size_{0}, compressionType_{CompressionType::Uncompressed} {}
+
+  uint64_t offset() const {
+    return offset_;
+  }
+
+  uint32_t size() const {
+    return size_;
+  }
+
+  CompressionType compressionType() const {
+    return compressionType_;
+  }
+
+ private:
+  uint64_t offset_;
+  uint32_t size_;
+  CompressionType compressionType_;
+};
+
+} // namespace facebook::nimble

--- a/dwio/nimble/tablet/TabletWriter.h
+++ b/dwio/nimble/tablet/TabletWriter.h
@@ -20,6 +20,7 @@
 #include "dwio/nimble/common/Checksum.h"
 #include "dwio/nimble/common/Vector.h"
 #include "dwio/nimble/tablet/FooterGenerated.h"
+#include "dwio/nimble/tablet/MetadataBuffer.h"
 #include "velox/common/file/File.h"
 #include "velox/common/memory/Memory.h"
 #include "velox/vector/TypeAliases.h"
@@ -93,12 +94,6 @@ class TabletWriter {
       velox::WriteFile* file,
       velox::memory::MemoryPool& pool,
       Options options);
-
-  struct MetadataSection {
-    uint64_t offset{0};
-    uint32_t size{0};
-    CompressionType compressionType{CompressionType::Uncompressed};
-  };
 
   // Write metadata entry to file
   CompressionType writeMetadata(std::string_view metadata);

--- a/dwio/nimble/tablet/tests/CMakeLists.txt
+++ b/dwio/nimble/tablet/tests/CMakeLists.txt
@@ -11,7 +11,8 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-add_executable(nimble_tabletReader_tests TabletTests.cpp)
+add_executable(
+  nimble_tabletReader_tests TabletTest.cpp MetadataBufferTest.cpp)
 
 add_test(nimble_tabletReader_tests nimble_tabletReader_tests)
 

--- a/dwio/nimble/tablet/tests/MetadataBufferTest.cpp
+++ b/dwio/nimble/tablet/tests/MetadataBufferTest.cpp
@@ -1,0 +1,241 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "dwio/nimble/tablet/MetadataBuffer.h"
+#include <gtest/gtest.h>
+#include "dwio/nimble/tablet/Compression.h"
+#include "folly/io/IOBuf.h"
+#include "velox/common/memory/Memory.h"
+
+using namespace ::facebook;
+
+namespace {
+
+class MetadataBufferTest : public ::testing::Test {
+ protected:
+  static void SetUpTestCase() {
+    velox::memory::MemoryManager::initialize({});
+  }
+
+  void SetUp() override {}
+
+  std::shared_ptr<velox::memory::MemoryPool> rootPool_{
+      velox::memory::memoryManager()->addRootPool("MetadataBufferTest")};
+  std::shared_ptr<velox::memory::MemoryPool> pool_{
+      rootPool_->addLeafChild("MetadataBufferTest")};
+};
+
+// Test data for various test cases
+const std::string kTestData = "Hello, MetadataBuffer!";
+const std::string kLargeTestData = std::string(1000, 'A');
+
+TEST_F(MetadataBufferTest, uncompressedStringView) {
+  nimble::MetadataBuffer buffer(
+      *pool_, kTestData, nimble::CompressionType::Uncompressed);
+
+  auto content = buffer.content();
+  EXPECT_EQ(content, kTestData);
+  EXPECT_EQ(content.size(), kTestData.size());
+}
+
+TEST_F(MetadataBufferTest, uncompressedEmptyStringView) {
+  nimble::MetadataBuffer buffer(
+      *pool_, "", nimble::CompressionType::Uncompressed);
+
+  auto content = buffer.content();
+  EXPECT_TRUE(content.empty());
+  EXPECT_EQ(content.size(), 0);
+}
+
+TEST_F(MetadataBufferTest, zstdCompressedStringView) {
+  // First compress the data
+  auto compressed = nimble::ZstdCompression::compress(*pool_, kLargeTestData);
+  ASSERT_TRUE(compressed.has_value());
+
+  std::string_view compressedView{compressed->data(), compressed->size()};
+
+  // Create buffer from compressed data
+  nimble::MetadataBuffer buffer(
+      *pool_, compressedView, nimble::CompressionType::Zstd);
+
+  auto content = buffer.content();
+  EXPECT_EQ(content, kLargeTestData);
+  EXPECT_EQ(content.size(), kLargeTestData.size());
+}
+
+TEST_F(MetadataBufferTest, uncompressedIOBufFullRange) {
+  folly::IOBuf iobuf{folly::IOBuf::COPY_BUFFER, kTestData};
+
+  nimble::MetadataBuffer buffer(
+      *pool_, iobuf, nimble::CompressionType::Uncompressed);
+
+  auto content = buffer.content();
+  EXPECT_EQ(content, kTestData);
+  EXPECT_EQ(content.size(), kTestData.size());
+}
+
+TEST_F(MetadataBufferTest, uncompressedIOBufWithOffsetAndLength) {
+  std::string data = "PrefixHello, MetadataBuffer!Suffix";
+  folly::IOBuf iobuf{folly::IOBuf::COPY_BUFFER, data};
+
+  size_t offset = 6; // Skip "Prefix"
+  size_t length = kTestData.size();
+
+  nimble::MetadataBuffer buffer(
+      *pool_, iobuf, offset, length, nimble::CompressionType::Uncompressed);
+
+  auto content = buffer.content();
+  EXPECT_EQ(content, kTestData);
+  EXPECT_EQ(content.size(), kTestData.size());
+}
+
+TEST_F(MetadataBufferTest, zstdCompressedIOBuf) {
+  // First compress the data
+  auto compressed = nimble::ZstdCompression::compress(*pool_, kLargeTestData);
+  ASSERT_TRUE(compressed.has_value());
+
+  folly::IOBuf iobuf{
+      folly::IOBuf::COPY_BUFFER, compressed->data(), compressed->size()};
+
+  nimble::MetadataBuffer buffer(*pool_, iobuf, nimble::CompressionType::Zstd);
+
+  auto content = buffer.content();
+  EXPECT_EQ(content, kLargeTestData);
+}
+
+TEST_F(MetadataBufferTest, zstdCompressedIOBufWithOffsetAndLength) {
+  // First compress the data
+  auto compressed = nimble::ZstdCompression::compress(*pool_, kLargeTestData);
+  ASSERT_TRUE(compressed.has_value());
+
+  // Add prefix and suffix
+  std::string prefix = "PREFIX";
+  std::string suffix = "SUFFIX";
+  std::string fullData =
+      prefix + std::string(compressed->data(), compressed->size()) + suffix;
+
+  folly::IOBuf iobuf{folly::IOBuf::COPY_BUFFER, fullData};
+
+  nimble::MetadataBuffer buffer(
+      *pool_,
+      iobuf,
+      prefix.size(),
+      compressed->size(),
+      nimble::CompressionType::Zstd);
+
+  auto content = buffer.content();
+  EXPECT_EQ(content, kLargeTestData);
+}
+
+TEST_F(MetadataBufferTest, chainedIOBuf) {
+  // Create a chained IOBuf
+  auto iobuf = folly::IOBuf::create(10);
+  iobuf->append(5);
+  std::memcpy(iobuf->writableData(), "Hello", 5);
+
+  auto next = folly::IOBuf::create(10);
+  next->append(7);
+  std::memcpy(next->writableData(), ", World", 7);
+
+  iobuf->appendToChain(std::move(next));
+
+  nimble::MetadataBuffer buffer(
+      *pool_, *iobuf, nimble::CompressionType::Uncompressed);
+
+  auto content = buffer.content();
+  EXPECT_EQ(content, "Hello, World");
+}
+
+TEST_F(MetadataBufferTest, sectionConstruction) {
+  nimble::MetadataBuffer buffer(
+      *pool_, kTestData, nimble::CompressionType::Uncompressed);
+
+  nimble::Section section{std::move(buffer)};
+
+  auto content = section.content();
+  EXPECT_EQ(content, kTestData);
+}
+
+TEST_F(MetadataBufferTest, sectionStringViewConversion) {
+  nimble::MetadataBuffer buffer(
+      *pool_, kTestData, nimble::CompressionType::Uncompressed);
+
+  nimble::Section section{std::move(buffer)};
+
+  std::string_view content = static_cast<std::string_view>(section);
+  EXPECT_EQ(content, kTestData);
+}
+
+TEST_F(MetadataBufferTest, metadataSectionConstructor) {
+  uint64_t offset = 100;
+  uint32_t size = 200;
+  nimble::CompressionType type = nimble::CompressionType::Zstd;
+
+  nimble::MetadataSection section{offset, size, type};
+
+  EXPECT_EQ(section.offset(), offset);
+  EXPECT_EQ(section.size(), size);
+  EXPECT_EQ(section.compressionType(), type);
+}
+
+TEST_F(MetadataBufferTest, metadataSectionDefaultConstructor) {
+  nimble::MetadataSection section;
+
+  EXPECT_EQ(section.offset(), 0);
+  EXPECT_EQ(section.size(), 0);
+  EXPECT_EQ(section.compressionType(), nimble::CompressionType::Uncompressed);
+}
+
+TEST_F(MetadataBufferTest, metadataSectionAccessors) {
+  uint64_t offset = 12345;
+  uint32_t size = 67890;
+  nimble::CompressionType type = nimble::CompressionType::Zstd;
+
+  nimble::MetadataSection section{offset, size, type};
+
+  EXPECT_EQ(section.offset(), offset);
+  EXPECT_EQ(section.size(), size);
+  EXPECT_EQ(section.compressionType(), type);
+}
+
+TEST_F(MetadataBufferTest, largeDataUncompressed) {
+  std::string largeData(10000, 'X');
+
+  nimble::MetadataBuffer buffer(
+      *pool_, largeData, nimble::CompressionType::Uncompressed);
+
+  auto content = buffer.content();
+  EXPECT_EQ(content.size(), largeData.size());
+  EXPECT_EQ(content, largeData);
+}
+
+TEST_F(MetadataBufferTest, largeDataCompressed) {
+  std::string largeData(10000, 'Y');
+
+  // Compress the data
+  auto compressed = nimble::ZstdCompression::compress(*pool_, largeData);
+  ASSERT_TRUE(compressed.has_value());
+
+  std::string_view compressedView{compressed->data(), compressed->size()};
+
+  // Create buffer from compressed data
+  nimble::MetadataBuffer buffer(
+      *pool_, compressedView, nimble::CompressionType::Zstd);
+
+  auto content = buffer.content();
+  EXPECT_EQ(content, largeData);
+}
+} // namespace


### PR DESCRIPTION
Summary: Refactored MetadataBuffer by moving it from tablet to common directory, and add more unit tests

Differential Revision: D87964917
