### PR TITLE
feat: Add maxBytes global limit to NimbleIndexProjector

### DIFF
--- a/dwio/nimble/index/tests/KeyChunkDecoderTest.cpp
+++ b/dwio/nimble/index/tests/KeyChunkDecoderTest.cpp
@@ -127,5 +127,66 @@ TEST_F(KeyChunkDecoderTest, singleEntry) {
   EXPECT_EQ(materialized[0], "only");
 }
 
+// Regression tests for the use-after-move bug fixed in D103765334. Before the
+// fix, decodeKeyChunk returned DecodedKeyChunk by value and its string
+// allocator lambda captured the local `result` by reference. After the move
+// out of the function, the lambda referenced a destroyed stack frame; calling
+// materialize() later wrote the allocated buffer into the dangling reference
+// (ASAN: stack-use-after-return), leaving the caller's stringBuffers empty.
+//
+// The fix changes the return type to std::shared_ptr<DecodedKeyChunk> and
+// has the lambda capture a raw pointer to the heap-allocated object. The
+// shared_ptr keeps the DecodedKeyChunk alive across moves and assignments,
+// so the lambda's pointer stays valid. These tests verify that materialize()
+// after a move or move-assignment correctly populates stringBuffers and
+// produces the right values.
+TEST_F(KeyChunkDecoderTest, materializeAfterMove) {
+  std::vector<std::string_view> keys = {"foo", "bar", "baz"};
+  auto chunkData = encodeChunk(keys);
+
+  std::shared_ptr<DecodedKeyChunk> moved;
+  {
+    auto decoded =
+        decodeKeyChunk(makeStream(chunkData), *leafPool_, dataBuffer_);
+    moved = std::move(decoded);
+  }
+
+  ASSERT_NE(moved->encoding, nullptr);
+
+  moved->encoding->reset();
+  std::vector<std::string_view> materialized(3);
+  moved->encoding->materialize(3, materialized.data());
+
+  EXPECT_FALSE(moved->stringBuffers.empty());
+
+  EXPECT_EQ(materialized[0], "foo");
+  EXPECT_EQ(materialized[1], "bar");
+  EXPECT_EQ(materialized[2], "baz");
+}
+
+// Verifies the lambda's pointer remains valid through move-assignment, which
+// destroys the previously-held DecodedKeyChunk before binding the new one.
+TEST_F(KeyChunkDecoderTest, materializeAfterMoveAssign) {
+  std::vector<std::string_view> keys1 = {"alpha", "beta"};
+  std::vector<std::string_view> keys2 = {"gamma", "delta", "epsilon"};
+  auto chunkData1 = encodeChunk(keys1);
+  auto chunkData2 = encodeChunk(keys2);
+
+  auto holder = decodeKeyChunk(makeStream(chunkData1), *leafPool_, dataBuffer_);
+  holder = decodeKeyChunk(makeStream(chunkData2), *leafPool_, dataBuffer_);
+
+  ASSERT_NE(holder->encoding, nullptr);
+  EXPECT_EQ(holder->encoding->rowCount(), 3);
+
+  holder->encoding->reset();
+  std::vector<std::string_view> materialized(3);
+  holder->encoding->materialize(3, materialized.data());
+
+  EXPECT_FALSE(holder->stringBuffers.empty());
+  EXPECT_EQ(materialized[0], "gamma");
+  EXPECT_EQ(materialized[1], "delta");
+  EXPECT_EQ(materialized[2], "epsilon");
+}
+
 } // namespace
 } // namespace facebook::nimble::index

--- a/dwio/nimble/velox/index/NimbleIndexProjector.cpp
+++ b/dwio/nimble/velox/index/NimbleIndexProjector.cpp
@@ -77,27 +77,15 @@ NimbleIndexProjector::NimbleIndexProjector(
 NimbleIndexProjector::Result NimbleIndexProjector::project(
     const Request& request,
     const Options& options) {
-  NIMBLE_CHECK_NULL(request_, "project() is not reentrant");
-  NIMBLE_CHECK_NULL(options_, "project() is not reentrant");
-  request_ = &request;
-  options_ = &options;
+  initRequest(request, options);
   SCOPE_EXIT {
-    request_ = nullptr;
-    options_ = nullptr;
-    rowsPerRequest_.clear();
-    stripeRowRanges_.clear();
-    stripeRangeMap_.clear();
+    clearRequest();
   };
-
-  NIMBLE_CHECK_GT(request_->keyBounds.size(), 0, "keyBounds must not be empty");
 
   lookupStripes();
 
-  numReadRows_ = 0;
-  const auto numRequests = request_->keyBounds.size();
-  rowsPerRequest_.assign(numRequests, 0);
   Result result;
-  result.responses.resize(numRequests);
+  result.responses.resize(numRequests_);
 
   for (uint32_t i = 0; i < stripeRangeMap_.numStripes; ++i) {
     const uint32_t stripeIndex = stripeRangeMap_.startStripe + i;
@@ -115,6 +103,29 @@ NimbleIndexProjector::Result NimbleIndexProjector::project(
   return result;
 }
 
+void NimbleIndexProjector::initRequest(
+    const Request& request,
+    const Options& options) {
+  NIMBLE_CHECK_NULL(request_, "project() is not reentrant");
+  NIMBLE_CHECK_NULL(options_, "project() is not reentrant");
+  NIMBLE_CHECK_GT(request.keyBounds.size(), 0, "keyBounds must not be empty");
+  request_ = &request;
+  options_ = &options;
+  numRequests_ = static_cast<uint32_t>(request.keyBounds.size());
+  numReadRows_ = 0;
+  numReadBytes_ = 0;
+  rowsPerRequest_.assign(numRequests_, 0);
+}
+
+void NimbleIndexProjector::clearRequest() {
+  request_ = nullptr;
+  options_ = nullptr;
+  numRequests_ = 0;
+  rowsPerRequest_.clear();
+  stripeRowRanges_.clear();
+  stripeRangeMap_.clear();
+}
+
 void NimbleIndexProjector::lookupStripes() {
   velox::CpuWallTimer timer(stats_.lookupTiming);
 
@@ -122,7 +133,6 @@ void NimbleIndexProjector::lookupStripes() {
       index::IndexLookup::LookupRequest::rangeScan(request_->keyBounds));
 
   // Find the stripe range across all requests.
-  const auto numRequests = request_->keyBounds.size();
   uint32_t minStripe = numStripes_;
   uint32_t maxStripe = 0;
 
@@ -137,11 +147,11 @@ void NimbleIndexProjector::lookupStripes() {
     }
   };
   std::vector<RequestStripeRange> requestRanges;
-  requestRanges.reserve(numRequests);
+  requestRanges.reserve(numRequests_);
 
   uint32_t numRowRanges = 0;
   const auto& tablet = readerBase_->tablet();
-  for (size_t requestIdx = 0; requestIdx < numRequests; ++requestIdx) {
+  for (size_t requestIdx = 0; requestIdx < numRequests_; ++requestIdx) {
     const auto rowRanges = result[requestIdx];
     if (rowRanges.empty()) {
       requestRanges.emplace_back(RequestStripeRange{0, 0, {}});
@@ -192,7 +202,7 @@ void NimbleIndexProjector::lookupStripes() {
   // Fill entries using a copy of offsets as write cursors.
   stripeRangeMap_.rowRanges.resize(numRowRanges);
   auto writeCursors = stripeRangeMap_.stripeOffsets;
-  for (size_t requestIdx = 0; requestIdx < numRequests; ++requestIdx) {
+  for (size_t requestIdx = 0; requestIdx < numRequests_; ++requestIdx) {
     const auto& requestRange = requestRanges[requestIdx];
     if (requestRange.empty()) {
       continue;
@@ -344,9 +354,10 @@ bool NimbleIndexProjector::buildStripeResult(
     rowsPerRequest_[request.requestIndex] += rowRange.numRows();
   }
 
+  numReadBytes_ += chunk.data.computeChainDataLength();
   result.chunks.emplace_back(std::move(chunk));
 
-  return !(options_->maxRows > 0 && numReadRows_ >= options_->maxRows);
+  return !checkOutputLimit();
 }
 
 void NimbleIndexProjector::setResumeKeys(

--- a/dwio/nimble/velox/index/NimbleIndexProjector.h
+++ b/dwio/nimble/velox/index/NimbleIndexProjector.h
@@ -74,6 +74,11 @@ class NimbleIndexProjector {
     /// stripe is still included (stripe-boundary soft limit). Processing
     /// stops after that stripe completes.
     uint64_t maxRows{0};
+    /// Soft limit on total serialized bytes across all requests. 0 means no
+    /// limit. Like maxRows, operates at stripe granularity: at least one
+    /// stripe is always included, then processing stops after the stripe
+    /// that exceeds the budget.
+    uint64_t maxBytes{0};
     /// Hard per-request row limit. 0 means no limit. Each request's row
     /// range is clipped so that it never exceeds this many rows total.
     /// No resume key is set — the request is considered fulfilled.
@@ -107,9 +112,9 @@ class NimbleIndexProjector {
     /// Slices into Result::chunks for this request. Empty for miss.
     std::vector<ChunkSlice> slices;
 
-    /// If the result was truncated by maxRows, the encoded resume key for
-    /// continuation. The caller constructs new key bounds using this as
-    /// lowerKey with their original upperKey. nullopt if complete or miss.
+    /// If the result was truncated by maxRows or maxBytes, the encoded resume
+    /// key for continuation. The caller constructs new key bounds using this
+    /// as lowerKey with their original upperKey. nullopt if complete or miss.
     std::optional<std::string> resumeKey;
   };
 
@@ -212,6 +217,20 @@ class NimbleIndexProjector {
     }
   };
 
+  // Initializes per-project() state: stores request/options pointers, sizes
+  // rowsPerRequest_, and resets running totals. Caches numRequests_.
+  void initRequest(const Request& request, const Options& options);
+
+  // Clears all per-project() state set by initRequest(). Invoked on scope
+  // exit so a subsequent project() call starts from a clean slate.
+  void clearRequest();
+
+  // Returns true if a global output limit (maxRows or maxBytes) has been hit.
+  bool checkOutputLimit() const {
+    return (options_->maxRows > 0 && numReadRows_ >= options_->maxRows) ||
+        (options_->maxBytes > 0 && numReadBytes_ >= options_->maxBytes);
+  }
+
   // Looks up all requests via the cluster index and maps them to stripes.
   // Populates stripeRangeMap_.
   void lookupStripes();
@@ -222,8 +241,8 @@ class NimbleIndexProjector {
 
   // Loads projected streams for the stripe, serializes them into kTabletRaw
   // format, and maps the result to per-request row ranges. Returns false if
-  // a global limit (maxRows) was hit, signaling the caller to stop and set
-  // resume keys.
+  // a global limit (maxRows or maxBytes) was hit, signaling the caller to
+  // stop and set resume keys.
   bool processStripe(
       uint32_t stripeIndex,
       std::span<const StripeRowRange> stripeRowRanges,
@@ -241,7 +260,8 @@ class NimbleIndexProjector {
 
   // Assigns the serialized chunk to per-request results based on row ranges.
   // Applies maxRowsPerRequest hard clipping and accumulates numReadRows_.
-  // Returns false if a global limit (maxRows) was hit after this stripe.
+  // Returns false if a global limit (maxRows or maxBytes) was hit after this
+  // stripe.
   bool buildStripeResult(
       uint32_t stripeIndex,
       std::span<const StripeRowRange> stripeRowRanges,
@@ -294,9 +314,15 @@ class NimbleIndexProjector {
   // Set during project() and cleared on return.
   const Request* request_{nullptr};
   const Options* options_{nullptr};
+  // Number of requests in the current project() call. Cached from
+  // request_->keyBounds.size() to avoid repeated pointer chases.
+  uint32_t numRequests_{0};
 
   // Running total of rows read across all requests for maxRows enforcement.
   uint64_t numReadRows_{0};
+  // Running total of serialized bytes across all stripes for maxBytes
+  // enforcement.
+  uint64_t numReadBytes_{0};
   // Accumulated rows per request for maxRowsPerRequest enforcement.
   std::vector<uint64_t> rowsPerRequest_;
   // Current stripe's row ranges after pruning saturated requests.

--- a/dwio/nimble/velox/index/tests/NimbleIndexProjectorTest.cpp
+++ b/dwio/nimble/velox/index/tests/NimbleIndexProjectorTest.cpp
@@ -1484,7 +1484,6 @@ TEST_P(NimbleIndexProjectorTest, maxRowsSingleRowStripes) {
 
 TEST_P(NimbleIndexProjectorTest, maxRowsPerRequestClipping) {
   auto rowType = ROW({"key", "value"}, {BIGINT(), INTEGER()});
-  // 10 stripes x 100 rows.
   writeResumeKeyTestData();
 
   std::vector<Subfield> subfields;
@@ -1565,6 +1564,194 @@ TEST_P(NimbleIndexProjectorTest, maxRowsPerRequestIndependentPruning) {
     }
     EXPECT_EQ(totalRows, 100);
     EXPECT_FALSE(response.resumeKey.has_value());
+  }
+}
+
+TEST_P(NimbleIndexProjectorTest, maxBytesTruncation) {
+  writeResumeKeyTestData();
+  auto rowType = ROW({"key", "value"}, {BIGINT(), INTEGER()});
+
+  std::vector<Subfield> subfields;
+  subfields.emplace_back("value");
+
+  // First, read one stripe without limits to learn the per-stripe byte size.
+  uint64_t bytesPerStripe;
+  {
+    auto projector = createProjector(subfields);
+    auto bounds = makeRangeLookup(rowType, {"key"}, 0, 100);
+    NimbleIndexProjector::Request request;
+    request.keyBounds = {bounds};
+    auto result = projector.project(request, {});
+    ASSERT_EQ(result.chunks.size(), 1);
+    bytesPerStripe = result.chunks[0].data.computeChainDataLength();
+    ASSERT_GT(bytesPerStripe, 0);
+  }
+
+  // Range [0, 500) spans 5 stripes. Set byte limit to allow ~2 stripes.
+  {
+    auto projector = createProjector(subfields);
+    auto bounds = makeRangeLookup(rowType, {"key"}, 0, 500);
+    NimbleIndexProjector::Request request;
+    request.keyBounds = {bounds};
+    NimbleIndexProjector::Options options;
+    options.maxBytes = bytesPerStripe * 2;
+
+    auto result = projector.project(request, options);
+    ASSERT_EQ(result.responses.size(), 1);
+    const auto& response = result.responses[0];
+
+    // Should be truncated with a resume key.
+    ASSERT_TRUE(response.resumeKey.has_value());
+
+    // Should have read exactly 2 stripes (byte budget consumed after 2).
+    EXPECT_EQ(projector.stats().numReadStripes, 2);
+    EXPECT_EQ(projector.stats().numReadRows, 200);
+  }
+}
+
+TEST_P(NimbleIndexProjectorTest, maxBytesNoTruncation) {
+  writeResumeKeyTestData();
+  auto rowType = ROW({"key", "value"}, {BIGINT(), INTEGER()});
+
+  std::vector<Subfield> subfields;
+  subfields.emplace_back("value");
+
+  // maxBytes=0 (unlimited) -> no truncation, no resume key.
+  {
+    auto projector = createProjector(subfields);
+    auto bounds = makeRangeLookup(rowType, {"key"}, 100, 300);
+    NimbleIndexProjector::Request request;
+    request.keyBounds = {bounds};
+    auto result = projector.project(request, {});
+    ASSERT_EQ(result.responses.size(), 1);
+    EXPECT_FALSE(result.responses[0].resumeKey.has_value());
+  }
+
+  // maxBytes larger than total data -> no truncation, no resume key.
+  {
+    auto projector = createProjector(subfields);
+    auto bounds = makeRangeLookup(rowType, {"key"}, 100, 300);
+    NimbleIndexProjector::Request request;
+    request.keyBounds = {bounds};
+    NimbleIndexProjector::Options options;
+    options.maxBytes = std::numeric_limits<uint64_t>::max();
+    auto result = projector.project(request, options);
+    ASSERT_EQ(result.responses.size(), 1);
+    EXPECT_FALSE(result.responses[0].resumeKey.has_value());
+  }
+}
+
+TEST_P(NimbleIndexProjectorTest, maxBytesPagination) {
+  writeResumeKeyTestData();
+  auto rowType = ROW({"key", "value"}, {BIGINT(), INTEGER()});
+
+  std::vector<Subfield> subfields;
+  subfields.emplace_back("value");
+
+  // Learn per-stripe byte size.
+  uint64_t bytesPerStripe;
+  {
+    auto projector = createProjector(subfields);
+    auto bounds = makeRangeLookup(rowType, {"key"}, 0, 100);
+    NimbleIndexProjector::Request request;
+    request.keyBounds = {bounds};
+    auto result = projector.project(request, {});
+    ASSERT_EQ(result.chunks.size(), 1);
+    bytesPerStripe = result.chunks[0].data.computeChainDataLength();
+  }
+
+  // Paginate through the full range using byte limits.
+  auto paginate =
+      [&](int64_t lowerKey, int64_t upperKey, uint64_t maxBytes) -> uint64_t {
+    auto currentBounds = makeRangeLookup(rowType, {"key"}, lowerKey, upperKey);
+    uint64_t totalReadRows = 0;
+    int iterations = 0;
+    const int maxIterations = 100;
+
+    while (iterations < maxIterations) {
+      ++iterations;
+      auto projector = createProjector(subfields);
+      NimbleIndexProjector::Request request;
+      request.keyBounds = {currentBounds};
+      NimbleIndexProjector::Options options;
+      options.maxBytes = maxBytes;
+
+      auto result = projector.project(request, options);
+      EXPECT_EQ(result.responses.size(), 1);
+      totalReadRows += projector.stats().numReadRows;
+
+      const auto& response = result.responses[0];
+      if (!response.resumeKey.has_value()) {
+        break;
+      }
+      currentBounds = velox::serializer::EncodedKeyBounds{
+          .lowerKey = response.resumeKey.value(),
+          .upperKey = currentBounds.upperKey};
+    }
+    EXPECT_LT(iterations, maxIterations);
+    return totalReadRows;
+  };
+
+  EXPECT_EQ(paginate(0, 1000, bytesPerStripe), 1000);
+  EXPECT_EQ(paginate(0, 1000, bytesPerStripe * 2), 1000);
+  EXPECT_EQ(paginate(0, 1000, bytesPerStripe * 3), 1000);
+  EXPECT_EQ(paginate(0, 1000, bytesPerStripe * 100), 1000);
+  EXPECT_EQ(paginate(150, 750, bytesPerStripe), 600);
+  EXPECT_EQ(paginate(150, 750, bytesPerStripe * 2), 600);
+}
+
+TEST_P(NimbleIndexProjectorTest, maxBytesAndMaxRowsInteraction) {
+  writeResumeKeyTestData();
+  auto rowType = ROW({"key", "value"}, {BIGINT(), INTEGER()});
+
+  std::vector<Subfield> subfields;
+  subfields.emplace_back("value");
+
+  // Learn per-stripe byte size.
+  uint64_t bytesPerStripe;
+  {
+    auto projector = createProjector(subfields);
+    auto bounds = makeRangeLookup(rowType, {"key"}, 0, 100);
+    NimbleIndexProjector::Request request;
+    request.keyBounds = {bounds};
+    auto result = projector.project(request, {});
+    ASSERT_EQ(result.chunks.size(), 1);
+    bytesPerStripe = result.chunks[0].data.computeChainDataLength();
+  }
+
+  // Range [0, 500) = 5 stripes, 500 rows.
+  auto bounds = makeRangeLookup(rowType, {"key"}, 0, 500);
+
+  // Case 1: Global row limit is tighter (50 rows < 3 stripes of bytes).
+  {
+    auto projector = createProjector(subfields);
+    NimbleIndexProjector::Request request;
+    request.keyBounds = {bounds};
+    NimbleIndexProjector::Options options;
+    options.maxRows = 50;
+    options.maxBytes = bytesPerStripe * 3;
+
+    auto result = projector.project(request, options);
+    ASSERT_EQ(result.responses.size(), 1);
+    ASSERT_TRUE(result.responses[0].resumeKey.has_value());
+    EXPECT_EQ(projector.stats().numReadStripes, 1);
+    EXPECT_EQ(projector.stats().numReadRows, 100);
+  }
+
+  // Case 2: Byte limit is tighter (1 stripe < 500 rows).
+  {
+    auto projector = createProjector(subfields);
+    NimbleIndexProjector::Request request;
+    request.keyBounds = {bounds};
+    NimbleIndexProjector::Options options;
+    options.maxRows = 500;
+    options.maxBytes = bytesPerStripe;
+
+    auto result = projector.project(request, options);
+    ASSERT_EQ(result.responses.size(), 1);
+    ASSERT_TRUE(result.responses[0].resumeKey.has_value());
+    EXPECT_EQ(projector.stats().numReadStripes, 1);
+    EXPECT_EQ(projector.stats().numReadRows, 100);
   }
 }
 
@@ -1777,6 +1964,106 @@ TEST_P(NimbleIndexProjectorTest, maxRowsMultiRequestMixedSatisfaction) {
   EXPECT_TRUE(result.responses[3].slices.empty());
   ASSERT_TRUE(result.responses[3].resumeKey.has_value());
   EXPECT_EQ(result.responses[3].resumeKey.value(), bounds3.lowerKey);
+}
+
+TEST_P(NimbleIndexProjectorTest, maxBytesAndMaxRowsPerRequestInteraction) {
+  writeResumeKeyTestData();
+  auto rowType = ROW({"key", "value"}, {BIGINT(), INTEGER()});
+
+  std::vector<Subfield> subfields;
+  subfields.emplace_back("value");
+
+  // Learn per-stripe byte size.
+  uint64_t bytesPerStripe;
+  {
+    auto projector = createProjector(subfields);
+    auto bounds = makeRangeLookup(rowType, {"key"}, 0, 100);
+    NimbleIndexProjector::Request request;
+    request.keyBounds = {bounds};
+    auto result = projector.project(request, {});
+    ASSERT_EQ(result.chunks.size(), 1);
+    bytesPerStripe = result.chunks[0].data.computeChainDataLength();
+  }
+
+  // maxRowsPerRequest clips to 150 rows (mid-stripe), maxBytes allows 5
+  // stripes. maxRowsPerRequest is tighter.
+  {
+    auto projector = createProjector(subfields);
+    auto bounds = makeRangeLookup(rowType, {"key"}, 0, 500);
+    NimbleIndexProjector::Request request;
+    request.keyBounds = {bounds};
+    NimbleIndexProjector::Options options;
+    options.maxRowsPerRequest = 150;
+    options.maxBytes = bytesPerStripe * 5;
+
+    auto result = projector.project(request, options);
+    ASSERT_EQ(result.responses.size(), 1);
+    EXPECT_FALSE(result.responses[0].resumeKey.has_value());
+    EXPECT_EQ(projector.stats().numReadRows, 150);
+  }
+
+  // maxBytes allows 1 stripe (100 rows), maxRowsPerRequest allows 300.
+  // maxBytes is tighter — sets resume key.
+  {
+    auto projector = createProjector(subfields);
+    auto bounds = makeRangeLookup(rowType, {"key"}, 0, 500);
+    NimbleIndexProjector::Request request;
+    request.keyBounds = {bounds};
+    NimbleIndexProjector::Options options;
+    options.maxRowsPerRequest = 300;
+    options.maxBytes = bytesPerStripe;
+
+    auto result = projector.project(request, options);
+    ASSERT_EQ(result.responses.size(), 1);
+    EXPECT_TRUE(result.responses[0].resumeKey.has_value());
+    EXPECT_EQ(projector.stats().numReadStripes, 1);
+    EXPECT_EQ(projector.stats().numReadRows, 100);
+  }
+}
+
+TEST_P(NimbleIndexProjectorTest, maxBytesLargeScale) {
+  auto rowType = ROW({"key", "value"}, {BIGINT(), INTEGER()});
+  // 50 stripes x 200 rows = 10,000 rows.
+  writeResumeKeyTestData(/*rowsPerBatch=*/200, /*numBatches=*/50);
+
+  std::vector<Subfield> subfields;
+  subfields.emplace_back("value");
+
+  // Learn per-stripe byte size.
+  uint64_t bytesPerStripe;
+  {
+    auto projector = createProjector(subfields);
+    auto bounds = makeRangeLookup(rowType, {"key"}, 0, 200);
+    NimbleIndexProjector::Request request;
+    request.keyBounds = {bounds};
+    auto result = projector.project(request, {});
+    ASSERT_EQ(result.chunks.size(), 1);
+    bytesPerStripe = result.chunks[0].data.computeChainDataLength();
+  }
+
+  // Paginate all 10,000 rows with byte limit of ~3 stripes per page.
+  auto currentBounds = makeRangeLookup(rowType, {"key"}, 0, 10000);
+  uint64_t totalReadRows = 0;
+  int pages = 0;
+  while (pages < 100) {
+    ++pages;
+    auto projector = createProjector(subfields);
+    NimbleIndexProjector::Request request;
+    request.keyBounds = {currentBounds};
+    NimbleIndexProjector::Options options;
+    options.maxBytes = bytesPerStripe * 3;
+    auto result = projector.project(request, options);
+    EXPECT_EQ(result.responses.size(), 1);
+    totalReadRows += projector.stats().numReadRows;
+    if (!result.responses[0].resumeKey.has_value()) {
+      break;
+    }
+    currentBounds = velox::serializer::EncodedKeyBounds{
+        .lowerKey = result.responses[0].resumeKey.value(),
+        .upperKey = currentBounds.upperKey};
+  }
+  EXPECT_LT(pages, 100);
+  EXPECT_EQ(totalReadRows, 10000);
 }
 
 INSTANTIATE_TEST_CASE_P(


### PR DESCRIPTION
Summary:

Adds `maxBytes` to `NimbleIndexProjector::Options` — a global soft limit on total serialized bytes across all requests. Like `maxRows`, it operates at stripe granularity: at least one stripe is always included, then processing stops after the stripe that exceeds the byte budget. Sets resume keys on truncated requests for pagination.

When both `maxRows` and `maxBytes` are set, processing stops when either limit is hit. Both are checked in `buildStripeResult()` via a combined `limitHit` condition.

`maxBytes` measures the actual serialized chunk data held in `Result::chunks`, making it a direct proxy for memory usage.

Also adds regression tests for the `decodeKeyChunk` use-after-move fix (`stringBuffers` shared_ptr change): `materializeAfterMove` and `materializeAfterReassignment` verify that moved/reassigned `DecodedKeyChunk` objects correctly materialize string values.

Reviewed By: xiaoxmeng

Differential Revision: D99391142


