### PR TITLE
Change default index encoding to Prefix and add parameterized tests

### DIFF
--- a/dwio/nimble/index/IndexConfig.cpp
+++ b/dwio/nimble/index/IndexConfig.cpp
@@ -18,12 +18,8 @@
 
 namespace facebook::nimble {
 
-EncodingLayout IndexConfig::defaultEncodingLayout(
-    CompressionType compressionType) {
-  return EncodingLayout{
-      EncodingType::Trivial,
-      compressionType,
-      {EncodingLayout{EncodingType::Trivial, CompressionType::Uncompressed}}};
+EncodingLayout IndexConfig::defaultEncodingLayout() {
+  return EncodingLayout{EncodingType::Prefix, CompressionType::Uncompressed};
 }
 
 } // namespace facebook::nimble

--- a/dwio/nimble/index/IndexConfig.h
+++ b/dwio/nimble/index/IndexConfig.h
@@ -37,6 +37,7 @@ struct IndexConfig {
   /// efficient range-based filtering. An exception is thrown if keys are found
   /// to be out of order.
   bool enforceKeyOrder{false};
+  uint32_t prefixRestartInterval{16};
   /// When flushing key stream into chunks, key stream with raw data size
   /// smaller than this threshold will not be flushed.
   /// Note: this threshold is ignored when it is time to flush a stripe.
@@ -47,10 +48,7 @@ struct IndexConfig {
   uint64_t maxChunkRawSize{20 << 20};
 
   /// Returns the default encoding layout for index key stream.
-  /// TrivialEncoding for string_view needs a nested encoding for string
-  /// lengths.
-  static EncodingLayout defaultEncodingLayout(
-      CompressionType compressionType = CompressionType::Zstd);
+  static EncodingLayout defaultEncodingLayout();
 };
 
 } // namespace facebook::nimble

--- a/dwio/nimble/index/IndexReader.cpp
+++ b/dwio/nimble/index/IndexReader.cpp
@@ -140,8 +140,11 @@ void IndexReader::loadChunk() {
         return buffer->asMutable<void>();
       });
   NIMBLE_CHECK_EQ(encoding_->dataType(), DataType::String);
-  // TODO: support prefix encoding for encoded keys.
-  NIMBLE_CHECK_EQ(encoding_->encodingType(), EncodingType::Trivial);
+  NIMBLE_CHECK(
+      encoding_->encodingType() == EncodingType::Trivial ||
+          encoding_->encodingType() == EncodingType::Prefix,
+      "Unsupported encoding type: {}",
+      encoding_->encodingType());
 }
 
 void IndexReader::prepareInputBuffer(int32_t size) {

--- a/dwio/nimble/velox/IndexWriter.cpp
+++ b/dwio/nimble/velox/IndexWriter.cpp
@@ -77,11 +77,12 @@ IndexWriter::IndexWriter(
       enforceKeyOrder_{config.enforceKeyOrder},
       minChunkSize_{config.minChunkRawSize},
       maxChunkSize_{config.maxChunkRawSize} {
-  // Key stream encoding only supports trivial encoding without nested children.
-  NIMBLE_CHECK_EQ(
-      encodingLayout_.encodingType(),
-      EncodingType::Trivial,
-      "Key stream encoding only supports Trivial encoding");
+  // Key stream encoding only supports Prefix or Trivial encoding.
+  NIMBLE_CHECK(
+      encodingLayout_.encodingType() == EncodingType::Prefix ||
+          encodingLayout_.encodingType() == EncodingType::Trivial,
+      "Key stream encoding only supports Prefix or Trivial encoding, but got: {}",
+      encodingLayout_.encodingType());
 }
 
 std::unique_ptr<EncodingSelectionPolicy<std::string_view>>


### PR DESCRIPTION
Summary:
This change updates the default encoding for index key streams from Trivial to Prefix encoding in IndexConfig. It also updates the validation in IndexWriter to allow both Prefix and Trivial encodings for key streams.

Additionally, this change converts both VeloxWriterIndexTest and IndexWriterDataTest to parameterized tests that test both Prefix and Trivial encoding types to ensure both encoding paths are properly exercised.

Differential Revision: D90835308


