### PR TITLE
misc: Add RowType accessors and refactor Projector updateColumnNames

### DIFF
--- a/dwio/nimble/serializer/tests/ProjectorTest.cpp
+++ b/dwio/nimble/serializer/tests/ProjectorTest.cpp
@@ -1567,10 +1567,7 @@ TEST_F(ProjectorTest, projectWithUpdatedNestedRowType) {
   });
 
   const int numRows = 3;
-  std::vector<int32_t> idVals;
-  for (int i = 0; i < numRows; ++i) {
-    idVals.emplace_back(i);
-  }
+  std::vector<int32_t> idVals = {0, 1, 2};
   auto ids = makeIntVector(idVals);
 
   // Create map with nested row values.

--- a/dwio/nimble/velox/SchemaReader.h
+++ b/dwio/nimble/velox/SchemaReader.h
@@ -167,6 +167,14 @@ class RowType : public Type {
   const std::shared_ptr<const Type>& childAt(size_t index) const;
   const std::string& nameAt(size_t index) const;
 
+  const std::vector<std::string>& names() const {
+    return names_;
+  }
+
+  const std::vector<std::shared_ptr<const Type>>& children() const {
+    return children_;
+  }
+
   /// Finds a child by name.
   /// @return Child index if found, std::nullopt otherwise.
   std::optional<size_t> findChild(std::string_view name) const;

--- a/dwio/nimble/velox/tests/SchemaTest.cpp
+++ b/dwio/nimble/velox/tests/SchemaTest.cpp
@@ -653,6 +653,19 @@ TEST(SchemaTests, rowTypeFindChild) {
 
   auto empty = row.findChild("");
   EXPECT_FALSE(empty.has_value());
+
+  // Verify names() and children() accessors.
+  const auto& names = row.names();
+  ASSERT_EQ(names.size(), 3);
+  EXPECT_EQ(names[0], "alpha");
+  EXPECT_EQ(names[1], "beta");
+  EXPECT_EQ(names[2], "gamma");
+
+  const auto& children = row.children();
+  ASSERT_EQ(children.size(), 3);
+  EXPECT_EQ(children[0].get(), row.childAt(0).get());
+  EXPECT_EQ(children[1].get(), row.childAt(1).get());
+  EXPECT_EQ(children[2].get(), row.childAt(2).get());
 }
 
 TEST(SchemaTests, flatMapTypeFindChild) {


### PR DESCRIPTION
Summary:
CONTEXT: The Projector's updateColumnNames helpers can be simplified with
switch-case dispatch, `changed |=` pattern, and bulk vector operations
via new RowType accessors.

WHAT:
- Add `names()` and `children()` const accessors to RowType for bulk
  vector access (SchemaReader.h)
- Use collection `insert()` with RowType::names()/children() iterators
  instead of per-element loop for remaining children
- Use `changed |=` pattern instead of `if (expr) { changed = true; }`
  in updateRowColumnNames and updateFlatMapColumnNames
- Extract `asArrayWithOffsets()`/`asArray()` reference once in
  updateArrayColumnNames to avoid redundant calls
- Convert updateMapColumnNames to switch case with NIMBLE_UNREACHABLE
  for unsupported kinds
- Convert updateColumnNames dispatcher to switch on velox::TypeKind
- Pre-allocate test vector instead of emplace_back in loop

Differential Revision: D94840082


