### PR TITLE
refactor: Rename seekAtOrAfter to seek with inclusive parameter

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ BUILD_BASE_DIR=_build
 BUILD_DIR=release
 BUILD_TYPE=Release
 
-CMAKE_FLAGS := -DCMAKE_BUILD_TYPE=$(BUILD_TYPE)
+CMAKE_FLAGS := -DCMAKE_BUILD_TYPE=$(BUILD_TYPE) -DVELOX_ENABLE_GEO=OFF
 
 # Use Ninja if available. If Ninja is used, pass through parallelism control flags.
 USE_NINJA ?= 1

--- a/dwio/nimble/encodings/Encoding.h
+++ b/dwio/nimble/encodings/Encoding.h
@@ -157,13 +157,14 @@ class Encoding {
   // iterator; if you need to move your row pointer back, reset() and skip().
   virtual void skip(uint32_t rowCount) = 0;
 
-  /// Seeks to the position at or after the given value.
+  /// Seeks to the first row matching the target value.
   ///
   /// @param value Pointer to target value to seek.
-  /// @return Row index if found, std::nullopt if value is greater than all
-  /// entries.
-  virtual std::optional<uint32_t> seekAtOrAfter(const void* value) {
-    NIMBLE_UNSUPPORTED("seekAtOrAfter is not supported.");
+  /// @param inclusive When true, returns the first row >= value.
+  ///        When false, returns the first row > value.
+  /// @return Row index if found, std::nullopt if no matching row exists.
+  virtual std::optional<uint32_t> seek(const void* value, bool inclusive) {
+    NIMBLE_UNSUPPORTED("seek is not supported.");
   }
 
   // Materializes the next |rowCount| rows into buffer. Advances

--- a/dwio/nimble/encodings/PrefixEncoding.cpp
+++ b/dwio/nimble/encodings/PrefixEncoding.cpp
@@ -165,7 +165,9 @@ void PrefixEncoding::seekToRestartPoint(uint32_t restartIndex) {
   decodedValue_.clear();
 }
 
-std::optional<uint32_t> PrefixEncoding::seekAtOrAfter(const void* value) {
+std::optional<uint32_t> PrefixEncoding::seek(
+    const void* value,
+    bool inclusive) {
   const auto& targetValue = *static_cast<const std::string_view*>(value);
 
   // Binary search among restart points to find the block containing the target.
@@ -196,15 +198,21 @@ std::optional<uint32_t> PrefixEncoding::seekAtOrAfter(const void* value) {
   // Seek to the identified restart point
   seekToRestartPoint(left);
 
-  // Linear scan within the block
-  while (currentRow_ < rowCount_) {
-    const std::string_view currentValue = decodeEntry();
-    if (currentValue >= targetValue) {
-      return currentRow_ - 1;
+  // Linear scan within the block.
+  if (inclusive) {
+    while (currentRow_ < rowCount_) {
+      if (decodeEntry() >= targetValue) {
+        return currentRow_ - 1;
+      }
+    }
+  } else {
+    while (currentRow_ < rowCount_) {
+      if (decodeEntry() > targetValue) {
+        return currentRow_ - 1;
+      }
     }
   }
 
-  // Target is greater than all entries.
   return std::nullopt;
 }
 

--- a/dwio/nimble/encodings/PrefixEncoding.h
+++ b/dwio/nimble/encodings/PrefixEncoding.h
@@ -93,10 +93,7 @@ class PrefixEncoding final
 
   /// Seeks to the position at or after the given value.
   ///
-  /// @param value Pointer to target value to seek.
-  /// @return Row index if found, std::nullopt if value is greater than all
-  /// entries.
-  std::optional<uint32_t> seekAtOrAfter(const void* value) final;
+  std::optional<uint32_t> seek(const void* value, bool inclusive) final;
 
   template <typename DecoderVisitor>
   void readWithVisitor(DecoderVisitor& visitor, ReadWithVisitorParams& params);

--- a/dwio/nimble/encodings/TrivialEncoding.cpp
+++ b/dwio/nimble/encodings/TrivialEncoding.cpp
@@ -91,8 +91,9 @@ uint64_t TrivialEncoding<std::string_view>::uncompressedDataBytes() const {
   return uncompressedDataBytes_;
 }
 
-std::optional<uint32_t> TrivialEncoding<std::string_view>::seekAtOrAfter(
-    const void* value) {
+std::optional<uint32_t> TrivialEncoding<std::string_view>::seek(
+    const void* value,
+    bool inclusive) {
   const auto* seekValue = static_cast<const std::string_view*>(value);
   NIMBLE_CHECK_NOT_NULL(seekValue);
 
@@ -114,11 +115,14 @@ std::optional<uint32_t> TrivialEncoding<std::string_view>::seekAtOrAfter(
     pos += buffer_[i];
   }
 
-  auto it = std::lower_bound(
-      values.begin(),
-      values.end(),
-      *seekValue,
-      [](std::string_view a, std::string_view b) { return a < b; });
+  // inclusive: first row >= value (lower_bound).
+  // exclusive: first row > value (upper_bound).
+  const auto comparator = [](std::string_view a, std::string_view b) {
+    return a < b;
+  };
+  const auto it = inclusive
+      ? std::lower_bound(values.begin(), values.end(), *seekValue, comparator)
+      : std::upper_bound(values.begin(), values.end(), *seekValue, comparator);
 
   if (it == values.end()) {
     return std::nullopt;

--- a/dwio/nimble/encodings/TrivialEncoding.h
+++ b/dwio/nimble/encodings/TrivialEncoding.h
@@ -112,7 +112,7 @@ class TrivialEncoding<std::string_view> final
   // Returns the total size of the characters payload in bytes
   uint64_t uncompressedDataBytes() const;
 
-  std::optional<uint32_t> seekAtOrAfter(const void* value) final;
+  std::optional<uint32_t> seek(const void* value, bool inclusive) final;
 
   static std::string_view encode(
       EncodingSelection<std::string_view>& selection,

--- a/dwio/nimble/encodings/legacy/PrefixEncoding.cpp
+++ b/dwio/nimble/encodings/legacy/PrefixEncoding.cpp
@@ -150,7 +150,9 @@ void PrefixEncoding::seekToRestartPoint(uint32_t restartIndex) {
   decodedValue_.clear();
 }
 
-std::optional<uint32_t> PrefixEncoding::seekAtOrAfter(const void* value) {
+std::optional<uint32_t> PrefixEncoding::seek(
+    const void* value,
+    bool inclusive) {
   const auto& targetValue = *static_cast<const std::string_view*>(value);
 
   uint32_t left = 0;
@@ -175,10 +177,17 @@ std::optional<uint32_t> PrefixEncoding::seekAtOrAfter(const void* value) {
 
   seekToRestartPoint(left);
 
-  while (currentRow_ < rowCount_) {
-    const std::string_view currentValue = decodeEntry();
-    if (currentValue >= targetValue) {
-      return currentRow_ - 1;
+  if (inclusive) {
+    while (currentRow_ < rowCount_) {
+      if (decodeEntry() >= targetValue) {
+        return currentRow_ - 1;
+      }
+    }
+  } else {
+    while (currentRow_ < rowCount_) {
+      if (decodeEntry() > targetValue) {
+        return currentRow_ - 1;
+      }
     }
   }
 

--- a/dwio/nimble/encodings/legacy/PrefixEncoding.h
+++ b/dwio/nimble/encodings/legacy/PrefixEncoding.h
@@ -50,7 +50,7 @@ class PrefixEncoding final
   void skip(uint32_t rowCount) final;
   void materialize(uint32_t rowCount, void* buffer) final;
 
-  std::optional<uint32_t> seekAtOrAfter(const void* value) final;
+  std::optional<uint32_t> seek(const void* value, bool inclusive) final;
 
   template <typename DecoderVisitor>
   void readWithVisitor(DecoderVisitor& visitor, ReadWithVisitorParams& params);

--- a/dwio/nimble/encodings/tests/PrefixEncodingTest.cpp
+++ b/dwio/nimble/encodings/tests/PrefixEncodingTest.cpp
@@ -412,7 +412,7 @@ TEST_F(PrefixEncodingTest, fuzzerMaterialize) {
   }
 }
 
-// Test seekAtOrAfter with exact match and no-match scenarios.
+// Test seek with exact match and no-match scenarios.
 // For each test case, we test seeking at specified positions.
 TEST_F(PrefixEncodingTest, seekExactMatch) {
   struct TestCase {
@@ -463,25 +463,40 @@ TEST_F(PrefixEncodingTest, seekExactMatch) {
     auto encoding =
         EncodingFactory().create(*pool_, encoded, createStringBufferFactory());
 
-    // Test exact match
-    for (uint32_t pos : testCase.seekPositions) {
-      SCOPED_TRACE(fmt::format("seek position {}", pos));
-      auto result = encoding->seekAtOrAfter(&values[pos]);
-      ASSERT_TRUE(result.has_value());
-      EXPECT_EQ(result.value(), pos);
-    }
+    for (bool inclusive : {true, false}) {
+      SCOPED_TRACE(fmt::format("inclusive={}", inclusive));
 
-    // Test no match (value larger than max)
-    {
-      SCOPED_TRACE("value larger than max");
-      std::string_view largerValue = "zzz_larger_than_all";
-      auto result = encoding->seekAtOrAfter(&largerValue);
-      EXPECT_FALSE(result.has_value());
+      // Test exact match
+      for (uint32_t pos : testCase.seekPositions) {
+        SCOPED_TRACE(fmt::format("seek position {}", pos));
+        auto result = encoding->seek(&values[pos], inclusive);
+        if (inclusive) {
+          ASSERT_TRUE(result.has_value());
+          EXPECT_EQ(result.value(), pos);
+        } else {
+          // inclusive=false: first row > target. For exact match, that's pos+1.
+          // If pos is the last row, result is nullopt.
+          if (pos + 1 < testCase.numValues) {
+            ASSERT_TRUE(result.has_value());
+            EXPECT_EQ(result.value(), pos + 1);
+          } else {
+            EXPECT_FALSE(result.has_value());
+          }
+        }
+      }
+
+      // Test no match (value larger than max)
+      {
+        SCOPED_TRACE("value larger than max");
+        std::string_view largerValue = "zzz_larger_than_all";
+        auto result = encoding->seek(&largerValue, inclusive);
+        EXPECT_FALSE(result.has_value());
+      }
     }
   }
 }
 
-// Test seekAtOrAfter with non-exact match scenarios.
+// Test seek with non-exact match scenarios.
 // Values are generated with gaps (e.g., key_0, key_2, key_4, ...) so we can
 // seek for values that don't exist (e.g., key_1, key_3) and verify we get
 // the next value.
@@ -543,38 +558,43 @@ TEST_F(PrefixEncodingTest, seekNonExactMatch) {
     auto encoding =
         EncodingFactory().create(*pool_, encoded, createStringBufferFactory());
 
-    // Test non-exact match
+    for (bool inclusive : {true, false}) {
+      SCOPED_TRACE(fmt::format("inclusive={}", inclusive));
 
-    // Test non-exact match: seek for value that doesn't exist (odd keys)
-    // e.g., seek for key_001 should return position of key_002 (index 1)
-    for (uint32_t pos : testCase.seekBeforePositions) {
-      SCOPED_TRACE(fmt::format("seek before position {}", pos));
-      // Create a key that falls between values[pos-1] and values[pos]
-      // values[pos] = key_(pos*2), so we seek for key_(pos*2-1)
-      // Zero-pad to 3 digits to match the value format
-      std::string targetKey = fmt::format("key_{:03d}", pos * 2 - 1);
-      std::string_view target = targetKey;
-      auto result = encoding->seekAtOrAfter(&target);
-      ASSERT_TRUE(result.has_value());
-      // Should return pos since key_(pos*2-1) < key_(pos*2)
-      EXPECT_EQ(result.value(), pos);
-    }
+      // Test non-exact match: seek for value that doesn't exist (odd keys)
+      // e.g., seek for key_001 should return position of key_002 (index 1)
+      // For non-exact matches, inclusive and exclusive give the same result
+      // since the target doesn't exist in the data.
+      for (uint32_t pos : testCase.seekBeforePositions) {
+        SCOPED_TRACE(fmt::format("seek before position {}", pos));
+        // Create a key that falls between values[pos-1] and values[pos]
+        // values[pos] = key_(pos*2), so we seek for key_(pos*2-1)
+        // Zero-pad to 3 digits to match the value format
+        std::string targetKey = fmt::format("key_{:03d}", pos * 2 - 1);
+        std::string_view target = targetKey;
+        auto result = encoding->seek(&target, inclusive);
+        ASSERT_TRUE(result.has_value());
+        // Should return pos since key_(pos*2-1) < key_(pos*2)
+        // Same for both inclusive and exclusive (target not in data).
+        EXPECT_EQ(result.value(), pos);
+      }
 
-    // Test seeking before all values
-    {
-      SCOPED_TRACE("value before all");
-      std::string_view beforeAll = "aaa_before_all";
-      auto result = encoding->seekAtOrAfter(&beforeAll);
-      ASSERT_TRUE(result.has_value());
-      EXPECT_EQ(result.value(), 0);
-    }
+      // Test seeking before all values
+      {
+        SCOPED_TRACE("value before all");
+        std::string_view beforeAll = "aaa_before_all";
+        auto result = encoding->seek(&beforeAll, inclusive);
+        ASSERT_TRUE(result.has_value());
+        EXPECT_EQ(result.value(), 0);
+      }
 
-    // Test no match (value larger than max)
-    {
-      SCOPED_TRACE("value larger than max");
-      std::string_view largerValue = "zzz_larger_than_all";
-      auto result = encoding->seekAtOrAfter(&largerValue);
-      EXPECT_FALSE(result.has_value());
+      // Test no match (value larger than max)
+      {
+        SCOPED_TRACE("value larger than max");
+        std::string_view largerValue = "zzz_larger_than_all";
+        auto result = encoding->seek(&largerValue, inclusive);
+        EXPECT_FALSE(result.has_value());
+      }
     }
   }
 }
@@ -590,12 +610,14 @@ TEST_F(PrefixEncodingTest, seekBeforeAll) {
   auto encoding =
       EncodingFactory().create(*pool_, encoded, createStringBufferFactory());
 
-  // Seek to value before all entries
   std::string_view target = "apple";
-  auto result = encoding->seekAtOrAfter(&target);
-
-  ASSERT_TRUE(result.has_value());
-  EXPECT_EQ(result.value(), 0); // Should point to first entry
+  for (bool inclusive : {true, false}) {
+    SCOPED_TRACE(fmt::format("inclusive={}", inclusive));
+    encoding->reset();
+    auto result = encoding->seek(&target, inclusive);
+    ASSERT_TRUE(result.has_value());
+    EXPECT_EQ(result.value(), 0);
+  }
 }
 
 TEST_F(PrefixEncodingTest, seekAfterAll) {
@@ -609,11 +631,13 @@ TEST_F(PrefixEncodingTest, seekAfterAll) {
   auto encoding =
       EncodingFactory().create(*pool_, encoded, createStringBufferFactory());
 
-  // Seek to value after all entries
   std::string_view target = "zucchini";
-  auto result = encoding->seekAtOrAfter(&target);
-
-  EXPECT_FALSE(result.has_value());
+  for (bool inclusive : {true, false}) {
+    SCOPED_TRACE(fmt::format("inclusive={}", inclusive));
+    encoding->reset();
+    auto result = encoding->seek(&target, inclusive);
+    EXPECT_FALSE(result.has_value());
+  }
 }
 
 // Fuzzer-style test with random inputs and random seek targets.
@@ -669,61 +693,64 @@ TEST_F(PrefixEncodingTest, fuzzerSeek) {
     auto encoding =
         EncodingFactory().create(*pool_, encoded, createStringBufferFactory());
 
-    // Helper: simple linear search
-    auto linearSearch =
-        [&values](std::string_view target) -> std::optional<uint32_t> {
+    // Linear search reference implementation.
+    auto linearSearch = [&values](
+                            std::string_view target,
+                            bool inclusive) -> std::optional<uint32_t> {
       for (size_t i = 0; i < values.size(); ++i) {
-        if (values[i] >= target) {
+        const bool found = inclusive ? values[i] >= target : values[i] > target;
+        if (found) {
           return static_cast<uint32_t>(i);
         }
       }
       return std::nullopt;
     };
 
-    // Perform random seeks
-    for (uint32_t s = 0; s < kSeeksPerIteration; ++s) {
-      // Generate random seek target
-      // Range: 0 to numValues*2+1 to cover before, within, and after all values
-      std::uniform_int_distribution<uint32_t> targetDist(0, numValues * 2 + 1);
-      uint32_t targetIdx = targetDist(rng);
-      // Zero-pad to 3 digits to match the value format
-      std::string targetKey = fmt::format("key_{:03d}", targetIdx);
-      std::string_view target = targetKey;
+    for (bool inclusive : {true, false}) {
+      SCOPED_TRACE(fmt::format("inclusive={}", inclusive));
 
-      auto expected = linearSearch(target);
-      auto actual = encoding->seekAtOrAfter(&target);
+      // Perform random seeks.
+      for (uint32_t s = 0; s < kSeeksPerIteration; ++s) {
+        std::uniform_int_distribution<uint32_t> targetDist(
+            0, numValues * 2 + 1);
+        uint32_t targetIdx = targetDist(rng);
+        std::string targetKey = fmt::format("key_{:03d}", targetIdx);
+        std::string_view target = targetKey;
 
-      if (expected.has_value()) {
-        ASSERT_TRUE(actual.has_value())
-            << "Expected position " << expected.value() << " for target "
-            << targetKey;
-        EXPECT_EQ(actual.value(), expected.value())
-            << "Mismatch for target " << targetKey;
-      } else {
-        EXPECT_FALSE(actual.has_value())
-            << "Expected nullopt for target " << targetKey << " but got "
-            << actual.value();
+        auto expected = linearSearch(target, inclusive);
+        auto actual = encoding->seek(&target, inclusive);
+
+        if (expected.has_value()) {
+          ASSERT_TRUE(actual.has_value())
+              << "Expected position " << expected.value() << " for target "
+              << targetKey;
+          EXPECT_EQ(actual.value(), expected.value())
+              << "Mismatch for target " << targetKey;
+        } else {
+          EXPECT_FALSE(actual.has_value())
+              << "Expected nullopt for target " << targetKey << " but got "
+              << actual.value();
+        }
       }
-    }
 
-    // Also test edge cases for this iteration
-    // 1. Value before all
-    {
-      std::string_view beforeAll = "aaa_before";
-      auto expected = linearSearch(beforeAll);
-      auto actual = encoding->seekAtOrAfter(&beforeAll);
-      ASSERT_TRUE(expected.has_value());
-      ASSERT_TRUE(actual.has_value());
-      EXPECT_EQ(actual.value(), expected.value());
-    }
+      // Edge case: value before all.
+      {
+        std::string_view beforeAll = "aaa_before";
+        auto expected = linearSearch(beforeAll, inclusive);
+        auto actual = encoding->seek(&beforeAll, inclusive);
+        ASSERT_TRUE(expected.has_value());
+        ASSERT_TRUE(actual.has_value());
+        EXPECT_EQ(actual.value(), expected.value());
+      }
 
-    // 2. Value after all
-    {
-      std::string_view afterAll = "zzz_after";
-      auto expected = linearSearch(afterAll);
-      auto actual = encoding->seekAtOrAfter(&afterAll);
-      EXPECT_FALSE(expected.has_value());
-      EXPECT_FALSE(actual.has_value());
+      // Edge case: value after all.
+      {
+        std::string_view afterAll = "zzz_after";
+        auto expected = linearSearch(afterAll, inclusive);
+        auto actual = encoding->seek(&afterAll, inclusive);
+        EXPECT_FALSE(expected.has_value());
+        EXPECT_FALSE(actual.has_value());
+      }
     }
   }
 }
@@ -1157,7 +1184,7 @@ TEST_F(PrefixEncodingTest, fuzzerEncode) {
   }
 }
 
-// Test seekAtOrAfter with duplicate keys that span across restart intervals.
+// Test seek with duplicate keys that span across restart intervals.
 // This specifically tests the fix where seeking for a key that matches
 // a restart point value should return the earliest occurrence, which may be
 // in the previous restart interval.
@@ -1170,6 +1197,9 @@ TEST_F(PrefixEncodingTest, seekExactMatchWithDuplicatesAcrossRestarts) {
     std::vector<std::string> values;
     std::string seekKey;
     uint32_t expectedPosition;
+    // Expected position for inclusive=false (first row > seekKey).
+    // nullopt means no such row exists.
+    std::optional<uint32_t> expectedExclusivePosition;
   };
 
   const std::vector<TestCase> testCases = {
@@ -1195,7 +1225,8 @@ TEST_F(PrefixEncodingTest, seekExactMatchWithDuplicatesAcrossRestarts) {
          return v;
        }(),
        "key_16",
-       14},
+       14,
+       18},
 
       // Duplicate key at restart point with more duplicates before
       // Restart point at index 32, duplicates at indices 28-35
@@ -1216,7 +1247,8 @@ TEST_F(PrefixEncodingTest, seekExactMatchWithDuplicatesAcrossRestarts) {
          return v;
        }(),
        "key_32",
-       28},
+       28,
+       36},
 
       // Single duplicate before restart point
       {"single duplicate before restart point",
@@ -1235,7 +1267,8 @@ TEST_F(PrefixEncodingTest, seekExactMatchWithDuplicatesAcrossRestarts) {
          return v;
        }(),
        "key_16",
-       15},
+       15,
+       17},
 
       // Duplicates spanning multiple restart intervals
       // Restart points at 16, 32; duplicates from index 14 to 34
@@ -1256,7 +1289,8 @@ TEST_F(PrefixEncodingTest, seekExactMatchWithDuplicatesAcrossRestarts) {
          return v;
        }(),
        "key_dup",
-       14},
+       14,
+       std::nullopt},
 
       // Duplicates at restart point but none before (should still work)
       {"duplicates at restart point only",
@@ -1276,7 +1310,8 @@ TEST_F(PrefixEncodingTest, seekExactMatchWithDuplicatesAcrossRestarts) {
          return v;
        }(),
        "key_20",
-       16},
+       16,
+       21},
 
       // All same values (extreme case)
       {"all same values",
@@ -1289,7 +1324,8 @@ TEST_F(PrefixEncodingTest, seekExactMatchWithDuplicatesAcrossRestarts) {
          return v;
        }(),
        "same_key",
-       0},
+       0,
+       std::nullopt},
   };
 
   for (const auto& testCase : testCases) {
@@ -1308,24 +1344,57 @@ TEST_F(PrefixEncodingTest, seekExactMatchWithDuplicatesAcrossRestarts) {
     auto encoding =
         EncodingFactory().create(*pool_, encoded, createStringBufferFactory());
 
-    std::string_view seekKey = testCase.seekKey;
-    auto result = encoding->seekAtOrAfter(&seekKey);
-    ASSERT_TRUE(result.has_value())
-        << "Expected to find key: " << testCase.seekKey;
-    EXPECT_EQ(result.value(), testCase.expectedPosition)
-        << "Expected position " << testCase.expectedPosition << " for key "
-        << testCase.seekKey << " but got " << result.value();
+    for (bool inclusive : {true, false}) {
+      SCOPED_TRACE(fmt::format("inclusive={}", inclusive));
 
-    // Also verify that the value at the returned position matches
-    encoding->reset();
-    if (result.value() > 0) {
-      encoding->skip(result.value());
+      std::string_view seekKey = testCase.seekKey;
+      auto result = encoding->seek(&seekKey, inclusive);
+
+      if (inclusive) {
+        ASSERT_TRUE(result.has_value())
+            << "Expected to find key: " << testCase.seekKey;
+        EXPECT_EQ(result.value(), testCase.expectedPosition)
+            << "Expected position " << testCase.expectedPosition << " for key "
+            << testCase.seekKey << " but got " << result.value();
+
+        // Also verify that the value at the returned position matches
+        encoding->reset();
+        if (result.value() > 0) {
+          encoding->skip(result.value());
+        }
+        std::string_view decoded;
+        encoding->materialize(1, &decoded);
+        EXPECT_EQ(decoded, testCase.seekKey)
+            << "Value at position " << result.value() << " should be "
+            << testCase.seekKey;
+      } else {
+        if (testCase.expectedExclusivePosition.has_value()) {
+          ASSERT_TRUE(result.has_value())
+              << "Expected to find position "
+              << testCase.expectedExclusivePosition.value() << " for key "
+              << testCase.seekKey;
+          EXPECT_EQ(result.value(), testCase.expectedExclusivePosition.value())
+              << "Expected exclusive position "
+              << testCase.expectedExclusivePosition.value() << " for key "
+              << testCase.seekKey << " but got " << result.value();
+
+          // Verify the value at returned position is strictly greater
+          encoding->reset();
+          if (result.value() > 0) {
+            encoding->skip(result.value());
+          }
+          std::string_view decoded;
+          encoding->materialize(1, &decoded);
+          EXPECT_GT(decoded, testCase.seekKey)
+              << "Value at position " << result.value() << " should be > "
+              << testCase.seekKey;
+        } else {
+          EXPECT_FALSE(result.has_value())
+              << "Expected nullopt for exclusive seek of key "
+              << testCase.seekKey << " but got " << result.value();
+        }
+      }
     }
-    std::string_view decoded;
-    encoding->materialize(1, &decoded);
-    EXPECT_EQ(decoded, testCase.seekKey)
-        << "Value at position " << result.value() << " should be "
-        << testCase.seekKey;
   }
 }
 } // namespace facebook::nimble::test

--- a/dwio/nimble/encodings/tests/TrivialEncodingTest.cpp
+++ b/dwio/nimble/encodings/tests/TrivialEncodingTest.cpp
@@ -122,6 +122,7 @@ TEST_P(TrivialEncodingTestWithCompression, seekExactMatch) {
   struct {
     std::string_view seekValue;
     std::optional<uint32_t> expected;
+    std::optional<uint32_t> expectedExclusive;
 
     std::string debugString() const {
       if (expected.has_value()) {
@@ -130,28 +131,33 @@ TEST_P(TrivialEncodingTestWithCompression, seekExactMatch) {
       return fmt::format("seek '{}' -> not found", seekValue);
     }
   } testCases[] = {
-      // Exact matches
-      {"", 0},
-      {"apple", 1},
-      {"banana", 2},
-      {"cherry", 3},
-      {"date", 4},
-      {"elderberry", 5},
-      // Between values (should return next value)
-      {"carrot", 3},
-      {"aaa", 1},
-      {"coconut", 4},
-      // After all values (not found)
-      {"zebra", std::nullopt},
-      {"fig", std::nullopt}};
+      // Exact matches: exclusive returns next row after match
+      {"", 0, 1},
+      {"apple", 1, 2},
+      {"banana", 2, 3},
+      {"cherry", 3, 4},
+      {"date", 4, 5},
+      {"elderberry", 5, std::nullopt},
+      // Between values (should return next value): same for both
+      {"carrot", 3, 3},
+      {"aaa", 1, 1},
+      {"coconut", 4, 4},
+      // After all values (not found): same for both
+      {"zebra", std::nullopt, std::nullopt},
+      {"fig", std::nullopt, std::nullopt}};
 
-  for (const auto& testCase : testCases) {
-    SCOPED_TRACE(testCase.debugString());
-    encoding->reset();
-    auto result = encoding->seekAtOrAfter(&testCase.seekValue);
-    ASSERT_EQ(result.has_value(), testCase.expected.has_value());
-    if (testCase.expected.has_value()) {
-      EXPECT_EQ(result.value(), testCase.expected.value());
+  for (bool inclusive : {true, false}) {
+    SCOPED_TRACE(fmt::format("inclusive={}", inclusive));
+    for (const auto& testCase : testCases) {
+      SCOPED_TRACE(testCase.debugString());
+      encoding->reset();
+      auto result = encoding->seek(&testCase.seekValue, inclusive);
+      const auto& expectedResult =
+          inclusive ? testCase.expected : testCase.expectedExclusive;
+      ASSERT_EQ(result.has_value(), expectedResult.has_value());
+      if (expectedResult.has_value()) {
+        EXPECT_EQ(result.value(), expectedResult.value());
+      }
     }
   }
 }
@@ -164,6 +170,7 @@ TEST_P(TrivialEncodingTestWithCompression, seekExactMatchWithDuplicateValues) {
   struct {
     std::string_view seekValue;
     std::optional<uint32_t> expected;
+    std::optional<uint32_t> expectedExclusive;
 
     std::string debugString() const {
       if (expected.has_value()) {
@@ -172,26 +179,31 @@ TEST_P(TrivialEncodingTestWithCompression, seekExactMatchWithDuplicateValues) {
       return fmt::format("seek '{}' -> not found", seekValue);
     }
   } testCases[] = {
-      // Should return first occurrence of duplicate values
-      {"apple", 0},
-      {"banana", 2},
-      {"cherry", 5},
-      // Between values (should return first of next value)
-      {"aaa", 0},
-      {"app", 0},
-      {"az", 2},
-      {"car", 5},
-      // After all values (not found)
-      {"date", std::nullopt},
-      {"zebra", std::nullopt}};
+      // Exact matches: exclusive skips past ALL duplicates
+      {"apple", 0, 2},
+      {"banana", 2, 5},
+      {"cherry", 5, std::nullopt},
+      // Between values (should return first of next value): same for both
+      {"aaa", 0, 0},
+      {"app", 0, 0},
+      {"az", 2, 2},
+      {"car", 5, 5},
+      // After all values (not found): same for both
+      {"date", std::nullopt, std::nullopt},
+      {"zebra", std::nullopt, std::nullopt}};
 
-  for (const auto& testCase : testCases) {
-    SCOPED_TRACE(testCase.debugString());
-    encoding->reset();
-    auto result = encoding->seekAtOrAfter(&testCase.seekValue);
-    ASSERT_EQ(result.has_value(), testCase.expected.has_value());
-    if (testCase.expected.has_value()) {
-      EXPECT_EQ(result.value(), testCase.expected.value());
+  for (bool inclusive : {true, false}) {
+    SCOPED_TRACE(fmt::format("inclusive={}", inclusive));
+    for (const auto& testCase : testCases) {
+      SCOPED_TRACE(testCase.debugString());
+      encoding->reset();
+      auto result = encoding->seek(&testCase.seekValue, inclusive);
+      const auto& expectedResult =
+          inclusive ? testCase.expected : testCase.expectedExclusive;
+      ASSERT_EQ(result.has_value(), expectedResult.has_value());
+      if (expectedResult.has_value()) {
+        EXPECT_EQ(result.value(), expectedResult.value());
+      }
     }
   }
 }
@@ -206,6 +218,7 @@ TEST_P(TrivialEncodingTestWithCompression, seekAfterValueWithDuplicateValues) {
   struct {
     std::string_view seekValue;
     std::optional<uint32_t> expected;
+    std::optional<uint32_t> expectedExclusive;
 
     std::string debugString() const {
       if (expected.has_value()) {
@@ -214,29 +227,34 @@ TEST_P(TrivialEncodingTestWithCompression, seekAfterValueWithDuplicateValues) {
       return fmt::format("seek '{}' -> not found", seekValue);
     }
   } testCases[] = {
-      // Before first duplicate group
-      {"", 0},
-      {"aaa", 0},
-      // Between apple (end) and cherry (start)
-      {"banana", 3},
-      {"car", 3},
-      // Between cherry (end) and grape
-      {"date", 5},
-      {"fig", 5},
-      // Between grape and kiwi (start of end duplicates)
-      {"honey", 6},
-      // After last duplicate group (not found)
-      {"lemon", std::nullopt},
-      {"zebra", std::nullopt},
+      // Before first duplicate group: non-match, same for both
+      {"", 0, 0},
+      {"aaa", 0, 0},
+      // Between apple (end) and cherry (start): non-match, same for both
+      {"banana", 3, 3},
+      {"car", 3, 3},
+      // Between cherry (end) and grape: non-match, same for both
+      {"date", 5, 5},
+      {"fig", 5, 5},
+      // Between grape and kiwi (start of end duplicates): non-match, same
+      {"honey", 6, 6},
+      // After last duplicate group (not found): same for both
+      {"lemon", std::nullopt, std::nullopt},
+      {"zebra", std::nullopt, std::nullopt},
   };
 
-  for (const auto& testCase : testCases) {
-    SCOPED_TRACE(testCase.debugString());
-    encoding->reset();
-    auto result = encoding->seekAtOrAfter(&testCase.seekValue);
-    ASSERT_EQ(result.has_value(), testCase.expected.has_value());
-    if (testCase.expected.has_value()) {
-      EXPECT_EQ(result.value(), testCase.expected.value());
+  for (bool inclusive : {true, false}) {
+    SCOPED_TRACE(fmt::format("inclusive={}", inclusive));
+    for (const auto& testCase : testCases) {
+      SCOPED_TRACE(testCase.debugString());
+      encoding->reset();
+      auto result = encoding->seek(&testCase.seekValue, inclusive);
+      const auto& expectedResult =
+          inclusive ? testCase.expected : testCase.expectedExclusive;
+      ASSERT_EQ(result.has_value(), expectedResult.has_value());
+      if (expectedResult.has_value()) {
+        EXPECT_EQ(result.value(), expectedResult.value());
+      }
     }
   }
 }
@@ -248,6 +266,7 @@ TEST_P(TrivialEncodingTestWithCompression, seekExactMatchWithEmptyEncoding) {
   struct {
     std::string_view seekValue;
     std::optional<uint32_t> expected;
+    std::optional<uint32_t> expectedExclusive;
 
     std::string debugString() const {
       if (expected.has_value()) {
@@ -257,18 +276,23 @@ TEST_P(TrivialEncodingTestWithCompression, seekExactMatchWithEmptyEncoding) {
     }
   } testCases[] = {
       // All seeks should return not found for empty encoding
-      {"", std::nullopt},
-      {"apple", std::nullopt},
-      {"test", std::nullopt},
+      {"", std::nullopt, std::nullopt},
+      {"apple", std::nullopt, std::nullopt},
+      {"test", std::nullopt, std::nullopt},
   };
 
-  for (const auto& testCase : testCases) {
-    SCOPED_TRACE(testCase.debugString());
-    encoding->reset();
-    auto result = encoding->seekAtOrAfter(&testCase.seekValue);
-    ASSERT_EQ(result.has_value(), testCase.expected.has_value());
-    if (testCase.expected.has_value()) {
-      EXPECT_EQ(result.value(), testCase.expected.value());
+  for (bool inclusive : {true, false}) {
+    SCOPED_TRACE(fmt::format("inclusive={}", inclusive));
+    for (const auto& testCase : testCases) {
+      SCOPED_TRACE(testCase.debugString());
+      encoding->reset();
+      auto result = encoding->seek(&testCase.seekValue, inclusive);
+      const auto& expectedResult =
+          inclusive ? testCase.expected : testCase.expectedExclusive;
+      ASSERT_EQ(result.has_value(), expectedResult.has_value());
+      if (expectedResult.has_value()) {
+        EXPECT_EQ(result.value(), expectedResult.value());
+      }
     }
   }
 }
@@ -281,6 +305,7 @@ TEST_P(TrivialEncodingTestWithCompression, seekAfterValue) {
   struct {
     std::string_view seekValue;
     std::optional<uint32_t> expected;
+    std::optional<uint32_t> expectedExclusive;
 
     std::string debugString() const {
       if (expected.has_value()) {
@@ -289,31 +314,36 @@ TEST_P(TrivialEncodingTestWithCompression, seekAfterValue) {
       return fmt::format("seek '{}' -> not found", seekValue);
     }
   } testCases[] = {
-      // Before first value
-      {"", 0},
-      {"aaa", 0},
-      // Between apple and cherry
-      {"banana", 1},
-      {"cat", 1},
-      // Between cherry and elderberry
-      {"date", 2},
-      {"duck", 2},
-      // Between elderberry and grape
-      {"fig", 3},
-      // Between grape and kiwi
-      {"honey", 4},
-      {"ice", 4},
-      // After last value (not found)
-      {"lemon", std::nullopt},
-      {"mango", std::nullopt}};
+      // Before first value: non-match, same for both
+      {"", 0, 0},
+      {"aaa", 0, 0},
+      // Between apple and cherry: non-match, same for both
+      {"banana", 1, 1},
+      {"cat", 1, 1},
+      // Between cherry and elderberry: non-match, same for both
+      {"date", 2, 2},
+      {"duck", 2, 2},
+      // Between elderberry and grape: non-match, same for both
+      {"fig", 3, 3},
+      // Between grape and kiwi: non-match, same for both
+      {"honey", 4, 4},
+      {"ice", 4, 4},
+      // After last value (not found): same for both
+      {"lemon", std::nullopt, std::nullopt},
+      {"mango", std::nullopt, std::nullopt}};
 
-  for (const auto& testCase : testCases) {
-    SCOPED_TRACE(testCase.debugString());
-    encoding->reset();
-    auto result = encoding->seekAtOrAfter(&testCase.seekValue);
-    ASSERT_EQ(result.has_value(), testCase.expected.has_value());
-    if (testCase.expected.has_value()) {
-      EXPECT_EQ(result.value(), testCase.expected.value());
+  for (bool inclusive : {true, false}) {
+    SCOPED_TRACE(fmt::format("inclusive={}", inclusive));
+    for (const auto& testCase : testCases) {
+      SCOPED_TRACE(testCase.debugString());
+      encoding->reset();
+      auto result = encoding->seek(&testCase.seekValue, inclusive);
+      const auto& expectedResult =
+          inclusive ? testCase.expected : testCase.expectedExclusive;
+      ASSERT_EQ(result.has_value(), expectedResult.has_value());
+      if (expectedResult.has_value()) {
+        EXPECT_EQ(result.value(), expectedResult.value());
+      }
     }
   }
 }
@@ -352,7 +382,8 @@ TEST_F(TrivialEncodingTest, seekUnsupportedEncodings) {
         nimble::test::Encoder<nimble::RLEEncoding<std::string_view>>::
             createEncoding(*buffer_, values, makeStringBufferFactory());
     NIMBLE_ASSERT_THROW(
-        encoding->seekAtOrAfter(&seekValue), "seekAtOrAfter is not supported");
+        encoding->seek(&seekValue, /*inclusive=*/true),
+        "seek is not supported");
   }
 
   // Dictionary encoding
@@ -365,7 +396,8 @@ TEST_F(TrivialEncodingTest, seekUnsupportedEncodings) {
         nimble::test::Encoder<nimble::DictionaryEncoding<std::string_view>>::
             createEncoding(*buffer_, values, makeStringBufferFactory());
     NIMBLE_ASSERT_THROW(
-        encoding->seekAtOrAfter(&seekValue), "seekAtOrAfter is not supported");
+        encoding->seek(&seekValue, /*inclusive=*/true),
+        "seek is not supported");
   }
 
   // Constant encoding
@@ -377,7 +409,8 @@ TEST_F(TrivialEncodingTest, seekUnsupportedEncodings) {
         nimble::test::Encoder<nimble::ConstantEncoding<std::string_view>>::
             createEncoding(*buffer_, values, makeStringBufferFactory());
     NIMBLE_ASSERT_THROW(
-        encoding->seekAtOrAfter(&seekValue), "seekAtOrAfter is not supported");
+        encoding->seek(&seekValue, /*inclusive=*/true),
+        "seek is not supported");
   }
 
   // MainlyConstant encoding
@@ -391,7 +424,8 @@ TEST_F(TrivialEncodingTest, seekUnsupportedEncodings) {
         nimble::MainlyConstantEncoding<std::string_view>>::
         createEncoding(*buffer_, values, makeStringBufferFactory());
     NIMBLE_ASSERT_THROW(
-        encoding->seekAtOrAfter(&seekValue), "seekAtOrAfter is not supported");
+        encoding->seek(&seekValue, /*inclusive=*/true),
+        "seek is not supported");
   }
 
   // Nullable encoding
@@ -408,7 +442,8 @@ TEST_F(TrivialEncodingTest, seekUnsupportedEncodings) {
             createNullableEncoding(
                 *buffer_, values, nulls, makeStringBufferFactory());
     NIMBLE_ASSERT_THROW(
-        encoding->seekAtOrAfter(&seekValue), "seekAtOrAfter is not supported");
+        encoding->seek(&seekValue, /*inclusive=*/true),
+        "seek is not supported");
   }
 
   // Trivial encoding for non-string types
@@ -421,8 +456,8 @@ TEST_F(TrivialEncodingTest, seekUnsupportedEncodings) {
             *buffer_, intValues, makeStringBufferFactory());
     int32_t intSeekValue = 1;
     NIMBLE_ASSERT_THROW(
-        encoding->seekAtOrAfter(&intSeekValue),
-        "seekAtOrAfter is not supported");
+        encoding->seek(&intSeekValue, /*inclusive=*/true),
+        "seek is not supported");
   }
 
   // FixedBitWidth encoding (integer only)
@@ -435,8 +470,8 @@ TEST_F(TrivialEncodingTest, seekUnsupportedEncodings) {
             createEncoding(*buffer_, intValues, makeStringBufferFactory());
     uint32_t intSeekValue = 1;
     NIMBLE_ASSERT_THROW(
-        encoding->seekAtOrAfter(&intSeekValue),
-        "seekAtOrAfter is not supported");
+        encoding->seek(&intSeekValue, /*inclusive=*/true),
+        "seek is not supported");
   }
 
   // Varint encoding (integer only)
@@ -449,8 +484,8 @@ TEST_F(TrivialEncodingTest, seekUnsupportedEncodings) {
             *buffer_, intValues, makeStringBufferFactory());
     uint32_t intSeekValue = 1;
     NIMBLE_ASSERT_THROW(
-        encoding->seekAtOrAfter(&intSeekValue),
-        "seekAtOrAfter is not supported");
+        encoding->seek(&intSeekValue, /*inclusive=*/true),
+        "seek is not supported");
   }
 
   // RLE encoding for integers
@@ -464,8 +499,8 @@ TEST_F(TrivialEncodingTest, seekUnsupportedEncodings) {
             *buffer_, intValues, makeStringBufferFactory());
     int32_t intSeekValue = 1;
     NIMBLE_ASSERT_THROW(
-        encoding->seekAtOrAfter(&intSeekValue),
-        "seekAtOrAfter is not supported");
+        encoding->seek(&intSeekValue, /*inclusive=*/true),
+        "seek is not supported");
   }
 
   // SparseBool encoding
@@ -479,7 +514,7 @@ TEST_F(TrivialEncodingTest, seekUnsupportedEncodings) {
             *buffer_, boolValues, makeStringBufferFactory());
     bool boolSeekValue = true;
     NIMBLE_ASSERT_THROW(
-        encoding->seekAtOrAfter(&boolSeekValue),
-        "seekAtOrAfter is not supported");
+        encoding->seek(&boolSeekValue, /*inclusive=*/true),
+        "seek is not supported");
   }
 }

--- a/dwio/nimble/index/ClusterIndexReader.cpp
+++ b/dwio/nimble/index/ClusterIndexReader.cpp
@@ -67,7 +67,7 @@ std::optional<uint32_t> ClusterIndexReader::seekAtOrAfterInChunk(
     std::string_view encodedKey) {
   seekToChunk(chunkOffset);
   NIMBLE_CHECK_NOT_NULL(encoding_);
-  return encoding_->seekAtOrAfter(&encodedKey);
+  return encoding_->seek(&encodedKey, /*inclusive=*/true);
 }
 
 bool ClusterIndexReader::ensureInput(int size) {

--- a/dwio/nimble/velox/tests/VeloxWriterTest.cpp
+++ b/dwio/nimble/velox/tests/VeloxWriterTest.cpp
@@ -3433,7 +3433,7 @@ class VeloxWriterIndexTest
   // 2. Looks up the stripe via ClusterIndex
   // 3. Gets chunk location within stripe via ClusterIndexGroup::lookupChunk
   // 4. Loads the key stream chunk and decodes it
-  // 5. Uses seekAtOrAfter to find the exact row within the chunk
+  // 5. Uses seek to find the exact row within the chunk
   // 6. For duplicate keys, verifies the found row id matches the earliest row
   //    with the same key value
   void verifyValueIndex(
@@ -3464,7 +3464,7 @@ class VeloxWriterIndexTest
         indexColumns, type, sortOrders, leafPool_.get());
 
     // Pre-encode all keys and build a map from encoded key to earliest row
-    // id. This handles duplicate keys where seekAtOrAfter returns the first
+    // id. This handles duplicate keys where seek returns the first
     // occurrence.
     std::map<std::string, uint64_t> keyToEarliestRowId;
     std::vector<std::string> allEncodedKeys;
@@ -3584,19 +3584,20 @@ class VeloxWriterIndexTest
         // Reset encoding and seek to find the row within the chunk
         keyEncoding->reset();
 
-        // Use seekAtOrAfter to find the exact row position within the
+        // Use seek to find the exact row position within the
         // remaining rows
-        auto seekResult = keyEncoding->seekAtOrAfter(&encodedKeyView);
+        auto seekResult =
+            keyEncoding->seek(&encodedKeyView, /*inclusive=*/true);
         ASSERT_TRUE(seekResult.has_value())
-            << "seekAtOrAfter should find key at row " << currentRowId;
+            << "seek should find key at row " << currentRowId;
 
         // Calculate the actual file row id
-        // seekAtOrAfter returns the offset from current position where the
+        // seek returns the offset from current position where the
         // key was found
         uint64_t fileRowId = stripeStartRows[stripeIndex] +
             chunkLocation->rowOffset + seekResult.value();
 
-        // For duplicate keys, seekAtOrAfter returns the first occurrence.
+        // For duplicate keys, seek returns the first occurrence.
         // Verify that the found row id matches the earliest row with the same
         // key.
         uint64_t expectedFileRowId = keyToEarliestRowId.at(encodedKey);


### PR DESCRIPTION
Summary:
CONTEXT: The cluster index lookup needs two seek modes for point lookup vs range scan: seekAtOrAfter (first row >= key) for lower bounds and seekAfter (first row > key) for upper bounds.

WHAT: Renames seekAtOrAfter to seek with an explicit bool inclusive parameter (no default). When inclusive=true returns first row >= value, when false returns first row > value. Implements both modes in PrefixEncoding (split loops) and TrivialEncoding (lower_bound vs upper_bound). Also updates legacy PrefixEncoding.

Reviewed By: tanjialiang

Differential Revision: D101948480


