### PR TITLE
feat: Add MetadataInput for IO-coalesced metadata loading with optional caching (#705)

### DIFF
--- a/dwio/nimble/common/tests/TestUtils.h
+++ b/dwio/nimble/common/tests/TestUtils.h
@@ -15,8 +15,11 @@
  */
 #pragma once
 
+#include <chrono>
 #include <cstdint>
+#include <mutex>
 #include <string_view>
+#include <thread>
 #include <type_traits>
 
 #include "dwio/nimble/common/Buffer.h"
@@ -394,12 +397,28 @@ class TrackingReadFile : public velox::ReadFile {
   explicit TrackingReadFile(std::shared_ptr<velox::ReadFile> delegate)
       : delegate_(std::move(delegate)) {}
 
+  void setReadDelayUs(uint64_t delayUs) {
+    readDelayUs_ = delayUs;
+  }
+
+  void setReadError(std::exception_ptr error) {
+    std::lock_guard<std::mutex> l(mu_);
+    readError_ = std::move(error);
+  }
+
+  void clearReadError() {
+    std::lock_guard<std::mutex> l(mu_);
+    readError_ = nullptr;
+  }
+
   std::string_view pread(
       uint64_t offset,
       uint64_t length,
       void* buf,
       const velox::FileIoContext& context = {}) const override {
     updateMaxReadOffset(offset + length);
+    maybeThrow();
+    maybeDelay();
     return delegate_->pread(offset, length, buf, context);
   }
 
@@ -408,6 +427,8 @@ class TrackingReadFile : public velox::ReadFile {
       uint64_t length,
       const velox::FileIoContext& context = {}) const override {
     updateMaxReadOffset(offset + length);
+    maybeThrow();
+    maybeDelay();
     return delegate_->pread(offset, length, context);
   }
 
@@ -420,6 +441,9 @@ class TrackingReadFile : public velox::ReadFile {
       totalLength += buffer.size();
     }
     updateMaxReadOffset(offset + totalLength);
+    ioGroups_.wlock()->push_back({offset, totalLength});
+    maybeThrow();
+    maybeDelay();
     return delegate_->preadv(offset, buffers, context);
   }
 
@@ -430,6 +454,8 @@ class TrackingReadFile : public velox::ReadFile {
     for (const auto& region : regions) {
       updateMaxReadOffset(region.offset + region.length);
     }
+    maybeThrow();
+    maybeDelay();
     return delegate_->preadv(regions, iobufs, context);
   }
 
@@ -462,6 +488,23 @@ class TrackingReadFile : public velox::ReadFile {
     maxReadOffset_.store(0, std::memory_order_relaxed);
   }
 
+  struct IoGroup {
+    uint64_t offset;
+    uint64_t size;
+
+    std::string debugString() const {
+      return fmt::format("[offset={}, size={}]", offset, size);
+    }
+  };
+
+  std::vector<IoGroup> ioGroups() const {
+    return *ioGroups_.rlock();
+  }
+
+  void resetIoGroups() {
+    ioGroups_.wlock()->clear();
+  }
+
  private:
   void updateMaxReadOffset(uint64_t endOffset) const {
     auto current = maxReadOffset_.load(std::memory_order_relaxed);
@@ -471,8 +514,26 @@ class TrackingReadFile : public velox::ReadFile {
     }
   }
 
+  void maybeThrow() const {
+    std::lock_guard<std::mutex> l(mu_);
+    if (readError_ != nullptr) {
+      std::rethrow_exception(readError_);
+    }
+  }
+
+  void maybeDelay() const {
+    const auto delayUs = readDelayUs_.load(std::memory_order_relaxed);
+    if (delayUs > 0) {
+      std::this_thread::sleep_for(std::chrono::microseconds(delayUs));
+    }
+  }
+
   const std::shared_ptr<velox::ReadFile> delegate_;
   mutable std::atomic_uint64_t maxReadOffset_{0};
+  mutable folly::Synchronized<std::vector<IoGroup>> ioGroups_;
+  std::atomic_uint64_t readDelayUs_{0};
+  mutable std::mutex mu_;
+  std::exception_ptr readError_;
 };
 
 } // namespace facebook::nimble::testing

--- a/dwio/nimble/index/tests/ClusterIndexTestBase.cpp
+++ b/dwio/nimble/index/tests/ClusterIndexTestBase.cpp
@@ -18,10 +18,23 @@
 #include "dwio/nimble/tablet/ChunkIndexGenerated.h"
 #include "dwio/nimble/tablet/ClusterIndexGenerated.h"
 #include "folly/json/json.h"
+#include "velox/buffer/Buffer.h"
 #include "velox/common/testutil/TestValue.h"
 #include "velox/dwio/common/SeekableInputStream.h"
 
 namespace facebook::nimble::index::test {
+
+namespace {
+
+velox::BufferPtr toBufferPtr(
+    std::string_view data,
+    velox::memory::MemoryPool* pool) {
+  auto buffer = velox::AlignedBuffer::allocate<char>(data.size(), pool);
+  std::memcpy(buffer->asMutable<char>(), data.data(), data.size());
+  return buffer;
+}
+
+} // namespace
 
 void ClusterIndexTestBase::SetUpTestCase() {
   velox::memory::MemoryManager::initialize({});
@@ -338,7 +351,10 @@ std::unique_ptr<ClusterIndex> ClusterIndexTestBase::createClusterIndex(
     LoadDataFn loadData,
     velox::memory::MemoryPool* pool) {
   Section indexSection{MetadataBuffer(
-      *pool_, indexBuffers.rootIndex, CompressionType::Uncompressed)};
+      MetadataBuffer::decompress(
+          toBufferPtr(indexBuffers.rootIndex, pool_.get()),
+          CompressionType::Uncompressed,
+          pool_.get()))};
 
   // Capture indexPartitions data and pool for the metadata loader callback.
   auto indexPartitionsData =
@@ -348,11 +364,14 @@ std::unique_ptr<ClusterIndex> ClusterIndexTestBase::createClusterIndex(
   return ClusterIndex::create(
       std::move(indexSection),
       [indexPartitionsData, metadataPool](const MetadataSection& section) {
-        return std::make_unique<MetadataBuffer>(
-            *metadataPool,
-            std::string_view(
-                indexPartitionsData->data() + section.offset(), section.size()),
-            section.compressionType());
+        return std::make_unique<MetadataBuffer>(MetadataBuffer::decompress(
+            toBufferPtr(
+                std::string_view(
+                    indexPartitionsData->data() + section.offset(),
+                    section.size()),
+                metadataPool),
+            section.compressionType(),
+            metadataPool));
       },
       std::move(loadData),
       pool);
@@ -380,12 +399,15 @@ std::shared_ptr<ChunkIndexGroup> ClusterIndexTestBase::createChunkIndex(
     offset += indexBuffers.chunkIndexGroupSizes[g];
   }
 
-  auto chunkIndexBuffer = std::make_unique<MetadataBuffer>(
-      *pool_,
-      std::string_view(
-          indexBuffers.chunkIndexGroups.data() + offset,
-          indexBuffers.chunkIndexGroupSizes[stripeGroupIndex]),
-      CompressionType::Uncompressed);
+  auto chunkIndexBuffer =
+      std::make_unique<MetadataBuffer>(MetadataBuffer::decompress(
+          toBufferPtr(
+              std::string_view(
+                  indexBuffers.chunkIndexGroups.data() + offset,
+                  indexBuffers.chunkIndexGroupSizes[stripeGroupIndex]),
+              pool_.get()),
+          CompressionType::Uncompressed,
+          pool_.get()));
 
   return ChunkIndexGroup::create(
       firstStripe, stripeCount, std::move(chunkIndexBuffer));

--- a/dwio/nimble/index/tests/ClusterIndexWriterTest.cpp
+++ b/dwio/nimble/index/tests/ClusterIndexWriterTest.cpp
@@ -23,6 +23,7 @@
 #include "dwio/nimble/index/ClusterIndexWriter.h"
 #include "dwio/nimble/index/IndexConfig.h"
 #include "dwio/nimble/index/SortOrder.h"
+#include "velox/buffer/Buffer.h"
 #include "velox/common/base/tests/GTestUtils.h"
 #include "velox/common/memory/Memory.h"
 #include "velox/dwio/common/SeekableInputStream.h"
@@ -32,6 +33,14 @@
 
 namespace facebook::nimble::index::test {
 namespace {
+
+velox::BufferPtr toBufferPtr(
+    std::string_view data,
+    velox::memory::MemoryPool* pool) {
+  auto buffer = velox::AlignedBuffer::allocate<char>(data.size(), pool);
+  std::memcpy(buffer->asMutable<char>(), data.data(), data.size());
+  return buffer;
+}
 
 class ClusterIndexWriterTest : public testing::Test,
                                public velox::test::VectorTestBase {
@@ -1100,19 +1109,24 @@ TEST_P(ClusterIndexWriterChunkTest, maxRowsPerKeyChunk) {
   ASSERT_EQ(partitionMetadata.size(), 1);
 
   // Load ClusterIndex from serialized data and verify layout.
-  Section rootSection{
-      MetadataBuffer(*pool_, rootIndexData, CompressionType::Uncompressed)};
+  Section rootSection{MetadataBuffer(
+      MetadataBuffer::decompress(
+          toBufferPtr(rootIndexData, pool_.get()),
+          CompressionType::Uncompressed,
+          pool_.get()))};
   auto partData = std::make_shared<std::string>(partitionMetadata[0]);
   auto streamData = std::make_shared<std::string>(keyStreamData);
 
   auto clusterIndex = ClusterIndex::create(
       std::move(rootSection),
       [partData, this](const MetadataSection& section) {
-        return std::make_unique<MetadataBuffer>(
-            *pool_,
-            std::string_view(
-                partData->data() + section.offset(), section.size()),
-            section.compressionType());
+        return std::make_unique<MetadataBuffer>(MetadataBuffer::decompress(
+            toBufferPtr(
+                std::string_view(
+                    partData->data() + section.offset(), section.size()),
+                pool_.get()),
+            section.compressionType(),
+            pool_.get()));
       },
       [streamData](const velox::common::Region& region)
           -> std::unique_ptr<velox::dwio::common::SeekableInputStream> {

--- a/dwio/nimble/tablet/Compression.cpp
+++ b/dwio/nimble/tablet/Compression.cpp
@@ -23,19 +23,25 @@
 
 namespace facebook::nimble {
 
-std::optional<Vector<char>> ZstdCompression::compress(
-    velox::memory::MemoryPool& memoryPool,
+std::optional<velox::BufferPtr> ZstdCompression::compress(
     std::string_view source,
-    int32_t level) {
-  Vector<char> buffer{&memoryPool, source.size() + sizeof(uint32_t)};
-  auto pos = buffer.data();
+    velox::memory::MemoryPool* pool,
+    int32_t compressionLevel) {
+  NIMBLE_CHECK_NOT_NULL(pool);
+  NIMBLE_CHECK_GE(
+      compressionLevel, ZSTD_minCLevel(), "Compression level below minimum");
+  NIMBLE_CHECK_LE(
+      compressionLevel, ZSTD_maxCLevel(), "Compression level above maximum");
+  const auto maxSize = source.size() + sizeof(uint32_t);
+  auto buffer = velox::AlignedBuffer::allocateExact<char>(maxSize, pool);
+  auto* pos = buffer->asMutable<char>();
   encoding::writeUint32(source.size(), pos);
   auto ret = ZSTD_compress(
       pos,
       source.size() - sizeof(uint32_t),
       source.data(),
       source.size(),
-      level);
+      compressionLevel);
   if (ZSTD_isError(ret)) {
     NIMBLE_CHECK(
         ZSTD_getErrorCode(ret) == ZSTD_ErrorCode::ZSTD_error_dstSize_tooSmall,
@@ -43,23 +49,46 @@ std::optional<Vector<char>> ZstdCompression::compress(
     return std::nullopt;
   }
 
-  buffer.resize(ret + sizeof(uint32_t));
-  return {buffer};
+  buffer->setSize(ret + sizeof(uint32_t));
+  return buffer;
 }
 
-Vector<char> ZstdCompression::uncompress(
-    velox::memory::MemoryPool& memoryPool,
-    std::string_view source) {
+velox::BufferPtr ZstdCompression::uncompress(
+    std::string_view source,
+    velox::memory::MemoryPool* pool) {
+  NIMBLE_CHECK_NOT_NULL(pool);
   auto pos = source.data();
   const uint32_t uncompressedSize = encoding::readUint32(pos);
-  Vector<char> buffer{&memoryPool, uncompressedSize};
+  auto buffer =
+      velox::AlignedBuffer::allocateExact<char>(uncompressedSize, pool);
   auto ret = ZSTD_decompress(
-      buffer.data(), buffer.size(), pos, source.size() - sizeof(uint32_t));
+      buffer->asMutable<char>(),
+      buffer->size(),
+      pos,
+      source.size() - sizeof(uint32_t));
   NIMBLE_CHECK(
       !ZSTD_isError(ret),
       "Error uncompressing data: {}",
       ZSTD_getErrorName(ret));
   return buffer;
+}
+
+void ZstdCompression::uncompress(
+    std::string_view source,
+    void* destination,
+    uint64_t destinationSize) {
+  auto pos = source.data();
+  const uint32_t uncompressedSize = encoding::readUint32(pos);
+  NIMBLE_CHECK_EQ(
+      destinationSize,
+      uncompressedSize,
+      "Destination size mismatch with uncompressed size");
+  auto ret = ZSTD_decompress(
+      destination, destinationSize, pos, source.size() - sizeof(uint32_t));
+  NIMBLE_CHECK(
+      !ZSTD_isError(ret),
+      "Error uncompressing data: {}",
+      ZSTD_getErrorName(ret));
 }
 
 } // namespace facebook::nimble

--- a/dwio/nimble/tablet/Compression.h
+++ b/dwio/nimble/tablet/Compression.h
@@ -15,20 +15,30 @@
  */
 #pragma once
 
-#include "dwio/nimble/common/Vector.h"
+#include <optional>
+#include <string_view>
+
+#include "velox/buffer/Buffer.h"
 
 namespace facebook::nimble {
 
 class ZstdCompression {
  public:
-  static std::optional<Vector<char>> compress(
-      velox::memory::MemoryPool& memoryPool,
+  static std::optional<velox::BufferPtr> compress(
       std::string_view source,
-      int32_t level = 1);
+      velox::memory::MemoryPool* pool,
+      int32_t compressionLevel = 1);
 
-  static Vector<char> uncompress(
-      velox::memory::MemoryPool& memoryPool,
-      std::string_view source);
+  static velox::BufferPtr uncompress(
+      std::string_view source,
+      velox::memory::MemoryPool* pool);
+
+  /// Decompresses into a caller-provided destination buffer.
+  /// Skips the 4-byte uncompressed size header in source.
+  static void uncompress(
+      std::string_view source,
+      void* destination,
+      uint64_t destinationSize);
 };
 
 } // namespace facebook::nimble

--- a/dwio/nimble/tablet/Footer.fbs
+++ b/dwio/nimble/tablet/Footer.fbs
@@ -38,6 +38,7 @@ table MetadataSection {
   offset:uint64;
   size:uint32;
   compression_type:CompressionType;
+  uncompressed_size:uint32;
 }
 
 table OptionalMetadataSections {
@@ -45,6 +46,7 @@ table OptionalMetadataSections {
   offsets:[uint64];
   sizes:[uint32];
   compression_types:[CompressionType];
+  uncompressed_sizes:[uint32];
 }
 
 table Footer {

--- a/dwio/nimble/tablet/MetadataBuffer.cpp
+++ b/dwio/nimble/tablet/MetadataBuffer.cpp
@@ -15,80 +15,121 @@
  */
 
 #include "dwio/nimble/tablet/MetadataBuffer.h"
+#include "dwio/nimble/common/Exceptions.h"
 #include "dwio/nimble/tablet/Compression.h"
 #include "folly/io/Cursor.h"
 
 namespace facebook::nimble {
 
-namespace {
-
-folly::IOBuf
-cloneAndCoalesce(const folly::IOBuf& src, size_t offset, size_t size) {
-  folly::io::Cursor cursor(&src);
-  NIMBLE_CHECK_GE(cursor.totalLength(), offset, "Offset out of range");
-  cursor.skip(offset);
-  NIMBLE_CHECK_GE(cursor.totalLength(), size, "Size out of range");
-  folly::IOBuf result;
-  cursor.clone(result, size);
-  result.coalesceWithHeadroomTailroom(0, 0);
-  return result;
+MetadataBuffer::MetadataBuffer(velox::BufferPtr buffer)
+    : buffer_{std::move(buffer)} {
+  NIMBLE_CHECK_NOT_NULL(buffer_);
 }
 
-std::string_view toStringView(const folly::IOBuf& buf) {
-  return {reinterpret_cast<const char*>(buf.data()), buf.length()};
+MetadataBuffer::MetadataBuffer(velox::cache::CachePin pin)
+    : pin_{std::move(pin)} {
+  NIMBLE_CHECK(!pin_.empty(), "CachePin must not be empty");
+  pin_.checkedEntry();
+}
+
+MetadataBuffer::~MetadataBuffer() = default;
+
+MetadataBuffer::MetadataBuffer(MetadataBuffer&&) noexcept = default;
+
+MetadataBuffer& MetadataBuffer::operator=(MetadataBuffer&&) noexcept = default;
+
+MetadataBuffer MetadataBuffer::clone() const {
+  if (buffer_ != nullptr) {
+    return MetadataBuffer{buffer_};
+  }
+  NIMBLE_CHECK(!pin_.empty(), "Cannot clone empty MetadataBuffer");
+  return MetadataBuffer{pin_};
+}
+
+MetadataSection::MetadataSection(
+    uint64_t offset,
+    uint32_t size,
+    CompressionType compressionType,
+    std::optional<uint32_t> uncompressedSize)
+    : offset_{offset},
+      size_{size},
+      compressionType_{compressionType},
+      uncompressedSize_{uncompressedSize} {
+  if (uncompressedSize_.has_value()) {
+    if (compressionType_ == CompressionType::Uncompressed) {
+      NIMBLE_CHECK_EQ(
+          uncompressedSize_.value(),
+          size_,
+          "Uncompressed size must equal size for uncompressed data");
+    } else {
+      NIMBLE_CHECK_GE(
+          uncompressedSize_.value(),
+          size_,
+          "Uncompressed size must be >= compressed size");
+    }
+  }
+}
+
+namespace {
+
+velox::BufferPtr
+copyToBuffer(const char* data, size_t size, velox::memory::MemoryPool* pool) {
+  auto buffer = velox::AlignedBuffer::allocateExact<char>(size, pool);
+  std::memcpy(buffer->asMutable<char>(), data, size);
+  return buffer;
+}
+
+velox::BufferPtr decompressZstd(
+    std::string_view data,
+    velox::memory::MemoryPool* pool) {
+  return ZstdCompression::uncompress(data, pool);
 }
 
 } // namespace
 
-MetadataBuffer::MetadataBuffer(
-    velox::memory::MemoryPool& pool,
-    std::string_view ref,
-    CompressionType type)
-    : buffer_{&pool} {
-  switch (type) {
-    case CompressionType::Uncompressed: {
-      buffer_.resize(ref.size());
-      std::copy(ref.cbegin(), ref.cend(), buffer_.begin());
-      break;
-    }
-    case CompressionType::Zstd: {
-      buffer_ = ZstdCompression::uncompress(pool, ref);
-      break;
-    }
-    default:
-      NIMBLE_UNREACHABLE("Unexpected stream compression type: {}", type);
+velox::BufferPtr MetadataBuffer::decompress(
+    velox::BufferPtr data,
+    CompressionType type,
+    velox::memory::MemoryPool* pool) {
+  if (type == CompressionType::Uncompressed) {
+    return data;
   }
+  NIMBLE_CHECK_EQ(
+      static_cast<int>(type),
+      static_cast<int>(CompressionType::Zstd),
+      "Unsupported metadata compression type");
+  return decompressZstd({data->as<char>(), data->size()}, pool);
 }
 
-MetadataBuffer::MetadataBuffer(
-    velox::memory::MemoryPool& pool,
+velox::BufferPtr MetadataBuffer::decompress(
     const folly::IOBuf& iobuf,
     size_t offset,
     size_t length,
-    CompressionType type)
-    : buffer_{&pool} {
-  switch (type) {
-    case CompressionType::Uncompressed: {
-      buffer_.resize(length);
-      folly::io::Cursor cursor(&iobuf);
-      cursor.skip(offset);
-      cursor.pull(buffer_.data(), length);
-      break;
-    }
-    case CompressionType::Zstd: {
-      auto compressed = cloneAndCoalesce(iobuf, offset, length);
-      buffer_ = ZstdCompression::uncompress(pool, toStringView(compressed));
-      break;
-    }
-    default:
-      NIMBLE_UNREACHABLE("Unexpected stream compression type: {}", type);
-  }
-}
+    CompressionType type,
+    velox::memory::MemoryPool* pool) {
+  folly::io::Cursor cursor(&iobuf);
+  cursor.skip(offset);
 
-MetadataBuffer::MetadataBuffer(
-    velox::memory::MemoryPool& pool,
-    const folly::IOBuf& iobuf,
-    CompressionType type)
-    : MetadataBuffer{pool, iobuf, 0, iobuf.computeChainDataLength(), type} {}
+  if (type == CompressionType::Uncompressed) {
+    auto buffer = velox::AlignedBuffer::allocateExact<char>(length, pool);
+    cursor.pull(buffer->asMutable<char>(), length);
+    return buffer;
+  }
+
+  NIMBLE_CHECK_EQ(
+      static_cast<int>(type),
+      static_cast<int>(CompressionType::Zstd),
+      "Unsupported metadata compression type");
+
+  const auto contiguous = cursor.peekBytes();
+  if (contiguous.size() >= length) {
+    return decompressZstd(
+        {reinterpret_cast<const char*>(contiguous.data()), length}, pool);
+  }
+
+  auto buffer = velox::AlignedBuffer::allocateExact<char>(length, pool);
+  cursor.pull(buffer->asMutable<char>(), length);
+  return decompressZstd({buffer->as<char>(), buffer->size()}, pool);
+}
 
 } // namespace facebook::nimble

--- a/dwio/nimble/tablet/MetadataBuffer.h
+++ b/dwio/nimble/tablet/MetadataBuffer.h
@@ -16,41 +16,73 @@
 #pragma once
 
 #include <functional>
+#include <optional>
 #include <string>
 #include <string_view>
 #include <vector>
 
 #include "dwio/nimble/common/Types.h"
-#include "dwio/nimble/common/Vector.h"
 #include "folly/io/IOBuf.h"
+#include "velox/buffer/Buffer.h"
+#include "velox/common/caching/AsyncDataCache.h"
 
 namespace facebook::nimble {
 
 class MetadataBuffer {
  public:
-  MetadataBuffer(
-      velox::memory::MemoryPool& pool,
-      std::string_view ref,
-      CompressionType type = CompressionType::Uncompressed);
+  // Creates from decompressed data in a pool-tracked buffer.
+  explicit MetadataBuffer(velox::BufferPtr buffer);
 
-  MetadataBuffer(
-      velox::memory::MemoryPool& pool,
+  // Creates from a cache pin with decompressed data.
+  explicit MetadataBuffer(velox::cache::CachePin pin);
+
+  ~MetadataBuffer();
+  MetadataBuffer(const MetadataBuffer&) = delete;
+  MetadataBuffer& operator=(const MetadataBuffer&) = delete;
+  MetadataBuffer(MetadataBuffer&&) noexcept;
+  MetadataBuffer& operator=(MetadataBuffer&&) noexcept;
+
+  /// Creates a shallow copy sharing the same underlying buffer or cache pin.
+  MetadataBuffer clone() const;
+
+  std::string_view content() const {
+    if (!pin_.empty()) {
+      return cacheContent();
+    }
+    return bufferContent();
+  }
+
+  /// Decompresses metadata from a pool-tracked buffer. Returns the buffer
+  /// directly for uncompressed data (zero copy), or decompresses for Zstd.
+  static velox::BufferPtr decompress(
+      velox::BufferPtr data,
+      CompressionType type,
+      velox::memory::MemoryPool* pool);
+
+  /// Decompresses metadata from an IOBuf slice and returns a BufferPtr.
+  static velox::BufferPtr decompress(
       const folly::IOBuf& iobuf,
       size_t offset,
       size_t length,
-      CompressionType type = CompressionType::Uncompressed);
-
-  MetadataBuffer(
-      velox::memory::MemoryPool& pool,
-      const folly::IOBuf& iobuf,
-      CompressionType type = CompressionType::Uncompressed);
-
-  std::string_view content() const {
-    return {buffer_.data(), buffer_.size()};
-  }
+      CompressionType type,
+      velox::memory::MemoryPool* pool);
 
  private:
-  Vector<char> buffer_;
+  inline std::string_view bufferContent() const {
+    return {buffer_->as<char>(), buffer_->size()};
+  }
+
+  inline std::string_view cacheContent() const {
+    auto* entry = pin_.checkedEntry();
+    return {entry->contiguousData(), static_cast<size_t>(entry->size())};
+  }
+
+  // Exactly one of buffer_ or pin_ is set.
+  // buffer_: holds decompressed data in a pool-tracked buffer (direct path).
+  // pin_: holds decompressed data in a contiguous AsyncDataCache entry
+  //   (cached path, keeps the cache entry pinned while this buffer is alive).
+  velox::BufferPtr buffer_;
+  velox::cache::CachePin pin_;
 };
 
 class Section {
@@ -75,11 +107,15 @@ class Section {
 
 class MetadataSection {
  public:
+  /// 'uncompressedSize' is nullopt for files written before the
+  /// uncompressed_size field was added to the FlatBuffers footer.
+  /// When nullopt, readers must determine the size from the compressed
+  /// data (e.g., reading the 4-byte Zstd size prefix).
   MetadataSection(
       uint64_t offset,
       uint32_t size,
-      CompressionType compressionType)
-      : offset_{offset}, size_{size}, compressionType_{compressionType} {}
+      CompressionType compressionType,
+      std::optional<uint32_t> uncompressedSize = std::nullopt);
 
   MetadataSection()
       : offset_{0}, size_{0}, compressionType_{CompressionType::Uncompressed} {}
@@ -96,10 +132,15 @@ class MetadataSection {
     return compressionType_;
   }
 
+  std::optional<uint32_t> uncompressedSize() const {
+    return uncompressedSize_;
+  }
+
  private:
   uint64_t offset_;
   uint32_t size_;
   CompressionType compressionType_;
+  std::optional<uint32_t> uncompressedSize_;
 };
 
 /// Callback type for creating metadata sections in the file.

--- a/dwio/nimble/tablet/MetadataInput.cpp
+++ b/dwio/nimble/tablet/MetadataInput.cpp
@@ -1,0 +1,582 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "dwio/nimble/tablet/MetadataInput.h"
+
+#include <algorithm>
+#include <numeric>
+
+#include "dwio/nimble/common/Exceptions.h"
+#include "dwio/nimble/tablet/Compression.h"
+#include "folly/Range.h"
+#include "folly/ScopeGuard.h"
+#include "folly/executors/QueuedImmediateExecutor.h"
+#include "velox/common/base/AsyncSource.h"
+#include "velox/common/base/CoalesceIo.h"
+#include "velox/common/testutil/TestValue.h"
+#include "velox/common/time/Timer.h"
+
+namespace facebook::nimble {
+
+namespace {
+
+inline int64_t sectionGap(
+    const MetadataSection& prev,
+    const MetadataSection& next) {
+  const int64_t gap = static_cast<int64_t>(next.offset()) -
+      static_cast<int64_t>(prev.offset() + prev.size());
+  NIMBLE_CHECK_GE(gap, 0, "Metadata sections overlap");
+  return gap;
+}
+
+} // namespace
+
+// --- MetadataHandle ---
+
+std::shared_ptr<MetadataBuffer> MetadataHandle::read() {
+  return input_->read(index_);
+}
+
+// --- MetadataInput ---
+
+MetadataInput::MetadataInput(
+    velox::ReadFile* file,
+    velox::memory::MemoryPool* pool,
+    const velox::io::ReaderOptions& options)
+    : file_{file},
+      pool_{pool},
+      maxCoalesceDistance_{options.maxCoalesceDistance()},
+      maxCoalesceBytes_{options.maxCoalesceBytes()},
+      executor_{options.ioExecutor().get()},
+      ioStats_{options.metadataIoStats()} {
+  NIMBLE_CHECK_NOT_NULL(ioStats_);
+}
+
+MetadataHandle MetadataInput::enqueue(const MetadataSection& section) {
+  NIMBLE_CHECK(!loaded_, "enqueue() not allowed after load(); call reset()");
+  const auto index = static_cast<uint32_t>(sections_.size());
+  sections_.emplace_back(section);
+  return MetadataHandle{this, index};
+}
+
+void MetadataInput::reset() {
+  sections_.clear();
+  loaded_ = false;
+}
+
+std::shared_ptr<MetadataBuffer> MetadataInput::read(uint32_t index) {
+  NIMBLE_CHECK(loaded_, "load() must be called before read()");
+  NIMBLE_CHECK_LT(index, sections_.size(), "Invalid metadata handle index");
+  NIMBLE_CHECK_NOT_NULL(
+      sections_[index].buffer,
+      "Metadata buffer already consumed or not loaded");
+  return std::move(sections_[index].buffer);
+}
+
+std::shared_ptr<MetadataBuffer> MetadataInput::decompressAndStore(
+    const MetadataSection& section,
+    velox::BufferPtr&& buffer) {
+  NIMBLE_CHECK_EQ(
+      section.size(), buffer->size(), "Buffer size mismatch with section size");
+  if (section.compressionType() == CompressionType::Uncompressed) {
+    return store(section, std::move(buffer));
+  }
+  NIMBLE_CHECK_EQ(
+      static_cast<int>(section.compressionType()),
+      static_cast<int>(CompressionType::Zstd),
+      "Unsupported metadata compression type");
+  std::string_view data{buffer->as<char>(), buffer->size()};
+  return store(section, ZstdCompression::uncompress(data, pool_));
+}
+
+std::optional<uint32_t> MetadataInput::resolveUncompressedSize(
+    const MetadataSection& section) {
+  if (section.uncompressedSize().has_value()) {
+    return section.uncompressedSize();
+  }
+  if (section.compressionType() == CompressionType::Uncompressed) {
+    return section.size();
+  }
+  return std::nullopt;
+}
+
+std::vector<MetadataInput::IoGroup> MetadataInput::computeIoGroups(
+    const std::vector<uint32_t>& sectionIndices,
+    const std::vector<folly::Range<char*>>& readRanges) {
+  std::vector<int32_t> items(sectionIndices.size());
+  std::iota(items.begin(), items.end(), 0);
+
+  int64_t coalescedBytes = 0;
+  std::vector<int32_t> groupEnds;
+
+  const auto ioStats = velox::coalesceIo<int32_t, char>(
+      items,
+      /*maxGap=*/maxCoalesceDistance_,
+      /*rangesPerIo=*/std::numeric_limits<int32_t>::max(),
+      /*offsetFunc=*/
+      [&](int32_t i) -> uint64_t {
+        return sections_[sectionIndices[i]].section.offset();
+      },
+      /*sizeFunc=*/
+      [&](int32_t i) -> int32_t {
+        return sections_[sectionIndices[i]].section.size();
+      },
+      /*numRanges=*/
+      [&](int32_t i) -> int32_t {
+        const auto size = sections_[sectionIndices[i]].section.size();
+        if (coalescedBytes + size > maxCoalesceBytes_) {
+          coalescedBytes = 0;
+          return velox::kNoCoalesce;
+        }
+        coalescedBytes += size;
+        return 1;
+      },
+      /*addRanges=*/
+      [&](const int32_t& /*i*/, std::vector<char>& ranges) {
+        // Dummy range so coalesceIo sees non-empty ranges for kNoCoalesce
+        // flush check.
+        ranges.push_back(0);
+      },
+      /*skipRange=*/
+      [&](int32_t /*gap*/, std::vector<char>& /*ranges*/) {},
+      /*ioFunc=*/
+      [&](const std::vector<int32_t>& /*items*/,
+          int32_t /*begin*/,
+          int32_t end,
+          uint64_t /*offset*/,
+          const std::vector<char>& /*ranges*/) {
+        coalescedBytes = 0;
+        groupEnds.push_back(end);
+      });
+
+  recordCoalescedIoStats(ioStats);
+  velox::common::testutil::TestValue::adjust(
+      "facebook::nimble::MetadataInput::computeIoGroups",
+      const_cast<velox::CoalesceIoStats*>(&ioStats));
+
+  std::vector<IoGroup> ioGroups;
+  int32_t groupStart = 0;
+  for (const auto groupEnd : groupEnds) {
+    IoGroup group;
+    group.offset = sections_[sectionIndices[groupStart]].section.offset();
+    auto lastEnd = group.offset;
+    for (int32_t i = groupStart; i < groupEnd; ++i) {
+      const auto& section = sections_[sectionIndices[i]].section;
+      if (section.offset() > lastEnd) {
+        const auto gap = section.offset() - lastEnd;
+        group.ranges.emplace_back(
+            nullptr, reinterpret_cast<char*>(static_cast<uint64_t>(gap)));
+      }
+      group.ranges.emplace_back(readRanges[i]);
+      lastEnd = section.offset() + section.size();
+    }
+    ioGroups.emplace_back(std::move(group));
+    groupStart = groupEnd;
+  }
+  return ioGroups;
+}
+
+void MetadataInput::executeIoGroups(std::vector<IoGroup>& ioGroups) {
+  std::vector<std::unique_ptr<velox::AsyncSource<folly::Unit>>> asyncIos;
+  asyncIos.reserve(ioGroups.size());
+  for (const auto& group : ioGroups) {
+    asyncIos.emplace_back(
+        std::make_unique<velox::AsyncSource<folly::Unit>>([this, &group]() {
+          uint64_t storageReadUs{0};
+          {
+            velox::MicrosecondTimer ioTimer(&storageReadUs);
+            file_->preadv(group.offset, group.ranges);
+          }
+          ioStats_->storageReadLatencyUs().increment(storageReadUs);
+          ioStats_->incTotalScanTimeNs(storageReadUs * 1'000);
+          return std::make_unique<folly::Unit>();
+        }));
+  }
+
+  QueryIoLatencyGuard queryIoGuard{ioStats_};
+  if (executor_ != nullptr && asyncIos.size() > 1) {
+    for (size_t i = 0; i + 1 < asyncIos.size(); ++i) {
+      executor_->add([&asyncIo = asyncIos[i]]() { asyncIo->prepare(); });
+    }
+  }
+  std::exception_ptr error;
+  for (auto& asyncIo : asyncIos) {
+    try {
+      asyncIo->move();
+    } catch (...) {
+      if (error == nullptr) {
+        error = std::current_exception();
+      }
+    }
+  }
+  if (error != nullptr) {
+    std::rethrow_exception(error);
+  }
+}
+
+void MetadataInput::loadFromFile(std::vector<uint32_t>& sectionIndices) {
+  if (sectionIndices.empty()) {
+    return;
+  }
+
+  std::sort(sectionIndices.begin(), sectionIndices.end(), [&](auto a, auto b) {
+    return sections_[a].section.offset() < sections_[b].section.offset();
+  });
+
+  prepareReadBuffers(sectionIndices);
+  SCOPE_EXIT {
+    buffers_.clear();
+    readRanges_.clear();
+  };
+  auto ioGroups = computeIoGroups(sectionIndices, readRanges_);
+  executeIoGroups(ioGroups);
+  processLoadedBuffers(sectionIndices);
+}
+
+void MetadataInput::recordCoalescedIoStats(
+    const velox::CoalesceIoStats& ioStats) {
+  ioStats_->read().increment(ioStats.payloadBytes + ioStats.extraBytes);
+  ioStats_->incRawBytesRead(ioStats.payloadBytes);
+  ioStats_->incRawOverreadBytes(ioStats.extraBytes);
+}
+
+// --- DirectMetadataInput ---
+
+DirectMetadataInput::DirectMetadataInput(
+    velox::ReadFile* file,
+    velox::memory::MemoryPool* pool,
+    const velox::io::ReaderOptions& options)
+    : MetadataInput(file, pool, options) {}
+
+void DirectMetadataInput::load() {
+  NIMBLE_CHECK(!loaded_, "load() already called; call reset() first");
+  NIMBLE_CHECK(!sections_.empty(), "No sections enqueued");
+  std::vector<uint32_t> sectionIndices(sections_.size());
+  std::iota(sectionIndices.begin(), sectionIndices.end(), 0);
+  loadFromFile(sectionIndices);
+  loaded_ = true;
+}
+
+void DirectMetadataInput::prepareReadBuffers(
+    const std::vector<uint32_t>& sectionIndices) {
+  buffers_.resize(sectionIndices.size());
+  readRanges_.resize(sectionIndices.size());
+  for (size_t i = 0; i < sectionIndices.size(); ++i) {
+    const auto size = sections_[sectionIndices[i]].section.size();
+    buffers_[i] = velox::AlignedBuffer::allocate<char>(size, pool_);
+    readRanges_[i] = {buffers_[i]->asMutable<char>(), size};
+  }
+}
+
+void DirectMetadataInput::processLoadedBuffers(
+    const std::vector<uint32_t>& sectionIndices) {
+  NIMBLE_CHECK_EQ(buffers_.size(), sectionIndices.size());
+  for (size_t i = 0; i < sectionIndices.size(); ++i) {
+    auto& loaded = sections_[sectionIndices[i]];
+    loaded.buffer = decompressAndStore(loaded.section, std::move(buffers_[i]));
+  }
+}
+
+std::shared_ptr<MetadataBuffer> DirectMetadataInput::store(
+    const MetadataSection& /*section*/,
+    velox::BufferPtr&& decompressed) {
+  return std::make_shared<MetadataBuffer>(std::move(decompressed));
+}
+
+// --- CachedMetadataInput ---
+
+CachedMetadataInput::CachedMetadataInput(
+    velox::ReadFile* file,
+    velox::StringIdLease fileId,
+    velox::cache::AsyncDataCache* cache,
+    velox::memory::MemoryPool* pool,
+    const velox::io::ReaderOptions& options)
+    : MetadataInput(file, pool, options),
+      cache_{cache},
+      fileId_{std::move(fileId)} {
+  NIMBLE_CHECK_NOT_NULL(cache_);
+}
+
+void CachedMetadataInput::reset() {
+  MetadataInput::reset();
+  cachePins_.clear();
+}
+
+velox::cache::CachePin CachedMetadataInput::acquireCachePin(
+    const velox::cache::RawFileCacheKey& key,
+    uint32_t size) {
+  for (;;) {
+    folly::SemiFuture<bool> waitFuture{false};
+    auto pin =
+        cache_->findOrCreate(key, size, /*contiguous=*/true, &waitFuture);
+    if (!pin.empty()) {
+      return pin;
+    }
+    uint64_t waitUs{0};
+    {
+      velox::MicrosecondTimer timer(&waitUs);
+      auto& exec = folly::QueuedImmediateExecutor::instance();
+      std::move(waitFuture).via(&exec).wait();
+    }
+    ioStats_->queryThreadIoLatencyUs().increment(waitUs);
+    ioStats_->cacheWaitLatencyUs().increment(waitUs);
+  }
+}
+
+std::shared_ptr<MetadataBuffer> CachedMetadataInput::tryCacheHit(
+    uint32_t expectedSize,
+    velox::cache::CachePin& pin) {
+  auto* entry = pin.checkedEntry();
+  if (!entry->isShared()) {
+    return nullptr;
+  }
+  NIMBLE_CHECK(
+      entry->hasContiguousData(), "Cached entry must have contiguous data");
+  NIMBLE_CHECK_EQ(
+      entry->size(),
+      expectedSize,
+      "Cached entry size mismatch with expected size");
+  ioStats_->ramHit().increment(entry->size());
+  return std::make_shared<MetadataBuffer>(std::move(pin));
+}
+
+std::shared_ptr<MetadataBuffer> CachedMetadataInput::promoteCachePin(
+    const MetadataSection& section,
+    velox::cache::CachePin pin,
+    velox::io::IoCounter& ioCounter) {
+  auto* entry = pin.checkedEntry();
+  NIMBLE_CHECK(entry->isExclusive(), "Expected exclusive cache pin");
+  NIMBLE_CHECK(
+      entry->hasContiguousData(), "Cache entry must have contiguous data");
+  NIMBLE_CHECK_GE(
+      entry->size(), section.size(), "Cache entry smaller than section size");
+  const auto uncompressedSize = resolveUncompressedSize(section);
+  if (uncompressedSize.has_value()) {
+    NIMBLE_CHECK_EQ(
+        entry->size(),
+        uncompressedSize.value(),
+        "Cache entry size mismatch with uncompressed size");
+  }
+  ioCounter.increment(entry->size());
+  entry->setExclusiveToShared();
+  return std::make_shared<MetadataBuffer>(std::move(pin));
+}
+
+void CachedMetadataInput::loadFromSsd(std::vector<uint32_t>& missIndices) {
+  if (missIndices.empty()) {
+    return;
+  }
+  auto* ssdCache = cache_->ssdCache();
+  if (ssdCache == nullptr) {
+    return;
+  }
+
+  struct SsdHit {
+    uint32_t sectionIndex;
+    velox::cache::SsdPin ssdPin;
+    velox::cache::CachePin cachePin;
+  };
+  std::vector<SsdHit> ssdHits;
+  std::vector<uint32_t> remainingMissIndices;
+  remainingMissIndices.reserve(missIndices.size());
+
+  auto& ssdFile = ssdCache->file(fileId_.id());
+  for (const auto index : missIndices) {
+    auto& loaded = sections_[index];
+    const velox::cache::RawFileCacheKey key{
+        fileId_.id(), loaded.section.offset()};
+
+    auto ssdPin = ssdFile.find(key);
+    if (ssdPin.empty()) {
+      remainingMissIndices.emplace_back(index);
+      continue;
+    }
+
+    const auto ssdSize = ssdPin.run().size();
+    const auto uncompressedSize = resolveUncompressedSize(loaded.section);
+    if (uncompressedSize.has_value()) {
+      NIMBLE_CHECK_EQ(
+          ssdSize,
+          uncompressedSize.value(),
+          "SSD entry size mismatch with expected uncompressed size");
+    }
+
+    // Allocate memory cache entry for loading from SSD.
+    auto pin = acquireCachePin(key, ssdSize);
+    auto buffer = tryCacheHit(ssdSize, pin);
+    if (buffer != nullptr) {
+      loaded.buffer = std::move(buffer);
+      continue;
+    }
+    ssdHits.emplace_back(SsdHit{index, std::move(ssdPin), std::move(pin)});
+  }
+
+  missIndices = std::move(remainingMissIndices);
+
+  if (ssdHits.empty()) {
+    return;
+  }
+
+  // Batch SsdFile::load() for all SSD hits.
+  std::vector<velox::cache::SsdPin> ssdPins;
+  std::vector<velox::cache::CachePin> cachePins;
+  ssdPins.reserve(ssdHits.size());
+  cachePins.reserve(ssdHits.size());
+  for (auto& hit : ssdHits) {
+    ssdPins.emplace_back(std::move(hit.ssdPin));
+    cachePins.emplace_back(std::move(hit.cachePin));
+  }
+  uint64_t ssdLoadUs{0};
+  {
+    velox::MicrosecondTimer timer(&ssdLoadUs);
+    ssdFile.load(ssdPins, cachePins);
+  }
+  ioStats_->queryThreadIoLatencyUs().increment(ssdLoadUs);
+  ioStats_->ssdCacheReadLatencyUs().increment(ssdLoadUs);
+  for (uint32_t i = 0; i < ssdHits.size(); ++i) {
+    const auto& section = sections_[ssdHits[i].sectionIndex].section;
+    sections_[ssdHits[i].sectionIndex].buffer =
+        promoteCachePin(section, std::move(cachePins[i]), ioStats_->ssdRead());
+  }
+}
+
+std::vector<uint32_t> CachedMetadataInput::loadFromCache() {
+  NIMBLE_CHECK(cachePins_.empty(), "Cache pins not cleared from previous load");
+  cachePins_.resize(sections_.size());
+  std::vector<uint32_t> missIndices;
+  missIndices.reserve(sections_.size());
+  for (uint32_t index = 0; index < sections_.size(); ++index) {
+    const auto& section = sections_[index].section;
+    const velox::cache::RawFileCacheKey key{fileId_.id(), section.offset()};
+    const auto uncompressedSize = resolveUncompressedSize(section);
+
+    if (uncompressedSize.has_value()) {
+      auto pin = acquireCachePin(key, uncompressedSize.value());
+      auto buffer = tryCacheHit(uncompressedSize.value(), pin);
+      if (buffer != nullptr) {
+        sections_[index].buffer = std::move(buffer);
+        continue;
+      }
+      cachePins_[index] = std::move(pin);
+      missIndices.push_back(index);
+    } else {
+      missIndices.push_back(index);
+    }
+  }
+  return missIndices;
+}
+
+void CachedMetadataInput::load() {
+  NIMBLE_CHECK(!loaded_, "load() already called; call reset() first");
+  NIMBLE_CHECK(!sections_.empty(), "No sections enqueued");
+
+  auto missIndices = loadFromCache();
+  loadFromSsd(missIndices);
+  loadFromFile(missIndices);
+  loaded_ = true;
+}
+
+void CachedMetadataInput::prepareReadBuffers(
+    const std::vector<uint32_t>& sectionIndices) {
+  NIMBLE_CHECK_EQ(
+      cachePins_.size(),
+      sections_.size(),
+      "Cache pins size mismatch with sections");
+
+  // For uncompressed sections with cache pins, read directly into the
+  // pin's contiguous data. For compressed sections or sections without
+  // pins, allocate a temporary buffer.
+  buffers_.resize(sectionIndices.size());
+  readRanges_.resize(sectionIndices.size());
+  for (size_t i = 0; i < sectionIndices.size(); ++i) {
+    const auto sectionIndex = sectionIndices[i];
+    const auto& section = sections_[sectionIndex].section;
+    const auto& pin = cachePins_[sectionIndex];
+    if (pin.has_value() &&
+        section.compressionType() == CompressionType::Uncompressed) {
+      NIMBLE_CHECK(
+          pin->entry()->hasContiguousData(),
+          "Cache entry must have contiguous data");
+      readRanges_[i] = {pin->entry()->contiguousData(), section.size()};
+    } else {
+      buffers_[i] = velox::AlignedBuffer::allocate<char>(section.size(), pool_);
+      readRanges_[i] = {buffers_[i]->asMutable<char>(), section.size()};
+    }
+  }
+}
+
+void CachedMetadataInput::processLoadedBuffers(
+    const std::vector<uint32_t>& sectionIndices) {
+  NIMBLE_CHECK_EQ(buffers_.size(), sectionIndices.size());
+  NIMBLE_CHECK_EQ(cachePins_.size(), sections_.size());
+  SCOPE_EXIT {
+    cachePins_.clear();
+  };
+
+  for (size_t i = 0; i < sectionIndices.size(); ++i) {
+    const auto sectionIndex = sectionIndices[i];
+    auto& loaded = sections_[sectionIndex];
+    auto& pin = cachePins_[sectionIndex];
+    if (pin.has_value()) {
+      if (loaded.section.compressionType() != CompressionType::Uncompressed) {
+        NIMBLE_CHECK_NOT_NULL(buffers_[i]);
+        NIMBLE_CHECK(
+            pin->entry()->hasContiguousData(),
+            "Cache entry must have contiguous data");
+        std::string_view compressed{
+            buffers_[i]->as<char>(), loaded.section.size()};
+        ZstdCompression::uncompress(
+            compressed, pin->entry()->contiguousData(), pin->entry()->size());
+      }
+      loaded.buffer =
+          promoteCachePin(loaded.section, std::move(*pin), ioStats_->read());
+    } else {
+      NIMBLE_CHECK(
+          !loaded.section.uncompressedSize().has_value(),
+          "Section without cache pin should not have uncompressed size set");
+      loaded.buffer =
+          decompressAndStore(loaded.section, std::move(buffers_[i]));
+    }
+  }
+}
+
+std::shared_ptr<MetadataBuffer> CachedMetadataInput::store(
+    const MetadataSection& section,
+    velox::BufferPtr&& decompressed) {
+  // NOTE: This path handles sections without pre-claimed cache pins (old files
+  // without uncompressed_size). Sections with pins are handled directly in
+  // loadFromFile. This will be deprecated once all nimble metadata sections
+  // include uncompressed size.
+  const velox::cache::RawFileCacheKey key{fileId_.id(), section.offset()};
+  auto pin = acquireCachePin(key, decompressed->size());
+  auto buffer = tryCacheHit(decompressed->size(), pin);
+  if (buffer != nullptr) {
+    return buffer;
+  }
+
+  auto* entry = pin.checkedEntry();
+  NIMBLE_CHECK(
+      entry->hasContiguousData(), "Cache entry must have contiguous data");
+  NIMBLE_CHECK_EQ(
+      entry->size(),
+      decompressed->size(),
+      "Cache entry size mismatch with decompressed size");
+  auto* destination = entry->contiguousData();
+  std::memcpy(destination, decompressed->as<char>(), decompressed->size());
+  entry->setExclusiveToShared();
+  return std::make_shared<MetadataBuffer>(std::move(pin));
+}
+
+} // namespace facebook::nimble

--- a/dwio/nimble/tablet/MetadataInput.h
+++ b/dwio/nimble/tablet/MetadataInput.h
@@ -1,0 +1,268 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <memory>
+#include <vector>
+
+#include <optional>
+#include "dwio/nimble/tablet/MetadataBuffer.h"
+#include "folly/Range.h"
+#include "velox/common/caching/AsyncDataCache.h"
+#include "velox/common/caching/SsdCache.h"
+#include "velox/common/file/File.h"
+#include "velox/common/io/Options.h"
+
+namespace facebook::nimble {
+
+namespace test {
+class MetadataInputTestHelper;
+class CachedMetadataInputTestHelper;
+} // namespace test
+
+class MetadataInput;
+
+/// Handle to an enqueued metadata section. Returned by
+/// MetadataInput::enqueue(). Call read() to get the decompressed
+/// MetadataBuffer — either from a prior coalesced load() or by
+/// triggering on-demand IO for just this section.
+class MetadataHandle {
+ public:
+  MetadataHandle(MetadataInput* input, uint32_t index)
+      : input_{input}, index_{index} {}
+
+  /// Returns the decompressed MetadataBuffer. If load() was called
+  /// on the parent MetadataInput, returns the already-loaded result.
+  /// Otherwise triggers on-demand IO for this section only.
+  std::shared_ptr<MetadataBuffer> read();
+
+ private:
+  MetadataInput* const input_;
+  const uint32_t index_;
+};
+
+/// Reads metadata sections from a Nimble file with IO coalescing.
+///
+/// Supports two-phase IO: enqueue() registers sections and returns a
+/// MetadataHandle, load() executes coalesced preadv for all enqueued
+/// sections. The handle's read() returns the decompressed MetadataBuffer.
+///
+/// IO coalescing is controlled by maxCoalesceDistance and maxCoalesceBytes
+/// from io::ReaderOptions, shared with data IO settings.
+///
+/// Two implementations:
+///   - DirectMetadataInput: IO coalescing, no caching
+///   - CachedMetadataInput: IO coalescing + AsyncDataCache for decompressed
+///     metadata with memory/SSD tier support
+///
+/// NOTE: Not thread-safe. All calls must be serialized by the caller.
+class MetadataInput {
+ public:
+  MetadataInput(
+      velox::ReadFile* file,
+      velox::memory::MemoryPool* pool,
+      const velox::io::ReaderOptions& options);
+
+  virtual ~MetadataInput() = default;
+
+  /// Enqueues a metadata section for coalesced IO. Returns a handle
+  /// to retrieve the result later via handle.read().
+  MetadataHandle enqueue(const MetadataSection& section);
+
+  /// Executes coalesced preadv for all enqueued sections, then
+  /// decompresses and stores each section via the subclass.
+  virtual void load() = 0;
+
+  /// Resets all internal state for the next round of enqueue/load/read.
+  virtual void reset();
+
+ protected:
+  struct LoadedSection {
+    explicit LoadedSection(MetadataSection _section) : section{_section} {}
+
+    MetadataSection section;
+    std::shared_ptr<MetadataBuffer> buffer;
+  };
+
+  /// Reads sections at the given indices from file with IO coalescing,
+  /// decompresses, and calls store() for each. Sorts indices in-place.
+  void loadFromFile(std::vector<uint32_t>& sectionIndices);
+
+  /// Subclass sets up per-section read buffers and ranges.
+  virtual void prepareReadBuffers(
+      const std::vector<uint32_t>& sectionIndices) = 0;
+
+  /// Subclass processes loaded buffers into MetadataBuffers.
+  virtual void processLoadedBuffers(
+      const std::vector<uint32_t>& sectionIndices) = 0;
+
+  /// Decompresses the buffer and calls store(). For uncompressed data,
+  /// passes the buffer directly (zero copy).
+  std::shared_ptr<MetadataBuffer> decompressAndStore(
+      const MetadataSection& section,
+      velox::BufferPtr&& buffer);
+
+  /// Subclass creates the MetadataBuffer from a decompressed buffer.
+  virtual std::shared_ptr<MetadataBuffer> store(
+      const MetadataSection& section,
+      velox::BufferPtr&& decompressed) = 0;
+
+  struct IoGroup {
+    uint64_t offset;
+    std::vector<folly::Range<char*>> ranges;
+  };
+
+  // Computes IO group boundaries using coalesceIo, then builds preadv
+  // ranges for each group with null-data ranges for gaps.
+  // 'readRanges' provides the writable destination for each section.
+  std::vector<IoGroup> computeIoGroups(
+      const std::vector<uint32_t>& sectionIndices,
+      const std::vector<folly::Range<char*>>& readRanges);
+
+  // Dispatches IO groups in parallel via AsyncSource when executor is
+  // available, records IO stats, and propagates the first error.
+  void executeIoGroups(std::vector<IoGroup>& ioGroups);
+
+  // Returns the uncompressed size, or nullopt if unknown (old files
+  // without uncompressed_size — will be deprecated).
+  static std::optional<uint32_t> resolveUncompressedSize(
+      const MetadataSection& section);
+
+  // Records coalesced IO stats (payload, total read, overread).
+  void recordCoalescedIoStats(const velox::CoalesceIoStats& ioStats);
+
+  // RAII guard that measures elapsed time and records it as query thread
+  // IO latency when the scope exits.
+  class QueryIoLatencyGuard {
+   public:
+    explicit QueryIoLatencyGuard(velox::io::IoStatistics* ioStats)
+        : ioStats_{ioStats}, timer_{&usecs_} {}
+
+    ~QueryIoLatencyGuard() {
+      ioStats_->queryThreadIoLatencyUs().increment(usecs_);
+    }
+
+   private:
+    velox::io::IoStatistics* const ioStats_;
+    uint64_t usecs_{0};
+    velox::MicrosecondTimer timer_;
+  };
+
+  velox::ReadFile* const file_;
+  velox::memory::MemoryPool* const pool_;
+  // Max gap in bytes between consecutive sections to merge into one IO.
+  const int32_t maxCoalesceDistance_;
+  // Max total bytes per coalesced IO batch.
+  const int64_t maxCoalesceBytes_;
+  folly::Executor* const executor_;
+  velox::io::IoStatistics* const ioStats_;
+
+  std::vector<LoadedSection> sections_;
+  bool loaded_{false};
+
+  // Per-section read state, populated by prepareReadBuffers().
+  std::vector<velox::BufferPtr> buffers_;
+  std::vector<folly::Range<char*>> readRanges_;
+
+ private:
+  virtual std::shared_ptr<MetadataBuffer> read(uint32_t index);
+
+  friend class MetadataHandle;
+  friend class test::MetadataInputTestHelper;
+};
+
+/// Direct metadata loading with IO coalescing, no caching.
+class DirectMetadataInput : public MetadataInput {
+ public:
+  DirectMetadataInput(
+      velox::ReadFile* file,
+      velox::memory::MemoryPool* pool,
+      const velox::io::ReaderOptions& options);
+
+  void load() override;
+
+ protected:
+  void prepareReadBuffers(const std::vector<uint32_t>& sectionIndices) override;
+  void processLoadedBuffers(
+      const std::vector<uint32_t>& sectionIndices) override;
+  std::shared_ptr<MetadataBuffer> store(
+      const MetadataSection& section,
+      velox::BufferPtr&& decompressed) override;
+};
+
+/// Cached metadata loading with IO coalescing and AsyncDataCache.
+/// Checks memory cache and SSD cache before file IO.
+/// Caches decompressed metadata in contiguous cache entries.
+/// Cache key is the compressed file offset.
+class CachedMetadataInput : public MetadataInput {
+ public:
+  CachedMetadataInput(
+      velox::ReadFile* file,
+      velox::StringIdLease fileId,
+      velox::cache::AsyncDataCache* cache,
+      velox::memory::MemoryPool* pool,
+      const velox::io::ReaderOptions& options);
+
+  void load() override;
+  void reset() override;
+
+ protected:
+  void prepareReadBuffers(const std::vector<uint32_t>& sectionIndices) override;
+  void processLoadedBuffers(
+      const std::vector<uint32_t>& sectionIndices) override;
+  std::shared_ptr<MetadataBuffer> store(
+      const MetadataSection& section,
+      velox::BufferPtr&& decompressed) override;
+
+ private:
+  // Checks memory cache for all sections. Returns indices of sections
+  // not found in cache. Pre-claims exclusive pins for known-size misses.
+  std::vector<uint32_t> loadFromCache();
+
+  // Checks SSD cache for memory misses, batch-loads SSD hits into
+  // memory cache. Removes loaded indices from missIndices in-place.
+  void loadFromSsd(std::vector<uint32_t>& missIndices);
+
+  // Waits for a cache pin to become available via findOrCreate.
+  // Blocks until the pin is no longer exclusively held by another thread.
+  velox::cache::CachePin acquireCachePin(
+      const velox::cache::RawFileCacheKey& key,
+      uint32_t size);
+
+  // If the pin is shared (cache hit), validates the entry, records ramHit
+  // stats, and returns the MetadataBuffer. Returns nullptr on cache miss.
+  std::shared_ptr<MetadataBuffer> tryCacheHit(
+      uint32_t expectedSize,
+      velox::cache::CachePin& pin);
+
+  // Validates an exclusive cache pin entry, promotes it to shared, and
+  // returns a MetadataBuffer. Records the given IO counter stats.
+  std::shared_ptr<MetadataBuffer> promoteCachePin(
+      const MetadataSection& section,
+      velox::cache::CachePin pin,
+      velox::io::IoCounter& ioCounter);
+
+  velox::cache::AsyncDataCache* const cache_;
+  const velox::StringIdLease fileId_;
+
+  // Pre-claimed exclusive cache pins from loadFromCache(), indexed by
+  // section index. Present for sections with known uncompressed size.
+  std::vector<std::optional<velox::cache::CachePin>> cachePins_;
+
+  friend class test::CachedMetadataInputTestHelper;
+};
+
+} // namespace facebook::nimble

--- a/dwio/nimble/tablet/TabletReader.cpp
+++ b/dwio/nimble/tablet/TabletReader.cpp
@@ -48,12 +48,12 @@ std::unique_ptr<MetadataBuffer> tryCreateMetadataBufferFromFooter(
   if (section.offset() + footerSize < fileSize) {
     return nullptr;
   }
-  return std::make_unique<MetadataBuffer>(
-      pool,
+  return std::make_unique<MetadataBuffer>(MetadataBuffer::decompress(
       footerIoBuf,
       section.offset() + footerSize - fileSize,
       section.size(),
-      section.compressionType());
+      section.compressionType(),
+      &pool));
 }
 
 } // namespace
@@ -137,11 +137,14 @@ inline void validateOptionalSections(
 // Converts a FlatBuffers section (with offset/size/compression_type fields)
 // to a MetadataSection.
 template <typename T>
-MetadataSection toMetadataSection(const T* fbSection) {
+MetadataSection toMetadataSection(const T* section) {
+  const auto uncompressedSize = section->uncompressed_size();
   return MetadataSection{
-      fbSection->offset(),
-      fbSection->size(),
-      static_cast<CompressionType>(fbSection->compression_type())};
+      section->offset(),
+      section->size(),
+      static_cast<CompressionType>(section->compression_type()),
+      uncompressedSize > 0 ? std::optional<uint32_t>(uncompressedSize)
+                           : std::nullopt};
 }
 
 size_t copyTo(const folly::IOBuf& source, void* target, size_t size) {
@@ -432,12 +435,12 @@ void TabletReader::initFooter(
     const folly::IOBuf& footerIoBuf,
     uint64_t footerIoSize) {
   NIMBLE_CHECK_NULL(footer_);
-  footer_ = std::make_unique<MetadataBuffer>(
-      *pool_,
+  footer_ = std::make_unique<MetadataBuffer>(MetadataBuffer::decompress(
       footerIoBuf,
       footerIoSize - kPostscriptSize - ps_.footerSize(),
       ps_.footerSize(),
-      ps_.footerCompressionType());
+      ps_.footerCompressionType(),
+      pool_));
 }
 
 void TabletReader::loadStripes(
@@ -479,12 +482,12 @@ void TabletReader::loadStripes(
     file_->preadv({&footerIoRegion, 1}, {&footerIoBuf, 1});
     NIMBLE_CHECK_EQ(footerIoSize, footerIoBuf.computeChainDataLength());
   }
-  stripes_ = std::make_unique<MetadataBuffer>(
-      *pool_,
+  stripes_ = std::make_unique<MetadataBuffer>(MetadataBuffer::decompress(
       footerIoBuf,
       stripesSection->offset() + footerIoSize - fileSize_,
       stripesSection->size(),
-      static_cast<CompressionType>(stripesSection->compression_type()));
+      static_cast<CompressionType>(stripesSection->compression_type()),
+      pool_));
 }
 
 void TabletReader::initStripes() {
@@ -530,6 +533,7 @@ void TabletReader::initOptionalSections() {
   validateOptionalSections(optionalSections);
 
   optionalSections_.reserve(optionalSections->names()->size());
+  const auto* uncompressedSizes = optionalSections->uncompressed_sizes();
   for (auto i = 0; i < optionalSections->names()->size(); ++i) {
     optionalSections_.insert(
         std::make_pair(
@@ -538,7 +542,10 @@ void TabletReader::initOptionalSections() {
                 optionalSections->offsets()->Get(i),
                 optionalSections->sizes()->Get(i),
                 static_cast<CompressionType>(
-                    optionalSections->compression_types()->Get(i))}));
+                    optionalSections->compression_types()->Get(i)),
+                uncompressedSizes != nullptr
+                    ? std::optional<uint32_t>(uncompressedSizes->Get(i))
+                    : std::nullopt}));
   }
 }
 
@@ -566,12 +573,12 @@ TabletReader::SectionLoader TabletReader::makeSectionLoader(
       [this, &footerIoBuf, footerIoOffset](
           const MetadataSection& section) -> std::unique_ptr<MetadataBuffer> {
         if (section.offset() >= footerIoOffset) {
-          return std::make_unique<MetadataBuffer>(
-              *pool_,
+          return std::make_unique<MetadataBuffer>(MetadataBuffer::decompress(
               footerIoBuf,
               section.offset() - footerIoOffset,
               section.size(),
-              section.compressionType());
+              section.compressionType(),
+              pool_));
         }
         return readMetadata(section, velox::dwio::common::LogType::FILE);
       };
@@ -706,12 +713,12 @@ bool TabletReader::tryLoadAndInitFooterFromCache() {
   // Build footer MetadataBuffer from an IOBuf chain wrapping the cached
   // ranges (zero-copy). MetadataBuffer copies from the IOBuf cursor
   // internally — no intermediate contiguous copy needed.
-  footer_ = std::make_unique<MetadataBuffer>(
-      *pool_,
+  footer_ = std::make_unique<MetadataBuffer>(MetadataBuffer::decompress(
       cached->toIOBuf(),
       0,
       ps_.footerSize(),
-      ps_.footerCompressionType());
+      ps_.footerCompressionType(),
+      pool_));
   return true;
 }
 
@@ -767,11 +774,11 @@ std::unique_ptr<MetadataBuffer> TabletReader::readMetadata(
   }
 
   // Direct file read path.
-  folly::IOBuf buffer;
-  velox::common::Region region{section.offset(), section.size(), "metadata"};
-  file_->preadv({&region, 1}, {&buffer, 1});
-  return std::make_unique<MetadataBuffer>(
-      *pool_, buffer, section.compressionType());
+  auto buffer =
+      velox::AlignedBuffer::allocateExact<char>(section.size(), pool_);
+  file_->pread(section.offset(), section.size(), buffer->asMutable<char>());
+  return std::make_unique<MetadataBuffer>(MetadataBuffer::decompress(
+      std::move(buffer), section.compressionType(), pool_));
 }
 
 std::unique_ptr<MetadataBuffer> TabletReader::readMetadata(
@@ -782,25 +789,25 @@ std::unique_ptr<MetadataBuffer> TabletReader::readMetadata(
   // Try zero-copy: get contiguous data from stream.
   if (stream->Next(&data, &size) &&
       static_cast<uint64_t>(size) >= section.size()) {
-    return std::make_unique<MetadataBuffer>(
-        *pool_,
-        std::string_view{static_cast<const char*>(data), section.size()},
-        section.compressionType());
+    auto buffer =
+        velox::AlignedBuffer::allocateExact<char>(section.size(), pool_);
+    std::memcpy(
+        buffer->asMutable<char>(),
+        static_cast<const char*>(data),
+        section.size());
+    return std::make_unique<MetadataBuffer>(MetadataBuffer::decompress(
+        std::move(buffer), section.compressionType(), pool_));
   }
 
-  // Data is fragmented — copy into IOBuf.
+  // Data is fragmented — copy into contiguous buffer.
   if (size > 0) {
     stream->BackUp(size);
   }
-  folly::IOBuf buffer(folly::IOBuf::CREATE, section.size());
-  stream->readFully(
-      reinterpret_cast<char*>(buffer.writableData()), section.size());
-  buffer.append(section.size());
-  return std::make_unique<MetadataBuffer>(
-      *pool_,
-      std::string_view{
-          reinterpret_cast<const char*>(buffer.data()), buffer.length()},
-      section.compressionType());
+  auto buffer =
+      velox::AlignedBuffer::allocateExact<char>(section.size(), pool_);
+  stream->readFully(buffer->asMutable<char>(), section.size());
+  return std::make_unique<MetadataBuffer>(MetadataBuffer::decompress(
+      std::move(buffer), section.compressionType(), pool_));
 }
 
 std::shared_ptr<StripeGroup> TabletReader::loadStripeGroup(
@@ -1076,7 +1083,7 @@ std::optional<Section> TabletReader::loadOptionalSection(
     auto itCache = optionalSectionsCache->find(name);
     if (itCache != optionalSectionsCache->end()) {
       if (keepCache) {
-        return Section{MetadataBuffer{*itCache->second}};
+        return Section{itCache->second->clone()};
       } else {
         auto metadata = std::move(itCache->second);
         optionalSectionsCache->erase(itCache);

--- a/dwio/nimble/tablet/TabletWriter.cpp
+++ b/dwio/nimble/tablet/TabletWriter.cpp
@@ -209,7 +209,8 @@ void TabletWriter::close() {
                                 stripes.offset(),
                                 stripes.size(),
                                 static_cast<serialization::CompressionType>(
-                                    stripes.compressionType()))
+                                    stripes.compressionType()),
+                                stripes.uncompressedSize().value())
                           : 0,
           !stripeGroups_.empty()
               ? builder.CreateVector<
@@ -221,7 +222,8 @@ void TabletWriter::close() {
                           stripeGroups_[i].offset(),
                           stripeGroups_[i].size(),
                           static_cast<serialization::CompressionType>(
-                              stripeGroups_[i].compressionType()));
+                              stripeGroups_[i].compressionType()),
+                          stripeGroups_[i].uncompressedSize().value());
                     })
               : 0,
           !optionalSections_.empty()
@@ -381,12 +383,12 @@ CompressionType TabletWriter::writeMetadata(std::string_view metadata) {
   const auto size = metadata.size();
   const bool shouldCompress = size > options_.metadataCompressionThreshold;
   CompressionType compressionType{CompressionType::Uncompressed};
-  std::optional<Vector<char>> compressed;
+  std::optional<velox::BufferPtr> compressed;
   if (shouldCompress) {
-    compressed = ZstdCompression::compress(*pool_, metadata);
+    compressed = ZstdCompression::compress(metadata, pool_);
     if (compressed.has_value()) {
       compressionType = CompressionType::Zstd;
-      metadata = {compressed->data(), compressed->size()};
+      metadata = {compressed.value()->as<char>(), compressed.value()->size()};
     }
   }
   writeWithChecksum(metadata);
@@ -394,10 +396,11 @@ CompressionType TabletWriter::writeMetadata(std::string_view metadata) {
 }
 
 MetadataSection TabletWriter::createMetadataSection(std::string_view metadata) {
+  const auto uncompressedSize = static_cast<uint32_t>(metadata.size());
   auto offset = file_->size();
   auto compressionType = writeMetadata(metadata);
   auto size = static_cast<uint32_t>(file_->size() - offset);
-  return MetadataSection{offset, size, compressionType};
+  return MetadataSection{offset, size, compressionType, uncompressedSize};
 }
 
 void TabletWriter::invokeCloseCallback() {
@@ -519,9 +522,14 @@ TabletWriter::createOptionalMetadataSection(
             return optionalSections[i].second.size();
           }),
       builder.CreateVector<uint8_t>(
-          optionalSections.size(), [&optionalSections](size_t i) {
+          optionalSections.size(),
+          [&optionalSections](size_t i) {
             return static_cast<uint8_t>(
                 optionalSections[i].second.compressionType());
+          }),
+      builder.CreateVector<uint32_t>(
+          optionalSections.size(), [&optionalSections](size_t i) {
+            return optionalSections[i].second.uncompressedSize().value();
           }));
 }
 

--- a/dwio/nimble/tablet/tests/ChunkIndexWriterTest.cpp
+++ b/dwio/nimble/tablet/tests/ChunkIndexWriterTest.cpp
@@ -69,8 +69,12 @@ class ChunkIndexWriterTest : public ::testing::Test {
       const std::string& groupData,
       uint32_t firstStripe,
       uint32_t stripeCount) {
-    auto buffer = std::make_unique<MetadataBuffer>(
-        *pool_, groupData, CompressionType::Uncompressed);
+    auto inputBuffer =
+        velox::AlignedBuffer::allocate<char>(groupData.size(), pool_.get());
+    std::memcpy(
+        inputBuffer->asMutable<char>(), groupData.data(), groupData.size());
+    auto buffer = std::make_unique<MetadataBuffer>(MetadataBuffer::decompress(
+        std::move(inputBuffer), CompressionType::Uncompressed, pool_.get()));
     return index::ChunkIndexGroup::create(
         firstStripe, stripeCount, std::move(buffer));
   }

--- a/dwio/nimble/tablet/tests/ClusterIndexWriterTest.cpp
+++ b/dwio/nimble/tablet/tests/ClusterIndexWriterTest.cpp
@@ -577,7 +577,10 @@ TEST_F(ClusterIndexWriterTest, writeAndReadWithSingleGroup) {
 
   // Read and verify root index
   Section rootIndexSection{MetadataBuffer(
-      *pool_, fileIndex.rootIndexData, CompressionType::Uncompressed)};
+      MetadataBuffer::decompress(
+          fileIndex.rootIndexData,
+          CompressionType::Uncompressed,
+          pool_.get()))};
   auto clusterIndex = index::ClusterIndex::create(std::move(rootIndexSection));
 
   // Verify basic properties
@@ -836,7 +839,10 @@ TEST_F(ClusterIndexWriterTest, writeAndReadWithMultipleGroups) {
 
   // Read and verify root index
   Section rootIndexSection{MetadataBuffer(
-      *pool_, fileIndex.rootIndexData, CompressionType::Uncompressed)};
+      MetadataBuffer::decompress(
+          fileIndex.rootIndexData,
+          CompressionType::Uncompressed,
+          pool_.get()))};
   auto clusterIndex = index::ClusterIndex::create(std::move(rootIndexSection));
 
   // Verify basic properties
@@ -1176,7 +1182,10 @@ TEST_F(ClusterIndexWriterTest, writeAndReadWithMultipleGroupsAndEmptyStream) {
 
   // Read and verify root index
   Section rootIndexSection{MetadataBuffer(
-      *pool_, fileIndex.rootIndexData, CompressionType::Uncompressed)};
+      MetadataBuffer::decompress(
+          fileIndex.rootIndexData,
+          CompressionType::Uncompressed,
+          pool_.get()))};
   auto clusterIndex = index::ClusterIndex::create(std::move(rootIndexSection));
 
   // Verify basic properties

--- a/dwio/nimble/tablet/tests/CompressionTest.cpp
+++ b/dwio/nimble/tablet/tests/CompressionTest.cpp
@@ -15,8 +15,12 @@
  */
 
 #include "dwio/nimble/tablet/Compression.h"
+
 #include <gtest/gtest.h>
-#include "dwio/nimble/tablet/MetadataBuffer.h"
+#include <zstd.h>
+
+#include "dwio/nimble/common/Exceptions.h"
+#include "dwio/nimble/common/tests/GTestUtils.h"
 #include "velox/common/memory/Memory.h"
 
 using namespace ::facebook;
@@ -53,21 +57,52 @@ const std::string kLargeDataForTest = [] {
   return data;
 }();
 
-TEST_F(CompressionTest, SimpleCompressionTest) {
-  // First compress the data
-  auto compressed =
-      nimble::ZstdCompression::compress(*pool_, kLargeDataForTest);
-  ASSERT_TRUE(compressed.has_value());
+TEST_F(CompressionTest, compressRoundTrip) {
+  struct TestParam {
+    size_t size;
+    char fillChar;
+    std::string debugString() const {
+      return fmt::format("size {}, fillChar {}", size, fillChar);
+    }
+  };
+  for (const auto& testData : std::vector<TestParam>{
+           {0, '\0'}, {100, 'A'}, {2'001, 'B'}, {100'000, 'X'}}) {
+    SCOPED_TRACE(testData.debugString());
+    const std::string data(testData.size, testData.fillChar);
+    auto compressed = nimble::ZstdCompression::compress(data, pool_.get());
+    ASSERT_TRUE(compressed.has_value());
 
-  std::string_view compressedView{compressed->data(), compressed->size()};
+    std::string_view compressedView{
+        compressed.value()->as<char>(), compressed.value()->size()};
+    auto decompressed =
+        nimble::ZstdCompression::uncompress(compressedView, pool_.get());
 
-  // Create buffer from compressed data
-  nimble::MetadataBuffer buffer(
-      *pool_, compressedView, nimble::CompressionType::Zstd);
+    std::string_view result{decompressed->as<char>(), decompressed->size()};
+    EXPECT_EQ(result, data);
+  }
+}
 
-  auto content = buffer.content();
-  EXPECT_EQ(content, kLargeDataForTest);
-  EXPECT_EQ(content.size(), kLargeDataForTest.size());
+TEST_F(CompressionTest, compressIncompressible) {
+  std::string data;
+  data.reserve(256);
+  for (int i = 0; i < 256; ++i) {
+    data.push_back(static_cast<char>(i));
+  }
+
+  auto compressed = nimble::ZstdCompression::compress(data, pool_.get());
+  EXPECT_FALSE(compressed.has_value());
+}
+
+TEST_F(CompressionTest, invalidCompressionLevel) {
+  const std::string data(1'000, 'A');
+  NIMBLE_ASSERT_THROW(
+      nimble::ZstdCompression::compress(
+          data, pool_.get(), ZSTD_maxCLevel() + 1),
+      "Compression level above maximum");
+  NIMBLE_ASSERT_THROW(
+      nimble::ZstdCompression::compress(
+          data, pool_.get(), ZSTD_minCLevel() - 1),
+      "Compression level below minimum");
 }
 
 } // namespace

--- a/dwio/nimble/tablet/tests/MetadataBufferTest.cpp
+++ b/dwio/nimble/tablet/tests/MetadataBufferTest.cpp
@@ -15,14 +15,30 @@
  */
 
 #include "dwio/nimble/tablet/MetadataBuffer.h"
+
 #include <gtest/gtest.h>
+
+#include "dwio/nimble/common/Exceptions.h"
+#include "dwio/nimble/common/tests/GTestUtils.h"
 #include "dwio/nimble/tablet/Compression.h"
 #include "folly/io/IOBuf.h"
+#include "velox/common/caching/AsyncDataCache.h"
+#include "velox/common/caching/FileIds.h"
+#include "velox/common/caching/SsdCache.h"
 #include "velox/common/memory/Memory.h"
+#include "velox/common/memory/MmapAllocator.h"
 
 using namespace ::facebook;
 
 namespace {
+
+velox::BufferPtr toBufferPtr(
+    std::string_view data,
+    velox::memory::MemoryPool* pool) {
+  auto buffer = velox::AlignedBuffer::allocate<char>(data.size(), pool);
+  std::memcpy(buffer->asMutable<char>(), data.data(), data.size());
+  return buffer;
+}
 
 class MetadataBufferTest : public ::testing::Test {
  protected:
@@ -38,140 +54,152 @@ class MetadataBufferTest : public ::testing::Test {
       rootPool_->addLeafChild("MetadataBufferTest")};
 };
 
-// Test data for various test cases
 const std::string kTestData = "Hello, MetadataBuffer!";
-const std::string kLargeTestData = std::string(1000, 'A');
+const std::string kLargeTestData = std::string(1'000, 'A');
 
-TEST_F(MetadataBufferTest, uncompressedStringView) {
-  nimble::MetadataBuffer buffer(
-      *pool_, kTestData, nimble::CompressionType::Uncompressed);
+TEST_F(MetadataBufferTest, decompressBufferPtr) {
+  struct TestParam {
+    std::string inputData;
+    nimble::CompressionType compressionType;
+    std::string debugString() const {
+      return fmt::format(
+          "size {}, compressionType {}",
+          inputData.size(),
+          static_cast<int>(compressionType));
+    }
+  };
+  for (const auto& testData : std::vector<TestParam>{
+           {"", nimble::CompressionType::Uncompressed},
+           {"", nimble::CompressionType::Zstd},
+           {kTestData, nimble::CompressionType::Uncompressed},
+           {kLargeTestData, nimble::CompressionType::Uncompressed},
+           {kLargeTestData, nimble::CompressionType::Zstd}}) {
+    SCOPED_TRACE(testData.debugString());
 
-  auto content = buffer.content();
-  EXPECT_EQ(content, kTestData);
-  EXPECT_EQ(content.size(), kTestData.size());
+    velox::BufferPtr inputBuffer;
+    if (testData.compressionType == nimble::CompressionType::Uncompressed) {
+      inputBuffer = toBufferPtr(testData.inputData, pool_.get());
+    } else {
+      auto compressed =
+          nimble::ZstdCompression::compress(testData.inputData, pool_.get());
+      ASSERT_TRUE(compressed.has_value());
+      inputBuffer = std::move(compressed.value());
+    }
+
+    nimble::MetadataBuffer buffer(
+        nimble::MetadataBuffer::decompress(
+            std::move(inputBuffer), testData.compressionType, pool_.get()));
+
+    auto content = buffer.content();
+    EXPECT_EQ(content, testData.inputData);
+    EXPECT_EQ(content.size(), testData.inputData.size());
+  }
 }
 
-TEST_F(MetadataBufferTest, uncompressedEmptyStringView) {
-  nimble::MetadataBuffer buffer(
-      *pool_, "", nimble::CompressionType::Uncompressed);
+TEST_F(MetadataBufferTest, decompressIOBuf) {
+  struct TestParam {
+    std::string inputData;
+    nimble::CompressionType compressionType;
+    bool compressible;
+    std::string prefix;
+    std::string suffix;
+    bool chained;
+    std::string debugString() const {
+      return fmt::format(
+          "size {}, compressionType {}, compressible {}, prefix '{}', suffix '{}', chained {}",
+          inputData.size(),
+          static_cast<int>(compressionType),
+          compressible,
+          prefix,
+          suffix,
+          chained);
+    }
+  };
+  std::vector<TestParam> testSettings;
+  for (const auto& inputData : {std::string(""), kTestData, kLargeTestData}) {
+    for (const auto compressionType :
+         {nimble::CompressionType::Uncompressed,
+          nimble::CompressionType::Zstd}) {
+      const bool compressible =
+          compressionType == nimble::CompressionType::Uncompressed ||
+          nimble::ZstdCompression::compress(inputData, pool_.get()).has_value();
+      for (bool withOffset : {false, true}) {
+        for (bool chained : {false, true}) {
+          testSettings.push_back(
+              {inputData,
+               compressionType,
+               compressible,
+               withOffset ? "PREFIX" : "",
+               withOffset ? "SUFFIX" : "",
+               chained});
+        }
+      }
+    }
+  }
+  for (const auto& testData : testSettings) {
+    SCOPED_TRACE(testData.debugString());
 
-  auto content = buffer.content();
-  EXPECT_TRUE(content.empty());
-  EXPECT_EQ(content.size(), 0);
-}
+    if (!testData.compressible) {
+      auto compressed =
+          nimble::ZstdCompression::compress(testData.inputData, pool_.get());
+      EXPECT_FALSE(compressed.has_value());
+      continue;
+    }
 
-TEST_F(MetadataBufferTest, zstdCompressedStringView) {
-  // First compress the data
-  auto compressed = nimble::ZstdCompression::compress(*pool_, kLargeTestData);
-  ASSERT_TRUE(compressed.has_value());
+    std::string rawData;
+    if (testData.compressionType == nimble::CompressionType::Zstd) {
+      auto compressed =
+          nimble::ZstdCompression::compress(testData.inputData, pool_.get());
+      ASSERT_TRUE(compressed.has_value());
+      rawData = std::string(
+          compressed.value()->as<char>(), compressed.value()->size());
+    } else {
+      rawData = testData.inputData;
+    }
 
-  std::string_view compressedView{compressed->data(), compressed->size()};
+    const auto offset = testData.prefix.size();
+    const auto length = rawData.size();
+    const std::string fullData = testData.prefix + rawData + testData.suffix;
 
-  // Create buffer from compressed data
-  nimble::MetadataBuffer buffer(
-      *pool_, compressedView, nimble::CompressionType::Zstd);
+    std::unique_ptr<folly::IOBuf> iobuf;
+    if (testData.chained && fullData.size() >= 2) {
+      const auto mid = fullData.size() / 2;
+      iobuf = folly::IOBuf::copyBuffer(fullData.data(), mid);
+      iobuf->appendToChain(
+          folly::IOBuf::copyBuffer(
+              fullData.data() + mid, fullData.size() - mid));
+    } else {
+      iobuf = folly::IOBuf::copyBuffer(fullData);
+    }
 
-  auto content = buffer.content();
-  EXPECT_EQ(content, kLargeTestData);
-  EXPECT_EQ(content.size(), kLargeTestData.size());
-}
+    nimble::MetadataBuffer buffer(
+        nimble::MetadataBuffer::decompress(
+            *iobuf, offset, length, testData.compressionType, pool_.get()));
 
-TEST_F(MetadataBufferTest, uncompressedIOBufFullRange) {
-  folly::IOBuf iobuf{folly::IOBuf::COPY_BUFFER, kTestData};
-
-  nimble::MetadataBuffer buffer(
-      *pool_, iobuf, nimble::CompressionType::Uncompressed);
-
-  auto content = buffer.content();
-  EXPECT_EQ(content, kTestData);
-  EXPECT_EQ(content.size(), kTestData.size());
-}
-
-TEST_F(MetadataBufferTest, uncompressedIOBufWithOffsetAndLength) {
-  std::string data = "PrefixHello, MetadataBuffer!Suffix";
-  folly::IOBuf iobuf{folly::IOBuf::COPY_BUFFER, data};
-
-  size_t offset = 6; // Skip "Prefix"
-  size_t length = kTestData.size();
-
-  nimble::MetadataBuffer buffer(
-      *pool_, iobuf, offset, length, nimble::CompressionType::Uncompressed);
-
-  auto content = buffer.content();
-  EXPECT_EQ(content, kTestData);
-  EXPECT_EQ(content.size(), kTestData.size());
-}
-
-TEST_F(MetadataBufferTest, zstdCompressedIOBuf) {
-  // First compress the data
-  auto compressed = nimble::ZstdCompression::compress(*pool_, kLargeTestData);
-  ASSERT_TRUE(compressed.has_value());
-
-  folly::IOBuf iobuf{
-      folly::IOBuf::COPY_BUFFER, compressed->data(), compressed->size()};
-
-  nimble::MetadataBuffer buffer(*pool_, iobuf, nimble::CompressionType::Zstd);
-
-  auto content = buffer.content();
-  EXPECT_EQ(content, kLargeTestData);
-}
-
-TEST_F(MetadataBufferTest, zstdCompressedIOBufWithOffsetAndLength) {
-  // First compress the data
-  auto compressed = nimble::ZstdCompression::compress(*pool_, kLargeTestData);
-  ASSERT_TRUE(compressed.has_value());
-
-  // Add prefix and suffix
-  std::string prefix = "PREFIX";
-  std::string suffix = "SUFFIX";
-  std::string fullData =
-      prefix + std::string(compressed->data(), compressed->size()) + suffix;
-
-  folly::IOBuf iobuf{folly::IOBuf::COPY_BUFFER, fullData};
-
-  nimble::MetadataBuffer buffer(
-      *pool_,
-      iobuf,
-      prefix.size(),
-      compressed->size(),
-      nimble::CompressionType::Zstd);
-
-  auto content = buffer.content();
-  EXPECT_EQ(content, kLargeTestData);
-}
-
-TEST_F(MetadataBufferTest, chainedIOBuf) {
-  // Create a chained IOBuf
-  auto iobuf = folly::IOBuf::create(10);
-  iobuf->append(5);
-  std::memcpy(iobuf->writableData(), "Hello", 5);
-
-  auto next = folly::IOBuf::create(10);
-  next->append(7);
-  std::memcpy(next->writableData(), ", World", 7);
-
-  iobuf->appendToChain(std::move(next));
-
-  nimble::MetadataBuffer buffer(
-      *pool_, *iobuf, nimble::CompressionType::Uncompressed);
-
-  auto content = buffer.content();
-  EXPECT_EQ(content, "Hello, World");
+    auto content = buffer.content();
+    EXPECT_EQ(content, testData.inputData);
+  }
 }
 
 TEST_F(MetadataBufferTest, sectionConstruction) {
   nimble::MetadataBuffer buffer(
-      *pool_, kTestData, nimble::CompressionType::Uncompressed);
+      nimble::MetadataBuffer::decompress(
+          toBufferPtr(kTestData, pool_.get()),
+          nimble::CompressionType::Uncompressed,
+          pool_.get()));
 
   nimble::Section section{std::move(buffer)};
 
-  auto content = section.content();
+  const auto content = section.content();
   EXPECT_EQ(content, kTestData);
 }
 
 TEST_F(MetadataBufferTest, sectionStringViewConversion) {
   nimble::MetadataBuffer buffer(
-      *pool_, kTestData, nimble::CompressionType::Uncompressed);
+      nimble::MetadataBuffer::decompress(
+          toBufferPtr(kTestData, pool_.get()),
+          nimble::CompressionType::Uncompressed,
+          pool_.get()));
 
   nimble::Section section{std::move(buffer)};
 
@@ -181,7 +209,10 @@ TEST_F(MetadataBufferTest, sectionStringViewConversion) {
 
 TEST_F(MetadataBufferTest, sectionBuffer) {
   nimble::MetadataBuffer buffer(
-      *pool_, kTestData, nimble::CompressionType::Uncompressed);
+      nimble::MetadataBuffer::decompress(
+          toBufferPtr(kTestData, pool_.get()),
+          nimble::CompressionType::Uncompressed,
+          pool_.get()));
 
   nimble::Section section{std::move(buffer)};
 
@@ -190,63 +221,214 @@ TEST_F(MetadataBufferTest, sectionBuffer) {
   EXPECT_EQ(bufferRef.content(), section.content());
 }
 
-TEST_F(MetadataBufferTest, metadataSectionConstructor) {
-  uint64_t offset = 100;
-  uint32_t size = 200;
-  nimble::CompressionType type = nimble::CompressionType::Zstd;
+TEST_F(MetadataBufferTest, metadataSection) {
+  {
+    nimble::MetadataSection section{100, 200, nimble::CompressionType::Zstd};
+    EXPECT_EQ(section.offset(), 100);
+    EXPECT_EQ(section.size(), 200);
+    EXPECT_EQ(section.compressionType(), nimble::CompressionType::Zstd);
+    EXPECT_FALSE(section.uncompressedSize().has_value());
+  }
 
-  nimble::MetadataSection section{offset, size, type};
-
-  EXPECT_EQ(section.offset(), offset);
-  EXPECT_EQ(section.size(), size);
-  EXPECT_EQ(section.compressionType(), type);
+  {
+    nimble::MetadataSection section;
+    EXPECT_EQ(section.offset(), 0);
+    EXPECT_EQ(section.size(), 0);
+    EXPECT_EQ(section.compressionType(), nimble::CompressionType::Uncompressed);
+    EXPECT_FALSE(section.uncompressedSize().has_value());
+  }
 }
 
-TEST_F(MetadataBufferTest, metadataSectionDefaultConstructor) {
-  nimble::MetadataSection section;
+TEST_F(MetadataBufferTest, metadataSectionUncompressedSize) {
+  struct TestParam {
+    uint32_t size;
+    nimble::CompressionType compressionType;
+    std::optional<uint32_t> uncompressedSize;
+    std::string debugString() const {
+      return fmt::format(
+          "size {}, compressionType {}, uncompressedSize {}",
+          size,
+          static_cast<int>(compressionType),
+          uncompressedSize.has_value()
+              ? std::to_string(uncompressedSize.value())
+              : std::string("nullopt"));
+    }
+  };
+  for (const auto& testData : std::vector<TestParam>{
+           {50, nimble::CompressionType::Zstd, 200},
+           {50, nimble::CompressionType::Zstd, std::nullopt},
+           {100, nimble::CompressionType::Uncompressed, 100},
+           {100, nimble::CompressionType::Uncompressed, std::nullopt}}) {
+    SCOPED_TRACE(testData.debugString());
+    nimble::MetadataSection section{
+        0, testData.size, testData.compressionType, testData.uncompressedSize};
 
-  EXPECT_EQ(section.offset(), 0);
-  EXPECT_EQ(section.size(), 0);
-  EXPECT_EQ(section.compressionType(), nimble::CompressionType::Uncompressed);
+    EXPECT_EQ(section.size(), testData.size);
+    EXPECT_EQ(section.compressionType(), testData.compressionType);
+    EXPECT_EQ(section.uncompressedSize(), testData.uncompressedSize);
+  }
 }
 
-TEST_F(MetadataBufferTest, metadataSectionAccessors) {
-  uint64_t offset = 12345;
-  uint32_t size = 67890;
-  nimble::CompressionType type = nimble::CompressionType::Zstd;
+TEST_F(MetadataBufferTest, metadataBufferMove) {
+  // Move construction.
+  {
+    nimble::MetadataBuffer buffer(
+        nimble::MetadataBuffer::decompress(
+            toBufferPtr(kTestData, pool_.get()),
+            nimble::CompressionType::Uncompressed,
+            pool_.get()));
 
-  nimble::MetadataSection section{offset, size, type};
+    nimble::MetadataBuffer moved{std::move(buffer)};
+    EXPECT_EQ(moved.content(), kTestData);
+  }
 
-  EXPECT_EQ(section.offset(), offset);
-  EXPECT_EQ(section.size(), size);
-  EXPECT_EQ(section.compressionType(), type);
+  // Move assignment.
+  {
+    nimble::MetadataBuffer buffer(
+        nimble::MetadataBuffer::decompress(
+            toBufferPtr(kTestData, pool_.get()),
+            nimble::CompressionType::Uncompressed,
+            pool_.get()));
+
+    nimble::MetadataBuffer other(
+        nimble::MetadataBuffer::decompress(
+            toBufferPtr("other", pool_.get()),
+            nimble::CompressionType::Uncompressed,
+            pool_.get()));
+
+    other = std::move(buffer);
+    EXPECT_EQ(other.content(), kTestData);
+  }
 }
 
-TEST_F(MetadataBufferTest, largeDataUncompressed) {
-  std::string largeData(10000, 'X');
-
-  nimble::MetadataBuffer buffer(
-      *pool_, largeData, nimble::CompressionType::Uncompressed);
-
-  auto content = buffer.content();
-  EXPECT_EQ(content.size(), largeData.size());
-  EXPECT_EQ(content, largeData);
+TEST_F(MetadataBufferTest, metadataSectionErrors) {
+  NIMBLE_ASSERT_THROW(
+      nimble::MetadataSection(
+          0, 100, nimble::CompressionType::Uncompressed, 200),
+      "Uncompressed size must equal size for uncompressed data");
+  NIMBLE_ASSERT_THROW(
+      nimble::MetadataSection(0, 100, nimble::CompressionType::Zstd, 50),
+      "Uncompressed size must be >= compressed size");
 }
 
-TEST_F(MetadataBufferTest, largeDataCompressed) {
-  std::string largeData(10000, 'Y');
+class MetadataBufferCacheTest : public ::testing::Test {
+ protected:
+  static constexpr uint64_t kCacheSize = 64 << 20;
 
-  // Compress the data
-  auto compressed = nimble::ZstdCompression::compress(*pool_, largeData);
-  ASSERT_TRUE(compressed.has_value());
+  void SetUp() override {
+    velox::memory::MemoryManager::Options options;
+    options.useMmapAllocator = true;
+    options.allocatorCapacity = kCacheSize;
+    options.arbitratorCapacity = kCacheSize;
+    options.trackDefaultUsage = true;
+    manager_ = std::make_unique<velox::memory::MemoryManager>(options);
+    allocator_ =
+        static_cast<velox::memory::MmapAllocator*>(manager_->allocator());
+    cache_ = velox::cache::AsyncDataCache::create(allocator_);
+    fileId_ = std::make_unique<velox::StringIdLease>(
+        velox::fileIds(), "MetadataBufferCacheTest");
+  }
 
-  std::string_view compressedView{compressed->data(), compressed->size()};
+  void TearDown() override {
+    fileId_.reset();
+    if (cache_ != nullptr) {
+      cache_->shutdown();
+    }
+    cache_.reset();
+    manager_.reset();
+  }
 
-  // Create buffer from compressed data
-  nimble::MetadataBuffer buffer(
-      *pool_, compressedView, nimble::CompressionType::Zstd);
+  velox::cache::CachePin makePin(uint64_t cacheOffset, std::string_view data) {
+    velox::cache::RawFileCacheKey cacheKey{fileId_->id(), cacheOffset};
+    auto pin = cache_->findOrCreate(cacheKey, data.size());
+    EXPECT_FALSE(pin.empty());
+    EXPECT_TRUE(pin.entry()->isExclusive());
+    auto ranges = pin.entry()->dataRanges(data.size());
+    size_t offset = 0;
+    for (auto& range : ranges) {
+      const auto copySize = std::min(range.size(), data.size() - offset);
+      std::memcpy(range.data(), data.data() + offset, copySize);
+      offset += copySize;
+    }
+    pin.entry()->setExclusiveToShared();
+    return pin;
+  }
 
-  auto content = buffer.content();
-  EXPECT_EQ(content, largeData);
+  std::unique_ptr<velox::memory::MemoryManager> manager_;
+  velox::memory::MmapAllocator* allocator_{nullptr};
+  std::shared_ptr<velox::cache::AsyncDataCache> cache_;
+  std::unique_ptr<velox::StringIdLease> fileId_;
+};
+
+TEST_F(MetadataBufferCacheTest, cachePinData) {
+  for (const auto& data : {std::string("tiny"), std::string(1'000, 'X')}) {
+    SCOPED_TRACE(fmt::format("size {}", data.size()));
+
+    {
+      auto pin = makePin(0, data);
+      EXPECT_FALSE(pin.empty());
+      nimble::MetadataBuffer pinBuffer{std::move(pin)};
+      EXPECT_EQ(pinBuffer.content(), data);
+    }
+
+    {
+      auto pool = manager_->addLeafPool("bufferTest");
+      auto buffer = toBufferPtr(data, pool.get());
+      nimble::MetadataBuffer bufferObj{std::move(buffer)};
+      EXPECT_EQ(bufferObj.content(), data);
+    }
+  }
 }
+
+TEST_F(MetadataBufferCacheTest, metadataBufferMoveWithPin) {
+  {
+    const std::string data = "move-test";
+    auto pin = makePin(100, data);
+    nimble::MetadataBuffer buffer{std::move(pin)};
+    nimble::MetadataBuffer moved{std::move(buffer)};
+    EXPECT_EQ(moved.content(), data);
+  }
+
+  {
+    const std::string data1 = "first";
+    const std::string data2 = "second";
+    auto pin1 = makePin(200, data1);
+    auto pin2 = makePin(300, data2);
+    nimble::MetadataBuffer buffer1{std::move(pin1)};
+    nimble::MetadataBuffer buffer2{std::move(pin2)};
+    buffer2 = std::move(buffer1);
+    EXPECT_EQ(buffer2.content(), data1);
+  }
+}
+
+TEST_F(MetadataBufferCacheTest, cachePinSection) {
+  const std::string data = "section-cache-test";
+  auto pin = makePin(400, data);
+
+  nimble::Section section{nimble::MetadataBuffer{std::move(pin)}};
+  EXPECT_EQ(section.content(), data);
+}
+
+TEST_F(MetadataBufferTest, cloneBufferPtr) {
+  auto buffer = toBufferPtr(kTestData, pool_.get());
+  nimble::MetadataBuffer original{std::move(buffer)};
+  EXPECT_EQ(original.content(), kTestData);
+
+  auto cloned = original.clone();
+  EXPECT_EQ(cloned.content(), kTestData);
+  EXPECT_EQ(original.content(), cloned.content());
+  EXPECT_EQ(original.content().data(), cloned.content().data());
+}
+
+TEST_F(MetadataBufferCacheTest, cloneCachePin) {
+  const std::string data = "clone-pin-test";
+  auto pin = makePin(500, data);
+  nimble::MetadataBuffer original{std::move(pin)};
+  EXPECT_EQ(original.content(), data);
+
+  auto cloned = original.clone();
+  EXPECT_EQ(cloned.content(), data);
+  EXPECT_EQ(original.content(), cloned.content());
+}
+
 } // namespace

--- a/dwio/nimble/tablet/tests/MetadataInputTest.cpp
+++ b/dwio/nimble/tablet/tests/MetadataInputTest.cpp
@@ -1,0 +1,1371 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "dwio/nimble/tablet/MetadataInput.h"
+
+#include <gtest/gtest.h>
+
+#include "dwio/nimble/common/Exceptions.h"
+#include "dwio/nimble/common/tests/GTestUtils.h"
+#include "dwio/nimble/common/tests/TestUtils.h"
+#include "dwio/nimble/tablet/Compression.h"
+#include "velox/common/base/CoalesceIo.h"
+#include "velox/common/base/tests/GTestUtils.h"
+#include "velox/common/caching/AsyncDataCache.h"
+#include "velox/common/caching/FileIds.h"
+#include "velox/common/caching/SsdCache.h"
+#include "velox/common/caching/SsdFile.h"
+#include "velox/common/file/File.h"
+#include "velox/common/file/FileSystems.h"
+#include "velox/common/io/IoStatistics.h"
+#include "velox/common/io/Options.h"
+#include "velox/common/memory/Memory.h"
+#include "velox/common/memory/MmapAllocator.h"
+#include "velox/common/testutil/TempDirectoryPath.h"
+#include "velox/common/testutil/TestValue.h"
+
+#include "folly/executors/IOThreadPoolExecutor.h"
+
+using namespace facebook;
+
+namespace facebook::nimble::test {
+
+class MetadataInputTestHelper {
+ public:
+  explicit MetadataInputTestHelper(nimble::MetadataInput* input)
+      : input_{input} {}
+
+  bool testingLoaded() const {
+    return input_->loaded_;
+  }
+
+  uint32_t testingSectionCount() const {
+    return input_->sections_.size();
+  }
+
+  const nimble::MetadataSection& testingSection(uint32_t index) const {
+    return input_->sections_[index].section;
+  }
+
+  bool testingHasBuffer(uint32_t index) const {
+    return input_->sections_[index].buffer != nullptr;
+  }
+
+ private:
+  nimble::MetadataInput* const input_;
+};
+
+class CachedMetadataInputTestHelper : public MetadataInputTestHelper {
+ public:
+  explicit CachedMetadataInputTestHelper(nimble::CachedMetadataInput* input)
+      : MetadataInputTestHelper(input), input_{input} {}
+
+  uint32_t testingCachePinCount() const {
+    return input_->cachePins_.size();
+  }
+
+  bool testingHasCachePin(uint32_t index) const {
+    return index < input_->cachePins_.size() &&
+        input_->cachePins_[index].has_value();
+  }
+
+ private:
+  nimble::CachedMetadataInput* const input_;
+};
+
+} // namespace facebook::nimble::test
+
+namespace {
+
+// Builds a flat file buffer containing sections at specified offsets.
+// Each section's data is written at its offset in the file. Gaps are
+// filled with 0xCC bytes so we can detect over-reads.
+std::string buildFileContent(
+    const std::vector<nimble::MetadataSection>& sections,
+    const std::vector<std::string>& sectionData) {
+  EXPECT_EQ(sections.size(), sectionData.size());
+  uint64_t fileSize = 0;
+  for (size_t i = 0; i < sections.size(); ++i) {
+    fileSize = std::max(fileSize, sections[i].offset() + sectionData[i].size());
+  }
+  std::string fileContent(fileSize, '\xCC');
+  for (size_t i = 0; i < sections.size(); ++i) {
+    std::memcpy(
+        fileContent.data() + sections[i].offset(),
+        sectionData[i].data(),
+        sectionData[i].size());
+  }
+  return fileContent;
+}
+
+class MetadataInputTestBase : public ::testing::Test {
+ protected:
+  velox::io::ReaderOptions makeReaderOptions(
+      int32_t maxCoalesceDistance = 1 << 20,
+      int64_t maxCoalesceBytes = 128 << 20) {
+    velox::io::ReaderOptions options(
+        pool_.get(), &dataIoStats_, &metadataIoStats_);
+    options.setMaxCoalesceDistance(maxCoalesceDistance);
+    options.setMaxCoalesceBytes(maxCoalesceBytes);
+    return options;
+  }
+
+  std::shared_ptr<velox::memory::MemoryPool> rootPool_;
+  std::shared_ptr<velox::memory::MemoryPool> pool_;
+  velox::io::IoStatistics dataIoStats_;
+  velox::io::IoStatistics metadataIoStats_;
+};
+
+struct SectionSpec {
+  std::string data;
+  nimble::CompressionType compressionType;
+  bool hasUncompressedSize{true};
+};
+
+struct EnqueueLoadReadTestParam {
+  std::vector<SectionSpec> specs;
+  std::string debugString() const {
+    return fmt::format(
+        "{} sections, [{}]",
+        specs.size(),
+        fmt::join(
+            specs | std::views::transform([](const auto& s) {
+              return fmt::format(
+                  "comp{}:sz{}:uncomp{}",
+                  static_cast<int>(s.compressionType),
+                  s.data.size(),
+                  s.hasUncompressedSize);
+            }),
+            ", "));
+  }
+};
+
+void buildSections(
+    const std::vector<SectionSpec>& specs,
+    velox::memory::MemoryPool* pool,
+    std::vector<nimble::MetadataSection>& sections,
+    std::vector<std::string>& fileDataParts) {
+  uint64_t offset = 0;
+  for (const auto& spec : specs) {
+    std::string onDiskData;
+    const uint32_t uncompressedSize = spec.data.size();
+    if (spec.compressionType == nimble::CompressionType::Zstd) {
+      auto compressed = nimble::ZstdCompression::compress(spec.data, pool);
+      ASSERT_TRUE(compressed.has_value());
+      onDiskData = {compressed.value()->as<char>(), compressed.value()->size()};
+    } else {
+      onDiskData = spec.data;
+    }
+    sections.emplace_back(
+        offset,
+        static_cast<uint32_t>(onDiskData.size()),
+        spec.compressionType,
+        spec.hasUncompressedSize ? std::optional<uint32_t>(uncompressedSize)
+                                 : std::nullopt);
+    fileDataParts.emplace_back(std::move(onDiskData));
+    offset += fileDataParts.back().size();
+  }
+}
+
+std::vector<EnqueueLoadReadTestParam> enqueueLoadReadTestSettings() {
+  return {
+      {{{"Hello, MetadataInput!", nimble::CompressionType::Uncompressed}}},
+      {{{std::string(1'000, 'A'), nimble::CompressionType::Zstd}}},
+      // Compressed without uncompressed size (old file format).
+      {{{std::string(1'000, 'A'), nimble::CompressionType::Zstd, false}}},
+      {{{"section-zero", nimble::CompressionType::Uncompressed},
+        {"section-one", nimble::CompressionType::Uncompressed},
+        {"section-two", nimble::CompressionType::Uncompressed}}},
+      {{{std::string(1'000, 'B'), nimble::CompressionType::Zstd},
+        {std::string(2'000, 'C'), nimble::CompressionType::Zstd}}},
+      {{{"uncompressed-first", nimble::CompressionType::Uncompressed},
+        {std::string(1'000, 'D'), nimble::CompressionType::Zstd}}},
+      {{{std::string(1'000, 'E'), nimble::CompressionType::Zstd},
+        {"uncompressed-second", nimble::CompressionType::Uncompressed}}},
+      {{{"head", nimble::CompressionType::Uncompressed},
+        {std::string(1'000, 'F'), nimble::CompressionType::Zstd},
+        {"tail", nimble::CompressionType::Uncompressed}}},
+      // Mixed: with and without uncompressed size.
+      {{{"with-size", nimble::CompressionType::Uncompressed, true},
+        {std::string(1'000, 'I'), nimble::CompressionType::Zstd, false},
+        {std::string(2'000, 'J'), nimble::CompressionType::Zstd, true}}},
+      // All without uncompressed size.
+      {{{std::string(1'000, 'K'), nimble::CompressionType::Zstd, false},
+        {std::string(2'000, 'L'), nimble::CompressionType::Zstd, false}}},
+      {{{std::string(64 * 1'024, 'G'), nimble::CompressionType::Uncompressed}}},
+      {{{std::string(64 * 1'024, 'H'), nimble::CompressionType::Zstd}}},
+  };
+}
+
+class DirectMetadataInputTest : public MetadataInputTestBase {
+ protected:
+  static void SetUpTestCase() {
+    velox::memory::MemoryManager::testingSetInstance({});
+    velox::common::testutil::TestValue::enable();
+  }
+
+  void SetUp() override {
+    rootPool_ =
+        velox::memory::memoryManager()->addRootPool("DirectMetadataInputTest");
+    pool_ = rootPool_->addLeafChild("leaf");
+  }
+};
+
+TEST_F(DirectMetadataInputTest, enqueueLoadRead) {
+  for (const auto& testData : enqueueLoadReadTestSettings()) {
+    SCOPED_TRACE(testData.debugString());
+
+    std::vector<nimble::MetadataSection> sections;
+    std::vector<std::string> fileDataParts;
+    buildSections(testData.specs, pool_.get(), sections, fileDataParts);
+
+    const auto fileContent = buildFileContent(sections, fileDataParts);
+    auto readFile = std::make_shared<velox::InMemoryReadFile>(fileContent);
+
+    const auto options = makeReaderOptions();
+    nimble::DirectMetadataInput input(readFile.get(), pool_.get(), options);
+    nimble::test::MetadataInputTestHelper helper(&input);
+
+    EXPECT_FALSE(helper.testingLoaded());
+    EXPECT_EQ(helper.testingSectionCount(), 0);
+
+    std::vector<nimble::MetadataHandle> handles;
+    for (uint32_t i = 0; i < sections.size(); ++i) {
+      handles.push_back(input.enqueue(sections[i]));
+      EXPECT_EQ(helper.testingSectionCount(), i + 1);
+      EXPECT_FALSE(helper.testingHasBuffer(i));
+    }
+    EXPECT_FALSE(helper.testingLoaded());
+
+    input.load();
+    EXPECT_TRUE(helper.testingLoaded());
+    for (uint32_t i = 0; i < sections.size(); ++i) {
+      EXPECT_TRUE(helper.testingHasBuffer(i));
+    }
+
+    for (uint32_t i = 0; i < sections.size(); ++i) {
+      auto buffer = handles[i].read();
+      ASSERT_NE(buffer, nullptr);
+      EXPECT_EQ(buffer->content(), testData.specs[i].data);
+      EXPECT_FALSE(helper.testingHasBuffer(i));
+    }
+  }
+}
+
+TEST_F(DirectMetadataInputTest, reverseEnqueueOrder) {
+  const std::string data0 = "first-in-file";
+  const std::string data1 = "second-in-file";
+
+  const uint64_t offset0 = 0;
+  const uint64_t offset1 = data0.size();
+
+  nimble::MetadataSection section0{
+      offset0,
+      static_cast<uint32_t>(data0.size()),
+      nimble::CompressionType::Uncompressed,
+      static_cast<uint32_t>(data0.size())};
+  nimble::MetadataSection section1{
+      offset1,
+      static_cast<uint32_t>(data1.size()),
+      nimble::CompressionType::Uncompressed,
+      static_cast<uint32_t>(data1.size())};
+
+  const auto fileContent =
+      buildFileContent({section0, section1}, {data0, data1});
+  auto readFile = std::make_shared<velox::InMemoryReadFile>(fileContent);
+
+  const auto options = makeReaderOptions();
+  nimble::DirectMetadataInput input(readFile.get(), pool_.get(), options);
+
+  // Enqueue in reverse file order — should still work.
+  auto handle1 = input.enqueue(section1);
+  auto handle0 = input.enqueue(section0);
+  input.load();
+
+  EXPECT_EQ(handle0.read()->content(), data0);
+  EXPECT_EQ(handle1.read()->content(), data1);
+}
+
+TEST_F(DirectMetadataInputTest, stateTransitions) {
+  const std::string data = "state-test";
+  nimble::MetadataSection section{
+      0,
+      static_cast<uint32_t>(data.size()),
+      nimble::CompressionType::Uncompressed,
+      static_cast<uint32_t>(data.size())};
+  const auto fileContent = buildFileContent({section}, {data});
+  auto readFile = std::make_shared<velox::InMemoryReadFile>(fileContent);
+
+  const auto options = makeReaderOptions();
+  nimble::DirectMetadataInput input(readFile.get(), pool_.get(), options);
+  nimble::test::MetadataInputTestHelper helper(&input);
+
+  // Before enqueue.
+  EXPECT_FALSE(helper.testingLoaded());
+  EXPECT_EQ(helper.testingSectionCount(), 0);
+
+  // After enqueue.
+  auto handle = input.enqueue(section);
+  EXPECT_FALSE(helper.testingLoaded());
+  EXPECT_EQ(helper.testingSectionCount(), 1);
+  EXPECT_EQ(helper.testingSection(0).offset(), 0);
+  EXPECT_EQ(helper.testingSection(0).size(), data.size());
+  EXPECT_FALSE(helper.testingHasBuffer(0));
+
+  // After load.
+  input.load();
+  EXPECT_TRUE(helper.testingLoaded());
+  EXPECT_EQ(helper.testingSectionCount(), 1);
+  EXPECT_TRUE(helper.testingHasBuffer(0));
+
+  // After read — buffer consumed.
+  EXPECT_EQ(handle.read()->content(), data);
+  EXPECT_FALSE(helper.testingHasBuffer(0));
+
+  // After reset — back to initial state.
+  input.reset();
+  EXPECT_FALSE(helper.testingLoaded());
+  EXPECT_EQ(helper.testingSectionCount(), 0);
+
+  // Can enqueue/load/read again after reset.
+  auto handle2 = input.enqueue(section);
+  EXPECT_EQ(helper.testingSectionCount(), 1);
+  input.load();
+  EXPECT_TRUE(helper.testingLoaded());
+  EXPECT_EQ(handle2.read()->content(), data);
+
+  // Load without enqueue throws.
+  {
+    nimble::DirectMetadataInput emptyInput(
+        readFile.get(), pool_.get(), options);
+    NIMBLE_ASSERT_THROW(emptyInput.load(), "No sections enqueued");
+  }
+
+  // Read before load throws.
+  {
+    nimble::DirectMetadataInput freshInput(
+        readFile.get(), pool_.get(), options);
+    auto h = freshInput.enqueue(section);
+    NIMBLE_ASSERT_THROW(h.read(), "load() must be called before read()");
+  }
+
+  // Without reset, enqueue throws.
+  NIMBLE_ASSERT_THROW(
+      input.enqueue(section), "enqueue() not allowed after load()");
+  // Without reset, load throws.
+  NIMBLE_ASSERT_THROW(input.load(), "load() already called");
+
+  // Double read throws.
+  input.reset();
+  auto handle3 = input.enqueue(section);
+  input.load();
+  handle3.read();
+  NIMBLE_ASSERT_THROW(handle3.read(), "Metadata buffer already consumed");
+}
+
+TEST_F(DirectMetadataInputTest, ioStats) {
+  constexpr uint64_t kInjectedDelayUs = 10'000;
+  const std::string data = std::string(500, 'X');
+  nimble::MetadataSection section{
+      0,
+      static_cast<uint32_t>(data.size()),
+      nimble::CompressionType::Uncompressed,
+      static_cast<uint32_t>(data.size())};
+  const auto fileContent = buildFileContent({section}, {data});
+  auto innerFile = std::make_shared<velox::InMemoryReadFile>(fileContent);
+  auto readFile =
+      std::make_shared<nimble::testing::TrackingReadFile>(innerFile);
+  readFile->setReadDelayUs(kInjectedDelayUs);
+
+  const auto readCountBefore = metadataIoStats_.read().count();
+  const auto readSumBefore = metadataIoStats_.read().sum();
+  const auto rawBytesBefore = metadataIoStats_.rawBytesRead();
+  const auto overreadBefore = metadataIoStats_.rawOverreadBytes();
+  const auto totalScanTimeBefore = metadataIoStats_.totalScanTimeNs();
+  const auto storageLatencySumBefore =
+      metadataIoStats_.storageReadLatencyUs().sum();
+  const auto storageLatencyCountBefore =
+      metadataIoStats_.storageReadLatencyUs().count();
+  const auto queryIoLatencyCountBefore =
+      metadataIoStats_.queryThreadIoLatencyUs().count();
+
+  const auto options = makeReaderOptions();
+  nimble::DirectMetadataInput input(readFile.get(), pool_.get(), options);
+  input.enqueue(section);
+  input.load();
+
+  EXPECT_GT(metadataIoStats_.read().count(), readCountBefore);
+  EXPECT_EQ(metadataIoStats_.read().sum() - readSumBefore, data.size());
+  EXPECT_EQ(metadataIoStats_.rawBytesRead() - rawBytesBefore, data.size());
+  EXPECT_EQ(metadataIoStats_.rawOverreadBytes(), overreadBefore);
+  EXPECT_GE(
+      metadataIoStats_.totalScanTimeNs() - totalScanTimeBefore,
+      kInjectedDelayUs * 1'000);
+  EXPECT_GT(
+      metadataIoStats_.storageReadLatencyUs().count(),
+      storageLatencyCountBefore);
+  EXPECT_GE(
+      metadataIoStats_.storageReadLatencyUs().sum() - storageLatencySumBefore,
+      kInjectedDelayUs);
+  EXPECT_GT(
+      metadataIoStats_.queryThreadIoLatencyUs().count(),
+      queryIoLatencyCountBefore);
+}
+
+struct SectionLayout {
+  uint64_t offset;
+  uint32_t size;
+};
+
+DEBUG_ONLY_TEST_F(DirectMetadataInputTest, ioCoalescing) {
+  struct TestParam {
+    std::vector<SectionLayout> sections;
+    int32_t maxCoalesceDistance;
+    int64_t maxCoalesceBytes;
+    int32_t expectedNumIos;
+    uint64_t expectedOverread;
+    std::string debugString() const {
+      return fmt::format(
+          "{} sections, maxCoalesceDistance {}, maxCoalesceBytes {}, expectedNumIos {}, expectedOverread {}",
+          sections.size(),
+          maxCoalesceDistance,
+          maxCoalesceBytes,
+          expectedNumIos,
+          expectedOverread);
+    }
+  };
+
+  constexpr int64_t kLargeBytes = 128 << 20;
+
+  std::vector<TestParam> testSettings = {
+      // Single section → 1 IO.
+      {{{0, 100}}, 0, kLargeBytes, 1, 0},
+      // Two contiguous sections → 1 IO.
+      {{{0, 100}, {100, 200}}, 0, kLargeBytes, 1, 0},
+      // Three contiguous sections → 1 IO.
+      {{{0, 50}, {50, 60}, {110, 90}}, 0, kLargeBytes, 1, 0},
+      // Two sections with small gap, distance=0 → 2 IOs.
+      {{{0, 100}, {150, 100}}, 0, kLargeBytes, 2, 0},
+      // Two sections with gap within coalesce distance → 1 IO.
+      {{{0, 100}, {150, 100}}, 100, kLargeBytes, 1, 50},
+      // Two sections with gap exceeding coalesce distance → 2 IOs.
+      {{{0, 100}, {250, 100}}, 100, kLargeBytes, 2, 0},
+      // Three sections: first two coalesce, third separate.
+      {{{0, 100}, {120, 80}, {500, 100}}, 50, kLargeBytes, 2, 20},
+      // Three sections: all coalesce with large distance.
+      {{{0, 100}, {200, 100}, {400, 100}}, 200, kLargeBytes, 1, 200},
+      // Large gap, small distance → separate IOs.
+      {{{0, 1'000}, {10'000, 1'000}}, 100, kLargeBytes, 2, 0},
+      // maxCoalesceBytes splits contiguous sections.
+      {{{0, 100}, {100, 100}, {200, 100}}, 0, 150, 2, 0},
+      // maxCoalesceBytes exactly fits two sections → third splits.
+      {{{0, 100}, {100, 100}, {200, 100}}, 0, 200, 2, 0},
+      // maxCoalesceBytes fits all three.
+      {{{0, 100}, {100, 100}, {200, 100}}, 0, 300, 1, 0},
+      // maxCoalesceBytes splits every section into its own IO.
+      {{{0, 100}, {100, 100}, {200, 100}}, 0, 50, 3, 0},
+      // maxCoalesceBytes with gap: gap coalesced but bytes limit splits.
+      {{{0, 100}, {150, 100}, {300, 100}}, 200, 200, 2, 50},
+  };
+
+  for (const auto& testData : testSettings) {
+    SCOPED_TRACE(testData.debugString());
+
+    // Build file with sections filled with deterministic data.
+    uint64_t fileSize = 0;
+    for (const auto& s : testData.sections) {
+      fileSize = std::max(fileSize, s.offset + s.size);
+    }
+    std::string fileContent(fileSize, '\xCC');
+    std::vector<std::string> expectedData;
+    std::vector<nimble::MetadataSection> sections;
+    for (uint32_t i = 0; i < testData.sections.size(); ++i) {
+      const auto& layout = testData.sections[i];
+      std::string data(layout.size, 'A' + i);
+      std::memcpy(fileContent.data() + layout.offset, data.data(), data.size());
+      sections.emplace_back(
+          layout.offset,
+          layout.size,
+          nimble::CompressionType::Uncompressed,
+          layout.size);
+      expectedData.push_back(std::move(data));
+    }
+
+    auto readFile = std::make_shared<velox::InMemoryReadFile>(fileContent);
+
+    const auto rawBytesBefore = metadataIoStats_.rawBytesRead();
+    const auto overreadBefore = metadataIoStats_.rawOverreadBytes();
+
+    velox::CoalesceIoStats capturedStats;
+    SCOPED_TESTVALUE_SET(
+        "facebook::nimble::MetadataInput::computeIoGroups",
+        std::function<void(const velox::CoalesceIoStats*)>(
+            [&](const velox::CoalesceIoStats* stats) {
+              capturedStats = *stats;
+            }));
+
+    const auto options = makeReaderOptions(
+        testData.maxCoalesceDistance, testData.maxCoalesceBytes);
+    nimble::DirectMetadataInput input(readFile.get(), pool_.get(), options);
+    for (const auto& section : sections) {
+      input.enqueue(section);
+    }
+    input.load();
+
+    EXPECT_EQ(capturedStats.numIos, testData.expectedNumIos);
+    EXPECT_EQ(capturedStats.extraBytes, testData.expectedOverread);
+
+    uint64_t expectedPayloadBytes = 0;
+    for (const auto& s : testData.sections) {
+      expectedPayloadBytes += s.size;
+    }
+    EXPECT_EQ(
+        metadataIoStats_.rawBytesRead() - rawBytesBefore, expectedPayloadBytes);
+    EXPECT_EQ(
+        metadataIoStats_.rawOverreadBytes() - overreadBefore,
+        testData.expectedOverread);
+  }
+}
+
+TEST_F(DirectMetadataInputTest, ioError) {
+  struct TestParam {
+    std::vector<SectionSpec> specs;
+    int32_t maxCoalesceDistance;
+    std::string debugString() const {
+      return fmt::format(
+          "{} sections, maxCoalesceDistance {}, [{}]",
+          specs.size(),
+          maxCoalesceDistance,
+          fmt::join(
+              specs | std::views::transform([](const auto& s) {
+                return fmt::format(
+                    "comp{}:sz{}:uncomp{}",
+                    static_cast<int>(s.compressionType),
+                    s.data.size(),
+                    s.hasUncompressedSize);
+              }),
+              ", "));
+    }
+  };
+
+  std::vector<TestParam> testSettings = {
+      {{{std::string(100, 'A'), nimble::CompressionType::Uncompressed}}, 0},
+      {{{std::string(1'000, 'B'), nimble::CompressionType::Zstd}}, 0},
+      {{{std::string(1'000, 'C'), nimble::CompressionType::Zstd, false}}, 0},
+      {{{std::string(100, 'D'), nimble::CompressionType::Uncompressed},
+        {std::string(100, 'E'), nimble::CompressionType::Uncompressed}},
+       0},
+      {{{std::string(100, 'F'), nimble::CompressionType::Uncompressed},
+        {std::string(1'000, 'G'), nimble::CompressionType::Zstd, false}},
+       0},
+      {{{std::string(100, 'H'), nimble::CompressionType::Uncompressed},
+        {std::string(1'000, 'I'), nimble::CompressionType::Zstd},
+        {std::string(100, 'J'), nimble::CompressionType::Uncompressed}},
+       0},
+      {{{std::string(100, 'K'), nimble::CompressionType::Uncompressed},
+        {std::string(100, 'L'), nimble::CompressionType::Uncompressed}},
+       1 << 20},
+  };
+
+  for (const auto& testData : testSettings) {
+    SCOPED_TRACE(testData.debugString());
+
+    std::vector<nimble::MetadataSection> sections;
+    std::vector<std::string> fileDataParts;
+    buildSections(testData.specs, pool_.get(), sections, fileDataParts);
+
+    const auto fileContent = buildFileContent(sections, fileDataParts);
+    auto innerFile = std::make_shared<velox::InMemoryReadFile>(fileContent);
+    auto readFile =
+        std::make_shared<nimble::testing::TrackingReadFile>(innerFile);
+    readFile->setReadError(
+        std::make_exception_ptr(std::runtime_error("injected IO error")));
+
+    const auto options = makeReaderOptions(testData.maxCoalesceDistance);
+    nimble::DirectMetadataInput input(readFile.get(), pool_.get(), options);
+    for (const auto& section : sections) {
+      input.enqueue(section);
+    }
+    EXPECT_THROW(input.load(), std::runtime_error);
+
+    // After IO error, reset and retry with error cleared should succeed.
+    readFile->clearReadError();
+    input.reset();
+    std::vector<nimble::MetadataHandle> handles;
+    for (const auto& section : sections) {
+      handles.push_back(input.enqueue(section));
+    }
+    input.load();
+    for (uint32_t i = 0; i < handles.size(); ++i) {
+      EXPECT_EQ(handles[i].read()->content(), testData.specs[i].data);
+    }
+  }
+}
+
+// --- CachedMetadataInput tests ---
+// Parameterized by whether SSD cache is enabled.
+
+class CachedMetadataInputTest : public MetadataInputTestBase,
+                                public ::testing::WithParamInterface<bool> {
+ protected:
+  static constexpr uint64_t kCacheSize = 64 << 20;
+  static constexpr uint64_t kSsdSize = 64 << 20;
+
+  static void SetUpTestCase() {
+    velox::common::testutil::TestValue::enable();
+  }
+
+  bool enableSsd() const {
+    return GetParam();
+  }
+
+  void SetUp() override {
+    velox::filesystems::registerLocalFileSystem();
+    velox::memory::MemoryManager::Options options;
+    options.useMmapAllocator = true;
+    options.allocatorCapacity = kCacheSize;
+    options.arbitratorCapacity = kCacheSize;
+    options.trackDefaultUsage = true;
+    manager_ = std::make_unique<velox::memory::MemoryManager>(options);
+    allocator_ =
+        static_cast<velox::memory::MmapAllocator*>(manager_->allocator());
+
+    std::unique_ptr<velox::cache::SsdCache> ssdCache;
+    if (enableSsd()) {
+      tempDir_ = velox::common::testutil::TempDirectoryPath::create();
+      ssdExecutor_ = std::make_unique<folly::IOThreadPoolExecutor>(1);
+      ssdCache = std::make_unique<velox::cache::SsdCache>(
+          velox::cache::SsdCache::Config(
+              fmt::format("{}/cache", tempDir_->getPath()),
+              kSsdSize,
+              1,
+              ssdExecutor_.get()));
+    }
+    cache_ =
+        velox::cache::AsyncDataCache::create(allocator_, std::move(ssdCache));
+    rootPool_ = manager_->addRootPool("CachedMetadataInputTest");
+    pool_ = rootPool_->addLeafChild("leaf");
+    fileId_ = std::make_unique<velox::StringIdLease>(
+        velox::fileIds(), "CachedMetadataInputTest");
+  }
+
+  void TearDown() override {
+    fileId_.reset();
+    if (cache_ != nullptr) {
+      cache_->shutdown();
+    }
+    cache_.reset();
+    pool_.reset();
+    rootPool_.reset();
+    manager_.reset();
+    ssdExecutor_.reset();
+    tempDir_.reset();
+  }
+
+  std::unique_ptr<nimble::CachedMetadataInput> createCachedInput(
+      velox::ReadFile* readFile,
+      int32_t maxCoalesceDistance = 1 << 20) {
+    velox::StringIdLease fileIdClone(
+        velox::fileIds(), "CachedMetadataInputTest");
+    const auto options = makeReaderOptions(maxCoalesceDistance);
+    return std::make_unique<nimble::CachedMetadataInput>(
+        readFile, std::move(fileIdClone), cache_.get(), pool_.get(), options);
+  }
+
+  std::unique_ptr<velox::memory::MemoryManager> manager_;
+  velox::memory::MmapAllocator* allocator_{nullptr};
+  std::shared_ptr<velox::cache::AsyncDataCache> cache_;
+  std::unique_ptr<velox::StringIdLease> fileId_;
+  std::shared_ptr<velox::common::testutil::TempDirectoryPath> tempDir_;
+  std::unique_ptr<folly::IOThreadPoolExecutor> ssdExecutor_;
+};
+
+TEST_P(CachedMetadataInputTest, enqueueLoadRead) {
+  for (const auto& testData : enqueueLoadReadTestSettings()) {
+    SCOPED_TRACE(testData.debugString());
+    cache_->clear();
+
+    std::vector<nimble::MetadataSection> sections;
+    std::vector<std::string> fileDataParts;
+    buildSections(testData.specs, pool_.get(), sections, fileDataParts);
+
+    const auto fileContent = buildFileContent(sections, fileDataParts);
+    auto readFile = std::make_shared<velox::InMemoryReadFile>(fileContent);
+
+    auto input = createCachedInput(readFile.get());
+    nimble::test::MetadataInputTestHelper helper(input.get());
+
+    EXPECT_FALSE(helper.testingLoaded());
+    EXPECT_EQ(helper.testingSectionCount(), 0);
+
+    std::vector<nimble::MetadataHandle> handles;
+    for (uint32_t i = 0; i < sections.size(); ++i) {
+      handles.push_back(input->enqueue(sections[i]));
+      EXPECT_EQ(helper.testingSectionCount(), i + 1);
+      EXPECT_FALSE(helper.testingHasBuffer(i));
+    }
+    EXPECT_FALSE(helper.testingLoaded());
+
+    input->load();
+    EXPECT_TRUE(helper.testingLoaded());
+    for (uint32_t i = 0; i < sections.size(); ++i) {
+      EXPECT_TRUE(helper.testingHasBuffer(i));
+    }
+
+    for (uint32_t i = 0; i < sections.size(); ++i) {
+      auto buffer = handles[i].read();
+      ASSERT_NE(buffer, nullptr);
+      EXPECT_EQ(buffer->content(), testData.specs[i].data);
+      EXPECT_FALSE(helper.testingHasBuffer(i));
+    }
+  }
+}
+
+TEST_P(CachedMetadataInputTest, reverseEnqueueOrder) {
+  const std::string data0 = "first-in-file";
+  const std::string data1 = "second-in-file";
+
+  const uint64_t offset0 = 0;
+  const uint64_t offset1 = data0.size();
+
+  nimble::MetadataSection section0{
+      offset0,
+      static_cast<uint32_t>(data0.size()),
+      nimble::CompressionType::Uncompressed,
+      static_cast<uint32_t>(data0.size())};
+  nimble::MetadataSection section1{
+      offset1,
+      static_cast<uint32_t>(data1.size()),
+      nimble::CompressionType::Uncompressed,
+      static_cast<uint32_t>(data1.size())};
+
+  const auto fileContent =
+      buildFileContent({section0, section1}, {data0, data1});
+  auto readFile = std::make_shared<velox::InMemoryReadFile>(fileContent);
+
+  auto input = createCachedInput(readFile.get());
+
+  auto handle1 = input->enqueue(section1);
+  auto handle0 = input->enqueue(section0);
+  input->load();
+
+  EXPECT_EQ(handle0.read()->content(), data0);
+  EXPECT_EQ(handle1.read()->content(), data1);
+}
+
+TEST_P(CachedMetadataInputTest, enqueueLoadReadWithCache) {
+  for (const auto& testData : enqueueLoadReadTestSettings()) {
+    SCOPED_TRACE(testData.debugString());
+    cache_->clear();
+
+    std::vector<nimble::MetadataSection> sections;
+    std::vector<std::string> fileDataParts;
+    buildSections(testData.specs, pool_.get(), sections, fileDataParts);
+
+    const auto fileContent = buildFileContent(sections, fileDataParts);
+    auto readFile = std::make_shared<velox::InMemoryReadFile>(fileContent);
+
+    // First load — populates cache, expect zero ram hits.
+    {
+      const auto ramHitBefore = metadataIoStats_.ramHit().count();
+      const auto storageLatencyBefore =
+          metadataIoStats_.storageReadLatencyUs().count();
+      auto input = createCachedInput(readFile.get());
+      std::vector<nimble::MetadataHandle> handles;
+      for (const auto& section : sections) {
+        handles.push_back(input->enqueue(section));
+      }
+      input->load();
+      for (uint32_t i = 0; i < handles.size(); ++i) {
+        EXPECT_EQ(handles[i].read()->content(), testData.specs[i].data);
+      }
+      EXPECT_EQ(metadataIoStats_.ramHit().count(), ramHitBefore);
+      EXPECT_GT(
+          metadataIoStats_.storageReadLatencyUs().count(),
+          storageLatencyBefore);
+    }
+
+    // Count sections with known uncompressed size — only these get
+    // pre-claimed cache pins and can be fully served from RAM cache.
+    const uint32_t sectionsWithSize = std::count_if(
+        testData.specs.begin(), testData.specs.end(), [](const auto& s) {
+          return s.hasUncompressedSize;
+        });
+
+    // Second load — sections with uncompressed size hit cache directly.
+    // Sections without it still go through loadFromFile → store().
+    {
+      const auto ramHitBefore = metadataIoStats_.ramHit().count();
+      auto input = createCachedInput(readFile.get());
+      std::vector<nimble::MetadataHandle> handles;
+      for (const auto& section : sections) {
+        handles.push_back(input->enqueue(section));
+      }
+      input->load();
+      for (uint32_t i = 0; i < handles.size(); ++i) {
+        EXPECT_EQ(handles[i].read()->content(), testData.specs[i].data);
+      }
+      EXPECT_GE(
+          metadataIoStats_.ramHit().count() - ramHitBefore, sectionsWithSize);
+    }
+
+    // Third load (SSD only) — flush RAM to SSD, clear RAM, read from SSD.
+    if (enableSsd()) {
+      // Flush all saveable entries to SSD.
+      ASSERT_TRUE(cache_->ssdCache()->startWrite());
+      cache_->saveToSsd(/*saveAll=*/true);
+      cache_->ssdCache()->waitForWriteToFinish();
+
+      // Clear RAM cache — entries survive on SSD.
+      cache_->clear();
+
+      const auto ramHitBefore = metadataIoStats_.ramHit().count();
+      const auto ssdReadBefore = metadataIoStats_.ssdRead().count();
+      const auto storageLatencyBefore =
+          metadataIoStats_.storageReadLatencyUs().count();
+
+      auto input = createCachedInput(readFile.get());
+      std::vector<nimble::MetadataHandle> handles;
+      for (const auto& section : sections) {
+        handles.push_back(input->enqueue(section));
+      }
+      input->load();
+      for (uint32_t i = 0; i < handles.size(); ++i) {
+        EXPECT_EQ(handles[i].read()->content(), testData.specs[i].data);
+      }
+
+      // No RAM hits, SSD hits for sections with known size, no file IO.
+      EXPECT_EQ(metadataIoStats_.ramHit().count(), ramHitBefore);
+      EXPECT_GE(
+          metadataIoStats_.ssdRead().count() - ssdReadBefore, sectionsWithSize);
+      EXPECT_EQ(
+          metadataIoStats_.storageReadLatencyUs().count(),
+          storageLatencyBefore);
+    }
+  }
+}
+
+TEST_P(CachedMetadataInputTest, stateTransitions) {
+  const std::string data = "cached-state-test";
+  nimble::MetadataSection section{
+      0,
+      static_cast<uint32_t>(data.size()),
+      nimble::CompressionType::Uncompressed,
+      static_cast<uint32_t>(data.size())};
+  const auto fileContent = buildFileContent({section}, {data});
+  auto readFile = std::make_shared<velox::InMemoryReadFile>(fileContent);
+
+  auto input = createCachedInput(readFile.get());
+  nimble::test::CachedMetadataInputTestHelper helper(input.get());
+
+  // Before enqueue.
+  EXPECT_FALSE(helper.testingLoaded());
+  EXPECT_EQ(helper.testingSectionCount(), 0);
+  EXPECT_EQ(helper.testingCachePinCount(), 0);
+
+  // After enqueue.
+  auto handle = input->enqueue(section);
+  EXPECT_FALSE(helper.testingLoaded());
+  EXPECT_EQ(helper.testingSectionCount(), 1);
+  EXPECT_EQ(helper.testingSection(0).offset(), 0);
+  EXPECT_EQ(helper.testingSection(0).size(), data.size());
+  EXPECT_FALSE(helper.testingHasBuffer(0));
+
+  // After load.
+  input->load();
+  EXPECT_TRUE(helper.testingLoaded());
+  EXPECT_EQ(helper.testingSectionCount(), 1);
+  EXPECT_TRUE(helper.testingHasBuffer(0));
+  // cachePins_ cleared after load completes.
+  EXPECT_EQ(helper.testingCachePinCount(), 0);
+
+  // After read — buffer consumed.
+  EXPECT_EQ(handle.read()->content(), data);
+  EXPECT_FALSE(helper.testingHasBuffer(0));
+
+  // After reset — back to initial state.
+  input->reset();
+  EXPECT_FALSE(helper.testingLoaded());
+  EXPECT_EQ(helper.testingSectionCount(), 0);
+  EXPECT_EQ(helper.testingCachePinCount(), 0);
+
+  // Can enqueue/load/read again after reset.
+  auto handle2 = input->enqueue(section);
+  input->load();
+  EXPECT_TRUE(helper.testingLoaded());
+  EXPECT_EQ(handle2.read()->content(), data);
+
+  // Without reset, enqueue throws.
+  NIMBLE_ASSERT_THROW(
+      input->enqueue(section), "enqueue() not allowed after load()");
+  // Without reset, load throws.
+  NIMBLE_ASSERT_THROW(input->load(), "load() already called");
+}
+
+DEBUG_ONLY_TEST_P(CachedMetadataInputTest, ioCoalescing) {
+  struct TestParam {
+    std::vector<SectionLayout> sections;
+    int32_t maxCoalesceDistance;
+    int64_t maxCoalesceBytes;
+    int32_t expectedNumIos;
+    uint64_t expectedOverread;
+    std::string debugString() const {
+      return fmt::format(
+          "{} sections, maxCoalesceDistance {}, maxCoalesceBytes {}, expectedNumIos {}, expectedOverread {}",
+          sections.size(),
+          maxCoalesceDistance,
+          maxCoalesceBytes,
+          expectedNumIos,
+          expectedOverread);
+    }
+  };
+
+  constexpr int64_t kLargeBytes = 128 << 20;
+
+  std::vector<TestParam> testSettings = {
+      {{{0, 100}}, 0, kLargeBytes, 1, 0},
+      {{{0, 100}, {100, 200}}, 0, kLargeBytes, 1, 0},
+      {{{0, 50}, {50, 60}, {110, 90}}, 0, kLargeBytes, 1, 0},
+      {{{0, 100}, {150, 100}}, 0, kLargeBytes, 2, 0},
+      {{{0, 100}, {150, 100}}, 100, kLargeBytes, 1, 50},
+      {{{0, 100}, {250, 100}}, 100, kLargeBytes, 2, 0},
+      {{{0, 100}, {120, 80}, {500, 100}}, 50, kLargeBytes, 2, 20},
+      {{{0, 100}, {200, 100}, {400, 100}}, 200, kLargeBytes, 1, 200},
+      {{{0, 1'000}, {10'000, 1'000}}, 100, kLargeBytes, 2, 0},
+      {{{0, 100}, {100, 100}, {200, 100}}, 0, 150, 2, 0},
+      {{{0, 100}, {100, 100}, {200, 100}}, 0, 200, 2, 0},
+      {{{0, 100}, {100, 100}, {200, 100}}, 0, 300, 1, 0},
+      {{{0, 100}, {100, 100}, {200, 100}}, 0, 50, 3, 0},
+      {{{0, 100}, {150, 100}, {300, 100}}, 200, 200, 2, 50},
+  };
+
+  for (const auto& testData : testSettings) {
+    SCOPED_TRACE(testData.debugString());
+    cache_->clear();
+
+    uint64_t fileSize = 0;
+    std::vector<std::string> sectionData;
+    std::vector<nimble::MetadataSection> sections;
+    for (uint32_t i = 0; i < testData.sections.size(); ++i) {
+      const auto& layout = testData.sections[i];
+      fileSize = std::max(fileSize, layout.offset + layout.size);
+      sectionData.emplace_back(layout.size, 'A' + i);
+      sections.emplace_back(
+          layout.offset,
+          layout.size,
+          nimble::CompressionType::Uncompressed,
+          layout.size);
+    }
+
+    std::string fileContent(fileSize, '\xCC');
+    for (uint32_t i = 0; i < sections.size(); ++i) {
+      std::memcpy(
+          fileContent.data() + sections[i].offset(),
+          sectionData[i].data(),
+          sectionData[i].size());
+    }
+
+    auto readFile = std::make_shared<velox::InMemoryReadFile>(fileContent);
+    const auto options = makeReaderOptions(
+        testData.maxCoalesceDistance, testData.maxCoalesceBytes);
+
+    uint64_t expectedPayloadBytes = 0;
+    for (const auto& s : testData.sections) {
+      expectedPayloadBytes += s.size;
+    }
+
+    // First load — cold cache, expect file IO with coalescing.
+    {
+      const auto rawBytesBefore = metadataIoStats_.rawBytesRead();
+      const auto overreadBefore = metadataIoStats_.rawOverreadBytes();
+      const auto ramHitBefore = metadataIoStats_.ramHit().count();
+
+      velox::CoalesceIoStats capturedStats;
+      SCOPED_TESTVALUE_SET(
+          "facebook::nimble::MetadataInput::computeIoGroups",
+          std::function<void(const velox::CoalesceIoStats*)>(
+              [&](const velox::CoalesceIoStats* stats) {
+                capturedStats = *stats;
+              }));
+
+      auto input = std::make_unique<nimble::CachedMetadataInput>(
+          readFile.get(),
+          velox::StringIdLease(velox::fileIds(), "CachedMetadataInputTest"),
+          cache_.get(),
+          pool_.get(),
+          options);
+      for (const auto& section : sections) {
+        input->enqueue(section);
+      }
+      input->load();
+
+      EXPECT_EQ(capturedStats.numIos, testData.expectedNumIos);
+      EXPECT_EQ(capturedStats.extraBytes, testData.expectedOverread);
+      EXPECT_EQ(
+          metadataIoStats_.rawBytesRead() - rawBytesBefore,
+          expectedPayloadBytes);
+      EXPECT_EQ(
+          metadataIoStats_.rawOverreadBytes() - overreadBefore,
+          testData.expectedOverread);
+      EXPECT_EQ(metadataIoStats_.ramHit().count(), ramHitBefore);
+    }
+
+    // Second load — warm cache, expect all RAM hits, zero file IO.
+    {
+      const auto rawBytesBefore = metadataIoStats_.rawBytesRead();
+      const auto overreadBefore = metadataIoStats_.rawOverreadBytes();
+      const auto ramHitBefore = metadataIoStats_.ramHit().count();
+      const auto storageLatencyBefore =
+          metadataIoStats_.storageReadLatencyUs().count();
+
+      auto input = std::make_unique<nimble::CachedMetadataInput>(
+          readFile.get(),
+          velox::StringIdLease(velox::fileIds(), "CachedMetadataInputTest"),
+          cache_.get(),
+          pool_.get(),
+          options);
+      for (const auto& section : sections) {
+        input->enqueue(section);
+      }
+      input->load();
+
+      EXPECT_EQ(metadataIoStats_.rawBytesRead(), rawBytesBefore);
+      EXPECT_EQ(metadataIoStats_.rawOverreadBytes(), overreadBefore);
+      EXPECT_EQ(
+          metadataIoStats_.ramHit().count() - ramHitBefore, sections.size());
+      EXPECT_EQ(
+          metadataIoStats_.storageReadLatencyUs().count(),
+          storageLatencyBefore);
+    }
+
+    // Third load (SSD only) — flush RAM to SSD, clear RAM, read from SSD.
+    if (enableSsd()) {
+      ASSERT_TRUE(cache_->ssdCache()->startWrite());
+      cache_->saveToSsd(/*saveAll=*/true);
+      cache_->ssdCache()->waitForWriteToFinish();
+      cache_->clear();
+
+      const auto rawBytesBefore = metadataIoStats_.rawBytesRead();
+      const auto overreadBefore = metadataIoStats_.rawOverreadBytes();
+      const auto ramHitBefore = metadataIoStats_.ramHit().count();
+      const auto ssdReadBefore = metadataIoStats_.ssdRead().count();
+      const auto storageLatencyBefore =
+          metadataIoStats_.storageReadLatencyUs().count();
+
+      auto input = std::make_unique<nimble::CachedMetadataInput>(
+          readFile.get(),
+          velox::StringIdLease(velox::fileIds(), "CachedMetadataInputTest"),
+          cache_.get(),
+          pool_.get(),
+          options);
+      for (const auto& section : sections) {
+        input->enqueue(section);
+      }
+      input->load();
+
+      // No RAM hits, all SSD hits, no file IO, no overread.
+      EXPECT_EQ(metadataIoStats_.rawBytesRead(), rawBytesBefore);
+      EXPECT_EQ(metadataIoStats_.rawOverreadBytes(), overreadBefore);
+      EXPECT_EQ(metadataIoStats_.ramHit().count(), ramHitBefore);
+      EXPECT_EQ(
+          metadataIoStats_.ssdRead().count() - ssdReadBefore, sections.size());
+      EXPECT_EQ(
+          metadataIoStats_.storageReadLatencyUs().count(),
+          storageLatencyBefore);
+    }
+  }
+}
+
+TEST_P(CachedMetadataInputTest, partialCacheHit) {
+  const std::string data0 = "partial-hit-0";
+  const std::string data1 = "partial-hit-1";
+
+  const uint64_t offset0 = 0;
+  const uint64_t offset1 = data0.size();
+
+  nimble::MetadataSection section0{
+      offset0,
+      static_cast<uint32_t>(data0.size()),
+      nimble::CompressionType::Uncompressed,
+      static_cast<uint32_t>(data0.size())};
+  nimble::MetadataSection section1{
+      offset1,
+      static_cast<uint32_t>(data1.size()),
+      nimble::CompressionType::Uncompressed,
+      static_cast<uint32_t>(data1.size())};
+
+  const auto fileContent =
+      buildFileContent({section0, section1}, {data0, data1});
+  auto readFile = std::make_shared<velox::InMemoryReadFile>(fileContent);
+  cache_->clear();
+
+  // Load only section0 to populate cache for it.
+  {
+    auto input = createCachedInput(readFile.get());
+    auto handle = input->enqueue(section0);
+    input->load();
+    EXPECT_EQ(handle.read()->content(), data0);
+  }
+
+  // Load both sections — section0 should be a cache hit, section1 a miss.
+  {
+    const auto ramHitBefore = metadataIoStats_.ramHit().count();
+    auto input = createCachedInput(readFile.get());
+    auto handle0 = input->enqueue(section0);
+    auto handle1 = input->enqueue(section1);
+    input->load();
+    EXPECT_EQ(handle0.read()->content(), data0);
+    EXPECT_EQ(handle1.read()->content(), data1);
+    EXPECT_GT(metadataIoStats_.ramHit().count(), ramHitBefore);
+  }
+
+  // SSD partial hit: flush section0+section1 to SSD, clear RAM, then load
+  // only section1 so section0 stays only on SSD. Reload both — section0
+  // should come from SSD, section1 from RAM.
+  if (enableSsd()) {
+    ASSERT_TRUE(cache_->ssdCache()->startWrite());
+    cache_->saveToSsd(/*saveAll=*/true);
+    cache_->ssdCache()->waitForWriteToFinish();
+    cache_->clear();
+
+    // Reload only section1 into RAM.
+    {
+      auto input = createCachedInput(readFile.get());
+      auto handle = input->enqueue(section1);
+      input->load();
+      EXPECT_EQ(handle.read()->content(), data1);
+    }
+
+    const auto ssdReadBefore = metadataIoStats_.ssdRead().count();
+    const auto ramHitBefore = metadataIoStats_.ramHit().count();
+    const auto storageLatencyBefore =
+        metadataIoStats_.storageReadLatencyUs().count();
+    {
+      auto input = createCachedInput(readFile.get());
+      auto handle0 = input->enqueue(section0);
+      auto handle1 = input->enqueue(section1);
+      input->load();
+      EXPECT_EQ(handle0.read()->content(), data0);
+      EXPECT_EQ(handle1.read()->content(), data1);
+    }
+    // section0 from SSD, section1 from RAM, no file IO.
+    EXPECT_GT(metadataIoStats_.ssdRead().count(), ssdReadBefore);
+    EXPECT_GT(metadataIoStats_.ramHit().count(), ramHitBefore);
+    EXPECT_EQ(
+        metadataIoStats_.storageReadLatencyUs().count(), storageLatencyBefore);
+  }
+}
+
+TEST_P(CachedMetadataInputTest, ioError) {
+  struct TestParam {
+    std::vector<SectionSpec> specs;
+    int32_t maxCoalesceDistance;
+    std::string debugString() const {
+      return fmt::format(
+          "{} sections, maxCoalesceDistance {}, [{}]",
+          specs.size(),
+          maxCoalesceDistance,
+          fmt::join(
+              specs | std::views::transform([](const auto& s) {
+                return fmt::format(
+                    "comp{}:sz{}:uncomp{}",
+                    static_cast<int>(s.compressionType),
+                    s.data.size(),
+                    s.hasUncompressedSize);
+              }),
+              ", "));
+    }
+  };
+
+  std::vector<TestParam> testSettings = {
+      // Single uncompressed, 1 IO group.
+      {{{std::string(100, 'A'), nimble::CompressionType::Uncompressed}}, 0},
+      // Single compressed with known size.
+      {{{std::string(1'000, 'B'), nimble::CompressionType::Zstd}}, 0},
+      // Single compressed without known size.
+      {{{std::string(1'000, 'C'), nimble::CompressionType::Zstd, false}}, 0},
+      // Two sections, no coalescing → 2 IO groups (async dispatch).
+      {{{std::string(100, 'D'), nimble::CompressionType::Uncompressed},
+        {std::string(100, 'E'), nimble::CompressionType::Uncompressed}},
+       0},
+      // Mixed compression with/without known size.
+      {{{std::string(100, 'F'), nimble::CompressionType::Uncompressed},
+        {std::string(1'000, 'G'), nimble::CompressionType::Zstd, false}},
+       0},
+      // Three sections, no coalescing → 3 IO groups.
+      {{{std::string(100, 'H'), nimble::CompressionType::Uncompressed},
+        {std::string(1'000, 'I'), nimble::CompressionType::Zstd},
+        {std::string(100, 'J'), nimble::CompressionType::Uncompressed}},
+       0},
+      // Two sections coalesced → 1 IO group.
+      {{{std::string(100, 'K'), nimble::CompressionType::Uncompressed},
+        {std::string(100, 'L'), nimble::CompressionType::Uncompressed}},
+       1 << 20},
+  };
+
+  for (const auto& testData : testSettings) {
+    SCOPED_TRACE(testData.debugString());
+    cache_->clear();
+
+    std::vector<nimble::MetadataSection> sections;
+    std::vector<std::string> fileDataParts;
+    buildSections(testData.specs, pool_.get(), sections, fileDataParts);
+
+    const auto fileContent = buildFileContent(sections, fileDataParts);
+    auto innerFile = std::make_shared<velox::InMemoryReadFile>(fileContent);
+    auto readFile =
+        std::make_shared<nimble::testing::TrackingReadFile>(innerFile);
+    readFile->setReadError(
+        std::make_exception_ptr(std::runtime_error("injected IO error")));
+
+    const auto options = makeReaderOptions(testData.maxCoalesceDistance);
+    auto input = std::make_unique<nimble::CachedMetadataInput>(
+        readFile.get(),
+        velox::StringIdLease(velox::fileIds(), "CachedMetadataInputTest"),
+        cache_.get(),
+        pool_.get(),
+        options);
+    for (const auto& section : sections) {
+      input->enqueue(section);
+    }
+    EXPECT_THROW(input->load(), std::runtime_error);
+
+    // After IO error, reset and retry with error cleared should succeed.
+    readFile->clearReadError();
+    input->reset();
+    std::vector<nimble::MetadataHandle> handles;
+    for (const auto& section : sections) {
+      handles.push_back(input->enqueue(section));
+    }
+    input->load();
+    for (uint32_t i = 0; i < handles.size(); ++i) {
+      EXPECT_EQ(handles[i].read()->content(), testData.specs[i].data);
+    }
+  }
+}
+
+DEBUG_ONLY_TEST_P(CachedMetadataInputTest, ssdIoError) {
+  if (!enableSsd()) {
+    return;
+  }
+
+  const std::string data = "ssd-io-error-test";
+  nimble::MetadataSection section{
+      0,
+      static_cast<uint32_t>(data.size()),
+      nimble::CompressionType::Uncompressed,
+      static_cast<uint32_t>(data.size())};
+  const auto fileContent = buildFileContent({section}, {data});
+  auto readFile = std::make_shared<velox::InMemoryReadFile>(fileContent);
+  cache_->clear();
+
+  // Populate cache, flush to SSD, clear RAM.
+  {
+    auto input = createCachedInput(readFile.get());
+    auto handle = input->enqueue(section);
+    input->load();
+    EXPECT_EQ(handle.read()->content(), data);
+  }
+  ASSERT_TRUE(cache_->ssdCache()->startWrite());
+  cache_->saveToSsd(/*saveAll=*/true);
+  cache_->ssdCache()->waitForWriteToFinish();
+  cache_->clear();
+
+  // Inject SSD read error — load() should propagate the exception.
+  SCOPED_TESTVALUE_SET(
+      "facebook::velox::cache::SsdFile::load",
+      std::function<void(velox::cache::SsdFile*)>(
+          [&](velox::cache::SsdFile* /*ssdFile*/) {
+            VELOX_FAIL("injected SSD IO error");
+          }));
+  {
+    auto input = createCachedInput(readFile.get());
+    input->enqueue(section);
+    VELOX_ASSERT_THROW(input->load(), "injected SSD IO error");
+  }
+}
+
+TEST_P(CachedMetadataInputTest, cachePinRetention) {
+  const std::string data = "pin-retention-test-data";
+  nimble::MetadataSection section{
+      0,
+      static_cast<uint32_t>(data.size()),
+      nimble::CompressionType::Uncompressed,
+      static_cast<uint32_t>(data.size())};
+  const auto fileContent = buildFileContent({section}, {data});
+  auto readFile = std::make_shared<velox::InMemoryReadFile>(fileContent);
+  cache_->clear();
+
+  // Load and read — MetadataBuffer holds the cache pin reference.
+  auto input = createCachedInput(readFile.get());
+  auto handle = input->enqueue(section);
+  input->load();
+  auto buffer = handle.read();
+  ASSERT_NE(buffer, nullptr);
+  EXPECT_EQ(buffer->content(), data);
+
+  // Clear the cache — the entry is still pinned by the MetadataBuffer,
+  // so it can't be evicted.
+  cache_->clear();
+
+  // The buffer still holds valid data via the cache pin.
+  EXPECT_EQ(buffer->content(), data);
+
+  // A second load should still hit RAM cache because the pin keeps the
+  // entry alive even after clear().
+  const auto ramHitBefore = metadataIoStats_.ramHit().count();
+  {
+    auto input2 = createCachedInput(readFile.get());
+    auto handle2 = input2->enqueue(section);
+    input2->load();
+    auto buffer2 = handle2.read();
+    ASSERT_NE(buffer2, nullptr);
+    EXPECT_EQ(buffer2->content(), data);
+  }
+  EXPECT_GT(metadataIoStats_.ramHit().count(), ramHitBefore);
+
+  // Drop the original buffer — releases the pin.
+  buffer.reset();
+
+  // Now clear should fully evict.
+  cache_->clear();
+
+  // Third load — cold miss, requires file IO.
+  const auto ramHitBefore2 = metadataIoStats_.ramHit().count();
+  const auto storageLatencyBefore =
+      metadataIoStats_.storageReadLatencyUs().count();
+  {
+    auto input3 = createCachedInput(readFile.get());
+    auto handle3 = input3->enqueue(section);
+    input3->load();
+    auto buffer3 = handle3.read();
+    ASSERT_NE(buffer3, nullptr);
+    EXPECT_EQ(buffer3->content(), data);
+  }
+  EXPECT_EQ(metadataIoStats_.ramHit().count(), ramHitBefore2);
+  EXPECT_GT(
+      metadataIoStats_.storageReadLatencyUs().count(), storageLatencyBefore);
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    CachedMetadataInputTests,
+    CachedMetadataInputTest,
+    ::testing::Values(false, true),
+    [](const ::testing::TestParamInfo<bool>& info) {
+      return info.param ? "WithSsd" : "WithoutSsd";
+    });
+
+} // namespace

--- a/dwio/nimble/tablet/tests/TabletTest.cpp
+++ b/dwio/nimble/tablet/tests/TabletTest.cpp
@@ -4667,4 +4667,58 @@ TEST_F(TabletTest, concurrentReadersWithCacheEviction) {
   cache->shutdown();
 }
 
+TEST_P(TabletWithIndexTest, metadataSectionUncompressedSize) {
+  std::string file;
+  velox::InMemoryWriteFile writeFile(&file);
+  nimble::Buffer buffer(*pool_);
+
+  nimble::index::test::TestClusterIndexMetadataWriter indexHelper(
+      *pool_, {"col1"}, {SortOrder{.ascending = true}});
+
+  auto tabletWriter = nimble::TabletWriter::create(
+      &writeFile,
+      *pool_,
+      {
+          .metadataFlushThreshold = 1'024 * 1'024 * 1'024,
+          .streamDeduplicationEnabled = false,
+          .enableChunkIndex = true,
+          .stripeGroupFlushCallback =
+              indexHelper.createStripeGroupFlushCallback(),
+          .closeCallback = indexHelper.createCloseCallback(),
+      });
+
+  for (int stripe = 0; stripe < 2; ++stripe) {
+    auto streams = createStreams(
+        buffer, {{.offset = 0, .chunks = {{.rowCount = 100, .size = 50}}}});
+    indexHelper.addStripe(
+        {{.rowCount = 100, .key = fmt::format("key_{:03d}", stripe)}});
+    tabletWriter->writeStripe(100, std::move(streams));
+  }
+  tabletWriter->close();
+  writeFile.close();
+
+  auto readFile = std::make_shared<velox::InMemoryReadFile>(file);
+  const auto layout = nimble::FileLayout::create(readFile, pool_.get());
+
+  ASSERT_TRUE(layout.stripes.uncompressedSize().has_value());
+  EXPECT_GT(layout.stripes.uncompressedSize().value(), 0);
+  EXPECT_GE(layout.stripes.uncompressedSize().value(), layout.stripes.size());
+
+  for (size_t i = 0; i < layout.stripeGroups.size(); ++i) {
+    SCOPED_TRACE(fmt::format("stripeGroup {}", i));
+    ASSERT_TRUE(layout.stripeGroups[i].uncompressedSize().has_value());
+    EXPECT_GT(layout.stripeGroups[i].uncompressedSize().value(), 0);
+    EXPECT_GE(
+        layout.stripeGroups[i].uncompressedSize().value(),
+        layout.stripeGroups[i].size());
+  }
+
+  for (const auto& [name, section] : layout.optionalSections) {
+    SCOPED_TRACE(fmt::format("optionalSection '{}'", name));
+    ASSERT_TRUE(section.uncompressedSize().has_value());
+    EXPECT_GT(section.uncompressedSize().value(), 0);
+    EXPECT_GE(section.uncompressedSize().value(), section.size());
+  }
+}
+
 } // namespace

--- a/dwio/nimble/velox/ChunkedStream.cpp
+++ b/dwio/nimble/velox/ChunkedStream.cpp
@@ -35,7 +35,7 @@ bool InMemoryChunkedStream::hasNext() {
 
 std::string_view InMemoryChunkedStream::nextChunk() {
   ensureLoaded();
-  uncompressed_.clear();
+  uncompressed_.reset();
   NIMBLE_CHECK_LE(
       kChunkHeaderSize,
       stream_.size() - (pos_ - stream_.data()),
@@ -52,9 +52,8 @@ std::string_view InMemoryChunkedStream::nextChunk() {
       break;
     }
     case CompressionType::Zstd: {
-      uncompressed_ =
-          ZstdCompression::uncompress(*uncompressed_.pool(), {pos_, length});
-      chunk = {uncompressed_.data(), uncompressed_.size()};
+      uncompressed_ = ZstdCompression::uncompress({pos_, length}, &memoryPool_);
+      chunk = {uncompressed_->as<char>(), uncompressed_->size()};
       break;
     }
     default: {
@@ -77,7 +76,7 @@ CompressionType InMemoryChunkedStream::peekCompressionType() {
 }
 
 void InMemoryChunkedStream::reset() {
-  uncompressed_.clear();
+  uncompressed_.reset();
   pos_ = stream_.data();
 }
 

--- a/dwio/nimble/velox/ChunkedStream.h
+++ b/dwio/nimble/velox/ChunkedStream.h
@@ -20,9 +20,9 @@
 #include <string_view>
 
 #include "dwio/nimble/common/Types.h"
-#include "dwio/nimble/common/Vector.h"
 #include "dwio/nimble/tablet/TabletReader.h"
 #include "folly/io/IOBuf.h"
+#include "velox/buffer/Buffer.h"
 
 namespace facebook::nimble {
 
@@ -44,9 +44,9 @@ class InMemoryChunkedStream : public ChunkedStream {
   InMemoryChunkedStream(
       velox::memory::MemoryPool& memoryPool,
       std::unique_ptr<StreamLoader> streamLoader)
-      : streamLoader_{std::move(streamLoader)},
-        pos_{nullptr},
-        uncompressed_{&memoryPool} {}
+      : memoryPool_{memoryPool},
+        streamLoader_{std::move(streamLoader)},
+        pos_{nullptr} {}
 
   bool hasNext() override;
 
@@ -59,10 +59,11 @@ class InMemoryChunkedStream : public ChunkedStream {
  private:
   void ensureLoaded();
 
+  velox::memory::MemoryPool& memoryPool_;
   std::unique_ptr<StreamLoader> streamLoader_;
   std::string_view stream_;
   const char* pos_;
-  Vector<char> uncompressed_;
+  velox::BufferPtr uncompressed_;
 };
 
 } // namespace facebook::nimble

--- a/dwio/nimble/velox/ChunkedStreamWriter.cpp
+++ b/dwio/nimble/velox/ChunkedStreamWriter.cpp
@@ -39,12 +39,12 @@ std::vector<std::string_view> ChunkedStreamWriter::encode(
 
   if (compressionParams_.type == CompressionType::Zstd) {
     auto compressed = ZstdCompression::compress(
-        buffer_.getMemoryPool(), chunk, compressionParams_.zstdLevel);
+        chunk, &buffer_.getMemoryPool(), compressionParams_.zstdLevel);
     if (compressed.has_value()) {
-      writeChunkHeader(compressed->size(), CompressionType::Zstd, pos);
+      writeChunkHeader(compressed.value()->size(), CompressionType::Zstd, pos);
       return {
           {header, kChunkHeaderSize},
-          buffer_.takeOwnership(compressed->releaseOwnership())};
+          buffer_.takeOwnership(std::move(*compressed))};
     }
   }
 

--- a/dwio/nimble/velox/selective/tests/E2EFilterTest.cpp
+++ b/dwio/nimble/velox/selective/tests/E2EFilterTest.cpp
@@ -29,6 +29,7 @@
 #include "velox/common/caching/AsyncDataCache.h"
 #include "velox/common/caching/FileIds.h"
 #include "velox/common/caching/ScanTracker.h"
+#include "velox/common/io/IoStatistics.h"
 #include "velox/common/memory/MallocAllocator.h"
 #include "velox/dwio/common/CachedBufferedInput.h"
 #include "velox/dwio/common/tests/utils/E2EFilterTestBase.h"
@@ -87,7 +88,8 @@ class E2EFilterTest
           memory::MemoryAllocator::Options{
               .capacity = 512 << 20, .reservationByteLimit = 0});
       cache_ = cache::AsyncDataCache::create(allocator_.get());
-      cacheIoStatistics_ = std::make_shared<io::IoStatistics>();
+      dataIoStats_ = std::make_shared<io::IoStatistics>();
+      metadataIoStats_ = std::make_shared<io::IoStatistics>();
       scanTracker_ = std::make_shared<cache::ScanTracker>(
           "testTracker", nullptr, 256 << 10);
       ioExecutor_ = std::make_unique<folly::CPUThreadPoolExecutor>(10);
@@ -364,9 +366,7 @@ class E2EFilterTest
       StringIdLease fileId(ids, "testFile");
       StringIdLease groupId(ids, "testGroup");
       io::ReaderOptions cacheReaderOpts(
-          &readerOpts.memoryPool(),
-          cacheIoStatistics_.get(),
-          cacheIoStatistics_.get());
+          &readerOpts.memoryPool(), dataIoStats_.get(), metadataIoStats_.get());
       input = std::make_unique<dwio::common::CachedBufferedInput>(
           std::move(readFile),
           dwio::common::MetricsLog::voidLog(),
@@ -374,7 +374,7 @@ class E2EFilterTest
           cache_.get(),
           scanTracker_,
           std::move(groupId),
-          cacheIoStatistics_,
+          dataIoStats_,
           nullptr,
           ioExecutor_.get(),
           cacheReaderOpts);
@@ -401,7 +401,8 @@ class E2EFilterTest
   // Cache infrastructure (only initialized when enableCache is true).
   std::shared_ptr<memory::MallocAllocator> allocator_;
   std::shared_ptr<cache::AsyncDataCache> cache_;
-  std::shared_ptr<io::IoStatistics> cacheIoStatistics_;
+  std::shared_ptr<io::IoStatistics> dataIoStats_;
+  std::shared_ptr<io::IoStatistics> metadataIoStats_;
   std::shared_ptr<cache::ScanTracker> scanTracker_;
   std::unique_ptr<folly::CPUThreadPoolExecutor> ioExecutor_;
 

--- a/dwio/nimble/velox/selective/tests/E2EIndexTest.cpp
+++ b/dwio/nimble/velox/selective/tests/E2EIndexTest.cpp
@@ -27,6 +27,7 @@
 #include "velox/common/caching/AsyncDataCache.h"
 #include "velox/common/caching/FileIds.h"
 #include "velox/common/caching/ScanTracker.h"
+#include "velox/common/io/IoStatistics.h"
 #include "velox/common/memory/MallocAllocator.h"
 #include "velox/common/memory/Memory.h"
 #include "velox/dwio/common/CachedBufferedInput.h"


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebookincubator/velox/pull/17438


CONTEXT: Nimble metadata (stripes, stripe groups, cluster index) is stored compressed on disk and decompressed on every read. There is no process-wide caching of the decompressed metadata — each reader decompresses independently, wasting CPU. Metadata sections are also read individually without IO coalescing.

WHAT:

**FlatBuffers schema:**
- Add `uncompressed_size` field to MetadataSection table, enabling efficient pre-allocation of decompression buffers. Old files read 0 (default) for backward compatibility. The MetadataSection C++ class stores this as `std::optional<uint32_t>` — nullopt for old files, present for new files.

**ZstdCompression:**
- Add uncompress(source, destination, destinationSize) overload for decompressing directly into a caller-provided buffer (zero copy into cache pins).

**MetadataBuffer:**
- Add CachePin storage path alongside the existing BufferPtr path. content() dispatches between the two, enabling zero-copy access to cached metadata.
- Add static decompress() factory methods for BufferPtr and IOBuf inputs.

**MetadataInput:**
- Two-phase IO: enqueue() registers sections and returns a MetadataHandle, load() executes coalesced preadv for all enqueued sections, handle.read() returns the decompressed MetadataBuffer.
- DirectMetadataInput: IO coalescing via velox::coalesceIo, no caching.
- CachedMetadataInput: IO coalescing + AsyncDataCache (memory + SSD tiers). Checks memory cache → SSD cache → file IO. Caches decompressed metadata in contiguous cache entries. For uncompressed sections, reads directly into cache pin buffers (zero copy). For compressed sections, decompresses directly into cache pin buffers.
- QueryIoLatencyGuard RAII class for measuring IO latency.
- Records coalesced IO stats (payload bytes, overread bytes).

**TabletReader integration:**
- Uses MetadataInput for loading stripe group and optional section metadata with IO coalescing.

Reviewed By: Yuhta, tanjialiang

Differential Revision: D102478682


