### PR TITLE
Add rowCount() method to StreamIndex for index-based skip validation

### DIFF
--- a/dwio/nimble/index/StripeIndexGroup.h
+++ b/dwio/nimble/index/StripeIndexGroup.h
@@ -72,6 +72,9 @@ class StripeIndexGroup {
       uint32_t stripe,
       uint32_t streamId) const;
 
+  /// Returns the total number of rows for the specified stripe and stream.
+  uint32_t rowCount(uint32_t stripe, uint32_t streamId) const;
+
   /// Returns the region for the key stream of the specified stripe.
   /// The key stream is stored in the StripeIndexGroup metadata.
   /// Returns std::nullopt if the stripe has no key stream.
@@ -117,6 +120,9 @@ class StreamIndex {
   /// Lookup chunk by row ID
   /// Returns chunk offset and size, or std::nullopt if not found
   std::optional<ChunkLocation> lookupChunk(uint32_t rowId) const;
+
+  /// Returns the total number of rows in this stream
+  uint32_t rowCount() const;
 
   /// Returns the stream ID this index is for
   uint32_t streamId() const {


### PR DESCRIPTION
Summary:
This diff adds a `rowCount()` method to `StreamIndex` and `StripeIndexGroup` to enable validation of skip operations when using stream indices.

1. **StripeIndexGroup.h**: Added `rowCount(uint32_t stripe, uint32_t streamId)` method to `StripeIndexGroup` and `rowCount()` method to `StreamIndex`.

2. **StripeIndexGroup.cpp**: Added implementations that retrieve the total row count for a stream by reading the last chunk's accumulated rows from `stream_chunk_rows`.

This method is useful for:
- Pre-validating skip operations to ensure target rows exist before seeking
- Avoiding unnecessary chunk loading when skipping to exact chunk boundaries
- Supporting the index-based skip optimization in `ChunkedDecoder::skipWithIndex()`

Differential Revision: D89973887


