### PR TITLE
Fix Broken Reader Test Build

### DIFF
--- a/dwio/nimble/velox/tests/VeloxReaderTests.cpp
+++ b/dwio/nimble/velox/tests/VeloxReaderTests.cpp
@@ -3963,7 +3963,7 @@ class TestNimbleReaderFactory {
       const nimble::VeloxWriterOptions& writerOptions = {})
       : file_{std::make_unique<velox::InMemoryReadFile>(
             nimble::test::createNimbleFile(rootPool, vectors, writerOptions))},
-        type_{velox::checked_pointer_cast<const velox::RowType>(
+        type_{velox::checkedPointerCast<const velox::RowType>(
             vectors[0]->type())},
         pool_{&leafPool} {}
 


### PR DESCRIPTION
Summary: Broken after Velox casting method was renamed in D87847685.

Differential Revision: D88279625


