### PR TITLE
fix(exception): Remove folly/debugging/symbolizer/Symbolizer.h from NimbleException.h and Exceptions.h

### DIFF
--- a/dwio/nimble/common/Exceptions.h
+++ b/dwio/nimble/common/Exceptions.h
@@ -22,7 +22,6 @@
 #include "dwio/nimble/common/NimbleException.h"
 #include "folly/FixedString.h"
 #include "folly/Preprocessor.h"
-#include "folly/debugging/symbolizer/Symbolizer.h"
 
 // Standard errors used throughout the codebase.
 

--- a/dwio/nimble/common/NimbleException.cpp
+++ b/dwio/nimble/common/NimbleException.cpp
@@ -17,6 +17,7 @@
 #include "dwio/nimble/common/NimbleException.h"
 
 #include <folly/Conv.h>
+#include <folly/debugging/symbolizer/Symbolizer.h>
 #include <glog/logging.h>
 
 namespace facebook::nimble {

--- a/dwio/nimble/common/NimbleException.h
+++ b/dwio/nimble/common/NimbleException.h
@@ -16,7 +16,6 @@
 #pragma once
 
 #include <folly/FixedString.h>
-#include <folly/debugging/symbolizer/Symbolizer.h>
 #include <folly/synchronization/CallOnce.h>
 #include <exception>
 #include <string>


### PR DESCRIPTION
Summary:
Move the heavy folly/debugging/symbolizer/Symbolizer.h include from the headers to NimbleException.cpp, where the symbolizer is actually used. The header only stores raw uintptr_t frames — no symbolizer types are needed in the interface.

This removes ~5-8M of preprocessed includes from every file that includes Exceptions.h (78 files across the entire nimble codebase), as the symbolizer pulls in ELF parsing, DWARF debug info, libunwind bindings, and signal handling infrastructure.

BUCK: Move //folly/debugging/symbolizer:symbolizer from exported_deps to deps in NimbleException target.

Differential Revision: D102443939


