### PR TITLE
serde: Simplify serialization versions to kLegacy and kCompact

### DIFF
--- a/dwio/nimble/serializer/Deserializer.cpp
+++ b/dwio/nimble/serializer/Deserializer.cpp
@@ -540,7 +540,7 @@ void Deserializer::deserialize(
   // Iterate batches and add stream data with row offsets. Streams missing from
   // a batch will have gaps that are filled later during reading.
   uint32_t rowOffset{0};
-  serde::StreamDataReader reader{options_};
+  serde::StreamDataReader reader{pool_, options_};
   for (auto sv : data) {
     const auto batchRows = reader.initialize(sv);
     reader.iterateStreams([&](uint32_t offset, std::string_view streamData) {

--- a/dwio/nimble/serializer/DeserializerImpl.cpp
+++ b/dwio/nimble/serializer/DeserializerImpl.cpp
@@ -23,6 +23,7 @@
 #include "dwio/nimble/common/Types.h"
 #include "dwio/nimble/common/Varint.h"
 #include "dwio/nimble/encodings/EncodingFactory.h"
+#include "dwio/nimble/serializer/SerializerImpl.h"
 
 namespace facebook::nimble::serde {
 
@@ -47,6 +48,9 @@ uint32_t StreamData::copyTo(char* output, uint32_t bufferSize) {
 }
 
 uint32_t StreamData::decodeStrings(uint32_t count, std::string_view* output) {
+  if (encodingEnabled_) {
+    return decode(output, /*offset=*/0, count, /*width=*/0);
+  }
   uint32_t index = 0;
   while (pos_ < end_ && index < count) {
     output[index++] = encoding::readString(pos_);
@@ -191,19 +195,23 @@ uint32_t StreamData::decode(
   return count;
 }
 
-StreamDataReader::StreamDataReader(const DeserializerOptions& options)
-    : options_{options} {}
+StreamDataReader::StreamDataReader(
+    velox::memory::MemoryPool* pool,
+    const DeserializerOptions& options)
+    : options_{options}, pool_{pool} {
+  NIMBLE_CHECK_NOT_NULL(pool_);
+}
 
 uint32_t StreamDataReader::initialize(std::string_view data) {
   pos_ = data.data();
   end_ = data.end();
   if (options_.hasVersionHeader()) {
     const auto version = static_cast<SerializationVersion>(*pos_);
-    NIMBLE_CHECK_LE(
-        version,
-        SerializationVersion::kSparseEncoded,
+    NIMBLE_CHECK(
+        version == SerializationVersion::kLegacy ||
+            version == SerializationVersion::kCompact,
         "Unsupported version {}",
-        version);
+        static_cast<uint8_t>(version));
     // Verify the version read from serialized data matches options.
     NIMBLE_CHECK_EQ(
         version,
@@ -213,9 +221,8 @@ uint32_t StreamDataReader::initialize(std::string_view data) {
         *options_.version);
     ++pos_;
   }
-  // Encoded versions (kDenseEncoded, kSparseEncoded) use varint for compact
-  // row counts.
   if (options_.enableEncoding()) {
+    // kCompact: varint row count.
     return varint::readVarint32(&pos_);
   }
   return encoding::readUint32(pos_);
@@ -224,34 +231,33 @@ uint32_t StreamDataReader::initialize(std::string_view data) {
 void StreamDataReader::iterateStreams(
     const std::function<void(uint32_t offset, std::string_view data)>&
         callback) {
-  if (options_.sparseFormat()) {
-    // Sparse format: [stream_count][offsets...][data...]
-    NIMBLE_CHECK_LE(
-        pos_ + sizeof(uint32_t), end_, "Truncated data: missing stream count");
-    const uint32_t streamCount = encoding::readUint32(pos_);
+  if (options_.enableEncoding()) {
+    // kCompact format:
+    // [stream_data_0]...[stream_data_N][encoded_stream_sizes][stream_sizes_encoded_size:u32]
+    // Read stream_sizes_encoded_size from last 4 bytes, decode sizes from
+    // trailer.
+    const uint32_t streamSizesEncodedSize =
+        detail::readStreamSizesEncodedSize(end_);
+    const auto streamSizes = detail::decodeStreamSizes(
+        {end_ - sizeof(uint32_t) - streamSizesEncodedSize,
+         streamSizesEncodedSize},
+        pool_);
 
-    // Sanity check: stream count should be reasonable.
-    const size_t remainingBytes = end_ - pos_;
-    NIMBLE_CHECK_LE(
-        streamCount,
-        remainingBytes / sizeof(uint32_t),
-        "Invalid stream count exceeds remaining data");
-
-    std::vector<uint32_t> offsets(streamCount);
-    for (uint32_t i = 0; i < streamCount; ++i) {
-      offsets[i] = encoding::readUint32(pos_);
+    for (uint32_t i = 0; i < streamSizes.size(); ++i) {
+      std::string_view streamData(pos_, streamSizes[i]);
+      pos_ += streamSizes[i];
+      if (!streamData.empty()) {
+        callback(i, streamData);
+      }
     }
-
-    for (uint32_t i = 0; i < streamCount; ++i) {
-      auto streamData = encoding::readString(pos_);
-      callback(offsets[i], streamData);
-    }
+    pos_ = end_; // Skip past trailer.
   } else {
-    NIMBLE_CHECK(options_.denseFormat());
-    // Dense format (version 0): streams in order with zeros for missing.
+    // kLegacy format: streams in order with inline u32 sizes.
     uint32_t offset = 0;
     while (pos_ < end_) {
-      auto streamData = encoding::readString(pos_);
+      uint32_t size = encoding::readUint32(pos_);
+      std::string_view streamData(pos_, size);
+      pos_ += size;
       if (!streamData.empty()) {
         callback(offset, streamData);
       }

--- a/dwio/nimble/serializer/DeserializerImpl.h
+++ b/dwio/nimble/serializer/DeserializerImpl.h
@@ -130,7 +130,9 @@ void StreamData::materialize(uint32_t count, T* output) {
 
 class StreamDataReader {
  public:
-  explicit StreamDataReader(const DeserializerOptions& options);
+  StreamDataReader(
+      velox::memory::MemoryPool* pool,
+      const DeserializerOptions& options);
 
   /// Returns number of rows serialized.
   /// Validates that the version in serialized data matches options.
@@ -140,8 +142,13 @@ class StreamDataReader {
       const std::function<void(uint32_t offset, std::string_view data)>&
           callback);
 
+  bool encodingEnabled() const {
+    return options_.enableEncoding();
+  }
+
  private:
   const DeserializerOptions& options_;
+  velox::memory::MemoryPool* const pool_;
   const char* pos_{nullptr};
   const char* end_{nullptr};
 };

--- a/dwio/nimble/serializer/Options.cpp
+++ b/dwio/nimble/serializer/Options.cpp
@@ -20,14 +20,10 @@ namespace facebook::nimble {
 
 std::string toString(SerializationVersion version) {
   switch (version) {
-    case SerializationVersion::kDense:
-      return "kDense";
-    case SerializationVersion::kSparse:
-      return "kSparse";
-    case SerializationVersion::kDenseEncoded:
-      return "kDenseEncoded";
-    case SerializationVersion::kSparseEncoded:
-      return "kSparseEncoded";
+    case SerializationVersion::kLegacy:
+      return "kLegacy";
+    case SerializationVersion::kCompact:
+      return "kCompact";
   }
   return fmt::format("Unknown({})", static_cast<uint8_t>(version));
 }
@@ -37,23 +33,11 @@ bool SerializerOptions::hasVersionHeader() const {
 }
 
 SerializationVersion SerializerOptions::serializationVersion() const {
-  return version.value_or(SerializationVersion::kDense);
+  return version.value_or(SerializationVersion::kLegacy);
 }
 
 bool SerializerOptions::enableEncoding() const {
-  auto v = serializationVersion();
-  return v == SerializationVersion::kDenseEncoded ||
-      v == SerializationVersion::kSparseEncoded;
-}
-
-bool SerializerOptions::denseFormat() const {
-  return !sparseFormat();
-}
-
-bool SerializerOptions::sparseFormat() const {
-  auto v = serializationVersion();
-  return v == SerializationVersion::kSparse ||
-      v == SerializationVersion::kSparseEncoded;
+  return serializationVersion() == SerializationVersion::kCompact;
 }
 
 bool DeserializerOptions::hasVersionHeader() const {
@@ -61,23 +45,11 @@ bool DeserializerOptions::hasVersionHeader() const {
 }
 
 SerializationVersion DeserializerOptions::serializationVersion() const {
-  return version.value_or(SerializationVersion::kDense);
+  return version.value_or(SerializationVersion::kLegacy);
 }
 
 bool DeserializerOptions::enableEncoding() const {
-  auto v = serializationVersion();
-  return v == SerializationVersion::kDenseEncoded ||
-      v == SerializationVersion::kSparseEncoded;
-}
-
-bool DeserializerOptions::denseFormat() const {
-  return !sparseFormat();
-}
-
-bool DeserializerOptions::sparseFormat() const {
-  const auto v = serializationVersion();
-  return v == SerializationVersion::kSparse ||
-      v == SerializationVersion::kSparseEncoded;
+  return serializationVersion() == SerializationVersion::kCompact;
 }
 
 } // namespace facebook::nimble

--- a/dwio/nimble/serializer/Options.h
+++ b/dwio/nimble/serializer/Options.h
@@ -30,20 +30,19 @@
 namespace facebook::nimble {
 
 /// Serialization format version.
-/// Combines stream format (Dense/Sparse) with encoding type (legacy/nimble).
 ///
-/// Stream formats:
-/// - Dense: Streams in offset order, zeros for missing streams
-/// - Sparse: Explicit stream_count and offsets array
+/// - kLegacy: Simple zstd compression with inline u32 sizes.
+///   Wire:
+///   [version:1B][rowCount:u32][size_0:u32][stream_data_0]...[size_N:u32][stream_data_N]
 ///
-/// Encoding types:
-/// - Legacy: Simple zstd compression [size:u32][compression_type:i8][data...]
-/// - Encoded: Nimble encoding framework (Dictionary, RLE, etc.)
+/// - kCompact: Nimble encoding with a dense sizes trailer.
+///   Wire: [version:1B][rowCount:varint][stream_data_0]...[stream_data_N]
+///         [encoded_stream_sizes][stream_sizes_encoded_size:u32]
+///   The trailer contains nimble-encoded stream sizes (sizes[i] = byte size
+///   of stream i, 0 for missing) followed by the encoded sizes length (u32).
 enum class SerializationVersion : uint8_t {
-  kDense = 0, // Dense format, legacy compression
-  kSparse = 1, // Sparse format, legacy compression
-  kDenseEncoded = 2, // Dense format, nimble encoding
-  kSparseEncoded = 3, // Sparse format, nimble encoding
+  kLegacy = 0,
+  kCompact = 1,
 };
 
 std::string toString(SerializationVersion version);
@@ -60,16 +59,16 @@ struct SerializerOptions {
   int32_t compressionLevel{0};
 
   /// Serialization format version.
-  /// - nullopt (default): Dense format with no version header (kDense).
-  /// - kDense/kSparse: Legacy compression format.
-  /// - kDenseEncoded/kSparseEncoded: Nimble encoding format.
+  /// - nullopt (default): Legacy format with no version header (kLegacy).
+  /// - kLegacy: Legacy compression format.
+  /// - kCompact: Nimble encoding format with dense sizes header.
   std::optional<SerializationVersion> version{};
 
   /// Columns that should be encoded as flat maps.
   folly::F14FastSet<std::string> flatMapColumns{};
 
   /// Factory for creating encoding selection policies.
-  /// Only used when version is kDenseEncoded or kSparseEncoded.
+  /// Only used when version is kCompact.
   /// Falls back to this when encodingLayoutTree doesn't have a layout for a
   /// stream.
   EncodingSelectionPolicyFactory encodingSelectionPolicyFactory =
@@ -78,7 +77,7 @@ struct SerializerOptions {
   };
 
   /// Compression options for encodings.
-  /// Only used when version is kDenseEncoded or kSparseEncoded.
+  /// Only used when version is kCompact.
   CompressionOptions compressionOptions{};
 
   /// Optional captured encoding layout tree.
@@ -89,27 +88,37 @@ struct SerializerOptions {
   /// tree.
   std::optional<EncodingLayoutTree> encodingLayoutTree{};
 
-  // Helper methods for version checks
+  /// Optional encoding type for stream sizes in the sizes header.
+  /// When specified, forces sizes to use this encoding type.
+  /// When nullopt (default), uses cost-based selection via
+  /// ManualEncodingSelectionPolicyFactory.
+  std::optional<EncodingType> streamSizesEncodingType{};
+
+  /// Returns true if the serialized data has a version header byte.
   bool hasVersionHeader() const;
+
+  /// Returns the effective serialization version.
   SerializationVersion serializationVersion() const;
+
+  /// Returns true if nimble encoding is enabled (version is kCompact).
   bool enableEncoding() const;
-  bool denseFormat() const;
-  bool sparseFormat() const;
 };
 
 struct DeserializerOptions {
   /// Serialization format version expected in the input.
-  /// - nullopt (default): Dense format (version 0) with no version header.
-  /// - kDense/kSparse: Legacy compression format.
-  /// - kDenseEncoded/kSparseEncoded: Nimble encoding format.
+  /// - nullopt (default): Legacy format (version 0) with no version header.
+  /// - kLegacy: Legacy compression format.
+  /// - kCompact: Nimble encoding format with dense sizes header.
   std::optional<SerializationVersion> version{};
 
-  // Helper methods for version checks
+  /// Returns true if the serialized data has a version header byte.
   bool hasVersionHeader() const;
+
+  /// Returns the effective serialization version.
   SerializationVersion serializationVersion() const;
+
+  /// Returns true if nimble encoding is enabled (version is kCompact).
   bool enableEncoding() const;
-  bool denseFormat() const;
-  bool sparseFormat() const;
 };
 
 } // namespace facebook::nimble

--- a/dwio/nimble/serializer/Projector.cpp
+++ b/dwio/nimble/serializer/Projector.cpp
@@ -197,7 +197,6 @@ std::shared_ptr<const Type> updateColumnNames(
   }
 }
 
-// Tracks which children are selected at each RowType/FlatMapType.
 // Matches Projector::SelectedChildrenMap.
 using SelectedChildrenMap = folly::F14FastMap<const Type*, std::set<size_t>>;
 
@@ -565,14 +564,22 @@ void Projector::buildProjectedSchema(
 Projector::Projector(
     std::shared_ptr<const Type> inputSchema,
     const std::vector<Subfield>& projectSubfields,
+    velox::memory::MemoryPool* pool,
     Options options)
-    : options_(std::move(options)), inputSchema_(std::move(inputSchema)) {
+    : pool_(pool),
+      options_(std::move(options)),
+      inputSchema_(std::move(inputSchema)) {
+  NIMBLE_CHECK_NOT_NULL(pool_, "Memory pool cannot be null");
   NIMBLE_CHECK_NOT_NULL(inputSchema_, "Input schema cannot be null");
   NIMBLE_CHECK(
       inputSchema_->isRow(),
       "Input schema must be a RowType, got: {}",
       inputSchema_->kind());
   NIMBLE_CHECK(!projectSubfields.empty(), "Must project at least one subfield");
+  NIMBLE_CHECK_EQ(
+      options_.projectVersion,
+      SerializationVersion::kCompact,
+      "Projection output version must be kCompact");
 
   // Update inputSchema_ with projectType names for schema evolution.
   if (options_.projectType) {
@@ -604,81 +611,46 @@ std::string Projector::project(std::string_view input) const {
   const char* end = input.data() + input.size();
 
   // Parse input header.
-  SerializationVersion inputVersion = SerializationVersion::kDense;
+  SerializationVersion inputVersion = SerializationVersion::kLegacy;
   if (options_.inputHasVersionHeader) {
     inputVersion = static_cast<SerializationVersion>(*pos++);
   }
 
-  // Verify input/output format compatibility.
-  // Projector copies raw bytes, so encoding type must match:
-  // - kDense/kSparse use legacy raw encoding
-  // - kDenseEncoded/kSparseEncoded use nimble encoding
-  const bool inputEncoded =
-      (inputVersion == SerializationVersion::kDenseEncoded ||
-       inputVersion == SerializationVersion::kSparseEncoded);
-  const bool outputEncoded =
-      (options_.projectVersion == SerializationVersion::kDenseEncoded ||
-       options_.projectVersion == SerializationVersion::kSparseEncoded);
+  // Input must also be kCompact — projector copies raw bytes, so encoding
+  // format must match. kLegacy uses zstd compression while kCompact uses
+  // nimble encoding; cross-format projection would require re-encoding.
   NIMBLE_CHECK_EQ(
-      inputEncoded,
-      outputEncoded,
-      "Incompatible input/output formats: input={}, output={}. "
-      "Cannot project between raw and encoded formats.",
-      static_cast<int>(inputVersion),
-      static_cast<int>(options_.projectVersion));
+      inputVersion,
+      SerializationVersion::kCompact,
+      "Input must be kCompact format, got: {}",
+      inputVersion);
 
   // Fast path: pass-through when all streams selected and formats match.
-  if (passThrough_ && options_.inputHasVersionHeader &&
-      inputVersion == options_.projectVersion) {
+  if (passThrough_ && options_.inputHasVersionHeader) {
     return std::string(input);
   }
 
-  // Encoded versions use varint for compact row counts.
-  uint32_t rowCount;
-  if (inputEncoded) {
-    rowCount = varint::readVarint32(&pos);
-  } else {
-    rowCount = encoding::readUint32(pos);
-  }
+  const uint32_t rowCount = varint::readVarint32(&pos);
 
   // Parse only selected streams, skipping empty ones.
-  auto projectedStreams =
-      detail::projectStreams(pos, end, inputVersion, inputStreamIndices_);
+  auto projectedStreams = detail::projectStreams(
+      pos, end, inputVersion, inputStreamIndices_, pool_);
 
-  const bool outputSparse =
-      (options_.projectVersion == SerializationVersion::kSparse ||
-       options_.projectVersion == SerializationVersion::kSparseEncoded);
-
-  // Build output buffer.
+  // Build output buffer: header, stream data, then trailer with sizes.
   std::string output;
   output.reserve(input.size());
 
-  if (outputSparse) {
-    // Sparse output: write only non-empty streams with their offsets.
-    std::vector<uint32_t> streamOffsets;
-    streamOffsets.reserve(projectedStreams.size());
-    for (const auto& stream : projectedStreams) {
-      streamOffsets.emplace_back(stream.index);
-    }
-    detail::writeHeader(
-        output, options_.projectVersion, rowCount, streamOffsets);
-    for (const auto& stream : projectedStreams) {
-      detail::writeStream(output, stream.data);
-    }
-  } else {
-    // Dense output: write all selected streams in order, including empty ones.
-    detail::writeHeader(output, options_.projectVersion, rowCount, {});
-    uint32_t nextProjected = 0;
-    for (uint32_t i = 0; i < inputStreamIndices_.size(); ++i) {
-      if (nextProjected < projectedStreams.size() &&
-          projectedStreams[nextProjected].index == i) {
-        detail::writeStream(output, projectedStreams[nextProjected].data);
-        ++nextProjected;
-      } else {
-        detail::writeStream(output, {});
-      }
-    }
+  std::vector<uint32_t> streamSizes(inputStreamIndices_.size(), 0);
+  for (const auto& stream : projectedStreams) {
+    streamSizes[stream.index] = stream.data.size();
   }
+  detail::writeHeader(output, options_.projectVersion, rowCount);
+  for (const auto& stream : projectedStreams) {
+    auto* dataPos = detail::extend(output, stream.data.size());
+    std::memcpy(dataPos, stream.data.data(), stream.data.size());
+  }
+  detail::writeTrailer(
+      streamSizes, options_.streamSizesEncodingType, pool_, output);
 
   return output;
 }

--- a/dwio/nimble/serializer/Projector.h
+++ b/dwio/nimble/serializer/Projector.h
@@ -25,6 +25,7 @@
 #include "dwio/nimble/serializer/Options.h"
 #include "dwio/nimble/velox/SchemaReader.h"
 #include "folly/container/F14Map.h"
+#include "velox/common/memory/Memory.h"
 #include "velox/type/Subfield.h"
 #include "velox/type/Type.h"
 
@@ -73,12 +74,13 @@ class Projector {
     /// If false, input is assumed to be legacy dense format (raw encoding).
     bool inputHasVersionHeader{false};
 
-    /// Output serialization format version.
-    /// The output always has a version header.
-    /// Must be compatible with input encoding type:
-    /// - Raw formats (kDense/kSparse) for legacy or raw input
-    /// - Encoded formats (kDenseEncoded/kSparseEncoded) for encoded input
-    SerializationVersion projectVersion{SerializationVersion::kSparseEncoded};
+    /// Output serialization format version. Must be kCompact.
+    SerializationVersion projectVersion{SerializationVersion::kCompact};
+
+    /// Optional encoding type for stream sizes in the sizes header.
+    /// When specified, forces sizes to use this encoding type.
+    /// When nullopt (default), uses cost-based selection.
+    std::optional<EncodingType> streamSizesEncodingType{};
 
     /// Optional velox type with up-to-date column names from the current
     /// table schema. After schema evolution (e.g., column renames), the
@@ -92,11 +94,14 @@ class Projector {
   /// @param inputSchema Nimble schema of serialized data.
   /// @param projectSubfields Columns to project (using projectType names if
   ///        set).
+  /// @param pool Memory pool for encoding/decoding offsets in sparse format.
+  ///        Must not be null.
   /// @param options Includes optional projectType for schema evolution.
   /// @throws If a subfield path cannot be resolved against the schema.
   Projector(
       std::shared_ptr<const Type> inputSchema,
       const std::vector<Subfield>& projectSubfields,
+      velox::memory::MemoryPool* pool,
       Options options);
 
   /// Projects a single input buffer.
@@ -133,6 +138,7 @@ class Projector {
   // match the data layout produced by project().
   void buildProjectedSchema(const SelectedChildrenMap& selectedChildren);
 
+  velox::memory::MemoryPool* const pool_;
   const Options options_;
 
   std::shared_ptr<const Type> inputSchema_;

--- a/dwio/nimble/serializer/Serializer.h
+++ b/dwio/nimble/serializer/Serializer.h
@@ -82,8 +82,6 @@ class Serializer {
   mutable FieldWriterContext context_;
   std::unique_ptr<FieldWriter> writer_;
   mutable Vector<char> buffer_;
-  // Reusable buffer for collecting non-empty streams during serialization.
-  mutable std::vector<const StreamData*> nonEmptyStreams_;
   // Map from stream offset to encoding layout for replaying captured encodings.
   // Only populated when options_.encodingLayoutTree is set.
   // Mutable because FlatMap keys can be added during const serialize().
@@ -98,38 +96,16 @@ void Serializer::serialize(
     T& buffer) const {
   writer_->write(vector, ranges);
 
-  // For kSparse format, collect non-empty streams upfront (needed for header).
-  // For kDense format, we iterate over all streams and skip empty ones.
-  if (options_.sparseFormat()) {
-    NIMBLE_CHECK(nonEmptyStreams_.empty());
-    nonEmptyStreams_.reserve(context_.streams().size());
-    for (auto& [_, streamData] : context_.streams()) {
-      if (!streamData->data().empty() || !streamData->nonNulls().empty()) {
-        nonEmptyStreams_.push_back(streamData.get());
-      }
-    }
-  }
-
-  // Write header and stream data.
   serde::StreamDataWriter<T> streamWriter{
       options_,
       buffer,
       static_cast<uint32_t>(ranges.size()),
-      nonEmptyStreams_,
       pool_,
       getStreamEncodingLayouts()};
-  if (options_.sparseFormat()) {
-    for (const auto* streamData : nonEmptyStreams_) {
-      streamWriter.writeData(*streamData);
-    }
-    nonEmptyStreams_.clear();
-  } else {
-    NIMBLE_CHECK(options_.denseFormat());
-    for (auto& [_, streamData] : context_.streams()) {
-      streamWriter.writeData(*streamData);
-    }
+  for (auto& [_, streamData] : context_.streams()) {
+    streamWriter.writeData(*streamData);
   }
-  // Pass nodeCount for SerializationVersion::kDense to fill trailing zeros.
+  // Pass nodeCount for kLegacy to fill trailing zeros.
   streamWriter.close(context_.schemaBuilder().nodeCount());
 
   writer_->reset();

--- a/dwio/nimble/serializer/SerializerImpl.h
+++ b/dwio/nimble/serializer/SerializerImpl.h
@@ -25,7 +25,6 @@
 #include "dwio/nimble/encodings/EncodingFactory.h"
 #include "dwio/nimble/serializer/Options.h"
 #include "dwio/nimble/velox/StreamData.h"
-#include "folly/container/F14Map.h"
 #include "velox/common/Casts.h"
 #include "velox/common/memory/Memory.h"
 
@@ -42,7 +41,8 @@ void encodeStrings(std::string_view input, uint32_t size, char* output);
 uint32_t
 encode(const SerializerOptions& options, std::string_view input, char* output);
 
-/// Write zeros for missing streams in dense format (version 0).
+/// Write zeros for missing streams in kLegacy format.
+/// Each missing stream is a zero-length stream (size=0, u32 = 4 bytes).
 template <typename T>
 void writeMissingStreams(T& buffer, uint32_t lastStream, uint32_t nextStream) {
   NIMBLE_CHECK_LE(lastStream + 1, nextStream, "unexpected stream offset");
@@ -62,144 +62,193 @@ char* extend(T& buffer, uint32_t size) {
   return buffer.data() + oldSize;
 }
 
+/// Encode typed values using a given encoding selection policy factory.
+/// When encodingLayout is provided, replays the captured encoding.
+/// Otherwise, uses the policy factory to select encoding.
+template <typename T>
+std::string_view encodeTyped(
+    std::span<const T> values,
+    nimble::Buffer& encodingBuffer,
+    const EncodingSelectionPolicyFactory& policyFactory,
+    const CompressionOptions& compressionOptions = {},
+    const EncodingLayout* encodingLayout = nullptr) {
+  std::unique_ptr<EncodingSelectionPolicy<T>> typedPolicy;
+  if (encodingLayout != nullptr) {
+    typedPolicy = std::make_unique<ReplayedEncodingSelectionPolicy<T>>(
+        *encodingLayout, compressionOptions, policyFactory);
+  } else {
+    auto policy = policyFactory(TypeTraits<T>::dataType);
+    auto* rawTypedPolicy =
+        dynamic_cast<EncodingSelectionPolicy<T>*>(policy.release());
+    NIMBLE_CHECK_NOT_NULL(
+        rawTypedPolicy,
+        "Policy type mismatch for {}",
+        toString(TypeTraits<T>::dataType));
+    typedPolicy.reset(rawTypedPolicy);
+  }
+  return EncodingFactory::encode<T>(
+      std::move(typedPolicy),
+      values,
+      encodingBuffer,
+      Encoding::Options{.useVarintRowCount = true});
+}
+
+/// Reads the encoded stream sizes size (u32) from the kCompact trailer.
+/// The last 4 bytes of the buffer store the byte size of the encoded sizes.
+inline uint32_t readStreamSizesEncodedSize(const char* end) {
+  const char* pos = end - sizeof(uint32_t);
+  return encoding::readUint32(pos);
+}
+
+/// Decodes the nimble-encoded stream sizes array.
+/// Element count is self-describing (stored in the nimble encoding header).
+/// sizes[i] = byte size of stream i (0 for missing).
+inline std::vector<uint32_t> decodeStreamSizes(
+    std::string_view encodedSizes,
+    velox::memory::MemoryPool* pool) {
+  NIMBLE_CHECK_NOT_NULL(pool);
+  auto encoding = EncodingFactory::decode(
+      *pool,
+      encodedSizes,
+      nullptr,
+      Encoding::Options{.useVarintRowCount = true});
+  const uint32_t count = encoding->rowCount();
+  std::vector<uint32_t> values(count);
+  encoding->materialize(count, values.data());
+  return values;
+}
+
 /// Writes serialization header to buffer.
 /// Works with any buffer type that has size(), resize(), and data() methods.
+///
+/// kLegacy wire format:
+///   [version:1B][rowCount:u32][size_0:u32][stream_data_0]...[size_N:u32][stream_data_N]
+///
+/// kCompact wire format:
+///   [version:1B][rowCount:varint][stream_data_0][stream_data_1]...[encoded_stream_sizes][stream_sizes_encoded_size:u32]
+///
+/// For kLegacy: writes [optional_version:1B][rowCount:u32]
+/// For kCompact: writes [version:1B][rowCount:varint]
 ///
 /// @param buffer Output buffer (std::string, velox::Buffer, etc.)
 /// @param version Serialization format version (nullopt = no version byte)
 /// @param rowCount Number of rows
-/// @param streamOffsets Stream offsets for sparse format (empty for dense)
 template <typename T>
 void writeHeader(
     T& buffer,
     std::optional<SerializationVersion> version,
-    uint32_t rowCount,
-    const std::vector<uint32_t>& streamOffsets) {
+    uint32_t rowCount) {
   // Write version byte if provided.
-  bool sparseFormat = false;
   if (version.has_value()) {
     auto* versionPos = extend(buffer, 1);
     *versionPos = static_cast<char>(version.value());
-    sparseFormat =
-        (version.value() == SerializationVersion::kSparse ||
-         version.value() == SerializationVersion::kSparseEncoded);
   }
 
-  // Write row count.
-  // Encoded versions (kDenseEncoded, kSparseEncoded) use varint for compact
-  // row counts.
-  const bool useVarint = version.has_value() &&
-      (version.value() == SerializationVersion::kDenseEncoded ||
-       version.value() == SerializationVersion::kSparseEncoded);
-  if (useVarint) {
+  const bool isDense =
+      version.has_value() && version.value() == SerializationVersion::kCompact;
+  if (isDense) {
     auto* rowCountPos = extend(buffer, varint::varintSize(rowCount));
     varint::writeVarint(rowCount, &rowCountPos);
   } else {
     auto* rowCountPos = extend(buffer, sizeof(uint32_t));
     encoding::writeUint32(rowCount, rowCountPos);
   }
+}
 
-  // Sparse format: write stream count and offsets.
-  if (sparseFormat) {
-    auto* streamCountPos = extend(buffer, sizeof(uint32_t));
-    encoding::writeUint32(
-        static_cast<uint32_t>(streamOffsets.size()), streamCountPos);
+/// Writes the kCompact trailer: appends
+/// [encoded_stream_sizes][stream_sizes_encoded_size:u32] to buffer.
+///
+/// @param streamSizes Dense stream sizes array. sizes[i] = byte size of
+///        stream i (0 for missing).
+/// @param streamSizesEncodingType Optional encoding type override.
+/// @param pool Memory pool for encoding.
+/// @param buffer Output buffer.
+template <typename T>
+void writeTrailer(
+    const std::vector<uint32_t>& streamSizes,
+    std::optional<EncodingType> streamSizesEncodingType,
+    velox::memory::MemoryPool* pool,
+    T& buffer) {
+  NIMBLE_CHECK_NOT_NULL(pool);
+  nimble::Buffer encodingBuffer{*pool};
+  auto factory = streamSizesEncodingType.has_value()
+      ? ManualEncodingSelectionPolicyFactory({{*streamSizesEncodingType, 1.0}})
+      : ManualEncodingSelectionPolicyFactory();
+  auto encodedStreamSizes = encodeTyped<uint32_t>(
+      streamSizes, encodingBuffer, [&factory](DataType dataType) {
+        return factory.createPolicy(dataType);
+      });
+  const uint32_t encodedSize = encodedStreamSizes.size();
+  auto* encodedStreamSizesPos = extend(buffer, encodedSize);
+  std::memcpy(encodedStreamSizesPos, encodedStreamSizes.data(), encodedSize);
 
-    for (uint32_t offset : streamOffsets) {
-      auto* offsetPos = extend(buffer, sizeof(uint32_t));
-      encoding::writeUint32(offset, offsetPos);
-    }
-  }
+  // Append encodedSize as fixed u32 at the very end.
+  auto* encodedSizePos = extend(buffer, sizeof(uint32_t));
+  encoding::writeUint32(encodedSize, encodedSizePos);
 }
 
 /// Writes a single stream to the buffer.
-/// Writes [size:u32][data...] format used by all serialization versions.
+/// Writes [size][data...] where size is varint (useVarint=true) or u32
+/// (useVarint=false).
 ///
-/// @param buffer Output buffer (std::string, velox::Buffer, etc.)
+/// @tparam useVarint True for varint size prefix, false for u32
 /// @param streamData The stream data to write
-template <typename T>
-void writeStream(T& buffer, std::string_view streamData) {
-  auto* sizePos = extend(buffer, sizeof(uint32_t));
-  encoding::writeUint32(streamData.size(), sizePos);
-
-  if (!streamData.empty()) {
-    auto* dataPos = extend(buffer, streamData.size());
-    std::memcpy(dataPos, streamData.data(), streamData.size());
+/// @param buffer Output buffer (std::string, velox::Buffer, etc.)
+template <bool useVarint, typename T>
+void writeStream(std::string_view streamData, T& buffer) {
+  const uint32_t dataSize = streamData.size();
+  uint32_t prefixSize;
+  if constexpr (useVarint) {
+    prefixSize = varint::varintSize(dataSize);
+  } else {
+    prefixSize = sizeof(uint32_t);
+  }
+  auto* pos = extend(buffer, prefixSize + dataSize);
+  if constexpr (useVarint) {
+    varint::writeVarint(dataSize, &pos);
+  } else {
+    encoding::writeUint32(dataSize, pos);
+  }
+  if (dataSize > 0) {
+    std::memcpy(pos, streamData.data(), dataSize);
   }
 }
 
 /// Reads a single stream from the buffer.
-/// Reads [size:u32][data...] format used by all serialization versions.
-/// Advances pos past the stream.
+/// Reads [size][data...] where size is varint (useVarint=true) or u32
+/// (useVarint=false). Advances pos past the stream.
 ///
+/// @tparam useVarint True for varint size prefix, false for u32
 /// @param pos Pointer to current position (updated after read)
 /// @return View of the stream data
-inline std::string_view readStream(const char*& pos) {
-  const uint32_t size = encoding::readUint32(pos);
+template <bool useVarint>
+std::string_view readStream(const char*& pos) {
+  uint32_t size;
+  if constexpr (useVarint) {
+    size = varint::readVarint32(&pos);
+  } else {
+    size = encoding::readUint32(pos);
+  }
   std::string_view data(pos, size);
   pos += size;
   return data;
 }
 
 /// Skips a single stream in the buffer without reading its data.
-/// Advances pos past [size:u32][data...].
-inline void skipStream(const char*& pos) {
-  const uint32_t size = encoding::readUint32(pos);
+/// Advances pos past [size][data...].
+template <bool useVarint>
+void skipStream(const char*& pos) {
+  uint32_t size;
+  if constexpr (useVarint) {
+    size = varint::readVarint32(&pos);
+  } else {
+    size = encoding::readUint32(pos);
+  }
   pos += size;
 }
 
-/// Parses all streams from a serialized buffer.
-/// Returns a vector of stream data indexed by their original offset.
-///
-/// For dense format: Returns streams in order (index = offset).
-/// For sparse format: Returns streams indexed by their offset from header.
-///
-/// @param pos Pointer past the header (version + rowCount already read)
-/// @param end End of buffer
-/// @param version Serialization format version
-/// @return Vector of stream data (may have gaps for dense format)
-inline std::vector<std::string_view>
-parseStreams(const char* pos, const char* end, SerializationVersion version) {
-  std::vector<std::string_view> streams;
-
-  const bool sparseFormat =
-      (version == SerializationVersion::kSparse ||
-       version == SerializationVersion::kSparseEncoded);
-  if (sparseFormat) {
-    // Sparse format: [stream_count:u32][offsets...][stream_data...]
-    const uint32_t streamCount = encoding::readUint32(pos);
-    std::vector<uint32_t> offsets(streamCount);
-    uint32_t maxOffset = 0;
-    for (uint32_t i = 0; i < streamCount; ++i) {
-      offsets[i] = encoding::readUint32(pos);
-      maxOffset = std::max(maxOffset, offsets[i]);
-    }
-    if (streamCount > 0) {
-      streams.resize(maxOffset + 1);
-    }
-
-    // Read streams and place at their offsets.
-    for (uint32_t i = 0; i < streamCount; ++i) {
-      streams[offsets[i]] = readStream(pos);
-    }
-  } else {
-    NIMBLE_CHECK(
-        version == SerializationVersion::kDense ||
-            version == SerializationVersion::kDenseEncoded,
-        "unexpected version {}",
-        version);
-    // Dense format: [stream_0][stream_1]...
-    // Each stream: [size:u32][data...]
-    while (pos < end) {
-      streams.emplace_back(readStream(pos));
-    }
-  }
-
-  return streams;
-}
-
 struct ProjectedStream {
-  // Index into selectedIndices (0-based output stream index).
+  // Index into selectedStreamIndices (0-based output stream index).
   uint32_t index;
   std::string_view data;
 
@@ -214,75 +263,63 @@ struct ProjectedStream {
 /// @param pos Pointer past the header (version + rowCount already read)
 /// @param end End of buffer
 /// @param version Serialization format version
-/// @param selectedIndices Sorted input stream indices to extract
+/// @param selectedStreamIndices Sorted input stream indices to extract
+/// @param pool Memory pool for decoding nimble-encoded sizes
 /// @return Non-empty projected streams sorted by output offset
 inline std::vector<ProjectedStream> projectStreams(
     const char* pos,
     const char* end,
     SerializationVersion version,
-    const std::vector<uint32_t>& selectedIndices) {
+    const std::vector<uint32_t>& selectedStreamIndices,
+    velox::memory::MemoryPool* pool) {
+  NIMBLE_CHECK_NOT_NULL(pool);
   std::vector<ProjectedStream> streams;
-  streams.reserve(selectedIndices.size());
+  streams.reserve(selectedStreamIndices.size());
 
-  const bool sparseFormat =
-      (version == SerializationVersion::kSparse ||
-       version == SerializationVersion::kSparseEncoded);
-  if (sparseFormat) {
-    // Sparse: read offsets, then selectively read only needed stream data.
-    const uint32_t streamCount = encoding::readUint32(pos);
-    std::vector<uint32_t> offsets(streamCount);
-    for (uint32_t i = 0; i < streamCount; ++i) {
-      offsets[i] = encoding::readUint32(pos);
-    }
+  if (version == SerializationVersion::kCompact) {
+    // kCompact: read encodedSize from last 4 bytes, decode sizes from trailer.
+    const uint32_t encodedSize = readStreamSizesEncodedSize(end);
+    auto streamSizes = decodeStreamSizes(
+        {end - sizeof(uint32_t) - encodedSize, encodedSize}, pool);
+    const char* dataStart = pos;
 
-    // Build lookup: input offset -> output index.
-    folly::F14FastMap<uint32_t, uint32_t> projectedOffsets;
-    projectedOffsets.reserve(selectedIndices.size());
-    for (uint32_t i = 0; i < selectedIndices.size(); ++i) {
-      projectedOffsets[selectedIndices[i]] = i;
-    }
-
-    bool needsSort = false;
-    for (uint32_t i = 0; i < streamCount; ++i) {
-      auto it = projectedOffsets.find(offsets[i]);
-      if (it != projectedOffsets.end()) {
-        auto data = readStream(pos);
-        if (!data.empty()) {
-          // Sparse offsets are typically written in order by the serializer,
-          // but the format does not guarantee it.
-          if (FOLLY_UNLIKELY(
-                  !streams.empty() && it->second < streams.back().index)) {
-            needsSort = true;
-          }
-          streams.push_back({it->second, data});
+    // selectedStreamIndices is sorted. Walk through streamSizes, accumulating
+    // data offsets, and extract data for selected indices.
+    uint32_t dataOffset = 0;
+    uint32_t nextSelectedStreamIdx = 0;
+    const uint32_t numStreams = streamSizes.size();
+    for (uint32_t i = 0;
+         i < numStreams && nextSelectedStreamIdx < selectedStreamIndices.size();
+         ++i) {
+      if (i == selectedStreamIndices[nextSelectedStreamIdx]) {
+        if (streamSizes[i] > 0) {
+          streams.emplace_back(
+              ProjectedStream{
+                  nextSelectedStreamIdx,
+                  {dataStart + dataOffset, streamSizes[i]}});
         }
-      } else {
-        skipStream(pos);
+        ++nextSelectedStreamIdx;
       }
-    }
-
-    if (needsSort) {
-      std::sort(streams.begin(), streams.end());
+      dataOffset += streamSizes[i];
     }
   } else {
-    NIMBLE_CHECK(
-        version == SerializationVersion::kDense ||
-            version == SerializationVersion::kDenseEncoded,
+    NIMBLE_CHECK_EQ(
+        version,
+        SerializationVersion::kLegacy,
         "unexpected version {}",
         version);
-    // Dense: read streams sequentially, skip unneeded ones.
-    // selectedIndices is sorted, so we walk through in order.
+    // kLegacy: read streams sequentially with inline u32 sizes.
     for (uint32_t streamIdx = 0, nextProjected = 0;
-         pos < end && nextProjected < selectedIndices.size();
+         pos < end && nextProjected < selectedStreamIndices.size();
          ++streamIdx) {
-      if (streamIdx == selectedIndices[nextProjected]) {
-        auto data = readStream(pos);
+      if (streamIdx == selectedStreamIndices[nextProjected]) {
+        auto data = readStream<false>(pos);
         if (!data.empty()) {
-          streams.push_back({nextProjected, data});
+          streams.emplace_back(ProjectedStream{nextProjected, data});
         }
         ++nextProjected;
       } else {
-        skipStream(pos);
+        skipStream<false>(pos);
       }
     }
   }
@@ -290,10 +327,56 @@ inline std::vector<ProjectedStream> projectStreams(
   return streams;
 }
 
-/// Encode scalar data using nimble encoding framework.
-/// When encodingLayout is provided, replays the captured encoding.
-/// Otherwise, uses encodingSelectionPolicyFactory to select encoding.
-/// Returns the encoded data as string_view into the encoding buffer.
+/// Parses all streams from a serialized buffer.
+/// Returns a vector of stream data indexed by their original offset.
+///
+/// For kLegacy: Returns streams in order with inline u32 sizes.
+/// For kCompact: Returns streams indexed by their offset from sizes header.
+///
+/// @param pos Pointer past the header (version + rowCount already read)
+/// @param end End of buffer
+/// @param version Serialization format version
+/// @param pool Memory pool for decoding nimble-encoded sizes.
+/// @return Vector of stream data (may have gaps for kLegacy format)
+inline std::vector<std::string_view> parseStreams(
+    const char* pos,
+    const char* end,
+    SerializationVersion version,
+    velox::memory::MemoryPool* pool) {
+  NIMBLE_CHECK_NOT_NULL(pool, "Memory pool cannot be null");
+
+  std::vector<std::string_view> streams;
+
+  if (version == SerializationVersion::kCompact) {
+    // kCompact format:
+    // [stream_data_0]...[stream_data_N][encoded_stream_sizes][stream_sizes_encoded_size:u32]
+    // Read stream_sizes_encoded_size from last 4 bytes, decode sizes from
+    // trailer.
+    const uint32_t encodedSize = readStreamSizesEncodedSize(end);
+    auto streamSizes = decodeStreamSizes(
+        {end - sizeof(uint32_t) - encodedSize, encodedSize}, pool);
+    streams.resize(streamSizes.size());
+
+    for (uint32_t i = 0; i < streamSizes.size(); ++i) {
+      streams[i] = std::string_view(pos, streamSizes[i]);
+      pos += streamSizes[i];
+    }
+  } else {
+    NIMBLE_CHECK_EQ(
+        version,
+        SerializationVersion::kLegacy,
+        "unexpected version {}",
+        version);
+    // kLegacy format: inline [size:u32][data]...
+    while (pos < end) {
+      streams.emplace_back(readStream<false>(pos));
+    }
+  }
+
+  return streams;
+}
+
+/// Encode scalar data using nimble encoding framework with serializer options.
 template <typename T, typename Buffer>
 std::string_view encodeTyped(
     const SerializerOptions& options,
@@ -303,34 +386,12 @@ std::string_view encodeTyped(
     const EncodingLayout* encodingLayout) {
   const auto count = data.size() / sizeof(T);
   std::span<const T> values{reinterpret_cast<const T*>(data.data()), count};
-
-  std::unique_ptr<EncodingSelectionPolicy<T>> typedPolicy;
-  if (encodingLayout != nullptr) {
-    // Replay captured encoding from encodingLayoutTree.
-    typedPolicy = std::make_unique<ReplayedEncodingSelectionPolicy<T>>(
-        *encodingLayout,
-        options.compressionOptions,
-        options.encodingSelectionPolicyFactory);
-  } else {
-    // Use encoding selection policy factory to determine encoding.
-    auto policy =
-        options.encodingSelectionPolicyFactory(TypeTraits<T>::dataType);
-    auto* rawTypedPolicy =
-        dynamic_cast<EncodingSelectionPolicy<T>*>(policy.release());
-    NIMBLE_CHECK_NOT_NULL(
-        rawTypedPolicy,
-        "Policy type mismatch for {}",
-        toString(TypeTraits<T>::dataType));
-    typedPolicy.reset(rawTypedPolicy);
-  }
-
-  // Encoded versions always use varint for compact row counts in encoding
-  // prefixes.
-  return EncodingFactory::encode<T>(
-      std::move(typedPolicy),
+  return encodeTyped<T>(
       values,
       encodingBuffer,
-      Encoding::Options{.useVarintRowCount = true});
+      options.encodingSelectionPolicyFactory,
+      options.compressionOptions,
+      encodingLayout);
 }
 
 /// Dispatch to typed nimble encoding based on ScalarKind.
@@ -391,31 +452,28 @@ std::string_view encodeScalar(
 template <typename T>
 class StreamDataWriter {
  public:
-  /// Constructor writes the header:
-  /// - No version header: [rowCount]...
-  /// - With version header: [version][rowCount]...
-  /// - Sparse format adds: [stream_count][offsets...]
+  /// Constructor. For kLegacy, writes the header immediately. For kCompact,
+  /// writes the header prefix (version + rowCount).
   ///
-  /// @param nonEmptyStreams Required for kSparse format (to write stream_count
-  ///        and offsets in header). Ignored for kDense format.
   /// @param pool Memory pool for encoding buffer allocation.
-  /// @param encodingLayoutTree Optional encoding layout tree for replaying
+  /// @param streamEncodingLayouts Optional encoding layouts for replaying
   ///        captured encodings. When provided, looks up EncodingLayout by
   ///        stream offset and uses ReplayedEncodingSelectionPolicy.
   StreamDataWriter(
       const SerializerOptions& options,
       T& buffer,
       uint32_t rowCount,
-      const std::vector<const nimble::StreamData*>& nonEmptyStreams,
       velox::memory::MemoryPool* pool,
       const std::unordered_map<uint32_t, const EncodingLayout*>*
           streamEncodingLayouts);
 
-  /// Write encoded data for a single stream directly to buffer.
+  /// Write encoded data for a single stream.
+  /// For both formats, writes directly to buffer.
+  /// For kCompact, also tracks stream sizes for the trailer.
   void writeData(const nimble::StreamData& streamData);
 
-  /// Close the writer. For dense format, fills trailing zeros up to nodeCount.
-  /// For sparse format, this is a no-op (header already written).
+  /// Close the writer. For kLegacy, fills trailing zeros up to nodeCount.
+  /// For kCompact, writes the trailer (encoded sizes).
   void close(uint32_t nodeCount = 0);
 
  private:
@@ -437,8 +495,11 @@ class StreamDataWriter {
 
   // --- Mutable members ---
   T& buffer_;
-  // Track last stream offset for dense format zero-filling.
+  // Track last stream offset for kLegacy format zero-filling.
   uint32_t lastStream_{0xffffffff};
+  // Dense stream sizes for kCompact trailer. streamSizes_[i] = byte size of
+  // stream i (0 for missing/empty).
+  std::vector<uint32_t> streamSizes_;
 };
 
 template <typename T>
@@ -446,7 +507,6 @@ StreamDataWriter<T>::StreamDataWriter(
     const SerializerOptions& options,
     T& buffer,
     uint32_t rowCount,
-    const std::vector<const nimble::StreamData*>& nonEmptyStreams,
     velox::memory::MemoryPool* pool,
     const std::unordered_map<uint32_t, const EncodingLayout*>*
         streamEncodingLayouts)
@@ -460,22 +520,13 @@ StreamDataWriter<T>::StreamDataWriter(
   NIMBLE_CHECK(
       streamEncodingLayouts_ == nullptr || options_.enableEncoding(),
       "streamEncodingLayouts can only be set when encoding is enabled");
+  NIMBLE_CHECK_NOT_NULL(pool, "Memory pool cannot be null");
 
-  // Build stream offsets for sparse format.
-  std::vector<uint32_t> streamOffsets;
-  if (options_.sparseFormat()) {
-    streamOffsets.reserve(nonEmptyStreams.size());
-    for (const auto* streamData : nonEmptyStreams) {
-      streamOffsets.emplace_back(streamData->descriptor().offset());
-    }
-  }
-
-  // Write header using shared implementation.
   std::optional<SerializationVersion> version;
   if (options_.hasVersionHeader()) {
     version = options_.serializationVersion();
   }
-  detail::writeHeader(buffer_, version, rowCount, streamOffsets);
+  detail::writeHeader(buffer_, version, rowCount);
 }
 
 template <typename T>
@@ -497,12 +548,16 @@ void StreamDataWriter<T>::writeData(const nimble::StreamData& streamData) {
   const auto scalarKind = streamData.descriptor().scalarKind();
   const auto streamOffset = streamData.descriptor().offset();
 
-  if (!options_.sparseFormat()) {
-    // Dense format: fill zeros for missing streams before writing.
-    NIMBLE_CHECK_LE(lastStream_ + 1, streamOffset, "unexpected stream offset");
-    detail::writeMissingStreams(buffer_, lastStream_, streamOffset);
-    lastStream_ = streamOffset;
+  if (options_.enableEncoding()) {
+    // kCompact: encode stream and buffer the result.
+    encodeStream(scalarKind, data, streamOffset);
+    return;
   }
+
+  // kLegacy: fill zeros for missing streams before writing.
+  NIMBLE_CHECK_LE(lastStream_ + 1, streamOffset, "unexpected stream offset");
+  detail::writeMissingStreams(buffer_, lastStream_, streamOffset);
+  lastStream_ = streamOffset;
 
   encodeStream(scalarKind, data, streamOffset);
 }
@@ -523,13 +578,16 @@ void StreamDataWriter<T>::encodeStream(
     }
 
     // Use nimble encoding framework for optimal compression.
-    // Wire format: [size:u32][nimble_encoded_data...]
-    // The nimble encoding is self-describing with its own header.
     auto encoded = detail::encodeScalar<T>(
         options_, scalarKind, data, *pool_, *encodingBuffer_, encodingLayout);
 
-    // Write size prefix followed by encoded data.
-    detail::writeStream(buffer_, encoded);
+    // kCompact: write directly to buffer and track size for trailer.
+    if (streamOffset >= streamSizes_.size()) {
+      streamSizes_.resize(streamOffset + 1, 0);
+    }
+    streamSizes_[streamOffset] = static_cast<uint32_t>(encoded.size());
+    auto* pos = detail::extend(buffer_, encoded.size());
+    std::memcpy(pos, encoded.data(), encoded.size());
   } else if (
       scalarKind == ScalarKind::String || scalarKind == ScalarKind::Binary) {
     // Legacy string encoding: [total_size:u32][len_0:u32][data_0]...
@@ -550,11 +608,14 @@ void StreamDataWriter<T>::encodeStream(
 
 template <typename T>
 void StreamDataWriter<T>::close(uint32_t nodeCount) {
-  if (!options_.sparseFormat()) {
-    // Dense format: fill trailing zeros up to nodeCount.
+  if (options_.enableEncoding()) {
+    // kCompact: write trailer with encoded stream sizes.
+    detail::writeTrailer(
+        streamSizes_, options_.streamSizesEncodingType, pool_, buffer_);
+  } else {
+    // kLegacy: fill trailing zeros up to nodeCount.
     detail::writeMissingStreams(buffer_, lastStream_, nodeCount);
   }
-  // Sparse format: no-op (header and data already written).
 }
 
 } // namespace facebook::nimble::serde

--- a/dwio/nimble/serializer/tests/OptionsTest.cpp
+++ b/dwio/nimble/serializer/tests/OptionsTest.cpp
@@ -21,10 +21,8 @@ using namespace facebook::nimble;
 
 TEST(OptionsTest, serializationVersionEnumValues) {
   // Verify enum underlying values match expected wire format versions.
-  EXPECT_EQ(static_cast<uint8_t>(SerializationVersion::kDense), 0);
-  EXPECT_EQ(static_cast<uint8_t>(SerializationVersion::kSparse), 1);
-  EXPECT_EQ(static_cast<uint8_t>(SerializationVersion::kDenseEncoded), 2);
-  EXPECT_EQ(static_cast<uint8_t>(SerializationVersion::kSparseEncoded), 3);
+  EXPECT_EQ(static_cast<uint8_t>(SerializationVersion::kLegacy), 0);
+  EXPECT_EQ(static_cast<uint8_t>(SerializationVersion::kCompact), 1);
 }
 
 TEST(OptionsTest, serializerOptionsDefaults) {
@@ -37,74 +35,42 @@ TEST(OptionsTest, serializerOptionsDefaults) {
   EXPECT_FALSE(options.version.has_value());
   EXPECT_TRUE(options.flatMapColumns.empty());
 
-  // Verify helper methods with defaults (nullopt = dense format).
+  // Verify helper methods with defaults (nullopt = legacy format).
   EXPECT_FALSE(options.hasVersionHeader());
-  EXPECT_EQ(options.serializationVersion(), SerializationVersion::kDense);
+  EXPECT_EQ(options.serializationVersion(), SerializationVersion::kLegacy);
   EXPECT_FALSE(options.enableEncoding());
-  EXPECT_TRUE(options.denseFormat());
-  EXPECT_FALSE(options.sparseFormat());
 
   // Verify default encoding selection policy factory creates a valid policy.
   auto policy = options.encodingSelectionPolicyFactory(DataType::Int32);
   EXPECT_NE(policy, nullptr);
 }
 
+TEST(OptionsTest, serializerOptionsWithLegacyVersion) {
+  // Explicit kLegacy still means version header is present.
+  SerializerOptions options{.version = SerializationVersion::kLegacy};
+
+  EXPECT_TRUE(options.version.has_value());
+  EXPECT_EQ(*options.version, SerializationVersion::kLegacy);
+  EXPECT_TRUE(options.hasVersionHeader());
+  EXPECT_EQ(options.serializationVersion(), SerializationVersion::kLegacy);
+  EXPECT_FALSE(options.enableEncoding());
+}
+
 TEST(OptionsTest, serializerOptionsWithDenseVersion) {
-  // Explicit kDense still means version header is present.
-  SerializerOptions options{.version = SerializationVersion::kDense};
+  SerializerOptions options{.version = SerializationVersion::kCompact};
 
   EXPECT_TRUE(options.version.has_value());
-  EXPECT_EQ(*options.version, SerializationVersion::kDense);
+  EXPECT_EQ(*options.version, SerializationVersion::kCompact);
   EXPECT_TRUE(options.hasVersionHeader());
-  EXPECT_EQ(options.serializationVersion(), SerializationVersion::kDense);
-  EXPECT_FALSE(options.enableEncoding());
-  EXPECT_TRUE(options.denseFormat());
-  EXPECT_FALSE(options.sparseFormat());
-}
-
-TEST(OptionsTest, serializerOptionsWithSparseVersion) {
-  SerializerOptions options{.version = SerializationVersion::kSparse};
-
-  EXPECT_TRUE(options.version.has_value());
-  EXPECT_EQ(*options.version, SerializationVersion::kSparse);
-  EXPECT_TRUE(options.hasVersionHeader());
-  EXPECT_EQ(options.serializationVersion(), SerializationVersion::kSparse);
-  EXPECT_FALSE(options.enableEncoding());
-  EXPECT_FALSE(options.denseFormat());
-  EXPECT_TRUE(options.sparseFormat());
-}
-
-TEST(OptionsTest, serializerOptionsWithDenseEncodedVersion) {
-  SerializerOptions options{.version = SerializationVersion::kDenseEncoded};
-
-  EXPECT_TRUE(options.version.has_value());
-  EXPECT_EQ(*options.version, SerializationVersion::kDenseEncoded);
-  EXPECT_TRUE(options.hasVersionHeader());
-  EXPECT_EQ(
-      options.serializationVersion(), SerializationVersion::kDenseEncoded);
+  EXPECT_EQ(options.serializationVersion(), SerializationVersion::kCompact);
   EXPECT_TRUE(options.enableEncoding());
-  EXPECT_TRUE(options.denseFormat());
-  EXPECT_FALSE(options.sparseFormat());
-}
-
-TEST(OptionsTest, serializerOptionsWithSparseEncodedVersion) {
-  SerializerOptions options{.version = SerializationVersion::kSparseEncoded};
-
-  EXPECT_TRUE(options.version.has_value());
-  EXPECT_EQ(*options.version, SerializationVersion::kSparseEncoded);
-  EXPECT_TRUE(options.hasVersionHeader());
-  EXPECT_EQ(
-      options.serializationVersion(), SerializationVersion::kSparseEncoded);
-  EXPECT_TRUE(options.enableEncoding());
-  EXPECT_FALSE(options.denseFormat());
-  EXPECT_TRUE(options.sparseFormat());
 }
 
 TEST(OptionsTest, serializerOptionsWithFlatMapColumns) {
   SerializerOptions options{
       .compressionType = CompressionType::Zstd,
       .compressionLevel = 3,
-      .version = SerializationVersion::kSparse,
+      .version = SerializationVersion::kCompact,
       .flatMapColumns = {"col1", "col2"},
   };
 
@@ -122,61 +88,29 @@ TEST(OptionsTest, deserializerOptionsDefaults) {
   // Verify default values.
   EXPECT_FALSE(options.version.has_value());
 
-  // Verify helper methods with defaults (nullopt = dense format).
+  // Verify helper methods with defaults (nullopt = legacy format).
   EXPECT_FALSE(options.hasVersionHeader());
-  EXPECT_EQ(options.serializationVersion(), SerializationVersion::kDense);
+  EXPECT_EQ(options.serializationVersion(), SerializationVersion::kLegacy);
   EXPECT_FALSE(options.enableEncoding());
-  EXPECT_TRUE(options.denseFormat());
-  EXPECT_FALSE(options.sparseFormat());
+}
+
+TEST(OptionsTest, deserializerOptionsWithLegacyVersion) {
+  // Explicit kLegacy still means version header is expected.
+  DeserializerOptions options{.version = SerializationVersion::kLegacy};
+
+  EXPECT_TRUE(options.version.has_value());
+  EXPECT_EQ(*options.version, SerializationVersion::kLegacy);
+  EXPECT_TRUE(options.hasVersionHeader());
+  EXPECT_EQ(options.serializationVersion(), SerializationVersion::kLegacy);
+  EXPECT_FALSE(options.enableEncoding());
 }
 
 TEST(OptionsTest, deserializerOptionsWithDenseVersion) {
-  // Explicit kDense still means version header is expected.
-  DeserializerOptions options{.version = SerializationVersion::kDense};
+  DeserializerOptions options{.version = SerializationVersion::kCompact};
 
   EXPECT_TRUE(options.version.has_value());
-  EXPECT_EQ(*options.version, SerializationVersion::kDense);
+  EXPECT_EQ(*options.version, SerializationVersion::kCompact);
   EXPECT_TRUE(options.hasVersionHeader());
-  EXPECT_EQ(options.serializationVersion(), SerializationVersion::kDense);
-  EXPECT_FALSE(options.enableEncoding());
-  EXPECT_TRUE(options.denseFormat());
-  EXPECT_FALSE(options.sparseFormat());
-}
-
-TEST(OptionsTest, deserializerOptionsWithSparseVersion) {
-  DeserializerOptions options{.version = SerializationVersion::kSparse};
-
-  EXPECT_TRUE(options.version.has_value());
-  EXPECT_EQ(*options.version, SerializationVersion::kSparse);
-  EXPECT_TRUE(options.hasVersionHeader());
-  EXPECT_EQ(options.serializationVersion(), SerializationVersion::kSparse);
-  EXPECT_FALSE(options.enableEncoding());
-  EXPECT_FALSE(options.denseFormat());
-  EXPECT_TRUE(options.sparseFormat());
-}
-
-TEST(OptionsTest, deserializerOptionsWithDenseEncodedVersion) {
-  DeserializerOptions options{.version = SerializationVersion::kDenseEncoded};
-
-  EXPECT_TRUE(options.version.has_value());
-  EXPECT_EQ(*options.version, SerializationVersion::kDenseEncoded);
-  EXPECT_TRUE(options.hasVersionHeader());
-  EXPECT_EQ(
-      options.serializationVersion(), SerializationVersion::kDenseEncoded);
+  EXPECT_EQ(options.serializationVersion(), SerializationVersion::kCompact);
   EXPECT_TRUE(options.enableEncoding());
-  EXPECT_TRUE(options.denseFormat());
-  EXPECT_FALSE(options.sparseFormat());
-}
-
-TEST(OptionsTest, deserializerOptionsWithSparseEncodedVersion) {
-  DeserializerOptions options{.version = SerializationVersion::kSparseEncoded};
-
-  EXPECT_TRUE(options.version.has_value());
-  EXPECT_EQ(*options.version, SerializationVersion::kSparseEncoded);
-  EXPECT_TRUE(options.hasVersionHeader());
-  EXPECT_EQ(
-      options.serializationVersion(), SerializationVersion::kSparseEncoded);
-  EXPECT_TRUE(options.enableEncoding());
-  EXPECT_FALSE(options.denseFormat());
-  EXPECT_TRUE(options.sparseFormat());
 }

--- a/dwio/nimble/serializer/tests/ProjectorTest.cpp
+++ b/dwio/nimble/serializer/tests/ProjectorTest.cpp
@@ -38,104 +38,26 @@ namespace facebook::nimble::serde {
 // version.
 struct FormatParam {
   std::optional<SerializationVersion> inputVersion;
-  SerializationVersion outputVersion;
 
-  // For test naming.
+  // For test naming. Output is always kCompact.
   std::string name() const {
-    std::string inputName;
     if (!inputVersion.has_value()) {
-      inputName = "NoVersion";
-    } else {
-      switch (inputVersion.value()) {
-        case SerializationVersion::kDense:
-          inputName = "Dense";
-          break;
-        case SerializationVersion::kDenseEncoded:
-          inputName = "DenseEncoded";
-          break;
-        case SerializationVersion::kSparse:
-          inputName = "Sparse";
-          break;
-        case SerializationVersion::kSparseEncoded:
-          inputName = "SparseEncoded";
-          break;
-      }
+      return "NoVersion";
     }
-
-    std::string outputName;
-    switch (outputVersion) {
-      case SerializationVersion::kDense:
-        outputName = "Dense";
-        break;
-      case SerializationVersion::kDenseEncoded:
-        outputName = "DenseEncoded";
-        break;
-      case SerializationVersion::kSparse:
-        outputName = "Sparse";
-        break;
-      case SerializationVersion::kSparseEncoded:
-        outputName = "SparseEncoded";
-        break;
+    switch (inputVersion.value()) {
+      case SerializationVersion::kLegacy:
+        return "Legacy";
+      case SerializationVersion::kCompact:
+        return "Dense";
     }
-
-    return inputName + "_to_" + outputName;
   }
 };
 
-// Check if input/output format combination is compatible.
-// Projector copies raw bytes, so encoding type must match:
-// - kDense/kSparse use legacy raw encoding
-// - kDenseEncoded/kSparseEncoded use nimble encoding
-// - No-version (legacy) uses raw encoding
-bool isCompatibleFormat(
-    std::optional<SerializationVersion> input,
-    SerializationVersion output) {
-  // No-version (legacy) is raw encoding, compatible with kDense/kSparse.
-  if (!input.has_value()) {
-    return output == SerializationVersion::kDense ||
-        output == SerializationVersion::kSparse;
-  }
-
-  const bool inputEncoded =
-      (input.value() == SerializationVersion::kDenseEncoded ||
-       input.value() == SerializationVersion::kSparseEncoded);
-  const bool outputEncoded =
-      (output == SerializationVersion::kDenseEncoded ||
-       output == SerializationVersion::kSparseEncoded);
-
-  return inputEncoded == outputEncoded;
-}
-
-// Generate compatible format combinations.
+// Generate format combinations. Both input and output must be kCompact.
 std::vector<FormatParam> allFormatCombinations() {
-  std::vector<FormatParam> params;
-
-  // Input versions: 4 with version header + 1 without (legacy dense).
-  std::vector<std::optional<SerializationVersion>> inputVersions = {
-      SerializationVersion::kDense,
-      SerializationVersion::kDenseEncoded,
-      SerializationVersion::kSparse,
-      SerializationVersion::kSparseEncoded,
-      std::nullopt, // No version header (legacy dense format).
+  return {
+      {SerializationVersion::kCompact},
   };
-
-  // Output versions: always has version header.
-  std::vector<SerializationVersion> outputVersions = {
-      SerializationVersion::kDense,
-      SerializationVersion::kDenseEncoded,
-      SerializationVersion::kSparse,
-      SerializationVersion::kSparseEncoded,
-  };
-
-  for (const auto& input : inputVersions) {
-    for (const auto& output : outputVersions) {
-      if (isCompatibleFormat(input, output)) {
-        params.push_back({input, output});
-      }
-    }
-  }
-
-  return params;
 }
 
 // Base test fixture with helper methods.
@@ -262,25 +184,22 @@ class ProjectorFormatTest : public ProjectorTestBase,
   SerializerOptions inputSerializerOptions() const {
     const auto& param = GetParam();
     if (!param.inputVersion.has_value()) {
-      // No version header - use default (legacy dense).
       return SerializerOptions{};
     }
     return SerializerOptions{.version = param.inputVersion.value()};
   }
 
-  // Get projector options.
+  // Get projector options. Output is always kCompact.
   Projector::Options projectorOptions() const {
     const auto& param = GetParam();
     return Projector::Options{
         .inputHasVersionHeader = param.inputVersion.has_value(),
-        .projectVersion = param.outputVersion,
     };
   }
 
-  // Get deserializer options for output format.
+  // Get deserializer options for output format. Always kCompact.
   DeserializerOptions outputDeserializerOptions() const {
-    const auto& param = GetParam();
-    return {.version = param.outputVersion};
+    return {.version = SerializationVersion::kCompact};
   }
 };
 
@@ -305,7 +224,7 @@ TEST_P(ProjectorFormatTest, projectSingleColumn) {
 
   // Project only column "b".
   auto subfields = makeSubfields({"b"});
-  Projector projector(inputSchema, subfields, projectorOptions());
+  Projector projector(inputSchema, subfields, pool_.get(), projectorOptions());
   auto outputSchema = projector.projectedSchema();
 
   // Verify output schema has only one column.
@@ -363,7 +282,7 @@ TEST_P(ProjectorFormatTest, projectMultipleColumns) {
 
   // Project columns "a" and "c".
   auto subfields = makeSubfields({"a", "c"});
-  Projector projector(inputSchema, subfields, projectorOptions());
+  Projector projector(inputSchema, subfields, pool_.get(), projectorOptions());
   auto outputSchema = projector.projectedSchema();
 
   ASSERT_EQ(outputSchema->asRow().childrenCount(), 2);
@@ -425,7 +344,7 @@ TEST_P(ProjectorFormatTest, projectNestedField) {
 
   // Project only "outer.inner1".
   auto subfields = makeSubfields({"outer.inner1"});
-  Projector projector(inputSchema, subfields, projectorOptions());
+  Projector projector(inputSchema, subfields, pool_.get(), projectorOptions());
   auto outputSchema = projector.projectedSchema();
 
   // Output schema: ROW { outer: ROW { inner1: INTEGER } }
@@ -498,7 +417,7 @@ TEST_P(ProjectorFormatTest, projectArrayColumn) {
 
   // Project only "arr".
   auto subfields = makeSubfields({"arr"});
-  Projector projector(inputSchema, subfields, projectorOptions());
+  Projector projector(inputSchema, subfields, pool_.get(), projectorOptions());
   auto outputSchema = projector.projectedSchema();
 
   ASSERT_EQ(outputSchema->asRow().childrenCount(), 1);
@@ -543,7 +462,7 @@ TEST_P(ProjectorFormatTest, emptyInput) {
   auto inputSchema = getNimbleSchema(type, inputSerializerOptions());
 
   auto subfields = makeSubfields({"a"});
-  Projector projector(inputSchema, subfields, projectorOptions());
+  Projector projector(inputSchema, subfields, pool_.get(), projectorOptions());
   auto outputSchema = projector.projectedSchema();
 
   // Helper to verify result.
@@ -589,83 +508,19 @@ TEST_F(ProjectorTest, incompatibleFormatsRejected) {
 
   auto subfields = makeSubfields({"a"});
 
-  // Test encoded input -> raw output (incompatible).
+  // Test kLegacy output version — rejected in constructor.
   {
-    SerializerOptions serOpts{.version = SerializationVersion::kDenseEncoded};
-    auto serialized = serialize(vec, type, serOpts);
-    auto inputSchema = getNimbleSchema(type, serOpts);
-
-    Projector projector(
-        inputSchema,
-        subfields,
-        {.inputHasVersionHeader = true,
-         .projectVersion = SerializationVersion::kDense});
+    auto inputSchema =
+        getNimbleSchema(type, {.version = SerializationVersion::kCompact});
 
     NIMBLE_ASSERT_THROW(
-        projector.project(serialized), "Incompatible input/output formats");
-  }
-
-  {
-    SerializerOptions serOpts{.version = SerializationVersion::kSparseEncoded};
-    auto serialized = serialize(vec, type, serOpts);
-    auto inputSchema = getNimbleSchema(type, serOpts);
-
-    Projector projector(
-        inputSchema,
-        subfields,
-        {.inputHasVersionHeader = true,
-         .projectVersion = SerializationVersion::kSparse});
-
-    NIMBLE_ASSERT_THROW(
-        projector.project(serialized), "Incompatible input/output formats");
-  }
-
-  // Test raw input -> encoded output (incompatible).
-  {
-    SerializerOptions serOpts{.version = SerializationVersion::kDense};
-    auto serialized = serialize(vec, type, serOpts);
-    auto inputSchema = getNimbleSchema(type, serOpts);
-
-    Projector projector(
-        inputSchema,
-        subfields,
-        {.inputHasVersionHeader = true,
-         .projectVersion = SerializationVersion::kDenseEncoded});
-
-    NIMBLE_ASSERT_THROW(
-        projector.project(serialized), "Incompatible input/output formats");
-  }
-
-  {
-    SerializerOptions serOpts{.version = SerializationVersion::kSparse};
-    auto serialized = serialize(vec, type, serOpts);
-    auto inputSchema = getNimbleSchema(type, serOpts);
-
-    Projector projector(
-        inputSchema,
-        subfields,
-        {.inputHasVersionHeader = true,
-         .projectVersion = SerializationVersion::kSparseEncoded});
-
-    NIMBLE_ASSERT_THROW(
-        projector.project(serialized), "Incompatible input/output formats");
-  }
-
-  // Test no-version (legacy raw) -> encoded output (incompatible).
-  {
-    // Legacy format has no version header.
-    SerializerOptions serOpts{};
-    auto serialized = serialize(vec, type, serOpts);
-    auto inputSchema = getNimbleSchema(type, serOpts);
-
-    Projector projector(
-        inputSchema,
-        subfields,
-        {.inputHasVersionHeader = false,
-         .projectVersion = SerializationVersion::kDenseEncoded});
-
-    NIMBLE_ASSERT_THROW(
-        projector.project(serialized), "Incompatible input/output formats");
+        Projector(
+            inputSchema,
+            subfields,
+            pool_.get(),
+            {.inputHasVersionHeader = true,
+             .projectVersion = SerializationVersion::kLegacy}),
+        "Projection output version must be kCompact");
   }
 }
 
@@ -676,7 +531,7 @@ TEST_F(ProjectorTest, emptyProjectionInvalid) {
       {"b", BIGINT()},
   });
 
-  SerializerOptions serOpts{.version = SerializationVersion::kDenseEncoded};
+  SerializerOptions serOpts{.version = SerializationVersion::kCompact};
   auto inputSchema = getNimbleSchema(type, serOpts);
 
   // Empty subfields should throw.
@@ -685,8 +540,9 @@ TEST_F(ProjectorTest, emptyProjectionInvalid) {
       Projector(
           inputSchema,
           emptySubfields,
+          pool_.get(),
           {.inputHasVersionHeader = true,
-           .projectVersion = SerializationVersion::kDenseEncoded}),
+           .projectVersion = SerializationVersion::kCompact}),
       "Must project at least one subfield");
 }
 
@@ -706,81 +562,25 @@ TEST_F(ProjectorTest, fullProjectionPassThrough) {
           makeStringVector({"x", "y", "z"}),
       });
 
-  // Test all 4 versions - pass through when input and output match.
-  for (auto version :
-       {SerializationVersion::kDense,
-        SerializationVersion::kDenseEncoded,
-        SerializationVersion::kSparse,
-        SerializationVersion::kSparseEncoded}) {
-    SCOPED_TRACE(static_cast<int>(version));
-
-    SerializerOptions serOpts{.version = version};
-    auto serialized = serialize(vec, type, serOpts);
-    auto inputSchema = getNimbleSchema(type, serOpts);
-
-    // Full projection - all columns selected, same format.
-    auto subfields = makeSubfields({"a", "b", "c"});
-    Projector projector(
-        inputSchema,
-        subfields,
-        {.inputHasVersionHeader = true, .projectVersion = version});
-
-    auto projected = projector.project(serialized);
-
-    // Fast path: output should be identical to input (pass through).
-    EXPECT_EQ(projected, serialized);
-
-    // Verify can still deserialize correctly.
-    auto outputSchema = projector.projectedSchema();
-    auto result = deserialize(projected, outputSchema, {.version = version});
-    ASSERT_EQ(result->size(), 3);
-
-    auto resultRow = result->as<RowVector>();
-    EXPECT_EQ(resultRow->childAt(0)->as<FlatVector<int32_t>>()->valueAt(0), 1);
-    EXPECT_EQ(
-        resultRow->childAt(1)->as<FlatVector<int64_t>>()->valueAt(0), 100);
-  }
-}
-
-// Test full projection with format conversion (no fast path).
-TEST_F(ProjectorTest, fullProjectionFormatConversion) {
-  auto type = ROW({
-      {"a", INTEGER()},
-      {"b", BIGINT()},
-  });
-
-  auto vec = makeSimpleRowVector(
-      {"a", "b"},
-      {
-          makeIntVector<int32_t>({1, 2}),
-          makeIntVector<int64_t>({100, 200}),
-      });
-
-  // Input: dense encoded format.
-  SerializerOptions serOpts{.version = SerializationVersion::kDenseEncoded};
+  SerializerOptions serOpts{.version = SerializationVersion::kCompact};
   auto serialized = serialize(vec, type, serOpts);
   auto inputSchema = getNimbleSchema(type, serOpts);
 
-  // Full projection but converting to sparse format.
-  auto subfields = makeSubfields({"a", "b"});
+  // Full projection - all columns selected, same format.
+  auto subfields = makeSubfields({"a", "b", "c"});
   Projector projector(
-      inputSchema,
-      subfields,
-      {.inputHasVersionHeader = true,
-       .projectVersion = SerializationVersion::kSparseEncoded});
+      inputSchema, subfields, pool_.get(), {.inputHasVersionHeader = true});
 
   auto projected = projector.project(serialized);
 
-  // Not a fast path - output differs from input (different format).
-  EXPECT_NE(projected, serialized);
+  // Fast path: output should be identical to input (pass through).
+  EXPECT_EQ(projected, serialized);
 
-  // But still deserializes correctly.
+  // Verify can still deserialize correctly.
   auto outputSchema = projector.projectedSchema();
   auto result = deserialize(
-      projected,
-      outputSchema,
-      {.version = SerializationVersion::kSparseEncoded});
-  ASSERT_EQ(result->size(), 2);
+      projected, outputSchema, {.version = SerializationVersion::kCompact});
+  ASSERT_EQ(result->size(), 3);
 
   auto resultRow = result->as<RowVector>();
   EXPECT_EQ(resultRow->childAt(0)->as<FlatVector<int32_t>>()->valueAt(0), 1);
@@ -791,7 +591,7 @@ TEST_F(ProjectorTest, fullProjectionFormatConversion) {
 TEST_F(ProjectorTest, unsupportedArraySubscript) {
   auto type = ROW({{"arr", ARRAY(INTEGER())}});
 
-  SerializerOptions serOpts{.version = SerializationVersion::kDenseEncoded};
+  SerializerOptions serOpts{.version = SerializationVersion::kCompact};
   auto inputSchema = getNimbleSchema(type, serOpts);
 
   // Array subscripts are not supported.
@@ -801,8 +601,9 @@ TEST_F(ProjectorTest, unsupportedArraySubscript) {
       Projector(
           inputSchema,
           subfields,
+          pool_.get(),
           {.inputHasVersionHeader = true,
-           .projectVersion = SerializationVersion::kDenseEncoded}),
+           .projectVersion = SerializationVersion::kCompact}),
       "Unsupported subfield kind");
 }
 
@@ -810,7 +611,7 @@ TEST_F(ProjectorTest, unsupportedArraySubscript) {
 TEST_F(ProjectorTest, unsupportedMapKeyProjection) {
   auto type = ROW({{"m", MAP(VARCHAR(), INTEGER())}});
 
-  SerializerOptions serOpts{.version = SerializationVersion::kDenseEncoded};
+  SerializerOptions serOpts{.version = SerializationVersion::kCompact};
   auto inputSchema = getNimbleSchema(type, serOpts);
 
   // Regular map subscripts are not supported (would need re-encoding).
@@ -820,8 +621,9 @@ TEST_F(ProjectorTest, unsupportedMapKeyProjection) {
       Projector(
           inputSchema,
           subfields,
+          pool_.get(),
           {.inputHasVersionHeader = true,
-           .projectVersion = SerializationVersion::kDenseEncoded}),
+           .projectVersion = SerializationVersion::kCompact}),
       "String subscript");
 }
 
@@ -877,16 +679,14 @@ TEST_F(ProjectorTest, flatMapSerializeDeserializeNoProjction) {
 
   // Serialize with FlatMap encoding.
   SerializerOptions serOpts{
-      .version = SerializationVersion::kDenseEncoded,
+      .version = SerializationVersion::kCompact,
       .flatMapColumns = {"features"},
   };
   auto [serialized, inputSchema] = serializeWithSchema(vec, type, serOpts);
 
   // Deserialize directly (no projection).
   auto result = deserialize(
-      serialized,
-      inputSchema,
-      {.version = SerializationVersion::kDenseEncoded});
+      serialized, inputSchema, {.version = SerializationVersion::kCompact});
 
   ASSERT_EQ(result->size(), 2);
   auto resultRow = result->as<RowVector>();
@@ -950,7 +750,7 @@ TEST_F(ProjectorTest, projectEntireFlatMapColumn) {
 
   // Serialize with FlatMap encoding.
   SerializerOptions serOpts{
-      .version = SerializationVersion::kDenseEncoded,
+      .version = SerializationVersion::kCompact,
       .flatMapColumns = {"features"},
   };
   auto [serialized, inputSchema] = serializeWithSchema(vec, type, serOpts);
@@ -960,17 +760,16 @@ TEST_F(ProjectorTest, projectEntireFlatMapColumn) {
   Projector projector(
       inputSchema,
       subfields,
+      pool_.get(),
       {.inputHasVersionHeader = true,
-       .projectVersion = SerializationVersion::kDenseEncoded});
+       .projectVersion = SerializationVersion::kCompact});
 
   auto outputSchema = projector.projectedSchema();
   auto projected = projector.project(serialized);
 
   // Deserialize and verify.
   auto result = deserialize(
-      projected,
-      outputSchema,
-      {.version = SerializationVersion::kDenseEncoded});
+      projected, outputSchema, {.version = SerializationVersion::kCompact});
 
   ASSERT_EQ(result->size(), 2);
   auto resultRow = result->as<RowVector>();
@@ -1034,7 +833,7 @@ TEST_F(ProjectorTest, projectFlatMapAllKeys) {
 
   // Serialize with FlatMap encoding.
   SerializerOptions serOpts{
-      .version = SerializationVersion::kDenseEncoded,
+      .version = SerializationVersion::kCompact,
       .flatMapColumns = {"features"},
   };
   auto [serialized, inputSchema] = serializeWithSchema(vec, type, serOpts);
@@ -1045,17 +844,16 @@ TEST_F(ProjectorTest, projectFlatMapAllKeys) {
   Projector projector(
       inputSchema,
       subfields,
+      pool_.get(),
       {.inputHasVersionHeader = true,
-       .projectVersion = SerializationVersion::kDenseEncoded});
+       .projectVersion = SerializationVersion::kCompact});
 
   auto outputSchema = projector.projectedSchema();
   auto projected = projector.project(serialized);
 
   // Deserialize and verify.
   auto result = deserialize(
-      projected,
-      outputSchema,
-      {.version = SerializationVersion::kDenseEncoded});
+      projected, outputSchema, {.version = SerializationVersion::kCompact});
 
   ASSERT_EQ(result->size(), 2);
   auto resultRow = result->as<RowVector>();
@@ -1119,7 +917,7 @@ TEST_F(ProjectorTest, flatMapStreamIndices) {
 
   // Serialize with FlatMap encoding.
   SerializerOptions serOpts{
-      .version = SerializationVersion::kDenseEncoded,
+      .version = SerializationVersion::kCompact,
       .flatMapColumns = {"features"},
   };
   auto [serialized, inputSchema] = serializeWithSchema(vec, type, serOpts);
@@ -1153,8 +951,9 @@ TEST_F(ProjectorTest, flatMapStreamIndices) {
   Projector projector(
       inputSchema,
       subfields,
+      pool_.get(),
       {.inputHasVersionHeader = true,
-       .projectVersion = SerializationVersion::kDenseEncoded});
+       .projectVersion = SerializationVersion::kCompact});
 
   const auto& indices = projector.testingInputStreamIndices();
   LOG(INFO) << "Projected stream indices: ";
@@ -1243,7 +1042,7 @@ TEST_F(ProjectorTest, projectFlatMapSingleKey) {
   // Use serializeWithSchema to get schema AFTER serialization (when FlatMap
   // keys are discovered).
   SerializerOptions serOpts{
-      .version = SerializationVersion::kDenseEncoded,
+      .version = SerializationVersion::kCompact,
       .flatMapColumns = {"features"},
   };
   auto [serialized, inputSchema] = serializeWithSchema(vec, type, serOpts);
@@ -1253,8 +1052,9 @@ TEST_F(ProjectorTest, projectFlatMapSingleKey) {
   Projector projector(
       inputSchema,
       subfields,
+      pool_.get(),
       {.inputHasVersionHeader = true,
-       .projectVersion = SerializationVersion::kDenseEncoded});
+       .projectVersion = SerializationVersion::kCompact});
 
   auto outputSchema = projector.projectedSchema();
 
@@ -1269,9 +1069,7 @@ TEST_F(ProjectorTest, projectFlatMapSingleKey) {
   // Project and deserialize.
   auto projected = projector.project(serialized);
   auto result = deserialize(
-      projected,
-      outputSchema,
-      {.version = SerializationVersion::kDenseEncoded});
+      projected, outputSchema, {.version = SerializationVersion::kCompact});
 
   ASSERT_EQ(result->size(), 3);
   auto resultRow = result->as<RowVector>();
@@ -1337,7 +1135,7 @@ TEST_F(ProjectorTest, projectFlatMapMultipleKeys) {
   // Serialize with FlatMap encoding.
   // Use serializeWithSchema to get schema AFTER serialization.
   SerializerOptions serOpts{
-      .version = SerializationVersion::kDenseEncoded,
+      .version = SerializationVersion::kCompact,
       .flatMapColumns = {"features"},
   };
   auto [serialized, inputSchema] = serializeWithSchema(vec, type, serOpts);
@@ -1347,8 +1145,9 @@ TEST_F(ProjectorTest, projectFlatMapMultipleKeys) {
   Projector projector(
       inputSchema,
       subfields,
+      pool_.get(),
       {.inputHasVersionHeader = true,
-       .projectVersion = SerializationVersion::kDenseEncoded});
+       .projectVersion = SerializationVersion::kCompact});
 
   auto outputSchema = projector.projectedSchema();
 
@@ -1361,9 +1160,7 @@ TEST_F(ProjectorTest, projectFlatMapMultipleKeys) {
   // Project and deserialize.
   auto projected = projector.project(serialized);
   auto result = deserialize(
-      projected,
-      outputSchema,
-      {.version = SerializationVersion::kDenseEncoded});
+      projected, outputSchema, {.version = SerializationVersion::kCompact});
 
   ASSERT_EQ(result->size(), 2);
   auto resultRow = result->as<RowVector>();
@@ -1427,7 +1224,7 @@ TEST_F(ProjectorTest, projectFlatMapNonExistentKey) {
 
   // Serialize with FlatMap encoding to discover keys 1, 2, 3.
   SerializerOptions serOpts{
-      .version = SerializationVersion::kDenseEncoded,
+      .version = SerializationVersion::kCompact,
       .flatMapColumns = {"features"},
   };
   auto [serialized, inputSchema] = serializeWithSchema(vec, type, serOpts);
@@ -1440,8 +1237,9 @@ TEST_F(ProjectorTest, projectFlatMapNonExistentKey) {
       Projector(
           inputSchema,
           subfields,
+          pool_.get(),
           {.inputHasVersionHeader = true,
-           .projectVersion = SerializationVersion::kDenseEncoded}),
+           .projectVersion = SerializationVersion::kCompact}),
       "Key '999' not found in FlatMapType");
 }
 
@@ -1454,7 +1252,7 @@ TEST_F(ProjectorTest, streamIndicesCorrect) {
   });
   // Stream 0 is root row nulls.
 
-  SerializerOptions serOpts{.version = SerializationVersion::kDenseEncoded};
+  SerializerOptions serOpts{.version = SerializationVersion::kCompact};
   auto inputSchema = getNimbleSchema(type, serOpts);
 
   // Project "b" only - should include streams 0 (root nulls) and 2 (b data).
@@ -1462,8 +1260,9 @@ TEST_F(ProjectorTest, streamIndicesCorrect) {
   Projector projector(
       inputSchema,
       subfields,
+      pool_.get(),
       {.inputHasVersionHeader = true,
-       .projectVersion = SerializationVersion::kDenseEncoded});
+       .projectVersion = SerializationVersion::kCompact});
 
   const auto& indices = projector.testingInputStreamIndices();
   ASSERT_EQ(indices.size(), 2);
@@ -1508,7 +1307,7 @@ TEST_F(ProjectorTest, projectWithUpdatedRowType) {
       std::vector<VectorPtr>{ids, names, values});
 
   // Serialize with old column names.
-  SerializerOptions serOpts{.version = SerializationVersion::kDenseEncoded};
+  SerializerOptions serOpts{.version = SerializationVersion::kCompact};
   auto [serialized, inputSchema] = serializeWithSchema(vec, inputType, serOpts);
 
   // Query uses new column names from projectType.
@@ -1519,17 +1318,18 @@ TEST_F(ProjectorTest, projectWithUpdatedRowType) {
       Projector(
           inputSchema,
           subfields,
+          pool_.get(),
           {.inputHasVersionHeader = true,
-           .projectVersion = SerializationVersion::kDenseEncoded}),
+           .projectVersion = SerializationVersion::kCompact}),
       "Field 'new_id' not found in RowType");
 
   // With projectType, name mapping is auto-computed and projection succeeds.
   Projector::Options opts{
       .inputHasVersionHeader = true,
-      .projectVersion = SerializationVersion::kDenseEncoded,
+      .projectVersion = SerializationVersion::kCompact,
       .projectType = projectType,
   };
-  Projector projector(inputSchema, subfields, opts);
+  Projector projector(inputSchema, subfields, pool_.get(), opts);
 
   auto projected = projector.project(serialized);
   ASSERT_FALSE(projected.empty());
@@ -1617,7 +1417,7 @@ TEST_F(ProjectorTest, projectWithUpdatedNestedRowType) {
 
   // Serialize with FlatMap to discover keys.
   SerializerOptions serOpts{
-      .version = SerializationVersion::kDenseEncoded,
+      .version = SerializationVersion::kCompact,
       .flatMapColumns = {"features"},
   };
   auto [serialized, inputSchema] = serializeWithSchema(vec, inputType, serOpts);
@@ -1630,8 +1430,9 @@ TEST_F(ProjectorTest, projectWithUpdatedNestedRowType) {
     Projector projectorNoType(
         inputSchema,
         subfields,
+        pool_.get(),
         {.inputHasVersionHeader = true,
-         .projectVersion = SerializationVersion::kDenseEncoded});
+         .projectVersion = SerializationVersion::kCompact});
     const auto& nestedRow = projectorNoType.projectedSchema()
                                 ->asRow()
                                 .childAt(0)
@@ -1644,10 +1445,10 @@ TEST_F(ProjectorTest, projectWithUpdatedNestedRowType) {
   // With projectType, nested row field is renamed.
   Projector::Options opts{
       .inputHasVersionHeader = true,
-      .projectVersion = SerializationVersion::kDenseEncoded,
+      .projectVersion = SerializationVersion::kCompact,
       .projectType = projectType,
   };
-  Projector projector(inputSchema, subfields, opts);
+  Projector projector(inputSchema, subfields, pool_.get(), opts);
 
   auto projected = projector.project(serialized);
   ASSERT_FALSE(projected.empty());
@@ -1733,7 +1534,7 @@ TEST_F(ProjectorTest, projectNestedFieldUnderFlatMapValue) {
       std::vector<VectorPtr>{ids, mapVector});
 
   SerializerOptions serOpts{
-      .version = SerializationVersion::kDenseEncoded,
+      .version = SerializationVersion::kCompact,
       .flatMapColumns = {"features"},
   };
   auto [serialized, inputSchema] = serializeWithSchema(vec, inputType, serOpts);
@@ -1746,16 +1547,18 @@ TEST_F(ProjectorTest, projectNestedFieldUnderFlatMapValue) {
       Projector(
           inputSchema,
           subfields,
+          pool_.get(),
           {.inputHasVersionHeader = true,
-           .projectVersion = SerializationVersion::kDenseEncoded}),
+           .projectVersion = SerializationVersion::kCompact}),
       "Field 'new_value' not found in RowType");
 
   // With projectType, nested field is renamed and projection succeeds.
   Projector projector(
       inputSchema,
       subfields,
+      pool_.get(),
       {.inputHasVersionHeader = true,
-       .projectVersion = SerializationVersion::kDenseEncoded,
+       .projectVersion = SerializationVersion::kCompact,
        .projectType = projectType});
 
   auto projected = projector.project(serialized);
@@ -1852,7 +1655,7 @@ TEST_F(ProjectorTest, projectMultipleFlatMapColumns) {
 
   // Serialize both maps as FlatMaps.
   SerializerOptions serOpts{
-      .version = SerializationVersion::kSparseEncoded,
+      .version = SerializationVersion::kCompact,
       .flatMapColumns = {"map_a", "map_b"},
   };
   auto [serialized, inputSchema] = serializeWithSchema(vec, type, serOpts);
@@ -1876,8 +1679,9 @@ TEST_F(ProjectorTest, projectMultipleFlatMapColumns) {
   Projector projector(
       inputSchema,
       subfields,
+      pool_.get(),
       {.inputHasVersionHeader = true,
-       .projectVersion = SerializationVersion::kSparseEncoded});
+       .projectVersion = SerializationVersion::kCompact});
 
   auto outputSchema = projector.projectedSchema();
 
@@ -1895,9 +1699,7 @@ TEST_F(ProjectorTest, projectMultipleFlatMapColumns) {
   // misaligned stream offsets between schema and data.
   auto projected = projector.project(serialized);
   auto result = deserialize(
-      projected,
-      outputSchema,
-      {.version = SerializationVersion::kSparseEncoded});
+      projected, outputSchema, {.version = SerializationVersion::kCompact});
 
   ASSERT_EQ(result->size(), numRows);
   auto resultRow = result->as<RowVector>();

--- a/dwio/nimble/serializer/tests/SerializationTest.cpp
+++ b/dwio/nimble/serializer/tests/SerializationTest.cpp
@@ -31,13 +31,12 @@ using namespace facebook;
 using namespace facebook::nimble;
 
 // Test parameters for parameterized tests.
-// For encoding modes (kDenseEncoded, kSparseEncoded), we test both with and
-// without compression to exercise the compressionOptions path in
-// ReplayedEncodingSelectionPolicy.
+// For kCompact mode, we test both with and without compression to exercise the
+// compressionOptions path in ReplayedEncodingSelectionPolicy.
 struct TestParams {
   std::optional<SerializationVersion> version;
-  // Compression options for encoding modes. Only used when encodingLayoutTree
-  // is specified and version is kDenseEncoded or kSparseEncoded.
+  // Compression options for kCompact mode. Only used when encodingLayoutTree
+  // is specified.
   CompressionOptions compressionOptions{};
   // Whether compression is enabled (for test naming).
   bool compressionEnabled{false};
@@ -194,20 +193,14 @@ namespace {
 std::string formatName(const ::testing::TestParamInfo<TestParams>& info) {
   std::string name;
   if (!info.param.version.has_value()) {
-    name = "DenseFormat";
+    name = "LegacyFormat";
   } else {
     switch (*info.param.version) {
-      case SerializationVersion::kDense:
+      case SerializationVersion::kLegacy:
+        name = "LegacyFormat";
+        break;
+      case SerializationVersion::kCompact:
         name = "DenseFormat";
-        break;
-      case SerializationVersion::kSparse:
-        name = "SparseFormat";
-        break;
-      case SerializationVersion::kDenseEncoded:
-        name = "DenseEncodedFormat";
-        break;
-      case SerializationVersion::kSparseEncoded:
-        name = "SparseEncodedFormat";
         break;
     }
   }
@@ -1254,8 +1247,8 @@ TEST_P(SerializationTest, nullsNotSupported) {
         "nulls not supported");
   }
 
-  // Test 4: FlatMap with null value (only for sparse formats).
-  if (SerializerOptions{.version = version()}.sparseFormat()) {
+  // Test 4: FlatMap with null value (only for kCompact format).
+  if (SerializerOptions{.version = version()}.enableEncoding()) {
     auto type = velox::ROW({
         {"id", velox::BIGINT()},
         {"features", velox::MAP(velox::INTEGER(), velox::DOUBLE())},
@@ -1477,17 +1470,15 @@ TEST_P(SerializationTest, versionMismatch) {
   auto serialized =
       serializer.serialize(input, OrderedRanges::of(0, input->size()));
 
-  // Try to deserialize with sparse format (expects version header).
-  // The first byte is rowCount (not version), so it will be read as version.
-  // If rowCount > 1 (kSparse), it will fail the version check.
+  // Try to deserialize with kCompact (expects version header).
+  // The first byte is rowCount (not version), so it will be read as version
+  // and fail the version check.
   Deserializer deserializer{
       SchemaReader::getSchema(serializer.schemaBuilder().schemaNodes()),
       pool_.get(),
-      DeserializerOptions{.version = SerializationVersion::kSparse}};
+      DeserializerOptions{.version = SerializationVersion::kCompact}};
 
   velox::VectorPtr output;
-  // The version check should fail because the first byte (part of rowCount)
-  // is likely > 1, which exceeds the maximum supported version (kSparse = 1).
   NIMBLE_ASSERT_THROW(
       deserializer.deserialize(serialized, output), "Unsupported version");
 }
@@ -1878,8 +1869,8 @@ TEST_P(SerializationTest, encodingLayoutTreeFlatMap) {
 
   SerializerOptions options{
       .version = version(),
-      .compressionOptions = compressionOptions(),
       .flatMapColumns = {"features", "tags"},
+      .compressionOptions = compressionOptions(),
       .encodingLayoutTree = layoutTree,
   };
 
@@ -2157,21 +2148,14 @@ INSTANTIATE_TEST_SUITE_P(
     AllFormats,
     SerializationTest,
     ::testing::Values(
-        // Non-encoding modes (compression options don't apply).
-        TestParams{.version = std::nullopt}, // Dense format
-        TestParams{.version = SerializationVersion::kSparse},
-        // Encoding modes without compression.
-        TestParams{.version = SerializationVersion::kDenseEncoded},
-        TestParams{.version = SerializationVersion::kSparseEncoded},
-        // Encoding modes with compression enabled (for encodingLayoutTree
+        // Legacy format (no nimble encoding).
+        TestParams{.version = std::nullopt},
+        // kCompact format without compression.
+        TestParams{.version = SerializationVersion::kCompact},
+        // kCompact format with compression enabled (for encodingLayoutTree
         // tests).
         TestParams{
-            .version = SerializationVersion::kDenseEncoded,
-            .compressionOptions =
-                {.compressionAcceptRatio = 1.0f, .zstdMinCompressionSize = 0},
-            .compressionEnabled = true},
-        TestParams{
-            .version = SerializationVersion::kSparseEncoded,
+            .version = SerializationVersion::kCompact,
             .compressionOptions =
                 {.compressionAcceptRatio = 1.0f, .zstdMinCompressionSize = 0},
             .compressionEnabled = true}),

--- a/dwio/nimble/serializer/tests/SerializerImplTest.cpp
+++ b/dwio/nimble/serializer/tests/SerializerImplTest.cpp
@@ -19,137 +19,141 @@
 #include "dwio/nimble/common/EncodingPrimitives.h"
 #include "dwio/nimble/common/Varint.h"
 #include "dwio/nimble/serializer/SerializerImpl.h"
+#include "velox/common/memory/Memory.h"
 
 using namespace facebook::nimble;
 using namespace facebook::nimble::serde;
+using namespace facebook::velox;
 
 class WriteHeaderTest : public ::testing::Test {
  protected:
-  // Helper to read header from buffer and verify contents.
+  static void SetUpTestSuite() {
+    memory::MemoryManager::testingSetInstance(memory::MemoryManager::Options{});
+  }
+
+  void SetUp() override {
+    pool_ = memory::memoryManager()->addLeafPool("write_header_test");
+  }
+
+  // Helper to build a complete kCompact buffer: header + data + trailer.
+  std::string buildDenseHeaderTrailer(
+      uint32_t rowCount,
+      const std::vector<uint32_t>& sizes,
+      std::optional<EncodingType> encodingType = std::nullopt) {
+    std::string buffer;
+    serde::detail::writeHeader(
+        buffer, SerializationVersion::kCompact, rowCount);
+    serde::detail::writeTrailer(sizes, encodingType, pool_.get(), buffer);
+    return buffer;
+  }
+
+  // Helper to verify header by writing and parsing back using roundtrip.
+  // For kCompact format, verifies the dense sizes array from trailer.
   void verifyHeader(
       const std::string& buffer,
       SerializationVersion expectedVersion,
       uint32_t expectedRowCount,
-      const std::vector<uint32_t>& expectedOffsets) {
+      const std::vector<uint32_t>& expectedSizes = {}) {
     const char* pos = buffer.data();
+    const char* end = buffer.data() + buffer.size();
 
     // Read version byte.
     auto actualVersion = static_cast<SerializationVersion>(*pos++);
     EXPECT_EQ(actualVersion, expectedVersion);
 
-    // Read row count. Encoded versions use varint.
-    const bool useVarint =
-        (expectedVersion == SerializationVersion::kDenseEncoded ||
-         expectedVersion == SerializationVersion::kSparseEncoded);
+    // Read row count. kCompact uses varint, kLegacy uses u32.
+    const bool isDense = (expectedVersion == SerializationVersion::kCompact);
     uint32_t actualRowCount;
-    if (useVarint) {
+    if (isDense) {
       actualRowCount = varint::readVarint32(&pos);
     } else {
       actualRowCount = encoding::readUint32(pos);
     }
     EXPECT_EQ(actualRowCount, expectedRowCount);
 
-    // For sparse formats, read stream count and offsets.
-    const bool sparseFormat =
-        (expectedVersion == SerializationVersion::kSparse ||
-         expectedVersion == SerializationVersion::kSparseEncoded);
-    if (sparseFormat) {
-      uint32_t streamCount = encoding::readUint32(pos);
-      EXPECT_EQ(streamCount, expectedOffsets.size());
-
-      for (size_t i = 0; i < expectedOffsets.size(); ++i) {
-        uint32_t offset = encoding::readUint32(pos);
-        EXPECT_EQ(offset, expectedOffsets[i]);
-      }
+    // For kCompact format, read sizesSize from last 4 bytes of trailer.
+    if (isDense) {
+      const uint32_t sizesSize = serde::detail::readStreamSizesEncodedSize(end);
+      auto actualSizes = serde::detail::decodeStreamSizes(
+          {end - sizeof(uint32_t) - sizesSize, sizesSize}, pool_.get());
+      EXPECT_EQ(actualSizes, expectedSizes);
     }
-
-    // Verify we consumed exactly the expected amount.
-    size_t rowCountSize =
-        useVarint ? varint::varintSize(expectedRowCount) : sizeof(uint32_t);
-    size_t expectedSize = 1 + rowCountSize; // version + rowCount
-    if (sparseFormat) {
-      expectedSize +=
-          sizeof(uint32_t) + expectedOffsets.size() * sizeof(uint32_t);
-    }
-    EXPECT_EQ(buffer.size(), expectedSize);
   }
+
+  std::shared_ptr<memory::MemoryPool> pool_;
 };
 
-TEST_F(WriteHeaderTest, denseFormats) {
-  for (auto version :
-       {SerializationVersion::kDense, SerializationVersion::kDenseEncoded}) {
-    SCOPED_TRACE(static_cast<int>(version));
-    std::string buffer;
-    serde::detail::writeHeader(buffer, version, 100, {});
-    verifyHeader(buffer, version, 100, {});
-  }
+TEST_F(WriteHeaderTest, legacyFormat) {
+  std::string buffer;
+  serde::detail::writeHeader(buffer, SerializationVersion::kLegacy, 100);
+  verifyHeader(buffer, SerializationVersion::kLegacy, 100, {});
 }
 
-TEST_F(WriteHeaderTest, sparseFormatsWithOffsets) {
-  std::vector<uint32_t> offsets = {0, 1, 2};
-  for (auto version :
-       {SerializationVersion::kSparse, SerializationVersion::kSparseEncoded}) {
-    SCOPED_TRACE(static_cast<int>(version));
-    std::string buffer;
-    serde::detail::writeHeader(buffer, version, 200, offsets);
-    verifyHeader(buffer, version, 200, offsets);
-  }
+TEST_F(WriteHeaderTest, denseFormatWithSizes) {
+  // Dense sizes array: sizes[0]=10, sizes[1]=20, sizes[2]=30.
+  std::vector<uint32_t> sizes = {10, 20, 30};
+  auto buffer = buildDenseHeaderTrailer(200, sizes);
+  verifyHeader(buffer, SerializationVersion::kCompact, 200, sizes);
 }
 
-TEST_F(WriteHeaderTest, sparseFormatsEmptyOffsets) {
-  for (auto version :
-       {SerializationVersion::kSparse, SerializationVersion::kSparseEncoded}) {
-    SCOPED_TRACE(static_cast<int>(version));
-    std::string buffer;
-    serde::detail::writeHeader(buffer, version, 10, {});
-    verifyHeader(buffer, version, 10, {});
-  }
+TEST_F(WriteHeaderTest, denseFormatEmptySizes) {
+  auto buffer = buildDenseHeaderTrailer(10, {});
+  verifyHeader(buffer, SerializationVersion::kCompact, 10, {});
 }
 
-TEST_F(WriteHeaderTest, sparseFormatsManyOffsets) {
-  std::vector<uint32_t> offsets;
+TEST_F(WriteHeaderTest, denseFormatManySizes) {
+  // Dense sizes array with 200 entries (100 non-zero interleaved with zeros).
+  std::vector<uint32_t> sizes(200, 0);
   for (uint32_t i = 0; i < 100; ++i) {
-    offsets.push_back(i * 2); // Non-sequential offsets.
+    sizes[i * 2] = i + 1;
   }
-  for (auto version :
-       {SerializationVersion::kSparse, SerializationVersion::kSparseEncoded}) {
-    SCOPED_TRACE(static_cast<int>(version));
-    std::string buffer;
-    serde::detail::writeHeader(buffer, version, 1000, offsets);
-    verifyHeader(buffer, version, 1000, offsets);
-  }
+  auto buffer = buildDenseHeaderTrailer(1000, sizes);
+  verifyHeader(buffer, SerializationVersion::kCompact, 1000, sizes);
 }
 
 TEST_F(WriteHeaderTest, zeroRowCount) {
-  for (auto version :
-       {SerializationVersion::kDense,
-        SerializationVersion::kDenseEncoded,
-        SerializationVersion::kSparse,
-        SerializationVersion::kSparseEncoded}) {
-    SCOPED_TRACE(static_cast<int>(version));
+  {
+    SCOPED_TRACE("kLegacy");
     std::string buffer;
-    serde::detail::writeHeader(buffer, version, 0, {});
-    verifyHeader(buffer, version, 0, {});
+    serde::detail::writeHeader(buffer, SerializationVersion::kLegacy, 0);
+    verifyHeader(buffer, SerializationVersion::kLegacy, 0, {});
+  }
+  {
+    SCOPED_TRACE("kCompact");
+    auto buffer = buildDenseHeaderTrailer(0, {});
+    verifyHeader(buffer, SerializationVersion::kCompact, 0, {});
   }
 }
 
 TEST_F(WriteHeaderTest, maxRowCount) {
-  for (auto version :
-       {SerializationVersion::kDense,
-        SerializationVersion::kDenseEncoded,
-        SerializationVersion::kSparse,
-        SerializationVersion::kSparseEncoded}) {
-    SCOPED_TRACE(static_cast<int>(version));
+  {
+    SCOPED_TRACE("kLegacy");
     std::string buffer;
     serde::detail::writeHeader(
-        buffer, version, std::numeric_limits<uint32_t>::max(), {});
-    verifyHeader(buffer, version, std::numeric_limits<uint32_t>::max(), {});
+        buffer,
+        SerializationVersion::kLegacy,
+        std::numeric_limits<uint32_t>::max());
+    verifyHeader(
+        buffer,
+        SerializationVersion::kLegacy,
+        std::numeric_limits<uint32_t>::max(),
+        {});
+  }
+  {
+    SCOPED_TRACE("kCompact");
+    auto buffer =
+        buildDenseHeaderTrailer(std::numeric_limits<uint32_t>::max(), {});
+    verifyHeader(
+        buffer,
+        SerializationVersion::kCompact,
+        std::numeric_limits<uint32_t>::max(),
+        {});
   }
 }
 
 TEST_F(WriteHeaderTest, noVersionHeader) {
   std::string buffer;
-  serde::detail::writeHeader(buffer, std::nullopt, 100, {});
+  serde::detail::writeHeader(buffer, std::nullopt, 100);
 
   // No version byte - only row count.
   EXPECT_EQ(buffer.size(), sizeof(uint32_t));
@@ -161,518 +165,697 @@ TEST_F(WriteHeaderTest, noVersionHeader) {
 
 class WriteStreamTest : public ::testing::Test {
  protected:
-  void verifyStream(const std::string& buffer, std::string_view expectedData) {
+  void verifyStream(
+      const std::string& buffer,
+      std::string_view expectedData,
+      bool useVarint) {
     const char* pos = buffer.data();
 
     // Read size.
-    uint32_t actualSize = encoding::readUint32(pos);
+    uint32_t actualSize;
+    if (useVarint) {
+      actualSize = varint::readVarint32(&pos);
+    } else {
+      actualSize = encoding::readUint32(pos);
+    }
     EXPECT_EQ(actualSize, expectedData.size());
 
     // Read data.
     std::string_view actualData(pos, actualSize);
     EXPECT_EQ(actualData, expectedData);
-
-    // Verify total buffer size.
-    EXPECT_EQ(buffer.size(), sizeof(uint32_t) + expectedData.size());
   }
 };
 
 TEST_F(WriteStreamTest, emptyStream) {
-  std::string buffer;
-  serde::detail::writeStream(buffer, "");
-
-  verifyStream(buffer, "");
+  {
+    SCOPED_TRACE("u32");
+    std::string buffer;
+    serde::detail::writeStream<false>("", buffer);
+    verifyStream(buffer, "", false);
+  }
+  {
+    SCOPED_TRACE("varint");
+    std::string buffer;
+    serde::detail::writeStream<true>("", buffer);
+    verifyStream(buffer, "", true);
+  }
 }
 
 TEST_F(WriteStreamTest, singleByteStream) {
-  std::string buffer;
-  serde::detail::writeStream(buffer, "X");
-
-  verifyStream(buffer, "X");
+  {
+    SCOPED_TRACE("u32");
+    std::string buffer;
+    serde::detail::writeStream<false>("X", buffer);
+    verifyStream(buffer, "X", false);
+  }
+  {
+    SCOPED_TRACE("varint");
+    std::string buffer;
+    serde::detail::writeStream<true>("X", buffer);
+    verifyStream(buffer, "X", true);
+  }
 }
 
 TEST_F(WriteStreamTest, multiByteStream) {
-  std::string buffer;
   std::string data = "Hello, World!";
-  serde::detail::writeStream(buffer, data);
-
-  verifyStream(buffer, data);
+  {
+    SCOPED_TRACE("u32");
+    std::string buffer;
+    serde::detail::writeStream<false>(data, buffer);
+    verifyStream(buffer, data, false);
+  }
+  {
+    SCOPED_TRACE("varint");
+    std::string buffer;
+    serde::detail::writeStream<true>(data, buffer);
+    verifyStream(buffer, data, true);
+  }
 }
 
 TEST_F(WriteStreamTest, binaryStream) {
-  std::string buffer;
   std::string data;
   for (int i = 0; i < 256; ++i) {
     data.push_back(static_cast<char>(i));
   }
-  serde::detail::writeStream(buffer, data);
-
-  verifyStream(buffer, data);
+  {
+    SCOPED_TRACE("u32");
+    std::string buffer;
+    serde::detail::writeStream<false>(data, buffer);
+    verifyStream(buffer, data, false);
+  }
+  {
+    SCOPED_TRACE("varint");
+    std::string buffer;
+    serde::detail::writeStream<true>(data, buffer);
+    verifyStream(buffer, data, true);
+  }
 }
 
 TEST_F(WriteStreamTest, multipleStreams) {
-  std::string buffer;
   std::string data1 = "first";
   std::string data2 = "second";
   std::string data3 = "third";
 
-  serde::detail::writeStream(buffer, data1);
-  serde::detail::writeStream(buffer, data2);
-  serde::detail::writeStream(buffer, data3);
+  {
+    SCOPED_TRACE("u32");
+    std::string buffer;
+    serde::detail::writeStream<false>(data1, buffer);
+    serde::detail::writeStream<false>(data2, buffer);
+    serde::detail::writeStream<false>(data3, buffer);
 
-  // Verify all three streams were written.
-  const char* pos = buffer.data();
+    const char* pos = buffer.data();
+    EXPECT_EQ(serde::detail::readStream<false>(pos), data1);
+    EXPECT_EQ(serde::detail::readStream<false>(pos), data2);
+    EXPECT_EQ(serde::detail::readStream<false>(pos), data3);
+    EXPECT_EQ(pos, buffer.data() + buffer.size());
+  }
+  {
+    SCOPED_TRACE("varint");
+    std::string buffer;
+    serde::detail::writeStream<true>(data1, buffer);
+    serde::detail::writeStream<true>(data2, buffer);
+    serde::detail::writeStream<true>(data3, buffer);
 
-  uint32_t size1 = encoding::readUint32(pos);
-  EXPECT_EQ(size1, data1.size());
-  EXPECT_EQ(std::string_view(pos, size1), data1);
-  pos += size1;
-
-  uint32_t size2 = encoding::readUint32(pos);
-  EXPECT_EQ(size2, data2.size());
-  EXPECT_EQ(std::string_view(pos, size2), data2);
-  pos += size2;
-
-  uint32_t size3 = encoding::readUint32(pos);
-  EXPECT_EQ(size3, data3.size());
-  EXPECT_EQ(std::string_view(pos, size3), data3);
+    const char* pos = buffer.data();
+    EXPECT_EQ(serde::detail::readStream<true>(pos), data1);
+    EXPECT_EQ(serde::detail::readStream<true>(pos), data2);
+    EXPECT_EQ(serde::detail::readStream<true>(pos), data3);
+    EXPECT_EQ(pos, buffer.data() + buffer.size());
+  }
 }
 
 // Tests for readStream
 
-TEST(ReadStreamTest, emptyStream) {
-  std::string buffer;
-  serde::detail::writeStream(buffer, "");
+TEST(ReadStreamTest, roundTrip) {
+  {
+    SCOPED_TRACE("u32");
+    std::string buffer;
+    serde::detail::writeStream<false>("", buffer);
+    serde::detail::writeStream<false>("X", buffer);
+    serde::detail::writeStream<false>("Hello, World!", buffer);
 
-  const char* pos = buffer.data();
-  auto result = serde::detail::readStream(pos);
+    const char* pos = buffer.data();
+    EXPECT_TRUE(serde::detail::readStream<false>(pos).empty());
+    EXPECT_EQ(serde::detail::readStream<false>(pos), "X");
+    EXPECT_EQ(serde::detail::readStream<false>(pos), "Hello, World!");
+    EXPECT_EQ(pos, buffer.data() + buffer.size());
+  }
+  {
+    SCOPED_TRACE("varint");
+    std::string buffer;
+    serde::detail::writeStream<true>("", buffer);
+    serde::detail::writeStream<true>("X", buffer);
+    serde::detail::writeStream<true>("Hello, World!", buffer);
 
-  EXPECT_TRUE(result.empty());
-  EXPECT_EQ(pos, buffer.data() + buffer.size());
-}
-
-TEST(ReadStreamTest, singleByteStream) {
-  std::string buffer;
-  serde::detail::writeStream(buffer, "X");
-
-  const char* pos = buffer.data();
-  auto result = serde::detail::readStream(pos);
-
-  EXPECT_EQ(result, "X");
-  EXPECT_EQ(pos, buffer.data() + buffer.size());
-}
-
-TEST(ReadStreamTest, multiByteStream) {
-  std::string buffer;
-  std::string data = "Hello, World!";
-  serde::detail::writeStream(buffer, data);
-
-  const char* pos = buffer.data();
-  auto result = serde::detail::readStream(pos);
-
-  EXPECT_EQ(result, data);
-  EXPECT_EQ(pos, buffer.data() + buffer.size());
-}
-
-TEST(ReadStreamTest, multipleStreams) {
-  std::string buffer;
-  serde::detail::writeStream(buffer, "first");
-  serde::detail::writeStream(buffer, "second");
-  serde::detail::writeStream(buffer, "third");
-
-  const char* pos = buffer.data();
-
-  auto result1 = serde::detail::readStream(pos);
-  EXPECT_EQ(result1, "first");
-
-  auto result2 = serde::detail::readStream(pos);
-  EXPECT_EQ(result2, "second");
-
-  auto result3 = serde::detail::readStream(pos);
-  EXPECT_EQ(result3, "third");
-
-  EXPECT_EQ(pos, buffer.data() + buffer.size());
+    const char* pos = buffer.data();
+    EXPECT_TRUE(serde::detail::readStream<true>(pos).empty());
+    EXPECT_EQ(serde::detail::readStream<true>(pos), "X");
+    EXPECT_EQ(serde::detail::readStream<true>(pos), "Hello, World!");
+    EXPECT_EQ(pos, buffer.data() + buffer.size());
+  }
 }
 
 // Tests for parseStreams
 
 class ParseStreamsTest : public ::testing::Test {
  protected:
-  // Helper to build a dense format buffer.
-  std::string buildDenseBuffer(const std::vector<std::string>& streams) {
+  static void SetUpTestSuite() {
+    memory::MemoryManager::testingSetInstance(memory::MemoryManager::Options{});
+  }
+
+  void SetUp() override {
+    pool_ = memory::memoryManager()->addLeafPool("parse_streams_test");
+  }
+
+  // Helper to build a kLegacy format buffer with u32 sizes.
+  std::string buildLegacyBuffer(const std::vector<std::string>& streams) {
     std::string buffer;
     for (const auto& stream : streams) {
-      serde::detail::writeStream(buffer, stream);
+      serde::detail::writeStream<false>(stream, buffer);
     }
     return buffer;
   }
 
-  // Helper to build a sparse format buffer.
-  std::string buildSparseBuffer(
-      const std::vector<std::pair<uint32_t, std::string>>& offsetsAndData) {
-    std::string buffer;
-
-    // Write stream count.
-    char countBuf[sizeof(uint32_t)];
-    char* countPtr = countBuf;
-    encoding::writeUint32(offsetsAndData.size(), countPtr);
-    buffer.append(countBuf, sizeof(uint32_t));
-
-    // Write offsets.
-    for (const auto& [offset, _] : offsetsAndData) {
-      char offsetBuf[sizeof(uint32_t)];
-      char* offsetPtr = offsetBuf;
-      encoding::writeUint32(offset, offsetPtr);
-      buffer.append(offsetBuf, sizeof(uint32_t));
-    }
-
-    // Write stream data.
-    for (const auto& [_, data] : offsetsAndData) {
-      serde::detail::writeStream(buffer, data);
-    }
-
-    return buffer;
-  }
+  std::shared_ptr<memory::MemoryPool> pool_;
 };
 
-TEST_F(ParseStreamsTest, denseFormatEmpty) {
+TEST_F(ParseStreamsTest, legacyFormatEmpty) {
   std::string buffer;
+  auto streams = serde::detail::parseStreams(
+      buffer.data(),
+      buffer.data() + buffer.size(),
+      SerializationVersion::kLegacy,
+      pool_.get());
+  EXPECT_TRUE(streams.empty());
+}
 
-  for (auto version :
-       {SerializationVersion::kDense, SerializationVersion::kDenseEncoded}) {
-    SCOPED_TRACE(static_cast<int>(version));
-    auto streams = serde::detail::parseStreams(
-        buffer.data(), buffer.data() + buffer.size(), version);
-    EXPECT_TRUE(streams.empty());
+TEST_F(ParseStreamsTest, legacyFormatSingleStream) {
+  auto buffer = buildLegacyBuffer({"hello"});
+  auto streams = serde::detail::parseStreams(
+      buffer.data(),
+      buffer.data() + buffer.size(),
+      SerializationVersion::kLegacy,
+      pool_.get());
+  ASSERT_EQ(streams.size(), 1);
+  EXPECT_EQ(streams[0], "hello");
+}
+
+TEST_F(ParseStreamsTest, legacyFormatMultipleStreams) {
+  auto buffer = buildLegacyBuffer({"first", "second", "third"});
+  auto streams = serde::detail::parseStreams(
+      buffer.data(),
+      buffer.data() + buffer.size(),
+      SerializationVersion::kLegacy,
+      pool_.get());
+  ASSERT_EQ(streams.size(), 3);
+  EXPECT_EQ(streams[0], "first");
+  EXPECT_EQ(streams[1], "second");
+  EXPECT_EQ(streams[2], "third");
+}
+
+// kCompact format tests use writeHeader/parseStreams roundtrip since
+// the size encoding is now opaque (nimble-encoded).
+
+TEST_F(ParseStreamsTest, denseFormatEmpty) {
+  // Write header + trailer with empty sizes array, then parse.
+  std::string buffer;
+  serde::detail::writeHeader(buffer, SerializationVersion::kCompact, 10);
+  serde::detail::writeTrailer({}, std::nullopt, pool_.get(), buffer);
+
+  auto streams = serde::detail::parseStreams(
+      // Skip version byte and row count varint.
+      buffer.data() + 1 + varint::varintSize(10),
+      buffer.data() + buffer.size(),
+      SerializationVersion::kCompact,
+      pool_.get());
+  EXPECT_TRUE(streams.empty());
+}
+
+TEST_F(ParseStreamsTest, denseFormatSequential) {
+  // Dense sizes array: sizes[0]=4, sizes[1]=3, sizes[2]=3.
+  std::vector<std::string> data = {"zero", "one", "two"};
+  std::vector<uint32_t> sizes;
+  for (const auto& d : data) {
+    sizes.push_back(d.size());
+  }
+
+  std::string buffer;
+  serde::detail::writeHeader(buffer, SerializationVersion::kCompact, 100);
+  for (const auto& d : data) {
+    buffer.append(d);
+  }
+  serde::detail::writeTrailer(sizes, std::nullopt, pool_.get(), buffer);
+
+  // Skip version byte + varint row count.
+  const char* pos = buffer.data() + 1;
+  varint::readVarint32(&pos);
+
+  auto streams = serde::detail::parseStreams(
+      pos,
+      buffer.data() + buffer.size(),
+      SerializationVersion::kCompact,
+      pool_.get());
+
+  ASSERT_EQ(streams.size(), 3);
+  EXPECT_EQ(streams[0], "zero");
+  EXPECT_EQ(streams[1], "one");
+  EXPECT_EQ(streams[2], "two");
+}
+
+TEST_F(ParseStreamsTest, denseFormatWithGaps) {
+  // Dense sizes array with gaps (zeros at indices 1, 3, 4).
+  // sizes = {4, 0, 3, 0, 0, 4}
+  std::vector<uint32_t> sizes = {4, 0, 3, 0, 0, 4};
+
+  std::string buffer;
+  serde::detail::writeHeader(buffer, SerializationVersion::kCompact, 100);
+  buffer.append("zero");
+  buffer.append("two");
+  buffer.append("five");
+  serde::detail::writeTrailer(sizes, std::nullopt, pool_.get(), buffer);
+
+  const char* pos = buffer.data() + 1;
+  varint::readVarint32(&pos);
+
+  auto streams = serde::detail::parseStreams(
+      pos,
+      buffer.data() + buffer.size(),
+      SerializationVersion::kCompact,
+      pool_.get());
+
+  ASSERT_EQ(streams.size(), 6);
+  EXPECT_EQ(streams[0], "zero");
+  EXPECT_TRUE(streams[1].empty()); // gap
+  EXPECT_EQ(streams[2], "two");
+  EXPECT_TRUE(streams[3].empty()); // gap
+  EXPECT_TRUE(streams[4].empty()); // gap
+  EXPECT_EQ(streams[5], "five");
+}
+
+TEST_F(ParseStreamsTest, denseFormatOnlyLastStream) {
+  // Dense sizes array with only the last stream present.
+  // sizes = {0, 0, 0, 0, 5}
+  std::vector<uint32_t> sizes = {0, 0, 0, 0, 5};
+
+  std::string buffer;
+  serde::detail::writeHeader(buffer, SerializationVersion::kCompact, 100);
+  buffer.append("hello");
+  serde::detail::writeTrailer(sizes, std::nullopt, pool_.get(), buffer);
+
+  const char* pos = buffer.data() + 1;
+  varint::readVarint32(&pos);
+
+  auto streams = serde::detail::parseStreams(
+      pos,
+      buffer.data() + buffer.size(),
+      SerializationVersion::kCompact,
+      pool_.get());
+
+  ASSERT_EQ(streams.size(), 5);
+  EXPECT_TRUE(streams[0].empty());
+  EXPECT_TRUE(streams[1].empty());
+  EXPECT_TRUE(streams[2].empty());
+  EXPECT_TRUE(streams[3].empty());
+  EXPECT_EQ(streams[4], "hello");
+}
+
+// Tests for encodeTyped / decodeStreamSizes roundtrip.
+
+class EncodeDecodeTest : public ::testing::Test {
+ protected:
+  static void SetUpTestSuite() {
+    memory::MemoryManager::testingSetInstance(memory::MemoryManager::Options{});
+  }
+
+  void SetUp() override {
+    pool_ = memory::memoryManager()->addLeafPool("encode_decode_test");
+  }
+
+  // Helper to encode a uint32_t array using nimble encoding.
+  // Returns the raw encoded buffer (no size prefix).
+  std::string encodeAndWrite(const std::vector<uint32_t>& values) {
+    facebook::nimble::Buffer encodingBuffer{*pool_};
+    ManualEncodingSelectionPolicyFactory factory;
+    auto encoded = serde::detail::encodeTyped<uint32_t>(
+        values, encodingBuffer, [&factory](DataType dataType) {
+          return factory.createPolicy(dataType);
+        });
+    return std::string(encoded.data(), encoded.size());
+  }
+
+  std::shared_ptr<memory::MemoryPool> pool_;
+};
+
+TEST_F(EncodeDecodeTest, decodeStreamSizesRoundtrip) {
+  struct TestParam {
+    std::vector<uint32_t> values;
+    std::string debugString() const {
+      return fmt::format("values.size() {}", values.size());
+    }
+  };
+  std::vector<TestParam> testSettings = {
+      {{}},
+      {{0}},
+      {{0, 1, 2}},
+      {{5, 0, 3, 1, 4, 2}},
+      {{100, 200, 300, 400, 500}},
+  };
+  for (const auto& testData : testSettings) {
+    SCOPED_TRACE(testData.debugString());
+
+    auto buffer = encodeAndWrite(testData.values);
+    auto decoded = serde::detail::decodeStreamSizes(buffer, pool_.get());
+    EXPECT_EQ(decoded, testData.values);
   }
 }
 
-TEST_F(ParseStreamsTest, denseFormatSingleStream) {
-  auto buffer = buildDenseBuffer({"hello"});
-
-  for (auto version :
-       {SerializationVersion::kDense, SerializationVersion::kDenseEncoded}) {
-    SCOPED_TRACE(static_cast<int>(version));
-    auto streams = serde::detail::parseStreams(
-        buffer.data(), buffer.data() + buffer.size(), version);
-
-    ASSERT_EQ(streams.size(), 1);
-    EXPECT_EQ(streams[0], "hello");
+TEST_F(EncodeDecodeTest, decodeStreamSizesLargeValues) {
+  std::vector<uint32_t> values;
+  for (uint32_t i = 0; i < 1000; ++i) {
+    values.push_back(i * 3);
   }
+
+  auto buffer = encodeAndWrite(values);
+  auto decoded = serde::detail::decodeStreamSizes(buffer, pool_.get());
+  EXPECT_EQ(decoded, values);
 }
 
-TEST_F(ParseStreamsTest, denseFormatMultipleStreams) {
-  auto buffer = buildDenseBuffer({"first", "second", "third"});
+TEST_F(EncodeDecodeTest, streamSizesEncodingType) {
+  std::vector<uint32_t> sizes = {2, 2, 2};
 
-  for (auto version :
-       {SerializationVersion::kDense, SerializationVersion::kDenseEncoded}) {
-    SCOPED_TRACE(static_cast<int>(version));
+  for (auto encodingType :
+       {EncodingType::Trivial,
+        EncodingType::FixedBitWidth,
+        EncodingType::Varint}) {
+    SCOPED_TRACE(toString(encodingType));
+
+    std::string buffer;
+    serde::detail::writeHeader(buffer, SerializationVersion::kCompact, 100);
+    buffer.append("s0");
+    buffer.append("s1");
+    buffer.append("s2");
+    serde::detail::writeTrailer(sizes, encodingType, pool_.get(), buffer);
+
+    const char* pos = buffer.data() + 1;
+    varint::readVarint32(&pos);
     auto streams = serde::detail::parseStreams(
-        buffer.data(), buffer.data() + buffer.size(), version);
+        pos,
+        buffer.data() + buffer.size(),
+        SerializationVersion::kCompact,
+        pool_.get());
 
     ASSERT_EQ(streams.size(), 3);
-    EXPECT_EQ(streams[0], "first");
-    EXPECT_EQ(streams[1], "second");
-    EXPECT_EQ(streams[2], "third");
+    EXPECT_EQ(streams[0], "s0");
+    EXPECT_EQ(streams[1], "s1");
+    EXPECT_EQ(streams[2], "s2");
   }
 }
 
-TEST_F(ParseStreamsTest, sparseFormatEmpty) {
-  auto buffer = buildSparseBuffer({});
+TEST_F(EncodeDecodeTest, streamSizesEncodingTypeDefault) {
+  std::vector<uint32_t> sizes = {1, 1, 1};
 
-  for (auto version :
-       {SerializationVersion::kSparse, SerializationVersion::kSparseEncoded}) {
-    SCOPED_TRACE(static_cast<int>(version));
-    auto streams = serde::detail::parseStreams(
-        buffer.data(), buffer.data() + buffer.size(), version);
-    EXPECT_TRUE(streams.empty());
-  }
-}
+  std::string buffer;
+  serde::detail::writeHeader(buffer, SerializationVersion::kCompact, 100);
+  buffer.append("a");
+  buffer.append("b");
+  buffer.append("c");
+  serde::detail::writeTrailer(sizes, std::nullopt, pool_.get(), buffer);
 
-TEST_F(ParseStreamsTest, sparseFormatSequential) {
-  auto buffer = buildSparseBuffer({{0, "zero"}, {1, "one"}, {2, "two"}});
+  const char* pos = buffer.data() + 1;
+  varint::readVarint32(&pos);
+  auto streams = serde::detail::parseStreams(
+      pos,
+      buffer.data() + buffer.size(),
+      SerializationVersion::kCompact,
+      pool_.get());
 
-  for (auto version :
-       {SerializationVersion::kSparse, SerializationVersion::kSparseEncoded}) {
-    SCOPED_TRACE(static_cast<int>(version));
-    auto streams = serde::detail::parseStreams(
-        buffer.data(), buffer.data() + buffer.size(), version);
-
-    ASSERT_EQ(streams.size(), 3);
-    EXPECT_EQ(streams[0], "zero");
-    EXPECT_EQ(streams[1], "one");
-    EXPECT_EQ(streams[2], "two");
-  }
-}
-
-TEST_F(ParseStreamsTest, sparseFormatWithGaps) {
-  auto buffer = buildSparseBuffer({{0, "zero"}, {2, "two"}, {5, "five"}});
-
-  for (auto version :
-       {SerializationVersion::kSparse, SerializationVersion::kSparseEncoded}) {
-    SCOPED_TRACE(static_cast<int>(version));
-    auto streams = serde::detail::parseStreams(
-        buffer.data(), buffer.data() + buffer.size(), version);
-
-    ASSERT_EQ(streams.size(), 6);
-    EXPECT_EQ(streams[0], "zero");
-    EXPECT_TRUE(streams[1].empty()); // gap
-    EXPECT_EQ(streams[2], "two");
-    EXPECT_TRUE(streams[3].empty()); // gap
-    EXPECT_TRUE(streams[4].empty()); // gap
-    EXPECT_EQ(streams[5], "five");
-  }
-}
-
-TEST_F(ParseStreamsTest, sparseFormatOutOfOrder) {
-  // Offsets don't have to be in order.
-  auto buffer = buildSparseBuffer({{2, "two"}, {0, "zero"}, {1, "one"}});
-
-  for (auto version :
-       {SerializationVersion::kSparse, SerializationVersion::kSparseEncoded}) {
-    SCOPED_TRACE(static_cast<int>(version));
-    auto streams = serde::detail::parseStreams(
-        buffer.data(), buffer.data() + buffer.size(), version);
-
-    ASSERT_EQ(streams.size(), 3);
-    EXPECT_EQ(streams[0], "zero");
-    EXPECT_EQ(streams[1], "one");
-    EXPECT_EQ(streams[2], "two");
-  }
+  ASSERT_EQ(streams.size(), 3);
+  EXPECT_EQ(streams[0], "a");
+  EXPECT_EQ(streams[1], "b");
+  EXPECT_EQ(streams[2], "c");
 }
 
 // Tests for projectStreams
 
-class ProjectStreamsTest : public ParseStreamsTest {};
+class ProjectStreamsTest : public ParseStreamsTest {
+ protected:
+  // Helper to build a kCompact buffer using writeHeader + raw data.
+  // Takes (streamIndex, data) pairs and builds a dense sizes array.
+  // Returns buffer starting after version byte + row count (streams position).
+  std::string buildDenseBuffer(
+      const std::vector<std::pair<uint32_t, std::string>>& indexAndData) {
+    // Build dense sizes array.
+    uint32_t maxIndex = 0;
+    for (const auto& [index, _] : indexAndData) {
+      maxIndex = std::max(maxIndex, index);
+    }
+    std::vector<uint32_t> sizes(indexAndData.empty() ? 0 : maxIndex + 1, 0);
+    for (const auto& [index, data] : indexAndData) {
+      sizes[index] = data.size();
+    }
+
+    std::string buffer;
+    serde::detail::writeHeader(buffer, SerializationVersion::kCompact, 100);
+
+    // Append raw stream data in index order (only non-zero sizes).
+    // Sort by index to ensure correct order.
+    auto sorted = indexAndData;
+    std::sort(sorted.begin(), sorted.end());
+    for (const auto& [_, data] : sorted) {
+      buffer.append(data);
+    }
+
+    // Write trailer with encoded sizes.
+    serde::detail::writeTrailer(sizes, std::nullopt, pool_.get(), buffer);
+
+    // Skip version byte + varint row count to get to streams position.
+    const char* pos = buffer.data() + 1;
+    varint::readVarint32(&pos);
+    auto offset = pos - buffer.data();
+    return buffer.substr(offset);
+  }
+};
+
+TEST_F(ProjectStreamsTest, legacySelectAll) {
+  auto buffer = buildLegacyBuffer({"aaa", "bbb", "ccc"});
+  std::vector<uint32_t> selected = {0, 1, 2};
+  auto streams = serde::detail::projectStreams(
+      buffer.data(),
+      buffer.data() + buffer.size(),
+      SerializationVersion::kLegacy,
+      selected,
+      pool_.get());
+
+  ASSERT_EQ(streams.size(), 3);
+  EXPECT_EQ(streams[0].index, 0);
+  EXPECT_EQ(streams[0].data, "aaa");
+  EXPECT_EQ(streams[1].index, 1);
+  EXPECT_EQ(streams[1].data, "bbb");
+  EXPECT_EQ(streams[2].index, 2);
+  EXPECT_EQ(streams[2].data, "ccc");
+}
+
+TEST_F(ProjectStreamsTest, legacySelectSubset) {
+  auto buffer = buildLegacyBuffer({"aaa", "bbb", "ccc", "ddd", "eee"});
+  std::vector<uint32_t> selected = {1, 3};
+  auto streams = serde::detail::projectStreams(
+      buffer.data(),
+      buffer.data() + buffer.size(),
+      SerializationVersion::kLegacy,
+      selected,
+      pool_.get());
+
+  ASSERT_EQ(streams.size(), 2);
+  EXPECT_EQ(streams[0].index, 0);
+  EXPECT_EQ(streams[0].data, "bbb");
+  EXPECT_EQ(streams[1].index, 1);
+  EXPECT_EQ(streams[1].data, "ddd");
+}
+
+TEST_F(ProjectStreamsTest, legacySelectFirst) {
+  auto buffer = buildLegacyBuffer({"aaa", "bbb", "ccc"});
+  std::vector<uint32_t> selected = {0};
+  auto streams = serde::detail::projectStreams(
+      buffer.data(),
+      buffer.data() + buffer.size(),
+      SerializationVersion::kLegacy,
+      selected,
+      pool_.get());
+
+  ASSERT_EQ(streams.size(), 1);
+  EXPECT_EQ(streams[0].index, 0);
+  EXPECT_EQ(streams[0].data, "aaa");
+}
+
+TEST_F(ProjectStreamsTest, legacySelectLast) {
+  auto buffer = buildLegacyBuffer({"aaa", "bbb", "ccc"});
+  std::vector<uint32_t> selected = {2};
+  auto streams = serde::detail::projectStreams(
+      buffer.data(),
+      buffer.data() + buffer.size(),
+      SerializationVersion::kLegacy,
+      selected,
+      pool_.get());
+
+  ASSERT_EQ(streams.size(), 1);
+  EXPECT_EQ(streams[0].index, 0);
+  EXPECT_EQ(streams[0].data, "ccc");
+}
+
+TEST_F(ProjectStreamsTest, legacySkipsEmptyStreams) {
+  auto buffer = buildLegacyBuffer({"aaa", "", "ccc"});
+  std::vector<uint32_t> selected = {0, 1, 2};
+  auto streams = serde::detail::projectStreams(
+      buffer.data(),
+      buffer.data() + buffer.size(),
+      SerializationVersion::kLegacy,
+      selected,
+      pool_.get());
+
+  // Empty stream at index 1 is skipped.
+  ASSERT_EQ(streams.size(), 2);
+  EXPECT_EQ(streams[0].index, 0);
+  EXPECT_EQ(streams[0].data, "aaa");
+  EXPECT_EQ(streams[1].index, 2);
+  EXPECT_EQ(streams[1].data, "ccc");
+}
+
+TEST_F(ProjectStreamsTest, legacyAllEmpty) {
+  auto buffer = buildLegacyBuffer({"", "", ""});
+  std::vector<uint32_t> selected = {0, 1, 2};
+  auto streams = serde::detail::projectStreams(
+      buffer.data(),
+      buffer.data() + buffer.size(),
+      SerializationVersion::kLegacy,
+      selected,
+      pool_.get());
+  EXPECT_TRUE(streams.empty());
+}
 
 TEST_F(ProjectStreamsTest, denseSelectAll) {
-  auto buffer = buildDenseBuffer({"aaa", "bbb", "ccc"});
+  auto buffer = buildDenseBuffer({{0, "aaa"}, {1, "bbb"}, {2, "ccc"}});
 
-  for (auto version :
-       {SerializationVersion::kDense, SerializationVersion::kDenseEncoded}) {
-    SCOPED_TRACE(static_cast<int>(version));
-    std::vector<uint32_t> selected = {0, 1, 2};
-    auto streams = serde::detail::projectStreams(
-        buffer.data(), buffer.data() + buffer.size(), version, selected);
+  std::vector<uint32_t> selected = {0, 1, 2};
+  auto streams = serde::detail::projectStreams(
+      buffer.data(),
+      buffer.data() + buffer.size(),
+      SerializationVersion::kCompact,
+      selected,
+      pool_.get());
 
-    ASSERT_EQ(streams.size(), 3);
-    EXPECT_EQ(streams[0].index, 0);
-    EXPECT_EQ(streams[0].data, "aaa");
-    EXPECT_EQ(streams[1].index, 1);
-    EXPECT_EQ(streams[1].data, "bbb");
-    EXPECT_EQ(streams[2].index, 2);
-    EXPECT_EQ(streams[2].data, "ccc");
-  }
+  ASSERT_EQ(streams.size(), 3);
+  EXPECT_EQ(streams[0].index, 0);
+  EXPECT_EQ(streams[0].data, "aaa");
+  EXPECT_EQ(streams[1].index, 1);
+  EXPECT_EQ(streams[1].data, "bbb");
+  EXPECT_EQ(streams[2].index, 2);
+  EXPECT_EQ(streams[2].data, "ccc");
 }
 
 TEST_F(ProjectStreamsTest, denseSelectSubset) {
-  auto buffer = buildDenseBuffer({"aaa", "bbb", "ccc", "ddd", "eee"});
+  auto buffer = buildDenseBuffer(
+      {{0, "aaa"}, {1, "bbb"}, {2, "ccc"}, {3, "ddd"}, {4, "eee"}});
 
-  for (auto version :
-       {SerializationVersion::kDense, SerializationVersion::kDenseEncoded}) {
-    SCOPED_TRACE(static_cast<int>(version));
-    std::vector<uint32_t> selected = {1, 3};
-    auto streams = serde::detail::projectStreams(
-        buffer.data(), buffer.data() + buffer.size(), version, selected);
+  std::vector<uint32_t> selected = {1, 3};
+  auto streams = serde::detail::projectStreams(
+      buffer.data(),
+      buffer.data() + buffer.size(),
+      SerializationVersion::kCompact,
+      selected,
+      pool_.get());
 
-    ASSERT_EQ(streams.size(), 2);
-    EXPECT_EQ(streams[0].index, 0);
-    EXPECT_EQ(streams[0].data, "bbb");
-    EXPECT_EQ(streams[1].index, 1);
-    EXPECT_EQ(streams[1].data, "ddd");
-  }
+  ASSERT_EQ(streams.size(), 2);
+  EXPECT_EQ(streams[0].index, 0);
+  EXPECT_EQ(streams[0].data, "bbb");
+  EXPECT_EQ(streams[1].index, 1);
+  EXPECT_EQ(streams[1].data, "ddd");
 }
 
-TEST_F(ProjectStreamsTest, denseSelectFirst) {
-  auto buffer = buildDenseBuffer({"aaa", "bbb", "ccc"});
+TEST_F(ProjectStreamsTest, denseWithGaps) {
+  // Input has gaps (offsets 0, 2, 5). Select 0 and 5.
+  auto buffer = buildDenseBuffer({{0, "zero"}, {2, "two"}, {5, "five"}});
 
-  for (auto version :
-       {SerializationVersion::kDense, SerializationVersion::kDenseEncoded}) {
-    SCOPED_TRACE(static_cast<int>(version));
-    std::vector<uint32_t> selected = {0};
-    auto streams = serde::detail::projectStreams(
-        buffer.data(), buffer.data() + buffer.size(), version, selected);
+  std::vector<uint32_t> selected = {0, 5};
+  auto streams = serde::detail::projectStreams(
+      buffer.data(),
+      buffer.data() + buffer.size(),
+      SerializationVersion::kCompact,
+      selected,
+      pool_.get());
 
-    ASSERT_EQ(streams.size(), 1);
-    EXPECT_EQ(streams[0].index, 0);
-    EXPECT_EQ(streams[0].data, "aaa");
-  }
+  ASSERT_EQ(streams.size(), 2);
+  EXPECT_EQ(streams[0].index, 0);
+  EXPECT_EQ(streams[0].data, "zero");
+  EXPECT_EQ(streams[1].index, 1);
+  EXPECT_EQ(streams[1].data, "five");
 }
 
-TEST_F(ProjectStreamsTest, denseSelectLast) {
-  auto buffer = buildDenseBuffer({"aaa", "bbb", "ccc"});
+TEST_F(ProjectStreamsTest, denseSelectedNotInInput) {
+  // Input has offsets {0, 2}. Select {0, 1, 2} — offset 1 is missing.
+  auto buffer = buildDenseBuffer({{0, "zero"}, {2, "two"}});
 
-  for (auto version :
-       {SerializationVersion::kDense, SerializationVersion::kDenseEncoded}) {
-    SCOPED_TRACE(static_cast<int>(version));
-    std::vector<uint32_t> selected = {2};
-    auto streams = serde::detail::projectStreams(
-        buffer.data(), buffer.data() + buffer.size(), version, selected);
+  std::vector<uint32_t> selected = {0, 1, 2};
+  auto streams = serde::detail::projectStreams(
+      buffer.data(),
+      buffer.data() + buffer.size(),
+      SerializationVersion::kCompact,
+      selected,
+      pool_.get());
 
-    ASSERT_EQ(streams.size(), 1);
-    EXPECT_EQ(streams[0].index, 0);
-    EXPECT_EQ(streams[0].data, "ccc");
-  }
+  // Offset 1 not in input, so only 2 non-empty streams returned.
+  ASSERT_EQ(streams.size(), 2);
+  EXPECT_EQ(streams[0].index, 0);
+  EXPECT_EQ(streams[0].data, "zero");
+  EXPECT_EQ(streams[1].index, 2);
+  EXPECT_EQ(streams[1].data, "two");
+}
+
+TEST_F(ProjectStreamsTest, denseEmpty) {
+  auto buffer = buildDenseBuffer({});
+
+  std::vector<uint32_t> selected = {0, 1};
+  auto streams = serde::detail::projectStreams(
+      buffer.data(),
+      buffer.data() + buffer.size(),
+      SerializationVersion::kCompact,
+      selected,
+      pool_.get());
+  EXPECT_TRUE(streams.empty());
+}
+
+TEST_F(ProjectStreamsTest, denseSelectFirstAndLast) {
+  auto buffer = buildDenseBuffer({{0, "zero"}, {1, "one"}, {2, "two"}});
+
+  std::vector<uint32_t> selected = {0, 2};
+  auto streams = serde::detail::projectStreams(
+      buffer.data(),
+      buffer.data() + buffer.size(),
+      SerializationVersion::kCompact,
+      selected,
+      pool_.get());
+
+  ASSERT_EQ(streams.size(), 2);
+  EXPECT_EQ(streams[0].index, 0);
+  EXPECT_EQ(streams[0].data, "zero");
+  EXPECT_EQ(streams[1].index, 1);
+  EXPECT_EQ(streams[1].data, "two");
 }
 
 TEST_F(ProjectStreamsTest, denseSkipsEmptyStreams) {
-  auto buffer = buildDenseBuffer({"aaa", "", "ccc"});
+  auto buffer = buildDenseBuffer({{0, "aaa"}, {1, ""}, {2, "ccc"}});
 
-  for (auto version :
-       {SerializationVersion::kDense, SerializationVersion::kDenseEncoded}) {
-    SCOPED_TRACE(static_cast<int>(version));
-    std::vector<uint32_t> selected = {0, 1, 2};
-    auto streams = serde::detail::projectStreams(
-        buffer.data(), buffer.data() + buffer.size(), version, selected);
+  std::vector<uint32_t> selected = {0, 1, 2};
+  auto streams = serde::detail::projectStreams(
+      buffer.data(),
+      buffer.data() + buffer.size(),
+      SerializationVersion::kCompact,
+      selected,
+      pool_.get());
 
-    // Empty stream at index 1 is skipped.
-    ASSERT_EQ(streams.size(), 2);
-    EXPECT_EQ(streams[0].index, 0);
-    EXPECT_EQ(streams[0].data, "aaa");
-    EXPECT_EQ(streams[1].index, 2);
-    EXPECT_EQ(streams[1].data, "ccc");
-  }
-}
-
-TEST_F(ProjectStreamsTest, denseAllEmpty) {
-  auto buffer = buildDenseBuffer({"", "", ""});
-
-  for (auto version :
-       {SerializationVersion::kDense, SerializationVersion::kDenseEncoded}) {
-    SCOPED_TRACE(static_cast<int>(version));
-    std::vector<uint32_t> selected = {0, 1, 2};
-    auto streams = serde::detail::projectStreams(
-        buffer.data(), buffer.data() + buffer.size(), version, selected);
-    EXPECT_TRUE(streams.empty());
-  }
-}
-
-TEST_F(ProjectStreamsTest, sparseSelectAll) {
-  auto buffer = buildSparseBuffer({{0, "aaa"}, {1, "bbb"}, {2, "ccc"}});
-
-  for (auto version :
-       {SerializationVersion::kSparse, SerializationVersion::kSparseEncoded}) {
-    SCOPED_TRACE(static_cast<int>(version));
-    std::vector<uint32_t> selected = {0, 1, 2};
-    auto streams = serde::detail::projectStreams(
-        buffer.data(), buffer.data() + buffer.size(), version, selected);
-
-    ASSERT_EQ(streams.size(), 3);
-    EXPECT_EQ(streams[0].index, 0);
-    EXPECT_EQ(streams[0].data, "aaa");
-    EXPECT_EQ(streams[1].index, 1);
-    EXPECT_EQ(streams[1].data, "bbb");
-    EXPECT_EQ(streams[2].index, 2);
-    EXPECT_EQ(streams[2].data, "ccc");
-  }
-}
-
-TEST_F(ProjectStreamsTest, sparseSelectSubset) {
-  auto buffer = buildSparseBuffer(
-      {{0, "aaa"}, {1, "bbb"}, {2, "ccc"}, {3, "ddd"}, {4, "eee"}});
-
-  for (auto version :
-       {SerializationVersion::kSparse, SerializationVersion::kSparseEncoded}) {
-    SCOPED_TRACE(static_cast<int>(version));
-    std::vector<uint32_t> selected = {1, 3};
-    auto streams = serde::detail::projectStreams(
-        buffer.data(), buffer.data() + buffer.size(), version, selected);
-
-    ASSERT_EQ(streams.size(), 2);
-    EXPECT_EQ(streams[0].index, 0);
-    EXPECT_EQ(streams[0].data, "bbb");
-    EXPECT_EQ(streams[1].index, 1);
-    EXPECT_EQ(streams[1].data, "ddd");
-  }
-}
-
-TEST_F(ProjectStreamsTest, sparseWithGaps) {
-  // Input has gaps (offsets 0, 2, 5). Select 0 and 5.
-  auto buffer = buildSparseBuffer({{0, "zero"}, {2, "two"}, {5, "five"}});
-
-  for (auto version :
-       {SerializationVersion::kSparse, SerializationVersion::kSparseEncoded}) {
-    SCOPED_TRACE(static_cast<int>(version));
-    std::vector<uint32_t> selected = {0, 5};
-    auto streams = serde::detail::projectStreams(
-        buffer.data(), buffer.data() + buffer.size(), version, selected);
-
-    ASSERT_EQ(streams.size(), 2);
-    EXPECT_EQ(streams[0].index, 0);
-    EXPECT_EQ(streams[0].data, "zero");
-    EXPECT_EQ(streams[1].index, 1);
-    EXPECT_EQ(streams[1].data, "five");
-  }
-}
-
-TEST_F(ProjectStreamsTest, sparseSelectedNotInInput) {
-  // Input has offsets {0, 2}. Select {0, 1, 2} — offset 1 is missing.
-  auto buffer = buildSparseBuffer({{0, "zero"}, {2, "two"}});
-
-  for (auto version :
-       {SerializationVersion::kSparse, SerializationVersion::kSparseEncoded}) {
-    SCOPED_TRACE(static_cast<int>(version));
-    std::vector<uint32_t> selected = {0, 1, 2};
-    auto streams = serde::detail::projectStreams(
-        buffer.data(), buffer.data() + buffer.size(), version, selected);
-
-    // Offset 1 not in input, so only 2 non-empty streams returned.
-    ASSERT_EQ(streams.size(), 2);
-    EXPECT_EQ(streams[0].index, 0);
-    EXPECT_EQ(streams[0].data, "zero");
-    EXPECT_EQ(streams[1].index, 2);
-    EXPECT_EQ(streams[1].data, "two");
-  }
-}
-
-TEST_F(ProjectStreamsTest, sparseEmpty) {
-  auto buffer = buildSparseBuffer({});
-
-  for (auto version :
-       {SerializationVersion::kSparse, SerializationVersion::kSparseEncoded}) {
-    SCOPED_TRACE(static_cast<int>(version));
-    std::vector<uint32_t> selected = {0, 1};
-    auto streams = serde::detail::projectStreams(
-        buffer.data(), buffer.data() + buffer.size(), version, selected);
-    EXPECT_TRUE(streams.empty());
-  }
-}
-
-TEST_F(ProjectStreamsTest, sparseOutOfOrder) {
-  // Sparse offsets written out of order: {2, 0, 1}.
-  auto buffer = buildSparseBuffer({{2, "two"}, {0, "zero"}, {1, "one"}});
-
-  for (auto version :
-       {SerializationVersion::kSparse, SerializationVersion::kSparseEncoded}) {
-    SCOPED_TRACE(static_cast<int>(version));
-    std::vector<uint32_t> selected = {0, 2};
-    auto streams = serde::detail::projectStreams(
-        buffer.data(), buffer.data() + buffer.size(), version, selected);
-
-    // Results sorted by output offset.
-    ASSERT_EQ(streams.size(), 2);
-    EXPECT_EQ(streams[0].index, 0);
-    EXPECT_EQ(streams[0].data, "zero");
-    EXPECT_EQ(streams[1].index, 1);
-    EXPECT_EQ(streams[1].data, "two");
-  }
-}
-
-TEST_F(ProjectStreamsTest, sparseSkipsEmptyStreams) {
-  auto buffer = buildSparseBuffer({{0, "aaa"}, {1, ""}, {2, "ccc"}});
-
-  for (auto version :
-       {SerializationVersion::kSparse, SerializationVersion::kSparseEncoded}) {
-    SCOPED_TRACE(static_cast<int>(version));
-    std::vector<uint32_t> selected = {0, 1, 2};
-    auto streams = serde::detail::projectStreams(
-        buffer.data(), buffer.data() + buffer.size(), version, selected);
-
-    // Empty stream at offset 1 is skipped.
-    ASSERT_EQ(streams.size(), 2);
-    EXPECT_EQ(streams[0].index, 0);
-    EXPECT_EQ(streams[0].data, "aaa");
-    EXPECT_EQ(streams[1].index, 2);
-    EXPECT_EQ(streams[1].data, "ccc");
-  }
+  // Empty stream at offset 1 is skipped.
+  ASSERT_EQ(streams.size(), 2);
+  EXPECT_EQ(streams[0].index, 0);
+  EXPECT_EQ(streams[0].data, "aaa");
+  EXPECT_EQ(streams[1].index, 2);
+  EXPECT_EQ(streams[1].data, "ccc");
 }


### PR DESCRIPTION
Summary:
CONTEXT: The serializer had four versions: kDense (v0), kDenseEncoded (v1),
kSparse (v2), and kSparseEncoded (v3). The naming was confusing —
kSparseEncoded actually used a dense sizes array, and kDenseEncoded was a
minor variant of kDense.

WHAT:
Rename and simplify to two versions:
- kLegacy (v0): Legacy format with simple zstd compression, inline u32 sizes.
  Wire: [version:1B][rowCount:u32][size_0:u32][data_0]...[size_N:u32][data_N]
- kCompact (v1): Compact format with nimble encoding and sizes trailer.
  Wire: [version:1B][rowCount:varint][data_0]...[data_N][encoded_sizes][sizesSize:u32]

Remove kDenseEncoded and kSparse entirely. Values 2-3 are reserved.

Key changes:
- Rename enum values: kDense(v0)->kLegacy, kSparseEncoded(v3)->kCompact(v1).
  Remove kDenseEncoded(v1) and kSparse(v2).
- Move encoded sizes from header placeholder to trailer: the sizesSize u32 is
  now appended at the very end of the buffer, eliminating the need to seek back
  and fill a placeholder in the header.
- writeHeader() returns void (no placeholder offset), writeTrailer() appends
  [encoded_sizes][sizesSize:u32] at the end.
- readEncodedSizesLength() reads sizesSize from last 4 bytes of buffer.
- writeStream/readStream/skipStream use template<bool useVarint> — true for
  kCompact, false for kLegacy.
- decodeStreamSizes() takes pool as last param, as pointer.
- writeTrailer() takes pool as pointer.
- writeStream() extends buffer once instead of twice.
- StreamDataWriter tracks maxStreamOffset_ to avoid scanning streamOffsets_ in
  close().
- Projector enforces output version must be kCompact (constructor check).
  Removed kLegacy output path from project().
- Simplify format helpers: remove isSparseFormat(), isEncodedFormat(),
  denseFormat(), sparseFormat(). enableEncoding() is the single check.
- Update downstream callers: NimbleThrift.h, rexdb benchmarks.

Reviewed By: srsuryadev

Differential Revision: D95171089


