### PR TITLE
misc: Add findChild methods and nameMapping for schema evolution

### DIFF
--- a/dwio/nimble/velox/SchemaReader.cpp
+++ b/dwio/nimble/velox/SchemaReader.cpp
@@ -265,6 +265,14 @@ const std::string& RowType::nameAt(size_t index) const {
   return names_[index];
 }
 
+std::optional<size_t> RowType::findChild(std::string_view name) const {
+  const auto it = std::find(names_.begin(), names_.end(), name);
+  if (it == names_.end()) {
+    return std::nullopt;
+  }
+  return it - names_.begin();
+}
+
 FlatMapType::FlatMapType(
     StreamDescriptor nullsDescriptor,
     ScalarKind keyScalarKind,
@@ -311,6 +319,14 @@ const std::shared_ptr<const Type>& FlatMapType::childAt(size_t index) const {
 const std::string& FlatMapType::nameAt(size_t index) const {
   NIMBLE_CHECK_LT(index, names_.size(), "Index out of range.");
   return names_[index];
+}
+
+std::optional<size_t> FlatMapType::findChild(std::string_view name) const {
+  const auto it = std::find(names_.begin(), names_.end(), name);
+  if (it == names_.end()) {
+    return std::nullopt;
+  }
+  return it - names_.begin();
 }
 
 ArrayWithOffsetsType::ArrayWithOffsetsType(

--- a/dwio/nimble/velox/SchemaReader.h
+++ b/dwio/nimble/velox/SchemaReader.h
@@ -17,6 +17,8 @@
 
 #include <functional>
 #include <memory>
+#include <optional>
+#include <string_view>
 #include <vector>
 
 #include "dwio/nimble/velox/SchemaTypes.h"
@@ -165,6 +167,10 @@ class RowType : public Type {
   const std::shared_ptr<const Type>& childAt(size_t index) const;
   const std::string& nameAt(size_t index) const;
 
+  /// Finds a child by name.
+  /// @return Child index if found, std::nullopt otherwise.
+  std::optional<size_t> findChild(std::string_view name) const;
+
  protected:
   StreamDescriptor nullsDescriptor_;
   std::vector<std::string> names_;
@@ -186,6 +192,10 @@ class FlatMapType : public Type {
   size_t childrenCount() const;
   const std::shared_ptr<const Type>& childAt(size_t index) const;
   const std::string& nameAt(size_t index) const;
+
+  /// Finds a child (key) by name.
+  /// @return Child index if found, std::nullopt otherwise.
+  std::optional<size_t> findChild(std::string_view name) const;
 
  private:
   StreamDescriptor nullsDescriptor_;


### PR DESCRIPTION
Summary:
CONTEXT: The Projector class projects columns/subfields from serialized Nimble
data without decoding. When schema evolution occurs (e.g., column renames),
we need a way to map query column names to data schema names.

WHAT:
- Added findChild(name) methods to RowType and FlatMapType for efficient
  child lookup by name, returning std::optional<size_t>
- Added nameMapping to Projector::Options for schema evolution support
- Renamed inputSchema_ to dataSchema_ for clarity (the schema represents
  data schema, not necessarily the current table schema)
- Updated resolveSubfield to use the new findChild methods and nameMapping
- Enhanced error messages to show mapped names when different from original

Differential Revision: D94793209


