### PR TITLE
feat: Add LZ4 compressor to Nimble encoding framework

### DIFF
--- a/dwio/nimble/common/Constants.h
+++ b/dwio/nimble/common/Constants.h
@@ -24,6 +24,7 @@ namespace facebook::nimble {
 /// than this threshold.
 constexpr uint32_t kMetaInternalMinCompressionSize{40};
 constexpr uint32_t kZstdMinCompressionSize{25};
+constexpr uint32_t kLz4MinCompressionSize{12};
 
 /// Default options for the ChunkFlushPolicy.
 /// Threshold to trigger chunking to relieve memory pressure

--- a/dwio/nimble/common/Types.cpp
+++ b/dwio/nimble/common/Types.cpp
@@ -98,8 +98,8 @@ std::string toString(CompressionType compressionType) {
       return "Zstd";
     case CompressionType::MetaInternal:
       return "MetaInternal";
-    case CompressionType::LZ4:
-      return "LZ4";
+    case CompressionType::Lz4:
+      return "Lz4";
     default:
       return fmt::format(
           "Unknown compression type: {}",

--- a/dwio/nimble/common/Types.h
+++ b/dwio/nimble/common/Types.h
@@ -134,8 +134,7 @@ enum class CompressionType : uint8_t {
   // Zstd doesn't require us to externally store level or any other info.
   Zstd = 1,
   MetaInternal = 2,
-  // LZ4 block mode; requires externally stored uncompressed size.
-  LZ4 = 3,
+  Lz4 = 3,
 };
 
 std::string toString(CompressionType compressionType);

--- a/dwio/nimble/common/tests/TypesTest.cpp
+++ b/dwio/nimble/common/tests/TypesTest.cpp
@@ -90,7 +90,7 @@ TEST(TypesTest, CompressionTypeToString) {
   EXPECT_EQ(toString(CompressionType::Uncompressed), "Uncompressed");
   EXPECT_EQ(toString(CompressionType::Zstd), "Zstd");
   EXPECT_EQ(toString(CompressionType::MetaInternal), "MetaInternal");
-  EXPECT_EQ(toString(CompressionType::LZ4), "LZ4");
+  EXPECT_EQ(toString(CompressionType::Lz4), "Lz4");
 }
 
 TEST(TypesTest, CompressionTypeToStringUnknown) {

--- a/dwio/nimble/encodings/CMakeLists.txt
+++ b/dwio/nimble/encodings/CMakeLists.txt
@@ -18,6 +18,7 @@ add_subdirectory(legacy)
 add_library(
   nimble_encodings
   Compression.cpp
+  Lz4Compressor.cpp
   ConstantEncoding.cpp
   Encoding.cpp
   EncodingFactory.cpp
@@ -38,4 +39,5 @@ target_link_libraries(
   Folly::folly
   absl::flat_hash_map
   protobuf::libprotobuf
+  lz4
 )

--- a/dwio/nimble/encodings/Compression.cpp
+++ b/dwio/nimble/encodings/Compression.cpp
@@ -16,6 +16,7 @@
 #include "dwio/nimble/encodings/Compression.h"
 #include "dwio/nimble/common/EncodingPrimitives.h"
 #include "dwio/nimble/common/Exceptions.h"
+#include "dwio/nimble/encodings/Lz4Compressor.h"
 #include "dwio/nimble/encodings/ZstdCompressor.h"
 
 #ifndef DISABLE_META_INTERNAL_COMPRESSOR
@@ -28,9 +29,11 @@ namespace {
 
 struct CompressorRegistry {
   CompressorRegistry() {
-    compressors.reserve(2);
+    compressors.reserve(3);
     compressors.emplace(
         CompressionType::Zstd, std::make_unique<ZstdCompressor>());
+    compressors.emplace(
+        CompressionType::Lz4, std::make_unique<Lz4Compressor>());
 #ifndef DISABLE_META_INTERNAL_COMPRESSOR
     compressors.emplace(
         CompressionType::MetaInternal,

--- a/dwio/nimble/encodings/EncodingSelection.h
+++ b/dwio/nimble/encodings/EncodingSelection.h
@@ -76,6 +76,10 @@ struct ZstdCompressionParameters {
   int16_t compressionLevel = 3;
 };
 
+struct Lz4CompressionParameters {
+  int16_t accelerationLevel = 1;
+};
+
 /// An identifier for the meta internal compression policy.
 class MetaInternalCompressionKey {
  public:
@@ -131,6 +135,7 @@ struct MetaInternalCompressionParameters {
 
 struct CompressionParameters {
   ZstdCompressionParameters zstd{};
+  Lz4CompressionParameters lz4{};
   MetaInternalCompressionParameters metaInternal{};
 };
 

--- a/dwio/nimble/encodings/EncodingSelectionPolicy.h
+++ b/dwio/nimble/encodings/EncodingSelectionPolicy.h
@@ -109,6 +109,8 @@ struct CompressionOptions {
 #endif
   uint64_t zstdMinCompressionSize = kZstdMinCompressionSize;
   uint32_t zstdCompressionLevel = 3;
+  uint64_t lz4MinCompressionSize = kLz4MinCompressionSize;
+  uint32_t lz4AccelerationLevel = 1;
   uint64_t internalMinCompressionSize = kMetaInternalMinCompressionSize;
   uint32_t internalCompressionLevel = 4;
   uint32_t internalDecompressionLevel = 2;
@@ -223,6 +225,14 @@ class ManualEncodingSelectionPolicy : public EncodingSelectionPolicy<T> {
               .minCompressionSize = compressionOptions_.zstdMinCompressionSize};
           information.parameters.zstd.compressionLevel =
               compressionOptions_.zstdCompressionLevel;
+          return information;
+        }
+        if (compressionOptions_.compressionType == CompressionType::Lz4) {
+          CompressionInformation information{
+              .compressionType = CompressionType::Lz4,
+              .minCompressionSize = compressionOptions_.lz4MinCompressionSize};
+          information.parameters.lz4.accelerationLevel =
+              compressionOptions_.lz4AccelerationLevel;
           return information;
         }
         CompressionInformation information{

--- a/dwio/nimble/encodings/Lz4Compressor.cpp
+++ b/dwio/nimble/encodings/Lz4Compressor.cpp
@@ -1,0 +1,78 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "dwio/nimble/encodings/Lz4Compressor.h"
+
+#include <lz4.h>
+#include <optional>
+
+namespace facebook::nimble {
+
+CompressionResult Lz4Compressor::compress(
+    velox::memory::MemoryPool& memoryPool,
+    std::string_view data,
+    DataType /* dataType */,
+    int /* bitWidth */,
+    const CompressionPolicy& compressionPolicy) {
+  auto parameters = compressionPolicy.compression().parameters.lz4;
+  Vector<char> buffer{&memoryPool, data.size() + sizeof(uint32_t)};
+  auto pos = buffer.data();
+  encoding::writeUint32(data.size(), pos);
+  auto ret = LZ4_compress_fast(
+      data.data(), pos, data.size(), data.size(), parameters.accelerationLevel);
+  if (ret == 0 || static_cast<size_t>(ret) + sizeof(uint32_t) >= data.size()) {
+    return {
+        .compressionType = CompressionType::Uncompressed,
+        .buffer = std::nullopt,
+    };
+  }
+
+  buffer.resize(ret + sizeof(uint32_t));
+  return {
+      .compressionType = CompressionType::Lz4,
+      .buffer = std::move(buffer),
+  };
+}
+
+velox::BufferPtr Lz4Compressor::uncompress(
+    velox::memory::MemoryPool& memoryPool,
+    const CompressionType /* compressionType */,
+    const DataType /* dataType */,
+    std::string_view data,
+    velox::BufferPool* bufferPool) {
+  auto pos = data.data();
+  const uint32_t uncompressedSize = encoding::readUint32(pos);
+  auto buffer = allocateBuffer(memoryPool, bufferPool, uncompressedSize);
+  auto ret = LZ4_decompress_safe(
+      pos,
+      buffer->asMutable<char>(),
+      data.size() - sizeof(uint32_t),
+      uncompressedSize);
+  NIMBLE_CHECK(ret >= 0, "Error decompressing LZ4 data.");
+  return buffer;
+}
+
+std::optional<size_t> Lz4Compressor::uncompressedSize(
+    std::string_view data) const {
+  auto* pos = data.data();
+  return encoding::readUint32(pos);
+}
+
+CompressionType Lz4Compressor::compressionType() {
+  return CompressionType::Lz4;
+}
+
+} // namespace facebook::nimble

--- a/dwio/nimble/encodings/Lz4Compressor.h
+++ b/dwio/nimble/encodings/Lz4Compressor.h
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "dwio/nimble/encodings/Compression.h"
+
+namespace facebook::nimble {
+
+class Lz4Compressor : public ICompressor {
+ public:
+  CompressionResult compress(
+      velox::memory::MemoryPool& memoryPool,
+      std::string_view data,
+      DataType dataType,
+      int bitWidth,
+      const CompressionPolicy& compressionPolicy) override;
+
+  velox::BufferPtr uncompress(
+      velox::memory::MemoryPool& memoryPool,
+      CompressionType compressionType,
+      DataType dataType,
+      std::string_view data,
+      velox::BufferPool* bufferPool = nullptr) override;
+
+  std::optional<size_t> uncompressedSize(std::string_view data) const override;
+
+  CompressionType compressionType() override;
+};
+
+} // namespace facebook::nimble

--- a/dwio/nimble/encodings/tests/CMakeLists.txt
+++ b/dwio/nimble/encodings/tests/CMakeLists.txt
@@ -19,8 +19,10 @@ add_executable(
   ConstantEncodingTest.cpp
   EncodingLayoutTest.cpp
   EncodingSelectionTest.cpp
+  CompressionTest.cpp
   EncodingTest.cpp
   EncodingLegacyTest.cpp
+  Lz4CompressorTest.cpp
   MainlyConstantEncodingTest.cpp
   NullableEncodingTest.cpp
   PrefixEncodingTest.cpp

--- a/dwio/nimble/encodings/tests/CompressionTest.cpp
+++ b/dwio/nimble/encodings/tests/CompressionTest.cpp
@@ -37,13 +37,15 @@ class TestCompressionPolicy : public nimble::CompressionPolicy {
       uint64_t minCompressionSize) {
     EXPECT_TRUE(
         compressionType == nimble::CompressionType::Zstd ||
-        compressionType == nimble::CompressionType::MetaInternal);
+        compressionType == nimble::CompressionType::MetaInternal ||
+        compressionType == nimble::CompressionType::Lz4);
 
     compressionInfo_ = {
         .compressionType = compressionType,
         .minCompressionSize = minCompressionSize};
 
     compressionInfo_.parameters.zstd.compressionLevel = 3;
+    compressionInfo_.parameters.lz4.accelerationLevel = 1;
     compressionInfo_.parameters.metaInternal.compressionLevel = 4;
     compressionInfo_.parameters.metaInternal.decompressionLevel = 2;
   }
@@ -132,6 +134,12 @@ TYPED_TEST(CompressionTests, MinCompressibleSizeZstd) {
       nimble::CompressionType::Zstd, nimble::kZstdMinCompressionSize);
 }
 
+TYPED_TEST(CompressionTests, MinCompressibleSizeLz4) {
+  using T = TypeParam;
+  assertMinCompressibleSizeMetaInternal<T>(
+      nimble::CompressionType::Lz4, nimble::kLz4MinCompressionSize);
+}
+
 TEST(CompressionTests, VerifyDefaultMinCompressionSize) {
   nimble::CompressionOptions compressionOptions{};
   EXPECT_EQ(
@@ -140,6 +148,8 @@ TEST(CompressionTests, VerifyDefaultMinCompressionSize) {
   EXPECT_EQ(
       compressionOptions.zstdMinCompressionSize,
       nimble::kZstdMinCompressionSize);
+  EXPECT_EQ(
+      compressionOptions.lz4MinCompressionSize, nimble::kLz4MinCompressionSize);
 }
 
 TEST(CompressionTests, MinCompresssionSizeIsApplied) {

--- a/dwio/nimble/encodings/tests/Lz4CompressorTest.cpp
+++ b/dwio/nimble/encodings/tests/Lz4CompressorTest.cpp
@@ -1,0 +1,153 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "dwio/nimble/encodings/Lz4Compressor.h"
+#include <gtest/gtest.h>
+#include <cstring>
+#include <random>
+#include "velox/common/memory/Memory.h"
+
+using namespace facebook::nimble;
+
+namespace {
+
+class TestLz4CompressionPolicy : public CompressionPolicy {
+ public:
+  explicit TestLz4CompressionPolicy(uint64_t minCompressionSize = 0) {
+    compressionInfo_ = {
+        .compressionType = CompressionType::Lz4,
+        .minCompressionSize = minCompressionSize};
+    compressionInfo_.parameters.lz4.accelerationLevel = 1;
+  }
+
+  CompressionInformation compression() const override {
+    return compressionInfo_;
+  }
+
+  bool shouldAccept(
+      CompressionType /* compressionType */,
+      uint64_t uncompressedSize,
+      uint64_t compressedSize) const override {
+    return compressedSize < uncompressedSize;
+  }
+
+ private:
+  CompressionInformation compressionInfo_;
+};
+
+} // namespace
+
+TEST(Lz4CompressorTest, CompressionType) {
+  Lz4Compressor compressor;
+  EXPECT_EQ(CompressionType::Lz4, compressor.compressionType());
+}
+
+TEST(Lz4CompressorTest, RoundTrip) {
+  auto pool = facebook::velox::memory::deprecatedAddDefaultLeafMemoryPool();
+  Lz4Compressor compressor;
+  TestLz4CompressionPolicy policy;
+
+  std::vector<char> original(1024);
+  for (size_t i = 0; i < original.size(); ++i) {
+    original[i] = static_cast<char>(i % 10);
+  }
+  std::string_view input(original.data(), original.size());
+
+  auto result = compressor.compress(*pool, input, DataType::Int8, 0, policy);
+  EXPECT_EQ(CompressionType::Lz4, result.compressionType);
+  ASSERT_TRUE(result.buffer.has_value());
+
+  std::string_view compressed(result.buffer->data(), result.buffer->size());
+
+  auto decompressed = compressor.uncompress(
+      *pool, CompressionType::Lz4, DataType::Int8, compressed);
+  ASSERT_EQ(original.size(), decompressed->size());
+  EXPECT_EQ(
+      0,
+      std::memcmp(original.data(), decompressed->as<char>(), original.size()));
+}
+
+TEST(Lz4CompressorTest, UncompressedSize) {
+  auto pool = facebook::velox::memory::deprecatedAddDefaultLeafMemoryPool();
+  Lz4Compressor compressor;
+  TestLz4CompressionPolicy policy;
+
+  std::vector<char> original(512);
+  for (size_t i = 0; i < original.size(); ++i) {
+    original[i] = static_cast<char>(i % 7);
+  }
+  std::string_view input(original.data(), original.size());
+
+  auto result = compressor.compress(*pool, input, DataType::Int32, 0, policy);
+  ASSERT_EQ(CompressionType::Lz4, result.compressionType);
+  ASSERT_TRUE(result.buffer.has_value());
+
+  std::string_view compressed(result.buffer->data(), result.buffer->size());
+  auto size = compressor.uncompressedSize(compressed);
+  ASSERT_TRUE(size.has_value());
+  EXPECT_EQ(original.size(), size.value());
+}
+
+TEST(Lz4CompressorTest, IncompressibleData) {
+  auto pool = facebook::velox::memory::deprecatedAddDefaultLeafMemoryPool();
+  Lz4Compressor compressor;
+  TestLz4CompressionPolicy policy;
+
+  std::mt19937 rng(42);
+  std::uniform_int_distribution<int> dist(0, 255);
+  std::vector<char> randomData(256);
+  for (auto& byte : randomData) {
+    byte = static_cast<char>(dist(rng));
+  }
+  std::string_view input(randomData.data(), randomData.size());
+
+  auto result = compressor.compress(*pool, input, DataType::Int8, 0, policy);
+  EXPECT_EQ(CompressionType::Uncompressed, result.compressionType);
+  EXPECT_FALSE(result.buffer.has_value());
+}
+
+TEST(Lz4CompressorTest, RoundTripVariousDataTypes) {
+  auto pool = facebook::velox::memory::deprecatedAddDefaultLeafMemoryPool();
+  Lz4Compressor compressor;
+  TestLz4CompressionPolicy policy;
+
+  std::vector<int32_t> int32Data(256, 42);
+  std::string_view input(
+      reinterpret_cast<const char*>(int32Data.data()),
+      int32Data.size() * sizeof(int32_t));
+
+  auto result = compressor.compress(*pool, input, DataType::Int32, 0, policy);
+  EXPECT_EQ(CompressionType::Lz4, result.compressionType);
+  ASSERT_TRUE(result.buffer.has_value());
+
+  std::string_view compressed(result.buffer->data(), result.buffer->size());
+  auto decompressed = compressor.uncompress(
+      *pool, CompressionType::Lz4, DataType::Int8, compressed);
+  ASSERT_EQ(input.size(), decompressed->size());
+  EXPECT_EQ(
+      0, std::memcmp(input.data(), decompressed->as<char>(), input.size()));
+}
+
+TEST(Lz4CompressorTest, MinCompressionSizeSkipsSmallData) {
+  auto pool = facebook::velox::memory::deprecatedAddDefaultLeafMemoryPool();
+  Lz4Compressor compressor;
+
+  std::vector<char> data(50, 'a');
+  std::string_view input(data.data(), data.size());
+
+  TestLz4CompressionPolicy policy(data.size() + 1);
+  CompressionEncoder<int8_t> encoder{*pool, policy, DataType::Int8, input};
+  EXPECT_EQ(CompressionType::Uncompressed, encoder.compressionType());
+}

--- a/dwio/nimble/serializer/DeserializerImpl.cpp
+++ b/dwio/nimble/serializer/DeserializerImpl.cpp
@@ -146,7 +146,7 @@ void StreamData::decompress() {
       end_ = pos_ + decompressedSize;
       break;
     }
-    case CompressionType::LZ4: {
+    case CompressionType::Lz4: {
       // LZ4 block data is preceded by the uncompressed size (uint32).
       // Wire format: [origSize:u32][lz4_data...]
       const auto decompressedSize = encoding::readUint32(pos_);
@@ -403,7 +403,7 @@ void StreamDataReader::appendChunkData(
       NIMBLE_CHECK(!ZSTD_isError(ret), "Error decompressing chunk data");
       break;
     }
-    case CompressionType::LZ4: {
+    case CompressionType::Lz4: {
       const auto* pos = data;
       const auto decompressedSize = encoding::readUint32(pos);
       const auto compressedSize =

--- a/dwio/nimble/serializer/SerializerImpl.cpp
+++ b/dwio/nimble/serializer/SerializerImpl.cpp
@@ -144,7 +144,7 @@ encode(const SerializerOptions& options, std::string_view input, char* output) {
         }
         break;
       }
-      case CompressionType::LZ4: {
+      case CompressionType::Lz4: {
         // LZ4 block mode is not self-descriptive (unlike ZSTD frames), so we
         // prepend the uncompressed size as a uint32 before the compressed data.
         // Wire format: [size:u32][compType:i8=3][origSize:u32][lz4_data...]

--- a/dwio/nimble/serializer/tests/SerializerImplTest.cpp
+++ b/dwio/nimble/serializer/tests/SerializerImplTest.cpp
@@ -1751,7 +1751,7 @@ class LZ4RoundtripTest : public TabletRawChunkStripTest {
  protected:
   static std::string buildLegacyLZ4CompressedData(std::string_view payload) {
     std::string result;
-    result.push_back(static_cast<char>(CompressionType::LZ4));
+    result.push_back(static_cast<char>(CompressionType::Lz4));
 
     const auto origSize = static_cast<uint32_t>(payload.size());
     result.resize(result.size() + sizeof(uint32_t));
@@ -1788,7 +1788,7 @@ class LZ4RoundtripTest : public TabletRawChunkStripTest {
     std::string chunk(kChunkHeaderSize + chunkPayloadSize, '\0');
     auto* pos = chunk.data();
     writeChunkHeader(
-        static_cast<uint32_t>(chunkPayloadSize), CompressionType::LZ4, pos);
+        static_cast<uint32_t>(chunkPayloadSize), CompressionType::Lz4, pos);
     encoding::writeUint32(static_cast<uint32_t>(data.size()), pos);
     std::memcpy(pos, compressed.data(), compressedSize);
     return chunk;
@@ -1916,7 +1916,7 @@ TEST_F(LZ4RoundtripTest, encodeDecodeLZ4Roundtrip) {
       expected.size() * sizeof(int32_t));
 
   SerializerOptions options;
-  options.compressionType = CompressionType::LZ4;
+  options.compressionType = CompressionType::Lz4;
   options.compressionThreshold = 1;
 
   std::string buffer(input.size() + 2 * sizeof(uint32_t) + 1, '\0');
@@ -1951,7 +1951,7 @@ TEST_F(LZ4RoundtripTest, encodeLZ4BelowThresholdStaysUncompressed) {
       expected.size() * sizeof(int32_t));
 
   SerializerOptions options;
-  options.compressionType = CompressionType::LZ4;
+  options.compressionType = CompressionType::Lz4;
   options.compressionThreshold = 1'000'000;
 
   std::string buffer(input.size() + 2 * sizeof(uint32_t) + 1, '\0');
@@ -1984,7 +1984,7 @@ TEST_F(LZ4RoundtripTest, encodeDecodeLZ4HighCompression) {
       expected.size() * sizeof(int32_t));
 
   SerializerOptions options;
-  options.compressionType = CompressionType::LZ4;
+  options.compressionType = CompressionType::Lz4;
   options.compressionThreshold = 1;
   options.compressionLevel = 9;
 

--- a/dwio/nimble/tablet/Footer.fbs
+++ b/dwio/nimble/tablet/Footer.fbs
@@ -19,6 +19,7 @@ enum CompressionType:uint8 {
   Uncompressed = 0,
   Zstd = 1,
   MetaInternal = 2,
+  Lz4 = 3,
 }
 
 table Stripes {


### PR DESCRIPTION
Summary:

Add LZ4 as a new compression type alongside Zstd and MetaInternal in the Nimble encoding framework. LZ4 offers faster compression/decompression with a lower compression ratio, which is useful for latency-sensitive workloads.

Changes:
- Add `Lz4 = 3` to `CompressionType` enum and FlatBuffers footer schema
- Add `Lz4Compressor` implementing `ICompressor` using `LZ4_compress_fast` / `LZ4_decompress_safe`
- Wire format matches Zstd: `[uncompressedSize:4B][lz4Data]`
- Add `Lz4CompressionParameters` with `accelerationLevel` (default 1)
- Add LZ4 fields to `CompressionOptions` and `AlwaysCompressPolicy`
- Register `Lz4Compressor` in the compressor registry
- Add `kLz4MinCompressionSize = 12` (experimentally derived)
- The compressor returns `Uncompressed` if compressed output >= original size

Reviewed By: xiaoxmeng

Differential Revision: D104136656
