### PR TITLE
Make statistics physical size threadsafe

### DIFF
--- a/dwio/nimble/velox/stats/ColumnStatistics.h
+++ b/dwio/nimble/velox/stats/ColumnStatistics.h
@@ -84,7 +84,7 @@ class ColumnStatistics {
   uint64_t valueCount_{0};
   uint64_t nullCount_{0};
   uint64_t logicalSize_{0};
-  uint64_t physicalSize_{0};
+  std::atomic_uint64_t physicalSize_{0};
 };
 
 class StringStatistics : public ColumnStatistics {


### PR DESCRIPTION
Summary:
There is a thread safety issue when updating the physical size statistics with parallel encodings. Previously the code holds one state per stream id, but now the accounting unit is per schema node, causing the contention.

The fix is to specifically make the physical size state atomic in the column statistics.

Reviewed By: apurva-meta

Differential Revision: D91933623


