### PR TITLE
refactor: Move file io stats inside spill stats

### DIFF
--- a/dwio/nimble/velox/selective/tests/ChunkedDecoderTest.cpp
+++ b/dwio/nimble/velox/selective/tests/ChunkedDecoderTest.cpp
@@ -107,7 +107,7 @@ TEST_F(ChunkedDecoderTest, bufferedInput) {
       nullptr,
       StringIdLease{},
       fileIoStats,
-      std::make_shared<filesystems::File::IoStats>(),
+      nullptr,
       executor.get(),
       readerOpts);
 


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebookincubator/velox/pull/16255

This diff moves fs stats inside spill stats. it requires changes of
1) making spill stats thread safe
2) isolating IoStats out to an individual module for resolving cyclic dependency
3) updating all call sites

Reviewed By: xiaoxmeng

Differential Revision: D92416339
