### PR TITLE
fix(writer): Fix KeyStreamOffset overflow by using stripe-level offset

### DIFF
--- a/dwio/nimble/index/StripeIndexGroup.cpp
+++ b/dwio/nimble/index/StripeIndexGroup.cpp
@@ -241,7 +241,8 @@ uint32_t StripeIndexGroup::rowCount(uint32_t stripe, uint32_t streamId) const {
 }
 
 velox::common::Region StripeIndexGroup::keyStreamRegion(
-    uint32_t stripeIndex) const {
+    uint32_t stripeIndex,
+    uint64_t stripeBaseOffset) const {
   const uint32_t stripeOffset = this->stripeOffset(stripeIndex);
   const auto* root =
       asFlatBuffersRoot<serialization::StripeIndexGroup>(metadata_->content());
@@ -262,7 +263,9 @@ velox::common::Region StripeIndexGroup::keyStreamRegion(
   const uint32_t keyStreamOffset = offsets->Get(stripeOffset);
   const uint32_t keyStreamSize = sizes->Get(stripeOffset);
   NIMBLE_CHECK_GT(keyStreamSize, 0);
-  return velox::common::Region{keyStreamOffset, keyStreamSize};
+
+  return velox::common::Region{
+      stripeBaseOffset + keyStreamOffset, keyStreamSize};
 }
 
 std::unique_ptr<StreamIndex> StreamIndex::create(

--- a/dwio/nimble/index/StripeIndexGroup.h
+++ b/dwio/nimble/index/StripeIndexGroup.h
@@ -77,7 +77,9 @@ class StripeIndexGroup {
 
   /// Returns the region for the key stream of the specified stripe.
   /// The key stream is stored in the StripeIndexGroup metadata.
-  velox::common::Region keyStreamRegion(uint32_t stripeIndex) const;
+  velox::common::Region keyStreamRegion(
+      uint32_t stripeIndex,
+      uint64_t stripeBaseOffset) const;
 
  private:
   StripeIndexGroup(

--- a/dwio/nimble/tablet/Index.fbs
+++ b/dwio/nimble/tablet/Index.fbs
@@ -21,7 +21,8 @@ namespace facebook.nimble.serialization;
 /// Value index for key stream data within a stripe group.
 /// Contains stream-level and chunk-level metadata for key-based lookups.
 table StripeValueIndex {
-  /// Byte offset of key stream for each stripe (relative to file start).
+  /// Byte offset of key stream for each stripe, relative to each stripe's
+  /// data start position.
   key_stream_offsets:[uint32];
   /// Byte size of key stream for each stripe.
   key_stream_sizes:[uint32];

--- a/dwio/nimble/tablet/TabletIndexWriter.h
+++ b/dwio/nimble/tablet/TabletIndexWriter.h
@@ -120,7 +120,8 @@ class TabletIndexWriter {
   /// Records chunk-level metadata including row counts, byte offsets, and
   /// last key values for each chunk.
   ///
-  /// @param keyStreamOffset File offset where the key stream starts.
+  /// @param keyStreamOffset Key stream offset relative to the stripe's data
+  ///        start position.
   /// @param keyChunks Key chunks to write.
   /// @param writeWithChecksum Callback to write data with checksum.
   /// @return Number of bytes written for the key stream.

--- a/dwio/nimble/tablet/TabletWriter.cpp
+++ b/dwio/nimble/tablet/TabletWriter.cpp
@@ -566,9 +566,9 @@ void TabletWriter::writeKeyStream(const std::optional<KeyStream>& keyStream) {
   NIMBLE_CHECK(keyStream.has_value());
 
   indexWriter_->writeKeyStream(
-      file_->size(), keyStream.value().chunks, [this](std::string_view data) {
-        writeWithChecksum(data);
-      });
+      file_->size() - stripeOffsets_.back(),
+      keyStream.value().chunks,
+      [this](std::string_view data) { writeWithChecksum(data); });
 }
 
 void TabletWriter::addStreamIndex(

--- a/dwio/nimble/tools/NimbleDumpLib.cpp
+++ b/dwio/nimble/tools/NimbleDumpLib.cpp
@@ -1173,8 +1173,8 @@ void NimbleDumpLib::emitIndex() {
          ++stripeIndex) {
       auto stripeId =
           tabletReader->stripeIdentifier(stripeIndex, /*loadIndex=*/true);
-      auto keyStreamRegion =
-          stripeId.indexGroup()->keyStreamRegion(stripeIndex);
+      auto keyStreamRegion = stripeId.indexGroup()->keyStreamRegion(
+          stripeIndex, tabletReader->stripeOffset(stripeIndex));
       keyStreamFormatter.writeRow({
           std::to_string(stripeIndex),
           commaSeparated(keyStreamRegion.offset),

--- a/dwio/nimble/velox/selective/ReaderBase.cpp
+++ b/dwio/nimble/velox/selective/ReaderBase.cpp
@@ -137,7 +137,8 @@ StripeStreams::enqueueKeyStream() {
   const auto& indexGroup = stripeIdentifier_->indexGroup();
   NIMBLE_CHECK_NOT_NULL(indexGroup);
 
-  const auto region = indexGroup->keyStreamRegion(stripe_);
+  const auto region = indexGroup->keyStreamRegion(
+      stripe_, readerBase_->tablet().stripeOffset(stripe_));
   const dwio::common::StreamIdentifier sid(kKeyStreamId);
   return readerBase_->input().enqueue(region, &sid);
 }

--- a/dwio/nimble/velox/tests/VeloxWriterTest.cpp
+++ b/dwio/nimble/velox/tests/VeloxWriterTest.cpp
@@ -3286,8 +3286,8 @@ class VeloxWriterIndexTest
             << stripeIndex;
 
         // Get key stream region for this stripe
-        const auto keyStreamRegion =
-            stripeId.indexGroup()->keyStreamRegion(stripeIndex);
+        const auto keyStreamRegion = stripeId.indexGroup()->keyStreamRegion(
+            stripeIndex, tablet.stripeOffset(stripeIndex));
 
         // Cache key: chunk file offset (unique across all stripes)
         const uint64_t chunkFileOffset =
@@ -4105,7 +4105,8 @@ TEST_F(VeloxWriterTest, customPrefixRestartInterval) {
         << "Index group should be available";
 
     // Get key stream region
-    const auto keyStreamRegion = stripeId.indexGroup()->keyStreamRegion(0);
+    const auto keyStreamRegion =
+        stripeId.indexGroup()->keyStreamRegion(0, tablet->stripeOffset(0));
 
     // Load the key stream data
     velox::common::Region region{


### PR DESCRIPTION
Summary: Fix KeyStreamOffset overflow by using stripe-level offset

Differential Revision: D93991879


