### PR TITLE
fix: Fix SparseBoolEncoding null pointer crash when rowCount is zero

### DIFF
--- a/dwio/nimble/encodings/SparseBoolEncoding.cpp
+++ b/dwio/nimble/encodings/SparseBoolEncoding.cpp
@@ -54,6 +54,9 @@ void SparseBoolEncoding::skip(uint32_t rowCount) {
 }
 
 void SparseBoolEncoding::materialize(uint32_t rowCount, void* buffer) {
+  if (rowCount == 0) {
+    return;
+  }
   const uint32_t end = row_ + rowCount;
   if (sparseValue_) {
     memset(buffer, 0, rowCount);
@@ -75,6 +78,9 @@ void SparseBoolEncoding::materializeBoolsAsBits(
     uint32_t rowCount,
     uint64_t* buffer,
     int begin) {
+  if (rowCount == 0) {
+    return;
+  }
   velox::bits::fillBits(buffer, begin, begin + rowCount, !sparseValue_);
   const auto end = row_ + rowCount;
   if (sparseValue_) {

--- a/dwio/nimble/encodings/legacy/SparseBoolEncoding.cpp
+++ b/dwio/nimble/encodings/legacy/SparseBoolEncoding.cpp
@@ -53,6 +53,9 @@ void SparseBoolEncoding::skip(uint32_t rowCount) {
 }
 
 void SparseBoolEncoding::materialize(uint32_t rowCount, void* buffer) {
+  if (rowCount == 0) {
+    return;
+  }
   const uint32_t end = row_ + rowCount;
   if (sparseValue_) {
     memset(buffer, 0, rowCount);
@@ -74,6 +77,9 @@ void SparseBoolEncoding::materializeBoolsAsBits(
     uint32_t rowCount,
     uint64_t* buffer,
     int begin) {
+  if (rowCount == 0) {
+    return;
+  }
   velox::bits::fillBits(buffer, begin, begin + rowCount, !sparseValue_);
   const auto end = row_ + rowCount;
   if (sparseValue_) {

--- a/dwio/nimble/encodings/tests/EncodingLegacyTest.cpp
+++ b/dwio/nimble/encodings/tests/EncodingLegacyTest.cpp
@@ -592,3 +592,106 @@ TYPED_TEST(EncodingLegacyTest, scatteredMaterialize) {
     }
   }
 }
+
+// Regression test for legacy SparseBoolEncoding null pointer crash when
+// rowCount == 0. memset(nullptr, 0, 0) is undefined behavior.
+class LegacySparseBoolZeroRowTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    pool_ = velox::memory::deprecatedAddDefaultLeafMemoryPool();
+    buffer_ = std::make_unique<nimble::Buffer>(*pool_);
+  }
+
+  std::unique_ptr<nimble::legacy::SparseBoolEncoding> createSparseBoolEncoding(
+      const nimble::Vector<bool>& values) {
+    auto physicalValues = std::span<const bool>(values.data(), values.size());
+    nimble::EncodingSelection<bool> selection{
+        {.encodingType = nimble::EncodingType::SparseBool,
+         .compressionPolicyFactory =
+             []() {
+               return std::make_unique<TestCompressPolicy>(false, false);
+             }},
+        nimble::Statistics<bool>::create(physicalValues),
+        std::make_unique<TestTrivialEncodingSelectionPolicy<bool>>(
+            false, false)};
+    auto encoded = nimble::legacy::SparseBoolEncoding::encode(
+        selection, physicalValues, *buffer_);
+    return std::make_unique<nimble::legacy::SparseBoolEncoding>(
+        *pool_, encoded, nullptr);
+  }
+
+  std::shared_ptr<velox::memory::MemoryPool> pool_;
+  std::unique_ptr<nimble::Buffer> buffer_;
+};
+
+TEST_F(LegacySparseBoolZeroRowTest, materializeZeroRows) {
+  nimble::Vector<bool> values{pool_.get()};
+  for (int i = 0; i < 100; ++i) {
+    values.push_back(i == 50);
+  }
+
+  auto encoding = createSparseBoolEncoding(values);
+
+  // Materializing zero rows with nullptr must not crash.
+  encoding->materialize(0, nullptr);
+
+  // Encoding should still work correctly after zero-row materialize.
+  nimble::Vector<bool> result(pool_.get(), 100);
+  encoding->materialize(100, result.data());
+  for (int i = 0; i < 100; ++i) {
+    ASSERT_EQ(result[i], values[i]) << "i: " << i;
+  }
+}
+
+TEST_F(LegacySparseBoolZeroRowTest, materializeZeroRowsMidStream) {
+  nimble::Vector<bool> values{pool_.get()};
+  for (int i = 0; i < 100; ++i) {
+    values.push_back(i == 50);
+  }
+
+  auto encoding = createSparseBoolEncoding(values);
+
+  nimble::Vector<bool> result(pool_.get(), 100);
+  encoding->materialize(30, result.data());
+  encoding->materialize(0, nullptr);
+  encoding->materialize(70, result.data());
+  for (int i = 0; i < 70; ++i) {
+    ASSERT_EQ(result[i], values[30 + i]) << "i: " << i;
+  }
+}
+
+TEST_F(LegacySparseBoolZeroRowTest, materializeBoolsAsBitsZeroRows) {
+  nimble::Vector<bool> values{pool_.get()};
+  for (int i = 0; i < 100; ++i) {
+    values.push_back(i == 50);
+  }
+
+  auto encoding = createSparseBoolEncoding(values);
+
+  // materializeBoolsAsBits with zero rows and nullptr must not crash.
+  encoding->materializeBoolsAsBits(0, nullptr, 0);
+
+  // Should still work correctly after the zero-row call.
+  uint64_t bits[2] = {};
+  encoding->materializeBoolsAsBits(100, bits, 0);
+  for (int i = 0; i < 100; ++i) {
+    ASSERT_EQ(velox::bits::isBitSet(bits, i), values[i]) << "i: " << i;
+  }
+}
+
+TEST_F(LegacySparseBoolZeroRowTest, materializeZeroRowsSparseValueFalse) {
+  nimble::Vector<bool> values{pool_.get()};
+  for (int i = 0; i < 100; ++i) {
+    values.push_back(i != 50);
+  }
+
+  auto encoding = createSparseBoolEncoding(values);
+
+  encoding->materialize(0, nullptr);
+
+  nimble::Vector<bool> result(pool_.get(), 100);
+  encoding->materialize(100, result.data());
+  for (int i = 0; i < 100; ++i) {
+    ASSERT_EQ(result[i], values[i]) << "i: " << i;
+  }
+}

--- a/dwio/nimble/encodings/tests/EncodingTest.cpp
+++ b/dwio/nimble/encodings/tests/EncodingTest.cpp
@@ -35,6 +35,7 @@
 #include "dwio/nimble/encodings/SparseBoolEncoding.h"
 #include "dwio/nimble/encodings/TrivialEncoding.h"
 #include "dwio/nimble/encodings/VarintEncoding.h"
+#include "dwio/nimble/encodings/tests/TestUtils.h"
 #include "folly/Random.h"
 #include "velox/common/base/BitUtil.h"
 #include "velox/common/memory/Memory.h"
@@ -270,6 +271,114 @@ using TestTypes = ::testing::Types<
     ALL_TYPES(nimble::ConstantEncoding)>;
 
 TYPED_TEST_CASE(EncodingTest, TestTypes);
+
+// Regression test for SparseBoolEncoding null pointer crash when rowCount == 0.
+// memset(nullptr, 0, 0) is undefined behavior per the C/C++ standard.
+class SparseBoolZeroRowTest : public ::testing::Test {
+ protected:
+  static void SetUpTestCase() {
+    velox::memory::MemoryManager::testingSetInstance({});
+  }
+
+  void SetUp() override {
+    pool_ = velox::memory::deprecatedAddDefaultLeafMemoryPool();
+    buffer_ = std::make_unique<nimble::Buffer>(*pool_);
+  }
+
+  std::function<void*(uint32_t)> makeStringBufferFactory() {
+    return [this](uint32_t totalLength) {
+      auto& buf = stringBuffers_.emplace_back(
+          velox::AlignedBuffer::allocate<char>(totalLength, pool_.get()));
+      return buf->asMutable<void>();
+    };
+  }
+
+  std::shared_ptr<velox::memory::MemoryPool> pool_;
+  std::unique_ptr<nimble::Buffer> buffer_;
+  std::vector<velox::BufferPtr> stringBuffers_;
+};
+
+TEST_F(SparseBoolZeroRowTest, materializeZeroRows) {
+  // Create encoding with sparse true values (few trues among mostly false).
+  nimble::Vector<bool> values{pool_.get()};
+  for (int i = 0; i < 100; ++i) {
+    values.push_back(i == 50);
+  }
+
+  auto encoding = facebook::nimble::test::Encoder<nimble::SparseBoolEncoding>::
+      createEncoding(*buffer_, values, makeStringBufferFactory());
+
+  // Materializing zero rows with nullptr must not crash.
+  encoding->materialize(0, nullptr);
+
+  // Encoding should still work correctly after zero-row materialize.
+  nimble::Vector<bool> result(pool_.get(), 100);
+  encoding->materialize(100, result.data());
+  for (int i = 0; i < 100; ++i) {
+    ASSERT_EQ(result[i], values[i]) << "i: " << i;
+  }
+}
+
+TEST_F(SparseBoolZeroRowTest, materializeZeroRowsMidStream) {
+  nimble::Vector<bool> values{pool_.get()};
+  for (int i = 0; i < 100; ++i) {
+    values.push_back(i == 50);
+  }
+
+  auto encoding = facebook::nimble::test::Encoder<nimble::SparseBoolEncoding>::
+      createEncoding(*buffer_, values, makeStringBufferFactory());
+
+  // Read some rows, then do a zero-row materialize, then continue reading.
+  nimble::Vector<bool> result(pool_.get(), 100);
+  encoding->materialize(30, result.data());
+  encoding->materialize(0, nullptr);
+  encoding->materialize(70, result.data());
+  for (int i = 0; i < 70; ++i) {
+    ASSERT_EQ(result[i], values[30 + i]) << "i: " << i;
+  }
+}
+
+TEST_F(SparseBoolZeroRowTest, materializeBoolsAsBitsZeroRows) {
+  nimble::Vector<bool> values{pool_.get()};
+  for (int i = 0; i < 100; ++i) {
+    values.push_back(i == 50);
+  }
+
+  auto encoding = facebook::nimble::test::Encoder<nimble::SparseBoolEncoding>::
+      createEncoding(*buffer_, values, makeStringBufferFactory());
+  auto* sparseBool = dynamic_cast<nimble::SparseBoolEncoding*>(encoding.get());
+  ASSERT_NE(sparseBool, nullptr);
+
+  // materializeBoolsAsBits with zero rows and nullptr must not crash.
+  sparseBool->materializeBoolsAsBits(0, nullptr, 0);
+
+  // Should still work correctly after the zero-row call.
+  uint64_t bits[2] = {};
+  sparseBool->materializeBoolsAsBits(100, bits, 0);
+  for (int i = 0; i < 100; ++i) {
+    ASSERT_EQ(velox::bits::isBitSet(bits, i), values[i]) << "i: " << i;
+  }
+}
+
+TEST_F(SparseBoolZeroRowTest, materializeZeroRowsSparseValueFalse) {
+  // Create encoding with sparse false values (few falses among mostly true).
+  nimble::Vector<bool> values{pool_.get()};
+  for (int i = 0; i < 100; ++i) {
+    values.push_back(i != 50);
+  }
+
+  auto encoding = facebook::nimble::test::Encoder<nimble::SparseBoolEncoding>::
+      createEncoding(*buffer_, values, makeStringBufferFactory());
+
+  // Materializing zero rows with nullptr must not crash.
+  encoding->materialize(0, nullptr);
+
+  nimble::Vector<bool> result(pool_.get(), 100);
+  encoding->materialize(100, result.data());
+  for (int i = 0; i < 100; ++i) {
+    ASSERT_EQ(result[i], values[i]) << "i: " << i;
+  }
+}
 
 TYPED_TEST(EncodingTest, materialize) {
   auto seed = folly::Random::rand32();


### PR DESCRIPTION
Summary:
SparseBoolEncoding::materialize() and materializeBoolsAsBits() call memset() and velox::bits::fillBits() on the buffer unconditionally. When rowCount == 0, callers may pass a nullptr buffer, and memset(nullptr, 0, 0) is undefined behavior per the C/C++ standard. Sanitizers in Vader's nimble_*_velox_rewrite validation stages catch this as a null pointer dereference crash, contributing ~80 UNKNOWN errors (17% of total) in the dwrf_reader_checksum alert (T265094977).

The fix adds an early return guard `if (rowCount == 0) return;` at the top of both materialize() and materializeBoolsAsBits() in both the legacy and non-legacy SparseBoolEncoding implementations.

Differential Revision: D101258299


