### PR TITLE
feat(selective): Preserve dictionary vector for pure string dictionary encoded data (#707)

### DIFF
--- a/dwio/nimble/encodings/EncodingUtils.h
+++ b/dwio/nimble/encodings/EncodingUtils.h
@@ -55,17 +55,14 @@ inline int dataTypeSize(DataType type) {
     case DataType::Double:
       return 8;
     default:
-      NIMBLE_UNSUPPORTED(toString(type));
+      NIMBLE_UNSUPPORTED("{}", type);
   }
 }
 
 template <typename F>
 auto encodingTypeDispatchString(Encoding& encoding, F f) {
   NIMBLE_CHECK_EQ(
-      encoding.dataType(),
-      DataType::String,
-      "{}",
-      toString(encoding.dataType()));
+      encoding.dataType(), DataType::String, "{}", encoding.dataType());
   switch (encoding.encodingType()) {
     case EncodingType::Trivial:
       return f(static_cast<TrivialEncoding<std::string_view>&>(encoding));
@@ -83,17 +80,14 @@ auto encodingTypeDispatchString(Encoding& encoding, F f) {
     case EncodingType::Prefix:
       return f(static_cast<PrefixEncoding&>(encoding));
     default:
-      NIMBLE_UNSUPPORTED(toString(encoding.encodingType()));
+      NIMBLE_UNSUPPORTED("{}", encoding.encodingType());
   }
 }
 
 template <typename T, typename F>
 auto encodingTypeDispatchNonString(Encoding& encoding, F&& f) {
   NIMBLE_CHECK_EQ(
-      dataTypeSize(encoding.dataType()),
-      sizeof(T),
-      "{}",
-      toString(encoding.dataType()));
+      dataTypeSize(encoding.dataType()), sizeof(T), "{}", encoding.dataType());
   switch (encoding.encodingType()) {
     case EncodingType::Trivial:
       return f(static_cast<TrivialEncoding<T>&>(encoding));
@@ -109,7 +103,7 @@ auto encodingTypeDispatchNonString(Encoding& encoding, F&& f) {
       if constexpr (std::is_same_v<T, bool>) {
         return f(static_cast<SparseBoolEncoding&>(encoding));
       } else {
-        NIMBLE_UNREACHABLE(toString(encoding.dataType()));
+        NIMBLE_UNREACHABLE("{}", encoding.dataType());
       }
     case EncodingType::Varint:
       if constexpr (folly::IsOneOf<
@@ -122,7 +116,7 @@ auto encodingTypeDispatchNonString(Encoding& encoding, F&& f) {
                         double>::value) {
         return f(static_cast<VarintEncoding<T>&>(encoding));
       } else {
-        NIMBLE_UNREACHABLE(toString(encoding.dataType()));
+        NIMBLE_UNREACHABLE("{}", encoding.dataType());
       }
     case EncodingType::Constant:
       return f(static_cast<ConstantEncoding<T>&>(encoding));
@@ -131,7 +125,7 @@ auto encodingTypeDispatchNonString(Encoding& encoding, F&& f) {
     case EncodingType::Delta:
       return f(static_cast<DeltaEncoding<T>&>(encoding));
     default:
-      NIMBLE_UNSUPPORTED(toString(encoding.encodingType()));
+      NIMBLE_UNSUPPORTED("{}", encoding.encodingType());
   }
 }
 
@@ -180,5 +174,35 @@ struct DefaultEncodingTrait {
     nimble::callReadWithVisitor(encoding, visitor, params);
   }
 };
+
+/// Dispatches readIndicesWithVisitor to the correct encoding type.
+/// Supports DictionaryEncoding and NullableEncoding wrapping Dictionary.
+template <typename V>
+void callReadIndicesWithVisitor(
+    Encoding& encoding,
+    V& visitor,
+    ReadWithVisitorParams& params) {
+  if (encoding.encodingType() == EncodingType::Dictionary) {
+    static_cast<DictionaryEncoding<std::string_view>&>(encoding)
+        .readIndicesWithVisitor(visitor, params);
+  } else if (encoding.encodingType() == EncodingType::Nullable) {
+    static_cast<NullableEncoding<std::string_view>&>(encoding)
+        .readIndicesWithVisitor(visitor, params);
+  } else {
+    NIMBLE_UNREACHABLE(
+        "Dictionary indices dispatch on unsupported encoding: {}",
+        encoding.encodingType());
+  }
+}
+
+/// Extracts the dictionary alphabet from an encoding as a vector of values.
+/// Works through Nullable wrappers via virtual dictionaryEntries().
+template <typename T>
+inline std::vector<T> buildEncodingDictionaryAlphabet(
+    const Encoding* encoding) {
+  const auto size = encoding->dictionarySize();
+  const auto* entries = static_cast<const T*>(encoding->dictionaryEntries());
+  return {entries, entries + size};
+}
 
 } // namespace facebook::nimble

--- a/dwio/nimble/encodings/PrefixEncoding.h
+++ b/dwio/nimble/encodings/PrefixEncoding.h
@@ -72,6 +72,9 @@ class PrefixEncoding final
   static constexpr std::string_view kRestartIntervalConfigKey =
       "prefix-encoding.restart-interval";
 
+  /// Constructs a PrefixEncoding with string buffer factory support.
+  /// Pre-materializes all string data into a factory-allocated buffer,
+  /// ensuring string data outlives the encoding instance.
   PrefixEncoding(
       velox::memory::MemoryPool& pool,
       std::string_view data,

--- a/dwio/nimble/encodings/tests/EncodingTest.cpp
+++ b/dwio/nimble/encodings/tests/EncodingTest.cpp
@@ -32,6 +32,7 @@
 #include "dwio/nimble/encodings/DictionaryEncoding.h"
 #include "dwio/nimble/encodings/EncodingFactory.h"
 #include "dwio/nimble/encodings/EncodingSelectionPolicy.h"
+#include "dwio/nimble/encodings/EncodingUtils.h"
 #include "dwio/nimble/encodings/FixedBitWidthEncoding.h"
 #include "dwio/nimble/encodings/MainlyConstantEncoding.h"
 #include "dwio/nimble/encodings/NullableEncoding.h"
@@ -939,8 +940,8 @@ TYPED_TEST(DictionaryApiTypedTest, nullableBasics) {
     data = {T(1), T(2), T(1), T(3), T(2)};
   }
   nimble::Vector<bool> nulls{this->pool_.get()};
-  for (bool b : {true, true, false, true, true}) {
-    nulls.push_back(b);
+  for (bool null : {true, true, false, true, true}) {
+    nulls.push_back(null);
   }
 
   auto encoding = this->encodeNullableDictionary(data, nulls);
@@ -964,6 +965,43 @@ TYPED_TEST(DictionaryApiTypedTest, nullableBasics) {
   for (uint32_t i = 0; i < 3; ++i) {
     const auto* entry = static_cast<const T*>(encoding->dictionaryEntry(i));
     EXPECT_EQ(*entry, entries[i]);
+  }
+}
+
+// Verifies that dictionary size excludes values that only appear in
+// null-masked rows. "charlie"/T(3) only appears at row 2 which is null,
+// so the dictionary should contain only 2 entries.
+TYPED_TEST(DictionaryApiTypedTest, nullableAlphabetValue) {
+  using T = TypeParam;
+  // Row:  0       1       2         3       4
+  // Data: alpha   bravo   charlie   alpha   bravo
+  // Null: true    true    false     true    true
+  // "charlie" at row 2 is the only occurrence and it's masked by null.
+  std::vector<T> data;
+  if constexpr (std::is_same_v<T, std::string_view>) {
+    data = {"alpha", "bravo", "charlie", "alpha", "bravo"};
+  } else {
+    data = {T(1), T(2), T(3), T(1), T(2)};
+  }
+  nimble::Vector<bool> nulls{this->pool_.get()};
+  for (bool null : {true, true, false, true, true}) {
+    nulls.push_back(null);
+  }
+
+  auto encoding = this->encodeNullableDictionary(data, nulls);
+  ASSERT_TRUE(encoding->isNullable());
+  EXPECT_TRUE(encoding->dictionaryEnabled());
+  // Only "alpha" and "bravo" (or T(1) and T(2)) are non-null entries.
+  EXPECT_EQ(encoding->dictionarySize(), 2);
+
+  const auto* entries = static_cast<const T*>(encoding->dictionaryEntries());
+  ASSERT_NE(entries, nullptr);
+  std::set<T> actualUniques(entries, entries + encoding->dictionarySize());
+  if constexpr (std::is_same_v<T, std::string_view>) {
+    EXPECT_THAT(
+        actualUniques, ::testing::UnorderedElementsAre("alpha", "bravo"));
+  } else {
+    EXPECT_THAT(actualUniques, ::testing::UnorderedElementsAre(T(1), T(2)));
   }
 }
 
@@ -1031,6 +1069,174 @@ TYPED_TEST(DictionaryApiTypedTest, nullableFuzz) {
       const auto* entry = static_cast<const T*>(encoding->dictionaryEntry(i));
       EXPECT_EQ(*entry, entries[i]);
     }
+  }
+}
+
+TYPED_TEST(DictionaryApiTypedTest, buildAlphabet) {
+  using T = TypeParam;
+  std::vector<T> data;
+  if constexpr (std::is_same_v<T, std::string_view>) {
+    data = {"alpha", "bravo", "alpha", "charlie", "bravo"};
+  } else {
+    data = {T(1), T(2), T(1), T(3), T(2)};
+  }
+
+  auto encoding = this->encodeDictionary(data);
+  auto alphabet = nimble::buildEncodingDictionaryAlphabet<T>(encoding.get());
+  EXPECT_EQ(alphabet.size(), 3);
+  std::set<T> actual(alphabet.begin(), alphabet.end());
+  if constexpr (std::is_same_v<T, std::string_view>) {
+    EXPECT_EQ(actual, (std::set<T>{"alpha", "bravo", "charlie"}));
+  } else {
+    EXPECT_EQ(actual, (std::set<T>{T(1), T(2), T(3)}));
+  }
+}
+
+TYPED_TEST(DictionaryApiTypedTest, buildAlphabetNullable) {
+  using T = TypeParam;
+  std::vector<T> data;
+  if constexpr (std::is_same_v<T, std::string_view>) {
+    data = {"alpha", "bravo", "alpha", "charlie", "bravo"};
+  } else {
+    data = {T(1), T(2), T(1), T(3), T(2)};
+  }
+  nimble::Vector<bool> nulls{this->pool_.get()};
+  for (bool null : {true, true, false, true, true}) {
+    nulls.push_back(null);
+  }
+
+  auto encoding = this->encodeNullableDictionary(data, nulls);
+  auto alphabet = nimble::buildEncodingDictionaryAlphabet<T>(encoding.get());
+  EXPECT_EQ(alphabet.size(), 3);
+  std::set<T> actual(alphabet.begin(), alphabet.end());
+  if constexpr (std::is_same_v<T, std::string_view>) {
+    EXPECT_EQ(actual, (std::set<T>{"alpha", "bravo", "charlie"}));
+  } else {
+    EXPECT_EQ(actual, (std::set<T>{T(1), T(2), T(3)}));
+  }
+}
+
+// Verifies that buildEncodingDictionaryAlphabet excludes values that only
+// appear in null-masked rows.
+TYPED_TEST(DictionaryApiTypedTest, buildAlphabetNullableAlphabetValue) {
+  using T = TypeParam;
+  std::vector<T> data;
+  if constexpr (std::is_same_v<T, std::string_view>) {
+    data = {"alpha", "bravo", "charlie", "alpha", "bravo"};
+  } else {
+    data = {T(1), T(2), T(3), T(1), T(2)};
+  }
+  nimble::Vector<bool> nulls{this->pool_.get()};
+  for (bool null : {true, true, false, true, true}) {
+    nulls.push_back(null);
+  }
+
+  auto encoding = this->encodeNullableDictionary(data, nulls);
+  auto alphabet = nimble::buildEncodingDictionaryAlphabet<T>(encoding.get());
+  EXPECT_EQ(alphabet.size(), 2);
+  std::set<T> actual(alphabet.begin(), alphabet.end());
+  if constexpr (std::is_same_v<T, std::string_view>) {
+    EXPECT_EQ(actual, (std::set<T>{"alpha", "bravo"}));
+  } else {
+    EXPECT_EQ(actual, (std::set<T>{T(1), T(2)}));
+  }
+}
+
+TYPED_TEST(DictionaryApiTypedTest, buildAlphabetFuzz) {
+  using T = TypeParam;
+  for (int run = 0; run < 20; ++run) {
+    auto seed = folly::Random::rand32();
+    std::mt19937 rng(seed);
+    const auto numRows = 10 + rng() % 200;
+    const auto cardinality = 2 + rng() % 10;
+
+    if constexpr (std::is_same_v<T, std::string_view>) {
+      this->stringPool_.clear();
+      for (int j = 0; j < cardinality; ++j) {
+        const int len = rng() % 30;
+        std::string s = fmt::format("{}:", j);
+        for (int k = 0; k < len; ++k) {
+          s += static_cast<char>('a' + rng() % 26);
+        }
+        this->stringPool_.push_back(std::move(s));
+      }
+    }
+
+    std::vector<T> data;
+    std::set<T> expectedUniques;
+    data.reserve(numRows);
+    for (int i = 0; i < numRows; ++i) {
+      T val;
+      if constexpr (std::is_same_v<T, std::string_view>) {
+        val = std::string_view(this->stringPool_[rng() % cardinality]);
+      } else {
+        val = static_cast<T>(rng() % cardinality);
+      }
+      data.push_back(val);
+      expectedUniques.insert(val);
+    }
+
+    SCOPED_TRACE(fmt::format("run={} seed={} numRows={}", run, seed, numRows));
+
+    auto encoding = this->encodeDictionary(data);
+    auto alphabet = nimble::buildEncodingDictionaryAlphabet<T>(encoding.get());
+    EXPECT_EQ(alphabet.size(), expectedUniques.size());
+    std::set<T> actual(alphabet.begin(), alphabet.end());
+    EXPECT_EQ(actual, expectedUniques);
+  }
+}
+
+TYPED_TEST(DictionaryApiTypedTest, buildAlphabetNullableFuzz) {
+  using T = TypeParam;
+  for (int run = 0; run < 20; ++run) {
+    auto seed = folly::Random::rand32();
+    std::mt19937 rng(seed);
+    const auto numRows = 10 + rng() % 200;
+    const auto cardinality = 2 + rng() % 10;
+
+    if constexpr (std::is_same_v<T, std::string_view>) {
+      this->stringPool_.clear();
+      for (int j = 0; j < cardinality; ++j) {
+        const int len = rng() % 30;
+        std::string s = fmt::format("{}:", j);
+        for (int k = 0; k < len; ++k) {
+          s += static_cast<char>('a' + rng() % 26);
+        }
+        this->stringPool_.push_back(std::move(s));
+      }
+    }
+
+    std::vector<T> data;
+    nimble::Vector<bool> nulls{this->pool_.get()};
+    std::set<T> expectedUniques;
+    data.reserve(numRows);
+    nulls.reserve(numRows);
+    for (int i = 0; i < numRows; ++i) {
+      bool isNull = (rng() % 5 == 0);
+      nulls.push_back(!isNull);
+      T val;
+      if constexpr (std::is_same_v<T, std::string_view>) {
+        val = std::string_view(this->stringPool_[rng() % cardinality]);
+      } else {
+        val = static_cast<T>(rng() % cardinality);
+      }
+      data.push_back(val);
+      if (!isNull) {
+        expectedUniques.insert(val);
+      }
+    }
+
+    if (expectedUniques.empty()) {
+      continue;
+    }
+
+    SCOPED_TRACE(fmt::format("run={} seed={} numRows={}", run, seed, numRows));
+
+    auto encoding = this->encodeNullableDictionary(data, nulls);
+    auto alphabet = nimble::buildEncodingDictionaryAlphabet<T>(encoding.get());
+    EXPECT_EQ(alphabet.size(), expectedUniques.size());
+    std::set<T> actual(alphabet.begin(), alphabet.end());
+    EXPECT_EQ(actual, expectedUniques);
   }
 }
 

--- a/dwio/nimble/encodings/tests/ReadWithVisitorTest.cpp
+++ b/dwio/nimble/encodings/tests/ReadWithVisitorTest.cpp
@@ -2777,8 +2777,7 @@ TEST_P(ReadWithVisitorTest, readIndicesWithVisitorNullable) {
       visitor(filter, reader, rows, extractValues);
   auto params = makeReadWithVisitorParams(visitor, rows, pool());
 
-  static_cast<NullableEncoding<std::string_view>&>(*encoding)
-      .readIndicesWithVisitor(visitor, params);
+  callReadIndicesWithVisitor(*encoding, visitor, params);
 
   ASSERT_EQ(reader->numValues(), kRows);
   const auto* indices = reader->rawIndices();
@@ -2789,6 +2788,131 @@ TEST_P(ReadWithVisitorTest, readIndicesWithVisitorNullable) {
     ASSERT_GE(indices[i], 0) << "row " << i;
     ASSERT_LT(indices[i], static_cast<int32_t>(alphabetSize)) << "row " << i;
     EXPECT_EQ(alphabet[indices[i]], kAlphabet[i % 3]) << "row " << i;
+  }
+}
+
+// ===========================================================================
+// Test: readIndicesWithVisitor with a value exclusively in null-masked rows.
+// Verifies that the dictionary excludes "delta" which only appears at null
+// positions (rows 0, 4, 8, ...) and that indices correctly map to the
+// 3-entry non-null alphabet.
+// ===========================================================================
+TEST_P(ReadWithVisitorTest, readIndicesWithVisitorNullableAlphabetValue) {
+  if (!useNonLegacy()) {
+    GTEST_SKIP() << "readIndicesWithVisitor requires non-legacy encoding";
+  }
+  constexpr int kRows = 20;
+  // "delta" appears only at rows 0,4,8,12,16 which are all null.
+  // Non-null rows see only "alpha", "bravo", "charlie".
+  constexpr std::string_view kValues[] = {"delta", "alpha", "bravo", "charlie"};
+  auto isNull = [](auto i) { return i % 4 == 0; };
+
+  auto input = makeRowVector({makeFlatVector<StringView>(
+      kRows, [&](auto i) { return StringView(kValues[i % 4]); }, isNull)});
+  auto rowType = asRowType(input->type());
+  auto ctx = makeFileContext(input);
+  auto scanSpec = std::make_shared<common::ScanSpec>("root");
+  scanSpec->addAllChildFields(*rowType);
+  auto root = buildReader(*ctx, rowType, *scanSpec);
+
+  auto* structReader =
+      dynamic_cast<dwio::common::SelectiveStructColumnReaderBase*>(root.get());
+  auto* reader =
+      static_cast<StringColumnReaderTestAccessor*>(structReader->children()[0]);
+  ASSERT_NE(reader, nullptr);
+
+  std::vector<vector_size_t> rowVec(kRows);
+  std::iota(rowVec.begin(), rowVec.end(), 0);
+  RowSet rows(rowVec.data(), rowVec.size());
+  reader->doPrepareReadAsIndices(0, rows, nullptr);
+
+  // Build encoding manually with only non-null values.
+  nimble::Vector<std::string_view> nonNullVec{pool()};
+  for (int i = 0; i < kRows; ++i) {
+    if (!isNull(i)) {
+      nonNullVec.push_back(kValues[i % 4]);
+    }
+  }
+  auto nonNullSpan =
+      std::span<const std::string_view>(nonNullVec.data(), nonNullVec.size());
+  nimble::EncodingSelection<std::string_view> valSelection{
+      {.encodingType = nimble::EncodingType::Dictionary},
+      nimble::Statistics<std::string_view>::create(nonNullSpan),
+      std::make_unique<TrivialNestedPolicy<std::string_view>>()};
+  Buffer valBuffer(*pool());
+  auto serializedValues = nimble::DictionaryEncoding<std::string_view>::encode(
+      valSelection, nonNullSpan, valBuffer);
+
+  nimble::Vector<bool> nullBits{pool()};
+  for (int i = 0; i < kRows; ++i) {
+    nullBits.push_back(!isNull(i));
+  }
+  auto nullSpan = std::span<const bool>(nullBits.data(), nullBits.size());
+  nimble::EncodingSelection<bool> nullSelection{
+      {.encodingType = nimble::EncodingType::Trivial},
+      nimble::Statistics<bool>::create(nullSpan),
+      std::make_unique<TrivialNestedPolicy<bool>>()};
+  Buffer nullBuffer(*pool());
+  auto serializedNulls = nimble::TrivialEncoding<bool>::encode(
+      nullSelection, nullSpan, nullBuffer);
+
+  const uint32_t encodingSize = nimble::Encoding::kPrefixSize + 4 +
+      serializedValues.size() + serializedNulls.size();
+  Buffer assemblyBuffer(*pool());
+  char* reserved = assemblyBuffer.reserve(encodingSize);
+  char* pos = reserved;
+  nimble::encoding::writeChar(
+      static_cast<char>(nimble::EncodingType::Nullable), pos);
+  nimble::encoding::writeChar(static_cast<char>(nimble::DataType::String), pos);
+  nimble::encoding::writeUint32(kRows, pos);
+  nimble::encoding::writeString(serializedValues, pos);
+  nimble::encoding::writeBytes(serializedNulls, pos);
+
+  std::vector<velox::BufferPtr> stringBuffers;
+  auto encoding = nimble::EncodingFactory().create(
+      *pool(), std::string_view(reserved, encodingSize), [&](uint32_t size) {
+        stringBuffers.push_back(
+            velox::AlignedBuffer::allocate<char>(size, pool()));
+        return stringBuffers.back()->asMutable<void>();
+      });
+
+  ASSERT_TRUE(encoding->isNullable());
+  ASSERT_TRUE(encoding->dictionaryEnabled());
+  // Dictionary should have 3 entries (alpha, bravo, charlie), NOT 4.
+  // "delta" only appeared in null rows and was excluded.
+  EXPECT_EQ(encoding->dictionarySize(), 3);
+
+  const auto* alphabet =
+      static_cast<const std::string_view*>(encoding->dictionaryEntries());
+  std::set<std::string_view> alphabetSet(
+      alphabet, alphabet + encoding->dictionarySize());
+  EXPECT_FALSE(alphabetSet.count("delta"))
+      << "Dictionary should not contain null-masked-only value";
+  EXPECT_TRUE(alphabetSet.count("alpha"));
+  EXPECT_TRUE(alphabetSet.count("bravo"));
+  EXPECT_TRUE(alphabetSet.count("charlie"));
+
+  common::AlwaysTrue filter;
+  dwio::common::ExtractToReader extractValues(reader);
+  DecoderVisitor<
+      int32_t,
+      common::AlwaysTrue,
+      dwio::common::ExtractToReader,
+      /*isDense=*/true>
+      visitor(filter, reader, rows, extractValues);
+  auto params = makeReadWithVisitorParams(visitor, rows, pool());
+
+  callReadIndicesWithVisitor(*encoding, visitor, params);
+
+  ASSERT_EQ(reader->numValues(), kRows);
+  const auto* indices = reader->rawIndices();
+  for (int i = 0; i < kRows; ++i) {
+    if (isNull(i)) {
+      continue;
+    }
+    ASSERT_GE(indices[i], 0) << "row " << i;
+    ASSERT_LT(indices[i], 3) << "row " << i;
+    EXPECT_EQ(alphabet[indices[i]], kValues[i % 4]) << "row " << i;
   }
 }
 
@@ -2921,8 +3045,7 @@ TEST_P(ReadWithVisitorTest, fuzzReadIndicesWithVisitorNullable) {
         visitor(filter, reader, rows, extractValues);
     auto params = makeReadWithVisitorParams(visitor, rows, this->pool());
 
-    static_cast<NullableEncoding<std::string_view>&>(*encoding)
-        .readIndicesWithVisitor(visitor, params);
+    callReadIndicesWithVisitor(*encoding, visitor, params);
 
     ASSERT_EQ(reader->numValues(), numRows);
     const auto* indices = reader->rawIndices();

--- a/dwio/nimble/velox/selective/ChunkedDecoder.cpp
+++ b/dwio/nimble/velox/selective/ChunkedDecoder.cpp
@@ -30,6 +30,7 @@ namespace facebook::nimble {
 using namespace facebook::velox;
 
 void ChunkedDecoder::loadNextChunk() {
+  invokeOnChunkLoad();
   auto ret = ensureInput(kChunkHeaderSize);
   NIMBLE_CHECK(ret, "Failed to read chunk header");
   const auto [length, compressionType] = readChunkHeader(inputData_);
@@ -367,6 +368,12 @@ std::optional<size_t> ChunkedDecoder::estimateStringDataSize() const {
   stringDataSizeEstimate_ = Compression::uncompressedSize(
       dataCompressionType, {inputData_ + blobOffset, blobSize});
   return stringDataSizeEstimate_;
+}
+
+bool ChunkedDecoder::dictionaryConvertible() {
+  NIMBLE_CHECK_NOT_NULL(
+      encoding_, "Call ensureLoaded() before dictionaryConvertible()");
+  return encoding_->dictionaryEnabled();
 }
 
 } // namespace facebook::nimble

--- a/dwio/nimble/velox/selective/ChunkedDecoder.h
+++ b/dwio/nimble/velox/selective/ChunkedDecoder.h
@@ -16,7 +16,10 @@
 
 #pragma once
 
+#include "dwio/nimble/common/ChunkHeader.h"
+#include "dwio/nimble/encodings/DictionaryEncoding.h"
 #include "dwio/nimble/encodings/EncodingUtils.h"
+#include "dwio/nimble/encodings/NullableEncoding.h"
 #include "dwio/nimble/encodings/legacy/EncodingTrait.h"
 #include "dwio/nimble/index/ChunkIndexGroup.h"
 #include "dwio/nimble/velox/selective/NimbleData.h"
@@ -48,6 +51,13 @@ class ChunkedDecoder {
     NIMBLE_CHECK_NOT_NULL(encodingFactory_);
   }
 
+  /// Registers a callback invoked whenever loadNextChunk() loads a new chunk.
+  /// Used by StringColumnReader to invalidate dictionary state that is tied
+  /// to the current chunk's encoding and string buffers.
+  void setOnChunkLoad(std::function<void()> callback) {
+    onChunkLoad_ = std::move(callback);
+  }
+
   /// Skip non null values.
   void skip(int64_t numValues);
 
@@ -77,46 +87,61 @@ class ChunkedDecoder {
     const auto numRows = visitor.numRows();
     ReadWithVisitorParams params{};
     bool resultNullsPrepared{false};
-    params.prepareResultNulls = [&] {
+    // Allocate one extra byte (8 bits) for nulls to handle multi-chunk
+    // reading, where each chunk we need to align the result nulls to byte
+    // boundary then shift.
+    params.prepareResultNulls = [&resultNullsPrepared, &visitor, &rows] {
       if (FOLLY_UNLIKELY(!resultNullsPrepared)) {
-        // Allocate one extra byte for nulls to handle multi-chunk reading,
-        // where each chunk we need to align the result nulls to byte boundary
-        // then shift.
-        visitor.reader().prepareNulls(rows, true, 8);
+        visitor.reader().prepareNulls(
+            rows, /*mayResize=*/true, /*extraBits=*/8);
         resultNullsPrepared = true;
       }
     };
-    params.initReturnReaderNulls = [&] {
+    params.initReturnReaderNulls = [&visitor, &rows] {
       visitor.reader().initReturnReaderNulls(rows);
     };
+    bool readerNullsMade{false};
     if (auto& nulls = visitor.reader().nullsInReadRange()) {
+      // For flat map child columns, NimbleData::readNulls() may alias inMap_
+      // and nullsInReadRange_ to the same buffer (when the child has no
+      // separate nulls stream). Since makeReaderNulls() returns a mutable
+      // pointer that NullableEncoding will overwrite with value-level nulls,
+      // we must copy-on-first-write to avoid corrupting the in-map bitmap.
       if (static_cast<const NimbleData&>(visitor.reader().formatData())
               .inMap() == nulls->template as<uint64_t>()) {
-        params.makeReaderNulls = [&, copied = false]() mutable {
-          if (FOLLY_UNLIKELY(!copied)) {
-            // Make a copy to avoid value nulls overwriting in-map buffer.
-            nulls = velox::AlignedBuffer::copy(pool_, nulls);
-            copied = true;
-          }
-          return nulls->template asMutable<uint64_t>();
-        };
+        params.makeReaderNulls =
+            [&readerNullsMade, &nulls, pool = pool_]() mutable {
+              if (FOLLY_UNLIKELY(!readerNullsMade)) {
+                nulls = velox::AlignedBuffer::copy(pool, nulls);
+                readerNullsMade = true;
+              }
+              return nulls->template asMutable<uint64_t>();
+            };
       } else {
-        params.makeReaderNulls = [&nulls] {
+        params.makeReaderNulls = [&readerNullsMade, &nulls] {
+          readerNullsMade = true;
           return nulls->template asMutable<uint64_t>();
         };
       }
       dispatchReadWithVisitorImpl<true>(
           visitor, nulls->template as<uint64_t>(), params);
     } else {
-      params.makeReaderNulls = [this, numRows, &visitor] {
-        auto& nulls = visitor.reader().nullsInReadRange();
-        if (FOLLY_UNLIKELY(!nulls)) {
-          nulls = velox::AlignedBuffer::allocate<bool>(
-              visitor.rowAt(numRows - 1) + 1, pool_, velox::bits::kNotNull);
+      params.makeReaderNulls = [&readerNullsMade, this, numRows, &visitor] {
+        if (FOLLY_UNLIKELY(!readerNullsMade)) {
+          auto& nulls = visitor.reader().nullsInReadRange();
+          if (!nulls) {
+            nulls = velox::AlignedBuffer::allocate<bool>(
+                visitor.rowAt(numRows - 1) + 1,
+                pool_,
+                /*value=*/velox::bits::kNotNull);
+          }
+          readerNullsMade = true;
         }
-        return nulls->template asMutable<uint64_t>();
+        return visitor.reader()
+            .nullsInReadRange()
+            ->template asMutable<uint64_t>();
       };
-      dispatchReadWithVisitorImpl<false>(visitor, nullptr, params);
+      dispatchReadWithVisitorImpl<false>(visitor, /*nulls=*/nullptr, params);
     }
   }
 
@@ -187,20 +212,170 @@ class ChunkedDecoder {
     }
   }
 
-  // A temporary solution to estimate row size before column statistics are
-  // implemented.  This is based on the first chunk so is only accurate when
-  // there is a single chunk in the stripe, or all the first chunks of all
-  // streams are aligned at the same row count (unlikely).
-  //
-  // TODO: Remove after column statistics are added.
+  /// A temporary solution to estimate row size before column statistics are
+  /// implemented.  This is based on the first chunk so is only accurate when
+  /// there is a single chunk in the stripe, or all the first chunks of all
+  /// streams are aligned at the same row count (unlikely).
+  ///
+  /// TODO: Remove after column statistics are added.
   std::optional<size_t> estimateRowCount() const;
 
-  // A temporary solution to estimate row size, similar to estimateRowCount().
-  //
-  // TODO: Remove after column statistics are added.
+  /// A temporary solution to estimate row size, similar to estimateRowCount().
+  ///
+  /// TODO: Remove after column statistics are added.
   std::optional<size_t> estimateStringDataSize() const;
 
+  /// Ensures a chunk with remaining values is loaded. Loads the first chunk
+  /// if none has been loaded yet, or advances to the next chunk if the current
+  /// one is fully consumed. Called before inspecting the current encoding
+  /// (e.g., dictionaryConvertible, currentEncoding) so that the caller sees
+  /// the encoding and remainingValues of the chunk that will actually be read.
+  void ensureLoaded() {
+    if (encoding_ != nullptr && remainingValues_ != 0) {
+      return;
+    }
+
+    if (hasMoreChunks()) {
+      loadNextChunk();
+    }
+  }
+
+  /// Returns the current encoding, or nullptr if no chunk has been loaded yet.
+  const Encoding* currentEncoding() const {
+    return encoding_.get();
+  }
+
+  /// Returns true if the current chunk's encoding is convertible to dictionary
+  /// indices (Dictionary or Nullable wrapping Dictionary).
+  /// Caller must call ensureLoaded() first.
+  bool dictionaryConvertible();
+
+  int64_t remainingValues() const {
+    return remainingValues_;
+  }
+
+  /// Reads dictionary indices from the current chunk's encoding.
+  /// Non-legacy encodings only: requires stringDecoderZeroCopy_ == true.
+  template <typename DictionaryVisitor>
+  void readDictionaryIndices(DictionaryVisitor& visitor) {
+    NIMBLE_CHECK(
+        stringDecoderZeroCopy_,
+        "Dictionary indices reading requires non-legacy encoding path");
+    const velox::RowSet rows(visitor.rows(), visitor.numRows());
+    NIMBLE_DCHECK(std::is_sorted(rows.begin(), rows.end()));
+    ReadWithVisitorParams params{};
+    bool resultNullsPrepared{false};
+    // Allocate one extra byte (8 bits) for nulls to handle multi-chunk
+    // reading, where each chunk we need to align the result nulls to byte
+    // boundary then shift.
+    params.prepareResultNulls = [&resultNullsPrepared, &visitor, &rows] {
+      if (FOLLY_UNLIKELY(!resultNullsPrepared)) {
+        visitor.reader().prepareNulls(
+            rows, /*mayResize=*/true, /*extraBits=*/8);
+        resultNullsPrepared = true;
+      }
+    };
+    params.initReturnReaderNulls = [&visitor, &rows] {
+      visitor.reader().initReturnReaderNulls(rows);
+    };
+    bool readerNullsMade{false};
+    if (auto& nulls = visitor.reader().nullsInReadRange()) {
+      // For flat map child columns, NimbleData::readNulls() may alias inMap_
+      // and nullsInReadRange_ to the same buffer (when the child has no
+      // separate nulls stream). Since makeReaderNulls() returns a mutable
+      // pointer that NullableEncoding will overwrite with value-level nulls,
+      // we must copy-on-first-write to avoid corrupting the in-map bitmap.
+      if (static_cast<const NimbleData&>(visitor.reader().formatData())
+              .inMap() == nulls->template as<uint64_t>()) {
+        params.makeReaderNulls =
+            [&readerNullsMade, &nulls, pool = pool_]() mutable {
+              if (FOLLY_UNLIKELY(!readerNullsMade)) {
+                nulls = velox::AlignedBuffer::copy(pool, nulls);
+                readerNullsMade = true;
+              }
+              return nulls->template asMutable<uint64_t>();
+            };
+      } else {
+        params.makeReaderNulls = [&readerNullsMade, &nulls] {
+          readerNullsMade = true;
+          return nulls->template asMutable<uint64_t>();
+        };
+      }
+      readDictionaryIndicesImpl<true>(
+          visitor, nulls->template as<uint64_t>(), params);
+    } else {
+      params.makeReaderNulls = [&readerNullsMade, this, &visitor] {
+        if (FOLLY_UNLIKELY(!readerNullsMade)) {
+          auto& nulls = visitor.reader().nullsInReadRange();
+          if (!nulls) {
+            nulls = velox::AlignedBuffer::allocate<bool>(
+                visitor.rowAt(visitor.numRows() - 1) + 1,
+                pool_,
+                /*value=*/velox::bits::kNotNull);
+          }
+          readerNullsMade = true;
+        }
+        return visitor.reader()
+            .nullsInReadRange()
+            ->template asMutable<uint64_t>();
+      };
+      readDictionaryIndicesImpl<false>(visitor, /*nulls=*/nullptr, params);
+    }
+  }
+
  private:
+  // For regular cases, kHasNulls is false because NullableEncoding handles
+  // the nulls from the outside. But when dealing with flatmap types, inMap
+  // streams are not part of the data stream but interact with the value
+  // streams just like nulls. Not using this parameter causes a bug for
+  // flatmap data shapes.
+  template <bool kHasNulls, typename V>
+  void readDictionaryIndicesImpl(
+      V& visitor,
+      const uint64_t* nulls,
+      ReadWithVisitorParams& params) {
+    constexpr bool kExtractToReader = std::
+        is_same_v<typename V::Extract, velox::dwio::common::ExtractToReader>;
+    NIMBLE_CHECK_GT(remainingValues_, 0);
+    params.numScanned = 0;
+    const auto numRows = visitor.numRows();
+    velox::vector_size_t numNulls{0};
+    velox::vector_size_t numNonNulls{0};
+    const auto endRowIndex = computeNextRowIndex<kHasNulls>(
+        visitor, nulls, params, numRows, numNulls, numNonNulls);
+    if (visitor.rowIndex() < endRowIndex) {
+      visitor.setRows(velox::RowSet(visitor.rows(), endRowIndex));
+      if (numNonNulls > 0) {
+        callReadIndicesWithVisitor(*encoding_, visitor, params);
+      } else if (!visitor.allowNulls()) {
+        visitor.setRowIndex(endRowIndex);
+      } else {
+        bool emitNullsRowByRow = true;
+        if constexpr (kExtractToReader) {
+          params.prepareResultNulls();
+          if (visitor.reader().returnReaderNulls()) {
+            auto numValues = endRowIndex - visitor.rowIndex();
+            visitor.setRowIndex(endRowIndex);
+            visitor.addNumValues(numValues);
+            emitNullsRowByRow = false;
+          }
+        }
+        if (emitNullsRowByRow) {
+          bool atEnd = false;
+          while (!atEnd) {
+            visitor.processNull(atEnd);
+          }
+        }
+      }
+    }
+    advancePosition(numNonNulls);
+    params.numScanned += numNulls + numNonNulls;
+    if (stringDecoderZeroCopy_) {
+      visitor.reader().setStringBuffers(
+          {currentStringBuffers_.begin(), currentStringBuffers_.end()});
+    }
+  }
+
   template <bool kHasMask>
   bool testNulls(
       const uint64_t* nulls,
@@ -333,36 +508,38 @@ class ChunkedDecoder {
       }
       velox::vector_size_t numNulls;
       velox::vector_size_t numNonNulls;
-      const auto nextRowIndex = computeNextRowIndex<kHasNulls>(
+      const auto endRowIndex = computeNextRowIndex<kHasNulls>(
           visitor, nulls, params, numRows, numNulls, numNonNulls);
       VLOG(1) << visitor.reader().fileType().fullName() << ":"
               << " rowIndex=" << visitor.rowIndex()
-              << " nextRowIndex=" << nextRowIndex << " numNulls=" << numNulls
+              << " endRowIndex=" << endRowIndex << " numNulls=" << numNulls
               << " numNonNulls=" << numNonNulls
               << " remainingValues_=" << remainingValues_;
-      if (visitor.rowIndex() < nextRowIndex) {
-        visitor.setRows(velox::RowSet(visitor.rows(), nextRowIndex));
+      if (visitor.rowIndex() < endRowIndex) {
+        visitor.setRows(velox::RowSet(visitor.rows(), endRowIndex));
         if (numNonNulls > 0) {
           EncodingTrait::callReadWithVisitor(*encoding_, visitor, params);
         } else if (!visitor.allowNulls()) {
-          visitor.setRowIndex(nextRowIndex);
+          visitor.setRowIndex(endRowIndex);
         } else {
+          bool emitNullsRowByRow = true;
           if constexpr (kExtractToReader) {
             params.prepareResultNulls();
             if (visitor.reader().returnReaderNulls()) {
-              auto numValues = nextRowIndex - visitor.rowIndex();
-              visitor.setRowIndex(nextRowIndex);
+              auto numValues = endRowIndex - visitor.rowIndex();
+              visitor.setRowIndex(endRowIndex);
               visitor.addNumValues(numValues);
-              goto updateRemainingValues;
+              emitNullsRowByRow = false;
             }
           }
-          bool atEnd = false;
-          while (!atEnd) {
-            visitor.processNull(atEnd);
+          if (emitNullsRowByRow) {
+            bool atEnd = false;
+            while (!atEnd) {
+              visitor.processNull(atEnd);
+            }
           }
         }
-      updateRemainingValues:
-        NIMBLE_DCHECK_EQ(visitor.rowIndex(), nextRowIndex);
+        NIMBLE_CHECK_EQ(visitor.rowIndex(), endRowIndex);
       }
       advancePosition(numNonNulls);
       params.numScanned += numNulls + numNonNulls;
@@ -381,6 +558,12 @@ class ChunkedDecoder {
     }
   }
 
+  // Returns true if the input stream has at least one more chunk header
+  // available, indicating that loadNextChunk() can be called.
+  bool hasMoreChunks() {
+    return ensureInput(kChunkHeaderSize);
+  }
+
   // Ensures that the input buffer has at least 'size' bytes available for
   // reading. If the current buffer doesn't have enough data, this method will
   // read more data from the underlying input stream until the requirement is
@@ -391,6 +574,12 @@ class ChunkedDecoder {
 
   // TODO: remove with row size estimate hacks.
   bool ensureInputIncremental_hack(int size, const char*& pos);
+
+  void invokeOnChunkLoad() {
+    if (onChunkLoad_) {
+      onChunkLoad_();
+    }
+  }
 
   void loadNextChunk();
 
@@ -453,6 +642,10 @@ class ChunkedDecoder {
 
   // Tracks the current row position in the stream.
   uint32_t rowPosition_{0};
+
+  // Callback invoked at the start of loadNextChunk(). Used by
+  // StringColumnReader to invalidate dictionary state on chunk transitions.
+  std::function<void()> onChunkLoad_;
 
   friend class ChunkedDecoderTestHelper;
 };

--- a/dwio/nimble/velox/selective/StringColumnReader.cpp
+++ b/dwio/nimble/velox/selective/StringColumnReader.cpp
@@ -17,7 +17,9 @@
 #include "dwio/nimble/velox/selective/StringColumnReader.h"
 
 #include "dwio/nimble/encodings/legacy/EncodingUtils.h"
+#include "velox/common/testutil/TestValue.h"
 #include "velox/dwio/common/SelectiveColumnReaderInternal.h"
+#include "velox/vector/DictionaryVector.h"
 
 namespace facebook::nimble {
 
@@ -29,21 +31,114 @@ uint64_t StringColumnReader::skip(uint64_t numValues) {
   return numValues;
 }
 
+void StringColumnReader::ensureDictionaryState() {
+  if (hasDictionaryState()) {
+    return;
+  }
+  // Invalidate dictionary state when a new chunk is loaded, since the new
+  // chunk may have a different encoding or dictionary alphabet.
+  decoder_.setOnChunkLoad([this] { dictionaryState_.clear(); });
+  dictionaryState_.alphabet = buildEncodingDictionaryAlphabet<std::string_view>(
+      decoder_.currentEncoding());
+}
+
+bool StringColumnReader::readWithDictionary(
+    int64_t offset,
+    const RowSet& rows,
+    const uint64_t* incomingNulls) {
+  // Dictionary path requires: no filter pushdown, no value hook, non-legacy
+  // encoding path (zero-copy), single-chunk read, and dictionary-convertible
+  // encoding.
+  if (scanSpec_->hasFilter() || scanSpec_->valueHook() ||
+      !formatData().stringDecoderZeroCopy()) {
+    return false;
+  }
+  decoder_.ensureLoaded();
+  const auto numRequestedRows = rows.back() + 1;
+  // The decoder must have enough remaining values in the current chunk to
+  // cover both the skip (from readOffset_ to offset, executed by prepareRead
+  // → seekTo → skip) and the read range (rows 0 through rows.back()). If
+  // this total exceeds remainingValues, the skip or read would cross a chunk
+  // boundary, invalidating the dictionary state built below.
+  const auto numValuesNeeded = offset - readOffset_ + numRequestedRows;
+  if (decoder_.remainingValues() < numValuesNeeded ||
+      !decoder_.dictionaryConvertible()) {
+    return false;
+  }
+  // NOTE: ensureDictionaryState must move back after readDictionaryIndices
+  // when nested encodings (MC, RLE) are supported, since the dictionary
+  // alphabet may not be available until the encoding is actually read.
+  ensureDictionaryState();
+  velox::common::testutil::TestValue::adjust(
+      "facebook::nimble::StringColumnReader::readWithDictionary",
+      &dictionaryState_.alphabet);
+  prepareRead<int32_t>(offset, rows, incomingNulls);
+  dwio::common::StringColumnReadWithVisitorHelper<
+      /*kEncodingHasNulls=*/false,
+      /*kDictionary=*/true>(*this, rows)([&](auto visitor) {
+    auto dictVisitor = visitor.toStringDictionaryColumnVisitor();
+    decoder_.readDictionaryIndices(dictVisitor);
+  });
+  readOffset_ += numRequestedRows;
+  return true;
+}
+
 void StringColumnReader::read(
     int64_t offset,
     const RowSet& rows,
     const uint64_t* incomingNulls) {
+  if (readWithDictionary(offset, rows, incomingNulls)) {
+    return;
+  }
+  dictionaryState_.clear();
   prepareRead<std::string_view>(offset, rows, incomingNulls);
-  dwio::common::StringColumnReadWithVisitorHelper<false, false>(
+  dwio::common::StringColumnReadWithVisitorHelper<
+      /*kEncodingHasNulls=*/false,
+      /*kDictionary=*/false>(
       *this, rows)([&](auto visitor) { decoder_.readWithVisitor(visitor); });
   readOffset_ += rows.back() + 1;
 }
 
+void StringColumnReader::ensureAlphabetVector() {
+  if (dictionaryState_.alphabetVector != nullptr) {
+    return;
+  }
+  const auto alphabetSize =
+      static_cast<vector_size_t>(dictionaryState_.alphabet.size());
+  auto values = AlignedBuffer::allocate<StringView>(alphabetSize, pool_);
+  auto* rawValues = values->asMutable<StringView>();
+  for (vector_size_t i = 0; i < alphabetSize; ++i) {
+    rawValues[i] = StringView(
+        dictionaryState_.alphabet[i].data(),
+        dictionaryState_.alphabet[i].size());
+  }
+  auto buffers = stringBuffers_;
+  dictionaryState_.alphabetVector = std::make_shared<FlatVector<StringView>>(
+      pool_,
+      fileType_->type(),
+      BufferPtr(nullptr),
+      alphabetSize,
+      std::move(values),
+      std::move(buffers));
+}
+
 void StringColumnReader::getValues(const RowSet& rows, VectorPtr* result) {
-  rawStringBuffer_ = nullptr;
-  rawStringSize_ = 0;
-  rawStringUsed_ = 0;
-  getFlatValues<StringView, StringView>(rows, result, fileType_->type());
+  if (hasDictionaryState()) {
+    compactScalarValues<int32_t, int32_t>(rows, /*isFinal=*/false);
+    ensureAlphabetVector();
+
+    *result = std::make_shared<DictionaryVector<StringView>>(
+        pool_,
+        resultNulls(),
+        numValues_,
+        dictionaryState_.alphabetVector,
+        values_);
+  } else {
+    rawStringBuffer_ = nullptr;
+    rawStringSize_ = 0;
+    rawStringUsed_ = 0;
+    getFlatValues<StringView, StringView>(rows, result, fileType_->type());
+  }
 }
 
 bool StringColumnReader::estimateMaterializedSize(

--- a/dwio/nimble/velox/selective/StringColumnReader.h
+++ b/dwio/nimble/velox/selective/StringColumnReader.h
@@ -16,6 +16,7 @@
 
 #pragma once
 
+#include <vector>
 #include "dwio/nimble/velox/selective/ChunkedDecoder.h"
 #include "velox/dwio/common/SelectiveColumnReader.h"
 
@@ -44,11 +45,45 @@ class StringColumnReader : public velox::dwio::common::SelectiveColumnReader {
       const override;
 
  protected:
+  // Cached dictionary alphabet and materialized vector for the current chunk's
+  // encoding. Cleared on chunk transitions via the onChunkLoad callback.
+  struct DictionaryState {
+    // Raw alphabet entries extracted from the encoding's dictionary.
+    std::vector<std::string_view> alphabet;
+    // Materialized FlatVector wrapping alphabet for DictionaryVector output.
+    velox::VectorPtr alphabetVector;
+
+    void clear() {
+      alphabet.clear();
+      alphabetVector.reset();
+    }
+  };
+
   ChunkedDecoder decoder_;
+  DictionaryState dictionaryState_;
 
  private:
   bool readsNullsOnly() const final {
     return false;
+  }
+
+  // Populates dictionaryState_ from the current chunk's encoding if not
+  // already set. Registers the onChunkLoad callback on first call.
+  void ensureDictionaryState();
+
+  // Materializes the alphabet FlatVector from dictionaryState_.alphabet
+  // for use in DictionaryVector output.
+  void ensureAlphabetVector();
+
+  // Attempts to read using the dictionary index path. Returns true if the
+  // dict path was taken, false if the caller should fall back to flat read.
+  bool readWithDictionary(
+      int64_t offset,
+      const velox::RowSet& rows,
+      const uint64_t* incomingNulls);
+
+  bool hasDictionaryState() const {
+    return !dictionaryState_.alphabet.empty();
   }
 };
 

--- a/dwio/nimble/velox/selective/tests/ChunkedDecoderTest.cpp
+++ b/dwio/nimble/velox/selective/tests/ChunkedDecoderTest.cpp
@@ -1339,6 +1339,109 @@ TEST_F(ChunkedDecoderDataTest, fuzzer) {
   }
 }
 
+TEST_P(ChunkedDecoderDataTest, ensureLoadedAndAccessors) {
+  auto [streamData, chunkInfos] =
+      encodeChunkedStream<uint32_t>({{1, 2, 3, 4, 5}});
+  auto streamIndex = createTestStreamIndex(chunkInfos);
+  auto input = std::make_unique<velox::dwio::common::SeekableArrayInputStream>(
+      streamData.data(), streamData.size());
+  ChunkedDecoder decoder(
+      std::move(input),
+      streamIndex,
+      false,
+      &encodingFactory(),
+      pool_.get(),
+      true);
+
+  EXPECT_EQ(decoder.currentEncoding(), nullptr);
+  EXPECT_EQ(decoder.remainingValues(), 0);
+
+  decoder.ensureLoaded();
+
+  ASSERT_NE(decoder.currentEncoding(), nullptr);
+  EXPECT_EQ(decoder.remainingValues(), 5);
+  EXPECT_FALSE(decoder.dictionaryConvertible());
+}
+
+TEST_P(ChunkedDecoderDataTest, onChunkLoadCallback) {
+  auto [streamData, chunkInfos] =
+      encodeChunkedStream<uint32_t>({{1, 2, 3}, {4, 5, 6}});
+  auto streamIndex = createTestStreamIndex(chunkInfos);
+  auto input = std::make_unique<velox::dwio::common::SeekableArrayInputStream>(
+      streamData.data(), streamData.size());
+  ChunkedDecoder decoder(
+      std::move(input), streamIndex, false, &encodingFactory(), pool_.get());
+
+  int callbackCount = 0;
+  decoder.setOnChunkLoad([&] { ++callbackCount; });
+
+  decoder.ensureLoaded();
+  EXPECT_EQ(callbackCount, 1);
+
+  // Skip past chunk 1 (3 values) into chunk 2, triggering a second load.
+  decoder.skip(4);
+  EXPECT_EQ(callbackCount, 2);
+}
+
+TEST_P(ChunkedDecoderDataTest, hasMoreChunks) {
+  auto [streamData, chunkInfos] =
+      encodeChunkedStream<uint32_t>({{1, 2, 3}, {4, 5}});
+  auto streamIndex = createTestStreamIndex(chunkInfos);
+  auto input = std::make_unique<velox::dwio::common::SeekableArrayInputStream>(
+      streamData.data(), streamData.size());
+  ChunkedDecoder decoder(
+      std::move(input), streamIndex, false, &encodingFactory(), pool_.get());
+
+  // Before any load, there are chunks available.
+  decoder.ensureLoaded();
+  EXPECT_EQ(decoder.remainingValues(), 3);
+
+  // Skip all of chunk 1. Chunk 2 is not yet loaded but available.
+  decoder.skip(3);
+  EXPECT_EQ(decoder.remainingValues(), 0);
+
+  // ensureLoaded reloads when exhausted and more chunks exist.
+  decoder.ensureLoaded();
+  EXPECT_EQ(decoder.remainingValues(), 2);
+
+  // Skip all of chunk 2. No more chunks available.
+  decoder.skip(2);
+  EXPECT_EQ(decoder.remainingValues(), 0);
+
+  // ensureLoaded is a no-op when no more chunks exist.
+  decoder.ensureLoaded();
+  EXPECT_EQ(decoder.remainingValues(), 0);
+}
+
+// Verifies that ensureLoaded fires onChunkLoad when reloading an exhausted
+// chunk, allowing the caller to invalidate cached state.
+TEST_P(ChunkedDecoderDataTest, ensureLoadedFiresOnChunkLoadOnReload) {
+  auto [streamData, chunkInfos] =
+      encodeChunkedStream<uint32_t>({{1, 2, 3}, {4, 5, 6}});
+  auto streamIndex = createTestStreamIndex(chunkInfos);
+  auto input = std::make_unique<velox::dwio::common::SeekableArrayInputStream>(
+      streamData.data(), streamData.size());
+  ChunkedDecoder decoder(
+      std::move(input), streamIndex, false, &encodingFactory(), pool_.get());
+
+  int callbackCount = 0;
+  decoder.setOnChunkLoad([&] { ++callbackCount; });
+
+  // First load.
+  decoder.ensureLoaded();
+  EXPECT_EQ(callbackCount, 1);
+  EXPECT_EQ(decoder.remainingValues(), 3);
+
+  // Consume chunk 1.
+  decoder.skip(3);
+  EXPECT_EQ(decoder.remainingValues(), 0);
+
+  // ensureLoaded reloads chunk 2, firing the callback.
+  decoder.ensureLoaded();
+  EXPECT_EQ(callbackCount, 2);
+  EXPECT_EQ(decoder.remainingValues(), 3);
+}
+
 } // namespace
 
 } // namespace facebook::nimble

--- a/dwio/nimble/velox/selective/tests/E2EFilterTest.cpp
+++ b/dwio/nimble/velox/selective/tests/E2EFilterTest.cpp
@@ -347,6 +347,13 @@ class E2EFilterTest
       options.clusterIndexConfig = std::move(clusterIndexConfig);
     }
     auto writeFile = std::make_unique<InMemoryWriteFile>(&sinkData_);
+    // Branch on whether we need forced dictionary encoding, since
+    // EncodingLayoutTree is not move-assignable due to const members.
+    if (useForcedDictionaryEncoding_) {
+      // Need to set encodingLayoutTree at construction time.
+      options.encodingLayoutTree.emplace(
+          buildForcedDictionaryEncodingLayoutTree());
+    }
     VeloxWriter writer(
         writeSchema_, std::move(writeFile), *rootPool_, std::move(options));
     for (auto& batch : batches) {
@@ -387,6 +394,50 @@ class E2EFilterTest
   folly::F14FastMap<std::string, std::set<std::string>> flatMapColumns_;
   folly::F14FastSet<std::string> deduplicatedArrayColumns_;
   folly::F14FastSet<std::string> deduplicatedMapColumns_;
+  // When true, forces dictionary encoding for string columns via
+  // EncodingLayoutTree. This is useful for testing nested encoding scenarios
+  // where dictionary is not at the top level (e.g., Nullable -> Dictionary).
+  bool useForcedDictionaryEncoding_{false};
+
+  // Builds an encoding layout tree that forces dictionary encoding for string
+  // columns. When data has nulls, the writer will wrap this with nullable
+  // encoding, creating a Nullable -> Dictionary nesting.
+  EncodingLayoutTree buildForcedDictionaryEncodingLayoutTree() {
+    std::vector<EncodingLayoutTree> children;
+    for (column_index_t i = 0;
+         i < static_cast<column_index_t>(rowType_->size());
+         ++i) {
+      const auto& childType = rowType_->childAt(i);
+      const auto& childName = rowType_->nameOf(i);
+
+      if (childType->isVarchar() || childType->isVarbinary()) {
+        // Dictionary has two sub-encodings: Alphabet (id=0) and Indices (id=1).
+        // Specify nullopt for both to let the writer decide their encodings.
+        // Without these children, the layout replay fails with
+        // "Sub-encoding identifier out of range" when the writer creates
+        // Dictionary's sub-encoding selection policies.
+        children.push_back(
+            EncodingLayoutTree{
+                Kind::Scalar,
+                {{EncodingLayoutTree::StreamIdentifiers::Scalar::ScalarStream,
+                  EncodingLayout{
+                      EncodingType::Dictionary,
+                      {},
+                      CompressionType::Uncompressed,
+                      {
+                          // Alphabet (id=0): let writer decide
+                          std::nullopt,
+                          // Indices (id=1): let writer decide
+                          std::nullopt,
+                      }}}},
+                std::string(childName)});
+      } else {
+        children.push_back(
+            EncodingLayoutTree{Kind::Scalar, {}, std::string(childName)});
+      }
+    }
+    return EncodingLayoutTree{Kind::Row, {}, "", std::move(children)};
+  }
 
   // Optional encoding factors for ManualEncodingSelectionPolicyFactory.
   // When set, writeToMemory will use these factors instead of the default
@@ -1685,6 +1736,519 @@ TEST_P(PrefixEncodingE2ETest, filterOnString) {
         /*numCombinations=*/5,
         withRecursiveNulls);
   }
+}
+
+// Test for cross-stripe reading of string data with filters.
+// This tests that dictionary column visitors work correctly when reading
+// across multiple stripes, where the dictionary may change between stripes.
+TEST_P(E2EFilterTest, stringDictionaryAcrossStripes) {
+  // Use frequent stripe flushes to maximize cross-stripe reads.
+  flushEveryNBatches_ = 1;
+  for (bool withRecursiveNulls : {false, true}) {
+    SCOPED_TRACE(fmt::format("withRecursiveNulls={}", withRecursiveNulls));
+    testWithTypes(
+        "string_val:string,"
+        "string_val_2:string,"
+        "long_val:bigint",
+        [&]() {
+          makeStringDistribution("string_val", 100, true, false);
+          makeStringDistribution("string_val_2", 170, false, true);
+        },
+        /*wrapInStruct=*/false,
+        {"string_val", "long_val"},
+        /*numCombinations=*/5,
+        withRecursiveNulls);
+  }
+}
+
+TEST_P(E2EFilterTest, stringUniqueAcrossStripes) {
+  // Use frequent stripe flushes to maximize cross-stripe reads.
+  flushEveryNBatches_ = 1;
+  for (bool withRecursiveNulls : {false, true}) {
+    SCOPED_TRACE(fmt::format("withRecursiveNulls={}", withRecursiveNulls));
+    testWithTypes(
+        "string_val:string,"
+        "string_val_2:string,"
+        "long_val:bigint",
+        [&]() {
+          makeStringUnique("string_val");
+          makeStringUnique("string_val_2");
+        },
+        /*wrapInStruct=*/false,
+        {"string_val", "long_val"},
+        /*numCombinations=*/5,
+        withRecursiveNulls);
+  }
+}
+
+// Test for nested encodings where dictionary encoding is NOT at the top level.
+// This tests scenarios like Nullable -> Dictionary, which may have different
+// behavior than Dictionary at the top level.
+TEST_P(E2EFilterTest, stringDictionaryNestedUnderNullable) {
+  // Force dictionary encoding for string columns via encoding layout.
+  useForcedDictionaryEncoding_ = true;
+  for (bool withRecursiveNulls : {false, true}) {
+    SCOPED_TRACE(fmt::format("withRecursiveNulls={}", withRecursiveNulls));
+    testWithTypes(
+        "string_val:string,"
+        "string_val_2:string,"
+        "long_val:bigint",
+        [&]() {
+          makeStringDistribution("string_val", 100, true, false);
+          makeStringDistribution("string_val_2", 170, false, true);
+        },
+        /*wrapInStruct=*/false,
+        {"string_val", "long_val"},
+        /*numCombinations=*/5,
+        withRecursiveNulls);
+  }
+}
+
+TEST_P(E2EFilterTest, filterOnNestedDictionaryString) {
+  // Force dictionary encoding for string columns via encoding layout.
+  useForcedDictionaryEncoding_ = true;
+  for (bool withRecursiveNulls : {false, true}) {
+    SCOPED_TRACE(fmt::format("withRecursiveNulls={}", withRecursiveNulls));
+    testWithTypes(
+        "string_val:string,"
+        "string_val_2:string,"
+        "long_val:bigint",
+        [&]() {
+          makeStringDistribution("string_val", 50, true, true);
+          makeStringDistribution("string_val_2", 80, true, false);
+        },
+        /*wrapInStruct=*/false,
+        {"string_val", "string_val_2", "long_val"},
+        /*numCombinations=*/5,
+        withRecursiveNulls);
+  }
+}
+
+// Test combining cross-stripe reading with nested dictionary encodings.
+// This is the most challenging scenario for dictionary column visitors.
+TEST_P(E2EFilterTest, stringDictionaryCrossStripeWithNestedEncoding) {
+  // Use both frequent stripe flushes and forced dictionary encoding.
+  flushEveryNBatches_ = 1;
+  useForcedDictionaryEncoding_ = true;
+  for (bool withRecursiveNulls : {false, true}) {
+    SCOPED_TRACE(fmt::format("withRecursiveNulls={}", withRecursiveNulls));
+    testWithTypes(
+        "string_val:string,"
+        "string_val_2:string,"
+        "long_val:bigint",
+        [&]() {
+          makeStringDistribution("string_val", 100, true, false);
+          makeStringDistribution("string_val_2", 170, false, true);
+        },
+        /*wrapInStruct=*/false,
+        {"string_val", "long_val"},
+        /*numCombinations=*/5,
+        withRecursiveNulls);
+  }
+}
+
+TEST_P(E2EFilterTest, stringFilterOnBothColumnsCrossStripeNested) {
+  // Use both frequent stripe flushes and forced dictionary encoding.
+  flushEveryNBatches_ = 1;
+  useForcedDictionaryEncoding_ = true;
+  for (bool withRecursiveNulls : {false, true}) {
+    SCOPED_TRACE(fmt::format("withRecursiveNulls={}", withRecursiveNulls));
+    testWithTypes(
+        "string_val:string,"
+        "string_val_2:string,"
+        "long_val:bigint",
+        [&]() {
+          makeStringDistribution("string_val", 50, true, true);
+          makeStringDistribution("string_val_2", 80, true, false);
+        },
+        /*wrapInStruct=*/false,
+        {"string_val", "string_val_2", "long_val"},
+        /*numCombinations=*/5,
+        withRecursiveNulls);
+  }
+}
+
+// Test for nested encoding where dictionary is not at the top level.
+// This test creates a MainlyConstant → Dictionary nesting by:
+// 1. Creating data where most values are a constant (triggers MainlyConstant)
+// 2. Forcing the otherValues_ child to use Dictionary encoding via
+// EncodingLayoutTree
+//
+// This scenario is challenging because dictionaryEncoding() may only check
+// for direct Dictionary or Nullable→Dictionary, not deeper nesting like
+// MainlyConstant→Dictionary.
+TEST_P(E2EFilterTest, nestedMainlyConstantWithDictionary) {
+  // Create data where most values are a constant string.
+  // ~90% of values will be the constant, ~10% will be "other" values.
+  auto type = ROW({"string_val", "long_val"}, {VARCHAR(), BIGINT()});
+
+  const size_t kRowCount = 1000;
+  std::vector<std::string> stringVals;
+  std::vector<int64_t> longVals;
+  stringVals.reserve(kRowCount);
+  longVals.reserve(kRowCount);
+
+  const std::string kConstantValue = "MOSTLY_CONSTANT_VALUE";
+  // For the "other" values, use low cardinality to encourage dictionary
+  // encoding for the otherValues_ child of MainlyConstant.
+  const std::vector<std::string> otherValues = {
+      "OTHER_A", "OTHER_B", "OTHER_C", "OTHER_D", "OTHER_E"};
+
+  for (size_t i = 0; i < kRowCount; ++i) {
+    if (i % 10 == 0) {
+      // ~10% of rows have "other" values (low cardinality for dictionary).
+      stringVals.push_back(otherValues[i % otherValues.size()]);
+    } else {
+      // ~90% of rows have the constant value.
+      stringVals.push_back(kConstantValue);
+    }
+    longVals.push_back(i);
+  }
+
+  auto stringVector =
+      velox::test::VectorMaker(leafPool_.get())
+          .flatVector<velox::StringView>(kRowCount, [&](auto row) {
+            return velox::StringView(stringVals[row]);
+          });
+  auto longVector = velox::test::VectorMaker(leafPool_.get())
+                        .flatVector<int64_t>(
+                            kRowCount, [&](auto row) { return longVals[row]; });
+
+  auto batch = std::make_shared<RowVector>(
+      leafPool_.get(),
+      type,
+      nullptr,
+      kRowCount,
+      std::vector<VectorPtr>{stringVector, longVector});
+
+  // Build EncodingLayoutTree that forces MainlyConstant with Dictionary child
+  // for otherValues_.
+  // The encoding hierarchy we want:
+  //   Row
+  //     -> Scalar (string_val): MainlyConstant
+  //         -> OtherValues (child 1): Dictionary
+  //     -> Scalar (long_val): default
+  EncodingLayoutTree encodingLayoutTree{
+      Kind::Row,
+      {},
+      "",
+      {
+          EncodingLayoutTree{
+              Kind::Scalar,
+              {{EncodingLayoutTree::StreamIdentifiers::Scalar::ScalarStream,
+                EncodingLayout{
+                    EncodingType::MainlyConstant,
+                    {},
+                    CompressionType::Uncompressed,
+                    {
+                        // Child 0: IsCommon (let the writer decide)
+                        std::nullopt,
+                        // Child 1: OtherValues -> Dictionary
+                        EncodingLayout{
+                            EncodingType::Dictionary,
+                            {},
+                            CompressionType::Uncompressed,
+                            {
+                                // Alphabet (id=0): let writer decide
+                                std::nullopt,
+                                // Indices (id=1): let writer decide
+                                std::nullopt,
+                            }},
+                    }}}},
+              "string_val"},
+          EncodingLayoutTree{Kind::Scalar, {}, "long_val"},
+      }};
+
+  // Write the data with the forced encoding layout.
+  auto writeFile = std::make_unique<InMemoryWriteFile>(&sinkData_);
+  VeloxWriterOptions writerOptions;
+  writerOptions.encodingLayoutTree.emplace(std::move(encodingLayoutTree));
+  VeloxWriter writer(type, std::move(writeFile), *rootPool_, writerOptions);
+  writer.write(batch);
+  writer.close();
+
+  // Read back and verify the data is correct.
+  auto input = std::make_unique<velox::dwio::common::BufferedInput>(
+      std::make_shared<velox::InMemoryReadFile>(sinkData_),
+      *leafPool_,
+      velox::dwio::common::MetricsLog::voidLog());
+
+  velox::io::IoStatistics dataIoStats;
+  velox::io::IoStatistics metadataIoStats;
+  auto reader = makeReader(
+      velox::dwio::common::ReaderOptions{
+          leafPool_.get(), &dataIoStats, &metadataIoStats},
+      std::move(input));
+  auto scanSpec = std::make_shared<velox::common::ScanSpec>("root");
+  scanSpec->addAllChildFields(*type);
+  velox::dwio::common::RowReaderOptions rowReaderOptions;
+  rowReaderOptions.setScanSpec(scanSpec);
+  auto rowReader = reader->createRowReader(rowReaderOptions);
+
+  // Read all rows and verify.
+  auto result = BaseVector::create(type, 0, leafPool_.get());
+  size_t totalRows = 0;
+  while (rowReader->next(1000, result)) {
+    auto* rowResult = result->as<RowVector>();
+    ASSERT_NE(rowResult, nullptr);
+    totalRows += rowResult->size();
+
+    DecodedVector decodedString(*rowResult->childAt(0));
+    DecodedVector decodedLong(*rowResult->childAt(1));
+
+    for (size_t i = 0; i < rowResult->size(); ++i) {
+      auto rowIdx = decodedLong.valueAt<int64_t>(i);
+      std::string expected;
+      if (rowIdx % 10 == 0) {
+        expected = otherValues[rowIdx % otherValues.size()];
+      } else {
+        expected = kConstantValue;
+      }
+      ASSERT_EQ(decodedString.valueAt<StringView>(i).str(), expected)
+          << "Mismatch at row=" << rowIdx;
+    }
+  }
+
+  EXPECT_EQ(totalRows, kRowCount);
+}
+
+// Verifies that the reader returns DictionaryVector<StringView> for
+// dictionary-encoded string columns when stringBufferOptimized is enabled.
+// The dictionary path is only taken for simple encoding shapes:
+//   - Dictionary (top-level)
+//   - Nullable -> Dictionary (dictionary with nulls)
+TEST_P(E2EFilterTest, dictionaryVectorReturned) {
+  useForcedDictionaryEncoding_ = true;
+  auto type = ROW({"string_val", "long_val"}, {VARCHAR(), BIGINT()});
+
+  const vector_size_t kRowCount = 1000;
+  // Use low cardinality to ensure dictionary encoding is chosen.
+  std::vector<std::string> stringStorage(kRowCount);
+  for (vector_size_t i = 0; i < kRowCount; ++i) {
+    stringStorage[i] = fmt::format("VAL_{}", i % 10);
+  }
+  auto stringVector =
+      velox::test::VectorMaker(leafPool_.get())
+          .flatVector<velox::StringView>(kRowCount, [&](auto row) {
+            return velox::StringView(stringStorage[row]);
+          });
+  auto longVector = velox::test::VectorMaker(leafPool_.get())
+                        .flatVector<int64_t>(kRowCount, [](auto row) {
+                          return static_cast<int64_t>(row);
+                        });
+
+  auto batch = std::make_shared<RowVector>(
+      leafPool_.get(),
+      type,
+      nullptr,
+      kRowCount,
+      std::vector<VectorPtr>{stringVector, longVector});
+
+  // Write directly (without writeToMemory) to avoid the default chunking
+  // policy that splits the data into multiple chunks. The dictionary path
+  // requires all requested rows to fit in a single chunk.
+  {
+    auto writeFile = std::make_unique<InMemoryWriteFile>(&sinkData_);
+    VeloxWriterOptions writerOptions;
+    if (useForcedDictionaryEncoding_) {
+      rowType_ = asRowType(type);
+      writerOptions.encodingLayoutTree.emplace(
+          buildForcedDictionaryEncodingLayoutTree());
+    }
+    VeloxWriter writer(
+        type, std::move(writeFile), *rootPool_, std::move(writerOptions));
+    writer.write(batch);
+    writer.close();
+  }
+
+  auto input = std::make_unique<velox::dwio::common::BufferedInput>(
+      std::make_shared<velox::InMemoryReadFile>(sinkData_),
+      *leafPool_,
+      velox::dwio::common::MetricsLog::voidLog());
+
+  velox::io::IoStatistics dataIoStats;
+  velox::io::IoStatistics metadataIoStats;
+  velox::dwio::common::ReaderOptions readerOpts{
+      leafPool_.get(), &dataIoStats, &metadataIoStats};
+  auto reader = makeReader(readerOpts, std::move(input));
+  auto scanSpec = std::make_shared<velox::common::ScanSpec>("root");
+  scanSpec->addAllChildFields(*type);
+  velox::dwio::common::RowReaderOptions rowReaderOptions;
+  rowReaderOptions.setScanSpec(scanSpec);
+  rowReaderOptions.setStringDecoderZeroCopy(param().stringDecoderZeroCopy);
+  auto rowReader = reader->createRowReader(rowReaderOptions);
+
+  auto result = BaseVector::create(type, 0, leafPool_.get());
+  size_t totalRows = 0;
+  while (rowReader->next(1000, result)) {
+    auto* rowResult = result->as<RowVector>();
+    ASSERT_NE(rowResult, nullptr);
+    totalRows += rowResult->size();
+
+    auto stringChild = rowResult->childAt(0)->loadedVector();
+    if (param().stringDecoderZeroCopy) {
+      // With string buffer optimization, the dictionary path should return
+      // a DictionaryVector wrapping a FlatVector alphabet.
+      ASSERT_EQ(stringChild->encoding(), VectorEncoding::Simple::DICTIONARY)
+          << "Expected DICTIONARY encoding for string column, got "
+          << stringChild->encoding();
+    }
+
+    // Verify values are correct regardless of encoding.
+    DecodedVector decoded(*stringChild);
+    for (size_t i = 0; i < rowResult->size(); ++i) {
+      auto expected = fmt::format("VAL_{}", i % 10);
+      ASSERT_EQ(decoded.valueAt<StringView>(i).str(), expected)
+          << "Mismatch at row=" << i;
+    }
+  }
+
+  EXPECT_EQ(totalRows, kRowCount);
+}
+
+// Test for cross-chunk encoding changes where encoding type varies between
+// chunks. This is a challenging scenario for dictionary column visitors because
+// the first chunk may use dictionary encoding while subsequent chunks may use
+// trivial encoding (or vice versa).
+//
+// The test creates data where:
+// - Batch 0: Highly repetitive strings -> likely dictionary encoding
+// - Batch 1: Unique strings -> likely trivial encoding
+// - Batch 2: Highly repetitive strings -> likely dictionary encoding
+// - Batch 3: Unique strings -> likely trivial encoding
+// - ... (8 batches total)
+//
+// Each batch is 200 rows and flushed as a separate chunk. The reader requests
+// 1000 rows per next() call, forcing each read to span ~5 chunks with
+// different encodings.
+TEST_P(E2EFilterTest, crossChunkEncodingChange) {
+  // Use frequent chunk/stripe flushes to create multiple chunks with different
+  // data characteristics.
+  flushEveryNBatches_ = 1;
+
+  // Create custom batches with alternating encoding characteristics.
+  // Use small batches (200 rows) so that next(1000) spans multiple chunks.
+  auto type =
+      ROW({"string_val", "string_val_2", "long_val"},
+          {VARCHAR(), VARCHAR(), BIGINT()});
+
+  const size_t kRowsPerBatch = 200;
+  const int kNumBatches = 8;
+  std::vector<RowVectorPtr> batches;
+
+  for (int batchIdx = 0; batchIdx < kNumBatches; ++batchIdx) {
+    std::vector<std::string> stringVals;
+    std::vector<std::string> stringVals2;
+    std::vector<int64_t> longVals;
+
+    stringVals.reserve(kRowsPerBatch);
+    stringVals2.reserve(kRowsPerBatch);
+    longVals.reserve(kRowsPerBatch);
+
+    if (batchIdx % 2 == 0) {
+      // Even batches: highly repetitive strings -> dictionary encoding.
+      // Use very low cardinality to ensure dictionary encoding is chosen.
+      for (size_t i = 0; i < kRowsPerBatch; ++i) {
+        stringVals.push_back(fmt::format("DICT_VAL_{}", i % 5));
+        stringVals2.push_back(fmt::format("DICT2_VAL_{}", i % 3));
+        longVals.push_back(batchIdx * kRowsPerBatch + i);
+      }
+    } else {
+      // Odd batches: unique strings -> trivial encoding.
+      // Use unique values to prevent dictionary encoding.
+      for (size_t i = 0; i < kRowsPerBatch; ++i) {
+        stringVals.push_back(
+            fmt::format("UNIQUE_VAL_BATCH{}_ROW{}_EXTRA_PADDING", batchIdx, i));
+        stringVals2.push_back(
+            fmt::format("UNIQUE2_VAL_BATCH{}_ROW{}_MORE_PADDING", batchIdx, i));
+        longVals.push_back(batchIdx * kRowsPerBatch + i);
+      }
+    }
+
+    auto stringVector =
+        velox::test::VectorMaker(leafPool_.get())
+            .flatVector<velox::StringView>(kRowsPerBatch, [&](auto row) {
+              return velox::StringView(stringVals[row]);
+            });
+    auto stringVector2 =
+        velox::test::VectorMaker(leafPool_.get())
+            .flatVector<velox::StringView>(kRowsPerBatch, [&](auto row) {
+              return velox::StringView(stringVals2[row]);
+            });
+    auto longVector = velox::test::VectorMaker(leafPool_.get())
+                          .flatVector<int64_t>(kRowsPerBatch, [&](auto row) {
+                            return longVals[row];
+                          });
+
+    batches.push_back(
+        std::make_shared<RowVector>(
+            leafPool_.get(),
+            type,
+            nullptr,
+            kRowsPerBatch,
+            std::vector<VectorPtr>{stringVector, stringVector2, longVector}));
+  }
+
+  // Write the data to memory.
+  writeToMemory(type, batches, /*forRowGroupSkip=*/false);
+
+  // Read back and verify the data is correct.
+  auto input = std::make_unique<velox::dwio::common::BufferedInput>(
+      std::make_shared<velox::InMemoryReadFile>(sinkData_),
+      *leafPool_,
+      velox::dwio::common::MetricsLog::voidLog());
+
+  velox::io::IoStatistics dataIoStats;
+  velox::io::IoStatistics metadataIoStats;
+  auto reader = makeReader(
+      velox::dwio::common::ReaderOptions{
+          leafPool_.get(), &dataIoStats, &metadataIoStats},
+      std::move(input));
+  auto scanSpec = std::make_shared<velox::common::ScanSpec>("root");
+  scanSpec->addAllChildFields(*type);
+  velox::dwio::common::RowReaderOptions rowReaderOptions;
+  rowReaderOptions.setScanSpec(scanSpec);
+  auto rowReader = reader->createRowReader(rowReaderOptions);
+
+  // Read with batch size larger than chunk size, forcing cross-chunk reads.
+  // Each chunk has 200 rows, so next(1000) should span ~5 chunks.
+  auto result = BaseVector::create(type, 0, leafPool_.get());
+  size_t totalRows = 0;
+  while (rowReader->next(1000, result)) {
+    auto* rowResult = result->as<RowVector>();
+    ASSERT_NE(rowResult, nullptr);
+    totalRows += rowResult->size();
+
+    // Verify the string values are correct.
+    DecodedVector decodedString(*rowResult->childAt(0));
+    DecodedVector decodedString2(*rowResult->childAt(1));
+    DecodedVector decodedLong(*rowResult->childAt(2));
+
+    for (size_t i = 0; i < rowResult->size(); ++i) {
+      auto globalRow = decodedLong.valueAt<int64_t>(i);
+      auto batchIdx = globalRow / kRowsPerBatch;
+      auto rowInBatch = globalRow % kRowsPerBatch;
+
+      std::string expectedStr;
+      std::string expectedStr2;
+      if (batchIdx % 2 == 0) {
+        expectedStr = fmt::format("DICT_VAL_{}", rowInBatch % 5);
+        expectedStr2 = fmt::format("DICT2_VAL_{}", rowInBatch % 3);
+      } else {
+        expectedStr = fmt::format(
+            "UNIQUE_VAL_BATCH{}_ROW{}_EXTRA_PADDING", batchIdx, rowInBatch);
+        expectedStr2 = fmt::format(
+            "UNIQUE2_VAL_BATCH{}_ROW{}_MORE_PADDING", batchIdx, rowInBatch);
+      }
+
+      ASSERT_EQ(decodedString.valueAt<StringView>(i).str(), expectedStr)
+          << "Mismatch at globalRow=" << globalRow;
+      ASSERT_EQ(decodedString2.valueAt<StringView>(i).str(), expectedStr2)
+          << "Mismatch at globalRow=" << globalRow;
+    }
+  }
+
+  EXPECT_EQ(totalRows, kNumBatches * kRowsPerBatch);
 }
 
 } // namespace facebook::nimble

--- a/dwio/nimble/velox/selective/tests/StringColumnReaderTest.cpp
+++ b/dwio/nimble/velox/selective/tests/StringColumnReaderTest.cpp
@@ -17,7 +17,11 @@
 #include "dwio/nimble/velox/selective/SelectiveNimbleReader.h"
 
 #include "dwio/nimble/common/tests/NimbleFileWriter.h"
+#include "dwio/nimble/velox/FlushPolicy.h"
+#include "dwio/nimble/velox/VeloxWriter.h"
+#include "velox/common/base/tests/GTestUtils.h"
 #include "velox/common/io/IoStatistics.h"
+#include "velox/common/testutil/TestValue.h"
 #include "velox/vector/tests/utils/VectorTestBase.h"
 
 #include <gtest/gtest.h>
@@ -34,6 +38,7 @@ class StringColumnReaderTest : public ::testing::Test,
  protected:
   static void SetUpTestCase() {
     memory::initializeMemoryManager(velox::memory::MemoryManager::Options{});
+    common::testutil::TestValue::enable();
     registerSelectiveNimbleReaderFactory();
   }
 
@@ -142,6 +147,52 @@ class StringColumnReaderTest : public ::testing::Test,
   const std::shared_ptr<io::IoStatistics> metadataIoStats_{
       std::make_shared<io::IoStatistics>()};
 };
+
+// Returns the encoding of a vector, loading through lazy wrappers if present.
+VectorEncoding::Simple getEncoding(const VectorPtr& vector) {
+  return BaseVector::loadedVectorShared(vector)->encoding();
+}
+
+// Validates correctness and checks the expected encoding per batch.
+// expectedEncodings[i] is the expected encoding for the i-th non-empty batch.
+// totalRows is the total number of rows in the file (used to drive the read
+// loop). expected is the expected string column values (only qualifying rows).
+// childIndex selects which child of the result RowVector to check.
+void validateWithEncodingChecks(
+    const BaseVector& expected,
+    dwio::common::RowReader& rowReader,
+    int batchSize,
+    int totalRows,
+    const std::vector<VectorEncoding::Simple>& expectedEncodings,
+    const RowTypePtr& resultType,
+    velox::memory::MemoryPool* pool,
+    int childIndex = 0) {
+  auto result = BaseVector::create(resultType, 0, pool);
+  int numScanned = 0;
+  int outputOffset = 0;
+  int batchIndex = 0;
+  while (numScanned < totalRows) {
+    numScanned += rowReader.next(batchSize, result);
+    result->validate();
+    if (result->size() == 0) {
+      continue;
+    }
+    auto* row = result->asUnchecked<RowVector>();
+    auto stringChild = BaseVector::loadedVectorShared(row->childAt(childIndex));
+    ASSERT_LT(batchIndex, expectedEncodings.size());
+    EXPECT_EQ(stringChild->encoding(), expectedEncodings[batchIndex])
+        << "Non-empty batch " << batchIndex << " at output offset "
+        << outputOffset << " has unexpected encoding";
+    for (int j = 0; j < result->size(); ++j) {
+      ASSERT_TRUE(stringChild->equalValueAt(&expected, j, outputOffset + j))
+          << "Mismatch at row " << (outputOffset + j);
+    }
+    outputOffset += result->size();
+    ++batchIndex;
+  }
+  ASSERT_EQ(outputOffset, expected.size());
+  ASSERT_EQ(0, rowReader.next(1, result));
+}
 
 // Strings shorter than StringView::kInlineSize (12 bytes).
 TEST_P(StringColumnReaderTest, shortStrings) {
@@ -303,6 +354,801 @@ TEST_P(StringColumnReaderTest, stringSkipAndRead) {
   scanSpec->addAllChildFields(*input->type());
   auto readers = makeReaders(input, scanSpec, stringDecoderZeroCopy);
   validate(*input, *readers.rowReader, 7);
+}
+
+// Verifies that dictionary state is correctly invalidated when a decoder-level
+// skip crosses a chunk boundary. Uses a two-column schema where a filter on c0
+// rejects all rows in chunk 1, causing c1 (string, lazy-loaded) to remain
+// unread during batch 1. When batch 2 loads c1 via ColumnLoader, seekTo
+// triggers skip(500) across the chunk boundary.
+TEST_P(StringColumnReaderTest, skipAcrossChunkBoundary) {
+  const bool passStringBuffersFromDecoder = GetParam();
+  if (!passStringBuffersFromDecoder) {
+    return;
+  }
+
+  constexpr int kChunkRows = 500;
+
+  // Chunk 1: c0 = [0..499], c1 = {"aaa","bbb","ccc"} repeating.
+  auto chunk1 = makeRowVector({
+      makeFlatVector<int64_t>(kChunkRows, [](auto i) { return i; }),
+      makeFlatVector<std::string>(
+          kChunkRows,
+          [](auto i) {
+            return std::vector<std::string>{"aaa", "bbb", "ccc"}[i % 3];
+          }),
+  });
+  // Chunk 2: c0 = [500..999], c1 = {"xxx","yyy"} repeating.
+  auto chunk2 = makeRowVector({
+      makeFlatVector<int64_t>(
+          kChunkRows, [](auto i) { return kChunkRows + i; }),
+      makeFlatVector<std::string>(
+          kChunkRows,
+          [](auto i) { return std::vector<std::string>{"xxx", "yyy"}[i % 2]; }),
+  });
+
+  VeloxWriterOptions writerOptions;
+  writerOptions.enableChunking = true;
+  writerOptions.minStreamChunkRawSize = 0;
+  writerOptions.flushPolicyFactory = [] {
+    return std::make_unique<LambdaFlushPolicy>(
+        /*flushLambda=*/[](const StripeProgress&) { return false; },
+        /*chunkLambda=*/[](const StripeProgress&) { return true; });
+  };
+  auto file = test::createNimbleFile(
+      *rootPool(), {chunk1, chunk2}, writerOptions, /*flushAfterWrite=*/false);
+
+  // Filter on c0 rejects chunk 1 ([0,499]), accepts chunk 2 ([500,999]).
+  auto readType = ROW({"c0", "c1"}, {BIGINT(), VARCHAR()});
+  auto scanSpec = std::make_shared<common::ScanSpec>("root");
+  scanSpec->addAllChildFields(*readType);
+  scanSpec->childByName("c0")->setFilter(
+      std::make_unique<common::BigintRange>(
+          kChunkRows, 2 * kChunkRows - 1, /*nullAllowed=*/false));
+
+  auto expectedStrings = makeFlatVector<std::string>(kChunkRows, [](auto i) {
+    return std::vector<std::string>{"xxx", "yyy"}[i % 2];
+  });
+
+  auto readers =
+      makeReaders(chunk1, file, scanSpec, passStringBuffersFromDecoder);
+
+  // Batch 1 (rows 0-499): c0 filter rejects all → c1 lazy, not loaded.
+  // Batch 2 (rows 500-999): c1 loaded via ColumnLoader → seekTo(500) →
+  //   skip(500) across chunk boundary → flat fallback.
+  using E = VectorEncoding::Simple;
+  validateWithEncodingChecks(
+      *expectedStrings,
+      *readers.rowReader,
+      kChunkRows,
+      /*totalRows=*/2 * kChunkRows,
+      {E::FLAT},
+      readType,
+      pool(),
+      /*childIndex=*/1);
+}
+
+// Verifies skip and dictionary behavior when the filter creates a gap in the
+// middle of the file. The filter accepts rows [0,249] and [600,900], creating
+// a skip that crosses the chunk boundary (at row 500) mid-file.
+//
+// Batch layout (batch size 250, 1000 total rows, chunk boundary at 500):
+//   Batch 0 (offset=0):   c0 accepts 0-249, c1 loaded at readOffset=0 → dict
+//   Batch 1 (offset=250): c0 rejects all    → c1 lazy, not loaded
+//   Batch 2 (offset=500): c0 accepts 600-749, c1 loaded, readOffset=250 →
+//     seekTo(500), skip(250) crosses chunk boundary → flat
+//   Batch 3 (offset=750): c0 accepts 750-900, readOffset=750 → dict
+TEST_P(StringColumnReaderTest, skipAcrossChunkBoundaryMidFile) {
+  const bool passStringBuffersFromDecoder = GetParam();
+  if (!passStringBuffersFromDecoder) {
+    return;
+  }
+
+  constexpr int kChunkRows = 500;
+  constexpr int kBatchSize = 250;
+
+  auto chunk1 = makeRowVector({
+      makeFlatVector<int64_t>(kChunkRows, [](auto i) { return i; }),
+      makeFlatVector<std::string>(
+          kChunkRows,
+          [](auto i) {
+            return std::vector<std::string>{"aaa", "bbb", "ccc"}[i % 3];
+          }),
+  });
+  auto chunk2 = makeRowVector({
+      makeFlatVector<int64_t>(
+          kChunkRows, [](auto i) { return kChunkRows + i; }),
+      makeFlatVector<std::string>(
+          kChunkRows,
+          [](auto i) { return std::vector<std::string>{"xxx", "yyy"}[i % 2]; }),
+  });
+
+  VeloxWriterOptions writerOptions;
+  writerOptions.enableChunking = true;
+  writerOptions.minStreamChunkRawSize = 0;
+  writerOptions.flushPolicyFactory = [] {
+    return std::make_unique<LambdaFlushPolicy>(
+        /*flushLambda=*/[](const StripeProgress&) { return false; },
+        /*chunkLambda=*/[](const StripeProgress&) { return true; });
+  };
+  auto file = test::createNimbleFile(
+      *rootPool(), {chunk1, chunk2}, writerOptions, /*flushAfterWrite=*/false);
+
+  // Filter: accept [0, 249] ∪ [600, 900].
+  auto readType = ROW({"c0", "c1"}, {BIGINT(), VARCHAR()});
+  auto scanSpec = std::make_shared<common::ScanSpec>("root");
+  scanSpec->addAllChildFields(*readType);
+  std::vector<std::unique_ptr<common::BigintRange>> ranges;
+  ranges.push_back(
+      std::make_unique<common::BigintRange>(
+          0, kBatchSize - 1, /*nullAllowed=*/false));
+  ranges.push_back(
+      std::make_unique<common::BigintRange>(600, 900, /*nullAllowed=*/false));
+  scanSpec->childByName("c0")->setFilter(
+      std::make_unique<common::BigintMultiRange>(
+          std::move(ranges), /*nullAllowed=*/false));
+
+  // Expected string output: rows 0-249 from chunk 1, rows 600-900 from chunk 2.
+  // 250 + 150 + 151 = 551 total qualifying rows.
+  auto expectedStrings = makeFlatVector<std::string>(551, [](auto i) {
+    if (i < 250) {
+      return std::vector<std::string>{"aaa", "bbb", "ccc"}[i % 3];
+    }
+    // Rows 600-900 in the file → offset 100-400 within chunk 2.
+    int chunk2Offset = (i - 250) + 100;
+    return std::vector<std::string>{"xxx", "yyy"}[chunk2Offset % 2];
+  });
+
+  auto readers =
+      makeReaders(chunk1, file, scanSpec, passStringBuffersFromDecoder);
+
+  using E = VectorEncoding::Simple;
+  validateWithEncodingChecks(
+      *expectedStrings,
+      *readers.rowReader,
+      kBatchSize,
+      /*totalRows=*/2 * kChunkRows,
+      {E::DICTIONARY, E::FLAT, E::DICTIONARY},
+      readType,
+      pool(),
+      /*childIndex=*/1);
+}
+
+// Verifies that the dictionary path is entered when a skip stays within the
+// same chunk. Uses a single large chunk so there is no chunk boundary. A filter
+// on c0 rejects batch 0, causing c1 to be lazy. When batch 1 loads c1, seekTo
+// skips 500 values — but all within the same 1000-value chunk. The tighter
+// remainingValues gate (offset + numRequestedRows - readOffset_ <=
+// remainingValues) allows the dict path here, unlike the conservative
+// readOffset_ != offset gate which would bail.
+//
+// The filter also creates gaps (accepts only even rows) so the first dictionary
+// batch exercises the visitor's gap-skipping logic.
+TEST_P(StringColumnReaderTest, skipWithinChunkReturnsDictionary) {
+  const bool passStringBuffersFromDecoder = GetParam();
+  if (!passStringBuffersFromDecoder) {
+    return;
+  }
+
+  constexpr int kChunkRows = 1000;
+  constexpr int kBatchSize = 500;
+
+  auto input = makeRowVector({
+      makeFlatVector<int64_t>(kChunkRows, [](auto i) { return i; }),
+      makeFlatVector<std::string>(
+          kChunkRows,
+          [](auto i) {
+            return std::vector<std::string>{"aaa", "bbb", "ccc"}[i % 3];
+          }),
+  });
+
+  VeloxWriterOptions writerOptions;
+  writerOptions.enableChunking = true;
+  writerOptions.minStreamChunkRawSize = 0;
+  writerOptions.flushPolicyFactory = [] {
+    return std::make_unique<LambdaFlushPolicy>(
+        /*flushLambda=*/[](const StripeProgress&) { return false; },
+        /*chunkLambda=*/[](const StripeProgress&) { return false; });
+  };
+  auto file = test::createNimbleFile(*rootPool(), input, writerOptions);
+
+  // Filter: accept [600, 700] ∪ [800, 900]. Rejects all of batch 0 and
+  // creates a gap (rows 701-799) in batch 1's qualifying rows.
+  auto readType = ROW({"c0", "c1"}, {BIGINT(), VARCHAR()});
+  auto scanSpec = std::make_shared<common::ScanSpec>("root");
+  scanSpec->addAllChildFields(*readType);
+  std::vector<std::unique_ptr<common::BigintRange>> ranges;
+  ranges.push_back(
+      std::make_unique<common::BigintRange>(600, 700, /*nullAllowed=*/false));
+  ranges.push_back(
+      std::make_unique<common::BigintRange>(800, 900, /*nullAllowed=*/false));
+  scanSpec->childByName("c0")->setFilter(
+      std::make_unique<common::BigintMultiRange>(
+          std::move(ranges), /*nullAllowed=*/false));
+
+  // 101 rows from [600,700] + 101 rows from [800,900] = 202 qualifying rows.
+  auto expectedStrings = makeFlatVector<std::string>(202, [](auto i) {
+    int row = i < 101 ? 600 + i : 800 + (i - 101);
+    return std::vector<std::string>{"aaa", "bbb", "ccc"}[row % 3];
+  });
+
+  auto readers =
+      makeReaders(input, file, scanSpec, passStringBuffersFromDecoder);
+
+  // Batch 0 (offset=0): c0 rejects all → c1 lazy, readOffset stays 0.
+  // Batch 1 (offset=500): c0 accepts [600,700] ∪ [800,900] → c1 loaded via
+  //   ColumnLoader, readOffset=0, offset=500. Skip 500 within single
+  //   1000-value chunk. remainingValues (1000) >= 500 + 901 - 0 = 1401? No...
+  //   rows = outputRows relative to offset 500: [100..200, 300..400].
+  //   numRequestedRows = 401. totalValuesNeeded = 500 + 401 = 901 <= 1000.
+  //   Dict path with gapped rows.
+  using E = VectorEncoding::Simple;
+  validateWithEncodingChecks(
+      *expectedStrings,
+      *readers.rowReader,
+      kBatchSize,
+      /*totalRows=*/kChunkRows,
+      {E::DICTIONARY},
+      readType,
+      pool(),
+      /*childIndex=*/1);
+}
+
+// Verifies that the dictionary path recovers after a flat fallback mid-file.
+// Two chunks of 400 rows, batch size 250, filter accepts [0,349] ∪ [600,799].
+//
+//   Batch 0 (offset=0):   c0 accepts [0,249]. c1 readOffset=0, no skip.
+//     remainingValues=400 >= 250. DICT. readOffset → 250.
+//   Batch 1 (offset=250): c0 accepts [250,349], outputRows=[0..99].
+//     readOffset=250, no skip. remainingValues=150 >= 100. DICT.
+//     readOffset → 350.
+//   Batch 2 (offset=500): c0 accepts [600,749], outputRows=[100..249].
+//     readOffset=350, skip=150. totalNeeded=150+250=400 > remaining=50.
+//     Skip crosses chunk boundary → FLAT. readOffset → 750.
+//   Batch 3 (offset=750): c0 accepts [750,799], outputRows=[0..49].
+//     readOffset=750, no skip. remainingValues=50 >= 50. DICT.
+TEST_P(StringColumnReaderTest, skipCrossesChunkButNextBatchRecoversDictionary) {
+  const bool passStringBuffersFromDecoder = GetParam();
+  if (!passStringBuffersFromDecoder) {
+    return;
+  }
+
+  constexpr int kChunkRows = 400;
+  constexpr int kBatchSize = 250;
+
+  auto chunk1 = makeRowVector({
+      makeFlatVector<int64_t>(kChunkRows, [](auto i) { return i; }),
+      makeFlatVector<std::string>(
+          kChunkRows,
+          [](auto i) {
+            return std::vector<std::string>{"aaa", "bbb", "ccc"}[i % 3];
+          }),
+  });
+  auto chunk2 = makeRowVector({
+      makeFlatVector<int64_t>(
+          kChunkRows, [](auto i) { return kChunkRows + i; }),
+      makeFlatVector<std::string>(
+          kChunkRows,
+          [](auto i) { return std::vector<std::string>{"xxx", "yyy"}[i % 2]; }),
+  });
+
+  VeloxWriterOptions writerOptions;
+  writerOptions.enableChunking = true;
+  writerOptions.minStreamChunkRawSize = 0;
+  writerOptions.flushPolicyFactory = [] {
+    return std::make_unique<LambdaFlushPolicy>(
+        /*flushLambda=*/[](const StripeProgress&) { return false; },
+        /*chunkLambda=*/[](const StripeProgress&) { return true; });
+  };
+  auto file = test::createNimbleFile(
+      *rootPool(), {chunk1, chunk2}, writerOptions, /*flushAfterWrite=*/false);
+
+  auto readType = ROW({"c0", "c1"}, {BIGINT(), VARCHAR()});
+  auto scanSpec = std::make_shared<common::ScanSpec>("root");
+  scanSpec->addAllChildFields(*readType);
+  std::vector<std::unique_ptr<common::BigintRange>> ranges;
+  ranges.push_back(
+      std::make_unique<common::BigintRange>(0, 349, /*nullAllowed=*/false));
+  ranges.push_back(
+      std::make_unique<common::BigintRange>(
+          600, 2 * kChunkRows - 1, /*nullAllowed=*/false));
+  scanSpec->childByName("c0")->setFilter(
+      std::make_unique<common::BigintMultiRange>(
+          std::move(ranges), /*nullAllowed=*/false));
+
+  // 350 rows from chunk 1 (rows 0-349) + 200 rows from chunk 2 (rows 600-799).
+  auto expectedStrings = makeFlatVector<std::string>(550, [](auto i) {
+    if (i < 350) {
+      return std::vector<std::string>{"aaa", "bbb", "ccc"}[i % 3];
+    }
+    int chunk2Offset = (i - 350) + 200;
+    return std::vector<std::string>{"xxx", "yyy"}[chunk2Offset % 2];
+  });
+
+  auto readers =
+      makeReaders(chunk1, file, scanSpec, passStringBuffersFromDecoder);
+
+  using E = VectorEncoding::Simple;
+  validateWithEncodingChecks(
+      *expectedStrings,
+      *readers.rowReader,
+      kBatchSize,
+      /*totalRows=*/2 * kChunkRows,
+      {E::DICTIONARY, E::DICTIONARY, E::FLAT, E::DICTIONARY},
+      readType,
+      pool(),
+      /*childIndex=*/1);
+}
+
+// Verifies dictionary recovery after a chunk boundary crossing. The decoder
+// fully consumes chunk 1 in batches 0-1, then batch 2 is lazy (c1 not
+// loaded). When batch 3 loads c1, ensureLoaded() advances to chunk 2 (firing
+// onChunkLoad to clear stale state), then ensureDictionaryState() rebuilds
+// the alphabet from chunk 2. The skip stays within chunk 2.
+TEST_P(StringColumnReaderTest, skipAcrossChunkBoundaryDictRecovery) {
+  const bool passStringBuffersFromDecoder = GetParam();
+  if (!passStringBuffersFromDecoder) {
+    return;
+  }
+
+  constexpr int kChunkRows = 500;
+  constexpr int kBatchSize = 250;
+
+  auto chunk1 = makeRowVector({
+      makeFlatVector<int64_t>(kChunkRows, [](auto i) { return i; }),
+      makeFlatVector<std::string>(
+          kChunkRows,
+          [](auto i) {
+            return std::vector<std::string>{"aaa", "bbb", "ccc"}[i % 3];
+          }),
+  });
+  auto chunk2 = makeRowVector({
+      makeFlatVector<int64_t>(
+          kChunkRows, [](auto i) { return kChunkRows + i; }),
+      makeFlatVector<std::string>(
+          kChunkRows,
+          [](auto i) { return std::vector<std::string>{"xxx", "yyy"}[i % 2]; }),
+  });
+
+  VeloxWriterOptions writerOptions;
+  writerOptions.enableChunking = true;
+  writerOptions.minStreamChunkRawSize = 0;
+  writerOptions.flushPolicyFactory = [] {
+    return std::make_unique<LambdaFlushPolicy>(
+        /*flushLambda=*/[](const StripeProgress&) { return false; },
+        /*chunkLambda=*/[](const StripeProgress&) { return true; });
+  };
+  auto file = test::createNimbleFile(
+      *rootPool(), {chunk1, chunk2}, writerOptions, /*flushAfterWrite=*/false);
+
+  // Filter: accept [0, 499] and [750, 999]. Rejects batch 2 (rows 500-749).
+  auto readType = ROW({"c0", "c1"}, {BIGINT(), VARCHAR()});
+  auto scanSpec = std::make_shared<common::ScanSpec>("root");
+  scanSpec->addAllChildFields(*readType);
+  std::vector<std::unique_ptr<common::BigintRange>> ranges;
+  ranges.push_back(
+      std::make_unique<common::BigintRange>(
+          0, kChunkRows - 1, /*nullAllowed=*/false));
+  ranges.push_back(
+      std::make_unique<common::BigintRange>(
+          750, 2 * kChunkRows - 1, /*nullAllowed=*/false));
+  scanSpec->childByName("c0")->setFilter(
+      std::make_unique<common::BigintMultiRange>(
+          std::move(ranges), /*nullAllowed=*/false));
+
+  // Expected: 500 rows from chunk 1 + 250 rows from chunk 2 (rows 750-999).
+  auto expectedStrings = makeFlatVector<std::string>(750, [](auto i) {
+    if (i < 500) {
+      return std::vector<std::string>{"aaa", "bbb", "ccc"}[i % 3];
+    }
+    int chunk2Offset = (i - 500) + 250;
+    return std::vector<std::string>{"xxx", "yyy"}[chunk2Offset % 2];
+  });
+
+  auto readers =
+      makeReaders(chunk1, file, scanSpec, passStringBuffersFromDecoder);
+
+  // Batch 0 (offset=0, rows 0-249): chunk 1, 500 remaining >= 250 → dict
+  // Batch 1 (offset=250, rows 250-499): chunk 1, 250 remaining >= 250 → dict
+  //   After this batch, decoder has consumed all 500 values in chunk 1.
+  // Batch 2 (offset=500, rows 500-749): c0 rejects all → c1 lazy, not loaded.
+  //   readOffset stays at 500, decoder remainingValues=0.
+  // Batch 3 (offset=750, rows 750-999): c1 loaded via ColumnLoader.
+  //   ensureLoaded() loads chunk 2 (remainingValues=500). readOffset=500,
+  //   offset=750, skip=250 within chunk 2. 500 >= 250+250=500 → dict.
+  using E = VectorEncoding::Simple;
+  validateWithEncodingChecks(
+      *expectedStrings,
+      *readers.rowReader,
+      kBatchSize,
+      /*totalRows=*/2 * kChunkRows,
+      {E::DICTIONARY, E::DICTIONARY, E::DICTIONARY},
+      readType,
+      pool(),
+      /*childIndex=*/1);
+}
+
+// Verifies that the remainingValues gate
+// forces a flat-path fallback mid-file. With 2 chunks of 300 rows and batch
+// size 200:
+//   Read 1 (rows 0-199): chunk 1 has 300 remaining >= 200, dict path taken,
+//     alphabet built from chunk 1.
+//   Read 2 (rows 200-399): chunk 1 has only 100 remaining < 200, falls to flat
+//     path which must clear dictionary state.
+//   Read 3 (rows 400-599): chunk 2 has enough rows, dict path re-entered.
+//     Must rebuild alphabet from chunk 2, not reuse stale chunk 1 alphabet.
+TEST_P(StringColumnReaderTest, readAcrossChunkBoundary) {
+  const bool passStringBuffersFromDecoder = GetParam();
+  if (!passStringBuffersFromDecoder) {
+    return;
+  }
+
+  auto chunk1 = makeRowVector({makeFlatVector<std::string>(300, [](auto i) {
+    return std::vector<std::string>{"aaa", "bbb"}[i % 2];
+  })});
+  auto chunk2 = makeRowVector({makeFlatVector<std::string>(300, [](auto i) {
+    return std::vector<std::string>{"xxx", "yyy"}[i % 2];
+  })});
+
+  VeloxWriterOptions writerOptions;
+  writerOptions.enableChunking = true;
+  writerOptions.minStreamChunkRawSize = 0;
+  writerOptions.flushPolicyFactory = [] {
+    return std::make_unique<LambdaFlushPolicy>(
+        /*flushLambda=*/[](const StripeProgress&) { return false; },
+        /*chunkLambda=*/[](const StripeProgress&) { return true; });
+  };
+  auto file = test::createNimbleFile(
+      *rootPool(), {chunk1, chunk2}, writerOptions, /*flushAfterWrite=*/false);
+
+  auto expected = makeRowVector({makeFlatVector<std::string>(600, [](auto i) {
+    if (i < 300) {
+      return std::vector<std::string>{"aaa", "bbb"}[i % 2];
+    }
+    return std::vector<std::string>{"xxx", "yyy"}[(i - 300) % 2];
+  })});
+
+  auto scanSpec = std::make_shared<common::ScanSpec>("root");
+  scanSpec->addAllChildFields(*expected->type());
+  auto readers =
+      makeReaders(expected, file, scanSpec, passStringBuffersFromDecoder);
+  // 600 rows, batch_size=200, chunk boundary at 300:
+  //   Batch 0 (0-199): 300 remaining >= 200 → dict
+  //   Batch 1 (200-399): 100 remaining < 200 → flat (crosses boundary)
+  //   Batch 2 (400-599): chunk 2, 300 remaining >= 200 → dict
+  using E = VectorEncoding::Simple;
+  validateWithEncodingChecks(
+      *expected->childAt(0),
+      *readers.rowReader,
+      200,
+      /*totalRows=*/600,
+      {E::DICTIONARY, E::FLAT, E::DICTIONARY},
+      asRowType(expected->type()),
+      pool());
+}
+
+// Flatmap string column read via dictionary path.
+// When a string column is inside a flatmap, rows where the key is absent have
+// inMap=0 (null). The encoding only has data for in-map rows. The dictionary
+// path must account for these nulls when reading indices. If kHasNulls is
+// ignored in readDictionaryIndicesImpl, the encoding will try to read more
+// values than it contains.
+TEST_P(StringColumnReaderTest, flatMapStringDictionaryPath) {
+  const bool stringDecoderZeroCopy = GetParam();
+  if (!stringDecoderZeroCopy) {
+    GTEST_SKIP() << "Dictionary path requires stringDecoderZeroCopy";
+  }
+
+  // Write map<int8_t, varchar> as a flatmap. Key 1 is present in all rows,
+  // key 2 is present in only some rows (creating inMap nulls for key 2).
+  constexpr int kRows = 100;
+  std::vector<int8_t> allKeys;
+  std::vector<std::string> allVals;
+  std::vector<vector_size_t> mapOffsets;
+  std::vector<vector_size_t> mapSizes;
+  for (int i = 0; i < kRows; ++i) {
+    mapOffsets.push_back(allKeys.size());
+    allKeys.push_back(1);
+    allVals.push_back("val_" + std::to_string(i % 5));
+    if (i % 3 != 0) {
+      allKeys.push_back(2);
+      allVals.push_back("key2_" + std::to_string(i % 4));
+    }
+    mapSizes.push_back(allKeys.size() - mapOffsets.back());
+  }
+  auto keysFv = makeFlatVector<int8_t>(allKeys);
+  auto valsFv = makeFlatVector<std::string>(allVals);
+  auto offBuf = allocateOffsets(kRows, pool());
+  auto sizBuf = allocateSizes(kRows, pool());
+  auto* rawOff = offBuf->asMutable<vector_size_t>();
+  auto* rawSiz = sizBuf->asMutable<vector_size_t>();
+  for (int i = 0; i < kRows; ++i) {
+    rawOff[i] = mapOffsets[i];
+    rawSiz[i] = mapSizes[i];
+  }
+  auto input = makeRowVector({std::make_shared<MapVector>(
+      pool(),
+      MAP(TINYINT(), VARCHAR()),
+      nullptr,
+      kRows,
+      offBuf,
+      sizBuf,
+      keysFv,
+      valsFv)});
+
+  VeloxWriterOptions writerOptions;
+  writerOptions.flatMapColumns = {{"c0", {}}};
+  auto file = test::createNimbleFile(*rootPool(), input, writerOptions);
+
+  // Read back as struct with flatmap-as-struct projection.
+  auto outType = ROW({"c0"}, {ROW({"1", "2"}, {VARCHAR(), VARCHAR()})});
+  auto scanSpec = std::make_shared<common::ScanSpec>("root");
+  scanSpec->addAllChildFields(*outType);
+  scanSpec->childByName("c0")->setFlatMapAsStruct(true);
+
+  auto readFile = std::make_shared<InMemoryReadFile>(file);
+  auto factory =
+      dwio::common::getReaderFactory(dwio::common::FileFormat::NIMBLE);
+  dwio::common::ReaderOptions options(
+      pool(), dataIoStats_.get(), metadataIoStats_.get());
+  options.setScanSpec(scanSpec);
+  auto reader = factory->createReader(
+      std::make_unique<dwio::common::BufferedInput>(readFile, *pool()),
+      options);
+  dwio::common::RowReaderOptions rowOptions;
+  rowOptions.setScanSpec(scanSpec);
+  rowOptions.setRequestedType(asRowType(input->type()));
+  rowOptions.setStringDecoderZeroCopy(true);
+  auto rowReader = reader->createRowReader(rowOptions);
+
+  // Build expected output: key 1 always present, key 2 null when i%3==0.
+  auto expected = makeRowVector({makeRowVector(
+      {"1", "2"},
+      {
+          makeFlatVector<std::string>(
+              kRows, [](auto i) { return "val_" + std::to_string(i % 5); }),
+          makeFlatVector<std::string>(
+              kRows,
+              [](auto i) { return "key2_" + std::to_string(i % 4); },
+              [](auto i) { return i % 3 == 0; }),
+      })});
+
+  auto result = BaseVector::create(outType, 0, pool());
+  int numScanned = 0;
+  int offset = 0;
+  while (numScanned < kRows) {
+    numScanned += rowReader->next(23, result);
+    result->validate();
+    for (int j = 0; j < result->size(); ++j) {
+      ASSERT_TRUE(result->equalValueAt(expected.get(), j, offset + j))
+          << "Mismatch at row " << (offset + j) << ": expected "
+          << expected->toString(offset + j) << " got " << result->toString(j);
+    }
+    offset += result->size();
+  }
+  ASSERT_EQ(numScanned, kRows);
+  ASSERT_EQ(0, rowReader->next(1, result));
+}
+
+// Verifies that dictionary state is invalidated via onChunkLoad when a flat
+// path read triggers a chunk transition, and the next dict-path read must
+// rebuild its alphabet from the new chunk.
+//
+// Verifies that dictionary state is invalidated via onChunkLoad when
+// consecutive reads consume exactly aligned chunks.
+//
+// Layout: chunk 1 and chunk 2 both have exactly kBatchSize rows.
+// With the ensureLoaded() fix (reload when remainingValues_==0):
+//   Read 1: ensureLoaded() loads chunk 1, remainingValues==kBatchSize,
+//     dict path entered, alphabet built from chunk 1 (2 entries).
+//   Read 2: remainingValues==0, ensureLoaded() loads chunk 2 via
+//     loadNextChunk() which fires onChunkLoad → clears dictionaryState_.
+//     Dict path re-entered, alphabet rebuilt from chunk 2 (3 entries).
+// Without onChunkLoad: stale 2-entry alphabet is reused for chunk 2's
+// 3-entry dictionary, producing wrong values or index-out-of-bounds.
+DEBUG_ONLY_TEST_P(
+    StringColumnReaderTest,
+    chunkTransitionInvalidatesDictionaryState) {
+  const bool stringDecoderZeroCopy = GetParam();
+  if (!stringDecoderZeroCopy) {
+    GTEST_SKIP() << "Dictionary path requires stringDecoderZeroCopy";
+  }
+
+  constexpr int kBatchSize = 500;
+  // Chunk 1: 3-entry alphabet {"aaa", "bbb", "ccc"}.
+  auto chunk1 =
+      makeRowVector({makeFlatVector<std::string>(kBatchSize, [](auto i) {
+        return std::vector<std::string>{"aaa", "bbb", "ccc"}[i % 3];
+      })});
+  // Chunk 2: completely different 5-entry alphabet.
+  auto chunk2 =
+      makeRowVector({makeFlatVector<std::string>(kBatchSize, [](auto i) {
+        return std::vector<std::string>{"pp", "qq", "rr", "ss", "tt"}[i % 5];
+      })});
+
+  // Write chunks manually so each write() produces exactly one chunk.
+  // Set minStreamChunkRawSize=0 to prevent the chunker from merging small
+  // writes into a single chunk.
+  VeloxWriterOptions writerOptions;
+  writerOptions.enableChunking = true;
+  writerOptions.minStreamChunkRawSize = 0;
+  writerOptions.flushPolicyFactory = [] {
+    return std::make_unique<LambdaFlushPolicy>(
+        /*flushLambda=*/[](const StripeProgress&) { return false; },
+        /*chunkLambda=*/[](const StripeProgress&) { return true; });
+  };
+  std::string file;
+  {
+    auto writeFile = std::make_unique<velox::InMemoryWriteFile>(&file);
+    VeloxWriter writer(
+        chunk1->type(),
+        std::move(writeFile),
+        *rootPool(),
+        std::move(writerOptions));
+    writer.write(chunk1);
+    writer.write(chunk2);
+    writer.close();
+  }
+
+  auto expected =
+      makeRowVector({makeFlatVector<std::string>(kBatchSize * 2, [](auto i) {
+        if (i < kBatchSize) {
+          return std::vector<std::string>{"aaa", "bbb", "ccc"}[i % 3];
+        }
+        return std::vector<std::string>{
+            "pp", "qq", "rr", "ss", "tt"}[(i - kBatchSize) % 5];
+      })});
+
+  auto scanSpec = std::make_shared<common::ScanSpec>("root");
+  scanSpec->addAllChildFields(*expected->type());
+  auto readers = makeReaders(expected, file, scanSpec, stringDecoderZeroCopy);
+
+  int dictPathEntries = 0;
+  SCOPED_TESTVALUE_SET(
+      "facebook::nimble::StringColumnReader::readWithDictionary",
+      std::function<void(const std::vector<std::string_view>*)>(
+          [&](const std::vector<std::string_view>* alphabet) {
+            std::set<std::string> entries;
+            for (const auto& sv : *alphabet) {
+              entries.insert(std::string(sv));
+            }
+            if (dictPathEntries == 0) {
+              // Chunk 1 alphabet should contain chunk 1 values only.
+              EXPECT_TRUE(entries.count("aaa"));
+              EXPECT_FALSE(entries.count("pp"))
+                  << "Chunk 1 alphabet contains stale chunk 2 values";
+            } else {
+              // Chunk 2 alphabet should contain chunk 2 values only.
+              EXPECT_TRUE(entries.count("pp"));
+              EXPECT_FALSE(entries.count("aaa"))
+                  << "Chunk 2 alphabet contains stale chunk 1 values";
+            }
+            ++dictPathEntries;
+          }));
+
+  validateWithEncodingChecks(
+      *expected->childAt(0),
+      *readers.rowReader,
+      kBatchSize,
+      /*totalRows=*/2 * kBatchSize,
+      {VectorEncoding::Simple::DICTIONARY, VectorEncoding::Simple::DICTIONARY},
+      asRowType(expected->type()),
+      pool());
+  // Both reads should enter the dict path: one per chunk. The validate call
+  // verifies data correctness and DictionaryVector output — if the
+  // onChunkLoad callback didn't clear stale dictionary state, the second
+  // read would use chunk 1's alphabet to decode chunk 2's indices.
+  EXPECT_EQ(dictPathEntries, 2)
+      << "Expected dict path to be entered for both chunks";
+}
+
+// Verifies correctness when reads cross stripe boundaries in a non-chunked
+// layout. We always break reads at the stripe boundaries, so there are no chunk
+// transitions, thus we can always read with dictionary encoding.
+TEST_P(StringColumnReaderTest, readAcrossStripeBoundary) {
+  const bool stringDecoderZeroCopy = GetParam();
+  if (!stringDecoderZeroCopy) {
+    GTEST_SKIP() << "Dictionary path requires stringDecoderZeroCopy";
+  }
+
+  constexpr int kStripeRows = 150;
+  // Stripe 1: alphabet {"alpha", "bravo", "charlie"}.
+  auto stripe1 =
+      makeRowVector({makeFlatVector<std::string>(kStripeRows, [](auto i) {
+        return std::vector<std::string>{"alpha", "bravo", "charlie"}[i % 3];
+      })});
+  // Stripe 2: different alphabet {"delta", "echo"}.
+  auto stripe2 =
+      makeRowVector({makeFlatVector<std::string>(kStripeRows, [](auto i) {
+        return std::vector<std::string>{"delta", "echo"}[i % 2];
+      })});
+
+  // Each write call becomes a separate stripe. Remove MainlyConstant from
+  // read factors to force Dictionary as top-level encoding.
+  auto readFactors = ManualEncodingSelectionPolicyFactory::defaultReadFactors();
+  std::erase_if(readFactors, [](const auto& pair) {
+    return pair.first == EncodingType::MainlyConstant;
+  });
+  VeloxWriterOptions writerOptions;
+  writerOptions.enableChunking = true;
+  writerOptions.encodingSelectionPolicyFactory =
+      [readFactors](DataType dataType) {
+        return ManualEncodingSelectionPolicyFactory(readFactors)
+            .createPolicy(dataType);
+      };
+  auto file = test::createNimbleFile(
+      *rootPool(), {stripe1, stripe2}, writerOptions, /*flushAfterWrite=*/true);
+
+  auto expected =
+      makeRowVector({makeFlatVector<std::string>(kStripeRows * 2, [](auto i) {
+        if (i < kStripeRows) {
+          return std::vector<std::string>{"alpha", "bravo", "charlie"}[i % 3];
+        }
+        return std::vector<std::string>{"delta", "echo"}[(i - kStripeRows) % 2];
+      })});
+
+  auto scanSpec = std::make_shared<common::ScanSpec>("root");
+  scanSpec->addAllChildFields(*expected->type());
+  auto readers = makeReaders(expected, file, scanSpec, stringDecoderZeroCopy);
+  // 300 rows, batch_size=100, stripe boundary at 150:
+  //   Batch 0 (0-99): stripe 1, 150 remaining >= 100 → dict
+  //   Batch 1 (100-149): stripe 1, 50 remaining >= 50 → dict
+  //   Batch 2 (0-99): stripe 2 (fresh reader), 150 remaining >= 100 → dict
+  //   Batch 3 (100-149): stripe 2, 50 remaining >= 50 → dict
+  using E = VectorEncoding::Simple;
+  validateWithEncodingChecks(
+      *expected->childAt(0),
+      *readers.rowReader,
+      100,
+      /*totalRows=*/2 * kStripeRows,
+      {E::DICTIONARY, E::DICTIONARY, E::DICTIONARY, E::DICTIONARY},
+      asRowType(expected->type()),
+      pool());
+}
+
+// Verifies that the dictionary path is entered and the alphabet has the
+// expected size for single-chunk reads. Uses TestValue to inspect internal
+// reader state without exposing private members.
+DEBUG_ONLY_TEST_P(StringColumnReaderTest, dictionaryPathAlphabetSize) {
+  const bool stringDecoderZeroCopy = GetParam();
+  if (!stringDecoderZeroCopy) {
+    GTEST_SKIP() << "Dictionary path requires stringDecoderZeroCopy";
+  }
+
+  constexpr int kRows = 500;
+  // 3-entry alphabet with high repetition to trigger Dictionary encoding.
+  auto input = makeRowVector({makeFlatVector<std::string>(kRows, [](auto i) {
+    return std::vector<std::string>{"alpha", "bravo", "charlie"}[i % 3];
+  })});
+
+  auto scanSpec = std::make_shared<common::ScanSpec>("root");
+  scanSpec->addAllChildFields(*input->type());
+  auto readers = makeReaders(input, scanSpec, stringDecoderZeroCopy);
+
+  int dictPathEntries = 0;
+  SCOPED_TESTVALUE_SET(
+      "facebook::nimble::StringColumnReader::readWithDictionary",
+      std::function<void(const std::vector<std::string_view>*)>(
+          [&](const std::vector<std::string_view>* alphabet) {
+            ++dictPathEntries;
+            std::set<std::string> entries;
+            for (const auto& sv : *alphabet) {
+              entries.insert(std::string(sv));
+            }
+            EXPECT_TRUE(entries.count("alpha"));
+            EXPECT_TRUE(entries.count("bravo"));
+            EXPECT_TRUE(entries.count("charlie"));
+          }));
+
+  validateWithEncodingChecks(
+      *input->childAt(0),
+      *readers.rowReader,
+      kRows,
+      /*totalRows=*/kRows,
+      {VectorEncoding::Simple::DICTIONARY},
+      asRowType(input->type()),
+      pool());
+  EXPECT_EQ(dictPathEntries, 1);
 }
 
 INSTANTIATE_TEST_CASE_P(


### PR DESCRIPTION
Summary:

The selective reader common framework has some infrastructure to decode, filter and operate based on dictionary encodings, and then preserve the dictionary encoding to the output vector. This largely reduces the cpu cost and memory footprint for string selective readers for data shapes with high dictionary efficiency.

In this diff stack, we utilize the DictionaryColumnVisitor for nimble selective reader in the follow steps:
1) preserve dictionary vector for pure dictionary encoded data without filter pushdown
2) utilize the optimization for nested encodings
3) utilize the optimization even with mixed encoding types across chunks
4) integrate filter pushdown for this optimization
For each step of the implementation we essentially guard the utilization of the added optimizations based on workload shape, while ensuring all tests would pass. 

This is the diff for step 1), where we add the crux of the optimization and all the necessary test cases. Specifically,
a) introduce readIndicesWithVisitor methods for the relevant encodings, and the new dispatch methods e2e (encoding utils -> decoder -> reader)
b) utilize StringDictionaryColumnVisitor in string reader when we have the applicable simple encoding layout.

Reviewed By: xiaoxmeng

Differential Revision: D93419988


