### PR TITLE
refactor(encoding): Move black-box compression code out-of white-box compression/encodings directory (#733)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -167,6 +167,7 @@ include_directories(SYSTEM ${CMAKE_BINARY_DIR}/_deps/xsimd-src/include/)
 
 add_subdirectory(velox)
 add_subdirectory(dwio/nimble/common)
+add_subdirectory(dwio/nimble/compression)
 add_subdirectory(dwio/nimble/tools)
 add_subdirectory(dwio/nimble/encodings)
 add_subdirectory(dwio/nimble/index)

--- a/dwio/nimble/compression/CMakeLists.txt
+++ b/dwio/nimble/compression/CMakeLists.txt
@@ -11,30 +11,11 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-add_subdirectory(benchmarks)
-add_subdirectory(tests)
-add_subdirectory(legacy)
-
 add_library(
-  nimble_encodings
-  ConstantEncoding.cpp
-  Encoding.cpp
-  EncodingFactory.cpp
-  EncodingLayout.cpp
-  MainlyConstantEncoding.cpp
-  PrefixEncoding.cpp
-  RleEncoding.cpp
-  SparseBoolEncoding.cpp
-  Statistics.cpp
-  TrivialEncoding.cpp
+  nimble_compression
+  Compression.cpp
+  Lz4Compressor.cpp
+  ZstdCompressor.cpp
 )
 
-target_link_libraries(
-  nimble_encodings
-  nimble_compression
-  nimble_common
-  velox_common_base
-  Folly::folly
-  absl::flat_hash_map
-  protobuf::libprotobuf
-)
+target_link_libraries(nimble_compression nimble_common Folly::folly lz4)

--- a/dwio/nimble/compression/Compression.cpp
+++ b/dwio/nimble/compression/Compression.cpp
@@ -13,14 +13,14 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#include "dwio/nimble/encodings/Compression.h"
+#include "dwio/nimble/compression/Compression.h"
 #include "dwio/nimble/common/EncodingPrimitives.h"
 #include "dwio/nimble/common/Exceptions.h"
-#include "dwio/nimble/encodings/Lz4Compressor.h"
-#include "dwio/nimble/encodings/ZstdCompressor.h"
+#include "dwio/nimble/compression/Lz4Compressor.h"
+#include "dwio/nimble/compression/ZstdCompressor.h"
 
 #ifndef DISABLE_META_INTERNAL_COMPRESSOR
-#include "dwio/nimble/encodings/fb/MetaInternalCompressor.h"
+#include "dwio/nimble/compression/fb/MetaInternalCompressor.h"
 #endif
 
 namespace facebook::nimble {

--- a/dwio/nimble/compression/Compression.h
+++ b/dwio/nimble/compression/Compression.h
@@ -18,7 +18,7 @@
 #include "dwio/nimble/common/EncodingPrimitives.h"
 #include "dwio/nimble/common/Types.h"
 #include "dwio/nimble/common/Vector.h"
-#include "dwio/nimble/encodings/EncodingSelection.h"
+#include "dwio/nimble/compression/CompressionPolicy.h"
 #include "folly/io/IOBuf.h"
 #include "velox/buffer/Buffer.h"
 #include "velox/buffer/BufferPool.h"
@@ -145,7 +145,7 @@ class CompressionEncoder {
       DataType dataType,
       int bitWidth,
       size_t uncompressedSize,
-      std::function<std::span<char>()> allocateUncompressedBuffer,
+      const std::function<std::span<char>()>& allocateUncompressedBuffer,
       std::function<void(char*&)> encoder)
       : encoder_{std::move(encoder)},
         dataSize_{uncompressedSize},

--- a/dwio/nimble/compression/CompressionPolicy.h
+++ b/dwio/nimble/compression/CompressionPolicy.h
@@ -1,0 +1,132 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <cstdint>
+#include <string>
+
+#include "dwio/nimble/common/Types.h"
+#include "folly/json/json.h"
+
+namespace facebook::nimble {
+
+///
+/// Compression policy type definitions:
+/// A compression policy defines which compression algorithm to apply on the
+/// data (if any) and what parameters to use for this compression algorithm. In
+/// addition, once compression is applied to the data, the compression policy
+/// can decide if the compressed result is statisfactory or if it should be
+/// discarded.
+struct ZstdCompressionParameters {
+  int16_t compressionLevel = 3;
+};
+
+struct Lz4CompressionParameters {
+  int16_t accelerationLevel = 1;
+};
+
+/// An identifier for the meta internal compression policy.
+class MetaInternalCompressionKey {
+ public:
+  MetaInternalCompressionKey() = default;
+
+  MetaInternalCompressionKey(
+      std::string ns,
+      std::string tableName,
+      std::string columnName)
+      : ns_{std::move(ns)},
+        tableName_{std::move(tableName)},
+        columnName_{std::move(columnName)} {}
+
+  const std::string& ns() const {
+    return ns_;
+  }
+
+  const std::string& tableName() const {
+    return tableName_;
+  }
+
+  const std::string& columnName() const {
+    return columnName_;
+  }
+
+  std::string toString() const {
+    folly::dynamic json = folly::dynamic::object("ns", ns_)(
+        "tableName", tableName_)("columnName", columnName_);
+    return folly::toJson(json);
+  }
+
+  static MetaInternalCompressionKey fromString(const std::string& str) {
+    auto json = folly::parseJson(str);
+    return MetaInternalCompressionKey{
+        json["ns"].asString(),
+        json["tableName"].asString(),
+        json["columnName"].asString()};
+  }
+
+ private:
+  std::string ns_;
+  std::string tableName_;
+  std::string columnName_;
+};
+
+struct MetaInternalCompressionParameters {
+  int16_t compressionLevel = 0;
+  int16_t decompressionLevel = 0;
+  bool useVariableBitWidthCompressor = true;
+  MetaInternalCompressionKey compressionKey;
+};
+
+struct CompressionParameters {
+  ZstdCompressionParameters zstd{};
+  Lz4CompressionParameters lz4{};
+  MetaInternalCompressionParameters metaInternal{};
+};
+
+struct CompressionInformation {
+  CompressionType compressionType{};
+  CompressionParameters parameters{};
+  uint64_t minCompressionSize = 0;
+};
+
+class CompressionPolicy {
+ public:
+  virtual CompressionInformation compression() const = 0;
+  virtual bool shouldAccept(
+      CompressionType /* compressionType */,
+      uint64_t /* uncompressedSize */,
+      uint64_t /* compressedSize */) const = 0;
+
+  virtual ~CompressionPolicy() = default;
+};
+
+/// Default compression policy. Default behavior (if not compression policy is
+/// provided) is to not compress.
+class NoCompressionPolicy : public CompressionPolicy {
+ public:
+  CompressionInformation compression() const override {
+    return {.compressionType = CompressionType::Uncompressed};
+  }
+
+  virtual bool shouldAccept(
+      CompressionType /* compressionType */,
+      uint64_t /* uncompressedSize */,
+      uint64_t /* compressedSize */) const override {
+    return false;
+  }
+};
+
+} // namespace facebook::nimble

--- a/dwio/nimble/compression/Lz4Compressor.cpp
+++ b/dwio/nimble/compression/Lz4Compressor.cpp
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-#include "dwio/nimble/encodings/Lz4Compressor.h"
+#include "dwio/nimble/compression/Lz4Compressor.h"
 
 #include <lz4.h>
 #include <optional>

--- a/dwio/nimble/compression/Lz4Compressor.h
+++ b/dwio/nimble/compression/Lz4Compressor.h
@@ -16,21 +16,21 @@
 
 #pragma once
 
-#include "dwio/nimble/encodings/Compression.h"
+#include "dwio/nimble/compression/Compression.h"
 
 namespace facebook::nimble {
 
-class ZstdCompressor : public ICompressor {
+class Lz4Compressor : public ICompressor {
  public:
   CompressionResult compress(
-      velox::memory::MemoryPool& pool,
+      velox::memory::MemoryPool& memoryPool,
       std::string_view data,
       DataType dataType,
       int bitWidth,
       const CompressionPolicy& compressionPolicy) override;
 
   velox::BufferPtr uncompress(
-      velox::memory::MemoryPool& pool,
+      velox::memory::MemoryPool& memoryPool,
       CompressionType compressionType,
       DataType dataType,
       std::string_view data,

--- a/dwio/nimble/compression/ZstdCompressor.cpp
+++ b/dwio/nimble/compression/ZstdCompressor.cpp
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-#include "dwio/nimble/encodings/ZstdCompressor.h"
+#include "dwio/nimble/compression/ZstdCompressor.h"
 
 #include <zstd.h>
 #include <zstd_errors.h>

--- a/dwio/nimble/compression/ZstdCompressor.h
+++ b/dwio/nimble/compression/ZstdCompressor.h
@@ -16,21 +16,21 @@
 
 #pragma once
 
-#include "dwio/nimble/encodings/Compression.h"
+#include "dwio/nimble/compression/Compression.h"
 
 namespace facebook::nimble {
 
-class Lz4Compressor : public ICompressor {
+class ZstdCompressor : public ICompressor {
  public:
   CompressionResult compress(
-      velox::memory::MemoryPool& memoryPool,
+      velox::memory::MemoryPool& pool,
       std::string_view data,
       DataType dataType,
       int bitWidth,
       const CompressionPolicy& compressionPolicy) override;
 
   velox::BufferPtr uncompress(
-      velox::memory::MemoryPool& memoryPool,
+      velox::memory::MemoryPool& pool,
       CompressionType compressionType,
       DataType dataType,
       std::string_view data,

--- a/dwio/nimble/encodings/EncodingSelection.h
+++ b/dwio/nimble/encodings/EncodingSelection.h
@@ -21,11 +21,11 @@
 
 #include "dwio/nimble/common/Exceptions.h"
 #include "dwio/nimble/common/Types.h"
+#include "dwio/nimble/compression/CompressionPolicy.h"
 #include "dwio/nimble/encodings/EncodingFactory.h"
 #include "dwio/nimble/encodings/EncodingIdentifier.h"
 #include "dwio/nimble/encodings/EncodingLayout.h"
 #include "dwio/nimble/encodings/Statistics.h"
-#include "folly/json/json.h"
 
 namespace facebook::nimble {
 
@@ -64,113 +64,6 @@ namespace facebook::nimble {
 /// encoding for the nested stream.
 
 class EncodingSelectionPolicyBase;
-
-///
-/// Compression policy type definitions:
-/// A compression policy defines which compression algorithm to apply on the
-/// data (if any) and what parameters to use for this compression algorithm. In
-/// addition, once compression is applied to the data, the compression policy
-/// can decide if the compressed result is statisfactory or if it should be
-/// discarded.
-struct ZstdCompressionParameters {
-  int16_t compressionLevel = 3;
-};
-
-struct Lz4CompressionParameters {
-  int16_t accelerationLevel = 1;
-};
-
-/// An identifier for the meta internal compression policy.
-class MetaInternalCompressionKey {
- public:
-  MetaInternalCompressionKey() = default;
-
-  MetaInternalCompressionKey(
-      std::string ns,
-      std::string tableName,
-      std::string columnName)
-      : ns_{std::move(ns)},
-        tableName_{std::move(tableName)},
-        columnName_{std::move(columnName)} {}
-
-  const std::string& ns() const {
-    return ns_;
-  }
-
-  const std::string& tableName() const {
-    return tableName_;
-  }
-
-  const std::string& columnName() const {
-    return columnName_;
-  }
-
-  std::string toString() const {
-    folly::dynamic json = folly::dynamic::object("ns", ns_)(
-        "tableName", tableName_)("columnName", columnName_);
-    return folly::toJson(json);
-  }
-
-  static MetaInternalCompressionKey fromString(const std::string& str) {
-    // will throw upon failure to parse or missing fields
-    auto json = folly::parseJson(str);
-    return MetaInternalCompressionKey{
-        json["ns"].asString(),
-        json["tableName"].asString(),
-        json["columnName"].asString()};
-  }
-
- private:
-  std::string ns_;
-  std::string tableName_;
-  std::string columnName_;
-};
-
-struct MetaInternalCompressionParameters {
-  int16_t compressionLevel = 0;
-  int16_t decompressionLevel = 0;
-  bool useVariableBitWidthCompressor = true;
-  MetaInternalCompressionKey compressionKey;
-};
-
-struct CompressionParameters {
-  ZstdCompressionParameters zstd{};
-  Lz4CompressionParameters lz4{};
-  MetaInternalCompressionParameters metaInternal{};
-};
-
-struct CompressionInformation {
-  CompressionType compressionType{};
-  CompressionParameters parameters{};
-  uint64_t minCompressionSize = 0;
-};
-
-class CompressionPolicy {
- public:
-  virtual CompressionInformation compression() const = 0;
-  virtual bool shouldAccept(
-      CompressionType /* compressionType */,
-      uint64_t /* uncompressedSize */,
-      uint64_t /* compressedSize */) const = 0;
-
-  virtual ~CompressionPolicy() = default;
-};
-
-/// Default compression policy. Default behavior (if not compression policy is
-/// provided) is to not compress.
-class NoCompressionPolicy : public CompressionPolicy {
- public:
-  CompressionInformation compression() const override {
-    return {.compressionType = CompressionType::Uncompressed};
-  }
-
-  virtual bool shouldAccept(
-      CompressionType /* compressionType */,
-      uint64_t /* uncompressedSize */,
-      uint64_t /* compressedSize */) const override {
-    return false;
-  }
-};
 
 /// Type representing a selected encoding.
 /// This is the result type returned from the select() method of an encoding

--- a/dwio/nimble/encodings/FixedBitWidthEncoding.h
+++ b/dwio/nimble/encodings/FixedBitWidthEncoding.h
@@ -24,7 +24,7 @@
 #include "dwio/nimble/common/Exceptions.h"
 #include "dwio/nimble/common/FixedBitArray.h"
 #include "dwio/nimble/common/Vector.h"
-#include "dwio/nimble/encodings/Compression.h"
+#include "dwio/nimble/compression/Compression.h"
 #include "dwio/nimble/encodings/Encoding.h"
 #include "velox/dwio/common/DecoderUtil.h"
 

--- a/dwio/nimble/encodings/TrivialEncoding.h
+++ b/dwio/nimble/encodings/TrivialEncoding.h
@@ -23,7 +23,7 @@
 #include "dwio/nimble/common/EncodingType.h"
 #include "dwio/nimble/common/FixedBitArray.h"
 #include "dwio/nimble/common/Types.h"
-#include "dwio/nimble/encodings/Compression.h"
+#include "dwio/nimble/compression/Compression.h"
 #include "dwio/nimble/encodings/Encoding.h"
 #include "dwio/nimble/encodings/EncodingIdentifier.h"
 #include "dwio/nimble/encodings/EncodingSelection.h"

--- a/dwio/nimble/encodings/legacy/FixedBitWidthEncoding.h
+++ b/dwio/nimble/encodings/legacy/FixedBitWidthEncoding.h
@@ -24,7 +24,7 @@
 #include "dwio/nimble/common/Exceptions.h"
 #include "dwio/nimble/common/FixedBitArray.h"
 #include "dwio/nimble/common/Vector.h"
-#include "dwio/nimble/encodings/Compression.h"
+#include "dwio/nimble/compression/Compression.h"
 #include "dwio/nimble/encodings/Encoding.h"
 #include "dwio/nimble/encodings/legacy/Encoding.h"
 

--- a/dwio/nimble/encodings/legacy/SparseBoolEncoding.cpp
+++ b/dwio/nimble/encodings/legacy/SparseBoolEncoding.cpp
@@ -19,7 +19,7 @@
 
 #include "dwio/nimble/common/EncodingPrimitives.h"
 #include "dwio/nimble/common/Types.h"
-#include "dwio/nimble/encodings/Compression.h"
+#include "dwio/nimble/compression/Compression.h"
 #include "dwio/nimble/encodings/legacy/EncodingFactory.h"
 
 namespace facebook::nimble::legacy {

--- a/dwio/nimble/encodings/legacy/TrivialEncoding.h
+++ b/dwio/nimble/encodings/legacy/TrivialEncoding.h
@@ -23,7 +23,7 @@
 #include "dwio/nimble/common/EncodingType.h"
 #include "dwio/nimble/common/FixedBitArray.h"
 #include "dwio/nimble/common/Types.h"
-#include "dwio/nimble/encodings/Compression.h"
+#include "dwio/nimble/compression/Compression.h"
 #include "dwio/nimble/encodings/Encoding.h"
 #include "dwio/nimble/encodings/EncodingIdentifier.h"
 #include "dwio/nimble/encodings/EncodingSelection.h"

--- a/dwio/nimble/encodings/tests/Lz4CompressorTest.cpp
+++ b/dwio/nimble/encodings/tests/Lz4CompressorTest.cpp
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#include "dwio/nimble/encodings/Lz4Compressor.h"
+#include "dwio/nimble/compression/Lz4Compressor.h"
 #include <gtest/gtest.h>
 #include <cstring>
 #include <random>

--- a/dwio/nimble/encodings/tests/ZstdCompressorTest.cpp
+++ b/dwio/nimble/encodings/tests/ZstdCompressorTest.cpp
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#include "dwio/nimble/encodings/ZstdCompressor.h"
+#include "dwio/nimble/compression/ZstdCompressor.h"
 #include <gtest/gtest.h>
 #include <cstring>
 #include <random>


### PR DESCRIPTION
Summary:

Move all compression-related files from `dwio/nimble/encodings/` into a new `dwio/nimble/encodings/compression/` subdirectory for better code organization.

Moved files:
- `Compression.{h,cpp}` — core compression interface and registry
- `ZstdCompressor.{h,cpp}` — ZSTD implementation
- `Lz4Compressor.{h,cpp}` — LZ4 implementation
- `fb/MetaInternalCompressor.{h,cpp}` — Meta internal (Zstrong) implementation
- `fb/MetaInternalMCCompressor.{h,cpp}` — Managed Compression implementation

Updated all `#include` paths in encoding headers, legacy encodings, tests, and external consumers. BUCK and CMakeLists.txt updated to reference the new paths. The files remain part of the same `encodings` BUCK target to avoid a circular dependency (`Compression.h` depends on `EncodingSelection.h`).

Reviewed By: DanielMunozT, apurva-meta, xiaoxmeng

Differential Revision: D105372304
