### PR TITLE
feat(encoding): Add dictionary API to Encoding base class (#686)

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ Nimble integrates Velox as a Git submodule, referencing a specific commit of the
 Velox repository. The Velox badge at the top of this README shows the current
 commit and how far behind it is from Velox main.
 
-[See what changed since the current Velox commit.](https://github.com/facebookincubator/velox/compare/777a81f5e7f9cc8007f26a44fa9c598ad31596a2...main)
+[See what changed since the current Velox commit.](https://github.com/facebookincubator/velox/compare/6e26e2253d16106135b525d57664c529fcf6920e...main)
 <!-- pre-commit check-velox-readme validates the SHA above matches the submodule -->
 
 Advance Velox when your changes depend on code in Velox that

--- a/dwio/nimble/encodings/DictionaryEncoding.h
+++ b/dwio/nimble/encodings/DictionaryEncoding.h
@@ -60,6 +60,12 @@ class DictionaryEncoding
   template <typename DecoderVisitor>
   void readWithVisitor(DecoderVisitor& visitor, ReadWithVisitorParams& params);
 
+  /// Reads dictionary indices only, without looking up values from the
+  /// alphabet. This is used for dictionary-aware readers that return
+  /// DictionaryVector. Non-legacy encodings only.
+  template <typename V>
+  void readIndicesWithVisitor(V& visitor, ReadWithVisitorParams& params);
+
   static std::string_view encode(
       EncodingSelection<physicalType>& selection,
       std::span<const physicalType> values,
@@ -67,6 +73,26 @@ class DictionaryEncoding
       const Encoding::Options& options = {});
 
   std::string debugString(int offset) const final;
+
+  bool dictionaryEnabled() const override {
+    return true;
+  }
+
+  uint32_t dictionarySize() const override {
+    return alphabet_.size();
+  }
+
+  const void* dictionaryEntry(uint32_t index) const override {
+    return &alphabet_[index];
+  }
+
+  const void* dictionaryEntries() const override {
+    return alphabet_.data();
+  }
+
+  const Encoding* indicesEncoding() const {
+    return indicesEncoding_.get();
+  }
 
  private:
   // Stores pre-loaded alphabet
@@ -200,6 +226,18 @@ void DictionaryEncoding<T>::readWithVisitor(
     const auto index = indicesBuffer_[visitor.rowIndex() - startRowIndex];
     return alphabet_[index];
   });
+}
+
+/// Reads indices only without looking up values from the alphabet.
+/// This is used for dictionary-aware readers that return DictionaryVector.
+template <typename T>
+template <typename V>
+void DictionaryEncoding<T>::readIndicesWithVisitor(
+    V& visitor,
+    ReadWithVisitorParams& params) {
+  // Call readWithVisitor on the indices encoding directly.
+  // The visitor is expected to handle int32_t values (dictionary indices).
+  callReadWithVisitor(*indicesEncoding_, visitor, params);
 }
 
 template <typename T>

--- a/dwio/nimble/encodings/Encoding.h
+++ b/dwio/nimble/encodings/Encoding.h
@@ -26,40 +26,40 @@
 
 #include <type_traits>
 
-// The Encoding class defines an interface for interacting with encodings
-// (aka vectors, aka arrays) of encoded data. The API is tailored for
-// typical usage patterns within query engines, and is designed to be
-// easily extensible.
-//
-// Some general notes:
-//  1. Output bitmaps are compatible with the FixedBitArray class. In
-//     particular this means you must use FixedBitArray::bufferSize to
-//     determine the space needed for the bitmaps you pass to, e.g.,
-//     the output buffer of Encoding::Equals.
-//  2. When passing types into functions via the void* interfaces,
-//     and when materializing data, numeric types are input/output via
-//     their native types, while string are passed via std::string_view
-//     -- NOT std::string!
-//  3. We refer to the 'row pointer' in various places. Think of this as
-//     the iterator over the encoding's data. Encoding::Reset() is like
-//     rp = vec.begin(), advancing N rows is like rp = rp + N, etc.
-//  4. An Encoding doesn't own the underlying data. If you want to create two
-//     copies for some reason on the same data go ahead, they are totally
-//     independent.
-//  5. Each subclass of Encoding will provide its own serialization methods.
-//     The resulting string should be passed to the subclass's constructor
-//     at read time.
-//  6. Although serialized Encodings can be stored independently if desired
-//     (as they are just strings), when written to disk they are normally
-//     stored together in a Tablet (see tablet.h).
-//  7. We consistently use 4 byte unsigned integers for things like offsets
-//     and row counts. Encodings, and indeed entire Tablets, are required to
-//     fit within a uint32_t in size. This is enforced in the normal
-//     ingestion pathways. If you directly use the serialization methods,
-//     be careful that this remains true!
-//  8. See the notes in the Encoding class about array encodings. These
-//  encodings
-//     have slightly different semantics than other encodings.
+/// The Encoding class defines an interface for interacting with encodings
+/// (aka vectors, aka arrays) of encoded data. The API is tailored for
+/// typical usage patterns within query engines, and is designed to be
+/// easily extensible.
+///
+/// Some general notes:
+///  1. Output bitmaps are compatible with the FixedBitArray class. In
+///     particular this means you must use FixedBitArray::bufferSize to
+///     determine the space needed for the bitmaps you pass to, e.g.,
+///     the output buffer of Encoding::Equals.
+///  2. When passing types into functions via the void* interfaces,
+///     and when materializing data, numeric types are input/output via
+///     their native types, while string are passed via std::string_view
+///     -- NOT std::string!
+///  3. We refer to the 'row pointer' in various places. Think of this as
+///     the iterator over the encoding's data. Encoding::Reset() is like
+///     rp = vec.begin(), advancing N rows is like rp = rp + N, etc.
+///  4. An Encoding doesn't own the underlying data. If you want to create two
+///     copies for some reason on the same data go ahead, they are totally
+///     independent.
+///  5. Each subclass of Encoding will provide its own serialization methods.
+///     The resulting string should be passed to the subclass's constructor
+///     at read time.
+///  6. Although serialized Encodings can be stored independently if desired
+///     (as they are just strings), when written to disk they are normally
+///     stored together in a Tablet (see tablet.h).
+///  7. We consistently use 4 byte unsigned integers for things like offsets
+///     and row counts. Encodings, and indeed entire Tablets, are required to
+///     fit within a uint32_t in size. This is enforced in the normal
+///     ingestion pathways. If you directly use the serialization methods,
+///     be careful that this remains true!
+///  8. See the notes in the Encoding class about array encodings. These
+///  encodings
+///     have slightly different semantics than other encodings.
 
 namespace facebook::nimble {
 
@@ -150,11 +150,11 @@ class Encoding {
     return 0;
   }
 
-  // Resets the internal state (e.g. row pointer) to newly constructed form.
+  /// Resets the internal state (e.g. row pointer) to newly constructed form.
   virtual void reset() = 0;
 
-  // Advances the row pointer N rows. Note that we don't provide a 'backwards'
-  // iterator; if you need to move your row pointer back, reset() and skip().
+  /// Advances the row pointer N rows. Note that we don't provide a 'backwards'
+  /// iterator; if you need to move your row pointer back, reset() and skip().
   virtual void skip(uint32_t rowCount) = 0;
 
   /// Seeks to the first row matching the target value.
@@ -167,39 +167,39 @@ class Encoding {
     NIMBLE_UNSUPPORTED("seek is not supported.");
   }
 
-  // Materializes the next |rowCount| rows into buffer. Advances
-  // the row pointer |rowCount|.
-  //
-  // Remember that buffer is interpreted as a physicalType*, with
-  // std::string_view* for strings and bool* (not a bitmap) for bool. For
-  // non-POD types, namely string data, note that the materialized values are
-  // only guaranteed valid until the next non-const call to *this.
-  //
-  // If this->isNullable(), null rows are materialized as physicalType(). To be
-  // able to distinguish between nulls and non-null physicalType() values, use
-  // MaterializeNullable.
+  /// Materializes the next |rowCount| rows into buffer. Advances
+  /// the row pointer |rowCount|.
+  ///
+  /// Remember that buffer is interpreted as a physicalType*, with
+  /// std::string_view* for strings and bool* (not a bitmap) for bool. For
+  /// non-POD types, namely string data, note that the materialized values are
+  /// only guaranteed valid until the next non-const call to *this.
+  ///
+  /// If this->isNullable(), null rows are materialized as physicalType(). To be
+  /// able to distinguish between nulls and non-null physicalType() values, use
+  /// MaterializeNullable.
   virtual void materialize(uint32_t rowCount, void* buffer) = 0;
 
-  // Nullable method.
-  // Like Materialize, but also sets the ith bit of bitmap to reflect whether
-  // ith row was null or not. 0 means null, 1 means not null. Null rows are left
-  // untouched instead of being filled with default values.
-  //
-  // If |scatterBitmap| is provided, |rowCount| still indicates how many items
-  // to be read from the encoding. However, instead of placing them sequentially
-  // in the output |buffer|, the items are scattered. This means that item will
-  // be place into the slot where the corresponding positional bit is set to 1
-  // in |scatterBitmap|, (note that the value being read may be null). For every
-  // positional scatter bit set to 0, it will fill a null in the poisition in
-  // the output |buffer|. |rowCount| should match the number of bits set to 1 in
-  // |scatterBitmap|. For scattered reads, |buffer| and |nulls| should
-  // have enough space to accommodate |scatterBitmap.size()| items. When
-  // |offset| is specified, use the |scatterBitmap| starting from |offset| and
-  // scatter to |buffer| and |nulls| starting from |offset|.
-  //
-  // Returns number of items that are not null. In the case when all values are
-  // non null, |nulls| will not be filled with all 1s. It's expected that
-  // caller explicitly checks for that condition.
+  /// Nullable method.
+  /// Like Materialize, but also sets the ith bit of bitmap to reflect whether
+  /// ith row was null or not. 0 means null, 1 means not null. Null rows are
+  /// left untouched instead of being filled with default values.
+  ///
+  /// If |scatterBitmap| is provided, |rowCount| still indicates how many items
+  /// to be read from the encoding. However, instead of placing them
+  /// sequentially in the output |buffer|, the items are scattered. This means
+  /// that item will be place into the slot where the corresponding positional
+  /// bit is set to 1 in |scatterBitmap|, (note that the value being read may be
+  /// null). For every positional scatter bit set to 0, it will fill a null in
+  /// the poisition in the output |buffer|. |rowCount| should match the number
+  /// of bits set to 1 in |scatterBitmap|. For scattered reads, |buffer| and
+  /// |nulls| should have enough space to accommodate |scatterBitmap.size()|
+  /// items. When |offset| is specified, use the |scatterBitmap| starting from
+  /// |offset| and scatter to |buffer| and |nulls| starting from |offset|.
+  ///
+  /// Returns number of items that are not null. In the case when all values are
+  /// non null, |nulls| will not be filled with all 1s. It's expected that
+  /// caller explicitly checks for that condition.
   virtual uint32_t materializeNullable(
       uint32_t rowCount,
       void* buffer,
@@ -207,7 +207,7 @@ class Encoding {
       const velox::bits::Bitmap* scatterBitmap = nullptr,
       uint32_t offset = 0) = 0;
 
-  // Read bool values to output buffer as bits.
+  /// Read bool values to output buffer as bits.
   virtual void materializeBoolsAsBits(
       uint32_t /*rowCount*/,
       uint64_t* /*buffer*/,
@@ -215,40 +215,48 @@ class Encoding {
     NIMBLE_NOT_IMPLEMENTED(typeid(*this).name());
   }
 
-  // Whether this encoding is nullable, i.e. contains any nulls. This property
-  // modifies how engines need to interpret many of the function results, and a
-  // number of functions are only callable if isNullable() returns true.
+  /// Whether this encoding is nullable, i.e. contains any nulls. This property
+  /// modifies how engines need to interpret many of the function results, and a
+  /// number of functions are only callable if isNullable() returns true.
   virtual bool isNullable() const {
     return false;
   }
 
-  // A number of functions are legal to call only if the encoding is dictionary
-  // enabled, such as retrieving the dictionary indices or looking up a value
-  // by dictionary index.
-  virtual bool isDictionaryEnabled() const {
+  /// Returns true if this encoding stores dictionary-encoded data.
+  /// When true, dictionarySize(), dictionaryEntry(), and dictionaryEntries()
+  /// are valid to call.
+  virtual bool dictionaryEnabled() const {
     return false;
   }
 
-  // Dictionary method.
-  // The size of the dictionary, which is equal to the number of unique values.
+  /// Returns the number of unique values in the dictionary.
   virtual uint32_t dictionarySize() const {
-    NIMBLE_UNSUPPORTED("Data is not dictionary encoded.");
+    NIMBLE_UNREACHABLE("dictionarySize on non-dictionary encoding");
   }
 
-  // Dictionary method.
-  // Returns the value at the given index, which must be in [0, num_entries).
-  // This pointer is only guaranteed valid until the next Entry call.
+  /// Returns a pointer to the value at the given dictionary index.
+  /// The index must be in [0, dictionarySize()). The pointer is valid for
+  /// the lifetime of the encoding.
   virtual const void* dictionaryEntry(uint32_t /* index */) const {
-    NIMBLE_UNSUPPORTED("Data is not dictionary encoded.");
+    NIMBLE_UNREACHABLE("dictionaryEntry on non-dictionary encoding");
   }
 
-  // Dictionary method.
-  // Materializes the next |rowCount| dictionary indices into buffer. Advances
-  // The row pointer |rowCount|.
+  /// Returns a pointer to the contiguous dictionary alphabet data.
+  /// The pointer is valid for the lifetime of the encoding. The caller
+  /// must cast to the appropriate type (e.g., `const std::string_view*`).
+  /// For NullableEncoding, unwraps and delegates to the inner encoding.
+  /// Future stacks should extend to recursively find the inner
+  /// DictionaryEncoding through MainlyConstant and RLE wrappers.
+  virtual const void* dictionaryEntries() const {
+    NIMBLE_UNREACHABLE("dictionaryEntries on non-dictionary encoding");
+  }
+
+  /// Materializes the next |rowCount| dictionary indices into buffer.
+  /// Advances the row pointer |rowCount|.
   virtual void materializeIndices(
       uint32_t /* rowCount */,
       uint32_t* /* buffer */) {
-    NIMBLE_UNSUPPORTED("Data is not dictionary encoded.");
+    NIMBLE_UNREACHABLE("materializeIndices on non-dictionary encoding");
   }
 
   // A string for debugging/iteration that gives details about *this.

--- a/dwio/nimble/encodings/NullableEncoding.h
+++ b/dwio/nimble/encodings/NullableEncoding.h
@@ -20,6 +20,7 @@
 #include "dwio/nimble/common/EncodingPrimitives.h"
 #include "dwio/nimble/common/Types.h"
 #include "dwio/nimble/common/Vector.h"
+#include "dwio/nimble/encodings/DictionaryEncoding.h"
 #include "dwio/nimble/encodings/Encoding.h"
 #include "dwio/nimble/encodings/EncodingFactory.h"
 #include "dwio/nimble/encodings/EncodingIdentifier.h"
@@ -65,6 +66,15 @@ class NullableEncoding final
   template <typename DecoderVisitor>
   void readWithVisitor(DecoderVisitor& visitor, ReadWithVisitorParams& params);
 
+  /// Reads dictionary indices from a NullableEncoding that wraps a
+  /// DictionaryEncoding. Handles nulls, then delegates to the inner
+  /// DictionaryEncoding's readIndicesWithVisitor().
+  /// Non-legacy encodings only.
+  template <typename IndicesVisitor>
+  void readIndicesWithVisitor(
+      IndicesVisitor& visitor,
+      ReadWithVisitorParams& params);
+
   static std::string_view encodeNullable(
       EncodingSelection<physicalType>& selection,
       std::span<const physicalType> values,
@@ -74,7 +84,29 @@ class NullableEncoding final
 
   std::string debugString(int offset) const final;
 
+  // Dictionary API — delegates to the inner (non-null) encoding.
+  bool dictionaryEnabled() const override {
+    return nonNulls()->dictionaryEnabled();
+  }
+
+  uint32_t dictionarySize() const override {
+    return nonNulls()->dictionarySize();
+  }
+
+  const void* dictionaryEntry(uint32_t index) const override {
+    return nonNulls()->dictionaryEntry(index);
+  }
+
+  const void* dictionaryEntries() const override {
+    return nonNulls()->dictionaryEntries();
+  }
+
  private:
+  /// Materializes null bits into the visitor's reader null bitmap.
+  /// Shared by readWithVisitor and readIndicesWithVisitor.
+  template <typename V>
+  void materializeNullsForVisitor(V& visitor, ReadWithVisitorParams& params);
+
   // One bit for each row. A true bit represents a row with a non-null value.
   const char* bitmap_;
   std::unique_ptr<Encoding> nonNullValues_;
@@ -246,7 +278,7 @@ uint32_t NullableEncoding<T>::materializeNullable(
 
 template <typename T>
 template <typename V>
-void NullableEncoding<T>::readWithVisitor(
+void NullableEncoding<T>::materializeNullsForVisitor(
     V& visitor,
     ReadWithVisitorParams& params) {
   const auto endRow = visitor.rowAt(visitor.numRows() - 1);
@@ -280,7 +312,31 @@ void NullableEncoding<T>::readWithVisitor(
     nulls_->materializeBoolsAsBits(rowCount, nulls, params.numScanned);
   }
   params.initReturnReaderNulls();
+}
+
+template <typename T>
+template <typename V>
+void NullableEncoding<T>::readWithVisitor(
+    V& visitor,
+    ReadWithVisitorParams& params) {
+  materializeNullsForVisitor(visitor, params);
   callReadWithVisitor(*nonNullValues_, visitor, params);
+}
+
+template <typename T>
+template <typename V>
+void NullableEncoding<T>::readIndicesWithVisitor(
+    V& visitor,
+    ReadWithVisitorParams& params) {
+  materializeNullsForVisitor(visitor, params);
+  NIMBLE_CHECK_EQ(
+      nonNullValues_->encodingType(),
+      EncodingType::Dictionary,
+      "readIndicesWithVisitor called on NullableEncoding with non-dictionary "
+      "inner encoding: {}",
+      nonNullValues_->encodingType());
+  auto& dictEnc = static_cast<DictionaryEncoding<T>&>(*nonNullValues_);
+  dictEnc.readIndicesWithVisitor(visitor, params);
 }
 
 template <typename T>

--- a/dwio/nimble/encodings/tests/CMakeLists.txt
+++ b/dwio/nimble/encodings/tests/CMakeLists.txt
@@ -40,6 +40,7 @@ target_link_libraries(
   nimble_common
   nimble_tools_common
   velox_common_base
+  gmock
   gtest
   gtest_main
   Folly::folly

--- a/dwio/nimble/encodings/tests/EncodingTest.cpp
+++ b/dwio/nimble/encodings/tests/EncodingTest.cpp
@@ -15,11 +15,14 @@
  */
 #include "dwio/nimble/encodings/Encoding.h"
 #include <glog/logging.h>
+#include <gmock/gmock.h>
 #include <gtest/gtest.h>
 #include <memory>
+#include <set>
 #include <span>
 #include <vector>
 #include "dwio/nimble/common/Buffer.h"
+#include "dwio/nimble/common/EncodingPrimitives.h"
 #include "dwio/nimble/common/FixedBitArray.h"
 #include "dwio/nimble/common/Types.h"
 #include "dwio/nimble/common/Vector.h"
@@ -31,6 +34,7 @@
 #include "dwio/nimble/encodings/EncodingSelectionPolicy.h"
 #include "dwio/nimble/encodings/FixedBitWidthEncoding.h"
 #include "dwio/nimble/encodings/MainlyConstantEncoding.h"
+#include "dwio/nimble/encodings/NullableEncoding.h"
 #include "dwio/nimble/encodings/RleEncoding.h"
 #include "dwio/nimble/encodings/SparseBoolEncoding.h"
 #include "dwio/nimble/encodings/TrivialEncoding.h"
@@ -132,6 +136,7 @@ class TestTrivialEncodingSelectionPolicy
   bool shouldCompress_;
   bool useVariableBitWidthCompressor_;
 };
+
 } // namespace
 
 template <typename EncodingType, bool UseVarint>
@@ -718,5 +723,466 @@ TYPED_TEST(EncodingTest, scatteredMaterialize) {
         }
       }
     }
+  }
+}
+
+// Templatized dictionary API tests covering all DictionaryEncoding-compatible
+// types: numeric types + string_view + bool.
+template <typename T>
+class DictionaryApiTypedTest : public ::testing::Test {
+ protected:
+  using PhysicalType = typename nimble::TypeTraits<T>::physicalType;
+
+  void SetUp() override {
+    pool_ = facebook::velox::memory::deprecatedAddDefaultLeafMemoryPool();
+    buffer_ = std::make_unique<nimble::Buffer>(*pool_);
+  }
+
+  std::unique_ptr<nimble::Encoding> encodeDictionary(
+      const std::vector<T>& values) {
+    nimble::Vector<T> vec{pool_.get()};
+    for (auto v : values) {
+      vec.push_back(v);
+    }
+    auto physicalValues = std::span<const PhysicalType>(
+        reinterpret_cast<const PhysicalType*>(vec.data()), vec.size());
+    nimble::EncodingSelection<PhysicalType> selection{
+        {.encodingType = nimble::EncodingType::Dictionary},
+        nimble::Statistics<PhysicalType>::create(physicalValues),
+        std::make_unique<TestTrivialEncodingSelectionPolicy<T>>(false, false)};
+    auto encoded = nimble::DictionaryEncoding<T>::encode(
+        selection, physicalValues, *buffer_);
+    return std::make_unique<nimble::DictionaryEncoding<T>>(
+        *pool_, encoded, [this](uint32_t size) {
+          stringBuffers_.push_back(
+              velox::AlignedBuffer::allocate<char>(size, pool_.get()));
+          return stringBuffers_.back()->asMutable<void>();
+        });
+  }
+
+  std::unique_ptr<nimble::Encoding> encodeNullableDictionary(
+      const std::vector<T>& values,
+      const nimble::Vector<bool>& nulls) {
+    NIMBLE_CHECK_EQ(values.size(), nulls.size());
+    const uint32_t rowCount = values.size();
+
+    // Encode non-null values as DictionaryEncoding.
+    nimble::Vector<T> nonNullVec{pool_.get()};
+    for (size_t i = 0; i < values.size(); ++i) {
+      if (nulls[i]) {
+        nonNullVec.push_back(values[i]);
+      }
+    }
+    auto nonNullSpan = std::span<const PhysicalType>(
+        reinterpret_cast<const PhysicalType*>(nonNullVec.data()),
+        nonNullVec.size());
+    nimble::Buffer valBuffer{*pool_};
+    nimble::EncodingSelection<PhysicalType> valSelection{
+        {.encodingType = nimble::EncodingType::Dictionary},
+        nimble::Statistics<PhysicalType>::create(nonNullSpan),
+        std::make_unique<TestTrivialEncodingSelectionPolicy<T>>(false, false)};
+    auto serializedValues = nimble::DictionaryEncoding<T>::encode(
+        valSelection, nonNullSpan, valBuffer);
+
+    // Encode nulls as TrivialEncoding<bool>.
+    auto nullSpan = std::span<const bool>(nulls.data(), nulls.size());
+    nimble::Buffer nullBuffer{*pool_};
+    nimble::EncodingSelection<bool> nullSelection{
+        {.encodingType = nimble::EncodingType::Trivial},
+        nimble::Statistics<bool>::create(nullSpan),
+        std::make_unique<TestTrivialEncodingSelectionPolicy<bool>>(
+            false, false)};
+    auto serializedNulls = nimble::TrivialEncoding<bool>::encode(
+        nullSelection, nullSpan, nullBuffer);
+
+    // Assemble the NullableEncoding binary format:
+    // [EncodingType:1][DataType:1][rowCount:4] | uint32(valSize) | valBytes |
+    // nullBytes
+    const uint32_t encodingSize = nimble::Encoding::kPrefixSize + 4 +
+        serializedValues.size() + serializedNulls.size();
+    char* reserved = buffer_->reserve(encodingSize);
+    char* pos = reserved;
+    nimble::encoding::writeChar(
+        static_cast<char>(nimble::EncodingType::Nullable), pos);
+    nimble::encoding::writeChar(
+        static_cast<char>(nimble::TypeTraits<T>::dataType), pos);
+    nimble::encoding::writeUint32(rowCount, pos);
+    nimble::encoding::writeString(serializedValues, pos);
+    nimble::encoding::writeBytes(serializedNulls, pos);
+
+    return nimble::EncodingFactory().create(
+        *pool_,
+        std::string_view(reserved, encodingSize),
+        [this](uint32_t size) {
+          stringBuffers_.push_back(
+              velox::AlignedBuffer::allocate<char>(size, pool_.get()));
+          return stringBuffers_.back()->asMutable<void>();
+        });
+  }
+
+  std::shared_ptr<velox::memory::MemoryPool> pool_;
+  std::unique_ptr<nimble::Buffer> buffer_;
+  std::vector<velox::BufferPtr> stringBuffers_;
+  std::vector<std::string> stringPool_;
+};
+
+using DictionaryApiTypes = ::testing::Types<
+    int8_t,
+    int16_t,
+    int32_t,
+    int64_t,
+    uint8_t,
+    uint16_t,
+    uint32_t,
+    uint64_t,
+    float,
+    double,
+    std::string_view>;
+
+TYPED_TEST_SUITE(DictionaryApiTypedTest, DictionaryApiTypes);
+
+TYPED_TEST(DictionaryApiTypedTest, basics) {
+  using T = TypeParam;
+  std::vector<T> data;
+  if constexpr (std::is_same_v<T, std::string_view>) {
+    data = {"alpha", "bravo", "alpha", "charlie", "bravo"};
+  } else {
+    data = {T(1), T(2), T(1), T(3), T(2)};
+  }
+
+  auto encoding = this->encodeDictionary(data);
+  EXPECT_TRUE(encoding->dictionaryEnabled());
+  EXPECT_EQ(encoding->dictionarySize(), 3);
+
+  const auto* entries = static_cast<const T*>(encoding->dictionaryEntries());
+  ASSERT_NE(entries, nullptr);
+  std::set<T> actualUniques(entries, entries + 3);
+
+  if constexpr (std::is_same_v<T, std::string_view>) {
+    EXPECT_THAT(
+        actualUniques,
+        ::testing::UnorderedElementsAre("alpha", "bravo", "charlie"));
+  } else {
+    EXPECT_THAT(
+        actualUniques, ::testing::UnorderedElementsAre(T(1), T(2), T(3)));
+  }
+
+  for (uint32_t i = 0; i < 3; ++i) {
+    const auto* entry = static_cast<const T*>(encoding->dictionaryEntry(i));
+    EXPECT_EQ(*entry, entries[i]);
+  }
+}
+
+TYPED_TEST(DictionaryApiTypedTest, fuzz) {
+  using T = TypeParam;
+  auto seed = folly::Random::rand32();
+  LOG(INFO) << "seed: " << seed;
+  std::mt19937 rng(seed);
+
+  constexpr int kNumRuns = 10;
+  constexpr int kMaxRows = 300;
+
+  for (int run = 0; run < kNumRuns; ++run) {
+    const int numRows = 2 + rng() % kMaxRows;
+    const int cardinality = 2 + rng() % 10;
+
+    // For string types, build a pool of unique random strings per run.
+    if constexpr (std::is_same_v<T, std::string_view>) {
+      this->stringPool_.clear();
+      for (int j = 0; j < cardinality; ++j) {
+        const int len = rng() % 30;
+        std::string s = fmt::format("{}:", j);
+        for (int k = 0; k < len; ++k) {
+          s += static_cast<char>('a' + rng() % 26);
+        }
+        this->stringPool_.push_back(std::move(s));
+      }
+    }
+
+    std::vector<T> data;
+    std::set<T> expectedUniques;
+    data.reserve(numRows);
+    for (int i = 0; i < numRows; ++i) {
+      T val;
+      if constexpr (std::is_same_v<T, std::string_view>) {
+        val = std::string_view(this->stringPool_[rng() % cardinality]);
+      } else {
+        val = static_cast<T>(rng() % cardinality);
+      }
+      data.push_back(val);
+      expectedUniques.insert(val);
+    }
+
+    SCOPED_TRACE(fmt::format("run={} seed={} numRows={}", run, seed, numRows));
+
+    auto encoding = this->encodeDictionary(data);
+    ASSERT_TRUE(encoding->dictionaryEnabled());
+    ASSERT_EQ(encoding->dictionarySize(), expectedUniques.size());
+
+    const auto* entries = static_cast<const T*>(encoding->dictionaryEntries());
+    std::set<T> actualUniques(entries, entries + encoding->dictionarySize());
+    EXPECT_EQ(actualUniques, expectedUniques);
+
+    for (uint32_t i = 0; i < encoding->dictionarySize(); ++i) {
+      const auto* entry = static_cast<const T*>(encoding->dictionaryEntry(i));
+      EXPECT_EQ(*entry, entries[i]);
+    }
+  }
+}
+
+TYPED_TEST(DictionaryApiTypedTest, nullableBasics) {
+  using T = TypeParam;
+  std::vector<T> data;
+  if constexpr (std::is_same_v<T, std::string_view>) {
+    data = {"alpha", "bravo", "alpha", "charlie", "bravo"};
+  } else {
+    data = {T(1), T(2), T(1), T(3), T(2)};
+  }
+  nimble::Vector<bool> nulls{this->pool_.get()};
+  for (bool b : {true, true, false, true, true}) {
+    nulls.push_back(b);
+  }
+
+  auto encoding = this->encodeNullableDictionary(data, nulls);
+  ASSERT_TRUE(encoding->isNullable());
+  EXPECT_TRUE(encoding->dictionaryEnabled());
+  EXPECT_EQ(encoding->dictionarySize(), 3);
+
+  const auto* entries = static_cast<const T*>(encoding->dictionaryEntries());
+  ASSERT_NE(entries, nullptr);
+  std::set<T> actualUniques(entries, entries + 3);
+
+  if constexpr (std::is_same_v<T, std::string_view>) {
+    EXPECT_THAT(
+        actualUniques,
+        ::testing::UnorderedElementsAre("alpha", "bravo", "charlie"));
+  } else {
+    EXPECT_THAT(
+        actualUniques, ::testing::UnorderedElementsAre(T(1), T(2), T(3)));
+  }
+
+  for (uint32_t i = 0; i < 3; ++i) {
+    const auto* entry = static_cast<const T*>(encoding->dictionaryEntry(i));
+    EXPECT_EQ(*entry, entries[i]);
+  }
+}
+
+TYPED_TEST(DictionaryApiTypedTest, nullableFuzz) {
+  using T = TypeParam;
+  auto seed = folly::Random::rand32();
+  LOG(INFO) << "seed: " << seed;
+  std::mt19937 rng(seed);
+
+  constexpr int kNumRuns = 10;
+  constexpr int kMaxRows = 300;
+
+  for (int run = 0; run < kNumRuns; ++run) {
+    const int numRows = 2 + rng() % kMaxRows;
+    const int cardinality = 2 + rng() % 10;
+
+    if constexpr (std::is_same_v<T, std::string_view>) {
+      this->stringPool_.clear();
+      for (int j = 0; j < cardinality; ++j) {
+        const int len = rng() % 30;
+        std::string s = fmt::format("{}:", j);
+        for (int k = 0; k < len; ++k) {
+          s += static_cast<char>('a' + rng() % 26);
+        }
+        this->stringPool_.push_back(std::move(s));
+      }
+    }
+
+    std::vector<T> data;
+    nimble::Vector<bool> nulls{this->pool_.get()};
+    std::set<T> expectedUniques;
+    data.reserve(numRows);
+    nulls.reserve(numRows);
+    for (int i = 0; i < numRows; ++i) {
+      bool isNull = (rng() % 5 == 0);
+      nulls.push_back(!isNull);
+      T val;
+      if constexpr (std::is_same_v<T, std::string_view>) {
+        val = std::string_view(this->stringPool_[rng() % cardinality]);
+      } else {
+        val = static_cast<T>(rng() % cardinality);
+      }
+      data.push_back(val);
+      if (!isNull) {
+        expectedUniques.insert(val);
+      }
+    }
+
+    if (expectedUniques.empty()) {
+      continue;
+    }
+
+    SCOPED_TRACE(fmt::format("run={} seed={} numRows={}", run, seed, numRows));
+
+    auto encoding = this->encodeNullableDictionary(data, nulls);
+    ASSERT_TRUE(encoding->isNullable());
+    ASSERT_TRUE(encoding->dictionaryEnabled());
+    ASSERT_EQ(encoding->dictionarySize(), expectedUniques.size());
+
+    const auto* entries = static_cast<const T*>(encoding->dictionaryEntries());
+    std::set<T> actualUniques(entries, entries + encoding->dictionarySize());
+    EXPECT_EQ(actualUniques, expectedUniques);
+
+    for (uint32_t i = 0; i < encoding->dictionarySize(); ++i) {
+      const auto* entry = static_cast<const T*>(encoding->dictionaryEntry(i));
+      EXPECT_EQ(*entry, entries[i]);
+    }
+  }
+}
+
+// Non-templated test for unsupported encodings and bool dictionary.
+class DictionaryApiTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    pool_ = facebook::velox::memory::deprecatedAddDefaultLeafMemoryPool();
+    buffer_ = std::make_unique<nimble::Buffer>(*pool_);
+  }
+
+  std::shared_ptr<velox::memory::MemoryPool> pool_;
+  std::unique_ptr<nimble::Buffer> buffer_;
+  std::vector<velox::BufferPtr> stringBuffers_;
+};
+
+// Verifies that every non-dictionary encoding type returns
+// dictionaryEnabled()=false and aborts on dictionary-specific methods.
+TEST_F(DictionaryApiTest, unsupportedEncodings) {
+  auto verifyUnsupported = [](nimble::Encoding& enc, const char* name) {
+    SCOPED_TRACE(name);
+    EXPECT_FALSE(enc.dictionaryEnabled());
+    EXPECT_THROW(enc.dictionarySize(), nimble::NimbleInternalError);
+    EXPECT_THROW(enc.dictionaryEntry(0), nimble::NimbleInternalError);
+    EXPECT_THROW(enc.dictionaryEntries(), nimble::NimbleInternalError);
+  };
+
+  // Trivial<string_view>
+  {
+    nimble::Vector<std::string_view> vals{pool_.get()};
+    vals.push_back("a");
+    vals.push_back("b");
+    auto span = std::span<const std::string_view>(vals.data(), vals.size());
+    nimble::EncodingSelection<std::string_view> sel{
+        {.encodingType = nimble::EncodingType::Trivial},
+        nimble::Statistics<std::string_view>::create(span),
+        std::make_unique<TestTrivialEncodingSelectionPolicy<std::string_view>>(
+            false, false)};
+    auto encoded =
+        nimble::TrivialEncoding<std::string_view>::encode(sel, span, *buffer_);
+    auto enc = nimble::EncodingFactory().create(
+        *pool_, encoded, [this](uint32_t size) {
+          stringBuffers_.push_back(
+              velox::AlignedBuffer::allocate<char>(size, pool_.get()));
+          return stringBuffers_.back()->asMutable<void>();
+        });
+    verifyUnsupported(*enc, "Trivial");
+  }
+
+  // Constant<uint32_t>
+  {
+    std::vector<uint32_t> data(10, 42);
+    auto span = std::span<const uint32_t>(data);
+    nimble::EncodingSelection<uint32_t> sel{
+        {.encodingType = nimble::EncodingType::Constant},
+        nimble::Statistics<uint32_t>::create(span),
+        std::make_unique<TestTrivialEncodingSelectionPolicy<uint32_t>>(
+            false, false)};
+    auto encoded =
+        nimble::ConstantEncoding<uint32_t>::encode(sel, span, *buffer_);
+    auto enc = nimble::EncodingFactory().create(*pool_, encoded, nullptr);
+    verifyUnsupported(*enc, "Constant");
+  }
+
+  // RLE<uint32_t>
+  {
+    std::vector<uint32_t> data(10, 5);
+    auto span = std::span<const uint32_t>(data);
+    nimble::EncodingSelection<uint32_t> sel{
+        {.encodingType = nimble::EncodingType::RLE},
+        nimble::Statistics<uint32_t>::create(span),
+        std::make_unique<TestTrivialEncodingSelectionPolicy<uint32_t>>(
+            false, false)};
+    auto encoded = nimble::RLEEncoding<uint32_t>::encode(sel, span, *buffer_);
+    auto enc = nimble::EncodingFactory().create(*pool_, encoded, nullptr);
+    verifyUnsupported(*enc, "RLE");
+  }
+
+  // FixedBitWidth<uint32_t>
+  {
+    std::vector<uint32_t> data = {1, 3, 7, 15};
+    auto span = std::span<const uint32_t>(data);
+    nimble::EncodingSelection<uint32_t> sel{
+        {.encodingType = nimble::EncodingType::FixedBitWidth},
+        nimble::Statistics<uint32_t>::create(span),
+        std::make_unique<TestTrivialEncodingSelectionPolicy<uint32_t>>(
+            false, false)};
+    auto encoded =
+        nimble::FixedBitWidthEncoding<uint32_t>::encode(sel, span, *buffer_);
+    auto enc = nimble::EncodingFactory().create(*pool_, encoded, nullptr);
+    verifyUnsupported(*enc, "FixedBitWidth");
+  }
+
+  // MainlyConstant<uint32_t>
+  {
+    std::vector<uint32_t> data(10, 99);
+    data.push_back(1);
+    auto span = std::span<const uint32_t>(data);
+    nimble::EncodingSelection<uint32_t> sel{
+        {.encodingType = nimble::EncodingType::MainlyConstant},
+        nimble::Statistics<uint32_t>::create(span),
+        std::make_unique<TestTrivialEncodingSelectionPolicy<uint32_t>>(
+            false, false)};
+    auto encoded =
+        nimble::MainlyConstantEncoding<uint32_t>::encode(sel, span, *buffer_);
+    auto enc = nimble::EncodingFactory().create(*pool_, encoded, nullptr);
+    verifyUnsupported(*enc, "MainlyConstant");
+  }
+
+  // SparseBool
+  {
+    nimble::Vector<bool> vals{pool_.get()};
+    for (int i = 0; i < 10; ++i) {
+      vals.push_back(i != 5);
+    }
+    auto span = std::span<const bool>(vals.data(), vals.size());
+    nimble::EncodingSelection<bool> sel{
+        {.encodingType = nimble::EncodingType::SparseBool},
+        nimble::Statistics<bool>::create(span),
+        std::make_unique<TestTrivialEncodingSelectionPolicy<bool>>(
+            false, false)};
+    auto encoded = nimble::SparseBoolEncoding::encode(sel, span, *buffer_);
+    auto enc = nimble::EncodingFactory().create(*pool_, encoded, nullptr);
+    verifyUnsupported(*enc, "SparseBool");
+  }
+
+  // Varint<uint64_t>
+  {
+    std::vector<uint64_t> data = {100, 200, 300};
+    auto span = std::span<const uint64_t>(data);
+    nimble::EncodingSelection<uint64_t> sel{
+        {.encodingType = nimble::EncodingType::Varint},
+        nimble::Statistics<uint64_t>::create(span),
+        std::make_unique<TestTrivialEncodingSelectionPolicy<uint64_t>>(
+            false, false)};
+    auto encoded =
+        nimble::VarintEncoding<uint64_t>::encode(sel, span, *buffer_);
+    auto enc = nimble::EncodingFactory().create(*pool_, encoded, nullptr);
+    verifyUnsupported(*enc, "Varint");
+  }
+
+  // Delta<uint32_t>
+  {
+    std::vector<uint32_t> data = {10, 20, 30};
+    auto span = std::span<const uint32_t>(data);
+    nimble::EncodingSelection<uint32_t> sel{
+        {.encodingType = nimble::EncodingType::Delta},
+        nimble::Statistics<uint32_t>::create(span),
+        std::make_unique<TestTrivialEncodingSelectionPolicy<uint32_t>>(
+            false, false)};
+    auto encoded = nimble::DeltaEncoding<uint32_t>::encode(sel, span, *buffer_);
+    auto enc = nimble::EncodingFactory().create(*pool_, encoded, nullptr);
+    verifyUnsupported(*enc, "Delta");
   }
 }

--- a/dwio/nimble/encodings/tests/ReadWithVisitorTest.cpp
+++ b/dwio/nimble/encodings/tests/ReadWithVisitorTest.cpp
@@ -41,9 +41,11 @@
 #include "dwio/nimble/velox/selective/ReaderBase.h"
 #include "dwio/nimble/velox/selective/RowSizeTracker.h"
 #include "dwio/nimble/velox/selective/StringColumnReader.h"
+#include "folly/Random.h"
 #include "velox/dwio/common/ColumnVisitors.h"
 #include "velox/dwio/common/SelectiveColumnReader.h"
 #include "velox/dwio/common/SelectiveStructColumnReader.h"
+#include "velox/vector/fuzzer/VectorFuzzer.h"
 #include "velox/vector/tests/utils/VectorTestBase.h"
 
 namespace facebook::nimble {
@@ -65,6 +67,40 @@ class IntegerColumnReaderTestAccessor : public IntegerColumnReader {
   void
   doPrepareRead(int64_t offset, const RowSet& rows, const uint64_t* nulls) {
     this->template prepareRead<T>(offset, rows, nulls);
+  }
+
+  const int32_t* rawIndices() const {
+    return reinterpret_cast<const int32_t*>(rawValues_);
+  }
+
+  void advanceReadOffset(const RowSet& rows) {
+    readOffset_ += rows.back() + 1;
+  }
+};
+
+// ---------------------------------------------------------------------------
+// Test-only accessor for StringColumnReader: exposes prepareRead<int32_t>
+// and rawValues_ so tests can call readIndicesWithVisitor and verify the
+// indices stored in the reader's buffer.
+// No new data members — static_cast from StringColumnReader* is layout-safe.
+// ---------------------------------------------------------------------------
+class StringColumnReaderTestAccessor : public StringColumnReader {
+ public:
+  using StringColumnReader::StringColumnReader;
+
+  void doPrepareReadAsIndices(
+      int64_t offset,
+      const RowSet& rows,
+      const uint64_t* nulls) {
+    this->template prepareRead<int32_t>(offset, rows, nulls);
+  }
+
+  ChunkedDecoder& chunkedDecoder() {
+    return decoder_;
+  }
+
+  const int32_t* rawIndices() const {
+    return reinterpret_cast<const int32_t*>(rawValues_);
   }
 
   void advanceReadOffset(const RowSet& rows) {
@@ -2260,6 +2296,760 @@ TEST_P(ReadWithVisitorTest, encodingLevel_Delta_AlwaysTrue_Dense_SlowPath) {
   auto values = getValues<int64_t>(reader);
   for (int i = 0; i < kRows; ++i) {
     EXPECT_EQ(values[i], i * 3) << "row " << i;
+  }
+}
+
+// ===========================================================================
+// Test: readIndicesWithVisitor at the encoding level.
+TEST_P(ReadWithVisitorTest, readIndicesWithVisitorString) {
+  if (!useNonLegacy()) {
+    GTEST_SKIP() << "readIndicesWithVisitor requires non-legacy encoding";
+  }
+  constexpr int kRows = 50;
+  constexpr std::string_view kAlphabet[] = {"alpha", "bravo", "charlie"};
+
+  // Write the same data to get reader infrastructure.
+  auto input = makeRowVector({makeFlatVector<StringView>(
+      kRows, [&](auto i) { return StringView(kAlphabet[i % 3]); })});
+  auto rowType = asRowType(input->type());
+  auto ctx = makeFileContext(input);
+  auto scanSpec = std::make_shared<common::ScanSpec>("root");
+  scanSpec->addAllChildFields(*rowType);
+  auto root = buildReader(*ctx, rowType, *scanSpec);
+
+  auto* structReader =
+      dynamic_cast<dwio::common::SelectiveStructColumnReaderBase*>(root.get());
+  auto* reader =
+      static_cast<StringColumnReaderTestAccessor*>(structReader->children()[0]);
+  ASSERT_NE(reader, nullptr);
+
+  std::vector<vector_size_t> rowVec(kRows);
+  std::iota(rowVec.begin(), rowVec.end(), 0);
+  RowSet rows(rowVec.data(), rowVec.size());
+  reader->doPrepareReadAsIndices(0, rows, nullptr);
+
+  // Encode the same data as DictionaryEncoding independently.
+  nimble::Vector<std::string_view> vec{pool()};
+  for (int i = 0; i < kRows; ++i) {
+    vec.push_back(kAlphabet[i % 3]);
+  }
+  auto span = std::span<const std::string_view>(vec.data(), vec.size());
+  nimble::EncodingSelection<std::string_view> selection{
+      {.encodingType = nimble::EncodingType::Dictionary},
+      nimble::Statistics<std::string_view>::create(span),
+      std::make_unique<TrivialNestedPolicy<std::string_view>>()};
+  Buffer encBuffer(*pool());
+  auto encoded = nimble::DictionaryEncoding<std::string_view>::encode(
+      selection, span, encBuffer);
+  std::vector<velox::BufferPtr> stringBuffers;
+  auto encoding =
+      std::make_unique<nimble::DictionaryEncoding<std::string_view>>(
+          *pool(), encoded, [&](uint32_t size) {
+            stringBuffers.push_back(
+                velox::AlignedBuffer::allocate<char>(size, pool()));
+            return stringBuffers.back()->asMutable<void>();
+          });
+
+  ASSERT_TRUE(encoding->dictionaryEnabled());
+  const auto alphabetSize = encoding->dictionarySize();
+  const auto* alphabet =
+      static_cast<const std::string_view*>(encoding->dictionaryEntries());
+
+  // Build visitor that writes int32 indices to the reader's rawValues_.
+  common::AlwaysTrue filter;
+  dwio::common::ExtractToReader extractValues(reader);
+  DecoderVisitor<
+      int32_t,
+      common::AlwaysTrue,
+      dwio::common::ExtractToReader,
+      /*isDense=*/true>
+      visitor(filter, reader, rows, extractValues);
+  auto params = makeReadWithVisitorParams(visitor, rows, pool());
+
+  encoding->readIndicesWithVisitor(visitor, params);
+
+  ASSERT_EQ(reader->numValues(), kRows);
+  const auto* indices = reader->rawIndices();
+  for (int i = 0; i < kRows; ++i) {
+    ASSERT_GE(indices[i], 0) << "row " << i;
+    ASSERT_LT(indices[i], static_cast<int32_t>(alphabetSize)) << "row " << i;
+    EXPECT_EQ(alphabet[indices[i]], kAlphabet[i % 3]) << "row " << i;
+  }
+}
+
+// Test: Fuzz readIndicesWithVisitor at the encoding level.
+// Random string data, verifies indices map to correct alphabet entries.
+TEST_P(ReadWithVisitorTest, fuzzReadIndicesWithVisitorString) {
+  if (!useNonLegacy()) {
+    GTEST_SKIP() << "readIndicesWithVisitor requires non-legacy encoding";
+  }
+  auto seed = folly::Random::rand32();
+  LOG(INFO) << "seed: " << seed;
+  std::mt19937 rng(seed);
+
+  constexpr int kNumRuns = 10;
+
+  for (int run = 0; run < kNumRuns; ++run) {
+    const int numRows = 20 + rng() % 100;
+    const int cardinality = 2 + rng() % 8;
+
+    SCOPED_TRACE(fmt::format("run={} seed={} numRows={}", run, seed, numRows));
+
+    // Generate random alphabet.
+    std::vector<std::string> pool;
+    for (int j = 0; j < cardinality; ++j) {
+      int len = rng() % 20;
+      std::string s = fmt::format("{}:", j);
+      for (int k = 0; k < len; ++k) {
+        s += static_cast<char>('a' + rng() % 26);
+      }
+      pool.push_back(std::move(s));
+    }
+
+    // Generate data sampling from the pool.
+    std::vector<std::string_view> data;
+    data.reserve(numRows);
+    for (int i = 0; i < numRows; ++i) {
+      data.push_back(pool[rng() % pool.size()]);
+    }
+
+    // Build reader infrastructure from the same data.
+    auto input = makeRowVector({makeFlatVector<StringView>(
+        numRows, [&](auto i) { return StringView(data[i]); })});
+    auto rowType = asRowType(input->type());
+    auto ctx = makeFileContext(input);
+    auto scanSpec = std::make_shared<common::ScanSpec>("root");
+    scanSpec->addAllChildFields(*rowType);
+    auto root = buildReader(*ctx, rowType, *scanSpec);
+
+    auto* structReader =
+        dynamic_cast<dwio::common::SelectiveStructColumnReaderBase*>(
+            root.get());
+    auto* reader = static_cast<StringColumnReaderTestAccessor*>(
+        structReader->children()[0]);
+
+    std::vector<vector_size_t> rowVec(numRows);
+    std::iota(rowVec.begin(), rowVec.end(), 0);
+    RowSet rows(rowVec.data(), rowVec.size());
+    reader->doPrepareReadAsIndices(0, rows, nullptr);
+
+    // Encode independently as DictionaryEncoding.
+    nimble::Vector<std::string_view> vec{this->pool()};
+    for (auto& d : data) {
+      vec.push_back(d);
+    }
+    auto span = std::span<const std::string_view>(vec.data(), vec.size());
+    nimble::EncodingSelection<std::string_view> selection{
+        {.encodingType = nimble::EncodingType::Dictionary},
+        nimble::Statistics<std::string_view>::create(span),
+        std::make_unique<TrivialNestedPolicy<std::string_view>>()};
+    Buffer encBuffer(*this->pool());
+    auto encoded = nimble::DictionaryEncoding<std::string_view>::encode(
+        selection, span, encBuffer);
+    std::vector<velox::BufferPtr> stringBuffers;
+    auto encoding =
+        std::make_unique<nimble::DictionaryEncoding<std::string_view>>(
+            *this->pool(), encoded, [&](uint32_t size) {
+              stringBuffers.push_back(
+                  velox::AlignedBuffer::allocate<char>(size, this->pool()));
+              return stringBuffers.back()->asMutable<void>();
+            });
+
+    const auto alphabetSize = encoding->dictionarySize();
+    const auto* alphabet =
+        static_cast<const std::string_view*>(encoding->dictionaryEntries());
+
+    common::AlwaysTrue filter;
+    dwio::common::ExtractToReader extractValues(reader);
+    DecoderVisitor<
+        int32_t,
+        common::AlwaysTrue,
+        dwio::common::ExtractToReader,
+        /*isDense=*/true>
+        visitor(filter, reader, rows, extractValues);
+    auto params = makeReadWithVisitorParams(visitor, rows, this->pool());
+
+    encoding->readIndicesWithVisitor(visitor, params);
+
+    ASSERT_EQ(reader->numValues(), numRows);
+    const auto* indices = reader->rawIndices();
+    for (int i = 0; i < numRows; ++i) {
+      ASSERT_GE(indices[i], 0) << "row " << i;
+      ASSERT_LT(indices[i], static_cast<int32_t>(alphabetSize)) << "row " << i;
+      EXPECT_EQ(alphabet[indices[i]], data[i]) << "row " << i;
+    }
+  }
+}
+
+// ===========================================================================
+// Test: readIndicesWithVisitor on integer DictionaryEncoding (multiple types).
+// ===========================================================================
+TEST_P(ReadWithVisitorTest, readIndicesWithVisitorInteger) {
+  if (!useNonLegacy()) {
+    GTEST_SKIP() << "readIndicesWithVisitor requires non-legacy encoding";
+  }
+
+  auto runForType = [&]<typename T>(T) {
+    SCOPED_TRACE(fmt::format("type size = {}", sizeof(T)));
+    constexpr int kRows = 50;
+    const T kAlphabet[] = {T(10), T(20), T(30)};
+
+    auto input = makeRowVector(
+        {makeFlatVector<T>(kRows, [&](auto i) { return kAlphabet[i % 3]; })});
+    auto rowType = asRowType(input->type());
+    auto ctx = makeFileContext(input);
+    auto scanSpec = std::make_shared<common::ScanSpec>("root");
+    scanSpec->addAllChildFields(*rowType);
+    auto root = buildReader(*ctx, rowType, *scanSpec);
+
+    auto* structReader =
+        dynamic_cast<dwio::common::SelectiveStructColumnReaderBase*>(
+            root.get());
+    auto* reader = static_cast<IntegerColumnReaderTestAccessor*>(
+        dynamic_cast<IntegerColumnReader*>(structReader->children()[0]));
+    ASSERT_NE(reader, nullptr);
+
+    std::vector<vector_size_t> rowVec(kRows);
+    std::iota(rowVec.begin(), rowVec.end(), 0);
+    RowSet rows(rowVec.data(), rowVec.size());
+    reader->doPrepareRead<int32_t>(0, rows, nullptr);
+
+    using PhysicalType = nimble::TypeTraits<T>::physicalType;
+    nimble::Vector<T> vec{pool()};
+    for (int i = 0; i < kRows; ++i) {
+      vec.push_back(kAlphabet[i % 3]);
+    }
+    auto span = std::span<const PhysicalType>(
+        reinterpret_cast<const PhysicalType*>(vec.data()), vec.size());
+    nimble::EncodingSelection<PhysicalType> selection{
+        {.encodingType = nimble::EncodingType::Dictionary},
+        nimble::Statistics<PhysicalType>::create(span),
+        std::make_unique<TrivialNestedPolicy<T>>()};
+    Buffer encBuffer(*pool());
+    auto encoded =
+        nimble::DictionaryEncoding<T>::encode(selection, span, encBuffer);
+    auto encoding = std::make_unique<nimble::DictionaryEncoding<T>>(
+        *pool(), encoded, nullptr);
+
+    ASSERT_TRUE(encoding->dictionaryEnabled());
+    const auto alphabetSize = encoding->dictionarySize();
+    const auto* alphabet = static_cast<const T*>(encoding->dictionaryEntries());
+
+    common::AlwaysTrue filter;
+    dwio::common::ExtractToReader extractValues(reader);
+    DecoderVisitor<
+        int32_t,
+        common::AlwaysTrue,
+        dwio::common::ExtractToReader,
+        /*isDense=*/true>
+        visitor(filter, reader, rows, extractValues);
+    auto params = makeReadWithVisitorParams(visitor, rows, pool());
+
+    encoding->readIndicesWithVisitor(visitor, params);
+
+    ASSERT_EQ(reader->numValues(), kRows);
+    const auto* indices = reader->rawIndices();
+    for (int i = 0; i < kRows; ++i) {
+      ASSERT_GE(indices[i], 0) << "row " << i;
+      ASSERT_LT(indices[i], static_cast<int32_t>(alphabetSize)) << "row " << i;
+      EXPECT_EQ(alphabet[indices[i]], kAlphabet[i % 3]) << "row " << i;
+    }
+  };
+
+  runForType(int16_t{});
+  runForType(int32_t{});
+  runForType(int64_t{});
+}
+
+// ===========================================================================
+// Test: Fuzz readIndicesWithVisitor on integer DictionaryEncoding.
+// ===========================================================================
+TEST_P(ReadWithVisitorTest, fuzzReadIndicesWithVisitorInteger) {
+  if (!useNonLegacy()) {
+    GTEST_SKIP() << "readIndicesWithVisitor requires non-legacy encoding";
+  }
+  auto seed = folly::Random::rand32();
+  LOG(INFO) << "seed: " << seed;
+  std::mt19937 rng(seed);
+
+  constexpr int kNumRuns = 10;
+
+  auto runForType = [&]<typename T>(T, int run) {
+    const int numRows = 20 + rng() % 100;
+    const int cardinality = 2 + rng() % 8;
+
+    SCOPED_TRACE(
+        fmt::format(
+            "run={} seed={} numRows={} typeSize={}",
+            run,
+            seed,
+            numRows,
+            sizeof(T)));
+
+    std::vector<T> alphabet;
+    for (int j = 0; j < cardinality; ++j) {
+      alphabet.push_back(static_cast<T>(j * 7 + 1));
+    }
+
+    std::vector<T> data;
+    data.reserve(numRows);
+    for (int i = 0; i < numRows; ++i) {
+      data.push_back(alphabet[rng() % alphabet.size()]);
+    }
+
+    auto input = makeRowVector(
+        {makeFlatVector<T>(numRows, [&](auto i) { return data[i]; })});
+    auto rowType = asRowType(input->type());
+    auto ctx = makeFileContext(input);
+    auto scanSpec = std::make_shared<common::ScanSpec>("root");
+    scanSpec->addAllChildFields(*rowType);
+    auto root = buildReader(*ctx, rowType, *scanSpec);
+
+    auto* structReader =
+        dynamic_cast<dwio::common::SelectiveStructColumnReaderBase*>(
+            root.get());
+    auto* reader = static_cast<IntegerColumnReaderTestAccessor*>(
+        dynamic_cast<IntegerColumnReader*>(structReader->children()[0]));
+    ASSERT_NE(reader, nullptr);
+
+    std::vector<vector_size_t> rowVec(numRows);
+    std::iota(rowVec.begin(), rowVec.end(), 0);
+    RowSet rows(rowVec.data(), rowVec.size());
+    reader->doPrepareRead<int32_t>(0, rows, nullptr);
+
+    using PhysicalType = nimble::TypeTraits<T>::physicalType;
+    nimble::Vector<T> vec{this->pool()};
+    for (auto& d : data) {
+      vec.push_back(d);
+    }
+    auto span = std::span<const PhysicalType>(
+        reinterpret_cast<const PhysicalType*>(vec.data()), vec.size());
+    nimble::EncodingSelection<PhysicalType> selection{
+        {.encodingType = nimble::EncodingType::Dictionary},
+        nimble::Statistics<PhysicalType>::create(span),
+        std::make_unique<TrivialNestedPolicy<T>>()};
+    Buffer encBuffer(*this->pool());
+    auto encoded =
+        nimble::DictionaryEncoding<T>::encode(selection, span, encBuffer);
+    auto encoding = std::make_unique<nimble::DictionaryEncoding<T>>(
+        *this->pool(), encoded, nullptr);
+
+    ASSERT_TRUE(encoding->dictionaryEnabled());
+    const auto alphabetSize = encoding->dictionarySize();
+    const auto* entries = static_cast<const T*>(encoding->dictionaryEntries());
+
+    common::AlwaysTrue filter;
+    dwio::common::ExtractToReader extractValues(reader);
+    DecoderVisitor<
+        int32_t,
+        common::AlwaysTrue,
+        dwio::common::ExtractToReader,
+        /*isDense=*/true>
+        visitor(filter, reader, rows, extractValues);
+    auto params = makeReadWithVisitorParams(visitor, rows, this->pool());
+
+    encoding->readIndicesWithVisitor(visitor, params);
+
+    ASSERT_EQ(reader->numValues(), numRows);
+    const auto* indices = reader->rawIndices();
+    for (int i = 0; i < numRows; ++i) {
+      ASSERT_GE(indices[i], 0) << "row " << i;
+      ASSERT_LT(indices[i], static_cast<int32_t>(alphabetSize)) << "row " << i;
+      EXPECT_EQ(entries[indices[i]], data[i]) << "row " << i;
+    }
+  };
+
+  for (int run = 0; run < kNumRuns; ++run) {
+    switch (run % 3) {
+      case 0:
+        runForType(int16_t{}, run);
+        break;
+      case 1:
+        runForType(int32_t{}, run);
+        break;
+      case 2:
+        runForType(int64_t{}, run);
+        break;
+    }
+  }
+}
+
+// ===========================================================================
+// Test: readIndicesWithVisitor on NullableEncoding<DictionaryEncoding<string>>.
+// ===========================================================================
+TEST_P(ReadWithVisitorTest, readIndicesWithVisitorNullable) {
+  if (!useNonLegacy()) {
+    GTEST_SKIP() << "readIndicesWithVisitor requires non-legacy encoding";
+  }
+  constexpr int kRows = 50;
+  constexpr std::string_view kAlphabet[] = {"alpha", "bravo", "charlie"};
+
+  auto input = makeRowVector({makeFlatVector<StringView>(
+      kRows,
+      [&](auto i) { return StringView(kAlphabet[i % 3]); },
+      nullEvery(5))});
+  auto rowType = asRowType(input->type());
+  auto ctx = makeFileContext(input);
+  auto scanSpec = std::make_shared<common::ScanSpec>("root");
+  scanSpec->addAllChildFields(*rowType);
+  auto root = buildReader(*ctx, rowType, *scanSpec);
+
+  auto* structReader =
+      dynamic_cast<dwio::common::SelectiveStructColumnReaderBase*>(root.get());
+  auto* reader =
+      static_cast<StringColumnReaderTestAccessor*>(structReader->children()[0]);
+  ASSERT_NE(reader, nullptr);
+
+  std::vector<vector_size_t> rowVec(kRows);
+  std::iota(rowVec.begin(), rowVec.end(), 0);
+  RowSet rows(rowVec.data(), rowVec.size());
+  reader->doPrepareReadAsIndices(0, rows, nullptr);
+
+  nimble::Vector<std::string_view> nonNullVec{pool()};
+  for (int i = 0; i < kRows; ++i) {
+    if (i % 5 != 0) {
+      nonNullVec.push_back(kAlphabet[i % 3]);
+    }
+  }
+  auto nonNullSpan =
+      std::span<const std::string_view>(nonNullVec.data(), nonNullVec.size());
+  nimble::EncodingSelection<std::string_view> valSelection{
+      {.encodingType = nimble::EncodingType::Dictionary},
+      nimble::Statistics<std::string_view>::create(nonNullSpan),
+      std::make_unique<TrivialNestedPolicy<std::string_view>>()};
+  Buffer valBuffer(*pool());
+  auto serializedValues = nimble::DictionaryEncoding<std::string_view>::encode(
+      valSelection, nonNullSpan, valBuffer);
+
+  nimble::Vector<bool> nullBits{pool()};
+  for (int i = 0; i < kRows; ++i) {
+    nullBits.push_back(i % 5 != 0);
+  }
+  auto nullSpan = std::span<const bool>(nullBits.data(), nullBits.size());
+  nimble::EncodingSelection<bool> nullSelection{
+      {.encodingType = nimble::EncodingType::Trivial},
+      nimble::Statistics<bool>::create(nullSpan),
+      std::make_unique<TrivialNestedPolicy<bool>>()};
+  Buffer nullBuffer(*pool());
+  auto serializedNulls = nimble::TrivialEncoding<bool>::encode(
+      nullSelection, nullSpan, nullBuffer);
+
+  const uint32_t encodingSize = nimble::Encoding::kPrefixSize + 4 +
+      serializedValues.size() + serializedNulls.size();
+  Buffer assemblyBuffer(*pool());
+  char* reserved = assemblyBuffer.reserve(encodingSize);
+  char* pos = reserved;
+  nimble::encoding::writeChar(
+      static_cast<char>(nimble::EncodingType::Nullable), pos);
+  nimble::encoding::writeChar(static_cast<char>(nimble::DataType::String), pos);
+  nimble::encoding::writeUint32(kRows, pos);
+  nimble::encoding::writeString(serializedValues, pos);
+  nimble::encoding::writeBytes(serializedNulls, pos);
+
+  std::vector<velox::BufferPtr> stringBuffers;
+  auto encoding = nimble::EncodingFactory().create(
+      *pool(), std::string_view(reserved, encodingSize), [&](uint32_t size) {
+        stringBuffers.push_back(
+            velox::AlignedBuffer::allocate<char>(size, pool()));
+        return stringBuffers.back()->asMutable<void>();
+      });
+
+  ASSERT_TRUE(encoding->isNullable());
+  ASSERT_TRUE(encoding->dictionaryEnabled());
+  const auto alphabetSize = encoding->dictionarySize();
+  const auto* alphabet =
+      static_cast<const std::string_view*>(encoding->dictionaryEntries());
+
+  common::AlwaysTrue filter;
+  dwio::common::ExtractToReader extractValues(reader);
+  DecoderVisitor<
+      int32_t,
+      common::AlwaysTrue,
+      dwio::common::ExtractToReader,
+      /*isDense=*/true>
+      visitor(filter, reader, rows, extractValues);
+  auto params = makeReadWithVisitorParams(visitor, rows, pool());
+
+  static_cast<NullableEncoding<std::string_view>&>(*encoding)
+      .readIndicesWithVisitor(visitor, params);
+
+  ASSERT_EQ(reader->numValues(), kRows);
+  const auto* indices = reader->rawIndices();
+  for (int i = 0; i < kRows; ++i) {
+    if (i % 5 == 0) {
+      continue;
+    }
+    ASSERT_GE(indices[i], 0) << "row " << i;
+    ASSERT_LT(indices[i], static_cast<int32_t>(alphabetSize)) << "row " << i;
+    EXPECT_EQ(alphabet[indices[i]], kAlphabet[i % 3]) << "row " << i;
+  }
+}
+
+// ===========================================================================
+// Test: Fuzz readIndicesWithVisitor on NullableEncoding<DictionaryEncoding>.
+// ===========================================================================
+TEST_P(ReadWithVisitorTest, fuzzReadIndicesWithVisitorNullable) {
+  if (!useNonLegacy()) {
+    GTEST_SKIP() << "readIndicesWithVisitor requires non-legacy encoding";
+  }
+  auto seed = folly::Random::rand32();
+  LOG(INFO) << "seed: " << seed;
+  std::mt19937 rng(seed);
+
+  constexpr int kNumRuns = 10;
+
+  for (int run = 0; run < kNumRuns; ++run) {
+    const int numRows = 20 + rng() % 100;
+    const int cardinality = 2 + rng() % 8;
+
+    SCOPED_TRACE(fmt::format("run={} seed={} numRows={}", run, seed, numRows));
+
+    std::vector<std::string> stringPool;
+    for (int j = 0; j < cardinality; ++j) {
+      int len = rng() % 20;
+      std::string s = fmt::format("{}:", j);
+      for (int k = 0; k < len; ++k) {
+        s += static_cast<char>('a' + rng() % 26);
+      }
+      stringPool.push_back(std::move(s));
+    }
+
+    std::vector<std::string_view> data;
+    nimble::Vector<bool> nullBits{pool()};
+    data.reserve(numRows);
+    for (int i = 0; i < numRows; ++i) {
+      bool isNull = (rng() % 5 == 0);
+      nullBits.push_back(!isNull);
+      data.push_back(stringPool[rng() % stringPool.size()]);
+    }
+
+    nimble::Vector<std::string_view> nonNullVec{pool()};
+    for (int i = 0; i < numRows; ++i) {
+      if (nullBits[i]) {
+        nonNullVec.push_back(data[i]);
+      }
+    }
+
+    if (nonNullVec.empty()) {
+      continue;
+    }
+
+    auto input = makeRowVector({makeFlatVector<StringView>(
+        numRows,
+        [&](auto i) { return StringView(data[i]); },
+        [&](auto i) { return !nullBits[i]; })});
+    auto rowType = asRowType(input->type());
+    auto ctx = makeFileContext(input);
+    auto scanSpec = std::make_shared<common::ScanSpec>("root");
+    scanSpec->addAllChildFields(*rowType);
+    auto root = buildReader(*ctx, rowType, *scanSpec);
+
+    auto* structReader =
+        dynamic_cast<dwio::common::SelectiveStructColumnReaderBase*>(
+            root.get());
+    auto* reader = static_cast<StringColumnReaderTestAccessor*>(
+        structReader->children()[0]);
+
+    std::vector<vector_size_t> rowVec(numRows);
+    std::iota(rowVec.begin(), rowVec.end(), 0);
+    RowSet rows(rowVec.data(), rowVec.size());
+    reader->doPrepareReadAsIndices(0, rows, nullptr);
+
+    auto nonNullSpan =
+        std::span<const std::string_view>(nonNullVec.data(), nonNullVec.size());
+    nimble::EncodingSelection<std::string_view> valSelection{
+        {.encodingType = nimble::EncodingType::Dictionary},
+        nimble::Statistics<std::string_view>::create(nonNullSpan),
+        std::make_unique<TrivialNestedPolicy<std::string_view>>()};
+    Buffer valBuffer(*this->pool());
+    auto serializedValues =
+        nimble::DictionaryEncoding<std::string_view>::encode(
+            valSelection, nonNullSpan, valBuffer);
+
+    auto nullSpan = std::span<const bool>(nullBits.data(), nullBits.size());
+    nimble::EncodingSelection<bool> nullSelection{
+        {.encodingType = nimble::EncodingType::Trivial},
+        nimble::Statistics<bool>::create(nullSpan),
+        std::make_unique<TrivialNestedPolicy<bool>>()};
+    Buffer nullBuffer(*this->pool());
+    auto serializedNulls = nimble::TrivialEncoding<bool>::encode(
+        nullSelection, nullSpan, nullBuffer);
+
+    const uint32_t encodingSize = nimble::Encoding::kPrefixSize + 4 +
+        serializedValues.size() + serializedNulls.size();
+    Buffer assemblyBuffer(*this->pool());
+    char* reserved = assemblyBuffer.reserve(encodingSize);
+    char* pos = reserved;
+    nimble::encoding::writeChar(
+        static_cast<char>(nimble::EncodingType::Nullable), pos);
+    nimble::encoding::writeChar(
+        static_cast<char>(nimble::DataType::String), pos);
+    nimble::encoding::writeUint32(numRows, pos);
+    nimble::encoding::writeString(serializedValues, pos);
+    nimble::encoding::writeBytes(serializedNulls, pos);
+
+    std::vector<velox::BufferPtr> stringBuffers;
+    auto encoding = nimble::EncodingFactory().create(
+        *this->pool(),
+        std::string_view(reserved, encodingSize),
+        [&](uint32_t size) {
+          stringBuffers.push_back(
+              velox::AlignedBuffer::allocate<char>(size, this->pool()));
+          return stringBuffers.back()->asMutable<void>();
+        });
+
+    ASSERT_TRUE(encoding->isNullable());
+    ASSERT_TRUE(encoding->dictionaryEnabled());
+    const auto alphabetSize = encoding->dictionarySize();
+    const auto* alphabet =
+        static_cast<const std::string_view*>(encoding->dictionaryEntries());
+
+    common::AlwaysTrue filter;
+    dwio::common::ExtractToReader extractValues(reader);
+    DecoderVisitor<
+        int32_t,
+        common::AlwaysTrue,
+        dwio::common::ExtractToReader,
+        /*isDense=*/true>
+        visitor(filter, reader, rows, extractValues);
+    auto params = makeReadWithVisitorParams(visitor, rows, this->pool());
+
+    static_cast<NullableEncoding<std::string_view>&>(*encoding)
+        .readIndicesWithVisitor(visitor, params);
+
+    ASSERT_EQ(reader->numValues(), numRows);
+    const auto* indices = reader->rawIndices();
+    for (int i = 0; i < numRows; ++i) {
+      if (!nullBits[i]) {
+        continue;
+      }
+      ASSERT_GE(indices[i], 0) << "row " << i;
+      ASSERT_LT(indices[i], static_cast<int32_t>(alphabetSize)) << "row " << i;
+      EXPECT_EQ(alphabet[indices[i]], data[i]) << "row " << i;
+    }
+  }
+}
+
+// ===========================================================================
+// Test: Dictionary-encoded string data read through the flat path.
+// Verifies that DictionaryEncoding::readWithVisitor correctly decodes
+// dictionary indices → alphabet lookup → StringView output.
+// ===========================================================================
+TEST_P(ReadWithVisitorTest, stringDictionaryEncoded) {
+  constexpr int kRows = 100;
+  constexpr std::string_view kExpected[] = {"alpha", "bravo", "charlie"};
+  auto input = makeRowVector({makeFlatVector<StringView>(
+      kRows, [&](auto i) { return StringView(kExpected[i % 3]); })});
+  auto rowType = asRowType(input->type());
+
+  auto ctx = makeFileContext(input);
+  auto scanSpec = std::make_shared<common::ScanSpec>("root");
+  scanSpec->addAllChildFields(*rowType);
+  scanSpec->childByName("c0")->setFilter(
+      std::make_unique<common::AlwaysTrue>());
+
+  auto root = buildReader(*ctx, rowType, *scanSpec);
+  auto* child = readColumn(root.get(), kRows);
+
+  ASSERT_EQ(child->numValues(), kRows);
+  auto values = getValues<StringView>(child);
+  for (int i = 0; i < kRows; ++i) {
+    EXPECT_EQ(
+        std::string_view(values[i].data(), values[i].size()), kExpected[i % 3])
+        << "row " << i;
+  }
+}
+
+// ===========================================================================
+// Test: Nullable dictionary-encoded string data.
+// Verifies correct value output when NullableEncoding wraps DictionaryEncoding.
+// ===========================================================================
+TEST_P(ReadWithVisitorTest, stringDictionaryEncodedNullable) {
+  constexpr int kRows = 100;
+  constexpr std::string_view kExpected[] = {"x", "y", "z"};
+  auto input = makeRowVector({makeFlatVector<StringView>(
+      kRows,
+      [&](auto i) { return StringView(kExpected[i % 3]); },
+      nullEvery(7))});
+  auto rowType = asRowType(input->type());
+
+  auto ctx = makeFileContext(input);
+  auto scanSpec = std::make_shared<common::ScanSpec>("root");
+  scanSpec->addAllChildFields(*rowType);
+  scanSpec->childByName("c0")->setFilter(
+      std::make_unique<common::AlwaysTrue>());
+
+  auto root = buildReader(*ctx, rowType, *scanSpec);
+  auto* child = readColumn(root.get(), kRows);
+
+  ASSERT_EQ(child->numValues(), kRows);
+  auto values = getValues<StringView>(child);
+  for (int i = 0; i < kRows; ++i) {
+    if (i % 7 == 0) {
+      continue;
+    }
+    EXPECT_EQ(
+        std::string_view(values[i].data(), values[i].size()), kExpected[i % 3])
+        << "row " << i;
+  }
+}
+
+// ===========================================================================
+// Test: Fuzz string data with VectorFuzzer — exercises DictionaryEncoding
+// readWithVisitor with randomized alphabet content and null patterns.
+// ===========================================================================
+TEST_P(ReadWithVisitorTest, fuzzStringDictionaryEncoded) {
+  auto seed = folly::Random::rand32();
+  LOG(INFO) << "seed: " << seed;
+
+  constexpr int kNumRuns = 10;
+
+  for (int run = 0; run < kNumRuns; ++run) {
+    auto runSeed = seed + run;
+    velox::VectorFuzzer::Options opts;
+    opts.vectorSize = 50 + runSeed % 200;
+    opts.nullRatio = (runSeed % 3 == 0) ? 0.0 : 0.2;
+    opts.stringLength = 1 + runSeed % 20;
+    opts.stringVariableLength = true;
+    velox::VectorFuzzer fuzzer(opts, pool(), runSeed);
+
+    SCOPED_TRACE(
+        fmt::format(
+            "run={} seed={} vectorSize={} nullRatio={}",
+            run,
+            runSeed,
+            opts.vectorSize,
+            opts.nullRatio));
+
+    auto c0 = fuzzer.fuzzFlat(velox::VARCHAR());
+    auto input = makeRowVector({c0});
+    auto rowType = asRowType(input->type());
+
+    auto ctx = makeFileContext(input);
+    auto scanSpec = std::make_shared<common::ScanSpec>("root");
+    scanSpec->addAllChildFields(*rowType);
+    scanSpec->childByName("c0")->setFilter(
+        std::make_unique<common::AlwaysTrue>());
+
+    auto root = buildReader(*ctx, rowType, *scanSpec);
+    auto* child = readColumn(root.get(), opts.vectorSize);
+
+    // Build expected values from the input vector (AlwaysTrue passes all rows).
+    auto* flat = c0->asFlatVector<StringView>();
+    int expectedCount = opts.vectorSize;
+    ASSERT_EQ(child->numValues(), expectedCount);
+
+    auto values = getValues<StringView>(child);
+    for (int i = 0; i < expectedCount; ++i) {
+      if (flat->isNullAt(i)) {
+        continue;
+      }
+      auto expected = flat->valueAt(i);
+      EXPECT_EQ(
+          std::string_view(values[i].data(), values[i].size()),
+          std::string_view(expected.data(), expected.size()))
+          << "row " << i;
+    }
   }
 }
 

--- a/dwio/nimble/velox/selective/StringColumnReader.h
+++ b/dwio/nimble/velox/selective/StringColumnReader.h
@@ -43,12 +43,13 @@ class StringColumnReader : public velox::dwio::common::SelectiveColumnReader {
   bool estimateMaterializedSize(size_t& byteSize, size_t& rowCount)
       const override;
 
+ protected:
+  ChunkedDecoder decoder_;
+
  private:
   bool readsNullsOnly() const final {
     return false;
   }
-
-  ChunkedDecoder decoder_;
 };
 
 } // namespace facebook::nimble


### PR DESCRIPTION
Summary:

Add virtual methods to Encoding for accessing dictionary alphabet data:
- isDictionaryEnabled(): overridden by DictionaryEncoding (true) and NullableEncoding (delegates)
- dictionarySize(): overridden by DictionaryEncoding and NullableEncoding
- dictionaryEntry(index): overridden by DictionaryEncoding and NullableEncoding
- dictionaryEntries(): new, returns contiguous alphabet data as void*

These complement the existing dictionaryEntry(index) API with bulk access,
enabling callers to build alphabet vectors without per-element virtual calls.
NullableEncoding delegates all dictionary methods to its inner encoding.

Reviewed By: xiaoxmeng

Differential Revision: D103504288


