### PR TITLE
feat: Integrate MetadataInput into TabletReader and index IO

### DIFF
--- a/dwio/nimble/common/tests/TestUtils.h
+++ b/dwio/nimble/common/tests/TestUtils.h
@@ -312,10 +312,19 @@ class InMemoryTrackableReadFile final : public velox::ReadFile {
   }
 
   uint64_t preadv(
-      uint64_t /* offset */,
-      const std::vector<folly::Range<char*>>& /* buffers */,
-      const velox::FileIoContext& context = {}) const final {
-    NIMBLE_UNSUPPORTED("Not used by Nimble");
+      uint64_t offset,
+      const std::vector<folly::Range<char*>>& buffers,
+      const velox::FileIoContext& /*context*/ = {}) const final {
+    uint64_t totalRead = 0;
+    for (const auto& range : buffers) {
+      if (range.data() != nullptr) {
+        file_.pread(offset, range.size(), range.data());
+      }
+      chunks_.wlock()->push_back({offset, range.size()});
+      offset += range.size();
+      totalRead += range.size();
+    }
+    return totalRead;
   }
 
   uint64_t preadv(

--- a/dwio/nimble/index/ClusterIndex.cpp
+++ b/dwio/nimble/index/ClusterIndex.cpp
@@ -23,9 +23,10 @@
 #include "dwio/nimble/index/KeyChunkDecoder.h"
 #include "dwio/nimble/tablet/ClusterIndexGenerated.h"
 #include "dwio/nimble/tablet/MetadataBuffer.h"
+#include "dwio/nimble/tablet/MetadataInput.h"
 #include "folly/ScopeGuard.h"
 #include "folly/json/json.h"
-#include "velox/dwio/common/SeekableInputStream.h"
+#include "velox/dwio/common/BufferedInput.h"
 
 namespace facebook::nimble::index {
 
@@ -135,21 +136,25 @@ ClusterIndex::~ClusterIndex() = default;
 
 std::unique_ptr<ClusterIndex> ClusterIndex::create(
     Section rootSection,
-    LoadMetadataFn loadMetadata,
-    LoadDataFn loadData,
-    velox::memory::MemoryPool* pool) {
+    velox::memory::MemoryPool* pool,
+    const Options& options) {
+  options.validate();
+  NIMBLE_CHECK_EQ(
+      static_cast<const void*>(&options.ioOptions->memoryPool()),
+      static_cast<const void*>(pool),
+      "ioOptions pool must match the provided pool");
   return std::unique_ptr<ClusterIndex>(new ClusterIndex(
       std::move(rootSection),
-      std::move(loadMetadata),
-      std::move(loadData),
-      pool));
+      pool,
+      createIndexMetadataInput(options),
+      createIndexDataInput(options, *pool)));
 }
 
 ClusterIndex::ClusterIndex(
     Section rootSection,
-    LoadMetadataFn loadMetadata,
-    LoadDataFn loadData,
-    velox::memory::MemoryPool* pool)
+    velox::memory::MemoryPool* pool,
+    std::shared_ptr<MetadataInput> metadataInput,
+    std::unique_ptr<velox::dwio::common::BufferedInput> dataInput)
     : IndexLookup{IndexType::Cluster},
       rootSection_{std::move(rootSection)},
       indexRoot_{getIndexRoot(rootSection_)},
@@ -161,8 +166,8 @@ ClusterIndex::ClusterIndex(
       partitionKeys_{getPartitionLastKeys(indexRoot_)},
       partitionRows_{getPartitionRows(indexRoot_)},
       numRows_{partitionRows_.back()},
-      loadData_{std::move(loadData)},
-      loadMetadata_{std::move(loadMetadata)},
+      metadataInput_{std::move(metadataInput)},
+      dataInput_{std::move(dataInput)},
       pool_{pool},
       partitions_(numPartitions_) {
   NIMBLE_CHECK(!indexColumns_.empty());
@@ -170,8 +175,8 @@ ClusterIndex::ClusterIndex(
   NIMBLE_CHECK_EQ(partitionRows_.size(), numPartitions_ + 1);
   NIMBLE_CHECK_EQ(partitionRows_.front(), 0);
   NIMBLE_CHECK_EQ(partitionKeys_.size(), numPartitions_);
-  NIMBLE_CHECK_NOT_NULL(loadMetadata_);
-  NIMBLE_CHECK_NOT_NULL(loadData_);
+  NIMBLE_CHECK_NOT_NULL(metadataInput_);
+  NIMBLE_CHECK_NOT_NULL(dataInput_);
   NIMBLE_CHECK_NOT_NULL(pool_);
 }
 
@@ -397,13 +402,12 @@ const ClusterIndex::IndexPartition* ClusterIndex::loadPartition(
   NIMBLE_CHECK_LT(partitionId, numPartitions_);
   auto& partition = partitions_[partitionId];
   if (partition == nullptr) {
-    NIMBLE_CHECK_NOT_NULL(
-        loadMetadata_,
-        "No metadata loader — cannot load partition {} on demand",
-        partitionId);
     const auto section = partitionSection(partitionId);
-    partition =
-        std::make_unique<IndexPartition>(partitionId, loadMetadata_(section));
+    auto handle = metadataInput_->enqueue(section);
+    MetadataInput::LoadGuard guard(metadataInput_.get());
+    auto result = handle.read();
+    partition = std::make_unique<IndexPartition>(
+        partitionId, std::make_unique<MetadataBuffer>(std::move(*result)));
   }
   return partition.get();
 }
@@ -468,8 +472,13 @@ const ClusterIndex::DecodedChunk& ClusterIndex::getDecodedChunk(
   decodedChunk.reset(chunkLocation.chunkOffset);
 
   const auto region = partition->chunkStreamRegion(chunkLocation);
-  decodedChunk.data =
-      decodeKeyChunk(loadData_(region), *pool_, partition->dataBuffer);
+  decodedChunk.data = decodeKeyChunk(
+      dataInput_->read(
+          region.offset,
+          region.length,
+          velox::dwio::common::LogType::GROUP_INDEX),
+      *pool_,
+      partition->dataBuffer);
   NIMBLE_CHECK_EQ(
       decodedChunk.data->encoding->dataType(),
       DataType::String,

--- a/dwio/nimble/index/ClusterIndex.h
+++ b/dwio/nimble/index/ClusterIndex.h
@@ -26,7 +26,6 @@
 #include "dwio/nimble/index/IndexTypes.h"
 #include "dwio/nimble/index/KeyChunkDecoder.h"
 #include "dwio/nimble/index/SortOrder.h"
-#include "dwio/nimble/tablet/Callbacks.h"
 #include "dwio/nimble/tablet/ClusterIndexGenerated.h"
 #include "dwio/nimble/tablet/MetadataBuffer.h"
 #include "dwio/nimble/tablet/MetadataCache.h"
@@ -35,9 +34,11 @@
 
 namespace facebook::nimble {
 class Encoding;
+class MetadataInput;
 } // namespace facebook::nimble
 
 namespace facebook::velox::dwio::common {
+class BufferedInput;
 class SeekableInputStream;
 } // namespace facebook::velox::dwio::common
 
@@ -72,15 +73,12 @@ class ClusterIndex : public IndexLookup {
   ~ClusterIndex() override;
 
   /// @param rootSection Root index section from the file footer.
-  /// @param loadMetadata Callback to load partition metadata on demand.
-  /// @param loadData Optional callback for row-level precision.
-  ///        When null, lookup() returns chunk-level precision.
-  /// @param pool Memory pool. Required when loadData is provided.
+  /// Creates with Options — index creates its own MetadataInput and data
+  /// input internally with index-specific IO stats.
   static std::unique_ptr<ClusterIndex> create(
       Section rootSection,
-      LoadMetadataFn loadMetadata,
-      LoadDataFn loadData,
-      velox::memory::MemoryPool* pool);
+      velox::memory::MemoryPool* pool,
+      const Options& options);
 
   const std::vector<std::string>& indexColumns() const override {
     return indexColumns_;
@@ -147,9 +145,9 @@ class ClusterIndex : public IndexLookup {
  private:
   ClusterIndex(
       Section rootSection,
-      LoadMetadataFn loadMetadata,
-      LoadDataFn loadData,
-      velox::memory::MemoryPool* pool);
+      velox::memory::MemoryPool* pool,
+      std::shared_ptr<MetadataInput> metadataInput,
+      std::unique_ptr<velox::dwio::common::BufferedInput> dataInput);
 
   // Cached decoded chunk, one per IndexPartition.
   struct DecodedChunk {
@@ -305,10 +303,8 @@ class ClusterIndex : public IndexLookup {
   // Total number of rows in the file.
   const uint32_t numRows_;
 
-  const LoadDataFn loadData_;
-  const LoadMetadataFn loadMetadata_;
-
-  /// Memory pool for allocations.
+  const std::shared_ptr<MetadataInput> metadataInput_;
+  const std::unique_ptr<velox::dwio::common::BufferedInput> dataInput_;
   velox::memory::MemoryPool* const pool_;
 
   // --- Mutable state ---

--- a/dwio/nimble/index/DenseIndexRegistry.cpp
+++ b/dwio/nimble/index/DenseIndexRegistry.cpp
@@ -21,7 +21,10 @@
 #include "dwio/nimble/index/HashIndex.h"
 #include "dwio/nimble/index/SortedIndex.h"
 #include "dwio/nimble/tablet/HashIndexGenerated.h"
+#include "dwio/nimble/tablet/MetadataInput.h"
 #include "dwio/nimble/tablet/SortedIndexGenerated.h"
+#include "velox/dwio/common/BufferedInput.h"
+#include "velox/dwio/common/SeekableInputStream.h"
 
 namespace facebook::nimble::index {
 
@@ -92,23 +95,24 @@ DenseIndexRegistry::parseDescriptors(
 std::unique_ptr<DenseIndexRegistry> DenseIndexRegistry::create(
     std::optional<Section> hashSection,
     std::optional<Section> sortedSection,
-    LoadMetadataFn loadMetadata,
-    LoadDataFn loadData,
+    const IndexLookup::Options& options,
     velox::memory::MemoryPool* pool) {
+  options.validate();
   if (!hashSection.has_value() && !sortedSection.has_value()) {
     return nullptr;
   }
+  auto metadataInput =
+      std::shared_ptr<MetadataInput>(createIndexMetadataInput(options));
+  auto dataInput = std::shared_ptr<velox::dwio::common::BufferedInput>(
+      createIndexDataInput(options, *pool));
   auto registry = std::unique_ptr<DenseIndexRegistry>(new DenseIndexRegistry());
   if (hashSection.has_value()) {
     registry->registerHashIndices(
-        std::move(hashSection.value()), loadMetadata, pool);
+        std::move(hashSection.value()), metadataInput, pool);
   }
   if (sortedSection.has_value()) {
     registry->registerSortedIndices(
-        std::move(sortedSection.value()),
-        loadMetadata,
-        std::move(loadData),
-        pool);
+        std::move(sortedSection.value()), metadataInput, dataInput, pool);
   }
   registry->validate();
   return registry;
@@ -127,41 +131,45 @@ void DenseIndexRegistry::validate() const {
 
 void DenseIndexRegistry::registerHashIndices(
     Section directorySection,
-    LoadMetadataFn loadMetadata,
+    std::shared_ptr<MetadataInput> metadataInput,
     velox::memory::MemoryPool* pool) {
   hashDescriptors_ = parseDescriptors<serialization::HashIndexDirectory>(
       directorySection, "Hash index");
 
   hashIndexCache_ = std::make_unique<MetadataCache<uint32_t, HashIndex>>(
-      [this, loadMetadata = std::move(loadMetadata), pool](
+      [this, metadataInput, pool](
           uint32_t index) -> std::shared_ptr<HashIndex> {
         const auto& descriptor = hashDescriptors_[index];
-        auto indexMetadata = loadMetadata(descriptor.section);
-        NIMBLE_CHECK_NOT_NULL(indexMetadata);
+        auto handle = metadataInput->enqueue(descriptor.section);
+        MetadataInput::LoadGuard guard(metadataInput.get());
+        auto result = handle.read();
+        auto indexMetadata =
+            std::make_unique<MetadataBuffer>(std::move(*result));
         return HashIndex::create(
-            descriptor.columns, std::move(indexMetadata), loadMetadata, pool);
+            descriptor.columns, std::move(indexMetadata), metadataInput, pool);
       },
       /*pinEntries=*/true);
 }
 
 void DenseIndexRegistry::registerSortedIndices(
     Section directorySection,
-    LoadMetadataFn loadMetadata,
-    LoadDataFn loadData,
+    std::shared_ptr<MetadataInput> metadataInput,
+    std::shared_ptr<velox::dwio::common::BufferedInput> dataInput,
     velox::memory::MemoryPool* pool) {
   sortedDescriptors_ = parseDescriptors<serialization::SortedIndexDirectory>(
       directorySection, "Sorted index");
 
   sortedIndexCache_ = std::make_unique<MetadataCache<uint32_t, SortedIndex>>(
-      [this,
-       loadMetadata = std::move(loadMetadata),
-       loadData = std::move(loadData),
-       pool](uint32_t index) -> std::shared_ptr<SortedIndex> {
+      [this, metadataInput, dataInput, pool](
+          uint32_t index) -> std::shared_ptr<SortedIndex> {
         const auto& descriptor = sortedDescriptors_[index];
-        auto indexMetadata = loadMetadata(descriptor.section);
-        NIMBLE_CHECK_NOT_NULL(indexMetadata);
+        auto handle = metadataInput->enqueue(descriptor.section);
+        MetadataInput::LoadGuard guard(metadataInput.get());
+        auto result = handle.read();
+        auto indexMetadata =
+            std::make_unique<MetadataBuffer>(std::move(*result));
         return SortedIndex::create(
-            descriptor.columns, std::move(indexMetadata), loadData, pool);
+            descriptor.columns, std::move(indexMetadata), dataInput, pool);
       },
       /*pinEntries=*/true);
 }

--- a/dwio/nimble/index/DenseIndexRegistry.h
+++ b/dwio/nimble/index/DenseIndexRegistry.h
@@ -21,7 +21,6 @@
 #include <vector>
 
 #include "dwio/nimble/index/IndexLookup.h"
-#include "dwio/nimble/tablet/Callbacks.h"
 #include "dwio/nimble/tablet/MetadataBuffer.h"
 #include "dwio/nimble/tablet/MetadataCache.h"
 
@@ -38,11 +37,12 @@ class DenseIndexRegistry {
  public:
   /// Creates a registry from optional hash and sorted index sections.
   /// Returns nullptr if both sections are empty.
+  /// Creates with Options — indexes create their own MetadataInput
+  /// internally with index-specific IO stats.
   static std::unique_ptr<DenseIndexRegistry> create(
       std::optional<Section> hashSection,
       std::optional<Section> sortedSection,
-      LoadMetadataFn loadMetadata,
-      LoadDataFn loadData,
+      const IndexLookup::Options& options,
       velox::memory::MemoryPool* pool);
 
   /// Finds any dense index matching the given columns.
@@ -54,13 +54,13 @@ class DenseIndexRegistry {
 
   void registerHashIndices(
       Section directorySection,
-      LoadMetadataFn loadMetadata,
+      std::shared_ptr<MetadataInput> metadataInput,
       velox::memory::MemoryPool* pool);
 
   void registerSortedIndices(
       Section directorySection,
-      LoadMetadataFn loadMetadata,
-      LoadDataFn loadData,
+      std::shared_ptr<MetadataInput> metadataInput,
+      std::shared_ptr<velox::dwio::common::BufferedInput> dataInput,
       velox::memory::MemoryPool* pool);
 
   struct IndexDescriptor {

--- a/dwio/nimble/index/HashIndex.cpp
+++ b/dwio/nimble/index/HashIndex.cpp
@@ -22,6 +22,7 @@
 #include "dwio/nimble/common/Exceptions.h"
 #include "dwio/nimble/index/HashIndexUtils.h"
 #include "dwio/nimble/tablet/HashIndexGenerated.h"
+#include "dwio/nimble/tablet/MetadataInput.h"
 #include "velox/common/base/BitUtil.h"
 
 namespace facebook::nimble::index {
@@ -134,7 +135,7 @@ std::vector<RowRange> resolveRowRanges(
 HashIndex::HashIndex(
     std::vector<std::string> columns,
     std::unique_ptr<MetadataBuffer> indexMetadata,
-    LoadMetadataFn loadMetadata,
+    std::shared_ptr<MetadataInput> metadataInput,
     velox::memory::MemoryPool* pool)
     : IndexLookup{IndexType::Hash},
       columns_{std::move(columns)},
@@ -146,12 +147,15 @@ HashIndex::HashIndex(
       maxKey_{getMaxKey(*indexMetadata_)},
       bloomFilter_{buildBloomFilter(*indexMetadata_, pool_)},
       partitions_{buildPartitionDescriptors(*indexMetadata_, numBuckets_)},
+      metadataInput_{std::move(metadataInput)},
       partitionCache_{
-          [this, loadMetadata = std::move(loadMetadata)](
-              uint32_t partitionIndex) -> std::shared_ptr<Partition> {
+          [this](uint32_t partitionIndex) -> std::shared_ptr<Partition> {
             const auto& descriptor = partitions_[partitionIndex];
-            auto metadata = loadMetadata(descriptor.section);
-            return Partition::create(std::move(metadata));
+            auto handle = metadataInput_->enqueue(descriptor.section);
+            MetadataInput::LoadGuard guard(metadataInput_.get());
+            auto result = handle.read();
+            return Partition::create(
+                std::make_unique<MetadataBuffer>(std::move(*result)));
           }} {}
 
 // static
@@ -192,12 +196,12 @@ HashIndex::buildPartitionDescriptors(
 std::unique_ptr<HashIndex> HashIndex::create(
     std::vector<std::string> columns,
     std::unique_ptr<MetadataBuffer> indexMetadata,
-    LoadMetadataFn loadMetadata,
+    std::shared_ptr<MetadataInput> metadataInput,
     velox::memory::MemoryPool* pool) {
   return std::unique_ptr<HashIndex>(new HashIndex(
       std::move(columns),
       std::move(indexMetadata),
-      std::move(loadMetadata),
+      std::move(metadataInput),
       pool));
 }
 

--- a/dwio/nimble/index/HashIndex.h
+++ b/dwio/nimble/index/HashIndex.h
@@ -25,7 +25,6 @@
 
 #include "dwio/nimble/index/BloomFilter.h"
 #include "dwio/nimble/index/IndexLookup.h"
-#include "dwio/nimble/tablet/Callbacks.h"
 #include "dwio/nimble/tablet/MetadataBuffer.h"
 #include "dwio/nimble/tablet/MetadataCache.h"
 #include "flatbuffers/flatbuffers.h"
@@ -82,14 +81,14 @@ class HashIndex : public IndexLookup {
   static std::unique_ptr<HashIndex> create(
       std::vector<std::string> columns,
       std::unique_ptr<MetadataBuffer> indexMetadata,
-      LoadMetadataFn loadMetadata,
+      std::shared_ptr<MetadataInput> metadataInput,
       velox::memory::MemoryPool* pool);
 
  private:
   HashIndex(
       std::vector<std::string> columns,
       std::unique_ptr<MetadataBuffer> indexMetadata,
-      LoadMetadataFn loadMetadata,
+      std::shared_ptr<MetadataInput> metadataInput,
       velox::memory::MemoryPool* pool);
 
   // Loaded partition data. Raw pointers reference the underlying FlatBuffer
@@ -156,6 +155,7 @@ class HashIndex : public IndexLookup {
   // Partition descriptors and lazily loaded partition data.
   // Always has at least one partition.
   const std::vector<PartitionDescriptor> partitions_;
+  const std::shared_ptr<MetadataInput> metadataInput_;
   mutable MetadataCache<uint32_t, Partition> partitionCache_;
 
   mutable std::atomic_uint64_t numLookups_{0};

--- a/dwio/nimble/index/IndexLookup.cpp
+++ b/dwio/nimble/index/IndexLookup.cpp
@@ -16,8 +16,69 @@
 #include "dwio/nimble/index/IndexLookup.h"
 
 #include "dwio/nimble/common/Exceptions.h"
+#include "dwio/nimble/tablet/MetadataInput.h"
+#include "velox/common/caching/FileHandle.h"
+#include "velox/common/io/Options.h"
+#include "velox/dwio/common/CachedBufferedInput.h"
+#include "velox/dwio/common/DirectBufferedInput.h"
 
 namespace facebook::nimble::index {
+
+void IndexLookup::Options::validate() const {
+  NIMBLE_CHECK_NOT_NULL(file.get());
+  NIMBLE_CHECK_NOT_NULL(ioOptions);
+  NIMBLE_CHECK(
+      (fileHandle != nullptr) == (cache != nullptr),
+      "fileHandle and cache must both be set or neither");
+  if (fileHandle != nullptr) {
+    NIMBLE_CHECK_EQ(
+        static_cast<const void*>(file.get()),
+        static_cast<const void*>(fileHandle->file.get()),
+        "file and fileHandle->file must point to the same file");
+  }
+}
+
+std::unique_ptr<MetadataInput> createIndexMetadataInput(
+    const IndexLookup::Options& options) {
+  return (options.fileHandle != nullptr)
+      ? MetadataInput::create(
+            options.fileHandle, options.cache, *options.ioOptions)
+      : MetadataInput::create(options.file.get(), *options.ioOptions);
+}
+
+std::unique_ptr<velox::dwio::common::BufferedInput> createIndexDataInput(
+    const IndexLookup::Options& options,
+    velox::memory::MemoryPool& pool) {
+  auto readFile = options.file;
+  auto* rawStats = options.ioOptions->indexIoStats();
+  auto indexIoStats = rawStats != nullptr
+      ? std::shared_ptr<velox::io::IoStatistics>(
+            std::shared_ptr<velox::io::IoStatistics>{}, rawStats)
+      : std::make_shared<velox::io::IoStatistics>();
+  if (options.cache != nullptr) {
+    return std::make_unique<velox::dwio::common::CachedBufferedInput>(
+        std::move(readFile),
+        velox::dwio::common::MetricsLog::voidLog(),
+        options.fileHandle->uuid,
+        options.cache,
+        nullptr,
+        velox::StringIdLease(),
+        std::move(indexIoStats),
+        nullptr,
+        nullptr,
+        *options.ioOptions);
+  }
+  return std::make_unique<velox::dwio::common::DirectBufferedInput>(
+      std::move(readFile),
+      velox::dwio::common::MetricsLog::voidLog(),
+      velox::StringIdLease(),
+      nullptr,
+      velox::StringIdLease(),
+      std::move(indexIoStats),
+      nullptr,
+      nullptr,
+      *options.ioOptions);
+}
 
 std::string toString(IndexType indexType) {
   switch (indexType) {

--- a/dwio/nimble/index/IndexLookup.h
+++ b/dwio/nimble/index/IndexLookup.h
@@ -31,6 +31,24 @@
 #include "velox/common/base/RuntimeMetrics.h"
 #include "velox/serializers/KeyEncoder.h"
 
+namespace facebook::nimble {
+class MetadataInput;
+} // namespace facebook::nimble
+
+namespace facebook::velox {
+class ReadFile;
+struct FileHandle;
+namespace cache {
+class AsyncDataCache;
+} // namespace cache
+namespace dwio::common {
+class BufferedInput;
+} // namespace dwio::common
+namespace io {
+class ReaderOptions;
+} // namespace io
+} // namespace facebook::velox
+
 namespace facebook::nimble::index {
 
 /// Type of index.
@@ -62,6 +80,22 @@ std::ostream& operator<<(std::ostream& out, IndexType indexType);
 ///   bound. Only supported on cluster index.
 class IndexLookup {
  public:
+  /// IO options for index lookup creation. fileHandle and cache must
+  /// both be set (cached path) or both null (direct path).
+  struct Options {
+    /// File to read index metadata and key stream data from.
+    std::shared_ptr<velox::ReadFile> file;
+    /// IO settings: coalescing, executor, and index IO stats.
+    const velox::io::ReaderOptions* ioOptions{nullptr};
+    /// File handle for cache key. Set with cache for cached path.
+    const velox::FileHandle* fileHandle{nullptr};
+    /// Data cache for index metadata. Set with fileHandle for cached path.
+    velox::cache::AsyncDataCache* cache{nullptr};
+
+    /// Validates options consistency.
+    void validate() const;
+  };
+
   /// Batch lookup request. Contains encoded keys or key bounds and options.
   class LookupRequest {
    public:
@@ -225,6 +259,15 @@ class IndexLookup {
  private:
   const IndexType type_;
 };
+
+/// Creates a MetadataInput (cached or direct) from index options.
+std::unique_ptr<MetadataInput> createIndexMetadataInput(
+    const IndexLookup::Options& options);
+
+/// Creates a BufferedInput (cached or direct) from index options.
+std::unique_ptr<velox::dwio::common::BufferedInput> createIndexDataInput(
+    const IndexLookup::Options& options,
+    velox::memory::MemoryPool& pool);
 
 inline std::string toString(IndexLookup::LookupRequest::Mode mode) {
   switch (mode) {

--- a/dwio/nimble/index/SortedIndex.cpp
+++ b/dwio/nimble/index/SortedIndex.cpp
@@ -66,24 +66,27 @@ uint8_t getRowIdWidth(const MetadataBuffer& metadata) {
 SortedIndex::SortedIndex(
     std::vector<std::string> columns,
     std::unique_ptr<MetadataBuffer> indexMetadata,
-    LoadDataFn loadData,
+    std::shared_ptr<velox::dwio::common::BufferedInput> dataInput,
     velox::memory::MemoryPool* pool)
     : IndexLookup{IndexType::Sorted},
       columns_{std::move(columns)},
       indexMetadata_{std::move(indexMetadata)},
       pool_{pool},
       rowIdWidth_{getRowIdWidth(*indexMetadata_)},
-      loadData_{std::move(loadData)},
+      dataInput_{std::move(dataInput)},
       sortedIndex_{getSortedIndexRoot(*indexMetadata_)},
       numChunks_{sortedIndex_->chunk_keys()->size()} {}
 
 std::unique_ptr<SortedIndex> SortedIndex::create(
     std::vector<std::string> columns,
     std::unique_ptr<MetadataBuffer> indexMetadata,
-    LoadDataFn loadData,
+    std::shared_ptr<velox::dwio::common::BufferedInput> dataInput,
     velox::memory::MemoryPool* pool) {
   return std::unique_ptr<SortedIndex>(new SortedIndex(
-      std::move(columns), std::move(indexMetadata), std::move(loadData), pool));
+      std::move(columns),
+      std::move(indexMetadata),
+      std::move(dataInput),
+      pool));
 }
 
 std::string_view SortedIndex::chunkKey(uint32_t chunkIdx) const {
@@ -128,9 +131,13 @@ std::shared_ptr<DecodedKeyChunk> SortedIndex::loadChunk(
   const uint32_t chunkOffset = this->chunkOffset(chunkIdx);
   const uint32_t chunkSize = this->chunkSize(chunkIdx);
 
-  auto inputStream =
-      loadData_(velox::common::Region{streamOffset + chunkOffset, chunkSize});
-  return decodeKeyChunk(std::move(inputStream), *pool_, chunkBuffer_);
+  return decodeKeyChunk(
+      dataInput_->read(
+          streamOffset + chunkOffset,
+          chunkSize,
+          velox::dwio::common::LogType::FOOTER),
+      *pool_,
+      chunkBuffer_);
 }
 
 std::string_view SortedIndex::extractKey(

--- a/dwio/nimble/index/SortedIndex.h
+++ b/dwio/nimble/index/SortedIndex.h
@@ -25,9 +25,8 @@
 
 #include "dwio/nimble/index/IndexLookup.h"
 #include "dwio/nimble/index/KeyChunkDecoder.h"
-#include "dwio/nimble/tablet/Callbacks.h"
 #include "dwio/nimble/tablet/MetadataBuffer.h"
-#include "velox/dwio/common/SeekableInputStream.h"
+#include "velox/dwio/common/BufferedInput.h"
 
 namespace facebook::nimble::serialization {
 struct SortedIndex;
@@ -71,14 +70,14 @@ class SortedIndex : public IndexLookup {
   static std::unique_ptr<SortedIndex> create(
       std::vector<std::string> columns,
       std::unique_ptr<MetadataBuffer> indexMetadata,
-      LoadDataFn loadData,
+      std::shared_ptr<velox::dwio::common::BufferedInput> dataInput,
       velox::memory::MemoryPool* pool);
 
  private:
   SortedIndex(
       std::vector<std::string> columns,
       std::unique_ptr<MetadataBuffer> indexMetadata,
-      LoadDataFn loadData,
+      std::shared_ptr<velox::dwio::common::BufferedInput> dataInput,
       velox::memory::MemoryPool* pool);
 
   // Finds the chunk index for the given key via binary search on chunk keys.
@@ -144,8 +143,7 @@ class SortedIndex : public IndexLookup {
   velox::memory::MemoryPool* const pool_;
   const uint8_t rowIdWidth_;
 
-  // Callback to load key stream data from file by region.
-  const LoadDataFn loadData_;
+  const std::shared_ptr<velox::dwio::common::BufferedInput> dataInput_;
 
   // Parsed from the FlatBuffer.
   const serialization::SortedIndex* const sortedIndex_;

--- a/dwio/nimble/index/tests/ClusterIndexTest.cpp
+++ b/dwio/nimble/index/tests/ClusterIndexTest.cpp
@@ -83,16 +83,12 @@ class ClusterIndexTest : public ClusterIndexTestBase {
     return result;
   }
 
-  // Creates a LoadDataFn from key stream data.
-  LoadDataFn createLoadDataFn(const std::string& streamData) {
-    auto data = std::make_shared<std::string>(streamData);
-    return [data](const velox::common::Region& region)
-               -> std::unique_ptr<SeekableInputStream> {
-      return std::make_unique<SeekableArrayInputStream>(
-          reinterpret_cast<const unsigned char*>(data->data() + region.offset),
-          region.length > 0 ? region.length : data->size() - region.offset);
-    };
+  velox::ReadFile* createKeyStreamFile(const std::string& streamData) {
+    keyStreamFile_ = std::make_shared<velox::InMemoryReadFile>(streamData);
+    return keyStreamFile_.get();
   }
+
+  std::shared_ptr<velox::ReadFile> keyStreamFile_;
 
   // Creates a Stripe with only the keyStream specified.
   Stripe createStripeWithKeys(const KeyStream& keyStream) {
@@ -209,8 +205,8 @@ TEST_F(ClusterIndexTest, lookup) {
 
   auto indexBuffers =
       createTestClusterIndex(indexColumns, minKey, stripes, stripeGroups);
-  auto clusterIndex = createClusterIndex(
-      indexBuffers, createLoadDataFn(combinedStream), pool_.get());
+  auto clusterIndex =
+      createClusterIndex(indexBuffers, createKeyStreamFile(combinedStream));
 
   // Partition 0: rows 0-1 (keys "ccc", "fff")
   // Partition 1: rows 2 (key "iii")
@@ -304,8 +300,8 @@ TEST_F(ClusterIndexTest, lookupAllStripes) {
 
   auto indexBuffers =
       createTestClusterIndex(indexColumns, minKey, stripes, stripeGroups);
-  auto clusterIndex = createClusterIndex(
-      indexBuffers, createLoadDataFn(combinedStream), pool_.get());
+  auto clusterIndex =
+      createClusterIndex(indexBuffers, createKeyStreamFile(combinedStream));
 
   // Partition 0: rows 0-1 (keys "ccc", "fff")
   // Partition 1: row 2 (key "iii")
@@ -398,8 +394,8 @@ TEST_F(ClusterIndexTest, lookupWithSameKeys) {
 
   auto indexBuffers =
       createTestClusterIndex(indexColumns, minKey, stripes, stripeGroups);
-  auto clusterIndex = createClusterIndex(
-      indexBuffers, createLoadDataFn(combinedStream), pool_.get());
+  auto clusterIndex =
+      createClusterIndex(indexBuffers, createKeyStreamFile(combinedStream));
 
   // Partition 0: rows 0-1 (both "aaa"), Partition 1: row 2 ("aaa").
   struct TestCase {
@@ -469,8 +465,8 @@ TEST_F(ClusterIndexTest, lookupWithKeyStream) {
 
   auto indexBuffers =
       createTestClusterIndex(indexColumns, minKey, stripes, stripeGroups);
-  auto clusterIndex = createClusterIndex(
-      indexBuffers, createLoadDataFn(encodedStream.data), pool_.get());
+  auto clusterIndex =
+      createClusterIndex(indexBuffers, createKeyStreamFile(encodedStream.data));
 
   struct TestCase {
     std::string lookupKey;
@@ -549,8 +545,8 @@ TEST_F(ClusterIndexTest, lookupWithKeyStreamMultiplePartitions) {
 
   auto indexBuffers =
       createTestClusterIndex(indexColumns, minKey, stripes, stripeGroups);
-  auto clusterIndex = createClusterIndex(
-      indexBuffers, createLoadDataFn(combinedStream), pool_.get());
+  auto clusterIndex =
+      createClusterIndex(indexBuffers, createKeyStreamFile(combinedStream));
 
   struct TestCase {
     std::string lookupKey;
@@ -829,7 +825,7 @@ class ClusterIndexLookupTest : public ClusterIndexTest,
     auto indexBuffers =
         createTestClusterIndex(indexColumns, minKey, stripes, stripeGroups);
     clusterIndex_ = createClusterIndex(
-        indexBuffers, createLoadDataFn(encodedStream_.data), pool_.get());
+        indexBuffers, createKeyStreamFile(encodedStream_.data));
   }
 
   EncodedKeyStream encodedStream_;

--- a/dwio/nimble/index/tests/ClusterIndexTestBase.cpp
+++ b/dwio/nimble/index/tests/ClusterIndexTestBase.cpp
@@ -15,11 +15,15 @@
  */
 #include "dwio/nimble/index/tests/ClusterIndexTestBase.h"
 
+#include "dwio/nimble/index/tests/ClusterIndexTestUtils.h"
 #include "dwio/nimble/tablet/ChunkIndexGenerated.h"
 #include "dwio/nimble/tablet/ClusterIndexGenerated.h"
+#include "dwio/nimble/tablet/MetadataInput.h"
 #include "folly/json/json.h"
 #include "velox/buffer/Buffer.h"
+#include "velox/common/io/Options.h"
 #include "velox/common/testutil/TestValue.h"
+#include "velox/dwio/common/BufferedInput.h"
 #include "velox/dwio/common/SeekableInputStream.h"
 
 namespace facebook::nimble::index::test {
@@ -338,43 +342,33 @@ ClusterIndexTestBase::createChunkOnlyTestClusterIndex(
 }
 
 std::unique_ptr<ClusterIndex> ClusterIndexTestBase::createClusterIndex(
-    const IndexBuffers& indexBuffers) {
-  auto noopLoadData = [](const velox::common::Region&)
-      -> std::unique_ptr<velox::dwio::common::SeekableInputStream> {
-    NIMBLE_UNREACHABLE("No key stream data in this test");
-  };
-  return createClusterIndex(indexBuffers, std::move(noopLoadData), pool_.get());
-}
-
-std::unique_ptr<ClusterIndex> ClusterIndexTestBase::createClusterIndex(
     const IndexBuffers& indexBuffers,
-    LoadDataFn loadData,
-    velox::memory::MemoryPool* pool) {
+    velox::ReadFile* keyStreamFile) {
   Section indexSection{MetadataBuffer(
       MetadataBuffer::decompress(
           toBufferPtr(indexBuffers.rootIndex, pool_.get()),
           CompressionType::Uncompressed,
           pool_.get()))};
 
-  // Capture indexPartitions data and pool for the metadata loader callback.
-  auto indexPartitionsData =
-      std::make_shared<std::string>(indexBuffers.indexPartitions);
-  auto* metadataPool = pool_.get();
+  metadataFile_ =
+      std::make_shared<velox::InMemoryReadFile>(indexBuffers.indexPartitions);
+  ioStats_ = std::make_unique<velox::io::IoStatistics>();
+  velox::io::ReaderOptions readerOptions(pool_.get());
+  readerOptions.setMetadataIoStats(ioStats_.get());
+  auto metadataInput =
+      MetadataInput::create(metadataFile_.get(), readerOptions);
 
-  return ClusterIndex::create(
+  auto dataFile = keyStreamFile != nullptr
+      ? std::shared_ptr<velox::ReadFile>(
+            std::shared_ptr<velox::ReadFile>{}, keyStreamFile)
+      : metadataFile_;
+  auto dataInput = std::make_unique<velox::dwio::common::BufferedInput>(
+      std::move(dataFile), *pool_);
+  return ClusterIndexTestHelper::create(
       std::move(indexSection),
-      [indexPartitionsData, metadataPool](const MetadataSection& section) {
-        return std::make_unique<MetadataBuffer>(MetadataBuffer::decompress(
-            toBufferPtr(
-                std::string_view(
-                    indexPartitionsData->data() + section.offset(),
-                    section.size()),
-                metadataPool),
-            section.compressionType(),
-            metadataPool));
-      },
-      std::move(loadData),
-      pool);
+      pool_.get(),
+      std::move(metadataInput),
+      std::move(dataInput));
 }
 
 std::shared_ptr<ChunkIndexGroup> ClusterIndexTestBase::createChunkIndex(

--- a/dwio/nimble/index/tests/ClusterIndexTestBase.h
+++ b/dwio/nimble/index/tests/ClusterIndexTestBase.h
@@ -23,6 +23,8 @@
 #include "dwio/nimble/index/ChunkIndexGroup.h"
 #include "dwio/nimble/index/ClusterIndex.h"
 #include "dwio/nimble/tablet/MetadataBuffer.h"
+#include "velox/common/file/File.h"
+#include "velox/common/io/IoStatistics.h"
 #include "velox/common/memory/Memory.h"
 
 namespace facebook::nimble::index::test {
@@ -95,16 +97,11 @@ class ClusterIndexTestBase : public ::testing::Test {
       const std::vector<int>& stripeGroups);
 
   /// Creates a ClusterIndex from the serialized IndexBuffers.
-  /// @param loadData Callback to load key stream data.
-  /// @param pool Memory pool for key stream reader allocations.
+  /// @param keyStreamFile ReadFile for key stream data (or nullptr for
+  ///        metadata-only tests that don't need key stream access).
   std::unique_ptr<ClusterIndex> createClusterIndex(
       const IndexBuffers& indexBuffers,
-      LoadDataFn loadData,
-      velox::memory::MemoryPool* pool);
-
-  /// Convenience overload with a no-op key stream loader.
-  std::unique_ptr<ClusterIndex> createClusterIndex(
-      const IndexBuffers& indexBuffers);
+      velox::ReadFile* keyStreamFile = nullptr);
 
   /// Creates a ChunkIndexGroup from the serialized IndexBuffers.
   std::shared_ptr<ChunkIndexGroup> createChunkIndex(
@@ -115,6 +112,8 @@ class ClusterIndexTestBase : public ::testing::Test {
       velox::memory::memoryManager()->addRootPool("ClusterIndexTestBase")};
   std::shared_ptr<velox::memory::MemoryPool> pool_{
       rootPool_->addLeafChild("ClusterIndexTestBase")};
+  std::shared_ptr<velox::ReadFile> metadataFile_;
+  std::unique_ptr<velox::io::IoStatistics> ioStats_;
 };
 
 } // namespace facebook::nimble::index::test

--- a/dwio/nimble/index/tests/ClusterIndexTestUtils.h
+++ b/dwio/nimble/index/tests/ClusterIndexTestUtils.h
@@ -29,6 +29,7 @@
 #include "dwio/nimble/tablet/TabletWriter.h"
 #include "dwio/nimble/velox/ChunkedStream.h"
 #include "dwio/nimble/velox/VeloxWriterOptions.h"
+#include "velox/dwio/common/BufferedInput.h"
 #include "velox/vector/ComplexVector.h"
 #include "velox/vector/fuzzer/VectorFuzzer.h"
 
@@ -166,6 +167,18 @@ Stream createStream(Buffer& buffer, const StreamSpec& spec);
 /// for testing purposes. This is a friend class of ClusterIndex.
 class ClusterIndexTestHelper {
  public:
+  static std::unique_ptr<ClusterIndex> create(
+      Section rootSection,
+      velox::memory::MemoryPool* pool,
+      std::shared_ptr<MetadataInput> metadataInput,
+      std::unique_ptr<velox::dwio::common::BufferedInput> dataInput) {
+    return std::unique_ptr<ClusterIndex>(new ClusterIndex(
+        std::move(rootSection),
+        pool,
+        std::move(metadataInput),
+        std::move(dataInput)));
+  }
+
   explicit ClusterIndexTestHelper(const ClusterIndex* clusterIndex)
       : clusterIndex_(clusterIndex) {}
 

--- a/dwio/nimble/index/tests/ClusterIndexWriterTest.cpp
+++ b/dwio/nimble/index/tests/ClusterIndexWriterTest.cpp
@@ -23,9 +23,14 @@
 #include "dwio/nimble/index/ClusterIndexWriter.h"
 #include "dwio/nimble/index/IndexConfig.h"
 #include "dwio/nimble/index/SortOrder.h"
+#include "dwio/nimble/index/tests/ClusterIndexTestUtils.h"
+#include "dwio/nimble/tablet/MetadataInput.h"
 #include "velox/buffer/Buffer.h"
 #include "velox/common/base/tests/GTestUtils.h"
+#include "velox/common/io/IoStatistics.h"
+#include "velox/common/io/Options.h"
 #include "velox/common/memory/Memory.h"
+#include "velox/dwio/common/BufferedInput.h"
 #include "velox/dwio/common/SeekableInputStream.h"
 #include "velox/serializers/KeyEncoder.h"
 #include "velox/vector/fuzzer/VectorFuzzer.h"
@@ -1114,28 +1119,20 @@ TEST_P(ClusterIndexWriterChunkTest, maxRowsPerKeyChunk) {
           toBufferPtr(rootIndexData, pool_.get()),
           CompressionType::Uncompressed,
           pool_.get()))};
-  auto partData = std::make_shared<std::string>(partitionMetadata[0]);
-  auto streamData = std::make_shared<std::string>(keyStreamData);
+  auto metadataFile =
+      std::make_shared<velox::InMemoryReadFile>(partitionMetadata[0]);
+  velox::io::IoStatistics ioStats;
+  velox::io::ReaderOptions readerOptions(pool_.get());
+  readerOptions.setMetadataIoStats(&ioStats);
+  auto metadataInput = MetadataInput::create(metadataFile.get(), readerOptions);
+  auto dataInput = std::make_unique<velox::dwio::common::BufferedInput>(
+      std::make_shared<velox::InMemoryReadFile>(keyStreamData), *pool_);
 
-  auto clusterIndex = ClusterIndex::create(
+  auto clusterIndex = test::ClusterIndexTestHelper::create(
       std::move(rootSection),
-      [partData, this](const MetadataSection& section) {
-        return std::make_unique<MetadataBuffer>(MetadataBuffer::decompress(
-            toBufferPtr(
-                std::string_view(
-                    partData->data() + section.offset(), section.size()),
-                pool_.get()),
-            section.compressionType(),
-            pool_.get()));
-      },
-      [streamData](const velox::common::Region& region)
-          -> std::unique_ptr<velox::dwio::common::SeekableInputStream> {
-        return std::make_unique<velox::dwio::common::SeekableArrayInputStream>(
-            reinterpret_cast<const unsigned char*>(
-                streamData->data() + region.offset),
-            region.length);
-      },
-      pool_.get());
+      pool_.get(),
+      std::move(metadataInput),
+      std::move(dataInput));
 
   // Verify partition count and layout.
   EXPECT_EQ(clusterIndex->numPartitions(), 1);

--- a/dwio/nimble/index/tests/DenseIndexRegistryTest.cpp
+++ b/dwio/nimble/index/tests/DenseIndexRegistryTest.cpp
@@ -28,6 +28,8 @@
 #include "dwio/nimble/velox/VeloxReader.h"
 #include "dwio/nimble/velox/VeloxWriter.h"
 #include "velox/common/file/FileSystems.h"
+#include "velox/common/io/IoStatistics.h"
+#include "velox/common/io/Options.h"
 #include "velox/common/memory/Memory.h"
 #include "velox/common/testutil/TempDirectoryPath.h"
 #include "velox/vector/FlatVector.h"
@@ -95,7 +97,13 @@ class DenseIndexRegistryTest : public ::testing::Test {
   std::shared_ptr<TabletReader> openTablet(const std::string& filePath) {
     auto fs = velox::filesystems::getFileSystem(filePath, {});
     auto readFile = fs->openFileForRead(filePath);
-    return TabletReader::create(std::move(readFile), leafPool_.get(), {});
+    ioStats_ = std::make_unique<velox::io::IoStatistics>();
+    readerOptions_ =
+        std::make_unique<velox::io::ReaderOptions>(leafPool_.get());
+    readerOptions_->setMetadataIoStats(ioStats_.get());
+    TabletReader::Options options;
+    options.ioOptions = *readerOptions_;
+    return TabletReader::create(std::move(readFile), leafPool_.get(), options);
   }
 
   std::string tempFilePath(const std::string& name) {
@@ -106,15 +114,18 @@ class DenseIndexRegistryTest : public ::testing::Test {
   std::shared_ptr<velox::memory::MemoryPool> leafPool_;
   std::shared_ptr<velox::common::testutil::TempDirectoryPath> tempDir_;
   std::deque<std::string> valueStrings_;
+  std::unique_ptr<velox::io::IoStatistics> ioStats_;
+  std::unique_ptr<velox::io::ReaderOptions> readerOptions_;
 };
 
 TEST_F(DenseIndexRegistryTest, emptyRegistry) {
+  auto file = std::make_shared<velox::InMemoryReadFile>(std::string{});
+  velox::io::IoStatistics ioStats;
+  velox::io::ReaderOptions ioOptions(leafPool_.get());
+  ioOptions.setMetadataIoStats(&ioStats);
+  IndexLookup::Options options{.file = file, .ioOptions = &ioOptions};
   auto registry = DenseIndexRegistry::create(
-      std::nullopt,
-      std::nullopt,
-      [](const MetadataSection&) { return nullptr; },
-      [](const velox::common::Region&) { return nullptr; },
-      leafPool_.get());
+      std::nullopt, std::nullopt, options, leafPool_.get());
   EXPECT_EQ(registry, nullptr);
 }
 

--- a/dwio/nimble/index/tests/IndexLookupTest.cpp
+++ b/dwio/nimble/index/tests/IndexLookupTest.cpp
@@ -19,6 +19,15 @@
 
 #include "dwio/nimble/common/tests/GTestUtils.h"
 #include "dwio/nimble/index/IndexLookup.h"
+#include "dwio/nimble/tablet/MetadataInput.h"
+#include "velox/common/caching/AsyncDataCache.h"
+#include "velox/common/caching/FileHandle.h"
+#include "velox/common/caching/FileIds.h"
+#include "velox/common/file/File.h"
+#include "velox/common/io/Options.h"
+#include "velox/common/memory/MallocAllocator.h"
+#include "velox/common/memory/Memory.h"
+#include "velox/dwio/common/BufferedInput.h"
 
 namespace facebook::nimble::index::test {
 namespace {
@@ -28,6 +37,11 @@ using LookupResult = IndexLookup::LookupResult;
 using LookupOptions = IndexLookup::LookupOptions;
 
 class IndexLookupTest : public ::testing::Test {
+ public:
+  static void SetUpTestCase() {
+    velox::memory::MemoryManager::testingSetInstance({});
+  }
+
  protected:
   static velox::serializer::EncodedKeyBounds makePointKey(
       const std::string& key) {
@@ -194,6 +208,148 @@ TEST_F(IndexLookupTest, fmtFormat) {
 TEST_F(IndexLookupTest, unknownIndexType) {
   const auto unknown = static_cast<IndexType>(99);
   NIMBLE_ASSERT_THROW(toString(unknown), "Unknown IndexType: 99");
+}
+
+TEST_F(IndexLookupTest, optionsValidateRequiredFields) {
+  {
+    SCOPED_TRACE("null file");
+    IndexLookup::Options options;
+    NIMBLE_ASSERT_THROW(options.validate(), "");
+  }
+  {
+    SCOPED_TRACE("null ioOptions");
+    auto file = std::make_shared<velox::InMemoryReadFile>(std::string{});
+    IndexLookup::Options options{.file = file};
+    NIMBLE_ASSERT_THROW(options.validate(), "");
+  }
+}
+
+TEST_F(IndexLookupTest, optionsValidateFileHandleAndCache) {
+  auto file = std::make_shared<velox::InMemoryReadFile>(std::string{});
+  auto pool = velox::memory::memoryManager()->addLeafPool();
+  velox::io::ReaderOptions ioOptions(pool.get());
+
+  {
+    SCOPED_TRACE("direct path (no fileHandle, no cache)");
+    IndexLookup::Options options{.file = file, .ioOptions = &ioOptions};
+    EXPECT_NO_THROW(options.validate());
+  }
+  {
+    SCOPED_TRACE("fileHandle without cache");
+    velox::FileHandle fileHandle;
+    fileHandle.file = file;
+    IndexLookup::Options options{
+        .file = file, .ioOptions = &ioOptions, .fileHandle = &fileHandle};
+    NIMBLE_ASSERT_THROW(
+        options.validate(), "fileHandle and cache must both be set or neither");
+  }
+  {
+    SCOPED_TRACE("cache without fileHandle");
+    IndexLookup::Options options{
+        .file = file,
+        .ioOptions = &ioOptions,
+        .cache = reinterpret_cast<velox::cache::AsyncDataCache*>(0x1)};
+    NIMBLE_ASSERT_THROW(
+        options.validate(), "fileHandle and cache must both be set or neither");
+  }
+  {
+    SCOPED_TRACE("file mismatch with fileHandle->file");
+    auto file2 = std::make_shared<velox::InMemoryReadFile>(std::string{});
+    velox::FileHandle fileHandle2;
+    fileHandle2.file = file2;
+    IndexLookup::Options options{
+        .file = file,
+        .ioOptions = &ioOptions,
+        .fileHandle = &fileHandle2,
+        .cache = reinterpret_cast<velox::cache::AsyncDataCache*>(0x1)};
+    NIMBLE_ASSERT_THROW(
+        options.validate(),
+        "file and fileHandle->file must point to the same file");
+  }
+}
+
+TEST_F(IndexLookupTest, createIndexMetadataInput) {
+  struct TestParam {
+    bool cached;
+    std::string debugString() const {
+      return cached ? "cached" : "direct";
+    }
+  };
+  std::vector<TestParam> testSettings = {{false}, {true}};
+  for (const auto& testData : testSettings) {
+    SCOPED_TRACE(testData.debugString());
+    auto file = std::make_shared<velox::InMemoryReadFile>(std::string{});
+    auto pool = velox::memory::memoryManager()->addLeafPool();
+    velox::io::IoStatistics metadataIoStats;
+    velox::io::ReaderOptions ioOptions(pool.get());
+    ioOptions.setMetadataIoStats(&metadataIoStats);
+
+    std::shared_ptr<velox::memory::MallocAllocator> allocator;
+    std::shared_ptr<velox::cache::AsyncDataCache> cache;
+    std::unique_ptr<velox::FileHandle> fileHandle;
+    if (testData.cached) {
+      allocator = std::make_shared<velox::memory::MallocAllocator>(
+          velox::memory::MemoryAllocator::Options{.capacity = 1UL << 30});
+      cache = velox::cache::AsyncDataCache::create(allocator.get());
+      fileHandle = std::make_unique<velox::FileHandle>();
+      fileHandle->file = file;
+      fileHandle->uuid = velox::StringIdLease(velox::fileIds(), "testFile");
+    }
+
+    IndexLookup::Options options{
+        .file = file,
+        .ioOptions = &ioOptions,
+        .fileHandle = fileHandle.get(),
+        .cache = cache.get()};
+    auto metadataInput = createIndexMetadataInput(options);
+    ASSERT_NE(metadataInput, nullptr);
+    EXPECT_EQ(metadataInput->cached(), testData.cached);
+  }
+}
+
+TEST_F(IndexLookupTest, createIndexDataInput) {
+  struct TestParam {
+    bool cached;
+    bool hasIndexIoStats;
+    std::string debugString() const {
+      return fmt::format(
+          "cached {}, hasIndexIoStats {}", cached, hasIndexIoStats);
+    }
+  };
+  std::vector<TestParam> testSettings = {
+      {false, true}, {false, false}, {true, true}};
+  for (const auto& testData : testSettings) {
+    SCOPED_TRACE(testData.debugString());
+    auto file = std::make_shared<velox::InMemoryReadFile>(std::string{});
+    auto pool = velox::memory::memoryManager()->addLeafPool();
+    velox::io::IoStatistics metadataIoStats;
+    velox::io::IoStatistics indexIoStats;
+    velox::io::ReaderOptions ioOptions(pool.get());
+    ioOptions.setMetadataIoStats(&metadataIoStats);
+    if (testData.hasIndexIoStats) {
+      ioOptions.setIndexIoStats(&indexIoStats);
+    }
+
+    std::shared_ptr<velox::memory::MallocAllocator> allocator;
+    std::shared_ptr<velox::cache::AsyncDataCache> cache;
+    std::unique_ptr<velox::FileHandle> fileHandle;
+    if (testData.cached) {
+      allocator = std::make_shared<velox::memory::MallocAllocator>(
+          velox::memory::MemoryAllocator::Options{.capacity = 1UL << 30});
+      cache = velox::cache::AsyncDataCache::create(allocator.get());
+      fileHandle = std::make_unique<velox::FileHandle>();
+      fileHandle->file = file;
+      fileHandle->uuid = velox::StringIdLease(velox::fileIds(), "testFile");
+    }
+
+    IndexLookup::Options options{
+        .file = file,
+        .ioOptions = &ioOptions,
+        .fileHandle = fileHandle.get(),
+        .cache = cache.get()};
+    auto dataInput = createIndexDataInput(options, *pool);
+    ASSERT_NE(dataInput, nullptr);
+  }
 }
 
 } // namespace

--- a/dwio/nimble/tablet/CMakeLists.txt
+++ b/dwio/nimble/tablet/CMakeLists.txt
@@ -112,15 +112,19 @@ target_include_directories(
 )
 add_dependencies(nimble_sorted_index_fb nimble_sorted_index_schema_fb)
 
-add_library(nimble_tablet_common Compression.cpp MetadataBuffer.cpp)
+add_library(nimble_tablet_common Compression.cpp MetadataBuffer.cpp
+                                 MetadataInput.cpp Postscript.cpp)
 target_link_libraries(
   nimble_tablet_common
   nimble_footer_fb
   nimble_common
+  velox_caching
+  velox_file
+  velox_memory
   Folly::folly
 )
 
-add_library(nimble_tablet_reader FileLayout.cpp Postscript.cpp TabletReader.cpp)
+add_library(nimble_tablet_reader FileLayout.cpp TabletReader.cpp)
 target_link_libraries(
   nimble_tablet_reader
   PUBLIC

--- a/dwio/nimble/tablet/FileLayout.cpp
+++ b/dwio/nimble/tablet/FileLayout.cpp
@@ -18,6 +18,7 @@
 #include "dwio/nimble/tablet/Constants.h"
 #include "dwio/nimble/tablet/TabletReader.h"
 #include "velox/common/file/FileSystems.h"
+#include "velox/common/io/Options.h"
 
 #include <numeric>
 
@@ -26,7 +27,16 @@ namespace facebook::nimble {
 FileLayout FileLayout::create(
     std::shared_ptr<velox::ReadFile> file,
     velox::memory::MemoryPool* pool) {
-  auto tablet = TabletReader::create(std::move(file), pool, {});
+  velox::io::IoStatistics dataStats;
+  velox::io::IoStatistics metadataStats;
+  velox::io::IoStatistics indexStats;
+  velox::io::ReaderOptions readerOptions(pool);
+  readerOptions.setDataIoStats(&dataStats);
+  readerOptions.setMetadataIoStats(&metadataStats);
+  readerOptions.setIndexIoStats(&indexStats);
+  TabletReader::Options options;
+  options.ioOptions = readerOptions;
+  auto tablet = TabletReader::create(std::move(file), pool, options);
 
   FileLayout layout;
   layout.fileSize = tablet->fileSize();

--- a/dwio/nimble/tablet/MetadataBuffer.cpp
+++ b/dwio/nimble/tablet/MetadataBuffer.cpp
@@ -17,7 +17,6 @@
 #include "dwio/nimble/tablet/MetadataBuffer.h"
 #include "dwio/nimble/common/Exceptions.h"
 #include "dwio/nimble/tablet/Compression.h"
-#include "folly/io/Cursor.h"
 
 namespace facebook::nimble {
 
@@ -119,34 +118,17 @@ velox::BufferPtr MetadataBuffer::decompress(
 }
 
 velox::BufferPtr MetadataBuffer::decompress(
-    const folly::IOBuf& iobuf,
-    size_t offset,
-    size_t length,
+    std::string_view data,
     CompressionType type,
     velox::memory::MemoryPool* pool) {
-  folly::io::Cursor cursor(&iobuf);
-  cursor.skip(offset);
-
   if (type == CompressionType::Uncompressed) {
-    auto buffer = velox::AlignedBuffer::allocateExact<char>(length, pool);
-    cursor.pull(buffer->asMutable<char>(), length);
-    return buffer;
+    return copyToBuffer(data.data(), data.size(), pool);
   }
-
   NIMBLE_CHECK_EQ(
       static_cast<int>(type),
       static_cast<int>(CompressionType::Zstd),
       "Unsupported metadata compression type");
-
-  const auto contiguous = cursor.peekBytes();
-  if (contiguous.size() >= length) {
-    return decompressZstd(
-        {reinterpret_cast<const char*>(contiguous.data()), length}, pool);
-  }
-
-  auto buffer = velox::AlignedBuffer::allocateExact<char>(length, pool);
-  cursor.pull(buffer->asMutable<char>(), length);
-  return decompressZstd({buffer->as<char>(), buffer->size()}, pool);
+  return decompressZstd(data, pool);
 }
 
 std::unique_ptr<MetadataBuffer> MetadataBuffer::slice(

--- a/dwio/nimble/tablet/MetadataBuffer.h
+++ b/dwio/nimble/tablet/MetadataBuffer.h
@@ -22,7 +22,6 @@
 #include <vector>
 
 #include "dwio/nimble/common/Types.h"
-#include "folly/io/IOBuf.h"
 #include "velox/buffer/Buffer.h"
 #include "velox/common/caching/AsyncDataCache.h"
 
@@ -65,11 +64,9 @@ class MetadataBuffer {
       CompressionType type,
       velox::memory::MemoryPool* pool);
 
-  /// Decompresses metadata from an IOBuf slice and returns a BufferPtr.
+  /// Decompresses metadata from a string_view and returns a BufferPtr.
   static velox::BufferPtr decompress(
-      const folly::IOBuf& iobuf,
-      size_t offset,
-      size_t length,
+      std::string_view data,
       CompressionType type,
       velox::memory::MemoryPool* pool);
 

--- a/dwio/nimble/tablet/MetadataInput.cpp
+++ b/dwio/nimble/tablet/MetadataInput.cpp
@@ -16,13 +16,16 @@
 #include "dwio/nimble/tablet/MetadataInput.h"
 
 #include <algorithm>
+
 #include <numeric>
+#include "velox/common/caching/FileHandle.h"
 
 #include "dwio/nimble/common/Exceptions.h"
 #include "dwio/nimble/tablet/Compression.h"
 #include "folly/Range.h"
 #include "folly/ScopeGuard.h"
 #include "folly/executors/QueuedImmediateExecutor.h"
+#include "folly/io/Cursor.h"
 #include "velox/common/base/AsyncSource.h"
 #include "velox/common/base/CoalesceIo.h"
 #include "velox/common/testutil/TestValue.h"
@@ -51,12 +54,31 @@ std::shared_ptr<MetadataBuffer> MetadataHandle::read() {
 
 // --- MetadataInput ---
 
+std::unique_ptr<MetadataInput> MetadataInput::create(
+    velox::ReadFile* file,
+    const velox::io::ReaderOptions& readerOptions) {
+  NIMBLE_CHECK_NOT_NULL(file);
+  return std::unique_ptr<MetadataInput>(
+      new DirectMetadataInput(file, readerOptions));
+}
+
+std::unique_ptr<MetadataInput> MetadataInput::create(
+    const velox::FileHandle* fileHandle,
+    velox::cache::AsyncDataCache* cache,
+    const velox::io::ReaderOptions& readerOptions) {
+  NIMBLE_CHECK_NOT_NULL(fileHandle);
+  NIMBLE_CHECK_NOT_NULL(cache);
+  auto* file = fileHandle->file.get();
+  NIMBLE_CHECK_NOT_NULL(file);
+  return std::unique_ptr<MetadataInput>(
+      new CachedMetadataInput(file, fileHandle->uuid, cache, readerOptions));
+}
+
 MetadataInput::MetadataInput(
     velox::ReadFile* file,
-    velox::memory::MemoryPool* pool,
     const velox::io::ReaderOptions& options)
     : file_{file},
-      pool_{pool},
+      pool_{&options.memoryPool()},
       maxCoalesceDistance_{options.maxCoalesceDistance()},
       maxCoalesceBytes_{options.maxCoalesceBytes()},
       executor_{options.ioExecutor().get()},
@@ -74,6 +96,17 @@ MetadataHandle MetadataInput::enqueue(const MetadataSection& section) {
 void MetadataInput::reset() {
   sections_.clear();
   loaded_ = false;
+}
+
+std::unique_ptr<MetadataBuffer> MetadataInput::findCachedMetadata(
+    uint64_t /*offset*/) {
+  NIMBLE_UNREACHABLE("findCachedMetadata requires CachedMetadataInput");
+}
+
+void MetadataInput::cacheMetadata(
+    uint64_t /*cacheOffset*/,
+    std::span<const std::string_view> /*ranges*/) {
+  NIMBLE_UNREACHABLE("cacheMetadata requires CachedMetadataInput");
 }
 
 std::shared_ptr<MetadataBuffer> MetadataInput::read(uint32_t index) {
@@ -256,9 +289,8 @@ void MetadataInput::recordCoalescedIoStats(
 
 DirectMetadataInput::DirectMetadataInput(
     velox::ReadFile* file,
-    velox::memory::MemoryPool* pool,
     const velox::io::ReaderOptions& options)
-    : MetadataInput(file, pool, options) {}
+    : MetadataInput(file, options) {}
 
 void DirectMetadataInput::load() {
   NIMBLE_CHECK(!loaded_, "load() already called; call reset() first");
@@ -275,7 +307,7 @@ void DirectMetadataInput::prepareReadBuffers(
   readRanges_.resize(sectionIndices.size());
   for (size_t i = 0; i < sectionIndices.size(); ++i) {
     const auto size = sections_[sectionIndices[i]].section.size();
-    buffers_[i] = velox::AlignedBuffer::allocate<char>(size, pool_);
+    buffers_[i] = velox::AlignedBuffer::allocateExact<char>(size, pool_);
     readRanges_[i] = {buffers_[i]->asMutable<char>(), size};
   }
 }
@@ -301,11 +333,8 @@ CachedMetadataInput::CachedMetadataInput(
     velox::ReadFile* file,
     velox::StringIdLease fileId,
     velox::cache::AsyncDataCache* cache,
-    velox::memory::MemoryPool* pool,
     const velox::io::ReaderOptions& options)
-    : MetadataInput(file, pool, options),
-      cache_{cache},
-      fileId_{std::move(fileId)} {
+    : MetadataInput(file, options), cache_{cache}, fileId_{std::move(fileId)} {
   NIMBLE_CHECK_NOT_NULL(cache_);
 }
 
@@ -577,6 +606,63 @@ std::shared_ptr<MetadataBuffer> CachedMetadataInput::store(
   std::memcpy(destination, decompressed->as<char>(), decompressed->size());
   entry->setExclusiveToShared();
   return std::make_shared<MetadataBuffer>(std::move(pin));
+}
+
+std::unique_ptr<MetadataBuffer> CachedMetadataInput::findCachedMetadata(
+    uint64_t offset) {
+  for (;;) {
+    const velox::cache::RawFileCacheKey key{fileId_.id(), offset};
+    folly::SemiFuture<bool> waitFuture{false};
+    auto pin = cache_->findOrCreate(key, 0, /*contiguous=*/true, &waitFuture);
+    if (pin.empty()) {
+      if (!waitFuture.valid()) {
+        return nullptr;
+      }
+      uint64_t waitUs{0};
+      {
+        velox::MicrosecondTimer timer(&waitUs);
+        auto& exec = folly::QueuedImmediateExecutor::instance();
+        std::move(waitFuture).via(&exec).wait();
+      }
+      ioStats_->queryThreadIoLatencyUs().increment(waitUs);
+      ioStats_->cacheWaitLatencyUs().increment(waitUs);
+      continue;
+    }
+    auto* entry = pin.checkedEntry();
+    if (!entry->isShared()) {
+      return nullptr;
+    }
+    NIMBLE_CHECK(
+        entry->hasContiguousData(), "Cached entry must have contiguous data");
+    ioStats_->ramHit().increment(entry->size());
+    return std::make_unique<MetadataBuffer>(std::move(pin));
+  }
+}
+
+void CachedMetadataInput::cacheMetadata(
+    uint64_t cacheOffset,
+    std::span<const std::string_view> ranges) {
+  uint64_t totalSize = 0;
+  for (const auto& range : ranges) {
+    totalSize += range.size();
+  }
+  const velox::cache::RawFileCacheKey key{fileId_.id(), cacheOffset};
+  auto pin = acquireCachePin(key, totalSize);
+  velox::common::testutil::TestValue::adjust(
+      "facebook::nimble::CachedMetadataInput::cacheMetadata", &pin);
+  auto* entry = pin.checkedEntry();
+  if (entry->isShared()) {
+    return;
+  }
+  NIMBLE_CHECK(
+      entry->hasContiguousData(), "Cache entry must have contiguous data");
+  NIMBLE_CHECK_EQ(entry->size(), totalSize);
+  auto* dest = entry->contiguousData();
+  for (const auto& range : ranges) {
+    std::memcpy(dest, range.data(), range.size());
+    dest += range.size();
+  }
+  entry->setExclusiveToShared();
 }
 
 } // namespace facebook::nimble

--- a/dwio/nimble/tablet/MetadataInput.h
+++ b/dwio/nimble/tablet/MetadataInput.h
@@ -16,15 +16,21 @@
 #pragma once
 
 #include <memory>
+#include <span>
 #include <vector>
 
 #include <optional>
+#include "dwio/nimble/common/Exceptions.h"
 #include "dwio/nimble/tablet/MetadataBuffer.h"
 #include "folly/Range.h"
 #include "velox/common/caching/AsyncDataCache.h"
 #include "velox/common/caching/SsdCache.h"
 #include "velox/common/file/File.h"
 #include "velox/common/io/Options.h"
+
+namespace facebook::velox {
+struct FileHandle;
+} // namespace facebook::velox
 
 namespace facebook::nimble {
 
@@ -71,12 +77,23 @@ class MetadataHandle {
 /// NOTE: Not thread-safe. All calls must be serialized by the caller.
 class MetadataInput {
  public:
-  MetadataInput(
+  /// Creates a DirectMetadataInput for non-cached reads.
+  static std::unique_ptr<MetadataInput> create(
       velox::ReadFile* file,
-      velox::memory::MemoryPool* pool,
-      const velox::io::ReaderOptions& options);
+      const velox::io::ReaderOptions& readerOptions);
+
+  /// Creates a CachedMetadataInput using fileHandle->uuid as cache key.
+  static std::unique_ptr<MetadataInput> create(
+      const velox::FileHandle* fileHandle,
+      velox::cache::AsyncDataCache* cache,
+      const velox::io::ReaderOptions& readerOptions);
 
   virtual ~MetadataInput() = default;
+
+  /// Returns true if this MetadataInput is backed by a cache.
+  virtual bool cached() const {
+    return false;
+  }
 
   /// Enqueues a metadata section for coalesced IO. Returns a handle
   /// to retrieve the result later via handle.read().
@@ -89,7 +106,39 @@ class MetadataInput {
   /// Resets all internal state for the next round of enqueue/load/read.
   virtual void reset();
 
+  /// RAII guard that calls load() on construction and reset() on destruction.
+  class LoadGuard {
+   public:
+    explicit LoadGuard(MetadataInput* input) : input_{input} {
+      NIMBLE_CHECK_NOT_NULL(input_);
+      input_->load();
+    }
+
+    ~LoadGuard() {
+      input_->reset();
+    }
+
+    LoadGuard(const LoadGuard&) = delete;
+    LoadGuard& operator=(const LoadGuard&) = delete;
+
+   private:
+    MetadataInput* const input_;
+  };
+
+  /// Tries to find cached metadata at the given offset. Returns a
+  /// MetadataBuffer holding a cache pin if found, nullptr otherwise.
+  /// DirectMetadataInput always returns nullptr.
+  virtual std::unique_ptr<MetadataBuffer> findCachedMetadata(uint64_t offset);
+
+  /// Caches data at the given offset from multiple contiguous ranges.
+  /// Ranges are written sequentially into a single cache entry.
+  virtual void cacheMetadata(
+      uint64_t cacheOffset,
+      std::span<const std::string_view> ranges);
+
  protected:
+  MetadataInput(velox::ReadFile* file, const velox::io::ReaderOptions& options);
+
   struct LoadedSection {
     explicit LoadedSection(MetadataSection _section) : section{_section} {}
 
@@ -187,12 +236,14 @@ class MetadataInput {
 /// Direct metadata loading with IO coalescing, no caching.
 class DirectMetadataInput : public MetadataInput {
  public:
+  void load() override;
+
+ private:
+  friend class MetadataInput;
+
   DirectMetadataInput(
       velox::ReadFile* file,
-      velox::memory::MemoryPool* pool,
       const velox::io::ReaderOptions& options);
-
-  void load() override;
 
  protected:
   void prepareReadBuffers(const std::vector<uint32_t>& sectionIndices) override;
@@ -209,15 +260,19 @@ class DirectMetadataInput : public MetadataInput {
 /// Cache key is the compressed file offset.
 class CachedMetadataInput : public MetadataInput {
  public:
-  CachedMetadataInput(
-      velox::ReadFile* file,
-      velox::StringIdLease fileId,
-      velox::cache::AsyncDataCache* cache,
-      velox::memory::MemoryPool* pool,
-      const velox::io::ReaderOptions& options);
+  bool cached() const override {
+    return true;
+  }
 
   void load() override;
+
   void reset() override;
+
+  std::unique_ptr<MetadataBuffer> findCachedMetadata(uint64_t offset) override;
+
+  void cacheMetadata(
+      uint64_t cacheOffset,
+      std::span<const std::string_view> ranges) override;
 
  protected:
   void prepareReadBuffers(const std::vector<uint32_t>& sectionIndices) override;
@@ -254,6 +309,14 @@ class CachedMetadataInput : public MetadataInput {
       const MetadataSection& section,
       velox::cache::CachePin pin,
       velox::io::IoCounter& ioCounter);
+
+  friend class MetadataInput;
+
+  CachedMetadataInput(
+      velox::ReadFile* file,
+      velox::StringIdLease fileId,
+      velox::cache::AsyncDataCache* cache,
+      const velox::io::ReaderOptions& options);
 
   velox::cache::AsyncDataCache* const cache_;
   const velox::StringIdLease fileId_;

--- a/dwio/nimble/tablet/TabletReader.cpp
+++ b/dwio/nimble/tablet/TabletReader.cpp
@@ -20,8 +20,6 @@
 #include "dwio/nimble/tablet/ChunkIndexGenerated.h"
 #include "dwio/nimble/tablet/Constants.h"
 #include "dwio/nimble/tablet/FooterGenerated.h"
-#include "velox/dwio/common/BufferedInput.h"
-#include "velox/dwio/common/CachedBufferedInput.h"
 #include "velox/dwio/common/SeekableInputStream.h"
 
 #include "folly/io/Cursor.h"
@@ -36,35 +34,53 @@ namespace facebook::nimble {
 
 namespace {
 
-// Tries to create a MetadataBuffer from the footer IO buffer if the metadata
-// section fits within it. Returns nullptr if the section is not contained in
-// the footer buffer.
-std::unique_ptr<MetadataBuffer> tryCreateMetadataBufferFromFooter(
-    velox::memory::MemoryPool& pool,
-    const folly::IOBuf& footerIoBuf,
-    uint64_t fileSize,
-    const MetadataSection& section) {
-  const auto footerSize = footerIoBuf.computeChainDataLength();
-  if (section.offset() + footerSize < fileSize) {
+// Tries to create a MetadataBuffer from the speculative read buffer if the
+// metadata section fits within it. Returns nullptr if not covered.
+std::unique_ptr<MetadataBuffer> tryExtractFromBuffer(
+    std::string_view footerBuf,
+    uint64_t footerOffset,
+    const MetadataSection& section,
+    velox::memory::MemoryPool* pool) {
+  if (footerBuf.empty() || section.offset() < footerOffset) {
     return nullptr;
   }
+  const uint64_t bufOffset = section.offset() - footerOffset;
+  NIMBLE_CHECK_LE(
+      bufOffset + section.size(),
+      footerBuf.size(),
+      "Metadata section exceeds speculative read buffer");
   return std::make_unique<MetadataBuffer>(MetadataBuffer::decompress(
-      footerIoBuf,
-      section.offset() + footerSize - fileSize,
-      section.size(),
+      footerBuf.substr(bufOffset, section.size()),
       section.compressionType(),
-      &pool));
+      pool));
+}
+
+// Ensures the buffer has at least the requested capacity.
+void ensureBuffer(
+    velox::BufferPtr& buffer,
+    uint64_t size,
+    velox::memory::MemoryPool* pool) {
+  NIMBLE_CHECK(
+      buffer == nullptr || buffer->unique(), "Cannot reuse shared buffer");
+  if (buffer == nullptr || buffer->size() < size) {
+    buffer = velox::AlignedBuffer::allocateExact<char>(size, pool);
+  }
+}
+
+// Reads raw bytes from file into a caller-provided destination.
+void rawRead(
+    velox::ReadFile* file,
+    uint64_t offset,
+    uint64_t size,
+    void* dest) {
+  file->pread(offset, size, dest);
 }
 
 } // namespace
 
 TabletReader::Options TabletReader::configureOptions(
-    const velox::dwio::common::ReaderOptions& options,
-    velox::dwio::common::BufferedInput* bufferedInput) {
+    const velox::dwio::common::ReaderOptions& options) {
   Options tabletOptions;
-  if (options.fileMetadataCacheEnabled()) {
-    tabletOptions.bufferedInput = bufferedInput;
-  }
   tabletOptions.maxFooterIoBytes = options.footerSpeculativeIoSize();
   tabletOptions.preloadOptionalSections = {
       std::string(kSchemaSection), std::string(kVectorizedStatsSection)};
@@ -77,6 +93,7 @@ TabletReader::Options TabletReader::configureOptions(
     tabletOptions.preloadOptionalSections.emplace_back(kChunkIndexSection);
   }
   tabletOptions.pinFileMetadata = options.pinFileMetadata();
+  tabletOptions.ioOptions = options;
   return tabletOptions;
 }
 
@@ -159,22 +176,6 @@ size_t copyTo(const folly::IOBuf& source, void* target, size_t size) {
   return offset;
 }
 
-folly::IOBuf
-cloneAndCoalesce(const folly::IOBuf& src, size_t offset, size_t size) {
-  folly::io::Cursor cursor(&src);
-  NIMBLE_CHECK_GE(cursor.totalLength(), offset, "Offset out of range");
-  cursor.skip(offset);
-  NIMBLE_CHECK_GE(cursor.totalLength(), size, "Size out of range");
-  folly::IOBuf result;
-  cursor.clone(result, size);
-  result.coalesceWithHeadroomTailroom(0, 0);
-  return result;
-}
-
-std::string_view toStringView(const folly::IOBuf& buf) {
-  return {reinterpret_cast<const char*>(buf.data()), buf.length()};
-}
-
 } // namespace
 
 StripeGroup::StripeGroup(
@@ -222,37 +223,47 @@ std::span<const uint32_t> StripeGroup::streamSizes(uint32_t stripe) const {
   return {streamSizes_ + (stripe - firstStripe_) * streamCount_, streamCount_};
 }
 
-namespace {
-
-// Creates an owned BufferedInput clone for metadata reads. When
-// pinFileMetadata is enabled with CachedBufferedInput, creates a
-// non-cacheable clone so AsyncDataCache does not retain raw metadata
-// bytes (MetadataCache already pins parsed objects). Otherwise, creates
-// a regular clone.
-std::unique_ptr<velox::dwio::common::BufferedInput> createMetadataInput(
-    const TabletReader::Options& options) {
-  if (options.bufferedInput == nullptr) {
-    return nullptr;
-  }
-  if (options.pinFileMetadata) {
-    auto* cachedInput = dynamic_cast<velox::dwio::common::CachedBufferedInput*>(
-        options.bufferedInput);
-    if (cachedInput != nullptr) {
-      return cachedInput->cloneNonCacheable();
-    }
-  }
-  return options.bufferedInput->clone();
-}
-
-} // namespace
-
 TabletReader::TabletReader(
     std::shared_ptr<velox::ReadFile> readFile,
     MemoryPool& pool,
     const Options& options)
     : pool_{&pool},
       file_{std::move(readFile)},
-      metadataInput_{createMetadataInput(options)},
+      loadClusterIndex_{options.loadClusterIndex},
+      loadChunkIndex_{options.loadChunkIndex},
+      loadDenseIndexes_{options.loadDenseIndexes},
+      defaultIoStats_{[&]() -> std::unique_ptr<velox::io::IoStatistics> {
+        if (options.ioOptions.has_value() &&
+            options.ioOptions->metadataIoStats() != nullptr) {
+          return nullptr;
+        }
+        return std::make_unique<velox::io::IoStatistics>();
+      }()},
+      ioOptions_{[&]() {
+        if (options.ioOptions.has_value()) {
+          auto opts = *options.ioOptions;
+          if (opts.metadataIoStats() == nullptr) {
+            opts.setMetadataIoStats(defaultIoStats_.get());
+          }
+          return opts;
+        }
+        velox::io::ReaderOptions opts(&pool);
+        opts.setMetadataIoStats(defaultIoStats_.get());
+        return opts;
+      }()},
+      indexOptions_{index::IndexLookup::Options{
+          file_,
+          &ioOptions_,
+          options.fileHandle,
+          options.cache}},
+      metadataInput_{[&]() {
+        if (options.fileHandle != nullptr) {
+          NIMBLE_CHECK_NOT_NULL(options.cache);
+          return MetadataInput::create(
+              options.fileHandle, options.cache, ioOptions_);
+        }
+        return MetadataInput::create(file_.get(), ioOptions_);
+      }()},
       stripeGroupCache_{
           [this](uint32_t stripeGroupIndex) {
             return loadStripeGroup(stripeGroupIndex);
@@ -263,142 +274,246 @@ TabletReader::TabletReader(
             return loadChunkIndexGroup(stripeGroupIndex);
           },
           options.pinFileMetadata} {
+  NIMBLE_CHECK_EQ(
+      static_cast<const void*>(&ioOptions_.memoryPool()),
+      static_cast<const void*>(pool_),
+      "ioOptions pool must match the provided pool");
   init(options);
 }
 
 void TabletReader::init(const Options& options) {
   fileSize_ = file_->size();
   NIMBLE_CHECK_FILE(
-      fileSize_ >= kPostscriptSize,
+      fileSize_ >= Postscript::kSize,
       "Corrupted file. File size {} is smaller than postscript size {}.",
       velox::succinctBytes(fileSize_),
-      velox::succinctBytes(kPostscriptSize));
+      velox::succinctBytes(Postscript::kSize));
 
   if (initFromCache(options)) {
     return;
   }
 
-  uint64_t footerIoSize;
-  uint64_t footerIoOffset;
-  folly::IOBuf footerIoBuf;
+  uint64_t footerIoSize{0};
+  uint64_t footerOffset{0};
+  velox::BufferPtr footerBuf;
 
-  loadAndInitFooter(
-      options.maxFooterIoBytes, footerIoBuf, footerIoSize, footerIoOffset);
-  loadStripes(footerIoBuf, footerIoSize, footerIoOffset, options);
-  initStripes();
-  if (stripeCount_ > 0) {
-    preloadStripeGroup(footerIoBuf);
-  }
+  loadFooter(options.maxFooterIoBytes, footerBuf, footerIoSize, footerOffset);
+  NIMBLE_CHECK_NOT_NULL(footer_);
 
+  const auto footerView = footerBuf != nullptr
+      ? std::string_view{footerBuf->as<char>(), footerBuf->size()}
+      : std::string_view{};
+
+  // Parse optional sections metadata from footer before enqueueing.
   initOptionalSections();
-  preloadOptionalSections(
-      options, makeSectionLoader(footerIoBuf, footerIoOffset));
 
-  if (options.loadClusterIndex) {
-    initClusterIndex();
-  }
+  // Enqueue stripes + optional sections. Try extracting from footerBuf
+  // first (speculative mode), enqueue the rest for coalesced IO.
+  std::vector<EnqueuedSection> enqueued;
+  enqueueStripesSection(footerView, footerOffset, enqueued);
+  enqueueOptionalSections(options, footerView, footerOffset, enqueued);
 
-  if (options.loadChunkIndex) {
-    initChunkIndex();
-    preloadChunkIndex(footerIoBuf);
-  }
+  loadEnqueuedSections(enqueued);
 
-  if (options.loadDenseIndexes) {
-    initDenseIndexes();
-  }
+  initStripes(footerView, footerOffset);
+  initClusterIndex();
+  initChunkIndex(footerView, footerOffset);
+  initDenseIndexes();
 
-  cacheMetadata(footerIoBuf, footerIoOffset);
+  cacheMetadata(footerView, footerOffset);
 }
 
-void TabletReader::loadAndInitFooter(
+void TabletReader::loadFooter(
     uint64_t maxFooterIoBytes,
-    folly::IOBuf& footerIoBuf,
+    velox::BufferPtr& footerBuf,
     uint64_t& footerIoSize,
-    uint64_t& footerIoOffset) {
-  footerIoBuf = folly::IOBuf();
-  if (maxFooterIoBytes == 0) {
-    // Adaptive mode: read postscript first, then exact footer size.
-    // First read: just the postscript (last 20 bytes)
-    {
-      const velox::common::Region psRegion{
-          fileSize_ - kPostscriptSize, kPostscriptSize, "postscript"};
-      folly::IOBuf psIoBuf;
-      file_->preadv({&psRegion, 1}, {&psIoBuf, 1});
-      ps_ = Postscript::parse(toStringView(psIoBuf));
-    }
-
-    // Second read: exact footer + postscript
-    footerIoSize = ps_.footerSize() + kPostscriptSize;
-    footerIoOffset = fileSize_ - footerIoSize;
-    {
-      const velox::common::Region footerIoRegion{
-          footerIoOffset, footerIoSize, "footer"};
-      file_->preadv({&footerIoRegion, 1}, {&footerIoBuf, 1});
-    }
-    NIMBLE_CHECK_EQ(footerIoSize, footerIoBuf.computeChainDataLength());
-
-    initFooter(footerIoBuf, footerIoSize);
-  } else {
-    // Speculative mode: read maxFooterIoBytes (or fileSize_ if smaller)
+    uint64_t& footerOffset) {
+  // Postscript and footer are not cached individually — they are cached
+  // together at the synthetic key fileSize_ by cacheMetadata().
+  if (maxFooterIoBytes > 0) {
+    // Speculative mode: one big read covers PS + footer + more.
+    // Extract PS and footer from the buffer — no separate reads.
+    NIMBLE_CHECK_GE(
+        maxFooterIoBytes,
+        Postscript::kSize,
+        "maxFooterIoBytes must be at least Postscript::kSize");
     footerIoSize = std::min(maxFooterIoBytes, fileSize_);
-    footerIoOffset = fileSize_ - footerIoSize;
-    {
-      const velox::common::Region footerIoRegion{
-          footerIoOffset, footerIoSize, "footer"};
-      file_->preadv({&footerIoRegion, 1}, {&footerIoBuf, 1});
-    }
-    NIMBLE_CHECK_EQ(footerIoSize, footerIoBuf.computeChainDataLength());
+    footerOffset = fileSize_ - footerIoSize;
+    ensureBuffer(footerBuf, footerIoSize, pool_);
+    rawRead(
+        file_.get(),
+        footerOffset,
+        footerBuf->size(),
+        footerBuf->asMutable<char>());
 
-    initPostScript(footerIoBuf, footerIoSize);
+    ps_ = Postscript::parse(
+        std::string_view{
+            footerBuf->as<char>() + footerIoSize - Postscript::kSize,
+            Postscript::kSize});
 
-    // If initial read didn't cover the full footer, do a second read.
-    const uint64_t requiredSize = ps_.footerSize() + kPostscriptSize;
+    // If the speculative read didn't cover the full footer, re-read.
+    const uint64_t requiredSize = ps_.footerSize() + Postscript::kSize;
     if (requiredSize > footerIoSize) {
       footerIoSize = requiredSize;
-      footerIoOffset = fileSize_ - footerIoSize;
-      const velox::common::Region footerIoRegion{
-          footerIoOffset, footerIoSize, "footer"};
-      file_->preadv({&footerIoRegion, 1}, {&footerIoBuf, 1});
-      NIMBLE_CHECK_EQ(footerIoSize, footerIoBuf.computeChainDataLength());
+      footerOffset = fileSize_ - footerIoSize;
+      ensureBuffer(footerBuf, footerIoSize, pool_);
+      rawRead(
+          file_.get(),
+          footerOffset,
+          footerBuf->size(),
+          footerBuf->asMutable<char>());
     }
 
-    initFooter(footerIoBuf, footerIoSize);
+    const uint64_t footerOffset =
+        footerIoSize - Postscript::kSize - ps_.footerSize();
+    footer_ = std::make_unique<MetadataBuffer>(MetadataBuffer::decompress(
+        std::string_view{
+            footerBuf->as<char>() + footerOffset, ps_.footerSize()},
+        ps_.footerCompressionType(),
+        pool_));
+  } else {
+    // Adaptive mode: read PS first, then footer.
+    ensureBuffer(footerBuf, Postscript::kSize, pool_);
+    rawRead(
+        file_.get(),
+        fileSize_ - Postscript::kSize,
+        Postscript::kSize,
+        footerBuf->asMutable<char>());
+    ps_ = Postscript::parse(
+        std::string_view{footerBuf->as<char>(), Postscript::kSize});
+
+    footerIoSize = ps_.footerSize() + Postscript::kSize;
+    footerOffset = fileSize_ - footerIoSize;
+
+    ensureBuffer(footerBuf, ps_.footerSize(), pool_);
+    rawRead(
+        file_.get(),
+        footerOffset,
+        ps_.footerSize(),
+        footerBuf->asMutable<char>());
+    footer_ = std::make_unique<MetadataBuffer>(MetadataBuffer::decompress(
+        std::move(footerBuf), ps_.footerCompressionType(), pool_));
   }
 }
 
-void TabletReader::initPostScript(
-    const folly::IOBuf& footerIoBuf,
-    uint64_t footerIoSize) {
-  NIMBLE_CHECK_GE(
-      footerIoSize,
-      kPostscriptSize,
-      "Footer IO size {} must be at least postscript size {}",
-      velox::succinctBytes(footerIoSize),
-      velox::succinctBytes(kPostscriptSize));
+bool TabletReader::loadFooterFromCache() {
+  if (!metadataInput_->cached()) {
+    return false;
+  }
+  auto cachedFooter = metadataInput_->findCachedMetadata(fileSize_);
+  if (cachedFooter == nullptr) {
+    return false;
+  }
 
-  folly::IOBuf psIoBuf = cloneAndCoalesce(
-      footerIoBuf,
-      footerIoBuf.computeChainDataLength() - kPostscriptSize,
-      kPostscriptSize);
-  ps_ = Postscript::parse(toStringView(psIoBuf));
+  const auto content = cachedFooter->content();
+  NIMBLE_CHECK_GE(
+      content.size(), Postscript::kSize, "Cached footer+PS entry too small");
+
+  ps_ = Postscript::parse(
+      content.substr(content.size() - Postscript::kSize, Postscript::kSize));
+
+  const auto footerSize = content.size() - Postscript::kSize;
+  NIMBLE_CHECK_EQ(
+      ps_.footerSize(),
+      footerSize,
+      "Cached footer size mismatch with postscript");
+
+  footer_ = cachedFooter->slice(0, footerSize);
+  return true;
 }
 
-void TabletReader::initFooter(
-    const folly::IOBuf& footerIoBuf,
-    uint64_t footerIoSize) {
-  NIMBLE_CHECK_NULL(footer_);
-  footer_ = std::make_unique<MetadataBuffer>(MetadataBuffer::decompress(
-      footerIoBuf,
-      footerIoSize - kPostscriptSize - ps_.footerSize(),
-      ps_.footerSize(),
-      ps_.footerCompressionType(),
-      pool_));
+bool TabletReader::initFromCache(const Options& options) {
+  if (!loadFooterFromCache()) {
+    return false;
+  }
+  initOptionalSections();
+
+  // Enqueue stripes + optional sections together for coalesced IO.
+  // Empty files (0 rows) have no stripes section but still need optional
+  // sections loaded (e.g., schema describes column types even with no rows).
+  std::vector<EnqueuedSection> enqueued;
+  enqueueStripesSection(enqueued);
+  enqueueOptionalSections(options, enqueued);
+
+  loadEnqueuedSections(enqueued);
+
+  initStripes();
+  initClusterIndex();
+  initChunkIndex();
+  initDenseIndexes();
+  return true;
+}
+
+void TabletReader::cacheMetadata(
+    std::string_view footerBuf,
+    uint64_t footerOffset) {
+  if (!metadataInput_->cached()) {
+    return;
+  }
+  if (footerBuf.empty()) {
+    return;
+  }
+
+  auto cacheSection = [&](uint64_t regionOffset,
+                          uint64_t regionSize,
+                          std::optional<uint64_t> cacheOffset = std::nullopt) {
+    if (regionOffset < footerOffset) {
+      return;
+    }
+    const uint64_t bufOffset = regionOffset - footerOffset;
+    if (bufOffset + regionSize > footerBuf.size()) {
+      return;
+    }
+    std::string_view range = footerBuf.substr(bufOffset, regionSize);
+    metadataInput_->cacheMetadata(
+        cacheOffset.value_or(regionOffset), {&range, 1});
+  };
+
+  // Cache decompressed footer + PS at synthetic offset fileSize_.
+  // Store uncompressed so loadFooterFromCache can slice without decompressing.
+  {
+    const auto footerContent = footer_->content();
+    const auto psData = ps_.serialize();
+    std::array<std::string_view, 2> ranges{footerContent, psData};
+    metadataInput_->cacheMetadata(fileSize_, ranges);
+  }
+
+  const auto* footer = footerRoot(*footer_);
+
+  if (auto* stripesSection = footer->stripes()) {
+    cacheSection(stripesSection->offset(), stripesSection->size());
+  }
+
+  if (auto* stripeGroups = footer->stripe_groups();
+      stripeGroups != nullptr && stripeGroups->size() > 0) {
+    auto* stripeGroup = stripeGroups->Get(0);
+    cacheSection(stripeGroup->offset(), stripeGroup->size());
+  }
+
+  if (clusterIndex_ != nullptr) {
+    auto clusterIndexIt =
+        optionalSections_.find(std::string{kClusterIndexSection});
+    NIMBLE_CHECK(clusterIndexIt != optionalSections_.end());
+    cacheSection(
+        clusterIndexIt->second.offset(), clusterIndexIt->second.size());
+  }
+
+  if (chunkIndex_ != nullptr) {
+    auto chunkIndexIt = optionalSections_.find(std::string{kChunkIndexSection});
+    NIMBLE_CHECK(chunkIndexIt != optionalSections_.end());
+    cacheSection(chunkIndexIt->second.offset(), chunkIndexIt->second.size());
+
+    const auto& firstSection = chunkIndex_->groupMetadata(0);
+    if (firstSection.size() > 0) {
+      cacheSection(firstSection.offset(), firstSection.size());
+    }
+  }
 }
 
 void TabletReader::loadStripes(
-    folly::IOBuf& footerIoBuf,
+    velox::BufferPtr& footerBuf,
     uint64_t& footerIoSize,
-    uint64_t& footerIoOffset,
+    uint64_t& footerOffset,
     const Options& options) {
   NIMBLE_CHECK_NOT_NULL(footer_);
   NIMBLE_CHECK_NULL(stripes_);
@@ -410,8 +525,7 @@ void TabletReader::loadStripes(
     return;
   }
 
-  // Compute the lowest offset we need in the buffer: stripes section and
-  // index sections (if present, may be at a lower offset than stripes).
+  // Compute the lowest offset we need in the buffer.
   uint64_t requiredOffset = stripesSection->offset();
   const auto updateOffset = [&](std::string_view sectionName) {
     auto it = optionalSections_.find(std::string{sectionName});
@@ -428,21 +542,101 @@ void TabletReader::loadStripes(
   const uint64_t requiredSize = fileSize_ - requiredOffset;
   if (requiredSize > footerIoSize) {
     footerIoSize = requiredSize;
-    footerIoOffset = fileSize_ - footerIoSize;
-    const velox::common::Region footerIoRegion{
-        footerIoOffset, footerIoSize, "footer+stripes"};
-    file_->preadv({&footerIoRegion, 1}, {&footerIoBuf, 1});
-    NIMBLE_CHECK_EQ(footerIoSize, footerIoBuf.computeChainDataLength());
+    footerOffset = fileSize_ - footerIoSize;
+    ensureBuffer(footerBuf, footerIoSize, pool_);
+    rawRead(
+        file_.get(),
+        footerOffset,
+        footerBuf->size(),
+        footerBuf->asMutable<char>());
   }
-  stripes_ = std::make_unique<MetadataBuffer>(MetadataBuffer::decompress(
-      footerIoBuf,
-      stripesSection->offset() + footerIoSize - fileSize_,
-      stripesSection->size(),
-      static_cast<CompressionType>(stripesSection->compression_type()),
-      pool_));
+  const auto footerView = footerBuf != nullptr
+      ? std::string_view{footerBuf->as<char>(), footerBuf->size()}
+      : std::string_view{};
+  const auto stripesMetadataSection = toMetadataSection(stripesSection);
+  auto fromBuf = tryExtractFromBuffer(
+      footerView, footerOffset, stripesMetadataSection, pool_);
+  if (fromBuf != nullptr) {
+    stripes_ = std::move(fromBuf);
+  } else {
+    stripes_ = readMetadata(stripesMetadataSection);
+  }
 }
 
-void TabletReader::initStripes() {
+void TabletReader::enqueueStripesSection(
+    std::string_view footerBuf,
+    uint64_t footerOffset,
+    std::vector<EnqueuedSection>& enqueued) {
+  const auto* footer = footerRoot(*footer_);
+  auto* stripesSection = footer->stripes();
+  if (stripesSection == nullptr) {
+    return;
+  }
+  const auto section = toMetadataSection(stripesSection);
+  auto fromBuf = tryExtractFromBuffer(footerBuf, footerOffset, section, pool_);
+  if (fromBuf != nullptr) {
+    stripes_ = std::move(fromBuf);
+  } else {
+    enqueued.push_back(
+        {EnqueuedSection::Type::kStripes,
+         {},
+         metadataInput_->enqueue(section)});
+  }
+}
+
+void TabletReader::enqueueOptionalSections(
+    const Options& options,
+    std::string_view footerBuf,
+    uint64_t footerOffset,
+    std::vector<EnqueuedSection>& enqueued) {
+  auto optionalSectionCache = optionalSectionsCache_.wlock();
+  for (const auto& name : preloadSectionNames(options)) {
+    // Skip sections not present in this file (e.g., old files without
+    // chunk index, small files without stats).
+    auto it = optionalSections_.find(name);
+    if (it == optionalSections_.end()) {
+      continue;
+    }
+    auto fromBuf =
+        tryExtractFromBuffer(footerBuf, footerOffset, it->second, pool_);
+    if (fromBuf != nullptr) {
+      optionalSectionCache->insert({name, std::move(fromBuf)});
+    } else {
+      enqueued.push_back(
+          {EnqueuedSection::Type::kOptionalSection,
+           name,
+           metadataInput_->enqueue(it->second)});
+    }
+  }
+}
+
+void TabletReader::loadEnqueuedSections(
+    std::vector<EnqueuedSection>& enqueued) {
+  if (enqueued.empty()) {
+    return;
+  }
+  MetadataInput::LoadGuard guard{metadataInput_.get()};
+  auto optionalSectionCache = optionalSectionsCache_.wlock();
+  for (auto& entry : enqueued) {
+    auto buffer =
+        std::make_unique<MetadataBuffer>(std::move(*entry.handle.read()));
+    if (entry.type == EnqueuedSection::Type::kStripes) {
+      NIMBLE_CHECK_NULL(stripes_, "Stripes already loaded");
+      stripes_ = std::move(buffer);
+    } else {
+      NIMBLE_CHECK_EQ(
+          static_cast<int>(entry.type),
+          static_cast<int>(EnqueuedSection::Type::kOptionalSection));
+      auto [_, inserted] = optionalSectionCache->insert(
+          {std::move(entry.name), std::move(buffer)});
+      NIMBLE_CHECK(inserted, "Optional section already loaded");
+    }
+  }
+}
+
+void TabletReader::initStripes(
+    std::string_view footerBuf,
+    uint64_t footerOffset) {
   const auto* footer = footerRoot(*footer_);
   NIMBLE_CHECK_EQ(tabletRowCount_, 0);
   tabletRowCount_ = footer->row_count();
@@ -471,6 +665,27 @@ void TabletReader::initStripes() {
   stripeRows_[0] = 0;
   for (uint32_t i = 0; i < stripeCount_; ++i) {
     stripeRows_[i + 1] = stripeRows_[i] + rowCounts[i];
+  }
+
+  // Eagerly pin the first stripe group if covered by the speculative buffer.
+  const auto* stripeGroups = footer->stripe_groups();
+  NIMBLE_CHECK_NOT_NULL(stripeGroups, "Stripe groups is null.");
+  NIMBLE_CHECK_EQ(
+      stripeGroups->size(),
+      *stripes->group_indices()->rbegin() + 1,
+      "Unexpected stripe group count");
+  if (stripeGroups->size() == 1) {
+    auto metadataBuffer = tryExtractFromBuffer(
+        footerBuf,
+        footerOffset,
+        toMetadataSection(stripeGroups->Get(0)),
+        pool_);
+    if (metadataBuffer != nullptr) {
+      stripeGroupCache_.pin(
+          0,
+          std::make_shared<StripeGroup>(
+              0, *stripes_, std::move(metadataBuffer)));
+    }
   }
 }
 
@@ -503,37 +718,48 @@ void TabletReader::initOptionalSections() {
 
 std::vector<std::string> TabletReader::preloadSectionNames(
     const Options& options) const {
-  return options.preloadOptionalSections;
+  auto names = options.preloadOptionalSections;
+  if (options.loadDenseIndexes) {
+    names.emplace_back(kHashIndexSection);
+    names.emplace_back(kSortedIndexSection);
+  }
+  return names;
 }
 
 void TabletReader::preloadOptionalSections(
     const Options& options,
-    const SectionLoader& loader) {
+    std::string_view footerBuf,
+    uint64_t footerOffset) {
+  std::vector<EnqueuedSection> pending;
+  auto optionalSectionCache = optionalSectionsCache_.wlock();
   for (const auto& name : preloadSectionNames(options)) {
+    // Skip sections not present in this file (e.g., old files without
+    // chunk index, small files without stats).
     auto it = optionalSections_.find(name);
     if (it == optionalSections_.end()) {
       continue;
     }
-    optionalSectionsCache_.wlock()->insert({name, loader(it->second)});
+    const auto& section = it->second;
+    auto fromFooter =
+        tryExtractFromBuffer(footerBuf, footerOffset, section, pool_);
+    if (fromFooter != nullptr) {
+      optionalSectionCache->insert({name, std::move(fromFooter)});
+      continue;
+    }
+    pending.push_back(
+        {EnqueuedSection::Type::kOptionalSection,
+         name,
+         metadataInput_->enqueue(section)});
   }
-}
-
-TabletReader::SectionLoader TabletReader::makeSectionLoader(
-    const folly::IOBuf& footerIoBuf,
-    uint64_t footerIoOffset) const {
-  return
-      [this, &footerIoBuf, footerIoOffset](
-          const MetadataSection& section) -> std::unique_ptr<MetadataBuffer> {
-        if (section.offset() >= footerIoOffset) {
-          return std::make_unique<MetadataBuffer>(MetadataBuffer::decompress(
-              footerIoBuf,
-              section.offset() - footerIoOffset,
-              section.size(),
-              section.compressionType(),
-              pool_));
-        }
-        return readMetadata(section, velox::dwio::common::LogType::FILE);
-      };
+  if (!pending.empty()) {
+    MetadataInput::LoadGuard guard{metadataInput_.get()};
+    for (auto& entry : pending) {
+      auto buffer = entry.handle.read();
+      optionalSectionCache->insert(
+          {std::move(entry.name),
+           std::make_unique<MetadataBuffer>(std::move(*buffer))});
+    }
+  }
 }
 
 std::shared_ptr<TabletReader> TabletReader::create(
@@ -549,16 +775,16 @@ uint64_t TabletReader::calculateChecksum(
     velox::memory::MemoryPool& pool,
     velox::ReadFile* readFile,
     uint64_t chunkSize) {
-  const auto postscriptStart = readFile->size() - kPostscriptSize;
-  Vector<char> postscript(&pool, kPostscriptSize);
-  readFile->pread(postscriptStart, kPostscriptSize, postscript.data());
+  const auto postscriptStart = readFile->size() - Postscript::kSize;
+  Vector<char> postscript(&pool, Postscript::kSize);
+  readFile->pread(postscriptStart, Postscript::kSize, postscript.data());
   const ChecksumType checksumType = *reinterpret_cast<ChecksumType*>(
       postscript.data() + kPostscriptChecksumedSize);
 
   const auto checksum = ChecksumFactory::create(checksumType);
   Vector<char> buffer(&pool);
   uint64_t sizeToRead =
-      readFile->size() - kPostscriptSize + kPostscriptChecksumedSize;
+      readFile->size() - Postscript::kSize + kPostscriptChecksumedSize;
   uint64_t offset{0};
   while (sizeToRead > 0) {
     const auto sizeOneRead = std::min(chunkSize, sizeToRead);
@@ -628,138 +854,14 @@ uint32_t TabletReader::stripeGroupIndex(uint32_t stripeIndex) const {
   return stripesRoot(*stripes_)->group_indices()->Get(stripeIndex);
 }
 
-bool TabletReader::hasCache() const {
-  return metadataInput_ != nullptr && metadataInput_->hasCache();
-}
-
-bool TabletReader::tryLoadAndInitFooterFromCache() {
-  // Try to read footer+PS from cache at synthetic offset fileSize_.
-  // fileSize_ is a well-known key computable without any file IO.
-  auto cached = metadataInput_->findCachedRegion(fileSize_);
-  if (!cached.has_value()) {
-    return false;
-  }
-
-  // Warm path: parse PS + footer from cached data, zero file IO.
-  // Data layout: [footer | PS] (file's natural byte order).
-  const auto size = cached->size();
-  NIMBLE_CHECK_GE(size, kPostscriptSize, "Cached footer+PS entry too small");
-
-  // PS is only 20 bytes at the tail. The last range always covers it since
-  // cache pages are at least 4KB.
-  const auto& ranges = cached->ranges();
-  const auto& lastRange = ranges.back();
-  NIMBLE_CHECK_GE(
-      lastRange.size(),
-      kPostscriptSize,
-      "Last cache range too small to cover postscript");
-  ps_ = Postscript::parse(
-      std::string_view{
-          lastRange.data() + lastRange.size() - kPostscriptSize,
-          kPostscriptSize});
-  NIMBLE_CHECK_EQ(
-      ps_.footerSize() + kPostscriptSize,
-      size,
-      "Cached footer+PS size mismatch");
-
-  // Build footer MetadataBuffer from an IOBuf chain wrapping the cached
-  // ranges (zero-copy). MetadataBuffer copies from the IOBuf cursor
-  // internally — no intermediate contiguous copy needed.
-  footer_ = std::make_unique<MetadataBuffer>(MetadataBuffer::decompress(
-      cached->toIOBuf(),
-      0,
-      ps_.footerSize(),
-      ps_.footerCompressionType(),
-      pool_));
-  return true;
-}
-
-bool TabletReader::initFromCache(const Options& options) {
-  if (!hasCache()) {
-    return false;
-  }
-
-  if (!tryLoadAndInitFooterFromCache()) {
-    return false;
-  }
-  initOptionalSections();
-
-  loadStripesAndSections(options);
-
-  initStripes();
-  if (options.loadClusterIndex) {
-    initClusterIndex();
-  }
-  if (options.loadChunkIndex) {
-    initChunkIndex();
-  }
-  if (options.loadDenseIndexes) {
-    initDenseIndexes();
-  }
-  return true;
-}
-
-void TabletReader::loadStripesAndSections(const Options& options) {
-  // Enqueue all needed reads, then load once for coalesced IO.
-  auto enqueuedStripes = enqueueStripesSection();
-  if (!enqueuedStripes.has_value()) {
-    return;
-  }
-  auto enqueuedSections = enqueueOptionalSections(preloadSectionNames(options));
-
-  // Single load — BufferedInput coalesces adjacent regions.
-  metadataInput_->load(velox::dwio::common::LogType::FOOTER);
-
-  loadEnqueuedOptionalSections(std::move(enqueuedSections));
-
-  stripes_ = readMetadata(
-      std::move(enqueuedStripes->stream), enqueuedStripes->section);
-}
-
 std::unique_ptr<MetadataBuffer> TabletReader::readMetadata(
-    const MetadataSection& section,
-    velox::dwio::common::LogType logType) const {
-  if (metadataInput_ != nullptr) {
-    return readMetadata(
-        metadataInput_->read(section.offset(), section.size(), logType),
-        section);
-  }
-
-  // Direct file read path.
-  auto buffer =
-      velox::AlignedBuffer::allocateExact<char>(section.size(), pool_);
-  file_->pread(section.offset(), section.size(), buffer->asMutable<char>());
-  return std::make_unique<MetadataBuffer>(MetadataBuffer::decompress(
-      std::move(buffer), section.compressionType(), pool_));
-}
-
-std::unique_ptr<MetadataBuffer> TabletReader::readMetadata(
-    std::unique_ptr<velox::dwio::common::SeekableInputStream> stream,
     const MetadataSection& section) const {
-  const void* data{nullptr};
-  int32_t size{0};
-  // Try zero-copy: get contiguous data from stream.
-  if (stream->Next(&data, &size) &&
-      static_cast<uint64_t>(size) >= section.size()) {
-    auto buffer =
-        velox::AlignedBuffer::allocateExact<char>(section.size(), pool_);
-    std::memcpy(
-        buffer->asMutable<char>(),
-        static_cast<const char*>(data),
-        section.size());
-    return std::make_unique<MetadataBuffer>(MetadataBuffer::decompress(
-        std::move(buffer), section.compressionType(), pool_));
-  }
-
-  // Data is fragmented — copy into contiguous buffer.
-  if (size > 0) {
-    stream->BackUp(size);
-  }
-  auto buffer =
-      velox::AlignedBuffer::allocateExact<char>(section.size(), pool_);
-  stream->readFully(buffer->asMutable<char>(), section.size());
-  return std::make_unique<MetadataBuffer>(MetadataBuffer::decompress(
-      std::move(buffer), section.compressionType(), pool_));
+  NIMBLE_CHECK_GT(section.size(), 0, "Metadata section size must be non-zero");
+  std::lock_guard<std::mutex> lock(metadataInputMutex_);
+  auto handle = metadataInput_->enqueue(section);
+  MetadataInput::LoadGuard guard{metadataInput_.get()};
+  auto result = handle.read();
+  return std::make_unique<MetadataBuffer>(std::move(*result));
 }
 
 std::shared_ptr<StripeGroup> TabletReader::loadStripeGroup(
@@ -769,9 +871,7 @@ std::shared_ptr<StripeGroup> TabletReader::loadStripeGroup(
 
   const auto section = toMetadataSection(stripeGroupInfo);
   return std::make_shared<StripeGroup>(
-      stripeGroupIndex,
-      *stripes_,
-      readMetadata(section, velox::dwio::common::LogType::GROUP));
+      stripeGroupIndex, *stripes_, readMetadata(section));
 }
 
 std::shared_ptr<StripeGroup> TabletReader::stripeGroup(
@@ -790,39 +890,24 @@ TabletReader::StripeGroupMetadata TabletReader::loadStripeGroupMetadata(
   std::unique_ptr<MetadataBuffer> groupMetadata;
   std::unique_ptr<MetadataBuffer> chunkIndexMetadata;
 
-  if (metadataInput_ != nullptr) {
-    // Use enqueue/load pattern for coalesced IO. BufferedInput will coalesce
-    // adjacent regions into a single read when possible.
-    auto groupStream = metadataInput_->enqueue(
-        {groupSection.offset(), groupSection.size(), "stripe_group"});
+  {
+    std::lock_guard<std::mutex> lock(metadataInputMutex_);
+    auto groupHandle = metadataInput_->enqueue(groupSection);
 
-    std::unique_ptr<velox::dwio::common::SeekableInputStream> chunkIndexStream;
-    MetadataSection chunkIndexSection;
+    std::optional<MetadataHandle> chunkIndexHandle;
     if (hasChunkIndex) {
-      chunkIndexSection = chunkIndex_->groupMetadata(stripeGroupIndex);
-      chunkIndexStream = metadataInput_->enqueue(
-          {chunkIndexSection.offset(),
-           chunkIndexSection.size(),
-           "chunk_index_group"});
+      chunkIndexHandle.emplace(metadataInput_->enqueue(
+          chunkIndex_->groupMetadata(stripeGroupIndex)));
     }
 
-    // Single load() call - BufferedInput coalesces adjacent regions.
-    metadataInput_->load(velox::dwio::common::LogType::GROUP);
+    MetadataInput::LoadGuard guard{metadataInput_.get()};
 
-    groupMetadata = readMetadata(std::move(groupStream), groupSection);
+    auto groupShared = groupHandle.read();
+    groupMetadata = std::make_unique<MetadataBuffer>(std::move(*groupShared));
     if (hasChunkIndex) {
+      auto chunkShared = chunkIndexHandle->read();
       chunkIndexMetadata =
-          readMetadata(std::move(chunkIndexStream), chunkIndexSection);
-    }
-  } else {
-    // Fall back to separate direct file reads.
-    groupMetadata =
-        readMetadata(groupSection, velox::dwio::common::LogType::GROUP);
-    if (hasChunkIndex) {
-      const auto& chunkIndexSection =
-          chunkIndex_->groupMetadata(stripeGroupIndex);
-      chunkIndexMetadata = readMetadata(
-          chunkIndexSection, velox::dwio::common::LogType::GROUP_INDEX);
+          std::make_unique<MetadataBuffer>(std::move(*chunkShared));
     }
   }
 
@@ -1043,8 +1128,11 @@ std::optional<Section> TabletReader::loadOptionalSection(
       }
     }
   }
-  return Section{
-      std::move(*readMetadata(it->second, velox::dwio::common::LogType::FILE))};
+  if (it->second.size() == 0) {
+    return Section{
+        MetadataBuffer{velox::AlignedBuffer::allocate<char>(0, pool_)}};
+  }
+  return Section{std::move(*readMetadata(it->second))};
 }
 
 bool TabletReader::hasChunkIndexSection() const {
@@ -1056,6 +1144,9 @@ bool TabletReader::hasClusterIndexSection() const {
 }
 
 void TabletReader::initClusterIndex() {
+  if (!loadClusterIndex_) {
+    return;
+  }
   NIMBLE_CHECK_NULL(clusterIndex_, "Index already initialized.");
 
   if (!hasClusterIndexSection()) {
@@ -1067,29 +1158,7 @@ void TabletReader::initClusterIndex() {
   NIMBLE_CHECK(indexSection.has_value(), "Failed to load index section.");
 
   clusterIndex_ = ClusterIndex::create(
-      std::move(indexSection.value()),
-      [this](const MetadataSection& section) {
-        return readMetadata(section, velox::dwio::common::LogType::GROUP_INDEX);
-      },
-      [this](const velox::common::Region& region)
-          -> std::unique_ptr<velox::dwio::common::SeekableInputStream> {
-        if (metadataInput_ != nullptr) {
-          return metadataInput_->read(
-              region.offset,
-              region.length,
-              velox::dwio::common::LogType::GROUP_INDEX);
-        }
-        // Fall back to direct file read when no BufferedInput is available.
-        auto input =
-            std::make_shared<velox::dwio::common::ReadFileInputStream>(file_);
-        return std::make_unique<velox::dwio::common::SeekableFileInputStream>(
-            std::move(input),
-            region.offset,
-            region.length,
-            *pool_,
-            velox::dwio::common::LogType::GROUP_INDEX);
-      },
-      pool_);
+      std::move(indexSection.value()), pool_, indexOptions_);
 }
 
 const index::IndexLookup* TabletReader::denseIndex(
@@ -1101,210 +1170,23 @@ const index::IndexLookup* TabletReader::denseIndex(
 }
 
 void TabletReader::initDenseIndexes() {
-  auto loadMetadataFn = [this](const MetadataSection& metadataSection) {
-    return readMetadata(metadataSection, velox::dwio::common::LogType::FOOTER);
-  };
-
-  auto loadDataFn = [this](const velox::common::Region& region)
-      -> std::unique_ptr<velox::dwio::common::SeekableInputStream> {
-    if (metadataInput_ != nullptr) {
-      return metadataInput_->read(
-          region.offset, region.length, velox::dwio::common::LogType::FOOTER);
-    }
-    auto input =
-        std::make_shared<velox::dwio::common::ReadFileInputStream>(file_);
-    return std::make_unique<velox::dwio::common::SeekableFileInputStream>(
-        std::move(input),
-        region.offset,
-        region.length,
-        *pool_,
-        velox::dwio::common::LogType::FOOTER);
-  };
-
+  if (!loadDenseIndexes_) {
+    return;
+  }
   denseIndexRegistry_ = DenseIndexRegistry::create(
       loadOptionalSection(std::string{kHashIndexSection}, /*keepCache=*/false),
       loadOptionalSection(
           std::string{kSortedIndexSection}, /*keepCache=*/false),
-      loadMetadataFn,
-      std::move(loadDataFn),
+      indexOptions_,
       pool_);
 }
 
-void TabletReader::preloadStripeGroup(const folly::IOBuf& footerIoBuf) {
-  NIMBLE_CHECK_NOT_NULL(stripes_);
-
-  const auto* footer = footerRoot(*footer_);
-  const auto* stripes = stripesRoot(*stripes_);
-  auto* stripeGroups = footer->stripe_groups();
-  NIMBLE_CHECK_NOT_NULL(stripeGroups, "Stripe groups is null.");
-  NIMBLE_CHECK_EQ(
-      stripeGroups->size(),
-      *stripes->group_indices()->rbegin() + 1,
-      "Unexpected stripe group count");
-
-  // Eagerly pin the first stripe group if it's already in the footer buffer.
-  if (stripeGroups->size() == 1) {
-    auto metadataBuffer = tryCreateMetadataBufferFromFooter(
-        *pool_,
-        footerIoBuf,
-        fileSize_,
-        toMetadataSection(stripeGroups->Get(0)));
-    if (metadataBuffer != nullptr) {
-      stripeGroupCache_.pin(
-          0,
-          std::make_shared<StripeGroup>(
-              0, *stripes_, std::move(metadataBuffer)));
-    }
-  }
-}
-
-void TabletReader::preloadChunkIndex(const folly::IOBuf& footerIoBuf) {
-  if (chunkIndex_ == nullptr) {
+void TabletReader::initChunkIndex(
+    std::string_view footerBuf,
+    uint64_t footerOffset) {
+  if (!loadChunkIndex_) {
     return;
   }
-  NIMBLE_CHECK_GT(chunkIndex_->numGroups(), 0);
-
-  // Eagerly pin the first chunk index group if it's already in the footer
-  // buffer.
-  const auto& chunkIndexGroupMetadata = chunkIndex_->groupMetadata(0);
-  if (chunkIndexGroupMetadata.size() == 0) {
-    return;
-  }
-
-  if (chunkIndex_->numGroups() == 1) {
-    auto metadataBuffer = tryCreateMetadataBufferFromFooter(
-        *pool_, footerIoBuf, fileSize_, chunkIndexGroupMetadata);
-    if (metadataBuffer != nullptr) {
-      chunkIndexCache_.pin(
-          0,
-          ChunkIndexGroup::create(
-              firstStripe(0), stripeCount(0), std::move(metadataBuffer)));
-    }
-  }
-}
-
-std::vector<TabletReader::EnqueuedSection>
-TabletReader::enqueueOptionalSections(
-    const std::vector<std::string>& sectionNames) {
-  std::vector<EnqueuedSection> enqueuedSections;
-  for (const auto& name : sectionNames) {
-    auto it = optionalSections_.find(name);
-    if (it == optionalSections_.end()) {
-      continue;
-    }
-    enqueuedSections.push_back(
-        {name,
-         it->second,
-         metadataInput_->enqueue(
-             {it->second.offset(), it->second.size(), "optional"})});
-  }
-  return enqueuedSections;
-}
-
-void TabletReader::loadEnqueuedOptionalSections(
-    std::vector<EnqueuedSection>&& sections) {
-  auto cache = optionalSectionsCache_.wlock();
-  for (auto& entry : sections) {
-    cache->insert(
-        {entry.name, readMetadata(std::move(entry.stream), entry.section)});
-  }
-}
-
-std::optional<TabletReader::EnqueuedSection>
-TabletReader::enqueueStripesSection() {
-  const auto* footer = footerRoot(*footer_);
-  auto* stripesSection = footer->stripes();
-  if (stripesSection == nullptr) {
-    NIMBLE_CHECK_EQ(footer->row_count(), 0);
-    return std::nullopt;
-  }
-  NIMBLE_CHECK_GT(footer->row_count(), 0);
-  NIMBLE_CHECK_NOT_NULL(metadataInput_);
-  const auto section = toMetadataSection(stripesSection);
-  return EnqueuedSection{
-      "stripes",
-      section,
-      metadataInput_->enqueue({section.offset(), section.size(), "stripes"})};
-}
-
-void TabletReader::cacheMetadata(
-    const folly::IOBuf& footerIoBuf,
-    uint64_t footerIoOffset) {
-  if (!hasCache()) {
-    return;
-  }
-
-  const auto footerIoSize = footerIoBuf.computeChainDataLength();
-
-  // Extracts a region from the IOBuf and caches it without coalescing.
-  // Regions outside the buffer are silently skipped. cacheOffset overrides the
-  // region offset as the cache key — used for footer+PS which is cached at
-  // synthetic key fileSize_ (computable without file IO).
-  auto extract = [&](uint64_t regionOffset,
-                     uint64_t regionSize,
-                     std::optional<uint64_t> cacheOffset = std::nullopt) {
-    if (regionOffset < footerIoOffset) {
-      return;
-    }
-    const uint64_t ioBufOffset = regionOffset - footerIoOffset;
-    if (ioBufOffset + regionSize > footerIoSize) {
-      return;
-    }
-    metadataInput_->cacheRegion(
-        cacheOffset.value_or(regionOffset),
-        regionSize,
-        footerIoBuf,
-        ioBufOffset);
-  };
-
-  // Cache footer+PS at synthetic offset fileSize_ (beyond EOF). This lets
-  // tryLoadAndInitFooterFromCache probe the cache using only the file size
-  // (known without any IO), avoiding the circular dependency of needing
-  // footerSize (from the postscript) to compute the real offset.
-  const uint64_t footerPsSize = ps_.footerSize() + kPostscriptSize;
-  extract(fileSize_ - footerPsSize, footerPsSize, fileSize_);
-
-  const auto* footer = footerRoot(*footer_);
-
-  // Cache stripes section.
-  if (auto* stripesSection = footer->stripes()) {
-    extract(stripesSection->offset(), stripesSection->size());
-  }
-
-  // Cache first stripe group.
-  if (auto* stripeGroups = footer->stripe_groups();
-      stripeGroups != nullptr && stripeGroups->size() > 0) {
-    auto* stripeGroup = stripeGroups->Get(0);
-    extract(stripeGroup->offset(), stripeGroup->size());
-  }
-
-  // Cache cluster index section.
-  if (clusterIndex_ != nullptr) {
-    auto clusterIndexIt =
-        optionalSections_.find(std::string{kClusterIndexSection});
-    NIMBLE_CHECK(clusterIndexIt != optionalSections_.end());
-    extract(clusterIndexIt->second.offset(), clusterIndexIt->second.size());
-
-    // Cache first partition index metadata.
-    const auto partitionIndexSection = clusterIndex_->partitionSection(0);
-    extract(partitionIndexSection.offset(), partitionIndexSection.size());
-  }
-
-  // Cache chunk index section.
-  if (chunkIndex_ != nullptr) {
-    auto chunkIndexIt = optionalSections_.find(std::string{kChunkIndexSection});
-    NIMBLE_CHECK(chunkIndexIt != optionalSections_.end());
-    extract(chunkIndexIt->second.offset(), chunkIndexIt->second.size());
-
-    // Cache first chunk index group.
-    const auto& firstSection = chunkIndex_->groupMetadata(0);
-    if (firstSection.size() > 0) {
-      extract(firstSection.offset(), firstSection.size());
-    }
-  }
-}
-
-void TabletReader::initChunkIndex() {
   if (!hasChunkIndexSection()) {
     return;
   }
@@ -1316,6 +1198,22 @@ void TabletReader::initChunkIndex() {
   auto chunkIndex = ChunkIndex::create(std::move(section.value()));
   if (chunkIndex->numGroups() > 0) {
     chunkIndex_ = std::move(chunkIndex);
+  }
+
+  // Eagerly pin the first chunk index group if covered by the speculative
+  // buffer.
+  if (chunkIndex_ != nullptr && chunkIndex_->numGroups() == 1) {
+    const auto& groupMetadata = chunkIndex_->groupMetadata(0);
+    if (groupMetadata.size() > 0) {
+      auto metadataBuffer =
+          tryExtractFromBuffer(footerBuf, footerOffset, groupMetadata, pool_);
+      if (metadataBuffer != nullptr) {
+        chunkIndexCache_.pin(
+            0,
+            ChunkIndexGroup::create(
+                firstStripe(0), stripeCount(0), std::move(metadataBuffer)));
+      }
+    }
   }
 }
 
@@ -1386,7 +1284,7 @@ std::shared_ptr<ChunkIndexGroup> TabletReader::loadChunkIndexGroup(
   return ChunkIndexGroup::create(
       this->firstStripe(stripeGroupIndex),
       this->stripeCount(stripeGroupIndex),
-      readMetadata(section, velox::dwio::common::LogType::GROUP_INDEX));
+      readMetadata(section));
 }
 
 } // namespace facebook::nimble

--- a/dwio/nimble/tablet/TabletReader.h
+++ b/dwio/nimble/tablet/TabletReader.h
@@ -31,15 +31,13 @@
 #include "dwio/nimble/tablet/FileLayout.h"
 #include "dwio/nimble/tablet/MetadataBuffer.h"
 #include "dwio/nimble/tablet/MetadataCache.h"
+#include "dwio/nimble/tablet/MetadataInput.h"
 #include "folly/Synchronized.h"
+#include "velox/common/caching/FileHandle.h"
 #include "velox/common/file/File.h"
+#include "velox/common/io/Options.h"
 #include "velox/dwio/common/MetricsLog.h"
 #include "velox/dwio/common/Options.h"
-
-namespace facebook::velox::dwio::common {
-class BufferedInput;
-class SeekableInputStream;
-} // namespace facebook::velox::dwio::common
 
 /// The TabletReader class is the on-disk layout for nimble.
 ///
@@ -170,18 +168,30 @@ class TabletReader {
     /// Whether to load the dense indexes during initialization. Default true.
     bool loadDenseIndexes{true};
 
-    /// Non-owning pointer to a BufferedInput for metadata reads. When set,
-    /// TabletReader clones this internally for its own metadata IO. When
-    /// pinFileMetadata is enabled with a CachedBufferedInput, a
-    /// non-cacheable clone is created so AsyncDataCache does not retain raw
-    /// metadata bytes (MetadataCache already pins parsed objects).
-    velox::dwio::common::BufferedInput* bufferedInput{nullptr};
-
     /// If true, pins parsed metadata objects (StripeGroup, ChunkIndexGroup)
     /// in the cache with strong references so they are never evicted. This
     /// avoids re-reading and re-parsing metadata on every stripe access when
     /// the weak-pointer cache entries would otherwise expire.
     bool pinFileMetadata{false};
+
+    /// IO options providing pool, IO stats, coalescing params, and executor.
+    /// When not set, a default is created internally from the provided pool.
+    std::optional<velox::io::ReaderOptions> ioOptions;
+
+    /// File handle and cache for CachedMetadataInput. Both must be set
+    /// together. When set, creates CachedMetadataInput using
+    /// fileHandle->uuid as cache key. When neither is set, creates
+    /// DirectMetadataInput.
+    ///
+    /// FileHandle contains:
+    ///   - file: shared_ptr<ReadFile> for IO
+    ///   - uuid: StringIdLease used as identifier in downstream data
+    ///     caching structures (saves memory vs using filename)
+    ///   - groupId: StringIdLease for the group of files this belongs to
+    ///     (e.g. directory), used for coarse granularity access tracking
+    ///     such as deciding SSD placement
+    const velox::FileHandle* fileHandle{nullptr};
+    velox::cache::AsyncDataCache* cache{nullptr};
   };
 
   /// Compute checksum from the beginning of the file all the way to footer
@@ -199,11 +209,8 @@ class TabletReader {
       const Options& options);
 
   /// Configures TabletReader::Options from Velox ReaderOptions.
-  /// @param bufferedInput Optional BufferedInput pointer to set on the
-  ///        returned Options for metadata reads.
   static Options configureOptions(
-      const velox::dwio::common::ReaderOptions& options,
-      velox::dwio::common::BufferedInput* bufferedInput = nullptr);
+      const velox::dwio::common::ReaderOptions& options);
 
   /// Returns a collection of stream loaders for the given stripe. The stream
   /// loaders are returned in the same order as the input stream identifiers
@@ -351,57 +358,77 @@ class TabletReader {
 
   void init(const Options& options);
 
-  // Cache init path.
-  //
-  // Returns true if this reader is backed by a BufferedInput with Velox
-  // async data cache.
-  bool hasCache() const;
-
-  // Tries to initialize entirely from Velox async data cache (zero file IO).
-  // Probes the cache for footer+PS at synthetic offset fileSize, parses PS and
-  // footer, then loads all remaining metadata via cache hits. Returns true on
-  // success, false on cache miss (caller falls through to cold path).
+  // Tries to initialize entirely from cache. Returns true if successful
+  // (all metadata loaded from cache, no file IO needed).
   bool initFromCache(const Options& options);
 
-  // Tries to parse PS and footer from cached footer+PS entry at synthetic
-  // offset fileSize. Returns true on cache hit, false on miss.
-  bool tryLoadAndInitFooterFromCache();
+  // Tries to load footer+PS from cache at synthetic key fileSize_.
+  bool loadFooterFromCache();
 
-  // Populates AsyncDataCache with exact-size metadata entries from the
-  // speculative tail read IOBuf. Enables zero-IO init for subsequent readers.
-  // No-op if there is no cache.
-  void cacheMetadata(const folly::IOBuf& footerIoBuf, uint64_t footerIoOffset);
+  // Caches metadata sections from the speculative read buffer into
+  // CachedMetadataInput for subsequent opens.
+  void cacheMetadata(std::string_view footerBuf, uint64_t footerOffset);
 
-  // Footer/postscript parsing.
-  //
-  // Parses the postscript from the last kPostscriptSize bytes of footerIoBuf.
-  void initPostScript(const folly::IOBuf& footerIoBuf, uint64_t footerIoSize);
-
-  // Parses the footer from footerIoBuf using the already-parsed postscript.
-  void initFooter(const folly::IOBuf& footerIoBuf, uint64_t footerIoSize);
-
-  // Reads and parses both postscript and footer from file. Supports two modes:
-  // - Adaptive (maxFooterIoBytes=0): reads postscript first, then exact footer.
-  // - Speculative: reads maxFooterIoBytes, re-reads if footer is larger.
-  void loadAndInitFooter(
+  // Reads postscript and footer via MetadataInput. For speculative mode,
+  // also does a speculative read into footerBuf for downstream preload.
+  void loadFooter(
       uint64_t maxFooterIoBytes,
-      folly::IOBuf& footerIoBuf,
+      velox::BufferPtr& footerBuf,
       uint64_t& footerIoSize,
-      uint64_t& footerIoOffset);
+      uint64_t& footerOffset);
 
   // Stripes.
   //
-  // Loads stripes_ from the footerIoBuf. Handles both single-read and re-read
-  // cases when the speculative read didn't capture the full stripes section.
+  // Loads stripes_ from the speculative read buffer, falling back to
+  // MetadataInput when the buffer doesn't cover the stripes section.
   void loadStripes(
-      folly::IOBuf& footerIoBuf,
+      velox::BufferPtr& footerBuf,
       uint64_t& footerIoSize,
-      uint64_t& footerIoOffset,
+      uint64_t& footerOffset,
       const Options& options);
 
-  // Parses stripes_ to populate stripe metadata (counts, offsets, etc.).
-  // Used by test init path.
-  void initStripes();
+  // Tracks a section enqueued to MetadataInput for batched coalesced loading.
+  struct EnqueuedSection {
+    enum class Type { kStripes, kOptionalSection };
+
+    Type type;
+    std::string name;
+    MetadataHandle handle{nullptr, 0};
+  };
+
+  // Enqueues the stripes section for coalesced loading via MetadataInput.
+  // Tries to extract from footerBuf first; enqueues to MetadataInput on miss.
+  void enqueueStripesSection(
+      std::string_view footerBuf,
+      uint64_t footerOffset,
+      std::vector<EnqueuedSection>& enqueued);
+
+  void enqueueStripesSection(std::vector<EnqueuedSection>& enqueued) {
+    enqueueStripesSection({}, 0, enqueued);
+  }
+
+  // Enqueues optional sections for coalesced loading via MetadataInput.
+  // Tries to extract from footerBuf first; enqueues to MetadataInput on miss.
+  // Skips sections not present in this file.
+  void enqueueOptionalSections(
+      const Options& options,
+      std::string_view footerBuf,
+      uint64_t footerOffset,
+      std::vector<EnqueuedSection>& enqueued);
+
+  void enqueueOptionalSections(
+      const Options& options,
+      std::vector<EnqueuedSection>& enqueued) {
+    enqueueOptionalSections(options, {}, 0, enqueued);
+  }
+
+  // Loads all enqueued sections via MetadataInput and stores results:
+  // stripes go to stripes_, optional sections go to optionalSectionsCache_.
+  void loadEnqueuedSections(std::vector<EnqueuedSection>& enqueued);
+
+  // Parses stripes_ to populate stripe metadata and preloads the first
+  // stripe group from footerBuf when available.
+  void initStripes(std::string_view footerBuf = {}, uint64_t footerOffset = 0);
 
   // Stripe groups.
   //
@@ -410,10 +437,6 @@ class TabletReader {
   std::shared_ptr<StripeGroup> stripeGroup(uint32_t stripeGroupIndex) const;
 
   std::shared_ptr<StripeGroup> loadStripeGroup(uint32_t stripeGroupIndex) const;
-
-  // Eagerly pins the first stripe group if it's already in the footer IOBuf.
-  // Pinning saves deserialization cost on subsequent accesses.
-  void preloadStripeGroup(const folly::IOBuf& footerIoBuf);
 
   // Index.
   //
@@ -425,9 +448,8 @@ class TabletReader {
     std::shared_ptr<ChunkIndexGroup> chunkIndex;
   };
 
-  // Loads stripe group, cluster index group, and chunk index together using
-  // coalesced IO when BufferedInput is available. Falls back to separate loads
-  // otherwise.
+  // Loads stripe group and chunk index together using coalesced IO via
+  // MetadataInput.
   StripeGroupMetadata loadStripeGroupMetadata(uint32_t stripeGroupIndex) const;
 
   // Optional sections.
@@ -439,67 +461,25 @@ class TabletReader {
   // sections plus the index section if present.
   std::vector<std::string> preloadSectionNames(const Options& options) const;
 
-  // Preloads optional sections into optionalSectionsCache_ using the provided
-  // loader callback to read each section.
-  using SectionLoader = std::function<std::unique_ptr<MetadataBuffer>(
-      const MetadataSection& section)>;
+  // Preloads optional sections into optionalSectionsCache_. Tries to
+  // extract from the speculative read buffer first, then batches remaining
+  // sections through MetadataInput.
   void preloadOptionalSections(
       const Options& options,
-      const SectionLoader& loader);
+      std::string_view footerBuf,
+      uint64_t footerOffset);
 
-  // Creates a SectionLoader that tries to extract from footerIoBuf first
-  // (for sections at offset >= footerIoOffset), falling back to readMetadata.
-  SectionLoader makeSectionLoader(
-      const folly::IOBuf& footerIoBuf,
-      uint64_t footerIoOffset) const;
-
-  // BufferedInput coalesced IO.
-  //
-  // Holds a section enqueued for coalesced IO via BufferedInput.
-  // After metadataBufferedInput_->load(), the stream can be read to get section
-  // data.
-  struct EnqueuedSection {
-    std::string name;
-    MetadataSection section;
-    std::unique_ptr<velox::dwio::common::SeekableInputStream> stream;
-  };
-
-  // Loads stripes and optional sections via BufferedInput's enqueue/load
-  // pattern for coalesced IO. Populates stripes_ and optionalSectionsCache_.
-  // No-op for empty files (no stripes). Caller must call initStripes() after.
-  void loadStripesAndSections(const Options& options);
-
-  // Enqueues a read for the stripes section via BufferedInput. Returns nullopt
-  // if no stripes (empty file). Caller must call metadataBufferedInput_->load()
-  // after.
-  std::optional<EnqueuedSection> enqueueStripesSection();
-
-  // Enqueues reads for the given optional section names via BufferedInput.
-  // Skips names not found in optionalSections_. Caller must call
-  // metadataBufferedInput_->load() after this to execute the coalesced IO.
-  std::vector<EnqueuedSection> enqueueOptionalSections(
-      const std::vector<std::string>& sectionNames);
-
-  // Reads enqueued sections and inserts them into optionalSectionsCache_.
-  // Must be called after metadataBufferedInput_->load().
-  void loadEnqueuedOptionalSections(std::vector<EnqueuedSection>&& sections);
-
-  // Low-level IO.
-  //
-  // Reads metadata from a MetadataSection (offset + size + compressionType).
-  // Uses BufferedInput when available, otherwise reads directly from file.
+  // Reads and decompresses a metadata section via MetadataInput.
   std::unique_ptr<MetadataBuffer> readMetadata(
-      const MetadataSection& section,
-      velox::dwio::common::LogType logType) const;
-
-  // Reads metadata from a pre-loaded stream (e.g. from enqueue/load pattern).
-  std::unique_ptr<MetadataBuffer> readMetadata(
-      std::unique_ptr<velox::dwio::common::SeekableInputStream> stream,
       const MetadataSection& section) const;
 
   void initDenseIndexes();
 
-  void initChunkIndex();
+  // Loads chunk index and preloads the first group from footerBuf
+  // when available.
+  void initChunkIndex(
+      std::string_view footerBuf = {},
+      uint64_t footerOffset = 0);
 
   // Returns the cached ChunkIndexGroup for the given stripe group index.
   std::shared_ptr<ChunkIndexGroup> chunkIndex(uint32_t stripeGroupIndex) const;
@@ -507,10 +487,6 @@ class TabletReader {
   // Loads the ChunkIndexGroup for the given stripe group index from file.
   std::shared_ptr<ChunkIndexGroup> loadChunkIndexGroup(
       uint32_t stripeGroupIndex) const;
-
-  // Eagerly pins the first chunk index group if it's already in the footer
-  // IOBuf. Pinning saves deserialization cost on subsequent accesses.
-  void preloadChunkIndex(const folly::IOBuf& footerIoBuf);
 
   // Computes first stripe index for the given stripe group.
   uint32_t firstStripe(uint32_t stripeGroupIndex) const;
@@ -520,10 +496,22 @@ class TabletReader {
 
   MemoryPool* const pool_;
   const std::shared_ptr<velox::ReadFile> file_;
-  // Owned BufferedInput clone for metadata reads. Created by cloning
-  // options.bufferedInput during construction. When pinFileMetadata is
-  // enabled with CachedBufferedInput, uses a non-cacheable clone.
-  const std::unique_ptr<velox::dwio::common::BufferedInput> metadataInput_;
+  const bool loadClusterIndex_;
+  const bool loadChunkIndex_;
+  const bool loadDenseIndexes_;
+  // Default IO stats when caller doesn't provide ioOptions.
+  const std::unique_ptr<velox::io::IoStatistics> defaultIoStats_;
+  // Resolved IO options — either copied from Options or created with defaults.
+  const velox::io::ReaderOptions ioOptions_;
+  // IO config for index creation — indexes create their own MetadataInput
+  // with index-specific IO stats.
+  const index::IndexLookup::Options indexOptions_;
+
+  // Owned MetadataInput for coalesced metadata IO. Always created —
+  // uses DirectMetadataInput (no cache) or CachedMetadataInput depending
+  // on options.
+  const std::unique_ptr<MetadataInput> metadataInput_;
+  mutable std::mutex metadataInputMutex_;
 
   uint64_t fileSize_{0};
   Postscript ps_;

--- a/dwio/nimble/tablet/tests/MetadataBufferTest.cpp
+++ b/dwio/nimble/tablet/tests/MetadataBufferTest.cpp
@@ -21,7 +21,6 @@
 #include "dwio/nimble/common/Exceptions.h"
 #include "dwio/nimble/common/tests/GTestUtils.h"
 #include "dwio/nimble/tablet/Compression.h"
-#include "folly/io/IOBuf.h"
 #include "velox/common/caching/AsyncDataCache.h"
 #include "velox/common/caching/FileIds.h"
 #include "velox/common/caching/SsdCache.h"
@@ -123,23 +122,17 @@ TEST_F(MetadataBufferTest, decompressBufferPtr) {
   }
 }
 
-TEST_F(MetadataBufferTest, decompressIOBuf) {
+TEST_F(MetadataBufferTest, decompressStringView) {
   struct TestParam {
     std::string inputData;
     nimble::CompressionType compressionType;
     bool compressible;
-    std::string prefix;
-    std::string suffix;
-    bool chained;
     std::string debugString() const {
       return fmt::format(
-          "size {}, compressionType {}, compressible {}, prefix '{}', suffix '{}', chained {}",
+          "size {}, compressionType {}, compressible {}",
           inputData.size(),
           static_cast<int>(compressionType),
-          compressible,
-          prefix,
-          suffix,
-          chained);
+          compressible);
     }
   };
   std::vector<TestParam> testSettings;
@@ -150,17 +143,7 @@ TEST_F(MetadataBufferTest, decompressIOBuf) {
       const bool compressible =
           compressionType == nimble::CompressionType::Uncompressed ||
           nimble::ZstdCompression::compress(inputData, pool_.get()).has_value();
-      for (bool withOffset : {false, true}) {
-        for (bool chained : {false, true}) {
-          testSettings.push_back(
-              {inputData,
-               compressionType,
-               compressible,
-               withOffset ? "PREFIX" : "",
-               withOffset ? "SUFFIX" : "",
-               chained});
-        }
-      }
+      testSettings.push_back({inputData, compressionType, compressible});
     }
   }
   for (const auto& testData : testSettings) {
@@ -184,24 +167,9 @@ TEST_F(MetadataBufferTest, decompressIOBuf) {
       rawData = testData.inputData;
     }
 
-    const auto offset = testData.prefix.size();
-    const auto length = rawData.size();
-    const std::string fullData = testData.prefix + rawData + testData.suffix;
-
-    std::unique_ptr<folly::IOBuf> iobuf;
-    if (testData.chained && fullData.size() >= 2) {
-      const auto mid = fullData.size() / 2;
-      iobuf = folly::IOBuf::copyBuffer(fullData.data(), mid);
-      iobuf->appendToChain(
-          folly::IOBuf::copyBuffer(
-              fullData.data() + mid, fullData.size() - mid));
-    } else {
-      iobuf = folly::IOBuf::copyBuffer(fullData);
-    }
-
     nimble::MetadataBuffer buffer(
         nimble::MetadataBuffer::decompress(
-            *iobuf, offset, length, testData.compressionType, pool_.get()));
+            rawData, testData.compressionType, pool_.get()));
 
     auto content = buffer.content();
     EXPECT_EQ(content, testData.inputData);

--- a/dwio/nimble/tablet/tests/MetadataInputTest.cpp
+++ b/dwio/nimble/tablet/tests/MetadataInputTest.cpp
@@ -25,6 +25,7 @@
 #include "velox/common/base/CoalesceIo.h"
 #include "velox/common/base/tests/GTestUtils.h"
 #include "velox/common/caching/AsyncDataCache.h"
+#include "velox/common/caching/FileHandle.h"
 #include "velox/common/caching/FileIds.h"
 #include "velox/common/caching/SsdCache.h"
 #include "velox/common/caching/SsdFile.h"
@@ -38,6 +39,9 @@
 #include "velox/common/testutil/TestValue.h"
 
 #include "folly/executors/IOThreadPoolExecutor.h"
+#include "folly/synchronization/Baton.h"
+
+#include <thread>
 
 using namespace facebook;
 
@@ -237,21 +241,21 @@ TEST_F(DirectMetadataInputTest, enqueueLoadRead) {
     auto readFile = std::make_shared<velox::InMemoryReadFile>(fileContent);
 
     const auto options = makeReaderOptions();
-    nimble::DirectMetadataInput input(readFile.get(), pool_.get(), options);
-    nimble::test::MetadataInputTestHelper helper(&input);
+    auto input = nimble::MetadataInput::create(readFile.get(), options);
+    nimble::test::MetadataInputTestHelper helper(input.get());
 
     EXPECT_FALSE(helper.testingLoaded());
     EXPECT_EQ(helper.testingSectionCount(), 0);
 
     std::vector<nimble::MetadataHandle> handles;
     for (uint32_t i = 0; i < sections.size(); ++i) {
-      handles.push_back(input.enqueue(sections[i]));
+      handles.push_back(input->enqueue(sections[i]));
       EXPECT_EQ(helper.testingSectionCount(), i + 1);
       EXPECT_FALSE(helper.testingHasBuffer(i));
     }
     EXPECT_FALSE(helper.testingLoaded());
 
-    input.load();
+    input->load();
     EXPECT_TRUE(helper.testingLoaded());
     for (uint32_t i = 0; i < sections.size(); ++i) {
       EXPECT_TRUE(helper.testingHasBuffer(i));
@@ -289,12 +293,12 @@ TEST_F(DirectMetadataInputTest, reverseEnqueueOrder) {
   auto readFile = std::make_shared<velox::InMemoryReadFile>(fileContent);
 
   const auto options = makeReaderOptions();
-  nimble::DirectMetadataInput input(readFile.get(), pool_.get(), options);
+  auto input = nimble::MetadataInput::create(readFile.get(), options);
 
   // Enqueue in reverse file order — should still work.
-  auto handle1 = input.enqueue(section1);
-  auto handle0 = input.enqueue(section0);
-  input.load();
+  auto handle1 = input->enqueue(section1);
+  auto handle0 = input->enqueue(section0);
+  input->load();
 
   EXPECT_EQ(handle0.read()->content(), data0);
   EXPECT_EQ(handle1.read()->content(), data1);
@@ -311,15 +315,15 @@ TEST_F(DirectMetadataInputTest, stateTransitions) {
   auto readFile = std::make_shared<velox::InMemoryReadFile>(fileContent);
 
   const auto options = makeReaderOptions();
-  nimble::DirectMetadataInput input(readFile.get(), pool_.get(), options);
-  nimble::test::MetadataInputTestHelper helper(&input);
+  auto input = nimble::MetadataInput::create(readFile.get(), options);
+  nimble::test::MetadataInputTestHelper helper(input.get());
 
   // Before enqueue.
   EXPECT_FALSE(helper.testingLoaded());
   EXPECT_EQ(helper.testingSectionCount(), 0);
 
   // After enqueue.
-  auto handle = input.enqueue(section);
+  auto handle = input->enqueue(section);
   EXPECT_FALSE(helper.testingLoaded());
   EXPECT_EQ(helper.testingSectionCount(), 1);
   EXPECT_EQ(helper.testingSection(0).offset(), 0);
@@ -327,7 +331,7 @@ TEST_F(DirectMetadataInputTest, stateTransitions) {
   EXPECT_FALSE(helper.testingHasBuffer(0));
 
   // After load.
-  input.load();
+  input->load();
   EXPECT_TRUE(helper.testingLoaded());
   EXPECT_EQ(helper.testingSectionCount(), 1);
   EXPECT_TRUE(helper.testingHasBuffer(0));
@@ -337,42 +341,40 @@ TEST_F(DirectMetadataInputTest, stateTransitions) {
   EXPECT_FALSE(helper.testingHasBuffer(0));
 
   // After reset — back to initial state.
-  input.reset();
+  input->reset();
   EXPECT_FALSE(helper.testingLoaded());
   EXPECT_EQ(helper.testingSectionCount(), 0);
 
   // Can enqueue/load/read again after reset.
-  auto handle2 = input.enqueue(section);
+  auto handle2 = input->enqueue(section);
   EXPECT_EQ(helper.testingSectionCount(), 1);
-  input.load();
+  input->load();
   EXPECT_TRUE(helper.testingLoaded());
   EXPECT_EQ(handle2.read()->content(), data);
 
   // Load without enqueue throws.
   {
-    nimble::DirectMetadataInput emptyInput(
-        readFile.get(), pool_.get(), options);
-    NIMBLE_ASSERT_THROW(emptyInput.load(), "No sections enqueued");
+    auto emptyInput = nimble::MetadataInput::create(readFile.get(), options);
+    NIMBLE_ASSERT_THROW(emptyInput->load(), "No sections enqueued");
   }
 
   // Read before load throws.
   {
-    nimble::DirectMetadataInput freshInput(
-        readFile.get(), pool_.get(), options);
-    auto h = freshInput.enqueue(section);
+    auto freshInput = nimble::MetadataInput::create(readFile.get(), options);
+    auto h = freshInput->enqueue(section);
     NIMBLE_ASSERT_THROW(h.read(), "load() must be called before read()");
   }
 
   // Without reset, enqueue throws.
   NIMBLE_ASSERT_THROW(
-      input.enqueue(section), "enqueue() not allowed after load()");
+      input->enqueue(section), "enqueue() not allowed after load()");
   // Without reset, load throws.
-  NIMBLE_ASSERT_THROW(input.load(), "load() already called");
+  NIMBLE_ASSERT_THROW(input->load(), "load() already called");
 
   // Double read throws.
-  input.reset();
-  auto handle3 = input.enqueue(section);
-  input.load();
+  input->reset();
+  auto handle3 = input->enqueue(section);
+  input->load();
   handle3.read();
   NIMBLE_ASSERT_THROW(handle3.read(), "Metadata buffer already consumed");
 }
@@ -404,9 +406,9 @@ TEST_F(DirectMetadataInputTest, ioStats) {
       metadataIoStats_.queryThreadIoLatencyUs().count();
 
   const auto options = makeReaderOptions();
-  nimble::DirectMetadataInput input(readFile.get(), pool_.get(), options);
-  input.enqueue(section);
-  input.load();
+  auto input = nimble::MetadataInput::create(readFile.get(), options);
+  input->enqueue(section);
+  input->load();
 
   EXPECT_GT(metadataIoStats_.read().count(), readCountBefore);
   EXPECT_EQ(metadataIoStats_.read().sum() - readSumBefore, data.size());
@@ -520,11 +522,11 @@ DEBUG_ONLY_TEST_F(DirectMetadataInputTest, ioCoalescing) {
 
     const auto options = makeReaderOptions(
         testData.maxCoalesceDistance, testData.maxCoalesceBytes);
-    nimble::DirectMetadataInput input(readFile.get(), pool_.get(), options);
+    auto input = nimble::MetadataInput::create(readFile.get(), options);
     for (const auto& section : sections) {
-      input.enqueue(section);
+      input->enqueue(section);
     }
-    input.load();
+    input->load();
 
     EXPECT_EQ(capturedStats.numIos, testData.expectedNumIos);
     EXPECT_EQ(capturedStats.extraBytes, testData.expectedOverread);
@@ -596,24 +598,49 @@ TEST_F(DirectMetadataInputTest, ioError) {
         std::make_exception_ptr(std::runtime_error("injected IO error")));
 
     const auto options = makeReaderOptions(testData.maxCoalesceDistance);
-    nimble::DirectMetadataInput input(readFile.get(), pool_.get(), options);
+    auto input = nimble::MetadataInput::create(readFile.get(), options);
     for (const auto& section : sections) {
-      input.enqueue(section);
+      input->enqueue(section);
     }
-    EXPECT_THROW(input.load(), std::runtime_error);
+    EXPECT_THROW(input->load(), std::runtime_error);
 
     // After IO error, reset and retry with error cleared should succeed.
     readFile->clearReadError();
-    input.reset();
+    input->reset();
     std::vector<nimble::MetadataHandle> handles;
     for (const auto& section : sections) {
-      handles.push_back(input.enqueue(section));
+      handles.push_back(input->enqueue(section));
     }
-    input.load();
+    input->load();
     for (uint32_t i = 0; i < handles.size(); ++i) {
       EXPECT_EQ(handles[i].read()->content(), testData.specs[i].data);
     }
   }
+}
+
+TEST_F(DirectMetadataInputTest, loadGuard) {
+  NIMBLE_ASSERT_THROW(nimble::MetadataInput::LoadGuard(nullptr), "");
+
+  std::string sectionData(64, 'A');
+  nimble::MetadataSection section{0, 64, nimble::CompressionType::Uncompressed};
+  auto fileContent = buildFileContent({section}, {sectionData});
+  auto file = std::make_shared<velox::InMemoryReadFile>(std::move(fileContent));
+  auto options = makeReaderOptions();
+  auto input = nimble::MetadataInput::create(file.get(), options);
+
+  auto handle = input->enqueue(section);
+  nimble::test::MetadataInputTestHelper helper(input.get());
+  EXPECT_FALSE(helper.testingLoaded());
+
+  {
+    nimble::MetadataInput::LoadGuard guard(input.get());
+    EXPECT_TRUE(helper.testingLoaded());
+    auto result = handle.read();
+    ASSERT_NE(result, nullptr);
+    EXPECT_EQ(result->content(), sectionData);
+  }
+  EXPECT_FALSE(helper.testingLoaded());
+  EXPECT_EQ(helper.testingSectionCount(), 0);
 }
 
 // --- CachedMetadataInput tests ---
@@ -676,19 +703,25 @@ class CachedMetadataInputTest : public MetadataInputTestBase,
     tempDir_.reset();
   }
 
-  std::unique_ptr<nimble::CachedMetadataInput> createCachedInput(
+  std::unique_ptr<nimble::MetadataInput> createCachedInput(
       velox::ReadFile* readFile,
-      int32_t maxCoalesceDistance = 1 << 20) {
-    velox::StringIdLease fileIdClone(
-        velox::fileIds(), "CachedMetadataInputTest");
-    const auto options = makeReaderOptions(maxCoalesceDistance);
-    return std::make_unique<nimble::CachedMetadataInput>(
-        readFile, std::move(fileIdClone), cache_.get(), pool_.get(), options);
+      int32_t maxCoalesceDistance = 1 << 20,
+      int64_t maxCoalesceBytes = 128 << 20) {
+    fileHandle_ = std::make_unique<velox::FileHandle>();
+    fileHandle_->file = std::shared_ptr<velox::ReadFile>(
+        std::shared_ptr<velox::ReadFile>{}, readFile);
+    fileHandle_->uuid =
+        velox::StringIdLease(velox::fileIds(), "CachedMetadataInputTest");
+    const auto options =
+        makeReaderOptions(maxCoalesceDistance, maxCoalesceBytes);
+    return nimble::MetadataInput::create(
+        fileHandle_.get(), cache_.get(), options);
   }
 
   std::unique_ptr<velox::memory::MemoryManager> manager_;
   velox::memory::MmapAllocator* allocator_{nullptr};
   std::shared_ptr<velox::cache::AsyncDataCache> cache_;
+  std::unique_ptr<velox::FileHandle> fileHandle_;
   std::unique_ptr<velox::StringIdLease> fileId_;
   std::shared_ptr<velox::common::testutil::TempDirectoryPath> tempDir_;
   std::unique_ptr<folly::IOThreadPoolExecutor> ssdExecutor_;
@@ -870,7 +903,8 @@ TEST_P(CachedMetadataInputTest, stateTransitions) {
   auto readFile = std::make_shared<velox::InMemoryReadFile>(fileContent);
 
   auto input = createCachedInput(readFile.get());
-  nimble::test::CachedMetadataInputTestHelper helper(input.get());
+  nimble::test::CachedMetadataInputTestHelper helper(
+      dynamic_cast<nimble::CachedMetadataInput*>(input.get()));
 
   // Before enqueue.
   EXPECT_FALSE(helper.testingLoaded());
@@ -980,8 +1014,6 @@ DEBUG_ONLY_TEST_P(CachedMetadataInputTest, ioCoalescing) {
     }
 
     auto readFile = std::make_shared<velox::InMemoryReadFile>(fileContent);
-    const auto options = makeReaderOptions(
-        testData.maxCoalesceDistance, testData.maxCoalesceBytes);
 
     uint64_t expectedPayloadBytes = 0;
     for (const auto& s : testData.sections) {
@@ -1002,12 +1034,10 @@ DEBUG_ONLY_TEST_P(CachedMetadataInputTest, ioCoalescing) {
                 capturedStats = *stats;
               }));
 
-      auto input = std::make_unique<nimble::CachedMetadataInput>(
+      auto input = createCachedInput(
           readFile.get(),
-          velox::StringIdLease(velox::fileIds(), "CachedMetadataInputTest"),
-          cache_.get(),
-          pool_.get(),
-          options);
+          testData.maxCoalesceDistance,
+          testData.maxCoalesceBytes);
       for (const auto& section : sections) {
         input->enqueue(section);
       }
@@ -1032,12 +1062,7 @@ DEBUG_ONLY_TEST_P(CachedMetadataInputTest, ioCoalescing) {
       const auto storageLatencyBefore =
           metadataIoStats_.storageReadLatencyUs().count();
 
-      auto input = std::make_unique<nimble::CachedMetadataInput>(
-          readFile.get(),
-          velox::StringIdLease(velox::fileIds(), "CachedMetadataInputTest"),
-          cache_.get(),
-          pool_.get(),
-          options);
+      auto input = createCachedInput(readFile.get());
       for (const auto& section : sections) {
         input->enqueue(section);
       }
@@ -1066,12 +1091,7 @@ DEBUG_ONLY_TEST_P(CachedMetadataInputTest, ioCoalescing) {
       const auto storageLatencyBefore =
           metadataIoStats_.storageReadLatencyUs().count();
 
-      auto input = std::make_unique<nimble::CachedMetadataInput>(
-          readFile.get(),
-          velox::StringIdLease(velox::fileIds(), "CachedMetadataInputTest"),
-          cache_.get(),
-          pool_.get(),
-          options);
+      auto input = createCachedInput(readFile.get());
       for (const auto& section : sections) {
         input->enqueue(section);
       }
@@ -1232,13 +1252,8 @@ TEST_P(CachedMetadataInputTest, ioError) {
     readFile->setReadError(
         std::make_exception_ptr(std::runtime_error("injected IO error")));
 
-    const auto options = makeReaderOptions(testData.maxCoalesceDistance);
-    auto input = std::make_unique<nimble::CachedMetadataInput>(
-        readFile.get(),
-        velox::StringIdLease(velox::fileIds(), "CachedMetadataInputTest"),
-        cache_.get(),
-        pool_.get(),
-        options);
+    auto input =
+        createCachedInput(readFile.get(), testData.maxCoalesceDistance);
     for (const auto& section : sections) {
       input->enqueue(section);
     }
@@ -1359,6 +1374,120 @@ TEST_P(CachedMetadataInputTest, cachePinRetention) {
   EXPECT_EQ(metadataIoStats_.ramHit().count(), ramHitBefore2);
   EXPECT_GT(
       metadataIoStats_.storageReadLatencyUs().count(), storageLatencyBefore);
+}
+
+TEST_P(CachedMetadataInputTest, loadGuard) {
+  NIMBLE_ASSERT_THROW(nimble::MetadataInput::LoadGuard(nullptr), "");
+
+  std::string sectionData(64, 'B');
+  nimble::MetadataSection section{0, 64, nimble::CompressionType::Uncompressed};
+  auto fileContent = buildFileContent({section}, {sectionData});
+  auto readFile =
+      std::make_shared<velox::InMemoryReadFile>(std::move(fileContent));
+  auto input = createCachedInput(readFile.get());
+
+  auto handle = input->enqueue(section);
+  nimble::test::MetadataInputTestHelper helper(input.get());
+  EXPECT_FALSE(helper.testingLoaded());
+
+  {
+    nimble::MetadataInput::LoadGuard guard(input.get());
+    EXPECT_TRUE(helper.testingLoaded());
+    auto result = handle.read();
+    ASSERT_NE(result, nullptr);
+    EXPECT_EQ(result->content(), sectionData);
+  }
+  EXPECT_FALSE(helper.testingLoaded());
+  EXPECT_EQ(helper.testingSectionCount(), 0);
+}
+
+TEST_F(DirectMetadataInputTest, cacheMethodsThrow) {
+  auto file = std::make_shared<velox::InMemoryReadFile>(std::string(100, 'x'));
+  auto options = makeReaderOptions();
+  auto input = nimble::MetadataInput::create(file.get(), options);
+  EXPECT_FALSE(input->cached());
+  NIMBLE_ASSERT_THROW(input->findCachedMetadata(0), "");
+  std::string_view data = "test";
+  std::span<const std::string_view> ranges(&data, 1);
+  NIMBLE_ASSERT_THROW(input->cacheMetadata(0, ranges), "");
+}
+
+TEST_P(CachedMetadataInputTest, cacheAndFindMetadata) {
+  auto readFile =
+      std::make_shared<velox::InMemoryReadFile>(std::string(100, 'x'));
+  auto input = createCachedInput(readFile.get());
+  EXPECT_TRUE(input->cached());
+
+  // Cache miss before caching.
+  EXPECT_EQ(input->findCachedMetadata(42), nullptr);
+
+  // Cache data at offset 42.
+  std::string data1 = "hello";
+  std::string data2 = "world";
+  std::array<std::string_view, 2> ranges = {data1, data2};
+  input->cacheMetadata(42, ranges);
+
+  // Cache hit after caching.
+  auto result = input->findCachedMetadata(42);
+  ASSERT_NE(result, nullptr);
+  EXPECT_EQ(result->content().size(), data1.size() + data2.size());
+  EXPECT_EQ(result->content(), std::string_view("helloworld"));
+}
+
+DEBUG_ONLY_TEST_P(CachedMetadataInputTest, concurrentCacheAndFind) {
+  auto readFile =
+      std::make_shared<velox::InMemoryReadFile>(std::string(100, 'x'));
+
+  // Verifies that findCachedMetadata blocks while another thread holds an
+  // exclusive cache pin via cacheMetadata, then returns the cached result
+  // once the pin is promoted to shared.
+  std::string cachedData(1'000, 'Z');
+  std::array<std::string_view, 1> ranges = {cachedData};
+
+  folly::Baton<> pinAcquired;
+  folly::Baton<> writerResume;
+
+  SCOPED_TESTVALUE_SET(
+      "facebook::nimble::CachedMetadataInput::cacheMetadata",
+      std::function<void(const velox::cache::CachePin*)>(
+          [&](const velox::cache::CachePin*) {
+            pinAcquired.post();
+            writerResume.wait();
+          }));
+
+  auto input1 = createCachedInput(readFile.get());
+  auto input2 = createCachedInput(readFile.get());
+
+  std::atomic_bool finderDone{false};
+  std::unique_ptr<nimble::MetadataBuffer> foundResult;
+
+  // Start cacher thread — will block in TestValue after acquiring exclusive
+  // pin.
+  std::thread cacher([&] { input1->cacheMetadata(99, ranges); });
+
+  pinAcquired.wait();
+
+  // Start finder thread — will block in findCachedMetadata waiting for the
+  // exclusive pin to be released.
+  std::thread finder([&] {
+    foundResult = input2->findCachedMetadata(99);
+    finderDone.store(true);
+  });
+
+  // Verify finder is blocked while cacher holds the exclusive pin.
+  EXPECT_EQ(foundResult, nullptr);
+  std::this_thread::sleep_for(std::chrono::seconds(1));
+  EXPECT_FALSE(finderDone.load());
+
+  // Resume cacher — writes data and promotes pin to shared.
+  writerResume.post();
+  cacher.join();
+  finder.join();
+
+  EXPECT_TRUE(finderDone.load());
+  ASSERT_NE(foundResult, nullptr);
+  EXPECT_EQ(foundResult->content().size(), cachedData.size());
+  EXPECT_EQ(foundResult->content(), cachedData);
 }
 
 INSTANTIATE_TEST_SUITE_P(

--- a/dwio/nimble/tablet/tests/TabletTest.cpp
+++ b/dwio/nimble/tablet/tests/TabletTest.cpp
@@ -44,13 +44,12 @@
 #include "velox/common/file/File.h"
 
 #include "velox/common/caching/AsyncDataCache.h"
+#include "velox/common/caching/FileHandle.h"
 #include "velox/common/caching/FileIds.h"
 #include "velox/common/io/IoStatistics.h"
+#include "velox/common/io/Options.h"
 #include "velox/common/memory/MallocAllocator.h"
 #include "velox/common/memory/Memory.h"
-#include "velox/dwio/common/BufferedInput.h"
-#include "velox/dwio/common/CachedBufferedInput.h"
-#include "velox/dwio/common/DirectBufferedInput.h"
 #include "velox/dwio/common/ExecutorBarrier.h"
 
 using namespace facebook;
@@ -162,7 +161,8 @@ class TabletTest : public ::testing::TestWithParam<BufferedInputMode> {
   }
 
   void TearDown() override {
-    bufferedInput_.reset();
+    fileHandle_.reset();
+    readerOptions_.reset();
     if (cache_) {
       cache_->shutdown();
       cache_.reset();
@@ -171,85 +171,72 @@ class TabletTest : public ::testing::TestWithParam<BufferedInputMode> {
     executor_.reset();
   }
 
-  /// Creates a BufferedInput based on the test mode.
-  /// Returns nullptr for kNone mode.
-  velox::dwio::common::BufferedInput* createBufferedInput(
-      std::shared_ptr<velox::ReadFile> readFile) {
-    auto mode = GetParam();
-
-    auto& ids = velox::fileIds();
-    fileId_ = std::make_unique<velox::StringIdLease>(ids, "testFile");
-    groupId_ = std::make_unique<velox::StringIdLease>(ids, "testGroup");
-
-    velox::io::ReaderOptions readerOptions(pool_.get());
-    readerOptions.setDataIoStats(dataIoStats_.get());
-    readerOptions.setMetadataIoStats(metadataIoStats_.get());
-
-    switch (mode) {
-      case BufferedInputMode::kNone:
-        return nullptr;
-
-      case BufferedInputMode::kBufferedInput:
-        bufferedInput_ = std::make_unique<velox::dwio::common::BufferedInput>(
-            readFile, *pool_);
-        return bufferedInput_.get();
-
-      case BufferedInputMode::kDirectBufferedInput:
-        tracker_ = std::make_shared<velox::cache::ScanTracker>(
-            "testTracker", nullptr, 256 << 10);
-        bufferedInput_ =
-            std::make_unique<velox::dwio::common::DirectBufferedInput>(
-                readFile,
-                velox::dwio::common::MetricsLog::voidLog(),
-                std::move(*fileId_),
-                tracker_,
-                std::move(*groupId_),
-                dataIoStats_,
-                nullptr,
-                executor_.get(),
-                readerOptions);
-        return bufferedInput_.get();
-
-      case BufferedInputMode::kCachedBufferedInput:
-        if (!allocator_) {
-          allocator_ = std::make_shared<velox::memory::MallocAllocator>(
-              velox::memory::MemoryAllocator::Options{
-                  .capacity = 1UL << 30, .reservationByteLimit = 0});
-        }
-        if (!cache_) {
-          cache_ = velox::cache::AsyncDataCache::create(allocator_.get());
-        }
-        tracker_ = std::make_shared<velox::cache::ScanTracker>(
-            "testTracker", nullptr, 256 << 10);
-        bufferedInput_ =
-            std::make_unique<velox::dwio::common::CachedBufferedInput>(
-                readFile,
-                velox::dwio::common::MetricsLog::voidLog(),
-                std::move(*fileId_),
-                cache_.get(),
-                tracker_,
-                std::move(*groupId_),
-                dataIoStats_,
-                nullptr,
-                executor_.get(),
-                readerOptions);
-        return bufferedInput_.get();
-    }
-    return nullptr;
+  /// Configures MetadataInput fields on TabletReader::Options based on
+  /// test mode.
+  void configureMetadataInput(nimble::TabletReader::Options& options) {
+    ensureReaderOptions();
+    options.ioOptions = *readerOptions_;
   }
 
+  void configureMetadataInput(
+      nimble::TabletReader::Options& options,
+      BufferedInputMode mode) {
+    ensureReaderOptions();
+    options.ioOptions = *readerOptions_;
+
+    if (mode == BufferedInputMode::kCachedBufferedInput) {
+      if (!allocator_) {
+        allocator_ = std::make_shared<velox::memory::MallocAllocator>(
+            velox::memory::MemoryAllocator::Options{
+                .capacity = 1UL << 30, .reservationByteLimit = 0});
+      }
+      if (!cache_) {
+        cache_ = velox::cache::AsyncDataCache::create(allocator_.get());
+      }
+      auto& ids = velox::fileIds();
+      auto fileKey = fmt::format(
+          "testFile_{}", reinterpret_cast<uintptr_t>(readFile_.get()));
+      fileHandle_ = std::make_unique<velox::FileHandle>();
+      fileHandle_->uuid = velox::StringIdLease(ids, fileKey);
+      fileHandle_->groupId = velox::StringIdLease(ids, "testGroup");
+      options.cache = cache_.get();
+      options.fileHandle = fileHandle_.get();
+    }
+  }
+
+ private:
+  void ensureReaderOptions() {
+    if (readerOptions_ == nullptr) {
+      readerOptions_ = std::make_unique<velox::io::ReaderOptions>(pool_.get());
+      readerOptions_->setDataIoStats(dataIoStats_.get());
+      readerOptions_->setMetadataIoStats(metadataIoStats_.get());
+      readerOptions_->setIndexIoStats(indexIoStats_.get());
+    }
+  }
+
+ protected:
   bool expectHasCache() const {
     return GetParam() == BufferedInputMode::kCachedBufferedInput;
   }
 
-  /// Creates a TabletReader with BufferedInput configured based on test mode.
-  /// This is the primary method tests should use to create readers.
+  /// Creates a TabletReader with MetadataInput configured based on test mode.
+  std::shared_ptr<nimble::TabletReader> createTabletReader(
+      std::shared_ptr<velox::ReadFile> readFile,
+      nimble::TabletReader::Options options,
+      BufferedInputMode mode) {
+    readFile_ = readFile;
+    configureMetadataInput(options, mode);
+    if (fileHandle_ != nullptr) {
+      fileHandle_->file = readFile_;
+    }
+    return nimble::TabletReader::create(readFile_, pool_.get(), options);
+  }
+
   std::shared_ptr<nimble::TabletReader> createTabletReader(
       std::shared_ptr<velox::ReadFile> readFile,
       nimble::TabletReader::Options options = {}) {
-    readFile_ = readFile;
-    options.bufferedInput = createBufferedInput(readFile_);
-    return nimble::TabletReader::create(readFile_, pool_.get(), options);
+    return createTabletReader(
+        std::move(readFile), std::move(options), GetParam());
   }
 
   /// Overload for string file content (creates InMemoryReadFile internally).
@@ -265,15 +252,15 @@ class TabletTest : public ::testing::TestWithParam<BufferedInputMode> {
       std::make_shared<velox::io::IoStatistics>()};
   std::shared_ptr<velox::io::IoStatistics> metadataIoStats_{
       std::make_shared<velox::io::IoStatistics>()};
+  std::shared_ptr<velox::io::IoStatistics> indexIoStats_{
+      std::make_shared<velox::io::IoStatistics>()};
 
   std::shared_ptr<velox::ReadFile> readFile_;
   std::unique_ptr<folly::CPUThreadPoolExecutor> executor_;
   std::shared_ptr<velox::memory::MallocAllocator> allocator_;
   std::shared_ptr<velox::cache::AsyncDataCache> cache_;
-  std::shared_ptr<velox::cache::ScanTracker> tracker_;
-  std::unique_ptr<velox::StringIdLease> fileId_;
-  std::unique_ptr<velox::StringIdLease> groupId_;
-  std::unique_ptr<velox::dwio::common::BufferedInput> bufferedInput_;
+  std::unique_ptr<velox::FileHandle> fileHandle_;
+  std::unique_ptr<velox::io::ReaderOptions> readerOptions_;
 
   // Runs a single write/read test using input parameters
   void parameterizedTest(
@@ -321,7 +308,7 @@ class TabletTest : public ::testing::TestWithParam<BufferedInputMode> {
         auto readFile =
             std::make_shared<nimble::testing::InMemoryTrackableReadFile>(
                 file, useChainedBuffers);
-        auto tablet = nimble::TabletReader::create(readFile, pool_.get(), {});
+        auto tablet = createTabletReader(readFile);
 
         // Get stripe group count through the read path
         nimble::test::TabletReaderTestHelper tabletHelper(tablet.get());
@@ -421,7 +408,9 @@ class TabletTest : public ::testing::TestWithParam<BufferedInputMode> {
           }
         }
 
-        EXPECT_EQ(extraReads, (stripeGroupCount == 1 ? 0 : stripeGroupCount));
+        if (!expectHasCache()) {
+          EXPECT_EQ(extraReads, (stripeGroupCount == 1 ? 0 : stripeGroupCount));
+        }
 
         if (errorVerifier.has_value()) {
           FAIL() << "Error verifier is provided, but no exception was thrown.";
@@ -517,8 +506,7 @@ class TabletTest : public ::testing::TestWithParam<BufferedInputMode> {
       auto readFile =
           std::make_shared<nimble::testing::InMemoryTrackableReadFile>(
               file, useChainedBuffers);
-      auto tablet =
-          nimble::TabletReader::create(readFile, this->pool_.get(), {});
+      auto tablet = createTabletReader(readFile);
       auto storedChecksum = tablet->checksum();
       EXPECT_EQ(
           storedChecksum,
@@ -895,7 +883,7 @@ TEST_P(TabletTest, optionalSections) {
     auto readFile =
         std::make_shared<nimble::testing::InMemoryTrackableReadFile>(
             file, useChainedBuffers);
-    auto tablet = nimble::TabletReader::create(readFile, pool_.get(), {});
+    auto tablet = createTabletReader(readFile);
 
     ASSERT_EQ(tablet->optionalSections().size(), 4);
 
@@ -976,7 +964,7 @@ TEST_P(TabletTest, optionalSectionsEmpty) {
     auto readFile =
         std::make_shared<nimble::testing::InMemoryTrackableReadFile>(
             file, useChainedBuffers);
-    auto tablet = nimble::TabletReader::create(readFile, pool_.get(), {});
+    auto tablet = createTabletReader(readFile);
 
     ASSERT_TRUE(tablet->optionalSections().empty());
 
@@ -999,7 +987,7 @@ TEST_P(TabletTest, hasOptionalSection) {
 
   auto readFile =
       std::make_shared<nimble::testing::InMemoryTrackableReadFile>(file, true);
-  auto tablet = nimble::TabletReader::create(readFile, pool_.get(), {});
+  auto tablet = createTabletReader(readFile);
 
   // Test that hasOptionalSection returns true for existing sections
   EXPECT_TRUE(tablet->hasOptionalSection("section1"));
@@ -1023,7 +1011,7 @@ TEST_P(TabletTest, hasOptionalSectionEmpty) {
 
   auto readFile =
       std::make_shared<nimble::testing::InMemoryTrackableReadFile>(file, true);
-  auto tablet = nimble::TabletReader::create(readFile, pool_.get(), {});
+  auto tablet = createTabletReader(readFile);
 
   // Test that hasOptionalSection returns false when there are no sections
   EXPECT_FALSE(tablet->hasOptionalSection("section1"));
@@ -1066,6 +1054,7 @@ TEST_P(TabletTest, optionalSectionsPreload) {
                 file, useChainedBuffers);
         nimble::TabletReader::Options options;
         options.preloadOptionalSections = preload;
+        configureMetadataInput(options);
         auto tablet =
             nimble::TabletReader::create(readFile, pool_.get(), options);
 
@@ -1085,8 +1074,8 @@ TEST_P(TabletTest, optionalSectionsPreload) {
     };
 
     // Not preloading anything.
-    // Expecting one initial read, to read the footer.
-    // Each section load should increment read count
+    // Initial reads: single speculative preadv for footer+PS (1).
+    // Each section load adds one preadv via MetadataInput.
     verify(
         /* preload */ {},
         /* expectedInitialReads */ 1,
@@ -1099,8 +1088,8 @@ TEST_P(TabletTest, optionalSectionsPreload) {
             {"section1", 7, "aaaa"},
         });
 
-    // Preloading small section covered by footer.
-    // Expecting one initial read, to read only the footer.
+    // Preloading small section covered by speculative IOBuf.
+    // Initial reads: speculative preadv (1).
     verify(
         /* preload */ {"section4"},
         /* expectedInitialReads */ 1,
@@ -1116,9 +1105,8 @@ TEST_P(TabletTest, optionalSectionsPreload) {
             {"section4", 6, "dddd"},
         });
 
-    // Preloading section partially covered by footer.
-    // Expecting one initial read for the footer, and an additional read to read
-    // the full preloaded section.
+    // Preloading section not covered by speculative IOBuf.
+    // Initial reads: speculative preadv (1) + preload read (2).
     verify(
         /* preload */ {"section3"},
         /* expectedInitialReads */ 2,
@@ -1134,9 +1122,8 @@ TEST_P(TabletTest, optionalSectionsPreload) {
             {"section3", 7, random},
         });
 
-    // Preloading section completely not covered by footer.
-    // Expecting one initial read for the footer, and an additional read to read
-    // the uncovered preloaded section.
+    // Preloading section completely not covered by speculative IOBuf.
+    // Initial reads: speculative preadv (1) + preload read (2).
     verify(
         /* preload */ {"section1"},
         /* expectedInitialReads */ 2,
@@ -1153,8 +1140,7 @@ TEST_P(TabletTest, optionalSectionsPreload) {
         });
 
     // Preloading multiple sections. One covered, and the other is not.
-    // Expecting one initial read for the footer, and an additional read to read
-    // the uncovered preloaded section.
+    // Initial reads: speculative preadv (1) + preload read (2).
     verify(
         /* preload */ {"section2", "section4"},
         /* expectedInitialReads */ 2,
@@ -1178,26 +1164,37 @@ TEST_P(TabletTest, optionalSectionsPreload) {
 
     // Preloading all sections. Two are fully covered, and three are
     // partially or not covered.
-    // Expecting one initial read for the footer (and the covered sections), and
-    // additional reads to read the partial/uncovered preloaded sections.
-    verify(
-        /* preload */
-        {"section2", "section4", "section1", "section3", "section5"},
-        /* expectedInitialReads */ 4,
-        {
-            // All sections are preloaded, so no addtional reads
-            {"section1", 4, "aaaa"},
-            {"section2", 4, "bbbb"},
-            {"section3", 4, random},
-            {"section4", 4, "dddd"},
-            {"section5", 4, "eeee"},
-            // Now all sections are consumed so all should trigger reads
-            {"section1", 5, "aaaa"},
-            {"section2", 6, "bbbb"},
-            {"section3", 7, random},
-            {"section4", 8, "dddd"},
-            {"section5", 9, "eeee"},
-        });
+    // Initial reads: speculative preadv (1) + preload reads for uncovered
+    // sections.
+    // With MetadataInput coalescing, the number of initial reads depends
+    // on how many uncovered sections are coalesced. Skip exact count check
+    // and verify content correctness only.
+    {
+      auto readFile =
+          std::make_shared<nimble::testing::InMemoryTrackableReadFile>(
+              file, /*useChainedBuffers=*/false);
+      nimble::TabletReader::Options options;
+      options.preloadOptionalSections = {
+          "section2", "section4", "section1", "section3", "section5"};
+      configureMetadataInput(options);
+      auto tablet =
+          nimble::TabletReader::create(readFile, pool_.get(), options);
+
+      for (const auto& name :
+           {"section1", "section2", "section3", "section4", "section5"}) {
+        auto section = tablet->loadOptionalSection(name);
+        ASSERT_TRUE(section.has_value());
+      }
+      const auto readsAfterPreload = readFile->chunks().size();
+
+      // Re-loading consumed sections should trigger new reads.
+      for (const auto& name :
+           {"section1", "section2", "section3", "section4", "section5"}) {
+        auto section = tablet->loadOptionalSection(name);
+        ASSERT_TRUE(section.has_value());
+      }
+      EXPECT_GT(readFile->chunks().size(), readsAfterPreload);
+    }
   }
 }
 
@@ -1551,7 +1548,7 @@ TEST_P(TabletWithIndexTest, stripeIdentifier) {
 
   // Read and verify
   auto readFile = std::make_shared<velox::InMemoryReadFile>(file);
-  auto tablet = nimble::TabletReader::create(readFile, pool_.get(), {});
+  auto tablet = createTabletReader(readFile);
 
   ASSERT_EQ(tablet->stripeCount(), 1);
   ASSERT_NE(tablet->clusterIndex(), nullptr);
@@ -1689,7 +1686,7 @@ TEST_P(TabletWithIndexTest, singleGroup) {
   // Read and verify the tablet
   auto readFile =
       std::make_shared<nimble::testing::InMemoryTrackableReadFile>(file, false);
-  auto tablet = nimble::TabletReader::create(readFile, pool_.get(), {});
+  auto tablet = createTabletReader(readFile);
 
   // Use test helper to verify stripe group count through the read path
   nimble::test::TabletReaderTestHelper tabletHelper(tablet.get());
@@ -2084,7 +2081,7 @@ TEST_P(TabletWithIndexTest, multipleGroups) {
   // Read and verify the tablet
   auto readFile =
       std::make_shared<nimble::testing::InMemoryTrackableReadFile>(file, false);
-  auto tablet = nimble::TabletReader::create(readFile, pool_.get(), {});
+  auto tablet = createTabletReader(readFile);
 
   // Use test helper to verify stripe group count
   nimble::test::TabletReaderTestHelper tabletHelper(tablet.get());
@@ -2518,7 +2515,7 @@ TEST_P(TabletWithIndexTest, singleGroupWithEmptyStream) {
   // Read and verify the tablet
   auto readFile =
       std::make_shared<nimble::testing::InMemoryTrackableReadFile>(file, false);
-  auto tablet = nimble::TabletReader::create(readFile, pool_.get(), {});
+  auto tablet = createTabletReader(readFile);
 
   // Use test helper to verify stripe group count
   nimble::test::TabletReaderTestHelper tabletHelper(tablet.get());
@@ -2944,7 +2941,7 @@ TEST_P(TabletWithIndexTest, multipleGroupsWithEmptyStream) {
   // Read and verify the tablet
   auto readFile =
       std::make_shared<nimble::testing::InMemoryTrackableReadFile>(file, false);
-  auto tablet = nimble::TabletReader::create(readFile, pool_.get(), {});
+  auto tablet = createTabletReader(readFile);
 
   // Use test helper to verify stripe group count
   nimble::test::TabletReaderTestHelper tabletHelper(tablet.get());
@@ -3353,7 +3350,7 @@ TEST_P(TabletWithIndexTest, streamDeduplication) {
   // Read and verify the tablet
   auto readFile =
       std::make_shared<nimble::testing::InMemoryTrackableReadFile>(file, false);
-  auto tablet = nimble::TabletReader::create(readFile, pool_.get(), {});
+  auto tablet = createTabletReader(readFile);
 
   // Use test helper to verify stripe group count
   nimble::test::TabletReaderTestHelper tabletHelper(tablet.get());
@@ -3532,7 +3529,7 @@ TEST_P(TabletWithIndexTest, keyOrderEnforcement) {
         auto readFile =
             std::make_shared<nimble::testing::InMemoryTrackableReadFile>(
                 file, false);
-        auto tablet = nimble::TabletReader::create(readFile, pool_.get(), {});
+        auto tablet = createTabletReader(readFile);
         EXPECT_EQ(tablet->stripeCount(), 2);
         EXPECT_TRUE(tablet->hasOptionalSection(
             std::string(nimble::kClusterIndexSection)));
@@ -3568,7 +3565,7 @@ TEST_P(TabletWithIndexTest, noIndex) {
   // Verify no index section and no chunk index section
   auto readFile =
       std::make_shared<nimble::testing::InMemoryTrackableReadFile>(file, false);
-  auto tablet = nimble::TabletReader::create(readFile, pool_.get(), {});
+  auto tablet = createTabletReader(readFile);
   EXPECT_EQ(tablet->stripeCount(), 1);
   EXPECT_FALSE(
       tablet->hasOptionalSection(std::string(nimble::kClusterIndexSection)));
@@ -3679,7 +3676,7 @@ TEST_F(TabletWithIndexTest, configCombinations) {
     auto readFile =
         std::make_shared<nimble::testing::InMemoryTrackableReadFile>(
             file, false);
-    auto tablet = nimble::TabletReader::create(readFile, pool_.get(), {});
+    auto tablet = createTabletReader(readFile, {}, BufferedInputMode::kNone);
     EXPECT_EQ(tablet->stripeCount(), 2);
 
     // Verify optional sections
@@ -3772,7 +3769,7 @@ TEST_P(TabletWithIndexTest, emptyFileWithIndexConfig) {
   // Verify the file can be read.
   auto readFile =
       std::make_shared<nimble::testing::InMemoryTrackableReadFile>(file, false);
-  auto tablet = nimble::TabletReader::create(readFile, pool_.get(), {});
+  auto tablet = createTabletReader(readFile);
 
   // Verify no stripes.
   EXPECT_EQ(tablet->stripeCount(), 0);
@@ -4021,8 +4018,12 @@ TEST_P(TabletWithIndexTest, cacheWarmPath) {
   EXPECT_GT(coldCacheStats.numNew, 0);
   EXPECT_EQ(coldCacheStats.numEvict, 0);
 
-  // Reset IO stats for the warm path.
-  dataIoStats_ = std::make_shared<velox::dwio::common::IoStatistics>();
+  // Reset IO stats and readerOptions for the warm path so the new
+  // IoStatistics pointers are picked up by ensureReaderOptions.
+  dataIoStats_ = std::make_shared<velox::io::IoStatistics>();
+  metadataIoStats_ = std::make_shared<velox::io::IoStatistics>();
+  indexIoStats_ = std::make_shared<velox::io::IoStatistics>();
+  readerOptions_.reset();
 
   // Warm path: second reader should initialize from cache with zero IO.
   {
@@ -4032,11 +4033,9 @@ TEST_P(TabletWithIndexTest, cacheWarmPath) {
     EXPECT_TRUE(warmReader->hasClusterIndex());
     EXPECT_NE(warmReader->clusterIndex(), nullptr);
 
-    // Warm path should serve all data from RAM cache.
-    EXPECT_GT(dataIoStats_->ramHit().count(), 0);
-    EXPECT_EQ(dataIoStats_->ssdRead().count(), 0);
-    EXPECT_EQ(dataIoStats_->read().count(), 0);
-    EXPECT_EQ(dataIoStats_->prefetch().count(), 0);
+    // Warm path should serve metadata from RAM cache.
+    EXPECT_GT(metadataIoStats_->ramHit().count(), 0);
+    EXPECT_EQ(metadataIoStats_->rawBytesRead(), 0);
 
     // Verify stripe groups are accessible from cache.
     for (uint32_t i = 0; i < kNumStripes; ++i) {
@@ -4137,6 +4136,7 @@ TEST_P(TabletTest, readerOptionsAdaptiveMode) {
       std::make_shared<nimble::testing::InMemoryTrackableReadFile>(file, false);
   nimble::TabletReader::Options options;
   options.maxFooterIoBytes = 0; // Adaptive mode
+  configureMetadataInput(options);
   auto tablet = nimble::TabletReader::create(readFile, pool_.get(), options);
 
   EXPECT_EQ(tablet->stripeCount(), 1);
@@ -4168,6 +4168,7 @@ TEST_P(TabletTest, readerOptionsSpeculativeMode) {
       std::make_shared<nimble::testing::InMemoryTrackableReadFile>(file, false);
   nimble::TabletReader::Options options;
   options.maxFooterIoBytes = 1024; // Small speculative read
+  configureMetadataInput(options);
   auto tablet = nimble::TabletReader::create(readFile, pool_.get(), options);
 
   EXPECT_EQ(tablet->stripeCount(), 1);
@@ -4242,43 +4243,13 @@ TEST_P(TabletTest, configureOptionsIndexFlags) {
   }
 }
 
-TEST_P(TabletTest, configureOptionsBufferedInput) {
-  // Verify configureOptions only sets bufferedInput when
-  // fileMetadataCacheEnabled is true.
-  velox::dwio::common::ReaderOptions readerOptions(pool_.get());
-  readerOptions.setDataIoStats(dataIoStats_.get());
-  readerOptions.setMetadataIoStats(metadataIoStats_.get());
-
-  // Create a dummy BufferedInput to pass as the second parameter.
-  std::string emptyFile;
-  auto readFile = std::make_shared<velox::InMemoryReadFile>(emptyFile);
-  velox::dwio::common::BufferedInput bufferedInput(readFile, *pool_);
-
-  {
-    SCOPED_TRACE("fileMetadataCacheEnabled=false (default)");
-    auto opts =
-        nimble::TabletReader::configureOptions(readerOptions, &bufferedInput);
-    EXPECT_EQ(opts.bufferedInput, nullptr);
-  }
-
-  {
-    SCOPED_TRACE("fileMetadataCacheEnabled=true");
-    readerOptions.setFileMetadataCacheEnabled(true);
-    auto opts =
-        nimble::TabletReader::configureOptions(readerOptions, &bufferedInput);
-    EXPECT_EQ(opts.bufferedInput, &bufferedInput);
-  }
-}
-
-TEST_P(TabletTest, bufferedInputMetadataReads) {
-  // Test that BufferedInput is used for metadata reads when provided.
+TEST_P(TabletTest, metadataInputReads) {
   std::string file;
   velox::InMemoryWriteFile writeFile(&file);
   nimble::Buffer buffer(*pool_);
 
   auto tabletWriter = nimble::TabletWriter::create(&writeFile, *pool_, {});
 
-  // Write multiple stripes to ensure we have stripe group metadata to read.
   for (int i = 0; i < 3; ++i) {
     std::vector<nimble::Stream> streams;
     const auto size = 100;
@@ -4294,117 +4265,11 @@ TEST_P(TabletTest, bufferedInputMetadataReads) {
   writeFile.close();
 
   auto tablet = createTabletReader(file);
-
-  nimble::test::TabletReaderTestHelper tabletHelper(tablet.get());
-  EXPECT_EQ(tabletHelper.hasCache(), expectHasCache());
   EXPECT_EQ(tablet->stripeCount(), 3);
 
-  // Verify we can read stripe data.
   auto stripeId = tablet->stripeIdentifier(0);
   EXPECT_EQ(stripeId.stripeId(), 0);
   EXPECT_NE(stripeId.stripeGroup(), nullptr);
-}
-
-TEST_P(TabletTest, cacheWarmPath) {
-  // Test that a second TabletReader on the same file initializes from
-  // AsyncDataCache with zero file IO when file-metadata-cache is enabled.
-  // Only meaningful for CachedBufferedInput mode.
-  if (GetParam() != BufferedInputMode::kCachedBufferedInput) {
-    GTEST_SKIP() << "Cache warm path only applies to CachedBufferedInput";
-  }
-
-  // Write a file with multiple stripes.
-  std::string file;
-  velox::InMemoryWriteFile writeFile(&file);
-  nimble::Buffer buffer(*pool_);
-
-  auto tabletWriter = nimble::TabletWriter::create(&writeFile, *pool_, {});
-  constexpr int kNumStripes = 3;
-  for (int i = 0; i < kNumStripes; ++i) {
-    std::vector<nimble::Stream> streams;
-    const auto size = 100;
-    auto pos = buffer.reserve(size);
-    std::memset(pos, 'a' + i, size);
-    streams.push_back({
-        .offset = 0,
-        .chunks = {{.rowCount = 100, .content = {std::string_view(pos, size)}}},
-    });
-    tabletWriter->writeStripe(100, std::move(streams));
-  }
-  tabletWriter->close();
-  writeFile.close();
-
-  auto readFile = std::make_shared<velox::InMemoryReadFile>(file);
-
-  // Initialize cache before the cold reader so we can verify it starts empty.
-  // Normally lazy-initialized in createBufferedInput.
-  allocator_ = std::make_shared<velox::memory::MallocAllocator>(
-      velox::memory::MemoryAllocator::Options{
-          .capacity = 1UL << 30, .reservationByteLimit = 0});
-  cache_ = velox::cache::AsyncDataCache::create(allocator_.get());
-
-  // Cache should be empty before the cold reader.
-  auto coldCacheStats = cache_->refreshStats();
-  EXPECT_EQ(coldCacheStats.numEntries, 0);
-  EXPECT_EQ(coldCacheStats.numHit, 0);
-  EXPECT_EQ(coldCacheStats.numNew, 0);
-
-  // Cold path: first reader populates the cache.
-  {
-    auto coldReader = createTabletReader(readFile);
-    EXPECT_EQ(coldReader->stripeCount(), kNumStripes);
-    EXPECT_EQ(coldReader->tabletRowCount(), kNumStripes * 100);
-
-    // Cold init uses direct file_->preadv() which bypasses
-    // CachedBufferedInput, so no reads are tracked through IoStatistics.
-    EXPECT_EQ(dataIoStats_->ramHit().count(), 0);
-    EXPECT_EQ(dataIoStats_->ssdRead().count(), 0);
-    EXPECT_EQ(dataIoStats_->read().count(), 0);
-    EXPECT_EQ(dataIoStats_->prefetch().count(), 0);
-
-    auto stripeId = coldReader->stripeIdentifier(0);
-    EXPECT_EQ(stripeId.stripeId(), 0);
-    EXPECT_NE(stripeId.stripeGroup(), nullptr);
-  }
-
-  // Cold reader should have populated the cache with metadata entries.
-  // numHit may be > 0 from self-hits within the cold reader (coalesced IO can
-  // populate a cache entry that is then hit by a subsequent read).
-  coldCacheStats = cache_->refreshStats();
-  EXPECT_GT(coldCacheStats.numEntries, 0);
-  EXPECT_GT(coldCacheStats.numNew, 0);
-  EXPECT_EQ(coldCacheStats.numEvict, 0);
-
-  // Reset IO stats for the warm path.
-  dataIoStats_ = std::make_shared<velox::dwio::common::IoStatistics>();
-
-  // Warm path: second reader should initialize from cache with zero IO.
-  {
-    auto warmReader = createTabletReader(readFile);
-    EXPECT_EQ(warmReader->stripeCount(), kNumStripes);
-    EXPECT_EQ(warmReader->tabletRowCount(), kNumStripes * 100);
-    for (uint32_t i = 0; i < kNumStripes; ++i) {
-      EXPECT_EQ(warmReader->stripeRowCount(i), 100);
-    }
-
-    // Warm path should serve all data from RAM cache with zero storage reads.
-    EXPECT_GT(dataIoStats_->ramHit().count(), 0);
-    EXPECT_EQ(dataIoStats_->ssdRead().count(), 0);
-    EXPECT_EQ(dataIoStats_->read().count(), 0);
-    EXPECT_EQ(dataIoStats_->prefetch().count(), 0);
-
-    auto stripeId = warmReader->stripeIdentifier(0);
-    EXPECT_EQ(stripeId.stripeId(), 0);
-    EXPECT_NE(stripeId.stripeGroup(), nullptr);
-  }
-
-  // Warm reader should have additional cache hits beyond what the cold reader
-  // generated, with no new entries or evictions.
-  auto warmCacheStats = cache_->refreshStats();
-  EXPECT_EQ(warmCacheStats.numEntries, coldCacheStats.numEntries);
-  EXPECT_GT(warmCacheStats.numHit, coldCacheStats.numHit);
-  EXPECT_EQ(warmCacheStats.numNew, coldCacheStats.numNew);
-  EXPECT_EQ(warmCacheStats.numEvict, 0);
 }
 
 TEST_P(TabletTest, rowToStripe) {
@@ -4507,6 +4372,91 @@ TEST_P(TabletTest, rowToStripeSingleStripe) {
       tablet->rowToStripe(tablet->tabletRowCount()), "exceeds total row count");
 }
 
+TEST_P(TabletTest, cacheWarmPath) {
+  if (GetParam() != BufferedInputMode::kCachedBufferedInput) {
+    GTEST_SKIP() << "Cache warm path only applies to CachedBufferedInput";
+  }
+
+  std::string file;
+  velox::InMemoryWriteFile writeFile(&file);
+  nimble::Buffer buffer(*pool_);
+
+  auto tabletWriter = nimble::TabletWriter::create(
+      &writeFile,
+      *pool_,
+      {.metadataFlushThreshold = 1024 * 1024 * 1024,
+       .streamDeduplicationEnabled = false});
+
+  constexpr int kNumStripes = 3;
+  for (int i = 0; i < kNumStripes; ++i) {
+    std::vector<nimble::Stream> streams;
+    const auto size = 50;
+    auto* pos = buffer.reserve(size);
+    std::memset(pos, 'a' + i, size);
+    streams.push_back(
+        {.offset = 0,
+         .chunks = {
+             {.rowCount = 100, .content = {std::string_view(pos, size)}}}});
+    tabletWriter->writeStripe(100, std::move(streams));
+  }
+  tabletWriter->close();
+  writeFile.close();
+
+  auto readFile = std::make_shared<velox::InMemoryReadFile>(file);
+
+  allocator_ = std::make_shared<velox::memory::MallocAllocator>(
+      velox::memory::MemoryAllocator::Options{
+          .capacity = 1UL << 30, .reservationByteLimit = 0});
+  cache_ = velox::cache::AsyncDataCache::create(allocator_.get());
+
+  auto coldCacheStats = cache_->refreshStats();
+  EXPECT_EQ(coldCacheStats.numEntries, 0);
+
+  // Cold path: first reader populates the cache.
+  {
+    auto coldReader = createTabletReader(readFile);
+    EXPECT_EQ(coldReader->stripeCount(), kNumStripes);
+    EXPECT_EQ(coldReader->tabletRowCount(), kNumStripes * 100);
+
+    for (uint32_t i = 0; i < kNumStripes; ++i) {
+      auto stripeId = coldReader->stripeIdentifier(i);
+      EXPECT_NE(stripeId.stripeGroup(), nullptr);
+    }
+  }
+
+  coldCacheStats = cache_->refreshStats();
+  EXPECT_GT(coldCacheStats.numEntries, 0);
+  EXPECT_EQ(coldCacheStats.numEvict, 0);
+
+  // Reset IO stats for the warm path.
+  dataIoStats_ = std::make_shared<velox::io::IoStatistics>();
+  metadataIoStats_ = std::make_shared<velox::io::IoStatistics>();
+  indexIoStats_ = std::make_shared<velox::io::IoStatistics>();
+  readerOptions_.reset();
+
+  // Warm path: second reader should initialize from cache with zero file IO.
+  {
+    auto warmReader = createTabletReader(readFile);
+    EXPECT_EQ(warmReader->stripeCount(), kNumStripes);
+    EXPECT_EQ(warmReader->tabletRowCount(), kNumStripes * 100);
+
+    EXPECT_GT(metadataIoStats_->ramHit().count(), 0);
+    EXPECT_EQ(metadataIoStats_->rawBytesRead(), 0);
+    EXPECT_EQ(dataIoStats_->rawBytesRead(), 0);
+    EXPECT_EQ(indexIoStats_->rawBytesRead(), 0);
+
+    for (uint32_t i = 0; i < kNumStripes; ++i) {
+      auto stripeId = warmReader->stripeIdentifier(i);
+      EXPECT_NE(stripeId.stripeGroup(), nullptr);
+    }
+  }
+
+  auto warmCacheStats = cache_->refreshStats();
+  EXPECT_EQ(warmCacheStats.numEntries, coldCacheStats.numEntries);
+  EXPECT_GT(warmCacheStats.numHit, coldCacheStats.numHit);
+  EXPECT_EQ(warmCacheStats.numEvict, 0);
+}
+
 INSTANTIATE_TEST_SUITE_P(
     BufferedInputModes,
     TabletTest,
@@ -4570,63 +4520,31 @@ TEST_F(TabletTest, concurrentReadersWithCacheEviction) {
     auto& ids = velox::fileIds();
 
     while (!stop.load(std::memory_order_relaxed)) {
-      // Each thread cycles through a fixed BufferedInput mode.
       auto mode = static_cast<BufferedInputMode>(threadId % 4);
-      std::unique_ptr<velox::dwio::common::BufferedInput> bi;
-      std::shared_ptr<velox::cache::ScanTracker> tracker;
       velox::io::ReaderOptions readerOptions(threadPool.get());
       readerOptions.setDataIoStats(dataIoStats_.get());
       readerOptions.setMetadataIoStats(metadataIoStats_.get());
       nimble::TabletReader::Options options;
+      options.ioOptions = readerOptions;
 
+      velox::FileHandle fileHandle;
       switch (mode) {
         case BufferedInputMode::kNone:
-          break;
-
         case BufferedInputMode::kBufferedInput:
-          bi = std::make_unique<velox::dwio::common::BufferedInput>(
-              readFile, *threadPool);
+        case BufferedInputMode::kDirectBufferedInput:
           break;
-
-        case BufferedInputMode::kDirectBufferedInput: {
-          tracker = std::make_shared<velox::cache::ScanTracker>(
-              "tracker", nullptr, 256 << 10);
-          velox::StringIdLease fileId(ids, fmt::format("stress_{}", threadId));
-          velox::StringIdLease groupId(ids, "stressGroup");
-          bi = std::make_unique<velox::dwio::common::DirectBufferedInput>(
-              readFile,
-              velox::dwio::common::MetricsLog::voidLog(),
-              std::move(fileId),
-              tracker,
-              std::move(groupId),
-              dataIoStats_,
-              nullptr,
-              executor.get(),
-              readerOptions);
-          break;
-        }
 
         case BufferedInputMode::kCachedBufferedInput: {
-          tracker = std::make_shared<velox::cache::ScanTracker>(
-              "tracker", nullptr, 256 << 10);
-          velox::StringIdLease fileId(ids, "stressFile");
-          velox::StringIdLease groupId(ids, "stressGroup");
-          bi = std::make_unique<velox::dwio::common::CachedBufferedInput>(
-              readFile,
-              velox::dwio::common::MetricsLog::voidLog(),
-              std::move(fileId),
-              cache.get(),
-              tracker,
-              std::move(groupId),
-              dataIoStats_,
-              nullptr,
-              executor.get(),
-              readerOptions);
+          fileHandle.file = readFile;
+          fileHandle.uuid =
+              velox::StringIdLease(ids, fmt::format("stress_{}", threadId));
+          fileHandle.groupId = velox::StringIdLease(ids, "stressGroup");
+          options.cache = cache.get();
+          options.fileHandle = &fileHandle;
           break;
         }
       }
 
-      options.bufferedInput = bi.get();
       auto reader =
           nimble::TabletReader::create(readFile, threadPool.get(), options);
       EXPECT_EQ(reader->stripeCount(), 5);

--- a/dwio/nimble/tablet/tests/TabletTestUtils.h
+++ b/dwio/nimble/tablet/tests/TabletTestUtils.h
@@ -84,12 +84,6 @@ class TabletReaderTestHelper {
     return offsets;
   }
 
-  // Returns true if this reader is backed by a BufferedInput with Velox
-  // async data cache.
-  bool hasCache() const {
-    return tabletReader_->hasCache();
-  }
-
   /// Returns the stripe sizes array.
   /// Stripe size is computed as the difference between consecutive offsets,
   /// with the last stripe size computed using the file size.

--- a/dwio/nimble/velox/selective/ReaderBase.cpp
+++ b/dwio/nimble/velox/selective/ReaderBase.cpp
@@ -49,7 +49,7 @@ TypePtr getFileSchema(
 std::shared_ptr<ReaderBase> ReaderBase::create(
     std::unique_ptr<velox::dwio::common::BufferedInput> input,
     const velox::dwio::common::ReaderOptions& options) {
-  auto tabletOptions = TabletReader::configureOptions(options, input.get());
+  auto tabletOptions = TabletReader::configureOptions(options);
 
   auto tablet = TabletReader::create(
       input->getReadFile(), &options.memoryPool(), tabletOptions);

--- a/dwio/nimble/velox/tests/VeloxReaderTest.cpp
+++ b/dwio/nimble/velox/tests/VeloxReaderTest.cpp
@@ -35,13 +35,13 @@
 #include "velox/common/Casts.h"
 #include "velox/common/base/BitUtil.h"
 #include "velox/common/caching/AsyncDataCache.h"
+#include "velox/common/caching/FileHandle.h"
 #include "velox/common/caching/FileIds.h"
 #include "velox/common/caching/ScanTracker.h"
 #include "velox/common/io/IoStatistics.h"
+#include "velox/common/io/Options.h"
 #include "velox/common/memory/MallocAllocator.h"
-#include "velox/dwio/common/CachedBufferedInput.h"
 #include "velox/dwio/common/ColumnSelector.h"
-#include "velox/dwio/common/DirectBufferedInput.h"
 #include "velox/type/CppToType.h"
 #include "velox/type/Type.h"
 #include "velox/vector/BaseVector.h"
@@ -523,41 +523,21 @@ class VeloxReaderTest : public ::testing::TestWithParam<TestParam> {
       velox::memory::MemoryPool* pool) {
     nimble::TabletReader::Options tabletOptions;
     tabletOptions.pinFileMetadata = pinFileMetadata();
+    ioReaderOptions_ = std::make_unique<velox::io::ReaderOptions>(pool);
+    ioReaderOptions_->setDataIoStats(dataIoStats_.get());
+    ioReaderOptions_->setMetadataIoStats(metadataIoStats_.get());
+    tabletOptions.ioOptions = *ioReaderOptions_;
     if (enableCache() || pinFileMetadata()) {
       auto& ids = velox::fileIds();
       auto fileIdStr = fmt::format("testFile_{}", nextFileId_++);
-      velox::StringIdLease fileId(ids, fileIdStr);
-      velox::StringIdLease groupId(ids, "testGroup");
-      velox::io::ReaderOptions ioReaderOpts(pool);
-      ioReaderOpts.setDataIoStats(dataIoStats_.get());
-      ioReaderOpts.setMetadataIoStats(metadataIoStats_.get());
+      fileHandle_ = std::make_unique<velox::FileHandle>();
+      fileHandle_->file = readFile;
+      fileHandle_->uuid = velox::StringIdLease(ids, fileIdStr);
+      fileHandle_->groupId = velox::StringIdLease(ids, "testGroup");
       if (cache_ != nullptr) {
-        cachedInput_ =
-            std::make_unique<velox::dwio::common::CachedBufferedInput>(
-                readFile,
-                velox::dwio::common::MetricsLog::voidLog(),
-                std::move(fileId),
-                cache_.get(),
-                scanTracker_,
-                std::move(groupId),
-                dataIoStats_,
-                nullptr, // ioStats
-                ioExecutor_.get(),
-                ioReaderOpts);
-      } else {
-        cachedInput_ =
-            std::make_unique<velox::dwio::common::DirectBufferedInput>(
-                readFile,
-                velox::dwio::common::MetricsLog::voidLog(),
-                std::move(fileId),
-                scanTracker_,
-                std::move(groupId),
-                dataIoStats_,
-                nullptr, // ioStats
-                ioExecutor_.get(),
-                ioReaderOpts);
+        tabletOptions.cache = cache_.get();
+        tabletOptions.fileHandle = fileHandle_.get();
       }
-      tabletOptions.bufferedInput = cachedInput_.get();
     }
     return nimble::TabletReader::create(readFile, pool, tabletOptions);
   }
@@ -1382,7 +1362,8 @@ class VeloxReaderTest : public ::testing::TestWithParam<TestParam> {
   std::shared_ptr<velox::cache::ScanTracker> scanTracker_;
   std::unique_ptr<folly::CPUThreadPoolExecutor> ioExecutor_;
   // Held alive for the duration of createTablet/createVeloxReader.
-  std::unique_ptr<velox::dwio::common::BufferedInput> cachedInput_;
+  std::unique_ptr<velox::FileHandle> fileHandle_;
+  std::unique_ptr<velox::io::ReaderOptions> ioReaderOptions_;
   uint64_t nextFileId_{0};
 };
 


### PR DESCRIPTION
Summary:
CONTEXT: TabletReader used BufferedInput for all metadata IO (footer, stripes, indexes, optional sections). This did not support IO coalescing or caching for metadata reads, requiring multiple small reads. Index IO (ClusterIndex, HashIndex, SortedIndex) used callback-based loading patterns that hid the IO abstraction.

WHAT:
- Replace BufferedInput-based metadata IO in TabletReader with MetadataInput abstraction (DirectMetadataInput for non-cached, CachedMetadataInput for cached path).
- Support cache-aware initialization via initFromCache() with synthetic cache key at fileSize_.
- Add speculative vs adaptive footer loading: speculative reads once and extracts PS+footer from buffer; adaptive reads twice.
- Add EnqueuedSection with Type enum for unified stripes + optional sections coalesced loading.
- Add MetadataInput::LoadGuard RAII for exception-safe load/reset pairing.
- Make DirectMetadataInput/CachedMetadataInput constructors private, only accessible via MetadataInput::create factory methods.
- Add IndexLookup::Options struct with validate(), replacing IndexIOConfig. Supports shared_ptr<ReadFile> for clean lifetime management.
- Add createIndexMetadataInput/createIndexDataInput utilities in IndexLookup.cpp for creating MetadataInput (direct/cached) and BufferedInput (DirectBufferedInput/CachedBufferedInput) from Options.
- Refactor ClusterIndex to directly use MetadataInput + BufferedInput as members instead of LoadMetadataFn/LoadDataFn callbacks.
- Refactor HashIndex to directly use shared MetadataInput for partition loading.
- Refactor SortedIndex to directly use shared BufferedInput for key stream reads.
- Refactor DenseIndexRegistry to use Options-based create, passing MetadataInput and BufferedInput to HashIndex/SortedIndex.
- Move readerOptions assignment into TabletReader::configureOptions so callers do not need to set it separately.
- Replace IOBuf usage with string_view and BufferPtr for metadata decompression.
- Add cacheWarmPath tests for both TabletTest and TabletWithIndexTest.
- Add concurrent cache test (concurrentCacheAndFind) verifying findCachedMetadata blocks while exclusive pin is held.
- Add IndexLookup::Options validate/factory tests including cached path.
- Add LoadGuard tests for both direct and cached MetadataInput.
- Fix findCachedMetadata to return nullptr on cache miss instead of asserting.

Benchmark (nimble_index_projector, 60s, 3 runs, A/B on same master):
                Baseline (master)     With changes        Delta
  Batches/60s   1302 / 1311 / 1307    1301 / 1276 / 1276  ~same (within noise)
  Wall/batch    46.03 / 45.72 / 45.84 46.07 / 46.96 / 46.98 ~same
  Peak memory   25.24 / 22.19 / 22.46 22.58 / 22.81 / 23.05 ~same

Differential Revision: D104349994
