### PR TITLE
perf: Reuse decompression buffer across StreamData lifetimes in Deserializer

### DIFF
--- a/dwio/nimble/serializer/Deserializer.cpp
+++ b/dwio/nimble/serializer/Deserializer.cpp
@@ -235,6 +235,7 @@ class DeserializerImpl : public Decoder {
     const serde::StreamData::Options options{
         .version = segment.version,
         .bufferPool = bufferPool_.get(),
+        .decompressionBuffer = &decompressionBuffer_,
     };
     streamData_.emplace(
         scalarKind_, segment.data, stringBuffers, pool_, options);
@@ -570,6 +571,10 @@ class DeserializerImpl : public Decoder {
   // are reused instead of being allocated/freed through MemoryPool each time.
   // Null when buffer pooling is disabled via DeserializerOptions.
   const std::unique_ptr<velox::BufferPool> bufferPool_;
+  // Decompression buffer reused across StreamData lifetimes. Persists across
+  // clear()/addBatch() cycles so the buffer capacity is reused instead of
+  // freed and re-allocated on each segment transition.
+  velox::BufferPtr decompressionBuffer_;
 
   // --- Batch decode state (reset in clear()) ---
   // Total top-level rows across all batches. Used for FlatMap gap detection to

--- a/dwio/nimble/serializer/DeserializerImpl.cpp
+++ b/dwio/nimble/serializer/DeserializerImpl.cpp
@@ -53,8 +53,10 @@ StreamData::StreamData(
       encodingEnabled_{nonLegacyFormat(options.version)},
       useVarintRowCount_{!isTabletRawFormat(options.version)},
       bufferPool_{options.bufferPool},
+      decompressionBuffer_{options.decompressionBuffer},
       stringBuffers_{&stringBuffers} {
   NIMBLE_CHECK_NOT_NULL(pool_, "Memory pool required for encoding");
+  NIMBLE_CHECK_NOT_NULL(decompressionBuffer_, "Decompression buffer required");
   init(data);
 }
 
@@ -103,6 +105,13 @@ void StreamData::init(std::string_view data) {
   }
 }
 
+void StreamData::ensureDecompressionBuffer(size_t minBytes) {
+  auto& buffer = decompressionBuf();
+  if (buffer == nullptr || !buffer->unique() || buffer->capacity() < minBytes) {
+    buffer = velox::AlignedBuffer::allocateExact<char>(minBytes, pool_);
+  }
+}
+
 void StreamData::decompress() {
   NIMBLE_CHECK(!encodingEnabled_);
 
@@ -124,16 +133,17 @@ void StreamData::decompress() {
           decompressedSize != ZSTD_CONTENTSIZE_ERROR &&
               decompressedSize != ZSTD_CONTENTSIZE_UNKNOWN,
           "Error determining decompressed size");
-      decompressionBuffer_.resize(decompressedSize);
+      ensureDecompressionBuffer(decompressedSize);
+      auto& buffer = decompressionBuf();
       const auto ret = ZSTD_decompressDCtx(
           getThreadLocalDCtx(),
-          decompressionBuffer_.data(),
+          buffer->asMutable<char>(),
           decompressedSize,
           pos_,
           compressedSize);
       NIMBLE_CHECK(!ZSTD_isError(ret), "Error decompressing data");
-      pos_ = decompressionBuffer_.data();
-      end_ = pos_ + decompressionBuffer_.size();
+      pos_ = buffer->as<char>();
+      end_ = pos_ + decompressedSize;
       break;
     }
     case CompressionType::LZ4: {
@@ -141,18 +151,19 @@ void StreamData::decompress() {
       // Wire format: [origSize:u32][lz4_data...]
       const auto decompressedSize = encoding::readUint32(pos_);
       const auto compressedSize = static_cast<size_t>(end_ - pos_);
-      decompressionBuffer_.resize(decompressedSize);
+      ensureDecompressionBuffer(decompressedSize);
+      auto& buffer = decompressionBuf();
       const auto ret = LZ4_decompress_safe(
           pos_,
-          decompressionBuffer_.data(),
+          buffer->asMutable<char>(),
           static_cast<int>(compressedSize),
           static_cast<int>(decompressedSize));
       NIMBLE_CHECK_EQ(
           ret,
           static_cast<int>(decompressedSize),
           "LZ4 decompressed size mismatch");
-      pos_ = decompressionBuffer_.data();
-      end_ = pos_ + decompressionBuffer_.size();
+      pos_ = buffer->as<char>();
+      end_ = pos_ + decompressedSize;
       break;
     }
     default:

--- a/dwio/nimble/serializer/DeserializerImpl.h
+++ b/dwio/nimble/serializer/DeserializerImpl.h
@@ -39,6 +39,10 @@ class StreamData {
     SerializationVersion version;
     /// Optional pool for encoding scratch buffers.
     velox::BufferPool* bufferPool{nullptr};
+    /// Externally-owned decompression buffer. Required (must not be null).
+    /// Owned by DeserializerImpl to persist across segment transitions so the
+    /// buffer capacity is reused.
+    velox::BufferPtr* decompressionBuffer{nullptr};
   };
 
   /// Constructor for thrift decoder: creates an empty stream that will be
@@ -52,11 +56,16 @@ class StreamData {
   StreamData(
       ScalarKind kind,
       std::vector<velox::BufferPtr>& stringBuffers,
-      velox::memory::MemoryPool* pool)
+      velox::memory::MemoryPool* pool,
+      velox::BufferPtr* decompressionBuffer)
       : kind_{kind},
         pool_{pool},
         encodingEnabled_{false},
-        stringBuffers_{&stringBuffers} {}
+        decompressionBuffer_{decompressionBuffer},
+        stringBuffers_{&stringBuffers} {
+    NIMBLE_CHECK_NOT_NULL(
+        decompressionBuffer_, "Decompression buffer required");
+  }
 
   /// @param kind Scalar kind for the stream data.
   /// @param data Stream data to initialize with.
@@ -127,6 +136,12 @@ class StreamData {
   template <typename T>
   void materialize(uint32_t count, T* output);
 
+  velox::BufferPtr& decompressionBuf() {
+    return *decompressionBuffer_;
+  }
+
+  void ensureDecompressionBuffer(size_t minBytes);
+
   const ScalarKind kind_{ScalarKind::Undefined};
   velox::memory::MemoryPool* const pool_{nullptr};
   // Whether nimble encoding is enabled. Non-const to allow reset() to change.
@@ -138,10 +153,13 @@ class StreamData {
   // Optional pool for encoding scratch buffers. Owned externally
   // (typically by DeserializerImpl) to persist across StreamData lifetimes.
   velox::BufferPool* const bufferPool_{nullptr};
+  // Externally-owned decompression buffer. Always non-null — checked in both
+  // constructors. Owned by DeserializerImpl or thrift Decoder to persist
+  // across StreamData lifetimes.
+  velox::BufferPtr* const decompressionBuffer_{nullptr};
 
   const char* pos_{nullptr};
   const char* end_{nullptr};
-  std::string decompressionBuffer_;
   std::unique_ptr<Encoding> encoding_;
   // Track consumed rows for nimble encoding path.
   uint32_t readRows_{0};

--- a/dwio/nimble/serializer/tests/SerializerImplTest.cpp
+++ b/dwio/nimble/serializer/tests/SerializerImplTest.cpp
@@ -1658,6 +1658,8 @@ class ZstdDCtxReuseTest : public TabletRawChunkStripTest {
     });
     return result;
   }
+
+  BufferPtr decompressionBuffer_;
 };
 
 TEST_F(ZstdDCtxReuseTest, streamDataLegacyZstdWithDCtx) {
@@ -1673,7 +1675,9 @@ TEST_F(ZstdDCtxReuseTest, streamDataLegacyZstdWithDCtx) {
       compressed,
       stringBuffers,
       pool_.get(),
-      serde::StreamData::Options{.version = SerializationVersion::kLegacy});
+      serde::StreamData::Options{
+          .version = SerializationVersion::kLegacy,
+          .decompressionBuffer = &decompressionBuffer_});
 
   std::vector<int32_t> output(expected.size());
   sd.copyTo(
@@ -1700,7 +1704,9 @@ TEST_F(ZstdDCtxReuseTest, streamDataDCtxReusedAcrossReset) {
       compressed1,
       stringBuffers,
       pool_.get(),
-      serde::StreamData::Options{.version = SerializationVersion::kLegacy});
+      serde::StreamData::Options{
+          .version = SerializationVersion::kLegacy,
+          .decompressionBuffer = &decompressionBuffer_});
 
   std::vector<int32_t> output1(values1.size());
   sd.copyTo(
@@ -1787,6 +1793,8 @@ class LZ4RoundtripTest : public TabletRawChunkStripTest {
     std::memcpy(pos, compressed.data(), compressedSize);
     return chunk;
   }
+
+  BufferPtr decompressionBuffer_;
 };
 
 TEST_F(LZ4RoundtripTest, streamDataLegacyLZ4) {
@@ -1802,7 +1810,9 @@ TEST_F(LZ4RoundtripTest, streamDataLegacyLZ4) {
       compressed,
       stringBuffers,
       pool_.get(),
-      serde::StreamData::Options{.version = SerializationVersion::kLegacy});
+      serde::StreamData::Options{
+          .version = SerializationVersion::kLegacy,
+          .decompressionBuffer = &decompressionBuffer_});
 
   std::vector<int32_t> output(expected.size());
   sd.copyTo(
@@ -1830,7 +1840,9 @@ TEST_F(LZ4RoundtripTest, streamDataLZ4ReusedAcrossReset) {
       compressed1,
       stringBuffers,
       pool_.get(),
-      serde::StreamData::Options{.version = SerializationVersion::kLegacy});
+      serde::StreamData::Options{
+          .version = SerializationVersion::kLegacy,
+          .decompressionBuffer = &decompressionBuffer_});
 
   std::vector<int32_t> output1(values1.size());
   sd.copyTo(
@@ -1921,7 +1933,9 @@ TEST_F(LZ4RoundtripTest, encodeDecodeLZ4Roundtrip) {
       streamData,
       stringBuffers,
       pool_.get(),
-      serde::StreamData::Options{.version = SerializationVersion::kLegacy});
+      serde::StreamData::Options{
+          .version = SerializationVersion::kLegacy,
+          .decompressionBuffer = &decompressionBuffer_});
 
   std::vector<int32_t> output(expected.size());
   sd.copyTo(
@@ -1952,7 +1966,9 @@ TEST_F(LZ4RoundtripTest, encodeLZ4BelowThresholdStaysUncompressed) {
       streamData,
       stringBuffers,
       pool_.get(),
-      serde::StreamData::Options{.version = SerializationVersion::kLegacy});
+      serde::StreamData::Options{
+          .version = SerializationVersion::kLegacy,
+          .decompressionBuffer = &decompressionBuffer_});
 
   std::vector<int32_t> output(expected.size());
   sd.copyTo(
@@ -1984,7 +2000,9 @@ TEST_F(LZ4RoundtripTest, encodeDecodeLZ4HighCompression) {
       streamData,
       stringBuffers,
       pool_.get(),
-      serde::StreamData::Options{.version = SerializationVersion::kLegacy});
+      serde::StreamData::Options{
+          .version = SerializationVersion::kLegacy,
+          .decompressionBuffer = &decompressionBuffer_});
 
   std::vector<int32_t> output(expected.size());
   sd.copyTo(


### PR DESCRIPTION
Summary:
Replace per-StreamData std::string decompression buffer with a velox::BufferPtr
owned by DeserializerImpl that persists across segment transitions. When StreamData
is destroyed and recreated between batch segments, the buffer capacity is reused
instead of freed and re-allocated.

Changes:
- Add decompressionBuffer field to StreamData::Options for external buffer ownership
- StreamData uses external buffer when provided, falls back to internal BufferPtr
- DeserializerImpl owns the buffer, passes it through Options
- ensureDecompressionBuffer() reuses existing capacity when sufficient
- Routes decompression memory through Velox MemoryPool instead of jemalloc

Differential Revision: D104506541


