### PR TITLE
misc: Advance velox submodule to 101d383a (#713)

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ Nimble integrates Velox as a Git submodule, referencing a specific commit of the
 Velox repository. The Velox badge at the top of this README shows the current
 commit and how far behind it is from Velox main.
 
-[See what changed since the current Velox commit.](https://github.com/facebookincubator/velox/compare/2145e80c843606211f95947559ca617e3c1a623a...main)
+[See what changed since the current Velox commit.](https://github.com/facebookincubator/velox/compare/101d383a85bd824a9a714ce6fa611ccdec629d1c...main)
 <!-- pre-commit check-velox-readme validates the SHA above matches the submodule -->
 
 Advance Velox when your changes depend on code in Velox that


### PR DESCRIPTION
Summary:

CONTEXT: The ReaderOptions API changed in velox (D104504414) — constructor is now pool-only with setters for IO stats. The nimble OSS build needs the updated velox to compile.

WHAT: Advance velox submodule from 2145e80c to 101d383a to pick up the ReaderOptions refactor.

___

overriding_review_checks_triggers_an_audit_and_retroactive_review
Oncall Short Name: presto_interactive

Differential Revision: D104563523
