### PR TITLE
refactor: Simplify DenseIndex FlatBuffers schema (#665)

### DIFF
--- a/dwio/nimble/index/CMakeLists.txt
+++ b/dwio/nimble/index/CMakeLists.txt
@@ -20,6 +20,7 @@ add_library(
   ClusterIndexGroup.cpp
   ClusterIndexReader.cpp
   IndexFilter.cpp
+  IndexLookup.cpp
   SortOrder.cpp
 )
 
@@ -33,7 +34,9 @@ target_link_libraries(
   velox_core
   velox_type
   velox_vector
+  nimble_velox_common
   velox_key_encoder
+  fmt::fmt
   velox_dwio_common
   velox_memory
   Folly::folly

--- a/dwio/nimble/index/IndexLookup.cpp
+++ b/dwio/nimble/index/IndexLookup.cpp
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "dwio/nimble/index/IndexLookup.h"
+
+#include "dwio/nimble/common/Exceptions.h"
+
+namespace facebook::nimble::index {
+
+std::string toString(IndexType indexType) {
+  switch (indexType) {
+    case IndexType::Cluster:
+      return "Cluster";
+    case IndexType::Dense:
+      return "Dense";
+    default:
+      NIMBLE_UNREACHABLE("Unknown IndexType: {}", static_cast<int>(indexType));
+  }
+}
+
+std::ostream& operator<<(std::ostream& out, IndexType indexType) {
+  return out << toString(indexType);
+}
+
+} // namespace facebook::nimble::index

--- a/dwio/nimble/index/IndexLookup.h
+++ b/dwio/nimble/index/IndexLookup.h
@@ -1,0 +1,160 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <cstdint>
+#include <optional>
+#include <ostream>
+#include <string>
+#include <string_view>
+#include <vector>
+
+#include <fmt/format.h>
+#include <folly/Range.h>
+
+#include "dwio/nimble/common/Exceptions.h"
+#include "dwio/nimble/velox/RowRange.h"
+#include "velox/serializers/KeyEncoder.h"
+
+namespace facebook::nimble::index {
+
+/// Type of index.
+enum class IndexType {
+  /// Range-based index on sorted data. Supports range scans and point lookups
+  /// using key boundaries per stripe/chunk.
+  Cluster,
+  /// Hash-based index for point lookups on unsorted data. Maps composite key
+  /// columns to exact row numbers.
+  Dense,
+};
+
+std::string toString(IndexType indexType);
+std::ostream& operator<<(std::ostream& out, IndexType indexType);
+
+/// Unified index interface for both cluster and dense indices.
+///
+/// This provides a common abstraction for index metadata and lookup
+/// capabilities. Both ClusterIndex and DenseIndex implement this interface,
+/// enabling the reader to select the best index for a given query without
+/// knowing the concrete type.
+///
+/// The lookup semantics differ by index type:
+/// - Cluster index: returns file-level RowRanges spanning matching rows
+/// - Dense index: returns file-level RowRanges for exact single rows
+class IndexLookup {
+ public:
+  /// Batch lookup request. Contains encoded key bounds and options.
+  class LookupRequest {
+   public:
+    /// Options for controlling lookup behavior.
+    struct Options {
+      /// Limit results to this file-level row range. Rows outside this range
+      /// are excluded from the result. When set, the index only searches
+      /// within the specified range. When not set, the entire file is searched.
+      std::optional<RowRange> rowRange;
+    };
+
+    LookupRequest(
+        const std::vector<velox::serializer::EncodedKeyBounds>& keyBounds,
+        Options options = {})
+        : keyBounds_{keyBounds}, options_{options} {
+      NIMBLE_CHECK(!keyBounds_.empty());
+    }
+
+    uint32_t size() const {
+      return keyBounds_.size();
+    }
+
+    const velox::serializer::EncodedKeyBounds& keyBound(uint32_t idx) const {
+      NIMBLE_DCHECK_LT(idx, keyBounds_.size());
+      return keyBounds_[idx];
+    }
+
+    const Options& options() const {
+      return options_;
+    }
+
+   private:
+    const std::vector<velox::serializer::EncodedKeyBounds> keyBounds_;
+    const Options options_;
+  };
+
+  using LookupOptions = LookupRequest::Options;
+
+  /// Batch lookup result. Stores a flat array of RowRanges with
+  /// per-key offsets for O(1) access via operator[].
+  class LookupResult {
+   public:
+    LookupResult(
+        std::vector<RowRange> rowRanges,
+        std::vector<uint32_t> resultOffsets)
+        : rowRanges_{std::move(rowRanges)},
+          resultOffsets_{std::move(resultOffsets)} {
+      NIMBLE_CHECK_GT(resultOffsets_.size(), 1);
+      NIMBLE_CHECK_GE(
+          rowRanges_.size(),
+          resultOffsets_.back(),
+          "Result offsets reference beyond rowRanges");
+    }
+
+    uint32_t size() const {
+      return resultOffsets_.size() - 1;
+    }
+
+    folly::Range<const RowRange*> operator[](uint32_t idx) const {
+      NIMBLE_DCHECK_LT(idx, size());
+      NIMBLE_DCHECK_LE(resultOffsets_[idx], resultOffsets_[idx + 1]);
+      NIMBLE_DCHECK_LE(resultOffsets_[idx + 1], rowRanges_.size());
+      return {
+          rowRanges_.data() + resultOffsets_[idx],
+          rowRanges_.data() + resultOffsets_[idx + 1]};
+    }
+
+   private:
+    const std::vector<RowRange> rowRanges_;
+    const std::vector<uint32_t> resultOffsets_;
+  };
+
+  virtual ~IndexLookup() = default;
+
+  /// Returns the type of this index.
+  virtual IndexType indexType() const = 0;
+
+  /// Returns the column names this index covers, in index definition order.
+  virtual const std::vector<std::string>& indexColumns() const = 0;
+
+  /// Batch lookup of row locations matching the encoded key bounds.
+  ///
+  /// For cluster index: supports both point lookups and range lookups.
+  ///   Returns file-level RowRanges spanning matching rows.
+  /// For dense index: only supports point lookups. Returns file-level
+  ///   RowRanges for exact single rows (may return multiple per key).
+  ///
+  /// Results are indexed by input key position: result[i] returns the
+  /// RowRanges for request.keyBounds()[i].
+  virtual LookupResult lookup(const LookupRequest& request) const = 0;
+};
+
+} // namespace facebook::nimble::index
+
+template <>
+struct fmt::formatter<facebook::nimble::index::IndexType>
+    : formatter<std::string> {
+  auto format(facebook::nimble::index::IndexType s, format_context& ctx) const {
+    return formatter<std::string>::format(
+        facebook::nimble::index::toString(s), ctx);
+  }
+};

--- a/dwio/nimble/index/tests/CMakeLists.txt
+++ b/dwio/nimble/index/tests/CMakeLists.txt
@@ -42,6 +42,7 @@ add_executable(
   IndexConstantsTest.cpp
   IndexConfigTest.cpp
   IndexFilterTest.cpp
+  IndexLookupTest.cpp
   ClusterIndexReaderTest.cpp
   ClusterIndexGroupTest.cpp
   ClusterIndexTest.cpp

--- a/dwio/nimble/index/tests/IndexLookupTest.cpp
+++ b/dwio/nimble/index/tests/IndexLookupTest.cpp
@@ -1,0 +1,204 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include <gtest/gtest.h>
+
+#include <sstream>
+
+#include "dwio/nimble/common/tests/GTestUtils.h"
+#include "dwio/nimble/index/IndexLookup.h"
+
+namespace facebook::nimble::index::test {
+namespace {
+
+using LookupRequest = IndexLookup::LookupRequest;
+using LookupResult = IndexLookup::LookupResult;
+using LookupOptions = IndexLookup::LookupOptions;
+
+class IndexLookupTest : public ::testing::Test {
+ protected:
+  static velox::serializer::EncodedKeyBounds makePointKey(
+      const std::string& key) {
+    return {.lowerKey = key, .upperKey = key};
+  }
+
+  static velox::serializer::EncodedKeyBounds makeRangeKey(
+      const std::string& lower,
+      const std::string& upper) {
+    return {.lowerKey = lower, .upperKey = upper};
+  }
+};
+
+TEST_F(IndexLookupTest, basicRequest) {
+  std::vector<velox::serializer::EncodedKeyBounds> keys = {
+      makePointKey("aaa"), makePointKey("bbb")};
+  LookupRequest request(keys);
+
+  EXPECT_EQ(request.size(), 2);
+  EXPECT_TRUE(request.keyBound(0).isPointLookup());
+  EXPECT_EQ(request.keyBound(0).lowerKey.value(), "aaa");
+  EXPECT_EQ(request.keyBound(1).lowerKey.value(), "bbb");
+  EXPECT_FALSE(request.options().rowRange.has_value());
+}
+
+TEST_F(IndexLookupTest, withOptions) {
+  std::vector<velox::serializer::EncodedKeyBounds> keys = {makePointKey("key")};
+  LookupRequest request(keys, {.rowRange = RowRange(10, 100)});
+
+  EXPECT_EQ(request.size(), 1);
+  EXPECT_TRUE(request.options().rowRange.has_value());
+  EXPECT_EQ(request.options().rowRange->startRow, 10);
+  EXPECT_EQ(request.options().rowRange->endRow, 100);
+}
+
+TEST_F(IndexLookupTest, moveConstruction) {
+  std::vector<velox::serializer::EncodedKeyBounds> keys = {
+      makePointKey("aaa"), makePointKey("bbb"), makePointKey("ccc")};
+  LookupRequest request(std::move(keys));
+
+  EXPECT_EQ(request.size(), 3);
+  EXPECT_EQ(request.keyBound(2).lowerKey.value(), "ccc");
+}
+
+TEST_F(IndexLookupTest, emptyKeyBoundsThrows) {
+  NIMBLE_ASSERT_THROW(LookupRequest({}), "");
+}
+
+TEST_F(IndexLookupTest, rangeKeys) {
+  std::vector<velox::serializer::EncodedKeyBounds> keys = {
+      makeRangeKey("aaa", "zzz")};
+  LookupRequest request(keys);
+
+  EXPECT_FALSE(request.keyBound(0).isPointLookup());
+  EXPECT_EQ(request.keyBound(0).lowerKey.value(), "aaa");
+  EXPECT_EQ(request.keyBound(0).upperKey.value(), "zzz");
+}
+
+TEST_F(IndexLookupTest, singleKeyWithResult) {
+  std::vector<RowRange> rowRanges = {RowRange(10, 20)};
+  std::vector<uint32_t> resultOffsets = {0, 1};
+  LookupResult result(std::move(rowRanges), std::move(resultOffsets));
+
+  EXPECT_EQ(result.size(), 1);
+  EXPECT_EQ(result[0].size(), 1);
+  EXPECT_EQ(result[0][0].startRow, 10);
+  EXPECT_EQ(result[0][0].endRow, 20);
+}
+
+TEST_F(IndexLookupTest, singleKeyMultiResults) {
+  std::vector<RowRange> rowRanges = {
+      RowRange(10, 20), RowRange(50, 60), RowRange(100, 110)};
+  std::vector<uint32_t> resultOffsets = {0, 3};
+  LookupResult result(std::move(rowRanges), std::move(resultOffsets));
+
+  EXPECT_EQ(result.size(), 1);
+  EXPECT_EQ(result[0].size(), 3);
+  EXPECT_EQ(result[0][0].startRow, 10);
+  EXPECT_EQ(result[0][1].startRow, 50);
+  EXPECT_EQ(result[0][2].startRow, 100);
+}
+
+TEST_F(IndexLookupTest, singleKeyNoResult) {
+  std::vector<RowRange> rowRanges;
+  std::vector<uint32_t> resultOffsets = {0, 0};
+  LookupResult result(std::move(rowRanges), std::move(resultOffsets));
+
+  EXPECT_EQ(result.size(), 1);
+  EXPECT_TRUE(result[0].empty());
+}
+
+TEST_F(IndexLookupTest, multipleKeys) {
+  std::vector<RowRange> rowRanges = {
+      RowRange(0, 10), RowRange(50, 60), RowRange(100, 110)};
+  // key0 → 1 result, key1 → 0 results, key2 → 2 results
+  std::vector<uint32_t> resultOffsets = {0, 1, 1, 3};
+  LookupResult result(std::move(rowRanges), std::move(resultOffsets));
+
+  EXPECT_EQ(result.size(), 3);
+
+  EXPECT_EQ(result[0].size(), 1);
+  EXPECT_EQ(result[0][0].startRow, 0);
+
+  EXPECT_TRUE(result[1].empty());
+
+  EXPECT_EQ(result[2].size(), 2);
+  EXPECT_EQ(result[2][0].startRow, 50);
+  EXPECT_EQ(result[2][1].startRow, 100);
+}
+
+TEST_F(IndexLookupTest, allKeysEmpty) {
+  std::vector<RowRange> rowRanges;
+  std::vector<uint32_t> resultOffsets = {0, 0, 0, 0};
+  LookupResult result(std::move(rowRanges), std::move(resultOffsets));
+
+  EXPECT_EQ(result.size(), 3);
+  EXPECT_TRUE(result[0].empty());
+  EXPECT_TRUE(result[1].empty());
+  EXPECT_TRUE(result[2].empty());
+  NIMBLE_ASSERT_THROW(result[3], "");
+}
+
+TEST_F(IndexLookupTest, tooFewOffsets) {
+  NIMBLE_ASSERT_THROW(LookupResult({}, {0}), "");
+}
+
+TEST_F(IndexLookupTest, emptyOffsets) {
+  NIMBLE_ASSERT_THROW(LookupResult({}, {}), "");
+}
+
+TEST_F(IndexLookupTest, offsetsBeyondRowRanges) {
+  std::vector<RowRange> rowRanges = {RowRange(0, 10)};
+  // Offset 2 references beyond the single-element rowRanges vector.
+  NIMBLE_ASSERT_THROW(LookupResult(std::move(rowRanges), {0, 2}), "");
+}
+
+TEST_F(IndexLookupTest, offsetsBeyondRowRangesMultiKey) {
+  std::vector<RowRange> rowRanges = {RowRange(0, 10), RowRange(20, 30)};
+  // Last offset 3 references beyond the 2-element rowRanges vector.
+  NIMBLE_ASSERT_THROW(LookupResult(std::move(rowRanges), {0, 1, 3}), "");
+}
+
+TEST_F(IndexLookupTest, nonMonotonicOffsets) {
+  std::vector<RowRange> rowRanges = {RowRange(0, 10), RowRange(20, 30)};
+  // Offsets go backwards: 0, 2, 1 — violates monotonic invariant.
+  LookupResult result(std::move(rowRanges), {0, 2, 1});
+  EXPECT_EQ(result.size(), 2);
+  // First key access is valid.
+  EXPECT_EQ(result[0].size(), 2);
+  // Second key access triggers DCHECK on non-monotonic offsets.
+  NIMBLE_ASSERT_THROW(result[1], "");
+}
+
+TEST_F(IndexLookupTest, toString) {
+  EXPECT_EQ(toString(IndexType::Cluster), "Cluster");
+  EXPECT_EQ(toString(IndexType::Dense), "Dense");
+}
+
+TEST_F(IndexLookupTest, ostream) {
+  std::ostringstream oss;
+  oss << IndexType::Cluster << " " << IndexType::Dense;
+  EXPECT_EQ(oss.str(), "Cluster Dense");
+}
+
+TEST_F(IndexLookupTest, fmtFormat) {
+  EXPECT_EQ(fmt::format("{}", IndexType::Cluster), "Cluster");
+  EXPECT_EQ(fmt::format("{}", IndexType::Dense), "Dense");
+  EXPECT_EQ(
+      fmt::format("type={}, count={}", IndexType::Dense, 42),
+      "type=Dense, count=42");
+}
+
+} // namespace
+} // namespace facebook::nimble::index::test

--- a/dwio/nimble/tablet/Constants.h
+++ b/dwio/nimble/tablet/Constants.h
@@ -36,5 +36,6 @@ constexpr std::string_view kVectorizedStatsSection =
     "columnar.vectorized_stats";
 constexpr std::string_view kClusterIndexSection = "columnar.cluster.index";
 constexpr std::string_view kChunkIndexSection = "columnar.chunk.index";
+constexpr std::string_view kDenseIndexSection = "columnar.dense.index";
 
 } // namespace facebook::nimble

--- a/dwio/nimble/tablet/DenseIndex.fbs
+++ b/dwio/nimble/tablet/DenseIndex.fbs
@@ -28,9 +28,6 @@ namespace facebook.nimble.serialization;
 ///   3. Scan keys in bucket by exact key match
 ///   4. Return matching row numbers
 table DenseIndex {
-  /// Names of columns forming the composite key.
-  index_columns:[string];
-
   /// Total number of rows indexed.
   row_count:uint64;
 
@@ -41,11 +38,6 @@ table DenseIndex {
   num_keys:uint64;
   /// Load factor used during construction (for diagnostics).
   load_factor:float;
-
-  /// Accumulated row counts per stripe (prefix sum).
-  /// Enables translating global row number to (stripe, stripe-local row).
-  /// Size = stripe_count.
-  stripe_row_counts:[uint32];
 
   /// Optional bloom filter for fast negative lookups.
   bloom_filter:BloomFilter;
@@ -75,7 +67,7 @@ table DenseIndexPartition {
   /// Binary-encoded composite keys for this partition. Aligned with
   /// row_numbers: encoded_keys[i] corresponds to row_numbers[i].
   encoded_keys:[string];
-  /// Global row numbers for this partition. Aligned with encoded_keys.
+  /// File row numbers for this partition. Aligned with encoded_keys.
   row_numbers:[uint32];
 }
 


### PR DESCRIPTION
Summary:

CONTEXT: The DenseIndex FlatBuffers schema had fields that duplicated information available elsewhere. `index_columns` was moved to DenseIndexSection for lazy loading, and `stripe_row_counts` was removed since the reader resolves stripe boundaries from the tablet footer.

WHAT: Removes redundant fields from DenseIndex table:
- `index_columns`: moved to DenseIndexSection (avoids loading full index just to check column names)
- `stripe_row_counts`: stripe boundaries resolved from tablet footer
- Adds `kDenseIndexSection` constant for the optional section name

Differential Revision: D101763949


