### PR TITLE
feat: Populate resume key on lookup truncation in NimbleIndexProjector

### DIFF
--- a/dwio/nimble/velox/index/NimbleIndexProjector.cpp
+++ b/dwio/nimble/velox/index/NimbleIndexProjector.cpp
@@ -93,19 +93,22 @@ NimbleIndexProjector::Result NimbleIndexProjector::project(
 
   lookupStripes();
 
+  numReadRows_ = 0;
   const auto numRequests = request_->keyBounds.size();
+  rowsPerRequest_.assign(numRequests, 0);
   Result result;
   result.responses.resize(numRequests);
-  rowsPerRequest_.assign(numRequests, 0);
 
   for (uint32_t i = 0; i < stripeRangeMap_.numStripes; ++i) {
-    const auto stripeRowRanges =
-        stripeRangeMap_.stripeRowRanges(stripeRangeMap_.startStripe + i);
+    const uint32_t stripeIndex = stripeRangeMap_.startStripe + i;
+    const auto stripeRowRanges = stripeRangeMap_.stripeRowRanges(stripeIndex);
     if (!pruneStripeRowRanges(stripeRowRanges)) {
       continue;
     }
-    const uint32_t stripeIndex = stripeRangeMap_.startStripe + i;
-    processStripe(stripeIndex, result);
+    if (!processStripe(stripeIndex, stripeRowRanges_, result)) {
+      setResumeKeys(stripeIndex, stripeRowRanges_, result);
+      break;
+    }
   }
 
   updateIoStats();
@@ -220,8 +223,10 @@ bool NimbleIndexProjector::pruneStripeRowRanges(
   return !stripeRowRanges_.empty();
 }
 
-void NimbleIndexProjector::processStripe(uint32_t stripeIndex, Result& result) {
-  // Set up the stripe for data stream loading.
+bool NimbleIndexProjector::processStripe(
+    uint32_t stripeIndex,
+    std::span<const StripeRowRange> stripeRowRanges,
+    Result& result) {
   streams_.setStripe(stripeIndex);
 
   // TODO: Support fine-grained row range fetches from a stripe. For now, we
@@ -229,7 +234,8 @@ void NimbleIndexProjector::processStripe(uint32_t stripeIndex, Result& result) {
   // values. The result references a portion of it based on the row range.
   auto inputStreams = loadStripe();
   auto stripeChunk = serializeStripe(stripeIndex, inputStreams);
-  buildStripeResult(std::move(stripeChunk), result);
+  return buildStripeResult(
+      stripeIndex, stripeRowRanges, std::move(stripeChunk), result);
 }
 
 NimbleIndexProjector::InputStreams NimbleIndexProjector::loadStripe() {
@@ -309,32 +315,85 @@ NimbleIndexProjector::Chunk NimbleIndexProjector::serializeStripe(
   return chunk;
 }
 
-void NimbleIndexProjector::buildStripeResult(Chunk&& chunk, Result& result) {
+bool NimbleIndexProjector::buildStripeResult(
+    uint32_t stripeIndex,
+    std::span<const StripeRowRange> stripeRowRanges,
+    Chunk&& chunk,
+    Result& result) {
   const auto chunkIndex = static_cast<uint32_t>(result.chunks.size());
 
-  for (const auto& request : stripeRowRanges_) {
+  for (const auto& request : stripeRowRanges) {
     NIMBLE_CHECK(!request.rowRange.empty());
     auto rowRange = request.rowRange;
 
+    // Saturated requests are filtered out by the caller in project().
     if (options_->maxRowsPerRequest > 0) {
-      // Saturated requests are filtered out by the caller in project().
       NIMBLE_CHECK_GT(
           options_->maxRowsPerRequest, rowsPerRequest_[request.requestIndex]);
       const auto remaining =
           options_->maxRowsPerRequest - rowsPerRequest_[request.requestIndex];
-
       if (static_cast<uint64_t>(rowRange.numRows()) > remaining) {
         rowRange.endRow = rowRange.startRow + static_cast<uint32_t>(remaining);
       }
     }
-    stats_.numReadRows += rowRange.numRows();
 
+    stats_.numReadRows += rowRange.numRows();
+    numReadRows_ += rowRange.numRows();
     result.responses[request.requestIndex].slices.emplace_back(
         ChunkSlice{chunkIndex, rowRange});
     rowsPerRequest_[request.requestIndex] += rowRange.numRows();
   }
 
   result.chunks.emplace_back(std::move(chunk));
+
+  return !(options_->maxRows > 0 && numReadRows_ >= options_->maxRows);
+}
+
+void NimbleIndexProjector::setResumeKeys(
+    uint32_t stripeIndex,
+    std::span<const StripeRowRange> stripeRowRanges,
+    Result& result) {
+  // No next stripe in the range map — all mapped requests end at this stripe.
+  const auto nextStripe = stripeIndex + 1;
+  if (nextStripe >= stripeRangeMap_.startStripe + stripeRangeMap_.numStripes) {
+    return;
+  }
+
+  // No next stripe in the file — all requests are fully satisfied.
+  const auto stripeStartRow =
+      static_cast<uint32_t>(readerBase_->tablet().stripeStartRow(stripeIndex));
+  const auto nextStripeStartRow = stripeStartRow + stripeRowCount(stripeIndex);
+  if (nextStripeStartRow >= readerBase_->tablet().tabletRowCount()) {
+    return;
+  }
+
+  auto resumeKey = clusterIndex_->keyAtRow(nextStripeStartRow);
+  const auto nextRanges = stripeRangeMap_.stripeRowRanges(nextStripe);
+
+  for (const auto& request : stripeRowRanges) {
+    auto& response = result.responses[request.requestIndex];
+    NIMBLE_CHECK(!response.resumeKey.has_value());
+    if (std::any_of(
+            nextRanges.begin(), nextRanges.end(), [&](const auto& range) {
+              return range.requestIndex == request.requestIndex;
+            })) {
+      const auto& keyBounds = request_->keyBounds[request.requestIndex];
+      response.resumeKey = velox::serializer::EncodedKeyBounds{
+          .lowerKey = resumeKey, .upperKey = keyBounds.upperKey};
+    }
+  }
+
+  // For requests that were never started (empty slices, no resume key),
+  // set resume key to their original bounds so the caller can retry.
+  for (size_t i = 0; i < result.responses.size(); ++i) {
+    auto& response = result.responses[i];
+    if (response.slices.empty() && !response.resumeKey.has_value()) {
+      const auto& keyBounds = request_->keyBounds[i];
+      if (keyBounds.lowerKey.has_value()) {
+        response.resumeKey = keyBounds;
+      }
+    }
+  }
 }
 
 void NimbleIndexProjector::updateIoStats() {

--- a/dwio/nimble/velox/index/NimbleIndexProjector.h
+++ b/dwio/nimble/velox/index/NimbleIndexProjector.h
@@ -69,7 +69,14 @@ class NimbleIndexProjector {
 
   /// Options for controlling projection behavior.
   struct Options {
-    /// Maximum number of rows per request. 0 means no limit.
+    /// Soft limit on total rows across all requests. 0 means no limit.
+    /// When the running total exceeds this limit mid-stripe, the entire
+    /// stripe is still included (stripe-boundary soft limit). Processing
+    /// stops after that stripe completes.
+    uint64_t maxRows{0};
+    /// Hard per-request row limit. 0 means no limit. Each request's row
+    /// range is clipped so that it never exceeds this many rows total.
+    /// No resume key is set — the request is considered fulfilled.
     uint64_t maxRowsPerRequest{0};
   };
 
@@ -135,8 +142,8 @@ class NimbleIndexProjector {
     /// numScannedRows since we project entire stripes. With fine-grained
     /// row range fetches (value fetch), this will be smaller.
     uint64_t numProjectedRows{0};
-    /// Number of rows read by request row ranges (may be less than matched
-    /// rows when truncated by maxRowsPerRequest).
+    /// Number of rows read by request row ranges (may exceed maxRows due to
+    /// stripe-boundary soft limit).
     uint64_t numReadRows{0};
     /// Total bytes read from tablet stream data (raw encoded bytes, excluding
     /// serialization overhead like headers and trailers).
@@ -208,29 +215,44 @@ class NimbleIndexProjector {
   // Populates stripeRangeMap_.
   void lookupStripes();
 
-  // Copies stripeRowRanges to stripeRowRanges_ and removes saturated
-  // requests. Returns true if there are remaining requests to process.
+  // Prunes stripe row ranges for requests that have exceeded their
+  // maxRowsPerRequest budget. Returns false if no active requests remain.
   bool pruneStripeRowRanges(std::span<const StripeRowRange> stripeRowRanges);
 
-  // Processes a single stripe: loads data streams, serializes projected
-  // columns, and builds results with maxRowsPerRequest truncation.
-  // Uses stripeRowRanges_ populated by pruneStripeRowRanges().
-  void processStripe(uint32_t stripeIndex, Result& result);
+  // Loads projected streams for the stripe, serializes them into kTabletRaw
+  // format, and maps the result to per-request row ranges. Returns false if
+  // a global limit (maxRows) was hit, signaling the caller to stop and set
+  // resume keys.
+  bool processStripe(
+      uint32_t stripeIndex,
+      std::span<const StripeRowRange> stripeRowRanges,
+      Result& result);
 
   using InputStreams =
       std::vector<std::unique_ptr<velox::dwio::common::SeekableInputStream>>;
 
-  // Enqueues and loads projected data streams from the tablet.
+  // Enqueues projected streams into StripeStreams and loads them from disk.
   InputStreams loadStripe();
 
-  // Stitches loaded raw tablet bytes into kTabletRaw format without
-  // decode/re-encode. Updates scan/projection stats.
+  // Stitches loaded raw stream bytes into a single kTabletRaw chunk
+  // (header + data + trailer) without decode/re-encode.
   Chunk serializeStripe(uint32_t stripeIndex, InputStreams& inputStreams);
 
-  // Maps the serialized stripe chunk to request results based on row ranges.
-  // Applies maxRowsPerRequest truncation.
-  // Uses stripeRowRanges_ populated by pruneStripeRowRanges().
-  void buildStripeResult(Chunk&& chunk, Result& result);
+  // Assigns the serialized chunk to per-request results based on row ranges.
+  // Applies maxRowsPerRequest hard clipping and accumulates numReadRows_.
+  // Returns false if a global limit (maxRows) was hit after this stripe.
+  bool buildStripeResult(
+      uint32_t stripeIndex,
+      std::span<const StripeRowRange> stripeRowRanges,
+      Chunk&& chunk,
+      Result& result);
+
+  // Sets resume keys on all truncated requests that have data in the next
+  // unprocessed stripe.
+  void setResumeKeys(
+      uint32_t stripeIndex,
+      std::span<const StripeRowRange> stripeRowRanges,
+      Result& result);
 
   inline uint32_t stripeRowCount(uint32_t stripe) const {
     return static_cast<uint32_t>(readerBase_->tablet().stripeRowCount(stripe));
@@ -272,10 +294,11 @@ class NimbleIndexProjector {
   const Request* request_{nullptr};
   const Options* options_{nullptr};
 
-  // Accumulated rows read per request for maxRowsPerRequest enforcement.
+  // Running total of rows read across all requests for maxRows enforcement.
+  uint64_t numReadRows_{0};
+  // Accumulated rows per request for maxRowsPerRequest enforcement.
   std::vector<uint64_t> rowsPerRequest_;
   // Current stripe's row ranges after pruning saturated requests.
-  // Populated by pruneStripeRowRanges(), consumed by processStripe().
   std::vector<StripeRowRange> stripeRowRanges_;
   // CSR mapping from stripes to request row ranges. Populated by
   // lookupStripes(), read-only during stripe processing.

--- a/dwio/nimble/velox/index/tests/NimbleIndexProjectorTest.cpp
+++ b/dwio/nimble/velox/index/tests/NimbleIndexProjectorTest.cpp
@@ -155,6 +155,56 @@ class NimbleIndexProjectorTest : public ::testing::TestWithParam<TestParam> {
     return encoded[0];
   }
 
+  // Creates encoded key bounds for a range scan on a single int64 key.
+  // The range is [lowerKey, upperKey) (lower inclusive, upper exclusive).
+  velox::serializer::EncodedKeyBounds makeRangeLookup(
+      const RowTypePtr& keyType,
+      const std::vector<std::string>& indexColumns,
+      int64_t lowerKey,
+      int64_t upperKey) {
+    if (keyEncoder_ == nullptr) {
+      std::vector<velox::core::SortOrder> sortOrders(
+          indexColumns.size(), velox::core::SortOrder{true, false});
+      keyEncoder_ = velox::serializer::KeyEncoder::create(
+          indexColumns, keyType, sortOrders, leafPool_.get());
+    }
+
+    auto lowerVector = vectorMaker_->rowVector(
+        indexColumns, {vectorMaker_->flatVector<int64_t>({lowerKey})});
+    auto upperVector = vectorMaker_->rowVector(
+        indexColumns, {vectorMaker_->flatVector<int64_t>({upperKey})});
+
+    velox::serializer::IndexBounds bounds;
+    bounds.indexColumns = indexColumns;
+    bounds.set(
+        velox::serializer::IndexBound{lowerVector, true},
+        velox::serializer::IndexBound{upperVector, false});
+
+    auto encoded = keyEncoder_->encodeIndexBounds(bounds);
+    EXPECT_EQ(encoded.size(), 1);
+    return encoded[0];
+  }
+
+  // Writes deterministic data with keys 0..numBatches*rowsPerBatch-1 across
+  // multiple stripes (one stripe per batch).
+  void writeResumeKeyTestData(int rowsPerBatch = 100, int numBatches = 10) {
+    std::vector<RowVectorPtr> batches;
+    for (int b = 0; b < numBatches; ++b) {
+      std::vector<int64_t> keys(rowsPerBatch);
+      std::vector<int32_t> values(rowsPerBatch);
+      for (int i = 0; i < rowsPerBatch; ++i) {
+        keys[i] = b * rowsPerBatch + i;
+        values[i] = keys[i] * 10;
+      }
+      batches.emplace_back(vectorMaker_->rowVector(
+          {"key", "value"},
+          {vectorMaker_->flatVector<int64_t>(keys),
+           vectorMaker_->flatVector<int32_t>(values)}));
+    }
+    // stripeSize=1 forces each batch into its own stripe.
+    writeData(batches, {"key"}, {}, /*stripeSize=*/1);
+  }
+
   const std::shared_ptr<io::IoStatistics> dataIoStats_{
       std::make_shared<io::IoStatistics>()};
   const std::shared_ptr<io::IoStatistics> metadataIoStats_{
@@ -1073,6 +1123,659 @@ TEST_P(NimbleIndexProjectorTest, pinnedMetadataNoReread) {
   EXPECT_LE(trackingFile->maxReadOffset(), metadataBoundary)
       << "Second project should not re-read metadata when "
       << GetParam().debugString();
+}
+
+TEST_P(NimbleIndexProjectorTest, resumeKeyOnTruncation) {
+  auto rowType = ROW({"key", "value"}, {BIGINT(), INTEGER()});
+  // 10 stripes x 100 rows = 1000 rows, keys 0..999.
+  writeResumeKeyTestData();
+
+  std::vector<Subfield> subfields;
+  subfields.emplace_back("value");
+  auto projector = createProjector(subfields);
+
+  // Range scan [0, 500) with maxRows=50. Since maxRows is a soft limit
+  // at stripe boundaries and each stripe has 100 rows, the first stripe
+  // (100 rows) exceeds the limit but is fully included.
+  auto bounds = makeRangeLookup(rowType, {"key"}, 0, 500);
+  NimbleIndexProjector::Request request;
+  request.keyBounds = {bounds};
+  NimbleIndexProjector::Options options;
+  options.maxRows = 50;
+  auto result = projector.project(request, options);
+
+  ASSERT_EQ(result.responses.size(), 1);
+  const auto& response = result.responses[0];
+  ASSERT_FALSE(response.slices.empty());
+
+  // Soft limit: first stripe (100 rows) included fully.
+  uint64_t totalRows = 0;
+  for (const auto& slice : response.slices) {
+    totalRows += slice.rows.numRows();
+  }
+  EXPECT_EQ(totalRows, 100);
+
+  // Resume key must be set since the request spans more stripes.
+  ASSERT_TRUE(response.resumeKey.has_value());
+  EXPECT_TRUE(response.resumeKey->lowerKey.has_value());
+  EXPECT_EQ(response.resumeKey->upperKey, bounds.upperKey);
+}
+
+TEST_P(NimbleIndexProjectorTest, resumeKeyNotSetWithoutTruncation) {
+  auto rowType = ROW({"key", "value"}, {BIGINT(), INTEGER()});
+  writeResumeKeyTestData();
+
+  std::vector<Subfield> subfields;
+  subfields.emplace_back("value");
+
+  // Case 1: maxRows = 0 (unlimited).
+  {
+    auto projector = createProjector(subfields);
+    auto bounds = makeRangeLookup(rowType, {"key"}, 0, 50);
+    NimbleIndexProjector::Request request;
+    request.keyBounds = {bounds};
+    auto result = projector.project(request, {});
+    ASSERT_EQ(result.responses.size(), 1);
+    EXPECT_FALSE(result.responses[0].resumeKey.has_value());
+  }
+
+  // Case 2: maxRows > total matching rows.
+  {
+    auto projector = createProjector(subfields);
+    auto bounds = makeRangeLookup(rowType, {"key"}, 0, 50);
+    NimbleIndexProjector::Request request;
+    request.keyBounds = {bounds};
+    NimbleIndexProjector::Options options;
+    options.maxRows = 10000;
+    auto result = projector.project(request, options);
+    ASSERT_EQ(result.responses.size(), 1);
+    EXPECT_FALSE(result.responses[0].resumeKey.has_value());
+  }
+
+  // Case 3: Point lookup (always returns <=1 row per key).
+  {
+    auto projector = createProjector(subfields);
+    auto bounds = makePointLookup(rowType, {"key"}, 50);
+    NimbleIndexProjector::Request request;
+    request.keyBounds = {bounds};
+    NimbleIndexProjector::Options options;
+    options.maxRows = 10;
+    auto result = projector.project(request, options);
+    ASSERT_EQ(result.responses.size(), 1);
+    EXPECT_FALSE(result.responses[0].resumeKey.has_value());
+  }
+}
+
+TEST_P(NimbleIndexProjectorTest, softLimitAtStripeBoundary) {
+  auto rowType = ROW({"key", "value"}, {BIGINT(), INTEGER()});
+  // 10 stripes x 100 rows.
+  writeResumeKeyTestData(/*rowsPerBatch=*/100, /*numBatches=*/10);
+
+  std::vector<Subfield> subfields;
+  subfields.emplace_back("value");
+
+  // maxRows=99: below stripe size, but soft limit includes entire first stripe.
+  {
+    auto projector = createProjector(subfields);
+    auto bounds = makeRangeLookup(rowType, {"key"}, 0, 500);
+    NimbleIndexProjector::Request request;
+    request.keyBounds = {bounds};
+    NimbleIndexProjector::Options options;
+    options.maxRows = 99;
+    auto result = projector.project(request, options);
+
+    ASSERT_EQ(result.responses.size(), 1);
+    uint64_t totalRows = 0;
+    for (const auto& slice : result.responses[0].slices) {
+      totalRows += slice.rows.numRows();
+    }
+    EXPECT_EQ(totalRows, 100);
+    EXPECT_TRUE(result.responses[0].resumeKey.has_value());
+  }
+
+  // maxRows=100: exactly one stripe, stops after it.
+  {
+    auto projector = createProjector(subfields);
+    auto bounds = makeRangeLookup(rowType, {"key"}, 0, 500);
+    NimbleIndexProjector::Request request;
+    request.keyBounds = {bounds};
+    NimbleIndexProjector::Options options;
+    options.maxRows = 100;
+    auto result = projector.project(request, options);
+
+    ASSERT_EQ(result.responses.size(), 1);
+    uint64_t totalRows = 0;
+    for (const auto& slice : result.responses[0].slices) {
+      totalRows += slice.rows.numRows();
+    }
+    EXPECT_EQ(totalRows, 100);
+    EXPECT_TRUE(result.responses[0].resumeKey.has_value());
+  }
+
+  // maxRows=101: exceeds first stripe, processes second stripe too (soft
+  // limit). Second stripe has 100 rows, total = 200.
+  {
+    auto projector = createProjector(subfields);
+    auto bounds = makeRangeLookup(rowType, {"key"}, 0, 500);
+    NimbleIndexProjector::Request request;
+    request.keyBounds = {bounds};
+    NimbleIndexProjector::Options options;
+    options.maxRows = 101;
+    auto result = projector.project(request, options);
+
+    ASSERT_EQ(result.responses.size(), 1);
+    uint64_t totalRows = 0;
+    for (const auto& slice : result.responses[0].slices) {
+      totalRows += slice.rows.numRows();
+    }
+    EXPECT_EQ(totalRows, 200);
+    EXPECT_TRUE(result.responses[0].resumeKey.has_value());
+  }
+}
+
+TEST_P(NimbleIndexProjectorTest, resumeKeyPagination) {
+  auto rowType = ROW({"key", "value"}, {BIGINT(), INTEGER()});
+  // 10 stripes x 100 rows = 1000 rows, keys 0..999.
+  writeResumeKeyTestData();
+
+  std::vector<Subfield> subfields;
+  subfields.emplace_back("value");
+
+  const int64_t rangeStart = 0;
+  const int64_t rangeEnd = 1000;
+  // maxRows=150 with 100-row stripes: each page gets 2 stripes (200 rows)
+  // because 1st stripe (100) is under limit, 2nd stripe (200 total) exceeds
+  // the soft limit and stops.
+  const uint64_t maxRows = 150;
+
+  uint64_t totalRowsRead = 0;
+  auto currentBounds = makeRangeLookup(rowType, {"key"}, rangeStart, rangeEnd);
+  int pageCount = 0;
+
+  while (true) {
+    auto projector = createProjector(subfields);
+    NimbleIndexProjector::Request request;
+    request.keyBounds = {currentBounds};
+    NimbleIndexProjector::Options options;
+    options.maxRows = maxRows;
+    auto result = projector.project(request, options);
+
+    ASSERT_EQ(result.responses.size(), 1);
+    const auto& response = result.responses[0];
+
+    uint64_t pageRows = 0;
+    for (const auto& slice : response.slices) {
+      pageRows += slice.rows.numRows();
+    }
+    EXPECT_GT(pageRows, 0) << "Page " << pageCount << " returned no rows";
+    totalRowsRead += pageRows;
+    ++pageCount;
+
+    if (!response.resumeKey.has_value()) {
+      break;
+    }
+
+    currentBounds = response.resumeKey.value();
+    ASSERT_LT(pageCount, 100) << "Pagination loop exceeded safety limit";
+  }
+
+  // All rows should have been read across all pages.
+  EXPECT_EQ(totalRowsRead, static_cast<uint64_t>(rangeEnd - rangeStart));
+}
+
+TEST_P(NimbleIndexProjectorTest, maxRowsTotalAcrossRequests) {
+  auto rowType = ROW({"key", "value"}, {BIGINT(), INTEGER()});
+  // 10 stripes x 100 rows = 1000 rows, keys 0..999.
+  writeResumeKeyTestData();
+
+  std::vector<Subfield> subfields;
+  subfields.emplace_back("value");
+  auto projector = createProjector(subfields);
+
+  // Two range scans: request 0 spans stripes 0-4, request 1 spans stripe 9.
+  // maxRows=50 (soft limit): first stripe (100 rows) exceeds limit, stops.
+  // Request 0 gets 100 rows from stripe 0, request 1 gets nothing (stripe 9
+  // is never reached).
+  auto bounds0 = makeRangeLookup(rowType, {"key"}, 0, 500);
+  auto bounds1 = makeRangeLookup(rowType, {"key"}, 900, 1000);
+
+  NimbleIndexProjector::Request request;
+  request.keyBounds = {bounds0, bounds1};
+  NimbleIndexProjector::Options options;
+  options.maxRows = 50;
+  auto result = projector.project(request, options);
+
+  ASSERT_EQ(result.responses.size(), 2);
+
+  // Request 0: gets full first stripe (100 rows), has resume key.
+  {
+    const auto& response = result.responses[0];
+    uint64_t totalRows = 0;
+    for (const auto& slice : response.slices) {
+      totalRows += slice.rows.numRows();
+    }
+    EXPECT_EQ(totalRows, 100);
+    EXPECT_TRUE(response.resumeKey.has_value());
+  }
+
+  // Request 1: stripe 9 was never processed, resume key = original start key.
+  {
+    const auto& response = result.responses[1];
+    EXPECT_TRUE(response.slices.empty());
+    ASSERT_TRUE(response.resumeKey.has_value());
+    EXPECT_EQ(response.resumeKey->lowerKey, bounds1.lowerKey);
+    EXPECT_EQ(response.resumeKey->upperKey, bounds1.upperKey);
+  }
+}
+
+TEST_P(NimbleIndexProjectorTest, noResumeKeyWhenRequestFullySatisfied) {
+  auto rowType = ROW({"key", "value"}, {BIGINT(), INTEGER()});
+  // 10 stripes x 100 rows = 1000 rows, keys 0..999.
+  writeResumeKeyTestData();
+
+  std::vector<Subfield> subfields;
+  subfields.emplace_back("value");
+  auto projector = createProjector(subfields);
+
+  // Request 0: [0, 100) — exactly one stripe, fully satisfied.
+  // Request 1: [0, 500) — spans 5 stripes, will be truncated.
+  // maxRows=100: first stripe covers both, request 0 ends within it.
+  auto bounds0 = makeRangeLookup(rowType, {"key"}, 0, 100);
+  auto bounds1 = makeRangeLookup(rowType, {"key"}, 0, 500);
+
+  NimbleIndexProjector::Request request;
+  request.keyBounds = {bounds0, bounds1};
+  NimbleIndexProjector::Options options;
+  options.maxRows = 100;
+  auto result = projector.project(request, options);
+
+  ASSERT_EQ(result.responses.size(), 2);
+
+  // Request 0: fully satisfied within stripe 0 — no resume key.
+  {
+    const auto& response = result.responses[0];
+    ASSERT_FALSE(response.slices.empty());
+    EXPECT_FALSE(response.resumeKey.has_value());
+  }
+
+  // Request 1: spans beyond stripe 0, truncated — has resume key.
+  {
+    const auto& response = result.responses[1];
+    ASSERT_FALSE(response.slices.empty());
+    EXPECT_TRUE(response.resumeKey.has_value());
+  }
+}
+
+TEST_P(NimbleIndexProjectorTest, maxRowsExceedsTotal) {
+  auto rowType = ROW({"key", "value"}, {BIGINT(), INTEGER()});
+  // 10 stripes x 100 rows = 1000 rows.
+  writeResumeKeyTestData();
+
+  std::vector<Subfield> subfields;
+  subfields.emplace_back("value");
+  auto projector = createProjector(subfields);
+
+  // maxRows larger than total matching rows — no truncation.
+  auto bounds = makeRangeLookup(rowType, {"key"}, 0, 300);
+  NimbleIndexProjector::Request request;
+  request.keyBounds = {bounds};
+  NimbleIndexProjector::Options options;
+  options.maxRows = 10000;
+  auto result = projector.project(request, options);
+
+  ASSERT_EQ(result.responses.size(), 1);
+  uint64_t totalRows = 0;
+  for (const auto& slice : result.responses[0].slices) {
+    totalRows += slice.rows.numRows();
+  }
+  EXPECT_EQ(totalRows, 300);
+  EXPECT_FALSE(result.responses[0].resumeKey.has_value());
+}
+
+TEST_P(NimbleIndexProjectorTest, maxRowsZeroMeansUnlimited) {
+  auto rowType = ROW({"key", "value"}, {BIGINT(), INTEGER()});
+  writeResumeKeyTestData();
+
+  std::vector<Subfield> subfields;
+  subfields.emplace_back("value");
+  auto projector = createProjector(subfields);
+
+  auto bounds = makeRangeLookup(rowType, {"key"}, 0, 1000);
+  NimbleIndexProjector::Request request;
+  request.keyBounds = {bounds};
+  NimbleIndexProjector::Options options;
+  options.maxRows = 0;
+  auto result = projector.project(request, options);
+
+  ASSERT_EQ(result.responses.size(), 1);
+  uint64_t totalRows = 0;
+  for (const auto& slice : result.responses[0].slices) {
+    totalRows += slice.rows.numRows();
+  }
+  EXPECT_EQ(totalRows, 1000);
+  EXPECT_FALSE(result.responses[0].resumeKey.has_value());
+}
+
+TEST_P(NimbleIndexProjectorTest, maxRowsSingleRowStripes) {
+  auto rowType = ROW({"key", "value"}, {BIGINT(), INTEGER()});
+  // 10 stripes x 1 row each.
+  writeResumeKeyTestData(/*rowsPerBatch=*/1, /*numBatches=*/10);
+
+  std::vector<Subfield> subfields;
+  subfields.emplace_back("value");
+  auto projector = createProjector(subfields);
+
+  // maxRows=3: should process exactly 3 stripes (3 rows).
+  auto bounds = makeRangeLookup(rowType, {"key"}, 0, 10);
+  NimbleIndexProjector::Request request;
+  request.keyBounds = {bounds};
+  NimbleIndexProjector::Options options;
+  options.maxRows = 3;
+  auto result = projector.project(request, options);
+
+  ASSERT_EQ(result.responses.size(), 1);
+  uint64_t totalRows = 0;
+  for (const auto& slice : result.responses[0].slices) {
+    totalRows += slice.rows.numRows();
+  }
+  EXPECT_EQ(totalRows, 3);
+  EXPECT_TRUE(result.responses[0].resumeKey.has_value());
+}
+
+TEST_P(NimbleIndexProjectorTest, maxRowsPerRequestClipping) {
+  auto rowType = ROW({"key", "value"}, {BIGINT(), INTEGER()});
+  // 10 stripes x 100 rows.
+  writeResumeKeyTestData();
+
+  std::vector<Subfield> subfields;
+  subfields.emplace_back("value");
+
+  // Stripe-aligned: 200 rows = exactly 2 stripes. No resume key.
+  {
+    auto projector = createProjector(subfields);
+    auto bounds = makeRangeLookup(rowType, {"key"}, 0, 500);
+    NimbleIndexProjector::Request request;
+    request.keyBounds = {bounds};
+    NimbleIndexProjector::Options options;
+    options.maxRowsPerRequest = 200;
+    auto result = projector.project(request, options);
+
+    ASSERT_EQ(result.responses.size(), 1);
+    EXPECT_FALSE(result.responses[0].resumeKey.has_value());
+    EXPECT_EQ(projector.stats().numReadRows, 200);
+  }
+
+  // Mid-stripe hard cut: 150 rows = 1 full stripe (100) + 50 from stripe 2.
+  {
+    auto projector = createProjector(subfields);
+    auto bounds = makeRangeLookup(rowType, {"key"}, 0, 500);
+    NimbleIndexProjector::Request request;
+    request.keyBounds = {bounds};
+    NimbleIndexProjector::Options options;
+    options.maxRowsPerRequest = 150;
+    auto result = projector.project(request, options);
+
+    ASSERT_EQ(result.responses.size(), 1);
+    const auto& response = result.responses[0];
+    EXPECT_FALSE(response.resumeKey.has_value());
+    EXPECT_EQ(projector.stats().numReadRows, 150);
+    ASSERT_EQ(response.slices.size(), 2);
+    EXPECT_EQ(response.slices[0].rows.numRows(), 100);
+    EXPECT_EQ(response.slices[1].rows.numRows(), 50);
+  }
+}
+
+TEST_P(NimbleIndexProjectorTest, maxRowsPerRequestIndependentPruning) {
+  auto rowType = ROW({"key", "value"}, {BIGINT(), INTEGER()});
+  writeResumeKeyTestData();
+
+  std::vector<Subfield> subfields;
+  subfields.emplace_back("value");
+  auto projector = createProjector(subfields);
+
+  // Request 0: [0, 500) spans stripes 0-4.
+  // Request 1: [200, 800) spans stripes 2-7.
+  // maxRowsPerRequest=100: each gets exactly 100 rows, no resume key.
+  auto bounds0 = makeRangeLookup(rowType, {"key"}, 0, 500);
+  auto bounds1 = makeRangeLookup(rowType, {"key"}, 200, 800);
+
+  NimbleIndexProjector::Request request;
+  request.keyBounds = {bounds0, bounds1};
+  NimbleIndexProjector::Options options;
+  options.maxRowsPerRequest = 100;
+  auto result = projector.project(request, options);
+
+  ASSERT_EQ(result.responses.size(), 2);
+
+  {
+    const auto& response = result.responses[0];
+    uint64_t totalRows = 0;
+    for (const auto& slice : response.slices) {
+      totalRows += slice.rows.numRows();
+    }
+    EXPECT_EQ(totalRows, 100);
+    EXPECT_FALSE(response.resumeKey.has_value());
+  }
+
+  {
+    const auto& response = result.responses[1];
+    uint64_t totalRows = 0;
+    for (const auto& slice : response.slices) {
+      totalRows += slice.rows.numRows();
+    }
+    EXPECT_EQ(totalRows, 100);
+    EXPECT_FALSE(response.resumeKey.has_value());
+  }
+}
+
+TEST_P(NimbleIndexProjectorTest, maxRowsPerRequestAndGlobalMaxRows) {
+  auto rowType = ROW({"key", "value"}, {BIGINT(), INTEGER()});
+  writeResumeKeyTestData();
+
+  std::vector<Subfield> subfields;
+  subfields.emplace_back("value");
+
+  // Per-request limit is tighter: 100 rows/request vs 500 global.
+  // Request is fulfilled (100 rows), no resume key from maxRowsPerRequest.
+  {
+    auto projector = createProjector(subfields);
+    auto bounds = makeRangeLookup(rowType, {"key"}, 0, 500);
+    NimbleIndexProjector::Request request;
+    request.keyBounds = {bounds};
+    NimbleIndexProjector::Options options;
+    options.maxRowsPerRequest = 100;
+    options.maxRows = 500;
+
+    auto result = projector.project(request, options);
+    ASSERT_EQ(result.responses.size(), 1);
+    EXPECT_FALSE(result.responses[0].resumeKey.has_value());
+    EXPECT_EQ(projector.stats().numReadRows, 100);
+  }
+
+  // Global limit is tighter: 50 rows global vs 300 rows/request.
+  // Global limit triggers resume key (stripe-boundary soft limit = 100 rows).
+  {
+    auto projector = createProjector(subfields);
+    auto bounds = makeRangeLookup(rowType, {"key"}, 0, 500);
+    NimbleIndexProjector::Request request;
+    request.keyBounds = {bounds};
+    NimbleIndexProjector::Options options;
+    options.maxRowsPerRequest = 300;
+    options.maxRows = 50;
+
+    auto result = projector.project(request, options);
+    ASSERT_EQ(result.responses.size(), 1);
+    EXPECT_TRUE(result.responses[0].resumeKey.has_value());
+    EXPECT_EQ(projector.stats().numReadStripes, 1);
+    EXPECT_EQ(projector.stats().numReadRows, 100);
+  }
+
+  // Per-request hard limit cuts mid-stripe: 50 rows/request < 100-row stripe.
+  // No resume key — request is fulfilled with 50 rows.
+  {
+    auto projector = createProjector(subfields);
+    auto bounds = makeRangeLookup(rowType, {"key"}, 0, 500);
+    NimbleIndexProjector::Request request;
+    request.keyBounds = {bounds};
+    NimbleIndexProjector::Options options;
+    options.maxRowsPerRequest = 50;
+    options.maxRows = 500;
+
+    auto result = projector.project(request, options);
+    ASSERT_EQ(result.responses.size(), 1);
+    EXPECT_FALSE(result.responses[0].resumeKey.has_value());
+    EXPECT_EQ(projector.stats().numReadRows, 50);
+  }
+}
+
+TEST_P(
+    NimbleIndexProjectorTest,
+    maxRowsPerRequestMultiRequestMidStripeClipping) {
+  auto rowType = ROW({"key", "value"}, {BIGINT(), INTEGER()});
+  // 10 stripes x 100 rows.
+  writeResumeKeyTestData();
+
+  std::vector<Subfield> subfields;
+  subfields.emplace_back("value");
+  auto projector = createProjector(subfields);
+
+  // Request 0: [0, 300) spans stripes 0-2.
+  // Request 1: [0, 300) same range.
+  // maxRowsPerRequest=150: both get 100 (stripe 0) + 50 (clipped stripe 1).
+  auto bounds0 = makeRangeLookup(rowType, {"key"}, 0, 300);
+  auto bounds1 = makeRangeLookup(rowType, {"key"}, 0, 300);
+
+  NimbleIndexProjector::Request request;
+  request.keyBounds = {bounds0, bounds1};
+  NimbleIndexProjector::Options options;
+  options.maxRowsPerRequest = 150;
+  auto result = projector.project(request, options);
+
+  ASSERT_EQ(result.responses.size(), 2);
+  for (int i = 0; i < 2; ++i) {
+    SCOPED_TRACE(fmt::format("request {}", i));
+    const auto& response = result.responses[i];
+    uint64_t totalRows = 0;
+    for (const auto& slice : response.slices) {
+      totalRows += slice.rows.numRows();
+    }
+    EXPECT_EQ(totalRows, 150);
+    EXPECT_FALSE(response.resumeKey.has_value());
+    ASSERT_EQ(response.slices.size(), 2);
+    EXPECT_EQ(response.slices[0].rows.numRows(), 100);
+    EXPECT_EQ(response.slices[1].rows.numRows(), 50);
+  }
+}
+
+TEST_P(NimbleIndexProjectorTest, maxRowsPerRequestSingleRow) {
+  auto rowType = ROW({"key", "value"}, {BIGINT(), INTEGER()});
+  // 10 stripes x 100 rows.
+  writeResumeKeyTestData();
+
+  std::vector<Subfield> subfields;
+  subfields.emplace_back("value");
+  auto projector = createProjector(subfields);
+
+  // maxRowsPerRequest=1: each request gets exactly 1 row, clipped from the
+  // first row of the first matching stripe.
+  auto bounds = makeRangeLookup(rowType, {"key"}, 0, 500);
+  NimbleIndexProjector::Request request;
+  request.keyBounds = {bounds};
+  NimbleIndexProjector::Options options;
+  options.maxRowsPerRequest = 1;
+  auto result = projector.project(request, options);
+
+  ASSERT_EQ(result.responses.size(), 1);
+  const auto& response = result.responses[0];
+  EXPECT_FALSE(response.resumeKey.has_value());
+  EXPECT_EQ(projector.stats().numReadRows, 1);
+  ASSERT_EQ(response.slices.size(), 1);
+  EXPECT_EQ(response.slices[0].rows.numRows(), 1);
+}
+
+TEST_P(NimbleIndexProjectorTest, maxRowsLargeScale) {
+  auto rowType = ROW({"key", "value"}, {BIGINT(), INTEGER()});
+  // 50 stripes x 200 rows = 10,000 rows.
+  writeResumeKeyTestData(/*rowsPerBatch=*/200, /*numBatches=*/50);
+
+  std::vector<Subfield> subfields;
+  subfields.emplace_back("value");
+
+  // Paginate through all 10,000 rows with maxRows=500 (soft limit).
+  // Each page gets at least 500 rows (soft limit includes the full stripe
+  // that crosses the threshold, so ~600 rows per page with 200-row stripes).
+  auto paginate = [&](uint64_t maxRows) -> uint64_t {
+    auto currentBounds = makeRangeLookup(rowType, {"key"}, 0, 10000);
+    uint64_t totalReadRows = 0;
+    int pages = 0;
+    while (pages < 100) {
+      ++pages;
+      auto projector = createProjector(subfields);
+      NimbleIndexProjector::Request request;
+      request.keyBounds = {currentBounds};
+      NimbleIndexProjector::Options options;
+      options.maxRows = maxRows;
+      auto result = projector.project(request, options);
+      EXPECT_EQ(result.responses.size(), 1);
+      totalReadRows += projector.stats().numReadRows;
+      if (!result.responses[0].resumeKey.has_value()) {
+        break;
+      }
+      currentBounds = result.responses[0].resumeKey.value();
+    }
+    EXPECT_LT(pages, 100);
+    return totalReadRows;
+  };
+
+  EXPECT_EQ(paginate(500), 10000);
+  EXPECT_EQ(paginate(1000), 10000);
+  EXPECT_EQ(paginate(5000), 10000);
+}
+
+TEST_P(NimbleIndexProjectorTest, maxRowsMultiRequestMixedSatisfaction) {
+  auto rowType = ROW({"key", "value"}, {BIGINT(), INTEGER()});
+  // 10 stripes x 100 rows.
+  writeResumeKeyTestData();
+
+  std::vector<Subfield> subfields;
+  subfields.emplace_back("value");
+  auto projector = createProjector(subfields);
+
+  // Request 0: [0, 50) — within stripe 0, fully satisfied.
+  // Request 1: [0, 100) — exactly stripe 0, fully satisfied.
+  // Request 2: [0, 500) — spans 5 stripes, truncated by maxRows.
+  // Request 3: [950, 1000) — stripe 9, never reached.
+  // maxRows=100: processes stripe 0, then stops.
+  auto bounds0 = makeRangeLookup(rowType, {"key"}, 0, 50);
+  auto bounds1 = makeRangeLookup(rowType, {"key"}, 0, 100);
+  auto bounds2 = makeRangeLookup(rowType, {"key"}, 0, 500);
+  auto bounds3 = makeRangeLookup(rowType, {"key"}, 950, 1000);
+
+  NimbleIndexProjector::Request request;
+  request.keyBounds = {bounds0, bounds1, bounds2, bounds3};
+  NimbleIndexProjector::Options options;
+  options.maxRows = 100;
+  auto result = projector.project(request, options);
+
+  ASSERT_EQ(result.responses.size(), 4);
+
+  // Request 0: 50 rows, fully satisfied, no resume key.
+  EXPECT_FALSE(result.responses[0].slices.empty());
+  EXPECT_FALSE(result.responses[0].resumeKey.has_value());
+
+  // Request 1: 100 rows, fully satisfied (ends at stripe boundary), no resume.
+  EXPECT_FALSE(result.responses[1].slices.empty());
+  EXPECT_FALSE(result.responses[1].resumeKey.has_value());
+
+  // Request 2: 100 rows from stripe 0, has data in stripes 1-4, resume key.
+  EXPECT_FALSE(result.responses[2].slices.empty());
+  EXPECT_TRUE(result.responses[2].resumeKey.has_value());
+
+  // Request 3: stripe 9 never processed, resume key = original start key.
+  EXPECT_TRUE(result.responses[3].slices.empty());
+  ASSERT_TRUE(result.responses[3].resumeKey.has_value());
+  EXPECT_EQ(result.responses[3].resumeKey->lowerKey, bounds3.lowerKey);
+  EXPECT_EQ(result.responses[3].resumeKey->upperKey, bounds3.upperKey);
 }
 
 INSTANTIATE_TEST_CASE_P(


### PR DESCRIPTION
Summary:

When `maxRowsPerRequest` truncates a range scan result, compute a resume key so the caller can paginate with a follow-up `project()` call. The resume key is `{lowerKey = keyAtNextRow, upperKey = originalUpperBound}`.

Adds `ClusterIndex::keyAtRow(uint32_t row)` which resolves a file-level row position to its encoded key by: binary searching `partitionRows_` to find the partition, `lookupChunkByRow()` to find the chunk within the partition, then decoding the chunk and using `reset()/skip()/materialize()` to read the key value.

Reviewed By: xiaoxmeng

Differential Revision: D98702773


