### PR TITLE
feat: Add keyAtRow and lookupChunkByRow to ClusterIndex

### DIFF
--- a/dwio/nimble/encodings/Encoding.h
+++ b/dwio/nimble/encodings/Encoding.h
@@ -167,6 +167,12 @@ class Encoding {
     NIMBLE_UNSUPPORTED("seek is not supported.");
   }
 
+  /// Materializes the value at the given row index into buffer.
+  /// Only supported by Trivial and Prefix encodings.
+  virtual void get(uint32_t /*row*/, void* /*buffer*/) {
+    NIMBLE_NOT_IMPLEMENTED("get is not supported by this encoding type");
+  }
+
   /// Materializes the next |rowCount| rows into buffer. Advances
   /// the row pointer |rowCount|.
   ///

--- a/dwio/nimble/encodings/PrefixEncoding.cpp
+++ b/dwio/nimble/encodings/PrefixEncoding.cpp
@@ -156,6 +156,14 @@ uint32_t PrefixEncoding::restartOffset(uint32_t restartIndex) const {
   return encoding::readUint32(offsetPos);
 }
 
+void PrefixEncoding::get(uint32_t row, void* buffer) {
+  reset();
+  if (row > 0) {
+    skip(row);
+  }
+  materialize(1, buffer);
+}
+
 void PrefixEncoding::seekToRestartPoint(uint32_t restartIndex) {
   NIMBLE_CHECK_LT(restartIndex, numRestarts_, "Restart index out of bounds");
 

--- a/dwio/nimble/encodings/PrefixEncoding.h
+++ b/dwio/nimble/encodings/PrefixEncoding.h
@@ -94,6 +94,8 @@ class PrefixEncoding final
   /// @param buffer Output buffer for std::string_view values.
   void materialize(uint32_t rowCount, void* buffer) final;
 
+  void get(uint32_t row, void* buffer) final;
+
   /// Seeks to the position at or after the given value.
   ///
   std::optional<uint32_t> seek(const void* value, bool inclusive) final;

--- a/dwio/nimble/encodings/TrivialEncoding.cpp
+++ b/dwio/nimble/encodings/TrivialEncoding.cpp
@@ -85,6 +85,14 @@ void TrivialEncoding<std::string_view>::materialize(
   row_ += rowCount;
 }
 
+void TrivialEncoding<std::string_view>::get(uint32_t row, void* buffer) {
+  reset();
+  if (row > 0) {
+    skip(row);
+  }
+  materialize(1, buffer);
+}
+
 uint64_t TrivialEncoding<std::string_view>::uncompressedDataBytes() const {
   return uncompressedDataBytes_;
 }

--- a/dwio/nimble/encodings/TrivialEncoding.h
+++ b/dwio/nimble/encodings/TrivialEncoding.h
@@ -62,6 +62,7 @@ class TrivialEncoding final
   void reset() final;
   void skip(uint32_t rowCount) final;
   void materialize(uint32_t rowCount, void* buffer) final;
+  void get(uint32_t row, void* buffer) final;
 
   template <typename DecoderVisitor>
   void readWithVisitor(DecoderVisitor& visitor, ReadWithVisitorParams& params);
@@ -109,6 +110,7 @@ class TrivialEncoding<std::string_view> final
   void reset() final;
   void skip(uint32_t rowCount) final;
   void materialize(uint32_t rowCount, void* buffer) final;
+  void get(uint32_t row, void* buffer) final;
 
   template <typename DecoderVisitor>
   void readWithVisitor(DecoderVisitor& visitor, ReadWithVisitorParams& params);
@@ -233,6 +235,11 @@ void TrivialEncoding<T>::materialize(uint32_t rowCount, void* buffer) {
   const auto start = values_ + row_;
   std::copy(start, start + rowCount, static_cast<T*>(buffer));
   row_ += rowCount;
+}
+
+template <typename T>
+void TrivialEncoding<T>::get(uint32_t row, void* buffer) {
+  *static_cast<T*>(buffer) = values_[row];
 }
 
 template <typename T>

--- a/dwio/nimble/encodings/tests/PrefixEncodingTest.cpp
+++ b/dwio/nimble/encodings/tests/PrefixEncodingTest.cpp
@@ -1397,4 +1397,43 @@ TEST_F(PrefixEncodingTest, seekExactMatchWithDuplicatesAcrossRestarts) {
     }
   }
 }
+TEST_F(PrefixEncodingTest, getByRow) {
+  const std::vector<std::string_view> values = {
+      "apple", "application", "apply", "banana", "bandana", "band"};
+  Buffer buffer{*pool_};
+  auto encoded = EncodingFactory::encode<std::string_view>(
+      createSelectionPolicy(), values, buffer);
+  stringBuffers_.clear();
+  auto encoding =
+      EncodingFactory().create(*pool_, encoded, createStringBufferFactory());
+
+  for (uint32_t i = 0; i < values.size(); ++i) {
+    SCOPED_TRACE(fmt::format("row={}", i));
+    std::string_view result;
+    encoding->get(i, &result);
+    EXPECT_EQ(result, values[i]);
+  }
+}
+
+TEST_F(PrefixEncodingTest, getByRowRepeatedCalls) {
+  const std::vector<std::string_view> values = {
+      "prefix_aaa", "prefix_bbb", "prefix_ccc"};
+  Buffer buffer{*pool_};
+  auto encoded = EncodingFactory::encode<std::string_view>(
+      createSelectionPolicy(), values, buffer);
+  stringBuffers_.clear();
+  auto encoding =
+      EncodingFactory().create(*pool_, encoded, createStringBufferFactory());
+
+  std::string_view result;
+  encoding->get(2, &result);
+  EXPECT_EQ(result, "prefix_ccc");
+  encoding->get(0, &result);
+  EXPECT_EQ(result, "prefix_aaa");
+  encoding->get(2, &result);
+  EXPECT_EQ(result, "prefix_ccc");
+  encoding->get(1, &result);
+  EXPECT_EQ(result, "prefix_bbb");
+}
+
 } // namespace facebook::nimble::test

--- a/dwio/nimble/encodings/tests/TrivialEncodingTest.cpp
+++ b/dwio/nimble/encodings/tests/TrivialEncodingTest.cpp
@@ -518,3 +518,57 @@ TEST_F(TrivialEncodingTest, seekUnsupportedEncodings) {
         "seek is not supported");
   }
 }
+
+TEST_F(TrivialEncodingTest, getStringByRow) {
+  const auto values = toVector({"alpha", "beta", "gamma", "delta", "epsilon"});
+  auto encoding = createEncoding(values);
+
+  for (uint32_t i = 0; i < values.size(); ++i) {
+    SCOPED_TRACE(fmt::format("row={}", i));
+    std::string_view result;
+    encoding->get(i, &result);
+    EXPECT_EQ(result, values[i]);
+  }
+}
+
+TEST_F(TrivialEncodingTest, getStringSingleRow) {
+  const auto values = toVector({"only"});
+  auto encoding = createEncoding(values);
+
+  std::string_view result;
+  encoding->get(0, &result);
+  EXPECT_EQ(result, "only");
+}
+
+TEST_F(TrivialEncodingTest, getStringRepeatedCalls) {
+  const auto values = toVector({"aaa", "bbb", "ccc"});
+  auto encoding = createEncoding(values);
+
+  // Repeated get() calls on the same and different rows.
+  std::string_view result;
+  encoding->get(2, &result);
+  EXPECT_EQ(result, "ccc");
+  encoding->get(0, &result);
+  EXPECT_EQ(result, "aaa");
+  encoding->get(2, &result);
+  EXPECT_EQ(result, "ccc");
+  encoding->get(1, &result);
+  EXPECT_EQ(result, "bbb");
+}
+
+TEST_F(TrivialEncodingTest, getUnsupportedEncodingThrows) {
+  nimble::Vector<int32_t> intValues{pool_.get()};
+  intValues.push_back(1);
+  intValues.push_back(1);
+  intValues.push_back(2);
+  auto encoding =
+      nimble::test::Encoder<nimble::RLEEncoding<int32_t>>::createEncoding(
+          *buffer_, intValues, [&](uint32_t len) {
+            auto& buf = stringBuffers_.emplace_back(
+                velox::AlignedBuffer::allocate<char>(len, pool_.get()));
+            return buf->asMutable<void>();
+          });
+  int32_t result;
+  NIMBLE_ASSERT_THROW(
+      encoding->get(0, &result), "get is not supported by this encoding type");
+}

--- a/dwio/nimble/index/ClusterIndex.cpp
+++ b/dwio/nimble/index/ClusterIndex.cpp
@@ -18,6 +18,7 @@
 
 #include <algorithm>
 
+#include "dwio/nimble/common/ChunkHeader.h"
 #include "dwio/nimble/common/Exceptions.h"
 #include "dwio/nimble/common/Types.h"
 #include "dwio/nimble/index/KeyChunkDecoder.h"
@@ -191,6 +192,29 @@ std::optional<uint32_t> ClusterIndex::lookupPartition(
     return std::nullopt;
   }
   return static_cast<uint32_t>(it - partitionKeys_.begin());
+}
+
+const ClusterIndex::IndexPartition* ClusterIndex::lookupPartition(
+    uint32_t row) const {
+  NIMBLE_CHECK_LT(
+      row, numRows_, "Row {} is beyond file total rows {}", row, numRows_);
+  const auto it =
+      std::upper_bound(partitionRows_.begin(), partitionRows_.end(), row);
+  NIMBLE_CHECK(it != partitionRows_.begin());
+  const uint32_t partitionId =
+      static_cast<uint32_t>(it - partitionRows_.begin()) - 1;
+  return loadPartition(partitionId);
+}
+
+uint32_t ClusterIndex::partitionRow(uint32_t row) const {
+  NIMBLE_CHECK_LT(
+      row, numRows_, "Row {} is beyond file total rows {}", row, numRows_);
+  const auto it =
+      std::upper_bound(partitionRows_.begin(), partitionRows_.end(), row);
+  NIMBLE_CHECK(it != partitionRows_.begin());
+  const uint32_t partitionId =
+      static_cast<uint32_t>(it - partitionRows_.begin()) - 1;
+  return row - partitionRows_[partitionId];
 }
 
 void ClusterIndex::resolvePartitionBounds() const {
@@ -503,6 +527,57 @@ uint32_t ClusterIndex::seekInChunk(
     NIMBLE_CHECK(false, "Key must be found within a matched chunk");
   }
   return chunkLocation.rowOffset + rowInChunk.value();
+}
+
+ChunkLocation ClusterIndex::lookupChunk(
+    const IndexPartition* partition,
+    uint32_t partitionRow) const {
+  NIMBLE_DCHECK_NOT_NULL(partition);
+  // chunk_rows is cumulative: chunk_rows[i] = total rows through chunk i.
+  // Binary search for the first chunk whose cumulative rows > partitionRow.
+  const auto* chunkRows = partition->index->chunk_rows();
+  NIMBLE_CHECK_NOT_NULL(chunkRows);
+  const auto it =
+      std::upper_bound(chunkRows->begin(), chunkRows->end(), partitionRow);
+  NIMBLE_CHECK(
+      it != chunkRows->end(),
+      "Row {} is beyond partition {} total rows",
+      partitionRow,
+      partition->id);
+  const uint32_t idx = it - chunkRows->begin();
+  return ChunkLocation{
+      partition->chunkOffset(idx),
+      partition->chunkSize(idx),
+      partition->rowOffset(idx)};
+}
+
+std::string ClusterIndex::keyAtRow(uint32_t row) const {
+  const auto* partition = lookupPartition(row);
+  const auto partitionRow = this->partitionRow(row);
+
+  const auto* chunkRows = partition->index->chunk_rows();
+  const auto* chunkKeys = partition->index->chunk_keys();
+  NIMBLE_CHECK_NOT_NULL(chunkRows);
+  NIMBLE_CHECK_NOT_NULL(chunkKeys);
+
+  const auto chunkIt =
+      std::upper_bound(chunkRows->begin(), chunkRows->end(), partitionRow);
+  NIMBLE_CHECK(chunkIt != chunkRows->end());
+  const uint32_t chunkIdx = chunkIt - chunkRows->begin();
+
+  // Fast path: the last row of each chunk has its key in chunk_keys metadata.
+  const uint32_t chunkEndRow = chunkRows->Get(chunkIdx);
+  if (partitionRow == chunkEndRow - 1) {
+    return std::string(chunkKeys->Get(chunkIdx)->string_view());
+  }
+
+  const auto chunkLocation = lookupChunk(partition, partitionRow);
+  const auto& decodedChunk = getDecodedChunk(partition, chunkLocation);
+  const uint32_t rowInChunk = partitionRow - chunkLocation.rowOffset;
+
+  std::string_view value;
+  decodedChunk.data->encoding->get(rowInChunk, &value);
+  return std::string(value);
 }
 
 } // namespace facebook::nimble::index

--- a/dwio/nimble/index/ClusterIndex.h
+++ b/dwio/nimble/index/ClusterIndex.h
@@ -98,6 +98,11 @@ class ClusterIndex : public IndexLookup {
     return lastKey_;
   }
 
+  /// Returns the encoded key at the given file-level row position.
+  /// Requires loadData to have been provided at construction.
+  /// Used to compute resume keys when lookup results are truncated.
+  std::string keyAtRow(uint32_t row) const override;
+
   /// Returns the number of partitions in the index.
   uint32_t numPartitions() const {
     return numPartitions_;
@@ -219,6 +224,12 @@ class ClusterIndex : public IndexLookup {
   // Returns nullopt if the key is beyond all partitions.
   std::optional<uint32_t> lookupPartition(std::string_view key) const;
 
+  // Finds the partition containing the given file-level row.
+  const IndexPartition* lookupPartition(uint32_t row) const;
+
+  // Converts a file-level row to a partition-relative row number.
+  uint32_t partitionRow(uint32_t row) const;
+
   // A bound to resolve within a partition.
   // Stores a pointer to the target row field (startRow or endRow) in the
   // caller's RowRange. resolvePartitionBounds writes the resolved file-level
@@ -260,6 +271,13 @@ class ClusterIndex : public IndexLookup {
   ChunkLocation lookupChunk(
       const IndexPartition* partition,
       std::string_view encodedKey) const;
+
+  // Finds the chunk containing the given partition-relative row via binary
+  // search on chunk_rows. Returns a ChunkLocation with the chunk's offset,
+  // size, and row offset within the partition.
+  ChunkLocation lookupChunk(
+      const IndexPartition* partition,
+      uint32_t partitionRow) const;
 
   // Loads or returns cached decoded chunk for the given location.
   // Reuses partition-level buffers to avoid repeated allocations.

--- a/dwio/nimble/index/IndexLookup.h
+++ b/dwio/nimble/index/IndexLookup.h
@@ -248,6 +248,12 @@ class IndexLookup {
   /// Returns the maximum key in this index.
   virtual std::string_view maxKey() const = 0;
 
+  /// Returns the encoded key at the given file-level row position.
+  /// Not all index types support this — the default throws.
+  virtual std::string keyAtRow(uint32_t /*row*/) const {
+    NIMBLE_NOT_IMPLEMENTED("keyAtRow is not supported by this index type");
+  }
+
   /// Returns runtime statistics accumulated during lookups.
   virtual folly::F14FastMap<std::string, velox::RuntimeMetric> stats() const {
     return {};

--- a/dwio/nimble/index/tests/ClusterIndexTest.cpp
+++ b/dwio/nimble/index/tests/ClusterIndexTest.cpp
@@ -1001,6 +1001,29 @@ TEST_P(ClusterIndexLookupTest, pointLookupBatchMixed) {
   EXPECT_EQ(result[2][0].endRow, 5);
 }
 
+TEST_P(ClusterIndexLookupTest, keyAtRow) {
+  // 9 rows: key_a(0), key_b(1), ..., key_i(8)
+  const std::vector<std::string> expectedKeys = {
+      "key_a",
+      "key_b",
+      "key_c",
+      "key_d",
+      "key_e",
+      "key_f",
+      "key_g",
+      "key_h",
+      "key_i"};
+  for (uint32_t row = 0; row < 9; ++row) {
+    SCOPED_TRACE(fmt::format("row={}", row));
+    EXPECT_EQ(clusterIndex_->keyAtRow(row), expectedKeys[row]);
+  }
+}
+
+TEST_P(ClusterIndexLookupTest, keyAtRowOutOfRange) {
+  NIMBLE_ASSERT_THROW(clusterIndex_->keyAtRow(9), "beyond file total rows");
+  NIMBLE_ASSERT_THROW(clusterIndex_->keyAtRow(100), "beyond file total rows");
+}
+
 INSTANTIATE_TEST_SUITE_P(
     ChunkGranularity,
     ClusterIndexLookupTest,
@@ -1008,6 +1031,198 @@ INSTANTIATE_TEST_SUITE_P(
     [](const ::testing::TestParamInfo<uint32_t>& info) {
       return fmt::format("rowsPerChunk_{}", info.param);
     });
+
+TEST_F(ClusterIndexTest, keyAtRowMultiplePartitions) {
+  // 2 partitions: partition 0 = rows 0-2 (key_a,key_b,key_c),
+  //               partition 1 = rows 3-5 (key_d,key_e,key_f)
+  std::vector<std::vector<std::string>> partition0Keys = {
+      {"key_a", "key_b", "key_c"}};
+  std::vector<std::vector<std::string>> partition1Keys = {
+      {"key_d", "key_e", "key_f"}};
+
+  auto encoded0 = encodeKeyStream(partition0Keys);
+  auto encoded1 = encodeKeyStream(partition1Keys);
+  std::string combinedStream = encoded0.data + encoded1.data;
+
+  std::vector<std::string> indexColumns = {"col1"};
+  std::string minKey = "key_0";
+  std::vector<Stripe> stripes = {
+      createStripeWithKeys(
+          {.streamOffset = 0,
+           .streamSize = static_cast<uint32_t>(encoded0.data.size()),
+           .stream = {.numChunks = 1, .chunkRows = {3}, .chunkOffsets = {0}},
+           .chunkKeys = {"key_c"}}),
+      createStripeWithKeys(
+          {.streamOffset = static_cast<uint32_t>(encoded0.data.size()),
+           .streamSize = static_cast<uint32_t>(encoded1.data.size()),
+           .stream = {.numChunks = 1, .chunkRows = {3}, .chunkOffsets = {0}},
+           .chunkKeys = {"key_f"}})};
+  std::vector<int> stripeGroups = {1, 1};
+
+  auto indexBuffers =
+      createTestClusterIndex(indexColumns, minKey, stripes, stripeGroups);
+  auto clusterIndex =
+      createClusterIndex(indexBuffers, createKeyStreamFile(combinedStream));
+
+  const std::vector<std::string> expectedKeys = {
+      "key_a", "key_b", "key_c", "key_d", "key_e", "key_f"};
+  for (uint32_t row = 0; row < 6; ++row) {
+    SCOPED_TRACE(fmt::format("row={}", row));
+    EXPECT_EQ(clusterIndex->keyAtRow(row), expectedKeys[row]);
+  }
+
+  NIMBLE_ASSERT_THROW(clusterIndex->keyAtRow(6), "beyond file total rows");
+}
+
+TEST_F(ClusterIndexTest, keyAtRowMultipleChunksPerPartition) {
+  // 1 partition, 3 chunks of 2 rows each = 6 rows total.
+  // Verifies correct lookup at chunk boundaries.
+  std::vector<std::vector<std::string>> keyChunks = {
+      {"key_a", "key_b"}, {"key_c", "key_d"}, {"key_e", "key_f"}};
+  auto encoded = encodeKeyStream(keyChunks);
+
+  std::vector<std::string> indexColumns = {"col1"};
+  std::string minKey = "key_0";
+  std::vector<Stripe> stripes = {createStripeWithKeys(
+      {.streamOffset = 0,
+       .streamSize = static_cast<uint32_t>(encoded.data.size()),
+       .stream =
+           {.numChunks = 3,
+            .chunkRows = {2, 2, 2},
+            .chunkOffsets = encoded.chunkOffsets},
+       .chunkKeys = {"key_b", "key_d", "key_f"}})};
+  std::vector<int> stripeGroups = {1};
+
+  auto indexBuffers =
+      createTestClusterIndex(indexColumns, minKey, stripes, stripeGroups);
+  auto clusterIndex =
+      createClusterIndex(indexBuffers, createKeyStreamFile(encoded.data));
+
+  const std::vector<std::string> expectedKeys = {
+      "key_a", "key_b", "key_c", "key_d", "key_e", "key_f"};
+  for (uint32_t row = 0; row < 6; ++row) {
+    SCOPED_TRACE(fmt::format("row={}", row));
+    EXPECT_EQ(clusterIndex->keyAtRow(row), expectedKeys[row]);
+  }
+
+  NIMBLE_ASSERT_THROW(clusterIndex->keyAtRow(6), "beyond file total rows");
+}
+
+TEST_F(ClusterIndexTest, keyAtRowMultiplePartitionsMultipleChunks) {
+  // 2 partitions, each with 2 chunks of 2 rows = 8 rows total.
+  // Tests partition boundary + chunk boundary interactions.
+  std::vector<std::vector<std::string>> p0Chunks = {
+      {"key_a", "key_b"}, {"key_c", "key_d"}};
+  std::vector<std::vector<std::string>> p1Chunks = {
+      {"key_e", "key_f"}, {"key_g", "key_h"}};
+
+  auto encoded0 = encodeKeyStream(p0Chunks);
+  auto encoded1 = encodeKeyStream(p1Chunks);
+  std::string combinedStream = encoded0.data + encoded1.data;
+
+  std::vector<std::string> indexColumns = {"col1"};
+  std::string minKey = "key_0";
+  std::vector<Stripe> stripes = {
+      createStripeWithKeys(
+          {.streamOffset = 0,
+           .streamSize = static_cast<uint32_t>(encoded0.data.size()),
+           .stream =
+               {.numChunks = 2,
+                .chunkRows = {2, 2},
+                .chunkOffsets = encoded0.chunkOffsets},
+           .chunkKeys = {"key_b", "key_d"}}),
+      createStripeWithKeys(
+          {.streamOffset = static_cast<uint32_t>(encoded0.data.size()),
+           .streamSize = static_cast<uint32_t>(encoded1.data.size()),
+           .stream =
+               {.numChunks = 2,
+                .chunkRows = {2, 2},
+                .chunkOffsets = encoded1.chunkOffsets},
+           .chunkKeys = {"key_f", "key_h"}})};
+  std::vector<int> stripeGroups = {1, 1};
+
+  auto indexBuffers =
+      createTestClusterIndex(indexColumns, minKey, stripes, stripeGroups);
+  auto clusterIndex =
+      createClusterIndex(indexBuffers, createKeyStreamFile(combinedStream));
+
+  const std::vector<std::string> expectedKeys = {
+      "key_a", "key_b", "key_c", "key_d", "key_e", "key_f", "key_g", "key_h"};
+  for (uint32_t row = 0; row < 8; ++row) {
+    SCOPED_TRACE(fmt::format("row={}", row));
+    EXPECT_EQ(clusterIndex->keyAtRow(row), expectedKeys[row]);
+  }
+
+  // Partition boundary: row 3 is last of partition 0, row 4 is first of
+  // partition 1.
+  EXPECT_EQ(clusterIndex->keyAtRow(3), "key_d");
+  EXPECT_EQ(clusterIndex->keyAtRow(4), "key_e");
+
+  NIMBLE_ASSERT_THROW(clusterIndex->keyAtRow(8), "beyond file total rows");
+}
+
+TEST_F(ClusterIndexTest, keyAtRowSingleRow) {
+  // Edge case: file with exactly 1 row.
+  std::vector<std::vector<std::string>> keyChunks = {{"only_key"}};
+  auto encoded = encodeKeyStream(keyChunks);
+
+  std::vector<std::string> indexColumns = {"col1"};
+  std::string minKey = "key_0";
+  std::vector<Stripe> stripes = {createStripeWithKeys(
+      {.streamOffset = 0,
+       .streamSize = static_cast<uint32_t>(encoded.data.size()),
+       .stream = {.numChunks = 1, .chunkRows = {1}, .chunkOffsets = {0}},
+       .chunkKeys = {"only_key"}})};
+  std::vector<int> stripeGroups = {1};
+
+  auto indexBuffers =
+      createTestClusterIndex(indexColumns, minKey, stripes, stripeGroups);
+  auto clusterIndex =
+      createClusterIndex(indexBuffers, createKeyStreamFile(encoded.data));
+
+  EXPECT_EQ(clusterIndex->keyAtRow(0), "only_key");
+  NIMBLE_ASSERT_THROW(clusterIndex->keyAtRow(1), "beyond file total rows");
+}
+
+TEST_F(ClusterIndexTest, keyAtRowUnevenChunks) {
+  // 1 partition with uneven chunks: 1 row, 3 rows, 2 rows = 6 rows total.
+  std::vector<std::vector<std::string>> keyChunks = {
+      {"key_a"}, {"key_b", "key_c", "key_d"}, {"key_e", "key_f"}};
+  auto encoded = encodeKeyStream(keyChunks);
+
+  std::vector<std::string> indexColumns = {"col1"};
+  std::string minKey = "key_0";
+  std::vector<Stripe> stripes = {createStripeWithKeys(
+      {.streamOffset = 0,
+       .streamSize = static_cast<uint32_t>(encoded.data.size()),
+       .stream =
+           {.numChunks = 3,
+            .chunkRows = {1, 3, 2},
+            .chunkOffsets = encoded.chunkOffsets},
+       .chunkKeys = {"key_a", "key_d", "key_f"}})};
+  std::vector<int> stripeGroups = {1};
+
+  auto indexBuffers =
+      createTestClusterIndex(indexColumns, minKey, stripes, stripeGroups);
+  auto clusterIndex =
+      createClusterIndex(indexBuffers, createKeyStreamFile(encoded.data));
+
+  const std::vector<std::string> expectedKeys = {
+      "key_a", "key_b", "key_c", "key_d", "key_e", "key_f"};
+  for (uint32_t row = 0; row < 6; ++row) {
+    SCOPED_TRACE(fmt::format("row={}", row));
+    EXPECT_EQ(clusterIndex->keyAtRow(row), expectedKeys[row]);
+  }
+
+  // Chunk boundaries: row 0 = chunk 0 (single), row 1 = first of chunk 1,
+  // row 3 = last of chunk 1, row 4 = first of chunk 2.
+  EXPECT_EQ(clusterIndex->keyAtRow(0), "key_a");
+  EXPECT_EQ(clusterIndex->keyAtRow(1), "key_b");
+  EXPECT_EQ(clusterIndex->keyAtRow(3), "key_d");
+  EXPECT_EQ(clusterIndex->keyAtRow(4), "key_e");
+
+  NIMBLE_ASSERT_THROW(clusterIndex->keyAtRow(6), "beyond file total rows");
+}
 
 } // namespace
 } // namespace facebook::nimble::index::test


### PR DESCRIPTION
Summary:

Add ClusterIndex::keyAtRow(row) to retrieve the encoded key at a given file-level row number, and the internal lookupChunkByRow helper that maps a partition-relative row to its chunk via binary search on cumulative row counts. These are needed by NimbleIndexProjector to compute resume keys for paginated lookups.

Reviewed By: xiaoxmeng

Differential Revision: D105225824


