### PR TITLE
feat(encoding): Add runtime compression type selection to AlwaysCompressPolicy (#663)

### DIFF
--- a/dwio/nimble/encodings/EncodingSelectionPolicy.h
+++ b/dwio/nimble/encodings/EncodingSelectionPolicy.h
@@ -102,6 +102,11 @@ using EncodingSelectionPolicyFactory =
 
 struct CompressionOptions {
   float compressionAcceptRatio = 0.98f;
+#ifndef DISABLE_META_INTERNAL_COMPRESSOR
+  CompressionType compressionType = CompressionType::MetaInternal;
+#else
+  CompressionType compressionType = CompressionType::Zstd;
+#endif
   uint64_t zstdMinCompressionSize = kZstdMinCompressionSize;
   uint32_t zstdCompressionLevel = 3;
   uint64_t internalMinCompressionSize = kMetaInternalMinCompressionSize;
@@ -212,7 +217,14 @@ class ManualEncodingSelectionPolicy : public EncodingSelectionPolicy<T> {
           : compressionOptions_{std::move(compressionOptions)} {}
 
       CompressionInformation compression() const override {
-#ifndef DISABLE_META_INTERNAL_COMPRESSOR
+        if (compressionOptions_.compressionType == CompressionType::Zstd) {
+          CompressionInformation information{
+              .compressionType = CompressionType::Zstd,
+              .minCompressionSize = compressionOptions_.zstdMinCompressionSize};
+          information.parameters.zstd.compressionLevel =
+              compressionOptions_.zstdCompressionLevel;
+          return information;
+        }
         CompressionInformation information{
             .compressionType = CompressionType::MetaInternal,
             .minCompressionSize =
@@ -226,14 +238,6 @@ class ManualEncodingSelectionPolicy : public EncodingSelectionPolicy<T> {
         information.parameters.metaInternal.compressionKey =
             compressionOptions_.metaInternalCompressionKey;
         return information;
-#else
-        CompressionInformation information{
-            .compressionType = CompressionType::Zstd,
-            .minCompressionSize = compressionOptions_.zstdMinCompressionSize};
-        information.parameters.zstd.compressionLevel =
-            compressionOptions_.zstdCompressionLevel;
-        return information;
-#endif
       }
 
       virtual bool shouldAccept(

--- a/dwio/nimble/encodings/tests/EncodingSelectionTest.cpp
+++ b/dwio/nimble/encodings/tests/EncodingSelectionTest.cpp
@@ -1390,3 +1390,108 @@ TEST(ReplayedEncodingSelectionPolicyTest, nestedEncodingCompressionType) {
     EXPECT_EQ(decoded, data);
   }
 }
+
+TEST(ManualEncodingSelectionPolicyTest, defaultCompressionType) {
+  // Verify that default CompressionOptions uses the compile-time default
+  // compression type.
+  std::vector<uint32_t> data(1000, 42);
+
+  auto policy =
+      std::make_unique<nimble::ManualEncodingSelectionPolicy<uint32_t>>(
+          nimble::ManualEncodingSelectionPolicyFactory::defaultReadFactors(),
+          nimble::CompressionOptions{},
+          std::nullopt);
+  auto result =
+      policy->select(data, nimble::Statistics<uint32_t>::create(data));
+  auto compressionPolicy = result.compressionPolicyFactory();
+  auto info = compressionPolicy->compression();
+
+#ifndef DISABLE_META_INTERNAL_COMPRESSOR
+  EXPECT_EQ(info.compressionType, nimble::CompressionType::MetaInternal);
+#else
+  EXPECT_EQ(info.compressionType, nimble::CompressionType::Zstd);
+#endif
+}
+
+TEST(ManualEncodingSelectionPolicyTest, explicitZstdCompressionType) {
+  // Verify that explicitly setting compressionType to Zstd overrides the
+  // compile-time default.
+  std::vector<uint32_t> data(1000, 42);
+
+  nimble::CompressionOptions options{
+      .compressionType = nimble::CompressionType::Zstd,
+  };
+  auto policy =
+      std::make_unique<nimble::ManualEncodingSelectionPolicy<uint32_t>>(
+          nimble::ManualEncodingSelectionPolicyFactory::defaultReadFactors(),
+          options,
+          std::nullopt);
+  auto result =
+      policy->select(data, nimble::Statistics<uint32_t>::create(data));
+  auto compressionPolicy = result.compressionPolicyFactory();
+  auto info = compressionPolicy->compression();
+
+  EXPECT_EQ(info.compressionType, nimble::CompressionType::Zstd);
+  EXPECT_EQ(
+      info.parameters.zstd.compressionLevel, options.zstdCompressionLevel);
+}
+
+TEST(ManualEncodingSelectionPolicyTest, explicitMetaInternalCompressionType) {
+  // Verify that explicitly setting compressionType to MetaInternal overrides
+  // the compile-time default.
+  std::vector<uint32_t> data(1000, 42);
+
+  nimble::CompressionOptions options{
+      .compressionType = nimble::CompressionType::MetaInternal,
+      .internalCompressionLevel = 7,
+      .internalDecompressionLevel = 3,
+  };
+  auto policy =
+      std::make_unique<nimble::ManualEncodingSelectionPolicy<uint32_t>>(
+          nimble::ManualEncodingSelectionPolicyFactory::defaultReadFactors(),
+          options,
+          std::nullopt);
+  auto result =
+      policy->select(data, nimble::Statistics<uint32_t>::create(data));
+  auto compressionPolicy = result.compressionPolicyFactory();
+  auto info = compressionPolicy->compression();
+
+  EXPECT_EQ(info.compressionType, nimble::CompressionType::MetaInternal);
+  EXPECT_EQ(
+      info.parameters.metaInternal.compressionLevel,
+      options.internalCompressionLevel);
+  EXPECT_EQ(
+      info.parameters.metaInternal.decompressionLevel,
+      options.internalDecompressionLevel);
+}
+
+TEST(ManualEncodingSelectionPolicyTest, compressionTypeRoundTrip) {
+  // Verify that data encoded with an explicit compression type can be
+  // decoded correctly.
+  auto pool = velox::memory::deprecatedAddDefaultLeafMemoryPool();
+  nimble::Buffer buffer(*pool);
+
+  std::vector<uint32_t> data(1000, 42);
+
+  nimble::CompressionOptions options{
+      .compressionType = nimble::CompressionType::Zstd,
+  };
+  auto policy =
+      std::make_unique<nimble::ManualEncodingSelectionPolicy<uint32_t>>(
+          nimble::ManualEncodingSelectionPolicyFactory::defaultReadFactors(),
+          options,
+          std::nullopt);
+
+  auto encoded = nimble::EncodingFactory::encode<uint32_t>(
+      std::move(policy), std::span<const uint32_t>(data), buffer);
+
+  auto encoding = nimble::EncodingFactory().create(
+      *pool, encoded, [&](uint32_t totalLength) -> void* {
+        return pool->allocate(totalLength);
+      });
+  EXPECT_EQ(encoding->rowCount(), data.size());
+
+  std::vector<uint32_t> decoded(data.size());
+  encoding->materialize(static_cast<uint32_t>(data.size()), decoded.data());
+  EXPECT_EQ(decoded, data);
+}


### PR DESCRIPTION
Summary:

AlwaysCompressPolicy currently hardcodes the compression type at compile time via `#ifndef DISABLE_META_INTERNAL_COMPRESSOR` — MetaInternal (ZStrong) for internal builds, ZSTD for OSS. There is no runtime way to choose between compressors.

This adds an optional `compressionType` field to `CompressionOptions`. When set, `AlwaysCompressPolicy` uses the specified type instead of the compile-time default. When `nullopt` (the default), behavior is unchanged — fully backward compatible.

This is useful for benchmarking different compressors (our EBF SST benchmarks showed ZStrong decompression is 81-94% slower than ZSTD for per-stream compression of small buffers) and for workloads that benefit from a specific compressor.

Reviewed By: HuamengJiang

Differential Revision: D101430098
