### PR TITLE
Pass string buffers from encodings in selective reader

### DIFF
--- a/dwio/nimble/encodings/Encoding.h
+++ b/dwio/nimble/encodings/Encoding.h
@@ -86,6 +86,10 @@ struct ReadWithVisitorParams {
   // across potential multiple chunks during one read.
   std::function<void()> prepareResultNulls;
 
+  // TODO: hmmmm, do we still need this? We will need to pass this into the
+  // encodingFactory. Then the decoder needs to setStringVectors on the reader.
+  std::function<void*(uint32_t)> stringBufferFactory;
+
   // Number of rows scanned so far.  Contains rows scanned in previous chunks
   // during this read call as well.
   vector_size_t numScanned;

--- a/dwio/nimble/velox/FieldReader.cpp
+++ b/dwio/nimble/velox/FieldReader.cpp
@@ -913,6 +913,7 @@ class TimestampMicroNanoFieldReader final : public FieldReader {
         [&]() { return ensureNulls(vector, rowCount); },
         scatterBitmap);
 
+    stringBuffers.clear();
     nanosBuffer_.resize(nonNullCount);
     nanosDecoder_->next(
         nonNullCount,

--- a/dwio/nimble/velox/selective/ChunkedDecoder.h
+++ b/dwio/nimble/velox/selective/ChunkedDecoder.h
@@ -310,6 +310,8 @@ class ChunkedDecoder {
     constexpr bool kExtractToReader = std::
         is_same_v<typename V::Extract, velox::dwio::common::ExtractToReader>;
     const auto numRows = visitor.numRows();
+
+    std::vector<velox::BufferPtr> stringBuffers;
     while (visitor.rowIndex() < numRows) {
       if constexpr (!kHasNulls) {
         if (FOLLY_UNLIKELY(remainingValues_ == 0)) {
@@ -351,6 +353,18 @@ class ChunkedDecoder {
       }
       advancePosition(numNonNulls);
       params.numScanned += numNulls + numNonNulls;
+
+      // Note: we can over queue the current string buffers by exactly
+      // once, but that doesn't change the life cycle of the buffers for now.
+      // Keeping this pattern for simplicity.
+      // For non-string types, currentStringBuffers_ will be empty
+      for (const auto& buf : currentStringBuffers_) {
+        stringBuffers.push_back(buf);
+      }
+    }
+
+    if (visitor.reader().formatData().getStringBuffersFromDecoder()) {
+      visitor.reader().setStringBuffers(std::move(stringBuffers));
     }
   }
 

--- a/dwio/nimble/velox/selective/NimbleData.cpp
+++ b/dwio/nimble/velox/selective/NimbleData.cpp
@@ -31,7 +31,8 @@ NimbleData::NimbleData(
     std::function<std::unique_ptr<Encoding>(
         velox::memory::MemoryPool&,
         std::string_view,
-        std::function<void*(uint32_t)>)> encodingFactory)
+        std::function<void*(uint32_t)>)> encodingFactory,
+    bool getStringBuffersFromDecoder)
     : nimbleType_(nimbleType),
       streams_(&streams),
       pool_(&memoryPool),
@@ -85,6 +86,7 @@ NimbleData::NimbleData(
     default:
       NIMBLE_UNSUPPORTED("{}", toString(nimbleType->kind()));
   }
+  getStringBuffersFromDecoder_ = getStringBuffersFromDecoder;
 }
 
 void NimbleData::readNulls(
@@ -218,7 +220,12 @@ std::unique_ptr<velox::dwio::common::FormatData> NimbleParams::toFormatData(
     const std::shared_ptr<const velox::dwio::common::TypeWithId>& /*type*/,
     const velox::common::ScanSpec& /*scanSpec*/) {
   return std::make_unique<NimbleData>(
-      nimbleType_, *streams_, pool(), inMapDecoder_, encodingFactory_);
+      nimbleType_,
+      *streams_,
+      pool(),
+      inMapDecoder_,
+      encodingFactory_,
+      getStringBuffersFromDecoder_);
 }
 
 } // namespace facebook::nimble

--- a/dwio/nimble/velox/selective/NimbleData.h
+++ b/dwio/nimble/velox/selective/NimbleData.h
@@ -35,7 +35,8 @@ class NimbleData : public velox::dwio::common::FormatData {
       std::function<std::unique_ptr<Encoding>(
           velox::memory::MemoryPool&,
           std::string_view,
-          std::function<void*(uint32_t)>)> encodingFactory);
+          std::function<void*(uint32_t)>)> encodingFactory,
+      bool getStringBuffersFromDecoder);
 
   /// Read internal node nulls. For leaf nodes, we only copy `incomingNulls' if
   /// it exists.
@@ -128,13 +129,15 @@ class NimbleParams : public velox::dwio::common::FormatParams {
           velox::memory::MemoryPool&,
           std::string_view,
           std::function<void*(uint32_t)>)> encodingFactory,
+      bool getStringBuffersFromDecoder = false,
       bool preserveFlatMapsInMemory = false)
       : FormatParams(pool, stats),
         nimbleType_(nimbleType),
         streams_(&streams),
         rowSizeTracker_(rowSizeTracker),
         preserveFlatMapsInMemory_(preserveFlatMapsInMemory),
-        encodingFactory_(encodingFactory) {}
+        encodingFactory_(std::move(encodingFactory)),
+        getStringBuffersFromDecoder_{getStringBuffersFromDecoder} {}
 
   std::unique_ptr<velox::dwio::common::FormatData> toFormatData(
       const std::shared_ptr<const velox::dwio::common::TypeWithId>& /*type*/,
@@ -148,6 +151,7 @@ class NimbleParams : public velox::dwio::common::FormatParams {
         *streams_,
         rowSizeTracker_,
         encodingFactory_,
+        getStringBuffersFromDecoder_,
         preserveFlatMapsInMemory_);
   }
 
@@ -182,6 +186,7 @@ class NimbleParams : public velox::dwio::common::FormatParams {
       std::string_view,
       std::function<void*(uint32_t)> stringBufferFactory)>
       encodingFactory_;
+  bool getStringBuffersFromDecoder_{false};
 };
 
 } // namespace facebook::nimble

--- a/dwio/nimble/velox/selective/SelectiveNimbleReader.cpp
+++ b/dwio/nimble/velox/selective/SelectiveNimbleReader.cpp
@@ -336,6 +336,7 @@ void SelectiveNimbleRowReader::loadCurrentStripe() {
                 -> std::unique_ptr<Encoding> {
         return legacy::EncodingFactory::decode(pool, data, stringBufferFactory);
       },
+      options_.passStringBuffersFromDecoder(),
       options_.preserveFlatMapsInMemory());
   columnReader_ = buildColumnReader(
       options_.requestedType() ? options_.requestedType()


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebookincubator/velox/pull/15912

Pass string buffers from nimble encodings, with branching in all surface area handling string buffers in selective reader base.

Reviewed By: Yuhta

Differential Revision: D88914641
