### PR TITLE
Fix crash in RawSizeUtils passthrough flatmap detection

### DIFF
--- a/dwio/nimble/velox/RawSizeUtils.cpp
+++ b/dwio/nimble/velox/RawSizeUtils.cpp
@@ -716,9 +716,11 @@ uint64_t getRawSizeFromRowVectorInternal(
   // Check if this is a passthrough flatmap (only when we have schema info):
   // 1. The type's node ID is in flatMapNodeIds (configured as flatmap)
   // 2. The vector at that level is a ROW vector
+  // 3. The schema type is MAP (not ROW from readSchema conversion)
   const bool isPassthroughFlatMap = type &&
       flatMapNodeIds.contains(type->id()) &&
-      vector->typeKind() == velox::TypeKind::ROW;
+      vector->typeKind() == velox::TypeKind::ROW &&
+      type->type()->kind() == velox::TypeKind::MAP;
 
   if (isPassthroughFlatMap) {
     return getRawSizeFromPassthroughFlatMap(

--- a/dwio/nimble/velox/RawSizeUtils.h
+++ b/dwio/nimble/velox/RawSizeUtils.h
@@ -37,7 +37,8 @@ std::optional<size_t> getTypeSizeFromKind(velox::TypeKind kind);
 // flatMapNodeIds contains the node IDs that are configured as flatmaps.
 // A passthrough flatmap is detected when:
 // 1. The node's id is in flatMapNodeIds, AND
-// 2. The vector at that level is a ROW vector
+// 2. The vector at that level is a ROW vector, AND
+// 3. The schema type is MAP (not ROW from readSchema conversion)
 // ignoreTopLevelNulls: when true, top-level row nulls are ignored (treated as
 // non-null) to match FieldWriter behavior when that option is enabled.
 // type can be nullptr when schema is not available.

--- a/dwio/nimble/velox/tests/RawSizeTest.cpp
+++ b/dwio/nimble/velox/tests/RawSizeTest.cpp
@@ -16,6 +16,7 @@
 #include <gtest/gtest.h>
 
 #include "dwio/nimble/velox/RawSizeUtils.h"
+#include "velox/dwio/common/TypeWithId.h"
 #include "velox/vector/tests/utils/VectorMaker.h"
 
 using namespace facebook;
@@ -1847,4 +1848,38 @@ TEST_F(RawSizeTestFixture, LocalDecodedVectorMoveConstructor) {
   ASSERT_NE(&decodedVector, nullptr);
 
   // No checks on localDecodedVector1 as it's been moved
+}
+
+// Regression test: when a ROW TypeWithId node has its ID in flatMapNodeIds
+// but the schema type is ROW (not MAP), getRawSizeFromVector should treat it
+// as a regular ROW vector instead of crashing in passthrough flatmap path.
+// This happens during flatmap-as-struct rewrite where MAP is converted to ROW
+// in the readSchema.
+TEST_F(RawSizeTestFixture, RowTypeWithIdInFlatMapNodeIdsDoesNotCrash) {
+  // Create a ROW vector with a single child (simulates a flatmap column
+  // with 1 feature read as struct).
+  auto child = vectorMaker_->flatVector<int32_t>({1, 2, 3});
+  auto rowVector = vectorMaker_->rowVector({"feature0"}, {child});
+
+  // Create a ROW TypeWithId (as readSchema would produce).
+  // ID assignment: 0=root ROW, 1=child ROW (the "flatmap" column), 2=INT
+  auto schema =
+      velox::ROW({{"c0", velox::ROW({{"feature0", velox::INTEGER()}})}});
+  auto typeWithId = velox::dwio::common::TypeWithId::create(schema);
+  const auto* childTypeWithId = typeWithId->childAt(0).get();
+
+  // Mark the ROW child's node ID as a flatmap node.
+  // This simulates the rewrite flow where the ROW TypeWithId node from
+  // readSchema has its ID added to flatMapNodeIds.
+  folly::F14FastSet<uint32_t> flatMapNodeIds{childTypeWithId->id()};
+
+  ranges_.add(0, rowVector->size());
+
+  // Should not crash — the fix ensures passthrough flatmap detection
+  // requires the schema type to be MAP.
+  auto rawSize = nimble::getRawSizeFromVector(
+      rowVector, ranges_, context_, childTypeWithId, flatMapNodeIds);
+
+  // Should compute regular ROW vector raw size (3 int32 values).
+  ASSERT_EQ(rawSize, sizeof(int32_t) * 3);
 }


### PR DESCRIPTION
Summary:
Fix `vector::_M_range_check` crash in `getRawSizeFromRowVectorInternal` when computing raw size for flatmap-as-struct rewritten files.

The `isPassthroughFlatMap` condition matched ROW TypeWithId nodes from the readSchema (where MAP was converted to ROW for flatmap-as-struct reading), but `getRawSizeFromPassthroughFlatMap` assumes the TypeWithId is MAP with 2 children (key, value). When a flatmap column has only 1 feature, the ROW TypeWithId has 1 child, causing `type.childAt(1)` to throw `std::out_of_range`.

Add a check that the schema type is actually MAP before entering the passthrough flatmap path.

Validation Service Scuba logs: https://fburl.com/scuba/dwrf_reader_checksum/3vye8eda

Differential Revision: D94724481


