### PR TITLE
feat: Add fast path to PrefixEncoding when no duplicates

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -114,6 +114,9 @@ set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${SCRIPT_CXX_FLAGS}")
 
 message("FINAL CMAKE_CXX_FLAGS=${CMAKE_CXX_FLAGS}")
 
+add_compile_options(-ffunction-sections -fdata-sections)
+add_link_options(-Wl,--gc-sections)
+
 include(CTest) # include after project() but before add_subdirectory()
 
 find_package(flatbuffers)

--- a/dwio/nimble/encodings/Encoding.h
+++ b/dwio/nimble/encodings/Encoding.h
@@ -134,6 +134,11 @@ class Encoding {
   // iterator; if you need to move your row pointer back, reset() and skip().
   virtual void skip(uint32_t rowCount) = 0;
 
+  /// Seeks to the position at or after the given value.
+  ///
+  /// @param value Pointer to target value to seek.
+  /// @return Row index if found, std::nullopt if value is greater than all
+  /// entries.
   virtual std::optional<uint32_t> seekAtOrAfter(const void* value) {
     NIMBLE_UNSUPPORTED("seekAtOrAfter is not supported.");
   }

--- a/dwio/nimble/encodings/tests/PrefixEncodingTest.cpp
+++ b/dwio/nimble/encodings/tests/PrefixEncodingTest.cpp
@@ -1157,4 +1157,175 @@ TEST_F(PrefixEncodingTest, fuzzerEncode) {
   }
 }
 
+// Test seekAtOrAfter with duplicate keys that span across restart intervals.
+// This specifically tests the fix where seeking for a key that matches
+// a restart point value should return the earliest occurrence, which may be
+// in the previous restart interval.
+TEST_F(PrefixEncodingTest, seekExactMatchWithDuplicatesAcrossRestarts) {
+  // Test case: duplicates at restart boundary
+  // Restart interval is 16, so restart points are at indices 0, 16, 32, etc.
+  // We create data where duplicate keys span the restart boundary.
+  struct TestCase {
+    std::string_view name;
+    std::vector<std::string> values;
+    std::string seekKey;
+    uint32_t expectedPosition;
+  };
+
+  const std::vector<TestCase> testCases = {
+      // Duplicate key "key_16" appears at indices 14, 15, 16, 17
+      // Restart point at index 16 has value "key_16"
+      // Seeking for "key_16" should return 14 (first occurrence in previous
+      // interval)
+      {"duplicates before restart point (index 16)",
+       // Indices 0-13: unique keys, 14-17: "key_16", 18-31: unique keys
+       []() {
+         std::vector<std::string> v;
+         v.reserve(14);
+         for (int i = 0; i < 14; ++i) {
+           v.push_back(fmt::format("key_{:02d}", i));
+         }
+         // Duplicates spanning restart boundary (indices 14, 15, 16, 17)
+         for (int i = 0; i < 4; ++i) {
+           v.emplace_back("key_16");
+         }
+         for (int i = 18; i < 32; ++i) {
+           v.push_back(fmt::format("key_{:02d}", i));
+         }
+         return v;
+       }(),
+       "key_16",
+       14},
+
+      // Duplicate key at restart point with more duplicates before
+      // Restart point at index 32, duplicates at indices 28-35
+      {"duplicates before restart point (index 32)",
+       []() {
+         std::vector<std::string> v;
+         v.reserve(28);
+         for (int i = 0; i < 28; ++i) {
+           v.push_back(fmt::format("key_{:02d}", i));
+         }
+         // Duplicates spanning restart boundary at index 32 (indices 28-35)
+         for (int i = 0; i < 8; ++i) {
+           v.emplace_back("key_32");
+         }
+         for (int i = 36; i < 50; ++i) {
+           v.push_back(fmt::format("key_{:02d}", i));
+         }
+         return v;
+       }(),
+       "key_32",
+       28},
+
+      // Single duplicate before restart point
+      {"single duplicate before restart point",
+       []() {
+         std::vector<std::string> v;
+         v.reserve(15);
+         for (int i = 0; i < 15; ++i) {
+           v.push_back(fmt::format("key_{:02d}", i));
+         }
+         // Index 15 and 16 both have "key_16"
+         v.emplace_back("key_16");
+         v.emplace_back("key_16");
+         for (int i = 17; i < 32; ++i) {
+           v.push_back(fmt::format("key_{:02d}", i));
+         }
+         return v;
+       }(),
+       "key_16",
+       15},
+
+      // Duplicates spanning multiple restart intervals
+      // Restart points at 16, 32; duplicates from index 14 to 34
+      {"duplicates spanning multiple restart intervals",
+       []() {
+         std::vector<std::string> v;
+         v.reserve(14);
+         for (int i = 0; i < 14; ++i) {
+           v.push_back(fmt::format("key_{:02d}", i));
+         }
+         // Duplicates from index 14 to 34 (spanning restarts at 16 and 32)
+         for (int i = 0; i < 21; ++i) {
+           v.emplace_back("key_dup");
+         }
+         for (int i = 35; i < 50; ++i) {
+           v.push_back(fmt::format("key_{:02d}", i));
+         }
+         return v;
+       }(),
+       "key_dup",
+       14},
+
+      // Duplicates at restart point but none before (should still work)
+      {"duplicates at restart point only",
+       []() {
+         std::vector<std::string> v;
+         v.reserve(16);
+         for (int i = 0; i < 16; ++i) {
+           v.push_back(fmt::format("key_{:02d}", i));
+         }
+         // Duplicates starting exactly at restart point (indices 16-19)
+         for (int i = 0; i < 4; ++i) {
+           v.emplace_back("key_20");
+         }
+         for (int i = 20; i < 32; ++i) {
+           v.push_back(fmt::format("key_{:02d}", i));
+         }
+         return v;
+       }(),
+       "key_20",
+       16},
+
+      // All same values (extreme case)
+      {"all same values",
+       []() {
+         std::vector<std::string> v;
+         v.reserve(50);
+         for (int i = 0; i < 50; ++i) {
+           v.emplace_back("same_key");
+         }
+         return v;
+       }(),
+       "same_key",
+       0},
+  };
+
+  for (const auto& testCase : testCases) {
+    SCOPED_TRACE(testCase.name);
+
+    std::vector<std::string_view> values;
+    values.reserve(testCase.values.size());
+    for (const auto& s : testCase.values) {
+      values.push_back(s);
+    }
+
+    Buffer buffer{*pool_};
+    auto encoded = EncodingFactory::encode<std::string_view>(
+        createSelectionPolicy(), values, buffer);
+    stringBuffers_.clear();
+    auto encoding =
+        EncodingFactory::decode(*pool_, encoded, createStringBufferFactory());
+
+    std::string_view seekKey = testCase.seekKey;
+    auto result = encoding->seekAtOrAfter(&seekKey);
+    ASSERT_TRUE(result.has_value())
+        << "Expected to find key: " << testCase.seekKey;
+    EXPECT_EQ(result.value(), testCase.expectedPosition)
+        << "Expected position " << testCase.expectedPosition << " for key "
+        << testCase.seekKey << " but got " << result.value();
+
+    // Also verify that the value at the returned position matches
+    encoding->reset();
+    if (result.value() > 0) {
+      encoding->skip(result.value());
+    }
+    std::string_view decoded;
+    encoding->materialize(1, &decoded);
+    EXPECT_EQ(decoded, testCase.seekKey)
+        << "Value at position " << result.value() << " should be "
+        << testCase.seekKey;
+  }
+}
 } // namespace facebook::nimble::test

--- a/dwio/nimble/index/IndexReader.cpp
+++ b/dwio/nimble/index/IndexReader.cpp
@@ -35,11 +35,9 @@ IndexReader::IndexReader(
     std::unique_ptr<velox::dwio::common::SeekableInputStream> input,
     uint32_t stripeIndex,
     std::shared_ptr<StripeIndexGroup> indexGroup,
-    bool noDuplicateKey,
     velox::memory::MemoryPool* pool)
     : stripeIndex_{stripeIndex},
       indexGroup_{std::move(indexGroup)},
-      noDuplicateKey_{noDuplicateKey},
       input_{std::move(input)},
       pool_{pool} {
   NIMBLE_CHECK_NOT_NULL(input_);
@@ -50,14 +48,9 @@ std::unique_ptr<IndexReader> IndexReader::create(
     std::unique_ptr<velox::dwio::common::SeekableInputStream> input,
     uint32_t stripeIndex,
     std::shared_ptr<StripeIndexGroup> indexGroup,
-    bool noDuplicateKey,
     velox::memory::MemoryPool* pool) {
   return std::unique_ptr<IndexReader>(new IndexReader(
-      std::move(input),
-      stripeIndex,
-      std::move(indexGroup),
-      noDuplicateKey,
-      pool));
+      std::move(input), stripeIndex, std::move(indexGroup), pool));
 }
 
 std::optional<uint32_t> IndexReader::seekAtOrAfter(

--- a/dwio/nimble/index/IndexReader.h
+++ b/dwio/nimble/index/IndexReader.h
@@ -44,7 +44,6 @@ class IndexReader {
       std::unique_ptr<velox::dwio::common::SeekableInputStream> input,
       uint32_t stripeIndex,
       std::shared_ptr<StripeIndexGroup> indexGroup,
-      bool noDuplicateKey,
       velox::memory::MemoryPool* pool);
 
   /// Seek to the position at or after the given encoded key.
@@ -57,7 +56,6 @@ class IndexReader {
       std::unique_ptr<velox::dwio::common::SeekableInputStream> input,
       uint32_t stripeIndex,
       std::shared_ptr<StripeIndexGroup> indexGroup,
-      bool noDuplicateKey,
       velox::memory::MemoryPool* pool);
 
   /// Seek to a key at or after the given encoded key within a chunk.
@@ -80,7 +78,6 @@ class IndexReader {
 
   const uint32_t stripeIndex_;
   const std::shared_ptr<StripeIndexGroup> indexGroup_;
-  const bool noDuplicateKey_;
 
   const std::unique_ptr<velox::dwio::common::SeekableInputStream> input_;
   velox::memory::MemoryPool* const pool_;

--- a/dwio/nimble/index/TabletIndex.cpp
+++ b/dwio/nimble/index/TabletIndex.cpp
@@ -80,10 +80,6 @@ std::vector<SortOrder> getSortOrders(const serialization::Index* indexRoot) {
   return result;
 }
 
-bool getNoDuplicateKey(const serialization::Index* indexRoot) {
-  return indexRoot->no_duplicate_key();
-}
-
 } // namespace
 
 std::unique_ptr<TabletIndex> TabletIndex::create(Section indexSection) {
@@ -97,8 +93,7 @@ TabletIndex::TabletIndex(Section indexSection)
       numIndexGroups_{getIndexGroupCount(indexRoot_)},
       stripeKeys_{getStripeKeys(indexRoot_)},
       indexColumns_{getIndexColumns(indexRoot_)},
-      sortOrders_{getSortOrders(indexRoot_)},
-      noDuplicateKey_{getNoDuplicateKey(indexRoot_)} {
+      sortOrders_{getSortOrders(indexRoot_)} {
   NIMBLE_CHECK(!indexColumns_.empty());
   NIMBLE_CHECK_EQ(numStripes_ + 1, stripeKeys_.size());
   NIMBLE_CHECK_EQ(indexColumns_.size(), sortOrders_.size());

--- a/dwio/nimble/index/TabletIndex.h
+++ b/dwio/nimble/index/TabletIndex.h
@@ -127,14 +127,6 @@ class TabletIndex {
     return sortOrders_;
   }
 
-  /// Returns whether the index was built with no duplicate keys.
-  /// When true, seek operations can return immediately upon exact match.
-  ///
-  /// @return True if index has no duplicate keys
-  bool noDuplicateKey() const {
-    return noDuplicateKey_;
-  }
-
   /// Returns metadata for a specific index group.
   ///
   /// @param groupIndex The zero-based stripe group index.
@@ -161,7 +153,6 @@ class TabletIndex {
   const std::vector<std::string_view> stripeKeys_;
   const std::vector<std::string> indexColumns_;
   const std::vector<SortOrder> sortOrders_;
-  const bool noDuplicateKey_;
 };
 
 } // namespace facebook::nimble::index

--- a/dwio/nimble/index/tests/IndexReaderTest.cpp
+++ b/dwio/nimble/index/tests/IndexReaderTest.cpp
@@ -114,14 +114,14 @@ TEST_F(IndexReaderTest, singleChunkSingleKey) {
       createTestTabletIndex(indexColumns, minKey, stripes, stripeGroups);
   auto stripeIndexGroup =
       createStripeIndexGroup(indexBuffers, /*stripeGroupIndex=*/0);
+
   auto reader = IndexReader::create(
       createInputStream(encodedStream.data),
-      0,
+      /*stripeIndex=*/0,
       stripeIndexGroup,
-      /*noDuplicateKey=*/false,
       pool_.get());
 
-  // Test exact matches, keys between existing keys
+  // Test exact key match
   auto result = reader->seekAtOrAfter("key_a");
   ASSERT_TRUE(result.has_value());
   EXPECT_EQ(result.value(), 0);
@@ -157,11 +157,7 @@ TEST_F(IndexReaderTest, singleChunkMultipleKeys) {
       createStripeIndexGroup(indexBuffers, /*stripeGroupIndex=*/0);
 
   auto reader = IndexReader::create(
-      createInputStream(encodedStream.data),
-      0,
-      stripeIndexGroup,
-      /*noDuplicateKey=*/false,
-      pool_.get());
+      createInputStream(encodedStream.data), 0, stripeIndexGroup, pool_.get());
 
   // Test exact matches, keys between existing keys, and keys after last key.
   // Keys between existing keys should return the next key's row.
@@ -217,11 +213,7 @@ TEST_F(IndexReaderTest, multipleChunks) {
       createStripeIndexGroup(indexBuffers, /*stripeGroupIndex=*/0);
 
   auto reader = IndexReader::create(
-      createInputStream(encodedStream.data),
-      0,
-      stripeIndexGroup,
-      /*noDuplicateKey=*/false,
-      pool_.get());
+      createInputStream(encodedStream.data), 0, stripeIndexGroup, pool_.get());
 
   // Test keys across all chunks with mixed found/not-found cases.
   // Chunk 0: row offset 0, Chunk 1: row offset 3, Chunk 2: row offset 6
@@ -281,11 +273,7 @@ TEST_F(IndexReaderTest, seekBetweenChunks) {
       createStripeIndexGroup(indexBuffers, /*stripeGroupIndex=*/0);
 
   auto reader = IndexReader::create(
-      createInputStream(encodedStream.data),
-      0,
-      stripeIndexGroup,
-      /*noDuplicateKey=*/false,
-      pool_.get());
+      createInputStream(encodedStream.data), 0, stripeIndexGroup, pool_.get());
 
   // Key falls between chunk 0's max (ccc) and chunk 1's content (ddd)
   // The index lookup should direct us to chunk 1, and we find ddd
@@ -357,11 +345,7 @@ TEST_F(IndexReaderTest, multipleStripes) {
 
   // Test reader for stripe 0
   auto reader0 = IndexReader::create(
-      createInputStream(encodedStream0.data),
-      0,
-      stripeIndexGroup,
-      /*noDuplicateKey=*/false,
-      pool_.get());
+      createInputStream(encodedStream0.data), 0, stripeIndexGroup, pool_.get());
 
   auto result = reader0->seekAtOrAfter("key_a");
   ASSERT_TRUE(result.has_value());
@@ -373,11 +357,7 @@ TEST_F(IndexReaderTest, multipleStripes) {
 
   // Test reader for stripe 1
   auto reader1 = IndexReader::create(
-      createInputStream(encodedStream1.data),
-      1,
-      stripeIndexGroup,
-      /*noDuplicateKey=*/false,
-      pool_.get());
+      createInputStream(encodedStream1.data), 1, stripeIndexGroup, pool_.get());
 
   result = reader1->seekAtOrAfter("key_d");
   ASSERT_TRUE(result.has_value());
@@ -408,11 +388,7 @@ TEST_F(IndexReaderTest, emptyStringKey) {
       createStripeIndexGroup(indexBuffers, /*stripeGroupIndex=*/0);
 
   auto reader = IndexReader::create(
-      createInputStream(encodedStream.data),
-      0,
-      stripeIndexGroup,
-      /*noDuplicateKey=*/false,
-      pool_.get());
+      createInputStream(encodedStream.data), 0, stripeIndexGroup, pool_.get());
 
   // Test empty string key
   auto result = reader->seekAtOrAfter("");
@@ -452,11 +428,7 @@ TEST_F(IndexReaderTest, largeNumberOfKeys) {
       createStripeIndexGroup(indexBuffers, /*stripeGroupIndex=*/0);
 
   auto reader = IndexReader::create(
-      createInputStream(encodedStream.data),
-      0,
-      stripeIndexGroup,
-      /*noDuplicateKey=*/false,
-      pool_.get());
+      createInputStream(encodedStream.data), 0, stripeIndexGroup, pool_.get());
 
   // Test some specific keys
   std::vector<int> testIndices = {0, 1, 10, 100, 500, 999};
@@ -512,11 +484,7 @@ TEST_F(IndexReaderTest, repeatedSeeksToSameChunk) {
       createStripeIndexGroup(indexBuffers, /*stripeGroupIndex=*/0);
 
   auto reader = IndexReader::create(
-      createInputStream(encodedStream.data),
-      0,
-      stripeIndexGroup,
-      /*noDuplicateKey=*/false,
-      pool_.get());
+      createInputStream(encodedStream.data), 0, stripeIndexGroup, pool_.get());
 
   // Test repeated seeks within each chunk and across chunks.
   // Mix forward, backward, and repeated seeks to test caching behavior.
@@ -566,11 +534,7 @@ TEST_F(IndexReaderTest, unevenChunkSizes) {
       createStripeIndexGroup(indexBuffers, /*stripeGroupIndex=*/0);
 
   auto reader = IndexReader::create(
-      createInputStream(encodedStream.data),
-      0,
-      stripeIndexGroup,
-      /*noDuplicateKey=*/false,
-      pool_.get());
+      createInputStream(encodedStream.data), 0, stripeIndexGroup, pool_.get());
 
   // Chunk 0: row offset 0, 1 key
   // Chunk 1: row offset 1, 5 keys
@@ -626,11 +590,7 @@ TEST_F(IndexReaderTest, binaryKeys) {
       createStripeIndexGroup(indexBuffers, /*stripeGroupIndex=*/0);
 
   auto reader = IndexReader::create(
-      createInputStream(encodedStream.data),
-      0,
-      stripeIndexGroup,
-      /*noDuplicateKey=*/false,
-      pool_.get());
+      createInputStream(encodedStream.data), 0, stripeIndexGroup, pool_.get());
 
   // Test exact matches and not-found cases for binary keys.
   // Keys after the last key should return std::nullopt.

--- a/dwio/nimble/tablet/Index.fbs
+++ b/dwio/nimble/tablet/Index.fbs
@@ -79,11 +79,6 @@ table Index {
   stripe_counts:[uint32];
   /// Metadata sections for each stripe index group.
   stripe_index_groups:[MetadataSection];
-  /// If true, indicates that the index was built with no duplicate keys.
-  /// This enables optimized seek operations that can return immediately
-  /// upon finding an exact match, rather than scanning for duplicates.
-  /// Defaults to false for backward compatibility.
-  no_duplicate_key:bool = false;
 }
 
 root_type Index;

--- a/dwio/nimble/tablet/TabletIndexWriter.cpp
+++ b/dwio/nimble/tablet/TabletIndexWriter.cpp
@@ -419,8 +419,7 @@ void TabletIndexWriter::writeRootIndex(
           indexColumnsVector,
           sortOrdersVector,
           stripeCountsVector,
-          stripeIndexGroupsVector,
-          config_.noDuplicateKey));
+          stripeIndexGroupsVector));
   writeOptionalSection(std::string(kIndexSection), asView(builder));
 }
 

--- a/dwio/nimble/tablet/tests/TabletTest.cpp
+++ b/dwio/nimble/tablet/tests/TabletTest.cpp
@@ -3466,93 +3466,73 @@ TEST_F(TabletWithIndexTest, streamDeduplication) {
 
 TEST_F(TabletWithIndexTest, keyOrderEnforcement) {
   // Test key order enforcement behavior with enforceKeyOrder = true/false
-  // Test both out-of-order keys and duplicate keys scenarios
-  enum class TestCase { kOutOfOrder, kDuplicateKeys };
-
   for (bool enforceKeyOrder : {true, false}) {
-    for (auto testCase : {TestCase::kOutOfOrder, TestCase::kDuplicateKeys}) {
-      SCOPED_TRACE(
-          fmt::format(
-              "enforceKeyOrder={}, testCase={}",
-              enforceKeyOrder,
-              testCase == TestCase::kOutOfOrder ? "OutOfOrder"
-                                                : "DuplicateKeys"));
+    SCOPED_TRACE(fmt::format("enforceKeyOrder={}", enforceKeyOrder));
 
-      std::string file;
-      velox::InMemoryWriteFile writeFile(&file);
+    std::string file;
+    velox::InMemoryWriteFile writeFile(&file);
 
-      nimble::TabletIndexConfig indexConfig{
-          .columns = {"col1"},
-          .sortOrders = {SortOrder{.ascending = true}},
-          .enforceKeyOrder = enforceKeyOrder,
-          .noDuplicateKey = enforceKeyOrder,
-      };
+    nimble::TabletIndexConfig indexConfig{
+        .columns = {"col1"},
+        .sortOrders = {SortOrder{.ascending = true}},
+        .enforceKeyOrder = enforceKeyOrder,
+        .noDuplicateKey = enforceKeyOrder,
+    };
 
-      auto tabletWriter = nimble::TabletWriter::create(
-          &writeFile,
-          *pool_,
-          {
-              .indexConfig = indexConfig,
-          });
+    auto tabletWriter = nimble::TabletWriter::create(
+        &writeFile,
+        *pool_,
+        {
+            .indexConfig = indexConfig,
+        });
 
-      nimble::Buffer buffer{*pool_};
+    nimble::Buffer buffer{*pool_};
 
-      // Write first stripe with key ending at "ddd"
-      {
-        std::vector<nimble::Stream> streams;
-        auto pos = buffer.reserve(10);
-        std::memset(pos, 'A', 10);
-        streams.push_back(
-            {.offset = 0,
-             .chunks = {{.rowCount = 100, .content = {{pos, 10}}}}});
+    // Write first stripe with key ending at "ddd"
+    {
+      std::vector<nimble::Stream> streams;
+      auto pos = buffer.reserve(10);
+      std::memset(pos, 'A', 10);
+      streams.push_back(
+          {.offset = 0, .chunks = {{.rowCount = 100, .content = {{pos, 10}}}}});
 
-        auto keyStream = createKeyStream(
-            buffer, {{.rowCount = 100, .firstKey = "ccc", .lastKey = "ddd"}});
-        tabletWriter->writeStripe(
-            100, std::move(streams), std::move(keyStream));
-      }
+      auto keyStream = createKeyStream(
+          buffer, {{.rowCount = 100, .firstKey = "ccc", .lastKey = "ddd"}});
+      tabletWriter->writeStripe(100, std::move(streams), std::move(keyStream));
+    }
 
-      // Write second stripe with invalid key ordering
-      {
-        std::vector<nimble::Stream> streams;
-        auto pos = buffer.reserve(10);
-        std::memset(pos, 'B', 10);
-        streams.push_back(
-            {.offset = 0,
-             .chunks = {{.rowCount = 100, .content = {{pos, 10}}}}});
+    // Write second stripe with key ending before "ddd" (out of order)
+    {
+      std::vector<nimble::Stream> streams;
+      auto pos = buffer.reserve(10);
+      std::memset(pos, 'B', 10);
+      streams.push_back(
+          {.offset = 0, .chunks = {{.rowCount = 100, .content = {{pos, 10}}}}});
 
-        // Create key stream based on test case:
-        // - OutOfOrder: Key "bbb" < previous "ddd"
-        // - DuplicateKeys: Key "ddd" == previous "ddd"
-        auto keyStream = testCase == TestCase::kOutOfOrder
-            ? createKeyStream(
-                  buffer,
-                  {{.rowCount = 100, .firstKey = "aaa", .lastKey = "bbb"}})
-            : createKeyStream(
-                  buffer,
-                  {{.rowCount = 100, .firstKey = "ddd", .lastKey = "ddd"}});
+      // Key "bbb" < "ddd", out of order
+      auto keyStream = createKeyStream(
+          buffer, {{.rowCount = 100, .firstKey = "aaa", .lastKey = "bbb"}});
 
-        if (enforceKeyOrder) {
-          // Should throw when enforceKeyOrder is true
-          NIMBLE_ASSERT_USER_THROW(
-              tabletWriter->writeStripe(
-                  100, std::move(streams), std::move(keyStream)),
-              "Stripe keys must be in strictly ascending order (duplicates are not allowed)");
-        } else {
-          // Should NOT throw when enforceKeyOrder is false
-          EXPECT_NO_THROW(tabletWriter->writeStripe(
-              100, std::move(streams), std::move(keyStream)));
+      if (enforceKeyOrder) {
+        // Should throw when enforceKeyOrder is true
+        NIMBLE_ASSERT_USER_THROW(
+            tabletWriter->writeStripe(
+                100, std::move(streams), std::move(keyStream)),
+            "Stripe keys must be in strictly ascending order");
+      } else {
+        // Should NOT throw when enforceKeyOrder is false
+        EXPECT_NO_THROW(tabletWriter->writeStripe(
+            100, std::move(streams), std::move(keyStream)));
 
-          tabletWriter->close();
-          writeFile.close();
+        tabletWriter->close();
+        writeFile.close();
 
-          // Verify file is readable
-          nimble::testing::InMemoryTrackableReadFile readFile(file, false);
-          auto tablet = nimble::TabletReader::create(&readFile, *pool_);
-          EXPECT_EQ(tablet->stripeCount(), 2);
-          EXPECT_TRUE(
-              tablet->hasOptionalSection(std::string(nimble::kIndexSection)));
-        }
+        // Verify file is readable
+        nimble::testing::InMemoryTrackableReadFile readFile(file, false);
+        auto tablet = nimble::TabletReader::create(&readFile, *pool_);
+        EXPECT_EQ(tablet->stripeCount(), 2);
+        EXPECT_TRUE(
+            tablet->hasOptionalSection(std::string(nimble::kIndexSection)));
       }
     }
   }

--- a/dwio/nimble/velox/selective/SelectiveNimbleReader.cpp
+++ b/dwio/nimble/velox/selective/SelectiveNimbleReader.cpp
@@ -611,12 +611,10 @@ void SelectiveNimbleRowReader::buildIndexReader(NimbleParams& params) {
   if ((currentStripe_ != startStripe_) && (currentStripe_ != endStripe_ - 1)) {
     return;
   }
-  NIMBLE_CHECK_NOT_NULL(tabletIndex_);
   indexReader_ = index::IndexReader::create(
       params.streams().enqueueKeyStream(),
       params.streams().stripeIndex(),
       params.streams().indexGroup(),
-      tabletIndex_->noDuplicateKey(),
       &params.pool());
 }
 

--- a/dwio/nimble/velox/tests/VeloxWriterTest.cpp
+++ b/dwio/nimble/velox/tests/VeloxWriterTest.cpp
@@ -3743,6 +3743,113 @@ TEST_F(VeloxWriterTest, indexEnforceKeyOrder) {
   }
 }
 
+TEST_P(VeloxWriterIndexTest, duplicateKeys) {
+  // Test index with duplicate key values (non-unique keys).
+  // This is a valid scenario where multiple rows have the same key value.
+  auto type = defaultType();
+
+  nimble::IndexConfig indexConfig = createIndexConfig({"key_col"});
+
+  std::string file;
+  auto writeFile = std::make_unique<velox::InMemoryWriteFile>(&file);
+
+  // constexpr int kNumBatches = 10;
+  constexpr int kNumBatches = 1;
+  // constexpr int kBatchSize = 100;
+  constexpr int kBatchSize = 32;
+  constexpr uint32_t kSeed = 12345;
+  // Use flush-per-batch to create multiple stripes
+  nimble::VeloxWriter writer(
+      type,
+      std::move(writeFile),
+      *rootPool_,
+      createWriterOptions(indexConfig, []() {
+        return std::make_unique<nimble::LambdaFlushPolicy>(
+            [](auto) { return true; }, [](auto) { return false; });
+      }));
+
+  velox::test::VectorMaker vectorMaker{leafPool_.get()};
+
+  // Configure fuzzer to generate various encodings for non-key columns
+  velox::VectorFuzzer::Options fuzzerOpts;
+  fuzzerOpts.vectorSize = kBatchSize;
+  fuzzerOpts.nullRatio = 0.1;
+  fuzzerOpts.containerLength = 5;
+  fuzzerOpts.stringLength = 20;
+  fuzzerOpts.containerVariableLength = true;
+  velox::VectorFuzzer fuzzer(fuzzerOpts, leafPool_.get(), kSeed);
+
+  // Generate pre-sorted batches with duplicate keys.
+  // Each key value repeats 5 times before incrementing.
+  std::vector<velox::RowVectorPtr> batches;
+  int64_t keyVal = 0;
+  for (int batch = 0; batch < kNumBatches; ++batch) {
+    std::vector<int64_t> keyValues;
+
+    for (int i = 0; i < kBatchSize; ++i) {
+      keyValues.push_back(keyVal);
+      // Increment key every 5 rows to create duplicates
+      if (((batch * kBatchSize + i + 1) % 5) == 0) {
+        ++keyVal;
+      }
+    }
+
+    // Build children: key column + fuzzed non-key columns
+    std::vector<velox::VectorPtr> children;
+    children.push_back(vectorMaker.flatVector<int64_t>(keyValues));
+    for (size_t colIdx = 1; colIdx < type->size(); ++colIdx) {
+      children.push_back(fuzzer.fuzz(type->childAt(colIdx)));
+    }
+
+    auto batchVec = std::make_shared<velox::RowVector>(
+        leafPool_.get(),
+        type,
+        nullptr, // no nulls at top level
+        kBatchSize,
+        std::move(children));
+    batches.push_back(batchVec);
+    writer.write(batchVec);
+  }
+  writer.close();
+
+  // Read and verify
+  velox::InMemoryReadFile readFile(file);
+  nimble::VeloxReader reader(&readFile, *leafPool_);
+
+  const auto& tablet = reader.tabletReader();
+
+  // Verify index exists
+  const auto* index = tablet.index();
+  ASSERT_NE(index, nullptr);
+  EXPECT_EQ(index->indexColumns().size(), 1);
+  EXPECT_EQ(index->indexColumns()[0], "key_col");
+
+  // Verify stripe keys are monotonically increasing (even with duplicates)
+  for (uint32_t i = 1; i < index->numStripes(); ++i) {
+    EXPECT_LE(index->stripeKey(i - 1), index->stripeKey(i))
+        << "Stripe keys should be in non-descending order";
+  }
+
+  // Verify we can look up stripes by key
+  auto firstLocation = index->lookup(index->minKey());
+  ASSERT_TRUE(firstLocation.has_value());
+  EXPECT_EQ(firstLocation->stripeIndex, 0);
+
+  auto lastLocation = index->lookup(index->maxKey());
+  ASSERT_TRUE(lastLocation.has_value());
+  EXPECT_EQ(lastLocation->stripeIndex, index->numStripes() - 1);
+
+  // Read back all data and verify row-by-row match with written batches
+  verifyFileData(file, type, batches);
+
+  // Verify position index chunk row counts
+  verifyPositionIndex(tablet);
+
+  // Verify value index maps each key to correct row position
+  // With duplicate keys, lookup should find the first occurrence
+  verifyValueIndex(tablet, &readFile, type, batches, {"key_col"});
+}
+
 TEST_P(VeloxWriterIndexTest, chunking) {
   // Test index with chunking enabled
   auto type = defaultType();


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebookincubator/velox/pull/16321

The change allows PrefixEncoding to use noDuplicate parameter to go for a fast path searching (terminate early without needing to continuing binary search or scanning).

Differential Revision: D92676762


