### PR TITLE
feat: Add MetadataBuffer::slice for sub-range extraction

### DIFF
--- a/dwio/nimble/tablet/MetadataBuffer.cpp
+++ b/dwio/nimble/tablet/MetadataBuffer.cpp
@@ -22,14 +22,31 @@
 namespace facebook::nimble {
 
 MetadataBuffer::MetadataBuffer(velox::BufferPtr buffer)
-    : buffer_{std::move(buffer)} {
+    : MetadataBuffer(buffer, 0, buffer->size()) {}
+
+MetadataBuffer::MetadataBuffer(
+    velox::BufferPtr buffer,
+    uint64_t offset,
+    uint64_t size)
+    : buffer_{std::move(buffer)}, offset_{offset}, size_{size} {
   NIMBLE_CHECK_NOT_NULL(buffer_);
+  NIMBLE_CHECK_LE(offset_ + size_, buffer_->size());
 }
 
 MetadataBuffer::MetadataBuffer(velox::cache::CachePin pin)
-    : pin_{std::move(pin)} {
+    : MetadataBuffer(
+          pin,
+          0,
+          static_cast<uint64_t>(pin.checkedEntry()->size())) {}
+
+MetadataBuffer::MetadataBuffer(
+    velox::cache::CachePin pin,
+    uint64_t offset,
+    uint64_t size)
+    : pin_{std::move(pin)}, offset_{offset}, size_{size} {
   NIMBLE_CHECK(!pin_.empty(), "CachePin must not be empty");
-  pin_.checkedEntry();
+  NIMBLE_CHECK_LE(
+      offset_ + size_, static_cast<uint64_t>(pin_.checkedEntry()->size()));
 }
 
 MetadataBuffer::~MetadataBuffer() = default;
@@ -40,10 +57,10 @@ MetadataBuffer& MetadataBuffer::operator=(MetadataBuffer&&) noexcept = default;
 
 MetadataBuffer MetadataBuffer::clone() const {
   if (buffer_ != nullptr) {
-    return MetadataBuffer{buffer_};
+    return MetadataBuffer{buffer_, offset_, size_};
   }
   NIMBLE_CHECK(!pin_.empty(), "Cannot clone empty MetadataBuffer");
-  return MetadataBuffer{pin_};
+  return MetadataBuffer{pin_, offset_, size_};
 }
 
 MetadataSection::MetadataSection(
@@ -130,6 +147,19 @@ velox::BufferPtr MetadataBuffer::decompress(
   auto buffer = velox::AlignedBuffer::allocateExact<char>(length, pool);
   cursor.pull(buffer->asMutable<char>(), length);
   return decompressZstd({buffer->as<char>(), buffer->size()}, pool);
+}
+
+std::unique_ptr<MetadataBuffer> MetadataBuffer::slice(
+    uint64_t offset,
+    uint64_t size) const {
+  NIMBLE_CHECK_LE(offset + size, size_, "Slice range exceeds buffer content");
+  if (buffer_ != nullptr) {
+    return std::unique_ptr<MetadataBuffer>(
+        new MetadataBuffer(buffer_, offset_ + offset, size));
+  }
+  NIMBLE_CHECK(!pin_.empty(), "Cannot slice empty MetadataBuffer");
+  return std::unique_ptr<MetadataBuffer>(
+      new MetadataBuffer(pin_, offset_ + offset, size));
 }
 
 } // namespace facebook::nimble

--- a/dwio/nimble/tablet/MetadataBuffer.h
+++ b/dwio/nimble/tablet/MetadataBuffer.h
@@ -28,6 +28,10 @@
 
 namespace facebook::nimble {
 
+namespace test {
+class MetadataBufferTestHelper;
+} // namespace test
+
 class MetadataBuffer {
  public:
   // Creates from decompressed data in a pool-tracked buffer.
@@ -45,11 +49,13 @@ class MetadataBuffer {
   /// Creates a shallow copy sharing the same underlying buffer or cache pin.
   MetadataBuffer clone() const;
 
+  /// Creates a zero-copy MetadataBuffer viewing a sub-range of this buffer's
+  /// content. Shares the underlying buffer or cache pin.
+  std::unique_ptr<MetadataBuffer> slice(uint64_t offset, uint64_t size) const;
+
   std::string_view content() const {
-    if (!pin_.empty()) {
-      return cacheContent();
-    }
-    return bufferContent();
+    const auto data = pin_.empty() ? bufferContent() : cacheContent();
+    return data.substr(offset_, size_);
   }
 
   /// Decompresses metadata from a pool-tracked buffer. Returns the buffer
@@ -68,6 +74,9 @@ class MetadataBuffer {
       velox::memory::MemoryPool* pool);
 
  private:
+  MetadataBuffer(velox::BufferPtr buffer, uint64_t offset, uint64_t size);
+  MetadataBuffer(velox::cache::CachePin pin, uint64_t offset, uint64_t size);
+
   inline std::string_view bufferContent() const {
     return {buffer_->as<char>(), buffer_->size()};
   }
@@ -83,6 +92,12 @@ class MetadataBuffer {
   //   (cached path, keeps the cache entry pinned while this buffer is alive).
   velox::BufferPtr buffer_;
   velox::cache::CachePin pin_;
+  // Sub-range within the underlying storage. Default (0, full size) covers
+  // the entire content. Set by slice() for sub-range views.
+  uint64_t offset_{0};
+  uint64_t size_{0};
+
+  friend class test::MetadataBufferTestHelper;
 };
 
 class Section {

--- a/dwio/nimble/tablet/TabletReader.cpp
+++ b/dwio/nimble/tablet/TabletReader.cpp
@@ -322,7 +322,7 @@ void TabletReader::init(const Options& options) {
       velox::succinctBytes(fileSize_),
       velox::succinctBytes(kPostscriptSize));
 
-  if (tryInitFromCache(options)) {
+  if (initFromCache(options)) {
     return;
   }
 
@@ -722,7 +722,7 @@ bool TabletReader::tryLoadAndInitFooterFromCache() {
   return true;
 }
 
-bool TabletReader::tryInitFromCache(const Options& options) {
+bool TabletReader::initFromCache(const Options& options) {
   if (!hasCache()) {
     return false;
   }

--- a/dwio/nimble/tablet/TabletReader.h
+++ b/dwio/nimble/tablet/TabletReader.h
@@ -361,7 +361,7 @@ class TabletReader {
   // Probes the cache for footer+PS at synthetic offset fileSize, parses PS and
   // footer, then loads all remaining metadata via cache hits. Returns true on
   // success, false on cache miss (caller falls through to cold path).
-  bool tryInitFromCache(const Options& options);
+  bool initFromCache(const Options& options);
 
   // Tries to parse PS and footer from cached footer+PS entry at synthetic
   // offset fileSize. Returns true on cache hit, false on miss.

--- a/dwio/nimble/tablet/tests/MetadataBufferTest.cpp
+++ b/dwio/nimble/tablet/tests/MetadataBufferTest.cpp
@@ -30,7 +30,34 @@
 
 using namespace ::facebook;
 
+namespace facebook::nimble::test {
+
+class MetadataBufferTestHelper {
+ public:
+  static uint64_t offset(const MetadataBuffer& buffer) {
+    return buffer.offset_;
+  }
+
+  static uint64_t size(const MetadataBuffer& buffer) {
+    return buffer.size_;
+  }
+
+  static void verifySlice(
+      const MetadataBuffer& buffer,
+      uint64_t expectedOffset,
+      uint64_t expectedSize,
+      std::string_view expectedContent) {
+    EXPECT_EQ(offset(buffer), expectedOffset);
+    EXPECT_EQ(size(buffer), expectedSize);
+    EXPECT_EQ(buffer.content(), expectedContent);
+  }
+};
+
+} // namespace facebook::nimble::test
+
 namespace {
+
+using TestHelper = nimble::test::MetadataBufferTestHelper;
 
 velox::BufferPtr toBufferPtr(
     std::string_view data,
@@ -429,6 +456,172 @@ TEST_F(MetadataBufferCacheTest, cloneCachePin) {
   auto cloned = original.clone();
   EXPECT_EQ(cloned.content(), data);
   EXPECT_EQ(original.content(), cloned.content());
+}
+
+TEST_F(MetadataBufferTest, sliceBufferPtr) {
+  struct SliceOp {
+    uint64_t offset;
+    uint64_t size;
+    uint64_t expectedAbsoluteOffset;
+    std::string expectedContent;
+
+    std::string debugString() const {
+      return fmt::format(
+          "offset {}, size {}, expectedAbsoluteOffset {}, expectedContent '{}'",
+          offset,
+          size,
+          expectedAbsoluteOffset,
+          expectedContent);
+    }
+  };
+
+  struct TestParam {
+    std::string data;
+    std::vector<std::vector<SliceOp>> sliceChains;
+
+    std::string debugString() const {
+      return fmt::format("data '{}'", data);
+    }
+  };
+
+  // clang-format off
+  std::vector<TestParam> testSettings = {
+      {kTestData,
+       {
+           {{0, kTestData.size(), 0, kTestData}},
+           {{0, 0, 0, ""}},
+           {{7, 14, 7, "MetadataBuffer"}},
+           {{7, 14, 7, "MetadataBuffer"}, {8, 6, 15, "Buffer"}},
+           {{7, 14, 7, "MetadataBuffer"}, {0, 8, 7, "Metadata"}, {4, 4, 11, "data"}},
+           {{0, 5, 0, "Hello"}},
+           {{kTestData.size() - 1, 1, kTestData.size() - 1, "!"}},
+       }},
+      {kLargeTestData,
+       {
+           {{0, 1'000, 0, kLargeTestData}},
+           {{500, 500, 500, std::string(500, 'A')}},
+           {{0, 100, 0, std::string(100, 'A')}, {50, 50, 50, std::string(50, 'A')}},
+       }},
+  };
+  // clang-format on
+
+  for (const auto& testData : testSettings) {
+    SCOPED_TRACE(testData.debugString());
+    auto buffer = toBufferPtr(testData.data, pool_.get());
+    nimble::MetadataBuffer original{std::move(buffer)};
+    TestHelper::verifySlice(original, 0, testData.data.size(), testData.data);
+
+    for (const auto& chain : testData.sliceChains) {
+      ASSERT_FALSE(chain.empty());
+      SCOPED_TRACE(chain[0].debugString());
+
+      auto current = original.slice(chain[0].offset, chain[0].size);
+      TestHelper::verifySlice(
+          *current,
+          chain[0].expectedAbsoluteOffset,
+          chain[0].size,
+          chain[0].expectedContent);
+      TestHelper::verifySlice(original, 0, testData.data.size(), testData.data);
+
+      for (size_t i = 1; i < chain.size(); ++i) {
+        SCOPED_TRACE(chain[i].debugString());
+        current = current->slice(chain[i].offset, chain[i].size);
+        TestHelper::verifySlice(
+            *current,
+            chain[i].expectedAbsoluteOffset,
+            chain[i].size,
+            chain[i].expectedContent);
+      }
+    }
+  }
+}
+
+TEST_F(MetadataBufferTest, sliceBufferPtrOutOfRange) {
+  auto buffer = toBufferPtr(kTestData, pool_.get());
+  nimble::MetadataBuffer original{std::move(buffer)};
+
+  NIMBLE_ASSERT_THROW(
+      original.slice(0, kTestData.size() + 1),
+      "Slice range exceeds buffer content");
+  NIMBLE_ASSERT_THROW(
+      original.slice(kTestData.size(), 1),
+      "Slice range exceeds buffer content");
+
+  auto sliced = original.slice(7, 14);
+  NIMBLE_ASSERT_THROW(
+      sliced->slice(0, 15), "Slice range exceeds buffer content");
+  NIMBLE_ASSERT_THROW(
+      sliced->slice(14, 1), "Slice range exceeds buffer content");
+}
+
+TEST_F(MetadataBufferCacheTest, sliceCachePin) {
+  struct SliceOp {
+    uint64_t offset;
+    uint64_t size;
+    uint64_t expectedAbsoluteOffset;
+    std::string expectedContent;
+
+    std::string debugString() const {
+      return fmt::format(
+          "offset {}, size {}, expectedAbsoluteOffset {}, expectedContent '{}'",
+          offset,
+          size,
+          expectedAbsoluteOffset,
+          expectedContent);
+    }
+  };
+
+  const std::string data = "Hello, CacheSlice!";
+  auto pin = makePin(600, data);
+  nimble::MetadataBuffer original{std::move(pin)};
+  TestHelper::verifySlice(original, 0, data.size(), data);
+
+  // clang-format off
+  std::vector<std::vector<SliceOp>> sliceChains = {
+      {{0, data.size(), 0, data}},
+      {{0, 0, 0, ""}},
+      {{7, 10, 7, "CacheSlice"}},
+      {{7, 10, 7, "CacheSlice"}, {5, 5, 12, "Slice"}},
+      {{7, 10, 7, "CacheSlice"}, {0, 5, 7, "Cache"}, {0, 3, 7, "Cac"}},
+      {{data.size() - 1, 1, data.size() - 1, "!"}},
+  };
+  // clang-format on
+
+  for (const auto& chain : sliceChains) {
+    ASSERT_FALSE(chain.empty());
+    SCOPED_TRACE(chain[0].debugString());
+
+    auto current = original.slice(chain[0].offset, chain[0].size);
+    TestHelper::verifySlice(
+        *current,
+        chain[0].expectedAbsoluteOffset,
+        chain[0].size,
+        chain[0].expectedContent);
+    TestHelper::verifySlice(original, 0, data.size(), data);
+
+    for (size_t i = 1; i < chain.size(); ++i) {
+      SCOPED_TRACE(chain[i].debugString());
+      current = current->slice(chain[i].offset, chain[i].size);
+      TestHelper::verifySlice(
+          *current,
+          chain[i].expectedAbsoluteOffset,
+          chain[i].size,
+          chain[i].expectedContent);
+    }
+  }
+}
+
+TEST_F(MetadataBufferCacheTest, sliceCachePinOutOfRange) {
+  const std::string data = "short";
+  auto pin = makePin(700, data);
+  nimble::MetadataBuffer original{std::move(pin)};
+
+  NIMBLE_ASSERT_THROW(
+      original.slice(0, data.size() + 1), "Slice range exceeds buffer content");
+
+  auto sliced = original.slice(1, 3);
+  NIMBLE_ASSERT_THROW(
+      sliced->slice(0, 4), "Slice range exceeds buffer content");
 }
 
 } // namespace


### PR DESCRIPTION
Summary:
CONTEXT: Upcoming TabletReader MetadataInput integration needs to extract footer portions from cached metadata buffers.

WHAT: Add `MetadataBuffer::slice(offset, size, pool)` which creates a new MetadataBuffer from a sub-range of the buffer content. Copies the sub-range into a new pool-allocated buffer.

Differential Revision: D104605626


