### PR TITLE
feat: Add separate data and metadata IoStatistics to ReaderOptions (#685)

### DIFF
--- a/dwio/nimble/tablet/tests/TabletTest.cpp
+++ b/dwio/nimble/tablet/tests/TabletTest.cpp
@@ -45,6 +45,7 @@
 
 #include "velox/common/caching/AsyncDataCache.h"
 #include "velox/common/caching/FileIds.h"
+#include "velox/common/io/IoStatistics.h"
 #include "velox/common/memory/MallocAllocator.h"
 #include "velox/common/memory/Memory.h"
 #include "velox/dwio/common/BufferedInput.h"
@@ -158,7 +159,6 @@ class TabletTest : public ::testing::TestWithParam<BufferedInputMode> {
 
   void SetUp() override {
     executor_ = std::make_unique<folly::CPUThreadPoolExecutor>(2);
-    ioStatistics_ = std::make_shared<velox::dwio::common::IoStatistics>();
   }
 
   void TearDown() override {
@@ -181,7 +181,8 @@ class TabletTest : public ::testing::TestWithParam<BufferedInputMode> {
     fileId_ = std::make_unique<velox::StringIdLease>(ids, "testFile");
     groupId_ = std::make_unique<velox::StringIdLease>(ids, "testGroup");
 
-    velox::io::ReaderOptions readerOptions(pool_.get());
+    velox::io::ReaderOptions readerOptions(
+        pool_.get(), dataIoStats_.get(), metadataIoStats_.get());
 
     switch (mode) {
       case BufferedInputMode::kNone:
@@ -202,7 +203,7 @@ class TabletTest : public ::testing::TestWithParam<BufferedInputMode> {
                 std::move(*fileId_),
                 tracker_,
                 std::move(*groupId_),
-                ioStatistics_,
+                dataIoStats_,
                 nullptr,
                 executor_.get(),
                 readerOptions);
@@ -227,7 +228,7 @@ class TabletTest : public ::testing::TestWithParam<BufferedInputMode> {
                 cache_.get(),
                 tracker_,
                 std::move(*groupId_),
-                ioStatistics_,
+                dataIoStats_,
                 nullptr,
                 executor_.get(),
                 readerOptions);
@@ -259,9 +260,13 @@ class TabletTest : public ::testing::TestWithParam<BufferedInputMode> {
         std::move(options));
   }
 
+  std::shared_ptr<velox::io::IoStatistics> dataIoStats_{
+      std::make_shared<velox::io::IoStatistics>()};
+  std::shared_ptr<velox::io::IoStatistics> metadataIoStats_{
+      std::make_shared<velox::io::IoStatistics>()};
+
   std::shared_ptr<velox::ReadFile> readFile_;
   std::unique_ptr<folly::CPUThreadPoolExecutor> executor_;
-  std::shared_ptr<velox::dwio::common::IoStatistics> ioStatistics_;
   std::shared_ptr<velox::memory::MallocAllocator> allocator_;
   std::shared_ptr<velox::cache::AsyncDataCache> cache_;
   std::shared_ptr<velox::cache::ScanTracker> tracker_;
@@ -3989,10 +3994,10 @@ TEST_P(TabletWithIndexTest, cacheWarmPath) {
     EXPECT_NE(coldReader->clusterIndex(), nullptr);
 
     // Cold init bypasses CachedBufferedInput — no IoStatistics tracking.
-    EXPECT_EQ(ioStatistics_->ramHit().count(), 0);
-    EXPECT_EQ(ioStatistics_->ssdRead().count(), 0);
-    EXPECT_EQ(ioStatistics_->read().count(), 0);
-    EXPECT_EQ(ioStatistics_->prefetch().count(), 0);
+    EXPECT_EQ(dataIoStats_->ramHit().count(), 0);
+    EXPECT_EQ(dataIoStats_->ssdRead().count(), 0);
+    EXPECT_EQ(dataIoStats_->read().count(), 0);
+    EXPECT_EQ(dataIoStats_->prefetch().count(), 0);
 
     // Verify stripe groups are accessible.
     for (uint32_t i = 0; i < kNumStripes; ++i) {
@@ -4016,7 +4021,7 @@ TEST_P(TabletWithIndexTest, cacheWarmPath) {
   EXPECT_EQ(coldCacheStats.numEvict, 0);
 
   // Reset IO stats for the warm path.
-  ioStatistics_ = std::make_shared<velox::dwio::common::IoStatistics>();
+  dataIoStats_ = std::make_shared<velox::dwio::common::IoStatistics>();
 
   // Warm path: second reader should initialize from cache with zero IO.
   {
@@ -4027,10 +4032,10 @@ TEST_P(TabletWithIndexTest, cacheWarmPath) {
     EXPECT_NE(warmReader->clusterIndex(), nullptr);
 
     // Warm path should serve all data from RAM cache.
-    EXPECT_GT(ioStatistics_->ramHit().count(), 0);
-    EXPECT_EQ(ioStatistics_->ssdRead().count(), 0);
-    EXPECT_EQ(ioStatistics_->read().count(), 0);
-    EXPECT_EQ(ioStatistics_->prefetch().count(), 0);
+    EXPECT_GT(dataIoStats_->ramHit().count(), 0);
+    EXPECT_EQ(dataIoStats_->ssdRead().count(), 0);
+    EXPECT_EQ(dataIoStats_->read().count(), 0);
+    EXPECT_EQ(dataIoStats_->prefetch().count(), 0);
 
     // Verify stripe groups are accessible from cache.
     for (uint32_t i = 0; i < kNumStripes; ++i) {
@@ -4347,10 +4352,10 @@ TEST_P(TabletTest, cacheWarmPath) {
 
     // Cold init uses direct file_->preadv() which bypasses
     // CachedBufferedInput, so no reads are tracked through IoStatistics.
-    EXPECT_EQ(ioStatistics_->ramHit().count(), 0);
-    EXPECT_EQ(ioStatistics_->ssdRead().count(), 0);
-    EXPECT_EQ(ioStatistics_->read().count(), 0);
-    EXPECT_EQ(ioStatistics_->prefetch().count(), 0);
+    EXPECT_EQ(dataIoStats_->ramHit().count(), 0);
+    EXPECT_EQ(dataIoStats_->ssdRead().count(), 0);
+    EXPECT_EQ(dataIoStats_->read().count(), 0);
+    EXPECT_EQ(dataIoStats_->prefetch().count(), 0);
 
     auto stripeId = coldReader->stripeIdentifier(0);
     EXPECT_EQ(stripeId.stripeId(), 0);
@@ -4366,7 +4371,7 @@ TEST_P(TabletTest, cacheWarmPath) {
   EXPECT_EQ(coldCacheStats.numEvict, 0);
 
   // Reset IO stats for the warm path.
-  ioStatistics_ = std::make_shared<velox::dwio::common::IoStatistics>();
+  dataIoStats_ = std::make_shared<velox::dwio::common::IoStatistics>();
 
   // Warm path: second reader should initialize from cache with zero IO.
   {
@@ -4378,10 +4383,10 @@ TEST_P(TabletTest, cacheWarmPath) {
     }
 
     // Warm path should serve all data from RAM cache with zero storage reads.
-    EXPECT_GT(ioStatistics_->ramHit().count(), 0);
-    EXPECT_EQ(ioStatistics_->ssdRead().count(), 0);
-    EXPECT_EQ(ioStatistics_->read().count(), 0);
-    EXPECT_EQ(ioStatistics_->prefetch().count(), 0);
+    EXPECT_GT(dataIoStats_->ramHit().count(), 0);
+    EXPECT_EQ(dataIoStats_->ssdRead().count(), 0);
+    EXPECT_EQ(dataIoStats_->read().count(), 0);
+    EXPECT_EQ(dataIoStats_->prefetch().count(), 0);
 
     auto stripeId = warmReader->stripeIdentifier(0);
     EXPECT_EQ(stripeId.stripeId(), 0);
@@ -4512,8 +4517,7 @@ INSTANTIATE_TEST_SUITE_P(
 // Stress test: concurrent readers with mixed BufferedInput modes and periodic
 // cache eviction. Exercises race conditions between cache population, cache
 // eviction, and reader initialization.
-TEST(TabletStressTest, concurrentReadersWithCacheEviction) {
-  velox::memory::MemoryManager::testingSetInstance({});
+TEST_F(TabletTest, concurrentReadersWithCacheEviction) {
   auto pool =
       velox::memory::MemoryManager::getInstance()->addRootPool("stressTest");
 
@@ -4564,9 +4568,9 @@ TEST(TabletStressTest, concurrentReadersWithCacheEviction) {
       // Each thread cycles through a fixed BufferedInput mode.
       auto mode = static_cast<BufferedInputMode>(threadId % 4);
       std::unique_ptr<velox::dwio::common::BufferedInput> bi;
-      auto ioStats = std::make_shared<velox::dwio::common::IoStatistics>();
       std::shared_ptr<velox::cache::ScanTracker> tracker;
-      velox::io::ReaderOptions readerOptions(threadPool.get());
+      velox::io::ReaderOptions readerOptions(
+          threadPool.get(), dataIoStats_.get(), metadataIoStats_.get());
       nimble::TabletReader::Options options;
 
       switch (mode) {
@@ -4589,7 +4593,7 @@ TEST(TabletStressTest, concurrentReadersWithCacheEviction) {
               std::move(fileId),
               tracker,
               std::move(groupId),
-              ioStats,
+              dataIoStats_,
               nullptr,
               executor.get(),
               readerOptions);
@@ -4608,7 +4612,7 @@ TEST(TabletStressTest, concurrentReadersWithCacheEviction) {
               cache.get(),
               tracker,
               std::move(groupId),
-              ioStats,
+              dataIoStats_,
               nullptr,
               executor.get(),
               readerOptions);

--- a/dwio/nimble/velox/selective/tests/E2EFilterTest.cpp
+++ b/dwio/nimble/velox/selective/tests/E2EFilterTest.cpp
@@ -359,7 +359,10 @@ class E2EFilterTest
       auto& ids = fileIds();
       StringIdLease fileId(ids, "testFile");
       StringIdLease groupId(ids, "testGroup");
-      io::ReaderOptions cacheReaderOpts(&readerOpts.memoryPool());
+      io::ReaderOptions cacheReaderOpts(
+          &readerOpts.memoryPool(),
+          cacheIoStatistics_.get(),
+          cacheIoStatistics_.get());
       input = std::make_unique<dwio::common::CachedBufferedInput>(
           std::move(readFile),
           dwio::common::MetricsLog::voidLog(),

--- a/dwio/nimble/velox/selective/tests/E2EIndexTest.cpp
+++ b/dwio/nimble/velox/selective/tests/E2EIndexTest.cpp
@@ -198,7 +198,8 @@ class E2EIndexTestBase : public ::testing::Test {
     rootPool_ = memory::memoryManager()->addRootPool("E2EIndexTest");
     leafPool_ = rootPool_->addLeafChild("E2EIndexTestLeaf");
     vectorMaker_ = std::make_unique<velox::test::VectorMaker>(leafPool_.get());
-    ioStatistics_ = std::make_shared<io::IoStatistics>();
+    dataIoStats_ = std::make_shared<io::IoStatistics>();
+    metadataIoStats_ = std::make_shared<io::IoStatistics>();
     scanTracker_ =
         std::make_shared<cache::ScanTracker>("testTracker", nullptr, 256 << 10);
     ioExecutor_ = std::make_unique<folly::CPUThreadPoolExecutor>(10);
@@ -352,7 +353,10 @@ class E2EIndexTestBase : public ::testing::Test {
     const auto readerId = readerIdCounter_++;
     StringIdLease fileId(ids, fmt::format("testFile_{}", readerId));
     StringIdLease groupId(ids, fmt::format("testGroup_{}", readerId));
-    io::ReaderOptions ioReaderOpts(&readerOptions.memoryPool());
+    io::ReaderOptions ioReaderOpts(
+        &readerOptions.memoryPool(),
+        dataIoStats_.get(),
+        metadataIoStats_.get());
     if (cache_ != nullptr) {
       input = std::make_unique<CachedBufferedInput>(
           readFile,
@@ -361,7 +365,7 @@ class E2EIndexTestBase : public ::testing::Test {
           cache_.get(),
           scanTracker_,
           std::move(groupId),
-          ioStatistics_,
+          dataIoStats_,
           nullptr,
           ioExecutor_.get(),
           ioReaderOpts);
@@ -372,7 +376,7 @@ class E2EIndexTestBase : public ::testing::Test {
           std::move(fileId),
           scanTracker_,
           std::move(groupId),
-          ioStatistics_,
+          dataIoStats_,
           nullptr,
           ioExecutor_.get(),
           ioReaderOpts);
@@ -513,7 +517,8 @@ class E2EIndexTestBase : public ::testing::Test {
   // Cache infrastructure (only initialized when enableCache is true).
   std::shared_ptr<memory::MallocAllocator> allocator_;
   std::shared_ptr<cache::AsyncDataCache> cache_;
-  std::shared_ptr<io::IoStatistics> ioStatistics_;
+  std::shared_ptr<io::IoStatistics> dataIoStats_;
+  std::shared_ptr<io::IoStatistics> metadataIoStats_;
   std::shared_ptr<cache::ScanTracker> scanTracker_;
   std::unique_ptr<folly::CPUThreadPoolExecutor> ioExecutor_;
 };

--- a/dwio/nimble/velox/selective/tests/SelectiveNimbleReaderTest.cpp
+++ b/dwio/nimble/velox/selective/tests/SelectiveNimbleReaderTest.cpp
@@ -33,6 +33,7 @@
 #include "velox/common/caching/AsyncDataCache.h"
 #include "velox/common/caching/FileIds.h"
 #include "velox/common/caching/ScanTracker.h"
+#include "velox/common/io/IoStatistics.h"
 #include "velox/common/memory/MallocAllocator.h"
 #include "velox/dwio/common/CachedBufferedInput.h"
 #include "velox/dwio/common/DirectBufferedInput.h"
@@ -98,7 +99,6 @@ class SelectiveNimbleReaderTest
   }
 
   void SetUp() override {
-    ioStatistics_ = std::make_shared<io::IoStatistics>();
     scanTracker_ =
         std::make_shared<cache::ScanTracker>("testTracker", nullptr, 256 << 10);
     ioExecutor_ = std::make_unique<folly::CPUThreadPoolExecutor>(10);
@@ -149,7 +149,8 @@ class SelectiveNimbleReaderTest
     const auto readerId = readerIdCounter_++;
     StringIdLease fileId(ids, fmt::format("testFile_{}", readerId));
     StringIdLease groupId(ids, fmt::format("testGroup_{}", readerId));
-    io::ReaderOptions ioReaderOpts(pool());
+    io::ReaderOptions ioReaderOpts(
+        pool(), dataIoStats_.get(), metadataIoStats_.get());
     if (cache_ != nullptr) {
       input = std::make_unique<dwio::common::CachedBufferedInput>(
           readFile,
@@ -158,7 +159,7 @@ class SelectiveNimbleReaderTest
           cache_.get(),
           scanTracker_,
           std::move(groupId),
-          ioStatistics_,
+          dataIoStats_,
           nullptr,
           ioExecutor_.get(),
           ioReaderOpts);
@@ -169,7 +170,7 @@ class SelectiveNimbleReaderTest
           std::move(fileId),
           scanTracker_,
           std::move(groupId),
-          ioStatistics_,
+          dataIoStats_,
           nullptr,
           ioExecutor_.get(),
           ioReaderOpts);
@@ -205,7 +206,10 @@ class SelectiveNimbleReaderTest
   // Cache infrastructure (only initialized when enableCache is true).
   std::shared_ptr<memory::MallocAllocator> allocator_;
   std::shared_ptr<cache::AsyncDataCache> cache_;
-  std::shared_ptr<io::IoStatistics> ioStatistics_;
+  const std::shared_ptr<io::IoStatistics> dataIoStats_{
+      std::make_shared<io::IoStatistics>()};
+  const std::shared_ptr<io::IoStatistics> metadataIoStats_{
+      std::make_shared<io::IoStatistics>()};
   std::shared_ptr<cache::ScanTracker> scanTracker_;
   std::unique_ptr<folly::CPUThreadPoolExecutor> ioExecutor_;
 
@@ -2489,7 +2493,8 @@ TEST_P(SelectiveNimbleReaderTest, pinnedMetadataNoReread) {
   const auto readerId = readerIdCounter_++;
   StringIdLease fileId(ids, fmt::format("testFile_{}", readerId));
   StringIdLease groupId(ids, fmt::format("testGroup_{}", readerId));
-  io::ReaderOptions ioReaderOpts(pool());
+  io::ReaderOptions ioReaderOpts(
+      pool(), dataIoStats_.get(), metadataIoStats_.get());
   std::unique_ptr<dwio::common::BufferedInput> bufferedInput;
   if (cache_ != nullptr) {
     bufferedInput = std::make_unique<dwio::common::CachedBufferedInput>(
@@ -2499,7 +2504,7 @@ TEST_P(SelectiveNimbleReaderTest, pinnedMetadataNoReread) {
         cache_.get(),
         scanTracker_,
         std::move(groupId),
-        ioStatistics_,
+        dataIoStats_,
         nullptr,
         ioExecutor_.get(),
         ioReaderOpts);
@@ -2510,7 +2515,7 @@ TEST_P(SelectiveNimbleReaderTest, pinnedMetadataNoReread) {
         std::move(fileId),
         scanTracker_,
         std::move(groupId),
-        ioStatistics_,
+        dataIoStats_,
         nullptr,
         ioExecutor_.get(),
         ioReaderOpts);

--- a/dwio/nimble/velox/tests/VeloxReaderTest.cpp
+++ b/dwio/nimble/velox/tests/VeloxReaderTest.cpp
@@ -36,6 +36,7 @@
 #include "velox/common/caching/AsyncDataCache.h"
 #include "velox/common/caching/FileIds.h"
 #include "velox/common/caching/ScanTracker.h"
+#include "velox/common/io/IoStatistics.h"
 #include "velox/common/memory/MallocAllocator.h"
 #include "velox/dwio/common/CachedBufferedInput.h"
 #include "velox/dwio/common/ColumnSelector.h"
@@ -479,7 +480,6 @@ class VeloxReaderTest : public ::testing::TestWithParam<TestParam> {
   void SetUp() override {
     rootPool_ = velox::memory::memoryManager()->addRootPool("default_root");
     leafPool_ = rootPool_->addLeafChild("default_leaf");
-    ioStatistics_ = std::make_shared<velox::io::IoStatistics>();
     scanTracker_ = std::make_shared<velox::cache::ScanTracker>(
         "testTracker", nullptr, 256 << 10);
     ioExecutor_ = std::make_unique<folly::CPUThreadPoolExecutor>(10);
@@ -527,7 +527,8 @@ class VeloxReaderTest : public ::testing::TestWithParam<TestParam> {
       auto fileIdStr = fmt::format("testFile_{}", nextFileId_++);
       velox::StringIdLease fileId(ids, fileIdStr);
       velox::StringIdLease groupId(ids, "testGroup");
-      velox::io::ReaderOptions ioReaderOpts(pool);
+      velox::io::ReaderOptions ioReaderOpts(
+          pool, dataIoStats_.get(), metadataIoStats_.get());
       if (cache_ != nullptr) {
         cachedInput_ =
             std::make_unique<velox::dwio::common::CachedBufferedInput>(
@@ -537,7 +538,7 @@ class VeloxReaderTest : public ::testing::TestWithParam<TestParam> {
                 cache_.get(),
                 scanTracker_,
                 std::move(groupId),
-                ioStatistics_,
+                dataIoStats_,
                 nullptr, // ioStats
                 ioExecutor_.get(),
                 ioReaderOpts);
@@ -549,7 +550,7 @@ class VeloxReaderTest : public ::testing::TestWithParam<TestParam> {
                 std::move(fileId),
                 scanTracker_,
                 std::move(groupId),
-                ioStatistics_,
+                dataIoStats_,
                 nullptr, // ioStats
                 ioExecutor_.get(),
                 ioReaderOpts);
@@ -1372,7 +1373,10 @@ class VeloxReaderTest : public ::testing::TestWithParam<TestParam> {
   // Cache infrastructure (only initialized when enableCache is true).
   std::shared_ptr<velox::memory::MallocAllocator> allocator_;
   std::shared_ptr<velox::cache::AsyncDataCache> cache_;
-  std::shared_ptr<velox::io::IoStatistics> ioStatistics_;
+  const std::shared_ptr<velox::io::IoStatistics> dataIoStats_{
+      std::make_shared<velox::io::IoStatistics>()};
+  const std::shared_ptr<velox::io::IoStatistics> metadataIoStats_{
+      std::make_shared<velox::io::IoStatistics>()};
   std::shared_ptr<velox::cache::ScanTracker> scanTracker_;
   std::unique_ptr<folly::CPUThreadPoolExecutor> ioExecutor_;
   // Held alive for the duration of createTablet/createVeloxReader.


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebookincubator/velox/pull/17395


Previously, only data stream IO was tracked through CachedBufferedInput/DirectBufferedInput via a single IoStatistics instance. Metadata IO (footer, stripe groups, index sections) was completely invisible to the stats layer.

Add two IoStatistics pointers to ReaderOptions — `dataIoStats` for data stream IO and `metaIoStats` for metadata IO — so they can be tracked and reported independently. FileDataSource creates a separate metaIoStats_ alongside the existing dataIoStats_ (renamed from ioStatistics_). Both are threaded through FileSplitReader and all subclasses (Hive, Iceberg, Paimon) into ReaderOptions.

Add `addIoStatsToRuntimeStats()` utility function that generates prefixed runtime stat entries (storage reads, SSD reads, RAM hits, overread bytes) from an IoStatistics instance, and use it to report metadata IO stats with "metadata." prefix in `getRuntimeStats()`.

Reviewed By: HuamengJiang

Differential Revision: D103486623


