### PR TITLE
misc: Create nimble sort order struct

### DIFF
--- a/dwio/nimble/index/CMakeLists.txt
+++ b/dwio/nimble/index/CMakeLists.txt
@@ -15,6 +15,7 @@ add_library(
   nimble_index
   IndexFilter.cpp
   IndexReader.cpp
+  SortOrder.cpp
   StripeIndexGroup.cpp
   TabletIndex.cpp
 )

--- a/dwio/nimble/index/IndexConfig.h
+++ b/dwio/nimble/index/IndexConfig.h
@@ -20,7 +20,7 @@
 
 #include "dwio/nimble/common/Types.h"
 #include "dwio/nimble/encodings/EncodingLayout.h"
-#include "velox/core/PlanNode.h"
+#include "dwio/nimble/index/SortOrder.h"
 
 namespace facebook::nimble {
 
@@ -33,9 +33,9 @@ struct IndexConfig {
   /// that enable efficient data skipping during reads.
   std::vector<std::string> columns;
   /// Specifies the sort order for each index column.
-  /// If empty, defaults to ascending order with nulls first for all columns.
+  /// If empty, defaults to ascending order for all columns.
   /// If not empty, must have the same size as 'columns'.
-  std::vector<velox::core::SortOrder> sortOrders;
+  std::vector<SortOrder> sortOrders;
   /// If true, enforces that encoded keys must be in strictly ascending order
   /// (each key must be greater than the previous). This ensures that stripe
   /// boundaries maintain sorted order for efficient range-based filtering.

--- a/dwio/nimble/index/IndexFilter.cpp
+++ b/dwio/nimble/index/IndexFilter.cpp
@@ -73,9 +73,9 @@ struct FilterBoundInfo {
 // supported yet.
 FilterBoundInfo getFilterBoundInfo(
     const Filter& filter,
-    const core::SortOrder& sortOrder) {
+    const SortOrder& sortOrder) {
   FilterBoundInfo info;
-  const bool isDesc = !sortOrder.isAscending();
+  const bool isDesc = !sortOrder.ascending;
 
   switch (filter.kind()) {
     case FilterKind::kBigintRange: {
@@ -196,7 +196,7 @@ void addColumnBound(
     const Filter& filter,
     const std::string& columnName,
     const TypePtr& columnType,
-    const core::SortOrder& sortOrder,
+    const SortOrder& sortOrder,
     std::vector<std::string>& columnNames,
     std::vector<TypePtr>& columnTypes,
     std::vector<VectorPtr>& lowerVectors,
@@ -207,7 +207,7 @@ void addColumnBound(
   columnNames.push_back(columnName);
   columnTypes.push_back(columnType);
 
-  const bool isDesc = !sortOrder.isAscending();
+  const bool isDesc = !sortOrder.ascending;
 
   // Helper to add vectors considering sort order.
   // For DESC columns, we swap lower and upper bounds.
@@ -378,7 +378,7 @@ void addColumnBound(
 
 std::optional<FilterToIndexBoundsResult> convertFilterToIndexBounds(
     const std::vector<std::string>& indexColumns,
-    const std::vector<core::SortOrder>& sortOrders,
+    const std::vector<SortOrder>& sortOrders,
     const RowTypePtr& rowType,
     ScanSpec& scanSpec,
     memory::MemoryPool* pool) {

--- a/dwio/nimble/index/IndexFilter.h
+++ b/dwio/nimble/index/IndexFilter.h
@@ -18,8 +18,8 @@
 #include <optional>
 #include <vector>
 
+#include "dwio/nimble/index/SortOrder.h"
 #include "velox/common/memory/MemoryPool.h"
-#include "velox/core/PlanNode.h"
 #include "velox/dwio/common/ScanSpec.h"
 #include "velox/serializers/KeyEncoder.h"
 #include "velox/type/Filter.h"
@@ -86,7 +86,7 @@ struct FilterToIndexBoundsResult {
 ///         filters if filters can be converted, std::nullopt otherwise.
 std::optional<FilterToIndexBoundsResult> convertFilterToIndexBounds(
     const std::vector<std::string>& indexColumns,
-    const std::vector<velox::core::SortOrder>& sortOrders,
+    const std::vector<SortOrder>& sortOrders,
     const velox::RowTypePtr& rowType,
     velox::common::ScanSpec& scanSpec,
     velox::memory::MemoryPool* pool);

--- a/dwio/nimble/index/SortOrder.cpp
+++ b/dwio/nimble/index/SortOrder.cpp
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "dwio/nimble/index/SortOrder.h"
+
+namespace facebook::nimble {
+
+folly::dynamic SortOrder::serialize() const {
+  folly::dynamic obj = folly::dynamic::object;
+  obj["ascending"] = ascending;
+  return obj;
+}
+
+SortOrder SortOrder::deserialize(const folly::dynamic& obj) {
+  return SortOrder{.ascending = obj["ascending"].asBool()};
+}
+
+velox::core::SortOrder SortOrder::toVeloxSortOrder() const {
+  return velox::core::SortOrder{ascending, /*nullsFirst=*/false};
+}
+
+} // namespace facebook::nimble

--- a/dwio/nimble/index/SortOrder.h
+++ b/dwio/nimble/index/SortOrder.h
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <vector>
+
+#include "folly/json/dynamic.h"
+#include "velox/core/PlanNode.h"
+
+namespace facebook::nimble {
+
+/// Specifies the sort order for an index column.
+/// Nulls are always sorted last.
+struct SortOrder {
+  bool ascending{true};
+
+  bool operator==(const SortOrder& other) const = default;
+
+  /// Serializes the sort order to a folly::dynamic object.
+  folly::dynamic serialize() const;
+
+  /// Deserializes a sort order from a folly::dynamic object.
+  static SortOrder deserialize(const folly::dynamic& obj);
+
+  /// Converts to velox::core::SortOrder.
+  /// Nulls are always last.
+  velox::core::SortOrder toVeloxSortOrder() const;
+};
+
+} // namespace facebook::nimble

--- a/dwio/nimble/index/TabletIndex.cpp
+++ b/dwio/nimble/index/TabletIndex.cpp
@@ -68,16 +68,14 @@ std::vector<std::string> getIndexColumns(
   return result;
 }
 
-std::vector<velox::core::SortOrder> getSortOrders(
-    const serialization::Index* indexRoot) {
+std::vector<SortOrder> getSortOrders(const serialization::Index* indexRoot) {
   const auto* sortOrders = indexRoot->sort_orders();
   NIMBLE_CHECK_NOT_NULL(sortOrders);
-  std::vector<velox::core::SortOrder> result;
+  std::vector<SortOrder> result;
   result.reserve(sortOrders->size());
   for (const auto* sortOrder : *sortOrders) {
     result.emplace_back(
-        velox::core::SortOrder::deserialize(
-            folly::parseJson(sortOrder->string_view())));
+        SortOrder::deserialize(folly::parseJson(sortOrder->string_view())));
   }
   return result;
 }

--- a/dwio/nimble/index/TabletIndex.h
+++ b/dwio/nimble/index/TabletIndex.h
@@ -20,8 +20,8 @@
 #include <string_view>
 #include <vector>
 
+#include "dwio/nimble/index/SortOrder.h"
 #include "dwio/nimble/tablet/MetadataBuffer.h"
-#include "velox/core/PlanNode.h"
 
 namespace facebook::nimble::serialization {
 struct Index;
@@ -123,7 +123,7 @@ class TabletIndex {
   /// Returns the sort orders for each index column.
   ///
   /// @return Vector of sort orders, one per index column
-  const std::vector<velox::core::SortOrder>& sortOrders() const {
+  const std::vector<SortOrder>& sortOrders() const {
     return sortOrders_;
   }
 
@@ -152,7 +152,7 @@ class TabletIndex {
   const uint32_t numIndexGroups_;
   const std::vector<std::string_view> stripeKeys_;
   const std::vector<std::string> indexColumns_;
-  const std::vector<velox::core::SortOrder> sortOrders_;
+  const std::vector<SortOrder> sortOrders_;
 };
 
 } // namespace facebook::nimble::index

--- a/dwio/nimble/index/tests/IndexFilterTest.cpp
+++ b/dwio/nimble/index/tests/IndexFilterTest.cpp
@@ -103,7 +103,7 @@ TEST_F(IndexFilterTest, basic) {
     NIMBLE_ASSERT_THROW(
         convertFilterToIndexBounds(
             {"a", "b"},
-            {core::kAscNullsFirst},
+            {SortOrder{.ascending = true}},
             rowType,
             *scanSpec,
             pool_.get()),
@@ -118,7 +118,7 @@ TEST_F(IndexFilterTest, basic) {
 
     auto result = convertFilterToIndexBounds(
         {"nonexistent"},
-        {core::kAscNullsFirst},
+        {SortOrder{.ascending = true}},
         rowType,
         *scanSpec,
         pool_.get());
@@ -136,7 +136,7 @@ TEST_F(IndexFilterTest, noMatchingFilter) {
     auto scanSpec = createScanSpec(rowType, filters);
 
     auto result = convertFilterToIndexBounds(
-        {"a"}, {core::kAscNullsFirst}, rowType, *scanSpec, pool_.get());
+        {"a"}, {SortOrder{.ascending = true}}, rowType, *scanSpec, pool_.get());
     EXPECT_FALSE(result.has_value());
     // Filter on "b" should still be set.
     EXPECT_NE(scanSpec->childByName("b")->filter(), nullptr);
@@ -149,7 +149,7 @@ TEST_F(IndexFilterTest, noMatchingFilter) {
     auto scanSpec = createScanSpec(rowType, filters);
 
     auto result = convertFilterToIndexBounds(
-        {"a"}, {core::kAscNullsFirst}, rowType, *scanSpec, pool_.get());
+        {"a"}, {SortOrder{.ascending = true}}, rowType, *scanSpec, pool_.get());
     EXPECT_FALSE(result.has_value());
     EXPECT_NE(scanSpec->childByName("a")->filter(), nullptr);
   }
@@ -161,7 +161,7 @@ TEST_F(IndexFilterTest, noMatchingFilter) {
     auto scanSpec = createScanSpec(rowType, filters);
 
     auto result = convertFilterToIndexBounds(
-        {"a"}, {core::kAscNullsFirst}, rowType, *scanSpec, pool_.get());
+        {"a"}, {SortOrder{.ascending = true}}, rowType, *scanSpec, pool_.get());
     EXPECT_FALSE(result.has_value());
     EXPECT_NE(scanSpec->childByName("a")->filter(), nullptr);
   }
@@ -174,7 +174,7 @@ TEST_F(IndexFilterTest, noMatchingFilter) {
     auto scanSpec = createScanSpec(rowType, filters);
 
     auto result = convertFilterToIndexBounds(
-        {"a"}, {core::kAscNullsFirst}, rowType, *scanSpec, pool_.get());
+        {"a"}, {SortOrder{.ascending = true}}, rowType, *scanSpec, pool_.get());
     EXPECT_FALSE(result.has_value());
     EXPECT_NE(scanSpec->childByName("a")->filter(), nullptr);
   }
@@ -186,7 +186,7 @@ TEST_F(IndexFilterTest, noMatchingFilter) {
     auto scanSpec = createScanSpec(rowType, filters);
 
     auto result = convertFilterToIndexBounds(
-        {"a"}, {core::kAscNullsFirst}, rowType, *scanSpec, pool_.get());
+        {"a"}, {SortOrder{.ascending = true}}, rowType, *scanSpec, pool_.get());
     EXPECT_FALSE(result.has_value());
     EXPECT_NE(scanSpec->childByName("a")->filter(), nullptr);
   }
@@ -198,7 +198,7 @@ TEST_F(IndexFilterTest, noMatchingFilter) {
     auto scanSpec = createScanSpec(rowType, filters);
 
     auto result = convertFilterToIndexBounds(
-        {"a"}, {core::kAscNullsFirst}, rowType, *scanSpec, pool_.get());
+        {"a"}, {SortOrder{.ascending = true}}, rowType, *scanSpec, pool_.get());
     EXPECT_FALSE(result.has_value());
     EXPECT_NE(scanSpec->childByName("a")->filter(), nullptr);
   }
@@ -214,7 +214,9 @@ TEST_F(IndexFilterTest, noMatchingFilter) {
 
     auto result = convertFilterToIndexBounds(
         {"a", "b", "c"},
-        {core::kAscNullsFirst, core::kAscNullsFirst, core::kAscNullsFirst},
+        {SortOrder{.ascending = true},
+         SortOrder{.ascending = true},
+         SortOrder{.ascending = true}},
         threeColRowType,
         *scanSpec,
         pool_.get());
@@ -247,7 +249,9 @@ TEST_F(IndexFilterTest, removedFilters) {
 
     auto result = convertFilterToIndexBounds(
         {"a", "b", "c"},
-        {core::kAscNullsFirst, core::kAscNullsFirst, core::kAscNullsFirst},
+        {SortOrder{.ascending = true},
+         SortOrder{.ascending = true},
+         SortOrder{.ascending = true}},
         rowType,
         *scanSpec,
         pool_.get());
@@ -270,7 +274,9 @@ TEST_F(IndexFilterTest, removedFilters) {
 
     auto result = convertFilterToIndexBounds(
         {"a", "b", "c"},
-        {core::kAscNullsFirst, core::kAscNullsFirst, core::kAscNullsFirst},
+        {SortOrder{.ascending = true},
+         SortOrder{.ascending = true},
+         SortOrder{.ascending = true}},
         rowType,
         *scanSpec,
         pool_.get());
@@ -295,7 +301,9 @@ TEST_F(IndexFilterTest, removedFilters) {
 
     auto result = convertFilterToIndexBounds(
         {"a", "b", "c"},
-        {core::kAscNullsFirst, core::kAscNullsFirst, core::kAscNullsFirst},
+        {SortOrder{.ascending = true},
+         SortOrder{.ascending = true},
+         SortOrder{.ascending = true}},
         rowType,
         *scanSpec,
         pool_.get());
@@ -317,7 +325,7 @@ TEST_F(IndexFilterTest, removedFilters) {
 
     auto result = convertFilterToIndexBounds(
         {"a", "b"},
-        {core::kAscNullsFirst, core::kAscNullsFirst},
+        {SortOrder{.ascending = true}, SortOrder{.ascending = true}},
         rowType,
         *scanSpec,
         pool_.get());
@@ -337,7 +345,7 @@ TEST_F(IndexFilterTest, removedFilters) {
     auto scanSpec = createScanSpec(rowType, filters);
 
     auto result = convertFilterToIndexBounds(
-        {"a"}, {core::kAscNullsFirst}, rowType, *scanSpec, pool_.get());
+        {"a"}, {SortOrder{.ascending = true}}, rowType, *scanSpec, pool_.get());
     EXPECT_FALSE(result.has_value());
   }
 
@@ -348,7 +356,7 @@ TEST_F(IndexFilterTest, removedFilters) {
     auto scanSpec = createScanSpec(rowType, filters);
 
     auto result = convertFilterToIndexBounds(
-        {"a"}, {core::kAscNullsFirst}, rowType, *scanSpec, pool_.get());
+        {"a"}, {SortOrder{.ascending = true}}, rowType, *scanSpec, pool_.get());
     EXPECT_FALSE(result.has_value());
   }
 }
@@ -360,13 +368,13 @@ TEST_F(IndexFilterTest, sortOrder) {
   // Loop over the last column's sort order (ASC or DESC).
   auto rowType = ROW({"a", "b", "c"}, {BIGINT(), BIGINT(), BIGINT()});
 
-  std::vector<core::SortOrder> sortOrdersToTest = {
-      core::kAscNullsFirst, core::kDescNullsFirst};
+  std::vector<SortOrder> sortOrdersToTest = {
+      SortOrder{.ascending = true}, SortOrder{.ascending = false}};
   for (const auto& lastColSortOrder : sortOrdersToTest) {
     SCOPED_TRACE(
         fmt::format(
             "lastColSortOrder: {}",
-            lastColSortOrder.isAscending() ? "ASC" : "DESC"));
+            lastColSortOrder.ascending ? "ASC" : "DESC"));
 
     std::unordered_map<std::string, std::unique_ptr<Filter>> filters;
     filters["a"] = std::make_unique<BigintRange>(42, 42, false);
@@ -377,7 +385,9 @@ TEST_F(IndexFilterTest, sortOrder) {
     // Mixed sort orders: asc, desc, and lastColSortOrder for "c".
     auto result = convertFilterToIndexBounds(
         {"a", "b", "c"},
-        {core::kAscNullsFirst, core::kDescNullsFirst, lastColSortOrder},
+        {SortOrder{.ascending = true},
+         SortOrder{.ascending = false},
+         lastColSortOrder},
         rowType,
         *scanSpec,
         pool_.get());
@@ -398,7 +408,7 @@ TEST_F(IndexFilterTest, sortOrder) {
     verifyBound<int64_t>(bounds.lowerBound->bound, "b", 100);
     verifyBound<int64_t>(bounds.upperBound->bound, "b", 100);
     // Range on "c": bounds swapped for descending sort order.
-    if (lastColSortOrder.isAscending()) {
+    if (lastColSortOrder.ascending) {
       verifyBound<int64_t>(bounds.lowerBound->bound, "c", 10);
       verifyBound<int64_t>(bounds.upperBound->bound, "c", 20);
     } else {
@@ -415,18 +425,18 @@ TEST_F(IndexFilterTest, sortOrder) {
 
 class IndexFilterTestWithSortOrder
     : public IndexFilterTestBase,
-      public ::testing::WithParamInterface<core::SortOrder> {
+      public ::testing::WithParamInterface<SortOrder> {
  protected:
-  core::SortOrder sortOrder() const {
+  SortOrder sortOrder() const {
     return GetParam();
   }
 
-  std::vector<core::SortOrder> sortOrders(size_t count) const {
-    return std::vector<core::SortOrder>(count, sortOrder());
+  std::vector<SortOrder> sortOrders(size_t count) const {
+    return std::vector<SortOrder>(count, sortOrder());
   }
 
   bool isAscending() const {
-    return sortOrder().isAscending();
+    return sortOrder().ascending;
   }
 
   // For range filters, lower/upper bounds are swapped for descending sort.
@@ -1785,9 +1795,11 @@ TEST_P(IndexFilterTestWithSortOrder, mixedFilterDataTypes) {
 INSTANTIATE_TEST_SUITE_P(
     SortOrders,
     IndexFilterTestWithSortOrder,
-    ::testing::Values(core::kAscNullsFirst, core::kDescNullsFirst),
-    [](const ::testing::TestParamInfo<core::SortOrder>& info) {
-      return info.param.isAscending() ? "Ascending" : "Descending";
+    ::testing::Values(
+        SortOrder{.ascending = true},
+        SortOrder{.ascending = false}),
+    [](const ::testing::TestParamInfo<SortOrder>& info) {
+      return info.param.ascending ? "Ascending" : "Descending";
     });
 
 } // namespace facebook::nimble::index::test

--- a/dwio/nimble/index/tests/SortOrderTest.cpp
+++ b/dwio/nimble/index/tests/SortOrderTest.cpp
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <gtest/gtest.h>
+
+#include "dwio/nimble/index/SortOrder.h"
+
+namespace facebook::nimble::index::test {
+
+TEST(SortOrderTest, basicOperations) {
+  SortOrder defaultOrder;
+  EXPECT_TRUE(defaultOrder.ascending);
+
+  SortOrder ascending{.ascending = true};
+  SortOrder descending{.ascending = false};
+  EXPECT_EQ(defaultOrder, ascending);
+  EXPECT_NE(ascending, descending);
+
+  EXPECT_EQ(ascending, SortOrder::deserialize(ascending.serialize()));
+  EXPECT_EQ(descending, SortOrder::deserialize(descending.serialize()));
+}
+
+TEST(SortOrderTest, toVeloxSortOrder) {
+  SortOrder ascending{.ascending = true};
+  auto veloxAsc = ascending.toVeloxSortOrder();
+  EXPECT_TRUE(veloxAsc.isAscending());
+  EXPECT_FALSE(veloxAsc.isNullsFirst());
+
+  SortOrder descending{.ascending = false};
+  auto veloxDesc = descending.toVeloxSortOrder();
+  EXPECT_FALSE(veloxDesc.isAscending());
+  EXPECT_FALSE(veloxDesc.isNullsFirst());
+}
+
+} // namespace facebook::nimble::index::test

--- a/dwio/nimble/tablet/TabletIndexWriter.h
+++ b/dwio/nimble/tablet/TabletIndexWriter.h
@@ -21,8 +21,8 @@
 #include <vector>
 
 #include "dwio/nimble/common/Buffer.h"
+#include "dwio/nimble/index/SortOrder.h"
 #include "dwio/nimble/tablet/MetadataBuffer.h"
-#include "velox/core/PlanNode.h"
 
 namespace facebook::nimble {
 
@@ -37,7 +37,7 @@ struct TabletIndexConfig {
   std::vector<std::string> columns;
   /// Specifies the sort order for each index column.
   /// Must not be empty and must have the same size as 'columns'.
-  std::vector<velox::core::SortOrder> sortOrders;
+  std::vector<SortOrder> sortOrders;
   /// If true, enforces that encoded keys must be in strictly ascending order
   /// across stripes.
   bool enforceKeyOrder{false};

--- a/dwio/nimble/tablet/tests/TabletIndexWriterTest.cpp
+++ b/dwio/nimble/tablet/tests/TabletIndexWriterTest.cpp
@@ -92,7 +92,7 @@ TEST_F(TabletIndexWriterTest, basic) {
     TabletIndexConfig config{
         .columns = {"col1", "col2"},
         .sortOrders =
-            {velox::core::kAscNullsFirst, velox::core::kDescNullsLast},
+            {SortOrder{.ascending = true}, SortOrder{.ascending = false}},
         .enforceKeyOrder = true,
     };
     auto writer = TabletIndexWriter::create(config, *pool_);
@@ -133,7 +133,7 @@ TEST_F(TabletIndexWriterTest, basic) {
   {
     TabletIndexConfig config{
         .columns = {"col1", "col2"},
-        .sortOrders = {velox::core::kAscNullsFirst},
+        .sortOrders = {SortOrder{.ascending = true}},
         .enforceKeyOrder = false,
     };
     NIMBLE_ASSERT_USER_THROW(
@@ -148,7 +148,7 @@ TEST_F(TabletIndexWriterTest, stripeKeyOutOfOrderCheck) {
 
     TabletIndexConfig config{
         .columns = {"col1"},
-        .sortOrders = {velox::core::kAscNullsFirst},
+        .sortOrders = {SortOrder{.ascending = true}},
         .enforceKeyOrder = enforceKeyOrder};
     auto writer = TabletIndexWriter::create(config, *pool_);
 
@@ -178,7 +178,7 @@ TEST_F(TabletIndexWriterTest, stripeKeyOutOfOrderCheck) {
 TEST_F(TabletIndexWriterTest, singleRowFirstStripe) {
   TabletIndexConfig config{
       .columns = {"col1"},
-      .sortOrders = {velox::core::kAscNullsFirst},
+      .sortOrders = {SortOrder{.ascending = true}},
       .enforceKeyOrder = true};
   auto writer = TabletIndexWriter::create(config, *pool_);
 
@@ -206,7 +206,7 @@ TEST_F(TabletIndexWriterTest, singleRowFirstStripe) {
 TEST_F(TabletIndexWriterTest, checkNotFinalizedAfterWriteRootIndex) {
   TabletIndexConfig config{
       .columns = {"col1"},
-      .sortOrders = {velox::core::kAscNullsFirst},
+      .sortOrders = {SortOrder{.ascending = true}},
       .enforceKeyOrder = false};
   auto writer = TabletIndexWriter::create(config, *pool_);
 
@@ -245,7 +245,7 @@ TEST_F(TabletIndexWriterTest, checkNotFinalizedAfterWriteRootIndex) {
 TEST_F(TabletIndexWriterTest, emptyStripeKeys) {
   TabletIndexConfig config{
       .columns = {"col1"},
-      .sortOrders = {velox::core::kAscNullsFirst},
+      .sortOrders = {SortOrder{.ascending = true}},
       .enforceKeyOrder = false};
   auto writer = TabletIndexWriter::create(config, *pool_);
 
@@ -260,7 +260,7 @@ TEST_F(TabletIndexWriterTest, emptyStripeKeys) {
 TEST_F(TabletIndexWriterTest, emptyStreamInStripe) {
   TabletIndexConfig config{
       .columns = {"col1"},
-      .sortOrders = {velox::core::kAscNullsFirst},
+      .sortOrders = {SortOrder{.ascending = true}},
       .enforceKeyOrder = false};
   auto writer = TabletIndexWriter::create(config, *pool_);
 
@@ -298,7 +298,8 @@ TEST_F(TabletIndexWriterTest, emptyStreamInStripe) {
 TEST_F(TabletIndexWriterTest, writeAndReadWithSingleGroup) {
   TabletIndexConfig config{
       .columns = {"col1", "col2"},
-      .sortOrders = {velox::core::kAscNullsFirst, velox::core::kDescNullsLast},
+      .sortOrders =
+          {SortOrder{.ascending = true}, SortOrder{.ascending = false}},
       .enforceKeyOrder = true,
   };
   auto writer = TabletIndexWriter::create(config, *pool_);
@@ -408,8 +409,8 @@ TEST_F(TabletIndexWriterTest, writeAndReadWithSingleGroup) {
 
   // Verify sort orders
   ASSERT_EQ(tabletIndex->sortOrders().size(), 2);
-  EXPECT_EQ(tabletIndex->sortOrders()[0], velox::core::kAscNullsFirst);
-  EXPECT_EQ(tabletIndex->sortOrders()[1], velox::core::kDescNullsLast);
+  EXPECT_EQ(tabletIndex->sortOrders()[0], SortOrder{.ascending = true});
+  EXPECT_EQ(tabletIndex->sortOrders()[1], SortOrder{.ascending = false});
 
   // Verify stripe keys
   EXPECT_EQ(tabletIndex->minKey(), "aaa");
@@ -535,7 +536,8 @@ TEST_F(TabletIndexWriterTest, writeAndReadWithSingleGroup) {
 TEST_F(TabletIndexWriterTest, writeAndReadWithMultipleGroups) {
   TabletIndexConfig config{
       .columns = {"col1", "col2"},
-      .sortOrders = {velox::core::kAscNullsFirst, velox::core::kDescNullsLast},
+      .sortOrders =
+          {SortOrder{.ascending = true}, SortOrder{.ascending = false}},
       .enforceKeyOrder = true,
   };
   auto writer = TabletIndexWriter::create(config, *pool_);
@@ -785,7 +787,7 @@ TEST_F(TabletIndexWriterTest, writeAndReadWithMultipleGroups) {
 TEST_F(TabletIndexWriterTest, writeAndReadWithMultipleGroupsAndEmptyStream) {
   TabletIndexConfig config{
       .columns = {"col1"},
-      .sortOrders = {velox::core::kAscNullsFirst},
+      .sortOrders = {SortOrder{.ascending = true}},
       .enforceKeyOrder = true,
   };
   auto writer = TabletIndexWriter::create(config, *pool_);

--- a/dwio/nimble/tablet/tests/TabletTest.cpp
+++ b/dwio/nimble/tablet/tests/TabletTest.cpp
@@ -37,6 +37,7 @@
 #include "velox/dwio/common/ExecutorBarrier.h"
 
 using namespace facebook;
+using nimble::SortOrder;
 
 namespace {
 
@@ -1473,7 +1474,7 @@ TEST_F(TabletWithIndexTest, stripeIdentifier) {
 
   nimble::TabletIndexConfig indexConfig{
       .columns = {"col1"},
-      .sortOrders = {velox::core::kAscNullsFirst},
+      .sortOrders = {SortOrder{.ascending = true}},
       .enforceKeyOrder = true,
   };
 
@@ -1529,7 +1530,8 @@ TEST_F(TabletWithIndexTest, singleGroup) {
 
   nimble::TabletIndexConfig indexConfig{
       .columns = {"col1", "col2"},
-      .sortOrders = {velox::core::kAscNullsFirst, velox::core::kAscNullsFirst},
+      .sortOrders =
+          {SortOrder{.ascending = true}, SortOrder{.ascending = true}},
       .enforceKeyOrder = true,
   };
 
@@ -1951,7 +1953,8 @@ TEST_F(TabletWithIndexTest, multipleGroups) {
 
   nimble::TabletIndexConfig indexConfig{
       .columns = {"col1", "col2"},
-      .sortOrders = {velox::core::kAscNullsFirst, velox::core::kAscNullsFirst},
+      .sortOrders =
+          {SortOrder{.ascending = true}, SortOrder{.ascending = true}},
       .enforceKeyOrder = true,
   };
 
@@ -2327,7 +2330,7 @@ TEST_F(TabletWithIndexTest, singleGroupWithEmptyStream) {
 
   nimble::TabletIndexConfig indexConfig{
       .columns = {"col1"},
-      .sortOrders = {velox::core::kAscNullsFirst},
+      .sortOrders = {SortOrder{.ascending = true}},
       .enforceKeyOrder = true,
   };
 
@@ -2742,7 +2745,7 @@ TEST_F(TabletWithIndexTest, multipleGroupsWithEmptyStream) {
 
   nimble::TabletIndexConfig indexConfig{
       .columns = {"col1"},
-      .sortOrders = {velox::core::kAscNullsFirst},
+      .sortOrders = {SortOrder{.ascending = true}},
       .enforceKeyOrder = true,
   };
 
@@ -3215,7 +3218,7 @@ TEST_F(TabletWithIndexTest, streamDeduplication) {
 
   nimble::TabletIndexConfig indexConfig{
       .columns = {"col1"},
-      .sortOrders = {velox::core::kAscNullsFirst},
+      .sortOrders = {SortOrder{.ascending = true}},
       .enforceKeyOrder = true,
   };
 
@@ -3480,7 +3483,7 @@ TEST_F(TabletWithIndexTest, keyOrderEnforcement) {
 
       nimble::TabletIndexConfig indexConfig{
           .columns = {"col1"},
-          .sortOrders = {velox::core::kAscNullsFirst},
+          .sortOrders = {SortOrder{.ascending = true}},
           .enforceKeyOrder = enforceKeyOrder,
       };
 

--- a/dwio/nimble/tools/NimbleDumpLib.cpp
+++ b/dwio/nimble/tools/NimbleDumpLib.cpp
@@ -1131,10 +1131,8 @@ void NimbleDumpLib::emitIndex() {
     if (i > 0) {
       ostream_ << ", ";
     }
-    ostream_ << columns[i] << " ("
-             << (sortOrders[i].isAscending() ? "ASC" : "DESC")
-             << (sortOrders[i].isNullsFirst() ? " NULLS FIRST" : " NULLS LAST")
-             << ")";
+    ostream_ << columns[i] << " (" << (sortOrders[i].ascending ? "ASC" : "DESC")
+             << " NULLS LAST)";
   }
   ostream_ << std::endl;
   ostream_ << "Number of Stripes: " << commaSeparated(index->numStripes())

--- a/dwio/nimble/velox/IndexWriter.h
+++ b/dwio/nimble/velox/IndexWriter.h
@@ -117,8 +117,8 @@ class IndexWriter {
 
   /// Returns the sort orders for each index column.
   /// The returned vector will have the same size as the index columns.
-  const std::vector<velox::core::SortOrder>& sortOrders() const {
-    return keyEncoder_->sortOrders();
+  const std::vector<SortOrder>& sortOrders() const {
+    return sortOrders_;
   }
 
   /// Closes the writer and releases resources.
@@ -150,6 +150,7 @@ class IndexWriter {
   void validateNoNullKeys(const velox::VectorPtr& input) const;
 
   velox::memory::MemoryPool* const pool_;
+  const std::vector<SortOrder> sortOrders_;
   const std::unique_ptr<velox::serializer::KeyEncoder> keyEncoder_;
   const std::unique_ptr<ContentStreamData<std::string_view>> keyStream_;
   const EncodingLayout encodingLayout_;

--- a/dwio/nimble/velox/tests/VeloxWriterTest.cpp
+++ b/dwio/nimble/velox/tests/VeloxWriterTest.cpp
@@ -97,7 +97,7 @@ TEST_F(VeloxWriterTest, emptyFileWithIndexEnabled) {
 
   nimble::IndexConfig indexConfig{
       .columns = {"key_col"},
-      .sortOrders = {velox::core::kAscNullsFirst},
+      .sortOrders = {nimble::SortOrder{.ascending = true}},
       .enforceKeyOrder = true,
   };
 
@@ -3211,10 +3211,10 @@ class VeloxWriterIndexTest
       startRow += tablet.stripeRowCount(i);
     }
 
-    // Create sort orders for KeyEncoder (all ascending, nulls first)
+    // Create sort orders for KeyEncoder (all ascending, nulls last)
     std::vector<velox::core::SortOrder> sortOrders(
         indexColumns.size(),
-        velox::core::SortOrder(true, true)); // ascending, nulls first
+        velox::core::SortOrder(true, false)); // ascending, nulls last
 
     // Create KeyEncoder for encoding row keys
     auto keyEncoder = velox::serializer::KeyEncoder::create(


### PR DESCRIPTION
Summary: Create nimble SortOrder struct that replaces the velox SortOrder in nimble index config. The nimble SortOrder only has orders, and defaulting null last semantics.

Reviewed By: xiaoxmeng

Differential Revision: D92458844


