### PR TITLE
perf(encoding): Relax FBW fast path gate for unsigned integer types

### DIFF
--- a/dwio/nimble/encodings/FixedBitWidthEncoding.h
+++ b/dwio/nimble/encodings/FixedBitWidthEncoding.h
@@ -26,6 +26,7 @@
 #include "dwio/nimble/common/Vector.h"
 #include "dwio/nimble/encodings/Compression.h"
 #include "dwio/nimble/encodings/Encoding.h"
+#include "velox/dwio/common/DecoderUtil.h"
 
 // The FixedBitWidthEncoding stores integer data in a fixed number of
 // bits equal to the number of bits required to represent the largest value in
@@ -156,24 +157,21 @@ template <typename V>
 void FixedBitWidthEncoding<T>::readWithVisitor(
     V& visitor,
     ReadWithVisitorParams& params) {
-  // Fast path: use bulk scan for integral types with no filter and no hook.
-  // Supports 4-byte types (common for dictionary indices) and 8-byte types
-  // (int64/uint64 columns). The fast path only supports ExtractToReader.
-  // Output type must be compatible:
-  // - Same type: direct memcpy
-  // - Widening (larger output type): loop with conversion
   using OutputType = detail::ValueType<typename V::DataType>;
-  constexpr bool kExtractToReader =
-      std::is_same_v<typename V::Extract, velox::dwio::common::ExtractToReader>;
-  constexpr bool kSameType = std::is_same_v<physicalType, OutputType>;
-  constexpr bool kIsWidening = sizeof(OutputType) > sizeof(physicalType) &&
+  constexpr bool kIsSuitableWidth =
+      (isFourByteIntegralType<physicalType>() ||
+       isEightByteIntegralType<physicalType>());
+  constexpr bool kIsFluidCast = sizeof(OutputType) >= sizeof(physicalType) &&
       std::is_integral_v<OutputType> && std::is_integral_v<physicalType>;
-  constexpr bool kIsFourByte = isFourByteIntegralType<physicalType>();
-  constexpr bool kIsEightByteIntegral = isEightByteIntegralType<physicalType>();
-  constexpr bool kCanUseFastPath = (kIsFourByte || kIsEightByteIntegral) &&
-      !V::kHasFilter && !V::kHasHook && kExtractToReader &&
-      (kSameType || kIsWidening);
-  if constexpr (kCanUseFastPath) {
+  // Fast path: use bulk scan for 4-byte and 8-byte integral types with no
+  // filter and no hook. Supports both signed and unsigned types as long as
+  // the output type is integral and at least as wide as the physical type.
+  if constexpr (
+      kIsSuitableWidth && !V::kHasFilter && !V::kHasHook &&
+      std::is_same_v<
+          typename V::Extract,
+          velox::dwio::common::ExtractToReader> &&
+      kIsFluidCast) {
     auto* nulls = visitor.reader().rawNullsInReadRange();
     detail::readWithVisitorFast(*this, visitor, params, nulls);
     return;
@@ -197,8 +195,7 @@ void FixedBitWidthEncoding<T>::bulkScan(
     const vector_size_t* selectedRows,
     vector_size_t numSelected,
     const vector_size_t* scatterRows) {
-  using DataType = typename V::DataType;
-  using OutputType = detail::ValueType<DataType>;
+  using OutputType = detail::ValueType<typename V::DataType>;
   static_assert(
       isFourByteIntegralType<physicalType>() ||
           isEightByteIntegralType<physicalType>(),
@@ -262,10 +259,18 @@ void FixedBitWidthEncoding<T>::bulkScan(
     }
   }
 
-  // Update row_ based on the last row read.
+  // Scatter: when nulls are present (kScatter=true), values are packed
+  // contiguously but need to be placed at their correct output positions.
+  // Process in reverse to avoid overwriting unread values.
+  if constexpr (kScatter) {
+    for (int32_t i = numSelected - 1; i >= 0; --i) {
+      values[scatterRows[i]] = values[i];
+    }
+  }
+
   row_ += selectedRows[numSelected - 1] - currentRow + 1;
 
-  visitor.addNumValues(V::dense ? numRows : numSelected);
+  visitor.addNumValues(numRows);
   visitor.setRowIndex(visitor.numRows());
 }
 

--- a/dwio/nimble/encodings/tests/ReadWithVisitorTest.cpp
+++ b/dwio/nimble/encodings/tests/ReadWithVisitorTest.cpp
@@ -1688,6 +1688,149 @@ TEST_P(
 }
 
 // ---------------------------------------------------------------------------
+// 13a. FixedBitWidthEncoding<uint32_t> + AlwaysTrue + dense + FAST PATH
+//      Exercises the unsigned integer fast path. The relaxed gate accepts
+//      integral output types at least as wide as the physical type, including
+//      unsigned→signed same-size casts (uint32_t→int32_t).
+// ---------------------------------------------------------------------------
+TEST_P(
+    ReadWithVisitorTest,
+    encodingLevel_FixedBitWidth_AlwaysTrue_Dense_UInt32_FastPath) {
+  constexpr int kRows = 500;
+
+  std::vector<uint32_t> data(kRows);
+  for (int i = 0; i < kRows; ++i) {
+    data[i] = static_cast<uint32_t>(i % 16);
+  }
+
+  auto input = makeRowVector({makeFlatVector<int32_t>(
+      kRows, [](auto i) { return static_cast<int32_t>(i % 16); })});
+  auto rowType = asRowType(input->type());
+  auto ctx = makeFileContext(input);
+  auto scanSpec = std::make_shared<common::ScanSpec>("root");
+  scanSpec->addAllChildFields(*rowType);
+  scanSpec->childByName("c0")->setFilter(
+      std::make_unique<common::AlwaysTrue>());
+  auto root = buildReader(*ctx, rowType, *scanSpec);
+
+  auto* structReader =
+      dynamic_cast<dwio::common::SelectiveStructColumnReaderBase*>(root.get());
+  auto* reader = static_cast<IntegerColumnReaderTestAccessor*>(
+      dynamic_cast<IntegerColumnReader*>(structReader->children()[0]));
+  ASSERT_NE(reader, nullptr);
+
+  std::vector<vector_size_t> rowVec(kRows);
+  std::iota(rowVec.begin(), rowVec.end(), 0);
+  RowSet rows(rowVec.data(), rowVec.size());
+
+  reader->doPrepareRead<int32_t>(0, rows, nullptr);
+
+  Buffer buffer(*pool());
+  auto encoding = createFromCustomLayout<uint32_t>(
+      FixedBitWidthEnc{}, data, *pool(), buffer);
+
+  common::AlwaysTrue filter;
+  dwio::common::ExtractToReader extractValues(reader);
+  constexpr bool kIsDense = true;
+  DecoderVisitor<
+      int32_t,
+      common::AlwaysTrue,
+      dwio::common::ExtractToReader,
+      kIsDense>
+      visitor(filter, reader, rows, extractValues);
+  auto params = makeReadWithVisitorParams(visitor, rows, pool());
+
+  dispatchCallReadWithVisitor(*encoding, visitor, params);
+
+  EXPECT_EQ(reader->numValues(), kRows);
+  auto values = getValues<int32_t>(reader);
+  for (int i = 0; i < kRows; ++i) {
+    EXPECT_EQ(values[i], i % 16) << "row " << i;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// 13b. FixedBitWidthEncoding<int32_t> + AlwaysTrue + dense + FAST PATH + NULLS
+//      Tests the scatter path in bulkScan when encoding-level nulls are present
+//      (as set by NullableEncoding). Non-null values must land at their correct
+//      scattered positions in the output buffer.
+// ---------------------------------------------------------------------------
+TEST_P(
+    ReadWithVisitorTest,
+    encodingLevel_FixedBitWidth_AlwaysTrue_Dense_Int32_FastPath_WithNulls) {
+  constexpr int kRows = 500;
+
+  auto nulls = velox::allocateNulls(kRows, pool(), velox::bits::kNotNull);
+  auto* rawNulls = nulls->asMutable<uint64_t>();
+  int expectedNonNull = 0;
+  for (int i = 0; i < kRows; ++i) {
+    if (i % 5 == 0) {
+      velox::bits::setNull(rawNulls, i);
+    } else {
+      ++expectedNonNull;
+    }
+  }
+
+  std::vector<int32_t> nonNullData(expectedNonNull);
+  {
+    int j = 0;
+    for (int i = 0; i < kRows; ++i) {
+      if (i % 5 != 0) {
+        nonNullData[j++] = i % 16;
+      }
+    }
+  }
+
+  auto input = makeRowVector({makeFlatVector<int32_t>(
+      kRows, [](auto i) { return static_cast<int32_t>(i % 16); })});
+  auto rowType = asRowType(input->type());
+  auto ctx = makeFileContext(input);
+  auto scanSpec = std::make_shared<common::ScanSpec>("root");
+  scanSpec->addAllChildFields(*rowType);
+  scanSpec->childByName("c0")->setFilter(
+      std::make_unique<common::AlwaysTrue>());
+  auto root = buildReader(*ctx, rowType, *scanSpec);
+
+  auto* structReader =
+      dynamic_cast<dwio::common::SelectiveStructColumnReaderBase*>(root.get());
+  auto* reader = static_cast<IntegerColumnReaderTestAccessor*>(
+      dynamic_cast<IntegerColumnReader*>(structReader->children()[0]));
+  ASSERT_NE(reader, nullptr);
+
+  std::vector<vector_size_t> rowVec(kRows);
+  std::iota(rowVec.begin(), rowVec.end(), 0);
+  RowSet rows(rowVec.data(), rowVec.size());
+
+  reader->doPrepareRead<int32_t>(0, rows, nullptr);
+  reader->nullsInReadRange() = nulls;
+
+  Buffer buffer(*pool());
+  auto encoding = createFromCustomLayout<int32_t>(
+      FixedBitWidthEnc{}, nonNullData, *pool(), buffer);
+
+  common::AlwaysTrue filter;
+  dwio::common::ExtractToReader extractValues(reader);
+  constexpr bool kIsDense = true;
+  DecoderVisitor<
+      int32_t,
+      common::AlwaysTrue,
+      dwio::common::ExtractToReader,
+      kIsDense>
+      visitor(filter, reader, rows, extractValues);
+  auto params = makeReadWithVisitorParams(visitor, rows, pool());
+
+  dispatchCallReadWithVisitor(*encoding, visitor, params);
+
+  EXPECT_EQ(reader->numValues(), kRows);
+  auto values = getValues<int32_t>(reader);
+  for (int i = 0; i < kRows; ++i) {
+    if (i % 5 != 0) {
+      EXPECT_EQ(values[i], i % 16) << "non-null row " << i;
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
 // 14. DeltaEncoding<int64_t> + AlwaysTrue + dense
 //     Delta always uses slow path (no bulkScan).
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
Summary:
Relaxes the compile-time type constraint in FixedBitWidthEncoding::readWithVisitor
to accept unsigned integral types (e.g., uint32_t for dictionary indices). The
previous gate required exact type match or signed widening. Now any integral
output type at least as wide as the physical type is accepted.

This exposes a scattering bug:
After decoding numSelected values into values[0..numSelected-1], the old code just called
addNumValues(V::dense ? numRows : numSelected). The values sat at the wrong positions — position 0 had the value for row 0, position 1 had the value for row 2, etc. But the reader expected values at their scattered positions (position 0 for row 0, position 2 for row 2, position 3 for row 3, ...). The null positions (1, 4) should have been gaps.

The fix:
  1. Scatter the packed values to their correct output positions using scatterRows: iterate in reverse (i = numSelected-1 down to 0) to avoid overwriting unread values, placing values[i] at values[scatterRows[i]].
 2. Always use addNumValues(numRows) instead of addNumValues(V::dense ? numRows : numSelected) — after scatter, the output has numRows positions (including null gaps), not numSelected.

Reviewed By: xiaoxmeng

Differential Revision: D101522698


