### PR TITLE
feat: Add to support write index with empty nimble file

### DIFF
--- a/dwio/nimble/index/TabletIndex.h
+++ b/dwio/nimble/index/TabletIndex.h
@@ -113,6 +113,13 @@ class TabletIndex {
     return numStripes_;
   }
 
+  /// Returns true if the index is empty (has no stripes).
+  ///
+  /// @return true if the index has no stripes, false otherwise
+  bool empty() const {
+    return numStripes_ == 0;
+  }
+
   /// Returns the index columns.
   ///
   /// @return Vector of index column names

--- a/dwio/nimble/index/tests/TabletIndexTest.cpp
+++ b/dwio/nimble/index/tests/TabletIndexTest.cpp
@@ -75,6 +75,7 @@ TEST_F(TabletIndexTest, basic) {
   auto tabletIndex = createTabletIndex(indexBuffers);
 
   EXPECT_EQ(tabletIndex->numStripes(), 4);
+  EXPECT_FALSE(tabletIndex->empty());
   EXPECT_EQ(tabletIndex->minKey(), "aaa");
   EXPECT_EQ(tabletIndex->maxKey(), "eee");
 

--- a/dwio/nimble/tablet/TabletIndexWriter.h
+++ b/dwio/nimble/tablet/TabletIndexWriter.h
@@ -152,6 +152,8 @@ class TabletIndexWriter {
 
   /// Writes the root index as an optional section.
   /// Call this at file close to persist the file-level index.
+  /// For empty files (no stripes), writes config only (columns, sort orders)
+  /// but no stripe keys or stripe index groups.
   ///
   /// @param stripeGroupIndices Mapping of stripe index to stripe group index.
   /// @param writeOptionalSection Callback to write optional section.
@@ -163,6 +165,10 @@ class TabletIndexWriter {
   void checkNotFinalized() const {
     NIMBLE_CHECK(!finalized_, "TabletIndexWriter has been finalized");
   }
+
+  // Writes an empty root index with config only (columns, sort orders)
+  // but no stripe keys or stripe index groups.
+  void writeEmptyRootIndex(const WriteOptionalSectionFn& writeOptionalSection);
 
   TabletIndexWriter(
       const TabletIndexConfig& config,

--- a/dwio/nimble/velox/selective/CMakeLists.txt
+++ b/dwio/nimble/velox/selective/CMakeLists.txt
@@ -21,6 +21,7 @@ add_library(
   ReaderBase.cpp
   RowSizeTracker.cpp
   SelectiveNimbleReader.cpp
+  SelectiveNimbleIndexReader.cpp
   SelectiveNimbleReaderInitHookOSS.cpp
   StringColumnReader.cpp
   StructColumnReader.cpp

--- a/dwio/nimble/velox/selective/SelectiveNimbleIndexReader.cpp
+++ b/dwio/nimble/velox/selective/SelectiveNimbleIndexReader.cpp
@@ -41,7 +41,6 @@ std::vector<std::string> convertIndexColumnsToFileSchema(
     const std::shared_ptr<const Type>& nimbleSchema,
     const RowTypePtr& fileSchema) {
   const auto nimbleRowType = asRowType(convertToVeloxType(*nimbleSchema));
-
   std::vector<std::string> convertedIndexColumns;
   convertedIndexColumns.reserve(nimbleIndexColumns.size());
   for (const auto& nimbleColName : nimbleIndexColumns) {
@@ -231,6 +230,11 @@ void SelectiveNimbleIndexReader::mapRequestsToStripes() {
   stripeToRequests_.clear();
   stripeIndex_ = 0;
   requestStates_.resize(numRequests_);
+
+  // Early exit if the index is empty (no stripes).
+  if (tabletIndex_->empty()) {
+    return;
+  }
 
   for (size_t requestIdx = 0; requestIdx < numRequests_; ++requestIdx) {
     const auto& bounds = encodedKeyBounds_[requestIdx];

--- a/dwio/nimble/velox/selective/SelectiveNimbleReader.cpp
+++ b/dwio/nimble/velox/selective/SelectiveNimbleReader.cpp
@@ -559,7 +559,7 @@ void SelectiveNimbleRowReader::restoreFilters() {
   // Restore filters that were removed during index bound conversion.
   // This is needed because the scan spec may be shared across multiple
   // split readers in multiple split execution modes.
-  NIMBLE_DCHECK(
+  NIMBLE_CHECK(
       filtersToRestore_.empty() || tabletIndex_ != nullptr,
       "filtersToRestore_ should only be set when index bounds are used");
   for (auto& [columnName, filter] : filtersToRestore_) {


### PR DESCRIPTION
Summary:
TabletIndexWriter - Added writeEmptyRootIndex() for empty file case
TabletIndex - Added empty() method, updated validation and lookup() for empty case
TabletReader - Skip preloading when no index groups
SelectiveNimbleIndexReader - Early exit in mapRequestsToStripes() when index is empty

Differential Revision: D93267699


