### PR TITLE
perf: Optimize deduplicated readers when all nested rows are selected

### DIFF
--- a/.github/workflows/sanity_check.yml
+++ b/.github/workflows/sanity_check.yml
@@ -15,6 +15,11 @@ name: Run Sanity Checks
 
 on:
   pull_request:
+    types:
+      - opened
+      - reopened
+      - edited
+      - synchronize
 
 permissions:
   contents: read


### PR DESCRIPTION
Summary:
When all nested rows are selected, we use `velox::iota` to both
allocate memory and (avoid to) initialize the row set values.  This decreases
both memory and cpu usage when no rows are filtered out.

Differential Revision: D94093080


