### PR TITLE
fix: FixedBitWidthEncoding - skip compression when it is not effective for byte aligned data

### DIFF
--- a/dwio/nimble/velox/tests/FieldWriterStatsTest.cpp
+++ b/dwio/nimble/velox/tests/FieldWriterStatsTest.cpp
@@ -1136,7 +1136,7 @@ TEST_F(FieldWriterStatsTests, mixedColumnsFieldWriterStats) {
   auto mapKeyStat = ColumnStats{
       .logicalSize = sizeof(int8_t) * 8, .physicalSize = 20, .valueCount = 8};
   auto mapValueStat = ColumnStats{
-      .logicalSize = sizeof(int32_t) * 8, .physicalSize = 32, .valueCount = 8};
+      .logicalSize = sizeof(int32_t) * 8, .physicalSize = 28, .valueCount = 8};
   auto mapStat = ColumnStats{
       .logicalSize = mapKeyStat.logicalSize + mapValueStat.logicalSize +
           nimble::kNullSize * 2,


### PR DESCRIPTION
Summary:
Skip compression on when it is not effective for byte padded data

From microbenchmarks, we see ~150-165% gain in compression ratio with nearly same CPU compute.

Differential Revision: D92934530


