### PR TITLE
feat: Support LZ4 Compression in Serializer (#699)

### DIFF
--- a/dwio/nimble/common/Types.cpp
+++ b/dwio/nimble/common/Types.cpp
@@ -98,6 +98,8 @@ std::string toString(CompressionType compressionType) {
       return "Zstd";
     case CompressionType::MetaInternal:
       return "MetaInternal";
+    case CompressionType::LZ4:
+      return "LZ4";
     default:
       return fmt::format(
           "Unknown compression type: {}",

--- a/dwio/nimble/common/Types.h
+++ b/dwio/nimble/common/Types.h
@@ -134,6 +134,8 @@ enum class CompressionType : uint8_t {
   // Zstd doesn't require us to externally store level or any other info.
   Zstd = 1,
   MetaInternal = 2,
+  // LZ4 block mode; requires externally stored uncompressed size.
+  LZ4 = 3,
 };
 
 std::string toString(CompressionType compressionType);

--- a/dwio/nimble/common/tests/TypesTest.cpp
+++ b/dwio/nimble/common/tests/TypesTest.cpp
@@ -90,6 +90,7 @@ TEST(TypesTest, CompressionTypeToString) {
   EXPECT_EQ(toString(CompressionType::Uncompressed), "Uncompressed");
   EXPECT_EQ(toString(CompressionType::Zstd), "Zstd");
   EXPECT_EQ(toString(CompressionType::MetaInternal), "MetaInternal");
+  EXPECT_EQ(toString(CompressionType::LZ4), "LZ4");
 }
 
 TEST(TypesTest, CompressionTypeToStringUnknown) {

--- a/dwio/nimble/serializer/DeserializerImpl.cpp
+++ b/dwio/nimble/serializer/DeserializerImpl.cpp
@@ -16,6 +16,8 @@
 
 #include "dwio/nimble/serializer/DeserializerImpl.h"
 
+#include <lz4.h>
+
 #include "dwio/nimble/common/ChunkHeader.h"
 #include "dwio/nimble/common/EncodingPrimitives.h"
 #include "dwio/nimble/common/Exceptions.h"
@@ -130,6 +132,25 @@ void StreamData::decompress() {
           pos_,
           compressedSize);
       NIMBLE_CHECK(!ZSTD_isError(ret), "Error decompressing data");
+      pos_ = decompressionBuffer_.data();
+      end_ = pos_ + decompressionBuffer_.size();
+      break;
+    }
+    case CompressionType::LZ4: {
+      // LZ4 block data is preceded by the uncompressed size (uint32).
+      // Wire format: [origSize:u32][lz4_data...]
+      const auto decompressedSize = encoding::readUint32(pos_);
+      const auto compressedSize = static_cast<size_t>(end_ - pos_);
+      decompressionBuffer_.resize(decompressedSize);
+      const auto ret = LZ4_decompress_safe(
+          pos_,
+          decompressionBuffer_.data(),
+          static_cast<int>(compressedSize),
+          static_cast<int>(decompressedSize));
+      NIMBLE_CHECK_EQ(
+          ret,
+          static_cast<int>(decompressedSize),
+          "LZ4 decompressed size mismatch");
       pos_ = decompressionBuffer_.data();
       end_ = pos_ + decompressionBuffer_.size();
       break;
@@ -369,6 +390,24 @@ void StreamDataReader::appendChunkData(
           data,
           length);
       NIMBLE_CHECK(!ZSTD_isError(ret), "Error decompressing chunk data");
+      break;
+    }
+    case CompressionType::LZ4: {
+      const auto* pos = data;
+      const auto decompressedSize = encoding::readUint32(pos);
+      const auto compressedSize =
+          static_cast<size_t>(length - sizeof(uint32_t));
+      const auto offset = chunkStrippingBuffer_.size();
+      chunkStrippingBuffer_.resize(offset + decompressedSize);
+      const auto ret = LZ4_decompress_safe(
+          pos,
+          chunkStrippingBuffer_.data() + offset,
+          static_cast<int>(compressedSize),
+          static_cast<int>(decompressedSize));
+      NIMBLE_CHECK_EQ(
+          ret,
+          static_cast<int>(decompressedSize),
+          "LZ4 chunk decompressed size mismatch");
       break;
     }
     default:

--- a/dwio/nimble/serializer/SerializerImpl.cpp
+++ b/dwio/nimble/serializer/SerializerImpl.cpp
@@ -16,6 +16,10 @@
 
 #include "dwio/nimble/serializer/SerializerImpl.h"
 
+#include <limits>
+
+#include <lz4.h>
+#include <lz4hc.h>
 #include <zstd.h>
 #include <zstd_errors.h>
 
@@ -136,6 +140,34 @@ encode(const SerializerOptions& options, std::string_view input, char* output) {
           // Fall back to uncompressed
         } else {
           size = ret;
+          writeUncompressed = false;
+        }
+        break;
+      }
+      case CompressionType::LZ4: {
+        // LZ4 block mode is not self-descriptive (unlike ZSTD frames), so we
+        // prepend the uncompressed size as a uint32 before the compressed data.
+        // Wire format: [size:u32][compType:i8=3][origSize:u32][lz4_data...]
+        const auto origSize = static_cast<uint32_t>(input.size());
+        encoding::writeUint32(origSize, compPos);
+        constexpr int kMinHcLevel = LZ4HC_CLEVEL_MIN;
+        const auto compressedSize = options.compressionLevel >= kMinHcLevel
+            ? LZ4_compress_HC(
+                  input.data(),
+                  compPos,
+                  static_cast<int>(input.size()),
+                  static_cast<int>(size),
+                  options.compressionLevel)
+            : LZ4_compress_default(
+                  input.data(),
+                  compPos,
+                  static_cast<int>(input.size()),
+                  static_cast<int>(size));
+        if (compressedSize == 0 ||
+            static_cast<uint32_t>(compressedSize) >= origSize) {
+          // Fall back to uncompressed
+        } else {
+          size = sizeof(uint32_t) + compressedSize;
           writeUncompressed = false;
         }
         break;

--- a/dwio/nimble/serializer/SerializerImpl.h
+++ b/dwio/nimble/serializer/SerializerImpl.h
@@ -662,9 +662,11 @@ void StreamDataWriter<T>::encodeStream(
     auto* pos = detail::extend(buffer_, size + sizeof(uint32_t));
     detail::encodeStrings(data, size, pos);
   } else {
-    // Legacy scalar encoding: [size:u32][compression_type:i8][data...]
+    // Legacy scalar encoding:
+    //   Zstd: [size:u32][compType:i8][data...]
+    //   LZ4:  [size:u32][compType:i8][origSize:u32][data...]
     const auto bufferStart = buffer_.size();
-    const uint32_t maxSize = data.size() + sizeof(uint32_t) + 1;
+    const uint32_t maxSize = data.size() + 2 * sizeof(uint32_t) + 1;
     auto* pos = detail::extend(buffer_, maxSize);
     const auto encodedSize = detail::encode(options_, data, pos);
     if (encodedSize < maxSize) {

--- a/dwio/nimble/serializer/tests/SerializerImplTest.cpp
+++ b/dwio/nimble/serializer/tests/SerializerImplTest.cpp
@@ -15,6 +15,7 @@
  */
 
 #include <gtest/gtest.h>
+#include <lz4.h>
 #include <zstd.h>
 
 #include "dwio/nimble/common/ChunkHeader.h"
@@ -1738,4 +1739,256 @@ TEST_F(ZstdDCtxReuseTest, streamDataReaderDCtxReusedAcrossStreams) {
   ASSERT_EQ(result.size(), 2);
   EXPECT_EQ(result[0].second, payload1);
   EXPECT_EQ(result[1].second, payload2);
+}
+
+class LZ4RoundtripTest : public TabletRawChunkStripTest {
+ protected:
+  static std::string buildLegacyLZ4CompressedData(std::string_view payload) {
+    std::string result;
+    result.push_back(static_cast<char>(CompressionType::LZ4));
+
+    const auto origSize = static_cast<uint32_t>(payload.size());
+    result.resize(result.size() + sizeof(uint32_t));
+    auto* sizePos = result.data() + 1;
+    encoding::writeUint32(origSize, sizePos);
+
+    const auto maxSize = LZ4_compressBound(static_cast<int>(payload.size()));
+    const auto offset = result.size();
+    result.resize(offset + maxSize);
+    const auto compressedSize = LZ4_compress_default(
+        payload.data(),
+        result.data() + offset,
+        static_cast<int>(payload.size()),
+        maxSize);
+    NIMBLE_CHECK_GT(compressedSize, 0, "LZ4 compression failed");
+    result.resize(offset + compressedSize);
+    return result;
+  }
+
+  static std::string buildLZ4CompressedChunk(std::string_view data) {
+    const auto maxCompressedSize =
+        LZ4_compressBound(static_cast<int>(data.size()));
+    std::string compressed(maxCompressedSize, '\0');
+    const auto compressedSize = LZ4_compress_default(
+        data.data(),
+        compressed.data(),
+        static_cast<int>(data.size()),
+        maxCompressedSize);
+    NIMBLE_CHECK_GT(compressedSize, 0, "LZ4 compression failed");
+    compressed.resize(compressedSize);
+
+    // Chunk payload: [origSize:u32][lz4_data...]
+    const auto chunkPayloadSize = sizeof(uint32_t) + compressedSize;
+    std::string chunk(kChunkHeaderSize + chunkPayloadSize, '\0');
+    auto* pos = chunk.data();
+    writeChunkHeader(
+        static_cast<uint32_t>(chunkPayloadSize), CompressionType::LZ4, pos);
+    encoding::writeUint32(static_cast<uint32_t>(data.size()), pos);
+    std::memcpy(pos, compressed.data(), compressedSize);
+    return chunk;
+  }
+};
+
+TEST_F(LZ4RoundtripTest, streamDataLegacyLZ4) {
+  const std::vector<int32_t> expected = {10, 20, 30, 40, 50};
+  std::string_view payload(
+      reinterpret_cast<const char*>(expected.data()),
+      expected.size() * sizeof(int32_t));
+  auto compressed = buildLegacyLZ4CompressedData(payload);
+
+  std::vector<BufferPtr> stringBuffers;
+  serde::StreamData sd(
+      ScalarKind::Int32,
+      compressed,
+      stringBuffers,
+      pool_.get(),
+      serde::StreamData::Options{.version = SerializationVersion::kLegacy});
+
+  std::vector<int32_t> output(expected.size());
+  sd.copyTo(
+      reinterpret_cast<char*>(output.data()),
+      static_cast<uint32_t>(output.size() * sizeof(int32_t)));
+  EXPECT_EQ(output, expected);
+}
+
+TEST_F(LZ4RoundtripTest, streamDataLZ4ReusedAcrossReset) {
+  const std::vector<int32_t> values1 = {1, 2, 3};
+  std::string_view payload1(
+      reinterpret_cast<const char*>(values1.data()),
+      values1.size() * sizeof(int32_t));
+  auto compressed1 = buildLegacyLZ4CompressedData(payload1);
+
+  const std::vector<int32_t> values2 = {100, 200};
+  std::string_view payload2(
+      reinterpret_cast<const char*>(values2.data()),
+      values2.size() * sizeof(int32_t));
+  auto compressed2 = buildLegacyLZ4CompressedData(payload2);
+
+  std::vector<BufferPtr> stringBuffers;
+  serde::StreamData sd(
+      ScalarKind::Int32,
+      compressed1,
+      stringBuffers,
+      pool_.get(),
+      serde::StreamData::Options{.version = SerializationVersion::kLegacy});
+
+  std::vector<int32_t> output1(values1.size());
+  sd.copyTo(
+      reinterpret_cast<char*>(output1.data()),
+      static_cast<uint32_t>(output1.size() * sizeof(int32_t)));
+  EXPECT_EQ(output1, values1);
+
+  sd.reset(compressed2, SerializationVersion::kLegacy);
+
+  std::vector<int32_t> output2(values2.size());
+  sd.copyTo(
+      reinterpret_cast<char*>(output2.data()),
+      static_cast<uint32_t>(output2.size() * sizeof(int32_t)));
+  EXPECT_EQ(output2, values2);
+}
+
+TEST_F(LZ4RoundtripTest, streamDataReaderLZ4CompressedChunk) {
+  std::string payload = "compressed data that should be lz4 encoded for test";
+  auto chunk = buildLZ4CompressedChunk(payload);
+  auto result = deserializeTabletRaw(10, {{0, chunk}});
+
+  ASSERT_EQ(result.size(), 1);
+  EXPECT_EQ(result[0].first, 0);
+  EXPECT_EQ(result[0].second, payload);
+}
+
+TEST_F(LZ4RoundtripTest, streamDataReaderLZ4ReusedAcrossStreams) {
+  std::string payload1 = "first compressed stream payload data";
+  std::string payload2 = "second compressed stream payload data";
+  auto chunk1 = buildLZ4CompressedChunk(payload1);
+  auto chunk2 = buildLZ4CompressedChunk(payload2);
+
+  auto result = deserializeTabletRaw(10, {{0, chunk1}, {1, chunk2}});
+
+  ASSERT_EQ(result.size(), 2);
+  EXPECT_EQ(result[0].second, payload1);
+  EXPECT_EQ(result[1].second, payload2);
+}
+
+TEST_F(LZ4RoundtripTest, streamDataReaderLZ4MultipleChunks) {
+  std::string part1 = "first chunk of lz4 compressed data here";
+  std::string part2 = "second chunk of lz4 compressed data here";
+  auto stream = concatChunks(
+      {buildLZ4CompressedChunk(part1), buildLZ4CompressedChunk(part2)});
+  auto result = deserializeTabletRaw(10, {{0, stream}});
+
+  ASSERT_EQ(result.size(), 1);
+  EXPECT_EQ(result[0].first, 0);
+  EXPECT_EQ(result[0].second, part1 + part2);
+}
+
+TEST_F(LZ4RoundtripTest, streamDataReaderLZ4MixedWithUncompressed) {
+  std::string part1 = "uncompressed chunk one";
+  std::string part2 = "lz4 compressed chunk two with some data";
+  std::string part3 = "another uncompressed chunk three";
+  auto stream = concatChunks(
+      {buildUncompressedChunk(part1),
+       buildLZ4CompressedChunk(part2),
+       buildUncompressedChunk(part3)});
+  auto result = deserializeTabletRaw(10, {{0, stream}});
+
+  ASSERT_EQ(result.size(), 1);
+  EXPECT_EQ(result[0].first, 0);
+  EXPECT_EQ(result[0].second, part1 + part2 + part3);
+}
+
+TEST_F(LZ4RoundtripTest, encodeDecodeLZ4Roundtrip) {
+  const std::vector<int32_t> expected(256);
+  std::string_view input(
+      reinterpret_cast<const char*>(expected.data()),
+      expected.size() * sizeof(int32_t));
+
+  SerializerOptions options;
+  options.compressionType = CompressionType::LZ4;
+  options.compressionThreshold = 1;
+
+  std::string buffer(input.size() + 2 * sizeof(uint32_t) + 1, '\0');
+  const auto encodedSize = serde::detail::encode(options, input, buffer.data());
+
+  // encode() outputs [size:u32][compressionType:i8][data...]; StreamData
+  // expects the stream without the size prefix.
+  std::string_view streamData(
+      buffer.data() + sizeof(uint32_t), encodedSize - sizeof(uint32_t));
+
+  std::vector<BufferPtr> stringBuffers;
+  serde::StreamData sd(
+      ScalarKind::Int32,
+      streamData,
+      stringBuffers,
+      pool_.get(),
+      serde::StreamData::Options{.version = SerializationVersion::kLegacy});
+
+  std::vector<int32_t> output(expected.size());
+  sd.copyTo(
+      reinterpret_cast<char*>(output.data()),
+      static_cast<uint32_t>(output.size() * sizeof(int32_t)));
+  EXPECT_EQ(output, expected);
+}
+
+TEST_F(LZ4RoundtripTest, encodeLZ4BelowThresholdStaysUncompressed) {
+  const std::vector<int32_t> expected = {1, 2, 3};
+  std::string_view input(
+      reinterpret_cast<const char*>(expected.data()),
+      expected.size() * sizeof(int32_t));
+
+  SerializerOptions options;
+  options.compressionType = CompressionType::LZ4;
+  options.compressionThreshold = 1'000'000;
+
+  std::string buffer(input.size() + 2 * sizeof(uint32_t) + 1, '\0');
+  const auto encodedSize = serde::detail::encode(options, input, buffer.data());
+
+  std::string_view streamData(
+      buffer.data() + sizeof(uint32_t), encodedSize - sizeof(uint32_t));
+
+  std::vector<BufferPtr> stringBuffers;
+  serde::StreamData sd(
+      ScalarKind::Int32,
+      streamData,
+      stringBuffers,
+      pool_.get(),
+      serde::StreamData::Options{.version = SerializationVersion::kLegacy});
+
+  std::vector<int32_t> output(expected.size());
+  sd.copyTo(
+      reinterpret_cast<char*>(output.data()),
+      static_cast<uint32_t>(output.size() * sizeof(int32_t)));
+  EXPECT_EQ(output, expected);
+}
+
+TEST_F(LZ4RoundtripTest, encodeDecodeLZ4HighCompression) {
+  const std::vector<int32_t> expected(256);
+  std::string_view input(
+      reinterpret_cast<const char*>(expected.data()),
+      expected.size() * sizeof(int32_t));
+
+  SerializerOptions options;
+  options.compressionType = CompressionType::LZ4;
+  options.compressionThreshold = 1;
+  options.compressionLevel = 9;
+
+  std::string buffer(input.size() + 2 * sizeof(uint32_t) + 1, '\0');
+  const auto encodedSize = serde::detail::encode(options, input, buffer.data());
+
+  std::string_view streamData(
+      buffer.data() + sizeof(uint32_t), encodedSize - sizeof(uint32_t));
+
+  std::vector<BufferPtr> stringBuffers;
+  serde::StreamData sd(
+      ScalarKind::Int32,
+      streamData,
+      stringBuffers,
+      pool_.get(),
+      serde::StreamData::Options{.version = SerializationVersion::kLegacy});
+
+  std::vector<int32_t> output(expected.size());
+  sd.copyTo(
+      reinterpret_cast<char*>(output.data()),
+      static_cast<uint32_t>(output.size() * sizeof(int32_t)));
+  EXPECT_EQ(output, expected);
 }


### PR DESCRIPTION
Summary:

Introduces LZ4 compression support for Nimble payloads. LZ4 block-mode decompression should generally be faster Zstd, which benefits latency-sensitive read/serving path like Sequence Storage. Local DISCO benchmarks confirm better end-to-end decode performance with LZ4 relative to the current Zstd default. For write-path flexibility, compression levels >= 3 dispatch to `LZ4_compress_HC` (higher compression ratio, same decode speed), following the same pattern as Velox's `Lz4RawCodec`.

---
**Serializer** (`SerializerImpl.cpp`): New `CompressionType::LZ4` case in `encode()` that prepends the uncompressed size as a uint32 header before the LZ4-compressed payload, falling back to uncompressed if compression doesn't reduce size. Dispatches to `LZ4_compress_HC` when `compressionLevel >= LZ4HC_CLEVEL_MIN`.

**Deserializer** (`DeserializerImpl.cpp`): LZ4 decompression in both the legacy stream path (`decompress()`) and the kTabletRaw chunk path (`appendChunkData()`). Both read the uint32 origSize header and verify the decompressed output matches. The decoder is unchanged by compression level — `LZ4_decompress_safe` handles both default and HC output identically.

**Wire format**: `[origSize:u32][lz4_data...]`, consistent across legacy streams and kTabletRaw chunks. The origSize header is required because LZ4 block mode (unlike Zstd frames) is not self-describing.

**Types** (`Types.h`): Added `CompressionType::LZ4 = 3` enum value with `toString` support.

**Tests**: 9 test cases mirroring the existing Zstd test structure: legacy roundtrip, reset/reuse, kTabletRaw single and multi-chunk decompression, mixed compression, `encode()`-path roundtrip with threshold fallback, and HC high-compression roundtrip.

Differential Revision: D103479854


