### PR TITLE
Stream Deduplication

### DIFF
--- a/dwio/nimble/tablet/TabletWriter.h
+++ b/dwio/nimble/tablet/TabletWriter.h
@@ -53,6 +53,7 @@ class TabletWriter {
     uint32_t metadataFlushThreshold{kMetadataFlushThreshold};
     uint32_t metadataCompressionThreshold{kMetadataCompressionThreshold};
     ChecksumType checksumType{ChecksumType::XXH3_64};
+    bool streamDeduplicationEnabled{false};
   };
 
   static std::unique_ptr<TabletWriter> create(
@@ -119,7 +120,7 @@ class TabletWriter {
 
   void writeWithChecksum(std::string_view data);
   void writeWithChecksum(const folly::IOBuf& buf);
-  void writeChunkWithChecksum(const Chunk& chunk);
+  void writeStreamWithChecksum(const Stream& stream);
 
   velox::WriteFile* const file_;
   velox::memory::MemoryPool* const pool_;


### PR DESCRIPTION
Summary:
Introducing stream level deduplication.

With this change, before writing streams to a stripe, we are identifying streams that are byte-identical and only write one copy of the stream to the file.
All other identical streams will store the same offset and size as the original stream.

To opt-in for this behavior, a new option was introduced: streamDeduplicationEnabled.

C++ reader was modified to identify if streams are duplicated and only load them once.
Selective reader seems to already handle this read deduplication.
Java was not modified. It is loading the same stream multiple times (which is not a regression over what we currently have).

Reviewed By: sdruzkin

Differential Revision: D88087515


