### PR TITLE
migrate rename to folly::available_concurrency (assorted)

### DIFF
--- a/dwio/nimble/velox/FieldWriter.cpp
+++ b/dwio/nimble/velox/FieldWriter.cpp
@@ -2346,7 +2346,7 @@ DecodingContextPool::DecodingContextPool(
     std::function<void(void)> vectorDecoderVisitor)
     : vectorDecoderVisitor_{std::move(vectorDecoderVisitor)} {
   NIMBLE_CHECK(vectorDecoderVisitor_, "vectorDecoderVisitor must be set");
-  pool_.reserve(folly::hardware_concurrency());
+  pool_.reserve(folly::available_concurrency());
 }
 
 void DecodingContextPool::addContext(

--- a/dwio/nimble/velox/tests/DecodingContextPoolTests.cpp
+++ b/dwio/nimble/velox/tests/DecodingContextPoolTests.cpp
@@ -61,7 +61,7 @@ TEST(DecodingContextPoolTest, FillPool) {
 }
 
 TEST(DecodingContextPoolTest, ParallelFillPool) {
-  auto parallelismFactor = folly::hardware_concurrency();
+  auto parallelismFactor = folly::available_concurrency();
   auto executor = folly::CPUThreadPoolExecutor{parallelismFactor};
 
   DecodingContextPool pool;

--- a/dwio/nimble/velox/tests/VeloxReaderTests.cpp
+++ b/dwio/nimble/velox/tests/VeloxReaderTests.cpp
@@ -2483,7 +2483,7 @@ TEST_P(VeloxReaderTests, fuzzSimple) {
   auto batches = 20;
   std::mt19937 rng{seed};
 
-  for (auto parallelismFactor : {0U, 1U, folly::hardware_concurrency()}) {
+  for (auto parallelismFactor : {0U, 1U, folly::available_concurrency()}) {
     LOG(INFO) << "Parallelism Factor: " << parallelismFactor;
 
     // Executor needs to outlive writerOptions since the latter has a keepAlive
@@ -2605,7 +2605,7 @@ TEST_P(VeloxReaderTests, fuzzComplex) {
   // the former.
   std::shared_ptr<folly::CPUThreadPoolExecutor> executor;
 
-  for (auto parallelismFactor : {0U, 1U, folly::hardware_concurrency()}) {
+  for (auto parallelismFactor : {0U, 1U, folly::available_concurrency()}) {
     LOG(INFO) << "Parallelism Factor: " << parallelismFactor;
 
     nimble::VeloxWriterOptions writerOptions;

--- a/dwio/nimble/velox/tests/VeloxWriterTest.cpp
+++ b/dwio/nimble/velox/tests/VeloxWriterTest.cpp
@@ -2339,7 +2339,7 @@ TEST_F(VeloxWriterTest, fuzzComplex) {
                                                     : folly::Random::rand32();
   LOG(INFO) << "seed: " << seed;
   std::mt19937 rng{seed};
-  for (auto parallelismFactor : {0U, 1U, folly::hardware_concurrency()}) {
+  for (auto parallelismFactor : {0U, 1U, folly::available_concurrency()}) {
     std::shared_ptr<folly::CPUThreadPoolExecutor> executor;
     nimble::VeloxWriterOptions writerOptions;
     writerOptions.enableChunking = true;


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebookincubator/axiom/pull/896

The name `hardware_concurrency`, while parallel to `std::thread::hardware_concurrency`, may be misleading. Migrate to the name `available_concurrency`.

Differential Revision: D93262843


