### PR TITLE
Add per-chunk statistics computation and serialization in Nimble

### DIFF
--- a/dwio/nimble/common/Types.h
+++ b/dwio/nimble/common/Types.h
@@ -15,6 +15,7 @@
  */
 #pragma once
 
+#include <cstdint>
 #include <memory>
 #include <string>
 #include <string_view>
@@ -319,6 +320,16 @@ template <typename T>
 constexpr bool isBoolType() {
   return std::is_same_v<T, bool>;
 }
+
+/// Per-chunk column statistics for filter pushdown.
+/// Min/max stored as raw bytes in the stream's native type (little-endian).
+/// Empty minValue/maxValue means stats are unavailable.
+struct ChunkStats {
+  bool hasNulls{false};
+  uint64_t nullCount{0};
+  std::string minValue;
+  std::string maxValue;
+};
 
 } // namespace facebook::nimble
 

--- a/dwio/nimble/tablet/Chunk.h
+++ b/dwio/nimble/tablet/Chunk.h
@@ -16,8 +16,11 @@
 #pragma once
 
 #include <cstdint>
+#include <optional>
 #include <string_view>
 #include <vector>
+
+#include "dwio/nimble/common/Types.h"
 
 namespace facebook::nimble {
 
@@ -31,6 +34,9 @@ struct Chunk {
   /// of string views. Each string_view points to a buffer containing a portion
   /// of the chunk's data. Multiple buffers may be used for large chunks.
   std::vector<std::string_view> content;
+
+  /// Per-chunk statistics. Populated when chunk stats are enabled.
+  std::optional<ChunkStats> stats;
 
   /// Returns the total byte size of all content in this chunk.
   uint32_t contentSize() const {

--- a/dwio/nimble/tablet/ChunkIndex.fbs
+++ b/dwio/nimble/tablet/ChunkIndex.fbs
@@ -39,6 +39,18 @@ table StripeChunkIndex {
   stream_chunk_rows:[uint32];
   /// Byte offset of each chunk within its stream.
   stream_chunk_offsets:[uint32];
+
+  /// Per-stream chunk statistics for filter pushdown.
+  stream_stats:[StreamChunkStats];
+}
+
+/// Min/max stored as raw bytes in the stream's native type (little-endian).
+table StreamChunkStats {
+  has_nulls:[ubyte];
+  min_values:[ubyte];
+  max_values:[ubyte];
+  value_size:uint32;
+  null_counts:[int64];
 }
 
 /// Root table for the chunk index optional section.

--- a/dwio/nimble/tablet/ChunkIndexWriter.cpp
+++ b/dwio/nimble/tablet/ChunkIndexWriter.cpp
@@ -19,6 +19,7 @@
 #include <algorithm>
 
 #include "dwio/nimble/common/Exceptions.h"
+#include "dwio/nimble/tablet/Chunk.h"
 #include "dwio/nimble/tablet/ChunkIndexGenerated.h"
 #include "dwio/nimble/tablet/Constants.h"
 #include "dwio/nimble/tablet/TabletWriter.h"
@@ -35,12 +36,81 @@ std::string_view asView(const flatbuffers::FlatBufferBuilder& builder) {
       builder.GetSize()};
 }
 
+flatbuffers::Offset<serialization::StreamChunkStats> serializeStreamStats(
+    flatbuffers::FlatBufferBuilder& builder,
+    const std::vector<ChunkStats>& chunks) {
+  if (chunks.empty()) {
+    return serialization::CreateStreamChunkStats(builder);
+  }
+  const auto n = chunks.size();
+
+  std::vector<uint8_t> hasNulls(n);
+  std::vector<int64_t> nullCounts(n);
+  for (size_t i = 0; i < n; ++i) {
+    hasNulls[i] = chunks[i].hasNulls ? 1 : 0;
+    nullCounts[i] = static_cast<int64_t>(chunks[i].nullCount);
+  }
+
+  // Determine value_size and validate that all chunks have consistent sizes.
+  // If any chunk has a different size or is missing min/max while others have
+  // it, drop min/max for the entire stream to avoid false filter bounds.
+  uint32_t valueSize = 0;
+  bool seenEmpty = false;
+  for (const auto& c : chunks) {
+    if (c.minValue.empty()) {
+      seenEmpty = true;
+    } else {
+      if (seenEmpty) {
+        // Earlier chunk(s) had empty min/max — inconsistent.
+        valueSize = 0;
+        break;
+      }
+      if (valueSize == 0) {
+        valueSize = static_cast<uint32_t>(c.minValue.size());
+      }
+      if (c.minValue.size() != valueSize || c.maxValue.size() != valueSize) {
+        valueSize = 0;
+        break;
+      }
+    }
+  }
+  if (seenEmpty) {
+    valueSize = 0;
+  }
+
+  // Concatenate min/max bytes.
+  flatbuffers::Offset<flatbuffers::Vector<uint8_t>> minsVec = 0;
+  flatbuffers::Offset<flatbuffers::Vector<uint8_t>> maxsVec = 0;
+  if (valueSize > 0) {
+    std::vector<uint8_t> allMins, allMaxs;
+    allMins.reserve(n * valueSize);
+    allMaxs.reserve(n * valueSize);
+    for (const auto& c : chunks) {
+      allMins.insert(allMins.end(), c.minValue.begin(), c.minValue.end());
+      allMaxs.insert(allMaxs.end(), c.maxValue.begin(), c.maxValue.end());
+    }
+    minsVec = builder.CreateVector(allMins);
+    maxsVec = builder.CreateVector(allMaxs);
+  }
+
+  return serialization::CreateStreamChunkStats(
+      builder,
+      /*has_nulls=*/builder.CreateVector(hasNulls),
+      /*min_values=*/minsVec,
+      /*max_values=*/maxsVec,
+      /*value_size=*/valueSize,
+      /*null_counts=*/builder.CreateVector(nullCounts));
+}
+
 } // namespace
 
 ChunkIndexWriter::ChunkIndexWriter(
     velox::memory::MemoryPool& pool,
-    float minAvgChunksPerStream)
-    : pool_{&pool}, minAvgChunksPerStream_{minAvgChunksPerStream} {}
+    float minAvgChunksPerStream,
+    bool enableChunkStats)
+    : pool_{&pool},
+      minAvgChunksPerStream_{minAvgChunksPerStream},
+      enableChunkStats_{enableChunkStats} {}
 
 void ChunkIndexWriter::newStripe(size_t streamCount) {
   NIMBLE_CHECK(!finalized_, "ChunkIndexWriter has been finalized");
@@ -59,15 +129,22 @@ void ChunkIndexWriter::addStream(
   NIMBLE_CHECK(!groupIndex_->empty());
   NIMBLE_CHECK_LT(streamIndex, groupIndex_->stripes.back().streams.size());
 
-  auto& index = groupIndex_->stripes.back().streams[streamIndex];
+  auto& stream = groupIndex_->stripes.back().streams[streamIndex];
   uint32_t accumulatedRows{0};
   uint32_t accumulatedOffset{0};
   for (const auto& chunk : chunks) {
     accumulatedRows += chunk.rowCount;
-    index.chunkRows.emplace_back(accumulatedRows);
-    index.chunkOffsets.emplace_back(accumulatedOffset);
+    stream.chunkRows.emplace_back(accumulatedRows);
+    stream.chunkOffsets.emplace_back(accumulatedOffset);
     accumulatedOffset += chunk.contentSize();
-    ++index.chunkCount;
+    ++stream.chunkCount;
+    if (enableChunkStats_) {
+      if (chunk.stats.has_value()) {
+        stream.chunkStats.emplace_back(*chunk.stats);
+      } else {
+        stream.chunkStats.emplace_back();
+      }
+    }
   }
 }
 
@@ -106,7 +183,7 @@ void ChunkIndexWriter::writeGroup(
     }
   }
 
-  // Flatten chunk data for all streams.
+  // Flatten chunk position data for all streams.
   std::vector<uint32_t> flattenedStreamChunkCounts;
   flattenedStreamChunkCounts.reserve(stripeCount * streamCount);
 
@@ -143,12 +220,34 @@ void ChunkIndexWriter::writeGroup(
   }
 
   flatbuffers::FlatBufferBuilder builder(kInitialFooterSize);
+
+  flatbuffers::Offset<
+      flatbuffers::Vector<flatbuffers::Offset<serialization::StreamChunkStats>>>
+      streamStatsVec = 0;
+  if (enableChunkStats_) {
+    std::vector<flatbuffers::Offset<serialization::StreamChunkStats>>
+        streamStats;
+    streamStats.reserve(stripeCount * streamCount);
+    for (const auto& stripe : groupIndex_->stripes) {
+      for (size_t sid = 0; sid < streamCount; ++sid) {
+        if (sid < stripe.streams.size()) {
+          streamStats.push_back(
+              serializeStreamStats(builder, stripe.streams[sid].chunkStats));
+        } else {
+          streamStats.push_back(serializeStreamStats(builder, {}));
+        }
+      }
+    }
+    streamStatsVec = builder.CreateVector(streamStats);
+  }
+
   auto chunkIndex = serialization::CreateStripeChunkIndex(
       builder,
       static_cast<uint32_t>(streamCount),
       builder.CreateVector(flattenedStreamChunkCounts),
       builder.CreateVector(flattenedChunkRows),
-      builder.CreateVector(flattenedChunkOffsets));
+      builder.CreateVector(flattenedChunkOffsets),
+      streamStatsVec);
   builder.Finish(chunkIndex);
 
   chunkIndexSections_.push_back(createMetadataSection(asView(builder)));

--- a/dwio/nimble/tablet/ChunkIndexWriter.h
+++ b/dwio/nimble/tablet/ChunkIndexWriter.h
@@ -19,6 +19,7 @@
 #include <memory>
 #include <vector>
 
+#include "dwio/nimble/common/Types.h"
 #include "dwio/nimble/tablet/MetadataBuffer.h"
 
 namespace facebook::nimble {
@@ -43,9 +44,11 @@ class ChunkIndexWriter {
   /// @param minAvgChunksPerStream Skip writing chunk index for a stripe group
   ///        if the average number of chunks per stream is below this threshold.
   ///        0 disables chunk index skipping.
+  /// @param enableChunkStats Whether to serialize per-chunk statistics.
   explicit ChunkIndexWriter(
       velox::memory::MemoryPool& pool,
-      float minAvgChunksPerStream = 2);
+      float minAvgChunksPerStream = 2,
+      bool enableChunkStats = false);
 
   ChunkIndexWriter(const ChunkIndexWriter&) = delete;
   ChunkIndexWriter& operator=(const ChunkIndexWriter&) = delete;
@@ -82,6 +85,8 @@ class ChunkIndexWriter {
     std::vector<uint32_t> chunkRows;
     // Byte offsets of each chunk within the stream.
     std::vector<uint32_t> chunkOffsets;
+    // Per-chunk statistics. Empty when stats are disabled.
+    std::vector<ChunkStats> chunkStats;
     // Number of chunks in this stripe for this stream.
     uint32_t chunkCount{0};
   };
@@ -102,6 +107,8 @@ class ChunkIndexWriter {
 
   velox::memory::MemoryPool* const pool_;
   const float minAvgChunksPerStream_;
+  // Whether per-chunk statistics are serialized into the chunk index.
+  const bool enableChunkStats_;
   std::unique_ptr<GroupIndex> groupIndex_;
   // Metadata sections for chunk index flatbuffers (used by writeRoot).
   std::vector<MetadataSection> chunkIndexSections_;

--- a/dwio/nimble/tablet/TabletWriter.cpp
+++ b/dwio/nimble/tablet/TabletWriter.cpp
@@ -40,8 +40,13 @@ TabletWriter::TabletWriter(
       chunkIndexWriter_{
           options_.enableChunkIndex ? std::make_unique<ChunkIndexWriter>(
                                           pool,
-                                          options_.chunkIndexMinAvgChunks)
-                                    : nullptr} {}
+                                          options_.chunkIndexMinAvgChunks,
+                                          options_.enableChunkStats)
+                                    : nullptr} {
+  NIMBLE_CHECK(
+      !options_.enableChunkStats || options_.enableChunkIndex,
+      "enableChunkStats requires enableChunkIndex to be true.");
+}
 
 namespace {
 template <typename Source, typename Target = Source>

--- a/dwio/nimble/tablet/TabletWriter.h
+++ b/dwio/nimble/tablet/TabletWriter.h
@@ -18,6 +18,7 @@
 
 #include "dwio/nimble/common/Buffer.h"
 #include "dwio/nimble/common/Checksum.h"
+#include "dwio/nimble/common/Types.h"
 #include "dwio/nimble/common/Vector.h"
 #include "dwio/nimble/tablet/Chunk.h"
 #include "dwio/nimble/tablet/ChunkIndexWriter.h"
@@ -75,6 +76,8 @@ class TabletWriter {
     // of chunks per stream is below this threshold. 0 disables chunk index
     // skipping.
     float chunkIndexMinAvgChunks{2};
+    // Serialize per-chunk min/max statistics into the chunk index.
+    bool enableChunkStats{false};
     // Callback invoked at stripe group flush boundaries. Used by index
     // writers (e.g., ClusterIndexWriter) to write partition data aligned
     // with stripe groups.
@@ -188,7 +191,7 @@ class TabletWriter {
   velox::memory::MemoryPool* const pool_;
   const Options options_;
   const std::unique_ptr<Checksum> checksum_;
-  // Chunk-level position index.
+  // Chunk-level position index and per-chunk statistics.
   const std::unique_ptr<ChunkIndexWriter> chunkIndexWriter_;
 
   // Number of rows in each stripe.

--- a/dwio/nimble/tablet/tests/ChunkStatsTest.cpp
+++ b/dwio/nimble/tablet/tests/ChunkStatsTest.cpp
@@ -1,0 +1,390 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "dwio/nimble/tablet/ChunkIndexWriter.h"
+
+#include <cmath>
+#include <limits>
+#include <vector>
+
+#include <gtest/gtest.h>
+
+#include "dwio/nimble/common/Buffer.h"
+#include "dwio/nimble/index/tests/ClusterIndexTestUtils.h"
+#include "dwio/nimble/tablet/ChunkIndexGenerated.h"
+#include "dwio/nimble/tablet/Constants.h"
+#include "dwio/nimble/tablet/TabletWriter.h"
+#include "dwio/nimble/velox/StreamChunker.h"
+#include "velox/common/memory/Memory.h"
+
+namespace facebook::nimble::test {
+
+using index::test::ChunkSpec;
+using index::test::createChunks;
+
+namespace {
+
+// Helper to create a ChunkStats with PLAIN-encoded int64 min/max.
+ChunkStats makeIntStats(
+    int64_t min,
+    int64_t max,
+    bool hasNulls = false,
+    uint64_t nullCount = 0) {
+  ChunkStats stats;
+  stats.hasNulls = hasNulls;
+  stats.nullCount = nullCount;
+  stats.minValue.assign(reinterpret_cast<const char*>(&min), sizeof(int64_t));
+  stats.maxValue.assign(reinterpret_cast<const char*>(&max), sizeof(int64_t));
+  return stats;
+}
+
+// Helper to create a ChunkStats with PLAIN-encoded double min/max.
+ChunkStats makeDoubleStats(double min, double max, bool hasNulls = false) {
+  ChunkStats stats;
+  stats.hasNulls = hasNulls;
+  stats.minValue.assign(reinterpret_cast<const char*>(&min), sizeof(double));
+  stats.maxValue.assign(reinterpret_cast<const char*>(&max), sizeof(double));
+  return stats;
+}
+
+// Helper to read an int64 from a raw byte vector at chunk index i.
+int64_t readInt64(const flatbuffers::Vector<uint8_t>* vec, size_t chunkIndex) {
+  int64_t val;
+  std::memcpy(&val, vec->data() + chunkIndex * sizeof(int64_t), sizeof(val));
+  return val;
+}
+
+// Helper to read a double from a raw byte vector at chunk index i.
+double readDouble(const flatbuffers::Vector<uint8_t>* vec, size_t chunkIndex) {
+  double val;
+  std::memcpy(&val, vec->data() + chunkIndex * sizeof(double), sizeof(val));
+  return val;
+}
+
+} // namespace
+
+// Captures serialized chunk index data for verification in tests.
+struct TestChunkStatsFileIndex {
+  std::vector<std::string> groupMetadataSections;
+  std::string rootIndexData;
+};
+
+class ChunkStatsTest : public ::testing::Test {
+ protected:
+  static void SetUpTestCase() {
+    velox::memory::MemoryManager::testingSetInstance({});
+  }
+
+  void SetUp() override {
+    pool_ = velox::memory::memoryManager()->addLeafPool();
+  }
+
+  static auto createMetadataSectionCallback(
+      TestChunkStatsFileIndex& fileIndex) {
+    return [&fileIndex](std::string_view metadata) -> MetadataSection {
+      fileIndex.groupMetadataSections.emplace_back(metadata);
+      return MetadataSection(
+          0,
+          static_cast<uint32_t>(metadata.size()),
+          CompressionType::Uncompressed);
+    };
+  }
+
+  static auto writeRootCallback(TestChunkStatsFileIndex& fileIndex) {
+    return [&fileIndex](const std::string& name, std::string_view content) {
+      EXPECT_EQ(name, nimble::kChunkIndexSection);
+      fileIndex.rootIndexData = std::string(content);
+    };
+  }
+
+  std::shared_ptr<velox::memory::MemoryPool> pool_;
+};
+
+TEST_F(ChunkStatsTest, integerStatsRoundTrip) {
+  ChunkIndexWriter writer(*pool_, 0, /*enableChunkStats=*/true);
+  Buffer buffer{*pool_};
+  TestChunkStatsFileIndex fileIndex;
+
+  // 1 stripe, 2 streams. Stream 0 has int stats, stream 1 has no stats.
+  writer.newStripe(2);
+
+  auto chunks0 = createChunks(buffer, {{100, 40}, {100, 40}});
+  chunks0[0].stats = makeIntStats(10, 50);
+  chunks0[1].stats = makeIntStats(-5, 100, /*hasNulls=*/true, /*nullCount=*/7);
+  writer.addStream(0, chunks0);
+
+  auto chunks1 = createChunks(buffer, {{100, 30}});
+  writer.addStream(1, chunks1);
+
+  writer.writeGroup(2, 1, createMetadataSectionCallback(fileIndex));
+  writer.writeRoot(writeRootCallback(fileIndex));
+
+  ASSERT_EQ(fileIndex.groupMetadataSections.size(), 1);
+  ASSERT_FALSE(fileIndex.rootIndexData.empty());
+
+  const auto* stripeIndex =
+      flatbuffers::GetRoot<serialization::StripeChunkIndex>(
+          fileIndex.groupMetadataSections[0].data());
+  ASSERT_NE(stripeIndex, nullptr);
+
+  const auto* streamStatsVec = stripeIndex->stream_stats();
+  ASSERT_NE(streamStatsVec, nullptr);
+  ASSERT_EQ(streamStatsVec->size(), 2);
+
+  // Stream 0: int stats for 2 chunks.
+  const auto* ss0 = streamStatsVec->Get(0);
+  ASSERT_NE(ss0, nullptr);
+  ASSERT_NE(ss0->min_values(), nullptr);
+  ASSERT_NE(ss0->max_values(), nullptr);
+  ASSERT_NE(ss0->has_nulls(), nullptr);
+  EXPECT_EQ(ss0->value_size(), sizeof(int64_t));
+  ASSERT_EQ(ss0->min_values()->size(), 2 * sizeof(int64_t));
+
+  ASSERT_NE(ss0->null_counts(), nullptr);
+  EXPECT_EQ(readInt64(ss0->min_values(), 0), 10);
+  EXPECT_EQ(readInt64(ss0->max_values(), 0), 50);
+  EXPECT_EQ(ss0->has_nulls()->Get(0), 0);
+  EXPECT_EQ(ss0->null_counts()->Get(0), 0);
+
+  EXPECT_EQ(readInt64(ss0->min_values(), 1), -5);
+  EXPECT_EQ(readInt64(ss0->max_values(), 1), 100);
+  EXPECT_EQ(ss0->has_nulls()->Get(1), 1);
+  EXPECT_EQ(ss0->null_counts()->Get(1), 7);
+
+  // Stream 1: no typed stats.
+  const auto* ss1 = streamStatsVec->Get(1);
+  ASSERT_NE(ss1, nullptr);
+  EXPECT_EQ(ss1->min_values(), nullptr);
+}
+
+TEST_F(ChunkStatsTest, doubleStatsRoundTrip) {
+  ChunkIndexWriter writer(*pool_, 0, /*enableChunkStats=*/true);
+  Buffer buffer{*pool_};
+  TestChunkStatsFileIndex fileIndex;
+
+  writer.newStripe(1);
+
+  auto chunks = createChunks(buffer, {{200, 80}});
+  chunks[0].stats = makeDoubleStats(-1.5, 99.9);
+  writer.addStream(0, chunks);
+
+  writer.writeGroup(1, 1, createMetadataSectionCallback(fileIndex));
+  writer.writeRoot(writeRootCallback(fileIndex));
+
+  const auto* stripeIndex =
+      flatbuffers::GetRoot<serialization::StripeChunkIndex>(
+          fileIndex.groupMetadataSections[0].data());
+  const auto* ss0 = stripeIndex->stream_stats()->Get(0);
+
+  ASSERT_NE(ss0->min_values(), nullptr);
+  ASSERT_NE(ss0->max_values(), nullptr);
+  EXPECT_EQ(ss0->value_size(), sizeof(double));
+  EXPECT_DOUBLE_EQ(readDouble(ss0->min_values(), 0), -1.5);
+  EXPECT_DOUBLE_EQ(readDouble(ss0->max_values(), 0), 99.9);
+}
+
+TEST_F(ChunkStatsTest, noStatsNoStreamStatsField) {
+  ChunkIndexWriter writer(*pool_, 0, /*enableChunkStats=*/false);
+  Buffer buffer{*pool_};
+  TestChunkStatsFileIndex fileIndex;
+
+  writer.newStripe(1);
+  writer.addStream(0, createChunks(buffer, {{100, 40}}));
+  writer.writeGroup(1, 1, createMetadataSectionCallback(fileIndex));
+  writer.writeRoot(writeRootCallback(fileIndex));
+
+  const auto* stripeIndex =
+      flatbuffers::GetRoot<serialization::StripeChunkIndex>(
+          fileIndex.groupMetadataSections[0].data());
+  // No stats attached — stream_stats should be absent (null offset).
+  EXPECT_EQ(stripeIndex->stream_stats(), nullptr);
+}
+
+TEST_F(ChunkStatsTest, multipleStripesInGroup) {
+  ChunkIndexWriter writer(*pool_, 0, /*enableChunkStats=*/true);
+  Buffer buffer{*pool_};
+  TestChunkStatsFileIndex fileIndex;
+
+  writer.newStripe(1);
+  auto chunks0 = createChunks(buffer, {{100, 40}});
+  chunks0[0].stats = makeIntStats(1, 10);
+  writer.addStream(0, chunks0);
+
+  writer.newStripe(1);
+  auto chunks1 = createChunks(buffer, {{100, 40}});
+  chunks1[0].stats = makeIntStats(20, 30, /*hasNulls=*/true);
+  writer.addStream(0, chunks1);
+
+  writer.writeGroup(1, 2, createMetadataSectionCallback(fileIndex));
+  writer.writeRoot(writeRootCallback(fileIndex));
+
+  const auto* stripeIndex =
+      flatbuffers::GetRoot<serialization::StripeChunkIndex>(
+          fileIndex.groupMetadataSections[0].data());
+  const auto* streamStatsVec = stripeIndex->stream_stats();
+  ASSERT_NE(streamStatsVec, nullptr);
+  ASSERT_EQ(streamStatsVec->size(), 2);
+
+  const auto* s0 = streamStatsVec->Get(0);
+  EXPECT_EQ(readInt64(s0->min_values(), 0), 1);
+  EXPECT_EQ(readInt64(s0->max_values(), 0), 10);
+  EXPECT_EQ(s0->has_nulls()->Get(0), 0);
+
+  const auto* s1 = streamStatsVec->Get(1);
+  EXPECT_EQ(readInt64(s1->min_values(), 0), 20);
+  EXPECT_EQ(readInt64(s1->max_values(), 0), 30);
+  EXPECT_EQ(s1->has_nulls()->Get(0), 1);
+}
+
+TEST_F(ChunkStatsTest, partialStatsOmitsMinMax) {
+  // When some chunks have stats and others don't (e.g., floats with NaN),
+  // the writer must omit min/max for the entire stream to avoid false
+  // bounds that would cause incorrect filter pushdown.
+  ChunkIndexWriter writer(*pool_, 0, /*enableChunkStats=*/true);
+  Buffer buffer{*pool_};
+  TestChunkStatsFileIndex fileIndex;
+
+  writer.newStripe(1);
+
+  auto chunks = createChunks(buffer, {{100, 40}, {100, 40}});
+  chunks[0].stats = makeIntStats(10, 50);
+  // Chunk 1 has stats but with empty minValue/maxValue (simulates NaN).
+  chunks[1].stats = ChunkStats{};
+  chunks[1].stats->hasNulls = false;
+  writer.addStream(0, chunks);
+
+  writer.writeGroup(1, 1, createMetadataSectionCallback(fileIndex));
+  writer.writeRoot(writeRootCallback(fileIndex));
+
+  const auto* stripeIndex =
+      flatbuffers::GetRoot<serialization::StripeChunkIndex>(
+          fileIndex.groupMetadataSections[0].data());
+  const auto* streamStatsVec = stripeIndex->stream_stats();
+  ASSERT_NE(streamStatsVec, nullptr);
+  ASSERT_EQ(streamStatsVec->size(), 1);
+
+  const auto* ss0 = streamStatsVec->Get(0);
+  ASSERT_NE(ss0, nullptr);
+  // has_nulls is still available since it's independent of min/max.
+  ASSERT_NE(ss0->has_nulls(), nullptr);
+  // min/max must be omitted (not zero-filled) to avoid false bounds.
+  EXPECT_EQ(ss0->min_values(), nullptr);
+  EXPECT_EQ(ss0->max_values(), nullptr);
+  EXPECT_EQ(ss0->value_size(), 0);
+}
+
+// Direct unit tests for detail::computeChunkStats.
+
+TEST(ComputeChunkStatsTest, integerMinMax) {
+  std::vector<int64_t> data = {5, -3, 42, 0, 17};
+  auto stats = detail::computeChunkStats(data.begin(), data.end());
+
+  EXPECT_FALSE(stats.hasNulls);
+  ASSERT_EQ(stats.minValue.size(), sizeof(int64_t));
+  ASSERT_EQ(stats.maxValue.size(), sizeof(int64_t));
+
+  int64_t minVal, maxVal;
+  std::memcpy(&minVal, stats.minValue.data(), sizeof(int64_t));
+  std::memcpy(&maxVal, stats.maxValue.data(), sizeof(int64_t));
+  EXPECT_EQ(minVal, -3);
+  EXPECT_EQ(maxVal, 42);
+}
+
+TEST(ComputeChunkStatsTest, integerWithNulls) {
+  std::vector<int32_t> data = {10, 20};
+  auto stats = detail::computeChunkStats(
+      data.begin(), data.end(), /*hasNulls=*/true, /*nullCount=*/3);
+
+  EXPECT_TRUE(stats.hasNulls);
+  EXPECT_EQ(stats.nullCount, 3);
+  ASSERT_EQ(stats.minValue.size(), sizeof(int32_t));
+  ASSERT_EQ(stats.maxValue.size(), sizeof(int32_t));
+
+  int32_t minVal, maxVal;
+  std::memcpy(&minVal, stats.minValue.data(), sizeof(int32_t));
+  std::memcpy(&maxVal, stats.maxValue.data(), sizeof(int32_t));
+  EXPECT_EQ(minVal, 10);
+  EXPECT_EQ(maxVal, 20);
+}
+
+TEST(ComputeChunkStatsTest, floatMinMax) {
+  std::vector<double> data = {1.5, -0.5, 100.0};
+  auto stats = detail::computeChunkStats(data.begin(), data.end());
+
+  EXPECT_FALSE(stats.hasNulls);
+  ASSERT_EQ(stats.minValue.size(), sizeof(double));
+  ASSERT_EQ(stats.maxValue.size(), sizeof(double));
+
+  double minVal, maxVal;
+  std::memcpy(&minVal, stats.minValue.data(), sizeof(double));
+  std::memcpy(&maxVal, stats.maxValue.data(), sizeof(double));
+  EXPECT_DOUBLE_EQ(minVal, -0.5);
+  EXPECT_DOUBLE_EQ(maxVal, 100.0);
+}
+
+TEST(ComputeChunkStatsTest, floatNaNBailout) {
+  std::vector<double> data = {
+      1.0, std::numeric_limits<double>::quiet_NaN(), 3.0};
+  auto stats = detail::computeChunkStats(data.begin(), data.end());
+
+  EXPECT_FALSE(stats.hasNulls);
+  EXPECT_TRUE(stats.minValue.empty());
+  EXPECT_TRUE(stats.maxValue.empty());
+}
+
+TEST(ComputeChunkStatsTest, floatAllNaN) {
+  std::vector<float> data = {
+      std::numeric_limits<float>::quiet_NaN(),
+      std::numeric_limits<float>::quiet_NaN()};
+  auto stats = detail::computeChunkStats(data.begin(), data.end());
+
+  EXPECT_TRUE(stats.minValue.empty());
+  EXPECT_TRUE(stats.maxValue.empty());
+}
+
+TEST(ComputeChunkStatsTest, emptyRange) {
+  std::vector<int64_t> data;
+  auto stats = detail::computeChunkStats(data.begin(), data.end());
+
+  EXPECT_FALSE(stats.hasNulls);
+  EXPECT_TRUE(stats.minValue.empty());
+  EXPECT_TRUE(stats.maxValue.empty());
+}
+
+TEST(ComputeChunkStatsTest, boolProducesNoMinMax) {
+  std::vector<bool> data = {true, false, true};
+  auto stats = detail::computeChunkStats(data.begin(), data.end());
+
+  EXPECT_FALSE(stats.hasNulls);
+  EXPECT_TRUE(stats.minValue.empty());
+  EXPECT_TRUE(stats.maxValue.empty());
+}
+
+TEST(ComputeChunkStatsTest, singleElement) {
+  std::vector<int64_t> data = {42};
+  auto stats = detail::computeChunkStats(data.begin(), data.end());
+
+  ASSERT_EQ(stats.minValue.size(), sizeof(int64_t));
+  ASSERT_EQ(stats.maxValue.size(), sizeof(int64_t));
+
+  int64_t minVal, maxVal;
+  std::memcpy(&minVal, stats.minValue.data(), sizeof(int64_t));
+  std::memcpy(&maxVal, stats.maxValue.data(), sizeof(int64_t));
+  EXPECT_EQ(minVal, 42);
+  EXPECT_EQ(maxVal, 42);
+}
+
+} // namespace facebook::nimble::test

--- a/dwio/nimble/velox/StreamChunker.h
+++ b/dwio/nimble/velox/StreamChunker.h
@@ -16,6 +16,10 @@
 
 #pragma once
 
+#include <algorithm>
+#include <bit>
+#include <cmath>
+
 #include "dwio/nimble/velox/StreamData.h"
 
 namespace facebook::nimble {
@@ -42,6 +46,55 @@ inline bool shouldOmitNullStream(
   }
   return isFirstChunk || streamData.empty();
 }
+
+// Copies the raw bytes of 'value' into 'dst'.
+template <typename T>
+void assignBytes(std::string& dst, const T& value) {
+  static_assert(
+      std::endian::native == std::endian::little,
+      "Chunk stats binary format assumes little-endian byte order.");
+  dst.assign(reinterpret_cast<const char*>(&value), sizeof(T));
+}
+
+// Computes per-chunk statistics (hasNulls, nullCount, min/max) from a typed
+// data range.
+template <typename Iter>
+ChunkStats computeChunkStats(
+    Iter begin,
+    Iter end,
+    bool hasNulls = false,
+    uint64_t nullCount = 0) {
+  using T = typename std::iterator_traits<Iter>::value_type;
+  ChunkStats stats;
+  stats.hasNulls = hasNulls;
+  stats.nullCount = nullCount;
+  if (begin == end) {
+    return stats;
+  }
+  // Integer types (excluding bool).
+  if constexpr (std::is_integral_v<T> && !std::is_same_v<T, bool>) {
+    auto [minIt, maxIt] = std::minmax_element(begin, end);
+    assignBytes(stats.minValue, *minIt);
+    assignBytes(stats.maxValue, *maxIt);
+  }
+  // Float/double: bail out entirely if any NaN is present.
+  else if constexpr (std::is_floating_point_v<T>) {
+    T minVal = std::numeric_limits<T>::max();
+    T maxVal = std::numeric_limits<T>::lowest();
+    for (auto it = begin; it != end; ++it) {
+      if (std::isnan(*it)) {
+        return stats;
+      }
+      minVal = std::min(minVal, *it);
+      maxVal = std::max(maxVal, *it);
+    }
+    assignBytes(stats.minValue, minVal);
+    assignBytes(stats.maxValue, maxVal);
+  }
+  // Bool and other types: no min/max.
+  return stats;
+}
+
 } // namespace detail
 
 /**
@@ -52,6 +105,7 @@ struct StreamChunkerOptions {
   uint64_t maxChunkSize;
   bool ensureFullChunks;
   bool isFirstChunk;
+  bool enableChunkStats{false};
 };
 
 /**
@@ -95,6 +149,7 @@ class ContentStreamChunker final : public StreamChunker {
         minChunkSize_{options.minChunkSize},
         maxChunkSize_{options.maxChunkSize},
         ensureFullChunks_{options.ensureFullChunks},
+        enableChunkStats_{options.enableChunkStats},
         extraMemory_{streamData_->extraMemory()} {
     static_assert(
         std::is_same_v<StreamDataT, ContentStreamData<T>> ||
@@ -119,12 +174,24 @@ class ContentStreamChunker final : public StreamChunker {
         reinterpret_cast<const char*>(
             streamData_->mutableData().data() + dataElementOffset_),
         chunkSize.dataElementCount * sizeof(T)};
+
+    // Non-nullable stream: compute min/max over the data slice directly.
+    std::optional<ChunkStats> chunkStats;
+    if (enableChunkStats_ && chunkSize.dataElementCount > 0) {
+      const auto* begin =
+          streamData_->mutableData().data() + dataElementOffset_;
+      chunkStats =
+          detail::computeChunkStats(begin, begin + chunkSize.dataElementCount);
+    }
+
     dataElementOffset_ += chunkSize.dataElementCount;
     extraMemory_ -= chunkSize.extraMemory;
     return StreamDataView{
         streamData_->descriptor(),
         dataChunk,
-        static_cast<uint32_t>(chunkSize.dataElementCount)};
+        static_cast<uint32_t>(chunkSize.dataElementCount),
+        std::nullopt,
+        std::move(chunkStats)};
   }
 
  private:
@@ -231,6 +298,7 @@ class ContentStreamChunker final : public StreamChunker {
   const uint64_t minChunkSize_;
   const uint64_t maxChunkSize_;
   const bool ensureFullChunks_;
+  const bool enableChunkStats_;
 
   size_t dataElementOffset_{0};
   size_t extraMemory_{0};
@@ -363,6 +431,7 @@ class NullableContentStreamChunker final : public StreamChunker {
             streamData.nonNulls().empty(),
             options.isFirstChunk)},
         ensureFullChunks_{options.ensureFullChunks},
+        enableChunkStats_{options.enableChunkStats},
         extraMemory_{streamData_->extraMemory()} {
     static_assert(sizeof(bool) == 1);
     NIMBLE_CHECK(
@@ -396,22 +465,50 @@ class NullableContentStreamChunker final : public StreamChunker {
         streamData_->mutableNonNulls().data() + nonNullsOffset_,
         chunkSize.nullElementCount);
 
+    const bool chunkHasNulls =
+        chunkSize.nullElementCount > chunkSize.dataElementCount;
+
+    // Nullable stream: compute min/max over non-null values only.
+    std::optional<ChunkStats> chunkStats;
+    if (enableChunkStats_) {
+      if (chunkSize.dataElementCount > 0) {
+        const auto* begin =
+            streamData_->mutableData().data() + dataElementOffset_;
+        const uint64_t nullCount =
+            chunkSize.nullElementCount - chunkSize.dataElementCount;
+        chunkStats = detail::computeChunkStats(
+            begin,
+            begin + chunkSize.dataElementCount,
+            chunkHasNulls,
+            nullCount);
+      } else {
+        // All-null chunk: no data to compute min/max, only null info.
+        ChunkStats stats;
+        stats.hasNulls = true;
+        stats.nullCount = chunkSize.nullElementCount;
+        chunkStats = std::move(stats);
+      }
+    }
+
     dataElementOffset_ += chunkSize.dataElementCount;
     nonNullsOffset_ += chunkSize.nullElementCount;
     extraMemory_ -= chunkSize.extraMemory;
 
-    if (chunkSize.nullElementCount > chunkSize.dataElementCount) {
+    if (chunkHasNulls) {
       return StreamDataView{
           streamData_->descriptor(),
           dataChunk,
           static_cast<uint32_t>(chunkSize.nullElementCount),
-          nonNullsChunk};
+          nonNullsChunk,
+          std::move(chunkStats)};
     }
     NIMBLE_CHECK_EQ(chunkSize.dataElementCount, chunkSize.nullElementCount);
     return StreamDataView{
         streamData_->descriptor(),
         dataChunk,
-        static_cast<uint32_t>(chunkSize.dataElementCount)};
+        static_cast<uint32_t>(chunkSize.dataElementCount),
+        std::nullopt,
+        std::move(chunkStats)};
   }
 
  private:
@@ -517,6 +614,7 @@ class NullableContentStreamChunker final : public StreamChunker {
   const uint64_t maxChunkSize_;
   const bool omitStream_;
   const bool ensureFullChunks_;
+  const bool enableChunkStats_;
 
   size_t dataElementOffset_{0};
   size_t nonNullsOffset_{0};
@@ -589,7 +687,8 @@ class NullableContentStringStreamChunker final : public StreamChunker {
             options.minChunkSize,
             streamData.nonNulls().empty(),
             options.isFirstChunk)},
-        ensureFullChunks_{options.ensureFullChunks} {
+        ensureFullChunks_{options.ensureFullChunks},
+        enableChunkStats_{options.enableChunkStats} {
     static_assert(sizeof(bool) == 1);
     streamData_->materializeNulls();
   }
@@ -627,6 +726,20 @@ class NullableContentStringStreamChunker final : public StreamChunker {
         streamData_->mutableNonNulls().data() + nonNullsOffset_,
         chunkSize.nullElementCount);
 
+    // String stream: no typed min/max (variable-length), only null info.
+    std::optional<ChunkStats> chunkStats;
+    if (enableChunkStats_) {
+      const bool chunkHasNulls =
+          chunkSize.nullElementCount > chunkSize.dataElementCount;
+      const uint64_t nullCount = chunkHasNulls
+          ? chunkSize.nullElementCount - chunkSize.dataElementCount
+          : 0;
+      ChunkStats stats;
+      stats.hasNulls = chunkHasNulls;
+      stats.nullCount = nullCount;
+      chunkStats = std::move(stats);
+    }
+
     lengthsOffset_ += chunkSize.dataElementCount;
     nonNullsOffset_ += chunkSize.nullElementCount;
     bufferOffset_ += chunkSize.extraMemory;
@@ -636,13 +749,16 @@ class NullableContentStringStreamChunker final : public StreamChunker {
           streamData_->descriptor(),
           dataChunk,
           static_cast<uint32_t>(chunkSize.nullElementCount),
-          nonNullsChunk};
+          nonNullsChunk,
+          std::move(chunkStats)};
     }
     NIMBLE_DCHECK_EQ(chunkSize.dataElementCount, chunkSize.nullElementCount);
     return StreamDataView{
         streamData_->descriptor(),
         dataChunk,
-        static_cast<uint32_t>(chunkSize.dataElementCount)};
+        static_cast<uint32_t>(chunkSize.dataElementCount),
+        {},
+        std::move(chunkStats)};
   }
 
  private:
@@ -771,6 +887,7 @@ class NullableContentStringStreamChunker final : public StreamChunker {
   const uint64_t maxChunkSize_;
   const bool omitStream_;
   const bool ensureFullChunks_;
+  const bool enableChunkStats_;
 
   size_t lengthsOffset_{0};
   size_t nonNullsOffset_{0};

--- a/dwio/nimble/velox/StreamData.h
+++ b/dwio/nimble/velox/StreamData.h
@@ -20,6 +20,7 @@
 #include <span>
 #include <string_view>
 
+#include "dwio/nimble/common/Types.h"
 #include "dwio/nimble/common/Vector.h"
 #include "dwio/nimble/velox/BufferGrowthPolicy.h"
 #include "dwio/nimble/velox/SchemaBuilder.h"
@@ -94,17 +95,20 @@ class StreamDataView final : public StreamData {
       const StreamDescriptorBuilder& descriptor,
       std::string_view data,
       uint32_t rowCount,
-      std::optional<std::span<const bool>> nonNulls = std::nullopt)
+      std::optional<std::span<const bool>> nonNulls = std::nullopt,
+      std::optional<ChunkStats> stats = std::nullopt)
       : StreamData(descriptor),
         data_{data},
         rowCount_{rowCount},
-        nonNulls_{nonNulls} {}
+        nonNulls_{nonNulls},
+        stats_{std::move(stats)} {}
 
   StreamDataView(StreamDataView&& other) noexcept
       : StreamData(other.descriptor()),
         data_{other.data_},
         rowCount_{other.rowCount_},
-        nonNulls_{other.nonNulls_} {}
+        nonNulls_{other.nonNulls_},
+        stats_{std::move(other.stats_)} {}
 
   StreamDataView(const StreamDataView&) = delete;
 
@@ -142,10 +146,15 @@ class StreamDataView final : public StreamData {
     NIMBLE_UNREACHABLE("StreamDataView is non-owning");
   }
 
+  const std::optional<ChunkStats>& stats() const {
+    return stats_;
+  }
+
  private:
   const std::string_view data_;
   const uint32_t rowCount_;
   const std::optional<std::span<const bool>> nonNulls_;
+  std::optional<ChunkStats> stats_;
 };
 
 /// Content only data stream.

--- a/dwio/nimble/velox/VeloxWriter.cpp
+++ b/dwio/nimble/velox/VeloxWriter.cpp
@@ -706,6 +706,7 @@ VeloxWriter::VeloxWriter(
                context_->options().enableStreamDeduplication,
            .enableChunkIndex = context_->options().enableChunkIndex,
            .chunkIndexMinAvgChunks = context_->options().chunkIndexMinAvgChunks,
+           .enableChunkStats = context_->options().enableChunkStats,
            .stripeGroupFlushCallback = clusterIndexWriter_ != nullptr
                ? TabletWriter::StripeGroupFlushCallback(
                      [this](
@@ -722,6 +723,15 @@ VeloxWriter::VeloxWriter(
              writeIndexes(writeDataFn, createMetadataFn, writeMetadataFn);
            }})} {
   NIMBLE_CHECK_NOT_NULL(file_);
+
+  if (context_->options().enableChunkStats) {
+    NIMBLE_CHECK(
+        context_->options().enableChunking,
+        "enableChunkStats requires enableChunking to be true.");
+    NIMBLE_CHECK(
+        context_->options().enableChunkIndex,
+        "enableChunkStats requires enableChunkIndex to be true.");
+  }
 
   // Register handler for dynamically discovered FlatMap keys before creating
   // the writer tree, so that predefined keys also trigger the handler.
@@ -1168,17 +1178,20 @@ bool VeloxWriter::encodeStreamChunk(
   bool writtenChunk{false};
   logicalBytes += streamData.memoryUsed();
   auto& streamChunks = encodedStream.chunks;
+  const bool enableChunkStats = context_->options().enableChunkStats;
   auto chunker = getStreamChunker(
       streamData,
       StreamChunkerOptions{
           .minChunkSize = minChunkSize,
           .maxChunkSize = maxChunkSize,
           .ensureFullChunks = ensureFullChunks,
-          .isFirstChunk = streamChunks.empty()});
+          .isFirstChunk = streamChunks.empty(),
+          .enableChunkStats = enableChunkStats});
   uint64_t encodedChunkBytes{0};
   while (auto chunkView = chunker->next()) {
     auto& streamChunk = streamChunks.emplace_back();
     encodedChunkBytes += encodeChunk(*chunkView, streamChunk);
+    streamChunk.stats = chunkView->stats();
     writtenChunk = true;
   }
   streamBytes += encodedChunkBytes;

--- a/dwio/nimble/velox/VeloxWriterOptions.h
+++ b/dwio/nimble/velox/VeloxWriterOptions.h
@@ -225,6 +225,10 @@ struct VeloxWriterOptions {
 
   bool enableChunking{false};
 
+  // Compute per-chunk min/max stats for chunk-level filter pushdown.
+  // Requires enableChunkIndex and enableChunking.
+  bool enableChunkStats{false};
+
   // This callback will be visited on access to getDecodedVector in order to
   // monitor usage of decoded vectors vs. data that is passed-through in the
   // writer. Default function is no-op since its used for tests only.

--- a/dwio/nimble/velox/tests/VeloxWriterTest.cpp
+++ b/dwio/nimble/velox/tests/VeloxWriterTest.cpp
@@ -32,6 +32,7 @@
 #include "dwio/nimble/encodings/PrefixEncoding.h"
 #include "dwio/nimble/encodings/tests/TestUtils.h"
 #include "dwio/nimble/index/tests/ClusterIndexTestUtils.h"
+#include "dwio/nimble/tablet/ChunkIndexGenerated.h"
 #include "dwio/nimble/tablet/Constants.h"
 #include "dwio/nimble/tablet/FileLayout.h"
 #include "dwio/nimble/velox/ChunkedStream.h"
@@ -6111,6 +6112,96 @@ DEBUG_ONLY_TEST_F(VeloxWriterTest, parallelEncodeFlatMapTaskCount) {
   velox::VectorPtr result;
   ASSERT_TRUE(reader.next(numBatches * 100, result));
   EXPECT_EQ(result->size(), numBatches * 100);
+}
+
+TEST_F(VeloxWriterTest, chunkStatsEndToEndInteger) {
+  velox::test::VectorMaker vectorMaker{leafPool_.get()};
+
+  auto vector = vectorMaker.rowVector(
+      {"c1"}, {vectorMaker.flatVector<int64_t>({10, -5, 42, 100, 7})});
+
+  std::string file;
+  auto writeFile = std::make_unique<velox::InMemoryWriteFile>(&file);
+
+  nimble::VeloxWriter writer(
+      vector->type(),
+      std::move(writeFile),
+      *rootPool_,
+      {.enableChunkIndex = true,
+       .chunkIndexMinAvgChunks = 0,
+       .minStreamChunkRawSize = 0,
+       .flushPolicyFactory =
+           []() {
+             return std::make_unique<nimble::LambdaFlushPolicy>(
+                 [](auto&) { return false; }, [](auto&) { return true; });
+           },
+       .enableChunking = true,
+       .enableChunkStats = true});
+
+  writer.write(vector);
+  writer.close();
+
+  auto readFile = std::make_shared<velox::InMemoryReadFile>(file);
+  auto tablet = nimble::TabletReader::create(readFile, leafPool_.get(), {});
+
+  ASSERT_TRUE(tablet->hasChunkIndexSection());
+
+  // Verify data round-trips correctly.
+  nimble::VeloxReader reader(
+      std::make_shared<velox::InMemoryReadFile>(file), *leafPool_);
+  velox::VectorPtr result;
+  ASSERT_TRUE(reader.next(vector->size(), result));
+  ASSERT_EQ(result->size(), vector->size());
+  for (auto i = 0; i < vector->size(); ++i) {
+    ASSERT_TRUE(vector->equalValueAt(result.get(), i, i));
+  }
+}
+
+TEST_F(VeloxWriterTest, chunkStatsEndToEndNullableString) {
+  velox::test::VectorMaker vectorMaker{leafPool_.get()};
+
+  auto vector = vectorMaker.rowVector(
+      {"c1"},
+      {vectorMaker.flatVectorNullable<velox::StringView>(
+          {std::optional<velox::StringView>{"hello"},
+           std::nullopt,
+           std::optional<velox::StringView>{"world"}})});
+
+  std::string file;
+  auto writeFile = std::make_unique<velox::InMemoryWriteFile>(&file);
+
+  nimble::VeloxWriter writer(
+      vector->type(),
+      std::move(writeFile),
+      *rootPool_,
+      {.enableChunkIndex = true,
+       .chunkIndexMinAvgChunks = 0,
+       .minStreamChunkRawSize = 0,
+       .flushPolicyFactory =
+           []() {
+             return std::make_unique<nimble::LambdaFlushPolicy>(
+                 [](auto&) { return false; }, [](auto&) { return true; });
+           },
+       .enableChunking = true,
+       .enableChunkStats = true});
+
+  writer.write(vector);
+  writer.close();
+
+  // Verify data round-trips correctly.
+  nimble::VeloxReader reader(
+      std::make_shared<velox::InMemoryReadFile>(file), *leafPool_);
+  velox::VectorPtr result;
+  ASSERT_TRUE(reader.next(vector->size(), result));
+  ASSERT_EQ(result->size(), vector->size());
+  for (auto i = 0; i < vector->size(); ++i) {
+    ASSERT_TRUE(vector->equalValueAt(result.get(), i, i));
+  }
+
+  // Verify chunk index section exists (string stats have nulls-only info).
+  auto readFile = std::make_shared<velox::InMemoryReadFile>(file);
+  auto tablet = nimble::TabletReader::create(readFile, leafPool_.get(), {});
+  EXPECT_TRUE(tablet->hasChunkIndexSection());
 }
 
 } // namespace facebook


### PR DESCRIPTION
Summary:
CONTEXT: Nimble lacks per-chunk column statistics for filter pushdown. Currently, filters on non-indexed columns require reading and decoding every chunk within a stripe.

WHAT: This diff adds the write-path infrastructure for per-chunk min/max statistics using a Parquet-inspired binary design:
- ChunkStats struct with raw-byte min/max values (PLAIN-encoded in the stream native type) + hasNulls flag + nullCount, making the schema type-agnostic
- ChunkIndex.fbs extended with StreamChunkStats table using min_values/max_values [ubyte] + value_size + has_nulls + null_counts
- Stats computed during StreamChunker::next() via std::minmax_element on the exact chunk slice, with NaN-aware handling for floats
- ChunkIndexWriter serializes per-chunk stats into the chunk index alongside position data
- NimbleConfig: added nimble.chunk.stats.enabled DDL property and wiring in NimbleWriterOptionBuilder
- Unit tests for chunk stats round-trip and direct computeChunkStats tests

New FlatBuffer fields are optional so old readers ignore them and old files work without them.

Differential Revision: D104712551


