### PR TITLE
feat: Add runtime stats for nimble index lookup join (#698)

### DIFF
--- a/dwio/nimble/velox/selective/SelectiveNimbleIndexReader.cpp
+++ b/dwio/nimble/velox/selective/SelectiveNimbleIndexReader.cpp
@@ -25,12 +25,13 @@
 #include "dwio/nimble/velox/selective/ColumnReader.h"
 #include "dwio/nimble/velox/selective/ReaderBase.h"
 #include "dwio/nimble/velox/selective/RowSizeTracker.h"
-#include "velox/common/base/RuntimeMetrics.h"
+#include "velox/common/time/CpuWallTimer.h"
 #include "velox/serializers/KeyEncoder.h"
 
 namespace facebook::nimble {
 
 using namespace facebook::velox;
+using RuntimeCounter = velox::RuntimeCounter;
 
 namespace {
 
@@ -167,7 +168,17 @@ SelectiveNimbleIndexReader::SelectiveNimbleIndexReader(
           readerBase_->nimbleSchema(),
           readerBase_->fileSchema())},
       streams_{readerBase_},
-      numStripes_{static_cast<int32_t>(readerBase_->tablet().stripeCount())} {}
+      numStripes_{static_cast<int32_t>(readerBase_->tablet().stripeCount())},
+      stats_{
+          {std::string(dwio::common::IndexReader::kIndexStripeLoadWallNanos),
+           velox::RuntimeMetric(velox::RuntimeCounter::Unit::kNanos)},
+          {std::string(dwio::common::IndexReader::kIndexStripeLoadCpuNanos),
+           velox::RuntimeMetric(velox::RuntimeCounter::Unit::kNanos)},
+          {std::string(dwio::common::IndexReader::kIndexDataDecodeWallNanos),
+           velox::RuntimeMetric(velox::RuntimeCounter::Unit::kNanos)},
+          {std::string(dwio::common::IndexReader::kIndexDataDecodeCpuNanos),
+           velox::RuntimeMetric(velox::RuntimeCounter::Unit::kNanos)},
+      } {}
 
 void SelectiveNimbleIndexReader::startLookup(
     const velox::serializer::IndexBounds& indexBounds,
@@ -194,12 +205,8 @@ void SelectiveNimbleIndexReader::startLookup(
   readyOutputRows_ = 0;
 
   // Report lookup stats.
-  addThreadLocalRuntimeStat(
-      dwio::common::IndexReader::kNumIndexLookupRequests,
-      velox::RuntimeCounter(numRequests_));
-  addThreadLocalRuntimeStat(
-      dwio::common::IndexReader::kNumIndexLookupStripes,
-      velox::RuntimeCounter(stripes_.size()));
+  addStat(dwio::common::IndexReader::kNumIndexLookupRequests, numRequests_);
+  addStat(dwio::common::IndexReader::kNumIndexLookupStripes, stripes_.size());
 }
 
 bool SelectiveNimbleIndexReader::hasNext() const {
@@ -262,12 +269,14 @@ void SelectiveNimbleIndexReader::resolveRequestStripes() {
   const auto result = clusterIndex_->lookup(
       index::IndexLookup::LookupRequest::rangeScan(encodedKeyBounds_));
 
+  uint64_t numMatchedRows = 0;
   for (size_t requestIdx = 0; requestIdx < numRequests_; ++requestIdx) {
     const auto locations = result[requestIdx];
     if (locations.empty()) {
       continue;
     }
 
+    numMatchedRows += locations[0].numRows();
     requestStates_[requestIdx].rowRange = locations[0];
 
     const auto startStripe =
@@ -303,10 +312,15 @@ void SelectiveNimbleIndexReader::resolveRequestStripes() {
 
   // Collect and sort unique stripes.
   stripes_.reserve(stripeToRequests_.size());
+  uint64_t numScannedRows = 0;
   for (const auto& [stripe, _] : stripeToRequests_) {
     stripes_.push_back(stripe);
+    numScannedRows += stripeRowCount(stripe);
   }
   std::sort(stripes_.begin(), stripes_.end());
+
+  addStat(dwio::common::IndexReader::kNumIndexScannedRows, numScannedRows);
+  addStat(dwio::common::IndexReader::kNumIndexMatchedRows, numMatchedRows);
 }
 
 bool SelectiveNimbleIndexReader::loadStripe() {
@@ -391,11 +405,9 @@ void SelectiveNimbleIndexReader::buildStripeReadSegments(
     splitStripeRowRanges(requestRanges);
   }
   NIMBLE_CHECK(!readSegments_.empty());
-
-  // Report read segment stats.
-  addThreadLocalRuntimeStat(
+  addStat(
       dwio::common::IndexReader::kNumIndexLookupReadSegments,
-      velox::RuntimeCounter(readSegments_.size()));
+      readSegments_.size());
 
   readSegmentIndex_ = 0;
   prepareStripeSegmentRead();
@@ -496,30 +508,37 @@ void SelectiveNimbleIndexReader::splitStripeRowRanges(
 }
 
 void SelectiveNimbleIndexReader::initStripeColumnReader(uint32_t stripeIndex) {
-  addThreadLocalRuntimeStat(
-      dwio::common::RowReader::kNumStripeLoads, velox::RuntimeCounter(1));
+  addStat(dwio::common::RowReader::kNumStripeLoads, 1);
+  loadedStripes_.insert(stripeIndex);
 
-  streams_.setStripe(stripeIndex);
-  NimbleParams params(
-      *readerBase_->pool(),
-      columnReaderStatistics_,
-      readerBase_->nimbleSchema(),
-      streams_,
-      options_.trackRowSize() ? rowSizeTracker_.get() : nullptr,
-      *encodingFactory_,
-      options_.stringDecoderZeroCopy(),
-      options_.preserveFlatMapsInMemory());
+  CpuWallTiming timing;
+  {
+    CpuWallTimer timer(timing);
+    streams_.setStripe(stripeIndex);
+    NimbleParams params(
+        *readerBase_->pool(),
+        columnReaderStatistics_,
+        readerBase_->nimbleSchema(),
+        streams_,
+        options_.trackRowSize() ? rowSizeTracker_.get() : nullptr,
+        *encodingFactory_,
+        options_.stringDecoderZeroCopy(),
+        options_.preserveFlatMapsInMemory());
 
-  columnReader_ = buildColumnReader(
-      fileOutputType_,
-      readerBase_->fileSchemaWithId(),
-      params,
-      *options_.scanSpec(),
-      true);
-  rowSizeTracker_->finalizeProjection();
-  columnReader_->setIsTopLevel();
+    columnReader_ = buildColumnReader(
+        fileOutputType_,
+        readerBase_->fileSchemaWithId(),
+        params,
+        *options_.scanSpec(),
+        true);
+    rowSizeTracker_->finalizeProjection();
+    columnReader_->setIsTopLevel();
 
-  streams_.load();
+    streams_.load();
+  }
+  addStat(
+      dwio::common::IndexReader::kIndexStripeLoadWallNanos, timing.wallNanos);
+  addStat(dwio::common::IndexReader::kIndexStripeLoadCpuNanos, timing.cpuNanos);
 }
 
 uint64_t SelectiveNimbleIndexReader::readStripeFragment(RowVectorPtr& output) {
@@ -533,7 +552,14 @@ uint64_t SelectiveNimbleIndexReader::readStripeFragment(RowVectorPtr& output) {
 
   VectorPtr readOutput =
       BaseVector::create(outputType_, 0, readerBase_->pool());
-  columnReader_->next(rowsToRead, readOutput, /*mutation=*/nullptr);
+  CpuWallTiming timing;
+  {
+    CpuWallTimer timer(timing);
+    columnReader_->next(rowsToRead, readOutput, /*mutation=*/nullptr);
+  }
+  addStat(
+      dwio::common::IndexReader::kIndexDataDecodeWallNanos, timing.wallNanos);
+  addStat(dwio::common::IndexReader::kIndexDataDecodeCpuNanos, timing.cpuNanos);
   if (readOutput->size() > 0) {
     readOutput->loadedVector();
   }
@@ -777,4 +803,23 @@ void SelectiveNimbleIndexReader::reset() {
   readyOutputRows_ = 0;
   columnReader_.reset();
 }
+
+folly::F14FastMap<std::string, velox::RuntimeMetric>
+SelectiveNimbleIndexReader::stats() const {
+  folly::F14FastMap<std::string, velox::RuntimeMetric> result;
+  // Only emit metrics that received at least one addValue() call.
+  // Pre-initialized timing entries that were never written are skipped.
+  for (const auto& [name, metric] : stats_) {
+    if (metric.count > 0) {
+      result.emplace(name, metric);
+    }
+  }
+  if (!loadedStripes_.empty()) {
+    result[std::string(
+        dwio::common::IndexReader::kNumIndexDistinctStripesLoaded)] =
+        RuntimeMetric(static_cast<int64_t>(loadedStripes_.size()));
+  }
+  return result;
+}
+
 } // namespace facebook::nimble

--- a/dwio/nimble/velox/selective/SelectiveNimbleIndexReader.h
+++ b/dwio/nimble/velox/selective/SelectiveNimbleIndexReader.h
@@ -66,6 +66,9 @@ class SelectiveNimbleIndexReader : public velox::dwio::common::IndexReader {
   /// returned before any results for request N+1.
   std::unique_ptr<Result> next(velox::vector_size_t maxOutputRows) override;
 
+  /// Returns accumulated runtime stats for this index reader.
+  folly::F14FastMap<std::string, velox::RuntimeMetric> stats() const override;
+
  private:
   using RowRangeMap = folly::F14FastMap<RowRange, size_t, RowRangeHash>;
 
@@ -307,6 +310,18 @@ class SelectiveNimbleIndexReader : public velox::dwio::common::IndexReader {
   velox::vector_size_t nextOutputRequest_{0};
   velox::vector_size_t lastReadyOutputRequest_{-1};
   velox::vector_size_t readyOutputRows_{0};
+
+  void addStat(std::string_view name, int64_t value) {
+    stats_[std::string(name)].addValue(value);
+  }
+
+  // Tracks distinct stripes loaded for the numDistinctStripesLoaded metric.
+  folly::F14FastSet<uint32_t> loadedStripes_;
+
+  // Accumulated runtime stats. Timing entries are pre-initialized in the
+  // constructor with their unit so addValue() preserves the unit. stats()
+  // emits only entries with count > 0.
+  folly::F14FastMap<std::string, velox::RuntimeMetric> stats_;
 };
 
 } // namespace facebook::nimble


### PR DESCRIPTION
Summary:

Adds runtime stats for index lookup operations performed by the Nimble selective index reader, reported through the format-agnostic dwio::common::IndexReader stats API (constants added in a prior change).

Reader-level emissions added in SelectiveNimbleIndexReader:
- indexStripeLoadWallNanos / indexStripeLoadCpuNanos: time loading stripes during index lookup.
- indexDataDecodeWallNanos / indexDataDecodeCpuNanos: time decoding column data from loaded stripes.
- numIndexDistinctStripesLoaded: unique stripes loaded across the reader's lifetime; comparing against numStripeLoads spots redundant loads.
- numIndexScannedRows / numIndexMatchedRows: cluster-index selectivity tracking.
- numIndexLookupStripes: unique stripes per startLookup() call, summed across calls.

SelectiveNimbleIndexReader migrates from addThreadLocalRuntimeStat to IndexReader::stats(). Timing entries are pre-initialized in the constructor with Unit::kNanos so per-sample addValue() calls preserve the unit; stats() returns only entries with count > 0, skipping pre-initialized but never-touched metrics.

Test infrastructure migrates from thread-local RuntimeStatWriter to indexSource->runtimeStats() and adds coverage for numStripeLoads, numIndexLookupStripes, numIndexLookupRequests, numIndexLookupReadSegments, numIndexScannedRows, numIndexMatchedRows, and numIndexDistinctStripesLoaded.

Reviewed By: xiaoxmeng

Differential Revision: D103273604


