### PR TITLE
fix: Update copyright headers (#725)

### DIFF
--- a/dwio/nimble/benchmarks/BenchmarkSuite.h
+++ b/dwio/nimble/benchmarks/BenchmarkSuite.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/dwio/nimble/tablet/CMakeLists.txt
+++ b/dwio/nimble/tablet/CMakeLists.txt
@@ -112,8 +112,13 @@ target_include_directories(
 )
 add_dependencies(nimble_sorted_index_fb nimble_sorted_index_schema_fb)
 
-add_library(nimble_tablet_common Compression.cpp MetadataBuffer.cpp
-                                 MetadataInput.cpp Postscript.cpp)
+add_library(
+  nimble_tablet_common
+  Compression.cpp
+  MetadataBuffer.cpp
+  MetadataInput.cpp
+  Postscript.cpp
+)
 target_link_libraries(
   nimble_tablet_common
   nimble_footer_fb

--- a/dwio/nimble/velox/selective/VariableLengthColumnReader.cpp
+++ b/dwio/nimble/velox/selective/VariableLengthColumnReader.cpp
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
 
 #include "dwio/nimble/velox/selective/VariableLengthColumnReader.h"
 

--- a/dwio/nimble/velox/selective/VariableLengthColumnReader.h
+++ b/dwio/nimble/velox/selective/VariableLengthColumnReader.h
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
 
 #pragma once
 

--- a/dwio/nimble/velox/stats/tests/VectorizedFileStatsTests.cpp
+++ b/dwio/nimble/velox/stats/tests/VectorizedFileStatsTests.cpp
@@ -1,4 +1,18 @@
-// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 #include <gtest/gtest.h>
 


### PR DESCRIPTION
Summary:

The Open Source Automated Checkup tool flagged `facebookincubator/nimble` for failing the Copyright Headers requirement.

Three OSS-exported source files needed fixes:

- `benchmarks/BenchmarkSuite.h` — replaced legacy `Copyright (c) Facebook, Inc. and its affiliates.` with the Meta Platforms Apache header (the Facebook→Meta delta exceeds `scripts/license-header.py`'s editdist=12 fuzzy-match tolerance).
- `velox/stats/tests/VectorizedFileStatsTests.cpp` — replaced the proprietary `// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.` header with the standard Apache OSS header.
- `velox/selective/VariableLengthColumnReader.{h,cpp}` — removed a stray proprietary line sitting just below the existing Apache header.

All other internal-only files (under `tools/fb/`, `velox/fb/`) are stripped by ShipIt and not exported to GitHub, so they don't need updating.

Reviewed By: kevinwilfong

Differential Revision: D105238030


