### PR TITLE
refactor: Rename VeloxWriter::RunStats to Stats and cleanup API

### DIFF
--- a/dwio/nimble/velox/VeloxWriter.cpp
+++ b/dwio/nimble/velox/VeloxWriter.cpp
@@ -865,14 +865,14 @@ void VeloxWriter::close() {
       file_->close();
       context_->setBytesWritten(file_->size());
 
-      auto runStats = getRunStats();
+      auto stats = this->stats();
       // TODO: compute and populate input size.
       FileCloseMetrics metrics{
           .rowCount = context_->rowsInFile(),
           .stripeCount = context_->getStripeIndex(),
           .fileSize = context_->bytesWritten(),
-          .totalFlushCpuUsec = runStats.flushCpuTimeUsec,
-          .totalFlushWallTimeUsec = runStats.flushWallTimeUsec};
+          .totalFlushCpuUsec = stats.flushCpuTimeUs,
+          .totalFlushWallTimeUsec = stats.flushWallTimeUs};
       context_->logger()->logFileClose(metrics);
       file_ = nullptr;
     } catch (const std::exception& e) {
@@ -1341,15 +1341,15 @@ bool VeloxWriter::evaluateFlushPolicy() {
   return false;
 }
 
-VeloxWriter::RunStats VeloxWriter::getRunStats() const {
-  return RunStats{
+VeloxWriter::Stats VeloxWriter::stats() const {
+  return Stats{
       .bytesWritten = context_->bytesWritten(),
       .stripeCount = folly::to<uint32_t>(context_->getStripeIndex()),
       .rawSize = context_->fileRawSize(),
       .rowsPerStripe = context_->rowsPerStripe(),
-      .flushCpuTimeUsec = context_->totalFlushTiming().cpuNanos / 1'000,
-      .flushWallTimeUsec = context_->totalFlushTiming().wallNanos / 1'000,
-      .encodingSelectionCpuTimeUsec =
+      .flushCpuTimeUs = context_->totalFlushTiming().cpuNanos / 1'000,
+      .flushWallTimeUs = context_->totalFlushTiming().wallNanos / 1'000,
+      .encodingSelectionCpuTimeUs =
           context_->encodingSelectionTiming().cpuNanos / 1'000,
       .inputBufferReallocCount = context_->inputBufferGrowthStats().count,
       .inputBufferReallocItemCount =

--- a/dwio/nimble/velox/VeloxWriter.h
+++ b/dwio/nimble/velox/VeloxWriter.h
@@ -57,25 +57,32 @@ class VeloxWriter {
 
   void flush();
 
-  struct RunStats {
+  struct Stats {
+    // Total bytes written to the file.
     uint64_t bytesWritten;
+    // Number of stripes written to the file.
     uint32_t stripeCount;
+    // Uncompressed size of data written to the file.
     uint64_t rawSize;
+    // Number of rows in each stripe.
     std::vector<uint64_t> rowsPerStripe;
-    uint64_t flushCpuTimeUsec;
-    uint64_t flushWallTimeUsec;
-    uint64_t encodingSelectionCpuTimeUsec;
-    // These 2 stats should be from memory pool and have better
-    // coverage in the future.
+    // CPU time spent flushing data in microseconds.
+    uint64_t flushCpuTimeUs;
+    // Wall clock time spent flushing data in microseconds.
+    uint64_t flushWallTimeUs;
+    // CPU time spent on encoding selection in microseconds.
+    uint64_t encodingSelectionCpuTimeUs;
+    // Number of input buffer reallocations. These 2 stats should be from memory
+    // pool and have better coverage in the future.
     uint64_t inputBufferReallocCount;
+    // Number of items moved during input buffer reallocations.
     uint64_t inputBufferReallocItemCount;
-    // std::unordered_map<offset_size, ColumnStats> columnStats;
-    // Only available at file close.
-    // NOTE: expected to be exposed as a view, for merging with
-    // base stats objects. User needs to explicitly copy.
+    // Per-column statistics. Only available at file close.
+    // NOTE: expected to be exposed as a view, for merging with base stats
+    // objects. User needs to explicitly copy.
     std::vector<ColumnStatistics*> columnStats;
   };
-  RunStats getRunStats() const;
+  Stats stats() const;
 
  private:
   inline bool hasIndex() const;

--- a/dwio/nimble/velox/tests/FieldWriterStatsTests.cpp
+++ b/dwio/nimble/velox/tests/FieldWriterStatsTests.cpp
@@ -91,7 +91,7 @@ class FieldWriterStatsTests : public ::testing::Test {
     writer.close();
 
     // Verify returned column stats.
-    const auto& actualStats = writer.getRunStats().columnStats;
+    const auto& actualStats = writer.stats().columnStats;
     ASSERT_EQ(actualStats.size(), expectedStats.size());
     for (auto i = 0; i < actualStats.size(); ++i) {
       const auto& actualStat = actualStats.at(i);
@@ -1293,7 +1293,7 @@ TEST_F(FieldWriterStatsTests, flatmapWithDeduplicatedValuesStats) {
   writer.close();
 
   // Verify the writer completed successfully and stats are collected
-  const auto& actualStats = writer.getRunStats().columnStats;
+  const auto& actualStats = writer.stats().columnStats;
   ASSERT_FALSE(actualStats.empty());
 
   // The root stats should have non-zero logical size
@@ -1381,7 +1381,7 @@ TEST_F(FieldWriterStatsTests, flatmapWithSlidingWindowMapStats) {
   writer.close();
 
   // Verify the writer completed successfully and stats are collected
-  const auto& actualStats = writer.getRunStats().columnStats;
+  const auto& actualStats = writer.stats().columnStats;
   ASSERT_FALSE(actualStats.empty());
 
   // The root stats should have non-zero logical size


### PR DESCRIPTION
Summary:
Improve VeloxWriter stats API naming and documentation:
- Rename `RunStats` struct to `Stats` for brevity
- Rename `getRunStats()` method to `stats()` following common C++ conventions
- Rename time fields from `*Usec` suffix to `*Us` suffix for consistency
- Add documentation comments for each field in the Stats struct

This makes the API more concise and self-documenting.

Differential Revision: D93385724


