### PR TITLE
Add cluster index utilities

### DIFF
--- a/dwio/nimble/index/CMakeLists.txt
+++ b/dwio/nimble/index/CMakeLists.txt
@@ -13,11 +13,12 @@
 # limitations under the License.
 add_subdirectory(tests)
 
-add_library(nimble_index KeyEncoder.cpp)
+add_library(nimble_index KeyEncoder.cpp StripeIndexGroup.cpp)
 target_link_libraries(
   nimble_index
   nimble_common
   nimble_encodings
+  nimble_tablet_common
   velox_core
   velox_type
   velox_vector

--- a/dwio/nimble/index/StripeIndexGroup.h
+++ b/dwio/nimble/index/StripeIndexGroup.h
@@ -1,0 +1,124 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <cstdint>
+#include <memory>
+#include <optional>
+#include <string_view>
+
+#include "dwio/nimble/common/Exceptions.h"
+#include "velox/common/file/Region.h"
+
+namespace facebook::nimble {
+
+class MetadataBuffer;
+class StripeGroup;
+
+/// Represents the location of a chunk within a stream.
+/// Both offsets are relative:
+/// - streamOffset: relative to the stream start offset within the stripe
+/// - rowOffset: relative to the stripe start row id
+struct ChunkLocation {
+  uint32_t streamOffset;
+  uint32_t rowOffset;
+
+  ChunkLocation(uint32_t _streamOffset, uint32_t _rowOffset)
+      : streamOffset(_streamOffset), rowOffset(_rowOffset) {}
+};
+
+class StreamIndex;
+
+class StripeIndexGroup {
+ public:
+  static std::shared_ptr<StripeIndexGroup> create(
+      uint32_t stripeGroupIndex,
+      const MetadataBuffer& rootIndex,
+      std::unique_ptr<MetadataBuffer> groupIndex);
+
+  /// Lookup chunk by stripe and encoded key.
+  /// The lookup is performed on the key stream which is stored in the
+  /// StripeIndexGroup metadata.
+  /// Returns chunk location, or std::nullopt if not found.
+  std::optional<ChunkLocation> lookupChunk(
+      uint32_t stripe,
+      std::string_view encodedKey) const;
+
+  /// Lookup chunk by stripe, stream ID, and row ID.
+  /// Returns chunk location, or std::nullopt if not found.
+  std::optional<ChunkLocation>
+  lookupChunk(uint32_t stripe, uint32_t streamId, uint32_t rowId) const;
+
+  /// Creates a StreamIndex for the specified stripe and stream ID.
+  std::unique_ptr<StreamIndex> createStreamIndex(
+      uint32_t stripe,
+      uint32_t streamId) const;
+
+  /// Returns the region for the key stream of the specified stripe.
+  /// The key stream is stored in the StripeIndexGroup metadata.
+  /// Returns std::nullopt if the stripe has no key stream.
+  std::optional<velox::common::Region> keyStreamRegion(
+      uint32_t stripeIndex) const;
+
+ private:
+  StripeIndexGroup(
+      uint32_t groupIndex,
+      uint32_t firstStripe,
+      std::unique_ptr<MetadataBuffer> metadata);
+
+  inline uint32_t stripeOffset(uint32_t stripe) const {
+    NIMBLE_CHECK_GE(
+        stripe, firstStripe_, "Stripe index is before this group's range");
+    const uint32_t offset = stripe - firstStripe_;
+    NIMBLE_CHECK_LT(
+        offset,
+        stripeCount_,
+        "Stripe offset is out of range for this stripe index group");
+    return offset;
+  }
+
+  const std::unique_ptr<MetadataBuffer> metadata_;
+  const uint32_t groupIndex_;
+  const uint32_t firstStripe_;
+  const uint32_t stripeCount_;
+  const uint32_t streamCount_;
+};
+
+/// StreamIndex is a convenience wrapper around StripeIndexGroup for rowId-based
+/// chunk location lookup on a specific stream.
+class StreamIndex {
+ public:
+  static std::unique_ptr<StreamIndex> create(
+      const StripeIndexGroup* stripeIndexGroup,
+      uint32_t stripe,
+      uint32_t streamId);
+
+  /// Lookup chunk by row ID
+  /// Returns chunk offset and size, or std::nullopt if not found
+  std::optional<ChunkLocation> lookupChunk(uint32_t rowId) const;
+
+ private:
+  StreamIndex(
+      const StripeIndexGroup* stripeIndexGroup,
+      uint32_t stripe,
+      uint32_t streamId);
+
+  const StripeIndexGroup* const stripeIndexGroup_;
+  const uint32_t stripe_;
+  const uint32_t streamId_;
+};
+
+} // namespace facebook::nimble

--- a/dwio/nimble/index/TabletIndex.cpp
+++ b/dwio/nimble/index/TabletIndex.cpp
@@ -1,0 +1,127 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "dwio/nimble/index/TabletIndex.h"
+
+#include <algorithm>
+#include "dwio/nimble/common/Exceptions.h"
+#include "dwio/nimble/tablet/IndexGenerated.h"
+
+namespace facebook::nimble {
+
+namespace {
+const serialization::Index* getIndexRoot(const MetadataBuffer& indexSection) {
+  const auto* indexRoot =
+      flatbuffers::GetRoot<serialization::Index>(indexSection.content().data());
+  NIMBLE_CHECK_NOT_NULL(indexRoot);
+  return indexRoot;
+}
+
+uint32_t getStripeCount(const MetadataBuffer& indexSection) {
+  const auto* indexRoot = getIndexRoot(indexSection);
+  const auto* stripeKeys = indexRoot->stripe_keys();
+  NIMBLE_CHECK_NOT_NULL(stripeKeys);
+  return stripeKeys->size() - 1;
+}
+
+std::vector<std::string_view> getStripeKeys(
+    const MetadataBuffer& indexSection) {
+  const auto* indexRoot = getIndexRoot(indexSection);
+  const auto* stripeKeys = indexRoot->stripe_keys();
+  NIMBLE_CHECK_NOT_NULL(stripeKeys);
+  std::vector<std::string_view> result;
+  result.reserve(stripeKeys->size());
+  for (const auto* stripeKey : *stripeKeys) {
+    result.emplace_back(stripeKey->string_view());
+  }
+  return result;
+}
+
+std::vector<std::string> getIndexColumns(const MetadataBuffer& indexSection) {
+  const auto* indexRoot = getIndexRoot(indexSection);
+  const auto* indexColumns = indexRoot->index_columns();
+  NIMBLE_CHECK_NOT_NULL(indexColumns);
+  std::vector<std::string> result;
+  result.reserve(indexColumns->size());
+  for (const auto* column : *indexColumns) {
+    result.emplace_back(column->string_view());
+  }
+  return result;
+}
+
+} // namespace
+
+std::unique_ptr<TabletIndex> TabletIndex::create(
+    std::unique_ptr<MetadataBuffer> indexSection) {
+  return std::unique_ptr<TabletIndex>(new TabletIndex(std::move(indexSection)));
+}
+
+TabletIndex::TabletIndex(std::unique_ptr<MetadataBuffer> indexSection)
+    : indexSection_{std::move(indexSection)},
+      numStripes_{getStripeCount(*indexSection_)},
+      stripeKeys_{getStripeKeys(*indexSection_)},
+      indexColumns_{getIndexColumns(*indexSection_)} {
+  NIMBLE_CHECK(!indexColumns_.empty());
+  NIMBLE_CHECK_EQ(numStripes_ + 1, stripeKeys_.size());
+
+  // Validate consistency between stripe group indices and stripe index groups
+  const auto* indexRoot = getIndexRoot(*indexSection_);
+  const auto* stripeIndexGroups = indexRoot->stripe_index_groups();
+  NIMBLE_CHECK_NOT_NULL(stripeIndexGroups);
+  NIMBLE_CHECK_GE(
+      numStripes_,
+      stripeIndexGroups->size(),
+      "Number of stripe index groups cannot exceed number of stripes");
+}
+
+std::optional<StripeLocation> TabletIndex::lookup(
+    std::string_view encodedKey) const {
+  // Check if key is before the first stripe key
+  if (encodedKey < stripeKeys_[0]) {
+    return std::nullopt;
+  }
+
+  // Find the target stripe using binary search
+  // We search in stripeKeys_[1..numStripes_] to find the first stripe's last
+  // key >= encodedKey.
+  const auto it = std::lower_bound(
+      stripeKeys_.begin() + 1,
+      stripeKeys_.begin() + numStripes_ + 1,
+      encodedKey);
+
+  // Calculate which stripe contains the key
+  const uint32_t targetStripe = (it - stripeKeys_.begin()) - 1;
+
+  // Check if the key is beyond all stripes
+  if (targetStripe >= numStripes_) {
+    return std::nullopt;
+  }
+
+  return StripeLocation{targetStripe};
+}
+
+MetadataSection TabletIndex::indexGroupMetadata(uint32_t groupIndex) const {
+  const auto* indexRoot = getIndexRoot(*indexSection_);
+  const auto* indexGroupSections = indexRoot->stripe_index_groups();
+  NIMBLE_CHECK_NOT_NULL(indexGroupSections);
+  NIMBLE_CHECK_LT(groupIndex, indexGroupSections->size());
+  const auto* metadata = indexGroupSections->Get(groupIndex);
+  return MetadataSection{
+      metadata->offset(),
+      metadata->size(),
+      static_cast<CompressionType>(metadata->compression_type())};
+}
+} // namespace facebook::nimble

--- a/dwio/nimble/index/TabletIndex.h
+++ b/dwio/nimble/index/TabletIndex.h
@@ -1,0 +1,134 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <optional>
+#include <string_view>
+#include <vector>
+#include "dwio/nimble/tablet/MetadataBuffer.h"
+
+namespace facebook::nimble {
+
+/// Represents the global stripe index within a tablet.
+struct StripeLocation {
+  explicit StripeLocation(uint32_t _stripeIndex) : stripeIndex(_stripeIndex) {}
+
+  uint32_t stripeIndex;
+
+  bool operator==(const StripeLocation& other) const {
+    return stripeIndex == other.stripeIndex;
+  }
+};
+
+/// TabletIndex provides efficient key-based stripe lookup for Nimble tablets.
+///
+/// The index uses a flatbuffer-backed serialized index structure that maps
+/// encoded keys to stripe locations. Internally, the class maintains minimal
+/// cached state (stripe count and stripe keys) while accessing other metadata
+/// on-demand from the underlying flatbuffer for optimal memory efficiency.
+///
+/// Key features:
+/// - Binary search-based stripe lookup using cached stripe keys
+/// - On-demand access to index group metadata
+/// - Validates index structure consistency during construction
+///
+/// Example usage:
+///   ...
+///   auto index = TabletIndex::create(std::move(indexSection));
+///   auto location = index->lookup(encodedKey);
+///   if (location) {
+///     auto stripeGroupIndex =
+///     tabletReader.stripeGroupIndex(location->stripeIndex); auto metadata =
+///     index->indexGroupMetadata(stripeGroupIndex);
+///   }
+///   ... read stripe data ...
+///
+class TabletIndex {
+ public:
+  /// Creates a TabletIndex for efficient key-based stripe lookups.
+  ///
+  /// @param indexSection The index section buffer containing the serialized
+  ///        index data
+  /// @return A unique pointer to a newly created TabletIndex
+  static std::unique_ptr<TabletIndex> create(
+      std::unique_ptr<MetadataBuffer> indexSection);
+
+  /// Looks up the stripe location containing the specified encoded key using
+  /// binary search.
+  ///
+  /// The lookup finds the stripe whose key range includes the given encodedKey.
+  /// Returns std::nullopt if the key is outside all stripe ranges (before the
+  /// first stripe key or after the last stripe key).
+  ///
+  /// @param encodedKey The binary-encoded search key
+  /// @return StripeLocation containing stripe index if found, std::nullopt
+  ///         otherwise
+  std::optional<StripeLocation> lookup(std::string_view encodedKey) const;
+
+  /// Returns the minimum key across all stripes (first stripe key).
+  ///
+  /// @return The encoded minimum key value
+  std::string_view minKey() const {
+    return stripeKeys_.front();
+  }
+
+  /// Returns the maximum key across all stripes (last stripe key).
+  ///
+  /// @return The encoded maximum key value
+  std::string_view maxKey() const {
+    return stripeKeys_.back();
+  }
+
+  /// Returns the encoded key for a specific stripe.
+  ///
+  /// @param stripeIndex The zero-based stripe index
+  /// @return The encoded key for the specified stripe
+  std::string_view stripeKey(size_t stripeIndex) const {
+    return stripeKeys_[stripeIndex + 1];
+  }
+
+  /// Returns the total number of stripes in the tablet.
+  ///
+  /// @return Number of stripes
+  size_t numStripes() const {
+    return numStripes_;
+  }
+
+  /// Returns the index columns.
+  ///
+  /// @return Vector of index column names
+  const std::vector<std::string>& indexColumns() const {
+    return indexColumns_;
+  }
+
+  /// Returns metadata for a specific index group.
+  ///
+  /// @param groupIndex The zero-based stripe group index.
+  /// @return Metadata section containing offset, size, and
+  ///         compression info for the stripe index group
+  MetadataSection indexGroupMetadata(uint32_t groupIndex) const;
+
+ private:
+  explicit TabletIndex(std::unique_ptr<MetadataBuffer> indexSection);
+
+  const std::unique_ptr<MetadataBuffer> indexSection_;
+  const uint32_t numStripes_;
+  const std::vector<std::string_view> stripeKeys_;
+  const std::vector<std::string> indexColumns_;
+};
+
+} // namespace facebook::nimble

--- a/dwio/nimble/index/tests/CMakeLists.txt
+++ b/dwio/nimble/index/tests/CMakeLists.txt
@@ -11,7 +11,13 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-add_executable(nimble_index_tests KeyEncoderTest.cpp)
+add_executable(
+  nimble_index_tests
+  KeyEncoderTest.cpp
+  StripeIndexGroupTest.cpp
+  TabletIndexTest.cpp
+  TabletIndexTestBase.cpp
+)
 
 add_test(nimble_index_tests nimble_index_tests)
 

--- a/dwio/nimble/index/tests/StripeIndexGroupTest.cpp
+++ b/dwio/nimble/index/tests/StripeIndexGroupTest.cpp
@@ -1,0 +1,667 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include <gtest/gtest.h>
+#include <limits>
+
+#include "dwio/nimble/common/tests/GTestUtils.h"
+#include "dwio/nimble/common/tests/TestUtils.h"
+#include "dwio/nimble/index/StripeIndexGroup.h"
+#include "dwio/nimble/index/tests/TabletIndexTestBase.h"
+#include "dwio/nimble/tablet/TabletReader.h"
+
+namespace facebook::nimble::test {
+
+class StripeIndexGroupTest : public TabletIndexTestBase {};
+
+TEST_F(StripeIndexGroupTest, chunkLocation) {
+  ChunkLocation loc1{100, 200};
+  EXPECT_EQ(loc1.streamOffset, 100);
+  EXPECT_EQ(loc1.rowOffset, 200);
+
+  ChunkLocation loc2{0, 0};
+  EXPECT_EQ(loc2.streamOffset, 0);
+  EXPECT_EQ(loc2.rowOffset, 0);
+
+  ChunkLocation loc3{UINT32_MAX, UINT32_MAX};
+  EXPECT_EQ(loc3.streamOffset, UINT32_MAX);
+  EXPECT_EQ(loc3.rowOffset, UINT32_MAX);
+}
+
+TEST_F(StripeIndexGroupTest, keyStreamRegion) {
+  std::vector<std::string> indexColumns = {"col1"};
+  std::string minKey = "aaa";
+  std::vector<Stripe> stripes = {
+      {.streams = {{.numChunks = 1, .chunkRows = {100}, .chunkOffsets = {0}}},
+       .keyStream =
+           {.streamOffset = 0,
+            .streamSize = 100,
+            .stream = {.numChunks = 1, .chunkRows = {100}, .chunkOffsets = {0}},
+            .chunkKeys = {"bbb"}}},
+      {.streams = {{.numChunks = 1, .chunkRows = {200}, .chunkOffsets = {0}}},
+       .keyStream =
+           {.streamOffset = 100,
+            .streamSize = 150,
+            .stream = {.numChunks = 1, .chunkRows = {200}, .chunkOffsets = {0}},
+            .chunkKeys = {"ccc"}}},
+      {.streams = {{.numChunks = 1, .chunkRows = {150}, .chunkOffsets = {0}}},
+       .keyStream =
+           {.streamOffset = 250,
+            .streamSize = 200,
+            .stream = {.numChunks = 1, .chunkRows = {150}, .chunkOffsets = {0}},
+            .chunkKeys = {"ddd"}}},
+      {.streams = {{.numChunks = 1, .chunkRows = {120}, .chunkOffsets = {0}}},
+       .keyStream = {
+           .streamOffset = 450,
+           .streamSize = 50,
+           .stream = {.numChunks = 1, .chunkRows = {120}, .chunkOffsets = {0}},
+           .chunkKeys = {"eee"}}}};
+  std::vector<int> stripeGroups = {2, 2};
+
+  auto indexBuffers =
+      createTestTabletIndex(indexColumns, minKey, stripes, stripeGroups);
+
+  // Test all key stream regions using parameterized test cases
+  struct {
+    uint32_t groupIndex;
+    uint32_t stripeIndex;
+    uint32_t expectedOffset;
+    uint32_t expectedLength;
+  } testCases[] = {
+      // Group 0: stripes 0, 1
+      {0, 0, 0, 100},
+      {0, 1, 100, 150},
+      // Group 1: stripes 2, 3
+      {1, 2, 250, 200},
+      {1, 3, 450, 50},
+  };
+
+  for (const auto& testCase : testCases) {
+    SCOPED_TRACE(
+        fmt::format(
+            "groupIndex {} stripeIndex {}",
+            testCase.groupIndex,
+            testCase.stripeIndex));
+    auto stripeIndexGroup =
+        createStripeIndexGroup(indexBuffers, testCase.groupIndex);
+    ASSERT_NE(stripeIndexGroup, nullptr);
+
+    auto region = stripeIndexGroup->keyStreamRegion(testCase.stripeIndex);
+    ASSERT_TRUE(region.has_value());
+    EXPECT_EQ(region->offset, testCase.expectedOffset);
+    EXPECT_EQ(region->length, testCase.expectedLength);
+  }
+}
+
+TEST_F(StripeIndexGroupTest, lookupChunkWithEncodedKey) {
+  std::vector<std::string> indexColumns = {"col1"};
+  std::string minKey = "aaa";
+  std::vector<Stripe> stripes = {
+      {.streams = {{.numChunks = 1, .chunkRows = {100}, .chunkOffsets = {0}}},
+       .keyStream =
+           {.streamOffset = 0,
+            .streamSize = 100,
+            .stream =
+                {.numChunks = 3,
+                 .chunkRows = {100, 200, 300},
+                 .chunkOffsets = {0, 50, 120}},
+            .chunkKeys = {"ccc", "fff", "iii"}}},
+      {.streams = {{.numChunks = 1, .chunkRows = {200}, .chunkOffsets = {0}}},
+       .keyStream = {
+           .streamOffset = 100,
+           .streamSize = 150,
+           .stream =
+               {.numChunks = 2,
+                .chunkRows = {150, 300},
+                .chunkOffsets = {0, 80}},
+           .chunkKeys = {"mmm", "ppp"}}}};
+  std::vector<int> stripeGroups = {2};
+
+  auto indexBuffers =
+      createTestTabletIndex(indexColumns, minKey, stripes, stripeGroups);
+  auto stripeIndexGroup = createStripeIndexGroup(indexBuffers, 0);
+  ASSERT_NE(stripeIndexGroup, nullptr);
+
+  struct {
+    uint32_t stripeIndex;
+    std::string encodedKey;
+    std::optional<uint32_t> expectedStreamOffset;
+    std::optional<uint32_t> expectedRowOffset;
+  } testCases[] = {
+      // Stripe 0: chunks with keys "ccc", "fff", "iii"
+      // Key before first chunk locate at the first chunk as we
+      // expect the caller will locate the right stripe with tablet index.
+      {0, "aa", 0, 0},
+      {0, "aaa", 0, 0},
+      {0, "bbb", 0, 0},
+      // Key at first chunk boundary
+      {0, "ccc", 0, 0},
+      // Key between first and second chunk
+      {0, "ddd", 50, 100},
+      {0, "eee", 50, 100},
+      // Key at second chunk boundary
+      {0, "fff", 50, 100},
+      // Key between second and third chunk
+      {0, "ggg", 120, 300},
+      {0, "hhh", 120, 300},
+      // Key at third chunk boundary
+      {0, "iii", 120, 300},
+      // Key after last chunk - not found
+      {0, "jjj", std::nullopt, std::nullopt},
+      {0, "zzz", std::nullopt, std::nullopt},
+
+      // Stripe 1: chunks with keys "mmm", "ppp"
+      // Key before first chunk locate at the first chunk as we
+      // expect the caller will locate the right stripe with tablet index.
+      {1, "aaa", 0, 0},
+      {1, "lll", 0, 0},
+      // Key at first chunk boundary
+      {1, "mmm", 0, 0},
+      // Key between first and second chunk
+      {1, "nnn", 80, 150},
+      {1, "ooo", 80, 150},
+      // Key at second chunk boundary
+      {1, "ppp", 80, 150},
+      // Key after last chunk - not found
+      {1, "qqq", std::nullopt, std::nullopt},
+      {1, "zzz", std::nullopt, std::nullopt}};
+
+  for (const auto& testCase : testCases) {
+    SCOPED_TRACE(
+        fmt::format(
+            "stripeIndex {} encodedKey {}",
+            testCase.stripeIndex,
+            testCase.encodedKey));
+    auto result = stripeIndexGroup->lookupChunk(
+        testCase.stripeIndex, testCase.encodedKey);
+    if (testCase.expectedStreamOffset.has_value()) {
+      ASSERT_TRUE(result.has_value())
+          << "Expected chunk at streamOffset "
+          << testCase.expectedStreamOffset.value() << ", rowOffset "
+          << testCase.expectedRowOffset.value() << " for key '"
+          << testCase.encodedKey << "', but lookup returned nullopt";
+      EXPECT_EQ(result->streamOffset, testCase.expectedStreamOffset.value());
+      EXPECT_EQ(result->rowOffset, testCase.expectedRowOffset.value());
+    } else {
+      EXPECT_FALSE(result.has_value())
+          << "Expected nullopt for key '" << testCase.encodedKey
+          << "', but got streamOffset " << result->streamOffset
+          << ", rowOffset " << result->rowOffset;
+    }
+  }
+}
+
+TEST_F(StripeIndexGroupTest, lookupChunkWithRowId) {
+  std::vector<std::string> indexColumns = {"col1"};
+  std::string minKey = "aaa";
+  // Setup: 2 stripes, each with 2 streams with different chunk configurations
+  std::vector<Stripe> stripes = {
+      {.streams =
+           {// Stream 0: 3 chunks at rows {100, 250, 400}, offsets {0, 50, 120}
+            {.numChunks = 3,
+             .chunkRows = {100, 250, 400},
+             .chunkOffsets = {0, 50, 120}},
+            // Stream 1: 2 chunks at rows {150, 300}, offsets {0, 80}
+            {.numChunks = 2, .chunkRows = {150, 300}, .chunkOffsets = {0, 80}}},
+       .keyStream =
+           {.streamOffset = 0,
+            .streamSize = 100,
+            .stream = {.numChunks = 1, .chunkRows = {400}, .chunkOffsets = {0}},
+            .chunkKeys = {"bbb"}}},
+      {.streams =
+           {// Stream 0: 2 chunks at rows {200, 350}, offsets {0, 60}
+            {.numChunks = 2, .chunkRows = {200, 350}, .chunkOffsets = {0, 60}},
+            // Stream 1: 3 chunks at rows {100, 200, 350}, offsets {0, 40, 90}
+            {.numChunks = 3,
+             .chunkRows = {100, 200, 350},
+             .chunkOffsets = {0, 40, 90}}},
+       .keyStream = {
+           .streamOffset = 100,
+           .streamSize = 100,
+           .stream = {.numChunks = 1, .chunkRows = {350}, .chunkOffsets = {0}},
+           .chunkKeys = {"ccc"}}}};
+  std::vector<int> stripeGroups = {2};
+
+  auto indexBuffers =
+      createTestTabletIndex(indexColumns, minKey, stripes, stripeGroups);
+  auto stripeIndexGroup = createStripeIndexGroup(indexBuffers, 0);
+  ASSERT_NE(stripeIndexGroup, nullptr);
+
+  struct {
+    uint32_t stripeIndex;
+    uint32_t streamId;
+    uint32_t rowId;
+    std::optional<uint32_t> expectedStreamOffset;
+    std::optional<uint32_t> expectedRowOffset;
+  } testCases[] = {
+      // Stripe 0, Stream 0: chunks at rows {100, 250, 400}, offsets {0, 50,
+      // 120}
+      // Row 0 - first row of first chunk
+      {0, 0, 0, 0, 0},
+      // Row in first chunk [0, 100)
+      {0, 0, 50, 0, 0},
+      {0, 0, 99, 0, 0},
+      // Row at first chunk boundary (100) - second chunk
+      {0, 0, 100, 50, 100},
+      // Row in second chunk [100, 350)
+      {0, 0, 150, 50, 100},
+      {0, 0, 249, 50, 100},
+      {0, 0, 349, 50, 100},
+      // Row at second chunk boundary (350) - third chunk
+      {0, 0, 350, 120, 350},
+      // Row in third chunk [350, 750)
+      {0, 0, 351, 120, 350},
+      {0, 0, 399, 120, 350},
+      {0, 0, 749, 120, 350},
+      // Row at/after last chunk boundary - not found
+      {0, 0, 750, std::nullopt, std::nullopt},
+      {0, 0, 850, std::nullopt, std::nullopt},
+
+      // Stripe 0, Stream 1: chunks at rows {150, 300}, offsets {0, 80}
+      // Accumulated rows: {150, 450}
+      // Row 0 - first row of first chunk
+      {0, 1, 0, 0, 0},
+      // Row in first chunk [0, 150)
+      {0, 1, 75, 0, 0},
+      {0, 1, 149, 0, 0},
+      // Row at first chunk boundary (150) - second chunk
+      {0, 1, 150, 80, 150},
+      // Row in second chunk [150, 450)
+      {0, 1, 200, 80, 150},
+      {0, 1, 299, 80, 150},
+      {0, 1, 449, 80, 150},
+      // Row at/after last chunk boundary - not found
+      {0, 1, 450, std::nullopt, std::nullopt},
+      {0, 1, 500, std::nullopt, std::nullopt},
+
+      // Stripe 1, Stream 0: chunks at rows {200, 350}, offsets {0, 60}
+      // Accumulated rows: {200, 550}
+      // Row 0 - first row of first chunk
+      {1, 0, 0, 0, 0},
+      // Row in first chunk [0, 200)
+      {1, 0, 100, 0, 0},
+      {1, 0, 199, 0, 0},
+      // Row at first chunk boundary (200) - second chunk
+      {1, 0, 200, 60, 200},
+      // Row in second chunk [200, 550)
+      {1, 0, 275, 60, 200},
+      {1, 0, 400, 60, 200},
+      {1, 0, 549, 60, 200},
+      // Row at/after last chunk boundary - not found
+      {1, 0, 550, std::nullopt, std::nullopt},
+      {1, 0, 600, std::nullopt, std::nullopt},
+
+      // Stripe 1, Stream 1: chunks at rows {100, 200, 350}, offsets {0, 40, 90}
+      // Accumulated rows: {100, 300, 650}
+      // Row 0 - first row of first chunk
+      {1, 1, 0, 0, 0},
+      // Row in first chunk [0, 100)
+      {1, 1, 50, 0, 0},
+      {1, 1, 99, 0, 0},
+      // Row at first chunk boundary (100) - second chunk
+      {1, 1, 100, 40, 100},
+      // Row in second chunk [100, 300)
+      {1, 1, 150, 40, 100},
+      {1, 1, 200, 40, 100},
+      {1, 1, 299, 40, 100},
+      // Row at second chunk boundary (300) - third chunk
+      {1, 1, 300, 90, 300},
+      // Row in third chunk [300, 650)
+      {1, 1, 400, 90, 300},
+      {1, 1, 500, 90, 300},
+      {1, 1, 649, 90, 300},
+      // Row at/after last chunk boundary - not found
+      {1, 1, 650, std::nullopt, std::nullopt},
+      {1, 1, 700, std::nullopt, std::nullopt}};
+
+  for (const auto& testCase : testCases) {
+    SCOPED_TRACE(
+        fmt::format(
+            "stripeIndex {} streamId {} rowId {} expectedStreamOffset {} expectedRowOffset {}",
+            testCase.stripeIndex,
+            testCase.streamId,
+            testCase.rowId,
+            testCase.expectedStreamOffset.has_value()
+                ? std::to_string(testCase.expectedStreamOffset.value())
+                : "nullopt",
+            testCase.expectedRowOffset.has_value()
+                ? std::to_string(testCase.expectedRowOffset.value())
+                : "nullopt"));
+    auto result = stripeIndexGroup->lookupChunk(
+        testCase.stripeIndex, testCase.streamId, testCase.rowId);
+    if (testCase.expectedStreamOffset.has_value()) {
+      ASSERT_TRUE(result.has_value())
+          << "Expected chunk at streamOffset "
+          << testCase.expectedStreamOffset.value() << ", rowOffset "
+          << testCase.expectedRowOffset.value() << " for stripe "
+          << testCase.stripeIndex << ", stream " << testCase.streamId
+          << ", rowId " << testCase.rowId << ", but lookup returned nullopt";
+      EXPECT_EQ(result->streamOffset, testCase.expectedStreamOffset.value());
+      EXPECT_EQ(result->rowOffset, testCase.expectedRowOffset.value());
+    } else {
+      EXPECT_FALSE(result.has_value())
+          << "Expected nullopt for stripe " << testCase.stripeIndex
+          << ", stream " << testCase.streamId << ", rowId " << testCase.rowId
+          << ", but got streamOffset " << result->streamOffset << ", rowOffset "
+          << result->rowOffset;
+    }
+  }
+}
+
+TEST_F(StripeIndexGroupTest, createStreamIndex) {
+  std::vector<std::string> indexColumns = {"col1"};
+  std::string minKey = "aaa";
+  std::vector<Stripe> stripes = {
+      {.streams =
+           {{.numChunks = 3,
+             .chunkRows = {100, 200, 300},
+             .chunkOffsets = {0, 50, 120}},
+            {.numChunks = 2, .chunkRows = {150, 300}, .chunkOffsets = {0, 80}}},
+       .keyStream = {
+           .streamOffset = 0,
+           .streamSize = 100,
+           .stream =
+               {.numChunks = 3,
+                .chunkRows = {100, 200, 300},
+                .chunkOffsets = {0, 30, 70}},
+           .chunkKeys = {"bbb", "ccc", "ddd"}}}};
+  std::vector<int> stripeGroups = {1};
+
+  auto indexBuffers =
+      createTestTabletIndex(indexColumns, minKey, stripes, stripeGroups);
+  auto stripeIndexGroup = createStripeIndexGroup(indexBuffers, 0);
+  ASSERT_NE(stripeIndexGroup, nullptr);
+
+  // Create StreamIndex for stream 0 in stripe 0
+  auto streamIndex = stripeIndexGroup->createStreamIndex(0, 0);
+  ASSERT_NE(streamIndex, nullptr);
+}
+
+TEST_F(StripeIndexGroupTest, streamIndexLookupChunk) {
+  std::vector<std::string> indexColumns = {"col1"};
+  std::string minKey = "aaa";
+  // Setup: 4 stripes across 2 groups, each stripe with 2 streams
+  std::vector<Stripe> stripes = {
+      // Stripe 0 (Group 0)
+      {.streams =
+           {// Stream 0: 3 chunks at rows {100, 250, 400}, offsets {0, 50, 120}
+            {.numChunks = 3,
+             .chunkRows = {100, 250, 400},
+             .chunkOffsets = {0, 50, 120}},
+            // Stream 1: 2 chunks at rows {150, 300}, offsets {0, 80}
+            {.numChunks = 2, .chunkRows = {150, 300}, .chunkOffsets = {0, 80}}},
+       .keyStream =
+           {.streamOffset = 0,
+            .streamSize = 100,
+            .stream = {.numChunks = 1, .chunkRows = {400}, .chunkOffsets = {0}},
+            .chunkKeys = {"bbb"}}},
+      // Stripe 1 (Group 0)
+      {.streams =
+           {// Stream 0: 2 chunks at rows {200, 350}, offsets {0, 60}
+            {.numChunks = 2, .chunkRows = {200, 350}, .chunkOffsets = {0, 60}},
+            // Stream 1: 3 chunks at rows {100, 200, 350}, offsets {0, 40, 90}
+            {.numChunks = 3,
+             .chunkRows = {100, 200, 350},
+             .chunkOffsets = {0, 40, 90}}},
+       .keyStream =
+           {.streamOffset = 100,
+            .streamSize = 100,
+            .stream = {.numChunks = 1, .chunkRows = {350}, .chunkOffsets = {0}},
+            .chunkKeys = {"ccc"}}},
+      // Stripe 2 (Group 1)
+      {.streams =
+           {// Stream 0: 2 chunks at rows {150, 300}, offsets {0, 70}
+            {.numChunks = 2, .chunkRows = {150, 300}, .chunkOffsets = {0, 70}},
+            // Stream 1: 2 chunks at rows {180, 360}, offsets {0, 55}
+            {.numChunks = 2, .chunkRows = {180, 360}, .chunkOffsets = {0, 55}}},
+       .keyStream =
+           {.streamOffset = 200,
+            .streamSize = 100,
+            .stream = {.numChunks = 1, .chunkRows = {300}, .chunkOffsets = {0}},
+            .chunkKeys = {"ddd"}}},
+      // Stripe 3 (Group 1)
+      {.streams =
+           {// Stream 0: 3 chunks at rows {80, 160, 240}, offsets {0, 30, 65}
+            {.numChunks = 3,
+             .chunkRows = {80, 160, 240},
+             .chunkOffsets = {0, 30, 65}},
+            // Stream 1: 2 chunks at rows {120, 240}, offsets {0, 45}
+            {.numChunks = 2, .chunkRows = {120, 240}, .chunkOffsets = {0, 45}}},
+       .keyStream = {
+           .streamOffset = 300,
+           .streamSize = 100,
+           .stream = {.numChunks = 1, .chunkRows = {240}, .chunkOffsets = {0}},
+           .chunkKeys = {"eee"}}}};
+  std::vector<int> stripeGroups = {2, 2};
+
+  auto indexBuffers =
+      createTestTabletIndex(indexColumns, minKey, stripes, stripeGroups);
+
+  struct {
+    uint32_t groupIndex;
+    uint32_t stripeIndex;
+    uint32_t streamId;
+    uint32_t rowId;
+    std::optional<uint32_t> expectedStreamOffset;
+    std::optional<uint32_t> expectedRowOffset;
+  } testCases[] = {
+      // Group 0, Stripe 0, Stream 0: chunks at rows {100, 250, 400}, offsets
+      // {0, 50, 120}
+      // Accumulated rows: {100, 350, 750}
+      {0, 0, 0, 0, 0, 0},
+      {0, 0, 0, 50, 0, 0},
+      {0, 0, 0, 99, 0, 0},
+      {0, 0, 0, 100, 50, 100},
+      {0, 0, 0, 349, 50, 100},
+      {0, 0, 0, 350, 120, 350},
+      {0, 0, 0, 749, 120, 350},
+      {0, 0, 0, 750, std::nullopt, std::nullopt},
+
+      // Group 0, Stripe 0, Stream 1: chunks at rows {150, 300}, offsets {0, 80}
+      // Accumulated rows: {150, 450}
+      {0, 0, 1, 0, 0, 0},
+      {0, 0, 1, 149, 0, 0},
+      {0, 0, 1, 150, 80, 150},
+      {0, 0, 1, 449, 80, 150},
+      {0, 0, 1, 450, std::nullopt, std::nullopt},
+
+      // Group 0, Stripe 1, Stream 0: chunks at rows {200, 350}, offsets {0, 60}
+      // Accumulated rows: {200, 550}
+      {0, 1, 0, 0, 0, 0},
+      {0, 1, 0, 199, 0, 0},
+      {0, 1, 0, 200, 60, 200},
+      {0, 1, 0, 549, 60, 200},
+      {0, 1, 0, 550, std::nullopt, std::nullopt},
+
+      // Group 0, Stripe 1, Stream 1: chunks at rows {100, 200, 350}, offsets
+      // {0, 40, 90}
+      // Accumulated rows: {100, 300, 650}
+      {0, 1, 1, 0, 0, 0},
+      {0, 1, 1, 99, 0, 0},
+      {0, 1, 1, 100, 40, 100},
+      {0, 1, 1, 299, 40, 100},
+      {0, 1, 1, 300, 90, 300},
+      {0, 1, 1, 649, 90, 300},
+      {0, 1, 1, 650, std::nullopt, std::nullopt},
+
+      // Group 1, Stripe 2, Stream 0: chunks at rows {150, 300}, offsets {0, 70}
+      // Accumulated rows: {150, 450}
+      {1, 2, 0, 0, 0, 0},
+      {1, 2, 0, 149, 0, 0},
+      {1, 2, 0, 150, 70, 150},
+      {1, 2, 0, 449, 70, 150},
+      {1, 2, 0, 450, std::nullopt, std::nullopt},
+
+      // Group 1, Stripe 2, Stream 1: chunks at rows {180, 360}, offsets {0, 55}
+      // Accumulated rows: {180, 540}
+      {1, 2, 1, 0, 0, 0},
+      {1, 2, 1, 179, 0, 0},
+      {1, 2, 1, 180, 55, 180},
+      {1, 2, 1, 539, 55, 180},
+      {1, 2, 1, 540, std::nullopt, std::nullopt},
+
+      // Group 1, Stripe 3, Stream 0: chunks at rows {80, 160, 240}, offsets {0,
+      // 30, 65}
+      // Accumulated rows: {80, 240, 480}
+      {1, 3, 0, 0, 0, 0},
+      {1, 3, 0, 79, 0, 0},
+      {1, 3, 0, 80, 30, 80},
+      {1, 3, 0, 239, 30, 80},
+      {1, 3, 0, 240, 65, 240},
+      {1, 3, 0, 479, 65, 240},
+      {1, 3, 0, 480, std::nullopt, std::nullopt},
+
+      // Group 1, Stripe 3, Stream 1: chunks at rows {120, 240}, offsets {0, 45}
+      // Accumulated rows: {120, 360}
+      {1, 3, 1, 0, 0, 0},
+      {1, 3, 1, 119, 0, 0},
+      {1, 3, 1, 120, 45, 120},
+      {1, 3, 1, 359, 45, 120},
+      {1, 3, 1, 360, std::nullopt, std::nullopt},
+  };
+
+  for (const auto& testCase : testCases) {
+    SCOPED_TRACE(
+        fmt::format(
+            "groupIndex {} stripeIndex {} streamId {} rowId {}",
+            testCase.groupIndex,
+            testCase.stripeIndex,
+            testCase.streamId,
+            testCase.rowId));
+
+    // Create StripeIndexGroup based on groupIndex parameter
+    auto stripeIndexGroup =
+        createStripeIndexGroup(indexBuffers, testCase.groupIndex);
+    ASSERT_NE(stripeIndexGroup, nullptr);
+
+    // Create StreamIndex and test lookupChunk through it
+    auto streamIndex = stripeIndexGroup->createStreamIndex(
+        testCase.stripeIndex, testCase.streamId);
+    ASSERT_NE(streamIndex, nullptr);
+
+    auto result = streamIndex->lookupChunk(testCase.rowId);
+    if (testCase.expectedStreamOffset.has_value()) {
+      ASSERT_TRUE(result.has_value())
+          << "Expected chunk at streamOffset "
+          << testCase.expectedStreamOffset.value() << ", rowOffset "
+          << testCase.expectedRowOffset.value() << " for group "
+          << testCase.groupIndex << ", stripe " << testCase.stripeIndex
+          << ", stream " << testCase.streamId << ", rowId " << testCase.rowId
+          << ", but lookup returned nullopt";
+      EXPECT_EQ(result->streamOffset, testCase.expectedStreamOffset.value());
+      EXPECT_EQ(result->rowOffset, testCase.expectedRowOffset.value());
+    } else {
+      EXPECT_FALSE(result.has_value())
+          << "Expected nullopt for group " << testCase.groupIndex << ", stripe "
+          << testCase.stripeIndex << ", stream " << testCase.streamId
+          << ", rowId " << testCase.rowId << ", but got streamOffset "
+          << result->streamOffset << ", rowOffset " << result->rowOffset;
+    }
+  }
+}
+
+TEST_F(StripeIndexGroupTest, stripeIndexAndStreamIdOutOfBound) {
+  std::vector<std::string> indexColumns = {"col1"};
+  std::string minKey = "aaa";
+  // Setup: 4 stripes across 2 groups, each stripe with 2 streams
+  std::vector<Stripe> stripes = {
+      // Stripe 0 (Group 0)
+      {.streams =
+           {{.numChunks = 1, .chunkRows = {100}, .chunkOffsets = {0}},
+            {.numChunks = 1, .chunkRows = {100}, .chunkOffsets = {0}}},
+       .keyStream =
+           {.streamOffset = 0,
+            .streamSize = 100,
+            .stream = {.numChunks = 1, .chunkRows = {100}, .chunkOffsets = {0}},
+            .chunkKeys = {"bbb"}}},
+      // Stripe 1 (Group 0)
+      {.streams =
+           {{.numChunks = 1, .chunkRows = {100}, .chunkOffsets = {0}},
+            {.numChunks = 1, .chunkRows = {100}, .chunkOffsets = {0}}},
+       .keyStream =
+           {.streamOffset = 100,
+            .streamSize = 100,
+            .stream = {.numChunks = 1, .chunkRows = {100}, .chunkOffsets = {0}},
+            .chunkKeys = {"ccc"}}},
+      // Stripe 2 (Group 1)
+      {.streams =
+           {{.numChunks = 1, .chunkRows = {100}, .chunkOffsets = {0}},
+            {.numChunks = 1, .chunkRows = {100}, .chunkOffsets = {0}}},
+       .keyStream =
+           {.streamOffset = 200,
+            .streamSize = 100,
+            .stream = {.numChunks = 1, .chunkRows = {100}, .chunkOffsets = {0}},
+            .chunkKeys = {"ddd"}}},
+      // Stripe 3 (Group 1)
+      {.streams =
+           {{.numChunks = 1, .chunkRows = {100}, .chunkOffsets = {0}},
+            {.numChunks = 1, .chunkRows = {100}, .chunkOffsets = {0}}},
+       .keyStream = {
+           .streamOffset = 300,
+           .streamSize = 100,
+           .stream = {.numChunks = 1, .chunkRows = {100}, .chunkOffsets = {0}},
+           .chunkKeys = {"eee"}}}};
+  std::vector<int> stripeGroups = {2, 2};
+
+  auto indexBuffers =
+      createTestTabletIndex(indexColumns, minKey, stripes, stripeGroups);
+
+  // Test Group 0 (stripes 0, 1)
+  auto stripeIndexGroup0 = createStripeIndexGroup(indexBuffers, 0);
+  ASSERT_NE(stripeIndexGroup0, nullptr);
+
+  // Stripe index before group's range (group 0 starts at stripe 0)
+  // This won't trigger "before range" since group 0 starts at stripe 0.
+  // Test stripe index after group's range
+  NIMBLE_ASSERT_THROW(
+      stripeIndexGroup0->lookupChunk(2, 0, 0),
+      "Stripe offset is out of range for this stripe index group");
+  NIMBLE_ASSERT_THROW(
+      stripeIndexGroup0->lookupChunk(3, 0, 0),
+      "Stripe offset is out of range for this stripe index group");
+
+  // Test streamId out of range (group has 2 streams: 0, 1)
+  NIMBLE_ASSERT_THROW(
+      stripeIndexGroup0->lookupChunk(0, 2, 0), "streamId out of range");
+  NIMBLE_ASSERT_THROW(
+      stripeIndexGroup0->lookupChunk(1, 10, 0), "streamId out of range");
+
+  // Test Group 1 (stripes 2, 3)
+  auto stripeIndexGroup1 = createStripeIndexGroup(indexBuffers, 1);
+  ASSERT_NE(stripeIndexGroup1, nullptr);
+
+  // Stripe index before group's range (group 1 starts at stripe 2)
+  NIMBLE_ASSERT_THROW(
+      stripeIndexGroup1->lookupChunk(0, 0, 0),
+      "Stripe index is before this group's range");
+  NIMBLE_ASSERT_THROW(
+      stripeIndexGroup1->lookupChunk(1, 0, 0),
+      "Stripe index is before this group's range");
+
+  // Stripe index after group's range (group 1 has stripes 2, 3)
+  NIMBLE_ASSERT_THROW(
+      stripeIndexGroup1->lookupChunk(4, 0, 0),
+      "Stripe offset is out of range for this stripe index group");
+  NIMBLE_ASSERT_THROW(
+      stripeIndexGroup1->lookupChunk(5, 0, 0),
+      "Stripe offset is out of range for this stripe index group");
+
+  // Test streamId out of range for group 1
+  NIMBLE_ASSERT_THROW(
+      stripeIndexGroup1->lookupChunk(2, 2, 0), "streamId out of range");
+  NIMBLE_ASSERT_THROW(
+      stripeIndexGroup1->lookupChunk(3, 5, 0), "streamId out of range");
+}
+} // namespace facebook::nimble::test

--- a/dwio/nimble/index/tests/TabletIndexTest.cpp
+++ b/dwio/nimble/index/tests/TabletIndexTest.cpp
@@ -1,0 +1,229 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include <gtest/gtest.h>
+#include <limits>
+
+#include "dwio/nimble/common/tests/TestUtils.h"
+#include "dwio/nimble/index/TabletIndex.h"
+#include "dwio/nimble/index/tests/TabletIndexTestBase.h"
+#include "dwio/nimble/tablet/TabletReader.h"
+
+namespace facebook::nimble::test {
+
+class TabletIndexTest : public TabletIndexTestBase {};
+
+TEST_F(TabletIndexTest, stripeLocation) {
+  StripeLocation loc1{0};
+  EXPECT_EQ(loc1.stripeIndex, 0);
+
+  StripeLocation loc2{42};
+  EXPECT_EQ(loc2.stripeIndex, 42);
+
+  StripeLocation loc3{UINT32_MAX};
+  EXPECT_EQ(loc3.stripeIndex, UINT32_MAX);
+
+  EXPECT_NE(loc1, loc2);
+  EXPECT_EQ(loc1, loc1);
+}
+
+TEST_F(TabletIndexTest, basic) {
+  std::vector<std::string> indexColumns = {"col1", "col2", "col3"};
+  std::string minKey = "aaa";
+  std::vector<Stripe> stripes = {
+      {.streams = {{.numChunks = 1, .chunkRows = {100}, .chunkOffsets = {0}}},
+       .keyStream =
+           {.streamOffset = 0,
+            .streamSize = 100,
+            .stream = {.numChunks = 1, .chunkRows = {100}, .chunkOffsets = {0}},
+            .chunkKeys = {"bbb"}}},
+      {.streams = {{.numChunks = 1, .chunkRows = {200}, .chunkOffsets = {0}}},
+       .keyStream =
+           {.streamOffset = 100,
+            .streamSize = 100,
+            .stream = {.numChunks = 1, .chunkRows = {200}, .chunkOffsets = {0}},
+            .chunkKeys = {"ccc"}}},
+      {.streams = {{.numChunks = 1, .chunkRows = {150}, .chunkOffsets = {0}}},
+       .keyStream =
+           {.streamOffset = 200,
+            .streamSize = 100,
+            .stream = {.numChunks = 1, .chunkRows = {150}, .chunkOffsets = {0}},
+            .chunkKeys = {"ddd"}}},
+      {.streams = {{.numChunks = 1, .chunkRows = {120}, .chunkOffsets = {0}}},
+       .keyStream = {
+           .streamOffset = 300,
+           .streamSize = 100,
+           .stream = {.numChunks = 1, .chunkRows = {120}, .chunkOffsets = {0}},
+           .chunkKeys = {"eee"}}}};
+  std::vector<int> stripeGroups = {2, 1, 1};
+
+  auto indexBuffers =
+      createTestTabletIndex(indexColumns, minKey, stripes, stripeGroups);
+  auto tabletIndex = createTabletIndex(indexBuffers);
+
+  EXPECT_EQ(tabletIndex->numStripes(), 4);
+  EXPECT_EQ(tabletIndex->minKey(), "aaa");
+  EXPECT_EQ(tabletIndex->maxKey(), "eee");
+
+  EXPECT_EQ(tabletIndex->stripeKey(0), "bbb");
+  EXPECT_EQ(tabletIndex->stripeKey(1), "ccc");
+  EXPECT_EQ(tabletIndex->stripeKey(2), "ddd");
+  EXPECT_EQ(tabletIndex->stripeKey(3), "eee");
+
+  const auto& cols = tabletIndex->indexColumns();
+  EXPECT_EQ(cols.size(), 3);
+  EXPECT_EQ(cols[0], "col1");
+  EXPECT_EQ(cols[1], "col2");
+  EXPECT_EQ(cols[2], "col3");
+
+  auto metadata0 = tabletIndex->indexGroupMetadata(0);
+  EXPECT_EQ(metadata0.offset(), 0);
+  EXPECT_GT(metadata0.size(), 0);
+  EXPECT_EQ(metadata0.compressionType(), CompressionType::Uncompressed);
+
+  auto metadata1 = tabletIndex->indexGroupMetadata(1);
+  EXPECT_EQ(metadata1.offset(), metadata0.size());
+  EXPECT_GT(metadata1.size(), 0);
+  EXPECT_EQ(metadata1.compressionType(), CompressionType::Uncompressed);
+
+  auto metadata2 = tabletIndex->indexGroupMetadata(2);
+  EXPECT_EQ(metadata2.offset(), metadata0.size() + metadata1.size());
+  EXPECT_GT(metadata2.size(), 0);
+  EXPECT_EQ(metadata2.compressionType(), CompressionType::Uncompressed);
+  EXPECT_EQ(
+      metadata2.offset() + metadata2.size(), indexBuffers.indexGroups.size());
+}
+
+TEST_F(TabletIndexTest, lookup) {
+  std::vector<std::string> indexColumns = {"key_col"};
+  std::string minKey = "aaa";
+  std::vector<Stripe> stripes = {
+      {.streams = {{.numChunks = 1, .chunkRows = {100}, .chunkOffsets = {0}}},
+       .keyStream =
+           {.streamOffset = 0,
+            .streamSize = 100,
+            .stream = {.numChunks = 1, .chunkRows = {100}, .chunkOffsets = {0}},
+            .chunkKeys = {"ccc"}}},
+      {.streams = {{.numChunks = 1, .chunkRows = {200}, .chunkOffsets = {0}}},
+       .keyStream =
+           {.streamOffset = 100,
+            .streamSize = 100,
+            .stream = {.numChunks = 1, .chunkRows = {200}, .chunkOffsets = {0}},
+            .chunkKeys = {"fff"}}},
+      {.streams = {{.numChunks = 1, .chunkRows = {150}, .chunkOffsets = {0}}},
+       .keyStream = {
+           .streamOffset = 200,
+           .streamSize = 100,
+           .stream = {.numChunks = 1, .chunkRows = {150}, .chunkOffsets = {0}},
+           .chunkKeys = {"iii"}}}};
+  std::vector<int> stripeGroups = {2, 1};
+
+  auto indexBuffers =
+      createTestTabletIndex(indexColumns, minKey, stripes, stripeGroups);
+  auto tabletIndex = createTabletIndex(indexBuffers);
+
+  // Stripe keys: minKey="aaa", stripe0="ccc", stripe1="fff", stripe2="iii"
+  struct {
+    std::string lookupKey;
+    std::optional<uint32_t> expectedStripeIndex;
+  } testCases[] = {
+      // Keys before minKey
+      {"000", std::nullopt},
+      {"aa", std::nullopt},
+      // Keys in stripe 0 range [aaa, ccc]
+      {"aaa", 0},
+      {"bbb", 0},
+      {"ccc", 0},
+      // Keys in stripe 1 range (ccc, fff]
+      {"ddd", 1},
+      {"eee", 1},
+      {"fff", 1},
+      // Keys in stripe 2 range (fff, iii]
+      {"ggg", 2},
+      {"hhh", 2},
+      {"iii", 2},
+      // Keys after last stripe max key
+      {"jjj", std::nullopt},
+      {"zzz", std::nullopt}};
+
+  for (const auto& testCase : testCases) {
+    SCOPED_TRACE(testCase.lookupKey);
+    auto result = tabletIndex->lookup(testCase.lookupKey);
+    if (testCase.expectedStripeIndex.has_value()) {
+      ASSERT_TRUE(result.has_value());
+      EXPECT_EQ(result->stripeIndex, testCase.expectedStripeIndex.value());
+    } else {
+      EXPECT_FALSE(result.has_value());
+    }
+  }
+}
+
+TEST_F(TabletIndexTest, lookupWithSameKeys) {
+  std::vector<std::string> indexColumns = {"key_col"};
+  std::string minKey = "aaa";
+  std::vector<Stripe> stripes = {
+      {.streams = {{.numChunks = 1, .chunkRows = {100}, .chunkOffsets = {0}}},
+       .keyStream =
+           {.streamOffset = 0,
+            .streamSize = 100,
+            .stream = {.numChunks = 1, .chunkRows = {100}, .chunkOffsets = {0}},
+            .chunkKeys = {"aaa"}}},
+      {.streams = {{.numChunks = 1, .chunkRows = {200}, .chunkOffsets = {0}}},
+       .keyStream =
+           {.streamOffset = 100,
+            .streamSize = 100,
+            .stream = {.numChunks = 1, .chunkRows = {200}, .chunkOffsets = {0}},
+            .chunkKeys = {"aaa"}}},
+      {.streams = {{.numChunks = 1, .chunkRows = {150}, .chunkOffsets = {0}}},
+       .keyStream = {
+           .streamOffset = 200,
+           .streamSize = 100,
+           .stream = {.numChunks = 1, .chunkRows = {150}, .chunkOffsets = {0}},
+           .chunkKeys = {"aaa"}}}};
+  std::vector<int> stripeGroups = {2, 1};
+
+  auto indexBuffers =
+      createTestTabletIndex(indexColumns, minKey, stripes, stripeGroups);
+  auto tabletIndex = createTabletIndex(indexBuffers);
+
+  // All stripe keys are the same: minKey="aaa", stripe0="aaa", stripe1="aaa",
+  // stripe2="aaa"
+  struct {
+    std::string lookupKey;
+    std::optional<uint32_t> expectedStripeIndex;
+  } testCases[] = {
+      // Keys before minKey
+      {"000", std::nullopt},
+      {"aa", std::nullopt},
+      // Key at minKey (same as all stripe keys) returns last stripe
+      {"aaa", 0},
+      // Keys after the common key
+      {"aab", std::nullopt},
+      {"bbb", std::nullopt},
+      {"zzz", std::nullopt}};
+
+  for (const auto& testCase : testCases) {
+    SCOPED_TRACE(testCase.lookupKey);
+    auto result = tabletIndex->lookup(testCase.lookupKey);
+    if (testCase.expectedStripeIndex.has_value()) {
+      ASSERT_TRUE(result.has_value());
+      EXPECT_EQ(result->stripeIndex, testCase.expectedStripeIndex.value());
+    } else {
+      EXPECT_FALSE(result.has_value());
+    }
+  }
+}
+
+} // namespace facebook::nimble::test

--- a/dwio/nimble/index/tests/TabletIndexTestBase.cpp
+++ b/dwio/nimble/index/tests/TabletIndexTestBase.cpp
@@ -1,0 +1,228 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "dwio/nimble/index/tests/TabletIndexTestBase.h"
+
+#include "dwio/nimble/tablet/IndexGenerated.h"
+
+namespace facebook::nimble::test {
+
+void TabletIndexTestBase::SetUpTestCase() {
+  velox::memory::MemoryManager::initialize({});
+}
+
+TabletIndexTestBase::IndexBuffers TabletIndexTestBase::createTestTabletIndex(
+    const std::vector<std::string>& indexColumns,
+    const std::string& minKey,
+    const std::vector<Stripe>& stripes,
+    const std::vector<int>& stripeGroups) {
+  IndexBuffers result;
+
+  flatbuffers::FlatBufferBuilder builder;
+
+  // Build stripe_group_indices - for each stripe, which group it belongs to.
+  // Size equals number of stripes.
+  std::vector<uint32_t> stripeGroupIndices;
+  stripeGroupIndices.reserve(stripes.size());
+  for (uint32_t groupIdx = 0; groupIdx < stripeGroups.size(); ++groupIdx) {
+    for (int i = 0; i < stripeGroups[groupIdx]; ++i) {
+      stripeGroupIndices.push_back(groupIdx);
+    }
+  }
+
+  // Build StripeIndexGroup for each group and serialize to buffer
+  std::vector<flatbuffers::Offset<serialization::MetadataSection>>
+      stripeIndexGroupMetadataOffsets;
+  stripeIndexGroupMetadataOffsets.reserve(stripeGroups.size());
+
+  uint32_t stripeIdx = 0;
+  for (const auto& groupStripeCount : stripeGroups) {
+    // Create a separate builder for each StripeIndexGroup
+    flatbuffers::FlatBufferBuilder groupBuilder;
+
+    // Collect data for all stripes in this group
+    std::vector<uint32_t> keyStreamOffsets;
+    std::vector<uint32_t> keyStreamSizes;
+    std::vector<uint32_t> keyStreamChunkCounts;
+    std::vector<uint32_t> keyStreamChunkRows;
+    std::vector<flatbuffers::Offset<flatbuffers::String>> keyStreamChunkKeys;
+    std::vector<uint32_t> keyStreamChunkOffsets;
+
+    std::vector<uint32_t> streamChunkCounts;
+    std::vector<uint32_t> streamChunkIndexes;
+    std::vector<uint32_t> streamChunkRows;
+    std::vector<uint32_t> streamChunkOffsets;
+
+    uint32_t currentChunkIndex = 0;
+    // chunkCounts are accumulated values for key stream only
+    uint32_t accumulatedKeyStreamChunkCount = 0;
+    for (int i = 0; i < groupStripeCount; ++i, ++stripeIdx) {
+      NIMBLE_CHECK_LT(stripeIdx, stripes.size());
+      const auto& stripe = stripes[stripeIdx];
+
+      // Add key stream data for this stripe
+      const auto& keyStream = stripe.keyStream;
+      keyStreamOffsets.push_back(keyStream.streamOffset);
+      keyStreamSizes.push_back(keyStream.streamSize);
+      accumulatedKeyStreamChunkCount += keyStream.stream.numChunks;
+      keyStreamChunkCounts.push_back(accumulatedKeyStreamChunkCount);
+      NIMBLE_CHECK_EQ(
+          keyStream.stream.numChunks, keyStream.stream.chunkRows.size());
+      // chunkRows are accumulated values (cumulative row counts)
+      uint32_t accumulatedKeyStreamRows = 0;
+      for (const auto& row : keyStream.stream.chunkRows) {
+        accumulatedKeyStreamRows += row;
+        keyStreamChunkRows.push_back(accumulatedKeyStreamRows);
+      }
+      NIMBLE_CHECK_EQ(
+          keyStream.stream.numChunks, keyStream.stream.chunkOffsets.size());
+      for (const auto& offset : keyStream.stream.chunkOffsets) {
+        keyStreamChunkOffsets.push_back(offset);
+      }
+
+      NIMBLE_CHECK_EQ(keyStream.stream.numChunks, keyStream.chunkKeys.size());
+      for (const auto& key : keyStream.chunkKeys) {
+        keyStreamChunkKeys.push_back(groupBuilder.CreateString(key));
+      }
+
+      // Add position index data for each stream in this stripe
+      for (const auto& stream : stripe.streams) {
+        streamChunkCounts.push_back(stream.numChunks);
+        streamChunkIndexes.push_back(currentChunkIndex);
+        NIMBLE_CHECK_EQ(stream.numChunks, stream.chunkRows.size());
+        // chunkRows are accumulated values (cumulative row counts)
+        uint32_t accumulatedRows = 0;
+        for (const auto& row : stream.chunkRows) {
+          accumulatedRows += row;
+          streamChunkRows.push_back(accumulatedRows);
+        }
+        NIMBLE_CHECK_EQ(stream.numChunks, stream.chunkOffsets.size());
+        for (const auto& offset : stream.chunkOffsets) {
+          streamChunkOffsets.push_back(offset);
+        }
+        currentChunkIndex += stream.numChunks;
+      }
+    }
+
+    // Build StripeValueIndex for this group
+    auto valueIndex = serialization::CreateStripeValueIndex(
+        groupBuilder,
+        groupBuilder.CreateVector(keyStreamOffsets),
+        groupBuilder.CreateVector(keyStreamSizes),
+        groupBuilder.CreateVector(keyStreamChunkCounts),
+        groupBuilder.CreateVector(keyStreamChunkRows),
+        groupBuilder.CreateVector(keyStreamChunkKeys),
+        groupBuilder.CreateVector(keyStreamChunkOffsets));
+
+    // Build StripePositionIndex for this group
+    auto positionIndex = serialization::CreateStripePositionIndex(
+        groupBuilder,
+        groupBuilder.CreateVector(streamChunkCounts),
+        groupBuilder.CreateVector(streamChunkIndexes),
+        groupBuilder.CreateVector(streamChunkRows),
+        groupBuilder.CreateVector(streamChunkOffsets));
+
+    // Build StripeIndexGroup combining all stripes in this group
+    auto stripeIndexGroup = serialization::CreateStripeIndexGroup(
+        groupBuilder, groupStripeCount, valueIndex, positionIndex);
+    groupBuilder.Finish(stripeIndexGroup);
+
+    // Record offset before appending
+    uint64_t offset = result.indexGroups.size();
+    uint32_t size = groupBuilder.GetSize();
+
+    // Append serialized StripeIndexGroup to the buffer
+    result.indexGroups.append(
+        reinterpret_cast<const char*>(groupBuilder.GetBufferPointer()), size);
+
+    // Create MetadataSection for this group in the main builder
+    auto metadataSection = serialization::CreateMetadataSection(
+        builder, offset, size, serialization::CompressionType_Uncompressed);
+    stripeIndexGroupMetadataOffsets.push_back(metadataSection);
+  }
+  // Build stripe_keys vector
+  // First element is the min key, rest are max keys of each stripe
+  // Max key of each stripe is the last key in keyStream.chunkKeys
+  std::vector<flatbuffers::Offset<flatbuffers::String>> stripeKeyOffsets;
+  stripeKeyOffsets.reserve(stripes.size() + 1);
+  stripeKeyOffsets.push_back(builder.CreateString(minKey));
+  for (const auto& stripe : stripes) {
+    const auto& chunkKeys = stripe.keyStream.chunkKeys;
+    NIMBLE_CHECK(!chunkKeys.empty());
+    stripeKeyOffsets.push_back(builder.CreateString(chunkKeys.back()));
+  }
+
+  // Build index_columns vector
+  std::vector<flatbuffers::Offset<flatbuffers::String>> indexColumnOffsets;
+  indexColumnOffsets.reserve(indexColumns.size());
+  for (const auto& column : indexColumns) {
+    indexColumnOffsets.push_back(builder.CreateString(column));
+  }
+
+  // Create all vectors right before CreateIndex to avoid offset invalidation
+  auto stripeKeysVector = builder.CreateVector(stripeKeyOffsets);
+  auto indexColumnsVector = builder.CreateVector(indexColumnOffsets);
+  auto stripeGroupIndicesVector = builder.CreateVector(stripeGroupIndices);
+  auto stripeIndexGroupsVector =
+      builder.CreateVector(stripeIndexGroupMetadataOffsets);
+
+  // Build the Index table
+  auto index = serialization::CreateIndex(
+      builder,
+      stripeKeysVector,
+      indexColumnsVector,
+      stripeGroupIndicesVector,
+      stripeIndexGroupsVector);
+
+  builder.Finish(index);
+
+  result.rootIndex = std::string(
+      reinterpret_cast<const char*>(builder.GetBufferPointer()),
+      builder.GetSize());
+
+  return result;
+}
+
+std::unique_ptr<TabletIndex> TabletIndexTestBase::createTabletIndex(
+    const IndexBuffers& indexBuffers) {
+  auto indexSection = std::make_unique<MetadataBuffer>(
+      *pool_, indexBuffers.rootIndex, CompressionType::Uncompressed);
+  return TabletIndex::create(std::move(indexSection));
+}
+
+std::shared_ptr<StripeIndexGroup> TabletIndexTestBase::createStripeIndexGroup(
+    const IndexBuffers& indexBuffers,
+    uint32_t stripeGroupIndex) {
+  // Create the root index MetadataBuffer
+  MetadataBuffer rootIndexBuffer(
+      *pool_, indexBuffers.rootIndex, CompressionType::Uncompressed);
+
+  // Get the metadata for the specified stripe group from the root index
+  auto tabletIndex = createTabletIndex(indexBuffers);
+  auto metadata = tabletIndex->indexGroupMetadata(stripeGroupIndex);
+
+  // Create the group index MetadataBuffer from the indexGroups buffer
+  // using the offset and size from the metadata
+  auto groupIndexBuffer = std::make_unique<MetadataBuffer>(
+      *pool_,
+      std::string_view(
+          indexBuffers.indexGroups.data() + metadata.offset(), metadata.size()),
+      metadata.compressionType());
+
+  return StripeIndexGroup::create(
+      stripeGroupIndex, rootIndexBuffer, std::move(groupIndexBuffer));
+}
+
+} // namespace facebook::nimble::test

--- a/dwio/nimble/index/tests/TabletIndexTestBase.h
+++ b/dwio/nimble/index/tests/TabletIndexTestBase.h
@@ -1,0 +1,97 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <gtest/gtest.h>
+#include <string>
+#include <vector>
+
+#include "dwio/nimble/common/Exceptions.h"
+#include "dwio/nimble/index/StripeIndexGroup.h"
+#include "dwio/nimble/index/TabletIndex.h"
+#include "dwio/nimble/tablet/MetadataBuffer.h"
+#include "velox/common/memory/Memory.h"
+
+namespace facebook::nimble::test {
+
+/// Base test class providing common test utilities for tablet index tests.
+class TabletIndexTestBase : public ::testing::Test {
+ protected:
+  static void SetUpTestCase();
+
+  void SetUp() override {}
+
+  struct Stream {
+    uint32_t numChunks;
+    std::vector<int32_t> chunkRows;
+    std::vector<uint32_t> chunkOffsets;
+  };
+
+  struct KeyStream {
+    uint32_t streamOffset;
+    uint32_t streamSize;
+    Stream stream;
+    std::vector<std::string> chunkKeys;
+  };
+
+  struct Stripe {
+    std::vector<Stream> streams;
+    KeyStream keyStream;
+  };
+
+  /// Structure to hold the serialized index buffers.
+  struct IndexBuffers {
+    /// Serialized StripeIndexGroup flatbuffers appended sequentially.
+    std::string indexGroups;
+    /// Serialized root Index flatbuffer.
+    std::string rootIndex;
+  };
+
+  /// Helper function to create a serialized Index flatbuffer for testing.
+  /// @param indexColumns Vector of index column names
+  /// @param stripes Vector of stripe data
+  /// @param stripeGroups Vector indicating how many stripes are in each group
+  /// @return IndexBuffers containing serialized StripeIndexGroups and root
+  /// Index
+  IndexBuffers createTestTabletIndex(
+      const std::vector<std::string>& indexColumns,
+      const std::string& minKey,
+      const std::vector<Stripe>& stripes,
+      const std::vector<int>& stripeGroups);
+
+  /// Creates a TabletIndex from the serialized IndexBuffers.
+  /// @param indexBuffers The serialized index buffers from
+  /// createTestTabletIndex
+  /// @return A unique pointer to a TabletIndex
+  std::unique_ptr<TabletIndex> createTabletIndex(
+      const IndexBuffers& indexBuffers);
+
+  /// Creates a StripeIndexGroup from the serialized IndexBuffers.
+  /// @param indexBuffers The serialized index buffers from
+  /// createTestTabletIndex
+  /// @param stripeGroupIndex The index of the stripe group to create
+  /// @return A shared pointer to a StripeIndexGroup
+  std::shared_ptr<StripeIndexGroup> createStripeIndexGroup(
+      const IndexBuffers& indexBuffers,
+      uint32_t stripeGroupIndex);
+
+  std::shared_ptr<velox::memory::MemoryPool> rootPool_{
+      velox::memory::memoryManager()->addRootPool("TabletIndexTestBase")};
+  std::shared_ptr<velox::memory::MemoryPool> pool_{
+      rootPool_->addLeafChild("TabletIndexTestBase")};
+};
+
+} // namespace facebook::nimble::test

--- a/dwio/nimble/tablet/Index.fbs
+++ b/dwio/nimble/tablet/Index.fbs
@@ -24,11 +24,12 @@ table StripeValueIndex {
   key_stream_chunk_counts:[uint32];
   key_stream_chunk_rows:[uint32];
   key_stream_chunk_keys:[string];
+  key_stream_chunk_offsets:[uint32];
 }
 
 table StripePositionIndex {
   stream_chunk_counts:[uint32];
-  stream_start_chunk_offsets:[uint32];
+  stream_chunk_indexes:[uint32];
   stream_chunk_rows:[uint32];
   stream_chunk_offsets:[uint32];
 }


### PR DESCRIPTION
Summary:
Index Structure

The hierarchical index structure (TabletIndex → StripeIndexGroup → StreamIndex)

TabletIndex (root-level, one per tablet)
    │
    ├── Stripe 0 ─┐
    ├── Stripe 1 ─┼──► StripeIndexGroup 0
    │             │
    ├── Stripe 2 ─┼──► StripeIndexGroup 1
    ├── Stripe 3 ─┘
    │
    └── ...
         │
         └──► StreamIndex (per-stream view within a stripe)

TabletIndex:
Root-level index that maps encoded keys to stripe locations
Stores: stripe keys (min key + max key per stripe), index column names, references to stripe index groups
Key operation: lookup(encodedKey) → StripeLocation{stripeIndex} using binary search

StripeIndexGroup:
Contains index data for a group of stripes (multiple stripes share one group for efficiency)
Stores two types of indexes:
Value Index: Key stream offsets/sizes, chunk keys, chunk rows, chunk offsets (for key-based lookups)
Position Index: Per-stream chunk counts, chunk indexes, chunk rows, chunk offsets (for row-based lookups)
Key operations: lookupChunk(stripe, encodedKey), lookupChunk(stripe, streamId, rowId), keyStreamRegion(stripeIndex)

StreamIndex:
Lightweight wrapper for convenient row-based lookups on a specific stream
Key operation: lookupChunk(rowId) → delegates to StripeIndexGroup::lookupChunk(stripe, streamId, rowId)

ChunkLocation:
Fields: streamOffset (offset within stream), rowOffset (row offset within stripe)

Others:
Schema updates to Index.fbs
TabletReader accessor additions
Test facilitities: TabletIndexTestBase
Comprehensive test coverage on two type of indexes

Differential Revision: D89578105


