### PR TITLE
Nimble Timestamp Type Support

### DIFF
--- a/dwio/nimble/tools/NimbleDumpLib.cpp
+++ b/dwio/nimble/tools/NimbleDumpLib.cpp
@@ -383,6 +383,14 @@ void NimbleDumpLib::emitSchema(bool collapseFlatMap) {
             folly::to<std::string>(type.asScalar().scalarDescriptor().offset());
         break;
       }
+      case Kind::TimestampMicroNano: {
+        auto& timestamp = type.asTimestampMicroNano();
+        offsets = "m:" +
+            folly::to<std::string>(timestamp.microsDescriptor().offset()) +
+            ",n:" +
+            folly::to<std::string>(timestamp.nanosDescriptor().offset());
+        break;
+      }
       case Kind::Array: {
         offsets =
             folly::to<std::string>(type.asArray().lengthsDescriptor().offset());

--- a/dwio/nimble/velox/EncodingLayoutTree.h
+++ b/dwio/nimble/velox/EncodingLayoutTree.h
@@ -30,6 +30,10 @@ class EncodingLayoutTree {
     struct Scalar {
       constexpr static StreamIdentifier ScalarStream = 0;
     };
+    struct TimestampMicroNano {
+      constexpr static StreamIdentifier MicrosStream = 0;
+      constexpr static StreamIdentifier NanosStream = 1;
+    };
     struct Array {
       constexpr static StreamIdentifier LengthsStream = 0;
     };

--- a/dwio/nimble/velox/LayoutPlanner.cpp
+++ b/dwio/nimble/velox/LayoutPlanner.cpp
@@ -28,6 +28,12 @@ void appendAllNestedStreams(
       childrenOffsets.push_back(type.asScalar().scalarDescriptor().offset());
       break;
     }
+    case Kind::TimestampMicroNano: {
+      auto& timestamp = type.asTimestampMicroNano();
+      childrenOffsets.push_back(timestamp.microsDescriptor().offset());
+      childrenOffsets.push_back(timestamp.nanosDescriptor().offset());
+      break;
+    }
     case Kind::Row: {
       auto& row = type.asRow();
       childrenOffsets.push_back(row.nullsDescriptor().offset());

--- a/dwio/nimble/velox/Schema.fbs
+++ b/dwio/nimble/velox/Schema.fbs
@@ -29,6 +29,7 @@ enum Kind:uint8 {
   Bool,
   String,
   Binary,
+  TimestampMicroNano,
   Row = 50,
   Array,
   Map,

--- a/dwio/nimble/velox/SchemaBuilder.h
+++ b/dwio/nimble/velox/SchemaBuilder.h
@@ -45,6 +45,7 @@ namespace facebook::nimble {
 
 class SchemaBuilder;
 class ScalarTypeBuilder;
+class TimestampMicroNanoTypeBuilder;
 class ArrayTypeBuilder;
 class MapTypeBuilder;
 class RowTypeBuilder;
@@ -99,6 +100,7 @@ class TypeBuilder {
   Kind kind() const;
 
   ScalarTypeBuilder& asScalar();
+  TimestampMicroNanoTypeBuilder& asTimestampMicroNano();
   ArrayTypeBuilder& asArray();
   MapTypeBuilder& asMap();
   SlidingWindowMapTypeBuilder& asSlidingWindowMap();
@@ -106,6 +108,7 @@ class TypeBuilder {
   FlatMapTypeBuilder& asFlatMap();
   ArrayWithOffsetsTypeBuilder& asArrayWithOffsets();
   const ScalarTypeBuilder& asScalar() const;
+  const TimestampMicroNanoTypeBuilder& asTimestampMicroNano() const;
   const ArrayTypeBuilder& asArray() const;
   const MapTypeBuilder& asMap() const;
   const SlidingWindowMapTypeBuilder& asSlidingWindowMap() const;
@@ -134,6 +137,20 @@ class ScalarTypeBuilder : public TypeBuilder {
   ScalarTypeBuilder(SchemaBuilder& schemaBuilder, ScalarKind scalarKind);
 
   StreamDescriptorBuilder scalarDescriptor_;
+
+  friend class SchemaBuilder;
+};
+
+class TimestampMicroNanoTypeBuilder : public TypeBuilder {
+ public:
+  const StreamDescriptorBuilder& microsDescriptor() const;
+  const StreamDescriptorBuilder& nanosDescriptor() const;
+
+ private:
+  explicit TimestampMicroNanoTypeBuilder(SchemaBuilder& schemaBuilder);
+
+  StreamDescriptorBuilder microsDescriptor_;
+  StreamDescriptorBuilder nanosDescriptor_;
 
   friend class SchemaBuilder;
 };
@@ -268,6 +285,11 @@ class SchemaBuilder {
   std::shared_ptr<ScalarTypeBuilder> createScalarTypeBuilder(
       ScalarKind scalarKind);
 
+  // Create a builder representing a timestamp with microsecond precision and
+  // optional nanosecond precision.
+  std::shared_ptr<TimestampMicroNanoTypeBuilder>
+  createTimestampMicroNanoTypeBuilder();
+
   // Create an array builder
   std::shared_ptr<ArrayTypeBuilder> createArrayTypeBuilder();
 
@@ -329,6 +351,7 @@ class SchemaBuilder {
   offset_size currentOffset_ = 0;
 
   friend class ScalarTypeBuilder;
+  friend class TimestampMicroNanoTypeBuilder;
   friend class LengthsTypeBuilder;
   friend class ArrayTypeBuilder;
   friend class ArrayWithOffsetsTypeBuilder;

--- a/dwio/nimble/velox/SchemaReader.h
+++ b/dwio/nimble/velox/SchemaReader.h
@@ -36,6 +36,7 @@
 namespace facebook::nimble {
 
 class ScalarType;
+class TimestampMicroNanoType;
 class RowType;
 class ArrayType;
 class ArrayWithOffsetsType;
@@ -48,6 +49,7 @@ class Type {
   Kind kind() const;
 
   bool isScalar() const;
+  bool isTimestampMicroNano() const;
   bool isRow() const;
   bool isArray() const;
   bool isArrayWithOffsets() const;
@@ -56,6 +58,7 @@ class Type {
   bool isSlidingWindowMap() const;
 
   const ScalarType& asScalar() const;
+  const TimestampMicroNanoType& asTimestampMicroNano() const;
   const RowType& asRow() const;
   const ArrayType& asArray() const;
   const ArrayWithOffsetsType& asArrayWithOffsets() const;
@@ -83,6 +86,20 @@ class ScalarType : public Type {
 
  private:
   StreamDescriptor scalarDescriptor_;
+};
+
+class TimestampMicroNanoType : public Type {
+ public:
+  explicit TimestampMicroNanoType(
+      StreamDescriptor microsDescriptor,
+      StreamDescriptor nanosDescriptor);
+
+  const StreamDescriptor& microsDescriptor() const;
+  const StreamDescriptor& nanosDescriptor() const;
+
+ private:
+  StreamDescriptor microsDescriptor_;
+  StreamDescriptor nanosDescriptor_;
 };
 
 class ArrayType : public Type {

--- a/dwio/nimble/velox/SchemaTypes.cpp
+++ b/dwio/nimble/velox/SchemaTypes.cpp
@@ -52,6 +52,7 @@ std::string toString(Kind kind) {
     return #KIND;    \
   }
     CASE(Scalar);
+    CASE(TimestampMicroNano);
     CASE(Row);
     CASE(Array);
     CASE(ArrayWithOffsets);

--- a/dwio/nimble/velox/SchemaTypes.h
+++ b/dwio/nimble/velox/SchemaTypes.h
@@ -44,6 +44,7 @@ enum class ScalarKind : uint8_t {
 
 enum class Kind : uint8_t {
   Scalar,
+  TimestampMicroNano,
   Row,
   Array,
   ArrayWithOffsets,

--- a/dwio/nimble/velox/VeloxWriter.cpp
+++ b/dwio/nimble/velox/VeloxWriter.cpp
@@ -484,6 +484,23 @@ void initializeEncodingLayouts(
               typeBuilder.asScalar(), scalarDescriptor, Scalar::ScalarStream);
           break;
         }
+        case Kind::TimestampMicroNano: {
+          NIMBLE_CHECK_EQ(
+              encodingLayoutTree.schemaKind(),
+              Kind::TimestampMicroNano,
+              "Incompatible encoding layout node. Expecting TimestampMicroNano node but got {}.",
+              toString(encodingLayoutTree.schemaKind()));
+          auto& timestampMicroNanoBuilder = typeBuilder.asTimestampMicroNano();
+          _SET_STREAM_CONTEXT(
+              timestampMicroNanoBuilder,
+              microsDescriptor,
+              TimestampMicroNano::MicrosStream);
+          _SET_STREAM_CONTEXT(
+              timestampMicroNanoBuilder,
+              nanosDescriptor,
+              TimestampMicroNano::NanosStream);
+          break;
+        }
         case Kind::Row: {
           NIMBLE_CHECK_EQ(
               encodingLayoutTree.schemaKind(),

--- a/dwio/nimble/velox/tests/SchemaTests.cpp
+++ b/dwio/nimble/velox/tests/SchemaTests.cpp
@@ -66,13 +66,14 @@ TEST(SchemaTests, SchemaUtils) {
           {"c14", OFFSETARRAY(INTEGER())},
           {"c15", SLIDINGWINDOWMAP(INTEGER(), INTEGER())},
           {"c16", ROW({{"d1", TINYINT()}, {"d2", ARRAY(TINYINT())}})},
+          {"c17", TIMESTAMPMICRONANO()},
       }));
 
   auto nodes = builder.getSchemaNodes();
   nimble::test::verifySchemaNodes(
       nodes,
       {
-          {nimble::Kind::Row, 27, nimble::ScalarKind::Bool, std::nullopt, 16},
+          {nimble::Kind::Row, 29, nimble::ScalarKind::Bool, std::nullopt, 17},
           {nimble::Kind::Scalar, 0, nimble::ScalarKind::Int8, "c1"},
           {nimble::Kind::Array, 2, nimble::ScalarKind::UInt32, "c2"},
           {nimble::Kind::Scalar, 1, nimble::ScalarKind::Int8},
@@ -106,12 +107,18 @@ TEST(SchemaTests, SchemaUtils) {
           {nimble::Kind::Scalar, 23, nimble::ScalarKind::Int8, "d1"},
           {nimble::Kind::Array, 25, nimble::ScalarKind::UInt32, "d2"},
           {nimble::Kind::Scalar, 24, nimble::ScalarKind::Int8},
+          {nimble::Kind::TimestampMicroNano,
+           27,
+           nimble::ScalarKind::Int64,
+           "c17"},
+          {nimble::Kind::Scalar, 28, nimble::ScalarKind::UInt16},
       });
 
-  verifyLabels(nodes, {"/",   "/0",  "/1",  "/1",   "/2",    "/3",    "/3",
-                       "/3",  "/4",  "/5",  "/6",   "/7",    "/8",    "/9",
-                       "/10", "/11", "/12", "/13",  "/13",   "/13",   "/14",
-                       "/14", "/14", "/14", "/15/", "/15/0", "/15/1", "/15/1"});
+  verifyLabels(
+      nodes, {"/",    "/0",    "/1",    "/1",    "/2",  "/3",  "/3",  "/3",
+              "/4",   "/5",    "/6",    "/7",    "/8",  "/9",  "/10", "/11",
+              "/12",  "/13",   "/13",   "/13",   "/14", "/14", "/14", "/14",
+              "/15/", "/15/0", "/15/1", "/15/1", "/16", "/16"});
 
   fm2.addChild("f1");
 
@@ -119,7 +126,7 @@ TEST(SchemaTests, SchemaUtils) {
   nimble::test::verifySchemaNodes(
       nodes,
       {
-          {nimble::Kind::Row, 27, nimble::ScalarKind::Bool, std::nullopt, 16},
+          {nimble::Kind::Row, 29, nimble::ScalarKind::Bool, std::nullopt, 17},
           {nimble::Kind::Scalar, 0, nimble::ScalarKind::Int8, "c1"},
           {nimble::Kind::Array, 2, nimble::ScalarKind::UInt32, "c2"},
           {nimble::Kind::Scalar, 1, nimble::ScalarKind::Int8},
@@ -128,9 +135,9 @@ TEST(SchemaTests, SchemaUtils) {
           {nimble::Kind::Scalar, 4, nimble::ScalarKind::Int8},
           {nimble::Kind::Scalar, 5, nimble::ScalarKind::Int8},
           {nimble::Kind::FlatMap, 7, nimble::ScalarKind::Float, "c5", 1},
-          {nimble::Kind::Scalar, 30, nimble::ScalarKind::Bool, "f1"},
-          {nimble::Kind::Array, 29, nimble::ScalarKind::UInt32},
-          {nimble::Kind::Scalar, 28, nimble::ScalarKind::Int64},
+          {nimble::Kind::Scalar, 32, nimble::ScalarKind::Bool, "f1"},
+          {nimble::Kind::Array, 31, nimble::ScalarKind::UInt32},
+          {nimble::Kind::Scalar, 30, nimble::ScalarKind::Int64},
           {nimble::Kind::Scalar, 8, nimble::ScalarKind::Int16, "c6"},
           {nimble::Kind::Scalar, 9, nimble::ScalarKind::Int32, "c7"},
           {nimble::Kind::Scalar, 10, nimble::ScalarKind::Int64, "c8"},
@@ -156,13 +163,19 @@ TEST(SchemaTests, SchemaUtils) {
           {nimble::Kind::Scalar, 23, nimble::ScalarKind::Int8, "d1"},
           {nimble::Kind::Array, 25, nimble::ScalarKind::UInt32, "d2"},
           {nimble::Kind::Scalar, 24, nimble::ScalarKind::Int8},
+          {nimble::Kind::TimestampMicroNano,
+           27,
+           nimble::ScalarKind::Int64,
+           "c17"},
+          {nimble::Kind::Scalar, 28, nimble::ScalarKind::UInt16},
       });
 
   verifyLabels(
-      nodes, {"/",   "/0",    "/1",    "/1",    "/2",    "/3",    "/3",   "/3",
-              "/4",  "/4/f1", "/4/f1", "/4/f1", "/5",    "/6",    "/7",   "/8",
-              "/9",  "/10",   "/11",   "/12",   "/13",   "/13",   "/13",  "/14",
-              "/14", "/14",   "/14",   "/15/",  "/15/0", "/15/1", "/15/1"});
+      nodes,
+      {"/",     "/0",    "/1",    "/1",    "/2",  "/3",  "/3",  "/3",  "/4",
+       "/4/f1", "/4/f1", "/4/f1", "/5",    "/6",  "/7",  "/8",  "/9",  "/10",
+       "/11",   "/12",   "/13",   "/13",   "/13", "/14", "/14", "/14", "/14",
+       "/15/",  "/15/0", "/15/1", "/15/1", "/16", "/16"});
 
   fm1.addChild("f1");
   fm1.addChild("f2");
@@ -173,28 +186,28 @@ TEST(SchemaTests, SchemaUtils) {
   nimble::test::verifySchemaNodes(
       nodes,
       {
-          {nimble::Kind::Row, 27, nimble::ScalarKind::Bool, std::nullopt, 16},
+          {nimble::Kind::Row, 29, nimble::ScalarKind::Bool, std::nullopt, 17},
           {nimble::Kind::Scalar, 0, nimble::ScalarKind::Int8, "c1"},
           {nimble::Kind::Array, 2, nimble::ScalarKind::UInt32, "c2"},
           {nimble::Kind::Scalar, 1, nimble::ScalarKind::Int8},
           {nimble::Kind::FlatMap, 3, nimble::ScalarKind::Int8, "c3", 2},
-          {nimble::Kind::Scalar, 32, nimble::ScalarKind::Bool, "f1"},
-          {nimble::Kind::Scalar, 31, nimble::ScalarKind::Int8},
-          {nimble::Kind::Scalar, 34, nimble::ScalarKind::Bool, "f2"},
+          {nimble::Kind::Scalar, 34, nimble::ScalarKind::Bool, "f1"},
           {nimble::Kind::Scalar, 33, nimble::ScalarKind::Int8},
+          {nimble::Kind::Scalar, 36, nimble::ScalarKind::Bool, "f2"},
+          {nimble::Kind::Scalar, 35, nimble::ScalarKind::Int8},
           {nimble::Kind::Map, 6, nimble::ScalarKind::UInt32, "c4"},
           {nimble::Kind::Scalar, 4, nimble::ScalarKind::Int8},
           {nimble::Kind::Scalar, 5, nimble::ScalarKind::Int8},
           {nimble::Kind::FlatMap, 7, nimble::ScalarKind::Float, "c5", 3},
-          {nimble::Kind::Scalar, 30, nimble::ScalarKind::Bool, "f1"},
-          {nimble::Kind::Array, 29, nimble::ScalarKind::UInt32},
-          {nimble::Kind::Scalar, 28, nimble::ScalarKind::Int64},
-          {nimble::Kind::Scalar, 37, nimble::ScalarKind::Bool, "f2"},
-          {nimble::Kind::Array, 36, nimble::ScalarKind::UInt32},
-          {nimble::Kind::Scalar, 35, nimble::ScalarKind::Int64},
-          {nimble::Kind::Scalar, 40, nimble::ScalarKind::Bool, "f3"},
-          {nimble::Kind::Array, 39, nimble::ScalarKind::UInt32},
-          {nimble::Kind::Scalar, 38, nimble::ScalarKind::Int64},
+          {nimble::Kind::Scalar, 32, nimble::ScalarKind::Bool, "f1"},
+          {nimble::Kind::Array, 31, nimble::ScalarKind::UInt32},
+          {nimble::Kind::Scalar, 30, nimble::ScalarKind::Int64},
+          {nimble::Kind::Scalar, 39, nimble::ScalarKind::Bool, "f2"},
+          {nimble::Kind::Array, 38, nimble::ScalarKind::UInt32},
+          {nimble::Kind::Scalar, 37, nimble::ScalarKind::Int64},
+          {nimble::Kind::Scalar, 42, nimble::ScalarKind::Bool, "f3"},
+          {nimble::Kind::Array, 41, nimble::ScalarKind::UInt32},
+          {nimble::Kind::Scalar, 40, nimble::ScalarKind::Int64},
           {nimble::Kind::Scalar, 8, nimble::ScalarKind::Int16, "c6"},
           {nimble::Kind::Scalar, 9, nimble::ScalarKind::Int32, "c7"},
           {nimble::Kind::Scalar, 10, nimble::ScalarKind::Int64, "c8"},
@@ -220,15 +233,21 @@ TEST(SchemaTests, SchemaUtils) {
           {nimble::Kind::Scalar, 23, nimble::ScalarKind::Int8, "d1"},
           {nimble::Kind::Array, 25, nimble::ScalarKind::UInt32, "d2"},
           {nimble::Kind::Scalar, 24, nimble::ScalarKind::Int8},
+          {nimble::Kind::TimestampMicroNano,
+           27,
+           nimble::ScalarKind::Int64,
+           "c17"},
+          {nimble::Kind::Scalar, 28, nimble::ScalarKind::UInt16},
       });
 
   verifyLabels(
-      nodes, {"/",     "/0",    "/1",    "/1",    "/2",    "/2/f1", "/2/f1",
-              "/2/f2", "/2/f2", "/3",    "/3",    "/3",    "/4",    "/4/f1",
-              "/4/f1", "/4/f1", "/4/f2", "/4/f2", "/4/f2", "/4/f3", "/4/f3",
-              "/4/f3", "/5",    "/6",    "/7",    "/8",    "/9",    "/10",
-              "/11",   "/12",   "/13",   "/13",   "/13",   "/14",   "/14",
-              "/14",   "/14",   "/15/",  "/15/0", "/15/1", "/15/1"});
+      nodes,
+      {"/",     "/0",    "/1",    "/1",    "/2",    "/2/f1", "/2/f1", "/2/f2",
+       "/2/f2", "/3",    "/3",    "/3",    "/4",    "/4/f1", "/4/f1", "/4/f1",
+       "/4/f2", "/4/f2", "/4/f2", "/4/f3", "/4/f3", "/4/f3", "/5",    "/6",
+       "/7",    "/8",    "/9",    "/10",   "/11",   "/12",   "/13",   "/13",
+       "/13",   "/14",   "/14",   "/14",   "/14",   "/15/",  "/15/0", "/15/1",
+       "/15/1", "/16",   "/16"});
 }
 
 TEST(SchemaTests, RoundTrip) {
@@ -245,8 +264,9 @@ TEST(SchemaTests, RoundTrip) {
   //     d1:TINYINT,
   //     d2:ARRAY<UINT>)
   //   )
+  //   c9:TIMESTAMPMICROS
 
-  auto row = builder.createRowTypeBuilder(8);
+  auto row = builder.createRowTypeBuilder(9);
   {
     auto scalar = builder.createScalarTypeBuilder(nimble::ScalarKind::Int32);
     row->addChild("c1", scalar);
@@ -300,11 +320,16 @@ TEST(SchemaTests, RoundTrip) {
     row->addChild("c8", row2);
   }
 
+  {
+    auto timestampMicroNano = builder.createTimestampMicroNanoTypeBuilder();
+    row->addChild("c9", timestampMicroNano);
+  }
+
   auto nodes = builder.getSchemaNodes();
   nimble::test::verifySchemaNodes(
       nodes,
       {
-          {nimble::Kind::Row, 0, nimble::ScalarKind::Bool, std::nullopt, 8},
+          {nimble::Kind::Row, 0, nimble::ScalarKind::Bool, std::nullopt, 9},
           {nimble::Kind::Scalar, 1, nimble::ScalarKind::Int32, "c1", 0},
           {nimble::Kind::FlatMap, 2, nimble::ScalarKind::Int8, "c2", 0},
           {nimble::Kind::Map, 3, nimble::ScalarKind::UInt32, "c3"},
@@ -331,29 +356,16 @@ TEST(SchemaTests, RoundTrip) {
           {nimble::Kind::Scalar, 16, nimble::ScalarKind::Int8, "d1"},
           {nimble::Kind::Array, 17, nimble::ScalarKind::UInt32, "d2"},
           {nimble::Kind::Scalar, 18, nimble::ScalarKind::UInt32},
+          {nimble::Kind::TimestampMicroNano,
+           19,
+           nimble::ScalarKind::Int64,
+           "c9"},
+          {nimble::Kind::Scalar, 20, nimble::ScalarKind::UInt16, std::nullopt},
       });
 
-  verifyLabels(
-      nodes,
-      {"/",
-       "/0",
-       "/1",
-       "/2",
-       "/2",
-       "/2",
-       "/3",
-       "/4",
-       "/5",
-       "/5",
-       "/5",
-       "/6",
-       "/6",
-       "/6",
-       "/6",
-       "/7/",
-       "/7/0",
-       "/7/1",
-       "/7/1"});
+  verifyLabels(nodes, {"/",  "/0",  "/1",   "/2",   "/2",   "/2", "/3",
+                       "/4", "/5",  "/5",   "/5",   "/6",   "/6", "/6",
+                       "/6", "/7/", "/7/0", "/7/1", "/7/1", "/8", "/8"});
 
   {
     auto array = builder.createArrayTypeBuilder();
@@ -379,21 +391,21 @@ TEST(SchemaTests, RoundTrip) {
   nimble::test::verifySchemaNodes(
       nodes,
       {
-          {nimble::Kind::Row, 0, nimble::ScalarKind::Bool, std::nullopt, 8},
+          {nimble::Kind::Row, 0, nimble::ScalarKind::Bool, std::nullopt, 9},
           {nimble::Kind::Scalar, 1, nimble::ScalarKind::Int32, "c1", 0},
           {nimble::Kind::FlatMap, 2, nimble::ScalarKind::Int8, "c2", 2},
-          {nimble::Kind::Scalar, 21, nimble::ScalarKind::Bool, "f1"},
-          {nimble::Kind::Array, 19, nimble::ScalarKind::UInt32},
-          {nimble::Kind::Scalar, 20, nimble::ScalarKind::Double},
-          {nimble::Kind::Scalar, 24, nimble::ScalarKind::Bool, "f2"},
-          {nimble::Kind::Array, 22, nimble::ScalarKind::UInt32},
-          {nimble::Kind::Scalar, 23, nimble::ScalarKind::Double},
+          {nimble::Kind::Scalar, 23, nimble::ScalarKind::Bool, "f1"},
+          {nimble::Kind::Array, 21, nimble::ScalarKind::UInt32},
+          {nimble::Kind::Scalar, 22, nimble::ScalarKind::Double},
+          {nimble::Kind::Scalar, 26, nimble::ScalarKind::Bool, "f2"},
+          {nimble::Kind::Array, 24, nimble::ScalarKind::UInt32},
+          {nimble::Kind::Scalar, 25, nimble::ScalarKind::Double},
           {nimble::Kind::Map, 3, nimble::ScalarKind::UInt32, "c3"},
           {nimble::Kind::Scalar, 4, nimble::ScalarKind::String},
           {nimble::Kind::Scalar, 5, nimble::ScalarKind::Float},
           {nimble::Kind::FlatMap, 6, nimble::ScalarKind::Int64, "c4", 1},
-          {nimble::Kind::Scalar, 26, nimble::ScalarKind::Bool, "f1"},
-          {nimble::Kind::Scalar, 25, nimble::ScalarKind::Int32},
+          {nimble::Kind::Scalar, 28, nimble::ScalarKind::Bool, "f1"},
+          {nimble::Kind::Scalar, 27, nimble::ScalarKind::Int32},
           {nimble::Kind::Scalar, 7, nimble::ScalarKind::Bool, "c5"},
           {nimble::Kind::ArrayWithOffsets, 9, nimble::ScalarKind::UInt32, "c6"},
           {nimble::Kind::Scalar, 8, nimble::ScalarKind::UInt32},
@@ -409,13 +421,18 @@ TEST(SchemaTests, RoundTrip) {
           {nimble::Kind::Scalar, 16, nimble::ScalarKind::Int8, "d1"},
           {nimble::Kind::Array, 17, nimble::ScalarKind::UInt32, "d2"},
           {nimble::Kind::Scalar, 18, nimble::ScalarKind::UInt32},
+          {nimble::Kind::TimestampMicroNano,
+           19,
+           nimble::ScalarKind::Int64,
+           "c9"},
+          {nimble::Kind::Scalar, 20, nimble::ScalarKind::UInt16, std::nullopt},
       });
 
-  verifyLabels(
-      nodes,
-      {"/",  "/0", "/1", "/1/f1", "/1/f1", "/1/f1", "/1/f2", "/1/f2", "/1/f2",
-       "/2", "/2", "/2", "/3",    "/3/f1", "/3/f1", "/4",    "/5",    "/5",
-       "/5", "/6", "/6", "/6",    "/6",    "/7/",   "/7/0",  "/7/1",  "/7/1"});
+  verifyLabels(nodes, {"/",     "/0",    "/1",    "/1/f1", "/1/f1", "/1/f1",
+                       "/1/f2", "/1/f2", "/1/f2", "/2",    "/2",    "/2",
+                       "/3",    "/3/f1", "/3/f1", "/4",    "/5",    "/5",
+                       "/5",    "/6",    "/6",    "/6",    "/6",    "/7/",
+                       "/7/0",  "/7/1",  "/7/1",  "/8",    "/8"});
 
   {
     auto array = builder.createArrayTypeBuilder();
@@ -434,26 +451,26 @@ TEST(SchemaTests, RoundTrip) {
   nimble::test::verifySchemaNodes(
       nodes,
       {
-          {nimble::Kind::Row, 0, nimble::ScalarKind::Bool, std::nullopt, 8},
+          {nimble::Kind::Row, 0, nimble::ScalarKind::Bool, std::nullopt, 9},
           {nimble::Kind::Scalar, 1, nimble::ScalarKind::Int32, "c1", 0},
           {nimble::Kind::FlatMap, 2, nimble::ScalarKind::Int8, "c2", 3},
-          {nimble::Kind::Scalar, 21, nimble::ScalarKind::Bool, "f1"},
-          {nimble::Kind::Array, 19, nimble::ScalarKind::UInt32},
-          {nimble::Kind::Scalar, 20, nimble::ScalarKind::Double},
-          {nimble::Kind::Scalar, 24, nimble::ScalarKind::Bool, "f2"},
-          {nimble::Kind::Array, 22, nimble::ScalarKind::UInt32},
-          {nimble::Kind::Scalar, 23, nimble::ScalarKind::Double},
-          {nimble::Kind::Scalar, 29, nimble::ScalarKind::Bool, "f3"},
-          {nimble::Kind::Array, 27, nimble::ScalarKind::UInt32},
-          {nimble::Kind::Scalar, 28, nimble::ScalarKind::Double},
+          {nimble::Kind::Scalar, 23, nimble::ScalarKind::Bool, "f1"},
+          {nimble::Kind::Array, 21, nimble::ScalarKind::UInt32},
+          {nimble::Kind::Scalar, 22, nimble::ScalarKind::Double},
+          {nimble::Kind::Scalar, 26, nimble::ScalarKind::Bool, "f2"},
+          {nimble::Kind::Array, 24, nimble::ScalarKind::UInt32},
+          {nimble::Kind::Scalar, 25, nimble::ScalarKind::Double},
+          {nimble::Kind::Scalar, 31, nimble::ScalarKind::Bool, "f3"},
+          {nimble::Kind::Array, 29, nimble::ScalarKind::UInt32},
+          {nimble::Kind::Scalar, 30, nimble::ScalarKind::Double},
           {nimble::Kind::Map, 3, nimble::ScalarKind::UInt32, "c3"},
           {nimble::Kind::Scalar, 4, nimble::ScalarKind::String},
           {nimble::Kind::Scalar, 5, nimble::ScalarKind::Float},
           {nimble::Kind::FlatMap, 6, nimble::ScalarKind::Int64, "c4", 2},
-          {nimble::Kind::Scalar, 26, nimble::ScalarKind::Bool, "f1"},
-          {nimble::Kind::Scalar, 25, nimble::ScalarKind::Int32},
-          {nimble::Kind::Scalar, 31, nimble::ScalarKind::Bool, "f2"},
-          {nimble::Kind::Scalar, 30, nimble::ScalarKind::Int32},
+          {nimble::Kind::Scalar, 28, nimble::ScalarKind::Bool, "f1"},
+          {nimble::Kind::Scalar, 27, nimble::ScalarKind::Int32},
+          {nimble::Kind::Scalar, 33, nimble::ScalarKind::Bool, "f2"},
+          {nimble::Kind::Scalar, 32, nimble::ScalarKind::Int32},
           {nimble::Kind::Scalar, 7, nimble::ScalarKind::Bool, "c5"},
           {nimble::Kind::ArrayWithOffsets, 9, nimble::ScalarKind::UInt32, "c6"},
           {nimble::Kind::Scalar, 8, nimble::ScalarKind::UInt32},
@@ -469,14 +486,19 @@ TEST(SchemaTests, RoundTrip) {
           {nimble::Kind::Scalar, 16, nimble::ScalarKind::Int8, "d1"},
           {nimble::Kind::Array, 17, nimble::ScalarKind::UInt32, "d2"},
           {nimble::Kind::Scalar, 18, nimble::ScalarKind::UInt32},
+          {nimble::Kind::TimestampMicroNano,
+           19,
+           nimble::ScalarKind::Int64,
+           "c9"},
+          {nimble::Kind::Scalar, 20, nimble::ScalarKind::UInt16, std::nullopt},
       });
 
   verifyLabels(
-      nodes,
-      {"/",     "/0",    "/1",    "/1/f1", "/1/f1", "/1/f1", "/1/f2", "/1/f2",
-       "/1/f2", "/1/f3", "/1/f3", "/1/f3", "/2",    "/2",    "/2",    "/3",
-       "/3/f1", "/3/f1", "/3/f2", "/3/f2", "/4",    "/5",    "/5",    "/5",
-       "/6",    "/6",    "/6",    "/6",    "/7/",   "/7/0",  "/7/1",  "/7/1"});
+      nodes, {"/",     "/0",    "/1",    "/1/f1", "/1/f1", "/1/f1", "/1/f2",
+              "/1/f2", "/1/f2", "/1/f3", "/1/f3", "/1/f3", "/2",    "/2",
+              "/2",    "/3",    "/3/f1", "/3/f1", "/3/f2", "/3/f2", "/4",
+              "/5",    "/5",    "/5",    "/6",    "/6",    "/6",    "/6",
+              "/7/",   "/7/0",  "/7/1",  "/7/1",  "/8",    "/8"});
 
   auto result = nimble::SchemaReader::getSchema(nodes);
   nimble::test::compareSchema(nodes, result);

--- a/dwio/nimble/velox/tests/SchemaUtils.cpp
+++ b/dwio/nimble/velox/tests/SchemaUtils.cpp
@@ -54,6 +54,19 @@ void compareSchema(
       EXPECT_EQ(0, node.childrenCount());
       break;
     }
+    case nimble::Kind::TimestampMicroNano: {
+      auto& timestamp = type->asTimestampMicroNano();
+      EXPECT_EQ(timestamp.microsDescriptor().offset(), node.offset());
+      EXPECT_EQ(nimble::ScalarKind::Int64, node.scalarKind());
+      EXPECT_EQ(0, node.childrenCount());
+
+      const auto& nanosNode = nodes[index++];
+      EXPECT_FALSE(nanosNode.name().has_value());
+      EXPECT_EQ(Kind::Scalar, nanosNode.kind());
+      EXPECT_EQ(ScalarKind::UInt16, nanosNode.scalarKind());
+      EXPECT_EQ(timestamp.nanosDescriptor().offset(), nanosNode.offset());
+      break;
+    }
     case nimble::Kind::Row: {
       auto& row = type->asRow();
       EXPECT_EQ(row.nullsDescriptor().offset(), node.offset());

--- a/dwio/nimble/velox/tests/SchemaUtils.h
+++ b/dwio/nimble/velox/tests/SchemaUtils.h
@@ -110,6 +110,7 @@ void schema(
 #define BOOLEAN() builder.createScalarTypeBuilder(nimble::ScalarKind::Bool)
 #define STRING() builder.createScalarTypeBuilder(nimble::ScalarKind::String)
 #define BINARY() builder.createScalarTypeBuilder(nimble::ScalarKind::Binary)
+#define TIMESTAMPMICRONANO() builder.createTimestampMicroNanoTypeBuilder()
 #define ARRAY(elements) facebook::nimble::test::array(builder, elements)
 #define OFFSETARRAY(elements) \
   facebook::nimble::test::arrayWithOffsets(builder, elements)


### PR DESCRIPTION
Summary:
Add Nimble schema type support for TimestampMicroNano.

Adding this type requires updates to all dependent switch cases on this schema type. Therefore many files need to be update alongside this change to prevent build failures.

Reviewed By: sdruzkin

Differential Revision: D87830650


