### PR TITLE
feat: Raw size util to handle upcast (#464)

### DIFF
--- a/dwio/nimble/velox/RawSizeUtils.cpp
+++ b/dwio/nimble/velox/RawSizeUtils.cpp
@@ -118,6 +118,82 @@ uint64_t buildChildRanges(
   return nullCount;
 }
 
+// RawSizeUtils is used by writer libraries. An upcast happens when the
+// input vector's type is narrower than the writer's target schema type.
+// e.g. when writing a BIGINT column, the input vector may be an INTEGER.
+// Only allows same-family promotions: integer->integer, float->float
+// where the schema type is larger or equal.
+bool isValidUpcast(velox::TypeKind vectorType, velox::TypeKind schemaType) {
+  const auto vectorSize =
+      facebook::nimble::getTypeSize(*velox::createScalarType(vectorType));
+  const auto schemaSize =
+      facebook::nimble::getTypeSize(*velox::createScalarType(schemaType));
+
+  if (!vectorSize.has_value() || !schemaSize.has_value()) {
+    return false;
+  }
+
+  // Integer type family
+  static const std::unordered_set<velox::TypeKind> integerTypes = {
+      velox::TypeKind::BOOLEAN,
+      velox::TypeKind::TINYINT,
+      velox::TypeKind::SMALLINT,
+      velox::TypeKind::INTEGER,
+      velox::TypeKind::BIGINT,
+  };
+
+  // Floating point type family
+  static const std::unordered_set<velox::TypeKind> floatTypes = {
+      velox::TypeKind::REAL,
+      velox::TypeKind::DOUBLE,
+  };
+
+  // Integer to integer upcast
+  if (integerTypes.contains(vectorType) && integerTypes.contains(schemaType)) {
+    return *schemaSize >= *vectorSize;
+  }
+
+  // Float to float upcast
+  if (floatTypes.contains(vectorType) && floatTypes.contains(schemaType)) {
+    return *schemaSize >= *vectorSize;
+  }
+
+  return false;
+}
+
+// Returns the size of the requested type for fixed width request type size.
+// Returns std::nullopt if vector type is variable length or incompatible with
+// the schema type.
+std::optional<uint64_t> getFixedWidthRequestTypeSize(
+    const velox::VectorPtr& vector,
+    const velox::dwio::common::TypeWithId* type) {
+  if (type == nullptr) {
+    return facebook::nimble::getTypeSize(*vector->type());
+  }
+
+  const auto vectorTypeKind = vector->typeKind();
+  const auto schemaTypeKind = type->type()->kind();
+  if (vectorTypeKind == schemaTypeKind) {
+    return facebook::nimble::getTypeSize(*type->type());
+  }
+
+  auto schemaTypeSize = facebook::nimble::getTypeSize(*type->type());
+
+  // Only validate and handle type mismatch for scalar (leaf) types.
+  // Complex types (ROW, MAP, ARRAY) are allowed to mismatch for cases like
+  // passthrough flatmaps and we let upstream decide whether to run the
+  // compatibility check.
+  if (schemaTypeSize.has_value()) {
+    VELOX_CHECK(
+        isValidUpcast(vectorTypeKind, schemaTypeKind),
+        "Invalid type coercion from {} to {}. Only upcasting within the same type family is allowed.",
+        vectorTypeKind,
+        schemaTypeKind);
+    return schemaTypeSize;
+  }
+
+  return std::nullopt;
+}
 } // namespace
 
 // Computes raw size for fixed-width scalar vectors.
@@ -128,8 +204,8 @@ template <velox::TypeKind K>
 uint64_t getRawSizeFromFixedWidthVector(
     const velox::VectorPtr& vector,
     const velox::common::Ranges& ranges,
-    RawSizeContext& context,
-    std::optional<uint64_t> requestTypeWidth = std::nullopt) {
+    uint64_t requestTypeWidth,
+    RawSizeContext& context) {
   VELOX_CHECK_NOT_NULL(vector);
   VELOX_DCHECK(
       K == velox::TypeKind::BOOLEAN || K == velox::TypeKind::TINYINT ||
@@ -139,8 +215,7 @@ uint64_t getRawSizeFromFixedWidthVector(
       "Wrong vector type. Expected BOOLEAN | TINYINT | SMALLINT | INTEGER | BIGINT | REAL | DOUBLE | TIMESTAMP.");
   using T = typename velox::TypeTraits<K>::NativeType;
 
-  // Use provided request type width or default to sizeof(T)
-  const uint64_t elementSize = requestTypeWidth.value_or(sizeof(T));
+  const uint64_t elementSize = requestTypeWidth;
 
   const auto& encoding = vector->encoding();
   switch (encoding) {
@@ -746,47 +821,46 @@ uint64_t getRawSizeFromVectorInternal(
     bool ignoreTopLevelNulls) {
   VELOX_CHECK_NOT_NULL(vector);
 
-  auto vectorTypeKind = vector->typeKind();
+  const auto vectorTypeKind = vector->typeKind();
 
-  // If we have schema info and there's a type mismatch, handle it.
-  // Type mismatch is only allowed for leaf (scalar) types.
-  // Complex type mismatches (e.g., ROW vs MAP for passthrough flatmaps) are
-  // handled in the type-specific functions.
+  // If we have schema info and there's a scalar type mismatch (e.g., int32_t
+  // vector with BIGINT schema), we use the schema type's size for the raw size
+  // calculation. This is passed as requestTypeWidth into the normal dispatch
+  // below, so the existing getRawSizeFromFixedWidthVector handles it uniformly.
+  const auto requestTypeWidth = getFixedWidthRequestTypeSize(vector, type);
 
   switch (vectorTypeKind) {
     case velox::TypeKind::BOOLEAN: {
       return getRawSizeFromFixedWidthVector<velox::TypeKind::BOOLEAN>(
-          vector, ranges, context);
+          vector, ranges, *requestTypeWidth, context);
     }
     case velox::TypeKind::TINYINT: {
       return getRawSizeFromFixedWidthVector<velox::TypeKind::TINYINT>(
-          vector, ranges, context);
+          vector, ranges, *requestTypeWidth, context);
     }
     case velox::TypeKind::SMALLINT: {
       return getRawSizeFromFixedWidthVector<velox::TypeKind::SMALLINT>(
-          vector, ranges, context);
+          vector, ranges, *requestTypeWidth, context);
     }
     case velox::TypeKind::INTEGER: {
       return getRawSizeFromFixedWidthVector<velox::TypeKind::INTEGER>(
-          vector, ranges, context);
+          vector, ranges, *requestTypeWidth, context);
     }
     case velox::TypeKind::BIGINT: {
       return getRawSizeFromFixedWidthVector<velox::TypeKind::BIGINT>(
-          vector, ranges, context);
+          vector, ranges, *requestTypeWidth, context);
     }
     case velox::TypeKind::REAL: {
       return getRawSizeFromFixedWidthVector<velox::TypeKind::REAL>(
-          vector, ranges, context);
+          vector, ranges, *requestTypeWidth, context);
     }
     case velox::TypeKind::DOUBLE: {
       return getRawSizeFromFixedWidthVector<velox::TypeKind::DOUBLE>(
-          vector, ranges, context);
+          vector, ranges, *requestTypeWidth, context);
     }
     case velox::TypeKind::TIMESTAMP: {
-      // TIMESTAMP uses a logical size of 12 bytes (8 + 4) instead of
-      // sizeof(Timestamp) = 16
       return getRawSizeFromFixedWidthVector<velox::TypeKind::TIMESTAMP>(
-          vector, ranges, context, kTimestampLogicalSize);
+          vector, ranges, *requestTypeWidth, context);
     }
     case velox::TypeKind::VARCHAR:
     case velox::TypeKind::VARBINARY: {

--- a/dwio/nimble/velox/RawSizeUtils.h
+++ b/dwio/nimble/velox/RawSizeUtils.h
@@ -27,11 +27,10 @@ namespace facebook::nimble {
 
 constexpr uint64_t kNullSize = 1;
 
-// Returns the size in bytes for a given TypeKind.
-// Used for calculating key sizes in passthrough flatmaps and for
-// handling type mismatches between vector types and schema types.
-// Returns std::nullopt for variable-length types (VARCHAR, VARBINARY, etc.)
-std::optional<size_t> getTypeSizeFromKind(velox::TypeKind kind);
+/// Returns the logical byte size for a fixed-width Velox type.
+/// For TIMESTAMP returns 12 bytes (8 + 4) to match DWRF/Nimble convention.
+/// Returns std::nullopt for variable-length or complex types.
+std::optional<size_t> getTypeSize(const velox::Type& type);
 
 // Get raw size from vector with schema and flatmap node IDs.
 // flatMapNodeIds contains the node IDs that are configured as flatmaps.

--- a/dwio/nimble/velox/tests/RawSizeTest.cpp
+++ b/dwio/nimble/velox/tests/RawSizeTest.cpp
@@ -1835,6 +1835,369 @@ TEST_F(RawSizeTestFixture, ThrowOnDefaultEncodingVariableWidth) {
       velox::VeloxRuntimeError);
 }
 
+// Test type compatibility helper functions
+TEST_F(RawSizeTestFixture, TypeSizeFromKind) {
+  // Fixed-width types should return their sizes via getTypeSize
+  EXPECT_EQ(nimble::getTypeSize(*velox::BOOLEAN()), sizeof(bool));
+  EXPECT_EQ(nimble::getTypeSize(*velox::TINYINT()), sizeof(int8_t));
+  EXPECT_EQ(nimble::getTypeSize(*velox::SMALLINT()), sizeof(int16_t));
+  EXPECT_EQ(nimble::getTypeSize(*velox::INTEGER()), sizeof(int32_t));
+  EXPECT_EQ(nimble::getTypeSize(*velox::BIGINT()), sizeof(int64_t));
+  EXPECT_EQ(nimble::getTypeSize(*velox::REAL()), sizeof(float));
+  EXPECT_EQ(nimble::getTypeSize(*velox::DOUBLE()), sizeof(double));
+  // Timestamp uses 12 bytes (8 for seconds + 4 for nanos)
+  EXPECT_EQ(nimble::getTypeSize(*velox::TIMESTAMP()), 12);
+
+  // Variable-width and complex types should return std::nullopt
+  EXPECT_FALSE(nimble::getTypeSize(*velox::VARCHAR()).has_value());
+  EXPECT_FALSE(nimble::getTypeSize(*velox::VARBINARY()).has_value());
+  EXPECT_FALSE(
+      nimble::getTypeSize(*velox::ARRAY(velox::INTEGER())).has_value());
+  EXPECT_FALSE(
+      nimble::getTypeSize(*velox::MAP(velox::INTEGER(), velox::VARCHAR()))
+          .has_value());
+  EXPECT_FALSE(
+      nimble::getTypeSize(*velox::ROW({velox::INTEGER()})).has_value());
+}
+
+// Tests for schema-aware raw size calculation with type mismatches
+class RawSizeTypeCompatibilityTestFixture : public RawSizeBaseTestFixture {
+ protected:
+  std::shared_ptr<velox::dwio::common::TypeWithId> makeTypeWithId(
+      const velox::TypePtr& type) {
+    return velox::dwio::common::TypeWithId::create(type);
+  }
+};
+
+// Test scalar type mismatch: int32_t vector with BIGINT schema
+TEST_F(RawSizeTypeCompatibilityTestFixture, ScalarIntegerToBigint) {
+  constexpr velox::vector_size_t SIZE = 10;
+  auto vector =
+      vectorMaker_->flatVector<int32_t>({1, 2, 3, 4, 5, 6, 7, 8, 9, 10});
+  auto schemaType = makeTypeWithId(velox::BIGINT());
+  folly::F14FastSet<uint32_t> flatMapNodeIds;
+
+  ranges_.add(0, SIZE);
+
+  // Without schema: int32_t * 10 = 40 bytes
+  auto rawSizeWithoutSchema =
+      nimble::getRawSizeFromVector(vector, ranges_, context_);
+  EXPECT_EQ(rawSizeWithoutSchema, sizeof(int32_t) * SIZE);
+
+  // With schema (BIGINT): int64_t * 10 = 80 bytes
+  context_ = nimble::RawSizeContext();
+  auto rawSizeWithSchema = nimble::getRawSizeFromVector(
+      vector, ranges_, context_, schemaType.get(), flatMapNodeIds);
+  EXPECT_EQ(rawSizeWithSchema, sizeof(int64_t) * SIZE);
+}
+
+// Test scalar type mismatch with nulls: int32_t vector with BIGINT schema
+TEST_F(RawSizeTypeCompatibilityTestFixture, ScalarIntegerToBigintWithNulls) {
+  auto vector = vectorMaker_->flatVectorNullable<int32_t>(
+      {1, std::nullopt, 3, 4, std::nullopt, 6, 7, 8, 9, 10});
+  auto schemaType = makeTypeWithId(velox::BIGINT());
+  folly::F14FastSet<uint32_t> flatMapNodeIds;
+
+  ranges_.add(0, 10);
+
+  // Without schema: (int32_t * 8) + (kNullSize * 2) = 32 + 2 = 34 bytes
+  auto rawSizeWithoutSchema =
+      nimble::getRawSizeFromVector(vector, ranges_, context_);
+  EXPECT_EQ(rawSizeWithoutSchema, sizeof(int32_t) * 8 + nimble::kNullSize * 2);
+
+  // With schema (BIGINT): (int64_t * 8) + (kNullSize * 2) = 64 + 2 = 66 bytes
+  context_ = nimble::RawSizeContext();
+  auto rawSizeWithSchema = nimble::getRawSizeFromVector(
+      vector, ranges_, context_, schemaType.get(), flatMapNodeIds);
+  EXPECT_EQ(rawSizeWithSchema, sizeof(int64_t) * 8 + nimble::kNullSize * 2);
+}
+
+// Test REAL to DOUBLE promotion
+TEST_F(RawSizeTypeCompatibilityTestFixture, ScalarRealToDouble) {
+  constexpr velox::vector_size_t SIZE = 5;
+  auto vector = vectorMaker_->flatVector<float>({1.0f, 2.0f, 3.0f, 4.0f, 5.0f});
+  auto schemaType = makeTypeWithId(velox::DOUBLE());
+  folly::F14FastSet<uint32_t> flatMapNodeIds;
+
+  ranges_.add(0, SIZE);
+
+  // Without schema: float * 5 = 20 bytes
+  auto rawSizeWithoutSchema =
+      nimble::getRawSizeFromVector(vector, ranges_, context_);
+  EXPECT_EQ(rawSizeWithoutSchema, sizeof(float) * SIZE);
+
+  // With schema (DOUBLE): double * 5 = 40 bytes
+  context_ = nimble::RawSizeContext();
+  auto rawSizeWithSchema = nimble::getRawSizeFromVector(
+      vector, ranges_, context_, schemaType.get(), flatMapNodeIds);
+  EXPECT_EQ(rawSizeWithSchema, sizeof(double) * SIZE);
+}
+
+// Test SMALLINT to INTEGER promotion
+TEST_F(RawSizeTypeCompatibilityTestFixture, ScalarSmallintToInteger) {
+  constexpr velox::vector_size_t SIZE = 4;
+  auto vector = vectorMaker_->flatVector<int16_t>({1, 2, 3, 4});
+  auto schemaType = makeTypeWithId(velox::INTEGER());
+  folly::F14FastSet<uint32_t> flatMapNodeIds;
+
+  ranges_.add(0, SIZE);
+
+  // Without schema: int16_t * 4 = 8 bytes
+  auto rawSizeWithoutSchema =
+      nimble::getRawSizeFromVector(vector, ranges_, context_);
+  EXPECT_EQ(rawSizeWithoutSchema, sizeof(int16_t) * SIZE);
+
+  // With schema (INTEGER): int32_t * 4 = 16 bytes
+  context_ = nimble::RawSizeContext();
+  auto rawSizeWithSchema = nimble::getRawSizeFromVector(
+      vector, ranges_, context_, schemaType.get(), flatMapNodeIds);
+  EXPECT_EQ(rawSizeWithSchema, sizeof(int32_t) * SIZE);
+}
+
+// Test TINYINT to BIGINT promotion (largest gap)
+TEST_F(RawSizeTypeCompatibilityTestFixture, ScalarTinyintToBigint) {
+  constexpr velox::vector_size_t SIZE = 8;
+  auto vector = vectorMaker_->flatVector<int8_t>({1, 2, 3, 4, 5, 6, 7, 8});
+  auto schemaType = makeTypeWithId(velox::BIGINT());
+  folly::F14FastSet<uint32_t> flatMapNodeIds;
+
+  ranges_.add(0, SIZE);
+
+  // Without schema: int8_t * 8 = 8 bytes
+  auto rawSizeWithoutSchema =
+      nimble::getRawSizeFromVector(vector, ranges_, context_);
+  EXPECT_EQ(rawSizeWithoutSchema, sizeof(int8_t) * SIZE);
+
+  // With schema (BIGINT): int64_t * 8 = 64 bytes
+  context_ = nimble::RawSizeContext();
+  auto rawSizeWithSchema = nimble::getRawSizeFromVector(
+      vector, ranges_, context_, schemaType.get(), flatMapNodeIds);
+  EXPECT_EQ(rawSizeWithSchema, sizeof(int64_t) * SIZE);
+}
+
+// Test BOOLEAN to INTEGER promotion (boolean is now in integer family)
+TEST_F(RawSizeTypeCompatibilityTestFixture, ScalarBooleanToInteger) {
+  constexpr velox::vector_size_t SIZE = 6;
+  auto vector =
+      vectorMaker_->flatVector<bool>({true, false, true, true, false, true});
+  auto schemaType = makeTypeWithId(velox::INTEGER());
+  folly::F14FastSet<uint32_t> flatMapNodeIds;
+
+  ranges_.add(0, SIZE);
+
+  // Without schema: bool * 6 = 6 bytes
+  auto rawSizeWithoutSchema =
+      nimble::getRawSizeFromVector(vector, ranges_, context_);
+  EXPECT_EQ(rawSizeWithoutSchema, sizeof(bool) * SIZE);
+
+  // With schema (INTEGER): int32_t * 6 = 24 bytes
+  context_ = nimble::RawSizeContext();
+  auto rawSizeWithSchema = nimble::getRawSizeFromVector(
+      vector, ranges_, context_, schemaType.get(), flatMapNodeIds);
+  EXPECT_EQ(rawSizeWithSchema, sizeof(int32_t) * SIZE);
+}
+
+// Test BOOLEAN to BIGINT promotion
+TEST_F(RawSizeTypeCompatibilityTestFixture, ScalarBooleanToBigint) {
+  constexpr velox::vector_size_t SIZE = 4;
+  auto vector = vectorMaker_->flatVector<bool>({true, false, true, false});
+  auto schemaType = makeTypeWithId(velox::BIGINT());
+  folly::F14FastSet<uint32_t> flatMapNodeIds;
+
+  ranges_.add(0, SIZE);
+
+  // Without schema: bool * 4 = 4 bytes
+  auto rawSizeWithoutSchema =
+      nimble::getRawSizeFromVector(vector, ranges_, context_);
+  EXPECT_EQ(rawSizeWithoutSchema, sizeof(bool) * SIZE);
+
+  // With schema (BIGINT): int64_t * 4 = 32 bytes
+  context_ = nimble::RawSizeContext();
+  auto rawSizeWithSchema = nimble::getRawSizeFromVector(
+      vector, ranges_, context_, schemaType.get(), flatMapNodeIds);
+  EXPECT_EQ(rawSizeWithSchema, sizeof(int64_t) * SIZE);
+}
+
+// Test BOOLEAN to INTEGER with nulls
+TEST_F(RawSizeTypeCompatibilityTestFixture, ScalarBooleanToIntegerWithNulls) {
+  auto vector = vectorMaker_->flatVectorNullable<bool>(
+      {true, std::nullopt, false, true, std::nullopt});
+  auto schemaType = makeTypeWithId(velox::INTEGER());
+  folly::F14FastSet<uint32_t> flatMapNodeIds;
+
+  ranges_.add(0, 5);
+
+  // Without schema: bool * 3 + null * 2 = 3 + 2 = 5 bytes
+  auto rawSizeWithoutSchema =
+      nimble::getRawSizeFromVector(vector, ranges_, context_);
+  EXPECT_EQ(rawSizeWithoutSchema, sizeof(bool) * 3 + nimble::kNullSize * 2);
+
+  // With schema (INTEGER): int32_t * 3 + null * 2 = 12 + 2 = 14 bytes
+  context_ = nimble::RawSizeContext();
+  auto rawSizeWithSchema = nimble::getRawSizeFromVector(
+      vector, ranges_, context_, schemaType.get(), flatMapNodeIds);
+  EXPECT_EQ(rawSizeWithSchema, sizeof(int32_t) * 3 + nimble::kNullSize * 2);
+}
+
+// Test array with element type mismatch
+TEST_F(RawSizeTypeCompatibilityTestFixture, ArrayWithTypeMismatch) {
+  // Create ARRAY<int32_t> vector with 2 rows:
+  // Row 0: [1, 2, 3] (3 elements)
+  // Row 1: [4, 5] (2 elements)
+  // Total: 5 int32_t elements = 20 bytes without schema
+  auto arrayVector = vectorMaker_->arrayVector<int32_t>({{1, 2, 3}, {4, 5}});
+  auto schemaType = makeTypeWithId(velox::ARRAY(velox::BIGINT()));
+  folly::F14FastSet<uint32_t> flatMapNodeIds;
+
+  ranges_.add(0, 2);
+
+  // Without schema: int32_t * 5 = 20 bytes
+  auto rawSizeWithoutSchema =
+      nimble::getRawSizeFromVector(arrayVector, ranges_, context_);
+  EXPECT_EQ(rawSizeWithoutSchema, sizeof(int32_t) * 5);
+
+  // With schema (ARRAY<BIGINT>): int64_t * 5 = 40 bytes
+  context_ = nimble::RawSizeContext();
+  auto rawSizeWithSchema = nimble::getRawSizeFromVector(
+      arrayVector, ranges_, context_, schemaType.get(), flatMapNodeIds);
+  EXPECT_EQ(rawSizeWithSchema, sizeof(int64_t) * 5);
+}
+
+// Test map with value type mismatch
+TEST_F(RawSizeTypeCompatibilityTestFixture, MapWithValueTypeMismatch) {
+  // Create MAP<VARCHAR, int32_t> vector with 2 entries:
+  // Entry 0: {"a" -> 1}
+  // Entry 1: {"bb" -> 2}
+  // Key sizes: 1 + 2 = 3 bytes
+  // Value sizes: int32_t * 2 = 8 bytes
+  // Total without schema: 11 bytes
+  auto mapVector = vectorMaker_->mapVector<velox::StringView, int32_t>(
+      {{{velox::StringView("a"), 1}}, {{velox::StringView("bb"), 2}}});
+  auto schemaType =
+      makeTypeWithId(velox::MAP(velox::VARCHAR(), velox::BIGINT()));
+  folly::F14FastSet<uint32_t> flatMapNodeIds;
+
+  ranges_.add(0, 2);
+
+  // Without schema: 3 (keys) + 8 (int32_t values) = 11 bytes
+  auto rawSizeWithoutSchema =
+      nimble::getRawSizeFromVector(mapVector, ranges_, context_);
+  EXPECT_EQ(rawSizeWithoutSchema, 3 + sizeof(int32_t) * 2);
+
+  // With schema (MAP<VARCHAR, BIGINT>): 3 (keys) + 16 (int64_t values) = 19
+  // bytes
+  context_ = nimble::RawSizeContext();
+  auto rawSizeWithSchema = nimble::getRawSizeFromVector(
+      mapVector, ranges_, context_, schemaType.get(), flatMapNodeIds);
+  EXPECT_EQ(rawSizeWithSchema, 3 + sizeof(int64_t) * 2);
+}
+
+// Test map with key type mismatch
+TEST_F(RawSizeTypeCompatibilityTestFixture, MapWithKeyTypeMismatch) {
+  // Create MAP<int32_t, VARCHAR> vector with 2 entries:
+  // Entry 0: {1 -> "a"}
+  // Entry 1: {2 -> "bb"}
+  // Key sizes (int32_t): 4 * 2 = 8 bytes
+  // Value sizes: 1 + 2 = 3 bytes
+  // Total without schema: 11 bytes
+  auto mapVector = vectorMaker_->mapVector<int32_t, velox::StringView>(
+      {{{1, velox::StringView("a")}}, {{2, velox::StringView("bb")}}});
+  auto schemaType =
+      makeTypeWithId(velox::MAP(velox::BIGINT(), velox::VARCHAR()));
+  folly::F14FastSet<uint32_t> flatMapNodeIds;
+
+  ranges_.add(0, 2);
+
+  // Without schema: 8 (int32_t keys) + 3 (varchar values) = 11 bytes
+  auto rawSizeWithoutSchema =
+      nimble::getRawSizeFromVector(mapVector, ranges_, context_);
+  EXPECT_EQ(rawSizeWithoutSchema, sizeof(int32_t) * 2 + 3);
+
+  // With schema (MAP<BIGINT, VARCHAR>): 16 (int64_t keys) + 3 (varchar values)
+  // = 19 bytes
+  context_ = nimble::RawSizeContext();
+  auto rawSizeWithSchema = nimble::getRawSizeFromVector(
+      mapVector, ranges_, context_, schemaType.get(), flatMapNodeIds);
+  EXPECT_EQ(rawSizeWithSchema, sizeof(int64_t) * 2 + 3);
+}
+
+// Test constant vector with type mismatch
+TEST_F(RawSizeTypeCompatibilityTestFixture, ConstantVectorWithTypeMismatch) {
+  constexpr velox::vector_size_t SIZE = 100;
+  std::vector<std::optional<int32_t>> vec(SIZE, 42);
+  auto constVector = vectorMaker_->constantVector<int32_t>(vec);
+  auto schemaType = makeTypeWithId(velox::BIGINT());
+  folly::F14FastSet<uint32_t> flatMapNodeIds;
+
+  ranges_.add(0, SIZE);
+
+  // Without schema: int32_t * 100 = 400 bytes
+  auto rawSizeWithoutSchema =
+      nimble::getRawSizeFromVector(constVector, ranges_, context_);
+  EXPECT_EQ(rawSizeWithoutSchema, sizeof(int32_t) * SIZE);
+
+  // With schema (BIGINT): int64_t * 100 = 800 bytes
+  context_ = nimble::RawSizeContext();
+  auto rawSizeWithSchema = nimble::getRawSizeFromVector(
+      constVector, ranges_, context_, schemaType.get(), flatMapNodeIds);
+  EXPECT_EQ(rawSizeWithSchema, sizeof(int64_t) * SIZE);
+}
+
+// Test dictionary vector with type mismatch
+TEST_F(RawSizeTypeCompatibilityTestFixture, DictionaryVectorWithTypeMismatch) {
+  constexpr velox::vector_size_t SIZE = 10;
+  auto flatVector =
+      vectorMaker_->flatVector<int32_t>({1, 2, 3, 4, 5, 6, 7, 8, 9, 10});
+  auto indices = randomIndices(SIZE);
+  auto dictVector = velox::BaseVector::wrapInDictionary(
+      velox::BufferPtr(nullptr), indices, SIZE, flatVector);
+
+  auto schemaType = makeTypeWithId(velox::BIGINT());
+  folly::F14FastSet<uint32_t> flatMapNodeIds;
+
+  ranges_.add(0, SIZE);
+
+  // Without schema: int32_t * 10 = 40 bytes
+  auto rawSizeWithoutSchema =
+      nimble::getRawSizeFromVector(dictVector, ranges_, context_);
+  EXPECT_EQ(rawSizeWithoutSchema, sizeof(int32_t) * SIZE);
+
+  // With schema (BIGINT): int64_t * 10 = 80 bytes
+  context_ = nimble::RawSizeContext();
+  auto rawSizeWithSchema = nimble::getRawSizeFromVector(
+      dictVector, ranges_, context_, schemaType.get(), flatMapNodeIds);
+  EXPECT_EQ(rawSizeWithSchema, sizeof(int64_t) * SIZE);
+}
+
+// Test row vector with nested type mismatches
+TEST_F(RawSizeTypeCompatibilityTestFixture, RowVectorWithTypeMismatch) {
+  // Create ROW with:
+  // - col0: int32_t values [1, 2]
+  // - col1: float values [1.0, 2.0]
+  auto childVector1 = vectorMaker_->flatVector<int32_t>({1, 2});
+  auto childVector2 = vectorMaker_->flatVector<float>({1.0f, 2.0f});
+  auto rowVector =
+      vectorMaker_->rowVector({"col0", "col1"}, {childVector1, childVector2});
+
+  // Schema declares BIGINT and DOUBLE
+  auto schemaType = makeTypeWithId(
+      velox::ROW({{"col0", velox::BIGINT()}, {"col1", velox::DOUBLE()}}));
+  folly::F14FastSet<uint32_t> flatMapNodeIds;
+
+  ranges_.add(0, 2);
+
+  // Without schema: (int32_t * 2) + (float * 2) = 8 + 8 = 16 bytes
+  auto rawSizeWithoutSchema = nimble::getRawSizeFromRowVector(
+      rowVector, ranges_, context_, nullptr, {}, true);
+  EXPECT_EQ(rawSizeWithoutSchema, sizeof(int32_t) * 2 + sizeof(float) * 2);
+
+  // With schema: (int64_t * 2) + (double * 2) = 16 + 16 = 32 bytes
+  context_ = nimble::RawSizeContext();
+  auto rawSizeWithSchema = nimble::getRawSizeFromRowVector(
+      rowVector, ranges_, context_, schemaType.get(), flatMapNodeIds, true);
+  EXPECT_EQ(rawSizeWithSchema, sizeof(int64_t) * 2 + sizeof(double) * 2);
+}
+
 TEST_F(RawSizeTestFixture, LocalDecodedVectorMoveConstructor) {
   auto localDecodedVector1 =
       facebook::nimble::DecodedVectorManager::LocalDecodedVector(


### PR DESCRIPTION
Summary:

When making changes in stats collection path and now cross validating raw/logical size calculation from vector and field writer collection, we found some test failures in feature reaper tests due to test data specifying inconsistent input vector type and schema type. The writer supports this upcast implicitly otherwise, so the right thing to do is to support it in a lightweight fashion.

We do still have to fix the test case where it tried to pass integer to a float column.

Reviewed By: xiaoxmeng

Differential Revision: D91559828


