### PR TITLE
perf: avoid unnecessary dynamic_cast

### DIFF
--- a/dwio/nimble/velox/SchemaReader.cpp
+++ b/dwio/nimble/velox/SchemaReader.cpp
@@ -112,7 +112,7 @@ const ArrayType& Type::asArray() const {
       isArray(),
       "Cannot cast to Array. Current type is {}.",
       getKindName(kind_));
-  return dynamic_cast<const ArrayType&>(*this);
+  return static_cast<const ArrayType&>(*this);
 }
 
 const ArrayWithOffsetsType& Type::asArrayWithOffsets() const {


### PR DESCRIPTION
Summary: Replaced `dynamic_cast<const ArrayType&>(*this)` with `static_cast<const ArrayType&>(*this)` in `Type::asArray()` at line 115 of `fbcode/dwio/nimble/velox/SchemaReader.cpp`. This is safe because the preceding `NIMBLE_CHECK(isArray(), ...)` already validates that `kind_ == Kind::Array`, making the RTTI-based `dynamic_cast` redundant. `static_cast` is resolved at compile time with zero runtime overhead, eliminating the RTTI traversal cost of `dynamic_cast`.

Reviewed By: skrueger

Differential Revision: D102276872


