### PR TITLE
Support Passing Additional Parameters Through SerDe

### DIFF
--- a/dwio/nimble/common/Constants.h
+++ b/dwio/nimble/common/Constants.h
@@ -22,16 +22,26 @@ namespace facebook::nimble {
 
 /// Attempt to compress a data stream only if the data size is equal or greater
 /// than this threshold.
-constexpr uint32_t kMetaInternalMinCompressionSize = 40;
-constexpr uint32_t kZstdMinCompressionSize = 25;
+constexpr uint32_t kMetaInternalMinCompressionSize{40};
+constexpr uint32_t kZstdMinCompressionSize{25};
 
 /// Default options for the ChunkFlushPolicy.
 /// Threshold to trigger chunking to relieve memory pressure
-constexpr uint64_t kChunkingWriterMemoryHighThreshold = 400 << 20; // 400MB
+constexpr uint64_t kChunkingWriterMemoryHighThreshold{2ULL << 30}; // 2 GB
 /// Threshold below which chunking stops.
-constexpr uint64_t kChunkingWriterMemoryLowThreshold = 300 << 20; // 300MB
+constexpr uint64_t kChunkingWriterMemoryLowThreshold{1ULL << 30}; // 1 GB
 /// Target size for encoded stripes.
-constexpr uint64_t kChunkingWriterTargetStripeStorageSize = 100 << 20; // 100MB
+constexpr uint64_t kChunkingWriterTargetStripeStorageSize{100 << 20}; // 100MB
 /// Expected ratio of raw to encoded data.
-constexpr double kChunkingWriterEstimatedCompressionFactor = 3.7;
+constexpr double kChunkingWriterEstimatedCompressionFactor{3.7};
+/// When flushing data streams into chunks, streams with raw data size smaller
+/// than this threshold will not be flushed.
+/// Note: this threshold is ignored when it is time to flush a stripe.
+constexpr uint64_t kChunkingWriterMinChunkSize{512 << 10}; // 512KB
+/// When flushing data streams into chunks, streams with raw data size larger
+/// than this threshold will be broken down into multiple smaller chunks. Each
+/// chunk will be at most this size.
+constexpr uint64_t kChunkingWriterMaxChunkSize{20 << 20}; // 20MB
+/// Used in place of kChunkingWriterMaxChunkSize for tables with large schemas.
+constexpr uint64_t kChunkingWriterWideSchemaMaxChunkSize{2 << 20}; // 2MB
 } // namespace facebook::nimble

--- a/dwio/nimble/velox/VeloxWriterOptions.h
+++ b/dwio/nimble/velox/VeloxWriterOptions.h
@@ -102,7 +102,7 @@ struct VeloxWriterOptions {
   uint64_t maxStreamChunkRawSize{20 << 20};
 
   // Used in place of maxStreamChunkRawSize for tables with large schemas.
-  uint32_t wideSchemaMaxStreamChunkRawSize{2 << 20};
+  uint64_t wideSchemaMaxStreamChunkRawSize{2 << 20};
 
   // When the number of schema nodes exceeds this threshold we use
   // wideSchemaMaxStreamChunkRawSize in place of maxStreamChunkRawSize.


### PR DESCRIPTION
Summary: In the future we may want to experiment with enabling different min and max chunk sizes for different tables. This diff makes that possible by adding the follwing as acceptable SerDe parameters:

Differential Revision: D89508807


