### PR TITLE
feat(selective): Fixed bit width encoding bulk scan

### DIFF
--- a/dwio/nimble/encodings/FixedBitWidthEncoding.h
+++ b/dwio/nimble/encodings/FixedBitWidthEncoding.h
@@ -63,6 +63,17 @@ class FixedBitWidthEncoding final
   template <typename DecoderVisitor>
   void readWithVisitor(DecoderVisitor& visitor, ReadWithVisitorParams& params);
 
+  // Bulk scan method for fast path decoding.
+  // Reads multiple values at once and processes them through the visitor.
+  // This is used by readWithVisitorFast for efficient batch processing.
+  template <bool kHasNulls, typename Visitor>
+  void bulkScan(
+      Visitor& visitor,
+      uint32_t nonNullsSoFar,
+      const int32_t* rows,
+      int32_t numRows,
+      const int32_t* scatterRows);
+
   static std::string_view encode(
       EncodingSelection<physicalType>& selection,
       std::span<const physicalType> values,
@@ -147,6 +158,27 @@ template <typename V>
 void FixedBitWidthEncoding<T>::readWithVisitor(
     V& visitor,
     ReadWithVisitorParams& params) {
+  // Fast path: use bulk scan for 4-byte integral types with no filter and no
+  // hook. This is common for dictionary indices (uint32_t).
+  // The fast path only supports ExtractToReader (not hooks).
+  // We also check that the output type is compatible:
+  // - Same type: direct memcpy
+  // - Widening (larger output type): loop with conversion
+  using OutputType = detail::ValueType<typename V::DataType>;
+  constexpr bool kExtractToReader =
+      std::is_same_v<typename V::Extract, velox::dwio::common::ExtractToReader>;
+  constexpr bool kSameType = std::is_same_v<physicalType, OutputType>;
+  constexpr bool kIsWidening = sizeof(OutputType) > sizeof(physicalType) &&
+      std::is_integral_v<OutputType> && std::is_integral_v<physicalType>;
+  constexpr bool kCanUseFastPath = isFourByteIntegralType<physicalType>() &&
+      !V::kHasFilter && !V::kHasHook && kExtractToReader &&
+      (kSameType || kIsWidening);
+  if constexpr (kCanUseFastPath) {
+    auto* nulls = visitor.reader().rawNullsInReadRange();
+    detail::readWithVisitorFast(*this, visitor, params, nulls);
+    return;
+  }
+  // Slow path: process one value at a time.
   detail::readWithVisitorSlow(
       visitor,
       params,
@@ -155,6 +187,77 @@ void FixedBitWidthEncoding<T>::readWithVisitor(
         physicalType value = fixedBitArray_.get(row_++) + baseline_;
         return value;
       });
+}
+
+template <typename T>
+template <bool kHasNulls, typename V>
+void FixedBitWidthEncoding<T>::bulkScan(
+    V& visitor,
+    uint32_t currentRow,
+    const int32_t* nonNullRows,
+    int32_t numNonNulls,
+    const int32_t* scatterRows) {
+  using DataType = typename V::DataType;
+  using OutputType = detail::ValueType<DataType>;
+  static_assert(
+      isFourByteIntegralType<physicalType>(),
+      "bulkScan only supports 4-byte integral types");
+
+  if (numNonNulls == 0) {
+    return;
+  }
+
+  const auto numRows = visitor.numRows() - visitor.rowIndex();
+
+  // Calculate offset between our internal position and the external row number.
+  // This handles cases where the encoding position (row_) differs from the
+  // logical row number (currentRow).
+  const auto offset =
+      static_cast<int32_t>(row_) - static_cast<int32_t>(currentRow);
+
+  // Get the output buffer.
+  auto* values = detail::mutableValues<OutputType>(visitor, numRows);
+
+  // Check type compatibility:
+  // - Same type or same-size integral types: use fast memcpy
+  //   (e.g., uint32_t vs int32_t have same bit representation)
+  // - Widening (e.g., int32 → int64): use loop with implicit conversion
+  constexpr bool kSameSize = sizeof(physicalType) == sizeof(OutputType);
+  constexpr bool kIsUpcast = sizeof(OutputType) > sizeof(physicalType) &&
+      std::is_integral_v<OutputType> && std::is_integral_v<physicalType>;
+
+  if constexpr (V::dense) {
+    // Dense case: values are contiguous, read in bulk.
+    buffer_.resize(numNonNulls);
+    fixedBitArray_.bulkGetWithBaseline32(
+        nonNullRows[0] + offset,
+        numNonNulls,
+        reinterpret_cast<uint32_t*>(buffer_.data()),
+        baseline_);
+
+    if constexpr (kSameSize) {
+      // Same size types: use fast memcpy (works for same type or
+      // signed/unsigned variants like int32_t vs uint32_t).
+      std::memcpy(values, buffer_.data(), numNonNulls * sizeof(physicalType));
+    } else if constexpr (kIsUpcast) {
+      // Widening case: copy with implicit type conversion.
+      // Compilers typically auto-vectorize this pattern.
+      for (int32_t i = 0; i < numNonNulls; ++i) {
+        values[i] = static_cast<OutputType>(buffer_[i]);
+      }
+    }
+  } else {
+    // Sparse case: read individual values at specified positions.
+    for (int32_t i = 0; i < numNonNulls; ++i) {
+      values[i] = fixedBitArray_.get(nonNullRows[i] + offset) + baseline_;
+    }
+  }
+
+  // Update row_ based on the last row read.
+  row_ += nonNullRows[numNonNulls - 1] - currentRow + 1;
+
+  visitor.addNumValues(V::dense ? numRows : numNonNulls);
+  visitor.setRowIndex(visitor.numRows());
 }
 
 template <typename T>

--- a/dwio/nimble/encodings/tests/EncodingLayoutTestHelper.cpp
+++ b/dwio/nimble/encodings/tests/EncodingLayoutTestHelper.cpp
@@ -1,0 +1,121 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "dwio/nimble/encodings/tests/EncodingLayoutTestHelper.h"
+
+#include "dwio/nimble/encodings/EncodingIdentifier.h"
+
+namespace facebook::nimble {
+
+// ===========================================================================
+// Leaf encoding conversions
+// ===========================================================================
+
+TrivialEnc::operator EncodingLayout() const {
+  return EncodingLayout(
+      EncodingType::Trivial, {}, CompressionType::Uncompressed);
+}
+
+ConstantEnc::operator EncodingLayout() const {
+  return EncodingLayout(
+      EncodingType::Constant, {}, CompressionType::Uncompressed);
+}
+
+FixedBitWidthEnc::operator EncodingLayout() const {
+  return EncodingLayout(
+      EncodingType::FixedBitWidth, {}, CompressionType::Uncompressed);
+}
+
+VarintEnc::operator EncodingLayout() const {
+  return EncodingLayout(
+      EncodingType::Varint, {}, CompressionType::Uncompressed);
+}
+
+SparseBoolEnc::operator EncodingLayout() const {
+  return EncodingLayout(
+      EncodingType::SparseBool, {}, CompressionType::Uncompressed);
+}
+
+// ===========================================================================
+// Compound encoding conversions
+// ===========================================================================
+
+RLEEnc::operator EncodingLayout() const {
+  constexpr auto kRunLengths = EncodingIdentifiers::RunLength::RunLengths;
+  constexpr auto kRunValues = EncodingIdentifiers::RunLength::RunValues;
+  static_assert(kRunLengths == 0 && kRunValues == 1);
+
+  std::vector<std::optional<const EncodingLayout>> children;
+  children.reserve(2);
+  children.emplace_back(runLengths);
+  children.emplace_back(runValues);
+  return EncodingLayout(
+      EncodingType::RLE,
+      {},
+      CompressionType::Uncompressed,
+      std::move(children));
+}
+
+DictionaryEnc::operator EncodingLayout() const {
+  constexpr auto kAlphabet = EncodingIdentifiers::Dictionary::Alphabet;
+  constexpr auto kIndices = EncodingIdentifiers::Dictionary::Indices;
+  static_assert(kAlphabet == 0 && kIndices == 1);
+
+  std::vector<std::optional<const EncodingLayout>> children;
+  children.reserve(2);
+  children.emplace_back(alphabet);
+  children.emplace_back(indices);
+  return EncodingLayout(
+      EncodingType::Dictionary,
+      {},
+      CompressionType::Uncompressed,
+      std::move(children));
+}
+
+MainlyConstantEnc::operator EncodingLayout() const {
+  constexpr auto kIsCommon = EncodingIdentifiers::MainlyConstant::IsCommon;
+  constexpr auto kOtherValues =
+      EncodingIdentifiers::MainlyConstant::OtherValues;
+  static_assert(kIsCommon == 0 && kOtherValues == 1);
+
+  std::vector<std::optional<const EncodingLayout>> children;
+  children.reserve(2);
+  children.emplace_back(isCommon);
+  children.emplace_back(otherValues);
+  return EncodingLayout(
+      EncodingType::MainlyConstant,
+      {},
+      CompressionType::Uncompressed,
+      std::move(children));
+}
+
+NullableEnc::operator EncodingLayout() const {
+  constexpr auto kData = EncodingIdentifiers::Nullable::Data;
+  constexpr auto kNulls = EncodingIdentifiers::Nullable::Nulls;
+  static_assert(kData == 0 && kNulls == 1);
+
+  std::vector<std::optional<const EncodingLayout>> children;
+  children.reserve(2);
+  children.emplace_back(data);
+  children.emplace_back(nulls);
+  return EncodingLayout(
+      EncodingType::Nullable,
+      {},
+      CompressionType::Uncompressed,
+      std::move(children));
+}
+
+} // namespace facebook::nimble

--- a/dwio/nimble/encodings/tests/EncodingLayoutTestHelper.h
+++ b/dwio/nimble/encodings/tests/EncodingLayoutTestHelper.h
@@ -1,0 +1,167 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include "dwio/nimble/encodings/EncodingFactory.h"
+#include "dwio/nimble/encodings/EncodingLayout.h"
+#include "dwio/nimble/encodings/EncodingSelection.h"
+#include "dwio/nimble/encodings/EncodingSelectionPolicy.h"
+
+namespace facebook::nimble {
+
+// ===========================================================================
+// Leaf encoding structs (no children)
+// ===========================================================================
+
+struct TrivialEnc {
+  operator EncodingLayout() const;
+};
+
+struct ConstantEnc {
+  operator EncodingLayout() const;
+};
+
+struct FixedBitWidthEnc {
+  operator EncodingLayout() const;
+};
+
+struct VarintEnc {
+  operator EncodingLayout() const;
+};
+
+struct SparseBoolEnc {
+  operator EncodingLayout() const;
+};
+
+// ===========================================================================
+// Compound encoding structs (with named children, defaulting to TrivialEnc{})
+// ===========================================================================
+
+struct RLEEnc {
+  EncodingLayout runLengths = TrivialEnc{};
+  EncodingLayout runValues = TrivialEnc{};
+  operator EncodingLayout() const;
+};
+
+struct DictionaryEnc {
+  EncodingLayout alphabet = TrivialEnc{};
+  EncodingLayout indices = TrivialEnc{};
+  operator EncodingLayout() const;
+};
+
+struct MainlyConstantEnc {
+  EncodingLayout isCommon = TrivialEnc{};
+  EncodingLayout otherValues = TrivialEnc{};
+  operator EncodingLayout() const;
+};
+
+struct NullableEnc {
+  EncodingLayout data = TrivialEnc{};
+  EncodingLayout nulls = TrivialEnc{};
+  operator EncodingLayout() const;
+};
+
+// ===========================================================================
+// TrivialNestedPolicy — always selects Trivial for nested sub-streams.
+// ===========================================================================
+
+template <typename T>
+class TrivialNestedPolicy : public EncodingSelectionPolicy<T> {
+  using physicalType = typename TypeTraits<T>::physicalType;
+
+ public:
+  EncodingSelectionResult select(
+      std::span<const physicalType>,
+      const Statistics<physicalType>&) override {
+    return {.encodingType = EncodingType::Trivial};
+  }
+  EncodingSelectionResult selectNullable(
+      std::span<const physicalType>,
+      std::span<const bool>,
+      const Statistics<physicalType>&) override {
+    return {.encodingType = EncodingType::Nullable};
+  }
+  std::unique_ptr<EncodingSelectionPolicyBase>
+  createImpl(EncodingType, NestedEncodingIdentifier, DataType type) override {
+    UNIQUE_PTR_FACTORY(type, TrivialNestedPolicy);
+  }
+};
+
+// ===========================================================================
+// createFromCustomLayout — encode data using an EncodingLayout tree.
+// ===========================================================================
+
+template <typename T>
+std::unique_ptr<Encoding> createFromCustomLayout(
+    const EncodingLayout& layout,
+    const std::vector<T>& data,
+    velox::memory::MemoryPool& pool,
+    Buffer& buffer) {
+  auto policy = std::make_unique<ReplayedEncodingSelectionPolicy<T>>(
+      layout,
+      CompressionOptions{},
+      [](DataType type) -> std::unique_ptr<EncodingSelectionPolicyBase> {
+        UNIQUE_PTR_FACTORY(type, TrivialNestedPolicy);
+      });
+  auto encoded = EncodingFactory::encode<T>(
+      std::move(policy), std::span<const T>(data.data(), data.size()), buffer);
+  return EncodingFactory::decode(pool, encoded, nullptr);
+}
+
+// ===========================================================================
+// createNullableFromCustomLayout — encode nullable data using a layout for
+// the non-null values child.
+// ===========================================================================
+
+template <typename T>
+std::unique_ptr<Encoding> createNullableFromCustomLayout(
+    const EncodingLayout& dataLayout,
+    const std::vector<std::optional<T>>& data,
+    velox::memory::MemoryPool& pool,
+    Buffer& buffer) {
+  using physicalType = typename TypeTraits<T>::physicalType;
+
+  std::vector<physicalType> nonNullValues;
+  Vector<bool> nulls(&pool);
+  nulls.resize(data.size());
+  for (size_t i = 0; i < data.size(); ++i) {
+    nulls[i] = data[i].has_value();
+    if (data[i].has_value()) {
+      nonNullValues.push_back(
+          reinterpret_cast<const physicalType&>(data[i].value()));
+    }
+  }
+
+  std::span<const physicalType> valuesSpan(
+      nonNullValues.data(), nonNullValues.size());
+  std::span<const bool> nullsSpan(nulls.data(), nulls.size());
+
+  NullableEnc nullableEnc{.data = dataLayout};
+  EncodingLayout nullableLayout = nullableEnc;
+
+  auto policy = std::make_unique<ReplayedEncodingSelectionPolicy<T>>(
+      nullableLayout,
+      CompressionOptions{},
+      [](DataType type) -> std::unique_ptr<EncodingSelectionPolicyBase> {
+        UNIQUE_PTR_FACTORY(type, TrivialNestedPolicy);
+      });
+
+  auto encoded = EncodingFactory::encodeNullable<T>(
+      std::move(policy), valuesSpan, nullsSpan, buffer);
+  return EncodingFactory::decode(pool, encoded, nullptr);
+}
+
+} // namespace facebook::nimble

--- a/dwio/nimble/encodings/tests/ReadWithVisitorTest.cpp
+++ b/dwio/nimble/encodings/tests/ReadWithVisitorTest.cpp
@@ -1,0 +1,1643 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Tests that exercise readWithVisitor code paths by constructing real
+// SelectiveColumnReader instances via buildColumnReader and calling read()
+// directly.  This bypasses the RowReader::next() pipeline while still using
+// the full encoding → ChunkedDecoder → readWithVisitor chain.
+//
+// Data patterns are chosen to exercise specific encoding types:
+//   constant → ConstantEncoding
+//   sequential/random → FixedBitWidthEncoding / TrivialEncoding
+//   repeated runs → RLEEncoding
+//   nullable wrappers → NullableEncoding
+
+#include <gtest/gtest.h>
+
+#include "dwio/nimble/common/Buffer.h"
+#include "dwio/nimble/common/tests/NimbleFileWriter.h"
+#include "dwio/nimble/encodings/EncodingFactory.h"
+#include "dwio/nimble/encodings/EncodingUtils.h"
+#include "dwio/nimble/encodings/tests/EncodingLayoutTestHelper.h"
+#include "dwio/nimble/velox/selective/ByteColumnReader.h"
+#include "dwio/nimble/velox/selective/ColumnReader.h"
+#include "dwio/nimble/velox/selective/IntegerColumnReader.h"
+#include "dwio/nimble/velox/selective/NimbleData.h"
+#include "dwio/nimble/velox/selective/ReaderBase.h"
+#include "dwio/nimble/velox/selective/RowSizeTracker.h"
+#include "dwio/nimble/velox/selective/StringColumnReader.h"
+#include "velox/dwio/common/ColumnVisitors.h"
+#include "velox/dwio/common/SelectiveColumnReader.h"
+#include "velox/dwio/common/SelectiveStructColumnReader.h"
+#include "velox/vector/tests/utils/VectorTestBase.h"
+
+namespace facebook::nimble {
+namespace {
+
+using namespace facebook::velox;
+
+// ---------------------------------------------------------------------------
+// Test-only accessor: exposes protected prepareRead and readOffset_ so that
+// tests can call readWithVisitor explicitly with a hand-built ColumnVisitor.
+// No new data members — static_cast from the real IntegerColumnReader* is
+// layout-safe.
+// ---------------------------------------------------------------------------
+class IntegerColumnReaderTestAccessor : public IntegerColumnReader {
+ public:
+  using IntegerColumnReader::IntegerColumnReader;
+
+  template <typename T>
+  void
+  doPrepareRead(int64_t offset, const RowSet& rows, const uint64_t* nulls) {
+    this->template prepareRead<T>(offset, rows, nulls);
+  }
+
+  void advanceReadOffset(const RowSet& rows) {
+    readOffset_ += rows.back() + 1;
+  }
+};
+
+// ---------------------------------------------------------------------------
+// Test fixture
+// ---------------------------------------------------------------------------
+class ReadWithVisitorTest : public ::testing::Test,
+                            public velox::test::VectorTestBase {
+ protected:
+  static void SetUpTestCase() {
+    memory::initializeMemoryManager(memory::MemoryManager::Options{});
+  }
+
+  // Holds the infrastructure needed to build column readers for a single file.
+  struct FileContext {
+    std::string fileData;
+    std::shared_ptr<ReaderBase> readerBase;
+    std::unique_ptr<StripeStreams> streams;
+    dwio::common::ColumnReaderStatistics stats;
+    std::unique_ptr<RowSizeTracker> rowSizeTracker;
+  };
+
+  // Write |input| to an in-memory nimble file and prepare the stripe for
+  // reading.  Returns a heap-allocated context to avoid copy/move issues.
+  std::unique_ptr<FileContext> makeFileContext(const RowVectorPtr& input) {
+    auto ctx = std::make_unique<FileContext>();
+    ctx->fileData = test::createNimbleFile(*rootPool_, input);
+
+    auto readFile = std::make_shared<InMemoryReadFile>(ctx->fileData);
+    dwio::common::ReaderOptions readerOpts(pool());
+    ctx->readerBase = ReaderBase::create(
+        std::make_unique<dwio::common::BufferedInput>(readFile, *pool()),
+        readerOpts);
+
+    ctx->streams = std::make_unique<StripeStreams>(ctx->readerBase);
+    ctx->streams->setStripe(0);
+
+    ctx->rowSizeTracker =
+        std::make_unique<RowSizeTracker>(ctx->readerBase->fileSchemaWithId());
+
+    return ctx;
+  }
+
+  // Build a struct column reader (root) for the given schema + scanSpec.
+  // Returns the root reader; its children() are the individual column
+  // readers whose read() we want to exercise.
+  std::unique_ptr<dwio::common::SelectiveColumnReader> buildReader(
+      FileContext& ctx,
+      const RowTypePtr& rowType,
+      common::ScanSpec& scanSpec) {
+    NimbleParams params(
+        *pool(),
+        ctx.stats,
+        ctx.readerBase->nimbleSchema(),
+        *ctx.streams,
+        ctx.rowSizeTracker.get(),
+        [](memory::MemoryPool& pool,
+           std::string_view data,
+           std::function<void*(uint32_t)> sbf) -> std::unique_ptr<Encoding> {
+          return EncodingFactory::decode(pool, data, std::move(sbf));
+        });
+
+    auto reader = buildColumnReader(
+        rowType,
+        ctx.readerBase->fileSchemaWithId(),
+        params,
+        scanSpec,
+        /*isRoot=*/true);
+    reader->setIsTopLevel();
+    ctx.streams->load();
+    return reader;
+  }
+
+  // Build root reader, get its first child, call read(), return child.
+  // Caller inspects outputRows / numValues / rawValues / hasNulls on it.
+  dwio::common::SelectiveColumnReader* readColumn(
+      dwio::common::SelectiveColumnReader* root,
+      int numRows) {
+    // RowSet: sequential [0 .. numRows-1]
+    std::vector<vector_size_t> rowVec(numRows);
+    std::iota(rowVec.begin(), rowVec.end(), 0);
+    RowSet rows(rowVec.data(), rowVec.size());
+
+    // Trigger read on the root struct reader which calls read() on children.
+    root->read(0, rows, nullptr);
+
+    auto* structReader =
+        dynamic_cast<dwio::common::SelectiveStructColumnReaderBase*>(root);
+    EXPECT_NE(structReader, nullptr);
+    EXPECT_FALSE(structReader->children().empty());
+    return structReader->children()[0];
+  }
+
+  // Helper: get typed values from a column reader after read().
+  template <typename T>
+  std::vector<T> getValues(dwio::common::SelectiveColumnReader* reader) {
+    auto* raw = reinterpret_cast<const T*>(reader->rawValues());
+    return std::vector<T>(raw, raw + reader->numValues());
+  }
+};
+
+// ===========================================================================
+// Test: Dense read, no filter, sequential int64 data (no nulls)
+// Exercises TrivialEncoding / FixedBitWidthEncoding readWithVisitor with
+// AlwaysTrue filter.
+// ===========================================================================
+TEST_F(ReadWithVisitorTest, denseNoFilterNoNulls) {
+  constexpr int kRows = 200;
+  auto input = makeRowVector(
+      {makeFlatVector<int64_t>(kRows, [](auto i) { return i * 7; })});
+  auto rowType = asRowType(input->type());
+
+  auto ctx = makeFileContext(input);
+  auto scanSpec = std::make_shared<common::ScanSpec>("root");
+  scanSpec->addAllChildFields(*rowType);
+  // AlwaysTrue filter forces read() instead of lazy-loading the child.
+  // This exercises the same readWithVisitor<AlwaysTrue> code path.
+  scanSpec->childByName("c0")->setFilter(
+      std::make_unique<common::AlwaysTrue>());
+
+  auto root = buildReader(*ctx, rowType, *scanSpec);
+  auto* child = readColumn(root.get(), kRows);
+
+  EXPECT_EQ(child->numValues(), kRows);
+  auto values = getValues<int64_t>(child);
+  for (int i = 0; i < kRows; ++i) {
+    EXPECT_EQ(values[i], i * 7) << "row " << i;
+  }
+}
+
+// ===========================================================================
+// Test: Dense read, no filter, nullable int64 (exercises NullableEncoding)
+// ===========================================================================
+TEST_F(ReadWithVisitorTest, denseNoFilterWithNulls) {
+  constexpr int kRows = 200;
+  auto input = makeRowVector(
+      {makeFlatVector<int64_t>(kRows, folly::identity, nullEvery(7))});
+  auto rowType = asRowType(input->type());
+
+  auto ctx = makeFileContext(input);
+  auto scanSpec = std::make_shared<common::ScanSpec>("root");
+  scanSpec->addAllChildFields(*rowType);
+  scanSpec->childByName("c0")->setFilter(
+      std::make_unique<common::AlwaysTrue>());
+
+  auto root = buildReader(*ctx, rowType, *scanSpec);
+  auto* child = readColumn(root.get(), kRows);
+
+  // Every row is "output" since there is no filter.
+  EXPECT_EQ(child->numValues(), kRows);
+  EXPECT_TRUE(child->hasNulls());
+}
+
+// ===========================================================================
+// Test: BigintRange filter, sequential data — sparse visitor output
+// ===========================================================================
+TEST_F(ReadWithVisitorTest, sparseWithBigintRange) {
+  constexpr int kRows = 500;
+  auto input = makeRowVector({makeFlatVector<int64_t>(kRows, folly::identity)});
+  auto rowType = asRowType(input->type());
+
+  auto ctx = makeFileContext(input);
+  auto scanSpec = std::make_shared<common::ScanSpec>("root");
+  scanSpec->addAllChildFields(*rowType);
+  scanSpec->childByName("c0")->setFilter(
+      std::make_unique<common::BigintRange>(100, 200, false));
+
+  auto root = buildReader(*ctx, rowType, *scanSpec);
+  auto* child = readColumn(root.get(), kRows);
+
+  // Exactly rows [100..200] pass the filter → 101 values.
+  EXPECT_EQ(child->numValues(), 101);
+  auto rows = child->outputRows();
+  EXPECT_EQ(rows[0], 100);
+  EXPECT_EQ(rows[rows.size() - 1], 200);
+}
+
+// ===========================================================================
+// Test: BigintRange filter + nullable data — filter skips nulls
+// ===========================================================================
+TEST_F(ReadWithVisitorTest, rangeFilterWithNulls) {
+  constexpr int kRows = 500;
+  auto c0 = makeFlatVector<int64_t>(kRows, folly::identity, nullEvery(7));
+  auto input = makeRowVector({c0});
+  auto rowType = asRowType(input->type());
+
+  auto ctx = makeFileContext(input);
+  auto scanSpec = std::make_shared<common::ScanSpec>("root");
+  scanSpec->addAllChildFields(*rowType);
+  scanSpec->childByName("c0")->setFilter(
+      std::make_unique<common::BigintRange>(50, 300, false));
+
+  auto root = buildReader(*ctx, rowType, *scanSpec);
+  auto* child = readColumn(root.get(), kRows);
+
+  // Count expected: value in [50,300] AND not null.
+  int expected = 0;
+  for (int i = 0; i < kRows; ++i) {
+    if (!c0->isNullAt(i) && c0->valueAt(i) >= 50 && c0->valueAt(i) <= 300) {
+      ++expected;
+    }
+  }
+  EXPECT_EQ(child->numValues(), expected);
+}
+
+// ===========================================================================
+// Test: IsNotNull filter on nullable data
+// ===========================================================================
+TEST_F(ReadWithVisitorTest, isNotNullFilter) {
+  constexpr int kRows = 300;
+  auto input = makeRowVector(
+      {makeFlatVector<int64_t>(kRows, folly::identity, nullEvery(5))});
+  auto rowType = asRowType(input->type());
+
+  auto ctx = makeFileContext(input);
+  auto scanSpec = std::make_shared<common::ScanSpec>("root");
+  scanSpec->addAllChildFields(*rowType);
+  scanSpec->childByName("c0")->setFilter(std::make_unique<common::IsNotNull>());
+
+  auto root = buildReader(*ctx, rowType, *scanSpec);
+  auto* child = readColumn(root.get(), kRows);
+
+  int expectedNonNull = 0;
+  for (int i = 0; i < kRows; ++i) {
+    expectedNonNull += (i % 5 != 0) ? 1 : 0;
+  }
+  EXPECT_EQ(child->numValues(), expectedNonNull);
+  // All output values are non-null; hasNulls should be false (or true only
+  // if the encoding delivers reader-nulls).
+}
+
+// ===========================================================================
+// Test: Constant data → ConstantEncoding::readWithVisitor
+// ===========================================================================
+TEST_F(ReadWithVisitorTest, constantEncoding) {
+  constexpr int kRows = 300;
+  auto input =
+      makeRowVector({makeFlatVector<int64_t>(kRows, [](auto) { return 42; })});
+  auto rowType = asRowType(input->type());
+
+  auto ctx = makeFileContext(input);
+  auto scanSpec = std::make_shared<common::ScanSpec>("root");
+  scanSpec->addAllChildFields(*rowType);
+  scanSpec->childByName("c0")->setFilter(
+      std::make_unique<common::AlwaysTrue>());
+
+  auto root = buildReader(*ctx, rowType, *scanSpec);
+  auto* child = readColumn(root.get(), kRows);
+
+  EXPECT_EQ(child->numValues(), kRows);
+  auto values = getValues<int64_t>(child);
+  for (int i = 0; i < kRows; ++i) {
+    EXPECT_EQ(values[i], 42);
+  }
+}
+
+// ===========================================================================
+// Test: Constant data + non-matching filter → zero output rows
+// ===========================================================================
+TEST_F(ReadWithVisitorTest, constantEncodingFilterMiss) {
+  constexpr int kRows = 300;
+  auto input =
+      makeRowVector({makeFlatVector<int64_t>(kRows, [](auto) { return 42; })});
+  auto rowType = asRowType(input->type());
+
+  auto ctx = makeFileContext(input);
+  auto scanSpec = std::make_shared<common::ScanSpec>("root");
+  scanSpec->addAllChildFields(*rowType);
+  scanSpec->childByName("c0")->setFilter(
+      std::make_unique<common::BigintRange>(100, 200, false));
+
+  auto root = buildReader(*ctx, rowType, *scanSpec);
+  auto* child = readColumn(root.get(), kRows);
+
+  EXPECT_EQ(child->numValues(), 0);
+  EXPECT_TRUE(child->outputRows().empty());
+}
+
+// ===========================================================================
+// Test: Boolean data with BoolValue filter (SparseBoolEncoding)
+// ===========================================================================
+TEST_F(ReadWithVisitorTest, boolWithFilter) {
+  constexpr int kRows = 300;
+  auto c0 = makeFlatVector<bool>(kRows, [](auto i) { return i % 3 != 0; });
+  auto input = makeRowVector({c0});
+  auto rowType = asRowType(input->type());
+
+  auto ctx = makeFileContext(input);
+  auto scanSpec = std::make_shared<common::ScanSpec>("root");
+  scanSpec->addAllChildFields(*rowType);
+  scanSpec->childByName("c0")->setFilter(
+      std::make_unique<common::BoolValue>(true, false));
+
+  auto root = buildReader(*ctx, rowType, *scanSpec);
+  auto* child = readColumn(root.get(), kRows);
+
+  int expectedTrue = 0;
+  for (int i = 0; i < kRows; ++i) {
+    expectedTrue += (i % 3 != 0) ? 1 : 0;
+  }
+  EXPECT_EQ(child->numValues(), expectedTrue);
+}
+
+// ===========================================================================
+// Test: Boolean data with nulls + filter
+// ===========================================================================
+TEST_F(ReadWithVisitorTest, boolWithNullsAndFilter) {
+  constexpr int kRows = 300;
+  auto c0 = makeFlatVector<bool>(
+      kRows, [](auto i) { return i % 3 != 0; }, nullEvery(7));
+  auto input = makeRowVector({c0});
+  auto rowType = asRowType(input->type());
+
+  auto ctx = makeFileContext(input);
+  auto scanSpec = std::make_shared<common::ScanSpec>("root");
+  scanSpec->addAllChildFields(*rowType);
+  scanSpec->childByName("c0")->setFilter(
+      std::make_unique<common::BoolValue>(true, false));
+
+  auto root = buildReader(*ctx, rowType, *scanSpec);
+  auto* child = readColumn(root.get(), kRows);
+
+  int expected = 0;
+  for (int i = 0; i < kRows; ++i) {
+    if (!c0->isNullAt(i) && c0->valueAt(i)) {
+      ++expected;
+    }
+  }
+  EXPECT_EQ(child->numValues(), expected);
+}
+
+// ===========================================================================
+// Test: String data, no filter (TrivialEncoding<string_view>)
+// ===========================================================================
+TEST_F(ReadWithVisitorTest, stringNoFilter) {
+  constexpr int kRows = 200;
+  auto input = makeRowVector({makeFlatVector<StringView>(kRows, [](auto i) {
+    return StringView::makeInline(fmt::format("s{}", i));
+  })});
+  auto rowType = asRowType(input->type());
+
+  auto ctx = makeFileContext(input);
+  auto scanSpec = std::make_shared<common::ScanSpec>("root");
+  scanSpec->addAllChildFields(*rowType);
+  scanSpec->childByName("c0")->setFilter(
+      std::make_unique<common::AlwaysTrue>());
+
+  auto root = buildReader(*ctx, rowType, *scanSpec);
+  auto* child = readColumn(root.get(), kRows);
+
+  EXPECT_EQ(child->numValues(), kRows);
+}
+
+// ===========================================================================
+// Test: String data with nulls + IsNotNull filter
+// ===========================================================================
+TEST_F(ReadWithVisitorTest, stringWithNullsIsNotNull) {
+  constexpr int kRows = 200;
+  auto c0 = makeFlatVector<StringView>(
+      kRows,
+      [](auto i) { return StringView::makeInline(fmt::format("s{}", i)); },
+      nullEvery(5));
+  auto input = makeRowVector({c0});
+  auto rowType = asRowType(input->type());
+
+  auto ctx = makeFileContext(input);
+  auto scanSpec = std::make_shared<common::ScanSpec>("root");
+  scanSpec->addAllChildFields(*rowType);
+  scanSpec->childByName("c0")->setFilter(std::make_unique<common::IsNotNull>());
+
+  auto root = buildReader(*ctx, rowType, *scanSpec);
+  auto* child = readColumn(root.get(), kRows);
+
+  int expectedNonNull = 0;
+  for (int i = 0; i < kRows; ++i) {
+    expectedNonNull += (i % 5 != 0) ? 1 : 0;
+  }
+  EXPECT_EQ(child->numValues(), expectedNonNull);
+}
+
+// ===========================================================================
+// Test: All-null data → NullableEncoding with all-null inner
+// ===========================================================================
+TEST_F(ReadWithVisitorTest, allNullData) {
+  constexpr int kRows = 100;
+  auto input = makeRowVector(
+      {makeFlatVector<int64_t>(kRows, [](auto) { return 0; }, nullEvery(1))});
+  auto rowType = asRowType(input->type());
+
+  auto ctx = makeFileContext(input);
+  auto scanSpec = std::make_shared<common::ScanSpec>("root");
+  scanSpec->addAllChildFields(*rowType);
+  // Use IsNotNull to verify null handling in readWithVisitor — all rows are
+  // null so zero rows should pass.
+  scanSpec->childByName("c0")->setFilter(std::make_unique<common::IsNotNull>());
+
+  auto root = buildReader(*ctx, rowType, *scanSpec);
+  auto* child = readColumn(root.get(), kRows);
+
+  EXPECT_EQ(child->numValues(), 0);
+  EXPECT_TRUE(child->outputRows().empty());
+}
+
+// ===========================================================================
+// Test: All-null data + IsNotNull filter → zero output
+// ===========================================================================
+TEST_F(ReadWithVisitorTest, allNullWithIsNotNull) {
+  constexpr int kRows = 100;
+  auto input = makeRowVector(
+      {makeFlatVector<int64_t>(kRows, [](auto) { return 0; }, nullEvery(1))});
+  auto rowType = asRowType(input->type());
+
+  auto ctx = makeFileContext(input);
+  auto scanSpec = std::make_shared<common::ScanSpec>("root");
+  scanSpec->addAllChildFields(*rowType);
+  scanSpec->childByName("c0")->setFilter(std::make_unique<common::IsNotNull>());
+
+  auto root = buildReader(*ctx, rowType, *scanSpec);
+  auto* child = readColumn(root.get(), kRows);
+
+  EXPECT_EQ(child->numValues(), 0);
+}
+
+// ===========================================================================
+// Test: Large sequential data + range filter (multi-chunk / stripe)
+// ===========================================================================
+TEST_F(ReadWithVisitorTest, largeDataRangeFilter) {
+  constexpr int kRows = 10000;
+  auto c0 = makeFlatVector<int64_t>(kRows, folly::identity, nullEvery(13));
+  auto input = makeRowVector({c0});
+  auto rowType = asRowType(input->type());
+
+  auto ctx = makeFileContext(input);
+  auto scanSpec = std::make_shared<common::ScanSpec>("root");
+  scanSpec->addAllChildFields(*rowType);
+  scanSpec->childByName("c0")->setFilter(
+      std::make_unique<common::BigintRange>(1000, 5000, false));
+
+  auto root = buildReader(*ctx, rowType, *scanSpec);
+  auto* child = readColumn(root.get(), kRows);
+
+  int expected = 0;
+  for (int i = 0; i < kRows; ++i) {
+    if (!c0->isNullAt(i) && c0->valueAt(i) >= 1000 && c0->valueAt(i) <= 5000) {
+      ++expected;
+    }
+  }
+  EXPECT_EQ(child->numValues(), expected);
+
+  // Verify outputRows are sorted and in range.
+  auto rows = child->outputRows();
+  for (int i = 0; i < rows.size(); ++i) {
+    EXPECT_GE(rows[i], 1000);
+    EXPECT_LE(rows[i], 5000);
+    if (i > 0) {
+      EXPECT_GT(rows[i], rows[i - 1]);
+    }
+  }
+}
+
+// ===========================================================================
+// Test: Multiple types (int32, double) — exercises different column readers
+// ===========================================================================
+TEST_F(ReadWithVisitorTest, multipleColumnTypesWithFilters) {
+  constexpr int kRows = 300;
+  auto c0 =
+      makeFlatVector<int32_t>(kRows, [](auto i) { return i; }, nullEvery(11));
+  auto c1 = makeFlatVector<double>(
+      kRows, [](auto i) { return i * 0.5; }, nullEvery(7));
+  auto input = makeRowVector({c0, c1});
+  auto rowType = asRowType(input->type());
+
+  auto ctx = makeFileContext(input);
+  auto scanSpec = std::make_shared<common::ScanSpec>("root");
+  scanSpec->addAllChildFields(*rowType);
+  // Filter on int column — exercises int readWithVisitor with sparse output.
+  scanSpec->childByName("c0")->setFilter(
+      std::make_unique<common::BigintRange>(50, 150, false));
+
+  auto root = buildReader(*ctx, rowType, *scanSpec);
+  auto* child = readColumn(root.get(), kRows);
+
+  int expected = 0;
+  for (int i = 0; i < kRows; ++i) {
+    if (!c0->isNullAt(i) && c0->valueAt(i) >= 50 && c0->valueAt(i) <= 150) {
+      ++expected;
+    }
+  }
+  EXPECT_EQ(child->numValues(), expected);
+  EXPECT_FALSE(child->outputRows().empty());
+}
+
+// ===========================================================================
+// Test: Filter on one column of multi-column row — exercises sparse rows
+// propagation to second column
+// ===========================================================================
+TEST_F(ReadWithVisitorTest, filterOnOneColumnInspectState) {
+  constexpr int kRows = 300;
+  auto c0 = makeFlatVector<int64_t>(kRows, folly::identity);
+  auto input = makeRowVector({c0});
+  auto rowType = asRowType(input->type());
+
+  auto ctx = makeFileContext(input);
+  auto scanSpec = std::make_shared<common::ScanSpec>("root");
+  scanSpec->addAllChildFields(*rowType);
+  scanSpec->childByName("c0")->setFilter(
+      std::make_unique<common::BigintRange>(50, 100, false));
+
+  auto root = buildReader(*ctx, rowType, *scanSpec);
+  auto* child = readColumn(root.get(), kRows);
+
+  // c0 filter passes rows [50..100] → 51 values.
+  EXPECT_EQ(child->numValues(), 51);
+
+  // Verify outputRows are exactly [50..100].
+  auto rows = child->outputRows();
+  EXPECT_EQ(rows.size(), 51);
+  for (int i = 0; i < rows.size(); ++i) {
+    EXPECT_EQ(rows[i], 50 + i);
+  }
+
+  // Verify values.
+  auto values = getValues<int64_t>(child);
+  for (int i = 0; i < values.size(); ++i) {
+    EXPECT_EQ(values[i], 50 + i);
+  }
+}
+
+// ===========================================================================
+// EXPLICIT readWithVisitor TESTS
+//
+// These tests manually construct a ColumnVisitor with explicit template
+// parameters and call readWithVisitor on the concrete column reader.
+// This bypasses readCommon / processFilter entirely.
+// ===========================================================================
+
+// Explicit readWithVisitor: BigintRange filter, dense rows, ExtractToReader.
+TEST_F(ReadWithVisitorTest, explicitReadWithVisitor_BigintRange_Dense) {
+  constexpr int kRows = 500;
+  auto input = makeRowVector({makeFlatVector<int64_t>(kRows, folly::identity)});
+  auto rowType = asRowType(input->type());
+
+  auto ctx = makeFileContext(input);
+  auto scanSpec = std::make_shared<common::ScanSpec>("root");
+  scanSpec->addAllChildFields(*rowType);
+  scanSpec->childByName("c0")->setFilter(
+      std::make_unique<common::BigintRange>(100, 200, false));
+
+  auto root = buildReader(*ctx, rowType, *scanSpec);
+
+  // Extract the child IntegerColumnReader.
+  auto* structReader =
+      dynamic_cast<dwio::common::SelectiveStructColumnReaderBase*>(root.get());
+  ASSERT_NE(structReader, nullptr);
+  auto* child = structReader->children()[0];
+
+  // Cast to our test accessor to call prepareRead.
+  auto* reader = static_cast<IntegerColumnReaderTestAccessor*>(
+      dynamic_cast<IntegerColumnReader*>(child));
+  ASSERT_NE(reader, nullptr);
+
+  // Build dense RowSet [0..kRows-1].
+  std::vector<vector_size_t> rowVec(kRows);
+  std::iota(rowVec.begin(), rowVec.end(), 0);
+  RowSet rows(rowVec.data(), rowVec.size());
+
+  // Step 1: prepareRead — sets up nulls, output buffers, values capacity.
+  reader->doPrepareRead<int64_t>(0, rows, nullptr);
+
+  // Step 2: Construct ColumnVisitor with explicit template parameters.
+  common::BigintRange filter(100, 200, false);
+  dwio::common::ExtractToReader extractValues(reader);
+  constexpr bool kIsDense = true;
+  DecoderVisitor<
+      int64_t,
+      common::BigintRange,
+      dwio::common::ExtractToReader,
+      kIsDense>
+      visitor(filter, reader, rows, extractValues);
+
+  // Step 3: Explicit readWithVisitor call.
+  reader->readWithVisitor(rows, std::move(visitor));
+  reader->advanceReadOffset(rows);
+
+  // Step 4: Inspect reader state.
+  EXPECT_EQ(reader->numValues(), 101);
+  auto outRows = reader->outputRows();
+  EXPECT_EQ(outRows.size(), 101);
+  EXPECT_EQ(outRows[0], 100);
+  EXPECT_EQ(outRows[100], 200);
+
+  auto values = getValues<int64_t>(reader);
+  for (int i = 0; i < 101; ++i) {
+    EXPECT_EQ(values[i], 100 + i);
+  }
+}
+
+// Explicit readWithVisitor: AlwaysTrue filter (no filtering), dense rows.
+TEST_F(ReadWithVisitorTest, explicitReadWithVisitor_AlwaysTrue_Dense) {
+  constexpr int kRows = 200;
+  auto input = makeRowVector(
+      {makeFlatVector<int64_t>(kRows, [](auto i) { return i * 3; })});
+  auto rowType = asRowType(input->type());
+
+  auto ctx = makeFileContext(input);
+  auto scanSpec = std::make_shared<common::ScanSpec>("root");
+  scanSpec->addAllChildFields(*rowType);
+  scanSpec->childByName("c0")->setFilter(
+      std::make_unique<common::AlwaysTrue>());
+
+  auto root = buildReader(*ctx, rowType, *scanSpec);
+  auto* structReader =
+      dynamic_cast<dwio::common::SelectiveStructColumnReaderBase*>(root.get());
+  auto* reader = static_cast<IntegerColumnReaderTestAccessor*>(
+      dynamic_cast<IntegerColumnReader*>(structReader->children()[0]));
+  ASSERT_NE(reader, nullptr);
+
+  std::vector<vector_size_t> rowVec(kRows);
+  std::iota(rowVec.begin(), rowVec.end(), 0);
+  RowSet rows(rowVec.data(), rowVec.size());
+
+  reader->doPrepareRead<int64_t>(0, rows, nullptr);
+
+  common::AlwaysTrue filter;
+  dwio::common::ExtractToReader extractValues(reader);
+  constexpr bool kIsDense = true;
+  DecoderVisitor<
+      int64_t,
+      common::AlwaysTrue,
+      dwio::common::ExtractToReader,
+      kIsDense>
+      visitor(filter, reader, rows, extractValues);
+
+  reader->readWithVisitor(rows, std::move(visitor));
+  reader->advanceReadOffset(rows);
+
+  EXPECT_EQ(reader->numValues(), kRows);
+  auto values = getValues<int64_t>(reader);
+  for (int i = 0; i < kRows; ++i) {
+    EXPECT_EQ(values[i], i * 3);
+  }
+}
+
+// Explicit readWithVisitor: BigintRange filter, sparse rows (non-dense).
+TEST_F(ReadWithVisitorTest, explicitReadWithVisitor_BigintRange_Sparse) {
+  constexpr int kRows = 500;
+  auto input = makeRowVector({makeFlatVector<int64_t>(kRows, folly::identity)});
+  auto rowType = asRowType(input->type());
+
+  auto ctx = makeFileContext(input);
+  auto scanSpec = std::make_shared<common::ScanSpec>("root");
+  scanSpec->addAllChildFields(*rowType);
+  scanSpec->childByName("c0")->setFilter(
+      std::make_unique<common::BigintRange>(0, 499, false));
+
+  auto root = buildReader(*ctx, rowType, *scanSpec);
+  auto* structReader =
+      dynamic_cast<dwio::common::SelectiveStructColumnReaderBase*>(root.get());
+  auto* reader = static_cast<IntegerColumnReaderTestAccessor*>(
+      dynamic_cast<IntegerColumnReader*>(structReader->children()[0]));
+  ASSERT_NE(reader, nullptr);
+
+  // Sparse RowSet: every other row → non-dense (rows.back() != rows.size()-1).
+  std::vector<vector_size_t> rowVec;
+  for (int i = 0; i < kRows; i += 2) {
+    rowVec.push_back(i);
+  }
+  RowSet rows(rowVec.data(), rowVec.size());
+
+  reader->doPrepareRead<int64_t>(0, rows, nullptr);
+
+  common::BigintRange filter(0, 499, false);
+  dwio::common::ExtractToReader extractValues(reader);
+  constexpr bool kIsDense = false;
+  DecoderVisitor<
+      int64_t,
+      common::BigintRange,
+      dwio::common::ExtractToReader,
+      kIsDense>
+      visitor(filter, reader, rows, extractValues);
+
+  reader->readWithVisitor(rows, std::move(visitor));
+  reader->advanceReadOffset(rows);
+
+  // All even-indexed rows pass the filter.
+  EXPECT_EQ(reader->numValues(), static_cast<int>(rowVec.size()));
+  auto values = getValues<int64_t>(reader);
+  for (int i = 0; i < values.size(); ++i) {
+    EXPECT_EQ(values[i], i * 2);
+  }
+}
+
+// Explicit readWithVisitor: IsNotNull filter on nullable data.
+TEST_F(ReadWithVisitorTest, explicitReadWithVisitor_IsNotNull_Nullable) {
+  constexpr int kRows = 300;
+  auto input = makeRowVector(
+      {makeFlatVector<int64_t>(kRows, folly::identity, nullEvery(5))});
+  auto rowType = asRowType(input->type());
+
+  auto ctx = makeFileContext(input);
+  auto scanSpec = std::make_shared<common::ScanSpec>("root");
+  scanSpec->addAllChildFields(*rowType);
+  scanSpec->childByName("c0")->setFilter(std::make_unique<common::IsNotNull>());
+
+  auto root = buildReader(*ctx, rowType, *scanSpec);
+  auto* structReader =
+      dynamic_cast<dwio::common::SelectiveStructColumnReaderBase*>(root.get());
+  auto* reader = static_cast<IntegerColumnReaderTestAccessor*>(
+      dynamic_cast<IntegerColumnReader*>(structReader->children()[0]));
+  ASSERT_NE(reader, nullptr);
+
+  std::vector<vector_size_t> rowVec(kRows);
+  std::iota(rowVec.begin(), rowVec.end(), 0);
+  RowSet rows(rowVec.data(), rowVec.size());
+
+  reader->doPrepareRead<int64_t>(0, rows, nullptr);
+
+  common::IsNotNull filter;
+  dwio::common::ExtractToReader extractValues(reader);
+  constexpr bool kIsDense = true;
+  DecoderVisitor<
+      int64_t,
+      common::IsNotNull,
+      dwio::common::ExtractToReader,
+      kIsDense>
+      visitor(filter, reader, rows, extractValues);
+
+  reader->readWithVisitor(rows, std::move(visitor));
+  reader->advanceReadOffset(rows);
+
+  int expectedNonNull = 0;
+  for (int i = 0; i < kRows; ++i) {
+    expectedNonNull += (i % 5 != 0) ? 1 : 0;
+  }
+  EXPECT_EQ(reader->numValues(), expectedNonNull);
+}
+
+// ===========================================================================
+// ENCODING-LEVEL readWithVisitor TESTS
+//
+// These tests create Encoding* instances directly with forced encoding types
+// and call callReadWithVisitor(*encoding, visitor, params) on them, fully
+// isolating the encoding under test from file I/O.  The nimble file is only
+// used to set up the SelectiveColumnReader infrastructure needed by the
+// ColumnVisitor.
+// ===========================================================================
+
+// Construct ReadWithVisitorParams for the non-null path, modeled after
+// ChunkedDecoder::readWithVisitor.
+template <typename V>
+ReadWithVisitorParams makeReadWithVisitorParams(
+    V& visitor,
+    const RowSet& rows,
+    velox::memory::MemoryPool* memPool) {
+  ReadWithVisitorParams params{};
+  params.prepareResultNulls = [&visitor, &rows] {
+    visitor.reader().prepareNulls(rows, true, 8);
+  };
+  params.initReturnReaderNulls = [&visitor, &rows] {
+    visitor.reader().initReturnReaderNulls(rows);
+  };
+  const auto numRows = visitor.numRows();
+  params.makeReaderNulls = [memPool, numRows, &visitor] {
+    auto& nulls = visitor.reader().nullsInReadRange();
+    if (!nulls) {
+      nulls = velox::AlignedBuffer::allocate<bool>(
+          visitor.rowAt(numRows - 1) + 1, memPool, velox::bits::kNotNull);
+    }
+    return nulls->template asMutable<uint64_t>();
+  };
+  params.numScanned = 0;
+  return params;
+}
+
+// ---------------------------------------------------------------------------
+// 1. TrivialEncoding<int64_t> + BigintRange + dense
+// ---------------------------------------------------------------------------
+TEST_F(ReadWithVisitorTest, encodingLevel_Trivial_BigintRange_Dense) {
+  constexpr int kRows = 500;
+
+  // Sequential data [0..499].
+  std::vector<int64_t> data(kRows);
+  std::iota(data.begin(), data.end(), 0);
+
+  // Write nimble file with the same data (for reader infrastructure).
+  auto input = makeRowVector({makeFlatVector<int64_t>(kRows, folly::identity)});
+  auto rowType = asRowType(input->type());
+  auto ctx = makeFileContext(input);
+  auto scanSpec = std::make_shared<common::ScanSpec>("root");
+  scanSpec->addAllChildFields(*rowType);
+  scanSpec->childByName("c0")->setFilter(
+      std::make_unique<common::BigintRange>(100, 200, false));
+  auto root = buildReader(*ctx, rowType, *scanSpec);
+
+  auto* structReader =
+      dynamic_cast<dwio::common::SelectiveStructColumnReaderBase*>(root.get());
+  auto* reader = static_cast<IntegerColumnReaderTestAccessor*>(
+      dynamic_cast<IntegerColumnReader*>(structReader->children()[0]));
+  ASSERT_NE(reader, nullptr);
+
+  std::vector<vector_size_t> rowVec(kRows);
+  std::iota(rowVec.begin(), rowVec.end(), 0);
+  RowSet rows(rowVec.data(), rowVec.size());
+
+  reader->doPrepareRead<int64_t>(0, rows, nullptr);
+
+  // Create the encoding independently with forced TrivialEncoding.
+  Buffer buffer(*pool());
+  auto encoding =
+      createFromCustomLayout<int64_t>(TrivialEnc{}, data, *pool(), buffer);
+
+  // Construct visitor and params, then call callReadWithVisitor directly.
+  common::BigintRange filter(100, 200, false);
+  dwio::common::ExtractToReader extractValues(reader);
+  constexpr bool kIsDense = true;
+  DecoderVisitor<
+      int64_t,
+      common::BigintRange,
+      dwio::common::ExtractToReader,
+      kIsDense>
+      visitor(filter, reader, rows, extractValues);
+  auto params = makeReadWithVisitorParams(visitor, rows, pool());
+
+  callReadWithVisitor(*encoding, visitor, params);
+
+  EXPECT_EQ(reader->numValues(), 101);
+  auto outRows = reader->outputRows();
+  EXPECT_EQ(outRows[0], 100);
+  EXPECT_EQ(outRows[100], 200);
+  auto values = getValues<int64_t>(reader);
+  for (int i = 0; i < 101; ++i) {
+    EXPECT_EQ(values[i], 100 + i);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// 2. ConstantEncoding<int64_t> + AlwaysTrue + dense
+// ---------------------------------------------------------------------------
+TEST_F(ReadWithVisitorTest, encodingLevel_Constant_AlwaysTrue_Dense) {
+  constexpr int kRows = 300;
+
+  // All-same data.
+  std::vector<int64_t> data(kRows, 42);
+
+  auto input =
+      makeRowVector({makeFlatVector<int64_t>(kRows, [](auto) { return 42; })});
+  auto rowType = asRowType(input->type());
+  auto ctx = makeFileContext(input);
+  auto scanSpec = std::make_shared<common::ScanSpec>("root");
+  scanSpec->addAllChildFields(*rowType);
+  scanSpec->childByName("c0")->setFilter(
+      std::make_unique<common::AlwaysTrue>());
+  auto root = buildReader(*ctx, rowType, *scanSpec);
+
+  auto* structReader =
+      dynamic_cast<dwio::common::SelectiveStructColumnReaderBase*>(root.get());
+  auto* reader = static_cast<IntegerColumnReaderTestAccessor*>(
+      dynamic_cast<IntegerColumnReader*>(structReader->children()[0]));
+  ASSERT_NE(reader, nullptr);
+
+  std::vector<vector_size_t> rowVec(kRows);
+  std::iota(rowVec.begin(), rowVec.end(), 0);
+  RowSet rows(rowVec.data(), rowVec.size());
+
+  reader->doPrepareRead<int64_t>(0, rows, nullptr);
+
+  Buffer buffer(*pool());
+  auto encoding =
+      createFromCustomLayout<int64_t>(ConstantEnc{}, data, *pool(), buffer);
+
+  common::AlwaysTrue filter;
+  dwio::common::ExtractToReader extractValues(reader);
+  constexpr bool kIsDense = true;
+  DecoderVisitor<
+      int64_t,
+      common::AlwaysTrue,
+      dwio::common::ExtractToReader,
+      kIsDense>
+      visitor(filter, reader, rows, extractValues);
+  auto params = makeReadWithVisitorParams(visitor, rows, pool());
+
+  callReadWithVisitor(*encoding, visitor, params);
+
+  EXPECT_EQ(reader->numValues(), kRows);
+  auto values = getValues<int64_t>(reader);
+  for (int i = 0; i < kRows; ++i) {
+    EXPECT_EQ(values[i], 42);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// 3. FixedBitWidthEncoding<int64_t> + BigintRange + sparse
+// ---------------------------------------------------------------------------
+TEST_F(ReadWithVisitorTest, encodingLevel_FixedBitWidth_BigintRange_Sparse) {
+  constexpr int kRows = 500;
+
+  // Small-range data [0..15] that fits in fixed-bit-width encoding.
+  std::vector<int64_t> data(kRows);
+  for (int i = 0; i < kRows; ++i) {
+    data[i] = i % 16;
+  }
+
+  auto input = makeRowVector(
+      {makeFlatVector<int64_t>(kRows, [](auto i) { return i % 16; })});
+  auto rowType = asRowType(input->type());
+  auto ctx = makeFileContext(input);
+  auto scanSpec = std::make_shared<common::ScanSpec>("root");
+  scanSpec->addAllChildFields(*rowType);
+  scanSpec->childByName("c0")->setFilter(
+      std::make_unique<common::BigintRange>(5, 10, false));
+  auto root = buildReader(*ctx, rowType, *scanSpec);
+
+  auto* structReader =
+      dynamic_cast<dwio::common::SelectiveStructColumnReaderBase*>(root.get());
+  auto* reader = static_cast<IntegerColumnReaderTestAccessor*>(
+      dynamic_cast<IntegerColumnReader*>(structReader->children()[0]));
+  ASSERT_NE(reader, nullptr);
+
+  // Sparse RowSet: every other row.
+  std::vector<vector_size_t> rowVec;
+  for (int i = 0; i < kRows; i += 2) {
+    rowVec.push_back(i);
+  }
+  RowSet rows(rowVec.data(), rowVec.size());
+
+  reader->doPrepareRead<int64_t>(0, rows, nullptr);
+
+  Buffer buffer(*pool());
+  auto encoding = createFromCustomLayout<int64_t>(
+      FixedBitWidthEnc{}, data, *pool(), buffer);
+
+  common::BigintRange filter(5, 10, false);
+  dwio::common::ExtractToReader extractValues(reader);
+  constexpr bool kIsDense = false;
+  DecoderVisitor<
+      int64_t,
+      common::BigintRange,
+      dwio::common::ExtractToReader,
+      kIsDense>
+      visitor(filter, reader, rows, extractValues);
+  auto params = makeReadWithVisitorParams(visitor, rows, pool());
+
+  callReadWithVisitor(*encoding, visitor, params);
+
+  // Count expected: even-indexed rows where data[i] in [5..10].
+  int expected = 0;
+  for (int i = 0; i < kRows; i += 2) {
+    if (data[i] >= 5 && data[i] <= 10) {
+      ++expected;
+    }
+  }
+  EXPECT_EQ(reader->numValues(), expected);
+
+  auto values = getValues<int64_t>(reader);
+  for (int i = 0; i < reader->numValues(); ++i) {
+    EXPECT_GE(values[i], 5);
+    EXPECT_LE(values[i], 10);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// 4. RLEEncoding<int64_t> + AlwaysTrue + dense
+// ---------------------------------------------------------------------------
+TEST_F(ReadWithVisitorTest, encodingLevel_RLE_AlwaysTrue_Dense) {
+  constexpr int kRows = 500;
+
+  // Repeated-run data: 50 copies of each value [0..9].
+  std::vector<int64_t> data(kRows);
+  for (int i = 0; i < kRows; ++i) {
+    data[i] = i / 50;
+  }
+
+  auto input = makeRowVector(
+      {makeFlatVector<int64_t>(kRows, [](auto i) { return i / 50; })});
+  auto rowType = asRowType(input->type());
+  auto ctx = makeFileContext(input);
+  auto scanSpec = std::make_shared<common::ScanSpec>("root");
+  scanSpec->addAllChildFields(*rowType);
+  scanSpec->childByName("c0")->setFilter(
+      std::make_unique<common::AlwaysTrue>());
+  auto root = buildReader(*ctx, rowType, *scanSpec);
+
+  auto* structReader =
+      dynamic_cast<dwio::common::SelectiveStructColumnReaderBase*>(root.get());
+  auto* reader = static_cast<IntegerColumnReaderTestAccessor*>(
+      dynamic_cast<IntegerColumnReader*>(structReader->children()[0]));
+  ASSERT_NE(reader, nullptr);
+
+  std::vector<vector_size_t> rowVec(kRows);
+  std::iota(rowVec.begin(), rowVec.end(), 0);
+  RowSet rows(rowVec.data(), rowVec.size());
+
+  reader->doPrepareRead<int64_t>(0, rows, nullptr);
+
+  Buffer buffer(*pool());
+  auto encoding =
+      createFromCustomLayout<int64_t>(RLEEnc{}, data, *pool(), buffer);
+
+  common::AlwaysTrue filter;
+  dwio::common::ExtractToReader extractValues(reader);
+  constexpr bool kIsDense = true;
+  DecoderVisitor<
+      int64_t,
+      common::AlwaysTrue,
+      dwio::common::ExtractToReader,
+      kIsDense>
+      visitor(filter, reader, rows, extractValues);
+  auto params = makeReadWithVisitorParams(visitor, rows, pool());
+
+  callReadWithVisitor(*encoding, visitor, params);
+
+  EXPECT_EQ(reader->numValues(), kRows);
+  auto values = getValues<int64_t>(reader);
+  for (int i = 0; i < kRows; ++i) {
+    EXPECT_EQ(values[i], i / 50) << "row " << i;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// 5. TrivialEncoding
+// 5. TrivialEncoding<int64_t> + AlwaysTrue + dense + SLOW PATH
+//    hasBulkPath=false forces readWithVisitorSlow regardless of CPU features.
+// ---------------------------------------------------------------------------
+TEST_F(ReadWithVisitorTest, encodingLevel_Trivial_AlwaysTrue_Dense_SlowPath) {
+  constexpr int kRows = 500;
+
+  std::vector<int64_t> data(kRows);
+  std::iota(data.begin(), data.end(), 0);
+
+  auto input = makeRowVector({makeFlatVector<int64_t>(kRows, folly::identity)});
+  auto rowType = asRowType(input->type());
+  auto ctx = makeFileContext(input);
+  auto scanSpec = std::make_shared<common::ScanSpec>("root");
+  scanSpec->addAllChildFields(*rowType);
+  scanSpec->childByName("c0")->setFilter(
+      std::make_unique<common::AlwaysTrue>());
+  auto root = buildReader(*ctx, rowType, *scanSpec);
+
+  auto* structReader =
+      dynamic_cast<dwio::common::SelectiveStructColumnReaderBase*>(root.get());
+  auto* reader = static_cast<IntegerColumnReaderTestAccessor*>(
+      dynamic_cast<IntegerColumnReader*>(structReader->children()[0]));
+  ASSERT_NE(reader, nullptr);
+
+  std::vector<vector_size_t> rowVec(kRows);
+  std::iota(rowVec.begin(), rowVec.end(), 0);
+  RowSet rows(rowVec.data(), rowVec.size());
+
+  reader->doPrepareRead<int64_t>(0, rows, nullptr);
+
+  Buffer buffer(*pool());
+  auto encoding =
+      createFromCustomLayout<int64_t>(TrivialEnc{}, data, *pool(), buffer);
+
+  common::AlwaysTrue filter;
+  dwio::common::ExtractToReader extractValues(reader);
+  constexpr bool kIsDense = true;
+  constexpr bool kHasBulkPath = false;
+  velox::dwio::common::ColumnVisitor<
+      int64_t,
+      common::AlwaysTrue,
+      dwio::common::ExtractToReader,
+      kIsDense,
+      kHasBulkPath>
+      visitor(filter, reader, rows, extractValues);
+  auto params = makeReadWithVisitorParams(visitor, rows, pool());
+
+  callReadWithVisitor(*encoding, visitor, params);
+
+  EXPECT_EQ(reader->numValues(), kRows);
+  auto values = getValues<int64_t>(reader);
+  for (int i = 0; i < kRows; ++i) {
+    EXPECT_EQ(values[i], i);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// 6. RLEEncoding<int64_t> + AlwaysTrue + dense + SLOW PATH
+// ---------------------------------------------------------------------------
+TEST_F(ReadWithVisitorTest, encodingLevel_RLE_AlwaysTrue_Dense_SlowPath) {
+  constexpr int kRows = 500;
+
+  std::vector<int64_t> data(kRows);
+  for (int i = 0; i < kRows; ++i) {
+    data[i] = i / 50;
+  }
+
+  auto input = makeRowVector(
+      {makeFlatVector<int64_t>(kRows, [](auto i) { return i / 50; })});
+  auto rowType = asRowType(input->type());
+  auto ctx = makeFileContext(input);
+  auto scanSpec = std::make_shared<common::ScanSpec>("root");
+  scanSpec->addAllChildFields(*rowType);
+  scanSpec->childByName("c0")->setFilter(
+      std::make_unique<common::AlwaysTrue>());
+  auto root = buildReader(*ctx, rowType, *scanSpec);
+
+  auto* structReader =
+      dynamic_cast<dwio::common::SelectiveStructColumnReaderBase*>(root.get());
+  auto* reader = static_cast<IntegerColumnReaderTestAccessor*>(
+      dynamic_cast<IntegerColumnReader*>(structReader->children()[0]));
+  ASSERT_NE(reader, nullptr);
+
+  std::vector<vector_size_t> rowVec(kRows);
+  std::iota(rowVec.begin(), rowVec.end(), 0);
+  RowSet rows(rowVec.data(), rowVec.size());
+
+  reader->doPrepareRead<int64_t>(0, rows, nullptr);
+
+  Buffer buffer(*pool());
+  auto encoding =
+      createFromCustomLayout<int64_t>(RLEEnc{}, data, *pool(), buffer);
+
+  common::AlwaysTrue filter;
+  dwio::common::ExtractToReader extractValues(reader);
+  constexpr bool kIsDense = true;
+  constexpr bool kHasBulkPath = false;
+  velox::dwio::common::ColumnVisitor<
+      int64_t,
+      common::AlwaysTrue,
+      dwio::common::ExtractToReader,
+      kIsDense,
+      kHasBulkPath>
+      visitor(filter, reader, rows, extractValues);
+  auto params = makeReadWithVisitorParams(visitor, rows, pool());
+
+  callReadWithVisitor(*encoding, visitor, params);
+
+  EXPECT_EQ(reader->numValues(), kRows);
+  auto values = getValues<int64_t>(reader);
+  for (int i = 0; i < kRows; ++i) {
+    EXPECT_EQ(values[i], i / 50) << "row " << i;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// 7. MainlyConstantEncoding<int64_t> + AlwaysTrue + dense (FAST path)
+// ---------------------------------------------------------------------------
+TEST_F(ReadWithVisitorTest, encodingLevel_MainlyConstant_AlwaysTrue_Dense) {
+  constexpr int kRows = 500;
+
+  std::vector<int64_t> data(kRows, 42);
+  data[100] = 7;
+  data[200] = 13;
+  data[300] = 19;
+  data[400] = 23;
+  data[450] = 29;
+
+  auto input = makeRowVector({makeFlatVector<int64_t>(data)});
+  auto rowType = asRowType(input->type());
+  auto ctx = makeFileContext(input);
+  auto scanSpec = std::make_shared<common::ScanSpec>("root");
+  scanSpec->addAllChildFields(*rowType);
+  scanSpec->childByName("c0")->setFilter(
+      std::make_unique<common::AlwaysTrue>());
+  auto root = buildReader(*ctx, rowType, *scanSpec);
+
+  auto* structReader =
+      dynamic_cast<dwio::common::SelectiveStructColumnReaderBase*>(root.get());
+  auto* reader = static_cast<IntegerColumnReaderTestAccessor*>(
+      dynamic_cast<IntegerColumnReader*>(structReader->children()[0]));
+  ASSERT_NE(reader, nullptr);
+
+  std::vector<vector_size_t> rowVec(kRows);
+  std::iota(rowVec.begin(), rowVec.end(), 0);
+  RowSet rows(rowVec.data(), rowVec.size());
+
+  reader->doPrepareRead<int64_t>(0, rows, nullptr);
+
+  Buffer buffer(*pool());
+  auto encoding = createFromCustomLayout<int64_t>(
+      MainlyConstantEnc{}, data, *pool(), buffer);
+
+  common::AlwaysTrue filter;
+  dwio::common::ExtractToReader extractValues(reader);
+  constexpr bool kIsDense = true;
+  DecoderVisitor<
+      int64_t,
+      common::AlwaysTrue,
+      dwio::common::ExtractToReader,
+      kIsDense>
+      visitor(filter, reader, rows, extractValues);
+  auto params = makeReadWithVisitorParams(visitor, rows, pool());
+
+  callReadWithVisitor(*encoding, visitor, params);
+
+  EXPECT_EQ(reader->numValues(), kRows);
+  auto values = getValues<int64_t>(reader);
+  for (int i = 0; i < kRows; ++i) {
+    EXPECT_EQ(values[i], data[i]) << "row " << i;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// 8. MainlyConstantEncoding
+// 8. MainlyConstantEncoding<int64_t> + AlwaysTrue + dense + SLOW PATH
+// ---------------------------------------------------------------------------
+TEST_F(
+    ReadWithVisitorTest,
+    encodingLevel_MainlyConstant_AlwaysTrue_Dense_SlowPath) {
+  constexpr int kRows = 500;
+
+  std::vector<int64_t> data(kRows, 42);
+  data[100] = 7;
+  data[200] = 13;
+  data[300] = 19;
+  data[400] = 23;
+  data[450] = 29;
+
+  auto input = makeRowVector({makeFlatVector<int64_t>(data)});
+  auto rowType = asRowType(input->type());
+  auto ctx = makeFileContext(input);
+  auto scanSpec = std::make_shared<common::ScanSpec>("root");
+  scanSpec->addAllChildFields(*rowType);
+  scanSpec->childByName("c0")->setFilter(
+      std::make_unique<common::AlwaysTrue>());
+  auto root = buildReader(*ctx, rowType, *scanSpec);
+
+  auto* structReader =
+      dynamic_cast<dwio::common::SelectiveStructColumnReaderBase*>(root.get());
+  auto* reader = static_cast<IntegerColumnReaderTestAccessor*>(
+      dynamic_cast<IntegerColumnReader*>(structReader->children()[0]));
+  ASSERT_NE(reader, nullptr);
+
+  std::vector<vector_size_t> rowVec(kRows);
+  std::iota(rowVec.begin(), rowVec.end(), 0);
+  RowSet rows(rowVec.data(), rowVec.size());
+
+  reader->doPrepareRead<int64_t>(0, rows, nullptr);
+
+  Buffer buffer(*pool());
+  auto encoding = createFromCustomLayout<int64_t>(
+      MainlyConstantEnc{}, data, *pool(), buffer);
+
+  common::AlwaysTrue filter;
+  dwio::common::ExtractToReader extractValues(reader);
+  constexpr bool kIsDense = true;
+  constexpr bool kHasBulkPath = false;
+  velox::dwio::common::ColumnVisitor<
+      int64_t,
+      common::AlwaysTrue,
+      dwio::common::ExtractToReader,
+      kIsDense,
+      kHasBulkPath>
+      visitor(filter, reader, rows, extractValues);
+  auto params = makeReadWithVisitorParams(visitor, rows, pool());
+
+  callReadWithVisitor(*encoding, visitor, params);
+
+  EXPECT_EQ(reader->numValues(), kRows);
+  auto values = getValues<int64_t>(reader);
+  for (int i = 0; i < kRows; ++i) {
+    EXPECT_EQ(values[i], data[i]) << "row " << i;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// 9. DictionaryEncoding
+// 9. DictionaryEncoding<int64_t> + AlwaysTrue + dense
+//    Dictionary always uses slow path (no bulkScan).
+// ---------------------------------------------------------------------------
+TEST_F(ReadWithVisitorTest, encodingLevel_Dictionary_AlwaysTrue_Dense) {
+  constexpr int kRows = 500;
+
+  std::vector<int64_t> data(kRows);
+  for (int i = 0; i < kRows; ++i) {
+    data[i] = (i % 5) * 10;
+  }
+
+  auto input = makeRowVector(
+      {makeFlatVector<int64_t>(kRows, [](auto i) { return (i % 5) * 10; })});
+  auto rowType = asRowType(input->type());
+  auto ctx = makeFileContext(input);
+  auto scanSpec = std::make_shared<common::ScanSpec>("root");
+  scanSpec->addAllChildFields(*rowType);
+  scanSpec->childByName("c0")->setFilter(
+      std::make_unique<common::AlwaysTrue>());
+  auto root = buildReader(*ctx, rowType, *scanSpec);
+
+  auto* structReader =
+      dynamic_cast<dwio::common::SelectiveStructColumnReaderBase*>(root.get());
+  auto* reader = static_cast<IntegerColumnReaderTestAccessor*>(
+      dynamic_cast<IntegerColumnReader*>(structReader->children()[0]));
+  ASSERT_NE(reader, nullptr);
+
+  std::vector<vector_size_t> rowVec(kRows);
+  std::iota(rowVec.begin(), rowVec.end(), 0);
+  RowSet rows(rowVec.data(), rowVec.size());
+
+  reader->doPrepareRead<int64_t>(0, rows, nullptr);
+
+  Buffer buffer(*pool());
+  auto encoding =
+      createFromCustomLayout<int64_t>(DictionaryEnc{}, data, *pool(), buffer);
+
+  common::AlwaysTrue filter;
+  dwio::common::ExtractToReader extractValues(reader);
+  constexpr bool kIsDense = true;
+  DecoderVisitor<
+      int64_t,
+      common::AlwaysTrue,
+      dwio::common::ExtractToReader,
+      kIsDense>
+      visitor(filter, reader, rows, extractValues);
+  auto params = makeReadWithVisitorParams(visitor, rows, pool());
+
+  callReadWithVisitor(*encoding, visitor, params);
+
+  EXPECT_EQ(reader->numValues(), kRows);
+  auto values = getValues<int64_t>(reader);
+  for (int i = 0; i < kRows; ++i) {
+    EXPECT_EQ(values[i], (i % 5) * 10) << "row " << i;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// 10. DictionaryEncoding<int64_t> + BigintRange + sparse
+// ---------------------------------------------------------------------------
+TEST_F(ReadWithVisitorTest, encodingLevel_Dictionary_BigintRange_Sparse) {
+  constexpr int kRows = 500;
+
+  std::vector<int64_t> data(kRows);
+  for (int i = 0; i < kRows; ++i) {
+    data[i] = (i % 5) * 10;
+  }
+
+  auto input = makeRowVector(
+      {makeFlatVector<int64_t>(kRows, [](auto i) { return (i % 5) * 10; })});
+  auto rowType = asRowType(input->type());
+  auto ctx = makeFileContext(input);
+  auto scanSpec = std::make_shared<common::ScanSpec>("root");
+  scanSpec->addAllChildFields(*rowType);
+  scanSpec->childByName("c0")->setFilter(
+      std::make_unique<common::BigintRange>(15, 35, false));
+  auto root = buildReader(*ctx, rowType, *scanSpec);
+
+  auto* structReader =
+      dynamic_cast<dwio::common::SelectiveStructColumnReaderBase*>(root.get());
+  auto* reader = static_cast<IntegerColumnReaderTestAccessor*>(
+      dynamic_cast<IntegerColumnReader*>(structReader->children()[0]));
+  ASSERT_NE(reader, nullptr);
+
+  std::vector<vector_size_t> rowVec;
+  for (int i = 0; i < kRows; i += 2) {
+    rowVec.push_back(i);
+  }
+  RowSet rows(rowVec.data(), rowVec.size());
+
+  reader->doPrepareRead<int64_t>(0, rows, nullptr);
+
+  Buffer buffer(*pool());
+  auto encoding =
+      createFromCustomLayout<int64_t>(DictionaryEnc{}, data, *pool(), buffer);
+
+  common::BigintRange filter(15, 35, false);
+  dwio::common::ExtractToReader extractValues(reader);
+  constexpr bool kIsDense = false;
+  DecoderVisitor<
+      int64_t,
+      common::BigintRange,
+      dwio::common::ExtractToReader,
+      kIsDense>
+      visitor(filter, reader, rows, extractValues);
+  auto params = makeReadWithVisitorParams(visitor, rows, pool());
+
+  callReadWithVisitor(*encoding, visitor, params);
+
+  int expected = 0;
+  for (int i = 0; i < kRows; i += 2) {
+    if (data[i] >= 15 && data[i] <= 35) {
+      ++expected;
+    }
+  }
+  EXPECT_EQ(reader->numValues(), expected);
+
+  auto values = getValues<int64_t>(reader);
+  for (int i = 0; i < reader->numValues(); ++i) {
+    EXPECT_GE(values[i], 15);
+    EXPECT_LE(values[i], 35);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// 11. MainlyConstant<Dictionary> + AlwaysTrue + dense (FAST path, composite)
+// ---------------------------------------------------------------------------
+TEST_F(
+    ReadWithVisitorTest,
+    encodingLevel_MainlyConstant_Dictionary_AlwaysTrue_Dense) {
+  constexpr int kRows = 500;
+
+  // Mostly 42; non-common values cycle through {100, 101, 102}.
+  std::vector<int64_t> data(kRows, 42);
+  for (int i = 0; i < kRows; i += 10) {
+    data[i] = 100 + (i / 10) % 3;
+  }
+
+  auto input = makeRowVector({makeFlatVector<int64_t>(data)});
+  auto rowType = asRowType(input->type());
+  auto ctx = makeFileContext(input);
+  auto scanSpec = std::make_shared<common::ScanSpec>("root");
+  scanSpec->addAllChildFields(*rowType);
+  scanSpec->childByName("c0")->setFilter(
+      std::make_unique<common::AlwaysTrue>());
+  auto root = buildReader(*ctx, rowType, *scanSpec);
+
+  auto* structReader =
+      dynamic_cast<dwio::common::SelectiveStructColumnReaderBase*>(root.get());
+  auto* reader = static_cast<IntegerColumnReaderTestAccessor*>(
+      dynamic_cast<IntegerColumnReader*>(structReader->children()[0]));
+  ASSERT_NE(reader, nullptr);
+
+  std::vector<vector_size_t> rowVec(kRows);
+  std::iota(rowVec.begin(), rowVec.end(), 0);
+  RowSet rows(rowVec.data(), rowVec.size());
+
+  reader->doPrepareRead<int64_t>(0, rows, nullptr);
+
+  Buffer buffer(*pool());
+  auto encoding = createFromCustomLayout<int64_t>(
+      MainlyConstantEnc{.otherValues = DictionaryEnc{}}, data, *pool(), buffer);
+
+  common::AlwaysTrue filter;
+  dwio::common::ExtractToReader extractValues(reader);
+  constexpr bool kIsDense = true;
+  DecoderVisitor<
+      int64_t,
+      common::AlwaysTrue,
+      dwio::common::ExtractToReader,
+      kIsDense>
+      visitor(filter, reader, rows, extractValues);
+  auto params = makeReadWithVisitorParams(visitor, rows, pool());
+
+  callReadWithVisitor(*encoding, visitor, params);
+
+  EXPECT_EQ(reader->numValues(), kRows);
+  auto values = getValues<int64_t>(reader);
+  for (int i = 0; i < kRows; ++i) {
+    EXPECT_EQ(values[i], data[i]) << "row " << i;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// 12. MainlyConstant<Dictionary> + AlwaysTrue + dense + SLOW PATH (composite)
+// ---------------------------------------------------------------------------
+TEST_F(
+    ReadWithVisitorTest,
+    encodingLevel_MainlyConstant_Dictionary_AlwaysTrue_Dense_SlowPath) {
+  constexpr int kRows = 500;
+
+  std::vector<int64_t> data(kRows, 42);
+  for (int i = 0; i < kRows; i += 10) {
+    data[i] = 100 + (i / 10) % 3;
+  }
+
+  auto input = makeRowVector({makeFlatVector<int64_t>(data)});
+  auto rowType = asRowType(input->type());
+  auto ctx = makeFileContext(input);
+  auto scanSpec = std::make_shared<common::ScanSpec>("root");
+  scanSpec->addAllChildFields(*rowType);
+  scanSpec->childByName("c0")->setFilter(
+      std::make_unique<common::AlwaysTrue>());
+  auto root = buildReader(*ctx, rowType, *scanSpec);
+
+  auto* structReader =
+      dynamic_cast<dwio::common::SelectiveStructColumnReaderBase*>(root.get());
+  auto* reader = static_cast<IntegerColumnReaderTestAccessor*>(
+      dynamic_cast<IntegerColumnReader*>(structReader->children()[0]));
+  ASSERT_NE(reader, nullptr);
+
+  std::vector<vector_size_t> rowVec(kRows);
+  std::iota(rowVec.begin(), rowVec.end(), 0);
+  RowSet rows(rowVec.data(), rowVec.size());
+
+  reader->doPrepareRead<int64_t>(0, rows, nullptr);
+
+  Buffer buffer(*pool());
+  auto encoding = createFromCustomLayout<int64_t>(
+      MainlyConstantEnc{.otherValues = DictionaryEnc{}}, data, *pool(), buffer);
+
+  common::AlwaysTrue filter;
+  dwio::common::ExtractToReader extractValues(reader);
+  constexpr bool kIsDense = true;
+  constexpr bool kHasBulkPath = false;
+  velox::dwio::common::ColumnVisitor<
+      int64_t,
+      common::AlwaysTrue,
+      dwio::common::ExtractToReader,
+      kIsDense,
+      kHasBulkPath>
+      visitor(filter, reader, rows, extractValues);
+  auto params = makeReadWithVisitorParams(visitor, rows, pool());
+
+  callReadWithVisitor(*encoding, visitor, params);
+
+  EXPECT_EQ(reader->numValues(), kRows);
+  auto values = getValues<int64_t>(reader);
+  for (int i = 0; i < kRows; ++i) {
+    EXPECT_EQ(values[i], data[i]) << "row " << i;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// 13. FixedBitWidthEncoding<int32_t> + AlwaysTrue + dense + FAST PATH
+//     The FixedBitWidth fast path (bulkScan) requires:
+//       - isFourByteIntegralType (int32_t/uint32_t only, NOT int64_t)
+//       - No filter (!kHasFilter → AlwaysTrue)
+//       - No hook (!kHasHook → ExtractToReader)
+//       - kExtractToReader && (kSameType || kIsWidening)
+//     This test uses int32_t data to satisfy all conditions.
+// ---------------------------------------------------------------------------
+TEST_F(
+    ReadWithVisitorTest,
+    encodingLevel_FixedBitWidth_AlwaysTrue_Dense_Int32_FastPath) {
+  constexpr int kRows = 500;
+
+  // Small-range int32 data that fits in fixed-bit-width encoding.
+  std::vector<int32_t> data(kRows);
+  for (int i = 0; i < kRows; ++i) {
+    data[i] = i % 16;
+  }
+
+  // Write a nimble file with an int32 column (INTEGER type).
+  auto input = makeRowVector({makeFlatVector<int32_t>(
+      kRows, [](auto i) { return static_cast<int32_t>(i % 16); })});
+  auto rowType = asRowType(input->type());
+  auto ctx = makeFileContext(input);
+  auto scanSpec = std::make_shared<common::ScanSpec>("root");
+  scanSpec->addAllChildFields(*rowType);
+  scanSpec->childByName("c0")->setFilter(
+      std::make_unique<common::AlwaysTrue>());
+  auto root = buildReader(*ctx, rowType, *scanSpec);
+
+  auto* structReader =
+      dynamic_cast<dwio::common::SelectiveStructColumnReaderBase*>(root.get());
+  auto* reader = static_cast<IntegerColumnReaderTestAccessor*>(
+      dynamic_cast<IntegerColumnReader*>(structReader->children()[0]));
+  ASSERT_NE(reader, nullptr);
+
+  std::vector<vector_size_t> rowVec(kRows);
+  std::iota(rowVec.begin(), rowVec.end(), 0);
+  RowSet rows(rowVec.data(), rowVec.size());
+
+  // prepareRead with int32_t — must match the column's physical type.
+  reader->doPrepareRead<int32_t>(0, rows, nullptr);
+
+  Buffer buffer(*pool());
+  auto encoding = createFromCustomLayout<int32_t>(
+      FixedBitWidthEnc{}, data, *pool(), buffer);
+
+  // Visitor DataType = int32_t → dispatch matches
+  // FixedBitWidthEncoding<int32_t>. AlwaysTrue + ExtractToReader +
+  // hasBulkPath=true (default) → fast path.
+  common::AlwaysTrue filter;
+  dwio::common::ExtractToReader extractValues(reader);
+  constexpr bool kIsDense = true;
+  DecoderVisitor<
+      int32_t,
+      common::AlwaysTrue,
+      dwio::common::ExtractToReader,
+      kIsDense>
+      visitor(filter, reader, rows, extractValues);
+  auto params = makeReadWithVisitorParams(visitor, rows, pool());
+
+  callReadWithVisitor(*encoding, visitor, params);
+
+  EXPECT_EQ(reader->numValues(), kRows);
+  auto values = getValues<int32_t>(reader);
+  for (int i = 0; i < kRows; ++i) {
+    EXPECT_EQ(values[i], i % 16) << "row " << i;
+  }
+}
+
+} // namespace
+} // namespace facebook::nimble

--- a/dwio/nimble/velox/selective/tests/E2EFilterTest.cpp
+++ b/dwio/nimble/velox/selective/tests/E2EFilterTest.cpp
@@ -73,12 +73,18 @@ class E2EFilterTest : public dwio::common::E2EFilterTestBase,
       bool wrapInStruct,
       const std::vector<std::string>& filterable,
       int32_t numCombinations,
-      bool withRecursiveNulls = true) {
+      bool withRecursiveNulls = true,
+      std::optional<std::vector<std::pair<EncodingType, float>>>
+          encodingFactors = std::nullopt) {
     // Select index columns if index is enabled.
     std::vector<std::string> indexColumns;
     if (indexEnabled()) {
       indexColumns = selectIndexColumns(columns, wrapInStruct);
     }
+
+    // Set encoding factors for this test run.
+    encodingFactors_ = encodingFactors;
+
     if (!withRecursiveNulls) {
       testScenario(
           columns,
@@ -88,6 +94,7 @@ class E2EFilterTest : public dwio::common::E2EFilterTestBase,
           numCombinations,
           /*withRecursiveNulls=*/false,
           indexColumns);
+      encodingFactors_.reset();
       return;
     }
 
@@ -111,6 +118,9 @@ class E2EFilterTest : public dwio::common::E2EFilterTestBase,
         numCombinations,
         /*withRecursiveNulls=*/true,
         indexColumns);
+
+    // Clear encoding factors after test run.
+    encodingFactors_.reset();
   }
 
   // Selects eligible index columns (integer types) from the schema.
@@ -203,6 +213,17 @@ class E2EFilterTest : public dwio::common::E2EFilterTestBase,
     VeloxWriterOptions options;
     options.skipConstantFlatMapInMapStreams = skipConstantFlatMapInMapStreams();
     options.enableChunking = true;
+
+    // Use custom encoding factors if set.
+    // Capture by value to avoid dangling reference.
+    if (encodingFactors_.has_value()) {
+      auto factors = encodingFactors_.value();
+      options.encodingSelectionPolicyFactory = [factors](DataType dataType) {
+        ManualEncodingSelectionPolicyFactory factory(factors);
+        return factory.createPolicy(dataType);
+      };
+    }
+
     auto i = 0;
     options.flushPolicyFactory = [&] {
       return std::make_unique<LambdaFlushPolicy>(
@@ -248,6 +269,53 @@ class E2EFilterTest : public dwio::common::E2EFilterTestBase,
   folly::F14FastSet<std::string> deduplicatedArrayColumns_;
   folly::F14FastSet<std::string> deduplicatedMapColumns_;
 
+  // Optional encoding factors for ManualEncodingSelectionPolicyFactory.
+  // When set, writeToMemory will use these factors instead of the default
+  // encoding selection policy. Clear after test to avoid affecting other tests.
+  std::optional<std::vector<std::pair<EncodingType, float>>> encodingFactors_;
+
+  // Generates encoding factors that strongly favor a specific encoding type.
+  // Encodings with lower read factors are preferred (factor represents CPU
+  // cost). The favored encoding gets a low factor (0.1), while others get high
+  // factors (100.0). Only includes encodings in the pool; omitting encodings
+  // from the pool prevents them from being selected. Trivial encoding is always
+  // included as a fallback.
+  static std::vector<std::pair<EncodingType, float>> biasedEncodingFactors(
+      EncodingType favored) {
+    std::vector<std::pair<EncodingType, float>> factors;
+
+    // Trivial is always needed as a fallback when other encodings don't apply.
+    // Use a high factor to discourage it unless necessary.
+    factors.emplace_back(EncodingType::Trivial, 100.0);
+
+    // Add the favored encoding with a low factor (strongly preferred).
+    if (favored != EncodingType::Trivial) {
+      factors.emplace_back(favored, 0.1);
+    } else {
+      // If Trivial is favored, just use it with low factor.
+      factors[0].second = 0.1;
+    }
+
+    // For certain encodings, we need to include additional encodings in the
+    // pool to handle edge cases (e.g., constant values).
+    switch (favored) {
+      case EncodingType::FixedBitWidth:
+      case EncodingType::RLE:
+      case EncodingType::Varint:
+        // These may fall back to Constant for constant data.
+        factors.emplace_back(EncodingType::Constant, 100.0);
+        break;
+      case EncodingType::MainlyConstant:
+        // MainlyConstant needs Constant for the common value.
+        factors.emplace_back(EncodingType::Constant, 100.0);
+        break;
+      default:
+        break;
+    }
+
+    return factors;
+  }
+
  private:
   void setUpFlatMapColumns() {
     auto rowTypeWithId = dwio::common::TypeWithId::create(rowType_);
@@ -291,6 +359,90 @@ TEST_P(E2EFilterTest, integer) {
       true,
       {"short_val", "int_val", "long_val"},
       20);
+}
+
+// Biased variant that forces FixedBitWidth encoding selection.
+TEST_P(E2EFilterTest, integerBiasedFixedBitWidth) {
+  testWithTypes(
+      "short_val:smallint,"
+      "int_val:int,"
+      "long_val:bigint",
+      [&]() {
+        makeIntDistribution<int16_t>(
+            "short_val",
+            /*min=*/10,
+            /*max=*/1000,
+            /*repeats=*/1,
+            /*rareFrequency=*/0,
+            /*rareMin=*/0,
+            /*rareMax=*/0,
+            /*keepNulls=*/false);
+        makeIntDistribution<int32_t>(
+            "int_val",
+            /*min=*/100,
+            /*max=*/100000,
+            /*repeats=*/1,
+            /*rareFrequency=*/0,
+            /*rareMin=*/0,
+            /*rareMax=*/0,
+            /*keepNulls=*/false);
+        makeIntDistribution<int64_t>(
+            "long_val",
+            /*min=*/1000,
+            /*max=*/1000000,
+            /*repeats=*/1,
+            /*rareFrequency=*/0,
+            /*rareMin=*/0,
+            /*rareMax=*/0,
+            /*keepNulls=*/false);
+      },
+      /*wrapInStruct=*/false,
+      {"short_val", "int_val", "long_val"},
+      /*numCombinations=*/20,
+      /*withRecursiveNulls=*/true,
+      biasedEncodingFactors(EncodingType::FixedBitWidth));
+}
+
+// Biased variant that forces Trivial encoding selection.
+TEST_P(E2EFilterTest, integerBiasedTrivial) {
+  testWithTypes(
+      "short_val:smallint,"
+      "int_val:int,"
+      "long_val:bigint",
+      [&]() {
+        makeIntDistribution<int16_t>(
+            "short_val",
+            /*min=*/10,
+            /*max=*/1000,
+            /*repeats=*/1,
+            /*rareFrequency=*/0,
+            /*rareMin=*/0,
+            /*rareMax=*/0,
+            /*keepNulls=*/false);
+        makeIntDistribution<int32_t>(
+            "int_val",
+            /*min=*/100,
+            /*max=*/100000,
+            /*repeats=*/1,
+            /*rareFrequency=*/0,
+            /*rareMin=*/0,
+            /*rareMax=*/0,
+            /*keepNulls=*/false);
+        makeIntDistribution<int64_t>(
+            "long_val",
+            /*min=*/1000,
+            /*max=*/1000000,
+            /*repeats=*/1,
+            /*rareFrequency=*/0,
+            /*rareMin=*/0,
+            /*rareMax=*/0,
+            /*keepNulls=*/false);
+      },
+      /*wrapInStruct=*/false,
+      {"short_val", "int_val", "long_val"},
+      /*numCombinations=*/20,
+      /*withRecursiveNulls=*/true,
+      biasedEncodingFactors(EncodingType::Trivial));
 }
 
 TEST_P(E2EFilterTest, integerLowCardinality) {
@@ -348,6 +500,27 @@ TEST_P(E2EFilterTest, integerRle) {
       true,
       {"short_val", "int_val", "long_val"},
       20);
+}
+
+// Biased variant that forces RLE encoding selection.
+TEST_P(E2EFilterTest, integerRleBiased) {
+  testWithTypes(
+      "short_val:smallint,"
+      "int_val:int,"
+      "long_val:bigint",
+      [&]() {
+        makeIntRle<int16_t>("short_val");
+        makeIntRle<int32_t>("int_val");
+        makeIntRle<int64_t>("long_val");
+        makeIntRle<int16_t>("struct_val.short_val");
+        makeIntRle<int32_t>("struct_val.int_val");
+        makeIntRle<int64_t>("struct_val.long_val");
+      },
+      /*wrapInStruct=*/true,
+      {"short_val", "int_val", "long_val"},
+      /*numCombinations=*/20,
+      /*withRecursiveNulls=*/true,
+      biasedEncodingFactors(EncodingType::RLE));
 }
 
 TEST_P(E2EFilterTest, integerRleCustomSeed_4049269257) {
@@ -432,6 +605,24 @@ TEST_P(E2EFilterTest, mainlyConstant) {
       true,
       {"short_val", "int_val", "long_val"},
       20);
+}
+
+// Biased variant that forces MainlyConstant encoding selection.
+TEST_P(E2EFilterTest, mainlyConstantBiased) {
+  testWithTypes(
+      "short_val:smallint,"
+      "int_val:int,"
+      "long_val:bigint",
+      [&]() {
+        makeIntMainlyConstant<int16_t>("short_val");
+        makeIntMainlyConstant<int32_t>("int_val");
+        makeIntMainlyConstant<int64_t>("long_val");
+      },
+      /*wrapInStruct=*/false,
+      {"short_val", "int_val", "long_val"},
+      /*numCombinations=*/20,
+      /*withRecursiveNulls=*/true,
+      biasedEncodingFactors(EncodingType::MainlyConstant));
 }
 
 TEST_P(E2EFilterTest, float) {

--- a/dwio/nimble/velox/selective/tests/SelectiveNimbleReaderTest.cpp
+++ b/dwio/nimble/velox/selective/tests/SelectiveNimbleReaderTest.cpp
@@ -1914,5 +1914,141 @@ INSTANTIATE_TEST_CASE_P(
     SelectiveNimbleReaderTest,
     testing::Values(false, true));
 
+// Tests for FixedBitWidthEncoding fast path.
+// The fast path is used for 4-byte integral types without filters or hooks.
+
+TEST_P(SelectiveNimbleReaderTest, fixedBitWidthFastPathSameType) {
+  // Tests that the fast path works correctly for same-type reads (int32 →
+  // int32). This exercises the memcpy branch in bulkScan.
+  const bool passStringBuffersFromDecoder = GetParam();
+  for (bool hasNulls : {false, true}) {
+    SCOPED_TRACE(fmt::format("hasNulls={}", hasNulls));
+    auto data = makeFlatVector<int32_t>(
+        1000, [](auto i) { return i * 7; }, hasNulls ? nullEvery(17) : nullptr);
+    auto input = makeRowVector({data});
+    auto file = test::createNimbleFile(*rootPool(), input);
+    auto scanSpec = std::make_shared<common::ScanSpec>("root");
+    scanSpec->addAllChildFields(*input->type());
+    auto readers =
+        makeReaders(input, file, scanSpec, passStringBuffersFromDecoder);
+    // Read in a single large batch to exercise the dense fast path.
+    validate(*input, *readers.rowReader, 1000, -1, [](auto) { return true; });
+  }
+}
+
+TEST_P(SelectiveNimbleReaderTest, fixedBitWidthFastPathUpcast) {
+  // Tests that the fast path works correctly for upcast reads (int32 →
+  // int64). This exercises the upcast loop branch in bulkScan.
+  const bool passStringBuffersFromDecoder = GetParam();
+  for (bool hasNulls : {false, true}) {
+    SCOPED_TRACE(fmt::format("hasNulls={}", hasNulls));
+    // Write as int32.
+    auto writeData = makeFlatVector<int32_t>(
+        1000, [](auto i) { return i * 7; }, hasNulls ? nullEvery(17) : nullptr);
+    auto input = makeRowVector({writeData});
+    auto file = test::createNimbleFile(*rootPool(), input);
+
+    // Read as int64 (schema evolution / upcast).
+    auto readData = makeFlatVector<int64_t>(
+        1000, [](auto i) { return i * 7; }, hasNulls ? nullEvery(17) : nullptr);
+    auto expected = makeRowVector({readData});
+    auto scanSpec = std::make_shared<common::ScanSpec>("root");
+    scanSpec->addAllChildFields(*expected->type());
+    auto readers =
+        makeReaders(expected, file, scanSpec, passStringBuffersFromDecoder);
+    // Read in a single large batch to exercise the dense fast path.
+    validate(
+        *expected, *readers.rowReader, 1000, -1, [](auto) { return true; });
+  }
+}
+
+TEST_P(SelectiveNimbleReaderTest, fixedBitWidthFastPathMultipleBatches) {
+  // Tests that the fast path works correctly with multiple batches.
+  // This exercises the row tracking and position management.
+  const bool passStringBuffersFromDecoder = GetParam();
+  for (bool hasNulls : {false, true}) {
+    SCOPED_TRACE(fmt::format("hasNulls={}", hasNulls));
+    auto data = makeFlatVector<int32_t>(
+        500,
+        [](auto i) { return i * 3 + 1; },
+        hasNulls ? nullEvery(11) : nullptr);
+    auto input = makeRowVector({data});
+    auto file = test::createNimbleFile(*rootPool(), input);
+    auto scanSpec = std::make_shared<common::ScanSpec>("root");
+    scanSpec->addAllChildFields(*input->type());
+    auto readers =
+        makeReaders(input, file, scanSpec, passStringBuffersFromDecoder);
+    // Read in small batches to test batch boundary handling.
+    validate(*input, *readers.rowReader, 37, -1, [](auto) { return true; });
+  }
+}
+
+TEST_P(SelectiveNimbleReaderTest, fixedBitWidthFastPathLargeValues) {
+  // Tests that the fast path handles large values correctly.
+  // This verifies baseline handling in the encoding.
+  const bool passStringBuffersFromDecoder = GetParam();
+  for (bool hasNulls : {false, true}) {
+    SCOPED_TRACE(fmt::format("hasNulls={}", hasNulls));
+    auto data = makeFlatVector<int32_t>(
+        200,
+        [](auto i) { return static_cast<int32_t>(1'000'000'000 + i * 100); },
+        hasNulls ? nullEvery(13) : nullptr);
+    auto input = makeRowVector({data});
+    auto file = test::createNimbleFile(*rootPool(), input);
+    auto scanSpec = std::make_shared<common::ScanSpec>("root");
+    scanSpec->addAllChildFields(*input->type());
+    auto readers =
+        makeReaders(input, file, scanSpec, passStringBuffersFromDecoder);
+    validate(*input, *readers.rowReader, 200, -1, [](auto) { return true; });
+  }
+}
+
+TEST_P(SelectiveNimbleReaderTest, fixedBitWidthFastPathNegativeValues) {
+  // Tests that the fast path handles negative values correctly.
+  const bool passStringBuffersFromDecoder = GetParam();
+  for (bool hasNulls : {false, true}) {
+    SCOPED_TRACE(fmt::format("hasNulls={}", hasNulls));
+    auto data = makeFlatVector<int32_t>(
+        300,
+        [](auto i) { return static_cast<int32_t>(i) - 150; },
+        hasNulls ? nullEvery(19) : nullptr);
+    auto input = makeRowVector({data});
+    auto file = test::createNimbleFile(*rootPool(), input);
+    auto scanSpec = std::make_shared<common::ScanSpec>("root");
+    scanSpec->addAllChildFields(*input->type());
+    auto readers =
+        makeReaders(input, file, scanSpec, passStringBuffersFromDecoder);
+    validate(*input, *readers.rowReader, 300, -1, [](auto) { return true; });
+  }
+}
+
+TEST_P(SelectiveNimbleReaderTest, fixedBitWidthFastPathUpcastNegative) {
+  // Tests that the fast path handles upcast with negative values correctly.
+  // This verifies sign extension works properly.
+  const bool passStringBuffersFromDecoder = GetParam();
+  for (bool hasNulls : {false, true}) {
+    SCOPED_TRACE(fmt::format("hasNulls={}", hasNulls));
+    // Write as int32.
+    auto writeData = makeFlatVector<int32_t>(
+        200,
+        [](auto i) { return static_cast<int32_t>(i) - 100; },
+        hasNulls ? nullEvery(11) : nullptr);
+    auto input = makeRowVector({writeData});
+    auto file = test::createNimbleFile(*rootPool(), input);
+
+    // Read as int64.
+    auto readData = makeFlatVector<int64_t>(
+        200,
+        [](auto i) { return static_cast<int64_t>(i) - 100; },
+        hasNulls ? nullEvery(11) : nullptr);
+    auto expected = makeRowVector({readData});
+    auto scanSpec = std::make_shared<common::ScanSpec>("root");
+    scanSpec->addAllChildFields(*expected->type());
+    auto readers =
+        makeReaders(expected, file, scanSpec, passStringBuffersFromDecoder);
+    validate(*expected, *readers.rowReader, 200, -1, [](auto) { return true; });
+  }
+}
+
 } // namespace
 } // namespace facebook::nimble


### PR DESCRIPTION
Summary: Provide the missing fast path implementation for FixedBitWidthEncoding for performance parity with DWRF selective reader on the fitting data shapes. Some relevant examples include DictionaryEncoding that typically encodes indices as fixed bit width.

Differential Revision: D93517985


