### PR TITLE
refactor: Enforce callers to provide metadataIoStats to TabletReader (#731)

### DIFF
--- a/dwio/nimble/index/tests/HashIndexTest.cpp
+++ b/dwio/nimble/index/tests/HashIndexTest.cpp
@@ -23,6 +23,7 @@
 #include "dwio/nimble/index/IndexLookup.h"
 
 #include "dwio/nimble/tablet/TabletReader.h"
+#include "dwio/nimble/tablet/tests/TabletTestUtils.h"
 #include "dwio/nimble/velox/VeloxReader.h"
 #include "dwio/nimble/velox/VeloxWriter.h"
 #include "velox/common/file/FileSystems.h"
@@ -103,7 +104,10 @@ class HashIndexTestBase {
   std::shared_ptr<TabletReader> openTablet(const std::string& filePath) {
     auto fs = velox::filesystems::getFileSystem(filePath, {});
     auto readFile = fs->openFileForRead(filePath);
-    return TabletReader::create(std::move(readFile), leafPool_.get(), {});
+    return TabletReader::create(
+        std::move(readFile),
+        leafPool_.get(),
+        ::facebook::nimble::test::makeTestTabletOptions(leafPool_.get()));
   }
 
   // Encodes a lookup key for a single row and returns the encoded key.

--- a/dwio/nimble/index/tests/SortedIndexTest.cpp
+++ b/dwio/nimble/index/tests/SortedIndexTest.cpp
@@ -26,6 +26,7 @@
 #include "velox/common/base/tests/GTestUtils.h"
 
 #include "dwio/nimble/tablet/TabletReader.h"
+#include "dwio/nimble/tablet/tests/TabletTestUtils.h"
 #include "dwio/nimble/velox/VeloxReader.h"
 #include "dwio/nimble/velox/VeloxWriter.h"
 #include "velox/common/file/FileSystems.h"
@@ -99,7 +100,10 @@ class SortedIndexTestBase {
   std::shared_ptr<TabletReader> openTablet(const std::string& filePath) {
     auto fs = velox::filesystems::getFileSystem(filePath, {});
     auto readFile = fs->openFileForRead(filePath);
-    return TabletReader::create(std::move(readFile), leafPool_.get(), {});
+    return TabletReader::create(
+        std::move(readFile),
+        leafPool_.get(),
+        ::facebook::nimble::test::makeTestTabletOptions(leafPool_.get()));
   }
 
   std::string encodeLookupKey(

--- a/dwio/nimble/serializer/tests/SerializationTest.cpp
+++ b/dwio/nimble/serializer/tests/SerializationTest.cpp
@@ -25,6 +25,7 @@
 #include "dwio/nimble/serializer/SerializerImpl.h"
 #include "dwio/nimble/tablet/Constants.h"
 #include "dwio/nimble/tablet/TabletReader.h"
+#include "dwio/nimble/tablet/tests/TabletTestUtils.h"
 #include "dwio/nimble/velox/EncodingLayoutTree.h"
 #include "dwio/nimble/velox/SchemaSerialization.h"
 #include "dwio/nimble/velox/SchemaUtils.h"
@@ -41,6 +42,7 @@
 
 using namespace facebook;
 using namespace facebook::nimble;
+using facebook::nimble::test::makeTestTabletOptions;
 
 // Test parameters for parameterized tests.
 // For kCompact mode, we test both with and without compression to exercise the
@@ -510,7 +512,7 @@ SerializationTest::SerializeResult SerializationTest::serializeTabletRaw(
   auto readFile =
       std::make_shared<velox::InMemoryReadFile>(std::string_view(fileData));
   auto tablet = nimble::TabletReader::create(
-      readFile, pool_.get(), nimble::TabletReader::Options{});
+      readFile, pool_.get(), makeTestTabletOptions(pool_.get()));
   EXPECT_GT(tablet->stripeCount(), 0);
 
   // Load the nimble schema from the tablet file.
@@ -3134,7 +3136,7 @@ TEST_F(SerializationTest, zstdThreadLocalDCtxHighParallelism) {
   auto readFile =
       std::make_shared<velox::InMemoryReadFile>(std::string_view(fileData));
   auto tablet = nimble::TabletReader::create(
-      readFile, pool_.get(), nimble::TabletReader::Options{});
+      readFile, pool_.get(), makeTestTabletOptions(pool_.get()));
   auto schemaSection =
       tablet->loadOptionalSection(std::string(nimble::kSchemaSection));
   auto nimbleSchema =
@@ -3256,7 +3258,7 @@ TEST_F(SerializationTest, zstdThreadLocalDCtxConcurrentDeserializers) {
     auto readFile =
         std::make_shared<velox::InMemoryReadFile>(std::string_view(fileData));
     auto tablet = nimble::TabletReader::create(
-        readFile, pool_.get(), nimble::TabletReader::Options{});
+        readFile, pool_.get(), makeTestTabletOptions(pool_.get()));
     auto schemaSection =
         tablet->loadOptionalSection(std::string(nimble::kSchemaSection));
     schemas[t] = nimble::SchemaDeserializer::deserialize(
@@ -3425,7 +3427,7 @@ TEST_F(SerializationTest, zstdThreadLocalDCtxFlatMapWithParallelDecode) {
   auto readFile =
       std::make_shared<velox::InMemoryReadFile>(std::string_view(fileData));
   auto tablet = nimble::TabletReader::create(
-      readFile, pool_.get(), nimble::TabletReader::Options{});
+      readFile, pool_.get(), makeTestTabletOptions(pool_.get()));
   auto schemaSection =
       tablet->loadOptionalSection(std::string(nimble::kSchemaSection));
   auto nimbleSchema =
@@ -3544,7 +3546,7 @@ TEST_F(SerializationTest, zstdThreadLocalDCtxRepeatedBatches) {
   auto readFile =
       std::make_shared<velox::InMemoryReadFile>(std::string_view(fileData));
   auto tablet = nimble::TabletReader::create(
-      readFile, pool_.get(), nimble::TabletReader::Options{});
+      readFile, pool_.get(), makeTestTabletOptions(pool_.get()));
   auto schemaSection =
       tablet->loadOptionalSection(std::string(nimble::kSchemaSection));
   auto nimbleSchema =

--- a/dwio/nimble/tablet/TabletReader.cpp
+++ b/dwio/nimble/tablet/TabletReader.cpp
@@ -232,24 +232,11 @@ TabletReader::TabletReader(
       loadClusterIndex_{options.loadClusterIndex},
       loadChunkIndex_{options.loadChunkIndex},
       loadDenseIndexes_{options.loadDenseIndexes},
-      defaultIoStats_{[&]() -> std::shared_ptr<velox::io::IoStatistics> {
-        if (options.ioOptions.has_value() &&
-            options.ioOptions->metadataIoStats() != nullptr) {
-          return nullptr;
-        }
-        return std::make_unique<velox::io::IoStatistics>();
-      }()},
       ioOptions_{[&]() {
-        if (options.ioOptions.has_value()) {
-          auto opts = *options.ioOptions;
-          if (opts.metadataIoStats() == nullptr) {
-            opts.setMetadataIoStats(defaultIoStats_);
-          }
-          return opts;
-        }
-        velox::io::ReaderOptions opts(&pool);
-        opts.setMetadataIoStats(defaultIoStats_);
-        return opts;
+        NIMBLE_CHECK(options.ioOptions.has_value(), "ioOptions is not set.");
+        NIMBLE_CHECK_NOT_NULL(
+            options.ioOptions->metadataIoStats(), "metadataIoStats is null.");
+        return *options.ioOptions;
       }()},
       indexOptions_{index::IndexLookup::Options{
           file_,

--- a/dwio/nimble/tablet/TabletReader.h
+++ b/dwio/nimble/tablet/TabletReader.h
@@ -175,7 +175,8 @@ class TabletReader {
     bool pinFileMetadata{false};
 
     /// IO options providing pool, IO stats, coalescing params, and executor.
-    /// When not set, a default is created internally from the provided pool.
+    /// Must be set with a non-null metadataIoStats; the constructor enforces
+    /// this with a NIMBLE_CHECK.
     std::optional<velox::io::ReaderOptions> ioOptions;
 
     /// File handle and cache for CachedMetadataInput. Both must be set
@@ -499,9 +500,8 @@ class TabletReader {
   const bool loadClusterIndex_;
   const bool loadChunkIndex_;
   const bool loadDenseIndexes_;
-  // Default IO stats when caller doesn't provide ioOptions.
-  const std::shared_ptr<velox::io::IoStatistics> defaultIoStats_;
-  // Resolved IO options — either copied from Options or created with defaults.
+  // IO options copied from Options.ioOptions (required, with non-null
+  // metadataIoStats).
   const velox::io::ReaderOptions ioOptions_;
   // IO config for index creation — indexes create their own MetadataInput
   // with index-specific IO stats.

--- a/dwio/nimble/tablet/tests/TabletTestUtils.h
+++ b/dwio/nimble/tablet/tests/TabletTestUtils.h
@@ -17,8 +17,20 @@
 #pragma once
 
 #include "dwio/nimble/tablet/TabletReader.h"
+#include "velox/common/io/IoStatistics.h"
+#include "velox/common/io/Options.h"
 
 namespace facebook::nimble::test {
+
+/// Creates a TabletReader::Options object for testing purposes.
+/// Test only, production must plumb their own `IoStatistics`.
+inline TabletReader::Options makeTestTabletOptions(
+    velox::memory::MemoryPool* pool) {
+  TabletReader::Options options;
+  options.ioOptions.emplace(pool).setMetadataIoStats(
+      std::make_shared<velox::io::IoStatistics>());
+  return options;
+}
 
 /// Test helper class for TabletReader that provides access to private members
 /// for testing purposes. This follows the same pattern as

--- a/dwio/nimble/tools/NimbleDslLib.cpp
+++ b/dwio/nimble/tools/NimbleDslLib.cpp
@@ -334,7 +334,10 @@ void NimbleDslLib::select(
     uint64_t limit,
     uint64_t offset,
     std::optional<uint32_t> stripeId) {
-  auto tablet = TabletReader::create(file_, pool_.get(), {});
+  TabletReader::Options tabletOptions;
+  tabletOptions.ioOptions.emplace(pool_.get())
+      .setMetadataIoStats(std::make_shared<velox::io::IoStatistics>());
+  auto tablet = TabletReader::create(file_, pool_.get(), tabletOptions);
 
   // First create a reader without projection to get the full schema.
   VeloxReader schemaReader{tablet, *pool_};
@@ -437,7 +440,10 @@ void NimbleDslLib::select(
 }
 
 void NimbleDslLib::describe() {
-  auto tablet = TabletReader::create(file_, pool_.get(), {});
+  TabletReader::Options tabletOptions;
+  tabletOptions.ioOptions.emplace(pool_.get())
+      .setMetadataIoStats(std::make_shared<velox::io::IoStatistics>());
+  auto tablet = TabletReader::create(file_, pool_.get(), tabletOptions);
   VeloxReader reader{tablet, *pool_};
   const auto& veloxType = reader.type();
 
@@ -530,6 +536,8 @@ void NimbleDslLib::showStats() {
   TabletReader::Options tabletOptions;
   tabletOptions.preloadOptionalSections = {
       std::string(kVectorizedStatsSection)};
+  tabletOptions.ioOptions.emplace(pool_.get())
+      .setMetadataIoStats(std::make_shared<velox::io::IoStatistics>());
   auto tablet = TabletReader::create(file_, pool_.get(), tabletOptions);
   VeloxReader reader{tablet, *pool_};
 
@@ -637,7 +645,10 @@ void NimbleDslLib::showOptionalSections() {
 }
 
 void NimbleDslLib::showEncoding(std::optional<uint32_t> stripeId) {
-  auto tablet = TabletReader::create(file_, pool_.get(), {});
+  TabletReader::Options tabletOptions;
+  tabletOptions.ioOptions.emplace(pool_.get())
+      .setMetadataIoStats(std::make_shared<velox::io::IoStatistics>());
+  auto tablet = TabletReader::create(file_, pool_.get(), tabletOptions);
   VeloxReader reader{tablet, *pool_};
   StreamLabels labels{reader.schema()};
 

--- a/dwio/nimble/tools/NimbleDumpLib.cpp
+++ b/dwio/nimble/tools/NimbleDumpLib.cpp
@@ -308,6 +308,8 @@ NimbleDumpLib::NimbleDumpLib(
 void NimbleDumpLib::emitInfo() {
   TabletReader::Options options;
   options.preloadOptionalSections = {std::string(kStatsSection)};
+  options.ioOptions.emplace(pool_.get())
+      .setMetadataIoStats(std::make_shared<velox::io::IoStatistics>());
   const auto tablet = TabletReader::create(file_, pool_.get(), options);
   ostream_ << CYAN(enableColors_) << "Nimble File "
            << RESET_COLOR(enableColors_) << "Version " << tablet->majorVersion()
@@ -382,7 +384,10 @@ void NimbleDumpLib::emitInfo() {
 }
 
 void NimbleDumpLib::emitSchema(bool collapseFlatMap) {
-  auto tablet = TabletReader::create(file_, pool_.get(), {});
+  TabletReader::Options options;
+  options.ioOptions.emplace(pool_.get())
+      .setMetadataIoStats(std::make_shared<velox::io::IoStatistics>());
+  auto tablet = TabletReader::create(file_, pool_.get(), options);
   VeloxReader reader{tablet, *pool_};
 
   auto emitOffsets = [](const Type& type) {
@@ -485,7 +490,10 @@ void NimbleDumpLib::emitSchema(bool collapseFlatMap) {
 }
 
 void NimbleDumpLib::emitStripes(bool noHeader) {
-  const auto tabletReader = TabletReader::create(file_, pool_.get(), {});
+  TabletReader::Options options;
+  options.ioOptions.emplace(pool_.get())
+      .setMetadataIoStats(std::make_shared<velox::io::IoStatistics>());
+  const auto tabletReader = TabletReader::create(file_, pool_.get(), options);
   TableFormatter formatter(
       ostream_,
       enableColors_,
@@ -517,7 +525,10 @@ void NimbleDumpLib::emitStreams(
     bool showStreamRawSize,
     bool showInMapStream,
     std::optional<uint32_t> stripeId) {
-  auto tabletReader = TabletReader::create(file_, pool_.get(), {});
+  TabletReader::Options options;
+  options.ioOptions.emplace(pool_.get())
+      .setMetadataIoStats(std::make_shared<velox::io::IoStatistics>());
+  auto tabletReader = TabletReader::create(file_, pool_.get(), options);
 
   std::vector<std::tuple<std::string, uint8_t, Alignment>> fields;
   fields.emplace_back("Stripe Id", 9, Alignment::Left);
@@ -608,7 +619,10 @@ void NimbleDumpLib::emitHistogram(
     bool topLevel,
     bool noHeader,
     std::optional<uint32_t> stripeId) {
-  auto tabletReader = TabletReader::create(file_, pool_.get(), {});
+  TabletReader::Options options;
+  options.ioOptions.emplace(pool_.get())
+      .setMetadataIoStats(std::make_shared<velox::io::IoStatistics>());
+  auto tabletReader = TabletReader::create(file_, pool_.get(), options);
   std::unordered_map<
       GroupingKey,
       EncodingHistogramValue,
@@ -695,7 +709,10 @@ void NimbleDumpLib::emitContent(
     uint32_t streamId,
     std::optional<uint32_t> stripeId,
     const std::string& separator) {
-  auto tabletReader = TabletReader::create(file_, pool_.get(), {});
+  TabletReader::Options options;
+  options.ioOptions.emplace(pool_.get())
+      .setMetadataIoStats(std::make_shared<velox::io::IoStatistics>());
+  auto tabletReader = TabletReader::create(file_, pool_.get(), options);
 
   uint32_t maxStreamCount;
   bool found = false;
@@ -747,7 +764,10 @@ void NimbleDumpLib::emitBinary(
     std::function<std::unique_ptr<std::ostream>()> outputFactory,
     uint32_t streamId,
     uint32_t stripeId) {
-  auto tabletReader = TabletReader::create(file_, pool_.get(), {});
+  TabletReader::Options options;
+  options.ioOptions.emplace(pool_.get())
+      .setMetadataIoStats(std::make_shared<velox::io::IoStatistics>());
+  auto tabletReader = TabletReader::create(file_, pool_.get(), options);
   auto stripeIdentifier = tabletReader->stripeIdentifier(stripeId);
   if (streamId >= tabletReader->streamCount(stripeIdentifier)) {
     throw folly::ProgramExit(
@@ -958,7 +978,10 @@ void NimbleDumpLib::emitLayout(bool noHeader, bool compressed) {
 }
 
 void NimbleDumpLib::emitStripesMetadata(bool noHeader) {
-  auto tabletReader = TabletReader::create(file_, pool_.get(), {});
+  TabletReader::Options options;
+  options.ioOptions.emplace(pool_.get())
+      .setMetadataIoStats(std::make_shared<velox::io::IoStatistics>());
+  auto tabletReader = TabletReader::create(file_, pool_.get(), options);
   TableFormatter formatter(
       ostream_,
       enableColors_,
@@ -1075,7 +1098,10 @@ void NimbleDumpLib::emitFileLayout(bool noHeader) {
 }
 
 void NimbleDumpLib::emitStripeGroupsMetadata(bool noHeader) {
-  auto tabletReader = TabletReader::create(file_, pool_.get(), {});
+  TabletReader::Options options;
+  options.ioOptions.emplace(pool_.get())
+      .setMetadataIoStats(std::make_shared<velox::io::IoStatistics>());
+  auto tabletReader = TabletReader::create(file_, pool_.get(), options);
   TableFormatter formatter(
       ostream_,
       enableColors_,
@@ -1104,7 +1130,10 @@ void NimbleDumpLib::emitOptionalSectionsMetadata(bool noHeader) {
     nimble::MetadataSection metadata;
   };
 
-  auto tabletReader = TabletReader::create(file_, pool_.get(), {});
+  TabletReader::Options options;
+  options.ioOptions.emplace(pool_.get())
+      .setMetadataIoStats(std::make_shared<velox::io::IoStatistics>());
+  auto tabletReader = TabletReader::create(file_, pool_.get(), options);
   std::vector<NamedMetdataSection> sections;
   sections.reserve(tabletReader->optionalSections().size());
   for (const auto& [name, metadata] : tabletReader->optionalSections()) {
@@ -1136,7 +1165,10 @@ void NimbleDumpLib::emitOptionalSectionsMetadata(bool noHeader) {
 }
 
 void NimbleDumpLib::emitIndex() {
-  auto tabletReader = TabletReader::create(file_, pool_.get(), {});
+  TabletReader::Options options;
+  options.ioOptions.emplace(pool_.get())
+      .setMetadataIoStats(std::make_shared<velox::io::IoStatistics>());
+  auto tabletReader = TabletReader::create(file_, pool_.get(), options);
   if (!tabletReader->hasClusterIndex()) {
     ostream_ << "Index: Not configured" << std::endl;
     return;
@@ -1325,6 +1357,8 @@ void NimbleDumpLib::emitStats(bool noHeader) {
   TabletReader::Options options;
   options.preloadOptionalSections = {
       std::string(kVectorizedStatsSection), std::string(kStatsSection)};
+  options.ioOptions.emplace(pool_.get())
+      .setMetadataIoStats(std::make_shared<velox::io::IoStatistics>());
   auto tabletReader = TabletReader::create(file_, pool_.get(), options);
 
   auto vectorizedStatsSection =

--- a/dwio/nimble/velox/VeloxReader.cpp
+++ b/dwio/nimble/velox/VeloxReader.cpp
@@ -149,13 +149,18 @@ uint64_t NimbleUnit::getIoSize() {
   return ioSize_.value();
 }
 
-} // namespace
-
-TabletReader::Options VeloxReader::defaultTabletReaderOptions() {
+// Default `TabletReader::Options` used by `VeloxReader`'s convenience
+// constructors: preload the schema section and attach a fresh `IoStatistics`.
+TabletReader::Options defaultTabletReaderOptions(
+    velox::memory::MemoryPool* pool) {
   TabletReader::Options options;
   options.preloadOptionalSections = {std::string(kSchemaSection)};
+  options.ioOptions.emplace(pool).setMetadataIoStats(
+      std::make_shared<velox::io::IoStatistics>());
   return options;
 }
+
+} // namespace
 
 VeloxReader::VeloxReader(
     velox::ReadFile* file,
@@ -166,7 +171,7 @@ VeloxReader::VeloxReader(
           TabletReader::create(
               std::shared_ptr<velox::ReadFile>(file, [](auto*) {}),
               &pool,
-              defaultTabletReaderOptions()),
+              defaultTabletReaderOptions(&pool)),
           pool,
           std::move(selector),
           std::move(params)) {}
@@ -180,7 +185,7 @@ VeloxReader::VeloxReader(
           TabletReader::create(
               std::move(file),
               &pool,
-              defaultTabletReaderOptions()),
+              defaultTabletReaderOptions(&pool)),
           pool,
           std::move(selector),
           std::move(params)) {}

--- a/dwio/nimble/velox/VeloxReader.h
+++ b/dwio/nimble/velox/VeloxReader.h
@@ -175,8 +175,6 @@ class VeloxReader {
   // Returns the total number of rows skipped.
   uint64_t skipStripes(uint32_t startStripeIndex, uint64_t rowsToSkip);
 
-  static TabletReader::Options defaultTabletReaderOptions();
-
   std::unique_ptr<velox::dwio::common::UnitLoader> getUnitLoader();
 
   uint32_t getUnitIndex(uint32_t stripeIndex) const;

--- a/dwio/nimble/velox/index/tests/NimbleIndexProjectorTest.cpp
+++ b/dwio/nimble/velox/index/tests/NimbleIndexProjectorTest.cpp
@@ -22,6 +22,7 @@
 #include "dwio/nimble/common/tests/TestUtils.h"
 #include "dwio/nimble/serializer/Deserializer.h"
 #include "dwio/nimble/tablet/TabletReader.h"
+#include "dwio/nimble/tablet/tests/TabletTestUtils.h"
 #include "dwio/nimble/velox/SchemaUtils.h"
 #include "dwio/nimble/velox/VeloxReader.h"
 #include "dwio/nimble/velox/VeloxWriter.h"
@@ -906,7 +907,8 @@ TEST_P(NimbleIndexProjectorTest, featureReorderingStorageReads) {
     writeFile(/*enableReordering=*/true);
     auto readFile =
         std::make_shared<InMemoryReadFile>(std::string_view(sinkData_));
-    auto tablet = TabletReader::create(readFile, leafPool_.get(), {});
+    auto tablet = TabletReader::create(
+        readFile, leafPool_.get(), makeTestTabletOptions(leafPool_.get()));
     ASSERT_GE(tablet->stripeCount(), 1);
 
     auto stripeId = tablet->stripeIdentifier(0);
@@ -1037,7 +1039,8 @@ TEST_P(NimbleIndexProjectorTest, pinnedMetadataNoReread) {
   auto trackingFile = std::make_shared<testing::TrackingReadFile>(innerFile);
 
   // Compute metadata boundary: the start of the first stripe group metadata.
-  auto tablet = TabletReader::create(innerFile, leafPool_.get(), {});
+  auto tablet = TabletReader::create(
+      innerFile, leafPool_.get(), makeTestTabletOptions(leafPool_.get()));
   auto stripeGroupsMeta = tablet->stripeGroupsMetadata();
   ASSERT_FALSE(stripeGroupsMeta.empty());
   const auto metadataBoundary = stripeGroupsMeta[0].offset();

--- a/dwio/nimble/velox/selective/tests/E2EFilterTest.cpp
+++ b/dwio/nimble/velox/selective/tests/E2EFilterTest.cpp
@@ -21,6 +21,7 @@
 #include "dwio/nimble/encodings/EncodingLayout.h"
 #include "dwio/nimble/tablet/Constants.h"
 #include "dwio/nimble/tablet/TabletReader.h"
+#include "dwio/nimble/tablet/tests/TabletTestUtils.h"
 #include "dwio/nimble/velox/ChunkedStream.h"
 #include "dwio/nimble/velox/EncodingLayoutTree.h"
 #include "dwio/nimble/velox/SchemaSerialization.h"
@@ -517,7 +518,8 @@ class E2EFilterTest
   void verifyColumnEncodingsOnDisk(EncodingType expectedEncodingType) {
     auto readFile = std::make_shared<InMemoryReadFile>(sinkData_);
     auto& pool = *leafPool_;
-    auto tablet = TabletReader::create(readFile, &pool, {});
+    auto tablet = TabletReader::create(
+        readFile, &pool, test::makeTestTabletOptions(&pool));
     auto section = tablet->loadOptionalSection(std::string(kSchemaSection));
     ASSERT_TRUE(section.has_value());
     auto schema = SchemaDeserializer::deserialize(section->content().data());

--- a/dwio/nimble/velox/selective/tests/SelectiveNimbleReaderTest.cpp
+++ b/dwio/nimble/velox/selective/tests/SelectiveNimbleReaderTest.cpp
@@ -26,6 +26,7 @@
 #include "dwio/nimble/encodings/EncodingLayout.h"
 #include "dwio/nimble/tablet/Constants.h"
 #include "dwio/nimble/tablet/TabletReader.h"
+#include "dwio/nimble/tablet/tests/TabletTestUtils.h"
 #include "dwio/nimble/velox/ChunkedStream.h"
 #include "dwio/nimble/velox/EncodingLayoutTree.h"
 #include "dwio/nimble/velox/SchemaSerialization.h"
@@ -327,7 +328,8 @@ class SelectiveNimbleReaderTest
       EncodingType expectedEncodingType,
       bool isNullable = true) {
     auto readFile = std::make_shared<velox::InMemoryReadFile>(file);
-    auto tablet = TabletReader::create(readFile, pool(), {});
+    auto tablet = TabletReader::create(
+        readFile, pool(), test::makeTestTabletOptions(pool()));
     auto section = tablet->loadOptionalSection(std::string(kSchemaSection));
     ASSERT_TRUE(section.has_value());
     auto schema = SchemaDeserializer::deserialize(section->content().data());
@@ -2552,7 +2554,8 @@ TEST_P(SelectiveNimbleReaderTest, pinnedMetadataNoReread) {
 
   // Get the metadata boundary. Stripe group metadata starts right after the
   // last stripe's data. Any read at or above this offset is a metadata read.
-  auto tablet = TabletReader::create(delegate, pool(), {});
+  auto tablet = TabletReader::create(
+      delegate, pool(), test::makeTestTabletOptions(pool()));
   const auto stripeGroupsMeta = tablet->stripeGroupsMetadata();
   ASSERT_EQ(stripeGroupsMeta.size(), 1);
   const auto metadataBoundary = stripeGroupsMeta[0].offset();

--- a/dwio/nimble/velox/tests/VeloxReaderTest.cpp
+++ b/dwio/nimble/velox/tests/VeloxReaderTest.cpp
@@ -25,6 +25,7 @@
 #include "dwio/nimble/common/tests/NimbleFileWriter.h"
 #include "dwio/nimble/common/tests/TestUtils.h"
 #include "dwio/nimble/tablet/TabletReader.h"
+#include "dwio/nimble/tablet/tests/TabletTestUtils.h"
 #include "dwio/nimble/velox/ChunkedStream.h"
 #include "dwio/nimble/velox/SchemaUtils.h"
 #include "dwio/nimble/velox/VeloxReader.h"
@@ -68,6 +69,8 @@ DEFINE_uint32(
 using nimble::testing::TrackingReadFile;
 
 namespace {
+
+using nimble::test::makeTestTabletOptions;
 
 struct VeloxMapGeneratorConfig {
   // A RowType containing a group of map feature column types.
@@ -386,7 +389,9 @@ size_t streamsReadCount(
   // Assumed for the algorithm
   NIMBLE_CHECK_EQ(false, readFile->shouldCoalesce());
   auto tablet = nimble::TabletReader::create(
-      std::shared_ptr<velox::ReadFile>(readFile, [](auto*) {}), &pool, {});
+      std::shared_ptr<velox::ReadFile>(readFile, [](auto*) {}),
+      &pool,
+      makeTestTabletOptions(&pool));
   NIMBLE_CHECK_GE(tablet->stripeCount(), 1);
   auto stripeIdentifier = tablet->stripeIdentifier(0);
   auto offsets = tablet->streamOffsets(stripeIdentifier);
@@ -417,7 +422,9 @@ std::unordered_set<nimble::offset_size> existingStreamOffsets(
     velox::ReadFile* readFile,
     uint32_t stripeIndex) {
   auto tablet = nimble::TabletReader::create(
-      std::shared_ptr<velox::ReadFile>(readFile, [](auto*) {}), &pool, {});
+      std::shared_ptr<velox::ReadFile>(readFile, [](auto*) {}),
+      &pool,
+      makeTestTabletOptions(&pool));
   NIMBLE_CHECK_LT(stripeIndex, tablet->stripeCount(), "Stripe out of range");
   auto stripeId = tablet->stripeIdentifier(stripeIndex);
   auto streamSizes = tablet->streamSizes(stripeId);
@@ -931,7 +938,8 @@ class VeloxReaderTest : public ::testing::TestWithParam<TestParam> {
 
     auto readFile = std::make_shared<velox::InMemoryReadFile>(file);
 
-    auto tablet = nimble::TabletReader::create(readFile, leafPool_.get(), {});
+    auto tablet = nimble::TabletReader::create(
+        readFile, leafPool_.get(), makeTestTabletOptions(leafPool_.get()));
     auto selector =
         std::make_shared<velox::dwio::common::ColumnSelector>(schema);
     std::unique_ptr<nimble::VeloxReader> reader =
@@ -4677,7 +4685,9 @@ class TestNimbleReaderFactory {
 
   std::shared_ptr<nimble::TabletReader> createTablet() {
     return nimble::TabletReader::create(
-        std::shared_ptr<velox::ReadFile>(file_.get(), [](auto*) {}), pool_, {});
+        std::shared_ptr<velox::ReadFile>(file_.get(), [](auto*) {}),
+        pool_,
+        makeTestTabletOptions(pool_));
   }
 
  private:

--- a/dwio/nimble/velox/tests/VeloxWriterTest.cpp
+++ b/dwio/nimble/velox/tests/VeloxWriterTest.cpp
@@ -34,6 +34,7 @@
 #include "dwio/nimble/index/tests/ClusterIndexTestUtils.h"
 #include "dwio/nimble/tablet/Constants.h"
 #include "dwio/nimble/tablet/FileLayout.h"
+#include "dwio/nimble/tablet/tests/TabletTestUtils.h"
 #include "dwio/nimble/velox/ChunkedStream.h"
 #include "dwio/nimble/velox/EncodingLayoutTree.h"
 #include "dwio/nimble/velox/FlushPolicy.h"
@@ -59,6 +60,8 @@ DEFINE_uint32(
     0,
     "If provided, this seed will be used when executing tests. "
     "Otherwise, a random seed will be used.");
+
+using nimble::test::makeTestTabletOptions;
 
 class VeloxWriterTest : public ::testing::Test {
  protected:
@@ -449,7 +452,8 @@ TEST_F(VeloxWriterTest, featureReorderingStreamCollocation) {
     }
 
     auto readFile = std::make_shared<velox::InMemoryReadFile>(file);
-    auto tablet = nimble::TabletReader::create(readFile, leafPool_.get(), {});
+    auto tablet = nimble::TabletReader::create(
+        readFile, leafPool_.get(), makeTestTabletOptions(leafPool_.get()));
     ASSERT_GE(tablet->stripeCount(), 1);
     if (enableIndex) {
       ASSERT_NE(tablet->clusterIndex(), nullptr) << "Cluster index must exist";
@@ -952,7 +956,8 @@ TEST_F(VeloxWriterTest, encodingLayout) {
     auto readFile =
         std::make_shared<nimble::testing::InMemoryTrackableReadFile>(
             file, useChainedBuffers);
-    auto tablet = nimble::TabletReader::create(readFile, leafPool_.get(), {});
+    auto tablet = nimble::TabletReader::create(
+        readFile, leafPool_.get(), makeTestTabletOptions(leafPool_.get()));
     auto section =
         tablet->loadOptionalSection(std::string(nimble::kSchemaSection));
     NIMBLE_CHECK(section.has_value(), "Schema not found.");
@@ -1473,8 +1478,8 @@ void testChunks(
   folly::writeFile(file, "/tmp/afile");
 
   auto tabletReadFile = std::make_shared<velox::InMemoryReadFile>(file);
-  auto tablet =
-      nimble::TabletReader::create(tabletReadFile, leafPool.get(), {});
+  auto tablet = nimble::TabletReader::create(
+      tabletReadFile, leafPool.get(), makeTestTabletOptions(leafPool.get()));
   verifier(*tablet);
 
   nimble::VeloxReader reader(
@@ -2355,7 +2360,8 @@ TEST_F(VeloxWriterTest, rawSizeWritten) {
     writer.close();
 
     auto statsReadFile = std::make_shared<velox::InMemoryReadFile>(file);
-    nimble::TabletReader::Options readerOptions;
+    nimble::TabletReader::Options readerOptions =
+        makeTestTabletOptions(leafPool_.get());
     readerOptions.preloadOptionalSections = {
         std::string(facebook::nimble::kStatsSection)};
     auto tablet = facebook::nimble::TabletReader::create(
@@ -2383,7 +2389,8 @@ TEST_F(VeloxWriterTest, rawSizeWritten) {
     writer.close();
 
     auto vecStatsReadFile = std::make_shared<velox::InMemoryReadFile>(file);
-    nimble::TabletReader::Options readerOptions;
+    nimble::TabletReader::Options readerOptions =
+        makeTestTabletOptions(leafPool_.get());
     readerOptions.preloadOptionalSections = {
         std::string(facebook::nimble::kVectorizedStatsSection)};
     auto tablet = facebook::nimble::TabletReader::create(
@@ -4399,7 +4406,8 @@ TEST_F(VeloxWriterTest, customPrefixRestartInterval) {
 
     // Read back and verify the restart interval in the key encoding
     auto readFile = std::make_shared<velox::InMemoryReadFile>(file);
-    auto tablet = nimble::TabletReader::create(readFile, leafPool_.get(), {});
+    auto tablet = nimble::TabletReader::create(
+        readFile, leafPool_.get(), makeTestTabletOptions(leafPool_.get()));
 
     const auto* index = tablet->clusterIndex();
     ASSERT_NE(index, nullptr) << "Index must exist";
@@ -4618,7 +4626,8 @@ void verifyDeltaEncoding(
     bool checkChildren = false) {
   auto readFile =
       std::make_shared<nimble::testing::InMemoryTrackableReadFile>(file, false);
-  auto tablet = nimble::TabletReader::create(readFile, &pool, {});
+  auto tablet = nimble::TabletReader::create(
+      readFile, &pool, makeTestTabletOptions(&pool));
   auto section =
       tablet->loadOptionalSection(std::string(nimble::kSchemaSection));
   NIMBLE_CHECK(section.has_value(), "Schema not found.");
@@ -4681,7 +4690,8 @@ TEST_F(VeloxWriterTest, encodingLayoutDelta) {
     auto readFile =
         std::make_shared<nimble::testing::InMemoryTrackableReadFile>(
             file, useChainedBuffers);
-    auto tablet = nimble::TabletReader::create(readFile, leafPool_.get(), {});
+    auto tablet = nimble::TabletReader::create(
+        readFile, leafPool_.get(), makeTestTabletOptions(leafPool_.get()));
     auto section =
         tablet->loadOptionalSection(std::string(nimble::kSchemaSection));
     NIMBLE_CHECK(section.has_value(), "Schema not found.");
@@ -4911,7 +4921,8 @@ TEST_F(VeloxWriterTest, encodingLayoutDeltaMultiStripe) {
 
   auto readFile =
       std::make_shared<nimble::testing::InMemoryTrackableReadFile>(file, false);
-  auto tablet = nimble::TabletReader::create(readFile, leafPool_.get(), {});
+  auto tablet = nimble::TabletReader::create(
+      readFile, leafPool_.get(), makeTestTabletOptions(leafPool_.get()));
   ASSERT_GT(tablet->stripeCount(), 1);
 
   verifyDeltaEncoding(file, *leafPool_, true);
@@ -4990,7 +5001,8 @@ TEST_F(VeloxWriterTest, encodingLayoutDeltaMultiColumn) {
   // Verify both column encodings.
   auto readFile =
       std::make_shared<nimble::testing::InMemoryTrackableReadFile>(file, false);
-  auto tablet = nimble::TabletReader::create(readFile, leafPool_.get(), {});
+  auto tablet = nimble::TabletReader::create(
+      readFile, leafPool_.get(), makeTestTabletOptions(leafPool_.get()));
   auto section =
       tablet->loadOptionalSection(std::string(nimble::kSchemaSection));
   NIMBLE_CHECK(section.has_value(), "Schema not found.");
@@ -5194,8 +5206,10 @@ TEST_F(VeloxWriterTest, encodingLayoutDeltaMultiStripeLegacyRead) {
 
   auto readFileTrackable =
       std::make_shared<nimble::testing::InMemoryTrackableReadFile>(file, false);
-  auto tablet =
-      nimble::TabletReader::create(readFileTrackable, leafPool_.get(), {});
+  auto tablet = nimble::TabletReader::create(
+      readFileTrackable,
+      leafPool_.get(),
+      makeTestTabletOptions(leafPool_.get()));
   ASSERT_GT(tablet->stripeCount(), 1);
 
   verifyDeltaEncoding(file, *leafPool_, true);


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebookincubator/velox/pull/17534


Remove the `defaultIoStats_` fallback in `TabletReader` and instead enforce that callers always supply `ioOptions` with a non-null `metadataIoStats()`. The constructor now does an early `NIMBLE_CHECK` / `NIMBLE_CHECK_NOT_NULL` in its init list, so any caller that forgets to set the field fails fast at construction with a clear message.

Reviewed By: xiaoxmeng

Differential Revision: D105338687


