### PR TITLE
feat: Add nimble encoding support in serializer/deserializer

### DIFF
--- a/dwio/nimble/encodings/EncodingSelection.h
+++ b/dwio/nimble/encodings/EncodingSelection.h
@@ -79,25 +79,47 @@ struct ZstdCompressionParameters {
 /// An identifier for the meta internal compression policy.
 class MetaInternalCompressionKey {
  public:
+  MetaInternalCompressionKey() = default;
+
+  MetaInternalCompressionKey(
+      std::string ns,
+      std::string tableName,
+      std::string columnName)
+      : ns_{std::move(ns)},
+        tableName_{std::move(tableName)},
+        columnName_{std::move(columnName)} {}
+
+  const std::string& ns() const {
+    return ns_;
+  }
+
+  const std::string& tableName() const {
+    return tableName_;
+  }
+
+  const std::string& columnName() const {
+    return columnName_;
+  }
+
   std::string toString() const {
-    folly::dynamic json = folly::dynamic::object("ns", ns)(
-        "tableName", tableName)("columnName", columnName);
+    folly::dynamic json = folly::dynamic::object("ns", ns_)(
+        "tableName", tableName_)("columnName", columnName_);
     return folly::toJson(json);
   }
 
   static MetaInternalCompressionKey fromString(const std::string& str) {
     // will throw upon failure to parse or missing fields
     auto json = folly::parseJson(str);
-    return {
-        .ns = json["ns"].asString(),
-        .tableName = json["tableName"].asString(),
-        .columnName = json["columnName"].asString(),
-    };
+    return MetaInternalCompressionKey{
+        json["ns"].asString(),
+        json["tableName"].asString(),
+        json["columnName"].asString()};
   }
 
-  std::string ns;
-  std::string tableName;
-  std::string columnName;
+ private:
+  std::string ns_;
+  std::string tableName_;
+  std::string columnName_;
 };
 
 struct MetaInternalCompressionParameters {

--- a/dwio/nimble/encodings/EncodingSelectionPolicy.h
+++ b/dwio/nimble/encodings/EncodingSelectionPolicy.h
@@ -669,4 +669,6 @@ class ReplayedEncodingSelectionPolicy
   const EncodingSelectionPolicyFactory& encodingSelectionPolicyFactory_;
 };
 
+#undef COMMA
+
 } // namespace facebook::nimble

--- a/dwio/nimble/encodings/tests/MetaInternalCompressionKeyTest.cpp
+++ b/dwio/nimble/encodings/tests/MetaInternalCompressionKeyTest.cpp
@@ -27,77 +27,68 @@ class MetaInternalCompressionKeyTest : public ::testing::Test {
     MetaInternalCompressionKey deserialized =
         MetaInternalCompressionKey::fromString(serialized);
 
-    EXPECT_EQ(key.ns, deserialized.ns);
-    EXPECT_EQ(key.tableName, deserialized.tableName);
-    EXPECT_EQ(key.columnName, deserialized.columnName);
+    EXPECT_EQ(key.ns(), deserialized.ns());
+    EXPECT_EQ(key.tableName(), deserialized.tableName());
+    EXPECT_EQ(key.columnName(), deserialized.columnName());
   }
 };
 
 TEST_F(MetaInternalCompressionKeyTest, BasicRoundTrip) {
-  MetaInternalCompressionKey key{
-      .ns = "namespace", .tableName = "table", .columnName = "column"};
+  MetaInternalCompressionKey key{"namespace", "table", "column"};
 
   roundTripTest(key);
 }
 
 TEST_F(MetaInternalCompressionKeyTest, EmptyFields) {
-  MetaInternalCompressionKey key{.ns = "", .tableName = "", .columnName = ""};
+  MetaInternalCompressionKey key{"", "", ""};
 
   roundTripTest(key);
 }
 
 TEST_F(MetaInternalCompressionKeyTest, SingleFieldEmpty) {
   // Test with one field empty at a time
-  MetaInternalCompressionKey key1{
-      .ns = "", .tableName = "table", .columnName = "column"};
+  MetaInternalCompressionKey key1{"", "table", "column"};
   roundTripTest(key1);
 
-  MetaInternalCompressionKey key2{
-      .ns = "namespace", .tableName = "", .columnName = "column"};
+  MetaInternalCompressionKey key2{"namespace", "", "column"};
   roundTripTest(key2);
 
-  MetaInternalCompressionKey key3{
-      .ns = "namespace", .tableName = "table", .columnName = ""};
+  MetaInternalCompressionKey key3{"namespace", "table", ""};
   roundTripTest(key3);
 }
 
 TEST_F(MetaInternalCompressionKeyTest, ColonCharacters) {
   // Test with colon characters in various fields
-  MetaInternalCompressionKey key1{
-      .ns = "name:space", .tableName = "table", .columnName = "column"};
+  MetaInternalCompressionKey key1{"name:space", "table", "column"};
   roundTripTest(key1);
 
-  MetaInternalCompressionKey key2{
-      .ns = "namespace", .tableName = "ta:ble", .columnName = "column"};
+  MetaInternalCompressionKey key2{"namespace", "ta:ble", "column"};
   roundTripTest(key2);
 
-  MetaInternalCompressionKey key3{
-      .ns = "namespace", .tableName = "table", .columnName = "col:umn"};
+  MetaInternalCompressionKey key3{"namespace", "table", "col:umn"};
   roundTripTest(key3);
 
   // Test with multiple colons in each field
   MetaInternalCompressionKey key4{
-      .ns = "name::space:with:many:colons",
-      .tableName = "ta::ble::name",
-      .columnName = "col::umn::name"};
+      "name::space:with:many:colons", "ta::ble::name", "col::umn::name"};
   roundTripTest(key4);
 }
 
 TEST_F(MetaInternalCompressionKeyTest, SpecialCharacters) {
   // Test with various special characters that JSON should handle properly
   MetaInternalCompressionKey key{
-      .ns = "namespace\"with'quotes",
-      .tableName = "table\nwith\nnewlines",
-      .columnName = "column\\with\\backslashes"};
+      "namespace\"with'quotes",
+      "table\nwith\nnewlines",
+      "column\\with\\backslashes"};
   roundTripTest(key);
 }
 
 TEST_F(MetaInternalCompressionKeyTest, MixedSpecialCharacters) {
   // Test with a mix of challenging characters
   MetaInternalCompressionKey key{
-      .ns = "ns:with\"quotes'and\nnewlines\tand\\\\:backslashes",
-      .tableName = "table:with:many:colons:and\"quotes",
-      .columnName = "column\nwith\r\nmixed\ttabs:and\\:colons"};
+      "ns:with\"quotes'and\nnewlines\tand\\\\:backslashes",
+      "table:with:many:colons:and\"quotes",
+      "column\nwith\r\nmixed\ttabs:and\\:colons"};
   roundTripTest(key);
 }
 
@@ -141,16 +132,16 @@ TEST_F(MetaInternalCompressionKeyTest, ExtraFieldsInJson) {
   // Test that extra fields in JSON are ignored
   std::string jsonWithExtra = R"({
     "ns": "namespace",
-    "tableName": "table", 
+    "tableName": "table",
     "columnName": "column",
     "extraField": "ignored"
   })";
 
   MetaInternalCompressionKey key =
       MetaInternalCompressionKey::fromString(jsonWithExtra);
-  EXPECT_EQ(key.ns, "namespace");
-  EXPECT_EQ(key.tableName, "table");
-  EXPECT_EQ(key.columnName, "column");
+  EXPECT_EQ(key.ns(), "namespace");
+  EXPECT_EQ(key.tableName(), "table");
+  EXPECT_EQ(key.columnName(), "column");
 }
 
 TEST_F(MetaInternalCompressionKeyTest, NullValuesInJson) {


### PR DESCRIPTION
Summary:
CONTEXT: The current serializer uses simple zstd compression for non-string
scalar streams. This provides limited compression efficiency compared to
nimble's specialized encodings (Dictionary, RLE, FixedBitWidth, Constant, etc.)
which are optimized for columnar data patterns.

WHAT: This change integrates the nimble encoding framework to enable better
compression and read performance:

1. **New Options**:
   - `SerializerOptions.enableNimbleEncoding`: Enable nimble encoding for
     scalar streams (default: false for backward compatibility)
   - `SerializerOptions.encodingSelectionPolicyFactory`: Factory for creating
     encoding selection policies (default: ManualEncodingSelectionPolicyFactory)
   - `SerializerOptions.compressionOptions`: Compression options for encodings
   - `DeserializerOptions.enableNimbleEncoding`: Enable nimble decoding

2. **Serialization Changes** (SerializerImpl.h):
   - Added `encodeWithNimble<T>()` template for type-specific nimble encoding
   - Added `encodeScalarWithNimble<Buffer>()` for runtime ScalarKind dispatch
   - Updated `StreamDataWriter::encodeStream()` to use nimble encoding when
     enabled, with wire format: [size:u32][nimble_encoded_data...]
   - String/Binary types continue using existing format (nimble encoding for
     strings not yet supported)

3. **Deserialization Changes** (DeserializerImpl.h/cpp, Deserializer.cpp):
   - Added `StreamData` constructor with nimble encoding support
   - Added `decodeNimble()` using `EncodingFactory::decode()` to create nimble
     `Encoding` object from encoded data
   - `StreamData::decode<T>()` template uses `Encoding::materialize()` for
     nimble-encoded streams, falls back to legacy copy for others
   - Updated `DeserializerImpl::addBatch()` to detect nimble encoding and
     create appropriate StreamData instances

4. **Backward Compatibility**:
   - `enableNimbleEncoding=false` (default) preserves existing wire format
   - Legacy encoded data continues to work with the existing decode path
   - Detection based on `enableNimbleEncoding` option, not data inspection

Differential Revision: D94253315


