### PR TITLE
feat: Support stripe level batched index read

### DIFF
--- a/dwio/nimble/index/TabletIndex.cpp
+++ b/dwio/nimble/index/TabletIndex.cpp
@@ -20,7 +20,9 @@
 #include "dwio/nimble/common/Exceptions.h"
 #include "dwio/nimble/tablet/IndexGenerated.h"
 #include "dwio/nimble/tablet/MetadataBuffer.h"
+#include "folly/String.h"
 #include "folly/json/json.h"
+#include "folly/logging/xlog.h"
 
 namespace facebook::nimble::index {
 
@@ -122,7 +124,6 @@ std::optional<StripeLocation> TabletIndex::lookup(
 
   // Calculate which stripe contains the key
   const uint32_t targetStripe = (it - stripeKeys_.begin()) - 1;
-
   // Check if the key is beyond all stripes
   if (targetStripe >= numStripes_) {
     return std::nullopt;

--- a/dwio/nimble/index/tests/IndexTestUtils.cpp
+++ b/dwio/nimble/index/tests/IndexTestUtils.cpp
@@ -60,12 +60,16 @@ void writeFile(
     const std::string& filePath,
     const std::vector<velox::RowVectorPtr>& data,
     IndexConfig indexConfig,
-    velox::memory::MemoryPool& pool) {
+    velox::memory::MemoryPool& pool,
+    std::function<std::unique_ptr<FlushPolicy>()> flushPolicyFactory) {
   NIMBLE_CHECK(!data.empty(), "Data must not be empty");
 
   VeloxWriterOptions options;
   options.enableChunking = true;
   options.indexConfig = std::move(indexConfig);
+  if (flushPolicyFactory) {
+    options.flushPolicyFactory = std::move(flushPolicyFactory);
+  }
 
   auto fs = velox::filesystems::getFileSystem(filePath, {});
   auto writeFile = fs->openFileForWrite(

--- a/dwio/nimble/index/tests/IndexTestUtils.h
+++ b/dwio/nimble/index/tests/IndexTestUtils.h
@@ -65,11 +65,15 @@ std::vector<velox::RowVectorPtr> generateData(
 /// @param data Vector of RowVectorPtr to write.
 /// @param indexConfig Index configuration specifying columns, sort orders, etc.
 /// @param pool Memory pool for writing.
+/// @param flushPolicyFactory Optional factory for custom flush policy to
+/// control
+///        stripe sizes. If not provided, uses default flush policy.
 void writeFile(
     const std::string& filePath,
     const std::vector<velox::RowVectorPtr>& data,
     IndexConfig indexConfig,
-    velox::memory::MemoryPool& pool);
+    velox::memory::MemoryPool& pool,
+    std::function<std::unique_ptr<FlushPolicy>()> flushPolicyFactory = nullptr);
 
 /// Simple StreamLoader implementation for testing that holds data in memory.
 class TestStreamLoader : public StreamLoader {

--- a/dwio/nimble/velox/selective/SelectiveNimbleIndexReader.cpp
+++ b/dwio/nimble/velox/selective/SelectiveNimbleIndexReader.cpp
@@ -1,0 +1,749 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "dwio/nimble/velox/selective/SelectiveNimbleIndexReader.h"
+
+#include <utility>
+
+#include "dwio/nimble/encodings/EncodingFactory.h"
+#include "dwio/nimble/encodings/legacy/EncodingFactory.h"
+#include "dwio/nimble/index/IndexReader.h"
+#include "dwio/nimble/velox/SchemaUtils.h"
+#include "dwio/nimble/velox/selective/ColumnReader.h"
+#include "dwio/nimble/velox/selective/ReaderBase.h"
+#include "dwio/nimble/velox/selective/RowSizeTracker.h"
+#include "velox/common/base/RuntimeMetrics.h"
+#include "velox/serializers/KeyEncoder.h"
+
+namespace facebook::nimble {
+
+using namespace facebook::velox;
+
+namespace {
+
+// Converts index column names from nimble schema (internal file names) to
+// file schema (user-facing names).
+std::vector<std::string> convertIndexColumnsToFileSchema(
+    const std::vector<std::string>& nimbleIndexColumns,
+    const std::shared_ptr<const Type>& nimbleSchema,
+    const RowTypePtr& fileSchema) {
+  const auto nimbleRowType = asRowType(convertToVeloxType(*nimbleSchema));
+
+  std::vector<std::string> convertedIndexColumns;
+  convertedIndexColumns.reserve(nimbleIndexColumns.size());
+  for (const auto& nimbleColName : nimbleIndexColumns) {
+    const auto colIndex = nimbleRowType->getChildIdxIfExists(nimbleColName);
+    NIMBLE_CHECK(
+        colIndex.has_value(),
+        "Index column '{}' not found in nimble schema: {}",
+        nimbleColName,
+        nimbleRowType->toString());
+    convertedIndexColumns.push_back(fileSchema->nameOf(colIndex.value()));
+  }
+  return convertedIndexColumns;
+}
+
+// Converts nimble SortOrders to velox::core::SortOrders.
+std::vector<velox::core::SortOrder> toVeloxSortOrders(
+    const std::vector<SortOrder>& sortOrders,
+    size_t numBoundColumns) {
+  std::vector<velox::core::SortOrder> veloxSortOrders;
+  veloxSortOrders.reserve(numBoundColumns);
+  for (size_t i = 0; i < numBoundColumns; ++i) {
+    veloxSortOrders.push_back(sortOrders[i].toVeloxSortOrder());
+  }
+  return veloxSortOrders;
+}
+
+} // namespace
+
+size_t SelectiveNimbleIndexReader::RowRangeHash::operator()(
+    const RowRange& range) const {
+  return folly::hash::hash_combine(range.startRow, range.endRow);
+}
+
+void SelectiveNimbleIndexReader::RequestState::incPendingStripes() {
+  ++pendingStripes;
+}
+
+void SelectiveNimbleIndexReader::RequestState::decPendingStripes() {
+  VELOX_CHECK_GT(pendingStripes, 0);
+  --pendingStripes;
+}
+
+std::string SelectiveNimbleIndexReader::ReadSegment::toString() const {
+  std::string requestIndicesStr;
+  for (size_t i = 0; i < requestIndices.size(); ++i) {
+    if (i > 0) {
+      requestIndicesStr += ", ";
+    }
+    requestIndicesStr += std::to_string(requestIndices[i]);
+  }
+  return fmt::format(
+      "ReadSegment{{rowRange: {}, requestIndices: [{}]}}",
+      rowRange.toString(),
+      requestIndicesStr);
+}
+
+void SelectiveNimbleIndexReader::OutputChunk::dropRef() {
+  NIMBLE_CHECK_GT(refCount, 0);
+  if (--refCount == 0) {
+    data.reset();
+  }
+}
+
+SelectiveNimbleIndexReader::SelectiveNimbleIndexReader(
+    std::shared_ptr<ReaderBase> readerBase,
+    const dwio::common::RowReaderOptions& options)
+    : readerBase_(std::move(readerBase)),
+      options_(options),
+      rowSizeTracker_(
+          std::make_unique<RowSizeTracker>(readerBase_->fileSchemaWithId())),
+      hasFilters_(options.scanSpec()->hasFilter()),
+      outputType_(
+          options.requestedType() ? options.requestedType()
+                                  : readerBase_->fileSchema()),
+      tabletIndex_{readerBase_->tablet().index()},
+      indexColumns_{convertIndexColumnsToFileSchema(
+          tabletIndex_->indexColumns(),
+          readerBase_->nimbleSchema(),
+          readerBase_->fileSchema())},
+      streams_{readerBase_} {
+  initReadRange();
+}
+
+void SelectiveNimbleIndexReader::startLookup(
+    const velox::serializer::IndexBounds& indexBounds) {
+  reset();
+
+  numRequests_ = indexBounds.numRows();
+  // Encode the index bounds.
+  encodedKeyBounds_ = encodeIndexBounds(indexBounds);
+  NIMBLE_CHECK_EQ(
+      encodedKeyBounds_.size(),
+      numRequests_,
+      "Encoded key bounds size mismatch");
+
+  // Build stripe to request mapping.
+  mapRequestsToStripes();
+
+  // Initialize request output tracking.
+  nextOutputRequest_ = 0;
+  lastReadyOutputRequest_ = -1;
+  readyOutputRows_ = 0;
+
+  // Report lookup stats.
+  addThreadLocalRuntimeStat(
+      dwio::common::IndexReader::kNumIndexLookupRequests,
+      velox::RuntimeCounter(numRequests_));
+  addThreadLocalRuntimeStat(
+      dwio::common::IndexReader::kNumIndexLookupStripes,
+      velox::RuntimeCounter(stripes_.size()));
+}
+
+bool SelectiveNimbleIndexReader::hasNext() const {
+  return numRequests_ > 0 &&
+      (stripeIndex_ < stripes_.size() || readyOutputRows_ > 0 ||
+       nextOutputRequest_ <= lastReadyOutputRequest_);
+}
+
+std::unique_ptr<connector::IndexSource::Result>
+SelectiveNimbleIndexReader::next(vector_size_t maxOutputRows) {
+  NIMBLE_CHECK_GT(numRequests_, 0, "No lookup in progress");
+
+  // Process stripes until we can produce output or finish.
+  while (stripeIndex_ < stripes_.size() && !canProduceOutput(maxOutputRows)) {
+    if (!loadStripe()) {
+      continue;
+    }
+    NIMBLE_CHECK(stripeLoaded_);
+
+    // Process segments within this stripe.
+    while (readSegmentIndex_ < readSegments_.size() &&
+           !canProduceOutput(maxOutputRows)) {
+      auto& segment = readSegments_[readSegmentIndex_];
+      RowVectorPtr segmentOutput;
+      const uint64_t readRows = readStripeFragment(segmentOutput);
+      VELOX_CHECK_EQ(readRows, segment.rowRange.numRows());
+      addStripeSegmentOutput(segment, segmentOutput);
+      advanceStripeReadSegment();
+    }
+
+    advanceStripe();
+  }
+
+  return produceOutput();
+}
+
+void SelectiveNimbleIndexReader::initReadRange() {
+  const auto& tablet = readerBase_->tablet();
+  // Index reader always reads from the entire file.
+  numStripes_ = tablet.stripeCount();
+  int64_t numRows = 0;
+  stripeRowOffsets_.resize(numStripes_);
+  // Sanity check: options should cover the entire file.
+  const auto low = options_.offset();
+  const auto high = options_.limit();
+  for (int i = 0; i < numStripes_; ++i) {
+    NIMBLE_CHECK(
+        low <= tablet.stripeOffset(i) && tablet.stripeOffset(i) < high,
+        "Index reader requires options to cover the entire file, but stripe {} "
+        "at offset {} is outside range [{}, {})",
+        i,
+        tablet.stripeOffset(i),
+        low,
+        high);
+    stripeRowOffsets_[i] = numRows;
+    numRows += tablet.stripeRowCount(i);
+  }
+}
+
+std::vector<velox::serializer::EncodedKeyBounds>
+SelectiveNimbleIndexReader::encodeIndexBounds(
+    const velox::serializer::IndexBounds& indexBounds) {
+  NIMBLE_CHECK_NOT_NULL(tabletIndex_);
+  if (keyEncoder_ == nullptr) {
+    const auto& sortOrders = tabletIndex_->sortOrders();
+    keyEncoder_ = velox::serializer::KeyEncoder::create(
+        indexBounds.indexColumns,
+        asRowType(indexBounds.type()),
+        toVeloxSortOrders(sortOrders, indexBounds.indexColumns.size()),
+        readerBase_->pool());
+  }
+  return keyEncoder_->encodeIndexBounds(indexBounds);
+}
+
+void SelectiveNimbleIndexReader::mapRequestsToStripes() {
+  stripes_.clear();
+  stripeToRequests_.clear();
+  stripeIndex_ = 0;
+  requestStates_.resize(numRequests_);
+
+  for (size_t requestIdx = 0; requestIdx < numRequests_; ++requestIdx) {
+    const auto& bounds = encodedKeyBounds_[requestIdx];
+    std::vector<uint32_t> requestStripes;
+
+    // Determine start stripe from lower bound.
+    uint32_t startStripe = 0;
+    if (bounds.lowerKey.has_value()) {
+      const auto lowerLocation = tabletIndex_->lookup(bounds.lowerKey.value());
+      if (lowerLocation.has_value()) {
+        startStripe = static_cast<uint32_t>(lowerLocation->stripeIndex);
+      } else if (bounds.lowerKey.value() > tabletIndex_->maxKey()) {
+        continue; // No stripes match.
+      }
+    }
+
+    // Determine end stripe from upper bound.
+    uint32_t endStripe = numStripes_;
+    if (bounds.upperKey.has_value()) {
+      const auto upperLocation = tabletIndex_->lookup(bounds.upperKey.value());
+      if (upperLocation.has_value()) {
+        endStripe = std::min(
+            endStripe, static_cast<uint32_t>(upperLocation->stripeIndex) + 1);
+      } else if (bounds.upperKey.value() < tabletIndex_->minKey()) {
+        continue; // No stripes match.
+      }
+    }
+
+    // Add stripes to the mapping.
+    for (uint32_t stripe = startStripe; stripe < endStripe; ++stripe) {
+      stripeToRequests_[stripe].push_back(requestIdx);
+      requestStates_[requestIdx].incPendingStripes();
+    }
+  }
+
+  // Collect and sort unique stripes.
+  stripes_.reserve(stripeToRequests_.size());
+  for (const auto& [stripe, _] : stripeToRequests_) {
+    stripes_.push_back(stripe);
+  }
+  std::sort(stripes_.begin(), stripes_.end());
+}
+
+bool SelectiveNimbleIndexReader::loadStripe() {
+  if (stripeLoaded_) {
+    return true;
+  }
+  const uint32_t stripeIndex = stripes_[stripeIndex_];
+  prepareStripeReading(stripeIndex);
+  if (readSegments_.empty()) {
+    ++stripeIndex_;
+    return false;
+  }
+  stripeLoaded_ = true;
+  return true;
+}
+
+void SelectiveNimbleIndexReader::prepareStripeReading(uint32_t stripeIndex) {
+  readSegments_.clear();
+  readSegmentIndex_ = 0;
+
+  auto it = stripeToRequests_.find(stripeIndex);
+  NIMBLE_CHECK(it != stripeToRequests_.end());
+  NIMBLE_CHECK(!it->second.empty());
+
+  auto& requestRows = it->second;
+
+  // Collect encoded bounds for requests in this stripe.
+  std::vector<velox::serializer::EncodedKeyBounds> stripeKeyBounds;
+  stripeKeyBounds.reserve(requestRows.size());
+  for (vector_size_t requestRow : requestRows) {
+    stripeKeyBounds.push_back(encodedKeyBounds_[requestRow]);
+  }
+
+  // Load the stripe and build index reader.
+  loadStripeWithIndex(stripeIndex);
+
+  // Get row ranges for all requests.
+  auto stripeRowRanges = lookupRowRanges(stripeIndex, stripeKeyBounds);
+  NIMBLE_CHECK_EQ(stripeRowRanges.size(), requestRows.size());
+
+  // Filter out empty ranges and store per-request row ranges.
+  std::vector<std::pair<vector_size_t, RowRange>> requestRanges;
+  requestRanges.reserve(requestRows.size());
+  for (size_t i = 0; i < requestRows.size(); ++i) {
+    const auto& range = stripeRowRanges[i];
+    if (!range.empty()) {
+      requestRanges.emplace_back(requestRows[i], range);
+      requestStates_[requestRows[i]].rowRange = range;
+    } else {
+      // Decrement pending stripes for requests with empty row ranges.
+      requestStates_[requestRows[i]].decPendingStripes();
+    }
+  }
+  // Update ready output requests after decrementing pending stripes for empty
+  // row ranges. This ensures requests with no matching rows in this stripe
+  // can still be marked as ready if all their stripes have been processed.
+  updateReadyOutputRequests();
+
+  // Update requestRows to only contain non-empty requests.
+  requestRows.clear();
+  for (const auto& [requestIdx, _] : requestRanges) {
+    requestRows.push_back(requestIdx);
+  }
+
+  if (requestRows.empty()) {
+    return;
+  }
+
+  buildStripeReadSegments(requestRanges);
+}
+
+void SelectiveNimbleIndexReader::buildStripeReadSegments(
+    const std::vector<std::pair<vector_size_t, RowRange>>& requestRanges) {
+  if (!hasFilters_) {
+    mergeStripeRowRanges(requestRanges);
+  } else {
+    splitStripeRowRanges(requestRanges);
+  }
+  VELOX_CHECK(!readSegments_.empty());
+
+  // Report read segment stats.
+  addThreadLocalRuntimeStat(
+      dwio::common::IndexReader::kNumIndexLookupReadSegments,
+      velox::RuntimeCounter(readSegments_.size()));
+
+  readSegmentIndex_ = 0;
+  prepareStripeSegmentRead();
+}
+
+void SelectiveNimbleIndexReader::mergeStripeRowRanges(
+    const std::vector<std::pair<vector_size_t, RowRange>>& requestRanges) {
+  VELOX_CHECK(!hasFilters_);
+  // No filter case: merge row ranges for efficient reading with seek.
+  // Each request will reference the appropriate portion of the merged read.
+
+  // Sort ranges by start row.
+  std::vector<RowRange> sortedRanges;
+  sortedRanges.reserve(requestRanges.size());
+  for (const auto& [_, range] : requestRanges) {
+    sortedRanges.push_back(range);
+  }
+  std::sort(
+      sortedRanges.begin(),
+      sortedRanges.end(),
+      [](const auto& a, const auto& b) { return a.startRow < b.startRow; });
+
+  // Merge overlapping ranges.
+  std::vector<RowRange> mergedRanges;
+  RowRange current = sortedRanges[0];
+  for (size_t i = 1; i < sortedRanges.size(); ++i) {
+    const auto& range = sortedRanges[i];
+    if (range.startRow <= current.endRow) {
+      current.endRow = std::max(current.endRow, range.endRow);
+    } else {
+      mergedRanges.push_back(current);
+      current = range;
+    }
+  }
+  mergedRanges.push_back(current);
+
+  // Create one read segment per merged range.
+  // Each segment references all requests that overlap with it.
+  for (const auto& mergedRange : mergedRanges) {
+    ReadSegment segment;
+    segment.rowRange = mergedRange;
+    for (const auto& [requestIdx, range] : requestRanges) {
+      // Check if merged range contains the request range.
+      if (mergedRange.contains(range)) {
+        segment.requestIndices.push_back(requestIdx);
+      }
+    }
+    // Each merged range must have at least one contained request.
+    NIMBLE_CHECK(
+        !segment.requestIndices.empty(),
+        "Merged range [{}, {}) has no contained requests",
+        mergedRange.startRow,
+        mergedRange.endRow);
+    readSegments_.push_back(std::move(segment));
+  }
+}
+
+void SelectiveNimbleIndexReader::splitStripeRowRanges(
+    const std::vector<std::pair<vector_size_t, RowRange>>& requestRanges) {
+  VELOX_CHECK(hasFilters_);
+  // Filter case: split overlapping ranges into non-overlapping segments.
+  // Example: [0,100) and [50,150) -> [0,50), [50,100), [100,150)
+  // Each segment is read separately, and requests reference their segments.
+
+  // Collect all unique boundary points.
+  std::vector<vector_size_t> boundaries;
+  boundaries.reserve(requestRanges.size() * 2);
+  for (const auto& [_, range] : requestRanges) {
+    boundaries.push_back(range.startRow);
+    boundaries.push_back(range.endRow);
+  }
+  std::sort(boundaries.begin(), boundaries.end());
+  boundaries.erase(
+      std::unique(boundaries.begin(), boundaries.end()), boundaries.end());
+
+  // Create segments from consecutive boundary points.
+  for (size_t i = 0; i + 1 < boundaries.size(); ++i) {
+    RowRange segmentRange{boundaries[i], boundaries[i + 1]};
+    if (segmentRange.empty()) {
+      continue;
+    }
+
+    // Find which requests contain this segment.
+    std::vector<vector_size_t> containingRequests;
+    for (const auto& [requestIdx, range] : requestRanges) {
+      if (range.contains(segmentRange)) {
+        containingRequests.push_back(requestIdx);
+      }
+    }
+
+    if (!containingRequests.empty()) {
+      ReadSegment segment;
+      segment.rowRange = segmentRange;
+      segment.requestIndices = std::move(containingRequests);
+      readSegments_.push_back(std::move(segment));
+    }
+  }
+}
+
+void SelectiveNimbleIndexReader::loadStripeWithIndex(uint32_t stripeIndex) {
+  addThreadLocalRuntimeStat(
+      dwio::common::RowReader::kNumStripeLoads, velox::RuntimeCounter(1));
+
+  streams_.setStripe(stripeIndex, /*loadIndex=*/true);
+  NimbleParams params(
+      *readerBase_->pool(),
+      columnReaderStatistics_,
+      readerBase_->nimbleSchema(),
+      streams_,
+      options_.trackRowSize() ? rowSizeTracker_.get() : nullptr,
+      options_.passStringBuffersFromDecoder()
+          ? [](velox::memory::MemoryPool& pool,
+               std::string_view data,
+               std::function<void*(uint32_t)> stringBufferFactory)
+                -> std::unique_ptr<Encoding> {
+        return EncodingFactory::decode(pool, data, std::move(stringBufferFactory));
+      }
+          : [](velox::memory::MemoryPool& pool,
+               std::string_view data,
+               std::function<void*(uint32_t)> stringBufferFactory)
+                -> std::unique_ptr<Encoding> {
+        return legacy::EncodingFactory::decode(pool, data, std::move(stringBufferFactory));
+      },
+      options_.passStringBuffersFromDecoder(),
+      options_.preserveFlatMapsInMemory());
+
+  columnReader_ = buildColumnReader(
+      outputType_,
+      readerBase_->fileSchemaWithId(),
+      params,
+      *options_.scanSpec(),
+      true);
+  rowSizeTracker_->finalizeProjection();
+  columnReader_->setIsTopLevel();
+
+  // Build index reader.
+  indexReader_ = index::IndexReader::create(
+      params.streams().enqueueKeyStream(),
+      params.streams().stripeIndex(),
+      params.streams().indexGroup(),
+      &params.pool());
+
+  streams_.load();
+}
+
+std::vector<SelectiveNimbleIndexReader::RowRange>
+SelectiveNimbleIndexReader::lookupRowRanges(
+    uint32_t stripeIndex,
+    const std::vector<velox::serializer::EncodedKeyBounds>& keyBounds) {
+  NIMBLE_CHECK_NOT_NULL(indexReader_);
+
+  const auto numStripeRows = static_cast<velox::vector_size_t>(
+      readerBase_->tablet().stripeRowCount(stripeIndex));
+  std::vector<RowRange> result;
+  result.reserve(keyBounds.size());
+
+  for (const auto& bounds : keyBounds) {
+    velox::vector_size_t startRow = 0;
+    if (bounds.lowerKey.has_value()) {
+      const auto lowerRow =
+          indexReader_->seekAtOrAfter(bounds.lowerKey.value());
+      if (lowerRow.has_value()) {
+        startRow = static_cast<velox::vector_size_t>(lowerRow.value());
+      } else {
+        // No rows match the lower bound and skip the request.
+        result.emplace_back();
+        continue;
+      }
+    }
+
+    velox::vector_size_t endRow = numStripeRows;
+    if (bounds.upperKey.has_value()) {
+      const auto upperRow =
+          indexReader_->seekAtOrAfter(bounds.upperKey.value());
+      if (upperRow.has_value()) {
+        endRow = static_cast<velox::vector_size_t>(upperRow.value());
+      }
+    }
+    result.emplace_back(startRow, endRow);
+  }
+  return result;
+}
+
+uint64_t SelectiveNimbleIndexReader::readStripeFragment(RowVectorPtr& output) {
+  if (readSegmentIndex_ >= readSegments_.size()) {
+    return 0;
+  }
+
+  const auto& segment = readSegments_[readSegmentIndex_];
+  const auto rowsToRead = segment.rowRange.endRow - segment.rowRange.startRow;
+  VELOX_CHECK_GT(rowsToRead, 0);
+
+  VectorPtr readOutput =
+      BaseVector::create(outputType_, 0, readerBase_->pool());
+  columnReader_->next(rowsToRead, readOutput, /*mutation=*/nullptr);
+  if (readOutput->size() > 0) {
+    readOutput->loadedVector();
+  }
+  output = checkedPointerCast<RowVector>(readOutput);
+  return rowsToRead;
+}
+
+void SelectiveNimbleIndexReader::advanceStripeReadSegment() {
+  ++readSegmentIndex_;
+  prepareStripeSegmentRead();
+}
+
+void SelectiveNimbleIndexReader::prepareStripeSegmentRead() {
+  if (readSegmentIndex_ < readSegments_.size()) {
+    columnReader_->seekTo(
+        readSegments_[readSegmentIndex_].rowRange.startRow,
+        /*readsNullsOnly=*/false);
+  }
+}
+
+void SelectiveNimbleIndexReader::advanceStripe() {
+  if (readSegmentIndex_ >= readSegments_.size()) {
+    ++stripeIndex_;
+    stripeLoaded_ = false;
+    readSegments_.clear();
+    readSegmentIndex_ = 0;
+    columnReader_.reset();
+    indexReader_.reset();
+  }
+}
+
+bool SelectiveNimbleIndexReader::canProduceOutput(
+    vector_size_t maxOutputRows) const {
+  return readyOutputRows_ >= maxOutputRows;
+}
+
+void SelectiveNimbleIndexReader::addStripeSegmentOutput(
+    const ReadSegment& segment,
+    RowVectorPtr output) {
+  VELOX_CHECK_NOT_NULL(output);
+  const auto outputRows = output->size();
+  if (outputRows == 0) {
+    updatePendingStripes(segment);
+  } else {
+    outputSegments_.emplace_back(std::move(output));
+    const size_t outputIndex = outputSegments_.size() - 1;
+    trackStripeSegmentOutputRefs(segment, outputIndex, outputRows);
+    NIMBLE_CHECK_GT(outputSegments_[outputIndex].refCount, 0);
+  }
+  updateReadyOutputRequests();
+}
+
+void SelectiveNimbleIndexReader::trackStripeSegmentOutputRefs(
+    const ReadSegment& segment,
+    size_t outputIndex,
+    vector_size_t outputRows) {
+  VELOX_CHECK_GT(outputRows, 0);
+  const auto startRow = segment.rowRange.startRow;
+  const auto readRows = segment.rowRange.numRows();
+
+  if (!hasFilters_) {
+    // No filter: outputRows == readRows. Each request extracts its portion
+    // based on its row range.
+    NIMBLE_CHECK_EQ(outputRows, readRows);
+    const auto readEndRow = segment.rowRange.endRow;
+    for (vector_size_t requestIdx : segment.requestIndices) {
+      const auto& range = requestStates_[requestIdx].rowRange;
+      const auto overlapStart = std::max(startRow, range.startRow);
+      const auto overlapEnd = std::min(readEndRow, range.endRow);
+      const auto overlapRows = overlapEnd - overlapStart;
+
+      requestStates_[requestIdx].outputRefs.emplace_back(
+          RequestState::OutputReference{
+              outputIndex,
+              RowRange{overlapStart - startRow, overlapEnd - startRow}});
+      outputSegments_[outputIndex].addRef();
+      requestStates_[requestIdx].outputRows += overlapRows;
+    }
+  } else {
+    // With filter: outputRows <= readRows. Each request in the segment
+    // gets the entire filtered output (since they share the same row range).
+    NIMBLE_CHECK_LE(outputRows, readRows);
+
+    for (vector_size_t requestIdx : segment.requestIndices) {
+      requestStates_[requestIdx].outputRefs.emplace_back(
+          RequestState::OutputReference{outputIndex, RowRange{0, outputRows}});
+      outputSegments_[outputIndex].addRef();
+      requestStates_[requestIdx].outputRows += outputRows;
+    }
+  }
+  updatePendingStripes(segment);
+}
+
+void SelectiveNimbleIndexReader::updatePendingStripes(
+    const ReadSegment& segment) {
+  for (vector_size_t requestIdx : segment.requestIndices) {
+    const auto& requestRange = requestStates_[requestIdx].rowRange;
+    if (segment.rowRange.endRow >= requestRange.endRow) {
+      --requestStates_[requestIdx].pendingStripes;
+    }
+  }
+}
+
+void SelectiveNimbleIndexReader::updateReadyOutputRequests() {
+  for (auto i = lastReadyOutputRequest_ + 1;
+       i < static_cast<vector_size_t>(numRequests_);
+       ++i) {
+    if (requestStates_[i].pendingStripes != 0) {
+      break;
+    }
+    lastReadyOutputRequest_ = i;
+    readyOutputRows_ += requestStates_[i].outputRows;
+    // Skip empty output request.
+    if (requestStates_[i].empty() && i == nextOutputRequest_) {
+      ++nextOutputRequest_;
+    }
+  }
+}
+
+std::unique_ptr<connector::IndexSource::Result>
+SelectiveNimbleIndexReader::produceOutput() {
+  if (readyOutputRows_ == 0) {
+    VELOX_CHECK_EQ(stripeIndex_, stripes_.size());
+    reset();
+    return nullptr;
+  }
+
+  VELOX_CHECK_LE(nextOutputRequest_, lastReadyOutputRequest_);
+
+  // Count total output rows from all ready requests.
+  vector_size_t totalOutputRows = 0;
+  for (auto i = nextOutputRequest_; i <= lastReadyOutputRequest_; ++i) {
+    totalOutputRows += requestStates_[i].outputRows;
+  }
+  VELOX_CHECK_EQ(totalOutputRows, readyOutputRows_);
+
+  // Allocate output buffers for all ready requests.
+  RowVectorPtr output = BaseVector::create<RowVector>(
+      outputType_, totalOutputRows, readerBase_->pool());
+  auto inputHits = AlignedBuffer::allocate<vector_size_t>(
+      totalOutputRows, readerBase_->pool());
+  auto* rawInputHits = inputHits->asMutable<vector_size_t>();
+
+  // Build output for all ready requests.
+  vector_size_t outputOffset = 0;
+  for (auto requestIdx = nextOutputRequest_;
+       requestIdx <= lastReadyOutputRequest_;
+       ++requestIdx) {
+    const auto& state = requestStates_[requestIdx];
+    if (state.empty()) {
+      continue;
+    }
+
+    for (const auto& ref : state.outputRefs) {
+      auto& chunk = outputSegments_[ref.chunkIndex];
+      const auto numRows = ref.rowRange.endRow - ref.rowRange.startRow;
+      output->copy(
+          chunk.data.get(), outputOffset, ref.rowRange.startRow, numRows);
+
+      // Fill inputHits with the request index for each output row.
+      std::fill(
+          rawInputHits + outputOffset,
+          rawInputHits + outputOffset + numRows,
+          requestIdx);
+
+      outputOffset += numRows;
+      chunk.dropRef();
+    }
+  }
+  NIMBLE_CHECK_EQ(outputOffset, totalOutputRows);
+
+  nextOutputRequest_ = lastReadyOutputRequest_ + 1;
+  readyOutputRows_ = 0;
+  return std::make_unique<connector::IndexSource::Result>(
+      std::move(inputHits), std::move(output));
+}
+
+void SelectiveNimbleIndexReader::reset() {
+  numRequests_ = 0;
+  encodedKeyBounds_.clear();
+  stripes_.clear();
+  stripeToRequests_.clear();
+  stripeIndex_ = 0;
+  stripeLoaded_ = false;
+  readSegments_.clear();
+  readSegmentIndex_ = 0;
+  requestStates_.clear();
+  outputSegments_.clear();
+  nextOutputRequest_ = 0;
+  lastReadyOutputRequest_ = -1;
+  readyOutputRows_ = 0;
+  columnReader_.reset();
+  indexReader_.reset();
+}
+
+} // namespace facebook::nimble

--- a/dwio/nimble/velox/selective/SelectiveNimbleIndexReader.h
+++ b/dwio/nimble/velox/selective/SelectiveNimbleIndexReader.h
@@ -1,0 +1,297 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <folly/container/F14Map.h>
+#include <memory>
+#include <vector>
+
+#include "dwio/nimble/index/IndexReader.h"
+#include "dwio/nimble/index/TabletIndex.h"
+#include "dwio/nimble/velox/selective/ReaderBase.h"
+#include "dwio/nimble/velox/selective/RowSizeTracker.h"
+#include "velox/connectors/Connector.h"
+#include "velox/dwio/common/Reader.h"
+#include "velox/dwio/common/SelectiveColumnReader.h"
+#include "velox/serializers/KeyEncoder.h"
+
+namespace facebook::nimble {
+
+/// SelectiveNimbleIndexReader implements the IndexReader interface for
+/// Nimble files with cluster indexes. It handles:
+/// - Encoding index bounds into Nimble-specific encoded keys
+/// - Looking up stripes and row ranges using the tablet index
+/// - Managing stripe iteration and data reading
+/// - Returning results in request order via the next() iterator pattern
+///
+/// This class moves the control logic (stripe iteration, row range computation,
+/// key encoding) from HiveIndexReader into the format-specific reader, allowing
+/// HiveIndexReader to focus on index bounds creation and result assembly.
+class SelectiveNimbleIndexReader : public velox::dwio::common::IndexReader {
+ public:
+  using Result = velox::connector::IndexSource::Result;
+
+  SelectiveNimbleIndexReader(
+      std::shared_ptr<ReaderBase> readerBase,
+      const velox::dwio::common::RowReaderOptions& options);
+
+  ~SelectiveNimbleIndexReader() override = default;
+
+  /// Starts a new batch lookup with the given index bounds.
+  /// Encodes the bounds, looks up matching stripes, and prepares for iteration.
+  void startLookup(const velox::serializer::IndexBounds& indexBounds) override;
+
+  /// Returns true if there are more results to fetch from the current lookup.
+  bool hasNext() const override;
+
+  /// Returns the next batch of results from the current lookup.
+  /// Results are returned in request order - all results for request N are
+  /// returned before any results for request N+1.
+  std::unique_ptr<Result> next(velox::vector_size_t maxOutputRows) override;
+
+ private:
+  // Represents a row range within a stripe [startRow, endRow).
+  struct RowRange {
+    velox::vector_size_t startRow{0}; // Inclusive
+    velox::vector_size_t endRow{0}; // Exclusive
+
+    RowRange() = default;
+    RowRange(velox::vector_size_t _startRow, velox::vector_size_t _endRow)
+        : startRow(_startRow), endRow(_endRow) {}
+
+    velox::vector_size_t numRows() const {
+      return endRow - startRow;
+    }
+
+    bool empty() const {
+      return startRow >= endRow;
+    }
+
+    // Returns true if this range fully contains other.
+    bool contains(const RowRange& other) const {
+      return startRow <= other.startRow && other.endRow <= endRow;
+    }
+
+    bool operator==(const RowRange& other) const {
+      return startRow == other.startRow && endRow == other.endRow;
+    }
+
+    std::string toString() const {
+      return fmt::format("[{}, {})", startRow, endRow);
+    }
+  };
+
+  struct RowRangeHash {
+    size_t operator()(const RowRange& range) const;
+  };
+
+  using RowRangeMap = folly::F14FastMap<RowRange, size_t, RowRangeHash>;
+
+  // Represents a read segment - a contiguous row range to read from the file.
+  // Multiple requests may reference the same segment (when they share row
+  // ranges).
+  struct ReadSegment {
+    RowRange rowRange;
+    // Request indices that reference this segment.
+    std::vector<velox::vector_size_t> requestIndices;
+
+    std::string toString() const;
+  };
+
+  // Per-request state for tracking output assembly.
+  struct RequestState {
+    // Number of stripes still pending for this request.
+    int32_t pendingStripes{0};
+
+    // Row range for this request within the current stripe.
+    RowRange rowRange;
+
+    velox::vector_size_t outputRows{0};
+    struct OutputReference {
+      size_t chunkIndex{};
+      RowRange rowRange;
+    };
+    std::vector<OutputReference> outputRefs;
+
+    // Returns true if no pending stripes and no output rows accumulated.
+    bool empty() const {
+      VELOX_CHECK_EQ(outputRows == 0, outputRefs.empty());
+      return pendingStripes == 0 && outputRows == 0;
+    }
+
+    /// Increments the pending stripe count when a new stripe is mapped to this
+    /// request.
+    void incPendingStripes();
+
+    /// Decrements the pending stripe count when a stripe finishes processing
+    /// for this request (either with data or empty).
+    void decPendingStripes();
+  };
+
+  // Output chunk with reference counting.
+  struct OutputChunk {
+    velox::RowVectorPtr data;
+    int32_t refCount{0};
+
+    explicit OutputChunk(velox::RowVectorPtr _data) : data(std::move(_data)) {}
+
+    void addRef() {
+      ++refCount;
+    }
+    void dropRef();
+  };
+
+  /// Initializes stripe row offsets for efficient row range calculations.
+  void initReadRange();
+
+  /// Encodes raw index bounds into Nimble-specific encoded key format.
+  /// @param indexBounds The index bounds to encode.
+  /// @return Vector of encoded key bounds ready for index lookup.
+  std::vector<velox::serializer::EncodedKeyBounds> encodeIndexBounds(
+      const velox::serializer::IndexBounds& indexBounds);
+
+  /// Maps each request to the stripes it needs to read from by performing
+  /// index lookups for all encoded key bounds.
+  void mapRequestsToStripes();
+
+  /// Loads the current stripe if not already loaded.
+  /// @return True if a stripe was loaded, false if no more stripes.
+  bool loadStripe();
+
+  /// Prepares a stripe for reading by initializing streams and column readers.
+  /// @param stripeIndex The index of the stripe to prepare.
+  void prepareStripeReading(uint32_t stripeIndex);
+
+  /// Builds read segments from request ranges based on filter presence.
+  /// Dispatches to mergeStripeRowRanges or splitStripeRowRanges.
+  void buildStripeReadSegments(
+      const std::vector<std::pair<velox::vector_size_t, RowRange>>&
+          requestRanges);
+
+  /// Builds read segments by merging overlapping row ranges.
+  /// Used when no filters are present for efficient reading with seek.
+  void mergeStripeRowRanges(
+      const std::vector<std::pair<velox::vector_size_t, RowRange>>&
+          requestRanges);
+
+  /// Builds read segments by splitting overlapping row ranges into
+  /// non-overlapping segments. Used when filters are present.
+  void splitStripeRowRanges(
+      const std::vector<std::pair<velox::vector_size_t, RowRange>>&
+          requestRanges);
+
+  /// Loads a stripe and performs index lookup to determine row ranges.
+  /// @param stripeIndex The index of the stripe to load.
+  void loadStripeWithIndex(uint32_t stripeIndex);
+
+  /// Looks up row ranges for each request within a specific stripe.
+  /// @param stripeIndex The stripe to look up.
+  /// @param keyBounds The encoded key bounds for each request.
+  /// @return Vector of row ranges, one per request.
+  std::vector<RowRange> lookupRowRanges(
+      uint32_t stripeIndex,
+      const std::vector<velox::serializer::EncodedKeyBounds>& keyBounds);
+
+  /// Prepares the column reader for reading the current segment by seeking to
+  /// the segment's start row. Does nothing if readSegmentIndex_ is out of
+  /// range.
+  void prepareStripeSegmentRead();
+
+  /// Reads a fragment of data from the current stripe's read segment.
+  /// @param output The output vector to populate.
+  /// @return Number of rows read.
+  uint64_t readStripeFragment(velox::RowVectorPtr& output);
+
+  /// Advances to the next read segment within the current stripe.
+  void advanceStripeReadSegment();
+
+  /// Advances to the next stripe in the iteration.
+  void advanceStripe();
+
+  /// Adds output data for a segment to the output chunks and tracks references.
+  /// @param segment The segment that produced this output.
+  /// @param output The output data to add.
+  void addStripeSegmentOutput(
+      const ReadSegment& segment,
+      velox::RowVectorPtr output);
+
+  /// Tracks output references for requests in a segment.
+  /// @param segment The segment containing request indices.
+  /// @param outputIndex Index of the output chunk.
+  /// @param outputRows Number of rows in the output.
+  void trackStripeSegmentOutputRefs(
+      const ReadSegment& segment,
+      size_t outputIndex,
+      velox::vector_size_t outputRows);
+
+  /// Updates pending stripe counts for requests after processing a segment.
+  /// @param segment The segment that was processed.
+  void updatePendingStripes(const ReadSegment& segment);
+
+  /// Updates the count of ready output requests that can be returned.
+  void updateReadyOutputRequests();
+
+  /// Checks if enough output is ready to produce results.
+  /// @param maxOutputRows Maximum rows to produce.
+  /// @return True if output can be produced.
+  bool canProduceOutput(velox::vector_size_t maxOutputRows) const;
+
+  /// Produces the next batch of output results.
+  /// @return Result containing output rows and request indices.
+  std::unique_ptr<Result> produceOutput();
+
+  /// Resets all state for a new lookup operation.
+  void reset();
+
+  const std::shared_ptr<ReaderBase> readerBase_;
+  const velox::dwio::common::RowReaderOptions options_;
+  const std::unique_ptr<RowSizeTracker> rowSizeTracker_;
+  const bool hasFilters_;
+  const velox::RowTypePtr outputType_;
+  const TabletIndex* const tabletIndex_;
+  const std::vector<std::string> indexColumns_;
+
+  StripeStreams streams_;
+  std::vector<int64_t> stripeRowOffsets_;
+  int32_t numStripes_{0};
+
+  std::unique_ptr<velox::serializer::KeyEncoder> keyEncoder_;
+  std::unique_ptr<index::IndexReader> indexReader_;
+
+  std::unique_ptr<velox::dwio::common::SelectiveColumnReader> columnReader_;
+  velox::dwio::common::ColumnReaderStatistics columnReaderStatistics_;
+
+  // Current lookup state.
+  size_t numRequests_{0};
+  std::vector<velox::serializer::EncodedKeyBounds> encodedKeyBounds_;
+  std::vector<uint32_t> stripes_;
+  folly::F14FastMap<uint32_t, std::vector<velox::vector_size_t>>
+      stripeToRequests_;
+  size_t stripeIndex_{0};
+  bool stripeLoaded_{false};
+  std::vector<ReadSegment> readSegments_;
+  size_t readSegmentIndex_{0};
+
+  // Output state.
+  std::vector<RequestState> requestStates_;
+  std::vector<OutputChunk> outputSegments_;
+  velox::vector_size_t nextOutputRequest_{0};
+  velox::vector_size_t lastReadyOutputRequest_{-1};
+  velox::vector_size_t readyOutputRows_{0};
+};
+
+} // namespace facebook::nimble


### PR DESCRIPTION
Summary:
This diff implements stripe-level batched index read support for Nimble files in Velox. The key motivation is to improve index lookup performance by processing multiple lookup requests in batches at the stripe level, rather than processing each request individually.

**New `SelectiveNimbleIndexReader` class**: A new format-specific index reader that handles:
   - Encoding index bounds into Nimble-specific encoded keys
   - Looking up stripes and row ranges using the tablet index
   - Managing stripe iteration and data reading with batched processing
   - Returning results in request order via an iterator pattern (`startLookup`/`hasNext`/`next`)

**Batched stripe processing**: Instead of loading stripes per-request, the reader:
   - Maps all lookup requests to their matching stripes upfront
   - Merges overlapping row ranges within stripes for efficient reading
   - Tracks output references with ref-counting to share read data across requests

**Optimized row range handling**:
   - Without filters: Merges overlapping row ranges and each request extracts its portion
   - With filters: Splits overlapping ranges into non-overlapping segments to preserve filter semantics

**HiveIndexReader refactoring**: Simplified to focus on index bounds creation and result assembly, delegating control logic to format-specific readers.

**KeyEncoder enhancements**: Added support for encoding index bounds with constant values for more efficient range queries.

**New runtime stats**: Added metrics for tracking index lookup performance:
   - `kNumIndexLookupRequests`: Total lookup requests
   - `kNumIndexLookupStripes`: Number of stripes accessed
   - `kNumIndexLookupReadSegments`: Number of read segments processed

Differential Revision: D92848948


