### PR TITLE
fix: Fix int32_t overflow in LegacyStringFieldReader for batches with >2GB string data

### DIFF
--- a/dwio/nimble/velox/FieldReader.cpp
+++ b/dwio/nimble/velox/FieldReader.cpp
@@ -781,18 +781,18 @@ class LegacyStringFieldReader final : public FieldReader {
         stringBuffers,
         [&]() { return ensureNulls(vector, rowCount); },
         scatterBitmap);
-    int32_t totalLength = 0;
+    size_t totalLength = 0;
     const bool hasNulls = (nonNullCount != rowCount);
     if (!hasNulls) {
       vector->resetNulls();
       for (uint32_t i = 0; i < rowCount; ++i) {
-        totalLength += static_cast<int32_t>(buffer_[i].length());
+        totalLength += buffer_[i].length();
       }
     } else {
       vector->setNullCount(rowCount - nonNullCount);
       for (uint32_t i = 0; i < rowCount; ++i) {
         if (!vector->isNullAt(i)) {
-          totalLength += static_cast<int32_t>(buffer_[i].length());
+          totalLength += buffer_[i].length();
         }
       }
     }
@@ -801,7 +801,7 @@ class LegacyStringFieldReader final : public FieldReader {
         velox::AlignedBuffer::allocate<char>(totalLength, pool_);
     char* dataPtr = data->asMutable<char>();
     auto* valuesPtr = vector->mutableValues()->asMutable<velox::StringView>();
-    int32_t currentOffset = 0;
+    size_t currentOffset = 0;
     if (!hasNulls) {
       for (uint32_t i = 0; i < rowCount; ++i) {
         std::copy(buffer_[i].data(), buffer_[i].end(), dataPtr + currentOffset);


### PR DESCRIPTION
Summary:
`LegacyStringFieldReader::next` used `int32_t` for `totalLength` and
`currentOffset` when accumulating the total byte length of all strings
in a batch. When the total string data exceeds 2GB (~2.1 billion bytes),
`int32_t` overflows to a negative value. This negative value is then
implicitly sign-extended to `size_t` (unsigned 64-bit) when passed to
`AlignedBuffer::allocate<char>()`, producing a near-UINT64_MAX value
(e.g. 18446744072179713190) which fails the `preferredSize >= size`
assertion in `MemoryPool::preferredSize`.

The bug was introduced in D88676104, which created `LegacyStringFieldReader`
as a separate class from `StringFieldReader`. The original `StringFieldReader`
set string views individually without accumulating lengths, so it never
had this overflow. The new `LegacyStringFieldReader` uses an
accumulate-and-copy pattern but incorrectly used `int32_t` for the
accumulator.

Fix: Change `totalLength` and `currentOffset` from `int32_t` to `size_t`,
and remove the unnecessary `static_cast<int32_t>` on individual string
lengths.

Reviewed By: srsuryadev

Differential Revision: D94171941


