### PR TITLE
feat: Add FileLayout API for optimized reader IO and writer state tracking

### DIFF
--- a/dwio/nimble/tablet/FileLayout.cpp
+++ b/dwio/nimble/tablet/FileLayout.cpp
@@ -26,8 +26,7 @@ namespace facebook::nimble {
 FileLayout FileLayout::create(
     velox::ReadFile* file,
     velox::memory::MemoryPool* pool) {
-  NIMBLE_CHECK_NOT_NULL(pool);
-  auto tablet = TabletReader::create(file, *pool);
+  auto tablet = TabletReader::create(file, pool, {});
 
   FileLayout layout;
   layout.fileSize = tablet->fileSize();

--- a/dwio/nimble/tablet/tests/CMakeLists.txt
+++ b/dwio/nimble/tablet/tests/CMakeLists.txt
@@ -32,7 +32,6 @@ target_link_libraries(
   velox_dwio_common
   velox_memory
   velox_file
-  velox_testutil
   gtest
   gtest_main
   glog::glog

--- a/dwio/nimble/velox/VeloxReader.cpp
+++ b/dwio/nimble/velox/VeloxReader.cpp
@@ -151,9 +151,10 @@ uint64_t NimbleUnit::getIoSize() {
 
 } // namespace
 
-const std::vector<std::string>& VeloxReader::preloadedOptionalSections() {
-  static std::vector<std::string> sections{std::string(kSchemaSection)};
-  return sections;
+TabletReader::Options VeloxReader::defaultTabletReaderOptions() {
+  TabletReader::Options options;
+  options.preloadOptionalSections = {std::string(kSchemaSection)};
+  return options;
 }
 
 VeloxReader::VeloxReader(
@@ -162,11 +163,7 @@ VeloxReader::VeloxReader(
     std::shared_ptr<const velox::dwio::common::ColumnSelector> selector,
     VeloxReadParams params)
     : VeloxReader(
-          TabletReader::create(
-              file,
-              pool,
-              /* preloadOptionalSections */
-              preloadedOptionalSections()),
+          TabletReader::create(file, &pool, defaultTabletReaderOptions()),
           pool,
           std::move(selector),
           std::move(params)) {}
@@ -179,8 +176,8 @@ VeloxReader::VeloxReader(
     : VeloxReader(
           TabletReader::create(
               std::move(file),
-              pool, /* preloadOptionalSections */
-              preloadedOptionalSections()),
+              &pool,
+              defaultTabletReaderOptions()),
           pool,
           std::move(selector),
           std::move(params)) {}

--- a/dwio/nimble/velox/VeloxReader.h
+++ b/dwio/nimble/velox/VeloxReader.h
@@ -175,7 +175,7 @@ class VeloxReader {
   // Returns the total number of rows skipped.
   uint64_t skipStripes(uint32_t startStripeIndex, uint64_t rowsToSkip);
 
-  static const std::vector<std::string>& preloadedOptionalSections();
+  static TabletReader::Options defaultTabletReaderOptions();
 
   std::unique_ptr<velox::dwio::common::UnitLoader> getUnitLoader();
 

--- a/dwio/nimble/velox/VeloxWriter.h
+++ b/dwio/nimble/velox/VeloxWriter.h
@@ -26,8 +26,8 @@
 #include "velox/vector/BaseVector.h"
 #include "velox/vector/DecodedVector.h"
 
-// The VeloxWriter takes a velox VectorPtr and writes it to an Nimble file
-// format.
+/// The VeloxWriter takes a velox VectorPtr and writes it to an Nimble file
+/// format.
 
 namespace facebook::nimble {
 
@@ -39,7 +39,7 @@ class WriterContext;
 
 using index::IndexWriter;
 
-// Writer that takes velox vector as input and produces nimble file.
+/// Writer that takes velox vector as input and produces nimble file.
 class VeloxWriter {
  public:
   VeloxWriter(
@@ -50,7 +50,7 @@ class VeloxWriter {
 
   ~VeloxWriter();
 
-  // Return value of 'true' means this write ended with a flush.
+  /// Return value of 'true' means this write ended with a flush.
   bool write(const velox::VectorPtr& input);
 
   void close();
@@ -58,30 +58,32 @@ class VeloxWriter {
   void flush();
 
   struct Stats {
-    // Total bytes written to the file.
+    /// Total bytes written to the file.
     uint64_t bytesWritten;
-    // Number of stripes written to the file.
+    /// Number of stripes written to the file.
     uint32_t stripeCount;
-    // Uncompressed size of data written to the file.
+    /// Uncompressed size of data written to the file.
     uint64_t rawSize;
-    // Number of rows in each stripe.
+    /// Number of rows in each stripe.
     std::vector<uint64_t> rowsPerStripe;
-    // CPU time spent flushing data in microseconds.
+    /// CPU time spent flushing data in microseconds.
     uint64_t flushCpuTimeUs;
-    // Wall clock time spent flushing data in microseconds.
+    /// Wall clock time spent flushing data in microseconds.
     uint64_t flushWallTimeUs;
-    // CPU time spent on encoding selection in microseconds.
+    /// CPU time spent on encoding selection in microseconds.
     uint64_t encodingSelectionCpuTimeUs;
-    // Number of input buffer reallocations. These 2 stats should be from memory
-    // pool and have better coverage in the future.
+    /// Number of input buffer reallocations. These 2 stats should be from
+    /// memory pool and have better coverage in the future.
     uint64_t inputBufferReallocCount;
-    // Number of items moved during input buffer reallocations.
+    /// Number of items moved during input buffer reallocations.
     uint64_t inputBufferReallocItemCount;
-    // Per-column statistics. Only available at file close.
-    // NOTE: expected to be exposed as a view, for merging with base stats
-    // objects. User needs to explicitly copy.
+    /// Per-column statistics. Only available at file close.
+    /// NOTE: expected to be exposed as a view, for merging with base stats
+    /// objects. User needs to explicitly copy.
     std::vector<ColumnStatistics*> columnStats;
   };
+
+  /// Returns writer statistics.
   Stats stats() const;
 
  private:

--- a/dwio/nimble/velox/selective/ReaderBase.cpp
+++ b/dwio/nimble/velox/selective/ReaderBase.cpp
@@ -28,8 +28,12 @@ using namespace facebook::velox;
 
 namespace {
 const std::string kSchemaSectionString(kSchemaSection);
-const std::vector<std::string> kPreloadOptionalSections = {
-    kSchemaSectionString};
+
+TabletReader::Options defaultTabletReaderOptions() {
+  TabletReader::Options options;
+  options.preloadOptionalSections = {kSchemaSectionString};
+  return options;
+}
 
 std::shared_ptr<const facebook::nimble::Type> loadSchema(
     const TabletReader& tablet) {
@@ -56,8 +60,8 @@ std::shared_ptr<ReaderBase> ReaderBase::create(
   auto tablet = TabletReader::create(
       // TODO: Make TabletReader taking BufferedInput.
       input->getReadFile().get(),
-      options.memoryPool(),
-      kPreloadOptionalSections);
+      &options.memoryPool(),
+      defaultTabletReaderOptions());
 
   auto* pool = &options.memoryPool();
   const auto& randomSkip = options.randomSkip();

--- a/dwio/nimble/velox/tests/VeloxReaderTest.cpp
+++ b/dwio/nimble/velox/tests/VeloxReaderTest.cpp
@@ -372,7 +372,7 @@ size_t streamsReadCount(
     const std::vector<nimble::testing::Chunk>& chunks) {
   // Assumed for the algorithm
   NIMBLE_CHECK_EQ(false, readFile->shouldCoalesce());
-  auto tablet = nimble::TabletReader::create(readFile, pool);
+  auto tablet = nimble::TabletReader::create(readFile, &pool, {});
   NIMBLE_CHECK_GE(tablet->stripeCount(), 1);
   auto stripeIdentifier = tablet->stripeIdentifier(0);
   auto offsets = tablet->streamOffsets(stripeIdentifier);
@@ -782,7 +782,8 @@ class VeloxReaderTest : public ::testing::TestWithParam<bool> {
     std::unique_ptr<velox::InMemoryReadFile> readFile =
         std::make_unique<velox::InMemoryReadFile>(file);
 
-    auto tablet = nimble::TabletReader::create(std::move(readFile), *leafPool_);
+    auto tablet =
+        nimble::TabletReader::create(std::move(readFile), leafPool_.get(), {});
     auto selector =
         std::make_shared<velox::dwio::common::ColumnSelector>(schema);
     std::unique_ptr<nimble::VeloxReader> reader =
@@ -4045,7 +4046,7 @@ class TestNimbleReaderFactory {
   }
 
   std::shared_ptr<nimble::TabletReader> createTablet() {
-    return nimble::TabletReader::create(file_.get(), *pool_);
+    return nimble::TabletReader::create(file_.get(), pool_, {});
   }
 
  private:


### PR DESCRIPTION
Summary:
CONTEXT:
When opening Nimble files, TabletReader performs a discovery phase that reads the
postscript to determine footer size, then reads the footer, and potentially re-reads
stripes if they weren't captured in the initial IO. In scenarios where file layout
metadata is available externally (e.g., from a coordinator or catalog), this discovery
IO can be skipped entirely by providing precomputed layout information.

Additionally, TabletWriter lacked validation to prevent operations after close(),
which could lead to undefined behavior.

WHAT:
1. **FileLayout API for TabletReader**:
   - Add `Options::fileLayout` to accept precomputed file metadata
   - Add `initFromFileLayout()` path that skips postscript discovery IO
   - Refactor `init()` into cleaner helper functions: `initPostScriptAndFooter()`,
     `initStripes()`, `initFooter()`
   - Consolidate TabletReader::create() API to use Options struct consistently

2. **Writer state tracking**:
   - Add State enum (kActive, kClosed) to TabletWriter
   - Add validation in close(), writeStripe(), writeOptionalSection() to prevent
     operations after close
   - Clear error messages for invalid state transitions

3. **TabletReader IO modes**:
   - FileLayout mode: Single coalesced read for footer+stripes+index (0 discovery IO)
   - Adaptive mode (footerIoBytes=0): Reads postscript first, then exact footer size
   - Speculative mode (footerIoBytes>0): Speculative tail read, re-reads if needed

4. **Test coverage**:
   - Add `fileLayoutSkipsPostScriptIo` test verifying IO behavior differences
   - Add `writeAfterCloseThrows` test for writer state validation
   - Add `readerOptionsFileLayoutMismatch` test for error handling
   - Update tests to use NIMBLE_ASSERT_USER_THROW for better error verification

The followup is the cache integration

Differential Revision: D94470250
