### PR TITLE
refactor: Trivial cleanup in FieldReader, FieldWriter, StreamUtil

### DIFF
--- a/dwio/nimble/velox/FieldReader.cpp
+++ b/dwio/nimble/velox/FieldReader.cpp
@@ -2615,8 +2615,8 @@ class FlatMapKeyNode {
   }
 
   void loadValues(velox::VectorPtr& values) {
-    valueReader_->next(numValues_, values, /* scatterBitmap */ nullptr);
-    NIMBLE_DCHECK(numValues_ == values->size(), "Items not loaded");
+    valueReader_->next(numValues_, values, /*scatterBitmap=*/nullptr);
+    NIMBLE_DCHECK_EQ(numValues_, values->size(), "Items not loaded");
   }
 
   void skip(uint32_t numValues) {


### PR DESCRIPTION
Summary:
Minor style improvements:
- Use const auto where applicable
- Brace initialization
- Explicit null checks (if (ptr != nullptr) instead of if (ptr))
- Use asChecked<> instead of as<> with separate null check
- NIMBLE_DCHECK_EQ instead of NIMBLE_DCHECK for equality checks

Differential Revision: D94037387


