### PR TITLE
feat: Add allow/disallow duplicate feature in nimble index

### DIFF
--- a/dwio/nimble/index/IndexConfig.h
+++ b/dwio/nimble/index/IndexConfig.h
@@ -36,12 +36,17 @@ struct IndexConfig {
   /// If empty, defaults to ascending order for all columns.
   /// If not empty, must have the same size as 'columns'.
   std::vector<SortOrder> sortOrders;
-  /// If true, enforces that encoded keys must be in strictly ascending order
-  /// (each key must be greater than the previous). This ensures that stripe
-  /// boundaries maintain sorted order for efficient range-based filtering.
-  /// An exception is thrown if keys are found to be out of order or if
-  /// duplicate keys are detected.
+  /// If true, enforces that encoded keys must be in ascending order.
+  /// This ensures that stripe boundaries maintain sorted order for efficient
+  /// range-based filtering. An exception is thrown if keys are found to be
+  /// out of order. Duplicate keys are allowed unless noDuplicateKey is also
+  /// set.
   bool enforceKeyOrder{false};
+  /// If true, enforces that encoded keys must be in strictly ascending order
+  /// with no duplicate keys allowed. If enforceKeyOrder is true, setting this
+  /// option enforces the no duplicates check. An exception is thrown if keys
+  /// are out of order or if duplicate keys are detected.
+  bool noDuplicateKey{false};
   /// The encoding layout for the key stream.
   /// Only Prefix and Trivial encodings are supported.
   /// Users should pass a fully constructed EncodingLayout.

--- a/dwio/nimble/velox/IndexWriter.h
+++ b/dwio/nimble/velox/IndexWriter.h
@@ -158,6 +158,7 @@ class IndexWriter {
   // Stores the indices of key columns in the input schema for efficient null
   // validation without repeated name lookups.
   const std::vector<velox::column_index_t> keyColumnIndices_;
+  const bool noDuplicateKey_;
   const uint64_t minChunkSize_;
   const uint64_t maxChunkSize_;
 

--- a/dwio/nimble/velox/tests/VeloxWriterTest.cpp
+++ b/dwio/nimble/velox/tests/VeloxWriterTest.cpp
@@ -3685,6 +3685,7 @@ TEST_F(VeloxWriterTest, indexEnforceKeyOrder) {
       nimble::IndexConfig indexConfig{
           .columns = {"key_col"},
           .enforceKeyOrder = enforceKeyOrder,
+          .noDuplicateKey = enforceKeyOrder,
       };
 
       std::string file;


### PR DESCRIPTION
Summary:
The newly added `noDuplicate` configuration in the index config is designed to prevent the insertion of duplicate entries within an index. When enabled, this setting ensures that any attempt to add a record that matches an existing entry—based on the defined uniqueness criteria—will not be allowed.

The followup will be to persist this in file such that when reading index, optimal algorithm can be picked based on the duplicate/non-duplicate nature of the keys

Differential Revision: D92356847


