### PR TITLE
misc: Move Postscript class from TabletReader.h to FileLayout.h

### DIFF
--- a/dwio/nimble/tablet/FileLayout.cpp
+++ b/dwio/nimble/tablet/FileLayout.cpp
@@ -31,18 +31,12 @@ FileLayout FileLayout::create(
   FileLayout layout;
   layout.fileSize = tablet->fileSize();
 
-  // Postscript
-  const auto footerSize = tablet->footerSize();
-  layout.postscript = {
-      .majorVersion = static_cast<uint16_t>(tablet->majorVersion()),
-      .minorVersion = static_cast<uint16_t>(tablet->minorVersion()),
-      .checksumType = tablet->checksumType(),
-      .footer =
-          MetadataSection{
-              layout.fileSize - footerSize - kPostscriptSize,
-              footerSize,
-              tablet->footerCompressionType()},
-  };
+  // Postscript and footer
+  layout.postscript = tablet->postscript();
+  layout.footer = MetadataSection{
+      layout.fileSize - layout.postscript.footerSize() - kPostscriptSize,
+      layout.postscript.footerSize(),
+      layout.postscript.footerCompressionType()};
 
   // Stripes metadata
   auto stripesMetadata = tablet->stripesMetadata();

--- a/dwio/nimble/tablet/TabletReader.cpp
+++ b/dwio/nimble/tablet/TabletReader.cpp
@@ -167,8 +167,8 @@ Postscript::Postscript(
     uint32_t footerSize,
     CompressionType footerCompressionType,
     ChecksumType checksumType,
-    uint16_t majorVersion,
-    uint16_t minorVersion)
+    uint32_t majorVersion,
+    uint32_t minorVersion)
     : footerSize_(footerSize),
       footerCompressionType_(footerCompressionType),
       checksum_(0),
@@ -178,11 +178,11 @@ Postscript::Postscript(
 
 Postscript Postscript::create(const FileLayout& layout) {
   return Postscript(
-      layout.postscript.footer.size(),
-      layout.postscript.footer.compressionType(),
-      layout.postscript.checksumType,
-      layout.postscript.majorVersion,
-      layout.postscript.minorVersion);
+      layout.footer.size(),
+      layout.footer.compressionType(),
+      layout.postscript.checksumType(),
+      layout.postscript.majorVersion(),
+      layout.postscript.minorVersion());
 }
 
 TabletReader::TabletReader(
@@ -347,7 +347,7 @@ void TabletReader::initFromFileLayout(const Options& options) {
 
   // Calculate what to read within the memory budget.
   // At minimum we need the footer and stripes section.
-  const uint64_t footerSize = layout.postscript.footer.size() + kPostscriptSize;
+  const uint64_t footerSize = layout.footer.size() + kPostscriptSize;
   uint64_t footerReadSize = footerSize;
 
   // Include stripes section if present (stored before footer).
@@ -356,7 +356,7 @@ void TabletReader::initFromFileLayout(const Options& options) {
     // Stripes section should be contiguous with footer.
     NIMBLE_CHECK_EQ(
         layout.stripes.offset() + layout.stripes.size(),
-        layout.postscript.footer.offset(),
+        layout.footer.offset(),
         "Stripes section not contiguous with footer");
     footerReadSize += layout.stripes.size();
   }

--- a/dwio/nimble/tablet/TabletReader.h
+++ b/dwio/nimble/tablet/TabletReader.h
@@ -20,7 +20,6 @@
 #include <span>
 #include <vector>
 
-#include "dwio/nimble/common/Types.h"
 #include "dwio/nimble/common/Vector.h"
 #include "dwio/nimble/index/StripeIndexGroup.h"
 #include "dwio/nimble/index/TabletIndex.h"
@@ -57,57 +56,6 @@ class TabletReaderTestHelper;
 } // namespace test
 
 using MemoryPool = facebook::velox::memory::MemoryPool;
-
-class Postscript {
- public:
-  Postscript() = default;
-
-  uint32_t footerSize() const {
-    return footerSize_;
-  }
-
-  CompressionType footerCompressionType() const {
-    return footerCompressionType_;
-  }
-
-  uint64_t checksum() const {
-    return checksum_;
-  }
-
-  ChecksumType checksumType() const {
-    return checksumType_;
-  }
-
-  uint32_t majorVersion() const {
-    return majorVersion_;
-  }
-
-  uint32_t minorVersion() const {
-    return minorVersion_;
-  }
-
-  /// Create Postscript from FileLayout (skips checksum which requires file
-  /// read).
-  static Postscript create(const FileLayout& layout);
-
-  /// Parse Postscript from raw bytes read from the end of a nimble file.
-  static Postscript parse(std::string_view data);
-
- private:
-  Postscript(
-      uint32_t footerSize,
-      CompressionType footerCompressionType,
-      ChecksumType checksumType,
-      uint16_t majorVersion,
-      uint16_t minorVersion);
-
-  uint32_t footerSize_;
-  CompressionType footerCompressionType_;
-  uint64_t checksum_;
-  ChecksumType checksumType_;
-  uint32_t majorVersion_;
-  uint32_t minorVersion_;
-};
 
 /// Stream loader abstraction.
 /// This is the returned object when loading streams from a tablet.
@@ -338,6 +286,10 @@ class TabletReader {
 
   uint64_t fileSize() const {
     return file_->size();
+  }
+
+  const Postscript& postscript() const {
+    return ps_;
   }
 
   uint32_t footerSize() const {

--- a/dwio/nimble/tablet/tests/FileLayoutTest.cpp
+++ b/dwio/nimble/tablet/tests/FileLayoutTest.cpp
@@ -95,18 +95,18 @@ TEST_F(FileLayoutTest, nonEmptyFile) {
 
     // Verify layout fields
     EXPECT_EQ(layout.fileSize, file.size());
-    EXPECT_EQ(layout.postscript.majorVersion, nimble::kVersionMajor);
-    EXPECT_EQ(layout.postscript.minorVersion, nimble::kVersionMinor);
-    EXPECT_EQ(layout.postscript.checksumType, nimble::ChecksumType::XXH3_64);
-    EXPECT_GT(layout.postscript.footer.size(), 0);
-    EXPECT_LT(layout.postscript.footer.offset(), layout.fileSize);
+    EXPECT_EQ(layout.postscript.majorVersion(), nimble::kVersionMajor);
+    EXPECT_EQ(layout.postscript.minorVersion(), nimble::kVersionMinor);
+    EXPECT_EQ(layout.postscript.checksumType(), nimble::ChecksumType::XXH3_64);
+    EXPECT_GT(layout.footer.size(), 0);
+    EXPECT_LT(layout.footer.offset(), layout.fileSize);
     EXPECT_EQ(layout.stripeGroups.size(), 1);
     EXPECT_TRUE(layout.indexGroups.empty()); // No index configured
 
     // Verify stripe group metadata
     const auto& stripeGroup = layout.stripeGroups[0];
     EXPECT_GT(stripeGroup.size(), 0);
-    EXPECT_LT(stripeGroup.offset(), layout.postscript.footer.offset());
+    EXPECT_LT(stripeGroup.offset(), layout.footer.offset());
 
     // Verify per-stripe info
     EXPECT_EQ(layout.stripesInfo.size(), 2);
@@ -131,8 +131,8 @@ TEST_F(FileLayoutTest, emptyFile) {
   auto layout = nimble::FileLayout::create(&readFile, pool_.get());
 
   EXPECT_EQ(layout.fileSize, file.size());
-  EXPECT_EQ(layout.postscript.majorVersion, nimble::kVersionMajor);
-  EXPECT_EQ(layout.postscript.minorVersion, nimble::kVersionMinor);
+  EXPECT_EQ(layout.postscript.majorVersion(), nimble::kVersionMajor);
+  EXPECT_EQ(layout.postscript.minorVersion(), nimble::kVersionMinor);
   EXPECT_TRUE(layout.stripeGroups.empty());
   EXPECT_TRUE(layout.indexGroups.empty());
   EXPECT_TRUE(layout.stripesInfo.empty());

--- a/dwio/nimble/tablet/tests/TabletTest.cpp
+++ b/dwio/nimble/tablet/tests/TabletTest.cpp
@@ -3826,8 +3826,8 @@ TEST_F(TabletTest, readerOptionsFileLayoutPath) {
 
   EXPECT_EQ(tablet->stripeCount(), 1);
   EXPECT_EQ(tablet->stripeRowCount(0), 700);
-  EXPECT_EQ(tablet->majorVersion(), layout.postscript.majorVersion);
-  EXPECT_EQ(tablet->minorVersion(), layout.postscript.minorVersion);
+  EXPECT_EQ(tablet->majorVersion(), layout.postscript.majorVersion());
+  EXPECT_EQ(tablet->minorVersion(), layout.postscript.minorVersion());
 }
 
 TEST_F(TabletTest, readerOptionsFileLayoutMismatch) {
@@ -3891,8 +3891,8 @@ TEST_F(TabletTest, fileLayoutSkipsPostScriptIo) {
   auto layout = nimble::FileLayout::create(&layoutReadFile, pool_.get());
 
   // Calculate expected read size: footer + stripes section + postscript
-  const uint64_t expectedReadSize = layout.postscript.footer.size() +
-      nimble::kPostscriptSize + layout.stripes.size();
+  const uint64_t expectedReadSize =
+      layout.footer.size() + nimble::kPostscriptSize + layout.stripes.size();
   const uint64_t expectedReadOffset = file.size() - expectedReadSize;
 
   // Read using FileLayout - should do a single read for exact footer size

--- a/dwio/nimble/tools/NimbleDumpLib.cpp
+++ b/dwio/nimble/tools/NimbleDumpLib.cpp
@@ -1018,9 +1018,9 @@ void NimbleDumpLib::emitFileLayout(bool noHeader) {
   // Footer
   entries.push_back({
       "File Footer",
-      toString(layout.postscript.footer.compressionType()),
-      layout.postscript.footer.offset(),
-      layout.postscript.footer.size(),
+      toString(layout.footer.compressionType()),
+      layout.footer.offset(),
+      layout.footer.size(),
   });
 
   // Postscript

--- a/dwio/nimble/velox/tests/VeloxWriterTest.cpp
+++ b/dwio/nimble/velox/tests/VeloxWriterTest.cpp
@@ -87,9 +87,9 @@ TEST_F(VeloxWriterTest, emptyFile) {
   velox::InMemoryReadFile readFile(file);
   auto layout = nimble::FileLayout::create(&readFile, leafPool_.get());
   EXPECT_EQ(layout.fileSize, file.size());
-  EXPECT_EQ(layout.postscript.majorVersion, nimble::kVersionMajor);
-  EXPECT_EQ(layout.postscript.minorVersion, nimble::kVersionMinor);
-  EXPECT_GT(layout.postscript.footer.size(), 0);
+  EXPECT_EQ(layout.postscript.majorVersion(), nimble::kVersionMajor);
+  EXPECT_EQ(layout.postscript.minorVersion(), nimble::kVersionMinor);
+  EXPECT_GT(layout.footer.size(), 0);
   EXPECT_TRUE(layout.stripeGroups.empty());
   EXPECT_TRUE(layout.indexGroups.empty());
   EXPECT_TRUE(layout.stripesInfo.empty());
@@ -262,7 +262,7 @@ TEST_F(VeloxWriterTest, rootHasNulls) {
   EXPECT_TRUE(layout.indexGroups.empty());
   // Stripes metadata should be valid (stripeGroups not empty)
   EXPECT_GT(layout.stripes.size(), 0);
-  EXPECT_LT(layout.stripes.offset(), layout.postscript.footer.offset());
+  EXPECT_LT(layout.stripes.offset(), layout.footer.offset());
   // Per-stripe info
   EXPECT_EQ(layout.stripesInfo.size(), 1);
   EXPECT_EQ(layout.stripesInfo[0].stripeGroupIndex, 0);
@@ -3865,7 +3865,7 @@ TEST_P(VeloxWriterIndexTest, duplicateKeys) {
     EXPECT_EQ(layout.indexGroups.size(), 1);
     // Stripes metadata should be valid
     EXPECT_GT(layout.stripes.size(), 0);
-    EXPECT_LT(layout.stripes.offset(), layout.postscript.footer.offset());
+    EXPECT_LT(layout.stripes.offset(), layout.footer.offset());
     // Index group should be before stripes section
     EXPECT_LT(layout.indexGroups[0].offset(), layout.stripes.offset());
     // Per-stripe info


### PR DESCRIPTION
Summary:
CONTEXT: The Postscript class contains file format metadata (version, checksum,
footer info) that is logically part of the file layout. This refactoring prepares
for better FileLayout integration with TabletReader.

WHAT:
- Move Postscript class definition from TabletReader.h to FileLayout.h
- Remove the nested FileLayout::Postscript struct (redundant with the class)
- Add `footer` as a separate field in FileLayout (previously nested in Postscript)
- Add `postscript()` getter to TabletReader to expose the Postscript object
- Update FileLayout::create() to use the new structure
- Update tests and tools to use the new API

Reviewed By: han-yan01

Differential Revision: D94619842


