### PR TITLE
Use varint encoding for row count in encoding prefix (#657)

### DIFF
--- a/dwio/nimble/encodings/EncodingLayout.cpp
+++ b/dwio/nimble/encodings/EncodingLayout.cpp
@@ -19,6 +19,7 @@
 #include <vector>
 #include "dwio/nimble/common/EncodingPrimitives.h"
 #include "dwio/nimble/common/Exceptions.h"
+#include "dwio/nimble/common/Varint.h"
 
 namespace facebook::nimble {
 
@@ -148,13 +149,28 @@ const EncodingLayout::Config& EncodingLayout::config() const {
 
 namespace {
 
-constexpr uint32_t kEncodingPrefixSize = 6;
+constexpr uint32_t kFixedEncodingPrefixSize = 6;
+
+// Computes the encoding prefix size. The prefix is:
+// 1 byte encoding type + 1 byte data type + row count.
+// Row count is either 4 bytes (fixed) or varint-encoded.
+uint32_t encodingPrefixSize(std::string_view encoding, bool useVarintRowCount) {
+  if (!useVarintRowCount) {
+    return kFixedEncodingPrefixSize;
+  }
+  // Skip encoding type (1 byte) + data type (1 byte), then measure varint.
+  const char* pos = encoding.data() + 2;
+  varint::skipVarint(&pos);
+  return static_cast<uint32_t>(pos - encoding.data());
+}
 
 } // namespace
 
-EncodingLayout EncodingLayoutCapture::capture(std::string_view encoding) {
-  NIMBLE_CHECK_GE(
-      encoding.size(), kEncodingPrefixSize, "Encoding size too small.");
+EncodingLayout EncodingLayoutCapture::capture(
+    std::string_view encoding,
+    bool useVarintRowCount) {
+  const uint32_t prefixSize = encodingPrefixSize(encoding, useVarintRowCount);
+  NIMBLE_CHECK_GE(encoding.size(), prefixSize, "Encoding size too small.");
 
   const auto encodingType =
       encoding::peek<uint8_t, EncodingType>(encoding.data());
@@ -162,8 +178,8 @@ EncodingLayout EncodingLayoutCapture::capture(std::string_view encoding) {
 
   if (encodingType == EncodingType::FixedBitWidth ||
       encodingType == EncodingType::Trivial) {
-    compressionType = encoding::peek<uint8_t, CompressionType>(
-        encoding.data() + kEncodingPrefixSize);
+    compressionType =
+        encoding::peek<uint8_t, CompressionType>(encoding.data() + prefixSize);
   }
 
   std::vector<std::optional<const EncodingLayout>> children;
@@ -179,12 +195,13 @@ EncodingLayout EncodingLayoutCapture::capture(std::string_view encoding) {
       const auto dataType =
           encoding::peek<uint8_t, DataType>(encoding.data() + 1);
       if (dataType == DataType::String) {
-        const char* pos = encoding.data() + kEncodingPrefixSize + 1;
+        const char* pos = encoding.data() + prefixSize + 1;
         const uint32_t lengthsBytes = encoding::readUint32(pos);
 
         children.reserve(1);
         children.emplace_back(
-            EncodingLayoutCapture::capture({pos, lengthsBytes}));
+            EncodingLayoutCapture::capture(
+                {pos, lengthsBytes}, useVarintRowCount));
       }
       break;
     }
@@ -192,38 +209,42 @@ EncodingLayout EncodingLayoutCapture::capture(std::string_view encoding) {
       children.reserve(1);
       children.emplace_back(
           EncodingLayoutCapture::capture(
-              encoding.substr(kEncodingPrefixSize + 1)));
+              encoding.substr(prefixSize + 1), useVarintRowCount));
       break;
     }
     case EncodingType::MainlyConstant: {
       children.reserve(2);
 
-      const char* pos = encoding.data() + kEncodingPrefixSize;
+      const char* pos = encoding.data() + prefixSize;
       const uint32_t isCommonBytes = encoding::readUint32(pos);
 
       children.emplace_back(
-          EncodingLayoutCapture::capture({pos, isCommonBytes}));
+          EncodingLayoutCapture::capture(
+              {pos, isCommonBytes}, useVarintRowCount));
 
       pos += isCommonBytes;
       const uint32_t otherValuesBytes = encoding::readUint32(pos);
 
       children.emplace_back(
-          EncodingLayoutCapture::capture({pos, otherValuesBytes}));
+          EncodingLayoutCapture::capture(
+              {pos, otherValuesBytes}, useVarintRowCount));
       break;
     }
     case EncodingType::Dictionary: {
       children.reserve(2);
-      const char* pos = encoding.data() + kEncodingPrefixSize;
+      const char* pos = encoding.data() + prefixSize;
       const uint32_t alphabetBytes = encoding::readUint32(pos);
 
       children.emplace_back(
-          EncodingLayoutCapture::capture({pos, alphabetBytes}));
+          EncodingLayoutCapture::capture(
+              {pos, alphabetBytes}, useVarintRowCount));
 
       pos += alphabetBytes;
 
       children.emplace_back(
           EncodingLayoutCapture::capture(
-              {pos, encoding.size() - (pos - encoding.data())}));
+              {pos, encoding.size() - (pos - encoding.data())},
+              useVarintRowCount));
       break;
     }
     case EncodingType::RLE: {
@@ -232,55 +253,61 @@ EncodingLayout EncodingLayoutCapture::capture(std::string_view encoding) {
 
       children.reserve(dataType == DataType::Bool ? 1 : 2);
 
-      const char* pos = encoding.data() + kEncodingPrefixSize;
+      const char* pos = encoding.data() + prefixSize;
       const uint32_t runLengthBytes = encoding::readUint32(pos);
 
       children.emplace_back(
-          EncodingLayoutCapture::capture({pos, runLengthBytes}));
+          EncodingLayoutCapture::capture(
+              {pos, runLengthBytes}, useVarintRowCount));
 
       if (dataType != DataType::Bool) {
         pos += runLengthBytes;
 
         children.emplace_back(
             EncodingLayoutCapture::capture(
-                {pos, encoding.size() - (pos - encoding.data())}));
+                {pos, encoding.size() - (pos - encoding.data())},
+                useVarintRowCount));
       }
       break;
     }
     case EncodingType::Delta: {
       children.reserve(3);
 
-      const char* pos = encoding.data() + kEncodingPrefixSize;
+      const char* pos = encoding.data() + prefixSize;
       const uint32_t deltaBytes = encoding::readUint32(pos);
       const uint32_t restatementBytes = encoding::readUint32(pos);
 
-      children.emplace_back(EncodingLayoutCapture::capture({pos, deltaBytes}));
+      children.emplace_back(
+          EncodingLayoutCapture::capture({pos, deltaBytes}, useVarintRowCount));
 
       pos += deltaBytes;
 
       children.emplace_back(
-          EncodingLayoutCapture::capture({pos, restatementBytes}));
+          EncodingLayoutCapture::capture(
+              {pos, restatementBytes}, useVarintRowCount));
 
       pos += restatementBytes;
 
       children.emplace_back(
           EncodingLayoutCapture::capture(
-              {pos, encoding.size() - (pos - encoding.data())}));
+              {pos, encoding.size() - (pos - encoding.data())},
+              useVarintRowCount));
       break;
     }
     case EncodingType::Nullable: {
-      const char* pos = encoding.data() + kEncodingPrefixSize;
+      const char* pos = encoding.data() + prefixSize;
       const uint32_t dataBytes = encoding::readUint32(pos);
 
       // For nullable encodings we only capture the data encoding part, so we
       // are "overwriting" the current captured node with the nested data node.
-      return EncodingLayoutCapture::capture({pos, dataBytes});
+      return EncodingLayoutCapture::capture(
+          {pos, dataBytes}, useVarintRowCount);
     }
     case EncodingType::Sentinel: {
       // For sentinel encodings we only capture the data encoding part, so we
       // are "overwriting" the current captured node with the nested data node.
       return EncodingLayoutCapture::capture(
-          encoding.substr(kEncodingPrefixSize + 8));
+          encoding.substr(prefixSize + 8), useVarintRowCount);
     }
   }
 

--- a/dwio/nimble/encodings/EncodingLayout.h
+++ b/dwio/nimble/encodings/EncodingLayout.h
@@ -81,7 +81,11 @@ class EncodingLayoutCapture {
   /// It traverses the encoding headers in the stream and produces a serialized
   /// encoding tree layout.
   /// |encoding| - The serialized encoding
-  static EncodingLayout capture(std::string_view encoding);
+  /// |useVarintRowCount| - If true, expect varint-encoded row counts instead of
+  /// fixed 4-byte row counts in encoding prefixes.
+  static EncodingLayout capture(
+      std::string_view encoding,
+      bool useVarintRowCount = false);
 };
 
 } // namespace facebook::nimble

--- a/dwio/nimble/encodings/legacy/EncodingFactory.h
+++ b/dwio/nimble/encodings/legacy/EncodingFactory.h
@@ -80,3 +80,25 @@ class EncodingFactory : public ::facebook::nimble::EncodingFactory {
 };
 
 } // namespace facebook::nimble::legacy
+
+namespace facebook::nimble {
+
+/// Creates the appropriate EncodingFactory based on file version and options.
+/// When useVarintRowCount is true, returns a non-legacy EncodingFactory with
+/// varint row count support. When passStringBuffersFromDecoder is true, returns
+/// a non-legacy EncodingFactory with default options. Otherwise, returns a
+/// legacy EncodingFactory.
+inline std::unique_ptr<const EncodingFactory> makeEncodingFactory(
+    bool useVarintRowCount,
+    bool passStringBuffersFromDecoder) {
+  if (useVarintRowCount) {
+    return std::make_unique<EncodingFactory>(
+        Encoding::Options{.useVarintRowCount = true});
+  }
+  if (passStringBuffersFromDecoder) {
+    return std::make_unique<EncodingFactory>();
+  }
+  return std::make_unique<legacy::EncodingFactory>();
+}
+
+} // namespace facebook::nimble

--- a/dwio/nimble/encodings/tests/EncodingSelectionTest.cpp
+++ b/dwio/nimble/encodings/tests/EncodingSelectionTest.cpp
@@ -67,6 +67,7 @@ void verifyEncodingTree(
   std::vector<EncodingDetails> actual;
   nimble::tools::traverseEncodings(
       stream,
+      false,
       [&](auto encodingType,
           auto dataType,
           auto level,
@@ -158,6 +159,7 @@ void test(std::span<const T> values, std::vector<EncodingDetails> expected) {
   std::vector<EncodingDetails> actual;
   nimble::tools::traverseEncodings(
       serialized,
+      false,
       [&](auto encodingType,
           auto dataType,
           auto level,

--- a/dwio/nimble/encodings/tests/TestUtils.cpp
+++ b/dwio/nimble/encodings/tests/TestUtils.cpp
@@ -15,25 +15,43 @@
  */
 
 #include "dwio/nimble/encodings/tests/TestUtils.h"
+#include "dwio/nimble/common/Varint.h"
 #include "dwio/nimble/encodings/EncodingUtils.h"
 
 namespace facebook::nimble::test {
 
-static constexpr int kRowCountOffset = 2;
-static constexpr int kPrefixSize = 6;
 static constexpr int kCompressionTypeSize = 1;
+
+// Read the row count from an encoding prefix at the given position.
+// Advances pos past the row count field.
+static uint32_t readRowCount(const char*& pos, bool useVarintRowCount) {
+  if (useVarintRowCount) {
+    return varint::readVarint32(&pos);
+  } else {
+    return encoding::readUint32(pos);
+  }
+}
+
+// Skip the encoding prefix (encoding type + data type + row count) starting
+// at pos. Returns the row count read.
+static uint32_t skipPrefix(const char*& pos, bool useVarintRowCount) {
+  pos += 2; // encoding type + data type
+  return readRowCount(pos, useVarintRowCount);
+}
 
 uint64_t TestUtils::getRawDataSize(
     velox::memory::MemoryPool& memoryPool,
-    std::string_view encodingStr) {
+    std::string_view encodingStr,
+    bool useVarintRowCount) {
+  const Encoding::Options options{.useVarintRowCount = useVarintRowCount};
   std::vector<velox::BufferPtr> newStringBuffers;
   const auto stringBufferFactory = [&](uint32_t totalLength) {
     auto& buffer = newStringBuffers.emplace_back(
         velox::AlignedBuffer::allocate<char>(totalLength, &memoryPool));
     return buffer->asMutable<void>();
   };
-  auto encoding =
-      EncodingFactory().create(memoryPool, encodingStr, stringBufferFactory);
+  const EncodingFactory factory{options};
+  auto encoding = factory.create(memoryPool, encodingStr, stringBufferFactory);
   EncodingType encodingType = encoding->encodingType();
   DataType dataType = encoding->dataType();
   uint32_t rowCount = encoding->rowCount();
@@ -43,24 +61,29 @@ uint64_t TestUtils::getRawDataSize(
   }
 
   if (encodingType == EncodingType::Nullable) {
-    auto pos = encodingStr.data() + kPrefixSize;
+    // Skip the outer prefix to find the inner data.
+    auto pos = encodingStr.data();
+    skipPrefix(pos, useVarintRowCount);
     auto nonNullsSize = encoding::readUint32(pos);
-    // Sum of the  nulls count and size of the non-null child encoding.
-    return getRawDataSize(memoryPool, {pos, nonNullsSize}) + rowCount;
+    // Sum of the nulls count and size of the non-null child encoding.
+    return getRawDataSize(memoryPool, {pos, nonNullsSize}, useVarintRowCount) +
+        rowCount;
   } else {
     if (dataType != DataType::String) {
       auto typeSize = nimble::detail::dataTypeSize(dataType);
       auto result = typeSize * rowCount;
       return result;
     } else {
-      auto pos = encodingStr.data() + kPrefixSize; // Skip the prefix.
+      // Skip the prefix to get to the encoding-specific data.
+      auto pos = encodingStr.data();
+      skipPrefix(pos, useVarintRowCount);
       uint64_t result = 0;
 
       switch (encodingType) {
         case EncodingType::Trivial: {
           pos += kCompressionTypeSize;
           auto lengthsSize = encoding::readUint32(pos);
-          auto lengths = EncodingFactory().create(
+          auto lengths = factory.create(
               memoryPool, {pos, lengthsSize}, stringBufferFactory);
           std::vector<uint32_t> buffer(rowCount);
           lengths->materialize(rowCount, buffer.data());
@@ -79,31 +102,38 @@ uint64_t TestUtils::getRawDataSize(
           pos += isCommonSize;
           auto otherValuesSize = encoding::readUint32(pos);
           auto otherValuesOffset = pos;
-          auto otherValuesCount =
-              encoding::peek<uint32_t>(pos + kRowCountOffset);
+          // Read the sub-encoding's row count by parsing its prefix.
+          const char* subPos = pos;
+          subPos += 2; // encoding type + data type
+          auto otherValuesCount = readRowCount(subPos, useVarintRowCount);
           pos += otherValuesSize;
           auto constantValueSize = encoding::readUint32(pos);
           result += (rowCount - otherValuesCount) * constantValueSize;
-          result +=
-              getRawDataSize(memoryPool, {otherValuesOffset, otherValuesSize});
+          result += getRawDataSize(
+              memoryPool,
+              {otherValuesOffset, otherValuesSize},
+              useVarintRowCount);
           break;
         }
 
         case EncodingType::Dictionary: {
           auto alphabetSize = encoding::readUint32(pos);
-          auto alphabetCount = encoding::peek<uint32_t>(pos + kRowCountOffset);
-          auto alphabet = EncodingFactory().create(
+          // Read the sub-encoding's row count.
+          const char* subPos = pos;
+          subPos += 2; // encoding type + data type
+          auto alphabetCount = readRowCount(subPos, useVarintRowCount);
+          auto alphabet = factory.create(
               memoryPool, {pos, alphabetSize}, stringBufferFactory);
           std::vector<std::string_view> alphabetBuffer(alphabetCount);
           alphabet->materialize(alphabetCount, alphabetBuffer.data());
 
           pos += alphabetSize;
           auto indicesSize = encodingStr.length() - (pos - encodingStr.data());
-          auto indices = EncodingFactory().create(
+          auto indices = factory.create(
               memoryPool, {pos, indicesSize}, stringBufferFactory);
           std::vector<uint32_t> indicesBuffer(rowCount);
           indices->materialize(rowCount, indicesBuffer.data());
-          for (int i = 0; i < rowCount; ++i) {
+          for (uint32_t i = 0; i < rowCount; ++i) {
             result += alphabetBuffer[indicesBuffer[i]].size();
           }
           break;
@@ -111,9 +141,11 @@ uint64_t TestUtils::getRawDataSize(
 
         case EncodingType::RLE: {
           auto runLengthsSize = encoding::readUint32(pos);
-          auto runLengthsCount =
-              encoding::peek<uint32_t>(pos + kRowCountOffset);
-          auto runLengths = EncodingFactory().create(
+          // Read the sub-encoding's row count.
+          const char* subPos = pos;
+          subPos += 2; // encoding type + data type
+          auto runLengthsCount = readRowCount(subPos, useVarintRowCount);
+          auto runLengths = factory.create(
               memoryPool, {pos, runLengthsSize}, stringBufferFactory);
           std::vector<uint32_t> runLengthsBuffer(runLengthsCount);
           runLengths->materialize(runLengthsCount, runLengthsBuffer.data());
@@ -121,12 +153,12 @@ uint64_t TestUtils::getRawDataSize(
           pos += runLengthsSize;
           auto runValuesSize =
               encodingStr.length() - (pos - encodingStr.data());
-          auto runValues = EncodingFactory().create(
+          auto runValues = factory.create(
               memoryPool, {pos, runValuesSize}, stringBufferFactory);
           std::vector<std::string_view> runValuesBuffer(runLengthsCount);
           runValues->materialize(runLengthsCount, runValuesBuffer.data());
 
-          for (int i = 0; i < runLengthsCount; ++i) {
+          for (uint32_t i = 0; i < runLengthsCount; ++i) {
             result += runLengthsBuffer[i] * runValuesBuffer[i].size();
           }
           break;

--- a/dwio/nimble/encodings/tests/TestUtils.h
+++ b/dwio/nimble/encodings/tests/TestUtils.h
@@ -258,6 +258,7 @@ class TestUtils {
  public:
   static uint64_t getRawDataSize(
       velox::memory::MemoryPool& memoryPool,
-      std::string_view encodingStr);
+      std::string_view encodingStr,
+      bool useVarintRowCount = false);
 };
 } // namespace facebook::nimble::test

--- a/dwio/nimble/index/ClusterIndexReader.cpp
+++ b/dwio/nimble/index/ClusterIndexReader.cpp
@@ -19,7 +19,6 @@
 #include "dwio/nimble/common/EncodingPrimitives.h"
 #include "dwio/nimble/common/Exceptions.h"
 #include "dwio/nimble/common/Types.h"
-#include "dwio/nimble/encodings/EncodingFactory.h"
 
 namespace facebook::nimble::index {
 
@@ -29,11 +28,13 @@ ClusterIndexReader::ClusterIndexReader(
     std::unique_ptr<velox::dwio::common::SeekableInputStream> input,
     uint32_t stripeIndex,
     std::shared_ptr<ClusterIndexGroup> indexGroup,
+    const EncodingFactory& encodingFactory,
     velox::memory::MemoryPool* pool)
     : stripeIndex_{stripeIndex},
       indexGroup_{std::move(indexGroup)},
       input_{std::move(input)},
-      pool_{pool} {
+      pool_{pool},
+      encodingFactory_{encodingFactory} {
   NIMBLE_CHECK_NOT_NULL(input_);
   NIMBLE_CHECK_NOT_NULL(pool_);
 }
@@ -42,9 +43,14 @@ std::unique_ptr<ClusterIndexReader> ClusterIndexReader::create(
     std::unique_ptr<velox::dwio::common::SeekableInputStream> input,
     uint32_t stripeIndex,
     std::shared_ptr<ClusterIndexGroup> indexGroup,
+    const EncodingFactory& encodingFactory,
     velox::memory::MemoryPool* pool) {
   return std::unique_ptr<ClusterIndexReader>(new ClusterIndexReader(
-      std::move(input), stripeIndex, std::move(indexGroup), pool));
+      std::move(input),
+      stripeIndex,
+      std::move(indexGroup),
+      encodingFactory,
+      pool));
 }
 
 std::optional<uint32_t> ClusterIndexReader::seekAtOrAfter(
@@ -129,7 +135,7 @@ void ClusterIndexReader::loadChunk() {
   inputData_ += length;
   inputSize_ -= length;
   stringBuffers_.clear();
-  encoding_ = nimble::EncodingFactory().create(
+  encoding_ = encodingFactory_.create(
       *pool_,
       std::string_view(chunkData, chunkSize),
       [&](uint32_t totalLength) {

--- a/dwio/nimble/index/ClusterIndexReader.h
+++ b/dwio/nimble/index/ClusterIndexReader.h
@@ -20,6 +20,7 @@
 #include <string_view>
 
 #include "dwio/nimble/encodings/Encoding.h"
+#include "dwio/nimble/encodings/EncodingFactory.h"
 #include "dwio/nimble/index/ClusterIndexGroup.h"
 #include "velox/dwio/common/SeekableInputStream.h"
 
@@ -44,6 +45,7 @@ class ClusterIndexReader {
       std::unique_ptr<velox::dwio::common::SeekableInputStream> input,
       uint32_t stripeIndex,
       std::shared_ptr<ClusterIndexGroup> indexGroup,
+      const EncodingFactory& encodingFactory,
       velox::memory::MemoryPool* pool);
 
   /// Seek to the position at or after the given encoded key.
@@ -56,6 +58,7 @@ class ClusterIndexReader {
       std::unique_ptr<velox::dwio::common::SeekableInputStream> input,
       uint32_t stripeIndex,
       std::shared_ptr<ClusterIndexGroup> indexGroup,
+      const EncodingFactory& encodingFactory,
       velox::memory::MemoryPool* pool);
 
   /// Seek to a key at or after the given encoded key within a chunk.
@@ -81,6 +84,7 @@ class ClusterIndexReader {
 
   const std::unique_ptr<velox::dwio::common::SeekableInputStream> input_;
   velox::memory::MemoryPool* const pool_;
+  const EncodingFactory encodingFactory_;
 
   const char* inputData_{nullptr};
   int64_t inputSize_{0};

--- a/dwio/nimble/index/tests/ClusterIndexReaderTest.cpp
+++ b/dwio/nimble/index/tests/ClusterIndexReaderTest.cpp
@@ -119,6 +119,7 @@ TEST_F(ClusterIndexReaderTest, singleChunkSingleKey) {
       createInputStream(encodedStream.data),
       /*stripeIndex=*/0,
       clusterIndexGroup,
+      EncodingFactory{},
       pool_.get());
 
   // Test exact key match
@@ -157,7 +158,11 @@ TEST_F(ClusterIndexReaderTest, singleChunkMultipleKeys) {
       createClusterIndexGroup(indexBuffers, /*stripeGroupIndex=*/0);
 
   auto reader = ClusterIndexReader::create(
-      createInputStream(encodedStream.data), 0, clusterIndexGroup, pool_.get());
+      createInputStream(encodedStream.data),
+      0,
+      clusterIndexGroup,
+      EncodingFactory{},
+      pool_.get());
 
   // Test exact matches, keys between existing keys, and keys after last key.
   // Keys between existing keys should return the next key's row.
@@ -213,7 +218,11 @@ TEST_F(ClusterIndexReaderTest, multipleChunks) {
       createClusterIndexGroup(indexBuffers, /*stripeGroupIndex=*/0);
 
   auto reader = ClusterIndexReader::create(
-      createInputStream(encodedStream.data), 0, clusterIndexGroup, pool_.get());
+      createInputStream(encodedStream.data),
+      0,
+      clusterIndexGroup,
+      EncodingFactory{},
+      pool_.get());
 
   // Test keys across all chunks with mixed found/not-found cases.
   // Chunk 0: row offset 0, Chunk 1: row offset 3, Chunk 2: row offset 6
@@ -273,7 +282,11 @@ TEST_F(ClusterIndexReaderTest, seekBetweenChunks) {
       createClusterIndexGroup(indexBuffers, /*stripeGroupIndex=*/0);
 
   auto reader = ClusterIndexReader::create(
-      createInputStream(encodedStream.data), 0, clusterIndexGroup, pool_.get());
+      createInputStream(encodedStream.data),
+      0,
+      clusterIndexGroup,
+      EncodingFactory{},
+      pool_.get());
 
   // Key falls between chunk 0's max (ccc) and chunk 1's content (ddd)
   // The index lookup should direct us to chunk 1, and we find ddd
@@ -348,6 +361,7 @@ TEST_F(ClusterIndexReaderTest, multipleStripes) {
       createInputStream(encodedStream0.data),
       0,
       clusterIndexGroup,
+      EncodingFactory{},
       pool_.get());
 
   auto result = reader0->seekAtOrAfter("key_a");
@@ -363,6 +377,7 @@ TEST_F(ClusterIndexReaderTest, multipleStripes) {
       createInputStream(encodedStream1.data),
       1,
       clusterIndexGroup,
+      EncodingFactory{},
       pool_.get());
 
   result = reader1->seekAtOrAfter("key_d");
@@ -394,7 +409,11 @@ TEST_F(ClusterIndexReaderTest, emptyStringKey) {
       createClusterIndexGroup(indexBuffers, /*stripeGroupIndex=*/0);
 
   auto reader = ClusterIndexReader::create(
-      createInputStream(encodedStream.data), 0, clusterIndexGroup, pool_.get());
+      createInputStream(encodedStream.data),
+      0,
+      clusterIndexGroup,
+      EncodingFactory{},
+      pool_.get());
 
   // Test empty string key
   auto result = reader->seekAtOrAfter("");
@@ -434,7 +453,11 @@ TEST_F(ClusterIndexReaderTest, largeNumberOfKeys) {
       createClusterIndexGroup(indexBuffers, /*stripeGroupIndex=*/0);
 
   auto reader = ClusterIndexReader::create(
-      createInputStream(encodedStream.data), 0, clusterIndexGroup, pool_.get());
+      createInputStream(encodedStream.data),
+      0,
+      clusterIndexGroup,
+      EncodingFactory{},
+      pool_.get());
 
   // Test some specific keys
   std::vector<int> testIndices = {0, 1, 10, 100, 500, 999};
@@ -490,7 +513,11 @@ TEST_F(ClusterIndexReaderTest, repeatedSeeksToSameChunk) {
       createClusterIndexGroup(indexBuffers, /*stripeGroupIndex=*/0);
 
   auto reader = ClusterIndexReader::create(
-      createInputStream(encodedStream.data), 0, clusterIndexGroup, pool_.get());
+      createInputStream(encodedStream.data),
+      0,
+      clusterIndexGroup,
+      EncodingFactory{},
+      pool_.get());
 
   // Test repeated seeks within each chunk and across chunks.
   // Mix forward, backward, and repeated seeks to test caching behavior.
@@ -540,7 +567,11 @@ TEST_F(ClusterIndexReaderTest, unevenChunkSizes) {
       createClusterIndexGroup(indexBuffers, /*stripeGroupIndex=*/0);
 
   auto reader = ClusterIndexReader::create(
-      createInputStream(encodedStream.data), 0, clusterIndexGroup, pool_.get());
+      createInputStream(encodedStream.data),
+      0,
+      clusterIndexGroup,
+      EncodingFactory{},
+      pool_.get());
 
   // Chunk 0: row offset 0, 1 key
   // Chunk 1: row offset 1, 5 keys
@@ -596,7 +627,11 @@ TEST_F(ClusterIndexReaderTest, binaryKeys) {
       createClusterIndexGroup(indexBuffers, /*stripeGroupIndex=*/0);
 
   auto reader = ClusterIndexReader::create(
-      createInputStream(encodedStream.data), 0, clusterIndexGroup, pool_.get());
+      createInputStream(encodedStream.data),
+      0,
+      clusterIndexGroup,
+      EncodingFactory{},
+      pool_.get());
 
   // Test exact matches and not-found cases for binary keys.
   // Keys after the last key should return std::nullopt.

--- a/dwio/nimble/serializer/Deserializer.cpp
+++ b/dwio/nimble/serializer/Deserializer.cpp
@@ -92,12 +92,14 @@ class DeserializerImpl : public Decoder {
       const Type* type,
       bool inMapStream,
       bool enableBufferPool,
+      std::optional<bool> useVarintRowCountOverride,
       velox::memory::MemoryPool* pool)
       : type_{type},
         pool_{pool},
         inMapStream_{inMapStream},
         scalarKind_{getScalarKindForType(*type)},
         typeStorageWidth_{getTypeStorageWidth(*type)},
+        useVarintRowCountOverride_{useVarintRowCountOverride},
         bufferPool_{
             enableBufferPool ? std::make_unique<velox::BufferPool>()
                              : nullptr} {}
@@ -210,6 +212,7 @@ class DeserializerImpl : public Decoder {
     const serde::StreamData::Options options{
         .version = segment.version,
         .bufferPool = bufferPool_.get(),
+        .useVarintRowCountOverride = useVarintRowCountOverride_,
     };
     streamData_.emplace(
         scalarKind_, segment.data, stringBuffers, pool_, options);
@@ -543,6 +546,8 @@ class DeserializerImpl : public Decoder {
   // Cached from type at construction to avoid per-call dispatch.
   const ScalarKind scalarKind_;
   const uint32_t typeStorageWidth_;
+  // Override for varint row count format in kTabletRaw streams.
+  const std::optional<bool> useVarintRowCountOverride_;
   // Pool for encoding scratch buffers (e.g. MainlyConstant's isCommon and
   // otherValues buffers). Persists across clear()/addBatch() cycles so buffers
   // are reused instead of being allocated/freed through MemoryPool each time.
@@ -688,11 +693,14 @@ Deserializer::Deserializer(
 void Deserializer::createDeserializersForType(
     const Type& type,
     uint32_t depth) {
+  const auto useVarintOverride =
+      options_.useVarintRowCount ? std::optional<bool>{true} : std::nullopt;
   deserializerMap_[getMainDescriptor(type).offset()] =
       std::make_unique<DeserializerImpl>(
           &type,
           /*inMapStream=*/false,
           options_.enableBufferPool,
+          useVarintOverride,
           pool_);
   // FlatMap is only supported at depth 1 (top-level columns). FlatMap keys can
   // vary across batches, causing gaps in nulls/inMap streams. Gap detection is
@@ -707,6 +715,7 @@ void Deserializer::createDeserializersForType(
           &type,
           /*inMapStream=*/true,
           options_.enableBufferPool,
+          useVarintOverride,
           pool_);
       inMapChildTypes_[inMapOffset] = flatMap.childAt(i).get();
     }

--- a/dwio/nimble/serializer/DeserializerImpl.cpp
+++ b/dwio/nimble/serializer/DeserializerImpl.cpp
@@ -37,7 +37,9 @@ StreamData::StreamData(
     : kind_{kind},
       pool_{pool},
       encodingEnabled_{nonLegacyFormat(options.version)},
-      useVarintRowCount_{!isTabletRawFormat(options.version)},
+      useVarintRowCount_{options.useVarintRowCountOverride.value_or(
+          !isTabletRawFormat(options.version))},
+      useVarintRowCountOverride_{options.useVarintRowCountOverride},
       bufferPool_{options.bufferPool},
       stringBuffers_{&stringBuffers} {
   NIMBLE_CHECK_NOT_NULL(pool_, "Memory pool required for encoding");
@@ -69,7 +71,8 @@ void StreamData::reset(std::string_view data, SerializationVersion version) {
   readRows_ = 0;
   encoding_.reset();
   encodingEnabled_ = nonLegacyFormat(version);
-  useVarintRowCount_ = !isTabletRawFormat(version);
+  useVarintRowCount_ =
+      useVarintRowCountOverride_.value_or(!isTabletRawFormat(version));
   // Re-initialize with new data.
   init(data);
 }

--- a/dwio/nimble/serializer/DeserializerImpl.h
+++ b/dwio/nimble/serializer/DeserializerImpl.h
@@ -37,6 +37,10 @@ class StreamData {
     SerializationVersion version;
     /// Optional pool for encoding scratch buffers.
     velox::BufferPool* bufferPool{nullptr};
+    /// Override for varint row count. When set, uses this value instead of
+    /// deriving from the serialization version. Used for kTabletRaw format
+    /// where the source file may have varint row counts.
+    std::optional<bool> useVarintRowCountOverride{std::nullopt};
   };
 
   /// Constructor for thrift decoder: creates an empty stream that will be
@@ -129,10 +133,14 @@ class StreamData {
   velox::memory::MemoryPool* const pool_{nullptr};
   // Whether nimble encoding is enabled. Non-const to allow reset() to change.
   bool encodingEnabled_{false};
-  // Whether encoding headers use varint row counts (true for kCompact/
-  // kCompactRaw) or fixed u32 (false for kTabletRaw). Non-const to allow
-  // reset() to change.
+  // Whether encoding headers use varint row counts. True for kCompact and
+  // kCompactRaw. For kTabletRaw, depends on whether the source tablet file
+  // had index enabled (varint row counts are bundled with index). Non-const to
+  // allow reset() to change.
   bool useVarintRowCount_{true};
+  // Override for varint row count. When set, reset() uses this value instead
+  // of deriving from the serialization version.
+  std::optional<bool> useVarintRowCountOverride_{std::nullopt};
   // Optional pool for encoding scratch buffers. Owned externally
   // (typically by DeserializerImpl) to persist across StreamData lifetimes.
   velox::BufferPool* const bufferPool_{nullptr};

--- a/dwio/nimble/serializer/Options.h
+++ b/dwio/nimble/serializer/Options.h
@@ -59,8 +59,9 @@ namespace facebook::nimble {
 ///   (1) Each stream's data includes tablet chunk headers:
 ///       [chunkSize:u32][compressionType:1B][encoded_data...]
 ///       which the Deserializer strips before decoding.
-///   (2) Encoding headers within streams use fixed u32 row counts
-///       (useVarintRowCount=false), matching the tablet's default format.
+///   (2) Encoding headers within streams use the row count format of the
+///       source tablet file (fixed u32 for non-indexed files, varint for
+///       indexed files with tablet format v0.2+).
 ///   Wire: [version:1B][rowCount:varint][stream_data_0]...[stream_data_N]
 ///         [encodingType:1B][raw_sizes_payload][trailer_size:u32]
 enum class SerializationVersion : uint8_t {
@@ -236,6 +237,13 @@ struct DeserializerOptions {
   /// Minimum number of child streams per parallel decode task. Ensures each
   /// coroutine task has enough work to amortize threading overhead.
   uint32_t minStreamsPerDecodeUnit{1};
+
+  /// Whether encoding headers in kTabletRaw streams use varint row counts.
+  /// Only relevant for kTabletRaw format. When true, encoding prefixes in the
+  /// raw tablet bytes use varint-encoded row counts instead of fixed 4-byte
+  /// uint32. Set this when the source tablet file was written with version
+  /// >= 0.2 and had index enabled.
+  bool useVarintRowCount{false};
 };
 
 } // namespace facebook::nimble

--- a/dwio/nimble/tablet/Constants.h
+++ b/dwio/nimble/tablet/Constants.h
@@ -20,7 +20,7 @@ namespace facebook::nimble {
 constexpr uint16_t kMagicNumber = 0xA1FA;
 constexpr uint64_t kInitialFooterSize = 8 * 1024 * 1024; // 8MB
 constexpr uint16_t kVersionMajor = 0;
-constexpr uint16_t kVersionMinor = 1;
+constexpr uint16_t kVersionMinor = 2;
 
 // Total size of the fields after the flatbuffer.
 constexpr uint32_t kPostscriptSize = 20;

--- a/dwio/nimble/tablet/NimbleFeatureVersion.h
+++ b/dwio/nimble/tablet/NimbleFeatureVersion.h
@@ -1,0 +1,102 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <cstdint>
+#include <limits>
+
+namespace facebook::nimble {
+
+/// Represents a Nimble file format version as (major, minor).
+/// Comparison is lexicographic: major is compared first, then minor.
+struct NimbleVersion {
+  uint16_t major;
+  uint16_t minor;
+
+  constexpr bool operator<(const NimbleVersion& other) const {
+    return major < other.major || (major == other.major && minor < other.minor);
+  }
+
+  constexpr bool operator<=(const NimbleVersion& other) const {
+    return !(other < *this);
+  }
+
+  constexpr bool operator>=(const NimbleVersion& other) const {
+    return !(*this < other);
+  }
+
+  constexpr bool operator==(const NimbleVersion& other) const {
+    return major == other.major && minor == other.minor;
+  }
+
+  constexpr bool operator!=(const NimbleVersion& other) const {
+    return !(*this == other);
+  }
+
+  constexpr bool operator>(const NimbleVersion& other) const {
+    return other < *this;
+  }
+};
+
+/// Defines the version range [introduced, deprecated) for a feature.
+/// A feature is active when: version >= introduced AND version < deprecated.
+/// Use kMaxVersion for deprecated to indicate a feature that is not yet
+/// deprecated.
+struct NimbleFeatureVersionRange {
+  NimbleVersion introduced;
+  NimbleVersion deprecated;
+
+  constexpr bool isActive(const NimbleVersion& version) const {
+    return version >= introduced && version < deprecated;
+  }
+};
+
+/// Sentinel version representing "not deprecated" (no upper bound).
+constexpr NimbleVersion kMaxVersion{
+    std::numeric_limits<uint16_t>::max(),
+    std::numeric_limits<uint16_t>::max()};
+
+/// Version ranges for each feature.
+/// When adding a new feature:
+///   1. Add a constexpr NimbleFeatureVersionRange here with the introduced
+///      version and kMaxVersion as the deprecated version.
+///   2. Bump kVersionMajor/kVersionMinor in Constants.h to match.
+///   3. In the writer, gate the new behavior on the current version.
+///   4. In the reader, gate decoding on the file's version.
+///
+/// When deprecating a feature, set the deprecated version to the version
+/// that removes it.
+
+/// Version (0, 1): Baseline Nimble format.
+
+/// Version (0, 2): Varint-encoded row counts in encoding prefixes.
+/// When active AND index is enabled, encoding prefixes use variable-length
+/// row counts instead of fixed 4-byte uint32.
+constexpr NimbleFeatureVersionRange kVersionRangeVarintRowCount{
+    {0, 2},
+    kMaxVersion};
+
+/// Returns true if the given file version supports varint row counts.
+/// Callers on the read side must also check that the file has an index section,
+/// since varint row counts are bundled with the index feature for safe rollout.
+constexpr bool hasVarintRowCount(uint32_t majorVersion, uint32_t minorVersion) {
+  return kVersionRangeVarintRowCount.isActive(
+      NimbleVersion{
+          static_cast<uint16_t>(majorVersion),
+          static_cast<uint16_t>(minorVersion)});
+}
+
+} // namespace facebook::nimble

--- a/dwio/nimble/tablet/TabletReader.h
+++ b/dwio/nimble/tablet/TabletReader.h
@@ -30,6 +30,7 @@
 #include "dwio/nimble/tablet/FileLayout.h"
 #include "dwio/nimble/tablet/MetadataBuffer.h"
 #include "dwio/nimble/tablet/MetadataCache.h"
+#include "dwio/nimble/tablet/NimbleFeatureVersion.h"
 #include "folly/Synchronized.h"
 #include "velox/common/file/File.h"
 #include "velox/dwio/common/MetricsLog.h"
@@ -243,6 +244,15 @@ class TabletReader {
 
   // Returns true if the file has a cluster index optional section.
   bool hasClusterIndexSection() const;
+
+  // Returns true if this file uses varint-encoded row counts in encoding
+  // prefixes. Combines version check (>= 0.2) with index section presence.
+  // TODO: Once all readers support varint row counts (version >= 0.2), enable
+  // varint unconditionally and remove the index check.
+  bool useVarintRowCount() const {
+    return hasVarintRowCount(majorVersion(), minorVersion()) &&
+        hasClusterIndexSection();
+  }
 
   // Returns true if the cluster index is loaded.
   inline bool hasClusterIndex() const {

--- a/dwio/nimble/tablet/tests/NimbleFeatureVersionTest.cpp
+++ b/dwio/nimble/tablet/tests/NimbleFeatureVersionTest.cpp
@@ -1,0 +1,97 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "dwio/nimble/tablet/NimbleFeatureVersion.h"
+#include <gtest/gtest.h>
+
+namespace facebook::nimble {
+namespace {
+
+TEST(NimbleFeatureVersionTest, VersionComparison) {
+  // Equal versions.
+  EXPECT_EQ((NimbleVersion{0, 1}), (NimbleVersion{0, 1}));
+  EXPECT_EQ((NimbleVersion{1, 0}), (NimbleVersion{1, 0}));
+
+  // Less-than: minor version difference.
+  EXPECT_LT((NimbleVersion{0, 1}), (NimbleVersion{0, 2}));
+  EXPECT_LT((NimbleVersion{0, 0}), (NimbleVersion{0, 1}));
+
+  // Less-than: major version takes precedence.
+  EXPECT_LT((NimbleVersion{0, 99}), (NimbleVersion{1, 0}));
+  EXPECT_LT((NimbleVersion{0, 2}), (NimbleVersion{1, 0}));
+
+  // Greater-than.
+  EXPECT_GT((NimbleVersion{0, 2}), (NimbleVersion{0, 1}));
+  EXPECT_GT((NimbleVersion{1, 0}), (NimbleVersion{0, 99}));
+
+  // Less-than-or-equal.
+  EXPECT_LE((NimbleVersion{0, 1}), (NimbleVersion{0, 1}));
+  EXPECT_LE((NimbleVersion{0, 1}), (NimbleVersion{0, 2}));
+
+  // Greater-than-or-equal.
+  EXPECT_GE((NimbleVersion{0, 2}), (NimbleVersion{0, 2}));
+  EXPECT_GE((NimbleVersion{0, 2}), (NimbleVersion{0, 1}));
+
+  // Not-equal.
+  EXPECT_NE((NimbleVersion{0, 1}), (NimbleVersion{0, 2}));
+  EXPECT_NE((NimbleVersion{0, 1}), (NimbleVersion{1, 1}));
+}
+
+TEST(NimbleFeatureVersionTest, HasVarintRowCount) {
+  // Baseline version (0, 1) does not support varint row count.
+  EXPECT_FALSE(hasVarintRowCount(0, 1));
+  EXPECT_FALSE(hasVarintRowCount(0, 0));
+
+  // Version (0, 2) and above support varint row count.
+  EXPECT_TRUE(hasVarintRowCount(0, 2));
+  EXPECT_TRUE(hasVarintRowCount(0, 3));
+
+  // Major version bump also implies support.
+  EXPECT_TRUE(hasVarintRowCount(1, 0));
+  EXPECT_TRUE(hasVarintRowCount(1, 1));
+}
+
+TEST(NimbleFeatureVersionTest, FeatureVersionRange) {
+  // Active range: [introduced, deprecated).
+  constexpr NimbleFeatureVersionRange range{{0, 2}, {1, 0}};
+  EXPECT_FALSE(range.isActive(NimbleVersion{0, 1}));
+  EXPECT_TRUE(range.isActive(NimbleVersion{0, 2}));
+  EXPECT_TRUE(range.isActive(NimbleVersion{0, 99}));
+  // Deprecated at (1, 0).
+  EXPECT_FALSE(range.isActive(NimbleVersion{1, 0}));
+  EXPECT_FALSE(range.isActive(NimbleVersion{1, 1}));
+
+  // Range with kMaxVersion means never deprecated.
+  constexpr NimbleFeatureVersionRange openRange{{0, 2}, kMaxVersion};
+  EXPECT_FALSE(openRange.isActive(NimbleVersion{0, 1}));
+  EXPECT_TRUE(openRange.isActive(NimbleVersion{0, 2}));
+  EXPECT_TRUE(openRange.isActive(NimbleVersion{1, 0}));
+  EXPECT_TRUE(openRange.isActive(NimbleVersion{100, 0}));
+}
+
+TEST(NimbleFeatureVersionTest, ConstexprEvaluation) {
+  // Verify that version operations work at compile time.
+  static_assert(NimbleVersion{0, 1} < NimbleVersion{0, 2});
+  static_assert(NimbleVersion{0, 2} == NimbleVersion{0, 2});
+  static_assert(NimbleVersion{0, 99} < NimbleVersion{1, 0});
+  static_assert(hasVarintRowCount(0, 2));
+  static_assert(!hasVarintRowCount(0, 1));
+  static_assert(kVersionRangeVarintRowCount.introduced == NimbleVersion{0, 2});
+  static_assert(kVersionRangeVarintRowCount.deprecated == kMaxVersion);
+}
+
+} // namespace
+} // namespace facebook::nimble

--- a/dwio/nimble/tools/EncodingSelectionLogger.cpp
+++ b/dwio/nimble/tools/EncodingSelectionLogger.cpp
@@ -66,7 +66,8 @@ void logEncodingSelection(const std::vector<std::string>& source) {
       nimble::EncodingFactory::encode<T>(std::move(policy), values, buffer);
 
   LOG(INFO) << "Encoding: " << GREEN
-            << nimble::tools::getEncodingLabel(serialized) << RESET_COLOR;
+            << nimble::tools::getEncodingLabel(serialized, false)
+            << RESET_COLOR;
 }
 
 int main(int argc, char* argv[]) {

--- a/dwio/nimble/tools/EncodingUtilities.cpp
+++ b/dwio/nimble/tools/EncodingUtilities.cpp
@@ -15,22 +15,35 @@
  */
 #include "dwio/nimble/tools/EncodingUtilities.h"
 #include "dwio/nimble/common/Exceptions.h"
+#include "dwio/nimble/common/Varint.h"
 
 namespace facebook::nimble::tools {
 namespace {
-constexpr uint32_t kEncodingPrefixSize = 6;
+constexpr uint32_t kFixedEncodingPrefixSize = 6;
+
+// Computes the encoding prefix size (encoding type + data type + row count).
+// Row count is either 4 bytes (fixed) or varint-encoded.
+uint32_t encodingPrefixSize(std::string_view stream, bool useVarintRowCount) {
+  if (!useVarintRowCount) {
+    return kFixedEncodingPrefixSize;
+  }
+  const char* pos = stream.data() + 2;
+  varint::skipVarint(&pos);
+  return static_cast<uint32_t>(pos - stream.data());
+}
 
 void extractCompressionType(
     EncodingType encodingType,
     DataType /* dataType */,
     std::string_view stream,
+    bool useVarintRowCount,
     std::unordered_map<EncodingPropertyType, EncodingProperty>& properties) {
   switch (encodingType) {
     // Compression type is the byte right after the encoding header for both
     // encodings.
     case EncodingType::Trivial:
     case EncodingType::FixedBitWidth: {
-      auto pos = stream.data() + kEncodingPrefixSize;
+      auto pos = stream.data() + encodingPrefixSize(stream, useVarintRowCount);
       properties.insert(
           {EncodingPropertyType::Compression,
            EncodingProperty{
@@ -57,9 +70,11 @@ std::unordered_map<EncodingPropertyType, EncodingProperty>
 extractEncodingProperties(
     EncodingType encodingType,
     DataType dataType,
-    std::string_view stream) {
+    std::string_view stream,
+    bool useVarintRowCount) {
   std::unordered_map<EncodingPropertyType, EncodingProperty> properties{};
-  extractCompressionType(encodingType, dataType, stream, properties);
+  extractCompressionType(
+      encodingType, dataType, stream, useVarintRowCount, properties);
   properties.insert(
       {EncodingPropertyType::EncodedSize,
        {.value = folly::to<std::string>(stream.size())}});
@@ -68,6 +83,7 @@ extractEncodingProperties(
 
 void traverseEncodings(
     std::string_view stream,
+    bool useVarintRowCount,
     uint32_t level,
     uint32_t index,
     const std::string& nestedEncodingName,
@@ -80,8 +96,8 @@ void traverseEncodings(
         std::unordered_map<
             EncodingPropertyType,
             EncodingProperty> /* properties */)> visitor) {
-  NIMBLE_CHECK(
-      stream.size() >= kEncodingPrefixSize, "Unexpected end of stream.");
+  const uint32_t prefixSize = encodingPrefixSize(stream, useVarintRowCount);
+  NIMBLE_CHECK(stream.size() >= prefixSize, "Unexpected end of stream.");
 
   const EncodingType encodingType = static_cast<EncodingType>(stream[0]);
   auto dataType = static_cast<DataType>(stream[1]);
@@ -91,7 +107,8 @@ void traverseEncodings(
       level,
       index,
       nestedEncodingName,
-      extractEncodingProperties(encodingType, dataType, stream));
+      extractEncodingProperties(
+          encodingType, dataType, stream, useVarintRowCount));
 
   if (!continueTraversal) {
     return;
@@ -107,17 +124,23 @@ void traverseEncodings(
     }
     case EncodingType::Trivial: {
       if (dataType == DataType::String) {
-        const char* pos = stream.data() + kEncodingPrefixSize + 1;
+        const char* pos = stream.data() + prefixSize + 1;
         const uint32_t lengthsBytes = encoding::readUint32(pos);
         traverseEncodings(
-            {pos, lengthsBytes}, level + 1, 0, "Lengths", visitor);
+            {pos, lengthsBytes},
+            useVarintRowCount,
+            level + 1,
+            0,
+            "Lengths",
+            visitor);
       }
       break;
     }
     case EncodingType::SparseBool: {
-      const char* pos = stream.data() + kEncodingPrefixSize + 1;
+      const char* pos = stream.data() + prefixSize + 1;
       traverseEncodings(
           {pos, stream.size() - (pos - stream.data())},
+          useVarintRowCount,
           level + 1,
           0,
           "Indices",
@@ -125,24 +148,40 @@ void traverseEncodings(
       break;
     }
     case EncodingType::MainlyConstant: {
-      const char* pos = stream.data() + kEncodingPrefixSize;
+      const char* pos = stream.data() + prefixSize;
       const uint32_t isCommonBytes = encoding::readUint32(pos);
       traverseEncodings(
-          {pos, isCommonBytes}, level + 1, 0, "IsCommon", visitor);
+          {pos, isCommonBytes},
+          useVarintRowCount,
+          level + 1,
+          0,
+          "IsCommon",
+          visitor);
       pos += isCommonBytes;
       const uint32_t otherValueBytes = encoding::readUint32(pos);
       traverseEncodings(
-          {pos, otherValueBytes}, level + 1, 1, "OtherValues", visitor);
+          {pos, otherValueBytes},
+          useVarintRowCount,
+          level + 1,
+          1,
+          "OtherValues",
+          visitor);
       break;
     }
     case EncodingType::Dictionary: {
-      const char* pos = stream.data() + kEncodingPrefixSize;
+      const char* pos = stream.data() + prefixSize;
       const uint32_t alphabetBytes = encoding::readUint32(pos);
       traverseEncodings(
-          {pos, alphabetBytes}, level + 1, 0, "Alphabet", visitor);
+          {pos, alphabetBytes},
+          useVarintRowCount,
+          level + 1,
+          0,
+          "Alphabet",
+          visitor);
       pos += alphabetBytes;
       traverseEncodings(
           {pos, stream.size() - (pos - stream.data())},
+          useVarintRowCount,
           level + 1,
           1,
           "Indices",
@@ -150,14 +189,20 @@ void traverseEncodings(
       break;
     }
     case EncodingType::RLE: {
-      const char* pos = stream.data() + kEncodingPrefixSize;
+      const char* pos = stream.data() + prefixSize;
       const uint32_t runLengthBytes = encoding::readUint32(pos);
       traverseEncodings(
-          {pos, runLengthBytes}, level + 1, 0, "Lengths", visitor);
+          {pos, runLengthBytes},
+          useVarintRowCount,
+          level + 1,
+          0,
+          "Lengths",
+          visitor);
       if (dataType != DataType::Bool) {
         pos += runLengthBytes;
         traverseEncodings(
             {pos, stream.size() - (pos - stream.data())},
+            useVarintRowCount,
             level + 1,
             1,
             "Values",
@@ -166,16 +211,28 @@ void traverseEncodings(
       break;
     }
     case EncodingType::Delta: {
-      const char* pos = stream.data() + kEncodingPrefixSize;
+      const char* pos = stream.data() + prefixSize;
       const uint32_t deltaBytes = encoding::readUint32(pos);
       const uint32_t restatementBytes = encoding::readUint32(pos);
-      traverseEncodings({pos, deltaBytes}, level + 1, 0, "Deltas", visitor);
+      traverseEncodings(
+          {pos, deltaBytes},
+          useVarintRowCount,
+          level + 1,
+          0,
+          "Deltas",
+          visitor);
       pos += deltaBytes;
       traverseEncodings(
-          {pos, restatementBytes}, level + 1, 1, "Restatements", visitor);
+          {pos, restatementBytes},
+          useVarintRowCount,
+          level + 1,
+          1,
+          "Restatements",
+          visitor);
       pos += restatementBytes;
       traverseEncodings(
           {pos, stream.size() - (pos - stream.data())},
+          useVarintRowCount,
           level + 1,
           2,
           "IsRestatements",
@@ -183,12 +240,14 @@ void traverseEncodings(
       break;
     }
     case EncodingType::Nullable: {
-      const char* pos = stream.data() + kEncodingPrefixSize;
+      const char* pos = stream.data() + prefixSize;
       const uint32_t dataBytes = encoding::readUint32(pos);
-      traverseEncodings({pos, dataBytes}, level + 1, 0, "Data", visitor);
+      traverseEncodings(
+          {pos, dataBytes}, useVarintRowCount, level + 1, 0, "Data", visitor);
       pos += dataBytes;
       traverseEncodings(
           {pos, stream.size() - (pos - stream.data())},
+          useVarintRowCount,
           level + 1,
           1,
           "Nulls",
@@ -196,9 +255,10 @@ void traverseEncodings(
       break;
     }
     case EncodingType::Sentinel: {
-      const char* pos = stream.data() + kEncodingPrefixSize + 8;
+      const char* pos = stream.data() + prefixSize + 8;
       traverseEncodings(
           {pos, stream.size() - (pos - stream.data())},
+          useVarintRowCount,
           level + 1,
           0,
           "Sentinels",
@@ -221,6 +281,7 @@ std::ostream& operator<<(std::ostream& out, EncodingPropertyType propertyType) {
 
 void traverseEncodings(
     std::string_view stream,
+    bool useVarintRowCount,
     std::function<bool(
         EncodingType,
         DataType,
@@ -230,10 +291,12 @@ void traverseEncodings(
         std::unordered_map<
             EncodingPropertyType,
             EncodingProperty> /* properties */)> visitor) {
-  traverseEncodings(stream, 0, 0, "", visitor);
+  traverseEncodings(stream, useVarintRowCount, 0, 0, "", visitor);
 }
 
-std::string getStreamInputLabel(nimble::ChunkedStream& stream) {
+std::string getStreamInputLabel(
+    nimble::ChunkedStream& stream,
+    bool useVarintRowCount) {
   std::string label;
   uint32_t chunkId = 0;
   while (stream.hasNext()) {
@@ -242,7 +305,7 @@ std::string getStreamInputLabel(nimble::ChunkedStream& stream) {
     if (compression != CompressionType::Uncompressed) {
       label += "{" + toString(compression) + "}";
     }
-    label += ":" + getEncodingLabel(stream.nextChunk());
+    label += ":" + getEncodingLabel(stream.nextChunk(), useVarintRowCount);
 
     if (stream.hasNext()) {
       label += ";";
@@ -251,12 +314,13 @@ std::string getStreamInputLabel(nimble::ChunkedStream& stream) {
   return label;
 }
 
-std::string getEncodingLabel(std::string_view stream) {
+std::string getEncodingLabel(std::string_view stream, bool useVarintRowCount) {
   std::string label;
   uint32_t currentLevel = 0;
 
   traverseEncodings(
       stream,
+      useVarintRowCount,
       [&](EncodingType encodingType,
           DataType dataType,
           uint32_t level,

--- a/dwio/nimble/tools/EncodingUtilities.h
+++ b/dwio/nimble/tools/EncodingUtilities.h
@@ -39,6 +39,7 @@ struct EncodingProperty {
 
 void traverseEncodings(
     std::string_view stream,
+    bool useVarintRowCount,
     std::function<bool(
         EncodingType,
         DataType,
@@ -49,7 +50,9 @@ void traverseEncodings(
             EncodingPropertyType,
             EncodingProperty> /* properties */)> visitor);
 
-std::string getStreamInputLabel(nimble::ChunkedStream& stream);
-std::string getEncodingLabel(std::string_view stream);
+std::string getStreamInputLabel(
+    nimble::ChunkedStream& stream,
+    bool useVarintRowCount);
+std::string getEncodingLabel(std::string_view stream, bool useVarintRowCount);
 
 } // namespace facebook::nimble::tools

--- a/dwio/nimble/tools/NimbleDslLib.cpp
+++ b/dwio/nimble/tools/NimbleDslLib.cpp
@@ -543,8 +543,8 @@ void NimbleDslLib::showStats() {
     return;
   }
 
-  auto fileStats =
-      VectorizedFileStats::deserialize(statsSection->content(), *pool_);
+  auto fileStats = VectorizedFileStats::deserialize(
+      statsSection->content(), tablet->useVarintRowCount(), *pool_);
   if (!fileStats) {
     ostream_ << RED(enableColors_) << "Failed to deserialize statistics."
              << RESET_COLOR(enableColors_) << std::endl;
@@ -650,6 +650,8 @@ void NimbleDslLib::showEncoding(std::optional<uint32_t> stripeId) {
        {"Stream Label", 25, Alignment::Left},
        {"Encoding", 60, Alignment::Left}}};
 
+  const bool useVarint = tablet->useVarintRowCount();
+
   if (tablet->stripeCount() == 0) {
     return;
   }
@@ -670,7 +672,7 @@ void NimbleDslLib::showEncoding(std::optional<uint32_t> stripeId) {
       auto& stream = streams[j];
       if (stream) {
         InMemoryChunkedStream chunkedStream{*pool_, std::move(stream)};
-        auto encodingLabel = getStreamInputLabel(chunkedStream);
+        auto encodingLabel = getStreamInputLabel(chunkedStream, useVarint);
         formatter.writeRow({
             std::to_string(i),
             std::to_string(j),

--- a/dwio/nimble/tools/NimbleDumpLib.cpp
+++ b/dwio/nimble/tools/NimbleDumpLib.cpp
@@ -559,6 +559,7 @@ void NimbleDumpLib::emitStreams(
     }
   }
 
+  const bool useVarint = tabletReader->useVarintRowCount();
   traverseTablet(
       *pool_,
       *tabletReader,
@@ -568,12 +569,16 @@ void NimbleDumpLib::emitStreams(
         auto stripeIdentifier = tabletReader->stripeIdentifier(stripeId);
         uint32_t itemCount = 0;
         uint64_t rawStreamSize = 0;
+        const EncodingFactory factory{
+            Encoding::Options{.useVarintRowCount = useVarint}};
         while (stream.hasNext()) {
           auto chunk = stream.nextChunk();
-          itemCount += *reinterpret_cast<const uint32_t*>(chunk.data() + 2);
+          auto encoding =
+              factory.create(*pool_, chunk, [](uint32_t) { return nullptr; });
+          itemCount += encoding->rowCount();
           if (showStreamRawSize) {
-            rawStreamSize +=
-                nimble::test::TestUtils::getRawDataSize(*pool_, chunk);
+            rawStreamSize += nimble::test::TestUtils::getRawDataSize(
+                *pool_, chunk, useVarint);
           }
         }
 
@@ -597,7 +602,7 @@ void NimbleDumpLib::emitStreams(
         if (showInMapStream) {
           values.emplace_back(inMapStreams.contains(streamId) ? "T" : "F");
         }
-        values.push_back(getStreamInputLabel(stream));
+        values.push_back(getStreamInputLabel(stream, useVarint));
         formatter.writeRow(values);
       });
 }
@@ -618,6 +623,7 @@ void NimbleDumpLib::emitHistogram(
       {toString(CompressionType::Zstd), CompressionType::Zstd},
       {toString(CompressionType::MetaInternal), CompressionType::MetaInternal},
   };
+  const bool useVarint = tabletReader->useVarintRowCount();
   traverseTablet(
       *pool_,
       *tabletReader,
@@ -627,6 +633,7 @@ void NimbleDumpLib::emitHistogram(
         while (stream.hasNext()) {
           traverseEncodings(
               stream.nextChunk(),
+              useVarint,
               [&](EncodingType encodingType,
                   DataType dataType,
                   uint32_t level,
@@ -715,10 +722,13 @@ void NimbleDumpLib::emitContent(
           velox::AlignedBuffer::allocate<char>(totalLength, pool_.get()));
       return buffer->asMutable<void>();
     };
+    const bool useVarint = tabletReader->useVarintRowCount();
     if (auto& stream = streams[0]) {
+      const EncodingFactory factory{
+          Encoding::Options{.useVarintRowCount = useVarint}};
       InMemoryChunkedStream chunkedStream{*pool_, std::move(stream)};
       while (chunkedStream.hasNext()) {
-        auto encoding = EncodingFactory().create(
+        auto encoding = factory.create(
             *pool_, chunkedStream.nextChunk(), stringBufferFactory);
         uint32_t totalRows = encoding->rowCount();
         while (totalRows > 0) {

--- a/dwio/nimble/tools/tests/EncodingUtilitiesTest.cpp
+++ b/dwio/nimble/tools/tests/EncodingUtilitiesTest.cpp
@@ -101,7 +101,7 @@ TEST_F(EncodingUtilitiesTest, EncodingPropertyTypeStreamOperator) {
 
 TEST_F(EncodingUtilitiesTest, GetEncodingLabelTrivial) {
   auto stream = buildTrivialUint32Stream({10, 20, 30});
-  auto label = getEncodingLabel(stream);
+  auto label = getEncodingLabel(stream, false);
   // Should contain "Trivial" and "Uint32"
   EXPECT_NE(label.find("Trivial"), std::string::npos);
   EXPECT_NE(label.find("Uint32"), std::string::npos);
@@ -111,7 +111,7 @@ TEST_F(EncodingUtilitiesTest, GetEncodingLabelTrivial) {
 
 TEST_F(EncodingUtilitiesTest, GetEncodingLabelConstant) {
   auto stream = buildConstantUint32Stream(42, 100);
-  auto label = getEncodingLabel(stream);
+  auto label = getEncodingLabel(stream, false);
   EXPECT_NE(label.find("Constant"), std::string::npos);
   EXPECT_NE(label.find("Uint32"), std::string::npos);
 }
@@ -125,6 +125,7 @@ TEST_F(EncodingUtilitiesTest, TraverseEncodingsTrivialVisitor) {
 
   traverseEncodings(
       stream,
+      false,
       [&](EncodingType encodingType,
           DataType dataType,
           uint32_t level,
@@ -158,6 +159,7 @@ TEST_F(EncodingUtilitiesTest, TraverseEncodingsConstantVisitor) {
 
   traverseEncodings(
       stream,
+      false,
       [&](EncodingType encodingType,
           DataType dataType,
           uint32_t level,
@@ -188,6 +190,7 @@ TEST_F(EncodingUtilitiesTest, TraverseEncodingsEarlyStop) {
 
   traverseEncodings(
       stream,
+      false,
       [&](EncodingType /* encodingType */,
           DataType /* dataType */,
           uint32_t /* level */,
@@ -208,6 +211,7 @@ TEST_F(EncodingUtilitiesTest, TraverseEncodingsEncodedSizeValue) {
 
   traverseEncodings(
       stream,
+      false,
       [&](EncodingType /* encodingType */,
           DataType /* dataType */,
           uint32_t /* level */,
@@ -238,7 +242,7 @@ TEST_F(EncodingUtilitiesTest, GetEncodingLabelWithRealTrivialEncoding) {
   auto encoded =
       nimble::test::Encoder<nimble::TrivialEncoding<uint32_t>>::encode(
           buffer, values);
-  auto label = getEncodingLabel(encoded);
+  auto label = getEncodingLabel(encoded, false);
   EXPECT_NE(label.find("Trivial"), std::string::npos);
   EXPECT_NE(label.find("Uint32"), std::string::npos);
 }
@@ -253,7 +257,7 @@ TEST_F(EncodingUtilitiesTest, GetEncodingLabelWithRealConstantEncoding) {
   auto encoded =
       nimble::test::Encoder<nimble::ConstantEncoding<uint32_t>>::encode(
           buffer, values);
-  auto label = getEncodingLabel(encoded);
+  auto label = getEncodingLabel(encoded, false);
   EXPECT_NE(label.find("Constant"), std::string::npos);
   EXPECT_NE(label.find("Uint32"), std::string::npos);
 }

--- a/dwio/nimble/velox/IndexWriter.cpp
+++ b/dwio/nimble/velox/IndexWriter.cpp
@@ -282,7 +282,10 @@ uint32_t IndexWriter::encodeChunkData(
     Buffer& buffer,
     KeyChunk& chunk) {
   const auto encoded = EncodingFactory::encode<std::string_view>(
-      createEncodingPolicy(), data, buffer);
+      createEncodingPolicy(),
+      data,
+      buffer,
+      Encoding::Options{.useVarintRowCount = true});
   NIMBLE_CHECK(!encoded.empty());
 
   chunk.rowCount = data.size();

--- a/dwio/nimble/velox/VeloxReader.cpp
+++ b/dwio/nimble/velox/VeloxReader.cpp
@@ -19,6 +19,7 @@
 #include <optional>
 #include <vector>
 #include "dwio/nimble/common/Exceptions.h"
+#include "dwio/nimble/encodings/EncodingFactory.h"
 #include "dwio/nimble/tablet/Constants.h"
 #include "dwio/nimble/velox/ChunkedStreamDecoder.h"
 #include "dwio/nimble/velox/MetadataGenerated.h"
@@ -185,6 +186,30 @@ VeloxReader::VeloxReader(
           std::move(selector),
           std::move(params)) {}
 
+namespace {
+
+VeloxReadParams adjustParamsForVersion(
+    VeloxReadParams params,
+    const TabletReader& tabletReader) {
+  if (tabletReader.useVarintRowCount()) {
+    params.encodingFactory =
+        [](velox::memory::MemoryPool& memPool,
+           std::string_view data,
+           std::function<void*(uint32_t)> stringBufferFactory)
+        -> std::unique_ptr<Encoding> {
+      const EncodingFactory factory{
+          Encoding::Options{.useVarintRowCount = true}};
+      return factory.create(memPool, data, std::move(stringBufferFactory));
+    };
+    // Non-legacy encodings require optimized string buffer handling, as
+    // LegacyStringFieldReader cannot work with non-legacy encodings.
+    params.optimizeStringBufferHandling = true;
+  }
+  return params;
+}
+
+} // namespace
+
 VeloxReader::VeloxReader(
     std::shared_ptr<const TabletReader> tabletReader,
     velox::memory::MemoryPool& pool,
@@ -192,7 +217,7 @@ VeloxReader::VeloxReader(
     VeloxReadParams params)
     : pool_{pool},
       tabletReader_{std::move(tabletReader)},
-      parameters_{std::move(params)},
+      parameters_{adjustParamsForVersion(std::move(params), *tabletReader_)},
       schema_{loadSchema(*tabletReader_)},
       type_{
           selector ? selector->getSchema()

--- a/dwio/nimble/velox/VeloxWriter.cpp
+++ b/dwio/nimble/velox/VeloxWriter.cpp
@@ -320,12 +320,18 @@ std::string_view encode(
                 .release()));
   }
 
+  // TODO: Varint row counts are currently bundled with the index feature to
+  // allow safe rollout with mixed file/reader versions. Once all readers
+  // support varint row counts (version >= 0.2), we can enable varint
+  // unconditionally and remove this index check.
+  const Encoding::Options options{
+      .useVarintRowCount = context.options().indexConfig.has_value()};
   if (streamData.hasNulls()) {
     std::span<const bool> notNulls = streamData.nonNulls();
     return EncodingFactory::encodeNullable(
-        std::move(policy), data, notNulls, buffer);
+        std::move(policy), data, notNulls, buffer, options);
   } else {
-    return EncodingFactory::encode(std::move(policy), data, buffer);
+    return EncodingFactory::encode(std::move(policy), data, buffer, options);
   }
 }
 
@@ -849,8 +855,14 @@ void VeloxWriter::writeColumnStats() {
     VectorizedFileStats fileStats{
         context_->columnStats(), encodingMemoryPool_.get()};
     Buffer buffer{*encodingMemoryPool_};
+    // TODO: Varint row counts are currently bundled with the index feature to
+    // allow safe rollout with mixed file/reader versions. Once all readers
+    // support varint row counts (version >= 0.2), we can enable varint
+    // unconditionally and remove this index check.
+    const bool useVarintRowCount = context_->options().indexConfig.has_value();
     tabletWriter_->writeOptionalSection(
-        std::string(kVectorizedStatsSection), fileStats.serialize(buffer));
+        std::string(kVectorizedStatsSection),
+        fileStats.serialize(buffer, useVarintRowCount));
   } else {
     flatbuffers::FlatBufferBuilder builder;
     builder.Finish(

--- a/dwio/nimble/velox/index/NimbleIndexProjector.cpp
+++ b/dwio/nimble/velox/index/NimbleIndexProjector.cpp
@@ -20,6 +20,7 @@
 
 #include "dwio/nimble/index/ClusterIndexReader.h"
 #include "dwio/nimble/serializer/SerializerImpl.h"
+#include "dwio/nimble/tablet/NimbleFeatureVersion.h"
 #include "dwio/nimble/velox/SchemaUtils.h"
 #include "folly/ScopeGuard.h"
 #include "velox/common/base/SuccinctPrinter.h"
@@ -64,6 +65,7 @@ NimbleIndexProjector::NimbleIndexProjector(
       pool_{readerBase_->pool()},
       tabletIndex_{readerBase_->tablet().clusterIndex()},
       numStripes_{readerBase_->tablet().stripeCount()},
+      useVarintRowCount_{readerBase_->tablet().useVarintRowCount()},
       streams_{readerBase_} {
   NIMBLE_CHECK_NOT_NULL(
       tabletIndex_, "NimbleIndexProjector requires a tablet with an index");
@@ -268,6 +270,8 @@ NimbleIndexProjector::lookupRowRanges(
       streams_.enqueueKeyStream(),
       streams_.stripeIndex(),
       streams_.clusterIndex(),
+      EncodingFactory{
+          Encoding::Options{.useVarintRowCount = useVarintRowCount_}},
       pool_);
   streams_.load();
 

--- a/dwio/nimble/velox/index/NimbleIndexProjector.h
+++ b/dwio/nimble/velox/index/NimbleIndexProjector.h
@@ -125,6 +125,13 @@ class NimbleIndexProjector {
     return projectedNimbleType_;
   }
 
+  /// Returns true if the projected output uses varint-encoded row counts.
+  /// Callers must set DeserializerOptions::useVarintRowCount accordingly
+  /// when deserializing the kTabletRaw output.
+  bool useVarintRowCount() const {
+    return useVarintRowCount_;
+  }
+
   /// Statistics captured during project().
   struct Stats {
     /// Number of stripes read from the tablet.
@@ -224,6 +231,7 @@ class NimbleIndexProjector {
   velox::memory::MemoryPool* const pool_;
   const ClusterIndex* const tabletIndex_;
   const uint32_t numStripes_{0};
+  const bool useVarintRowCount_{false};
 
   // Projected nimble schema built from file nimble schema. Preserves
   // encoding-specific types (ArrayWithOffsets, SlidingWindowMap, FlatMap).

--- a/dwio/nimble/velox/index/tests/NimbleIndexProjectorTest.cpp
+++ b/dwio/nimble/velox/index/tests/NimbleIndexProjectorTest.cpp
@@ -215,6 +215,7 @@ TEST_P(NimbleIndexProjectorTest, basicColumnProjection) {
   auto projectedNimbleSchema = convertToNimbleType(*projectedVeloxType);
   DeserializerOptions deserOptions;
   deserOptions.hasHeader = true;
+  deserOptions.useVarintRowCount = projector.useVarintRowCount();
   Deserializer deserializer(
       projectedNimbleSchema, leafPool_.get(), deserOptions);
 
@@ -502,6 +503,7 @@ TEST_P(NimbleIndexProjectorTest, flatMapProjection) {
   auto coalesced = chunk.data.cloneCoalescedAsValue();
   DeserializerOptions deserOptions;
   deserOptions.hasHeader = true;
+  deserOptions.useVarintRowCount = projector.useVarintRowCount();
   Deserializer deserializer(
       projector.projectedNimbleType(), leafPool_.get(), deserOptions);
 
@@ -652,6 +654,7 @@ TEST_P(NimbleIndexProjectorTest, flatMapKeyProjectionSchemaComparison) {
 
   DeserializerOptions deserOptions;
   deserOptions.hasHeader = true;
+  deserOptions.useVarintRowCount = projector.useVarintRowCount();
   Deserializer deserializer(buildSchema, leafPool_.get(), deserOptions);
   VectorPtr output;
   deserializer.deserialize(data, output);
@@ -713,6 +716,7 @@ TEST_P(NimbleIndexProjectorTest, flatMapIntKeyProjection) {
   auto coalesced = chunk.data.cloneCoalescedAsValue();
   DeserializerOptions deserOptions;
   deserOptions.hasHeader = true;
+  deserOptions.useVarintRowCount = projector.useVarintRowCount();
   Deserializer deserializer(
       projector.projectedNimbleType(), leafPool_.get(), deserOptions);
 

--- a/dwio/nimble/velox/selective/ChunkedDecoder.cpp
+++ b/dwio/nimble/velox/selective/ChunkedDecoder.cpp
@@ -18,6 +18,7 @@
 
 #include "dwio/nimble/common/ChunkHeader.h"
 #include "dwio/nimble/common/Types.h"
+#include "dwio/nimble/common/Varint.h"
 #include "dwio/nimble/encodings/EncodingFactory.h"
 #include "velox/common/testutil/TestValue.h"
 
@@ -282,16 +283,24 @@ std::optional<size_t> ChunkedDecoder::estimateRowCount() const {
       kChunkCompressionTypeOffset + /*chunkCompressionType=*/1;
   constexpr int kChunkRowCountOffset =
       kEncodingOffset + Encoding::kRowCountOffset;
+  const bool useVarintRowCount = encodingFactory_->options().useVarintRowCount;
+  // With varint, row count may be up to 5 bytes; with fixed format, 4 bytes.
+  const int rowCountMaxBytes = useVarintRowCount ? 5 : 4;
   NIMBLE_CHECK(
       const_cast<ChunkedDecoder*>(this)->ensureInput(
-          kChunkRowCountOffset + sizeof(uint32_t)));
+          kChunkRowCountOffset + rowCountMaxBytes));
   if (static_cast<CompressionType>(inputData_[kChunkCompressionTypeOffset]) !=
       CompressionType::Uncompressed) {
     rowCountEstimate_ = std::nullopt;
     return rowCountEstimate_;
   }
-  rowCountEstimate_ =
-      folly::loadUnaligned<uint32_t>(inputData_ + kChunkRowCountOffset);
+  if (useVarintRowCount) {
+    const char* pos = inputData_ + kChunkRowCountOffset;
+    rowCountEstimate_ = varint::readVarint32(&pos);
+  } else {
+    rowCountEstimate_ =
+        folly::loadUnaligned<uint32_t>(inputData_ + kChunkRowCountOffset);
+  }
   return rowCountEstimate_;
 }
 
@@ -302,8 +311,13 @@ std::optional<size_t> ChunkedDecoder::estimateStringDataSize() const {
   constexpr int kChunkCompressionTypeOffset{4};
   constexpr int kEncodingOffset{
       kChunkCompressionTypeOffset + /*chunkCompressionType=*/1};
+  // Ensure enough bytes to read through the encoding prefix (encoding type +
+  // data type + row count). Varint row count is up to 5 bytes; fixed is 4.
+  constexpr int kMaxVarintRowCountBytes = 5;
   NIMBLE_CHECK(
-      const_cast<ChunkedDecoder*>(this)->ensureInput(kEncodingOffset + 6));
+      const_cast<ChunkedDecoder*>(this)->ensureInput(
+          kEncodingOffset + Encoding::kRowCountOffset +
+          kMaxVarintRowCountBytes));
   auto* pos = inputData_;
   const auto chunkSize = encoding::readUint32(pos);
   const auto compressionType =
@@ -314,25 +328,42 @@ std::optional<size_t> ChunkedDecoder::estimateStringDataSize() const {
     stringDataSizeEstimate_ = std::nullopt;
     return stringDataSizeEstimate_;
   }
-  auto encodingStart = kEncodingOffset;
+  const bool useVarintRowCount = encodingFactory_->options().useVarintRowCount;
   size_t totalSize = pos + chunkSize - inputData_;
   auto encodingType = static_cast<EncodingType>(encoding::readChar(pos));
   NIMBLE_CHECK_EQ(
       static_cast<DataType>(encoding::readChar(pos)), DataType::String);
-  const auto rowCount = encoding::readUint32(pos);
+  uint32_t rowCount;
+  if (useVarintRowCount) {
+    rowCount = varint::readVarint32(const_cast<const char**>(&pos));
+  } else {
+    rowCount = encoding::readUint32(pos);
+  }
+  // Track where the current encoding's data starts (after its prefix).
+  auto* encodingDataStart = pos;
   // Peel off nullable encoding.
   if (encodingType == EncodingType::Nullable) {
-    encodingStart += Encoding::kPrefixSize + /*nonNullEncodingSize=*/4;
+    // Ensure we have enough bytes to read the nonNulls size (4 bytes).
     NIMBLE_CHECK(
         const_cast<ChunkedDecoder*>(this)->ensureInputIncremental_hack(
-            encodingStart + 6, pos));
+            static_cast<int>((pos - inputData_) + sizeof(uint32_t)), pos));
     const auto nonNullsBytes = encoding::readUint32(pos);
+    NIMBLE_CHECK(
+        const_cast<ChunkedDecoder*>(this)->ensureInputIncremental_hack(
+            static_cast<int>((pos - inputData_) + nonNullsBytes), pos));
     // TODO: it might not require an update here.
     totalSize = pos + nonNullsBytes - inputData_;
     encodingType = static_cast<EncodingType>(encoding::readChar(pos));
     NIMBLE_CHECK_EQ(
         static_cast<DataType>(encoding::readChar(pos)), DataType::String);
-    NIMBLE_CHECK_LE(encoding::readUint32(pos), rowCount);
+    uint32_t innerRowCount;
+    if (useVarintRowCount) {
+      innerRowCount = varint::readVarint32(const_cast<const char**>(&pos));
+    } else {
+      innerRowCount = encoding::readUint32(pos);
+    }
+    NIMBLE_CHECK_LE(innerRowCount, rowCount);
+    encodingDataStart = pos;
   }
   // TODO: we will soon add simple support for other encodings before we have
   // column stats implementation. In the vast majority of cases, String types
@@ -344,8 +375,9 @@ std::optional<size_t> ChunkedDecoder::estimateStringDataSize() const {
   {
     const auto ensured =
         const_cast<ChunkedDecoder*>(this)->ensureInputIncremental_hack(
-            encodingStart + Encoding::kPrefixSize +
-                TrivialEncoding<std::string_view>::kPrefixSize,
+            static_cast<int>(
+                (encodingDataStart - inputData_) +
+                TrivialEncoding<std::string_view>::kPrefixSize),
             pos);
     NIMBLE_CHECK(ensured);
   }

--- a/dwio/nimble/velox/selective/ChunkedDecoder.h
+++ b/dwio/nimble/velox/selective/ChunkedDecoder.h
@@ -301,12 +301,16 @@ class ChunkedDecoder {
 
   /// Selects the encoding trait based on getStringBuffersFromDecoder_ and
   /// forwards to the fully-monomorphic readWithVisitorImpl.
+  /// When useVarintRowCount is enabled, we must use DefaultEncodingTrait
+  /// because the non-legacy EncodingFactory creates non-legacy encoding types
+  /// that cannot be static_cast to legacy types.
   template <bool kHasNulls, typename V>
   void dispatchReadWithVisitorImpl(
       V& visitor,
       const uint64_t* nulls,
       ReadWithVisitorParams& params) {
-    if (getStringBuffersFromDecoder_) {
+    if (getStringBuffersFromDecoder_ ||
+        encodingFactory_->options().useVarintRowCount) {
       readWithVisitorImpl<kHasNulls, DefaultEncodingTrait>(
           visitor, nulls, params);
     } else {
@@ -429,6 +433,9 @@ class ChunkedDecoder {
   // encode nulls alongside values). When false, decode values without nulls
   // (standard case for scalar types).
   const bool decodeValuesWithNulls_;
+  // TODO: Remove encodingDecoder_ (or at least its useVarintRowCount) when
+  // column stats is fully supported (we won't need the raw row count for
+  // estimation anymore).
   const EncodingFactory* const encodingFactory_;
   const bool getStringBuffersFromDecoder_{false};
   // Optional stream index for accelerating skip operations

--- a/dwio/nimble/velox/selective/ReaderBase.cpp
+++ b/dwio/nimble/velox/selective/ReaderBase.cpp
@@ -93,8 +93,8 @@ ReaderBase::ReaderBase(
         if (!statsSection.has_value()) {
           return {};
         }
-        auto fileStats =
-            VectorizedFileStats::deserialize(statsSection->content(), *pool_);
+        auto fileStats = VectorizedFileStats::deserialize(
+            statsSection->content(), tablet_->useVarintRowCount(), *pool_);
         if (!fileStats) {
           return {};
         }

--- a/dwio/nimble/velox/selective/SelectiveNimbleIndexReader.cpp
+++ b/dwio/nimble/velox/selective/SelectiveNimbleIndexReader.cpp
@@ -147,10 +147,9 @@ SelectiveNimbleIndexReader::SelectiveNimbleIndexReader(
     const dwio::common::RowReaderOptions& options)
     : readerBase_(std::move(readerBase)),
       options_(options),
-      encodingFactory_(
-          options.passStringBuffersFromDecoder()
-              ? std::make_unique<const EncodingFactory>()
-              : std::make_unique<const legacy::EncodingFactory>()),
+      encodingFactory_(makeEncodingFactory(
+          readerBase_->tablet().useVarintRowCount(),
+          options.passStringBuffersFromDecoder())),
       rowSizeTracker_(
           std::make_unique<RowSizeTracker>(readerBase_->fileSchemaWithId())),
       hasFilters_(options.scanSpec()->hasFilter()),
@@ -593,6 +592,7 @@ void SelectiveNimbleIndexReader::loadStripeWithIndex(uint32_t stripeIndex) {
       params.streams().enqueueKeyStream(),
       params.streams().stripeIndex(),
       params.streams().clusterIndex(),
+      params.encodingFactory(),
       &params.pool());
 
   streams_.load();

--- a/dwio/nimble/velox/selective/SelectiveNimbleReader.cpp
+++ b/dwio/nimble/velox/selective/SelectiveNimbleReader.cpp
@@ -20,6 +20,7 @@
 #include "dwio/nimble/index/ClusterIndexReader.h"
 #include "dwio/nimble/index/IndexConstants.h"
 #include "dwio/nimble/index/IndexFilter.h"
+#include "dwio/nimble/tablet/NimbleFeatureVersion.h"
 #include "dwio/nimble/velox/SchemaUtils.h"
 #include "dwio/nimble/velox/selective/ColumnReader.h"
 #include "dwio/nimble/velox/selective/ReaderBase.h"
@@ -118,10 +119,9 @@ class SelectiveNimbleRowReader : public dwio::common::RowReader {
       const dwio::common::RowReaderOptions& options)
       : readerBase_{readerBase},
         options_{options},
-        encodingFactory_(
-            options.passStringBuffersFromDecoder()
-                ? std::make_unique<const EncodingFactory>()
-                : std::make_unique<const legacy::EncodingFactory>()),
+        encodingFactory_(makeEncodingFactory(
+            readerBase->tablet().useVarintRowCount(),
+            options.passStringBuffersFromDecoder())),
         streams_(readerBase_),
         rowSizeTracker_{
             std::make_unique<RowSizeTracker>(readerBase->fileSchemaWithId())} {
@@ -596,6 +596,7 @@ void SelectiveNimbleRowReader::buildIndexReader(NimbleParams& params) {
       params.streams().enqueueKeyStream(),
       params.streams().stripeIndex(),
       params.streams().clusterIndex(),
+      params.encodingFactory(),
       &params.pool());
 }
 

--- a/dwio/nimble/velox/selective/tests/ChunkedDecoderTest.cpp
+++ b/dwio/nimble/velox/selective/tests/ChunkedDecoderTest.cpp
@@ -81,6 +81,9 @@ class ChunkedDecoderTestHelper {
 
 namespace {
 
+// Default encoding factory for tests (non-legacy, no varint row counts).
+const EncodingFactory kDefaultEncodingFactory;
+
 class ChunkedDecoderTest : public testing::Test {
  protected:
   static void SetUpTestCase() {
@@ -137,8 +140,8 @@ TEST_F(ChunkedDecoderTest, bufferedInput) {
 
   auto chunkedDecoder = std::make_unique<nimble::ChunkedDecoder>(
       input->read(0, kFileSize, velox::dwio::common::LogType::TEST),
-      nullptr,
-      false,
+      /*streamIndex=*/nullptr,
+      /*decodeValuesWithNulls=*/false,
       &encodingFactory(),
       &pool());
   ChunkedDecoderTestHelper helper(chunkedDecoder.get());
@@ -154,8 +157,8 @@ TEST_F(ChunkedDecoderTest, ensureInput) {
   ChunkedDecoder decoder(
       std::make_unique<dwio::common::SeekableArrayInputStream>(
           data.data(), data.size(), /*block_size=*/1),
-      nullptr,
-      false,
+      /*streamIndex=*/nullptr,
+      /*decodeValuesWithNulls=*/false,
       &encodingFactory(),
       &pool());
   ChunkedDecoderTestHelper helper(&decoder);
@@ -712,7 +715,7 @@ TEST_P(ChunkedDecoderDataTest, skipTwoChunks) {
         std::make_unique<dwio::common::SeekableArrayInputStream>(
             streamData.data(), streamData.size()),
         streamIndex,
-        false,
+        /*decodeValuesWithNulls=*/false,
         &encodingFactory(),
         pool_.get());
 
@@ -857,7 +860,7 @@ TEST_P(ChunkedDecoderDataTest, skipMultipleChunks) {
           std::make_unique<dwio::common::SeekableArrayInputStream>(
               streamData.data(), streamData.size()),
           streamIndex,
-          false,
+          /*decodeValuesWithNulls=*/false,
           &encodingFactory(),
           pool_.get());
 
@@ -916,7 +919,7 @@ TEST_P(ChunkedDecoderDataTest, skipWithinCurrentChunk) {
       std::make_unique<dwio::common::SeekableArrayInputStream>(
           streamData.data(), streamData.size()),
       streamIndex,
-      false,
+      /*decodeValuesWithNulls=*/false,
       &encodingFactory(),
       pool_.get());
 
@@ -958,7 +961,7 @@ TEST_P(ChunkedDecoderDataTest, skipEntireStream) {
       std::make_unique<dwio::common::SeekableArrayInputStream>(
           streamData.data(), streamData.size()),
       streamIndex,
-      false,
+      /*decodeValuesWithNulls=*/false,
       &encodingFactory(),
       pool_.get());
 
@@ -990,7 +993,7 @@ TEST_P(ChunkedDecoderDataTest, skipAndReadMixed) {
       std::make_unique<dwio::common::SeekableArrayInputStream>(
           streamData.data(), streamData.size()),
       streamIndex,
-      false,
+      /*decodeValuesWithNulls=*/false,
       &encodingFactory(),
       pool_.get());
 
@@ -1046,7 +1049,7 @@ DEBUG_ONLY_TEST_P(ChunkedDecoderDataTest, skipChunkWithIndexCheck) {
       std::make_unique<dwio::common::SeekableArrayInputStream>(
           streamData.data(), streamData.size()),
       streamIndex,
-      false,
+      /*decodeValuesWithNulls=*/false,
       &encodingFactory(),
       pool_.get());
 
@@ -1217,15 +1220,15 @@ TEST_F(ChunkedDecoderDataTest, fuzzer) {
         std::make_unique<dwio::common::SeekableArrayInputStream>(
             streamData.data(), streamData.size()),
         streamIndex,
-        false,
+        /*decodeValuesWithNulls=*/false,
         &encodingFactory(),
         pool_.get());
 
     ChunkedDecoder decoderWithoutIndex(
         std::make_unique<dwio::common::SeekableArrayInputStream>(
             streamData.data(), streamData.size()),
-        nullptr,
-        false,
+        /*streamIndex=*/nullptr,
+        /*decodeValuesWithNulls=*/false,
         &encodingFactory(),
         pool_.get());
 

--- a/dwio/nimble/velox/selective/tests/E2EFilterTest.cpp
+++ b/dwio/nimble/velox/selective/tests/E2EFilterTest.cpp
@@ -467,8 +467,13 @@ class E2EFilterTest
         if (!chunkedStream.hasNext()) {
           continue;
         }
-        auto capture =
-            EncodingLayoutCapture::capture(chunkedStream.nextChunk());
+        // TODO: Varint row counts are currently bundled with the index
+        // feature to allow safe rollout with mixed file/reader versions.
+        // Once all readers support varint row counts (version >= 0.2), we
+        // can enable varint unconditionally and remove this index check.
+        auto capture = EncodingLayoutCapture::capture(
+            chunkedStream.nextChunk(),
+            /*useVarintRowCount=*/tablet->hasClusterIndexSection());
         // The top-level encoding may be Nullable (wrapping the data encoding)
         // or the data encoding directly.
         if (capture.encodingType() == EncodingType::Nullable) {

--- a/dwio/nimble/velox/selective/tests/SelectiveNimbleReaderTest.cpp
+++ b/dwio/nimble/velox/selective/tests/SelectiveNimbleReaderTest.cpp
@@ -333,7 +333,8 @@ class SelectiveNimbleReaderTest
 
       InMemoryChunkedStream chunkedStream{*pool(), std::move(streams[0])};
       ASSERT_TRUE(chunkedStream.hasNext());
-      auto capture = EncodingLayoutCapture::capture(chunkedStream.nextChunk());
+      auto capture = EncodingLayoutCapture::capture(
+          chunkedStream.nextChunk(), /*useVarintRowCount=*/false);
       if (isNullable) {
         // Nullable encoding wraps the data encoding. The data child is at
         // index 1 (index 0 is the nulls bool stream).

--- a/dwio/nimble/velox/stats/VectorizedStatistics.cpp
+++ b/dwio/nimble/velox/stats/VectorizedStatistics.cpp
@@ -76,24 +76,31 @@ std::optional<T> TypedVectorizedStatistic<T>::valueAt(size_t idx) const {
 template <typename T>
 std::string_view TypedVectorizedStatistic<T>::serialize(
     const EncodingSelectionPolicyFactory& encodingSelectionPolicyFactory,
-    nimble::Buffer& buffer) {
+    nimble::Buffer& buffer,
+    bool useVarintRowCount) {
   auto policy = std::unique_ptr<EncodingSelectionPolicy<T>>(
       static_cast<EncodingSelectionPolicy<T>*>(
           encodingSelectionPolicyFactory(TypeTraits<T>::dataType).release()));
   return EncodingFactory::encodeNullable<T>(
-      std::move(policy), values_, isValid_, buffer);
+      std::move(policy),
+      values_,
+      isValid_,
+      buffer,
+      Encoding::Options{.useVarintRowCount = useVarintRowCount});
 }
 
 template <typename T>
 void TypedVectorizedStatistic<T>::deserializeFrom(
     std::string_view payload,
+    bool useVarintRowCount,
     velox::memory::MemoryPool& pool) {
-  auto encoding =
-      EncodingFactory().create(pool, payload, [&](uint32_t totalLength) {
-        auto& buffer = stringBuffers_.emplace_back(
-            velox::AlignedBuffer::allocate<char>(totalLength, &pool));
-        return buffer->template asMutable<void>();
-      });
+  const EncodingFactory factory{
+      Encoding::Options{.useVarintRowCount = useVarintRowCount}};
+  auto encoding = factory.create(pool, payload, [&](uint32_t totalLength) {
+    auto& buffer = stringBuffers_.emplace_back(
+        velox::AlignedBuffer::allocate<char>(totalLength, &pool));
+    return buffer->template asMutable<void>();
+  });
   NIMBLE_CHECK_NOT_NULL(encoding);
   const auto& rowCount = encoding->rowCount();
   velox::BufferPtr nullsBuffer =
@@ -140,13 +147,15 @@ void TypedVectorizedStatistic<T>::deserializeFrom(
 template <>
 inline void TypedVectorizedStatistic<std::string_view>::deserializeFrom(
     std::string_view payload,
+    bool useVarintRowCount,
     velox::memory::MemoryPool& pool) {
-  auto encoding =
-      EncodingFactory().create(pool, payload, [&](uint32_t totalLength) {
-        auto& buffer = stringBuffers_.emplace_back(
-            velox::AlignedBuffer::allocate<char>(totalLength, &pool));
-        return buffer->template asMutable<void>();
-      });
+  const EncodingFactory factory{
+      Encoding::Options{.useVarintRowCount = useVarintRowCount}};
+  auto encoding = factory.create(pool, payload, [&](uint32_t totalLength) {
+    auto& buffer = stringBuffers_.emplace_back(
+        velox::AlignedBuffer::allocate<char>(totalLength, &pool));
+    return buffer->template asMutable<void>();
+  });
   NIMBLE_CHECK_NOT_NULL(encoding);
   const auto rowCount = encoding->rowCount();
   velox::BufferPtr nullsBuffer =
@@ -380,7 +389,9 @@ void VectorizedFileStats::addColumnStat(ColumnStatistics* stat) {
 // lengths encoding flag: 1 byte (0 = unencoded)
 // stat stream lengths: 8 bytes each, one per stat stream type
 // stat streams: independent encodings
-std::string_view VectorizedFileStats::serialize(nimble::Buffer& buffer) {
+std::string_view VectorizedFileStats::serialize(
+    nimble::Buffer& buffer,
+    bool useVarintRowCount) {
   uint64_t totalLength = 0;
   // add version
   totalLength += sizeof(uint16_t);
@@ -400,8 +411,8 @@ std::string_view VectorizedFileStats::serialize(nimble::Buffer& buffer) {
   // Serialize each stat stream
   std::vector<std::string_view> encodedStatStreams{};
   for (auto& statStream : statStreams_) {
-    auto encoded =
-        statStream.second->serialize(encodingSelectionPolicyFactory_, buffer);
+    auto encoded = statStream.second->serialize(
+        encodingSelectionPolicyFactory_, buffer, useVarintRowCount);
     encodedStatStreams.push_back(encoded);
     totalLength += encoded.size();
   }
@@ -444,6 +455,7 @@ std::string_view VectorizedFileStats::serialize(nimble::Buffer& buffer) {
 /* static */ std::unique_ptr<VectorizedFileStats>
 VectorizedFileStats::deserialize(
     const std::string_view payload,
+    bool useVarintRowCount,
     velox::memory::MemoryPool& pool) {
   auto pos = payload.data();
   auto totalLength = payload.size();
@@ -476,6 +488,7 @@ VectorizedFileStats::deserialize(
       statStreamTypes,
       streamLengths,
       std::string_view{pos, totalLength - (pos - payload.data())},
+      useVarintRowCount,
       pool));
 }
 
@@ -483,12 +496,16 @@ VectorizedFileStats::VectorizedFileStats(
     const std::vector<StatStreamType>& streamTypes,
     const std::vector<uint64_t>& streamLengths,
     std::string_view statStreams,
+    bool useVarintRowCount,
     velox::memory::MemoryPool& pool) {
   NIMBLE_CHECK_EQ(streamTypes.size(), streamLengths.size());
   auto pos = statStreams.data();
   for (size_t i = 0; i < streamTypes.size(); ++i) {
     if (auto vectorizedStat = deserializeVectorizedStatistic(
-            streamTypes[i], std::string_view{pos, streamLengths[i]}, pool)) {
+            streamTypes[i],
+            std::string_view{pos, streamLengths[i]},
+            useVarintRowCount,
+            pool)) {
       statStreams_.emplace(streamTypes[i], std::move(vectorizedStat));
       switch (streamTypes[i]) {
         case StatStreamType::VALUE_COUNT:
@@ -523,6 +540,7 @@ std::unique_ptr<VectorizedStatistic>
 VectorizedFileStats::deserializeVectorizedStatistic(
     StatStreamType streamType,
     std::string_view payload,
+    bool useVarintRowCount,
     velox::memory::MemoryPool& pool) {
   auto stat = VectorizedStatistic::create(streamType, &pool);
   if (UNLIKELY(!stat)) {
@@ -530,7 +548,7 @@ VectorizedFileStats::deserializeVectorizedStatistic(
               << static_cast<uint8_t>(streamType);
     return stat;
   }
-  stat->deserializeFrom(payload, pool);
+  stat->deserializeFrom(payload, useVarintRowCount, pool);
   return stat;
 }
 

--- a/dwio/nimble/velox/stats/VectorizedStatistics.h
+++ b/dwio/nimble/velox/stats/VectorizedStatistics.h
@@ -70,10 +70,12 @@ class VectorizedStatistic {
 
   virtual std::string_view serialize(
       const EncodingSelectionPolicyFactory& encodingSelectionPolicyFactory,
-      nimble::Buffer& buffer) = 0;
+      nimble::Buffer& buffer,
+      bool useVarintRowCount = false) = 0;
 
   virtual void deserializeFrom(
       std::string_view payload,
+      bool useVarintRowCount,
       velox::memory::MemoryPool& pool) = 0;
 
   static std::unique_ptr<VectorizedStatistic> create(
@@ -102,10 +104,12 @@ class TypedVectorizedStatistic : public VectorizedStatistic {
 
   std::string_view serialize(
       const EncodingSelectionPolicyFactory& encodingSelectionPolicyFactory,
-      nimble::Buffer& buffer) override;
+      nimble::Buffer& buffer,
+      bool useVarintRowCount = false) override;
 
   void deserializeFrom(
       std::string_view payload,
+      bool useVarintRowCount,
       velox::memory::MemoryPool& pool) override;
 
  protected:
@@ -124,10 +128,13 @@ class VectorizedFileStats {
       const std::vector<ColumnStatistics*>& columnStats,
       velox::memory::MemoryPool* pool);
 
-  std::string_view serialize(nimble::Buffer& buffer);
+  std::string_view serialize(
+      nimble::Buffer& buffer,
+      bool useVarintRowCount = false);
 
   static std::unique_ptr<VectorizedFileStats> deserialize(
       const std::string_view payload,
+      bool useVarintRowCount,
       velox::memory::MemoryPool& pool);
 
   std::vector<std::unique_ptr<ColumnStatistics>> toColumnStatistics(
@@ -139,6 +146,7 @@ class VectorizedFileStats {
       const std::vector<StatStreamType>& streamTypes,
       const std::vector<uint64_t>& streamLengths,
       std::string_view statStreams,
+      bool useVarintRowCount,
       velox::memory::MemoryPool& pool);
 
   std::vector<StatStreamType> getStatStreamTypes() const;
@@ -152,6 +160,7 @@ class VectorizedFileStats {
   std::unique_ptr<VectorizedStatistic> deserializeVectorizedStatistic(
       StatStreamType streamType,
       std::string_view payload,
+      bool useVarintRowCount,
       velox::memory::MemoryPool& pool);
 
   std::set<StatType> statTypes_;

--- a/dwio/nimble/velox/stats/tests/VectorizedFileStatsTests.cpp
+++ b/dwio/nimble/velox/stats/tests/VectorizedFileStatsTests.cpp
@@ -114,7 +114,8 @@ TEST_F(VectorizedFileStatsTests, RoundTripDefaultStats) {
   auto serialized = fileStats.serialize(buffer);
   EXPECT_FALSE(serialized.empty());
 
-  auto deserialized = VectorizedFileStats::deserialize(serialized, *leafPool_);
+  auto deserialized = VectorizedFileStats::deserialize(
+      serialized, /*useVarintRowCount=*/false, *leafPool_);
   EXPECT_NE(deserialized, nullptr);
 
   // Serialize again and compare
@@ -136,7 +137,8 @@ TEST_F(VectorizedFileStatsTests, RoundTripIntegralStats) {
   auto serialized = fileStats.serialize(buffer);
   EXPECT_FALSE(serialized.empty());
 
-  auto deserialized = VectorizedFileStats::deserialize(serialized, *leafPool_);
+  auto deserialized = VectorizedFileStats::deserialize(
+      serialized, /*useVarintRowCount=*/false, *leafPool_);
   EXPECT_NE(deserialized, nullptr);
 
   nimble::Buffer buffer2(*leafPool_);
@@ -158,7 +160,8 @@ TEST_F(VectorizedFileStatsTests, RoundTripFloatingPointStats) {
   auto serialized = fileStats.serialize(buffer);
   EXPECT_FALSE(serialized.empty());
 
-  auto deserialized = VectorizedFileStats::deserialize(serialized, *leafPool_);
+  auto deserialized = VectorizedFileStats::deserialize(
+      serialized, /*useVarintRowCount=*/false, *leafPool_);
   EXPECT_NE(deserialized, nullptr);
 
   nimble::Buffer buffer2(*leafPool_);
@@ -179,7 +182,8 @@ TEST_F(VectorizedFileStatsTests, RoundTripStringStats) {
   auto serialized = fileStats.serialize(buffer);
   EXPECT_FALSE(serialized.empty());
 
-  auto deserialized = VectorizedFileStats::deserialize(serialized, *leafPool_);
+  auto deserialized = VectorizedFileStats::deserialize(
+      serialized, /*useVarintRowCount=*/false, *leafPool_);
   EXPECT_NE(deserialized, nullptr);
 
   nimble::Buffer buffer2(*leafPool_);
@@ -202,7 +206,8 @@ TEST_F(VectorizedFileStatsTests, RoundTripMixedStats) {
   auto serialized = fileStats.serialize(buffer);
   EXPECT_FALSE(serialized.empty());
 
-  auto deserialized = VectorizedFileStats::deserialize(serialized, *leafPool_);
+  auto deserialized = VectorizedFileStats::deserialize(
+      serialized, /*useVarintRowCount=*/false, *leafPool_);
   EXPECT_NE(deserialized, nullptr);
 
   nimble::Buffer buffer2(*leafPool_);
@@ -218,7 +223,8 @@ TEST_F(VectorizedFileStatsTests, RoundTripEmptyStats) {
   nimble::Buffer buffer(*leafPool_);
   auto serialized = fileStats.serialize(buffer);
 
-  auto deserialized = VectorizedFileStats::deserialize(serialized, *leafPool_);
+  auto deserialized = VectorizedFileStats::deserialize(
+      serialized, /*useVarintRowCount=*/false, *leafPool_);
   EXPECT_NE(deserialized, nullptr);
 }
 
@@ -240,7 +246,8 @@ TEST_F(VectorizedFileStatsTests, RoundTripLargeNumberOfStats) {
   auto serialized = fileStats.serialize(buffer);
   EXPECT_FALSE(serialized.empty());
 
-  auto deserialized = VectorizedFileStats::deserialize(serialized, *leafPool_);
+  auto deserialized = VectorizedFileStats::deserialize(
+      serialized, /*useVarintRowCount=*/false, *leafPool_);
   EXPECT_NE(deserialized, nullptr);
 
   nimble::Buffer buffer2(*leafPool_);
@@ -469,7 +476,8 @@ TEST_F(VectorizedFileStatsTests, SchemaBasedRoundTripFlatRow) {
   EXPECT_FALSE(serialized.empty());
 
   // Deserialize and convert back to column statistics
-  auto deserialized = VectorizedFileStats::deserialize(serialized, *leafPool_);
+  auto deserialized = VectorizedFileStats::deserialize(
+      serialized, /*useVarintRowCount=*/false, *leafPool_);
   EXPECT_NE(deserialized, nullptr);
 
   auto roundTrippedStats = deserialized->toColumnStatistics(schema, nimbleType);
@@ -522,7 +530,8 @@ TEST_F(VectorizedFileStatsTests, SchemaBasedRoundTripNestedRow) {
   nimble::Buffer buffer(*leafPool_);
   auto serialized = fileStats.serialize(buffer);
 
-  auto deserialized = VectorizedFileStats::deserialize(serialized, *leafPool_);
+  auto deserialized = VectorizedFileStats::deserialize(
+      serialized, /*useVarintRowCount=*/false, *leafPool_);
   auto roundTrippedStats = deserialized->toColumnStatistics(schema, nimbleType);
   ASSERT_EQ(roundTrippedStats.size(), 5);
 
@@ -564,7 +573,8 @@ TEST_F(VectorizedFileStatsTests, SchemaBasedRoundTripWithArray) {
   nimble::Buffer buffer(*leafPool_);
   auto serialized = fileStats.serialize(buffer);
 
-  auto deserialized = VectorizedFileStats::deserialize(serialized, *leafPool_);
+  auto deserialized = VectorizedFileStats::deserialize(
+      serialized, /*useVarintRowCount=*/false, *leafPool_);
   auto roundTrippedStats = deserialized->toColumnStatistics(schema, nimbleType);
   ASSERT_EQ(roundTrippedStats.size(), 4);
 
@@ -599,7 +609,8 @@ TEST_F(VectorizedFileStatsTests, SchemaBasedRoundTripWithMap) {
   nimble::Buffer buffer(*leafPool_);
   auto serialized = fileStats.serialize(buffer);
 
-  auto deserialized = VectorizedFileStats::deserialize(serialized, *leafPool_);
+  auto deserialized = VectorizedFileStats::deserialize(
+      serialized, /*useVarintRowCount=*/false, *leafPool_);
   auto roundTrippedStats = deserialized->toColumnStatistics(schema, nimbleType);
   ASSERT_EQ(roundTrippedStats.size(), 4);
 
@@ -638,7 +649,8 @@ TEST_F(VectorizedFileStatsTests, SchemaBasedRoundTripWithNulloptMinMax) {
   nimble::Buffer buffer(*leafPool_);
   auto serialized = fileStats.serialize(buffer);
 
-  auto deserialized = VectorizedFileStats::deserialize(serialized, *leafPool_);
+  auto deserialized = VectorizedFileStats::deserialize(
+      serialized, /*useVarintRowCount=*/false, *leafPool_);
   auto roundTrippedStats = deserialized->toColumnStatistics(schema, nimbleType);
   ASSERT_EQ(roundTrippedStats.size(), 4);
 
@@ -675,7 +687,8 @@ TEST_F(VectorizedFileStatsTests, SchemaBasedRoundTripWithTimestamp) {
   nimble::Buffer buffer(*leafPool_);
   auto serialized = fileStats.serialize(buffer);
 
-  auto deserialized = VectorizedFileStats::deserialize(serialized, *leafPool_);
+  auto deserialized = VectorizedFileStats::deserialize(
+      serialized, /*useVarintRowCount=*/false, *leafPool_);
   auto roundTrippedStats = deserialized->toColumnStatistics(schema, nimbleType);
   ASSERT_EQ(roundTrippedStats.size(), 3);
 
@@ -728,7 +741,8 @@ TEST_F(VectorizedFileStatsTests, SchemaBasedRoundTripComplexNested) {
   nimble::Buffer buffer(*leafPool_);
   auto serialized = fileStats.serialize(buffer);
 
-  auto deserialized = VectorizedFileStats::deserialize(serialized, *leafPool_);
+  auto deserialized = VectorizedFileStats::deserialize(
+      serialized, /*useVarintRowCount=*/false, *leafPool_);
   auto roundTrippedStats = deserialized->toColumnStatistics(schema, nimbleType);
   ASSERT_EQ(roundTrippedStats.size(), 8);
 
@@ -783,7 +797,8 @@ TEST_F(VectorizedFileStatsTests, SchemaBasedRoundTripAllIntegralTypes) {
   nimble::Buffer buffer(*leafPool_);
   auto serialized = fileStats.serialize(buffer);
 
-  auto deserialized = VectorizedFileStats::deserialize(serialized, *leafPool_);
+  auto deserialized = VectorizedFileStats::deserialize(
+      serialized, /*useVarintRowCount=*/false, *leafPool_);
   auto roundTrippedStats = deserialized->toColumnStatistics(schema, nimbleType);
   ASSERT_EQ(roundTrippedStats.size(), 5);
 
@@ -814,7 +829,8 @@ TEST_F(VectorizedFileStatsTests, SchemaBasedRoundTripAllFloatingPointTypes) {
   nimble::Buffer buffer(*leafPool_);
   auto serialized = fileStats.serialize(buffer);
 
-  auto deserialized = VectorizedFileStats::deserialize(serialized, *leafPool_);
+  auto deserialized = VectorizedFileStats::deserialize(
+      serialized, /*useVarintRowCount=*/false, *leafPool_);
   auto roundTrippedStats = deserialized->toColumnStatistics(schema, nimbleType);
   ASSERT_EQ(roundTrippedStats.size(), 3);
 

--- a/dwio/nimble/velox/tests/VeloxWriterTest.cpp
+++ b/dwio/nimble/velox/tests/VeloxWriterTest.cpp
@@ -626,8 +626,8 @@ ChunkSizeResults validateChunkSize(
         const auto chunk = chunkedStream.nextChunk();
         const uint64_t chunkRawDataSize =
             nimble::test::TestUtils::getRawDataSize(pool, chunk);
-        const uint32_t rowCount =
-            *reinterpret_cast<const uint32_t*>(chunk.data() + kRowCountOffset);
+        const char* rowCountPos = chunk.data() + kRowCountOffset;
+        const uint32_t rowCount = nimble::encoding::peek<uint32_t>(rowCountPos);
         const double stringError =
             isStringStream ? rowCount * sizeof(std::string_view) : 0;
 
@@ -2388,7 +2388,7 @@ TEST_F(VeloxWriterTest, rawSizeWritten) {
 
     // Use VectorizedFileStats to deserialize the stats payload
     auto fileStats = nimble::VectorizedFileStats::deserialize(
-        statsSection->content(), *leafPool_);
+        statsSection->content(), /*useVarintRowCount=*/false, *leafPool_);
     ASSERT_NE(fileStats, nullptr);
 
     // Convert to column statistics using schema and nimbleType
@@ -3306,13 +3306,15 @@ class VeloxWriterIndexTest
           while (chunkedStream.hasNext()) {
             const auto chunkData = chunkedStream.nextChunk();
             std::vector<velox::BufferPtr> stringBuffers;
-            auto encoding = nimble::EncodingFactory().create(
-                *leafPool_, chunkData, [&](uint32_t totalLength) {
-                  auto& buffer = stringBuffers.emplace_back(
-                      velox::AlignedBuffer::allocate<char>(
-                          totalLength, leafPool_.get()));
-                  return buffer->asMutable<void>();
-                });
+            auto encoding =
+                nimble::EncodingFactory(
+                    nimble::Encoding::Options{.useVarintRowCount = true})
+                    .create(*leafPool_, chunkData, [&](uint32_t totalLength) {
+                      auto& buffer = stringBuffers.emplace_back(
+                          velox::AlignedBuffer::allocate<char>(
+                              totalLength, leafPool_.get()));
+                      return buffer->asMutable<void>();
+                    });
             EXPECT_EQ(encoding->rowCount(), expectedChunkRowCounts[chunkIndex])
                 << "Stripe " << stripeIdx << " stream " << streamId << " chunk "
                 << chunkIndex << " row count mismatch (sequential)";
@@ -3349,13 +3351,15 @@ class VeloxWriterIndexTest
               *leafPool_, chunkStreamData);
           auto encodingData = chunkDecoder.decode();
           std::vector<velox::BufferPtr> stringBuffers;
-          auto encoding = nimble::EncodingFactory().create(
-              *leafPool_, encodingData, [&](uint32_t totalLength) {
-                auto& buffer = stringBuffers.emplace_back(
-                    velox::AlignedBuffer::allocate<char>(
-                        totalLength, leafPool_.get()));
-                return buffer->asMutable<void>();
-              });
+          auto encoding =
+              nimble::EncodingFactory(
+                  nimble::Encoding::Options{.useVarintRowCount = true})
+                  .create(*leafPool_, encodingData, [&](uint32_t totalLength) {
+                    auto& buffer = stringBuffers.emplace_back(
+                        velox::AlignedBuffer::allocate<char>(
+                            totalLength, leafPool_.get()));
+                    return buffer->asMutable<void>();
+                  });
 
           EXPECT_EQ(encoding->rowCount(), expectedChunkRowCounts[i])
               << "Stripe " << stripeIdx << " stream " << streamId << " chunk "
@@ -3507,13 +3511,15 @@ class VeloxWriterIndexTest
 
           // Decode the key encoding from the chunk data
 
-          keyStreamCache[chunkFileOffset] = nimble::EncodingFactory().create(
-              *leafPool_, encodingData, [&](uint32_t totalLength) {
-                auto& buf = stringBuffers.emplace_back(
-                    velox::AlignedBuffer::allocate<char>(
-                        totalLength, leafPool_.get()));
-                return buf->asMutable<void>();
-              });
+          keyStreamCache[chunkFileOffset] =
+              nimble::EncodingFactory(
+                  nimble::Encoding::Options{.useVarintRowCount = true})
+                  .create(*leafPool_, encodingData, [&](uint32_t totalLength) {
+                    auto& buf = stringBuffers.emplace_back(
+                        velox::AlignedBuffer::allocate<char>(
+                            totalLength, leafPool_.get()));
+                    return buf->asMutable<void>();
+                  });
         }
 
         auto* keyEncoding = keyStreamCache[chunkFileOffset].get();
@@ -4328,13 +4334,15 @@ TEST_F(VeloxWriterTest, customPrefixRestartInterval) {
 
     // Decode the key encoding
     std::vector<velox::BufferPtr> stringBuffers;
-    auto keyEncoding = nimble::EncodingFactory().create(
-        *leafPool_, encodingData, [&](uint32_t totalLength) {
-          auto& buf = stringBuffers.emplace_back(
-              velox::AlignedBuffer::allocate<char>(
-                  totalLength, leafPool_.get()));
-          return buf->asMutable<void>();
-        });
+    auto keyEncoding =
+        nimble::EncodingFactory(
+            nimble::Encoding::Options{.useVarintRowCount = true})
+            .create(*leafPool_, encodingData, [&](uint32_t totalLength) {
+              auto& buf = stringBuffers.emplace_back(
+                  velox::AlignedBuffer::allocate<char>(
+                      totalLength, leafPool_.get()));
+              return buf->asMutable<void>();
+            });
 
     // Verify the restart interval through debugString()
     const std::string debug = keyEncoding->debugString(0);


### PR DESCRIPTION
Summary:

Change the Nimble encoding prefix row count field from a fixed 4-byte uint32_t to varint encoding. For typical small row counts (< 128 rows), this saves 3 bytes per encoding prefix.

The change is gated by a minor version bump (1 → 2) for backward compatibility:
- Write path: All encodings now use `Encoding::Options{.useVarintRowCount = true}` when index is enabled
- Read path: Files with version >= (0, 2) AND cluster index present decode with varint row counts; older files use the fixed 4-byte format

Key changes:
- Introduce `NimbleFeatureVersion.h` with `NimbleVersion` struct and `NimbleFeatureVersionRange` for centralized version-to-feature mapping. Future features follow the same pattern: add a version range, gate writer on current version, gate reader on file version.
- Bump `kVersionMinor` from 1 to 2 in Constants.h
- Thread `useVarintRowCount=true` through VeloxWriter, IndexWriter, and VectorizedStatistics encode paths
- Version-gate decode in VeloxReader, SelectiveNimbleReader, SelectiveNimbleIndexReader, ChunkedDecoder, IndexReader, and ReaderBase (stats deserialization)
- Fix tools (NimbleDumpLib, NimbleDslLib, EncodingLayoutTrainer, DumpNimbleTablet2DatabaseLib) to use varint-aware encoding traversal and row count reading
- Add `useVarintRowCount` parameter to `traverseEncodings()`, `getStreamInputLabel()`, and `getEncodingLabel()` in EncodingUtilities
- Update test utilities (TestUtils, VeloxWriterTest) to handle varint prefix parsing
- Update ~80 hardcoded physicalSize values in FieldWriterStatsTest to account for smaller prefixes
- Add NimbleFeatureVersionTest with version comparison, feature range, and constexpr tests

Differential Revision: D97174231
