### PR TITLE
perf: Lazy per-column I/O for projected columns in Nimble (#677)

### DIFF
--- a/dwio/nimble/velox/selective/ColumnLoader.h
+++ b/dwio/nimble/velox/selective/ColumnLoader.h
@@ -16,6 +16,7 @@
 
 #pragma once
 
+#include "dwio/nimble/velox/selective/ReaderBase.h"
 #include "dwio/nimble/velox/selective/RowSizeTracker.h"
 #include "velox/dwio/common/ColumnLoader.h"
 #include "velox/dwio/common/SelectiveStructColumnReader.h"
@@ -28,10 +29,12 @@ class TrackedColumnLoader : public velox::dwio::common::ColumnLoader {
       velox::dwio::common::SelectiveStructColumnReaderBase* structReader,
       velox::dwio::common::SelectiveColumnReader* fieldReader,
       uint64_t version,
-      RowSizeTracker* rowSizeTracker = nullptr)
+      RowSizeTracker* rowSizeTracker = nullptr,
+      LazyInput* lazyInput = nullptr)
       : velox::dwio::common::ColumnLoader{structReader, fieldReader, version},
         typeWithId_{fieldReader->fileType()},
-        rowSizeTracker_{rowSizeTracker} {}
+        rowSizeTracker_{rowSizeTracker},
+        lazyInput_{lazyInput} {}
 
  private:
   void loadInternal(
@@ -39,6 +42,13 @@ class TrackedColumnLoader : public velox::dwio::common::ColumnLoader {
       velox::ValueHook* hook,
       velox::vector_size_t resultSize,
       velox::VectorPtr* result) override {
+    if (lazyInput_ != nullptr) {
+      VELOX_CHECK_EQ(
+          version_,
+          structReader_->numReads(),
+          "Loading LazyVector after the enclosing reader has moved");
+      lazyInput_->load();
+    }
     velox::dwio::common::ColumnLoader::loadInternal(
         rows, hook, resultSize, result);
     if (result && rowSizeTracker_) {
@@ -197,7 +207,10 @@ class TrackedColumnLoader : public velox::dwio::common::ColumnLoader {
   }
 
   const velox::dwio::common::TypeWithId& typeWithId_;
-  RowSizeTracker* rowSizeTracker_;
+  RowSizeTracker* const rowSizeTracker_;
+  // Non-null when this column uses lazy I/O. Triggers load() on first
+  // lazy access to fetch the column's streams from WarmStorage.
+  LazyInput* const lazyInput_{nullptr};
 };
 
 } // namespace facebook::nimble

--- a/dwio/nimble/velox/selective/FlatMapColumnReader.cpp
+++ b/dwio/nimble/velox/selective/FlatMapColumnReader.cpp
@@ -113,8 +113,8 @@ std::vector<KeyNode<T>> makeKeyNodes(
       }
       childSpecs[node.key] = childSpec = valuesSpec;
     }
-    auto inMapInput =
-        params.streams().enqueue(nimbleType.inMapDescriptorAt(i).offset());
+    auto inMapInput = params.streams().enqueue(
+        nimbleType.inMapDescriptorAt(i).offset(), params.lazyColumnIo());
     if (inMapInput != nullptr) {
       node.inMap = std::make_unique<ChunkedDecoder>(
           std::move(inMapInput),

--- a/dwio/nimble/velox/selective/NimbleData.cpp
+++ b/dwio/nimble/velox/selective/NimbleData.cpp
@@ -30,12 +30,14 @@ NimbleData::NimbleData(
     ChunkedDecoder* inMapDecoder,
     const EncodingFactory& encodingFactory,
     bool stringDecoderZeroCopy,
-    bool nimblePreserveDictionaryEncoding)
+    bool nimblePreserveDictionaryEncoding,
+    bool lazyColumnIo)
     : nimbleType_(nimbleType),
       streams_(&streams),
       pool_(&memoryPool),
       inMapDecoder_(inMapDecoder),
-      encodingFactory_(&encodingFactory) {
+      encodingFactory_(&encodingFactory),
+      lazyColumnIo_(lazyColumnIo) {
   switch (nimbleType->kind()) {
     case Kind::Scalar:
       // Nulls in scalar types will be decoded along with values.
@@ -163,7 +165,7 @@ uint64_t NimbleData::skipNulls(uint64_t numValues, bool /*nullsOnly*/) {
 ChunkedDecoder NimbleData::makeScalarDecoder() {
   const auto streamId = nimbleType_->asScalar().scalarDescriptor().offset();
   return ChunkedDecoder(
-      streams_->enqueue(streamId),
+      streams_->enqueue(streamId, lazyColumnIo_),
       streams_->streamIndex(streamId),
       /*decodeValuesWithNulls=*/false,
       encodingFactory_,
@@ -176,7 +178,7 @@ ChunkedDecoder NimbleData::makeMicrosDecoder() {
   const auto streamId =
       nimbleType_->asTimestampMicroNano().microsDescriptor().offset();
   return ChunkedDecoder(
-      streams_->enqueue(streamId),
+      streams_->enqueue(streamId, lazyColumnIo_),
       streams_->streamIndex(streamId),
       /*decodeValuesWithNulls=*/false,
       encodingFactory_,
@@ -189,7 +191,7 @@ ChunkedDecoder NimbleData::makeNanosDecoder() {
   const auto streamId =
       nimbleType_->asTimestampMicroNano().nanosDescriptor().offset();
   return ChunkedDecoder(
-      streams_->enqueue(streamId),
+      streams_->enqueue(streamId, lazyColumnIo_),
       streams_->streamIndex(streamId),
       /*decodeValuesWithNulls=*/false,
       encodingFactory_,
@@ -214,7 +216,7 @@ std::unique_ptr<ChunkedDecoder> NimbleData::makeLengthDecoder() {
 std::unique_ptr<ChunkedDecoder> NimbleData::makeDecoder(
     const StreamDescriptor& descriptor,
     bool decodeValuesWithNulls) {
-  auto input = streams_->enqueue(descriptor.offset());
+  auto input = streams_->enqueue(descriptor.offset(), lazyColumnIo_);
   if (!input) {
     return nullptr;
   }
@@ -237,7 +239,8 @@ std::unique_ptr<velox::dwio::common::FormatData> NimbleParams::toFormatData(
       inMapDecoder_,
       *encodingFactory_,
       stringDecoderZeroCopy_,
-      nimblePreserveDictionaryEncoding_);
+      nimblePreserveDictionaryEncoding_,
+      lazyColumnIo_);
 }
 
 } // namespace facebook::nimble

--- a/dwio/nimble/velox/selective/NimbleData.h
+++ b/dwio/nimble/velox/selective/NimbleData.h
@@ -16,6 +16,8 @@
 
 #pragma once
 
+#include <folly/container/F14Set.h>
+
 #include "dwio/nimble/encodings/common/EncodingFactory.h"
 #include "dwio/nimble/velox/selective/ReaderBase.h"
 #include "dwio/nimble/velox/selective/RowSizeTracker.h"
@@ -34,7 +36,8 @@ class NimbleData : public velox::dwio::common::FormatData {
       ChunkedDecoder* inMapDecoder,
       const EncodingFactory& encodingFactory,
       bool stringDecoderZeroCopy,
-      bool nimblePreserveDictionaryEncoding = false);
+      bool nimblePreserveDictionaryEncoding = false,
+      bool lazyColumnIo = false);
 
   /// Read internal node nulls. For leaf nodes, we only copy `incomingNulls' if
   /// it exists.
@@ -114,6 +117,7 @@ class NimbleData : public velox::dwio::common::FormatData {
   velox::BufferPtr inMap_;
   const EncodingFactory* const encodingFactory_;
   bool nimblePreserveDictionaryEncoding_{false};
+  bool lazyColumnIo_{false};
 };
 
 class NimbleParams : public velox::dwio::common::FormatParams {
@@ -127,13 +131,17 @@ class NimbleParams : public velox::dwio::common::FormatParams {
       const EncodingFactory& encodingFactory,
       bool stringDecoderZeroCopy = false,
       bool preserveFlatMapsInMemory = false,
-      bool nimblePreserveDictionaryEncoding = false)
+      bool nimblePreserveDictionaryEncoding = false,
+      const folly::F14FastSet<std::string>* lazyIoColumns = nullptr,
+      bool lazyColumnIo = false)
       : FormatParams(pool, stats),
         nimbleType_(nimbleType),
         streams_(&streams),
         rowSizeTracker_(rowSizeTracker),
         preserveFlatMapsInMemory_(preserveFlatMapsInMemory),
+        lazyIoColumns_(lazyIoColumns),
         encodingFactory_(&encodingFactory),
+        lazyColumnIo_(lazyColumnIo),
         stringDecoderZeroCopy_{stringDecoderZeroCopy},
         nimblePreserveDictionaryEncoding_{nimblePreserveDictionaryEncoding} {}
 
@@ -151,7 +159,9 @@ class NimbleParams : public velox::dwio::common::FormatParams {
         *encodingFactory_,
         stringDecoderZeroCopy_,
         preserveFlatMapsInMemory_,
-        nimblePreserveDictionaryEncoding_);
+        nimblePreserveDictionaryEncoding_,
+        /*lazyIoColumns=*/nullptr,
+        lazyColumnIo_);
   }
 
   const std::shared_ptr<const Type>& nimbleType() const {
@@ -162,12 +172,39 @@ class NimbleParams : public velox::dwio::common::FormatParams {
     return *streams_;
   }
 
+  /// Marks this column for lazy I/O routing. Called by StructColumnReader
+  /// for top-level columns eligible for lazy I/O.
+  void setLazyColumnIo(bool lazyColumnIo) {
+    lazyColumnIo_ = lazyColumnIo;
+  }
+
+  /// Returns true if this column's streams should be routed to the lazy
+  /// input clone instead of the main (eager) input.
+  bool lazyColumnIo() const {
+    return lazyColumnIo_;
+  }
+
   void setInMapDecoder(ChunkedDecoder* decoder) {
     inMapDecoder_ = decoder;
   }
 
   bool preserveFlatMapsInMemory() const {
     return preserveFlatMapsInMemory_;
+  }
+
+  /// Returns true if any top-level columns are marked for lazy I/O.
+  bool hasLazyIoColumns() const {
+    return lazyIoColumns_ != nullptr;
+  }
+
+  /// Returns true if the top-level column 'name' should use lazy I/O.
+  bool lazyIoColumn(const std::string& name) const {
+    return lazyIoColumns_ != nullptr && lazyIoColumns_->count(name) > 0;
+  }
+
+  /// Returns the lazy I/O columns set.
+  const folly::F14FastSet<std::string>* lazyIoColumnsSet() const {
+    return lazyIoColumns_;
   }
 
   RowSizeTracker* rowSizeTracker() const {
@@ -183,7 +220,12 @@ class NimbleParams : public velox::dwio::common::FormatParams {
   StripeStreams* const streams_{nullptr};
   RowSizeTracker* const rowSizeTracker_{nullptr};
   const bool preserveFlatMapsInMemory_{false};
+  const folly::F14FastSet<std::string>* const lazyIoColumns_{nullptr};
   const EncodingFactory* const encodingFactory_;
+  // When true, enqueue() routes to the lazy input clone instead of the
+  // main eager input. Set for lazy columns; propagated to children via
+  // makeChildParams() so nested streams inherit the parent's routing.
+  bool lazyColumnIo_{false};
   ChunkedDecoder* inMapDecoder_{nullptr};
   bool stringDecoderZeroCopy_{false};
   bool nimblePreserveDictionaryEncoding_{false};

--- a/dwio/nimble/velox/selective/ReaderBase.cpp
+++ b/dwio/nimble/velox/selective/ReaderBase.cpp
@@ -121,6 +121,19 @@ ReaderBase::ReaderBase(
         return fileStats->toColumnStatistics(fileSchema_, nimbleSchema_);
       }()} {}
 
+void LazyInput::load() {
+  if (!loaded_) {
+    input_->load(velox::dwio::common::LogType::STREAM_BUNDLE);
+    loaded_ = true;
+  }
+}
+
+LazyInput* StripeStreams::createLazyInput() {
+  NIMBLE_CHECK_NULL(lazyInput_);
+  lazyInput_ = std::make_unique<LazyInput>(readerBase_->input().clone());
+  return lazyInput_.get();
+}
+
 std::optional<common::Region> StripeStreams::streamRegion(int streamId) const {
   NIMBLE_CHECK(stripeIdentifier_.has_value());
   const auto& tablet = readerBase_->tablet();
@@ -139,13 +152,16 @@ std::optional<common::Region> StripeStreams::streamRegion(int streamId) const {
 }
 
 std::unique_ptr<dwio::common::SeekableInputStream> StripeStreams::enqueue(
-    int streamId) {
+    int streamId,
+    bool lazyColumnIo) {
   const auto region = streamRegion(streamId);
   if (!region.has_value()) {
     return nullptr;
   }
   dwio::common::StreamIdentifier sid(streamId);
-  return readerBase_->input().enqueue(*region, &sid);
+  auto& input =
+      lazyColumnIo ? *lazyInput_->bufferedInput() : readerBase_->input();
+  return input.enqueue(*region, &sid);
 }
 
 std::vector<std::optional<StreamLocation>> StripeStreams::locateStreams(

--- a/dwio/nimble/velox/selective/ReaderBase.h
+++ b/dwio/nimble/velox/selective/ReaderBase.h
@@ -150,6 +150,30 @@ struct StreamLocation {
   velox::common::Region region;
 };
 
+/// Cloned BufferedInput for lazy I/O columns, loaded on first lazy access.
+/// All lazy columns in a stripe share a single LazyInput so their
+/// streams are coalesced into one WS read instead of N separate reads.
+///
+/// NOTE: this object is not thread-safe.
+class LazyInput {
+ public:
+  explicit LazyInput(std::unique_ptr<velox::dwio::common::BufferedInput> input)
+      : input_(std::move(input)) {}
+
+  /// Triggers WS I/O to load all enqueued lazy streams. Idempotent —
+  /// only the first call fetches data; subsequent calls are no-ops.
+  void load();
+
+  /// Returns the underlying BufferedInput for stream routing.
+  velox::dwio::common::BufferedInput* bufferedInput() const {
+    return input_.get();
+  }
+
+ private:
+  std::unique_ptr<velox::dwio::common::BufferedInput> input_;
+  bool loaded_{false};
+};
+
 class StripeStreams {
  public:
   explicit StripeStreams(const std::shared_ptr<ReaderBase>& readerBase)
@@ -157,6 +181,7 @@ class StripeStreams {
 
   void setStripe(int stripe) {
     stripe_ = stripe;
+    lazyInput_.reset();
     // Keep previous stripe's shared_ptrs (StripeGroup, ChunkIndexGroup)
     // alive while loading the new stripe. This prevents the weak-pointer
     // cache entries from expiring when consecutive stripes share the same
@@ -169,8 +194,11 @@ class StripeStreams {
     return streamRegion(streamId).has_value();
   }
 
+  /// Enqueue a stream for loading. When lazyColumnIo is true, routes to the
+  /// lazy input clone; otherwise to the main (eager) input.
   std::unique_ptr<velox::dwio::common::SeekableInputStream> enqueue(
-      int streamId);
+      int streamId,
+      bool lazyColumnIo = false);
 
   /// Returns the physical file location of each requested stream in the
   /// current stripe. Streams that do not exist or have zero size return
@@ -181,6 +209,10 @@ class StripeStreams {
   void load() {
     readerBase_->input().load(velox::dwio::common::LogType::STREAM_BUNDLE);
   }
+
+  /// Create a lazy input clone for lazy column I/O. Ownership is held
+  /// by StripeStreams; the clone is valid until the next setStripe() call.
+  LazyInput* createLazyInput();
 
   int32_t stripeIndex() const {
     return stripe_;
@@ -197,7 +229,11 @@ class StripeStreams {
 
   const std::shared_ptr<ReaderBase> readerBase_;
 
-  int stripe_;
+  int stripe_{};
+  // Owns the lazy input clone for the current stripe. Reset on
+  // setStripe(). StructColumnReader holds a raw LazyInput* pointer,
+  // guarded by the numReads_ version check.
+  std::unique_ptr<LazyInput> lazyInput_;
   std::optional<StripeIdentifier> stripeIdentifier_;
 };
 

--- a/dwio/nimble/velox/selective/SelectiveNimbleReader.cpp
+++ b/dwio/nimble/velox/selective/SelectiveNimbleReader.cpp
@@ -15,6 +15,7 @@
  */
 
 #include "dwio/nimble/velox/selective/SelectiveNimbleReader.h"
+#include <folly/container/F14Set.h>
 #include "dwio/nimble/encodings/common/EncodingFactory.h"
 #include "dwio/nimble/encodings/legacy/EncodingFactory.h"
 #include "dwio/nimble/index/ClusterIndex.h"
@@ -118,7 +119,8 @@ class SelectiveNimbleRowReader : public dwio::common::RowReader {
   SelectiveNimbleRowReader(
       const std::shared_ptr<ReaderBase>& readerBase,
       const dwio::common::RowReaderOptions& options)
-      : readerBase_{readerBase},
+      : lazyIoColumns_{computeLazyIoColumns(options)},
+        readerBase_{readerBase},
         options_{options},
         encodingFactory_(
             options.stringDecoderZeroCopy()
@@ -201,6 +203,16 @@ class SelectiveNimbleRowReader : public dwio::common::RowReader {
   // statistics. Only counts columns in the scan spec. Sets statsBasedRowSize_
   // if stats are available.
   void computeStatsBasedRowSize() const;
+
+  // Computes which top-level columns should use lazy I/O based on the scan
+  // spec and remaining filter columns. Returns a const set used for the
+  // lifetime of this reader.
+  static folly::F14FastSet<std::string> computeLazyIoColumns(
+      const dwio::common::RowReaderOptions& options);
+
+  // Precomputed set of top-level column names that should use lazy I/O.
+  // Const after construction — computed once per split.
+  const folly::F14FastSet<std::string> lazyIoColumns_;
 
   const std::shared_ptr<ReaderBase> readerBase_;
   const dwio::common::RowReaderOptions options_;
@@ -401,6 +413,38 @@ void SelectiveNimbleRowReader::initReadRange() {
   rowInCurrentStripe_ = 0;
 }
 
+// Computes the set of top-level columns eligible for lazy I/O. A column
+// qualifies if it has no pushdown filter, is not referenced by the remaining
+// filter, has no extraction transform, and is projected in the output.
+// Returns empty set when lazy I/O is disabled.
+folly::F14FastSet<std::string> SelectiveNimbleRowReader::computeLazyIoColumns(
+    const dwio::common::RowReaderOptions& options) {
+  folly::F14FastSet<std::string> lazyIoColumns;
+  if (!options.lazyColumnIo()) {
+    return lazyIoColumns;
+  }
+  auto* scanSpec = options.scanSpec().get();
+  VELOX_CHECK_NOT_NULL(scanSpec);
+  const auto& remainingFilterColumns = options.remainingFilterColumns();
+  for (auto* childSpec : scanSpec->stableChildren()) {
+    if (childSpec->isConstant() || !childSpec->readFromFile()) {
+      continue;
+    }
+    const auto& name = childSpec->fieldName();
+    NIMBLE_DCHECK(
+        childSpec->hasFilter() || childSpec->projectOut(),
+        "Column with no filter should be projected");
+    // A column is eligible for lazy I/O if it has no pushdown filter, is not
+    // referenced by the remaining filter (must be eager for filter eval), has
+    // no extraction transform, and is projected in the output.
+    if (!childSpec->hasFilter() && remainingFilterColumns.count(name) == 0 &&
+        !childSpec->hasTransform() && childSpec->projectOut()) {
+      lazyIoColumns.insert(name);
+    }
+  }
+  return lazyIoColumns;
+}
+
 void SelectiveNimbleRowReader::loadCurrentStripe() {
   addThreadLocalRuntimeStat(kNumStripeLoads, velox::RuntimeCounter(1));
 
@@ -414,7 +458,8 @@ void SelectiveNimbleRowReader::loadCurrentStripe() {
       *encodingFactory_,
       options_.stringDecoderZeroCopy(),
       options_.preserveFlatMapsInMemory(),
-      options_.nimblePreserveDictionaryEncoding());
+      options_.nimblePreserveDictionaryEncoding(),
+      lazyIoColumns_.empty() ? nullptr : &lazyIoColumns_);
 
   columnReader_ = buildColumnReader(
       options_.requestedType() ? options_.requestedType()

--- a/dwio/nimble/velox/selective/StructColumnReader.cpp
+++ b/dwio/nimble/velox/selective/StructColumnReader.cpp
@@ -59,8 +59,15 @@ StructColumnReader::StructColumnReader(
           params,
           scanSpec,
           isRoot) {
+  NIMBLE_CHECK(
+      !params.hasLazyIoColumns() || isRoot,
+      "Lazy I/O columns should only be set at root level");
   const auto& rowType = params.nimbleType()->asRow();
   const auto& fileRowType = fileType_->type()->asRow();
+  if (params.hasLazyIoColumns()) {
+    lazyInput_ = params.streams().createLazyInput();
+    lazyIoColumns_ = params.lazyIoColumnsSet();
+  }
   for (auto* childSpec : scanSpec.stableChildren()) {
     if (childSpec->isConstant() || isChildMissing(*childSpec)) {
       childSpec->setSubscript(kConstantChildSpecSubscript);
@@ -74,6 +81,9 @@ StructColumnReader::StructColumnReader(
     const auto& childRequestedType =
         requestedType_->asRow().findChild(childSpec->fieldName());
     auto childParams = params.makeChildParams(rowType.childAt(childIdx));
+    if (params.lazyIoColumn(childSpec->fieldName())) {
+      childParams.setLazyColumnIo(true);
+    }
     addChild(buildColumnReader(
         childRequestedType, childFileType, childParams, *childSpec, false));
     childSpec->setSubscript(children_.size() - 1);
@@ -92,6 +102,13 @@ bool StructColumnReader::estimateMaterializedSize(
     rowCount = *nullsRowCount;
   } else {
     rowCount = 0;
+  }
+  // When lazy columns exist, return false to fall through to RowSizeTracker.
+  // A partial estimate from eager columns only would underestimate row size
+  // (lazy columns are often large FlatMaps), causing oversized batches.
+  // RowSizeTracker learns the actual row size after the first batch.
+  if (lazyInput_ != nullptr) {
+    return false;
   }
   size_t rowSize{0};
   for (const auto& child : children_) {

--- a/dwio/nimble/velox/selective/StructColumnReader.h
+++ b/dwio/nimble/velox/selective/StructColumnReader.h
@@ -16,6 +16,7 @@
 
 #pragma once
 
+#include <folly/container/F14Set.h>
 #include "dwio/nimble/velox/selective/ColumnLoader.h"
 #include "dwio/nimble/velox/selective/NimbleData.h"
 #include "dwio/nimble/velox/selective/RowSizeTracker.h"
@@ -55,10 +56,8 @@ class StructColumnReaderBase
     // decoders.
   }
 
-  virtual std::unique_ptr<velox::dwio::common::ColumnLoader> makeColumnLoader(
+  std::unique_ptr<velox::dwio::common::ColumnLoader> makeColumnLoader(
       velox::vector_size_t index) override {
-    // Check if the child at this index has a transform with kNone extraction.
-    // If so, return a TransformColumnLoader to apply the transform lazily.
     for (const auto& childSpec : scanSpec_->children()) {
       if (childSpec->subscript() == index && childSpec->hasTransform() &&
           childSpec->extractionType() ==
@@ -87,12 +86,35 @@ class StructColumnReader : public StructColumnReaderBase {
   bool estimateMaterializedSize(size_t& byteSize, size_t& rowCount) const final;
 
  private:
+  // Creates a column loader for lazy I/O columns. Lazy columns get a
+  // TrackedColumnLoader that triggers LazyInput::load() on first access;
+  // non-lazy columns fall through to the base class loader.
+  std::unique_ptr<velox::dwio::common::ColumnLoader> makeColumnLoader(
+      velox::vector_size_t index) override {
+    if (lazyInput_ != nullptr) {
+      for (const auto& childSpec : scanSpec_->children()) {
+        if (childSpec->subscript() == index &&
+            lazyIoColumns_->count(childSpec->fieldName()) > 0) {
+          return std::make_unique<nimble::TrackedColumnLoader>(
+              this, children_[index], numReads_, rowSizeTracker_, lazyInput_);
+        }
+      }
+    }
+    return StructColumnReaderBase::makeColumnLoader(index);
+  }
+
   void addChild(std::unique_ptr<SelectiveColumnReader> child) {
     children_.push_back(child.get());
     childrenOwned_.push_back(std::move(child));
   }
 
   std::vector<std::unique_ptr<SelectiveColumnReader>> childrenOwned_;
+  // Lazy input for all lazy I/O columns in this stripe. Null when
+  // no columns use lazy I/O. Owned by StripeStreams.
+  LazyInput* lazyInput_{nullptr};
+  // Set of top-level column names eligible for lazy I/O. Pointer to the
+  // const set owned by SelectiveNimbleRowReader.
+  const folly::F14FastSet<std::string>* lazyIoColumns_{nullptr};
 };
 
 } // namespace facebook::nimble

--- a/dwio/nimble/velox/selective/tests/FlatMapColumnReaderTest.cpp
+++ b/dwio/nimble/velox/selective/tests/FlatMapColumnReaderTest.cpp
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+#include <folly/container/F14Set.h>
 #include "dwio/nimble/velox/selective/SelectiveNimbleReader.h"
 
 #include "dwio/nimble/common/tests/NimbleFileWriter.h"
@@ -67,7 +68,9 @@ class FlatMapColumnReaderTest : public ::testing::TestWithParam<bool>,
       const RowVectorPtr& expected,
       const std::string& file,
       const std::shared_ptr<common::ScanSpec>& scanSpec,
-      bool preserveFlatMapsInMemory = false) {
+      bool preserveFlatMapsInMemory = false,
+      bool lazyColumnIo = false,
+      const folly::F14FastSet<std::string>& remainingFilterColumns = {}) {
     auto readFile = std::make_shared<InMemoryReadFile>(file);
     auto factory =
         dwio::common::getReaderFactory(dwio::common::FileFormat::NIMBLE);
@@ -84,6 +87,10 @@ class FlatMapColumnReaderTest : public ::testing::TestWithParam<bool>,
     rowOptions.setScanSpec(scanSpec);
     rowOptions.setRequestedType(type);
     rowOptions.setPreserveFlatMapsInMemory(preserveFlatMapsInMemory);
+    rowOptions.setLazyColumnIo(lazyColumnIo);
+    if (!remainingFilterColumns.empty()) {
+      rowOptions.setRemainingFilterColumns(remainingFilterColumns);
+    }
     readers.rowReader = readers.reader->createRowReader(rowOptions);
     return readers;
   }
@@ -527,6 +534,632 @@ TEST_P(FlatMapColumnReaderTest, nativeWithNulls) {
       makeReaders(input, file, scanSpec, /*preserveFlatMapsInMemory=*/true);
   auto expected = makeRowVector({flatMap->toMapVector(), flatMap});
   validate(*expected, *readers.rowReader, 3);
+}
+
+// ----- Lazy I/O tests -----
+
+TEST_P(FlatMapColumnReaderTest, lazyIOFilterOnScalar) {
+  auto input = makeRowVector({
+      makeFlatVector<int64_t>({10, 20, 30, 40, 50}),
+      makeMapVector<int32_t, int64_t>({
+          {{1, 100}, {2, 200}},
+          {{1, 300}},
+          {{2, 400}, {3, 500}},
+          {{1, 600}, {2, 700}, {3, 800}},
+          {},
+      }),
+  });
+  auto file = writeFlatMapFile(input, "c1");
+  auto scanSpec = std::make_shared<common::ScanSpec>("root");
+  scanSpec->addAllChildFields(*input->type());
+  scanSpec->childByName("c0")->setFilter(
+      std::make_unique<common::BigintRange>(30, 100, false));
+  auto readers = makeReaders(
+      input,
+      file,
+      scanSpec,
+      /*preserveFlatMapsInMemory=*/false,
+      /*lazyColumnIo=*/true);
+  VectorPtr result = BaseVector::create(asRowType(input->type()), 0, pool());
+  readers.rowReader->next(100, result);
+  ASSERT_EQ(result->size(), 3);
+  auto expected = makeRowVector({
+      makeFlatVector<int64_t>({30, 40, 50}),
+      makeMapVector<int32_t, int64_t>({
+          {{2, 400}, {3, 500}},
+          {{1, 600}, {2, 700}, {3, 800}},
+          {},
+      }),
+  });
+  velox::test::assertEqualVectors(expected, result);
+}
+
+TEST_P(FlatMapColumnReaderTest, lazyIOFilterDropsAll) {
+  auto input = makeRowVector({
+      makeFlatVector<int64_t>({10, 20, 30}),
+      makeMapVector<int32_t, int64_t>({
+          {{1, 100}},
+          {{2, 200}},
+          {{3, 300}},
+      }),
+  });
+  auto file = writeFlatMapFile(input, "c1");
+  auto scanSpec = std::make_shared<common::ScanSpec>("root");
+  scanSpec->addAllChildFields(*input->type());
+  scanSpec->childByName("c0")->setFilter(
+      std::make_unique<common::BigintRange>(999, 1000, false));
+  auto readers = makeReaders(
+      input,
+      file,
+      scanSpec,
+      /*preserveFlatMapsInMemory=*/false,
+      /*lazyColumnIo=*/true);
+  VectorPtr result = BaseVector::create(asRowType(input->type()), 0, pool());
+  readers.rowReader->next(100, result);
+  ASSERT_EQ(result->size(), 0);
+}
+
+TEST_P(FlatMapColumnReaderTest, lazyIOFilterOnScalarAsStruct) {
+  auto input = makeRowVector({
+      makeFlatVector<int64_t>({10, 20, 30, 40}),
+      makeMapVector<int32_t, int64_t>({
+          {{1, 100}, {2, 200}},
+          {{1, 300}},
+          {{2, 400}, {3, 500}},
+          {{1, 600}, {2, 700}, {3, 800}},
+      }),
+  });
+  auto file = writeFlatMapFile(input, "c1");
+  auto outType =
+      ROW({"c0", "c1"},
+          {BIGINT(), ROW({"1", "2", "3"}, {BIGINT(), BIGINT(), BIGINT()})});
+  auto scanSpec = std::make_shared<common::ScanSpec>("root");
+  scanSpec->addAllChildFields(*outType);
+  scanSpec->childByName("c1")->setFlatMapAsStruct(true);
+  scanSpec->childByName("c0")->setFilter(
+      std::make_unique<common::BigintRange>(30, 100, false));
+  auto readers = makeReaders(
+      input,
+      file,
+      scanSpec,
+      /*preserveFlatMapsInMemory=*/false,
+      /*lazyColumnIo=*/true);
+  VectorPtr batch = BaseVector::create(outType, 0, pool());
+  readers.rowReader->next(100, batch);
+  ASSERT_EQ(batch->size(), 2);
+  batch->validate();
+  auto expected = makeRowVector(
+      {"c0", "c1"},
+      {makeFlatVector<int64_t>({30, 40}),
+       makeRowVector(
+           {"1", "2", "3"},
+           {
+               makeNullableFlatVector<int64_t>({std::nullopt, 600}),
+               makeNullableFlatVector<int64_t>({400, 700}),
+               makeNullableFlatVector<int64_t>({500, 800}),
+           })});
+  velox::test::assertEqualVectors(expected, batch);
+}
+
+TEST_P(FlatMapColumnReaderTest, lazyIOMultiBatch) {
+  auto input = makeRowVector({
+      makeFlatVector<int64_t>(
+          50, [](auto i) { return static_cast<int64_t>(i); }),
+      makeMapVector<int32_t, int64_t>(
+          50,
+          [](auto i) { return 1 + i % 3; },
+          [](auto j) { return static_cast<int32_t>(1 + j % 3); },
+          [](auto j) { return static_cast<int64_t>(j * 10); }),
+  });
+  auto file = writeFlatMapFile(input, "c1");
+  auto scanSpec = std::make_shared<common::ScanSpec>("root");
+  scanSpec->addAllChildFields(*input->type());
+  // Keep rows where c0 >= 25 (25 of 50 rows survive).
+  scanSpec->childByName("c0")->setFilter(
+      std::make_unique<common::BigintRange>(25, 100, false));
+  auto readers = makeReaders(
+      input,
+      file,
+      scanSpec,
+      /*preserveFlatMapsInMemory=*/false,
+      /*lazyColumnIo=*/true);
+  auto result = BaseVector::create(asRowType(input->type()), 0, pool());
+  int totalOutput = 0;
+  int totalScanned = 0;
+  while (totalScanned < 50) {
+    auto n = readers.rowReader->next(7, result);
+    if (n == 0) {
+      break;
+    }
+    result->validate();
+    totalOutput += result->size();
+    totalScanned += n;
+  }
+  ASSERT_EQ(totalScanned, 50);
+  ASSERT_EQ(totalOutput, 25);
+}
+
+TEST_P(FlatMapColumnReaderTest, lazyIOMultipleComplexColumns) {
+  auto input = makeRowVector({
+      makeFlatVector<int64_t>({10, 20, 30, 40, 50}),
+      makeMapVector<int32_t, int64_t>({
+          {{1, 100}, {2, 200}},
+          {{1, 300}},
+          {{2, 400}, {3, 500}},
+          {{1, 600}, {2, 700}, {3, 800}},
+          {},
+      }),
+      makeMapVector<int32_t, int32_t>({
+          {{10, 1}},
+          {{20, 2}, {30, 3}},
+          {{10, 4}},
+          {{20, 5}},
+          {{10, 6}, {30, 7}},
+      }),
+  });
+  VeloxWriterOptions writerOptions;
+  writerOptions.flatMapColumns = {{"c1", {}}, {"c2", {}}};
+  writerOptions.skipConstantFlatMapInMapStreams = GetParam();
+  auto file = test::createNimbleFile(*rootPool(), input, writerOptions);
+  auto scanSpec = std::make_shared<common::ScanSpec>("root");
+  scanSpec->addAllChildFields(*input->type());
+  scanSpec->childByName("c0")->setFilter(
+      std::make_unique<common::BigintRange>(30, 100, false));
+  auto readers = makeReaders(
+      input,
+      file,
+      scanSpec,
+      /*preserveFlatMapsInMemory=*/false,
+      /*lazyColumnIo=*/true);
+  VectorPtr result = BaseVector::create(asRowType(input->type()), 0, pool());
+  readers.rowReader->next(100, result);
+  ASSERT_EQ(result->size(), 3);
+  auto expected = makeRowVector({
+      makeFlatVector<int64_t>({30, 40, 50}),
+      makeMapVector<int32_t, int64_t>({
+          {{2, 400}, {3, 500}},
+          {{1, 600}, {2, 700}, {3, 800}},
+          {},
+      }),
+      makeMapVector<int32_t, int32_t>({
+          {{10, 4}},
+          {{20, 5}},
+          {{10, 6}, {30, 7}},
+      }),
+  });
+  velox::test::assertEqualVectors(expected, result);
+}
+
+TEST_P(FlatMapColumnReaderTest, noLazyIOByDefault) {
+  auto input = makeRowVector({
+      makeFlatVector<int64_t>({10, 20, 30, 40, 50}),
+      makeMapVector<int32_t, int64_t>({
+          {{1, 100}, {2, 200}},
+          {{1, 300}},
+          {{2, 400}, {3, 500}},
+          {{1, 600}, {2, 700}, {3, 800}},
+          {},
+      }),
+  });
+  auto file = writeFlatMapFile(input, "c1");
+  auto scanSpec = std::make_shared<common::ScanSpec>("root");
+  scanSpec->addAllChildFields(*input->type());
+  scanSpec->childByName("c0")->setFilter(
+      std::make_unique<common::BigintRange>(30, 100, false));
+  auto readers = makeReaders(input, file, scanSpec);
+  VectorPtr result = BaseVector::create(asRowType(input->type()), 0, pool());
+  readers.rowReader->next(100, result);
+  ASSERT_EQ(result->size(), 3);
+  auto expected = makeRowVector({
+      makeFlatVector<int64_t>({30, 40, 50}),
+      makeMapVector<int32_t, int64_t>({
+          {{2, 400}, {3, 500}},
+          {{1, 600}, {2, 700}, {3, 800}},
+          {},
+      }),
+  });
+  velox::test::assertEqualVectors(expected, result);
+}
+
+// Remaining filter column should NOT be lazy — reads same data as eager.
+TEST_P(FlatMapColumnReaderTest, lazyIORemainingFilterStaysEager) {
+  auto input = makeRowVector({
+      makeFlatVector<int64_t>({10, 20, 30, 40, 50}),
+      makeMapVector<int32_t, int64_t>({
+          {{1, 100}, {2, 200}},
+          {{1, 300}},
+          {{2, 400}, {3, 500}},
+          {{1, 600}, {2, 700}, {3, 800}},
+          {},
+      }),
+  });
+  auto file = writeFlatMapFile(input, "c1");
+  auto scanSpec = std::make_shared<common::ScanSpec>("root");
+  scanSpec->addAllChildFields(*input->type());
+  scanSpec->childByName("c0")->setFilter(
+      std::make_unique<common::BigintRange>(30, 100, false));
+  auto readers = makeReaders(
+      input,
+      file,
+      scanSpec,
+      /*preserveFlatMapsInMemory=*/false,
+      /*lazyColumnIo=*/true,
+      /*remainingFilterColumns=*/{"c1"});
+  VectorPtr result = BaseVector::create(asRowType(input->type()), 0, pool());
+  readers.rowReader->next(100, result);
+  ASSERT_EQ(result->size(), 3);
+  auto expected = makeRowVector({
+      makeFlatVector<int64_t>({30, 40, 50}),
+      makeMapVector<int32_t, int64_t>({
+          {{2, 400}, {3, 500}},
+          {{1, 600}, {2, 700}, {3, 800}},
+          {},
+      }),
+  });
+  velox::test::assertEqualVectors(expected, result);
+}
+
+// No filter at all — hasFilterChild is false, nothing should be lazy.
+TEST_P(FlatMapColumnReaderTest, lazyIONoFilter) {
+  auto input = makeRowVector({
+      makeFlatVector<int64_t>({10, 20, 30}),
+      makeMapVector<int32_t, int64_t>({
+          {{1, 100}, {2, 200}},
+          {{1, 300}},
+          {{2, 400}, {3, 500}},
+      }),
+  });
+  auto file = writeFlatMapFile(input, "c1");
+  auto scanSpec = std::make_shared<common::ScanSpec>("root");
+  scanSpec->addAllChildFields(*input->type());
+  // No filter set on any column.
+  auto readers = makeReaders(
+      input,
+      file,
+      scanSpec,
+      /*preserveFlatMapsInMemory=*/false,
+      /*lazyColumnIo=*/true);
+  VectorPtr result = BaseVector::create(asRowType(input->type()), 0, pool());
+  readers.rowReader->next(100, result);
+  ASSERT_EQ(result->size(), 3);
+  velox::test::assertEqualVectors(input, result);
+}
+
+// Remaining filter only — no pushdown filter on any column. c0 should be
+// lazy, c1 should stay eager (in remainingFilterColumns).
+TEST_P(FlatMapColumnReaderTest, lazyIORemainingFilterOnly) {
+  auto input = makeRowVector({
+      makeFlatVector<int64_t>({10, 20, 30, 40, 50}),
+      makeMapVector<int32_t, int64_t>({
+          {{1, 100}, {2, 200}},
+          {{1, 300}},
+          {{2, 400}, {3, 500}},
+          {{1, 600}, {2, 700}, {3, 800}},
+          {},
+      }),
+  });
+  auto file = writeFlatMapFile(input, "c1");
+  auto scanSpec = std::make_shared<common::ScanSpec>("root");
+  scanSpec->addAllChildFields(*input->type());
+  // No pushdown filter on any column. c1 is in remainingFilterColumns.
+  auto readers = makeReaders(
+      input,
+      file,
+      scanSpec,
+      /*preserveFlatMapsInMemory=*/false,
+      /*lazyColumnIo=*/true,
+      /*remainingFilterColumns=*/{"c1"});
+  VectorPtr result = BaseVector::create(asRowType(input->type()), 0, pool());
+  readers.rowReader->next(100, result);
+  ASSERT_EQ(result->size(), 5);
+  velox::test::assertEqualVectors(input, result);
+}
+
+// Only scalar columns — c1 (no filter) is lazy.
+TEST_P(FlatMapColumnReaderTest, lazyIOScalarOnly) {
+  auto input = makeRowVector({
+      makeFlatVector<int64_t>({10, 20, 30, 40, 50}),
+      makeFlatVector<int32_t>({1, 2, 3, 4, 5}),
+  });
+  VeloxWriterOptions writerOptions;
+  writerOptions.skipConstantFlatMapInMapStreams = GetParam();
+  auto file = test::createNimbleFile(*rootPool(), input, writerOptions);
+  auto scanSpec = std::make_shared<common::ScanSpec>("root");
+  scanSpec->addAllChildFields(*input->type());
+  scanSpec->childByName("c0")->setFilter(
+      std::make_unique<common::BigintRange>(30, 100, false));
+  auto readers = makeReaders(
+      input,
+      file,
+      scanSpec,
+      /*preserveFlatMapsInMemory=*/false,
+      /*lazyColumnIo=*/true);
+  VectorPtr result = BaseVector::create(asRowType(input->type()), 0, pool());
+  readers.rowReader->next(100, result);
+  ASSERT_EQ(result->size(), 3);
+  auto expected = makeRowVector({
+      makeFlatVector<int64_t>({30, 40, 50}),
+      makeFlatVector<int32_t>({3, 4, 5}),
+  });
+  velox::test::assertEqualVectors(expected, result);
+}
+
+// Mixed scalar + FlatMap: scalar filter, scalar projected, FlatMap lazy.
+// Verifies interleaved lazy/non-lazy children work correctly.
+TEST_P(FlatMapColumnReaderTest, lazyIOMixedScalarAndFlatMap) {
+  auto input = makeRowVector({
+      makeFlatVector<int64_t>({10, 20, 30, 40, 50}),
+      makeFlatVector<int32_t>({1, 2, 3, 4, 5}),
+      makeMapVector<int32_t, int64_t>({
+          {{1, 100}},
+          {{2, 200}},
+          {{3, 300}},
+          {{1, 400}},
+          {{2, 500}},
+      }),
+      makeFlatVector<double>({1.1, 2.2, 3.3, 4.4, 5.5}),
+  });
+  VeloxWriterOptions writerOptions;
+  writerOptions.flatMapColumns = {{"c2", {}}};
+  writerOptions.skipConstantFlatMapInMapStreams = GetParam();
+  auto file = test::createNimbleFile(*rootPool(), input, writerOptions);
+  auto scanSpec = std::make_shared<common::ScanSpec>("root");
+  scanSpec->addAllChildFields(*input->type());
+  scanSpec->childByName("c0")->setFilter(
+      std::make_unique<common::BigintRange>(30, 100, false));
+  auto readers = makeReaders(
+      input,
+      file,
+      scanSpec,
+      /*preserveFlatMapsInMemory=*/false,
+      /*lazyColumnIo=*/true);
+  VectorPtr result = BaseVector::create(asRowType(input->type()), 0, pool());
+  readers.rowReader->next(100, result);
+  ASSERT_EQ(result->size(), 3);
+  auto expected = makeRowVector({
+      makeFlatVector<int64_t>({30, 40, 50}),
+      makeFlatVector<int32_t>({3, 4, 5}),
+      makeMapVector<int32_t, int64_t>({
+          {{3, 300}},
+          {{1, 400}},
+          {{2, 500}},
+      }),
+      makeFlatVector<double>({3.3, 4.4, 5.5}),
+  });
+  velox::test::assertEqualVectors(expected, result);
+}
+
+// FlatMap key selection is the only filter in the scan. hasFilterInSubtree()
+// detects it and enables lazy I/O; hasFilter() ignores it so the FlatMap
+// itself is still lazy. The scalar column c0 has no filter and should
+// also be lazy.
+TEST_P(FlatMapColumnReaderTest, lazyIOFlatMapKeySelectionAsOnlyFilter) {
+  auto input = makeRowVector({
+      makeFlatVector<int64_t>({10, 20, 30, 40, 50}),
+      makeMapVector<int32_t, int64_t>({
+          {{1, 100}, {2, 200}, {3, 300}},
+          {{1, 400}, {2, 500}},
+          {{1, 600}, {3, 700}},
+          {{2, 800}, {3, 900}},
+          {{1, 1000}},
+      }),
+  });
+  auto file = writeFlatMapFile(input, "c1");
+  auto outType =
+      ROW({"c0", "c1"}, {BIGINT(), ROW({"1", "2"}, {BIGINT(), BIGINT()})});
+  auto scanSpec = std::make_shared<common::ScanSpec>("root");
+  scanSpec->addAllChildFields(*outType);
+  scanSpec->childByName("c1")->setFlatMapAsStruct(true);
+  // No filter on c0 — the only filter is implicit key selection on c1.
+  auto readers = makeReaders(
+      input,
+      file,
+      scanSpec,
+      /*preserveFlatMapsInMemory=*/false,
+      /*lazyColumnIo=*/true);
+  VectorPtr batch = BaseVector::create(outType, 0, pool());
+  readers.rowReader->next(100, batch);
+  ASSERT_EQ(batch->size(), 5);
+  batch->validate();
+  auto expected = makeRowVector(
+      {"c0", "c1"},
+      {makeFlatVector<int64_t>({10, 20, 30, 40, 50}),
+       makeRowVector(
+           {"1", "2"},
+           {
+               makeNullableFlatVector<int64_t>(
+                   {100, 400, 600, std::nullopt, 1000}),
+               makeNullableFlatVector<int64_t>(
+                   {200, 500, std::nullopt, 800, std::nullopt}),
+           })});
+  velox::test::assertEqualVectors(expected, batch);
+}
+
+// Nested ROW column with a pushdown filter on a nested child. The parent
+// column should NOT be lazy because hasFilter() recurses into non-map
+// children and detects the nested filter.
+TEST_P(FlatMapColumnReaderTest, lazyIONestedRowWithFilter) {
+  auto rowType = ROW({"a", "b"}, {BIGINT(), BIGINT()});
+  auto input = makeRowVector({
+      makeFlatVector<int64_t>({10, 20, 30, 40, 50}),
+      makeRowVector(
+          {"a", "b"},
+          {
+              makeFlatVector<int64_t>({1, 2, 3, 4, 5}),
+              makeFlatVector<int64_t>({100, 200, 300, 400, 500}),
+          }),
+      makeMapVector<int32_t, int64_t>({
+          {{1, 10}},
+          {{2, 20}},
+          {{3, 30}},
+          {{1, 40}},
+          {{2, 50}},
+      }),
+  });
+  VeloxWriterOptions writerOptions;
+  writerOptions.flatMapColumns = {{"c2", {}}};
+  writerOptions.skipConstantFlatMapInMapStreams = GetParam();
+  auto file = test::createNimbleFile(*rootPool(), input, writerOptions);
+  auto scanSpec = std::make_shared<common::ScanSpec>("root");
+  scanSpec->addAllChildFields(*input->type());
+  // Filter on nested field c1.a — parent c1 should NOT be lazy.
+  scanSpec->childByName("c1")->childByName("a")->setFilter(
+      std::make_unique<common::BigintRange>(3, 100, false));
+  auto readers = makeReaders(
+      input,
+      file,
+      scanSpec,
+      /*preserveFlatMapsInMemory=*/false,
+      /*lazyColumnIo=*/true);
+  VectorPtr result = BaseVector::create(asRowType(input->type()), 0, pool());
+  readers.rowReader->next(100, result);
+  ASSERT_EQ(result->size(), 3);
+  auto expected = makeRowVector({
+      makeFlatVector<int64_t>({30, 40, 50}),
+      makeRowVector(
+          {"a", "b"},
+          {
+              makeFlatVector<int64_t>({3, 4, 5}),
+              makeFlatVector<int64_t>({300, 400, 500}),
+          }),
+      makeMapVector<int32_t, int64_t>({
+          {{3, 30}},
+          {{1, 40}},
+          {{2, 50}},
+      }),
+  });
+  velox::test::assertEqualVectors(expected, result);
+}
+
+// Nested ROW column with no filter — should use lazy I/O when a sibling has a
+// pushdown filter. Exercises the makeChildParams() path: the nested
+// StructColumnReader must not create LazyInput (guarded by NIMBLE_CHECK).
+TEST_P(FlatMapColumnReaderTest, lazyIONestedRowNoFilter) {
+  auto input = makeRowVector({
+      makeFlatVector<int64_t>({10, 20, 30, 40, 50}),
+      makeRowVector(
+          {"a", "b"},
+          {
+              makeFlatVector<int64_t>({1, 2, 3, 4, 5}),
+              makeFlatVector<int64_t>({100, 200, 300, 400, 500}),
+          }),
+  });
+  VeloxWriterOptions writerOptions;
+  writerOptions.skipConstantFlatMapInMapStreams = GetParam();
+  auto file = test::createNimbleFile(*rootPool(), input, writerOptions);
+  auto scanSpec = std::make_shared<common::ScanSpec>("root");
+  scanSpec->addAllChildFields(*input->type());
+  scanSpec->childByName("c0")->setFilter(
+      std::make_unique<common::BigintRange>(30, 100, false));
+  auto readers = makeReaders(
+      input,
+      file,
+      scanSpec,
+      /*preserveFlatMapsInMemory=*/false,
+      /*lazyColumnIo=*/true);
+  VectorPtr result = BaseVector::create(asRowType(input->type()), 0, pool());
+  readers.rowReader->next(100, result);
+  ASSERT_EQ(result->size(), 3);
+  auto expected = makeRowVector({
+      makeFlatVector<int64_t>({30, 40, 50}),
+      makeRowVector(
+          {"a", "b"},
+          {
+              makeFlatVector<int64_t>({3, 4, 5}),
+              makeFlatVector<int64_t>({300, 400, 500}),
+          }),
+  });
+  velox::test::assertEqualVectors(expected, result);
+}
+
+TEST_P(FlatMapColumnReaderTest, lazyIOTransformColumnStaysEager) {
+  auto input = makeRowVector({
+      makeFlatVector<int64_t>({10, 20, 30, 40, 50}),
+      makeFlatVector<int64_t>({1, 2, 3, 4, 5}),
+      makeMapVector<int32_t, int64_t>({
+          {{1, 100}, {2, 200}},
+          {{1, 300}},
+          {{2, 400}, {3, 500}},
+          {{1, 600}, {2, 700}, {3, 800}},
+          {},
+      }),
+  });
+  VeloxWriterOptions writerOptions;
+  writerOptions.skipConstantFlatMapInMapStreams = GetParam();
+  auto file = test::createNimbleFile(*rootPool(), input, writerOptions);
+  auto outType =
+      ROW({"c0", "c1", "c2"}, {BIGINT(), BIGINT(), input->type()->childAt(2)});
+  auto scanSpec = std::make_shared<common::ScanSpec>("root");
+  scanSpec->addAllChildFields(*outType);
+  scanSpec->childByName("c0")->setFilter(
+      std::make_unique<common::BigintRange>(30, 100, false));
+  scanSpec->childByName("c1")->setTransform(
+      [](const VectorPtr& v, memory::MemoryPool* pool) -> VectorPtr {
+        auto flat = v->asFlatVector<int64_t>();
+        auto result = BaseVector::create(BIGINT(), flat->size(), pool);
+        auto* out = result->asFlatVector<int64_t>();
+        for (auto i = 0; i < flat->size(); ++i) {
+          out->set(i, flat->valueAt(i) * 10);
+        }
+        return result;
+      },
+      BIGINT());
+  auto readers = makeReaders(
+      input,
+      file,
+      scanSpec,
+      /*preserveFlatMapsInMemory=*/false,
+      /*lazyColumnIo=*/true);
+  VectorPtr result = BaseVector::create(outType, 0, pool());
+  readers.rowReader->next(100, result);
+  ASSERT_EQ(result->size(), 3);
+  auto expected = makeRowVector({
+      makeFlatVector<int64_t>({30, 40, 50}),
+      makeFlatVector<int64_t>({30, 40, 50}),
+      makeMapVector<int32_t, int64_t>({
+          {{2, 400}, {3, 500}},
+          {{1, 600}, {2, 700}, {3, 800}},
+          {},
+      }),
+  });
+  velox::test::assertEqualVectors(expected, result);
+}
+
+TEST_P(FlatMapColumnReaderTest, lazyIORegularMapColumn) {
+  auto input = makeRowVector({
+      makeFlatVector<int64_t>({10, 20, 30, 40}),
+      makeMapVector<int32_t, int64_t>({
+          {{1, 100}, {2, 200}},
+          {{3, 300}},
+          {{4, 400}, {5, 500}},
+          {{6, 600}},
+      }),
+  });
+  VeloxWriterOptions writerOptions;
+  writerOptions.skipConstantFlatMapInMapStreams = GetParam();
+  auto file = test::createNimbleFile(*rootPool(), input, writerOptions);
+  auto scanSpec = std::make_shared<common::ScanSpec>("root");
+  scanSpec->addAllChildFields(*input->type());
+  scanSpec->childByName("c0")->setFilter(
+      std::make_unique<common::BigintRange>(20, 100, false));
+  auto readers = makeReaders(
+      input,
+      file,
+      scanSpec,
+      /*preserveFlatMapsInMemory=*/false,
+      /*lazyColumnIo=*/true);
+  VectorPtr result = BaseVector::create(asRowType(input->type()), 0, pool());
+  readers.rowReader->next(100, result);
+  ASSERT_EQ(result->size(), 3);
+  auto expected = makeRowVector({
+      makeFlatVector<int64_t>({20, 30, 40}),
+      makeMapVector<int32_t, int64_t>({
+          {{3, 300}},
+          {{4, 400}, {5, 500}},
+          {{6, 600}},
+      }),
+  });
+  velox::test::assertEqualVectors(expected, result);
 }
 
 INSTANTIATE_TEST_SUITE_P(

--- a/dwio/nimble/velox/selective/tests/SelectiveNimbleReaderTest.cpp
+++ b/dwio/nimble/velox/selective/tests/SelectiveNimbleReaderTest.cpp
@@ -31,7 +31,6 @@
 #include "dwio/nimble/velox/EncodingLayoutTree.h"
 #include "dwio/nimble/velox/SchemaSerialization.h"
 #include "dwio/nimble/velox/VeloxReader.h"
-#include "velox/common/base/tests/GTestUtils.h"
 #include "velox/common/caching/AsyncDataCache.h"
 #include "velox/common/caching/FileHandle.h"
 #include "velox/common/caching/FileIds.h"
@@ -140,7 +139,8 @@ class SelectiveNimbleReaderTest
       const std::string& file,
       const std::shared_ptr<common::ScanSpec>& scanSpec,
       bool stringDecoderZeroCopy,
-      bool preserveFlatMapsInMemory = false) {
+      bool preserveFlatMapsInMemory = false,
+      bool lazyColumnIo = false) {
     auto readFile = std::make_shared<InMemoryReadFile>(file);
     auto factory =
         dwio::common::getReaderFactory(dwio::common::FileFormat::NIMBLE);
@@ -193,6 +193,7 @@ class SelectiveNimbleReaderTest
     rowOptions.setRequestedType(type);
     rowOptions.setPreserveFlatMapsInMemory(preserveFlatMapsInMemory);
     rowOptions.setStringDecoderZeroCopy(stringDecoderZeroCopy);
+    rowOptions.setLazyColumnIo(lazyColumnIo);
     readers.rowReader = readers.reader->createRowReader(rowOptions);
     return readers;
   }
@@ -287,7 +288,7 @@ class SelectiveNimbleReaderTest
       int batchSize,
       ValidationFilter&& validationFilter,
       bool stringDecoderZeroCopy,
-      std::function<VectorPtr(bool)> makeExpectedData = nullptr) {
+      const std::function<VectorPtr(bool)>& makeExpectedData = nullptr) {
     for (bool hasNulls : {false, true}) {
       auto data = makeData(hasNulls);
       auto input = makeRowVector({data, data});
@@ -1384,6 +1385,220 @@ TEST_P(SelectiveNimbleReaderTest, estimatedRowSizeNoStats) {
   // The fallback may or may not return a value depending on whether
   // estimateMaterializedSize succeeds, but it should not crash.
   ASSERT_NO_THROW(readers.rowReader->estimatedRowSize());
+}
+
+// Lazy FlatMap child uses stream-based estimate, not RowSizeTracker
+// fallback.
+TEST_P(SelectiveNimbleReaderTest, estimatedRowSizeLazyColumn) {
+  const bool passStringBuffersFromDecoder = GetParam().stringDecoderZeroCopy;
+  constexpr int kSize = 200;
+
+  auto input = makeRowVector({
+      makeFlatVector<int64_t>(kSize, folly::identity),
+      makeMapVector<int32_t, int32_t>(
+          kSize,
+          [](auto) { return 10; }, // 10 keys per row
+          [](auto i) { return i; },
+          [](auto i) { return i * 100; }),
+  });
+
+  VeloxWriterOptions writerOptions;
+  writerOptions.flatMapColumns = {{"c1", {}}};
+  writerOptions.enableVectorizedStats = false;
+  auto fileContent = test::createNimbleFile(*rootPool(), input, writerOptions);
+
+  auto scanSpec = std::make_shared<common::ScanSpec>("root");
+  scanSpec->addAllChildFields(*input->type());
+  scanSpec->childByName("c0")->setFilter(
+      std::make_unique<common::BigintRange>(0, kSize, false));
+
+  auto readers = makeReaders(
+      input,
+      fileContent,
+      scanSpec,
+      passStringBuffersFromDecoder,
+      /*preserveFlatMapsInMemory=*/false,
+      /*lazyColumnIo=*/true);
+
+  auto estimatedRowSize = readers.rowReader->estimatedRowSize();
+  // With lazy columns, estimateMaterializedSize returns false and the
+  // fallback (1MB default or tracked row size) is used.
+  ASSERT_TRUE(estimatedRowSize.has_value());
+
+  validate(*input, *readers.rowReader, kSize, [](auto) { return true; });
+}
+
+// Map-key-only filter must not cause all children to be lazy.
+TEST_P(SelectiveNimbleReaderTest, estimatedRowSizeMapKeyFilterOnly) {
+  const bool passStringBuffersFromDecoder = GetParam().stringDecoderZeroCopy;
+  constexpr int kSize = 200;
+
+  auto input = makeRowVector({
+      makeMapVector<int32_t, int32_t>(
+          kSize,
+          [](auto) { return 5; },
+          [](auto i) { return i; },
+          [](auto i) { return i * 10; }),
+      makeMapVector<int32_t, int32_t>(
+          kSize,
+          [](auto) { return 3; },
+          [](auto i) { return i + 100; },
+          [](auto i) { return i * 20; }),
+  });
+
+  VeloxWriterOptions writerOptions;
+  writerOptions.flatMapColumns = {{"c0", {}}, {"c1", {}}};
+  writerOptions.enableVectorizedStats = false;
+  auto fileContent = test::createNimbleFile(*rootPool(), input, writerOptions);
+
+  auto scanSpec = std::make_shared<common::ScanSpec>("root");
+  scanSpec->addAllChildFields(*input->type());
+  scanSpec->childByName("c0")
+      ->childByName(common::ScanSpec::kMapKeysFieldName)
+      ->setFilter(std::make_unique<common::BigintRange>(0, 2, false));
+
+  auto readers = makeReaders(
+      input,
+      fileContent,
+      scanSpec,
+      passStringBuffersFromDecoder,
+      /*preserveFlatMapsInMemory=*/false,
+      /*lazyColumnIo=*/true);
+
+  auto estimatedRowSize = readers.rowReader->estimatedRowSize();
+  // Both FlatMap columns are lazy (map-key filters are invisible to
+  // hasFilter()). estimateMaterializedSize returns false (no eager children),
+  // falling through to RowSizeTracker.
+  ASSERT_TRUE(estimatedRowSize.has_value());
+  ASSERT_GT(*estimatedRowSize, 0);
+}
+
+// Lazy VARCHAR MAP column: estimate doesn't crash on string decoder,
+// laziness is preserved (data reads correctly after estimate).
+TEST_P(SelectiveNimbleReaderTest, estimatedRowSizeLazyStringColumn) {
+  const bool passStringBuffersFromDecoder = GetParam().stringDecoderZeroCopy;
+  constexpr int kSize = 200;
+
+  auto input = makeRowVector({
+      makeFlatVector<int64_t>(kSize, folly::identity),
+      makeMapVector<StringView, StringView>(
+          kSize,
+          [](auto) { return 5; },
+          [](auto i) {
+            return StringView::makeInline(fmt::format("key_{}", i));
+          },
+          [](auto i) {
+            return StringView::makeInline(fmt::format("val_{}", i));
+          }),
+  });
+
+  VeloxWriterOptions writerOptions;
+  writerOptions.flatMapColumns = {{"c1", {}}};
+  writerOptions.enableVectorizedStats = false;
+  auto fileContent = test::createNimbleFile(*rootPool(), input, writerOptions);
+
+  auto scanSpec = std::make_shared<common::ScanSpec>("root");
+  scanSpec->addAllChildFields(*input->type());
+  scanSpec->childByName("c0")->setFilter(
+      std::make_unique<common::BigintRange>(0, kSize, false));
+
+  auto readers = makeReaders(
+      input,
+      fileContent,
+      scanSpec,
+      passStringBuffersFromDecoder,
+      /*preserveFlatMapsInMemory=*/false,
+      /*lazyColumnIo=*/true);
+
+  auto estimatedRowSize = readers.rowReader->estimatedRowSize();
+  // With lazy columns, estimateMaterializedSize returns false and the
+  // fallback (1MB default or tracked row size) is used.
+  ASSERT_TRUE(estimatedRowSize.has_value());
+
+  validate(*input, *readers.rowReader, kSize, [](auto) { return true; });
+}
+
+// All columns lazy (no scalar projected): estimateMaterializedSize returns
+// false gracefully when rowCount=0, doesn't crash.
+TEST_P(SelectiveNimbleReaderTest, estimatedRowSizeAllLazy) {
+  const bool passStringBuffersFromDecoder = GetParam().stringDecoderZeroCopy;
+  constexpr int kSize = 200;
+
+  auto input = makeRowVector({
+      makeMapVector<int32_t, int32_t>(
+          kSize,
+          [](auto) { return 5; },
+          [](auto i) { return i; },
+          [](auto i) { return i * 10; }),
+  });
+
+  VeloxWriterOptions writerOptions;
+  writerOptions.flatMapColumns = {{"c0", {}}};
+  writerOptions.enableVectorizedStats = false;
+  auto fileContent = test::createNimbleFile(*rootPool(), input, writerOptions);
+
+  auto scanSpec = std::make_shared<common::ScanSpec>("root");
+  scanSpec->addAllChildFields(*input->type());
+
+  auto readers = makeReaders(
+      input,
+      fileContent,
+      scanSpec,
+      passStringBuffersFromDecoder,
+      /*preserveFlatMapsInMemory=*/false,
+      /*lazyColumnIo=*/true);
+
+  // Should not crash even though all columns are lazy and rowCount=0.
+  ASSERT_NO_THROW(readers.rowReader->estimatedRowSize());
+
+  validate(*input, *readers.rowReader, kSize, [](auto) { return true; });
+}
+
+// Lazy VARCHAR MAP with vectorized stats enabled and disabled.
+TEST_P(SelectiveNimbleReaderTest, estimatedRowSizeLazyStringWithStats) {
+  const bool passStringBuffersFromDecoder = GetParam().stringDecoderZeroCopy;
+  constexpr int kSize = 200;
+
+  auto input = makeRowVector({
+      makeFlatVector<int64_t>(kSize, folly::identity),
+      makeMapVector<StringView, StringView>(
+          kSize,
+          [](auto) { return 5; },
+          [](auto i) {
+            return StringView::makeInline(fmt::format("key_{}", i));
+          },
+          [](auto i) {
+            return StringView::makeInline(fmt::format("val_{}", i));
+          }),
+  });
+
+  for (bool enableStats : {false, true}) {
+    SCOPED_TRACE(fmt::format("enableVectorizedStats={}", enableStats));
+    VeloxWriterOptions writerOptions;
+    writerOptions.flatMapColumns = {{"c1", {}}};
+    writerOptions.enableVectorizedStats = enableStats;
+    auto fileContent =
+        test::createNimbleFile(*rootPool(), input, writerOptions);
+
+    auto scanSpec = std::make_shared<common::ScanSpec>("root");
+    scanSpec->addAllChildFields(*input->type());
+    scanSpec->childByName("c0")->setFilter(
+        std::make_unique<common::BigintRange>(0, kSize, false));
+
+    auto readers = makeReaders(
+        input,
+        fileContent,
+        scanSpec,
+        passStringBuffersFromDecoder,
+        /*preserveFlatMapsInMemory=*/false,
+        /*lazyColumnIo=*/true);
+
+    auto estimatedRowSize = readers.rowReader->estimatedRowSize();
+    ASSERT_TRUE(estimatedRowSize.has_value());
+    ASSERT_GT(*estimatedRowSize, 0);
+
+    validate(*input, *readers.rowReader, kSize, [](auto) { return true; });
+  }
 }
 
 TEST_P(SelectiveNimbleReaderTest, arrayWithOffsetsLastRunFilteredOut) {


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebookincubator/velox/pull/17350

Today, the Nimble selective reader loads all column streams upfront during stripe init — including columns wrapped in LazyVectors. The lazy contract only defers decoding; the underlying I/O is still eager. When a high-selectivity remaining filter eliminates most rows, the eagerly-loaded data for output-only columns is never decoded — but the I/O cost was already paid.

This diff extends laziness from decoding to I/O for all projected columns (scalar and complex) that have no pushdown filter, are not referenced by the remaining filter, and have no extraction transform. Qualifying columns share a single cloned BufferedInput per stripe, loaded only on first downstream access via TrackedColumnLoader. If the filter eliminates all rows in a stripe, the deferred columns' load() is never called — zero I/O for those columns in that stripe.

How it works:
- `computeLazyColumns()` runs once per split and precomputes the set of columns eligible for lazy I/O based on: no pushdown filter, not in remaining filter, no extraction transform, and projected in output.
- All lazy columns share a single cloned BufferedInput per stripe (via `createLazyInput()`), so their streams are coalesced into one WS read instead of N separate reads.
- Stream routing is explicit: `NimbleParams::setLazyTarget()` sets the clone as the target input for lazy columns. `enqueueStream()` routes to the clone or main input based on `lazyTarget_`. Nested children inherit the target via `makeChildParams()`.
- The shared clone is loaded via TrackedColumnLoader when any lazy column's LazyVector is first accessed. The idempotent `LazyInput::load()` guard ensures the clone is loaded at most once per stripe.
- Columns referenced by the remaining filter are excluded from lazy I/O to prevent loading the clone before the filter evaluates.
- Columns with extraction transforms are excluded since TransformColumnLoader does not call LazyInput::load().
- Batch size estimation: lazy columns cause estimateMaterializedSize() to return false (their ChunkedDecoders have no buffered data to peek at). This falls through to either file-level vectorized stats (preferred) or RowSizeTracker (learns actual row size after the first batch materializes lazy columns).

Gated behind the `lazy_column_io` session property (default off).

Reviewed By: HuamengJiang, xiaoxmeng

Differential Revision: D100277342


