### PR TITLE
Fix uninitialized member variables in DeduplicatedColumnStatistics

### DIFF
--- a/dwio/nimble/velox/stats/ColumnStatistics.h
+++ b/dwio/nimble/velox/stats/ColumnStatistics.h
@@ -154,8 +154,8 @@ class DeduplicatedColumnStatistics : public virtual ColumnStatistics {
 
  protected:
   std::unique_ptr<ColumnStatistics> baseStatistics_;
-  uint64_t dedupedCount_;
-  uint64_t dedupedLogicalSize_;
+  uint64_t dedupedCount_{0};
+  uint64_t dedupedLogicalSize_{0};
 };
 
 // The statistics collectors are ways to abstract away different


### PR DESCRIPTION
Summary:
Fix test failures in DeduplicatedStatisticsCollectorMerge caused by uninitialized dedupedCount_ and dedupedLogicalSize_ member variables. Without default initialization, these primitive types contained garbage values, causing incorrect statistics after merge operations.

Fixes: 
https://www.internalfb.com/intern/test/281475262545508
https://www.internalfb.com/intern/test/281475262545503
https://www.internalfb.com/intern/test/281475262514991
https://www.internalfb.com/intern/test/844425215969460

Reviewed By: sathishkrishnaraju

Differential Revision: D91059042


