### PR TITLE
feat: Support cluster index in tablet reader and writer

### DIFF
--- a/dwio/nimble/tablet/tests/CMakeLists.txt
+++ b/dwio/nimble/tablet/tests/CMakeLists.txt
@@ -37,6 +37,8 @@ target_link_libraries(
   nimble_tablet_tests
   nimble_tablet_reader
   nimble_tablet_writer
+  nimble_index
+  nimble_index_test_utils
   nimble_common
   velox_dwio_common
   velox_memory

--- a/dwio/nimble/velox/VeloxWriterOptions.h
+++ b/dwio/nimble/velox/VeloxWriterOptions.h
@@ -18,6 +18,7 @@
 #include "dwio/nimble/common/MetricsLogger.h"
 #include "dwio/nimble/common/Types.h"
 #include "dwio/nimble/encodings/EncodingSelectionPolicy.h"
+#include "dwio/nimble/index/IndexConfig.h"
 #include "dwio/nimble/velox/BufferGrowthPolicy.h"
 #include "dwio/nimble/velox/EncodingLayoutTree.h"
 #include "dwio/nimble/velox/FlushPolicy.h"
@@ -40,6 +41,10 @@ struct VeloxWriterOptions {
   // Property bag for storing user metadata in the file.
   std::unordered_map<std::string, std::string> metadata =
       detail::defaultMetadata();
+
+  /// If set, the cluster index on the specified columns will be built during
+  /// writing. The index stores the per-chunk min and max key for each stripe.
+  std::optional<IndexConfig> indexConfig;
 
   // Columns that should be encoded as flat maps
   folly::F14FastSet<std::string> flatMapColumns;

--- a/dwio/nimble/velox/tests/CMakeLists.txt
+++ b/dwio/nimble/velox/tests/CMakeLists.txt
@@ -51,6 +51,7 @@ target_link_libraries(
   nimble_common
   nimble_encodings
   nimble_encodings_tests_utils
+  nimble_index_test_utils
   velox_key_encoder
   velox_vector
   velox_vector_fuzzer

--- a/dwio/nimble/velox/tests/IndexWriterTest.cpp
+++ b/dwio/nimble/velox/tests/IndexWriterTest.cpp
@@ -411,7 +411,8 @@ TEST_P(IndexWriterDataTest, indexChunkSizeControl) {
     size_t numInputRows;
     uint64_t minChunkRawSize;
     uint64_t maxChunkRawSize;
-    // Whether to use ensureFullChunks in encodeChunk calls.
+    // Whether to use ensureFullChunks in encodeChunk
+    // calls.dwio/nimble/tools/fb/feature_reaper/NimbleRewrite.cpp
     bool ensureFullChunks;
     // Expected total chunk count after all encoding.
     size_t expectedChunks;


### PR DESCRIPTION
Summary:
TabletWriter: Added indexConfig option, extended writeStripe() for KeyStream, integrated TabletIndexWriter, and made indexWriter_ a const member
TabletReader: Added TabletIndex and StripeIndexGroup integration, extended StripeIdentifier, implemented indexGroupCache_ with reference-counted caching, and added index preloading optimization
VeloxWriter: Extended options with IndexWriterOptions
Test Coverage: Tests for various scenarios (single/multiple groups, empty streams, stream deduplication)

Differential Revision: D89945792
