### PR TITLE
fix: Change NIMBLE_DCHECK to NIMBLE_CHECK in LookupResult::operator[]

### DIFF
--- a/dwio/nimble/index/IndexLookup.h
+++ b/dwio/nimble/index/IndexLookup.h
@@ -174,9 +174,9 @@ class IndexLookup {
     }
 
     folly::Range<const RowRange*> operator[](uint32_t idx) const {
-      NIMBLE_DCHECK_LT(idx, size());
-      NIMBLE_DCHECK_LE(resultOffsets_[idx], resultOffsets_[idx + 1]);
-      NIMBLE_DCHECK_LE(resultOffsets_[idx + 1], rowRanges_.size());
+      NIMBLE_CHECK_LT(idx, size());
+      NIMBLE_CHECK_LE(resultOffsets_[idx], resultOffsets_[idx + 1]);
+      NIMBLE_CHECK_LE(resultOffsets_[idx + 1], rowRanges_.size());
       return {
           rowRanges_.data() + resultOffsets_[idx],
           rowRanges_.data() + resultOffsets_[idx + 1]};


### PR DESCRIPTION
Summary:
The bounds and monotonicity checks in `LookupResult::operator[]` used `NIMBLE_DCHECK` variants, which are compiled out in optimized builds. This caused `IndexLookupTest.allKeysEmpty` and `IndexLookupTest.nonMonotonicOffsets` to fail in opt mode because out-of-bounds and non-monotonic accesses no longer threw exceptions as the tests expected.

Changed all three assertions from `NIMBLE_DCHECK_LT`/`NIMBLE_DCHECK_LE` to `NIMBLE_CHECK_LT`/`NIMBLE_CHECK_LE` so invariants are enforced in all build modes.

Differential Revision: D103459518


