### PR TITLE
feat: Add sorted index for point lookups and range scans (#676)

### DIFF
--- a/dwio/nimble/index/CMakeLists.txt
+++ b/dwio/nimble/index/CMakeLists.txt
@@ -18,10 +18,15 @@ add_library(
   ChunkIndexGroup.cpp
   ClusterIndex.cpp
   ClusterIndexWriter.cpp
+  DenseIndexRegistry.cpp
   HashIndex.cpp
   HashIndexWriter.cpp
   IndexFilter.cpp
+  KeyChunkDecoder.cpp
+  SortedIndex.cpp
+  SortedIndexWriter.cpp
   IndexLookup.cpp
+  IndexWriter.cpp
   SortOrder.cpp
 )
 
@@ -34,6 +39,7 @@ target_link_libraries(
   nimble_chunk_index_fb
   nimble_hash_index_fb
   nimble_bloom_filter_fb
+  nimble_sorted_index_fb
   velox_core
   velox_type
   velox_vector

--- a/dwio/nimble/index/ClusterIndex.cpp
+++ b/dwio/nimble/index/ClusterIndex.cpp
@@ -18,11 +18,9 @@
 
 #include <algorithm>
 
-#include "dwio/nimble/common/ChunkHeader.h"
 #include "dwio/nimble/common/Exceptions.h"
-
 #include "dwio/nimble/common/Types.h"
-#include "dwio/nimble/encodings/EncodingFactory.h"
+#include "dwio/nimble/index/KeyChunkDecoder.h"
 #include "dwio/nimble/tablet/ClusterIndexGenerated.h"
 #include "dwio/nimble/tablet/MetadataBuffer.h"
 #include "folly/ScopeGuard.h"
@@ -110,17 +108,17 @@ std::vector<SortOrder> getSortOrders(
 
 // Builds cumulative row offsets from partition_row_counts in the FlatBuffer.
 // Returns a prefix-sum vector of size numPartitions + 1.
-std::vector<velox::vector_size_t> getPartitionRows(
+std::vector<uint32_t> getPartitionRows(
     const serialization::ClusterIndex* indexRoot) {
   const auto* rowCounts = indexRoot->partition_row_counts();
   NIMBLE_CHECK_NOT_NULL(rowCounts);
   NIMBLE_CHECK_GT(rowCounts->size(), 0, "partition_row_counts cannot be empty");
 
-  std::vector<velox::vector_size_t> offsets;
+  std::vector<uint32_t> offsets;
   offsets.reserve(rowCounts->size() + 1);
   offsets.emplace_back(0);
   for (uint32_t i = 0; i < rowCounts->size(); ++i) {
-    const auto count = static_cast<velox::vector_size_t>(rowCounts->Get(i));
+    const auto count = static_cast<uint32_t>(rowCounts->Get(i));
     NIMBLE_CHECK_GT(count, 0, "Partition {} has zero rows", i);
     offsets.emplace_back(offsets.back() + count);
   }
@@ -132,15 +130,6 @@ std::vector<velox::vector_size_t> getPartitionRows(
 // ---------------------------------------------------------------------------
 // ClusterIndex
 // ---------------------------------------------------------------------------
-
-ClusterIndex::DecodedChunk::~DecodedChunk() = default;
-
-void ClusterIndex::DecodedChunk::reset(uint32_t _chunkOffset) {
-  chunkOffset = _chunkOffset;
-  encoding.reset();
-  dataStream.reset();
-  stringBuffers.clear();
-}
 
 ClusterIndex::~ClusterIndex() = default;
 
@@ -331,15 +320,14 @@ IndexLookup::LookupResult ClusterIndex::lookup(
   return buildLookupResult(request.options());
 }
 
-velox::vector_size_t ClusterIndex::resolvePartitionRow(
+uint32_t ClusterIndex::resolvePartitionRow(
     const IndexPartition* partition,
     std::string_view encodedKey,
     bool inclusive) const {
   const auto chunkLocation = lookupChunk(partition, encodedKey);
   const auto partitionRow =
       seekInChunk(partition, chunkLocation, encodedKey, inclusive);
-  return static_cast<velox::vector_size_t>(
-      partitionRows_[partition->id] + partitionRow);
+  return partitionRows_[partition->id] + partitionRow;
 }
 
 MetadataSection ClusterIndex::partitionSection(uint32_t partitionId) const {
@@ -472,7 +460,7 @@ const ClusterIndex::DecodedChunk& ClusterIndex::getDecodedChunk(
     const ChunkLocation& chunkLocation) const {
   NIMBLE_DCHECK_NOT_NULL(partition);
   auto& decodedChunk = partition->decodedChunk;
-  if (decodedChunk.encoding != nullptr &&
+  if (decodedChunk.data.encoding != nullptr &&
       decodedChunk.chunkOffset == chunkLocation.chunkOffset) {
     return decodedChunk;
   }
@@ -480,58 +468,12 @@ const ClusterIndex::DecodedChunk& ClusterIndex::getDecodedChunk(
   decodedChunk.reset(chunkLocation.chunkOffset);
 
   const auto region = partition->chunkStreamRegion(chunkLocation);
-  auto inputStream = loadData_(region);
-
-  const void* buf;
-  int bufLen{0};
-  NIMBLE_CHECK(inputStream->Next(&buf, &bufLen));
-  NIMBLE_CHECK_GE(bufLen, kChunkHeaderSize);
-  const auto* header = static_cast<const char*>(buf);
-  const auto chunkHeader = readChunkHeader(header);
+  decodedChunk.data =
+      decodeKeyChunk(loadData_(region), *pool_, partition->dataBuffer);
   NIMBLE_CHECK_EQ(
-      chunkHeader.compressionType,
-      CompressionType::Uncompressed,
-      "Compressed key chunks are not supported");
-  const auto dataLen = chunkHeader.length;
-
-  // Read chunk payload. Zero-copy when data is contiguous in stream buffer.
-  bufLen -= kChunkHeaderSize;
-  const char* chunkData;
-  if (bufLen >= static_cast<int>(dataLen)) {
-    // All chunk data in current buffer — point directly at it.
-    // Keep inputStream alive so the buffer remains valid.
-    decodedChunk.dataStream = std::move(inputStream);
-    chunkData = header;
-  } else {
-    // Data spans multiple buffers — copy into reusable partition buffer.
-    auto* dest = partition->ensureDataBuffer(dataLen, pool_);
-    std::memcpy(dest, header, bufLen);
-    int copied = bufLen;
-    while (copied < static_cast<int>(dataLen)) {
-      NIMBLE_CHECK(inputStream->Next(&buf, &bufLen));
-      const int toCopy = std::min(bufLen, static_cast<int>(dataLen) - copied);
-      std::memcpy(dest + copied, buf, toCopy);
-      copied += toCopy;
-    }
-    chunkData = dest;
-    decodedChunk.dataStream.reset();
-  }
-
-  decodedChunk.encoding = nimble::EncodingFactory().create(
-      *pool_, std::string_view(chunkData, dataLen), [&](uint32_t totalLength) {
-        auto& buffer = decodedChunk.stringBuffers.emplace_back(
-            velox::AlignedBuffer::allocate<char>(totalLength, pool_));
-        return buffer->asMutable<void>();
-      });
-  NIMBLE_CHECK_EQ(
-      decodedChunk.encoding->dataType(),
+      decodedChunk.data.encoding->dataType(),
       DataType::String,
       "Expected String data type");
-  NIMBLE_CHECK(
-      decodedChunk.encoding->encodingType() == EncodingType::Trivial ||
-          decodedChunk.encoding->encodingType() == EncodingType::Prefix,
-      "Unsupported encoding type: {}",
-      decodedChunk.encoding->encodingType());
 
   return decodedChunk;
 }
@@ -542,12 +484,12 @@ uint32_t ClusterIndex::seekInChunk(
     std::string_view encodedKey,
     bool inclusive) const {
   const auto& chunk = getDecodedChunk(partition, chunkLocation);
-  const auto rowInChunk = chunk.encoding->seek(&encodedKey, inclusive);
+  const auto rowInChunk = chunk.data.encoding->seek(&encodedKey, inclusive);
   if (!rowInChunk.has_value()) {
     // For exclusive seek (inclusive=false), no row > key means the end is
     // past all rows in this partition.
     if (!inclusive) {
-      return chunkLocation.rowOffset + chunk.encoding->rowCount();
+      return chunkLocation.rowOffset + chunk.data.encoding->rowCount();
     }
     NIMBLE_CHECK(false, "Key must be found within a matched chunk");
   }

--- a/dwio/nimble/index/ClusterIndex.h
+++ b/dwio/nimble/index/ClusterIndex.h
@@ -24,6 +24,7 @@
 
 #include "dwio/nimble/index/IndexLookup.h"
 #include "dwio/nimble/index/IndexTypes.h"
+#include "dwio/nimble/index/KeyChunkDecoder.h"
 #include "dwio/nimble/index/SortOrder.h"
 #include "dwio/nimble/tablet/Callbacks.h"
 #include "dwio/nimble/tablet/ClusterIndexGenerated.h"
@@ -90,12 +91,12 @@ class ClusterIndex : public IndexLookup {
   // -- ClusterIndex-specific methods --
 
   /// Returns the minimum key across all partitions.
-  std::string_view minKey() const {
+  std::string_view minKey() const override {
     return firstKey_;
   }
 
   /// Returns the maximum key across all partitions.
-  std::string_view maxKey() const {
+  std::string_view maxKey() const override {
     return lastKey_;
   }
 
@@ -150,18 +151,15 @@ class ClusterIndex : public IndexLookup {
       LoadDataFn loadData,
       velox::memory::MemoryPool* pool);
 
-  // Decoded chunk encoding, one cached per IndexPartition.
+  // Cached decoded chunk, one per IndexPartition.
   struct DecodedChunk {
-    ~DecodedChunk();
-
-    void reset(uint32_t _chunkOffset);
+    void reset(uint32_t newChunkOffset) {
+      chunkOffset = newChunkOffset;
+      data = {};
+    }
 
     uint32_t chunkOffset{0};
-    // Zero-copy path: stream kept alive so its buffer backs the encoding.
-    std::unique_ptr<velox::dwio::common::SeekableInputStream> dataStream;
-    std::unique_ptr<nimble::Encoding> encoding;
-    // Buffers for encoding string data.
-    std::vector<velox::BufferPtr> stringBuffers;
+    DecodedKeyChunk data;
   };
 
   // Parsed partition metadata, cached on demand.
@@ -214,7 +212,7 @@ class ClusterIndex : public IndexLookup {
   // The partition's last key must be >= encodedKey (guaranteed by the caller's
   // binary search on partition keys).
   // @param inclusive true for first row >= key, false for first row > key.
-  velox::vector_size_t resolvePartitionRow(
+  uint32_t resolvePartitionRow(
       const IndexPartition* partition,
       std::string_view encodedKey,
       bool inclusive) const;
@@ -233,13 +231,13 @@ class ClusterIndex : public IndexLookup {
     // true for lower bound (first row >= key), false for upper bound
     // (first row > key).
     bool inclusive;
-    velox::vector_size_t* targetRow;
+    uint32_t* targetRow;
 
     PartitionLookup(
         uint32_t _partitionId,
         std::string_view _encodedKey,
         bool _inclusive,
-        velox::vector_size_t* _targetRow)
+        uint32_t* _targetRow)
         : partitionId{_partitionId},
           encodedKey{_encodedKey},
           inclusive{_inclusive},
@@ -302,10 +300,10 @@ class ClusterIndex : public IndexLookup {
   // partitionRows_[i] is the start row of partition i.
   // partitionRows_[numPartitions_] == numRows_.
   // Size = numPartitions_ + 1.
-  const std::vector<velox::vector_size_t> partitionRows_;
+  const std::vector<uint32_t> partitionRows_;
 
   // Total number of rows in the file.
-  const velox::vector_size_t numRows_;
+  const uint32_t numRows_;
 
   const LoadDataFn loadData_;
   const LoadMetadataFn loadMetadata_;

--- a/dwio/nimble/index/ClusterIndexWriter.cpp
+++ b/dwio/nimble/index/ClusterIndexWriter.cpp
@@ -66,7 +66,7 @@ std::vector<velox::core::SortOrder> toVeloxSortOrders(
   return result;
 }
 
-std::unique_ptr<velox::serializer::KeyEncoder> createKeyEncoder(
+std::unique_ptr<velox::serializer::KeyEncoder> createClusterKeyEncoder(
     const ClusterIndexConfig& config,
     const velox::RowTypePtr& inputType,
     velox::memory::MemoryPool* pool) {
@@ -82,17 +82,6 @@ std::unique_ptr<velox::serializer::KeyEncoder> createKeyEncoder(
       inputType,
       toVeloxSortOrders(config.sortOrders, config.columns.size()),
       pool);
-}
-
-std::vector<velox::column_index_t> getKeyColumnIndices(
-    const ClusterIndexConfig& config,
-    const velox::RowTypePtr& inputType) {
-  std::vector<velox::column_index_t> indices;
-  indices.reserve(config.columns.size());
-  for (const auto& columnName : config.columns) {
-    indices.push_back(inputType->getChildIdx(columnName));
-  }
-  return indices;
 }
 
 std::string_view asView(const flatbuffers::FlatBufferBuilder& builder) {
@@ -138,10 +127,10 @@ ClusterIndexWriter::ClusterIndexWriter(
                                           config.columns.size(),
                                           SortOrder{.ascending = true})
                                     : config.sortOrders},
-      keyEncoder_{createKeyEncoder(config, inputType, pool)},
+      keyEncoder_{createClusterKeyEncoder(config, inputType, pool)},
       encodingLayout_{config.encodingLayout},
       enforceKeyOrder_{config.enforceKeyOrder},
-      keyColumnIndices_{getKeyColumnIndices(config, inputType)},
+      keyColumnIndices_{getKeyColumnIndices({config.columns}, inputType)},
       noDuplicateKey_{config.noDuplicateKey},
       maxRowsPerKeyChunk_{config.maxRowsPerKeyChunk},
       keyStream_{std::make_unique<ContentStreamData<std::string_view>>(
@@ -157,29 +146,6 @@ ClusterIndexWriter::ClusterIndexWriter(
       encodingType);
 }
 
-void ClusterIndexWriter::validateNoNullKeys(
-    const velox::VectorPtr& input) const {
-  const auto* rowVector = input->asChecked<velox::RowVector>();
-  const auto& children = rowVector->children();
-  for (const auto columnIndex : keyColumnIndices_) {
-    const auto& child = children[columnIndex];
-    if (!child->mayHaveNulls()) {
-      continue;
-    }
-    const auto* nulls = child->rawNulls();
-    if (nulls == nullptr) {
-      continue;
-    }
-    const auto nullCount = velox::bits::countNulls(nulls, 0, input->size());
-    NIMBLE_USER_CHECK_EQ(
-        nullCount,
-        0,
-        "Null value not allowed in key column at index {}: found {} null(s)",
-        columnIndex,
-        nullCount);
-  }
-}
-
 std::unique_ptr<EncodingSelectionPolicy<std::string_view>>
 ClusterIndexWriter::createEncodingPolicy() const {
   return std::make_unique<ReplayedEncodingSelectionPolicy<std::string_view>>(
@@ -191,13 +157,13 @@ ClusterIndexWriter::createEncodingPolicy() const {
 }
 
 void ClusterIndexWriter::write(const velox::VectorPtr& input) {
-  NIMBLE_CHECK(!closed_, "ClusterIndexWriter has been closed");
+  checkNotClosed();
 
   if (input->size() == 0) {
     return;
   }
 
-  validateNoNullKeys(input);
+  validateNoNullKeys(input, keyColumnIndices_);
 
   const auto newKeyStart = keyStream_->mutableData().size();
   keyStream_->ensureMutableDataCapacity(newKeyStart + input->size());
@@ -334,12 +300,12 @@ void ClusterIndexWriter::encodeKeyChunk(
 }
 
 void ClusterIndexWriter::close(
+    const WriteDataFn& /*writeDataFn*/,
     const CreateMetadataSectionFn& createMetadataFn,
     const WriteOptionalSectionFn& writeMetadataFn) {
-  NIMBLE_CHECK(!closed_, "ClusterIndexWriter has been closed");
+  setClosed();
 
   SCOPE_EXIT {
-    closed_ = true;
     keyStream_->reset();
     keyBuffer_.reset();
     indexPartition_.reset();
@@ -420,7 +386,7 @@ void ClusterIndexWriter::ensureIndexPartition() {
 void ClusterIndexWriter::flush(
     const WriteDataFn& writeDataFn,
     const CreateMetadataSectionFn& createMetadataFn) {
-  NIMBLE_CHECK(!closed_, "ClusterIndexWriter has been closed");
+  checkNotClosed();
 
   // Force-encode any remaining accumulated keys. This must happen before the
   // indexPartition_ null check because when key chunking is disabled

--- a/dwio/nimble/index/ClusterIndexWriter.h
+++ b/dwio/nimble/index/ClusterIndexWriter.h
@@ -87,6 +87,7 @@ class ClusterIndexWriter : public IndexWriter {
       const CreateMetadataSectionFn& createMetadataFn) override;
 
   void close(
+      const WriteDataFn& writeDataFn,
       const CreateMetadataSectionFn& createMetadataFn,
       const WriteOptionalSectionFn& writeMetadataFn) override;
 
@@ -113,9 +114,6 @@ class ClusterIndexWriter : public IndexWriter {
   // Creates a new encoding policy instance for key encoding.
   std::unique_ptr<EncodingSelectionPolicy<std::string_view>>
   createEncodingPolicy() const;
-
-  // Validates that no null values exist in key columns.
-  void validateNoNullKeys(const velox::VectorPtr& input) const;
 
   // Validates all new encoded keys are in ascending order. Compares against
   // the previous key in the buffer or lastEncodedKey_ across clears.
@@ -196,8 +194,6 @@ class ClusterIndexWriter : public IndexWriter {
   std::unique_ptr<IndexPartition> indexPartition_;
   // Root-level index accumulator.
   std::unique_ptr<IndexRoot> indexRoot_;
-
-  bool closed_{false};
 };
 
 } // namespace facebook::nimble::index

--- a/dwio/nimble/index/DenseIndexRegistry.cpp
+++ b/dwio/nimble/index/DenseIndexRegistry.cpp
@@ -1,0 +1,197 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "dwio/nimble/index/DenseIndexRegistry.h"
+
+#include <fmt/ranges.h>
+
+#include "dwio/nimble/common/Exceptions.h"
+#include "dwio/nimble/index/HashIndex.h"
+#include "dwio/nimble/index/SortedIndex.h"
+#include "dwio/nimble/tablet/HashIndexGenerated.h"
+#include "dwio/nimble/tablet/SortedIndexGenerated.h"
+
+namespace facebook::nimble::index {
+
+namespace {
+
+bool columnsMatch(
+    const std::vector<std::string>& indexColumns,
+    const std::vector<std::string>& queryColumns) {
+  if (indexColumns.size() != queryColumns.size()) {
+    return false;
+  }
+  for (size_t i = 0; i < indexColumns.size(); ++i) {
+    if (indexColumns[i] != queryColumns[i]) {
+      return false;
+    }
+  }
+  return true;
+}
+
+} // namespace
+
+template <typename FbDirectory>
+std::vector<DenseIndexRegistry::IndexDescriptor>
+DenseIndexRegistry::parseDescriptors(
+    const Section& directorySection,
+    const std::string& indexTypeName) {
+  const auto* root =
+      flatbuffers::GetRoot<FbDirectory>(directorySection.content().data());
+  NIMBLE_CHECK_NOT_NULL(root);
+  const auto* indices = root->indices();
+  NIMBLE_CHECK_NOT_NULL(indices);
+
+  std::vector<DenseIndexRegistry::IndexDescriptor> descriptors;
+  descriptors.reserve(indices->size());
+  for (const auto* indexSection : *indices) {
+    NIMBLE_CHECK_NOT_NULL(indexSection);
+    const auto* columns = indexSection->index_columns();
+    NIMBLE_CHECK_NOT_NULL(columns);
+    NIMBLE_CHECK_GT(columns->size(), 0u, "{} must have columns", indexTypeName);
+
+    std::vector<std::string> columnNames;
+    columnNames.reserve(columns->size());
+    for (const auto* col : *columns) {
+      columnNames.emplace_back(col->string_view());
+    }
+
+    for (const auto& descriptor : descriptors) {
+      NIMBLE_CHECK(
+          !columnsMatch(descriptor.columns, columnNames),
+          "Duplicate {} columns: [{}]",
+          indexTypeName,
+          fmt::join(columnNames, ", "));
+    }
+
+    const auto* sectionRef = indexSection->section();
+    NIMBLE_CHECK_NOT_NULL(sectionRef);
+    descriptors.emplace_back(
+        DenseIndexRegistry::IndexDescriptor{
+            std::move(columnNames),
+            MetadataSection{
+                sectionRef->offset(),
+                sectionRef->size(),
+                static_cast<CompressionType>(sectionRef->compression_type())}});
+  }
+  return descriptors;
+}
+
+std::unique_ptr<DenseIndexRegistry> DenseIndexRegistry::create(
+    std::optional<Section> hashSection,
+    std::optional<Section> sortedSection,
+    LoadMetadataFn loadMetadata,
+    LoadDataFn loadData,
+    velox::memory::MemoryPool* pool) {
+  if (!hashSection.has_value() && !sortedSection.has_value()) {
+    return nullptr;
+  }
+  auto registry = std::unique_ptr<DenseIndexRegistry>(new DenseIndexRegistry());
+  if (hashSection.has_value()) {
+    registry->registerHashIndices(
+        std::move(hashSection.value()), loadMetadata, pool);
+  }
+  if (sortedSection.has_value()) {
+    registry->registerSortedIndices(
+        std::move(sortedSection.value()),
+        loadMetadata,
+        std::move(loadData),
+        pool);
+  }
+  registry->validate();
+  return registry;
+}
+
+void DenseIndexRegistry::validate() const {
+  for (const auto& hashDescriptor : hashDescriptors_) {
+    for (const auto& sortedDescriptor : sortedDescriptors_) {
+      NIMBLE_CHECK(
+          !columnsMatch(hashDescriptor.columns, sortedDescriptor.columns),
+          "Duplicate dense index columns across hash and sorted: [{}]",
+          fmt::join(hashDescriptor.columns, ", "));
+    }
+  }
+}
+
+void DenseIndexRegistry::registerHashIndices(
+    Section directorySection,
+    LoadMetadataFn loadMetadata,
+    velox::memory::MemoryPool* pool) {
+  hashDescriptors_ = parseDescriptors<serialization::HashIndexDirectory>(
+      directorySection, "Hash index");
+
+  hashIndexCache_ = std::make_unique<MetadataCache<uint32_t, HashIndex>>(
+      [this, loadMetadata = std::move(loadMetadata), pool](
+          uint32_t index) -> std::shared_ptr<HashIndex> {
+        const auto& descriptor = hashDescriptors_[index];
+        auto indexMetadata = loadMetadata(descriptor.section);
+        NIMBLE_CHECK_NOT_NULL(indexMetadata);
+        return HashIndex::create(
+            descriptor.columns, std::move(indexMetadata), loadMetadata, pool);
+      },
+      /*pinEntries=*/true);
+}
+
+void DenseIndexRegistry::registerSortedIndices(
+    Section directorySection,
+    LoadMetadataFn loadMetadata,
+    LoadDataFn loadData,
+    velox::memory::MemoryPool* pool) {
+  sortedDescriptors_ = parseDescriptors<serialization::SortedIndexDirectory>(
+      directorySection, "Sorted index");
+
+  sortedIndexCache_ = std::make_unique<MetadataCache<uint32_t, SortedIndex>>(
+      [this,
+       loadMetadata = std::move(loadMetadata),
+       loadData = std::move(loadData),
+       pool](uint32_t index) -> std::shared_ptr<SortedIndex> {
+        const auto& descriptor = sortedDescriptors_[index];
+        auto indexMetadata = loadMetadata(descriptor.section);
+        NIMBLE_CHECK_NOT_NULL(indexMetadata);
+        return SortedIndex::create(
+            descriptor.columns, std::move(indexMetadata), loadData, pool);
+      },
+      /*pinEntries=*/true);
+}
+
+const HashIndex* DenseIndexRegistry::findHashIndex(
+    const std::vector<std::string>& queryColumns) const {
+  for (uint32_t i = 0; i < hashDescriptors_.size(); ++i) {
+    if (columnsMatch(hashDescriptors_[i].columns, queryColumns)) {
+      return hashIndexCache_->getOrCreate(i).get();
+    }
+  }
+  return nullptr;
+}
+
+const SortedIndex* DenseIndexRegistry::findSortedIndex(
+    const std::vector<std::string>& queryColumns) const {
+  for (uint32_t i = 0; i < sortedDescriptors_.size(); ++i) {
+    if (columnsMatch(sortedDescriptors_[i].columns, queryColumns)) {
+      return sortedIndexCache_->getOrCreate(i).get();
+    }
+  }
+  return nullptr;
+}
+
+const IndexLookup* DenseIndexRegistry::findIndex(
+    const std::vector<std::string>& queryColumns) const {
+  if (auto* hashIdx = findHashIndex(queryColumns)) {
+    return hashIdx;
+  }
+  return findSortedIndex(queryColumns);
+}
+
+} // namespace facebook::nimble::index

--- a/dwio/nimble/index/DenseIndexRegistry.h
+++ b/dwio/nimble/index/DenseIndexRegistry.h
@@ -1,0 +1,94 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <memory>
+#include <optional>
+#include <string>
+#include <vector>
+
+#include "dwio/nimble/index/IndexLookup.h"
+#include "dwio/nimble/tablet/Callbacks.h"
+#include "dwio/nimble/tablet/MetadataBuffer.h"
+#include "dwio/nimble/tablet/MetadataCache.h"
+
+namespace facebook::nimble::index {
+
+class HashIndex;
+class SortedIndex;
+
+/// Unified registry for dense indices (hash and sorted) on a Nimble file.
+///
+/// Loads from both "columnar.hash.index" and "columnar.sorted.index" optional
+/// sections. Validates no duplicate column sets across index types.
+class DenseIndexRegistry {
+ public:
+  /// Creates a registry from optional hash and sorted index sections.
+  /// Returns nullptr if both sections are empty.
+  static std::unique_ptr<DenseIndexRegistry> create(
+      std::optional<Section> hashSection,
+      std::optional<Section> sortedSection,
+      LoadMetadataFn loadMetadata,
+      LoadDataFn loadData,
+      velox::memory::MemoryPool* pool);
+
+  /// Finds any dense index matching the given columns.
+  const IndexLookup* findIndex(
+      const std::vector<std::string>& queryColumns) const;
+
+ private:
+  DenseIndexRegistry() = default;
+
+  void registerHashIndices(
+      Section directorySection,
+      LoadMetadataFn loadMetadata,
+      velox::memory::MemoryPool* pool);
+
+  void registerSortedIndices(
+      Section directorySection,
+      LoadMetadataFn loadMetadata,
+      LoadDataFn loadData,
+      velox::memory::MemoryPool* pool);
+
+  struct IndexDescriptor {
+    std::vector<std::string> columns;
+    MetadataSection section;
+  };
+
+  const HashIndex* findHashIndex(
+      const std::vector<std::string>& queryColumns) const;
+
+  const SortedIndex* findSortedIndex(
+      const std::vector<std::string>& queryColumns) const;
+
+  void validate() const;
+
+  template <typename FbDirectory>
+  static std::vector<IndexDescriptor> parseDescriptors(
+      const Section& directorySection,
+      const std::string& indexTypeName);
+
+  // Hash index state.
+  std::vector<IndexDescriptor> hashDescriptors_;
+  mutable std::unique_ptr<MetadataCache<uint32_t, HashIndex>> hashIndexCache_;
+
+  // Sorted index state.
+  std::vector<IndexDescriptor> sortedDescriptors_;
+  mutable std::unique_ptr<MetadataCache<uint32_t, SortedIndex>>
+      sortedIndexCache_;
+};
+
+} // namespace facebook::nimble::index

--- a/dwio/nimble/index/HashIndex.cpp
+++ b/dwio/nimble/index/HashIndex.cpp
@@ -59,6 +59,18 @@ uint32_t getNumBuckets(const MetadataBuffer& metadata) {
   return numBuckets;
 }
 
+std::string_view getMinKey(const MetadataBuffer& metadata) {
+  const auto* minKey = getHashIndexRoot(metadata)->min_key();
+  NIMBLE_CHECK_NOT_NULL(minKey);
+  return minKey->string_view();
+}
+
+std::string_view getMaxKey(const MetadataBuffer& metadata) {
+  const auto* maxKey = getHashIndexRoot(metadata)->max_key();
+  NIMBLE_CHECK_NOT_NULL(maxKey);
+  return maxKey->string_view();
+}
+
 std::unique_ptr<BloomFilter> buildBloomFilter(
     const MetadataBuffer& metadata,
     velox::memory::MemoryPool* pool) {
@@ -88,9 +100,7 @@ std::vector<RowRange> resolveRowRanges(
 
   std::vector<RowRange> result;
   const auto addRange = [&](uint32_t start, uint32_t end) {
-    RowRange range{
-        static_cast<velox::vector_size_t>(start),
-        static_cast<velox::vector_size_t>(end)};
+    RowRange range{start, end};
     if (filterRange.has_value()) {
       range = range.intersect(filterRange.value());
     }
@@ -132,6 +142,8 @@ HashIndex::HashIndex(
       pool_{pool},
       numBuckets_{getNumBuckets(*indexMetadata_)},
       bucketMask_{numBuckets_ - 1},
+      minKey_{getMinKey(*indexMetadata_)},
+      maxKey_{getMaxKey(*indexMetadata_)},
       bloomFilter_{buildBloomFilter(*indexMetadata_, pool_)},
       partitions_{buildPartitionDescriptors(*indexMetadata_, numBuckets_)},
       partitionCache_{
@@ -189,6 +201,14 @@ std::unique_ptr<HashIndex> HashIndex::create(
       pool));
 }
 
+std::string_view HashIndex::minKey() const {
+  return minKey_;
+}
+
+std::string_view HashIndex::maxKey() const {
+  return maxKey_;
+}
+
 IndexLookup::LookupResult HashIndex::lookup(
     const LookupRequest& request) const {
   NIMBLE_CHECK_EQ(
@@ -205,6 +225,13 @@ IndexLookup::LookupResult HashIndex::lookup(
   for (uint32_t i = 0; i < request.size(); ++i) {
     const auto key = request.pointKey(i);
     ++numLookups_;
+
+    // Check min/max key range for fast negative.
+    if (key < minKey_ || key > maxKey_) {
+      ++numMinMaxSkips_;
+      resultOffsets.push_back(rowRanges.size());
+      continue;
+    }
 
     // Check bloom filter for fast negative.
     if (bloomFilter_ != nullptr && !bloomFilter_->testKey(key)) {
@@ -239,6 +266,10 @@ folly::F14FastMap<std::string, velox::RuntimeMetric> HashIndex::stats() const {
   const auto numLookups = numLookups_.load();
   if (numLookups > 0) {
     result.emplace(kNumLookups, velox::RuntimeMetric(numLookups));
+  }
+  const auto numMinMaxSkips = numMinMaxSkips_.load();
+  if (numMinMaxSkips > 0) {
+    result.emplace(kNumMinMaxSkips, velox::RuntimeMetric(numMinMaxSkips));
   }
   const auto numBloomFilterSkips = numBloomFilterSkips_.load();
   if (numBloomFilterSkips > 0) {
@@ -320,101 +351,4 @@ std::shared_ptr<HashIndex::Partition> HashIndex::Partition::create(
   return std::shared_ptr<Partition>(new Partition(
       std::move(metadata), bucketOffsets->data(), keys, rows->data()));
 }
-
-// ---------------------------------------------------------------------------
-// DenseIndexRegistry
-// ---------------------------------------------------------------------------
-
-std::unique_ptr<DenseIndexRegistry> DenseIndexRegistry::create(
-    Section directorySection,
-    LoadMetadataFn loadMetadata,
-    velox::memory::MemoryPool* pool) {
-  const auto* root = flatbuffers::GetRoot<serialization::HashIndexDirectory>(
-      directorySection.content().data());
-  NIMBLE_CHECK_NOT_NULL(root);
-  const auto* indices = root->indices();
-  if (indices == nullptr) {
-    return nullptr;
-  }
-  NIMBLE_CHECK_GT(
-      indices->size(), 0u, "Hash index directory must not be empty");
-  return std::unique_ptr<DenseIndexRegistry>(new DenseIndexRegistry(
-      std::move(directorySection), std::move(loadMetadata), pool));
-}
-
-DenseIndexRegistry::DenseIndexRegistry(
-    Section directorySection,
-    LoadMetadataFn loadMetadata,
-    velox::memory::MemoryPool* pool)
-    : directorySection_{std::move(directorySection)},
-      indexCache_{
-          [this, loadMetadata = std::move(loadMetadata), pool](
-              uint32_t index) -> std::shared_ptr<HashIndex> {
-            const auto& descriptor = indexDescriptors_[index];
-            auto indexMetadata = loadMetadata(descriptor.section);
-            NIMBLE_CHECK_NOT_NULL(indexMetadata);
-            return HashIndex::create(
-                descriptor.columns,
-                std::move(indexMetadata),
-                loadMetadata,
-                pool);
-          },
-          /*pinEntries=*/true} {
-  parseIndexDescriptors();
-}
-
-void DenseIndexRegistry::parseIndexDescriptors() {
-  NIMBLE_CHECK(
-      indexDescriptors_.empty(), "Index descriptors already initialized");
-
-  const auto* root = flatbuffers::GetRoot<serialization::HashIndexDirectory>(
-      directorySection_.content().data());
-  NIMBLE_CHECK_NOT_NULL(root);
-  const auto* indices = root->indices();
-  NIMBLE_CHECK_NOT_NULL(indices);
-
-  indexDescriptors_.reserve(indices->size());
-  for (const auto* indexSection : *indices) {
-    NIMBLE_CHECK_NOT_NULL(indexSection);
-    const auto* columns = indexSection->index_columns();
-    NIMBLE_CHECK_NOT_NULL(columns);
-    NIMBLE_CHECK_GT(columns->size(), 0u, "Hash index must have columns");
-
-    std::vector<std::string> columnNames;
-    columnNames.reserve(columns->size());
-    for (const auto* col : *columns) {
-      columnNames.emplace_back(col->string_view());
-    }
-
-    // Check for duplicate index columns.
-    for (const auto& indexDescriptor : indexDescriptors_) {
-      NIMBLE_CHECK(
-          !columnsMatch(indexDescriptor.columns, columnNames),
-          "Duplicate hash index columns: [{}]",
-          fmt::join(columnNames, ", "));
-    }
-
-    const auto* sectionRef = indexSection->section();
-    NIMBLE_CHECK_NOT_NULL(sectionRef);
-    indexDescriptors_.emplace_back(
-        IndexDescriptor{
-            std::move(columnNames),
-            MetadataSection{
-                sectionRef->offset(),
-                sectionRef->size(),
-                static_cast<CompressionType>(sectionRef->compression_type())}});
-  }
-}
-
-const HashIndex* DenseIndexRegistry::findIndex(
-    const std::vector<std::string>& queryColumns) const {
-  NIMBLE_CHECK(!queryColumns.empty(), "queryColumns must not be empty");
-  for (uint32_t i = 0; i < indexDescriptors_.size(); ++i) {
-    if (columnsMatch(indexDescriptors_[i].columns, queryColumns)) {
-      return indexCache_.getOrCreate(i).get();
-    }
-  }
-  return nullptr;
-}
-
 } // namespace facebook::nimble::index

--- a/dwio/nimble/index/HashIndex.h
+++ b/dwio/nimble/index/HashIndex.h
@@ -64,12 +64,18 @@ class HashIndex : public IndexLookup {
       "hashIndex.numBloomFilterSkips"};
   // Number of row ranges returned across all lookups.
   static constexpr std::string_view kNumMatchedRows{"hashIndex.numMatchedRows"};
+  // Number of key lookups skipped by the min/max key check.
+  static constexpr std::string_view kNumMinMaxSkips{"hashIndex.numMinMaxSkips"};
 
   const std::vector<std::string>& indexColumns() const override {
     return columns_;
   }
 
   LookupResult lookup(const LookupRequest& request) const override;
+
+  std::string_view minKey() const override;
+
+  std::string_view maxKey() const override;
 
   folly::F14FastMap<std::string, velox::RuntimeMetric> stats() const override;
 
@@ -141,6 +147,8 @@ class HashIndex : public IndexLookup {
 
   const uint32_t numBuckets_;
   const uint32_t bucketMask_;
+  const std::string_view minKey_;
+  const std::string_view maxKey_;
 
   // Constructed from FlatBuffer data during initialization.
   const std::unique_ptr<BloomFilter> bloomFilter_;
@@ -151,59 +159,9 @@ class HashIndex : public IndexLookup {
   mutable MetadataCache<uint32_t, Partition> partitionCache_;
 
   mutable std::atomic_uint64_t numLookups_{0};
+  mutable std::atomic_uint64_t numMinMaxSkips_{0};
   mutable std::atomic_uint64_t numBloomFilterSkips_{0};
   mutable std::atomic_uint64_t numMatchedRows_{0};
-};
-
-/// Registry of hash indices for a Nimble file.
-///
-/// Loaded from the "columnar.hash.index" optional section. Owns individual
-/// HashIndex objects, each covering a different set of composite key columns.
-/// TabletReader owns this registry and callers look up the appropriate
-/// HashIndex by column names.
-class DenseIndexRegistry {
- public:
-  /// Creates a DenseIndexRegistry from the serialized directory section.
-  ///
-  /// @param directorySection The section containing the HashIndexDirectory
-  ///        with HashIndexSection entries.
-  /// @param loadMetadata Callback to load a MetadataSection from the file.
-  /// @param pool Memory pool for bloom filter data allocation.
-  /// @return A unique pointer to the registry, or nullptr if the section
-  ///         contains no indices.
-  static std::unique_ptr<DenseIndexRegistry> create(
-      Section directorySection,
-      LoadMetadataFn loadMetadata,
-      velox::memory::MemoryPool* pool);
-
-  /// Returns the number of hash indices in this registry.
-  size_t numIndices() const {
-    return indexDescriptors_.size();
-  }
-
-  /// Finds the hash index matching the given columns (lazy loaded).
-  /// Returns nullptr if no index matches.
-  const HashIndex* findIndex(
-      const std::vector<std::string>& queryColumns) const;
-
- private:
-  // Lightweight descriptor parsed from the directory section.
-  struct IndexDescriptor {
-    std::vector<std::string> columns;
-    MetadataSection section;
-  };
-
-  DenseIndexRegistry(
-      Section directorySection,
-      LoadMetadataFn loadMetadata,
-      velox::memory::MemoryPool* pool);
-
-  // Parses index descriptors from the directory section.
-  void parseIndexDescriptors();
-
-  Section directorySection_;
-  std::vector<IndexDescriptor> indexDescriptors_;
-  mutable MetadataCache<uint32_t, HashIndex> indexCache_;
 };
 
 } // namespace facebook::nimble::index

--- a/dwio/nimble/index/HashIndexWriter.cpp
+++ b/dwio/nimble/index/HashIndexWriter.cpp
@@ -36,32 +36,14 @@ namespace facebook::nimble::index {
 
 namespace {
 
-std::unique_ptr<velox::serializer::KeyEncoder> createEncoder(
-    const HashIndexConfig& config,
-    const velox::RowTypePtr& inputType,
-    velox::memory::MemoryPool* pool) {
-  // Hash index uses ascending sort order for key encoding (order doesn't
-  // matter for point lookups, but we need a consistent encoding).
-  std::vector<velox::core::SortOrder> sortOrders(
-      config.columns.size(), velox::core::SortOrder{true, false});
-  return velox::serializer::KeyEncoder::create(
-      config.columns, inputType, std::move(sortOrders), pool);
-}
-
-std::vector<velox::column_index_t> getKeyColumnIndices(
-    const std::vector<HashIndexConfig>& configs,
-    const velox::RowTypePtr& inputType) {
-  std::set<velox::column_index_t> indexSet;
-  std::vector<velox::column_index_t> indices;
+std::vector<std::vector<std::string>> extractColumnSets(
+    const std::vector<HashIndexConfig>& configs) {
+  std::vector<std::vector<std::string>> columnSets;
+  columnSets.reserve(configs.size());
   for (const auto& config : configs) {
-    for (const auto& columnName : config.columns) {
-      const auto idx = inputType->getChildIdx(columnName);
-      if (indexSet.insert(idx).second) {
-        indices.emplace_back(idx);
-      }
-    }
+    columnSets.emplace_back(config.columns);
   }
-  return indices;
+  return columnSets;
 }
 
 } // namespace
@@ -140,6 +122,16 @@ void HashIndexWriter::buildIndexFlatBuffer(
     flatbuffers::FlatBufferBuilder& builder,
     const IndexAccumulator& accumulator,
     const CreateMetadataSectionFn& createMetadataFn) const {
+  NIMBLE_CHECK(!accumulator.entries.empty());
+  const auto minIt = std::min_element(
+      accumulator.entries.begin(),
+      accumulator.entries.end(),
+      [](const auto& a, const auto& b) { return a.key < b.key; });
+  const auto maxIt = std::max_element(
+      accumulator.entries.begin(),
+      accumulator.entries.end(),
+      [](const auto& a, const auto& b) { return a.key < b.key; });
+
   const uint64_t numKeys = accumulator.entries.size();
   const uint32_t numBuckets = static_cast<uint32_t>(velox::bits::nextPowerOfTwo(
       std::max(
@@ -211,6 +203,10 @@ void HashIndexWriter::buildIndexFlatBuffer(
 
   auto partitionStartBucketsVec = builder.CreateVector(partitionStartBuckets);
   auto partitionSectionsVec = builder.CreateVector(partitionSections);
+  auto minKeyOffset =
+      builder.CreateString(minIt->key.data(), minIt->key.size());
+  auto maxKeyOffset =
+      builder.CreateString(maxIt->key.data(), maxIt->key.size());
 
   auto hashIndex = serialization::CreateHashIndex(
       builder,
@@ -219,6 +215,8 @@ void HashIndexWriter::buildIndexFlatBuffer(
       numKeys,
       actualLoadFactor,
       bloomFilterOffset,
+      minKeyOffset,
+      maxKeyOffset,
       partitionStartBucketsVec,
       partitionSectionsVec);
   builder.Finish(hashIndex);
@@ -277,7 +275,9 @@ HashIndexWriter::HashIndexWriter(
     const std::vector<HashIndexConfig>& configs,
     const velox::RowTypePtr& inputType,
     velox::memory::MemoryPool* pool)
-    : pool_{pool}, keyColumnIndices_{getKeyColumnIndices(configs, inputType)} {
+    : pool_{pool},
+      keyColumnIndices_{
+          getKeyColumnIndices(extractColumnSets(configs), inputType)} {
   NIMBLE_CHECK(!configs.empty(), "Hash index configs must not be empty");
   accumulators_.reserve(configs.size());
   for (const auto& config : configs) {
@@ -295,35 +295,13 @@ HashIndexWriter::HashIndexWriter(
     accumulators_.emplace_back(
         IndexAccumulator{
             .config = config,
-            .encoder = createEncoder(config, inputType, pool),
+            .encoder = createKeyEncoder(config.columns, inputType, pool),
         });
   }
 }
 
-void HashIndexWriter::validateNoNullKeys(const velox::VectorPtr& input) const {
-  const auto* rowVector = input->asChecked<velox::RowVector>();
-  const auto& children = rowVector->children();
-  for (const auto columnIndex : keyColumnIndices_) {
-    const auto& child = children[columnIndex];
-    if (!child->mayHaveNulls()) {
-      continue;
-    }
-    const auto* nulls = child->rawNulls();
-    if (nulls == nullptr) {
-      continue;
-    }
-    const auto nullCount = velox::bits::countNulls(nulls, 0, input->size());
-    NIMBLE_USER_CHECK_EQ(
-        nullCount,
-        0,
-        "Null value not allowed in hash index key column at index {}: found {} null(s)",
-        columnIndex,
-        nullCount);
-  }
-}
-
 void HashIndexWriter::write(const velox::VectorPtr& input) {
-  NIMBLE_CHECK(!closed_, "Cannot write after close");
+  checkNotClosed();
   if (input->size() == 0) {
     return;
   }
@@ -333,7 +311,7 @@ void HashIndexWriter::write(const velox::VectorPtr& input) {
       static_cast<uint64_t>(std::numeric_limits<uint32_t>::max()),
       "Hash index row count exceeds uint32 limit");
 
-  validateNoNullKeys(input);
+  validateNoNullKeys(input, keyColumnIndices_);
   ensureEncodingBuffer();
 
   for (auto& accumulator : accumulators_) {
@@ -359,10 +337,10 @@ void HashIndexWriter::write(const velox::VectorPtr& input) {
 }
 
 void HashIndexWriter::close(
+    const WriteDataFn& /*writeDataFn*/,
     const CreateMetadataSectionFn& createMetadataFn,
     const WriteOptionalSectionFn& writeMetadataFn) {
-  NIMBLE_CHECK(!closed_, "close() already called");
-  closed_ = true;
+  setClosed();
 
   if (numRows_ == 0) {
     return;

--- a/dwio/nimble/index/HashIndexWriter.h
+++ b/dwio/nimble/index/HashIndexWriter.h
@@ -97,6 +97,7 @@ class HashIndexWriter : public IndexWriter {
   void write(const velox::VectorPtr& input) override;
 
   void close(
+      const WriteDataFn& writeDataFn,
       const CreateMetadataSectionFn& createMetadataFn,
       const WriteOptionalSectionFn& writeMetadataFn) override;
 
@@ -143,9 +144,6 @@ class HashIndexWriter : public IndexWriter {
       uint32_t startBucket,
       uint32_t bucketCount);
 
-  // Validates that no null values exist in any key columns.
-  void validateNoNullKeys(const velox::VectorPtr& input) const;
-
   // Builds a bloom filter FlatBuffer offset, or 0 if bloom filter is disabled.
   flatbuffers::Offset<serialization::BloomFilter> buildBloomFilter(
       flatbuffers::FlatBufferBuilder& builder,
@@ -187,7 +185,6 @@ class HashIndexWriter : public IndexWriter {
   std::unique_ptr<Buffer> encodingBuffer_;
   std::vector<IndexAccumulator> accumulators_;
   uint32_t numRows_{0};
-  bool closed_{false};
 
   friend class test::HashIndexWriterTestHelper;
 };

--- a/dwio/nimble/index/IndexConfig.h
+++ b/dwio/nimble/index/IndexConfig.h
@@ -99,4 +99,23 @@ struct HashIndexConfig {
   uint64_t maxPartitionSizeBytes{0};
 };
 
+/// Configuration for sorted index generation.
+/// A sorted index stores a sorted key stream with embedded row IDs for
+/// point lookups and range scans on unsorted data. Unlike ClusterIndex
+/// (which requires sorted data), this is a secondary index.
+struct SortedIndexConfig {
+  /// Columns forming the composite key.
+  std::vector<std::string> columns;
+  /// The encoding layout for the key stream.
+  /// Only Prefix and Trivial encodings are supported.
+  EncodingLayout encodingLayout{
+      EncodingType::Prefix,
+      {},
+      CompressionType::Uncompressed};
+  /// Maximum rows per chunk within a partition. Controls in-memory search
+  /// granularity — chunks have boundary keys for binary search.
+  /// 0 means no splitting (one chunk per partition).
+  uint64_t maxRowsPerKeyChunk{0};
+};
+
 } // namespace facebook::nimble

--- a/dwio/nimble/index/IndexLookup.h
+++ b/dwio/nimble/index/IndexLookup.h
@@ -41,6 +41,9 @@ enum class IndexType {
   /// Hash-based index for point lookups on unsorted data. Maps composite key
   /// columns to exact row numbers.
   Hash,
+  /// Sorted key stream index for point lookups and range scans on unsorted
+  /// data. Stores sorted encoded_key || row_id entries.
+  Sorted,
 };
 
 std::string toString(IndexType indexType);
@@ -204,6 +207,12 @@ class IndexLookup {
   /// Results are indexed by input key position: result[i] returns the
   /// RowRanges for request.keyBounds()[i].
   virtual LookupResult lookup(const LookupRequest& request) const = 0;
+
+  /// Returns the minimum key in this index.
+  virtual std::string_view minKey() const = 0;
+
+  /// Returns the maximum key in this index.
+  virtual std::string_view maxKey() const = 0;
 
   /// Returns runtime statistics accumulated during lookups.
   virtual folly::F14FastMap<std::string, velox::RuntimeMetric> stats() const {

--- a/dwio/nimble/index/IndexWriter.cpp
+++ b/dwio/nimble/index/IndexWriter.cpp
@@ -1,0 +1,78 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "dwio/nimble/index/IndexWriter.h"
+
+#include <set>
+
+#include "dwio/nimble/common/Exceptions.h"
+#include "velox/common/base/Nulls.h"
+
+namespace facebook::nimble::index {
+
+// static
+void IndexWriter::validateNoNullKeys(
+    const velox::VectorPtr& input,
+    const std::vector<velox::column_index_t>& keyColumnIndices) {
+  const auto* rowVector = input->asChecked<velox::RowVector>();
+  const auto& children = rowVector->children();
+  for (const auto columnIndex : keyColumnIndices) {
+    const auto& child = children[columnIndex];
+    if (!child->mayHaveNulls()) {
+      continue;
+    }
+    const auto* nulls = child->rawNulls();
+    if (nulls == nullptr) {
+      continue;
+    }
+    const auto nullCount = velox::bits::countNulls(nulls, 0, input->size());
+    NIMBLE_USER_CHECK_EQ(
+        nullCount,
+        0,
+        "Null value not allowed in index key column at index {}: found {} null(s)",
+        columnIndex,
+        nullCount);
+  }
+}
+
+// static
+std::unique_ptr<velox::serializer::KeyEncoder> IndexWriter::createKeyEncoder(
+    const std::vector<std::string>& columns,
+    const velox::RowTypePtr& inputType,
+    velox::memory::MemoryPool* pool) {
+  std::vector<velox::core::SortOrder> sortOrders(
+      columns.size(), velox::core::SortOrder{true, false});
+  return velox::serializer::KeyEncoder::create(
+      columns, inputType, std::move(sortOrders), pool);
+}
+
+// static
+std::vector<velox::column_index_t> IndexWriter::getKeyColumnIndices(
+    const std::vector<std::vector<std::string>>& columnSets,
+    const velox::RowTypePtr& inputType) {
+  std::set<velox::column_index_t> indexSet;
+  std::vector<velox::column_index_t> indices;
+  for (const auto& columns : columnSets) {
+    for (const auto& columnName : columns) {
+      const auto idx = inputType->getChildIdx(columnName);
+      if (indexSet.insert(idx).second) {
+        indices.emplace_back(idx);
+      }
+    }
+  }
+  return indices;
+}
+
+} // namespace facebook::nimble::index

--- a/dwio/nimble/index/IndexWriter.h
+++ b/dwio/nimble/index/IndexWriter.h
@@ -15,9 +15,13 @@
  */
 #pragma once
 
+#include <memory>
 #include <string>
+#include <vector>
 
+#include "dwio/nimble/common/Exceptions.h"
 #include "dwio/nimble/tablet/MetadataBuffer.h"
+#include "velox/serializers/KeyEncoder.h"
 #include "velox/vector/ComplexVector.h"
 
 namespace facebook::nimble::index {
@@ -44,8 +48,38 @@ class IndexWriter {
   /// Finalizes the index, writes it as an optional section, and releases
   /// resources.
   virtual void close(
+      const WriteDataFn& writeDataFn,
       const CreateMetadataSectionFn& createMetadataFn,
       const WriteOptionalSectionFn& writeMetadataFn) = 0;
+
+ protected:
+  void checkNotClosed() const {
+    NIMBLE_CHECK(!closed_, "IndexWriter has been closed");
+  }
+
+  void setClosed() {
+    NIMBLE_CHECK(!closed_, "close() already called");
+    closed_ = true;
+  }
+
+  // Validates that no null values exist in the specified key columns.
+  static void validateNoNullKeys(
+      const velox::VectorPtr& input,
+      const std::vector<velox::column_index_t>& keyColumnIndices);
+
+  // Creates a KeyEncoder with ascending sort order for the given columns.
+  static std::unique_ptr<velox::serializer::KeyEncoder> createKeyEncoder(
+      const std::vector<std::string>& columns,
+      const velox::RowTypePtr& inputType,
+      velox::memory::MemoryPool* pool);
+
+  // Returns deduplicated key column indices across multiple column sets.
+  static std::vector<velox::column_index_t> getKeyColumnIndices(
+      const std::vector<std::vector<std::string>>& columnSets,
+      const velox::RowTypePtr& inputType);
+
+ private:
+  bool closed_{false};
 };
 
 } // namespace facebook::nimble::index

--- a/dwio/nimble/index/KeyChunkDecoder.cpp
+++ b/dwio/nimble/index/KeyChunkDecoder.cpp
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "dwio/nimble/index/KeyChunkDecoder.h"
+
+#include "dwio/nimble/common/ChunkHeader.h"
+#include "dwio/nimble/common/Exceptions.h"
+#include "dwio/nimble/encodings/EncodingFactory.h"
+
+namespace facebook::nimble::index {
+
+DecodedKeyChunk decodeKeyChunk(
+    std::unique_ptr<velox::dwio::common::SeekableInputStream> inputStream,
+    velox::memory::MemoryPool& pool,
+    velox::BufferPtr& dataBuffer) {
+  const void* buf;
+  int bufLen{0};
+  NIMBLE_CHECK(inputStream->Next(&buf, &bufLen));
+  NIMBLE_CHECK_GE(bufLen, kChunkHeaderSize);
+  const auto* header = static_cast<const char*>(buf);
+  const auto chunkHeader = readChunkHeader(header);
+  NIMBLE_CHECK_EQ(
+      chunkHeader.compressionType,
+      CompressionType::Uncompressed,
+      "Compressed key chunks are not supported");
+
+  const auto dataLen = chunkHeader.length;
+  DecodedKeyChunk result;
+
+  // Determine the contiguous data pointer. If the first buffer contains all
+  // the data, use it directly (zero-copy). Otherwise, copy across buffers.
+  // readChunkHeader advanced 'header' past the chunk header, so the remaining
+  // available bytes are bufLen - kChunkHeaderSize.
+  const char* chunkData;
+  bufLen -= kChunkHeaderSize;
+  if (bufLen >= static_cast<int>(dataLen)) {
+    result.dataStream = std::move(inputStream);
+    chunkData = header;
+  } else {
+    if (dataBuffer == nullptr || dataBuffer->capacity() < dataLen) {
+      dataBuffer = velox::AlignedBuffer::allocate<char>(dataLen, &pool);
+    }
+    dataBuffer->setSize(dataLen);
+    auto* dest = dataBuffer->asMutable<char>();
+    std::memcpy(dest, header, bufLen);
+    int copied = bufLen;
+    while (copied < static_cast<int>(dataLen)) {
+      NIMBLE_CHECK(inputStream->Next(&buf, &bufLen));
+      const int toCopy = std::min(bufLen, static_cast<int>(dataLen) - copied);
+      std::memcpy(dest + copied, buf, toCopy);
+      copied += toCopy;
+    }
+    chunkData = dest;
+  }
+
+  result.encoding = nimble::EncodingFactory().create(
+      pool, std::string_view(chunkData, dataLen), [&](uint32_t totalLength) {
+        auto& buffer = result.stringBuffers.emplace_back(
+            velox::AlignedBuffer::allocate<char>(totalLength, &pool));
+        return buffer->asMutable<void>();
+      });
+  NIMBLE_CHECK(
+      result.encoding->encodingType() == EncodingType::Trivial ||
+          result.encoding->encodingType() == EncodingType::Prefix,
+      "Unsupported encoding type: {}",
+      result.encoding->encodingType());
+  return result;
+}
+
+} // namespace facebook::nimble::index

--- a/dwio/nimble/index/KeyChunkDecoder.h
+++ b/dwio/nimble/index/KeyChunkDecoder.h
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <memory>
+#include <vector>
+
+#include "dwio/nimble/encodings/Encoding.h"
+#include "velox/buffer/Buffer.h"
+#include "velox/common/memory/Memory.h"
+#include "velox/dwio/common/SeekableInputStream.h"
+
+namespace facebook::nimble::index {
+
+/// Decoded key chunk with ownership of backing buffers.
+struct DecodedKeyChunk {
+  // Zero-copy path: stream kept alive so its buffer backs the encoding.
+  std::unique_ptr<velox::dwio::common::SeekableInputStream> dataStream;
+  std::unique_ptr<nimble::Encoding> encoding;
+  std::vector<velox::BufferPtr> stringBuffers;
+};
+
+/// Decodes a key chunk from an input stream. Reads the chunk header, validates
+/// compression and encoding type, and creates the encoding. Handles both
+/// contiguous (zero-copy) and multi-buffer reads.
+///
+/// @param dataBuffer Reusable buffer for multi-buffer reads. When the data
+///        spans multiple stream buffers, this buffer is resized and reused
+///        instead of allocating a new one. The caller retains ownership and the
+///        buffer must outlive the returned DecodedKeyChunk.
+DecodedKeyChunk decodeKeyChunk(
+    std::unique_ptr<velox::dwio::common::SeekableInputStream> inputStream,
+    velox::memory::MemoryPool& pool,
+    velox::BufferPtr& dataBuffer);
+
+} // namespace facebook::nimble::index

--- a/dwio/nimble/index/SortedIndex.cpp
+++ b/dwio/nimble/index/SortedIndex.cpp
@@ -1,0 +1,339 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "dwio/nimble/index/SortedIndex.h"
+
+#include <algorithm>
+
+#include <fmt/ranges.h>
+
+#include "dwio/nimble/common/Exceptions.h"
+#include "dwio/nimble/tablet/SortedIndexGenerated.h"
+
+namespace facebook::nimble::index {
+
+namespace {
+
+bool columnsMatch(
+    const std::vector<std::string>& indexColumns,
+    const std::vector<std::string>& queryColumns) {
+  if (indexColumns.size() != queryColumns.size()) {
+    return false;
+  }
+  for (size_t i = 0; i < indexColumns.size(); ++i) {
+    if (indexColumns[i] != queryColumns[i]) {
+      return false;
+    }
+  }
+  return true;
+}
+
+const serialization::SortedIndex* getSortedIndexRoot(
+    const MetadataBuffer& metadata) {
+  const auto* entry = flatbuffers::GetRoot<serialization::SortedIndex>(
+      metadata.content().data());
+  NIMBLE_CHECK_NOT_NULL(entry);
+  return entry;
+}
+
+uint8_t getRowIdWidth(const MetadataBuffer& metadata) {
+  const auto width = getSortedIndexRoot(metadata)->row_id_width();
+  NIMBLE_CHECK(
+      width >= 1 && width <= 4,
+      "Invalid row ID width: {}",
+      static_cast<int>(width));
+  return width;
+}
+
+} // namespace
+
+// ---------------------------------------------------------------------------
+// SortedIndex
+// ---------------------------------------------------------------------------
+
+SortedIndex::SortedIndex(
+    std::vector<std::string> columns,
+    std::unique_ptr<MetadataBuffer> indexMetadata,
+    LoadDataFn loadData,
+    velox::memory::MemoryPool* pool)
+    : IndexLookup{IndexType::Sorted},
+      columns_{std::move(columns)},
+      indexMetadata_{std::move(indexMetadata)},
+      pool_{pool},
+      rowIdWidth_{getRowIdWidth(*indexMetadata_)},
+      loadData_{std::move(loadData)},
+      sortedIndex_{getSortedIndexRoot(*indexMetadata_)},
+      numChunks_{sortedIndex_->chunk_keys()->size()} {}
+
+std::unique_ptr<SortedIndex> SortedIndex::create(
+    std::vector<std::string> columns,
+    std::unique_ptr<MetadataBuffer> indexMetadata,
+    LoadDataFn loadData,
+    velox::memory::MemoryPool* pool) {
+  return std::unique_ptr<SortedIndex>(new SortedIndex(
+      std::move(columns), std::move(indexMetadata), std::move(loadData), pool));
+}
+
+std::string_view SortedIndex::chunkKey(uint32_t chunkIdx) const {
+  return sortedIndex_->chunk_keys()->Get(chunkIdx)->string_view();
+}
+
+uint32_t SortedIndex::chunkOffset(uint32_t chunkIdx) const {
+  return sortedIndex_->chunk_offsets()->Get(chunkIdx);
+}
+
+uint32_t SortedIndex::chunkSize(uint32_t chunkIdx) const {
+  const uint32_t offset = chunkOffset(chunkIdx);
+  const uint32_t nextOffset = chunkIdx + 1 < numChunks_
+      ? chunkOffset(chunkIdx + 1)
+      : sortedIndex_->key_stream_size();
+  return nextOffset - offset;
+}
+
+uint32_t SortedIndex::rowOffset(uint32_t chunkIdx) const {
+  return chunkIdx == 0 ? 0 : sortedIndex_->chunk_rows()->Get(chunkIdx - 1);
+}
+
+std::optional<uint32_t> SortedIndex::findChunkIndex(
+    std::string_view key) const {
+  const auto* chunkKeys = sortedIndex_->chunk_keys();
+  const auto it = std::lower_bound(
+      chunkKeys->begin(),
+      chunkKeys->end(),
+      key,
+      [](const flatbuffers::String* chunkKey, std::string_view searchKey) {
+        return chunkKey->string_view() < searchKey;
+      });
+  if (it == chunkKeys->end()) {
+    return std::nullopt;
+  }
+  return static_cast<uint32_t>(std::distance(chunkKeys->begin(), it));
+}
+
+DecodedKeyChunk SortedIndex::loadChunk(uint32_t chunkIdx) const {
+  const uint64_t streamOffset = sortedIndex_->key_stream_offset();
+  const uint32_t chunkOffset = this->chunkOffset(chunkIdx);
+  const uint32_t chunkSize = this->chunkSize(chunkIdx);
+
+  auto inputStream =
+      loadData_(velox::common::Region{streamOffset + chunkOffset, chunkSize});
+  return decodeKeyChunk(std::move(inputStream), *pool_, chunkBuffer_);
+}
+
+std::string_view SortedIndex::extractKey(
+    std::string_view compositeEntry) const {
+  NIMBLE_DCHECK_GE(compositeEntry.size(), rowIdWidth_);
+  return compositeEntry.substr(0, compositeEntry.size() - rowIdWidth_);
+}
+
+uint32_t SortedIndex::extractRowId(std::string_view compositeEntry) const {
+  NIMBLE_DCHECK_GE(compositeEntry.size(), rowIdWidth_);
+  const auto* data = reinterpret_cast<const uint8_t*>(
+      compositeEntry.data() + compositeEntry.size() - rowIdWidth_);
+  uint32_t rowId = 0;
+  for (uint8_t i = 0; i < rowIdWidth_; ++i) {
+    rowId = (rowId << 8) | data[i];
+  }
+  return rowId;
+}
+
+std::string SortedIndex::firstSeekKey(std::string_view key) const {
+  std::string result(key);
+  result.append(rowIdWidth_, '\0');
+  return result;
+}
+
+std::string SortedIndex::lastSeekKey(std::string_view key) const {
+  std::string result(key);
+  result.append(rowIdWidth_, '\xFF');
+  return result;
+}
+
+void SortedIndex::scanEntries(
+    uint32_t startChunk,
+    std::string_view startSeekKey,
+    std::string_view endSeekKey,
+    std::string_view boundKey,
+    bool isPointLookup,
+    const std::optional<RowRange>& filterRange,
+    std::vector<RowRange>& rowRanges) const {
+  // Returns true if entries matching the scan range may continue past this
+  // chunk boundary. For point lookup, this means the chunk's last key equals
+  // the lookup key (duplicates span). For range scan, this means the chunk's
+  // last key is below the upper bound.
+  auto hasMoreEntries = [&](uint32_t chunkIdx) {
+    const auto ck = chunkKey(chunkIdx);
+    return isPointLookup ? (ck == boundKey) : (ck < boundKey);
+  };
+
+  std::vector<uint32_t> matchedRows;
+  for (uint32_t ci = startChunk; ci < numChunks_; ++ci) {
+    if (ci > startChunk && !hasMoreEntries(ci - 1)) {
+      break;
+    }
+
+    auto chunk = loadChunk(ci);
+    const uint32_t rowCount = chunk.encoding->rowCount();
+
+    // Seek only in the first chunk. For continuation chunks, the loop guard
+    // ensures entries are in range, so start at 0.
+    const uint32_t startPos = (ci != startChunk)
+        ? 0
+        : chunk.encoding->seek(&startSeekKey, /*inclusive=*/true)
+              .value_or(rowCount);
+    if (startPos >= rowCount) {
+      break;
+    }
+
+    // If all remaining entries in this chunk match, skip the end seek.
+    const uint32_t endPos = hasMoreEntries(ci)
+        ? rowCount
+        : chunk.encoding->seek(&endSeekKey, /*inclusive=*/!isPointLookup)
+              .value_or(rowCount);
+    if (startPos >= endPos) {
+      break;
+    }
+
+    chunk.encoding->reset();
+    chunk.encoding->skip(startPos);
+    std::vector<std::string_view> entries(endPos - startPos);
+    chunk.encoding->materialize(endPos - startPos, entries.data());
+    for (const auto& entry : entries) {
+      matchedRows.emplace_back(extractRowId(entry));
+    }
+  }
+
+  if (filterRange.has_value()) {
+    for (const auto row : matchedRows) {
+      if (filterRange->contains(row)) {
+        rowRanges.emplace_back(row, row + 1);
+      }
+    }
+  } else {
+    for (const auto row : matchedRows) {
+      rowRanges.emplace_back(row, row + 1);
+    }
+  }
+}
+
+void SortedIndex::pointLookup(
+    std::string_view key,
+    const std::optional<RowRange>& filterRange,
+    std::vector<RowRange>& rowRanges) const {
+  if (key < minKey() || key > maxKey()) {
+    ++numMinMaxSkips_;
+    return;
+  }
+  const auto startChunkIdx = findChunkIndex(key);
+  if (!startChunkIdx.has_value()) {
+    return;
+  }
+  const auto firstKey = firstSeekKey(key);
+  const auto lastKey = lastSeekKey(key);
+  scanEntries(
+      startChunkIdx.value(),
+      firstKey,
+      lastKey,
+      key,
+      /*isPointLookup=*/true,
+      filterRange,
+      rowRanges);
+}
+
+void SortedIndex::rangeScan(
+    const velox::serializer::EncodedKeyBounds& bounds,
+    const std::optional<RowRange>& filterRange,
+    std::vector<RowRange>& rowRanges) const {
+  NIMBLE_CHECK(
+      bounds.lowerKey.has_value() && bounds.upperKey.has_value(),
+      "Range scan requires both lower and upper bounds");
+  const auto& lowerKey = bounds.lowerKey.value();
+  const auto& upperKey = bounds.upperKey.value();
+  if (lowerKey > maxKey() || upperKey <= minKey()) {
+    ++numMinMaxSkips_;
+    return;
+  }
+  const auto startChunkIdx = findChunkIndex(lowerKey);
+  if (!startChunkIdx.has_value()) {
+    return;
+  }
+  const auto lowerSeekKey = firstSeekKey(lowerKey);
+  const auto upperSeekKey = firstSeekKey(upperKey);
+  scanEntries(
+      startChunkIdx.value(),
+      lowerSeekKey,
+      upperSeekKey,
+      upperKey,
+      /*isPointLookup=*/false,
+      filterRange,
+      rowRanges);
+}
+
+std::string_view SortedIndex::minKey() const {
+  return sortedIndex_->min_key()->string_view();
+}
+
+std::string_view SortedIndex::maxKey() const {
+  return chunkKey(numChunks_ - 1);
+}
+
+IndexLookup::LookupResult SortedIndex::lookup(
+    const LookupRequest& request) const {
+  const auto& options = request.options();
+
+  std::vector<RowRange> rowRanges;
+  std::vector<uint32_t> resultOffsets;
+  resultOffsets.reserve(request.size() + 1);
+  resultOffsets.push_back(0);
+
+  for (uint32_t i = 0; i < request.size(); ++i) {
+    if (request.mode() == LookupRequest::Mode::PointLookup) {
+      ++numPointLookups_;
+      pointLookup(request.pointKey(i), options.rowRange, rowRanges);
+    } else {
+      ++numRangeScans_;
+      rangeScan(request.rangeBound(i), options.rowRange, rowRanges);
+    }
+
+    numMatchedRows_ += rowRanges.size() - resultOffsets.back();
+    resultOffsets.push_back(rowRanges.size());
+  }
+
+  return LookupResult{std::move(rowRanges), std::move(resultOffsets)};
+}
+
+folly::F14FastMap<std::string, velox::RuntimeMetric> SortedIndex::stats()
+    const {
+  folly::F14FastMap<std::string, velox::RuntimeMetric> result;
+  const auto numPointLookups = numPointLookups_.load();
+  if (numPointLookups > 0) {
+    result.emplace(kNumPointLookups, velox::RuntimeMetric(numPointLookups));
+  }
+  const auto numRangeScans = numRangeScans_.load();
+  if (numRangeScans > 0) {
+    result.emplace(kNumRangeScans, velox::RuntimeMetric(numRangeScans));
+  }
+  const auto numMinMaxSkips = numMinMaxSkips_.load();
+  if (numMinMaxSkips > 0) {
+    result.emplace(kNumMinMaxSkips, velox::RuntimeMetric(numMinMaxSkips));
+  }
+  const auto numMatchedRows = numMatchedRows_.load();
+  if (numMatchedRows > 0) {
+    result.emplace(kNumMatchedRows, velox::RuntimeMetric(numMatchedRows));
+  }
+  return result;
+}
+
+} // namespace facebook::nimble::index

--- a/dwio/nimble/index/SortedIndex.h
+++ b/dwio/nimble/index/SortedIndex.h
@@ -1,0 +1,163 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <atomic>
+#include <memory>
+#include <string>
+#include <string_view>
+#include <vector>
+
+#include <fmt/format.h>
+
+#include "dwio/nimble/index/IndexLookup.h"
+#include "dwio/nimble/index/KeyChunkDecoder.h"
+#include "dwio/nimble/tablet/Callbacks.h"
+#include "dwio/nimble/tablet/MetadataBuffer.h"
+#include "velox/dwio/common/SeekableInputStream.h"
+
+namespace facebook::nimble::serialization {
+struct SortedIndex;
+} // namespace facebook::nimble::serialization
+
+namespace facebook::nimble::index {
+
+/// A sorted index for point lookups and range scans on unsorted data.
+///
+/// Stores a sorted key stream where each entry is
+/// encoded_key || fixed_width_row_id. Lookup uses binary search on chunk
+/// boundary keys, then materializes and searches within the target chunk.
+///
+/// Lookup flow:
+///   1. Binary search chunk keys to find the chunk(s)
+///   2. Load and decode the chunk
+///   3. Materialize entries, binary search by key prefix
+///   4. Extract row IDs from entry suffix
+class SortedIndex : public IndexLookup {
+ public:
+  static constexpr std::string_view kNumPointLookups{
+      "sortedIndex.numPointLookups"};
+  static constexpr std::string_view kNumRangeScans{"sortedIndex.numRangeScans"};
+  static constexpr std::string_view kNumMinMaxSkips{
+      "sortedIndex.numMinMaxSkips"};
+  static constexpr std::string_view kNumMatchedRows{
+      "sortedIndex.numMatchedRows"};
+
+  const std::vector<std::string>& indexColumns() const override {
+    return columns_;
+  }
+
+  LookupResult lookup(const LookupRequest& request) const override;
+
+  std::string_view minKey() const override;
+
+  std::string_view maxKey() const override;
+
+  folly::F14FastMap<std::string, velox::RuntimeMetric> stats() const override;
+
+  static std::unique_ptr<SortedIndex> create(
+      std::vector<std::string> columns,
+      std::unique_ptr<MetadataBuffer> indexMetadata,
+      LoadDataFn loadData,
+      velox::memory::MemoryPool* pool);
+
+ private:
+  SortedIndex(
+      std::vector<std::string> columns,
+      std::unique_ptr<MetadataBuffer> indexMetadata,
+      LoadDataFn loadData,
+      velox::memory::MemoryPool* pool);
+
+  // Finds the chunk index for the given key via binary search on chunk keys.
+  // Returns the index of the first chunk whose last key >= the given key,
+  // or std::nullopt if no chunk contains the key.
+  std::optional<uint32_t> findChunkIndex(std::string_view key) const;
+
+  // Returns the last key of a chunk (used as the chunk boundary key).
+  std::string_view chunkKey(uint32_t chunkIdx) const;
+
+  // Returns the byte offset of a chunk in the key stream.
+  uint32_t chunkOffset(uint32_t chunkIdx) const;
+
+  // Returns the byte size of a chunk.
+  uint32_t chunkSize(uint32_t chunkIdx) const;
+
+  // Returns the row offset (number of entries before this chunk).
+  uint32_t rowOffset(uint32_t chunkIdx) const;
+
+  // Loads a chunk and creates the encoding without materializing entries.
+  DecodedKeyChunk loadChunk(uint32_t chunkIdx) const;
+
+  // Extracts the key prefix (without row ID suffix) from a composite entry.
+  std::string_view extractKey(std::string_view compositeEntry) const;
+
+  // Extracts the row ID from the last rowIdWidth_ bytes of a composite entry.
+  uint32_t extractRowId(std::string_view compositeEntry) const;
+
+  // Builds a composite seek key with minimum row ID suffix (all zeros).
+  // Used as inclusive lower bound in binary search.
+  std::string firstSeekKey(std::string_view key) const;
+
+  // Builds a composite seek key with maximum row ID suffix (all 0xFF).
+  // Used as exclusive upper bound in binary search.
+  std::string lastSeekKey(std::string_view key) const;
+
+  // Performs a point lookup for a single key and appends matching row ranges.
+  void pointLookup(
+      std::string_view key,
+      const std::optional<RowRange>& filterRange,
+      std::vector<RowRange>& rowRanges) const;
+
+  // Performs a range scan and appends matching row ranges.
+  void rangeScan(
+      const velox::serializer::EncodedKeyBounds& bounds,
+      const std::optional<RowRange>& filterRange,
+      std::vector<RowRange>& rowRanges) const;
+
+  // Scans entries across chunks and appends matching row ranges.
+  // boundKey controls chunk iteration: for point lookup this is the lookup key,
+  // for range scan this is the upper bound key.
+  void scanEntries(
+      uint32_t startChunk,
+      std::string_view startSeekKey,
+      std::string_view endSeekKey,
+      std::string_view boundKey,
+      bool isPointLookup,
+      const std::optional<RowRange>& filterRange,
+      std::vector<RowRange>& rowRanges) const;
+
+  const std::vector<std::string> columns_;
+  const std::unique_ptr<MetadataBuffer> indexMetadata_;
+  velox::memory::MemoryPool* const pool_;
+  const uint8_t rowIdWidth_;
+
+  // Callback to load key stream data from file by region.
+  const LoadDataFn loadData_;
+
+  // Parsed from the FlatBuffer.
+  const serialization::SortedIndex* const sortedIndex_;
+  const uint32_t numChunks_;
+
+  // Reusable buffer for multi-buffer chunk reads.
+  mutable velox::BufferPtr chunkBuffer_;
+
+  mutable std::atomic_uint64_t numPointLookups_{0};
+  mutable std::atomic_uint64_t numRangeScans_{0};
+  mutable std::atomic_uint64_t numMinMaxSkips_{0};
+  mutable std::atomic_uint64_t numMatchedRows_{0};
+};
+
+} // namespace facebook::nimble::index

--- a/dwio/nimble/index/SortedIndexWriter.cpp
+++ b/dwio/nimble/index/SortedIndexWriter.cpp
@@ -1,0 +1,351 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "dwio/nimble/index/SortedIndexWriter.h"
+
+#include <algorithm>
+#include <limits>
+#include <set>
+
+#include <fmt/ranges.h>
+
+#include "dwio/nimble/common/Exceptions.h"
+#include "dwio/nimble/encodings/EncodingFactory.h"
+#include "dwio/nimble/encodings/EncodingLayout.h"
+#include "dwio/nimble/encodings/EncodingSelectionPolicy.h"
+#include "dwio/nimble/tablet/Constants.h"
+#include "dwio/nimble/tablet/SortedIndexGenerated.h"
+#include "dwio/nimble/velox/ChunkedStreamWriter.h"
+#include "dwio/nimble/velox/StreamData.h"
+#include "flatbuffers/flatbuffers.h"
+
+#include "velox/common/base/BitUtil.h"
+#include "velox/common/base/Nulls.h"
+
+namespace facebook::nimble::index {
+
+namespace {
+
+std::vector<std::vector<std::string>> extractColumnSets(
+    const std::vector<SortedIndexConfig>& configs) {
+  std::vector<std::vector<std::string>> columnSets;
+  columnSets.reserve(configs.size());
+  for (const auto& config : configs) {
+    columnSets.emplace_back(config.columns);
+  }
+  return columnSets;
+}
+
+std::unique_ptr<EncodingSelectionPolicy<std::string_view>> createEncodingPolicy(
+    const EncodingLayout& layout) {
+  return std::make_unique<ReplayedEncodingSelectionPolicy<std::string_view>>(
+      layout,
+      CompressionOptions{},
+      [](DataType) -> std::unique_ptr<EncodingSelectionPolicyBase> {
+        return nullptr;
+      });
+}
+
+} // namespace
+
+// static
+uint8_t SortedIndexWriter::rowIdWidth(uint32_t numRows) {
+  if (numRows <= std::numeric_limits<uint8_t>::max()) {
+    return 1;
+  }
+  if (numRows <= std::numeric_limits<uint16_t>::max()) {
+    return 2;
+  }
+  if (numRows <= 0xFF'FFFF) {
+    return 3;
+  }
+  return 4;
+}
+
+void SortedIndexWriter::IndexAccumulator::sort() {
+  std::sort(
+      entries.begin(),
+      entries.end(),
+      [](const IndexEntry& a, const IndexEntry& b) {
+        if (a.key != b.key) {
+          return a.key < b.key;
+        }
+        return a.row < b.row;
+      });
+}
+
+void SortedIndexWriter::IndexAccumulator::clear() {
+  entries.clear();
+  entries.shrink_to_fit();
+  encoder.reset();
+  encodingBuffer.reset();
+}
+
+SortedIndexWriter::CompositeEntries SortedIndexWriter::buildCompositeEntries(
+    const std::vector<IndexEntry>& entries,
+    uint8_t idWidth) const {
+  uint64_t totalBytes = 0;
+  for (const auto& entry : entries) {
+    totalBytes += entry.key.size() + idWidth;
+  }
+
+  CompositeEntries result;
+  result.buffer = velox::AlignedBuffer::allocate<char>(totalBytes, pool_);
+  auto* dest = result.buffer->asMutable<char>();
+
+  result.entries.reserve(entries.size());
+  for (const auto& entry : entries) {
+    auto* entryStart = dest;
+    std::memcpy(dest, entry.key.data(), entry.key.size());
+    dest += entry.key.size();
+    for (int8_t shift = (idWidth - 1) * 8; shift >= 0; shift -= 8) {
+      *dest++ = static_cast<char>((entry.row >> shift) & 0xFF);
+    }
+    result.entries.emplace_back(entryStart, entry.key.size() + idWidth);
+  }
+  return result;
+}
+
+std::unique_ptr<SortedIndexWriter> SortedIndexWriter::create(
+    const std::vector<SortedIndexConfig>& configs,
+    const velox::TypePtr& inputType,
+    velox::memory::MemoryPool* pool) {
+  if (configs.empty()) {
+    return nullptr;
+  }
+  NIMBLE_CHECK_NOT_NULL(pool, "memory pool must not be null");
+  return std::unique_ptr<SortedIndexWriter>(
+      new SortedIndexWriter(configs, velox::asRowType(inputType), pool));
+}
+
+SortedIndexWriter::SortedIndexWriter(
+    const std::vector<SortedIndexConfig>& configs,
+    const velox::RowTypePtr& inputType,
+    velox::memory::MemoryPool* pool)
+    : pool_{pool},
+      keyColumnIndices_{
+          getKeyColumnIndices(extractColumnSets(configs), inputType)} {
+  NIMBLE_CHECK(!configs.empty(), "Sorted index configs must not be empty");
+  accumulators_.reserve(configs.size());
+  for (const auto& config : configs) {
+    NIMBLE_CHECK(
+        !config.columns.empty(), "Sorted index must have at least one column");
+    for (size_t i = 0; i < accumulators_.size(); ++i) {
+      NIMBLE_CHECK(
+          accumulators_[i].config.columns != config.columns,
+          "Duplicate sorted index columns: [{}]",
+          fmt::join(config.columns, ", "));
+    }
+    accumulators_.emplace_back(
+        IndexAccumulator{
+            .config = config,
+            .encoder = createKeyEncoder(config.columns, inputType, pool),
+        });
+  }
+}
+
+void SortedIndexWriter::write(const velox::VectorPtr& input) {
+  checkNotClosed();
+  if (input->size() == 0) {
+    return;
+  }
+
+  NIMBLE_USER_CHECK_LE(
+      numRows_ + static_cast<uint64_t>(input->size()),
+      static_cast<uint64_t>(std::numeric_limits<uint32_t>::max()),
+      "Sorted index row count exceeds uint32 limit");
+
+  validateNoNullKeys(input, keyColumnIndices_);
+
+  for (auto& accumulator : accumulators_) {
+    if (accumulator.encodingBuffer == nullptr) {
+      accumulator.encodingBuffer = std::make_unique<Buffer>(*pool_);
+    }
+    std::vector<std::string_view> keys;
+    accumulator.encoder->encode(input, keys, [&accumulator](size_t size) {
+      return accumulator.encodingBuffer->reserve(size);
+    });
+
+    const auto newSize = accumulator.entries.size() + input->size();
+    if (accumulator.entries.capacity() < newSize) {
+      accumulator.entries.reserve(
+          std::max(accumulator.entries.size() * 2, newSize));
+    }
+    for (velox::vector_size_t i = 0; i < input->size(); ++i) {
+      accumulator.entries.emplace_back(IndexEntry{keys[i], numRows_ + i});
+    }
+  }
+
+  numRows_ += input->size();
+}
+
+void SortedIndexWriter::buildIndex(
+    IndexAccumulator& accumulator,
+    const WriteDataFn& writeDataFn,
+    flatbuffers::FlatBufferBuilder& builder) {
+  accumulator.sort();
+
+  const uint8_t idWidth = rowIdWidth(numRows_);
+  auto composite = buildCompositeEntries(accumulator.entries, idWidth);
+
+  // Free entries and encoder — composite buffer now owns all key data.
+  accumulator.clear();
+
+  // Chunk and encode following ClusterIndexWriter pattern.
+  const uint64_t maxRows = accumulator.config.maxRowsPerKeyChunk > 0
+      ? accumulator.config.maxRowsPerKeyChunk
+      : composite.entries.size();
+
+  const auto numChunks = static_cast<uint32_t>(
+      velox::bits::divRoundUp(composite.entries.size(), maxRows));
+  std::vector<uint32_t> chunkRows;
+  chunkRows.reserve(numChunks);
+  std::vector<uint32_t> chunkOffsets;
+  chunkOffsets.reserve(numChunks);
+  std::vector<std::string_view> chunkKeys;
+  chunkKeys.reserve(numChunks);
+  std::vector<std::string_view> encodedChunks;
+  Buffer encodingBuffer(*pool_);
+  uint32_t keyStreamOffset = 0;
+
+  for (size_t offset = 0; offset < composite.entries.size();) {
+    const auto remaining =
+        static_cast<uint64_t>(composite.entries.size() - offset);
+    const auto numChunkRows = remaining < 2 * maxRows ? remaining : maxRows;
+
+    auto span = std::span<const std::string_view>(
+        composite.entries.data() + offset, numChunkRows);
+
+    // Encode chunk using EncodingFactory (Prefix or Trivial).
+    const auto encoded = EncodingFactory::encode<std::string_view>(
+        createEncodingPolicy(accumulator.config.encodingLayout),
+        span,
+        encodingBuffer);
+    NIMBLE_CHECK(!encoded.empty());
+
+    // Wrap with ChunkedStreamWriter.
+    ChunkedStreamWriter chunkWriter{encodingBuffer};
+    uint32_t chunkEncodedSize = 0;
+    for (auto& contentBuffer : chunkWriter.encode(encoded)) {
+      encodedChunks.push_back(std::move(contentBuffer));
+      chunkEncodedSize += encodedChunks.back().size();
+    }
+
+    // Record chunk metadata.
+    const uint32_t accumulatedRows =
+        chunkRows.empty() ? numChunkRows : chunkRows.back() + numChunkRows;
+    chunkRows.emplace_back(accumulatedRows);
+    chunkOffsets.emplace_back(keyStreamOffset);
+    chunkKeys.emplace_back(
+        extractKey(composite.entries[offset + numChunkRows - 1], idWidth));
+
+    keyStreamOffset += chunkEncodedSize;
+    offset += numChunkRows;
+  }
+
+  // Write key stream data blob to file via WriteDataFn.
+  const auto [fileOffset, fileSize] = writeDataFn(encodedChunks);
+  NIMBLE_CHECK_EQ(
+      keyStreamOffset,
+      fileSize,
+      "Key stream offset mismatch: tracked {} vs written {}",
+      keyStreamOffset,
+      fileSize);
+
+  // Build root SortedIndex FlatBuffer.
+  auto chunkRowsVec = builder.CreateVector(chunkRows);
+  auto chunkOffsetsVec = builder.CreateVector(chunkOffsets);
+  auto chunkKeysVec =
+      builder.CreateVector<flatbuffers::Offset<flatbuffers::String>>(
+          chunkKeys.size(), [&builder, &chunkKeys](size_t i) {
+            return builder.CreateString(
+                chunkKeys[i].data(), chunkKeys[i].size());
+          });
+  auto minKeyVec = builder.CreateString(
+      composite.entries.front().data(),
+      composite.entries.front().size() - idWidth);
+
+  builder.Finish(
+      serialization::CreateSortedIndex(
+          builder,
+          idWidth,
+          chunkRowsVec,
+          chunkOffsetsVec,
+          chunkKeysVec,
+          minKeyVec,
+          fileOffset,
+          fileSize));
+}
+
+void SortedIndexWriter::buildDirectoryFlatBuffer(
+    flatbuffers::FlatBufferBuilder& builder,
+    const std::vector<MetadataSection>& indexSections) const {
+  NIMBLE_CHECK(!accumulators_.empty());
+  NIMBLE_CHECK_EQ(indexSections.size(), accumulators_.size());
+
+  std::vector<flatbuffers::Offset<serialization::SortedIndexSection>>
+      sectionOffsets;
+  sectionOffsets.reserve(accumulators_.size());
+
+  for (size_t i = 0; i < accumulators_.size(); ++i) {
+    std::vector<flatbuffers::Offset<flatbuffers::String>> columnOffsets;
+    columnOffsets.reserve(accumulators_[i].config.columns.size());
+    for (const auto& col : accumulators_[i].config.columns) {
+      columnOffsets.emplace_back(builder.CreateString(col));
+    }
+    auto columnsVec = builder.CreateVector(columnOffsets);
+
+    const auto& section = indexSections[i];
+    auto metadataSection = serialization::CreateMetadataSection(
+        builder,
+        section.offset(),
+        section.size(),
+        static_cast<serialization::CompressionType>(section.compressionType()));
+
+    sectionOffsets.emplace_back(
+        serialization::CreateSortedIndexSection(
+            builder, columnsVec, metadataSection));
+  }
+
+  auto indicesVec = builder.CreateVector(sectionOffsets);
+  builder.Finish(
+      serialization::CreateSortedIndexDirectory(builder, indicesVec));
+}
+
+void SortedIndexWriter::close(
+    const WriteDataFn& writeDataFn,
+    const CreateMetadataSectionFn& createMetadataFn,
+    const WriteOptionalSectionFn& writeMetadataFn) {
+  setClosed();
+
+  if (numRows_ == 0) {
+    return;
+  }
+
+  std::vector<MetadataSection> indexSections;
+  indexSections.reserve(accumulators_.size());
+  for (auto& accumulator : accumulators_) {
+    flatbuffers::FlatBufferBuilder indexBuilder;
+    buildIndex(accumulator, writeDataFn, indexBuilder);
+    indexSections.emplace_back(createMetadataFn(asStringView(indexBuilder)));
+  }
+
+  flatbuffers::FlatBufferBuilder directoryBuilder;
+  buildDirectoryFlatBuffer(directoryBuilder, indexSections);
+  writeMetadataFn(
+      std::string(kSortedIndexSection), asStringView(directoryBuilder));
+}
+
+} // namespace facebook::nimble::index

--- a/dwio/nimble/index/SortedIndexWriter.h
+++ b/dwio/nimble/index/SortedIndexWriter.h
@@ -1,0 +1,149 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "dwio/nimble/common/Buffer.h"
+#include "dwio/nimble/index/IndexConfig.h"
+#include "dwio/nimble/index/IndexWriter.h"
+#include "dwio/nimble/tablet/MetadataBuffer.h"
+#include "flatbuffers/flatbuffers.h"
+#include "velox/buffer/Buffer.h"
+#include "velox/common/memory/Memory.h"
+#include "velox/serializers/KeyEncoder.h"
+#include "velox/vector/ComplexVector.h"
+
+namespace facebook::nimble::serialization {
+struct SortedIndex;
+} // namespace facebook::nimble::serialization
+
+namespace facebook::nimble::index {
+
+namespace test {
+class SortedIndexWriterTestHelper;
+} // namespace test
+
+/// Builds one or more sorted indices during file write.
+///
+/// Each sorted index stores a sorted key stream where entries are
+/// encoded_key || fixed_width_row_id. At close time, entries are sorted by
+/// key, chunked, and encoded using the same pipeline as ClusterIndex
+/// (EncodingFactory with Prefix/Trivial → ChunkedStreamWriter).
+///
+/// Supports both point lookups (binary search) and range scans on unsorted
+/// data. Unlike HashIndex (point-only, O(1)), this provides O(log n) lookups
+/// with range scan support.
+class SortedIndexWriter : public IndexWriter {
+ public:
+  /// Factory method. Returns nullptr if configs is empty.
+  static std::unique_ptr<SortedIndexWriter> create(
+      const std::vector<SortedIndexConfig>& configs,
+      const velox::TypePtr& inputType,
+      velox::memory::MemoryPool* pool);
+
+  ~SortedIndexWriter() override = default;
+
+  SortedIndexWriter(const SortedIndexWriter&) = delete;
+  SortedIndexWriter& operator=(const SortedIndexWriter&) = delete;
+  SortedIndexWriter(SortedIndexWriter&&) = delete;
+  SortedIndexWriter& operator=(SortedIndexWriter&&) = delete;
+
+  void write(const velox::VectorPtr& input) override;
+
+  void close(
+      const WriteDataFn& writeDataFn,
+      const CreateMetadataSectionFn& createMetadataFn,
+      const WriteOptionalSectionFn& writeMetadataFn) override;
+
+ private:
+  SortedIndexWriter(
+      const std::vector<SortedIndexConfig>& configs,
+      const velox::RowTypePtr& inputType,
+      velox::memory::MemoryPool* pool);
+
+  struct IndexEntry {
+    std::string_view key;
+    uint32_t row;
+  };
+
+  struct IndexAccumulator {
+    SortedIndexConfig config;
+    std::unique_ptr<velox::serializer::KeyEncoder> encoder;
+    std::vector<IndexEntry> entries;
+    // Backs encoded key string_views in entries. Each accumulator owns its
+    // buffer so it can be freed independently after composite entries are
+    // built.
+    std::unique_ptr<Buffer> encodingBuffer;
+
+    void sort();
+    void clear();
+  };
+
+  // Sorted composite entries with backing buffer.
+  struct CompositeEntries {
+    // Contiguous buffer backing all entry string_views.
+    velox::BufferPtr buffer;
+    // Views into buffer, one per entry: encoded_key || big_endian_row_id.
+    std::vector<std::string_view> entries;
+  };
+
+  // Determines the row ID width in bytes for the given row count.
+  static uint8_t rowIdWidth(uint32_t numRows);
+
+  // Extracts the key prefix (without row ID suffix) from a composite entry.
+  static std::string_view extractKey(
+      std::string_view compositeEntry,
+      uint8_t idWidth) {
+    return compositeEntry.substr(0, compositeEntry.size() - idWidth);
+  }
+
+  // Builds sorted composite entries from the accumulator's index entries.
+  // Each composite entry is encoded_key || big_endian_row_id packed into a
+  // single contiguous buffer.
+  CompositeEntries buildCompositeEntries(
+      const std::vector<IndexEntry>& entries,
+      uint8_t idWidth) const;
+
+  // Builds a single sorted index and writes its key stream data to the file.
+  void buildIndex(
+      IndexAccumulator& accumulator,
+      const WriteDataFn& writeDataFn,
+      flatbuffers::FlatBufferBuilder& builder);
+
+  // Builds the directory FlatBuffer with all index descriptors.
+  void buildDirectoryFlatBuffer(
+      flatbuffers::FlatBufferBuilder& builder,
+      const std::vector<MetadataSection>& indexSections) const;
+
+  static std::string_view asStringView(
+      const flatbuffers::FlatBufferBuilder& builder) {
+    return {
+        reinterpret_cast<const char*>(builder.GetBufferPointer()),
+        builder.GetSize()};
+  }
+
+  velox::memory::MemoryPool* const pool_;
+  const std::vector<velox::column_index_t> keyColumnIndices_;
+  std::vector<IndexAccumulator> accumulators_;
+  uint32_t numRows_{0};
+
+  friend class test::SortedIndexWriterTestHelper;
+};
+
+} // namespace facebook::nimble::index

--- a/dwio/nimble/index/tests/ClusterIndexTest.cpp
+++ b/dwio/nimble/index/tests/ClusterIndexTest.cpp
@@ -147,6 +147,9 @@ TEST_F(ClusterIndexTest, basic) {
   EXPECT_EQ(cols[1], "col2");
   EXPECT_EQ(cols[2], "col3");
 
+  EXPECT_EQ(clusterIndex->minKey(), "aaa");
+  EXPECT_EQ(clusterIndex->maxKey(), "eee");
+
   ClusterIndexTestHelper helper(clusterIndex.get());
   auto metadata0 = helper.partitionSection(0);
   EXPECT_EQ(metadata0.offset(), 0);
@@ -212,6 +215,9 @@ TEST_F(ClusterIndexTest, lookup) {
   // Partition 0: rows 0-1 (keys "ccc", "fff")
   // Partition 1: rows 2 (key "iii")
   // Total: 3 rows.
+
+  EXPECT_EQ(clusterIndex->minKey(), "aaa");
+  EXPECT_EQ(clusterIndex->maxKey(), "iii");
 
   // Key before minKey returns full file range.
   {

--- a/dwio/nimble/index/tests/ClusterIndexTestUtils.cpp
+++ b/dwio/nimble/index/tests/ClusterIndexTestUtils.cpp
@@ -359,6 +359,7 @@ void TestClusterIndexMetadataWriter::flushPartitionMetadata(
 TabletWriter::CloseCallback
 TestClusterIndexMetadataWriter::createCloseCallback() {
   return [this](
+             const WriteDataFn& /*writeDataFn*/,
              const CreateMetadataSectionFn& /*createMetadataFn*/,
              const WriteOptionalSectionFn& writeMetadataFn) {
     writeRoot(writeMetadataFn);

--- a/dwio/nimble/index/tests/ClusterIndexWriterTest.cpp
+++ b/dwio/nimble/index/tests/ClusterIndexWriterTest.cpp
@@ -155,7 +155,7 @@ TEST_F(ClusterIndexWriterTest, rejectNullKeys) {
 
     NIMBLE_ASSERT_USER_THROW(
         writer->write(batch),
-        "Null value not allowed in key column at index 1: found 1 null(s)");
+        "Null value not allowed in index key column at index 1: found 1 null(s)");
   }
 
   // Test multiple nulls in key column
@@ -176,7 +176,7 @@ TEST_F(ClusterIndexWriterTest, rejectNullKeys) {
 
     NIMBLE_ASSERT_USER_THROW(
         writer->write(batch),
-        "Null value not allowed in key column at index 1: found 3 null(s)");
+        "Null value not allowed in index key column at index 1: found 3 null(s)");
   }
 
   // Test no nulls passes validation
@@ -910,7 +910,9 @@ TEST_P(ClusterIndexWriterDataTest, close) {
   };
   WriteOptionalSectionFn noopWriteFn = [](const std::string&,
                                           std::string_view) {};
-  writer->close(createMetadataFn, noopWriteFn);
+  WriteDataFn noopWriteDataFn = [](const std::vector<std::string_view>&)
+      -> std::pair<uint64_t, uint32_t> { return {0, 0}; };
+  writer->close(noopWriteDataFn, createMetadataFn, noopWriteFn);
 }
 
 TEST_P(ClusterIndexWriterDataTest, writeAfterClose) {
@@ -925,14 +927,15 @@ TEST_P(ClusterIndexWriterDataTest, writeAfterClose) {
   };
   WriteOptionalSectionFn noopWriteFn = [](const std::string&,
                                           std::string_view) {};
-  writer->close(createMetadataFn, noopWriteFn);
+  WriteDataFn noopWriteDataFn = [](const std::vector<std::string_view>&)
+      -> std::pair<uint64_t, uint32_t> { return {0, 0}; };
+  writer->close(noopWriteDataFn, createMetadataFn, noopWriteFn);
 
   NIMBLE_ASSERT_THROW(
-      writer->write(makeInput({4, 5, 6})),
-      "ClusterIndexWriter has been closed");
+      writer->write(makeInput({4, 5, 6})), "IndexWriter has been closed");
   NIMBLE_ASSERT_THROW(
-      writer->close(createMetadataFn, noopWriteFn),
-      "ClusterIndexWriter has been closed");
+      writer->close(noopWriteDataFn, createMetadataFn, noopWriteFn),
+      "close() already called");
 }
 
 INSTANTIATE_TEST_SUITE_P(
@@ -1084,7 +1087,10 @@ TEST_P(ClusterIndexWriterChunkTest, maxRowsPerKeyChunk) {
 
   // Close the writer and capture the root index data.
   std::string rootIndexData;
+  WriteDataFn noopWriteDataFn2 = [](const std::vector<std::string_view>&)
+      -> std::pair<uint64_t, uint32_t> { return {0, 0}; };
   writer->close(
+      noopWriteDataFn2,
       createMetadataFn,
       [&rootIndexData](const std::string&, std::string_view content) {
         rootIndexData = std::string(content);

--- a/dwio/nimble/index/tests/DenseIndexRegistryTest.cpp
+++ b/dwio/nimble/index/tests/DenseIndexRegistryTest.cpp
@@ -1,0 +1,209 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <gtest/gtest.h>
+#include <deque>
+
+#include "dwio/nimble/common/tests/GTestUtils.h"
+#include "dwio/nimble/index/DenseIndexRegistry.h"
+#include "dwio/nimble/index/HashIndex.h"
+#include "dwio/nimble/index/IndexConfig.h"
+#include "dwio/nimble/index/IndexLookup.h"
+#include "dwio/nimble/index/SortedIndex.h"
+
+#include "dwio/nimble/tablet/TabletReader.h"
+#include "dwio/nimble/velox/VeloxReader.h"
+#include "dwio/nimble/velox/VeloxWriter.h"
+#include "velox/common/file/FileSystems.h"
+#include "velox/common/memory/Memory.h"
+#include "velox/common/testutil/TempDirectoryPath.h"
+#include "velox/vector/FlatVector.h"
+
+namespace facebook::nimble::index {
+namespace {
+
+class DenseIndexRegistryTest : public ::testing::Test {
+ protected:
+  static void SetUpTestCase() {
+    velox::filesystems::registerLocalFileSystem();
+    velox::memory::MemoryManager::testingSetInstance({});
+  }
+
+  void SetUp() override {
+    pool_ =
+        velox::memory::memoryManager()->addRootPool("DenseIndexRegistryTest");
+    leafPool_ = pool_->addLeafChild("leaf");
+    tempDir_ = velox::common::testutil::TempDirectoryPath::create();
+  }
+
+  static velox::RowTypePtr rowType() {
+    return velox::ROW({{"id", velox::INTEGER()}, {"value", velox::VARCHAR()}});
+  }
+
+  velox::VectorPtr makeBatch(int32_t startRow, int32_t numRows) {
+    auto ids =
+        velox::BaseVector::create(velox::INTEGER(), numRows, leafPool_.get());
+    auto values =
+        velox::BaseVector::create(velox::VARCHAR(), numRows, leafPool_.get());
+    auto* flatIds = ids->asFlatVector<int32_t>();
+    auto* flatValues = values->asFlatVector<velox::StringView>();
+    for (int i = 0; i < numRows; ++i) {
+      const int32_t id = startRow + i;
+      flatIds->set(i, id);
+      valueStrings_.emplace_back("v_" + std::to_string(id));
+      flatValues->set(i, velox::StringView(valueStrings_.back()));
+    }
+    return std::make_shared<velox::RowVector>(
+        leafPool_.get(),
+        rowType(),
+        nullptr,
+        numRows,
+        std::vector<velox::VectorPtr>{ids, values});
+  }
+
+  void writeFile(
+      const std::string& filePath,
+      const velox::RowTypePtr& schema,
+      const std::vector<velox::VectorPtr>& batches,
+      VeloxWriterOptions options) {
+    auto fs = velox::filesystems::getFileSystem(filePath, {});
+    auto file = fs->openFileForWrite(
+        filePath,
+        {.shouldCreateParentDirectories = true,
+         .shouldThrowOnFileAlreadyExists = false});
+
+    VeloxWriter writer(schema, std::move(file), *pool_, std::move(options));
+    for (const auto& batch : batches) {
+      writer.write(batch);
+    }
+    writer.close();
+  }
+
+  std::shared_ptr<TabletReader> openTablet(const std::string& filePath) {
+    auto fs = velox::filesystems::getFileSystem(filePath, {});
+    auto readFile = fs->openFileForRead(filePath);
+    return TabletReader::create(std::move(readFile), leafPool_.get(), {});
+  }
+
+  std::string tempFilePath(const std::string& name) {
+    return tempDir_->getPath() + "/" + name;
+  }
+
+  std::shared_ptr<velox::memory::MemoryPool> pool_;
+  std::shared_ptr<velox::memory::MemoryPool> leafPool_;
+  std::shared_ptr<velox::common::testutil::TempDirectoryPath> tempDir_;
+  std::deque<std::string> valueStrings_;
+};
+
+TEST_F(DenseIndexRegistryTest, emptyRegistry) {
+  auto registry = DenseIndexRegistry::create(
+      std::nullopt,
+      std::nullopt,
+      [](const MetadataSection&) { return nullptr; },
+      [](const velox::common::Region&) { return nullptr; },
+      leafPool_.get());
+  EXPECT_EQ(registry, nullptr);
+}
+
+TEST_F(DenseIndexRegistryTest, hashOnlyRegistry) {
+  std::vector<velox::VectorPtr> batches;
+  batches.push_back(makeBatch(0, 50));
+
+  const auto filePath = tempFilePath("hash_only");
+  VeloxWriterOptions options;
+  options.hashIndexConfigs.push_back(HashIndexConfig{.columns = {"id"}});
+  writeFile(filePath, rowType(), batches, std::move(options));
+
+  auto tablet = openTablet(filePath);
+
+  // Hash index on {"id"} should be found.
+  auto* hashIdx = tablet->denseIndex({"id"});
+  ASSERT_NE(hashIdx, nullptr);
+  EXPECT_EQ(hashIdx->type(), IndexType::Hash);
+  EXPECT_EQ(hashIdx->indexColumns(), std::vector<std::string>{"id"});
+
+  // Non-existent columns should return null.
+  EXPECT_EQ(tablet->denseIndex({"nonexistent"}), nullptr);
+}
+
+TEST_F(DenseIndexRegistryTest, sortedOnlyRegistry) {
+  std::vector<velox::VectorPtr> batches;
+  batches.push_back(makeBatch(0, 50));
+
+  const auto filePath = tempFilePath("sorted_only");
+  VeloxWriterOptions options;
+  options.sortedIndexConfigs.push_back(SortedIndexConfig{.columns = {"value"}});
+  writeFile(filePath, rowType(), batches, std::move(options));
+
+  auto tablet = openTablet(filePath);
+
+  // Sorted index on {"value"} should be found.
+  auto* sortedIdx = tablet->denseIndex({"value"});
+  ASSERT_NE(sortedIdx, nullptr);
+  EXPECT_EQ(sortedIdx->type(), IndexType::Sorted);
+  EXPECT_EQ(sortedIdx->indexColumns(), std::vector<std::string>{"value"});
+
+  // Non-existent columns should return null.
+  EXPECT_EQ(tablet->denseIndex({"nonexistent"}), nullptr);
+}
+
+TEST_F(DenseIndexRegistryTest, hashAndSortedLookup) {
+  std::vector<velox::VectorPtr> batches;
+  batches.push_back(makeBatch(0, 50));
+
+  const auto filePath = tempFilePath("hash_and_sorted");
+  VeloxWriterOptions options;
+  options.hashIndexConfigs.push_back(HashIndexConfig{.columns = {"id"}});
+  options.sortedIndexConfigs.push_back(SortedIndexConfig{.columns = {"value"}});
+  writeFile(filePath, rowType(), batches, std::move(options));
+
+  auto tablet = openTablet(filePath);
+
+  // Hash index on {"id"} should be found.
+  auto* hashIdx = tablet->denseIndex({"id"});
+  ASSERT_NE(hashIdx, nullptr);
+  EXPECT_EQ(hashIdx->type(), IndexType::Hash);
+
+  // Sorted index on {"value"} should be found.
+  auto* sortedIdx = tablet->denseIndex({"value"});
+  ASSERT_NE(sortedIdx, nullptr);
+  EXPECT_EQ(sortedIdx->type(), IndexType::Sorted);
+
+  // Non-existent columns should return null.
+  EXPECT_EQ(tablet->denseIndex({"nonexistent"}), nullptr);
+}
+
+TEST_F(DenseIndexRegistryTest, crossTypeDuplicateColumns) {
+  std::vector<velox::VectorPtr> batches;
+  batches.push_back(makeBatch(0, 50));
+
+  const auto filePath = tempFilePath("cross_type_duplicate");
+  VeloxWriterOptions options;
+  options.hashIndexConfigs.push_back(HashIndexConfig{.columns = {"id"}});
+  options.sortedIndexConfigs.push_back(SortedIndexConfig{.columns = {"id"}});
+
+  // The writer does not validate across index types, so writing succeeds.
+  writeFile(filePath, rowType(), batches, std::move(options));
+
+  // Opening the file should throw because the registry detects duplicate
+  // column sets across hash and sorted index types.
+  NIMBLE_ASSERT_THROW(
+      openTablet(filePath),
+      "Duplicate dense index columns across hash and sorted");
+}
+
+} // namespace
+} // namespace facebook::nimble::index

--- a/dwio/nimble/index/tests/HashIndexTest.cpp
+++ b/dwio/nimble/index/tests/HashIndexTest.cpp
@@ -144,11 +144,11 @@ class HashIndexTestBase {
 
   // Performs a point lookup and returns the result.
   IndexLookup::LookupResult pointLookup(
-      const HashIndex* hashIndex,
+      const IndexLookup* index,
       const std::vector<std::string>& columns,
       int32_t idValue) {
     auto key = encodeLookupKey(columns, idValue);
-    return hashIndex->lookup(
+    return index->lookup(
         IndexLookup::LookupRequest::pointLookup({std::move(key)}));
   }
 
@@ -240,6 +240,9 @@ TEST_P(HashIndexParamTest, roundTrip) {
   ASSERT_NE(hashIndex, nullptr);
   EXPECT_EQ(hashIndex->type(), IndexType::Hash);
   EXPECT_EQ(hashIndex->indexColumns(), columns());
+  EXPECT_FALSE(hashIndex->minKey().empty());
+  EXPECT_FALSE(hashIndex->maxKey().empty());
+  EXPECT_LE(hashIndex->minKey(), hashIndex->maxKey());
 }
 
 TEST_P(HashIndexParamTest, pointLookup) {
@@ -252,6 +255,9 @@ TEST_P(HashIndexParamTest, pointLookup) {
   auto tablet = openTablet(filePath);
   auto* hashIndex = tablet->denseIndex(columns());
   ASSERT_NE(hashIndex, nullptr);
+  EXPECT_FALSE(hashIndex->minKey().empty());
+  EXPECT_FALSE(hashIndex->maxKey().empty());
+  EXPECT_LE(hashIndex->minKey(), hashIndex->maxKey());
 
   {
     auto result = pointLookup(hashIndex, columns(), 20);
@@ -313,7 +319,16 @@ TEST_P(HashIndexParamTest, bloomFilterSkips) {
     const auto stats = hashIndex->stats();
     EXPECT_EQ(
         stats.at(HashIndex::kNumLookups).sum, kNumExisting + kNumNonExistent);
-    EXPECT_EQ(stats.at(HashIndex::kNumBloomFilterSkips).sum, kNumNonExistent);
+    // Non-existent keys are skipped by min/max check and/or bloom filter.
+    // All non-existent keys should be skipped by one of the two filters.
+    const int64_t numMinMaxSkips = stats.count(HashIndex::kNumMinMaxSkips) > 0
+        ? stats.at(HashIndex::kNumMinMaxSkips).sum
+        : 0;
+    const int64_t numBloomFilterSkips =
+        stats.count(HashIndex::kNumBloomFilterSkips) > 0
+        ? stats.at(HashIndex::kNumBloomFilterSkips).sum
+        : 0;
+    EXPECT_EQ(numMinMaxSkips + numBloomFilterSkips, kNumNonExistent);
     EXPECT_EQ(stats.at(HashIndex::kNumMatchedRows).sum, kNumExisting);
   }
 }

--- a/dwio/nimble/index/tests/HashIndexWriterTest.cpp
+++ b/dwio/nimble/index/tests/HashIndexWriterTest.cpp
@@ -103,6 +103,12 @@ class HashIndexWriterTestBase : public velox::test::VectorTestBase {
     return [](const std::string&, std::string_view) {};
   }
 
+  // No-op data write function for tests.
+  static WriteDataFn noopWriteDataFn() {
+    return [](const std::vector<std::string_view>&)
+               -> std::pair<uint64_t, uint32_t> { return {0, 0}; };
+  }
+
   // Validates the HashIndexDirectory has the expected indices with the
   // expected column names per index.
   static void validateDirectory(
@@ -311,9 +317,10 @@ TEST_P(HashIndexWriterParamTest, writeEmptyVector) {
 
   MockSectionStore store;
   bool writeCalled = false;
-  writer->close(store.createFn(), [&](const std::string&, std::string_view) {
-    writeCalled = true;
-  });
+  writer->close(
+      noopWriteDataFn(),
+      store.createFn(),
+      [&](const std::string&, std::string_view) { writeCalled = true; });
   EXPECT_FALSE(writeCalled);
   EXPECT_TRUE(store.sections.empty());
 }
@@ -330,7 +337,7 @@ TEST_P(HashIndexWriterParamTest, writeSingleBatch) {
 
   MockSectionStore store;
   std::string directory;
-  writer->close(store.createFn(), writeFn(directory));
+  writer->close(noopWriteDataFn(), store.createFn(), writeFn(directory));
 
   const auto& columns = GetParam().columns;
   validateDirectory(directory, {columns});
@@ -351,7 +358,7 @@ TEST_P(HashIndexWriterParamTest, writeMultipleBatches) {
 
   MockSectionStore store;
   std::string directory;
-  writer->close(store.createFn(), writeFn(directory));
+  writer->close(noopWriteDataFn(), store.createFn(), writeFn(directory));
 
   const auto& columns = GetParam().columns;
   validateDirectory(directory, {columns});
@@ -374,7 +381,7 @@ TEST_P(HashIndexWriterParamTest, writeWithEmptyBatchesMixed) {
 
   MockSectionStore store;
   std::string directory;
-  writer->close(store.createFn(), writeFn(directory));
+  writer->close(noopWriteDataFn(), store.createFn(), writeFn(directory));
 
   const auto& columns = GetParam().columns;
   validateDirectory(directory, {columns});
@@ -444,8 +451,7 @@ TEST_F(HashIndexWriterTest, rejectNullKeys) {
 
     if (tc.expectThrow) {
       NIMBLE_ASSERT_USER_THROW(
-          writer->write(batch),
-          "Null value not allowed in hash index key column");
+          writer->write(batch), "Null value not allowed in index key column");
     } else {
       EXPECT_NO_THROW(writer->write(batch));
     }
@@ -457,9 +463,10 @@ TEST_P(HashIndexWriterParamTest, writeAfterCloseThrows) {
   writer->write(makeInput({1}));
 
   MockSectionStore store;
-  writer->close(store.createFn(), noopWriteFn());
+  writer->close(noopWriteDataFn(), store.createFn(), noopWriteFn());
 
-  NIMBLE_ASSERT_THROW(writer->write(makeInput({2})), "Cannot write after");
+  NIMBLE_ASSERT_THROW(
+      writer->write(makeInput({2})), "IndexWriter has been closed");
 }
 
 TEST_P(HashIndexWriterParamTest, doubleCloseThrows) {
@@ -467,10 +474,11 @@ TEST_P(HashIndexWriterParamTest, doubleCloseThrows) {
   writer->write(makeInput({1}));
 
   MockSectionStore store;
-  writer->close(store.createFn(), noopWriteFn());
+  writer->close(noopWriteDataFn(), store.createFn(), noopWriteFn());
 
   NIMBLE_ASSERT_THROW(
-      writer->close(store.createFn(), noopWriteFn()), "close() already called");
+      writer->close(noopWriteDataFn(), store.createFn(), noopWriteFn()),
+      "close() already called");
 }
 
 TEST_P(HashIndexWriterParamTest, rowCountOverflow) {
@@ -492,7 +500,7 @@ TEST_F(HashIndexWriterTest, multipleIndices) {
 
   MockSectionStore store;
   std::string directory;
-  writer->close(store.createFn(), writeFn(directory));
+  writer->close(noopWriteDataFn(), store.createFn(), writeFn(directory));
 
   validateDirectory(directory, {{"col1"}, {"col0"}});
   // store has: partition for index 0, index 0, partition for index 1, index 1.
@@ -529,7 +537,7 @@ TEST_F(HashIndexWriterTest, withBloomFilter) {
 
     MockSectionStore store;
     std::string directory;
-    writer->close(store.createFn(), writeFn(directory));
+    writer->close(noopWriteDataFn(), store.createFn(), writeFn(directory));
 
     const auto* hashIndex = flatbuffers::GetRoot<serialization::HashIndex>(
         store.sections.back().data());
@@ -559,7 +567,7 @@ TEST_F(HashIndexWriterTest, withPartitioning) {
 
   MockSectionStore store;
   std::string directory;
-  writer->close(store.createFn(), writeFn(directory));
+  writer->close(noopWriteDataFn(), store.createFn(), writeFn(directory));
 
   validateDirectory(directory, {{"col1"}});
   // The last section is the HashIndex; preceding sections are partitions.
@@ -598,7 +606,7 @@ TEST_F(HashIndexWriterTest, loadFactorVariations) {
 
     MockSectionStore store;
     std::string directory;
-    writer->close(store.createFn(), writeFn(directory));
+    writer->close(noopWriteDataFn(), store.createFn(), writeFn(directory));
 
     validateDirectory(directory, {{"col1"}});
     validateIndex(store.sections.back(), 50, /*expectedNumPartitions=*/1);
@@ -616,7 +624,7 @@ TEST_P(HashIndexWriterParamTest, duplicateKeysAllowed) {
 
   MockSectionStore store;
   std::string directory;
-  writer->close(store.createFn(), writeFn(directory));
+  writer->close(noopWriteDataFn(), store.createFn(), writeFn(directory));
 
   validateDirectory(directory, {GetParam().columns});
   validateIndex(store.sections.back(), 5, /*expectedNumPartitions=*/1);

--- a/dwio/nimble/index/tests/KeyChunkDecoderTest.cpp
+++ b/dwio/nimble/index/tests/KeyChunkDecoderTest.cpp
@@ -1,0 +1,128 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <gtest/gtest.h>
+
+#include "dwio/nimble/common/Buffer.h"
+#include "dwio/nimble/encodings/EncodingFactory.h"
+#include "dwio/nimble/encodings/EncodingSelectionPolicy.h"
+#include "dwio/nimble/index/KeyChunkDecoder.h"
+#include "dwio/nimble/velox/ChunkedStreamWriter.h"
+#include "velox/common/memory/Memory.h"
+#include "velox/dwio/common/SeekableInputStream.h"
+
+namespace facebook::nimble::index {
+namespace {
+
+using velox::dwio::common::SeekableArrayInputStream;
+
+class KeyChunkDecoderTest : public ::testing::Test {
+ protected:
+  static void SetUpTestCase() {
+    velox::memory::MemoryManager::testingSetInstance({});
+  }
+
+  void SetUp() override {
+    pool_ = velox::memory::memoryManager()->addRootPool("KeyChunkDecoderTest");
+    leafPool_ = pool_->addLeafChild("leaf");
+  }
+
+  // Encodes string keys into a chunk stream blob using Trivial encoding.
+  std::string encodeChunk(const std::vector<std::string_view>& keys) {
+    Buffer encodingBuffer{*leafPool_};
+    auto policy =
+        std::make_unique<ManualEncodingSelectionPolicy<std::string_view>>(
+            std::vector<std::pair<EncodingType, float>>{
+                {EncodingType::Trivial, 1.0}},
+            CompressionOptions{},
+            std::nullopt);
+    auto encoded = EncodingFactory::encode<std::string_view>(
+        std::move(policy), keys, encodingBuffer);
+
+    ChunkedStreamWriter writer{encodingBuffer};
+    auto segments = writer.encode(encoded);
+    std::string result;
+    for (const auto& segment : segments) {
+      result.append(segment.data(), segment.size());
+    }
+    return result;
+  }
+
+  std::unique_ptr<SeekableArrayInputStream> makeStream(
+      const std::string& data) {
+    return std::make_unique<SeekableArrayInputStream>(
+        reinterpret_cast<const unsigned char*>(data.data()), data.size());
+  }
+
+  std::shared_ptr<velox::memory::MemoryPool> pool_;
+  std::shared_ptr<velox::memory::MemoryPool> leafPool_;
+  velox::BufferPtr dataBuffer_;
+};
+
+TEST_F(KeyChunkDecoderTest, decodeAndMaterialize) {
+  std::vector<std::string_view> keys = {"apple", "banana", "cherry"};
+  auto chunkData = encodeChunk(keys);
+
+  auto result = decodeKeyChunk(makeStream(chunkData), *leafPool_, dataBuffer_);
+  ASSERT_NE(result.encoding, nullptr);
+  EXPECT_EQ(result.encoding->rowCount(), 3);
+  EXPECT_EQ(result.encoding->encodingType(), EncodingType::Trivial);
+
+  std::vector<std::string_view> materialized(3);
+  result.encoding->materialize(3, materialized.data());
+  EXPECT_EQ(materialized[0], "apple");
+  EXPECT_EQ(materialized[1], "banana");
+  EXPECT_EQ(materialized[2], "cherry");
+}
+
+TEST_F(KeyChunkDecoderTest, seekAndSelectiveMaterialize) {
+  std::vector<std::string_view> keys = {"aaa", "bbb", "ccc", "ddd", "eee"};
+  auto chunkData = encodeChunk(keys);
+
+  auto result = decodeKeyChunk(makeStream(chunkData), *leafPool_, dataBuffer_);
+  ASSERT_NE(result.encoding, nullptr);
+  EXPECT_EQ(result.encoding->rowCount(), 5);
+
+  // Seek to "ccc" (position 2).
+  const std::string_view target = "ccc";
+  auto pos = result.encoding->seek(&target, /*inclusive=*/true);
+  ASSERT_TRUE(pos.has_value());
+  EXPECT_EQ(pos.value(), 2);
+
+  // Selectively materialize 2 entries from position 2.
+  result.encoding->reset();
+  result.encoding->skip(2);
+  std::vector<std::string_view> entries(2);
+  result.encoding->materialize(2, entries.data());
+  EXPECT_EQ(entries[0], "ccc");
+  EXPECT_EQ(entries[1], "ddd");
+}
+
+TEST_F(KeyChunkDecoderTest, singleEntry) {
+  std::vector<std::string_view> keys = {"only"};
+  auto chunkData = encodeChunk(keys);
+
+  auto result = decodeKeyChunk(makeStream(chunkData), *leafPool_, dataBuffer_);
+  ASSERT_NE(result.encoding, nullptr);
+  EXPECT_EQ(result.encoding->rowCount(), 1);
+
+  std::vector<std::string_view> materialized(1);
+  result.encoding->materialize(1, materialized.data());
+  EXPECT_EQ(materialized[0], "only");
+}
+
+} // namespace
+} // namespace facebook::nimble::index

--- a/dwio/nimble/index/tests/SortedIndexTest.cpp
+++ b/dwio/nimble/index/tests/SortedIndexTest.cpp
@@ -1,0 +1,693 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <gtest/gtest.h>
+#include <deque>
+
+#include "dwio/nimble/common/tests/GTestUtils.h"
+#include "dwio/nimble/index/IndexConfig.h"
+#include "dwio/nimble/index/IndexLookup.h"
+#include "dwio/nimble/index/SortedIndex.h"
+#include "dwio/nimble/index/SortedIndexWriter.h"
+#include "dwio/nimble/index/tests/SortedIndexTestUtils.h"
+#include "velox/common/base/tests/GTestUtils.h"
+
+#include "dwio/nimble/tablet/TabletReader.h"
+#include "dwio/nimble/velox/VeloxReader.h"
+#include "dwio/nimble/velox/VeloxWriter.h"
+#include "velox/common/file/FileSystems.h"
+#include "velox/common/memory/Memory.h"
+#include "velox/common/testutil/TempDirectoryPath.h"
+#include "velox/vector/FlatVector.h"
+
+namespace facebook::nimble::index {
+namespace {
+
+class SortedIndexTestBase {
+ protected:
+  static velox::RowTypePtr rowType() {
+    return velox::ROW({{"id", velox::INTEGER()}, {"value", velox::VARCHAR()}});
+  }
+
+  velox::VectorPtr makeBatch(int32_t startRow, int32_t numRows) {
+    auto ids =
+        velox::BaseVector::create(velox::INTEGER(), numRows, leafPool_.get());
+    auto values =
+        velox::BaseVector::create(velox::VARCHAR(), numRows, leafPool_.get());
+    auto* flatIds = ids->asFlatVector<int32_t>();
+    auto* flatValues = values->asFlatVector<velox::StringView>();
+    for (int i = 0; i < numRows; ++i) {
+      const int32_t id = startRow + i;
+      flatIds->set(i, id);
+      valueStrings_.emplace_back("v_" + std::to_string(id));
+      flatValues->set(i, velox::StringView(valueStrings_.back()));
+    }
+    return std::make_shared<velox::RowVector>(
+        leafPool_.get(),
+        rowType(),
+        nullptr,
+        numRows,
+        std::vector<velox::VectorPtr>{ids, values});
+  }
+
+  void writeFile(
+      const std::string& filePath,
+      const velox::RowTypePtr& schema,
+      const std::vector<velox::VectorPtr>& batches,
+      VeloxWriterOptions options) {
+    auto fs = velox::filesystems::getFileSystem(filePath, {});
+    auto file = fs->openFileForWrite(
+        filePath,
+        {.shouldCreateParentDirectories = true,
+         .shouldThrowOnFileAlreadyExists = false});
+
+    VeloxWriter writer(schema, std::move(file), *pool_, std::move(options));
+    for (const auto& batch : batches) {
+      writer.write(batch);
+    }
+    writer.close();
+  }
+
+  void writeFile(
+      const std::string& filePath,
+      const std::vector<velox::VectorPtr>& batches,
+      SortedIndexConfig indexConfig,
+      std::optional<uint64_t> flushSize = std::nullopt) {
+    VeloxWriterOptions options;
+    options.sortedIndexConfigs.push_back(std::move(indexConfig));
+    if (flushSize.has_value()) {
+      options.flushPolicyFactory = [size = flushSize.value()]() {
+        return std::make_unique<StripeRawSizeFlushPolicy>(size);
+      };
+    }
+    writeFile(filePath, rowType(), batches, std::move(options));
+  }
+
+  std::shared_ptr<TabletReader> openTablet(const std::string& filePath) {
+    auto fs = velox::filesystems::getFileSystem(filePath, {});
+    auto readFile = fs->openFileForRead(filePath);
+    return TabletReader::create(std::move(readFile), leafPool_.get(), {});
+  }
+
+  std::string encodeLookupKey(
+      const std::vector<std::string>& columns,
+      int32_t idValue) {
+    auto encoder = velox::serializer::KeyEncoder::create(
+        columns,
+        rowType(),
+        std::vector<velox::core::SortOrder>(
+            columns.size(), velox::core::SortOrder{true, false}),
+        leafPool_.get());
+
+    auto idCol =
+        velox::BaseVector::create(velox::INTEGER(), 1, leafPool_.get());
+    idCol->asFlatVector<int32_t>()->set(0, idValue);
+
+    auto valStr = "v_" + std::to_string(idValue);
+    auto valCol =
+        velox::BaseVector::create(velox::VARCHAR(), 1, leafPool_.get());
+    valCol->asFlatVector<velox::StringView>()->set(
+        0, velox::StringView(valStr));
+
+    auto lookupRow = std::make_shared<velox::RowVector>(
+        leafPool_.get(),
+        rowType(),
+        nullptr,
+        1,
+        std::vector<velox::VectorPtr>{idCol, valCol});
+
+    Buffer buffer(*leafPool_);
+    std::vector<std::string_view> encodedKeys;
+    encoder->encode(lookupRow, encodedKeys, [&buffer](size_t size) {
+      return buffer.reserve(size);
+    });
+    return std::string(encodedKeys[0]);
+  }
+
+  IndexLookup::LookupResult pointLookup(
+      const IndexLookup* index,
+      const std::vector<std::string>& columns,
+      int32_t idValue) {
+    auto key = encodeLookupKey(columns, idValue);
+    return index->lookup(
+        IndexLookup::LookupRequest::pointLookup({std::move(key)}));
+  }
+
+  IndexLookup::LookupResult rangeScan(
+      const IndexLookup* index,
+      const std::vector<std::string>& columns,
+      int32_t lowerValue,
+      int32_t upperValue) {
+    auto lowerKey = encodeLookupKey(columns, lowerValue);
+    auto upperKey = encodeLookupKey(columns, upperValue);
+    return index->lookup(
+        IndexLookup::LookupRequest::rangeScan(
+            {velox::serializer::EncodedKeyBounds{
+                std::move(lowerKey), std::move(upperKey)}}));
+  }
+
+  std::string tempFilePath(const std::string& name) {
+    return tempDir_->getPath() + "/" + name;
+  }
+
+  std::shared_ptr<velox::memory::MemoryPool> pool_;
+  std::shared_ptr<velox::memory::MemoryPool> leafPool_;
+  std::shared_ptr<velox::common::testutil::TempDirectoryPath> tempDir_;
+  std::deque<std::string> valueStrings_;
+};
+
+class SortedIndexTest : public SortedIndexTestBase, public ::testing::Test {
+ protected:
+  static void SetUpTestCase() {
+    velox::filesystems::registerLocalFileSystem();
+    velox::memory::MemoryManager::testingSetInstance({});
+  }
+
+  void SetUp() override {
+    pool_ = velox::memory::memoryManager()->addRootPool("SortedIndexTest");
+    leafPool_ = pool_->addLeafChild("leaf");
+    tempDir_ = velox::common::testutil::TempDirectoryPath::create();
+  }
+};
+
+struct SortedIndexTestParam {
+  std::vector<std::string> columns;
+  EncodingType encodingType{EncodingType::Prefix};
+
+  std::string debugString() const {
+    return fmt::format(
+        "columns: [{}], encoding: {}", fmt::join(columns, ", "), encodingType);
+  }
+};
+
+class SortedIndexParamTest
+    : public SortedIndexTestBase,
+      public ::testing::TestWithParam<SortedIndexTestParam> {
+ protected:
+  static void SetUpTestCase() {
+    velox::filesystems::registerLocalFileSystem();
+    velox::memory::MemoryManager::testingSetInstance({});
+  }
+
+  void SetUp() override {
+    pool_ = velox::memory::memoryManager()->addRootPool("SortedIndexParamTest");
+    leafPool_ = pool_->addLeafChild("leaf");
+    tempDir_ = velox::common::testutil::TempDirectoryPath::create();
+  }
+
+  const std::vector<std::string>& columns() const {
+    return GetParam().columns;
+  }
+
+  SortedIndexConfig indexConfig() const {
+    const auto encodingType = GetParam().encodingType;
+    auto layout = encodingType == EncodingType::Prefix
+        ? EncodingLayout{EncodingType::Prefix, {}, CompressionType::Uncompressed}
+        : EncodingLayout{
+              EncodingType::Trivial,
+              {},
+              CompressionType::Uncompressed,
+              {EncodingLayout{
+                  EncodingType::Trivial, {}, CompressionType::Uncompressed}}};
+    return SortedIndexConfig{
+        .columns = columns(), .encodingLayout = std::move(layout)};
+  }
+};
+
+INSTANTIATE_TEST_SUITE_P(
+    SingleAndCompositeKey,
+    SortedIndexParamTest,
+    testing::Values(
+        SortedIndexTestParam{{"id"}, EncodingType::Prefix},
+        SortedIndexTestParam{{"id"}, EncodingType::Trivial},
+        SortedIndexTestParam{{"id", "value"}, EncodingType::Prefix},
+        SortedIndexTestParam{{"id", "value"}, EncodingType::Trivial}),
+    [](const testing::TestParamInfo<SortedIndexTestParam>& info) {
+      return fmt::format(
+          "columns_{}_{}",
+          fmt::join(info.param.columns, "_"),
+          info.param.encodingType);
+    });
+
+TEST_P(SortedIndexParamTest, roundTrip) {
+  std::vector<velox::VectorPtr> batches;
+  batches.push_back(makeBatch(0, 100));
+
+  const auto filePath = tempFilePath("round_trip");
+  writeFile(filePath, batches, indexConfig());
+
+  auto tablet = openTablet(filePath);
+  auto* sortedIdx = tablet->denseIndex(columns());
+  ASSERT_NE(sortedIdx, nullptr);
+  EXPECT_EQ(sortedIdx->type(), IndexType::Sorted);
+  EXPECT_EQ(sortedIdx->indexColumns(), columns());
+
+  // Verify min/max keys are populated and ordered.
+  const auto minKey = sortedIdx->minKey();
+  const auto maxKey = sortedIdx->maxKey();
+  EXPECT_FALSE(minKey.empty());
+  EXPECT_FALSE(maxKey.empty());
+  EXPECT_LE(minKey, maxKey);
+
+  // Min key should match the encoded key for id=0, max for id=99.
+  EXPECT_EQ(minKey, encodeLookupKey(columns(), 0));
+  EXPECT_EQ(maxKey, encodeLookupKey(columns(), 99));
+}
+
+TEST_P(SortedIndexParamTest, pointLookup) {
+  std::vector<velox::VectorPtr> batches;
+  batches.push_back(makeBatch(0, 50));
+
+  const auto filePath = tempFilePath("point_lookup");
+  writeFile(filePath, batches, indexConfig());
+
+  auto tablet = openTablet(filePath);
+  auto* sortedIdx = tablet->denseIndex(columns());
+  ASSERT_NE(sortedIdx, nullptr);
+
+  {
+    auto result = pointLookup(sortedIdx, columns(), 20);
+    ASSERT_EQ(result.size(), 1);
+    EXPECT_EQ(result[0].size(), 1);
+  }
+
+  {
+    auto result = pointLookup(sortedIdx, columns(), 999);
+    ASSERT_EQ(result.size(), 1);
+    EXPECT_EQ(result[0].size(), 0);
+  }
+
+  const auto stats = sortedIdx->stats();
+  EXPECT_EQ(stats.at(SortedIndex::kNumPointLookups).sum, 2);
+  EXPECT_EQ(stats.count(SortedIndex::kNumRangeScans), 0);
+  EXPECT_EQ(stats.at(SortedIndex::kNumMinMaxSkips).sum, 1);
+  EXPECT_EQ(stats.at(SortedIndex::kNumMatchedRows).sum, 1);
+}
+
+TEST_P(SortedIndexParamTest, rangeScan) {
+  std::vector<velox::VectorPtr> batches;
+  batches.push_back(makeBatch(0, 50));
+
+  const auto filePath = tempFilePath("range_scan");
+  writeFile(filePath, batches, indexConfig());
+
+  auto tablet = openTablet(filePath);
+  auto* sortedIdx = tablet->denseIndex(columns());
+  ASSERT_NE(sortedIdx, nullptr);
+
+  // Range [10, 20) should return 10 rows.
+  {
+    auto result = rangeScan(sortedIdx, columns(), 10, 20);
+    ASSERT_EQ(result.size(), 1);
+    EXPECT_EQ(result[0].size(), 10);
+  }
+
+  // Range [100, 200) is beyond max key — skipped by min/max filter.
+  {
+    auto result = rangeScan(sortedIdx, columns(), 100, 200);
+    ASSERT_EQ(result.size(), 1);
+    EXPECT_EQ(result[0].size(), 0);
+  }
+
+  const auto stats = sortedIdx->stats();
+  EXPECT_EQ(stats.count(SortedIndex::kNumPointLookups), 0);
+  EXPECT_EQ(stats.at(SortedIndex::kNumRangeScans).sum, 2);
+  EXPECT_EQ(stats.at(SortedIndex::kNumMinMaxSkips).sum, 1);
+  EXPECT_EQ(stats.at(SortedIndex::kNumMatchedRows).sum, 10);
+}
+
+TEST_P(SortedIndexParamTest, rangeScanExclusiveUpperBound) {
+  std::vector<velox::VectorPtr> batches;
+  batches.push_back(makeBatch(0, 10));
+
+  const auto filePath = tempFilePath("range_exclusive");
+  writeFile(filePath, batches, indexConfig());
+
+  auto tablet = openTablet(filePath);
+  auto* sortedIdx = tablet->denseIndex(columns());
+  ASSERT_NE(sortedIdx, nullptr);
+
+  // Range [0, 10) should return all 10 rows.
+  {
+    auto result = rangeScan(sortedIdx, columns(), 0, 10);
+    ASSERT_EQ(result.size(), 1);
+    EXPECT_EQ(result[0].size(), 10);
+  }
+
+  // Range [0, 5) should return 5 rows.
+  {
+    auto result = rangeScan(sortedIdx, columns(), 0, 5);
+    ASSERT_EQ(result.size(), 1);
+    EXPECT_EQ(result[0].size(), 5);
+  }
+
+  // Range [5, 5) should return 0 rows (empty range).
+  {
+    auto result = rangeScan(sortedIdx, columns(), 5, 5);
+    ASSERT_EQ(result.size(), 1);
+    EXPECT_EQ(result[0].size(), 0);
+  }
+}
+
+TEST_P(SortedIndexParamTest, multipleStripes) {
+  std::vector<velox::VectorPtr> batches;
+  for (int b = 0; b < 5; ++b) {
+    batches.push_back(makeBatch(b * 20, 20));
+  }
+
+  const auto filePath = tempFilePath("multi_stripe");
+  writeFile(filePath, batches, indexConfig(), /*flushSize=*/256);
+
+  auto tablet = openTablet(filePath);
+  auto* sortedIdx = tablet->denseIndex(columns());
+  ASSERT_NE(sortedIdx, nullptr);
+  EXPECT_GT(tablet->stripeCount(), 1);
+
+  auto result = pointLookup(sortedIdx, columns(), 50);
+  ASSERT_EQ(result.size(), 1);
+  EXPECT_FALSE(result[0].empty());
+}
+
+TEST_F(SortedIndexTest, noSortedIndexConfig) {
+  auto noIndexType = velox::ROW({{"x", velox::INTEGER()}});
+
+  auto col = velox::BaseVector::create(velox::INTEGER(), 10, leafPool_.get());
+  auto* flat = col->asFlatVector<int32_t>();
+  for (int i = 0; i < 10; ++i) {
+    flat->set(i, i);
+  }
+  auto batch = std::make_shared<velox::RowVector>(
+      leafPool_.get(),
+      noIndexType,
+      nullptr,
+      10,
+      std::vector<velox::VectorPtr>{col});
+
+  const auto filePath = tempFilePath("no_index");
+  writeFile(filePath, noIndexType, {batch}, VeloxWriterOptions{});
+
+  auto tablet = openTablet(filePath);
+  EXPECT_EQ(tablet->denseIndex({"x"}), nullptr);
+}
+
+TEST_F(SortedIndexTest, multipleIndices) {
+  std::vector<velox::VectorPtr> batches;
+  batches.push_back(makeBatch(0, 20));
+
+  const auto filePath = tempFilePath("multi_indices");
+  {
+    VeloxWriterOptions options;
+    options.sortedIndexConfigs.push_back(SortedIndexConfig{.columns = {"id"}});
+    options.sortedIndexConfigs.push_back(
+        SortedIndexConfig{.columns = {"id", "value"}});
+    writeFile(filePath, rowType(), batches, std::move(options));
+  }
+
+  auto tablet = openTablet(filePath);
+
+  auto* index0 = tablet->denseIndex({"id"});
+  ASSERT_NE(index0, nullptr);
+  EXPECT_EQ(index0->indexColumns(), std::vector<std::string>{"id"});
+
+  auto* index1 = tablet->denseIndex({"id", "value"});
+  ASSERT_NE(index1, nullptr);
+  const std::vector<std::string> expected{"id", "value"};
+  EXPECT_EQ(index1->indexColumns(), expected);
+
+  EXPECT_EQ(tablet->denseIndex({"value"}), nullptr);
+  EXPECT_EQ(tablet->denseIndex({"value", "id"}), nullptr);
+}
+
+TEST_P(SortedIndexParamTest, duplicateKeys) {
+  // Write data with duplicate id values to verify they are all found.
+  auto ids = velox::BaseVector::create(velox::INTEGER(), 6, leafPool_.get());
+  auto values = velox::BaseVector::create(velox::VARCHAR(), 6, leafPool_.get());
+  auto* flatIds = ids->asFlatVector<int32_t>();
+  auto* flatValues = values->asFlatVector<velox::StringView>();
+  // ids: [1, 2, 1, 3, 2, 1]
+  std::vector<int32_t> idVals = {1, 2, 1, 3, 2, 1};
+  for (int i = 0; i < 6; ++i) {
+    flatIds->set(i, idVals[i]);
+    valueStrings_.emplace_back("v_" + std::to_string(idVals[i]));
+    flatValues->set(i, velox::StringView(valueStrings_.back()));
+  }
+  auto batch = std::make_shared<velox::RowVector>(
+      leafPool_.get(),
+      rowType(),
+      nullptr,
+      6,
+      std::vector<velox::VectorPtr>{ids, values});
+
+  const auto filePath = tempFilePath("duplicate_keys");
+  VeloxWriterOptions options;
+  options.sortedIndexConfigs.push_back(indexConfig());
+  writeFile(filePath, rowType(), {batch}, std::move(options));
+
+  auto tablet = openTablet(filePath);
+  auto* sortedIdx = tablet->denseIndex(columns());
+  ASSERT_NE(sortedIdx, nullptr);
+
+  // Key=1 appears 3 times.
+  {
+    auto result = pointLookup(sortedIdx, columns(), 1);
+    ASSERT_EQ(result.size(), 1);
+    EXPECT_EQ(result[0].size(), 3);
+  }
+
+  // Key=2 appears 2 times.
+  {
+    auto result = pointLookup(sortedIdx, columns(), 2);
+    ASSERT_EQ(result.size(), 1);
+    EXPECT_EQ(result[0].size(), 2);
+  }
+
+  // Key=3 appears 1 time.
+  {
+    auto result = pointLookup(sortedIdx, columns(), 3);
+    ASSERT_EQ(result.size(), 1);
+    EXPECT_EQ(result[0].size(), 1);
+  }
+
+  // Key=999 doesn't exist.
+  {
+    auto result = pointLookup(sortedIdx, columns(), 999);
+    ASSERT_EQ(result.size(), 1);
+    EXPECT_EQ(result[0].size(), 0);
+  }
+
+  // Range [1, 3) should return keys 1 and 2: 3 + 2 = 5 rows.
+  {
+    auto result = rangeScan(sortedIdx, columns(), 1, 3);
+    ASSERT_EQ(result.size(), 1);
+    EXPECT_EQ(result[0].size(), 5);
+  }
+
+  // Range [2, 4) should return keys 2 and 3: 2 + 1 = 3 rows.
+  {
+    auto result = rangeScan(sortedIdx, columns(), 2, 4);
+    ASSERT_EQ(result.size(), 1);
+    EXPECT_EQ(result[0].size(), 3);
+  }
+
+  // Range [1, 4) should return all 6 rows.
+  {
+    auto result = rangeScan(sortedIdx, columns(), 1, 4);
+    ASSERT_EQ(result.size(), 1);
+    EXPECT_EQ(result[0].size(), 6);
+  }
+
+  // Range [100, 200) is beyond max — empty.
+  {
+    auto result = rangeScan(sortedIdx, columns(), 100, 200);
+    ASSERT_EQ(result.size(), 1);
+    EXPECT_EQ(result[0].size(), 0);
+  }
+}
+
+TEST_F(SortedIndexTest, duplicateKeysAcrossChunks) {
+  // Write data where duplicate keys span chunk boundaries.
+  // Use maxRowsPerKeyChunk=3 so that 6 entries with the same key span 2 chunks.
+  const int32_t numRows = 10;
+  auto ids =
+      velox::BaseVector::create(velox::INTEGER(), numRows, leafPool_.get());
+  auto values =
+      velox::BaseVector::create(velox::VARCHAR(), numRows, leafPool_.get());
+  auto* flatIds = ids->asFlatVector<int32_t>();
+  auto* flatValues = values->asFlatVector<velox::StringView>();
+  // ids: [1, 1, 1, 1, 1, 1, 2, 2, 3, 3]
+  // After sorting by key, chunk boundary at row 3 splits key=1 across chunks.
+  const std::vector<int32_t> idVals = {1, 1, 1, 1, 1, 1, 2, 2, 3, 3};
+  for (int i = 0; i < numRows; ++i) {
+    flatIds->set(i, idVals[i]);
+    valueStrings_.emplace_back("v_" + std::to_string(idVals[i]));
+    flatValues->set(i, velox::StringView(valueStrings_.back()));
+  }
+  auto batch = std::make_shared<velox::RowVector>(
+      leafPool_.get(),
+      rowType(),
+      nullptr,
+      numRows,
+      std::vector<velox::VectorPtr>{ids, values});
+
+  const auto filePath = tempFilePath("dup_across_chunks");
+  VeloxWriterOptions options;
+  SortedIndexConfig config{.columns = {"id"}, .maxRowsPerKeyChunk = 3};
+  options.sortedIndexConfigs.push_back(std::move(config));
+  writeFile(filePath, rowType(), {batch}, std::move(options));
+
+  auto tablet = openTablet(filePath);
+  auto* sortedIdx = tablet->denseIndex({"id"});
+  ASSERT_NE(sortedIdx, nullptr);
+
+  // Key=1 appears 6 times, spanning at least 2 chunks (3 entries per chunk).
+  {
+    auto result = pointLookup(sortedIdx, {"id"}, 1);
+    ASSERT_EQ(result.size(), 1);
+    EXPECT_EQ(result[0].size(), 6);
+  }
+
+  // Key=2 appears 2 times.
+  {
+    auto result = pointLookup(sortedIdx, {"id"}, 2);
+    ASSERT_EQ(result.size(), 1);
+    EXPECT_EQ(result[0].size(), 2);
+  }
+
+  // Key=3 appears 2 times.
+  {
+    auto result = pointLookup(sortedIdx, {"id"}, 3);
+    ASSERT_EQ(result.size(), 1);
+    EXPECT_EQ(result[0].size(), 2);
+  }
+
+  // Non-existent key.
+  {
+    auto result = pointLookup(sortedIdx, {"id"}, 999);
+    ASSERT_EQ(result.size(), 1);
+    EXPECT_EQ(result[0].size(), 0);
+  }
+
+  // Range [1, 2) spans 2 chunks of key=1: 6 rows.
+  {
+    auto result = rangeScan(sortedIdx, {"id"}, 1, 2);
+    ASSERT_EQ(result.size(), 1);
+    EXPECT_EQ(result[0].size(), 6);
+  }
+
+  // Range [1, 3) includes keys 1 and 2: 6 + 2 = 8 rows.
+  {
+    auto result = rangeScan(sortedIdx, {"id"}, 1, 3);
+    ASSERT_EQ(result.size(), 1);
+    EXPECT_EQ(result[0].size(), 8);
+  }
+
+  // Range [1, 4) includes all keys: 6 + 2 + 2 = 10 rows.
+  {
+    auto result = rangeScan(sortedIdx, {"id"}, 1, 4);
+    ASSERT_EQ(result.size(), 1);
+    EXPECT_EQ(result[0].size(), 10);
+  }
+
+  // Range [2, 4) includes keys 2 and 3: 2 + 2 = 4 rows.
+  {
+    auto result = rangeScan(sortedIdx, {"id"}, 2, 4);
+    ASSERT_EQ(result.size(), 1);
+    EXPECT_EQ(result[0].size(), 4);
+  }
+
+  // Range beyond max — empty.
+  {
+    auto result = rangeScan(sortedIdx, {"id"}, 100, 200);
+    ASSERT_EQ(result.size(), 1);
+    EXPECT_EQ(result[0].size(), 0);
+  }
+}
+
+TEST_F(SortedIndexTest, createWithEmptyConfigs) {
+  auto writer = SortedIndexWriter::create({}, rowType(), leafPool_.get());
+  EXPECT_EQ(writer, nullptr);
+}
+
+TEST_F(SortedIndexTest, createWithNullPool) {
+  NIMBLE_ASSERT_THROW(
+      SortedIndexWriter::create(
+          {SortedIndexConfig{.columns = {"id"}}}, rowType(), nullptr),
+      "memory pool must not be null");
+}
+
+TEST_F(SortedIndexTest, createWithEmptyColumns) {
+  NIMBLE_ASSERT_THROW(
+      SortedIndexWriter::create(
+          {SortedIndexConfig{.columns = {}}}, rowType(), leafPool_.get()),
+      "Sorted index must have at least one column");
+}
+
+TEST_F(SortedIndexTest, createWithNonExistentColumn) {
+  VELOX_ASSERT_USER_THROW(
+      SortedIndexWriter::create(
+          {SortedIndexConfig{.columns = {"non_existent"}}},
+          rowType(),
+          leafPool_.get()),
+      "Field not found");
+}
+
+TEST_F(SortedIndexTest, createWithDuplicateColumns) {
+  NIMBLE_ASSERT_THROW(
+      SortedIndexWriter::create(
+          {SortedIndexConfig{.columns = {"id"}},
+           SortedIndexConfig{.columns = {"id"}}},
+          rowType(),
+          leafPool_.get()),
+      "Duplicate sorted index columns");
+
+  // Same columns in different order are allowed.
+  auto writer = SortedIndexWriter::create(
+      {SortedIndexConfig{.columns = {"id", "value"}},
+       SortedIndexConfig{.columns = {"value", "id"}}},
+      rowType(),
+      leafPool_.get());
+  EXPECT_NE(writer, nullptr);
+}
+
+TEST_F(SortedIndexTest, rowCountOverflow) {
+  auto overflowType = velox::ROW({{"key", velox::INTEGER()}});
+
+  SortedIndexConfig config{.columns = {"key"}};
+  auto writer =
+      SortedIndexWriter::create({config}, overflowType, leafPool_.get());
+  ASSERT_NE(writer, nullptr);
+
+  test::SortedIndexWriterTestHelper helper(writer.get());
+  helper.setNumRows(std::numeric_limits<uint32_t>::max() - 5);
+
+  auto keys = velox::BaseVector::create(velox::INTEGER(), 10, leafPool_.get());
+  auto* flatKeys = keys->asFlatVector<int32_t>();
+  for (int i = 0; i < 10; ++i) {
+    flatKeys->set(i, i);
+  }
+  auto batch = std::make_shared<velox::RowVector>(
+      leafPool_.get(),
+      overflowType,
+      nullptr,
+      10,
+      std::vector<velox::VectorPtr>{keys});
+
+  NIMBLE_ASSERT_USER_THROW(
+      writer->write(batch), "Sorted index row count exceeds uint32 limit");
+}
+
+} // namespace
+} // namespace facebook::nimble::index

--- a/dwio/nimble/index/tests/SortedIndexTestUtils.h
+++ b/dwio/nimble/index/tests/SortedIndexTestUtils.h
@@ -13,27 +13,24 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#include "dwio/nimble/index/IndexLookup.h"
 
-#include "dwio/nimble/common/Exceptions.h"
+#pragma once
 
-namespace facebook::nimble::index {
+#include "dwio/nimble/index/SortedIndexWriter.h"
 
-std::string toString(IndexType indexType) {
-  switch (indexType) {
-    case IndexType::Cluster:
-      return "Cluster";
-    case IndexType::Hash:
-      return "Hash";
-    case IndexType::Sorted:
-      return "Sorted";
-    default:
-      NIMBLE_UNREACHABLE("Unknown IndexType: {}", static_cast<int>(indexType));
+namespace facebook::nimble::index::test {
+
+class SortedIndexWriterTestHelper {
+ public:
+  explicit SortedIndexWriterTestHelper(SortedIndexWriter* writer)
+      : writer_(writer) {}
+
+  void setNumRows(uint32_t rows) {
+    writer_->numRows_ = rows;
   }
-}
 
-std::ostream& operator<<(std::ostream& out, IndexType indexType) {
-  return out << toString(indexType);
-}
+ private:
+  SortedIndexWriter* const writer_;
+};
 
-} // namespace facebook::nimble::index
+} // namespace facebook::nimble::index::test

--- a/dwio/nimble/tablet/CMakeLists.txt
+++ b/dwio/nimble/tablet/CMakeLists.txt
@@ -96,6 +96,22 @@ target_include_directories(
 )
 add_dependencies(nimble_hash_index_fb nimble_hash_index_schema_fb)
 
+build_flatbuffers(
+  "${CMAKE_CURRENT_SOURCE_DIR}/SortedIndex.fbs"
+  "${CMAKE_CURRENT_SOURCE_DIR}"
+  nimble_sorted_index_schema_fb
+  ""
+  "${CMAKE_CURRENT_BINARY_DIR}"
+  ""
+  ""
+)
+add_library(nimble_sorted_index_fb INTERFACE)
+target_include_directories(
+  nimble_sorted_index_fb
+  INTERFACE ${PROJECT_BINARY_DIR} ${FLATBUFFERS_INCLUDE_DIR}
+)
+add_dependencies(nimble_sorted_index_fb nimble_sorted_index_schema_fb)
+
 add_library(nimble_tablet_common Compression.cpp MetadataBuffer.cpp)
 target_link_libraries(
   nimble_tablet_common

--- a/dwio/nimble/tablet/Constants.h
+++ b/dwio/nimble/tablet/Constants.h
@@ -37,5 +37,6 @@ constexpr std::string_view kVectorizedStatsSection =
 constexpr std::string_view kClusterIndexSection = "columnar.cluster.index";
 constexpr std::string_view kChunkIndexSection = "columnar.chunk.index";
 constexpr std::string_view kHashIndexSection = "columnar.hash.index";
+constexpr std::string_view kSortedIndexSection = "columnar.sorted.index";
 
 } // namespace facebook::nimble

--- a/dwio/nimble/tablet/HashIndex.fbs
+++ b/dwio/nimble/tablet/HashIndex.fbs
@@ -42,6 +42,11 @@ table HashIndex {
   /// Optional bloom filter for fast negative lookups.
   bloom_filter:BloomFilter;
 
+  /// Minimum encoded key across all entries.
+  min_key:string;
+  /// Maximum encoded key across all entries.
+  max_key:string;
+
   /// Partitions. The hash table is always split into one or more partitions,
   /// each stored as a separate HashIndexPartition section. Small indices
   /// use a single partition; large indices are split by maxPartitionSizeBytes.

--- a/dwio/nimble/tablet/SortedIndex.fbs
+++ b/dwio/nimble/tablet/SortedIndex.fbs
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+include "Footer.fbs";
+
+namespace facebook.nimble.serialization;
+
+/// A single sorted index on a set of composite key columns.
+/// Stores a sorted key stream where each entry is
+/// encoded_key || fixed_width_row_id.
+///
+/// Lookup flow:
+///   1. Binary search chunk keys to find the chunk(s)
+///   2. Decode chunk, binary search/scan entries
+///   3. Extract row IDs from entry suffix
+table SortedIndex {
+  /// Width of the row ID suffix in bytes (1, 2, 3, or 4).
+  row_id_width:uint8;
+  /// Accumulated row counts per chunk (prefix sum).
+  chunk_rows:[uint32];
+  /// Byte offset of each chunk within the key stream data.
+  chunk_offsets:[uint32];
+  /// Last key (without row ID suffix) of each chunk for binary search.
+  chunk_keys:[string];
+  /// First key (without row ID suffix) across all chunks.
+  min_key:string;
+  /// Absolute file offset of the key stream data blob.
+  key_stream_offset:uint64;
+  /// Total size in bytes of the key stream data blob.
+  key_stream_size:uint32;
+}
+
+/// Lightweight descriptor for a sorted index in the directory.
+table SortedIndexSection {
+  /// Names of columns forming the composite key.
+  index_columns:[string];
+  /// Reference to the serialized SortedIndex.
+  section:MetadataSection;
+}
+
+/// Root table for the sorted index optional section.
+/// Stored in optional section "columnar.sorted.index".
+table SortedIndexDirectory {
+  /// One descriptor per sorted index defined on the file.
+  indices:[SortedIndexSection];
+}
+
+root_type SortedIndexDirectory;

--- a/dwio/nimble/tablet/TabletReader.cpp
+++ b/dwio/nimble/tablet/TabletReader.cpp
@@ -1133,7 +1133,7 @@ void TabletReader::initClusterIndex() {
       pool_);
 }
 
-const index::HashIndex* TabletReader::denseIndex(
+const index::IndexLookup* TabletReader::denseIndex(
     const std::vector<std::string>& columns) const {
   if (denseIndexRegistry_ == nullptr) {
     return nullptr;
@@ -1142,18 +1142,32 @@ const index::HashIndex* TabletReader::denseIndex(
 }
 
 void TabletReader::initDenseIndexes() {
-  auto section =
-      loadOptionalSection(std::string{kHashIndexSection}, /*keepCache=*/false);
-  if (!section.has_value()) {
-    return;
-  }
+  auto loadMetadataFn = [this](const MetadataSection& metadataSection) {
+    return readMetadata(metadataSection, velox::dwio::common::LogType::FOOTER);
+  };
+
+  auto loadDataFn = [this](const velox::common::Region& region)
+      -> std::unique_ptr<velox::dwio::common::SeekableInputStream> {
+    if (metadataInput_ != nullptr) {
+      return metadataInput_->read(
+          region.offset, region.length, velox::dwio::common::LogType::FOOTER);
+    }
+    auto input =
+        std::make_shared<velox::dwio::common::ReadFileInputStream>(file_);
+    return std::make_unique<velox::dwio::common::SeekableFileInputStream>(
+        std::move(input),
+        region.offset,
+        region.length,
+        *pool_,
+        velox::dwio::common::LogType::FOOTER);
+  };
 
   denseIndexRegistry_ = DenseIndexRegistry::create(
-      std::move(section.value()),
-      [this](const MetadataSection& metadataSection) {
-        return readMetadata(
-            metadataSection, velox::dwio::common::LogType::FOOTER);
-      },
+      loadOptionalSection(std::string{kHashIndexSection}, /*keepCache=*/false),
+      loadOptionalSection(
+          std::string{kSortedIndexSection}, /*keepCache=*/false),
+      loadMetadataFn,
+      std::move(loadDataFn),
       pool_);
 }
 

--- a/dwio/nimble/tablet/TabletReader.h
+++ b/dwio/nimble/tablet/TabletReader.h
@@ -25,7 +25,8 @@
 #include "dwio/nimble/index/ChunkIndex.h"
 #include "dwio/nimble/index/ChunkIndexGroup.h"
 #include "dwio/nimble/index/ClusterIndex.h"
-#include "dwio/nimble/index/HashIndex.h"
+#include "dwio/nimble/index/DenseIndexRegistry.h"
+#include "dwio/nimble/index/IndexLookup.h"
 #include "dwio/nimble/tablet/Constants.h"
 #include "dwio/nimble/tablet/FileLayout.h"
 #include "dwio/nimble/tablet/MetadataBuffer.h"
@@ -140,7 +141,6 @@ class StripeIdentifier {
 
 using index::ClusterIndex;
 using index::DenseIndexRegistry;
-using index::HashIndex;
 
 /// Provides read access to a tablet written by a TabletWriter.
 /// Example usage to read all streams from stripe 0 in a file:
@@ -259,7 +259,7 @@ class TabletReader {
   }
 
   /// Finds the dense index matching the given columns, or nullptr if none.
-  const index::HashIndex* denseIndex(
+  const index::IndexLookup* denseIndex(
       const std::vector<std::string>& columns) const;
 
   uint64_t fileSize() const {
@@ -543,7 +543,7 @@ class TabletReader {
   // Index related fields.
   std::unique_ptr<ClusterIndex> clusterIndex_;
 
-  // Dense index registry, loaded from "columnar.hash.index" optional section.
+  // Unified dense index registry for hash and sorted indices.
   std::unique_ptr<DenseIndexRegistry> denseIndexRegistry_;
 
   // Chunk index root, loaded from "chunk_index" optional section.

--- a/dwio/nimble/tablet/TabletWriter.cpp
+++ b/dwio/nimble/tablet/TabletWriter.cpp
@@ -404,13 +404,21 @@ void TabletWriter::invokeCloseCallback() {
   if (options_.closeCallback == nullptr) {
     return;
   }
+  auto writeDataFn = [this](const std::vector<std::string_view>& segments) {
+    const auto offset = file_->size();
+    for (const auto& segment : segments) {
+      writeWithChecksum(segment);
+    }
+    return std::make_pair(
+        offset, static_cast<uint32_t>(file_->size() - offset));
+  };
   auto createMetadataFn = [this](std::string_view metadata) {
     return createMetadataSection(metadata);
   };
   auto writeMetadataFn = [this](std::string name, std::string_view content) {
     writeOptionalSection(std::move(name), content);
   };
-  options_.closeCallback(createMetadataFn, writeMetadataFn);
+  options_.closeCallback(writeDataFn, createMetadataFn, writeMetadataFn);
 }
 
 void TabletWriter::invokeStripeGroupFlushCallback() {

--- a/dwio/nimble/tablet/TabletWriter.h
+++ b/dwio/nimble/tablet/TabletWriter.h
@@ -58,6 +58,7 @@ class TabletWriter {
   /// before the chunk index root and footer are written. Used by index
   /// writers to finalize and write the root index as an optional section.
   using CloseCallback = std::function<void(
+      const WriteDataFn& writeDataFn,
       const CreateMetadataSectionFn& createMetadataFn,
       const WriteOptionalSectionFn& writeMetadataFn)>;
 

--- a/dwio/nimble/velox/RowRange.h
+++ b/dwio/nimble/velox/RowRange.h
@@ -16,28 +16,31 @@
 
 #pragma once
 
+#include <cstdint>
+
 #include <fmt/format.h>
 #include <folly/hash/Hash.h>
-
-#include "velox/vector/TypeAliases.h"
 
 namespace facebook::nimble {
 
 /// Row range within a stripe [startRow, endRow).
 struct RowRange {
-  velox::vector_size_t startRow{0};
-  velox::vector_size_t endRow{0};
+  uint32_t startRow{0};
+  uint32_t endRow{0};
 
   RowRange() = default;
-  RowRange(velox::vector_size_t start, velox::vector_size_t end)
-      : startRow(start), endRow(end) {}
+  RowRange(uint32_t start, uint32_t end) : startRow(start), endRow(end) {}
 
-  inline velox::vector_size_t numRows() const {
+  inline uint32_t numRows() const {
     return endRow - startRow;
   }
 
   inline bool empty() const {
     return startRow >= endRow;
+  }
+
+  inline bool contains(uint32_t row) const {
+    return row >= startRow && row < endRow;
   }
 
   inline bool contains(const RowRange& other) const {

--- a/dwio/nimble/velox/VeloxWriter.cpp
+++ b/dwio/nimble/velox/VeloxWriter.cpp
@@ -680,6 +680,10 @@ VeloxWriter::VeloxWriter(
           context_->options().hashIndexConfigs,
           type,
           &(*context_->bufferMemoryPool()))},
+      sortedIndexWriter_{index::SortedIndexWriter::create(
+          context_->options().sortedIndexConfigs,
+          type,
+          &(*context_->bufferMemoryPool()))},
       tabletWriter_{TabletWriter::create(
           file_.get(),
           *encodingMemoryPool_,
@@ -705,9 +709,10 @@ VeloxWriter::VeloxWriter(
                      })
                : nullptr,
            .closeCallback = [this](
+                                const WriteDataFn& writeDataFn,
                                 const CreateMetadataSectionFn& createMetadataFn,
                                 const WriteOptionalSectionFn& writeMetadataFn) {
-             writeIndexes(createMetadataFn, writeMetadataFn);
+             writeIndexes(writeDataFn, createMetadataFn, writeMetadataFn);
            }})} {
   NIMBLE_CHECK_NOT_NULL(file_);
 
@@ -878,11 +883,16 @@ bool VeloxWriter::hasHashIndex() const {
   return hashIndexWriter_ != nullptr;
 }
 
+bool VeloxWriter::hasSortedIndex() const {
+  return sortedIndexWriter_ != nullptr;
+}
+
 void VeloxWriter::addIndexKey(
     const velox::VectorPtr& input,
     velox::dwio::common::ExecutorBarrier* barrier) {
   addClusterIndexKey(input, barrier);
   addHashIndexKey(input, barrier);
+  addSortedIndexKey(input, barrier);
 }
 
 void VeloxWriter::addClusterIndexKey(
@@ -911,14 +921,31 @@ void VeloxWriter::addHashIndexKey(
   }
 }
 
+void VeloxWriter::addSortedIndexKey(
+    const velox::VectorPtr& input,
+    velox::dwio::common::ExecutorBarrier* barrier) {
+  if (!hasSortedIndex()) {
+    return;
+  }
+  if (barrier != nullptr) {
+    barrier->add([&]() { sortedIndexWriter_->write(input); });
+  } else {
+    sortedIndexWriter_->write(input);
+  }
+}
+
 void VeloxWriter::writeIndexes(
+    const WriteDataFn& writeDataFn,
     const CreateMetadataSectionFn& createMetadataFn,
     const WriteOptionalSectionFn& writeMetadataFn) {
   if (hasHashIndex()) {
-    hashIndexWriter_->close(createMetadataFn, writeMetadataFn);
+    hashIndexWriter_->close(writeDataFn, createMetadataFn, writeMetadataFn);
+  }
+  if (hasSortedIndex()) {
+    sortedIndexWriter_->close(writeDataFn, createMetadataFn, writeMetadataFn);
   }
   if (hasClusterIndex()) {
-    clusterIndexWriter_->close(createMetadataFn, writeMetadataFn);
+    clusterIndexWriter_->close(writeDataFn, createMetadataFn, writeMetadataFn);
   }
 }
 

--- a/dwio/nimble/velox/VeloxWriter.h
+++ b/dwio/nimble/velox/VeloxWriter.h
@@ -18,6 +18,7 @@
 #include "dwio/nimble/common/Buffer.h"
 #include "dwio/nimble/index/ClusterIndexWriter.h"
 #include "dwio/nimble/index/HashIndexWriter.h"
+#include "dwio/nimble/index/SortedIndexWriter.h"
 #include "dwio/nimble/tablet/TabletWriter.h"
 #include "dwio/nimble/velox/FieldWriter.h"
 #include "dwio/nimble/velox/VeloxWriterOptions.h"
@@ -91,10 +92,10 @@ class VeloxWriter {
  private:
   inline bool hasClusterIndex() const;
   inline bool hasHashIndex() const;
+  inline bool hasSortedIndex() const;
 
-  // Adds index keys to all configured index writers (cluster index and hash
-  // index). If barrier is provided, the processing will be added to the barrier
-  // for parallel execution.
+  // Adds index keys to all configured index writers. If barrier is provided,
+  // the processing will be added to the barrier for parallel execution.
   void addIndexKey(
       const velox::VectorPtr& input,
       velox::dwio::common::ExecutorBarrier* barrier = nullptr);
@@ -104,6 +105,10 @@ class VeloxWriter {
       velox::dwio::common::ExecutorBarrier* barrier = nullptr);
 
   void addHashIndexKey(
+      const velox::VectorPtr& input,
+      velox::dwio::common::ExecutorBarrier* barrier = nullptr);
+
+  void addSortedIndexKey(
       const velox::VectorPtr& input,
       velox::dwio::common::ExecutorBarrier* barrier = nullptr);
 
@@ -168,6 +173,7 @@ class VeloxWriter {
   void writeSchema();
   // Finalizes and writes all indexes. Called via TabletWriter close callback.
   void writeIndexes(
+      const WriteDataFn& writeDataFn,
       const CreateMetadataSectionFn& createMetadataFn,
       const WriteOptionalSectionFn& writeMetadataFn);
 
@@ -184,6 +190,7 @@ class VeloxWriter {
   std::unique_ptr<velox::WriteFile> file_;
   const std::unique_ptr<index::ClusterIndexWriter> clusterIndexWriter_;
   const std::unique_ptr<index::HashIndexWriter> hashIndexWriter_;
+  const std::unique_ptr<index::SortedIndexWriter> sortedIndexWriter_;
   const std::unique_ptr<TabletWriter> tabletWriter_;
 
   std::unique_ptr<FieldWriter> rootWriter_;

--- a/dwio/nimble/velox/VeloxWriterOptions.h
+++ b/dwio/nimble/velox/VeloxWriterOptions.h
@@ -72,6 +72,11 @@ struct VeloxWriterOptions {
   /// index does not require sorted data.
   std::vector<HashIndexConfig> hashIndexConfigs;
 
+  /// Sorted index configurations. Each config builds an independent sorted
+  /// key stream index supporting both point lookups and range scans on
+  /// unsorted data.
+  std::vector<SortedIndexConfig> sortedIndexConfigs;
+
   // Columns that should be encoded as flat maps. Maps column name to a set
   /// of predefined key strings. When the set is empty, the column is
   /// treated as a flat map with dynamic key discovery. When non-empty, keys

--- a/dwio/nimble/velox/index/NimbleIndexProjector.cpp
+++ b/dwio/nimble/velox/index/NimbleIndexProjector.cpp
@@ -199,7 +199,7 @@ void NimbleIndexProjector::lookupStripes() {
          ++stripe) {
       const auto stripeOffset = stripe - minStripe;
       stripeRangeMap_.rowRanges[writeCursors[stripeOffset]++] = StripeRowRange{
-          static_cast<velox::vector_size_t>(requestIdx),
+          static_cast<uint32_t>(requestIdx),
           stripeRowRange(stripe, requestRange.rowRange)};
     }
   }
@@ -324,8 +324,7 @@ void NimbleIndexProjector::buildStripeResult(Chunk&& chunk, Result& result) {
           options_->maxRowsPerRequest - rowsPerRequest_[request.requestIndex];
 
       if (static_cast<uint64_t>(rowRange.numRows()) > remaining) {
-        rowRange.endRow =
-            rowRange.startRow + static_cast<vector_size_t>(remaining);
+        rowRange.endRow = rowRange.startRow + static_cast<uint32_t>(remaining);
       }
     }
     stats_.numReadRows += rowRange.numRows();

--- a/dwio/nimble/velox/index/NimbleIndexProjector.h
+++ b/dwio/nimble/velox/index/NimbleIndexProjector.h
@@ -170,7 +170,7 @@ class NimbleIndexProjector {
  private:
   // A request index paired with its stripe-relative row range.
   struct StripeRowRange {
-    velox::vector_size_t requestIndex{};
+    uint32_t requestIndex{};
     // Stripe-relative row range, already intersected with stripe boundaries.
     RowRange rowRange;
   };
@@ -240,10 +240,9 @@ class NimbleIndexProjector {
   // rowRangeLimit with the stripe boundaries.
   RowRange stripeRowRange(uint32_t stripe, const RowRange& rowRangeLimit)
       const {
-    const auto stripeStart = static_cast<velox::vector_size_t>(
-        readerBase_->tablet().stripeStartRow(stripe));
-    const auto stripeEnd =
-        stripeStart + static_cast<velox::vector_size_t>(stripeRowCount(stripe));
+    const auto stripeStart =
+        static_cast<uint32_t>(readerBase_->tablet().stripeStartRow(stripe));
+    const auto stripeEnd = stripeStart + stripeRowCount(stripe);
     const auto startRow = std::max(rowRangeLimit.startRow, stripeStart);
     const auto endRow = std::min(rowRangeLimit.endRow, stripeEnd);
     if (startRow >= endRow) {

--- a/dwio/nimble/velox/selective/SelectiveNimbleIndexReader.cpp
+++ b/dwio/nimble/velox/selective/SelectiveNimbleIndexReader.cpp
@@ -461,7 +461,7 @@ void SelectiveNimbleIndexReader::splitStripeRowRanges(
   // Each segment is read separately, and requests reference their segments.
 
   // Collect all unique boundary points.
-  std::vector<vector_size_t> boundaries;
+  std::vector<uint32_t> boundaries;
   boundaries.reserve(requestRanges.size() * 2);
   for (const auto& [_, range] : requestRanges) {
     boundaries.push_back(range.startRow);
@@ -644,7 +644,8 @@ void SelectiveNimbleIndexReader::trackStripeSegmentOutputRefs(
       }
 
       state.outputRefs.emplace_back(
-          RequestState::OutputReference{outputIndex, RowRange{0, rowsToAdd}});
+          RequestState::OutputReference{
+              outputIndex, RowRange{0, static_cast<uint32_t>(rowsToAdd)}});
       outputSegments_[outputIndex].addRef();
       state.outputRows += rowsToAdd;
     }

--- a/dwio/nimble/velox/selective/SelectiveNimbleIndexReader.h
+++ b/dwio/nimble/velox/selective/SelectiveNimbleIndexReader.h
@@ -131,14 +131,12 @@ class SelectiveNimbleIndexReader : public velox::dwio::common::IndexReader {
     void dropRef();
   };
 
-  velox::vector_size_t stripeRowOffset(uint32_t stripe) const {
-    return static_cast<velox::vector_size_t>(
-        readerBase_->tablet().stripeStartRow(stripe));
+  uint32_t stripeRowOffset(uint32_t stripe) const {
+    return static_cast<uint32_t>(readerBase_->tablet().stripeStartRow(stripe));
   }
 
-  velox::vector_size_t stripeRowCount(uint32_t stripe) const {
-    return static_cast<velox::vector_size_t>(
-        readerBase_->tablet().stripeRowCount(stripe));
+  uint32_t stripeRowCount(uint32_t stripe) const {
+    return static_cast<uint32_t>(readerBase_->tablet().stripeRowCount(stripe));
   }
 
   // Computes the stripe-relative row range by intersecting the file-level
@@ -146,8 +144,7 @@ class SelectiveNimbleIndexReader : public velox::dwio::common::IndexReader {
   RowRange stripeRowRange(uint32_t stripe, const RowRange& rowRangeLimit)
       const {
     const auto stripeStart = stripeRowOffset(stripe);
-    const auto stripeEnd =
-        stripeStart + static_cast<velox::vector_size_t>(stripeRowCount(stripe));
+    const auto stripeEnd = stripeStart + stripeRowCount(stripe);
     const auto startRow = std::max(rowRangeLimit.startRow, stripeStart);
     const auto endRow = std::min(rowRangeLimit.endRow, stripeEnd);
     if (startRow >= endRow) {

--- a/dwio/nimble/velox/tests/RowRangeTest.cpp
+++ b/dwio/nimble/velox/tests/RowRangeTest.cpp
@@ -51,6 +51,14 @@ TEST(RowRangeTest, contains) {
   EXPECT_FALSE(outer.contains(RowRange(5, 20)));
   EXPECT_FALSE(outer.contains(RowRange(30, 60)));
   EXPECT_FALSE(outer.contains(RowRange(5, 60)));
+
+  // Single row containment.
+  EXPECT_TRUE(outer.contains(10u));
+  EXPECT_TRUE(outer.contains(30u));
+  EXPECT_TRUE(outer.contains(49u));
+  EXPECT_FALSE(outer.contains(9u));
+  EXPECT_FALSE(outer.contains(50u));
+  EXPECT_FALSE(outer.contains(100u));
 }
 
 TEST(RowRangeTest, intersect) {


### PR DESCRIPTION
Summary:

CONTEXT: Nimble dense indices currently only support hash-based point lookups (O(1) but no ordering). For range scans on unsorted data (e.g., find all rows where key in [lower, upper)), we need a sorted key stream index. This diff adds SortedIndex — a secondary index that stores sorted entries and supports both O(log n) point lookups and range scans via binary search on chunk boundaries.

WHAT:

SortedIndex writer (SortedIndexWriter):
- Accumulates encoded_key || fixed_width_row_id entries during file writing, sorts them at close time, and encodes using the same pipeline as ClusterIndex (KeyEncoder -> EncodingFactory with Prefix/Trivial -> ChunkedStreamWriter).
- Row ID width (1-4 bytes, big-endian) is auto-determined from total row count.
- Configurable chunk size via maxRowsPerKeyChunk for search granularity.
- Supports multiple sorted indices per file via SortedIndexConfig.
- FlatBuffer schema (SortedIndex.fbs) stores chunk metadata: chunk_keys (boundary keys for binary search), chunk_offsets, chunk_rows (accumulated row counts), min_key, and key stream location.

SortedIndex reader:
- Binary search on chunk boundary keys to find target chunk(s) via findChunkIndex().
- Selective materialization: seek for start/end positions first, then only decode the matching range (avoids materializing entire chunks).
- Handles duplicate keys spanning chunk boundaries by scanning adjacent chunks.
- Unified scanEntries() method shared between pointLookup() and rangeScan() with hasMoreEntries() lambda for chunk boundary logic.
- firstSeekKey/lastSeekKey helpers for constructing composite seek keys with min/max row ID suffixes.
- Min/max key early filtering before chunk search.

DenseIndexRegistry refactoring:
- Factory-based create() method that takes optional hash/sorted sections, returns nullptr if both empty.
- Cross-type duplicate column validation via validate() called once after both index types registered.
- registerHashIndices/registerSortedIndices and findHashIndex/findSortedIndex are now private.
- Only findIndex() is public, returning IndexLookup*.
- Removed unnecessary directory section member variables.

IndexLookup interface changes:
- minKey()/maxKey() as pure virtual methods, implemented by ClusterIndex, HashIndex, and SortedIndex.
- Used for early filtering: point lookups skip if key < minKey or key > maxKey; range scans skip if lowerKey > maxKey or upperKey <= minKey.
- numMinMaxSkips stat tracked in both HashIndex and SortedIndex.

KeyChunkDecoder shared utility:
- Extracts common chunk decode logic (header parsing, compression validation, encoding creation) into decodeKeyChunk().
- Handles both contiguous (zero-copy) and multi-buffer reads with reusable BufferPtr.
- Used by SortedIndex::loadChunk() and ClusterIndex::getDecodedChunk(), replacing ~40 lines of duplicated inline decode logic each.
- ClusterIndex DecodedChunk now contains DecodedKeyChunk instead of duplicating fields.

HashIndex changes:
- Added min_key/max_key fields to HashIndex FlatBuffer schema.
- Writer computes min/max from accumulated keys and stores them.
- Reader stores minKey_/maxKey_ as const members, used for early filtering before bloom filter check.

RowRange changes:
- Changed fields from velox::vector_size_t (int32_t) to uint32_t — semantically correct since row positions are never negative.
- Added contains(uint32_t row) for single-row containment check, used in point lookup/range scan row filtering.
- Updated all callers across nimble (selective reader, index projector, serializer).

TabletReader:
- Unified to single denseIndex() accessor returning const IndexLookup* (removed separate sortedIndex()/denseIndex() typed accessors).

Other refactoring:
- Refactored IndexWriter base class and shared chunked stream writing logic from ClusterIndexWriter.
- Separated point lookup and range scan stats: kNumPointLookups, kNumRangeScans (replacing kNumLookups).

Differential Revision: D102527304
