### PR TITLE
Pass string buffer directly from decoder

### DIFF
--- a/dwio/nimble/encodings/CMakeLists.txt
+++ b/dwio/nimble/encodings/CMakeLists.txt
@@ -17,10 +17,12 @@ add_subdirectory(legacy)
 add_library(
   nimble_encodings
   Compression.cpp
+  ConstantEncoding.cpp
   Encoding.cpp
   EncodingFactory.cpp
   EncodingLayout.cpp
   EncodingLayoutCapture.cpp
+  MainlyConstantEncoding.cpp
   RleEncoding.cpp
   SparseBoolEncoding.cpp
   Statistics.cpp

--- a/dwio/nimble/encodings/ConstantEncoding.cpp
+++ b/dwio/nimble/encodings/ConstantEncoding.cpp
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "dwio/nimble/encodings/ConstantEncoding.h"
+
+namespace facebook::nimble {
+
+ConstantEncoding<std::string_view>::ConstantEncoding(
+    velox::memory::MemoryPool& memoryPool,
+    std::string_view data,
+    std::function<void*(uint32_t)> stringBufferFactory)
+    : ConstantEncodingBase<std::string_view>(memoryPool, data) {
+  const char* pos = data.data() + Encoding::kPrefixSize;
+  value_ = encoding::read<physicalType>(pos);
+  NIMBLE_CHECK(pos == data.end(), "Unexpected constant encoding end");
+  auto stringBuffer = static_cast<char*>(stringBufferFactory(value_.size()));
+  std::memcpy(stringBuffer, value_.begin(), value_.size());
+  value_ = std::string_view{stringBuffer, value_.size()};
+}
+
+} // namespace facebook::nimble

--- a/dwio/nimble/encodings/ConstantEncoding.h
+++ b/dwio/nimble/encodings/ConstantEncoding.h
@@ -31,36 +31,95 @@ namespace facebook::nimble {
 // Data layout is:
 // Encoding::kPrefixSize bytes: standard Encoding prefix
 // X bytes: the constant value via encoding primitive.
+
 template <typename T>
-class ConstantEncoding final
+class ConstantEncodingBase
     : public TypedEncoding<T, typename TypeTraits<T>::physicalType> {
+ public:
+  using cppDataType = T;
+  using physicalType = typename TypeTraits<T>::physicalType;
+
+  ConstantEncodingBase(
+      velox::memory::MemoryPool& memoryPool,
+      std::string_view data)
+      : TypedEncoding<T, physicalType>(memoryPool, data) {}
+
+  void reset() final {}
+
+  void skip(uint32_t /* rowCount */) final {}
+
+  void materialize(uint32_t rowCount, void* buffer) final {
+    physicalType* castBuffer = static_cast<physicalType*>(buffer);
+    for (uint32_t i = 0; i < rowCount; ++i) {
+      castBuffer[i] = value_;
+    }
+  }
+
+  void materializeBoolsAsBits(
+      uint32_t /*rowCount*/,
+      uint64_t* /*buffer*/,
+      int /*begin*/) override {
+    NIMBLE_UNREACHABLE("");
+  }
+
+  template <typename DecoderVisitor>
+  void readWithVisitor(DecoderVisitor& visitor, ReadWithVisitorParams& params) {
+    detail::readWithVisitorSlow(
+        visitor, params, nullptr, [&] { return value_; });
+  }
+
+  std::string debugString(int offset) const final {
+    return fmt::format(
+        "{}{}<{}> rowCount={} value={}",
+        std::string(offset, ' '),
+        toString(this->encodingType()),
+        toString(this->dataType()),
+        this->rowCount(),
+        AS_CONST(T, value_));
+  }
+
+  static std::string_view encode(
+      EncodingSelection<physicalType>& selection,
+      std::span<const physicalType> values,
+      Buffer& buffer) {
+    if (values.empty()) {
+      NIMBLE_INCOMPATIBLE_ENCODING("ConstantEncoding cannot be empty.");
+    }
+
+    if (selection.statistics().uniqueCounts().value().size() != 1) {
+      NIMBLE_INCOMPATIBLE_ENCODING("ConstantEncoding requires constant data.");
+    }
+
+    const uint32_t rowCount = values.size();
+    uint32_t encodingSize = Encoding::kPrefixSize;
+    if constexpr (isStringType<physicalType>()) {
+      encodingSize += 4 + values[0].size();
+    } else {
+      encodingSize += sizeof(physicalType);
+    }
+    char* reserved = buffer.reserve(encodingSize);
+    char* pos = reserved;
+    Encoding::serializePrefix(
+        EncodingType::Constant, TypeTraits<T>::dataType, rowCount, pos);
+    encoding::write<physicalType>(values[0], pos);
+    NIMBLE_DCHECK_EQ(pos - reserved, encodingSize, "Encoding size mismatch.");
+    return {reserved, encodingSize};
+  }
+
+ protected:
+  physicalType value_;
+};
+
+template <typename T>
+class ConstantEncoding : public ConstantEncodingBase<T> {
  public:
   using cppDataType = T;
   using physicalType = typename TypeTraits<T>::physicalType;
 
   ConstantEncoding(
       velox::memory::MemoryPool& memoryPool,
-      std::string_view data);
-
-  void reset() final;
-  void skip(uint32_t rowCount) final;
-  void materialize(uint32_t rowCount, void* buffer) final;
-
-  void materializeBoolsAsBits(uint32_t rowCount, uint64_t* buffer, int begin)
-      final;
-
-  template <typename DecoderVisitor>
-  void readWithVisitor(DecoderVisitor& visitor, ReadWithVisitorParams& params);
-
-  static std::string_view encode(
-      EncodingSelection<physicalType>& selection,
-      std::span<const physicalType> values,
-      Buffer& buffer);
-
-  std::string debugString(int offset) const final;
-
- private:
-  physicalType value_;
+      std::string_view data,
+      std::function<void*(uint32_t)> stringBufferFactory);
 };
 
 //
@@ -70,89 +129,47 @@ class ConstantEncoding final
 template <typename T>
 ConstantEncoding<T>::ConstantEncoding(
     velox::memory::MemoryPool& memoryPool,
-    std::string_view data)
-    : TypedEncoding<T, physicalType>(memoryPool, data) {
+    std::string_view data,
+    std::function<void*(uint32_t)> stringBufferFactory)
+    : ConstantEncodingBase<T>(memoryPool, data) {
   const char* pos = data.data() + Encoding::kPrefixSize;
-  value_ = encoding::read<physicalType>(pos);
+  this->value_ = encoding::read<physicalType>(pos);
   NIMBLE_CHECK(pos == data.end(), "Unexpected constant encoding end");
 }
 
-template <typename T>
-void ConstantEncoding<T>::reset() {}
+// Specialization for bool to override materializeBoolsAsBits
+template <>
+class ConstantEncoding<bool> final : public ConstantEncodingBase<bool> {
+ public:
+  using cppDataType = bool;
+  using physicalType = bool;
 
-template <typename T>
-void ConstantEncoding<T>::skip(uint32_t /* rowCount */) {}
-
-template <typename T>
-void ConstantEncoding<T>::materialize(uint32_t rowCount, void* buffer) {
-  physicalType* castBuffer = static_cast<physicalType*>(buffer);
-  for (uint32_t i = 0; i < rowCount; ++i) {
-    castBuffer[i] = value_;
+  ConstantEncoding(
+      velox::memory::MemoryPool& memoryPool,
+      std::string_view data,
+      std::function<void*(uint32_t)> stringBufferFactory)
+      : ConstantEncodingBase<bool>(memoryPool, data) {
+    const char* pos = data.data() + Encoding::kPrefixSize;
+    this->value_ = encoding::read<physicalType>(pos);
+    NIMBLE_CHECK(pos == data.end(), "Unexpected constant encoding end");
   }
-}
+
+  void materializeBoolsAsBits(uint32_t rowCount, uint64_t* buffer, int begin)
+      final {
+    velox::bits::fillBits(buffer, begin, begin + rowCount, this->value_);
+  }
+};
 
 template <>
-inline void ConstantEncoding<bool>::materializeBoolsAsBits(
-    uint32_t rowCount,
-    uint64_t* buffer,
-    int begin) {
-  velox::bits::fillBits(buffer, begin, begin + rowCount, value_);
-}
+class ConstantEncoding<std::string_view> final
+    : public ConstantEncodingBase<std::string_view> {
+ public:
+  using cppDataType = std::string_view;
+  using physicalType = std::string_view;
 
-template <typename T>
-void ConstantEncoding<T>::materializeBoolsAsBits(
-    uint32_t /*rowCount*/,
-    uint64_t* /*buffer*/,
-    int /*begin*/) {
-  NIMBLE_UNREACHABLE("");
-}
-
-template <typename T>
-template <typename V>
-void ConstantEncoding<T>::readWithVisitor(
-    V& visitor,
-    ReadWithVisitorParams& params) {
-  detail::readWithVisitorSlow(visitor, params, nullptr, [&] { return value_; });
-}
-
-template <typename T>
-std::string_view ConstantEncoding<T>::encode(
-    EncodingSelection<physicalType>& selection,
-    std::span<const physicalType> values,
-    Buffer& buffer) {
-  if (values.empty()) {
-    NIMBLE_INCOMPATIBLE_ENCODING("ConstantEncoding cannot be empty.");
-  }
-
-  if (selection.statistics().uniqueCounts().value().size() != 1) {
-    NIMBLE_INCOMPATIBLE_ENCODING("ConstantEncoding requires constant data.");
-  }
-
-  const uint32_t rowCount = values.size();
-  uint32_t encodingSize = Encoding::kPrefixSize;
-  if constexpr (isStringType<physicalType>()) {
-    encodingSize += 4 + values[0].size();
-  } else {
-    encodingSize += sizeof(physicalType);
-  }
-  char* reserved = buffer.reserve(encodingSize);
-  char* pos = reserved;
-  Encoding::serializePrefix(
-      EncodingType::Constant, TypeTraits<T>::dataType, rowCount, pos);
-  encoding::write<physicalType>(values[0], pos);
-  NIMBLE_DCHECK_EQ(pos - reserved, encodingSize, "Encoding size mismatch.");
-  return {reserved, encodingSize};
-}
-
-template <typename T>
-std::string ConstantEncoding<T>::debugString(int offset) const {
-  return fmt::format(
-      "{}{}<{}> rowCount={} value={}",
-      std::string(offset, ' '),
-      toString(Encoding::encodingType()),
-      toString(Encoding::dataType()),
-      Encoding::rowCount(),
-      AS_CONST(T, value_));
-}
-
+  ConstantEncoding(
+      velox::memory::MemoryPool& memoryPool,
+      std::string_view data,
+      std::function<void*(uint32_t)> stringBufferFactory);
+};
 } // namespace facebook::nimble

--- a/dwio/nimble/encodings/DeltaEncoding.h
+++ b/dwio/nimble/encodings/DeltaEncoding.h
@@ -60,7 +60,10 @@ class DeltaEncoding final
   using cppDataType = T;
   using physicalType = typename TypeTraits<T>::physicalType;
 
-  DeltaEncoding(velox::memory::MemoryPool& memoryPool, std::string_view data);
+  DeltaEncoding(
+      velox::memory::MemoryPool& memoryPool,
+      std::string_view data,
+      std::function<void*(uint32_t)> stringBufferFactory);
 
   void reset() final;
   void skip(uint32_t rowCount) final;
@@ -86,7 +89,8 @@ class DeltaEncoding final
 template <typename T>
 DeltaEncoding<T>::DeltaEncoding(
     velox::memory::MemoryPool& memoryPool,
-    std::string_view data)
+    std::string_view data,
+    std::function<void*(uint32_t)> stringBufferFactory)
     : TypedEncoding<T, physicalType>(memoryPool, data),
       deltasBuffer_(&memoryPool),
       restatementsBuffer_(&memoryPool),
@@ -94,13 +98,16 @@ DeltaEncoding<T>::DeltaEncoding(
   auto pos = data.data() + Encoding::kPrefixSize;
   const uint32_t restatementsOffset = encoding::readUint32(pos);
   const uint32_t isRestatementsOffset = encoding::readUint32(pos);
-  deltas_ = EncodingFactory::decode(memoryPool, {pos, restatementsOffset});
+  deltas_ = EncodingFactory::decode(
+      memoryPool, {pos, restatementsOffset}, stringBufferFactory);
   pos += restatementsOffset;
-  restatements_ =
-      EncodingFactory::decode(memoryPool, {pos, isRestatementsOffset});
+  restatements_ = EncodingFactory::decode(
+      memoryPool, {pos, isRestatementsOffset}, stringBufferFactory);
   pos += isRestatementsOffset;
   isRestatements_ = EncodingFactory::decode(
-      memoryPool, {pos, static_cast<size_t>(data.end() - pos)});
+      memoryPool,
+      {pos, static_cast<size_t>(data.end() - pos)},
+      stringBufferFactory);
 }
 
 template <typename T>

--- a/dwio/nimble/encodings/DictionaryEncoding.h
+++ b/dwio/nimble/encodings/DictionaryEncoding.h
@@ -49,7 +49,10 @@ class DictionaryEncoding
 
   static const int kAlphabetSizeOffset = Encoding::kPrefixSize;
 
-  DictionaryEncoding(velox::memory::MemoryPool& pool, std::string_view data);
+  DictionaryEncoding(
+      velox::memory::MemoryPool& pool,
+      std::string_view data,
+      std::function<void*(uint32_t)> stringBufferFactory);
 
   void reset() final;
   void skip(uint32_t rowCount) final;
@@ -83,21 +86,24 @@ class DictionaryEncoding
 template <typename T>
 DictionaryEncoding<T>::DictionaryEncoding(
     velox::memory::MemoryPool& pool,
-    std::string_view data)
+    std::string_view data,
+    std::function<void*(uint32_t)> stringBufferFactory)
     : TypedEncoding<T, physicalType>{pool, data},
       alphabet_{this->pool_},
       indicesBuffer_{this->pool_} {
   const auto* pos = data.data() + kAlphabetSizeOffset;
   const uint32_t alphabetSize = encoding::readUint32(pos);
-  alphabetEncoding_ =
-      EncodingFactory::decode(*this->pool_, {pos, alphabetSize});
+  alphabetEncoding_ = EncodingFactory::decode(
+      *this->pool_, {pos, alphabetSize}, stringBufferFactory);
   const uint32_t alphabetCount = alphabetEncoding_->rowCount();
   alphabet_.resize(alphabetCount);
   alphabetEncoding_->materialize(alphabetCount, alphabet_.data());
 
   pos += alphabetSize;
   indicesEncoding_ = EncodingFactory::decode(
-      *this->pool_, {pos, static_cast<size_t>(data.end() - pos)});
+      *this->pool_,
+      {pos, static_cast<size_t>(data.end() - pos)},
+      stringBufferFactory);
 }
 
 template <typename T>

--- a/dwio/nimble/encodings/EncodingFactory.h
+++ b/dwio/nimble/encodings/EncodingFactory.h
@@ -33,7 +33,8 @@ class EncodingFactory {
  public:
   static std::unique_ptr<Encoding> decode(
       velox::memory::MemoryPool& memoryPool,
-      std::string_view data);
+      std::string_view data,
+      std::function<void*(uint32_t)> stringBufferFactory);
 
   template <typename T>
   static std::string_view encode(

--- a/dwio/nimble/encodings/FixedBitWidthEncoding.h
+++ b/dwio/nimble/encodings/FixedBitWidthEncoding.h
@@ -54,7 +54,8 @@ class FixedBitWidthEncoding final
 
   FixedBitWidthEncoding(
       velox::memory::MemoryPool& memoryPool,
-      std::string_view data);
+      std::string_view data,
+      std::function<void*(uint32_t)> stringBufferFactory);
 
   void reset() final;
   void skip(uint32_t rowCount) final;
@@ -86,7 +87,8 @@ class FixedBitWidthEncoding final
 template <typename T>
 FixedBitWidthEncoding<T>::FixedBitWidthEncoding(
     velox::memory::MemoryPool& memoryPool,
-    std::string_view data)
+    std::string_view data,
+    std::function<void*(uint32_t)> /* stringBufferFactory */)
     : TypedEncoding<T, physicalType>{memoryPool, data},
       uncompressedData_{&memoryPool},
       buffer_{&memoryPool} {

--- a/dwio/nimble/encodings/MainlyConstantEncoding.cpp
+++ b/dwio/nimble/encodings/MainlyConstantEncoding.cpp
@@ -1,0 +1,101 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "dwio/nimble/encodings/MainlyConstantEncoding.h"
+
+namespace facebook::nimble {
+
+MainlyConstantEncoding<std::string_view>::MainlyConstantEncoding(
+    velox::memory::MemoryPool& memoryPool,
+    std::string_view data,
+    std::function<void*(uint32_t)> stringBufferFactory)
+    : MainlyConstantEncodingBase<std::string_view>(memoryPool, data) {
+  const char* pos = data.data() + Encoding::kPrefixSize;
+  const uint32_t isCommonBytes = encoding::readUint32(pos);
+  isCommon_ = EncodingFactory::decode(
+      *this->pool_, {pos, isCommonBytes}, stringBufferFactory);
+  pos += isCommonBytes;
+  const uint32_t otherValuesBytes = encoding::readUint32(pos);
+  otherValues_ = EncodingFactory::decode(
+      *this->pool_, {pos, otherValuesBytes}, stringBufferFactory);
+  pos += otherValuesBytes;
+  commonValue_ = encoding::read<physicalType>(pos);
+  NIMBLE_CHECK(pos == data.end(), "Unexpected mainly constant encoding end");
+  auto stringBuffer =
+      static_cast<char*>(stringBufferFactory(commonValue_.size()));
+  std::memcpy(stringBuffer, commonValue_.data(), commonValue_.size());
+  commonValue_ = std::string_view(stringBuffer, commonValue_.size());
+}
+
+std::string_view MainlyConstantEncoding<std::string_view>::encode(
+    EncodingSelection<physicalType>& selection,
+    std::span<const physicalType> values,
+    Buffer& buffer) {
+  if (values.empty()) {
+    NIMBLE_INCOMPATIBLE_ENCODING("MainlyConstantEncoding cannot be empty.");
+  }
+
+  const auto commonElement = std::max_element(
+      selection.statistics().uniqueCounts()->cbegin(),
+      selection.statistics().uniqueCounts()->cend(),
+      [](const auto& a, const auto& b) { return a.second < b.second; });
+
+  const uint32_t entryCount = values.size();
+  const uint32_t uncommonCount = entryCount - commonElement->second;
+
+  Vector<bool> isCommon{&buffer.getMemoryPool(), values.size(), true};
+  Vector<physicalType> otherValues(&buffer.getMemoryPool());
+  otherValues.reserve(uncommonCount);
+
+  physicalType commonValue = commonElement->first;
+  for (auto i = 0; i < values.size(); ++i) {
+    physicalType currentValue = values[i];
+    if (currentValue != commonValue) {
+      isCommon[i] = false;
+      otherValues.push_back(std::move(currentValue));
+    }
+  }
+
+  Buffer tempBuffer{buffer.getMemoryPool()};
+  std::string_view serializedIsCommon = selection.template encodeNested<bool>(
+      EncodingIdentifiers::MainlyConstant::IsCommon, isCommon, tempBuffer);
+  std::string_view serializedOtherValues =
+      selection.template encodeNested<physicalType>(
+          EncodingIdentifiers::MainlyConstant::OtherValues,
+          otherValues,
+          tempBuffer);
+
+  uint32_t encodingSize = Encoding::kPrefixSize + 8 +
+      serializedIsCommon.size() + serializedOtherValues.size();
+  if constexpr (isNumericType<physicalType>()) {
+    encodingSize += sizeof(physicalType);
+  } else {
+    encodingSize += 4 + commonValue.size();
+  }
+  char* reserved = buffer.reserve(encodingSize);
+  char* pos = reserved;
+  Encoding::serializePrefix(
+      EncodingType::MainlyConstant,
+      TypeTraits<std::string_view>::dataType,
+      entryCount,
+      pos);
+  encoding::writeString(serializedIsCommon, pos);
+  encoding::writeString(serializedOtherValues, pos);
+  encoding::write<physicalType>(commonValue, pos);
+  NIMBLE_DCHECK_EQ(pos - reserved, encodingSize, "Encoding size mismatch.");
+  return {reserved, encodingSize};
+}
+} // namespace facebook::nimble

--- a/dwio/nimble/encodings/MainlyConstantEncoding.h
+++ b/dwio/nimble/encodings/MainlyConstantEncoding.h
@@ -58,46 +58,263 @@ namespace facebook::nimble {
 // 4 bytes: num otherValues encoding bytes (Y)
 // Y bytes: otherValues encoding bytes
 // Z bytes: the constant value via encoding primitive.
+
 template <typename T>
-class MainlyConstantEncoding final
+class MainlyConstantEncodingBase
     : public TypedEncoding<T, typename TypeTraits<T>::physicalType> {
+ public:
+  using cppDataType = T;
+  using physicalType = typename TypeTraits<T>::physicalType;
+
+  MainlyConstantEncodingBase(
+      velox::memory::MemoryPool& memoryPool,
+      std::string_view data)
+      : TypedEncoding<T, physicalType>(memoryPool, data),
+        isCommonBuffer_(&memoryPool),
+        otherValuesBuffer_(&memoryPool) {}
+
+  void reset() final {
+    isCommon_->reset();
+    otherValues_->reset();
+  }
+
+  void skip(uint32_t rowCount) final {
+    isCommonBuffer_.resize(rowCount);
+    isCommon_->materialize(rowCount, isCommonBuffer_.data());
+    const uint32_t commonCount =
+        std::accumulate(isCommonBuffer_.begin(), isCommonBuffer_.end(), 0U);
+    const uint32_t nonCommonCount = rowCount - commonCount;
+    if (nonCommonCount == 0) {
+      return;
+    }
+
+    otherValues_->skip(nonCommonCount);
+  }
+
+  void materialize(uint32_t rowCount, void* buffer) final {
+    isCommonBuffer_.resize(rowCount);
+    isCommon_->materialize(rowCount, isCommonBuffer_.data());
+    const uint32_t commonCount =
+        std::accumulate(isCommonBuffer_.begin(), isCommonBuffer_.end(), 0U);
+    const uint32_t nonCommonCount = rowCount - commonCount;
+
+    if (nonCommonCount == 0) {
+      physicalType* output = static_cast<physicalType*>(buffer);
+      std::fill(output, output + rowCount, commonValue_);
+      return;
+    }
+
+    otherValuesBuffer_.reserve(nonCommonCount);
+    otherValues_->materialize(nonCommonCount, otherValuesBuffer_.data());
+    physicalType* output = static_cast<physicalType*>(buffer);
+    const physicalType* nextOtherValue = otherValuesBuffer_.begin();
+    for (uint32_t i = 0; i < rowCount; ++i) {
+      if (isCommonBuffer_[i]) {
+        *output++ = commonValue_;
+      } else {
+        *output++ = *nextOtherValue++;
+      }
+    }
+    NIMBLE_DCHECK_EQ(
+        nextOtherValue - otherValuesBuffer_.begin(),
+        nonCommonCount,
+        "Encoding size mismatch.");
+  }
+
+  template <typename DecoderVisitor>
+  void readWithVisitor(DecoderVisitor& visitor, ReadWithVisitorParams& params) {
+    auto* nulls = visitor.reader().rawNullsInReadRange();
+    if (velox::dwio::common::useFastPath(visitor, nulls)) {
+      detail::readWithVisitorFast(*this, visitor, params, nulls);
+      return;
+    }
+    detail::readWithVisitorSlow(
+        visitor,
+        params,
+        [&](auto toSkip) { skip(toSkip); },
+        [&] {
+          bool isCommon;
+          isCommon_->materialize(1, &isCommon);
+          if (isCommon) {
+            return commonValue_;
+          }
+          physicalType otherValue;
+          otherValues_->materialize(1, &otherValue);
+          return otherValue;
+        });
+  }
+
+  template <bool kScatter, typename V>
+  void bulkScan(
+      V& visitor,
+      vector_size_t currentNonNullRow,
+      const vector_size_t* nonNullRows,
+      vector_size_t numNonNulls,
+      const vector_size_t* scatterRows) {
+    using DataType = typename V::DataType;
+    using ValueType = detail::ValueType<DataType>;
+    constexpr bool kScatterValues = kScatter && !V::kHasFilter && !V::kHasHook;
+    ValueType* values;
+    const auto commonData =
+        detail::castFromPhysicalType<DataType>(commonValue_);
+    const bool commonPassed =
+        velox::common::applyFilter(visitor.filter(), commonData);
+    if constexpr (!V::kFilterOnly) {
+      auto numRows = visitor.numRows() - visitor.rowIndex();
+      values = detail::mutableValues<ValueType>(visitor, numRows);
+      if (commonPassed) {
+        auto commonValue = detail::dataToValue(visitor, commonData);
+        std::fill(values, values + numRows, commonValue);
+      }
+    }
+    const auto numIsCommon =
+        nonNullRows[numNonNulls - 1] + 1 - currentNonNullRow;
+    isCommonBuffer_.resize(velox::bits::nwords(numIsCommon) * sizeof(uint64_t));
+    auto* isCommon = reinterpret_cast<uint64_t*>(isCommonBuffer_.data());
+    isCommon_->materializeBoolsAsBits(numIsCommon, isCommon, 0);
+    auto numOtherValues =
+        numIsCommon - velox::bits::countBits(isCommon, 0, numIsCommon);
+    otherValuesBuffer_.resize(numOtherValues);
+    otherValues_->materialize(numOtherValues, otherValuesBuffer_.data());
+    numOtherValues = 0;
+    auto* filterHits =
+        V::kHasFilter ? visitor.outputRows(numNonNulls) : nullptr;
+    auto* rows = kScatter ? scatterRows : nonNullRows;
+    vector_size_t numValues = 0;
+    vector_size_t numHits = 0;
+    vector_size_t nonNullRowIndex = 0;
+    velox::bits::forEachUnsetBit(
+        isCommon, 0, numIsCommon, [&](vector_size_t i) {
+          i += currentNonNullRow;
+          auto commonBegin = nonNullRowIndex;
+          if constexpr (V::dense) {
+            nonNullRowIndex += i - nonNullRows[nonNullRowIndex];
+          } else {
+            while (nonNullRows[nonNullRowIndex] < i) {
+              ++nonNullRowIndex;
+            }
+          }
+          const auto numCommon = nonNullRowIndex - commonBegin;
+          if (V::kHasFilter && commonPassed && numCommon > 0) {
+            auto* begin = rows + commonBegin;
+            std::copy(begin, begin + numCommon, filterHits + numHits);
+            numHits += numCommon;
+          }
+          if (nonNullRows[nonNullRowIndex] > i) {
+            if constexpr (!V::kFilterOnly) {
+              vector_size_t numRows;
+              if constexpr (kScatterValues) {
+                numRows = scatterRows[nonNullRowIndex] - visitor.rowIndex();
+                visitor.addRowIndex(numRows);
+              } else {
+                numRows = commonPassed * numCommon;
+              }
+              numValues += numRows;
+            }
+            ++numOtherValues;
+            return;
+          }
+          auto otherData = detail::castFromPhysicalType<DataType>(
+              otherValuesBuffer_[numOtherValues++]);
+          bool otherPassed;
+          if constexpr (V::kHasFilter) {
+            otherPassed =
+                velox::common::applyFilter(visitor.filter(), otherData);
+            if (otherPassed) {
+              filterHits[numHits++] = rows[nonNullRowIndex];
+            }
+          } else {
+            otherPassed = true;
+          }
+          if constexpr (!V::kFilterOnly) {
+            auto* begin = values + numValues;
+            vector_size_t numRows;
+            if constexpr (kScatterValues) {
+              begin[scatterRows[nonNullRowIndex] - visitor.rowIndex()] =
+                  detail::dataToValue(visitor, otherData);
+              auto end = nonNullRowIndex + 1;
+              if (FOLLY_UNLIKELY(end == numNonNulls)) {
+                numRows = visitor.numRows() - visitor.rowIndex();
+              } else {
+                numRows = scatterRows[end] - visitor.rowIndex();
+              }
+              visitor.addRowIndex(numRows);
+            } else {
+              numRows = commonPassed * numCommon;
+              if (otherPassed) {
+                begin[numRows++] = detail::dataToValue(visitor, otherData);
+              }
+            }
+            numValues += numRows;
+          }
+          ++nonNullRowIndex;
+        });
+    auto numCommon = numNonNulls - nonNullRowIndex;
+    if (commonPassed && numCommon > 0) {
+      if constexpr (V::kHasFilter) {
+        auto* begin = rows + nonNullRowIndex;
+        std::copy(begin, begin + numCommon, filterHits + numHits);
+        numHits += numCommon;
+      }
+      if constexpr (!V::kFilterOnly) {
+        if constexpr (kScatterValues) {
+          numValues += visitor.numRows() - visitor.rowIndex();
+        } else {
+          numValues += numCommon;
+        }
+      }
+    }
+    visitor.setRowIndex(visitor.numRows());
+    if constexpr (V::kHasHook) {
+      NIMBLE_DCHECK_EQ(numValues, numNonNulls);
+      visitor.hook().addValues(scatterRows, values, numNonNulls);
+    } else {
+      visitor.addNumValues(V::kFilterOnly ? numHits : numValues);
+    }
+  }
+
+  std::string debugString(int offset) const final {
+    std::string log = fmt::format(
+        "{}{}<{}> rowCount={} commonValue={}",
+        std::string(offset, ' '),
+        toString(this->encodingType()),
+        toString(this->dataType()),
+        this->rowCount(),
+        commonValue_);
+    log += fmt::format(
+        "\n{}isCommon child:\n{}",
+        std::string(offset + 2, ' '),
+        isCommon_->debugString(offset + 4));
+    log += fmt::format(
+        "\n{}otherValues child:\n{}",
+        std::string(offset + 2, ' '),
+        otherValues_->debugString(offset + 4));
+    return log;
+  }
+
+ protected:
+  std::unique_ptr<Encoding> isCommon_;
+  std::unique_ptr<Encoding> otherValues_;
+  physicalType commonValue_;
+  Vector<bool> isCommonBuffer_;
+  Vector<physicalType> otherValuesBuffer_;
+};
+
+template <typename T>
+class MainlyConstantEncoding final : public MainlyConstantEncodingBase<T> {
  public:
   using cppDataType = T;
   using physicalType = typename TypeTraits<T>::physicalType;
 
   MainlyConstantEncoding(
       velox::memory::MemoryPool& memoryPool,
-      std::string_view data);
-
-  void reset() final;
-  void skip(uint32_t rowCount) final;
-  void materialize(uint32_t rowCount, void* buffer) final;
-
-  template <typename DecoderVisitor>
-  void readWithVisitor(DecoderVisitor& visitor, ReadWithVisitorParams& params);
-
-  template <bool kScatter, typename Visitor>
-  void bulkScan(
-      Visitor& visitor,
-      vector_size_t currentNonNullRow,
-      const vector_size_t* nonNullRows,
-      vector_size_t numNonNulls,
-      const vector_size_t* scatterRows);
+      std::string_view data,
+      std::function<void*(uint32_t)> stringBufferFactory);
 
   static std::string_view encode(
       EncodingSelection<physicalType>& selection,
       std::span<const physicalType> values,
       Buffer& buffer);
-
-  std::string debugString(int offset) const final;
-
- private:
-  std::unique_ptr<Encoding> isCommon_;
-  std::unique_ptr<Encoding> otherValues_;
-  physicalType commonValue_;
-  // Temporary bufs.
-  Vector<bool> isCommonBuffer_;
-  Vector<physicalType> otherValuesBuffer_;
 };
 
 //
@@ -107,230 +324,20 @@ class MainlyConstantEncoding final
 template <typename T>
 MainlyConstantEncoding<T>::MainlyConstantEncoding(
     velox::memory::MemoryPool& memoryPool,
-    std::string_view data)
-    : TypedEncoding<T, physicalType>(memoryPool, data),
-      isCommonBuffer_(&memoryPool),
-      otherValuesBuffer_(&memoryPool) {
+    std::string_view data,
+    std::function<void*(uint32_t)> stringBufferFactory)
+    : MainlyConstantEncodingBase<T>(memoryPool, data) {
   const char* pos = data.data() + Encoding::kPrefixSize;
   const uint32_t isCommonBytes = encoding::readUint32(pos);
-  isCommon_ = EncodingFactory::decode(*this->pool_, {pos, isCommonBytes});
+  this->isCommon_ = EncodingFactory::decode(
+      *this->pool_, {pos, isCommonBytes}, stringBufferFactory);
   pos += isCommonBytes;
   const uint32_t otherValuesBytes = encoding::readUint32(pos);
-  otherValues_ = EncodingFactory::decode(*this->pool_, {pos, otherValuesBytes});
+  this->otherValues_ = EncodingFactory::decode(
+      *this->pool_, {pos, otherValuesBytes}, stringBufferFactory);
   pos += otherValuesBytes;
-  commonValue_ = encoding::read<physicalType>(pos);
+  this->commonValue_ = encoding::read<physicalType>(pos);
   NIMBLE_CHECK(pos == data.end(), "Unexpected mainly constant encoding end");
-}
-
-template <typename T>
-void MainlyConstantEncoding<T>::reset() {
-  isCommon_->reset();
-  otherValues_->reset();
-}
-
-template <typename T>
-void MainlyConstantEncoding<T>::skip(uint32_t rowCount) {
-  // Hrm this isn't ideal. We should return to this later -- a new
-  // encoding func? Encoding::Accumulate to add up next N rows?
-  isCommonBuffer_.resize(rowCount);
-  isCommon_->materialize(rowCount, isCommonBuffer_.data());
-  const uint32_t commonCount =
-      std::accumulate(isCommonBuffer_.begin(), isCommonBuffer_.end(), 0U);
-  const uint32_t nonCommonCount = rowCount - commonCount;
-  if (nonCommonCount == 0) {
-    return;
-  }
-
-  otherValues_->skip(nonCommonCount);
-}
-
-template <typename T>
-void MainlyConstantEncoding<T>::materialize(uint32_t rowCount, void* buffer) {
-  // This too isn't ideal. We will want an Encoding::Indices method or
-  // something our SparseBool can use, giving back just the set indices
-  // rather than a materialization.
-  isCommonBuffer_.resize(rowCount);
-  isCommon_->materialize(rowCount, isCommonBuffer_.data());
-  const uint32_t commonCount =
-      std::accumulate(isCommonBuffer_.begin(), isCommonBuffer_.end(), 0U);
-  const uint32_t nonCommonCount = rowCount - commonCount;
-
-  if (nonCommonCount == 0) {
-    physicalType* output = static_cast<physicalType*>(buffer);
-    std::fill(output, output + rowCount, commonValue_);
-    return;
-  }
-
-  otherValuesBuffer_.reserve(nonCommonCount);
-  otherValues_->materialize(nonCommonCount, otherValuesBuffer_.data());
-  physicalType* output = static_cast<physicalType*>(buffer);
-  const physicalType* nextOtherValue = otherValuesBuffer_.begin();
-  // This is a generic scatter -- should we have a common scatter func?
-  for (uint32_t i = 0; i < rowCount; ++i) {
-    if (isCommonBuffer_[i]) {
-      *output++ = commonValue_;
-    } else {
-      *output++ = *nextOtherValue++;
-    }
-  }
-  NIMBLE_DCHECK_EQ(
-      nextOtherValue - otherValuesBuffer_.begin(),
-      nonCommonCount,
-      "Encoding size mismatch.");
-}
-
-template <typename T>
-template <bool kScatter, typename V>
-void MainlyConstantEncoding<T>::bulkScan(
-    V& visitor,
-    vector_size_t currentNonNullRow,
-    const vector_size_t* nonNullRows,
-    vector_size_t numNonNulls,
-    const vector_size_t* scatterRows) {
-  using DataType = typename V::DataType;
-  using ValueType = detail::ValueType<DataType>;
-  constexpr bool kScatterValues = kScatter && !V::kHasFilter && !V::kHasHook;
-  ValueType* values;
-  const auto commonData = detail::castFromPhysicalType<DataType>(commonValue_);
-  const bool commonPassed =
-      velox::common::applyFilter(visitor.filter(), commonData);
-  if constexpr (!V::kFilterOnly) {
-    auto numRows = visitor.numRows() - visitor.rowIndex();
-    values = detail::mutableValues<ValueType>(visitor, numRows);
-    if (commonPassed) {
-      auto commonValue = detail::dataToValue(visitor, commonData);
-      std::fill(values, values + numRows, commonValue);
-    }
-  }
-  const auto numIsCommon = nonNullRows[numNonNulls - 1] + 1 - currentNonNullRow;
-  isCommonBuffer_.resize(velox::bits::nwords(numIsCommon) * sizeof(uint64_t));
-  auto* isCommon = reinterpret_cast<uint64_t*>(isCommonBuffer_.data());
-  // TODO: Wrap otherValues_ in BufferedEncoding.  This way when isCommon_ is
-  // SparseBoolEncoding or RLE, we can materialize it on demand and do not need
-  // to allocate memory for the indices.
-  isCommon_->materializeBoolsAsBits(numIsCommon, isCommon, 0);
-  auto numOtherValues =
-      numIsCommon - velox::bits::countBits(isCommon, 0, numIsCommon);
-  otherValuesBuffer_.resize(numOtherValues);
-  otherValues_->materialize(numOtherValues, otherValuesBuffer_.data());
-  numOtherValues = 0;
-  auto* filterHits = V::kHasFilter ? visitor.outputRows(numNonNulls) : nullptr;
-  auto* rows = kScatter ? scatterRows : nonNullRows;
-  vector_size_t numValues = 0;
-  vector_size_t numHits = 0;
-  vector_size_t nonNullRowIndex = 0;
-  velox::bits::forEachUnsetBit(isCommon, 0, numIsCommon, [&](vector_size_t i) {
-    i += currentNonNullRow;
-    auto commonBegin = nonNullRowIndex;
-    if constexpr (V::dense) {
-      nonNullRowIndex += i - nonNullRows[nonNullRowIndex];
-    } else {
-      while (nonNullRows[nonNullRowIndex] < i) {
-        ++nonNullRowIndex;
-      }
-    }
-    const auto numCommon = nonNullRowIndex - commonBegin;
-    if (V::kHasFilter && commonPassed && numCommon > 0) {
-      auto* begin = rows + commonBegin;
-      std::copy(begin, begin + numCommon, filterHits + numHits);
-      numHits += numCommon;
-    }
-    if (nonNullRows[nonNullRowIndex] > i) {
-      if constexpr (!V::kFilterOnly) {
-        vector_size_t numRows;
-        if constexpr (kScatterValues) {
-          numRows = scatterRows[nonNullRowIndex] - visitor.rowIndex();
-          visitor.addRowIndex(numRows);
-        } else {
-          numRows = commonPassed * numCommon;
-        }
-        numValues += numRows;
-      }
-      ++numOtherValues;
-      return;
-    }
-    auto otherData = detail::castFromPhysicalType<DataType>(
-        otherValuesBuffer_[numOtherValues++]);
-    bool otherPassed;
-    if constexpr (V::kHasFilter) {
-      otherPassed = velox::common::applyFilter(visitor.filter(), otherData);
-      if (otherPassed) {
-        filterHits[numHits++] = rows[nonNullRowIndex];
-      }
-    } else {
-      otherPassed = true;
-    }
-    if constexpr (!V::kFilterOnly) {
-      auto* begin = values + numValues;
-      vector_size_t numRows;
-      if constexpr (kScatterValues) {
-        begin[scatterRows[nonNullRowIndex] - visitor.rowIndex()] =
-            detail::dataToValue(visitor, otherData);
-        auto end = nonNullRowIndex + 1;
-        if (FOLLY_UNLIKELY(end == numNonNulls)) {
-          numRows = visitor.numRows() - visitor.rowIndex();
-        } else {
-          numRows = scatterRows[end] - visitor.rowIndex();
-        }
-        visitor.addRowIndex(numRows);
-      } else {
-        numRows = commonPassed * numCommon;
-        if (otherPassed) {
-          begin[numRows++] = detail::dataToValue(visitor, otherData);
-        }
-      }
-      numValues += numRows;
-    }
-    ++nonNullRowIndex;
-  });
-  auto numCommon = numNonNulls - nonNullRowIndex;
-  if (commonPassed && numCommon > 0) {
-    if constexpr (V::kHasFilter) {
-      auto* begin = rows + nonNullRowIndex;
-      std::copy(begin, begin + numCommon, filterHits + numHits);
-      numHits += numCommon;
-    }
-    if constexpr (!V::kFilterOnly) {
-      if constexpr (kScatterValues) {
-        numValues += visitor.numRows() - visitor.rowIndex();
-      } else {
-        numValues += numCommon;
-      }
-    }
-  }
-  visitor.setRowIndex(visitor.numRows());
-  if constexpr (V::kHasHook) {
-    NIMBLE_DCHECK_EQ(numValues, numNonNulls);
-    visitor.hook().addValues(scatterRows, values, numNonNulls);
-  } else {
-    visitor.addNumValues(V::kFilterOnly ? numHits : numValues);
-  }
-}
-
-template <typename T>
-template <typename V>
-void MainlyConstantEncoding<T>::readWithVisitor(
-    V& visitor,
-    ReadWithVisitorParams& params) {
-  auto* nulls = visitor.reader().rawNullsInReadRange();
-  if (velox::dwio::common::useFastPath(visitor, nulls)) {
-    detail::readWithVisitorFast(*this, visitor, params, nulls);
-    return;
-  }
-  detail::readWithVisitorSlow(
-      visitor,
-      params,
-      [&](auto toSkip) { skip(toSkip); },
-      [&] {
-        bool isCommon;
-        isCommon_->materialize(1, &isCommon);
-        if (isCommon) {
-          return commonValue_;
-        }
-        physicalType otherValue;
-        otherValues_->materialize(1, &otherValue);
-        return otherValue;
-      });
 }
 
 namespace internal {} // namespace internal
@@ -393,24 +400,21 @@ std::string_view MainlyConstantEncoding<T>::encode(
   return {reserved, encodingSize};
 }
 
-template <typename T>
-std::string MainlyConstantEncoding<T>::debugString(int offset) const {
-  std::string log = fmt::format(
-      "{}{}<{}> rowCount={} commonValue={}",
-      std::string(offset, ' '),
-      toString(Encoding::encodingType()),
-      toString(Encoding::dataType()),
-      Encoding::rowCount(),
-      commonValue_);
-  log += fmt::format(
-      "\n{}isCommon child:\n{}",
-      std::string(offset + 2, ' '),
-      isCommon_->debugString(offset + 4));
-  log += fmt::format(
-      "\n{}otherValues child:\n{}",
-      std::string(offset + 2, ' '),
-      otherValues_->debugString(offset + 4));
-  return log;
-}
+template <>
+class MainlyConstantEncoding<std::string_view> final
+    : public MainlyConstantEncodingBase<std::string_view> {
+ public:
+  using cppDataType = std::string_view;
+  using physicalType = std::string_view;
 
+  MainlyConstantEncoding(
+      velox::memory::MemoryPool& memoryPool,
+      std::string_view data,
+      std::function<void*(uint32_t)> stringBufferFactory);
+
+  static std::string_view encode(
+      EncodingSelection<physicalType>& selection,
+      std::span<const physicalType> values,
+      Buffer& buffer);
+};
 } // namespace facebook::nimble

--- a/dwio/nimble/encodings/NullableEncoding.h
+++ b/dwio/nimble/encodings/NullableEncoding.h
@@ -45,7 +45,8 @@ class NullableEncoding final
 
   NullableEncoding(
       velox::memory::MemoryPool& memoryPool,
-      std::string_view data);
+      std::string_view data,
+      std::function<void*(uint32_t)> stringBufferFactory);
 
   uint32_t nullCount() const final;
   bool isNullable() const final;
@@ -91,16 +92,20 @@ class NullableEncoding final
 template <typename T>
 NullableEncoding<T>::NullableEncoding(
     velox::memory::MemoryPool& memoryPool,
-    std::string_view data)
+    std::string_view data,
+    std::function<void*(uint32_t)> stringBufferFactory)
     : TypedEncoding<T, physicalType>(memoryPool, data),
       indicesBuffer_(this->pool_),
       nullBuffer_(this->pool_) {
   const char* pos = data.data() + Encoding::kPrefixSize;
   const uint32_t nonNullsBytes = encoding::readUint32(pos);
-  nonNullValues_ = EncodingFactory::decode(*this->pool_, {pos, nonNullsBytes});
+  nonNullValues_ = EncodingFactory::decode(
+      *this->pool_, {pos, nonNullsBytes}, stringBufferFactory);
   pos += nonNullsBytes;
   nulls_ = EncodingFactory::decode(
-      *this->pool_, {pos, static_cast<size_t>(data.end() - pos)});
+      *this->pool_,
+      {pos, static_cast<size_t>(data.end() - pos)},
+      stringBufferFactory);
   NIMBLE_DCHECK_EQ(
       Encoding::rowCount(), nulls_->rowCount(), "Nulls count mismatch.");
 }

--- a/dwio/nimble/encodings/RleEncoding.cpp
+++ b/dwio/nimble/encodings/RleEncoding.cpp
@@ -17,10 +17,44 @@
 
 namespace facebook::nimble {
 
+RLEEncoding<std::string_view>::RLEEncoding(
+    velox::memory::MemoryPool& memoryPool,
+    std::string_view data,
+    std::function<void*(uint32_t)> stringBufferFactory)
+    : internal::RLEEncodingBase<
+          std::string_view,
+          RLEEncoding<std::string_view>>(memoryPool, data, stringBufferFactory),
+      values_{EncodingFactory::decode(
+          memoryPool,
+          {internal::RLEEncodingBase<
+               std::string_view,
+               RLEEncoding<std::string_view>>::getValuesStart(),
+           static_cast<size_t>(
+               data.end() -
+               internal::RLEEncodingBase<
+                   std::string_view,
+                   RLEEncoding<std::string_view>>::getValuesStart())},
+          stringBufferFactory)} {
+  internal::RLEEncodingBase<std::string_view, RLEEncoding<std::string_view>>::
+      reset();
+}
+
+std::string_view RLEEncoding<std::string_view>::nextValue() {
+  return values_.nextValue();
+}
+
+void RLEEncoding<std::string_view>::resetValues() {
+  values_.reset();
+}
+
 RLEEncoding<bool>::RLEEncoding(
     velox::memory::MemoryPool& memoryPool,
-    std::string_view data)
-    : internal::RLEEncodingBase<bool, RLEEncoding<bool>>(memoryPool, data) {
+    std::string_view data,
+    std::function<void*(uint32_t)> stringBufferFactory)
+    : internal::RLEEncodingBase<bool, RLEEncoding<bool>>(
+          memoryPool,
+          data,
+          stringBufferFactory) {
   initialValue_ = *reinterpret_cast<const bool*>(
       internal::RLEEncodingBase<bool, RLEEncoding<bool>>::getValuesStart());
   NIMBLE_CHECK(

--- a/dwio/nimble/encodings/SentinelEncoding.h
+++ b/dwio/nimble/encodings/SentinelEncoding.h
@@ -50,7 +50,8 @@ class SentinelEncoding final
 
   SentinelEncoding(
       velox::memory::MemoryPool& memoryPool,
-      std::string_view data);
+      std::string_view data,
+      std::function<void*(uint32_t)> stringBufferFactory);
 
   uint32_t nullCount() const final;
   bool isNullable() const final;
@@ -106,7 +107,8 @@ class SentinelEncoding final
 template <typename T>
 SentinelEncoding<T>::SentinelEncoding(
     velox::memory::MemoryPool& memoryPool,
-    std::string_view data)
+    std::string_view data,
+    std::function<void*(uint32_t)> /* stringBufferFactory */)
     : TypedEncoding<T, physicalType>(memoryPool, data), buffer_(&memoryPool) {
   const char* pos = data.data() + Encoding::kPrefixSize;
   nullCount_ = encoding::readUint32(pos);

--- a/dwio/nimble/encodings/SparseBoolEncoding.cpp
+++ b/dwio/nimble/encodings/SparseBoolEncoding.cpp
@@ -27,13 +27,15 @@ namespace facebook::nimble {
 
 SparseBoolEncoding::SparseBoolEncoding(
     velox::memory::MemoryPool& memoryPool,
-    std::string_view data)
+    std::string_view data,
+    std::function<void*(uint32_t)> stringBufferFactory)
     : TypedEncoding<bool, bool>{memoryPool, data},
       sparseValue_{static_cast<bool>(data[kSparseValueOffset])},
       indicesUncompressed_{&memoryPool},
       indices_{EncodingFactory::decode(
           memoryPool,
-          {data.data() + kIndicesOffset, data.size() - kIndicesOffset})} {
+          {data.data() + kIndicesOffset, data.size() - kIndicesOffset},
+          stringBufferFactory)} {
   reset();
 }
 

--- a/dwio/nimble/encodings/SparseBoolEncoding.h
+++ b/dwio/nimble/encodings/SparseBoolEncoding.h
@@ -53,7 +53,8 @@ class SparseBoolEncoding final : public TypedEncoding<bool, bool> {
 
   SparseBoolEncoding(
       velox::memory::MemoryPool& memoryPool,
-      std::string_view data);
+      std::string_view data,
+      std::function<void*(uint32_t)> stringBufferFactory);
 
   void reset() final;
   void skip(uint32_t rowCount) final;

--- a/dwio/nimble/encodings/TrivialEncoding.h
+++ b/dwio/nimble/encodings/TrivialEncoding.h
@@ -53,7 +53,10 @@ class TrivialEncoding final
   static constexpr int kDataOffset =
       Encoding::kPrefixSize + TrivialEncoding<T>::kPrefixSize;
 
-  TrivialEncoding(velox::memory::MemoryPool& memoryPool, std::string_view data);
+  TrivialEncoding(
+      velox::memory::MemoryPool& memoryPool,
+      std::string_view data,
+      std::function<void*(uint32_t)> stringBufferFactory);
 
   void reset() final;
   void skip(uint32_t rowCount) final;
@@ -99,7 +102,10 @@ class TrivialEncoding<std::string_view> final
   static constexpr int kLengthOffset =
       Encoding::kPrefixSize + TrivialEncoding<std::string_view>::kPrefixSize;
 
-  TrivialEncoding(velox::memory::MemoryPool& memoryPool, std::string_view data);
+  TrivialEncoding(
+      velox::memory::MemoryPool& memoryPool,
+      std::string_view data,
+      std::function<void*(uint32_t)> stringBufferFactory);
 
   void reset() final;
   void skip(uint32_t rowCount) final;
@@ -147,7 +153,10 @@ class TrivialEncoding<bool> final : public TypedEncoding<bool, bool> {
   static constexpr int kDataOffset =
       Encoding::kPrefixSize + TrivialEncoding<bool>::kPrefixSize;
 
-  TrivialEncoding(velox::memory::MemoryPool& pool, std::string_view data);
+  TrivialEncoding(
+      velox::memory::MemoryPool& pool,
+      std::string_view data,
+      std::function<void*(uint32_t)> stringBufferFactory);
 
   void reset() final;
   void skip(uint32_t rowCount) final;
@@ -177,7 +186,8 @@ class TrivialEncoding<bool> final : public TypedEncoding<bool, bool> {
 template <typename T>
 TrivialEncoding<T>::TrivialEncoding(
     velox::memory::MemoryPool& memoryPool,
-    std::string_view data)
+    std::string_view data,
+    std::function<void*(uint32_t)> /* stringBufferFactory */)
     : TypedEncoding<T, physicalType>{memoryPool, data},
       row_{0},
       values_{reinterpret_cast<const T*>(data.data() + kDataOffset)},
@@ -256,7 +266,8 @@ void TrivialEncoding<T>::bulkScan(
   T* values = detail::mutableValues<T>(visitor, numRows);
   const auto offset = static_cast<vector_size_t>(row_) - currentRow;
   if constexpr (V::dense) {
-    memcpy(values, values_ + nonNullRows[0] + offset, numNonNulls * sizeof(T));
+    std::memcpy(
+        values, values_ + nonNullRows[0] + offset, numNonNulls * sizeof(T));
   } else {
     for (vector_size_t i = 0; i < numNonNulls; ++i) {
       values[i] = values_[nonNullRows[i] + offset];

--- a/dwio/nimble/encodings/VarintEncoding.h
+++ b/dwio/nimble/encodings/VarintEncoding.h
@@ -50,7 +50,10 @@ class VarintEncoding final
   static const int kDataOffset = kBaselineOffset + sizeof(T);
   static const int kPrefixSize = kDataOffset - kBaselineOffset;
 
-  VarintEncoding(velox::memory::MemoryPool& pool, std::string_view data);
+  VarintEncoding(
+      velox::memory::MemoryPool& pool,
+      std::string_view data,
+      std::function<void*(uint32_t)> stringBufferFactory);
 
   void reset() final;
   void skip(uint32_t rowCount) final;
@@ -78,7 +81,8 @@ class VarintEncoding final
 template <typename T>
 VarintEncoding<T>::VarintEncoding(
     velox::memory::MemoryPool& pool,
-    std::string_view data)
+    std::string_view data,
+    std::function<void*(uint32_t)> /* stringBufferFactory */)
     : TypedEncoding<T, physicalType>(pool, data),
       baseValue_{*reinterpret_cast<const physicalType*>(
           data.data() + kBaselineOffset)},

--- a/dwio/nimble/encodings/legacy/ConstantEncoding.h
+++ b/dwio/nimble/encodings/legacy/ConstantEncoding.h
@@ -41,7 +41,8 @@ class ConstantEncoding final
 
   ConstantEncoding(
       velox::memory::MemoryPool& memoryPool,
-      std::string_view data);
+      std::string_view data,
+      std::function<void*(uint32_t)> stringBufferFactory);
 
   void reset() final;
   void skip(uint32_t rowCount) final;
@@ -71,7 +72,8 @@ class ConstantEncoding final
 template <typename T>
 ConstantEncoding<T>::ConstantEncoding(
     velox::memory::MemoryPool& memoryPool,
-    std::string_view data)
+    std::string_view data,
+    std::function<void*(uint32_t)> /* stringBufferFactory */)
     : TypedEncoding<T, physicalType>(memoryPool, data) {
   const char* pos = data.data() + Encoding::kPrefixSize;
   value_ = encoding::read<physicalType>(pos);

--- a/dwio/nimble/encodings/legacy/DictionaryEncoding.h
+++ b/dwio/nimble/encodings/legacy/DictionaryEncoding.h
@@ -48,7 +48,10 @@ class DictionaryEncoding
 
   static const int kAlphabetSizeOffset = Encoding::kPrefixSize;
 
-  DictionaryEncoding(velox::memory::MemoryPool& pool, std::string_view data);
+  DictionaryEncoding(
+      velox::memory::MemoryPool& pool,
+      std::string_view data,
+      std::function<void*(uint32_t)> stringBufferFactory);
 
   void reset() final;
   void skip(uint32_t rowCount) final;
@@ -82,21 +85,24 @@ class DictionaryEncoding
 template <typename T>
 DictionaryEncoding<T>::DictionaryEncoding(
     velox::memory::MemoryPool& pool,
-    std::string_view data)
+    std::string_view data,
+    std::function<void*(uint32_t)> stringBufferFactory)
     : TypedEncoding<T, physicalType>{pool, data},
       alphabet_{this->pool_},
       indicesBuffer_{this->pool_} {
   const auto* pos = data.data() + kAlphabetSizeOffset;
   const uint32_t alphabetSize = encoding::readUint32(pos);
-  alphabetEncoding_ =
-      EncodingFactory::decode(*this->pool_, {pos, alphabetSize});
+  alphabetEncoding_ = EncodingFactory::decode(
+      *this->pool_, {pos, alphabetSize}, stringBufferFactory);
   const uint32_t alphabetCount = alphabetEncoding_->rowCount();
   alphabet_.resize(alphabetCount);
   alphabetEncoding_->materialize(alphabetCount, alphabet_.data());
 
   pos += alphabetSize;
   indicesEncoding_ = EncodingFactory::decode(
-      *this->pool_, {pos, static_cast<size_t>(data.end() - pos)});
+      *this->pool_,
+      {pos, static_cast<size_t>(data.end() - pos)},
+      stringBufferFactory);
 }
 
 template <typename T>

--- a/dwio/nimble/encodings/legacy/EncodingFactory.cpp
+++ b/dwio/nimble/encodings/legacy/EncodingFactory.cpp
@@ -47,119 +47,159 @@ static std::span<const typename TypeTraits<T>::physicalType> toPhysicalSpan(
 
 std::unique_ptr<Encoding> EncodingFactory::decode(
     velox::memory::MemoryPool& memoryPool,
-    std::string_view data) {
+    std::string_view data,
+    std::function<void*(uint32_t)> stringBufferFactory) {
   // Maybe we should have a magic number of encodings too? Hrm.
   const EncodingType encodingType = static_cast<EncodingType>(data[0]);
   const DataType dataType = static_cast<DataType>(data[1]);
-#define RETURN_ENCODING_BY_LEAF_TYPE(Encoding, dataType)                     \
-  switch (dataType) {                                                        \
-    case DataType::Int8:                                                     \
-      return std::make_unique<Encoding<int8_t>>(memoryPool, data);           \
-    case DataType::Uint8:                                                    \
-      return std::make_unique<Encoding<uint8_t>>(memoryPool, data);          \
-    case DataType::Int16:                                                    \
-      return std::make_unique<Encoding<int16_t>>(memoryPool, data);          \
-    case DataType::Uint16:                                                   \
-      return std::make_unique<Encoding<uint16_t>>(memoryPool, data);         \
-    case DataType::Int32:                                                    \
-      return std::make_unique<Encoding<int32_t>>(memoryPool, data);          \
-    case DataType::Uint32:                                                   \
-      return std::make_unique<Encoding<uint32_t>>(memoryPool, data);         \
-    case DataType::Int64:                                                    \
-      return std::make_unique<Encoding<int64_t>>(memoryPool, data);          \
-    case DataType::Uint64:                                                   \
-      return std::make_unique<Encoding<uint64_t>>(memoryPool, data);         \
-    case DataType::Float:                                                    \
-      return std::make_unique<Encoding<float>>(memoryPool, data);            \
-    case DataType::Double:                                                   \
-      return std::make_unique<Encoding<double>>(memoryPool, data);           \
-    case DataType::Bool:                                                     \
-      return std::make_unique<Encoding<bool>>(memoryPool, data);             \
-    case DataType::String:                                                   \
-      return std::make_unique<Encoding<std::string_view>>(memoryPool, data); \
-    default:                                                                 \
-      NIMBLE_UNREACHABLE("Unknown encoding type {}.", toString(dataType))    \
+#define RETURN_ENCODING_BY_LEAF_TYPE(Encoding, dataType)                  \
+  switch (dataType) {                                                     \
+    case DataType::Int8:                                                  \
+      return std::make_unique<Encoding<int8_t>>(                          \
+          memoryPool, data, stringBufferFactory);                         \
+    case DataType::Uint8:                                                 \
+      return std::make_unique<Encoding<uint8_t>>(                         \
+          memoryPool, data, stringBufferFactory);                         \
+    case DataType::Int16:                                                 \
+      return std::make_unique<Encoding<int16_t>>(                         \
+          memoryPool, data, stringBufferFactory);                         \
+    case DataType::Uint16:                                                \
+      return std::make_unique<Encoding<uint16_t>>(                        \
+          memoryPool, data, stringBufferFactory);                         \
+    case DataType::Int32:                                                 \
+      return std::make_unique<Encoding<int32_t>>(                         \
+          memoryPool, data, stringBufferFactory);                         \
+    case DataType::Uint32:                                                \
+      return std::make_unique<Encoding<uint32_t>>(                        \
+          memoryPool, data, stringBufferFactory);                         \
+    case DataType::Int64:                                                 \
+      return std::make_unique<Encoding<int64_t>>(                         \
+          memoryPool, data, stringBufferFactory);                         \
+    case DataType::Uint64:                                                \
+      return std::make_unique<Encoding<uint64_t>>(                        \
+          memoryPool, data, stringBufferFactory);                         \
+    case DataType::Float:                                                 \
+      return std::make_unique<Encoding<float>>(                           \
+          memoryPool, data, stringBufferFactory);                         \
+    case DataType::Double:                                                \
+      return std::make_unique<Encoding<double>>(                          \
+          memoryPool, data, stringBufferFactory);                         \
+    case DataType::Bool:                                                  \
+      return std::make_unique<Encoding<bool>>(                            \
+          memoryPool, data, stringBufferFactory);                         \
+    case DataType::String:                                                \
+      return std::make_unique<Encoding<std::string_view>>(                \
+          memoryPool, data, stringBufferFactory);                         \
+    default:                                                              \
+      NIMBLE_UNREACHABLE("Unknown encoding type {}.", toString(dataType)) \
   }
 
-#define RETURN_ENCODING_BY_VARINT_TYPE(Encoding, dataType)           \
-  switch (dataType) {                                                \
-    case DataType::Int32:                                            \
-      return std::make_unique<Encoding<int32_t>>(memoryPool, data);  \
-    case DataType::Uint32:                                           \
-      return std::make_unique<Encoding<uint32_t>>(memoryPool, data); \
-    case DataType::Int64:                                            \
-      return std::make_unique<Encoding<int64_t>>(memoryPool, data);  \
-    case DataType::Uint64:                                           \
-      return std::make_unique<Encoding<uint64_t>>(memoryPool, data); \
-    case DataType::Float:                                            \
-      return std::make_unique<Encoding<float>>(memoryPool, data);    \
-    case DataType::Double:                                           \
-      return std::make_unique<Encoding<double>>(memoryPool, data);   \
-    default:                                                         \
-      NIMBLE_UNREACHABLE(                                            \
-          "Trying to deserialize a varint stream for "               \
-          "an incompatible data type {}.",                           \
-          toString(dataType));                                       \
+#define RETURN_ENCODING_BY_VARINT_TYPE(Encoding, dataType) \
+  switch (dataType) {                                      \
+    case DataType::Int32:                                  \
+      return std::make_unique<Encoding<int32_t>>(          \
+          memoryPool, data, stringBufferFactory);          \
+    case DataType::Uint32:                                 \
+      return std::make_unique<Encoding<uint32_t>>(         \
+          memoryPool, data, stringBufferFactory);          \
+    case DataType::Int64:                                  \
+      return std::make_unique<Encoding<int64_t>>(          \
+          memoryPool, data, stringBufferFactory);          \
+    case DataType::Uint64:                                 \
+      return std::make_unique<Encoding<uint64_t>>(         \
+          memoryPool, data, stringBufferFactory);          \
+    case DataType::Float:                                  \
+      return std::make_unique<Encoding<float>>(            \
+          memoryPool, data, stringBufferFactory);          \
+    case DataType::Double:                                 \
+      return std::make_unique<Encoding<double>>(           \
+          memoryPool, data, stringBufferFactory);          \
+    default:                                               \
+      NIMBLE_UNREACHABLE(                                  \
+          "Trying to deserialize a varint stream for "     \
+          "an incompatible data type {}.",                 \
+          toString(dataType));                             \
   }
 
-#define RETURN_ENCODING_BY_NON_BOOL_TYPE(Encoding, dataType)                 \
-  switch (dataType) {                                                        \
-    case DataType::Int8:                                                     \
-      return std::make_unique<Encoding<int8_t>>(memoryPool, data);           \
-    case DataType::Uint8:                                                    \
-      return std::make_unique<Encoding<uint8_t>>(memoryPool, data);          \
-    case DataType::Int16:                                                    \
-      return std::make_unique<Encoding<int16_t>>(memoryPool, data);          \
-    case DataType::Uint16:                                                   \
-      return std::make_unique<Encoding<uint16_t>>(memoryPool, data);         \
-    case DataType::Int32:                                                    \
-      return std::make_unique<Encoding<int32_t>>(memoryPool, data);          \
-    case DataType::Uint32:                                                   \
-      return std::make_unique<Encoding<uint32_t>>(memoryPool, data);         \
-    case DataType::Int64:                                                    \
-      return std::make_unique<Encoding<int64_t>>(memoryPool, data);          \
-    case DataType::Uint64:                                                   \
-      return std::make_unique<Encoding<uint64_t>>(memoryPool, data);         \
-    case DataType::Float:                                                    \
-      return std::make_unique<Encoding<float>>(memoryPool, data);            \
-    case DataType::Double:                                                   \
-      return std::make_unique<Encoding<double>>(memoryPool, data);           \
-    case DataType::String:                                                   \
-      return std::make_unique<Encoding<std::string_view>>(memoryPool, data); \
-    default:                                                                 \
-      NIMBLE_UNREACHABLE(                                                    \
-          "Trying to deserialize a non-bool stream for "                     \
-          "the bool data type {}.",                                          \
-          toString(dataType));                                               \
+#define RETURN_ENCODING_BY_NON_BOOL_TYPE(Encoding, dataType) \
+  switch (dataType) {                                        \
+    case DataType::Int8:                                     \
+      return std::make_unique<Encoding<int8_t>>(             \
+          memoryPool, data, stringBufferFactory);            \
+    case DataType::Uint8:                                    \
+      return std::make_unique<Encoding<uint8_t>>(            \
+          memoryPool, data, stringBufferFactory);            \
+    case DataType::Int16:                                    \
+      return std::make_unique<Encoding<int16_t>>(            \
+          memoryPool, data, stringBufferFactory);            \
+    case DataType::Uint16:                                   \
+      return std::make_unique<Encoding<uint16_t>>(           \
+          memoryPool, data, stringBufferFactory);            \
+    case DataType::Int32:                                    \
+      return std::make_unique<Encoding<int32_t>>(            \
+          memoryPool, data, stringBufferFactory);            \
+    case DataType::Uint32:                                   \
+      return std::make_unique<Encoding<uint32_t>>(           \
+          memoryPool, data, stringBufferFactory);            \
+    case DataType::Int64:                                    \
+      return std::make_unique<Encoding<int64_t>>(            \
+          memoryPool, data, stringBufferFactory);            \
+    case DataType::Uint64:                                   \
+      return std::make_unique<Encoding<uint64_t>>(           \
+          memoryPool, data, stringBufferFactory);            \
+    case DataType::Float:                                    \
+      return std::make_unique<Encoding<float>>(              \
+          memoryPool, data, stringBufferFactory);            \
+    case DataType::Double:                                   \
+      return std::make_unique<Encoding<double>>(             \
+          memoryPool, data, stringBufferFactory);            \
+    case DataType::String:                                   \
+      return std::make_unique<Encoding<std::string_view>>(   \
+          memoryPool, data, stringBufferFactory);            \
+    default:                                                 \
+      NIMBLE_UNREACHABLE(                                    \
+          "Trying to deserialize a non-bool stream for "     \
+          "the bool data type {}.",                          \
+          toString(dataType));                               \
   }
 
-#define RETURN_ENCODING_BY_NUMERIC_TYPE(Encoding, dataType)          \
-  switch (dataType) {                                                \
-    case DataType::Int8:                                             \
-      return std::make_unique<Encoding<int8_t>>(memoryPool, data);   \
-    case DataType::Uint8:                                            \
-      return std::make_unique<Encoding<uint8_t>>(memoryPool, data);  \
-    case DataType::Int16:                                            \
-      return std::make_unique<Encoding<int16_t>>(memoryPool, data);  \
-    case DataType::Uint16:                                           \
-      return std::make_unique<Encoding<uint16_t>>(memoryPool, data); \
-    case DataType::Int32:                                            \
-      return std::make_unique<Encoding<int32_t>>(memoryPool, data);  \
-    case DataType::Uint32:                                           \
-      return std::make_unique<Encoding<uint32_t>>(memoryPool, data); \
-    case DataType::Int64:                                            \
-      return std::make_unique<Encoding<int64_t>>(memoryPool, data);  \
-    case DataType::Uint64:                                           \
-      return std::make_unique<Encoding<uint64_t>>(memoryPool, data); \
-    case DataType::Float:                                            \
-      return std::make_unique<Encoding<float>>(memoryPool, data);    \
-    case DataType::Double:                                           \
-      return std::make_unique<Encoding<double>>(memoryPool, data);   \
-    default:                                                         \
-      NIMBLE_UNREACHABLE(                                            \
-          "Trying to deserialize a non-numeric stream for "          \
-          "a numeric data type {}.",                                 \
-          toString(dataType));                                       \
+#define RETURN_ENCODING_BY_NUMERIC_TYPE(Encoding, dataType) \
+  switch (dataType) {                                       \
+    case DataType::Int8:                                    \
+      return std::make_unique<Encoding<int8_t>>(            \
+          memoryPool, data, stringBufferFactory);           \
+    case DataType::Uint8:                                   \
+      return std::make_unique<Encoding<uint8_t>>(           \
+          memoryPool, data, stringBufferFactory);           \
+    case DataType::Int16:                                   \
+      return std::make_unique<Encoding<int16_t>>(           \
+          memoryPool, data, stringBufferFactory);           \
+    case DataType::Uint16:                                  \
+      return std::make_unique<Encoding<uint16_t>>(          \
+          memoryPool, data, stringBufferFactory);           \
+    case DataType::Int32:                                   \
+      return std::make_unique<Encoding<int32_t>>(           \
+          memoryPool, data, stringBufferFactory);           \
+    case DataType::Uint32:                                  \
+      return std::make_unique<Encoding<uint32_t>>(          \
+          memoryPool, data, stringBufferFactory);           \
+    case DataType::Int64:                                   \
+      return std::make_unique<Encoding<int64_t>>(           \
+          memoryPool, data, stringBufferFactory);           \
+    case DataType::Uint64:                                  \
+      return std::make_unique<Encoding<uint64_t>>(          \
+          memoryPool, data, stringBufferFactory);           \
+    case DataType::Float:                                   \
+      return std::make_unique<Encoding<float>>(             \
+          memoryPool, data, stringBufferFactory);           \
+    case DataType::Double:                                  \
+      return std::make_unique<Encoding<double>>(            \
+          memoryPool, data, stringBufferFactory);           \
+    default:                                                \
+      NIMBLE_UNREACHABLE(                                   \
+          "Trying to deserialize a non-numeric stream for " \
+          "a numeric data type {}.",                        \
+          toString(dataType));                              \
   }
 
   switch (encodingType) {
@@ -183,7 +223,8 @@ std::unique_ptr<Encoding> EncodingFactory::decode(
           dataType,
           DataType::Bool,
           "Trying to deserialize a SparseBoolEncoding with a non-bool data type.");
-      return std::make_unique<SparseBoolEncoding>(memoryPool, data);
+      return std::make_unique<SparseBoolEncoding>(
+          memoryPool, data, stringBufferFactory);
     }
     case EncodingType::Varint: {
       RETURN_ENCODING_BY_VARINT_TYPE(VarintEncoding, dataType);

--- a/dwio/nimble/encodings/legacy/EncodingFactory.h
+++ b/dwio/nimble/encodings/legacy/EncodingFactory.h
@@ -35,7 +35,8 @@ class EncodingFactory {
  public:
   static std::unique_ptr<Encoding> decode(
       velox::memory::MemoryPool& memoryPool,
-      std::string_view data);
+      std::string_view data,
+      std::function<void*(uint32_t)> stringBufferFactory);
 
   template <typename T>
   static std::string_view encode(

--- a/dwio/nimble/encodings/legacy/FixedBitWidthEncoding.h
+++ b/dwio/nimble/encodings/legacy/FixedBitWidthEncoding.h
@@ -55,7 +55,8 @@ class FixedBitWidthEncoding final
 
   FixedBitWidthEncoding(
       velox::memory::MemoryPool& memoryPool,
-      std::string_view data);
+      std::string_view data,
+      std::function<void*(uint32_t)> stringBufferFactory);
 
   void reset() final;
   void skip(uint32_t rowCount) final;
@@ -87,7 +88,8 @@ class FixedBitWidthEncoding final
 template <typename T>
 FixedBitWidthEncoding<T>::FixedBitWidthEncoding(
     velox::memory::MemoryPool& memoryPool,
-    std::string_view data)
+    std::string_view data,
+    std::function<void*(uint32_t)> /* stringBufferFactory */)
     : TypedEncoding<T, physicalType>{memoryPool, data},
       uncompressedData_{&memoryPool},
       buffer_{&memoryPool} {

--- a/dwio/nimble/encodings/legacy/RleEncoding.cpp
+++ b/dwio/nimble/encodings/legacy/RleEncoding.cpp
@@ -19,8 +19,12 @@ namespace facebook::nimble::legacy {
 
 RLEEncoding<bool>::RLEEncoding(
     velox::memory::MemoryPool& memoryPool,
-    std::string_view data)
-    : internal::RLEEncodingBase<bool, RLEEncoding<bool>>(memoryPool, data) {
+    std::string_view data,
+    std::function<void*(uint32_t)> stringBufferFactory)
+    : internal::RLEEncodingBase<bool, RLEEncoding<bool>>(
+          memoryPool,
+          data,
+          stringBufferFactory) {
   initialValue_ = *reinterpret_cast<const bool*>(
       internal::RLEEncodingBase<bool, RLEEncoding<bool>>::getValuesStart());
   NIMBLE_CHECK(

--- a/dwio/nimble/encodings/legacy/SparseBoolEncoding.cpp
+++ b/dwio/nimble/encodings/legacy/SparseBoolEncoding.cpp
@@ -27,13 +27,15 @@ namespace facebook::nimble::legacy {
 
 SparseBoolEncoding::SparseBoolEncoding(
     velox::memory::MemoryPool& memoryPool,
-    std::string_view data)
+    std::string_view data,
+    std::function<void*(uint32_t)> stringBufferFactory)
     : TypedEncoding<bool, bool>{memoryPool, data},
       sparseValue_{static_cast<bool>(data[kSparseValueOffset])},
       indicesUncompressed_{&memoryPool},
       indices_{EncodingFactory::decode(
           memoryPool,
-          {data.data() + kIndicesOffset, data.size() - kIndicesOffset})} {
+          {data.data() + kIndicesOffset, data.size() - kIndicesOffset},
+          stringBufferFactory)} {
   reset();
 }
 

--- a/dwio/nimble/encodings/legacy/SparseBoolEncoding.h
+++ b/dwio/nimble/encodings/legacy/SparseBoolEncoding.h
@@ -54,7 +54,8 @@ class SparseBoolEncoding final : public TypedEncoding<bool, bool> {
 
   SparseBoolEncoding(
       velox::memory::MemoryPool& memoryPool,
-      std::string_view data);
+      std::string_view data,
+      std::function<void*(uint32_t)> stringBufferFactory);
 
   void reset() final;
   void skip(uint32_t rowCount) final;

--- a/dwio/nimble/encodings/legacy/TrivialEncoding.cpp
+++ b/dwio/nimble/encodings/legacy/TrivialEncoding.cpp
@@ -20,7 +20,8 @@ namespace facebook::nimble::legacy {
 
 TrivialEncoding<std::string_view>::TrivialEncoding(
     velox::memory::MemoryPool& memoryPool,
-    std::string_view data)
+    std::string_view data,
+    std::function<void*(uint32_t)> stringBufferFactory)
     : TypedEncoding<std::string_view, std::string_view>{memoryPool, data},
       row_{0},
       buffer_{&memoryPool},
@@ -29,7 +30,8 @@ TrivialEncoding<std::string_view>::TrivialEncoding(
   auto dataCompressionType =
       static_cast<CompressionType>(encoding::readChar(pos));
   auto lengthsSize = encoding::readUint32(pos);
-  lengths_ = EncodingFactory::decode(memoryPool, {pos, lengthsSize});
+  lengths_ = EncodingFactory::decode(
+      memoryPool, {pos, lengthsSize}, stringBufferFactory);
   blob_ = pos + lengthsSize;
 
   if (dataCompressionType != CompressionType::Uncompressed) {
@@ -135,7 +137,8 @@ std::string_view TrivialEncoding<std::string_view>::encode(
 
 TrivialEncoding<bool>::TrivialEncoding(
     velox::memory::MemoryPool& pool,
-    std::string_view data)
+    std::string_view data,
+    std::function<void*(uint32_t)> /* stringBufferFactory */)
     : TypedEncoding<bool, bool>{pool, data},
       bitmap_{data.data() + kDataOffset},
       uncompressed_{&pool} {

--- a/dwio/nimble/encodings/legacy/TrivialEncoding.h
+++ b/dwio/nimble/encodings/legacy/TrivialEncoding.h
@@ -54,7 +54,10 @@ class TrivialEncoding final
   static constexpr int kDataOffset =
       Encoding::kPrefixSize + TrivialEncoding<T>::kPrefixSize;
 
-  TrivialEncoding(velox::memory::MemoryPool& memoryPool, std::string_view data);
+  TrivialEncoding(
+      velox::memory::MemoryPool& memoryPool,
+      std::string_view data,
+      std::function<void*(uint32_t)> stringBufferFactory);
 
   void reset() final;
   void skip(uint32_t rowCount) final;
@@ -100,7 +103,10 @@ class TrivialEncoding<std::string_view> final
   static constexpr int kLengthOffset =
       Encoding::kPrefixSize + TrivialEncoding<std::string_view>::kPrefixSize;
 
-  TrivialEncoding(velox::memory::MemoryPool& memoryPool, std::string_view data);
+  TrivialEncoding(
+      velox::memory::MemoryPool& memoryPool,
+      std::string_view data,
+      std::function<void*(uint32_t)> stringBufferFactory);
 
   void reset() final;
   void skip(uint32_t rowCount) final;
@@ -146,7 +152,10 @@ class TrivialEncoding<bool> final : public TypedEncoding<bool, bool> {
   static constexpr int kDataOffset =
       Encoding::kPrefixSize + TrivialEncoding<bool>::kPrefixSize;
 
-  TrivialEncoding(velox::memory::MemoryPool& pool, std::string_view data);
+  TrivialEncoding(
+      velox::memory::MemoryPool& pool,
+      std::string_view data,
+      std::function<void*(uint32_t)> stringBufferFactory);
 
   void reset() final;
   void skip(uint32_t rowCount) final;
@@ -176,7 +185,8 @@ class TrivialEncoding<bool> final : public TypedEncoding<bool, bool> {
 template <typename T>
 TrivialEncoding<T>::TrivialEncoding(
     velox::memory::MemoryPool& memoryPool,
-    std::string_view data)
+    std::string_view data,
+    std::function<void*(uint32_t)> /* stringBufferFactory */)
     : TypedEncoding<T, physicalType>{memoryPool, data},
       row_{0},
       values_{reinterpret_cast<const T*>(data.data() + kDataOffset)},

--- a/dwio/nimble/encodings/legacy/VarintEncoding.h
+++ b/dwio/nimble/encodings/legacy/VarintEncoding.h
@@ -49,7 +49,10 @@ class VarintEncoding final
   static const int kDataOffset = kBaselineOffset + sizeof(T);
   static const int kPrefixSize = kDataOffset - kBaselineOffset;
 
-  VarintEncoding(velox::memory::MemoryPool& pool, std::string_view data);
+  VarintEncoding(
+      velox::memory::MemoryPool& pool,
+      std::string_view data,
+      std::function<void*(uint32_t)> stringBufferFactory);
 
   void reset() final;
   void skip(uint32_t rowCount) final;
@@ -77,7 +80,8 @@ class VarintEncoding final
 template <typename T>
 VarintEncoding<T>::VarintEncoding(
     velox::memory::MemoryPool& pool,
-    std::string_view data)
+    std::string_view data,
+    std::function<void*(uint32_t)> /* stringBufferFactory */)
     : TypedEncoding<T, physicalType>(pool, data),
       baseValue_{*reinterpret_cast<const physicalType*>(
           data.data() + kBaselineOffset)},

--- a/dwio/nimble/encodings/tests/MainlyConstantEncodingTests.cpp
+++ b/dwio/nimble/encodings/tests/MainlyConstantEncodingTests.cpp
@@ -98,9 +98,15 @@ TYPED_TEST(MainlyConstantEncodingTest, SerializeThenDeserialize) {
   using D = TypeParam;
 
   auto valueGroups = this->template prepareValues<D>();
+  std::vector<velox::BufferPtr> newStringBuffers;
+  const auto stringBufferFactory = [&](uint32_t totalLength) {
+    auto& buffer = newStringBuffers.emplace_back(
+        velox::AlignedBuffer::allocate<char>(totalLength, this->pool_.get()));
+    return buffer->template asMutable<void>();
+  };
   for (const auto& values : valueGroups) {
     auto encoding = nimble::test::Encoder<nimble::MainlyConstantEncoding<D>>::
-        createEncoding(*this->buffer_, values);
+        createEncoding(*this->buffer_, values, stringBufferFactory);
 
     uint32_t rowCount = values.size();
     nimble::Vector<D> result(this->pool_.get(), rowCount);

--- a/dwio/nimble/encodings/tests/NullableEncodingTests.cpp
+++ b/dwio/nimble/encodings/tests/NullableEncodingTests.cpp
@@ -150,8 +150,16 @@ TYPED_TEST(NullableEncodingTest, Materialize) {
         const nimble::Vector<E> spreadData =
             spreadNullsIntoData<E>(*this->pool_, data, nulls);
 
+        std::vector<velox::BufferPtr> newStringBuffers;
+        const auto stringBufferFactory = [&](uint32_t totalLength) {
+          auto& buffer = newStringBuffers.emplace_back(
+              velox::AlignedBuffer::allocate<char>(
+                  totalLength, this->pool_.get()));
+          return buffer->template asMutable<void>();
+        };
         auto encoding = nimble::test::Encoder<nimble::NullableEncoding<E>>::
-            createNullableEncoding(*this->buffer_, data, nulls);
+            createNullableEncoding(
+                *this->buffer_, data, nulls, stringBufferFactory);
         ASSERT_EQ(encoding->dataType(), nimble::TypeTraits<E>::dataType);
         ASSERT_TRUE(encoding->isNullable());
         const uint32_t rowCount = encoding->rowCount();
@@ -246,8 +254,16 @@ TYPED_TEST(NullableEncodingTest, ScatteredMaterialize) {
         const nimble::Vector<E> spreadData =
             spreadNullsIntoData<E>(*this->pool_, data, nulls);
 
+        std::vector<velox::BufferPtr> newStringBuffers;
+        const auto stringBufferFactory = [&](uint32_t totalLength) {
+          auto& buffer = newStringBuffers.emplace_back(
+              velox::AlignedBuffer::allocate<char>(
+                  totalLength, this->pool_.get()));
+          return buffer->template asMutable<void>();
+        };
         auto encoding = nimble::test::Encoder<nimble::NullableEncoding<E>>::
-            createNullableEncoding(*this->buffer_, data, nulls);
+            createNullableEncoding(
+                *this->buffer_, data, nulls, stringBufferFactory);
         ASSERT_EQ(encoding->dataType(), nimble::TypeTraits<E>::dataType);
         ASSERT_TRUE(encoding->isNullable());
         const uint32_t rowCount = encoding->rowCount();
@@ -418,8 +434,16 @@ TYPED_TEST(NullableEncodingTest, MaterializeNullable) {
         const nimble::Vector<E> spreadData =
             spreadNullsIntoData<E>(*this->pool_, data, nulls);
 
+        std::vector<velox::BufferPtr> newStringBuffers;
+        const auto stringBufferFactory = [&](uint32_t totalLength) {
+          auto& buffer = newStringBuffers.emplace_back(
+              velox::AlignedBuffer::allocate<char>(
+                  totalLength, this->pool_.get()));
+          return buffer->template asMutable<void>();
+        };
         auto encoding = nimble::test::Encoder<nimble::NullableEncoding<E>>::
-            createNullableEncoding(*this->buffer_, data, nulls);
+            createNullableEncoding(
+                *this->buffer_, data, nulls, stringBufferFactory);
         ASSERT_TRUE(encoding->isNullable());
         const uint32_t rowCount = encoding->rowCount();
         nimble::Vector<E> buffer(this->pool_.get(), rowCount);

--- a/dwio/nimble/encodings/tests/RleEncodingTests.cpp
+++ b/dwio/nimble/encodings/tests/RleEncodingTests.cpp
@@ -148,10 +148,16 @@ TYPED_TEST(RleEncodingTest, SerializeThenDeserialize) {
   using D = TypeParam;
 
   auto valueGroups = this->template prepareValues<D>();
+  std::vector<velox::BufferPtr> newStringBuffers;
+  const auto stringBufferFactory = [&](uint32_t totalLength) {
+    auto& buffer = newStringBuffers.emplace_back(
+        velox::AlignedBuffer::allocate<char>(totalLength, this->pool_.get()));
+    return buffer->template asMutable<void>();
+  };
   for (const auto& values : valueGroups) {
     auto encoding =
         nimble::test::Encoder<nimble::RLEEncoding<D>>::createEncoding(
-            *this->buffer_, values);
+            *this->buffer_, values, stringBufferFactory);
     uint32_t rowCount = values.size();
     nimble::Vector<D> result(this->pool_.get(), rowCount);
     encoding->materialize(rowCount, result.data());

--- a/dwio/nimble/encodings/tests/TestGenerator.cpp
+++ b/dwio/nimble/encodings/tests/TestGenerator.cpp
@@ -355,8 +355,14 @@ int main(int argc, char* argv[]) {
     stream.read(buffer.data(), buffer.size());
 
     auto pool = facebook::velox::memory::deprecatedAddDefaultLeafMemoryPool();
-    auto encoding =
-        nimble::EncodingFactory::decode(*pool, {buffer.data(), buffer.size()});
+    std::vector<velox::BufferPtr> newStringBuffers;
+    const auto stringBufferFactory = [&](uint32_t totalLength) {
+      auto& buffer = newStringBuffers.emplace_back(
+          velox::AlignedBuffer::allocate<char>(totalLength, pool.get()));
+      return buffer->asMutable<void>();
+    };
+    auto encoding = nimble::EncodingFactory::decode(
+        *pool, {buffer.data(), buffer.size()}, stringBufferFactory);
     auto rowCount = encoding->rowCount();
     printScalarType(std::cout, *pool, *encoding, rowCount);
     return 0;

--- a/dwio/nimble/encodings/tests/TestUtils.h
+++ b/dwio/nimble/encodings/tests/TestUtils.h
@@ -220,19 +220,24 @@ class Encoder {
   static std::unique_ptr<nimble::Encoding> createEncoding(
       nimble::Buffer& buffer,
       const nimble::Vector<T>& values,
+      std::function<void*(uint32_t)> stringBufferFactory,
       CompressionType compressionType = CompressionType::Uncompressed) {
     return std::make_unique<E>(
-        buffer.getMemoryPool(), encode(buffer, values, compressionType));
+        buffer.getMemoryPool(),
+        encode(buffer, values, compressionType),
+        stringBufferFactory);
   }
 
   static std::unique_ptr<nimble::Encoding> createNullableEncoding(
       nimble::Buffer& buffer,
       const nimble::Vector<T>& values,
       const nimble::Vector<bool>& nulls,
+      std::function<void*(uint32_t)> stringBufferFactory,
       CompressionType compressionType = CompressionType::Uncompressed) {
     return std::make_unique<E>(
         buffer.getMemoryPool(),
-        encodeNullable(buffer, values, nulls, compressionType));
+        encodeNullable(buffer, values, nulls, compressionType),
+        stringBufferFactory);
   }
 };
 

--- a/dwio/nimble/index/IndexReader.h
+++ b/dwio/nimble/index/IndexReader.h
@@ -91,6 +91,8 @@ class IndexReader {
   uint32_t chunkOffset_{0};
   // The encoding for the current chunk. Reset when seeking to a new chunk.
   std::unique_ptr<nimble::Encoding> encoding_;
+  // Buffers holding string data for the current encoding
+  std::vector<velox::BufferPtr> stringBuffers_;
 };
 
 } // namespace facebook::nimble::index

--- a/dwio/nimble/velox/ChunkedStreamDecoder.cpp
+++ b/dwio/nimble/velox/ChunkedStreamDecoder.cpp
@@ -15,65 +15,16 @@
  */
 #include "dwio/nimble/velox/ChunkedStreamDecoder.h"
 
+#include "velox/buffer/Buffer.h"
+
 namespace facebook::nimble {
-
-namespace {
-void bufferStringContent(
-    Vector<char>& buffer,
-    void* values,
-    void* FOLLY_NULLABLE notNulls,
-    uint32_t offset,
-    uint32_t count) {
-  auto* source = reinterpret_cast<std::string_view*>(values) + offset;
-  uint64_t size = 0;
-  if (notNulls) {
-    for (auto i = 0; i < count; ++i) {
-      if (bits::getBit(i + offset, reinterpret_cast<const char*>(notNulls))) {
-        size += (source + i)->size();
-      }
-    }
-  } else {
-    for (auto i = 0; i < count; ++i) {
-      size += (source + i)->size();
-    }
-  }
-
-  uint64_t targetOffset = 0;
-  buffer.resize(size);
-
-  if (notNulls) {
-    for (auto i = 0; i < count; ++i) {
-      if (bits::getBit(i + offset, reinterpret_cast<const char*>(notNulls))) {
-        auto* value = source + i;
-        auto* target = buffer.data() + targetOffset;
-        if (!value->empty()) {
-          std::copy(value->cbegin(), value->cend(), target);
-          targetOffset += value->size();
-        }
-        *value = std::string_view{target, value->size()};
-      }
-    }
-  } else {
-    for (auto i = 0; i < count; ++i) {
-      auto* value = source + i;
-      auto* target = buffer.data() + targetOffset;
-      if (!value->empty()) {
-        std::copy(value->cbegin(), value->cend(), target);
-        targetOffset += value->size();
-      }
-      *value = std::string_view{target, value->size()};
-    }
-  }
-}
-
-} // namespace
-
 uint32_t ChunkedStreamDecoder::next(
     uint32_t count,
     void* output,
+    std::vector<velox::BufferPtr>& stringBuffers,
     std::function<void*()> nulls,
     const bits::Bitmap* scatterBitmap) {
-  stringBuffers_.clear();
+  NIMBLE_DCHECK(stringBuffers.empty());
 
   if (count == 0) {
     if (nulls && scatterBitmap) {
@@ -133,27 +84,19 @@ uint32_t ChunkedStreamDecoder::next(
       builder.set(offset, endOffset);
     }
 
-    if (encoding_->dataType() == DataType::String && rowsToRead != count) {
-      // We are going to load a new chunk.
-      // For string values, this means that the memory pointed by the
-      // string_views is going to be freed. Before we do so, we copy all
-      // strings to a temporary buffer and fix the string_views to point to the
-      // new location.
-      // NOTE1: Instead of copying the data, we can just hold on to
-      // the previous chunk(s) for a while. However, this means holding on to
-      // more memory, which is undesirable.
-      // NOTE2: We perform an additional copy of the strings later on, into the
-      // string buffers of the Velox Vector. Later diff will change this logic
-      // to directly copy the strings into the Velox string buffers directly.
-      auto& buffer = stringBuffers_.emplace_back(&pool_);
-      bufferStringContent(
-          buffer, output, nullsPtr, offset, (endOffset - offset));
-    }
-
     offset = endOffset;
     remaining_ -= rowsToRead;
     count -= rowsToRead;
     nonNullCount += chunkNonNullCount;
+
+    // Note: we can over queue the current string buffers by exactly
+    // once, but that doesn't change the life cycle of the buffers for now.
+    // Keeping this pattern for simplicity.
+    // For non-string types, currentStringBuffers_ will be empty
+    stringBuffers.reserve(currentStringBuffers_.size());
+    for (const auto& buf : currentStringBuffers_) {
+      stringBuffers.push_back(buf);
+    }
   }
 
   return nonNullCount;
@@ -176,7 +119,13 @@ void ChunkedStreamDecoder::reset() {
 
 void ChunkedStreamDecoder::ensureLoaded() {
   if (UNLIKELY(remaining_ == 0)) {
-    encoding_ = encodingFactory_(pool_, stream_->nextChunk());
+    currentStringBuffers_.clear();
+    encoding_ = encodingFactory_(
+        pool_, stream_->nextChunk(), [&](uint32_t totalLength) {
+          auto& buffer = currentStringBuffers_.emplace_back(
+              velox::AlignedBuffer::allocate<char>(totalLength, &pool_));
+          return buffer->asMutable<void>();
+        });
     remaining_ = encoding_->rowCount();
     NIMBLE_CHECK_GT(remaining_, 0, "Empty chunk");
   }

--- a/dwio/nimble/velox/ChunkedStreamDecoder.h
+++ b/dwio/nimble/velox/ChunkedStreamDecoder.h
@@ -29,7 +29,8 @@ class ChunkedStreamDecoder : public Decoder {
       std::unique_ptr<ChunkedStream> stream,
       std::function<std::unique_ptr<Encoding>(
           velox::memory::MemoryPool&,
-          std::string_view)> encodingFactory,
+          std::string_view,
+          std::function<void*(uint32_t)>)> encodingFactory,
       const MetricsLogger& logger)
       : pool_{pool},
         stream_{std::move(stream)},
@@ -39,6 +40,7 @@ class ChunkedStreamDecoder : public Decoder {
   uint32_t next(
       uint32_t count,
       void* output,
+      std::vector<velox::BufferPtr>& stringBuffers,
       std::function<void*()> nulls = nullptr,
       const bits::Bitmap* scatterBitmap = nullptr) override;
 
@@ -57,11 +59,13 @@ class ChunkedStreamDecoder : public Decoder {
   std::unique_ptr<ChunkedStream> stream_;
   std::unique_ptr<Encoding> encoding_;
   uint32_t remaining_{0};
-  std::function<
-      std::unique_ptr<Encoding>(velox::memory::MemoryPool&, std::string_view)>
+  std::function<std::unique_ptr<Encoding>(
+      velox::memory::MemoryPool&,
+      std::string_view,
+      std::function<void*(uint32_t)>)>
       encodingFactory_;
   const MetricsLogger& logger_;
-  std::vector<Vector<char>> stringBuffers_;
+  std::vector<velox::BufferPtr> currentStringBuffers_;
 };
 
 } // namespace facebook::nimble

--- a/dwio/nimble/velox/Decoder.h
+++ b/dwio/nimble/velox/Decoder.h
@@ -18,6 +18,7 @@
 #include <cstdint>
 #include <functional>
 #include "dwio/nimble/common/Bits.h"
+#include "velox/buffer/Buffer.h"
 
 namespace facebook::nimble {
 
@@ -27,9 +28,13 @@ class Decoder {
  public:
   virtual ~Decoder() = default;
 
+  // Decode next 'count' values into 'output'.
+  // For string types, stringBuffers will be populated with buffers holding
+  // the string data. For non-string types, stringBuffers will remain empty.
   virtual uint32_t next(
       uint32_t count,
       void* output,
+      std::vector<velox::BufferPtr>& stringBuffers,
       std::function<void*()> nulls = nullptr,
       const bits::Bitmap* scatterBitmap = nullptr) = 0;
 

--- a/dwio/nimble/velox/VeloxReader.h
+++ b/dwio/nimble/velox/VeloxReader.h
@@ -70,11 +70,15 @@ struct VeloxReadParams : public FieldReaderParams {
   // Used strictly for backward compatible migrations where the Encoding
   // implementations might have different read implementations, but
   // identical/backward compatible write behavior.
-  std::function<
-      std::unique_ptr<Encoding>(velox::memory::MemoryPool&, std::string_view)>
+  std::function<std::unique_ptr<Encoding>(
+      velox::memory::MemoryPool&,
+      std::string_view,
+      std::function<void*(uint32_t)>)>
       encodingFactory = [](velox::memory::MemoryPool& pool,
-                           std::string_view data) -> std::unique_ptr<Encoding> {
-    return EncodingFactory::decode(pool, data);
+                           std::string_view data,
+                           std::function<void*(uint32_t)> stringBufferFactory)
+      -> std::unique_ptr<Encoding> {
+    return EncodingFactory::decode(pool, data, stringBufferFactory);
   };
 };
 

--- a/dwio/nimble/velox/selective/NimbleData.cpp
+++ b/dwio/nimble/velox/selective/NimbleData.cpp
@@ -28,9 +28,10 @@ NimbleData::NimbleData(
     StripeStreams& streams,
     memory::MemoryPool& memoryPool,
     ChunkedDecoder* inMapDecoder,
-    std::function<
-        std::unique_ptr<Encoding>(velox::memory::MemoryPool&, std::string_view)>
-        encodingFactory)
+    std::function<std::unique_ptr<Encoding>(
+        velox::memory::MemoryPool&,
+        std::string_view,
+        std::function<void*(uint32_t)>)> encodingFactory)
     : nimbleType_(nimbleType),
       streams_(&streams),
       pool_(&memoryPool),

--- a/dwio/nimble/velox/selective/NimbleData.h
+++ b/dwio/nimble/velox/selective/NimbleData.h
@@ -34,7 +34,8 @@ class NimbleData : public velox::dwio::common::FormatData {
       ChunkedDecoder* inMapDecoder,
       std::function<std::unique_ptr<Encoding>(
           velox::memory::MemoryPool&,
-          std::string_view)> encodingFactory);
+          std::string_view,
+          std::function<void*(uint32_t)>)> encodingFactory);
 
   /// Read internal node nulls. For leaf nodes, we only copy `incomingNulls' if
   /// it exists.
@@ -108,8 +109,10 @@ class NimbleData : public velox::dwio::common::FormatData {
   ChunkedDecoder* const inMapDecoder_;
   std::unique_ptr<ChunkedDecoder> nullsDecoder_;
   velox::BufferPtr inMap_;
-  std::function<
-      std::unique_ptr<Encoding>(velox::memory::MemoryPool&, std::string_view)>
+  std::function<std::unique_ptr<Encoding>(
+      velox::memory::MemoryPool&,
+      std::string_view,
+      std::function<void*(uint32_t)>)>
       encodingFactory_;
 };
 
@@ -123,7 +126,8 @@ class NimbleParams : public velox::dwio::common::FormatParams {
       RowSizeTracker* rowSizeTracker,
       std::function<std::unique_ptr<Encoding>(
           velox::memory::MemoryPool&,
-          std::string_view)> encodingFactory,
+          std::string_view,
+          std::function<void*(uint32_t)>)> encodingFactory,
       bool preserveFlatMapsInMemory = false)
       : FormatParams(pool, stats),
         nimbleType_(nimbleType),
@@ -173,8 +177,10 @@ class NimbleParams : public velox::dwio::common::FormatParams {
   RowSizeTracker* const rowSizeTracker_{nullptr};
   const bool preserveFlatMapsInMemory_{false};
   ChunkedDecoder* inMapDecoder_{nullptr};
-  std::function<
-      std::unique_ptr<Encoding>(velox::memory::MemoryPool&, std::string_view)>
+  std::function<std::unique_ptr<Encoding>(
+      velox::memory::MemoryPool&,
+      std::string_view,
+      std::function<void*(uint32_t)> stringBufferFactory)>
       encodingFactory_;
 };
 

--- a/dwio/nimble/velox/selective/SelectiveNimbleReader.cpp
+++ b/dwio/nimble/velox/selective/SelectiveNimbleReader.cpp
@@ -324,12 +324,18 @@ void SelectiveNimbleRowReader::loadCurrentStripe() {
       streams_,
       options_.trackRowSize() ? rowSizeTracker_.get() : nullptr,
       options_.passStringBuffersFromDecoder()
-      ? [](velox::memory::MemoryPool& pool, std::string_view data)
-            -> std::unique_ptr<
-                Encoding> { return EncodingFactory::decode(pool, data); }
-      : [](velox::memory::MemoryPool& pool, std::string_view data)
-            -> std::unique_ptr<
-                Encoding> { return legacy::EncodingFactory::decode(pool, data); },
+          ? [](velox::memory::MemoryPool& pool,
+               std::string_view data,
+               std::function<void*(uint32_t)> stringBufferFactory)
+                -> std::unique_ptr<Encoding> {
+        return EncodingFactory::decode(pool, data, stringBufferFactory);
+      }
+          : [](velox::memory::MemoryPool& pool,
+               std::string_view data,
+               std::function<void*(uint32_t)> stringBufferFactory)
+                -> std::unique_ptr<Encoding> {
+        return legacy::EncodingFactory::decode(pool, data, stringBufferFactory);
+      },
       options_.preserveFlatMapsInMemory());
   columnReader_ = buildColumnReader(
       options_.requestedType() ? options_.requestedType()

--- a/dwio/nimble/velox/tests/VeloxReaderTests.cpp
+++ b/dwio/nimble/velox/tests/VeloxReaderTests.cpp
@@ -5619,14 +5619,19 @@ TEST_F(VeloxReaderTests, estimatedRowSizeSimple) {
   testPrimitive(velox::VARCHAR(), 0);
 }
 
+// TODO: soon we should get rid of row estimates entirely, so we are just tuning
+// the current heuristics. The Encodings with the newer memory handling would
+// boost the reported retained size (without actually allocating more memory).
+// This is ok for velox compute engines because they don't use the c++ Nimble
+// batch readers.
 TEST_F(VeloxReaderTests, estimatedRowSizeComplex) {
   // For string cases and with null cases, it is really hard to get an even
   // close estimation as velox always over provision memory for vectors. Loose
   // or very loose error rate is applied to the test verification as there is no
   // other way of binding the estimate verification with velox implementations.
   const double kMaxErrorRate = 0.2;
-  const double kMaxErrorRateLoose = 0.4;
-  const double kMaxErrorRateVeryLoose = 0.6;
+  const double kMaxErrorRateLoose = 0.5;
+  const double kMaxErrorRateVeryLoose = 0.7;
 
   auto testMultiValue = [&](uint32_t numRows,
                             uint32_t numElements,

--- a/dwio/nimble/velox/tests/VeloxWriterTest.cpp
+++ b/dwio/nimble/velox/tests/VeloxWriterTest.cpp
@@ -2951,8 +2951,14 @@ class VeloxWriterIndexTest : public VeloxWriterTest,
           uint32_t chunkIndex = 0;
           while (chunkedStream.hasNext()) {
             const auto chunkData = chunkedStream.nextChunk();
-            auto encoding =
-                nimble::EncodingFactory::decode(*leafPool_, chunkData);
+            std::vector<velox::BufferPtr> stringBuffers;
+            auto encoding = nimble::EncodingFactory::decode(
+                *leafPool_, chunkData, [&](uint32_t totalLength) {
+                  auto& buffer = stringBuffers.emplace_back(
+                      velox::AlignedBuffer::allocate<char>(
+                          totalLength, leafPool_.get()));
+                  return buffer->asMutable<void>();
+                });
             EXPECT_EQ(encoding->rowCount(), expectedChunkRowCounts[chunkIndex])
                 << "Stripe " << stripeIdx << " stream " << streamId << " chunk "
                 << chunkIndex << " row count mismatch (sequential)";
@@ -2987,8 +2993,14 @@ class VeloxWriterIndexTest : public VeloxWriterTest,
           nimble::index::test::SingleChunkDecoder chunkDecoder(
               *leafPool_, chunkStreamData);
           auto encodingData = chunkDecoder.decode();
-          auto encoding =
-              nimble::EncodingFactory::decode(*leafPool_, encodingData);
+          std::vector<velox::BufferPtr> stringBuffers;
+          auto encoding = nimble::EncodingFactory::decode(
+              *leafPool_, encodingData, [&](uint32_t totalLength) {
+                auto& buffer = stringBuffers.emplace_back(
+                    velox::AlignedBuffer::allocate<char>(
+                        totalLength, leafPool_.get()));
+                return buffer->asMutable<void>();
+              });
 
           EXPECT_EQ(encoding->rowCount(), expectedChunkRowCounts[i])
               << "Stripe " << stripeIdx << " stream " << streamId << " chunk "
@@ -3067,6 +3079,7 @@ class VeloxWriterIndexTest : public VeloxWriterTest,
         keyStreamCache;
     // Buffer for loaded key stream data (must outlive the encoding)
     std::unordered_map<uint64_t, std::string> keyStreamBufferCache;
+    std::vector<velox::BufferPtr> stringBuffers;
 
     // Verify each row's index lookup
     uint64_t currentRowId = 0;
@@ -3139,8 +3152,14 @@ class VeloxWriterIndexTest : public VeloxWriterTest,
           auto encodingData = chunkDecoder.decode();
 
           // Decode the key encoding from the chunk data
-          keyStreamCache[chunkFileOffset] =
-              nimble::EncodingFactory::decode(*leafPool_, encodingData);
+
+          keyStreamCache[chunkFileOffset] = nimble::EncodingFactory::decode(
+              *leafPool_, encodingData, [&](uint32_t totalLength) {
+                auto& buf = stringBuffers.emplace_back(
+                    velox::AlignedBuffer::allocate<char>(
+                        totalLength, leafPool_.get()));
+                return buf->asMutable<void>();
+              });
         }
 
         auto* keyEncoding = keyStreamCache[chunkFileOffset].get();


### PR DESCRIPTION
Summary:
Pass string buffer directly from encoders to column/field readers through decoders.

NOTE: Right now we hold onto the string buffer needed for TrivialEncoding for the entire chunk, which is a simplified version of the prototype. The tradeoff for the current simplicity is a worse memory footprint in some cases (e.g. uncompressed with not enough chunks), because we now hold the entire string buffer in the vector all the time, instead of that of just the relevant rows. A version with more granular handling of the string buffers: D88118029. This problem will also be mitigated as we have a better infrastructure for encoding selection to avoid picking uncompressed Trivial encoding payloads.

Reviewed By: helfman

Differential Revision: D88118028
