### PR TITLE
refactor: Migrate remaining string constants to string_view

### DIFF
--- a/dwio/nimble/velox/selective/tests/E2EIndexTest.cpp
+++ b/dwio/nimble/velox/selective/tests/E2EIndexTest.cpp
@@ -127,9 +127,9 @@ struct IndexEncodingParam {
 // Test helper to capture runtime stats.
 class TestRuntimeStatWriter : public BaseRuntimeStatWriter {
  public:
-  void addRuntimeStat(const std::string& name, const RuntimeCounter& value)
+  void addRuntimeStat(std::string_view name, const RuntimeCounter& value)
       override {
-    stats_.emplace_back(name, value);
+    stats_.emplace_back(std::string(name), value);
   }
 
   const std::vector<std::pair<std::string, RuntimeCounter>>& stats() const {


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebookincubator/velox/pull/16455

Migrate all remaining `static inline const std::string` constants to `static constexpr std::string_view` across the velox codebase. This follows the same pattern already applied in D93369906 (HashBuild, HashAggregation, TableScan, etc.) and D93369914 (HiveDataSource).

Constants migrated across 13 header files (72+ total):
- exec/Operator.h (17 spill/shuffle stats)
- exec/HashTable.h (16 hash table stats)
- exec/IndexLookupJoin.h (9 index lookup stats)
- exec/TableWriter.h (5 writer stats)
- exec/ScaleWriterLocalPartition.h (3 scale writer stats)
- exec/Merge.h (2 merge stats)
- exec/Window.h (1 window stat)
- exec/PrefixSort.h (1 prefix sort stat)
- exec/trace/Trace.h (14 trace metadata keys)
- connectors/Connector.h (7 connector stats)
- common/memory/SharedArbitrator.h (6 arbitration stats)
- vector/VectorStream.h (3 compression stats)
- dwio/common/Reader.h (5 reader stats)

All usages updated with explicit std::string() wrapping where needed for std::unordered_map<std::string, ...> operations (operator[], .at(), .count(), .find(), .emplace(), .insert()) and for addRuntimeStat/addThreadLocalRuntimeStat/addOperatorRuntimeStats calls which take const std::string&.

Differential Revision: D93702689


