### PR TITLE
Add benchmark tool to convert RecordIO to Nimble format

### DIFF
--- a/dwio/nimble/tools/NimbleDumpLib.h
+++ b/dwio/nimble/tools/NimbleDumpLib.h
@@ -53,6 +53,7 @@ class NimbleDumpLib {
   void emitStripesMetadata(bool noHeader);
   void emitStripeGroupsMetadata(bool noHeader);
   void emitOptionalSectionsMetadata(bool noHeader);
+  void emitIndex();
 
  private:
   std::shared_ptr<velox::memory::MemoryPool> pool_;


### PR DESCRIPTION
Summary:
This diff adds a benchmark tool to convert user sequence RecordIO files to Nimble file format with optional cluster index support, using the `traits_to_maps` UDF for data transformation.

- Added `MrsNimbleConversion` class in `Data.h/cpp` that uses the `traits_to_maps` UDF to convert user sequence data into a simpler format with one row per sub-sequence
- Created `UserSequenceRecordIoToNimbleMain.cpp` benchmark tool that reads RecordIO, applies the conversion, and writes to Nimble format
- Added shell script `run_user_sequence_recordio_to_nimble.sh` for running the benchmark
- Added gflags for configuring:
  - `--enable_index`: Enable/disable cluster index generation (default: true)
  - `--key_encoding_type`: Key encoding type for index (0=Prefix, 1=Trivial)
- Extended `NimbleDumpLib::emitIndex()` to log index stats including:
  - Index columns and sort orders
  - Number of stripes and index groups
  - Index group metadata (compression, offset, size)
  - Key stream offset and size per stripe

The output schema for each row is:
- `user_id`: int64
- `timestamp`: int64 (sub-sequence timestamp)
- `int_traits_map`: Map<int64, Array<int32>> (int trait values)
- `long_traits_map`: Map<int64, Array<int64>> (long trait values)

Differential Revision: D92458894


