### PR TITLE
feat: Add hive index reader for Nimble file format

### DIFF
--- a/dwio/nimble/index/IndexFilter.cpp
+++ b/dwio/nimble/index/IndexFilter.cpp
@@ -27,21 +27,20 @@ using namespace velox::common;
 namespace {
 
 // Dispatch macro for integer types (TINYINT, SMALLINT, INTEGER, BIGINT).
-#define INTEGER_TYPE_DISPATCH(FUNC, typeKind, ...)                       \
-  [&]() {                                                                \
-    switch (typeKind) {                                                  \
-      case TypeKind::TINYINT:                                            \
-        return FUNC<TypeKind::TINYINT>(__VA_ARGS__);                     \
-      case TypeKind::SMALLINT:                                           \
-        return FUNC<TypeKind::SMALLINT>(__VA_ARGS__);                    \
-      case TypeKind::INTEGER:                                            \
-        return FUNC<TypeKind::INTEGER>(__VA_ARGS__);                     \
-      case TypeKind::BIGINT:                                             \
-        return FUNC<TypeKind::BIGINT>(__VA_ARGS__);                      \
-      default:                                                           \
-        NIMBLE_UNREACHABLE(                                              \
-            "Unsupported integer type: {}", static_cast<int>(typeKind)); \
-    }                                                                    \
+#define INTEGER_TYPE_DISPATCH(FUNC, typeKind, ...)                    \
+  [&]() {                                                             \
+    switch (typeKind) {                                               \
+      case TypeKind::TINYINT:                                         \
+        return FUNC<TypeKind::TINYINT>(__VA_ARGS__);                  \
+      case TypeKind::SMALLINT:                                        \
+        return FUNC<TypeKind::SMALLINT>(__VA_ARGS__);                 \
+      case TypeKind::INTEGER:                                         \
+        return FUNC<TypeKind::INTEGER>(__VA_ARGS__);                  \
+      case TypeKind::BIGINT:                                          \
+        return FUNC<TypeKind::BIGINT>(__VA_ARGS__);                   \
+      default:                                                        \
+        NIMBLE_UNREACHABLE("Unsupported integer type: {}", typeKind); \
+    }                                                                 \
   }()
 
 template <TypeKind Kind>
@@ -410,6 +409,10 @@ std::optional<FilterToIndexBoundsResult> convertFilterToIndexBounds(
     if (filter == nullptr) {
       break;
     }
+    NIMBLE_CHECK(
+        childSpec->hasFilter(),
+        "Filter on index column '{}' is unexpectedly disabled",
+        columnName);
 
     // Check if the filter is convertible.
     const auto boundInfo = getFilterBoundInfo(*filter, sortOrder);

--- a/dwio/nimble/index/tests/CMakeLists.txt
+++ b/dwio/nimble/index/tests/CMakeLists.txt
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-add_library(nimble_index_test_utils TabletIndexTestUtils.cpp)
+add_library(nimble_index_test_utils IndexTestUtils.cpp)
 target_link_libraries(
   nimble_index_test_utils
   nimble_index

--- a/dwio/nimble/tablet/tests/TabletIndexWriterTest.cpp
+++ b/dwio/nimble/tablet/tests/TabletIndexWriterTest.cpp
@@ -23,7 +23,7 @@
 #include "dwio/nimble/common/tests/GTestUtils.h"
 #include "dwio/nimble/index/StripeIndexGroup.h"
 #include "dwio/nimble/index/TabletIndex.h"
-#include "dwio/nimble/index/tests/TabletIndexTestUtils.h"
+#include "dwio/nimble/index/tests/IndexTestUtils.h"
 #include "dwio/nimble/tablet/Constants.h"
 #include "dwio/nimble/tablet/IndexGenerated.h"
 #include "dwio/nimble/tablet/TabletWriter.h"

--- a/dwio/nimble/tablet/tests/TabletTest.cpp
+++ b/dwio/nimble/tablet/tests/TabletTest.cpp
@@ -24,7 +24,7 @@
 #include "dwio/nimble/common/Types.h"
 #include "dwio/nimble/common/tests/GTestUtils.h"
 #include "dwio/nimble/common/tests/TestUtils.h"
-#include "dwio/nimble/index/tests/TabletIndexTestUtils.h"
+#include "dwio/nimble/index/tests/IndexTestUtils.h"
 #include "dwio/nimble/tablet/Constants.h"
 #include "dwio/nimble/tablet/TabletReader.h"
 #include "dwio/nimble/tablet/TabletWriter.h"

--- a/dwio/nimble/velox/tests/VeloxWriterTest.cpp
+++ b/dwio/nimble/velox/tests/VeloxWriterTest.cpp
@@ -26,7 +26,7 @@
 #include "dwio/nimble/encodings/EncodingUtils.h"
 #include "dwio/nimble/encodings/PrefixEncoding.h"
 #include "dwio/nimble/encodings/tests/TestUtils.h"
-#include "dwio/nimble/index/tests/TabletIndexTestUtils.h"
+#include "dwio/nimble/index/tests/IndexTestUtils.h"
 #include "dwio/nimble/tablet/Constants.h"
 #include "dwio/nimble/velox/ChunkedStream.h"
 #include "dwio/nimble/velox/EncodingLayoutTree.h"


### PR DESCRIPTION
Summary:
This diff introduces HiveIndexReader, a new component that enables index-based lookup functionality for Hive tables stored in Nimble file format. The reader provides efficient point lookups by leveraging Nimble's cluster indexing capabilities.

HiveIndexReader: New class that wraps Nimble's SelectiveNimbleReader for index-based reads. Supports:
Setting probe data via setRequest() for index lookups
Iterating through matching rows with hasNext() and next()
Integration with AsyncDataCache for caching
IoStatistics tracking for monitoring cache hits

HiveTableHandle extension: Added indexColumns parameter to specify indexed columns, along with new APIs:
supportsIndexLookup() - Returns true if table has index columns configured
needsIndexSplit() - Returns true (index lookups require split info)
indexColumns() - Returns the list of indexed column names

SelectiveNimbleReader improvements:
Added reset() method to reuse the reader for multiple index lookups
Separated initIndex() (one-time setup) from setIndexBounds() (per-query setup)
Added split stripe boundary tracking for proper reset behavior

Test utilities: Renamed and enhanced TabletIndexTestUtils to IndexTestUtils with additional helpers for generating test data and writing indexed Nimble files.

The followup is to support skip list to handle batch lookup request in one pass of selective reader scan

Differential Revision: D91415139
