### PR TITLE
Memory Utilization Optimizations

### DIFF
--- a/dwio/nimble/velox/VeloxWriter.cpp
+++ b/dwio/nimble/velox/VeloxWriter.cpp
@@ -1158,6 +1158,7 @@ bool VeloxWriter::evalauateFlushPolicy() {
       // Sort streams for chunking based on raw memory usage.
       // TODO(T240072104): Improve performance by bucketing the streams
       // by size (by most significant bit) instead of sorting them.
+      // Only sort streams above minChunkSize.
       streamIndices.resize(streams.size());
       std::iota(streamIndices.begin(), streamIndices.end(), 0);
       std::sort(

--- a/dwio/nimble/velox/VeloxWriterOptions.h
+++ b/dwio/nimble/velox/VeloxWriterOptions.h
@@ -86,7 +86,7 @@ struct VeloxWriterOptions {
   // TODO: This options should be removed and integrated into the
   // inputGrowthPolicyFactory option (e.g. allow the caller to set an
   // ExactGrowthPolicy, as defined here: dwio/nimble/velox/BufferGrowthPolicy.h)
-  bool lowMemoryMode = false;
+  bool lowMemoryMode{false};
 
   // If present, metadata sections above this threshold size will be compressed.
   std::optional<uint32_t> metadataCompressionThreshold;
@@ -94,23 +94,23 @@ struct VeloxWriterOptions {
   // When flushing data streams into chunks, streams with raw data size smaller
   // than this threshold will not be flushed.
   // Note: this threshold is ignored when it is time to flush a stripe.
-  uint64_t minStreamChunkRawSize = 1024;
+  uint64_t minStreamChunkRawSize{512 << 10};
 
   // When flushing data streams into chunks, streams with raw data size larger
   // than this threshold will be broken down into multiple smaller chunks. Each
   // chunk will be at most this size.
-  uint64_t maxStreamChunkRawSize = 20 << 20;
+  uint64_t maxStreamChunkRawSize{20 << 20};
 
   // Used in place of maxStreamChunkRawSize for tables with large schemas.
-  uint32_t wideSchemaMaxStreamChunkRawSize = 4 << 20;
+  uint32_t wideSchemaMaxStreamChunkRawSize{2 << 20};
 
   // When the number of schema nodes exceeds this threshold we use
   // wideSchemaMaxStreamChunkRawSize in place of maxStreamChunkRawSize.
-  size_t largeSchemaThreshold = 5000;
+  size_t largeSchemaThreshold{500};
 
   // Number of streams to try chunking between memory pressure evaluations.
   // Note: this is ignored when it is time to flush a stripe.
-  size_t chunkedStreamBatchSize = 1024;
+  size_t chunkedStreamBatchSize{1024};
 
   // The factory function that produces the root encoding selection policy.
   // Encoding selection policy is the way to balance the tradeoffs of
@@ -162,7 +162,7 @@ struct VeloxWriterOptions {
   folly::Executor::KeepAlive<> encodingExecutor;
   folly::Executor::KeepAlive<> writeExecutor;
 
-  bool enableChunking = false;
+  bool enableChunking{false};
 
   // This callback will be visited on access to getDecodedVector in order to
   // monitor usage of decoded vectors vs. data that is passed-through in the

--- a/dwio/nimble/velox/tests/StreamChunkerTests.cpp
+++ b/dwio/nimble/velox/tests/StreamChunkerTests.cpp
@@ -120,39 +120,6 @@ class StreamChunkerTestsBase : public ::testing::Test {
   std::unique_ptr<InputBufferGrowthPolicy> inputBufferGrowthPolicy_;
 };
 
-TEST_F(StreamChunkerTestsBase, getNewBufferCapacityTest) {
-  // currentCapacityCount  < maxChunkElementCount
-  // currentCapacityCount * 0.5 < requiredCapacityCount
-  uint64_t maxChunkElementCount = 8;
-  uint64_t currentCapacityCount = 4;
-  uint64_t requiredCapacityCount = 3;
-  EXPECT_EQ(
-      detail::getNewBufferCapacity<int32_t>(
-          /*maxChunkSize=*/maxChunkElementCount * sizeof(int32_t),
-          /*currentCapacityCount=*/currentCapacityCount,
-          /*requiredCapacityCount=*/requiredCapacityCount),
-      requiredCapacityCount);
-
-  // currentCapacityCount  < maxChunkElementCount
-  // currentCapacityCount * 0.5 > requiredCapacityCount
-  requiredCapacityCount = 1;
-  EXPECT_EQ(
-      detail::getNewBufferCapacity<int32_t>(
-          /*maxChunkSize=*/maxChunkElementCount * sizeof(int32_t),
-          /*currentCapacityCount=*/currentCapacityCount,
-          /*requiredCapacityCount=*/requiredCapacityCount),
-      currentCapacityCount * 0.5);
-
-  currentCapacityCount = 40;
-  // currentCapacityCount  > maxChunkElementCount = 8 + (40 - 8) * 0.5 = 24
-  EXPECT_EQ(
-      detail::getNewBufferCapacity<int32_t>(
-          /*maxChunkSize=*/maxChunkElementCount * sizeof(int32_t),
-          /*currentCapacityCount=*/currentCapacityCount,
-          /*requiredCapacityCount=*/requiredCapacityCount),
-      24);
-}
-
 TEST_F(StreamChunkerTestsBase, getStreamChunkerTest) {
   // Ensure a chunker can be created for all types.
 #define TEST_STREAM_CHUNKER_FOR_TYPE(scalarKind, T)                    \


### PR DESCRIPTION
Summary:
When implementing the stream chunker, we anticipated that stream buffers after chunking will end up growing to the size that previously triggered chunking. As a tradeoff between minimizing reallocations (for performance) and actually releasing memory (to relieve memory pressure), we heuristically determine the new buffer capacity for each stream to be larger that required. The issue with this optimization is that it conflicts with the rest of our memory tracking logic since we now have retained memory in the memory pool that is not accounted for. We now know through local testing that disabling this optimization leads to better memory pressure relief.

We performed local DISCO tests with and without this optimization:

Differential Revision: D88223045


