### PR TITLE
feat: Add hash index for point lookups on unsorted data (#674)

### DIFF
--- a/dwio/nimble/index/CMakeLists.txt
+++ b/dwio/nimble/index/CMakeLists.txt
@@ -18,6 +18,8 @@ add_library(
   ChunkIndexGroup.cpp
   ClusterIndex.cpp
   ClusterIndexWriter.cpp
+  HashIndex.cpp
+  HashIndexWriter.cpp
   IndexFilter.cpp
   IndexLookup.cpp
   SortOrder.cpp
@@ -30,6 +32,8 @@ target_link_libraries(
   nimble_tablet_common
   nimble_cluster_index_fb
   nimble_chunk_index_fb
+  nimble_hash_index_fb
+  nimble_bloom_filter_fb
   velox_core
   velox_type
   velox_vector

--- a/dwio/nimble/index/ClusterIndex.cpp
+++ b/dwio/nimble/index/ClusterIndex.cpp
@@ -161,7 +161,8 @@ ClusterIndex::ClusterIndex(
     LoadMetadataFn loadMetadata,
     LoadDataFn loadData,
     velox::memory::MemoryPool* pool)
-    : rootSection_{std::move(rootSection)},
+    : IndexLookup{IndexType::Cluster},
+      rootSection_{std::move(rootSection)},
       indexRoot_{getIndexRoot(rootSection_)},
       numPartitions_{getIndexPartitionCount(indexRoot_)},
       indexColumns_{getIndexColumns(indexRoot_)},

--- a/dwio/nimble/index/ClusterIndex.h
+++ b/dwio/nimble/index/ClusterIndex.h
@@ -81,12 +81,6 @@ class ClusterIndex : public IndexLookup {
       LoadDataFn loadData,
       velox::memory::MemoryPool* pool);
 
-  // -- IndexLookup interface --
-
-  IndexType indexType() const override {
-    return IndexType::Cluster;
-  }
-
   const std::vector<std::string>& indexColumns() const override {
     return indexColumns_;
   }

--- a/dwio/nimble/index/ClusterIndexWriter.cpp
+++ b/dwio/nimble/index/ClusterIndexWriter.cpp
@@ -20,6 +20,7 @@
 #include "dwio/nimble/tablet/Constants.h"
 #include "dwio/nimble/velox/BufferGrowthPolicy.h"
 #include "dwio/nimble/velox/ChunkedStreamWriter.h"
+#include "folly/ScopeGuard.h"
 #include "folly/String.h"
 #include "folly/json/json.h"
 #include "velox/common/base/Nulls.h"
@@ -190,7 +191,7 @@ ClusterIndexWriter::createEncodingPolicy() const {
 }
 
 void ClusterIndexWriter::write(const velox::VectorPtr& input) {
-  NIMBLE_CHECK(!finalized_, "ClusterIndexWriter has been finalized");
+  NIMBLE_CHECK(!closed_, "ClusterIndexWriter has been closed");
 
   if (input->size() == 0) {
     return;
@@ -332,100 +333,25 @@ void ClusterIndexWriter::encodeKeyChunk(
   }
 }
 
-void ClusterIndexWriter::close() {
-  keyStream_->reset();
-  keyBuffer_.reset();
-  indexPartition_.reset();
-  indexRoot_.reset();
-  finalized_ = true;
-}
+void ClusterIndexWriter::close(
+    const CreateMetadataSectionFn& createMetadataFn,
+    const WriteOptionalSectionFn& writeMetadataFn) {
+  NIMBLE_CHECK(!closed_, "ClusterIndexWriter has been closed");
 
-void ClusterIndexWriter::ensureIndexRoot() {
-  if (indexRoot_ == nullptr) {
-    indexRoot_ = std::make_unique<IndexRoot>();
-  }
-}
-
-void ClusterIndexWriter::ensureIndexPartition() {
-  if (indexPartition_ == nullptr) {
-    indexPartition_ = std::make_unique<IndexPartition>();
-    indexPartition_->encodingBuffer = std::make_unique<Buffer>(*pool_);
-  }
-}
-
-void ClusterIndexWriter::flushPartition(
-    size_t stripeCount,
-    const WriteDataFn& writeData,
-    const CreateMetadataSectionFn& createMetadataSection) {
-  NIMBLE_CHECK(!finalized_, "ClusterIndexWriter has been finalized");
-  NIMBLE_CHECK_GT(stripeCount, 0);
-
-  // Force-encode any remaining accumulated keys. This must happen before the
-  // indexPartition_ null check because when key chunking is disabled
-  // (maxRowsPerKeyChunk_ == 0), encodeKeyChunks() returns early during write()
-  // and the partition is only created here.
-  encodeKeyChunks(/*force=*/true);
-
-  NIMBLE_CHECK_NOT_NULL(indexPartition_);
-  NIMBLE_CHECK(!indexPartition_->empty());
-
-  // Write key stream data to file.
-  const auto [fileOffset, fileSize] = writeData(indexPartition_->encodedChunks);
-  indexPartition_->keyStreamFileOffset = fileOffset;
-  indexPartition_->keyStreamFileSize = fileSize;
-
-  // Build ClusterIndexPartition FlatBuffer.
-  ensureIndexRoot();
-
-  flatbuffers::FlatBufferBuilder indexBuilder(kInitialFooterSize);
-
-  auto chunkRowsVec = indexBuilder.CreateVector(indexPartition_->chunkRows);
-  auto chunkOffsetsVec =
-      indexBuilder.CreateVector(indexPartition_->chunkOffsets);
-  auto chunkKeysVec =
-      indexBuilder.CreateVector<flatbuffers::Offset<flatbuffers::String>>(
-          indexPartition_->chunkKeys.size(), [&indexBuilder, this](size_t i) {
-            return indexBuilder.CreateString(indexPartition_->chunkKeys[i]);
-          });
-
-  indexBuilder.Finish(
-      serialization::CreateClusterIndexPartition(
-          indexBuilder,
-          indexPartition_->keyStreamFileOffset,
-          indexPartition_->keyStreamFileSize,
-          chunkRowsVec,
-          chunkOffsetsVec,
-          chunkKeysVec));
-
-  indexRoot_->indexPartitions.push_back(
-      createMetadataSection(asView(indexBuilder)));
-
-  // Record last key and row count for root-level index.
-  NIMBLE_CHECK(!indexPartition_->chunkKeys.empty());
-  indexRoot_->partitionKeys.emplace_back(indexPartition_->chunkKeys.back());
-  indexRoot_->partitionRowCounts.emplace_back(
-      indexPartition_->chunkRows.back());
-
-  // Reset partition state.
-  indexPartition_.reset();
-}
-
-std::string ClusterIndexWriter::finalize(
-    const CreateMetadataSectionFn& createMetadataSection) {
-  NIMBLE_CHECK(!finalized_, "ClusterIndexWriter has been finalized");
-
-  finalized_ = true;
+  SCOPE_EXIT {
+    closed_ = true;
+    keyStream_->reset();
+    keyBuffer_.reset();
+    indexPartition_.reset();
+    indexRoot_.reset();
+  };
 
   if (indexRoot_ == nullptr) {
-    return {};
+    return;
   }
 
   NIMBLE_CHECK(
       !indexRoot_->indexPartitions.empty(), "Must have at least one partition");
-
-  // Validate partition keys layout: [firstKey, lastKey0, lastKey1, ...,
-  // lastKeyN]. The firstKey was pushed during the first encodeKeyChunks() call,
-  // and each flushPartition() appends a lastKey.
   NIMBLE_CHECK_EQ(
       indexRoot_->partitionKeys.size(),
       indexRoot_->indexPartitions.size() + 1,
@@ -474,7 +400,76 @@ std::string ClusterIndexWriter::finalize(
           partitionsVector,
           partitionKeysVector,
           partitionRowCountsVector));
-  return std::string(asView(builder));
+
+  writeMetadataFn(std::string(kClusterIndexSection), asView(builder));
+}
+
+void ClusterIndexWriter::ensureIndexRoot() {
+  if (indexRoot_ == nullptr) {
+    indexRoot_ = std::make_unique<IndexRoot>();
+  }
+}
+
+void ClusterIndexWriter::ensureIndexPartition() {
+  if (indexPartition_ == nullptr) {
+    indexPartition_ = std::make_unique<IndexPartition>();
+    indexPartition_->encodingBuffer = std::make_unique<Buffer>(*pool_);
+  }
+}
+
+void ClusterIndexWriter::flush(
+    const WriteDataFn& writeDataFn,
+    const CreateMetadataSectionFn& createMetadataFn) {
+  NIMBLE_CHECK(!closed_, "ClusterIndexWriter has been closed");
+
+  // Force-encode any remaining accumulated keys. This must happen before the
+  // indexPartition_ null check because when key chunking is disabled
+  // (maxRowsPerKeyChunk_ == 0), encodeKeyChunks() returns early during write()
+  // and the partition is only created here.
+  encodeKeyChunks(/*force=*/true);
+
+  NIMBLE_CHECK_NOT_NULL(indexPartition_);
+  NIMBLE_CHECK(!indexPartition_->empty());
+
+  // Write key stream data to file.
+  const auto [fileOffset, fileSize] =
+      writeDataFn(indexPartition_->encodedChunks);
+  indexPartition_->keyStreamFileOffset = fileOffset;
+  indexPartition_->keyStreamFileSize = fileSize;
+
+  // Build ClusterIndexPartition FlatBuffer.
+  ensureIndexRoot();
+
+  flatbuffers::FlatBufferBuilder indexBuilder(kInitialFooterSize);
+
+  auto chunkRowsVec = indexBuilder.CreateVector(indexPartition_->chunkRows);
+  auto chunkOffsetsVec =
+      indexBuilder.CreateVector(indexPartition_->chunkOffsets);
+  auto chunkKeysVec =
+      indexBuilder.CreateVector<flatbuffers::Offset<flatbuffers::String>>(
+          indexPartition_->chunkKeys.size(), [&indexBuilder, this](size_t i) {
+            return indexBuilder.CreateString(indexPartition_->chunkKeys[i]);
+          });
+
+  indexBuilder.Finish(
+      serialization::CreateClusterIndexPartition(
+          indexBuilder,
+          indexPartition_->keyStreamFileOffset,
+          indexPartition_->keyStreamFileSize,
+          chunkRowsVec,
+          chunkOffsetsVec,
+          chunkKeysVec));
+
+  indexRoot_->indexPartitions.push_back(createMetadataFn(asView(indexBuilder)));
+
+  // Record last key and row count for root-level index.
+  NIMBLE_CHECK(!indexPartition_->chunkKeys.empty());
+  indexRoot_->partitionKeys.emplace_back(indexPartition_->chunkKeys.back());
+  indexRoot_->partitionRowCounts.emplace_back(
+      indexPartition_->chunkRows.back());
+
+  // Reset partition state.
+  indexPartition_.reset();
 }
 
 } // namespace facebook::nimble::index

--- a/dwio/nimble/index/ClusterIndexWriter.h
+++ b/dwio/nimble/index/ClusterIndexWriter.h
@@ -42,9 +42,9 @@ namespace facebook::nimble::index {
 ///   1. Create with config and input schema
 ///   2. For each batch: write(batch) to encode keys (auto-encodes chunks
 ///      when row count threshold is reached)
-///   3. At stripe group boundaries: flushPartition() writes key stream data
+///   3. At stripe group boundaries: flush() writes key stream data
 ///      and partition metadata
-///   4. At file close: finalize() to build and serialize the root index
+///   4. At file close: close() to finalize, serialize, and release resources
 ///
 /// Example usage:
 ///   auto writer = ClusterIndexWriter::create(config, inputType, pool);
@@ -52,8 +52,7 @@ namespace facebook::nimble::index {
 ///   // ... write more batches ...
 ///   writer->finishStripe();
 ///   // ... more stripes ...
-///   auto rootIndex = writer->finalize(createMetadataSection);
-///   writer->close();
+///   writer->close(createMetadataSection, writeOptionalSection);
 class ClusterIndexWriter : public IndexWriter {
  public:
   /// Factory method to create a ClusterIndexWriter instance.
@@ -82,25 +81,14 @@ class ClusterIndexWriter : public IndexWriter {
   /// @param input Input vector containing rows to encode.
   void write(const velox::VectorPtr& input) override;
 
-  /// Builds and serializes the root index. Called at file close.
-  /// Returns the serialized root index FlatBuffer to be stored as an optional
-  /// section. Partition data sections are written via createMetadataSection
-  /// during stripe group flushes (before this call).
-  ///
-  /// After finalize(), no further write() or finishStripe() calls are allowed.
-  std::string finalize(
-      const CreateMetadataSectionFn& createMetadataSection) override;
+  /// Flushes index data at stripe group boundary.
+  void flush(
+      const WriteDataFn& writeDataFn,
+      const CreateMetadataSectionFn& createMetadataFn) override;
 
-  /// Releases internal resources. Must be called after finalize().
-  void close() override;
-
-  /// Flushes partition data at stripe group boundary.
-  /// Writes encoded key data blob to file via writeData, then writes
-  /// partition metadata (chunk index) via createMetadataSection.
-  void flushPartition(
-      size_t stripeCount,
-      const WriteDataFn& writeData,
-      const CreateMetadataSectionFn& createMetadataSection) override;
+  void close(
+      const CreateMetadataSectionFn& createMetadataFn,
+      const WriteOptionalSectionFn& writeMetadataFn) override;
 
  private:
   ClusterIndexWriter(
@@ -149,19 +137,19 @@ class ClusterIndexWriter : public IndexWriter {
     std::vector<std::string> chunkKeys;
     // Encoded key stream segments from all chunks (flattened). Each chunk may
     // produce multiple segments via ChunkedStreamWriter. Concatenated and
-    // written to file during flushPartition().
+    // written to file during flush().
     // Views into encodingBuffer.
     std::vector<std::string_view> encodedChunks;
 
     // Buffer for encoded chunk stream data within this partition.
-    // Backs encodedChunks. Reset after flushPartition() writes the blob
+    // Backs encodedChunks. Reset after flush() writes the blob
     // to file.
     std::unique_ptr<Buffer> encodingBuffer;
     // Current write offset in the partition's key stream blob. Equals the
     // total encoded bytes so far. Used as the offset for the next chunk.
     uint32_t keyStreamOffset{0};
 
-    // File-level offset and size after flushPartition() writes the key
+    // File-level offset and size after flush() writes the key
     // data blob.
     uint64_t keyStreamFileOffset{0};
     uint32_t keyStreamFileSize{0};
@@ -177,7 +165,7 @@ class ClusterIndexWriter : public IndexWriter {
     // Keys for root-level binary search across all partitions.
     // Layout: [firstKey, lastKey0, lastKey1, ..., lastKeyN]
     // firstKey is pushed during the first encodeKeyChunks() call.
-    // Each flushPartition() appends a lastKey.
+    // Each flush() appends a lastKey.
     std::vector<std::string> partitionKeys;
     // Row count per partition, derived from chunkRows.back().
     std::vector<uint32_t> partitionRowCounts;
@@ -209,7 +197,7 @@ class ClusterIndexWriter : public IndexWriter {
   // Root-level index accumulator.
   std::unique_ptr<IndexRoot> indexRoot_;
 
-  bool finalized_{false};
+  bool closed_{false};
 };
 
 } // namespace facebook::nimble::index

--- a/dwio/nimble/index/HashIndex.cpp
+++ b/dwio/nimble/index/HashIndex.cpp
@@ -1,0 +1,420 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "dwio/nimble/index/HashIndex.h"
+
+#include <algorithm>
+
+#include <fmt/ranges.h>
+
+#include "dwio/nimble/common/Exceptions.h"
+#include "dwio/nimble/index/HashIndexUtils.h"
+#include "dwio/nimble/tablet/HashIndexGenerated.h"
+#include "velox/common/base/BitUtil.h"
+
+namespace facebook::nimble::index {
+
+namespace {
+
+// Checks if the given columns exactly match.
+bool columnsMatch(
+    const std::vector<std::string>& indexColumns,
+    const std::vector<std::string>& queryColumns) {
+  if (indexColumns.size() != queryColumns.size()) {
+    return false;
+  }
+  for (size_t i = 0; i < indexColumns.size(); ++i) {
+    if (indexColumns[i] != queryColumns[i]) {
+      return false;
+    }
+  }
+  return true;
+}
+
+const serialization::HashIndex* getHashIndexRoot(
+    const MetadataBuffer& metadata) {
+  const auto* entry =
+      flatbuffers::GetRoot<serialization::HashIndex>(metadata.content().data());
+  NIMBLE_CHECK_NOT_NULL(entry);
+  return entry;
+}
+
+uint32_t getNumBuckets(const MetadataBuffer& metadata) {
+  const auto numBuckets = getHashIndexRoot(metadata)->num_buckets();
+  NIMBLE_CHECK_GT(numBuckets, 0u, "Hash index must have buckets");
+  NIMBLE_CHECK(
+      velox::bits::isPowerOfTwo(numBuckets), "numBuckets must be a power of 2");
+  return numBuckets;
+}
+
+std::unique_ptr<BloomFilter> buildBloomFilter(
+    const MetadataBuffer& metadata,
+    velox::memory::MemoryPool* pool) {
+  const auto* bloomFilter = getHashIndexRoot(metadata)->bloom_filter();
+  if (bloomFilter == nullptr) {
+    return nullptr;
+  }
+  NIMBLE_CHECK_NOT_NULL(bloomFilter->data());
+  NIMBLE_CHECK_GT(bloomFilter->data()->size(), 0u);
+  const auto numBlocks = bloomFilter->num_blocks();
+  const auto* rawData = bloomFilter->data();
+  return std::make_unique<BloomFilter>(
+      numBlocks, rawData->data(), rawData->size(), pool);
+}
+
+// Sorts row numbers and merges consecutive rows into contiguous RowRanges.
+// If 'filterRange' is set, each range is intersected with the filter and
+// empty results are dropped.
+std::vector<RowRange> resolveRowRanges(
+    std::vector<uint32_t> rows,
+    const std::optional<RowRange>& filterRange) {
+  if (rows.empty()) {
+    return {};
+  }
+
+  std::sort(rows.begin(), rows.end());
+
+  std::vector<RowRange> result;
+  const auto addRange = [&](uint32_t start, uint32_t end) {
+    RowRange range{
+        static_cast<velox::vector_size_t>(start),
+        static_cast<velox::vector_size_t>(end)};
+    if (filterRange.has_value()) {
+      range = range.intersect(filterRange.value());
+    }
+    if (!range.empty()) {
+      result.emplace_back(range);
+    }
+  };
+
+  uint32_t rangeStart = rows[0];
+  uint32_t rangeEnd = rows[0] + 1;
+
+  for (size_t i = 1; i < rows.size(); ++i) {
+    if (rows[i] == rangeEnd) {
+      ++rangeEnd;
+    } else {
+      addRange(rangeStart, rangeEnd);
+      rangeStart = rows[i];
+      rangeEnd = rows[i] + 1;
+    }
+  }
+  addRange(rangeStart, rangeEnd);
+  return result;
+}
+
+} // namespace
+
+// ---------------------------------------------------------------------------
+// HashIndex
+// ---------------------------------------------------------------------------
+
+HashIndex::HashIndex(
+    std::vector<std::string> columns,
+    std::unique_ptr<MetadataBuffer> indexMetadata,
+    LoadMetadataFn loadMetadata,
+    velox::memory::MemoryPool* pool)
+    : IndexLookup{IndexType::Hash},
+      columns_{std::move(columns)},
+      indexMetadata_{std::move(indexMetadata)},
+      pool_{pool},
+      numBuckets_{getNumBuckets(*indexMetadata_)},
+      bucketMask_{numBuckets_ - 1},
+      bloomFilter_{buildBloomFilter(*indexMetadata_, pool_)},
+      partitions_{buildPartitionDescriptors(*indexMetadata_, numBuckets_)},
+      partitionCache_{
+          [this, loadMetadata = std::move(loadMetadata)](
+              uint32_t partitionIndex) -> std::shared_ptr<Partition> {
+            const auto& descriptor = partitions_[partitionIndex];
+            auto metadata = loadMetadata(descriptor.section);
+            return Partition::create(std::move(metadata));
+          }} {}
+
+// static
+std::vector<HashIndex::PartitionDescriptor>
+HashIndex::buildPartitionDescriptors(
+    const MetadataBuffer& metadata,
+    uint32_t numBuckets) {
+  const auto* entry = getHashIndexRoot(metadata);
+  const auto* partitionStartBuckets = entry->partition_start_buckets();
+  const auto* partitionSections = entry->partition_sections();
+  NIMBLE_CHECK_NOT_NULL(partitionStartBuckets);
+  NIMBLE_CHECK_NOT_NULL(partitionSections);
+  const auto numPartitions = partitionStartBuckets->size();
+  NIMBLE_CHECK_GT(numPartitions, 0u, "Hash index must have partitions");
+  NIMBLE_CHECK_EQ(partitionSections->size(), numPartitions);
+
+  std::vector<PartitionDescriptor> partitions;
+  partitions.reserve(numPartitions);
+  for (uint32_t i = 0; i < numPartitions; ++i) {
+    const uint32_t startBucket = partitionStartBuckets->Get(i);
+    const uint32_t endBucket = (i + 1 < numPartitions)
+        ? partitionStartBuckets->Get(i + 1)
+        : numBuckets;
+    const auto* sectionRef = partitionSections->Get(i);
+    NIMBLE_CHECK_NOT_NULL(sectionRef);
+    partitions.push_back(
+        PartitionDescriptor{
+            startBucket,
+            endBucket - startBucket,
+            MetadataSection{
+                sectionRef->offset(),
+                sectionRef->size(),
+                static_cast<CompressionType>(sectionRef->compression_type())}});
+  }
+  return partitions;
+}
+
+std::unique_ptr<HashIndex> HashIndex::create(
+    std::vector<std::string> columns,
+    std::unique_ptr<MetadataBuffer> indexMetadata,
+    LoadMetadataFn loadMetadata,
+    velox::memory::MemoryPool* pool) {
+  return std::unique_ptr<HashIndex>(new HashIndex(
+      std::move(columns),
+      std::move(indexMetadata),
+      std::move(loadMetadata),
+      pool));
+}
+
+IndexLookup::LookupResult HashIndex::lookup(
+    const LookupRequest& request) const {
+  NIMBLE_CHECK_EQ(
+      request.mode(),
+      LookupRequest::Mode::PointLookup,
+      "Hash index only supports point lookups");
+  const auto& options = request.options();
+
+  std::vector<RowRange> rowRanges;
+  std::vector<uint32_t> resultOffsets;
+  resultOffsets.reserve(request.size() + 1);
+  resultOffsets.push_back(0);
+
+  for (uint32_t i = 0; i < request.size(); ++i) {
+    const auto key = request.pointKey(i);
+    ++numLookups_;
+
+    // Check bloom filter for fast negative.
+    if (bloomFilter_ != nullptr && !bloomFilter_->testKey(key)) {
+      ++numBloomFilterSkips_;
+      resultOffsets.push_back(rowRanges.size());
+      continue;
+    }
+
+    // Find the bucket.
+    const uint32_t bucket = bucketIndex(key, bucketMask_);
+
+    // Load the partition containing this bucket.
+    const uint32_t partitionIdx = findPartitionIndex(bucket);
+    const auto& partition = partitionCache_.getOrCreate(partitionIdx);
+    const uint32_t bucketOffset =
+        bucket - partitions_[partitionIdx].startBucket;
+
+    auto resolved = resolveRowRanges(
+        partition->findRows(bucketOffset, key), options.rowRange);
+    numMatchedRows_ += resolved.size();
+    for (auto& range : resolved) {
+      rowRanges.emplace_back(range);
+    }
+    resultOffsets.push_back(rowRanges.size());
+  }
+
+  return LookupResult{std::move(rowRanges), std::move(resultOffsets)};
+}
+
+folly::F14FastMap<std::string, velox::RuntimeMetric> HashIndex::stats() const {
+  folly::F14FastMap<std::string, velox::RuntimeMetric> result;
+  const auto numLookups = numLookups_.load();
+  if (numLookups > 0) {
+    result.emplace(kNumLookups, velox::RuntimeMetric(numLookups));
+  }
+  const auto numBloomFilterSkips = numBloomFilterSkips_.load();
+  if (numBloomFilterSkips > 0) {
+    result.emplace(
+        kNumBloomFilterSkips, velox::RuntimeMetric(numBloomFilterSkips));
+  }
+  const auto numMatchedRows = numMatchedRows_.load();
+  if (numMatchedRows > 0) {
+    result.emplace(kNumMatchedRows, velox::RuntimeMetric(numMatchedRows));
+  }
+  return result;
+}
+
+uint32_t HashIndex::findPartitionIndex(uint32_t bucket) const {
+  const auto it = std::upper_bound(
+      partitions_.begin(),
+      partitions_.end(),
+      bucket,
+      [](uint32_t b, const auto& p) { return b < p.startBucket; });
+  NIMBLE_CHECK(
+      it != partitions_.begin(),
+      "Bucket {} is before the first partition",
+      bucket);
+  const uint32_t index =
+      static_cast<uint32_t>(std::distance(partitions_.begin(), it) - 1);
+  const auto& partition = partitions_[index];
+  NIMBLE_CHECK_LT(
+      bucket - partition.startBucket,
+      partition.bucketCount,
+      "Bucket {} is out of range for partition {}: {}",
+      bucket,
+      index,
+      partition.toString());
+  return index;
+}
+
+HashIndex::Partition::Partition(
+    std::unique_ptr<MetadataBuffer> metadata,
+    const uint32_t* bucketOffsets,
+    const flatbuffers::Vector<flatbuffers::Offset<flatbuffers::String>>* keys,
+    const uint32_t* rows)
+    : metadata_{std::move(metadata)},
+      bucketOffsets_{bucketOffsets},
+      keys_{keys},
+      rows_{rows} {}
+
+std::vector<uint32_t> HashIndex::Partition::findRows(
+    uint32_t bucketIndex,
+    std::string_view key) const {
+  const uint32_t bucketStart = bucketOffsets_[bucketIndex];
+  const uint32_t bucketEnd = bucketOffsets_[bucketIndex + 1];
+
+  std::vector<uint32_t> rows;
+  for (uint32_t keyIdx = bucketStart; keyIdx < bucketEnd; ++keyIdx) {
+    const auto* storedKey = keys_->Get(keyIdx);
+    if (storedKey->string_view() == key) {
+      rows.emplace_back(rows_[keyIdx]);
+    }
+  }
+  return rows;
+}
+
+std::shared_ptr<HashIndex::Partition> HashIndex::Partition::create(
+    std::unique_ptr<MetadataBuffer> metadata) {
+  const auto* partition =
+      flatbuffers::GetRoot<serialization::HashIndexPartition>(
+          metadata->content().data());
+  NIMBLE_CHECK_NOT_NULL(partition);
+
+  const auto* bucketOffsets = partition->bucket_offsets();
+  NIMBLE_CHECK_NOT_NULL(bucketOffsets);
+
+  const auto* keys = partition->encoded_keys();
+  NIMBLE_CHECK_NOT_NULL(keys);
+
+  const auto* rows = partition->row_numbers();
+  NIMBLE_CHECK_NOT_NULL(rows);
+
+  return std::shared_ptr<Partition>(new Partition(
+      std::move(metadata), bucketOffsets->data(), keys, rows->data()));
+}
+
+// ---------------------------------------------------------------------------
+// DenseIndexRegistry
+// ---------------------------------------------------------------------------
+
+std::unique_ptr<DenseIndexRegistry> DenseIndexRegistry::create(
+    Section directorySection,
+    LoadMetadataFn loadMetadata,
+    velox::memory::MemoryPool* pool) {
+  const auto* root = flatbuffers::GetRoot<serialization::HashIndexDirectory>(
+      directorySection.content().data());
+  NIMBLE_CHECK_NOT_NULL(root);
+  const auto* indices = root->indices();
+  if (indices == nullptr) {
+    return nullptr;
+  }
+  NIMBLE_CHECK_GT(
+      indices->size(), 0u, "Hash index directory must not be empty");
+  return std::unique_ptr<DenseIndexRegistry>(new DenseIndexRegistry(
+      std::move(directorySection), std::move(loadMetadata), pool));
+}
+
+DenseIndexRegistry::DenseIndexRegistry(
+    Section directorySection,
+    LoadMetadataFn loadMetadata,
+    velox::memory::MemoryPool* pool)
+    : directorySection_{std::move(directorySection)},
+      indexCache_{
+          [this, loadMetadata = std::move(loadMetadata), pool](
+              uint32_t index) -> std::shared_ptr<HashIndex> {
+            const auto& descriptor = indexDescriptors_[index];
+            auto indexMetadata = loadMetadata(descriptor.section);
+            NIMBLE_CHECK_NOT_NULL(indexMetadata);
+            return HashIndex::create(
+                descriptor.columns,
+                std::move(indexMetadata),
+                loadMetadata,
+                pool);
+          },
+          /*pinEntries=*/true} {
+  parseIndexDescriptors();
+}
+
+void DenseIndexRegistry::parseIndexDescriptors() {
+  NIMBLE_CHECK(
+      indexDescriptors_.empty(), "Index descriptors already initialized");
+
+  const auto* root = flatbuffers::GetRoot<serialization::HashIndexDirectory>(
+      directorySection_.content().data());
+  NIMBLE_CHECK_NOT_NULL(root);
+  const auto* indices = root->indices();
+  NIMBLE_CHECK_NOT_NULL(indices);
+
+  indexDescriptors_.reserve(indices->size());
+  for (const auto* indexSection : *indices) {
+    NIMBLE_CHECK_NOT_NULL(indexSection);
+    const auto* columns = indexSection->index_columns();
+    NIMBLE_CHECK_NOT_NULL(columns);
+    NIMBLE_CHECK_GT(columns->size(), 0u, "Hash index must have columns");
+
+    std::vector<std::string> columnNames;
+    columnNames.reserve(columns->size());
+    for (const auto* col : *columns) {
+      columnNames.emplace_back(col->string_view());
+    }
+
+    // Check for duplicate index columns.
+    for (const auto& indexDescriptor : indexDescriptors_) {
+      NIMBLE_CHECK(
+          !columnsMatch(indexDescriptor.columns, columnNames),
+          "Duplicate hash index columns: [{}]",
+          fmt::join(columnNames, ", "));
+    }
+
+    const auto* sectionRef = indexSection->section();
+    NIMBLE_CHECK_NOT_NULL(sectionRef);
+    indexDescriptors_.emplace_back(
+        IndexDescriptor{
+            std::move(columnNames),
+            MetadataSection{
+                sectionRef->offset(),
+                sectionRef->size(),
+                static_cast<CompressionType>(sectionRef->compression_type())}});
+  }
+}
+
+const HashIndex* DenseIndexRegistry::findIndex(
+    const std::vector<std::string>& queryColumns) const {
+  NIMBLE_CHECK(!queryColumns.empty(), "queryColumns must not be empty");
+  for (uint32_t i = 0; i < indexDescriptors_.size(); ++i) {
+    if (columnsMatch(indexDescriptors_[i].columns, queryColumns)) {
+      return indexCache_.getOrCreate(i).get();
+    }
+  }
+  return nullptr;
+}
+
+} // namespace facebook::nimble::index

--- a/dwio/nimble/index/HashIndex.h
+++ b/dwio/nimble/index/HashIndex.h
@@ -1,0 +1,209 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <atomic>
+#include <memory>
+#include <string>
+#include <string_view>
+#include <vector>
+
+#include <fmt/format.h>
+
+#include "dwio/nimble/index/BloomFilter.h"
+#include "dwio/nimble/index/IndexLookup.h"
+#include "dwio/nimble/tablet/Callbacks.h"
+#include "dwio/nimble/tablet/MetadataBuffer.h"
+#include "dwio/nimble/tablet/MetadataCache.h"
+#include "flatbuffers/flatbuffers.h"
+
+namespace facebook::nimble::serialization {
+struct HashIndex;
+} // namespace facebook::nimble::serialization
+
+namespace facebook::nimble::index {
+
+/// A hash index for point lookups on unsorted data.
+///
+/// Each HashIndex covers one set of composite key columns and is an
+/// independent object (analogous to ClusterIndex). Implements the IndexLookup
+/// interface for unified index dispatch.
+///
+/// Lookup flow:
+///   1. Optional bloom filter check for fast negative result
+///   2. Hash(key) mod numBuckets → bucket
+///   3. Load the partition containing the bucket (on-demand, cached)
+///   4. Scan entries in bucket by exact encoded key match
+///   5. Return file-level row locations
+///
+/// Example usage:
+///   auto* hashIndex = registry->findIndex({"col_a", "col_b"});
+///   auto results = hashIndex->lookup(key);
+///   for (const auto& loc : results) {
+///     // loc.range is a file-level [startRow, endRow) range
+///   }
+class HashIndex : public IndexLookup {
+ public:
+  // Total number of individual key lookups performed.
+  static constexpr std::string_view kNumLookups{"hashIndex.numLookups"};
+  // Number of key lookups skipped by the bloom filter (fast negatives).
+  static constexpr std::string_view kNumBloomFilterSkips{
+      "hashIndex.numBloomFilterSkips"};
+  // Number of row ranges returned across all lookups.
+  static constexpr std::string_view kNumMatchedRows{"hashIndex.numMatchedRows"};
+
+  const std::vector<std::string>& indexColumns() const override {
+    return columns_;
+  }
+
+  LookupResult lookup(const LookupRequest& request) const override;
+
+  folly::F14FastMap<std::string, velox::RuntimeMetric> stats() const override;
+
+  static std::unique_ptr<HashIndex> create(
+      std::vector<std::string> columns,
+      std::unique_ptr<MetadataBuffer> indexMetadata,
+      LoadMetadataFn loadMetadata,
+      velox::memory::MemoryPool* pool);
+
+ private:
+  HashIndex(
+      std::vector<std::string> columns,
+      std::unique_ptr<MetadataBuffer> indexMetadata,
+      LoadMetadataFn loadMetadata,
+      velox::memory::MemoryPool* pool);
+
+  // Loaded partition data. Raw pointers reference the underlying FlatBuffer
+  // data owned by the MetadataBuffer.
+  class Partition {
+   public:
+    static std::shared_ptr<Partition> create(
+        std::unique_ptr<MetadataBuffer> metadata);
+
+    // Returns file row numbers matching the encoded key in the given local
+    // bucket.
+    std::vector<uint32_t> findRows(uint32_t bucketIndex, std::string_view key)
+        const;
+
+   private:
+    Partition(
+        std::unique_ptr<MetadataBuffer> metadata,
+        const uint32_t* bucketOffsets,
+        const flatbuffers::Vector<flatbuffers::Offset<flatbuffers::String>>*
+            keys,
+        const uint32_t* rows);
+
+    const std::unique_ptr<MetadataBuffer> metadata_;
+    // Size = bucketCount + 1. Bucket i spans [offsets[i], offsets[i+1]).
+    const uint32_t* const bucketOffsets_;
+    const flatbuffers::Vector<flatbuffers::Offset<flatbuffers::String>>* const
+        keys_;
+    const uint32_t* const rows_;
+  };
+
+  // Partition section info parsed from the parallel partition arrays.
+  struct PartitionDescriptor {
+    uint32_t startBucket{};
+    uint32_t bucketCount{};
+    MetadataSection section;
+
+    std::string toString() const {
+      return fmt::format(
+          "startBucket: {}, bucketCount: {}", startBucket, bucketCount);
+    }
+  };
+
+  // Parses partition descriptors from the serialized index metadata.
+  static std::vector<PartitionDescriptor> buildPartitionDescriptors(
+      const MetadataBuffer& metadata,
+      uint32_t numBuckets);
+
+  // Finds the partition index for a given global bucket number.
+  uint32_t findPartitionIndex(uint32_t bucket) const;
+
+  const std::vector<std::string> columns_;
+  // Owns the loaded FlatBuffer data for this index.
+  const std::unique_ptr<MetadataBuffer> indexMetadata_;
+  velox::memory::MemoryPool* const pool_;
+
+  const uint32_t numBuckets_;
+  const uint32_t bucketMask_;
+
+  // Constructed from FlatBuffer data during initialization.
+  const std::unique_ptr<BloomFilter> bloomFilter_;
+
+  // Partition descriptors and lazily loaded partition data.
+  // Always has at least one partition.
+  const std::vector<PartitionDescriptor> partitions_;
+  mutable MetadataCache<uint32_t, Partition> partitionCache_;
+
+  mutable std::atomic_uint64_t numLookups_{0};
+  mutable std::atomic_uint64_t numBloomFilterSkips_{0};
+  mutable std::atomic_uint64_t numMatchedRows_{0};
+};
+
+/// Registry of hash indices for a Nimble file.
+///
+/// Loaded from the "columnar.hash.index" optional section. Owns individual
+/// HashIndex objects, each covering a different set of composite key columns.
+/// TabletReader owns this registry and callers look up the appropriate
+/// HashIndex by column names.
+class DenseIndexRegistry {
+ public:
+  /// Creates a DenseIndexRegistry from the serialized directory section.
+  ///
+  /// @param directorySection The section containing the HashIndexDirectory
+  ///        with HashIndexSection entries.
+  /// @param loadMetadata Callback to load a MetadataSection from the file.
+  /// @param pool Memory pool for bloom filter data allocation.
+  /// @return A unique pointer to the registry, or nullptr if the section
+  ///         contains no indices.
+  static std::unique_ptr<DenseIndexRegistry> create(
+      Section directorySection,
+      LoadMetadataFn loadMetadata,
+      velox::memory::MemoryPool* pool);
+
+  /// Returns the number of hash indices in this registry.
+  size_t numIndices() const {
+    return indexDescriptors_.size();
+  }
+
+  /// Finds the hash index matching the given columns (lazy loaded).
+  /// Returns nullptr if no index matches.
+  const HashIndex* findIndex(
+      const std::vector<std::string>& queryColumns) const;
+
+ private:
+  // Lightweight descriptor parsed from the directory section.
+  struct IndexDescriptor {
+    std::vector<std::string> columns;
+    MetadataSection section;
+  };
+
+  DenseIndexRegistry(
+      Section directorySection,
+      LoadMetadataFn loadMetadata,
+      velox::memory::MemoryPool* pool);
+
+  // Parses index descriptors from the directory section.
+  void parseIndexDescriptors();
+
+  Section directorySection_;
+  std::vector<IndexDescriptor> indexDescriptors_;
+  mutable MetadataCache<uint32_t, HashIndex> indexCache_;
+};
+
+} // namespace facebook::nimble::index

--- a/dwio/nimble/index/HashIndexUtils.h
+++ b/dwio/nimble/index/HashIndexUtils.h
@@ -13,25 +13,21 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#include "dwio/nimble/index/IndexLookup.h"
+#pragma once
 
-#include "dwio/nimble/common/Exceptions.h"
+#include <cstdint>
+#include <string_view>
+
+#include "folly/hash/Hash.h"
 
 namespace facebook::nimble::index {
 
-std::string toString(IndexType indexType) {
-  switch (indexType) {
-    case IndexType::Cluster:
-      return "Cluster";
-    case IndexType::Hash:
-      return "Hash";
-    default:
-      NIMBLE_UNREACHABLE("Unknown IndexType: {}", static_cast<int>(indexType));
-  }
-}
-
-std::ostream& operator<<(std::ostream& out, IndexType indexType) {
-  return out << toString(indexType);
+/// Computes the bucket index for an encoded key using FNV-1a hash.
+/// Used by both HashIndexWriter (write path) and HashIndex (read path).
+inline uint32_t bucketIndex(std::string_view key, uint32_t bucketMask) {
+  return static_cast<uint32_t>(
+             folly::hash::fnva64_buf(key.data(), key.size())) &
+      bucketMask;
 }
 
 } // namespace facebook::nimble::index

--- a/dwio/nimble/index/HashIndexWriter.cpp
+++ b/dwio/nimble/index/HashIndexWriter.cpp
@@ -1,0 +1,393 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "dwio/nimble/index/HashIndexWriter.h"
+
+#include <algorithm>
+#include <cmath>
+#include <limits>
+#include <set>
+
+#include <fmt/ranges.h>
+
+#include "dwio/nimble/common/Exceptions.h"
+#include "dwio/nimble/index/BloomFilter.h"
+#include "dwio/nimble/index/HashIndexUtils.h"
+#include "dwio/nimble/tablet/Constants.h"
+#include "dwio/nimble/tablet/HashIndexGenerated.h"
+#include "flatbuffers/flatbuffers.h"
+
+#include "velox/common/base/BitUtil.h"
+#include "velox/common/base/Nulls.h"
+
+namespace facebook::nimble::index {
+
+namespace {
+
+std::unique_ptr<velox::serializer::KeyEncoder> createEncoder(
+    const HashIndexConfig& config,
+    const velox::RowTypePtr& inputType,
+    velox::memory::MemoryPool* pool) {
+  // Hash index uses ascending sort order for key encoding (order doesn't
+  // matter for point lookups, but we need a consistent encoding).
+  std::vector<velox::core::SortOrder> sortOrders(
+      config.columns.size(), velox::core::SortOrder{true, false});
+  return velox::serializer::KeyEncoder::create(
+      config.columns, inputType, std::move(sortOrders), pool);
+}
+
+std::vector<velox::column_index_t> getKeyColumnIndices(
+    const std::vector<HashIndexConfig>& configs,
+    const velox::RowTypePtr& inputType) {
+  std::set<velox::column_index_t> indexSet;
+  std::vector<velox::column_index_t> indices;
+  for (const auto& config : configs) {
+    for (const auto& columnName : config.columns) {
+      const auto idx = inputType->getChildIdx(columnName);
+      if (indexSet.insert(idx).second) {
+        indices.emplace_back(idx);
+      }
+    }
+  }
+  return indices;
+}
+
+} // namespace
+
+// static
+// Estimates the serialized size of one bucket's keys.
+// Accounts for encoded key strings + row numbers + bucket directory overhead.
+size_t HashIndexWriter::estimateBucketSize(
+    const std::vector<uint32_t>& keyIndices,
+    const IndexAccumulator& accumulator) {
+  // Per-bucket overhead: bucket_offsets (uint32).
+  size_t size = sizeof(uint32_t);
+  for (const auto idx : keyIndices) {
+    // Per-key: row_numbers (uint32) + encoded key bytes + FlatBuffer string
+    // overhead (length prefix + padding). Conservative estimate.
+    size += sizeof(uint32_t) + accumulator.entries[idx].key.size() + 8;
+  }
+  return size;
+}
+
+// static
+// Builds a HashIndexPartition FlatBuffer for a range of buckets.
+void HashIndexWriter::buildIndexPartitionFlatBuffer(
+    flatbuffers::FlatBufferBuilder& builder,
+    const std::vector<std::vector<uint32_t>>& keyIndices,
+    const IndexAccumulator& accumulator,
+    uint32_t startBucket,
+    uint32_t bucketCount) {
+  // bucketCount + 1 offsets: offsets[i] is start, offsets[i+1] is end
+  // (exclusive) for bucket i. The last element is the total entry count.
+  std::vector<uint32_t> bucketOffsets(bucketCount + 1);
+  std::vector<flatbuffers::Offset<flatbuffers::String>> keys;
+  std::vector<uint32_t> rows;
+
+  uint32_t rowOffset = 0;
+  for (uint32_t i = 0; i < bucketCount; ++i) {
+    bucketOffsets[i] = rowOffset;
+    const auto& indices = keyIndices[startBucket + i];
+    for (const auto idx : indices) {
+      const auto& entry = accumulator.entries[idx];
+      keys.emplace_back(
+          builder.CreateString(entry.key.data(), entry.key.size()));
+      rows.emplace_back(entry.row);
+    }
+    rowOffset += indices.size();
+  }
+  bucketOffsets[bucketCount] = rowOffset;
+
+  builder.Finish(
+      serialization::CreateHashIndexPartition(
+          builder,
+          builder.CreateVector(bucketOffsets),
+          builder.CreateVector(keys),
+          builder.CreateVector(rows)));
+}
+
+flatbuffers::Offset<serialization::BloomFilter>
+HashIndexWriter::buildBloomFilter(
+    flatbuffers::FlatBufferBuilder& builder,
+    const IndexAccumulator& accumulator) const {
+  if (!accumulator.config.bloomFilter.has_value()) {
+    return 0;
+  }
+  const auto bitsPerKey = accumulator.config.bloomFilter->bitsPerKey;
+  BloomFilter bloomFilter(accumulator.entries.size(), bitsPerKey, pool_);
+  for (const auto& entry : accumulator.entries) {
+    bloomFilter.insert(entry.key);
+  }
+  auto dataVec =
+      builder.CreateVector(bloomFilter.data(), bloomFilter.dataSize());
+  return serialization::CreateBloomFilter(
+      builder, bloomFilter.numBlocks(), bitsPerKey, dataVec);
+}
+
+void HashIndexWriter::buildIndexFlatBuffer(
+    flatbuffers::FlatBufferBuilder& builder,
+    const IndexAccumulator& accumulator,
+    const CreateMetadataSectionFn& createMetadataFn) const {
+  const uint64_t numKeys = accumulator.entries.size();
+  const uint32_t numBuckets = static_cast<uint32_t>(velox::bits::nextPowerOfTwo(
+      std::max(
+          1u,
+          static_cast<uint32_t>(std::ceil(
+              static_cast<float>(numKeys) / accumulator.config.loadFactor)))));
+  const uint32_t bucketMask = numBuckets - 1;
+
+  // Assign keys to buckets.
+  std::vector<std::vector<uint32_t>> bucketKeyIndices(numBuckets);
+  for (uint64_t i = 0; i < numKeys; ++i) {
+    const uint32_t bucket = bucketIndex(accumulator.entries[i].key, bucketMask);
+    bucketKeyIndices[bucket].emplace_back(i);
+  }
+
+  const auto bloomFilterOffset = buildBloomFilter(builder, accumulator);
+
+  const float actualLoadFactor =
+      static_cast<float>(numKeys) / static_cast<float>(numBuckets);
+
+  // Determine partition boundaries. Always create at least one partition.
+  // When maxPartitionSizeBytes is set and data exceeds it, split into
+  // multiple partitions for on-demand loading.
+  uint32_t bucketsPerPartition = numBuckets;
+  if (accumulator.config.maxPartitionSizeBytes > 0 && numBuckets > 1) {
+    size_t estimatedTotalBucketSize = 0;
+    for (uint32_t i = 0; i < numBuckets; ++i) {
+      estimatedTotalBucketSize +=
+          estimateBucketSize(bucketKeyIndices[i], accumulator);
+    }
+    if (estimatedTotalBucketSize > accumulator.config.maxPartitionSizeBytes) {
+      const uint32_t numPartitions =
+          static_cast<uint32_t>(velox::bits::divRoundUp(
+              estimatedTotalBucketSize,
+              accumulator.config.maxPartitionSizeBytes));
+      bucketsPerPartition = velox::bits::divRoundUp(numBuckets, numPartitions);
+    }
+  }
+
+  std::vector<uint32_t> partitionStartBuckets;
+  std::vector<flatbuffers::Offset<serialization::MetadataSection>>
+      partitionSections;
+
+  for (uint32_t startBucket = 0; startBucket < numBuckets;
+       startBucket += bucketsPerPartition) {
+    const uint32_t endBucket =
+        std::min(startBucket + bucketsPerPartition, numBuckets);
+    const uint32_t bucketCount = endBucket - startBucket;
+
+    flatbuffers::FlatBufferBuilder partitionBuilder;
+    buildIndexPartitionFlatBuffer(
+        partitionBuilder,
+        bucketKeyIndices,
+        accumulator,
+        startBucket,
+        bucketCount);
+    const auto partitionSection =
+        createMetadataFn(asStringView(partitionBuilder));
+
+    partitionStartBuckets.emplace_back(startBucket);
+    partitionSections.emplace_back(
+        serialization::CreateMetadataSection(
+            builder,
+            partitionSection.offset(),
+            partitionSection.size(),
+            static_cast<serialization::CompressionType>(
+                partitionSection.compressionType())));
+  }
+
+  auto partitionStartBucketsVec = builder.CreateVector(partitionStartBuckets);
+  auto partitionSectionsVec = builder.CreateVector(partitionSections);
+
+  auto hashIndex = serialization::CreateHashIndex(
+      builder,
+      numKeys,
+      numBuckets,
+      numKeys,
+      actualLoadFactor,
+      bloomFilterOffset,
+      partitionStartBucketsVec,
+      partitionSectionsVec);
+  builder.Finish(hashIndex);
+}
+
+void HashIndexWriter::buildIndexDirectoryFlatBuffer(
+    flatbuffers::FlatBufferBuilder& builder,
+    const std::vector<MetadataSection>& indexSections) const {
+  NIMBLE_CHECK(!accumulators_.empty());
+  NIMBLE_CHECK_EQ(indexSections.size(), accumulators_.size());
+
+  std::vector<flatbuffers::Offset<serialization::HashIndexSection>>
+      sectionOffsets;
+  sectionOffsets.reserve(accumulators_.size());
+
+  for (size_t i = 0; i < accumulators_.size(); ++i) {
+    // Build column names for the directory entry.
+    std::vector<flatbuffers::Offset<flatbuffers::String>> columnOffsets;
+    columnOffsets.reserve(accumulators_[i].config.columns.size());
+    for (const auto& col : accumulators_[i].config.columns) {
+      columnOffsets.emplace_back(builder.CreateString(col));
+    }
+    auto columnsVec = builder.CreateVector(columnOffsets);
+
+    // Build MetadataSection reference.
+    const auto& section = indexSections[i];
+    auto metadataSection = serialization::CreateMetadataSection(
+        builder,
+        section.offset(),
+        section.size(),
+        static_cast<serialization::CompressionType>(section.compressionType()));
+
+    sectionOffsets.emplace_back(
+        serialization::CreateHashIndexSection(
+            builder, columnsVec, metadataSection));
+  }
+
+  auto indicesVec = builder.CreateVector(sectionOffsets);
+  auto directory = serialization::CreateHashIndexDirectory(builder, indicesVec);
+  builder.Finish(directory);
+}
+
+std::unique_ptr<HashIndexWriter> HashIndexWriter::create(
+    const std::vector<HashIndexConfig>& configs,
+    const velox::TypePtr& inputType,
+    velox::memory::MemoryPool* pool) {
+  if (configs.empty()) {
+    return nullptr;
+  }
+  NIMBLE_CHECK_NOT_NULL(pool, "memory pool must not be null");
+  return std::unique_ptr<HashIndexWriter>(
+      new HashIndexWriter(configs, velox::asRowType(inputType), pool));
+}
+
+HashIndexWriter::HashIndexWriter(
+    const std::vector<HashIndexConfig>& configs,
+    const velox::RowTypePtr& inputType,
+    velox::memory::MemoryPool* pool)
+    : pool_{pool}, keyColumnIndices_{getKeyColumnIndices(configs, inputType)} {
+  NIMBLE_CHECK(!configs.empty(), "Hash index configs must not be empty");
+  accumulators_.reserve(configs.size());
+  for (const auto& config : configs) {
+    NIMBLE_CHECK(
+        !config.columns.empty(), "Hash index must have at least one column");
+    // Check for duplicate index columns.
+    for (size_t i = 0; i < accumulators_.size(); ++i) {
+      NIMBLE_CHECK(
+          accumulators_[i].config.columns != config.columns,
+          "Duplicate hash index columns: [{}]",
+          fmt::join(config.columns, ", "));
+    }
+    NIMBLE_CHECK_GT(config.loadFactor, 0.0f, "Load factor must be positive");
+    NIMBLE_CHECK_LE(config.loadFactor, 1.0f, "Load factor must be at most 1.0");
+    accumulators_.emplace_back(
+        IndexAccumulator{
+            .config = config,
+            .encoder = createEncoder(config, inputType, pool),
+        });
+  }
+}
+
+void HashIndexWriter::validateNoNullKeys(const velox::VectorPtr& input) const {
+  const auto* rowVector = input->asChecked<velox::RowVector>();
+  const auto& children = rowVector->children();
+  for (const auto columnIndex : keyColumnIndices_) {
+    const auto& child = children[columnIndex];
+    if (!child->mayHaveNulls()) {
+      continue;
+    }
+    const auto* nulls = child->rawNulls();
+    if (nulls == nullptr) {
+      continue;
+    }
+    const auto nullCount = velox::bits::countNulls(nulls, 0, input->size());
+    NIMBLE_USER_CHECK_EQ(
+        nullCount,
+        0,
+        "Null value not allowed in hash index key column at index {}: found {} null(s)",
+        columnIndex,
+        nullCount);
+  }
+}
+
+void HashIndexWriter::write(const velox::VectorPtr& input) {
+  NIMBLE_CHECK(!closed_, "Cannot write after close");
+  if (input->size() == 0) {
+    return;
+  }
+
+  NIMBLE_USER_CHECK_LE(
+      numRows_ + static_cast<uint64_t>(input->size()),
+      static_cast<uint64_t>(std::numeric_limits<uint32_t>::max()),
+      "Hash index row count exceeds uint32 limit");
+
+  validateNoNullKeys(input);
+  ensureEncodingBuffer();
+
+  for (auto& accumulator : accumulators_) {
+    // Encode keys from this batch.
+    std::vector<std::string_view> keys;
+    accumulator.encoder->encode(input, keys, [this](size_t size) {
+      return encodingBuffer_->reserve(size);
+    });
+
+    // Record index entries. Encoded keys are string_views into
+    // encodingBuffer_ which guarantees pointer stability.
+    const auto newSize = accumulator.entries.size() + input->size();
+    if (accumulator.entries.capacity() < newSize) {
+      accumulator.entries.reserve(
+          std::max(accumulator.entries.size() * 2, newSize));
+    }
+    for (velox::vector_size_t i = 0; i < input->size(); ++i) {
+      accumulator.entries.emplace_back(IndexEntry{keys[i], numRows_ + i});
+    }
+  }
+
+  numRows_ += input->size();
+}
+
+void HashIndexWriter::close(
+    const CreateMetadataSectionFn& createMetadataFn,
+    const WriteOptionalSectionFn& writeMetadataFn) {
+  NIMBLE_CHECK(!closed_, "close() already called");
+  closed_ = true;
+
+  if (numRows_ == 0) {
+    return;
+  }
+
+  // Write each hash index as a separate section.
+  std::vector<MetadataSection> indexSections;
+  indexSections.reserve(accumulators_.size());
+  for (auto& accumulator : accumulators_) {
+    flatbuffers::FlatBufferBuilder indexBuilder;
+    buildIndexFlatBuffer(indexBuilder, accumulator, createMetadataFn);
+    indexSections.emplace_back(createMetadataFn(asStringView(indexBuilder)));
+  }
+
+  // Free encoded keys now that they've been serialized into FlatBuffers.
+  encodingBuffer_.reset();
+
+  flatbuffers::FlatBufferBuilder directoryBuilder;
+  buildIndexDirectoryFlatBuffer(directoryBuilder, indexSections);
+  writeMetadataFn(
+      std::string(kHashIndexSection), asStringView(directoryBuilder));
+
+  for (auto& accumulator : accumulators_) {
+    accumulator.clear();
+  }
+}
+
+} // namespace facebook::nimble::index

--- a/dwio/nimble/index/HashIndexWriter.h
+++ b/dwio/nimble/index/HashIndexWriter.h
@@ -1,0 +1,195 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "dwio/nimble/common/Buffer.h"
+#include "dwio/nimble/index/IndexConfig.h"
+#include "dwio/nimble/index/IndexWriter.h"
+#include "dwio/nimble/tablet/MetadataBuffer.h"
+#include "flatbuffers/flatbuffers.h"
+#include "velox/common/memory/Memory.h"
+#include "velox/serializers/KeyEncoder.h"
+#include "velox/vector/ComplexVector.h"
+
+namespace facebook::nimble::serialization {
+struct BloomFilter;
+} // namespace facebook::nimble::serialization
+
+namespace facebook::nimble::index {
+
+namespace test {
+class HashIndexWriterTestHelper;
+} // namespace test
+
+/// Builds one or more hash indices during file write.
+///
+/// The HashIndexWriter accumulates encoded keys and their file row numbers
+/// during writing, then builds hash tables and optional bloom filters at
+/// finalization (file close) time. The result is serialized as a FlatBuffer
+/// and stored as an optional section in the Nimble file.
+///
+/// Lifecycle:
+///   1. Create with configs and input schema
+///   2. For each batch: write(batch) to accumulate keys and row mappings
+///   3. At file close: finalize() to build and serialize the index
+///
+/// Serialization layout:
+///
+///   HashIndexDirectory (optional section, one per file)
+///   +-- HashIndexSection[0] --> HashIndex (separate section)
+///   |     +-- num_buckets, load_factor, bloom_filter
+///   |     +-- stripe_row_counts[]
+///   |     +-- partitions[]
+///   |           +-- Partition 0 (separate section)
+///   |           |     bucket_offsets:  [0, 2, 2, 3]
+///   |           |     bucket_counts:   [2, 0, 1, 1]
+///   |           |     encoded_keys:    [k0, k1, k2, k3]
+///   |           |     row_numbers:     [10, 42, 7, 99]
+///   |           +-- Partition 1 (loaded on-demand)
+///   |                 ...
+///   +-- HashIndexSection[1] --> HashIndex (second index)
+///         ...
+///
+///   Lookup: hash(key) & (num_buckets-1) --> bucket --> partition
+///     --> scan encoded_keys[offset..offset+count] for exact match
+///     --> return row_numbers[matched_offset]
+///
+/// Memory: Keys are accumulated in memory during writing. For files with
+/// billions of rows, consider the memory impact (~40-60 bytes per row per
+/// index for encoded keys + metadata).
+class HashIndexWriter : public IndexWriter {
+ public:
+  /// Factory method. Returns nullptr if configs is empty.
+  ///
+  /// @param configs Hash index configurations. One index per config.
+  /// @param inputType Schema of the input data.
+  /// @param pool Memory pool for allocations.
+  static std::unique_ptr<HashIndexWriter> create(
+      const std::vector<HashIndexConfig>& configs,
+      const velox::TypePtr& inputType,
+      velox::memory::MemoryPool* pool);
+
+  ~HashIndexWriter() override = default;
+
+  HashIndexWriter(const HashIndexWriter&) = delete;
+  HashIndexWriter& operator=(const HashIndexWriter&) = delete;
+  HashIndexWriter(HashIndexWriter&&) = delete;
+  HashIndexWriter& operator=(HashIndexWriter&&) = delete;
+
+  /// Encodes keys from the input batch and records row mappings.
+  void write(const velox::VectorPtr& input) override;
+
+  void close(
+      const CreateMetadataSectionFn& createMetadataFn,
+      const WriteOptionalSectionFn& writeMetadataFn) override;
+
+ private:
+  HashIndexWriter(
+      const std::vector<HashIndexConfig>& configs,
+      const velox::RowTypePtr& inputType,
+      velox::memory::MemoryPool* pool);
+
+  // An indexed key and its file row.
+  // The key is a string_view into the encodingBuffer_ arena which
+  // guarantees pointer stability for its lifetime.
+  struct IndexEntry {
+    std::string_view key;
+    uint32_t row;
+  };
+
+  // Per-index accumulator that collects keys and builds the hash table.
+  struct IndexAccumulator {
+    HashIndexConfig config;
+    std::unique_ptr<velox::serializer::KeyEncoder> encoder;
+    // Accumulated index entries with encoded keys pointing into
+    // encodingBuffer_.
+    std::vector<IndexEntry> entries;
+
+    void clear() {
+      entries.clear();
+      entries.shrink_to_fit();
+      encoder.reset();
+    }
+  };
+
+  // Estimates the serialized size of one bucket's keys.
+  // Accounts for encoded key strings + row numbers + bucket directory overhead.
+  static size_t estimateBucketSize(
+      const std::vector<uint32_t>& keyIndices,
+      const IndexAccumulator& accumulator);
+
+  // Builds a HashIndexPartition FlatBuffer for a range of buckets.
+  static void buildIndexPartitionFlatBuffer(
+      flatbuffers::FlatBufferBuilder& builder,
+      const std::vector<std::vector<uint32_t>>& keyIndices,
+      const IndexAccumulator& accumulator,
+      uint32_t startBucket,
+      uint32_t bucketCount);
+
+  // Validates that no null values exist in any key columns.
+  void validateNoNullKeys(const velox::VectorPtr& input) const;
+
+  // Builds a bloom filter FlatBuffer offset, or 0 if bloom filter is disabled.
+  flatbuffers::Offset<serialization::BloomFilter> buildBloomFilter(
+      flatbuffers::FlatBufferBuilder& builder,
+      const IndexAccumulator& accumulator) const;
+
+  // Builds a single HashIndex FlatBuffer for one accumulator.
+  // When partitioning is enabled, partition data sections are written via
+  // createMetadataFn and the entry contains partition descriptors.
+  void buildIndexFlatBuffer(
+      flatbuffers::FlatBufferBuilder& builder,
+      const IndexAccumulator& accumulator,
+      const CreateMetadataSectionFn& createMetadataFn) const;
+
+  // Builds the HashIndexDirectory FlatBuffer with HashIndexSection entries.
+  void buildIndexDirectoryFlatBuffer(
+      flatbuffers::FlatBufferBuilder& builder,
+      const std::vector<MetadataSection>& indexSections) const;
+
+  // Returns a string_view of the FlatBufferBuilder's output buffer.
+  static std::string_view asStringView(
+      const flatbuffers::FlatBufferBuilder& builder) {
+    return {
+        reinterpret_cast<const char*>(builder.GetBufferPointer()),
+        builder.GetSize()};
+  }
+
+  inline void ensureEncodingBuffer() {
+    if (encodingBuffer_ == nullptr) {
+      encodingBuffer_ = std::make_unique<Buffer>(*pool_);
+    }
+  }
+
+  velox::memory::MemoryPool* const pool_;
+  // Deduplicated key column indices across all hash indices for null
+  // validation.
+  const std::vector<velox::column_index_t> keyColumnIndices_;
+  // Arena buffer for encoded keys. Lazily created on first write().
+  // Encoded keys (string_views) in IndexEntry point into this buffer.
+  std::unique_ptr<Buffer> encodingBuffer_;
+  std::vector<IndexAccumulator> accumulators_;
+  uint32_t numRows_{0};
+  bool closed_{false};
+
+  friend class test::HashIndexWriterTestHelper;
+};
+
+} // namespace facebook::nimble::index

--- a/dwio/nimble/index/IndexConfig.h
+++ b/dwio/nimble/index/IndexConfig.h
@@ -15,6 +15,7 @@
  */
 #pragma once
 
+#include <optional>
 #include <string>
 #include <vector>
 
@@ -63,6 +64,39 @@ struct ClusterIndexConfig {
   /// give finer-grained lookups at the cost of more metadata.
   /// 0 means no splitting (one chunk per partition).
   uint64_t maxRowsPerKeyChunk{0};
+};
+
+/// Configuration for bloom filter.
+/// Shared by hash index and sorted index.
+struct BloomFilterConfig {
+  /// Bits per key for the bloom filter.
+  /// Higher values reduce false positive rate at the cost of more memory.
+  /// 10 bits/key ≈ 1% FPR, 7 bits/key ≈ 3% FPR.
+  float bitsPerKey{10.0f};
+};
+
+/// Configuration for hash index generation.
+/// A hash index provides point lookups from composite key columns to row
+/// numbers without requiring data to be sorted. Multiple hash indices can
+/// coexist per file, each on a different set of columns.
+struct HashIndexConfig {
+  /// Columns forming the composite key for point lookups.
+  std::vector<std::string> columns;
+
+  /// Target load factor for the hash table. numBuckets is computed as
+  /// nextPowerOfTwo(numKeys / loadFactor). Lower values reduce collisions
+  /// at the cost of more buckets.
+  float loadFactor{0.7f};
+
+  /// Optional bloom filter for fast negative lookups.
+  std::optional<BloomFilterConfig> bloomFilter;
+
+  /// Maximum partition size in bytes for on-demand loading.
+  /// When the serialized index data exceeds this threshold, buckets are
+  /// split into independently loadable partitions. Each partition is stored
+  /// as a separate section and loaded lazily during lookup.
+  /// 0 means no partitioning (all data in a single section).
+  uint64_t maxPartitionSizeBytes{0};
 };
 
 } // namespace facebook::nimble

--- a/dwio/nimble/index/IndexLookup.h
+++ b/dwio/nimble/index/IndexLookup.h
@@ -24,9 +24,11 @@
 
 #include <fmt/format.h>
 #include <folly/Range.h>
+#include <folly/container/F14Map.h>
 
 #include "dwio/nimble/common/Exceptions.h"
 #include "dwio/nimble/velox/RowRange.h"
+#include "velox/common/base/RuntimeMetrics.h"
 #include "velox/serializers/KeyEncoder.h"
 
 namespace facebook::nimble::index {
@@ -38,16 +40,16 @@ enum class IndexType {
   Cluster,
   /// Hash-based index for point lookups on unsorted data. Maps composite key
   /// columns to exact row numbers.
-  Dense,
+  Hash,
 };
 
 std::string toString(IndexType indexType);
 std::ostream& operator<<(std::ostream& out, IndexType indexType);
 
-/// Unified index interface for both cluster and dense indices.
+/// Unified index interface for both cluster and hash indices.
 ///
 /// This provides a common abstraction for index metadata and lookup
-/// capabilities. Both ClusterIndex and DenseIndex implement this interface,
+/// capabilities. Both ClusterIndex and HashIndex implement this interface,
 /// enabling the reader to select the best index for a given query without
 /// knowing the concrete type.
 ///
@@ -185,7 +187,9 @@ class IndexLookup {
   virtual ~IndexLookup() = default;
 
   /// Returns the type of this index.
-  virtual IndexType indexType() const = 0;
+  IndexType type() const {
+    return type_;
+  }
 
   /// Returns the column names this index covers, in index definition order.
   virtual const std::vector<std::string>& indexColumns() const = 0;
@@ -194,12 +198,23 @@ class IndexLookup {
   ///
   /// For cluster index: supports both point lookups and range lookups.
   ///   Returns file-level RowRanges spanning matching rows.
-  /// For dense index: only supports point lookups. Returns file-level
+  /// For hash index: only supports point lookups. Returns file-level
   ///   RowRanges for exact single rows (may return multiple per key).
   ///
   /// Results are indexed by input key position: result[i] returns the
   /// RowRanges for request.keyBounds()[i].
   virtual LookupResult lookup(const LookupRequest& request) const = 0;
+
+  /// Returns runtime statistics accumulated during lookups.
+  virtual folly::F14FastMap<std::string, velox::RuntimeMetric> stats() const {
+    return {};
+  }
+
+ protected:
+  explicit IndexLookup(IndexType type) : type_{type} {}
+
+ private:
+  const IndexType type_;
 };
 
 inline std::string toString(IndexLookup::LookupRequest::Mode mode) {

--- a/dwio/nimble/index/IndexWriter.h
+++ b/dwio/nimble/index/IndexWriter.h
@@ -22,14 +22,13 @@
 
 namespace facebook::nimble::index {
 
-/// Base interface for index writers (ClusterIndexWriter, DenseIndexWriter).
+/// Base interface for index writers (ClusterIndexWriter, HashIndexWriter).
 ///
 /// Lifecycle:
 ///   1. Create with config and input schema
 ///   2. For each batch: write(batch)
-///   3. At stripe group boundaries: flushPartition() to write index data
-///   4. At file close: finalize() to build and serialize the root index
-///   5. close() to release resources
+///   3. At stripe group boundaries: flush() to write index data
+///   4. At file close: close() to finalize, serialize, and release resources
 class IndexWriter {
  public:
   virtual ~IndexWriter() = default;
@@ -37,21 +36,16 @@ class IndexWriter {
   /// Processes a batch of input data for indexing.
   virtual void write(const velox::VectorPtr& input) = 0;
 
-  /// Builds and serializes the index. Called at file close.
-  /// Returns the serialized index to be stored as an optional section.
-  virtual std::string finalize(
-      const CreateMetadataSectionFn& createMetadataSection) = 0;
+  /// Flushes index data at stripe group boundaries.
+  virtual void flush(
+      const WriteDataFn& writeDataFn,
+      const CreateMetadataSectionFn& createMetadataFn) {}
 
-  /// Releases internal resources. Must be called after finalize().
-  virtual void close() = 0;
-
-  /// Flushes partition data at stripe group boundaries.
-  /// Writes key stream data via writeData, then writes partition metadata
-  /// via createMetadataSection.
-  virtual void flushPartition(
-      size_t stripeCount,
-      const WriteDataFn& writeData,
-      const CreateMetadataSectionFn& createMetadataSection) {}
+  /// Finalizes the index, writes it as an optional section, and releases
+  /// resources.
+  virtual void close(
+      const CreateMetadataSectionFn& createMetadataFn,
+      const WriteOptionalSectionFn& writeMetadataFn) = 0;
 };
 
 } // namespace facebook::nimble::index

--- a/dwio/nimble/index/tests/ClusterIndexTest.cpp
+++ b/dwio/nimble/index/tests/ClusterIndexTest.cpp
@@ -138,7 +138,7 @@ TEST_F(ClusterIndexTest, basic) {
       createTestClusterIndex(indexColumns, minKey, stripes, stripeGroups);
   auto clusterIndex = createClusterIndex(indexBuffers);
 
-  EXPECT_EQ(clusterIndex->indexType(), IndexType::Cluster);
+  EXPECT_EQ(clusterIndex->type(), IndexType::Cluster);
   EXPECT_EQ(clusterIndex->layout().numPartitions, 3);
 
   const auto& cols = clusterIndex->indexColumns();

--- a/dwio/nimble/index/tests/ClusterIndexTestUtils.cpp
+++ b/dwio/nimble/index/tests/ClusterIndexTestUtils.cpp
@@ -296,16 +296,14 @@ void TestClusterIndexMetadataWriter::addStripe(
 TabletWriter::StripeGroupFlushCallback
 TestClusterIndexMetadataWriter::createStripeGroupFlushCallback() {
   return [this](
-             size_t stripeCount,
-             const WriteDataFn& writeData,
-             const CreateMetadataSectionFn& createMetadataSection) {
-    flushKeyStream(stripeCount, writeData);
-    flushPartitionMetadata(stripeCount, createMetadataSection);
+             const WriteDataFn& writeDataFn,
+             const CreateMetadataSectionFn& createMetadataFn) {
+    flushKeyStream(writeDataFn);
+    flushPartitionMetadata(createMetadataFn);
   };
 }
 
 void TestClusterIndexMetadataWriter::flushKeyStream(
-    size_t stripeCount,
     const WriteDataFn& writeData) {
   if (encodedKeyData_.empty()) {
     return;
@@ -319,7 +317,6 @@ void TestClusterIndexMetadataWriter::flushKeyStream(
 }
 
 void TestClusterIndexMetadataWriter::flushPartitionMetadata(
-    size_t stripeCount,
     const CreateMetadataSectionFn& createMetadataSection) {
   if (partitionIndex_ == nullptr) {
     return;
@@ -362,9 +359,9 @@ void TestClusterIndexMetadataWriter::flushPartitionMetadata(
 TabletWriter::CloseCallback
 TestClusterIndexMetadataWriter::createCloseCallback() {
   return [this](
-             const WriteOptionalSectionFn& writeOptionalSection,
-             const CreateMetadataSectionFn& /*createMetadataSection*/) {
-    writeRoot(writeOptionalSection);
+             const CreateMetadataSectionFn& /*createMetadataFn*/,
+             const WriteOptionalSectionFn& writeMetadataFn) {
+    writeRoot(writeMetadataFn);
   };
 }
 

--- a/dwio/nimble/index/tests/ClusterIndexTestUtils.h
+++ b/dwio/nimble/index/tests/ClusterIndexTestUtils.h
@@ -275,10 +275,9 @@ class TestClusterIndexMetadataWriter {
 
   void writeRoot(const WriteOptionalSectionFn& writeOptionalSection);
 
-  void flushKeyStream(size_t stripeCount, const WriteDataFn& writeData);
+  void flushKeyStream(const WriteDataFn& writeData);
 
   void flushPartitionMetadata(
-      size_t stripeCount,
       const CreateMetadataSectionFn& createMetadataSection);
 
   velox::memory::MemoryPool* const pool_;

--- a/dwio/nimble/index/tests/ClusterIndexWriterTest.cpp
+++ b/dwio/nimble/index/tests/ClusterIndexWriterTest.cpp
@@ -904,29 +904,35 @@ TEST_P(ClusterIndexWriterDataTest, close) {
   ASSERT_NE(writer, nullptr);
 
   writer->write(makeInput({1, 2, 3}));
-  writer->close();
+  uint32_t nextSectionId = 0;
+  CreateMetadataSectionFn createMetadataFn = [&](std::string_view) {
+    return MetadataSection{nextSectionId++, 0, CompressionType::Uncompressed};
+  };
+  WriteOptionalSectionFn noopWriteFn = [](const std::string&,
+                                          std::string_view) {};
+  writer->close(createMetadataFn, noopWriteFn);
 }
 
-TEST_P(ClusterIndexWriterDataTest, writeAfterFinalize) {
+TEST_P(ClusterIndexWriterDataTest, writeAfterClose) {
   auto config = indexConfig(encodingType());
   auto writer = ClusterIndexWriter::create(config, type_, pool_.get());
   ASSERT_NE(writer, nullptr);
 
   writer->write(makeInput({1, 2, 3}));
   uint32_t nextSectionId = 0;
-  CreateMetadataSectionFn createMetadataSection = [&](std::string_view) {
+  CreateMetadataSectionFn createMetadataFn = [&](std::string_view) {
     return MetadataSection{nextSectionId++, 0, CompressionType::Uncompressed};
   };
-  writer->finalize(createMetadataSection);
+  WriteOptionalSectionFn noopWriteFn = [](const std::string&,
+                                          std::string_view) {};
+  writer->close(createMetadataFn, noopWriteFn);
 
   NIMBLE_ASSERT_THROW(
       writer->write(makeInput({4, 5, 6})),
-      "ClusterIndexWriter has been finalized");
+      "ClusterIndexWriter has been closed");
   NIMBLE_ASSERT_THROW(
-      writer->finalize(createMetadataSection),
-      "ClusterIndexWriter has been finalized");
-
-  writer->close();
+      writer->close(createMetadataFn, noopWriteFn),
+      "ClusterIndexWriter has been closed");
 }
 
 INSTANTIATE_TEST_SUITE_P(
@@ -1074,11 +1080,15 @@ TEST_P(ClusterIndexWriterChunkTest, maxRowsPerKeyChunk) {
     partitionMetadata.emplace_back(metadata);
     return MetadataSection(0, metadata.size(), CompressionType::Uncompressed);
   };
-  writer->flushPartition(1, writeDataFn, createMetadataFn);
+  writer->flush(writeDataFn, createMetadataFn);
 
-  // Finalize root index.
-  auto rootIndexData = writer->finalize(createMetadataFn);
-  writer->close();
+  // Close the writer and capture the root index data.
+  std::string rootIndexData;
+  writer->close(
+      createMetadataFn,
+      [&rootIndexData](const std::string&, std::string_view content) {
+        rootIndexData = std::string(content);
+      });
 
   ASSERT_FALSE(rootIndexData.empty());
   ASSERT_EQ(partitionMetadata.size(), 1);

--- a/dwio/nimble/index/tests/HashIndexTest.cpp
+++ b/dwio/nimble/index/tests/HashIndexTest.cpp
@@ -1,0 +1,491 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <gtest/gtest.h>
+#include <deque>
+
+#include "dwio/nimble/common/tests/GTestUtils.h"
+#include "dwio/nimble/index/HashIndex.h"
+#include "dwio/nimble/index/IndexConfig.h"
+#include "dwio/nimble/index/IndexLookup.h"
+
+#include "dwio/nimble/tablet/TabletReader.h"
+#include "dwio/nimble/velox/VeloxReader.h"
+#include "dwio/nimble/velox/VeloxWriter.h"
+#include "velox/common/file/FileSystems.h"
+#include "velox/common/memory/Memory.h"
+#include "velox/common/testutil/TempDirectoryPath.h"
+#include "velox/vector/FlatVector.h"
+
+namespace facebook::nimble::index {
+namespace {
+
+class HashIndexTestBase {
+ protected:
+  // Schema: {id: INTEGER, value: VARCHAR}.
+  // Both columns have unique values derived from row index.
+  static velox::RowTypePtr rowType() {
+    return velox::ROW({{"id", velox::INTEGER()}, {"value", velox::VARCHAR()}});
+  }
+
+  // Creates a batch of numRows with id=[startRow, startRow+numRows) and
+  // value="v_{id}".
+  velox::VectorPtr makeBatch(int32_t startRow, int32_t numRows) {
+    auto ids =
+        velox::BaseVector::create(velox::INTEGER(), numRows, leafPool_.get());
+    auto values =
+        velox::BaseVector::create(velox::VARCHAR(), numRows, leafPool_.get());
+    auto* flatIds = ids->asFlatVector<int32_t>();
+    auto* flatValues = values->asFlatVector<velox::StringView>();
+    for (int i = 0; i < numRows; ++i) {
+      const int32_t id = startRow + i;
+      flatIds->set(i, id);
+      valueStrings_.emplace_back("v_" + std::to_string(id));
+      flatValues->set(i, velox::StringView(valueStrings_.back()));
+    }
+    return std::make_shared<velox::RowVector>(
+        leafPool_.get(),
+        rowType(),
+        nullptr,
+        numRows,
+        std::vector<velox::VectorPtr>{ids, values});
+  }
+
+  // Writes batches to a file with the given schema and writer options.
+  void writeFile(
+      const std::string& filePath,
+      const velox::RowTypePtr& schema,
+      const std::vector<velox::VectorPtr>& batches,
+      VeloxWriterOptions options) {
+    auto fs = velox::filesystems::getFileSystem(filePath, {});
+    auto file = fs->openFileForWrite(
+        filePath,
+        {.shouldCreateParentDirectories = true,
+         .shouldThrowOnFileAlreadyExists = false});
+
+    VeloxWriter writer(schema, std::move(file), *pool_, std::move(options));
+    for (const auto& batch : batches) {
+      writer.write(batch);
+    }
+    writer.close();
+  }
+
+  // Convenience overload using the default schema.
+  void writeFile(
+      const std::string& filePath,
+      const std::vector<velox::VectorPtr>& batches,
+      HashIndexConfig indexConfig,
+      std::optional<uint64_t> flushSize = std::nullopt) {
+    VeloxWriterOptions options;
+    options.hashIndexConfigs.push_back(std::move(indexConfig));
+    if (flushSize.has_value()) {
+      options.flushPolicyFactory = [size = flushSize.value()]() {
+        return std::make_unique<StripeRawSizeFlushPolicy>(size);
+      };
+    }
+    writeFile(filePath, rowType(), batches, std::move(options));
+  }
+
+  // Opens a file and returns the TabletReader.
+  std::shared_ptr<TabletReader> openTablet(const std::string& filePath) {
+    auto fs = velox::filesystems::getFileSystem(filePath, {});
+    auto readFile = fs->openFileForRead(filePath);
+    return TabletReader::create(std::move(readFile), leafPool_.get(), {});
+  }
+
+  // Encodes a lookup key for a single row and returns the encoded key.
+  std::string encodeLookupKey(
+      const std::vector<std::string>& columns,
+      int32_t idValue) {
+    auto encoder = velox::serializer::KeyEncoder::create(
+        columns,
+        rowType(),
+        std::vector<velox::core::SortOrder>(
+            columns.size(), velox::core::SortOrder{true, false}),
+        leafPool_.get());
+
+    auto idCol =
+        velox::BaseVector::create(velox::INTEGER(), 1, leafPool_.get());
+    idCol->asFlatVector<int32_t>()->set(0, idValue);
+
+    auto valStr = "v_" + std::to_string(idValue);
+    auto valCol =
+        velox::BaseVector::create(velox::VARCHAR(), 1, leafPool_.get());
+    valCol->asFlatVector<velox::StringView>()->set(
+        0, velox::StringView(valStr));
+
+    auto lookupRow = std::make_shared<velox::RowVector>(
+        leafPool_.get(),
+        rowType(),
+        nullptr,
+        1,
+        std::vector<velox::VectorPtr>{idCol, valCol});
+
+    Buffer buffer(*leafPool_);
+    std::vector<std::string_view> encodedKeys;
+    encoder->encode(lookupRow, encodedKeys, [&buffer](size_t size) {
+      return buffer.reserve(size);
+    });
+    return std::string(encodedKeys[0]);
+  }
+
+  // Performs a point lookup and returns the result.
+  IndexLookup::LookupResult pointLookup(
+      const HashIndex* hashIndex,
+      const std::vector<std::string>& columns,
+      int32_t idValue) {
+    auto key = encodeLookupKey(columns, idValue);
+    return hashIndex->lookup(
+        IndexLookup::LookupRequest::pointLookup({std::move(key)}));
+  }
+
+  std::string tempFilePath(const std::string& name) {
+    return tempDir_->getPath() + "/" + name;
+  }
+
+  std::shared_ptr<velox::memory::MemoryPool> pool_;
+  std::shared_ptr<velox::memory::MemoryPool> leafPool_;
+  std::shared_ptr<velox::common::testutil::TempDirectoryPath> tempDir_;
+  // Deque for pointer stability across push_back calls, since StringViews
+  // in FlatVector reference these strings.
+  std::deque<std::string> valueStrings_;
+};
+
+// Non-parameterized fixture.
+class HashIndexTest : public HashIndexTestBase, public ::testing::Test {
+ protected:
+  static void SetUpTestCase() {
+    velox::filesystems::registerLocalFileSystem();
+    velox::memory::MemoryManager::testingSetInstance({});
+  }
+
+  void SetUp() override {
+    pool_ = velox::memory::memoryManager()->addRootPool("HashIndexTest");
+    leafPool_ = pool_->addLeafChild("leaf");
+    tempDir_ = velox::common::testutil::TempDirectoryPath::create();
+  }
+};
+
+// Parameterized fixture: single-column vs composite-key index.
+struct HashIndexTestParam {
+  std::vector<std::string> columns;
+
+  std::string debugString() const {
+    return fmt::format("columns: [{}]", fmt::join(columns, ", "));
+  }
+};
+
+class HashIndexParamTest : public HashIndexTestBase,
+                           public ::testing::TestWithParam<HashIndexTestParam> {
+ protected:
+  static void SetUpTestCase() {
+    velox::filesystems::registerLocalFileSystem();
+    velox::memory::MemoryManager::testingSetInstance({});
+  }
+
+  void SetUp() override {
+    pool_ = velox::memory::memoryManager()->addRootPool("HashIndexParamTest");
+    leafPool_ = pool_->addLeafChild("leaf");
+    tempDir_ = velox::common::testutil::TempDirectoryPath::create();
+  }
+
+  const std::vector<std::string>& columns() const {
+    return GetParam().columns;
+  }
+
+  HashIndexConfig indexConfig() const {
+    return HashIndexConfig{
+        .columns = columns(),
+        .bloomFilter = BloomFilterConfig{},
+    };
+  }
+};
+
+INSTANTIATE_TEST_SUITE_P(
+    SingleAndCompositeKey,
+    HashIndexParamTest,
+    testing::Values(
+        HashIndexTestParam{{"id"}},
+        HashIndexTestParam{{"id", "value"}}),
+    [](const testing::TestParamInfo<HashIndexTestParam>& info) {
+      return fmt::format("columns_{}", fmt::join(info.param.columns, "_"));
+    });
+
+TEST_P(HashIndexParamTest, roundTrip) {
+  std::vector<velox::VectorPtr> batches;
+  for (int b = 0; b < 3; ++b) {
+    batches.push_back(makeBatch(b * 100, 100));
+  }
+
+  const auto filePath = tempFilePath("round_trip");
+  auto config = indexConfig();
+  config.loadFactor = 0.5f;
+  writeFile(filePath, batches, std::move(config), /*flushSize=*/512);
+
+  auto tablet = openTablet(filePath);
+  auto* hashIndex = tablet->denseIndex(columns());
+  ASSERT_NE(hashIndex, nullptr);
+  EXPECT_EQ(hashIndex->type(), IndexType::Hash);
+  EXPECT_EQ(hashIndex->indexColumns(), columns());
+}
+
+TEST_P(HashIndexParamTest, pointLookup) {
+  std::vector<velox::VectorPtr> batches;
+  batches.push_back(makeBatch(0, 50));
+
+  const auto filePath = tempFilePath("point_lookup");
+  writeFile(filePath, batches, indexConfig());
+
+  auto tablet = openTablet(filePath);
+  auto* hashIndex = tablet->denseIndex(columns());
+  ASSERT_NE(hashIndex, nullptr);
+
+  {
+    auto result = pointLookup(hashIndex, columns(), 20);
+    ASSERT_EQ(result.size(), 1);
+    EXPECT_EQ(result[0].size(), 1);
+  }
+
+  {
+    auto result = pointLookup(hashIndex, columns(), 999);
+    ASSERT_EQ(result.size(), 1);
+    EXPECT_EQ(result[0].size(), 0);
+  }
+
+  const auto stats = hashIndex->stats();
+  EXPECT_EQ(stats.at(HashIndex::kNumLookups).sum, 2);
+  EXPECT_EQ(stats.at(HashIndex::kNumMatchedRows).sum, 1);
+  // Bloom filter may or may not skip the non-existent key depending on the
+  // hash — just verify the stats entry is present if skips occurred.
+  if (stats.count(HashIndex::kNumBloomFilterSkips) > 0) {
+    EXPECT_LE(stats.at(HashIndex::kNumBloomFilterSkips).sum, 1);
+  }
+}
+
+TEST_P(HashIndexParamTest, bloomFilterSkips) {
+  std::vector<velox::VectorPtr> batches;
+  batches.push_back(makeBatch(0, 50));
+
+  const auto filePath = tempFilePath("bloom_filter");
+  // Use high bitsPerKey to eliminate false positives, making bloom filter
+  // behavior fully deterministic for this test.
+  auto config = indexConfig();
+  config.bloomFilter = BloomFilterConfig{.bitsPerKey = 40.0f};
+  writeFile(filePath, batches, std::move(config));
+
+  auto tablet = openTablet(filePath);
+  auto* hashIndex = tablet->denseIndex(columns());
+  ASSERT_NE(hashIndex, nullptr);
+
+  const int32_t kNumExisting = 4;
+  for (int32_t key : {0, 10, 25, 49}) {
+    auto result = pointLookup(hashIndex, columns(), key);
+    ASSERT_EQ(result.size(), 1);
+    EXPECT_EQ(result[0].size(), 1);
+  }
+  {
+    const auto stats = hashIndex->stats();
+    EXPECT_EQ(stats.at(HashIndex::kNumLookups).sum, kNumExisting);
+    EXPECT_EQ(stats.count(HashIndex::kNumBloomFilterSkips), 0);
+    EXPECT_EQ(stats.at(HashIndex::kNumMatchedRows).sum, kNumExisting);
+  }
+
+  const int32_t kNumNonExistent = 100;
+  for (int32_t key = 1'000; key < 1'000 + kNumNonExistent; ++key) {
+    auto result = pointLookup(hashIndex, columns(), key);
+    ASSERT_EQ(result.size(), 1);
+    EXPECT_EQ(result[0].size(), 0);
+  }
+  {
+    const auto stats = hashIndex->stats();
+    EXPECT_EQ(
+        stats.at(HashIndex::kNumLookups).sum, kNumExisting + kNumNonExistent);
+    EXPECT_EQ(stats.at(HashIndex::kNumBloomFilterSkips).sum, kNumNonExistent);
+    EXPECT_EQ(stats.at(HashIndex::kNumMatchedRows).sum, kNumExisting);
+  }
+}
+
+TEST_P(HashIndexParamTest, rangeScanThrows) {
+  std::vector<velox::VectorPtr> batches;
+  batches.push_back(makeBatch(0, 10));
+
+  const auto filePath = tempFilePath("range_scan_throws");
+  writeFile(filePath, batches, indexConfig());
+
+  auto tablet = openTablet(filePath);
+  auto* hashIndex = tablet->denseIndex(columns());
+  ASSERT_NE(hashIndex, nullptr);
+
+  auto key = encodeLookupKey(columns(), 5);
+  NIMBLE_ASSERT_THROW(
+      hashIndex->lookup(
+          IndexLookup::LookupRequest::rangeScan(
+              {velox::serializer::EncodedKeyBounds{key, key}})),
+      "Hash index only supports point lookups");
+}
+
+TEST_P(HashIndexParamTest, multipleStripes) {
+  std::vector<velox::VectorPtr> batches;
+  for (int b = 0; b < 5; ++b) {
+    batches.push_back(makeBatch(b * 20, 20));
+  }
+
+  const auto filePath = tempFilePath("multi_batch");
+  writeFile(filePath, batches, indexConfig(), /*flushSize=*/256);
+
+  auto tablet = openTablet(filePath);
+  auto* hashIndex = tablet->denseIndex(columns());
+  ASSERT_NE(hashIndex, nullptr);
+  EXPECT_GT(tablet->stripeCount(), 1);
+
+  auto result = pointLookup(hashIndex, columns(), 50);
+  ASSERT_EQ(result.size(), 1);
+  EXPECT_FALSE(result[0].empty());
+}
+
+TEST_P(HashIndexParamTest, partitionedIndex) {
+  std::vector<velox::VectorPtr> batches;
+  batches.push_back(makeBatch(0, 200));
+
+  const auto filePath = tempFilePath("partitioned");
+  auto config = indexConfig();
+  config.maxPartitionSizeBytes = 64;
+  writeFile(filePath, batches, std::move(config));
+
+  auto tablet = openTablet(filePath);
+  auto* hashIndex = tablet->denseIndex(columns());
+  ASSERT_NE(hashIndex, nullptr);
+
+  for (int32_t lookupValue : {0, 50, 99, 150, 199}) {
+    SCOPED_TRACE(fmt::format("key={}", lookupValue));
+    auto result = pointLookup(hashIndex, columns(), lookupValue);
+    ASSERT_EQ(result.size(), 1);
+    EXPECT_EQ(result[0].size(), 1);
+  }
+
+  // Non-existent key.
+  auto result = pointLookup(hashIndex, columns(), 999);
+  ASSERT_EQ(result.size(), 1);
+  EXPECT_EQ(result[0].size(), 0);
+}
+
+TEST_P(HashIndexParamTest, partitionedMultipleBatches) {
+  std::vector<velox::VectorPtr> batches;
+  for (int b = 0; b < 5; ++b) {
+    batches.push_back(makeBatch(b * 40, 40));
+  }
+
+  const auto filePath = tempFilePath("partitioned_multi_batch");
+  auto config = indexConfig();
+  config.maxPartitionSizeBytes = 128;
+  writeFile(filePath, batches, std::move(config), /*flushSize=*/256);
+
+  auto tablet = openTablet(filePath);
+  auto* hashIndex = tablet->denseIndex(columns());
+  ASSERT_NE(hashIndex, nullptr);
+  EXPECT_GT(tablet->stripeCount(), 1);
+
+  for (int32_t lookupValue : {0, 50, 100, 150, 199}) {
+    SCOPED_TRACE(fmt::format("key={}", lookupValue));
+    auto result = pointLookup(hashIndex, columns(), lookupValue);
+    ASSERT_EQ(result.size(), 1);
+    EXPECT_FALSE(result[0].empty());
+  }
+}
+
+TEST_F(HashIndexTest, multipleIndices) {
+  auto colAType = velox::ROW({
+      {"col_a", velox::INTEGER()},
+      {"col_b", velox::VARCHAR()},
+      {"col_c", velox::BIGINT()},
+  });
+
+  const int32_t numRows = 20;
+  auto colA =
+      velox::BaseVector::create(velox::INTEGER(), numRows, leafPool_.get());
+  auto colB =
+      velox::BaseVector::create(velox::VARCHAR(), numRows, leafPool_.get());
+  auto colC =
+      velox::BaseVector::create(velox::BIGINT(), numRows, leafPool_.get());
+  auto* flatA = colA->asFlatVector<int32_t>();
+  auto* flatB = colB->asFlatVector<velox::StringView>();
+  auto* flatC = colC->asFlatVector<int64_t>();
+  std::vector<std::string> bStrings;
+  for (int i = 0; i < numRows; ++i) {
+    flatA->set(i, i);
+    bStrings.emplace_back("b_" + std::to_string(i));
+    flatB->set(i, velox::StringView(bStrings.back()));
+    flatC->set(i, i * 1'000);
+  }
+  auto batch = std::make_shared<velox::RowVector>(
+      leafPool_.get(),
+      colAType,
+      nullptr,
+      numRows,
+      std::vector<velox::VectorPtr>{colA, colB, colC});
+
+  const auto filePath = tempFilePath("multi_indices");
+  {
+    VeloxWriterOptions options;
+    options.hashIndexConfigs.push_back(HashIndexConfig{.columns = {"col_a"}});
+    options.hashIndexConfigs.push_back(
+        HashIndexConfig{.columns = {"col_b", "col_c"}});
+    writeFile(filePath, colAType, {batch}, std::move(options));
+  }
+
+  {
+    auto tablet = openTablet(filePath);
+
+    auto* index0 = tablet->denseIndex({"col_a"});
+    ASSERT_NE(index0, nullptr);
+    EXPECT_EQ(index0->indexColumns(), std::vector<std::string>{"col_a"});
+
+    auto* index1 = tablet->denseIndex({"col_b", "col_c"});
+    ASSERT_NE(index1, nullptr);
+    const std::vector<std::string> expected{"col_b", "col_c"};
+    EXPECT_EQ(index1->indexColumns(), expected);
+
+    EXPECT_EQ(tablet->denseIndex({"col_c"}), nullptr);
+    EXPECT_EQ(tablet->denseIndex({"col_a", "col_b"}), nullptr);
+  }
+}
+
+TEST_F(HashIndexTest, noHashIndexConfig) {
+  auto noIndexType = velox::ROW({{"x", velox::INTEGER()}});
+
+  auto col = velox::BaseVector::create(velox::INTEGER(), 10, leafPool_.get());
+  auto* flat = col->asFlatVector<int32_t>();
+  for (int i = 0; i < 10; ++i) {
+    flat->set(i, i);
+  }
+  auto batch = std::make_shared<velox::RowVector>(
+      leafPool_.get(),
+      noIndexType,
+      nullptr,
+      10,
+      std::vector<velox::VectorPtr>{col});
+
+  const auto filePath = tempFilePath("no_index");
+  writeFile(filePath, noIndexType, {batch}, VeloxWriterOptions{});
+
+  {
+    auto tablet = openTablet(filePath);
+    EXPECT_EQ(tablet->denseIndex({"x"}), nullptr);
+  }
+}
+
+} // namespace
+} // namespace facebook::nimble::index

--- a/dwio/nimble/index/tests/HashIndexTestUtils.h
+++ b/dwio/nimble/index/tests/HashIndexTestUtils.h
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "dwio/nimble/index/HashIndexWriter.h"
+
+namespace facebook::nimble::index::test {
+
+/// Test helper class for HashIndexWriter that provides access to private
+/// members for testing purposes.
+class HashIndexWriterTestHelper {
+ public:
+  explicit HashIndexWriterTestHelper(HashIndexWriter* writer)
+      : writer_(writer) {}
+
+  void setNumRows(uint32_t rows) {
+    writer_->numRows_ = rows;
+  }
+
+  uint32_t numRows() const {
+    return writer_->numRows_;
+  }
+
+  size_t numAccumulators() const {
+    return writer_->accumulators_.size();
+  }
+
+  size_t numEntries(size_t accumulatorIndex) const {
+    return writer_->accumulators_[accumulatorIndex].entries.size();
+  }
+
+ private:
+  HashIndexWriter* const writer_;
+};
+
+} // namespace facebook::nimble::index::test

--- a/dwio/nimble/index/tests/HashIndexUtilsTest.cpp
+++ b/dwio/nimble/index/tests/HashIndexUtilsTest.cpp
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <gtest/gtest.h>
+
+#include "dwio/nimble/index/HashIndexUtils.h"
+
+namespace facebook::nimble::index {
+namespace {
+
+TEST(HashIndexUtilsTest, deterministic) {
+  const uint32_t mask = 15;
+  const auto bucket1 = bucketIndex("key_abc", mask);
+  const auto bucket2 = bucketIndex("key_abc", mask);
+  EXPECT_EQ(bucket1, bucket2);
+}
+
+TEST(HashIndexUtilsTest, resultWithinMask) {
+  const uint32_t mask = 7;
+  for (int i = 0; i < 100; ++i) {
+    const auto key = "key_" + std::to_string(i);
+    const auto bucket = bucketIndex(key, mask);
+    EXPECT_LE(bucket, mask);
+  }
+}
+
+TEST(HashIndexUtilsTest, singleBucket) {
+  const uint32_t mask = 0;
+  EXPECT_EQ(bucketIndex("any_key", mask), 0);
+  EXPECT_EQ(bucketIndex("another_key", mask), 0);
+}
+
+TEST(HashIndexUtilsTest, emptyKey) {
+  const uint32_t mask = 15;
+  const auto bucket = bucketIndex("", mask);
+  EXPECT_LE(bucket, mask);
+}
+
+TEST(HashIndexUtilsTest, differentKeysDistribute) {
+  const uint32_t mask = 255;
+  std::set<uint32_t> buckets;
+  for (int i = 0; i < 100; ++i) {
+    buckets.insert(bucketIndex("key_" + std::to_string(i), mask));
+  }
+  EXPECT_GT(buckets.size(), 1);
+}
+
+} // namespace
+} // namespace facebook::nimble::index

--- a/dwio/nimble/index/tests/HashIndexWriterTest.cpp
+++ b/dwio/nimble/index/tests/HashIndexWriterTest.cpp
@@ -1,0 +1,626 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <fmt/format.h>
+#include <gtest/gtest.h>
+#include <limits>
+
+#include "dwio/nimble/common/Exceptions.h"
+#include "dwio/nimble/common/tests/GTestUtils.h"
+#include "dwio/nimble/index/HashIndex.h"
+#include "dwio/nimble/index/HashIndexUtils.h"
+#include "dwio/nimble/index/HashIndexWriter.h"
+#include "dwio/nimble/index/IndexConfig.h"
+#include "dwio/nimble/index/tests/HashIndexTestUtils.h"
+#include "dwio/nimble/tablet/HashIndexGenerated.h"
+#include "velox/common/base/tests/GTestUtils.h"
+
+#include "velox/common/memory/Memory.h"
+#include "velox/serializers/KeyEncoder.h"
+#include "velox/vector/tests/utils/VectorTestBase.h"
+
+namespace facebook::nimble::index::test {
+namespace {
+
+class HashIndexWriterTestBase : public velox::test::VectorTestBase {
+ protected:
+  static constexpr std::string_view kCol0{"col0"};
+  static constexpr std::string_view kCol1{"col1"};
+  static constexpr std::string_view kCol2{"col2"};
+
+  void setupType() {
+    type_ = velox::ROW(
+        {{std::string(kCol0), velox::VARCHAR()},
+         {std::string(kCol1), velox::INTEGER()},
+         {std::string(kCol2), velox::VARCHAR()}});
+  }
+
+  static HashIndexConfig config(std::vector<std::string> columns) {
+    return HashIndexConfig{.columns = std::move(columns)};
+  }
+
+  // Creates a row vector with the given key column values.
+  // col0 (VARCHAR) is derived from keyValues for uniqueness.
+  velox::RowVectorPtr makeInput(const std::vector<int32_t>& keyValues) {
+    col0Strings_.clear();
+    col0Strings_.reserve(keyValues.size());
+    std::vector<velox::StringView> col0Vals;
+    std::vector<velox::StringView> col2Vals;
+    col0Vals.reserve(keyValues.size());
+    col2Vals.reserve(keyValues.size());
+    for (const auto val : keyValues) {
+      col0Strings_.emplace_back(fmt::format("s_{}", val));
+      col0Vals.emplace_back(col0Strings_.back());
+      col2Vals.emplace_back("b");
+    }
+    return makeRowVector(
+        {std::string(kCol0), std::string(kCol1), std::string(kCol2)},
+        {makeFlatVector<velox::StringView>(col0Vals),
+         makeFlatVector<int32_t>(keyValues),
+         makeFlatVector<velox::StringView>(col2Vals)});
+  }
+
+  // Builds a mock createMetadataSection function that stores sections
+  // in memory and returns MetadataSection with sequential offsets.
+  struct MockSectionStore {
+    std::vector<std::string> sections;
+    uint64_t nextOffset{0};
+
+    CreateMetadataSectionFn createFn() {
+      return [this](std::string_view content) -> MetadataSection {
+        const auto offset = nextOffset;
+        const auto size = content.size();
+        sections.emplace_back(content);
+        nextOffset += size;
+        return MetadataSection{
+            offset, static_cast<uint32_t>(size), CompressionType::Uncompressed};
+      };
+    }
+  };
+
+  // Captures the directory written by close().
+  static WriteOptionalSectionFn writeFn(std::string& output) {
+    return [&output](const std::string& /*name*/, std::string_view content) {
+      output = std::string(content);
+    };
+  }
+
+  // No-op write function for tests that don't inspect the output.
+  static WriteOptionalSectionFn noopWriteFn() {
+    return [](const std::string&, std::string_view) {};
+  }
+
+  // Validates the HashIndexDirectory has the expected indices with the
+  // expected column names per index.
+  static void validateDirectory(
+      const std::string& directory,
+      const std::vector<std::vector<std::string>>& expectedColumns) {
+    const auto* root = flatbuffers::GetRoot<serialization::HashIndexDirectory>(
+        directory.data());
+    ASSERT_NE(root, nullptr);
+    const auto* indices = root->indices();
+    ASSERT_NE(indices, nullptr);
+    ASSERT_EQ(indices->size(), expectedColumns.size());
+
+    for (size_t idx = 0; idx < expectedColumns.size(); ++idx) {
+      SCOPED_TRACE(fmt::format("index {}", idx));
+      const auto* section = indices->Get(idx);
+      ASSERT_NE(section, nullptr);
+      const auto* columns = section->index_columns();
+      ASSERT_NE(columns, nullptr);
+      ASSERT_EQ(columns->size(), expectedColumns[idx].size());
+      for (size_t i = 0; i < expectedColumns[idx].size(); ++i) {
+        EXPECT_EQ(columns->Get(i)->string_view(), expectedColumns[idx][i]);
+      }
+    }
+  }
+
+  // Validates the HashIndex FlatBuffer has the expected row/key counts
+  // and valid partition structure. If expectedNumPartitions is 0, only
+  // validates at least one partition exists.
+  static void validateIndex(
+      const std::string& indexSection,
+      uint64_t expectedNumKeys,
+      uint32_t expectedNumPartitions = 0) {
+    const auto* hashIndex =
+        flatbuffers::GetRoot<serialization::HashIndex>(indexSection.data());
+    ASSERT_NE(hashIndex, nullptr);
+    EXPECT_EQ(hashIndex->row_count(), expectedNumKeys);
+    EXPECT_EQ(hashIndex->num_keys(), expectedNumKeys);
+    EXPECT_GT(hashIndex->num_buckets(), 0u);
+
+    const auto* partitionSections = hashIndex->partition_sections();
+    ASSERT_NE(partitionSections, nullptr);
+    if (expectedNumPartitions > 0) {
+      EXPECT_EQ(partitionSections->size(), expectedNumPartitions);
+    } else {
+      EXPECT_GE(partitionSections->size(), 1u);
+    }
+
+    const auto* partitionStartBuckets = hashIndex->partition_start_buckets();
+    ASSERT_NE(partitionStartBuckets, nullptr);
+    EXPECT_EQ(partitionStartBuckets->size(), partitionSections->size());
+  }
+
+  velox::RowTypePtr type_;
+  std::vector<std::string> col0Strings_;
+};
+
+// Non-parameterized fixture for tests with specific column configs.
+class HashIndexWriterTest : public HashIndexWriterTestBase,
+                            public testing::Test {
+ public:
+  static void SetUpTestCase() {
+    velox::memory::MemoryManager::testingSetInstance({});
+  }
+
+ protected:
+  void SetUp() override {
+    setupType();
+  }
+};
+
+// Parameterized fixture: runs with single-column and composite-key configs.
+struct HashIndexWriterTestParam {
+  std::vector<std::string> columns;
+
+  std::string debugString() const {
+    return fmt::format("columns: [{}]", fmt::join(columns, ", "));
+  }
+};
+
+class HashIndexWriterParamTest
+    : public HashIndexWriterTestBase,
+      public testing::TestWithParam<HashIndexWriterTestParam> {
+ public:
+  static void SetUpTestCase() {
+    velox::memory::MemoryManager::testingSetInstance({});
+  }
+
+ protected:
+  void SetUp() override {
+    setupType();
+  }
+
+  HashIndexConfig config() const {
+    return HashIndexConfig{.columns = GetParam().columns};
+  }
+};
+
+INSTANTIATE_TEST_SUITE_P(
+    SingleAndCompositeKey,
+    HashIndexWriterParamTest,
+    testing::Values(
+        HashIndexWriterTestParam{{"col1"}},
+        HashIndexWriterTestParam{{"col0", "col1"}}),
+    [](const testing::TestParamInfo<HashIndexWriterTestParam>& info) {
+      return fmt::format("columns_{}", fmt::join(info.param.columns, "_"));
+    });
+
+TEST_F(HashIndexWriterTest, createWithEmptyConfigs) {
+  auto writer = HashIndexWriter::create({}, type_, pool_.get());
+  EXPECT_EQ(writer, nullptr);
+}
+
+TEST_F(HashIndexWriterTest, createWithValidConfig) {
+  auto writer = HashIndexWriter::create({config({"col1"})}, type_, pool_.get());
+  EXPECT_NE(writer, nullptr);
+}
+
+TEST_F(HashIndexWriterTest, createWithNullPool) {
+  NIMBLE_ASSERT_THROW(
+      HashIndexWriter::create({config({"col1"})}, type_, nullptr),
+      "memory pool must not be null");
+}
+
+TEST_F(HashIndexWriterTest, createWithInvalidConfig) {
+  {
+    SCOPED_TRACE("empty columns");
+    HashIndexConfig config{.columns = {}};
+    NIMBLE_ASSERT_THROW(
+        HashIndexWriter::create({config}, type_, pool_.get()),
+        "Hash index must have at least one column");
+  }
+
+  {
+    SCOPED_TRACE("zero load factor");
+    HashIndexConfig config{.columns = {"col1"}, .loadFactor = 0.0f};
+    NIMBLE_ASSERT_THROW(
+        HashIndexWriter::create({config}, type_, pool_.get()),
+        "Load factor must be positive");
+  }
+
+  {
+    SCOPED_TRACE("negative load factor");
+    HashIndexConfig config{.columns = {"col1"}, .loadFactor = -0.5f};
+    NIMBLE_ASSERT_THROW(
+        HashIndexWriter::create({config}, type_, pool_.get()),
+        "Load factor must be positive");
+  }
+
+  {
+    SCOPED_TRACE("load factor > 1.0");
+    HashIndexConfig config{.columns = {"col1"}, .loadFactor = 1.5f};
+    NIMBLE_ASSERT_THROW(
+        HashIndexWriter::create({config}, type_, pool_.get()),
+        "Load factor must be at most 1.0");
+  }
+
+  {
+    SCOPED_TRACE("non-existent column");
+    HashIndexConfig config{.columns = {"non_existent"}};
+    VELOX_ASSERT_USER_THROW(
+        HashIndexWriter::create({config}, type_, pool_.get()),
+        "Field not found");
+  }
+}
+
+TEST_F(HashIndexWriterTest, createWithDuplicateColumns) {
+  // Exact duplicate columns.
+  NIMBLE_ASSERT_THROW(
+      HashIndexWriter::create(
+          {config({"col1"}), config({"col1"})}, type_, pool_.get()),
+      "Duplicate hash index columns");
+
+  // Duplicate multi-column index.
+  NIMBLE_ASSERT_THROW(
+      HashIndexWriter::create(
+          {config({"col0", "col1"}), config({"col0", "col1"})},
+          type_,
+          pool_.get()),
+      "Duplicate hash index columns");
+
+  // Same columns in different order are allowed (different index).
+  auto writer = HashIndexWriter::create(
+      {config({"col0", "col1"}), config({"col1", "col0"})}, type_, pool_.get());
+  EXPECT_NE(writer, nullptr);
+}
+
+TEST_F(HashIndexWriterTest, createMultipleIndices) {
+  auto writer = HashIndexWriter::create(
+      {config({"col1"}), config({"col0", "col2"})}, type_, pool_.get());
+  ASSERT_NE(writer, nullptr);
+
+  HashIndexWriterTestHelper helper(writer.get());
+  EXPECT_EQ(helper.numAccumulators(), 2);
+}
+
+TEST_P(HashIndexWriterParamTest, writeEmptyVector) {
+  auto writer = HashIndexWriter::create({config()}, type_, pool_.get());
+  ASSERT_NE(writer, nullptr);
+
+  auto emptyBatch = makeInput({});
+  writer->write(emptyBatch);
+
+  HashIndexWriterTestHelper helper(writer.get());
+  EXPECT_EQ(helper.numRows(), 0);
+  EXPECT_EQ(helper.numEntries(0), 0);
+
+  MockSectionStore store;
+  bool writeCalled = false;
+  writer->close(store.createFn(), [&](const std::string&, std::string_view) {
+    writeCalled = true;
+  });
+  EXPECT_FALSE(writeCalled);
+  EXPECT_TRUE(store.sections.empty());
+}
+
+TEST_P(HashIndexWriterParamTest, writeSingleBatch) {
+  auto writer = HashIndexWriter::create({config()}, type_, pool_.get());
+  ASSERT_NE(writer, nullptr);
+
+  writer->write(makeInput({1, 2, 3, 4, 5}));
+
+  HashIndexWriterTestHelper helper(writer.get());
+  EXPECT_EQ(helper.numRows(), 5);
+  EXPECT_EQ(helper.numEntries(0), 5);
+
+  MockSectionStore store;
+  std::string directory;
+  writer->close(store.createFn(), writeFn(directory));
+
+  const auto& columns = GetParam().columns;
+  validateDirectory(directory, {columns});
+  validateIndex(store.sections.back(), 5, /*expectedNumPartitions=*/1);
+}
+
+TEST_P(HashIndexWriterParamTest, writeMultipleBatches) {
+  auto writer = HashIndexWriter::create({config()}, type_, pool_.get());
+  ASSERT_NE(writer, nullptr);
+
+  writer->write(makeInput({1, 2, 3}));
+  writer->write(makeInput({4, 5}));
+  writer->write(makeInput({6, 7, 8, 9}));
+
+  HashIndexWriterTestHelper helper(writer.get());
+  EXPECT_EQ(helper.numRows(), 9);
+  EXPECT_EQ(helper.numEntries(0), 9);
+
+  MockSectionStore store;
+  std::string directory;
+  writer->close(store.createFn(), writeFn(directory));
+
+  const auto& columns = GetParam().columns;
+  validateDirectory(directory, {columns});
+  validateIndex(store.sections.back(), 9, /*expectedNumPartitions=*/1);
+}
+
+TEST_P(HashIndexWriterParamTest, writeWithEmptyBatchesMixed) {
+  auto writer = HashIndexWriter::create({config()}, type_, pool_.get());
+  ASSERT_NE(writer, nullptr);
+
+  writer->write(makeInput({}));
+  writer->write(makeInput({1, 2}));
+  writer->write(makeInput({}));
+  writer->write(makeInput({3}));
+  writer->write(makeInput({}));
+
+  HashIndexWriterTestHelper helper(writer.get());
+  EXPECT_EQ(helper.numRows(), 3);
+  EXPECT_EQ(helper.numEntries(0), 3);
+
+  MockSectionStore store;
+  std::string directory;
+  writer->close(store.createFn(), writeFn(directory));
+
+  const auto& columns = GetParam().columns;
+  validateDirectory(directory, {columns});
+  validateIndex(store.sections.back(), 3, /*expectedNumPartitions=*/1);
+}
+
+TEST_F(HashIndexWriterTest, rejectNullKeys) {
+  struct TestCase {
+    std::string name;
+    std::vector<std::string> columns;
+    std::vector<std::optional<velox::StringView>> col0;
+    std::vector<std::optional<int32_t>> col1;
+    bool expectThrow;
+
+    std::string debugString() const {
+      return name;
+    }
+  };
+
+  const std::vector<TestCase> testCases = {
+      {
+          "single null in integer key",
+          {"col1"},
+          {{"a"}, {"b"}, {"c"}},
+          {1, std::nullopt, 3},
+          true,
+      },
+      {
+          "all nulls in integer key",
+          {"col1"},
+          {{"a"}, {"b"}, {"c"}},
+          {std::nullopt, std::nullopt, std::nullopt},
+          true,
+      },
+      {
+          "null in varchar key of composite index",
+          {"col0", "col1"},
+          {std::nullopt, {"b"}, {"c"}},
+          {1, 2, 3},
+          true,
+      },
+      {
+          "no nulls passes",
+          {"col1"},
+          {{"a"}, {"b"}, {"c"}},
+          {1, 2, 3},
+          false,
+      },
+      {
+          "no nulls composite passes",
+          {"col0", "col1"},
+          {{"a"}, {"b"}, {"c"}},
+          {1, 2, 3},
+          false,
+      },
+  };
+
+  for (const auto& tc : testCases) {
+    SCOPED_TRACE(tc.debugString());
+    auto writer =
+        HashIndexWriter::create({config(tc.columns)}, type_, pool_.get());
+    auto batch = makeRowVector(
+        {std::string(kCol0), std::string(kCol1), std::string(kCol2)},
+        {makeNullableFlatVector<velox::StringView>(tc.col0),
+         makeNullableFlatVector<int32_t>(tc.col1),
+         makeFlatVector<velox::StringView>({"d", "e", "f"})});
+
+    if (tc.expectThrow) {
+      NIMBLE_ASSERT_USER_THROW(
+          writer->write(batch),
+          "Null value not allowed in hash index key column");
+    } else {
+      EXPECT_NO_THROW(writer->write(batch));
+    }
+  }
+}
+
+TEST_P(HashIndexWriterParamTest, writeAfterCloseThrows) {
+  auto writer = HashIndexWriter::create({config()}, type_, pool_.get());
+  writer->write(makeInput({1}));
+
+  MockSectionStore store;
+  writer->close(store.createFn(), noopWriteFn());
+
+  NIMBLE_ASSERT_THROW(writer->write(makeInput({2})), "Cannot write after");
+}
+
+TEST_P(HashIndexWriterParamTest, doubleCloseThrows) {
+  auto writer = HashIndexWriter::create({config()}, type_, pool_.get());
+  writer->write(makeInput({1}));
+
+  MockSectionStore store;
+  writer->close(store.createFn(), noopWriteFn());
+
+  NIMBLE_ASSERT_THROW(
+      writer->close(store.createFn(), noopWriteFn()), "close() already called");
+}
+
+TEST_P(HashIndexWriterParamTest, rowCountOverflow) {
+  auto writer = HashIndexWriter::create({config()}, type_, pool_.get());
+  ASSERT_NE(writer, nullptr);
+
+  HashIndexWriterTestHelper helper(writer.get());
+  helper.setNumRows(std::numeric_limits<uint32_t>::max() - 5);
+
+  NIMBLE_ASSERT_USER_THROW(
+      writer->write(makeInput({1, 2, 3, 4, 5, 6, 7, 8, 9, 10})),
+      "Hash index row count exceeds uint32 limit");
+}
+
+TEST_F(HashIndexWriterTest, multipleIndices) {
+  auto writer = HashIndexWriter::create(
+      {config({"col1"}), config({"col0"})}, type_, pool_.get());
+  writer->write(makeInput({1, 2, 3}));
+
+  MockSectionStore store;
+  std::string directory;
+  writer->close(store.createFn(), writeFn(directory));
+
+  validateDirectory(directory, {{"col1"}, {"col0"}});
+  // store has: partition for index 0, index 0, partition for index 1, index 1.
+  ASSERT_GE(store.sections.size(), 4);
+  // Index sections are at positions 1 and 3 (after their partitions).
+  validateIndex(store.sections[1], 3, /*expectedNumPartitions=*/1);
+  validateIndex(store.sections[3], 3, /*expectedNumPartitions=*/1);
+}
+
+TEST_F(HashIndexWriterTest, withBloomFilter) {
+  struct TestCase {
+    std::string name;
+    std::optional<BloomFilterConfig> bloomFilter;
+    bool expectBloomFilter;
+
+    std::string debugString() const {
+      return name;
+    }
+  };
+
+  const std::vector<TestCase> testCases = {
+      {"enabled", BloomFilterConfig{}, true},
+      {"disabled", std::nullopt, false},
+  };
+
+  for (const auto& tc : testCases) {
+    SCOPED_TRACE(tc.debugString());
+    HashIndexConfig indexConfig{
+        .columns = {"col1"},
+        .bloomFilter = tc.bloomFilter,
+    };
+    auto writer = HashIndexWriter::create({indexConfig}, type_, pool_.get());
+    writer->write(makeInput({1, 2, 3, 4, 5}));
+
+    MockSectionStore store;
+    std::string directory;
+    writer->close(store.createFn(), writeFn(directory));
+
+    const auto* hashIndex = flatbuffers::GetRoot<serialization::HashIndex>(
+        store.sections.back().data());
+    ASSERT_NE(hashIndex, nullptr);
+    if (tc.expectBloomFilter) {
+      EXPECT_NE(hashIndex->bloom_filter(), nullptr);
+    } else {
+      EXPECT_EQ(hashIndex->bloom_filter(), nullptr);
+    }
+  }
+}
+
+TEST_F(HashIndexWriterTest, withPartitioning) {
+  HashIndexConfig config{
+      .columns = {"col1"},
+      // Very small partition size to force multiple partitions.
+      .maxPartitionSizeBytes = 32,
+  };
+  auto writer = HashIndexWriter::create({config}, type_, pool_.get());
+
+  // Write enough rows to exceed partition size.
+  std::vector<int32_t> values;
+  for (int i = 0; i < 100; ++i) {
+    values.push_back(i);
+  }
+  writer->write(makeInput(values));
+
+  MockSectionStore store;
+  std::string directory;
+  writer->close(store.createFn(), writeFn(directory));
+
+  validateDirectory(directory, {{"col1"}});
+  // The last section is the HashIndex; preceding sections are partitions.
+  // With 100 keys and 32-byte partition limit, expect multiple partitions.
+  const auto* hashIndex = flatbuffers::GetRoot<serialization::HashIndex>(
+      store.sections.back().data());
+  ASSERT_NE(hashIndex, nullptr);
+  ASSERT_NE(hashIndex->partition_sections(), nullptr);
+  EXPECT_GT(hashIndex->partition_sections()->size(), 1u);
+  validateIndex(store.sections.back(), 100);
+}
+
+TEST_F(HashIndexWriterTest, loadFactorVariations) {
+  struct TestParam {
+    float loadFactor;
+
+    std::string debugString() const {
+      return fmt::format("loadFactor: {}", loadFactor);
+    }
+  };
+
+  std::vector<TestParam> testSettings = {{0.1f}, {0.5f}, {0.7f}, {1.0f}};
+
+  for (const auto& testData : testSettings) {
+    SCOPED_TRACE(testData.debugString());
+
+    HashIndexConfig config{
+        .columns = {"col1"}, .loadFactor = testData.loadFactor};
+    auto writer = HashIndexWriter::create({config}, type_, pool_.get());
+
+    std::vector<int32_t> values;
+    for (int i = 0; i < 50; ++i) {
+      values.push_back(i);
+    }
+    writer->write(makeInput(values));
+
+    MockSectionStore store;
+    std::string directory;
+    writer->close(store.createFn(), writeFn(directory));
+
+    validateDirectory(directory, {{"col1"}});
+    validateIndex(store.sections.back(), 50, /*expectedNumPartitions=*/1);
+  }
+}
+
+TEST_P(HashIndexWriterParamTest, duplicateKeysAllowed) {
+  auto writer = HashIndexWriter::create({config()}, type_, pool_.get());
+
+  writer->write(makeInput({1, 1, 2, 2, 3}));
+
+  HashIndexWriterTestHelper helper(writer.get());
+  EXPECT_EQ(helper.numRows(), 5);
+  EXPECT_EQ(helper.numEntries(0), 5);
+
+  MockSectionStore store;
+  std::string directory;
+  writer->close(store.createFn(), writeFn(directory));
+
+  validateDirectory(directory, {GetParam().columns});
+  validateIndex(store.sections.back(), 5, /*expectedNumPartitions=*/1);
+}
+
+} // namespace
+} // namespace facebook::nimble::index::test

--- a/dwio/nimble/index/tests/IndexLookupTest.cpp
+++ b/dwio/nimble/index/tests/IndexLookupTest.cpp
@@ -174,21 +174,26 @@ TEST_F(IndexLookupTest, nonMonotonicOffsets) {
 
 TEST_F(IndexLookupTest, toString) {
   EXPECT_EQ(toString(IndexType::Cluster), "Cluster");
-  EXPECT_EQ(toString(IndexType::Dense), "Dense");
+  EXPECT_EQ(toString(IndexType::Hash), "Hash");
 }
 
 TEST_F(IndexLookupTest, ostream) {
   std::ostringstream oss;
-  oss << IndexType::Cluster << " " << IndexType::Dense;
-  EXPECT_EQ(oss.str(), "Cluster Dense");
+  oss << IndexType::Cluster << " " << IndexType::Hash;
+  EXPECT_EQ(oss.str(), "Cluster Hash");
 }
 
 TEST_F(IndexLookupTest, fmtFormat) {
   EXPECT_EQ(fmt::format("{}", IndexType::Cluster), "Cluster");
-  EXPECT_EQ(fmt::format("{}", IndexType::Dense), "Dense");
+  EXPECT_EQ(fmt::format("{}", IndexType::Hash), "Hash");
   EXPECT_EQ(
-      fmt::format("type={}, count={}", IndexType::Dense, 42),
-      "type=Dense, count=42");
+      fmt::format("type={}, count={}", IndexType::Hash, 42),
+      "type=Hash, count=42");
+}
+
+TEST_F(IndexLookupTest, unknownIndexType) {
+  const auto unknown = static_cast<IndexType>(99);
+  NIMBLE_ASSERT_THROW(toString(unknown), "Unknown IndexType: 99");
 }
 
 } // namespace

--- a/dwio/nimble/tablet/CMakeLists.txt
+++ b/dwio/nimble/tablet/CMakeLists.txt
@@ -81,20 +81,20 @@ target_include_directories(
 add_dependencies(nimble_bloom_filter_fb nimble_bloom_filter_schema_fb)
 
 build_flatbuffers(
-  "${CMAKE_CURRENT_SOURCE_DIR}/DenseIndex.fbs"
+  "${CMAKE_CURRENT_SOURCE_DIR}/HashIndex.fbs"
   "${CMAKE_CURRENT_SOURCE_DIR}"
-  nimble_dense_index_schema_fb
+  nimble_hash_index_schema_fb
   ""
   "${CMAKE_CURRENT_BINARY_DIR}"
   ""
   ""
 )
-add_library(nimble_dense_index_fb INTERFACE)
+add_library(nimble_hash_index_fb INTERFACE)
 target_include_directories(
-  nimble_dense_index_fb
+  nimble_hash_index_fb
   INTERFACE ${PROJECT_BINARY_DIR} ${FLATBUFFERS_INCLUDE_DIR}
 )
-add_dependencies(nimble_dense_index_fb nimble_dense_index_schema_fb)
+add_dependencies(nimble_hash_index_fb nimble_hash_index_schema_fb)
 
 add_library(nimble_tablet_common Compression.cpp MetadataBuffer.cpp)
 target_link_libraries(
@@ -108,6 +108,7 @@ add_library(nimble_tablet_reader FileLayout.cpp TabletReader.cpp)
 target_link_libraries(
   nimble_tablet_reader
   PUBLIC nimble_tablet_common nimble_cluster_index_fb nimble_chunk_index_fb
+    nimble_hash_index_fb
 )
 
 add_library(nimble_tablet_writer ChunkIndexWriter.cpp TabletWriter.cpp)

--- a/dwio/nimble/tablet/Constants.h
+++ b/dwio/nimble/tablet/Constants.h
@@ -36,6 +36,6 @@ constexpr std::string_view kVectorizedStatsSection =
     "columnar.vectorized_stats";
 constexpr std::string_view kClusterIndexSection = "columnar.cluster.index";
 constexpr std::string_view kChunkIndexSection = "columnar.chunk.index";
-constexpr std::string_view kDenseIndexSection = "columnar.dense.index";
+constexpr std::string_view kHashIndexSection = "columnar.hash.index";
 
 } // namespace facebook::nimble

--- a/dwio/nimble/tablet/HashIndex.fbs
+++ b/dwio/nimble/tablet/HashIndex.fbs
@@ -19,7 +19,7 @@ include "Footer.fbs";
 
 namespace facebook.nimble.serialization;
 
-/// A single dense hash index on a set of composite key columns.
+/// A single hash index on a set of composite key columns.
 /// Uses a two-level hash table: bucket directory + key arrays.
 ///
 /// Lookup flow:
@@ -27,7 +27,7 @@ namespace facebook.nimble.serialization;
 ///   2. Hash(encodedKey) mod num_buckets → bucket
 ///   3. Scan keys in bucket by exact key match
 ///   4. Return matching row numbers
-table DenseIndex {
+table HashIndex {
   /// Total number of rows indexed.
   row_count:uint64;
 
@@ -43,27 +43,26 @@ table DenseIndex {
   bloom_filter:BloomFilter;
 
   /// Partitions. The hash table is always split into one or more partitions,
-  /// each stored as a separate DenseIndexPartition section. Small indices
+  /// each stored as a separate HashIndexPartition section. Small indices
   /// use a single partition; large indices are split by maxPartitionSizeBytes.
   /// Starting bucket index in the global bucket space (inclusive).
-  /// Size = partition_count.
+  /// Size = partition_count. Bucket count for partition i is derived from
+  /// partition_start_buckets[i+1] - partition_start_buckets[i], or
+  /// num_buckets - partition_start_buckets[i] for the last partition.
   partition_start_buckets:[uint32];
-  /// Number of buckets in each partition.
-  /// Size = partition_count.
-  partition_bucket_counts:[uint32];
-  /// References to the serialized DenseIndexPartition for each partition.
+  /// References to the serialized HashIndexPartition for each partition.
   /// Size = partition_count.
   partition_sections:[MetadataSection];
 }
 
-/// Data for a single partition of a dense index.
+/// Data for a single partition of a hash index.
 /// Stored as a separate section, loaded on-demand during lookup.
-table DenseIndexPartition {
-  /// Bucket directory for this partition. Indices are relative to the
-  /// partition's key arrays (encoded_keys and row_numbers).
+table HashIndexPartition {
+  /// Bucket directory for this partition. Size = bucketCount + 1.
+  /// bucket_offsets[i] is the start index and bucket_offsets[i+1] is the
+  /// end index (exclusive) in encoded_keys/row_numbers for bucket i.
+  /// The last element is the total number of entries.
   bucket_offsets:[uint32];
-  /// Number of keys in each bucket.
-  bucket_counts:[uint16];
   /// Binary-encoded composite keys for this partition. Aligned with
   /// row_numbers: encoded_keys[i] corresponds to row_numbers[i].
   encoded_keys:[string];
@@ -71,26 +70,26 @@ table DenseIndexPartition {
   row_numbers:[uint32];
 }
 
-/// Lightweight descriptor for a dense index.
+/// Lightweight descriptor for a hash index.
 /// Stores the index columns for lookup dispatch and a MetadataSection
-/// pointing to the serialized DenseIndex data.
-table DenseIndexSection {
+/// pointing to the serialized HashIndex data.
+table HashIndexSection {
   /// Names of columns forming the composite key.
   /// Duplicated here so the reader can find the right index
-  /// without loading the full DenseIndex data.
+  /// without loading the full HashIndex data.
   index_columns:[string];
-  /// Reference to the serialized DenseIndex stored as a
+  /// Reference to the serialized HashIndex stored as a
   /// separate section in the file.
   section:MetadataSection;
 }
 
-/// Root table for the dense index optional section.
-/// Supports multiple independent dense indices per file,
+/// Root table for the hash index optional section.
+/// Supports multiple independent hash indices per file,
 /// each on a different set of composite key columns.
-/// Stored in optional section "columnar.dense.index".
-table DenseIndexDirectory {
-  /// One descriptor per dense index defined on the file.
-  indices:[DenseIndexSection];
+/// Stored in optional section "columnar.hash.index".
+table HashIndexDirectory {
+  /// One descriptor per hash index defined on the file.
+  indices:[HashIndexSection];
 }
 
-root_type DenseIndexDirectory;
+root_type HashIndexDirectory;

--- a/dwio/nimble/tablet/TabletReader.cpp
+++ b/dwio/nimble/tablet/TabletReader.cpp
@@ -348,6 +348,10 @@ void TabletReader::init(const Options& options) {
     preloadChunkIndex(footerIoBuf);
   }
 
+  if (options.loadDenseIndexes) {
+    initDenseIndexes();
+  }
+
   cacheMetadata(footerIoBuf, footerIoOffset);
 }
 
@@ -729,6 +733,9 @@ bool TabletReader::tryInitFromCache(const Options& options) {
   }
   if (options.loadChunkIndex) {
     initChunkIndex();
+  }
+  if (options.loadDenseIndexes) {
+    initDenseIndexes();
   }
   return true;
 }
@@ -1122,6 +1129,30 @@ void TabletReader::initClusterIndex() {
             region.length,
             *pool_,
             velox::dwio::common::LogType::GROUP_INDEX);
+      },
+      pool_);
+}
+
+const index::HashIndex* TabletReader::denseIndex(
+    const std::vector<std::string>& columns) const {
+  if (denseIndexRegistry_ == nullptr) {
+    return nullptr;
+  }
+  return denseIndexRegistry_->findIndex(columns);
+}
+
+void TabletReader::initDenseIndexes() {
+  auto section =
+      loadOptionalSection(std::string{kHashIndexSection}, /*keepCache=*/false);
+  if (!section.has_value()) {
+    return;
+  }
+
+  denseIndexRegistry_ = DenseIndexRegistry::create(
+      std::move(section.value()),
+      [this](const MetadataSection& metadataSection) {
+        return readMetadata(
+            metadataSection, velox::dwio::common::LogType::FOOTER);
       },
       pool_);
 }

--- a/dwio/nimble/tablet/TabletReader.h
+++ b/dwio/nimble/tablet/TabletReader.h
@@ -25,6 +25,7 @@
 #include "dwio/nimble/index/ChunkIndex.h"
 #include "dwio/nimble/index/ChunkIndexGroup.h"
 #include "dwio/nimble/index/ClusterIndex.h"
+#include "dwio/nimble/index/HashIndex.h"
 #include "dwio/nimble/tablet/Constants.h"
 #include "dwio/nimble/tablet/FileLayout.h"
 #include "dwio/nimble/tablet/MetadataBuffer.h"
@@ -138,6 +139,8 @@ class StripeIdentifier {
 };
 
 using index::ClusterIndex;
+using index::DenseIndexRegistry;
+using index::HashIndex;
 
 /// Provides read access to a tablet written by a TabletWriter.
 /// Example usage to read all streams from stripe 0 in a file:
@@ -163,6 +166,9 @@ class TabletReader {
 
     /// Whether to load the chunk index during initialization. Default true.
     bool loadChunkIndex{true};
+
+    /// Whether to load the dense indexes during initialization. Default true.
+    bool loadDenseIndexes{true};
 
     /// Non-owning pointer to a BufferedInput for metadata reads. When set,
     /// TabletReader clones this internally for its own metadata IO. When
@@ -251,6 +257,10 @@ class TabletReader {
   const ClusterIndex* clusterIndex() const {
     return clusterIndex_.get();
   }
+
+  /// Finds the dense index matching the given columns, or nullptr if none.
+  const index::HashIndex* denseIndex(
+      const std::vector<std::string>& columns) const;
 
   uint64_t fileSize() const {
     return fileSize_;
@@ -487,6 +497,8 @@ class TabletReader {
       std::unique_ptr<velox::dwio::common::SeekableInputStream> stream,
       const MetadataSection& section) const;
 
+  void initDenseIndexes();
+
   void initChunkIndex();
 
   // Returns the cached ChunkIndexGroup for the given stripe group index.
@@ -530,6 +542,9 @@ class TabletReader {
 
   // Index related fields.
   std::unique_ptr<ClusterIndex> clusterIndex_;
+
+  // Dense index registry, loaded from "columnar.hash.index" optional section.
+  std::unique_ptr<DenseIndexRegistry> denseIndexRegistry_;
 
   // Chunk index root, loaded from "chunk_index" optional section.
   std::unique_ptr<ChunkIndex> chunkIndex_;

--- a/dwio/nimble/tablet/TabletWriter.cpp
+++ b/dwio/nimble/tablet/TabletWriter.cpp
@@ -404,17 +404,16 @@ void TabletWriter::invokeCloseCallback() {
   if (options_.closeCallback == nullptr) {
     return;
   }
-  auto writeOptionalSectionFn =
-      [this](std::string name, std::string_view content) {
-        writeOptionalSection(std::move(name), content);
-      };
   auto createMetadataFn = [this](std::string_view metadata) {
     return createMetadataSection(metadata);
   };
-  options_.closeCallback(writeOptionalSectionFn, createMetadataFn);
+  auto writeMetadataFn = [this](std::string name, std::string_view content) {
+    writeOptionalSection(std::move(name), content);
+  };
+  options_.closeCallback(createMetadataFn, writeMetadataFn);
 }
 
-void TabletWriter::invokeStripeGroupFlushCallback(size_t stripeCount) {
+void TabletWriter::invokeStripeGroupFlushCallback() {
   if (options_.stripeGroupFlushCallback == nullptr) {
     return;
   }
@@ -429,7 +428,7 @@ void TabletWriter::invokeStripeGroupFlushCallback(size_t stripeCount) {
   auto createMetadataFn = [this](std::string_view metadata) {
     return createMetadataSection(metadata);
   };
-  options_.stripeGroupFlushCallback(stripeCount, writeDataFn, createMetadataFn);
+  options_.stripeGroupFlushCallback(writeDataFn, createMetadataFn);
 }
 
 void TabletWriter::writeOptionalSection(
@@ -541,7 +540,7 @@ void TabletWriter::tryWriteStripeGroup(bool force) {
 
   writeChunkIndexGroup(streamCount, stripeCount);
 
-  invokeStripeGroupFlushCallback(stripeCount);
+  invokeStripeGroupFlushCallback();
 
   finishStripeGroup();
 }

--- a/dwio/nimble/tablet/TabletWriter.h
+++ b/dwio/nimble/tablet/TabletWriter.h
@@ -51,16 +51,15 @@ class TabletWriter {
   /// Called AFTER stripe group and chunk index metadata are written.
   /// Writes partition data (key stream + metadata) aligned with stripe groups.
   using StripeGroupFlushCallback = std::function<void(
-      size_t stripeCount,
-      const WriteDataFn& writeData,
-      const CreateMetadataSectionFn& createMetadataSection)>;
+      const WriteDataFn& writeDataFn,
+      const CreateMetadataSectionFn& createMetadataFn)>;
 
   /// Called during close() after all stripe groups have been flushed,
   /// before the chunk index root and footer are written. Used by index
   /// writers to finalize and write the root index as an optional section.
   using CloseCallback = std::function<void(
-      const WriteOptionalSectionFn& writeOptionalSection,
-      const CreateMetadataSectionFn& createMetadataSection)>;
+      const CreateMetadataSectionFn& createMetadataFn,
+      const WriteOptionalSectionFn& writeMetadataFn)>;
 
   struct Options {
     std::unique_ptr<LayoutPlanner> layoutPlanner{nullptr};
@@ -109,7 +108,7 @@ class TabletWriter {
   // a vector of content to be concatenated. Right now the Buffer class prevents
   // us from draining its content incrementally.
   void invokeCloseCallback();
-  void invokeStripeGroupFlushCallback(size_t stripeCount);
+  void invokeStripeGroupFlushCallback();
 
   void writeOptionalSection(std::string name, std::string_view content);
 

--- a/dwio/nimble/velox/VeloxWriter.cpp
+++ b/dwio/nimble/velox/VeloxWriter.cpp
@@ -676,6 +676,10 @@ VeloxWriter::VeloxWriter(
           context_->options().clusterIndexConfig,
           type,
           &(*context_->bufferMemoryPool()))},
+      hashIndexWriter_{index::HashIndexWriter::create(
+          context_->options().hashIndexConfigs,
+          type,
+          &(*context_->bufferMemoryPool()))},
       tabletWriter_{TabletWriter::create(
           file_.get(),
           *encodingMemoryPool_,
@@ -694,19 +698,17 @@ VeloxWriter::VeloxWriter(
            .stripeGroupFlushCallback = clusterIndexWriter_ != nullptr
                ? TabletWriter::StripeGroupFlushCallback(
                      [this](
-                         size_t stripeCount,
-                         const WriteDataFn& writeData,
-                         const CreateMetadataSectionFn& createMetadataSection) {
-                       clusterIndexWriter_->flushPartition(
-                           stripeCount, writeData, createMetadataSection);
+                         const WriteDataFn& writeDataFn,
+                         const CreateMetadataSectionFn& createMetadataFn) {
+                       clusterIndexWriter_->flush(
+                           writeDataFn, createMetadataFn);
                      })
                : nullptr,
-           .closeCallback =
-               [this](
-                   const WriteOptionalSectionFn& writeOptionalSection,
-                   const CreateMetadataSectionFn& createMetadataSection) {
-                 writeIndexes(createMetadataSection, writeOptionalSection);
-               }})} {
+           .closeCallback = [this](
+                                const CreateMetadataSectionFn& createMetadataFn,
+                                const WriteOptionalSectionFn& writeMetadataFn) {
+             writeIndexes(createMetadataFn, writeMetadataFn);
+           }})} {
   NIMBLE_CHECK_NOT_NULL(file_);
 
   // Register handler for dynamically discovered FlatMap keys before creating
@@ -872,10 +874,15 @@ bool VeloxWriter::hasClusterIndex() const {
   return clusterIndexWriter_ != nullptr;
 }
 
+bool VeloxWriter::hasHashIndex() const {
+  return hashIndexWriter_ != nullptr;
+}
+
 void VeloxWriter::addIndexKey(
     const velox::VectorPtr& input,
     velox::dwio::common::ExecutorBarrier* barrier) {
   addClusterIndexKey(input, barrier);
+  addHashIndexKey(input, barrier);
 }
 
 void VeloxWriter::addClusterIndexKey(
@@ -891,16 +898,27 @@ void VeloxWriter::addClusterIndexKey(
   }
 }
 
+void VeloxWriter::addHashIndexKey(
+    const velox::VectorPtr& input,
+    velox::dwio::common::ExecutorBarrier* barrier) {
+  if (!hasHashIndex()) {
+    return;
+  }
+  if (barrier != nullptr) {
+    barrier->add([&]() { hashIndexWriter_->write(input); });
+  } else {
+    hashIndexWriter_->write(input);
+  }
+}
+
 void VeloxWriter::writeIndexes(
-    const CreateMetadataSectionFn& createMetadataSection,
-    const WriteOptionalSectionFn& writeOptionalSection) {
+    const CreateMetadataSectionFn& createMetadataFn,
+    const WriteOptionalSectionFn& writeMetadataFn) {
+  if (hasHashIndex()) {
+    hashIndexWriter_->close(createMetadataFn, writeMetadataFn);
+  }
   if (hasClusterIndex()) {
-    const auto serialized =
-        clusterIndexWriter_->finalize(createMetadataSection);
-    if (!serialized.empty()) {
-      writeOptionalSection(std::string(kClusterIndexSection), serialized);
-    }
-    clusterIndexWriter_->close();
+    clusterIndexWriter_->close(createMetadataFn, writeMetadataFn);
   }
 }
 

--- a/dwio/nimble/velox/VeloxWriter.h
+++ b/dwio/nimble/velox/VeloxWriter.h
@@ -17,6 +17,7 @@
 
 #include "dwio/nimble/common/Buffer.h"
 #include "dwio/nimble/index/ClusterIndexWriter.h"
+#include "dwio/nimble/index/HashIndexWriter.h"
 #include "dwio/nimble/tablet/TabletWriter.h"
 #include "dwio/nimble/velox/FieldWriter.h"
 #include "dwio/nimble/velox/VeloxWriterOptions.h"
@@ -89,14 +90,20 @@ class VeloxWriter {
 
  private:
   inline bool hasClusterIndex() const;
-  // Adds index keys to the cluster index writer.
-  // If barrier is provided, the processing will be added to the barrier
+  inline bool hasHashIndex() const;
+
+  // Adds index keys to all configured index writers (cluster index and hash
+  // index). If barrier is provided, the processing will be added to the barrier
   // for parallel execution.
   void addIndexKey(
       const velox::VectorPtr& input,
       velox::dwio::common::ExecutorBarrier* barrier = nullptr);
 
   void addClusterIndexKey(
+      const velox::VectorPtr& input,
+      velox::dwio::common::ExecutorBarrier* barrier = nullptr);
+
+  void addHashIndexKey(
       const velox::VectorPtr& input,
       velox::dwio::common::ExecutorBarrier* barrier = nullptr);
 
@@ -161,8 +168,8 @@ class VeloxWriter {
   void writeSchema();
   // Finalizes and writes all indexes. Called via TabletWriter close callback.
   void writeIndexes(
-      const CreateMetadataSectionFn& createMetadataSection,
-      const WriteOptionalSectionFn& writeOptionalSection);
+      const CreateMetadataSectionFn& createMetadataFn,
+      const WriteOptionalSectionFn& writeMetadataFn);
 
   void ensureEncodingBuffer();
   void clearEncodingBuffer();
@@ -176,6 +183,7 @@ class VeloxWriter {
   const std::unique_ptr<detail::WriterContext> context_;
   std::unique_ptr<velox::WriteFile> file_;
   const std::unique_ptr<index::ClusterIndexWriter> clusterIndexWriter_;
+  const std::unique_ptr<index::HashIndexWriter> hashIndexWriter_;
   const std::unique_ptr<TabletWriter> tabletWriter_;
 
   std::unique_ptr<FieldWriter> rootWriter_;

--- a/dwio/nimble/velox/VeloxWriterOptions.h
+++ b/dwio/nimble/velox/VeloxWriterOptions.h
@@ -67,6 +67,11 @@ struct VeloxWriterOptions {
   /// writing. The index stores the per-chunk min and max key for each stripe.
   std::optional<ClusterIndexConfig> clusterIndexConfig;
 
+  /// Hash index configurations. Each config builds an independent hash-based
+  /// point lookup index on the specified columns. Unlike cluster index, hash
+  /// index does not require sorted data.
+  std::vector<HashIndexConfig> hashIndexConfigs;
+
   // Columns that should be encoded as flat maps. Maps column name to a set
   /// of predefined key strings. When the set is empty, the column is
   /// treated as a flat map with dynamic key discovery. When non-empty, keys


### PR DESCRIPTION
Summary:

CONTEXT: The cluster index only supports sorted data with range-based lookups. For unsorted data, we need a hash-based index for efficient point lookups.

WHAT: Adds HashIndex and HashIndexWriter for hash-based point lookups on unsorted data.

Write path (HashIndexWriter):
- Accumulates encoded keys and file row numbers during writing
- Builds hash tables with configurable load factor and optional bloom filter at file close
- Supports on-demand partitioning for large indices (maxPartitionSizeBytes)
- Serialized as FlatBuffer in the "columnar.hash.index" optional section

Read path (HashIndex):
- Hash(key) mod numBuckets to find bucket, then exact key match within bucket
- Optional bloom filter for fast negative lookups
- Partitions loaded on-demand and cached via MetadataCache
- Implements IndexLookup interface with stats() reporting (numLookups, numBloomFilterSkips, numMatchedRows)

Integration:
- DenseIndexRegistry on TabletReader for index discovery by column names
- HashIndexConfig on VeloxWriterOptions for write-time configuration
- IndexLookup base class extended with virtual stats() returning F14FastMap<string, RuntimeMetric>

Serialization:
- HashIndexPartition uses bucketCount+1 offsets (no separate counts array)
- HashIndexDirectory stores per-index column names and section references
- ClusterIndexWriter refactored: close() now finalizes and writes in one step (removed separate finalize())

Differential Revision: D102001732
