### PR TITLE
feat(hive): Add runtime metrics to index lookup join pipeline

### DIFF
--- a/dwio/nimble/index/ClusterIndexReader.cpp
+++ b/dwio/nimble/index/ClusterIndexReader.cpp
@@ -16,10 +16,13 @@
 
 #include "dwio/nimble/index/ClusterIndexReader.h"
 
+#include <chrono>
+
 #include "dwio/nimble/common/EncodingPrimitives.h"
 #include "dwio/nimble/common/Exceptions.h"
 #include "dwio/nimble/common/Types.h"
 #include "dwio/nimble/encodings/EncodingFactory.h"
+#include "velox/common/process/ProcessBase.h"
 
 namespace facebook::nimble::index {
 
@@ -49,6 +52,8 @@ std::unique_ptr<ClusterIndexReader> ClusterIndexReader::create(
 
 std::optional<uint32_t> ClusterIndexReader::seekAtOrAfter(
     std::string_view encodedKey) {
+  ++stats_.numSeeks;
+
   const auto chunkLocation = indexGroup_->lookupChunk(stripeIndex_, encodedKey);
   if (!chunkLocation.has_value()) {
     return std::nullopt;
@@ -65,7 +70,17 @@ std::optional<uint32_t> ClusterIndexReader::seekAtOrAfter(
 std::optional<uint32_t> ClusterIndexReader::seekAtOrAfterInChunk(
     uint32_t chunkOffset,
     std::string_view encodedKey) {
-  seekToChunk(chunkOffset);
+  // Phase 2: Seek to chunk (I/O + decode). Track both wall and CPU time.
+  {
+    auto wallStart = std::chrono::steady_clock::now();
+    auto cpuStart = velox::process::threadCpuNanos();
+    seekToChunk(chunkOffset);
+    stats_.chunkLoadCpuNanos += velox::process::threadCpuNanos() - cpuStart;
+    stats_.chunkLoadNanos +=
+        std::chrono::duration_cast<std::chrono::nanoseconds>(
+            std::chrono::steady_clock::now() - wallStart)
+            .count();
+  }
   NIMBLE_CHECK_NOT_NULL(encoding_);
   return encoding_->seekAtOrAfter(&encodedKey);
 }
@@ -94,6 +109,7 @@ bool ClusterIndexReader::ensureInput(int size) {
 
 void ClusterIndexReader::seekToChunk(uint32_t chunkOffset) {
   if ((chunkOffset_ == chunkOffset) && (encoding_ != nullptr)) {
+    ++stats_.chunkCacheHits;
     return;
   }
 

--- a/dwio/nimble/index/ClusterIndexReader.h
+++ b/dwio/nimble/index/ClusterIndexReader.h
@@ -16,6 +16,7 @@
 
 #pragma once
 
+#include <cstdint>
 #include <memory>
 #include <string_view>
 
@@ -24,6 +25,19 @@
 #include "velox/dwio/common/SeekableInputStream.h"
 
 namespace facebook::nimble::index {
+
+/// Accumulated timing stats from ClusterIndexReader::seekAtOrAfter() calls.
+struct ClusterIndexReaderStats {
+  /// Total wall time in nanoseconds for seekToChunk (chunk I/O + decode).
+  uint64_t chunkLoadNanos{0};
+  /// Total CPU time in nanoseconds for seekToChunk (chunk I/O + decode).
+  /// Wall - CPU = I/O wait time.
+  uint64_t chunkLoadCpuNanos{0};
+  /// Number of times seekToChunk found the chunk already loaded (cache hit).
+  uint64_t chunkCacheHits{0};
+  /// Total number of seekAtOrAfter calls.
+  uint64_t numSeeks{0};
+};
 
 /// Reader for cluster index keys within a stripe.
 ///
@@ -50,6 +64,11 @@ class ClusterIndexReader {
   /// Returns the row position if found, or std::nullopt if the key is beyond
   /// the range (i.e., greater than all stripe keys).
   std::optional<uint32_t> seekAtOrAfter(std::string_view encodedKey);
+
+  /// Returns accumulated timing stats from seekAtOrAfter calls.
+  const ClusterIndexReaderStats& stats() const {
+    return stats_;
+  }
 
  private:
   ClusterIndexReader(
@@ -93,6 +112,9 @@ class ClusterIndexReader {
   std::unique_ptr<nimble::Encoding> encoding_;
   // Buffers holding string data for the current encoding
   std::vector<velox::BufferPtr> stringBuffers_;
+
+  // Accumulated timing stats.
+  ClusterIndexReaderStats stats_;
 };
 
 } // namespace facebook::nimble::index

--- a/dwio/nimble/velox/selective/ChunkedDecoder.cpp
+++ b/dwio/nimble/velox/selective/ChunkedDecoder.cpp
@@ -16,12 +16,12 @@
 
 #include "dwio/nimble/velox/selective/ChunkedDecoder.h"
 
+#include <cstddef>
+
 #include "dwio/nimble/common/ChunkHeader.h"
 #include "dwio/nimble/common/Types.h"
 #include "dwio/nimble/encodings/EncodingFactory.h"
 #include "velox/common/testutil/TestValue.h"
-
-#include <cstddef>
 
 using facebook::velox::common::testutil::TestValue;
 
@@ -30,6 +30,8 @@ namespace facebook::nimble {
 using namespace facebook::velox;
 
 void ChunkedDecoder::loadNextChunk() {
+  ++ChunkedDecoderStats::threadLocal().numChunkLoads;
+
   auto ret = ensureInput(kChunkHeaderSize);
   NIMBLE_CHECK(ret, "Failed to read chunk header");
   const auto [length, compressionType] = readChunkHeader(inputData_);

--- a/dwio/nimble/velox/selective/ChunkedDecoder.h
+++ b/dwio/nimble/velox/selective/ChunkedDecoder.h
@@ -24,6 +24,21 @@
 
 namespace facebook::nimble {
 
+/// Thread-local counters for ChunkedDecoder activity.
+/// Reset and read by SelectiveNimbleIndexReader around columnReader_->next().
+struct ChunkedDecoderStats {
+  uint64_t numChunkLoads{0};
+
+  void reset() {
+    numChunkLoads = 0;
+  }
+
+  static ChunkedDecoderStats& threadLocal() {
+    thread_local ChunkedDecoderStats stats;
+    return stats;
+  }
+};
+
 class ChunkedDecoderTestHelper;
 
 class ChunkedDecoder {

--- a/dwio/nimble/velox/selective/SelectiveNimbleIndexReader.cpp
+++ b/dwio/nimble/velox/selective/SelectiveNimbleIndexReader.cpp
@@ -22,10 +22,12 @@
 #include "dwio/nimble/encodings/legacy/EncodingFactory.h"
 #include "dwio/nimble/index/ClusterIndexReader.h"
 #include "dwio/nimble/velox/SchemaUtils.h"
+#include "dwio/nimble/velox/selective/ChunkedDecoder.h"
 #include "dwio/nimble/velox/selective/ColumnReader.h"
 #include "dwio/nimble/velox/selective/ReaderBase.h"
 #include "dwio/nimble/velox/selective/RowSizeTracker.h"
 #include "velox/common/base/RuntimeMetrics.h"
+#include "velox/common/time/CpuWallTimer.h"
 #include "velox/serializers/KeyEncoder.h"
 
 namespace facebook::nimble {
@@ -449,6 +451,17 @@ void SelectiveNimbleIndexReader::prepareStripeReading(uint32_t stripeIndex) {
     return;
   }
 
+  // Track total row-range rows for selectivity analysis.
+  {
+    int64_t rowRangeRows = 0;
+    for (const auto& [_, range] : requestRanges) {
+      rowRangeRows += range.numRows();
+    }
+    addThreadLocalRuntimeStat(
+        dwio::common::IndexReader::kNumIndexMatchedRows,
+        velox::RuntimeCounter(rowRangeRows));
+  }
+
   buildStripeReadSegments(requestRanges);
 }
 
@@ -567,35 +580,53 @@ void SelectiveNimbleIndexReader::splitStripeRowRanges(
 void SelectiveNimbleIndexReader::loadStripeWithIndex(uint32_t stripeIndex) {
   addThreadLocalRuntimeStat(
       dwio::common::RowReader::kNumStripeLoads, velox::RuntimeCounter(1));
+  addThreadLocalRuntimeStat(
+      dwio::common::IndexReader::kNumIndexStripeTotalRows,
+      velox::RuntimeCounter(readerBase_->tablet().stripeRowCount(stripeIndex)));
 
-  streams_.setStripe(stripeIndex);
-  NimbleParams params(
-      *readerBase_->pool(),
-      columnReaderStatistics_,
-      readerBase_->nimbleSchema(),
-      streams_,
-      options_.trackRowSize() ? rowSizeTracker_.get() : nullptr,
-      *encodingFactory_,
-      options_.passStringBuffersFromDecoder(),
-      options_.preserveFlatMapsInMemory());
+  velox::CpuWallTiming stripeLoadTiming;
+  {
+    velox::DeltaCpuWallTimeStopWatch stopWatch;
+    streams_.setStripe(stripeIndex);
+    NimbleParams params(
+        *readerBase_->pool(),
+        columnReaderStatistics_,
+        readerBase_->nimbleSchema(),
+        streams_,
+        options_.trackRowSize() ? rowSizeTracker_.get() : nullptr,
+        *encodingFactory_,
+        options_.passStringBuffersFromDecoder(),
+        options_.preserveFlatMapsInMemory());
 
-  columnReader_ = buildColumnReader(
-      fileOutputType_,
-      readerBase_->fileSchemaWithId(),
-      params,
-      *options_.scanSpec(),
-      true);
-  rowSizeTracker_->finalizeProjection();
-  columnReader_->setIsTopLevel();
+    columnReader_ = buildColumnReader(
+        fileOutputType_,
+        readerBase_->fileSchemaWithId(),
+        params,
+        *options_.scanSpec(),
+        true);
+    rowSizeTracker_->finalizeProjection();
+    columnReader_->setIsTopLevel();
 
-  // Build index reader.
-  indexReader_ = index::ClusterIndexReader::create(
-      params.streams().enqueueKeyStream(),
-      params.streams().stripeIndex(),
-      params.streams().clusterIndex(),
-      &params.pool());
+    // Build index reader.
+    indexReader_ = index::ClusterIndexReader::create(
+        params.streams().enqueueKeyStream(),
+        params.streams().stripeIndex(),
+        params.streams().clusterIndex(),
+        &params.pool());
 
-  streams_.load();
+    streams_.load();
+    stripeLoadTiming = stopWatch.elapsed();
+  }
+  addThreadLocalRuntimeStat(
+      kStripeLoadWallNanos,
+      velox::RuntimeCounter(
+          static_cast<int64_t>(stripeLoadTiming.wallNanos),
+          velox::RuntimeCounter::Unit::kNanos));
+  addThreadLocalRuntimeStat(
+      kStripeLoadCpuNanos,
+      velox::RuntimeCounter(
+          static_cast<int64_t>(stripeLoadTiming.cpuNanos),
+          velox::RuntimeCounter::Unit::kNanos));
 }
 
 std::vector<RowRange> SelectiveNimbleIndexReader::lookupRowRanges(
@@ -632,6 +663,26 @@ std::vector<RowRange> SelectiveNimbleIndexReader::lookupRowRanges(
     }
     result.emplace_back(startRow, endRow);
   }
+
+  // Forward ClusterIndexReader stats.
+  const auto& idxStats = indexReader_->stats();
+  addThreadLocalRuntimeStat(
+      kChunkLoadWallNanos,
+      velox::RuntimeCounter(
+          static_cast<int64_t>(idxStats.chunkLoadNanos),
+          velox::RuntimeCounter::Unit::kNanos));
+  addThreadLocalRuntimeStat(
+      kChunkLoadCpuNanos,
+      velox::RuntimeCounter(
+          static_cast<int64_t>(idxStats.chunkLoadCpuNanos),
+          velox::RuntimeCounter::Unit::kNanos));
+  addThreadLocalRuntimeStat(
+      kChunkCacheHits,
+      velox::RuntimeCounter(static_cast<int64_t>(idxStats.chunkCacheHits)));
+  addThreadLocalRuntimeStat(
+      kNumIndexSeeks,
+      velox::RuntimeCounter(static_cast<int64_t>(idxStats.numSeeks)));
+
   return result;
 }
 
@@ -644,13 +695,38 @@ uint64_t SelectiveNimbleIndexReader::readStripeFragment(RowVectorPtr& output) {
   const auto rowsToRead = segment.rowRange.endRow - segment.rowRange.startRow;
   VELOX_CHECK_GT(rowsToRead, 0);
 
-  VectorPtr readOutput =
-      BaseVector::create(outputType_, 0, readerBase_->pool());
-  columnReader_->next(rowsToRead, readOutput, /*mutation=*/nullptr);
-  if (readOutput->size() > 0) {
-    readOutput->loadedVector();
+  // Reset thread-local ChunkedDecoder stats before the read.
+  auto& decoderStats = ChunkedDecoderStats::threadLocal();
+  decoderStats.reset();
+
+  velox::CpuWallTiming dataReadTiming;
+  {
+    velox::DeltaCpuWallTimeStopWatch stopWatch;
+    VectorPtr readOutput =
+        BaseVector::create(outputType_, 0, readerBase_->pool());
+    columnReader_->next(rowsToRead, readOutput, /*mutation=*/nullptr);
+    if (readOutput->size() > 0) {
+      readOutput->loadedVector();
+    }
+    output = checkedPointerCast<RowVector>(readOutput);
+    dataReadTiming = stopWatch.elapsed();
   }
-  output = checkedPointerCast<RowVector>(readOutput);
+  addThreadLocalRuntimeStat(
+      kDataReadWallNanos,
+      velox::RuntimeCounter(
+          static_cast<int64_t>(dataReadTiming.wallNanos),
+          velox::RuntimeCounter::Unit::kNanos));
+  addThreadLocalRuntimeStat(
+      kDataReadCpuNanos,
+      velox::RuntimeCounter(
+          static_cast<int64_t>(dataReadTiming.cpuNanos),
+          velox::RuntimeCounter::Unit::kNanos));
+
+  // Forward ChunkedDecoder chunk load count.
+  addThreadLocalRuntimeStat(
+      kDataChunkLoads,
+      velox::RuntimeCounter(static_cast<int64_t>(decoderStats.numChunkLoads)));
+
   return rowsToRead;
 }
 

--- a/dwio/nimble/velox/selective/SelectiveNimbleIndexReader.h
+++ b/dwio/nimble/velox/selective/SelectiveNimbleIndexReader.h
@@ -68,6 +68,27 @@ class SelectiveNimbleIndexReader : public velox::dwio::common::IndexReader {
   std::unique_ptr<Result> next(velox::vector_size_t maxOutputRows) override;
 
  private:
+  // Timing stat names for sub-phases of the index read path.
+  // Each I/O-heavy phase tracks both wall time and CPU time separately.
+  // Wall - CPU = I/O wait time.
+  static constexpr std::string_view kStripeLoadWallNanos =
+      "nimbleIndexStripeLoadWallNanos";
+  static constexpr std::string_view kStripeLoadCpuNanos =
+      "nimbleIndexStripeLoadCpuNanos";
+  static constexpr std::string_view kDataReadWallNanos =
+      "nimbleIndexDataReadWallNanos";
+  static constexpr std::string_view kDataReadCpuNanos =
+      "nimbleIndexDataReadCpuNanos";
+  static constexpr std::string_view kChunkLoadWallNanos =
+      "nimbleIndexChunkLoadWallNanos";
+  static constexpr std::string_view kChunkLoadCpuNanos =
+      "nimbleIndexChunkLoadCpuNanos";
+  static constexpr std::string_view kChunkCacheHits =
+      "nimbleIndexChunkCacheHits";
+  static constexpr std::string_view kNumIndexSeeks = "nimbleIndexNumSeeks";
+  static constexpr std::string_view kDataChunkLoads =
+      "nimbleIndexDataChunkLoads";
+
   using RowRangeMap = folly::F14FastMap<RowRange, size_t, RowRangeHash>;
 
   // Represents a read segment - a contiguous row range to read from the file.


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebookincubator/velox/pull/17052

Add performance metrics and I/O counters across the index lookup
pipeline to enable bottleneck analysis and selectivity monitoring.

IndexLookupJoin operator:
- numIndexSplits: split count

HiveIndexSource connector:
- connectorLookupWallTime: end-to-end iteration wall time
- connectorResultPrepareTime: output projection CPU time
- connectorIndexSetupWallNanos: startLookup() wall time
- connectorIndexReadWallNanos: next() data read wall time
- connectorPostFilterWallNanos: remaining filter wall time
- storageReadBytes/ramReadBytes/localReadBytes: cache stats

FileIndexReader:
- numFileIndexLookupRequests: startLookup() call count
- numFileIndexOutputRows: total output rows from next()

IndexReader (SelectiveNimbleIndexReader):
- numIndexStripeTotalRows: total rows in loaded stripes
- numIndexMatchedRows: rows matched by cluster index

Nimble-level timing (wall + CPU time for I/O-heavy phases):
- nimbleIndexStripeLoadWallNanos/CpuNanos: stripe loading
- nimbleIndexDataReadWallNanos/CpuNanos: data chunk reading
- nimbleIndexChunkLoadWallNanos/CpuNanos: index chunk I/O + decode
- nimbleIndexChunkCacheHits: index chunk cache hit count
- nimbleIndexNumSeeks: index seekAtOrAfter call count
- nimbleIndexDataChunkLoads: data chunk load count

Differential Revision: D99739876


