### PR TITLE
feat: Add coroutine-based parallel encoding for Nimble FieldWriter (#702)

### DIFF
--- a/dwio/nimble/velox/CMakeLists.txt
+++ b/dwio/nimble/velox/CMakeLists.txt
@@ -78,6 +78,7 @@ target_link_libraries(
   nimble_velox_schema
   nimble_velox_stream_data
   nimble_velox_schema_builder
+  velox_test_util
   Folly::folly
 )
 

--- a/dwio/nimble/velox/FieldWriter.cpp
+++ b/dwio/nimble/velox/FieldWriter.cpp
@@ -272,10 +272,8 @@ class SimpleFieldWriter : public FieldWriter {
             nodeId)},
         statisticsCollector_{context.getStatsCollector(nodeId)} {}
 
-  void write(
-      const velox::VectorPtr& vector,
-      const OrderedRanges& ranges,
-      folly::Executor*) override {
+  void write(const velox::VectorPtr& vector, const OrderedRanges& ranges)
+      override {
     auto size = ranges.size();
     auto& buffer = context_.stringBuffer();
     auto& data = valuesStream_.mutableData();
@@ -411,10 +409,8 @@ class StringFieldWriter : public FieldWriter {
         "StringFieldWriter only supports VARCHAR and VARBINARY types");
   }
 
-  void write(
-      const velox::VectorPtr& vector,
-      const OrderedRanges& ranges,
-      folly::Executor*) override {
+  void write(const velox::VectorPtr& vector, const OrderedRanges& ranges)
+      override {
     // Ensure string buffer capacity.
     auto size = ranges.size();
     const uint64_t totalBytes = getRawSizeFromVector(vector, ranges);
@@ -522,10 +518,8 @@ class TimestampFieldWriter : public FieldWriter {
             nodeId)},
         statisticsCollector_{context.getStatsCollector(nodeId)} {}
 
-  void write(
-      const velox::VectorPtr& vector,
-      const OrderedRanges& ranges,
-      folly::Executor*) override {
+  void write(const velox::VectorPtr& vector, const OrderedRanges& ranges)
+      override {
     auto size = ranges.size();
     Vector<int64_t>& microsData = microsStream_.mutableData();
     Vector<uint16_t>& nanosData = nanosStream_.mutableData();
@@ -625,10 +619,8 @@ class RowFieldWriter : public FieldWriter {
     }
   }
 
-  void write(
-      const velox::VectorPtr& vector,
-      const OrderedRanges& ranges,
-      folly::Executor* executor = nullptr) override {
+  void write(const velox::VectorPtr& vector, const OrderedRanges& ranges)
+      override {
     auto size = ranges.size();
     OrderedRanges childRanges;
     const OrderedRanges* childRangesPtr;
@@ -681,18 +673,8 @@ class RowFieldWriter : public FieldWriter {
       nullCount = size - nonNullCount;
     }
 
-    if (executor) {
-      for (auto i = 0; i < fields_.size(); ++i) {
-        executor->add([&field = fields_[i],
-                       &childVector = row->childAt(i),
-                       childRanges = *childRangesPtr]() {
-          field->write(childVector, childRanges);
-        });
-      }
-    } else {
-      for (auto i = 0; i < fields_.size(); ++i) {
-        fields_[i]->write(row->childAt(i), *childRangesPtr);
-      }
+    for (auto i = 0; i < fields_.size(); ++i) {
+      fields_[i]->write(row->childAt(i), *childRangesPtr);
     }
 
     collectStatistics(nullCount, size);
@@ -831,10 +813,8 @@ class ArrayFieldWriter : public MultiValueFieldWriter {
     typeBuilder_->asArray().setChildren(elements_->typeBuilder());
   }
 
-  void write(
-      const velox::VectorPtr& vector,
-      const OrderedRanges& ranges,
-      folly::Executor*) override {
+  void write(const velox::VectorPtr& vector, const OrderedRanges& ranges)
+      override {
     OrderedRanges childRanges;
     auto array = ingestLengths<velox::ArrayVector>(vector, ranges, childRanges);
     if (childRanges.size() > 0) {
@@ -872,10 +852,8 @@ class MapFieldWriter : public MultiValueFieldWriter {
         keys_->typeBuilder(), values_->typeBuilder());
   }
 
-  void write(
-      const velox::VectorPtr& vector,
-      const OrderedRanges& ranges,
-      folly::Executor*) override {
+  void write(const velox::VectorPtr& vector, const OrderedRanges& ranges)
+      override {
     OrderedRanges childRanges;
     auto map = ingestLengths<velox::MapVector>(vector, ranges, childRanges);
     if (childRanges.size() > 0) {
@@ -930,10 +908,8 @@ class SlidingWindowMapFieldWriter : public FieldWriter {
         type->type(), 1, context.bufferMemoryPool().get());
   }
 
-  void write(
-      const velox::VectorPtr& vector,
-      const OrderedRanges& ranges,
-      folly::Executor*) override {
+  void write(const velox::VectorPtr& vector, const OrderedRanges& ranges)
+      override {
     OrderedRanges childFilteredRanges;
     OrderedRanges fullChildRanges;
     // childItemCount is the (logical) total cardinality of map elements,
@@ -1395,10 +1371,8 @@ class FlatMapFieldWriter : public FieldWriter {
     }
   }
 
-  void write(
-      const velox::VectorPtr& vector,
-      const OrderedRanges& ranges,
-      folly::Executor* executor = nullptr) override {
+  void write(const velox::VectorPtr& vector, const OrderedRanges& ranges)
+      override {
     // Check the type of the received vector. Accepted types are ROW or MAP
     // (the latter either MapVector or FlatMapVector encodings).
     switch (vector->type()->kind()) {
@@ -1415,7 +1389,7 @@ class FlatMapFieldWriter : public FieldWriter {
             ingestFlatMap(vector, ranges);
             return;
           default:
-            ingestMap(vector, ranges, executor);
+            ingestMap(vector, ranges);
             return;
         }
         break;
@@ -1779,10 +1753,7 @@ class FlatMapFieldWriter : public FieldWriter {
     }
   }
 
-  void ingestMap(
-      const velox::VectorPtr& vector,
-      const OrderedRanges& ranges,
-      folly::Executor* executor = nullptr) {
+  void ingestMap(const velox::VectorPtr& vector, const OrderedRanges& ranges) {
     NIMBLE_CHECK(
         currentPassthroughFields_.empty(),
         "Mixing map and flatmap vectors in the FlatMapFieldWriter is not supported");
@@ -1880,14 +1851,8 @@ class FlatMapFieldWriter : public FieldWriter {
     if (nonNullCount > 0) {
       auto& values = map->mapValues();
 
-      if (executor) {
-        for (auto& pair : currentValueFields_) {
-          executor->add([&]() { pair.second->write(values, nonNullCount); });
-        }
-      } else {
-        for (auto& pair : currentValueFields_) {
-          pair.second->write(values, nonNullCount);
-        }
+      for (auto& pair : currentValueFields_) {
+        pair.second->write(values, nonNullCount);
       }
     }
     nonNullCount_ += nonNullCount;
@@ -2095,10 +2060,8 @@ class ArrayWithOffsetsFieldWriter : public FieldWriter {
         type->type(), 1, context.bufferMemoryPool().get());
   }
 
-  void write(
-      const velox::VectorPtr& vector,
-      const OrderedRanges& ranges,
-      folly::Executor*) override {
+  void write(const velox::VectorPtr& vector, const OrderedRanges& ranges)
+      override {
     OrderedRanges childFilteredRanges;
     // childItemCount is the (logical) total cardinality of array elements.
     uint64_t childItemCount = 0;

--- a/dwio/nimble/velox/FieldWriter.cpp
+++ b/dwio/nimble/velox/FieldWriter.cpp
@@ -14,6 +14,10 @@
  * limitations under the License.
  */
 #include "dwio/nimble/velox/FieldWriter.h"
+
+#include <folly/coro/BlockingWait.h>
+#include <folly/coro/Collect.h>
+#include <folly/coro/Invoke.h>
 #include <folly/system/HardwareConcurrency.h>
 #include "dwio/nimble/common/Exceptions.h"
 #include "dwio/nimble/velox/DeduplicationUtils.h"
@@ -22,6 +26,7 @@
 #include "dwio/nimble/velox/SchemaTypes.h"
 #include "dwio/nimble/velox/VectorAdapters.h"
 #include "velox/common/base/CompareFlags.h"
+#include "velox/common/testutil/TestValue.h"
 #include "velox/vector/ComplexVector.h"
 #include "velox/vector/DictionaryVector.h"
 #include "velox/vector/FlatMapVector.h"
@@ -621,63 +626,56 @@ class RowFieldWriter : public FieldWriter {
 
   void write(const velox::VectorPtr& vector, const OrderedRanges& ranges)
       override {
-    auto size = ranges.size();
-    OrderedRanges childRanges;
-    const OrderedRanges* childRangesPtr;
-    const velox::RowVector* row = vector->as<velox::RowVector>();
-    uint64_t nullCount = 0;
-
-    if (row) {
-      NIMBLE_CHECK_LE(
-          fields_.size(),
-          row->childrenSize(),
-          "Schema mismatch: expected {} fields, but got {} fields",
-          fields_.size(),
-          row->childrenSize());
-      nullsStream_.ensureAdditionalNullsCapacity(vector->mayHaveNulls(), size);
-      if (row->mayHaveNulls() && !ignoreNulls_) {
-        childRangesPtr = &childRanges;
-        auto nonNullCount = iterateNonNullIndices<true>(
-            ranges,
-            nullsStream_.mutableNonNulls(),
-            FlatAdapter<>{vector},
-            [&](auto offset) { childRanges.add(offset, 1); });
-        nullCount = size - nonNullCount;
-      } else {
-        childRangesPtr = &ranges;
-      }
-    } else {
-      auto decodingContext = context_.decodingContext();
-      auto& decoded = decodingContext.decode(vector, ranges);
-      row = decoded.base()->as<velox::RowVector>();
-      NIMBLE_CHECK_NOT_NULL(row, "Unexpected vector type");
-      NIMBLE_CHECK_LE(
-          fields_.size(),
-          row->childrenSize(),
-          "Schema mismatch: expected {} fields, but got {} fields",
-          fields_.size(),
-          row->childrenSize());
-      childRangesPtr = &childRanges;
-      nullsStream_.ensureAdditionalNullsCapacity(decoded.mayHaveNulls(), size);
-      auto nonNullCount = ignoreNulls_
-          ? iterateNonNullIndices<false>(
-                ranges,
-                nullsStream_.mutableNonNulls(),
-                DecodedAdapter<int8_t, true>{decoded},
-                [&](auto offset) { childRanges.add(offset, 1); })
-          : iterateNonNullIndices<true>(
-                ranges,
-                nullsStream_.mutableNonNulls(),
-                DecodedAdapter{decoded},
-                [&](auto offset) { childRanges.add(offset, 1); });
-      nullCount = size - nonNullCount;
+    if (parallelWriteEnabled(static_cast<uint32_t>(fields_.size()))) {
+      folly::coro::blockingWait(co_write(vector, ranges));
+      return;
     }
-
+    auto ctx = prepareChildRanges(vector, ranges);
     for (auto i = 0; i < fields_.size(); ++i) {
-      fields_[i]->write(row->childAt(i), *childRangesPtr);
+      fields_[i]->write(ctx.row->childAt(i), *ctx.childRangesPtr);
+    }
+    collectStatistics(ctx.nullCount, ctx.size);
+  }
+
+  folly::coro::Task<void> co_write(
+      const velox::VectorPtr& vector,
+      const OrderedRanges& ranges) override {
+    auto ctx = prepareChildRanges(vector, ranges);
+
+    const uint32_t numChildren = static_cast<uint32_t>(fields_.size());
+    const uint32_t taskCount = computeParallelWriteTaskCount(numChildren);
+    velox::common::testutil::TestValue::adjust(
+        "facebook::nimble::RowFieldWriter::co_write",
+        const_cast<uint32_t*>(&taskCount));
+
+    const uint32_t childrenPerTask = numChildren / taskCount;
+    const uint32_t numRemainderChildren = numChildren % taskCount;
+
+    auto writeRange = [this, &ctx](uint32_t startIdx, uint32_t endIdx) {
+      for (uint32_t i = startIdx; i < endIdx; ++i) {
+        fields_[i]->write(ctx.row->childAt(i), *ctx.childRangesPtr);
+      }
+    };
+
+    std::vector<folly::coro::TaskWithExecutor<void>> tasks;
+    tasks.reserve(taskCount);
+    uint32_t nextChildIdx = 0;
+    for (uint32_t taskId = 0; taskId < taskCount; ++taskId) {
+      const uint32_t endChildIdx = nextChildIdx + childrenPerTask +
+          (taskId < numRemainderChildren ? 1 : 0);
+      tasks.emplace_back(co_withExecutor(
+          context_.encodeExecutor(),
+          folly::coro::co_invoke(
+              [&writeRange, nextChildIdx, endChildIdx]()
+                  -> folly::coro::Task<void> {
+                writeRange(nextChildIdx, endChildIdx);
+                co_return;
+              })));
+      nextChildIdx = endChildIdx;
     }
 
-    collectStatistics(nullCount, size);
+    co_await folly::coro::collectAllRange(std::move(tasks));
+    collectStatistics(ctx.nullCount, ctx.size);
   }
 
   void reset() override {
@@ -695,6 +693,79 @@ class RowFieldWriter : public FieldWriter {
   }
 
  private:
+  // Result of null processing and child range computation, shared between
+  // the synchronous write() and coroutine co_write() paths.
+  struct PrepareContext {
+    // Decoded row vector (either direct cast or decoded from encoded input).
+    const velox::RowVector* row{};
+    // Ranges for child writes: points to either the original input ranges
+    // (when no nulls) or the filtered childRanges below.
+    const OrderedRanges* childRangesPtr{};
+    uint64_t nullCount{};
+    uint64_t size{};
+    // Filtered ranges containing only non-null row indices.
+    OrderedRanges childRanges;
+  };
+
+  PrepareContext prepareChildRanges(
+      const velox::VectorPtr& vector,
+      const OrderedRanges& ranges) {
+    PrepareContext ctx;
+    ctx.size = ranges.size();
+    ctx.nullCount = 0;
+    ctx.row = vector->as<velox::RowVector>();
+
+    if (ctx.row) {
+      NIMBLE_CHECK_LE(
+          fields_.size(),
+          ctx.row->childrenSize(),
+          "Schema mismatch: expected {} fields, but got {} fields",
+          fields_.size(),
+          ctx.row->childrenSize());
+      nullsStream_.ensureAdditionalNullsCapacity(
+          vector->mayHaveNulls(), ctx.size);
+      if (ctx.row->mayHaveNulls() && !ignoreNulls_) {
+        ctx.childRangesPtr = &ctx.childRanges;
+        auto nonNullCount = iterateNonNullIndices<true>(
+            ranges,
+            nullsStream_.mutableNonNulls(),
+            FlatAdapter<>{vector},
+            [&](auto offset) { ctx.childRanges.add(offset, 1); });
+        ctx.nullCount = ctx.size - nonNullCount;
+      } else {
+        ctx.childRangesPtr = &ranges;
+      }
+    } else {
+      auto decodingContext = context_.decodingContext();
+      auto& decoded = decodingContext.decode(vector, ranges);
+      ctx.row = decoded.base()->as<velox::RowVector>();
+      NIMBLE_CHECK_NOT_NULL(ctx.row, "Unexpected vector type");
+      NIMBLE_CHECK_LE(
+          fields_.size(),
+          ctx.row->childrenSize(),
+          "Schema mismatch: expected {} fields, but got {} fields",
+          fields_.size(),
+          ctx.row->childrenSize());
+      ctx.childRangesPtr = &ctx.childRanges;
+      nullsStream_.ensureAdditionalNullsCapacity(
+          decoded.mayHaveNulls(), ctx.size);
+      auto nonNullCount = ignoreNulls_
+          ? iterateNonNullIndices<false>(
+                ranges,
+                nullsStream_.mutableNonNulls(),
+                DecodedAdapter<int8_t, true>{decoded},
+                [&](auto offset) { ctx.childRanges.add(offset, 1); })
+          : iterateNonNullIndices<true>(
+                ranges,
+                nullsStream_.mutableNonNulls(),
+                DecodedAdapter{decoded},
+                [&](auto offset) { ctx.childRanges.add(offset, 1); });
+      ctx.nullCount = ctx.size - nonNullCount;
+    }
+
+    return ctx;
+  }
+
   void collectStatistics(uint64_t nullCount, uint64_t valueCount) {
     if (!statisticsCollector_) {
       return;
@@ -1851,8 +1922,13 @@ class FlatMapFieldWriter : public FieldWriter {
     if (nonNullCount > 0) {
       auto& values = map->mapValues();
 
-      for (auto& pair : currentValueFields_) {
-        pair.second->write(values, nonNullCount);
+      if (parallelWriteEnabled(
+              static_cast<uint32_t>(currentValueFields_.size()))) {
+        folly::coro::blockingWait(co_writeMapValues(values, nonNullCount));
+      } else {
+        for (auto& pair : currentValueFields_) {
+          pair.second->write(values, nonNullCount);
+        }
       }
     }
     nonNullCount_ += nonNullCount;
@@ -1901,6 +1977,52 @@ class FlatMapFieldWriter : public FieldWriter {
   }
 
  private:
+  folly::coro::Task<void> co_writeMapValues(
+      const velox::VectorPtr& values,
+      uint32_t nonNullCount) {
+    std::vector<FlatMapValueFieldWriter*> valueWriters;
+    valueWriters.reserve(currentValueFields_.size());
+    for (auto& pair : currentValueFields_) {
+      valueWriters.push_back(pair.second);
+    }
+
+    const uint32_t taskCount = computeParallelWriteTaskCount(
+        static_cast<uint32_t>(valueWriters.size()));
+    velox::common::testutil::TestValue::adjust(
+        "facebook::nimble::FlatMapFieldWriter::co_writeMapValues",
+        const_cast<uint32_t*>(&taskCount));
+
+    const uint32_t writersPerTask =
+        static_cast<uint32_t>(valueWriters.size()) / taskCount;
+    const uint32_t numRemainderWriters =
+        static_cast<uint32_t>(valueWriters.size()) % taskCount;
+
+    auto writeRange = [&valueWriters, &values, nonNullCount](
+                          uint32_t startIdx, uint32_t endIdx) {
+      for (uint32_t idx = startIdx; idx < endIdx; ++idx) {
+        valueWriters[idx]->write(values, nonNullCount);
+      }
+    };
+
+    std::vector<folly::coro::TaskWithExecutor<void>> tasks;
+    tasks.reserve(taskCount);
+    uint32_t nextIdx = 0;
+    for (uint32_t taskId = 0; taskId < taskCount; ++taskId) {
+      const uint32_t endIdx =
+          nextIdx + writersPerTask + (taskId < numRemainderWriters ? 1 : 0);
+      tasks.emplace_back(co_withExecutor(
+          context_.encodeExecutor(),
+          folly::coro::co_invoke(
+              [&writeRange, nextIdx, endIdx]() -> folly::coro::Task<void> {
+                writeRange(nextIdx, endIdx);
+                co_return;
+              })));
+      nextIdx = endIdx;
+    }
+
+    co_await folly::coro::collectAllRange(std::move(tasks));
+  }
+
   inline bool hasPredefinedKeys() const {
     return context_.getFlatMapNodeKeys(nodeId_) != nullptr;
   }
@@ -2725,6 +2847,22 @@ std::unique_ptr<FieldWriter> FieldWriter::create(
   }
   context.handleAddedType(*field->typeBuilder());
   return field;
+}
+
+uint32_t FieldWriter::computeParallelWriteTaskCount(
+    uint32_t numChildren) const {
+  if (numChildren == 0) {
+    return 0;
+  }
+  const uint32_t maxByStreams =
+      numChildren / std::max(1u, context_.minStreamsPerEncodeUnit());
+  return std::clamp(
+      std::min(context_.maxEncodeParallelism(), maxByStreams), 1u, numChildren);
+}
+
+bool FieldWriter::parallelWriteEnabled(uint32_t numChildren) const {
+  return context_.encodeExecutor() != nullptr &&
+      computeParallelWriteTaskCount(numChildren) > 1;
 }
 
 } // namespace facebook::nimble

--- a/dwio/nimble/velox/FieldWriter.h
+++ b/dwio/nimble/velox/FieldWriter.h
@@ -16,6 +16,11 @@
 
 #pragma once
 
+#include <set>
+
+#include <folly/Executor.h>
+#include <folly/coro/Task.h>
+
 #include "dwio/nimble/common/Buffer.h"
 #include "dwio/nimble/velox/BufferGrowthPolicy.h"
 #include "dwio/nimble/velox/OrderedRanges.h"
@@ -26,8 +31,6 @@
 #include "folly/container/F14Map.h"
 #include "folly/stats/StreamingStats.h"
 #include "velox/dwio/common/TypeWithId.h"
-
-#include <set>
 #include "velox/vector/DecodedVector.h"
 
 namespace facebook::nimble {
@@ -237,6 +240,28 @@ class FieldWriterContext {
 
   inline void setIgnoreTopLevelNulls(bool value) {
     ignoreTopLevelNulls_ = value;
+  }
+
+  void setParallelEncoding(
+      folly::Executor* executor,
+      uint32_t maxEncodeParallelism = 8,
+      uint32_t minStreamsPerEncodeUnit = 2) {
+    NIMBLE_CHECK_NOT_NULL(executor, "encodeExecutor must not be null");
+    encodeExecutor_ = executor;
+    maxEncodeParallelism_ = maxEncodeParallelism;
+    minStreamsPerEncodeUnit_ = minStreamsPerEncodeUnit;
+  }
+
+  folly::Executor* encodeExecutor() const {
+    return encodeExecutor_;
+  }
+
+  uint32_t maxEncodeParallelism() const {
+    return maxEncodeParallelism_;
+  }
+
+  uint32_t minStreamsPerEncodeUnit() const {
+    return minStreamsPerEncodeUnit_;
   }
 
   inline std::unique_ptr<InputBufferGrowthPolicy>& inputBufferGrowthPolicy() {
@@ -462,6 +487,10 @@ class FieldWriterContext {
   bool ignoreTopLevelNulls_{false};
   bool disableSharedStringBuffers_{false};
 
+  folly::Executor* encodeExecutor_{nullptr};
+  uint32_t maxEncodeParallelism_{0};
+  uint32_t minStreamsPerEncodeUnit_{1};
+
   std::unique_ptr<InputBufferGrowthPolicy> inputBufferGrowthPolicy_;
   std::unique_ptr<InputBufferGrowthPolicy> stringBufferGrowthPolicy_;
   InputBufferGrowthStats inputBufferGrowthStats_;
@@ -607,6 +636,13 @@ class FieldWriter {
       const velox::VectorPtr& vector,
       const OrderedRanges& ranges) = 0;
 
+  virtual folly::coro::Task<void> co_write(
+      const velox::VectorPtr& vector,
+      const OrderedRanges& ranges) {
+    write(vector, ranges);
+    co_return;
+  }
+
   // Collects stats and clears interanl state and any accumulated data in
   // internal buffers.
   virtual void reset() = 0;
@@ -629,6 +665,13 @@ class FieldWriter {
       std::function<void(const TypeBuilder&)> typeAddedHandler);
 
  protected:
+  // Computes the number of parallel write tasks based on max parallelism and
+  // minimum streams per task. The result is clamped to [1, numChildren].
+  uint32_t computeParallelWriteTaskCount(uint32_t numChildren) const;
+
+  // Returns true if child fields should be written in parallel.
+  bool parallelWriteEnabled(uint32_t numChildren) const;
+
   FieldWriterContext& context_;
   std::shared_ptr<TypeBuilder> typeBuilder_;
 };

--- a/dwio/nimble/velox/FieldWriter.h
+++ b/dwio/nimble/velox/FieldWriter.h
@@ -605,8 +605,7 @@ class FieldWriter {
   // Writes the vector to internal buffers.
   virtual void write(
       const velox::VectorPtr& vector,
-      const OrderedRanges& ranges,
-      folly::Executor* executor = nullptr) = 0;
+      const OrderedRanges& ranges) = 0;
 
   // Collects stats and clears interanl state and any accumulated data in
   // internal buffers.

--- a/dwio/nimble/velox/VeloxWriter.cpp
+++ b/dwio/nimble/velox/VeloxWriter.cpp
@@ -63,6 +63,13 @@ class WriterContext : public FieldWriterContext {
         : this->options_.stringBufferGrowthPolicyFactory();
     ignoreTopLevelNulls_ = options_.ignoreTopLevelNulls;
     disableSharedStringBuffers_ = options_.disableSharedStringBuffers;
+    if (this->options_.encodingExecutor &&
+        this->options_.maxEncodeParallelism > 0) {
+      setParallelEncoding(
+          this->options_.encodingExecutor.get(),
+          this->options_.maxEncodeParallelism,
+          this->options_.minStreamsPerEncodeUnit);
+    }
   }
 
   const VeloxWriterOptions& options() const {

--- a/dwio/nimble/velox/VeloxWriter.cpp
+++ b/dwio/nimble/velox/VeloxWriter.cpp
@@ -781,16 +781,8 @@ bool VeloxWriter::write(const velox::VectorPtr& input) {
       context_->updateFileRawSize(rawSize);
     }
 
-    if (context_->options().writeExecutor) {
-      velox::dwio::common::ExecutorBarrier barrier{
-          context_->options().writeExecutor};
-      rootWriter_->write(input, OrderedRanges::of(0, numRows), &barrier);
-      addIndexKey(input, &barrier);
-      barrier.waitAll();
-    } else {
-      rootWriter_->write(input, OrderedRanges::of(0, numRows));
-      addIndexKey(input);
-    }
+    rootWriter_->write(input, OrderedRanges::of(0, numRows));
+    addIndexKey(input);
 
     uint64_t memoryUsed{0};
     for (const auto& [_, stream] : context_->streams()) {

--- a/dwio/nimble/velox/VeloxWriterOptions.h
+++ b/dwio/nimble/velox/VeloxWriterOptions.h
@@ -201,8 +201,8 @@ struct VeloxWriterOptions {
 
   const velox::common::SpillConfig* spillConfig{nullptr};
 
-  // If provided, internal encoding operations will happen in parallel
-  // using the specified executor.
+  // If provided, internal encoding operations will happen in parallel using
+  // the specified executor.
   //
   // The KeepAlive wrapper ensures that the executor object will be kept alive
   // (allocated), and that the pool will be open for receiving new tasks. A
@@ -215,9 +215,13 @@ struct VeloxWriterOptions {
   // As a result, if a KeepAlive is still being held, clients trying to destruct
   // the last reference of a shared_ptr to that executor will block until all
   // KeepAlive references are destructed.
-  //
-  // - encodingExecutor: execute stream encoding operations in parallel.
   folly::Executor::KeepAlive<> encodingExecutor;
+
+  // When maxEncodeParallelism > 0 and encodingExecutor is set,
+  // FieldWriter::write() operations will be parallelized using coroutines
+  // scheduled on encodingExecutor.
+  uint32_t maxEncodeParallelism{0};
+  uint32_t minStreamsPerEncodeUnit{1};
 
   bool enableChunking{false};
 

--- a/dwio/nimble/velox/VeloxWriterOptions.h
+++ b/dwio/nimble/velox/VeloxWriterOptions.h
@@ -201,10 +201,10 @@ struct VeloxWriterOptions {
 
   const velox::common::SpillConfig* spillConfig{nullptr};
 
-  // If provided, internal writing/encoding operations will happen in parallel
-  // using the specified executors.
+  // If provided, internal encoding operations will happen in parallel
+  // using the specified executor.
   //
-  // The KeepAlive wrappers ensures that the executor object will be kept alive
+  // The KeepAlive wrapper ensures that the executor object will be kept alive
   // (allocated), and that the pool will be open for receiving new tasks. A
   // shared_ptr would only guarantee that the object is still allocated, but not
   // necessarily open for new task (e.g. it could have been .join()'ed through a
@@ -217,9 +217,7 @@ struct VeloxWriterOptions {
   // KeepAlive references are destructed.
   //
   // - encodingExecutor: execute stream encoding operations in parallel.
-  // - writeExecutor: execute FieldWriter::write() operations in parallel.
   folly::Executor::KeepAlive<> encodingExecutor;
-  folly::Executor::KeepAlive<> writeExecutor;
 
   bool enableChunking{false};
 

--- a/dwio/nimble/velox/tests/VeloxReaderTest.cpp
+++ b/dwio/nimble/velox/tests/VeloxReaderTest.cpp
@@ -2675,7 +2675,6 @@ TEST_P(VeloxReaderTest, fuzzSimple) {
       executor =
           std::make_shared<folly::CPUThreadPoolExecutor>(parallelismFactor);
       writerOptions.encodingExecutor = folly::getKeepAliveToken(*executor);
-      writerOptions.writeExecutor = folly::getKeepAliveToken(*executor);
     }
 
     for (auto i = 0; i < iterations; ++i) {
@@ -2798,7 +2797,6 @@ TEST_P(VeloxReaderTest, fuzzComplex) {
       executor =
           std::make_shared<folly::CPUThreadPoolExecutor>(parallelismFactor);
       writerOptions.encodingExecutor = folly::getKeepAliveToken(*executor);
-      writerOptions.writeExecutor = folly::getKeepAliveToken(*executor);
     }
 
     for (auto i = 0; i < iterations; ++i) {

--- a/dwio/nimble/velox/tests/VeloxWriterTest.cpp
+++ b/dwio/nimble/velox/tests/VeloxWriterTest.cpp
@@ -2539,7 +2539,6 @@ TEST_F(VeloxWriterTest, fuzzComplex) {
       executor =
           std::make_shared<folly::CPUThreadPoolExecutor>(parallelismFactor);
       writerOptions.encodingExecutor = folly::getKeepAliveToken(*executor);
-      writerOptions.writeExecutor = folly::getKeepAliveToken(*executor);
     }
 
     const auto iterations = 20;

--- a/dwio/nimble/velox/tests/VeloxWriterTest.cpp
+++ b/dwio/nimble/velox/tests/VeloxWriterTest.cpp
@@ -13,10 +13,13 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+#include <folly/executors/CPUThreadPoolExecutor.h>
 #include <folly/system/HardwareConcurrency.h>
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 #include <set>
+
+#include "velox/common/testutil/TestValue.h"
 
 #include <utility>
 #include "dwio/nimble/common/Exceptions.h"
@@ -5820,6 +5823,294 @@ TEST_F(VeloxWriterTest, flatmapColumnsKeysImplicitFlatMapColumn) {
     ASSERT_TRUE(expected->equalValueAt(result.get(), i, i))
         << "Mismatch at row " << i;
   }
+}
+
+struct ParallelEncodeParam {
+  uint32_t maxEncodeParallelism;
+  uint32_t minStreamsPerEncodeUnit;
+
+  std::string debugString() const {
+    return fmt::format(
+        "maxParallel_{}_minStreams_{}",
+        maxEncodeParallelism,
+        minStreamsPerEncodeUnit);
+  }
+};
+
+class ParallelEncodeWriterTest
+    : public VeloxWriterTest,
+      public ::testing::WithParamInterface<ParallelEncodeParam> {
+ protected:
+  nimble::VeloxWriterOptions parallelWriterOptions() {
+    nimble::VeloxWriterOptions options;
+    executor_ = std::make_shared<folly::CPUThreadPoolExecutor>(4);
+    options.encodingExecutor = folly::getKeepAliveToken(*executor_);
+    options.maxEncodeParallelism = GetParam().maxEncodeParallelism;
+    options.minStreamsPerEncodeUnit = GetParam().minStreamsPerEncodeUnit;
+    return options;
+  }
+
+  std::shared_ptr<folly::CPUThreadPoolExecutor> executor_;
+};
+
+TEST_P(ParallelEncodeWriterTest, rowParallelEncode) {
+  auto type = velox::ROW({
+      {"a", velox::BIGINT()},
+      {"b", velox::DOUBLE()},
+      {"c", velox::INTEGER()},
+      {"d", velox::BIGINT()},
+      {"e", velox::REAL()},
+      {"f", velox::BIGINT()},
+      {"g", velox::INTEGER()},
+      {"h", velox::DOUBLE()},
+  });
+
+  auto seed = folly::Random::rand32();
+  LOG(INFO) << "seed: " << seed;
+  velox::VectorFuzzer fuzzer(
+      {.vectorSize = 1000, .nullRatio = 0.1}, leafPool_.get(), seed);
+
+  auto writerOptions = parallelWriterOptions();
+
+  std::string seqFile;
+  std::string parFile;
+
+  {
+    auto writeFile = std::make_unique<velox::InMemoryWriteFile>(&seqFile);
+    nimble::VeloxWriter writer(type, std::move(writeFile), *rootPool_, {});
+    for (int i = 0; i < 10; ++i) {
+      writer.write(fuzzer.fuzzInputRow(type));
+    }
+    writer.close();
+  }
+
+  {
+    auto writeFile = std::make_unique<velox::InMemoryWriteFile>(&parFile);
+    nimble::VeloxWriter writer(
+        type, std::move(writeFile), *rootPool_, writerOptions);
+    fuzzer.reSeed(seed);
+    for (int i = 0; i < 10; ++i) {
+      writer.write(fuzzer.fuzzInputRow(type));
+    }
+    writer.close();
+  }
+
+  auto seqRead = std::make_shared<velox::InMemoryReadFile>(seqFile);
+  auto parRead = std::make_shared<velox::InMemoryReadFile>(parFile);
+  nimble::VeloxReader seqReader(seqRead.get(), *leafPool_);
+  nimble::VeloxReader parReader(parRead.get(), *leafPool_);
+
+  velox::VectorPtr seqResult;
+  velox::VectorPtr parResult;
+  while (seqReader.next(1000, seqResult)) {
+    ASSERT_TRUE(parReader.next(1000, parResult));
+    ASSERT_EQ(seqResult->size(), parResult->size());
+    for (velox::vector_size_t row = 0; row < seqResult->size(); ++row) {
+      ASSERT_TRUE(seqResult->equalValueAt(parResult.get(), row, row))
+          << "Mismatch at row " << row;
+    }
+  }
+}
+
+TEST_P(ParallelEncodeWriterTest, flatMapParallelEncode) {
+  auto type = velox::ROW({
+      {"flatmap", velox::MAP(velox::INTEGER(), velox::BIGINT())},
+      {"col", velox::BIGINT()},
+  });
+
+  auto seed = folly::Random::rand32();
+  LOG(INFO) << "seed: " << seed;
+  velox::VectorFuzzer fuzzer(
+      {.vectorSize = 1000, .nullRatio = 0.1, .containerLength = 20},
+      leafPool_.get(),
+      seed);
+
+  auto writerOptions = parallelWriterOptions();
+  writerOptions.flatMapColumns = {{"flatmap", {}}};
+
+  nimble::VeloxWriterOptions seqOptions;
+  seqOptions.flatMapColumns = {{"flatmap", {}}};
+
+  std::string seqFile;
+  std::string parFile;
+
+  {
+    auto writeFile = std::make_unique<velox::InMemoryWriteFile>(&seqFile);
+    nimble::VeloxWriter writer(
+        type, std::move(writeFile), *rootPool_, seqOptions);
+    for (int i = 0; i < 10; ++i) {
+      writer.write(fuzzer.fuzzInputRow(type));
+    }
+    writer.close();
+  }
+
+  {
+    auto writeFile = std::make_unique<velox::InMemoryWriteFile>(&parFile);
+    nimble::VeloxWriter writer(
+        type, std::move(writeFile), *rootPool_, writerOptions);
+    fuzzer.reSeed(seed);
+    for (int i = 0; i < 10; ++i) {
+      writer.write(fuzzer.fuzzInputRow(type));
+    }
+    writer.close();
+  }
+
+  auto seqRead = std::make_shared<velox::InMemoryReadFile>(seqFile);
+  auto parRead = std::make_shared<velox::InMemoryReadFile>(parFile);
+  nimble::VeloxReader seqReader(seqRead.get(), *leafPool_);
+  nimble::VeloxReader parReader(parRead.get(), *leafPool_);
+
+  velox::VectorPtr seqResult;
+  velox::VectorPtr parResult;
+  while (seqReader.next(1000, seqResult)) {
+    ASSERT_TRUE(parReader.next(1000, parResult));
+    ASSERT_EQ(seqResult->size(), parResult->size());
+    for (velox::vector_size_t row = 0; row < seqResult->size(); ++row) {
+      ASSERT_TRUE(seqResult->equalValueAt(parResult.get(), row, row))
+          << "Mismatch at row " << row;
+    }
+  }
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    ParallelEncodeWriterTestSuite,
+    ParallelEncodeWriterTest,
+    ::testing::Values(
+        ParallelEncodeParam{2, 1},
+        ParallelEncodeParam{4, 1},
+        ParallelEncodeParam{8, 1},
+        ParallelEncodeParam{4, 4},
+        ParallelEncodeParam{100, 1}),
+    [](const ::testing::TestParamInfo<ParallelEncodeParam>& info) {
+      return info.param.debugString();
+    });
+
+DEBUG_ONLY_TEST_F(VeloxWriterTest, parallelEncodeRowTaskCount) {
+  velox::common::testutil::TestValue::enable();
+
+  auto type = velox::ROW({
+      {"a", velox::BIGINT()},
+      {"b", velox::DOUBLE()},
+      {"c", velox::INTEGER()},
+      {"d", velox::BIGINT()},
+      {"e", velox::REAL()},
+      {"f", velox::BIGINT()},
+      {"g", velox::INTEGER()},
+      {"h", velox::DOUBLE()},
+  });
+
+  velox::VectorFuzzer fuzzer(
+      {.vectorSize = 100, .nullRatio = 0}, leafPool_.get());
+
+  struct TestCase {
+    uint32_t maxEncodeParallelism;
+    uint32_t minStreamsPerEncodeUnit;
+    uint32_t expectedTaskCount;
+  };
+
+  const std::vector<TestCase> testCases = {
+      {2, 1, 2},
+      {4, 1, 4},
+      {8, 1, 8},
+      {4, 4, 2},
+      {8, 4, 2},
+      {100, 1, 8},
+  };
+
+  folly::CPUThreadPoolExecutor executor(4);
+
+  for (const auto& testCase : testCases) {
+    SCOPED_TRACE(
+        fmt::format(
+            "maxParallel={}, minStreams={}, expected={}",
+            testCase.maxEncodeParallelism,
+            testCase.minStreamsPerEncodeUnit,
+            testCase.expectedTaskCount));
+
+    nimble::VeloxWriterOptions writerOptions;
+    writerOptions.encodingExecutor = folly::getKeepAliveToken(executor);
+    writerOptions.maxEncodeParallelism = testCase.maxEncodeParallelism;
+    writerOptions.minStreamsPerEncodeUnit = testCase.minStreamsPerEncodeUnit;
+
+    uint32_t parallelWriteCount = 0;
+    std::vector<uint32_t> observedTaskCounts;
+    SCOPED_TESTVALUE_SET(
+        "facebook::nimble::RowFieldWriter::co_write",
+        std::function<void(const uint32_t*)>([&](const uint32_t* taskCount) {
+          ++parallelWriteCount;
+          observedTaskCounts.emplace_back(*taskCount);
+        }));
+
+    std::string file;
+    auto writeFile = std::make_unique<velox::InMemoryWriteFile>(&file);
+    nimble::VeloxWriter writer(
+        type, std::move(writeFile), *rootPool_, writerOptions);
+
+    const size_t numBatches = 3;
+    for (size_t i = 0; i < numBatches; ++i) {
+      writer.write(fuzzer.fuzzInputRow(type));
+    }
+    writer.close();
+
+    EXPECT_EQ(parallelWriteCount, numBatches);
+    for (const auto taskCount : observedTaskCounts) {
+      EXPECT_EQ(taskCount, testCase.expectedTaskCount);
+    }
+
+    auto readFile = std::make_shared<velox::InMemoryReadFile>(file);
+    nimble::VeloxReader reader(readFile.get(), *leafPool_);
+    velox::VectorPtr result;
+    ASSERT_TRUE(reader.next(numBatches * 100, result));
+    EXPECT_EQ(result->size(), numBatches * 100);
+  }
+}
+
+DEBUG_ONLY_TEST_F(VeloxWriterTest, parallelEncodeFlatMapTaskCount) {
+  velox::common::testutil::TestValue::enable();
+
+  auto type = velox::ROW({
+      {"flatmap", velox::MAP(velox::INTEGER(), velox::BIGINT())},
+      {"col", velox::BIGINT()},
+  });
+
+  velox::VectorFuzzer fuzzer(
+      {.vectorSize = 100, .nullRatio = 0, .containerLength = 20},
+      leafPool_.get());
+
+  folly::CPUThreadPoolExecutor executor(4);
+
+  nimble::VeloxWriterOptions writerOptions;
+  writerOptions.flatMapColumns = {{"flatmap", {}}};
+  writerOptions.encodingExecutor = folly::getKeepAliveToken(executor);
+  writerOptions.maxEncodeParallelism = 4;
+  writerOptions.minStreamsPerEncodeUnit = 1;
+
+  uint32_t flatMapParallelCount = 0;
+  SCOPED_TESTVALUE_SET(
+      "facebook::nimble::FlatMapFieldWriter::co_writeMapValues",
+      std::function<void(const uint32_t*)>([&](const uint32_t* taskCount) {
+        ++flatMapParallelCount;
+        EXPECT_GT(*taskCount, 1);
+      }));
+
+  std::string file;
+  auto writeFile = std::make_unique<velox::InMemoryWriteFile>(&file);
+  nimble::VeloxWriter writer(
+      type, std::move(writeFile), *rootPool_, writerOptions);
+
+  const size_t numBatches = 5;
+  for (size_t i = 0; i < numBatches; ++i) {
+    writer.write(fuzzer.fuzzInputRow(type));
+  }
+  writer.close();
+
+  EXPECT_GT(flatMapParallelCount, 0);
+
+  auto readFile = std::make_shared<velox::InMemoryReadFile>(file);
+  nimble::VeloxReader reader(readFile.get(), *leafPool_);
+  velox::VectorPtr result;
+  ASSERT_TRUE(reader.next(numBatches * 100, result));
+  EXPECT_EQ(result->size(), numBatches * 100);
 }
 
 } // namespace facebook


### PR DESCRIPTION
Summary:

Adds coroutine-based parallelism to the Nimble write path, mirroring the reader's co_next() pattern. Uses folly::coro::collectAllRange to dispatch child field writes concurrently, with co_await yielding threads back to the executor to prevent deadlock in nested structures.

Key changes:
- FieldWriterContext: Add encodeExecutor, maxEncodeParallelism, minStreamsPerEncodeUnit config with setParallelEncoding() setter
- FieldWriter: Add co_write() virtual (default wraps sync write()), computeParallelWriteTaskCount(), parallelWriteEnabled() helpers
- RowFieldWriter: Add co_write() override that partitions child columns into coroutine task groups. Extract prepareChildRanges() helper to share null/range prep between write() and co_write()
- FlatMapFieldWriter: Add co_writeMapValues() that parallelizes per-key value writes across coroutine tasks
- VeloxWriterOptions: Add encodeExecutor, maxEncodeParallelism, minStreamsPerEncodeUnit options
- VeloxWriter: Wire options through WriterContext to setParallelEncoding()

Reviewed By: xiaoxmeng

Differential Revision: D101407347


