### PR TITLE
refactor(encoding): Use velox::BufferPtr for decompression buffers (#691)

### DIFF
--- a/dwio/nimble/encodings/Compression.cpp
+++ b/dwio/nimble/encodings/Compression.cpp
@@ -53,7 +53,7 @@ ICompressor& getCompressor(CompressionType compressionType) {
 } // namespace
 
 /* static */ CompressionResult Compression::compress(
-    velox::memory::MemoryPool& memoryPool,
+    velox::memory::MemoryPool& pool,
     std::string_view data,
     DataType dataType,
     int bitWidth,
@@ -61,16 +61,16 @@ ICompressor& getCompressor(CompressionType compressionType) {
   auto compression = compressionPolicy.compression();
 
   return getCompressor(compression.compressionType)
-      .compress(memoryPool, data, dataType, bitWidth, compressionPolicy);
+      .compress(pool, data, dataType, bitWidth, compressionPolicy);
 }
 
-/* static */ Vector<char> Compression::uncompress(
-    velox::memory::MemoryPool& memoryPool,
+/* static */ velox::BufferPtr Compression::uncompress(
+    velox::memory::MemoryPool& pool,
     CompressionType compressionType,
     DataType dataType,
     std::string_view data) {
   return getCompressor(compressionType)
-      .uncompress(memoryPool, compressionType, dataType, data);
+      .uncompress(pool, compressionType, dataType, data);
 }
 
 /* static */ std::optional<size_t> Compression::uncompressedSize(

--- a/dwio/nimble/encodings/Compression.h
+++ b/dwio/nimble/encodings/Compression.h
@@ -20,6 +20,7 @@
 #include "dwio/nimble/common/Vector.h"
 #include "dwio/nimble/encodings/EncodingSelection.h"
 #include "folly/io/IOBuf.h"
+#include "velox/buffer/Buffer.h"
 
 namespace facebook::nimble {
 
@@ -30,14 +31,14 @@ struct CompressionResult {
 
 struct ICompressor {
   virtual CompressionResult compress(
-      velox::memory::MemoryPool& memoryPool,
+      velox::memory::MemoryPool& pool,
       std::string_view data,
       DataType dataType,
       int bitWidth,
       const CompressionPolicy& compressionPolicy) = 0;
 
-  virtual Vector<char> uncompress(
-      velox::memory::MemoryPool& memoryPool,
+  virtual velox::BufferPtr uncompress(
+      velox::memory::MemoryPool& pool,
       CompressionType compressionType,
       DataType dataType,
       std::string_view data) = 0;
@@ -53,14 +54,14 @@ struct ICompressor {
 class Compression {
  public:
   static CompressionResult compress(
-      velox::memory::MemoryPool& memoryPool,
+      velox::memory::MemoryPool& pool,
       std::string_view data,
       DataType dataType,
       int bitWidth,
       const CompressionPolicy& compressionPolicy);
 
-  static Vector<char> uncompress(
-      velox::memory::MemoryPool& memoryPool,
+  static velox::BufferPtr uncompress(
+      velox::memory::MemoryPool& pool,
       CompressionType compressionType,
       DataType dataType,
       std::string_view data);
@@ -83,7 +84,7 @@ class CompressionEncoder {
   // This CTor handles the sub-pattern where the source data is already encoded
   // correctly, so no extra encoding is needed.
   CompressionEncoder(
-      velox::memory::MemoryPool& memoryPool,
+      velox::memory::MemoryPool& pool,
       const CompressionPolicy& compressionPolicy,
       DataType dataType,
       std::string_view uncompressedBuffer,
@@ -100,7 +101,7 @@ class CompressionEncoder {
     }
 
     auto compressionResult = Compression::compress(
-        memoryPool, uncompressedBuffer, dataType, bitWidth, compressionPolicy);
+        pool, uncompressedBuffer, dataType, bitWidth, compressionPolicy);
 
     if (compressionResult.compressionType == CompressionType::Uncompressed) {
       // Compression declined. Use the original buffer.
@@ -121,7 +122,7 @@ class CompressionEncoder {
   // different if compression is applied (it is written to a temp buffer), or if
   // compression is skipped (written directly to the stream buffer).
   CompressionEncoder(
-      velox::memory::MemoryPool& memoryPool,
+      velox::memory::MemoryPool& pool,
       const CompressionPolicy& compressionPolicy,
       DataType dataType,
       int bitWidth,
@@ -146,7 +147,7 @@ class CompressionEncoder {
     char* pos = uncompressed.data();
     encoder_(pos);
     auto compressionResult = Compression::compress(
-        memoryPool,
+        pool,
         {uncompressed.data(), uncompressed.size()},
         dataType,
         bitWidth,

--- a/dwio/nimble/encodings/FixedBitWidthEncoding.h
+++ b/dwio/nimble/encodings/FixedBitWidthEncoding.h
@@ -52,7 +52,7 @@ class FixedBitWidthEncoding final
   static const int kPrefixSize = 2 + sizeof(T);
 
   FixedBitWidthEncoding(
-      velox::memory::MemoryPool& memoryPool,
+      velox::memory::MemoryPool& pool,
       std::string_view data,
       std::function<void*(uint32_t)> stringBufferFactory,
       const Encoding::Options& options = {});
@@ -88,7 +88,7 @@ class FixedBitWidthEncoding final
   physicalType baseline_;
   FixedBitArray fixedBitArray_;
   uint32_t row_ = 0;
-  Vector<char> uncompressedData_;
+  velox::BufferPtr uncompressedData_;
   Vector<physicalType> buffer_;
 };
 
@@ -98,25 +98,23 @@ class FixedBitWidthEncoding final
 
 template <typename T>
 FixedBitWidthEncoding<T>::FixedBitWidthEncoding(
-    velox::memory::MemoryPool& memoryPool,
+    velox::memory::MemoryPool& pool,
     std::string_view data,
     std::function<void*(uint32_t)> /* stringBufferFactory */,
     const Encoding::Options& options)
-    : TypedEncoding<T, physicalType>{memoryPool, data, options},
-      uncompressedData_{&memoryPool},
-      buffer_{&memoryPool} {
+    : TypedEncoding<T, physicalType>{pool, data, options}, buffer_{&pool} {
   auto pos = data.data() + this->dataOffset();
   auto compressionType = static_cast<CompressionType>(encoding::readChar(pos));
   baseline_ = encoding::read<const physicalType>(pos);
   bitWidth_ = static_cast<uint32_t>(encoding::readChar(pos));
   if (compressionType != CompressionType::Uncompressed) {
     uncompressedData_ = Compression::uncompress(
-        memoryPool,
+        pool,
         compressionType,
         DataType::Undefined,
         {pos, static_cast<size_t>(data.end() - pos)});
     fixedBitArray_ = FixedBitArray{
-        {uncompressedData_.data(), uncompressedData_.size()}, bitWidth_};
+        {uncompressedData_->as<char>(), uncompressedData_->size()}, bitWidth_};
   } else {
     fixedBitArray_ =
         FixedBitArray{{pos, static_cast<size_t>(data.end() - pos)}, bitWidth_};

--- a/dwio/nimble/encodings/TrivialEncoding.cpp
+++ b/dwio/nimble/encodings/TrivialEncoding.cpp
@@ -19,32 +19,29 @@
 namespace facebook::nimble {
 
 TrivialEncoding<std::string_view>::TrivialEncoding(
-    velox::memory::MemoryPool& memoryPool,
+    velox::memory::MemoryPool& pool,
     std::string_view data,
     std::function<void*(uint32_t)> stringBufferFactory,
     const Encoding::Options& options)
-    : TypedEncoding<
-          std::string_view,
-          std::string_view>{memoryPool, data, options},
+    : TypedEncoding<std::string_view, std::string_view>{pool, data, options},
       row_{0},
-      buffer_{&memoryPool},
-      dataUncompressed_{&memoryPool} {
+      buffer_{&pool} {
   auto pos = data.data() + this->dataOffset();
   const auto dataCompressionType =
       static_cast<CompressionType>(encoding::readChar(pos));
   const auto lengthsSize = encoding::readUint32(pos);
   lengths_ = EncodingFactory(options).create(
-      memoryPool, {pos, lengthsSize}, stringBufferFactory);
+      pool, {pos, lengthsSize}, stringBufferFactory);
   blob_ = pos + lengthsSize;
 
   if (dataCompressionType != CompressionType::Uncompressed) {
     dataUncompressed_ = Compression::uncompress(
-        memoryPool,
+        pool,
         dataCompressionType,
         DataType::String,
         {blob_, static_cast<size_t>(data.end() - blob_)});
-    blob_ = reinterpret_cast<const char*>(dataUncompressed_.data());
-    uncompressedDataBytes_ = dataUncompressed_.size();
+    blob_ = dataUncompressed_->as<char>();
+    uncompressedDataBytes_ = dataUncompressed_->size();
   } else {
     uncompressedDataBytes_ = data.size() - std::distance(data.data(), blob_);
   }
@@ -54,7 +51,7 @@ TrivialEncoding<std::string_view>::TrivialEncoding(
   // TODO(huamengjiang): in a follow up, we will let the factory return a smart
   // pointer that can also be held by the encoding.
   std::memcpy(stringBuffer, blob_, uncompressedDataBytes_);
-  dataUncompressed_.clear();
+  dataUncompressed_.reset();
   blob_ = static_cast<char*>(stringBuffer);
   pos_ = blob_;
 }
@@ -199,8 +196,7 @@ TrivialEncoding<bool>::TrivialEncoding(
     std::function<void*(uint32_t)> /* stringBufferFactory */,
     const Encoding::Options& options)
     : TypedEncoding<bool, bool>{pool, data, options},
-      bitmap_{data.data() + this->dataOffset() + kPrefixSize},
-      uncompressed_{&pool} {
+      bitmap_{data.data() + this->dataOffset() + kPrefixSize} {
   const auto compressionType =
       static_cast<CompressionType>(data[this->dataOffset()]);
   if (compressionType != CompressionType::Uncompressed) {
@@ -209,14 +205,15 @@ TrivialEncoding<bool>::TrivialEncoding(
         compressionType,
         DataType::Undefined,
         {bitmap_, static_cast<size_t>(data.end() - bitmap_)});
-    bitmap_ = uncompressed_.data();
-    NIMBLE_CHECK(
-        bitmap_ + FixedBitArray::bufferSize(rowCount(), 1) ==
-            uncompressed_.end(),
+    bitmap_ = uncompressed_->as<char>();
+    NIMBLE_CHECK_EQ(
+        bitmap_ + FixedBitArray::bufferSize(rowCount(), 1),
+        uncompressed_->as<char>() + uncompressed_->size(),
         "Unexpected trivial encoding end");
   } else {
-    NIMBLE_CHECK(
-        bitmap_ + FixedBitArray::bufferSize(rowCount(), 1) == data.end(),
+    NIMBLE_CHECK_EQ(
+        bitmap_ + FixedBitArray::bufferSize(rowCount(), 1),
+        data.end(),
         "Unexpected trivial encoding end");
   }
 }

--- a/dwio/nimble/encodings/TrivialEncoding.h
+++ b/dwio/nimble/encodings/TrivialEncoding.h
@@ -50,7 +50,7 @@ class TrivialEncoding final
   static constexpr int kPrefixSize = 1;
 
   TrivialEncoding(
-      velox::memory::MemoryPool& memoryPool,
+      velox::memory::MemoryPool& pool,
       std::string_view data,
       std::function<void*(uint32_t)> stringBufferFactory,
       const Encoding::Options& options = {});
@@ -79,7 +79,7 @@ class TrivialEncoding final
  private:
   uint32_t row_;
   const T* values_;
-  Vector<char> uncompressed_;
+  velox::BufferPtr uncompressed_;
 };
 
 // For the string case the layout is:
@@ -97,7 +97,7 @@ class TrivialEncoding<std::string_view> final
   static constexpr int kPrefixSize = 5;
 
   TrivialEncoding(
-      velox::memory::MemoryPool& memoryPool,
+      velox::memory::MemoryPool& pool,
       std::string_view data,
       std::function<void*(uint32_t)> stringBufferFactory,
       const Encoding::Options& options = {});
@@ -132,7 +132,7 @@ class TrivialEncoding<std::string_view> final
   // NOTE: This is not necessarily the size of 'dataUncompressed_' because the
   // data could come as uncompressed.
   uint64_t uncompressedDataBytes_;
-  Vector<char> dataUncompressed_;
+  velox::BufferPtr dataUncompressed_;
 };
 
 // For the bool case the layout is:
@@ -171,7 +171,7 @@ class TrivialEncoding<bool> final : public TypedEncoding<bool, bool> {
  private:
   uint32_t row_{0};
   const char* bitmap_;
-  Vector<char> uncompressed_;
+  velox::BufferPtr uncompressed_;
 };
 
 //
@@ -180,31 +180,31 @@ class TrivialEncoding<bool> final : public TypedEncoding<bool, bool> {
 
 template <typename T>
 TrivialEncoding<T>::TrivialEncoding(
-    velox::memory::MemoryPool& memoryPool,
+    velox::memory::MemoryPool& pool,
     std::string_view data,
     std::function<void*(uint32_t)> /* stringBufferFactory */,
     const Encoding::Options& options)
-    : TypedEncoding<T, physicalType>{memoryPool, data, options},
+    : TypedEncoding<T, physicalType>{pool, data, options},
       row_{0},
       values_{reinterpret_cast<const T*>(
-          data.data() + this->dataOffset() + kPrefixSize)},
-      uncompressed_{&memoryPool} {
+          data.data() + this->dataOffset() + kPrefixSize)} {
   const auto valuesOffset = this->dataOffset() + kPrefixSize;
   auto compressionType = static_cast<CompressionType>(data[this->dataOffset()]);
   if (compressionType != CompressionType::Uncompressed) {
     uncompressed_ = Compression::uncompress(
-        memoryPool,
+        pool,
         compressionType,
         TypeTraits<physicalType>::dataType,
         {data.data() + valuesOffset, data.size() - valuesOffset});
-    values_ = reinterpret_cast<const T*>(uncompressed_.data());
-    NIMBLE_CHECK(
-        reinterpret_cast<const char*>(values_ + this->rowCount()) ==
-            uncompressed_.end(),
+    values_ = reinterpret_cast<const T*>(uncompressed_->as<char>());
+    NIMBLE_CHECK_EQ(
+        reinterpret_cast<const char*>(values_ + this->rowCount()),
+        uncompressed_->as<char>() + uncompressed_->size(),
         "Unexpected trivial encoding end");
   } else {
-    NIMBLE_CHECK(
-        reinterpret_cast<const char*>(values_ + this->rowCount()) == data.end(),
+    NIMBLE_CHECK_EQ(
+        reinterpret_cast<const char*>(values_ + this->rowCount()),
+        data.end(),
         "Unexpected trivial encoding end");
   }
 }

--- a/dwio/nimble/encodings/ZstdCompressor.cpp
+++ b/dwio/nimble/encodings/ZstdCompressor.cpp
@@ -24,13 +24,13 @@
 namespace facebook::nimble {
 
 CompressionResult ZstdCompressor::compress(
-    velox::memory::MemoryPool& memoryPool,
+    velox::memory::MemoryPool& pool,
     std::string_view data,
     DataType dataType,
     int /* bitWidth */,
     const CompressionPolicy& compressionPolicy) {
   auto parameters = compressionPolicy.compression().parameters.zstd;
-  Vector<char> buffer{&memoryPool, data.size() + sizeof(uint32_t)};
+  Vector<char> buffer{&pool, data.size() + sizeof(uint32_t)};
   auto pos = buffer.data();
   encoding::writeUint32(data.size(), pos);
   auto ret = ZSTD_compress(
@@ -67,18 +67,18 @@ ZSTD_DCtx* getThreadLocalDCtx() {
 }
 } // namespace
 
-Vector<char> ZstdCompressor::uncompress(
-    velox::memory::MemoryPool& memoryPool,
+velox::BufferPtr ZstdCompressor::uncompress(
+    velox::memory::MemoryPool& pool,
     const CompressionType compressionType,
     const DataType /* dataType */,
     std::string_view data) {
   auto pos = data.data();
   const uint32_t uncompressedSize = encoding::readUint32(pos);
-  Vector<char> buffer{&memoryPool, uncompressedSize};
+  auto buffer = velox::AlignedBuffer::allocate<char>(uncompressedSize, &pool);
   auto ret = ZSTD_decompressDCtx(
       getThreadLocalDCtx(),
-      buffer.data(),
-      buffer.size(),
+      buffer->asMutable<char>(),
+      buffer->size(),
       pos,
       data.size() - sizeof(uint32_t));
   NIMBLE_CHECK(

--- a/dwio/nimble/encodings/ZstdCompressor.h
+++ b/dwio/nimble/encodings/ZstdCompressor.h
@@ -23,14 +23,14 @@ namespace facebook::nimble {
 class ZstdCompressor : public ICompressor {
  public:
   CompressionResult compress(
-      velox::memory::MemoryPool& memoryPool,
+      velox::memory::MemoryPool& pool,
       std::string_view data,
       DataType dataType,
       int bitWidth,
       const CompressionPolicy& compressionPolicy) override;
 
-  Vector<char> uncompress(
-      velox::memory::MemoryPool& memoryPool,
+  velox::BufferPtr uncompress(
+      velox::memory::MemoryPool& pool,
       CompressionType compressionType,
       DataType dataType,
       std::string_view data) override;

--- a/dwio/nimble/encodings/legacy/FixedBitWidthEncoding.h
+++ b/dwio/nimble/encodings/legacy/FixedBitWidthEncoding.h
@@ -53,7 +53,7 @@ class FixedBitWidthEncoding final
   static const int kPrefixSize = 2 + sizeof(T);
 
   FixedBitWidthEncoding(
-      velox::memory::MemoryPool& memoryPool,
+      velox::memory::MemoryPool& pool,
       std::string_view data,
       std::function<void*(uint32_t)> stringBufferFactory);
 
@@ -76,7 +76,7 @@ class FixedBitWidthEncoding final
   physicalType baseline_;
   FixedBitArray fixedBitArray_{};
   uint32_t row_ = 0;
-  Vector<char> uncompressedData_;
+  velox::BufferPtr uncompressedData_;
   Vector<physicalType> buffer_;
 };
 
@@ -86,24 +86,22 @@ class FixedBitWidthEncoding final
 
 template <typename T>
 FixedBitWidthEncoding<T>::FixedBitWidthEncoding(
-    velox::memory::MemoryPool& memoryPool,
+    velox::memory::MemoryPool& pool,
     std::string_view data,
     std::function<void*(uint32_t)> /* stringBufferFactory */)
-    : TypedEncoding<T, physicalType>{memoryPool, data},
-      uncompressedData_{&memoryPool},
-      buffer_{&memoryPool} {
+    : TypedEncoding<T, physicalType>{pool, data}, buffer_{&pool} {
   auto pos = data.data() + kCompressionOffset;
   auto compressionType = static_cast<CompressionType>(encoding::readChar(pos));
   baseline_ = encoding::read<const physicalType>(pos);
   bitWidth_ = static_cast<uint32_t>(encoding::readChar(pos));
   if (compressionType != CompressionType::Uncompressed) {
     uncompressedData_ = Compression::uncompress(
-        memoryPool,
+        pool,
         compressionType,
         TypeTraits<physicalType>::dataType,
         {pos, static_cast<size_t>(data.end() - pos)});
     fixedBitArray_ = FixedBitArray{
-        {uncompressedData_.data(), uncompressedData_.size()}, bitWidth_};
+        {uncompressedData_->as<char>(), uncompressedData_->size()}, bitWidth_};
   } else {
     fixedBitArray_ =
         FixedBitArray{{pos, static_cast<size_t>(data.end() - pos)}, bitWidth_};

--- a/dwio/nimble/encodings/legacy/TrivialEncoding.cpp
+++ b/dwio/nimble/encodings/legacy/TrivialEncoding.cpp
@@ -19,29 +19,28 @@
 namespace facebook::nimble::legacy {
 
 TrivialEncoding<std::string_view>::TrivialEncoding(
-    velox::memory::MemoryPool& memoryPool,
+    velox::memory::MemoryPool& pool,
     std::string_view data,
     std::function<void*(uint32_t)> stringBufferFactory)
-    : TypedEncoding<std::string_view, std::string_view>{memoryPool, data},
+    : TypedEncoding<std::string_view, std::string_view>{pool, data},
       row_{0},
-      buffer_{&memoryPool},
-      dataUncompressed_{&memoryPool} {
+      buffer_{&pool} {
   auto pos = data.data() + kDataCompressionOffset;
   auto dataCompressionType =
       static_cast<CompressionType>(encoding::readChar(pos));
   auto lengthsSize = encoding::readUint32(pos);
-  lengths_ = EncodingFactory().create(
-      memoryPool, {pos, lengthsSize}, stringBufferFactory);
+  lengths_ =
+      EncodingFactory().create(pool, {pos, lengthsSize}, stringBufferFactory);
   blob_ = pos + lengthsSize;
 
   if (dataCompressionType != CompressionType::Uncompressed) {
     dataUncompressed_ = Compression::uncompress(
-        memoryPool,
+        pool,
         dataCompressionType,
         DataType::String,
         {blob_, static_cast<size_t>(data.end() - blob_)});
-    blob_ = reinterpret_cast<const char*>(dataUncompressed_.data());
-    uncompressedDataBytes_ = dataUncompressed_.size();
+    blob_ = dataUncompressed_->as<char>();
+    uncompressedDataBytes_ = dataUncompressed_->size();
   } else {
     uncompressedDataBytes_ = data.size() - std::distance(blob_, data.data());
   }
@@ -141,8 +140,7 @@ TrivialEncoding<bool>::TrivialEncoding(
     std::string_view data,
     std::function<void*(uint32_t)> /* stringBufferFactory */)
     : TypedEncoding<bool, bool>{pool, data},
-      bitmap_{data.data() + kDataOffset},
-      uncompressed_{&pool} {
+      bitmap_{data.data() + kDataOffset} {
   const auto compressionType =
       static_cast<CompressionType>(data[kCompressionTypeOffset]);
   if (compressionType != CompressionType::Uncompressed) {
@@ -151,14 +149,15 @@ TrivialEncoding<bool>::TrivialEncoding(
         compressionType,
         DataType::Undefined,
         {bitmap_, static_cast<size_t>(data.end() - bitmap_)});
-    bitmap_ = uncompressed_.data();
-    NIMBLE_CHECK(
-        bitmap_ + FixedBitArray::bufferSize(rowCount(), 1) ==
-            uncompressed_.end(),
+    bitmap_ = uncompressed_->as<char>();
+    NIMBLE_CHECK_EQ(
+        bitmap_ + FixedBitArray::bufferSize(rowCount(), 1),
+        uncompressed_->as<char>() + uncompressed_->size(),
         "Unexpected trivial encoding end");
   } else {
-    NIMBLE_CHECK(
-        bitmap_ + FixedBitArray::bufferSize(rowCount(), 1) == data.end(),
+    NIMBLE_CHECK_EQ(
+        bitmap_ + FixedBitArray::bufferSize(rowCount(), 1),
+        data.end(),
         "Unexpected trivial encoding end");
   }
 }

--- a/dwio/nimble/encodings/legacy/TrivialEncoding.h
+++ b/dwio/nimble/encodings/legacy/TrivialEncoding.h
@@ -54,7 +54,7 @@ class TrivialEncoding final
       Encoding::kPrefixSize + TrivialEncoding<T>::kPrefixSize;
 
   TrivialEncoding(
-      velox::memory::MemoryPool& memoryPool,
+      velox::memory::MemoryPool& pool,
       std::string_view data,
       std::function<void*(uint32_t)> stringBufferFactory);
 
@@ -81,7 +81,7 @@ class TrivialEncoding final
  private:
   uint32_t row_;
   const T* values_;
-  Vector<char> uncompressed_;
+  velox::BufferPtr uncompressed_;
 };
 
 // For the string case the layout is:
@@ -103,7 +103,7 @@ class TrivialEncoding<std::string_view> final
       Encoding::kPrefixSize + TrivialEncoding<std::string_view>::kPrefixSize;
 
   TrivialEncoding(
-      velox::memory::MemoryPool& memoryPool,
+      velox::memory::MemoryPool& pool,
       std::string_view data,
       std::function<void*(uint32_t)> stringBufferFactory);
 
@@ -134,7 +134,7 @@ class TrivialEncoding<std::string_view> final
   // NOTE: This is not necessarily the size of 'dataUncompressed_' because the
   // data could come as uncompressed.
   uint64_t uncompressedDataBytes_;
-  Vector<char> dataUncompressed_;
+  velox::BufferPtr dataUncompressed_;
 };
 
 // For the bool case the layout is:
@@ -174,7 +174,7 @@ class TrivialEncoding<bool> final : public TypedEncoding<bool, bool> {
  private:
   uint32_t row_{0};
   const char* bitmap_;
-  Vector<char> uncompressed_;
+  velox::BufferPtr uncompressed_;
 };
 
 //
@@ -183,29 +183,29 @@ class TrivialEncoding<bool> final : public TypedEncoding<bool, bool> {
 
 template <typename T>
 TrivialEncoding<T>::TrivialEncoding(
-    velox::memory::MemoryPool& memoryPool,
+    velox::memory::MemoryPool& pool,
     std::string_view data,
     std::function<void*(uint32_t)> /* stringBufferFactory */)
-    : TypedEncoding<T, physicalType>{memoryPool, data},
+    : TypedEncoding<T, physicalType>{pool, data},
       row_{0},
-      values_{reinterpret_cast<const T*>(data.data() + kDataOffset)},
-      uncompressed_{&memoryPool} {
+      values_{reinterpret_cast<const T*>(data.data() + kDataOffset)} {
   auto compressionType =
       static_cast<CompressionType>(data[kCompressionTypeOffset]);
   if (compressionType != CompressionType::Uncompressed) {
     uncompressed_ = Compression::uncompress(
-        memoryPool,
+        pool,
         compressionType,
         TypeTraits<physicalType>::dataType,
         {data.data() + kDataOffset, data.size() - kDataOffset});
-    values_ = reinterpret_cast<const T*>(uncompressed_.data());
-    NIMBLE_CHECK(
-        reinterpret_cast<const char*>(values_ + this->rowCount()) ==
-            uncompressed_.end(),
+    values_ = reinterpret_cast<const T*>(uncompressed_->as<char>());
+    NIMBLE_CHECK_EQ(
+        reinterpret_cast<const char*>(values_ + this->rowCount()),
+        uncompressed_->as<char>() + uncompressed_->size(),
         "Unexpected trivial encoding end");
   } else {
-    NIMBLE_CHECK(
-        reinterpret_cast<const char*>(values_ + this->rowCount()) == data.end(),
+    NIMBLE_CHECK_EQ(
+        reinterpret_cast<const char*>(values_ + this->rowCount()),
+        data.end(),
         "Unexpected trivial encoding end");
   }
 }

--- a/dwio/nimble/encodings/tests/ZstdCompressorTest.cpp
+++ b/dwio/nimble/encodings/tests/ZstdCompressorTest.cpp
@@ -74,9 +74,10 @@ TEST(ZstdCompressorTest, RoundTrip) {
 
   auto decompressed = compressor.uncompress(
       *pool, CompressionType::Zstd, DataType::Int8, compressed);
-  ASSERT_EQ(original.size(), decompressed.size());
+  ASSERT_EQ(original.size(), decompressed->size());
   EXPECT_EQ(
-      0, std::memcmp(original.data(), decompressed.data(), original.size()));
+      0,
+      std::memcmp(original.data(), decompressed->as<char>(), original.size()));
 }
 
 TEST(ZstdCompressorTest, UncompressedSize) {
@@ -138,8 +139,9 @@ TEST(ZstdCompressorTest, RoundTripVariousDataTypes) {
   std::string_view compressed(result.buffer->data(), result.buffer->size());
   auto decompressed = compressor.uncompress(
       *pool, CompressionType::Zstd, DataType::Int8, compressed);
-  ASSERT_EQ(input.size(), decompressed.size());
-  EXPECT_EQ(0, std::memcmp(input.data(), decompressed.data(), input.size()));
+  ASSERT_EQ(input.size(), decompressed->size());
+  EXPECT_EQ(
+      0, std::memcmp(input.data(), decompressed->as<char>(), input.size()));
 }
 
 TEST(ZstdCompressorTest, MinCompressionSizeSkipsSmallData) {


### PR DESCRIPTION
Summary:

Refactor the compression/decompression path to return velox::BufferPtr (AlignedBuffer) instead of nimble::Vector<char>. This is a prerequisite for introducing BufferPool-based buffer reuse in decompression, which will eliminate MemoryPool mutex contention during parallel decode.

Changes:
- ICompressor::uncompress() returns velox::BufferPtr instead of Vector<char>
- Compression::uncompress() returns velox::BufferPtr
- uncompressZstdWithReusedCtx() returns velox::BufferPtr
- ZstdCompressor, MetaInternalCompressor, MetaInternalMCCompressor updated
- TrivialEncoding (numeric, string_view, bool) and FixedBitWidthEncoding updated to store BufferPtr
- Legacy encoding variants updated similarly
- Removed debug instrumentation (zstdDecompressCount, per-task counters) from FieldReader

Reviewed By: xiaoxmeng

Differential Revision: D103723354


