### PR TITLE
feat(writer): Add chunking execution stats to VeloxWriter (#656)

### DIFF
--- a/dwio/nimble/velox/FieldWriter.h
+++ b/dwio/nimble/velox/FieldWriter.h
@@ -24,6 +24,7 @@
 #include "dwio/nimble/velox/stats/ColumnStatistics.h"
 #include "dwio/nimble/velox/stats/ColumnStatsUtils.h"
 #include "folly/container/F14Map.h"
+#include "folly/stats/StreamingStats.h"
 #include "velox/dwio/common/TypeWithId.h"
 
 #include <set>
@@ -255,6 +256,14 @@ class FieldWriterContext {
     return inputBufferGrowthStats_;
   }
 
+  inline void recordChunkSize(uint64_t encodedBytes) {
+    chunkSizeStats_.add(encodedBytes);
+  }
+
+  inline const folly::StreamingStats<uint64_t>& chunkSizeStats() const {
+    return chunkSizeStats_;
+  }
+
   inline std::vector<ColumnStatistics*> columnStats() {
     if (!statsFinalized_) {
       return {};
@@ -456,6 +465,7 @@ class FieldWriterContext {
   std::unique_ptr<InputBufferGrowthPolicy> inputBufferGrowthPolicy_;
   std::unique_ptr<InputBufferGrowthPolicy> stringBufferGrowthPolicy_;
   InputBufferGrowthStats inputBufferGrowthStats_;
+  folly::StreamingStats<uint64_t> chunkSizeStats_;
 
   std::function<void(const TypeBuilder&, std::string_view, const TypeBuilder&)>
       flatmapFieldAddedEventHandler_;

--- a/dwio/nimble/velox/VeloxWriter.cpp
+++ b/dwio/nimble/velox/VeloxWriter.cpp
@@ -1284,6 +1284,9 @@ bool VeloxWriter::writeChunks(
   }
 
   context_->addStripeFlushTiming(flushTiming);
+  if (writtenChunk) {
+    context_->recordChunkSize(chunkBytes);
+  }
   VLOG(1) << "writeChunk time: " << velox::succinctNanos(flushTiming.wallNanos)
           << ", chunk size: " << velox::succinctBytes(chunkBytes);
   return writtenChunk;
@@ -1442,6 +1445,7 @@ VeloxWriter::Stats VeloxWriter::stats() const {
       .inputBufferReallocCount = context_->inputBufferGrowthStats().count,
       .inputBufferReallocItemCount =
           context_->inputBufferGrowthStats().itemCount,
+      .chunkSizeStats = context_->chunkSizeStats(),
       .columnStats = context_->columnStats(),
   };
 }

--- a/dwio/nimble/velox/VeloxWriter.h
+++ b/dwio/nimble/velox/VeloxWriter.h
@@ -77,6 +77,9 @@ class VeloxWriter {
     uint64_t inputBufferReallocCount;
     /// Number of items moved during input buffer reallocations.
     uint64_t inputBufferReallocItemCount;
+    /// Cumulative encoded size distribution across all chunks written under
+    /// memory pressure. Empty when chunking is not triggered.
+    folly::StreamingStats<uint64_t> chunkSizeStats;
     /// Per-column statistics. Only available at file close.
     /// NOTE: expected to be exposed as a view, for merging with base stats
     /// objects. User needs to explicitly copy.

--- a/dwio/nimble/velox/tests/VeloxWriterTest.cpp
+++ b/dwio/nimble/velox/tests/VeloxWriterTest.cpp
@@ -3029,6 +3029,68 @@ INSTANTIATE_TEST_CASE_P(
             .expectedMinChunkCount = 1,
             .chunkedStreamBatchSize = 10}));
 
+TEST_F(VeloxWriterTest, chunkSizeStatsPopulatedWhenChunkingTriggered) {
+  const auto type = velox::ROW({{"c0", velox::BIGINT()}});
+
+  // Use ChunkFlushPolicy with low thresholds and enough data to guarantee
+  // chunking fires (mirrors ChunkFlushPolicyIntegration test setup).
+  nimble::VeloxWriterOptions options{
+      .minStreamChunkRawSize = 100,
+      .maxStreamChunkRawSize = 128 << 10,
+      .flushPolicyFactory = []() -> std::unique_ptr<nimble::FlushPolicy> {
+        return std::make_unique<nimble::ChunkFlushPolicy>(
+            nimble::ChunkFlushPolicyConfig{
+                .writerMemoryHighThresholdBytes = 80 << 10,
+                .writerMemoryLowThresholdBytes = 75 << 10,
+                .targetStripeSizeBytes = 250 << 10,
+                .estimatedCompressionFactor = 1.3,
+            });
+      },
+      .enableChunking = true,
+  };
+
+  std::string file;
+  auto writeFile = std::make_unique<velox::InMemoryWriteFile>(&file);
+  nimble::VeloxWriter writer(
+      type, std::move(writeFile), *rootPool_, std::move(options));
+
+  const auto batches = generateBatches(
+      type, /*batchCount=*/20, /*size=*/4000, /*seed=*/42, *leafPool_);
+  for (const auto& batch : batches) {
+    writer.write(batch);
+  }
+  writer.close();
+
+  const auto stats = writer.stats();
+  EXPECT_GT(stats.chunkSizeStats.count(), 0);
+  EXPECT_GT(stats.chunkSizeStats.mean(), 0);
+  EXPECT_LE(stats.chunkSizeStats.minimum(), stats.chunkSizeStats.maximum());
+}
+
+TEST_F(VeloxWriterTest, chunkSizeStatsEmptyWhenChunkingNotTriggered) {
+  const auto type = velox::ROW({{"c0", velox::BIGINT()}});
+
+  nimble::VeloxWriterOptions options{
+      .flushPolicyFactory = []() -> std::unique_ptr<nimble::FlushPolicy> {
+        return std::make_unique<nimble::StripeRawSizeFlushPolicy>(
+            256ULL << 20); // 256MB — will never flush in this test
+      },
+      .enableChunking = false,
+  };
+
+  std::string file;
+  auto writeFile = std::make_unique<velox::InMemoryWriteFile>(&file);
+  nimble::VeloxWriter writer(
+      type, std::move(writeFile), *rootPool_, std::move(options));
+
+  velox::test::VectorMaker vectorMaker{leafPool_.get()};
+  writer.write(vectorMaker.rowVector(
+      {"c0"}, {vectorMaker.flatVector<int64_t>({1, 2, 3, 4, 5})}));
+  writer.close();
+
+  EXPECT_EQ(writer.stats().chunkSizeStats.count(), 0);
+}
+
 // Parameterized test fixture for index tests.
 // When enableChunking is false, sets very high minChunkRawSize and
 // maxChunkRawSize to prevent chunking (one chunk per stream).


### PR DESCRIPTION
Summary:

Track chunk count and encoded chunk size distribution (mean, min, max,
stddev) using folly::StreamingStats in FieldWriterContext. Stats are
recorded in writeStreams() on each chunk trigger and exposed via
VeloxWriter::Stats::chunkSizeStats.

NimbleWriterAdapter forwards these to velox::IoStats via addCounter(),
which surfaces them on the Presto query page as operator runtime stats
under TableWriter:
  - nimble.chunkCount
  - nimble.avgChunkSizeBytes
  - nimble.minChunkSizeBytes
  - nimble.maxChunkSizeBytes
  - nimble.stddevChunkSizeBytes

Stats are only populated when chunking is triggered (chunkSizeStats.count() > 0),
so non-chunked writes are unaffected.

Reviewed By: raymondlin1

Differential Revision: D100318180


