### PR TITLE
feat(reader): Gate dictionary preservation optimizations behind session properties (#715)

### DIFF
--- a/dwio/nimble/velox/selective/NimbleData.cpp
+++ b/dwio/nimble/velox/selective/NimbleData.cpp
@@ -29,7 +29,8 @@ NimbleData::NimbleData(
     memory::MemoryPool& memoryPool,
     ChunkedDecoder* inMapDecoder,
     const EncodingFactory& encodingFactory,
-    bool stringDecoderZeroCopy)
+    bool stringDecoderZeroCopy,
+    bool nimblePreserveDictionaryEncoding)
     : nimbleType_(nimbleType),
       streams_(&streams),
       pool_(&memoryPool),
@@ -84,6 +85,7 @@ NimbleData::NimbleData(
       NIMBLE_UNSUPPORTED("{}", toString(nimbleType->kind()));
   }
   stringDecoderZeroCopy_ = stringDecoderZeroCopy;
+  nimblePreserveDictionaryEncoding_ = nimblePreserveDictionaryEncoding;
 }
 
 void NimbleData::readNulls(
@@ -234,7 +236,8 @@ std::unique_ptr<velox::dwio::common::FormatData> NimbleParams::toFormatData(
       pool(),
       inMapDecoder_,
       *encodingFactory_,
-      stringDecoderZeroCopy_);
+      stringDecoderZeroCopy_,
+      nimblePreserveDictionaryEncoding_);
 }
 
 } // namespace facebook::nimble

--- a/dwio/nimble/velox/selective/NimbleData.h
+++ b/dwio/nimble/velox/selective/NimbleData.h
@@ -33,7 +33,8 @@ class NimbleData : public velox::dwio::common::FormatData {
       velox::memory::MemoryPool& memoryPool,
       ChunkedDecoder* inMapDecoder,
       const EncodingFactory& encodingFactory,
-      bool stringDecoderZeroCopy);
+      bool stringDecoderZeroCopy,
+      bool nimblePreserveDictionaryEncoding = false);
 
   /// Read internal node nulls. For leaf nodes, we only copy `incomingNulls' if
   /// it exists.
@@ -96,6 +97,10 @@ class NimbleData : public velox::dwio::common::FormatData {
 
   std::unique_ptr<ChunkedDecoder> makeLengthDecoder();
 
+  bool nimblePreserveDictionaryEncoding() const {
+    return nimblePreserveDictionaryEncoding_;
+  }
+
  private:
   std::unique_ptr<ChunkedDecoder> makeDecoder(
       const StreamDescriptor& descriptor,
@@ -108,6 +113,7 @@ class NimbleData : public velox::dwio::common::FormatData {
   std::unique_ptr<ChunkedDecoder> nullsDecoder_;
   velox::BufferPtr inMap_;
   const EncodingFactory* const encodingFactory_;
+  bool nimblePreserveDictionaryEncoding_{false};
 };
 
 class NimbleParams : public velox::dwio::common::FormatParams {
@@ -120,14 +126,16 @@ class NimbleParams : public velox::dwio::common::FormatParams {
       RowSizeTracker* rowSizeTracker,
       const EncodingFactory& encodingFactory,
       bool stringDecoderZeroCopy = false,
-      bool preserveFlatMapsInMemory = false)
+      bool preserveFlatMapsInMemory = false,
+      bool nimblePreserveDictionaryEncoding = false)
       : FormatParams(pool, stats),
         nimbleType_(nimbleType),
         streams_(&streams),
         rowSizeTracker_(rowSizeTracker),
         preserveFlatMapsInMemory_(preserveFlatMapsInMemory),
         encodingFactory_(&encodingFactory),
-        stringDecoderZeroCopy_{stringDecoderZeroCopy} {}
+        stringDecoderZeroCopy_{stringDecoderZeroCopy},
+        nimblePreserveDictionaryEncoding_{nimblePreserveDictionaryEncoding} {}
 
   std::unique_ptr<velox::dwio::common::FormatData> toFormatData(
       const std::shared_ptr<const velox::dwio::common::TypeWithId>& /*type*/,
@@ -142,7 +150,8 @@ class NimbleParams : public velox::dwio::common::FormatParams {
         rowSizeTracker_,
         *encodingFactory_,
         stringDecoderZeroCopy_,
-        preserveFlatMapsInMemory_);
+        preserveFlatMapsInMemory_,
+        nimblePreserveDictionaryEncoding_);
   }
 
   const std::shared_ptr<const Type>& nimbleType() const {
@@ -177,6 +186,7 @@ class NimbleParams : public velox::dwio::common::FormatParams {
   const EncodingFactory* const encodingFactory_;
   ChunkedDecoder* inMapDecoder_{nullptr};
   bool stringDecoderZeroCopy_{false};
+  bool nimblePreserveDictionaryEncoding_{false};
 };
 
 } // namespace facebook::nimble

--- a/dwio/nimble/velox/selective/SelectiveNimbleReader.cpp
+++ b/dwio/nimble/velox/selective/SelectiveNimbleReader.cpp
@@ -409,7 +409,8 @@ void SelectiveNimbleRowReader::loadCurrentStripe() {
       options_.trackRowSize() ? rowSizeTracker_.get() : nullptr,
       *encodingFactory_,
       options_.stringDecoderZeroCopy(),
-      options_.preserveFlatMapsInMemory());
+      options_.preserveFlatMapsInMemory(),
+      options_.nimblePreserveDictionaryEncoding());
 
   columnReader_ = buildColumnReader(
       options_.requestedType() ? options_.requestedType()

--- a/dwio/nimble/velox/selective/StringColumnReader.cpp
+++ b/dwio/nimble/velox/selective/StringColumnReader.cpp
@@ -17,6 +17,7 @@
 #include "dwio/nimble/velox/selective/StringColumnReader.h"
 
 #include "dwio/nimble/encodings/legacy/EncodingUtils.h"
+#include "dwio/nimble/velox/selective/NimbleData.h"
 #include "velox/common/testutil/TestValue.h"
 #include "velox/dwio/common/SelectiveColumnReaderInternal.h"
 #include "velox/vector/DictionaryVector.h"
@@ -47,10 +48,12 @@ bool StringColumnReader::readWithDictionary(
     const RowSet& rows,
     const uint64_t* incomingNulls) {
   // Dictionary path requires: no filter pushdown, no value hook, non-legacy
-  // encoding path (zero-copy), single-chunk read, and dictionary-convertible
-  // encoding.
+  // encoding path (zero-copy), session property enabled, single-chunk read,
+  // and dictionary-convertible encoding.
   if (scanSpec_->hasFilter() || scanSpec_->valueHook() ||
-      !formatData().stringDecoderZeroCopy()) {
+      !formatData().stringDecoderZeroCopy() ||
+      !static_cast<const NimbleData&>(formatData())
+           .nimblePreserveDictionaryEncoding()) {
     return false;
   }
   decoder_.ensureLoaded();

--- a/dwio/nimble/velox/selective/tests/E2EFilterTest.cpp
+++ b/dwio/nimble/velox/selective/tests/E2EFilterTest.cpp
@@ -40,7 +40,8 @@ namespace {
 
 using namespace facebook::velox;
 
-using E2EFilterTestParams = std::tuple<bool, bool, bool, bool, bool, bool>;
+using E2EFilterTestParams =
+    std::tuple<bool, bool, bool, bool, bool, bool, bool>;
 
 struct E2EFilterTestParam {
   bool indexEnabled;
@@ -49,6 +50,7 @@ struct E2EFilterTestParam {
   bool stringDecoderZeroCopy;
   bool pinFileMetadata;
   bool enableCache;
+  bool nimblePreserveDictionaryEncoding;
 
   explicit E2EFilterTestParam(const E2EFilterTestParams& t)
       : indexEnabled{std::get<0>(t)},
@@ -56,17 +58,19 @@ struct E2EFilterTestParam {
         enableChunkIndex{std::get<2>(t)},
         stringDecoderZeroCopy{std::get<3>(t)},
         pinFileMetadata{std::get<4>(t)},
-        enableCache{std::get<5>(t)} {}
+        enableCache{std::get<5>(t)},
+        nimblePreserveDictionaryEncoding{std::get<6>(t)} {}
 
   std::string debugString() const {
     return fmt::format(
-        "index_{}_skipConstantInMap_{}_chunkIndex_{}_stringDecoderZeroCopy_{}_pinMetadata_{}_cache_{}",
+        "index_{}_skipConstantInMap_{}_chunkIndex_{}_stringDecoderZeroCopy_{}_pinMetadata_{}_cache_{}_nimblePreserveDict_{}",
         indexEnabled,
         skipConstantFlatMapInMapStreams,
         enableChunkIndex,
         stringDecoderZeroCopy,
         pinFileMetadata,
-        enableCache);
+        enableCache,
+        nimblePreserveDictionaryEncoding);
   }
 };
 
@@ -125,6 +129,8 @@ class E2EFilterTest
     opts.setTimestampPrecision(TimestampPrecision::kNanoseconds);
     opts.setIndexEnabled(indexEnabled());
     opts.setStringDecoderZeroCopy(param().stringDecoderZeroCopy);
+    opts.setNimblePreserveDictionaryEncoding(
+        param().nimblePreserveDictionaryEncoding);
   }
 
   void testWithTypes(
@@ -1606,6 +1612,7 @@ INSTANTIATE_TEST_SUITE_P(
         testing::Bool(),
         testing::Bool(),
         testing::Bool(),
+        testing::Bool(),
         testing::Bool()),
     [](const ::testing::TestParamInfo<E2EFilterTestParams>& info) {
       return E2EFilterTestParam{info.param}.debugString();
@@ -1632,6 +1639,8 @@ class PrefixEncodingE2ETest : public E2EFilterTest {
     // PrefixEncoding requires string buffer optimization for correct
     // string_view lifecycle management in readWithVisitor.
     opts.setStringDecoderZeroCopy(true);
+    opts.setNimblePreserveDictionaryEncoding(
+        param().nimblePreserveDictionaryEncoding);
   }
 
   void writeToMemory(
@@ -1692,6 +1701,7 @@ INSTANTIATE_TEST_SUITE_P(
     PrefixEncodingE2ETests,
     PrefixEncodingE2ETest,
     testing::Combine(
+        testing::Bool(),
         testing::Bool(),
         testing::Bool(),
         testing::Bool(),
@@ -2079,6 +2089,8 @@ TEST_P(E2EFilterTest, dictionaryVectorReturned) {
   velox::dwio::common::RowReaderOptions rowReaderOptions;
   rowReaderOptions.setScanSpec(scanSpec);
   rowReaderOptions.setStringDecoderZeroCopy(param().stringDecoderZeroCopy);
+  rowReaderOptions.setNimblePreserveDictionaryEncoding(
+      param().nimblePreserveDictionaryEncoding);
   auto rowReader = reader->createRowReader(rowReaderOptions);
 
   auto result = BaseVector::create(type, 0, leafPool_.get());
@@ -2089,8 +2101,9 @@ TEST_P(E2EFilterTest, dictionaryVectorReturned) {
     totalRows += rowResult->size();
 
     auto stringChild = rowResult->childAt(0)->loadedVector();
-    if (param().stringDecoderZeroCopy) {
-      // With string buffer optimization, the dictionary path should return
+    if (param().stringDecoderZeroCopy &&
+        param().nimblePreserveDictionaryEncoding) {
+      // With both flags enabled, the dictionary path should return
       // a DictionaryVector wrapping a FlatVector alphabet.
       ASSERT_EQ(stringChild->encoding(), VectorEncoding::Simple::DICTIONARY)
           << "Expected DICTIONARY encoding for string column, got "
@@ -2481,7 +2494,7 @@ INSTANTIATE_TEST_SUITE_P(
     NimbleExtractionTests,
     NimbleExtractionTest,
     ::testing::Values(
-        E2EFilterTestParams{false, false, false, false, false, false},
-        E2EFilterTestParams{false, false, false, false, false, true}));
+        E2EFilterTestParams{false, false, false, false, false, false, false},
+        E2EFilterTestParams{false, false, false, false, false, true, false}));
 
 } // namespace facebook::nimble

--- a/dwio/nimble/velox/selective/tests/StringColumnReaderTest.cpp
+++ b/dwio/nimble/velox/selective/tests/StringColumnReaderTest.cpp
@@ -75,6 +75,7 @@ class StringColumnReaderTest : public ::testing::Test,
     rowOptions.setScanSpec(scanSpec);
     rowOptions.setRequestedType(type);
     rowOptions.setStringDecoderZeroCopy(stringDecoderZeroCopy);
+    rowOptions.setNimblePreserveDictionaryEncoding(stringDecoderZeroCopy);
     readers.rowReader = readers.reader->createRowReader(rowOptions);
     return readers;
   }
@@ -899,6 +900,7 @@ TEST_P(StringColumnReaderTest, flatMapStringDictionaryPath) {
   rowOptions.setScanSpec(scanSpec);
   rowOptions.setRequestedType(asRowType(input->type()));
   rowOptions.setStringDecoderZeroCopy(true);
+  rowOptions.setNimblePreserveDictionaryEncoding(true);
   auto rowReader = reader->createRowReader(rowOptions);
 
   // Build expected output: key 1 always present, key 2 null when i%3==0.


### PR DESCRIPTION
Summary:

Use the previously added session properties to gate the Nimble selective reader
string optimizations, and parameterize the tests

Reviewed By: xiaoxmeng

Differential Revision: D102466740


