### PR TITLE
refactor: Add Postscript::serialize and use in TabletWriter (#718)

### DIFF
--- a/dwio/nimble/tablet/CMakeLists.txt
+++ b/dwio/nimble/tablet/CMakeLists.txt
@@ -120,7 +120,7 @@ target_link_libraries(
   Folly::folly
 )
 
-add_library(nimble_tablet_reader FileLayout.cpp TabletReader.cpp)
+add_library(nimble_tablet_reader FileLayout.cpp Postscript.cpp TabletReader.cpp)
 target_link_libraries(
   nimble_tablet_reader
   PUBLIC

--- a/dwio/nimble/tablet/FileLayout.h
+++ b/dwio/nimble/tablet/FileLayout.h
@@ -20,58 +20,11 @@
 #include <vector>
 #include "dwio/nimble/common/Types.h"
 #include "dwio/nimble/tablet/MetadataBuffer.h"
+#include "dwio/nimble/tablet/Postscript.h"
 #include "velox/common/file/File.h"
 #include "velox/common/memory/Memory.h"
 
 namespace facebook::nimble {
-
-/// Postscript information (last 20 bytes of a Nimble file).
-/// Contains file format version, checksum, and footer metadata.
-class Postscript {
- public:
-  Postscript() = default;
-
-  uint32_t footerSize() const {
-    return footerSize_;
-  }
-
-  CompressionType footerCompressionType() const {
-    return footerCompressionType_;
-  }
-
-  uint64_t checksum() const {
-    return checksum_;
-  }
-
-  ChecksumType checksumType() const {
-    return checksumType_;
-  }
-
-  uint32_t majorVersion() const {
-    return majorVersion_;
-  }
-
-  uint32_t minorVersion() const {
-    return minorVersion_;
-  }
-
-  static Postscript parse(std::string_view data);
-
- private:
-  Postscript(
-      uint32_t footerSize,
-      CompressionType footerCompressionType,
-      ChecksumType checksumType,
-      uint32_t majorVersion,
-      uint32_t minorVersion);
-
-  uint32_t footerSize_;
-  CompressionType footerCompressionType_;
-  uint64_t checksum_;
-  ChecksumType checksumType_;
-  uint32_t majorVersion_;
-  uint32_t minorVersion_;
-};
 
 /// Nimble Physical File Layout
 /// ============================

--- a/dwio/nimble/tablet/Postscript.cpp
+++ b/dwio/nimble/tablet/Postscript.cpp
@@ -1,0 +1,86 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "dwio/nimble/tablet/Postscript.h"
+
+#include <cstring>
+
+#include "dwio/nimble/common/Exceptions.h"
+#include "dwio/nimble/tablet/Constants.h"
+
+namespace facebook::nimble {
+
+Postscript::Postscript(
+    uint32_t footerSize,
+    CompressionType footerCompressionType,
+    ChecksumType checksumType,
+    uint32_t majorVersion,
+    uint32_t minorVersion)
+    : footerSize_(footerSize),
+      footerCompressionType_(footerCompressionType),
+      checksum_(0),
+      checksumType_(checksumType),
+      majorVersion_(majorVersion),
+      minorVersion_(minorVersion) {}
+
+Postscript Postscript::parse(std::string_view data) {
+  NIMBLE_CHECK_GE(data.size(), kSize, "Invalid postscript length");
+
+  Postscript ps;
+  auto pos = data.data() + data.size() - 2;
+  const uint16_t magicNumber = *reinterpret_cast<const uint16_t*>(pos);
+
+  NIMBLE_CHECK_EQ(
+      magicNumber, kMagicNumber, "Magic number mismatch. Not a nimble file!");
+
+  pos -= 4;
+  ps.majorVersion_ = *reinterpret_cast<const uint16_t*>(pos);
+  ps.minorVersion_ = *reinterpret_cast<const uint16_t*>(pos + 2);
+
+  NIMBLE_CHECK_LE(ps.majorVersion_, kVersionMajor, "Unsupported file version");
+
+  pos -= 14;
+  ps.footerSize_ = *reinterpret_cast<const uint32_t*>(pos);
+
+  static_assert(sizeof(CompressionType) == 1);
+  ps.footerCompressionType_ =
+      *reinterpret_cast<const CompressionType*>(pos + 4);
+
+  static_assert(sizeof(ChecksumType) == 1);
+  ps.checksumType_ = *reinterpret_cast<const ChecksumType*>(pos + 5);
+  ps.checksum_ = *reinterpret_cast<const uint64_t*>(pos + 6);
+  return ps;
+}
+
+std::string Postscript::serialize() const {
+  std::string buf(kSize, '\0');
+  auto* pos = buf.data();
+  std::memcpy(pos, &footerSize_, 4);
+  pos += 4;
+  std::memcpy(pos, &footerCompressionType_, 1);
+  pos += 1;
+  std::memcpy(pos, &checksumType_, 1);
+  pos += 1;
+  std::memcpy(pos, &checksum_, 8);
+  pos += 8;
+  std::memcpy(pos, &majorVersion_, 2);
+  pos += 2;
+  std::memcpy(pos, &minorVersion_, 2);
+  pos += 2;
+  std::memcpy(pos, &kMagicNumber, 2);
+  return buf;
+}
+
+} // namespace facebook::nimble

--- a/dwio/nimble/tablet/Postscript.h
+++ b/dwio/nimble/tablet/Postscript.h
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <string>
+#include <string_view>
+
+#include "dwio/nimble/common/Types.h"
+
+namespace facebook::nimble {
+
+/// Postscript information (last 20 bytes of a Nimble file).
+/// Contains file format version, checksum, and footer metadata.
+class Postscript {
+ public:
+  // 4 (footerSize) + 1 (compressionType) + 1 (checksumType) +
+  // 8 (checksum) + 2 (major) + 2 (minor) + 2 (magic) = 20 bytes.
+  static constexpr uint32_t kSize{20};
+
+  uint32_t footerSize() const {
+    return footerSize_;
+  }
+
+  CompressionType footerCompressionType() const {
+    return footerCompressionType_;
+  }
+
+  uint64_t checksum() const {
+    return checksum_;
+  }
+
+  ChecksumType checksumType() const {
+    return checksumType_;
+  }
+
+  uint32_t majorVersion() const {
+    return majorVersion_;
+  }
+
+  uint32_t minorVersion() const {
+    return minorVersion_;
+  }
+
+  Postscript() = default;
+
+  Postscript(
+      uint32_t footerSize,
+      CompressionType footerCompressionType,
+      ChecksumType checksumType,
+      uint32_t majorVersion,
+      uint32_t minorVersion);
+
+  /// Parses a postscript from the last kPostscriptSize bytes of data.
+  static Postscript parse(std::string_view data);
+
+  /// Serializes the postscript into a kPostscriptSize-byte string.
+  std::string serialize() const;
+
+ private:
+  uint32_t footerSize_{0};
+  CompressionType footerCompressionType_{CompressionType::Uncompressed};
+  uint64_t checksum_{0};
+  ChecksumType checksumType_{ChecksumType::XXH3_64};
+  uint32_t majorVersion_{0};
+  uint32_t minorVersion_{0};
+};
+
+} // namespace facebook::nimble

--- a/dwio/nimble/tablet/TabletReader.cpp
+++ b/dwio/nimble/tablet/TabletReader.cpp
@@ -222,54 +222,6 @@ std::span<const uint32_t> StripeGroup::streamSizes(uint32_t stripe) const {
   return {streamSizes_ + (stripe - firstStripe_) * streamCount_, streamCount_};
 }
 
-Postscript Postscript::parse(std::string_view data) {
-  NIMBLE_CHECK_GE(data.size(), kPostscriptSize, "Invalid postscript length");
-
-  Postscript ps;
-  // Read and validate magic
-  auto pos = data.data() + data.size() - 2;
-  const uint16_t magicNumber = *reinterpret_cast<const uint16_t*>(pos);
-
-  NIMBLE_CHECK_EQ(
-      magicNumber, kMagicNumber, "Magic number mismatch. Not a nimble file!");
-
-  // Read and validate versions
-  pos -= 4;
-  ps.majorVersion_ = *reinterpret_cast<const uint16_t*>(pos);
-  ps.minorVersion_ = *reinterpret_cast<const uint16_t*>(pos + 2);
-
-  NIMBLE_CHECK_LE(ps.majorVersion_, kVersionMajor, "Unsupported file version");
-
-  pos -= 14;
-  ps.footerSize_ = *reinterpret_cast<const uint32_t*>(pos);
-
-  // How CompressionType is written into and read from postscript requires
-  // its size must be 1 byte.
-  static_assert(sizeof(CompressionType) == 1);
-  ps.footerCompressionType_ =
-      *reinterpret_cast<const CompressionType*>(pos + 4);
-
-  // How ChecksumType is written into and read from postscript requires
-  // its size must be 1 byte.
-  static_assert(sizeof(ChecksumType) == 1);
-  ps.checksumType_ = *reinterpret_cast<const ChecksumType*>(pos + 5);
-  ps.checksum_ = *reinterpret_cast<const uint64_t*>(pos + 6);
-  return ps;
-}
-
-Postscript::Postscript(
-    uint32_t footerSize,
-    CompressionType footerCompressionType,
-    ChecksumType checksumType,
-    uint32_t majorVersion,
-    uint32_t minorVersion)
-    : footerSize_(footerSize),
-      footerCompressionType_(footerCompressionType),
-      checksum_(0),
-      checksumType_(checksumType),
-      majorVersion_(majorVersion),
-      minorVersion_(minorVersion) {}
-
 namespace {
 
 // Creates an owned BufferedInput clone for metadata reads. When

--- a/dwio/nimble/tablet/TabletWriter.cpp
+++ b/dwio/nimble/tablet/TabletWriter.cpp
@@ -18,6 +18,7 @@
 
 #include "dwio/nimble/tablet/Compression.h"
 #include "dwio/nimble/tablet/Constants.h"
+#include "dwio/nimble/tablet/FileLayout.h"
 
 namespace facebook::nimble {
 
@@ -235,21 +236,27 @@ void TabletWriter::close() {
   auto footerStart = file_->size();
   auto footerCompressionType = writeMetadata(asView(builder));
 
-  // End with the fixed length constants.
-  const uint64_t footerSize64Bit = (file_->size() - footerStart);
+  // Write postscript. The first kPostscriptChecksumedSize bytes are included
+  // in the file checksum; the rest (including the checksum itself) are not.
+  const uint64_t footerSize = file_->size() - footerStart;
   NIMBLE_CHECK_LE(
-      footerSize64Bit,
-      std::numeric_limits<uint32_t>::max(),
-      "Footer size too big.");
-  const uint32_t footerSize = footerSize64Bit;
-  writeWithChecksum({reinterpret_cast<const char*>(&footerSize), 4});
-  writeWithChecksum({reinterpret_cast<const char*>(&footerCompressionType), 1});
-  uint64_t checksum = checksum_->getChecksum();
-  file_->append({reinterpret_cast<const char*>(&options_.checksumType), 1});
-  file_->append({reinterpret_cast<const char*>(&checksum), 8});
-  file_->append({reinterpret_cast<const char*>(&kVersionMajor), 2});
-  file_->append({reinterpret_cast<const char*>(&kVersionMinor), 2});
-  file_->append({reinterpret_cast<const char*>(&kMagicNumber), 2});
+      footerSize, std::numeric_limits<uint32_t>::max(), "Footer size too big.");
+  Postscript ps{
+      static_cast<uint32_t>(footerSize),
+      footerCompressionType,
+      options_.checksumType,
+      kVersionMajor,
+      kVersionMinor};
+  auto psBuf = ps.serialize();
+  writeWithChecksum({psBuf.data(), kPostscriptChecksumedSize});
+  // Patch the checksum value into the serialized buffer. The checksum field
+  // starts after checksumType (1 byte after the checksummed region).
+  const uint64_t checksum = checksum_->getChecksum();
+  constexpr uint32_t kChecksumOffset = kPostscriptChecksumedSize + 1;
+  std::memcpy(psBuf.data() + kChecksumOffset, &checksum, sizeof(checksum));
+  file_->append(
+      {psBuf.data() + kPostscriptChecksumedSize,
+       kPostscriptSize - kPostscriptChecksumedSize});
 
   state_ = State::kClosed;
 }

--- a/dwio/nimble/tablet/tests/PostscriptTest.cpp
+++ b/dwio/nimble/tablet/tests/PostscriptTest.cpp
@@ -1,0 +1,119 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "dwio/nimble/tablet/Postscript.h"
+
+#include <gtest/gtest.h>
+
+#include "dwio/nimble/common/Exceptions.h"
+#include "dwio/nimble/common/tests/GTestUtils.h"
+#include "dwio/nimble/tablet/Constants.h"
+
+using namespace facebook::nimble;
+
+TEST(PostscriptTest, defaultConstruction) {
+  Postscript ps;
+  EXPECT_EQ(ps.footerSize(), 0);
+  EXPECT_EQ(ps.footerCompressionType(), CompressionType::Uncompressed);
+  EXPECT_EQ(ps.checksum(), 0);
+  EXPECT_EQ(ps.majorVersion(), 0);
+  EXPECT_EQ(ps.minorVersion(), 0);
+}
+
+TEST(PostscriptTest, parameterizedConstruction) {
+  Postscript ps{100, CompressionType::Zstd, ChecksumType::XXH3_64, 2, 3};
+  EXPECT_EQ(ps.footerSize(), 100);
+  EXPECT_EQ(ps.footerCompressionType(), CompressionType::Zstd);
+  EXPECT_EQ(ps.checksum(), 0);
+  EXPECT_EQ(ps.checksumType(), ChecksumType::XXH3_64);
+  EXPECT_EQ(ps.majorVersion(), 2);
+  EXPECT_EQ(ps.minorVersion(), 3);
+}
+
+TEST(PostscriptTest, serializeRoundTrip) {
+  struct TestParam {
+    uint32_t footerSize;
+    CompressionType compressionType;
+    ChecksumType checksumType;
+    uint32_t majorVersion;
+    uint32_t minorVersion;
+
+    std::string debugString() const {
+      return fmt::format(
+          "footerSize {}, compressionType {}, checksumType {}, version {}.{}",
+          footerSize,
+          static_cast<int>(compressionType),
+          static_cast<int>(checksumType),
+          majorVersion,
+          minorVersion);
+    }
+  };
+
+  std::vector<TestParam> testSettings = {
+      {0, CompressionType::Uncompressed, ChecksumType::XXH3_64, 0, 0},
+      {100, CompressionType::Zstd, ChecksumType::XXH3_64, kVersionMajor, 0},
+      {8 * 1024 * 1024,
+       CompressionType::Zstd,
+       ChecksumType::XXH3_64,
+       kVersionMajor,
+       kVersionMinor},
+      {std::numeric_limits<uint32_t>::max(),
+       CompressionType::Uncompressed,
+       ChecksumType::XXH3_64,
+       kVersionMajor,
+       0xFFFF},
+  };
+
+  for (const auto& testData : testSettings) {
+    SCOPED_TRACE(testData.debugString());
+
+    Postscript original{
+        testData.footerSize,
+        testData.compressionType,
+        testData.checksumType,
+        testData.majorVersion,
+        testData.minorVersion};
+
+    auto serialized = original.serialize();
+    EXPECT_EQ(serialized.size(), Postscript::kSize);
+
+    auto parsed = Postscript::parse(serialized);
+    EXPECT_EQ(parsed.footerSize(), original.footerSize());
+    EXPECT_EQ(parsed.footerCompressionType(), original.footerCompressionType());
+    EXPECT_EQ(parsed.checksum(), original.checksum());
+    EXPECT_EQ(parsed.checksumType(), original.checksumType());
+    EXPECT_EQ(parsed.majorVersion(), original.majorVersion());
+    EXPECT_EQ(parsed.minorVersion(), original.minorVersion());
+  }
+}
+
+TEST(PostscriptTest, serializeSize) {
+  Postscript ps{100, CompressionType::Zstd, ChecksumType::XXH3_64, 1, 0};
+  auto buf = ps.serialize();
+  EXPECT_EQ(buf.size(), Postscript::kSize);
+}
+
+TEST(PostscriptTest, parseTooSmall) {
+  std::string buf(Postscript::kSize - 1, '\0');
+  NIMBLE_ASSERT_THROW(Postscript::parse(buf), "Invalid postscript length");
+}
+
+TEST(PostscriptTest, parseBadMagic) {
+  Postscript ps{100, CompressionType::Zstd, ChecksumType::XXH3_64, 1, 0};
+  auto buf = ps.serialize();
+  buf[Postscript::kSize - 1] = 'X';
+  NIMBLE_ASSERT_THROW(Postscript::parse(buf), "Magic number mismatch");
+}


### PR DESCRIPTION
Summary:

CONTEXT: Postscript byte layout was duplicated between parse (reader) and manual byte writes (writer). This made the layout fragile and hard to maintain.

WHAT:
- Make Postscript constructor public so both reader and writer can construct it.
- Add Postscript::serialize() that produces the exact kPostscriptSize-byte binary layout, matching the on-disk format.
- Update TabletWriter::close() to use Postscript constructor + serialize() instead of manual byte writes, ensuring the byte layout is defined in one place.

Reviewed By: zacw7

Differential Revision: D104845480


