### PR TITLE
feat(nimble): Plumb FileIoContext through TabletReader direct preadv calls (#684)

### DIFF
--- a/dwio/nimble/common/tests/TestUtils.h
+++ b/dwio/nimble/common/tests/TestUtils.h
@@ -426,6 +426,7 @@ class TrackingReadFile : public velox::ReadFile {
       void* buf,
       const velox::FileIoContext& context = {}) const override {
     updateMaxReadOffset(offset + length);
+    incrementIoCount(context, "trackingReadFile.pread");
     maybeThrow();
     maybeDelay();
     return delegate_->pread(offset, length, buf, context);
@@ -436,6 +437,7 @@ class TrackingReadFile : public velox::ReadFile {
       uint64_t length,
       const velox::FileIoContext& context = {}) const override {
     updateMaxReadOffset(offset + length);
+    incrementIoCount(context, "trackingReadFile.pread");
     maybeThrow();
     maybeDelay();
     return delegate_->pread(offset, length, context);
@@ -451,6 +453,7 @@ class TrackingReadFile : public velox::ReadFile {
     }
     updateMaxReadOffset(offset + totalLength);
     ioGroups_.wlock()->push_back({offset, totalLength});
+    incrementIoCount(context, "trackingReadFile.preadv");
     maybeThrow();
     maybeDelay();
     return delegate_->preadv(offset, buffers, context);
@@ -463,6 +466,7 @@ class TrackingReadFile : public velox::ReadFile {
     for (const auto& region : regions) {
       updateMaxReadOffset(region.offset + region.length);
     }
+    incrementIoCount(context, "trackingReadFile.preadv");
     maybeThrow();
     maybeDelay();
     return delegate_->preadv(regions, iobufs, context);
@@ -515,6 +519,14 @@ class TrackingReadFile : public velox::ReadFile {
   }
 
  private:
+  static void incrementIoCount(
+      const velox::FileIoContext& context,
+      const std::string& name) {
+    if (context.ioStats != nullptr) {
+      context.ioStats->addCounter(name, velox::RuntimeCounter(1));
+    }
+  }
+
   void updateMaxReadOffset(uint64_t endOffset) const {
     auto current = maxReadOffset_.load(std::memory_order_relaxed);
     while (endOffset > current &&

--- a/dwio/nimble/index/IndexLookup.cpp
+++ b/dwio/nimble/index/IndexLookup.cpp
@@ -52,7 +52,8 @@ std::shared_ptr<MetadataInput> createIndexMetadataInput(
       .maxCoalesceBytes = options.ioOptions->maxCoalesceBytes(),
       .executor = options.ioOptions->ioExecutor().get(),
       .fileHandle = options.fileHandle,
-      .cache = options.cache};
+      .cache = options.cache,
+      .fileIoContext = options.ioOptions->fileIoContext()};
   return MetadataInput::create(options.file.get(), metadataOptions);
 }
 
@@ -60,6 +61,10 @@ std::shared_ptr<velox::dwio::common::BufferedInput> createIndexDataInput(
     const IndexLookup::Options& options) {
   auto readFile = options.file;
   auto indexIoStats = options.ioOptions->indexIoStats();
+  const auto* fileIoContext = options.ioOptions->fileIoContext();
+  auto fileOpts = fileIoContext != nullptr
+      ? fileIoContext->fileOpts
+      : folly::F14FastMap<std::string, std::string>{};
   if (options.cache != nullptr) {
     return std::make_shared<velox::dwio::common::CachedBufferedInput>(
         std::move(readFile),
@@ -71,7 +76,8 @@ std::shared_ptr<velox::dwio::common::BufferedInput> createIndexDataInput(
         std::move(indexIoStats),
         nullptr,
         nullptr,
-        *options.ioOptions);
+        *options.ioOptions,
+        std::move(fileOpts));
   }
   return std::make_shared<velox::dwio::common::DirectBufferedInput>(
       std::move(readFile),
@@ -82,7 +88,8 @@ std::shared_ptr<velox::dwio::common::BufferedInput> createIndexDataInput(
       std::move(indexIoStats),
       nullptr,
       nullptr,
-      *options.ioOptions);
+      *options.ioOptions,
+      std::move(fileOpts));
 }
 
 std::string toString(IndexType indexType) {

--- a/dwio/nimble/tablet/MetadataInput.cpp
+++ b/dwio/nimble/tablet/MetadataInput.cpp
@@ -54,7 +54,8 @@ MetadataInput::MetadataInput(velox::ReadFile* file, const Options& options)
       maxCoalesceDistance_{options.maxCoalesceDistance},
       maxCoalesceBytes_{options.maxCoalesceBytes},
       executor_{options.executor},
-      ioStats_{options.ioStats} {
+      ioStats_{options.ioStats},
+      fileIoContext_{options.fileIoContext} {
   NIMBLE_CHECK_NOT_NULL(pool_);
   NIMBLE_CHECK_NOT_NULL(ioStats_.get());
 }
@@ -77,7 +78,11 @@ void MetadataInput::readRaw(uint64_t offset, uint64_t size, void* dest) {
   uint64_t storageReadNs{0};
   {
     velox::NanosecondTimer timer{&storageReadNs};
-    file_->pread(offset, size, static_cast<char*>(dest));
+    if (fileIoContext_ != nullptr) {
+      file_->pread(offset, size, static_cast<char*>(dest), *fileIoContext_);
+    } else {
+      file_->pread(offset, size, static_cast<char*>(dest));
+    }
   }
   const uint64_t storageReadUs = storageReadNs / 1'000;
   ioStats_->queryThreadIoLatencyUs().increment(storageReadUs);
@@ -218,7 +223,11 @@ void MetadataInput::executeIoGroups(std::vector<IoGroup>& ioGroups) {
           uint64_t storageReadNs{0};
           {
             velox::NanosecondTimer ioTimer(&storageReadNs);
-            file_->preadv(group.offset, group.ranges);
+            if (fileIoContext_ != nullptr) {
+              file_->preadv(group.offset, group.ranges, *fileIoContext_);
+            } else {
+              file_->preadv(group.offset, group.ranges);
+            }
           }
           ioStats_->storageReadLatencyUs().increment(storageReadNs / 1'000);
           ioStats_->incTotalScanTimeNs(storageReadNs);

--- a/dwio/nimble/tablet/MetadataInput.h
+++ b/dwio/nimble/tablet/MetadataInput.h
@@ -59,8 +59,12 @@ class MetadataInput {
     // When both fileHandle and cache are set, creates CachedMetadataInput.
     const velox::FileHandle* fileHandle{nullptr};
     velox::cache::AsyncDataCache* cache{nullptr};
+    // Borrowed, caller-owned context forwarded to direct ReadFile calls. May
+    // be null. The pointee must outlive the MetadataInput.
+    const velox::FileIoContext* fileIoContext{nullptr};
   };
 
+  /// Creates a MetadataInput (direct or cached based on Options).
   static std::unique_ptr<MetadataInput> create(
       velox::ReadFile* file,
       const Options& options);
@@ -85,7 +89,7 @@ class MetadataInput {
 
   /// Raw tracked read for bootstrap IO (e.g. speculative footer read)
   /// before section boundaries are known. Records bytes and latency into
-  /// the same ioStats used by load().
+  /// the same ioStats used by load(). Uses the FileIoContext from Options.
   void readRaw(uint64_t offset, uint64_t size, void* dest);
 
   /// Caches data at the given offset from multiple contiguous ranges.
@@ -190,6 +194,9 @@ class MetadataInput {
   const int64_t maxCoalesceBytes_;
   folly::Executor* const executor_;
   const std::shared_ptr<velox::io::IoStatistics> ioStats_;
+  // Borrowed, caller-owned context forwarded to direct ReadFile calls. May be
+  // null; consumers fall back to a default context.
+  const velox::FileIoContext* const fileIoContext_;
 };
 
 /// Direct metadata loading with IO coalescing, no caching.

--- a/dwio/nimble/tablet/TabletReader.cpp
+++ b/dwio/nimble/tablet/TabletReader.cpp
@@ -20,6 +20,7 @@
 #include "dwio/nimble/tablet/ChunkIndexGenerated.h"
 #include "dwio/nimble/tablet/Constants.h"
 #include "dwio/nimble/tablet/FooterGenerated.h"
+#include "velox/dwio/common/BufferedInput.h"
 #include "velox/dwio/common/SeekableInputStream.h"
 
 #include "folly/io/Cursor.h"
@@ -66,11 +67,11 @@ void ensureBuffer(
     buffer = velox::AlignedBuffer::allocateExact<char>(size, pool);
   }
 }
-
 } // namespace
 
 TabletReader::Options TabletReader::configureOptions(
-    const velox::dwio::common::ReaderOptions& options) {
+    const velox::dwio::common::ReaderOptions& options,
+    const velox::dwio::common::BufferedInput* input) {
   Options tabletOptions;
   tabletOptions.maxFooterIoBytes = options.footerSpeculativeIoSize();
   tabletOptions.preloadOptionalSections = {
@@ -91,6 +92,10 @@ TabletReader::Options TabletReader::configureOptions(
   tabletOptions.fileHandle = options.fileHandle();
   tabletOptions.cache = options.cache();
   tabletOptions.ioOptions = options;
+  if (input != nullptr) {
+    tabletOptions.ioOptions->setFileIoContext(
+        &input->getInputStream()->fileIoContext());
+  }
   return tabletOptions;
 }
 
@@ -258,7 +263,8 @@ TabletReader::TabletReader(
             .ioStats = ioOptions_.metadataIoStats(),
             .maxCoalesceDistance = ioOptions_.maxCoalesceDistance(),
             .maxCoalesceBytes = ioOptions_.maxCoalesceBytes(),
-            .executor = ioOptions_.ioExecutor().get()};
+            .executor = ioOptions_.ioExecutor().get(),
+            .fileIoContext = ioOptions_.fileIoContext()};
         // cacheMetadata takes effect only when fileHandle and cache are
         // provided.
         if (options.cacheMetadata && options.fileHandle != nullptr) {
@@ -990,7 +996,13 @@ std::vector<std::unique_ptr<StreamLoader>> TabletReader::load(
   }
   if (!uniqueRegions.empty()) {
     std::vector<folly::IOBuf> iobufs(uniqueRegions.size());
-    file_->preadv(uniqueRegions, {iobufs.data(), iobufs.size()});
+    const auto* fileIoContext = ioOptions_.fileIoContext();
+    if (fileIoContext != nullptr) {
+      file_->preadv(
+          uniqueRegions, {iobufs.data(), iobufs.size()}, *fileIoContext);
+    } else {
+      file_->preadv(uniqueRegions, {iobufs.data(), iobufs.size()});
+    }
     NIMBLE_DCHECK_EQ(
         iobufs.size(), uniqueRegions.size(), "Buffer size mismatch.");
     for (uint32_t i = 0; i < uniqueRegions.size(); ++i) {

--- a/dwio/nimble/tablet/TabletReader.h
+++ b/dwio/nimble/tablet/TabletReader.h
@@ -54,6 +54,10 @@
 /// encoded stream, and in the worst case (totally random data) the encoded data
 /// will be the same size as the raw data.
 
+namespace facebook::velox::dwio::common {
+class BufferedInput;
+}
+
 namespace facebook::nimble {
 
 namespace test {
@@ -232,7 +236,8 @@ class TabletReader {
 
   /// Configures TabletReader::Options from Velox ReaderOptions.
   static Options configureOptions(
-      const velox::dwio::common::ReaderOptions& options);
+      const velox::dwio::common::ReaderOptions& options,
+      const velox::dwio::common::BufferedInput* input = nullptr);
 
   /// Returns a collection of stream loaders for the given stripe. The stream
   /// loaders are returned in the same order as the input stream identifiers

--- a/dwio/nimble/tablet/tests/MetadataInputTest.cpp
+++ b/dwio/nimble/tablet/tests/MetadataInputTest.cpp
@@ -257,6 +257,39 @@ TEST_F(DirectMetadataInputTest, duplicateSectionsThrow) {
       "Metadata input must not contain duplicate regions");
 }
 
+TEST_F(DirectMetadataInputTest, passesFileIoContextToReadFile) {
+  const std::string data0 = "first-section";
+  const std::string data1 = "second-section";
+
+  nimble::MetadataSection section0{
+      0,
+      static_cast<uint32_t>(data0.size()),
+      nimble::CompressionType::Uncompressed,
+      static_cast<uint32_t>(data0.size())};
+  nimble::MetadataSection section1{
+      32,
+      static_cast<uint32_t>(data1.size()),
+      nimble::CompressionType::Uncompressed,
+      static_cast<uint32_t>(data1.size())};
+
+  const auto fileContent =
+      buildFileContent({section0, section1}, {data0, data1});
+  auto readFile = std::make_shared<nimble::testing::TrackingReadFile>(
+      std::make_shared<velox::InMemoryReadFile>(fileContent));
+  velox::IoStats fileIoStats;
+  velox::FileIoContext fileIoContext{&fileIoStats};
+
+  auto options = makeMetadataInputOptions();
+  options.fileIoContext = &fileIoContext;
+  auto input = nimble::MetadataInput::create(readFile.get(), options);
+
+  auto results = input->load(std::array{section0, section1});
+
+  EXPECT_EQ(results[0]->content(), data0);
+  EXPECT_EQ(results[1]->content(), data1);
+  EXPECT_EQ(fileIoStats.stats().at("trackingReadFile.preadv").sum, 1);
+}
+
 TEST_F(DirectMetadataInputTest, repeatedLoad) {
   const std::string data = "repeat-test";
   nimble::MetadataSection section{

--- a/dwio/nimble/tablet/tests/TabletTest.cpp
+++ b/dwio/nimble/tablet/tests/TabletTest.cpp
@@ -1271,6 +1271,35 @@ TEST_P(TabletTest, duplicateStreamStats) {
   EXPECT_EQ(tabletWriter->stats().duplicateStreamBytes, data.size());
 }
 
+TEST_P(TabletTest, passesFileIoContextToFooterReads) {
+  std::string file;
+  velox::InMemoryWriteFile writeFile(&file);
+  auto tabletWriter = nimble::TabletWriter::create(&writeFile, *pool_, {});
+  tabletWriter->writeStripe(
+      1,
+      {nimble::Stream{
+          .offset = 0,
+          .chunks = {{.rowCount = 1, .content = {std::string_view{"abc"}}}},
+      }});
+  tabletWriter->close();
+  writeFile.close();
+
+  auto readFile = std::make_shared<nimble::testing::TrackingReadFile>(
+      std::make_shared<velox::InMemoryReadFile>(file));
+  velox::IoStats fileIoStats;
+  velox::FileIoContext fileIoContext{&fileIoStats};
+  nimble::TabletReader::Options options;
+  options.ioOptions.emplace(pool_.get())
+      .setMetadataIoStats(std::make_shared<velox::io::IoStatistics>());
+  options.ioOptions->setFileIoContext(&fileIoContext);
+  options.maxFooterIoBytes = 0;
+
+  auto tablet = nimble::TabletReader::create(readFile, pool_.get(), options);
+
+  EXPECT_EQ(tablet->tabletRowCount(), 1);
+  EXPECT_GT(fileIoStats.stats().at("trackingReadFile.pread").sum, 0);
+}
+
 TEST_P(TabletTest, chunkContentSize) {
   nimble::Chunk chunk;
   EXPECT_EQ(chunk.contentSize(), 0);

--- a/dwio/nimble/velox/selective/ReaderBase.cpp
+++ b/dwio/nimble/velox/selective/ReaderBase.cpp
@@ -84,7 +84,7 @@ std::shared_ptr<ReaderBase> ReaderBase::create(
     const velox::dwio::common::ReaderOptions& options) {
   input = maybePreloadInput(std::move(input), options);
 
-  auto tabletOptions = TabletReader::configureOptions(options);
+  auto tabletOptions = TabletReader::configureOptions(options, input.get());
 
   auto tablet = TabletReader::create(
       input->getReadFile(), &options.memoryPool(), tabletOptions);


### PR DESCRIPTION
Summary:

TabletReader performs file IO outside the normal BufferedInput read path: postscript/footer bootstrap reads, coalesced metadata loads through MetadataInput, index metadata/data reads, and stripe data loads. Those reads can reach ReadFile implementations such as WSReadFile, which record filesystem runtime stats from FileIoContext::ioStats. When TabletReader and its helper readers use the default FileIoContext{}, those filesystem stats are dropped even though the original BufferedInput has the operator's context.

This change carries the BufferedInput's FileIoContext through the current TabletReader architecture:

- `TabletReader::configureOptions(options, bufferedInput)` extracts `bufferedInput->getInputStream()->fileIoContext()` when a BufferedInput is supplied.
- `TabletReader::Options` and `TabletReader` store that FileIoContext.
- Footer/postscript `rawRead(...)` calls pass the context to `ReadFile::pread(...)`.
- `MetadataInput` stores the context and forwards it to coalesced `ReadFile::preadv(...)` calls.
- `IndexLookup::Options` carries the same context, and index metadata/data input construction uses it for direct metadata reads and file read options.
- Stripe-data loads continue to pass the same context to direct `file_->preadv(...)` calls.
- The selective Nimble reader path (`ReaderBase::create`) now passes its BufferedInput into `configureOptions` so the context is wired up automatically.
- The `TrackingReadFile` test helper now increments `trackingReadFile.pread`/`trackingReadFile.preadv` counters on the supplied `FileIoContext::ioStats`, enabling the new tests to assert that the context reaches the underlying ReadFile.

Depends on the prior commit (feat(dwio): Add public fileIoContext() accessor to ReadFileInputStream) for exposing the FileIoContext stored inside ReadFileInputStream.

Compatibility:
- Source-compatible: all new parameters default to `FileIoContext{}`/nullptr where existing callers do not have a BufferedInput.
- Behavior-compatible for standard ReadFile implementations that ignore FileIoContext::ioStats.
- Implementations that consume FileIoContext::ioStats, such as WSReadFile, now see the caller's filesystem stats context for TabletReader metadata and data reads.

Differential Revision: D103114180


