### PR TITLE
feat: Add prefix encoding support

### DIFF
--- a/dwio/nimble/common/Types.cpp
+++ b/dwio/nimble/common/Types.cpp
@@ -47,6 +47,8 @@ std::string toString(EncodingType encodingType) {
       return "MainlyConstant";
     case EncodingType::Sentinel:
       return "Sentinel";
+    case EncodingType::Prefix:
+      return "Prefix";
   }
   return fmt::format(
       "Unknown encoding type: {}", static_cast<int32_t>(encodingType));

--- a/dwio/nimble/common/Types.h
+++ b/dwio/nimble/common/Types.h
@@ -100,6 +100,10 @@ enum class EncodingType {
   // using a bool child vector to store whether each row is that special value,
   // and stores the non-special values as a separate encoding.
   MainlyConstant = 10,
+  // Stores sorted string data with prefix compression. Common prefixes are
+  // shared across consecutive entries to reduce storage. Supports seek
+  // operations for efficient random access.
+  Prefix = 11,
 };
 std::string toString(EncodingType encodingType);
 std::ostream& operator<<(std::ostream& out, EncodingType encodingType);

--- a/dwio/nimble/encodings/CMakeLists.txt
+++ b/dwio/nimble/encodings/CMakeLists.txt
@@ -23,6 +23,7 @@ add_library(
   EncodingLayout.cpp
   EncodingLayoutCapture.cpp
   MainlyConstantEncoding.cpp
+  PrefixEncoding.cpp
   RleEncoding.cpp
   SparseBoolEncoding.cpp
   Statistics.cpp

--- a/dwio/nimble/encodings/EncodingLayoutCapture.cpp
+++ b/dwio/nimble/encodings/EncodingLayoutCapture.cpp
@@ -30,8 +30,8 @@ constexpr uint32_t kEncodingPrefixSize = 6;
 } // namespace
 
 EncodingLayout EncodingLayoutCapture::capture(std::string_view encoding) {
-  NIMBLE_CHECK(
-      encoding.size() >= kEncodingPrefixSize, "Encoding size too small.");
+  NIMBLE_CHECK_GE(
+      encoding.size(), kEncodingPrefixSize, "Encoding size too small.");
 
   const auto encodingType =
       encoding::peek<uint8_t, EncodingType>(encoding.data());
@@ -47,7 +47,8 @@ EncodingLayout EncodingLayoutCapture::capture(std::string_view encoding) {
   switch (encodingType) {
     case EncodingType::FixedBitWidth:
     case EncodingType::Varint:
-    case EncodingType::Constant: {
+    case EncodingType::Constant:
+    case EncodingType::Prefix: {
       // Non nested encodings have zero children
       break;
     }

--- a/dwio/nimble/encodings/EncodingLayoutCapture.h
+++ b/dwio/nimble/encodings/EncodingLayoutCapture.h
@@ -22,10 +22,10 @@ namespace facebook::nimble {
 
 class EncodingLayoutCapture {
  public:
-  // Captures an encoding tree from an encoded stream.
-  // It traverses the encoding headers in the stream and produces a serialized
-  // encoding tree layout.
-  // |encoding| - The serialized encoding
+  /// Captures an encoding tree from an encoded stream.
+  /// It traverses the encoding headers in the stream and produces a serialized
+  /// encoding tree layout.
+  /// |encoding| - The serialized encoding
   static EncodingLayout capture(std::string_view encoding);
 };
 

--- a/dwio/nimble/encodings/EncodingSelectionPolicy.h
+++ b/dwio/nimble/encodings/EncodingSelectionPolicy.h
@@ -171,11 +171,11 @@ class ManualEncodingSelectionPolicy : public EncodingSelectionPolicy<T> {
     // Iterate on all candidate encodings, and pick the encoding with the
     // minimal cost.
     for (const auto& pair : readFactors_) {
-      auto encodingType = pair.first;
-      auto size =
+      const auto encodingType = pair.first;
+      const auto estimatedSize =
           detail::EncodingSizeEstimation<T, FixedByteWidth>::estimateSize(
               encodingType, values.size(), statistics);
-      if (!size.has_value()) {
+      if (!estimatedSize.has_value()) {
         NIMBLE_SELECTION_LOG(
             PURPLE << encodingType << " encoding is incompatible.");
         continue;
@@ -184,9 +184,10 @@ class ManualEncodingSelectionPolicy : public EncodingSelectionPolicy<T> {
       // We use read factor weights to raise/lower the favorability of each
       // encoding.
       auto readFactor = pair.second;
-      auto cost = size.value() * readFactor;
+      auto cost = estimatedSize.value() * readFactor;
       NIMBLE_SELECTION_LOG(
-          YELLOW << "Encoding: " << encodingType << ", Size: " << size.value()
+          YELLOW << "Encoding: " << encodingType
+                 << ", Size: " << estimatedSize.value()
                  << ", Factor: " << readFactor << ", Cost: " << cost);
       if (cost < minCost) {
         minCost = cost;

--- a/dwio/nimble/encodings/EncodingSizeEstimation.h
+++ b/dwio/nimble/encodings/EncodingSizeEstimation.h
@@ -373,9 +373,7 @@ struct EncodingSizeEstimation {
     }
 
     NIMBLE_UNREACHABLE(
-        fmt::format(
-            "Unable to estimate size for type {}.",
-            folly::demangle(typeid(T))));
+        "Unable to estimate size for type {}.", folly::demangle(typeid(T)));
   }
 
   template <EncodingType encodingType, typename dataType>

--- a/dwio/nimble/encodings/EncodingUtils.h
+++ b/dwio/nimble/encodings/EncodingUtils.h
@@ -20,6 +20,7 @@
 #include "dwio/nimble/encodings/FixedBitWidthEncoding.h"
 #include "dwio/nimble/encodings/MainlyConstantEncoding.h"
 #include "dwio/nimble/encodings/NullableEncoding.h"
+#include "dwio/nimble/encodings/PrefixEncoding.h"
 #include "dwio/nimble/encodings/RleEncoding.h"
 #include "dwio/nimble/encodings/SparseBoolEncoding.h"
 #include "dwio/nimble/encodings/TrivialEncoding.h"
@@ -78,6 +79,8 @@ auto encodingTypeDispatchString(Encoding& encoding, F f) {
     case EncodingType::MainlyConstant:
       return f(
           static_cast<MainlyConstantEncoding<std::string_view>&>(encoding));
+    case EncodingType::Prefix:
+      return f(static_cast<PrefixEncoding&>(encoding));
     default:
       NIMBLE_UNSUPPORTED(toString(encoding.encodingType()));
   }

--- a/dwio/nimble/encodings/PrefixEncoding.cpp
+++ b/dwio/nimble/encodings/PrefixEncoding.cpp
@@ -1,0 +1,317 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "dwio/nimble/encodings/PrefixEncoding.h"
+
+#include "dwio/nimble/common/EncodingPrimitives.h"
+#include "velox/buffer/Buffer.h"
+#include "velox/common/base/BitUtil.h"
+
+namespace facebook::nimble {
+
+PrefixEncoding::PrefixEncoding(
+    velox::memory::MemoryPool& pool,
+    std::string_view data)
+    : TypedEncoding<std::string_view, std::string_view>{pool, data},
+      restartInterval_{readRestartInterval(data)},
+      numRestarts_{computeNumRestarts(rowCount_, restartInterval_)},
+      restartOffsets_{restartOffsets(data)},
+      dataStart_{dataStart(data, numRestarts_)},
+      decodedValue_{pool_},
+      materializedValues_{pool_} {
+  reset();
+}
+
+// static
+uint32_t PrefixEncoding::readRestartInterval(std::string_view data) {
+  const auto* pos = data.data() + kRestartIntervalOffset;
+  return encoding::readUint32(pos);
+}
+
+// static
+uint32_t PrefixEncoding::computeNumRestarts(
+    uint32_t rowCount,
+    uint32_t restartInterval) {
+  return velox::bits::divRoundUp(rowCount, restartInterval);
+}
+
+// static
+const char* PrefixEncoding::restartOffsets(std::string_view data) {
+  return data.data() + kRestartOffsetsOffset;
+}
+
+// static
+const char* PrefixEncoding::dataStart(
+    std::string_view data,
+    uint32_t numRestarts) {
+  return data.data() + kRestartOffsetsOffset + (numRestarts * sizeof(uint32_t));
+}
+
+void PrefixEncoding::reset() {
+  currentPos_ = dataStart_;
+  currentRow_ = 0;
+  decodedValue_.clear();
+}
+
+void PrefixEncoding::skip(uint32_t rowCount) {
+  NIMBLE_CHECK_LE(currentRow_ + rowCount, rowCount_, "Invalid skip row count");
+
+  if (rowCount == 0) {
+    return;
+  }
+
+  const uint32_t targetRow = currentRow_ + rowCount;
+
+  // Calculate which restart block we're currently in and which we need to reach
+  const uint32_t currentRestartIndex = currentRow_ / restartInterval_;
+  const uint32_t targetRestartIndex = targetRow / restartInterval_;
+  NIMBLE_CHECK_LE(currentRestartIndex, targetRestartIndex);
+
+  // If target is in a different restart block, jump to the appropriate restart
+  // point
+  if (targetRestartIndex > currentRestartIndex &&
+      targetRestartIndex < numRestarts_) {
+    seekToRestartPoint(targetRestartIndex);
+  }
+
+  // Linear scan to reach exact target row
+  while (currentRow_ < targetRow) {
+    decodeEntry();
+  }
+}
+
+std::string_view PrefixEncoding::decodeEntry() {
+  // Decode shared prefix length
+  const uint32_t sharedPrefixLen = encoding::readUint32(currentPos_);
+  // Decode suffix length
+  const uint32_t suffixLen = encoding::readUint32(currentPos_);
+
+  // The shared prefix is already at the beginning of decodedValue_ from the
+  // previous decode. We just need to resize and append the suffix.
+  const uint32_t fullLen = sharedPrefixLen + suffixLen;
+  NIMBLE_CHECK_LE(
+      sharedPrefixLen, decodedValue_.size(), "Invalid shared prefix length");
+  decodedValue_.resize(fullLen);
+
+  // Copy suffix
+  if (suffixLen > 0) {
+    std::memcpy(decodedValue_.data() + sharedPrefixLen, currentPos_, suffixLen);
+    currentPos_ += suffixLen;
+  }
+  ++currentRow_;
+  return std::string_view(decodedValue_.data(), fullLen);
+}
+
+void PrefixEncoding::materialize(uint32_t rowCount, void* buffer) {
+  NIMBLE_CHECK_LE(currentRow_ + rowCount, rowCount_, "Invalid row count");
+
+  // Clear the buffer from previous materialize call
+  materializedValues_.clear();
+
+  // First pass: decode all entries and accumulate total size needed
+  // Store offsets and lengths for each entry
+  Vector<std::pair<uint32_t, uint32_t>> valueOffsets{pool_};
+  valueOffsets.reserve(rowCount);
+
+  for (uint32_t i = 0; i < rowCount; ++i) {
+    const std::string_view decodedValue = decodeEntry();
+    const uint32_t valueOffset = materializedValues_.size();
+    const uint32_t valueLength = decodedValue.size();
+    materializedValues_.insert(
+        materializedValues_.end(),
+        decodedValue.data(),
+        decodedValue.data() + valueLength);
+    valueOffsets.push_back({valueOffset, valueLength});
+  }
+
+  // Second pass: create string_views pointing into materializedValues_
+  std::string_view* valueOutput = static_cast<std::string_view*>(buffer);
+  for (uint32_t i = 0; i < rowCount; ++i) {
+    const auto [offset, len] = valueOffsets[i];
+    valueOutput[i] = std::string_view(materializedValues_.data() + offset, len);
+  }
+}
+
+uint32_t PrefixEncoding::restartOffset(uint32_t restartIndex) const {
+  NIMBLE_CHECK_LT(restartIndex, numRestarts_, "Restart index out of bounds");
+  const char* offsetPos = restartOffsets_ + (restartIndex * sizeof(uint32_t));
+  return encoding::readUint32(offsetPos);
+}
+
+void PrefixEncoding::seekToRestartPoint(uint32_t restartIndex) {
+  NIMBLE_CHECK_LT(restartIndex, numRestarts_, "Restart index out of bounds");
+
+  // Seek to the restart point
+  currentPos_ = dataStart_ + restartOffset(restartIndex);
+  currentRow_ = restartIndex * restartInterval_;
+  decodedValue_.clear();
+}
+
+std::optional<uint32_t> PrefixEncoding::seekAtOrAfter(const void* value) {
+  const auto& targetValue = *static_cast<const std::string_view*>(value);
+
+  // Binary search among restart points to find the block
+  uint32_t left = 0;
+  uint32_t right = numRestarts_;
+
+  while (left < right) {
+    const uint32_t mid = left + (right - left) / 2;
+
+    seekToRestartPoint(mid);
+    NIMBLE_CHECK_EQ(currentRow_, mid * restartInterval_);
+    std::string_view restartValue = decodeEntry();
+    if (restartValue == targetValue) {
+      // decodeEntry() increments currentRow_ after decoding, so return the
+      // row index before the increment
+      return currentRow_ - 1;
+    }
+
+    if (restartValue < targetValue) {
+      left = mid + 1;
+    } else {
+      right = mid;
+    }
+  }
+
+  // If left > 0, check the previous block
+  if (left > 0) {
+    --left;
+  }
+
+  // Seek to the identified restart point
+  seekToRestartPoint(left);
+  NIMBLE_CHECK_EQ(currentRow_, left * restartInterval_);
+
+  // Linear scan within the block
+  while (currentRow_ < rowCount_) {
+    std::string_view currentValue = decodeEntry();
+
+    if (currentValue >= targetValue) {
+      // decodeEntry() increments currentRow_ after decoding, so return the
+      // row index before the increment
+      return currentRow_ - 1;
+    }
+  }
+
+  // Target is greater than all entries
+  return std::nullopt;
+}
+
+std::string_view PrefixEncoding::encode(
+    EncodingSelection<physicalType>& /* unused */,
+    std::span<const physicalType> values,
+    Buffer& buffer) {
+  const uint32_t valueCount = values.size();
+
+  // Values must be sorted for prefix encoding to be effective
+  // In production, caller should ensure this or we can add a check
+
+  const uint32_t restartInterval = kDefaultRestartInterval;
+  const auto numRestarts = computeNumRestarts(values.size(), restartInterval);
+  Vector<uint32_t> restartOffsets{&buffer.getMemoryPool()};
+  restartOffsets.reserve(numRestarts);
+  Vector<char> encodedData{&buffer.getMemoryPool()};
+
+  std::string_view lastValue;
+  char buf[sizeof(uint32_t)];
+
+  for (uint32_t i = 0; i < valueCount; ++i) {
+    const auto& value = values[i];
+
+    // Determine if this is a restart point
+    const bool restart = (i % restartInterval == 0);
+
+    uint32_t sharedPrefixLen = 0;
+    if (!restart && i > 0) {
+      // Calculate shared prefix length with previous entry
+      size_t minLen = std::min(lastValue.size(), value.size());
+      while (sharedPrefixLen < minLen &&
+             lastValue[sharedPrefixLen] == value[sharedPrefixLen]) {
+        ++sharedPrefixLen;
+      }
+    }
+
+    if (restart) {
+      // Record restart offset (current position in encoded data)
+      restartOffsets.push_back(encodedData.size());
+    }
+
+    // Encode shared prefix length
+    char* pos = buf;
+    encoding::writeUint32(sharedPrefixLen, pos);
+    encodedData.insert(encodedData.end(), buf, pos);
+
+    // Encode suffix length
+    const uint32_t suffixLen = value.size() - sharedPrefixLen;
+    pos = buf;
+    encoding::writeUint32(suffixLen, pos);
+    encodedData.insert(encodedData.end(), buf, pos);
+
+    // Encode suffix data
+    if (suffixLen > 0) {
+      const char* suffixStart = value.data() + sharedPrefixLen;
+      encodedData.insert(
+          encodedData.end(), suffixStart, suffixStart + suffixLen);
+    }
+
+    lastValue = value;
+  }
+
+  // Calculate total encoding size:
+  // header + restart interval + restart offsets + encoded entries
+  NIMBLE_DCHECK_EQ(
+      numRestarts, restartOffsets.size(), "Restart count mismatch");
+  const uint32_t restartOffsetsSize = numRestarts * sizeof(uint32_t);
+  const uint32_t encodingSize =
+      kRestartOffsetsOffset + restartOffsetsSize + encodedData.size();
+
+  // Write encoded data to buffer
+  char* reserved = buffer.reserve(encodingSize);
+  char* pos = reserved;
+
+  // Write encoding prefix
+  Encoding::serializePrefix(
+      EncodingType::Prefix,
+      TypeTraits<std::string_view>::dataType,
+      valueCount,
+      pos);
+
+  // Write restart interval
+  encoding::writeUint32(restartInterval, pos);
+
+  // Write restart offsets (at head for better seek performance)
+  for (uint32_t offset : restartOffsets) {
+    encoding::writeUint32(offset, pos);
+  }
+
+  // Write encoded entries
+  encoding::writeBytes({encodedData.data(), encodedData.size()}, pos);
+
+  NIMBLE_DCHECK_EQ(pos - reserved, encodingSize, "Encoding size mismatch");
+
+  return {reserved, encodingSize};
+}
+
+std::string PrefixEncoding::debugString(int offset) const {
+  std::string log = Encoding::debugString(offset);
+  log += fmt::format(
+      "\n{}restart_interval={}, num_restarts={}",
+      std::string(offset, ' '),
+      restartInterval_,
+      numRestarts_);
+  return log;
+}
+
+} // namespace facebook::nimble

--- a/dwio/nimble/encodings/PrefixEncoding.h
+++ b/dwio/nimble/encodings/PrefixEncoding.h
@@ -1,0 +1,173 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <span>
+#include "dwio/nimble/common/Buffer.h"
+#include "dwio/nimble/common/EncodingPrimitives.h"
+#include "dwio/nimble/common/EncodingType.h"
+#include "dwio/nimble/common/Types.h"
+#include "dwio/nimble/common/Vector.h"
+#include "dwio/nimble/encodings/Encoding.h"
+#include "dwio/nimble/encodings/EncodingFactory.h"
+#include "dwio/nimble/encodings/EncodingIdentifier.h"
+#include "dwio/nimble/encodings/EncodingSelection.h"
+#include "velox/common/memory/Memory.h"
+
+/// PrefixEncoding stores sorted string data with prefix compression. Common
+/// prefixes are shared across consecutive entries to reduce storage space.
+///
+/// Based on prefix encoding algorithms from RocksDB, Apache Kudu, and Doris:
+/// - Consecutive sorted entries typically share common prefixes
+/// - Store prefix length + suffix for each entry instead of full strings
+/// - Periodically store full restart points for seek operations
+///
+/// Binary layout:
+/// - Encoding::kPrefixSize bytes: standard Encoding prefix
+/// - 4 bytes: restart interval (number of entries between restart points)
+/// - ZZ bytes: restart offsets array (uint32_t array of byte offsets,
+///   size = ceil(rowCount / restartInterval))
+/// - XX bytes: encoded entries (prefix_len | suffix_len | suffix_data)*
+///
+/// The restart offsets are placed at the head of the encoding block to
+/// accelerate memory access patterns for seek operations, as prefix encoding
+/// is primarily used for seeking in sorted data.
+///
+/// The number of restarts can be computed from rowCount and restartInterval:
+///   numRestarts = (rowCount + restartInterval - 1) / restartInterval
+///
+/// Each entry stores:
+/// - shared_prefix_len (uint32): bytes shared with previous entry
+/// - suffix_len (uint32): length of unique suffix
+/// - suffix_data: the suffix bytes
+///
+/// Restart points are full entries (shared_prefix_len = 0) stored at regular
+/// intervals to enable efficient seek operations.
+
+namespace facebook::nimble {
+
+/// Encoding for sorted string data with prefix compression and seek support.
+/// Only supports std::string_view data type.
+class PrefixEncoding final
+    : public TypedEncoding<std::string_view, std::string_view> {
+ public:
+  using cppDataType = std::string_view;
+  using physicalType = std::string_view;
+
+  static constexpr int kRestartIntervalOffset = Encoding::kPrefixSize;
+  static constexpr int kRestartOffsetsOffset = kRestartIntervalOffset + 4;
+  static constexpr uint32_t kDefaultRestartInterval = 16;
+
+  PrefixEncoding(velox::memory::MemoryPool& pool, std::string_view data);
+
+  void reset() final;
+  void skip(uint32_t rowCount) final;
+
+  /// Decodes and materializes string values into the output buffer.
+  ///
+  /// The output string_views remain valid until the next call to materialize(),
+  /// reset(), or until the encoding is destroyed. The encoding maintains an
+  /// internal buffer that holds the decoded string data.
+  ///
+  /// @param rowCount Number of rows to materialize.
+  /// @param buffer Output buffer for std::string_view values.
+  void materialize(uint32_t rowCount, void* buffer) final;
+
+  /// Seeks to the position at or after the given value.
+  ///
+  /// @param value Pointer to target value to seek.
+  /// @return Row index if found, std::nullopt if value is greater than all
+  /// entries.
+  std::optional<uint32_t> seekAtOrAfter(const void* value) final;
+
+  template <typename DecoderVisitor>
+  void readWithVisitor(DecoderVisitor& visitor, ReadWithVisitorParams& params);
+
+  /// Encodes sorted string values with prefix compression.
+  ///
+  /// @param selection Encoding selection policy.
+  /// @param values Values to encode. Must be sorted in ascending order.
+  /// @param buffer Output buffer for encoded data.
+  /// @return View of the encoded data.
+  static std::string_view encode(
+      EncodingSelection<physicalType>& selection,
+      std::span<const physicalType> values,
+      Buffer& buffer);
+
+  std::string debugString(int offset) const final;
+
+ private:
+  // Static helper methods for initializing const members
+  static uint32_t readRestartInterval(std::string_view data);
+  static const char* restartOffsets(std::string_view data);
+  static const char* dataStart(std::string_view data, uint32_t numRestarts);
+
+  // Computes numRestarts from rowCount and restartInterval
+  static uint32_t computeNumRestarts(
+      uint32_t rowCount,
+      uint32_t restartInterval);
+
+  // Decodes entry at current position and returns the full string.
+  // Stores result in decodedValue_ buffer.
+  //
+  // NOTE: The returned string_view is invalidated on the next decodeEntry call
+  // as decodedValue_ buffer is overwritten.
+  std::string_view decodeEntry();
+
+  // Seeks to the restart point at the given index.
+  void seekToRestartPoint(uint32_t restartIndex);
+
+  // Gets the offset for the restart point at the given index.
+  uint32_t restartOffset(uint32_t restartIndex) const;
+
+  // Restart interval - number of entries between restart points
+  const uint32_t restartInterval_;
+  // Number of restart points (computed from rowCount and restartInterval)
+  const uint32_t numRestarts_;
+  // Offset to start of restart offsets array
+  const char* const restartOffsets_;
+  // Offset to start of data section
+  const char* const dataStart_;
+
+  // Current read position in the data
+  const char* currentPos_{nullptr};
+  // Current row index being read
+  uint32_t currentRow_{0};
+  // Buffer to store decoded value. The shared prefix from the previous entry
+  // is already at the beginning of this buffer, so we only need to append the
+  // suffix for each new entry.
+  Vector<char> decodedValue_;
+  // Buffer to hold all materialized string data for the current batch.
+  // String views returned by materialize() point into this buffer and
+  // remain valid until the next materialize() call.
+  Vector<char> materializedValues_;
+};
+
+/// Template implementation (remain in header)
+///
+/// TODO: tune this later if needs for regular data column storage.
+template <typename V>
+void PrefixEncoding::readWithVisitor(
+    V& visitor,
+    ReadWithVisitorParams& params) {
+  detail::readWithVisitorSlow(
+      visitor,
+      params,
+      [&](auto toSkip) { this->skip(toSkip); },
+      [&] { return decodeEntry(); });
+}
+
+} // namespace facebook::nimble

--- a/dwio/nimble/encodings/tests/CMakeLists.txt
+++ b/dwio/nimble/encodings/tests/CMakeLists.txt
@@ -19,8 +19,8 @@ add_executable(
   ConstantEncodingTests.cpp
   EncodingLayoutTests.cpp
   EncodingSelectionTests.cpp
-  EncodingTests.cpp
-  EncodingTestsLegacy.cpp
+  EncodingTest.cpp
+  EncodingLegacyTest.cpp
   MainlyConstantEncodingTests.cpp
   NullableEncodingTests.cpp
   RleEncodingTests.cpp

--- a/dwio/nimble/encodings/tests/EncodingLegacyTest.cpp
+++ b/dwio/nimble/encodings/tests/EncodingLegacyTest.cpp
@@ -24,18 +24,18 @@
 #include "dwio/nimble/common/Types.h"
 #include "dwio/nimble/common/Vector.h"
 #include "dwio/nimble/common/tests/TestUtils.h"
-#include "dwio/nimble/encodings/ConstantEncoding.h"
 #include "dwio/nimble/encodings/DeltaEncoding.h"
-#include "dwio/nimble/encodings/DictionaryEncoding.h"
 #include "dwio/nimble/encodings/Encoding.h"
-#include "dwio/nimble/encodings/EncodingFactory.h"
 #include "dwio/nimble/encodings/EncodingSelectionPolicy.h"
-#include "dwio/nimble/encodings/FixedBitWidthEncoding.h"
-#include "dwio/nimble/encodings/MainlyConstantEncoding.h"
-#include "dwio/nimble/encodings/RleEncoding.h"
-#include "dwio/nimble/encodings/SparseBoolEncoding.h"
-#include "dwio/nimble/encodings/TrivialEncoding.h"
-#include "dwio/nimble/encodings/VarintEncoding.h"
+#include "dwio/nimble/encodings/legacy/ConstantEncoding.h"
+#include "dwio/nimble/encodings/legacy/DictionaryEncoding.h"
+#include "dwio/nimble/encodings/legacy/EncodingFactory.h"
+#include "dwio/nimble/encodings/legacy/FixedBitWidthEncoding.h"
+#include "dwio/nimble/encodings/legacy/MainlyConstantEncoding.h"
+#include "dwio/nimble/encodings/legacy/RleEncoding.h"
+#include "dwio/nimble/encodings/legacy/SparseBoolEncoding.h"
+#include "dwio/nimble/encodings/legacy/TrivialEncoding.h"
+#include "dwio/nimble/encodings/legacy/VarintEncoding.h"
 #include "folly/Random.h"
 #include "velox/common/memory/Memory.h"
 
@@ -43,7 +43,7 @@
 //
 // Nullable data will be tested via a separate file, as will structured data,
 // and any data-type-specific functions (e.g. for there are some Encoding calls
-// only valid for bools, and those are testing in BoolEncodingTests.cpp).
+// only valid for bools, and those are testing in BoolEncodingLegacyTest.cpp).
 //
 // The tests are templated so as to cover all data types and encoding types with
 // a single code path.
@@ -72,12 +72,14 @@ class TestCompressPolicy : public nimble::CompressionPolicy {
     return information;
   }
 
-  virtual bool shouldAccept(
+  bool shouldAccept(
       nimble::CompressionType /* compressionType */,
       uint64_t /* uncompressedSize */,
       uint64_t /* compressedSize */) const override {
     return true;
   }
+
+  ~TestCompressPolicy() override = default;
 
  private:
   bool compress_;
@@ -132,10 +134,9 @@ class TestTrivialEncodingSelectionPolicy
   bool useVariableBitWidthCompressor_;
 };
 } // namespace
-
 // C is the encoding type.
 template <typename C>
-class EncodingTests : public ::testing::Test {
+class EncodingLegacyTest : public ::testing::Test {
  protected:
   using E = typename C::cppDataType;
 
@@ -149,48 +150,48 @@ class EncodingTests : public ::testing::Test {
   struct EncodingTypeTraits {};
 
   template <>
-  struct EncodingTypeTraits<nimble::ConstantEncoding<E>> {
+  struct EncodingTypeTraits<nimble::legacy::ConstantEncoding<E>> {
     static inline nimble::EncodingType encodingType =
         nimble::EncodingType::Constant;
   };
 
   template <>
-  struct EncodingTypeTraits<nimble::DictionaryEncoding<E>> {
+  struct EncodingTypeTraits<nimble::legacy::DictionaryEncoding<E>> {
     static inline nimble::EncodingType encodingType =
         nimble::EncodingType::Dictionary;
   };
 
   template <>
-  struct EncodingTypeTraits<nimble::FixedBitWidthEncoding<E>> {
+  struct EncodingTypeTraits<nimble::legacy::FixedBitWidthEncoding<E>> {
     static inline nimble::EncodingType encodingType =
         nimble::EncodingType::FixedBitWidth;
   };
 
   template <>
-  struct EncodingTypeTraits<nimble::MainlyConstantEncoding<E>> {
+  struct EncodingTypeTraits<nimble::legacy::MainlyConstantEncoding<E>> {
     static inline nimble::EncodingType encodingType =
         nimble::EncodingType::MainlyConstant;
   };
 
   template <>
-  struct EncodingTypeTraits<nimble::RLEEncoding<E>> {
+  struct EncodingTypeTraits<nimble::legacy::RLEEncoding<E>> {
     static inline nimble::EncodingType encodingType = nimble::EncodingType::RLE;
   };
 
   template <>
-  struct EncodingTypeTraits<nimble::SparseBoolEncoding> {
+  struct EncodingTypeTraits<nimble::legacy::SparseBoolEncoding> {
     static inline nimble::EncodingType encodingType =
         nimble::EncodingType::SparseBool;
   };
 
   template <>
-  struct EncodingTypeTraits<nimble::TrivialEncoding<E>> {
+  struct EncodingTypeTraits<nimble::legacy::TrivialEncoding<E>> {
     static inline nimble::EncodingType encodingType =
         nimble::EncodingType::Trivial;
   };
 
   template <>
-  struct EncodingTypeTraits<nimble::VarintEncoding<E>> {
+  struct EncodingTypeTraits<nimble::legacy::VarintEncoding<E>> {
     static inline nimble::EncodingType encodingType =
         nimble::EncodingType::Varint;
   };
@@ -246,18 +247,18 @@ class EncodingTests : public ::testing::Test {
 #define ALL_TYPES(EncodingName) NON_BOOL_TYPES(EncodingName), EncodingName<bool>
 
 using TestTypes = ::testing::Types<
-    nimble::SparseBoolEncoding,
-    VARINT_TYPES(nimble::VarintEncoding),
-    NUMERIC_TYPES(nimble::FixedBitWidthEncoding),
-    NON_BOOL_TYPES(nimble::DictionaryEncoding),
-    NON_BOOL_TYPES(nimble::MainlyConstantEncoding),
-    ALL_TYPES(nimble::TrivialEncoding),
-    ALL_TYPES(nimble::RLEEncoding),
-    ALL_TYPES(nimble::ConstantEncoding)>;
+    nimble::legacy::SparseBoolEncoding,
+    VARINT_TYPES(nimble::legacy::VarintEncoding),
+    NUMERIC_TYPES(nimble::legacy::FixedBitWidthEncoding),
+    NON_BOOL_TYPES(nimble::legacy::DictionaryEncoding),
+    NON_BOOL_TYPES(nimble::legacy::MainlyConstantEncoding),
+    ALL_TYPES(nimble::legacy::TrivialEncoding),
+    ALL_TYPES(nimble::legacy::RLEEncoding),
+    ALL_TYPES(nimble::legacy::ConstantEncoding)>;
 
-TYPED_TEST_CASE(EncodingTests, TestTypes);
+TYPED_TEST_CASE(EncodingLegacyTest, TestTypes);
 
-TYPED_TEST(EncodingTests, Materialize) {
+TYPED_TEST(EncodingLegacyTest, materialize) {
   auto seed = folly::Random::rand32();
   LOG(INFO) << "seed: " << seed;
   std::mt19937 rng(seed);
@@ -368,7 +369,7 @@ void checkScatteredOutput(
   }
 }
 
-TYPED_TEST(EncodingTests, ScatteredMaterialize) {
+TYPED_TEST(EncodingLegacyTest, scatteredMaterialize) {
   using E = typename TypeParam::cppDataType;
 
   auto seed = folly::Random::rand32();

--- a/dwio/nimble/encodings/tests/EncodingTest.cpp
+++ b/dwio/nimble/encodings/tests/EncodingTest.cpp
@@ -1,0 +1,589 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "dwio/nimble/encodings/Encoding.h"
+#include <glog/logging.h>
+#include <gtest/gtest.h>
+#include <memory>
+#include <span>
+#include <vector>
+#include "dwio/nimble/common/Bits.h"
+#include "dwio/nimble/common/Buffer.h"
+#include "dwio/nimble/common/FixedBitArray.h"
+#include "dwio/nimble/common/Types.h"
+#include "dwio/nimble/common/Vector.h"
+#include "dwio/nimble/common/tests/TestUtils.h"
+#include "dwio/nimble/encodings/ConstantEncoding.h"
+#include "dwio/nimble/encodings/DeltaEncoding.h"
+#include "dwio/nimble/encodings/DictionaryEncoding.h"
+#include "dwio/nimble/encodings/EncodingFactory.h"
+#include "dwio/nimble/encodings/EncodingSelectionPolicy.h"
+#include "dwio/nimble/encodings/FixedBitWidthEncoding.h"
+#include "dwio/nimble/encodings/MainlyConstantEncoding.h"
+#include "dwio/nimble/encodings/RleEncoding.h"
+#include "dwio/nimble/encodings/SparseBoolEncoding.h"
+#include "dwio/nimble/encodings/TrivialEncoding.h"
+#include "dwio/nimble/encodings/VarintEncoding.h"
+#include "folly/Random.h"
+#include "velox/common/memory/Memory.h"
+
+// Tests the Encoding API for all basic Encoding implementations and data types.
+//
+// Nullable data will be tested via a separate file, as will structured data,
+// and any data-type-specific functions (e.g. for there are some Encoding calls
+// only valid for bools, and those are testing in BoolEncodingTests.cpp).
+//
+// The tests are templated so as to cover all data types and encoding types with
+// a single code path.
+
+using namespace facebook;
+
+namespace {
+
+class TestCompressPolicy : public nimble::CompressionPolicy {
+ public:
+  explicit TestCompressPolicy(bool compress, bool useVariableBitWidthCompressor)
+      : compress_{compress},
+        useVariableBitWidthCompressor_{useVariableBitWidthCompressor} {}
+
+  nimble::CompressionInformation compression() const override {
+    if (!compress_) {
+      return {.compressionType = nimble::CompressionType::Uncompressed};
+    }
+
+    nimble::CompressionInformation information{
+        .compressionType = nimble::CompressionType::MetaInternal};
+    information.parameters.metaInternal.compressionLevel = 9;
+    information.parameters.metaInternal.decompressionLevel = 2;
+    information.parameters.metaInternal.useVariableBitWidthCompressor =
+        useVariableBitWidthCompressor_;
+    return information;
+  }
+
+  virtual bool shouldAccept(
+      nimble::CompressionType /* compressionType */,
+      uint64_t /* uncompressedSize */,
+      uint64_t /* compressedSize */) const override {
+    return true;
+  }
+
+ private:
+  bool compress_;
+  bool useVariableBitWidthCompressor_;
+};
+
+template <typename T>
+class TestTrivialEncodingSelectionPolicy
+    : public nimble::EncodingSelectionPolicy<T> {
+  using physicalType = typename nimble::TypeTraits<T>::physicalType;
+
+ public:
+  explicit TestTrivialEncodingSelectionPolicy(
+      bool shouldCompress,
+      bool useVariableBitWidthCompressor)
+      : shouldCompress_{shouldCompress},
+        useVariableBitWidthCompressor_{useVariableBitWidthCompressor} {}
+
+  nimble::EncodingSelectionResult select(
+      std::span<const physicalType> /* values */,
+      const nimble::Statistics<physicalType>& /* statistics */) override {
+    return {
+        .encodingType = nimble::EncodingType::Trivial,
+        .compressionPolicyFactory = [this]() {
+          return std::make_unique<TestCompressPolicy>(
+              shouldCompress_, useVariableBitWidthCompressor_);
+        }};
+  }
+
+  nimble::EncodingSelectionResult selectNullable(
+      std::span<const physicalType> /* values */,
+      std::span<const bool> /* nulls */,
+      const nimble::Statistics<physicalType>& /* statistics */) override {
+    return {
+        .encodingType = nimble::EncodingType::Nullable,
+    };
+  }
+
+  std::unique_ptr<nimble::EncodingSelectionPolicyBase> createImpl(
+      nimble::EncodingType /* encodingType */,
+      nimble::NestedEncodingIdentifier /* identifier */,
+      nimble::DataType type) override {
+    UNIQUE_PTR_FACTORY(
+        type,
+        TestTrivialEncodingSelectionPolicy,
+        shouldCompress_,
+        useVariableBitWidthCompressor_);
+  }
+
+ private:
+  bool shouldCompress_;
+  bool useVariableBitWidthCompressor_;
+};
+} // namespace
+
+// C is the encoding type.
+template <typename C>
+class EncodingTest : public ::testing::Test {
+ protected:
+  using E = typename C::cppDataType;
+
+  void SetUp() override {
+    pool_ = facebook::velox::memory::deprecatedAddDefaultLeafMemoryPool();
+    buffer_ = std::make_unique<nimble::Buffer>(*this->pool_);
+    util_ = std::make_unique<nimble::testing::Util>(*this->pool_);
+  }
+
+  template <typename Encoding>
+  struct EncodingTypeTraits {};
+
+  template <>
+  struct EncodingTypeTraits<nimble::ConstantEncoding<E>> {
+    static inline nimble::EncodingType encodingType =
+        nimble::EncodingType::Constant;
+  };
+
+  template <>
+  struct EncodingTypeTraits<nimble::DictionaryEncoding<E>> {
+    static inline nimble::EncodingType encodingType =
+        nimble::EncodingType::Dictionary;
+  };
+
+  template <>
+  struct EncodingTypeTraits<nimble::FixedBitWidthEncoding<E>> {
+    static inline nimble::EncodingType encodingType =
+        nimble::EncodingType::FixedBitWidth;
+  };
+
+  template <>
+  struct EncodingTypeTraits<nimble::MainlyConstantEncoding<E>> {
+    static inline nimble::EncodingType encodingType =
+        nimble::EncodingType::MainlyConstant;
+  };
+
+  template <>
+  struct EncodingTypeTraits<nimble::RLEEncoding<E>> {
+    static inline nimble::EncodingType encodingType = nimble::EncodingType::RLE;
+  };
+
+  template <>
+  struct EncodingTypeTraits<nimble::SparseBoolEncoding> {
+    static inline nimble::EncodingType encodingType =
+        nimble::EncodingType::SparseBool;
+  };
+
+  template <>
+  struct EncodingTypeTraits<nimble::TrivialEncoding<E>> {
+    static inline nimble::EncodingType encodingType =
+        nimble::EncodingType::Trivial;
+  };
+
+  template <>
+  struct EncodingTypeTraits<nimble::VarintEncoding<E>> {
+    static inline nimble::EncodingType encodingType =
+        nimble::EncodingType::Varint;
+  };
+
+  std::unique_ptr<nimble::Encoding> createEncoding(
+      const nimble::Vector<E>& values,
+      bool compress,
+      bool useVariableBitWidthCompressor,
+      std::function<void*(uint32_t)> stringBufferFactory) {
+    using physicalType = typename nimble::TypeTraits<E>::physicalType;
+    auto physicalValues = std::span<const physicalType>(
+        reinterpret_cast<const physicalType*>(values.data()), values.size());
+    nimble::EncodingSelection<physicalType> selection{
+        {.encodingType = EncodingTypeTraits<C>::encodingType,
+         .compressionPolicyFactory =
+             [compress, useVariableBitWidthCompressor]() {
+               return std::make_unique<TestCompressPolicy>(
+                   compress, useVariableBitWidthCompressor);
+             }},
+        nimble::Statistics<physicalType>::create(physicalValues),
+        std::make_unique<TestTrivialEncodingSelectionPolicy<E>>(
+            compress, useVariableBitWidthCompressor)};
+
+    auto encoded = C::encode(selection, physicalValues, *buffer_);
+    return std::make_unique<C>(*this->pool_, encoded, stringBufferFactory);
+  }
+
+  // Each unit test runs on randomized data this many times before
+  // we conclude the unit test passed.
+  static constexpr int32_t kNumRandomRuns = 10;
+
+  // We want the number of row tested to potentially be large compared to a
+  // skip block. When we actually generate data we pick a random length between
+  // 1 and this size.
+  static constexpr int32_t kMaxRows = 2000;
+
+  std::shared_ptr<velox::memory::MemoryPool> pool_;
+  std::unique_ptr<nimble::Buffer> buffer_;
+  std::unique_ptr<nimble::testing::Util> util_;
+};
+
+#define VARINT_TYPES(EncodingName)                                      \
+  EncodingName<int32_t>, EncodingName<int64_t>, EncodingName<uint32_t>, \
+      EncodingName<uint64_t>, EncodingName<float>, EncodingName<double>
+
+#define NUMERIC_TYPES(EncodingName)                                        \
+  VARINT_TYPES(EncodingName), EncodingName<int8_t>, EncodingName<uint8_t>, \
+      EncodingName<int16_t>, EncodingName<uint16_t>
+
+#define NON_BOOL_TYPES(EncodingName) \
+  NUMERIC_TYPES(EncodingName), EncodingName<std::string_view>
+
+#define ALL_TYPES(EncodingName) NON_BOOL_TYPES(EncodingName), EncodingName<bool>
+
+using TestTypes = ::testing::Types<
+    nimble::SparseBoolEncoding,
+    VARINT_TYPES(nimble::VarintEncoding),
+    NUMERIC_TYPES(nimble::FixedBitWidthEncoding),
+    NON_BOOL_TYPES(nimble::DictionaryEncoding),
+    NON_BOOL_TYPES(nimble::MainlyConstantEncoding),
+    ALL_TYPES(nimble::TrivialEncoding),
+    ALL_TYPES(nimble::RLEEncoding),
+    ALL_TYPES(nimble::ConstantEncoding)>;
+
+TYPED_TEST_CASE(EncodingTest, TestTypes);
+
+TYPED_TEST(EncodingTest, materialize) {
+  auto seed = folly::Random::rand32();
+  LOG(INFO) << "seed: " << seed;
+  std::mt19937 rng(seed);
+
+  using E = typename TypeParam::cppDataType;
+
+  for (int run = 0; run < this->kNumRandomRuns; ++run) {
+    const std::vector<nimble::Vector<E>> dataPatterns =
+        this->util_->template makeDataPatterns<E>(
+            rng, this->kMaxRows, this->buffer_.get());
+    for (const auto& data : dataPatterns) {
+      for (auto compress : {false, true}) {
+        for (auto useVariableBitWidthCompressor : {false, true}) {
+          const int rowCount = data.size();
+          ASSERT_GT(rowCount, 0);
+          std::unique_ptr<nimble::Encoding> encoding;
+          std::vector<velox::BufferPtr> newStringBuffers;
+          const auto stringBufferFactory = [&](uint32_t totalLength) {
+            auto& buffer = newStringBuffers.emplace_back(
+                velox::AlignedBuffer::allocate<char>(
+                    totalLength, this->pool_.get()));
+            return buffer->template asMutable<void>();
+          };
+          try {
+            encoding = this->createEncoding(
+                data,
+                compress,
+                useVariableBitWidthCompressor,
+                stringBufferFactory);
+          } catch (const nimble::NimbleUserError& e) {
+            if (e.errorCode() == nimble::error_code::IncompatibleEncoding) {
+              continue;
+            }
+            throw;
+          }
+          ASSERT_EQ(encoding->dataType(), nimble::TypeTraits<E>::dataType);
+          nimble::Vector<E> buffer(this->pool_.get(), rowCount);
+
+          encoding->materialize(rowCount, buffer.data());
+          for (int i = 0; i < rowCount; ++i) {
+            ASSERT_EQ(buffer[i], data[i]) << "i: " << i;
+          }
+
+          encoding->reset();
+          const int firstBlock = rowCount / 2;
+          encoding->materialize(firstBlock, buffer.data());
+          for (int i = 0; i < firstBlock; ++i) {
+            ASSERT_EQ(buffer[i], data[i]);
+          }
+          const int secondBlock = rowCount - firstBlock;
+          encoding->materialize(secondBlock, buffer.data());
+          for (int i = 0; i < secondBlock; ++i) {
+            ASSERT_EQ(buffer[i], data[firstBlock + i]);
+          }
+
+          encoding->reset();
+          for (int i = 0; i < rowCount; ++i) {
+            encoding->materialize(1, buffer.data());
+            ASSERT_EQ(buffer[0], data[i]);
+          }
+
+          encoding->reset();
+          int start = 0;
+          int len = 0;
+          for (int i = 0; i < rowCount; ++i) {
+            start += len;
+            len += 1;
+            if (start + len > rowCount) {
+              break;
+            }
+            encoding->materialize(len, buffer.data());
+            for (int j = 0; j < len; ++j) {
+              ASSERT_EQ(data[start + j], buffer[j]);
+            }
+          }
+
+          const uint32_t offset = folly::Random::rand32(rng) % data.size();
+          const uint32_t length =
+              1 + folly::Random::rand32(rng) % (data.size() - offset);
+          encoding->reset();
+          encoding->skip(offset);
+          encoding->materialize(length, buffer.data());
+          for (uint32_t i = 0; i < length; ++i) {
+            ASSERT_EQ(buffer[i], data[offset + i]);
+          }
+        }
+      }
+    }
+  }
+}
+
+template <typename T>
+void checkScatteredOutput(
+    bool hasNulls,
+    size_t index,
+    const bool* scatter,
+    const T* actual,
+    const T* expected,
+    const char* nulls,
+    uint32_t& expectedRow) {
+  if (scatter[index]) {
+    ASSERT_EQ(actual[index], expected[expectedRow]);
+    ++expectedRow;
+  }
+
+  if (hasNulls) {
+    ASSERT_EQ(scatter[index], nimble::bits::getBit(index, nulls));
+  }
+}
+
+TYPED_TEST(EncodingTest, scatteredMaterialize) {
+  using E = typename TypeParam::cppDataType;
+
+  auto seed = folly::Random::rand32();
+  LOG(INFO) << "seed: " << seed;
+  std::mt19937 rng(seed);
+
+  for (int run = 0; run < this->kNumRandomRuns; ++run) {
+    const std::vector<nimble::Vector<E>> dataPatterns =
+        this->util_->template makeDataPatterns<E>(
+            rng, this->kMaxRows, this->buffer_.get());
+    for (const auto& data : dataPatterns) {
+      for (auto compress : {false, true}) {
+        for (auto useVariableBitWidthCompressor : {false, true}) {
+          const int rowCount = data.size();
+          ASSERT_GT(rowCount, 0);
+          std::unique_ptr<nimble::Encoding> encoding;
+          std::vector<velox::BufferPtr> newStringBuffers;
+          const auto stringBufferFactory = [&](uint32_t totalLength) {
+            auto& buffer = newStringBuffers.emplace_back(
+                velox::AlignedBuffer::allocate<char>(
+                    totalLength, this->pool_.get()));
+            return buffer->template asMutable<void>();
+          };
+          try {
+            encoding = this->createEncoding(
+                data,
+                compress,
+                useVariableBitWidthCompressor,
+                stringBufferFactory);
+          } catch (const nimble::NimbleUserError& e) {
+            if (e.errorCode() == nimble::error_code::IncompatibleEncoding) {
+              continue;
+            }
+            throw;
+          }
+          ASSERT_EQ(encoding->dataType(), nimble::TypeTraits<E>::dataType);
+
+          int setBits = 0;
+          std::vector<int32_t> scatterSizes(rowCount + 1);
+          scatterSizes[0] = 0;
+          nimble::Vector<bool> scatter(this->pool_.get());
+          while (setBits < rowCount) {
+            scatter.push_back(folly::Random::oneIn(2, rng));
+            if (scatter.back()) {
+              scatterSizes[++setBits] = scatter.size();
+            }
+          }
+
+          auto newRowCount = scatter.size();
+          auto requiredBytes = nimble::bits::bytesRequired(newRowCount);
+          // Note: Internally, some bit implementations use word boundaries to
+          // efficiently iterate on bitmaps. If the buffer doesn't end on a
+          // word boundary, this leads to ASAN buffer overflow (debug builds).
+          // So for now, we are allocating extra 7 bytes to make sure the
+          // buffer ends or exceeds a word boundary.
+          nimble::Buffer scatterBuffer{*this->pool_, requiredBytes + 7};
+          nimble::Buffer nullsBuffer{*this->pool_, requiredBytes + 7};
+          auto scatterPtr = scatterBuffer.reserve(requiredBytes);
+          auto nullsPtr = nullsBuffer.reserve(requiredBytes);
+          memset(scatterPtr, 0, requiredBytes);
+          nimble::bits::packBitmap(scatter, scatterPtr);
+
+          nimble::Vector<E> buffer(this->pool_.get(), newRowCount);
+
+          uint32_t expectedRow = 0;
+          uint32_t actualRows = 0;
+          {
+            nimble::bits::Bitmap scatterBitmap(scatterPtr, newRowCount);
+            actualRows = encoding->materializeNullable(
+                rowCount,
+                buffer.data(),
+                [&]() { return nullsPtr; },
+                &scatterBitmap);
+          }
+          ASSERT_EQ(actualRows, rowCount);
+          auto hasNulls = actualRows != newRowCount;
+          for (int i = 0; i < newRowCount; ++i) {
+            checkScatteredOutput(
+                hasNulls,
+                i,
+                scatter.data(),
+                buffer.data(),
+                data.data(),
+                nullsPtr,
+                expectedRow);
+          }
+          EXPECT_EQ(rowCount, expectedRow);
+
+          encoding->reset();
+          const int firstBlock = rowCount / 2;
+          const int firstScatterSize = scatterSizes[firstBlock];
+          expectedRow = 0;
+          {
+            nimble::bits::Bitmap scatterBitmap(scatterPtr, firstScatterSize);
+            actualRows = encoding->materializeNullable(
+                firstBlock,
+                buffer.data(),
+                [&]() { return nullsPtr; },
+                &scatterBitmap);
+          }
+          ASSERT_EQ(actualRows, firstBlock);
+          hasNulls = actualRows != firstScatterSize;
+          for (int i = 0; i < firstScatterSize; ++i) {
+            checkScatteredOutput(
+                hasNulls,
+                i,
+                scatter.data(),
+                buffer.data(),
+                data.data(),
+                nullsPtr,
+                expectedRow);
+          }
+          ASSERT_EQ(actualRows, expectedRow);
+
+          const int secondBlock = rowCount - firstBlock;
+          const int secondScatterSize = scatter.size() - firstScatterSize;
+          expectedRow = actualRows;
+          {
+            nimble::bits::Bitmap scatterBitmap(scatterPtr, newRowCount);
+            actualRows = encoding->materializeNullable(
+                secondBlock,
+                buffer.data(),
+                [&]() { return nullsPtr; },
+                &scatterBitmap,
+                firstScatterSize);
+          }
+          ASSERT_EQ(actualRows, secondBlock);
+          hasNulls = actualRows != secondScatterSize;
+          auto previousRows = expectedRow;
+          for (int i = firstScatterSize; i < newRowCount; ++i) {
+            checkScatteredOutput(
+                hasNulls,
+                i,
+                scatter.data(),
+                buffer.data(),
+                data.data(),
+                nullsPtr,
+                expectedRow);
+          }
+          ASSERT_EQ(actualRows, expectedRow - previousRows);
+          ASSERT_EQ(rowCount, expectedRow);
+
+          encoding->reset();
+          expectedRow = 0;
+          for (int i = 0; i < rowCount; ++i) {
+            // Note: Internally, some bit implementations use word boundaries
+            // to efficiently iterate on bitmaps. If the buffer doesn't end on
+            // a word boundary, this leads to ASAN buffer overflow (debug
+            // builds). So for now, we are using uint64_t as the bitmap to
+            // make sure the buffer ends on a word boundary.
+            auto scatterStart = scatterSizes[i];
+            auto scatterEnd = scatterSizes[i + 1];
+            {
+              nimble::bits::Bitmap scatterBitmap(scatterPtr, scatterEnd);
+              actualRows = encoding->materializeNullable(
+                  1,
+                  buffer.data(),
+                  [&]() { return nullsPtr; },
+                  &scatterBitmap,
+                  scatterStart);
+            }
+            ASSERT_EQ(actualRows, 1);
+            previousRows = expectedRow;
+            for (int j = scatterStart; j < scatterEnd; ++j) {
+              checkScatteredOutput(
+                  scatterEnd - scatterStart > 1,
+                  j,
+                  scatter.data(),
+                  buffer.data(),
+                  data.data(),
+                  nullsPtr,
+                  expectedRow);
+            }
+            ASSERT_EQ(actualRows, expectedRow - previousRows);
+          }
+          ASSERT_EQ(rowCount, expectedRow);
+
+          encoding->reset();
+          expectedRow = 0;
+          int start = 0;
+          int len = 0;
+          for (int i = 0; i < rowCount; ++i) {
+            start += len;
+            len += 1;
+            if (start + len > rowCount) {
+              break;
+            }
+            auto scatterStart = scatterSizes[start];
+            auto scatterEnd = scatterSizes[start + len];
+            {
+              nimble::bits::Bitmap scatterBitmap(scatterPtr, scatterEnd);
+              actualRows = encoding->materializeNullable(
+                  len,
+                  buffer.data(),
+                  [&]() { return nullsPtr; },
+                  &scatterBitmap,
+                  scatterStart);
+            }
+            ASSERT_EQ(actualRows, len);
+            hasNulls = actualRows != scatterEnd - scatterStart;
+            previousRows = expectedRow;
+            for (int j = scatterStart; j < scatterEnd; ++j) {
+              checkScatteredOutput(
+                  hasNulls,
+                  j,
+                  scatter.data(),
+                  buffer.data(),
+                  data.data(),
+                  nullsPtr,
+                  expectedRow);
+            }
+            ASSERT_EQ(actualRows, expectedRow - previousRows);
+          }
+        }
+      }
+    }
+  }
+}

--- a/dwio/nimble/encodings/tests/PrefixEncodingTest.cpp
+++ b/dwio/nimble/encodings/tests/PrefixEncodingTest.cpp
@@ -1,0 +1,1073 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "dwio/nimble/encodings/PrefixEncoding.h"
+#include <fmt/core.h>
+#include <gtest/gtest.h>
+#include "dwio/nimble/common/Buffer.h"
+#include "dwio/nimble/encodings/EncodingFactory.h"
+#include "dwio/nimble/encodings/EncodingSelection.h"
+#include "dwio/nimble/encodings/EncodingSelectionPolicy.h"
+#include "folly/Conv.h"
+#include "velox/buffer/Buffer.h"
+#include "velox/common/memory/Memory.h"
+
+using namespace ::facebook;
+
+namespace facebook::nimble::test {
+
+class PrefixEncodingTest : public ::testing::Test {
+ protected:
+  static void SetUpTestCase() {
+    velox::memory::MemoryManager::initialize({});
+  }
+
+  void SetUp() override {
+    pool_ = velox::memory::memoryManager()->addLeafPool();
+  }
+
+  std::unique_ptr<EncodingSelectionPolicy<std::string_view>>
+  createSelectionPolicy() {
+    // Create an EncodingLayout that specifies PrefixEncoding for the top level.
+    // Nested encodings (lengths, data) will be handled by the factory.
+    EncodingLayout layout{EncodingType::Prefix, CompressionType::Uncompressed};
+    return std::make_unique<ReplayedEncodingSelectionPolicy<std::string_view>>(
+        std::move(layout),
+        CompressionOptions{},
+        encodingSelectionPolicyFactory_);
+  }
+
+  // Helper function to create a string buffer factory for decoding
+  std::function<void*(uint32_t)> createStringBufferFactory() {
+    return [this](uint32_t totalLength) {
+      auto& buffer = stringBuffers_.emplace_back(
+          velox::AlignedBuffer::allocate<char>(totalLength, pool_.get()));
+      return buffer->asMutable<void>();
+    };
+  }
+
+  std::shared_ptr<velox::memory::MemoryPool> pool_;
+  std::vector<velox::BufferPtr> stringBuffers_;
+  ManualEncodingSelectionPolicyFactory manualPolicyFactory_;
+  EncodingSelectionPolicyFactory encodingSelectionPolicyFactory_ =
+      [this](DataType dataType) {
+        return manualPolicyFactory_.createPolicy(dataType);
+      };
+};
+
+TEST_F(PrefixEncodingTest, materialize) {
+  struct TestCase {
+    std::string_view name;
+    std::vector<std::string_view> values;
+  };
+
+  const std::vector<TestCase> testCases = {
+      {"basic sorted strings",
+       {"apple", "application", "apply", "banana", "bandana", "band"}},
+      {"empty strings", {"", "", "a", "ab", "abc"}},
+      {"all empty strings", {"", "", "", ""}},
+      {"long common prefix",
+       {"aaaaaaaaaaaaaaaaaaaa1",
+        "aaaaaaaaaaaaaaaaaaaa2",
+        "aaaaaaaaaaaaaaaaaaaa3",
+        "aaaaaaaaaaaaaaaaaaaa4"}},
+      {"single value", {"single"}},
+      {"all same values", {"same", "same", "same"}},
+      {"no common prefix", {"abc", "def", "ghi", "jkl"}},
+  };
+
+  for (const auto& testCase : testCases) {
+    SCOPED_TRACE(testCase.name);
+
+    Buffer buffer{*pool_};
+
+    auto encoded = EncodingFactory::encode<std::string_view>(
+        createSelectionPolicy(), testCase.values, buffer);
+    stringBuffers_.clear();
+    auto encoding =
+        EncodingFactory::decode(*pool_, encoded, createStringBufferFactory());
+
+    EXPECT_EQ(encoding->rowCount(), testCase.values.size());
+    EXPECT_EQ(encoding->encodingType(), EncodingType::Prefix);
+
+    std::vector<std::string_view> decoded(testCase.values.size());
+    encoding->materialize(testCase.values.size(), decoded.data());
+
+    for (size_t i = 0; i < testCase.values.size(); ++i) {
+      EXPECT_EQ(decoded[i], testCase.values[i]) << "Mismatch at index " << i;
+    }
+  }
+}
+
+// Test with varying number of restarts (restart interval = 16)
+// numRestarts = ceil(numValues / restartInterval)
+TEST_F(PrefixEncodingTest, varyingNumRestarts) {
+  struct TestCase {
+    std::string_view name;
+    uint32_t numValues;
+    uint32_t expectedRestarts;
+  };
+
+  const std::vector<TestCase> testCases = {
+      {"1 value, 1 restart", 1, 1},
+      {"16 values, 1 restart", 16, 1},
+      {"17 values, 2 restarts", 17, 2},
+      {"32 values, 2 restarts", 32, 2},
+      {"33 values, 3 restarts", 33, 3},
+      {"48 values, 3 restarts", 48, 3},
+      {"50 values, 4 restarts", 50, 4},
+      {"100 values, 7 restarts", 100, 7},
+  };
+
+  for (const auto& testCase : testCases) {
+    SCOPED_TRACE(testCase.name);
+
+    // Generate sorted string values with common prefix
+    std::vector<std::string> stringStorage;
+    std::vector<std::string_view> values;
+    stringStorage.reserve(testCase.numValues);
+    values.reserve(testCase.numValues);
+
+    for (uint32_t i = 0; i < testCase.numValues; ++i) {
+      stringStorage.push_back("prefix_" + folly::to<std::string>(i));
+    }
+    std::sort(stringStorage.begin(), stringStorage.end());
+    for (const auto& s : stringStorage) {
+      values.push_back(s);
+    }
+
+    Buffer buffer{*pool_};
+
+    auto encoded = EncodingFactory::encode<std::string_view>(
+        createSelectionPolicy(), values, buffer);
+    stringBuffers_.clear();
+    auto encoding =
+        EncodingFactory::decode(*pool_, encoded, createStringBufferFactory());
+
+    EXPECT_EQ(encoding->rowCount(), values.size());
+    EXPECT_EQ(encoding->encodingType(), EncodingType::Prefix);
+
+    // Verify debug string contains expected restart count
+    const std::string debug = encoding->debugString();
+    EXPECT_TRUE(
+        debug.find(
+            "num_restarts=" +
+            folly::to<std::string>(testCase.expectedRestarts)) !=
+        std::string::npos)
+        << "Debug: " << debug;
+
+    // Verify all values decode correctly
+    std::vector<std::string_view> decoded(values.size());
+    encoding->materialize(values.size(), decoded.data());
+
+    for (size_t i = 0; i < values.size(); ++i) {
+      EXPECT_EQ(decoded[i], values[i]) << "Mismatch at index " << i;
+    }
+
+    // Verify values again after reset
+    encoding->reset();
+    decoded.clear();
+    decoded.resize(values.size());
+    encoding->materialize(values.size(), decoded.data());
+    for (size_t i = 0; i < values.size(); ++i) {
+      EXPECT_EQ(decoded[i], values[i]) << "Mismatch after reset at index " << i;
+    }
+  }
+}
+
+// Test with a sequence of skip/materialize steps.
+// Each step specifies skipCount and materializeCount.
+// Zero skipCount means no skip, zero materializeCount means no materialize.
+TEST_F(PrefixEncodingTest, skipAndMaterializeSteps) {
+  struct Step {
+    uint32_t skipCount;
+    uint32_t materializeCount;
+  };
+
+  struct TestCase {
+    std::string_view name;
+    uint32_t numValues;
+    std::vector<Step> steps;
+  };
+
+  const std::vector<TestCase> testCases = {
+      // Single restart (<=16 values)
+      {"single restart, exhaust all",
+       10,
+       {{0, 3},
+        {2, 2},
+        {0, 3}}}, // materialize 3, skip 2, materialize 2, materialize 3 = 10
+      {"single restart, stop in middle",
+       10,
+       {{0, 3},
+        {2, 2}}}, // materialize 3, skip 2, materialize 2 = 7, stop early
+      {"single restart, skip only",
+       10,
+       {{5, 0}, {0, 5}}}, // skip 5, materialize 5 = 10
+      {"single restart, alternating",
+       16,
+       {{1, 2}, {1, 2}, {1, 2}, {1, 2}, {0, 4}}}, // (skip 1, mat 2) x 4 + mat 4
+                                                  // = 16
+
+      // Multiple restarts (>16 values, restart interval = 16)
+      {"two restarts, exhaust all",
+       32,
+       {{0, 10}, {5, 10}, {0, 7}}}, // mat 10, skip 5, mat 10, mat 7 = 32
+      {"two restarts, cross restart boundary",
+       32,
+       {{0, 14}, {0, 4}, {0, 14}}}, // mat 14, mat 4 (crosses 16), mat 14 = 32
+      {"three restarts, skip across restarts",
+       50,
+       {{20, 5},
+        {10, 10},
+        {0,
+         5}}}, // skip 20 (crosses restart), mat 5, skip 10, mat 10, mat 5 = 50
+      {"three restarts, stop in middle",
+       50,
+       {{0, 10},
+        {25,
+         5}}}, // mat 10, skip 25 (crosses two restarts), mat 5 = 40, stop early
+      {"four restarts, many small ops",
+       64,
+       {{2, 4}, {3, 5}, {4, 6}, {5, 7}, {6, 8}, {7, 7}}}, // various small ops
+  };
+
+  for (const auto& testCase : testCases) {
+    SCOPED_TRACE(testCase.name);
+
+    // Generate sorted string values
+    std::vector<std::string> stringStorage;
+    std::vector<std::string_view> values;
+    stringStorage.reserve(testCase.numValues);
+    values.reserve(testCase.numValues);
+
+    for (uint32_t i = 0; i < testCase.numValues; ++i) {
+      stringStorage.push_back("value_" + folly::to<std::string>(i));
+    }
+    std::sort(stringStorage.begin(), stringStorage.end());
+    for (const auto& s : stringStorage) {
+      values.push_back(s);
+    }
+
+    Buffer buffer{*pool_};
+
+    auto encoded = EncodingFactory::encode<std::string_view>(
+        createSelectionPolicy(), values, buffer);
+    stringBuffers_.clear();
+    auto encoding =
+        EncodingFactory::decode(*pool_, encoded, createStringBufferFactory());
+
+    // Run through steps twice
+
+    // Run through steps twice (second time after reset) to verify repeatability
+    for (int round = 0; round < 2; ++round) {
+      SCOPED_TRACE(fmt::format("round {}", round));
+
+      if (round > 0) {
+        encoding->reset();
+      }
+
+      uint32_t currentRow = 0;
+      for (size_t stepIdx = 0; stepIdx < testCase.steps.size(); ++stepIdx) {
+        const auto& step = testCase.steps[stepIdx];
+        SCOPED_TRACE(fmt::format("step {}", stepIdx));
+
+        // Skip if skipCount > 0
+        if (step.skipCount > 0) {
+          encoding->skip(step.skipCount);
+          currentRow += step.skipCount;
+        }
+
+        // Materialize if materializeCount > 0
+        if (step.materializeCount > 0) {
+          std::vector<std::string_view> decoded(step.materializeCount);
+          encoding->materialize(step.materializeCount, decoded.data());
+
+          for (uint32_t i = 0; i < step.materializeCount; ++i) {
+            EXPECT_EQ(decoded[i], values[currentRow + i])
+                << "Mismatch at row " << (currentRow + i);
+          }
+          currentRow += step.materializeCount;
+        }
+      }
+    }
+  }
+}
+
+// Fuzzer-style test with random inputs and random skip/materialize steps.
+// Each iteration generates random values and random steps, then runs two passes
+// with reset to verify repeatability.
+TEST_F(PrefixEncodingTest, fuzzerMaterialize) {
+  constexpr uint32_t kNumIterations = 100;
+  constexpr uint32_t kMaxNumValues = 200;
+  constexpr uint32_t kMinNumValues = 1;
+  constexpr uint32_t kMaxNumSteps = 20;
+
+  std::mt19937 rng(42); // Fixed seed for reproducibility
+
+  for (uint32_t iter = 0; iter < kNumIterations; ++iter) {
+    SCOPED_TRACE(fmt::format("iteration {}", iter));
+
+    // Random number of values (covers single and multiple restarts)
+    std::uniform_int_distribution<uint32_t> numValuesDist(
+        kMinNumValues, kMaxNumValues);
+    const uint32_t numValues = numValuesDist(rng);
+
+    // Generate sorted string values
+    std::vector<std::string> stringStorage;
+    std::vector<std::string_view> values;
+    stringStorage.reserve(numValues);
+    values.reserve(numValues);
+
+    for (uint32_t i = 0; i < numValues; ++i) {
+      stringStorage.push_back("key_" + folly::to<std::string>(i));
+    }
+    std::sort(stringStorage.begin(), stringStorage.end());
+    for (const auto& s : stringStorage) {
+      values.push_back(s);
+    }
+
+    Buffer buffer{*pool_};
+    auto encoded = EncodingFactory::encode<std::string_view>(
+        createSelectionPolicy(), values, buffer);
+    stringBuffers_.clear();
+    auto encoding =
+        EncodingFactory::decode(*pool_, encoded, createStringBufferFactory());
+
+    // Generate random steps
+    std::uniform_int_distribution<uint32_t> numStepsDist(1, kMaxNumSteps);
+    const uint32_t numSteps = numStepsDist(rng);
+
+    struct Step {
+      uint32_t skipCount;
+      uint32_t materializeCount;
+    };
+    std::vector<Step> steps;
+    steps.reserve(numSteps);
+
+    uint32_t remainingRows = numValues;
+    for (uint32_t s = 0; s < numSteps && remainingRows > 0; ++s) {
+      Step step{};
+
+      // Random skip (0 to remaining rows)
+      std::uniform_int_distribution<uint32_t> skipDist(0, remainingRows);
+      step.skipCount = skipDist(rng);
+      remainingRows -= step.skipCount;
+
+      if (remainingRows > 0) {
+        // Random materialize (0 to remaining rows)
+        std::uniform_int_distribution<uint32_t> matDist(0, remainingRows);
+        step.materializeCount = matDist(rng);
+        remainingRows -= step.materializeCount;
+      }
+
+      steps.push_back(step);
+    }
+
+    // Run through steps twice (second time after reset) to verify repeatability
+    for (int round = 0; round < 2; ++round) {
+      SCOPED_TRACE(fmt::format("round {}", round));
+
+      if (round > 0) {
+        encoding->reset();
+      }
+
+      uint32_t currentRow = 0;
+      for (size_t stepIdx = 0; stepIdx < steps.size(); ++stepIdx) {
+        const auto& step = steps[stepIdx];
+
+        // Skip if skipCount > 0
+        if (step.skipCount > 0) {
+          encoding->skip(step.skipCount);
+          currentRow += step.skipCount;
+        }
+
+        // Materialize if materializeCount > 0
+        if (step.materializeCount > 0) {
+          std::vector<std::string_view> decoded(step.materializeCount);
+          encoding->materialize(step.materializeCount, decoded.data());
+
+          for (uint32_t i = 0; i < step.materializeCount; ++i) {
+            EXPECT_EQ(decoded[i], values[currentRow + i])
+                << "Mismatch at row " << (currentRow + i);
+          }
+          currentRow += step.materializeCount;
+        }
+      }
+    }
+  }
+}
+
+// Test seekAtOrAfter with exact match and no-match scenarios.
+// For each test case, we test seeking at specified positions.
+TEST_F(PrefixEncodingTest, seekExactMatch) {
+  struct TestCase {
+    std::string_view name;
+    uint32_t numValues;
+    std::vector<uint32_t> seekPositions;
+  };
+
+  const std::vector<TestCase> testCases = {
+      // Single restart (<=16 values)
+      {"single restart (10 values)", 10, {0, 3, 5, 7, 9}},
+      {"single restart (16 values)", 16, {0, 4, 8, 12, 15}},
+      // Two restarts - test boundary and middle positions
+      {"two restarts (17 values)", 17, {0, 8, 15, 16}},
+      {"two restarts (32 values)", 32, {0, 5, 10, 15, 16, 20, 25, 31}},
+      // Three restarts - test boundaries and middle of each block
+      {"three restarts (48 values)", 48, {0, 7, 15, 16, 24, 31, 32, 40, 47}},
+      // Four restarts
+      {"four restarts (64 values)",
+       64,
+       {0, 5, 10, 15, 16, 20, 25, 31, 32, 40, 47, 48, 55, 63}},
+      // Many restarts
+      {"many restarts (100 values)",
+       100,
+       {0, 7, 15, 16, 24, 31, 32, 40, 47, 48, 55, 63, 64, 72, 80, 90, 99}},
+  };
+  for (const auto& testCase : testCases) {
+    SCOPED_TRACE(testCase.name);
+
+    // Generate sorted string values
+    std::vector<std::string> stringStorage;
+    std::vector<std::string_view> values;
+    stringStorage.reserve(testCase.numValues);
+    values.reserve(testCase.numValues);
+
+    for (uint32_t i = 0; i < testCase.numValues; ++i) {
+      stringStorage.push_back("key_" + folly::to<std::string>(i));
+    }
+    std::sort(stringStorage.begin(), stringStorage.end());
+    for (const auto& s : stringStorage) {
+      values.push_back(s);
+    }
+
+    Buffer buffer{*pool_};
+    auto encoded = EncodingFactory::encode<std::string_view>(
+        createSelectionPolicy(), values, buffer);
+    stringBuffers_.clear();
+    auto encoding =
+        EncodingFactory::decode(*pool_, encoded, createStringBufferFactory());
+
+    // Test exact match
+    for (uint32_t pos : testCase.seekPositions) {
+      SCOPED_TRACE(fmt::format("seek position {}", pos));
+      auto result = encoding->seekAtOrAfter(&values[pos]);
+      ASSERT_TRUE(result.has_value());
+      EXPECT_EQ(result.value(), pos);
+    }
+
+    // Test no match (value larger than max)
+    {
+      SCOPED_TRACE("value larger than max");
+      std::string_view largerValue = "zzz_larger_than_all";
+      auto result = encoding->seekAtOrAfter(&largerValue);
+      EXPECT_FALSE(result.has_value());
+    }
+  }
+}
+
+// Test seekAtOrAfter with non-exact match scenarios.
+// Values are generated with gaps (e.g., key_0, key_2, key_4, ...) so we can
+// seek for values that don't exist (e.g., key_1, key_3) and verify we get
+// the next value.
+TEST_F(PrefixEncodingTest, seekNonExactMatch) {
+  struct TestCase {
+    std::string_view name;
+    uint32_t numValues;
+    // Positions to generate seek targets for (we seek for value before this
+    // pos)
+    std::vector<uint32_t> seekBeforePositions;
+  };
+
+  const std::vector<TestCase> testCases = {
+      // Single restart (<=16 values)
+      {"single restart (10 values)", 10, {1, 3, 5, 7, 9}},
+      {"single restart (16 values)", 16, {1, 4, 8, 12, 15}},
+      // Two restarts - test boundary and middle positions
+      {"two restarts (17 values)", 17, {1, 8, 15, 16}},
+      {"two restarts (32 values)", 32, {1, 5, 10, 15, 16, 20, 25, 31}},
+      // Three restarts - test boundaries and middle of each block
+      {"three restarts (48 values)", 48, {1, 7, 15, 16, 24, 31, 32, 40, 47}},
+      // Four restarts
+      {"four restarts (64 values)",
+       64,
+       {1, 5, 10, 15, 16, 20, 25, 31, 32, 40, 47, 48, 55, 63}},
+      // Many restarts
+      {"many restarts (100 values)",
+       100,
+       {1, 7, 15, 16, 24, 31, 32, 40, 47, 48, 55, 63, 64, 72, 80, 90, 99}},
+  };
+
+  for (const auto& testCase : testCases) {
+    SCOPED_TRACE(testCase.name);
+
+    // Generate sorted string values with gaps (even indices only: 0, 2, 4, ...)
+    // This creates gaps where odd-indexed keys don't exist
+    // Use zero-padded numbers to ensure lexicographic order matches numeric
+    // order
+    std::vector<std::string> stringStorage;
+    std::vector<std::string_view> values;
+    stringStorage.reserve(testCase.numValues);
+    values.reserve(testCase.numValues);
+
+    for (uint32_t i = 0; i < testCase.numValues; ++i) {
+      // Use i*2 to create gaps (key_000, key_002, key_004, ...)
+      // Zero-pad to 3 digits to ensure lexicographic order matches numeric
+      // order
+      stringStorage.push_back(fmt::format("key_{:03d}", i * 2));
+    }
+    std::sort(stringStorage.begin(), stringStorage.end());
+    for (const auto& s : stringStorage) {
+      values.push_back(s);
+    }
+
+    Buffer buffer{*pool_};
+    auto encoded = EncodingFactory::encode<std::string_view>(
+        createSelectionPolicy(), values, buffer);
+    stringBuffers_.clear();
+    auto encoding =
+        EncodingFactory::decode(*pool_, encoded, createStringBufferFactory());
+
+    // Test non-exact match
+
+    // Test non-exact match: seek for value that doesn't exist (odd keys)
+    // e.g., seek for key_001 should return position of key_002 (index 1)
+    for (uint32_t pos : testCase.seekBeforePositions) {
+      SCOPED_TRACE(fmt::format("seek before position {}", pos));
+      // Create a key that falls between values[pos-1] and values[pos]
+      // values[pos] = key_(pos*2), so we seek for key_(pos*2-1)
+      // Zero-pad to 3 digits to match the value format
+      std::string targetKey = fmt::format("key_{:03d}", pos * 2 - 1);
+      std::string_view target = targetKey;
+      auto result = encoding->seekAtOrAfter(&target);
+      ASSERT_TRUE(result.has_value());
+      // Should return pos since key_(pos*2-1) < key_(pos*2)
+      EXPECT_EQ(result.value(), pos);
+    }
+
+    // Test seeking before all values
+    {
+      SCOPED_TRACE("value before all");
+      std::string_view beforeAll = "aaa_before_all";
+      auto result = encoding->seekAtOrAfter(&beforeAll);
+      ASSERT_TRUE(result.has_value());
+      EXPECT_EQ(result.value(), 0);
+    }
+
+    // Test no match (value larger than max)
+    {
+      SCOPED_TRACE("value larger than max");
+      std::string_view largerValue = "zzz_larger_than_all";
+      auto result = encoding->seekAtOrAfter(&largerValue);
+      EXPECT_FALSE(result.has_value());
+    }
+  }
+}
+
+TEST_F(PrefixEncodingTest, seekBeforeAll) {
+  std::vector<std::string_view> values = {"banana", "cherry", "date"};
+
+  Buffer buffer{*pool_};
+
+  auto encoded = EncodingFactory::encode<std::string_view>(
+      createSelectionPolicy(), values, buffer);
+  stringBuffers_.clear();
+  auto encoding =
+      EncodingFactory::decode(*pool_, encoded, createStringBufferFactory());
+
+  // Seek to value before all entries
+  std::string_view target = "apple";
+  auto result = encoding->seekAtOrAfter(&target);
+
+  ASSERT_TRUE(result.has_value());
+  EXPECT_EQ(result.value(), 0); // Should point to first entry
+}
+
+TEST_F(PrefixEncodingTest, seekAfterAll) {
+  std::vector<std::string_view> values = {"apple", "banana", "cherry"};
+
+  Buffer buffer{*pool_};
+
+  auto encoded = EncodingFactory::encode<std::string_view>(
+      createSelectionPolicy(), values, buffer);
+  stringBuffers_.clear();
+  auto encoding =
+      EncodingFactory::decode(*pool_, encoded, createStringBufferFactory());
+
+  // Seek to value after all entries
+  std::string_view target = "zucchini";
+  auto result = encoding->seekAtOrAfter(&target);
+
+  EXPECT_FALSE(result.has_value());
+}
+
+// Fuzzer-style test with random inputs and random seek targets.
+// Each iteration generates random values with varying number of restarts,
+// then performs random seeks and verifies against a simple linear search.
+TEST_F(PrefixEncodingTest, fuzzerSeek) {
+  constexpr uint32_t kNumIterations = 100;
+  constexpr uint32_t kSeeksPerIteration = 20;
+
+  // Test with different sizes to cover varying number of restarts
+  // restart interval = 16, so: 1-16 = 1 restart, 17-32 = 2 restarts, etc.
+  const std::vector<uint32_t> numValuesCases = {
+      5, // 1 restart (small)
+      16, // 1 restart (exact boundary)
+      17, // 2 restarts (just over boundary)
+      32, // 2 restarts (exact boundary)
+      50, // 4 restarts
+      100, // 7 restarts
+      200, // 13 restarts
+  };
+
+  std::mt19937 rng(42); // Fixed seed for reproducibility
+
+  for (uint32_t iter = 0; iter < kNumIterations; ++iter) {
+    SCOPED_TRACE(fmt::format("iteration {}", iter));
+
+    // Pick a random size from the cases
+    std::uniform_int_distribution<size_t> sizeDist(
+        0, numValuesCases.size() - 1);
+    const uint32_t numValues = numValuesCases[sizeDist(rng)];
+
+    // Generate sorted string values with gaps to allow non-exact matches
+    // Use i*2 to create gaps (key_000, key_002, key_004, ...)
+    // Use zero-padded numbers to ensure lexicographic order matches numeric
+    // order
+    std::vector<std::string> stringStorage;
+    std::vector<std::string_view> values;
+    stringStorage.reserve(numValues);
+    values.reserve(numValues);
+
+    for (uint32_t i = 0; i < numValues; ++i) {
+      stringStorage.push_back(fmt::format("key_{:03d}", i * 2));
+    }
+    std::sort(stringStorage.begin(), stringStorage.end());
+    for (const auto& s : stringStorage) {
+      values.push_back(s);
+    }
+
+    Buffer buffer{*pool_};
+    auto encoded = EncodingFactory::encode<std::string_view>(
+        createSelectionPolicy(), values, buffer);
+    stringBuffers_.clear();
+    auto encoding =
+        EncodingFactory::decode(*pool_, encoded, createStringBufferFactory());
+
+    // Helper: simple linear search
+    auto linearSearch =
+        [&values](std::string_view target) -> std::optional<uint32_t> {
+      for (size_t i = 0; i < values.size(); ++i) {
+        if (values[i] >= target) {
+          return static_cast<uint32_t>(i);
+        }
+      }
+      return std::nullopt;
+    };
+
+    // Perform random seeks
+    for (uint32_t s = 0; s < kSeeksPerIteration; ++s) {
+      // Generate random seek target
+      // Range: 0 to numValues*2+1 to cover before, within, and after all values
+      std::uniform_int_distribution<uint32_t> targetDist(0, numValues * 2 + 1);
+      uint32_t targetIdx = targetDist(rng);
+      // Zero-pad to 3 digits to match the value format
+      std::string targetKey = fmt::format("key_{:03d}", targetIdx);
+      std::string_view target = targetKey;
+
+      auto expected = linearSearch(target);
+      auto actual = encoding->seekAtOrAfter(&target);
+
+      if (expected.has_value()) {
+        ASSERT_TRUE(actual.has_value())
+            << "Expected position " << expected.value() << " for target "
+            << targetKey;
+        EXPECT_EQ(actual.value(), expected.value())
+            << "Mismatch for target " << targetKey;
+      } else {
+        EXPECT_FALSE(actual.has_value())
+            << "Expected nullopt for target " << targetKey << " but got "
+            << actual.value();
+      }
+    }
+
+    // Also test edge cases for this iteration
+    // 1. Value before all
+    {
+      std::string_view beforeAll = "aaa_before";
+      auto expected = linearSearch(beforeAll);
+      auto actual = encoding->seekAtOrAfter(&beforeAll);
+      ASSERT_TRUE(expected.has_value());
+      ASSERT_TRUE(actual.has_value());
+      EXPECT_EQ(actual.value(), expected.value());
+    }
+
+    // 2. Value after all
+    {
+      std::string_view afterAll = "zzz_after";
+      auto expected = linearSearch(afterAll);
+      auto actual = encoding->seekAtOrAfter(&afterAll);
+      EXPECT_FALSE(expected.has_value());
+      EXPECT_FALSE(actual.has_value());
+    }
+  }
+}
+
+TEST_F(PrefixEncodingTest, debugString) {
+  std::vector<std::string_view> values = {"apple", "banana", "cherry"};
+
+  Buffer buffer{*pool_};
+
+  auto encoded = EncodingFactory::encode<std::string_view>(
+      createSelectionPolicy(), values, buffer);
+  stringBuffers_.clear();
+  auto encoding =
+      EncodingFactory::decode(*pool_, encoded, createStringBufferFactory());
+
+  std::string debug = encoding->debugString();
+  EXPECT_TRUE(debug.find("Prefix") != std::string::npos);
+  EXPECT_TRUE(debug.find("restart_interval=") != std::string::npos);
+  EXPECT_TRUE(debug.find("num_restarts=") != std::string::npos);
+}
+
+// Test encode with various input patterns and verify with materialize.
+// This test generates different input patterns and verifies that encode/decode
+// round-trip produces correct results. Also tests restart interval boundary
+// conditions.
+TEST_F(PrefixEncodingTest, encode) {
+  struct TestCase {
+    std::string_view name;
+    std::function<std::vector<std::string>(uint32_t)> generator;
+    uint32_t numValues;
+  };
+
+  // Generator: sequential numbers with common prefix
+  auto sequentialWithPrefix = [](uint32_t n) {
+    std::vector<std::string> result;
+    result.reserve(n);
+    for (uint32_t i = 0; i < n; ++i) {
+      result.push_back(fmt::format("prefix_{:06d}", i));
+    }
+    std::sort(result.begin(), result.end());
+    return result;
+  };
+
+  // Generator: varying prefix lengths
+  auto varyingPrefixLengths = [](uint32_t n) {
+    std::vector<std::string> result;
+    result.reserve(n);
+    for (uint32_t i = 0; i < n; ++i) {
+      // Create strings with different prefix patterns
+      std::string prefix(i % 20 + 1, 'a'); // Prefix length 1-20
+      result.push_back(fmt::format("{}_{:04d}", prefix, i));
+    }
+    std::sort(result.begin(), result.end());
+    return result;
+  };
+
+  // Generator: strings with long common prefix
+  auto longCommonPrefix = [](uint32_t n) {
+    std::vector<std::string> result;
+    result.reserve(n);
+    std::string commonPrefix(100, 'x'); // 100-char common prefix
+    for (uint32_t i = 0; i < n; ++i) {
+      result.push_back(fmt::format("{}_{:06d}", commonPrefix, i));
+    }
+    std::sort(result.begin(), result.end());
+    return result;
+  };
+
+  // Generator: strings with no common prefix
+  auto noCommonPrefix = [](uint32_t n) {
+    std::vector<std::string> result;
+    result.reserve(n);
+    for (uint32_t i = 0; i < n; ++i) {
+      // Use different starting characters
+      char startChar = 'a' + (i % 26);
+      result.push_back(fmt::format("{}_{:06d}", startChar, i));
+    }
+    std::sort(result.begin(), result.end());
+    return result;
+  };
+
+  // Generator: mixed empty and non-empty strings
+  auto mixedEmpty = [](uint32_t n) {
+    std::vector<std::string> result;
+    result.reserve(n);
+    for (uint32_t i = 0; i < n; ++i) {
+      if (i % 5 == 0) {
+        result.push_back("");
+      } else {
+        result.push_back(fmt::format("str_{:04d}", i));
+      }
+    }
+    std::sort(result.begin(), result.end());
+    return result;
+  };
+
+  // Generator: varying prefix patterns
+  auto varyingPrefixPattern = [](uint32_t n) {
+    std::vector<std::string> result;
+    result.reserve(n);
+    const int patternLength = velox::bits::divRoundUp(n, 26);
+    for (uint32_t i = 0; i < n; ++i) {
+      // Create strings with different prefix patterns.
+      const std::string prefix(4, 'a' + (i / patternLength) % 26);
+      result.push_back(fmt::format("{}_{:04d}", prefix, i));
+    }
+    std::sort(result.begin(), result.end());
+    return result;
+  };
+
+  // Test cases with different sizes to cover restart interval boundaries
+  // Restart interval is 16, so we test: <16, =16, >16, multiples, etc.
+  const std::vector<TestCase> testCases = {
+      // Single restart (<=16 values)
+      {"sequential, 1 value", sequentialWithPrefix, 1},
+      {"sequential, 8 values", sequentialWithPrefix, 8},
+      {"sequential, 15 values (boundary-1)", sequentialWithPrefix, 15},
+      {"sequential, 16 values (exact boundary)", sequentialWithPrefix, 16},
+
+      // Two restarts (17-32 values)
+      {"sequential, 17 values (boundary+1)", sequentialWithPrefix, 17},
+      {"sequential, 24 values", sequentialWithPrefix, 24},
+      {"sequential, 31 values (boundary-1)", sequentialWithPrefix, 31},
+      {"sequential, 32 values (exact boundary)", sequentialWithPrefix, 32},
+
+      // Three restarts (33-48 values)
+      {"sequential, 33 values (boundary+1)", sequentialWithPrefix, 33},
+      {"sequential, 47 values (boundary-1)", sequentialWithPrefix, 47},
+      {"sequential, 48 values (exact boundary)", sequentialWithPrefix, 48},
+
+      // Four restarts (49-64 values)
+      {"sequential, 49 values (boundary+1)", sequentialWithPrefix, 49},
+      {"sequential, 63 values (boundary-1)", sequentialWithPrefix, 63},
+      {"sequential, 64 values (exact boundary)", sequentialWithPrefix, 64},
+      {"sequential, 65 values (boundary+1)", sequentialWithPrefix, 65},
+
+      // Multiple restarts - larger sizes
+      {"sequential, 100 values (7 restarts)", sequentialWithPrefix, 100},
+
+      // Different patterns with varying sizes
+      {"varying prefix, 50 values", varyingPrefixLengths, 50},
+      {"varying prefix pattern, 50 values", varyingPrefixPattern, 50},
+      {"long common prefix, 50 values", longCommonPrefix, 50},
+      {"no common prefix, 50 values", noCommonPrefix, 50},
+      {"mixed empty, 50 values", mixedEmpty, 50},
+
+      // Large datasets
+      {"sequential, 200 values (13 restarts)", sequentialWithPrefix, 200},
+      {"varying prefix, 200 values", varyingPrefixLengths, 200},
+      {"varying prefix pattern, 200 values", varyingPrefixPattern, 200},
+  };
+
+  for (const auto& testCase : testCases) {
+    SCOPED_TRACE(testCase.name);
+
+    // Generate input data
+    std::vector<std::string> stringStorage =
+        testCase.generator(testCase.numValues);
+    std::vector<std::string_view> values;
+    values.reserve(stringStorage.size());
+    for (const auto& s : stringStorage) {
+      values.push_back(s);
+    }
+
+    Buffer buffer{*pool_};
+
+    // Encode
+    auto encoded = EncodingFactory::encode<std::string_view>(
+        createSelectionPolicy(), values, buffer);
+    stringBuffers_.clear();
+    auto encoding =
+        EncodingFactory::decode(*pool_, encoded, createStringBufferFactory());
+
+    // Verify basic properties
+    EXPECT_EQ(encoding->rowCount(), values.size());
+    EXPECT_EQ(encoding->encodingType(), EncodingType::Prefix);
+
+    // Verify restart count
+    const uint32_t expectedRestarts = (testCase.numValues + 15) / 16;
+    const std::string debug = encoding->debugString();
+    EXPECT_TRUE(
+        debug.find(
+            "num_restarts=" + folly::to<std::string>(expectedRestarts)) !=
+        std::string::npos)
+        << "Debug: " << debug << ", expected restarts: " << expectedRestarts;
+
+    // Materialize all values and verify
+    std::vector<std::string_view> decoded(values.size());
+    encoding->materialize(values.size(), decoded.data());
+
+    for (size_t i = 0; i < values.size(); ++i) {
+      EXPECT_EQ(decoded[i], values[i]) << "Mismatch at index " << i;
+    }
+
+    // Reset and verify again
+    encoding->reset();
+    decoded.clear();
+    decoded.resize(values.size());
+    encoding->materialize(values.size(), decoded.data());
+
+    for (size_t i = 0; i < values.size(); ++i) {
+      EXPECT_EQ(decoded[i], values[i]) << "Mismatch after reset at index " << i;
+    }
+
+    // Test accessing values at restart boundaries
+    // Restart points are at indices: 0, 16, 32, 48, ...
+    for (uint32_t restartIdx = 0; restartIdx < expectedRestarts; ++restartIdx) {
+      const uint32_t restartPos = restartIdx * 16;
+      if (restartPos >= testCase.numValues) {
+        break;
+      }
+
+      // Reset and skip to restart position, then materialize
+      encoding->reset();
+      if (restartPos > 0) {
+        encoding->skip(restartPos);
+      }
+
+      // Materialize values starting from restart position
+      const uint32_t toMaterialize =
+          std::min(16u, testCase.numValues - restartPos);
+      std::vector<std::string_view> restartDecoded(toMaterialize);
+      encoding->materialize(toMaterialize, restartDecoded.data());
+
+      for (uint32_t i = 0; i < toMaterialize; ++i) {
+        EXPECT_EQ(restartDecoded[i], values[restartPos + i])
+            << "Mismatch at restart " << restartIdx << " offset " << i;
+      }
+    }
+
+    // Test materialize across restart boundaries with varying chunk sizes
+    encoding->reset();
+    const std::vector<uint32_t> chunkSizes = {10, 15, 20, 25};
+    uint32_t currentRow = 0;
+    for (uint32_t chunkSize : chunkSizes) {
+      if (currentRow >= testCase.numValues) {
+        break;
+      }
+      const uint32_t toRead =
+          std::min(chunkSize, testCase.numValues - currentRow);
+      std::vector<std::string_view> chunkDecoded(toRead);
+      encoding->materialize(toRead, chunkDecoded.data());
+
+      for (uint32_t i = 0; i < toRead; ++i) {
+        EXPECT_EQ(chunkDecoded[i], values[currentRow + i])
+            << "Cross-boundary mismatch at row " << (currentRow + i);
+      }
+      currentRow += toRead;
+    }
+  }
+}
+
+// Fuzzer-style encode test with random data generation.
+// Tests encode/decode round-trip with randomly generated string data.
+TEST_F(PrefixEncodingTest, fuzzerEncode) {
+  constexpr uint32_t kNumIterations = 50;
+  constexpr uint32_t kMaxNumValues = 200;
+  constexpr uint32_t kMinNumValues = 1;
+  constexpr uint32_t kMaxStringLength = 100;
+
+  std::mt19937 rng(12345); // Fixed seed for reproducibility
+
+  for (uint32_t iter = 0; iter < kNumIterations; ++iter) {
+    SCOPED_TRACE(fmt::format("iteration {}", iter));
+
+    // Random number of values
+    std::uniform_int_distribution<uint32_t> numValuesDist(
+        kMinNumValues, kMaxNumValues);
+    const uint32_t numValues = numValuesDist(rng);
+
+    // Generate random strings
+    std::vector<std::string> stringStorage;
+    stringStorage.reserve(numValues);
+
+    std::uniform_int_distribution<uint32_t> lengthDist(0, kMaxStringLength);
+    std::uniform_int_distribution<char> charDist('a', 'z');
+
+    for (uint32_t i = 0; i < numValues; ++i) {
+      const uint32_t len = lengthDist(rng);
+      std::string s;
+      s.reserve(len);
+      for (uint32_t j = 0; j < len; ++j) {
+        s.push_back(charDist(rng));
+      }
+      stringStorage.push_back(std::move(s));
+    }
+
+    // Sort to ensure valid input for prefix encoding
+    std::sort(stringStorage.begin(), stringStorage.end());
+
+    std::vector<std::string_view> values;
+    values.reserve(stringStorage.size());
+    for (const auto& s : stringStorage) {
+      values.push_back(s);
+    }
+
+    Buffer buffer{*pool_};
+
+    // Encode
+    auto encoded = EncodingFactory::encode<std::string_view>(
+        createSelectionPolicy(), values, buffer);
+    stringBuffers_.clear();
+    auto encoding =
+        EncodingFactory::decode(*pool_, encoded, createStringBufferFactory());
+
+    // Verify properties
+    EXPECT_EQ(encoding->rowCount(), values.size());
+    EXPECT_EQ(encoding->encodingType(), EncodingType::Prefix);
+
+    // Verify restart count
+    const uint32_t expectedRestarts = (numValues + 15) / 16;
+    const std::string debug = encoding->debugString();
+    EXPECT_TRUE(
+        debug.find(
+            "num_restarts=" + folly::to<std::string>(expectedRestarts)) !=
+        std::string::npos)
+        << "Debug: " << debug;
+
+    // Materialize and verify all values
+    std::vector<std::string_view> decoded(values.size());
+    encoding->materialize(values.size(), decoded.data());
+
+    for (size_t i = 0; i < values.size(); ++i) {
+      EXPECT_EQ(decoded[i], values[i]) << "Mismatch at index " << i;
+    }
+
+    // Test partial materialize across restart boundaries
+    encoding->reset();
+    uint32_t currentRow = 0;
+    while (currentRow < values.size()) {
+      // Random batch size (1 to remaining rows, max 30)
+      const uint32_t remaining = values.size() - currentRow;
+      std::uniform_int_distribution<uint32_t> batchDist(
+          1, std::min(remaining, 30u));
+      const uint32_t batchSize = batchDist(rng);
+
+      std::vector<std::string_view> batch(batchSize);
+      encoding->materialize(batchSize, batch.data());
+
+      for (uint32_t i = 0; i < batchSize; ++i) {
+        EXPECT_EQ(batch[i], values[currentRow + i])
+            << "Batch mismatch at row " << (currentRow + i);
+      }
+      currentRow += batchSize;
+    }
+  }
+}
+
+} // namespace facebook::nimble::test

--- a/dwio/nimble/tools/EncodingUtilities.cpp
+++ b/dwio/nimble/tools/EncodingUtilities.cpp
@@ -48,6 +48,7 @@ void extractCompressionType(
     case EncodingType::Delta:
     case EncodingType::Constant:
     case EncodingType::MainlyConstant:
+    case EncodingType::Prefix:
       break;
   }
 }
@@ -99,7 +100,8 @@ void traverseEncodings(
   switch (encodingType) {
     case EncodingType::FixedBitWidth:
     case EncodingType::Varint:
-    case EncodingType::Constant: {
+    case EncodingType::Constant:
+    case EncodingType::Prefix: {
       // don't have any nested encoding
       break;
     }

--- a/dwio/nimble/velox/ChunkedStream.cpp
+++ b/dwio/nimble/velox/ChunkedStream.cpp
@@ -53,8 +53,8 @@ std::string_view InMemoryChunkedStream::nextChunk() {
       break;
     }
     case CompressionType::Zstd: {
-      uncompressed_ = ZstdCompression::uncompress(
-          *uncompressed_.memoryPool(), {pos_, length});
+      uncompressed_ =
+          ZstdCompression::uncompress(*uncompressed_.pool(), {pos_, length});
       chunk = {uncompressed_.data(), uncompressed_.size()};
       break;
     }


### PR DESCRIPTION
Summary:
This diff adds a new PrefixEncoding for Nimble that efficiently stores sorted string data with prefix compression.  Sorted string data (e.g., dictionary keys, index keys) often has significant common prefixes between consecutive entries. PrefixEncoding exploits this by storing only the shared prefix length and unique suffix for each entry, significantly reducing storage space.

Implementation
The encoding stores:
Shared prefix length (uint32) - bytes shared with previous entry
Suffix length (uint32) - length of unique suffix
Suffix data - the actual suffix bytes
Restart points are full entries (shared_prefix_len = 0) stored at regular intervals (default: 16) to enable efficient seek operations without decoding from the beginning.

Binary Layout
Standard Encoding prefix (8 bytes)
Restart interval (4 bytes)
Number of restarts (4 bytes)
Encoded entries
Restart offsets array (uint32 per restart point)

Key Features
Prefix compression: Reduces storage for sorted strings with common prefixes
Efficient seek: Binary search on restart points + linear scan within block achieves O(log(n/interval) + interval) seek complexity
Skip optimization: Leverages restart points to skip across blocks efficiently
Buffer management: materializedValues_ buffer keeps string_views valid between materialize() call
Followup is to extend encoding API to take encoding options which allows to configure the restart interval

Differential Revision: D90654439


