### PR TITLE
Explicitly mark OptimizeStringBufferHandling.testScalarFieldLifeCycle tests as disabled

### DIFF
--- a/dwio/nimble/velox/tests/VeloxReaderTest.cpp
+++ b/dwio/nimble/velox/tests/VeloxReaderTest.cpp
@@ -4942,7 +4942,7 @@ TEST_P(VeloxReaderTest, rangeReads) {
   });
 }
 
-TEST_P(VeloxReaderTest, testScalarFieldLifeCycle) {
+TEST_P(VeloxReaderTest, DISABLED_testScalarFieldLifeCycle) {
   const auto testScalarFieldLifeCycle =
       [&](const std::shared_ptr<const velox::RowType> schema,
           int32_t batchSize,


### PR DESCRIPTION
Summary:
title

see https://docs.google.com/document/d/1EAUuP7_Qz_CBu41KY_W-dvPmTde53LsDrBQq0ZQsOaU/edit?usp=sharing

Reviewed By: HuamengJiang

Differential Revision: D94968881


