### PR TITLE
misc: Use varint for rowCount in encoding prefix and serializer headers

### DIFF
--- a/dwio/nimble/common/Varint.h
+++ b/dwio/nimble/common/Varint.h
@@ -42,7 +42,22 @@ const char* bulkVarintSkip(uint64_t n, const char* pos);
 uint64_t bulkVarintSize32(std::span<const uint32_t> values);
 uint64_t bulkVarintSize64(std::span<const uint64_t> values);
 
-// Inline non-bulk methods follow below.
+/// Inline non-bulk methods follow below.
+
+/// Returns the number of bytes needed to varint-encode a single value.
+/// Uses CLZ (count leading zeros) for O(1) computation instead of a loop.
+template <typename T>
+inline constexpr uint32_t varintSize(T val) noexcept {
+  if constexpr (sizeof(T) <= 4) {
+    // `| 1` avoids undefined behavior from __builtin_clz(0) and correctly
+    // returns 1 byte for val=0.
+    uint32_t bitsNeeded = 32 - __builtin_clz(static_cast<uint32_t>(val) | 1);
+    return (bitsNeeded + 6) / 7;
+  } else {
+    uint32_t bitsNeeded = 64 - __builtin_clzll(static_cast<uint64_t>(val) | 1);
+    return (bitsNeeded + 6) / 7;
+  }
+}
 
 template <typename T>
 inline void writeVarint(T val, char** pos) noexcept {

--- a/dwio/nimble/common/tests/VarintTests.cpp
+++ b/dwio/nimble/common/tests/VarintTests.cpp
@@ -27,6 +27,61 @@ namespace {
 const int kNumElements = 10000;
 }
 
+TEST(VarintTests, varintSize32) {
+  // Boundary values for varint encoding.
+  EXPECT_EQ(nimble::varint::varintSize(uint32_t{0}), 1);
+  EXPECT_EQ(nimble::varint::varintSize(uint32_t{1}), 1);
+  EXPECT_EQ(nimble::varint::varintSize(uint32_t{127}), 1);
+  EXPECT_EQ(nimble::varint::varintSize(uint32_t{128}), 2);
+  EXPECT_EQ(nimble::varint::varintSize(uint32_t{16383}), 2);
+  EXPECT_EQ(nimble::varint::varintSize(uint32_t{16384}), 3);
+  EXPECT_EQ(nimble::varint::varintSize(uint32_t{2097151}), 3);
+  EXPECT_EQ(nimble::varint::varintSize(uint32_t{2097152}), 4);
+  EXPECT_EQ(nimble::varint::varintSize(uint32_t{268435455}), 4);
+  EXPECT_EQ(nimble::varint::varintSize(uint32_t{268435456}), 5);
+  EXPECT_EQ(
+      nimble::varint::varintSize(std::numeric_limits<uint32_t>::max()), 5);
+
+  // Verify consistency with writeVarint for random values.
+  auto seed = folly::Random::rand32();
+  LOG(INFO) << "seed: " << seed;
+  std::mt19937 rng(seed);
+  char buf[folly::kMaxVarintLength32];
+  for (int i = 0; i < kNumElements; ++i) {
+    const int bitShift = folly::Random::rand32(rng) % 32;
+    uint32_t val = folly::Random::rand32(rng) >> bitShift;
+    char* pos = buf;
+    nimble::varint::writeVarint(val, &pos);
+    ASSERT_EQ(nimble::varint::varintSize(val), static_cast<uint32_t>(pos - buf))
+        << "mismatch for val=" << val;
+  }
+}
+
+TEST(VarintTests, varintSize64) {
+  // Boundary values for varint encoding.
+  EXPECT_EQ(nimble::varint::varintSize(uint64_t{0}), 1);
+  EXPECT_EQ(nimble::varint::varintSize(uint64_t{127}), 1);
+  EXPECT_EQ(nimble::varint::varintSize(uint64_t{128}), 2);
+  EXPECT_EQ(nimble::varint::varintSize(uint64_t{16383}), 2);
+  EXPECT_EQ(nimble::varint::varintSize(uint64_t{16384}), 3);
+  EXPECT_EQ(
+      nimble::varint::varintSize(std::numeric_limits<uint64_t>::max()), 10);
+
+  // Verify consistency with writeVarint for random values.
+  auto seed = folly::Random::rand32();
+  LOG(INFO) << "seed: " << seed;
+  std::mt19937 rng(seed);
+  char buf[folly::kMaxVarintLength64];
+  for (int i = 0; i < kNumElements; ++i) {
+    const int bitShift = folly::Random::rand64(rng) % 64;
+    uint64_t val = folly::Random::rand64(rng) >> bitShift;
+    char* pos = buf;
+    nimble::varint::writeVarint(val, &pos);
+    ASSERT_EQ(nimble::varint::varintSize(val), static_cast<uint32_t>(pos - buf))
+        << "mismatch for val=" << val;
+  }
+}
+
 TEST(VarintTests, WriteRead32) {
   auto seed = folly::Random::rand32();
   LOG(INFO) << "seed: " << seed;

--- a/dwio/nimble/encodings/ConstantEncoding.cpp
+++ b/dwio/nimble/encodings/ConstantEncoding.cpp
@@ -21,9 +21,10 @@ namespace facebook::nimble {
 ConstantEncoding<std::string_view>::ConstantEncoding(
     velox::memory::MemoryPool& memoryPool,
     std::string_view data,
-    std::function<void*(uint32_t)> stringBufferFactory)
-    : ConstantEncodingBase<std::string_view>(memoryPool, data) {
-  const char* pos = data.data() + Encoding::kPrefixSize;
+    std::function<void*(uint32_t)> stringBufferFactory,
+    const Encoding::Options& options)
+    : ConstantEncodingBase<std::string_view>(memoryPool, data, options) {
+  const char* pos = data.data() + this->dataOffset();
   value_ = encoding::read<physicalType>(pos);
   NIMBLE_CHECK(pos == data.end(), "Unexpected constant encoding end");
   auto stringBuffer = static_cast<char*>(stringBufferFactory(value_.size()));

--- a/dwio/nimble/encodings/ConstantEncoding.h
+++ b/dwio/nimble/encodings/ConstantEncoding.h
@@ -40,8 +40,9 @@ class ConstantEncodingBase
 
   ConstantEncodingBase(
       velox::memory::MemoryPool& memoryPool,
-      std::string_view data)
-      : TypedEncoding<T, physicalType>(memoryPool, data) {}
+      std::string_view data,
+      const Encoding::Options& options = {})
+      : TypedEncoding<T, physicalType>(memoryPool, data, options) {}
 
   void reset() final {}
 
@@ -80,7 +81,9 @@ class ConstantEncodingBase
   static std::string_view encode(
       EncodingSelection<physicalType>& selection,
       std::span<const physicalType> values,
-      Buffer& buffer) {
+      Buffer& buffer,
+      const Encoding::Options& options = {}) {
+    const bool useVarint = options.useVarintRowCount;
     if (values.empty()) {
       NIMBLE_INCOMPATIBLE_ENCODING("ConstantEncoding cannot be empty.");
     }
@@ -90,7 +93,7 @@ class ConstantEncodingBase
     }
 
     const uint32_t rowCount = values.size();
-    uint32_t encodingSize = Encoding::kPrefixSize;
+    uint32_t encodingSize = Encoding::serializePrefixSize(rowCount, useVarint);
     if constexpr (isStringType<physicalType>()) {
       encodingSize += 4 + values[0].size();
     } else {
@@ -99,7 +102,11 @@ class ConstantEncodingBase
     char* reserved = buffer.reserve(encodingSize);
     char* pos = reserved;
     Encoding::serializePrefix(
-        EncodingType::Constant, TypeTraits<T>::dataType, rowCount, pos);
+        EncodingType::Constant,
+        TypeTraits<T>::dataType,
+        rowCount,
+        useVarint,
+        pos);
     encoding::write<physicalType>(values[0], pos);
     NIMBLE_DCHECK_EQ(pos - reserved, encodingSize, "Encoding size mismatch.");
     return {reserved, encodingSize};
@@ -118,7 +125,8 @@ class ConstantEncoding : public ConstantEncodingBase<T> {
   ConstantEncoding(
       velox::memory::MemoryPool& memoryPool,
       std::string_view data,
-      std::function<void*(uint32_t)> stringBufferFactory);
+      std::function<void*(uint32_t)> stringBufferFactory,
+      const Encoding::Options& options = {});
 };
 
 //
@@ -129,11 +137,12 @@ template <typename T>
 ConstantEncoding<T>::ConstantEncoding(
     velox::memory::MemoryPool& memoryPool,
     std::string_view data,
-    std::function<void*(uint32_t)> stringBufferFactory)
-    : ConstantEncodingBase<T>(memoryPool, data) {
-  const char* pos = data.data() + Encoding::kPrefixSize;
+    std::function<void*(uint32_t)> /* stringBufferFactory */,
+    const Encoding::Options& options)
+    : ConstantEncodingBase<T>(memoryPool, data, options) {
+  const char* pos = data.data() + this->dataOffset();
   this->value_ = encoding::read<physicalType>(pos);
-  NIMBLE_CHECK(pos == data.end(), "Unexpected constant encoding end");
+  NIMBLE_CHECK_EQ(pos, data.end(), "Unexpected constant encoding end");
 }
 
 // Specialization for bool to override materializeBoolsAsBits
@@ -146,11 +155,12 @@ class ConstantEncoding<bool> final : public ConstantEncodingBase<bool> {
   ConstantEncoding(
       velox::memory::MemoryPool& memoryPool,
       std::string_view data,
-      std::function<void*(uint32_t)> stringBufferFactory)
-      : ConstantEncodingBase<bool>(memoryPool, data) {
-    const char* pos = data.data() + Encoding::kPrefixSize;
+      std::function<void*(uint32_t)> /* stringBufferFactory */,
+      const Encoding::Options& options = {})
+      : ConstantEncodingBase<bool>(memoryPool, data, options) {
+    const char* pos = data.data() + this->dataOffset();
     this->value_ = encoding::read<physicalType>(pos);
-    NIMBLE_CHECK(pos == data.end(), "Unexpected constant encoding end");
+    NIMBLE_CHECK_EQ(pos, data.end(), "Unexpected constant encoding end");
   }
 
   void materializeBoolsAsBits(uint32_t rowCount, uint64_t* buffer, int begin)
@@ -169,6 +179,7 @@ class ConstantEncoding<std::string_view> final
   ConstantEncoding(
       velox::memory::MemoryPool& memoryPool,
       std::string_view data,
-      std::function<void*(uint32_t)> stringBufferFactory);
+      std::function<void*(uint32_t)> stringBufferFactory,
+      const Encoding::Options& options = {});
 };
 } // namespace facebook::nimble

--- a/dwio/nimble/encodings/DictionaryEncoding.h
+++ b/dwio/nimble/encodings/DictionaryEncoding.h
@@ -47,12 +47,11 @@ class DictionaryEncoding
   using cppDataType = T;
   using physicalType = typename TypeTraits<T>::physicalType;
 
-  static const int kAlphabetSizeOffset = Encoding::kPrefixSize;
-
   DictionaryEncoding(
       velox::memory::MemoryPool& pool,
       std::string_view data,
-      std::function<void*(uint32_t)> stringBufferFactory);
+      std::function<void*(uint32_t)> stringBufferFactory,
+      const Encoding::Options& options = {});
 
   void reset() final;
   void skip(uint32_t rowCount) final;
@@ -64,7 +63,8 @@ class DictionaryEncoding
   static std::string_view encode(
       EncodingSelection<physicalType>& selection,
       std::span<const physicalType> values,
-      Buffer& buffer);
+      Buffer& buffer,
+      const Encoding::Options& options = {});
 
   std::string debugString(int offset) const final;
 
@@ -87,14 +87,15 @@ template <typename T>
 DictionaryEncoding<T>::DictionaryEncoding(
     velox::memory::MemoryPool& pool,
     std::string_view data,
-    std::function<void*(uint32_t)> stringBufferFactory)
-    : TypedEncoding<T, physicalType>{pool, data},
+    std::function<void*(uint32_t)> stringBufferFactory,
+    const Encoding::Options& options)
+    : TypedEncoding<T, physicalType>{pool, data, options},
       alphabet_{this->pool_},
       indicesBuffer_{this->pool_} {
-  const auto* pos = data.data() + kAlphabetSizeOffset;
+  const auto* pos = data.data() + this->dataOffset();
   const uint32_t alphabetSize = encoding::readUint32(pos);
   alphabetEncoding_ = EncodingFactory::decode(
-      *this->pool_, {pos, alphabetSize}, stringBufferFactory);
+      *this->pool_, {pos, alphabetSize}, stringBufferFactory, options);
   const uint32_t alphabetCount = alphabetEncoding_->rowCount();
   alphabet_.resize(alphabetCount);
   alphabetEncoding_->materialize(alphabetCount, alphabet_.data());
@@ -103,7 +104,8 @@ DictionaryEncoding<T>::DictionaryEncoding(
   indicesEncoding_ = EncodingFactory::decode(
       *this->pool_,
       {pos, static_cast<size_t>(data.end() - pos)},
-      stringBufferFactory);
+      stringBufferFactory,
+      options);
 }
 
 template <typename T>
@@ -204,7 +206,9 @@ template <typename T>
 std::string_view DictionaryEncoding<T>::encode(
     EncodingSelection<physicalType>& selection,
     std::span<const physicalType> values,
-    Buffer& buffer) {
+    Buffer& buffer,
+    const Encoding::Options& options) {
+  const bool useVarint = options.useVarintRowCount;
   const uint32_t valueCount = values.size();
   const uint32_t alphabetCount =
       selection.statistics().uniqueCounts().value().size();
@@ -272,17 +276,28 @@ std::string_view DictionaryEncoding<T>::encode(
   Buffer tempBuffer{buffer.getMemoryPool()};
   std::string_view serializedAlphabet =
       selection.template encodeNested<physicalType>(
-          EncodingIdentifiers::Dictionary::Alphabet, {alphabet}, tempBuffer);
+          EncodingIdentifiers::Dictionary::Alphabet,
+          {alphabet},
+          tempBuffer,
+          options);
   std::string_view serializedIndices =
       selection.template encodeNested<uint32_t>(
-          EncodingIdentifiers::Dictionary::Indices, {indices}, tempBuffer);
+          EncodingIdentifiers::Dictionary::Indices,
+          {indices},
+          tempBuffer,
+          options);
 
-  const uint32_t encodingSize = Encoding::kPrefixSize + 4 +
+  const uint32_t encodingSize =
+      Encoding::serializePrefixSize(valueCount, useVarint) + 4 +
       serializedAlphabet.size() + serializedIndices.size();
   char* reserved = buffer.reserve(encodingSize);
   char* pos = reserved;
   Encoding::serializePrefix(
-      EncodingType::Dictionary, TypeTraits<T>::dataType, valueCount, pos);
+      EncodingType::Dictionary,
+      TypeTraits<T>::dataType,
+      valueCount,
+      useVarint,
+      pos);
   encoding::writeUint32(serializedAlphabet.size(), pos);
   encoding::writeBytes(serializedAlphabet, pos);
   encoding::writeBytes(serializedIndices, pos);

--- a/dwio/nimble/encodings/Encoding.cpp
+++ b/dwio/nimble/encodings/Encoding.cpp
@@ -16,16 +16,46 @@
 #include "dwio/nimble/encodings/Encoding.h"
 #include "dwio/nimble/common/EncodingPrimitives.h"
 #include "dwio/nimble/common/Types.h"
+#include "dwio/nimble/common/Varint.h"
 
 namespace facebook::nimble {
 
-Encoding::Encoding(velox::memory::MemoryPool& pool, std::string_view data)
+Encoding::Encoding(
+    velox::memory::MemoryPool& pool,
+    std::string_view data,
+    const Options& options)
     : pool_{&pool},
       data_{data},
       encodingType_{data_[kEncodingTypeOffset]},
-      dataType_{static_cast<DataType>(data_[kDataTypeOffset])},
-      rowCount_{
-          *reinterpret_cast<const uint32_t*>(data_.data() + kRowCountOffset)} {}
+      options_{options},
+      dataType_{readDataType(data)},
+      rowCount_{readRowCount(data, options_.useVarintRowCount)},
+      prefixSize_{readPrefixSize(data, options_.useVarintRowCount)} {}
+
+/* static */ DataType Encoding::readDataType(std::string_view data) {
+  return static_cast<DataType>(data[kDataTypeOffset]);
+}
+
+/* static */ uint32_t Encoding::readRowCount(
+    std::string_view data,
+    bool useVarint) {
+  if (useVarint) {
+    const char* pos = data.data() + kRowCountOffset;
+    return varint::readVarint32(&pos);
+  }
+  return *reinterpret_cast<const uint32_t*>(data.data() + kRowCountOffset);
+}
+
+/* static */ uint32_t Encoding::readPrefixSize(
+    std::string_view data,
+    bool useVarint) {
+  if (useVarint) {
+    const char* pos = data.data() + kRowCountOffset;
+    varint::readVarint32(&pos);
+    return pos - data.data();
+  }
+  return kPrefixSize;
+}
 
 /* static */ void Encoding::copyIOBuf(char* pos, const folly::IOBuf& buf) {
   [[maybe_unused]] size_t length = buf.computeChainDataLength();
@@ -41,10 +71,24 @@ void Encoding::serializePrefix(
     EncodingType encodingType,
     DataType dataType,
     uint32_t rowCount,
+    bool useVarint,
     char*& pos) {
   encoding::writeChar(static_cast<char>(encodingType), pos);
   encoding::writeChar(static_cast<char>(dataType), pos);
-  encoding::writeUint32(rowCount, pos);
+  if (useVarint) {
+    varint::writeVarint(rowCount, &pos);
+  } else {
+    encoding::writeUint32(rowCount, pos);
+  }
+}
+
+/* static */ uint32_t Encoding::serializePrefixSize(
+    uint32_t rowCount,
+    bool useVarint) {
+  if (!useVarint) {
+    return kPrefixSize;
+  }
+  return kRowCountOffset + varint::varintSize(rowCount);
 }
 
 std::string Encoding::debugString(int offset) const {

--- a/dwio/nimble/encodings/Encoding.h
+++ b/dwio/nimble/encodings/Encoding.h
@@ -97,16 +97,29 @@ struct ReadWithVisitorParams {
 
 class Encoding {
  public:
+  /// Options for encoding/decoding, extracted from persisted storage version
+  /// (file footer or serializer version).
+  struct Options {
+    /// When true, rowCount in the encoding prefix is varint-encoded instead of
+    /// fixed 4-byte uint32. Determined from file format version or serializer
+    /// version.
+    bool useVarintRowCount;
+  };
+
   // The binary layout for each Encoding begins with the same prefix:
   // 1 byte: EncodingType
   // 1 byte: DataType
-  // 4 bytes: uint32_t num rows
+  // 4 bytes: uint32_t num rows (fixed format)
+  //   OR 1-5 bytes: varint num rows (when useVarintRowCount option is set)
   static constexpr int kEncodingTypeOffset = 0;
   static constexpr int kDataTypeOffset = 1;
   static constexpr int kRowCountOffset = 2;
   static constexpr int kPrefixSize = 6;
 
-  Encoding(velox::memory::MemoryPool& pool, std::string_view data);
+  Encoding(
+      velox::memory::MemoryPool& pool,
+      std::string_view data,
+      const Options& options = {});
   virtual ~Encoding() = default;
 
   EncodingType encodingType() const {
@@ -119,6 +132,12 @@ class Encoding {
 
   uint32_t rowCount() const {
     return rowCount_;
+  }
+
+  /// Returns the byte offset where encoding-specific data begins, right after
+  /// the common prefix (EncodingType + DataType + rowCount).
+  uint32_t dataOffset() const {
+    return prefixSize_;
   }
 
   static void copyIOBuf(char* pos, const folly::IOBuf& buf);
@@ -237,13 +256,25 @@ class Encoding {
       EncodingType encodingType,
       DataType dataType,
       uint32_t rowCount,
+      bool useVarint,
       char*& pos);
+
+  // Compute the prefix size for serialization. Returns kPrefixSize for fixed
+  // format, or 2 + varintSize(rowCount) for varint format.
+  static uint32_t serializePrefixSize(uint32_t rowCount, bool useVarint);
+
+  // Static helpers for initializer list computation.
+  static DataType readDataType(std::string_view data);
+  static uint32_t readRowCount(std::string_view data, bool useVarint);
+  static uint32_t readPrefixSize(std::string_view data, bool useVarint);
 
   velox::memory::MemoryPool* const pool_;
   const std::string_view data_;
   const EncodingType encodingType_;
+  const Options options_;
   const DataType dataType_;
   const uint32_t rowCount_;
+  const uint32_t prefixSize_;
 };
 
 // The TypedEncoding<physicalType> class exposes the same interface as the base
@@ -256,8 +287,11 @@ class TypedEncoding : public Encoding {
       std::is_same_v<physicalType, typename TypeTraits<T>::physicalType>);
 
  public:
-  TypedEncoding(velox::memory::MemoryPool& memoryPool, std::string_view data)
-      : Encoding{memoryPool, data} {}
+  TypedEncoding(
+      velox::memory::MemoryPool& memoryPool,
+      std::string_view data,
+      const Options& options = {})
+      : Encoding{memoryPool, data, options} {}
 
   // Similar to materialize(), but scatters values to output buffer according to
   // scatterBitmap. When scatterBitmap is nullptr or all 1's, the output

--- a/dwio/nimble/encodings/EncodingFactory.cpp
+++ b/dwio/nimble/encodings/EncodingFactory.cpp
@@ -43,7 +43,8 @@ static std::span<const typename TypeTraits<T>::physicalType> toPhysicalSpan(
 std::unique_ptr<Encoding> EncodingFactory::decode(
     velox::memory::MemoryPool& memoryPool,
     std::string_view data,
-    std::function<void*(uint32_t)> stringBufferFactory) {
+    std::function<void*(uint32_t)> stringBufferFactory,
+    const Encoding::Options& options) {
   // Maybe we should have a magic number of encodings too? Hrm.
   const EncodingType encodingType = static_cast<EncodingType>(data[0]);
   const DataType dataType = static_cast<DataType>(data[1]);
@@ -51,40 +52,40 @@ std::unique_ptr<Encoding> EncodingFactory::decode(
   switch (dataType) {                                                     \
     case DataType::Int8:                                                  \
       return std::make_unique<Encoding<int8_t>>(                          \
-          memoryPool, data, stringBufferFactory);                         \
+          memoryPool, data, stringBufferFactory, options);                \
     case DataType::Uint8:                                                 \
       return std::make_unique<Encoding<uint8_t>>(                         \
-          memoryPool, data, stringBufferFactory);                         \
+          memoryPool, data, stringBufferFactory, options);                \
     case DataType::Int16:                                                 \
       return std::make_unique<Encoding<int16_t>>(                         \
-          memoryPool, data, stringBufferFactory);                         \
+          memoryPool, data, stringBufferFactory, options);                \
     case DataType::Uint16:                                                \
       return std::make_unique<Encoding<uint16_t>>(                        \
-          memoryPool, data, stringBufferFactory);                         \
+          memoryPool, data, stringBufferFactory, options);                \
     case DataType::Int32:                                                 \
       return std::make_unique<Encoding<int32_t>>(                         \
-          memoryPool, data, stringBufferFactory);                         \
+          memoryPool, data, stringBufferFactory, options);                \
     case DataType::Uint32:                                                \
       return std::make_unique<Encoding<uint32_t>>(                        \
-          memoryPool, data, stringBufferFactory);                         \
+          memoryPool, data, stringBufferFactory, options);                \
     case DataType::Int64:                                                 \
       return std::make_unique<Encoding<int64_t>>(                         \
-          memoryPool, data, stringBufferFactory);                         \
+          memoryPool, data, stringBufferFactory, options);                \
     case DataType::Uint64:                                                \
       return std::make_unique<Encoding<uint64_t>>(                        \
-          memoryPool, data, stringBufferFactory);                         \
+          memoryPool, data, stringBufferFactory, options);                \
     case DataType::Float:                                                 \
       return std::make_unique<Encoding<float>>(                           \
-          memoryPool, data, stringBufferFactory);                         \
+          memoryPool, data, stringBufferFactory, options);                \
     case DataType::Double:                                                \
       return std::make_unique<Encoding<double>>(                          \
-          memoryPool, data, stringBufferFactory);                         \
+          memoryPool, data, stringBufferFactory, options);                \
     case DataType::Bool:                                                  \
       return std::make_unique<Encoding<bool>>(                            \
-          memoryPool, data, stringBufferFactory);                         \
+          memoryPool, data, stringBufferFactory, options);                \
     case DataType::String:                                                \
       return std::make_unique<Encoding<std::string_view>>(                \
-          memoryPool, data, stringBufferFactory);                         \
+          memoryPool, data, stringBufferFactory, options);                \
     default:                                                              \
       NIMBLE_UNREACHABLE("Unknown encoding type {}.", toString(dataType)) \
   }
@@ -93,22 +94,22 @@ std::unique_ptr<Encoding> EncodingFactory::decode(
   switch (dataType) {                                      \
     case DataType::Int32:                                  \
       return std::make_unique<Encoding<int32_t>>(          \
-          memoryPool, data, stringBufferFactory);          \
+          memoryPool, data, stringBufferFactory, options); \
     case DataType::Uint32:                                 \
       return std::make_unique<Encoding<uint32_t>>(         \
-          memoryPool, data, stringBufferFactory);          \
+          memoryPool, data, stringBufferFactory, options); \
     case DataType::Int64:                                  \
       return std::make_unique<Encoding<int64_t>>(          \
-          memoryPool, data, stringBufferFactory);          \
+          memoryPool, data, stringBufferFactory, options); \
     case DataType::Uint64:                                 \
       return std::make_unique<Encoding<uint64_t>>(         \
-          memoryPool, data, stringBufferFactory);          \
+          memoryPool, data, stringBufferFactory, options); \
     case DataType::Float:                                  \
       return std::make_unique<Encoding<float>>(            \
-          memoryPool, data, stringBufferFactory);          \
+          memoryPool, data, stringBufferFactory, options); \
     case DataType::Double:                                 \
       return std::make_unique<Encoding<double>>(           \
-          memoryPool, data, stringBufferFactory);          \
+          memoryPool, data, stringBufferFactory, options); \
     default:                                               \
       NIMBLE_UNREACHABLE(                                  \
           "Trying to deserialize a varint stream for "     \
@@ -120,37 +121,37 @@ std::unique_ptr<Encoding> EncodingFactory::decode(
   switch (dataType) {                                        \
     case DataType::Int8:                                     \
       return std::make_unique<Encoding<int8_t>>(             \
-          memoryPool, data, stringBufferFactory);            \
+          memoryPool, data, stringBufferFactory, options);   \
     case DataType::Uint8:                                    \
       return std::make_unique<Encoding<uint8_t>>(            \
-          memoryPool, data, stringBufferFactory);            \
+          memoryPool, data, stringBufferFactory, options);   \
     case DataType::Int16:                                    \
       return std::make_unique<Encoding<int16_t>>(            \
-          memoryPool, data, stringBufferFactory);            \
+          memoryPool, data, stringBufferFactory, options);   \
     case DataType::Uint16:                                   \
       return std::make_unique<Encoding<uint16_t>>(           \
-          memoryPool, data, stringBufferFactory);            \
+          memoryPool, data, stringBufferFactory, options);   \
     case DataType::Int32:                                    \
       return std::make_unique<Encoding<int32_t>>(            \
-          memoryPool, data, stringBufferFactory);            \
+          memoryPool, data, stringBufferFactory, options);   \
     case DataType::Uint32:                                   \
       return std::make_unique<Encoding<uint32_t>>(           \
-          memoryPool, data, stringBufferFactory);            \
+          memoryPool, data, stringBufferFactory, options);   \
     case DataType::Int64:                                    \
       return std::make_unique<Encoding<int64_t>>(            \
-          memoryPool, data, stringBufferFactory);            \
+          memoryPool, data, stringBufferFactory, options);   \
     case DataType::Uint64:                                   \
       return std::make_unique<Encoding<uint64_t>>(           \
-          memoryPool, data, stringBufferFactory);            \
+          memoryPool, data, stringBufferFactory, options);   \
     case DataType::Float:                                    \
       return std::make_unique<Encoding<float>>(              \
-          memoryPool, data, stringBufferFactory);            \
+          memoryPool, data, stringBufferFactory, options);   \
     case DataType::Double:                                   \
       return std::make_unique<Encoding<double>>(             \
-          memoryPool, data, stringBufferFactory);            \
+          memoryPool, data, stringBufferFactory, options);   \
     case DataType::String:                                   \
       return std::make_unique<Encoding<std::string_view>>(   \
-          memoryPool, data, stringBufferFactory);            \
+          memoryPool, data, stringBufferFactory, options);   \
     default:                                                 \
       NIMBLE_UNREACHABLE(                                    \
           "Trying to deserialize a non-bool stream for "     \
@@ -162,34 +163,34 @@ std::unique_ptr<Encoding> EncodingFactory::decode(
   switch (dataType) {                                       \
     case DataType::Int8:                                    \
       return std::make_unique<Encoding<int8_t>>(            \
-          memoryPool, data, stringBufferFactory);           \
+          memoryPool, data, stringBufferFactory, options);  \
     case DataType::Uint8:                                   \
       return std::make_unique<Encoding<uint8_t>>(           \
-          memoryPool, data, stringBufferFactory);           \
+          memoryPool, data, stringBufferFactory, options);  \
     case DataType::Int16:                                   \
       return std::make_unique<Encoding<int16_t>>(           \
-          memoryPool, data, stringBufferFactory);           \
+          memoryPool, data, stringBufferFactory, options);  \
     case DataType::Uint16:                                  \
       return std::make_unique<Encoding<uint16_t>>(          \
-          memoryPool, data, stringBufferFactory);           \
+          memoryPool, data, stringBufferFactory, options);  \
     case DataType::Int32:                                   \
       return std::make_unique<Encoding<int32_t>>(           \
-          memoryPool, data, stringBufferFactory);           \
+          memoryPool, data, stringBufferFactory, options);  \
     case DataType::Uint32:                                  \
       return std::make_unique<Encoding<uint32_t>>(          \
-          memoryPool, data, stringBufferFactory);           \
+          memoryPool, data, stringBufferFactory, options);  \
     case DataType::Int64:                                   \
       return std::make_unique<Encoding<int64_t>>(           \
-          memoryPool, data, stringBufferFactory);           \
+          memoryPool, data, stringBufferFactory, options);  \
     case DataType::Uint64:                                  \
       return std::make_unique<Encoding<uint64_t>>(          \
-          memoryPool, data, stringBufferFactory);           \
+          memoryPool, data, stringBufferFactory, options);  \
     case DataType::Float:                                   \
       return std::make_unique<Encoding<float>>(             \
-          memoryPool, data, stringBufferFactory);           \
+          memoryPool, data, stringBufferFactory, options);  \
     case DataType::Double:                                  \
       return std::make_unique<Encoding<double>>(            \
-          memoryPool, data, stringBufferFactory);           \
+          memoryPool, data, stringBufferFactory, options);  \
     default:                                                \
       NIMBLE_UNREACHABLE(                                   \
           "Trying to deserialize a non-numeric stream for " \
@@ -219,7 +220,7 @@ std::unique_ptr<Encoding> EncodingFactory::decode(
           DataType::Bool,
           "Trying to deserialize a SparseBoolEncoding with a non-bool data type.");
       return std::make_unique<SparseBoolEncoding>(
-          memoryPool, data, stringBufferFactory);
+          memoryPool, data, stringBufferFactory, options);
     }
     case EncodingType::Varint: {
       RETURN_ENCODING_BY_VARINT_TYPE(VarintEncoding, dataType);
@@ -235,7 +236,7 @@ std::unique_ptr<Encoding> EncodingFactory::decode(
           dataType,
           DataType::String,
           "Trying to deserialize a PrefixEncoding with a non-string data type.");
-      return std::make_unique<PrefixEncoding>(memoryPool, data);
+      return std::make_unique<PrefixEncoding>(memoryPool, data, options);
     }
     default: {
       NIMBLE_UNREACHABLE(
@@ -249,7 +250,8 @@ template <typename T>
 std::string_view EncodingFactory::encode(
     std::unique_ptr<EncodingSelectionPolicy<T>>&& selectorPolicy,
     std::span<const T> values,
-    Buffer& buffer) {
+    Buffer& buffer,
+    const Encoding::Options& options) {
   using physicalType = typename TypeTraits<T>::physicalType;
   auto physicalValues = toPhysicalSpan(values);
   auto statistics = Statistics<physicalType>::create(physicalValues);
@@ -259,7 +261,7 @@ std::string_view EncodingFactory::encode(
       std::move(statistics),
       std::move(selectorPolicy)};
   return EncodingFactory::encode<T>(
-      std::move(selection), physicalValues, buffer);
+      std::move(selection), physicalValues, buffer, options);
 }
 
 template <typename T>
@@ -267,7 +269,8 @@ std::string_view EncodingFactory::encodeNullable(
     std::unique_ptr<EncodingSelectionPolicy<T>>&& selectorPolicy,
     std::span<const T> values,
     std::span<const bool> nulls,
-    Buffer& buffer) {
+    Buffer& buffer,
+    const Encoding::Options& options) {
   using physicalType = typename TypeTraits<T>::physicalType;
   auto physicalValues = toPhysicalSpan(values);
   auto statistics = Statistics<physicalType>::create(physicalValues);
@@ -278,36 +281,40 @@ std::string_view EncodingFactory::encodeNullable(
       std::move(statistics),
       std::move(selectorPolicy)};
   return EncodingFactory::encodeNullable<T>(
-      std::move(selection), physicalValues, nulls, buffer);
+      std::move(selection), physicalValues, nulls, buffer, options);
 }
 
 template <typename T>
 std::string_view EncodingFactory::encode(
     EncodingSelection<typename TypeTraits<T>::physicalType>&& selection,
     std::span<const typename TypeTraits<T>::physicalType> values,
-    Buffer& buffer) {
+    Buffer& buffer,
+    const Encoding::Options& options) {
   using physicalType = typename TypeTraits<T>::physicalType;
   auto castedValues = toPhysicalSpan(values);
   switch (selection.encodingType()) {
     case EncodingType::Constant: {
-      return ConstantEncoding<T>::encode(selection, castedValues, buffer);
+      return ConstantEncoding<T>::encode(
+          selection, castedValues, buffer, options);
     }
     case EncodingType::Trivial: {
-      return TrivialEncoding<T>::encode(selection, castedValues, buffer);
+      return TrivialEncoding<T>::encode(
+          selection, castedValues, buffer, options);
     }
     case EncodingType::RLE: {
-      return RLEEncoding<T>::encode(selection, castedValues, buffer);
+      return RLEEncoding<T>::encode(selection, castedValues, buffer, options);
     }
     case EncodingType::Dictionary: {
       NIMBLE_DCHECK(
           (!std::is_same<T, bool>::value && !castedValues.empty()),
           "Invalid DictionaryEncoding selection.");
-      return DictionaryEncoding<T>::encode(selection, castedValues, buffer);
+      return DictionaryEncoding<T>::encode(
+          selection, castedValues, buffer, options);
     }
     case EncodingType::FixedBitWidth: {
       if constexpr (isNumericType<physicalType>()) {
         return FixedBitWidthEncoding<T>::encode(
-            selection, castedValues, buffer);
+            selection, castedValues, buffer, options);
       } else {
         NIMBLE_INCOMPATIBLE_ENCODING(
             "FixedBitWidth encoding should not be selected for non-numeric data types.");
@@ -321,7 +328,8 @@ std::string_view EncodingFactory::encode(
       if constexpr (
           isNumericType<physicalType>() &&
           (sizeof(physicalType) == 4 || sizeof(T) == 8)) {
-        return VarintEncoding<T>::encode(selection, castedValues, buffer);
+        return VarintEncoding<T>::encode(
+            selection, castedValues, buffer, options);
       } else {
         NIMBLE_INCOMPATIBLE_ENCODING(
             "Varint encoding can only be selected for large numeric data types.");
@@ -333,7 +341,7 @@ std::string_view EncodingFactory::encode(
             "MainlyConstant encoding should not be selected for bool data types.");
       } else {
         return MainlyConstantEncoding<T>::encode(
-            selection, castedValues, buffer);
+            selection, castedValues, buffer, options);
       }
     }
     case EncodingType::SparseBool: {
@@ -341,7 +349,8 @@ std::string_view EncodingFactory::encode(
         NIMBLE_INCOMPATIBLE_ENCODING(
             "SparseBool encoding should not be selected for non-bool data types.");
       } else {
-        return SparseBoolEncoding::encode(selection, castedValues, buffer);
+        return SparseBoolEncoding::encode(
+            selection, castedValues, buffer, options);
       }
     }
     case EncodingType::Prefix: {
@@ -349,7 +358,7 @@ std::string_view EncodingFactory::encode(
         NIMBLE_INCOMPATIBLE_ENCODING(
             "Prefix encoding should only be selected for string_view data types.");
       } else {
-        return PrefixEncoding::encode(selection, castedValues, buffer);
+        return PrefixEncoding::encode(selection, castedValues, buffer, options);
       }
     }
     default: {
@@ -364,12 +373,13 @@ std::string_view EncodingFactory::encodeNullable(
     EncodingSelection<typename TypeTraits<T>::physicalType>&& selection,
     std::span<const typename TypeTraits<T>::physicalType> values,
     std::span<const bool> nulls,
-    Buffer& buffer) {
+    Buffer& buffer,
+    const Encoding::Options& options) {
   auto physicalValues = toPhysicalSpan(values);
   switch (selection.encodingType()) {
     case EncodingType::Nullable: {
       return NullableEncoding<T>::encodeNullable(
-          selection, physicalValues, nulls, buffer);
+          selection, physicalValues, nulls, buffer, options);
     }
     default: {
       NIMBLE_UNSUPPORTED(
@@ -383,21 +393,25 @@ std::string_view EncodingFactory::encodeNullable(
   template std::string_view EncodingFactory::encode<type>(                     \
       std::unique_ptr<EncodingSelectionPolicy<type>> && selectorPolicy,        \
       std::span<const type> values,                                            \
-      Buffer & buffer);                                                        \
+      Buffer & buffer,                                                         \
+      const Encoding::Options& options);                                       \
   template std::string_view EncodingFactory::encodeNullable<type>(             \
       std::unique_ptr<EncodingSelectionPolicy<type>> && selectorPolicy,        \
       std::span<const type> values,                                            \
       std::span<const bool> nulls,                                             \
-      Buffer & buffer);                                                        \
+      Buffer & buffer,                                                         \
+      const Encoding::Options& options);                                       \
   template std::string_view EncodingFactory::encode<type>(                     \
       EncodingSelection<typename TypeTraits<type>::physicalType> && selection, \
       std::span<const typename TypeTraits<type>::physicalType> values,         \
-      Buffer & buffer);                                                        \
+      Buffer & buffer,                                                         \
+      const Encoding::Options& options);                                       \
   template std::string_view EncodingFactory::encodeNullable<type>(             \
       EncodingSelection<typename TypeTraits<type>::physicalType> && selection, \
       std::span<const typename TypeTraits<type>::physicalType> values,         \
       std::span<const bool> nulls,                                             \
-      Buffer & buffer);
+      Buffer & buffer,                                                         \
+      const Encoding::Options& options);
 
 DEFINE_TEMPLATES(int8_t);
 DEFINE_TEMPLATES(uint8_t);

--- a/dwio/nimble/encodings/EncodingFactory.h
+++ b/dwio/nimble/encodings/EncodingFactory.h
@@ -34,34 +34,39 @@ class EncodingFactory {
   static std::unique_ptr<Encoding> decode(
       velox::memory::MemoryPool& memoryPool,
       std::string_view data,
-      std::function<void*(uint32_t)> stringBufferFactory);
+      std::function<void*(uint32_t)> stringBufferFactory,
+      const Encoding::Options& options = {});
 
   template <typename T>
   static std::string_view encode(
       std::unique_ptr<EncodingSelectionPolicy<T>>&& selectorPolicy,
       std::span<const T> values,
-      Buffer& buffer);
+      Buffer& buffer,
+      const Encoding::Options& options = {});
 
   template <typename T>
   static std::string_view encodeNullable(
       std::unique_ptr<EncodingSelectionPolicy<T>>&& selectorPolicy,
       std::span<const T> values,
       std::span<const bool> nulls,
-      Buffer& buffer);
+      Buffer& buffer,
+      const Encoding::Options& options = {});
 
  private:
   template <typename T>
   static std::string_view encode(
       EncodingSelection<typename TypeTraits<T>::physicalType>&& selection,
       std::span<const typename TypeTraits<T>::physicalType> values,
-      Buffer& buffer);
+      Buffer& buffer,
+      const Encoding::Options& options = {});
 
   template <typename T>
   static std::string_view encodeNullable(
       EncodingSelection<typename TypeTraits<T>::physicalType>&& selection,
       std::span<const typename TypeTraits<T>::physicalType> values,
       std::span<const bool> nulls,
-      Buffer& buffer);
+      Buffer& buffer,
+      const Encoding::Options& options = {});
 
   friend class EncodingSelection<int8_t>;
   friend class EncodingSelection<uint8_t>;

--- a/dwio/nimble/encodings/EncodingSelection.h
+++ b/dwio/nimble/encodings/EncodingSelection.h
@@ -221,7 +221,8 @@ class EncodingSelection {
   std::string_view encodeNested(
       NestedEncodingIdentifier identifier,
       std::span<const NestedT> values,
-      Buffer& buffer);
+      Buffer& buffer,
+      const Encoding::Options& options = {});
 
  private:
   EncodingSelectionResult selectionResult_;
@@ -297,7 +298,8 @@ template <typename NestedT>
 std::string_view EncodingSelection<T>::encodeNested(
     NestedEncodingIdentifier identifier,
     std::span<const NestedT> values,
-    Buffer& buffer) {
+    Buffer& buffer,
+    const Encoding::Options& options) {
   // Create the nested encoding selection policy instance, and cast it to the
   // strongly templated type.
   auto nestedPolicy = std::unique_ptr<EncodingSelectionPolicy<NestedT>>(
@@ -313,7 +315,8 @@ std::string_view EncodingSelection<T>::encodeNested(
           std::move(statistics),
           std::move(nestedPolicy)},
       values,
-      buffer);
+      buffer,
+      options);
 }
 
 } // namespace facebook::nimble

--- a/dwio/nimble/encodings/FixedBitWidthEncoding.h
+++ b/dwio/nimble/encodings/FixedBitWidthEncoding.h
@@ -48,13 +48,13 @@ class FixedBitWidthEncoding final
   using cppDataType = T;
   using physicalType = typename TypeTraits<T>::physicalType;
 
-  static const int kCompressionOffset = Encoding::kPrefixSize;
   static const int kPrefixSize = 2 + sizeof(T);
 
   FixedBitWidthEncoding(
       velox::memory::MemoryPool& memoryPool,
       std::string_view data,
-      std::function<void*(uint32_t)> stringBufferFactory);
+      std::function<void*(uint32_t)> stringBufferFactory,
+      const Encoding::Options& options = {});
 
   void reset() final;
   void skip(uint32_t rowCount) final;
@@ -66,7 +66,8 @@ class FixedBitWidthEncoding final
   static std::string_view encode(
       EncodingSelection<physicalType>& selection,
       std::span<const physicalType> values,
-      Buffer& buffer);
+      Buffer& buffer,
+      const Encoding::Options& options = {});
 
   std::string debugString(int offset) const final;
 
@@ -87,11 +88,12 @@ template <typename T>
 FixedBitWidthEncoding<T>::FixedBitWidthEncoding(
     velox::memory::MemoryPool& memoryPool,
     std::string_view data,
-    std::function<void*(uint32_t)> /* stringBufferFactory */)
-    : TypedEncoding<T, physicalType>{memoryPool, data},
+    std::function<void*(uint32_t)> /* stringBufferFactory */,
+    const Encoding::Options& options)
+    : TypedEncoding<T, physicalType>{memoryPool, data, options},
       uncompressedData_{&memoryPool},
       buffer_{&memoryPool} {
-  auto pos = data.data() + kCompressionOffset;
+  auto pos = data.data() + this->dataOffset();
   auto compressionType = static_cast<CompressionType>(encoding::readChar(pos));
   baseline_ = encoding::read<const physicalType>(pos);
   bitWidth_ = static_cast<uint32_t>(encoding::readChar(pos));
@@ -159,7 +161,9 @@ template <typename T>
 std::string_view FixedBitWidthEncoding<T>::encode(
     EncodingSelection<physicalType>& selection,
     std::span<const physicalType> values,
-    Buffer& buffer) {
+    Buffer& buffer,
+    const Encoding::Options& options) {
+  const bool useVarint = options.useVarintRowCount;
   static_assert(
       std::is_same_v<
           typename std::make_unsigned<physicalType>::type,
@@ -219,12 +223,17 @@ std::string_view FixedBitWidthEncoding<T>::encode(
         return pos;
       }};
 
-  const uint32_t encodingSize = Encoding::kPrefixSize +
+  const uint32_t encodingSize =
+      Encoding::serializePrefixSize(rowCount, useVarint) +
       FixedBitWidthEncoding<T>::kPrefixSize + compressionEncoder.getSize();
   char* reserved = buffer.reserve(encodingSize);
   char* pos = reserved;
   Encoding::serializePrefix(
-      EncodingType::FixedBitWidth, TypeTraits<T>::dataType, rowCount, pos);
+      EncodingType::FixedBitWidth,
+      TypeTraits<T>::dataType,
+      rowCount,
+      useVarint,
+      pos);
   encoding::writeChar(
       static_cast<char>(compressionEncoder.compressionType()), pos);
   encoding::write(selection.statistics().min(), pos);

--- a/dwio/nimble/encodings/MainlyConstantEncoding.cpp
+++ b/dwio/nimble/encodings/MainlyConstantEncoding.cpp
@@ -21,16 +21,17 @@ namespace facebook::nimble {
 MainlyConstantEncoding<std::string_view>::MainlyConstantEncoding(
     velox::memory::MemoryPool& memoryPool,
     std::string_view data,
-    std::function<void*(uint32_t)> stringBufferFactory)
-    : MainlyConstantEncodingBase<std::string_view>(memoryPool, data) {
-  const char* pos = data.data() + Encoding::kPrefixSize;
+    std::function<void*(uint32_t)> stringBufferFactory,
+    const Encoding::Options& options)
+    : MainlyConstantEncodingBase<std::string_view>(memoryPool, data, options) {
+  const char* pos = data.data() + this->dataOffset();
   const uint32_t isCommonBytes = encoding::readUint32(pos);
   isCommon_ = EncodingFactory::decode(
-      *this->pool_, {pos, isCommonBytes}, stringBufferFactory);
+      *this->pool_, {pos, isCommonBytes}, stringBufferFactory, options);
   pos += isCommonBytes;
   const uint32_t otherValuesBytes = encoding::readUint32(pos);
   otherValues_ = EncodingFactory::decode(
-      *this->pool_, {pos, otherValuesBytes}, stringBufferFactory);
+      *this->pool_, {pos, otherValuesBytes}, stringBufferFactory, options);
   pos += otherValuesBytes;
   commonValue_ = encoding::read<physicalType>(pos);
   NIMBLE_CHECK(pos == data.end(), "Unexpected mainly constant encoding end");
@@ -43,7 +44,9 @@ MainlyConstantEncoding<std::string_view>::MainlyConstantEncoding(
 std::string_view MainlyConstantEncoding<std::string_view>::encode(
     EncodingSelection<physicalType>& selection,
     std::span<const physicalType> values,
-    Buffer& buffer) {
+    Buffer& buffer,
+    const Encoding::Options& options) {
+  const bool useVarint = options.useVarintRowCount;
   if (values.empty()) {
     NIMBLE_INCOMPATIBLE_ENCODING("MainlyConstantEncoding cannot be empty.");
   }
@@ -71,15 +74,19 @@ std::string_view MainlyConstantEncoding<std::string_view>::encode(
 
   Buffer tempBuffer{buffer.getMemoryPool()};
   std::string_view serializedIsCommon = selection.template encodeNested<bool>(
-      EncodingIdentifiers::MainlyConstant::IsCommon, isCommon, tempBuffer);
+      EncodingIdentifiers::MainlyConstant::IsCommon,
+      isCommon,
+      tempBuffer,
+      options);
   std::string_view serializedOtherValues =
       selection.template encodeNested<physicalType>(
           EncodingIdentifiers::MainlyConstant::OtherValues,
           otherValues,
-          tempBuffer);
+          tempBuffer,
+          options);
 
-  uint32_t encodingSize = Encoding::kPrefixSize + 8 +
-      serializedIsCommon.size() + serializedOtherValues.size();
+  uint32_t encodingSize = Encoding::serializePrefixSize(entryCount, useVarint) +
+      8 + serializedIsCommon.size() + serializedOtherValues.size();
   if constexpr (isNumericType<physicalType>()) {
     encodingSize += sizeof(physicalType);
   } else {
@@ -91,6 +98,7 @@ std::string_view MainlyConstantEncoding<std::string_view>::encode(
       EncodingType::MainlyConstant,
       TypeTraits<std::string_view>::dataType,
       entryCount,
+      useVarint,
       pos);
   encoding::writeString(serializedIsCommon, pos);
   encoding::writeString(serializedOtherValues, pos);

--- a/dwio/nimble/encodings/MainlyConstantEncoding.h
+++ b/dwio/nimble/encodings/MainlyConstantEncoding.h
@@ -68,8 +68,9 @@ class MainlyConstantEncodingBase
 
   MainlyConstantEncodingBase(
       velox::memory::MemoryPool& memoryPool,
-      std::string_view data)
-      : TypedEncoding<T, physicalType>(memoryPool, data),
+      std::string_view data,
+      const Encoding::Options& options = {})
+      : TypedEncoding<T, physicalType>(memoryPool, data, options),
         isCommonBuffer_(&memoryPool),
         otherValuesBuffer_(&memoryPool) {}
 
@@ -309,12 +310,14 @@ class MainlyConstantEncoding final : public MainlyConstantEncodingBase<T> {
   MainlyConstantEncoding(
       velox::memory::MemoryPool& memoryPool,
       std::string_view data,
-      std::function<void*(uint32_t)> stringBufferFactory);
+      std::function<void*(uint32_t)> stringBufferFactory,
+      const Encoding::Options& options = {});
 
   static std::string_view encode(
       EncodingSelection<physicalType>& selection,
       std::span<const physicalType> values,
-      Buffer& buffer);
+      Buffer& buffer,
+      const Encoding::Options& options = {});
 };
 
 //
@@ -325,16 +328,17 @@ template <typename T>
 MainlyConstantEncoding<T>::MainlyConstantEncoding(
     velox::memory::MemoryPool& memoryPool,
     std::string_view data,
-    std::function<void*(uint32_t)> stringBufferFactory)
-    : MainlyConstantEncodingBase<T>(memoryPool, data) {
-  const char* pos = data.data() + Encoding::kPrefixSize;
+    std::function<void*(uint32_t)> stringBufferFactory,
+    const Encoding::Options& options)
+    : MainlyConstantEncodingBase<T>(memoryPool, data, options) {
+  const char* pos = data.data() + this->dataOffset();
   const uint32_t isCommonBytes = encoding::readUint32(pos);
   this->isCommon_ = EncodingFactory::decode(
-      *this->pool_, {pos, isCommonBytes}, stringBufferFactory);
+      *this->pool_, {pos, isCommonBytes}, stringBufferFactory, options);
   pos += isCommonBytes;
   const uint32_t otherValuesBytes = encoding::readUint32(pos);
   this->otherValues_ = EncodingFactory::decode(
-      *this->pool_, {pos, otherValuesBytes}, stringBufferFactory);
+      *this->pool_, {pos, otherValuesBytes}, stringBufferFactory, options);
   pos += otherValuesBytes;
   this->commonValue_ = encoding::read<physicalType>(pos);
   NIMBLE_CHECK(pos == data.end(), "Unexpected mainly constant encoding end");
@@ -346,7 +350,9 @@ template <typename T>
 std::string_view MainlyConstantEncoding<T>::encode(
     EncodingSelection<physicalType>& selection,
     std::span<const physicalType> values,
-    Buffer& buffer) {
+    Buffer& buffer,
+    const Encoding::Options& options) {
+  const bool useVarint = options.useVarintRowCount;
   if (values.empty()) {
     NIMBLE_INCOMPATIBLE_ENCODING("MainlyConstantEncoding cannot be empty.");
   }
@@ -374,15 +380,19 @@ std::string_view MainlyConstantEncoding<T>::encode(
 
   Buffer tempBuffer{buffer.getMemoryPool()};
   std::string_view serializedIsCommon = selection.template encodeNested<bool>(
-      EncodingIdentifiers::MainlyConstant::IsCommon, isCommon, tempBuffer);
+      EncodingIdentifiers::MainlyConstant::IsCommon,
+      isCommon,
+      tempBuffer,
+      options);
   std::string_view serializedOtherValues =
       selection.template encodeNested<physicalType>(
           EncodingIdentifiers::MainlyConstant::OtherValues,
           otherValues,
-          tempBuffer);
+          tempBuffer,
+          options);
 
-  uint32_t encodingSize = Encoding::kPrefixSize + 8 +
-      serializedIsCommon.size() + serializedOtherValues.size();
+  uint32_t encodingSize = Encoding::serializePrefixSize(entryCount, useVarint) +
+      8 + serializedIsCommon.size() + serializedOtherValues.size();
   if constexpr (isNumericType<physicalType>()) {
     encodingSize += sizeof(physicalType);
   } else {
@@ -391,7 +401,11 @@ std::string_view MainlyConstantEncoding<T>::encode(
   char* reserved = buffer.reserve(encodingSize);
   char* pos = reserved;
   Encoding::serializePrefix(
-      EncodingType::MainlyConstant, TypeTraits<T>::dataType, entryCount, pos);
+      EncodingType::MainlyConstant,
+      TypeTraits<T>::dataType,
+      entryCount,
+      useVarint,
+      pos);
   // TODO: Reorder these so that metadata is at the beginning.
   encoding::writeString(serializedIsCommon, pos);
   encoding::writeString(serializedOtherValues, pos);
@@ -410,11 +424,13 @@ class MainlyConstantEncoding<std::string_view> final
   MainlyConstantEncoding(
       velox::memory::MemoryPool& memoryPool,
       std::string_view data,
-      std::function<void*(uint32_t)> stringBufferFactory);
+      std::function<void*(uint32_t)> stringBufferFactory,
+      const Encoding::Options& options = {});
 
   static std::string_view encode(
       EncodingSelection<physicalType>& selection,
       std::span<const physicalType> values,
-      Buffer& buffer);
+      Buffer& buffer,
+      const Encoding::Options& options = {});
 };
 } // namespace facebook::nimble

--- a/dwio/nimble/encodings/NullableEncoding.h
+++ b/dwio/nimble/encodings/NullableEncoding.h
@@ -45,7 +45,8 @@ class NullableEncoding final
   NullableEncoding(
       velox::memory::MemoryPool& memoryPool,
       std::string_view data,
-      std::function<void*(uint32_t)> stringBufferFactory);
+      std::function<void*(uint32_t)> stringBufferFactory,
+      const Encoding::Options& options = {});
 
   uint32_t nullCount() const final;
   bool isNullable() const final;
@@ -68,7 +69,8 @@ class NullableEncoding final
       EncodingSelection<physicalType>& selection,
       std::span<const physicalType> values,
       std::span<const bool> nulls,
-      Buffer& buffer);
+      Buffer& buffer,
+      const Encoding::Options& options = {});
 
   std::string debugString(int offset) const final;
 
@@ -92,19 +94,21 @@ template <typename T>
 NullableEncoding<T>::NullableEncoding(
     velox::memory::MemoryPool& memoryPool,
     std::string_view data,
-    std::function<void*(uint32_t)> stringBufferFactory)
-    : TypedEncoding<T, physicalType>(memoryPool, data),
+    std::function<void*(uint32_t)> stringBufferFactory,
+    const Encoding::Options& options)
+    : TypedEncoding<T, physicalType>(memoryPool, data, options),
       indicesBuffer_(this->pool_),
       nullBuffer_(this->pool_) {
-  const char* pos = data.data() + Encoding::kPrefixSize;
+  const char* pos = data.data() + this->dataOffset();
   const uint32_t nonNullsBytes = encoding::readUint32(pos);
   nonNullValues_ = EncodingFactory::decode(
-      *this->pool_, {pos, nonNullsBytes}, stringBufferFactory);
+      *this->pool_, {pos, nonNullsBytes}, stringBufferFactory, options);
   pos += nonNullsBytes;
   nulls_ = EncodingFactory::decode(
       *this->pool_,
       {pos, static_cast<size_t>(data.end() - pos)},
-      stringBufferFactory);
+      stringBufferFactory,
+      options);
   NIMBLE_DCHECK_EQ(
       Encoding::rowCount(), nulls_->rowCount(), "Nulls count mismatch.");
 }
@@ -284,22 +288,29 @@ std::string_view NullableEncoding<T>::encodeNullable(
     EncodingSelection<physicalType>& selection,
     std::span<const physicalType> values,
     std::span<const bool> nulls,
-    Buffer& buffer) {
+    Buffer& buffer,
+    const Encoding::Options& options) {
+  const bool useVarint = options.useVarintRowCount;
   const uint32_t rowCount = nulls.size();
 
   Buffer tempBuffer{buffer.getMemoryPool()};
   std::string_view serializedValues =
       selection.template encodeNested<physicalType>(
-          EncodingIdentifiers::Nullable::Data, values, tempBuffer);
+          EncodingIdentifiers::Nullable::Data, values, tempBuffer, options);
   std::string_view serializedNulls = selection.template encodeNested<bool>(
-      EncodingIdentifiers::Nullable::Nulls, nulls, tempBuffer);
+      EncodingIdentifiers::Nullable::Nulls, nulls, tempBuffer, options);
 
-  const uint32_t encodingSize = Encoding::kPrefixSize + 4 +
+  const uint32_t encodingSize =
+      Encoding::serializePrefixSize(rowCount, useVarint) + 4 +
       serializedValues.size() + serializedNulls.size();
   char* reserved = buffer.reserve(encodingSize);
   char* pos = reserved;
   Encoding::serializePrefix(
-      EncodingType::Nullable, TypeTraits<T>::dataType, rowCount, pos);
+      EncodingType::Nullable,
+      TypeTraits<T>::dataType,
+      rowCount,
+      useVarint,
+      pos);
   encoding::writeString(serializedValues, pos);
   encoding::writeBytes(serializedNulls, pos);
   NIMBLE_DCHECK_EQ(pos - reserved, encodingSize, "Encoding size mismatch.");

--- a/dwio/nimble/encodings/PrefixEncoding.cpp
+++ b/dwio/nimble/encodings/PrefixEncoding.cpp
@@ -23,20 +23,23 @@ namespace facebook::nimble {
 
 PrefixEncoding::PrefixEncoding(
     velox::memory::MemoryPool& pool,
-    std::string_view data)
-    : TypedEncoding<std::string_view, std::string_view>{pool, data},
-      restartInterval_{readRestartInterval(data)},
+    std::string_view data,
+    const Encoding::Options& options)
+    : TypedEncoding<std::string_view, std::string_view>{pool, data, options},
+      restartInterval_{readRestartInterval(data, dataOffset())},
       numRestarts_{computeNumRestarts(rowCount_, restartInterval_)},
-      restartOffsets_{restartOffsets(data)},
-      dataStart_{dataStart(data, numRestarts_)},
+      restartOffsets_{restartOffsets(data, dataOffset())},
+      dataStart_{dataStart(data, dataOffset(), numRestarts_)},
       decodedValue_{pool_},
       materializedValues_{pool_} {
   reset();
 }
 
 // static
-uint32_t PrefixEncoding::readRestartInterval(std::string_view data) {
-  const auto* pos = data.data() + kRestartIntervalOffset;
+uint32_t PrefixEncoding::readRestartInterval(
+    std::string_view data,
+    uint32_t startOffset) {
+  const auto* pos = data.data() + startOffset;
   return encoding::readUint32(pos);
 }
 
@@ -48,15 +51,18 @@ uint32_t PrefixEncoding::computeNumRestarts(
 }
 
 // static
-const char* PrefixEncoding::restartOffsets(std::string_view data) {
-  return data.data() + kRestartOffsetsOffset;
+const char* PrefixEncoding::restartOffsets(
+    std::string_view data,
+    uint32_t startOffset) {
+  return data.data() + startOffset + 4;
 }
 
 // static
 const char* PrefixEncoding::dataStart(
     std::string_view data,
+    uint32_t startOffset,
     uint32_t numRestarts) {
-  return data.data() + kRestartOffsetsOffset + (numRestarts * sizeof(uint32_t));
+  return data.data() + startOffset + 4 + (numRestarts * sizeof(uint32_t));
 }
 
 void PrefixEncoding::reset() {
@@ -220,7 +226,9 @@ uint32_t PrefixEncoding::restartInterval(
 std::string_view PrefixEncoding::encode(
     EncodingSelection<physicalType>& selection,
     std::span<const physicalType> values,
-    Buffer& buffer) {
+    Buffer& buffer,
+    const Encoding::Options& options) {
+  const bool useVarint = options.useVarintRowCount;
   const uint32_t valueCount = values.size();
 
   // Get restart interval from config, or use default
@@ -281,7 +289,8 @@ std::string_view PrefixEncoding::encode(
       numRestarts, restartOffsets.size(), "Restart count mismatch");
   const uint32_t restartOffsetsSize = numRestarts * sizeof(uint32_t);
   const uint32_t encodingSize =
-      kRestartOffsetsOffset + restartOffsetsSize + encodedData.size();
+      Encoding::serializePrefixSize(valueCount, useVarint) + 4 +
+      restartOffsetsSize + encodedData.size();
 
   // Write encoded data to buffer
   char* reserved = buffer.reserve(encodingSize);
@@ -292,6 +301,7 @@ std::string_view PrefixEncoding::encode(
       EncodingType::Prefix,
       TypeTraits<std::string_view>::dataType,
       valueCount,
+      useVarint,
       pos);
 
   // Write restart interval

--- a/dwio/nimble/encodings/PrefixEncoding.h
+++ b/dwio/nimble/encodings/PrefixEncoding.h
@@ -67,14 +67,15 @@ class PrefixEncoding final
   using cppDataType = std::string_view;
   using physicalType = std::string_view;
 
-  static constexpr int kRestartIntervalOffset = Encoding::kPrefixSize;
-  static constexpr int kRestartOffsetsOffset = kRestartIntervalOffset + 4;
   static constexpr uint32_t kDefaultRestartInterval = 16;
   // Config key for restart interval in EncodingSelectionResult::encodingConfig
   static constexpr std::string_view kRestartIntervalConfigKey =
       "prefix-encoding.restart-interval";
 
-  PrefixEncoding(velox::memory::MemoryPool& pool, std::string_view data);
+  PrefixEncoding(
+      velox::memory::MemoryPool& pool,
+      std::string_view data,
+      const Encoding::Options& options = {});
 
   void reset() final;
   void skip(uint32_t rowCount) final;
@@ -108,16 +109,22 @@ class PrefixEncoding final
   static std::string_view encode(
       EncodingSelection<physicalType>& selection,
       std::span<const physicalType> values,
-      Buffer& buffer);
+      Buffer& buffer,
+      const Encoding::Options& options = {});
 
   std::string debugString(int offset) const final;
 
  private:
-  // Static helper methods for initializing const members
-  // While decoding, extracts the restart interval from the encoded block.
-  static uint32_t readRestartInterval(std::string_view data);
-  static const char* restartOffsets(std::string_view data);
-  static const char* dataStart(std::string_view data, uint32_t numRestarts);
+  // Static helper methods for initializing const members.
+  // startOffset is where encoding-specific data begins (after the base prefix).
+  static uint32_t readRestartInterval(
+      std::string_view data,
+      uint32_t startOffset);
+  static const char* restartOffsets(
+      std::string_view data,
+      uint32_t startOffset);
+  static const char*
+  dataStart(std::string_view data, uint32_t startOffset, uint32_t numRestarts);
 
   // Computes numRestarts from rowCount and restartInterval
   static uint32_t computeNumRestarts(

--- a/dwio/nimble/encodings/RleEncoding.cpp
+++ b/dwio/nimble/encodings/RleEncoding.cpp
@@ -20,11 +20,13 @@ namespace facebook::nimble {
 RLEEncoding<bool>::RLEEncoding(
     velox::memory::MemoryPool& memoryPool,
     std::string_view data,
-    std::function<void*(uint32_t)> stringBufferFactory)
+    std::function<void*(uint32_t)> stringBufferFactory,
+    const Encoding::Options& options)
     : internal::RLEEncodingBase<bool, RLEEncoding<bool>>(
           memoryPool,
           data,
-          stringBufferFactory) {
+          stringBufferFactory,
+          options) {
   initialValue_ = *reinterpret_cast<const bool*>(
       internal::RLEEncodingBase<bool, RLEEncoding<bool>>::getValuesStart());
   NIMBLE_CHECK(

--- a/dwio/nimble/encodings/RleEncoding.h
+++ b/dwio/nimble/encodings/RleEncoding.h
@@ -57,14 +57,16 @@ class RLEEncodingBase
   RLEEncodingBase(
       velox::memory::MemoryPool& memoryPool,
       std::string_view data,
-      std::function<void*(uint32_t)> stringBufferFactory)
-      : TypedEncoding<T, physicalType>(memoryPool, data),
+      std::function<void*(uint32_t)> stringBufferFactory,
+      const Encoding::Options& options = {})
+      : TypedEncoding<T, physicalType>(memoryPool, data, options),
         materializedRunLengths_{EncodingFactory::decode(
             memoryPool,
-            {data.data() + Encoding::kPrefixSize + 4,
+            {data.data() + this->dataOffset() + 4,
              *reinterpret_cast<const uint32_t*>(
-                 data.data() + Encoding::kPrefixSize)},
-            stringBufferFactory)} {}
+                 data.data() + this->dataOffset())},
+            stringBufferFactory,
+            options)} {}
 
   void reset() {
     materializedRunLengths_.reset();
@@ -125,7 +127,9 @@ class RLEEncodingBase
   static std::string_view encode(
       EncodingSelection<physicalType>& selection,
       std::span<const physicalType> values,
-      Buffer& buffer) {
+      Buffer& buffer,
+      const Encoding::Options& options = {}) {
+    const bool useVarint = options.useVarintRowCount;
     const uint32_t valueCount = values.size();
     Vector<uint32_t> runLengths(&buffer.getMemoryPool());
     Vector<physicalType> runValues(&buffer.getMemoryPool());
@@ -134,17 +138,21 @@ class RLEEncodingBase
     Buffer tempBuffer{buffer.getMemoryPool()};
     std::string_view serializedRunLengths =
         selection.template encodeNested<uint32_t>(
-            EncodingIdentifiers::RunLength::RunLengths, runLengths, tempBuffer);
+            EncodingIdentifiers::RunLength::RunLengths,
+            runLengths,
+            tempBuffer,
+            options);
 
     std::string_view serializedRunValues =
-        getSerializedRunValues(selection, runValues, tempBuffer);
+        getSerializedRunValues(selection, runValues, tempBuffer, options);
 
-    const uint32_t encodingSize = Encoding::kPrefixSize + 4 +
+    const uint32_t encodingSize =
+        Encoding::serializePrefixSize(valueCount, useVarint) + 4 +
         serializedRunLengths.size() + serializedRunValues.size();
     char* reserved = buffer.reserve(encodingSize);
     char* pos = reserved;
     Encoding::serializePrefix(
-        EncodingType::RLE, TypeTraits<T>::dataType, valueCount, pos);
+        EncodingType::RLE, TypeTraits<T>::dataType, valueCount, useVarint, pos);
     encoding::writeString(serializedRunLengths, pos);
     encoding::writeBytes(serializedRunValues, pos);
     NIMBLE_DCHECK_EQ(pos - reserved, encodingSize, "Encoding size mismatch.");
@@ -152,9 +160,9 @@ class RLEEncodingBase
   }
 
   const char* getValuesStart() const {
-    return this->data_.data() + Encoding::kPrefixSize + 4 +
+    return this->data_.data() + this->dataOffset() + 4 +
         *reinterpret_cast<const uint32_t*>(
-               this->data_.data() + Encoding::kPrefixSize);
+               this->data_.data() + this->dataOffset());
   }
 
   RLEEncoding& derived() {
@@ -166,8 +174,10 @@ class RLEEncodingBase
   static std::string_view getSerializedRunValues(
       EncodingSelection<physicalType>& selection,
       const Vector<physicalType>& runValues,
-      Buffer& buffer) {
-    return RLEEncoding::getSerializedRunValues(selection, runValues, buffer);
+      Buffer& buffer,
+      const Encoding::Options& options = {}) {
+    return RLEEncoding::getSerializedRunValues(
+        selection, runValues, buffer, options);
   }
 
   uint32_t copiesRemaining_ = 0;
@@ -189,16 +199,18 @@ class RLEEncoding final : public internal::RLEEncodingBase<T, RLEEncoding<T>> {
   explicit RLEEncoding(
       velox::memory::MemoryPool& memoryPool,
       std::string_view data,
-      std::function<void*(uint32_t)> stringBufferFactory);
+      std::function<void*(uint32_t)> stringBufferFactory,
+      const Encoding::Options& options = {});
 
   physicalType nextValue();
   void resetValues();
   static std::string_view getSerializedRunValues(
       EncodingSelection<physicalType>& selection,
       const Vector<physicalType>& runValues,
-      Buffer& buffer) {
+      Buffer& buffer,
+      const Encoding::Options& options = {}) {
     return selection.template encodeNested<physicalType>(
-        EncodingIdentifiers::RunLength::RunValues, runValues, buffer);
+        EncodingIdentifiers::RunLength::RunValues, runValues, buffer, options);
   }
 
   template <typename DecoderVisitor>
@@ -235,14 +247,16 @@ class RLEEncoding<bool> final
   RLEEncoding(
       velox::memory::MemoryPool& memoryPool,
       std::string_view data,
-      std::function<void*(uint32_t)> stringBufferFactory);
+      std::function<void*(uint32_t)> stringBufferFactory,
+      const Encoding::Options& options = {});
 
   bool nextValue();
   void resetValues();
   static std::string_view getSerializedRunValues(
       EncodingSelection<bool>& /* selection */,
       const Vector<bool>& runValues,
-      Buffer& buffer) {
+      Buffer& buffer,
+      const Encoding::Options& /* options */ = {}) {
     char* reserved = buffer.reserve(sizeof(char));
     *reserved = runValues[0];
     return {reserved, 1};
@@ -264,18 +278,21 @@ template <typename T>
 RLEEncoding<T>::RLEEncoding(
     velox::memory::MemoryPool& memoryPool,
     std::string_view data,
-    std::function<void*(uint32_t)> stringBufferFactory)
+    std::function<void*(uint32_t)> stringBufferFactory,
+    const Encoding::Options& options)
     : internal::RLEEncodingBase<T, RLEEncoding<T>>(
           memoryPool,
           data,
-          stringBufferFactory),
+          stringBufferFactory,
+          options),
       values_{EncodingFactory::decode(
           memoryPool,
           {internal::RLEEncodingBase<T, RLEEncoding<T>>::getValuesStart(),
            static_cast<size_t>(
                data.end() -
                internal::RLEEncodingBase<T, RLEEncoding<T>>::getValuesStart())},
-          stringBufferFactory)} {
+          stringBufferFactory,
+          options)} {
   internal::RLEEncodingBase<T, RLEEncoding<T>>::reset();
 }
 

--- a/dwio/nimble/encodings/SparseBoolEncoding.cpp
+++ b/dwio/nimble/encodings/SparseBoolEncoding.cpp
@@ -26,14 +26,17 @@ namespace facebook::nimble {
 SparseBoolEncoding::SparseBoolEncoding(
     velox::memory::MemoryPool& memoryPool,
     std::string_view data,
-    std::function<void*(uint32_t)> stringBufferFactory)
-    : TypedEncoding<bool, bool>{memoryPool, data},
-      sparseValue_{static_cast<bool>(data[kSparseValueOffset])},
+    std::function<void*(uint32_t)> stringBufferFactory,
+    const Encoding::Options& options)
+    : TypedEncoding<bool, bool>{memoryPool, data, options},
+      sparseValue_{static_cast<bool>(data[this->dataOffset()])},
       indicesUncompressed_{&memoryPool},
       indices_{EncodingFactory::decode(
           memoryPool,
-          {data.data() + kIndicesOffset, data.size() - kIndicesOffset},
-          stringBufferFactory)} {
+          {data.data() + this->dataOffset() + kPrefixSize,
+           data.size() - this->dataOffset() - kPrefixSize},
+          stringBufferFactory,
+          options)} {
   reset();
 }
 
@@ -92,7 +95,9 @@ void SparseBoolEncoding::materializeBoolsAsBits(
 std::string_view SparseBoolEncoding::encode(
     EncodingSelection<bool>& selection,
     std::span<const bool> values,
-    Buffer& buffer) {
+    Buffer& buffer,
+    const Encoding::Options& options) {
+  const bool useVarint = options.useVarintRowCount;
   // Decide the polarity of the encoding.
   const uint64_t valueCount = values.size();
   const uint64_t setCount =
@@ -130,14 +135,18 @@ std::string_view SparseBoolEncoding::encode(
   Buffer tempBuffer{buffer.getMemoryPool()};
   std::string_view serializedIndices =
       selection.template encodeNested<uint32_t>(
-          EncodingIdentifiers::SparseBool::Indices, indices, tempBuffer);
+          EncodingIdentifiers::SparseBool::Indices,
+          indices,
+          tempBuffer,
+          options);
 
-  const uint32_t encodingSize = Encoding::kPrefixSize +
+  const uint32_t encodingSize =
+      Encoding::serializePrefixSize(valueCount, useVarint) +
       SparseBoolEncoding::kPrefixSize + serializedIndices.size();
   char* reserved = buffer.reserve(encodingSize);
   char* pos = reserved;
   Encoding::serializePrefix(
-      EncodingType::SparseBool, DataType::Bool, valueCount, pos);
+      EncodingType::SparseBool, DataType::Bool, valueCount, useVarint, pos);
   encoding::writeChar(sparseValue, pos);
   encoding::writeBytes(serializedIndices, pos);
 

--- a/dwio/nimble/encodings/SparseBoolEncoding.h
+++ b/dwio/nimble/encodings/SparseBoolEncoding.h
@@ -48,13 +48,12 @@ class SparseBoolEncoding final : public TypedEncoding<bool, bool> {
   using cppDataType = bool;
 
   static constexpr int kPrefixSize = 1;
-  static constexpr int kSparseValueOffset = Encoding::kPrefixSize;
-  static constexpr int kIndicesOffset = Encoding::kPrefixSize + 1;
 
   SparseBoolEncoding(
       velox::memory::MemoryPool& memoryPool,
       std::string_view data,
-      std::function<void*(uint32_t)> stringBufferFactory);
+      std::function<void*(uint32_t)> stringBufferFactory,
+      const Encoding::Options& options = {});
 
   void reset() final;
   void skip(uint32_t rowCount) final;
@@ -69,7 +68,8 @@ class SparseBoolEncoding final : public TypedEncoding<bool, bool> {
   static std::string_view encode(
       EncodingSelection<bool>& selection,
       std::span<const bool> values,
-      Buffer& buffer);
+      Buffer& buffer,
+      const Encoding::Options& options = {});
 
  private:
   // If true, then indices give the position of the set bits; if false they give

--- a/dwio/nimble/encodings/TrivialEncoding.cpp
+++ b/dwio/nimble/encodings/TrivialEncoding.cpp
@@ -21,17 +21,20 @@ namespace facebook::nimble {
 TrivialEncoding<std::string_view>::TrivialEncoding(
     velox::memory::MemoryPool& memoryPool,
     std::string_view data,
-    std::function<void*(uint32_t)> stringBufferFactory)
-    : TypedEncoding<std::string_view, std::string_view>{memoryPool, data},
+    std::function<void*(uint32_t)> stringBufferFactory,
+    const Encoding::Options& options)
+    : TypedEncoding<
+          std::string_view,
+          std::string_view>{memoryPool, data, options},
       row_{0},
       buffer_{&memoryPool},
       dataUncompressed_{&memoryPool} {
-  auto pos = data.data() + kDataCompressionOffset;
+  auto pos = data.data() + this->dataOffset();
   const auto dataCompressionType =
       static_cast<CompressionType>(encoding::readChar(pos));
   const auto lengthsSize = encoding::readUint32(pos);
   lengths_ = EncodingFactory::decode(
-      memoryPool, {pos, lengthsSize}, stringBufferFactory);
+      memoryPool, {pos, lengthsSize}, stringBufferFactory, options);
   blob_ = pos + lengthsSize;
 
   if (dataCompressionType != CompressionType::Uncompressed) {
@@ -127,7 +130,9 @@ std::optional<uint32_t> TrivialEncoding<std::string_view>::seekAtOrAfter(
 std::string_view TrivialEncoding<std::string_view>::encode(
     EncodingSelection<std::string_view>& selection,
     std::span<const std::string_view> values,
-    Buffer& buffer) {
+    Buffer& buffer,
+    const Encoding::Options& options) {
+  const bool useVarint = options.useVarintRowCount;
   const uint32_t valueCount = values.size();
   std::vector<uint32_t> lengths;
   lengths.reserve(valueCount);
@@ -138,7 +143,10 @@ std::string_view TrivialEncoding<std::string_view>::encode(
   Buffer tempBuffer{buffer.getMemoryPool()};
   std::string_view serializedLengths =
       selection.template encodeNested<uint32_t>(
-          EncodingIdentifiers::Trivial::Lengths, {lengths}, tempBuffer);
+          EncodingIdentifiers::Trivial::Lengths,
+          {lengths},
+          tempBuffer,
+          options);
 
   auto dataCompressionPolicy = selection.compressionPolicy();
   auto uncompressedSize = selection.statistics().totalStringsLength();
@@ -162,14 +170,15 @@ std::string_view TrivialEncoding<std::string_view>::encode(
         }
       }};
 
-  const uint32_t encodingSize = Encoding::kPrefixSize +
+  const uint32_t encodingSize =
+      Encoding::serializePrefixSize(valueCount, useVarint) +
       TrivialEncoding<std::string_view>::kPrefixSize +
       serializedLengths.size() + compressionEncoder.getSize();
 
   char* reserved = buffer.reserve(encodingSize);
   char* pos = reserved;
   Encoding::serializePrefix(
-      EncodingType::Trivial, DataType::String, valueCount, pos);
+      EncodingType::Trivial, DataType::String, valueCount, useVarint, pos);
   encoding::writeChar(
       static_cast<char>(compressionEncoder.compressionType()), pos);
   encoding::writeUint32(serializedLengths.size(), pos);
@@ -183,12 +192,13 @@ std::string_view TrivialEncoding<std::string_view>::encode(
 TrivialEncoding<bool>::TrivialEncoding(
     velox::memory::MemoryPool& pool,
     std::string_view data,
-    std::function<void*(uint32_t)> /* stringBufferFactory */)
-    : TypedEncoding<bool, bool>{pool, data},
-      bitmap_{data.data() + kDataOffset},
+    std::function<void*(uint32_t)> /* stringBufferFactory */,
+    const Encoding::Options& options)
+    : TypedEncoding<bool, bool>{pool, data, options},
+      bitmap_{data.data() + this->dataOffset() + kPrefixSize},
       uncompressed_{&pool} {
   const auto compressionType =
-      static_cast<CompressionType>(data[kCompressionTypeOffset]);
+      static_cast<CompressionType>(data[this->dataOffset()]);
   if (compressionType != CompressionType::Uncompressed) {
     uncompressed_ = Compression::uncompress(
         pool,
@@ -272,7 +282,9 @@ void TrivialEncoding<bool>::materializeBoolsAsBits(
 std::string_view TrivialEncoding<bool>::encode(
     EncodingSelection<bool>& selection,
     std::span<const bool> values,
-    Buffer& buffer) {
+    Buffer& buffer,
+    const Encoding::Options& options) {
+  const bool useVarint = options.useVarintRowCount;
   const uint32_t valueCount = values.size();
   const uint32_t bitmapBytes = FixedBitArray::bufferSize(valueCount, 1);
 
@@ -297,11 +309,13 @@ std::string_view TrivialEncoding<bool>::encode(
         pos += bitmapBytes;
       }};
 
-  const uint32_t encodingSize = kDataOffset + compressionEncoder.getSize();
+  const uint32_t encodingSize =
+      Encoding::serializePrefixSize(valueCount, useVarint) + kPrefixSize +
+      compressionEncoder.getSize();
   char* reserved = buffer.reserve(encodingSize);
   char* pos = reserved;
   Encoding::serializePrefix(
-      EncodingType::Trivial, DataType::Bool, valueCount, pos);
+      EncodingType::Trivial, DataType::Bool, valueCount, useVarint, pos);
   encoding::writeChar(
       static_cast<char>(compressionEncoder.compressionType()), pos);
   compressionEncoder.write(pos);

--- a/dwio/nimble/encodings/TrivialEncoding.h
+++ b/dwio/nimble/encodings/TrivialEncoding.h
@@ -48,14 +48,12 @@ class TrivialEncoding final
   using physicalType = typename TypeTraits<T>::physicalType;
 
   static constexpr int kPrefixSize = 1;
-  static constexpr int kCompressionTypeOffset = Encoding::kPrefixSize;
-  static constexpr int kDataOffset =
-      Encoding::kPrefixSize + TrivialEncoding<T>::kPrefixSize;
 
   TrivialEncoding(
       velox::memory::MemoryPool& memoryPool,
       std::string_view data,
-      std::function<void*(uint32_t)> stringBufferFactory);
+      std::function<void*(uint32_t)> stringBufferFactory,
+      const Encoding::Options& options = {});
 
   void reset() final;
   void skip(uint32_t rowCount) final;
@@ -75,7 +73,8 @@ class TrivialEncoding final
   static std::string_view encode(
       EncodingSelection<physicalType>& selection,
       std::span<const physicalType> values,
-      Buffer& buffer);
+      Buffer& buffer,
+      const Encoding::Options& options = {});
 
  private:
   uint32_t row_;
@@ -96,15 +95,12 @@ class TrivialEncoding<std::string_view> final
   using cppDataType = std::string_view;
 
   static constexpr int kPrefixSize = 5;
-  static constexpr int kDataCompressionOffset = Encoding::kPrefixSize;
-  static constexpr int kBlobOffsetOffset = Encoding::kPrefixSize + 1;
-  static constexpr int kLengthOffset =
-      Encoding::kPrefixSize + TrivialEncoding<std::string_view>::kPrefixSize;
 
   TrivialEncoding(
       velox::memory::MemoryPool& memoryPool,
       std::string_view data,
-      std::function<void*(uint32_t)> stringBufferFactory);
+      std::function<void*(uint32_t)> stringBufferFactory,
+      const Encoding::Options& options = {});
 
   void reset() final;
   void skip(uint32_t rowCount) final;
@@ -121,7 +117,8 @@ class TrivialEncoding<std::string_view> final
   static std::string_view encode(
       EncodingSelection<std::string_view>& selection,
       std::span<const std::string_view> values,
-      Buffer& buffer);
+      Buffer& buffer,
+      const Encoding::Options& options = {});
 
  private:
   uint32_t row_;
@@ -148,14 +145,12 @@ class TrivialEncoding<bool> final : public TypedEncoding<bool, bool> {
   using cppDataType = bool;
 
   static constexpr int kPrefixSize = 1;
-  static constexpr int kCompressionTypeOffset = Encoding::kPrefixSize;
-  static constexpr int kDataOffset =
-      Encoding::kPrefixSize + TrivialEncoding<bool>::kPrefixSize;
 
   TrivialEncoding(
       velox::memory::MemoryPool& pool,
       std::string_view data,
-      std::function<void*(uint32_t)> stringBufferFactory);
+      std::function<void*(uint32_t)> stringBufferFactory,
+      const Encoding::Options& options = {});
 
   void reset() final;
   void skip(uint32_t rowCount) final;
@@ -170,7 +165,8 @@ class TrivialEncoding<bool> final : public TypedEncoding<bool, bool> {
   static std::string_view encode(
       EncodingSelection<bool>& selection,
       std::span<const bool> values,
-      Buffer& buffer);
+      Buffer& buffer,
+      const Encoding::Options& options = {});
 
  private:
   uint32_t row_{0};
@@ -186,19 +182,21 @@ template <typename T>
 TrivialEncoding<T>::TrivialEncoding(
     velox::memory::MemoryPool& memoryPool,
     std::string_view data,
-    std::function<void*(uint32_t)> /* stringBufferFactory */)
-    : TypedEncoding<T, physicalType>{memoryPool, data},
+    std::function<void*(uint32_t)> /* stringBufferFactory */,
+    const Encoding::Options& options)
+    : TypedEncoding<T, physicalType>{memoryPool, data, options},
       row_{0},
-      values_{reinterpret_cast<const T*>(data.data() + kDataOffset)},
+      values_{reinterpret_cast<const T*>(
+          data.data() + this->dataOffset() + kPrefixSize)},
       uncompressed_{&memoryPool} {
-  auto compressionType =
-      static_cast<CompressionType>(data[kCompressionTypeOffset]);
+  const auto valuesOffset = this->dataOffset() + kPrefixSize;
+  auto compressionType = static_cast<CompressionType>(data[this->dataOffset()]);
   if (compressionType != CompressionType::Uncompressed) {
     uncompressed_ = Compression::uncompress(
         memoryPool,
         compressionType,
         TypeTraits<physicalType>::dataType,
-        {data.data() + kDataOffset, data.size() - kDataOffset});
+        {data.data() + valuesOffset, data.size() - valuesOffset});
     values_ = reinterpret_cast<const T*>(uncompressed_.data());
     NIMBLE_CHECK(
         reinterpret_cast<const char*>(values_ + this->rowCount()) ==
@@ -232,7 +230,9 @@ template <typename T>
 std::string_view TrivialEncoding<T>::encode(
     EncodingSelection<physicalType>& selection,
     std::span<const physicalType> values,
-    Buffer& buffer) {
+    Buffer& buffer,
+    const Encoding::Options& options) {
+  const bool useVarint = options.useVarintRowCount;
   const uint32_t rowCount = values.size();
   const uint32_t uncompressedSize = sizeof(T) * rowCount;
 
@@ -243,11 +243,13 @@ std::string_view TrivialEncoding<T>::encode(
       TypeTraits<physicalType>::dataType,
       {reinterpret_cast<const char*>(values.data()), uncompressedSize}};
 
-  const uint32_t encodingSize = kDataOffset + compressionEncoder.getSize();
+  const uint32_t encodingSize =
+      Encoding::serializePrefixSize(rowCount, useVarint) + kPrefixSize +
+      compressionEncoder.getSize();
   char* reserved = buffer.reserve(encodingSize);
   char* pos = reserved;
   Encoding::serializePrefix(
-      EncodingType::Trivial, TypeTraits<T>::dataType, rowCount, pos);
+      EncodingType::Trivial, TypeTraits<T>::dataType, rowCount, useVarint, pos);
   encoding::writeChar(
       static_cast<char>(compressionEncoder.compressionType()), pos);
   compressionEncoder.write(pos);

--- a/dwio/nimble/encodings/VarintEncoding.h
+++ b/dwio/nimble/encodings/VarintEncoding.h
@@ -45,14 +45,13 @@ class VarintEncoding final
   using cppDataType = T;
   using physicalType = typename TypeTraits<T>::physicalType;
 
-  static const int kBaselineOffset = Encoding::kPrefixSize;
-  static const int kDataOffset = kBaselineOffset + sizeof(T);
-  static const int kPrefixSize = kDataOffset - kBaselineOffset;
+  static constexpr int kPrefixSize = sizeof(T);
 
   VarintEncoding(
       velox::memory::MemoryPool& pool,
       std::string_view data,
-      std::function<void*(uint32_t)> stringBufferFactory);
+      std::function<void*(uint32_t)> stringBufferFactory,
+      const Encoding::Options& options = {});
 
   void reset() final;
   void skip(uint32_t rowCount) final;
@@ -64,7 +63,8 @@ class VarintEncoding final
   static std::string_view encode(
       EncodingSelection<physicalType>& selection,
       std::span<const physicalType> values,
-      Buffer& buffer);
+      Buffer& buffer,
+      const Encoding::Options& options = {});
 
  private:
   const physicalType baseValue_;
@@ -81,10 +81,11 @@ template <typename T>
 VarintEncoding<T>::VarintEncoding(
     velox::memory::MemoryPool& pool,
     std::string_view data,
-    std::function<void*(uint32_t)> /* stringBufferFactory */)
-    : TypedEncoding<T, physicalType>(pool, data),
+    std::function<void*(uint32_t)> /* stringBufferFactory */,
+    const Encoding::Options& options)
+    : TypedEncoding<T, physicalType>(pool, data, options),
       baseValue_{*reinterpret_cast<const physicalType*>(
-          data.data() + kBaselineOffset)},
+          data.data() + this->dataOffset())},
       buf_{this->pool_} {
   reset();
 }
@@ -92,7 +93,7 @@ VarintEncoding<T>::VarintEncoding(
 template <typename T>
 void VarintEncoding<T>::reset() {
   row_ = 0;
-  pos_ = Encoding::data_.data() + Encoding::kPrefixSize +
+  pos_ = Encoding::data_.data() + this->dataOffset() +
       VarintEncoding<T>::kPrefixSize;
 }
 
@@ -150,7 +151,9 @@ template <typename T>
 std::string_view VarintEncoding<T>::encode(
     EncodingSelection<physicalType>& selection,
     std::span<const physicalType> values,
-    Buffer& buffer) {
+    Buffer& buffer,
+    const Encoding::Options& options) {
+  const bool useVarint = options.useVarintRowCount;
   static_assert(
       std::is_same_v<
           typename std::make_unsigned<physicalType>::type,
@@ -170,15 +173,20 @@ std::string_view VarintEncoding<T>::encode(
         // to consume 2 bytes, etc.
         return sum + (bucketSize * (++index));
       });
-  const uint32_t encodingSize =
-      dataSize + Encoding::kPrefixSize + VarintEncoding<T>::kPrefixSize;
+  const uint32_t encodingSize = dataSize +
+      Encoding::serializePrefixSize(valueCount, useVarint) +
+      VarintEncoding<T>::kPrefixSize;
 
   // Adding 7 bytes, to allow bulk materialization to access the last 64 bit
   // word, even if it is not full.
   char* reserved = buffer.reserve(encodingSize);
   char* pos = reserved;
   Encoding::serializePrefix(
-      EncodingType::Varint, TypeTraits<T>::dataType, valueCount, pos);
+      EncodingType::Varint,
+      TypeTraits<T>::dataType,
+      valueCount,
+      useVarint,
+      pos);
   encoding::write(selection.statistics().min(), pos);
   for (auto value : values) {
     varint::writeVarint(value - selection.statistics().min(), &pos);

--- a/dwio/nimble/encodings/legacy/ConstantEncoding.h
+++ b/dwio/nimble/encodings/legacy/ConstantEncoding.h
@@ -140,7 +140,7 @@ std::string_view ConstantEncoding<T>::encode(
   char* reserved = buffer.reserve(encodingSize);
   char* pos = reserved;
   Encoding::serializePrefix(
-      EncodingType::Constant, TypeTraits<T>::dataType, rowCount, pos);
+      EncodingType::Constant, TypeTraits<T>::dataType, rowCount, false, pos);
   encoding::write<physicalType>(values[0], pos);
   NIMBLE_DCHECK_EQ(pos - reserved, encodingSize, "Encoding size mismatch.");
   return {reserved, encodingSize};

--- a/dwio/nimble/encodings/legacy/DictionaryEncoding.h
+++ b/dwio/nimble/encodings/legacy/DictionaryEncoding.h
@@ -281,7 +281,11 @@ std::string_view DictionaryEncoding<T>::encode(
   char* reserved = buffer.reserve(encodingSize);
   char* pos = reserved;
   Encoding::serializePrefix(
-      EncodingType::Dictionary, TypeTraits<T>::dataType, valueCount, pos);
+      EncodingType::Dictionary,
+      TypeTraits<T>::dataType,
+      valueCount,
+      false,
+      pos);
   encoding::writeUint32(serializedAlphabet.size(), pos);
   encoding::writeBytes(serializedAlphabet, pos);
   encoding::writeBytes(serializedIndices, pos);

--- a/dwio/nimble/encodings/legacy/FixedBitWidthEncoding.h
+++ b/dwio/nimble/encodings/legacy/FixedBitWidthEncoding.h
@@ -225,7 +225,11 @@ std::string_view FixedBitWidthEncoding<T>::encode(
   char* reserved = buffer.reserve(encodingSize);
   char* pos = reserved;
   Encoding::serializePrefix(
-      EncodingType::FixedBitWidth, TypeTraits<T>::dataType, rowCount, pos);
+      EncodingType::FixedBitWidth,
+      TypeTraits<T>::dataType,
+      rowCount,
+      false,
+      pos);
   encoding::writeChar(
       static_cast<char>(compressionEncoder.compressionType()), pos);
   encoding::write(selection.statistics().min(), pos);

--- a/dwio/nimble/encodings/legacy/MainlyConstantEncoding.h
+++ b/dwio/nimble/encodings/legacy/MainlyConstantEncoding.h
@@ -389,7 +389,11 @@ std::string_view MainlyConstantEncoding<T>::encode(
   char* reserved = buffer.reserve(encodingSize);
   char* pos = reserved;
   Encoding::serializePrefix(
-      EncodingType::MainlyConstant, TypeTraits<T>::dataType, entryCount, pos);
+      EncodingType::MainlyConstant,
+      TypeTraits<T>::dataType,
+      entryCount,
+      false,
+      pos);
   // TODO: Reorder these so that metadata is at the beginning.
   encoding::writeString(serializedIsCommon, pos);
   encoding::writeString(serializedOtherValues, pos);

--- a/dwio/nimble/encodings/legacy/NullableEncoding.h
+++ b/dwio/nimble/encodings/legacy/NullableEncoding.h
@@ -302,7 +302,7 @@ std::string_view NullableEncoding<T>::encodeNullable(
   char* reserved = buffer.reserve(encodingSize);
   char* pos = reserved;
   Encoding::serializePrefix(
-      EncodingType::Nullable, TypeTraits<T>::dataType, rowCount, pos);
+      EncodingType::Nullable, TypeTraits<T>::dataType, rowCount, false, pos);
   encoding::writeString(serializedValues, pos);
   encoding::writeBytes(serializedNulls, pos);
   NIMBLE_DCHECK_EQ(pos - reserved, encodingSize, "Encoding size mismatch.");

--- a/dwio/nimble/encodings/legacy/RleEncoding.h
+++ b/dwio/nimble/encodings/legacy/RleEncoding.h
@@ -144,7 +144,7 @@ class RLEEncodingBase
     char* reserved = buffer.reserve(encodingSize);
     char* pos = reserved;
     Encoding::serializePrefix(
-        EncodingType::RLE, TypeTraits<T>::dataType, valueCount, pos);
+        EncodingType::RLE, TypeTraits<T>::dataType, valueCount, false, pos);
     encoding::writeString(serializedRunLengths, pos);
     encoding::writeBytes(serializedRunValues, pos);
     NIMBLE_DCHECK_EQ(pos - reserved, encodingSize, "Encoding size mismatch.");

--- a/dwio/nimble/encodings/legacy/SparseBoolEncoding.cpp
+++ b/dwio/nimble/encodings/legacy/SparseBoolEncoding.cpp
@@ -138,7 +138,7 @@ std::string_view SparseBoolEncoding::encode(
   char* reserved = buffer.reserve(encodingSize);
   char* pos = reserved;
   Encoding::serializePrefix(
-      EncodingType::SparseBool, DataType::Bool, valueCount, pos);
+      EncodingType::SparseBool, DataType::Bool, valueCount, false, pos);
   encoding::writeChar(sparseValue, pos);
   encoding::writeBytes(serializedIndices, pos);
 

--- a/dwio/nimble/encodings/legacy/TrivialEncoding.cpp
+++ b/dwio/nimble/encodings/legacy/TrivialEncoding.cpp
@@ -125,7 +125,7 @@ std::string_view TrivialEncoding<std::string_view>::encode(
   char* reserved = buffer.reserve(encodingSize);
   char* pos = reserved;
   Encoding::serializePrefix(
-      EncodingType::Trivial, DataType::String, valueCount, pos);
+      EncodingType::Trivial, DataType::String, valueCount, false, pos);
   encoding::writeChar(
       static_cast<char>(compressionEncoder.compressionType()), pos);
   encoding::writeUint32(serializedLengths.size(), pos);
@@ -257,7 +257,7 @@ std::string_view TrivialEncoding<bool>::encode(
   char* reserved = buffer.reserve(encodingSize);
   char* pos = reserved;
   Encoding::serializePrefix(
-      EncodingType::Trivial, DataType::Bool, valueCount, pos);
+      EncodingType::Trivial, DataType::Bool, valueCount, false, pos);
   encoding::writeChar(
       static_cast<char>(compressionEncoder.compressionType()), pos);
   compressionEncoder.write(pos);

--- a/dwio/nimble/encodings/legacy/TrivialEncoding.h
+++ b/dwio/nimble/encodings/legacy/TrivialEncoding.h
@@ -246,7 +246,7 @@ std::string_view TrivialEncoding<T>::encode(
   char* reserved = buffer.reserve(encodingSize);
   char* pos = reserved;
   Encoding::serializePrefix(
-      EncodingType::Trivial, TypeTraits<T>::dataType, rowCount, pos);
+      EncodingType::Trivial, TypeTraits<T>::dataType, rowCount, false, pos);
   encoding::writeChar(
       static_cast<char>(compressionEncoder.compressionType()), pos);
   compressionEncoder.write(pos);

--- a/dwio/nimble/encodings/legacy/VarintEncoding.h
+++ b/dwio/nimble/encodings/legacy/VarintEncoding.h
@@ -177,7 +177,7 @@ std::string_view VarintEncoding<T>::encode(
   char* reserved = buffer.reserve(encodingSize);
   char* pos = reserved;
   Encoding::serializePrefix(
-      EncodingType::Varint, TypeTraits<T>::dataType, valueCount, pos);
+      EncodingType::Varint, TypeTraits<T>::dataType, valueCount, false, pos);
   encoding::write(selection.statistics().min(), pos);
   for (auto value : values) {
     varint::writeVarint(value - selection.statistics().min(), &pos);

--- a/dwio/nimble/encodings/tests/ConstantEncodingTest.cpp
+++ b/dwio/nimble/encodings/tests/ConstantEncodingTest.cpp
@@ -27,7 +27,15 @@
 
 using namespace facebook;
 
-template <typename C>
+template <typename DataType, bool UseVarint>
+struct TestConfig {
+  using data_type = DataType;
+  static constexpr bool useVarint = UseVarint;
+};
+
+#define TC(T) TestConfig<T, false>, TestConfig<T, true>
+
+template <typename Config>
 class ConstantEncodingTest : public ::testing::Test {
  protected:
   void SetUp() override {
@@ -121,14 +129,16 @@ class ConstantEncodingTest : public ::testing::Test {
   std::unique_ptr<nimble::Buffer> buffer_;
 };
 
-#define NUM_TYPES int32_t, double, float
+#define NUM_TYPES TC(int32_t), TC(double), TC(float)
 
 using TestTypes = ::testing::Types<NUM_TYPES>;
 
 TYPED_TEST_CASE(ConstantEncodingTest, TestTypes);
 
 TYPED_TEST(ConstantEncodingTest, SerializeThenDeserialize) {
-  using D = TypeParam;
+  using D = typename TypeParam::data_type;
+  const nimble::Encoding::Options options{
+      .useVarintRowCount = TypeParam::useVarint};
 
   auto valueGroups = this->template prepareValues<D>();
   std::vector<velox::BufferPtr> newStringBuffers;
@@ -140,7 +150,11 @@ TYPED_TEST(ConstantEncodingTest, SerializeThenDeserialize) {
   for (const auto& values : valueGroups) {
     auto encoding =
         nimble::test::Encoder<nimble::ConstantEncoding<D>>::createEncoding(
-            *this->buffer_, values, stringBufferFactory);
+            *this->buffer_,
+            values,
+            stringBufferFactory,
+            nimble::CompressionType::Uncompressed,
+            options);
 
     uint32_t rowCount = values.size();
     nimble::Vector<D> result(this->pool_.get(), rowCount);
@@ -156,7 +170,9 @@ TYPED_TEST(ConstantEncodingTest, SerializeThenDeserialize) {
 }
 
 TYPED_TEST(ConstantEncodingTest, NonConstantFailure) {
-  using D = TypeParam;
+  using D = typename TypeParam::data_type;
+  const nimble::Encoding::Options options{
+      .useVarintRowCount = TypeParam::useVarint};
 
   auto valueGroups = this->template prepareFailureValues<D>();
   std::vector<velox::BufferPtr> newStringBuffers;
@@ -168,7 +184,11 @@ TYPED_TEST(ConstantEncodingTest, NonConstantFailure) {
   for (const auto& values : valueGroups) {
     try {
       nimble::test::Encoder<nimble::ConstantEncoding<D>>::createEncoding(
-          *this->buffer_, values, stringBufferFactory);
+          *this->buffer_,
+          values,
+          stringBufferFactory,
+          nimble::CompressionType::Uncompressed,
+          options);
       FAIL() << "ConstantEncodingTest should fail due to non constant data";
     } catch (const nimble::NimbleUserError& e) {
       EXPECT_EQ(nimble::error_code::IncompatibleEncoding, e.errorCode());

--- a/dwio/nimble/encodings/tests/EncodingTest.cpp
+++ b/dwio/nimble/encodings/tests/EncodingTest.cpp
@@ -133,10 +133,18 @@ class TestTrivialEncodingSelectionPolicy
 };
 } // namespace
 
-// C is the encoding type.
-template <typename C>
+template <typename EncodingType, bool UseVarint>
+struct TestConfig {
+  using encoding_type = EncodingType;
+  static constexpr bool useVarint = UseVarint;
+};
+
+#define TC(T) TestConfig<T, false>, TestConfig<T, true>
+
+template <typename Config>
 class EncodingTest : public ::testing::Test {
  protected:
+  using C = typename Config::encoding_type;
   using E = typename C::cppDataType;
 
   void SetUp() override {
@@ -200,6 +208,7 @@ class EncodingTest : public ::testing::Test {
       bool compress,
       bool useVariableBitWidthCompressor,
       std::function<void*(uint32_t)> stringBufferFactory) {
+    constexpr bool useVarint = Config::useVarint;
     using physicalType = typename nimble::TypeTraits<E>::physicalType;
     auto physicalValues = std::span<const physicalType>(
         reinterpret_cast<const physicalType*>(values.data()), values.size());
@@ -214,8 +223,10 @@ class EncodingTest : public ::testing::Test {
         std::make_unique<TestTrivialEncodingSelectionPolicy<E>>(
             compress, useVariableBitWidthCompressor)};
 
-    auto encoded = C::encode(selection, physicalValues, *buffer_);
-    return std::make_unique<C>(*this->pool_, encoded, stringBufferFactory);
+    nimble::Encoding::Options options{.useVarintRowCount = useVarint};
+    auto encoded = C::encode(selection, physicalValues, *buffer_, options);
+    return std::make_unique<C>(
+        *this->pool_, encoded, stringBufferFactory, options);
   }
 
   // Each unit test runs on randomized data this many times before
@@ -232,21 +243,24 @@ class EncodingTest : public ::testing::Test {
   std::unique_ptr<nimble::testing::Util> util_;
 };
 
-#define VARINT_TYPES(EncodingName)                                      \
-  EncodingName<int32_t>, EncodingName<int64_t>, EncodingName<uint32_t>, \
-      EncodingName<uint64_t>, EncodingName<float>, EncodingName<double>
+#define VARINT_TYPES(EncodingName)                            \
+  TC(EncodingName<int32_t>), TC(EncodingName<int64_t>),       \
+      TC(EncodingName<uint32_t>), TC(EncodingName<uint64_t>), \
+      TC(EncodingName<float>), TC(EncodingName<double>)
 
-#define NUMERIC_TYPES(EncodingName)                                        \
-  VARINT_TYPES(EncodingName), EncodingName<int8_t>, EncodingName<uint8_t>, \
-      EncodingName<int16_t>, EncodingName<uint16_t>
+#define NUMERIC_TYPES(EncodingName)                         \
+  VARINT_TYPES(EncodingName), TC(EncodingName<int8_t>),     \
+      TC(EncodingName<uint8_t>), TC(EncodingName<int16_t>), \
+      TC(EncodingName<uint16_t>)
 
 #define NON_BOOL_TYPES(EncodingName) \
-  NUMERIC_TYPES(EncodingName), EncodingName<std::string_view>
+  NUMERIC_TYPES(EncodingName), TC(EncodingName<std::string_view>)
 
-#define ALL_TYPES(EncodingName) NON_BOOL_TYPES(EncodingName), EncodingName<bool>
+#define ALL_TYPES(EncodingName) \
+  NON_BOOL_TYPES(EncodingName), TC(EncodingName<bool>)
 
 using TestTypes = ::testing::Types<
-    nimble::SparseBoolEncoding,
+    TC(nimble::SparseBoolEncoding),
     VARINT_TYPES(nimble::VarintEncoding),
     NUMERIC_TYPES(nimble::FixedBitWidthEncoding),
     NON_BOOL_TYPES(nimble::DictionaryEncoding),
@@ -262,7 +276,7 @@ TYPED_TEST(EncodingTest, materialize) {
   LOG(INFO) << "seed: " << seed;
   std::mt19937 rng(seed);
 
-  using E = typename TypeParam::cppDataType;
+  using E = typename TypeParam::encoding_type::cppDataType;
 
   for (int run = 0; run < this->kNumRandomRuns; ++run) {
     const std::vector<nimble::Vector<E>> dataPatterns =
@@ -271,6 +285,11 @@ TYPED_TEST(EncodingTest, materialize) {
     for (const auto& data : dataPatterns) {
       for (auto compress : {false, true}) {
         for (auto useVariableBitWidthCompressor : {false, true}) {
+          SCOPED_TRACE(
+              fmt::format(
+                  "compress {}, variableBitWidth {}",
+                  compress,
+                  useVariableBitWidthCompressor));
           const int rowCount = data.size();
           ASSERT_GT(rowCount, 0);
           std::unique_ptr<nimble::Encoding> encoding;
@@ -294,6 +313,7 @@ TYPED_TEST(EncodingTest, materialize) {
             throw;
           }
           ASSERT_EQ(encoding->dataType(), nimble::TypeTraits<E>::dataType);
+          ASSERT_EQ(encoding->rowCount(), rowCount);
           nimble::Vector<E> buffer(this->pool_.get(), rowCount);
 
           encoding->materialize(rowCount, buffer.data());
@@ -371,7 +391,7 @@ void checkScatteredOutput(
 }
 
 TYPED_TEST(EncodingTest, scatteredMaterialize) {
-  using E = typename TypeParam::cppDataType;
+  using E = typename TypeParam::encoding_type::cppDataType;
 
   auto seed = folly::Random::rand32();
   LOG(INFO) << "seed: " << seed;

--- a/dwio/nimble/encodings/tests/MainlyConstantEncodingTest.cpp
+++ b/dwio/nimble/encodings/tests/MainlyConstantEncodingTest.cpp
@@ -27,7 +27,15 @@
 
 using namespace facebook;
 
-template <typename C>
+template <typename DataType, bool UseVarint>
+struct TestConfig {
+  using data_type = DataType;
+  static constexpr bool useVarint = UseVarint;
+};
+
+#define TC(T) TestConfig<T, false>, TestConfig<T, true>
+
+template <typename Config>
 class MainlyConstantEncodingTest : public ::testing::Test {
  protected:
   void SetUp() override {
@@ -88,14 +96,16 @@ class MainlyConstantEncodingTest : public ::testing::Test {
   std::unique_ptr<nimble::Buffer> buffer_;
 };
 
-#define NUM_TYPES int32_t, double, float
+#define NUM_TYPES TC(int32_t), TC(double), TC(float)
 
 using TestTypes = ::testing::Types<NUM_TYPES>;
 
 TYPED_TEST_CASE(MainlyConstantEncodingTest, TestTypes);
 
 TYPED_TEST(MainlyConstantEncodingTest, SerializeThenDeserialize) {
-  using D = TypeParam;
+  using D = typename TypeParam::data_type;
+  const nimble::Encoding::Options options{
+      .useVarintRowCount = TypeParam::useVarint};
 
   auto valueGroups = this->template prepareValues<D>();
   std::vector<velox::BufferPtr> newStringBuffers;
@@ -106,7 +116,12 @@ TYPED_TEST(MainlyConstantEncodingTest, SerializeThenDeserialize) {
   };
   for (const auto& values : valueGroups) {
     auto encoding = nimble::test::Encoder<nimble::MainlyConstantEncoding<D>>::
-        createEncoding(*this->buffer_, values, stringBufferFactory);
+        createEncoding(
+            *this->buffer_,
+            values,
+            stringBufferFactory,
+            nimble::CompressionType::Uncompressed,
+            options);
 
     uint32_t rowCount = values.size();
     nimble::Vector<D> result(this->pool_.get(), rowCount);

--- a/dwio/nimble/encodings/tests/NullableEncodingTest.cpp
+++ b/dwio/nimble/encodings/tests/NullableEncodingTest.cpp
@@ -41,6 +41,14 @@
 
 using namespace facebook;
 
+template <typename EncodingType, bool UseVarint>
+struct TestConfig {
+  using encoding_type = EncodingType;
+  static constexpr bool useVarint = UseVarint;
+};
+
+#define TC(T) TestConfig<T, false>, TestConfig<T, true>
+
 namespace {
 enum class NullsPattern {
   None,
@@ -49,10 +57,11 @@ enum class NullsPattern {
 };
 }
 
-// C is the encoding type.
-template <typename C>
+// Config wraps the encoding type and varint flag.
+template <typename Config>
 class NullableEncodingTest : public ::testing::Test {
  protected:
+  using C = typename Config::encoding_type;
   using E = typename C::cppDataType;
 
   void SetUp() override {
@@ -94,15 +103,17 @@ class NullableEncodingTest : public ::testing::Test {
   std::unique_ptr<nimble::testing::Util> util_;
 };
 
-#define ALL_TYPES(EncodingName)                                          \
-  EncodingName<int>, EncodingName<int64_t>, EncodingName<uint32_t>,      \
-      EncodingName<uint64_t>, EncodingName<float>, EncodingName<double>, \
-      EncodingName<std::string_view>, EncodingName<bool>
+#define ALL_TYPES(EncodingName)                               \
+  TC(EncodingName<int>), TC(EncodingName<int64_t>),           \
+      TC(EncodingName<uint32_t>), TC(EncodingName<uint64_t>), \
+      TC(EncodingName<float>), TC(EncodingName<double>),      \
+      TC(EncodingName<std::string_view>), TC(EncodingName<bool>)
 
-#define NON_BOOL_TYPES(EncodingName)                                     \
-  EncodingName<int>, EncodingName<int64_t>, EncodingName<uint32_t>,      \
-      EncodingName<uint64_t>, EncodingName<float>, EncodingName<double>, \
-      EncodingName<std::string_view>
+#define NON_BOOL_TYPES(EncodingName)                          \
+  TC(EncodingName<int>), TC(EncodingName<int64_t>),           \
+      TC(EncodingName<uint32_t>), TC(EncodingName<uint64_t>), \
+      TC(EncodingName<float>), TC(EncodingName<double>),      \
+      TC(EncodingName<std::string_view>)
 
 using TestTypes = ::testing::Types<
     ALL_TYPES(nimble::NullableEncoding),
@@ -131,7 +142,9 @@ nimble::Vector<E> spreadNullsIntoData(
 }
 
 TYPED_TEST(NullableEncodingTest, Materialize) {
-  using E = typename TypeParam::cppDataType;
+  using E = typename TypeParam::encoding_type::cppDataType;
+  const nimble::Encoding::Options options{
+      .useVarintRowCount = TypeParam::useVarint};
 
   auto seed = folly::Random::rand32();
   LOG(INFO) << "seed: " << seed;
@@ -159,7 +172,12 @@ TYPED_TEST(NullableEncodingTest, Materialize) {
         };
         auto encoding = nimble::test::Encoder<nimble::NullableEncoding<E>>::
             createNullableEncoding(
-                *this->buffer_, data, nulls, stringBufferFactory);
+                *this->buffer_,
+                data,
+                nulls,
+                stringBufferFactory,
+                nimble::CompressionType::Uncompressed,
+                options);
         ASSERT_EQ(encoding->dataType(), nimble::TypeTraits<E>::dataType);
         ASSERT_TRUE(encoding->isNullable());
         const uint32_t rowCount = encoding->rowCount();
@@ -239,7 +257,9 @@ void checkOutput(
 }
 
 TYPED_TEST(NullableEncodingTest, ScatteredMaterialize) {
-  using E = typename TypeParam::cppDataType;
+  using E = typename TypeParam::encoding_type::cppDataType;
+  const nimble::Encoding::Options options{
+      .useVarintRowCount = TypeParam::useVarint};
 
   auto seed = folly::Random::rand32();
   LOG(INFO) << "seed: " << seed;
@@ -267,7 +287,12 @@ TYPED_TEST(NullableEncodingTest, ScatteredMaterialize) {
         };
         auto encoding = nimble::test::Encoder<nimble::NullableEncoding<E>>::
             createNullableEncoding(
-                *this->buffer_, data, nulls, stringBufferFactory);
+                *this->buffer_,
+                data,
+                nulls,
+                stringBufferFactory,
+                nimble::CompressionType::Uncompressed,
+                options);
         ASSERT_EQ(encoding->dataType(), nimble::TypeTraits<E>::dataType);
         ASSERT_TRUE(encoding->isNullable());
         const uint32_t rowCount = encoding->rowCount();
@@ -423,7 +448,9 @@ TYPED_TEST(NullableEncodingTest, ScatteredMaterialize) {
 }
 
 TYPED_TEST(NullableEncodingTest, MaterializeNullable) {
-  using E = typename TypeParam::cppDataType;
+  using E = typename TypeParam::encoding_type::cppDataType;
+  const nimble::Encoding::Options options{
+      .useVarintRowCount = TypeParam::useVarint};
 
   auto seed = folly::Random::rand32();
   LOG(INFO) << "seed: " << seed;
@@ -450,7 +477,12 @@ TYPED_TEST(NullableEncodingTest, MaterializeNullable) {
         };
         auto encoding = nimble::test::Encoder<nimble::NullableEncoding<E>>::
             createNullableEncoding(
-                *this->buffer_, data, nulls, stringBufferFactory);
+                *this->buffer_,
+                data,
+                nulls,
+                stringBufferFactory,
+                nimble::CompressionType::Uncompressed,
+                options);
         ASSERT_TRUE(encoding->isNullable());
         const uint32_t rowCount = encoding->rowCount();
         nimble::Vector<E> buffer(this->pool_.get(), rowCount);

--- a/dwio/nimble/encodings/tests/RleEncodingTest.cpp
+++ b/dwio/nimble/encodings/tests/RleEncodingTest.cpp
@@ -27,7 +27,15 @@
 
 using namespace facebook;
 
-template <typename C>
+template <typename DataType, bool UseVarint>
+struct TestConfig {
+  using data_type = DataType;
+  static constexpr bool useVarint = UseVarint;
+};
+
+#define TC(T) TestConfig<T, false>, TestConfig<T, true>
+
+template <typename Config>
 class RleEncodingTest : public ::testing::Test {
  protected:
   void SetUp() override {
@@ -138,14 +146,16 @@ class RleEncodingTest : public ::testing::Test {
   std::unique_ptr<nimble::Buffer> buffer_;
 };
 
-#define NUM_TYPES int32_t, double, float
+#define NUM_TYPES TC(int32_t), TC(double), TC(float)
 
 using TestTypes = ::testing::Types<NUM_TYPES>;
 
 TYPED_TEST_CASE(RleEncodingTest, TestTypes);
 
 TYPED_TEST(RleEncodingTest, SerializeThenDeserialize) {
-  using D = TypeParam;
+  using D = typename TypeParam::data_type;
+  const nimble::Encoding::Options options{
+      .useVarintRowCount = TypeParam::useVarint};
 
   auto valueGroups = this->template prepareValues<D>();
   std::vector<velox::BufferPtr> newStringBuffers;
@@ -157,7 +167,11 @@ TYPED_TEST(RleEncodingTest, SerializeThenDeserialize) {
   for (const auto& values : valueGroups) {
     auto encoding =
         nimble::test::Encoder<nimble::RLEEncoding<D>>::createEncoding(
-            *this->buffer_, values, stringBufferFactory);
+            *this->buffer_,
+            values,
+            stringBufferFactory,
+            nimble::CompressionType::Uncompressed,
+            options);
     uint32_t rowCount = values.size();
     nimble::Vector<D> result(this->pool_.get(), rowCount);
     encoding->materialize(rowCount, result.data());

--- a/dwio/nimble/encodings/tests/TestUtils.h
+++ b/dwio/nimble/encodings/tests/TestUtils.h
@@ -175,7 +175,8 @@ class Encoder {
   static std::string_view encode(
       nimble::Buffer& buffer,
       const nimble::Vector<T>& values,
-      CompressionType compressionType = CompressionType::Uncompressed) {
+      CompressionType compressionType = CompressionType::Uncompressed,
+      const nimble::Encoding::Options& options = {}) {
     using physicalType = typename nimble::TypeTraits<T>::physicalType;
 
     auto physicalValues = std::span<const physicalType>(
@@ -190,7 +191,7 @@ class Encoder {
         std::make_unique<TestTrivialEncodingSelectionPolicy<T>>(
             compressionType)};
 
-    return E::encode(selection, physicalValues, buffer);
+    return E::encode(selection, physicalValues, buffer, options);
   }
 
   static std::string_view encodeNullable(
@@ -198,7 +199,8 @@ class Encoder {
       const nimble::Vector<T>& values,
       const nimble::Vector<bool>& nulls,
       nimble::CompressionType compressionType =
-          nimble::CompressionType::Uncompressed) {
+          nimble::CompressionType::Uncompressed,
+      const nimble::Encoding::Options& options = {}) {
     using physicalType = typename nimble::TypeTraits<T>::physicalType;
 
     auto physicalValues = std::span<const physicalType>(
@@ -214,18 +216,20 @@ class Encoder {
             compressionType)};
 
     return NullableEncoding<typename E::cppDataType>::encodeNullable(
-        selection, physicalValues, nulls, buffer);
+        selection, physicalValues, nulls, buffer, options);
   }
 
   static std::unique_ptr<nimble::Encoding> createEncoding(
       nimble::Buffer& buffer,
       const nimble::Vector<T>& values,
       std::function<void*(uint32_t)> stringBufferFactory,
-      CompressionType compressionType = CompressionType::Uncompressed) {
+      CompressionType compressionType = CompressionType::Uncompressed,
+      const nimble::Encoding::Options& options = {}) {
     return std::make_unique<E>(
         buffer.getMemoryPool(),
-        encode(buffer, values, compressionType),
-        stringBufferFactory);
+        encode(buffer, values, compressionType, options),
+        stringBufferFactory,
+        options);
   }
 
   static std::unique_ptr<nimble::Encoding> createNullableEncoding(
@@ -233,11 +237,13 @@ class Encoder {
       const nimble::Vector<T>& values,
       const nimble::Vector<bool>& nulls,
       std::function<void*(uint32_t)> stringBufferFactory,
-      CompressionType compressionType = CompressionType::Uncompressed) {
+      CompressionType compressionType = CompressionType::Uncompressed,
+      const nimble::Encoding::Options& options = {}) {
     return std::make_unique<E>(
         buffer.getMemoryPool(),
-        encodeNullable(buffer, values, nulls, compressionType),
-        stringBufferFactory);
+        encodeNullable(buffer, values, nulls, compressionType, options),
+        stringBufferFactory,
+        options);
   }
 };
 

--- a/dwio/nimble/serializer/DeserializerImpl.cpp
+++ b/dwio/nimble/serializer/DeserializerImpl.cpp
@@ -21,6 +21,7 @@
 #include "dwio/nimble/common/EncodingPrimitives.h"
 #include "dwio/nimble/common/Exceptions.h"
 #include "dwio/nimble/common/Types.h"
+#include "dwio/nimble/common/Varint.h"
 #include "dwio/nimble/encodings/EncodingFactory.h"
 
 namespace facebook::nimble::serde {
@@ -117,13 +118,20 @@ void StreamData::prepareForDecoding(std::string_view data) {
 
   // Use nimble EncodingFactory to decode the data.
   // The encoded data is self-describing with type information.
+  // Encoded serializer versions always use varint for encoding prefix row
+  // counts.
   // For string types, provide a stringBufferFactory that allocates separate
   // buffers using velox::AlignedBuffer for memory tracking.
-  encoding_ = EncodingFactory::decode(*pool_, data, [this](uint32_t size) {
-    auto& buffer = stringBuffers_.emplace_back(
-        velox::AlignedBuffer::allocate<char>(size, pool_));
-    return buffer->asMutable<void>();
-  });
+  Encoding::Options options{.useVarintRowCount = true};
+  encoding_ = EncodingFactory::decode(
+      *pool_,
+      data,
+      [this](uint32_t size) {
+        auto& buffer = stringBuffers_.emplace_back(
+            velox::AlignedBuffer::allocate<char>(size, pool_));
+        return buffer->asMutable<void>();
+      },
+      options);
 }
 
 uint32_t StreamData::decode(
@@ -204,6 +212,11 @@ uint32_t StreamDataReader::initialize(std::string_view data) {
         version,
         *options_.version);
     ++pos_;
+  }
+  // Encoded versions (kDenseEncoded, kSparseEncoded) use varint for compact
+  // row counts.
+  if (options_.enableEncoding()) {
+    return varint::readVarint32(&pos_);
   }
   return encoding::readUint32(pos_);
 }

--- a/dwio/nimble/serializer/Projector.cpp
+++ b/dwio/nimble/serializer/Projector.cpp
@@ -22,6 +22,7 @@
 
 #include "dwio/nimble/common/EncodingPrimitives.h"
 #include "dwio/nimble/common/Exceptions.h"
+#include "dwio/nimble/common/Varint.h"
 #include "dwio/nimble/serializer/SerializerImpl.h"
 #include "folly/container/F14Map.h"
 #include "velox/type/Type.h"
@@ -610,7 +611,13 @@ std::string Projector::project(std::string_view input) const {
     return std::string(input);
   }
 
-  const uint32_t rowCount = encoding::readUint32(pos);
+  // Encoded versions use varint for compact row counts.
+  uint32_t rowCount;
+  if (inputEncoded) {
+    rowCount = varint::readVarint32(&pos);
+  } else {
+    rowCount = encoding::readUint32(pos);
+  }
 
   // Parse all input streams using shared implementation.
   const auto inputStreams = detail::parseStreams(pos, end, inputVersion);

--- a/dwio/nimble/serializer/SerializerImpl.h
+++ b/dwio/nimble/serializer/SerializerImpl.h
@@ -20,6 +20,7 @@
 
 #include "dwio/nimble/common/Buffer.h"
 #include "dwio/nimble/common/EncodingPrimitives.h"
+#include "dwio/nimble/common/Varint.h"
 #include "dwio/nimble/encodings/EncodingFactory.h"
 #include "dwio/nimble/serializer/Options.h"
 #include "dwio/nimble/velox/StreamData.h"
@@ -83,8 +84,18 @@ void writeHeader(
   }
 
   // Write row count.
-  auto* rowCountPos = extend(buffer, sizeof(uint32_t));
-  encoding::writeUint32(rowCount, rowCountPos);
+  // Encoded versions (kDenseEncoded, kSparseEncoded) use varint for compact
+  // row counts.
+  const bool useVarint = version.has_value() &&
+      (version.value() == SerializationVersion::kDenseEncoded ||
+       version.value() == SerializationVersion::kSparseEncoded);
+  if (useVarint) {
+    auto* rowCountPos = extend(buffer, varint::varintSize(rowCount));
+    varint::writeVarint(rowCount, &rowCountPos);
+  } else {
+    auto* rowCountPos = extend(buffer, sizeof(uint32_t));
+    encoding::writeUint32(rowCount, rowCountPos);
+  }
 
   // Sparse format: write stream count and offsets.
   if (sparseFormat) {
@@ -212,8 +223,13 @@ std::string_view encodeTyped(
     typedPolicy.reset(rawTypedPolicy);
   }
 
+  // Encoded versions always use varint for compact row counts in encoding
+  // prefixes.
   return EncodingFactory::encode<T>(
-      std::move(typedPolicy), values, encodingBuffer);
+      std::move(typedPolicy),
+      values,
+      encodingBuffer,
+      Encoding::Options{.useVarintRowCount = true});
 }
 
 /// Dispatch to typed nimble encoding based on ScalarKind.

--- a/dwio/nimble/serializer/tests/SerializerImplTest.cpp
+++ b/dwio/nimble/serializer/tests/SerializerImplTest.cpp
@@ -17,6 +17,7 @@
 #include <gtest/gtest.h>
 
 #include "dwio/nimble/common/EncodingPrimitives.h"
+#include "dwio/nimble/common/Varint.h"
 #include "dwio/nimble/serializer/SerializerImpl.h"
 
 using namespace facebook::nimble;
@@ -36,8 +37,16 @@ class WriteHeaderTest : public ::testing::Test {
     auto actualVersion = static_cast<SerializationVersion>(*pos++);
     EXPECT_EQ(actualVersion, expectedVersion);
 
-    // Read row count.
-    uint32_t actualRowCount = encoding::readUint32(pos);
+    // Read row count. Encoded versions use varint.
+    const bool useVarint =
+        (expectedVersion == SerializationVersion::kDenseEncoded ||
+         expectedVersion == SerializationVersion::kSparseEncoded);
+    uint32_t actualRowCount;
+    if (useVarint) {
+      actualRowCount = varint::readVarint32(&pos);
+    } else {
+      actualRowCount = encoding::readUint32(pos);
+    }
     EXPECT_EQ(actualRowCount, expectedRowCount);
 
     // For sparse formats, read stream count and offsets.
@@ -55,7 +64,9 @@ class WriteHeaderTest : public ::testing::Test {
     }
 
     // Verify we consumed exactly the expected amount.
-    size_t expectedSize = 1 + sizeof(uint32_t); // version + rowCount
+    size_t rowCountSize =
+        useVarint ? varint::varintSize(expectedRowCount) : sizeof(uint32_t);
+    size_t expectedSize = 1 + rowCountSize; // version + rowCount
     if (sparseFormat) {
       expectedSize +=
           sizeof(uint32_t) + expectedOffsets.size() * sizeof(uint32_t);


### PR DESCRIPTION
Summary:
CONTEXT: rowCount is stored as a fixed 4-byte uint32 in encoding prefixes and serializer headers. For RPC serializer batches (10-100 rows), this wastes ~3 bytes per stream that could be 1-byte varints.

WHAT: Add varint rowCount support to nimble encodings and the RPC serializer.

Encoding layer:
- Add `Options` struct with `useVarintRowCount` flag to `Encoding` base class
- Constructor reads rowCount as varint or fixed uint32 based on options
- `serializePrefix()` and `serializePrefixSize()` accept `useVarint` parameter
- All encoding `encode()` methods accept `const Encoding::Options&` and propagate to nested encodings via `encodeNested()`
- `EncodingFactory` private methods accept `Options` consistently with public API
- Remove dead offset constants (`kDataOffset`, `kCompressionTypeOffset`, `kBaselineOffset`) that depended on fixed `Encoding::kPrefixSize`

Serializer layer:
- `kDenseEncoded` and `kSparseEncoded` versions now use varint for header rowCount
- `encodeTyped()` passes `useVarint=true` to `EncodingFactory::encode`
- `StreamDataReader::initialize()` reads varint rowCount for encoded versions
- `StreamData::prepareForDecoding()` passes varint options to `EncodingFactory::decode`
- `Projector::project()` reads varint rowCount for encoded input

Testing:
- Add Google typed-test parameterization (`TestConfig<T, UseVarint>`) to all encoding tests so every test automatically runs with both varint and non-varint modes
- Parameterized: EncodingTest, ConstantEncodingTest, MainlyConstantEncodingTest, RleEncodingTest, NullableEncodingTest
- TestUtils.h `Encoder` accepts `Options` and forwards to encode/decode

Differential Revision: D94853665
