### PR TITLE
refactor: Add chunkSize to ChunkLocation and rename ChunkIndexWriter::newStripe

### DIFF
--- a/dwio/nimble/index/ChunkIndexGroup.cpp
+++ b/dwio/nimble/index/ChunkIndexGroup.cpp
@@ -52,7 +52,8 @@ ChunkIndexGroup::ChunkIndexGroup(
 
 std::shared_ptr<StreamIndex> ChunkIndexGroup::createStreamIndex(
     uint32_t stripe,
-    uint32_t streamId) const {
+    uint32_t streamId,
+    uint32_t streamSize) const {
   if (streamId >= streamCount_) {
     return nullptr;
   }
@@ -78,27 +79,38 @@ std::shared_ptr<StreamIndex> ChunkIndexGroup::createStreamIndex(
   }
 
   return StreamIndex::create(
-      shared_from_this(), streamId, startChunkOffset, endChunkOffset);
+      shared_from_this(),
+      streamId,
+      startChunkOffset,
+      endChunkOffset,
+      streamSize);
 }
 
 std::shared_ptr<StreamIndex> StreamIndex::create(
     std::shared_ptr<const ChunkIndexGroup> chunkIndex,
     uint32_t streamId,
     uint32_t startChunkOffset,
-    uint32_t endChunkOffset) {
+    uint32_t endChunkOffset,
+    uint32_t streamSize) {
   return std::shared_ptr<StreamIndex>(new StreamIndex(
-      std::move(chunkIndex), streamId, startChunkOffset, endChunkOffset));
+      std::move(chunkIndex),
+      streamId,
+      startChunkOffset,
+      endChunkOffset,
+      streamSize));
 }
 
 StreamIndex::StreamIndex(
     std::shared_ptr<const ChunkIndexGroup> chunkIndex,
     uint32_t streamId,
     uint32_t startChunkOffset,
-    uint32_t endChunkOffset)
+    uint32_t endChunkOffset,
+    uint32_t streamSize)
     : chunkIndex_(std::move(chunkIndex)),
       streamId_(streamId),
       startChunkOffset_(startChunkOffset),
-      endChunkOffset_(endChunkOffset) {
+      endChunkOffset_(endChunkOffset),
+      streamSize_(streamSize) {
   NIMBLE_CHECK_NOT_NULL(chunkIndex_);
 }
 
@@ -124,7 +136,11 @@ ChunkLocation StreamIndex::lookupChunk(uint32_t rowId) const {
   NIMBLE_CHECK_NOT_NULL(chunkOffsets);
   const uint32_t rowOffset =
       chunkOffset == startChunkOffset_ ? 0 : chunkRows->Get(chunkOffset - 1);
-  return ChunkLocation{chunkOffsets->Get(chunkOffset), rowOffset};
+  const uint32_t streamOffset = chunkOffsets->Get(chunkOffset);
+  const uint32_t nextOffset = (chunkOffset + 1 < endChunkOffset_)
+      ? chunkOffsets->Get(chunkOffset + 1)
+      : streamSize_;
+  return ChunkLocation{streamOffset, nextOffset - streamOffset, rowOffset};
 }
 
 uint32_t StreamIndex::rowCount() const {

--- a/dwio/nimble/index/ChunkIndexGroup.h
+++ b/dwio/nimble/index/ChunkIndexGroup.h
@@ -53,9 +53,11 @@ class ChunkIndexGroup : public std::enable_shared_from_this<ChunkIndexGroup> {
 
   /// Creates a StreamIndex for the specified stripe and stream ID.
   /// Returns nullptr if the stream is not indexed (has ≤1 chunk).
+  /// @param streamSize Total byte size of the stream in this stripe.
   std::shared_ptr<StreamIndex> createStreamIndex(
       uint32_t stripe,
-      uint32_t streamId) const;
+      uint32_t streamId,
+      uint32_t streamSize) const;
 
  private:
   ChunkIndexGroup(
@@ -93,7 +95,8 @@ class StreamIndex {
       std::shared_ptr<const ChunkIndexGroup> chunkIndex,
       uint32_t streamId,
       uint32_t startChunkOffset,
-      uint32_t endChunkOffset);
+      uint32_t endChunkOffset,
+      uint32_t streamSize);
 
   /// Lookup chunk by row ID within the stream's row range.
   ChunkLocation lookupChunk(uint32_t rowId) const;
@@ -111,7 +114,8 @@ class StreamIndex {
       std::shared_ptr<const ChunkIndexGroup> chunkIndex,
       uint32_t streamId,
       uint32_t startChunkOffset,
-      uint32_t endChunkOffset);
+      uint32_t endChunkOffset,
+      uint32_t streamSize);
 
   // Kept alive to ensure metadata_ stays valid.
   const std::shared_ptr<const ChunkIndexGroup> chunkIndex_;
@@ -120,6 +124,9 @@ class StreamIndex {
   // flattened chunk_rows/chunk_offsets arrays.
   const uint32_t startChunkOffset_;
   const uint32_t endChunkOffset_;
+  // Total byte size of the stream in this stripe, used to compute
+  // the last chunk's size.
+  const uint32_t streamSize_;
 };
 
 } // namespace facebook::nimble::index

--- a/dwio/nimble/index/ClusterIndexGroup.cpp
+++ b/dwio/nimble/index/ClusterIndexGroup.cpp
@@ -87,7 +87,7 @@ std::optional<ChunkLocation> ClusterIndexGroup::lookupChunk(
   // location at offset 0.
   const auto* chunkIndex = root->chunk_index();
   if (chunkIndex == nullptr) {
-    return ChunkLocation{0, 0};
+    return ChunkLocation{0, 0, 0};
   }
 
   // Get chunk counts to determine the search range for this stripe.
@@ -132,7 +132,7 @@ std::optional<ChunkLocation> ClusterIndexGroup::lookupChunk(
   // Return the found chunk location.
   const uint32_t rowOffset =
       chunkOffset == startChunkIndex ? 0 : chunkRows->Get(chunkOffset - 1);
-  return ChunkLocation{chunkOffsets->Get(chunkOffset), rowOffset};
+  return ChunkLocation{chunkOffsets->Get(chunkOffset), 0, rowOffset};
 }
 
 velox::common::Region ClusterIndexGroup::keyStreamRegion(

--- a/dwio/nimble/index/ClusterIndexReader.cpp
+++ b/dwio/nimble/index/ClusterIndexReader.cpp
@@ -55,7 +55,7 @@ std::optional<uint32_t> ClusterIndexReader::seekAtOrAfter(
   }
 
   const auto rowOffset =
-      seekAtOrAfterInChunk(chunkLocation->streamOffset, encodedKey);
+      seekAtOrAfterInChunk(chunkLocation->chunkOffset, encodedKey);
   if (!rowOffset.has_value()) {
     return std::nullopt;
   }

--- a/dwio/nimble/index/IndexLookup.h
+++ b/dwio/nimble/index/IndexLookup.h
@@ -74,7 +74,7 @@ class IndexLookup {
       NIMBLE_CHECK(!keyBounds_.empty());
     }
 
-    uint32_t size() const {
+    size_t size() const {
       return keyBounds_.size();
     }
 
@@ -110,7 +110,7 @@ class IndexLookup {
           "Result offsets reference beyond rowRanges");
     }
 
-    uint32_t size() const {
+    size_t size() const {
       return resultOffsets_.size() - 1;
     }
 

--- a/dwio/nimble/index/IndexTypes.h
+++ b/dwio/nimble/index/IndexTypes.h
@@ -20,15 +20,20 @@
 namespace facebook::nimble::index {
 
 /// Represents the location of a chunk within a stream.
-/// Both offsets are relative:
-/// - streamOffset: relative to the stream start offset within the stripe
-/// - rowOffset: relative to the stripe start row id
+/// Both offsets are relative to the containing unit:
+/// - For chunk index: relative to the stripe (stream start offset and stripe
+///   start row).
+/// - For cluster index: relative to the index partition (key data blob offset
+///   and partition start row).
 struct ChunkLocation {
-  uint32_t streamOffset;
+  uint32_t chunkOffset;
+  uint32_t chunkSize;
   uint32_t rowOffset;
 
-  ChunkLocation(uint32_t _streamOffset, uint32_t _rowOffset)
-      : streamOffset(_streamOffset), rowOffset(_rowOffset) {}
+  ChunkLocation(uint32_t _chunkOffset, uint32_t _chunkSize, uint32_t _rowOffset)
+      : chunkOffset(_chunkOffset),
+        chunkSize(_chunkSize),
+        rowOffset(_rowOffset) {}
 };
 
 } // namespace facebook::nimble::index

--- a/dwio/nimble/index/tests/ChunkIndexTest.cpp
+++ b/dwio/nimble/index/tests/ChunkIndexTest.cpp
@@ -144,26 +144,26 @@ TEST_F(ChunkIndexTest, lookupChunkWithRowId) {
             testCase.stripeIndex,
             testCase.streamId,
             testCase.rowId));
-    auto streamIndex =
-        chunkIndex->createStreamIndex(testCase.stripeIndex, testCase.streamId);
+    auto streamIndex = chunkIndex->createStreamIndex(
+        testCase.stripeIndex, testCase.streamId, /*streamSize=*/1000);
     ASSERT_NE(streamIndex, nullptr);
     auto result = streamIndex->lookupChunk(testCase.rowId);
-    EXPECT_EQ(result.streamOffset, testCase.expectedStreamOffset);
+    EXPECT_EQ(result.chunkOffset, testCase.expectedStreamOffset);
     EXPECT_EQ(result.rowOffset, testCase.expectedRowOffset);
   }
 
   // Row at/after last chunk boundary — throws
-  auto s00 = chunkIndex->createStreamIndex(0, 0);
+  auto s00 = chunkIndex->createStreamIndex(0, 0, /*streamSize=*/1000);
   NIMBLE_ASSERT_THROW(s00->lookupChunk(750), "beyond the last chunk");
   NIMBLE_ASSERT_THROW(s00->lookupChunk(850), "beyond the last chunk");
 
-  auto s01 = chunkIndex->createStreamIndex(0, 1);
+  auto s01 = chunkIndex->createStreamIndex(0, 1, /*streamSize=*/1000);
   NIMBLE_ASSERT_THROW(s01->lookupChunk(450), "beyond the last chunk");
 
-  auto s10 = chunkIndex->createStreamIndex(1, 0);
+  auto s10 = chunkIndex->createStreamIndex(1, 0, /*streamSize=*/1000);
   NIMBLE_ASSERT_THROW(s10->lookupChunk(550), "beyond the last chunk");
 
-  auto s11 = chunkIndex->createStreamIndex(1, 1);
+  auto s11 = chunkIndex->createStreamIndex(1, 1, /*streamSize=*/1000);
   NIMBLE_ASSERT_THROW(s11->lookupChunk(650), "beyond the last chunk");
 }
 
@@ -192,8 +192,8 @@ TEST_F(ChunkIndexTest, createStreamIndex) {
   ASSERT_NE(chunkIndex, nullptr);
 
   // Multi-chunk streams return non-null StreamIndex.
-  EXPECT_NE(chunkIndex->createStreamIndex(0, 0), nullptr);
-  EXPECT_NE(chunkIndex->createStreamIndex(0, 1), nullptr);
+  EXPECT_NE(chunkIndex->createStreamIndex(0, 0, /*streamSize=*/1000), nullptr);
+  EXPECT_NE(chunkIndex->createStreamIndex(0, 1, /*streamSize=*/1000), nullptr);
 }
 
 TEST_F(ChunkIndexTest, singleChunkStreamReturnsNullptr) {
@@ -220,11 +220,11 @@ TEST_F(ChunkIndexTest, singleChunkStreamReturnsNullptr) {
   ASSERT_NE(chunkIndex, nullptr);
 
   // Single-chunk streams return nullptr.
-  EXPECT_EQ(chunkIndex->createStreamIndex(0, 0), nullptr);
-  EXPECT_EQ(chunkIndex->createStreamIndex(0, 2), nullptr);
+  EXPECT_EQ(chunkIndex->createStreamIndex(0, 0, /*streamSize=*/1000), nullptr);
+  EXPECT_EQ(chunkIndex->createStreamIndex(0, 2, /*streamSize=*/1000), nullptr);
 
   // Multi-chunk stream returns non-null.
-  auto streamIndex = chunkIndex->createStreamIndex(0, 1);
+  auto streamIndex = chunkIndex->createStreamIndex(0, 1, /*streamSize=*/1000);
   ASSERT_NE(streamIndex, nullptr);
   EXPECT_EQ(streamIndex->streamId(), 1);
 }
@@ -277,8 +277,8 @@ TEST_F(ChunkIndexTest, streamIndexStreamId) {
             "stripeIndex {} streamId {}",
             testCase.stripeIndex,
             testCase.streamId));
-    auto streamIndex =
-        chunkIndex->createStreamIndex(testCase.stripeIndex, testCase.streamId);
+    auto streamIndex = chunkIndex->createStreamIndex(
+        testCase.stripeIndex, testCase.streamId, /*streamSize=*/1000);
     ASSERT_NE(streamIndex, nullptr);
     EXPECT_EQ(streamIndex->streamId(), testCase.streamId);
   }
@@ -431,35 +431,43 @@ TEST_F(ChunkIndexTest, streamIndexLookupChunk) {
     auto chunkIndex = createChunkIndex(indexBuffers, testCase.groupIndex);
     ASSERT_NE(chunkIndex, nullptr);
 
-    auto streamIndex =
-        chunkIndex->createStreamIndex(testCase.stripeIndex, testCase.streamId);
+    auto streamIndex = chunkIndex->createStreamIndex(
+        testCase.stripeIndex, testCase.streamId, /*streamSize=*/1000);
     ASSERT_NE(streamIndex, nullptr);
 
     auto result = streamIndex->lookupChunk(testCase.rowId);
-    EXPECT_EQ(result.streamOffset, testCase.expectedStreamOffset);
+    EXPECT_EQ(result.chunkOffset, testCase.expectedStreamOffset);
     EXPECT_EQ(result.rowOffset, testCase.expectedRowOffset);
   }
 
   // Row at/after last chunk boundary — throws
   auto ci0 = createChunkIndex(indexBuffers, 0);
   NIMBLE_ASSERT_THROW(
-      ci0->createStreamIndex(0, 0)->lookupChunk(750), "beyond the last chunk");
+      ci0->createStreamIndex(0, 0, /*streamSize=*/1000)->lookupChunk(750),
+      "beyond the last chunk");
   NIMBLE_ASSERT_THROW(
-      ci0->createStreamIndex(0, 1)->lookupChunk(450), "beyond the last chunk");
+      ci0->createStreamIndex(0, 1, /*streamSize=*/1000)->lookupChunk(450),
+      "beyond the last chunk");
   NIMBLE_ASSERT_THROW(
-      ci0->createStreamIndex(1, 0)->lookupChunk(550), "beyond the last chunk");
+      ci0->createStreamIndex(1, 0, /*streamSize=*/1000)->lookupChunk(550),
+      "beyond the last chunk");
   NIMBLE_ASSERT_THROW(
-      ci0->createStreamIndex(1, 1)->lookupChunk(650), "beyond the last chunk");
+      ci0->createStreamIndex(1, 1, /*streamSize=*/1000)->lookupChunk(650),
+      "beyond the last chunk");
 
   auto ci1 = createChunkIndex(indexBuffers, 1);
   NIMBLE_ASSERT_THROW(
-      ci1->createStreamIndex(2, 0)->lookupChunk(450), "beyond the last chunk");
+      ci1->createStreamIndex(2, 0, /*streamSize=*/1000)->lookupChunk(450),
+      "beyond the last chunk");
   NIMBLE_ASSERT_THROW(
-      ci1->createStreamIndex(2, 1)->lookupChunk(540), "beyond the last chunk");
+      ci1->createStreamIndex(2, 1, /*streamSize=*/1000)->lookupChunk(540),
+      "beyond the last chunk");
   NIMBLE_ASSERT_THROW(
-      ci1->createStreamIndex(3, 0)->lookupChunk(480), "beyond the last chunk");
+      ci1->createStreamIndex(3, 0, /*streamSize=*/1000)->lookupChunk(480),
+      "beyond the last chunk");
   NIMBLE_ASSERT_THROW(
-      ci1->createStreamIndex(3, 1)->lookupChunk(360), "beyond the last chunk");
+      ci1->createStreamIndex(3, 1, /*streamSize=*/1000)->lookupChunk(360),
+      "beyond the last chunk");
 }
 
 TEST_F(ChunkIndexTest, stripeIndexAndStreamIdOutOfBound) {
@@ -514,15 +522,16 @@ TEST_F(ChunkIndexTest, stripeIndexAndStreamIdOutOfBound) {
 
   // Test stripe index after group's range
   NIMBLE_ASSERT_THROW(
-      chunkIndex0->createStreamIndex(2, 0),
+      chunkIndex0->createStreamIndex(2, 0, /*streamSize=*/1000),
       "Stripe offset is out of range for this chunk index group");
   NIMBLE_ASSERT_THROW(
-      chunkIndex0->createStreamIndex(3, 0),
+      chunkIndex0->createStreamIndex(3, 0, /*streamSize=*/1000),
       "Stripe offset is out of range for this chunk index group");
 
   // streamId >= streamCount returns nullptr.
-  EXPECT_EQ(chunkIndex0->createStreamIndex(0, 2), nullptr);
-  EXPECT_EQ(chunkIndex0->createStreamIndex(1, 10), nullptr);
+  EXPECT_EQ(chunkIndex0->createStreamIndex(0, 2, /*streamSize=*/1000), nullptr);
+  EXPECT_EQ(
+      chunkIndex0->createStreamIndex(1, 10, /*streamSize=*/1000), nullptr);
 
   // Test Group 1 (stripes 2, 3)
   auto chunkIndex1 = createChunkIndex(indexBuffers, 1);
@@ -530,23 +539,23 @@ TEST_F(ChunkIndexTest, stripeIndexAndStreamIdOutOfBound) {
 
   // Stripe index before group's range (group 1 starts at stripe 2)
   NIMBLE_ASSERT_THROW(
-      chunkIndex1->createStreamIndex(0, 0),
+      chunkIndex1->createStreamIndex(0, 0, /*streamSize=*/1000),
       "Stripe index is before this group's range");
   NIMBLE_ASSERT_THROW(
-      chunkIndex1->createStreamIndex(1, 0),
+      chunkIndex1->createStreamIndex(1, 0, /*streamSize=*/1000),
       "Stripe index is before this group's range");
 
   // Stripe index after group's range (group 1 has stripes 2, 3)
   NIMBLE_ASSERT_THROW(
-      chunkIndex1->createStreamIndex(4, 0),
+      chunkIndex1->createStreamIndex(4, 0, /*streamSize=*/1000),
       "Stripe offset is out of range for this chunk index group");
   NIMBLE_ASSERT_THROW(
-      chunkIndex1->createStreamIndex(5, 0),
+      chunkIndex1->createStreamIndex(5, 0, /*streamSize=*/1000),
       "Stripe offset is out of range for this chunk index group");
 
   // streamId >= streamCount returns nullptr.
-  EXPECT_EQ(chunkIndex1->createStreamIndex(2, 2), nullptr);
-  EXPECT_EQ(chunkIndex1->createStreamIndex(3, 5), nullptr);
+  EXPECT_EQ(chunkIndex1->createStreamIndex(2, 2, /*streamSize=*/1000), nullptr);
+  EXPECT_EQ(chunkIndex1->createStreamIndex(3, 5, /*streamSize=*/1000), nullptr);
 }
 
 TEST_F(ChunkIndexTest, streamIndexRowCount) {
@@ -651,8 +660,8 @@ TEST_F(ChunkIndexTest, streamIndexRowCount) {
     auto chunkIndex = createChunkIndex(indexBuffers, testCase.groupIndex);
     ASSERT_NE(chunkIndex, nullptr);
 
-    auto streamIndex =
-        chunkIndex->createStreamIndex(testCase.stripeIndex, testCase.streamId);
+    auto streamIndex = chunkIndex->createStreamIndex(
+        testCase.stripeIndex, testCase.streamId, /*streamSize=*/1000);
     ASSERT_NE(streamIndex, nullptr);
     EXPECT_EQ(streamIndex->rowCount(), testCase.expectedRowCount);
   }
@@ -709,23 +718,26 @@ TEST_F(ChunkIndexTest, chunkOnlyLookupByRowId) {
             testCase.stripeIndex,
             testCase.streamId,
             testCase.rowId));
-    auto streamIndex =
-        chunkIndex->createStreamIndex(testCase.stripeIndex, testCase.streamId);
+    auto streamIndex = chunkIndex->createStreamIndex(
+        testCase.stripeIndex, testCase.streamId, /*streamSize=*/1000);
     ASSERT_NE(streamIndex, nullptr);
     auto result = streamIndex->lookupChunk(testCase.rowId);
-    EXPECT_EQ(result.streamOffset, testCase.expectedStreamOffset);
+    EXPECT_EQ(result.chunkOffset, testCase.expectedStreamOffset);
     EXPECT_EQ(result.rowOffset, testCase.expectedRowOffset);
   }
 
   // Row at/after last chunk boundary — throws
   NIMBLE_ASSERT_THROW(
-      chunkIndex->createStreamIndex(0, 0)->lookupChunk(750),
+      chunkIndex->createStreamIndex(0, 0, /*streamSize=*/1000)
+          ->lookupChunk(750),
       "beyond the last chunk");
   NIMBLE_ASSERT_THROW(
-      chunkIndex->createStreamIndex(0, 1)->lookupChunk(450),
+      chunkIndex->createStreamIndex(0, 1, /*streamSize=*/1000)
+          ->lookupChunk(450),
       "beyond the last chunk");
   NIMBLE_ASSERT_THROW(
-      chunkIndex->createStreamIndex(1, 0)->lookupChunk(550),
+      chunkIndex->createStreamIndex(1, 0, /*streamSize=*/1000)
+          ->lookupChunk(550),
       "beyond the last chunk");
 }
 

--- a/dwio/nimble/index/tests/ClusterIndexGroupTest.cpp
+++ b/dwio/nimble/index/tests/ClusterIndexGroupTest.cpp
@@ -25,16 +25,19 @@ namespace facebook::nimble::index::test {
 class ClusterIndexGroupTest : public ClusterIndexTestBase {};
 
 TEST_F(ClusterIndexGroupTest, chunkLocation) {
-  ChunkLocation loc1{100, 200};
-  EXPECT_EQ(loc1.streamOffset, 100);
+  ChunkLocation loc1{100, 50, 200};
+  EXPECT_EQ(loc1.chunkOffset, 100);
+  EXPECT_EQ(loc1.chunkSize, 50);
   EXPECT_EQ(loc1.rowOffset, 200);
 
-  ChunkLocation loc2{0, 0};
-  EXPECT_EQ(loc2.streamOffset, 0);
+  ChunkLocation loc2{0, 0, 0};
+  EXPECT_EQ(loc2.chunkOffset, 0);
+  EXPECT_EQ(loc2.chunkSize, 0);
   EXPECT_EQ(loc2.rowOffset, 0);
 
-  ChunkLocation loc3{UINT32_MAX, UINT32_MAX};
-  EXPECT_EQ(loc3.streamOffset, UINT32_MAX);
+  ChunkLocation loc3{UINT32_MAX, UINT32_MAX, UINT32_MAX};
+  EXPECT_EQ(loc3.chunkOffset, UINT32_MAX);
+  EXPECT_EQ(loc3.chunkSize, UINT32_MAX);
   EXPECT_EQ(loc3.rowOffset, UINT32_MAX);
 }
 
@@ -220,7 +223,7 @@ TEST_F(ClusterIndexGroupTest, lookupChunkWithEncodedKey) {
   struct {
     uint32_t stripeIndex;
     std::string encodedKey;
-    std::optional<uint32_t> expectedStreamOffset;
+    std::optional<uint32_t> expectedChunkOffset;
     std::optional<uint32_t> expectedRowOffset;
   } testCases[] = {
       // Stripe 0: chunks with keys "ccc", "fff", "iii"
@@ -271,19 +274,19 @@ TEST_F(ClusterIndexGroupTest, lookupChunkWithEncodedKey) {
             testCase.encodedKey));
     auto result = clusterIndexGroup->lookupChunk(
         testCase.stripeIndex, testCase.encodedKey);
-    if (testCase.expectedStreamOffset.has_value()) {
+    if (testCase.expectedChunkOffset.has_value()) {
       ASSERT_TRUE(result.has_value())
           << "Expected chunk at streamOffset "
-          << testCase.expectedStreamOffset.value() << ", rowOffset "
+          << testCase.expectedChunkOffset.value() << ", rowOffset "
           << testCase.expectedRowOffset.value() << " for key '"
           << testCase.encodedKey << "', but lookup returned nullopt";
-      EXPECT_EQ(result->streamOffset, testCase.expectedStreamOffset.value());
+      EXPECT_EQ(result->chunkOffset, testCase.expectedChunkOffset.value());
       EXPECT_EQ(result->rowOffset, testCase.expectedRowOffset.value());
     } else {
       EXPECT_FALSE(result.has_value())
           << "Expected nullopt for key '" << testCase.encodedKey
-          << "', but got streamOffset " << result->streamOffset
-          << ", rowOffset " << result->rowOffset;
+          << "', but got streamOffset " << result->chunkOffset << ", rowOffset "
+          << result->rowOffset;
     }
   }
 }

--- a/dwio/nimble/tablet/Chunk.h
+++ b/dwio/nimble/tablet/Chunk.h
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <cstdint>
+#include <string_view>
+#include <vector>
+
+namespace facebook::nimble {
+
+/// Represents a single chunk of encoded data within a stream.
+/// A stream may be divided into multiple chunks to control memory usage during
+/// writing. Each chunk contains the encoded data and row count.
+struct Chunk {
+  uint32_t rowCount{0};
+
+  /// The encoded and compressed data content of this chunk, stored as a vector
+  /// of string views. Each string_view points to a buffer containing a portion
+  /// of the chunk's data. Multiple buffers may be used for large chunks.
+  std::vector<std::string_view> content;
+
+  /// Returns the total byte size of all content in this chunk.
+  uint32_t contentSize() const {
+    uint32_t size = 0;
+    for (const auto& c : content) {
+      size += c.size();
+    }
+    return size;
+  }
+};
+
+} // namespace facebook::nimble

--- a/dwio/nimble/tablet/TabletReader.cpp
+++ b/dwio/nimble/tablet/TabletReader.cpp
@@ -929,6 +929,13 @@ std::span<const uint32_t> TabletReader::streamSizes(
   return stripe.stripeGroup()->streamSizes(stripe.stripeId());
 }
 
+uint32_t TabletReader::streamSize(
+    const StripeIdentifier& stripe,
+    uint32_t streamId) const {
+  const auto sizes = streamSizes(stripe);
+  return streamId < sizes.size() ? sizes[streamId] : 0;
+}
+
 uint32_t TabletReader::streamCount(const StripeIdentifier& stripe) const {
   NIMBLE_DCHECK_LT(stripe.stripeId(), stripeCount_, "Stripe is out of range.");
   return stripe.stripeGroup()->streamCount();

--- a/dwio/nimble/tablet/TabletReader.h
+++ b/dwio/nimble/tablet/TabletReader.h
@@ -321,6 +321,10 @@ class TabletReader {
   /// `streamOffsets()`.
   std::span<const uint32_t> streamSizes(const StripeIdentifier& stripe) const;
 
+  /// Returns the byte size of a single stream in the specified stripe.
+  /// Returns 0 if the stream does not exist in this stripe.
+  uint32_t streamSize(const StripeIdentifier& stripe, uint32_t streamId) const;
+
   /// Returns stream count for the specified stripe. Has same constraint as
   /// `streamOffsets()`.
   uint32_t streamCount(const StripeIdentifier& stripe) const;

--- a/dwio/nimble/tablet/TabletWriter.cpp
+++ b/dwio/nimble/tablet/TabletWriter.cpp
@@ -23,14 +23,6 @@
 
 namespace facebook::nimble {
 
-uint32_t Chunk::contentSize() const {
-  uint32_t size = 0;
-  for (const auto& c : content) {
-    size += c.size();
-  }
-  return size;
-}
-
 std::unique_ptr<TabletWriter> TabletWriter::create(
     velox::WriteFile* file,
     velox::memory::MemoryPool& pool,

--- a/dwio/nimble/tablet/TabletWriter.h
+++ b/dwio/nimble/tablet/TabletWriter.h
@@ -19,6 +19,7 @@
 #include "dwio/nimble/common/Buffer.h"
 #include "dwio/nimble/common/Checksum.h"
 #include "dwio/nimble/common/Vector.h"
+#include "dwio/nimble/tablet/Chunk.h"
 #include "dwio/nimble/tablet/ChunkIndexWriter.h"
 #include "dwio/nimble/tablet/ClusterIndexWriter.h"
 #include "dwio/nimble/tablet/FileLayout.h"
@@ -28,26 +29,6 @@
 #include "velox/vector/TypeAliases.h"
 
 namespace facebook::nimble {
-/// Represents a single chunk of encoded data within a stream.
-/// A stream may be divided into multiple chunks to control memory usage during
-/// writing. Each chunk contains the encoded data and row count.
-struct Chunk {
-  /// Number of rows contained in this chunk.
-  uint32_t rowCount{0};
-
-  /// The encoded and compressed data content of this chunk, stored as a vector
-  /// of string views. Each string_view points to a buffer containing a portion
-  /// of the chunk's data. Multiple buffers may be used for large chunks.
-  std::vector<std::string_view> content;
-
-  /// Returns the total byte size of all content in this chunk.
-  uint32_t contentSize() const;
-};
-
-struct Stream {
-  uint32_t offset{0};
-  std::vector<Chunk> chunks;
-};
 
 /// Represents a chunk in a key stream with key boundaries.
 /// Used to enable efficient range-based lookups during reads.
@@ -63,6 +44,12 @@ struct KeyChunk : public Chunk {
 /// instead of Chunk and doesn't need offset tracking.
 struct KeyStream {
   std::vector<KeyChunk> chunks;
+};
+
+/// Represents a stream of chunks with a file offset.
+struct Stream {
+  uint32_t offset{0};
+  std::vector<Chunk> chunks;
 };
 
 struct ClusterIndexConfig;

--- a/dwio/nimble/tablet/tests/ChunkIndexWriterTest.cpp
+++ b/dwio/nimble/tablet/tests/ChunkIndexWriterTest.cpp
@@ -126,30 +126,37 @@ TEST_F(ChunkIndexWriterTest, singleStripe) {
   EXPECT_EQ(stream1Stats.chunkOffsets, (std::vector<uint32_t>{0, 20}));
 
   // Lookup via StreamIndex (public API).
-  auto stream0 = chunkIndex->createStreamIndex(0, 0);
+  // Stream 0: 3 chunks, sizes {10, 15, 8}, total = 33.
+  auto stream0 = chunkIndex->createStreamIndex(0, 0, 33);
   ASSERT_NE(stream0, nullptr);
 
   auto r00 = stream0->lookupChunk(0);
-  EXPECT_EQ(r00.streamOffset, 0);
+  EXPECT_EQ(r00.chunkOffset, 0);
+  EXPECT_EQ(r00.chunkSize, 10);
   EXPECT_EQ(r00.rowOffset, 0);
 
   auto r01 = stream0->lookupChunk(30);
-  EXPECT_EQ(r01.streamOffset, 10);
+  EXPECT_EQ(r01.chunkOffset, 10);
+  EXPECT_EQ(r01.chunkSize, 15);
   EXPECT_EQ(r01.rowOffset, 30);
 
   auto r02 = stream0->lookupChunk(75);
-  EXPECT_EQ(r02.streamOffset, 25);
+  EXPECT_EQ(r02.chunkOffset, 25);
+  EXPECT_EQ(r02.chunkSize, 8);
   EXPECT_EQ(r02.rowOffset, 75);
 
-  auto stream1 = chunkIndex->createStreamIndex(0, 1);
+  // Stream 1: 2 chunks, sizes {20, 12}, total = 32.
+  auto stream1 = chunkIndex->createStreamIndex(0, 1, 32);
   ASSERT_NE(stream1, nullptr);
 
   auto r10 = stream1->lookupChunk(0);
-  EXPECT_EQ(r10.streamOffset, 0);
+  EXPECT_EQ(r10.chunkOffset, 0);
+  EXPECT_EQ(r10.chunkSize, 20);
   EXPECT_EQ(r10.rowOffset, 0);
 
   auto r11 = stream1->lookupChunk(60);
-  EXPECT_EQ(r11.streamOffset, 20);
+  EXPECT_EQ(r11.chunkOffset, 20);
+  EXPECT_EQ(r11.chunkSize, 12);
   EXPECT_EQ(r11.rowOffset, 60);
 }
 
@@ -271,7 +278,7 @@ TEST_F(ChunkIndexWriterTest, multipleStripeGroups) {
     EXPECT_EQ(stats.chunkRows, (std::vector<uint32_t>{200}));
     EXPECT_EQ(stats.chunkOffsets, (std::vector<uint32_t>{0}));
     // Single-chunk stream returns nullptr.
-    EXPECT_EQ(ci->createStreamIndex(2, 0), nullptr);
+    EXPECT_EQ(ci->createStreamIndex(2, 0, 30), nullptr);
   }
 }
 
@@ -313,10 +320,10 @@ TEST_F(ChunkIndexWriterTest, emptyStream) {
   EXPECT_EQ(stream2.chunkOffsets, (std::vector<uint32_t>{0}));
 
   // createStreamIndex returns nullptr for streams with ≤1 chunk.
-  EXPECT_EQ(chunkIndex->createStreamIndex(0, 1), nullptr);
-  EXPECT_EQ(chunkIndex->createStreamIndex(0, 2), nullptr);
+  EXPECT_EQ(chunkIndex->createStreamIndex(0, 1, 0), nullptr);
+  EXPECT_EQ(chunkIndex->createStreamIndex(0, 2, 25), nullptr);
   // streamId out of range returns nullptr.
-  EXPECT_EQ(chunkIndex->createStreamIndex(0, 3), nullptr);
+  EXPECT_EQ(chunkIndex->createStreamIndex(0, 3, 0), nullptr);
 }
 
 TEST_F(ChunkIndexWriterTest, emptyFileNoStripeGroups) {
@@ -439,7 +446,7 @@ TEST_F(ChunkIndexWriterTest, multipleStripesInMultipleGroups) {
     EXPECT_EQ(s1.chunkCounts, (std::vector<uint32_t>{1}));
     EXPECT_EQ(s1.chunkRows, (std::vector<uint32_t>{100}));
     EXPECT_EQ(s1.chunkOffsets, (std::vector<uint32_t>{0}));
-    EXPECT_EQ(ci->createStreamIndex(2, 1), nullptr);
+    EXPECT_EQ(ci->createStreamIndex(2, 1, 20), nullptr);
   }
 }
 

--- a/dwio/nimble/tablet/tests/ChunkTest.cpp
+++ b/dwio/nimble/tablet/tests/ChunkTest.cpp
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include <gtest/gtest.h>
+
+#include "dwio/nimble/tablet/Chunk.h"
+
+namespace facebook::nimble {
+namespace {
+
+TEST(ChunkTest, emptyChunk) {
+  Chunk chunk;
+  EXPECT_EQ(chunk.rowCount, 0);
+  EXPECT_TRUE(chunk.content.empty());
+  EXPECT_EQ(chunk.contentSize(), 0);
+}
+
+TEST(ChunkTest, singleContent) {
+  Chunk chunk;
+  chunk.rowCount = 100;
+  chunk.content = {"hello"};
+  EXPECT_EQ(chunk.contentSize(), 5);
+}
+
+TEST(ChunkTest, multipleContent) {
+  Chunk chunk;
+  chunk.rowCount = 200;
+  chunk.content = {"abc", "defgh", "ij"};
+  EXPECT_EQ(chunk.contentSize(), 10);
+}
+
+TEST(ChunkTest, emptyContent) {
+  Chunk chunk;
+  chunk.rowCount = 50;
+  chunk.content = {"", "", ""};
+  EXPECT_EQ(chunk.contentSize(), 0);
+}
+
+TEST(ChunkTest, mixedContent) {
+  Chunk chunk;
+  chunk.rowCount = 10;
+  chunk.content = {"data", "", "more"};
+  EXPECT_EQ(chunk.contentSize(), 8);
+}
+
+} // namespace
+} // namespace facebook::nimble

--- a/dwio/nimble/tablet/tests/ClusterIndexWriterTest.cpp
+++ b/dwio/nimble/tablet/tests/ClusterIndexWriterTest.cpp
@@ -1514,19 +1514,23 @@ TEST_F(ClusterIndexWriterTest, chunkIndexOnlyWriteAndRead) {
 
   // Lookup via StreamIndex (public API).
   // Stream 0: chunks at rows {50, 50} -> accumulated {50, 100}
-  auto stream0 = chunkIndex->createStreamIndex(0, 0);
+  // Stream 0: 2 chunks of {50 rows, 10 bytes} and {50 rows, 12 bytes}.
+  // Total stream size = 10 + 12 = 22.
+  auto stream0 = chunkIndex->createStreamIndex(0, 0, 22);
   ASSERT_NE(stream0, nullptr);
 
   auto result00 = stream0->lookupChunk(0);
-  EXPECT_EQ(result00.streamOffset, 0);
+  EXPECT_EQ(result00.chunkOffset, 0);
+  EXPECT_EQ(result00.chunkSize, 10);
   EXPECT_EQ(result00.rowOffset, 0);
 
   auto result01 = stream0->lookupChunk(50);
-  EXPECT_EQ(result01.streamOffset, 10);
+  EXPECT_EQ(result01.chunkOffset, 10);
+  EXPECT_EQ(result01.chunkSize, 12);
   EXPECT_EQ(result01.rowOffset, 50);
 
   // Stream 1: 1 chunk → createStreamIndex returns nullptr.
-  EXPECT_EQ(chunkIndex->createStreamIndex(0, 1), nullptr);
+  EXPECT_EQ(chunkIndex->createStreamIndex(0, 1, 25), nullptr);
 }
 
 } // namespace facebook::nimble::test

--- a/dwio/nimble/tablet/tests/TabletTest.cpp
+++ b/dwio/nimble/tablet/tests/TabletTest.cpp
@@ -1231,6 +1231,88 @@ TEST_P(TabletTest, chunkContentSize) {
   EXPECT_EQ(chunk.contentSize(), 3);
 }
 
+TEST_P(TabletTest, streamSize) {
+  // Write a file with 2 stripes and verify streamSize API.
+  std::string file;
+  velox::InMemoryWriteFile writeFile(&file);
+  auto tabletWriter = nimble::TabletWriter::create(
+      &writeFile,
+      *pool_,
+      {.streamDeduplicationEnabled = false, .enableChunkIndex = true});
+
+  nimble::Buffer buffer{*pool_};
+
+  // Stripe 0: 3 streams with sizes 10, 20, 8.
+  {
+    std::vector<nimble::Stream> streams;
+    streams.push_back(
+        nimble::index::test::createStream(
+            buffer, {.offset = 0, .chunks = {{.rowCount = 50, .size = 10}}}));
+    streams.push_back(
+        nimble::index::test::createStream(
+            buffer, {.offset = 1, .chunks = {{.rowCount = 50, .size = 20}}}));
+    streams.push_back(
+        nimble::index::test::createStream(
+            buffer, {.offset = 2, .chunks = {{.rowCount = 50, .size = 8}}}));
+    tabletWriter->writeStripe(50, std::move(streams));
+  }
+
+  // Stripe 1: 2 streams (fewer than stripe 0).
+  {
+    std::vector<nimble::Stream> streams;
+    streams.push_back(
+        nimble::index::test::createStream(
+            buffer, {.offset = 0, .chunks = {{.rowCount = 30, .size = 15}}}));
+    streams.push_back(
+        nimble::index::test::createStream(
+            buffer, {.offset = 1, .chunks = {{.rowCount = 30, .size = 25}}}));
+    tabletWriter->writeStripe(30, std::move(streams));
+  }
+
+  tabletWriter->close();
+  writeFile.close();
+
+  auto readFile =
+      std::make_shared<nimble::testing::InMemoryTrackableReadFile>(file, false);
+  auto tablet = createTabletReader(readFile, nimble::TabletReader::Options{});
+
+  struct TestCase {
+    uint32_t stripeIndex;
+    uint32_t streamId;
+    uint32_t expectedSize;
+
+    std::string debugString() const {
+      return fmt::format(
+          "stripe {}, stream {}, expected {}",
+          stripeIndex,
+          streamId,
+          expectedSize);
+    }
+  };
+
+  std::vector<TestCase> testCases = {
+      // Stripe 0: 3 streams with sizes 10, 20, 8.
+      {0, 0, 10},
+      {0, 1, 20},
+      {0, 2, 8},
+      // Out of range returns 0.
+      {0, 3, 0},
+      {0, 100, 0},
+      // Stripe 1: 2 streams with sizes 15, 25.
+      {1, 0, 15},
+      {1, 1, 25},
+      // Stream 2 doesn't exist in stripe 1.
+      {1, 2, 0},
+  };
+
+  for (const auto& testCase : testCases) {
+    SCOPED_TRACE(testCase.debugString());
+    auto stripe = tablet->stripeIdentifier(testCase.stripeIndex);
+    EXPECT_EQ(
+        tablet->streamSize(stripe, testCase.streamId), testCase.expectedSize);
+  }
+}
+
 // TabletWithIndexTest is a derived test fixture for tablet index related tests.
 // It inherits the memory pool and helper methods from TabletTest.
 class TabletWithIndexTest : public TabletTest {

--- a/dwio/nimble/velox/selective/ChunkedDecoder.cpp
+++ b/dwio/nimble/velox/selective/ChunkedDecoder.cpp
@@ -233,7 +233,7 @@ void ChunkedDecoder::skipWithIndex(int64_t numValues) {
   const auto location = streamIndex_->lookupChunk(targetRow);
 
   // Seek to the chunk and skip within it.
-  seekToChunk(location.streamOffset);
+  seekToChunk(location.chunkOffset);
   rowPosition_ = location.rowOffset;
 
   const uint32_t rowsToSkipInChunk = targetRow - rowPosition_;

--- a/dwio/nimble/velox/selective/ReaderBase.cpp
+++ b/dwio/nimble/velox/selective/ReaderBase.cpp
@@ -136,7 +136,9 @@ std::shared_ptr<index::StreamIndex> StripeStreams::streamIndex(
   if (chunkIndex == nullptr) {
     return nullptr;
   }
-  return chunkIndex->createStreamIndex(stripe_, streamId);
+  const uint32_t streamSize =
+      readerBase_->tablet().streamSize(*stripeIdentifier_, streamId);
+  return chunkIndex->createStreamIndex(stripe_, streamId, streamSize);
 }
 
 std::unique_ptr<velox::dwio::common::SeekableInputStream>

--- a/dwio/nimble/velox/selective/tests/ChunkedDecoderTest.cpp
+++ b/dwio/nimble/velox/selective/tests/ChunkedDecoderTest.cpp
@@ -611,7 +611,7 @@ class ChunkedDecoderDataTest : public index::test::ClusterIndexTestBase,
     testIndexBuffers_ =
         createTestClusterIndex(indexColumns, minKey, stripes, stripeGroups);
     testChunkIndex_ = createChunkIndex(testIndexBuffers_, 0);
-    return testChunkIndex_->createStreamIndex(0, 0);
+    return testChunkIndex_->createStreamIndex(0, 0, /*streamSize=*/1000);
   }
 
  private:

--- a/dwio/nimble/velox/tests/VeloxWriterTest.cpp
+++ b/dwio/nimble/velox/tests/VeloxWriterTest.cpp
@@ -3533,7 +3533,7 @@ class VeloxWriterIndexTest
 
         // Cache key: chunk file offset (unique across all stripes)
         const uint64_t chunkFileOffset =
-            keyStreamRegion.offset + chunkLocation->streamOffset;
+            keyStreamRegion.offset + chunkLocation->chunkOffset;
 
         // Load and decode key chunk if not cached
         if (keyStreamCache.find(chunkFileOffset) == keyStreamCache.end()) {
@@ -3545,7 +3545,7 @@ class VeloxWriterIndexTest
           nimble::index::test::ClusterIndexGroupTestHelper helper(
               stripeId.clusterIndex().get());
           const uint32_t chunkLength = helper.keyChunkLength(
-              stripeIndex, chunkLocation->streamOffset, keyStreamRegion.length);
+              stripeIndex, chunkLocation->chunkOffset, keyStreamRegion.length);
 
           // Load the key chunk data from file
           velox::common::Region region{


### PR DESCRIPTION
Summary:
CONTEXT: ChunkLocation only stored stream offset and row offset but not the chunk byte size. Callers needed to compute chunk size by looking at the next chunk offset or stream size, duplicating logic in multiple places.

WHAT:
- Add chunkSize field to ChunkLocation for self-contained chunk metadata
- StreamIndex::create and createStreamIndex now take streamSize parameter to compute last chunk size
- Rename ChunkIndexWriter::newStripe → finishStripe for clarity
- Rename ChunkLocation::streamOffset → chunkOffset for consistency

Reviewed By: tanjialiang

Differential Revision: D101830061


