### PR TITLE
refactor: Enforce not-null IoStatistics in ReaderOptions (#690)

### DIFF
--- a/dwio/nimble/encodings/tests/ReadWithVisitorTest.cpp
+++ b/dwio/nimble/encodings/tests/ReadWithVisitorTest.cpp
@@ -42,6 +42,7 @@
 #include "dwio/nimble/velox/selective/RowSizeTracker.h"
 #include "dwio/nimble/velox/selective/StringColumnReader.h"
 #include "folly/Random.h"
+#include "velox/common/io/IoStatistics.h"
 #include "velox/dwio/common/ColumnVisitors.h"
 #include "velox/dwio/common/SelectiveColumnReader.h"
 #include "velox/dwio/common/SelectiveStructColumnReader.h"
@@ -141,7 +142,8 @@ class ReadWithVisitorTest : public ::testing::TestWithParam<bool>,
     ctx->fileData = test::createNimbleFile(*rootPool_, input);
 
     auto readFile = std::make_shared<InMemoryReadFile>(ctx->fileData);
-    dwio::common::ReaderOptions readerOpts(pool());
+    dwio::common::ReaderOptions readerOpts(
+        pool(), dataIoStats_.get(), metadataIoStats_.get());
     ctx->readerBase = ReaderBase::create(
         std::make_unique<dwio::common::BufferedInput>(readFile, *pool()),
         readerOpts);
@@ -250,6 +252,11 @@ class ReadWithVisitorTest : public ::testing::TestWithParam<bool>,
     auto* raw = reinterpret_cast<const T*>(reader->rawValues());
     return std::vector<T>(raw, raw + reader->numValues());
   }
+
+  const std::shared_ptr<io::IoStatistics> dataIoStats_{
+      std::make_shared<io::IoStatistics>()};
+  const std::shared_ptr<io::IoStatistics> metadataIoStats_{
+      std::make_shared<io::IoStatistics>()};
 };
 
 // ===========================================================================

--- a/dwio/nimble/tablet/tests/TabletTest.cpp
+++ b/dwio/nimble/tablet/tests/TabletTest.cpp
@@ -4182,7 +4182,8 @@ TEST_P(TabletTest, configureOptionsIndexFlags) {
     return std::find(sections.begin(), sections.end(), name) != sections.end();
   };
 
-  velox::dwio::common::ReaderOptions readerOptions(pool_.get());
+  velox::dwio::common::ReaderOptions readerOptions(
+      pool_.get(), dataIoStats_.get(), metadataIoStats_.get());
 
   {
     SCOPED_TRACE("defaults");
@@ -4242,7 +4243,8 @@ TEST_P(TabletTest, configureOptionsIndexFlags) {
 TEST_P(TabletTest, configureOptionsBufferedInput) {
   // Verify configureOptions only sets bufferedInput when
   // fileMetadataCacheEnabled is true.
-  velox::dwio::common::ReaderOptions readerOptions(pool_.get());
+  velox::dwio::common::ReaderOptions readerOptions(
+      pool_.get(), dataIoStats_.get(), metadataIoStats_.get());
 
   // Create a dummy BufferedInput to pass as the second parameter.
   std::string emptyFile;

--- a/dwio/nimble/velox/index/tests/NimbleIndexProjectorTest.cpp
+++ b/dwio/nimble/velox/index/tests/NimbleIndexProjectorTest.cpp
@@ -26,6 +26,7 @@
 #include "dwio/nimble/velox/VeloxReader.h"
 #include "dwio/nimble/velox/VeloxWriter.h"
 
+#include "velox/common/io/IoStatistics.h"
 #include "velox/common/memory/Memory.h"
 #include "velox/serializers/KeyEncoder.h"
 #include "velox/vector/tests/utils/VectorMaker.h"
@@ -117,7 +118,8 @@ class NimbleIndexProjectorTest : public ::testing::TestWithParam<TestParam> {
       const std::vector<Subfield>& projectedSubfields) {
     auto readFile =
         std::make_shared<InMemoryReadFile>(std::string_view(sinkData_));
-    dwio::common::ReaderOptions readerOptions(leafPool_.get());
+    dwio::common::ReaderOptions readerOptions(
+        leafPool_.get(), dataIoStats_.get(), metadataIoStats_.get());
     readerOptions.setFileFormat(FileFormat::NIMBLE);
     readerOptions.setFileMetadataCacheEnabled(GetParam().enableCache);
     readerOptions.setPinFileMetadata(GetParam().pinFileMetadata);
@@ -150,6 +152,11 @@ class NimbleIndexProjectorTest : public ::testing::TestWithParam<TestParam> {
     EXPECT_EQ(encoded.size(), 1);
     return encoded[0];
   }
+
+  const std::shared_ptr<io::IoStatistics> dataIoStats_{
+      std::make_shared<io::IoStatistics>()};
+  const std::shared_ptr<io::IoStatistics> metadataIoStats_{
+      std::make_shared<io::IoStatistics>()};
 
   std::shared_ptr<memory::MemoryPool> rootPool_;
   std::shared_ptr<memory::MemoryPool> leafPool_;
@@ -880,7 +887,8 @@ TEST_P(NimbleIndexProjectorTest, featureReorderingStorageReads) {
   auto makeProjector = [&](int32_t maxCoalesceDistance) {
     auto readFile =
         std::make_shared<InMemoryReadFile>(std::string_view(sinkData_));
-    dwio::common::ReaderOptions readerOptions(leafPool_.get());
+    dwio::common::ReaderOptions readerOptions(
+        leafPool_.get(), dataIoStats_.get(), metadataIoStats_.get());
     readerOptions.setFileFormat(FileFormat::NIMBLE);
     readerOptions.setMaxCoalesceDistance(maxCoalesceDistance);
 
@@ -1033,7 +1041,8 @@ TEST_P(NimbleIndexProjectorTest, pinnedMetadataNoReread) {
   const auto metadataBoundary = stripeGroupsMeta[0].offset();
   tablet.reset();
 
-  dwio::common::ReaderOptions readerOptions(leafPool_.get());
+  dwio::common::ReaderOptions readerOptions(
+      leafPool_.get(), dataIoStats_.get(), metadataIoStats_.get());
   readerOptions.setFileFormat(FileFormat::NIMBLE);
   readerOptions.setFileMetadataCacheEnabled(GetParam().enableCache);
   readerOptions.setPinFileMetadata(GetParam().pinFileMetadata);

--- a/dwio/nimble/velox/selective/tests/ChunkedDecoderTest.cpp
+++ b/dwio/nimble/velox/selective/tests/ChunkedDecoderTest.cpp
@@ -99,6 +99,10 @@ class ChunkedDecoderTest : public testing::Test {
     return encodingFactory_;
   }
 
+ protected:
+  io::IoStatistics dataIoStats_;
+  io::IoStatistics metadataIoStats_;
+
  private:
   std::shared_ptr<MemoryPool> leafPool_;
   EncodingFactory encodingFactory_;
@@ -121,7 +125,8 @@ TEST_F(ChunkedDecoderTest, bufferedInput) {
   }
 
   auto file = std::make_shared<InMemoryReadFile>(fileContent);
-  dwio::common::ReaderOptions readerOpts{&pool()};
+  dwio::common::ReaderOptions readerOpts{
+      &pool(), &dataIoStats_, &metadataIoStats_};
   readerOpts.setLoadQuantum(kLoadQuantum);
   auto executor = std::make_unique<folly::IOThreadPoolExecutor>(10, 10);
   auto input = std::make_unique<dwio::common::DirectBufferedInput>(

--- a/dwio/nimble/velox/selective/tests/E2EIndexTest.cpp
+++ b/dwio/nimble/velox/selective/tests/E2EIndexTest.cpp
@@ -337,7 +337,8 @@ class E2EIndexTestBase : public ::testing::Test {
       uint32_t randomSeed = 0) {
     auto readFile =
         std::make_shared<InMemoryReadFile>(std::string_view(sinkData_));
-    dwio::common::ReaderOptions readerOptions(leafPool_.get());
+    dwio::common::ReaderOptions readerOptions(
+        leafPool_.get(), dataIoStats_.get(), metadataIoStats_.get());
     readerOptions.setFileFormat(FileFormat::NIMBLE);
     setUpReaderOptions(readerOptions);
 

--- a/dwio/nimble/velox/selective/tests/FlatMapColumnReaderTest.cpp
+++ b/dwio/nimble/velox/selective/tests/FlatMapColumnReaderTest.cpp
@@ -18,6 +18,7 @@
 
 #include "dwio/nimble/common/tests/NimbleFileWriter.h"
 #include "velox/common/base/tests/GTestUtils.h"
+#include "velox/common/io/IoStatistics.h"
 #include "velox/dwio/common/TypeUtils.h"
 #include "velox/vector/tests/utils/VectorTestBase.h"
 
@@ -70,7 +71,8 @@ class FlatMapColumnReaderTest : public ::testing::TestWithParam<bool>,
     auto readFile = std::make_shared<InMemoryReadFile>(file);
     auto factory =
         dwio::common::getReaderFactory(dwio::common::FileFormat::NIMBLE);
-    dwio::common::ReaderOptions options(pool());
+    dwio::common::ReaderOptions options(
+        pool(), dataIoStats_.get(), metadataIoStats_.get());
     options.setScanSpec(scanSpec);
     Readers readers;
     readers.reader = factory->createReader(
@@ -105,6 +107,11 @@ class FlatMapColumnReaderTest : public ::testing::TestWithParam<bool>,
     ASSERT_EQ(numScanned, expected.size());
     ASSERT_EQ(0, rowReader.next(1, result));
   }
+
+  const std::shared_ptr<io::IoStatistics> dataIoStats_{
+      std::make_shared<io::IoStatistics>()};
+  const std::shared_ptr<io::IoStatistics> metadataIoStats_{
+      std::make_shared<io::IoStatistics>()};
 };
 
 // ----- FlatMapAsStruct tests -----

--- a/dwio/nimble/velox/selective/tests/NimbleDataTest.cpp
+++ b/dwio/nimble/velox/selective/tests/NimbleDataTest.cpp
@@ -18,6 +18,7 @@
 
 #include "dwio/nimble/common/tests/NimbleFileWriter.h"
 #include "velox/common/base/tests/GTestUtils.h"
+#include "velox/common/io/IoStatistics.h"
 #include "velox/dwio/common/TypeUtils.h"
 #include "velox/vector/tests/utils/VectorTestBase.h"
 
@@ -59,7 +60,8 @@ class NimbleDataTest : public ::testing::Test,
     auto readFile = std::make_shared<InMemoryReadFile>(file);
     auto factory =
         dwio::common::getReaderFactory(dwio::common::FileFormat::NIMBLE);
-    dwio::common::ReaderOptions options(pool());
+    dwio::common::ReaderOptions options(
+        pool(), dataIoStats_.get(), metadataIoStats_.get());
     options.setScanSpec(scanSpec);
     Readers readers;
     readers.reader = factory->createReader(
@@ -100,6 +102,11 @@ class NimbleDataTest : public ::testing::Test,
     ASSERT_EQ(numScanned, expected.size());
     ASSERT_EQ(0, rowReader.next(1, result));
   }
+
+  const std::shared_ptr<io::IoStatistics> dataIoStats_{
+      std::make_shared<io::IoStatistics>()};
+  const std::shared_ptr<io::IoStatistics> metadataIoStats_{
+      std::make_shared<io::IoStatistics>()};
 };
 
 // ----- NimbleData null handling tests -----

--- a/dwio/nimble/velox/selective/tests/NullColumnReaderTest.cpp
+++ b/dwio/nimble/velox/selective/tests/NullColumnReaderTest.cpp
@@ -18,6 +18,7 @@
 
 #include "dwio/nimble/common/tests/NimbleFileWriter.h"
 #include "velox/common/base/tests/GTestUtils.h"
+#include "velox/common/io/IoStatistics.h"
 #include "velox/dwio/common/TypeUtils.h"
 #include "velox/vector/tests/utils/VectorTestBase.h"
 
@@ -62,7 +63,8 @@ class NullColumnReaderTest : public ::testing::Test,
     auto readFile = std::make_shared<InMemoryReadFile>(file);
     auto factory =
         dwio::common::getReaderFactory(dwio::common::FileFormat::NIMBLE);
-    dwio::common::ReaderOptions options(pool());
+    dwio::common::ReaderOptions options(
+        pool(), dataIoStats_.get(), metadataIoStats_.get());
     options.setScanSpec(scanSpec);
     Readers readers;
     readers.reader = factory->createReader(
@@ -89,6 +91,11 @@ class NullColumnReaderTest : public ::testing::Test,
     readers.rowReader = readers.reader->createRowReader(rowOptions);
     return readers;
   }
+
+  const std::shared_ptr<io::IoStatistics> dataIoStats_{
+      std::make_shared<io::IoStatistics>()};
+  const std::shared_ptr<io::IoStatistics> metadataIoStats_{
+      std::make_shared<io::IoStatistics>()};
 };
 
 // Write ROW({c0: BIGINT}), read as ROW({c0: BIGINT, c1: BIGINT}).

--- a/dwio/nimble/velox/selective/tests/ScalarColumnReaderTest.cpp
+++ b/dwio/nimble/velox/selective/tests/ScalarColumnReaderTest.cpp
@@ -18,6 +18,7 @@
 
 #include "dwio/nimble/common/tests/NimbleFileWriter.h"
 #include "velox/common/base/tests/GTestUtils.h"
+#include "velox/common/io/IoStatistics.h"
 #include "velox/dwio/common/TypeUtils.h"
 #include "velox/vector/tests/utils/VectorTestBase.h"
 
@@ -61,7 +62,8 @@ class ScalarColumnReaderTest : public ::testing::Test,
     auto readFile = std::make_shared<InMemoryReadFile>(file);
     auto factory =
         dwio::common::getReaderFactory(dwio::common::FileFormat::NIMBLE);
-    dwio::common::ReaderOptions options(pool());
+    dwio::common::ReaderOptions options(
+        pool(), dataIoStats_.get(), metadataIoStats_.get());
     options.setScanSpec(scanSpec);
     Readers readers;
     readers.reader = factory->createReader(
@@ -98,7 +100,8 @@ class ScalarColumnReaderTest : public ::testing::Test,
     auto readFile = std::make_shared<InMemoryReadFile>(file);
     auto factory =
         dwio::common::getReaderFactory(dwio::common::FileFormat::NIMBLE);
-    dwio::common::ReaderOptions options(pool());
+    dwio::common::ReaderOptions options(
+        pool(), dataIoStats_.get(), metadataIoStats_.get());
     options.setScanSpec(scanSpec);
     Readers readers;
     readers.reader = factory->createReader(
@@ -164,6 +167,11 @@ class ScalarColumnReaderTest : public ::testing::Test,
     ASSERT_EQ(numScanned, input.size());
     ASSERT_EQ(0, rowReader.next(1, result));
   }
+
+  const std::shared_ptr<io::IoStatistics> dataIoStats_{
+      std::make_shared<io::IoStatistics>()};
+  const std::shared_ptr<io::IoStatistics> metadataIoStats_{
+      std::make_shared<io::IoStatistics>()};
 };
 
 // ----- ByteColumnReader (BOOLEAN) tests -----

--- a/dwio/nimble/velox/selective/tests/SelectiveNimbleReaderTest.cpp
+++ b/dwio/nimble/velox/selective/tests/SelectiveNimbleReaderTest.cpp
@@ -141,7 +141,8 @@ class SelectiveNimbleReaderTest
     auto readFile = std::make_shared<InMemoryReadFile>(file);
     auto factory =
         dwio::common::getReaderFactory(dwio::common::FileFormat::NIMBLE);
-    dwio::common::ReaderOptions options(pool());
+    dwio::common::ReaderOptions options(
+        pool(), dataIoStats_.get(), metadataIoStats_.get());
     options.setScanSpec(scanSpec);
     options.setPinFileMetadata(GetParam().pinFileMetadata);
     std::unique_ptr<dwio::common::BufferedInput> input;
@@ -1136,7 +1137,8 @@ TEST_P(SelectiveNimbleReaderTest, estimatedRowSize) {
     auto readFile = std::make_shared<InMemoryReadFile>(fileContent);
     auto factory =
         dwio::common::getReaderFactory(dwio::common::FileFormat::NIMBLE);
-    dwio::common::ReaderOptions options(pool());
+    dwio::common::ReaderOptions options(
+        pool(), dataIoStats_.get(), metadataIoStats_.get());
     options.setScanSpec(structScanSpec);
     auto reader = factory->createReader(
         std::make_unique<dwio::common::BufferedInput>(readFile, *pool()),
@@ -1210,7 +1212,8 @@ TEST_P(SelectiveNimbleReaderTest, estimatedRowSizePartialProjection) {
     auto readFile = std::make_shared<InMemoryReadFile>(fileContent);
     auto factory =
         dwio::common::getReaderFactory(dwio::common::FileFormat::NIMBLE);
-    dwio::common::ReaderOptions options(pool());
+    dwio::common::ReaderOptions options(
+        pool(), dataIoStats_.get(), metadataIoStats_.get());
     options.setScanSpec(partialSpec);
     auto reader = factory->createReader(
         std::make_unique<dwio::common::BufferedInput>(readFile, *pool()),
@@ -1309,7 +1312,8 @@ TEST_P(SelectiveNimbleReaderTest, estimatedRowSizeNestedRowPartialProjection) {
     auto readFile = std::make_shared<InMemoryReadFile>(fileContent);
     auto factory =
         dwio::common::getReaderFactory(dwio::common::FileFormat::NIMBLE);
-    dwio::common::ReaderOptions options(pool());
+    dwio::common::ReaderOptions options(
+        pool(), dataIoStats_.get(), metadataIoStats_.get());
     options.setScanSpec(partialSpec);
     auto reader = factory->createReader(
         std::make_unique<dwio::common::BufferedInput>(readFile, *pool()),
@@ -2255,7 +2259,8 @@ TEST_P(SelectiveNimbleReaderTest, columnDecodeMetrics) {
   auto readFile = std::make_shared<InMemoryReadFile>(file);
   auto factory =
       dwio::common::getReaderFactory(dwio::common::FileFormat::NIMBLE);
-  dwio::common::ReaderOptions options(pool());
+  dwio::common::ReaderOptions options(
+      pool(), dataIoStats_.get(), metadataIoStats_.get());
   options.setScanSpec(scanSpec);
   auto reader = factory->createReader(
       std::make_unique<dwio::common::BufferedInput>(readFile, *pool()),
@@ -2439,7 +2444,8 @@ TEST_P(SelectiveNimbleReaderTest, pinFileMetadata) {
     auto readFile = std::make_shared<InMemoryReadFile>(file);
     auto factory =
         dwio::common::getReaderFactory(dwio::common::FileFormat::NIMBLE);
-    dwio::common::ReaderOptions options(pool());
+    dwio::common::ReaderOptions options(
+        pool(), dataIoStats_.get(), metadataIoStats_.get());
     options.setScanSpec(scanSpec);
     options.setPinFileMetadata(true);
     if (enableCache) {
@@ -2484,7 +2490,8 @@ TEST_P(SelectiveNimbleReaderTest, pinnedMetadataNoReread) {
       dwio::common::getReaderFactory(dwio::common::FileFormat::NIMBLE);
   auto scanSpec = std::make_shared<common::ScanSpec>("root");
   scanSpec->addAllChildFields(*input->type());
-  dwio::common::ReaderOptions options(pool());
+  dwio::common::ReaderOptions options(
+      pool(), dataIoStats_.get(), metadataIoStats_.get());
   options.setScanSpec(scanSpec);
   options.setPinFileMetadata(true);
   options.setFileMetadataCacheEnabled(GetParam().enableCache);

--- a/dwio/nimble/velox/selective/tests/StringColumnReaderTest.cpp
+++ b/dwio/nimble/velox/selective/tests/StringColumnReaderTest.cpp
@@ -17,6 +17,7 @@
 #include "dwio/nimble/velox/selective/SelectiveNimbleReader.h"
 
 #include "dwio/nimble/common/tests/NimbleFileWriter.h"
+#include "velox/common/io/IoStatistics.h"
 #include "velox/vector/tests/utils/VectorTestBase.h"
 
 #include <gtest/gtest.h>
@@ -57,7 +58,8 @@ class StringColumnReaderTest : public ::testing::Test,
     auto readFile = std::make_shared<InMemoryReadFile>(file);
     auto factory =
         dwio::common::getReaderFactory(dwio::common::FileFormat::NIMBLE);
-    dwio::common::ReaderOptions options(pool());
+    dwio::common::ReaderOptions options(
+        pool(), dataIoStats_.get(), metadataIoStats_.get());
     options.setScanSpec(scanSpec);
     Readers readers;
     readers.reader = factory->createReader(
@@ -134,6 +136,11 @@ class StringColumnReaderTest : public ::testing::Test,
     ASSERT_EQ(numScanned, input.size());
     ASSERT_EQ(0, rowReader.next(1, result));
   }
+
+  const std::shared_ptr<io::IoStatistics> dataIoStats_{
+      std::make_shared<io::IoStatistics>()};
+  const std::shared_ptr<io::IoStatistics> metadataIoStats_{
+      std::make_shared<io::IoStatistics>()};
 };
 
 // Strings shorter than StringView::kInlineSize (12 bytes).

--- a/dwio/nimble/velox/selective/tests/TimestampColumnReaderTest.cpp
+++ b/dwio/nimble/velox/selective/tests/TimestampColumnReaderTest.cpp
@@ -18,6 +18,7 @@
 
 #include "dwio/nimble/common/tests/NimbleFileWriter.h"
 #include "velox/common/base/tests/GTestUtils.h"
+#include "velox/common/io/IoStatistics.h"
 #include "velox/dwio/common/TypeUtils.h"
 #include "velox/vector/tests/utils/VectorTestBase.h"
 
@@ -57,7 +58,8 @@ class TimestampColumnReaderTest : public ::testing::Test,
     auto readFile = std::make_shared<InMemoryReadFile>(file);
     auto factory =
         dwio::common::getReaderFactory(dwio::common::FileFormat::NIMBLE);
-    dwio::common::ReaderOptions options(pool());
+    dwio::common::ReaderOptions options(
+        pool(), dataIoStats_.get(), metadataIoStats_.get());
     options.setScanSpec(scanSpec);
     Readers readers;
     readers.reader = factory->createReader(
@@ -130,6 +132,11 @@ class TimestampColumnReaderTest : public ::testing::Test,
     ASSERT_EQ(numScanned, input.size());
     ASSERT_EQ(0, rowReader.next(1, result));
   }
+
+  const std::shared_ptr<io::IoStatistics> dataIoStats_{
+      std::make_shared<io::IoStatistics>()};
+  const std::shared_ptr<io::IoStatistics> metadataIoStats_{
+      std::make_shared<io::IoStatistics>()};
 };
 
 // Write and read timestamps with no filter.

--- a/dwio/nimble/velox/selective/tests/VariableLengthColumnReaderTest.cpp
+++ b/dwio/nimble/velox/selective/tests/VariableLengthColumnReaderTest.cpp
@@ -18,6 +18,7 @@
 
 #include "dwio/nimble/common/tests/NimbleFileWriter.h"
 #include "velox/common/base/tests/GTestUtils.h"
+#include "velox/common/io/IoStatistics.h"
 #include "velox/dwio/common/TypeUtils.h"
 #include "velox/vector/tests/utils/VectorTestBase.h"
 
@@ -57,7 +58,8 @@ class VariableLengthColumnReaderTest : public ::testing::Test,
     auto readFile = std::make_shared<InMemoryReadFile>(file);
     auto factory =
         dwio::common::getReaderFactory(dwio::common::FileFormat::NIMBLE);
-    dwio::common::ReaderOptions options(pool());
+    dwio::common::ReaderOptions options(
+        pool(), dataIoStats_.get(), metadataIoStats_.get());
     options.setScanSpec(scanSpec);
     Readers readers;
     readers.reader = factory->createReader(
@@ -130,6 +132,11 @@ class VariableLengthColumnReaderTest : public ::testing::Test,
     ASSERT_EQ(numScanned, input.size());
     ASSERT_EQ(0, rowReader.next(1, result));
   }
+
+  const std::shared_ptr<io::IoStatistics> dataIoStats_{
+      std::make_shared<io::IoStatistics>()};
+  const std::shared_ptr<io::IoStatistics> metadataIoStats_{
+      std::make_shared<io::IoStatistics>()};
 };
 
 // ----- ListColumnReader tests -----


### PR DESCRIPTION
Summary:

X-link: https://github.com/facebookincubator/velox/pull/17399

Add VELOX_CHECK_NOT_NULL for both dataIoStats and metadataIoStats in the base io::ReaderOptions constructor, and remove the = nullptr defaults from the derived dwio::common::ReaderOptions constructor. This ensures all readers explicitly provide IoStatistics for tracking storage reads, SSD reads, RAM cache hits, and overread bytes separately for data and metadata IO.

Updated the DWRF ReaderBase backward-compat and metadata constructors to require IoStatistics parameters. Fixed all callers across the codebase to explicitly create and pass separate dataIoStats and metadataIoStats. For test fixtures, IoStatistics are class members. For free functions where the reader does not outlive the function, local IoStatistics are used. For classes that own readers (DwrfCopier, DwrfToNimbleConverter, ParallelReader), IoStatistics are class members declared before the reader for correct lifetime.

Reviewed By: duxiao1212, tanjialiang

Differential Revision: D103639664
