### PR TITLE
fix(index): Fix use-after-move in decodeKeyChunk string allocator lambda

### DIFF
--- a/dwio/nimble/encodings/ZstdCompressor.cpp
+++ b/dwio/nimble/encodings/ZstdCompressor.cpp
@@ -18,6 +18,7 @@
 
 #include <zstd.h>
 #include <zstd_errors.h>
+#include <memory>
 #include <optional>
 
 namespace facebook::nimble {
@@ -52,6 +53,20 @@ CompressionResult ZstdCompressor::compress(
   };
 }
 
+namespace {
+ZSTD_DCtx* getThreadLocalDCtx() {
+  struct DCtxDeleter {
+    void operator()(ZSTD_DCtx* ctx) const {
+      ZSTD_freeDCtx(ctx);
+    }
+  };
+  static thread_local std::unique_ptr<ZSTD_DCtx, DCtxDeleter> ctx{
+      ZSTD_createDCtx()};
+  NIMBLE_CHECK(ctx != nullptr, "Failed to create ZSTD decompression context");
+  return ctx.get();
+}
+} // namespace
+
 Vector<char> ZstdCompressor::uncompress(
     velox::memory::MemoryPool& memoryPool,
     const CompressionType compressionType,
@@ -60,8 +75,12 @@ Vector<char> ZstdCompressor::uncompress(
   auto pos = data.data();
   const uint32_t uncompressedSize = encoding::readUint32(pos);
   Vector<char> buffer{&memoryPool, uncompressedSize};
-  auto ret = ZSTD_decompress(
-      buffer.data(), buffer.size(), pos, data.size() - sizeof(uint32_t));
+  auto ret = ZSTD_decompressDCtx(
+      getThreadLocalDCtx(),
+      buffer.data(),
+      buffer.size(),
+      pos,
+      data.size() - sizeof(uint32_t));
   NIMBLE_CHECK(
       !ZSTD_isError(ret),
       "Error uncompressing data: {}",

--- a/dwio/nimble/index/ClusterIndex.cpp
+++ b/dwio/nimble/index/ClusterIndex.cpp
@@ -460,7 +460,7 @@ const ClusterIndex::DecodedChunk& ClusterIndex::getDecodedChunk(
     const ChunkLocation& chunkLocation) const {
   NIMBLE_DCHECK_NOT_NULL(partition);
   auto& decodedChunk = partition->decodedChunk;
-  if (decodedChunk.data.encoding != nullptr &&
+  if (decodedChunk.data != nullptr &&
       decodedChunk.chunkOffset == chunkLocation.chunkOffset) {
     return decodedChunk;
   }
@@ -471,7 +471,7 @@ const ClusterIndex::DecodedChunk& ClusterIndex::getDecodedChunk(
   decodedChunk.data =
       decodeKeyChunk(loadData_(region), *pool_, partition->dataBuffer);
   NIMBLE_CHECK_EQ(
-      decodedChunk.data.encoding->dataType(),
+      decodedChunk.data->encoding->dataType(),
       DataType::String,
       "Expected String data type");
 
@@ -484,12 +484,12 @@ uint32_t ClusterIndex::seekInChunk(
     std::string_view encodedKey,
     bool inclusive) const {
   const auto& chunk = getDecodedChunk(partition, chunkLocation);
-  const auto rowInChunk = chunk.data.encoding->seek(&encodedKey, inclusive);
+  const auto rowInChunk = chunk.data->encoding->seek(&encodedKey, inclusive);
   if (!rowInChunk.has_value()) {
     // For exclusive seek (inclusive=false), no row > key means the end is
     // past all rows in this partition.
     if (!inclusive) {
-      return chunkLocation.rowOffset + chunk.data.encoding->rowCount();
+      return chunkLocation.rowOffset + chunk.data->encoding->rowCount();
     }
     NIMBLE_CHECK(false, "Key must be found within a matched chunk");
   }

--- a/dwio/nimble/index/ClusterIndex.h
+++ b/dwio/nimble/index/ClusterIndex.h
@@ -155,11 +155,11 @@ class ClusterIndex : public IndexLookup {
   struct DecodedChunk {
     void reset(uint32_t newChunkOffset) {
       chunkOffset = newChunkOffset;
-      data = {};
+      data.reset();
     }
 
     uint32_t chunkOffset{0};
-    DecodedKeyChunk data;
+    std::shared_ptr<DecodedKeyChunk> data;
   };
 
   // Parsed partition metadata, cached on demand.

--- a/dwio/nimble/index/KeyChunkDecoder.cpp
+++ b/dwio/nimble/index/KeyChunkDecoder.cpp
@@ -21,7 +21,7 @@
 
 namespace facebook::nimble::index {
 
-DecodedKeyChunk decodeKeyChunk(
+std::shared_ptr<DecodedKeyChunk> decodeKeyChunk(
     std::unique_ptr<velox::dwio::common::SeekableInputStream> inputStream,
     velox::memory::MemoryPool& pool,
     velox::BufferPtr& dataBuffer) {
@@ -37,7 +37,7 @@ DecodedKeyChunk decodeKeyChunk(
       "Compressed key chunks are not supported");
 
   const auto dataLen = chunkHeader.length;
-  DecodedKeyChunk result;
+  auto result = std::make_shared<DecodedKeyChunk>();
 
   // Determine the contiguous data pointer. If the first buffer contains all
   // the data, use it directly (zero-copy). Otherwise, copy across buffers.
@@ -46,7 +46,7 @@ DecodedKeyChunk decodeKeyChunk(
   const char* chunkData;
   bufLen -= kChunkHeaderSize;
   if (bufLen >= static_cast<int>(dataLen)) {
-    result.dataStream = std::move(inputStream);
+    result->dataStream = std::move(inputStream);
     chunkData = header;
   } else {
     if (dataBuffer == nullptr || dataBuffer->capacity() < dataLen) {
@@ -65,17 +65,20 @@ DecodedKeyChunk decodeKeyChunk(
     chunkData = dest;
   }
 
-  result.encoding = nimble::EncodingFactory().create(
-      pool, std::string_view(chunkData, dataLen), [&](uint32_t totalLength) {
-        auto& buffer = result.stringBuffers.emplace_back(
+  auto* raw = result.get();
+  result->encoding = nimble::EncodingFactory().create(
+      pool,
+      std::string_view(chunkData, dataLen),
+      [raw, &pool](uint32_t totalLength) {
+        auto& buffer = raw->stringBuffers.emplace_back(
             velox::AlignedBuffer::allocate<char>(totalLength, &pool));
         return buffer->asMutable<void>();
       });
   NIMBLE_CHECK(
-      result.encoding->encodingType() == EncodingType::Trivial ||
-          result.encoding->encodingType() == EncodingType::Prefix,
+      result->encoding->encodingType() == EncodingType::Trivial ||
+          result->encoding->encodingType() == EncodingType::Prefix,
       "Unsupported encoding type: {}",
-      result.encoding->encodingType());
+      result->encoding->encodingType());
   return result;
 }
 

--- a/dwio/nimble/index/KeyChunkDecoder.h
+++ b/dwio/nimble/index/KeyChunkDecoder.h
@@ -37,11 +37,15 @@ struct DecodedKeyChunk {
 /// compression and encoding type, and creates the encoding. Handles both
 /// contiguous (zero-copy) and multi-buffer reads.
 ///
+/// Returns a shared_ptr so the encoding's string allocator lambda (which
+/// captures a pointer to the DecodedKeyChunk) remains valid when the caller
+/// moves or reassigns the shared_ptr.
+///
 /// @param dataBuffer Reusable buffer for multi-buffer reads. When the data
 ///        spans multiple stream buffers, this buffer is resized and reused
 ///        instead of allocating a new one. The caller retains ownership and the
 ///        buffer must outlive the returned DecodedKeyChunk.
-DecodedKeyChunk decodeKeyChunk(
+std::shared_ptr<DecodedKeyChunk> decodeKeyChunk(
     std::unique_ptr<velox::dwio::common::SeekableInputStream> inputStream,
     velox::memory::MemoryPool& pool,
     velox::BufferPtr& dataBuffer);

--- a/dwio/nimble/index/SortedIndex.cpp
+++ b/dwio/nimble/index/SortedIndex.cpp
@@ -122,7 +122,8 @@ std::optional<uint32_t> SortedIndex::findChunkIndex(
   return static_cast<uint32_t>(std::distance(chunkKeys->begin(), it));
 }
 
-DecodedKeyChunk SortedIndex::loadChunk(uint32_t chunkIdx) const {
+std::shared_ptr<DecodedKeyChunk> SortedIndex::loadChunk(
+    uint32_t chunkIdx) const {
   const uint64_t streamOffset = sortedIndex_->key_stream_offset();
   const uint32_t chunkOffset = this->chunkOffset(chunkIdx);
   const uint32_t chunkSize = this->chunkSize(chunkIdx);
@@ -185,13 +186,13 @@ void SortedIndex::scanEntries(
     }
 
     auto chunk = loadChunk(ci);
-    const uint32_t rowCount = chunk.encoding->rowCount();
+    const uint32_t rowCount = chunk->encoding->rowCount();
 
     // Seek only in the first chunk. For continuation chunks, the loop guard
     // ensures entries are in range, so start at 0.
     const uint32_t startPos = (ci != startChunk)
         ? 0
-        : chunk.encoding->seek(&startSeekKey, /*inclusive=*/true)
+        : chunk->encoding->seek(&startSeekKey, /*inclusive=*/true)
               .value_or(rowCount);
     if (startPos >= rowCount) {
       break;
@@ -200,16 +201,16 @@ void SortedIndex::scanEntries(
     // If all remaining entries in this chunk match, skip the end seek.
     const uint32_t endPos = hasMoreEntries(ci)
         ? rowCount
-        : chunk.encoding->seek(&endSeekKey, /*inclusive=*/!isPointLookup)
+        : chunk->encoding->seek(&endSeekKey, /*inclusive=*/!isPointLookup)
               .value_or(rowCount);
     if (startPos >= endPos) {
       break;
     }
 
-    chunk.encoding->reset();
-    chunk.encoding->skip(startPos);
+    chunk->encoding->reset();
+    chunk->encoding->skip(startPos);
     std::vector<std::string_view> entries(endPos - startPos);
-    chunk.encoding->materialize(endPos - startPos, entries.data());
+    chunk->encoding->materialize(endPos - startPos, entries.data());
     for (const auto& entry : entries) {
       matchedRows.emplace_back(extractRowId(entry));
     }

--- a/dwio/nimble/index/SortedIndex.h
+++ b/dwio/nimble/index/SortedIndex.h
@@ -99,7 +99,7 @@ class SortedIndex : public IndexLookup {
   uint32_t rowOffset(uint32_t chunkIdx) const;
 
   // Loads a chunk and creates the encoding without materializing entries.
-  DecodedKeyChunk loadChunk(uint32_t chunkIdx) const;
+  std::shared_ptr<DecodedKeyChunk> loadChunk(uint32_t chunkIdx) const;
 
   // Extracts the key prefix (without row ID suffix) from a composite entry.
   std::string_view extractKey(std::string_view compositeEntry) const;

--- a/dwio/nimble/index/tests/KeyChunkDecoderTest.cpp
+++ b/dwio/nimble/index/tests/KeyChunkDecoderTest.cpp
@@ -77,12 +77,13 @@ TEST_F(KeyChunkDecoderTest, decodeAndMaterialize) {
   auto chunkData = encodeChunk(keys);
 
   auto result = decodeKeyChunk(makeStream(chunkData), *leafPool_, dataBuffer_);
-  ASSERT_NE(result.encoding, nullptr);
-  EXPECT_EQ(result.encoding->rowCount(), 3);
-  EXPECT_EQ(result.encoding->encodingType(), EncodingType::Trivial);
+  ASSERT_NE(result, nullptr);
+  ASSERT_NE(result->encoding, nullptr);
+  EXPECT_EQ(result->encoding->rowCount(), 3);
+  EXPECT_EQ(result->encoding->encodingType(), EncodingType::Trivial);
 
   std::vector<std::string_view> materialized(3);
-  result.encoding->materialize(3, materialized.data());
+  result->encoding->materialize(3, materialized.data());
   EXPECT_EQ(materialized[0], "apple");
   EXPECT_EQ(materialized[1], "banana");
   EXPECT_EQ(materialized[2], "cherry");
@@ -93,20 +94,21 @@ TEST_F(KeyChunkDecoderTest, seekAndSelectiveMaterialize) {
   auto chunkData = encodeChunk(keys);
 
   auto result = decodeKeyChunk(makeStream(chunkData), *leafPool_, dataBuffer_);
-  ASSERT_NE(result.encoding, nullptr);
-  EXPECT_EQ(result.encoding->rowCount(), 5);
+  ASSERT_NE(result, nullptr);
+  ASSERT_NE(result->encoding, nullptr);
+  EXPECT_EQ(result->encoding->rowCount(), 5);
 
   // Seek to "ccc" (position 2).
   const std::string_view target = "ccc";
-  auto pos = result.encoding->seek(&target, /*inclusive=*/true);
+  auto pos = result->encoding->seek(&target, /*inclusive=*/true);
   ASSERT_TRUE(pos.has_value());
   EXPECT_EQ(pos.value(), 2);
 
   // Selectively materialize 2 entries from position 2.
-  result.encoding->reset();
-  result.encoding->skip(2);
+  result->encoding->reset();
+  result->encoding->skip(2);
   std::vector<std::string_view> entries(2);
-  result.encoding->materialize(2, entries.data());
+  result->encoding->materialize(2, entries.data());
   EXPECT_EQ(entries[0], "ccc");
   EXPECT_EQ(entries[1], "ddd");
 }
@@ -116,11 +118,12 @@ TEST_F(KeyChunkDecoderTest, singleEntry) {
   auto chunkData = encodeChunk(keys);
 
   auto result = decodeKeyChunk(makeStream(chunkData), *leafPool_, dataBuffer_);
-  ASSERT_NE(result.encoding, nullptr);
-  EXPECT_EQ(result.encoding->rowCount(), 1);
+  ASSERT_NE(result, nullptr);
+  ASSERT_NE(result->encoding, nullptr);
+  EXPECT_EQ(result->encoding->rowCount(), 1);
 
   std::vector<std::string_view> materialized(1);
-  result.encoding->materialize(1, materialized.data());
+  result->encoding->materialize(1, materialized.data());
   EXPECT_EQ(materialized[0], "only");
 }
 

--- a/dwio/nimble/serializer/Deserializer.cpp
+++ b/dwio/nimble/serializer/Deserializer.cpp
@@ -115,11 +115,9 @@ class DeserializerImpl : public Decoder {
       const Type* type,
       bool inMapStream,
       bool enableBufferPool,
-      velox::memory::MemoryPool* pool,
-      ZSTD_DCtx* dctx)
+      velox::memory::MemoryPool* pool)
       : type_{type},
         pool_{pool},
-        dctx_{dctx},
         inMapStream_{inMapStream},
         scalarKind_{getScalarKindForType(*type)},
         typeStorageWidth_{getTypeStorageWidth(*type)},
@@ -239,7 +237,7 @@ class DeserializerImpl : public Decoder {
         .bufferPool = bufferPool_.get(),
     };
     streamData_.emplace(
-        scalarKind_, segment.data, stringBuffers, pool_, options, dctx_);
+        scalarKind_, segment.data, stringBuffers, pool_, options);
     return *streamData_;
   }
 
@@ -561,7 +559,6 @@ class DeserializerImpl : public Decoder {
   // --- Const members (set at construction, never modified) ---
   const Type* const type_;
   velox::memory::MemoryPool* const pool_;
-  ZSTD_DCtx* const dctx_;
   // True for inMap streams (fills with 'false' when missing), false for nulls
   // streams (fills with 'true' when missing).
   const bool inMapStream_;
@@ -681,17 +678,6 @@ Deserializer::Deserializer(
     velox::memory::MemoryPool* pool,
     DeserializerOptions options)
     : schema_{std::move(schema)}, pool_{pool}, options_{std::move(options)} {
-  NIMBLE_USER_CHECK(
-      !(options_.shareZstdDecompressionContext &&
-        (options_.decodeExecutor != nullptr ||
-         options_.maxDecodeParallelism != 0)),
-      "shareZstdDecompressionContext is mutually exclusive with parallel "
-      "decoding (decodeExecutor and maxDecodeParallelism); a single "
-      "ZSTD_DCtx is not safe to use concurrently");
-  if (options_.shareZstdDecompressionContext) {
-    dctx_.reset(ZSTD_createDCtx());
-  }
-
   const auto params = createFieldReaderParams();
 
   std::shared_ptr<const velox::dwio::common::TypeWithId> schemaWithId =
@@ -729,8 +715,7 @@ void Deserializer::createDeserializersForType(
           &type,
           /*inMapStream=*/false,
           options_.enableBufferPool,
-          pool_,
-          dctx_.get());
+          pool_);
   // FlatMap is only supported at depth 1 (top-level columns). FlatMap keys can
   // vary across batches, causing gaps in nulls/inMap streams. Gap detection is
   // enabled in DeserializerImpl whenever type->isFlatMap().
@@ -744,8 +729,7 @@ void Deserializer::createDeserializersForType(
           &type,
           /*inMapStream=*/true,
           options_.enableBufferPool,
-          pool_,
-          dctx_.get());
+          pool_);
       inMapChildTypes_[inMapOffset] = flatMap.childAt(i).get();
     }
   }
@@ -770,7 +754,7 @@ void Deserializer::deserialize(
   // Iterate batches and add stream data with row offsets. Streams missing from
   // a batch will have gaps that are filled later during reading.
   uint32_t rowOffset{0};
-  serde::StreamDataReader reader{pool_, options_, dctx_.get()};
+  serde::StreamDataReader reader{pool_, options_};
   for (auto sv : data) {
     const auto batchRows = reader.initialize(sv);
     const auto version = reader.version();

--- a/dwio/nimble/serializer/Deserializer.h
+++ b/dwio/nimble/serializer/Deserializer.h
@@ -15,8 +15,6 @@
  */
 #pragma once
 
-#include <zstd.h>
-
 #include "dwio/nimble/serializer/Options.h"
 #include "dwio/nimble/velox/FieldReader.h"
 #include "folly/container/F14Map.h"
@@ -43,12 +41,6 @@ class Deserializer {
       velox::VectorPtr& vector) const;
 
  private:
-  struct ZstdDCtxDeleter {
-    void operator()(ZSTD_DCtx* ctx) const {
-      ZSTD_freeDCtx(ctx);
-    }
-  };
-
   // Creates deserializers for a type and its FlatMap inMap streams.
   void createDeserializersForType(const Type& type, uint32_t depth);
 
@@ -87,9 +79,6 @@ class Deserializer {
   // Offsets that were set in inMapPresentOffsets_ this batch (for efficient
   // reset).
   mutable std::vector<uint32_t> inMapPresentOffsetsList_;
-
-  // Created only when options.shareZstdDecompressionContext is true.
-  mutable std::unique_ptr<ZSTD_DCtx, ZstdDCtxDeleter> dctx_;
 };
 
 } // namespace facebook::nimble

--- a/dwio/nimble/serializer/DeserializerImpl.cpp
+++ b/dwio/nimble/serializer/DeserializerImpl.cpp
@@ -26,16 +26,28 @@
 
 namespace facebook::nimble::serde {
 
+namespace {
+ZSTD_DCtx* getThreadLocalDCtx() {
+  struct DCtxDeleter {
+    void operator()(ZSTD_DCtx* ctx) const {
+      ZSTD_freeDCtx(ctx);
+    }
+  };
+  static thread_local std::unique_ptr<ZSTD_DCtx, DCtxDeleter> ctx{
+      ZSTD_createDCtx()};
+  NIMBLE_CHECK(ctx != nullptr, "Failed to create ZSTD decompression context");
+  return ctx.get();
+}
+} // namespace
+
 StreamData::StreamData(
     ScalarKind kind,
     std::string_view data,
     std::vector<velox::BufferPtr>& stringBuffers,
     velox::memory::MemoryPool* pool,
-    const Options& options,
-    ZSTD_DCtx* dctx)
+    const Options& options)
     : kind_{kind},
       pool_{pool},
-      dctx_{dctx},
       encodingEnabled_{nonLegacyFormat(options.version)},
       useVarintRowCount_{!isTabletRawFormat(options.version)},
       bufferPool_{options.bufferPool},
@@ -111,17 +123,12 @@ void StreamData::decompress() {
               decompressedSize != ZSTD_CONTENTSIZE_UNKNOWN,
           "Error determining decompressed size");
       decompressionBuffer_.resize(decompressedSize);
-      const auto ret = dctx_ ? ZSTD_decompressDCtx(
-                                   dctx_,
-                                   decompressionBuffer_.data(),
-                                   decompressedSize,
-                                   pos_,
-                                   compressedSize)
-                             : ZSTD_decompress(
-                                   decompressionBuffer_.data(),
-                                   decompressedSize,
-                                   pos_,
-                                   compressedSize);
+      const auto ret = ZSTD_decompressDCtx(
+          getThreadLocalDCtx(),
+          decompressionBuffer_.data(),
+          decompressedSize,
+          pos_,
+          compressedSize);
       NIMBLE_CHECK(!ZSTD_isError(ret), "Error decompressing data");
       pos_ = decompressionBuffer_.data();
       end_ = pos_ + decompressionBuffer_.size();
@@ -211,12 +218,8 @@ uint32_t StreamData::decode(
 
 StreamDataReader::StreamDataReader(
     velox::memory::MemoryPool* pool,
-    const DeserializerOptions& options,
-    ZSTD_DCtx* dctx)
-    : options_{options},
-      pool_{pool},
-      dctx_{dctx},
-      chunkStrippingBuffer_{pool_} {
+    const DeserializerOptions& options)
+    : options_{options}, pool_{pool}, chunkStrippingBuffer_{pool_} {
   NIMBLE_CHECK_NOT_NULL(pool_);
 }
 
@@ -359,17 +362,12 @@ void StreamDataReader::appendChunkData(
           "Error determining decompressed size");
       const auto offset = chunkStrippingBuffer_.size();
       chunkStrippingBuffer_.resize(offset + decompressedSize);
-      const auto ret = dctx_ ? ZSTD_decompressDCtx(
-                                   dctx_,
-                                   chunkStrippingBuffer_.data() + offset,
-                                   decompressedSize,
-                                   data,
-                                   length)
-                             : ZSTD_decompress(
-                                   chunkStrippingBuffer_.data() + offset,
-                                   decompressedSize,
-                                   data,
-                                   length);
+      const auto ret = ZSTD_decompressDCtx(
+          getThreadLocalDCtx(),
+          chunkStrippingBuffer_.data() + offset,
+          decompressedSize,
+          data,
+          length);
       NIMBLE_CHECK(!ZSTD_isError(ret), "Error decompressing chunk data");
       break;
     }

--- a/dwio/nimble/serializer/DeserializerImpl.h
+++ b/dwio/nimble/serializer/DeserializerImpl.h
@@ -65,16 +65,12 @@ class StreamData {
   /// @param stringBuffers External vector where string buffers from encoding
   ///        are stored. The caller must keep the vector alive while
   ///        string_views from this StreamData are in use.
-  /// @param dctx Optional reusable ZSTD decompression context. When non-null,
-  ///        ZSTD_decompressDCtx is used instead of ZSTD_decompress, avoiding
-  ///        per-call allocation of a ~100-200KB DCtx.
   StreamData(
       ScalarKind kind,
       std::string_view data,
       std::vector<velox::BufferPtr>& stringBuffers,
       velox::memory::MemoryPool* pool,
-      const Options& options,
-      ZSTD_DCtx* dctx = nullptr);
+      const Options& options);
 
   uint32_t copyTo(char* output, uint32_t bufferSize);
 
@@ -133,9 +129,6 @@ class StreamData {
 
   const ScalarKind kind_{ScalarKind::Undefined};
   velox::memory::MemoryPool* const pool_{nullptr};
-  // Optional reusable ZSTD decompression context. Non-owning; caller manages
-  // lifetime. When non-null, avoids per-call ZSTD_DCtx allocation (~100-200KB).
-  ZSTD_DCtx* const dctx_{nullptr};
   // Whether nimble encoding is enabled. Non-const to allow reset() to change.
   bool encodingEnabled_{false};
   // Whether encoding headers use varint row counts (true for kCompact/
@@ -172,8 +165,7 @@ class StreamDataReader {
  public:
   StreamDataReader(
       velox::memory::MemoryPool* pool,
-      const DeserializerOptions& options,
-      ZSTD_DCtx* dctx = nullptr);
+      const DeserializerOptions& options);
 
   /// Returns number of rows serialized.
   /// Validates that the version in serialized data matches options.
@@ -225,7 +217,6 @@ class StreamDataReader {
 
   const DeserializerOptions& options_;
   velox::memory::MemoryPool* const pool_;
-  ZSTD_DCtx* const dctx_{nullptr};
 
   // Serialization version detected from data. If the data has a version
   // header, this is read from the first byte; otherwise defaults to kLegacy.

--- a/dwio/nimble/serializer/Options.h
+++ b/dwio/nimble/serializer/Options.h
@@ -236,13 +236,6 @@ struct DeserializerOptions {
   /// Minimum number of child streams per parallel decode task. Ensures each
   /// coroutine task has enough work to amortize threading overhead.
   uint32_t minStreamsPerDecodeUnit{1};
-
-  /// When true, the Deserializer creates a single ZSTD_DCtx and shares it
-  /// across all StreamData objects to avoid per-call allocation of a
-  /// ~100-200KB DCtx by ZSTD_decompress(). Mutually exclusive with parallel
-  /// decoding (decodeExecutor != nullptr or maxDecodeParallelism != 0),
-  /// because a single ZSTD_DCtx is not safe to use concurrently.
-  bool shareZstdDecompressionContext{false};
 };
 
 } // namespace facebook::nimble

--- a/dwio/nimble/serializer/tests/OptionsTest.cpp
+++ b/dwio/nimble/serializer/tests/OptionsTest.cpp
@@ -113,7 +113,6 @@ TEST(OptionsTest, deserializerOptionsDefaults) {
   DeserializerOptions options{};
 
   EXPECT_FALSE(options.hasHeader);
-  EXPECT_FALSE(options.shareZstdDecompressionContext);
   EXPECT_EQ(options.decodeExecutor, nullptr);
   EXPECT_EQ(options.maxDecodeParallelism, 0u);
 }

--- a/dwio/nimble/serializer/tests/SerializationTest.cpp
+++ b/dwio/nimble/serializer/tests/SerializationTest.cpp
@@ -16,6 +16,7 @@
 #include <folly/Random.h>
 #include <folly/executors/CPUThreadPoolExecutor.h>
 #include <gtest/gtest.h>
+#include <thread>
 
 #include "dwio/nimble/common/tests/GTestUtils.h"
 #include "dwio/nimble/serializer/Deserializer.h"
@@ -2989,11 +2990,10 @@ TEST_F(SerializationTest, tabletRawDeserialization) {
   }
 }
 
-// Verifies that the Deserializer constructed with
-// shareZstdDecompressionContext=true successfully round-trips a kTabletRaw
-// stream containing zstd-compressed chunks. Exercises the shared ZSTD_DCtx
-// path through StreamDataReader and StreamData.
-TEST_F(SerializationTest, shareZstdDecompressionContextRoundTrip) {
+// Verifies ZSTD decompression round-trips correctly with the thread-local
+// ZSTD_DCtx reuse (always-on). Exercises the StreamDataReader and StreamData
+// decompress paths with kTabletRaw chunked format.
+TEST_F(SerializationTest, zstdThreadLocalDCtxRoundTrip) {
   auto rowType = velox::ROW(
       {{"col_a", velox::INTEGER()},
        {"col_b", velox::BIGINT()},
@@ -3012,11 +3012,61 @@ TEST_F(SerializationTest, shareZstdDecompressionContextRoundTrip) {
       serializeTabletRaw(rowType, {input}, /*enableChunking=*/true);
 
   nimble::Deserializer deserializer(
+      tabletRaw.schema, pool_.get(), DeserializerOptions{.hasHeader = true});
+
+  velox::VectorPtr deserialized;
+  for (const auto& assembled : tabletRaw.serialized) {
+    velox::VectorPtr stripeOutput;
+    deserializer.deserialize(std::string_view(assembled), stripeOutput);
+    ASSERT_NE(stripeOutput, nullptr);
+
+    if (deserialized == nullptr) {
+      deserialized = stripeOutput;
+    } else {
+      auto oldSize = deserialized->size();
+      deserialized->resize(oldSize + stripeOutput->size());
+      deserialized->copy(stripeOutput.get(), oldSize, 0, stripeOutput->size());
+    }
+  }
+
+  ASSERT_NE(deserialized, nullptr);
+  ASSERT_EQ(deserialized->size(), numRows);
+
+  for (velox::vector_size_t i = 0; i < numRows; ++i) {
+    ASSERT_TRUE(input->equalValueAt(deserialized.get(), i, i))
+        << "Mismatch at row " << i << "\nExpected: " << input->toString(i)
+        << "\nActual: " << deserialized->toString(i);
+  }
+}
+
+// Verifies ZSTD thread-local DCtx works correctly with parallel decode
+// (multiple threads each get their own context).
+TEST_F(SerializationTest, zstdThreadLocalDCtxWithParallelDecode) {
+  auto rowType = velox::ROW(
+      {{"col_a", velox::INTEGER()},
+       {"col_b", velox::BIGINT()},
+       {"col_c", velox::VARCHAR()}});
+
+  const int numRows = 100;
+  velox::VectorFuzzer fuzzer(
+      {.vectorSize = static_cast<size_t>(numRows),
+       .nullRatio = 0,
+       .stringLength = 20,
+       .stringVariableLength = true},
+      pool_.get());
+  auto input = fuzzer.fuzzInputRow(rowType);
+
+  auto tabletRaw =
+      serializeTabletRaw(rowType, {input}, /*enableChunking=*/true);
+
+  folly::CPUThreadPoolExecutor executor(2);
+  nimble::Deserializer deserializer(
       tabletRaw.schema,
       pool_.get(),
       DeserializerOptions{
           .hasHeader = true,
-          .shareZstdDecompressionContext = true,
+          .decodeExecutor = &executor,
+          .maxDecodeParallelism = 2,
       });
 
   velox::VectorPtr deserialized;
@@ -3044,53 +3094,528 @@ TEST_F(SerializationTest, shareZstdDecompressionContextRoundTrip) {
   }
 }
 
-// shareZstdDecompressionContext is incompatible with parallel decoding
-// because a single ZSTD_DCtx is not safe to use concurrently. The
-// Deserializer constructor must reject the combination.
-TEST_F(SerializationTest, shareZstdDecompressionContextRejectsDecodeExecutor) {
-  auto rowType = velox::ROW({{"col_a", velox::INTEGER()}});
-  auto tabletRaw = serializeTabletRaw(
-      rowType,
-      {velox::VectorFuzzer({.vectorSize = 4}, pool_.get())
-           .fuzzInputRow(rowType)},
-      /*enableChunking=*/true);
+// Stress-tests thread-local ZSTD_DCtx under high parallelism with many
+// columns and forced ZSTD compression, ensuring each thread's DCtx produces
+// correct results without cross-thread interference.
+TEST_F(SerializationTest, zstdThreadLocalDCtxHighParallelism) {
+  auto rowType = velox::ROW(
+      {{"col_a", velox::INTEGER()},
+       {"col_b", velox::BIGINT()},
+       {"col_c", velox::VARCHAR()},
+       {"col_d", velox::DOUBLE()},
+       {"col_e", velox::INTEGER()},
+       {"col_f", velox::BIGINT()},
+       {"col_g", velox::VARCHAR()},
+       {"col_h", velox::DOUBLE()}});
 
-  folly::CPUThreadPoolExecutor executor(1);
-  NIMBLE_ASSERT_USER_THROW(
-      nimble::Deserializer(
-          tabletRaw.schema,
-          pool_.get(),
-          DeserializerOptions{
-              .hasHeader = true,
-              .decodeExecutor = &executor,
-              .maxDecodeParallelism = 2,
-              .shareZstdDecompressionContext = true,
-          }),
-      "shareZstdDecompressionContext is mutually exclusive");
+  const int numRows = 1000;
+  velox::VectorFuzzer fuzzer(
+      {.vectorSize = static_cast<size_t>(numRows),
+       .nullRatio = 0,
+       .stringLength = 50,
+       .stringVariableLength = true},
+      pool_.get());
+  auto input = fuzzer.fuzzInputRow(rowType);
+
+  std::string fileData;
+  {
+    auto writeFile = std::make_unique<velox::InMemoryWriteFile>(&fileData);
+    nimble::VeloxWriterOptions writerOptions;
+    writerOptions.enableChunking = true;
+    writerOptions.compressionOptions.compressionType =
+        nimble::CompressionType::Zstd;
+    writerOptions.compressionOptions.zstdMinCompressionSize = 0;
+    nimble::VeloxWriter writer(
+        rowType, std::move(writeFile), *rootPool_, std::move(writerOptions));
+    writer.write(input);
+    writer.close();
+  }
+
+  auto readFile =
+      std::make_shared<velox::InMemoryReadFile>(std::string_view(fileData));
+  auto tablet = nimble::TabletReader::create(
+      readFile, pool_.get(), nimble::TabletReader::Options{});
+  auto schemaSection =
+      tablet->loadOptionalSection(std::string(nimble::kSchemaSection));
+  auto nimbleSchema =
+      nimble::SchemaDeserializer::deserialize(schemaSection->content().data());
+
+  std::set<uint32_t> offsetSet;
+  collectStreamOffsets(*nimbleSchema, offsetSet);
+  std::vector<uint32_t> streamOffsets(offsetSet.begin(), offsetSet.end());
+
+  std::vector<std::string> assembledBuffers;
+  for (uint32_t stripeIdx = 0; stripeIdx < tablet->stripeCount(); ++stripeIdx) {
+    const auto stripeId = tablet->stripeIdentifier(stripeIdx);
+    auto streamLoaders = tablet->load(stripeId, streamOffsets);
+    const auto stripeRows = tablet->stripeRowCount(stripeIdx);
+
+    std::string headerBuf;
+    serde::detail::writeHeader(
+        headerBuf, nimble::SerializationVersion::kTabletRaw, stripeRows);
+
+    const auto maxOffset = streamOffsets.back();
+    std::string streamData;
+    std::vector<uint32_t> streamSizes(maxOffset + 1, 0);
+    for (size_t i = 0; i < streamLoaders.size(); ++i) {
+      if (streamLoaders[i] == nullptr) {
+        continue;
+      }
+      auto stream = streamLoaders[i]->getStream();
+      streamData.append(stream.data(), stream.size());
+      streamSizes[streamOffsets[i]] = static_cast<uint32_t>(stream.size());
+    }
+
+    std::string trailerBuf;
+    serde::detail::writeRawTrailer(
+        streamSizes, nimble::EncodingType::Trivial, trailerBuf);
+
+    std::string assembled;
+    assembled.reserve(headerBuf.size() + streamData.size() + trailerBuf.size());
+    assembled.append(headerBuf);
+    assembled.append(streamData);
+    assembled.append(trailerBuf);
+    assembledBuffers.push_back(std::move(assembled));
+  }
+
+  folly::CPUThreadPoolExecutor executor(8);
+  nimble::Deserializer deserializer(
+      nimbleSchema,
+      pool_.get(),
+      DeserializerOptions{
+          .hasHeader = true,
+          .decodeExecutor = &executor,
+          .maxDecodeParallelism = 8,
+      });
+
+  velox::VectorPtr deserialized;
+  for (const auto& assembled : assembledBuffers) {
+    velox::VectorPtr stripeOutput;
+    deserializer.deserialize(std::string_view(assembled), stripeOutput);
+    ASSERT_NE(stripeOutput, nullptr);
+
+    if (deserialized == nullptr) {
+      deserialized = stripeOutput;
+    } else {
+      auto oldSize = deserialized->size();
+      deserialized->resize(oldSize + stripeOutput->size());
+      deserialized->copy(stripeOutput.get(), oldSize, 0, stripeOutput->size());
+    }
+  }
+
+  ASSERT_NE(deserialized, nullptr);
+  ASSERT_EQ(deserialized->size(), numRows);
+
+  for (velox::vector_size_t i = 0; i < numRows; ++i) {
+    ASSERT_TRUE(input->equalValueAt(deserialized.get(), i, i))
+        << "Mismatch at row " << i << "\nExpected: " << input->toString(i)
+        << "\nActual: " << deserialized->toString(i);
+  }
 }
 
-TEST_F(
-    SerializationTest,
-    shareZstdDecompressionContextRejectsMaxDecodeParallelism) {
-  auto rowType = velox::ROW({{"col_a", velox::INTEGER()}});
-  auto tabletRaw = serializeTabletRaw(
-      rowType,
-      {velox::VectorFuzzer({.vectorSize = 4}, pool_.get())
-           .fuzzInputRow(rowType)},
-      /*enableChunking=*/true);
+// Verifies thread-local ZSTD_DCtx correctness when multiple Deserializers
+// run concurrently on separate threads, each with their own data.
+TEST_F(SerializationTest, zstdThreadLocalDCtxConcurrentDeserializers) {
+  auto rowType = velox::ROW(
+      {{"col_a", velox::INTEGER()},
+       {"col_b", velox::BIGINT()},
+       {"col_c", velox::VARCHAR()}});
 
-  // decodeExecutor is null but maxDecodeParallelism alone still triggers
-  // rejection.
-  NIMBLE_ASSERT_USER_THROW(
-      nimble::Deserializer(
-          tabletRaw.schema,
-          pool_.get(),
-          DeserializerOptions{
-              .hasHeader = true,
-              .maxDecodeParallelism = 2,
-              .shareZstdDecompressionContext = true,
-          }),
-      "shareZstdDecompressionContext is mutually exclusive");
+  const int numRows = 500;
+  const int numThreads = 4;
+
+  std::vector<velox::VectorPtr> inputs;
+  for (int t = 0; t < numThreads; ++t) {
+    velox::VectorFuzzer fuzzer(
+        {.vectorSize = static_cast<size_t>(numRows),
+         .nullRatio = 0,
+         .stringLength = 30,
+         .stringVariableLength = true},
+        pool_.get(),
+        t);
+    inputs.push_back(fuzzer.fuzzInputRow(rowType));
+  }
+
+  std::vector<std::vector<std::string>> allAssembled(numThreads);
+  std::vector<std::shared_ptr<const Type>> schemas(numThreads);
+  for (int t = 0; t < numThreads; ++t) {
+    std::string fileData;
+    {
+      auto writeFile = std::make_unique<velox::InMemoryWriteFile>(&fileData);
+      nimble::VeloxWriterOptions writerOptions;
+      writerOptions.enableChunking = true;
+      writerOptions.compressionOptions.compressionType =
+          nimble::CompressionType::Zstd;
+      writerOptions.compressionOptions.zstdMinCompressionSize = 0;
+      nimble::VeloxWriter writer(
+          rowType, std::move(writeFile), *rootPool_, std::move(writerOptions));
+      writer.write(inputs[t]);
+      writer.close();
+    }
+
+    auto readFile =
+        std::make_shared<velox::InMemoryReadFile>(std::string_view(fileData));
+    auto tablet = nimble::TabletReader::create(
+        readFile, pool_.get(), nimble::TabletReader::Options{});
+    auto schemaSection =
+        tablet->loadOptionalSection(std::string(nimble::kSchemaSection));
+    schemas[t] = nimble::SchemaDeserializer::deserialize(
+        schemaSection->content().data());
+
+    std::set<uint32_t> offsetSet;
+    collectStreamOffsets(*schemas[t], offsetSet);
+    std::vector<uint32_t> streamOffsets(offsetSet.begin(), offsetSet.end());
+
+    for (uint32_t si = 0; si < tablet->stripeCount(); ++si) {
+      const auto stripeId = tablet->stripeIdentifier(si);
+      auto streamLoaders = tablet->load(stripeId, streamOffsets);
+      const auto stripeRows = tablet->stripeRowCount(si);
+
+      std::string headerBuf;
+      serde::detail::writeHeader(
+          headerBuf, nimble::SerializationVersion::kTabletRaw, stripeRows);
+
+      const auto maxOffset = streamOffsets.back();
+      std::string streamData;
+      std::vector<uint32_t> streamSizes(maxOffset + 1, 0);
+      for (size_t i = 0; i < streamLoaders.size(); ++i) {
+        if (streamLoaders[i] == nullptr) {
+          continue;
+        }
+        auto stream = streamLoaders[i]->getStream();
+        streamData.append(stream.data(), stream.size());
+        streamSizes[streamOffsets[i]] = static_cast<uint32_t>(stream.size());
+      }
+
+      std::string trailerBuf;
+      serde::detail::writeRawTrailer(
+          streamSizes, nimble::EncodingType::Trivial, trailerBuf);
+
+      std::string assembled;
+      assembled.reserve(
+          headerBuf.size() + streamData.size() + trailerBuf.size());
+      assembled.append(headerBuf);
+      assembled.append(streamData);
+      assembled.append(trailerBuf);
+      allAssembled[t].push_back(std::move(assembled));
+    }
+  }
+
+  std::vector<std::thread> threads;
+  std::vector<std::atomic<bool>> success(numThreads);
+  for (int t = 0; t < numThreads; ++t) {
+    success[t].store(false);
+  }
+
+  for (int t = 0; t < numThreads; ++t) {
+    threads.emplace_back([&, t]() {
+      auto threadPool = velox::memory::memoryManager()->addLeafPool(
+          "thread_" + std::to_string(t));
+      nimble::Deserializer deserializer(
+          schemas[t], threadPool.get(), DeserializerOptions{.hasHeader = true});
+
+      velox::VectorPtr deserialized;
+      for (const auto& assembled : allAssembled[t]) {
+        velox::VectorPtr stripeOutput;
+        deserializer.deserialize(std::string_view(assembled), stripeOutput);
+        if (stripeOutput == nullptr) {
+          return;
+        }
+
+        if (deserialized == nullptr) {
+          deserialized = stripeOutput;
+        } else {
+          auto oldSize = deserialized->size();
+          deserialized->resize(oldSize + stripeOutput->size());
+          deserialized->copy(
+              stripeOutput.get(), oldSize, 0, stripeOutput->size());
+        }
+      }
+
+      if (deserialized == nullptr ||
+          deserialized->size() != static_cast<size_t>(numRows)) {
+        return;
+      }
+      for (velox::vector_size_t i = 0; i < numRows; ++i) {
+        if (!inputs[t]->equalValueAt(deserialized.get(), i, i)) {
+          return;
+        }
+      }
+      success[t].store(true);
+    });
+  }
+
+  for (auto& thread : threads) {
+    thread.join();
+  }
+  for (int t = 0; t < numThreads; ++t) {
+    ASSERT_TRUE(success[t].load()) << "Thread " << t << " failed";
+  }
+}
+
+// Verifies thread-local ZSTD_DCtx works correctly with a flat-map schema
+// that produces many ZSTD-compressed key streams, combined with parallel
+// decode.
+TEST_F(SerializationTest, zstdThreadLocalDCtxFlatMapWithParallelDecode) {
+  auto rowType = velox::ROW(
+      {{"id", velox::BIGINT()},
+       {"features", velox::MAP(velox::INTEGER(), velox::REAL())}});
+
+  const int numRows = 500;
+  const int numKeys = 20;
+  const int totalEntries = numRows * numKeys;
+
+  auto ids = velox::BaseVector::create(velox::BIGINT(), numRows, pool_.get());
+  for (velox::vector_size_t i = 0; i < numRows; ++i) {
+    ids->asFlatVector<int64_t>()->set(i, i);
+  }
+
+  auto keys =
+      velox::BaseVector::create(velox::INTEGER(), totalEntries, pool_.get());
+  auto values =
+      velox::BaseVector::create(velox::REAL(), totalEntries, pool_.get());
+  for (velox::vector_size_t i = 0; i < totalEntries; ++i) {
+    keys->asFlatVector<int32_t>()->set(i, i % numKeys);
+    values->asFlatVector<float>()->set(i, static_cast<float>(i) * 0.1f);
+  }
+
+  auto offsets = velox::AlignedBuffer::allocate<velox::vector_size_t>(
+      numRows, pool_.get());
+  auto sizes = velox::AlignedBuffer::allocate<velox::vector_size_t>(
+      numRows, pool_.get());
+  auto rawOffsets = offsets->asMutable<velox::vector_size_t>();
+  auto rawSizes = sizes->asMutable<velox::vector_size_t>();
+  for (velox::vector_size_t i = 0; i < numRows; ++i) {
+    rawOffsets[i] = i * numKeys;
+    rawSizes[i] = numKeys;
+  }
+
+  auto mapVector = std::make_shared<velox::MapVector>(
+      pool_.get(),
+      velox::MAP(velox::INTEGER(), velox::REAL()),
+      nullptr,
+      numRows,
+      offsets,
+      sizes,
+      keys,
+      values);
+
+  auto input = std::make_shared<velox::RowVector>(
+      pool_.get(),
+      rowType,
+      nullptr,
+      numRows,
+      std::vector<velox::VectorPtr>{ids, mapVector});
+
+  std::string fileData;
+  {
+    auto writeFile = std::make_unique<velox::InMemoryWriteFile>(&fileData);
+    nimble::VeloxWriterOptions writerOptions;
+    writerOptions.enableChunking = true;
+    writerOptions.compressionOptions.compressionType =
+        nimble::CompressionType::Zstd;
+    writerOptions.compressionOptions.zstdMinCompressionSize = 0;
+    writerOptions.flatMapColumns = {{"features", {}}};
+    nimble::VeloxWriter writer(
+        rowType, std::move(writeFile), *rootPool_, std::move(writerOptions));
+    writer.write(input);
+    writer.close();
+  }
+
+  auto readFile =
+      std::make_shared<velox::InMemoryReadFile>(std::string_view(fileData));
+  auto tablet = nimble::TabletReader::create(
+      readFile, pool_.get(), nimble::TabletReader::Options{});
+  auto schemaSection =
+      tablet->loadOptionalSection(std::string(nimble::kSchemaSection));
+  auto nimbleSchema =
+      nimble::SchemaDeserializer::deserialize(schemaSection->content().data());
+
+  std::set<uint32_t> offsetSet;
+  collectStreamOffsets(*nimbleSchema, offsetSet);
+  std::vector<uint32_t> streamOffsets(offsetSet.begin(), offsetSet.end());
+
+  std::vector<std::string> assembledBuffers;
+  for (uint32_t stripeIdx = 0; stripeIdx < tablet->stripeCount(); ++stripeIdx) {
+    const auto stripeId = tablet->stripeIdentifier(stripeIdx);
+    auto streamLoaders = tablet->load(stripeId, streamOffsets);
+    const auto stripeRows = tablet->stripeRowCount(stripeIdx);
+
+    std::string headerBuf;
+    serde::detail::writeHeader(
+        headerBuf, nimble::SerializationVersion::kTabletRaw, stripeRows);
+
+    const auto maxOffset = streamOffsets.back();
+    std::string streamData;
+    std::vector<uint32_t> streamSizes(maxOffset + 1, 0);
+    for (size_t i = 0; i < streamLoaders.size(); ++i) {
+      if (streamLoaders[i] == nullptr) {
+        continue;
+      }
+      auto stream = streamLoaders[i]->getStream();
+      streamData.append(stream.data(), stream.size());
+      streamSizes[streamOffsets[i]] = static_cast<uint32_t>(stream.size());
+    }
+
+    std::string trailerBuf;
+    serde::detail::writeRawTrailer(
+        streamSizes, nimble::EncodingType::Trivial, trailerBuf);
+
+    std::string assembled;
+    assembled.reserve(headerBuf.size() + streamData.size() + trailerBuf.size());
+    assembled.append(headerBuf);
+    assembled.append(streamData);
+    assembled.append(trailerBuf);
+    assembledBuffers.push_back(std::move(assembled));
+  }
+
+  folly::CPUThreadPoolExecutor executor(4);
+  nimble::Deserializer deserializer(
+      nimbleSchema,
+      pool_.get(),
+      DeserializerOptions{
+          .hasHeader = true,
+          .decodeExecutor = &executor,
+          .maxDecodeParallelism = 4,
+      });
+
+  velox::VectorPtr deserialized;
+  for (const auto& assembled : assembledBuffers) {
+    velox::VectorPtr stripeOutput;
+    deserializer.deserialize(std::string_view(assembled), stripeOutput);
+    ASSERT_NE(stripeOutput, nullptr);
+
+    if (deserialized == nullptr) {
+      deserialized = stripeOutput;
+    } else {
+      auto oldSize = deserialized->size();
+      deserialized->resize(oldSize + stripeOutput->size());
+      deserialized->copy(stripeOutput.get(), oldSize, 0, stripeOutput->size());
+    }
+  }
+
+  ASSERT_NE(deserialized, nullptr);
+  ASSERT_EQ(deserialized->size(), numRows);
+
+  for (velox::vector_size_t i = 0; i < numRows; ++i) {
+    ASSERT_TRUE(input->equalValueAt(deserialized.get(), i, i))
+        << "Mismatch at row " << i << "\nExpected: " << input->toString(i)
+        << "\nActual: " << deserialized->toString(i);
+  }
+}
+
+// Verifies thread-local ZSTD_DCtx correctness across repeated batches
+// deserialized sequentially, ensuring the DCtx state resets properly.
+TEST_F(SerializationTest, zstdThreadLocalDCtxRepeatedBatches) {
+  auto rowType =
+      velox::ROW({{"col_a", velox::INTEGER()}, {"col_b", velox::VARCHAR()}});
+
+  const int numBatches = 20;
+  const int rowsPerBatch = 200;
+
+  std::vector<velox::VectorPtr> inputs;
+  for (int b = 0; b < numBatches; ++b) {
+    velox::VectorFuzzer fuzzer(
+        {.vectorSize = static_cast<size_t>(rowsPerBatch),
+         .nullRatio = 0,
+         .stringLength = 40,
+         .stringVariableLength = true},
+        pool_.get(),
+        b);
+    inputs.push_back(fuzzer.fuzzInputRow(rowType));
+  }
+
+  std::string fileData;
+  {
+    auto writeFile = std::make_unique<velox::InMemoryWriteFile>(&fileData);
+    nimble::VeloxWriterOptions writerOptions;
+    writerOptions.enableChunking = true;
+    writerOptions.compressionOptions.compressionType =
+        nimble::CompressionType::Zstd;
+    writerOptions.compressionOptions.zstdMinCompressionSize = 0;
+    nimble::VeloxWriter writer(
+        rowType, std::move(writeFile), *rootPool_, std::move(writerOptions));
+    for (const auto& input : inputs) {
+      writer.write(input);
+    }
+    writer.close();
+  }
+
+  auto readFile =
+      std::make_shared<velox::InMemoryReadFile>(std::string_view(fileData));
+  auto tablet = nimble::TabletReader::create(
+      readFile, pool_.get(), nimble::TabletReader::Options{});
+  auto schemaSection =
+      tablet->loadOptionalSection(std::string(nimble::kSchemaSection));
+  auto nimbleSchema =
+      nimble::SchemaDeserializer::deserialize(schemaSection->content().data());
+
+  std::set<uint32_t> offsetSet;
+  collectStreamOffsets(*nimbleSchema, offsetSet);
+  std::vector<uint32_t> streamOffsets(offsetSet.begin(), offsetSet.end());
+
+  std::vector<std::string> assembledBuffers;
+  for (uint32_t stripeIdx = 0; stripeIdx < tablet->stripeCount(); ++stripeIdx) {
+    const auto stripeId = tablet->stripeIdentifier(stripeIdx);
+    auto streamLoaders = tablet->load(stripeId, streamOffsets);
+    const auto stripeRows = tablet->stripeRowCount(stripeIdx);
+
+    std::string headerBuf;
+    serde::detail::writeHeader(
+        headerBuf, nimble::SerializationVersion::kTabletRaw, stripeRows);
+
+    const auto maxOffset = streamOffsets.back();
+    std::string streamData;
+    std::vector<uint32_t> streamSizes(maxOffset + 1, 0);
+    for (size_t i = 0; i < streamLoaders.size(); ++i) {
+      if (streamLoaders[i] == nullptr) {
+        continue;
+      }
+      auto stream = streamLoaders[i]->getStream();
+      streamData.append(stream.data(), stream.size());
+      streamSizes[streamOffsets[i]] = static_cast<uint32_t>(stream.size());
+    }
+
+    std::string trailerBuf;
+    serde::detail::writeRawTrailer(
+        streamSizes, nimble::EncodingType::Trivial, trailerBuf);
+
+    std::string assembled;
+    assembled.reserve(headerBuf.size() + streamData.size() + trailerBuf.size());
+    assembled.append(headerBuf);
+    assembled.append(streamData);
+    assembled.append(trailerBuf);
+    assembledBuffers.push_back(std::move(assembled));
+  }
+
+  folly::CPUThreadPoolExecutor executor(4);
+  nimble::Deserializer deserializer(
+      nimbleSchema,
+      pool_.get(),
+      DeserializerOptions{
+          .hasHeader = true,
+          .decodeExecutor = &executor,
+          .maxDecodeParallelism = 4,
+      });
+
+  velox::VectorPtr deserialized;
+  for (const auto& assembled : assembledBuffers) {
+    velox::VectorPtr stripeOutput;
+    deserializer.deserialize(std::string_view(assembled), stripeOutput);
+    ASSERT_NE(stripeOutput, nullptr);
+
+    if (deserialized == nullptr) {
+      deserialized = stripeOutput;
+    } else {
+      auto oldSize = deserialized->size();
+      deserialized->resize(oldSize + stripeOutput->size());
+      deserialized->copy(stripeOutput.get(), oldSize, 0, stripeOutput->size());
+    }
+  }
+
+  ASSERT_NE(deserialized, nullptr);
+  const int totalRows = numBatches * rowsPerBatch;
+  ASSERT_EQ(deserialized->size(), totalRows);
 }
 
 TEST_P(SerializationTest, flatMapDeserializeWithFlatMapSchema) {

--- a/dwio/nimble/serializer/tests/SerializerImplTest.cpp
+++ b/dwio/nimble/serializer/tests/SerializerImplTest.cpp
@@ -1611,13 +1611,6 @@ TEST_F(TabletRawChunkStripTest, largePayloadMultipleChunks) {
 
 class ZstdDCtxReuseTest : public TabletRawChunkStripTest {
  protected:
-  void SetUp() override {
-    TabletRawChunkStripTest::SetUp();
-    dctx_.reset(ZSTD_createDCtx());
-  }
-
-  // Build legacy-format compressed stream data for a non-string scalar:
-  // [CompressionType::Zstd (1B)][ZSTD-compressed payload]
   static std::string buildLegacyCompressedData(std::string_view payload) {
     std::string result;
     result.push_back(static_cast<char>(CompressionType::Zstd));
@@ -1654,7 +1647,7 @@ class ZstdDCtxReuseTest : public TabletRawChunkStripTest {
     serde::detail::writeRawTrailer(sizes, EncodingType::Trivial, buffer);
 
     DeserializerOptions options{.hasHeader = true};
-    StreamDataReader reader(pool_.get(), options, dctx_.get());
+    StreamDataReader reader(pool_.get(), options);
     auto actualRows = reader.initialize(std::string_view(buffer));
     EXPECT_EQ(actualRows, rowCount);
 
@@ -1664,14 +1657,6 @@ class ZstdDCtxReuseTest : public TabletRawChunkStripTest {
     });
     return result;
   }
-
-  struct DCtxDeleter {
-    void operator()(ZSTD_DCtx* ctx) const {
-      ZSTD_freeDCtx(ctx);
-    }
-  };
-
-  std::unique_ptr<ZSTD_DCtx, DCtxDeleter> dctx_;
 };
 
 TEST_F(ZstdDCtxReuseTest, streamDataLegacyZstdWithDCtx) {
@@ -1687,8 +1672,7 @@ TEST_F(ZstdDCtxReuseTest, streamDataLegacyZstdWithDCtx) {
       compressed,
       stringBuffers,
       pool_.get(),
-      serde::StreamData::Options{.version = SerializationVersion::kLegacy},
-      dctx_.get());
+      serde::StreamData::Options{.version = SerializationVersion::kLegacy});
 
   std::vector<int32_t> output(expected.size());
   sd.copyTo(
@@ -1715,8 +1699,7 @@ TEST_F(ZstdDCtxReuseTest, streamDataDCtxReusedAcrossReset) {
       compressed1,
       stringBuffers,
       pool_.get(),
-      serde::StreamData::Options{.version = SerializationVersion::kLegacy},
-      dctx_.get());
+      serde::StreamData::Options{.version = SerializationVersion::kLegacy});
 
   std::vector<int32_t> output1(values1.size());
   sd.copyTo(


### PR DESCRIPTION
Summary:
The string allocator lambda in `decodeKeyChunk` captured `result` (a local `DecodedKeyChunk`) by reference via `[&]`. After `decodeKeyChunk` returns and `result` is moved out, calling `materialize()` on the encoding invokes the lambda, which references `result.stringBuffers` on the destroyed stack frame (ASAN: stack-use-after-return).

Fix: change `stringBuffers` from `vector<BufferPtr>` to `shared_ptr<vector<BufferPtr>>` and capture the shared_ptr by value in the lambda. After the move, both the encoding's lambda and the new `DecodedKeyChunk` owner share the same vector.

This was latent because existing callers (`seekInChunk`) only call `seek()`, which doesn't allocate string buffers. The bug is triggered by `materialize()` (used by the upcoming `keyAtRow` API).

Reviewed By: xiaoxmeng

Differential Revision: D103765334


