### PR TITLE
Refactor ReaderOptions IoStatistics from raw pointers to shared_ptr (#723)

### DIFF
--- a/dwio/nimble/encodings/tests/ReadWithVisitorTest.cpp
+++ b/dwio/nimble/encodings/tests/ReadWithVisitorTest.cpp
@@ -142,8 +142,9 @@ class ReadWithVisitorTest : public ::testing::TestWithParam<bool>,
     ctx->fileData = test::createNimbleFile(*rootPool_, input);
 
     auto readFile = std::make_shared<InMemoryReadFile>(ctx->fileData);
-    dwio::common::ReaderOptions readerOpts(
-        pool(), dataIoStats_.get(), metadataIoStats_.get());
+    dwio::common::ReaderOptions readerOpts(pool());
+    readerOpts.setDataIoStats(dataIoStats_);
+    readerOpts.setMetadataIoStats(metadataIoStats_);
     ctx->readerBase = ReaderBase::create(
         std::make_unique<dwio::common::BufferedInput>(readFile, *pool()),
         readerOpts);

--- a/dwio/nimble/index/IndexLookup.cpp
+++ b/dwio/nimble/index/IndexLookup.cpp
@@ -50,11 +50,10 @@ std::unique_ptr<velox::dwio::common::BufferedInput> createIndexDataInput(
     const IndexLookup::Options& options,
     velox::memory::MemoryPool& pool) {
   auto readFile = options.file;
-  auto* rawStats = options.ioOptions->indexIoStats();
-  auto indexIoStats = rawStats != nullptr
-      ? std::shared_ptr<velox::io::IoStatistics>(
-            std::shared_ptr<velox::io::IoStatistics>{}, rawStats)
-      : std::make_shared<velox::io::IoStatistics>();
+  auto indexIoStats = options.ioOptions->indexIoStats();
+  if (indexIoStats == nullptr) {
+    indexIoStats = std::make_shared<velox::io::IoStatistics>();
+  }
   if (options.cache != nullptr) {
     return std::make_unique<velox::dwio::common::CachedBufferedInput>(
         std::move(readFile),

--- a/dwio/nimble/index/tests/ClusterIndexTestBase.cpp
+++ b/dwio/nimble/index/tests/ClusterIndexTestBase.cpp
@@ -352,9 +352,9 @@ std::unique_ptr<ClusterIndex> ClusterIndexTestBase::createClusterIndex(
 
   metadataFile_ =
       std::make_shared<velox::InMemoryReadFile>(indexBuffers.indexPartitions);
-  ioStats_ = std::make_unique<velox::io::IoStatistics>();
+  ioStats_ = std::make_shared<velox::io::IoStatistics>();
   velox::io::ReaderOptions readerOptions(pool_.get());
-  readerOptions.setMetadataIoStats(ioStats_.get());
+  readerOptions.setMetadataIoStats(ioStats_);
   auto metadataInput =
       MetadataInput::create(metadataFile_.get(), readerOptions);
 

--- a/dwio/nimble/index/tests/ClusterIndexTestBase.h
+++ b/dwio/nimble/index/tests/ClusterIndexTestBase.h
@@ -113,7 +113,7 @@ class ClusterIndexTestBase : public ::testing::Test {
   std::shared_ptr<velox::memory::MemoryPool> pool_{
       rootPool_->addLeafChild("ClusterIndexTestBase")};
   std::shared_ptr<velox::ReadFile> metadataFile_;
-  std::unique_ptr<velox::io::IoStatistics> ioStats_;
+  std::shared_ptr<velox::io::IoStatistics> ioStats_;
 };
 
 } // namespace facebook::nimble::index::test

--- a/dwio/nimble/index/tests/ClusterIndexWriterTest.cpp
+++ b/dwio/nimble/index/tests/ClusterIndexWriterTest.cpp
@@ -1121,9 +1121,9 @@ TEST_P(ClusterIndexWriterChunkTest, maxRowsPerKeyChunk) {
           pool_.get()))};
   auto metadataFile =
       std::make_shared<velox::InMemoryReadFile>(partitionMetadata[0]);
-  velox::io::IoStatistics ioStats;
+  auto ioStats = std::make_shared<velox::io::IoStatistics>();
   velox::io::ReaderOptions readerOptions(pool_.get());
-  readerOptions.setMetadataIoStats(&ioStats);
+  readerOptions.setMetadataIoStats(ioStats);
   auto metadataInput = MetadataInput::create(metadataFile.get(), readerOptions);
   auto dataInput = std::make_unique<velox::dwio::common::BufferedInput>(
       std::make_shared<velox::InMemoryReadFile>(keyStreamData), *pool_);

--- a/dwio/nimble/index/tests/DenseIndexRegistryTest.cpp
+++ b/dwio/nimble/index/tests/DenseIndexRegistryTest.cpp
@@ -97,10 +97,10 @@ class DenseIndexRegistryTest : public ::testing::Test {
   std::shared_ptr<TabletReader> openTablet(const std::string& filePath) {
     auto fs = velox::filesystems::getFileSystem(filePath, {});
     auto readFile = fs->openFileForRead(filePath);
-    ioStats_ = std::make_unique<velox::io::IoStatistics>();
+    ioStats_ = std::make_shared<velox::io::IoStatistics>();
     readerOptions_ =
         std::make_unique<velox::io::ReaderOptions>(leafPool_.get());
-    readerOptions_->setMetadataIoStats(ioStats_.get());
+    readerOptions_->setMetadataIoStats(ioStats_);
     TabletReader::Options options;
     options.ioOptions = *readerOptions_;
     return TabletReader::create(std::move(readFile), leafPool_.get(), options);
@@ -114,15 +114,15 @@ class DenseIndexRegistryTest : public ::testing::Test {
   std::shared_ptr<velox::memory::MemoryPool> leafPool_;
   std::shared_ptr<velox::common::testutil::TempDirectoryPath> tempDir_;
   std::deque<std::string> valueStrings_;
-  std::unique_ptr<velox::io::IoStatistics> ioStats_;
+  std::shared_ptr<velox::io::IoStatistics> ioStats_;
   std::unique_ptr<velox::io::ReaderOptions> readerOptions_;
 };
 
 TEST_F(DenseIndexRegistryTest, emptyRegistry) {
   auto file = std::make_shared<velox::InMemoryReadFile>(std::string{});
-  velox::io::IoStatistics ioStats;
+  auto ioStats = std::make_shared<velox::io::IoStatistics>();
   velox::io::ReaderOptions ioOptions(leafPool_.get());
-  ioOptions.setMetadataIoStats(&ioStats);
+  ioOptions.setMetadataIoStats(ioStats);
   IndexLookup::Options options{.file = file, .ioOptions = &ioOptions};
   auto registry = DenseIndexRegistry::create(
       std::nullopt, std::nullopt, options, leafPool_.get());

--- a/dwio/nimble/index/tests/IndexLookupTest.cpp
+++ b/dwio/nimble/index/tests/IndexLookupTest.cpp
@@ -280,9 +280,9 @@ TEST_F(IndexLookupTest, createIndexMetadataInput) {
     SCOPED_TRACE(testData.debugString());
     auto file = std::make_shared<velox::InMemoryReadFile>(std::string{});
     auto pool = velox::memory::memoryManager()->addLeafPool();
-    velox::io::IoStatistics metadataIoStats;
+    auto metadataIoStats = std::make_shared<velox::io::IoStatistics>();
     velox::io::ReaderOptions ioOptions(pool.get());
-    ioOptions.setMetadataIoStats(&metadataIoStats);
+    ioOptions.setMetadataIoStats(metadataIoStats);
 
     std::shared_ptr<velox::memory::MallocAllocator> allocator;
     std::shared_ptr<velox::cache::AsyncDataCache> cache;
@@ -322,12 +322,12 @@ TEST_F(IndexLookupTest, createIndexDataInput) {
     SCOPED_TRACE(testData.debugString());
     auto file = std::make_shared<velox::InMemoryReadFile>(std::string{});
     auto pool = velox::memory::memoryManager()->addLeafPool();
-    velox::io::IoStatistics metadataIoStats;
-    velox::io::IoStatistics indexIoStats;
+    auto metadataIoStats = std::make_shared<velox::io::IoStatistics>();
+    auto indexIoStats = std::make_shared<velox::io::IoStatistics>();
     velox::io::ReaderOptions ioOptions(pool.get());
-    ioOptions.setMetadataIoStats(&metadataIoStats);
+    ioOptions.setMetadataIoStats(metadataIoStats);
     if (testData.hasIndexIoStats) {
-      ioOptions.setIndexIoStats(&indexIoStats);
+      ioOptions.setIndexIoStats(indexIoStats);
     }
 
     std::shared_ptr<velox::memory::MallocAllocator> allocator;

--- a/dwio/nimble/tablet/FileLayout.cpp
+++ b/dwio/nimble/tablet/FileLayout.cpp
@@ -27,13 +27,13 @@ namespace facebook::nimble {
 FileLayout FileLayout::create(
     std::shared_ptr<velox::ReadFile> file,
     velox::memory::MemoryPool* pool) {
-  velox::io::IoStatistics dataStats;
-  velox::io::IoStatistics metadataStats;
-  velox::io::IoStatistics indexStats;
+  auto dataStats = std::make_shared<velox::io::IoStatistics>();
+  auto metadataStats = std::make_shared<velox::io::IoStatistics>();
+  auto indexStats = std::make_shared<velox::io::IoStatistics>();
   velox::io::ReaderOptions readerOptions(pool);
-  readerOptions.setDataIoStats(&dataStats);
-  readerOptions.setMetadataIoStats(&metadataStats);
-  readerOptions.setIndexIoStats(&indexStats);
+  readerOptions.setDataIoStats(dataStats);
+  readerOptions.setMetadataIoStats(metadataStats);
+  readerOptions.setIndexIoStats(indexStats);
   TabletReader::Options options;
   options.ioOptions = readerOptions;
   auto tablet = TabletReader::create(std::move(file), pool, options);

--- a/dwio/nimble/tablet/MetadataInput.cpp
+++ b/dwio/nimble/tablet/MetadataInput.cpp
@@ -83,7 +83,7 @@ MetadataInput::MetadataInput(
       maxCoalesceBytes_{options.maxCoalesceBytes()},
       executor_{options.ioExecutor().get()},
       ioStats_{options.metadataIoStats()} {
-  NIMBLE_CHECK_NOT_NULL(ioStats_);
+  NIMBLE_CHECK_NOT_NULL(ioStats_.get());
 }
 
 MetadataHandle MetadataInput::enqueue(const MetadataSection& section) {
@@ -238,7 +238,7 @@ void MetadataInput::executeIoGroups(std::vector<IoGroup>& ioGroups) {
         }));
   }
 
-  QueryIoLatencyGuard queryIoGuard{ioStats_};
+  QueryIoLatencyGuard queryIoGuard{ioStats_.get()};
   if (executor_ != nullptr && asyncIos.size() > 1) {
     for (size_t i = 0; i + 1 < asyncIos.size(); ++i) {
       executor_->add([&asyncIo = asyncIos[i]]() { asyncIo->prepare(); });

--- a/dwio/nimble/tablet/MetadataInput.h
+++ b/dwio/nimble/tablet/MetadataInput.h
@@ -217,7 +217,7 @@ class MetadataInput {
   // Max total bytes per coalesced IO batch.
   const int64_t maxCoalesceBytes_;
   folly::Executor* const executor_;
-  velox::io::IoStatistics* const ioStats_;
+  const std::shared_ptr<velox::io::IoStatistics> ioStats_;
 
   std::vector<LoadedSection> sections_;
   bool loaded_{false};

--- a/dwio/nimble/tablet/TabletReader.cpp
+++ b/dwio/nimble/tablet/TabletReader.cpp
@@ -232,7 +232,7 @@ TabletReader::TabletReader(
       loadClusterIndex_{options.loadClusterIndex},
       loadChunkIndex_{options.loadChunkIndex},
       loadDenseIndexes_{options.loadDenseIndexes},
-      defaultIoStats_{[&]() -> std::unique_ptr<velox::io::IoStatistics> {
+      defaultIoStats_{[&]() -> std::shared_ptr<velox::io::IoStatistics> {
         if (options.ioOptions.has_value() &&
             options.ioOptions->metadataIoStats() != nullptr) {
           return nullptr;
@@ -243,12 +243,12 @@ TabletReader::TabletReader(
         if (options.ioOptions.has_value()) {
           auto opts = *options.ioOptions;
           if (opts.metadataIoStats() == nullptr) {
-            opts.setMetadataIoStats(defaultIoStats_.get());
+            opts.setMetadataIoStats(defaultIoStats_);
           }
           return opts;
         }
         velox::io::ReaderOptions opts(&pool);
-        opts.setMetadataIoStats(defaultIoStats_.get());
+        opts.setMetadataIoStats(defaultIoStats_);
         return opts;
       }()},
       indexOptions_{index::IndexLookup::Options{

--- a/dwio/nimble/tablet/TabletReader.h
+++ b/dwio/nimble/tablet/TabletReader.h
@@ -500,7 +500,7 @@ class TabletReader {
   const bool loadChunkIndex_;
   const bool loadDenseIndexes_;
   // Default IO stats when caller doesn't provide ioOptions.
-  const std::unique_ptr<velox::io::IoStatistics> defaultIoStats_;
+  const std::shared_ptr<velox::io::IoStatistics> defaultIoStats_;
   // Resolved IO options — either copied from Options or created with defaults.
   const velox::io::ReaderOptions ioOptions_;
   // IO config for index creation — indexes create their own MetadataInput

--- a/dwio/nimble/tablet/tests/MetadataInputTest.cpp
+++ b/dwio/nimble/tablet/tests/MetadataInputTest.cpp
@@ -121,8 +121,8 @@ class MetadataInputTestBase : public ::testing::Test {
       int32_t maxCoalesceDistance = 1 << 20,
       int64_t maxCoalesceBytes = 128 << 20) {
     velox::io::ReaderOptions options(pool_.get());
-    options.setDataIoStats(&dataIoStats_);
-    options.setMetadataIoStats(&metadataIoStats_);
+    options.setDataIoStats(dataIoStats_);
+    options.setMetadataIoStats(metadataIoStats_);
     options.setMaxCoalesceDistance(maxCoalesceDistance);
     options.setMaxCoalesceBytes(maxCoalesceBytes);
     return options;
@@ -130,8 +130,10 @@ class MetadataInputTestBase : public ::testing::Test {
 
   std::shared_ptr<velox::memory::MemoryPool> rootPool_;
   std::shared_ptr<velox::memory::MemoryPool> pool_;
-  velox::io::IoStatistics dataIoStats_;
-  velox::io::IoStatistics metadataIoStats_;
+  std::shared_ptr<velox::io::IoStatistics> dataIoStats_{
+      std::make_shared<velox::io::IoStatistics>()};
+  std::shared_ptr<velox::io::IoStatistics> metadataIoStats_{
+      std::make_shared<velox::io::IoStatistics>()};
 };
 
 struct SectionSpec {
@@ -393,38 +395,38 @@ TEST_F(DirectMetadataInputTest, ioStats) {
       std::make_shared<nimble::testing::TrackingReadFile>(innerFile);
   readFile->setReadDelayUs(kInjectedDelayUs);
 
-  const auto readCountBefore = metadataIoStats_.read().count();
-  const auto readSumBefore = metadataIoStats_.read().sum();
-  const auto rawBytesBefore = metadataIoStats_.rawBytesRead();
-  const auto overreadBefore = metadataIoStats_.rawOverreadBytes();
-  const auto totalScanTimeBefore = metadataIoStats_.totalScanTimeNs();
+  const auto readCountBefore = metadataIoStats_->read().count();
+  const auto readSumBefore = metadataIoStats_->read().sum();
+  const auto rawBytesBefore = metadataIoStats_->rawBytesRead();
+  const auto overreadBefore = metadataIoStats_->rawOverreadBytes();
+  const auto totalScanTimeBefore = metadataIoStats_->totalScanTimeNs();
   const auto storageLatencySumBefore =
-      metadataIoStats_.storageReadLatencyUs().sum();
+      metadataIoStats_->storageReadLatencyUs().sum();
   const auto storageLatencyCountBefore =
-      metadataIoStats_.storageReadLatencyUs().count();
+      metadataIoStats_->storageReadLatencyUs().count();
   const auto queryIoLatencyCountBefore =
-      metadataIoStats_.queryThreadIoLatencyUs().count();
+      metadataIoStats_->queryThreadIoLatencyUs().count();
 
   const auto options = makeReaderOptions();
   auto input = nimble::MetadataInput::create(readFile.get(), options);
   input->enqueue(section);
   input->load();
 
-  EXPECT_GT(metadataIoStats_.read().count(), readCountBefore);
-  EXPECT_EQ(metadataIoStats_.read().sum() - readSumBefore, data.size());
-  EXPECT_EQ(metadataIoStats_.rawBytesRead() - rawBytesBefore, data.size());
-  EXPECT_EQ(metadataIoStats_.rawOverreadBytes(), overreadBefore);
+  EXPECT_GT(metadataIoStats_->read().count(), readCountBefore);
+  EXPECT_EQ(metadataIoStats_->read().sum() - readSumBefore, data.size());
+  EXPECT_EQ(metadataIoStats_->rawBytesRead() - rawBytesBefore, data.size());
+  EXPECT_EQ(metadataIoStats_->rawOverreadBytes(), overreadBefore);
   EXPECT_GE(
-      metadataIoStats_.totalScanTimeNs() - totalScanTimeBefore,
+      metadataIoStats_->totalScanTimeNs() - totalScanTimeBefore,
       kInjectedDelayUs * 1'000);
   EXPECT_GT(
-      metadataIoStats_.storageReadLatencyUs().count(),
+      metadataIoStats_->storageReadLatencyUs().count(),
       storageLatencyCountBefore);
   EXPECT_GE(
-      metadataIoStats_.storageReadLatencyUs().sum() - storageLatencySumBefore,
+      metadataIoStats_->storageReadLatencyUs().sum() - storageLatencySumBefore,
       kInjectedDelayUs);
   EXPECT_GT(
-      metadataIoStats_.queryThreadIoLatencyUs().count(),
+      metadataIoStats_->queryThreadIoLatencyUs().count(),
       queryIoLatencyCountBefore);
 }
 
@@ -509,8 +511,8 @@ DEBUG_ONLY_TEST_F(DirectMetadataInputTest, ioCoalescing) {
 
     auto readFile = std::make_shared<velox::InMemoryReadFile>(fileContent);
 
-    const auto rawBytesBefore = metadataIoStats_.rawBytesRead();
-    const auto overreadBefore = metadataIoStats_.rawOverreadBytes();
+    const auto rawBytesBefore = metadataIoStats_->rawBytesRead();
+    const auto overreadBefore = metadataIoStats_->rawOverreadBytes();
 
     velox::CoalesceIoStats capturedStats;
     SCOPED_TESTVALUE_SET(
@@ -536,9 +538,10 @@ DEBUG_ONLY_TEST_F(DirectMetadataInputTest, ioCoalescing) {
       expectedPayloadBytes += s.size;
     }
     EXPECT_EQ(
-        metadataIoStats_.rawBytesRead() - rawBytesBefore, expectedPayloadBytes);
+        metadataIoStats_->rawBytesRead() - rawBytesBefore,
+        expectedPayloadBytes);
     EXPECT_EQ(
-        metadataIoStats_.rawOverreadBytes() - overreadBefore,
+        metadataIoStats_->rawOverreadBytes() - overreadBefore,
         testData.expectedOverread);
   }
 }
@@ -814,9 +817,9 @@ TEST_P(CachedMetadataInputTest, enqueueLoadReadWithCache) {
 
     // First load — populates cache, expect zero ram hits.
     {
-      const auto ramHitBefore = metadataIoStats_.ramHit().count();
+      const auto ramHitBefore = metadataIoStats_->ramHit().count();
       const auto storageLatencyBefore =
-          metadataIoStats_.storageReadLatencyUs().count();
+          metadataIoStats_->storageReadLatencyUs().count();
       auto input = createCachedInput(readFile.get());
       std::vector<nimble::MetadataHandle> handles;
       for (const auto& section : sections) {
@@ -826,9 +829,9 @@ TEST_P(CachedMetadataInputTest, enqueueLoadReadWithCache) {
       for (uint32_t i = 0; i < handles.size(); ++i) {
         EXPECT_EQ(handles[i].read()->content(), testData.specs[i].data);
       }
-      EXPECT_EQ(metadataIoStats_.ramHit().count(), ramHitBefore);
+      EXPECT_EQ(metadataIoStats_->ramHit().count(), ramHitBefore);
       EXPECT_GT(
-          metadataIoStats_.storageReadLatencyUs().count(),
+          metadataIoStats_->storageReadLatencyUs().count(),
           storageLatencyBefore);
     }
 
@@ -842,7 +845,7 @@ TEST_P(CachedMetadataInputTest, enqueueLoadReadWithCache) {
     // Second load — sections with uncompressed size hit cache directly.
     // Sections without it still go through loadFromFile → store().
     {
-      const auto ramHitBefore = metadataIoStats_.ramHit().count();
+      const auto ramHitBefore = metadataIoStats_->ramHit().count();
       auto input = createCachedInput(readFile.get());
       std::vector<nimble::MetadataHandle> handles;
       for (const auto& section : sections) {
@@ -853,7 +856,7 @@ TEST_P(CachedMetadataInputTest, enqueueLoadReadWithCache) {
         EXPECT_EQ(handles[i].read()->content(), testData.specs[i].data);
       }
       EXPECT_GE(
-          metadataIoStats_.ramHit().count() - ramHitBefore, sectionsWithSize);
+          metadataIoStats_->ramHit().count() - ramHitBefore, sectionsWithSize);
     }
 
     // Third load (SSD only) — flush RAM to SSD, clear RAM, read from SSD.
@@ -866,10 +869,10 @@ TEST_P(CachedMetadataInputTest, enqueueLoadReadWithCache) {
       // Clear RAM cache — entries survive on SSD.
       cache_->clear();
 
-      const auto ramHitBefore = metadataIoStats_.ramHit().count();
-      const auto ssdReadBefore = metadataIoStats_.ssdRead().count();
+      const auto ramHitBefore = metadataIoStats_->ramHit().count();
+      const auto ssdReadBefore = metadataIoStats_->ssdRead().count();
       const auto storageLatencyBefore =
-          metadataIoStats_.storageReadLatencyUs().count();
+          metadataIoStats_->storageReadLatencyUs().count();
 
       auto input = createCachedInput(readFile.get());
       std::vector<nimble::MetadataHandle> handles;
@@ -882,11 +885,12 @@ TEST_P(CachedMetadataInputTest, enqueueLoadReadWithCache) {
       }
 
       // No RAM hits, SSD hits for sections with known size, no file IO.
-      EXPECT_EQ(metadataIoStats_.ramHit().count(), ramHitBefore);
+      EXPECT_EQ(metadataIoStats_->ramHit().count(), ramHitBefore);
       EXPECT_GE(
-          metadataIoStats_.ssdRead().count() - ssdReadBefore, sectionsWithSize);
+          metadataIoStats_->ssdRead().count() - ssdReadBefore,
+          sectionsWithSize);
       EXPECT_EQ(
-          metadataIoStats_.storageReadLatencyUs().count(),
+          metadataIoStats_->storageReadLatencyUs().count(),
           storageLatencyBefore);
     }
   }
@@ -1022,9 +1026,9 @@ DEBUG_ONLY_TEST_P(CachedMetadataInputTest, ioCoalescing) {
 
     // First load — cold cache, expect file IO with coalescing.
     {
-      const auto rawBytesBefore = metadataIoStats_.rawBytesRead();
-      const auto overreadBefore = metadataIoStats_.rawOverreadBytes();
-      const auto ramHitBefore = metadataIoStats_.ramHit().count();
+      const auto rawBytesBefore = metadataIoStats_->rawBytesRead();
+      const auto overreadBefore = metadataIoStats_->rawOverreadBytes();
+      const auto ramHitBefore = metadataIoStats_->ramHit().count();
 
       velox::CoalesceIoStats capturedStats;
       SCOPED_TESTVALUE_SET(
@@ -1046,21 +1050,21 @@ DEBUG_ONLY_TEST_P(CachedMetadataInputTest, ioCoalescing) {
       EXPECT_EQ(capturedStats.numIos, testData.expectedNumIos);
       EXPECT_EQ(capturedStats.extraBytes, testData.expectedOverread);
       EXPECT_EQ(
-          metadataIoStats_.rawBytesRead() - rawBytesBefore,
+          metadataIoStats_->rawBytesRead() - rawBytesBefore,
           expectedPayloadBytes);
       EXPECT_EQ(
-          metadataIoStats_.rawOverreadBytes() - overreadBefore,
+          metadataIoStats_->rawOverreadBytes() - overreadBefore,
           testData.expectedOverread);
-      EXPECT_EQ(metadataIoStats_.ramHit().count(), ramHitBefore);
+      EXPECT_EQ(metadataIoStats_->ramHit().count(), ramHitBefore);
     }
 
     // Second load — warm cache, expect all RAM hits, zero file IO.
     {
-      const auto rawBytesBefore = metadataIoStats_.rawBytesRead();
-      const auto overreadBefore = metadataIoStats_.rawOverreadBytes();
-      const auto ramHitBefore = metadataIoStats_.ramHit().count();
+      const auto rawBytesBefore = metadataIoStats_->rawBytesRead();
+      const auto overreadBefore = metadataIoStats_->rawOverreadBytes();
+      const auto ramHitBefore = metadataIoStats_->ramHit().count();
       const auto storageLatencyBefore =
-          metadataIoStats_.storageReadLatencyUs().count();
+          metadataIoStats_->storageReadLatencyUs().count();
 
       auto input = createCachedInput(readFile.get());
       for (const auto& section : sections) {
@@ -1068,12 +1072,12 @@ DEBUG_ONLY_TEST_P(CachedMetadataInputTest, ioCoalescing) {
       }
       input->load();
 
-      EXPECT_EQ(metadataIoStats_.rawBytesRead(), rawBytesBefore);
-      EXPECT_EQ(metadataIoStats_.rawOverreadBytes(), overreadBefore);
+      EXPECT_EQ(metadataIoStats_->rawBytesRead(), rawBytesBefore);
+      EXPECT_EQ(metadataIoStats_->rawOverreadBytes(), overreadBefore);
       EXPECT_EQ(
-          metadataIoStats_.ramHit().count() - ramHitBefore, sections.size());
+          metadataIoStats_->ramHit().count() - ramHitBefore, sections.size());
       EXPECT_EQ(
-          metadataIoStats_.storageReadLatencyUs().count(),
+          metadataIoStats_->storageReadLatencyUs().count(),
           storageLatencyBefore);
     }
 
@@ -1084,12 +1088,12 @@ DEBUG_ONLY_TEST_P(CachedMetadataInputTest, ioCoalescing) {
       cache_->ssdCache()->waitForWriteToFinish();
       cache_->clear();
 
-      const auto rawBytesBefore = metadataIoStats_.rawBytesRead();
-      const auto overreadBefore = metadataIoStats_.rawOverreadBytes();
-      const auto ramHitBefore = metadataIoStats_.ramHit().count();
-      const auto ssdReadBefore = metadataIoStats_.ssdRead().count();
+      const auto rawBytesBefore = metadataIoStats_->rawBytesRead();
+      const auto overreadBefore = metadataIoStats_->rawOverreadBytes();
+      const auto ramHitBefore = metadataIoStats_->ramHit().count();
+      const auto ssdReadBefore = metadataIoStats_->ssdRead().count();
       const auto storageLatencyBefore =
-          metadataIoStats_.storageReadLatencyUs().count();
+          metadataIoStats_->storageReadLatencyUs().count();
 
       auto input = createCachedInput(readFile.get());
       for (const auto& section : sections) {
@@ -1098,13 +1102,13 @@ DEBUG_ONLY_TEST_P(CachedMetadataInputTest, ioCoalescing) {
       input->load();
 
       // No RAM hits, all SSD hits, no file IO, no overread.
-      EXPECT_EQ(metadataIoStats_.rawBytesRead(), rawBytesBefore);
-      EXPECT_EQ(metadataIoStats_.rawOverreadBytes(), overreadBefore);
-      EXPECT_EQ(metadataIoStats_.ramHit().count(), ramHitBefore);
+      EXPECT_EQ(metadataIoStats_->rawBytesRead(), rawBytesBefore);
+      EXPECT_EQ(metadataIoStats_->rawOverreadBytes(), overreadBefore);
+      EXPECT_EQ(metadataIoStats_->ramHit().count(), ramHitBefore);
       EXPECT_EQ(
-          metadataIoStats_.ssdRead().count() - ssdReadBefore, sections.size());
+          metadataIoStats_->ssdRead().count() - ssdReadBefore, sections.size());
       EXPECT_EQ(
-          metadataIoStats_.storageReadLatencyUs().count(),
+          metadataIoStats_->storageReadLatencyUs().count(),
           storageLatencyBefore);
     }
   }
@@ -1143,14 +1147,14 @@ TEST_P(CachedMetadataInputTest, partialCacheHit) {
 
   // Load both sections — section0 should be a cache hit, section1 a miss.
   {
-    const auto ramHitBefore = metadataIoStats_.ramHit().count();
+    const auto ramHitBefore = metadataIoStats_->ramHit().count();
     auto input = createCachedInput(readFile.get());
     auto handle0 = input->enqueue(section0);
     auto handle1 = input->enqueue(section1);
     input->load();
     EXPECT_EQ(handle0.read()->content(), data0);
     EXPECT_EQ(handle1.read()->content(), data1);
-    EXPECT_GT(metadataIoStats_.ramHit().count(), ramHitBefore);
+    EXPECT_GT(metadataIoStats_->ramHit().count(), ramHitBefore);
   }
 
   // SSD partial hit: flush section0+section1 to SSD, clear RAM, then load
@@ -1170,10 +1174,10 @@ TEST_P(CachedMetadataInputTest, partialCacheHit) {
       EXPECT_EQ(handle.read()->content(), data1);
     }
 
-    const auto ssdReadBefore = metadataIoStats_.ssdRead().count();
-    const auto ramHitBefore = metadataIoStats_.ramHit().count();
+    const auto ssdReadBefore = metadataIoStats_->ssdRead().count();
+    const auto ramHitBefore = metadataIoStats_->ramHit().count();
     const auto storageLatencyBefore =
-        metadataIoStats_.storageReadLatencyUs().count();
+        metadataIoStats_->storageReadLatencyUs().count();
     {
       auto input = createCachedInput(readFile.get());
       auto handle0 = input->enqueue(section0);
@@ -1183,10 +1187,10 @@ TEST_P(CachedMetadataInputTest, partialCacheHit) {
       EXPECT_EQ(handle1.read()->content(), data1);
     }
     // section0 from SSD, section1 from RAM, no file IO.
-    EXPECT_GT(metadataIoStats_.ssdRead().count(), ssdReadBefore);
-    EXPECT_GT(metadataIoStats_.ramHit().count(), ramHitBefore);
+    EXPECT_GT(metadataIoStats_->ssdRead().count(), ssdReadBefore);
+    EXPECT_GT(metadataIoStats_->ramHit().count(), ramHitBefore);
     EXPECT_EQ(
-        metadataIoStats_.storageReadLatencyUs().count(), storageLatencyBefore);
+        metadataIoStats_->storageReadLatencyUs().count(), storageLatencyBefore);
   }
 }
 
@@ -1342,7 +1346,7 @@ TEST_P(CachedMetadataInputTest, cachePinRetention) {
 
   // A second load should still hit RAM cache because the pin keeps the
   // entry alive even after clear().
-  const auto ramHitBefore = metadataIoStats_.ramHit().count();
+  const auto ramHitBefore = metadataIoStats_->ramHit().count();
   {
     auto input2 = createCachedInput(readFile.get());
     auto handle2 = input2->enqueue(section);
@@ -1351,7 +1355,7 @@ TEST_P(CachedMetadataInputTest, cachePinRetention) {
     ASSERT_NE(buffer2, nullptr);
     EXPECT_EQ(buffer2->content(), data);
   }
-  EXPECT_GT(metadataIoStats_.ramHit().count(), ramHitBefore);
+  EXPECT_GT(metadataIoStats_->ramHit().count(), ramHitBefore);
 
   // Drop the original buffer — releases the pin.
   buffer.reset();
@@ -1360,9 +1364,9 @@ TEST_P(CachedMetadataInputTest, cachePinRetention) {
   cache_->clear();
 
   // Third load — cold miss, requires file IO.
-  const auto ramHitBefore2 = metadataIoStats_.ramHit().count();
+  const auto ramHitBefore2 = metadataIoStats_->ramHit().count();
   const auto storageLatencyBefore =
-      metadataIoStats_.storageReadLatencyUs().count();
+      metadataIoStats_->storageReadLatencyUs().count();
   {
     auto input3 = createCachedInput(readFile.get());
     auto handle3 = input3->enqueue(section);
@@ -1371,9 +1375,9 @@ TEST_P(CachedMetadataInputTest, cachePinRetention) {
     ASSERT_NE(buffer3, nullptr);
     EXPECT_EQ(buffer3->content(), data);
   }
-  EXPECT_EQ(metadataIoStats_.ramHit().count(), ramHitBefore2);
+  EXPECT_EQ(metadataIoStats_->ramHit().count(), ramHitBefore2);
   EXPECT_GT(
-      metadataIoStats_.storageReadLatencyUs().count(), storageLatencyBefore);
+      metadataIoStats_->storageReadLatencyUs().count(), storageLatencyBefore);
 }
 
 TEST_P(CachedMetadataInputTest, loadGuard) {

--- a/dwio/nimble/tablet/tests/TabletTest.cpp
+++ b/dwio/nimble/tablet/tests/TabletTest.cpp
@@ -208,9 +208,9 @@ class TabletTest : public ::testing::TestWithParam<BufferedInputMode> {
   void ensureReaderOptions() {
     if (readerOptions_ == nullptr) {
       readerOptions_ = std::make_unique<velox::io::ReaderOptions>(pool_.get());
-      readerOptions_->setDataIoStats(dataIoStats_.get());
-      readerOptions_->setMetadataIoStats(metadataIoStats_.get());
-      readerOptions_->setIndexIoStats(indexIoStats_.get());
+      readerOptions_->setDataIoStats(dataIoStats_);
+      readerOptions_->setMetadataIoStats(metadataIoStats_);
+      readerOptions_->setIndexIoStats(indexIoStats_);
     }
   }
 
@@ -4185,8 +4185,8 @@ TEST_P(TabletTest, configureOptionsIndexFlags) {
   };
 
   velox::dwio::common::ReaderOptions readerOptions(pool_.get());
-  readerOptions.setDataIoStats(dataIoStats_.get());
-  readerOptions.setMetadataIoStats(metadataIoStats_.get());
+  readerOptions.setDataIoStats(dataIoStats_);
+  readerOptions.setMetadataIoStats(metadataIoStats_);
 
   {
     SCOPED_TRACE("defaults");
@@ -4522,8 +4522,8 @@ TEST_F(TabletTest, concurrentReadersWithCacheEviction) {
     while (!stop.load(std::memory_order_relaxed)) {
       auto mode = static_cast<BufferedInputMode>(threadId % 4);
       velox::io::ReaderOptions readerOptions(threadPool.get());
-      readerOptions.setDataIoStats(dataIoStats_.get());
-      readerOptions.setMetadataIoStats(metadataIoStats_.get());
+      readerOptions.setDataIoStats(dataIoStats_);
+      readerOptions.setMetadataIoStats(metadataIoStats_);
       nimble::TabletReader::Options options;
       options.ioOptions = readerOptions;
 

--- a/dwio/nimble/velox/index/tests/NimbleIndexProjectorTest.cpp
+++ b/dwio/nimble/velox/index/tests/NimbleIndexProjectorTest.cpp
@@ -119,8 +119,8 @@ class NimbleIndexProjectorTest : public ::testing::TestWithParam<TestParam> {
     auto readFile =
         std::make_shared<InMemoryReadFile>(std::string_view(sinkData_));
     dwio::common::ReaderOptions readerOptions(leafPool_.get());
-    readerOptions.setDataIoStats(dataIoStats_.get());
-    readerOptions.setMetadataIoStats(metadataIoStats_.get());
+    readerOptions.setDataIoStats(dataIoStats_);
+    readerOptions.setMetadataIoStats(metadataIoStats_);
     readerOptions.setFileFormat(FileFormat::NIMBLE);
     readerOptions.setFileMetadataCacheEnabled(GetParam().enableCache);
     readerOptions.setPinFileMetadata(GetParam().pinFileMetadata);
@@ -889,8 +889,8 @@ TEST_P(NimbleIndexProjectorTest, featureReorderingStorageReads) {
     auto readFile =
         std::make_shared<InMemoryReadFile>(std::string_view(sinkData_));
     dwio::common::ReaderOptions readerOptions(leafPool_.get());
-    readerOptions.setDataIoStats(dataIoStats_.get());
-    readerOptions.setMetadataIoStats(metadataIoStats_.get());
+    readerOptions.setDataIoStats(dataIoStats_);
+    readerOptions.setMetadataIoStats(metadataIoStats_);
     readerOptions.setFileFormat(FileFormat::NIMBLE);
     readerOptions.setMaxCoalesceDistance(maxCoalesceDistance);
 
@@ -1044,8 +1044,8 @@ TEST_P(NimbleIndexProjectorTest, pinnedMetadataNoReread) {
   tablet.reset();
 
   dwio::common::ReaderOptions readerOptions(leafPool_.get());
-  readerOptions.setDataIoStats(dataIoStats_.get());
-  readerOptions.setMetadataIoStats(metadataIoStats_.get());
+  readerOptions.setDataIoStats(dataIoStats_);
+  readerOptions.setMetadataIoStats(metadataIoStats_);
   readerOptions.setFileFormat(FileFormat::NIMBLE);
   readerOptions.setFileMetadataCacheEnabled(GetParam().enableCache);
   readerOptions.setPinFileMetadata(GetParam().pinFileMetadata);

--- a/dwio/nimble/velox/selective/tests/ChunkedDecoderTest.cpp
+++ b/dwio/nimble/velox/selective/tests/ChunkedDecoderTest.cpp
@@ -100,8 +100,10 @@ class ChunkedDecoderTest : public testing::Test {
   }
 
  protected:
-  io::IoStatistics dataIoStats_;
-  io::IoStatistics metadataIoStats_;
+  std::shared_ptr<io::IoStatistics> dataIoStats_{
+      std::make_shared<io::IoStatistics>()};
+  std::shared_ptr<io::IoStatistics> metadataIoStats_{
+      std::make_shared<io::IoStatistics>()};
 
  private:
   std::shared_ptr<MemoryPool> leafPool_;
@@ -125,8 +127,9 @@ TEST_F(ChunkedDecoderTest, bufferedInput) {
   }
 
   auto file = std::make_shared<InMemoryReadFile>(fileContent);
-  dwio::common::ReaderOptions readerOpts{
-      &pool(), &dataIoStats_, &metadataIoStats_};
+  dwio::common::ReaderOptions readerOpts{&pool()};
+  readerOpts.setDataIoStats(dataIoStats_);
+  readerOpts.setMetadataIoStats(metadataIoStats_);
   readerOpts.setLoadQuantum(kLoadQuantum);
   auto executor = std::make_unique<folly::IOThreadPoolExecutor>(10, 10);
   auto input = std::make_unique<dwio::common::DirectBufferedInput>(

--- a/dwio/nimble/velox/selective/tests/E2EFilterTest.cpp
+++ b/dwio/nimble/velox/selective/tests/E2EFilterTest.cpp
@@ -380,8 +380,8 @@ class E2EFilterTest
       StringIdLease fileId(ids, "testFile");
       StringIdLease groupId(ids, "testGroup");
       io::ReaderOptions cacheReaderOpts(&readerOpts.memoryPool());
-      cacheReaderOpts.setDataIoStats(dataIoStats_.get());
-      cacheReaderOpts.setMetadataIoStats(metadataIoStats_.get());
+      cacheReaderOpts.setDataIoStats(dataIoStats_);
+      cacheReaderOpts.setMetadataIoStats(metadataIoStats_);
       input = std::make_unique<dwio::common::CachedBufferedInput>(
           std::move(readFile),
           dwio::common::MetricsLog::voidLog(),
@@ -1985,11 +1985,11 @@ TEST_P(E2EFilterTest, nestedMainlyConstantWithDictionary) {
       *leafPool_,
       velox::dwio::common::MetricsLog::voidLog());
 
-  velox::io::IoStatistics dataIoStats;
-  velox::io::IoStatistics metadataIoStats;
+  auto dataIoStats = std::make_shared<velox::io::IoStatistics>();
+  auto metadataIoStats = std::make_shared<velox::io::IoStatistics>();
   velox::dwio::common::ReaderOptions readerOpts(leafPool_.get());
-  readerOpts.setDataIoStats(&dataIoStats);
-  readerOpts.setMetadataIoStats(&metadataIoStats);
+  readerOpts.setDataIoStats(dataIoStats);
+  readerOpts.setMetadataIoStats(metadataIoStats);
   auto reader = makeReader(readerOpts, std::move(input));
   auto scanSpec = std::make_shared<velox::common::ScanSpec>("root");
   scanSpec->addAllChildFields(*type);
@@ -2078,11 +2078,11 @@ TEST_P(E2EFilterTest, dictionaryVectorReturned) {
       *leafPool_,
       velox::dwio::common::MetricsLog::voidLog());
 
-  velox::io::IoStatistics dataIoStats;
-  velox::io::IoStatistics metadataIoStats;
+  auto dataIoStats = std::make_shared<velox::io::IoStatistics>();
+  auto metadataIoStats = std::make_shared<velox::io::IoStatistics>();
   velox::dwio::common::ReaderOptions readerOpts(leafPool_.get());
-  readerOpts.setDataIoStats(&dataIoStats);
-  readerOpts.setMetadataIoStats(&metadataIoStats);
+  readerOpts.setDataIoStats(dataIoStats);
+  readerOpts.setMetadataIoStats(metadataIoStats);
   auto reader = makeReader(readerOpts, std::move(input));
   auto scanSpec = std::make_shared<velox::common::ScanSpec>("root");
   scanSpec->addAllChildFields(*type);
@@ -2214,11 +2214,11 @@ TEST_P(E2EFilterTest, crossChunkEncodingChange) {
       *leafPool_,
       velox::dwio::common::MetricsLog::voidLog());
 
-  velox::io::IoStatistics dataIoStats;
-  velox::io::IoStatistics metadataIoStats;
+  auto dataIoStats = std::make_shared<velox::io::IoStatistics>();
+  auto metadataIoStats = std::make_shared<velox::io::IoStatistics>();
   velox::dwio::common::ReaderOptions crossChunkReaderOpts(leafPool_.get());
-  crossChunkReaderOpts.setDataIoStats(&dataIoStats);
-  crossChunkReaderOpts.setMetadataIoStats(&metadataIoStats);
+  crossChunkReaderOpts.setDataIoStats(dataIoStats);
+  crossChunkReaderOpts.setMetadataIoStats(metadataIoStats);
   auto reader = makeReader(crossChunkReaderOpts, std::move(input));
   auto scanSpec = std::make_shared<velox::common::ScanSpec>("root");
   scanSpec->addAllChildFields(*type);
@@ -2298,8 +2298,9 @@ class NimbleExtractionTest : public E2EFilterTest {
 
     // Read.
     auto ioStats = std::make_shared<io::IoStatistics>();
-    dwio::common::ReaderOptions readerOpts{
-        leafPool_.get(), ioStats.get(), ioStats.get()};
+    dwio::common::ReaderOptions readerOpts(leafPool_.get());
+    readerOpts.setDataIoStats(ioStats);
+    readerOpts.setMetadataIoStats(ioStats);
     auto input = std::make_unique<dwio::common::BufferedInput>(
         std::make_shared<InMemoryReadFile>(sinkData_), readerOpts.memoryPool());
 

--- a/dwio/nimble/velox/selective/tests/E2EIndexTest.cpp
+++ b/dwio/nimble/velox/selective/tests/E2EIndexTest.cpp
@@ -339,8 +339,8 @@ class E2EIndexTestBase : public ::testing::Test {
     auto readFile =
         std::make_shared<InMemoryReadFile>(std::string_view(sinkData_));
     dwio::common::ReaderOptions readerOptions(leafPool_.get());
-    readerOptions.setDataIoStats(dataIoStats_.get());
-    readerOptions.setMetadataIoStats(metadataIoStats_.get());
+    readerOptions.setDataIoStats(dataIoStats_);
+    readerOptions.setMetadataIoStats(metadataIoStats_);
     readerOptions.setFileFormat(FileFormat::NIMBLE);
     setUpReaderOptions(readerOptions);
 
@@ -357,8 +357,8 @@ class E2EIndexTestBase : public ::testing::Test {
     StringIdLease fileId(ids, fmt::format("testFile_{}", readerId));
     StringIdLease groupId(ids, fmt::format("testGroup_{}", readerId));
     io::ReaderOptions ioReaderOpts(&readerOptions.memoryPool());
-    ioReaderOpts.setDataIoStats(dataIoStats_.get());
-    ioReaderOpts.setMetadataIoStats(metadataIoStats_.get());
+    ioReaderOpts.setDataIoStats(dataIoStats_);
+    ioReaderOpts.setMetadataIoStats(metadataIoStats_);
     if (cache_ != nullptr) {
       input = std::make_unique<CachedBufferedInput>(
           readFile,

--- a/dwio/nimble/velox/selective/tests/FlatMapColumnReaderTest.cpp
+++ b/dwio/nimble/velox/selective/tests/FlatMapColumnReaderTest.cpp
@@ -72,8 +72,8 @@ class FlatMapColumnReaderTest : public ::testing::TestWithParam<bool>,
     auto factory =
         dwio::common::getReaderFactory(dwio::common::FileFormat::NIMBLE);
     dwio::common::ReaderOptions options(pool());
-    options.setDataIoStats(dataIoStats_.get());
-    options.setMetadataIoStats(metadataIoStats_.get());
+    options.setDataIoStats(dataIoStats_);
+    options.setMetadataIoStats(metadataIoStats_);
     options.setScanSpec(scanSpec);
     Readers readers;
     readers.reader = factory->createReader(

--- a/dwio/nimble/velox/selective/tests/NimbleDataTest.cpp
+++ b/dwio/nimble/velox/selective/tests/NimbleDataTest.cpp
@@ -60,8 +60,9 @@ class NimbleDataTest : public ::testing::Test,
     auto readFile = std::make_shared<InMemoryReadFile>(file);
     auto factory =
         dwio::common::getReaderFactory(dwio::common::FileFormat::NIMBLE);
-    dwio::common::ReaderOptions options(
-        pool(), dataIoStats_.get(), metadataIoStats_.get());
+    dwio::common::ReaderOptions options(pool());
+    options.setDataIoStats(dataIoStats_);
+    options.setMetadataIoStats(metadataIoStats_);
     options.setScanSpec(scanSpec);
     Readers readers;
     readers.reader = factory->createReader(

--- a/dwio/nimble/velox/selective/tests/NullColumnReaderTest.cpp
+++ b/dwio/nimble/velox/selective/tests/NullColumnReaderTest.cpp
@@ -63,8 +63,9 @@ class NullColumnReaderTest : public ::testing::Test,
     auto readFile = std::make_shared<InMemoryReadFile>(file);
     auto factory =
         dwio::common::getReaderFactory(dwio::common::FileFormat::NIMBLE);
-    dwio::common::ReaderOptions options(
-        pool(), dataIoStats_.get(), metadataIoStats_.get());
+    dwio::common::ReaderOptions options(pool());
+    options.setDataIoStats(dataIoStats_);
+    options.setMetadataIoStats(metadataIoStats_);
     options.setScanSpec(scanSpec);
     Readers readers;
     readers.reader = factory->createReader(

--- a/dwio/nimble/velox/selective/tests/ScalarColumnReaderTest.cpp
+++ b/dwio/nimble/velox/selective/tests/ScalarColumnReaderTest.cpp
@@ -62,8 +62,9 @@ class ScalarColumnReaderTest : public ::testing::Test,
     auto readFile = std::make_shared<InMemoryReadFile>(file);
     auto factory =
         dwio::common::getReaderFactory(dwio::common::FileFormat::NIMBLE);
-    dwio::common::ReaderOptions options(
-        pool(), dataIoStats_.get(), metadataIoStats_.get());
+    dwio::common::ReaderOptions options(pool());
+    options.setDataIoStats(dataIoStats_);
+    options.setMetadataIoStats(metadataIoStats_);
     options.setScanSpec(scanSpec);
     Readers readers;
     readers.reader = factory->createReader(
@@ -100,8 +101,9 @@ class ScalarColumnReaderTest : public ::testing::Test,
     auto readFile = std::make_shared<InMemoryReadFile>(file);
     auto factory =
         dwio::common::getReaderFactory(dwio::common::FileFormat::NIMBLE);
-    dwio::common::ReaderOptions options(
-        pool(), dataIoStats_.get(), metadataIoStats_.get());
+    dwio::common::ReaderOptions options(pool());
+    options.setDataIoStats(dataIoStats_);
+    options.setMetadataIoStats(metadataIoStats_);
     options.setScanSpec(scanSpec);
     Readers readers;
     readers.reader = factory->createReader(

--- a/dwio/nimble/velox/selective/tests/SelectiveNimbleReaderTest.cpp
+++ b/dwio/nimble/velox/selective/tests/SelectiveNimbleReaderTest.cpp
@@ -142,8 +142,8 @@ class SelectiveNimbleReaderTest
     auto factory =
         dwio::common::getReaderFactory(dwio::common::FileFormat::NIMBLE);
     dwio::common::ReaderOptions options(pool());
-    options.setDataIoStats(dataIoStats_.get());
-    options.setMetadataIoStats(metadataIoStats_.get());
+    options.setDataIoStats(dataIoStats_);
+    options.setMetadataIoStats(metadataIoStats_);
     options.setScanSpec(scanSpec);
     options.setPinFileMetadata(GetParam().pinFileMetadata);
     std::unique_ptr<dwio::common::BufferedInput> input;
@@ -152,8 +152,8 @@ class SelectiveNimbleReaderTest
     StringIdLease fileId(ids, fmt::format("testFile_{}", readerId));
     StringIdLease groupId(ids, fmt::format("testGroup_{}", readerId));
     io::ReaderOptions ioReaderOpts(pool());
-    ioReaderOpts.setDataIoStats(dataIoStats_.get());
-    ioReaderOpts.setMetadataIoStats(metadataIoStats_.get());
+    ioReaderOpts.setDataIoStats(dataIoStats_);
+    ioReaderOpts.setMetadataIoStats(metadataIoStats_);
     if (cache_ != nullptr) {
       input = std::make_unique<dwio::common::CachedBufferedInput>(
           readFile,
@@ -1140,8 +1140,8 @@ TEST_P(SelectiveNimbleReaderTest, estimatedRowSize) {
     auto factory =
         dwio::common::getReaderFactory(dwio::common::FileFormat::NIMBLE);
     dwio::common::ReaderOptions options(pool());
-    options.setDataIoStats(dataIoStats_.get());
-    options.setMetadataIoStats(metadataIoStats_.get());
+    options.setDataIoStats(dataIoStats_);
+    options.setMetadataIoStats(metadataIoStats_);
     options.setScanSpec(structScanSpec);
     auto reader = factory->createReader(
         std::make_unique<dwio::common::BufferedInput>(readFile, *pool()),
@@ -1216,8 +1216,8 @@ TEST_P(SelectiveNimbleReaderTest, estimatedRowSizePartialProjection) {
     auto factory =
         dwio::common::getReaderFactory(dwio::common::FileFormat::NIMBLE);
     dwio::common::ReaderOptions options(pool());
-    options.setDataIoStats(dataIoStats_.get());
-    options.setMetadataIoStats(metadataIoStats_.get());
+    options.setDataIoStats(dataIoStats_);
+    options.setMetadataIoStats(metadataIoStats_);
     options.setScanSpec(partialSpec);
     auto reader = factory->createReader(
         std::make_unique<dwio::common::BufferedInput>(readFile, *pool()),
@@ -1317,8 +1317,8 @@ TEST_P(SelectiveNimbleReaderTest, estimatedRowSizeNestedRowPartialProjection) {
     auto factory =
         dwio::common::getReaderFactory(dwio::common::FileFormat::NIMBLE);
     dwio::common::ReaderOptions options(pool());
-    options.setDataIoStats(dataIoStats_.get());
-    options.setMetadataIoStats(metadataIoStats_.get());
+    options.setDataIoStats(dataIoStats_);
+    options.setMetadataIoStats(metadataIoStats_);
     options.setScanSpec(partialSpec);
     auto reader = factory->createReader(
         std::make_unique<dwio::common::BufferedInput>(readFile, *pool()),
@@ -2265,8 +2265,8 @@ TEST_P(SelectiveNimbleReaderTest, columnDecodeMetrics) {
   auto factory =
       dwio::common::getReaderFactory(dwio::common::FileFormat::NIMBLE);
   dwio::common::ReaderOptions options(pool());
-  options.setDataIoStats(dataIoStats_.get());
-  options.setMetadataIoStats(metadataIoStats_.get());
+  options.setDataIoStats(dataIoStats_);
+  options.setMetadataIoStats(metadataIoStats_);
   options.setScanSpec(scanSpec);
   auto reader = factory->createReader(
       std::make_unique<dwio::common::BufferedInput>(readFile, *pool()),
@@ -2451,8 +2451,8 @@ TEST_P(SelectiveNimbleReaderTest, pinFileMetadata) {
     auto factory =
         dwio::common::getReaderFactory(dwio::common::FileFormat::NIMBLE);
     dwio::common::ReaderOptions options(pool());
-    options.setDataIoStats(dataIoStats_.get());
-    options.setMetadataIoStats(metadataIoStats_.get());
+    options.setDataIoStats(dataIoStats_);
+    options.setMetadataIoStats(metadataIoStats_);
     options.setScanSpec(scanSpec);
     options.setPinFileMetadata(true);
     if (enableCache) {
@@ -2498,8 +2498,8 @@ TEST_P(SelectiveNimbleReaderTest, pinnedMetadataNoReread) {
   auto scanSpec = std::make_shared<common::ScanSpec>("root");
   scanSpec->addAllChildFields(*input->type());
   dwio::common::ReaderOptions options(pool());
-  options.setDataIoStats(dataIoStats_.get());
-  options.setMetadataIoStats(metadataIoStats_.get());
+  options.setDataIoStats(dataIoStats_);
+  options.setMetadataIoStats(metadataIoStats_);
   options.setScanSpec(scanSpec);
   options.setPinFileMetadata(true);
   options.setFileMetadataCacheEnabled(GetParam().enableCache);
@@ -2509,8 +2509,8 @@ TEST_P(SelectiveNimbleReaderTest, pinnedMetadataNoReread) {
   StringIdLease fileId(ids, fmt::format("testFile_{}", readerId));
   StringIdLease groupId(ids, fmt::format("testGroup_{}", readerId));
   io::ReaderOptions ioReaderOpts(pool());
-  ioReaderOpts.setDataIoStats(dataIoStats_.get());
-  ioReaderOpts.setMetadataIoStats(metadataIoStats_.get());
+  ioReaderOpts.setDataIoStats(dataIoStats_);
+  ioReaderOpts.setMetadataIoStats(metadataIoStats_);
   std::unique_ptr<dwio::common::BufferedInput> bufferedInput;
   if (cache_ != nullptr) {
     bufferedInput = std::make_unique<dwio::common::CachedBufferedInput>(

--- a/dwio/nimble/velox/selective/tests/StringColumnReaderTest.cpp
+++ b/dwio/nimble/velox/selective/tests/StringColumnReaderTest.cpp
@@ -63,8 +63,9 @@ class StringColumnReaderTest : public ::testing::Test,
     auto readFile = std::make_shared<InMemoryReadFile>(file);
     auto factory =
         dwio::common::getReaderFactory(dwio::common::FileFormat::NIMBLE);
-    dwio::common::ReaderOptions options(
-        pool(), dataIoStats_.get(), metadataIoStats_.get());
+    dwio::common::ReaderOptions options(pool());
+    options.setDataIoStats(dataIoStats_);
+    options.setMetadataIoStats(metadataIoStats_);
     options.setScanSpec(scanSpec);
     Readers readers;
     readers.reader = factory->createReader(
@@ -890,8 +891,9 @@ TEST_P(StringColumnReaderTest, flatMapStringDictionaryPath) {
   auto readFile = std::make_shared<InMemoryReadFile>(file);
   auto factory =
       dwio::common::getReaderFactory(dwio::common::FileFormat::NIMBLE);
-  dwio::common::ReaderOptions options(
-      pool(), dataIoStats_.get(), metadataIoStats_.get());
+  dwio::common::ReaderOptions options(pool());
+  options.setDataIoStats(dataIoStats_);
+  options.setMetadataIoStats(metadataIoStats_);
   options.setScanSpec(scanSpec);
   auto reader = factory->createReader(
       std::make_unique<dwio::common::BufferedInput>(readFile, *pool()),

--- a/dwio/nimble/velox/selective/tests/TimestampColumnReaderTest.cpp
+++ b/dwio/nimble/velox/selective/tests/TimestampColumnReaderTest.cpp
@@ -58,8 +58,9 @@ class TimestampColumnReaderTest : public ::testing::Test,
     auto readFile = std::make_shared<InMemoryReadFile>(file);
     auto factory =
         dwio::common::getReaderFactory(dwio::common::FileFormat::NIMBLE);
-    dwio::common::ReaderOptions options(
-        pool(), dataIoStats_.get(), metadataIoStats_.get());
+    dwio::common::ReaderOptions options(pool());
+    options.setDataIoStats(dataIoStats_);
+    options.setMetadataIoStats(metadataIoStats_);
     options.setScanSpec(scanSpec);
     Readers readers;
     readers.reader = factory->createReader(

--- a/dwio/nimble/velox/selective/tests/VariableLengthColumnReaderTest.cpp
+++ b/dwio/nimble/velox/selective/tests/VariableLengthColumnReaderTest.cpp
@@ -58,8 +58,9 @@ class VariableLengthColumnReaderTest : public ::testing::Test,
     auto readFile = std::make_shared<InMemoryReadFile>(file);
     auto factory =
         dwio::common::getReaderFactory(dwio::common::FileFormat::NIMBLE);
-    dwio::common::ReaderOptions options(
-        pool(), dataIoStats_.get(), metadataIoStats_.get());
+    dwio::common::ReaderOptions options(pool());
+    options.setDataIoStats(dataIoStats_);
+    options.setMetadataIoStats(metadataIoStats_);
     options.setScanSpec(scanSpec);
     Readers readers;
     readers.reader = factory->createReader(

--- a/dwio/nimble/velox/tests/VeloxReaderTest.cpp
+++ b/dwio/nimble/velox/tests/VeloxReaderTest.cpp
@@ -524,8 +524,8 @@ class VeloxReaderTest : public ::testing::TestWithParam<TestParam> {
     nimble::TabletReader::Options tabletOptions;
     tabletOptions.pinFileMetadata = pinFileMetadata();
     ioReaderOptions_ = std::make_unique<velox::io::ReaderOptions>(pool);
-    ioReaderOptions_->setDataIoStats(dataIoStats_.get());
-    ioReaderOptions_->setMetadataIoStats(metadataIoStats_.get());
+    ioReaderOptions_->setDataIoStats(dataIoStats_);
+    ioReaderOptions_->setMetadataIoStats(metadataIoStats_);
     tabletOptions.ioOptions = *ioReaderOptions_;
     if (enableCache() || pinFileMetadata()) {
       auto& ids = velox::fileIds();


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebookincubator/velox/pull/17518


Change `io::ReaderOptions` to hold `std::shared_ptr<IoStatistics>` instead of raw `IoStatistics*` pointers for `dataIoStats_`, `metadataIoStats_`, and `indexIoStats_` members. This simplifies lifetime management at call sites — most callers already owned `shared_ptr<IoStatistics>` and were passing `.get()` to the setters.

Setters now take `std::shared_ptr<IoStatistics>`, getters return `const std::shared_ptr<IoStatistics>&`. The deprecated constructor is updated to match.

Call site changes:
- Callers that already held `shared_ptr` (majority): removed `.get()` calls
- Callers with stack-allocated `IoStatistics`: converted to `make_shared`
- `SplitReader.cpp`: uses non-owning `shared_ptr` with no-op deleter for `PerfMetrics`-owned `FbIoStatistics`
- `MetadataInput` (Nimble): `ioStats_` member changed from raw to `shared_ptr`
- `ReaderBase` (DWRF): constructors and static helper updated

Reviewed By: zacw7

Differential Revision: D105191880


