### PR TITLE
perf(encoding): Add BufferPool support for decompression buffer reuse (#695)

### DIFF
--- a/dwio/nimble/encodings/Compression.cpp
+++ b/dwio/nimble/encodings/Compression.cpp
@@ -68,9 +68,10 @@ ICompressor& getCompressor(CompressionType compressionType) {
     velox::memory::MemoryPool& pool,
     CompressionType compressionType,
     DataType dataType,
-    std::string_view data) {
+    std::string_view data,
+    velox::BufferPool* bufferPool) {
   return getCompressor(compressionType)
-      .uncompress(pool, compressionType, dataType, data);
+      .uncompress(pool, compressionType, dataType, data, bufferPool);
 }
 
 /* static */ std::optional<size_t> Compression::uncompressedSize(

--- a/dwio/nimble/encodings/Compression.h
+++ b/dwio/nimble/encodings/Compression.h
@@ -21,6 +21,7 @@
 #include "dwio/nimble/encodings/EncodingSelection.h"
 #include "folly/io/IOBuf.h"
 #include "velox/buffer/Buffer.h"
+#include "velox/buffer/BufferPool.h"
 
 namespace facebook::nimble {
 
@@ -41,7 +42,8 @@ struct ICompressor {
       velox::memory::MemoryPool& pool,
       CompressionType compressionType,
       DataType dataType,
-      std::string_view data) = 0;
+      std::string_view data,
+      velox::BufferPool* bufferPool = nullptr) = 0;
 
   virtual std::optional<size_t> uncompressedSize(
       std::string_view data) const = 0;
@@ -50,6 +52,21 @@ struct ICompressor {
 
   virtual ~ICompressor() = default;
 };
+
+/// Allocates a buffer of at least 'bytes' capacity, trying the BufferPool
+/// first if available, falling back to MemoryPool allocation.
+inline velox::BufferPtr allocateBuffer(
+    velox::memory::MemoryPool& memoryPool,
+    velox::BufferPool* bufferPool,
+    uint64_t bytes) {
+  if (bufferPool != nullptr) {
+    if (auto buf = bufferPool->get(bytes)) {
+      buf->setSize(bytes);
+      return buf;
+    }
+  }
+  return velox::AlignedBuffer::allocate<char>(bytes, &memoryPool);
+}
 
 class Compression {
  public:
@@ -64,7 +81,8 @@ class Compression {
       velox::memory::MemoryPool& pool,
       CompressionType compressionType,
       DataType dataType,
-      std::string_view data);
+      std::string_view data,
+      velox::BufferPool* bufferPool = nullptr);
 
   static std::optional<size_t> uncompressedSize(
       CompressionType compressionType,

--- a/dwio/nimble/encodings/Encoding.h
+++ b/dwio/nimble/encodings/Encoding.h
@@ -281,6 +281,14 @@ class Encoding {
   static uint32_t readRowCount(std::string_view data, bool useVarint);
   static uint32_t readPrefixSize(std::string_view data, bool useVarint);
 
+  void releaseBuffer(velox::BufferPtr& buffer) {
+    if (auto* bufferPool = options_.bufferPool) {
+      bufferPool->release(std::move(buffer));
+    } else {
+      buffer.reset();
+    }
+  }
+
   velox::memory::MemoryPool* const pool_;
   const std::string_view data_;
   const EncodingType encodingType_;

--- a/dwio/nimble/encodings/FixedBitWidthEncoding.h
+++ b/dwio/nimble/encodings/FixedBitWidthEncoding.h
@@ -57,6 +57,10 @@ class FixedBitWidthEncoding final
       std::function<void*(uint32_t)> stringBufferFactory,
       const Encoding::Options& options = {});
 
+  ~FixedBitWidthEncoding() override {
+    this->releaseBuffer(uncompressedData_);
+  }
+
   void reset() final;
   void skip(uint32_t rowCount) final;
   void materialize(uint32_t rowCount, void* buffer) final;
@@ -112,7 +116,8 @@ FixedBitWidthEncoding<T>::FixedBitWidthEncoding(
         pool,
         compressionType,
         DataType::Undefined,
-        {pos, static_cast<size_t>(data.end() - pos)});
+        {pos, static_cast<size_t>(data.end() - pos)},
+        options.bufferPool);
     fixedBitArray_ = FixedBitArray{
         {uncompressedData_->as<char>(), uncompressedData_->size()}, bitWidth_};
   } else {

--- a/dwio/nimble/encodings/TrivialEncoding.cpp
+++ b/dwio/nimble/encodings/TrivialEncoding.cpp
@@ -39,7 +39,8 @@ TrivialEncoding<std::string_view>::TrivialEncoding(
         pool,
         dataCompressionType,
         DataType::String,
-        {blob_, static_cast<size_t>(data.end() - blob_)});
+        {blob_, static_cast<size_t>(data.end() - blob_)},
+        options.bufferPool);
     blob_ = dataUncompressed_->as<char>();
     uncompressedDataBytes_ = dataUncompressed_->size();
   } else {
@@ -51,7 +52,7 @@ TrivialEncoding<std::string_view>::TrivialEncoding(
   // TODO(huamengjiang): in a follow up, we will let the factory return a smart
   // pointer that can also be held by the encoding.
   std::memcpy(stringBuffer, blob_, uncompressedDataBytes_);
-  dataUncompressed_.reset();
+  releaseBuffer(dataUncompressed_);
   blob_ = static_cast<char*>(stringBuffer);
   pos_ = blob_;
 }
@@ -204,7 +205,8 @@ TrivialEncoding<bool>::TrivialEncoding(
         pool,
         compressionType,
         DataType::Undefined,
-        {bitmap_, static_cast<size_t>(data.end() - bitmap_)});
+        {bitmap_, static_cast<size_t>(data.end() - bitmap_)},
+        options.bufferPool);
     bitmap_ = uncompressed_->as<char>();
     NIMBLE_CHECK_EQ(
         bitmap_ + FixedBitArray::bufferSize(rowCount(), 1),

--- a/dwio/nimble/encodings/TrivialEncoding.h
+++ b/dwio/nimble/encodings/TrivialEncoding.h
@@ -55,6 +55,10 @@ class TrivialEncoding final
       std::function<void*(uint32_t)> stringBufferFactory,
       const Encoding::Options& options = {});
 
+  ~TrivialEncoding() override {
+    this->releaseBuffer(uncompressed_);
+  }
+
   void reset() final;
   void skip(uint32_t rowCount) final;
   void materialize(uint32_t rowCount, void* buffer) final;
@@ -152,6 +156,10 @@ class TrivialEncoding<bool> final : public TypedEncoding<bool, bool> {
       std::function<void*(uint32_t)> stringBufferFactory,
       const Encoding::Options& options = {});
 
+  ~TrivialEncoding() override {
+    this->releaseBuffer(uncompressed_);
+  }
+
   void reset() final;
   void skip(uint32_t rowCount) final;
   void materialize(uint32_t rowCount, void* buffer) final;
@@ -195,7 +203,8 @@ TrivialEncoding<T>::TrivialEncoding(
         pool,
         compressionType,
         TypeTraits<physicalType>::dataType,
-        {data.data() + valuesOffset, data.size() - valuesOffset});
+        {data.data() + valuesOffset, data.size() - valuesOffset},
+        options.bufferPool);
     values_ = reinterpret_cast<const T*>(uncompressed_->as<char>());
     NIMBLE_CHECK_EQ(
         reinterpret_cast<const char*>(values_ + this->rowCount()),

--- a/dwio/nimble/encodings/ZstdCompressor.cpp
+++ b/dwio/nimble/encodings/ZstdCompressor.cpp
@@ -71,10 +71,11 @@ velox::BufferPtr ZstdCompressor::uncompress(
     velox::memory::MemoryPool& pool,
     const CompressionType compressionType,
     const DataType /* dataType */,
-    std::string_view data) {
+    std::string_view data,
+    velox::BufferPool* bufferPool) {
   auto pos = data.data();
   const uint32_t uncompressedSize = encoding::readUint32(pos);
-  auto buffer = velox::AlignedBuffer::allocate<char>(uncompressedSize, &pool);
+  auto buffer = allocateBuffer(pool, bufferPool, uncompressedSize);
   auto ret = ZSTD_decompressDCtx(
       getThreadLocalDCtx(),
       buffer->asMutable<char>(),

--- a/dwio/nimble/encodings/ZstdCompressor.h
+++ b/dwio/nimble/encodings/ZstdCompressor.h
@@ -33,7 +33,8 @@ class ZstdCompressor : public ICompressor {
       velox::memory::MemoryPool& pool,
       CompressionType compressionType,
       DataType dataType,
-      std::string_view data) override;
+      std::string_view data,
+      velox::BufferPool* bufferPool = nullptr) override;
 
   std::optional<size_t> uncompressedSize(std::string_view data) const override;
 

--- a/dwio/nimble/encodings/tests/ZstdCompressorTest.cpp
+++ b/dwio/nimble/encodings/tests/ZstdCompressorTest.cpp
@@ -17,6 +17,7 @@
 #include <gtest/gtest.h>
 #include <cstring>
 #include <random>
+#include "velox/buffer/BufferPool.h"
 #include "velox/common/memory/Memory.h"
 
 using namespace facebook::nimble;
@@ -155,4 +156,101 @@ TEST(ZstdCompressorTest, MinCompressionSizeSkipsSmallData) {
   TestCompressionPolicy policy(data.size() + 1);
   CompressionEncoder<int8_t> encoder{*pool, policy, DataType::Int8, input};
   EXPECT_EQ(CompressionType::Uncompressed, encoder.compressionType());
+}
+
+TEST(ZstdCompressorTest, AllocateBufferFromPool) {
+  auto pool = facebook::velox::memory::deprecatedAddDefaultLeafMemoryPool();
+  facebook::velox::BufferPool bufferPool;
+
+  // Pool is empty — should fall back to MemoryPool allocation.
+  auto buf1 = allocateBuffer(*pool, &bufferPool, 100);
+  ASSERT_NE(buf1, nullptr);
+  EXPECT_GE(buf1->capacity(), 100);
+  EXPECT_EQ(buf1->size(), 100);
+
+  // Return the buffer to the pool.
+  bufferPool.release(std::move(buf1));
+  EXPECT_EQ(bufferPool.size(), 1);
+
+  // Now the pool has a buffer — should reuse it.
+  auto buf2 = allocateBuffer(*pool, &bufferPool, 50);
+  ASSERT_NE(buf2, nullptr);
+  EXPECT_GE(buf2->capacity(), 100);
+  EXPECT_EQ(buf2->size(), 50);
+  EXPECT_EQ(bufferPool.size(), 0);
+}
+
+TEST(ZstdCompressorTest, AllocateBufferNullPool) {
+  auto pool = facebook::velox::memory::deprecatedAddDefaultLeafMemoryPool();
+
+  // Null pool — should allocate from MemoryPool.
+  auto buf = allocateBuffer(*pool, nullptr, 200);
+  ASSERT_NE(buf, nullptr);
+  EXPECT_GE(buf->capacity(), 200);
+  EXPECT_EQ(buf->size(), 200);
+}
+
+TEST(ZstdCompressorTest, UncompressWithBufferPool) {
+  auto pool = facebook::velox::memory::deprecatedAddDefaultLeafMemoryPool();
+  ZstdCompressor compressor;
+  TestCompressionPolicy policy;
+  facebook::velox::BufferPool bufferPool;
+
+  std::vector<char> original(1024);
+  for (size_t i = 0; i < original.size(); ++i) {
+    original[i] = static_cast<char>(i % 10);
+  }
+  std::string_view input(original.data(), original.size());
+
+  auto result = compressor.compress(*pool, input, DataType::Int8, 0, policy);
+  ASSERT_TRUE(result.buffer.has_value());
+  std::string_view compressed(result.buffer->data(), result.buffer->size());
+
+  // Decompress with BufferPool — first call allocates fresh.
+  auto decompressed = compressor.uncompress(
+      *pool, CompressionType::Zstd, DataType::Int8, compressed, &bufferPool);
+  ASSERT_EQ(original.size(), decompressed->size());
+  EXPECT_EQ(
+      0,
+      std::memcmp(original.data(), decompressed->as<char>(), original.size()));
+
+  // Return buffer to pool, then decompress again — should reuse.
+  bufferPool.release(std::move(decompressed));
+  EXPECT_EQ(bufferPool.size(), 1);
+
+  auto decompressed2 = compressor.uncompress(
+      *pool, CompressionType::Zstd, DataType::Int8, compressed, &bufferPool);
+  EXPECT_EQ(bufferPool.size(), 0);
+  ASSERT_EQ(original.size(), decompressed2->size());
+  EXPECT_EQ(
+      0,
+      std::memcmp(original.data(), decompressed2->as<char>(), original.size()));
+}
+
+TEST(ZstdCompressorTest, BufferPoolReuseAcrossMultipleCycles) {
+  auto pool = facebook::velox::memory::deprecatedAddDefaultLeafMemoryPool();
+  ZstdCompressor compressor;
+  TestCompressionPolicy policy;
+  facebook::velox::BufferPool bufferPool;
+
+  std::vector<char> original(512);
+  for (size_t i = 0; i < original.size(); ++i) {
+    original[i] = static_cast<char>(i % 13);
+  }
+  std::string_view input(original.data(), original.size());
+
+  auto result = compressor.compress(*pool, input, DataType::Int32, 0, policy);
+  ASSERT_TRUE(result.buffer.has_value());
+  std::string_view compressed(result.buffer->data(), result.buffer->size());
+
+  // Simulate multiple encoding lifecycles: decompress → use → release → repeat.
+  for (int cycle = 0; cycle < 5; ++cycle) {
+    auto buf = compressor.uncompress(
+        *pool, CompressionType::Zstd, DataType::Int32, compressed, &bufferPool);
+    ASSERT_EQ(original.size(), buf->size());
+    EXPECT_EQ(
+        0, std::memcmp(original.data(), buf->as<char>(), original.size()));
+    bufferPool.release(std::move(buf));
+  }
+  EXPECT_EQ(bufferPool.size(), 1);
 }


### PR DESCRIPTION
Summary:

Extend the decompression path to accept an optional BufferPool for buffer reuse across encoding lifetimes. When a BufferPool is provided (via Encoding::Options), decompression buffers are acquired from the pool instead of allocating fresh from MemoryPool, and released back to the pool when the encoding is destroyed.

This eliminates repeated MemoryPool alloc/free calls for decompression buffers during parallel decode, avoiding the leaf pool mutex contention that causes hyper-linear CPU scaling.

Changes:
- Add allocateBuffer() helper that tries BufferPool first, falls back to AlignedBuffer::allocate
- Add bufferPool parameter to ICompressor::uncompress, Compression::uncompress, uncompressZstdWithReusedCtx, and all compressor implementations
- TrivialEncoding (numeric, bool) and FixedBitWidthEncoding: release decompression buffers back to the pool in destructor
- TrivialEncoding (string_view): release temporary decompression buffer back to pool after memcpy

Reviewed By: xiaoxmeng

Differential Revision: D103729503


