### PR TITLE
feat: Add batched index bounds encoding support to KeyEncoder

### DIFF
--- a/dwio/nimble/velox/selective/SelectiveNimbleReader.cpp
+++ b/dwio/nimble/velox/selective/SelectiveNimbleReader.cpp
@@ -521,7 +521,13 @@ void SelectiveNimbleRowReader::maybeSetIndexBounds() {
       asRowType(result->indexBounds.type()),
       toVeloxSortOrders(sortOrders, result->indexBounds.indexColumns.size()),
       readerBase_->pool());
-  encodedKeyBounds_ = keyEncoder->encodeIndexBounds(result->indexBounds);
+  auto encodedBounds = keyEncoder->encodeIndexBounds(result->indexBounds);
+  NIMBLE_CHECK_EQ(
+      encodedBounds.size(),
+      1,
+      "Expected single encoded bounds, got {}",
+      encodedBounds.size());
+  encodedKeyBounds_ = std::move(encodedBounds[0]);
 
   updateStartStripeFromLowerIndexBound();
   updateEndStripeFromUpperIndexBound();


### PR DESCRIPTION
Summary:
Enhances KeyEncoder to support batched index bounds encoding and updates the API to return a vector of encoded bounds instead of a single optional value.

Batched encoding support - encodeIndexBounds() now returns std::vector<EncodedKeyBounds>
Error handling change - The method throws on lower bound bump up failure instead of returning std::nullopt

IndexBounds API additions - set(), clear(), numRows() methods which will be used by HiveIndexReader for batch key bound encoding

SelectiveNimbleReader update - Handles the new vector return type

Differential Revision: D92646609


