### PR TITLE
Use emplace_back for ProjectedStream

### DIFF
--- a/dwio/nimble/serializer/Projector.cpp
+++ b/dwio/nimble/serializer/Projector.cpp
@@ -362,7 +362,7 @@ void resolveSubfield(
 
 using OffsetMap = folly::F14FastMap<uint32_t, uint32_t>;
 
-uint32_t mapOffset(const OffsetMap& offsetMap, uint32_t inputOffset) {
+inline uint32_t mapOffset(const OffsetMap& offsetMap, uint32_t inputOffset) {
   const auto it = offsetMap.find(inputOffset);
   NIMBLE_CHECK(
       it != offsetMap.end(),

--- a/dwio/nimble/serializer/SerializerImpl.h
+++ b/dwio/nimble/serializer/SerializerImpl.h
@@ -252,6 +252,8 @@ struct ProjectedStream {
   uint32_t index;
   std::string_view data;
 
+  ProjectedStream(uint32_t idx, std::string_view d) : index(idx), data(d) {}
+
   bool operator<(const ProjectedStream& other) const {
     return index < other.index;
   }
@@ -315,7 +317,7 @@ inline std::vector<ProjectedStream> projectStreams(
       if (streamIdx == selectedStreamIndices[nextProjected]) {
         auto data = readStream<false>(pos);
         if (!data.empty()) {
-          streams.emplace_back(ProjectedStream{nextProjected, data});
+          streams.emplace_back(nextProjected, data);
         }
         ++nextProjected;
       } else {


### PR DESCRIPTION
Summary: Added constructor to ProjectedStream and switched from push_back to emplace_back for in-place construction.

Differential Revision: D95412784


