### PR TITLE
perf: Reduce Thrift+Nimble decoding CPU time by 32% by reusing ZSTD_DCtx across streams in Nimble deserialization (#639)

### DIFF
--- a/dwio/nimble/serializer/Deserializer.cpp
+++ b/dwio/nimble/serializer/Deserializer.cpp
@@ -92,9 +92,11 @@ class DeserializerImpl : public Decoder {
       const Type* type,
       bool inMapStream,
       bool enableBufferPool,
-      velox::memory::MemoryPool* pool)
+      velox::memory::MemoryPool* pool,
+      ZSTD_DCtx* dctx)
       : type_{type},
         pool_{pool},
+        dctx_{dctx},
         inMapStream_{inMapStream},
         scalarKind_{getScalarKindForType(*type)},
         typeStorageWidth_{getTypeStorageWidth(*type)},
@@ -212,7 +214,7 @@ class DeserializerImpl : public Decoder {
         .bufferPool = bufferPool_.get(),
     };
     streamData_.emplace(
-        scalarKind_, segment.data, stringBuffers, pool_, options);
+        scalarKind_, segment.data, stringBuffers, pool_, options, dctx_);
     return *streamData_;
   }
 
@@ -537,6 +539,7 @@ class DeserializerImpl : public Decoder {
   // --- Const members (set at construction, never modified) ---
   const Type* const type_;
   velox::memory::MemoryPool* const pool_;
+  ZSTD_DCtx* const dctx_;
   // True for inMap streams (fills with 'false' when missing), false for nulls
   // streams (fills with 'true' when missing).
   const bool inMapStream_;
@@ -656,6 +659,17 @@ Deserializer::Deserializer(
     velox::memory::MemoryPool* pool,
     DeserializerOptions options)
     : schema_{std::move(schema)}, pool_{pool}, options_{std::move(options)} {
+  NIMBLE_USER_CHECK(
+      !(options_.shareZstdDecompressionContext &&
+        (options_.decodeExecutor != nullptr ||
+         options_.maxDecodeParallelism != 0)),
+      "shareZstdDecompressionContext is mutually exclusive with parallel "
+      "decoding (decodeExecutor and maxDecodeParallelism); a single "
+      "ZSTD_DCtx is not safe to use concurrently");
+  if (options_.shareZstdDecompressionContext) {
+    dctx_.reset(ZSTD_createDCtx());
+  }
+
   const auto params = createFieldReaderParams();
 
   std::shared_ptr<const velox::dwio::common::TypeWithId> schemaWithId =
@@ -693,7 +707,8 @@ void Deserializer::createDeserializersForType(
           &type,
           /*inMapStream=*/false,
           options_.enableBufferPool,
-          pool_);
+          pool_,
+          dctx_.get());
   // FlatMap is only supported at depth 1 (top-level columns). FlatMap keys can
   // vary across batches, causing gaps in nulls/inMap streams. Gap detection is
   // enabled in DeserializerImpl whenever type->isFlatMap().
@@ -707,7 +722,8 @@ void Deserializer::createDeserializersForType(
           &type,
           /*inMapStream=*/true,
           options_.enableBufferPool,
-          pool_);
+          pool_,
+          dctx_.get());
       inMapChildTypes_[inMapOffset] = flatMap.childAt(i).get();
     }
   }
@@ -732,7 +748,7 @@ void Deserializer::deserialize(
   // Iterate batches and add stream data with row offsets. Streams missing from
   // a batch will have gaps that are filled later during reading.
   uint32_t rowOffset{0};
-  serde::StreamDataReader reader{pool_, options_};
+  serde::StreamDataReader reader{pool_, options_, dctx_.get()};
   for (auto sv : data) {
     const auto batchRows = reader.initialize(sv);
     const auto version = reader.version();

--- a/dwio/nimble/serializer/Deserializer.h
+++ b/dwio/nimble/serializer/Deserializer.h
@@ -15,14 +15,14 @@
  */
 #pragma once
 
+#include <zstd.h>
+
 #include "dwio/nimble/serializer/Options.h"
 #include "dwio/nimble/velox/FieldReader.h"
 #include "folly/container/F14Map.h"
-#include "velox/common/memory/Memory.h"
 #include "velox/vector/BaseVector.h"
 
 namespace facebook::nimble {
-
 class Deserializer {
  public:
   using Options = DeserializerOptions;
@@ -43,6 +43,12 @@ class Deserializer {
       velox::VectorPtr& vector) const;
 
  private:
+  struct ZstdDCtxDeleter {
+    void operator()(ZSTD_DCtx* ctx) const {
+      ZSTD_freeDCtx(ctx);
+    }
+  };
+
   // Creates deserializers for a type and its FlatMap inMap streams.
   void createDeserializersForType(const Type& type, uint32_t depth);
 
@@ -81,6 +87,9 @@ class Deserializer {
   // Offsets that were set in inMapPresentOffsets_ this batch (for efficient
   // reset).
   mutable std::vector<uint32_t> inMapPresentOffsetsList_;
+
+  // Created only when options.shareZstdDecompressionContext is true.
+  mutable std::unique_ptr<ZSTD_DCtx, ZstdDCtxDeleter> dctx_;
 };
 
 } // namespace facebook::nimble

--- a/dwio/nimble/serializer/DeserializerImpl.cpp
+++ b/dwio/nimble/serializer/DeserializerImpl.cpp
@@ -16,8 +16,6 @@
 
 #include "dwio/nimble/serializer/DeserializerImpl.h"
 
-#include <zstd.h>
-
 #include "dwio/nimble/common/ChunkHeader.h"
 #include "dwio/nimble/common/EncodingPrimitives.h"
 #include "dwio/nimble/common/Exceptions.h"
@@ -33,9 +31,11 @@ StreamData::StreamData(
     std::string_view data,
     std::vector<velox::BufferPtr>& stringBuffers,
     velox::memory::MemoryPool* pool,
-    const Options& options)
+    const Options& options,
+    ZSTD_DCtx* dctx)
     : kind_{kind},
       pool_{pool},
+      dctx_{dctx},
       encodingEnabled_{nonLegacyFormat(options.version)},
       useVarintRowCount_{!isTabletRawFormat(options.version)},
       bufferPool_{options.bufferPool},
@@ -111,8 +111,17 @@ void StreamData::decompress() {
               decompressedSize != ZSTD_CONTENTSIZE_UNKNOWN,
           "Error determining decompressed size");
       decompressionBuffer_.resize(decompressedSize);
-      const auto ret = ZSTD_decompress(
-          decompressionBuffer_.data(), decompressedSize, pos_, compressedSize);
+      const auto ret = dctx_ ? ZSTD_decompressDCtx(
+                                   dctx_,
+                                   decompressionBuffer_.data(),
+                                   decompressedSize,
+                                   pos_,
+                                   compressedSize)
+                             : ZSTD_decompress(
+                                   decompressionBuffer_.data(),
+                                   decompressedSize,
+                                   pos_,
+                                   compressedSize);
       NIMBLE_CHECK(!ZSTD_isError(ret), "Error decompressing data");
       pos_ = decompressionBuffer_.data();
       end_ = pos_ + decompressionBuffer_.size();
@@ -202,8 +211,12 @@ uint32_t StreamData::decode(
 
 StreamDataReader::StreamDataReader(
     velox::memory::MemoryPool* pool,
-    const DeserializerOptions& options)
-    : options_{options}, pool_{pool}, chunkStrippingBuffer_{pool_} {
+    const DeserializerOptions& options,
+    ZSTD_DCtx* dctx)
+    : options_{options},
+      pool_{pool},
+      dctx_{dctx},
+      chunkStrippingBuffer_{pool_} {
   NIMBLE_CHECK_NOT_NULL(pool_);
 }
 
@@ -346,11 +359,17 @@ void StreamDataReader::appendChunkData(
           "Error determining decompressed size");
       const auto offset = chunkStrippingBuffer_.size();
       chunkStrippingBuffer_.resize(offset + decompressedSize);
-      const auto ret = ZSTD_decompress(
-          chunkStrippingBuffer_.data() + offset,
-          decompressedSize,
-          data,
-          length);
+      const auto ret = dctx_ ? ZSTD_decompressDCtx(
+                                   dctx_,
+                                   chunkStrippingBuffer_.data() + offset,
+                                   decompressedSize,
+                                   data,
+                                   length)
+                             : ZSTD_decompress(
+                                   chunkStrippingBuffer_.data() + offset,
+                                   decompressedSize,
+                                   data,
+                                   length);
       NIMBLE_CHECK(!ZSTD_isError(ret), "Error decompressing chunk data");
       break;
     }

--- a/dwio/nimble/serializer/DeserializerImpl.h
+++ b/dwio/nimble/serializer/DeserializerImpl.h
@@ -19,6 +19,8 @@
 #include <functional>
 #include <optional>
 
+#include <zstd.h>
+
 #include "dwio/nimble/common/Vector.h"
 #include "dwio/nimble/encodings/Encoding.h"
 #include "dwio/nimble/serializer/Options.h"
@@ -63,12 +65,16 @@ class StreamData {
   /// @param stringBuffers External vector where string buffers from encoding
   ///        are stored. The caller must keep the vector alive while
   ///        string_views from this StreamData are in use.
+  /// @param dctx Optional reusable ZSTD decompression context. When non-null,
+  ///        ZSTD_decompressDCtx is used instead of ZSTD_decompress, avoiding
+  ///        per-call allocation of a ~100-200KB DCtx.
   StreamData(
       ScalarKind kind,
       std::string_view data,
       std::vector<velox::BufferPtr>& stringBuffers,
       velox::memory::MemoryPool* pool,
-      const Options& options);
+      const Options& options,
+      ZSTD_DCtx* dctx = nullptr);
 
   uint32_t copyTo(char* output, uint32_t bufferSize);
 
@@ -127,6 +133,9 @@ class StreamData {
 
   const ScalarKind kind_{ScalarKind::Undefined};
   velox::memory::MemoryPool* const pool_{nullptr};
+  // Optional reusable ZSTD decompression context. Non-owning; caller manages
+  // lifetime. When non-null, avoids per-call ZSTD_DCtx allocation (~100-200KB).
+  ZSTD_DCtx* const dctx_{nullptr};
   // Whether nimble encoding is enabled. Non-const to allow reset() to change.
   bool encodingEnabled_{false};
   // Whether encoding headers use varint row counts (true for kCompact/
@@ -163,7 +172,8 @@ class StreamDataReader {
  public:
   StreamDataReader(
       velox::memory::MemoryPool* pool,
-      const DeserializerOptions& options);
+      const DeserializerOptions& options,
+      ZSTD_DCtx* dctx = nullptr);
 
   /// Returns number of rows serialized.
   /// Validates that the version in serialized data matches options.
@@ -215,6 +225,7 @@ class StreamDataReader {
 
   const DeserializerOptions& options_;
   velox::memory::MemoryPool* const pool_;
+  ZSTD_DCtx* const dctx_{nullptr};
 
   // Serialization version detected from data. If the data has a version
   // header, this is read from the first byte; otherwise defaults to kLegacy.

--- a/dwio/nimble/serializer/Options.h
+++ b/dwio/nimble/serializer/Options.h
@@ -236,6 +236,13 @@ struct DeserializerOptions {
   /// Minimum number of child streams per parallel decode task. Ensures each
   /// coroutine task has enough work to amortize threading overhead.
   uint32_t minStreamsPerDecodeUnit{1};
+
+  /// When true, the Deserializer creates a single ZSTD_DCtx and shares it
+  /// across all StreamData objects to avoid per-call allocation of a
+  /// ~100-200KB DCtx by ZSTD_decompress(). Mutually exclusive with parallel
+  /// decoding (decodeExecutor != nullptr or maxDecodeParallelism != 0),
+  /// because a single ZSTD_DCtx is not safe to use concurrently.
+  bool shareZstdDecompressionContext{false};
 };
 
 } // namespace facebook::nimble

--- a/dwio/nimble/serializer/tests/OptionsTest.cpp
+++ b/dwio/nimble/serializer/tests/OptionsTest.cpp
@@ -113,6 +113,9 @@ TEST(OptionsTest, deserializerOptionsDefaults) {
   DeserializerOptions options{};
 
   EXPECT_FALSE(options.hasHeader);
+  EXPECT_FALSE(options.shareZstdDecompressionContext);
+  EXPECT_EQ(options.decodeExecutor, nullptr);
+  EXPECT_EQ(options.maxDecodeParallelism, 0u);
 }
 
 TEST(OptionsTest, deserializerOptionsWithVersion) {

--- a/dwio/nimble/serializer/tests/SerializationTest.cpp
+++ b/dwio/nimble/serializer/tests/SerializationTest.cpp
@@ -2989,6 +2989,110 @@ TEST_F(SerializationTest, tabletRawDeserialization) {
   }
 }
 
+// Verifies that the Deserializer constructed with
+// shareZstdDecompressionContext=true successfully round-trips a kTabletRaw
+// stream containing zstd-compressed chunks. Exercises the shared ZSTD_DCtx
+// path through StreamDataReader and StreamData.
+TEST_F(SerializationTest, shareZstdDecompressionContextRoundTrip) {
+  auto rowType = velox::ROW(
+      {{"col_a", velox::INTEGER()},
+       {"col_b", velox::BIGINT()},
+       {"col_c", velox::VARCHAR()}});
+
+  const int numRows = 100;
+  velox::VectorFuzzer fuzzer(
+      {.vectorSize = static_cast<size_t>(numRows),
+       .nullRatio = 0,
+       .stringLength = 20,
+       .stringVariableLength = true},
+      pool_.get());
+  auto input = fuzzer.fuzzInputRow(rowType);
+
+  auto tabletRaw =
+      serializeTabletRaw(rowType, {input}, /*enableChunking=*/true);
+
+  nimble::Deserializer deserializer(
+      tabletRaw.schema,
+      pool_.get(),
+      DeserializerOptions{
+          .hasHeader = true,
+          .shareZstdDecompressionContext = true,
+      });
+
+  velox::VectorPtr deserialized;
+  for (const auto& assembled : tabletRaw.serialized) {
+    velox::VectorPtr stripeOutput;
+    deserializer.deserialize(std::string_view(assembled), stripeOutput);
+    ASSERT_NE(stripeOutput, nullptr);
+
+    if (deserialized == nullptr) {
+      deserialized = stripeOutput;
+    } else {
+      auto oldSize = deserialized->size();
+      deserialized->resize(oldSize + stripeOutput->size());
+      deserialized->copy(stripeOutput.get(), oldSize, 0, stripeOutput->size());
+    }
+  }
+
+  ASSERT_NE(deserialized, nullptr);
+  ASSERT_EQ(deserialized->size(), numRows);
+
+  for (velox::vector_size_t i = 0; i < numRows; ++i) {
+    ASSERT_TRUE(input->equalValueAt(deserialized.get(), i, i))
+        << "Mismatch at row " << i << "\nExpected: " << input->toString(i)
+        << "\nActual: " << deserialized->toString(i);
+  }
+}
+
+// shareZstdDecompressionContext is incompatible with parallel decoding
+// because a single ZSTD_DCtx is not safe to use concurrently. The
+// Deserializer constructor must reject the combination.
+TEST_F(SerializationTest, shareZstdDecompressionContextRejectsDecodeExecutor) {
+  auto rowType = velox::ROW({{"col_a", velox::INTEGER()}});
+  auto tabletRaw = serializeTabletRaw(
+      rowType,
+      {velox::VectorFuzzer({.vectorSize = 4}, pool_.get())
+           .fuzzInputRow(rowType)},
+      /*enableChunking=*/true);
+
+  folly::CPUThreadPoolExecutor executor(1);
+  NIMBLE_ASSERT_USER_THROW(
+      nimble::Deserializer(
+          tabletRaw.schema,
+          pool_.get(),
+          DeserializerOptions{
+              .hasHeader = true,
+              .decodeExecutor = &executor,
+              .maxDecodeParallelism = 2,
+              .shareZstdDecompressionContext = true,
+          }),
+      "shareZstdDecompressionContext is mutually exclusive");
+}
+
+TEST_F(
+    SerializationTest,
+    shareZstdDecompressionContextRejectsMaxDecodeParallelism) {
+  auto rowType = velox::ROW({{"col_a", velox::INTEGER()}});
+  auto tabletRaw = serializeTabletRaw(
+      rowType,
+      {velox::VectorFuzzer({.vectorSize = 4}, pool_.get())
+           .fuzzInputRow(rowType)},
+      /*enableChunking=*/true);
+
+  // decodeExecutor is null but maxDecodeParallelism alone still triggers
+  // rejection.
+  NIMBLE_ASSERT_USER_THROW(
+      nimble::Deserializer(
+          tabletRaw.schema,
+          pool_.get(),
+          DeserializerOptions{
+              .hasHeader = true,
+              .maxDecodeParallelism = 2,
+              .shareZstdDecompressionContext = true,
+          }),
+      "shareZstdDecompressionContext is mutually exclusive");
+}
+
 TEST_P(SerializationTest, flatMapDeserializeWithFlatMapSchema) {
   // Verifies that FlatMap-encoded data round-trips correctly when deserialized
   // with the FlatMap schema from the serializer (no projection).

--- a/dwio/nimble/serializer/tests/SerializerImplTest.cpp
+++ b/dwio/nimble/serializer/tests/SerializerImplTest.cpp
@@ -1604,3 +1604,155 @@ TEST_F(TabletRawChunkStripTest, largePayloadMultipleChunks) {
   ASSERT_EQ(result.size(), 1);
   EXPECT_EQ(result[0].second, payload);
 }
+
+// Tests for ZSTD_DCtx reuse in StreamData and StreamDataReader.
+// Inherits from TabletRawChunkStripTest for shared helpers
+// (buildCompressedChunk, pool_, etc.).
+
+class ZstdDCtxReuseTest : public TabletRawChunkStripTest {
+ protected:
+  void SetUp() override {
+    TabletRawChunkStripTest::SetUp();
+    dctx_.reset(ZSTD_createDCtx());
+  }
+
+  // Build legacy-format compressed stream data for a non-string scalar:
+  // [CompressionType::Zstd (1B)][ZSTD-compressed payload]
+  static std::string buildLegacyCompressedData(std::string_view payload) {
+    std::string result;
+    result.push_back(static_cast<char>(CompressionType::Zstd));
+    const auto maxSize = ZSTD_compressBound(payload.size());
+    const auto offset = result.size();
+    result.resize(offset + maxSize);
+    const auto compressedSize = ZSTD_compress(
+        result.data() + offset, maxSize, payload.data(), payload.size(), 1);
+    NIMBLE_CHECK(!ZSTD_isError(compressedSize));
+    result.resize(offset + compressedSize);
+    return result;
+  }
+
+  // Like TabletRawChunkStripTest::deserializeTabletRaw, but passes
+  // the fixture's shared dctx to StreamDataReader.
+  std::vector<std::pair<uint32_t, std::string>> deserializeTabletRawWithDCtx(
+      uint32_t rowCount,
+      const std::vector<std::pair<uint32_t, std::string>>& streams) {
+    uint32_t maxOffset = 0;
+    for (const auto& [offset, _] : streams) {
+      maxOffset = std::max(maxOffset, offset);
+    }
+    std::vector<uint32_t> sizes(streams.empty() ? 0 : maxOffset + 1, 0);
+    std::string streamData;
+    for (const auto& [offset, data] : streams) {
+      sizes[offset] = static_cast<uint32_t>(data.size());
+      streamData.append(data);
+    }
+
+    std::string buffer;
+    serde::detail::writeHeader(
+        buffer, SerializationVersion::kTabletRaw, rowCount);
+    buffer.append(streamData);
+    serde::detail::writeRawTrailer(sizes, EncodingType::Trivial, buffer);
+
+    DeserializerOptions options{.hasHeader = true};
+    StreamDataReader reader(pool_.get(), options, dctx_.get());
+    auto actualRows = reader.initialize(std::string_view(buffer));
+    EXPECT_EQ(actualRows, rowCount);
+
+    std::vector<std::pair<uint32_t, std::string>> result;
+    reader.iterateStreams([&](uint32_t offset, std::string_view data) {
+      result.emplace_back(offset, std::string(data));
+    });
+    return result;
+  }
+
+  struct DCtxDeleter {
+    void operator()(ZSTD_DCtx* ctx) const {
+      ZSTD_freeDCtx(ctx);
+    }
+  };
+
+  std::unique_ptr<ZSTD_DCtx, DCtxDeleter> dctx_;
+};
+
+TEST_F(ZstdDCtxReuseTest, streamDataLegacyZstdWithDCtx) {
+  const std::vector<int32_t> expected = {10, 20, 30, 40};
+  std::string_view payload(
+      reinterpret_cast<const char*>(expected.data()),
+      expected.size() * sizeof(int32_t));
+  auto compressed = buildLegacyCompressedData(payload);
+
+  std::vector<BufferPtr> stringBuffers;
+  serde::StreamData sd(
+      ScalarKind::Int32,
+      compressed,
+      stringBuffers,
+      pool_.get(),
+      serde::StreamData::Options{.version = SerializationVersion::kLegacy},
+      dctx_.get());
+
+  std::vector<int32_t> output(expected.size());
+  sd.copyTo(
+      reinterpret_cast<char*>(output.data()), output.size() * sizeof(int32_t));
+  EXPECT_EQ(output, expected);
+}
+
+TEST_F(ZstdDCtxReuseTest, streamDataDCtxReusedAcrossReset) {
+  const std::vector<int32_t> values1 = {1, 2, 3};
+  std::string_view payload1(
+      reinterpret_cast<const char*>(values1.data()),
+      values1.size() * sizeof(int32_t));
+  auto compressed1 = buildLegacyCompressedData(payload1);
+
+  const std::vector<int32_t> values2 = {100, 200};
+  std::string_view payload2(
+      reinterpret_cast<const char*>(values2.data()),
+      values2.size() * sizeof(int32_t));
+  auto compressed2 = buildLegacyCompressedData(payload2);
+
+  std::vector<BufferPtr> stringBuffers;
+  serde::StreamData sd(
+      ScalarKind::Int32,
+      compressed1,
+      stringBuffers,
+      pool_.get(),
+      serde::StreamData::Options{.version = SerializationVersion::kLegacy},
+      dctx_.get());
+
+  std::vector<int32_t> output1(values1.size());
+  sd.copyTo(
+      reinterpret_cast<char*>(output1.data()),
+      output1.size() * sizeof(int32_t));
+  EXPECT_EQ(output1, values1);
+
+  // Reset with new data; dctx is bound at construction and persists.
+  sd.reset(compressed2, SerializationVersion::kLegacy);
+
+  std::vector<int32_t> output2(values2.size());
+  sd.copyTo(
+      reinterpret_cast<char*>(output2.data()),
+      output2.size() * sizeof(int32_t));
+  EXPECT_EQ(output2, values2);
+}
+
+TEST_F(ZstdDCtxReuseTest, streamDataReaderCompressedChunkWithDCtx) {
+  std::string payload = "compressed data that should be zstd encoded for test";
+  auto chunk = buildCompressedChunk(payload);
+  auto result = deserializeTabletRawWithDCtx(10, {{0, chunk}});
+
+  ASSERT_EQ(result.size(), 1);
+  EXPECT_EQ(result[0].first, 0);
+  EXPECT_EQ(result[0].second, payload);
+}
+
+TEST_F(ZstdDCtxReuseTest, streamDataReaderDCtxReusedAcrossStreams) {
+  std::string payload1 = "first compressed stream payload data";
+  std::string payload2 = "second compressed stream payload data";
+  auto chunk1 = buildCompressedChunk(payload1);
+  auto chunk2 = buildCompressedChunk(payload2);
+
+  auto result = deserializeTabletRawWithDCtx(10, {{0, chunk1}, {1, chunk2}});
+
+  ASSERT_EQ(result.size(), 2);
+  EXPECT_EQ(result[0].second, payload1);
+  EXPECT_EQ(result[1].second, payload2);
+}


### PR DESCRIPTION
Summary:

ZSTD_decompress() (one-shot API) internally allocates and frees a
ZSTD_DCtx (~100-200KB) on every call. In the Nimble legacy
deserialization path, this happens once per stream per batch,
creating a hot alloc/free cycle through jemalloc's large extent
allocator.

This diff adds a persistent ZSTD_DCtx owned by nimble::Deserializer
and threads it through StreamDataReader and StreamData to use
ZSTD_decompressDCtx() instead. The change is backward-compatible:
all new parameters default to nullptr, falling back to the original
ZSTD_decompress() when no context is provided.

Reusing ZSTD_DCtx should be safe according to https://facebook.github.io/zstd/zstd_manual.html#Chapter9

# Benchmark results on aidn_v2
CPU time went from 40 CPU seconds to 27 CPU seconds.

Reviewed By: harsharastogi

Differential Revision: D99456594


