### PR TITLE
feat: Add index bounds setting in ScanSpec and some index code refactor

### DIFF
--- a/dwio/nimble/index/IndexConstants.h
+++ b/dwio/nimble/index/IndexConstants.h
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <cstdint>
+
+namespace facebook::nimble {
+
+// Placeholder stream ID for the key stream used in cluster index.
+// This is a reserved stream ID that should not be used by regular data streams.
+// The key stream contains encoded keys for efficient range-based filtering.
+constexpr uint32_t kKeyStreamId = UINT32_MAX;
+
+} // namespace facebook::nimble

--- a/dwio/nimble/index/StripeIndexGroup.h
+++ b/dwio/nimble/index/StripeIndexGroup.h
@@ -118,6 +118,11 @@ class StreamIndex {
   /// Returns chunk offset and size, or std::nullopt if not found
   std::optional<ChunkLocation> lookupChunk(uint32_t rowId) const;
 
+  /// Returns the stream ID this index is for
+  uint32_t streamId() const {
+    return streamId_;
+  }
+
  private:
   StreamIndex(
       const StripeIndexGroup* stripeIndexGroup,

--- a/dwio/nimble/index/tests/IndexConstantsTest.cpp
+++ b/dwio/nimble/index/tests/IndexConstantsTest.cpp
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <gtest/gtest.h>
+#include <limits>
+
+#include "dwio/nimble/index/IndexConstants.h"
+
+namespace facebook::nimble::index::test {
+
+TEST(IndexConstantsTest, kKeyStreamId) {
+  // kKeyStreamId should be UINT32_MAX to ensure it doesn't conflict with
+  // any real stream IDs.
+  EXPECT_EQ(kKeyStreamId, std::numeric_limits<uint32_t>::max());
+  EXPECT_EQ(kKeyStreamId, UINT32_MAX);
+}
+
+} // namespace facebook::nimble::index::test

--- a/dwio/nimble/index/tests/TabletIndexTestUtils.cpp
+++ b/dwio/nimble/index/tests/TabletIndexTestUtils.cpp
@@ -63,6 +63,11 @@ std::vector<Chunk> createChunks(
   return chunks;
 }
 
+Stream createStream(Buffer& buffer, const StreamSpec& spec) {
+  return Stream{
+      .offset = spec.offset, .chunks = createChunks(buffer, spec.chunks)};
+}
+
 KeyStreamStats StripeIndexGroupTestHelper::keyStreamStats() const {
   KeyStreamStats stats;
 

--- a/dwio/nimble/index/tests/TabletIndexTestUtils.h
+++ b/dwio/nimble/index/tests/TabletIndexTestUtils.h
@@ -120,6 +120,10 @@ std::vector<Chunk> createChunks(
     Buffer& buffer,
     const std::vector<ChunkSpec>& chunkSpecs);
 
+/// Creates a Stream with the specified test parameters.
+/// The buffer is used to store the chunk content.
+Stream createStream(Buffer& buffer, const StreamSpec& spec);
+
 /// Test helper class for StripeIndexGroup
 /// to private members for testing purposes. This is a friend class of
 /// StripeIndexGroup.

--- a/dwio/nimble/velox/IndexWriter.cpp
+++ b/dwio/nimble/velox/IndexWriter.cpp
@@ -15,8 +15,7 @@
  */
 #include "dwio/nimble/velox/IndexWriter.h"
 
-#include <limits>
-
+#include "dwio/nimble/index/IndexConstants.h"
 #include "dwio/nimble/velox/BufferGrowthPolicy.h"
 #include "dwio/nimble/velox/ChunkedStreamWriter.h"
 #include "dwio/nimble/velox/StreamChunker.h"
@@ -24,7 +23,7 @@
 namespace facebook::nimble::index {
 
 namespace {
-// The key stream uses a placeholder offset value (max offset_size) that does
+// The key stream uses a placeholder offset value (kKeyStreamId) that does
 // not correspond to any actual stream position. This offset is not used for
 // data retrieval but is required to conform to Nimble's stream typing
 // framework, which expects all streams to have an associated offset.
@@ -32,7 +31,7 @@ namespace {
 // ContentStreamData which stores a reference to the descriptor.
 const StreamDescriptorBuilder& keyStreamDescriptor() {
   static const StreamDescriptorBuilder descriptor{
-      std::numeric_limits<offset_size>::max(), ScalarKind::Binary};
+      kKeyStreamId, ScalarKind::Binary};
   return descriptor;
 }
 

--- a/dwio/nimble/velox/tests/CMakeLists.txt
+++ b/dwio/nimble/velox/tests/CMakeLists.txt
@@ -34,7 +34,7 @@ add_executable(
   StreamDataTest.cpp
   TypeTests.cpp
   VeloxReaderTests.cpp
-  VeloxWriterTests.cpp
+  VeloxWriterTest.cpp
   FieldWriterStatsTests.cpp
 )
 add_test(nimble_velox_tests nimble_velox_tests)


### PR DESCRIPTION
Summary:
This diff adds support for cluster index bounds filtering to ScanSpec and refactors some index-related code for better organization.

* ScanSpec IndexBounds Support (velox/dwio/common/ScanSpec.h):
  Added setIndexBounds() and indexBounds() methods to enable cluster index filtering on top-level columns
  The index bounds specify a range of values for index columns that can be used to skip stripes/rows during scanning
* Index Constants Refactoring (dwio/nimble/index/IndexConstants.h):
  Introduced new header file defining kKeyStreamId constant (UINT32_MAX) as a placeholder stream ID for cluster index key streams. This reserved ID ensures no conflicts with regular data streams
* StripeIndexGroup Enhancement (dwio/nimble/index/StripeIndexGroup.h):
 Added streamId() accessor method to StreamIndex class for retrieving the stream ID
* IndexWriter Cleanup (dwio/nimble/velox/IndexWriter.cpp):
  Refactored to use the new kKeyStreamId constant instead of inline std::numeric_limits<offset_size>::max()

Differential Revision: D89942683


