### PR TITLE
feat: Add extraction stream skipping in Nimble reader (#672)

### DIFF
--- a/dwio/nimble/velox/selective/StructColumnReader.h
+++ b/dwio/nimble/velox/selective/StructColumnReader.h
@@ -56,6 +56,16 @@ class StructColumnReaderBase
 
   virtual std::unique_ptr<velox::dwio::common::ColumnLoader> makeColumnLoader(
       velox::vector_size_t index) override {
+    // Check if the child at this index has a transform with kNone extraction.
+    // If so, return a TransformColumnLoader to apply the transform lazily.
+    for (const auto& childSpec : scanSpec_->children()) {
+      if (childSpec->subscript() == index && childSpec->hasTransform() &&
+          childSpec->extractionType() ==
+              velox::common::ScanSpec::ExtractionType::kNone) {
+        return std::make_unique<velox::dwio::common::TransformColumnLoader>(
+            this, children_[index], numReads_, childSpec->transform());
+      }
+    }
     return std::make_unique<nimble::TrackedColumnLoader>(
         this, children_[index], numReads_, rowSizeTracker_);
   }

--- a/dwio/nimble/velox/selective/VariableLengthColumnReader.cpp
+++ b/dwio/nimble/velox/selective/VariableLengthColumnReader.cpp
@@ -304,6 +304,17 @@ ListColumnReader::ListColumnReader(
             velox::common::ScanSpec::kArrayElementsFieldName));
   }
   scanSpec_->children()[0]->setProjectOut(true);
+
+  // For kSize extraction we only need the length stream, so skip creating
+  // the element reader entirely.  This avoids registering its streams and
+  // reduces IO.  When deltaUpdate is set, we still need the element reader
+  // because delta updates operate on the full array.
+  if (scanSpec.extractionType() ==
+          velox::common::ScanSpec::ExtractionType::kSize &&
+      !scanSpec.deltaUpdate()) {
+    return;
+  }
+
   auto childParams =
       params.makeChildParams(params.nimbleType()->asArray().elements());
   child_ = buildColumnReader(
@@ -346,8 +357,6 @@ uint64_t ListColumnReader::skip(uint64_t numValues) {
     }
     child_->seekTo(child_->readOffset() + childElements, false);
     childTargetReadOffset_ += childElements;
-  } else {
-    VELOX_FAIL("Variable length type reader with no children");
   }
   return velox::bits::countNonNulls(nulls, 0, numValues);
 }
@@ -361,11 +370,37 @@ bool ListColumnReader::estimateMaterializedSize(
 
 namespace {
 
+/// Returns true if the MAP extraction type needs the key child reader.
+/// When deltaUpdate is set, all child readers are needed regardless of
+/// ExtractionType because delta updates (e.g., MAP_CONCAT) operate on the
+/// full map.
+bool needsKeyReader(
+    velox::common::ScanSpec::ExtractionType extractionType,
+    bool hasDeltaUpdate) {
+  return hasDeltaUpdate ||
+      extractionType == velox::common::ScanSpec::ExtractionType::kNone ||
+      extractionType == velox::common::ScanSpec::ExtractionType::kKeys;
+}
+
+/// Returns true if the MAP extraction type needs the value child reader.
+/// When deltaUpdate is set, all child readers are needed regardless of
+/// ExtractionType because delta updates (e.g., MAP_CONCAT) operate on the
+/// full map.
+bool needsElementReader(
+    velox::common::ScanSpec::ExtractionType extractionType,
+    bool hasDeltaUpdate) {
+  return hasDeltaUpdate ||
+      extractionType == velox::common::ScanSpec::ExtractionType::kNone ||
+      extractionType == velox::common::ScanSpec::ExtractionType::kValues;
+}
+
 void makeMapChildrenReaders(
     const velox::dwio::common::TypeWithId& fileType,
     const velox::Type& requestedType,
     NimbleParams& params,
     const velox::common::ScanSpec& scanSpec,
+    velox::common::ScanSpec::ExtractionType extractionType,
+    bool hasDeltaUpdate,
     std::unique_ptr<velox::dwio::common::SelectiveColumnReader>& keyReader,
     std::unique_ptr<velox::dwio::common::SelectiveColumnReader>&
         elementReader) {
@@ -374,20 +409,26 @@ void makeMapChildrenReaders(
   auto& fileKeyType = fileType.childAt(0);
   auto& fileValueType = fileType.childAt(1);
   auto& mapSchemaType = params.nimbleType()->asMap();
-  auto keyParams = params.makeChildParams(mapSchemaType.keys());
-  keyReader = buildColumnReader(
-      keyType,
-      fileKeyType,
-      keyParams,
-      *scanSpec.children()[0],
-      /*isRoot=*/false);
-  auto valueParams = params.makeChildParams(mapSchemaType.values());
-  elementReader = buildColumnReader(
-      valueType,
-      fileValueType,
-      valueParams,
-      *scanSpec.children()[1],
-      /*isRoot=*/false);
+  // Skip creating child readers that extraction pushdown doesn't need.
+  // This avoids registering their streams and reduces IO.
+  if (needsKeyReader(extractionType, hasDeltaUpdate)) {
+    auto keyParams = params.makeChildParams(mapSchemaType.keys());
+    keyReader = buildColumnReader(
+        keyType,
+        fileKeyType,
+        keyParams,
+        *scanSpec.children()[0],
+        /*isRoot=*/false);
+  }
+  if (needsElementReader(extractionType, hasDeltaUpdate)) {
+    auto valueParams = params.makeChildParams(mapSchemaType.values());
+    elementReader = buildColumnReader(
+        valueType,
+        fileValueType,
+        valueParams,
+        *scanSpec.children()[1],
+        /*isRoot=*/false);
+  }
 }
 
 template <typename ReadLengths>
@@ -403,7 +444,10 @@ uint64_t skipMapChildren(
       velox::bits::nwords(numValues), memoryPool);
   auto nulls = nullsBuffer->as<uint64_t>();
   formatData.readNulls(numValues, nullptr, nullsBuffer);
-  NIMBLE_CHECK(keyReader || elementReader);
+  if (!keyReader && !elementReader) {
+    return velox::bits::countNonNulls(
+        nulls, 0, static_cast<uint32_t>(numValues));
+  }
   nimble::Vector<int32_t> buffer{memoryPool, numValues};
   uint64_t childElements = 0;
   readLengths(buffer.data(), numValues, nullptr);
@@ -435,9 +479,16 @@ MapColumnReader::MapColumnReader(
       *requestedType_,
       params,
       *scanSpec_,
+      scanSpec.extractionType(),
+      scanSpec.deltaUpdate() != nullptr,
       keyReader_,
       elementReader_);
-  children_ = {keyReader_.get(), elementReader_.get()};
+  if (keyReader_) {
+    children_.push_back(keyReader_.get());
+  }
+  if (elementReader_) {
+    children_.push_back(elementReader_.get());
+  }
 }
 
 void MapColumnReader::readLengths(
@@ -485,11 +536,15 @@ MapAsStructColumnReader::MapAsStructColumnReader(
           fileType,
           params,
           scanSpec} {
+  // MapAsStruct never uses extraction pushdown (asserted in base class),
+  // so always create both readers.
   makeMapChildrenReaders(
       *fileType_,
       *requestedType_,
       params,
       mapScanSpec_,
+      velox::common::ScanSpec::ExtractionType::kNone,
+      /*hasDeltaUpdate=*/false,
       keyReader_,
       elementReader_);
   children_ = {keyReader_.get(), elementReader_.get()};
@@ -909,6 +964,15 @@ DeduplicatedArrayColumnReader::DeduplicatedArrayColumnReader(
             velox::common::ScanSpec::kArrayElementsFieldName));
   }
   scanSpec_->children()[0]->setProjectOut(true);
+
+  // For kSize extraction we only need the length stream, so skip creating
+  // the element reader entirely.  This avoids registering its streams and
+  // reduces IO.
+  if (scanSpec.extractionType() ==
+      velox::common::ScanSpec::ExtractionType::kSize) {
+    return;
+  }
+
   auto childParams = params.makeChildParams(
       params.nimbleType()->asArrayWithOffsets().elements());
   child_ = buildColumnReader(
@@ -953,8 +1017,6 @@ uint64_t DeduplicatedArrayColumnReader::skip(uint64_t numValues) {
         deduplicatedReadHelper_.prepareDeduplicatedStates(numValues, nulls);
     deduplicatedReadHelper_.skip(numValues, alphabetSize);
     child_->seekTo(childTargetReadOffset_, false);
-  } else {
-    VELOX_FAIL("Variable length type reader with no children");
   }
   return velox::bits::countNonNulls(nulls, 0, numValues);
 }
@@ -977,6 +1039,13 @@ void DeduplicatedArrayColumnReader::getValues(
     const velox::RowSet& rows,
     velox::VectorPtr* result) {
   VELOX_DCHECK_NOT_NULL(result);
+
+  if (scanSpec_->extractionType() ==
+      velox::common::ScanSpec::ExtractionType::kSize) {
+    getExtractionSizeValues(rows, result);
+    return;
+  }
+
   deduplicatedReadHelper_.lastRunLoaded_ = true;
   // TODO: looks like elements of the alphabet is not properly
   // referenced, and thus we are already in the elements of the
@@ -1040,22 +1109,35 @@ DeduplicatedMapColumnReader::DeduplicatedMapColumnReader(
   auto& fileKeyType = fileType_->childAt(0);
   auto& fileValueType = fileType_->childAt(1);
 
+  const auto extractionType = scanSpec.extractionType();
+  const bool hasDeltaUpdate = scanSpec.deltaUpdate() != nullptr;
   auto& mapSchemaType = params.nimbleType()->asSlidingWindowMap();
-  auto keyParams = params.makeChildParams(mapSchemaType.keys());
-  keyReader_ = buildColumnReader(
-      keyType,
-      fileKeyType,
-      keyParams,
-      *scanSpec_->children()[0],
-      /*isRoot=*/false);
-  auto valueParams = params.makeChildParams(mapSchemaType.values());
-  elementReader_ = buildColumnReader(
-      valueType,
-      fileValueType,
-      valueParams,
-      *scanSpec_->children()[1],
-      /*isRoot=*/false);
-  children_ = {keyReader_.get(), elementReader_.get()};
+  // Skip creating child readers that extraction pushdown doesn't need.
+  // This avoids registering their streams and reduces IO.
+  if (needsKeyReader(extractionType, hasDeltaUpdate)) {
+    auto keyParams = params.makeChildParams(mapSchemaType.keys());
+    keyReader_ = buildColumnReader(
+        keyType,
+        fileKeyType,
+        keyParams,
+        *scanSpec_->children()[0],
+        /*isRoot=*/false);
+  }
+  if (needsElementReader(extractionType, hasDeltaUpdate)) {
+    auto valueParams = params.makeChildParams(mapSchemaType.values());
+    elementReader_ = buildColumnReader(
+        valueType,
+        fileValueType,
+        valueParams,
+        *scanSpec_->children()[1],
+        /*isRoot=*/false);
+  }
+  if (keyReader_) {
+    children_.push_back(keyReader_.get());
+  }
+  if (elementReader_) {
+    children_.push_back(elementReader_.get());
+  }
 }
 
 void DeduplicatedMapColumnReader::readLengths(
@@ -1096,8 +1178,6 @@ uint64_t DeduplicatedMapColumnReader::skip(uint64_t numValues) {
     if (elementReader_) {
       elementReader_->seekTo(childTargetReadOffset_, false);
     }
-  } else {
-    VELOX_FAIL("Variable length type reader with no children");
   }
   return velox::bits::countNonNulls(nulls, 0, numValues);
 }
@@ -1120,6 +1200,13 @@ void DeduplicatedMapColumnReader::getValues(
     const velox::RowSet& rows,
     velox::VectorPtr* result) {
   VELOX_DCHECK_NOT_NULL(result);
+  const auto extractionType = scanSpec_->extractionType();
+
+  if (extractionType != velox::common::ScanSpec::ExtractionType::kNone) {
+    getExtractionValues(rows, result);
+    return;
+  }
+
   deduplicatedReadHelper_.lastRunLoaded_ = true;
   // TODO: looks like elements of the alphabet is not properly
   // referenced, and thus we are already in the elements of the

--- a/dwio/nimble/velox/selective/VariableLengthColumnReader.h
+++ b/dwio/nimble/velox/selective/VariableLengthColumnReader.h
@@ -37,7 +37,9 @@ class ListColumnReader : public velox::dwio::common::SelectiveListColumnReader {
   uint64_t skip(uint64_t numValues) override;
 
   void resetFilterCaches() override {
-    child_->resetFilterCaches();
+    if (child_) {
+      child_->resetFilterCaches();
+    }
   }
 
   void seekToRowGroup(int64_t /*index*/) override {
@@ -167,7 +169,9 @@ class DeduplicatedArrayColumnReader
   void makeNestedRowSet(const velox::RowSet& rows, int32_t maxRow) override;
 
   void resetFilterCaches() override {
-    child_->resetFilterCaches();
+    if (child_) {
+      child_->resetFilterCaches();
+    }
   }
 
   void seekToRowGroup(int64_t /*index*/) override {

--- a/dwio/nimble/velox/selective/tests/E2EFilterTest.cpp
+++ b/dwio/nimble/velox/selective/tests/E2EFilterTest.cpp
@@ -33,6 +33,7 @@
 #include "velox/common/memory/MallocAllocator.h"
 #include "velox/dwio/common/CachedBufferedInput.h"
 #include "velox/dwio/common/tests/utils/E2EFilterTestBase.h"
+#include "velox/vector/tests/utils/VectorMaker.h"
 
 namespace facebook::nimble {
 namespace {
@@ -2252,5 +2253,235 @@ TEST_P(E2EFilterTest, crossChunkEncodingChange) {
 
   EXPECT_EQ(totalRows, kNumBatches * kRowsPerBatch);
 }
+
+// --- Column extraction pushdown tests ---
+// These tests write data to Nimble format, configure ScanSpec with extraction
+// transforms, and verify the reader applies them correctly.
+
+class NimbleExtractionTest : public E2EFilterTest {
+ protected:
+  struct ReadResult {
+    VectorPtr result;
+    std::unique_ptr<dwio::common::Reader> reader;
+    std::unique_ptr<dwio::common::RowReader> rowReader;
+  };
+
+  // Write data to Nimble in-memory and read with a configured ScanSpec.
+  // configureColSpec is invoked with the column's ScanSpec to apply
+  // extraction settings (setExtractionType, setExtractionFieldIndex,
+  // setFilter, setConstantValue on children, etc.).
+  ReadResult readWithTransform(
+      const RowVectorPtr& data,
+      const std::string& columnName,
+      std::function<void(common::ScanSpec*)> configureColSpec) {
+    // Write.
+    rowType_ = asRowType(data->type());
+    VeloxWriterOptions options;
+    auto writeFile = std::make_unique<InMemoryWriteFile>(&sinkData_);
+    VeloxWriter writer(
+        rowType_, std::move(writeFile), *rootPool_, std::move(options));
+    writer.write(data);
+    writer.close();
+
+    // Read.
+    auto ioStats = std::make_shared<io::IoStatistics>();
+    dwio::common::ReaderOptions readerOpts{
+        leafPool_.get(), ioStats.get(), ioStats.get()};
+    auto input = std::make_unique<dwio::common::BufferedInput>(
+        std::make_shared<InMemoryReadFile>(sinkData_), readerOpts.memoryPool());
+
+    ReadResult rr;
+    rr.reader = makeReader(readerOpts, std::move(input));
+
+    auto spec = std::make_shared<common::ScanSpec>("<root>");
+    spec->addAllChildFields(*rowType_);
+    if (configureColSpec) {
+      configureColSpec(spec->childByName(columnName));
+    }
+
+    dwio::common::RowReaderOptions rowReaderOpts;
+    setUpRowReaderOptions(rowReaderOpts, spec);
+    rr.rowReader = rr.reader->createRowReader(rowReaderOpts);
+
+    rr.result = BaseVector::create(rowType_, 0, leafPool_.get());
+    rr.rowReader->next(data->size(), rr.result);
+    return rr;
+  }
+};
+
+TEST_P(NimbleExtractionTest, mapKeysExtraction) {
+  // Write MAP(VARCHAR, BIGINT), apply MapKeys transform -> ARRAY(VARCHAR).
+  velox::test::VectorMaker vm(leafPool_.get());
+  auto mapVector = vm.mapVector<StringView, int64_t>(
+      {{{"a", 1}, {"b", 2}}, {{"c", 3}}, {{"d", 4}, {"e", 5}, {"f", 6}}});
+  auto data = vm.rowVector({"col"}, {mapVector});
+
+  // Reader handles MapKeys natively — no transform needed.
+  auto rr = readWithTransform(data, "col", [](common::ScanSpec* colSpec) {
+    colSpec->setExtractionType(common::ScanSpec::ExtractionType::kKeys);
+  });
+
+  auto* row = rr.result->as<RowVector>();
+  ASSERT_EQ(row->size(), 3);
+  auto* arr = row->childAt(0)->loadedVector()->as<ArrayVector>();
+  ASSERT_EQ(arr->sizeAt(0), 2);
+  ASSERT_EQ(arr->sizeAt(1), 1);
+  ASSERT_EQ(arr->sizeAt(2), 3);
+}
+
+TEST_P(NimbleExtractionTest, sizeExtraction) {
+  // Write MAP(VARCHAR, BIGINT), apply Size transform -> BIGINT.
+  velox::test::VectorMaker vm(leafPool_.get());
+  auto mapVector = vm.mapVector<StringView, int64_t>(
+      {{{"a", 1}, {"b", 2}, {"c", 3}}, {{"d", 4}}});
+  auto data = vm.rowVector({"col"}, {mapVector});
+
+  // Reader handles Size natively — no transform needed.
+  auto rr = readWithTransform(data, "col", [](common::ScanSpec* colSpec) {
+    colSpec->setExtractionType(common::ScanSpec::ExtractionType::kSize);
+  });
+
+  auto* row = rr.result->as<RowVector>();
+  ASSERT_EQ(row->size(), 2);
+  auto* sizes = row->childAt(0)->loadedVector()->as<FlatVector<int64_t>>();
+  ASSERT_EQ(sizes->valueAt(0), 3);
+  ASSERT_EQ(sizes->valueAt(1), 1);
+}
+
+TEST_P(NimbleExtractionTest, mapValuesExtraction) {
+  // Write MAP(VARCHAR, BIGINT), apply MapValues transform -> ARRAY(BIGINT).
+  velox::test::VectorMaker vm(leafPool_.get());
+  auto mapVector = vm.mapVector<StringView, int64_t>(
+      {{{"a", 10}}, {{"b", 20}, {"c", 30}}, {{"d", 40}}});
+  auto data = vm.rowVector({"col"}, {mapVector});
+
+  // Reader handles MapValues natively — no transform needed.
+  auto rr = readWithTransform(data, "col", [](common::ScanSpec* colSpec) {
+    colSpec->setExtractionType(common::ScanSpec::ExtractionType::kValues);
+  });
+
+  auto* row = rr.result->as<RowVector>();
+  ASSERT_EQ(row->size(), 3);
+  auto* arr = row->childAt(0)->loadedVector()->as<ArrayVector>();
+  ASSERT_EQ(arr->sizeAt(0), 1);
+  ASSERT_EQ(arr->sizeAt(1), 2);
+  ASSERT_EQ(arr->sizeAt(2), 1);
+  auto* elements = arr->elements()->as<FlatVector<int64_t>>();
+  ASSERT_EQ(elements->valueAt(0), 10);
+  ASSERT_EQ(elements->valueAt(1), 20);
+  ASSERT_EQ(elements->valueAt(2), 30);
+  ASSERT_EQ(elements->valueAt(3), 40);
+}
+
+TEST_P(NimbleExtractionTest, mapKeyFilterExtraction) {
+  // Write MAP(VARCHAR, BIGINT), apply MapKeyFilter for keys {"a","b"}.
+  velox::test::VectorMaker vm(leafPool_.get());
+  auto mapVector = vm.mapVector<StringView, int64_t>(
+      {{{"a", 1}, {"b", 2}, {"c", 3}}, {{"a", 10}, {"d", 40}}});
+  auto data = vm.rowVector({"col"}, {mapVector});
+
+  // MapKeyFilter is implemented as an IN filter on the map keys ScanSpec
+  // (type-preserving — MAP stays MAP).
+  auto rr = readWithTransform(data, "col", [](common::ScanSpec* colSpec) {
+    auto* keysSpec = colSpec->childByName(common::ScanSpec::kMapKeysFieldName);
+    keysSpec->setFilter(
+        std::make_unique<common::BytesValues>(
+            std::vector<std::string>{"a", "b"}, /*nullAllowed=*/false));
+  });
+
+  auto* row = rr.result->as<RowVector>();
+  ASSERT_EQ(row->size(), 2);
+  auto* filteredMap = row->childAt(0)->loadedVector()->as<MapVector>();
+  // Row 0: {"a":1, "b":2} kept, "c" filtered out.
+  ASSERT_EQ(filteredMap->sizeAt(0), 2);
+  // Row 1: {"a":10} kept, "d" filtered out.
+  ASSERT_EQ(filteredMap->sizeAt(1), 1);
+}
+
+TEST_P(NimbleExtractionTest, structFieldExtraction) {
+  // Write ROW(x: INT, y: VARCHAR), extract just field "x".
+  velox::test::VectorMaker vm(leafPool_.get());
+  auto structVector = vm.rowVector(
+      {"x", "y"},
+      {vm.flatVector<int32_t>({10, 20, 30}),
+       vm.flatVector<StringView>({"aa", "bb", "cc"})});
+  auto data = vm.rowVector({"col"}, {structVector});
+
+  // kField on struct: extract field index 0 ("x"); mark "y" constant null.
+  auto rr = readWithTransform(data, "col", [&](common::ScanSpec* colSpec) {
+    colSpec->setExtractionType(common::ScanSpec::ExtractionType::kField);
+    colSpec->setExtractionFieldIndex(0);
+    colSpec->childByName("y")->setConstantValue(
+        BaseVector::createNullConstant(VARCHAR(), 1, leafPool_.get()));
+  });
+
+  auto* row = rr.result->as<RowVector>();
+  ASSERT_EQ(row->size(), 3);
+  auto* xField = row->childAt(0)->loadedVector()->as<FlatVector<int32_t>>();
+  ASSERT_EQ(xField->valueAt(0), 10);
+  ASSERT_EQ(xField->valueAt(1), 20);
+  ASSERT_EQ(xField->valueAt(2), 30);
+}
+
+TEST_P(NimbleExtractionTest, arraySizeExtraction) {
+  // Write ARRAY(BIGINT), apply Size transform -> BIGINT.
+  velox::test::VectorMaker vm(leafPool_.get());
+  auto arrayVector = vm.arrayVector<int64_t>({{1, 2, 3}, {4}, {5, 6}});
+  auto data = vm.rowVector({"col"}, {arrayVector});
+
+  // Reader handles Size natively — no transform needed.
+  auto rr = readWithTransform(data, "col", [](common::ScanSpec* colSpec) {
+    colSpec->setExtractionType(common::ScanSpec::ExtractionType::kSize);
+  });
+
+  auto* row = rr.result->as<RowVector>();
+  ASSERT_EQ(row->size(), 3);
+  auto* sizes = row->childAt(0)->loadedVector()->as<FlatVector<int64_t>>();
+  ASSERT_EQ(sizes->valueAt(0), 3);
+  ASSERT_EQ(sizes->valueAt(1), 1);
+  ASSERT_EQ(sizes->valueAt(2), 2);
+}
+
+TEST_P(NimbleExtractionTest, mapValuesStructFieldExtraction) {
+  // Write MAP(VARCHAR, ROW(x: INT, y: INT)), apply
+  // [MapValues, AE, StructField("x")] -> ARRAY(INT).
+  velox::test::VectorMaker vm(leafPool_.get());
+  auto keys = vm.flatVector<StringView>({"a", "b", "c"});
+  auto structValues = vm.rowVector(
+      {"x", "y"},
+      {vm.flatVector<int32_t>({10, 20, 30}),
+       vm.flatVector<int32_t>({100, 200, 300})});
+  auto mapVector = vm.mapVector({0, 2}, keys, structValues);
+  auto data = vm.rowVector({"col"}, {mapVector});
+
+  // Reader handles MapValues via kValues and StructField("x") via kField
+  // on the values struct — no remaining transform needed.
+  auto rr = readWithTransform(data, "col", [&](common::ScanSpec* colSpec) {
+    colSpec->setExtractionType(common::ScanSpec::ExtractionType::kValues);
+    auto* valuesSpec =
+        colSpec->childByName(common::ScanSpec::kMapValuesFieldName);
+    valuesSpec->setExtractionType(common::ScanSpec::ExtractionType::kField);
+    valuesSpec->setExtractionFieldIndex(0);
+    valuesSpec->childByName("y")->setConstantValue(
+        BaseVector::createNullConstant(INTEGER(), 1, leafPool_.get()));
+  });
+
+  auto* row = rr.result->as<RowVector>();
+  ASSERT_EQ(row->size(), 2);
+  auto* arr = row->childAt(0)->loadedVector()->as<ArrayVector>();
+  ASSERT_EQ(arr->sizeAt(0), 2);
+  ASSERT_EQ(arr->sizeAt(1), 1);
+  auto* elements = arr->elements()->as<FlatVector<int32_t>>();
+  ASSERT_EQ(elements->valueAt(0), 10);
+  ASSERT_EQ(elements->valueAt(1), 20);
+  ASSERT_EQ(elements->valueAt(2), 30);
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    NimbleExtractionTests,
+    NimbleExtractionTest,
+    ::testing::Values(
+        E2EFilterTestParams{false, false, false, false, false, false},
+        E2EFilterTestParams{false, false, false, false, false, true}));
 
 } // namespace facebook::nimble

--- a/dwio/nimble/velox/selective/tests/SelectiveNimbleReaderTest.cpp
+++ b/dwio/nimble/velox/selective/tests/SelectiveNimbleReaderTest.cpp
@@ -2873,7 +2873,7 @@ TEST_P(SelectiveNimbleReaderTest, columnStatisticsInteger) {
   auto readers =
       makeReaders(input, fileContent, scanSpec, this->stringDecoderZeroCopy());
 
-  // Column 0 is the root ROW — column 1 is the first child (c0).
+  // Column 0 is the root ROW -- column 1 is the first child (c0).
   auto stats = readers.reader->columnStatistics(1);
   ASSERT_NE(stats, nullptr);
   ASSERT_TRUE(stats->getNumberOfValues().has_value());
@@ -2960,7 +2960,7 @@ TEST_P(SelectiveNimbleReaderTest, columnStatisticsOutOfRange) {
   // Out-of-range index returns nullptr.
   EXPECT_EQ(readers.reader->columnStatistics(999), nullptr);
 
-  // Column 0 is the root ROW — should return base ColumnStatistics.
+  // Column 0 is the root ROW -- should return base ColumnStatistics.
   auto rootStats = readers.reader->columnStatistics(0);
   ASSERT_NE(rootStats, nullptr);
   ASSERT_TRUE(rootStats->getNumberOfValues().has_value());
@@ -3029,6 +3029,317 @@ TEST_P(SelectiveNimbleReaderTest, columnStatisticsAllNull) {
   ASSERT_NE(intStats, nullptr);
   EXPECT_EQ(intStats->getMinimum(), std::nullopt);
   EXPECT_EQ(intStats->getMaximum(), std::nullopt);
+}
+
+TEST_P(SelectiveNimbleReaderTest, extractionTransformMapKeys) {
+  // Write a MAP(VARCHAR, BIGINT) column, read with a MapKeys extraction
+  // transform applied via ScanSpec.
+  auto mapVector = makeMapVector<StringView, int64_t>(
+      {{{"a", 1}, {"b", 2}}, {{"c", 3}}, {{"d", 4}, {"e", 5}, {"f", 6}}});
+  auto input = makeRowVector({"col"}, {mapVector});
+  auto file = test::createNimbleFile(*rootPool(), input);
+
+  auto scanSpec = std::make_shared<common::ScanSpec>("root");
+  scanSpec->addAllChildFields(*input->type());
+
+  scanSpec->childByName("col")->setExtractionType(
+      common::ScanSpec::ExtractionType::kKeys);
+
+  auto readers =
+      makeReaders(input, file, scanSpec, GetParam().stringDecoderZeroCopy);
+  auto result = BaseVector::create(input->type(), 0, pool());
+  ASSERT_EQ(readers.rowReader->next(10, result), 3);
+  auto* row = result->as<RowVector>();
+  auto* resultArray = row->childAt(0)->loadedVector()->as<ArrayVector>();
+  ASSERT_EQ(resultArray->size(), 3);
+  ASSERT_EQ(resultArray->sizeAt(0), 2);
+  ASSERT_EQ(resultArray->sizeAt(1), 1);
+  ASSERT_EQ(resultArray->sizeAt(2), 3);
+}
+
+TEST_P(SelectiveNimbleReaderTest, extractionTransformSize) {
+  // Write a MAP(VARCHAR, BIGINT) column, read with a Size extraction.
+  auto mapVector = makeMapVector<StringView, int64_t>(
+      {{{"a", 1}, {"b", 2}, {"c", 3}}, {{"d", 4}}});
+  auto input = makeRowVector({"col"}, {mapVector});
+  auto file = test::createNimbleFile(*rootPool(), input);
+
+  auto scanSpec = std::make_shared<common::ScanSpec>("root");
+  scanSpec->addAllChildFields(*input->type());
+
+  scanSpec->childByName("col")->setExtractionType(
+      common::ScanSpec::ExtractionType::kSize);
+
+  auto readers =
+      makeReaders(input, file, scanSpec, GetParam().stringDecoderZeroCopy);
+  auto result = BaseVector::create(input->type(), 0, pool());
+  ASSERT_EQ(readers.rowReader->next(10, result), 2);
+  auto* row = result->as<RowVector>();
+  auto* sizes = row->childAt(0)->loadedVector()->as<FlatVector<int64_t>>();
+  ASSERT_EQ(sizes->size(), 2);
+  ASSERT_EQ(sizes->valueAt(0), 3);
+  ASSERT_EQ(sizes->valueAt(1), 1);
+}
+
+TEST_P(SelectiveNimbleReaderTest, extractionTransformMapValuesStructField) {
+  // Write MAP(VARCHAR, ROW(x: INT, y: INT)), apply
+  // [MapValues, AE, StructField("x")] -> ARRAY(INT).
+  // The reader handles this natively via kValues on the map and kField on
+  // the values struct, so no post-read transform is needed.
+  auto keys = makeFlatVector<StringView>({"a", "b", "c"});
+  auto structValues = makeRowVector(
+      {"x", "y"},
+      {makeFlatVector<int32_t>({10, 20, 30}),
+       makeFlatVector<int32_t>({100, 200, 300})});
+  auto mapVector = makeMapVector({0, 2}, keys, structValues);
+  auto input = makeRowVector({"col"}, {mapVector});
+  auto file = test::createNimbleFile(*rootPool(), input);
+
+  auto scanSpec = std::make_shared<common::ScanSpec>("root");
+  scanSpec->addAllChildFields(*input->type());
+
+  // Configure ScanSpec directly: kValues on the map, then kField on the
+  // values struct (extracting field "x" at index 0).  Mark "y" constant
+  // null so it is not read.
+  auto* colSpec = scanSpec->childByName("col");
+  colSpec->setExtractionType(common::ScanSpec::ExtractionType::kValues);
+  auto* valuesSpec =
+      colSpec->childByName(common::ScanSpec::kMapValuesFieldName);
+  valuesSpec->setExtractionType(common::ScanSpec::ExtractionType::kField);
+  valuesSpec->setExtractionFieldIndex(0);
+  valuesSpec->childByName("y")->setConstantValue(
+      BaseVector::createNullConstant(INTEGER(), 1, pool()));
+
+  auto readers =
+      makeReaders(input, file, scanSpec, GetParam().stringDecoderZeroCopy);
+  auto result = BaseVector::create(input->type(), 0, pool());
+  ASSERT_EQ(readers.rowReader->next(10, result), 2);
+  auto* row = result->as<RowVector>();
+  auto* resultArray = row->childAt(0)->loadedVector()->as<ArrayVector>();
+  ASSERT_EQ(resultArray->size(), 2);
+  ASSERT_EQ(resultArray->sizeAt(0), 2);
+  ASSERT_EQ(resultArray->sizeAt(1), 1);
+  auto* elements = resultArray->elements()->as<FlatVector<int32_t>>();
+  ASSERT_EQ(elements->valueAt(0), 10);
+  ASSERT_EQ(elements->valueAt(1), 20);
+  ASSERT_EQ(elements->valueAt(2), 30);
+}
+
+TEST_P(SelectiveNimbleReaderTest, extractionSizeResultVectorReuse) {
+  // Verify the FlatVector<int64_t> result is reused across batches.
+  constexpr int kNumRows = 200;
+  std::vector<std::string> keyStrs(kNumRows * 2);
+  for (int i = 0; i < kNumRows * 2; ++i) {
+    keyStrs[i] = std::to_string(i);
+  }
+  auto keys = makeFlatVector<StringView>(
+      kNumRows * 2, [&](auto i) { return StringView(keyStrs[i]); });
+  auto values = makeFlatVector<int64_t>(kNumRows * 2, folly::identity);
+  std::vector<vector_size_t> offsets(kNumRows);
+  for (int i = 0; i < kNumRows; ++i) {
+    offsets[i] = i * 2;
+  }
+  auto mapVector = makeMapVector(offsets, keys, values);
+  auto input = makeRowVector({"col"}, {mapVector});
+  auto file = test::createNimbleFile(*rootPool(), input);
+
+  auto scanSpec = std::make_shared<common::ScanSpec>("root");
+  scanSpec->addAllChildFields(*input->type());
+  scanSpec->childByName("col")->setExtractionType(
+      common::ScanSpec::ExtractionType::kSize);
+
+  auto readers =
+      makeReaders(input, file, scanSpec, GetParam().stringDecoderZeroCopy);
+  auto result = BaseVector::create(input->type(), 0, pool());
+
+  // Read first batch.
+  ASSERT_GT(readers.rowReader->next(50, result), 0);
+  auto* row = result->as<RowVector>();
+  auto* child = row->childAt(0)->loadedVector();
+  ASSERT_TRUE(child->type()->isBigint());
+  auto* firstBatchPtr = child;
+
+  // Read second batch — FlatVector should be the same object.
+  ASSERT_GT(readers.rowReader->next(50, result), 0);
+  row = result->as<RowVector>();
+  child = row->childAt(0)->loadedVector();
+  ASSERT_EQ(child, firstBatchPtr)
+      << "FlatVector result should be reused across batches for Size extraction";
+
+  auto* sizes = child->as<FlatVector<int64_t>>();
+  for (int i = 0; i < sizes->size(); ++i) {
+    ASSERT_EQ(sizes->valueAt(i), 2);
+  }
+}
+
+TEST_P(SelectiveNimbleReaderTest, extractionTransformMapValues) {
+  // Write a MAP(VARCHAR, BIGINT) column, read with a MapValues extraction
+  // transform applied via ScanSpec.
+  auto mapVector = makeMapVector<StringView, int64_t>(
+      {{{"a", 10}}, {{"b", 20}, {"c", 30}}, {{"d", 40}}});
+  auto input = makeRowVector({"col"}, {mapVector});
+  auto file = test::createNimbleFile(*rootPool(), input);
+
+  auto scanSpec = std::make_shared<common::ScanSpec>("root");
+  scanSpec->addAllChildFields(*input->type());
+
+  scanSpec->childByName("col")->setExtractionType(
+      common::ScanSpec::ExtractionType::kValues);
+
+  auto readers =
+      makeReaders(input, file, scanSpec, GetParam().stringDecoderZeroCopy);
+  auto result = BaseVector::create(input->type(), 0, pool());
+  ASSERT_EQ(readers.rowReader->next(10, result), 3);
+  auto* row = result->as<RowVector>();
+  auto* resultArray = row->childAt(0)->loadedVector()->as<ArrayVector>();
+  ASSERT_EQ(resultArray->size(), 3);
+  ASSERT_EQ(resultArray->sizeAt(0), 1);
+  ASSERT_EQ(resultArray->sizeAt(1), 2);
+  ASSERT_EQ(resultArray->sizeAt(2), 1);
+  auto* elements = resultArray->elements()->as<FlatVector<int64_t>>();
+  ASSERT_EQ(elements->valueAt(0), 10);
+  ASSERT_EQ(elements->valueAt(1), 20);
+  ASSERT_EQ(elements->valueAt(2), 30);
+  ASSERT_EQ(elements->valueAt(3), 40);
+}
+
+TEST_P(SelectiveNimbleReaderTest, extractionTransformMapKeyFilter) {
+  // Write a MAP(VARCHAR, BIGINT) column, apply MapKeyFilter extraction
+  // to keep only selected keys.
+  auto mapVector = makeMapVector<StringView, int64_t>(
+      {{{"a", 1}, {"b", 2}, {"c", 3}}, {{"a", 10}, {"d", 40}}});
+  auto input = makeRowVector({"col"}, {mapVector});
+  auto file = test::createNimbleFile(*rootPool(), input);
+
+  auto scanSpec = std::make_shared<common::ScanSpec>("root");
+  scanSpec->addAllChildFields(*input->type());
+
+  // MapKeyFilter is implemented as an IN filter on the map keys ScanSpec
+  // (type-preserving — MAP stays MAP).
+  auto* colSpec = scanSpec->childByName("col");
+  auto* keysSpec = colSpec->childByName(common::ScanSpec::kMapKeysFieldName);
+  keysSpec->setFilter(
+      std::make_unique<common::BytesValues>(
+          std::vector<std::string>{"a", "b"}, /*nullAllowed=*/false));
+
+  auto readers =
+      makeReaders(input, file, scanSpec, GetParam().stringDecoderZeroCopy);
+  auto result = BaseVector::create(input->type(), 0, pool());
+  ASSERT_EQ(readers.rowReader->next(10, result), 2);
+  auto* row = result->as<RowVector>();
+  auto* filteredMap = row->childAt(0)->loadedVector()->as<MapVector>();
+  ASSERT_EQ(filteredMap->size(), 2);
+  // Row 0: {"a":1, "b":2} kept, "c" filtered out.
+  ASSERT_EQ(filteredMap->sizeAt(0), 2);
+  // Row 1: {"a":10} kept, "d" filtered out.
+  ASSERT_EQ(filteredMap->sizeAt(1), 1);
+}
+
+TEST_P(SelectiveNimbleReaderTest, extractionTransformStructField) {
+  // Write a ROW(x: INT, y: VARCHAR) column, extract just field "x".
+  auto structVector = makeRowVector(
+      {"x", "y"},
+      {makeFlatVector<int32_t>({10, 20, 30}),
+       makeFlatVector<StringView>({"aa", "bb", "cc"})});
+  auto input = makeRowVector({"col"}, {structVector});
+  auto file = test::createNimbleFile(*rootPool(), input);
+
+  auto scanSpec = std::make_shared<common::ScanSpec>("root");
+  scanSpec->addAllChildFields(*input->type());
+
+  // kField on struct: extract field index 0 ("x"); mark "y" constant null.
+  auto* colSpec = scanSpec->childByName("col");
+  colSpec->setExtractionType(common::ScanSpec::ExtractionType::kField);
+  colSpec->setExtractionFieldIndex(0);
+  colSpec->childByName("y")->setConstantValue(
+      BaseVector::createNullConstant(VARCHAR(), 1, pool()));
+
+  auto readers =
+      makeReaders(input, file, scanSpec, GetParam().stringDecoderZeroCopy);
+  auto result = BaseVector::create(input->type(), 0, pool());
+  ASSERT_EQ(readers.rowReader->next(10, result), 3);
+  auto* row = result->as<RowVector>();
+  auto* xField = row->childAt(0)->loadedVector()->as<FlatVector<int32_t>>();
+  ASSERT_EQ(xField->size(), 3);
+  ASSERT_EQ(xField->valueAt(0), 10);
+  ASSERT_EQ(xField->valueAt(1), 20);
+  ASSERT_EQ(xField->valueAt(2), 30);
+}
+
+TEST_P(SelectiveNimbleReaderTest, extractionTransformArraySize) {
+  // Write an ARRAY(BIGINT) column, read with Size extraction.
+  auto arrayVector = makeArrayVector<int64_t>({{1, 2, 3}, {4}, {5, 6}});
+  auto input = makeRowVector({"col"}, {arrayVector});
+  auto file = test::createNimbleFile(*rootPool(), input);
+
+  auto scanSpec = std::make_shared<common::ScanSpec>("root");
+  scanSpec->addAllChildFields(*input->type());
+
+  scanSpec->childByName("col")->setExtractionType(
+      common::ScanSpec::ExtractionType::kSize);
+
+  auto readers =
+      makeReaders(input, file, scanSpec, GetParam().stringDecoderZeroCopy);
+  auto result = BaseVector::create(input->type(), 0, pool());
+  ASSERT_EQ(readers.rowReader->next(10, result), 3);
+  auto* row = result->as<RowVector>();
+  auto* sizes = row->childAt(0)->loadedVector()->as<FlatVector<int64_t>>();
+  ASSERT_EQ(sizes->size(), 3);
+  ASSERT_EQ(sizes->valueAt(0), 3);
+  ASSERT_EQ(sizes->valueAt(1), 1);
+  ASSERT_EQ(sizes->valueAt(2), 2);
+}
+
+TEST_P(SelectiveNimbleReaderTest, extractionDeduplicatedArraySize) {
+  // Write an ARRAY(BIGINT) column using the deduplicated (ArrayWithOffsets)
+  // encoding path, then verify Size extraction works correctly.
+  auto arrayVector = makeArrayVector<int64_t>({{1, 2}, {3}, {4, 5, 6}, {1, 2}});
+  auto input = makeRowVector({"col"}, {arrayVector});
+  auto file = test::createNimbleFile(
+      *rootPool(), input, {.dictionaryArrayColumns = {"col"}});
+
+  auto scanSpec = std::make_shared<common::ScanSpec>("root");
+  scanSpec->addAllChildFields(*input->type());
+  scanSpec->childByName("col")->setExtractionType(
+      common::ScanSpec::ExtractionType::kSize);
+
+  auto readers =
+      makeReaders(input, file, scanSpec, GetParam().stringDecoderZeroCopy);
+  auto result = BaseVector::create(input->type(), 0, pool());
+  ASSERT_EQ(readers.rowReader->next(10, result), 4);
+  auto* row = result->as<RowVector>();
+  auto* sizes = row->childAt(0)->loadedVector()->as<FlatVector<int64_t>>();
+  ASSERT_EQ(sizes->size(), 4);
+  ASSERT_EQ(sizes->valueAt(0), 2);
+  ASSERT_EQ(sizes->valueAt(1), 1);
+  ASSERT_EQ(sizes->valueAt(2), 3);
+  ASSERT_EQ(sizes->valueAt(3), 2);
+}
+
+TEST_P(SelectiveNimbleReaderTest, extractionDeduplicatedMapSize) {
+  // Write a MAP(BIGINT, BIGINT) column using the deduplicated
+  // (SlidingWindowMap) encoding path, then verify Size extraction works.
+  auto keys = makeFlatVector<int64_t>({1, 2, 3, 4});
+  auto values = makeFlatVector<int64_t>({10, 20, 30, 40});
+  auto mapVector = makeMapVector({0, 3}, keys, values);
+  auto input = makeRowVector({"col"}, {mapVector});
+  auto file = test::createNimbleFile(
+      *rootPool(), input, {.deduplicatedMapColumns = {"col"}});
+
+  auto scanSpec = std::make_shared<common::ScanSpec>("root");
+  scanSpec->addAllChildFields(*input->type());
+  scanSpec->childByName("col")->setExtractionType(
+      common::ScanSpec::ExtractionType::kSize);
+
+  auto readers =
+      makeReaders(input, file, scanSpec, GetParam().stringDecoderZeroCopy);
+  auto result = BaseVector::create(input->type(), 0, pool());
+  ASSERT_EQ(readers.rowReader->next(10, result), 2);
+  auto* row = result->as<RowVector>();
+  auto* sizes = row->childAt(0)->loadedVector()->as<FlatVector<int64_t>>();
+  ASSERT_EQ(sizes->size(), 2);
+  ASSERT_EQ(sizes->valueAt(0), 3);
+  ASSERT_EQ(sizes->valueAt(1), 1);
 }
 
 INSTANTIATE_TEST_CASE_P(


### PR DESCRIPTION
Summary:

Apply same stream-skipping optimization to Nimble selective reader.
Skip creating child readers for List/DeduplicatedArray/Map/DeduplicatedMap
based on ExtractionType with deltaUpdate awareness.  Add Nimble
extraction tests for all ExtractionStep types including deduplicated
readers.

Reviewed By: maniloya

Differential Revision: D97671749


