### PR TITLE
fix(build): Add -fsized-deallocation for s2geometry on Clang (#673)

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ Nimble integrates Velox as a Git submodule, referencing a specific commit of the
 Velox repository. The Velox badge at the top of this README shows the current
 commit and how far behind it is from Velox main.
 
-[See what changed since the current Velox commit.](https://github.com/facebookincubator/velox/compare/cd335e8176cbf34e098db5b4308c9e78f4fccd80...main)
+[See what changed since the current Velox commit.](https://github.com/facebookincubator/velox/compare/6efe23e86eb0b5d6d9c1d09fa721b998e2091104...main)
 <!-- pre-commit check-velox-readme validates the SHA above matches the submodule -->
 
 Advance Velox when your changes depend on code in Velox that

--- a/dwio/nimble/tablet/CMakeLists.txt
+++ b/dwio/nimble/tablet/CMakeLists.txt
@@ -107,17 +107,10 @@ target_link_libraries(
 add_library(nimble_tablet_reader FileLayout.cpp TabletReader.cpp)
 target_link_libraries(
   nimble_tablet_reader
-  PUBLIC
-    nimble_tablet_common
-    nimble_cluster_index_fb
-    nimble_chunk_index_fb
+  PUBLIC nimble_tablet_common nimble_cluster_index_fb nimble_chunk_index_fb
 )
 
-add_library(
-  nimble_tablet_writer
-  ChunkIndexWriter.cpp
-  TabletWriter.cpp
-)
+add_library(nimble_tablet_writer ChunkIndexWriter.cpp TabletWriter.cpp)
 target_link_libraries(
   nimble_tablet_writer
   nimble_tablet_common


### PR DESCRIPTION
Summary:

X-link: https://github.com/facebookincubator/velox/pull/17323

The Nimble OSS Linux CI build fails when compiling s2geometry v0.12.0 with clang-15 and GCC 12's libstdc++. s2geometry's `port.h` uses C++14 sized deallocation (`::operator delete(ptr, size)`), but Clang does not enable this by default unlike GCC.

This adds `-fsized-deallocation` to the `s2` CMake target when building with Clang, matching what Meta does internally for Clang builds across fbcode.

Reviewed By: xiaoxmeng, apurva-meta

Differential Revision: D102265942
