### PR TITLE
feat(encoding): Add initial version of ALP encoding implementation for handling floats (#680)

### DIFF
--- a/dwio/nimble/common/Types.cpp
+++ b/dwio/nimble/common/Types.cpp
@@ -49,6 +49,8 @@ std::string toString(EncodingType encodingType) {
       return "Sentinel";
     case EncodingType::Prefix:
       return "Prefix";
+    case EncodingType::ALP:
+      return "ALP";
   }
   return fmt::format(
       "Unknown encoding type: {}", static_cast<int32_t>(encodingType));

--- a/dwio/nimble/common/Types.h
+++ b/dwio/nimble/common/Types.h
@@ -104,6 +104,10 @@ enum class EncodingType {
   // shared across consecutive entries to reduce storage. Supports seek
   // operations for efficient random access.
   Prefix = 11,
+  // Adaptive Lossless floating-Point encoding. Encodes float/double values
+  // with limited decimal precision as integers using a power-of-10 multiplier.
+  // Values that don't roundtrip exactly are stored as exceptions.
+  ALP = 12,
 };
 std::string toString(EncodingType encodingType);
 std::ostream& operator<<(std::ostream& out, EncodingType encodingType);

--- a/dwio/nimble/encodings/ALPEncoding.h
+++ b/dwio/nimble/encodings/ALPEncoding.h
@@ -1,0 +1,536 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <cmath>
+#include <cstring>
+#include <span>
+
+#include "dwio/nimble/common/Buffer.h"
+#include "dwio/nimble/common/EncodingPrimitives.h"
+#include "dwio/nimble/common/Types.h"
+#include "dwio/nimble/common/Vector.h"
+#include "dwio/nimble/encodings/Encoding.h"
+#include "dwio/nimble/encodings/EncodingFactory.h"
+#include "dwio/nimble/encodings/EncodingIdentifier.h"
+#include "dwio/nimble/encodings/EncodingSelection.h"
+
+// Adaptive Lossless floating-Point (ALP) encoding for float and double streams.
+//
+// Many real-world floating-point columns (prices, sensor readings, coordinates)
+// have limited decimal precision. ALP exploits this by multiplying each value
+// by 10^exponent, rounding to an integer, and storing the integers with a
+// compact sub-encoding (e.g. FixedBitWidth or Delta). On decode, each integer
+// is divided back by 10^exponent to recover the original float.
+//
+// Values that do not roundtrip exactly (non-finite values, or values whose
+// decimal precision exceeds the chosen exponent) are stored separately as
+// "exceptions" — their raw bit patterns are preserved in a side stream.
+// The encoding is rejected if exceptions exceed 5% of values.
+//
+// As an example, consider the data:
+//
+//   1.23  4.56  7.89  INF  0.01
+//
+// With exponent=2 (factor=100):
+//   Encoded integers:  123  456  789  0    1
+//   Exception mask:    F    F    F    T    F
+//   Exception values:               INF
+//
+// The encoded integers are stored via a nested sub-encoding. The exception
+// mask is stored as a bool sub-encoding. The exception values are stored as
+// raw physicalType values in a third sub-encoding.
+//
+// Three sub-streams are produced:
+//   [0] EncodedValues:    integer-encoded values (uint64_t)
+//   [1] ExceptionIndices: per-row bool mask (true = exception)
+//   [2] ExceptionValues:  raw float/double bits for exceptions
+//
+// When exceptionCount == 0, streams [1] and [2] are omitted entirely, and
+// decode takes a fast path that avoids the exception-patching loop.
+//
+// References:
+//   Afroozeh et al., "ALP: Adaptive Lossless floating-Point Compression"
+//   (SIGMOD 2023).
+
+namespace facebook::nimble {
+
+/// Internal helpers for ALP exponent search and value encoding.
+namespace alp {
+
+/// Reciprocal of the maximum allowed exception fraction. A value of 20 means
+/// at most 1/20 = 5% of rows may be exceptions before the encoding is rejected.
+constexpr uint64_t kMaxExceptionRate = 20;
+
+// Maximum exponent to try when searching for the best encoding factor.
+// For float: 7 decimal digits of precision.
+// For double: 15 decimal digits of precision.
+template <typename T>
+constexpr int maxExponent() {
+  if constexpr (std::is_same_v<T, float>) {
+    return 7;
+  } else {
+    return 15;
+  }
+}
+
+/// Integer type used to store encoded values. Both float and double use int64_t
+/// to avoid overflow when multiplying by large powers of 10.
+template <typename T>
+using EncodedIntType = int64_t;
+
+/// Precomputed powers of 10 for exponents 0..15.
+inline const double kPowersOf10[] = {
+    1e0,
+    1e1,
+    1e2,
+    1e3,
+    1e4,
+    1e5,
+    1e6,
+    1e7,
+    1e8,
+    1e9,
+    1e10,
+    1e11,
+    1e12,
+    1e13,
+    1e14,
+    1e15};
+
+/// Try encoding a single value with a given exponent. Multiplies by
+/// 10^exponent, rounds to integer, then divides back to verify a bit-exact
+/// roundtrip. Returns true if the value survives the roundtrip; on success,
+/// writes the integer result to `encoded`.
+template <typename T>
+bool tryEncode(T value, int exponent, EncodedIntType<T>& encoded) {
+  double factor = kPowersOf10[exponent];
+  double scaled = static_cast<double>(value) * factor;
+
+  // Check for overflow.
+  if (scaled > static_cast<double>(std::numeric_limits<int64_t>::max()) ||
+      scaled < static_cast<double>(std::numeric_limits<int64_t>::min())) {
+    return false;
+  }
+
+  encoded = static_cast<int64_t>(std::llround(scaled));
+  T decoded = static_cast<T>(static_cast<double>(encoded) / factor);
+  return decoded == value;
+}
+
+/// Sweep exponents 0..maxExponent<T>() and return the one that produces the
+/// fewest exceptions. Returns {bestExponent, exceptionCount}. Exits early if
+/// an exponent with zero exceptions is found.
+template <typename T>
+std::pair<int, uint32_t> findBestExponent(std::span<const T> values) {
+  int bestExponent = 0;
+  uint32_t bestExceptions = values.size();
+
+  for (int e = 0; e <= maxExponent<T>(); ++e) {
+    uint32_t exceptions = 0;
+    EncodedIntType<T> dummy;
+    for (const auto& v : values) {
+      if (!std::isfinite(v) || !tryEncode(v, e, dummy)) {
+        ++exceptions;
+      }
+    }
+    if (exceptions < bestExceptions) {
+      bestExceptions = exceptions;
+      bestExponent = e;
+      if (exceptions == 0) {
+        break;
+      }
+    }
+  }
+  return {bestExponent, bestExceptions};
+}
+
+} // namespace alp
+
+/// Serialized data layout:
+///   Encoding prefix (EncodingType::ALP, DataType, RowCount)
+///   1 byte:  exponent (power-of-10 multiplier index)
+///   4 bytes: exception count
+///   4 bytes: encoded values sub-encoding size (X)
+///   4 bytes: exception indices sub-encoding size (Y)
+///   X bytes: encoded integer values (nested sub-encoding)
+///   Y bytes: exception indices as bools (omitted when 0 exceptions)
+///   Z bytes: exception values as raw floats (omitted when 0 exceptions)
+template <typename T>
+class ALPEncoding final
+    : public TypedEncoding<T, typename TypeTraits<T>::physicalType> {
+  static_assert(
+      isFloatingPointType<T>(),
+      "ALPEncoding only supports float and double types.");
+
+ public:
+  using cppDataType = T;
+  using physicalType = typename TypeTraits<T>::physicalType;
+
+  /// Construct from serialized data. Parses the header fields and recursively
+  /// creates sub-encodings for the encoded values, exception indices, and
+  /// exception values streams.
+  ALPEncoding(
+      velox::memory::MemoryPool& memoryPool,
+      std::string_view data,
+      std::function<void*(uint32_t)> stringBufferFactory,
+      const Encoding::Options& options = {});
+
+  /// Reset all sub-encodings to the beginning of the stream.
+  void reset() final;
+
+  /// Skip rowCount values, advancing both the encoded-values stream and the
+  /// exception streams by the appropriate amounts.
+  void skip(uint32_t rowCount) final;
+
+  /// Decode rowCount values into buffer. Materializes encoded integers from
+  /// the sub-encoding, divides by 10^exponent, then patches in any exceptions.
+  void materialize(uint32_t rowCount, void* buffer) final;
+
+  /// Row-at-a-time decode for the selective reader path.
+  template <typename DecoderVisitor>
+  void readWithVisitor(DecoderVisitor& visitor, ReadWithVisitorParams& params);
+
+  /// Return a human-readable description of this encoding tree.
+  std::string debugString(int offset) const final;
+
+  /// Encode float/double values into the ALP serialized format. Finds the
+  /// best exponent via exhaustive search, encodes values as integers, and
+  /// stores exceptions separately. Throws NIMBLE_INCOMPATIBLE_ENCODING if
+  /// the exception rate exceeds 1/kMaxExceptionRate.
+  static std::string_view encode(
+      EncodingSelection<physicalType>& selection,
+      std::span<const physicalType> values,
+      Buffer& buffer,
+      const Encoding::Options& options = {});
+
+ private:
+  /// Power-of-10 index chosen during encoding (0..15).
+  int exponent_;
+
+  /// Total number of exception values in the stream.
+  uint32_t exceptionCount_;
+
+  /// Sub-encoding holding the integer-encoded values (uint64_t stream).
+  std::unique_ptr<Encoding> encodedValues_;
+
+  /// Sub-encoding holding a per-row bool mask (true = exception).
+  std::unique_ptr<Encoding> exceptionIndices_;
+
+  /// Sub-encoding holding the raw bit patterns of exception values.
+  std::unique_ptr<Encoding> exceptionValues_;
+
+  /// Temporary buffer for materialized encoded integers.
+  Vector<uint64_t> encodedBuffer_;
+
+  /// Temporary buffer for materialized exception mask.
+  Vector<bool> indicesBuffer_;
+
+  /// Temporary buffer for materialized exception values.
+  Vector<physicalType> exceptionsBuffer_;
+};
+
+//
+// End of public API. Implementation follows.
+//
+
+template <typename T>
+ALPEncoding<T>::ALPEncoding(
+    velox::memory::MemoryPool& memoryPool,
+    std::string_view data,
+    std::function<void*(uint32_t)> stringBufferFactory,
+    const Encoding::Options& options)
+    : TypedEncoding<T, physicalType>(memoryPool, data, options),
+      encodedBuffer_(&memoryPool),
+      indicesBuffer_(&memoryPool),
+      exceptionsBuffer_(&memoryPool) {
+  const EncodingFactory factory{options};
+  auto pos = data.data() + this->dataOffset();
+
+  exponent_ = static_cast<uint8_t>(encoding::readChar(pos));
+  exceptionCount_ = encoding::readUint32(pos);
+  const uint32_t encodedValuesSize = encoding::readUint32(pos);
+  const uint32_t exceptionIndicesSize = encoding::readUint32(pos);
+
+  encodedValues_ =
+      factory.create(memoryPool, {pos, encodedValuesSize}, stringBufferFactory);
+  pos += encodedValuesSize;
+
+  if (exceptionCount_ > 0) {
+    exceptionIndices_ = factory.create(
+        memoryPool, {pos, exceptionIndicesSize}, stringBufferFactory);
+    pos += exceptionIndicesSize;
+
+    exceptionValues_ = factory.create(
+        memoryPool,
+        {pos, static_cast<size_t>(data.end() - pos)},
+        std::move(stringBufferFactory));
+  }
+}
+
+template <typename T>
+void ALPEncoding<T>::reset() {
+  encodedValues_->reset();
+  if (exceptionCount_ > 0) {
+    exceptionIndices_->reset();
+    exceptionValues_->reset();
+  }
+}
+
+template <typename T>
+void ALPEncoding<T>::skip(uint32_t rowCount) {
+  if (rowCount == 0) {
+    return;
+  }
+
+  encodedValues_->skip(rowCount);
+
+  if (exceptionCount_ > 0) {
+    indicesBuffer_.resize(rowCount);
+    exceptionIndices_->materialize(rowCount, indicesBuffer_.data());
+    uint32_t exceptionsToSkip = 0;
+    for (uint32_t i = 0; i < rowCount; ++i) {
+      if (indicesBuffer_[i]) {
+        ++exceptionsToSkip;
+      }
+    }
+    if (exceptionsToSkip > 0) {
+      exceptionValues_->skip(exceptionsToSkip);
+    }
+  }
+}
+
+template <typename T>
+void ALPEncoding<T>::materialize(uint32_t rowCount, void* buffer) {
+  T* output = static_cast<T*>(buffer);
+  double factor = alp::kPowersOf10[exponent_];
+
+  // Read all encoded integer values (stored as uint64_t, interpreted as
+  // int64_t).
+  encodedBuffer_.resize(rowCount);
+  encodedValues_->materialize(rowCount, encodedBuffer_.data());
+
+  if (exceptionCount_ == 0) {
+    // Fast path: no exceptions.
+    for (uint32_t i = 0; i < rowCount; ++i) {
+      int64_t enc = static_cast<int64_t>(encodedBuffer_[i]);
+      output[i] = static_cast<T>(static_cast<double>(enc) / factor);
+    }
+    return;
+  }
+
+  // Read exception indices.
+  indicesBuffer_.resize(rowCount);
+  exceptionIndices_->materialize(rowCount, indicesBuffer_.data());
+
+  // Count and read exception values (stored as physicalType, reinterpreted as
+  // T).
+  uint32_t numExceptions = 0;
+  for (uint32_t i = 0; i < rowCount; ++i) {
+    if (indicesBuffer_[i]) {
+      ++numExceptions;
+    }
+  }
+  exceptionsBuffer_.resize(numExceptions);
+  if (numExceptions > 0) {
+    exceptionValues_->materialize(numExceptions, exceptionsBuffer_.data());
+  }
+
+  // Decode: use integer-decoded values, patching in exceptions.
+  uint32_t exceptionIdx = 0;
+  for (uint32_t i = 0; i < rowCount; ++i) {
+    if (indicesBuffer_[i]) {
+      // Reinterpret physicalType back to T.
+      T val;
+      std::memcpy(&val, &exceptionsBuffer_[exceptionIdx++], sizeof(T));
+      output[i] = val;
+    } else {
+      int64_t enc = static_cast<int64_t>(encodedBuffer_[i]);
+      output[i] = static_cast<T>(static_cast<double>(enc) / factor);
+    }
+  }
+}
+
+template <typename T>
+std::string_view ALPEncoding<T>::encode(
+    EncodingSelection<physicalType>& selection,
+    std::span<const physicalType> values,
+    Buffer& buffer,
+    const Encoding::Options& options) {
+  const bool useVarint = options.useVarintRowCount;
+  const uint32_t rowCount = static_cast<uint32_t>(values.size());
+
+  if (values.empty()) {
+    NIMBLE_INCOMPATIBLE_ENCODING("ALPEncoding can't be used with 0 rows.");
+  }
+
+  // Reinterpret physical values back to float/double for ALP analysis.
+  auto floatValues = std::span<const T>(
+      reinterpret_cast<const T*>(values.data()), values.size());
+
+  // Find the best exponent.
+  auto [exponent, exceptionCount] = alp::findBestExponent(floatValues);
+
+  // Reject if too many exceptions (> 1/kMaxExceptionRate of values).
+  if (exceptionCount > rowCount / alp::kMaxExceptionRate) {
+    NIMBLE_INCOMPATIBLE_ENCODING(
+        "ALP encoding has too many exceptions ({}/{}).",
+        exceptionCount,
+        rowCount);
+  }
+
+  // Encode all values as integers, collecting exceptions.
+  Vector<int64_t> encoded{&buffer.getMemoryPool()};
+  encoded.resize(rowCount);
+  Vector<bool> isException{&buffer.getMemoryPool()};
+  isException.resize(rowCount);
+  Vector<T> exceptionVals{&buffer.getMemoryPool()};
+  exceptionVals.reserve(exceptionCount);
+
+  for (uint32_t i = 0; i < rowCount; ++i) {
+    T v = floatValues[i];
+    alp::EncodedIntType<T> enc = 0;
+    if (std::isfinite(v) && alp::tryEncode(v, exponent, enc)) {
+      encoded[i] = enc;
+      isException[i] = false;
+    } else {
+      encoded[i] = 0; // Placeholder; exception value stored separately.
+      isException[i] = true;
+      exceptionVals.push_back(v);
+    }
+  }
+
+  // Encode the three sub-streams.
+  // Note: encodeNested<NestedT> requires NestedT to be its own physical type.
+  // So we use uint64_t for encoded integers (int64_t's physicalType) and
+  // physicalType for exception values (float's physicalType = uint32_t, etc.).
+  Buffer tempBuffer{buffer.getMemoryPool()};
+
+  const std::string_view serializedEncoded =
+      selection.template encodeNested<uint64_t>(
+          EncodingIdentifiers::ALP::EncodedValues,
+          std::span<const uint64_t>(
+              reinterpret_cast<const uint64_t*>(encoded.data()),
+              encoded.size()),
+          tempBuffer,
+          options);
+
+  std::string_view serializedIndices;
+  std::string_view serializedExceptions;
+
+  if (exceptionCount > 0) {
+    serializedIndices = selection.template encodeNested<bool>(
+        EncodingIdentifiers::ALP::ExceptionIndices,
+        isException,
+        tempBuffer,
+        options);
+
+    serializedExceptions = selection.template encodeNested<physicalType>(
+        EncodingIdentifiers::ALP::ExceptionValues,
+        std::span<const physicalType>(
+            reinterpret_cast<const physicalType*>(exceptionVals.data()),
+            exceptionVals.size()),
+        tempBuffer,
+        options);
+  }
+
+  // Layout: prefix + exponent(1) + exceptionCount(4) + encodedSize(4) +
+  //         indicesSize(4) + encoded + indices + exceptions
+  const uint32_t encodingSize =
+      Encoding::serializePrefixSize(rowCount, useVarint) + 1 + // exponent
+      4 + // exception count
+      4 + // encoded values size
+      4 + // exception indices size
+      static_cast<uint32_t>(serializedEncoded.size()) +
+      static_cast<uint32_t>(serializedIndices.size()) +
+      static_cast<uint32_t>(serializedExceptions.size());
+
+  char* reserved = buffer.reserve(encodingSize);
+  char* pos = reserved;
+  Encoding::serializePrefix(
+      EncodingType::ALP, TypeTraits<T>::dataType, rowCount, useVarint, pos);
+  encoding::writeChar(static_cast<char>(exponent), pos);
+  encoding::writeUint32(exceptionCount, pos);
+  encoding::writeUint32(static_cast<uint32_t>(serializedEncoded.size()), pos);
+  encoding::writeUint32(static_cast<uint32_t>(serializedIndices.size()), pos);
+  encoding::writeBytes(serializedEncoded, pos);
+  if (exceptionCount > 0) {
+    encoding::writeBytes(serializedIndices, pos);
+    encoding::writeBytes(serializedExceptions, pos);
+  }
+
+  NIMBLE_DCHECK_EQ(pos - reserved, encodingSize, "Encoding size mismatch.");
+  return {reserved, encodingSize};
+}
+
+template <typename T>
+template <typename DecoderVisitor>
+void ALPEncoding<T>::readWithVisitor(
+    DecoderVisitor& visitor,
+    ReadWithVisitorParams& params) {
+  detail::readWithVisitorSlow(
+      visitor,
+      params,
+      [&](auto toSkip) { skip(toSkip); },
+      [&] {
+        double factor = alp::kPowersOf10[exponent_];
+
+        uint64_t encRaw;
+        encodedValues_->materialize(1, &encRaw);
+
+        if (exceptionCount_ > 0) {
+          bool isExc;
+          exceptionIndices_->materialize(1, &isExc);
+          if (isExc) {
+            physicalType rawVal;
+            exceptionValues_->materialize(1, &rawVal);
+            T val;
+            std::memcpy(&val, &rawVal, sizeof(T));
+            return val;
+          }
+        }
+
+        int64_t enc = static_cast<int64_t>(encRaw);
+        return static_cast<T>(static_cast<double>(enc) / factor);
+      });
+}
+
+template <typename T>
+std::string ALPEncoding<T>::debugString(int offset) const {
+  std::string log = Encoding::debugString(offset);
+  log += fmt::format(
+      "\n{}exponent: {}, exceptions: {}",
+      std::string(offset + 2, ' '),
+      exponent_,
+      exceptionCount_);
+  log += fmt::format(
+      "\n{}encodedValues child:\n{}",
+      std::string(offset + 2, ' '),
+      encodedValues_->debugString(offset + 4));
+  if (exceptionCount_ > 0) {
+    log += fmt::format(
+        "\n{}exceptionIndices child:\n{}",
+        std::string(offset + 2, ' '),
+        exceptionIndices_->debugString(offset + 4));
+    log += fmt::format(
+        "\n{}exceptionValues child:\n{}",
+        std::string(offset + 2, ' '),
+        exceptionValues_->debugString(offset + 4));
+  }
+  return log;
+}
+
+} // namespace facebook::nimble

--- a/dwio/nimble/encodings/EncodingFactory.cpp
+++ b/dwio/nimble/encodings/EncodingFactory.cpp
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 #include "dwio/nimble/encodings/EncodingFactory.h"
+#include "dwio/nimble/encodings/ALPEncoding.h"
 #include "dwio/nimble/encodings/ConstantEncoding.h"
 #include "dwio/nimble/encodings/DeltaEncoding.h"
 #include "dwio/nimble/encodings/DictionaryEncoding.h"
@@ -243,6 +244,20 @@ std::unique_ptr<Encoding> EncodingFactory::create(
     case EncodingType::Delta: {
       RETURN_ENCODING_BY_NUMERIC_TYPE(DeltaEncoding, dataType);
     }
+    case EncodingType::ALP: {
+      switch (dataType) {
+        case DataType::Float:
+          return std::make_unique<ALPEncoding<float>>(
+              memoryPool, data, stringBufferFactory, options);
+        case DataType::Double:
+          return std::make_unique<ALPEncoding<double>>(
+              memoryPool, data, stringBufferFactory, options);
+        default:
+          NIMBLE_UNREACHABLE(
+              "ALPEncoding only supports Float and Double, got {}.",
+              toString(dataType));
+      }
+    }
     default: {
       NIMBLE_UNREACHABLE(
           "Trying to deserialize invalid EncodingType:{} -- garbage input?",
@@ -374,6 +389,14 @@ std::string_view EncodingFactory::encode(
         NIMBLE_INCOMPATIBLE_ENCODING(
             "Delta encoding should not be selected for non-numeric data type: {}.",
             toString(TypeTraits<T>::dataType));
+      }
+    }
+    case EncodingType::ALP: {
+      if constexpr (isFloatingPointType<T>()) {
+        return ALPEncoding<T>::encode(selection, castedValues, buffer, options);
+      } else {
+        NIMBLE_INCOMPATIBLE_ENCODING(
+            "ALP encoding only supports floating-point data types.");
       }
     }
     default: {

--- a/dwio/nimble/encodings/EncodingIdentifier.h
+++ b/dwio/nimble/encodings/EncodingIdentifier.h
@@ -57,6 +57,12 @@ struct EncodingIdentifiers {
     static constexpr NestedEncodingIdentifier Restatements = 1;
     static constexpr NestedEncodingIdentifier IsRestatements = 2;
   };
+
+  struct ALP {
+    static constexpr NestedEncodingIdentifier EncodedValues = 0;
+    static constexpr NestedEncodingIdentifier ExceptionIndices = 1;
+    static constexpr NestedEncodingIdentifier ExceptionValues = 2;
+  };
 };
 
 } // namespace facebook::nimble

--- a/dwio/nimble/encodings/EncodingLayout.cpp
+++ b/dwio/nimble/encodings/EncodingLayout.cpp
@@ -268,6 +268,31 @@ EncodingLayout EncodingLayoutCapture::capture(std::string_view encoding) {
               {pos, encoding.size() - (pos - encoding.data())}));
       break;
     }
+    case EncodingType::ALP: {
+      children.reserve(3);
+
+      const char* pos = encoding.data() + kEncodingPrefixSize;
+      // Skip exponent (1 byte).
+      pos += 1;
+      const uint32_t exceptionCount = encoding::readUint32(pos);
+      const uint32_t encodedValuesBytes = encoding::readUint32(pos);
+      const uint32_t exceptionIndicesBytes = encoding::readUint32(pos);
+
+      children.emplace_back(
+          EncodingLayoutCapture::capture({pos, encodedValuesBytes}));
+      pos += encodedValuesBytes;
+
+      if (exceptionCount > 0) {
+        children.emplace_back(
+            EncodingLayoutCapture::capture({pos, exceptionIndicesBytes}));
+        pos += exceptionIndicesBytes;
+
+        children.emplace_back(
+            EncodingLayoutCapture::capture(
+                {pos, encoding.size() - (pos - encoding.data())}));
+      }
+      break;
+    }
     case EncodingType::Nullable: {
       const char* pos = encoding.data() + kEncodingPrefixSize;
       const uint32_t dataBytes = encoding::readUint32(pos);

--- a/dwio/nimble/encodings/tests/ALPEncodingTest.cpp
+++ b/dwio/nimble/encodings/tests/ALPEncodingTest.cpp
@@ -1,0 +1,253 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "dwio/nimble/encodings/ALPEncoding.h"
+
+#include <cmath>
+#include <random>
+
+#include <gtest/gtest.h>
+#include "dwio/nimble/common/Buffer.h"
+#include "dwio/nimble/common/Vector.h"
+#include "dwio/nimble/encodings/EncodingFactory.h"
+#include "dwio/nimble/encodings/EncodingSelection.h"
+#include "dwio/nimble/encodings/EncodingSelectionPolicy.h"
+#include "velox/common/memory/Memory.h"
+
+using namespace facebook;
+
+namespace {
+
+// Test helper: creates an ALP encoding selection policy.
+template <typename T>
+class ALPTestPolicy : public nimble::EncodingSelectionPolicy<T> {
+  using physicalType = typename nimble::TypeTraits<T>::physicalType;
+
+ public:
+  nimble::EncodingSelectionResult select(
+      std::span<const physicalType>,
+      const nimble::Statistics<physicalType>&) override {
+    return {.encodingType = nimble::EncodingType::ALP};
+  }
+
+  nimble::EncodingSelectionResult selectNullable(
+      std::span<const physicalType>,
+      std::span<const bool>,
+      const nimble::Statistics<physicalType>&) override {
+    return {.encodingType = nimble::EncodingType::Nullable};
+  }
+
+  std::unique_ptr<nimble::EncodingSelectionPolicyBase> createImpl(
+      nimble::EncodingType,
+      nimble::NestedEncodingIdentifier,
+      nimble::DataType dataType) override {
+    // Create a trivial policy for nested streams.
+    return nimble::ManualEncodingSelectionPolicyFactory{
+        nimble::ManualEncodingSelectionPolicyFactory::defaultReadFactors(),
+        std::nullopt}
+        .createPolicy(dataType);
+  }
+};
+
+} // namespace
+
+template <typename T>
+class ALPEncodingTest : public ::testing::Test {
+ protected:
+  static void SetUpTestCase() {
+    velox::memory::MemoryManager::testingSetInstance({});
+  }
+
+  void SetUp() override {
+    rootPool_ = velox::memory::memoryManager()->addRootPool("ALPEncodingTest");
+    pool_ = rootPool_->addLeafChild("ALPEncodingTestLeaf");
+    buffer_ = std::make_unique<nimble::Buffer>(*pool_);
+  }
+
+  /// Encodes values with ALP, decodes, and verifies bit-exact roundtrip.
+  void testRoundtrip(const nimble::Vector<T>& values) {
+    using physicalType = typename nimble::TypeTraits<T>::physicalType;
+
+    auto physicalValues = std::span<const physicalType>(
+        reinterpret_cast<const physicalType*>(values.data()), values.size());
+
+    auto statistics = nimble::Statistics<physicalType>::create(physicalValues);
+    nimble::EncodingSelection<physicalType> selection{
+        {.encodingType = nimble::EncodingType::ALP},
+        std::move(statistics),
+        std::make_unique<ALPTestPolicy<T>>()};
+
+    auto encoded =
+        nimble::ALPEncoding<T>::encode(selection, physicalValues, *buffer_);
+
+    ASSERT_EQ(
+        static_cast<nimble::EncodingType>(encoded[0]),
+        nimble::EncodingType::ALP);
+
+    const nimble::EncodingFactory factory{{}};
+    auto encoding = factory.create(*pool_, encoded, nullptr);
+    ASSERT_EQ(encoding->rowCount(), values.size());
+
+    nimble::Vector<T> result{pool_.get()};
+    result.resize(values.size());
+    encoding->materialize(values.size(), result.data());
+
+    for (uint32_t i = 0; i < values.size(); ++i) {
+      if (std::isnan(values[i])) {
+        EXPECT_TRUE(std::isnan(result[i])) << "NaN mismatch at " << i;
+      } else {
+        EXPECT_EQ(
+            *reinterpret_cast<const physicalType*>(&values[i]),
+            *reinterpret_cast<const physicalType*>(&result[i]))
+            << "Bit mismatch at " << i << " (" << values[i] << " vs "
+            << result[i] << ")";
+      }
+    }
+  }
+
+  std::shared_ptr<velox::memory::MemoryPool> rootPool_;
+  std::shared_ptr<velox::memory::MemoryPool> pool_;
+  std::unique_ptr<nimble::Buffer> buffer_;
+};
+
+using FloatTypes = ::testing::Types<float, double>;
+TYPED_TEST_SUITE(ALPEncodingTest, FloatTypes);
+
+TYPED_TEST(ALPEncodingTest, LimitedPrecisionIntegers) {
+  nimble::Vector<TypeParam> values{this->pool_.get()};
+  for (int i = 0; i < 100; ++i) {
+    values.push_back(static_cast<TypeParam>(i));
+  }
+  this->testRoundtrip(values);
+}
+
+TYPED_TEST(ALPEncodingTest, TwoDecimalPlaces) {
+  nimble::Vector<TypeParam> values{this->pool_.get()};
+  for (int i = 0; i < 100; ++i) {
+    values.push_back(static_cast<TypeParam>(i) / static_cast<TypeParam>(100));
+  }
+  this->testRoundtrip(values);
+}
+
+TYPED_TEST(ALPEncodingTest, Prices) {
+  // Typical price values with 2 decimal places.
+  nimble::Vector<TypeParam> values{this->pool_.get()};
+  values.push_back(static_cast<TypeParam>(9.99));
+  values.push_back(static_cast<TypeParam>(19.99));
+  values.push_back(static_cast<TypeParam>(0.01));
+  values.push_back(static_cast<TypeParam>(100.00));
+  values.push_back(static_cast<TypeParam>(999.95));
+  values.push_back(static_cast<TypeParam>(0.50));
+  this->testRoundtrip(values);
+}
+
+TYPED_TEST(ALPEncodingTest, ConstantValues) {
+  nimble::Vector<TypeParam> values{this->pool_.get()};
+  for (int i = 0; i < 50; ++i) {
+    values.push_back(static_cast<TypeParam>(42.5));
+  }
+  this->testRoundtrip(values);
+}
+
+TYPED_TEST(ALPEncodingTest, WithFewExceptions) {
+  // Mostly limited precision, with a few special values.
+  nimble::Vector<TypeParam> values{this->pool_.get()};
+  for (int i = 0; i < 100; ++i) {
+    values.push_back(static_cast<TypeParam>(i) / static_cast<TypeParam>(10));
+  }
+  // Add a couple exceptions (infinity, NaN) -- under 5% threshold.
+  values[50] = std::numeric_limits<TypeParam>::infinity();
+  values[75] = std::numeric_limits<TypeParam>::quiet_NaN();
+  this->testRoundtrip(values);
+}
+
+TYPED_TEST(ALPEncodingTest, SkipAndMaterialize) {
+  using physicalType = typename nimble::TypeTraits<TypeParam>::physicalType;
+
+  nimble::Vector<TypeParam> values{this->pool_.get()};
+  for (int i = 0; i < 100; ++i) {
+    values.push_back(static_cast<TypeParam>(i) / static_cast<TypeParam>(10));
+  }
+
+  auto physicalValues = std::span<const physicalType>(
+      reinterpret_cast<const physicalType*>(values.data()), values.size());
+
+  auto statistics = nimble::Statistics<physicalType>::create(physicalValues);
+  nimble::EncodingSelection<physicalType> selection{
+      {.encodingType = nimble::EncodingType::ALP},
+      std::move(statistics),
+      std::make_unique<ALPTestPolicy<TypeParam>>()};
+
+  auto encoded = nimble::ALPEncoding<TypeParam>::encode(
+      selection, physicalValues, *this->buffer_);
+
+  const nimble::EncodingFactory factory{{}};
+  auto encoding = factory.create(*this->pool_, encoded, nullptr);
+
+  // Skip first 37, materialize remaining 63.
+  encoding->skip(37);
+  nimble::Vector<TypeParam> result{this->pool_.get()};
+  result.resize(63);
+  encoding->materialize(63, result.data());
+
+  for (uint32_t i = 0; i < 63; ++i) {
+    EXPECT_EQ(
+        *reinterpret_cast<const physicalType*>(&values[37 + i]),
+        *reinterpret_cast<const physicalType*>(&result[i]))
+        << "Mismatch at index " << (37 + i);
+  }
+}
+
+TYPED_TEST(ALPEncodingTest, ResetAndReread) {
+  using physicalType = typename nimble::TypeTraits<TypeParam>::physicalType;
+
+  nimble::Vector<TypeParam> values{this->pool_.get()};
+  for (int i = 0; i < 50; ++i) {
+    values.push_back(static_cast<TypeParam>(i) * static_cast<TypeParam>(0.25));
+  }
+
+  auto physicalValues = std::span<const physicalType>(
+      reinterpret_cast<const physicalType*>(values.data()), values.size());
+
+  auto statistics = nimble::Statistics<physicalType>::create(physicalValues);
+  nimble::EncodingSelection<physicalType> selection{
+      {.encodingType = nimble::EncodingType::ALP},
+      std::move(statistics),
+      std::make_unique<ALPTestPolicy<TypeParam>>()};
+
+  auto encoded = nimble::ALPEncoding<TypeParam>::encode(
+      selection, physicalValues, *this->buffer_);
+
+  const nimble::EncodingFactory factory{{}};
+  auto encoding = factory.create(*this->pool_, encoded, nullptr);
+
+  // Read first 20.
+  nimble::Vector<TypeParam> partial{this->pool_.get()};
+  partial.resize(20);
+  encoding->materialize(20, partial.data());
+
+  // Reset and re-read all.
+  encoding->reset();
+  nimble::Vector<TypeParam> result{this->pool_.get()};
+  result.resize(50);
+  encoding->materialize(50, result.data());
+
+  for (uint32_t i = 0; i < 50; ++i) {
+    EXPECT_EQ(
+        *reinterpret_cast<const physicalType*>(&values[i]),
+        *reinterpret_cast<const physicalType*>(&result[i]))
+        << "Mismatch at index " << i;
+  }
+}

--- a/dwio/nimble/tools/EncodingUtilities.cpp
+++ b/dwio/nimble/tools/EncodingUtilities.cpp
@@ -49,6 +49,7 @@ void extractCompressionType(
     case EncodingType::Constant:
     case EncodingType::MainlyConstant:
     case EncodingType::Prefix:
+    case EncodingType::ALP:
       break;
   }
 }
@@ -180,6 +181,32 @@ void traverseEncodings(
           2,
           "IsRestatements",
           visitor);
+      break;
+    }
+    case EncodingType::ALP: {
+      const char* pos = stream.data() + kEncodingPrefixSize;
+      pos += 1; // exponent
+      const uint32_t exceptionCount = encoding::readUint32(pos);
+      const uint32_t encodedValuesBytes = encoding::readUint32(pos);
+      const uint32_t exceptionIndicesBytes = encoding::readUint32(pos);
+      traverseEncodings(
+          {pos, encodedValuesBytes}, level + 1, 0, "EncodedValues", visitor);
+      pos += encodedValuesBytes;
+      if (exceptionCount > 0) {
+        traverseEncodings(
+            {pos, exceptionIndicesBytes},
+            level + 1,
+            1,
+            "ExceptionIndices",
+            visitor);
+        pos += exceptionIndicesBytes;
+        traverseEncodings(
+            {pos, stream.size() - (pos - stream.data())},
+            level + 1,
+            2,
+            "ExceptionValues",
+            visitor);
+      }
       break;
     }
     case EncodingType::Nullable: {


### PR DESCRIPTION
Summary:

Add the ALP (Adaptive Lossless floating-Point) encoding implementation and tests. This encoding was registered in the previous commit; this commit adds the actual implementation 

We need this for floating point values for handling tensors

files:

- ALPEncoding.h: Full implementation with encode/decode, skip, reset, readWithVisitor
- EncodingIdentifier.h: Nested encoding identifiers for ALP sub-streams (EncodedValues, ExceptionIndices, ExceptionValues)
- ALPEncodingTest.cpp: 7 test cases x 2 types (float, double) covering limited-precision integers, decimal values, prices, constants, exceptions, skip+materialize, and reset+reread



Will

Differential Revision: D100475601


