### PR TITLE
feat: Add compression type to SerializationDump stream stats

### DIFF
--- a/dwio/nimble/encodings/EncodingSelectionPolicy.h
+++ b/dwio/nimble/encodings/EncodingSelectionPolicy.h
@@ -102,6 +102,11 @@ using EncodingSelectionPolicyFactory =
 
 struct CompressionOptions {
   float compressionAcceptRatio = 0.98f;
+#ifndef DISABLE_META_INTERNAL_COMPRESSOR
+  CompressionType compressionType = CompressionType::MetaInternal;
+#else
+  CompressionType compressionType = CompressionType::Zstd;
+#endif
   uint64_t zstdMinCompressionSize = kZstdMinCompressionSize;
   uint32_t zstdCompressionLevel = 3;
   uint64_t internalMinCompressionSize = kMetaInternalMinCompressionSize;
@@ -212,7 +217,14 @@ class ManualEncodingSelectionPolicy : public EncodingSelectionPolicy<T> {
           : compressionOptions_{std::move(compressionOptions)} {}
 
       CompressionInformation compression() const override {
-#ifndef DISABLE_META_INTERNAL_COMPRESSOR
+        if (compressionOptions_.compressionType == CompressionType::Zstd) {
+          CompressionInformation information{
+              .compressionType = CompressionType::Zstd,
+              .minCompressionSize = compressionOptions_.zstdMinCompressionSize};
+          information.parameters.zstd.compressionLevel =
+              compressionOptions_.zstdCompressionLevel;
+          return information;
+        }
         CompressionInformation information{
             .compressionType = CompressionType::MetaInternal,
             .minCompressionSize =
@@ -226,14 +238,6 @@ class ManualEncodingSelectionPolicy : public EncodingSelectionPolicy<T> {
         information.parameters.metaInternal.compressionKey =
             compressionOptions_.metaInternalCompressionKey;
         return information;
-#else
-        CompressionInformation information{
-            .compressionType = CompressionType::Zstd,
-            .minCompressionSize = compressionOptions_.zstdMinCompressionSize};
-        information.parameters.zstd.compressionLevel =
-            compressionOptions_.zstdCompressionLevel;
-        return information;
-#endif
       }
 
       virtual bool shouldAccept(

--- a/dwio/nimble/encodings/tests/EncodingSelectionTest.cpp
+++ b/dwio/nimble/encodings/tests/EncodingSelectionTest.cpp
@@ -1390,3 +1390,108 @@ TEST(ReplayedEncodingSelectionPolicyTest, nestedEncodingCompressionType) {
     EXPECT_EQ(decoded, data);
   }
 }
+
+TEST(ManualEncodingSelectionPolicyTest, defaultCompressionType) {
+  // Verify that default CompressionOptions uses the compile-time default
+  // compression type.
+  std::vector<uint32_t> data(1000, 42);
+
+  auto policy =
+      std::make_unique<nimble::ManualEncodingSelectionPolicy<uint32_t>>(
+          nimble::ManualEncodingSelectionPolicyFactory::defaultReadFactors(),
+          nimble::CompressionOptions{},
+          std::nullopt);
+  auto result =
+      policy->select(data, nimble::Statistics<uint32_t>::create(data));
+  auto compressionPolicy = result.compressionPolicyFactory();
+  auto info = compressionPolicy->compression();
+
+#ifndef DISABLE_META_INTERNAL_COMPRESSOR
+  EXPECT_EQ(info.compressionType, nimble::CompressionType::MetaInternal);
+#else
+  EXPECT_EQ(info.compressionType, nimble::CompressionType::Zstd);
+#endif
+}
+
+TEST(ManualEncodingSelectionPolicyTest, explicitZstdCompressionType) {
+  // Verify that explicitly setting compressionType to Zstd overrides the
+  // compile-time default.
+  std::vector<uint32_t> data(1000, 42);
+
+  nimble::CompressionOptions options{
+      .compressionType = nimble::CompressionType::Zstd,
+  };
+  auto policy =
+      std::make_unique<nimble::ManualEncodingSelectionPolicy<uint32_t>>(
+          nimble::ManualEncodingSelectionPolicyFactory::defaultReadFactors(),
+          options,
+          std::nullopt);
+  auto result =
+      policy->select(data, nimble::Statistics<uint32_t>::create(data));
+  auto compressionPolicy = result.compressionPolicyFactory();
+  auto info = compressionPolicy->compression();
+
+  EXPECT_EQ(info.compressionType, nimble::CompressionType::Zstd);
+  EXPECT_EQ(
+      info.parameters.zstd.compressionLevel, options.zstdCompressionLevel);
+}
+
+TEST(ManualEncodingSelectionPolicyTest, explicitMetaInternalCompressionType) {
+  // Verify that explicitly setting compressionType to MetaInternal overrides
+  // the compile-time default.
+  std::vector<uint32_t> data(1000, 42);
+
+  nimble::CompressionOptions options{
+      .compressionType = nimble::CompressionType::MetaInternal,
+      .internalCompressionLevel = 7,
+      .internalDecompressionLevel = 3,
+  };
+  auto policy =
+      std::make_unique<nimble::ManualEncodingSelectionPolicy<uint32_t>>(
+          nimble::ManualEncodingSelectionPolicyFactory::defaultReadFactors(),
+          options,
+          std::nullopt);
+  auto result =
+      policy->select(data, nimble::Statistics<uint32_t>::create(data));
+  auto compressionPolicy = result.compressionPolicyFactory();
+  auto info = compressionPolicy->compression();
+
+  EXPECT_EQ(info.compressionType, nimble::CompressionType::MetaInternal);
+  EXPECT_EQ(
+      info.parameters.metaInternal.compressionLevel,
+      options.internalCompressionLevel);
+  EXPECT_EQ(
+      info.parameters.metaInternal.decompressionLevel,
+      options.internalDecompressionLevel);
+}
+
+TEST(ManualEncodingSelectionPolicyTest, compressionTypeRoundTrip) {
+  // Verify that data encoded with an explicit compression type can be
+  // decoded correctly.
+  auto pool = velox::memory::deprecatedAddDefaultLeafMemoryPool();
+  nimble::Buffer buffer(*pool);
+
+  std::vector<uint32_t> data(1000, 42);
+
+  nimble::CompressionOptions options{
+      .compressionType = nimble::CompressionType::Zstd,
+  };
+  auto policy =
+      std::make_unique<nimble::ManualEncodingSelectionPolicy<uint32_t>>(
+          nimble::ManualEncodingSelectionPolicyFactory::defaultReadFactors(),
+          options,
+          std::nullopt);
+
+  auto encoded = nimble::EncodingFactory::encode<uint32_t>(
+      std::move(policy), std::span<const uint32_t>(data), buffer);
+
+  auto encoding = nimble::EncodingFactory().create(
+      *pool, encoded, [&](uint32_t totalLength) -> void* {
+        return pool->allocate(totalLength);
+      });
+  EXPECT_EQ(encoding->rowCount(), data.size());
+
+  std::vector<uint32_t> decoded(data.size());
+  encoding->materialize(static_cast<uint32_t>(data.size()), decoded.data());
+  EXPECT_EQ(decoded, data);
+}

--- a/dwio/nimble/tools/SerializerDumpLib.cpp
+++ b/dwio/nimble/tools/SerializerDumpLib.cpp
@@ -99,6 +99,18 @@ SerializationDump::SerializationStats SerializationDump::serializationStats(
     const char* rowCountPos = pos + 2;
     si.rowCount = varint::readVarint32(&rowCountPos);
 
+    // Read compression type byte for TrivialEncoding only.
+    // TrivialEncoding layout:
+    //   [EncodingType][DataType][rowCount:varint][CompressionType:1B][data]
+    // Other encodings (Varint, RLE, FixedBitWidth, etc.) have encoding-specific
+    // prefix bytes at this position, so we only parse compression type for
+    // Trivial.
+    if (si.encodingType == EncodingType::Trivial &&
+        rowCountPos < pos + streamSize) {
+      si.compressionType =
+          static_cast<CompressionType>(static_cast<uint8_t>(*rowCountPos));
+    }
+
     uint32_t elemSize = dataTypeElementSize(si.dataType);
     si.rawSize = static_cast<uint64_t>(si.rowCount) * elemSize;
     si.encodedSize = streamSize;
@@ -133,11 +145,12 @@ std::string SerializationDump::SerializationStats::toString() const {
     double ratio =
         si.rawSize > 0 ? static_cast<double>(si.encodedSize) / si.rawSize : 0;
     result += fmt::format(
-        "  stream[{}]: encoding={}, dataType={}, rows={}, raw={} bytes,"
+        "  stream[{}]: encoding={}, dataType={}, compression={}, rows={}, raw={} bytes,"
         " encoded={} bytes, ratio={:.2f}{}\n",
         si.streamIndex,
         nimble::toString(si.encodingType),
         nimble::toString(si.dataType),
+        nimble::toString(si.compressionType),
         si.rowCount,
         si.rawSize,
         si.encodedSize,

--- a/dwio/nimble/tools/SerializerDumpLib.h
+++ b/dwio/nimble/tools/SerializerDumpLib.h
@@ -42,6 +42,8 @@ class SerializationDump {
     EncodingType encodingType{};
     /// Data type of the elements in this stream.
     DataType dataType{};
+    /// Compression type applied to this stream's encoded data.
+    CompressionType compressionType{CompressionType::Uncompressed};
     /// Number of rows (elements) in this stream.
     uint32_t rowCount{0};
     /// Uncompressed size in bytes (rowCount * element size).


### PR DESCRIPTION
Summary:

Add a `compressionType` field to `SerializationDump::StreamStats` so that per-stream compression information (Uncompressed, Zstd, MetaInternal) is captured and displayed in encoding dump output. This enables debugging and verifying which compression algorithm is applied to each stream in Nimble-encoded SST values.

Changes:
- `SerializerDumpLib.h`: Add `CompressionType compressionType` to `StreamStats`
- `SerializerDumpLib.cpp`: Parse the compression type byte from each stream's encoding prefix and include it in `toString()` output
- `NimbleEncodingDump.h`: Add `compressionType` to `FeatureEncodingStats`
- `NimbleEncodingDump.cpp`: Propagate compression type from stream stats to per-feature stats and display in the dump output table

Differential Revision: D101668912


