### PR TITLE
feat: Support sort orders from index writer to reader

### DIFF
--- a/dwio/nimble/encodings/PrefixEncoding.cpp
+++ b/dwio/nimble/encodings/PrefixEncoding.cpp
@@ -198,7 +198,7 @@ std::optional<uint32_t> PrefixEncoding::seekAtOrAfter(const void* value) {
 
   // Linear scan within the block
   while (currentRow_ < rowCount_) {
-    std::string_view currentValue = decodeEntry();
+    const std::string_view currentValue = decodeEntry();
     // Return when we find either:
     // 1. Exact match (since keys are unique, no need to scan further), or
     // 2. First value greater than target.

--- a/dwio/nimble/index/IndexConfig.h
+++ b/dwio/nimble/index/IndexConfig.h
@@ -19,6 +19,7 @@
 #include <vector>
 
 #include "dwio/nimble/encodings/EncodingLayout.h"
+#include "velox/core/PlanNode.h"
 
 namespace facebook::nimble {
 
@@ -30,6 +31,10 @@ struct IndexConfig {
   /// These columns will be encoded using KeyWriter to generate index keys
   /// that enable efficient data skipping during reads.
   std::vector<std::string> columns;
+  /// Specifies the sort order for each index column.
+  /// If empty, defaults to ascending order with nulls first for all columns.
+  /// If not empty, must have the same size as 'columns'.
+  std::vector<velox::core::SortOrder> sortOrders;
   /// Specifies the key encoding layout.
   EncodingLayout encodingLayout = defaultEncodingLayout();
   /// If true, enforces that encoded keys must be in strictly ascending order

--- a/dwio/nimble/index/TabletIndex.h
+++ b/dwio/nimble/index/TabletIndex.h
@@ -21,6 +21,7 @@
 #include <vector>
 
 #include "dwio/nimble/tablet/MetadataBuffer.h"
+#include "velox/core/PlanNode.h"
 
 namespace facebook::nimble::index {
 
@@ -115,6 +116,13 @@ class TabletIndex {
     return indexColumns_;
   }
 
+  /// Returns the sort orders for each index column.
+  ///
+  /// @return Vector of sort orders, one per index column
+  const std::vector<velox::core::SortOrder>& sortOrders() const {
+    return sortOrders_;
+  }
+
   /// Returns metadata for a specific index group.
   ///
   /// @param groupIndex The zero-based stripe group index.
@@ -139,6 +147,7 @@ class TabletIndex {
   const uint32_t numIndexGroups_;
   const std::vector<std::string_view> stripeKeys_;
   const std::vector<std::string> indexColumns_;
+  const std::vector<velox::core::SortOrder> sortOrders_;
 };
 
 } // namespace facebook::nimble::index

--- a/dwio/nimble/index/tests/TabletIndexTestBase.h
+++ b/dwio/nimble/index/tests/TabletIndexTestBase.h
@@ -62,10 +62,21 @@ class TabletIndexTestBase : public ::testing::Test {
 
   /// Helper function to create a serialized Index flatbuffer for testing.
   /// @param indexColumns Vector of index column names
+  /// @param sortOrders Vector of sort order strings (e.g., "ASC NULLS FIRST")
+  /// @param minKey Minimum key for the first stripe
   /// @param stripes Vector of stripe data
   /// @param stripeGroups Vector indicating how many stripes are in each group
   /// @return IndexBuffers containing serialized StripeIndexGroups and root
   /// Index
+  IndexBuffers createTestTabletIndex(
+      const std::vector<std::string>& indexColumns,
+      const std::vector<std::string>& sortOrders,
+      const std::string& minKey,
+      const std::vector<Stripe>& stripes,
+      const std::vector<int>& stripeGroups);
+
+  /// Convenience wrapper that uses default ascending sort orders for all
+  /// columns.
   IndexBuffers createTestTabletIndex(
       const std::vector<std::string>& indexColumns,
       const std::string& minKey,

--- a/dwio/nimble/tablet/Index.fbs
+++ b/dwio/nimble/tablet/Index.fbs
@@ -68,6 +68,11 @@ table Index {
   stripe_keys:[string];
   /// Names of columns used for indexing.
   index_columns:[string];
+  /// Sort orders for each index column.
+  /// Each string is serialized from velox::core::SortOrder
+  /// (e.g., "ASC NULLS FIRST", "DESC NULLS LAST").
+  /// Size must equal index_columns size.
+  sort_orders:[string];
   /// Accumulated stripe counts per group (prefix sum).
   /// For group i: stripe count = stripe_counts[i] - (i > 0 ? stripe_counts[i-1] : 0)
   /// For group i: first stripe = (i > 0 ? stripe_counts[i-1] : 0)

--- a/dwio/nimble/tablet/TabletIndexWriter.h
+++ b/dwio/nimble/tablet/TabletIndexWriter.h
@@ -22,6 +22,7 @@
 
 #include "dwio/nimble/common/Buffer.h"
 #include "dwio/nimble/tablet/MetadataBuffer.h"
+#include "velox/core/PlanNode.h"
 
 namespace facebook::nimble {
 
@@ -34,6 +35,9 @@ struct KeyStream;
 struct TabletIndexConfig {
   /// Columns to be indexed for data pruning.
   std::vector<std::string> columns;
+  /// Specifies the sort order for each index column.
+  /// Must not be empty and must have the same size as 'columns'.
+  std::vector<velox::core::SortOrder> sortOrders;
   /// If true, enforces that encoded keys must be in strictly ascending order
   /// across stripes.
   bool enforceKeyOrder{false};

--- a/dwio/nimble/tablet/tests/TabletTest.cpp
+++ b/dwio/nimble/tablet/tests/TabletTest.cpp
@@ -1473,6 +1473,7 @@ TEST_F(TabletWithIndexTest, stripeIdentifier) {
 
   nimble::TabletIndexConfig indexConfig{
       .columns = {"col1"},
+      .sortOrders = {velox::core::kAscNullsFirst},
       .enforceKeyOrder = true,
   };
 
@@ -1528,6 +1529,7 @@ TEST_F(TabletWithIndexTest, singleGroup) {
 
   nimble::TabletIndexConfig indexConfig{
       .columns = {"col1", "col2"},
+      .sortOrders = {velox::core::kAscNullsFirst, velox::core::kAscNullsFirst},
       .enforceKeyOrder = true,
   };
 
@@ -1949,6 +1951,7 @@ TEST_F(TabletWithIndexTest, multipleGroups) {
 
   nimble::TabletIndexConfig indexConfig{
       .columns = {"col1", "col2"},
+      .sortOrders = {velox::core::kAscNullsFirst, velox::core::kAscNullsFirst},
       .enforceKeyOrder = true,
   };
 
@@ -2324,6 +2327,7 @@ TEST_F(TabletWithIndexTest, singleGroupWithEmptyStream) {
 
   nimble::TabletIndexConfig indexConfig{
       .columns = {"col1"},
+      .sortOrders = {velox::core::kAscNullsFirst},
       .enforceKeyOrder = true,
   };
 
@@ -2738,6 +2742,7 @@ TEST_F(TabletWithIndexTest, multipleGroupsWithEmptyStream) {
 
   nimble::TabletIndexConfig indexConfig{
       .columns = {"col1"},
+      .sortOrders = {velox::core::kAscNullsFirst},
       .enforceKeyOrder = true,
   };
 
@@ -3210,6 +3215,7 @@ TEST_F(TabletWithIndexTest, streamDeduplication) {
 
   nimble::TabletIndexConfig indexConfig{
       .columns = {"col1"},
+      .sortOrders = {velox::core::kAscNullsFirst},
       .enforceKeyOrder = true,
   };
 
@@ -3474,6 +3480,7 @@ TEST_F(TabletWithIndexTest, keyOrderEnforcement) {
 
       nimble::TabletIndexConfig indexConfig{
           .columns = {"col1"},
+          .sortOrders = {velox::core::kAscNullsFirst},
           .enforceKeyOrder = enforceKeyOrder,
       };
 

--- a/dwio/nimble/velox/IndexWriter.h
+++ b/dwio/nimble/velox/IndexWriter.h
@@ -114,6 +114,12 @@ class IndexWriter {
   /// Returns true if there are accumulated keys to encode.
   bool hasKeys() const;
 
+  /// Returns the sort orders for each index column.
+  /// The returned vector will have the same size as the index columns.
+  const std::vector<velox::core::SortOrder>& sortOrders() const {
+    return keyEncoder_->sortOrders();
+  }
+
   /// Closes the writer and releases resources.
   void close();
 

--- a/dwio/nimble/velox/selective/SelectiveNimbleReader.cpp
+++ b/dwio/nimble/velox/selective/SelectiveNimbleReader.cpp
@@ -391,13 +391,10 @@ void SelectiveNimbleRowReader::initIndexBounds() {
 
   // Convert filters from scanSpec to index bounds.
   //
-  // TODO: Get sort orders from index metadata. Assuming ASC for now.
-  //
   // TODO: Add to restore the removed filters after this row reader finish
   // processing as we might be used in multiple split execution modes and the
   // scan spec is shared across split readers.
-  const std::vector<velox::core::SortOrder> sortOrders(
-      indexColumns.size(), velox::core::kAscNullsFirst);
+  const auto& sortOrders = tabletIndex->sortOrders();
   auto indexBounds = convertFilterToIndexBounds(
       indexColumns,
       sortOrders,


### PR DESCRIPTION
Summary:
This diff adds support for sort orders throughout the Nimble index system:

1. **TabletIndexWriter**: Adds validation that `sortOrders` must be provided and match the number of columns. Sort orders are serialized to JSON using `SortOrder::serialize()` and persisted in the FlatBuffers index schema.

2. **TabletIndex**: Adds `sortOrders()` getter to read persisted sort orders. Sort orders are deserialized from JSON using `SortOrder::deserialize()` with validation that the count matches index columns.

3. **IndexWriter**: Adds `sortOrders()` getter and updates `createKeyEncoder()` to pass sort orders to KeyEncoder. Validates that sortOrders is either empty (uses default AscNullsFirst) or matches column count.

4. **VeloxWriter**: Updates `createTabletIndexConfig()` to get sort orders from IndexWriter and pass them to TabletIndexWriter.

5. **SelectiveNimbleReader**: Reads sort orders from TabletIndex instead of hardcoding AscNullsFirst.

6. **IndexFilter.cpp**: Modified `getFilterBoundInfo()` to take a `sortOrder` parameter. For VARCHAR types (kBytesRange and kBytesValues), descending order is not supported because we can't find the next smallest string value, so the filter is marked as not convertible.

7. **E2EIndexTest**: Adds `sortOrder` field to `IndexEncodingParam` and infrastructure for testing different sort orders. Includes `prefixDesc()` and `trivialZstdDesc()` params (not yet enabled pending reader support for non-ascending orders).

8. **IndexWriterTest**: Adds comprehensive tests for different sort order combinations including validation tests and data verification tests.

Differential Revision: D90956221


