### PR TITLE
feat: Persist noDuplicateKey in index footer for fast path while search

### DIFF
--- a/dwio/nimble/index/IndexReader.cpp
+++ b/dwio/nimble/index/IndexReader.cpp
@@ -35,9 +35,11 @@ IndexReader::IndexReader(
     std::unique_ptr<velox::dwio::common::SeekableInputStream> input,
     uint32_t stripeIndex,
     std::shared_ptr<StripeIndexGroup> indexGroup,
+    bool noDuplicateKey,
     velox::memory::MemoryPool* pool)
     : stripeIndex_{stripeIndex},
       indexGroup_{std::move(indexGroup)},
+      noDuplicateKey_{noDuplicateKey},
       input_{std::move(input)},
       pool_{pool} {
   NIMBLE_CHECK_NOT_NULL(input_);
@@ -48,9 +50,14 @@ std::unique_ptr<IndexReader> IndexReader::create(
     std::unique_ptr<velox::dwio::common::SeekableInputStream> input,
     uint32_t stripeIndex,
     std::shared_ptr<StripeIndexGroup> indexGroup,
+    bool noDuplicateKey,
     velox::memory::MemoryPool* pool) {
   return std::unique_ptr<IndexReader>(new IndexReader(
-      std::move(input), stripeIndex, std::move(indexGroup), pool));
+      std::move(input),
+      stripeIndex,
+      std::move(indexGroup),
+      noDuplicateKey,
+      pool));
 }
 
 std::optional<uint32_t> IndexReader::seekAtOrAfter(

--- a/dwio/nimble/index/IndexReader.h
+++ b/dwio/nimble/index/IndexReader.h
@@ -44,6 +44,7 @@ class IndexReader {
       std::unique_ptr<velox::dwio::common::SeekableInputStream> input,
       uint32_t stripeIndex,
       std::shared_ptr<StripeIndexGroup> indexGroup,
+      bool noDuplicateKey,
       velox::memory::MemoryPool* pool);
 
   /// Seek to the position at or after the given encoded key.
@@ -56,6 +57,7 @@ class IndexReader {
       std::unique_ptr<velox::dwio::common::SeekableInputStream> input,
       uint32_t stripeIndex,
       std::shared_ptr<StripeIndexGroup> indexGroup,
+      bool noDuplicateKey,
       velox::memory::MemoryPool* pool);
 
   /// Seek to a key at or after the given encoded key within a chunk.
@@ -78,6 +80,7 @@ class IndexReader {
 
   const uint32_t stripeIndex_;
   const std::shared_ptr<StripeIndexGroup> indexGroup_;
+  const bool noDuplicateKey_;
 
   const std::unique_ptr<velox::dwio::common::SeekableInputStream> input_;
   velox::memory::MemoryPool* const pool_;

--- a/dwio/nimble/index/TabletIndex.cpp
+++ b/dwio/nimble/index/TabletIndex.cpp
@@ -80,6 +80,10 @@ std::vector<SortOrder> getSortOrders(const serialization::Index* indexRoot) {
   return result;
 }
 
+bool getNoDuplicateKey(const serialization::Index* indexRoot) {
+  return indexRoot->no_duplicate_key();
+}
+
 } // namespace
 
 std::unique_ptr<TabletIndex> TabletIndex::create(Section indexSection) {
@@ -93,7 +97,8 @@ TabletIndex::TabletIndex(Section indexSection)
       numIndexGroups_{getIndexGroupCount(indexRoot_)},
       stripeKeys_{getStripeKeys(indexRoot_)},
       indexColumns_{getIndexColumns(indexRoot_)},
-      sortOrders_{getSortOrders(indexRoot_)} {
+      sortOrders_{getSortOrders(indexRoot_)},
+      noDuplicateKey_{getNoDuplicateKey(indexRoot_)} {
   NIMBLE_CHECK(!indexColumns_.empty());
   NIMBLE_CHECK_EQ(numStripes_ + 1, stripeKeys_.size());
   NIMBLE_CHECK_EQ(indexColumns_.size(), sortOrders_.size());

--- a/dwio/nimble/index/TabletIndex.h
+++ b/dwio/nimble/index/TabletIndex.h
@@ -127,6 +127,14 @@ class TabletIndex {
     return sortOrders_;
   }
 
+  /// Returns whether the index was built with no duplicate keys.
+  /// When true, seek operations can return immediately upon exact match.
+  ///
+  /// @return True if index has no duplicate keys
+  bool noDuplicateKey() const {
+    return noDuplicateKey_;
+  }
+
   /// Returns metadata for a specific index group.
   ///
   /// @param groupIndex The zero-based stripe group index.
@@ -153,6 +161,7 @@ class TabletIndex {
   const std::vector<std::string_view> stripeKeys_;
   const std::vector<std::string> indexColumns_;
   const std::vector<SortOrder> sortOrders_;
+  const bool noDuplicateKey_;
 };
 
 } // namespace facebook::nimble::index

--- a/dwio/nimble/index/tests/IndexReaderTest.cpp
+++ b/dwio/nimble/index/tests/IndexReaderTest.cpp
@@ -114,14 +114,14 @@ TEST_F(IndexReaderTest, singleChunkSingleKey) {
       createTestTabletIndex(indexColumns, minKey, stripes, stripeGroups);
   auto stripeIndexGroup =
       createStripeIndexGroup(indexBuffers, /*stripeGroupIndex=*/0);
-
   auto reader = IndexReader::create(
       createInputStream(encodedStream.data),
-      /*stripeIndex=*/0,
+      0,
       stripeIndexGroup,
+      /*noDuplicateKey=*/false,
       pool_.get());
 
-  // Test exact key match
+  // Test exact matches, keys between existing keys
   auto result = reader->seekAtOrAfter("key_a");
   ASSERT_TRUE(result.has_value());
   EXPECT_EQ(result.value(), 0);
@@ -157,7 +157,11 @@ TEST_F(IndexReaderTest, singleChunkMultipleKeys) {
       createStripeIndexGroup(indexBuffers, /*stripeGroupIndex=*/0);
 
   auto reader = IndexReader::create(
-      createInputStream(encodedStream.data), 0, stripeIndexGroup, pool_.get());
+      createInputStream(encodedStream.data),
+      0,
+      stripeIndexGroup,
+      /*noDuplicateKey=*/false,
+      pool_.get());
 
   // Test exact matches, keys between existing keys, and keys after last key.
   // Keys between existing keys should return the next key's row.
@@ -213,7 +217,11 @@ TEST_F(IndexReaderTest, multipleChunks) {
       createStripeIndexGroup(indexBuffers, /*stripeGroupIndex=*/0);
 
   auto reader = IndexReader::create(
-      createInputStream(encodedStream.data), 0, stripeIndexGroup, pool_.get());
+      createInputStream(encodedStream.data),
+      0,
+      stripeIndexGroup,
+      /*noDuplicateKey=*/false,
+      pool_.get());
 
   // Test keys across all chunks with mixed found/not-found cases.
   // Chunk 0: row offset 0, Chunk 1: row offset 3, Chunk 2: row offset 6
@@ -273,7 +281,11 @@ TEST_F(IndexReaderTest, seekBetweenChunks) {
       createStripeIndexGroup(indexBuffers, /*stripeGroupIndex=*/0);
 
   auto reader = IndexReader::create(
-      createInputStream(encodedStream.data), 0, stripeIndexGroup, pool_.get());
+      createInputStream(encodedStream.data),
+      0,
+      stripeIndexGroup,
+      /*noDuplicateKey=*/false,
+      pool_.get());
 
   // Key falls between chunk 0's max (ccc) and chunk 1's content (ddd)
   // The index lookup should direct us to chunk 1, and we find ddd
@@ -345,7 +357,11 @@ TEST_F(IndexReaderTest, multipleStripes) {
 
   // Test reader for stripe 0
   auto reader0 = IndexReader::create(
-      createInputStream(encodedStream0.data), 0, stripeIndexGroup, pool_.get());
+      createInputStream(encodedStream0.data),
+      0,
+      stripeIndexGroup,
+      /*noDuplicateKey=*/false,
+      pool_.get());
 
   auto result = reader0->seekAtOrAfter("key_a");
   ASSERT_TRUE(result.has_value());
@@ -357,7 +373,11 @@ TEST_F(IndexReaderTest, multipleStripes) {
 
   // Test reader for stripe 1
   auto reader1 = IndexReader::create(
-      createInputStream(encodedStream1.data), 1, stripeIndexGroup, pool_.get());
+      createInputStream(encodedStream1.data),
+      1,
+      stripeIndexGroup,
+      /*noDuplicateKey=*/false,
+      pool_.get());
 
   result = reader1->seekAtOrAfter("key_d");
   ASSERT_TRUE(result.has_value());
@@ -388,7 +408,11 @@ TEST_F(IndexReaderTest, emptyStringKey) {
       createStripeIndexGroup(indexBuffers, /*stripeGroupIndex=*/0);
 
   auto reader = IndexReader::create(
-      createInputStream(encodedStream.data), 0, stripeIndexGroup, pool_.get());
+      createInputStream(encodedStream.data),
+      0,
+      stripeIndexGroup,
+      /*noDuplicateKey=*/false,
+      pool_.get());
 
   // Test empty string key
   auto result = reader->seekAtOrAfter("");
@@ -428,7 +452,11 @@ TEST_F(IndexReaderTest, largeNumberOfKeys) {
       createStripeIndexGroup(indexBuffers, /*stripeGroupIndex=*/0);
 
   auto reader = IndexReader::create(
-      createInputStream(encodedStream.data), 0, stripeIndexGroup, pool_.get());
+      createInputStream(encodedStream.data),
+      0,
+      stripeIndexGroup,
+      /*noDuplicateKey=*/false,
+      pool_.get());
 
   // Test some specific keys
   std::vector<int> testIndices = {0, 1, 10, 100, 500, 999};
@@ -484,7 +512,11 @@ TEST_F(IndexReaderTest, repeatedSeeksToSameChunk) {
       createStripeIndexGroup(indexBuffers, /*stripeGroupIndex=*/0);
 
   auto reader = IndexReader::create(
-      createInputStream(encodedStream.data), 0, stripeIndexGroup, pool_.get());
+      createInputStream(encodedStream.data),
+      0,
+      stripeIndexGroup,
+      /*noDuplicateKey=*/false,
+      pool_.get());
 
   // Test repeated seeks within each chunk and across chunks.
   // Mix forward, backward, and repeated seeks to test caching behavior.
@@ -534,7 +566,11 @@ TEST_F(IndexReaderTest, unevenChunkSizes) {
       createStripeIndexGroup(indexBuffers, /*stripeGroupIndex=*/0);
 
   auto reader = IndexReader::create(
-      createInputStream(encodedStream.data), 0, stripeIndexGroup, pool_.get());
+      createInputStream(encodedStream.data),
+      0,
+      stripeIndexGroup,
+      /*noDuplicateKey=*/false,
+      pool_.get());
 
   // Chunk 0: row offset 0, 1 key
   // Chunk 1: row offset 1, 5 keys
@@ -590,7 +626,11 @@ TEST_F(IndexReaderTest, binaryKeys) {
       createStripeIndexGroup(indexBuffers, /*stripeGroupIndex=*/0);
 
   auto reader = IndexReader::create(
-      createInputStream(encodedStream.data), 0, stripeIndexGroup, pool_.get());
+      createInputStream(encodedStream.data),
+      0,
+      stripeIndexGroup,
+      /*noDuplicateKey=*/false,
+      pool_.get());
 
   // Test exact matches and not-found cases for binary keys.
   // Keys after the last key should return std::nullopt.

--- a/dwio/nimble/tablet/Index.fbs
+++ b/dwio/nimble/tablet/Index.fbs
@@ -79,6 +79,11 @@ table Index {
   stripe_counts:[uint32];
   /// Metadata sections for each stripe index group.
   stripe_index_groups:[MetadataSection];
+  /// If true, indicates that the index was built with no duplicate keys.
+  /// This enables optimized seek operations that can return immediately
+  /// upon finding an exact match, rather than scanning for duplicates.
+  /// Defaults to false for backward compatibility.
+  no_duplicate_key:bool = false;
 }
 
 root_type Index;

--- a/dwio/nimble/tablet/TabletIndexWriter.h
+++ b/dwio/nimble/tablet/TabletIndexWriter.h
@@ -38,9 +38,14 @@ struct TabletIndexConfig {
   /// Specifies the sort order for each index column.
   /// Must not be empty and must have the same size as 'columns'.
   std::vector<SortOrder> sortOrders;
-  /// If true, enforces that encoded keys must be in strictly ascending order
-  /// across stripes.
+  /// If true, enforces that encoded keys must be in ascending order
+  /// across stripes. Duplicate keys are allowed unless noDuplicateKey is set.
   bool enforceKeyOrder{false};
+  /// If true, indicates that the index was built with no duplicate keys.
+  /// This enables optimized seek operations that can return immediately
+  /// upon finding an exact match, rather than scanning for duplicates.
+  /// When set, also enforces that keys are strictly ascending (no duplicates).
+  bool noDuplicateKey{false};
 };
 
 /// TabletIndexWriter manages all index-related state and operations for

--- a/dwio/nimble/tablet/tests/TabletTest.cpp
+++ b/dwio/nimble/tablet/tests/TabletTest.cpp
@@ -3485,6 +3485,7 @@ TEST_F(TabletWithIndexTest, keyOrderEnforcement) {
           .columns = {"col1"},
           .sortOrders = {SortOrder{.ascending = true}},
           .enforceKeyOrder = enforceKeyOrder,
+          .noDuplicateKey = enforceKeyOrder,
       };
 
       auto tabletWriter = nimble::TabletWriter::create(

--- a/dwio/nimble/velox/VeloxWriter.cpp
+++ b/dwio/nimble/velox/VeloxWriter.cpp
@@ -461,6 +461,7 @@ std::optional<TabletIndexConfig> createTabletIndexConfig(
       .columns = config->columns,
       .sortOrders = indexWriter->sortOrders(),
       .enforceKeyOrder = config->enforceKeyOrder,
+      .noDuplicateKey = config->noDuplicateKey,
   };
 }
 

--- a/dwio/nimble/velox/selective/SelectiveNimbleReader.cpp
+++ b/dwio/nimble/velox/selective/SelectiveNimbleReader.cpp
@@ -605,10 +605,12 @@ void SelectiveNimbleRowReader::buildIndexReader(NimbleParams& params) {
   if ((currentStripe_ != startStripe_) && (currentStripe_ != endStripe_ - 1)) {
     return;
   }
+  NIMBLE_CHECK_NOT_NULL(tabletIndex_);
   indexReader_ = index::IndexReader::create(
       params.streams().enqueueKeyStream(),
       params.streams().stripeIndex(),
       params.streams().indexGroup(),
+      tabletIndex_->noDuplicateKey(),
       &params.pool());
 }
 


### PR DESCRIPTION
Summary: This diff persists duplicate key field in root index metadata from index write path, and recovers it from index read path.

Reviewed By: xiaoxmeng

Differential Revision: D92669217


