### PR TITLE
misc: Respect Linux cgroups restrictions when sizing thread pools

### DIFF
--- a/dwio/nimble/velox/FieldWriter.cpp
+++ b/dwio/nimble/velox/FieldWriter.cpp
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 #include "dwio/nimble/velox/FieldWriter.h"
+#include <folly/system/HardwareConcurrency.h>
 #include "dwio/nimble/common/Exceptions.h"
 #include "dwio/nimble/common/Types.h"
 #include "dwio/nimble/velox/DeduplicationUtils.h"
@@ -1809,7 +1810,7 @@ DecodingContextPool::DecodingContextPool(
     std::function<void(void)> vectorDecoderVisitor)
     : vectorDecoderVisitor_{std::move(vectorDecoderVisitor)} {
   NIMBLE_CHECK(vectorDecoderVisitor_, "vectorDecoderVisitor must be set");
-  pool_.reserve(std::thread::hardware_concurrency());
+  pool_.reserve(folly::hardware_concurrency());
 }
 
 void DecodingContextPool::addContext(

--- a/dwio/nimble/velox/tests/DecodingContextPoolTests.cpp
+++ b/dwio/nimble/velox/tests/DecodingContextPoolTests.cpp
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+#include <folly/system/HardwareConcurrency.h>
 #include <gtest/gtest.h>
 #include "dwio/nimble/common/Exceptions.h"
 #include "dwio/nimble/velox/FieldWriter.h"
@@ -60,7 +61,7 @@ TEST(DecodingContextPoolTest, FillPool) {
 }
 
 TEST(DecodingContextPoolTest, ParallelFillPool) {
-  auto parallelismFactor = std::thread::hardware_concurrency();
+  auto parallelismFactor = folly::hardware_concurrency();
   auto executor = folly::CPUThreadPoolExecutor{parallelismFactor};
 
   DecodingContextPool pool;

--- a/dwio/nimble/velox/tests/VeloxReaderTests.cpp
+++ b/dwio/nimble/velox/tests/VeloxReaderTests.cpp
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+#include <folly/system/HardwareConcurrency.h>
 #include <gtest/gtest.h>
 #include <cmath>
 #include <optional>
@@ -2431,7 +2432,7 @@ TEST_F(VeloxReaderTests, fuzzSimple) {
   auto batches = 20;
   std::mt19937 rng{seed};
 
-  for (auto parallelismFactor : {0U, 1U, std::thread::hardware_concurrency()}) {
+  for (auto parallelismFactor : {0U, 1U, folly::hardware_concurrency()}) {
     LOG(INFO) << "Parallelism Factor: " << parallelismFactor;
 
     // Executor needs to outlive writerOptions since the latter has a keepAlive
@@ -2535,7 +2536,7 @@ TEST_F(VeloxReaderTests, fuzzComplex) {
   // the former.
   std::shared_ptr<folly::CPUThreadPoolExecutor> executor;
 
-  for (auto parallelismFactor : {0U, 1U, std::thread::hardware_concurrency()}) {
+  for (auto parallelismFactor : {0U, 1U, folly::hardware_concurrency()}) {
     LOG(INFO) << "Parallelism Factor: " << parallelismFactor;
 
     nimble::VeloxWriterOptions writerOptions;

--- a/dwio/nimble/velox/tests/VeloxWriterTests.cpp
+++ b/dwio/nimble/velox/tests/VeloxWriterTests.cpp
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+#include <folly/system/HardwareConcurrency.h>
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
@@ -2210,7 +2211,7 @@ TEST_F(VeloxWriterTests, fuzzComplex) {
                                                     : folly::Random::rand32();
   LOG(INFO) << "seed: " << seed;
   std::mt19937 rng{seed};
-  for (auto parallelismFactor : {0U, 1U, std::thread::hardware_concurrency()}) {
+  for (auto parallelismFactor : {0U, 1U, folly::hardware_concurrency()}) {
     std::shared_ptr<folly::CPUThreadPoolExecutor> executor;
     nimble::VeloxWriterOptions writerOptions;
     writerOptions.enableChunking = true;


### PR DESCRIPTION
Summary:
This change replaces uses of std::thread::hardware_concurrency with
folly::hardware_concurrency the latter of which always respects
container restrictions while the former does not.  This ensures that
when running inside of a Linux container with restrictions on the
available processors, thread pools and other data structures will not
be over-provisioned.

Differential Revision: D87913690


