### PR TITLE
feat: Add max scan rows limit for index lookup

### DIFF
--- a/dwio/nimble/velox/selective/SelectiveNimbleIndexReader.cpp
+++ b/dwio/nimble/velox/selective/SelectiveNimbleIndexReader.cpp
@@ -125,16 +125,20 @@ SelectiveNimbleIndexReader::SelectiveNimbleIndexReader(
 }
 
 void SelectiveNimbleIndexReader::startLookup(
-    const velox::serializer::IndexBounds& indexBounds) {
+    const velox::serializer::IndexBounds& indexBounds,
+    const Options& options) {
   reset();
 
   numRequests_ = indexBounds.numRows();
   // Encode the index bounds.
   encodedKeyBounds_ = encodeIndexBounds(indexBounds);
-  NIMBLE_CHECK_EQ(
+  VELOX_CHECK_EQ(
       encodedKeyBounds_.size(),
       numRequests_,
       "Encoded key bounds size mismatch");
+
+  // Cache options for use during output tracking.
+  requestOptions_ = options;
 
   // Build stripe to request mapping.
   mapRequestsToStripes();
@@ -236,6 +240,7 @@ void SelectiveNimbleIndexReader::mapRequestsToStripes() {
     return;
   }
 
+  const auto& tablet = readerBase_->tablet();
   for (size_t requestIdx = 0; requestIdx < numRequests_; ++requestIdx) {
     const auto& bounds = encodedKeyBounds_[requestIdx];
     std::vector<uint32_t> requestStripes;
@@ -262,11 +267,32 @@ void SelectiveNimbleIndexReader::mapRequestsToStripes() {
         continue; // No stripes match.
       }
     }
+    VELOX_CHECK_LT(startStripe, endStripe);
 
     // Add stripes to the mapping.
+    // For no-filter case, we can prune stripes based on pre-filter row counts
+    // since input rows == output rows. However, we only consider middle stripes
+    // (not first or last) for truncation, because first and last stripes may be
+    // partial and their actual row counts are unknown until lookupRowRanges().
+    // For filter case, we cannot prune stripes since we don't know output rows
+    // ahead of time. Instead, truncation based on actual output rows happens
+    // during output tracking in trackStripeSegmentOutputRefs().
+    uint64_t fullStripeRows = 0;
     for (uint32_t stripe = startStripe; stripe < endStripe; ++stripe) {
       stripeToRequests_[stripe].push_back(requestIdx);
       requestStates_[requestIdx].incPendingStripes();
+
+      // Only consider middle stripes for truncation since first and last
+      // stripes may be partial (unknown row counts until lookupRowRanges).
+
+      if (!hasFilters_ && requestOptions_.maxRowsPerRequest > 0) {
+        const bool isMiddleStripe =
+            stripe != startStripe && stripe != endStripe - 1;
+        fullStripeRows += isMiddleStripe ? tablet.stripeRowCount(stripe) : 0;
+        if (fullStripeRows >= requestOptions_.maxRowsPerRequest) {
+          break;
+        }
+      }
     }
   }
 
@@ -282,14 +308,25 @@ bool SelectiveNimbleIndexReader::loadStripe() {
   if (stripeLoaded_) {
     return true;
   }
-  const uint32_t stripeIndex = stripes_[stripeIndex_];
-  prepareStripeReading(stripeIndex);
-  if (readSegments_.empty()) {
-    ++stripeIndex_;
-    return false;
+  // Skip stripes if all requests have been removed due to stripe pruning.
+  while (stripeIndex_ < stripes_.size()) {
+    const uint32_t stripeIndex = stripes_[stripeIndex_];
+    auto it = stripeToRequests_.find(stripeIndex);
+    VELOX_CHECK(it != stripeToRequests_.end());
+    if (it->second.empty()) {
+      VELOX_CHECK_GT(requestOptions_.maxRowsPerRequest, 0);
+      ++stripeIndex_;
+      continue;
+    }
+    prepareStripeReading(stripeIndex);
+    if (readSegments_.empty()) {
+      ++stripeIndex_;
+      continue;
+    }
+    stripeLoaded_ = true;
+    return true;
   }
-  stripeLoaded_ = true;
-  return true;
+  return false;
 }
 
 void SelectiveNimbleIndexReader::prepareStripeReading(uint32_t stripeIndex) {
@@ -317,17 +354,39 @@ void SelectiveNimbleIndexReader::prepareStripeReading(uint32_t stripeIndex) {
   NIMBLE_CHECK_EQ(stripeRowRanges.size(), requestRows.size());
 
   // Filter out empty ranges and store per-request row ranges.
+  // For no-filter case, also truncate row ranges based on
+  // requestOptions_.maxRowsPerRequest since input rows == output rows.
   std::vector<std::pair<vector_size_t, RowRange>> requestRanges;
   requestRanges.reserve(requestRows.size());
   for (size_t i = 0; i < requestRows.size(); ++i) {
-    const auto& range = stripeRowRanges[i];
-    if (!range.empty()) {
-      requestRanges.emplace_back(requestRows[i], range);
-      requestStates_[requestRows[i]].rowRange = range;
-    } else {
+    auto& state = requestStates_[requestRows[i]];
+    VELOX_CHECK_GT(state.pendingStripes, 0);
+    auto range = stripeRowRanges[i];
+    if (range.empty()) {
       // Decrement pending stripes for requests with empty row ranges.
-      requestStates_[requestRows[i]].decPendingStripes();
+      state.decPendingStripes();
+      continue;
     }
+
+    // For no-filter case, truncate row range if accumulated output would
+    // exceed requestOptions_.maxRowsPerRequest. This avoids reading
+    // unnecessary data.
+    if (!hasFilters_ && requestOptions_.maxRowsPerRequest > 0) {
+      VELOX_CHECK_GT(requestOptions_.maxRowsPerRequest, state.outputRows);
+      const auto remainingRows =
+          requestOptions_.maxRowsPerRequest - state.outputRows;
+      const auto rangeRows = range.numRows();
+      if (rangeRows >= static_cast<vector_size_t>(remainingRows)) {
+        // Truncate the row range to fit within the limit.
+        range.endRow = range.startRow + remainingRows;
+        // All the rows will be processed within this stripe, so remove the
+        // request from subsequent stripes if there are any.
+        removeRequestFromSubsequentStripes(requestRows[i], stripeIndex_ + 1);
+      }
+    }
+
+    requestRanges.emplace_back(requestRows[i], range);
+    requestStates_[requestRows[i]].rowRange = std::move(range);
   }
   // Update ready output requests after decrementing pending stripes for empty
   // row ranges. This ensures requests with no matching rows in this stripe
@@ -617,32 +676,58 @@ void SelectiveNimbleIndexReader::trackStripeSegmentOutputRefs(
 
   if (!hasFilters_) {
     // No filter: outputRows == readRows. Each request extracts its portion
-    // based on its row range.
+    // based on its row range. Row range truncation is already done in
+    // prepareStripeReading.
     NIMBLE_CHECK_EQ(outputRows, readRows);
     const auto readEndRow = segment.rowRange.endRow;
     for (vector_size_t requestIdx : segment.requestIndices) {
-      const auto& range = requestStates_[requestIdx].rowRange;
+      auto& state = requestStates_[requestIdx];
+      const auto& range = state.rowRange;
       const auto overlapStart = std::max(startRow, range.startRow);
       const auto overlapEnd = std::min(readEndRow, range.endRow);
       const auto overlapRows = overlapEnd - overlapStart;
 
-      requestStates_[requestIdx].outputRefs.emplace_back(
+      state.outputRefs.emplace_back(
           RequestState::OutputReference{
               outputIndex,
               RowRange{overlapStart - startRow, overlapEnd - startRow}});
       outputSegments_[outputIndex].addRef();
-      requestStates_[requestIdx].outputRows += overlapRows;
+      state.outputRows += overlapRows;
+      VELOX_DCHECK(
+          requestOptions_.maxRowsPerRequest == 0 ||
+              state.outputRows <= requestOptions_.maxRowsPerRequest,
+          "Output rows {} exceeds maxRowsPerRequest {} for request {}",
+          state.outputRows,
+          requestOptions_.maxRowsPerRequest,
+          requestIdx);
     }
   } else {
     // With filter: outputRows <= readRows. Each request in the segment
-    // gets the entire filtered output (since they share the same row range).
+    // gets the filtered output. Apply truncation if
+    // requestOptions_.maxRowsPerRequest is set.
     NIMBLE_CHECK_LE(outputRows, readRows);
 
     for (vector_size_t requestIdx : segment.requestIndices) {
-      requestStates_[requestIdx].outputRefs.emplace_back(
-          RequestState::OutputReference{outputIndex, RowRange{0, outputRows}});
+      auto& state = requestStates_[requestIdx];
+
+      // Calculate how many rows to add, respecting the limit.
+      auto rowsToAdd = outputRows;
+      if (requestOptions_.maxRowsPerRequest > 0) {
+        if (requestOptions_.maxRowsPerRequest == state.outputRows) {
+          continue;
+        }
+        const auto remainingRows =
+            requestOptions_.maxRowsPerRequest - state.outputRows;
+        if (outputRows >= static_cast<vector_size_t>(remainingRows)) {
+          rowsToAdd = remainingRows;
+          removeRequestFromSubsequentStripes(requestIdx, stripeIndex_ + 1);
+        }
+      }
+
+      state.outputRefs.emplace_back(
+          RequestState::OutputReference{outputIndex, RowRange{0, rowsToAdd}});
       outputSegments_[outputIndex].addRef();
-      requestStates_[requestIdx].outputRows += outputRows;
+      state.outputRows += rowsToAdd;
     }
   }
   updatePendingStripes(segment);
@@ -732,8 +817,32 @@ SelectiveNimbleIndexReader::produceOutput() {
       std::move(inputHits), std::move(output));
 }
 
+void SelectiveNimbleIndexReader::removeRequestFromSubsequentStripes(
+    velox::vector_size_t requestIdx,
+    size_t startStripeIdx) {
+  auto& state = requestStates_[requestIdx];
+  // We must have at least one pending stripe (the current stripe) that will
+  // be processed. We only remove from subsequent stripes.
+  VELOX_CHECK_GE(state.pendingStripes, 1);
+  for (size_t i = startStripeIdx;
+       i < stripes_.size() && state.pendingStripes > 1;
+       ++i) {
+    const auto stripe = stripes_[i];
+    auto& requests = stripeToRequests_[stripe];
+    auto it = std::find(requests.begin(), requests.end(), requestIdx);
+    VELOX_CHECK(
+        it != requests.end(),
+        "Request {} must exist in stripe {} as stripes are contiguous",
+        requestIdx,
+        stripe);
+    requests.erase(it);
+    state.decPendingStripes();
+  }
+}
+
 void SelectiveNimbleIndexReader::reset() {
   numRequests_ = 0;
+  requestOptions_ = {};
   encodedKeyBounds_.clear();
   stripes_.clear();
   stripeToRequests_.clear();
@@ -749,5 +858,4 @@ void SelectiveNimbleIndexReader::reset() {
   columnReader_.reset();
   indexReader_.reset();
 }
-
 } // namespace facebook::nimble

--- a/dwio/nimble/velox/selective/SelectiveNimbleIndexReader.h
+++ b/dwio/nimble/velox/selective/SelectiveNimbleIndexReader.h
@@ -53,7 +53,9 @@ class SelectiveNimbleIndexReader : public velox::dwio::common::IndexReader {
 
   /// Starts a new batch lookup with the given index bounds.
   /// Encodes the bounds, looks up matching stripes, and prepares for iteration.
-  void startLookup(const velox::serializer::IndexBounds& indexBounds) override;
+  void startLookup(
+      const velox::serializer::IndexBounds& indexBounds,
+      const Options& options) override;
 
   /// Returns true if there are more results to fetch from the current lookup.
   bool hasNext() const override;
@@ -133,12 +135,12 @@ class SelectiveNimbleIndexReader : public velox::dwio::common::IndexReader {
       return pendingStripes == 0 && outputRows == 0;
     }
 
-    /// Increments the pending stripe count when a new stripe is mapped to this
-    /// request.
+    // Increments the pending stripe count when a new stripe is mapped to this
+    // request.
     void incPendingStripes();
 
-    /// Decrements the pending stripe count when a stripe finishes processing
-    /// for this request (either with data or empty).
+    // Decrements the pending stripe count when a stripe finishes processing
+    // for this request (either with data or empty).
     void decPendingStripes();
   };
 
@@ -155,106 +157,115 @@ class SelectiveNimbleIndexReader : public velox::dwio::common::IndexReader {
     void dropRef();
   };
 
-  /// Initializes stripe row offsets for efficient row range calculations.
+  // Initializes stripe row offsets for efficient row range calculations.
   void initReadRange();
 
-  /// Encodes raw index bounds into Nimble-specific encoded key format.
-  /// @param indexBounds The index bounds to encode.
-  /// @return Vector of encoded key bounds ready for index lookup.
+  // Encodes raw index bounds into Nimble-specific encoded key format.
+  // @param indexBounds The index bounds to encode.
+  // @return Vector of encoded key bounds ready for index lookup.
   std::vector<velox::serializer::EncodedKeyBounds> encodeIndexBounds(
       const velox::serializer::IndexBounds& indexBounds);
 
-  /// Maps each request to the stripes it needs to read from by performing
-  /// index lookups for all encoded key bounds.
+  // Maps each request to the stripes it needs to read from by performing
+  // index lookups for all encoded key bounds.
   void mapRequestsToStripes();
 
-  /// Loads the current stripe if not already loaded.
-  /// @return True if a stripe was loaded, false if no more stripes.
+  // Loads the current stripe if not already loaded.
+  // @return True if a stripe was loaded, false if no more stripes.
   bool loadStripe();
 
-  /// Prepares a stripe for reading by initializing streams and column readers.
-  /// @param stripeIndex The index of the stripe to prepare.
+  // Prepares a stripe for reading by initializing streams and column readers.
+  // @param stripeIndex The index of the stripe to prepare.
   void prepareStripeReading(uint32_t stripeIndex);
 
-  /// Builds read segments from request ranges based on filter presence.
-  /// Dispatches to mergeStripeRowRanges or splitStripeRowRanges.
+  // Builds read segments from request ranges based on filter presence.
+  // Dispatches to mergeStripeRowRanges or splitStripeRowRanges.
   void buildStripeReadSegments(
       const std::vector<std::pair<velox::vector_size_t, RowRange>>&
           requestRanges);
 
-  /// Builds read segments by merging overlapping row ranges.
-  /// Used when no filters are present for efficient reading with seek.
+  // Builds read segments by merging overlapping row ranges.
+  // Used when no filters are present for efficient reading with seek.
   void mergeStripeRowRanges(
       const std::vector<std::pair<velox::vector_size_t, RowRange>>&
           requestRanges);
 
-  /// Builds read segments by splitting overlapping row ranges into
-  /// non-overlapping segments. Used when filters are present.
+  // Builds read segments by splitting overlapping row ranges into
+  // non-overlapping segments. Used when filters are present.
   void splitStripeRowRanges(
       const std::vector<std::pair<velox::vector_size_t, RowRange>>&
           requestRanges);
 
-  /// Loads a stripe and performs index lookup to determine row ranges.
-  /// @param stripeIndex The index of the stripe to load.
+  // Loads a stripe and performs index lookup to determine row ranges.
+  // @param stripeIndex The index of the stripe to load.
   void loadStripeWithIndex(uint32_t stripeIndex);
 
-  /// Looks up row ranges for each request within a specific stripe.
-  /// @param stripeIndex The stripe to look up.
-  /// @param keyBounds The encoded key bounds for each request.
-  /// @return Vector of row ranges, one per request.
+  // Looks up row ranges for each request within a specific stripe.
+  // @param stripeIndex The stripe to look up.
+  // @param keyBounds The encoded key bounds for each request.
+  // @return Vector of row ranges, one per request.
   std::vector<RowRange> lookupRowRanges(
       uint32_t stripeIndex,
       const std::vector<velox::serializer::EncodedKeyBounds>& keyBounds);
 
-  /// Prepares the column reader for reading the current segment by seeking to
-  /// the segment's start row. Does nothing if readSegmentIndex_ is out of
-  /// range.
+  // Prepares the column reader for reading the current segment by seeking to
+  // the segment's start row. Does nothing if readSegmentIndex_ is out of
+  // range.
   void prepareStripeSegmentRead();
 
-  /// Reads a fragment of data from the current stripe's read segment.
-  /// @param output The output vector to populate.
-  /// @return Number of rows read.
+  // Reads a fragment of data from the current stripe's read segment.
+  // @param output The output vector to populate.
+  // @return Number of rows read.
   uint64_t readStripeFragment(velox::RowVectorPtr& output);
 
-  /// Advances to the next read segment within the current stripe.
+  // Advances to the next read segment within the current stripe.
   void advanceStripeReadSegment();
 
-  /// Advances to the next stripe in the iteration.
+  // Advances to the next stripe in the iteration.
   void advanceStripe();
 
-  /// Adds output data for a segment to the output chunks and tracks references.
-  /// @param segment The segment that produced this output.
-  /// @param output The output data to add.
+  // Adds output data for a segment to the output chunks and tracks references.
+  // @param segment The segment that produced this output.
+  // @param output The output data to add.
   void addStripeSegmentOutput(
       const ReadSegment& segment,
       velox::RowVectorPtr output);
 
-  /// Tracks output references for requests in a segment.
-  /// @param segment The segment containing request indices.
-  /// @param outputIndex Index of the output chunk.
-  /// @param outputRows Number of rows in the output.
+  // Tracks output references for requests in a segment.
+  // @param segment The segment containing request indices.
+  // @param outputIndex Index of the output chunk.
+  // @param outputRows Number of rows in the output.
   void trackStripeSegmentOutputRefs(
       const ReadSegment& segment,
       size_t outputIndex,
       velox::vector_size_t outputRows);
 
-  /// Updates pending stripe counts for requests after processing a segment.
-  /// @param segment The segment that was processed.
+  // Updates pending stripe counts for requests after processing a segment.
+  // @param segment The segment that was processed.
   void updatePendingStripes(const ReadSegment& segment);
 
-  /// Updates the count of ready output requests that can be returned.
+  // Updates the count of ready output requests that can be returned.
   void updateReadyOutputRequests();
 
-  /// Checks if enough output is ready to produce results.
-  /// @param maxOutputRows Maximum rows to produce.
-  /// @return True if output can be produced.
+  // Checks if enough output is ready to produce results.
+  // @param maxOutputRows Maximum rows to produce.
+  // @return True if output can be produced.
   bool canProduceOutput(velox::vector_size_t maxOutputRows) const;
 
-  /// Produces the next batch of output results.
-  /// @return Result containing output rows and request indices.
+  // Produces the next batch of output results.
+  // @return Result containing output rows and request indices.
   std::unique_ptr<Result> produceOutput();
 
-  /// Resets all state for a new lookup operation.
+  // Removes a request from all stripes starting from startStripeIdx. Called
+  // when a request has reached its maxRowsPerRequest_ limit and the remaining
+  // rows will be processed within the current stripe.
+  // @param requestIdx The request index to remove from subsequent stripes.
+  // @param startStripeIdx The starting stripe index to remove from.
+  void removeRequestFromSubsequentStripes(
+      velox::vector_size_t requestIdx,
+      size_t startStripeIdx);
+
+  // Resets all state for a new lookup operation.
   void reset();
 
   const std::shared_ptr<ReaderBase> readerBase_;
@@ -277,6 +288,7 @@ class SelectiveNimbleIndexReader : public velox::dwio::common::IndexReader {
 
   // Current lookup state.
   size_t numRequests_{0};
+  Options requestOptions_;
   std::vector<velox::serializer::EncodedKeyBounds> encodedKeyBounds_;
   std::vector<uint32_t> stripes_;
   folly::F14FastMap<uint32_t, std::vector<velox::vector_size_t>>


### PR DESCRIPTION
Summary:
This diff adds a `maxRowsPerIndexRequest` configuration option that limits the number of rows returned per index lookup request. This is useful for controlling memory usage and query performance when index lookups could potentially return very large result sets.

The implementation works differently based on whether filters are applied:
- **Without filters**: Stripes can be pruned upfront based on pre-filter row counts since input rows == output rows. Middle stripes are considered for truncation (first/last stripes may be partial with unknown row counts until `lookupRowRanges()`).
- **With filters**: Truncation is applied during output tracking in `trackStripeSegmentOutputRefs()` since we don't know output rows ahead of time.

- Add `maxRowsPerIndexRequest` config in `HiveConfig` (both session and config-level)
- Extend `IndexReader::Options` to pass `maxRowsPerRequest` to the reader
- Implement stripe pruning and row range truncation in `SelectiveNimbleIndexReader`
- Add `removeRequestFromSubsequentStripes()` helper for cleaning up requests that have reached their limit
- Add comprehensive unit tests for both `HiveIndexReader` and `HiveIndexSource` APIs

Differential Revision: D93313029


