### PR TITLE
refactor(dwio): Migrate folly/experimental/io to canonical paths

### DIFF
--- a/dwio/nimble/encodings/tests/TestGenerator.cpp
+++ b/dwio/nimble/encodings/tests/TestGenerator.cpp
@@ -22,7 +22,7 @@
 
 #include "common/init/light.h"
 #include "dwio/nimble/encodings/tests/TestUtils.h"
-#include "folly/experimental/io/FsUtil.h"
+#include "folly/io/FsUtil.h"
 
 using namespace facebook;
 


### PR DESCRIPTION
Summary:
Update dwio consumers to use canonical include paths and BUCK deps instead of folly/experimental/io shims.

Header migrations:
- folly/experimental/io/FsUtil.h → folly/io/FsUtil.h

BUCK dep migrations:
- //folly/experimental/io:fs_util → //folly/io:fs_util

Reviewed By: xiaoxmeng

Differential Revision: D93656818


