### PR TITLE
refactor: Add IO stats setters to ReaderOptions and use pool-only constructor

### DIFF
--- a/dwio/nimble/tablet/tests/MetadataInputTest.cpp
+++ b/dwio/nimble/tablet/tests/MetadataInputTest.cpp
@@ -116,8 +116,9 @@ class MetadataInputTestBase : public ::testing::Test {
   velox::io::ReaderOptions makeReaderOptions(
       int32_t maxCoalesceDistance = 1 << 20,
       int64_t maxCoalesceBytes = 128 << 20) {
-    velox::io::ReaderOptions options(
-        pool_.get(), &dataIoStats_, &metadataIoStats_);
+    velox::io::ReaderOptions options(pool_.get());
+    options.setDataIoStats(&dataIoStats_);
+    options.setMetadataIoStats(&metadataIoStats_);
     options.setMaxCoalesceDistance(maxCoalesceDistance);
     options.setMaxCoalesceBytes(maxCoalesceBytes);
     return options;

--- a/dwio/nimble/tablet/tests/TabletTest.cpp
+++ b/dwio/nimble/tablet/tests/TabletTest.cpp
@@ -181,8 +181,9 @@ class TabletTest : public ::testing::TestWithParam<BufferedInputMode> {
     fileId_ = std::make_unique<velox::StringIdLease>(ids, "testFile");
     groupId_ = std::make_unique<velox::StringIdLease>(ids, "testGroup");
 
-    velox::io::ReaderOptions readerOptions(
-        pool_.get(), dataIoStats_.get(), metadataIoStats_.get());
+    velox::io::ReaderOptions readerOptions(pool_.get());
+    readerOptions.setDataIoStats(dataIoStats_.get());
+    readerOptions.setMetadataIoStats(metadataIoStats_.get());
 
     switch (mode) {
       case BufferedInputMode::kNone:
@@ -4182,8 +4183,9 @@ TEST_P(TabletTest, configureOptionsIndexFlags) {
     return std::find(sections.begin(), sections.end(), name) != sections.end();
   };
 
-  velox::dwio::common::ReaderOptions readerOptions(
-      pool_.get(), dataIoStats_.get(), metadataIoStats_.get());
+  velox::dwio::common::ReaderOptions readerOptions(pool_.get());
+  readerOptions.setDataIoStats(dataIoStats_.get());
+  readerOptions.setMetadataIoStats(metadataIoStats_.get());
 
   {
     SCOPED_TRACE("defaults");
@@ -4243,8 +4245,9 @@ TEST_P(TabletTest, configureOptionsIndexFlags) {
 TEST_P(TabletTest, configureOptionsBufferedInput) {
   // Verify configureOptions only sets bufferedInput when
   // fileMetadataCacheEnabled is true.
-  velox::dwio::common::ReaderOptions readerOptions(
-      pool_.get(), dataIoStats_.get(), metadataIoStats_.get());
+  velox::dwio::common::ReaderOptions readerOptions(pool_.get());
+  readerOptions.setDataIoStats(dataIoStats_.get());
+  readerOptions.setMetadataIoStats(metadataIoStats_.get());
 
   // Create a dummy BufferedInput to pass as the second parameter.
   std::string emptyFile;
@@ -4571,8 +4574,9 @@ TEST_F(TabletTest, concurrentReadersWithCacheEviction) {
       auto mode = static_cast<BufferedInputMode>(threadId % 4);
       std::unique_ptr<velox::dwio::common::BufferedInput> bi;
       std::shared_ptr<velox::cache::ScanTracker> tracker;
-      velox::io::ReaderOptions readerOptions(
-          threadPool.get(), dataIoStats_.get(), metadataIoStats_.get());
+      velox::io::ReaderOptions readerOptions(threadPool.get());
+      readerOptions.setDataIoStats(dataIoStats_.get());
+      readerOptions.setMetadataIoStats(metadataIoStats_.get());
       nimble::TabletReader::Options options;
 
       switch (mode) {

--- a/dwio/nimble/velox/index/tests/NimbleIndexProjectorTest.cpp
+++ b/dwio/nimble/velox/index/tests/NimbleIndexProjectorTest.cpp
@@ -118,8 +118,9 @@ class NimbleIndexProjectorTest : public ::testing::TestWithParam<TestParam> {
       const std::vector<Subfield>& projectedSubfields) {
     auto readFile =
         std::make_shared<InMemoryReadFile>(std::string_view(sinkData_));
-    dwio::common::ReaderOptions readerOptions(
-        leafPool_.get(), dataIoStats_.get(), metadataIoStats_.get());
+    dwio::common::ReaderOptions readerOptions(leafPool_.get());
+    readerOptions.setDataIoStats(dataIoStats_.get());
+    readerOptions.setMetadataIoStats(metadataIoStats_.get());
     readerOptions.setFileFormat(FileFormat::NIMBLE);
     readerOptions.setFileMetadataCacheEnabled(GetParam().enableCache);
     readerOptions.setPinFileMetadata(GetParam().pinFileMetadata);
@@ -887,8 +888,9 @@ TEST_P(NimbleIndexProjectorTest, featureReorderingStorageReads) {
   auto makeProjector = [&](int32_t maxCoalesceDistance) {
     auto readFile =
         std::make_shared<InMemoryReadFile>(std::string_view(sinkData_));
-    dwio::common::ReaderOptions readerOptions(
-        leafPool_.get(), dataIoStats_.get(), metadataIoStats_.get());
+    dwio::common::ReaderOptions readerOptions(leafPool_.get());
+    readerOptions.setDataIoStats(dataIoStats_.get());
+    readerOptions.setMetadataIoStats(metadataIoStats_.get());
     readerOptions.setFileFormat(FileFormat::NIMBLE);
     readerOptions.setMaxCoalesceDistance(maxCoalesceDistance);
 
@@ -1041,8 +1043,9 @@ TEST_P(NimbleIndexProjectorTest, pinnedMetadataNoReread) {
   const auto metadataBoundary = stripeGroupsMeta[0].offset();
   tablet.reset();
 
-  dwio::common::ReaderOptions readerOptions(
-      leafPool_.get(), dataIoStats_.get(), metadataIoStats_.get());
+  dwio::common::ReaderOptions readerOptions(leafPool_.get());
+  readerOptions.setDataIoStats(dataIoStats_.get());
+  readerOptions.setMetadataIoStats(metadataIoStats_.get());
   readerOptions.setFileFormat(FileFormat::NIMBLE);
   readerOptions.setFileMetadataCacheEnabled(GetParam().enableCache);
   readerOptions.setPinFileMetadata(GetParam().pinFileMetadata);

--- a/dwio/nimble/velox/selective/tests/E2EFilterTest.cpp
+++ b/dwio/nimble/velox/selective/tests/E2EFilterTest.cpp
@@ -372,8 +372,9 @@ class E2EFilterTest
       auto& ids = fileIds();
       StringIdLease fileId(ids, "testFile");
       StringIdLease groupId(ids, "testGroup");
-      io::ReaderOptions cacheReaderOpts(
-          &readerOpts.memoryPool(), dataIoStats_.get(), metadataIoStats_.get());
+      io::ReaderOptions cacheReaderOpts(&readerOpts.memoryPool());
+      cacheReaderOpts.setDataIoStats(dataIoStats_.get());
+      cacheReaderOpts.setMetadataIoStats(metadataIoStats_.get());
       input = std::make_unique<dwio::common::CachedBufferedInput>(
           std::move(readFile),
           dwio::common::MetricsLog::voidLog(),
@@ -1975,10 +1976,10 @@ TEST_P(E2EFilterTest, nestedMainlyConstantWithDictionary) {
 
   velox::io::IoStatistics dataIoStats;
   velox::io::IoStatistics metadataIoStats;
-  auto reader = makeReader(
-      velox::dwio::common::ReaderOptions{
-          leafPool_.get(), &dataIoStats, &metadataIoStats},
-      std::move(input));
+  velox::dwio::common::ReaderOptions readerOpts(leafPool_.get());
+  readerOpts.setDataIoStats(&dataIoStats);
+  readerOpts.setMetadataIoStats(&metadataIoStats);
+  auto reader = makeReader(readerOpts, std::move(input));
   auto scanSpec = std::make_shared<velox::common::ScanSpec>("root");
   scanSpec->addAllChildFields(*type);
   velox::dwio::common::RowReaderOptions rowReaderOptions;
@@ -2068,8 +2069,9 @@ TEST_P(E2EFilterTest, dictionaryVectorReturned) {
 
   velox::io::IoStatistics dataIoStats;
   velox::io::IoStatistics metadataIoStats;
-  velox::dwio::common::ReaderOptions readerOpts{
-      leafPool_.get(), &dataIoStats, &metadataIoStats};
+  velox::dwio::common::ReaderOptions readerOpts(leafPool_.get());
+  readerOpts.setDataIoStats(&dataIoStats);
+  readerOpts.setMetadataIoStats(&metadataIoStats);
   auto reader = makeReader(readerOpts, std::move(input));
   auto scanSpec = std::make_shared<velox::common::ScanSpec>("root");
   scanSpec->addAllChildFields(*type);
@@ -2200,10 +2202,10 @@ TEST_P(E2EFilterTest, crossChunkEncodingChange) {
 
   velox::io::IoStatistics dataIoStats;
   velox::io::IoStatistics metadataIoStats;
-  auto reader = makeReader(
-      velox::dwio::common::ReaderOptions{
-          leafPool_.get(), &dataIoStats, &metadataIoStats},
-      std::move(input));
+  velox::dwio::common::ReaderOptions crossChunkReaderOpts(leafPool_.get());
+  crossChunkReaderOpts.setDataIoStats(&dataIoStats);
+  crossChunkReaderOpts.setMetadataIoStats(&metadataIoStats);
+  auto reader = makeReader(crossChunkReaderOpts, std::move(input));
   auto scanSpec = std::make_shared<velox::common::ScanSpec>("root");
   scanSpec->addAllChildFields(*type);
   velox::dwio::common::RowReaderOptions rowReaderOptions;

--- a/dwio/nimble/velox/selective/tests/E2EIndexTest.cpp
+++ b/dwio/nimble/velox/selective/tests/E2EIndexTest.cpp
@@ -338,8 +338,9 @@ class E2EIndexTestBase : public ::testing::Test {
       uint32_t randomSeed = 0) {
     auto readFile =
         std::make_shared<InMemoryReadFile>(std::string_view(sinkData_));
-    dwio::common::ReaderOptions readerOptions(
-        leafPool_.get(), dataIoStats_.get(), metadataIoStats_.get());
+    dwio::common::ReaderOptions readerOptions(leafPool_.get());
+    readerOptions.setDataIoStats(dataIoStats_.get());
+    readerOptions.setMetadataIoStats(metadataIoStats_.get());
     readerOptions.setFileFormat(FileFormat::NIMBLE);
     setUpReaderOptions(readerOptions);
 
@@ -355,10 +356,9 @@ class E2EIndexTestBase : public ::testing::Test {
     const auto readerId = readerIdCounter_++;
     StringIdLease fileId(ids, fmt::format("testFile_{}", readerId));
     StringIdLease groupId(ids, fmt::format("testGroup_{}", readerId));
-    io::ReaderOptions ioReaderOpts(
-        &readerOptions.memoryPool(),
-        dataIoStats_.get(),
-        metadataIoStats_.get());
+    io::ReaderOptions ioReaderOpts(&readerOptions.memoryPool());
+    ioReaderOpts.setDataIoStats(dataIoStats_.get());
+    ioReaderOpts.setMetadataIoStats(metadataIoStats_.get());
     if (cache_ != nullptr) {
       input = std::make_unique<CachedBufferedInput>(
           readFile,

--- a/dwio/nimble/velox/selective/tests/FlatMapColumnReaderTest.cpp
+++ b/dwio/nimble/velox/selective/tests/FlatMapColumnReaderTest.cpp
@@ -71,8 +71,9 @@ class FlatMapColumnReaderTest : public ::testing::TestWithParam<bool>,
     auto readFile = std::make_shared<InMemoryReadFile>(file);
     auto factory =
         dwio::common::getReaderFactory(dwio::common::FileFormat::NIMBLE);
-    dwio::common::ReaderOptions options(
-        pool(), dataIoStats_.get(), metadataIoStats_.get());
+    dwio::common::ReaderOptions options(pool());
+    options.setDataIoStats(dataIoStats_.get());
+    options.setMetadataIoStats(metadataIoStats_.get());
     options.setScanSpec(scanSpec);
     Readers readers;
     readers.reader = factory->createReader(

--- a/dwio/nimble/velox/selective/tests/SelectiveNimbleReaderTest.cpp
+++ b/dwio/nimble/velox/selective/tests/SelectiveNimbleReaderTest.cpp
@@ -141,8 +141,9 @@ class SelectiveNimbleReaderTest
     auto readFile = std::make_shared<InMemoryReadFile>(file);
     auto factory =
         dwio::common::getReaderFactory(dwio::common::FileFormat::NIMBLE);
-    dwio::common::ReaderOptions options(
-        pool(), dataIoStats_.get(), metadataIoStats_.get());
+    dwio::common::ReaderOptions options(pool());
+    options.setDataIoStats(dataIoStats_.get());
+    options.setMetadataIoStats(metadataIoStats_.get());
     options.setScanSpec(scanSpec);
     options.setPinFileMetadata(GetParam().pinFileMetadata);
     std::unique_ptr<dwio::common::BufferedInput> input;
@@ -150,8 +151,9 @@ class SelectiveNimbleReaderTest
     const auto readerId = readerIdCounter_++;
     StringIdLease fileId(ids, fmt::format("testFile_{}", readerId));
     StringIdLease groupId(ids, fmt::format("testGroup_{}", readerId));
-    io::ReaderOptions ioReaderOpts(
-        pool(), dataIoStats_.get(), metadataIoStats_.get());
+    io::ReaderOptions ioReaderOpts(pool());
+    ioReaderOpts.setDataIoStats(dataIoStats_.get());
+    ioReaderOpts.setMetadataIoStats(metadataIoStats_.get());
     if (cache_ != nullptr) {
       input = std::make_unique<dwio::common::CachedBufferedInput>(
           readFile,
@@ -1137,8 +1139,9 @@ TEST_P(SelectiveNimbleReaderTest, estimatedRowSize) {
     auto readFile = std::make_shared<InMemoryReadFile>(fileContent);
     auto factory =
         dwio::common::getReaderFactory(dwio::common::FileFormat::NIMBLE);
-    dwio::common::ReaderOptions options(
-        pool(), dataIoStats_.get(), metadataIoStats_.get());
+    dwio::common::ReaderOptions options(pool());
+    options.setDataIoStats(dataIoStats_.get());
+    options.setMetadataIoStats(metadataIoStats_.get());
     options.setScanSpec(structScanSpec);
     auto reader = factory->createReader(
         std::make_unique<dwio::common::BufferedInput>(readFile, *pool()),
@@ -1212,8 +1215,9 @@ TEST_P(SelectiveNimbleReaderTest, estimatedRowSizePartialProjection) {
     auto readFile = std::make_shared<InMemoryReadFile>(fileContent);
     auto factory =
         dwio::common::getReaderFactory(dwio::common::FileFormat::NIMBLE);
-    dwio::common::ReaderOptions options(
-        pool(), dataIoStats_.get(), metadataIoStats_.get());
+    dwio::common::ReaderOptions options(pool());
+    options.setDataIoStats(dataIoStats_.get());
+    options.setMetadataIoStats(metadataIoStats_.get());
     options.setScanSpec(partialSpec);
     auto reader = factory->createReader(
         std::make_unique<dwio::common::BufferedInput>(readFile, *pool()),
@@ -1312,8 +1316,9 @@ TEST_P(SelectiveNimbleReaderTest, estimatedRowSizeNestedRowPartialProjection) {
     auto readFile = std::make_shared<InMemoryReadFile>(fileContent);
     auto factory =
         dwio::common::getReaderFactory(dwio::common::FileFormat::NIMBLE);
-    dwio::common::ReaderOptions options(
-        pool(), dataIoStats_.get(), metadataIoStats_.get());
+    dwio::common::ReaderOptions options(pool());
+    options.setDataIoStats(dataIoStats_.get());
+    options.setMetadataIoStats(metadataIoStats_.get());
     options.setScanSpec(partialSpec);
     auto reader = factory->createReader(
         std::make_unique<dwio::common::BufferedInput>(readFile, *pool()),
@@ -2259,8 +2264,9 @@ TEST_P(SelectiveNimbleReaderTest, columnDecodeMetrics) {
   auto readFile = std::make_shared<InMemoryReadFile>(file);
   auto factory =
       dwio::common::getReaderFactory(dwio::common::FileFormat::NIMBLE);
-  dwio::common::ReaderOptions options(
-      pool(), dataIoStats_.get(), metadataIoStats_.get());
+  dwio::common::ReaderOptions options(pool());
+  options.setDataIoStats(dataIoStats_.get());
+  options.setMetadataIoStats(metadataIoStats_.get());
   options.setScanSpec(scanSpec);
   auto reader = factory->createReader(
       std::make_unique<dwio::common::BufferedInput>(readFile, *pool()),
@@ -2444,8 +2450,9 @@ TEST_P(SelectiveNimbleReaderTest, pinFileMetadata) {
     auto readFile = std::make_shared<InMemoryReadFile>(file);
     auto factory =
         dwio::common::getReaderFactory(dwio::common::FileFormat::NIMBLE);
-    dwio::common::ReaderOptions options(
-        pool(), dataIoStats_.get(), metadataIoStats_.get());
+    dwio::common::ReaderOptions options(pool());
+    options.setDataIoStats(dataIoStats_.get());
+    options.setMetadataIoStats(metadataIoStats_.get());
     options.setScanSpec(scanSpec);
     options.setPinFileMetadata(true);
     if (enableCache) {
@@ -2490,8 +2497,9 @@ TEST_P(SelectiveNimbleReaderTest, pinnedMetadataNoReread) {
       dwio::common::getReaderFactory(dwio::common::FileFormat::NIMBLE);
   auto scanSpec = std::make_shared<common::ScanSpec>("root");
   scanSpec->addAllChildFields(*input->type());
-  dwio::common::ReaderOptions options(
-      pool(), dataIoStats_.get(), metadataIoStats_.get());
+  dwio::common::ReaderOptions options(pool());
+  options.setDataIoStats(dataIoStats_.get());
+  options.setMetadataIoStats(metadataIoStats_.get());
   options.setScanSpec(scanSpec);
   options.setPinFileMetadata(true);
   options.setFileMetadataCacheEnabled(GetParam().enableCache);
@@ -2500,8 +2508,9 @@ TEST_P(SelectiveNimbleReaderTest, pinnedMetadataNoReread) {
   const auto readerId = readerIdCounter_++;
   StringIdLease fileId(ids, fmt::format("testFile_{}", readerId));
   StringIdLease groupId(ids, fmt::format("testGroup_{}", readerId));
-  io::ReaderOptions ioReaderOpts(
-      pool(), dataIoStats_.get(), metadataIoStats_.get());
+  io::ReaderOptions ioReaderOpts(pool());
+  ioReaderOpts.setDataIoStats(dataIoStats_.get());
+  ioReaderOpts.setMetadataIoStats(metadataIoStats_.get());
   std::unique_ptr<dwio::common::BufferedInput> bufferedInput;
   if (cache_ != nullptr) {
     bufferedInput = std::make_unique<dwio::common::CachedBufferedInput>(

--- a/dwio/nimble/velox/tests/VeloxReaderTest.cpp
+++ b/dwio/nimble/velox/tests/VeloxReaderTest.cpp
@@ -528,8 +528,9 @@ class VeloxReaderTest : public ::testing::TestWithParam<TestParam> {
       auto fileIdStr = fmt::format("testFile_{}", nextFileId_++);
       velox::StringIdLease fileId(ids, fileIdStr);
       velox::StringIdLease groupId(ids, "testGroup");
-      velox::io::ReaderOptions ioReaderOpts(
-          pool, dataIoStats_.get(), metadataIoStats_.get());
+      velox::io::ReaderOptions ioReaderOpts(pool);
+      ioReaderOpts.setDataIoStats(dataIoStats_.get());
+      ioReaderOpts.setMetadataIoStats(metadataIoStats_.get());
       if (cache_ != nullptr) {
         cachedInput_ =
             std::make_unique<velox::dwio::common::CachedBufferedInput>(


### PR DESCRIPTION
Summary:
CONTEXT: The ReaderOptions constructor required all three parameters (pool, dataIoStats, metadataIoStats) with VELOX_CHECK_NOT_NULL enforcement (D103639664). This caused friction for callers that do not need IO stats tracking (D104286501), and prevented MetadataInput from cleanly constructing ReaderOptions with only a pool.

WHAT: Change ReaderOptions to a pool-only constructor with setter methods for IO stats. Add a new indexIoStats member for tracking index read IO separately from data and metadata IO.

API changes in io::ReaderOptions (base class):
- Constructor: ReaderOptions(pool) — pool-only, no IO stats args
- New setters: setDataIoStats(), setMetadataIoStats(), setIndexIoStats()
- New member: indexIoStats_ with getter indexIoStats()
- All IO stats members default to nullptr

Same changes propagated to dwio::common::ReaderOptions (derived class).

All ~160 callers across velox/ and dwio/ updated to use pool-only constructor followed by setter calls.

Reviewed By: duxiao1212

Differential Revision: D104504414


