### PR TITLE
Integrate BufferedInput for TabletReader metadata IO

### DIFF
--- a/dwio/nimble/encodings/Encoding.h
+++ b/dwio/nimble/encodings/Encoding.h
@@ -106,11 +106,11 @@ class Encoding {
     bool useVarintRowCount;
   };
 
-  // The binary layout for each Encoding begins with the same prefix:
-  // 1 byte: EncodingType
-  // 1 byte: DataType
-  // 4 bytes: uint32_t num rows (fixed format)
-  //   OR 1-5 bytes: varint num rows (when useVarintRowCount option is set)
+  /// The binary layout for each Encoding begins with the same prefix:
+  /// 1 byte: EncodingType
+  /// 1 byte: DataType
+  /// 4 bytes: uint32_t num rows (fixed format)
+  ///   OR 1-5 bytes: varint num rows (when useVarintRowCount option is set)
   static constexpr int kEncodingTypeOffset = 0;
   static constexpr int kDataTypeOffset = 1;
   static constexpr int kRowCountOffset = 2;

--- a/dwio/nimble/tablet/FileLayout.h
+++ b/dwio/nimble/tablet/FileLayout.h
@@ -57,9 +57,6 @@ class Postscript {
 
   static Postscript parse(std::string_view data);
 
-  /// Creates a Postscript from FileLayout metadata.
-  static Postscript create(const struct FileLayout& layout);
-
  private:
   Postscript(
       uint32_t footerSize,

--- a/dwio/nimble/tablet/TabletReader.cpp
+++ b/dwio/nimble/tablet/TabletReader.cpp
@@ -19,6 +19,8 @@
 #include "dwio/nimble/common/Types.h"
 #include "dwio/nimble/tablet/Constants.h"
 #include "dwio/nimble/tablet/FooterGenerated.h"
+#include "velox/dwio/common/BufferedInput.h"
+#include "velox/dwio/common/SeekableInputStream.h"
 
 #include "folly/io/Cursor.h"
 
@@ -50,6 +52,48 @@ namespace {
 template <typename T>
 const T* asFlatBuffersRoot(std::string_view content) {
   return flatbuffers::GetRoot<T>(content.data());
+}
+
+inline const serialization::Footer* footerRoot(const MetadataBuffer& footer) {
+  return asFlatBuffersRoot<serialization::Footer>(footer.content());
+}
+
+inline const serialization::Stripes* stripesRoot(
+    const MetadataBuffer& stripes) {
+  return asFlatBuffersRoot<serialization::Stripes>(stripes.content());
+}
+
+inline void validateOptionalSections(
+    const serialization::OptionalMetadataSections* sections) {
+  NIMBLE_CHECK_NOT_NULL(sections, "Optional sections is null.");
+  NIMBLE_CHECK(sections->names(), "Optional sections names is null.");
+  NIMBLE_CHECK(sections->offsets(), "Optional sections offsets is null.");
+  NIMBLE_CHECK(sections->sizes(), "Optional sections sizes is null.");
+  NIMBLE_CHECK(
+      sections->compression_types(),
+      "Optional sections compression_types is null.");
+  NIMBLE_CHECK_EQ(
+      sections->names()->size(),
+      sections->offsets()->size(),
+      "Optional sections names and offsets size mismatch.");
+  NIMBLE_CHECK_EQ(
+      sections->names()->size(),
+      sections->sizes()->size(),
+      "Optional sections names and sizes size mismatch.");
+  NIMBLE_CHECK_EQ(
+      sections->names()->size(),
+      sections->compression_types()->size(),
+      "Optional sections names and compression_types size mismatch.");
+}
+
+// Converts a FlatBuffers section (with offset/size/compression_type fields)
+// to a MetadataSection.
+template <typename T>
+MetadataSection toMetadataSection(const T* fbSection) {
+  return MetadataSection{
+      fbSection->offset(),
+      fbSection->size(),
+      static_cast<CompressionType>(fbSection->compression_type())};
 }
 
 size_t copyTo(const folly::IOBuf& source, void* target, size_t size) {
@@ -89,8 +133,7 @@ StripeGroup::StripeGroup(
     : metadata_{std::move(stripeGroup)}, index_{stripeGroupIndex} {
   const auto* metadataRoot =
       asFlatBuffersRoot<serialization::StripeGroup>(metadata_->content());
-  const auto* stripesRoot =
-      asFlatBuffersRoot<serialization::Stripes>(stripes.content());
+  const auto* stripesParsed = stripesRoot(stripes);
 
   const auto streamCount = metadataRoot->stream_offsets()->size();
   NIMBLE_CHECK_EQ(
@@ -106,9 +149,9 @@ StripeGroup::StripeGroup(
   streamSizes_ = metadataRoot->stream_sizes()->data();
 
   // Find the first stripe that use this stripe group
-  auto* groupIndices = stripesRoot->group_indices()->data();
+  auto* groupIndices = stripesParsed->group_indices()->data();
   for (uint32_t stripeIndex = 0,
-                groupIndicesSize = stripesRoot->group_indices()->size();
+                groupIndicesSize = stripesParsed->group_indices()->size();
        stripeIndex < groupIndicesSize;
        ++stripeIndex) {
     if (groupIndices[stripeIndex] == stripeGroupIndex) {
@@ -176,15 +219,6 @@ Postscript::Postscript(
       majorVersion_(majorVersion),
       minorVersion_(minorVersion) {}
 
-Postscript Postscript::create(const FileLayout& layout) {
-  return Postscript(
-      layout.footer.size(),
-      layout.footer.compressionType(),
-      layout.postscript.checksumType(),
-      layout.postscript.majorVersion(),
-      layout.postscript.minorVersion());
-}
-
 TabletReader::TabletReader(
     std::shared_ptr<velox::ReadFile> readFile,
     MemoryPool& pool,
@@ -241,16 +275,14 @@ TabletReader::TabletReader(
 }
 
 void TabletReader::init(const Options& options) {
-  const auto fileSize = file_->size();
+  fileSize_ = file_->size();
   NIMBLE_CHECK_FILE(
-      fileSize >= kPostscriptSize,
+      fileSize_ >= kPostscriptSize,
       "Corrupted file. File size {} is smaller than postscript size {}.",
-      velox::succinctBytes(fileSize),
+      velox::succinctBytes(fileSize_),
       velox::succinctBytes(kPostscriptSize));
 
-  if (options.fileLayout.has_value()) {
-    // FileLayout provided - skip discovery, use layout directly.
-    initFromFileLayout(options);
+  if (tryInitFromCache(options)) {
     return;
   }
 
@@ -258,32 +290,36 @@ void TabletReader::init(const Options& options) {
   uint64_t footerIoOffset;
   folly::IOBuf footerIoBuf;
 
-  initPostScriptAndFooter(
-      fileSize,
-      options.footerIoBytes,
-      footerIoBuf,
-      footerIoSize,
-      footerIoOffset);
-  initStripes(fileSize, footerIoBuf, footerIoSize, footerIoOffset);
+  loadAndInitFooter(
+      options.maxFooterIoBytes, footerIoBuf, footerIoSize, footerIoOffset);
+  loadStripes(footerIoBuf, footerIoSize, footerIoOffset);
+  initStripes();
+  if (stripeCount_ > 0) {
+    preloadStripeGroup(footerIoBuf);
+  }
 
-  initOptionalSections(
-      footerIoBuf, footerIoOffset, options.preloadOptionalSections);
+  initOptionalSections();
+  preloadOptionalSections(
+      options, makeSectionLoader(footerIoBuf, footerIoOffset));
 
-  initIndex(footerIoBuf, footerIoOffset, fileSize);
+  initIndex();
+  preloadIndexGroup(footerIoBuf);
+
+  cacheMetadata(footerIoBuf, footerIoOffset);
 }
 
-void TabletReader::initPostScriptAndFooter(
-    uint64_t fileSize,
-    uint64_t footerIoBytes,
+void TabletReader::loadAndInitFooter(
+    uint64_t maxFooterIoBytes,
     folly::IOBuf& footerIoBuf,
     uint64_t& footerIoSize,
     uint64_t& footerIoOffset) {
-  if (footerIoBytes == 0) {
+  footerIoBuf = folly::IOBuf();
+  if (maxFooterIoBytes == 0) {
     // Adaptive mode: read postscript first, then exact footer size.
     // First read: just the postscript (last 20 bytes)
     {
       const velox::common::Region psRegion{
-          fileSize - kPostscriptSize, kPostscriptSize, "postscript"};
+          fileSize_ - kPostscriptSize, kPostscriptSize, "postscript"};
       folly::IOBuf psIoBuf;
       file_->preadv({&psRegion, 1}, {&psIoBuf, 1});
       ps_ = Postscript::parse(toStringView(psIoBuf));
@@ -291,7 +327,7 @@ void TabletReader::initPostScriptAndFooter(
 
     // Second read: exact footer + postscript
     footerIoSize = ps_.footerSize() + kPostscriptSize;
-    footerIoOffset = fileSize - footerIoSize;
+    footerIoOffset = fileSize_ - footerIoSize;
     {
       const velox::common::Region footerIoRegion{
           footerIoOffset, footerIoSize, "footer"};
@@ -301,9 +337,9 @@ void TabletReader::initPostScriptAndFooter(
 
     initFooter(footerIoBuf, footerIoSize);
   } else {
-    // Speculative mode: read footerIoBytes (or fileSize if smaller)
-    footerIoSize = std::min(footerIoBytes, fileSize);
-    footerIoOffset = fileSize - footerIoSize;
+    // Speculative mode: read maxFooterIoBytes (or fileSize_ if smaller)
+    footerIoSize = std::min(maxFooterIoBytes, fileSize_);
+    footerIoOffset = fileSize_ - footerIoSize;
     {
       const velox::common::Region footerIoRegion{
           footerIoOffset, footerIoSize, "footer"};
@@ -317,8 +353,7 @@ void TabletReader::initPostScriptAndFooter(
     const uint64_t requiredSize = ps_.footerSize() + kPostscriptSize;
     if (requiredSize > footerIoSize) {
       footerIoSize = requiredSize;
-      footerIoOffset = fileSize - footerIoSize;
-      footerIoBuf = folly::IOBuf();
+      footerIoOffset = fileSize_ - footerIoSize;
       const velox::common::Region footerIoRegion{
           footerIoOffset, footerIoSize, "footer"};
       file_->preadv({&footerIoRegion, 1}, {&footerIoBuf, 1});
@@ -327,91 +362,6 @@ void TabletReader::initPostScriptAndFooter(
 
     initFooter(footerIoBuf, footerIoSize);
   }
-}
-
-void TabletReader::initFromFileLayout(const Options& options) {
-  NIMBLE_DCHECK(options.fileLayout.has_value(), "FileLayout must be provided");
-  const auto& layout = *options.fileLayout;
-  const auto fileSize = file_->size();
-
-  // Validate layout matches file
-  NIMBLE_USER_CHECK_EQ(
-      layout.fileSize,
-      fileSize,
-      "FileLayout fileSize {} doesn't match actual file size {}",
-      layout.fileSize,
-      fileSize);
-
-  // Initialize postscript from layout
-  ps_ = Postscript::create(layout);
-
-  // Calculate what to read within the memory budget.
-  // At minimum we need the footer and stripes section.
-  const uint64_t footerSize = layout.footer.size() + kPostscriptSize;
-  uint64_t footerReadSize = footerSize;
-
-  // Include stripes section if present (stored before footer).
-  // Stripes section exists when stripeGroups is not empty.
-  if (!layout.stripeGroups.empty()) {
-    // Stripes section should be contiguous with footer.
-    NIMBLE_CHECK_EQ(
-        layout.stripes.offset() + layout.stripes.size(),
-        layout.footer.offset(),
-        "Stripes section not contiguous with footer");
-    footerReadSize += layout.stripes.size();
-  }
-
-  // Try to coalesce first stripe group if it fits in budget.
-  bool preloadFirstStripeGroup = false;
-  if (!layout.stripeGroups.empty() && options.footerIoBytes > 0) {
-    const auto& firstGroup = layout.stripeGroups[0];
-    // Check if first stripe group is contiguous with stripes section.
-    if (firstGroup.offset() + firstGroup.size() == layout.stripes.offset() &&
-        footerReadSize + firstGroup.size() <= options.footerIoBytes) {
-      footerReadSize += firstGroup.size();
-      preloadFirstStripeGroup = true;
-    }
-  }
-
-  // TODO: Add support for preloading first index group if it fits in budget.
-
-  // Read footer (and potentially stripes section and first stripe group).
-  uint64_t footerIoOffset = fileSize - footerReadSize;
-  folly::IOBuf footerIoBuf;
-  {
-    const velox::common::Region footerIoRegion{
-        footerIoOffset, footerReadSize, "footer"};
-    file_->preadv({&footerIoRegion, 1}, {&footerIoBuf, 1});
-  }
-  NIMBLE_CHECK_EQ(footerReadSize, footerIoBuf.computeChainDataLength());
-
-  initFooter(footerIoBuf, footerReadSize);
-
-  // Initialize stripes
-  initStripes(fileSize, footerIoBuf, footerReadSize, footerIoOffset);
-
-  // If first stripe group was preloaded, cache it.
-  if (preloadFirstStripeGroup) {
-    const auto& firstGroup = layout.stripeGroups[0];
-    const uint64_t groupOffsetInBuf = firstGroup.offset() - footerIoOffset;
-    auto groupMetadata = std::make_unique<MetadataBuffer>(
-        *pool_,
-        footerIoBuf,
-        groupOffsetInBuf,
-        firstGroup.size(),
-        firstGroup.compressionType());
-    auto stripeGroup =
-        std::make_shared<StripeGroup>(0, *stripes_, std::move(groupMetadata));
-    firstStripeGroup_.wlock()->swap(stripeGroup);
-  }
-
-  // Initialize optional sections (empty for now as we don't have them in
-  // buffer)
-  initOptionalSections(
-      footerIoBuf, footerIoOffset, options.preloadOptionalSections);
-
-  // Initialize index
-  initIndex(footerIoBuf, footerIoOffset, fileSize);
 }
 
 void TabletReader::initPostScript(
@@ -443,29 +393,31 @@ void TabletReader::initFooter(
       ps_.footerCompressionType());
 }
 
-void TabletReader::initStripes(
-    uint64_t fileSize,
+void TabletReader::loadStripes(
     folly::IOBuf& footerIoBuf,
     uint64_t& footerIoSize,
     uint64_t& footerIoOffset) {
   NIMBLE_CHECK_NOT_NULL(footer_);
-  auto* footerRoot =
-      asFlatBuffersRoot<serialization::Footer>(footer_->content());
-  NIMBLE_CHECK_EQ(tabletRowCount_, 0);
-  tabletRowCount_ = footerRoot->row_count();
+  NIMBLE_CHECK_NULL(stripes_);
 
-  auto* stripesSection = footerRoot->stripes();
+  const auto* footer = footerRoot(*footer_);
+  auto* stripesSection = footer->stripes();
   if (stripesSection == nullptr) {
-    NIMBLE_CHECK_EQ(tabletRowCount_, 0);
+    NIMBLE_CHECK_EQ(footer->row_count(), 0);
     return;
   }
 
-  // Check if stripes section is in the buffer; if not, re-read to include it.
-  const uint64_t requiredSize = fileSize - stripesSection->offset();
+  // Compute the lowest offset we need in the buffer: stripes section and
+  // index section (if present, may be at a lower offset than stripes).
+  uint64_t requiredOffset = stripesSection->offset();
+  auto indexIt = optionalSections_.find(std::string{kIndexSection});
+  if (indexIt != optionalSections_.end()) {
+    requiredOffset = std::min(requiredOffset, indexIt->second.offset());
+  }
+  const uint64_t requiredSize = fileSize_ - requiredOffset;
   if (requiredSize > footerIoSize) {
     footerIoSize = requiredSize;
-    footerIoOffset = fileSize - footerIoSize;
-    footerIoBuf = folly::IOBuf();
+    footerIoOffset = fileSize_ - footerIoSize;
     const velox::common::Region footerIoRegion{
         footerIoOffset, footerIoSize, "footer+stripes"};
     file_->preadv({&footerIoRegion, 1}, {&footerIoBuf, 1});
@@ -474,68 +426,21 @@ void TabletReader::initStripes(
   stripes_ = std::make_unique<MetadataBuffer>(
       *pool_,
       footerIoBuf,
-      stripesSection->offset() + footerIoSize - fileSize,
+      stripesSection->offset() + footerIoSize - fileSize_,
       stripesSection->size(),
       static_cast<CompressionType>(stripesSection->compression_type()));
-
-  const auto* stripes =
-      asFlatBuffersRoot<serialization::Stripes>(stripes_->content());
-  auto* stripeGroups = footerRoot->stripe_groups();
-  NIMBLE_CHECK_NOT_NULL(stripeGroups, "Stripe groups is null.");
-  NIMBLE_CHECK_EQ(
-      stripeGroups->size(),
-      *stripes->group_indices()->rbegin() + 1,
-      "Unexpected stripe group count");
-
-  // Always eagerly load if it's the only stripe group and is already
-  // fetched
-  const auto stripeGroup = stripeGroups->Get(0);
-  if (stripeGroups->size() == 1 &&
-      stripeGroup->offset() + footerIoSize >= fileSize) {
-    auto stripeGroupPtr =
-        stripeGroupCache_.get(0, [&](uint32_t stripeGroupIndex) {
-          return std::make_shared<StripeGroup>(
-              stripeGroupIndex,
-              *stripes_,
-              std::make_unique<MetadataBuffer>(
-                  *pool_,
-                  footerIoBuf,
-                  stripeGroup->offset() + footerIoSize - fileSize,
-                  stripeGroup->size(),
-                  static_cast<CompressionType>(
-                      stripeGroup->compression_type())));
-        });
-    *firstStripeGroup_.wlock() = std::move(stripeGroupPtr);
-  }
-
-  NIMBLE_CHECK_EQ(stripeCount_, 0);
-  stripeCount_ = stripes->row_counts()->size();
-  NIMBLE_CHECK_GT(stripeCount_, 0, "Unexpected stripe count");
-  NIMBLE_CHECK_EQ(
-      stripeCount_, stripes->offsets()->size(), "Unexpected stripe count");
-  NIMBLE_CHECK_EQ(
-      stripeCount_, stripes->sizes()->size(), "Unexpected stripe count");
-  NIMBLE_CHECK_EQ(
-      stripeCount_,
-      stripes->group_indices()->size(),
-      "Unexpected stripe count");
-
-  stripeRowCounts_ = stripes->row_counts()->data();
-  stripeOffsets_ = stripes->offsets()->data();
 }
 
 void TabletReader::initStripes() {
-  const auto* footerRoot =
-      asFlatBuffersRoot<serialization::Footer>(footer_->content());
+  const auto* footer = footerRoot(*footer_);
   NIMBLE_CHECK_EQ(tabletRowCount_, 0);
-  tabletRowCount_ = footerRoot->row_count();
+  tabletRowCount_ = footer->row_count();
   if (stripes_ == nullptr) {
     NIMBLE_CHECK_EQ(tabletRowCount_, 0);
     return;
   }
 
-  const auto* stripes =
-      asFlatBuffersRoot<serialization::Stripes>(stripes_->content());
+  const auto* stripes = stripesRoot(*stripes_);
 
   stripeCount_ = stripes->row_counts()->size();
   NIMBLE_CHECK_GT(stripeCount_, 0, "Unexpected stripe count");
@@ -551,40 +456,17 @@ void TabletReader::initStripes() {
   stripeOffsets_ = stripes->offsets()->data();
 }
 
-void TabletReader::initOptionalSections(
-    const folly::IOBuf& footerIoBuf,
-    uint64_t footerIoOffset,
-    const std::vector<std::string>& preloadOptionalSections) {
-  auto footerRoot =
-      asFlatBuffersRoot<serialization::Footer>(footer_->content());
+void TabletReader::initOptionalSections() {
+  const auto* footer = footerRoot(*footer_);
 
-  auto* optionalSections = footerRoot->optional_sections();
+  auto* optionalSections = footer->optional_sections();
   if (optionalSections == nullptr) {
     return;
   }
 
-  NIMBLE_CHECK(optionalSections->names(), "Optional sections names is null.");
-  NIMBLE_CHECK(
-      optionalSections->offsets(), "Optional sections offsets is null.");
-  NIMBLE_CHECK(optionalSections->sizes(), "Optional sections sizes is null.");
-  NIMBLE_CHECK(
-      optionalSections->compression_types(),
-      "Optional sections compression_types is null.");
-  NIMBLE_CHECK_EQ(
-      optionalSections->names()->size(),
-      optionalSections->offsets()->size(),
-      "Optional sections names and offsets size mismatch.");
-  NIMBLE_CHECK_EQ(
-      optionalSections->names()->size(),
-      optionalSections->sizes()->size(),
-      "Optional sections names and sizes size mismatch.");
-  NIMBLE_CHECK_EQ(
-      optionalSections->names()->size(),
-      optionalSections->compression_types()->size(),
-      "Optional sections names and compression_types size mismatch.");
+  validateOptionalSections(optionalSections);
 
   optionalSections_.reserve(optionalSections->names()->size());
-
   for (auto i = 0; i < optionalSections->names()->size(); ++i) {
     optionalSections_.insert(
         std::make_pair(
@@ -595,49 +477,45 @@ void TabletReader::initOptionalSections(
                 static_cast<CompressionType>(
                     optionalSections->compression_types()->Get(i))}));
   }
+}
 
-  std::vector<velox::common::Region> mustRead;
-  for (const auto& preload : preloadOptionalSections) {
-    auto it = optionalSections_.find(preload);
+std::vector<std::string> TabletReader::preloadSectionNames(
+    const Options& options) const {
+  auto names = options.preloadOptionalSections;
+  if (hasIndex()) {
+    names.emplace_back(kIndexSection);
+  }
+  return names;
+}
+
+void TabletReader::preloadOptionalSections(
+    const Options& options,
+    const SectionLoader& loader) {
+  for (const auto& name : preloadSectionNames(options)) {
+    auto it = optionalSections_.find(name);
     if (it == optionalSections_.end()) {
       continue;
     }
-
-    const auto sectionOffset = it->second.offset();
-    const auto sectionSize = it->second.size();
-    const auto sectionCompressionType = it->second.compressionType();
-
-    if (sectionOffset < footerIoOffset) {
-      // Section was not read yet. Need to read from file.
-      mustRead.emplace_back(sectionOffset, sectionSize, preload);
-    } else {
-      // Section already loaded from file
-      auto metadata = std::make_unique<MetadataBuffer>(
-          *pool_,
-          footerIoBuf,
-          sectionOffset - footerIoOffset,
-          sectionSize,
-          sectionCompressionType);
-      optionalSectionsCache_.wlock()->insert({preload, std::move(metadata)});
-    }
+    optionalSectionsCache_.wlock()->insert({name, loader(it->second)});
   }
+}
 
-  if (mustRead.empty()) {
-    return;
-  }
-  std::vector<folly::IOBuf> result(mustRead.size());
-  file_->preadv(mustRead, {result.data(), result.size()});
-  NIMBLE_CHECK_EQ(
-      result.size(),
-      mustRead.size(),
-      "Region and IOBuf vector sizes don't match");
-  for (size_t i = 0; i < result.size(); ++i) {
-    auto iobuf = std::move(result[i]);
-    const std::string preload{mustRead[i].label};
-    auto metadata = std::make_unique<MetadataBuffer>(
-        *pool_, iobuf, optionalSections_.at(preload).compressionType());
-    optionalSectionsCache_.wlock()->insert({preload, std::move(metadata)});
-  }
+TabletReader::SectionLoader TabletReader::makeSectionLoader(
+    const folly::IOBuf& footerIoBuf,
+    uint64_t footerIoOffset) const {
+  return
+      [this, &footerIoBuf, footerIoOffset](
+          const MetadataSection& section) -> std::unique_ptr<MetadataBuffer> {
+        if (section.offset() >= footerIoOffset) {
+          return std::make_unique<MetadataBuffer>(
+              *pool_,
+              footerIoBuf,
+              section.offset() - footerIoOffset,
+              section.size(),
+              section.compressionType());
+        }
+        return readMetadata(section, velox::dwio::common::LogType::FILE);
+      };
 }
 
 std::shared_ptr<TabletReader> TabletReader::create(
@@ -757,31 +635,148 @@ struct RegionEqual {
 } // namespace
 
 uint32_t TabletReader::stripeGroupIndex(uint32_t stripeIndex) const {
-  const auto* stripesRoot =
-      asFlatBuffersRoot<serialization::Stripes>(stripes_->content());
-  return stripesRoot->group_indices()->Get(stripeIndex);
+  return stripesRoot(*stripes_)->group_indices()->Get(stripeIndex);
+}
+
+bool TabletReader::hasCache() const {
+  return bufferedInput_ != nullptr && bufferedInput_->hasCache();
+}
+
+bool TabletReader::tryLoadAndInitFooterFromCache() {
+  // Try to read footer+PS from cache at synthetic offset fileSize_.
+  // fileSize_ is a well-known key computable without any file IO.
+  auto cached = bufferedInput_->findCachedRegion(fileSize_);
+  if (!cached.has_value()) {
+    return false;
+  }
+
+  // Warm path: parse PS + footer from cached data, zero file IO.
+  // Data layout: [footer | PS] (file's natural byte order).
+  const auto size = cached->size();
+  NIMBLE_CHECK_GE(size, kPostscriptSize, "Cached footer+PS entry too small");
+
+  // PS is only 20 bytes at the tail. The last range always covers it since
+  // cache pages are at least 4KB.
+  const auto& ranges = cached->ranges();
+  const auto& lastRange = ranges.back();
+  NIMBLE_CHECK_GE(
+      lastRange.size(),
+      kPostscriptSize,
+      "Last cache range too small to cover postscript");
+  ps_ = Postscript::parse(
+      std::string_view{
+          lastRange.data() + lastRange.size() - kPostscriptSize,
+          kPostscriptSize});
+  NIMBLE_CHECK_EQ(
+      ps_.footerSize() + kPostscriptSize,
+      size,
+      "Cached footer+PS size mismatch");
+
+  // Build footer MetadataBuffer from an IOBuf chain wrapping the cached
+  // ranges (zero-copy). MetadataBuffer copies from the IOBuf cursor
+  // internally — no intermediate contiguous copy needed.
+  footer_ = std::make_unique<MetadataBuffer>(
+      *pool_,
+      cached->toIOBuf(),
+      0,
+      ps_.footerSize(),
+      ps_.footerCompressionType());
+  return true;
+}
+
+bool TabletReader::tryInitFromCache(const Options& options) {
+  if (!hasCache()) {
+    return false;
+  }
+
+  if (!tryLoadAndInitFooterFromCache()) {
+    return false;
+  }
+  initOptionalSections();
+
+  loadStripesAndSections(options);
+
+  initStripes();
+  initIndex();
+  return true;
+}
+
+void TabletReader::loadStripesAndSections(const Options& options) {
+  // Enqueue all needed reads, then load once for coalesced IO.
+  auto enqueuedStripes = enqueueStripesSection();
+  if (!enqueuedStripes.has_value()) {
+    return;
+  }
+  auto enqueuedSections = enqueueOptionalSections(preloadSectionNames(options));
+
+  // Single load — BufferedInput coalesces adjacent regions.
+  bufferedInput_->load(velox::dwio::common::LogType::FOOTER);
+
+  loadEnqueuedOptionalSections(std::move(enqueuedSections));
+
+  stripes_ = readMetadata(
+      std::move(enqueuedStripes->stream), enqueuedStripes->section);
+}
+
+std::unique_ptr<MetadataBuffer> TabletReader::readMetadata(
+    const MetadataSection& section,
+    velox::dwio::common::LogType logType) const {
+  if (bufferedInput_ != nullptr) {
+    return readMetadata(
+        bufferedInput_->read(section.offset(), section.size(), logType),
+        section);
+  }
+
+  // Direct file read path.
+  folly::IOBuf buffer;
+  velox::common::Region region{section.offset(), section.size(), "metadata"};
+  file_->preadv({&region, 1}, {&buffer, 1});
+  return std::make_unique<MetadataBuffer>(
+      *pool_, buffer, section.compressionType());
+}
+
+std::unique_ptr<MetadataBuffer> TabletReader::readMetadata(
+    std::unique_ptr<velox::dwio::common::SeekableInputStream> stream,
+    const MetadataSection& section) const {
+  const void* data{nullptr};
+  int32_t size{0};
+  // Try zero-copy: get contiguous data from stream.
+  if (stream->Next(&data, &size) &&
+      static_cast<uint64_t>(size) >= section.size()) {
+    return std::make_unique<MetadataBuffer>(
+        *pool_,
+        std::string_view{static_cast<const char*>(data), section.size()},
+        section.compressionType());
+  }
+
+  // Data is fragmented — copy into IOBuf.
+  if (size > 0) {
+    stream->BackUp(size);
+  }
+  folly::IOBuf buffer(folly::IOBuf::CREATE, section.size());
+  stream->readFully(
+      reinterpret_cast<char*>(buffer.writableData()), section.size());
+  buffer.append(section.size());
+  return std::make_unique<MetadataBuffer>(
+      *pool_,
+      std::string_view{
+          reinterpret_cast<const char*>(buffer.data()), buffer.length()},
+      section.compressionType());
 }
 
 std::shared_ptr<StripeGroup> TabletReader::loadStripeGroup(
     uint32_t stripeGroupIndex) const {
-  auto* footerRoot =
-      asFlatBuffersRoot<serialization::Footer>(footer_->content());
-  auto stripeGroupInfo = footerRoot->stripe_groups()->Get(stripeGroupIndex);
-  velox::common::Region stripeGroupRegion{
-      stripeGroupInfo->offset(), stripeGroupInfo->size(), "StripeGroup"};
-  folly::IOBuf buffer;
-  file_->preadv({&stripeGroupRegion, 1}, {&buffer, 1});
+  const auto* footer = footerRoot(*footer_);
+  auto stripeGroupInfo = footer->stripe_groups()->Get(stripeGroupIndex);
 
-  // Reset the first stripe group that was loaded when we load another one
+  // Reset the first stripe group that was loaded when we load another one.
   firstStripeGroup_.wlock()->reset();
 
+  const auto section = toMetadataSection(stripeGroupInfo);
   return std::make_shared<StripeGroup>(
       stripeGroupIndex,
       *stripes_,
-      std::make_unique<MetadataBuffer>(
-          *pool_,
-          buffer,
-          static_cast<CompressionType>(stripeGroupInfo->compression_type())));
+      readMetadata(section, velox::dwio::common::LogType::GROUP));
 }
 
 std::shared_ptr<StripeGroup> TabletReader::stripeGroup(
@@ -797,23 +792,59 @@ std::shared_ptr<StripeIndexGroup> TabletReader::indexGroup(
 std::shared_ptr<StripeIndexGroup> TabletReader::loadIndexGroup(
     uint32_t stripeGroupIndex) const {
   NIMBLE_CHECK_NOT_NULL(tabletIndex_, "Index not initialized.");
+
+  // Reset the first index group that was loaded when we load another one.
   firstIndexGroup_.wlock()->reset();
 
   const auto section = tabletIndex_->groupIndexMetadata(stripeGroupIndex);
-  velox::common::Region indexGroupRegion{
-      section.offset(), section.size(), "StripeIndexGroup"};
-  folly::IOBuf buffer;
-  file_->preadv({&indexGroupRegion, 1}, {&buffer, 1});
-
-  // Reset the first index group that was loaded when we load another one
-
   return StripeIndexGroup::create(
       stripeGroupIndex,
       tabletIndex_->rootIndex(),
-      std::make_unique<MetadataBuffer>(
-          *pool_,
-          buffer,
-          static_cast<CompressionType>(section.compressionType())));
+      readMetadata(section, velox::dwio::common::LogType::GROUP_INDEX));
+}
+
+std::pair<std::shared_ptr<StripeGroup>, std::shared_ptr<StripeIndexGroup>>
+TabletReader::loadStripeAndIndexGroup(uint32_t stripeGroupIndex) const {
+  NIMBLE_CHECK_NOT_NULL(tabletIndex_, "Index not initialized.");
+
+  const auto* footer = footerRoot(*footer_);
+  const auto indexSection = tabletIndex_->groupIndexMetadata(stripeGroupIndex);
+  const auto groupSection =
+      toMetadataSection(footer->stripe_groups()->Get(stripeGroupIndex));
+
+  // Reset strong references when loading different groups.
+  firstStripeGroup_.wlock()->reset();
+  firstIndexGroup_.wlock()->reset();
+
+  std::unique_ptr<MetadataBuffer> groupMetadata;
+  std::unique_ptr<MetadataBuffer> indexMetadata;
+
+  if (bufferedInput_ != nullptr) {
+    // Use enqueue/load pattern for coalesced IO. BufferedInput will coalesce
+    // adjacent regions into a single read when possible.
+    auto groupStream = bufferedInput_->enqueue(
+        {groupSection.offset(), groupSection.size(), "stripe_group"});
+    auto indexStream = bufferedInput_->enqueue(
+        {indexSection.offset(), indexSection.size(), "index_group"});
+
+    // Single load() call - BufferedInput coalesces adjacent regions.
+    bufferedInput_->load(velox::dwio::common::LogType::GROUP);
+
+    groupMetadata = readMetadata(std::move(groupStream), groupSection);
+    indexMetadata = readMetadata(std::move(indexStream), indexSection);
+  } else {
+    // Fall back to separate direct file reads.
+    groupMetadata =
+        readMetadata(groupSection, velox::dwio::common::LogType::GROUP);
+    indexMetadata =
+        readMetadata(indexSection, velox::dwio::common::LogType::GROUP_INDEX);
+  }
+
+  auto stripeGroup = std::make_shared<StripeGroup>(
+      stripeGroupIndex, *stripes_, std::move(groupMetadata));
+  auto indexGroup = StripeIndexGroup::create(
+      stripeGroupIndex, tabletIndex_->rootIndex(), std::move(indexMetadata));
+  return {std::move(stripeGroup), std::move(indexGroup)};
 }
 
 std::span<const uint32_t> TabletReader::streamOffsets(
@@ -837,11 +868,46 @@ StripeIdentifier TabletReader::stripeIdentifier(
     uint32_t stripeIndex,
     bool loadIndex) const {
   NIMBLE_CHECK_LT(stripeIndex, stripeCount_, "Stripe is out of range.");
-  const auto stripeGroupIndex = this->stripeGroupIndex(stripeIndex);
+  const auto groupIndex = this->stripeGroupIndex(stripeIndex);
+
+  if (!loadIndex) {
+    // Index not requested - load stripe group only.
+    return StripeIdentifier{
+        stripeIndex, stripeGroup(groupIndex), /*indexGroup=*/nullptr};
+  }
+
+  // Index requested - ensure it exists.
+  NIMBLE_CHECK_NOT_NULL(
+      tabletIndex_,
+      "Index loading requested but file has no index. Check index() before requesting index loading.");
+
+  // Both stripe group and index group are needed. Check if either is already
+  // cached to avoid unnecessary coalesced loading.
+  const bool stripeGroupCached = stripeGroupCache_.hasCachedEntry(groupIndex);
+  const bool indexGroupCached = indexGroupCache_.hasCachedEntry(groupIndex);
+
+  if (stripeGroupCached || indexGroupCached) {
+    // At least one is already cached — no benefit from coalesced IO, so load
+    // each individually (the cached one is a no-op, the other reads from file).
+    return StripeIdentifier{
+        stripeIndex, stripeGroup(groupIndex), indexGroup(groupIndex)};
+  }
+
+  // Neither is cached - use coalesced loading for adjacent metadata sections.
+  auto [loadedStripeGroup, loadedIndexGroup] =
+      loadStripeAndIndexGroup(groupIndex);
+
+  // Inject into caches using custom builder that returns the already-loaded
+  // objects. This ensures the cache holds the reference.
+  auto cachedStripeGroup = stripeGroupCache_.get(
+      groupIndex,
+      [&loadedStripeGroup](uint32_t) { return std::move(loadedStripeGroup); });
+  auto cachedIndexGroup = indexGroupCache_.get(
+      groupIndex,
+      [&loadedIndexGroup](uint32_t) { return std::move(loadedIndexGroup); });
+
   return StripeIdentifier{
-      stripeIndex,
-      stripeGroup(stripeGroupIndex),
-      loadIndex ? indexGroup(stripeGroupIndex) : nullptr};
+      stripeIndex, std::move(cachedStripeGroup), std::move(cachedIndexGroup)};
 }
 
 std::vector<std::unique_ptr<StreamLoader>> TabletReader::load(
@@ -932,23 +998,18 @@ uint64_t TabletReader::totalStreamSize(
 }
 
 std::optional<MetadataSection> TabletReader::stripesMetadata() const {
-  auto* footerRoot =
-      asFlatBuffersRoot<serialization::Footer>(footer_->content());
-  auto* stripes = footerRoot->stripes();
+  const auto* footer = footerRoot(*footer_);
+  auto* stripes = footer->stripes();
   if (stripes == nullptr) {
     return std::nullopt;
   }
-  return MetadataSection{
-      stripes->offset(),
-      stripes->size(),
-      static_cast<CompressionType>(stripes->compression_type())};
+  return toMetadataSection(stripes);
 }
 
 std::vector<MetadataSection> TabletReader::stripeGroupsMetadata() const {
   std::vector<MetadataSection> groupsMetadata;
-  auto* footerRoot =
-      asFlatBuffersRoot<serialization::Footer>(footer_->content());
-  auto* stripeGroups = footerRoot->stripe_groups();
+  const auto* footer = footerRoot(*footer_);
+  auto* stripeGroups = footer->stripe_groups();
   if (stripeGroups == nullptr) {
     return groupsMetadata;
   }
@@ -957,12 +1018,7 @@ std::vector<MetadataSection> TabletReader::stripeGroupsMetadata() const {
       stripeGroups->cbegin(),
       stripeGroups->cend(),
       std::back_inserter(groupsMetadata),
-      [](const auto& stripeGroup) {
-        return MetadataSection{
-            stripeGroup->offset(),
-            stripeGroup->size(),
-            static_cast<CompressionType>(stripeGroup->compression_type())};
-      });
+      [](const auto& stripeGroup) { return toMetadataSection(stripeGroup); });
   return groupsMetadata;
 }
 
@@ -975,6 +1031,11 @@ std::optional<Section> TabletReader::loadOptionalSection(
     const std::string& name,
     bool keepCache) const {
   NIMBLE_CHECK(!name.empty(), "Optional section name cannot be empty.");
+  auto it = optionalSections_.find(name);
+  if (it == optionalSections_.end()) {
+    return std::nullopt;
+  }
+
   {
     auto optionalSectionsCache = optionalSectionsCache_.wlock();
     auto itCache = optionalSectionsCache->find(name);
@@ -988,30 +1049,15 @@ std::optional<Section> TabletReader::loadOptionalSection(
       }
     }
   }
-
-  auto it = optionalSections_.find(name);
-  if (it == optionalSections_.end()) {
-    return std::nullopt;
-  }
-
-  const auto offset = it->second.offset();
-  const auto size = it->second.size();
-  const auto compressionType = it->second.compressionType();
-
-  velox::common::Region region{offset, size, name};
-  folly::IOBuf iobuf;
-  file_->preadv({&region, 1}, {&iobuf, 1});
-  return Section{MetadataBuffer{*pool_, iobuf, compressionType}};
+  return Section{
+      std::move(*readMetadata(it->second, velox::dwio::common::LogType::FILE))};
 }
 
 bool TabletReader::hasIndex() const {
   return hasOptionalSection(std::string{kIndexSection});
 }
 
-void TabletReader::initIndex(
-    const folly::IOBuf& footerIoBuf,
-    uint64_t footerIoOffset,
-    uint64_t fileSize) {
+void TabletReader::initIndex() {
   NIMBLE_CHECK_NULL(tabletIndex_, "Index already initialized.");
 
   if (!hasIndex()) {
@@ -1023,17 +1069,62 @@ void TabletReader::initIndex(
   NIMBLE_CHECK(indexSection.has_value(), "Failed to load index section.");
 
   tabletIndex_ = TabletIndex::create(std::move(indexSection.value()));
+}
+
+void TabletReader::preloadStripeGroup(const folly::IOBuf& footerIoBuf) {
+  NIMBLE_CHECK_NOT_NULL(stripes_);
+  if (hasCache()) {
+    return;
+  }
+
+  const auto* footer = footerRoot(*footer_);
+  const auto* stripes = stripesRoot(*stripes_);
+  auto* stripeGroups = footer->stripe_groups();
+  NIMBLE_CHECK_NOT_NULL(stripeGroups, "Stripe groups is null.");
+  NIMBLE_CHECK_EQ(
+      stripeGroups->size(),
+      *stripes->group_indices()->rbegin() + 1,
+      "Unexpected stripe group count");
+
+  // Eagerly cache the first stripe group if it's already in the footer buffer.
+  const auto* stripeGroup = stripeGroups->Get(0);
+  if (stripeGroups->size() == 1 &&
+      stripeGroup->offset() + footerIoBuf.computeChainDataLength() >=
+          fileSize_) {
+    auto stripeGroupPtr =
+        stripeGroupCache_.get(0, [&](uint32_t stripeGroupIndex) {
+          return std::make_shared<StripeGroup>(
+              stripeGroupIndex,
+              *stripes_,
+              std::make_unique<MetadataBuffer>(
+                  *pool_,
+                  footerIoBuf,
+                  stripeGroup->offset() + footerIoBuf.computeChainDataLength() -
+                      fileSize_,
+                  stripeGroup->size(),
+                  static_cast<CompressionType>(
+                      stripeGroup->compression_type())));
+        });
+    *firstStripeGroup_.wlock() = std::move(stripeGroupPtr);
+  }
+}
+
+void TabletReader::preloadIndexGroup(const folly::IOBuf& footerIoBuf) {
+  // Skip when cache is available — on-demand reads will hit the cache.
+  if (tabletIndex_ == nullptr || hasCache()) {
+    return;
+  }
+
   const auto numIndexGroups = tabletIndex_->numIndexGroups();
-  // Skip preloading if there are no index groups (empty file case).
   if (numIndexGroups == 0) {
     return;
   }
 
-  // Preload the first stripe index group if it's already in the footer buffer
+  // Eagerly cache the first index group if it's already in the footer buffer.
   const auto firstIndexGroupMetadata = tabletIndex_->groupIndexMetadata(0);
   if (numIndexGroups == 1 &&
       firstIndexGroupMetadata.offset() + footerIoBuf.computeChainDataLength() >=
-          fileSize) {
+          fileSize_) {
     auto indexGroupPtr = indexGroupCache_.get(0, [&](uint32_t indexGroupIndex) {
       return StripeIndexGroup::create(
           indexGroupIndex,
@@ -1042,12 +1133,122 @@ void TabletReader::initIndex(
               *pool_,
               footerIoBuf,
               firstIndexGroupMetadata.offset() +
-                  footerIoBuf.computeChainDataLength() - fileSize,
+                  footerIoBuf.computeChainDataLength() - fileSize_,
               firstIndexGroupMetadata.size(),
               static_cast<CompressionType>(
                   firstIndexGroupMetadata.compressionType())));
     });
     *firstIndexGroup_.wlock() = std::move(indexGroupPtr);
+  }
+}
+
+std::vector<TabletReader::EnqueuedSection>
+TabletReader::enqueueOptionalSections(
+    const std::vector<std::string>& sectionNames) {
+  std::vector<EnqueuedSection> enqueuedSections;
+  for (const auto& name : sectionNames) {
+    auto it = optionalSections_.find(name);
+    if (it == optionalSections_.end()) {
+      continue;
+    }
+    enqueuedSections.push_back(
+        {name,
+         it->second,
+         bufferedInput_->enqueue(
+             {it->second.offset(), it->second.size(), "optional"})});
+  }
+  return enqueuedSections;
+}
+
+void TabletReader::loadEnqueuedOptionalSections(
+    std::vector<EnqueuedSection>&& sections) {
+  auto cache = optionalSectionsCache_.wlock();
+  for (auto& entry : sections) {
+    cache->insert(
+        {entry.name, readMetadata(std::move(entry.stream), entry.section)});
+  }
+}
+
+std::optional<TabletReader::EnqueuedSection>
+TabletReader::enqueueStripesSection() {
+  const auto* footer = footerRoot(*footer_);
+  auto* stripesSection = footer->stripes();
+  if (stripesSection == nullptr) {
+    NIMBLE_CHECK_EQ(footer->row_count(), 0);
+    return std::nullopt;
+  }
+  NIMBLE_CHECK_GT(footer->row_count(), 0);
+  NIMBLE_CHECK_NOT_NULL(bufferedInput_);
+  const auto section = toMetadataSection(stripesSection);
+  return EnqueuedSection{
+      "stripes",
+      section,
+      bufferedInput_->enqueue({section.offset(), section.size(), "stripes"})};
+}
+
+void TabletReader::cacheMetadata(
+    const folly::IOBuf& footerIoBuf,
+    uint64_t footerIoOffset) {
+  if (!hasCache()) {
+    return;
+  }
+
+  const auto footerIoSize = footerIoBuf.computeChainDataLength();
+
+  // Extracts a region from the IOBuf and caches it without coalescing.
+  // Regions outside the buffer are silently skipped. cacheOffset overrides the
+  // region offset as the cache key — used for footer+PS which is cached at
+  // synthetic key fileSize_ (computable without file IO).
+  auto extract = [&](uint64_t regionOffset,
+                     uint64_t regionSize,
+                     std::optional<uint64_t> cacheOffset = std::nullopt) {
+    if (regionOffset < footerIoOffset) {
+      return;
+    }
+    const uint64_t ioBufOffset = regionOffset - footerIoOffset;
+    if (ioBufOffset + regionSize > footerIoSize) {
+      return;
+    }
+    bufferedInput_->cacheRegion(
+        cacheOffset.value_or(regionOffset),
+        regionSize,
+        footerIoBuf,
+        ioBufOffset);
+  };
+
+  // Cache footer+PS at synthetic offset fileSize_ (beyond EOF). This lets
+  // tryLoadAndInitFooterFromCache probe the cache using only the file size
+  // (known without any IO), avoiding the circular dependency of needing
+  // footerSize (from the postscript) to compute the real offset.
+  const uint64_t footerPsSize = ps_.footerSize() + kPostscriptSize;
+  extract(fileSize_ - footerPsSize, footerPsSize, fileSize_);
+
+  const auto* footer = footerRoot(*footer_);
+
+  // Cache stripes section.
+  if (auto* stripesSection = footer->stripes()) {
+    extract(stripesSection->offset(), stripesSection->size());
+  }
+
+  // Cache first stripe group.
+  if (auto* stripeGroups = footer->stripe_groups();
+      stripeGroups != nullptr && stripeGroups->size() > 0) {
+    auto* stripeGroup = stripeGroups->Get(0);
+    extract(stripeGroup->offset(), stripeGroup->size());
+  }
+
+  // Cache index section.
+  if (tabletIndex_ == nullptr) {
+    return;
+  }
+  auto indexIt = optionalSections_.find(std::string{kIndexSection});
+  NIMBLE_CHECK(indexIt != optionalSections_.end());
+  extract(indexIt->second.offset(), indexIt->second.size());
+
+  // Cache first index group.
+  if (tabletIndex_->numIndexGroups() > 0) {
+    const auto indexGroup = tabletIndex_->groupIndexMetadata(0);
+    extract(indexGroup.offset(), indexGroup.size());
   }
 }
 

--- a/dwio/nimble/tablet/TabletReader.h
+++ b/dwio/nimble/tablet/TabletReader.h
@@ -15,6 +15,7 @@
  */
 #pragma once
 
+#include <functional>
 #include <memory>
 #include <optional>
 #include <span>
@@ -27,11 +28,12 @@
 #include "dwio/nimble/tablet/FileLayout.h"
 #include "dwio/nimble/tablet/MetadataBuffer.h"
 #include "folly/Synchronized.h"
-#include "folly/io/IOBuf.h"
 #include "velox/common/file/File.h"
+#include "velox/dwio/common/MetricsLog.h"
 
 namespace facebook::velox::dwio::common {
 class BufferedInput;
+class SeekableInputStream;
 } // namespace facebook::velox::dwio::common
 
 /// The TabletReader class is the on-disk layout for nimble.
@@ -93,8 +95,8 @@ class ReferenceCountedCache {
     return count;
   }
 
-  /// Returns whether the given key has a non-expired cached entry for testing.
-  bool testingHasCachedEntry(Key key) const {
+  /// Returns whether the given key has a non-expired cached entry.
+  bool hasCachedEntry(Key key) const {
     auto rlockedCache = cache_.rlock();
     auto it = rlockedCache->find(key);
     if (it == rlockedCache->end()) {
@@ -199,16 +201,10 @@ class TabletReader {
  public:
   /// Options for configuring TabletReader behavior.
   struct Options {
-    /// Precomputed file layout from external coordinator.
-    /// When provided, skips the discovery phase and uses this layout directly.
-    std::optional<FileLayout> fileLayout;
-
-    /// Controls footer IO behavior:
-    /// - Without fileLayout: speculative tail read size (0 = adaptive mode
-    ///   that reads postscript first, then exact footer size).
-    /// - With fileLayout: memory budget for coalesced metadata reads.
-    /// Default is 8MB (same as kInitialFooterSize).
-    uint64_t footerIoBytes{8 * 1024 * 1024};
+    /// Speculative tail read size (0 = adaptive mode that reads postscript
+    /// first, then exact footer size). Default is 8MB (same as
+    /// kInitialFooterSize).
+    uint64_t maxFooterIoBytes{8 * 1024 * 1024};
 
     /// Optional sections to eagerly load during initialization.
     std::vector<std::string> preloadOptionalSections;
@@ -285,7 +281,7 @@ class TabletReader {
   }
 
   uint64_t fileSize() const {
-    return file_->size();
+    return fileSize_;
   }
 
   const Postscript& postscript() const {
@@ -359,7 +355,7 @@ class TabletReader {
       MemoryPool& pool,
       const Options& options);
 
-  /// For testing use
+  // For testing use.
   TabletReader(
       std::shared_ptr<velox::ReadFile> readFile,
       MemoryPool& pool,
@@ -371,25 +367,72 @@ class TabletReader {
 
   void init(const Options& options);
 
-  // Initialize from precomputed file layout - skips discovery phase.
-  void initFromFileLayout(const Options& options);
+  // Cache init path.
+  //
+  // Returns true if this reader is backed by a BufferedInput with Velox
+  // async data cache.
+  bool hasCache() const;
 
+  // Tries to initialize entirely from Velox async data cache (zero file IO).
+  // Probes the cache for footer+PS at synthetic offset fileSize, parses PS and
+  // footer, then loads all remaining metadata via cache hits. Returns true on
+  // success, false on cache miss (caller falls through to cold path).
+  bool tryInitFromCache(const Options& options);
+
+  // Tries to parse PS and footer from cached footer+PS entry at synthetic
+  // offset fileSize. Returns true on cache hit, false on miss.
+  bool tryLoadAndInitFooterFromCache();
+
+  // Populates AsyncDataCache with exact-size metadata entries from the
+  // speculative tail read IOBuf. Enables zero-IO init for subsequent readers.
+  // No-op if there is no cache.
+  void cacheMetadata(const folly::IOBuf& footerIoBuf, uint64_t footerIoOffset);
+
+  // Footer/postscript parsing.
+  //
+  // Parses the postscript from the last kPostscriptSize bytes of footerIoBuf.
   void initPostScript(const folly::IOBuf& footerIoBuf, uint64_t footerIoSize);
 
+  // Parses the footer from footerIoBuf using the already-parsed postscript.
   void initFooter(const folly::IOBuf& footerIoBuf, uint64_t footerIoSize);
 
-  void initPostScriptAndFooter(
-      uint64_t fileSize,
-      uint64_t footerIoBytes,
+  // Reads and parses both postscript and footer from file. Supports two modes:
+  // - Adaptive (maxFooterIoBytes=0): reads postscript first, then exact footer.
+  // - Speculative: reads maxFooterIoBytes, re-reads if footer is larger.
+  void loadAndInitFooter(
+      uint64_t maxFooterIoBytes,
       folly::IOBuf& footerIoBuf,
       uint64_t& footerIoSize,
       uint64_t& footerIoOffset);
 
+  // Stripes.
+  //
+  // Loads stripes_ from the footerIoBuf. Handles both single-read and re-read
+  // cases when the speculative read didn't capture the full stripes section.
+  void loadStripes(
+      folly::IOBuf& footerIoBuf,
+      uint64_t& footerIoSize,
+      uint64_t& footerIoOffset);
+
+  // Parses stripes_ to populate stripe metadata (counts, offsets, etc.).
+  // Used by test init path.
+  void initStripes();
+
+  // Stripe groups.
+  //
   uint32_t stripeGroupIndex(uint32_t stripeIndex) const;
+
+  std::shared_ptr<StripeGroup> stripeGroup(uint32_t stripeGroupIndex) const;
 
   std::shared_ptr<StripeGroup> loadStripeGroup(uint32_t stripeGroupIndex) const;
 
-  std::shared_ptr<StripeGroup> stripeGroup(uint32_t stripeGroupIndex) const;
+  // Eagerly caches the first stripe group if it's already in the footer IOBuf.
+  // Skipped when cache is present — on-demand reads will hit the cache.
+  void preloadStripeGroup(const folly::IOBuf& footerIoBuf);
+
+  // Index.
+  //
+  void initIndex();
 
   // Returns the cached StripeIndexGroup for the given stripe group index.
   // The StripeIndexGroup contains index metadata for efficient data filtering
@@ -401,24 +444,79 @@ class TabletReader {
   std::shared_ptr<StripeIndexGroup> loadIndexGroup(
       uint32_t stripeGroupIndex) const;
 
-  void initStripes(
-      uint64_t fileSize,
-      folly::IOBuf& footerIoBuf,
-      uint64_t& footerIoSize,
-      uint64_t& footerIoOffset);
+  // Eagerly caches the first index group if it's already in the footer IOBuf.
+  // Skipped when cache is present — on-demand reads will hit the cache.
+  void preloadIndexGroup(const folly::IOBuf& footerIoBuf);
 
-  // Used by test init path.
-  void initStripes();
+  // Loads both stripe group and index group together using coalesced IO when
+  // BufferedInput is available. Falls back to separate loads otherwise.
+  std::pair<std::shared_ptr<StripeGroup>, std::shared_ptr<StripeIndexGroup>>
+  loadStripeAndIndexGroup(uint32_t stripeGroupIndex) const;
 
-  void initOptionalSections(
+  // Optional sections.
+  //
+  // Parses optional sections metadata from footer into optionalSections_ map.
+  void initOptionalSections();
+
+  // Returns the list of optional section names to preload: the user-specified
+  // sections plus the index section if present.
+  std::vector<std::string> preloadSectionNames(const Options& options) const;
+
+  // Preloads optional sections into optionalSectionsCache_ using the provided
+  // loader callback to read each section.
+  using SectionLoader = std::function<std::unique_ptr<MetadataBuffer>(
+      const MetadataSection& section)>;
+  void preloadOptionalSections(
+      const Options& options,
+      const SectionLoader& loader);
+
+  // Creates a SectionLoader that tries to extract from footerIoBuf first
+  // (for sections at offset >= footerIoOffset), falling back to readMetadata.
+  SectionLoader makeSectionLoader(
       const folly::IOBuf& footerIoBuf,
-      uint64_t footerIoOffset,
-      const std::vector<std::string>& preloadOptionalSections);
+      uint64_t footerIoOffset) const;
 
-  void initIndex(
-      const folly::IOBuf& footerIoBuf,
-      uint64_t footerIoOffset,
-      uint64_t fileSize);
+  // BufferedInput coalesced IO.
+  //
+  // Holds a section enqueued for coalesced IO via BufferedInput.
+  // After bufferedInput_->load(), the stream can be read to get section data.
+  struct EnqueuedSection {
+    std::string name;
+    MetadataSection section;
+    std::unique_ptr<velox::dwio::common::SeekableInputStream> stream;
+  };
+
+  // Loads stripes and optional sections via BufferedInput's enqueue/load
+  // pattern for coalesced IO. Populates stripes_ and optionalSectionsCache_.
+  // No-op for empty files (no stripes). Caller must call initStripes() after.
+  void loadStripesAndSections(const Options& options);
+
+  // Enqueues a read for the stripes section via BufferedInput. Returns nullopt
+  // if no stripes (empty file). Caller must call bufferedInput_->load() after.
+  std::optional<EnqueuedSection> enqueueStripesSection();
+
+  // Enqueues reads for the given optional section names via BufferedInput.
+  // Skips names not found in optionalSections_. Caller must call
+  // bufferedInput_->load() after this to execute the coalesced IO.
+  std::vector<EnqueuedSection> enqueueOptionalSections(
+      const std::vector<std::string>& sectionNames);
+
+  // Reads enqueued sections and inserts them into optionalSectionsCache_.
+  // Must be called after bufferedInput_->load().
+  void loadEnqueuedOptionalSections(std::vector<EnqueuedSection>&& sections);
+
+  // Low-level IO.
+  //
+  // Reads metadata from a MetadataSection (offset + size + compressionType).
+  // Uses BufferedInput when available, otherwise reads directly from file.
+  std::unique_ptr<MetadataBuffer> readMetadata(
+      const MetadataSection& section,
+      velox::dwio::common::LogType logType) const;
+
+  // Reads metadata from a pre-loaded stream (e.g. from enqueue/load pattern).
+  std::unique_ptr<MetadataBuffer> readMetadata(
+      std::unique_ptr<velox::dwio::common::SeekableInputStream> stream,
+      const MetadataSection& section) const;
 
   MemoryPool* const pool_;
   // Non-owning pointer to the file for reading. Always valid during the
@@ -428,10 +526,11 @@ class TabletReader {
   // valid throughout TabletReader's lifetime.
   const std::shared_ptr<velox::ReadFile> ownedFile_;
   // Optional BufferedInput for cached reads (non-owning, owned by caller).
-  // TODO: Integrate BufferedInput for metadata IO when set, enabling cache
-  // integration for footer, stripes, and stripe group reads.
+  // When set, metadata reads (stripe groups, index groups) go through
+  // BufferedInput for cache integration.
   velox::dwio::common::BufferedInput* const bufferedInput_;
 
+  uint64_t fileSize_{0};
   Postscript ps_;
   std::unique_ptr<MetadataBuffer> footer_;
   std::unique_ptr<MetadataBuffer> stripes_;

--- a/dwio/nimble/tablet/tests/TabletTest.cpp
+++ b/dwio/nimble/tablet/tests/TabletTest.cpp
@@ -15,10 +15,13 @@
  */
 #include <gtest/gtest.h>
 #include <algorithm>
+#include <atomic>
+#include <chrono>
 #include <filesystem>
 #include <fstream>
 #include <iterator>
 #include <limits>
+#include <thread>
 
 #include "dwio/nimble/common/Buffer.h"
 #include "dwio/nimble/common/Checksum.h"
@@ -37,7 +40,13 @@
 #include "folly/executors/CPUThreadPoolExecutor.h"
 #include "velox/common/file/File.h"
 
+#include "velox/common/caching/AsyncDataCache.h"
+#include "velox/common/caching/FileIds.h"
+#include "velox/common/memory/MallocAllocator.h"
 #include "velox/common/memory/Memory.h"
+#include "velox/dwio/common/BufferedInput.h"
+#include "velox/dwio/common/CachedBufferedInput.h"
+#include "velox/dwio/common/DirectBufferedInput.h"
 #include "velox/dwio/common/ExecutorBarrier.h"
 
 using namespace facebook;
@@ -56,6 +65,32 @@ DEFINE_uint32(
 
 // Total size of the fields after the flatbuffer.
 constexpr uint32_t kPostscriptSize = 20;
+
+/// BufferedInput test modes for parameterized testing.
+enum class BufferedInputMode {
+  /// No BufferedInput - direct file reads.
+  kNone,
+  /// Base BufferedInput class (no cache).
+  kBufferedInput,
+  /// DirectBufferedInput (no cache, but with coalescing).
+  kDirectBufferedInput,
+  /// CachedBufferedInput with AsyncDataCache.
+  kCachedBufferedInput,
+};
+
+std::string bufferedInputModeToString(BufferedInputMode mode) {
+  switch (mode) {
+    case BufferedInputMode::kNone:
+      return "None";
+    case BufferedInputMode::kBufferedInput:
+      return "BufferedInput";
+    case BufferedInputMode::kDirectBufferedInput:
+      return "DirectBufferedInput";
+    case BufferedInputMode::kCachedBufferedInput:
+      return "CachedBufferedInput";
+  }
+  return "Unknown";
+}
 
 struct StripeSpecifications {
   uint32_t rowCount;
@@ -112,13 +147,124 @@ std::vector<StripeData> createStripesData(
   return stripesData;
 }
 
-class TabletTest : public ::testing::Test {
+class TabletTest : public ::testing::TestWithParam<BufferedInputMode> {
  protected:
   static void SetUpTestCase() {
     velox::memory::MemoryManager::testingSetInstance({});
   }
 
-  void SetUp() override {}
+  void SetUp() override {
+    executor_ = std::make_unique<folly::CPUThreadPoolExecutor>(2);
+    ioStatistics_ = std::make_shared<velox::dwio::common::IoStatistics>();
+  }
+
+  void TearDown() override {
+    bufferedInput_.reset();
+    if (cache_) {
+      cache_->shutdown();
+      cache_.reset();
+    }
+    allocator_.reset();
+    executor_.reset();
+  }
+
+  /// Creates a BufferedInput based on the test mode.
+  /// Returns nullptr for kNone mode.
+  velox::dwio::common::BufferedInput* createBufferedInput(
+      std::shared_ptr<velox::ReadFile> readFile) {
+    auto mode = GetParam();
+
+    auto& ids = velox::fileIds();
+    fileId_ = std::make_unique<velox::StringIdLease>(ids, "testFile");
+    groupId_ = std::make_unique<velox::StringIdLease>(ids, "testGroup");
+
+    velox::io::ReaderOptions readerOptions(pool_.get());
+
+    switch (mode) {
+      case BufferedInputMode::kNone:
+        return nullptr;
+
+      case BufferedInputMode::kBufferedInput:
+        bufferedInput_ = std::make_unique<velox::dwio::common::BufferedInput>(
+            readFile, *pool_);
+        return bufferedInput_.get();
+
+      case BufferedInputMode::kDirectBufferedInput:
+        tracker_ = std::make_shared<velox::cache::ScanTracker>(
+            "testTracker", nullptr, 256 << 10);
+        bufferedInput_ =
+            std::make_unique<velox::dwio::common::DirectBufferedInput>(
+                readFile,
+                velox::dwio::common::MetricsLog::voidLog(),
+                std::move(*fileId_),
+                tracker_,
+                std::move(*groupId_),
+                ioStatistics_,
+                nullptr,
+                executor_.get(),
+                readerOptions);
+        return bufferedInput_.get();
+
+      case BufferedInputMode::kCachedBufferedInput:
+        if (!allocator_) {
+          allocator_ = std::make_shared<velox::memory::MallocAllocator>(
+              1UL << 30, 0 /* reservationByteLimit */);
+        }
+        if (!cache_) {
+          cache_ = velox::cache::AsyncDataCache::create(allocator_.get());
+        }
+        tracker_ = std::make_shared<velox::cache::ScanTracker>(
+            "testTracker", nullptr, 256 << 10);
+        bufferedInput_ =
+            std::make_unique<velox::dwio::common::CachedBufferedInput>(
+                readFile,
+                velox::dwio::common::MetricsLog::voidLog(),
+                std::move(*fileId_),
+                cache_.get(),
+                tracker_,
+                std::move(*groupId_),
+                ioStatistics_,
+                nullptr,
+                executor_.get(),
+                readerOptions);
+        return bufferedInput_.get();
+    }
+    return nullptr;
+  }
+
+  bool expectHasCache() const {
+    return GetParam() == BufferedInputMode::kCachedBufferedInput;
+  }
+
+  /// Creates a TabletReader with BufferedInput configured based on test mode.
+  /// This is the primary method tests should use to create readers.
+  std::shared_ptr<nimble::TabletReader> createTabletReader(
+      std::shared_ptr<velox::ReadFile> readFile,
+      nimble::TabletReader::Options options = {}) {
+    readFile_ = readFile;
+    auto* bufferedInput = createBufferedInput(readFile_);
+    options.bufferedInput = bufferedInput;
+    return nimble::TabletReader::create(readFile_.get(), pool_.get(), options);
+  }
+
+  /// Overload for string file content (creates InMemoryReadFile internally).
+  std::shared_ptr<nimble::TabletReader> createTabletReader(
+      const std::string& fileContent,
+      nimble::TabletReader::Options options = {}) {
+    return createTabletReader(
+        std::make_shared<velox::InMemoryReadFile>(fileContent),
+        std::move(options));
+  }
+
+  std::shared_ptr<velox::ReadFile> readFile_;
+  std::unique_ptr<folly::CPUThreadPoolExecutor> executor_;
+  std::shared_ptr<velox::dwio::common::IoStatistics> ioStatistics_;
+  std::shared_ptr<velox::memory::MallocAllocator> allocator_;
+  std::shared_ptr<velox::cache::AsyncDataCache> cache_;
+  std::shared_ptr<velox::cache::ScanTracker> tracker_;
+  std::unique_ptr<velox::StringIdLease> fileId_;
+  std::unique_ptr<velox::StringIdLease> groupId_;
+  std::unique_ptr<velox::dwio::common::BufferedInput> bufferedInput_;
 
   // Runs a single write/read test using input parameters
   void parameterizedTest(
@@ -638,12 +784,14 @@ class TabletTest : public ::testing::Test {
       rootPool_->addLeafChild("TabletTest")};
 };
 
-TEST_F(TabletTest, emptyWrite) {
+// --- TabletTest parameterized tests ---
+
+TEST_P(TabletTest, emptyWrite) {
   // Creating an Nimble file without writing any stripes
   test(/* stripes */ {});
 }
 
-TEST_F(TabletTest, writeDifferentStreamsPerStripe) {
+TEST_P(TabletTest, writeDifferentStreamsPerStripe) {
   // Write different subset of streams in each stripe
   test(
       /* stripes */
@@ -654,7 +802,7 @@ TEST_F(TabletTest, writeDifferentStreamsPerStripe) {
       });
 }
 
-TEST_F(TabletTest, checksumValidation) {
+TEST_P(TabletTest, checksumValidation) {
   std::vector<uint32_t> metadataCompressionThresholds{
       // use size 0 here so it will always force a footer compression
       0,
@@ -684,7 +832,7 @@ TEST_F(TabletTest, checksumValidation) {
   }
 }
 
-TEST_F(TabletTest, optionalSections) {
+TEST_P(TabletTest, optionalSections) {
   auto seed = folly::Random::rand32();
   LOG(INFO) << "seed: " << seed;
   std::mt19937 rng{seed};
@@ -803,7 +951,7 @@ TEST_F(TabletTest, optionalSections) {
   }
 }
 
-TEST_F(TabletTest, optionalSectionsEmpty) {
+TEST_P(TabletTest, optionalSectionsEmpty) {
   std::string file;
   velox::InMemoryWriteFile writeFile(&file);
   auto tabletWriter = nimble::TabletWriter::create(&writeFile, *pool_, {});
@@ -822,7 +970,7 @@ TEST_F(TabletTest, optionalSectionsEmpty) {
   }
 }
 
-TEST_F(TabletTest, hasOptionalSection) {
+TEST_P(TabletTest, hasOptionalSection) {
   std::string file;
   velox::InMemoryWriteFile writeFile(&file);
   auto tabletWriter = nimble::TabletWriter::create(&writeFile, *pool_, {});
@@ -849,7 +997,7 @@ TEST_F(TabletTest, hasOptionalSection) {
   EXPECT_FALSE(tablet->hasOptionalSection(std::string(nimble::kIndexSection)));
 }
 
-TEST_F(TabletTest, hasOptionalSectionEmpty) {
+TEST_P(TabletTest, hasOptionalSectionEmpty) {
   std::string file;
   velox::InMemoryWriteFile writeFile(&file);
   auto tabletWriter = nimble::TabletWriter::create(&writeFile, *pool_, {});
@@ -865,7 +1013,7 @@ TEST_F(TabletTest, hasOptionalSectionEmpty) {
   EXPECT_FALSE(tablet->hasOptionalSection("any_name"));
 }
 
-TEST_F(TabletTest, optionalSectionsPreload) {
+TEST_P(TabletTest, optionalSectionsPreload) {
   auto seed = folly::Random::rand32();
   LOG(INFO) << "seed: " << seed;
   std::mt19937 rng{seed};
@@ -1063,7 +1211,7 @@ class Guard {
   Actions& actions_;
 };
 
-TEST_F(TabletTest, referenceCountedCache) {
+TEST_P(TabletTest, referenceCountedCache) {
   Actions actions;
   facebook::nimble::ReferenceCountedCache<int, Guard> cache{
       [&](int id) { return std::make_shared<Guard>(id, actions); }};
@@ -1159,7 +1307,7 @@ TEST_F(TabletTest, referenceCountedCache) {
            {ActionEnum::kDestroyed, 0}}));
 }
 
-TEST_F(TabletTest, referenceCountedCacheStressParallelDuplicates) {
+TEST_P(TabletTest, referenceCountedCacheStressParallelDuplicates) {
   std::atomic_int counter{0};
   facebook::nimble::ReferenceCountedCache<int, int> cache{[&](int id) {
     ++counter;
@@ -1181,7 +1329,7 @@ TEST_F(TabletTest, referenceCountedCacheStressParallelDuplicates) {
   EXPECT_GE(counter.load(), kEntryIds);
 }
 
-TEST_F(TabletTest, referenceCountedCacheStressParallelDuplicatesSaveEntries) {
+TEST_P(TabletTest, referenceCountedCacheStressParallelDuplicatesSaveEntries) {
   std::atomic_int counter{0};
   facebook::nimble::ReferenceCountedCache<int, int> cache{[&](int id) {
     ++counter;
@@ -1205,7 +1353,7 @@ TEST_F(TabletTest, referenceCountedCacheStressParallelDuplicatesSaveEntries) {
   EXPECT_EQ(counter.load(), kEntryIds);
 }
 
-TEST_F(TabletTest, referenceCountedCacheStress) {
+TEST_P(TabletTest, referenceCountedCacheStress) {
   std::atomic_int counter{0};
   facebook::nimble::ReferenceCountedCache<int, int> cache{[&](int id) {
     ++counter;
@@ -1227,7 +1375,7 @@ TEST_F(TabletTest, referenceCountedCacheStress) {
   EXPECT_GE(counter.load(), kEntryIds);
 }
 
-TEST_F(TabletTest, referenceCountedCacheStressSaveEntries) {
+TEST_P(TabletTest, referenceCountedCacheStressSaveEntries) {
   std::atomic_int counter{0};
   facebook::nimble::ReferenceCountedCache<int, int> cache{[&](int id) {
     ++counter;
@@ -1251,7 +1399,7 @@ TEST_F(TabletTest, referenceCountedCacheStressSaveEntries) {
   EXPECT_EQ(counter.load(), kEntryIds);
 }
 
-TEST_F(TabletTest, deduplicateStreams) {
+TEST_P(TabletTest, deduplicateStreams) {
   auto seed = FLAGS_tablet_tests_seed > 0 ? FLAGS_tablet_tests_seed
                                           : folly::Random::rand32();
   LOG(INFO) << "seed: " << seed;
@@ -1266,7 +1414,7 @@ TEST_F(TabletTest, deduplicateStreams) {
   }
 }
 
-TEST_F(TabletTest, chunkContentSize) {
+TEST_P(TabletTest, chunkContentSize) {
   nimble::Chunk chunk;
   EXPECT_EQ(chunk.contentSize(), 0);
 
@@ -1473,7 +1621,7 @@ class TabletWithIndexTest : public TabletTest {
   }
 };
 
-TEST_F(TabletWithIndexTest, stripeIdentifier) {
+TEST_P(TabletWithIndexTest, stripeIdentifier) {
   // Test that stripeIdentifier correctly returns index group based on loadIndex
   // parameter. When loadIndex=false (default), indexGroup should be nullptr.
   // When loadIndex=true, indexGroup should be set.
@@ -1528,7 +1676,7 @@ TEST_F(TabletWithIndexTest, stripeIdentifier) {
   }
 }
 
-TEST_F(TabletWithIndexTest, singleGroup) {
+TEST_P(TabletWithIndexTest, singleGroup) {
   // Test writing a tablet with index configuration and reading it back.
   // Each stream has multiple chunks with varying row counts and sizes.
   // Different streams are not synchronized in chunk count, rows, or size.
@@ -1947,7 +2095,7 @@ TEST_F(TabletWithIndexTest, singleGroup) {
       });
 }
 
-TEST_F(TabletWithIndexTest, multipleGroups) {
+TEST_P(TabletWithIndexTest, multipleGroups) {
   // Test writing a tablet with index configuration and multiple stripe groups.
   // With metadataFlushThreshold = 0, each stripe is in its own group:
   // - Group 0: stripe 0
@@ -2322,7 +2470,7 @@ TEST_F(TabletWithIndexTest, multipleGroups) {
       });
 }
 
-TEST_F(TabletWithIndexTest, singleGroupWithEmptyStream) {
+TEST_P(TabletWithIndexTest, singleGroupWithEmptyStream) {
   // Test writing a tablet with 4 streams where some streams are empty in
   // certain stripes. This tests the position index handles missing streams
   // correctly.
@@ -2736,7 +2884,7 @@ TEST_F(TabletWithIndexTest, singleGroupWithEmptyStream) {
       });
 }
 
-TEST_F(TabletWithIndexTest, multipleGroupsWithEmptyStream) {
+TEST_P(TabletWithIndexTest, multipleGroupsWithEmptyStream) {
   // Test writing a tablet with 4 streams where some streams are empty in
   // certain stripes, with multiple stripe groups (one per stripe).
   // This tests the position index handles missing streams correctly across
@@ -3208,7 +3356,7 @@ TEST_F(TabletWithIndexTest, multipleGroupsWithEmptyStream) {
       });
 }
 
-TEST_F(TabletWithIndexTest, streamDeduplication) {
+TEST_P(TabletWithIndexTest, streamDeduplication) {
   // Test writing a tablet with stream deduplication enabled and index
   // configuration. Some streams have identical content and should be
   // deduplicated. This test verifies the position index correctly handles
@@ -3472,7 +3620,7 @@ TEST_F(TabletWithIndexTest, streamDeduplication) {
   }
 }
 
-TEST_F(TabletWithIndexTest, keyOrderEnforcement) {
+TEST_P(TabletWithIndexTest, keyOrderEnforcement) {
   // Test key order enforcement behavior with enforceKeyOrder = true/false
   for (bool enforceKeyOrder : {true, false}) {
     SCOPED_TRACE(fmt::format("enforceKeyOrder={}", enforceKeyOrder));
@@ -3546,7 +3694,7 @@ TEST_F(TabletWithIndexTest, keyOrderEnforcement) {
   }
 }
 
-TEST_F(TabletWithIndexTest, noIndex) {
+TEST_P(TabletWithIndexTest, noIndex) {
   // Test that without index config, no index section is written
   std::string file;
   velox::InMemoryWriteFile writeFile(&file);
@@ -3577,7 +3725,7 @@ TEST_F(TabletWithIndexTest, noIndex) {
   EXPECT_FALSE(tablet->hasOptionalSection(std::string(nimble::kIndexSection)));
 }
 
-TEST_F(TabletWithIndexTest, emptyFileWithIndexConfig) {
+TEST_P(TabletWithIndexTest, emptyFileWithIndexConfig) {
   // Test writing an empty file (no stripes) with index config.
   // The root index should contain only config (columns, sort orders)
   // but no stripe keys or stripe index groups.
@@ -3646,7 +3794,7 @@ TEST_F(TabletWithIndexTest, emptyFileWithIndexConfig) {
   EXPECT_FALSE(tabletIndex->lookup("zzz").has_value());
 }
 
-TEST_F(TabletWithIndexTest, fileLayoutWithIndex) {
+TEST_P(TabletWithIndexTest, fileLayoutWithIndex) {
   // Test FileLayout::create() with non-empty file that has index enabled.
   std::string file;
   velox::InMemoryWriteFile writeFile(&file);
@@ -3697,7 +3845,141 @@ TEST_F(TabletWithIndexTest, fileLayoutWithIndex) {
   }
 }
 
-TEST_F(TabletTest, writeAfterCloseThrows) {
+TEST_P(TabletWithIndexTest, cacheWarmPath) {
+  // Test that a second TabletReader on an indexed file initializes from
+  // AsyncDataCache with zero file IO, and that index data is also served
+  // from cache on the warm path.
+  if (GetParam() != BufferedInputMode::kCachedBufferedInput) {
+    GTEST_SKIP() << "Cache warm path only applies to CachedBufferedInput";
+  }
+
+  // Write a file with multiple stripes and index.
+  std::string file;
+  velox::InMemoryWriteFile writeFile(&file);
+  nimble::Buffer buffer(*pool_);
+
+  nimble::TabletIndexConfig indexConfig{
+      .columns = {"col1"},
+      .sortOrders = {SortOrder{.ascending = true}},
+      .enforceKeyOrder = true,
+  };
+
+  auto tabletWriter = nimble::TabletWriter::create(
+      &writeFile,
+      *pool_,
+      {
+          .metadataFlushThreshold = 1024 * 1024 * 1024,
+          .streamDeduplicationEnabled = false,
+          .indexConfig = indexConfig,
+      });
+
+  constexpr int kNumStripes = 3;
+  std::vector<std::string> firstKeys = {"aaa", "ccc", "eee"};
+  std::vector<std::string> lastKeys = {"bbb", "ddd", "fff"};
+  for (int i = 0; i < kNumStripes; ++i) {
+    auto streams = createStreams(
+        buffer, {{.offset = 0, .chunks = {{.rowCount = 100, .size = 50}}}});
+    auto keyStream = createKeyStream(
+        buffer,
+        {{.rowCount = 100, .firstKey = firstKeys[i], .lastKey = lastKeys[i]}});
+    tabletWriter->writeStripe(100, std::move(streams), std::move(keyStream));
+  }
+  tabletWriter->close();
+  writeFile.close();
+
+  auto readFile = std::make_shared<velox::InMemoryReadFile>(file);
+
+  // Initialize cache before the cold reader so we can verify it starts empty.
+  allocator_ = std::make_shared<velox::memory::MallocAllocator>(
+      1UL << 30, 0 /* reservationByteLimit */);
+  cache_ = velox::cache::AsyncDataCache::create(allocator_.get());
+
+  auto coldCacheStats = cache_->refreshStats();
+  EXPECT_EQ(coldCacheStats.numEntries, 0);
+
+  // Cold path: first reader populates the cache.
+  {
+    auto coldReader = createTabletReader(readFile);
+    EXPECT_EQ(coldReader->stripeCount(), kNumStripes);
+    EXPECT_EQ(coldReader->tabletRowCount(), kNumStripes * 100);
+    EXPECT_TRUE(coldReader->hasIndex());
+    EXPECT_NE(coldReader->index(), nullptr);
+
+    // Cold init bypasses CachedBufferedInput — no IoStatistics tracking.
+    EXPECT_EQ(ioStatistics_->ramHit().count(), 0);
+    EXPECT_EQ(ioStatistics_->ssdRead().count(), 0);
+    EXPECT_EQ(ioStatistics_->read().count(), 0);
+    EXPECT_EQ(ioStatistics_->prefetch().count(), 0);
+
+    // Verify stripe groups and index groups are accessible.
+    for (uint32_t i = 0; i < kNumStripes; ++i) {
+      auto stripeId = coldReader->stripeIdentifier(i, /*loadIndex=*/true);
+      EXPECT_NE(stripeId.stripeGroup(), nullptr);
+      EXPECT_NE(stripeId.indexGroup(), nullptr);
+    }
+
+    // Verify index lookup works.
+    auto location = coldReader->index()->lookup("bbb");
+    ASSERT_TRUE(location.has_value());
+    EXPECT_EQ(location->stripeIndex, 0);
+  }
+
+  coldCacheStats = cache_->refreshStats();
+  EXPECT_GT(coldCacheStats.numEntries, 0);
+  EXPECT_GT(coldCacheStats.numNew, 0);
+  EXPECT_EQ(coldCacheStats.numEvict, 0);
+
+  // Reset IO stats for the warm path.
+  ioStatistics_ = std::make_shared<velox::dwio::common::IoStatistics>();
+
+  // Warm path: second reader should initialize from cache with zero IO.
+  {
+    auto warmReader = createTabletReader(readFile);
+    EXPECT_EQ(warmReader->stripeCount(), kNumStripes);
+    EXPECT_EQ(warmReader->tabletRowCount(), kNumStripes * 100);
+    EXPECT_TRUE(warmReader->hasIndex());
+    EXPECT_NE(warmReader->index(), nullptr);
+
+    // Warm path should serve all data from RAM cache.
+    EXPECT_GT(ioStatistics_->ramHit().count(), 0);
+    EXPECT_EQ(ioStatistics_->ssdRead().count(), 0);
+    EXPECT_EQ(ioStatistics_->read().count(), 0);
+    EXPECT_EQ(ioStatistics_->prefetch().count(), 0);
+
+    // Verify stripe groups and index groups are accessible from cache.
+    for (uint32_t i = 0; i < kNumStripes; ++i) {
+      auto stripeId = warmReader->stripeIdentifier(i, /*loadIndex=*/true);
+      EXPECT_NE(stripeId.stripeGroup(), nullptr);
+      EXPECT_NE(stripeId.indexGroup(), nullptr);
+    }
+
+    // Verify index lookup still works from cache.
+    auto location = warmReader->index()->lookup("ddd");
+    ASSERT_TRUE(location.has_value());
+    EXPECT_EQ(location->stripeIndex, 1);
+  }
+
+  // Warm reader should have additional cache hits, no new entries or evictions.
+  auto warmCacheStats = cache_->refreshStats();
+  EXPECT_EQ(warmCacheStats.numEntries, coldCacheStats.numEntries);
+  EXPECT_GT(warmCacheStats.numHit, coldCacheStats.numHit);
+  EXPECT_EQ(warmCacheStats.numNew, coldCacheStats.numNew);
+  EXPECT_EQ(warmCacheStats.numEvict, 0);
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    BufferedInputModes,
+    TabletWithIndexTest,
+    ::testing::Values(
+        BufferedInputMode::kNone,
+        BufferedInputMode::kBufferedInput,
+        BufferedInputMode::kDirectBufferedInput,
+        BufferedInputMode::kCachedBufferedInput),
+    [](const ::testing::TestParamInfo<BufferedInputMode>& info) {
+      return bufferedInputModeToString(info.param);
+    });
+
+TEST_P(TabletTest, writeAfterCloseThrows) {
   // Test that write operations throw after close().
   std::string file;
   velox::InMemoryWriteFile writeFile(&file);
@@ -3732,8 +4014,8 @@ TEST_F(TabletTest, writeAfterCloseThrows) {
       tabletWriter->close(), "TabletWriter is already closed");
 }
 
-TEST_F(TabletTest, readerOptionsAdaptiveMode) {
-  // Test adaptive mode (footerIoBytes=0) which reads postscript first,
+TEST_P(TabletTest, readerOptionsAdaptiveMode) {
+  // Test adaptive mode (maxFooterIoBytes=0) which reads postscript first,
   // then exact footer size.
   std::string file;
   velox::InMemoryWriteFile writeFile(&file);
@@ -3753,18 +4035,18 @@ TEST_F(TabletTest, readerOptionsAdaptiveMode) {
   tabletWriter->close();
   writeFile.close();
 
-  // Read with adaptive mode (footerIoBytes=0)
+  // Read with adaptive mode (maxFooterIoBytes=0)
   nimble::testing::InMemoryTrackableReadFile readFile(file, false);
   nimble::TabletReader::Options options;
-  options.footerIoBytes = 0; // Adaptive mode
+  options.maxFooterIoBytes = 0; // Adaptive mode
   auto tablet = nimble::TabletReader::create(&readFile, pool_.get(), options);
 
   EXPECT_EQ(tablet->stripeCount(), 1);
   EXPECT_EQ(tablet->stripeRowCount(0), 500);
 }
 
-TEST_F(TabletTest, readerOptionsSpeculativeMode) {
-  // Test speculative mode (non-zero footerIoBytes).
+TEST_P(TabletTest, readerOptionsSpeculativeMode) {
+  // Test speculative mode (non-zero maxFooterIoBytes).
   std::string file;
   velox::InMemoryWriteFile writeFile(&file);
   nimble::Buffer buffer(*pool_);
@@ -3786,167 +4068,312 @@ TEST_F(TabletTest, readerOptionsSpeculativeMode) {
   // Read with speculative mode
   nimble::testing::InMemoryTrackableReadFile readFile(file, false);
   nimble::TabletReader::Options options;
-  options.footerIoBytes = 1024; // Small speculative read
+  options.maxFooterIoBytes = 1024; // Small speculative read
   auto tablet = nimble::TabletReader::create(&readFile, pool_.get(), options);
 
   EXPECT_EQ(tablet->stripeCount(), 1);
   EXPECT_EQ(tablet->stripeRowCount(0), 600);
 }
 
-TEST_F(TabletTest, readerOptionsFileLayoutPath) {
-  // Test fileLayout path which uses precomputed layout.
+TEST_P(TabletTest, bufferedInputMetadataReads) {
+  // Test that BufferedInput is used for metadata reads when provided.
   std::string file;
   velox::InMemoryWriteFile writeFile(&file);
   nimble::Buffer buffer(*pool_);
 
   auto tabletWriter = nimble::TabletWriter::create(&writeFile, *pool_, {});
 
-  std::vector<nimble::Stream> streams;
-  const auto size = 100;
-  auto pos = buffer.reserve(size);
-  std::memset(pos, 'z', size);
-  streams.push_back({
-      .offset = 0,
-      .chunks = {{.content = {std::string_view(pos, size)}}},
-  });
-  tabletWriter->writeStripe(700, std::move(streams));
+  // Write multiple stripes to ensure we have stripe group metadata to read.
+  for (int i = 0; i < 3; ++i) {
+    std::vector<nimble::Stream> streams;
+    const auto size = 100;
+    auto pos = buffer.reserve(size);
+    std::memset(pos, 'a' + i, size);
+    streams.push_back({
+        .offset = 0,
+        .chunks = {{.rowCount = 100, .content = {std::string_view(pos, size)}}},
+    });
+    tabletWriter->writeStripe(100, std::move(streams));
+  }
   tabletWriter->close();
   writeFile.close();
 
-  // Get layout using FileLayout::create()
-  velox::InMemoryReadFile layoutReadFile(file);
-  auto layout = nimble::FileLayout::create(&layoutReadFile, pool_.get());
+  auto tablet = createTabletReader(file);
 
-  // Read using the precomputed layout
-  nimble::testing::InMemoryTrackableReadFile readFile(file, false);
-  nimble::TabletReader::Options options;
-  options.fileLayout = layout;
-  options.footerIoBytes = 8 * 1024 * 1024; // Memory budget for coalescing
-  auto tablet = nimble::TabletReader::create(&readFile, pool_.get(), options);
+  nimble::test::TabletReaderTestHelper tabletHelper(tablet.get());
+  EXPECT_EQ(tabletHelper.hasCache(), expectHasCache());
+  EXPECT_EQ(tablet->stripeCount(), 3);
 
-  EXPECT_EQ(tablet->stripeCount(), 1);
-  EXPECT_EQ(tablet->stripeRowCount(0), 700);
-  EXPECT_EQ(tablet->majorVersion(), layout.postscript.majorVersion());
-  EXPECT_EQ(tablet->minorVersion(), layout.postscript.minorVersion());
+  // Verify we can read stripe data.
+  auto stripeId = tablet->stripeIdentifier(0);
+  EXPECT_EQ(stripeId.stripeId(), 0);
+  EXPECT_NE(stripeId.stripeGroup(), nullptr);
 }
 
-TEST_F(TabletTest, readerOptionsFileLayoutMismatch) {
-  // Test that fileLayout with wrong fileSize is rejected.
+TEST_P(TabletTest, cacheWarmPath) {
+  // Test that a second TabletReader on the same file initializes from
+  // AsyncDataCache with zero file IO when file-metadata-cache is enabled.
+  // Only meaningful for CachedBufferedInput mode.
+  if (GetParam() != BufferedInputMode::kCachedBufferedInput) {
+    GTEST_SKIP() << "Cache warm path only applies to CachedBufferedInput";
+  }
+
+  // Write a file with multiple stripes.
   std::string file;
   velox::InMemoryWriteFile writeFile(&file);
   nimble::Buffer buffer(*pool_);
 
   auto tabletWriter = nimble::TabletWriter::create(&writeFile, *pool_, {});
-
-  std::vector<nimble::Stream> streams;
-  const auto size = 100;
-  auto pos = buffer.reserve(size);
-  std::memset(pos, 'w', size);
-  streams.push_back({
-      .offset = 0,
-      .chunks = {{.content = {std::string_view(pos, size)}}},
-  });
-  tabletWriter->writeStripe(800, std::move(streams));
+  constexpr int kNumStripes = 3;
+  for (int i = 0; i < kNumStripes; ++i) {
+    std::vector<nimble::Stream> streams;
+    const auto size = 100;
+    auto pos = buffer.reserve(size);
+    std::memset(pos, 'a' + i, size);
+    streams.push_back({
+        .offset = 0,
+        .chunks = {{.rowCount = 100, .content = {std::string_view(pos, size)}}},
+    });
+    tabletWriter->writeStripe(100, std::move(streams));
+  }
   tabletWriter->close();
   writeFile.close();
 
-  // Get layout using FileLayout::create()
-  velox::InMemoryReadFile layoutReadFile(file);
-  auto layout = nimble::FileLayout::create(&layoutReadFile, pool_.get());
-  // Corrupt the layout
-  layout.fileSize = layout.fileSize + 100;
+  auto readFile = std::make_shared<velox::InMemoryReadFile>(file);
 
-  nimble::testing::InMemoryTrackableReadFile readFile(file, false);
-  nimble::TabletReader::Options options;
-  options.fileLayout = layout;
+  // Initialize cache before the cold reader so we can verify it starts empty.
+  // Normally lazy-initialized in createBufferedInput.
+  allocator_ = std::make_shared<velox::memory::MallocAllocator>(
+      1UL << 30, 0 /* reservationByteLimit */);
+  cache_ = velox::cache::AsyncDataCache::create(allocator_.get());
 
-  NIMBLE_ASSERT_USER_THROW(
-      nimble::TabletReader::create(&readFile, pool_.get(), options),
-      "doesn't match actual file size");
+  // Cache should be empty before the cold reader.
+  auto coldCacheStats = cache_->refreshStats();
+  EXPECT_EQ(coldCacheStats.numEntries, 0);
+  EXPECT_EQ(coldCacheStats.numHit, 0);
+  EXPECT_EQ(coldCacheStats.numNew, 0);
+
+  // Cold path: first reader populates the cache.
+  {
+    auto coldReader = createTabletReader(readFile);
+    EXPECT_EQ(coldReader->stripeCount(), kNumStripes);
+    EXPECT_EQ(coldReader->tabletRowCount(), kNumStripes * 100);
+
+    // Cold init uses direct file_->preadv() which bypasses
+    // CachedBufferedInput, so no reads are tracked through IoStatistics.
+    EXPECT_EQ(ioStatistics_->ramHit().count(), 0);
+    EXPECT_EQ(ioStatistics_->ssdRead().count(), 0);
+    EXPECT_EQ(ioStatistics_->read().count(), 0);
+    EXPECT_EQ(ioStatistics_->prefetch().count(), 0);
+
+    auto stripeId = coldReader->stripeIdentifier(0);
+    EXPECT_EQ(stripeId.stripeId(), 0);
+    EXPECT_NE(stripeId.stripeGroup(), nullptr);
+  }
+
+  // Cold reader should have populated the cache with metadata entries.
+  // numHit may be > 0 from self-hits within the cold reader (coalesced IO can
+  // populate a cache entry that is then hit by a subsequent read).
+  coldCacheStats = cache_->refreshStats();
+  EXPECT_GT(coldCacheStats.numEntries, 0);
+  EXPECT_GT(coldCacheStats.numNew, 0);
+  EXPECT_EQ(coldCacheStats.numEvict, 0);
+
+  // Reset IO stats for the warm path.
+  ioStatistics_ = std::make_shared<velox::dwio::common::IoStatistics>();
+
+  // Warm path: second reader should initialize from cache with zero IO.
+  {
+    auto warmReader = createTabletReader(readFile);
+    EXPECT_EQ(warmReader->stripeCount(), kNumStripes);
+    EXPECT_EQ(warmReader->tabletRowCount(), kNumStripes * 100);
+    for (uint32_t i = 0; i < kNumStripes; ++i) {
+      EXPECT_EQ(warmReader->stripeRowCount(i), 100);
+    }
+
+    // Warm path should serve all data from RAM cache with zero storage reads.
+    EXPECT_GT(ioStatistics_->ramHit().count(), 0);
+    EXPECT_EQ(ioStatistics_->ssdRead().count(), 0);
+    EXPECT_EQ(ioStatistics_->read().count(), 0);
+    EXPECT_EQ(ioStatistics_->prefetch().count(), 0);
+
+    auto stripeId = warmReader->stripeIdentifier(0);
+    EXPECT_EQ(stripeId.stripeId(), 0);
+    EXPECT_NE(stripeId.stripeGroup(), nullptr);
+  }
+
+  // Warm reader should have additional cache hits beyond what the cold reader
+  // generated, with no new entries or evictions.
+  auto warmCacheStats = cache_->refreshStats();
+  EXPECT_EQ(warmCacheStats.numEntries, coldCacheStats.numEntries);
+  EXPECT_GT(warmCacheStats.numHit, coldCacheStats.numHit);
+  EXPECT_EQ(warmCacheStats.numNew, coldCacheStats.numNew);
+  EXPECT_EQ(warmCacheStats.numEvict, 0);
 }
 
-TEST_F(TabletTest, fileLayoutSkipsPostScriptIo) {
-  // Test that FileLayout path skips postscript IO and reads exactly the
-  // footer size.
+INSTANTIATE_TEST_SUITE_P(
+    BufferedInputModes,
+    TabletTest,
+    ::testing::Values(
+        BufferedInputMode::kNone,
+        BufferedInputMode::kBufferedInput,
+        BufferedInputMode::kDirectBufferedInput,
+        BufferedInputMode::kCachedBufferedInput),
+    [](const ::testing::TestParamInfo<BufferedInputMode>& info) {
+      return bufferedInputModeToString(info.param);
+    });
+
+// Stress test: concurrent readers with mixed BufferedInput modes and periodic
+// cache eviction. Exercises race conditions between cache population, cache
+// eviction, and reader initialization.
+TEST(TabletStressTest, concurrentReadersWithCacheEviction) {
+  velox::memory::MemoryManager::testingSetInstance({});
+  auto pool =
+      velox::memory::MemoryManager::getInstance()->addRootPool("stressTest");
+
+  // Write a file with multiple stripes.
   std::string file;
-  velox::InMemoryWriteFile writeFile(&file);
-  nimble::Buffer buffer(*pool_);
+  {
+    auto writerPool = pool->addLeafChild("writer");
+    velox::InMemoryWriteFile writeFile(&file);
+    nimble::Buffer buffer(*writerPool);
+    auto tabletWriter =
+        nimble::TabletWriter::create(&writeFile, *writerPool, {});
+    constexpr int kNumStripes = 5;
+    for (int i = 0; i < kNumStripes; ++i) {
+      std::vector<nimble::Stream> streams;
+      const auto size = 200;
+      auto pos = buffer.reserve(size);
+      std::memset(pos, 'a' + i, size);
+      streams.push_back({
+          .offset = 0,
+          .chunks =
+              {{.rowCount = 200, .content = {std::string_view(pos, size)}}},
+      });
+      tabletWriter->writeStripe(200, std::move(streams));
+    }
+    tabletWriter->close();
+    writeFile.close();
+  }
 
-  auto tabletWriter = nimble::TabletWriter::create(&writeFile, *pool_, {});
+  auto readFile = std::make_shared<velox::InMemoryReadFile>(file);
 
-  std::vector<nimble::Stream> streams;
-  const auto size = 100;
-  auto pos = buffer.reserve(size);
-  std::memset(pos, 'a', size);
-  streams.push_back({
-      .offset = 0,
-      .chunks = {{.content = {std::string_view(pos, size)}}},
+  // Shared cache infrastructure.
+  auto allocator = std::make_shared<velox::memory::MallocAllocator>(
+      1UL << 30, 0 /* reservationByteLimit */);
+  auto cache = velox::cache::AsyncDataCache::create(allocator.get());
+  auto executor = std::make_unique<folly::CPUThreadPoolExecutor>(4);
+
+  constexpr int kNumReaderThreads = 8;
+  constexpr auto kTestDuration = std::chrono::seconds(20);
+  std::atomic_bool stop{false};
+  std::atomic_uint64_t readCount{0};
+
+  auto readerFunc = [&](int threadId) {
+    auto threadPool = pool->addLeafChild(fmt::format("reader_{}", threadId));
+    auto& ids = velox::fileIds();
+
+    while (!stop.load(std::memory_order_relaxed)) {
+      // Each thread cycles through a fixed BufferedInput mode.
+      auto mode = static_cast<BufferedInputMode>(threadId % 4);
+      std::unique_ptr<velox::dwio::common::BufferedInput> bi;
+      auto ioStats = std::make_shared<velox::dwio::common::IoStatistics>();
+      std::shared_ptr<velox::cache::ScanTracker> tracker;
+      velox::io::ReaderOptions readerOptions(threadPool.get());
+      nimble::TabletReader::Options options;
+
+      switch (mode) {
+        case BufferedInputMode::kNone:
+          break;
+
+        case BufferedInputMode::kBufferedInput:
+          bi = std::make_unique<velox::dwio::common::BufferedInput>(
+              readFile, *threadPool);
+          options.bufferedInput = bi.get();
+          break;
+
+        case BufferedInputMode::kDirectBufferedInput: {
+          tracker = std::make_shared<velox::cache::ScanTracker>(
+              "tracker", nullptr, 256 << 10);
+          velox::StringIdLease fileId(ids, fmt::format("stress_{}", threadId));
+          velox::StringIdLease groupId(ids, "stressGroup");
+          bi = std::make_unique<velox::dwio::common::DirectBufferedInput>(
+              readFile,
+              velox::dwio::common::MetricsLog::voidLog(),
+              std::move(fileId),
+              tracker,
+              std::move(groupId),
+              ioStats,
+              nullptr,
+              executor.get(),
+              readerOptions);
+          options.bufferedInput = bi.get();
+          break;
+        }
+
+        case BufferedInputMode::kCachedBufferedInput: {
+          tracker = std::make_shared<velox::cache::ScanTracker>(
+              "tracker", nullptr, 256 << 10);
+          velox::StringIdLease fileId(ids, "stressFile");
+          velox::StringIdLease groupId(ids, "stressGroup");
+          bi = std::make_unique<velox::dwio::common::CachedBufferedInput>(
+              readFile,
+              velox::dwio::common::MetricsLog::voidLog(),
+              std::move(fileId),
+              cache.get(),
+              tracker,
+              std::move(groupId),
+              ioStats,
+              nullptr,
+              executor.get(),
+              readerOptions);
+          options.bufferedInput = bi.get();
+          break;
+        }
+      }
+
+      auto reader = nimble::TabletReader::create(
+          readFile.get(), threadPool.get(), options);
+      EXPECT_EQ(reader->stripeCount(), 5);
+      EXPECT_EQ(reader->tabletRowCount(), 1000);
+
+      // Verify stripe data is accessible.
+      for (uint32_t i = 0; i < reader->stripeCount(); ++i) {
+        auto stripeId = reader->stripeIdentifier(i);
+        EXPECT_NE(stripeId.stripeGroup(), nullptr);
+      }
+      readCount.fetch_add(1, std::memory_order_relaxed);
+    }
+  };
+
+  // Start reader threads.
+  std::vector<std::thread> threads;
+  for (int i = 0; i < kNumReaderThreads; ++i) {
+    threads.emplace_back(readerFunc, i);
+  }
+
+  // Control thread: periodically evict all cache entries to force transitions
+  // between warm and cold init paths.
+  auto controlThread = std::thread([&] {
+    while (!stop.load(std::memory_order_relaxed)) {
+      std::this_thread::sleep_for(std::chrono::milliseconds(100));
+      cache->shrink(1);
+    }
   });
-  tabletWriter->writeStripe(800, std::move(streams));
-  tabletWriter->close();
-  writeFile.close();
 
-  // Get layout using FileLayout::create()
-  velox::InMemoryReadFile layoutReadFile(file);
-  auto layout = nimble::FileLayout::create(&layoutReadFile, pool_.get());
+  std::this_thread::sleep_for(kTestDuration);
+  stop.store(true, std::memory_order_relaxed);
 
-  // Calculate expected read size: footer + stripes section + postscript
-  const uint64_t expectedReadSize =
-      layout.footer.size() + nimble::kPostscriptSize + layout.stripes.size();
-  const uint64_t expectedReadOffset = file.size() - expectedReadSize;
+  for (auto& t : threads) {
+    t.join();
+  }
+  controlThread.join();
 
-  // Read using FileLayout - should do a single read for exact footer size
-  nimble::testing::InMemoryTrackableReadFile readFile(file, false);
-  nimble::TabletReader::Options options;
-  options.fileLayout = layout;
-  options.footerIoBytes = expectedReadSize; // Exact size, no extra coalescing
-  auto tablet = nimble::TabletReader::create(&readFile, pool_.get(), options);
+  LOG(INFO) << "Stress test: " << readCount.load() << " successful reads in "
+            << kTestDuration.count() << "s";
+  EXPECT_GT(readCount.load(), 0);
 
-  // Verify the tablet was created correctly
-  EXPECT_EQ(tablet->stripeCount(), 1);
-  EXPECT_EQ(tablet->stripeRowCount(0), 800);
-
-  // Verify IO pattern: with FileLayout, we should have exactly 1 read
-  // at the exact offset and size (no postscript discovery read)
-  auto chunks = readFile.chunks();
-  ASSERT_EQ(chunks.size(), 1);
-  EXPECT_EQ(chunks[0].offset, expectedReadOffset);
-  EXPECT_EQ(chunks[0].size, expectedReadSize);
-
-  // Compare with non-FileLayout path (adaptive mode) which does multiple reads:
-  // 1. First read: just the postscript (20 bytes)
-  // 2. Second read: footer + postscript
-  // 3. Potentially more reads if stripes section needs to be fetched
-  nimble::testing::InMemoryTrackableReadFile readFile2(file, false);
-  nimble::TabletReader::Options options2;
-  options2.footerIoBytes = 0; // Adaptive mode
-  auto tablet2 =
-      nimble::TabletReader::create(&readFile2, pool_.get(), options2);
-
-  auto chunks2 = readFile2.chunks();
-  // Adaptive mode does at least 2 reads (postscript discovery + footer)
-  EXPECT_GE(chunks2.size(), 2);
-  // First read is just the postscript (20 bytes at end of file)
-  EXPECT_EQ(chunks2[0].offset, file.size() - nimble::kPostscriptSize);
-  EXPECT_EQ(chunks2[0].size, nimble::kPostscriptSize);
-
-  // Key verification: FileLayout path (1 read) is more efficient than
-  // adaptive mode (>= 2 reads)
-  EXPECT_LT(chunks.size(), chunks2.size());
-
-  // Test with 8MB footerIoBytes (or entire file size) - speculative mode
-  // should also read everything in one IO when buffer is large enough
-  nimble::testing::InMemoryTrackableReadFile readFile3(file, false);
-  nimble::TabletReader::Options options3;
-  options3.footerIoBytes = 8 * 1024 * 1024; // 8MB - larger than file
-  auto tablet3 =
-      nimble::TabletReader::create(&readFile3, pool_.get(), options3);
-
-  auto chunks3 = readFile3.chunks();
-  // With large footerIoBytes, speculative mode reads entire file in one IO
-  ASSERT_EQ(chunks3.size(), 1);
-  // Should read the entire file (or at least footerIoBytes from the end)
-  EXPECT_EQ(chunks3[0].offset, 0);
-  EXPECT_EQ(chunks3[0].size, file.size());
+  cache->shutdown();
 }
+
 } // namespace

--- a/dwio/nimble/tablet/tests/TabletTestUtils.h
+++ b/dwio/nimble/tablet/tests/TabletTestUtils.h
@@ -45,7 +45,7 @@ class TabletReaderTestHelper {
 
   /// Returns true if the stripe group at the given index is cached.
   bool hasStripeGroupCached(uint32_t groupIndex) const {
-    return tabletReader_->stripeGroupCache_.testingHasCachedEntry(groupIndex);
+    return tabletReader_->stripeGroupCache_.hasCachedEntry(groupIndex);
   }
 
   /// Returns true if the first stripe group is cached and it's the only one.
@@ -63,7 +63,7 @@ class TabletReaderTestHelper {
 
   /// Returns true if the index group at the given index is cached.
   bool hasIndexGroupCached(uint32_t groupIndex) const {
-    return tabletReader_->indexGroupCache_.testingHasCachedEntry(groupIndex);
+    return tabletReader_->indexGroupCache_.hasCachedEntry(groupIndex);
   }
 
   /// Returns true if the first index group is cached and it's the only one.
@@ -82,6 +82,12 @@ class TabletReaderTestHelper {
       offsets.push_back(tabletReader_->stripeOffsets_[i]);
     }
     return offsets;
+  }
+
+  // Returns true if this reader is backed by a BufferedInput with Velox
+  // async data cache.
+  bool hasCache() const {
+    return tabletReader_->hasCache();
   }
 
   /// Returns the stripe sizes array.

--- a/dwio/nimble/velox/selective/ReaderBase.cpp
+++ b/dwio/nimble/velox/selective/ReaderBase.cpp
@@ -56,12 +56,14 @@ TypePtr getFileSchema(
 std::shared_ptr<ReaderBase> ReaderBase::create(
     std::unique_ptr<velox::dwio::common::BufferedInput> input,
     const velox::dwio::common::ReaderOptions& options) {
-  // Initialize all members
+  // Initialize tablet reader options with BufferedInput for metadata IO.
+  auto tabletOptions = defaultTabletReaderOptions();
+  if (options.fileMetadataCacheEnabled()) {
+    tabletOptions.bufferedInput = input.get();
+  }
+
   auto tablet = TabletReader::create(
-      // TODO: Make TabletReader taking BufferedInput.
-      input->getReadFile().get(),
-      &options.memoryPool(),
-      defaultTabletReaderOptions());
+      input->getReadFile().get(), &options.memoryPool(), tabletOptions);
 
   auto* pool = &options.memoryPool();
   const auto& randomSkip = options.randomSkip();


### PR DESCRIPTION
Summary:
CONTEXT:
TabletReader performs metadata reads (stripe groups, index groups, optional
sections) via direct file->preadv() calls, bypassing BufferedInput's caching
and coalescing capabilities. When BufferedInput has a backing cache (e.g.,
CachedBufferedInput with AsyncDataCache), these reads should go through
BufferedInput for cache integration. Additionally, TabletReader passes
fileSize as a parameter through many private methods unnecessarily.

WHAT:
1. **Cache warm path (zero-IO init)**:
   - Add maybeInitWithCache() — probes AsyncDataCache for footer+PS at
     synthetic offset=fileSize, stripes, stripe groups, and index groups.
     If all hit, initializes with zero file IO.
   - Add tryInitPostScriptAndFooterFromCache() — parses PS and footer
     directly from CachedRegion buffer ranges (zero-copy via Cursor).
   - Add cacheMetadata() — after cold-path tail read, breaks the IOBuf
     into exact-size cache entries (footer+PS, stripes, stripe group,
     index group) for subsequent readers.

2. **BufferedInput integration for metadata reads**:
   - Add readMetadata(MetadataSection, LogType) — reads from BufferedInput
     when available, falls back to direct file read.
   - Add readMetadata(SeekableInputStream, MetadataSection) — for
     pre-loaded streams from the enqueue/load pattern.
   - Eliminates the ReadData class and simplifies all metadata read sites.

3. **Coalesced stripe group + index group reads**:
   - Add loadStripeAndIndexGroup() — enqueues both using BufferedInput's
     enqueue/load pattern so adjacent regions are coalesced into one IO.

4. **Optional section preloading via BufferedInput**:
   - Add enqueueOptionalSections() / loadEnqueuedOptionalSections() —
     enqueues optional sections for coalesced loading via BufferedInput.

5. **Remove FileLayout-based init path**:
   - Remove Options::fileLayout, maybeInitWithFileLayout(), and
     Postscript::create(const FileLayout&). The cache warm path
     supersedes this — it provides zero-IO init without needing an
     external coordinator to supply a FileLayout.
   - Remove 3 related tests (readerOptionsFileLayoutPath,
     readerOptionsFileLayoutMismatch, fileLayoutSkipsPostScriptIo).

6. **Cache fileSize as member variable**:
   - Add fileSize_ member, set once in init() from file_->size().
   - Remove fileSize parameter from 7 private methods: maybeInitWithCache,
     tryInitPostScriptAndFooterFromCache, cacheMetadata,
     initPostScriptAndFooter, initStripes, preloadStripeGroup,
     preloadIndexGroup.

7. **Parameterized test infrastructure**:
   - Add BufferedInputMode enum (kNone, kBufferedInput,
     kDirectBufferedInput, kCachedBufferedInput) for test parameterization.
   - All existing tests run across all 4 modes.
   - Add cacheWarmPath test verifying cold→warm reader flow.

Note: Both cache layers serve different purposes:
- BufferedInput cache: Raw compressed bytes (avoid re-reading from disk)
- ReferenceCountedCache: Decompressed/parsed metadata (avoid re-parsing)

Differential Revision: D94539731


