### PR TITLE
refactor: Remove unused writeExecutor from Nimble FieldWriter (#701)

### DIFF
--- a/dwio/nimble/velox/FieldWriter.cpp
+++ b/dwio/nimble/velox/FieldWriter.cpp
@@ -272,10 +272,8 @@ class SimpleFieldWriter : public FieldWriter {
             nodeId)},
         statisticsCollector_{context.getStatsCollector(nodeId)} {}
 
-  void write(
-      const velox::VectorPtr& vector,
-      const OrderedRanges& ranges,
-      folly::Executor*) override {
+  void write(const velox::VectorPtr& vector, const OrderedRanges& ranges)
+      override {
     auto size = ranges.size();
     auto& buffer = context_.stringBuffer();
     auto& data = valuesStream_.mutableData();
@@ -411,10 +409,8 @@ class StringFieldWriter : public FieldWriter {
         "StringFieldWriter only supports VARCHAR and VARBINARY types");
   }
 
-  void write(
-      const velox::VectorPtr& vector,
-      const OrderedRanges& ranges,
-      folly::Executor*) override {
+  void write(const velox::VectorPtr& vector, const OrderedRanges& ranges)
+      override {
     // Ensure string buffer capacity.
     auto size = ranges.size();
     const uint64_t totalBytes = getRawSizeFromVector(vector, ranges);
@@ -522,10 +518,8 @@ class TimestampFieldWriter : public FieldWriter {
             nodeId)},
         statisticsCollector_{context.getStatsCollector(nodeId)} {}
 
-  void write(
-      const velox::VectorPtr& vector,
-      const OrderedRanges& ranges,
-      folly::Executor*) override {
+  void write(const velox::VectorPtr& vector, const OrderedRanges& ranges)
+      override {
     auto size = ranges.size();
     Vector<int64_t>& microsData = microsStream_.mutableData();
     Vector<uint16_t>& nanosData = nanosStream_.mutableData();
@@ -625,10 +619,8 @@ class RowFieldWriter : public FieldWriter {
     }
   }
 
-  void write(
-      const velox::VectorPtr& vector,
-      const OrderedRanges& ranges,
-      folly::Executor* executor = nullptr) override {
+  void write(const velox::VectorPtr& vector, const OrderedRanges& ranges)
+      override {
     auto size = ranges.size();
     OrderedRanges childRanges;
     const OrderedRanges* childRangesPtr;
@@ -681,18 +673,8 @@ class RowFieldWriter : public FieldWriter {
       nullCount = size - nonNullCount;
     }
 
-    if (executor) {
-      for (auto i = 0; i < fields_.size(); ++i) {
-        executor->add([&field = fields_[i],
-                       &childVector = row->childAt(i),
-                       childRanges = *childRangesPtr]() {
-          field->write(childVector, childRanges);
-        });
-      }
-    } else {
-      for (auto i = 0; i < fields_.size(); ++i) {
-        fields_[i]->write(row->childAt(i), *childRangesPtr);
-      }
+    for (auto i = 0; i < fields_.size(); ++i) {
+      fields_[i]->write(row->childAt(i), *childRangesPtr);
     }
 
     collectStatistics(nullCount, size);
@@ -831,10 +813,8 @@ class ArrayFieldWriter : public MultiValueFieldWriter {
     typeBuilder_->asArray().setChildren(elements_->typeBuilder());
   }
 
-  void write(
-      const velox::VectorPtr& vector,
-      const OrderedRanges& ranges,
-      folly::Executor*) override {
+  void write(const velox::VectorPtr& vector, const OrderedRanges& ranges)
+      override {
     OrderedRanges childRanges;
     auto array = ingestLengths<velox::ArrayVector>(vector, ranges, childRanges);
     if (childRanges.size() > 0) {
@@ -872,10 +852,8 @@ class MapFieldWriter : public MultiValueFieldWriter {
         keys_->typeBuilder(), values_->typeBuilder());
   }
 
-  void write(
-      const velox::VectorPtr& vector,
-      const OrderedRanges& ranges,
-      folly::Executor*) override {
+  void write(const velox::VectorPtr& vector, const OrderedRanges& ranges)
+      override {
     OrderedRanges childRanges;
     auto map = ingestLengths<velox::MapVector>(vector, ranges, childRanges);
     if (childRanges.size() > 0) {
@@ -930,10 +908,8 @@ class SlidingWindowMapFieldWriter : public FieldWriter {
         type->type(), 1, context.bufferMemoryPool().get());
   }
 
-  void write(
-      const velox::VectorPtr& vector,
-      const OrderedRanges& ranges,
-      folly::Executor*) override {
+  void write(const velox::VectorPtr& vector, const OrderedRanges& ranges)
+      override {
     OrderedRanges childFilteredRanges;
     OrderedRanges fullChildRanges;
     // childItemCount is the (logical) total cardinality of map elements,
@@ -1395,10 +1371,8 @@ class FlatMapFieldWriter : public FieldWriter {
     }
   }
 
-  void write(
-      const velox::VectorPtr& vector,
-      const OrderedRanges& ranges,
-      folly::Executor* executor = nullptr) override {
+  void write(const velox::VectorPtr& vector, const OrderedRanges& ranges)
+      override {
     // Check the type of the received vector. Accepted types are ROW or MAP
     // (the latter either MapVector or FlatMapVector encodings).
     switch (vector->type()->kind()) {
@@ -1415,7 +1389,7 @@ class FlatMapFieldWriter : public FieldWriter {
             ingestFlatMap(vector, ranges);
             return;
           default:
-            ingestMap(vector, ranges, executor);
+            ingestMap(vector, ranges);
             return;
         }
         break;
@@ -1779,10 +1753,7 @@ class FlatMapFieldWriter : public FieldWriter {
     }
   }
 
-  void ingestMap(
-      const velox::VectorPtr& vector,
-      const OrderedRanges& ranges,
-      folly::Executor* executor = nullptr) {
+  void ingestMap(const velox::VectorPtr& vector, const OrderedRanges& ranges) {
     NIMBLE_CHECK(
         currentPassthroughFields_.empty(),
         "Mixing map and flatmap vectors in the FlatMapFieldWriter is not supported");
@@ -1880,14 +1851,8 @@ class FlatMapFieldWriter : public FieldWriter {
     if (nonNullCount > 0) {
       auto& values = map->mapValues();
 
-      if (executor) {
-        for (auto& pair : currentValueFields_) {
-          executor->add([&]() { pair.second->write(values, nonNullCount); });
-        }
-      } else {
-        for (auto& pair : currentValueFields_) {
-          pair.second->write(values, nonNullCount);
-        }
+      for (auto& pair : currentValueFields_) {
+        pair.second->write(values, nonNullCount);
       }
     }
     nonNullCount_ += nonNullCount;
@@ -2095,10 +2060,8 @@ class ArrayWithOffsetsFieldWriter : public FieldWriter {
         type->type(), 1, context.bufferMemoryPool().get());
   }
 
-  void write(
-      const velox::VectorPtr& vector,
-      const OrderedRanges& ranges,
-      folly::Executor*) override {
+  void write(const velox::VectorPtr& vector, const OrderedRanges& ranges)
+      override {
     OrderedRanges childFilteredRanges;
     // childItemCount is the (logical) total cardinality of array elements.
     uint64_t childItemCount = 0;

--- a/dwio/nimble/velox/FieldWriter.h
+++ b/dwio/nimble/velox/FieldWriter.h
@@ -605,8 +605,7 @@ class FieldWriter {
   // Writes the vector to internal buffers.
   virtual void write(
       const velox::VectorPtr& vector,
-      const OrderedRanges& ranges,
-      folly::Executor* executor = nullptr) = 0;
+      const OrderedRanges& ranges) = 0;
 
   // Collects stats and clears interanl state and any accumulated data in
   // internal buffers.

--- a/dwio/nimble/velox/VeloxWriter.cpp
+++ b/dwio/nimble/velox/VeloxWriter.cpp
@@ -781,16 +781,8 @@ bool VeloxWriter::write(const velox::VectorPtr& input) {
       context_->updateFileRawSize(rawSize);
     }
 
-    if (context_->options().writeExecutor) {
-      velox::dwio::common::ExecutorBarrier barrier{
-          context_->options().writeExecutor};
-      rootWriter_->write(input, OrderedRanges::of(0, numRows), &barrier);
-      addIndexKey(input, &barrier);
-      barrier.waitAll();
-    } else {
-      rootWriter_->write(input, OrderedRanges::of(0, numRows));
-      addIndexKey(input);
-    }
+    rootWriter_->write(input, OrderedRanges::of(0, numRows));
+    addIndexKey(input);
 
     uint64_t memoryUsed{0};
     for (const auto& [_, stream] : context_->streams()) {

--- a/dwio/nimble/velox/VeloxWriterOptions.h
+++ b/dwio/nimble/velox/VeloxWriterOptions.h
@@ -201,10 +201,10 @@ struct VeloxWriterOptions {
 
   const velox::common::SpillConfig* spillConfig{nullptr};
 
-  // If provided, internal writing/encoding operations will happen in parallel
-  // using the specified executors.
+  // If provided, internal encoding operations will happen in parallel
+  // using the specified executor.
   //
-  // The KeepAlive wrappers ensures that the executor object will be kept alive
+  // The KeepAlive wrapper ensures that the executor object will be kept alive
   // (allocated), and that the pool will be open for receiving new tasks. A
   // shared_ptr would only guarantee that the object is still allocated, but not
   // necessarily open for new task (e.g. it could have been .join()'ed through a
@@ -217,9 +217,7 @@ struct VeloxWriterOptions {
   // KeepAlive references are destructed.
   //
   // - encodingExecutor: execute stream encoding operations in parallel.
-  // - writeExecutor: execute FieldWriter::write() operations in parallel.
   folly::Executor::KeepAlive<> encodingExecutor;
-  folly::Executor::KeepAlive<> writeExecutor;
 
   bool enableChunking{false};
 

--- a/dwio/nimble/velox/tests/VeloxReaderTest.cpp
+++ b/dwio/nimble/velox/tests/VeloxReaderTest.cpp
@@ -2675,7 +2675,6 @@ TEST_P(VeloxReaderTest, fuzzSimple) {
       executor =
           std::make_shared<folly::CPUThreadPoolExecutor>(parallelismFactor);
       writerOptions.encodingExecutor = folly::getKeepAliveToken(*executor);
-      writerOptions.writeExecutor = folly::getKeepAliveToken(*executor);
     }
 
     for (auto i = 0; i < iterations; ++i) {
@@ -2798,7 +2797,6 @@ TEST_P(VeloxReaderTest, fuzzComplex) {
       executor =
           std::make_shared<folly::CPUThreadPoolExecutor>(parallelismFactor);
       writerOptions.encodingExecutor = folly::getKeepAliveToken(*executor);
-      writerOptions.writeExecutor = folly::getKeepAliveToken(*executor);
     }
 
     for (auto i = 0; i < iterations; ++i) {

--- a/dwio/nimble/velox/tests/VeloxWriterTest.cpp
+++ b/dwio/nimble/velox/tests/VeloxWriterTest.cpp
@@ -2539,7 +2539,6 @@ TEST_F(VeloxWriterTest, fuzzComplex) {
       executor =
           std::make_shared<folly::CPUThreadPoolExecutor>(parallelismFactor);
       writerOptions.encodingExecutor = folly::getKeepAliveToken(*executor);
-      writerOptions.writeExecutor = folly::getKeepAliveToken(*executor);
     }
 
     const auto iterations = 20;


### PR DESCRIPTION
Summary:

The writeExecutor-based write parallelism in Nimble's FieldWriter provides no meaningful speedup (benchmarked at 1.02x on a flatmap-heavy schema with 2M rows). The ExecutorBarrier approach only parallelizes top-level column writes in RowFieldWriter, but cannot safely propagate the executor to nested writers (FlatMapFieldWriter) due to dangling reference issues from tasks capturing stack-local variables by reference.

This change removes:
- The folly::Executor* parameter from FieldWriter::write() and all overrides
- The writeExecutor option from VeloxWriterOptions
- The ExecutorBarrier write path from VeloxWriter::write()
- The writeExecutor-related code from dwio/tools/checksum.cpp
- Test references to writeExecutor in VeloxWriterTest and VeloxReaderTest

The encodingExecutor (which parallelizes stream encoding during flush) is unaffected and remains fully functional.

Reviewed By: xiaoxmeng

Differential Revision: D101407345


