### PR TITLE
feat: Add velox filter to index bounds conversion utility

### DIFF
--- a/dwio/nimble/index/CMakeLists.txt
+++ b/dwio/nimble/index/CMakeLists.txt
@@ -14,6 +14,7 @@
 add_library(
   nimble_index
   IndexConfig.cpp
+  IndexFilter.cpp
   IndexReader.cpp
   StripeIndexGroup.cpp
   TabletIndex.cpp

--- a/dwio/nimble/index/IndexFilter.cpp
+++ b/dwio/nimble/index/IndexFilter.cpp
@@ -1,0 +1,450 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "dwio/nimble/index/IndexFilter.h"
+
+#include "dwio/nimble/common/Exceptions.h"
+#include "velox/vector/FlatVector.h"
+
+namespace facebook::nimble {
+
+using namespace velox;
+using namespace velox::common;
+
+namespace {
+
+// Information extracted from a filter for building index bounds.
+struct FilterBoundInfo {
+  // Whether the filter is convertible to index bounds.
+  bool convertible{false};
+
+  // Whether this is a point lookup (lower == upper, both inclusive).
+  // Point lookups allow continuing to the next index column.
+  // Range scans must be the terminal column.
+  bool pointLookup{false};
+
+  // Whether the filter can be removed after applying index filtering.
+  bool canRemoveFilter{false};
+};
+
+// Check if a filter is convertible and whether it's a point lookup.
+FilterBoundInfo getFilterBoundInfo(const Filter& filter) {
+  FilterBoundInfo info;
+
+  switch (filter.kind()) {
+    case FilterKind::kBigintRange: {
+      if (filter.nullAllowed()) {
+        return info;
+      }
+      const auto& range = *filter.as<BigintRange>();
+      info.convertible = true;
+      info.pointLookup = range.isSingleValue();
+      info.canRemoveFilter = true;
+      break;
+    }
+
+    case FilterKind::kDoubleRange: {
+      if (filter.nullAllowed()) {
+        return info;
+      }
+      const auto& range = *filter.as<DoubleRange>();
+      if (range.lowerUnbounded() && range.upperUnbounded()) {
+        return info; // Not convertible
+      }
+      info.convertible = true;
+      // Point lookup: both bounds exist, equal, and both inclusive.
+      info.pointLookup = !range.lowerUnbounded() && !range.upperUnbounded() &&
+          range.lower() == range.upper() && !range.lowerExclusive() &&
+          !range.upperExclusive();
+      info.canRemoveFilter = true;
+      break;
+    }
+
+    case FilterKind::kFloatRange: {
+      if (filter.nullAllowed()) {
+        return info;
+      }
+      const auto& range = *filter.as<FloatRange>();
+      if (range.lowerUnbounded() && range.upperUnbounded()) {
+        return info; // Not convertible
+      }
+      info.convertible = true;
+      info.pointLookup = !range.lowerUnbounded() && !range.upperUnbounded() &&
+          range.lower() == range.upper() && !range.lowerExclusive() &&
+          !range.upperExclusive();
+      info.canRemoveFilter = true;
+      break;
+    }
+
+    case FilterKind::kBytesRange: {
+      if (filter.nullAllowed()) {
+        return info;
+      }
+      const auto& range = *filter.as<BytesRange>();
+      if (range.isLowerUnbounded() && range.isUpperUnbounded()) {
+        return info; // Not convertible
+      }
+      info.convertible = true;
+      info.pointLookup = range.isSingleValue();
+      info.canRemoveFilter = true;
+      break;
+    }
+
+    case FilterKind::kBytesValues: {
+      if (filter.nullAllowed()) {
+        return info;
+      }
+      const auto& values = filter.as<BytesValues>()->values();
+      // Only support single value for point lookup.
+      if (values.size() != 1) {
+        return info; // Not convertible
+      }
+      info.convertible = true;
+      info.pointLookup = true;
+      info.canRemoveFilter = true;
+      break;
+    }
+
+    case FilterKind::kBoolValue: {
+      if (filter.nullAllowed()) {
+        return info;
+      }
+      info.convertible = true;
+      info.pointLookup = true;
+      info.canRemoveFilter = true;
+      break;
+    }
+
+    case FilterKind::kTimestampRange: {
+      if (filter.nullAllowed()) {
+        return info;
+      }
+      const auto& range = *filter.as<TimestampRange>();
+      info.convertible = true;
+      info.pointLookup = range.isSingleValue();
+      info.canRemoveFilter = true;
+      break;
+    }
+
+    default:
+      // Unsupported filter type.
+      break;
+  }
+
+  return info;
+}
+
+// Set a value in a FlatVector at index 0.
+template <typename T>
+void setValue(FlatVector<T>* vector, T value) {
+  vector->set(0, value);
+}
+
+// Create bound vectors for a single column based on filter type.
+// Returns pair of (lowerVector, upperVector) and (lowerInclusive,
+// upperInclusive).
+// For DESC columns, lower and upper bounds are swapped to maintain correct
+// range semantics in a descending index.
+void addColumnBound(
+    const Filter& filter,
+    const std::string& columnName,
+    const TypePtr& columnType,
+    const core::SortOrder& sortOrder,
+    memory::MemoryPool* pool,
+    std::vector<std::string>& columnNames,
+    std::vector<TypePtr>& columnTypes,
+    std::vector<VectorPtr>& lowerVectors,
+    std::vector<VectorPtr>& upperVectors,
+    bool& lowerInclusive,
+    bool& upperInclusive) {
+  columnNames.push_back(columnName);
+  columnTypes.push_back(columnType);
+
+  const bool isDesc = !sortOrder.isAscending();
+
+  // Helper to add vectors considering sort order.
+  // For DESC columns, we swap lower and upper bounds.
+  const auto addVectors = [&](VectorPtr lower, VectorPtr upper) {
+    if (isDesc) {
+      lowerVectors.push_back(std::move(upper));
+      upperVectors.push_back(std::move(lower));
+    } else {
+      lowerVectors.push_back(std::move(lower));
+      upperVectors.push_back(std::move(upper));
+    }
+  };
+
+  switch (filter.kind()) {
+    case FilterKind::kBigintRange: {
+      const auto& range = *filter.as<BigintRange>();
+      auto lowerVector =
+          BaseVector::create<FlatVector<int64_t>>(columnType, 1, pool);
+      auto upperVector =
+          BaseVector::create<FlatVector<int64_t>>(columnType, 1, pool);
+      lowerVector->set(0, range.lower());
+      upperVector->set(0, range.upper());
+      addVectors(std::move(lowerVector), std::move(upperVector));
+      break;
+    }
+
+    case FilterKind::kDoubleRange: {
+      const auto& range = *filter.as<DoubleRange>();
+      auto lowerVector =
+          BaseVector::create<FlatVector<double>>(columnType, 1, pool);
+      auto upperVector =
+          BaseVector::create<FlatVector<double>>(columnType, 1, pool);
+      bool localLowerInclusive = true;
+      bool localUpperInclusive = true;
+      if (!range.lowerUnbounded()) {
+        lowerVector->set(0, range.lower());
+        localLowerInclusive = !range.lowerExclusive();
+      } else {
+        lowerVector->setNull(0, true);
+      }
+      if (!range.upperUnbounded()) {
+        upperVector->set(0, range.upper());
+        localUpperInclusive = !range.upperExclusive();
+      } else {
+        upperVector->setNull(0, true);
+      }
+      // For DESC, swap the inclusivity as well.
+      if (isDesc) {
+        lowerInclusive = lowerInclusive && localUpperInclusive;
+        upperInclusive = upperInclusive && localLowerInclusive;
+      } else {
+        lowerInclusive = lowerInclusive && localLowerInclusive;
+        upperInclusive = upperInclusive && localUpperInclusive;
+      }
+      addVectors(std::move(lowerVector), std::move(upperVector));
+      break;
+    }
+
+    case FilterKind::kFloatRange: {
+      const auto& range = *filter.as<FloatRange>();
+      auto lowerVector =
+          BaseVector::create<FlatVector<float>>(columnType, 1, pool);
+      auto upperVector =
+          BaseVector::create<FlatVector<float>>(columnType, 1, pool);
+      bool localLowerInclusive = true;
+      bool localUpperInclusive = true;
+      if (!range.lowerUnbounded()) {
+        lowerVector->set(0, static_cast<float>(range.lower()));
+        localLowerInclusive = !range.lowerExclusive();
+      } else {
+        lowerVector->setNull(0, true);
+      }
+      if (!range.upperUnbounded()) {
+        upperVector->set(0, static_cast<float>(range.upper()));
+        localUpperInclusive = !range.upperExclusive();
+      } else {
+        upperVector->setNull(0, true);
+      }
+      if (isDesc) {
+        lowerInclusive = lowerInclusive && localUpperInclusive;
+        upperInclusive = upperInclusive && localLowerInclusive;
+      } else {
+        lowerInclusive = lowerInclusive && localLowerInclusive;
+        upperInclusive = upperInclusive && localUpperInclusive;
+      }
+      addVectors(std::move(lowerVector), std::move(upperVector));
+      break;
+    }
+
+    case FilterKind::kBytesRange: {
+      const auto& range = *filter.as<BytesRange>();
+      auto lowerVector =
+          BaseVector::create<FlatVector<StringView>>(columnType, 1, pool);
+      auto upperVector =
+          BaseVector::create<FlatVector<StringView>>(columnType, 1, pool);
+      bool localLowerInclusive = true;
+      bool localUpperInclusive = true;
+      if (!range.isLowerUnbounded()) {
+        lowerVector->set(0, StringView(range.lower()));
+        localLowerInclusive = !range.isLowerExclusive();
+      } else {
+        lowerVector->setNull(0, true);
+      }
+      if (!range.isUpperUnbounded()) {
+        upperVector->set(0, StringView(range.upper()));
+        localUpperInclusive = !range.isUpperExclusive();
+      } else {
+        upperVector->setNull(0, true);
+      }
+      if (isDesc) {
+        lowerInclusive = lowerInclusive && localUpperInclusive;
+        upperInclusive = upperInclusive && localLowerInclusive;
+      } else {
+        lowerInclusive = lowerInclusive && localLowerInclusive;
+        upperInclusive = upperInclusive && localUpperInclusive;
+      }
+      addVectors(std::move(lowerVector), std::move(upperVector));
+      break;
+    }
+
+    case FilterKind::kBytesValues: {
+      const auto& values = filter.as<BytesValues>()->values();
+      const auto& value = *values.begin();
+      auto lowerVector =
+          BaseVector::create<FlatVector<StringView>>(columnType, 1, pool);
+      auto upperVector =
+          BaseVector::create<FlatVector<StringView>>(columnType, 1, pool);
+      lowerVector->set(0, StringView(value));
+      upperVector->set(0, StringView(value));
+      // Point lookup - no need to swap for DESC.
+      addVectors(std::move(lowerVector), std::move(upperVector));
+      break;
+    }
+
+    case FilterKind::kBoolValue: {
+      const auto& boolFilter = *filter.as<BoolValue>();
+      const bool value = boolFilter.testBool(true);
+      auto lowerVector =
+          BaseVector::create<FlatVector<bool>>(columnType, 1, pool);
+      auto upperVector =
+          BaseVector::create<FlatVector<bool>>(columnType, 1, pool);
+      lowerVector->set(0, value);
+      upperVector->set(0, value);
+      // Point lookup - no need to swap for DESC.
+      addVectors(std::move(lowerVector), std::move(upperVector));
+      break;
+    }
+
+    case FilterKind::kTimestampRange: {
+      const auto& range = *filter.as<TimestampRange>();
+      auto lowerVector =
+          BaseVector::create<FlatVector<Timestamp>>(columnType, 1, pool);
+      auto upperVector =
+          BaseVector::create<FlatVector<Timestamp>>(columnType, 1, pool);
+      lowerVector->set(0, range.lower());
+      upperVector->set(0, range.upper());
+      addVectors(std::move(lowerVector), std::move(upperVector));
+      break;
+    }
+
+    default:
+      NIMBLE_UNREACHABLE(
+          "Unsupported filter kind: {}", static_cast<int>(filter.kind()));
+  }
+}
+
+} // namespace
+
+std::optional<serializer::IndexBounds> convertFilterToIndexBounds(
+    const std::vector<std::string>& indexColumns,
+    const std::vector<core::SortOrder>& sortOrders,
+    const RowTypePtr& rowType,
+    ScanSpec& scanSpec,
+    memory::MemoryPool* pool) {
+  NIMBLE_CHECK(!indexColumns.empty(), "Index columns cannot be empty");
+  NIMBLE_CHECK_EQ(
+      indexColumns.size(),
+      sortOrders.size(),
+      "Index columns size must match sort orders size");
+
+  std::vector<std::string> boundColumnNames;
+  std::vector<TypePtr> boundColumnTypes;
+  std::vector<VectorPtr> lowerVectors;
+  std::vector<VectorPtr> upperVectors;
+  bool lowerInclusive{true};
+  bool upperInclusive{true};
+
+  for (size_t i = 0; i < indexColumns.size(); ++i) {
+    const auto& columnName = indexColumns[i];
+    const auto& sortOrder = sortOrders[i];
+
+    // Find the ScanSpec child for this column.
+    auto* childSpec = scanSpec.childByName(columnName);
+    if (childSpec == nullptr) {
+      break;
+    }
+
+    const auto* filter = childSpec->filter();
+    if (filter == nullptr) {
+      break;
+    }
+
+    // Check if the filter is convertible.
+    const auto boundInfo = getFilterBoundInfo(*filter);
+    if (!boundInfo.convertible) {
+      break;
+    }
+
+    // Get column type.
+    const auto columnIdx = rowType->getChildIdxIfExists(columnName);
+    NIMBLE_CHECK(
+        columnIdx.has_value(),
+        "Index column '{}' not found in row type",
+        columnName);
+    const auto& columnType = rowType->childAt(columnIdx.value());
+
+    // Add bounds for this column.
+    addColumnBound(
+        *filter,
+        columnName,
+        columnType,
+        sortOrder,
+        pool,
+        boundColumnNames,
+        boundColumnTypes,
+        lowerVectors,
+        upperVectors,
+        lowerInclusive,
+        upperInclusive);
+
+    // If this is a range scan (not point lookup), we must stop here.
+    // Cannot add more columns after a range scan.
+    if (!boundInfo.pointLookup) {
+      break;
+    }
+  }
+
+  // If no columns were added, return empty result.
+  if (boundColumnNames.empty()) {
+    return std::nullopt;
+  }
+
+  // Remove filters from scanSpec for columns that are covered by index bounds.
+  for (const auto& columnName : boundColumnNames) {
+    auto* childSpec = scanSpec.childByName(columnName);
+    if (childSpec != nullptr) {
+      childSpec->setFilter(nullptr);
+    }
+  }
+
+  // Build the IndexBounds.
+  serializer::IndexBounds bounds;
+  bounds.indexColumns = std::move(boundColumnNames);
+
+  // Create RowVectors for lower and upper bounds.
+  auto boundRowType =
+      ROW(std::vector<std::string>(bounds.indexColumns),
+          std::move(boundColumnTypes));
+
+  auto lowerRowVector = std::make_shared<RowVector>(
+      pool, boundRowType, nullptr, 1, std::move(lowerVectors));
+
+  auto upperRowVector = std::make_shared<RowVector>(
+      pool, boundRowType, nullptr, 1, std::move(upperVectors));
+
+  bounds.lowerBound =
+      serializer::IndexBound{std::move(lowerRowVector), lowerInclusive};
+  bounds.upperBound =
+      serializer::IndexBound{std::move(upperRowVector), upperInclusive};
+
+  return bounds;
+}
+
+} // namespace facebook::nimble

--- a/dwio/nimble/index/IndexFilter.h
+++ b/dwio/nimble/index/IndexFilter.h
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <optional>
+#include <vector>
+
+#include "velox/common/memory/MemoryPool.h"
+#include "velox/core/PlanNode.h"
+#include "velox/dwio/common/ScanSpec.h"
+#include "velox/serializers/KeyEncoder.h"
+#include "velox/type/Filter.h"
+#include "velox/type/Type.h"
+
+namespace facebook::nimble {
+
+/// Converts filters from ScanSpec to IndexBounds for index-based filtering.
+///
+/// This utility examines the ScanSpec and index column names to extract filters
+/// that can be converted to IndexBounds for efficient index-based pruning.
+/// Filters that are fully captured by the index bounds are removed from the
+/// ScanSpec directly.
+///
+/// IMPORTANT: The index columns provided can be a prefix of the file's index
+/// columns. For example, if the file has index columns [A, B, C], you can pass
+/// [A] or [A, B] to create bounds for prefix scans. The filters must still form
+/// a prefix of the provided index columns.
+///
+/// For example, with provided index columns [A, B, C]:
+/// - Filter on A only: valid, creates bounds for A
+/// - Filters on A and B: valid, creates bounds for A and B
+/// - Filters on A, B, and C: valid, creates bounds for all
+/// - Filter on B only: invalid, cannot skip A (returns empty)
+/// - Filters on A and C: creates bounds for A only (stops at missing B)
+///
+/// Sort Order Handling:
+/// For DESC columns, the bounds are inverted when creating index bounds:
+/// - Filter "x >= 10" on DESC column becomes upper bound (values decrease)
+/// - Filter "x <= 100" on DESC column becomes lower bound (values decrease)
+/// This ensures correct range scanning regardless of column sort order.
+///
+/// Supported filter types:
+/// - kBigintRange: Integer range filters (e.g., x >= 10 AND x <= 100)
+/// - kDoubleRange: Double range filters
+/// - kFloatRange: Float range filters
+/// - kBytesRange: String/bytes range filters
+/// - kBytesValues: String/bytes values filter (single value only)
+/// - kBoolValue: Boolean filters
+/// - kTimestampRange: Timestamp range filters
+///
+/// @param indexColumns Ordered list of index column names. Can be a prefix of
+///        the file's index columns. Must be in index definition order.
+/// @param sortOrders Sort order for each index column. Must have the same size
+///        as indexColumns.
+/// @param rowType The row type containing column type information.
+/// @param scanSpec The ScanSpec containing column filters. Filters that are
+///        fully captured by the index bounds will be removed from this
+///        ScanSpec.
+/// @param pool Memory pool for allocations.
+/// @return The converted IndexBounds if filters can be converted, std::nullopt
+///         otherwise.
+std::optional<velox::serializer::IndexBounds> convertFilterToIndexBounds(
+    const std::vector<std::string>& indexColumns,
+    const std::vector<velox::core::SortOrder>& sortOrders,
+    const velox::RowTypePtr& rowType,
+    velox::common::ScanSpec& scanSpec,
+    velox::memory::MemoryPool* pool);
+
+} // namespace facebook::nimble

--- a/dwio/nimble/index/tests/CMakeLists.txt
+++ b/dwio/nimble/index/tests/CMakeLists.txt
@@ -35,6 +35,8 @@ target_link_libraries(
 
 add_executable(
   nimble_index_tests
+  IndexConstantsTest.cpp
+  IndexFilterTest.cpp
   IndexReaderTest.cpp
   StripeIndexGroupTest.cpp
   TabletIndexTest.cpp

--- a/dwio/nimble/index/tests/IndexFilterTest.cpp
+++ b/dwio/nimble/index/tests/IndexFilterTest.cpp
@@ -1,0 +1,1589 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <gtest/gtest.h>
+
+#include "dwio/nimble/common/Exceptions.h"
+#include "dwio/nimble/common/tests/GTestUtils.h"
+#include "dwio/nimble/index/IndexFilter.h"
+#include "velox/common/memory/Memory.h"
+#include "velox/core/PlanNode.h"
+#include "velox/dwio/common/ScanSpec.h"
+#include "velox/type/Filter.h"
+#include "velox/vector/FlatVector.h"
+
+namespace facebook::nimble::index::test {
+
+using namespace velox;
+using namespace velox::common;
+
+class IndexFilterTestBase : public ::testing::Test {
+ protected:
+  static void SetUpTestCase() {
+    memory::MemoryManager::initialize({});
+  }
+
+  void SetUp() override {
+    pool_ = memory::memoryManager()->addLeafPool("IndexFilterTest");
+  }
+
+  std::unique_ptr<ScanSpec> createScanSpec(
+      const RowTypePtr& rowType,
+      const std::unordered_map<std::string, std::unique_ptr<Filter>>& filters) {
+    auto scanSpec = std::make_unique<ScanSpec>("root");
+    for (size_t i = 0; i < rowType->size(); ++i) {
+      auto* childSpec = scanSpec->addField(
+          rowType->nameOf(i), static_cast<column_index_t>(i));
+      auto it = filters.find(rowType->nameOf(i));
+      if (it != filters.end()) {
+        childSpec->setFilter(it->second->clone());
+      }
+    }
+    return scanSpec;
+  }
+
+  template <typename T>
+  void verifyBound(
+      const RowVectorPtr& bound,
+      const std::string& columnName,
+      T expectedValue) {
+    const auto& rowType = bound->type()->asRow();
+    auto idx = rowType.getChildIdx(columnName);
+    auto* flatVector = bound->childAt(idx)->as<FlatVector<T>>();
+    ASSERT_NE(flatVector, nullptr);
+    EXPECT_EQ(flatVector->valueAt(0), expectedValue);
+  }
+
+  void verifyNullBound(
+      const RowVectorPtr& bound,
+      const std::string& columnName) {
+    const auto& rowType = bound->type()->asRow();
+    auto idx = rowType.getChildIdx(columnName);
+    EXPECT_TRUE(bound->childAt(idx)->isNullAt(0));
+  }
+
+  std::shared_ptr<memory::MemoryPool> pool_;
+};
+
+class IndexFilterTest : public IndexFilterTestBase {};
+
+TEST_F(IndexFilterTest, basic) {
+  auto rowType = ROW({"a", "b"}, {BIGINT(), BIGINT()});
+
+  {
+    // Empty index columns.
+    std::unordered_map<std::string, std::unique_ptr<Filter>> filters;
+    filters["a"] = std::make_unique<BigintRange>(10, 20, false);
+    auto scanSpec = createScanSpec(rowType, filters);
+
+    NIMBLE_ASSERT_THROW(
+        convertFilterToIndexBounds({}, {}, rowType, *scanSpec, pool_.get()),
+        "Index columns cannot be empty");
+  }
+
+  {
+    // Index columns size mismatch with sort orders size.
+    std::unordered_map<std::string, std::unique_ptr<Filter>> filters;
+    filters["a"] = std::make_unique<BigintRange>(10, 20, false);
+    auto scanSpec = createScanSpec(rowType, filters);
+
+    NIMBLE_ASSERT_THROW(
+        convertFilterToIndexBounds(
+            {"a", "b"},
+            {core::kAscNullsFirst},
+            rowType,
+            *scanSpec,
+            pool_.get()),
+        "Index columns size must match sort orders size");
+  }
+
+  {
+    // Index column not in rowType - returns nullopt since there's no filter.
+    std::unordered_map<std::string, std::unique_ptr<Filter>> filters;
+    filters["a"] = std::make_unique<BigintRange>(10, 20, false);
+    auto scanSpec = createScanSpec(rowType, filters);
+
+    auto result = convertFilterToIndexBounds(
+        {"nonexistent"},
+        {core::kAscNullsFirst},
+        rowType,
+        *scanSpec,
+        pool_.get());
+    EXPECT_FALSE(result.has_value());
+  }
+}
+
+TEST_F(IndexFilterTest, noMatchingFilter) {
+  auto rowType = ROW({"a", "b"}, {BIGINT(), BIGINT()});
+
+  {
+    // No filter on index column "a".
+    std::unordered_map<std::string, std::unique_ptr<Filter>> filters;
+    filters["b"] = std::make_unique<BigintRange>(10, 20, false);
+    auto scanSpec = createScanSpec(rowType, filters);
+
+    auto result = convertFilterToIndexBounds(
+        {"a"}, {core::kAscNullsFirst}, rowType, *scanSpec, pool_.get());
+    EXPECT_FALSE(result.has_value());
+    // Filter on "b" should still be set.
+    EXPECT_NE(scanSpec->childByName("b")->filter(), nullptr);
+  }
+
+  {
+    // Unsupported filter type: IsNull.
+    std::unordered_map<std::string, std::unique_ptr<Filter>> filters;
+    filters["a"] = std::make_unique<IsNull>();
+    auto scanSpec = createScanSpec(rowType, filters);
+
+    auto result = convertFilterToIndexBounds(
+        {"a"}, {core::kAscNullsFirst}, rowType, *scanSpec, pool_.get());
+    EXPECT_FALSE(result.has_value());
+    EXPECT_NE(scanSpec->childByName("a")->filter(), nullptr);
+  }
+
+  {
+    // Unsupported filter type: IsNotNull.
+    std::unordered_map<std::string, std::unique_ptr<Filter>> filters;
+    filters["a"] = std::make_unique<IsNotNull>();
+    auto scanSpec = createScanSpec(rowType, filters);
+
+    auto result = convertFilterToIndexBounds(
+        {"a"}, {core::kAscNullsFirst}, rowType, *scanSpec, pool_.get());
+    EXPECT_FALSE(result.has_value());
+    EXPECT_NE(scanSpec->childByName("a")->filter(), nullptr);
+  }
+
+  {
+    // Unsupported filter type: BigintValuesUsingHashTable.
+    std::unordered_map<std::string, std::unique_ptr<Filter>> filters;
+    // Use values with large spread to force hash table instead of bitmask.
+    filters["a"] = common::createBigintValues({1, 1000, 10000, 100000}, false);
+    auto scanSpec = createScanSpec(rowType, filters);
+
+    auto result = convertFilterToIndexBounds(
+        {"a"}, {core::kAscNullsFirst}, rowType, *scanSpec, pool_.get());
+    EXPECT_FALSE(result.has_value());
+    EXPECT_NE(scanSpec->childByName("a")->filter(), nullptr);
+  }
+
+  {
+    // Unsupported filter type: NegatedBigintRange.
+    std::unordered_map<std::string, std::unique_ptr<Filter>> filters;
+    filters["a"] = std::make_unique<NegatedBigintRange>(10, 20, false);
+    auto scanSpec = createScanSpec(rowType, filters);
+
+    auto result = convertFilterToIndexBounds(
+        {"a"}, {core::kAscNullsFirst}, rowType, *scanSpec, pool_.get());
+    EXPECT_FALSE(result.has_value());
+    EXPECT_NE(scanSpec->childByName("a")->filter(), nullptr);
+  }
+
+  {
+    // Filter allows nulls - should not be convertible.
+    std::unordered_map<std::string, std::unique_ptr<Filter>> filters;
+    filters["a"] = std::make_unique<BigintRange>(10, 100, true);
+    auto scanSpec = createScanSpec(rowType, filters);
+
+    auto result = convertFilterToIndexBounds(
+        {"a"}, {core::kAscNullsFirst}, rowType, *scanSpec, pool_.get());
+    EXPECT_FALSE(result.has_value());
+    EXPECT_NE(scanSpec->childByName("a")->filter(), nullptr);
+  }
+
+  {
+    // Gap in filter chain: filter on "a" and "c", but not "b".
+    // Extraction stops at missing filter on "b", so only "a" is converted.
+    auto threeColRowType = ROW({"a", "b", "c"}, {BIGINT(), BIGINT(), BIGINT()});
+    std::unordered_map<std::string, std::unique_ptr<Filter>> filters;
+    filters["a"] = std::make_unique<BigintRange>(42, 42, false);
+    filters["c"] = std::make_unique<BigintRange>(100, 100, false);
+    auto scanSpec = createScanSpec(threeColRowType, filters);
+
+    auto result = convertFilterToIndexBounds(
+        {"a", "b", "c"},
+        {core::kAscNullsFirst, core::kAscNullsFirst, core::kAscNullsFirst},
+        threeColRowType,
+        *scanSpec,
+        pool_.get());
+    ASSERT_TRUE(result.has_value());
+
+    const auto& bounds = result.value();
+    // Only "a" should be included - stops at missing filter on "b".
+    EXPECT_EQ(bounds.indexColumns.size(), 1);
+    EXPECT_EQ(bounds.indexColumns[0], "a");
+
+    verifyBound<int64_t>(bounds.lowerBound->bound, "a", 42);
+    verifyBound<int64_t>(bounds.upperBound->bound, "a", 42);
+
+    // Filter on "a" removed, but "c" should still have filter since it wasn't
+    // converted (due to gap at "b").
+    EXPECT_EQ(scanSpec->childByName("a")->filter(), nullptr);
+    EXPECT_NE(scanSpec->childByName("c")->filter(), nullptr);
+  }
+}
+
+TEST_F(IndexFilterTest, sortOrder) {
+  // Test with different sort orders for different index columns.
+  // Point lookup on first two columns, range on third - all three columns
+  // should be included in the index bounds.
+  // Loop over the last column's sort order (ASC or DESC).
+  auto rowType = ROW({"a", "b", "c"}, {BIGINT(), BIGINT(), BIGINT()});
+
+  std::vector<core::SortOrder> sortOrdersToTest = {
+      core::kAscNullsFirst, core::kDescNullsFirst};
+  for (const auto& lastColSortOrder : sortOrdersToTest) {
+    SCOPED_TRACE(
+        fmt::format(
+            "lastColSortOrder: {}",
+            lastColSortOrder.isAscending() ? "ASC" : "DESC"));
+
+    std::unordered_map<std::string, std::unique_ptr<Filter>> filters;
+    filters["a"] = std::make_unique<BigintRange>(42, 42, false);
+    filters["b"] = std::make_unique<BigintRange>(100, 100, false);
+    filters["c"] = std::make_unique<BigintRange>(10, 20, false);
+    auto scanSpec = createScanSpec(rowType, filters);
+
+    // Mixed sort orders: asc, desc, and lastColSortOrder for "c".
+    auto result = convertFilterToIndexBounds(
+        {"a", "b", "c"},
+        {core::kAscNullsFirst, core::kDescNullsFirst, lastColSortOrder},
+        rowType,
+        *scanSpec,
+        pool_.get());
+    ASSERT_TRUE(result.has_value());
+
+    const auto& bounds = result.value();
+    // All three columns should be included: point lookup on "a" and "b",
+    // range on "c".
+    EXPECT_EQ(bounds.indexColumns.size(), 3);
+    EXPECT_EQ(bounds.indexColumns[0], "a");
+    EXPECT_EQ(bounds.indexColumns[1], "b");
+    EXPECT_EQ(bounds.indexColumns[2], "c");
+
+    // Point lookup on "a": same value for both bounds.
+    verifyBound<int64_t>(bounds.lowerBound->bound, "a", 42);
+    verifyBound<int64_t>(bounds.upperBound->bound, "a", 42);
+    // Point lookup on "b": same value for both bounds.
+    verifyBound<int64_t>(bounds.lowerBound->bound, "b", 100);
+    verifyBound<int64_t>(bounds.upperBound->bound, "b", 100);
+    // Range on "c": bounds swapped for descending sort order.
+    if (lastColSortOrder.isAscending()) {
+      verifyBound<int64_t>(bounds.lowerBound->bound, "c", 10);
+      verifyBound<int64_t>(bounds.upperBound->bound, "c", 20);
+    } else {
+      verifyBound<int64_t>(bounds.lowerBound->bound, "c", 20);
+      verifyBound<int64_t>(bounds.upperBound->bound, "c", 10);
+    }
+
+    // All filters should be removed from scanSpec.
+    EXPECT_EQ(scanSpec->childByName("a")->filter(), nullptr);
+    EXPECT_EQ(scanSpec->childByName("b")->filter(), nullptr);
+    EXPECT_EQ(scanSpec->childByName("c")->filter(), nullptr);
+  }
+}
+
+class IndexFilterTestWithSortOrder
+    : public IndexFilterTestBase,
+      public ::testing::WithParamInterface<core::SortOrder> {
+ protected:
+  core::SortOrder sortOrder() const {
+    return GetParam();
+  }
+
+  std::vector<core::SortOrder> sortOrders(size_t count) const {
+    return std::vector<core::SortOrder>(count, sortOrder());
+  }
+
+  bool isAscending() const {
+    return sortOrder().isAscending();
+  }
+
+  // For range filters, lower/upper bounds are swapped for descending sort.
+  template <typename T>
+  void verifyRangeBounds(
+      const velox::serializer::IndexBounds& bounds,
+      const std::string& columnName,
+      T lower,
+      T upper) {
+    if (isAscending()) {
+      verifyBound<T>(bounds.lowerBound->bound, columnName, lower);
+      verifyBound<T>(bounds.upperBound->bound, columnName, upper);
+    } else {
+      verifyBound<T>(bounds.lowerBound->bound, columnName, upper);
+      verifyBound<T>(bounds.upperBound->bound, columnName, lower);
+    }
+  }
+};
+
+TEST_P(IndexFilterTestWithSortOrder, bigintFilter) {
+  const auto rowType = ROW({"a", "b"}, {BIGINT(), BIGINT()});
+
+  {
+    // Prefix point lookup: single column point lookup on the first column.
+    std::unordered_map<std::string, std::unique_ptr<Filter>> filters;
+    filters["a"] = std::make_unique<BigintRange>(42, 42, false);
+    auto scanSpec = createScanSpec(rowType, filters);
+
+    auto result = convertFilterToIndexBounds(
+        {"a"}, sortOrders(1), rowType, *scanSpec, pool_.get());
+    ASSERT_TRUE(result.has_value());
+
+    const auto& bounds = result.value();
+    EXPECT_EQ(bounds.indexColumns, std::vector<std::string>{"a"});
+    ASSERT_TRUE(bounds.lowerBound.has_value());
+    ASSERT_TRUE(bounds.upperBound.has_value());
+    EXPECT_TRUE(bounds.lowerBound->inclusive);
+    EXPECT_TRUE(bounds.upperBound->inclusive);
+
+    // Point lookup: both bounds have same value regardless of sort order.
+    verifyBound<int64_t>(bounds.lowerBound->bound, "a", 42);
+    verifyBound<int64_t>(bounds.upperBound->bound, "a", 42);
+
+    // Filter should be removed from scanSpec.
+    EXPECT_EQ(scanSpec->childByName("a")->filter(), nullptr);
+  }
+
+  {
+    // Prefix range: range filter on the first index column only.
+    std::unordered_map<std::string, std::unique_ptr<Filter>> filters;
+    filters["a"] = std::make_unique<BigintRange>(10, 100, false);
+    auto scanSpec = createScanSpec(rowType, filters);
+
+    auto result = convertFilterToIndexBounds(
+        {"a"}, sortOrders(1), rowType, *scanSpec, pool_.get());
+    ASSERT_TRUE(result.has_value());
+
+    const auto& bounds = result.value();
+    EXPECT_EQ(bounds.indexColumns, std::vector<std::string>{"a"});
+    ASSERT_TRUE(bounds.lowerBound.has_value());
+    ASSERT_TRUE(bounds.upperBound.has_value());
+    EXPECT_TRUE(bounds.lowerBound->inclusive);
+    EXPECT_TRUE(bounds.upperBound->inclusive);
+
+    verifyRangeBounds<int64_t>(bounds, "a", 10, 100);
+
+    // Filter should be removed from scanSpec.
+    EXPECT_EQ(scanSpec->childByName("a")->filter(), nullptr);
+  }
+
+  {
+    // Point lookup + range: point lookup on first column, range on second,
+    // spanning two index columns.
+    std::unordered_map<std::string, std::unique_ptr<Filter>> filters;
+    filters["a"] = std::make_unique<BigintRange>(42, 42, false);
+    filters["b"] = std::make_unique<BigintRange>(10, 100, false);
+    auto scanSpec = createScanSpec(rowType, filters);
+
+    auto result = convertFilterToIndexBounds(
+        {"a", "b"}, sortOrders(2), rowType, *scanSpec, pool_.get());
+    ASSERT_TRUE(result.has_value());
+
+    const auto& bounds = result.value();
+    EXPECT_EQ(bounds.indexColumns.size(), 2);
+    EXPECT_EQ(bounds.indexColumns[0], "a");
+    EXPECT_EQ(bounds.indexColumns[1], "b");
+
+    // Point lookup on "a": same value regardless of sort order.
+    verifyBound<int64_t>(bounds.lowerBound->bound, "a", 42);
+    verifyBound<int64_t>(bounds.upperBound->bound, "a", 42);
+    // Range on "b": bounds swapped for descending sort.
+    verifyRangeBounds<int64_t>(bounds, "b", 10, 100);
+
+    // Both filters should be removed from scanSpec.
+    EXPECT_EQ(scanSpec->childByName("a")->filter(), nullptr);
+    EXPECT_EQ(scanSpec->childByName("b")->filter(), nullptr);
+  }
+
+  {
+    // Range + range: range filter on the first column stops extraction,
+    // so only the first column is converted, not the second.
+    std::unordered_map<std::string, std::unique_ptr<Filter>> filters;
+    filters["a"] = std::make_unique<BigintRange>(10, 100, false);
+    filters["b"] = std::make_unique<BigintRange>(200, 300, false);
+    auto scanSpec = createScanSpec(rowType, filters);
+
+    auto result = convertFilterToIndexBounds(
+        {"a", "b"}, sortOrders(2), rowType, *scanSpec, pool_.get());
+    ASSERT_TRUE(result.has_value());
+
+    const auto& bounds = result.value();
+    // Only column "a" should be included because it's a range scan.
+    // The range filter stops extraction from including subsequent columns.
+    EXPECT_EQ(bounds.indexColumns.size(), 1);
+    EXPECT_EQ(bounds.indexColumns[0], "a");
+
+    verifyRangeBounds<int64_t>(bounds, "a", 10, 100);
+
+    // Filter on "a" removed, but "b" should still have filter since it wasn't
+    // converted.
+    EXPECT_EQ(scanSpec->childByName("a")->filter(), nullptr);
+    EXPECT_NE(scanSpec->childByName("b")->filter(), nullptr);
+  }
+
+  {
+    // Point lookup + point lookup: point lookups on both index columns.
+    // Both columns should be included since point lookups allow extraction to
+    // continue.
+    std::unordered_map<std::string, std::unique_ptr<Filter>> filters;
+    filters["a"] = std::make_unique<BigintRange>(42, 42, false);
+    filters["b"] = std::make_unique<BigintRange>(100, 100, false);
+    auto scanSpec = createScanSpec(rowType, filters);
+
+    auto result = convertFilterToIndexBounds(
+        {"a", "b"}, sortOrders(2), rowType, *scanSpec, pool_.get());
+    ASSERT_TRUE(result.has_value());
+
+    const auto& bounds = result.value();
+    EXPECT_EQ(bounds.indexColumns.size(), 2);
+    EXPECT_EQ(bounds.indexColumns[0], "a");
+    EXPECT_EQ(bounds.indexColumns[1], "b");
+
+    // Point lookups: same value for both bounds regardless of sort order.
+    verifyBound<int64_t>(bounds.lowerBound->bound, "a", 42);
+    verifyBound<int64_t>(bounds.upperBound->bound, "a", 42);
+    verifyBound<int64_t>(bounds.lowerBound->bound, "b", 100);
+    verifyBound<int64_t>(bounds.upperBound->bound, "b", 100);
+
+    // Both filters should be removed from scanSpec.
+    EXPECT_EQ(scanSpec->childByName("a")->filter(), nullptr);
+    EXPECT_EQ(scanSpec->childByName("b")->filter(), nullptr);
+  }
+}
+
+TEST_P(IndexFilterTestWithSortOrder, doubleFilter) {
+  const auto rowType = ROW({"a", "b"}, {DOUBLE(), DOUBLE()});
+
+  {
+    // Prefix point lookup: single column point lookup on the first column.
+    std::unordered_map<std::string, std::unique_ptr<Filter>> filters;
+    filters["a"] = std::make_unique<DoubleRange>(
+        1.5, false, false, 1.5, false, false, false);
+    auto scanSpec = createScanSpec(rowType, filters);
+
+    auto result = convertFilterToIndexBounds(
+        {"a"}, sortOrders(1), rowType, *scanSpec, pool_.get());
+    ASSERT_TRUE(result.has_value());
+
+    const auto& bounds = result.value();
+    EXPECT_EQ(bounds.indexColumns, std::vector<std::string>{"a"});
+    ASSERT_TRUE(bounds.lowerBound.has_value());
+    ASSERT_TRUE(bounds.upperBound.has_value());
+    EXPECT_TRUE(bounds.lowerBound->inclusive);
+    EXPECT_TRUE(bounds.upperBound->inclusive);
+
+    // Point lookup: both bounds have same value regardless of sort order.
+    verifyBound<double>(bounds.lowerBound->bound, "a", 1.5);
+    verifyBound<double>(bounds.upperBound->bound, "a", 1.5);
+
+    // Filter should be removed from scanSpec.
+    EXPECT_EQ(scanSpec->childByName("a")->filter(), nullptr);
+  }
+
+  {
+    // Prefix range: range filter on the first index column only.
+    std::unordered_map<std::string, std::unique_ptr<Filter>> filters;
+    filters["a"] = std::make_unique<DoubleRange>(
+        1.5, false, false, 10.5, false, false, false);
+    auto scanSpec = createScanSpec(rowType, filters);
+
+    auto result = convertFilterToIndexBounds(
+        {"a"}, sortOrders(1), rowType, *scanSpec, pool_.get());
+    ASSERT_TRUE(result.has_value());
+
+    const auto& bounds = result.value();
+    EXPECT_EQ(bounds.indexColumns, std::vector<std::string>{"a"});
+    ASSERT_TRUE(bounds.lowerBound.has_value());
+    ASSERT_TRUE(bounds.upperBound.has_value());
+    EXPECT_TRUE(bounds.lowerBound->inclusive);
+    EXPECT_TRUE(bounds.upperBound->inclusive);
+
+    verifyRangeBounds<double>(bounds, "a", 1.5, 10.5);
+
+    // Filter should be removed from scanSpec.
+    EXPECT_EQ(scanSpec->childByName("a")->filter(), nullptr);
+  }
+
+  {
+    // Point lookup + range: point lookup on first column, range on second,
+    // spanning two index columns.
+    std::unordered_map<std::string, std::unique_ptr<Filter>> filters;
+    filters["a"] = std::make_unique<DoubleRange>(
+        1.5, false, false, 1.5, false, false, false);
+    filters["b"] = std::make_unique<DoubleRange>(
+        10.5, false, false, 100.5, false, false, false);
+    auto scanSpec = createScanSpec(rowType, filters);
+
+    auto result = convertFilterToIndexBounds(
+        {"a", "b"}, sortOrders(2), rowType, *scanSpec, pool_.get());
+    ASSERT_TRUE(result.has_value());
+
+    const auto& bounds = result.value();
+    EXPECT_EQ(bounds.indexColumns.size(), 2);
+    EXPECT_EQ(bounds.indexColumns[0], "a");
+    EXPECT_EQ(bounds.indexColumns[1], "b");
+
+    // Point lookup on "a": same value regardless of sort order.
+    verifyBound<double>(bounds.lowerBound->bound, "a", 1.5);
+    verifyBound<double>(bounds.upperBound->bound, "a", 1.5);
+    // Range on "b": bounds swapped for descending sort.
+    verifyRangeBounds<double>(bounds, "b", 10.5, 100.5);
+
+    // Both filters should be removed from scanSpec.
+    EXPECT_EQ(scanSpec->childByName("a")->filter(), nullptr);
+    EXPECT_EQ(scanSpec->childByName("b")->filter(), nullptr);
+  }
+
+  {
+    // Range + range: range filter on the first column stops extraction,
+    // so only the first column is converted, not the second.
+    std::unordered_map<std::string, std::unique_ptr<Filter>> filters;
+    filters["a"] = std::make_unique<DoubleRange>(
+        1.5, false, false, 10.5, false, false, false);
+    filters["b"] = std::make_unique<DoubleRange>(
+        20.5, false, false, 30.5, false, false, false);
+    auto scanSpec = createScanSpec(rowType, filters);
+
+    auto result = convertFilterToIndexBounds(
+        {"a", "b"}, sortOrders(2), rowType, *scanSpec, pool_.get());
+    ASSERT_TRUE(result.has_value());
+
+    const auto& bounds = result.value();
+    // Only column "a" should be included because it's a range scan.
+    // The range filter stops extraction from including subsequent columns.
+    EXPECT_EQ(bounds.indexColumns.size(), 1);
+    EXPECT_EQ(bounds.indexColumns[0], "a");
+
+    verifyRangeBounds<double>(bounds, "a", 1.5, 10.5);
+
+    // Filter on "a" removed, but "b" should still have filter since it wasn't
+    // converted.
+    EXPECT_EQ(scanSpec->childByName("a")->filter(), nullptr);
+    EXPECT_NE(scanSpec->childByName("b")->filter(), nullptr);
+  }
+
+  {
+    // Point lookup + point lookup: point lookups on both index columns.
+    // Both columns should be included since point lookups allow extraction to
+    // continue.
+    std::unordered_map<std::string, std::unique_ptr<Filter>> filters;
+    filters["a"] = std::make_unique<DoubleRange>(
+        1.5, false, false, 1.5, false, false, false);
+    filters["b"] = std::make_unique<DoubleRange>(
+        10.5, false, false, 10.5, false, false, false);
+    auto scanSpec = createScanSpec(rowType, filters);
+
+    auto result = convertFilterToIndexBounds(
+        {"a", "b"}, sortOrders(2), rowType, *scanSpec, pool_.get());
+    ASSERT_TRUE(result.has_value());
+
+    const auto& bounds = result.value();
+    EXPECT_EQ(bounds.indexColumns.size(), 2);
+    EXPECT_EQ(bounds.indexColumns[0], "a");
+    EXPECT_EQ(bounds.indexColumns[1], "b");
+
+    // Point lookups: same value for both bounds regardless of sort order.
+    verifyBound<double>(bounds.lowerBound->bound, "a", 1.5);
+    verifyBound<double>(bounds.upperBound->bound, "a", 1.5);
+    verifyBound<double>(bounds.lowerBound->bound, "b", 10.5);
+    verifyBound<double>(bounds.upperBound->bound, "b", 10.5);
+
+    // Both filters should be removed from scanSpec.
+    EXPECT_EQ(scanSpec->childByName("a")->filter(), nullptr);
+    EXPECT_EQ(scanSpec->childByName("b")->filter(), nullptr);
+  }
+
+  {
+    // Exclusive bounds.
+    auto singleColRowType = ROW({"a"}, {DOUBLE()});
+    std::unordered_map<std::string, std::unique_ptr<Filter>> filters;
+    filters["a"] = std::make_unique<DoubleRange>(
+        1.5, false, true, 10.5, false, true, false);
+    auto scanSpec = createScanSpec(singleColRowType, filters);
+
+    auto result = convertFilterToIndexBounds(
+        {"a"}, sortOrders(1), singleColRowType, *scanSpec, pool_.get());
+    ASSERT_TRUE(result.has_value());
+
+    const auto& bounds = result.value();
+    EXPECT_FALSE(bounds.lowerBound->inclusive);
+    EXPECT_FALSE(bounds.upperBound->inclusive);
+    verifyRangeBounds<double>(bounds, "a", 1.5, 10.5);
+  }
+
+  {
+    // Lower unbounded: -inf to 10.5 (inclusive).
+    auto singleColRowType = ROW({"a"}, {DOUBLE()});
+    std::unordered_map<std::string, std::unique_ptr<Filter>> filters;
+    filters["a"] = std::make_unique<DoubleRange>(
+        std::numeric_limits<double>::lowest(),
+        true,
+        false,
+        10.5,
+        false,
+        false,
+        false);
+    auto scanSpec = createScanSpec(singleColRowType, filters);
+
+    auto result = convertFilterToIndexBounds(
+        {"a"}, sortOrders(1), singleColRowType, *scanSpec, pool_.get());
+    ASSERT_TRUE(result.has_value());
+
+    const auto& bounds = result.value();
+    if (isAscending()) {
+      verifyNullBound(bounds.lowerBound->bound, "a");
+      verifyBound<double>(bounds.upperBound->bound, "a", 10.5);
+    } else {
+      verifyBound<double>(bounds.lowerBound->bound, "a", 10.5);
+      verifyNullBound(bounds.upperBound->bound, "a");
+    }
+  }
+
+  {
+    // Upper unbounded: 1.5 (inclusive) to +inf.
+    auto singleColRowType = ROW({"a"}, {DOUBLE()});
+    std::unordered_map<std::string, std::unique_ptr<Filter>> filters;
+    filters["a"] = std::make_unique<DoubleRange>(
+        1.5,
+        false,
+        false,
+        std::numeric_limits<double>::max(),
+        true,
+        false,
+        false);
+    auto scanSpec = createScanSpec(singleColRowType, filters);
+
+    auto result = convertFilterToIndexBounds(
+        {"a"}, sortOrders(1), singleColRowType, *scanSpec, pool_.get());
+    ASSERT_TRUE(result.has_value());
+
+    const auto& bounds = result.value();
+    if (isAscending()) {
+      verifyBound<double>(bounds.lowerBound->bound, "a", 1.5);
+      verifyNullBound(bounds.upperBound->bound, "a");
+    } else {
+      verifyNullBound(bounds.lowerBound->bound, "a");
+      verifyBound<double>(bounds.upperBound->bound, "a", 1.5);
+    }
+  }
+}
+
+TEST_P(IndexFilterTestWithSortOrder, floatFilter) {
+  const auto rowType = ROW({"a", "b"}, {REAL(), REAL()});
+
+  {
+    // Prefix point lookup: single column point lookup on the first column.
+    std::unordered_map<std::string, std::unique_ptr<Filter>> filters;
+    filters["a"] = std::make_unique<FloatRange>(
+        1.5f, false, false, 1.5f, false, false, false);
+    auto scanSpec = createScanSpec(rowType, filters);
+
+    auto result = convertFilterToIndexBounds(
+        {"a"}, sortOrders(1), rowType, *scanSpec, pool_.get());
+    ASSERT_TRUE(result.has_value());
+
+    const auto& bounds = result.value();
+    EXPECT_EQ(bounds.indexColumns, std::vector<std::string>{"a"});
+    ASSERT_TRUE(bounds.lowerBound.has_value());
+    ASSERT_TRUE(bounds.upperBound.has_value());
+    EXPECT_TRUE(bounds.lowerBound->inclusive);
+    EXPECT_TRUE(bounds.upperBound->inclusive);
+
+    // Point lookup: both bounds have same value regardless of sort order.
+    verifyBound<float>(bounds.lowerBound->bound, "a", 1.5f);
+    verifyBound<float>(bounds.upperBound->bound, "a", 1.5f);
+
+    // Filter should be removed from scanSpec.
+    EXPECT_EQ(scanSpec->childByName("a")->filter(), nullptr);
+  }
+
+  {
+    // Prefix range: range filter on the first index column only.
+    std::unordered_map<std::string, std::unique_ptr<Filter>> filters;
+    filters["a"] = std::make_unique<FloatRange>(
+        1.5f, false, false, 10.5f, false, false, false);
+    auto scanSpec = createScanSpec(rowType, filters);
+
+    auto result = convertFilterToIndexBounds(
+        {"a"}, sortOrders(1), rowType, *scanSpec, pool_.get());
+    ASSERT_TRUE(result.has_value());
+
+    const auto& bounds = result.value();
+    EXPECT_EQ(bounds.indexColumns, std::vector<std::string>{"a"});
+    ASSERT_TRUE(bounds.lowerBound.has_value());
+    ASSERT_TRUE(bounds.upperBound.has_value());
+    EXPECT_TRUE(bounds.lowerBound->inclusive);
+    EXPECT_TRUE(bounds.upperBound->inclusive);
+
+    verifyRangeBounds<float>(bounds, "a", 1.5f, 10.5f);
+
+    // Filter should be removed from scanSpec.
+    EXPECT_EQ(scanSpec->childByName("a")->filter(), nullptr);
+  }
+
+  {
+    // Point lookup + range: point lookup on first column, range on second,
+    // spanning two index columns.
+    std::unordered_map<std::string, std::unique_ptr<Filter>> filters;
+    filters["a"] = std::make_unique<FloatRange>(
+        1.5f, false, false, 1.5f, false, false, false);
+    filters["b"] = std::make_unique<FloatRange>(
+        10.5f, false, false, 100.5f, false, false, false);
+    auto scanSpec = createScanSpec(rowType, filters);
+
+    auto result = convertFilterToIndexBounds(
+        {"a", "b"}, sortOrders(2), rowType, *scanSpec, pool_.get());
+    ASSERT_TRUE(result.has_value());
+
+    const auto& bounds = result.value();
+    EXPECT_EQ(bounds.indexColumns.size(), 2);
+    EXPECT_EQ(bounds.indexColumns[0], "a");
+    EXPECT_EQ(bounds.indexColumns[1], "b");
+
+    // Point lookup on "a": same value regardless of sort order.
+    verifyBound<float>(bounds.lowerBound->bound, "a", 1.5f);
+    verifyBound<float>(bounds.upperBound->bound, "a", 1.5f);
+    // Range on "b": bounds swapped for descending sort.
+    verifyRangeBounds<float>(bounds, "b", 10.5f, 100.5f);
+
+    // Both filters should be removed from scanSpec.
+    EXPECT_EQ(scanSpec->childByName("a")->filter(), nullptr);
+    EXPECT_EQ(scanSpec->childByName("b")->filter(), nullptr);
+  }
+
+  {
+    // Range + range: range filter on the first column stops extraction,
+    // so only the first column is converted, not the second.
+    std::unordered_map<std::string, std::unique_ptr<Filter>> filters;
+    filters["a"] = std::make_unique<FloatRange>(
+        1.5f, false, false, 10.5f, false, false, false);
+    filters["b"] = std::make_unique<FloatRange>(
+        20.5f, false, false, 30.5f, false, false, false);
+    auto scanSpec = createScanSpec(rowType, filters);
+
+    auto result = convertFilterToIndexBounds(
+        {"a", "b"}, sortOrders(2), rowType, *scanSpec, pool_.get());
+    ASSERT_TRUE(result.has_value());
+
+    const auto& bounds = result.value();
+    // Only column "a" should be included because it's a range scan.
+    // The range filter stops extraction from including subsequent columns.
+    EXPECT_EQ(bounds.indexColumns.size(), 1);
+    EXPECT_EQ(bounds.indexColumns[0], "a");
+
+    verifyRangeBounds<float>(bounds, "a", 1.5f, 10.5f);
+
+    // Filter on "a" removed, but "b" should still have filter since it wasn't
+    // converted.
+    EXPECT_EQ(scanSpec->childByName("a")->filter(), nullptr);
+    EXPECT_NE(scanSpec->childByName("b")->filter(), nullptr);
+  }
+
+  {
+    // Point lookup + point lookup: point lookups on both index columns.
+    // Both columns should be included since point lookups allow extraction to
+    // continue.
+    std::unordered_map<std::string, std::unique_ptr<Filter>> filters;
+    filters["a"] = std::make_unique<FloatRange>(
+        1.5f, false, false, 1.5f, false, false, false);
+    filters["b"] = std::make_unique<FloatRange>(
+        10.5f, false, false, 10.5f, false, false, false);
+    auto scanSpec = createScanSpec(rowType, filters);
+
+    auto result = convertFilterToIndexBounds(
+        {"a", "b"}, sortOrders(2), rowType, *scanSpec, pool_.get());
+    ASSERT_TRUE(result.has_value());
+
+    const auto& bounds = result.value();
+    EXPECT_EQ(bounds.indexColumns.size(), 2);
+    EXPECT_EQ(bounds.indexColumns[0], "a");
+    EXPECT_EQ(bounds.indexColumns[1], "b");
+
+    // Point lookups: same value for both bounds regardless of sort order.
+    verifyBound<float>(bounds.lowerBound->bound, "a", 1.5f);
+    verifyBound<float>(bounds.upperBound->bound, "a", 1.5f);
+    verifyBound<float>(bounds.lowerBound->bound, "b", 10.5f);
+    verifyBound<float>(bounds.upperBound->bound, "b", 10.5f);
+
+    // Both filters should be removed from scanSpec.
+    EXPECT_EQ(scanSpec->childByName("a")->filter(), nullptr);
+    EXPECT_EQ(scanSpec->childByName("b")->filter(), nullptr);
+  }
+
+  {
+    // Exclusive bounds.
+    auto singleColRowType = ROW({"a"}, {REAL()});
+    std::unordered_map<std::string, std::unique_ptr<Filter>> filters;
+    filters["a"] = std::make_unique<FloatRange>(
+        1.5f, false, true, 10.5f, false, true, false);
+    auto scanSpec = createScanSpec(singleColRowType, filters);
+
+    auto result = convertFilterToIndexBounds(
+        {"a"}, sortOrders(1), singleColRowType, *scanSpec, pool_.get());
+    ASSERT_TRUE(result.has_value());
+
+    const auto& bounds = result.value();
+    EXPECT_FALSE(bounds.lowerBound->inclusive);
+    EXPECT_FALSE(bounds.upperBound->inclusive);
+    verifyRangeBounds<float>(bounds, "a", 1.5f, 10.5f);
+  }
+
+  {
+    // Lower unbounded: -inf to 10.5 (inclusive).
+    auto singleColRowType = ROW({"a"}, {REAL()});
+    std::unordered_map<std::string, std::unique_ptr<Filter>> filters;
+    filters["a"] = std::make_unique<FloatRange>(
+        std::numeric_limits<float>::lowest(),
+        true,
+        false,
+        10.5f,
+        false,
+        false,
+        false);
+    auto scanSpec = createScanSpec(singleColRowType, filters);
+
+    auto result = convertFilterToIndexBounds(
+        {"a"}, sortOrders(1), singleColRowType, *scanSpec, pool_.get());
+    ASSERT_TRUE(result.has_value());
+
+    const auto& bounds = result.value();
+    if (isAscending()) {
+      verifyNullBound(bounds.lowerBound->bound, "a");
+      verifyBound<float>(bounds.upperBound->bound, "a", 10.5f);
+    } else {
+      verifyBound<float>(bounds.lowerBound->bound, "a", 10.5f);
+      verifyNullBound(bounds.upperBound->bound, "a");
+    }
+  }
+
+  {
+    // Upper unbounded: 1.5 (inclusive) to +inf.
+    auto singleColRowType = ROW({"a"}, {REAL()});
+    std::unordered_map<std::string, std::unique_ptr<Filter>> filters;
+    filters["a"] = std::make_unique<FloatRange>(
+        1.5f,
+        false,
+        false,
+        std::numeric_limits<float>::max(),
+        true,
+        false,
+        false);
+    auto scanSpec = createScanSpec(singleColRowType, filters);
+
+    auto result = convertFilterToIndexBounds(
+        {"a"}, sortOrders(1), singleColRowType, *scanSpec, pool_.get());
+    ASSERT_TRUE(result.has_value());
+
+    const auto& bounds = result.value();
+    if (isAscending()) {
+      verifyBound<float>(bounds.lowerBound->bound, "a", 1.5f);
+      verifyNullBound(bounds.upperBound->bound, "a");
+    } else {
+      verifyNullBound(bounds.lowerBound->bound, "a");
+      verifyBound<float>(bounds.upperBound->bound, "a", 1.5f);
+    }
+  }
+}
+
+TEST_P(IndexFilterTestWithSortOrder, bytesFilter) {
+  const auto rowType = ROW({"a", "b"}, {VARCHAR(), VARCHAR()});
+
+  {
+    // Prefix point lookup using BytesValues with single value.
+    std::unordered_map<std::string, std::unique_ptr<Filter>> filters;
+    filters["a"] =
+        std::make_unique<BytesValues>(std::vector<std::string>{"hello"}, false);
+    auto scanSpec = createScanSpec(rowType, filters);
+
+    auto result = convertFilterToIndexBounds(
+        {"a"}, sortOrders(1), rowType, *scanSpec, pool_.get());
+    ASSERT_TRUE(result.has_value());
+
+    const auto& bounds = result.value();
+    EXPECT_EQ(bounds.indexColumns, std::vector<std::string>{"a"});
+    ASSERT_TRUE(bounds.lowerBound.has_value());
+    ASSERT_TRUE(bounds.upperBound.has_value());
+    EXPECT_TRUE(bounds.lowerBound->inclusive);
+    EXPECT_TRUE(bounds.upperBound->inclusive);
+
+    // Point lookup: both bounds have same value regardless of sort order.
+    verifyBound<StringView>(bounds.lowerBound->bound, "a", StringView("hello"));
+    verifyBound<StringView>(bounds.upperBound->bound, "a", StringView("hello"));
+
+    // Filter should be removed from scanSpec.
+    EXPECT_EQ(scanSpec->childByName("a")->filter(), nullptr);
+  }
+
+  {
+    // Prefix point lookup using BytesRange with same lower and upper.
+    std::unordered_map<std::string, std::unique_ptr<Filter>> filters;
+    filters["a"] = std::make_unique<BytesRange>(
+        "hello", false, false, "hello", false, false, false);
+    auto scanSpec = createScanSpec(rowType, filters);
+
+    auto result = convertFilterToIndexBounds(
+        {"a"}, sortOrders(1), rowType, *scanSpec, pool_.get());
+    ASSERT_TRUE(result.has_value());
+
+    const auto& bounds = result.value();
+    EXPECT_EQ(bounds.indexColumns, std::vector<std::string>{"a"});
+
+    // Point lookup: both bounds have same value regardless of sort order.
+    verifyBound<StringView>(bounds.lowerBound->bound, "a", StringView("hello"));
+    verifyBound<StringView>(bounds.upperBound->bound, "a", StringView("hello"));
+
+    // Filter should be removed from scanSpec.
+    EXPECT_EQ(scanSpec->childByName("a")->filter(), nullptr);
+  }
+
+  {
+    // Prefix range: range filter on the first index column only.
+    std::unordered_map<std::string, std::unique_ptr<Filter>> filters;
+    filters["a"] = std::make_unique<BytesRange>(
+        "abc", false, false, "xyz", false, false, false);
+    auto scanSpec = createScanSpec(rowType, filters);
+
+    auto result = convertFilterToIndexBounds(
+        {"a"}, sortOrders(1), rowType, *scanSpec, pool_.get());
+    ASSERT_TRUE(result.has_value());
+
+    const auto& bounds = result.value();
+    EXPECT_EQ(bounds.indexColumns, std::vector<std::string>{"a"});
+    ASSERT_TRUE(bounds.lowerBound.has_value());
+    ASSERT_TRUE(bounds.upperBound.has_value());
+    EXPECT_TRUE(bounds.lowerBound->inclusive);
+    EXPECT_TRUE(bounds.upperBound->inclusive);
+
+    verifyRangeBounds<StringView>(
+        bounds, "a", StringView("abc"), StringView("xyz"));
+
+    // Filter should be removed from scanSpec.
+    EXPECT_EQ(scanSpec->childByName("a")->filter(), nullptr);
+  }
+
+  {
+    // Point lookup + range: point lookup on first column (BytesValues),
+    // range on second (BytesRange), spanning two index columns.
+    std::unordered_map<std::string, std::unique_ptr<Filter>> filters;
+    filters["a"] =
+        std::make_unique<BytesValues>(std::vector<std::string>{"hello"}, false);
+    filters["b"] = std::make_unique<BytesRange>(
+        "abc", false, false, "xyz", false, false, false);
+    auto scanSpec = createScanSpec(rowType, filters);
+
+    auto result = convertFilterToIndexBounds(
+        {"a", "b"}, sortOrders(2), rowType, *scanSpec, pool_.get());
+    ASSERT_TRUE(result.has_value());
+
+    const auto& bounds = result.value();
+    EXPECT_EQ(bounds.indexColumns.size(), 2);
+    EXPECT_EQ(bounds.indexColumns[0], "a");
+    EXPECT_EQ(bounds.indexColumns[1], "b");
+
+    // Point lookup on "a": same value regardless of sort order.
+    verifyBound<StringView>(bounds.lowerBound->bound, "a", StringView("hello"));
+    verifyBound<StringView>(bounds.upperBound->bound, "a", StringView("hello"));
+    // Range on "b": bounds swapped for descending sort.
+    verifyRangeBounds<StringView>(
+        bounds, "b", StringView("abc"), StringView("xyz"));
+
+    // Both filters should be removed from scanSpec.
+    EXPECT_EQ(scanSpec->childByName("a")->filter(), nullptr);
+    EXPECT_EQ(scanSpec->childByName("b")->filter(), nullptr);
+  }
+
+  {
+    // Range + range: range filter on the first column stops extraction,
+    // so only the first column is converted, not the second.
+    std::unordered_map<std::string, std::unique_ptr<Filter>> filters;
+    filters["a"] = std::make_unique<BytesRange>(
+        "aaa", false, false, "bbb", false, false, false);
+    filters["b"] = std::make_unique<BytesRange>(
+        "ccc", false, false, "ddd", false, false, false);
+    auto scanSpec = createScanSpec(rowType, filters);
+
+    auto result = convertFilterToIndexBounds(
+        {"a", "b"}, sortOrders(2), rowType, *scanSpec, pool_.get());
+    ASSERT_TRUE(result.has_value());
+
+    const auto& bounds = result.value();
+    // Only column "a" should be included because it's a range scan.
+    // The range filter stops extraction from including subsequent columns.
+    EXPECT_EQ(bounds.indexColumns.size(), 1);
+    EXPECT_EQ(bounds.indexColumns[0], "a");
+
+    verifyRangeBounds<StringView>(
+        bounds, "a", StringView("aaa"), StringView("bbb"));
+
+    // Filter on "a" removed, but "b" should still have filter since it wasn't
+    // converted.
+    EXPECT_EQ(scanSpec->childByName("a")->filter(), nullptr);
+    EXPECT_NE(scanSpec->childByName("b")->filter(), nullptr);
+  }
+
+  {
+    // Point lookup + point lookup: point lookups on both index columns.
+    // Both columns should be included since point lookups allow extraction to
+    // continue.
+    std::unordered_map<std::string, std::unique_ptr<Filter>> filters;
+    filters["a"] =
+        std::make_unique<BytesValues>(std::vector<std::string>{"hello"}, false);
+    filters["b"] =
+        std::make_unique<BytesValues>(std::vector<std::string>{"world"}, false);
+    auto scanSpec = createScanSpec(rowType, filters);
+
+    auto result = convertFilterToIndexBounds(
+        {"a", "b"}, sortOrders(2), rowType, *scanSpec, pool_.get());
+    ASSERT_TRUE(result.has_value());
+
+    const auto& bounds = result.value();
+    EXPECT_EQ(bounds.indexColumns.size(), 2);
+    EXPECT_EQ(bounds.indexColumns[0], "a");
+    EXPECT_EQ(bounds.indexColumns[1], "b");
+
+    // Point lookups: same value for both bounds regardless of sort order.
+    verifyBound<StringView>(bounds.lowerBound->bound, "a", StringView("hello"));
+    verifyBound<StringView>(bounds.upperBound->bound, "a", StringView("hello"));
+    verifyBound<StringView>(bounds.lowerBound->bound, "b", StringView("world"));
+    verifyBound<StringView>(bounds.upperBound->bound, "b", StringView("world"));
+
+    // Both filters should be removed from scanSpec.
+    EXPECT_EQ(scanSpec->childByName("a")->filter(), nullptr);
+    EXPECT_EQ(scanSpec->childByName("b")->filter(), nullptr);
+  }
+
+  {
+    // Exclusive bounds.
+    auto singleColRowType = ROW({"a"}, {VARCHAR()});
+    std::unordered_map<std::string, std::unique_ptr<Filter>> filters;
+    filters["a"] = std::make_unique<BytesRange>(
+        "abc", false, true, "xyz", false, true, false);
+    auto scanSpec = createScanSpec(singleColRowType, filters);
+
+    auto result = convertFilterToIndexBounds(
+        {"a"}, sortOrders(1), singleColRowType, *scanSpec, pool_.get());
+    ASSERT_TRUE(result.has_value());
+
+    const auto& bounds = result.value();
+    EXPECT_FALSE(bounds.lowerBound->inclusive);
+    EXPECT_FALSE(bounds.upperBound->inclusive);
+    verifyRangeBounds<StringView>(
+        bounds, "a", StringView("abc"), StringView("xyz"));
+  }
+
+  {
+    // Lower unbounded: empty string to "xyz" (inclusive).
+    auto singleColRowType = ROW({"a"}, {VARCHAR()});
+    std::unordered_map<std::string, std::unique_ptr<Filter>> filters;
+    filters["a"] = std::make_unique<BytesRange>(
+        "", true, false, "xyz", false, false, false);
+    auto scanSpec = createScanSpec(singleColRowType, filters);
+
+    auto result = convertFilterToIndexBounds(
+        {"a"}, sortOrders(1), singleColRowType, *scanSpec, pool_.get());
+    ASSERT_TRUE(result.has_value());
+
+    const auto& bounds = result.value();
+    if (isAscending()) {
+      verifyNullBound(bounds.lowerBound->bound, "a");
+      verifyBound<StringView>(bounds.upperBound->bound, "a", StringView("xyz"));
+    } else {
+      verifyBound<StringView>(bounds.lowerBound->bound, "a", StringView("xyz"));
+      verifyNullBound(bounds.upperBound->bound, "a");
+    }
+  }
+
+  {
+    // Upper unbounded: "abc" (inclusive) to unbounded.
+    auto singleColRowType = ROW({"a"}, {VARCHAR()});
+    std::unordered_map<std::string, std::unique_ptr<Filter>> filters;
+    filters["a"] = std::make_unique<BytesRange>(
+        "abc", false, false, "", true, false, false);
+    auto scanSpec = createScanSpec(singleColRowType, filters);
+
+    auto result = convertFilterToIndexBounds(
+        {"a"}, sortOrders(1), singleColRowType, *scanSpec, pool_.get());
+    ASSERT_TRUE(result.has_value());
+
+    const auto& bounds = result.value();
+    if (isAscending()) {
+      verifyBound<StringView>(bounds.lowerBound->bound, "a", StringView("abc"));
+      verifyNullBound(bounds.upperBound->bound, "a");
+    } else {
+      verifyNullBound(bounds.lowerBound->bound, "a");
+      verifyBound<StringView>(bounds.upperBound->bound, "a", StringView("abc"));
+    }
+  }
+
+  {
+    // BytesValues with multiple values - should not be convertible.
+    auto singleColRowType = ROW({"a"}, {VARCHAR()});
+    std::unordered_map<std::string, std::unique_ptr<Filter>> filters;
+    filters["a"] = std::make_unique<BytesValues>(
+        std::vector<std::string>{"hello", "world"}, false);
+    auto scanSpec = createScanSpec(singleColRowType, filters);
+
+    auto result = convertFilterToIndexBounds(
+        {"a"}, sortOrders(1), singleColRowType, *scanSpec, pool_.get());
+    EXPECT_FALSE(result.has_value());
+  }
+}
+
+TEST_P(IndexFilterTestWithSortOrder, boolValueFilter) {
+  {
+    // Single column point lookup.
+    auto rowType = ROW({"a"}, {BOOLEAN()});
+
+    for (bool value : {true, false}) {
+      SCOPED_TRACE(fmt::format("BoolValue: {}", value));
+
+      std::unordered_map<std::string, std::unique_ptr<Filter>> filters;
+      filters["a"] = std::make_unique<BoolValue>(value, false);
+      auto scanSpec = createScanSpec(rowType, filters);
+
+      auto result = convertFilterToIndexBounds(
+          {"a"}, sortOrders(1), rowType, *scanSpec, pool_.get());
+      ASSERT_TRUE(result.has_value());
+
+      const auto& bounds = result.value();
+      verifyBound<bool>(bounds.lowerBound->bound, "a", value);
+      verifyBound<bool>(bounds.upperBound->bound, "a", value);
+    }
+  }
+
+  {
+    // Point lookup + point lookup: point lookups on both index columns.
+    // Both columns should be included since point lookups allow extraction to
+    // continue.
+    auto rowType = ROW({"a", "b"}, {BOOLEAN(), BOOLEAN()});
+
+    std::unordered_map<std::string, std::unique_ptr<Filter>> filters;
+    filters["a"] = std::make_unique<BoolValue>(true, false);
+    filters["b"] = std::make_unique<BoolValue>(false, false);
+    auto scanSpec = createScanSpec(rowType, filters);
+
+    auto result = convertFilterToIndexBounds(
+        {"a", "b"}, sortOrders(2), rowType, *scanSpec, pool_.get());
+    ASSERT_TRUE(result.has_value());
+
+    const auto& bounds = result.value();
+    EXPECT_EQ(bounds.indexColumns.size(), 2);
+    EXPECT_EQ(bounds.indexColumns[0], "a");
+    EXPECT_EQ(bounds.indexColumns[1], "b");
+
+    // Point lookups: same value for both bounds regardless of sort order.
+    verifyBound<bool>(bounds.lowerBound->bound, "a", true);
+    verifyBound<bool>(bounds.upperBound->bound, "a", true);
+    verifyBound<bool>(bounds.lowerBound->bound, "b", false);
+    verifyBound<bool>(bounds.upperBound->bound, "b", false);
+
+    // Both filters should be removed from scanSpec.
+    EXPECT_EQ(scanSpec->childByName("a")->filter(), nullptr);
+    EXPECT_EQ(scanSpec->childByName("b")->filter(), nullptr);
+  }
+
+  {
+    // Point lookup (bigint) + point lookup (bool): mixed types, both point
+    // lookups so both columns should be included.
+    auto rowType = ROW({"a", "b"}, {BIGINT(), BOOLEAN()});
+
+    std::unordered_map<std::string, std::unique_ptr<Filter>> filters;
+    filters["a"] = std::make_unique<BigintRange>(42, 42, false);
+    filters["b"] = std::make_unique<BoolValue>(true, false);
+    auto scanSpec = createScanSpec(rowType, filters);
+
+    auto result = convertFilterToIndexBounds(
+        {"a", "b"}, sortOrders(2), rowType, *scanSpec, pool_.get());
+    ASSERT_TRUE(result.has_value());
+
+    const auto& bounds = result.value();
+    EXPECT_EQ(bounds.indexColumns.size(), 2);
+    EXPECT_EQ(bounds.indexColumns[0], "a");
+    EXPECT_EQ(bounds.indexColumns[1], "b");
+
+    // Point lookups: same value for both bounds regardless of sort order.
+    verifyBound<int64_t>(bounds.lowerBound->bound, "a", 42);
+    verifyBound<int64_t>(bounds.upperBound->bound, "a", 42);
+    verifyBound<bool>(bounds.lowerBound->bound, "b", true);
+    verifyBound<bool>(bounds.upperBound->bound, "b", true);
+
+    // Both filters should be removed from scanSpec.
+    EXPECT_EQ(scanSpec->childByName("a")->filter(), nullptr);
+    EXPECT_EQ(scanSpec->childByName("b")->filter(), nullptr);
+  }
+
+  {
+    // Range (bigint) + point lookup (bool): range filter on first column stops
+    // extraction, so only the first column is converted.
+    auto rowType = ROW({"a", "b"}, {BIGINT(), BOOLEAN()});
+
+    std::unordered_map<std::string, std::unique_ptr<Filter>> filters;
+    filters["a"] = std::make_unique<BigintRange>(10, 100, false);
+    filters["b"] = std::make_unique<BoolValue>(true, false);
+    auto scanSpec = createScanSpec(rowType, filters);
+
+    auto result = convertFilterToIndexBounds(
+        {"a", "b"}, sortOrders(2), rowType, *scanSpec, pool_.get());
+    ASSERT_TRUE(result.has_value());
+
+    const auto& bounds = result.value();
+    // Only column "a" should be included because it's a range scan.
+    EXPECT_EQ(bounds.indexColumns.size(), 1);
+    EXPECT_EQ(bounds.indexColumns[0], "a");
+
+    verifyRangeBounds<int64_t>(bounds, "a", 10, 100);
+
+    // Filter on "a" removed, but "b" should still have filter since it wasn't
+    // converted.
+    EXPECT_EQ(scanSpec->childByName("a")->filter(), nullptr);
+    EXPECT_NE(scanSpec->childByName("b")->filter(), nullptr);
+  }
+}
+
+TEST_P(IndexFilterTestWithSortOrder, timestampFilter) {
+  const auto rowType = ROW({"a", "b"}, {TIMESTAMP(), TIMESTAMP()});
+  Timestamp lower(100, 0);
+  Timestamp upper(200, 0);
+
+  {
+    // Prefix point lookup: single column point lookup on the first column.
+    std::unordered_map<std::string, std::unique_ptr<Filter>> filters;
+    filters["a"] = std::make_unique<TimestampRange>(lower, lower, false);
+    auto scanSpec = createScanSpec(rowType, filters);
+
+    auto result = convertFilterToIndexBounds(
+        {"a"}, sortOrders(1), rowType, *scanSpec, pool_.get());
+    ASSERT_TRUE(result.has_value());
+
+    const auto& bounds = result.value();
+    EXPECT_EQ(bounds.indexColumns, std::vector<std::string>{"a"});
+    ASSERT_TRUE(bounds.lowerBound.has_value());
+    ASSERT_TRUE(bounds.upperBound.has_value());
+    EXPECT_TRUE(bounds.lowerBound->inclusive);
+    EXPECT_TRUE(bounds.upperBound->inclusive);
+
+    // Point lookup: both bounds have same value regardless of sort order.
+    verifyBound<Timestamp>(bounds.lowerBound->bound, "a", lower);
+    verifyBound<Timestamp>(bounds.upperBound->bound, "a", lower);
+
+    // Filter should be removed from scanSpec.
+    EXPECT_EQ(scanSpec->childByName("a")->filter(), nullptr);
+  }
+
+  {
+    // Prefix range: range filter on the first index column only.
+    std::unordered_map<std::string, std::unique_ptr<Filter>> filters;
+    filters["a"] = std::make_unique<TimestampRange>(lower, upper, false);
+    auto scanSpec = createScanSpec(rowType, filters);
+
+    auto result = convertFilterToIndexBounds(
+        {"a"}, sortOrders(1), rowType, *scanSpec, pool_.get());
+    ASSERT_TRUE(result.has_value());
+
+    const auto& bounds = result.value();
+    EXPECT_EQ(bounds.indexColumns, std::vector<std::string>{"a"});
+    ASSERT_TRUE(bounds.lowerBound.has_value());
+    ASSERT_TRUE(bounds.upperBound.has_value());
+    EXPECT_TRUE(bounds.lowerBound->inclusive);
+    EXPECT_TRUE(bounds.upperBound->inclusive);
+
+    verifyRangeBounds<Timestamp>(bounds, "a", lower, upper);
+
+    // Filter should be removed from scanSpec.
+    EXPECT_EQ(scanSpec->childByName("a")->filter(), nullptr);
+  }
+
+  {
+    // Point lookup + range: point lookup on first column, range on second,
+    // spanning two index columns.
+    Timestamp lower2(300, 0);
+    Timestamp upper2(400, 0);
+
+    std::unordered_map<std::string, std::unique_ptr<Filter>> filters;
+    filters["a"] = std::make_unique<TimestampRange>(lower, lower, false);
+    filters["b"] = std::make_unique<TimestampRange>(lower2, upper2, false);
+    auto scanSpec = createScanSpec(rowType, filters);
+
+    auto result = convertFilterToIndexBounds(
+        {"a", "b"}, sortOrders(2), rowType, *scanSpec, pool_.get());
+    ASSERT_TRUE(result.has_value());
+
+    const auto& bounds = result.value();
+    EXPECT_EQ(bounds.indexColumns.size(), 2);
+    EXPECT_EQ(bounds.indexColumns[0], "a");
+    EXPECT_EQ(bounds.indexColumns[1], "b");
+
+    // Point lookup on "a": same value regardless of sort order.
+    verifyBound<Timestamp>(bounds.lowerBound->bound, "a", lower);
+    verifyBound<Timestamp>(bounds.upperBound->bound, "a", lower);
+    // Range on "b": bounds swapped for descending sort.
+    verifyRangeBounds<Timestamp>(bounds, "b", lower2, upper2);
+
+    // Both filters should be removed from scanSpec.
+    EXPECT_EQ(scanSpec->childByName("a")->filter(), nullptr);
+    EXPECT_EQ(scanSpec->childByName("b")->filter(), nullptr);
+  }
+
+  {
+    // Range + range: range filter on the first column stops extraction,
+    // so only the first column is converted, not the second.
+    Timestamp lower2(300, 0);
+    Timestamp upper2(400, 0);
+
+    std::unordered_map<std::string, std::unique_ptr<Filter>> filters;
+    filters["a"] = std::make_unique<TimestampRange>(lower, upper, false);
+    filters["b"] = std::make_unique<TimestampRange>(lower2, upper2, false);
+    auto scanSpec = createScanSpec(rowType, filters);
+
+    auto result = convertFilterToIndexBounds(
+        {"a", "b"}, sortOrders(2), rowType, *scanSpec, pool_.get());
+    ASSERT_TRUE(result.has_value());
+
+    const auto& bounds = result.value();
+    // Only column "a" should be included because it's a range scan.
+    // The range filter stops extraction from including subsequent columns.
+    EXPECT_EQ(bounds.indexColumns.size(), 1);
+    EXPECT_EQ(bounds.indexColumns[0], "a");
+
+    verifyRangeBounds<Timestamp>(bounds, "a", lower, upper);
+
+    // Filter on "a" removed, but "b" should still have filter since it wasn't
+    // converted.
+    EXPECT_EQ(scanSpec->childByName("a")->filter(), nullptr);
+    EXPECT_NE(scanSpec->childByName("b")->filter(), nullptr);
+  }
+
+  {
+    // Point lookup + point lookup: point lookups on both index columns.
+    // Both columns should be included since point lookups allow extraction to
+    // continue.
+    Timestamp value2(300, 0);
+
+    std::unordered_map<std::string, std::unique_ptr<Filter>> filters;
+    filters["a"] = std::make_unique<TimestampRange>(lower, lower, false);
+    filters["b"] = std::make_unique<TimestampRange>(value2, value2, false);
+    auto scanSpec = createScanSpec(rowType, filters);
+
+    auto result = convertFilterToIndexBounds(
+        {"a", "b"}, sortOrders(2), rowType, *scanSpec, pool_.get());
+    ASSERT_TRUE(result.has_value());
+
+    const auto& bounds = result.value();
+    EXPECT_EQ(bounds.indexColumns.size(), 2);
+    EXPECT_EQ(bounds.indexColumns[0], "a");
+    EXPECT_EQ(bounds.indexColumns[1], "b");
+
+    // Point lookups: same value for both bounds regardless of sort order.
+    verifyBound<Timestamp>(bounds.lowerBound->bound, "a", lower);
+    verifyBound<Timestamp>(bounds.upperBound->bound, "a", lower);
+    verifyBound<Timestamp>(bounds.lowerBound->bound, "b", value2);
+    verifyBound<Timestamp>(bounds.upperBound->bound, "b", value2);
+
+    // Both filters should be removed from scanSpec.
+    EXPECT_EQ(scanSpec->childByName("a")->filter(), nullptr);
+    EXPECT_EQ(scanSpec->childByName("b")->filter(), nullptr);
+  }
+}
+
+TEST_P(IndexFilterTestWithSortOrder, mixedFilterDataTypes) {
+  {
+    // Bigint point lookup + varchar point lookup.
+    auto rowType = ROW({"a", "b"}, {BIGINT(), VARCHAR()});
+
+    std::unordered_map<std::string, std::unique_ptr<Filter>> filters;
+    filters["a"] = std::make_unique<BigintRange>(42, 42, false);
+    filters["b"] =
+        std::make_unique<BytesValues>(std::vector<std::string>{"hello"}, false);
+    auto scanSpec = createScanSpec(rowType, filters);
+
+    auto result = convertFilterToIndexBounds(
+        {"a", "b"}, sortOrders(2), rowType, *scanSpec, pool_.get());
+    ASSERT_TRUE(result.has_value());
+
+    const auto& bounds = result.value();
+    EXPECT_EQ(bounds.indexColumns.size(), 2);
+    EXPECT_EQ(bounds.indexColumns[0], "a");
+    EXPECT_EQ(bounds.indexColumns[1], "b");
+
+    verifyBound<int64_t>(bounds.lowerBound->bound, "a", 42);
+    verifyBound<int64_t>(bounds.upperBound->bound, "a", 42);
+    verifyBound<StringView>(bounds.lowerBound->bound, "b", StringView("hello"));
+    verifyBound<StringView>(bounds.upperBound->bound, "b", StringView("hello"));
+
+    EXPECT_EQ(scanSpec->childByName("a")->filter(), nullptr);
+    EXPECT_EQ(scanSpec->childByName("b")->filter(), nullptr);
+  }
+
+  {
+    // Double point lookup + bool point lookup.
+    auto rowType = ROW({"a", "b"}, {DOUBLE(), BOOLEAN()});
+
+    std::unordered_map<std::string, std::unique_ptr<Filter>> filters;
+    filters["a"] = std::make_unique<DoubleRange>(
+        1.5, false, false, 1.5, false, false, false);
+    filters["b"] = std::make_unique<BoolValue>(true, false);
+    auto scanSpec = createScanSpec(rowType, filters);
+
+    auto result = convertFilterToIndexBounds(
+        {"a", "b"}, sortOrders(2), rowType, *scanSpec, pool_.get());
+    ASSERT_TRUE(result.has_value());
+
+    const auto& bounds = result.value();
+    EXPECT_EQ(bounds.indexColumns.size(), 2);
+    EXPECT_EQ(bounds.indexColumns[0], "a");
+    EXPECT_EQ(bounds.indexColumns[1], "b");
+
+    verifyBound<double>(bounds.lowerBound->bound, "a", 1.5);
+    verifyBound<double>(bounds.upperBound->bound, "a", 1.5);
+    verifyBound<bool>(bounds.lowerBound->bound, "b", true);
+    verifyBound<bool>(bounds.upperBound->bound, "b", true);
+
+    EXPECT_EQ(scanSpec->childByName("a")->filter(), nullptr);
+    EXPECT_EQ(scanSpec->childByName("b")->filter(), nullptr);
+  }
+
+  {
+    // Varchar point lookup + timestamp range.
+    auto rowType = ROW({"a", "b"}, {VARCHAR(), TIMESTAMP()});
+    Timestamp lower(100, 0);
+    Timestamp upper(200, 0);
+
+    std::unordered_map<std::string, std::unique_ptr<Filter>> filters;
+    filters["a"] =
+        std::make_unique<BytesValues>(std::vector<std::string>{"hello"}, false);
+    filters["b"] = std::make_unique<TimestampRange>(lower, upper, false);
+    auto scanSpec = createScanSpec(rowType, filters);
+
+    auto result = convertFilterToIndexBounds(
+        {"a", "b"}, sortOrders(2), rowType, *scanSpec, pool_.get());
+    ASSERT_TRUE(result.has_value());
+
+    const auto& bounds = result.value();
+    EXPECT_EQ(bounds.indexColumns.size(), 2);
+    EXPECT_EQ(bounds.indexColumns[0], "a");
+    EXPECT_EQ(bounds.indexColumns[1], "b");
+
+    verifyBound<StringView>(bounds.lowerBound->bound, "a", StringView("hello"));
+    verifyBound<StringView>(bounds.upperBound->bound, "a", StringView("hello"));
+    verifyRangeBounds<Timestamp>(bounds, "b", lower, upper);
+
+    EXPECT_EQ(scanSpec->childByName("a")->filter(), nullptr);
+    EXPECT_EQ(scanSpec->childByName("b")->filter(), nullptr);
+  }
+
+  {
+    // Float range + bigint point lookup: range on first column stops
+    // extraction.
+    auto rowType = ROW({"a", "b"}, {REAL(), BIGINT()});
+
+    std::unordered_map<std::string, std::unique_ptr<Filter>> filters;
+    filters["a"] = std::make_unique<FloatRange>(
+        1.5f, false, false, 10.5f, false, false, false);
+    filters["b"] = std::make_unique<BigintRange>(42, 42, false);
+    auto scanSpec = createScanSpec(rowType, filters);
+
+    auto result = convertFilterToIndexBounds(
+        {"a", "b"}, sortOrders(2), rowType, *scanSpec, pool_.get());
+    ASSERT_TRUE(result.has_value());
+
+    const auto& bounds = result.value();
+    // Only "a" because it's a range filter.
+    EXPECT_EQ(bounds.indexColumns.size(), 1);
+    EXPECT_EQ(bounds.indexColumns[0], "a");
+
+    verifyRangeBounds<float>(bounds, "a", 1.5f, 10.5f);
+
+    EXPECT_EQ(scanSpec->childByName("a")->filter(), nullptr);
+    EXPECT_NE(scanSpec->childByName("b")->filter(), nullptr);
+  }
+
+  {
+    // Timestamp point lookup + double point lookup + bool point lookup:
+    // three different types, all point lookups.
+    auto rowType = ROW({"a", "b", "c"}, {TIMESTAMP(), DOUBLE(), BOOLEAN()});
+    Timestamp ts(100, 0);
+
+    std::unordered_map<std::string, std::unique_ptr<Filter>> filters;
+    filters["a"] = std::make_unique<TimestampRange>(ts, ts, false);
+    filters["b"] = std::make_unique<DoubleRange>(
+        2.5, false, false, 2.5, false, false, false);
+    filters["c"] = std::make_unique<BoolValue>(false, false);
+    auto scanSpec = createScanSpec(rowType, filters);
+
+    auto result = convertFilterToIndexBounds(
+        {"a", "b", "c"}, sortOrders(3), rowType, *scanSpec, pool_.get());
+    ASSERT_TRUE(result.has_value());
+
+    const auto& bounds = result.value();
+    EXPECT_EQ(bounds.indexColumns.size(), 3);
+    EXPECT_EQ(bounds.indexColumns[0], "a");
+    EXPECT_EQ(bounds.indexColumns[1], "b");
+    EXPECT_EQ(bounds.indexColumns[2], "c");
+
+    verifyBound<Timestamp>(bounds.lowerBound->bound, "a", ts);
+    verifyBound<Timestamp>(bounds.upperBound->bound, "a", ts);
+    verifyBound<double>(bounds.lowerBound->bound, "b", 2.5);
+    verifyBound<double>(bounds.upperBound->bound, "b", 2.5);
+    verifyBound<bool>(bounds.lowerBound->bound, "c", false);
+    verifyBound<bool>(bounds.upperBound->bound, "c", false);
+
+    EXPECT_EQ(scanSpec->childByName("a")->filter(), nullptr);
+    EXPECT_EQ(scanSpec->childByName("b")->filter(), nullptr);
+    EXPECT_EQ(scanSpec->childByName("c")->filter(), nullptr);
+  }
+
+  {
+    // Bigint point lookup + varchar range + float point lookup:
+    // range in middle stops extraction.
+    auto rowType = ROW({"a", "b", "c"}, {BIGINT(), VARCHAR(), REAL()});
+
+    std::unordered_map<std::string, std::unique_ptr<Filter>> filters;
+    filters["a"] = std::make_unique<BigintRange>(42, 42, false);
+    filters["b"] = std::make_unique<BytesRange>(
+        "abc", false, false, "xyz", false, false, false);
+    filters["c"] = std::make_unique<FloatRange>(
+        1.5f, false, false, 1.5f, false, false, false);
+    auto scanSpec = createScanSpec(rowType, filters);
+
+    auto result = convertFilterToIndexBounds(
+        {"a", "b", "c"}, sortOrders(3), rowType, *scanSpec, pool_.get());
+    ASSERT_TRUE(result.has_value());
+
+    const auto& bounds = result.value();
+    // "a" and "b" included, but "c" is not because "b" is a range.
+    EXPECT_EQ(bounds.indexColumns.size(), 2);
+    EXPECT_EQ(bounds.indexColumns[0], "a");
+    EXPECT_EQ(bounds.indexColumns[1], "b");
+
+    verifyBound<int64_t>(bounds.lowerBound->bound, "a", 42);
+    verifyBound<int64_t>(bounds.upperBound->bound, "a", 42);
+    verifyRangeBounds<StringView>(
+        bounds, "b", StringView("abc"), StringView("xyz"));
+
+    EXPECT_EQ(scanSpec->childByName("a")->filter(), nullptr);
+    EXPECT_EQ(scanSpec->childByName("b")->filter(), nullptr);
+    EXPECT_NE(scanSpec->childByName("c")->filter(), nullptr);
+  }
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    SortOrders,
+    IndexFilterTestWithSortOrder,
+    ::testing::Values(core::kAscNullsFirst, core::kDescNullsFirst),
+    [](const ::testing::TestParamInfo<core::SortOrder>& info) {
+      return info.param.isAscending() ? "Ascending" : "Descending";
+    });
+
+} // namespace facebook::nimble::index::test


### PR DESCRIPTION
Summary:
This diff adds a utility function `convertFilterToIndexBounds()` that converts Velox ScanSpec filters to IndexBounds for index-based filtering in Nimble.

**Filter type support**: Converts various Velox filter types to index bounds:
   - `BigintRange`: Integer range filters
   - `DoubleRange`: Double range filters  
   - `FloatRange`: Float range filters
   - `BytesRange`: String/bytes range filters
   - `BytesValues`: String/bytes values filter (single value only for point lookups)
   - `BoolValue`: Boolean filters
   - `TimestampRange`: Timestamp range filters
   -   Rejects filters that allow nulls or are otherwise not convertible to index bounds.

**Sort order handling**: Correctly handles both ascending and descending sort orders by swapping lower/upper bounds for DESC columns.

**Multi-column index support**: Supports extracting bounds for multiple index columns in prefix order:
   - Point lookups allow extraction to continue to subsequent columns
   - Range filters terminate extraction (subsequent columns not included)
   - Gaps in the filter chain (missing filter on intermediate column) stop extraction

**Filter removal**: Filters that are fully captured by index bounds are automatically removed from the ScanSpec to avoid redundant filtering.

Differential Revision: D90001035


