### PR TITLE
feat: Add option to collect column decoding time for selective readers

### DIFF
--- a/dwio/nimble/velox/selective/FlatMapColumnReader.cpp
+++ b/dwio/nimble/velox/selective/FlatMapColumnReader.cpp
@@ -326,7 +326,7 @@ class FlatMapColumnReader
       advanceFieldReader(child, offset);
     }
     for (auto* child : children_) {
-      child->read(offset, activeRows, mapNulls);
+      child->readWithTiming(offset, activeRows, mapNulls);
       child->addParentNulls(offset, mapNulls, rows);
     }
     readOffset_ = offset + rows.back() + 1;


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebookincubator/velox/pull/16635

Add per-column decode CPU time collection to selective readers. When collectColumnStats is enabled, tracks decode timing for primitive type columns alongside existing decompression metrics. Exports as column.<type>.<nodeId>.decodeCPUTimeNanos runtime metrics for performance analysis.

Reviewed By: Yuhta

Differential Revision: D94554467


