### PR TITLE
refactor(encoding): Extract prefix layout constants into `EncodingPrefix` struct

### DIFF
--- a/dwio/nimble/encodings/ConstantEncoding.h
+++ b/dwio/nimble/encodings/ConstantEncoding.h
@@ -28,7 +28,7 @@
 namespace facebook::nimble {
 
 // Data layout is:
-// Encoding::kPrefixSize bytes: standard Encoding prefix
+// EncodingPrefix::kFixedPrefixSize bytes: standard Encoding prefix
 // X bytes: the constant value via encoding primitive.
 
 template <typename T>

--- a/dwio/nimble/encodings/DeltaEncoding.h
+++ b/dwio/nimble/encodings/DeltaEncoding.h
@@ -53,7 +53,7 @@
 namespace facebook::nimble {
 
 // Data layout is:
-// Encoding::kPrefixSize bytes: standard Encoding prefix
+// EncodingPrefix::kFixedPrefixSize bytes: standard Encoding prefix
 // 4 bytes: restatement relative offset (X)
 // 4 bytes: is-restatement relative offset (Y)
 // X bytes: delta encoding bytes

--- a/dwio/nimble/encodings/DictionaryEncoding.h
+++ b/dwio/nimble/encodings/DictionaryEncoding.h
@@ -36,7 +36,7 @@
 namespace facebook::nimble {
 
 /// The layout for a dictionary encoding is:
-/// Encoding::kPrefixSize bytes: standard Encoding prefix
+/// EncodingPrefix::kFixedPrefixSize bytes: standard Encoding prefix
 /// 4 bytes: alphabet size
 /// XX bytes: alphabet encoding bytes
 /// YY bytes: indices encoding bytes

--- a/dwio/nimble/encodings/Encoding.cpp
+++ b/dwio/nimble/encodings/Encoding.cpp
@@ -14,9 +14,6 @@
  * limitations under the License.
  */
 #include "dwio/nimble/encodings/Encoding.h"
-#include "dwio/nimble/common/EncodingPrimitives.h"
-#include "dwio/nimble/common/Types.h"
-#include "dwio/nimble/common/Varint.h"
 
 namespace facebook::nimble {
 
@@ -26,36 +23,12 @@ Encoding::Encoding(
     const Options& options)
     : pool_{&pool},
       data_{data},
-      encodingType_{data_[kEncodingTypeOffset]},
+      encodingType_{data_[EncodingPrefix::kEncodingTypeOffset]},
       options_{options},
-      dataType_{readDataType(data)},
-      rowCount_{readRowCount(data, options_.useVarintRowCount)},
-      prefixSize_{readPrefixSize(data, options_.useVarintRowCount)} {}
-
-/* static */ DataType Encoding::readDataType(std::string_view data) {
-  return static_cast<DataType>(data[kDataTypeOffset]);
-}
-
-/* static */ uint32_t Encoding::readRowCount(
-    std::string_view data,
-    bool useVarint) {
-  if (useVarint) {
-    const char* pos = data.data() + kRowCountOffset;
-    return varint::readVarint32(&pos);
-  }
-  return *reinterpret_cast<const uint32_t*>(data.data() + kRowCountOffset);
-}
-
-/* static */ uint32_t Encoding::readPrefixSize(
-    std::string_view data,
-    bool useVarint) {
-  if (useVarint) {
-    const char* pos = data.data() + kRowCountOffset;
-    varint::readVarint32(&pos);
-    return pos - data.data();
-  }
-  return kPrefixSize;
-}
+      dataType_{EncodingPrefix::readDataType(data)},
+      rowCount_{EncodingPrefix::readRowCount(data, options_.useVarintRowCount)},
+      prefixSize_{
+          EncodingPrefix::readPrefixSize(data, options_.useVarintRowCount)} {}
 
 /* static */ void Encoding::copyIOBuf(char* pos, const folly::IOBuf& buf) {
   [[maybe_unused]] size_t length = buf.computeChainDataLength();
@@ -65,30 +38,6 @@ Encoding::Encoding(
     length -= data.size();
   }
   NIMBLE_DCHECK_EQ(length, 0, "IOBuf chain length corruption");
-}
-
-void Encoding::serializePrefix(
-    EncodingType encodingType,
-    DataType dataType,
-    uint32_t rowCount,
-    bool useVarint,
-    char*& pos) {
-  encoding::writeChar(static_cast<char>(encodingType), pos);
-  encoding::writeChar(static_cast<char>(dataType), pos);
-  if (useVarint) {
-    varint::writeVarint(rowCount, &pos);
-  } else {
-    encoding::writeUint32(rowCount, pos);
-  }
-}
-
-/* static */ uint32_t Encoding::serializePrefixSize(
-    uint32_t rowCount,
-    bool useVarint) {
-  if (!useVarint) {
-    return kPrefixSize;
-  }
-  return kRowCountOffset + varint::varintSize(rowCount);
 }
 
 std::string Encoding::debugString(int offset) const {

--- a/dwio/nimble/encodings/Encoding.h
+++ b/dwio/nimble/encodings/Encoding.h
@@ -19,6 +19,7 @@
 #include "dwio/nimble/common/Exceptions.h"
 #include "dwio/nimble/common/Types.h"
 #include "dwio/nimble/common/Vector.h"
+#include "dwio/nimble/encodings/EncodingPrefix.h"
 #include "velox/buffer/BufferPool.h"
 #include "velox/common/base/BitUtil.h"
 #include "velox/common/memory/Memory.h"
@@ -110,15 +111,11 @@ class Encoding {
     velox::BufferPool* bufferPool;
   };
 
-  /// The binary layout for each Encoding begins with the same prefix:
-  /// 1 byte: EncodingType
-  /// 1 byte: DataType
-  /// 4 bytes: uint32_t num rows (fixed format)
-  ///   OR 1-5 bytes: varint num rows (when useVarintRowCount option is set)
-  static constexpr int kEncodingTypeOffset = 0;
-  static constexpr int kDataTypeOffset = 1;
-  static constexpr int kRowCountOffset = 2;
-  static constexpr int kPrefixSize = 6;
+  static constexpr int kEncodingTypeOffset =
+      EncodingPrefix::kEncodingTypeOffset;
+  static constexpr int kDataTypeOffset = EncodingPrefix::kDataTypeOffset;
+  static constexpr int kRowCountOffset = EncodingPrefix::kRowCountOffset;
+  static constexpr int kPrefixSize = EncodingPrefix::kFixedPrefixSize;
 
   Encoding(
       velox::memory::MemoryPool& pool,
@@ -276,16 +273,25 @@ class Encoding {
       DataType dataType,
       uint32_t rowCount,
       bool useVarint,
-      char*& pos);
+      char*& pos) {
+    EncodingPrefix::serialize(encodingType, dataType, rowCount, useVarint, pos);
+  }
 
-  // Compute the prefix size for serialization. Returns kPrefixSize for fixed
-  // format, or 2 + varintSize(rowCount) for varint format.
-  static uint32_t serializePrefixSize(uint32_t rowCount, bool useVarint);
+  static uint32_t serializePrefixSize(uint32_t rowCount, bool useVarint) {
+    return EncodingPrefix::serializedSize(rowCount, useVarint);
+  }
 
-  // Static helpers for initializer list computation.
-  static DataType readDataType(std::string_view data);
-  static uint32_t readRowCount(std::string_view data, bool useVarint);
-  static uint32_t readPrefixSize(std::string_view data, bool useVarint);
+  static DataType readDataType(std::string_view data) {
+    return EncodingPrefix::readDataType(data);
+  }
+
+  static uint32_t readRowCount(std::string_view data, bool useVarint) {
+    return EncodingPrefix::readRowCount(data, useVarint);
+  }
+
+  static uint32_t readPrefixSize(std::string_view data, bool useVarint) {
+    return EncodingPrefix::readPrefixSize(data, useVarint);
+  }
 
   void releaseBuffer(velox::BufferPtr& buffer) {
     if (auto* bufferPool = options_.bufferPool) {

--- a/dwio/nimble/encodings/EncodingPrefix.h
+++ b/dwio/nimble/encodings/EncodingPrefix.h
@@ -1,0 +1,87 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <string_view>
+
+#include "dwio/nimble/common/EncodingPrimitives.h"
+#include "dwio/nimble/common/Types.h"
+#include "dwio/nimble/common/Varint.h"
+
+/// Binary layout constants and helpers for the common encoding prefix.
+///
+/// Every Encoding begins with the same prefix:
+///   1 byte:  EncodingType
+///   1 byte:  DataType
+///   4 bytes: uint32_t row count  (fixed format)
+///     OR 1-5 bytes: varint row count (when useVarintRowCount is set)
+
+namespace facebook::nimble {
+
+struct EncodingPrefix {
+  static constexpr int kEncodingTypeOffset = 0;
+  static constexpr int kDataTypeOffset = 1;
+  static constexpr int kRowCountOffset = 2;
+  /// Prefix size for the fixed (non-varint) row count format.
+  static constexpr int kFixedPrefixSize = 6;
+
+  static void serialize(
+      EncodingType encodingType,
+      DataType dataType,
+      uint32_t rowCount,
+      bool useVarint,
+      char*& pos) {
+    encoding::writeChar(static_cast<char>(encodingType), pos);
+    encoding::writeChar(static_cast<char>(dataType), pos);
+    if (useVarint) {
+      varint::writeVarint(rowCount, &pos);
+    } else {
+      encoding::writeUint32(rowCount, pos);
+    }
+  }
+
+  /// Returns kFixedPrefixSize for fixed format, or 2 + varintSize(rowCount)
+  /// for varint format.
+  static uint32_t serializedSize(uint32_t rowCount, bool useVarint) {
+    if (!useVarint) {
+      return kFixedPrefixSize;
+    }
+    return kRowCountOffset + varint::varintSize(rowCount);
+  }
+
+  static DataType readDataType(std::string_view data) {
+    return static_cast<DataType>(data[kDataTypeOffset]);
+  }
+
+  static uint32_t readRowCount(std::string_view data, bool useVarint) {
+    if (useVarint) {
+      const char* pos = data.data() + kRowCountOffset;
+      return varint::readVarint32(&pos);
+    }
+    return *reinterpret_cast<const uint32_t*>(data.data() + kRowCountOffset);
+  }
+
+  static uint32_t readPrefixSize(std::string_view data, bool useVarint) {
+    if (useVarint) {
+      const char* pos = data.data() + kRowCountOffset;
+      varint::readVarint32(&pos);
+      return pos - data.data();
+    }
+    return kFixedPrefixSize;
+  }
+};
+
+} // namespace facebook::nimble

--- a/dwio/nimble/encodings/FixedBitWidthEncoding.h
+++ b/dwio/nimble/encodings/FixedBitWidthEncoding.h
@@ -37,7 +37,7 @@
 namespace facebook::nimble {
 
 // Data layout is:
-// Encoding::kPrefixSize bytes: standard Encoding prefix
+// EncodingPrefix::kFixedPrefixSize bytes: standard Encoding prefix
 // 1 byte: compression type
 // sizeof(T) byte: baseline value
 // 1 byte: bit width

--- a/dwio/nimble/encodings/MainlyConstantEncoding.h
+++ b/dwio/nimble/encodings/MainlyConstantEncoding.h
@@ -73,7 +73,7 @@ Vector<V> getPooledBuffer(
 } // namespace detail
 
 // Data layout is:
-// Encoding::kPrefixSize bytes: standard Encoding prefix
+// EncodingPrefix::kFixedPrefixSize bytes: standard Encoding prefix
 // 4 bytes: num isCommon encoding bytes (X)
 // X bytes: isCommon encoding bytes
 // 4 bytes: num otherValues encoding bytes (Y)

--- a/dwio/nimble/encodings/NullableEncoding.h
+++ b/dwio/nimble/encodings/NullableEncoding.h
@@ -32,7 +32,7 @@
 namespace facebook::nimble {
 
 // Data layout is:
-// Encoding::kPrefixSize bytes: standard Encoding prefix
+// EncodingPrefix::kFixedPrefixSize bytes: standard Encoding prefix
 // 4 bytes: non-null child encoding size (X)
 // X bytes: non-null child encoding bytes
 // Y bytes: null child encoding bytes

--- a/dwio/nimble/encodings/PrefixEncoding.h
+++ b/dwio/nimble/encodings/PrefixEncoding.h
@@ -36,7 +36,7 @@
 /// - Periodically store full restart points for seek operations
 ///
 /// Binary layout:
-/// - Encoding::kPrefixSize bytes: standard Encoding prefix
+/// - EncodingPrefix::kFixedPrefixSize bytes: standard Encoding prefix
 /// - 4 bytes: restart interval (number of entries between restart points)
 /// - ZZ bytes: restart offsets array (uint32_t array of byte offsets,
 ///   size = ceil(rowCount / restartInterval))

--- a/dwio/nimble/encodings/RleEncoding.h
+++ b/dwio/nimble/encodings/RleEncoding.h
@@ -45,7 +45,7 @@ namespace internal {
 // to avoid having to use virtual functions (namely on
 // RLEEncodingBase::RunValue).
 // Data layout is:
-//   Encoding::kPrefixSize bytes: standard Encoding data
+//   EncodingPrefix::kFixedPrefixSize bytes: standard Encoding data
 //   4 bytes: runs size
 //   X bytes: runs encoding bytes
 template <typename T, typename RLEEncoding>

--- a/dwio/nimble/encodings/SentinelEncoding.h
+++ b/dwio/nimble/encodings/SentinelEncoding.h
@@ -35,7 +35,7 @@
 namespace facebook::nimble {
 
 // Data layout is:
-// Encoding::kPrefixSize bytes: standard Encoding prefix
+// EncodingPrefix::kFixedPrefixSize bytes: standard Encoding prefix
 // 4 bytes: num nulls
 // 4 bytes: non-null child encoding size (X)
 // X bytes: non-null child encoding bytes
@@ -109,7 +109,7 @@ SentinelEncoding<T>::SentinelEncoding(
     std::string_view data,
     std::function<void*(uint32_t)> /* stringBufferFactory */)
     : TypedEncoding<T, physicalType>(memoryPool, data), buffer_(&memoryPool) {
-  const char* pos = data.data() + Encoding::kPrefixSize;
+  const char* pos = data.data() + EncodingPrefix::kFixedPrefixSize;
   nullCount_ = encoding::readUint32(pos);
   const uint32_t sentineledBytes = encoding::readUint32(pos);
   sentineledData_ =
@@ -330,7 +330,7 @@ Vector<physicalType> createSentineledData(
 //       nulls.size() - std::accumulate(nulls.begin(), nulls.end(), 0u);
 //   std::string_view sentineledEncoding = serializeEncoding<physicalType>(
 //       sentineledData, sentinelParameters.valuesParameters().value(), buffer);
-//   uint32_t encodingSize = Encoding::kPrefixSize + 8 +
+//   uint32_t encodingSize = EncodingPrefix::kFixedPrefixSize + 8 +
 //   sentineledEncoding.size(); if constexpr (isNumericType<physicalType>()) {
 //     encodingSize += sizeof(physicalType);
 //   } else {
@@ -377,8 +377,8 @@ Vector<physicalType> createSentineledData(
 //       optimalSearchParams,
 //       &sentineledSize,
 //       sentinelParameters.valuesParameters().ensure());
-//   *size = Encoding::kPrefixSize + 8 + sentineledSize + sizeof(physicalType);
-//   return true;
+//   *size = EncodingPrefix::kFixedPrefixSize + 8 + sentineledSize +
+//   sizeof(physicalType); return true;
 // }
 
 // template <typename T>

--- a/dwio/nimble/encodings/SparseBoolEncoding.h
+++ b/dwio/nimble/encodings/SparseBoolEncoding.h
@@ -40,7 +40,7 @@
 namespace facebook::nimble {
 
 // Data layout is:
-// Encoding::kPrefixSize bytes: standard Encoding prefix
+// EncodingPrefix::kFixedPrefixSize bytes: standard Encoding prefix
 // 1 byte: whether the sparse bits are set or unset
 // XX bytes: indices encoding bytes
 class SparseBoolEncoding final : public TypedEncoding<bool, bool> {

--- a/dwio/nimble/encodings/TrivialEncoding.h
+++ b/dwio/nimble/encodings/TrivialEncoding.h
@@ -37,7 +37,7 @@ namespace facebook::nimble {
 
 // Handles the numeric cases. Bools and strings are specialized below.
 // Data layout is:
-// Encoding::kPrefixSize bytes: standard Encoding prefix
+// EncodingPrefix::kFixedPrefixSize bytes: standard Encoding prefix
 // 1 byte: lengths compression
 // rowCount * sizeof(physicalType) bytes: the data
 template <typename T>
@@ -88,7 +88,7 @@ class TrivialEncoding final
 };
 
 // For the string case the layout is:
-// Encoding::kPrefixSize bytes: standard Encoding prefix
+// EncodingPrefix::kFixedPrefixSize bytes: standard Encoding prefix
 // 1 byte: data compression
 // 4 bytes: offset to start of blob
 // XX bytes: bit packed lengths
@@ -142,7 +142,7 @@ class TrivialEncoding<std::string_view> final
 };
 
 // For the bool case the layout is:
-// Encoding::kPrefixSize bytes: standard Encoding prefix
+// EncodingPrefix::kFixedPrefixSize bytes: standard Encoding prefix
 // 1 byte: compression type
 // FBA::BufferSize(rowCount, 1) bytes: the bitmap
 template <>

--- a/dwio/nimble/encodings/VarintEncoding.h
+++ b/dwio/nimble/encodings/VarintEncoding.h
@@ -35,7 +35,7 @@
 namespace facebook::nimble {
 
 /// Data layout is:
-/// Encoding::kPrefixSize bytes: standard Encoding prefix
+/// EncodingPrefix::kFixedPrefixSize bytes: standard Encoding prefix
 /// sizeof(T) bytes: baseline value
 /// X bytes: the varint encoded bytes
 template <typename T>

--- a/dwio/nimble/encodings/legacy/ConstantEncoding.h
+++ b/dwio/nimble/encodings/legacy/ConstantEncoding.h
@@ -29,7 +29,7 @@
 namespace facebook::nimble::legacy {
 
 // Data layout is:
-// Encoding::kPrefixSize bytes: standard Encoding prefix
+// EncodingPrefix::kFixedPrefixSize bytes: standard Encoding prefix
 // X bytes: the constant value via encoding primitive.
 template <typename T>
 class ConstantEncoding final
@@ -74,7 +74,7 @@ ConstantEncoding<T>::ConstantEncoding(
     std::string_view data,
     std::function<void*(uint32_t)> /* stringBufferFactory */)
     : TypedEncoding<T, physicalType>(memoryPool, data) {
-  const char* pos = data.data() + Encoding::kPrefixSize;
+  const char* pos = data.data() + EncodingPrefix::kFixedPrefixSize;
   value_ = encoding::read<physicalType>(pos);
   NIMBLE_CHECK(pos == data.end(), "Unexpected constant encoding end");
 }
@@ -131,7 +131,7 @@ std::string_view ConstantEncoding<T>::encode(
   }
 
   const uint32_t rowCount = values.size();
-  uint32_t encodingSize = Encoding::kPrefixSize;
+  uint32_t encodingSize = EncodingPrefix::kFixedPrefixSize;
   if constexpr (isStringType<physicalType>()) {
     encodingSize += 4 + values[0].size();
   } else {

--- a/dwio/nimble/encodings/legacy/DeltaEncoding.h
+++ b/dwio/nimble/encodings/legacy/DeltaEncoding.h
@@ -50,7 +50,7 @@
 namespace facebook::nimble::legacy {
 
 // Data layout is:
-// Encoding::kPrefixSize bytes: standard Encoding prefix
+// EncodingPrefix::kFixedPrefixSize bytes: standard Encoding prefix
 // 4 bytes: restatement relative offset (X)
 // 4 bytes: is-restatement relative offset (Y)
 // X bytes: delta encoding bytes
@@ -107,7 +107,7 @@ DeltaEncoding<T>::DeltaEncoding(
       restatementsBuffer_(&memoryPool),
       isRestatementsBuffer_(&memoryPool) {
   const EncodingFactory factory;
-  auto pos = data.data() + Encoding::kPrefixSize;
+  auto pos = data.data() + EncodingPrefix::kFixedPrefixSize;
   const uint32_t restatementsOffset = encoding::readUint32(pos);
   const uint32_t isRestatementsOffset = encoding::readUint32(pos);
   deltas_ = factory.create(
@@ -274,7 +274,7 @@ std::string_view DeltaEncoding<T>::encode(
           isRestatements,
           tempBuffer);
 
-  const uint32_t encodingSize = Encoding::kPrefixSize + 8 +
+  const uint32_t encodingSize = EncodingPrefix::kFixedPrefixSize + 8 +
       static_cast<uint32_t>(serializedDeltas.size()) +
       static_cast<uint32_t>(serializedRestatements.size()) +
       static_cast<uint32_t>(serializedIsRestatements.size());

--- a/dwio/nimble/encodings/legacy/DictionaryEncoding.h
+++ b/dwio/nimble/encodings/legacy/DictionaryEncoding.h
@@ -35,7 +35,7 @@
 namespace facebook::nimble::legacy {
 
 /// The layout for a dictionary encoding is:
-/// Encoding::kPrefixSize bytes: standard Encoding prefix
+/// EncodingPrefix::kFixedPrefixSize bytes: standard Encoding prefix
 /// 4 bytes: alphabet size
 /// XX bytes: alphabet encoding bytes
 /// YY bytes: indices encoding bytes
@@ -46,7 +46,7 @@ class DictionaryEncoding
   using cppDataType = T;
   using physicalType = typename TypeTraits<T>::physicalType;
 
-  static const int kAlphabetSizeOffset = Encoding::kPrefixSize;
+  static const int kAlphabetSizeOffset = EncodingPrefix::kFixedPrefixSize;
 
   DictionaryEncoding(
       velox::memory::MemoryPool& pool,
@@ -277,7 +277,7 @@ std::string_view DictionaryEncoding<T>::encode(
       selection.template encodeNested<uint32_t>(
           EncodingIdentifiers::Dictionary::Indices, {indices}, tempBuffer);
 
-  const uint32_t encodingSize = Encoding::kPrefixSize + 4 +
+  const uint32_t encodingSize = EncodingPrefix::kFixedPrefixSize + 4 +
       serializedAlphabet.size() + serializedIndices.size();
   char* reserved = buffer.reserve(encodingSize);
   char* pos = reserved;

--- a/dwio/nimble/encodings/legacy/FixedBitWidthEncoding.h
+++ b/dwio/nimble/encodings/legacy/FixedBitWidthEncoding.h
@@ -37,7 +37,7 @@
 namespace facebook::nimble::legacy {
 
 // Data layout is:
-// Encoding::kPrefixSize bytes: standard Encoding prefix
+// EncodingPrefix::kFixedPrefixSize bytes: standard Encoding prefix
 // 1 byte: compression type
 // sizeof(T) byte: baseline value
 // 1 byte: bit width
@@ -49,7 +49,7 @@ class FixedBitWidthEncoding final
   using cppDataType = T;
   using physicalType = typename TypeTraits<T>::physicalType;
 
-  static const int kCompressionOffset = Encoding::kPrefixSize;
+  static const int kCompressionOffset = EncodingPrefix::kFixedPrefixSize;
   static const int kPrefixSize = 2 + sizeof(T);
 
   FixedBitWidthEncoding(
@@ -216,7 +216,7 @@ std::string_view FixedBitWidthEncoding<T>::encode(
         return pos;
       }};
 
-  const uint32_t encodingSize = Encoding::kPrefixSize +
+  const uint32_t encodingSize = EncodingPrefix::kFixedPrefixSize +
       FixedBitWidthEncoding<T>::kPrefixSize + compressionEncoder.getSize();
   char* reserved = buffer.reserve(encodingSize);
   char* pos = reserved;

--- a/dwio/nimble/encodings/legacy/MainlyConstantEncoding.h
+++ b/dwio/nimble/encodings/legacy/MainlyConstantEncoding.h
@@ -53,7 +53,7 @@
 namespace facebook::nimble::legacy {
 
 // Data layout is:
-// Encoding::kPrefixSize bytes: standard Encoding prefix
+// EncodingPrefix::kFixedPrefixSize bytes: standard Encoding prefix
 // 4 bytes: num isCommon encoding bytes (X)
 // X bytes: isCommon encoding bytes
 // 4 bytes: num otherValues encoding bytes (Y)
@@ -115,7 +115,7 @@ MainlyConstantEncoding<T>::MainlyConstantEncoding(
       isCommonBuffer_(&memoryPool),
       otherValuesBuffer_(&memoryPool) {
   const EncodingFactory factory;
-  const char* pos = data.data() + Encoding::kPrefixSize;
+  const char* pos = data.data() + EncodingPrefix::kFixedPrefixSize;
   const uint32_t isCommonBytes = encoding::readUint32(pos);
   isCommon_ =
       factory.create(*this->pool_, {pos, isCommonBytes}, stringBufferFactory);
@@ -380,7 +380,7 @@ std::string_view MainlyConstantEncoding<T>::encode(
           otherValues,
           tempBuffer);
 
-  uint32_t encodingSize = Encoding::kPrefixSize + 8 +
+  uint32_t encodingSize = EncodingPrefix::kFixedPrefixSize + 8 +
       serializedIsCommon.size() + serializedOtherValues.size();
   if constexpr (isNumericType<physicalType>()) {
     encodingSize += sizeof(physicalType);

--- a/dwio/nimble/encodings/legacy/NullableEncoding.h
+++ b/dwio/nimble/encodings/legacy/NullableEncoding.h
@@ -34,7 +34,7 @@
 namespace facebook::nimble::legacy {
 
 // Data layout is:
-// Encoding::kPrefixSize bytes: standard Encoding prefix
+// EncodingPrefix::kFixedPrefixSize bytes: standard Encoding prefix
 // 4 bytes: non-null child encoding size (X)
 // X bytes: non-null child encoding bytes
 // Y byes: null child encoding bytes
@@ -100,7 +100,7 @@ NullableEncoding<T>::NullableEncoding(
       indicesBuffer_(this->pool_),
       nullBuffer_(this->pool_) {
   const EncodingFactory factory;
-  const char* pos = data.data() + Encoding::kPrefixSize;
+  const char* pos = data.data() + EncodingPrefix::kFixedPrefixSize;
   const uint32_t nonNullsBytes = encoding::readUint32(pos);
   nonNullValues_ =
       factory.create(*this->pool_, {pos, nonNullsBytes}, stringBufferFactory);
@@ -298,7 +298,7 @@ std::string_view NullableEncoding<T>::encodeNullable(
   std::string_view serializedNulls = selection.template encodeNested<bool>(
       EncodingIdentifiers::Nullable::Nulls, nulls, tempBuffer);
 
-  const uint32_t encodingSize = Encoding::kPrefixSize + 4 +
+  const uint32_t encodingSize = EncodingPrefix::kFixedPrefixSize + 4 +
       serializedValues.size() + serializedNulls.size();
   char* reserved = buffer.reserve(encodingSize);
   char* pos = reserved;

--- a/dwio/nimble/encodings/legacy/RleEncoding.h
+++ b/dwio/nimble/encodings/legacy/RleEncoding.h
@@ -46,7 +46,7 @@ namespace internal {
 // to avoid having to use virtual functions (namely on
 // RLEEncodingBase::RunValue).
 // Data layout is:
-//   Encoding::kPrefixSize bytes: standard Encoding data
+//   EncodingPrefix::kFixedPrefixSize bytes: standard Encoding data
 //   4 bytes: runs size
 //   X bytes: runs encoding bytes
 template <typename T, typename RLEEncoding>
@@ -63,9 +63,9 @@ class RLEEncodingBase
       : TypedEncoding<T, physicalType>(memoryPool, data),
         materializedRunLengths_{EncodingFactory().create(
             memoryPool,
-            {data.data() + Encoding::kPrefixSize + 4,
+            {data.data() + EncodingPrefix::kFixedPrefixSize + 4,
              *reinterpret_cast<const uint32_t*>(
-                 data.data() + Encoding::kPrefixSize)},
+                 data.data() + EncodingPrefix::kFixedPrefixSize)},
             stringBufferFactory)} {}
 
   void reset() {
@@ -141,7 +141,7 @@ class RLEEncodingBase
     std::string_view serializedRunValues =
         getSerializedRunValues(selection, runValues, tempBuffer);
 
-    const uint32_t encodingSize = Encoding::kPrefixSize + 4 +
+    const uint32_t encodingSize = EncodingPrefix::kFixedPrefixSize + 4 +
         serializedRunLengths.size() + serializedRunValues.size();
     char* reserved = buffer.reserve(encodingSize);
     char* pos = reserved;
@@ -154,9 +154,9 @@ class RLEEncodingBase
   }
 
   const char* getValuesStart() const {
-    return this->data_.data() + Encoding::kPrefixSize + 4 +
+    return this->data_.data() + EncodingPrefix::kFixedPrefixSize + 4 +
         *reinterpret_cast<const uint32_t*>(
-               this->data_.data() + Encoding::kPrefixSize);
+               this->data_.data() + EncodingPrefix::kFixedPrefixSize);
   }
 
   RLEEncoding& derived() {

--- a/dwio/nimble/encodings/legacy/SentinelEncoding.h
+++ b/dwio/nimble/encodings/legacy/SentinelEncoding.h
@@ -35,7 +35,7 @@
 namespace facebook::nimble::legacy {
 
 // Data layout is:
-// Encoding::kPrefixSize bytes: standard Encoding prefix
+// EncodingPrefix::kFixedPrefixSize bytes: standard Encoding prefix
 // 4 bytes: num nulls
 // 4 bytes: non-null child encoding size (X)
 // X bytes: non-null child encoding bytes
@@ -107,7 +107,7 @@ SentinelEncoding<T>::SentinelEncoding(
     velox::memory::MemoryPool& memoryPool,
     std::string_view data)
     : TypedEncoding<T, physicalType>(memoryPool, data), buffer_(&memoryPool) {
-  const char* pos = data.data() + Encoding::kPrefixSize;
+  const char* pos = data.data() + EncodingPrefix::kFixedPrefixSize;
   nullCount_ = encoding::readUint32(pos);
   const uint32_t sentineledBytes = encoding::readUint32(pos);
   sentineledData_ =
@@ -328,7 +328,7 @@ Vector<physicalType> createSentineledData(
 //       nulls.size() - std::accumulate(nulls.begin(), nulls.end(), 0u);
 //   std::string_view sentineledEncoding = serializeEncoding<physicalType>(
 //       sentineledData, sentinelParameters.valuesParameters().value(), buffer);
-//   uint32_t encodingSize = Encoding::kPrefixSize + 8 +
+//   uint32_t encodingSize = EncodingPrefix::kFixedPrefixSize + 8 +
 //   sentineledEncoding.size(); if constexpr (isNumericType<physicalType>()) {
 //     encodingSize += sizeof(physicalType);
 //   } else {
@@ -375,8 +375,8 @@ Vector<physicalType> createSentineledData(
 //       optimalSearchParams,
 //       &sentineledSize,
 //       sentinelParameters.valuesParameters().ensure());
-//   *size = Encoding::kPrefixSize + 8 + sentineledSize + sizeof(physicalType);
-//   return true;
+//   *size = EncodingPrefix::kFixedPrefixSize + 8 + sentineledSize +
+//   sizeof(physicalType); return true;
 // }
 
 // template <typename T>

--- a/dwio/nimble/encodings/legacy/SparseBoolEncoding.cpp
+++ b/dwio/nimble/encodings/legacy/SparseBoolEncoding.cpp
@@ -139,7 +139,7 @@ std::string_view SparseBoolEncoding::encode(
       selection.template encodeNested<uint32_t>(
           EncodingIdentifiers::SparseBool::Indices, indices, tempBuffer);
 
-  const uint32_t encodingSize = Encoding::kPrefixSize +
+  const uint32_t encodingSize = EncodingPrefix::kFixedPrefixSize +
       SparseBoolEncoding::kPrefixSize + serializedIndices.size();
   char* reserved = buffer.reserve(encodingSize);
   char* pos = reserved;

--- a/dwio/nimble/encodings/legacy/SparseBoolEncoding.h
+++ b/dwio/nimble/encodings/legacy/SparseBoolEncoding.h
@@ -41,7 +41,7 @@
 namespace facebook::nimble::legacy {
 
 // Data layout is:
-// Encoding::kPrefixSize bytes: standard Encoding prefix
+// EncodingPrefix::kFixedPrefixSize bytes: standard Encoding prefix
 // 1 byte: whether the sparse bits are set or unset
 // XX bytes: indices encoding bytes
 class SparseBoolEncoding final : public TypedEncoding<bool, bool> {
@@ -49,8 +49,8 @@ class SparseBoolEncoding final : public TypedEncoding<bool, bool> {
   using cppDataType = bool;
 
   static constexpr int kPrefixSize = 1;
-  static constexpr int kSparseValueOffset = Encoding::kPrefixSize;
-  static constexpr int kIndicesOffset = Encoding::kPrefixSize + 1;
+  static constexpr int kSparseValueOffset = EncodingPrefix::kFixedPrefixSize;
+  static constexpr int kIndicesOffset = EncodingPrefix::kFixedPrefixSize + 1;
 
   SparseBoolEncoding(
       velox::memory::MemoryPool& memoryPool,

--- a/dwio/nimble/encodings/legacy/TrivialEncoding.cpp
+++ b/dwio/nimble/encodings/legacy/TrivialEncoding.cpp
@@ -117,7 +117,7 @@ std::string_view TrivialEncoding<std::string_view>::encode(
         }
       }};
 
-  const uint32_t encodingSize = Encoding::kPrefixSize +
+  const uint32_t encodingSize = EncodingPrefix::kFixedPrefixSize +
       TrivialEncoding<std::string_view>::kPrefixSize +
       serializedLengths.size() + compressionEncoder.getSize();
 

--- a/dwio/nimble/encodings/legacy/TrivialEncoding.h
+++ b/dwio/nimble/encodings/legacy/TrivialEncoding.h
@@ -38,7 +38,7 @@ namespace facebook::nimble::legacy {
 
 // Handles the numeric cases. Bools and strings are specialized below.
 // Data layout is:
-// Encoding::kPrefixSize bytes: standard Encoding prefix
+// EncodingPrefix::kFixedPrefixSize bytes: standard Encoding prefix
 // 1 byte: lengths compression
 // rowCount * sizeof(physicalType) bytes: the data
 template <typename T>
@@ -49,9 +49,10 @@ class TrivialEncoding final
   using physicalType = typename TypeTraits<T>::physicalType;
 
   static constexpr int kPrefixSize = 1;
-  static constexpr int kCompressionTypeOffset = Encoding::kPrefixSize;
+  static constexpr int kCompressionTypeOffset =
+      EncodingPrefix::kFixedPrefixSize;
   static constexpr int kDataOffset =
-      Encoding::kPrefixSize + TrivialEncoding<T>::kPrefixSize;
+      EncodingPrefix::kFixedPrefixSize + TrivialEncoding<T>::kPrefixSize;
 
   TrivialEncoding(
       velox::memory::MemoryPool& pool,
@@ -85,7 +86,7 @@ class TrivialEncoding final
 };
 
 // For the string case the layout is:
-// Encoding::kPrefixSize bytes: standard Encoding prefix
+// EncodingPrefix::kFixedPrefixSize bytes: standard Encoding prefix
 // 1 byte: data compression
 // 4 bytes: offset to start of blob
 // XX bytes: bit packed lengths
@@ -97,10 +98,11 @@ class TrivialEncoding<std::string_view> final
   using cppDataType = std::string_view;
 
   static constexpr int kPrefixSize = 5;
-  static constexpr int kDataCompressionOffset = Encoding::kPrefixSize;
-  static constexpr int kBlobOffsetOffset = Encoding::kPrefixSize + 1;
-  static constexpr int kLengthOffset =
-      Encoding::kPrefixSize + TrivialEncoding<std::string_view>::kPrefixSize;
+  static constexpr int kDataCompressionOffset =
+      EncodingPrefix::kFixedPrefixSize;
+  static constexpr int kBlobOffsetOffset = EncodingPrefix::kFixedPrefixSize + 1;
+  static constexpr int kLengthOffset = EncodingPrefix::kFixedPrefixSize +
+      TrivialEncoding<std::string_view>::kPrefixSize;
 
   TrivialEncoding(
       velox::memory::MemoryPool& pool,
@@ -138,7 +140,7 @@ class TrivialEncoding<std::string_view> final
 };
 
 // For the bool case the layout is:
-// Encoding::kPrefixSize bytes: standard Encoding prefix
+// EncodingPrefix::kFixedPrefixSize bytes: standard Encoding prefix
 // 1 byte: compression type
 // FBA::BufferSize(rowCount, 1) bytes: the bitmap
 template <>
@@ -147,9 +149,10 @@ class TrivialEncoding<bool> final : public TypedEncoding<bool, bool> {
   using cppDataType = bool;
 
   static constexpr int kPrefixSize = 1;
-  static constexpr int kCompressionTypeOffset = Encoding::kPrefixSize;
+  static constexpr int kCompressionTypeOffset =
+      EncodingPrefix::kFixedPrefixSize;
   static constexpr int kDataOffset =
-      Encoding::kPrefixSize + TrivialEncoding<bool>::kPrefixSize;
+      EncodingPrefix::kFixedPrefixSize + TrivialEncoding<bool>::kPrefixSize;
 
   TrivialEncoding(
       velox::memory::MemoryPool& pool,

--- a/dwio/nimble/encodings/legacy/VarintEncoding.h
+++ b/dwio/nimble/encodings/legacy/VarintEncoding.h
@@ -34,7 +34,7 @@
 namespace facebook::nimble::legacy {
 
 /// Data layout is:
-/// Encoding::kPrefixSize bytes: standard Encoding prefix
+/// EncodingPrefix::kFixedPrefixSize bytes: standard Encoding prefix
 /// sizeof(T) bytes: baseline value
 /// X bytes: the varint encoded bytes
 template <typename T>
@@ -44,7 +44,7 @@ class VarintEncoding final
   using cppDataType = T;
   using physicalType = typename TypeTraits<T>::physicalType;
 
-  static const int kBaselineOffset = Encoding::kPrefixSize;
+  static const int kBaselineOffset = EncodingPrefix::kFixedPrefixSize;
   static const int kDataOffset = kBaselineOffset + sizeof(T);
   static const int kPrefixSize = kDataOffset - kBaselineOffset;
 
@@ -91,7 +91,7 @@ VarintEncoding<T>::VarintEncoding(
 template <typename T>
 void VarintEncoding<T>::reset() {
   row_ = 0;
-  pos_ = Encoding::data_.data() + Encoding::kPrefixSize +
+  pos_ = Encoding::data_.data() + EncodingPrefix::kFixedPrefixSize +
       VarintEncoding<T>::kPrefixSize;
 }
 
@@ -169,8 +169,8 @@ std::string_view VarintEncoding<T>::encode(
         // to consume 2 bytes, etc.
         return sum + (bucketSize * (++index));
       });
-  const uint32_t encodingSize =
-      dataSize + Encoding::kPrefixSize + VarintEncoding<T>::kPrefixSize;
+  const uint32_t encodingSize = dataSize + EncodingPrefix::kFixedPrefixSize +
+      VarintEncoding<T>::kPrefixSize;
 
   // Adding 7 bytes, to allow bulk materialization to access the last 64 bit
   // word, even if it is not full.

--- a/dwio/nimble/encodings/tests/EncodingTest.cpp
+++ b/dwio/nimble/encodings/tests/EncodingTest.cpp
@@ -799,7 +799,7 @@ class DictionaryApiTypedTest : public ::testing::Test {
     // Assemble the NullableEncoding binary format:
     // [EncodingType:1][DataType:1][rowCount:4] | uint32(valSize) | valBytes |
     // nullBytes
-    const uint32_t encodingSize = nimble::Encoding::kPrefixSize + 4 +
+    const uint32_t encodingSize = nimble::EncodingPrefix::kFixedPrefixSize + 4 +
         serializedValues.size() + serializedNulls.size();
     char* reserved = buffer_->reserve(encodingSize);
     char* pos = reserved;

--- a/dwio/nimble/encodings/tests/ReadWithVisitorTest.cpp
+++ b/dwio/nimble/encodings/tests/ReadWithVisitorTest.cpp
@@ -2742,7 +2742,7 @@ TEST_P(ReadWithVisitorTest, readIndicesWithVisitorNullable) {
   auto serializedNulls = nimble::TrivialEncoding<bool>::encode(
       nullSelection, nullSpan, nullBuffer);
 
-  const uint32_t encodingSize = nimble::Encoding::kPrefixSize + 4 +
+  const uint32_t encodingSize = nimble::EncodingPrefix::kFixedPrefixSize + 4 +
       serializedValues.size() + serializedNulls.size();
   Buffer assemblyBuffer(*pool());
   char* reserved = assemblyBuffer.reserve(encodingSize);
@@ -2857,7 +2857,7 @@ TEST_P(ReadWithVisitorTest, readIndicesWithVisitorNullableAlphabetValue) {
   auto serializedNulls = nimble::TrivialEncoding<bool>::encode(
       nullSelection, nullSpan, nullBuffer);
 
-  const uint32_t encodingSize = nimble::Encoding::kPrefixSize + 4 +
+  const uint32_t encodingSize = nimble::EncodingPrefix::kFixedPrefixSize + 4 +
       serializedValues.size() + serializedNulls.size();
   Buffer assemblyBuffer(*pool());
   char* reserved = assemblyBuffer.reserve(encodingSize);
@@ -3007,7 +3007,7 @@ TEST_P(ReadWithVisitorTest, fuzzReadIndicesWithVisitorNullable) {
     auto serializedNulls = nimble::TrivialEncoding<bool>::encode(
         nullSelection, nullSpan, nullBuffer);
 
-    const uint32_t encodingSize = nimble::Encoding::kPrefixSize + 4 +
+    const uint32_t encodingSize = nimble::EncodingPrefix::kFixedPrefixSize + 4 +
         serializedValues.size() + serializedNulls.size();
     Buffer assemblyBuffer(*this->pool());
     char* reserved = assemblyBuffer.reserve(encodingSize);

--- a/dwio/nimble/velox/selective/ChunkedDecoder.cpp
+++ b/dwio/nimble/velox/selective/ChunkedDecoder.cpp
@@ -19,6 +19,7 @@
 #include "dwio/nimble/common/ChunkHeader.h"
 #include "dwio/nimble/common/Types.h"
 #include "dwio/nimble/encodings/EncodingFactory.h"
+#include "dwio/nimble/encodings/EncodingPrefix.h"
 #include "velox/common/testutil/TestValue.h"
 
 #include <cstddef>
@@ -282,7 +283,7 @@ std::optional<size_t> ChunkedDecoder::estimateRowCount() const {
   constexpr int kEncodingOffset =
       kChunkCompressionTypeOffset + /*chunkCompressionType=*/1;
   constexpr int kChunkRowCountOffset =
-      kEncodingOffset + Encoding::kRowCountOffset;
+      kEncodingOffset + EncodingPrefix::kRowCountOffset;
   NIMBLE_CHECK(
       const_cast<ChunkedDecoder*>(this)->ensureInput(
           kChunkRowCountOffset + sizeof(uint32_t)));
@@ -323,7 +324,8 @@ std::optional<size_t> ChunkedDecoder::estimateStringDataSize() const {
   const auto rowCount = encoding::readUint32(pos);
   // Peel off nullable encoding.
   if (encodingType == EncodingType::Nullable) {
-    encodingStart += Encoding::kPrefixSize + /*nonNullEncodingSize=*/4;
+    encodingStart +=
+        EncodingPrefix::kFixedPrefixSize + /*nonNullEncodingSize=*/4;
     NIMBLE_CHECK(
         const_cast<ChunkedDecoder*>(this)->ensureInputIncremental_hack(
             encodingStart + 6, pos));
@@ -345,7 +347,7 @@ std::optional<size_t> ChunkedDecoder::estimateStringDataSize() const {
   {
     const auto ensured =
         const_cast<ChunkedDecoder*>(this)->ensureInputIncremental_hack(
-            encodingStart + Encoding::kPrefixSize +
+            encodingStart + EncodingPrefix::kFixedPrefixSize +
                 TrivialEncoding<std::string_view>::kPrefixSize,
             pos);
     NIMBLE_CHECK(ensured);


### PR DESCRIPTION
Summary: Extract prefix layout constants into `EncodingPrefix` struct

Differential Revision: D105404786
