### PR TITLE
Optimize ChunkedDecoder performance

### DIFF
--- a/dwio/nimble/velox/selective/ChunkedDecoder.h
+++ b/dwio/nimble/velox/selective/ChunkedDecoder.h
@@ -295,11 +295,12 @@ class ChunkedDecoder {
       numNonNulls =
           std::min<int64_t>(end - params.numScanned, remainingValues_);
     }
-    auto i = visitor.rowIndex();
-    while (i < numRows && visitor.rowAt(i) < chunkEnd) {
-      ++i;
-    }
-    return i;
+
+    return std::lower_bound(
+               visitor.rows() + visitor.rowIndex(),
+               visitor.rows() + numRows,
+               chunkEnd) -
+        visitor.rows();
   }
 
   template <bool kHasNulls, typename V>


### PR DESCRIPTION
Summary:
One optimizations in ChunkedDecoder:
Replace linear search with binary search (std::lower_bound) in computeNextRowIndex for non-dense visitor mode. The rows array is already sorted, so this improves lookup from O(n) to O(log n).

Differential Revision: D93546256


