### PR TITLE
feat(writer): Enable (static) chunking by default (#727)

### DIFF
--- a/dwio/nimble/velox/VeloxWriterOptions.h
+++ b/dwio/nimble/velox/VeloxWriterOptions.h
@@ -223,7 +223,7 @@ struct VeloxWriterOptions {
   uint32_t maxEncodeParallelism{0};
   uint32_t minStreamsPerEncodeUnit{1};
 
-  bool enableChunking{false};
+  bool enableChunking{true};
 
   // This callback will be visited on access to getDecodedVector in order to
   // monitor usage of decoded vectors vs. data that is passed-through in the

--- a/dwio/nimble/velox/tests/VeloxReaderTest.cpp
+++ b/dwio/nimble/velox/tests/VeloxReaderTest.cpp
@@ -568,6 +568,7 @@ class VeloxReaderTest : public ::testing::TestWithParam<TestParam> {
 
   nimble::VeloxWriterOptions createFlatMapWriterOptions() const {
     nimble::VeloxWriterOptions options;
+    options.enableChunking = false;
     options.skipConstantFlatMapInMapStreams = skipConstantFlatMapInMapStreams();
     return options;
   }
@@ -6476,6 +6477,7 @@ TEST_P(VeloxReaderTest, estimatedRowSizeMix) {
           velox::ROW({{"flat_mix_col", typeFunc(elementType)}}));
 
       nimble::VeloxWriterOptions writerOptions;
+      writerOptions.enableChunking = false;
       // TODO: Remove the customized policy after estimation is supported
       // for all encoding types.
       writerOptions.encodingSelectionPolicyFactory =


### PR DESCRIPTION
Summary:

As we have already rolled out chunking to the majority of tables in ML namespaces, default chunking is safe to turn on and provides a basic level of memory boundedness: https://fb.workplace.com/groups/1269187491733358/posts/1321778583140915

We still have a JK knob to force turn off in case something goes wrong: dwio/nimble_chunking:enabled

Reviewed By: xiaoxmeng

Differential Revision: D105246796


