### PR TITLE
Refactor cluster index to use accumulated stripe counts

### DIFF
--- a/dwio/nimble/index/KeyEncoder.h
+++ b/dwio/nimble/index/KeyEncoder.h
@@ -160,14 +160,6 @@ class KeyEncoder {
 
   uint64_t estimateEncodedSize();
 
-  // Encodes a single column for all rows in columnar fashion.
-  void encodeColumn(
-      const velox::DecodedVector& decodedVector,
-      velox::vector_size_t numRows,
-      bool nullLast,
-      bool descending,
-      std::vector<char*>& rowOffsets) const;
-
   // Encodes a RowVector and returns encoded keys as strings.
   // Each row in the input vector produces one encoded key string.
   std::vector<std::string> encode(const velox::RowVectorPtr& input);

--- a/dwio/nimble/index/StripeIndexGroup.h
+++ b/dwio/nimble/index/StripeIndexGroup.h
@@ -77,6 +77,7 @@ class StripeIndexGroup {
   StripeIndexGroup(
       uint32_t groupIndex,
       uint32_t firstStripe,
+      uint32_t stripeCount,
       std::unique_ptr<MetadataBuffer> metadata);
 
   inline uint32_t stripeOffset(uint32_t stripe) const {

--- a/dwio/nimble/index/TabletIndex.h
+++ b/dwio/nimble/index/TabletIndex.h
@@ -19,6 +19,7 @@
 #include <optional>
 #include <string_view>
 #include <vector>
+
 #include "dwio/nimble/tablet/MetadataBuffer.h"
 
 namespace facebook::nimble {
@@ -53,7 +54,7 @@ struct StripeLocation {
 ///   if (location) {
 ///     auto stripeGroupIndex =
 ///     tabletReader.stripeGroupIndex(location->stripeIndex); auto metadata =
-///     index->indexGroupMetadata(stripeGroupIndex);
+///     index->groupIndexMetadata(stripeGroupIndex);
 ///   }
 ///   ... read stripe data ...
 ///
@@ -61,11 +62,10 @@ class TabletIndex {
  public:
   /// Creates a TabletIndex for efficient key-based stripe lookups.
   ///
-  /// @param indexSection The index section buffer containing the serialized
+  /// @param indexSection The index section containing the serialized
   ///        index data
   /// @return A unique pointer to a newly created TabletIndex
-  static std::unique_ptr<TabletIndex> create(
-      std::unique_ptr<MetadataBuffer> indexSection);
+  static std::unique_ptr<TabletIndex> create(Section indexSection);
 
   /// Looks up the stripe location containing the specified encoded key using
   /// binary search.
@@ -120,12 +120,16 @@ class TabletIndex {
   /// @param groupIndex The zero-based stripe group index.
   /// @return Metadata section containing offset, size, and
   ///         compression info for the stripe index group
-  MetadataSection indexGroupMetadata(uint32_t groupIndex) const;
+  MetadataSection groupIndexMetadata(uint32_t groupIndex) const;
+
+  /// Returns a reference to the root index metadata buffer.
+  /// This is needed by StripeIndexGroup to read stripe group information.
+  const MetadataBuffer& rootIndex() const;
 
  private:
-  explicit TabletIndex(std::unique_ptr<MetadataBuffer> indexSection);
+  explicit TabletIndex(Section indexSection);
 
-  const std::unique_ptr<MetadataBuffer> indexSection_;
+  const Section indexSection_;
   const uint32_t numStripes_;
   const std::vector<std::string_view> stripeKeys_;
   const std::vector<std::string> indexColumns_;

--- a/dwio/nimble/index/tests/TabletIndexTest.cpp
+++ b/dwio/nimble/index/tests/TabletIndexTest.cpp
@@ -88,17 +88,17 @@ TEST_F(TabletIndexTest, basic) {
   EXPECT_EQ(cols[1], "col2");
   EXPECT_EQ(cols[2], "col3");
 
-  auto metadata0 = tabletIndex->indexGroupMetadata(0);
+  auto metadata0 = tabletIndex->groupIndexMetadata(0);
   EXPECT_EQ(metadata0.offset(), 0);
   EXPECT_GT(metadata0.size(), 0);
   EXPECT_EQ(metadata0.compressionType(), CompressionType::Uncompressed);
 
-  auto metadata1 = tabletIndex->indexGroupMetadata(1);
+  auto metadata1 = tabletIndex->groupIndexMetadata(1);
   EXPECT_EQ(metadata1.offset(), metadata0.size());
   EXPECT_GT(metadata1.size(), 0);
   EXPECT_EQ(metadata1.compressionType(), CompressionType::Uncompressed);
 
-  auto metadata2 = tabletIndex->indexGroupMetadata(2);
+  auto metadata2 = tabletIndex->groupIndexMetadata(2);
   EXPECT_EQ(metadata2.offset(), metadata0.size() + metadata1.size());
   EXPECT_GT(metadata2.size(), 0);
   EXPECT_EQ(metadata2.compressionType(), CompressionType::Uncompressed);

--- a/dwio/nimble/tablet/Constants.h
+++ b/dwio/nimble/tablet/Constants.h
@@ -18,7 +18,7 @@
 namespace facebook::nimble {
 
 constexpr uint16_t kMagicNumber = 0xA1FA;
-constexpr uint64_t kInitialFooterSize = 8 * 1024 * 1024; // 8Mb
+constexpr uint64_t kInitialFooterSize = 8 * 1024 * 1024; // 8MB
 constexpr uint16_t kVersionMajor = 0;
 constexpr uint16_t kVersionMinor = 1;
 
@@ -32,5 +32,6 @@ constexpr uint32_t kPostscriptChecksumedSize = 5;
 constexpr std::string_view kSchemaSection = "columnar.schema";
 constexpr std::string_view kMetadataSection = "columnar.metadata";
 constexpr std::string_view kStatsSection = "columnar.stats";
+constexpr std::string_view kIndexSection = "columnar.index";
 
 } // namespace facebook::nimble

--- a/dwio/nimble/tablet/Index.fbs
+++ b/dwio/nimble/tablet/Index.fbs
@@ -18,32 +18,61 @@ include "Footer.fbs";
 
 namespace facebook.nimble.serialization;
 
+/// Value index for key stream data within a stripe group.
+/// Contains stream-level and chunk-level metadata for key-based lookups.
 table StripeValueIndex {
+  /// Byte offset of key stream for each stripe (relative to file start).
   key_stream_offsets:[uint32];
+  /// Byte size of key stream for each stripe.
   key_stream_sizes:[uint32];
+  /// Accumulated chunk counts per stripe.
+  /// For stripe i: chunk count = key_stream_chunk_counts[i] - (i > 0 ? key_stream_chunk_counts[i-1] : 0)
   key_stream_chunk_counts:[uint32];
+  /// Accumulated row counts per chunk (prefix sum of row counts).
+  /// For chunk j: start row = (j > 0 ? key_stream_chunk_rows[j-1] : 0)
   key_stream_chunk_rows:[uint32];
-  key_stream_chunk_keys:[string];
+  /// Byte offset of each chunk within its key stream.
   key_stream_chunk_offsets:[uint32];
+  /// Last key value for each chunk, used for binary search during lookups.
+  key_stream_chunk_keys:[string];
 }
 
+/// Position index for stream data within a stripe group.
+/// Enables chunk-level seeking within streams based on row IDs.
 table StripePositionIndex {
+  /// Chunk count per (stripe, stream) pair, flattened in row-major order.
   stream_chunk_counts:[uint32];
+  /// Start index in the chunk arrays for each (stripe, stream) pair.
   stream_chunk_indexes:[uint32];
+  /// Accumulated row counts per chunk (prefix sum of row counts).
+  /// For chunk j: start row = (j > 0 ? stream_chunk_rows[j-1] : 0)
   stream_chunk_rows:[uint32];
+  /// Byte offset of each chunk within its stream.
   stream_chunk_offsets:[uint32];
 }
 
+/// Index data for a group of stripes.
+/// Contains both value index (for key-based lookups) and position index (for row-based seeking).
 table StripeIndexGroup {
-  stripe_count:uint32;
   value_index:StripeValueIndex;
   position_index:StripePositionIndex;
 }
 
+/// Root index table for the entire file.
+/// Stored in the optional sections of the footer.
 table Index {
+  /// Key boundaries for each stripe.
+  /// First element is the min key of the first stripe.
+  /// Subsequent elements are the max key of each stripe.
+  /// Size = stripe_count + 1
   stripe_keys:[string];
+  /// Names of columns used for indexing.
   index_columns:[string];
-  stripe_group_indices:[uint32];
+  /// Accumulated stripe counts per group (prefix sum).
+  /// For group i: stripe count = stripe_counts[i] - (i > 0 ? stripe_counts[i-1] : 0)
+  /// For group i: first stripe = (i > 0 ? stripe_counts[i-1] : 0)
+  stripe_counts:[uint32];
+  /// Metadata sections for each stripe index group.
   stripe_index_groups:[MetadataSection];
 }
 

--- a/dwio/nimble/tablet/MetadataBuffer.h
+++ b/dwio/nimble/tablet/MetadataBuffer.h
@@ -60,6 +60,11 @@ class Section {
     return content();
   }
 
+  /// Returns a reference to the underlying MetadataBuffer.
+  const MetadataBuffer& buffer() const {
+    return buffer_;
+  }
+
  private:
   MetadataBuffer buffer_;
 };

--- a/dwio/nimble/tablet/tests/MetadataBufferTest.cpp
+++ b/dwio/nimble/tablet/tests/MetadataBufferTest.cpp
@@ -179,6 +179,17 @@ TEST_F(MetadataBufferTest, sectionStringViewConversion) {
   EXPECT_EQ(content, kTestData);
 }
 
+TEST_F(MetadataBufferTest, sectionBuffer) {
+  nimble::MetadataBuffer buffer(
+      *pool_, kTestData, nimble::CompressionType::Uncompressed);
+
+  nimble::Section section{std::move(buffer)};
+
+  const nimble::MetadataBuffer& bufferRef = section.buffer();
+  EXPECT_EQ(bufferRef.content(), kTestData);
+  EXPECT_EQ(bufferRef.content(), section.content());
+}
+
 TEST_F(MetadataBufferTest, metadataSectionConstructor) {
   uint64_t offset = 100;
   uint32_t size = 200;


### PR DESCRIPTION
Summary:
Renamed stripe_group_indices to stripe_counts - now stores accumulated stripe counts per group (prefix sum) instead of per-stripe group membership
Removed stripe_count from StripeIndexGroup as it can now be derived from the root index
Added  documentation for all index tables explaining the accumulated/prefix sum semantics

StripeIndexGroup.cpp updates:
getStripeCount() now takes the root index and computes stripe count from accumulated stripe_counts: stripe_counts[i] - stripe_counts[i-1]
getFirstStripe() derives the first stripe index from accumulated counts: stripe_counts[i-1] (or 0 for first group)
getStreamCount() now accepts stripe count as parameter since it's no longer stored in StripeIndexGroup

Test updates:
Updated TabletIndexTestBase.cpp to generate accumulated stripe counts instead of per-stripe group indices

Benefits:
Efficient O(1) lookup for stripe count and first stripe per group
Reduced storage in StripeIndexGroup (no longer stores stripe_count) and RootIndex (now store the per group count instead of per stripe index)

Differential Revision: D89631931


