### PR TITLE
refactor(reader): Rename memoryPool_ to pool_ in SelectiveColumnReader hierarchy

### DIFF
--- a/dwio/nimble/velox/selective/FlatMapColumnReader.cpp
+++ b/dwio/nimble/velox/selective/FlatMapColumnReader.cpp
@@ -166,7 +166,7 @@ class FlatMapAsStructColumnReader : public StructColumnReaderBase {
                 params,
                 scanSpec,
                 dwio::common::flatmap::FlatMapOutput::kStruct,
-                *memoryPool_)) {
+                *pool_)) {
     children_.resize(keyNodes_.size());
     for (auto& childSpec : scanSpec.children()) {
       childSpec->setSubscript(kConstantChildSpecSubscript);
@@ -237,7 +237,7 @@ class FlatMapColumnReader
                 params,
                 scanSpec,
                 dwio::common::flatmap::FlatMapOutput::kFlatMap,
-                *memoryPool_)) {
+                *pool_)) {
     // Instantiate and populate distinct keys vector.
     keysVector_ = BaseVector::create(
         CppToType<T>::create(),
@@ -387,7 +387,7 @@ class FlatMapAsMapColumnReader : public StructColumnReaderBase {
                 params,
                 scanSpec,
                 dwio::common::flatmap::FlatMapOutput::kMap,
-                *memoryPool_)) {}
+                *pool_)) {}
 
   void read(int64_t offset, const RowSet& rows, const uint64_t* incomingNulls)
       override {

--- a/dwio/nimble/velox/selective/NullColumnReader.h
+++ b/dwio/nimble/velox/selective/NullColumnReader.h
@@ -51,10 +51,10 @@ class NullColumnReader : public velox::dwio::common::SelectiveColumnReader {
     if (scanSpec_->isFlatMapAsStruct()) {
       NIMBLE_CHECK(result->get() && result->get()->type()->isRow());
       *result = velox::BaseVector::createNullConstant(
-          result->get()->type(), rows.size(), memoryPool_);
+          result->get()->type(), rows.size(), pool_);
     } else {
       *result = velox::BaseVector::createNullConstant(
-          requestedType_, rows.size(), memoryPool_);
+          requestedType_, rows.size(), pool_);
     }
   }
 

--- a/dwio/nimble/velox/selective/TimestampColumnReader.cpp
+++ b/dwio/nimble/velox/selective/TimestampColumnReader.cpp
@@ -32,9 +32,8 @@ uint64_t TimestampColumnReader::skip(uint64_t numValues) {
   // Read micros to temp buffer to count non-null values.
   // We need this count because the nanos stream only contains values for
   // non-null micros positions.
-  auto microsBuffer =
-      velox::AlignedBuffer::allocate<int64_t>(numValues, memoryPool_);
-  auto nullsBuffer = velox::allocateNulls(numValues, memoryPool_);
+  auto microsBuffer = velox::AlignedBuffer::allocate<int64_t>(numValues, pool_);
+  auto nullsBuffer = velox::allocateNulls(numValues, pool_);
 
   microsDecoder_.decodeNullable<int64_t>(
       nullsBuffer->asMutable<uint64_t>(),
@@ -77,8 +76,7 @@ void TimestampColumnReader::readHelper(
 
   if (!microsBuffer_ || !microsBuffer_->unique() ||
       microsBuffer_->capacity() < scannedPositions * sizeof(int64_t)) {
-    microsBuffer_ =
-        AlignedBuffer::allocate<int64_t>(scannedPositions, memoryPool_);
+    microsBuffer_ = AlignedBuffer::allocate<int64_t>(scannedPositions, pool_);
   }
   auto* microsData = microsBuffer_->asMutable<int64_t>();
 
@@ -88,7 +86,7 @@ void TimestampColumnReader::readHelper(
     // No incoming nulls and buffer is reusable.
     nullsBuffer = nullsInReadRange_;
   } else {
-    nullsBuffer = velox::allocateNulls(scannedPositions, memoryPool_);
+    nullsBuffer = velox::allocateNulls(scannedPositions, pool_);
   }
   auto* nullsData = nullsBuffer->asMutable<uint64_t>();
 
@@ -108,7 +106,7 @@ void TimestampColumnReader::readHelper(
 
   if (!nanosBuffer_ || !nanosBuffer_->unique() ||
       nanosBuffer_->capacity() < nonNullCount * sizeof(uint16_t)) {
-    nanosBuffer_ = AlignedBuffer::allocate<uint16_t>(nonNullCount, memoryPool_);
+    nanosBuffer_ = AlignedBuffer::allocate<uint16_t>(nonNullCount, pool_);
   }
   auto* nanosData = nanosBuffer_->asMutable<uint16_t>();
   if (nonNullCount > 0) {
@@ -121,7 +119,7 @@ void TimestampColumnReader::readHelper(
 
   if (!values_ || !values_->unique() ||
       values_->capacity() < numValues_ * sizeof(Timestamp)) {
-    values_ = AlignedBuffer::allocate<Timestamp>(numValues_, memoryPool_);
+    values_ = AlignedBuffer::allocate<Timestamp>(numValues_, pool_);
   }
   rawValues_ = values_->asMutable<char>();
   auto rawTs = values_->asMutable<Timestamp>();
@@ -129,7 +127,7 @@ void TimestampColumnReader::readHelper(
   // Create nulls buffer for the rows we are actually returning.
   if (!resultNulls_ || !resultNulls_->unique() ||
       resultNulls_->capacity() < velox::bits::nbytes(numValues_)) {
-    resultNulls_ = velox::allocateNulls(numValues_, memoryPool_);
+    resultNulls_ = velox::allocateNulls(numValues_, pool_);
   }
   rawResultNulls_ = resultNulls_->asMutable<uint64_t>();
   // Forces resultNulls() to use resultNulls_/rawResultNulls_

--- a/dwio/nimble/velox/selective/VariableLengthColumnReader.cpp
+++ b/dwio/nimble/velox/selective/VariableLengthColumnReader.cpp
@@ -332,11 +332,11 @@ void ListColumnReader::readLengths(
 
 uint64_t ListColumnReader::skip(uint64_t numValues) {
   auto nullsBuffer = velox::AlignedBuffer::allocate<uint64_t>(
-      velox::bits::nwords(numValues), memoryPool_);
+      velox::bits::nwords(numValues), pool_);
   auto nulls = nullsBuffer->as<uint64_t>();
   formatData_->readNulls(numValues, nullptr, nullsBuffer);
   if (child_) {
-    nimble::Vector<int32_t> buffer{memoryPool_, numValues};
+    nimble::Vector<int32_t> buffer{pool_, numValues};
     uint64_t childElements = 0;
     readLengths(buffer.data(), numValues, nullptr);
     for (size_t i = 0; i < numValues; ++i) {
@@ -458,7 +458,7 @@ void MapColumnReader::readLengths(
 uint64_t MapColumnReader::skip(uint64_t numValues) {
   return skipMapChildren(
       numValues,
-      memoryPool_,
+      pool_,
       *formatData_,
       keyReader_.get(),
       elementReader_.get(),
@@ -513,7 +513,7 @@ void MapAsStructColumnReader::readLengths(
 uint64_t MapAsStructColumnReader::skip(uint64_t numValues) {
   return skipMapChildren(
       numValues,
-      memoryPool_,
+      pool_,
       *formatData_,
       keyReader_.get(),
       elementReader_.get(),
@@ -625,7 +625,7 @@ size_t DeduplicatedReadHelper::prepareDeduplicatedStates(
   if (!runStartRowsHolder_ ||
       runStartRowsHolder_->capacity() < alphabetSize * sizeof(vector_size_t)) {
     runStartRowsHolder_ =
-        velox::allocateIndices(alphabetSize, columnReader_->memoryPool_);
+        velox::allocateIndices(alphabetSize, columnReader_->pool_);
     runStartRows_ = runStartRowsHolder_->asMutable<vector_size_t>();
   }
 
@@ -945,7 +945,7 @@ void DeduplicatedArrayColumnReader::makeNestedRowSet(
 uint64_t DeduplicatedArrayColumnReader::skip(uint64_t numValues) {
   VLOG(1) << "Skipping " << numValues << " values";
   auto nullsBuffer = velox::AlignedBuffer::allocate<uint64_t>(
-      velox::bits::nwords(numValues), memoryPool_);
+      velox::bits::nwords(numValues), pool_);
   auto nulls = nullsBuffer->as<uint64_t>();
   formatData_->readNulls(numValues, nullptr, nullsBuffer);
   if (child_) {
@@ -981,8 +981,8 @@ void DeduplicatedArrayColumnReader::getValues(
   // TODO: looks like elements of the alphabet is not properly
   // referenced, and thus we are already in the elements of the
   // next batch in lazy vector scenario.
-  auto dictionaryVector = prepareDictionaryArrayResult(
-      *result, requestedType_, rows.size(), memoryPool_);
+  auto dictionaryVector =
+      prepareDictionaryArrayResult(*result, requestedType_, rows.size(), pool_);
   if (!rows.empty()) {
     setComplexNulls(rows, *result);
   }
@@ -1083,7 +1083,7 @@ void DeduplicatedMapColumnReader::makeNestedRowSet(
 uint64_t DeduplicatedMapColumnReader::skip(uint64_t numValues) {
   VLOG(1) << "Skipping " << numValues << " values";
   auto nullsBuffer = velox::AlignedBuffer::allocate<uint64_t>(
-      velox::bits::nwords(numValues), memoryPool_);
+      velox::bits::nwords(numValues), pool_);
   auto nulls = nullsBuffer->as<uint64_t>();
   formatData_->readNulls(numValues, nullptr, nullsBuffer);
   if (keyReader_ || elementReader_) {
@@ -1124,8 +1124,8 @@ void DeduplicatedMapColumnReader::getValues(
   // TODO: looks like elements of the alphabet is not properly
   // referenced, and thus we are already in the elements of the
   // next batch in lazy vector scenario.
-  auto dictionaryVector = prepareDictionaryMapResult(
-      *result, requestedType_, rows.size(), memoryPool_);
+  auto dictionaryVector =
+      prepareDictionaryMapResult(*result, requestedType_, rows.size(), pool_);
   if (!rows.empty()) {
     setComplexNulls(rows, *result);
   }


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebookincubator/velox/pull/17246

Rename the protected member `memoryPool_` to `pool_` across the `SelectiveColumnReader` class hierarchy. The public accessor `memoryPool()` retains its name so external callers are unaffected.

This is a mechanical rename across 21 files spanning Velox common, DWRF selective readers, Parquet readers, and Nimble selective readers. The DWRF non-selective `ColumnReader` hierarchy has its own separate `memoryPool_` member and is intentionally left unchanged.

Differential Revision: D101539025


