### PR TITLE
Simplify MetadataInput to stateless load() API

### DIFF
--- a/dwio/nimble/index/ClusterIndex.cpp
+++ b/dwio/nimble/index/ClusterIndex.cpp
@@ -206,14 +206,10 @@ const ClusterIndex::IndexPartition* ClusterIndex::lookupPartition(
   return loadPartition(partitionId);
 }
 
-uint32_t ClusterIndex::partitionRow(uint32_t row) const {
-  NIMBLE_CHECK_LT(
-      row, numRows_, "Row {} is beyond file total rows {}", row, numRows_);
-  const auto it =
-      std::upper_bound(partitionRows_.begin(), partitionRows_.end(), row);
-  NIMBLE_CHECK(it != partitionRows_.begin());
-  const uint32_t partitionId =
-      static_cast<uint32_t>(it - partitionRows_.begin()) - 1;
+uint32_t ClusterIndex::partitionRow(uint32_t partitionId, uint32_t row) const {
+  NIMBLE_CHECK_LT(partitionId, numPartitions_);
+  NIMBLE_CHECK_GE(row, partitionRows_[partitionId]);
+  NIMBLE_CHECK_LT(row, partitionRows_[partitionId + 1]);
   return row - partitionRows_[partitionId];
 }
 
@@ -427,11 +423,10 @@ const ClusterIndex::IndexPartition* ClusterIndex::loadPartition(
   auto& partition = partitions_[partitionId];
   if (partition == nullptr) {
     const auto section = partitionSection(partitionId);
-    auto handle = metadataInput_->enqueue(section);
-    MetadataInput::LoadGuard guard(metadataInput_.get());
-    auto result = handle.read();
+    auto results = metadataInput_->load({&section, 1});
+    NIMBLE_CHECK_EQ(results.size(), 1);
     partition = std::make_unique<IndexPartition>(
-        partitionId, std::make_unique<MetadataBuffer>(std::move(*result)));
+        partitionId, std::make_unique<MetadataBuffer>(std::move(*results[0])));
   }
   return partition.get();
 }
@@ -553,7 +548,7 @@ ChunkLocation ClusterIndex::lookupChunk(
 
 std::string ClusterIndex::keyAtRow(uint32_t row) const {
   const auto* partition = lookupPartition(row);
-  const auto partitionRow = this->partitionRow(row);
+  const auto partitionRow = this->partitionRow(partition->id, row);
 
   const auto* chunkRows = partition->index->chunk_rows();
   const auto* chunkKeys = partition->index->chunk_keys();

--- a/dwio/nimble/index/ClusterIndex.h
+++ b/dwio/nimble/index/ClusterIndex.h
@@ -228,7 +228,7 @@ class ClusterIndex : public IndexLookup {
   const IndexPartition* lookupPartition(uint32_t row) const;
 
   // Converts a file-level row to a partition-relative row number.
-  uint32_t partitionRow(uint32_t row) const;
+  uint32_t partitionRow(uint32_t partitionId, uint32_t row) const;
 
   // A bound to resolve within a partition.
   // Stores a pointer to the target row field (startRow or endRow) in the

--- a/dwio/nimble/index/DenseIndexRegistry.cpp
+++ b/dwio/nimble/index/DenseIndexRegistry.cpp
@@ -140,11 +140,10 @@ void DenseIndexRegistry::registerHashIndices(
       [this, metadataInput, pool](
           uint32_t index) -> std::shared_ptr<HashIndex> {
         const auto& descriptor = hashDescriptors_[index];
-        auto handle = metadataInput->enqueue(descriptor.section);
-        MetadataInput::LoadGuard guard(metadataInput.get());
-        auto result = handle.read();
+        auto results = metadataInput->load({&descriptor.section, 1});
+        NIMBLE_CHECK_EQ(results.size(), 1);
         auto indexMetadata =
-            std::make_unique<MetadataBuffer>(std::move(*result));
+            std::make_unique<MetadataBuffer>(std::move(*results[0]));
         return HashIndex::create(
             descriptor.columns, std::move(indexMetadata), metadataInput, pool);
       },
@@ -163,11 +162,10 @@ void DenseIndexRegistry::registerSortedIndices(
       [this, metadataInput, dataInput, pool](
           uint32_t index) -> std::shared_ptr<SortedIndex> {
         const auto& descriptor = sortedDescriptors_[index];
-        auto handle = metadataInput->enqueue(descriptor.section);
-        MetadataInput::LoadGuard guard(metadataInput.get());
-        auto result = handle.read();
+        auto results = metadataInput->load({&descriptor.section, 1});
+        NIMBLE_CHECK_EQ(results.size(), 1);
         auto indexMetadata =
-            std::make_unique<MetadataBuffer>(std::move(*result));
+            std::make_unique<MetadataBuffer>(std::move(*results[0]));
         return SortedIndex::create(
             descriptor.columns, std::move(indexMetadata), dataInput, pool);
       },

--- a/dwio/nimble/index/HashIndex.cpp
+++ b/dwio/nimble/index/HashIndex.cpp
@@ -151,11 +151,10 @@ HashIndex::HashIndex(
       partitionCache_{
           [this](uint32_t partitionIndex) -> std::shared_ptr<Partition> {
             const auto& descriptor = partitions_[partitionIndex];
-            auto handle = metadataInput_->enqueue(descriptor.section);
-            MetadataInput::LoadGuard guard(metadataInput_.get());
-            auto result = handle.read();
+            auto results = metadataInput_->load({&descriptor.section, 1});
+            NIMBLE_CHECK_EQ(results.size(), 1);
             return Partition::create(
-                std::make_unique<MetadataBuffer>(std::move(*result)));
+                std::make_unique<MetadataBuffer>(std::move(*results[0])));
           }} {}
 
 // static

--- a/dwio/nimble/tablet/MetadataInput.cpp
+++ b/dwio/nimble/tablet/MetadataInput.cpp
@@ -46,12 +46,6 @@ inline int64_t sectionGap(
 
 } // namespace
 
-// --- MetadataHandle ---
-
-std::shared_ptr<MetadataBuffer> MetadataHandle::read() {
-  return input_->read(index_);
-}
-
 // --- MetadataInput ---
 
 std::unique_ptr<MetadataInput> MetadataInput::create(
@@ -86,16 +80,15 @@ MetadataInput::MetadataInput(
   NIMBLE_CHECK_NOT_NULL(ioStats_.get());
 }
 
-MetadataHandle MetadataInput::enqueue(const MetadataSection& section) {
-  NIMBLE_CHECK(!loaded_, "enqueue() not allowed after load(); call reset()");
-  const auto index = static_cast<uint32_t>(sections_.size());
-  sections_.emplace_back(section);
-  return MetadataHandle{this, index};
-}
-
-void MetadataInput::reset() {
-  sections_.clear();
-  loaded_ = false;
+std::vector<std::shared_ptr<MetadataBuffer>> MetadataInput::extractResults(
+    std::vector<LoadedSection>& sections) {
+  std::vector<std::shared_ptr<MetadataBuffer>> results;
+  results.reserve(sections.size());
+  for (auto& loaded : sections) {
+    NIMBLE_CHECK_NOT_NULL(loaded.buffer);
+    results.emplace_back(std::move(loaded.buffer));
+  }
+  return results;
 }
 
 std::unique_ptr<MetadataBuffer> MetadataInput::findCachedMetadata(
@@ -107,15 +100,6 @@ void MetadataInput::cacheMetadata(
     uint64_t /*cacheOffset*/,
     std::span<const std::string_view> /*ranges*/) {
   NIMBLE_UNREACHABLE("cacheMetadata requires CachedMetadataInput");
-}
-
-std::shared_ptr<MetadataBuffer> MetadataInput::read(uint32_t index) {
-  NIMBLE_CHECK(loaded_, "load() must be called before read()");
-  NIMBLE_CHECK_LT(index, sections_.size(), "Invalid metadata handle index");
-  NIMBLE_CHECK_NOT_NULL(
-      sections_[index].buffer,
-      "Metadata buffer already consumed or not loaded");
-  return std::move(sections_[index].buffer);
 }
 
 std::shared_ptr<MetadataBuffer> MetadataInput::decompressAndStore(
@@ -146,9 +130,10 @@ std::optional<uint32_t> MetadataInput::resolveUncompressedSize(
 }
 
 std::vector<MetadataInput::IoGroup> MetadataInput::computeIoGroups(
-    const std::vector<uint32_t>& sectionIndices,
+    const std::vector<LoadedSection>& sections,
+    const std::vector<uint32_t>& loadIndices,
     const std::vector<folly::Range<char*>>& readRanges) {
-  std::vector<int32_t> items(sectionIndices.size());
+  std::vector<int32_t> items(loadIndices.size());
   std::iota(items.begin(), items.end(), 0);
 
   int64_t coalescedBytes = 0;
@@ -160,15 +145,15 @@ std::vector<MetadataInput::IoGroup> MetadataInput::computeIoGroups(
       /*rangesPerIo=*/std::numeric_limits<int32_t>::max(),
       /*offsetFunc=*/
       [&](int32_t i) -> uint64_t {
-        return sections_[sectionIndices[i]].section.offset();
+        return sections[loadIndices[i]].section.offset();
       },
       /*sizeFunc=*/
       [&](int32_t i) -> int32_t {
-        return sections_[sectionIndices[i]].section.size();
+        return sections[loadIndices[i]].section.size();
       },
       /*numRanges=*/
       [&](int32_t i) -> int32_t {
-        const auto size = sections_[sectionIndices[i]].section.size();
+        const auto size = sections[loadIndices[i]].section.size();
         if (coalescedBytes + size > maxCoalesceBytes_) {
           coalescedBytes = 0;
           return velox::kNoCoalesce;
@@ -203,10 +188,10 @@ std::vector<MetadataInput::IoGroup> MetadataInput::computeIoGroups(
   int32_t groupStart = 0;
   for (const auto groupEnd : groupEnds) {
     IoGroup group;
-    group.offset = sections_[sectionIndices[groupStart]].section.offset();
+    group.offset = sections[loadIndices[groupStart]].section.offset();
     auto lastEnd = group.offset;
     for (int32_t i = groupStart; i < groupEnd; ++i) {
-      const auto& section = sections_[sectionIndices[i]].section;
+      const auto& section = sections[loadIndices[i]].section;
       if (section.offset() > lastEnd) {
         const auto gap = section.offset() - lastEnd;
         group.ranges.emplace_back(
@@ -259,23 +244,41 @@ void MetadataInput::executeIoGroups(std::vector<IoGroup>& ioGroups) {
   }
 }
 
-void MetadataInput::loadFromFile(std::vector<uint32_t>& sectionIndices) {
-  if (sectionIndices.empty()) {
+void MetadataInput::loadFromFile(
+    const std::vector<LoadedSection>& sections,
+    const std::vector<uint32_t>& loadIndices,
+    const std::vector<folly::Range<char*>>& readRanges) {
+  if (loadIndices.empty()) {
     return;
   }
 
-  std::sort(sectionIndices.begin(), sectionIndices.end(), [&](auto a, auto b) {
-    return sections_[a].section.offset() < sections_[b].section.offset();
+  // Sort by file offset for IO coalescing. Reorder both loadIndices
+  // and readRanges in lock-step. The caller's buffers[i] ↔
+  // loadIndices[i] correspondence is preserved.
+  std::vector<uint32_t> sortOrder(loadIndices.size());
+  std::iota(sortOrder.begin(), sortOrder.end(), 0);
+  std::sort(sortOrder.begin(), sortOrder.end(), [&](auto lhs, auto rhs) {
+    return sections[loadIndices[lhs]].section.offset() <
+        sections[loadIndices[rhs]].section.offset();
   });
 
-  prepareReadBuffers(sectionIndices);
-  SCOPE_EXIT {
-    buffers_.clear();
-    readRanges_.clear();
-  };
-  auto ioGroups = computeIoGroups(sectionIndices, readRanges_);
+  std::vector<uint32_t> sortedIndices(loadIndices.size());
+  std::vector<folly::Range<char*>> sortedRanges(readRanges.size());
+  for (size_t i = 0; i < sortOrder.size(); ++i) {
+    sortedIndices[i] = loadIndices[sortOrder[i]];
+    sortedRanges[i] = readRanges[sortOrder[i]];
+  }
+
+  auto ioGroups = computeIoGroups(sections, sortedIndices, sortedRanges);
   executeIoGroups(ioGroups);
-  processLoadedBuffers(sectionIndices);
+}
+
+void MetadataInput::loadFromFile(
+    const std::vector<LoadedSection>& sections,
+    const std::vector<folly::Range<char*>>& readRanges) {
+  std::vector<uint32_t> loadIndices(sections.size());
+  std::iota(loadIndices.begin(), loadIndices.end(), 0);
+  loadFromFile(sections, loadIndices, readRanges);
 }
 
 void MetadataInput::recordCoalescedIoStats(
@@ -292,33 +295,41 @@ DirectMetadataInput::DirectMetadataInput(
     const velox::io::ReaderOptions& options)
     : MetadataInput(file, options) {}
 
-void DirectMetadataInput::load() {
-  NIMBLE_CHECK(!loaded_, "load() already called; call reset() first");
-  NIMBLE_CHECK(!sections_.empty(), "No sections enqueued");
-  std::vector<uint32_t> sectionIndices(sections_.size());
-  std::iota(sectionIndices.begin(), sectionIndices.end(), 0);
-  loadFromFile(sectionIndices);
-  loaded_ = true;
-}
-
-void DirectMetadataInput::prepareReadBuffers(
-    const std::vector<uint32_t>& sectionIndices) {
-  buffers_.resize(sectionIndices.size());
-  readRanges_.resize(sectionIndices.size());
-  for (size_t i = 0; i < sectionIndices.size(); ++i) {
-    const auto size = sections_[sectionIndices[i]].section.size();
-    buffers_[i] = velox::AlignedBuffer::allocateExact<char>(size, pool_);
-    readRanges_[i] = {buffers_[i]->asMutable<char>(), size};
+void DirectMetadataInput::prepareBuffers(
+    const std::vector<LoadedSection>& loadSections,
+    ReadBuffers& readBuffers) {
+  readBuffers.buffers.resize(loadSections.size());
+  readBuffers.readRanges.resize(loadSections.size());
+  for (size_t i = 0; i < loadSections.size(); ++i) {
+    const auto size = loadSections[i].section.size();
+    readBuffers.buffers[i] =
+        velox::AlignedBuffer::allocateExact<char>(size, pool_);
+    readBuffers.readRanges[i] = {
+        readBuffers.buffers[i]->asMutable<char>(), size};
   }
 }
 
-void DirectMetadataInput::processLoadedBuffers(
-    const std::vector<uint32_t>& sectionIndices) {
-  NIMBLE_CHECK_EQ(buffers_.size(), sectionIndices.size());
-  for (size_t i = 0; i < sectionIndices.size(); ++i) {
-    auto& loaded = sections_[sectionIndices[i]];
-    loaded.buffer = decompressAndStore(loaded.section, std::move(buffers_[i]));
+std::vector<std::shared_ptr<MetadataBuffer>> DirectMetadataInput::load(
+    std::span<const MetadataSection> sections) {
+  NIMBLE_CHECK(!sections.empty(), "No sections to load");
+
+  std::vector<LoadedSection> loadSections;
+  loadSections.reserve(sections.size());
+  for (const auto& section : sections) {
+    loadSections.emplace_back(section);
   }
+
+  ReadBuffers readBuffers;
+  prepareBuffers(loadSections, readBuffers);
+
+  loadFromFile(loadSections, readBuffers.readRanges);
+
+  for (size_t i = 0; i < loadSections.size(); ++i) {
+    loadSections[i].buffer = decompressAndStore(
+        loadSections[i].section, std::move(readBuffers.buffers[i]));
+  }
+
+  return extractResults(loadSections);
 }
 
 std::shared_ptr<MetadataBuffer> DirectMetadataInput::store(
@@ -336,11 +347,6 @@ CachedMetadataInput::CachedMetadataInput(
     const velox::io::ReaderOptions& options)
     : MetadataInput(file, options), cache_{cache}, fileId_{std::move(fileId)} {
   NIMBLE_CHECK_NOT_NULL(cache_);
-}
-
-void CachedMetadataInput::reset() {
-  MetadataInput::reset();
-  cachePins_.clear();
 }
 
 velox::cache::CachePin CachedMetadataInput::acquireCachePin(
@@ -403,8 +409,11 @@ std::shared_ptr<MetadataBuffer> CachedMetadataInput::promoteCachePin(
   return std::make_shared<MetadataBuffer>(std::move(pin));
 }
 
-void CachedMetadataInput::loadFromSsd(std::vector<uint32_t>& missIndices) {
-  if (missIndices.empty()) {
+void CachedMetadataInput::loadFromSsd(
+    std::vector<LoadedSection>& sections,
+    std::vector<std::optional<velox::cache::CachePin>>& cachePins,
+    std::vector<uint32_t>& loadIndices) {
+  if (loadIndices.empty()) {
     return;
   }
   auto* ssdCache = cache_->ssdCache();
@@ -418,18 +427,18 @@ void CachedMetadataInput::loadFromSsd(std::vector<uint32_t>& missIndices) {
     velox::cache::CachePin cachePin;
   };
   std::vector<SsdHit> ssdHits;
-  std::vector<uint32_t> remainingMissIndices;
-  remainingMissIndices.reserve(missIndices.size());
+  std::vector<uint32_t> remainingLoadIndices;
+  remainingLoadIndices.reserve(loadIndices.size());
 
   auto& ssdFile = ssdCache->file(fileId_.id());
-  for (const auto index : missIndices) {
-    auto& loaded = sections_[index];
+  for (const auto index : loadIndices) {
+    auto& loaded = sections[index];
     const velox::cache::RawFileCacheKey key{
         fileId_.id(), loaded.section.offset()};
 
     auto ssdPin = ssdFile.find(key);
     if (ssdPin.empty()) {
-      remainingMissIndices.emplace_back(index);
+      remainingLoadIndices.emplace_back(index);
       continue;
     }
 
@@ -442,7 +451,6 @@ void CachedMetadataInput::loadFromSsd(std::vector<uint32_t>& missIndices) {
           "SSD entry size mismatch with expected uncompressed size");
     }
 
-    // Allocate memory cache entry for loading from SSD.
     auto pin = acquireCachePin(key, ssdSize);
     auto buffer = tryCacheHit(ssdSize, pin);
     if (buffer != nullptr) {
@@ -452,42 +460,42 @@ void CachedMetadataInput::loadFromSsd(std::vector<uint32_t>& missIndices) {
     ssdHits.emplace_back(SsdHit{index, std::move(ssdPin), std::move(pin)});
   }
 
-  missIndices = std::move(remainingMissIndices);
+  loadIndices = std::move(remainingLoadIndices);
 
   if (ssdHits.empty()) {
     return;
   }
 
-  // Batch SsdFile::load() for all SSD hits.
   std::vector<velox::cache::SsdPin> ssdPins;
-  std::vector<velox::cache::CachePin> cachePins;
+  std::vector<velox::cache::CachePin> loadPins;
   ssdPins.reserve(ssdHits.size());
-  cachePins.reserve(ssdHits.size());
+  loadPins.reserve(ssdHits.size());
   for (auto& hit : ssdHits) {
     ssdPins.emplace_back(std::move(hit.ssdPin));
-    cachePins.emplace_back(std::move(hit.cachePin));
+    loadPins.emplace_back(std::move(hit.cachePin));
   }
   uint64_t ssdLoadUs{0};
   {
     velox::MicrosecondTimer timer(&ssdLoadUs);
-    ssdFile.load(ssdPins, cachePins);
+    ssdFile.load(ssdPins, loadPins);
   }
   ioStats_->queryThreadIoLatencyUs().increment(ssdLoadUs);
   ioStats_->ssdCacheReadLatencyUs().increment(ssdLoadUs);
   for (uint32_t i = 0; i < ssdHits.size(); ++i) {
-    const auto& section = sections_[ssdHits[i].sectionIndex].section;
-    sections_[ssdHits[i].sectionIndex].buffer =
-        promoteCachePin(section, std::move(cachePins[i]), ioStats_->ssdRead());
+    const auto& section = sections[ssdHits[i].sectionIndex].section;
+    sections[ssdHits[i].sectionIndex].buffer =
+        promoteCachePin(section, std::move(loadPins[i]), ioStats_->ssdRead());
   }
 }
 
-std::vector<uint32_t> CachedMetadataInput::loadFromCache() {
-  NIMBLE_CHECK(cachePins_.empty(), "Cache pins not cleared from previous load");
-  cachePins_.resize(sections_.size());
-  std::vector<uint32_t> missIndices;
-  missIndices.reserve(sections_.size());
-  for (uint32_t index = 0; index < sections_.size(); ++index) {
-    const auto& section = sections_[index].section;
+std::vector<uint32_t> CachedMetadataInput::loadFromCache(
+    std::vector<LoadedSection>& sections,
+    std::vector<std::optional<velox::cache::CachePin>>& cachePins) {
+  cachePins.resize(sections.size());
+  std::vector<uint32_t> loadIndices;
+  loadIndices.reserve(sections.size());
+  for (uint32_t index = 0; index < sections.size(); ++index) {
+    const auto& section = sections[index].section;
     const velox::cache::RawFileCacheKey key{fileId_.id(), section.offset()};
     const auto uncompressedSize = resolveUncompressedSize(section);
 
@@ -495,77 +503,62 @@ std::vector<uint32_t> CachedMetadataInput::loadFromCache() {
       auto pin = acquireCachePin(key, uncompressedSize.value());
       auto buffer = tryCacheHit(uncompressedSize.value(), pin);
       if (buffer != nullptr) {
-        sections_[index].buffer = std::move(buffer);
+        sections[index].buffer = std::move(buffer);
         continue;
       }
-      cachePins_[index] = std::move(pin);
-      missIndices.push_back(index);
+      cachePins[index] = std::move(pin);
+      loadIndices.push_back(index);
     } else {
-      missIndices.push_back(index);
+      loadIndices.push_back(index);
     }
   }
-  return missIndices;
+  return loadIndices;
 }
 
-void CachedMetadataInput::load() {
-  NIMBLE_CHECK(!loaded_, "load() already called; call reset() first");
-  NIMBLE_CHECK(!sections_.empty(), "No sections enqueued");
-
-  auto missIndices = loadFromCache();
-  loadFromSsd(missIndices);
-  loadFromFile(missIndices);
-  loaded_ = true;
-}
-
-void CachedMetadataInput::prepareReadBuffers(
-    const std::vector<uint32_t>& sectionIndices) {
-  NIMBLE_CHECK_EQ(
-      cachePins_.size(),
-      sections_.size(),
-      "Cache pins size mismatch with sections");
-
-  // For uncompressed sections with cache pins, read directly into the
-  // pin's contiguous data. For compressed sections or sections without
-  // pins, allocate a temporary buffer.
-  buffers_.resize(sectionIndices.size());
-  readRanges_.resize(sectionIndices.size());
-  for (size_t i = 0; i < sectionIndices.size(); ++i) {
-    const auto sectionIndex = sectionIndices[i];
-    const auto& section = sections_[sectionIndex].section;
-    const auto& pin = cachePins_[sectionIndex];
+void CachedMetadataInput::prepareBuffers(
+    const std::vector<LoadedSection>& loadSections,
+    const std::vector<uint32_t>& loadIndices,
+    const std::vector<std::optional<velox::cache::CachePin>>& cachePins,
+    ReadBuffers& readBuffers) {
+  readBuffers.buffers.resize(loadIndices.size());
+  readBuffers.readRanges.resize(loadIndices.size());
+  for (size_t i = 0; i < loadIndices.size(); ++i) {
+    const auto sectionIndex = loadIndices[i];
+    const auto& section = loadSections[sectionIndex].section;
+    const auto& pin = cachePins[sectionIndex];
     if (pin.has_value() &&
         section.compressionType() == CompressionType::Uncompressed) {
       NIMBLE_CHECK(
           pin->entry()->hasContiguousData(),
           "Cache entry must have contiguous data");
-      readRanges_[i] = {pin->entry()->contiguousData(), section.size()};
+      readBuffers.readRanges[i] = {
+          pin->entry()->contiguousData(), section.size()};
     } else {
-      buffers_[i] = velox::AlignedBuffer::allocate<char>(section.size(), pool_);
-      readRanges_[i] = {buffers_[i]->asMutable<char>(), section.size()};
+      readBuffers.buffers[i] =
+          velox::AlignedBuffer::allocate<char>(section.size(), pool_);
+      readBuffers.readRanges[i] = {
+          readBuffers.buffers[i]->asMutable<char>(), section.size()};
     }
   }
 }
 
 void CachedMetadataInput::processLoadedBuffers(
-    const std::vector<uint32_t>& sectionIndices) {
-  NIMBLE_CHECK_EQ(buffers_.size(), sectionIndices.size());
-  NIMBLE_CHECK_EQ(cachePins_.size(), sections_.size());
-  SCOPE_EXIT {
-    cachePins_.clear();
-  };
-
-  for (size_t i = 0; i < sectionIndices.size(); ++i) {
-    const auto sectionIndex = sectionIndices[i];
-    auto& loaded = sections_[sectionIndex];
-    auto& pin = cachePins_[sectionIndex];
+    std::vector<LoadedSection>& loadSections,
+    const std::vector<uint32_t>& loadIndices,
+    std::vector<std::optional<velox::cache::CachePin>>& cachePins,
+    ReadBuffers& readBuffers) {
+  for (size_t i = 0; i < loadIndices.size(); ++i) {
+    const auto sectionIndex = loadIndices[i];
+    auto& loaded = loadSections[sectionIndex];
+    auto& pin = cachePins[sectionIndex];
     if (pin.has_value()) {
       if (loaded.section.compressionType() != CompressionType::Uncompressed) {
-        NIMBLE_CHECK_NOT_NULL(buffers_[i]);
+        NIMBLE_CHECK_NOT_NULL(readBuffers.buffers[i]);
         NIMBLE_CHECK(
             pin->entry()->hasContiguousData(),
             "Cache entry must have contiguous data");
         std::string_view compressed{
-            buffers_[i]->as<char>(), loaded.section.size()};
+            readBuffers.buffers[i]->as<char>(), loaded.section.size()};
         ZstdCompression::uncompress(
             compressed, pin->entry()->contiguousData(), pin->entry()->size());
       }
@@ -576,9 +569,34 @@ void CachedMetadataInput::processLoadedBuffers(
           !loaded.section.uncompressedSize().has_value(),
           "Section without cache pin should not have uncompressed size set");
       loaded.buffer =
-          decompressAndStore(loaded.section, std::move(buffers_[i]));
+          decompressAndStore(loaded.section, std::move(readBuffers.buffers[i]));
     }
   }
+}
+
+std::vector<std::shared_ptr<MetadataBuffer>> CachedMetadataInput::load(
+    std::span<const MetadataSection> sections) {
+  NIMBLE_CHECK(!sections.empty(), "No sections to load");
+
+  std::vector<LoadedSection> loadSections;
+  loadSections.reserve(sections.size());
+  for (const auto& section : sections) {
+    loadSections.emplace_back(section);
+  }
+
+  std::vector<std::optional<velox::cache::CachePin>> cachePins;
+  auto missIndices = loadFromCache(loadSections, cachePins);
+  loadFromSsd(loadSections, cachePins, missIndices);
+
+  if (!missIndices.empty()) {
+    ReadBuffers readBuffers;
+    prepareBuffers(loadSections, missIndices, cachePins, readBuffers);
+
+    loadFromFile(loadSections, missIndices, readBuffers.readRanges);
+    processLoadedBuffers(loadSections, missIndices, cachePins, readBuffers);
+  }
+
+  return extractResults(loadSections);
 }
 
 std::shared_ptr<MetadataBuffer> CachedMetadataInput::store(

--- a/dwio/nimble/tablet/MetadataInput.h
+++ b/dwio/nimble/tablet/MetadataInput.h
@@ -39,32 +39,11 @@ class MetadataInputTestHelper;
 class CachedMetadataInputTestHelper;
 } // namespace test
 
-class MetadataInput;
-
-/// Handle to an enqueued metadata section. Returned by
-/// MetadataInput::enqueue(). Call read() to get the decompressed
-/// MetadataBuffer — either from a prior coalesced load() or by
-/// triggering on-demand IO for just this section.
-class MetadataHandle {
- public:
-  MetadataHandle(MetadataInput* input, uint32_t index)
-      : input_{input}, index_{index} {}
-
-  /// Returns the decompressed MetadataBuffer. If load() was called
-  /// on the parent MetadataInput, returns the already-loaded result.
-  /// Otherwise triggers on-demand IO for this section only.
-  std::shared_ptr<MetadataBuffer> read();
-
- private:
-  MetadataInput* const input_;
-  const uint32_t index_;
-};
-
 /// Reads metadata sections from a Nimble file with IO coalescing.
 ///
-/// Supports two-phase IO: enqueue() registers sections and returns a
-/// MetadataHandle, load() executes coalesced preadv for all enqueued
-/// sections. The handle's read() returns the decompressed MetadataBuffer.
+/// Stateless, thread-safe API: load() takes a span of sections and returns
+/// decompressed MetadataBuffers. All per-call state is local — no member
+/// state is mutated during load(), so concurrent calls are safe.
 ///
 /// IO coalescing is controlled by maxCoalesceDistance and maxCoalesceBytes
 /// from io::ReaderOptions, shared with data IO settings.
@@ -73,8 +52,6 @@ class MetadataHandle {
 ///   - DirectMetadataInput: IO coalescing, no caching
 ///   - CachedMetadataInput: IO coalescing + AsyncDataCache for decompressed
 ///     metadata with memory/SSD tier support
-///
-/// NOTE: Not thread-safe. All calls must be serialized by the caller.
 class MetadataInput {
  public:
   /// Creates a DirectMetadataInput for non-cached reads.
@@ -95,35 +72,11 @@ class MetadataInput {
     return false;
   }
 
-  /// Enqueues a metadata section for coalesced IO. Returns a handle
-  /// to retrieve the result later via handle.read().
-  MetadataHandle enqueue(const MetadataSection& section);
-
-  /// Executes coalesced preadv for all enqueued sections, then
-  /// decompresses and stores each section via the subclass.
-  virtual void load() = 0;
-
-  /// Resets all internal state for the next round of enqueue/load/read.
-  virtual void reset();
-
-  /// RAII guard that calls load() on construction and reset() on destruction.
-  class LoadGuard {
-   public:
-    explicit LoadGuard(MetadataInput* input) : input_{input} {
-      NIMBLE_CHECK_NOT_NULL(input_);
-      input_->load();
-    }
-
-    ~LoadGuard() {
-      input_->reset();
-    }
-
-    LoadGuard(const LoadGuard&) = delete;
-    LoadGuard& operator=(const LoadGuard&) = delete;
-
-   private:
-    MetadataInput* const input_;
-  };
+  /// Loads metadata sections with coalesced IO. Returns one MetadataBuffer
+  /// per input section, in the same order. Thread-safe: all per-call state
+  /// is local.
+  virtual std::vector<std::shared_ptr<MetadataBuffer>> load(
+      std::span<const MetadataSection> sections) = 0;
 
   /// Tries to find cached metadata at the given offset. Returns a
   /// MetadataBuffer holding a cache pin if found, nullptr otherwise.
@@ -146,17 +99,26 @@ class MetadataInput {
     std::shared_ptr<MetadataBuffer> buffer;
   };
 
-  /// Reads sections at the given indices from file with IO coalescing,
-  /// decompresses, and calls store() for each. Sorts indices in-place.
-  void loadFromFile(std::vector<uint32_t>& sectionIndices);
+  // Per-section read state produced by prepareBuffers().
+  // buffers[i] owns the allocated memory (null when reading into cache pin).
+  // readRanges[i] is the writable destination for IO.
+  struct ReadBuffers {
+    std::vector<velox::BufferPtr> buffers;
+    std::vector<folly::Range<char*>> readRanges;
+  };
 
-  /// Subclass sets up per-section read buffers and ranges.
-  virtual void prepareReadBuffers(
-      const std::vector<uint32_t>& sectionIndices) = 0;
+  /// Sorts by file offset internally, computes coalesced IO groups,
+  /// and executes preadv. Does not reorder readRanges — the caller's
+  /// buffers[i] ↔ loadIndices[i] correspondence is preserved.
+  void loadFromFile(
+      const std::vector<LoadedSection>& sections,
+      const std::vector<uint32_t>& loadIndices,
+      const std::vector<folly::Range<char*>>& readRanges);
 
-  /// Subclass processes loaded buffers into MetadataBuffers.
-  virtual void processLoadedBuffers(
-      const std::vector<uint32_t>& sectionIndices) = 0;
+  /// Overload for loading all sections (sequential indices).
+  void loadFromFile(
+      const std::vector<LoadedSection>& sections,
+      const std::vector<folly::Range<char*>>& readRanges);
 
   /// Decompresses the buffer and calls store(). For uncompressed data,
   /// passes the buffer directly (zero copy).
@@ -169,6 +131,10 @@ class MetadataInput {
       const MetadataSection& section,
       velox::BufferPtr&& decompressed) = 0;
 
+  /// Extracts results from loaded sections into a vector of MetadataBuffers.
+  static std::vector<std::shared_ptr<MetadataBuffer>> extractResults(
+      std::vector<LoadedSection>& sections);
+
   struct IoGroup {
     uint64_t offset;
     std::vector<folly::Range<char*>> ranges;
@@ -178,7 +144,8 @@ class MetadataInput {
   // ranges for each group with null-data ranges for gaps.
   // 'readRanges' provides the writable destination for each section.
   std::vector<IoGroup> computeIoGroups(
-      const std::vector<uint32_t>& sectionIndices,
+      const std::vector<LoadedSection>& sections,
+      const std::vector<uint32_t>& loadIndices,
       const std::vector<folly::Range<char*>>& readRanges);
 
   // Dispatches IO groups in parallel via AsyncSource when executor is
@@ -219,39 +186,30 @@ class MetadataInput {
   folly::Executor* const executor_;
   const std::shared_ptr<velox::io::IoStatistics> ioStats_;
 
-  std::vector<LoadedSection> sections_;
-  bool loaded_{false};
-
-  // Per-section read state, populated by prepareReadBuffers().
-  std::vector<velox::BufferPtr> buffers_;
-  std::vector<folly::Range<char*>> readRanges_;
-
- private:
-  virtual std::shared_ptr<MetadataBuffer> read(uint32_t index);
-
-  friend class MetadataHandle;
   friend class test::MetadataInputTestHelper;
 };
 
 /// Direct metadata loading with IO coalescing, no caching.
 class DirectMetadataInput : public MetadataInput {
  public:
-  void load() override;
+  std::vector<std::shared_ptr<MetadataBuffer>> load(
+      std::span<const MetadataSection> sections) override;
+
+ protected:
+  std::shared_ptr<MetadataBuffer> store(
+      const MetadataSection& section,
+      velox::BufferPtr&& decompressed) override;
 
  private:
+  void prepareBuffers(
+      const std::vector<LoadedSection>& loadSections,
+      ReadBuffers& readBuffers);
+
   friend class MetadataInput;
 
   DirectMetadataInput(
       velox::ReadFile* file,
       const velox::io::ReaderOptions& options);
-
- protected:
-  void prepareReadBuffers(const std::vector<uint32_t>& sectionIndices) override;
-  void processLoadedBuffers(
-      const std::vector<uint32_t>& sectionIndices) override;
-  std::shared_ptr<MetadataBuffer> store(
-      const MetadataSection& section,
-      velox::BufferPtr&& decompressed) override;
 };
 
 /// Cached metadata loading with IO coalescing and AsyncDataCache.
@@ -264,9 +222,8 @@ class CachedMetadataInput : public MetadataInput {
     return true;
   }
 
-  void load() override;
-
-  void reset() override;
+  std::vector<std::shared_ptr<MetadataBuffer>> load(
+      std::span<const MetadataSection> sections) override;
 
   std::unique_ptr<MetadataBuffer> findCachedMetadata(uint64_t offset) override;
 
@@ -275,9 +232,6 @@ class CachedMetadataInput : public MetadataInput {
       std::span<const std::string_view> ranges) override;
 
  protected:
-  void prepareReadBuffers(const std::vector<uint32_t>& sectionIndices) override;
-  void processLoadedBuffers(
-      const std::vector<uint32_t>& sectionIndices) override;
   std::shared_ptr<MetadataBuffer> store(
       const MetadataSection& section,
       velox::BufferPtr&& decompressed) override;
@@ -285,11 +239,33 @@ class CachedMetadataInput : public MetadataInput {
  private:
   // Checks memory cache for all sections. Returns indices of sections
   // not found in cache. Pre-claims exclusive pins for known-size misses.
-  std::vector<uint32_t> loadFromCache();
+  std::vector<uint32_t> loadFromCache(
+      std::vector<LoadedSection>& sections,
+      std::vector<std::optional<velox::cache::CachePin>>& cachePins);
 
   // Checks SSD cache for memory misses, batch-loads SSD hits into
-  // memory cache. Removes loaded indices from missIndices in-place.
-  void loadFromSsd(std::vector<uint32_t>& missIndices);
+  // memory cache. Removes loaded indices from loadIndices in-place.
+  void loadFromSsd(
+      std::vector<LoadedSection>& sections,
+      std::vector<std::optional<velox::cache::CachePin>>& cachePins,
+      std::vector<uint32_t>& loadIndices);
+
+  // Decompresses loaded buffers and stores results into loadSections.
+  // For sections with cache pins, decompresses into the pin and promotes
+  // to shared. For sections without pins, uses decompressAndStore.
+  void processLoadedBuffers(
+      std::vector<LoadedSection>& loadSections,
+      const std::vector<uint32_t>& loadIndices,
+      std::vector<std::optional<velox::cache::CachePin>>& cachePins,
+      ReadBuffers& readBuffers);
+
+  // For uncompressed sections with cache pins, reads directly into the
+  // pin's contiguous data. Otherwise allocates a temp buffer.
+  void prepareBuffers(
+      const std::vector<LoadedSection>& loadSections,
+      const std::vector<uint32_t>& loadIndices,
+      const std::vector<std::optional<velox::cache::CachePin>>& cachePins,
+      ReadBuffers& readBuffers);
 
   // Waits for a cache pin to become available via findOrCreate.
   // Blocks until the pin is no longer exclusively held by another thread.
@@ -320,10 +296,6 @@ class CachedMetadataInput : public MetadataInput {
 
   velox::cache::AsyncDataCache* const cache_;
   const velox::StringIdLease fileId_;
-
-  // Pre-claimed exclusive cache pins from loadFromCache(), indexed by
-  // section index. Present for sections with known uncompressed size.
-  std::vector<std::optional<velox::cache::CachePin>> cachePins_;
 
   friend class test::CachedMetadataInputTestHelper;
 };

--- a/dwio/nimble/tablet/TabletReader.cpp
+++ b/dwio/nimble/tablet/TabletReader.cpp
@@ -294,13 +294,13 @@ void TabletReader::init(const Options& options) {
   // Parse optional sections metadata from footer before enqueueing.
   initOptionalSections();
 
-  // Enqueue stripes + optional sections. Try extracting from footerBuf
-  // first (speculative mode), enqueue the rest for coalesced IO.
-  std::vector<EnqueuedSection> enqueued;
-  enqueueStripesSection(footerView, footerOffset, enqueued);
-  enqueueOptionalSections(options, footerView, footerOffset, enqueued);
+  // Collect stripes + optional sections. Try extracting from footerBuf
+  // first (speculative mode), batch-load the rest via coalesced IO.
+  std::vector<LoadSection> sections;
+  collectStripesSection(footerView, footerOffset, sections);
+  collectOptionalSections(options, footerView, footerOffset, sections);
 
-  loadEnqueuedSections(enqueued);
+  loadSections(sections);
 
   initStripes(footerView, footerOffset);
   initClusterIndex();
@@ -415,14 +415,14 @@ bool TabletReader::initFromCache(const Options& options) {
   }
   initOptionalSections();
 
-  // Enqueue stripes + optional sections together for coalesced IO.
+  // Collect stripes + optional sections together for coalesced IO.
   // Empty files (0 rows) have no stripes section but still need optional
   // sections loaded (e.g., schema describes column types even with no rows).
-  std::vector<EnqueuedSection> enqueued;
-  enqueueStripesSection(enqueued);
-  enqueueOptionalSections(options, enqueued);
+  std::vector<LoadSection> sections;
+  collectStripesSection(sections);
+  collectOptionalSections(options, sections);
 
-  loadEnqueuedSections(enqueued);
+  loadSections(sections);
 
   initStripes();
   initClusterIndex();
@@ -550,10 +550,10 @@ void TabletReader::loadStripes(
   }
 }
 
-void TabletReader::enqueueStripesSection(
+void TabletReader::collectStripesSection(
     std::string_view footerBuf,
     uint64_t footerOffset,
-    std::vector<EnqueuedSection>& enqueued) {
+    std::vector<LoadSection>& loadSections) {
   const auto* footer = footerRoot(*footer_);
   auto* stripesSection = footer->stripes();
   if (stripesSection == nullptr) {
@@ -564,22 +564,18 @@ void TabletReader::enqueueStripesSection(
   if (fromBuf != nullptr) {
     stripes_ = std::move(fromBuf);
   } else {
-    enqueued.push_back(
-        {EnqueuedSection::Type::kStripes,
-         {},
-         metadataInput_->enqueue(section)});
+    loadSections.emplace_back(
+        LoadSection{LoadSection::Type::kStripes, {}, section});
   }
 }
 
-void TabletReader::enqueueOptionalSections(
+void TabletReader::collectOptionalSections(
     const Options& options,
     std::string_view footerBuf,
     uint64_t footerOffset,
-    std::vector<EnqueuedSection>& enqueued) {
+    std::vector<LoadSection>& loadSections) {
   auto optionalSectionCache = optionalSectionsCache_.wlock();
   for (const auto& name : preloadSectionNames(options)) {
-    // Skip sections not present in this file (e.g., old files without
-    // chunk index, small files without stats).
     auto it = optionalSections_.find(name);
     if (it == optionalSections_.end()) {
       continue;
@@ -589,33 +585,31 @@ void TabletReader::enqueueOptionalSections(
     if (fromBuf != nullptr) {
       optionalSectionCache->insert({name, std::move(fromBuf)});
     } else {
-      enqueued.push_back(
-          {EnqueuedSection::Type::kOptionalSection,
-           name,
-           metadataInput_->enqueue(it->second)});
+      loadSections.emplace_back(
+          LoadSection{LoadSection::Type::kOptionalSection, name, it->second});
     }
   }
 }
 
-void TabletReader::loadEnqueuedSections(
-    std::vector<EnqueuedSection>& enqueued) {
-  if (enqueued.empty()) {
+void TabletReader::loadSections(std::vector<LoadSection>& loadSections) {
+  if (loadSections.empty()) {
     return;
   }
-  MetadataInput::LoadGuard guard{metadataInput_.get()};
+  std::vector<MetadataSection> sections;
+  sections.reserve(loadSections.size());
+  for (const auto& p : loadSections) {
+    sections.emplace_back(p.section);
+  }
+  auto results = metadataInput_->load(sections);
   auto optionalSectionCache = optionalSectionsCache_.wlock();
-  for (auto& entry : enqueued) {
-    auto buffer =
-        std::make_unique<MetadataBuffer>(std::move(*entry.handle.read()));
-    if (entry.type == EnqueuedSection::Type::kStripes) {
+  for (size_t i = 0; i < loadSections.size(); ++i) {
+    auto buffer = std::make_unique<MetadataBuffer>(std::move(*results[i]));
+    if (loadSections[i].type == LoadSection::Type::kStripes) {
       NIMBLE_CHECK_NULL(stripes_, "Stripes already loaded");
       stripes_ = std::move(buffer);
     } else {
-      NIMBLE_CHECK_EQ(
-          static_cast<int>(entry.type),
-          static_cast<int>(EnqueuedSection::Type::kOptionalSection));
       auto [_, inserted] = optionalSectionCache->insert(
-          {std::move(entry.name), std::move(buffer)});
+          {std::move(loadSections[i].name), std::move(buffer)});
       NIMBLE_CHECK(inserted, "Optional section already loaded");
     }
   }
@@ -713,42 +707,6 @@ std::vector<std::string> TabletReader::preloadSectionNames(
   return names;
 }
 
-void TabletReader::preloadOptionalSections(
-    const Options& options,
-    std::string_view footerBuf,
-    uint64_t footerOffset) {
-  std::vector<EnqueuedSection> pending;
-  auto optionalSectionCache = optionalSectionsCache_.wlock();
-  for (const auto& name : preloadSectionNames(options)) {
-    // Skip sections not present in this file (e.g., old files without
-    // chunk index, small files without stats).
-    auto it = optionalSections_.find(name);
-    if (it == optionalSections_.end()) {
-      continue;
-    }
-    const auto& section = it->second;
-    auto fromFooter =
-        tryExtractFromBuffer(footerBuf, footerOffset, section, pool_);
-    if (fromFooter != nullptr) {
-      optionalSectionCache->insert({name, std::move(fromFooter)});
-      continue;
-    }
-    pending.push_back(
-        {EnqueuedSection::Type::kOptionalSection,
-         name,
-         metadataInput_->enqueue(section)});
-  }
-  if (!pending.empty()) {
-    MetadataInput::LoadGuard guard{metadataInput_.get()};
-    for (auto& entry : pending) {
-      auto buffer = entry.handle.read();
-      optionalSectionCache->insert(
-          {std::move(entry.name),
-           std::make_unique<MetadataBuffer>(std::move(*buffer))});
-    }
-  }
-}
-
 std::shared_ptr<TabletReader> TabletReader::create(
     std::shared_ptr<velox::ReadFile> readFile,
     MemoryPool* pool,
@@ -844,11 +802,9 @@ uint32_t TabletReader::stripeGroupIndex(uint32_t stripeIndex) const {
 std::unique_ptr<MetadataBuffer> TabletReader::readMetadata(
     const MetadataSection& section) const {
   NIMBLE_CHECK_GT(section.size(), 0, "Metadata section size must be non-zero");
-  std::lock_guard<std::mutex> lock(metadataInputMutex_);
-  auto handle = metadataInput_->enqueue(section);
-  MetadataInput::LoadGuard guard{metadataInput_.get()};
-  auto result = handle.read();
-  return std::make_unique<MetadataBuffer>(std::move(*result));
+  auto results = metadataInput_->load({&section, 1});
+  NIMBLE_CHECK_EQ(results.size(), 1);
+  return std::make_unique<MetadataBuffer>(std::move(*results[0]));
 }
 
 std::shared_ptr<StripeGroup> TabletReader::loadStripeGroup(
@@ -874,34 +830,22 @@ TabletReader::StripeGroupMetadata TabletReader::loadStripeGroupMetadata(
 
   const bool hasChunkIndex = this->hasChunkIndex(stripeGroupIndex);
 
-  std::unique_ptr<MetadataBuffer> groupMetadata;
-  std::unique_ptr<MetadataBuffer> chunkIndexMetadata;
-
-  {
-    std::lock_guard<std::mutex> lock(metadataInputMutex_);
-    auto groupHandle = metadataInput_->enqueue(groupSection);
-
-    std::optional<MetadataHandle> chunkIndexHandle;
-    if (hasChunkIndex) {
-      chunkIndexHandle.emplace(metadataInput_->enqueue(
-          chunkIndex_->groupMetadata(stripeGroupIndex)));
-    }
-
-    MetadataInput::LoadGuard guard{metadataInput_.get()};
-
-    auto groupShared = groupHandle.read();
-    groupMetadata = std::make_unique<MetadataBuffer>(std::move(*groupShared));
-    if (hasChunkIndex) {
-      auto chunkShared = chunkIndexHandle->read();
-      chunkIndexMetadata =
-          std::make_unique<MetadataBuffer>(std::move(*chunkShared));
-    }
+  std::vector<MetadataSection> sections;
+  sections.emplace_back(groupSection);
+  if (hasChunkIndex) {
+    sections.emplace_back(chunkIndex_->groupMetadata(stripeGroupIndex));
   }
+
+  auto results = metadataInput_->load(sections);
+
+  auto groupMetadata = std::make_unique<MetadataBuffer>(std::move(*results[0]));
 
   StripeGroupMetadata result;
   result.stripeGroup = std::make_shared<StripeGroup>(
       stripeGroupIndex, *stripes_, std::move(groupMetadata));
   if (hasChunkIndex) {
+    auto chunkIndexMetadata =
+        std::make_unique<MetadataBuffer>(std::move(*results[1]));
     result.chunkIndex = ChunkIndexGroup::create(
         result.stripeGroup->firstStripe(),
         result.stripeGroup->stripeCount(),

--- a/dwio/nimble/tablet/TabletReader.h
+++ b/dwio/nimble/tablet/TabletReader.h
@@ -388,44 +388,43 @@ class TabletReader {
       uint64_t& footerOffset,
       const Options& options);
 
-  // Tracks a section enqueued to MetadataInput for batched coalesced loading.
-  struct EnqueuedSection {
+  // Tracks a pending metadata section for batched coalesced loading.
+  struct LoadSection {
     enum class Type { kStripes, kOptionalSection };
 
     Type type;
     std::string name;
-    MetadataHandle handle{nullptr, 0};
+    MetadataSection section;
   };
 
-  // Enqueues the stripes section for coalesced loading via MetadataInput.
-  // Tries to extract from footerBuf first; enqueues to MetadataInput on miss.
-  void enqueueStripesSection(
+  // Collects stripes section for coalesced loading. Tries to extract from
+  // footerBuf first; adds to pending on miss.
+  void collectStripesSection(
       std::string_view footerBuf,
       uint64_t footerOffset,
-      std::vector<EnqueuedSection>& enqueued);
+      std::vector<LoadSection>& loadSections);
 
-  void enqueueStripesSection(std::vector<EnqueuedSection>& enqueued) {
-    enqueueStripesSection({}, 0, enqueued);
+  void collectStripesSection(std::vector<LoadSection>& loadSections) {
+    collectStripesSection({}, 0, loadSections);
   }
 
-  // Enqueues optional sections for coalesced loading via MetadataInput.
-  // Tries to extract from footerBuf first; enqueues to MetadataInput on miss.
-  // Skips sections not present in this file.
-  void enqueueOptionalSections(
+  // Collects optional sections for coalesced loading. Tries to extract from
+  // footerBuf first; adds to pending on miss.
+  void collectOptionalSections(
       const Options& options,
       std::string_view footerBuf,
       uint64_t footerOffset,
-      std::vector<EnqueuedSection>& enqueued);
+      std::vector<LoadSection>& loadSections);
 
-  void enqueueOptionalSections(
+  void collectOptionalSections(
       const Options& options,
-      std::vector<EnqueuedSection>& enqueued) {
-    enqueueOptionalSections(options, {}, 0, enqueued);
+      std::vector<LoadSection>& loadSections) {
+    collectOptionalSections(options, {}, 0, loadSections);
   }
 
-  // Loads all enqueued sections via MetadataInput and stores results:
+  // Loads all pending sections via MetadataInput and stores results:
   // stripes go to stripes_, optional sections go to optionalSectionsCache_.
-  void loadEnqueuedSections(std::vector<EnqueuedSection>& enqueued);
+  void loadSections(std::vector<LoadSection>& loadSections);
 
   // Parses stripes_ to populate stripe metadata and preloads the first
   // stripe group from footerBuf when available.
@@ -461,14 +460,6 @@ class TabletReader {
   // Returns the list of optional section names to preload: the user-specified
   // sections plus the index section if present.
   std::vector<std::string> preloadSectionNames(const Options& options) const;
-
-  // Preloads optional sections into optionalSectionsCache_. Tries to
-  // extract from the speculative read buffer first, then batches remaining
-  // sections through MetadataInput.
-  void preloadOptionalSections(
-      const Options& options,
-      std::string_view footerBuf,
-      uint64_t footerOffset);
 
   // Reads and decompresses a metadata section via MetadataInput.
   std::unique_ptr<MetadataBuffer> readMetadata(
@@ -509,9 +500,8 @@ class TabletReader {
 
   // Owned MetadataInput for coalesced metadata IO. Always created —
   // uses DirectMetadataInput (no cache) or CachedMetadataInput depending
-  // on options.
+  // on options. Thread-safe: load() is stateless.
   const std::unique_ptr<MetadataInput> metadataInput_;
-  mutable std::mutex metadataInputMutex_;
 
   uint64_t fileSize_{0};
   Postscript ps_;

--- a/dwio/nimble/tablet/tests/MetadataInputTest.cpp
+++ b/dwio/nimble/tablet/tests/MetadataInputTest.cpp
@@ -17,6 +17,7 @@
 #include "dwio/nimble/tablet/MetadataInput.h"
 
 #include <gtest/gtest.h>
+#include <array>
 
 #include "dwio/nimble/common/Exceptions.h"
 #include "dwio/nimble/common/tests/GTestUtils.h"
@@ -49,45 +50,13 @@ namespace facebook::nimble::test {
 
 class MetadataInputTestHelper {
  public:
-  explicit MetadataInputTestHelper(nimble::MetadataInput* input)
-      : input_{input} {}
-
-  bool testingLoaded() const {
-    return input_->loaded_;
-  }
-
-  uint32_t testingSectionCount() const {
-    return input_->sections_.size();
-  }
-
-  const nimble::MetadataSection& testingSection(uint32_t index) const {
-    return input_->sections_[index].section;
-  }
-
-  bool testingHasBuffer(uint32_t index) const {
-    return input_->sections_[index].buffer != nullptr;
-  }
-
- private:
-  nimble::MetadataInput* const input_;
+  explicit MetadataInputTestHelper(nimble::MetadataInput* /*input*/) {}
 };
 
 class CachedMetadataInputTestHelper : public MetadataInputTestHelper {
  public:
   explicit CachedMetadataInputTestHelper(nimble::CachedMetadataInput* input)
-      : MetadataInputTestHelper(input), input_{input} {}
-
-  uint32_t testingCachePinCount() const {
-    return input_->cachePins_.size();
-  }
-
-  bool testingHasCachePin(uint32_t index) const {
-    return index < input_->cachePins_.size() &&
-        input_->cachePins_[index].has_value();
-  }
-
- private:
-  nimble::CachedMetadataInput* const input_;
+      : MetadataInputTestHelper(input) {}
 };
 
 } // namespace facebook::nimble::test
@@ -231,7 +200,7 @@ class DirectMetadataInputTest : public MetadataInputTestBase {
   }
 };
 
-TEST_F(DirectMetadataInputTest, enqueueLoadRead) {
+TEST_F(DirectMetadataInputTest, loadSections) {
   for (const auto& testData : enqueueLoadReadTestSettings()) {
     SCOPED_TRACE(testData.debugString());
 
@@ -244,35 +213,17 @@ TEST_F(DirectMetadataInputTest, enqueueLoadRead) {
 
     const auto options = makeReaderOptions();
     auto input = nimble::MetadataInput::create(readFile.get(), options);
-    nimble::test::MetadataInputTestHelper helper(input.get());
 
-    EXPECT_FALSE(helper.testingLoaded());
-    EXPECT_EQ(helper.testingSectionCount(), 0);
-
-    std::vector<nimble::MetadataHandle> handles;
+    auto results = input->load(sections);
+    ASSERT_EQ(results.size(), sections.size());
     for (uint32_t i = 0; i < sections.size(); ++i) {
-      handles.push_back(input->enqueue(sections[i]));
-      EXPECT_EQ(helper.testingSectionCount(), i + 1);
-      EXPECT_FALSE(helper.testingHasBuffer(i));
-    }
-    EXPECT_FALSE(helper.testingLoaded());
-
-    input->load();
-    EXPECT_TRUE(helper.testingLoaded());
-    for (uint32_t i = 0; i < sections.size(); ++i) {
-      EXPECT_TRUE(helper.testingHasBuffer(i));
-    }
-
-    for (uint32_t i = 0; i < sections.size(); ++i) {
-      auto buffer = handles[i].read();
-      ASSERT_NE(buffer, nullptr);
-      EXPECT_EQ(buffer->content(), testData.specs[i].data);
-      EXPECT_FALSE(helper.testingHasBuffer(i));
+      ASSERT_NE(results[i], nullptr);
+      EXPECT_EQ(results[i]->content(), testData.specs[i].data);
     }
   }
 }
 
-TEST_F(DirectMetadataInputTest, reverseEnqueueOrder) {
+TEST_F(DirectMetadataInputTest, reverseSectionOrder) {
   const std::string data0 = "first-in-file";
   const std::string data1 = "second-in-file";
 
@@ -297,17 +248,14 @@ TEST_F(DirectMetadataInputTest, reverseEnqueueOrder) {
   const auto options = makeReaderOptions();
   auto input = nimble::MetadataInput::create(readFile.get(), options);
 
-  // Enqueue in reverse file order — should still work.
-  auto handle1 = input->enqueue(section1);
-  auto handle0 = input->enqueue(section0);
-  input->load();
-
-  EXPECT_EQ(handle0.read()->content(), data0);
-  EXPECT_EQ(handle1.read()->content(), data1);
+  // Sections in reverse file order — should still work.
+  auto results = input->load(std::array{section1, section0});
+  EXPECT_EQ(results[0]->content(), data1);
+  EXPECT_EQ(results[1]->content(), data0);
 }
 
-TEST_F(DirectMetadataInputTest, stateTransitions) {
-  const std::string data = "state-test";
+TEST_F(DirectMetadataInputTest, repeatedLoad) {
+  const std::string data = "repeat-test";
   nimble::MetadataSection section{
       0,
       static_cast<uint32_t>(data.size()),
@@ -318,67 +266,18 @@ TEST_F(DirectMetadataInputTest, stateTransitions) {
 
   const auto options = makeReaderOptions();
   auto input = nimble::MetadataInput::create(readFile.get(), options);
-  nimble::test::MetadataInputTestHelper helper(input.get());
 
-  // Before enqueue.
-  EXPECT_FALSE(helper.testingLoaded());
-  EXPECT_EQ(helper.testingSectionCount(), 0);
+  // Stateless: can call load() multiple times without reset.
+  auto results1 = input->load(std::array{section});
+  EXPECT_EQ(results1[0]->content(), data);
 
-  // After enqueue.
-  auto handle = input->enqueue(section);
-  EXPECT_FALSE(helper.testingLoaded());
-  EXPECT_EQ(helper.testingSectionCount(), 1);
-  EXPECT_EQ(helper.testingSection(0).offset(), 0);
-  EXPECT_EQ(helper.testingSection(0).size(), data.size());
-  EXPECT_FALSE(helper.testingHasBuffer(0));
+  auto results2 = input->load(std::array{section});
+  EXPECT_EQ(results2[0]->content(), data);
 
-  // After load.
-  input->load();
-  EXPECT_TRUE(helper.testingLoaded());
-  EXPECT_EQ(helper.testingSectionCount(), 1);
-  EXPECT_TRUE(helper.testingHasBuffer(0));
-
-  // After read — buffer consumed.
-  EXPECT_EQ(handle.read()->content(), data);
-  EXPECT_FALSE(helper.testingHasBuffer(0));
-
-  // After reset — back to initial state.
-  input->reset();
-  EXPECT_FALSE(helper.testingLoaded());
-  EXPECT_EQ(helper.testingSectionCount(), 0);
-
-  // Can enqueue/load/read again after reset.
-  auto handle2 = input->enqueue(section);
-  EXPECT_EQ(helper.testingSectionCount(), 1);
-  input->load();
-  EXPECT_TRUE(helper.testingLoaded());
-  EXPECT_EQ(handle2.read()->content(), data);
-
-  // Load without enqueue throws.
-  {
-    auto emptyInput = nimble::MetadataInput::create(readFile.get(), options);
-    NIMBLE_ASSERT_THROW(emptyInput->load(), "No sections enqueued");
-  }
-
-  // Read before load throws.
-  {
-    auto freshInput = nimble::MetadataInput::create(readFile.get(), options);
-    auto h = freshInput->enqueue(section);
-    NIMBLE_ASSERT_THROW(h.read(), "load() must be called before read()");
-  }
-
-  // Without reset, enqueue throws.
+  // Empty input throws.
   NIMBLE_ASSERT_THROW(
-      input->enqueue(section), "enqueue() not allowed after load()");
-  // Without reset, load throws.
-  NIMBLE_ASSERT_THROW(input->load(), "load() already called");
-
-  // Double read throws.
-  input->reset();
-  auto handle3 = input->enqueue(section);
-  input->load();
-  handle3.read();
-  NIMBLE_ASSERT_THROW(handle3.read(), "Metadata buffer already consumed");
+      input->load(std::span<const nimble::MetadataSection>{}),
+      "No sections to load");
 }
 
 TEST_F(DirectMetadataInputTest, ioStats) {
@@ -409,8 +308,7 @@ TEST_F(DirectMetadataInputTest, ioStats) {
 
   const auto options = makeReaderOptions();
   auto input = nimble::MetadataInput::create(readFile.get(), options);
-  input->enqueue(section);
-  input->load();
+  input->load(std::array{section});
 
   EXPECT_GT(metadataIoStats_->read().count(), readCountBefore);
   EXPECT_EQ(metadataIoStats_->read().sum() - readSumBefore, data.size());
@@ -525,10 +423,7 @@ DEBUG_ONLY_TEST_F(DirectMetadataInputTest, ioCoalescing) {
     const auto options = makeReaderOptions(
         testData.maxCoalesceDistance, testData.maxCoalesceBytes);
     auto input = nimble::MetadataInput::create(readFile.get(), options);
-    for (const auto& section : sections) {
-      input->enqueue(section);
-    }
-    input->load();
+    input->load(sections);
 
     EXPECT_EQ(capturedStats.numIos, testData.expectedNumIos);
     EXPECT_EQ(capturedStats.extraBytes, testData.expectedOverread);
@@ -602,48 +497,15 @@ TEST_F(DirectMetadataInputTest, ioError) {
 
     const auto options = makeReaderOptions(testData.maxCoalesceDistance);
     auto input = nimble::MetadataInput::create(readFile.get(), options);
-    for (const auto& section : sections) {
-      input->enqueue(section);
-    }
-    EXPECT_THROW(input->load(), std::runtime_error);
+    EXPECT_THROW(input->load(sections), std::runtime_error);
 
-    // After IO error, reset and retry with error cleared should succeed.
+    // After IO error, retry with error cleared should succeed (stateless).
     readFile->clearReadError();
-    input->reset();
-    std::vector<nimble::MetadataHandle> handles;
-    for (const auto& section : sections) {
-      handles.push_back(input->enqueue(section));
-    }
-    input->load();
-    for (uint32_t i = 0; i < handles.size(); ++i) {
-      EXPECT_EQ(handles[i].read()->content(), testData.specs[i].data);
+    auto results = input->load(sections);
+    for (uint32_t i = 0; i < results.size(); ++i) {
+      EXPECT_EQ(results[i]->content(), testData.specs[i].data);
     }
   }
-}
-
-TEST_F(DirectMetadataInputTest, loadGuard) {
-  NIMBLE_ASSERT_THROW(nimble::MetadataInput::LoadGuard(nullptr), "");
-
-  std::string sectionData(64, 'A');
-  nimble::MetadataSection section{0, 64, nimble::CompressionType::Uncompressed};
-  auto fileContent = buildFileContent({section}, {sectionData});
-  auto file = std::make_shared<velox::InMemoryReadFile>(std::move(fileContent));
-  auto options = makeReaderOptions();
-  auto input = nimble::MetadataInput::create(file.get(), options);
-
-  auto handle = input->enqueue(section);
-  nimble::test::MetadataInputTestHelper helper(input.get());
-  EXPECT_FALSE(helper.testingLoaded());
-
-  {
-    nimble::MetadataInput::LoadGuard guard(input.get());
-    EXPECT_TRUE(helper.testingLoaded());
-    auto result = handle.read();
-    ASSERT_NE(result, nullptr);
-    EXPECT_EQ(result->content(), sectionData);
-  }
-  EXPECT_FALSE(helper.testingLoaded());
-  EXPECT_EQ(helper.testingSectionCount(), 0);
 }
 
 // --- CachedMetadataInput tests ---
@@ -730,7 +592,7 @@ class CachedMetadataInputTest : public MetadataInputTestBase,
   std::unique_ptr<folly::IOThreadPoolExecutor> ssdExecutor_;
 };
 
-TEST_P(CachedMetadataInputTest, enqueueLoadRead) {
+TEST_P(CachedMetadataInputTest, loadSections) {
   for (const auto& testData : enqueueLoadReadTestSettings()) {
     SCOPED_TRACE(testData.debugString());
     cache_->clear();
@@ -743,35 +605,16 @@ TEST_P(CachedMetadataInputTest, enqueueLoadRead) {
     auto readFile = std::make_shared<velox::InMemoryReadFile>(fileContent);
 
     auto input = createCachedInput(readFile.get());
-    nimble::test::MetadataInputTestHelper helper(input.get());
-
-    EXPECT_FALSE(helper.testingLoaded());
-    EXPECT_EQ(helper.testingSectionCount(), 0);
-
-    std::vector<nimble::MetadataHandle> handles;
+    auto results = input->load(sections);
+    ASSERT_EQ(results.size(), sections.size());
     for (uint32_t i = 0; i < sections.size(); ++i) {
-      handles.push_back(input->enqueue(sections[i]));
-      EXPECT_EQ(helper.testingSectionCount(), i + 1);
-      EXPECT_FALSE(helper.testingHasBuffer(i));
-    }
-    EXPECT_FALSE(helper.testingLoaded());
-
-    input->load();
-    EXPECT_TRUE(helper.testingLoaded());
-    for (uint32_t i = 0; i < sections.size(); ++i) {
-      EXPECT_TRUE(helper.testingHasBuffer(i));
-    }
-
-    for (uint32_t i = 0; i < sections.size(); ++i) {
-      auto buffer = handles[i].read();
-      ASSERT_NE(buffer, nullptr);
-      EXPECT_EQ(buffer->content(), testData.specs[i].data);
-      EXPECT_FALSE(helper.testingHasBuffer(i));
+      ASSERT_NE(results[i], nullptr);
+      EXPECT_EQ(results[i]->content(), testData.specs[i].data);
     }
   }
 }
 
-TEST_P(CachedMetadataInputTest, reverseEnqueueOrder) {
+TEST_P(CachedMetadataInputTest, reverseSectionOrder) {
   const std::string data0 = "first-in-file";
   const std::string data1 = "second-in-file";
 
@@ -794,16 +637,12 @@ TEST_P(CachedMetadataInputTest, reverseEnqueueOrder) {
   auto readFile = std::make_shared<velox::InMemoryReadFile>(fileContent);
 
   auto input = createCachedInput(readFile.get());
-
-  auto handle1 = input->enqueue(section1);
-  auto handle0 = input->enqueue(section0);
-  input->load();
-
-  EXPECT_EQ(handle0.read()->content(), data0);
-  EXPECT_EQ(handle1.read()->content(), data1);
+  auto results = input->load(std::array{section1, section0});
+  EXPECT_EQ(results[0]->content(), data1);
+  EXPECT_EQ(results[1]->content(), data0);
 }
 
-TEST_P(CachedMetadataInputTest, enqueueLoadReadWithCache) {
+TEST_P(CachedMetadataInputTest, loadWithCache) {
   for (const auto& testData : enqueueLoadReadTestSettings()) {
     SCOPED_TRACE(testData.debugString());
     cache_->clear();
@@ -821,13 +660,9 @@ TEST_P(CachedMetadataInputTest, enqueueLoadReadWithCache) {
       const auto storageLatencyBefore =
           metadataIoStats_->storageReadLatencyUs().count();
       auto input = createCachedInput(readFile.get());
-      std::vector<nimble::MetadataHandle> handles;
-      for (const auto& section : sections) {
-        handles.push_back(input->enqueue(section));
-      }
-      input->load();
-      for (uint32_t i = 0; i < handles.size(); ++i) {
-        EXPECT_EQ(handles[i].read()->content(), testData.specs[i].data);
+      auto results = input->load(sections);
+      for (uint32_t i = 0; i < results.size(); ++i) {
+        EXPECT_EQ(results[i]->content(), testData.specs[i].data);
       }
       EXPECT_EQ(metadataIoStats_->ramHit().count(), ramHitBefore);
       EXPECT_GT(
@@ -835,25 +670,18 @@ TEST_P(CachedMetadataInputTest, enqueueLoadReadWithCache) {
           storageLatencyBefore);
     }
 
-    // Count sections with known uncompressed size — only these get
-    // pre-claimed cache pins and can be fully served from RAM cache.
     const uint32_t sectionsWithSize = std::count_if(
         testData.specs.begin(), testData.specs.end(), [](const auto& s) {
           return s.hasUncompressedSize;
         });
 
     // Second load — sections with uncompressed size hit cache directly.
-    // Sections without it still go through loadFromFile → store().
     {
       const auto ramHitBefore = metadataIoStats_->ramHit().count();
       auto input = createCachedInput(readFile.get());
-      std::vector<nimble::MetadataHandle> handles;
-      for (const auto& section : sections) {
-        handles.push_back(input->enqueue(section));
-      }
-      input->load();
-      for (uint32_t i = 0; i < handles.size(); ++i) {
-        EXPECT_EQ(handles[i].read()->content(), testData.specs[i].data);
+      auto results = input->load(sections);
+      for (uint32_t i = 0; i < results.size(); ++i) {
+        EXPECT_EQ(results[i]->content(), testData.specs[i].data);
       }
       EXPECT_GE(
           metadataIoStats_->ramHit().count() - ramHitBefore, sectionsWithSize);
@@ -861,12 +689,9 @@ TEST_P(CachedMetadataInputTest, enqueueLoadReadWithCache) {
 
     // Third load (SSD only) — flush RAM to SSD, clear RAM, read from SSD.
     if (enableSsd()) {
-      // Flush all saveable entries to SSD.
       ASSERT_TRUE(cache_->ssdCache()->startWrite());
       cache_->saveToSsd(/*saveAll=*/true);
       cache_->ssdCache()->waitForWriteToFinish();
-
-      // Clear RAM cache — entries survive on SSD.
       cache_->clear();
 
       const auto ramHitBefore = metadataIoStats_->ramHit().count();
@@ -875,16 +700,11 @@ TEST_P(CachedMetadataInputTest, enqueueLoadReadWithCache) {
           metadataIoStats_->storageReadLatencyUs().count();
 
       auto input = createCachedInput(readFile.get());
-      std::vector<nimble::MetadataHandle> handles;
-      for (const auto& section : sections) {
-        handles.push_back(input->enqueue(section));
-      }
-      input->load();
-      for (uint32_t i = 0; i < handles.size(); ++i) {
-        EXPECT_EQ(handles[i].read()->content(), testData.specs[i].data);
+      auto results = input->load(sections);
+      for (uint32_t i = 0; i < results.size(); ++i) {
+        EXPECT_EQ(results[i]->content(), testData.specs[i].data);
       }
 
-      // No RAM hits, SSD hits for sections with known size, no file IO.
       EXPECT_EQ(metadataIoStats_->ramHit().count(), ramHitBefore);
       EXPECT_GE(
           metadataIoStats_->ssdRead().count() - ssdReadBefore,
@@ -896,8 +716,8 @@ TEST_P(CachedMetadataInputTest, enqueueLoadReadWithCache) {
   }
 }
 
-TEST_P(CachedMetadataInputTest, stateTransitions) {
-  const std::string data = "cached-state-test";
+TEST_P(CachedMetadataInputTest, repeatedLoad) {
+  const std::string data = "cached-repeat-test";
   nimble::MetadataSection section{
       0,
       static_cast<uint32_t>(data.size()),
@@ -907,51 +727,18 @@ TEST_P(CachedMetadataInputTest, stateTransitions) {
   auto readFile = std::make_shared<velox::InMemoryReadFile>(fileContent);
 
   auto input = createCachedInput(readFile.get());
-  nimble::test::CachedMetadataInputTestHelper helper(
-      dynamic_cast<nimble::CachedMetadataInput*>(input.get()));
 
-  // Before enqueue.
-  EXPECT_FALSE(helper.testingLoaded());
-  EXPECT_EQ(helper.testingSectionCount(), 0);
-  EXPECT_EQ(helper.testingCachePinCount(), 0);
+  // Stateless: can call load() multiple times without reset.
+  auto results1 = input->load(std::array{section});
+  EXPECT_EQ(results1[0]->content(), data);
 
-  // After enqueue.
-  auto handle = input->enqueue(section);
-  EXPECT_FALSE(helper.testingLoaded());
-  EXPECT_EQ(helper.testingSectionCount(), 1);
-  EXPECT_EQ(helper.testingSection(0).offset(), 0);
-  EXPECT_EQ(helper.testingSection(0).size(), data.size());
-  EXPECT_FALSE(helper.testingHasBuffer(0));
+  auto results2 = input->load(std::array{section});
+  EXPECT_EQ(results2[0]->content(), data);
 
-  // After load.
-  input->load();
-  EXPECT_TRUE(helper.testingLoaded());
-  EXPECT_EQ(helper.testingSectionCount(), 1);
-  EXPECT_TRUE(helper.testingHasBuffer(0));
-  // cachePins_ cleared after load completes.
-  EXPECT_EQ(helper.testingCachePinCount(), 0);
-
-  // After read — buffer consumed.
-  EXPECT_EQ(handle.read()->content(), data);
-  EXPECT_FALSE(helper.testingHasBuffer(0));
-
-  // After reset — back to initial state.
-  input->reset();
-  EXPECT_FALSE(helper.testingLoaded());
-  EXPECT_EQ(helper.testingSectionCount(), 0);
-  EXPECT_EQ(helper.testingCachePinCount(), 0);
-
-  // Can enqueue/load/read again after reset.
-  auto handle2 = input->enqueue(section);
-  input->load();
-  EXPECT_TRUE(helper.testingLoaded());
-  EXPECT_EQ(handle2.read()->content(), data);
-
-  // Without reset, enqueue throws.
+  // Empty input throws.
   NIMBLE_ASSERT_THROW(
-      input->enqueue(section), "enqueue() not allowed after load()");
-  // Without reset, load throws.
-  NIMBLE_ASSERT_THROW(input->load(), "load() already called");
+      input->load(std::span<const nimble::MetadataSection>{}),
+      "No sections to load");
 }
 
 DEBUG_ONLY_TEST_P(CachedMetadataInputTest, ioCoalescing) {
@@ -1042,10 +829,7 @@ DEBUG_ONLY_TEST_P(CachedMetadataInputTest, ioCoalescing) {
           readFile.get(),
           testData.maxCoalesceDistance,
           testData.maxCoalesceBytes);
-      for (const auto& section : sections) {
-        input->enqueue(section);
-      }
-      input->load();
+      input->load(sections);
 
       EXPECT_EQ(capturedStats.numIos, testData.expectedNumIos);
       EXPECT_EQ(capturedStats.extraBytes, testData.expectedOverread);
@@ -1067,10 +851,7 @@ DEBUG_ONLY_TEST_P(CachedMetadataInputTest, ioCoalescing) {
           metadataIoStats_->storageReadLatencyUs().count();
 
       auto input = createCachedInput(readFile.get());
-      for (const auto& section : sections) {
-        input->enqueue(section);
-      }
-      input->load();
+      input->load(sections);
 
       EXPECT_EQ(metadataIoStats_->rawBytesRead(), rawBytesBefore);
       EXPECT_EQ(metadataIoStats_->rawOverreadBytes(), overreadBefore);
@@ -1096,12 +877,8 @@ DEBUG_ONLY_TEST_P(CachedMetadataInputTest, ioCoalescing) {
           metadataIoStats_->storageReadLatencyUs().count();
 
       auto input = createCachedInput(readFile.get());
-      for (const auto& section : sections) {
-        input->enqueue(section);
-      }
-      input->load();
+      input->load(sections);
 
-      // No RAM hits, all SSD hits, no file IO, no overread.
       EXPECT_EQ(metadataIoStats_->rawBytesRead(), rawBytesBefore);
       EXPECT_EQ(metadataIoStats_->rawOverreadBytes(), overreadBefore);
       EXPECT_EQ(metadataIoStats_->ramHit().count(), ramHitBefore);
@@ -1140,20 +917,17 @@ TEST_P(CachedMetadataInputTest, partialCacheHit) {
   // Load only section0 to populate cache for it.
   {
     auto input = createCachedInput(readFile.get());
-    auto handle = input->enqueue(section0);
-    input->load();
-    EXPECT_EQ(handle.read()->content(), data0);
+    auto results = input->load(std::array{section0});
+    EXPECT_EQ(results[0]->content(), data0);
   }
 
   // Load both sections — section0 should be a cache hit, section1 a miss.
   {
     const auto ramHitBefore = metadataIoStats_->ramHit().count();
     auto input = createCachedInput(readFile.get());
-    auto handle0 = input->enqueue(section0);
-    auto handle1 = input->enqueue(section1);
-    input->load();
-    EXPECT_EQ(handle0.read()->content(), data0);
-    EXPECT_EQ(handle1.read()->content(), data1);
+    auto results = input->load(std::array{section0, section1});
+    EXPECT_EQ(results[0]->content(), data0);
+    EXPECT_EQ(results[1]->content(), data1);
     EXPECT_GT(metadataIoStats_->ramHit().count(), ramHitBefore);
   }
 
@@ -1169,9 +943,8 @@ TEST_P(CachedMetadataInputTest, partialCacheHit) {
     // Reload only section1 into RAM.
     {
       auto input = createCachedInput(readFile.get());
-      auto handle = input->enqueue(section1);
-      input->load();
-      EXPECT_EQ(handle.read()->content(), data1);
+      auto results = input->load(std::array{section1});
+      EXPECT_EQ(results[0]->content(), data1);
     }
 
     const auto ssdReadBefore = metadataIoStats_->ssdRead().count();
@@ -1180,11 +953,9 @@ TEST_P(CachedMetadataInputTest, partialCacheHit) {
         metadataIoStats_->storageReadLatencyUs().count();
     {
       auto input = createCachedInput(readFile.get());
-      auto handle0 = input->enqueue(section0);
-      auto handle1 = input->enqueue(section1);
-      input->load();
-      EXPECT_EQ(handle0.read()->content(), data0);
-      EXPECT_EQ(handle1.read()->content(), data1);
+      auto results = input->load(std::array{section0, section1});
+      EXPECT_EQ(results[0]->content(), data0);
+      EXPECT_EQ(results[1]->content(), data1);
     }
     // section0 from SSD, section1 from RAM, no file IO.
     EXPECT_GT(metadataIoStats_->ssdRead().count(), ssdReadBefore);
@@ -1258,21 +1029,13 @@ TEST_P(CachedMetadataInputTest, ioError) {
 
     auto input =
         createCachedInput(readFile.get(), testData.maxCoalesceDistance);
-    for (const auto& section : sections) {
-      input->enqueue(section);
-    }
-    EXPECT_THROW(input->load(), std::runtime_error);
+    EXPECT_THROW(input->load(sections), std::runtime_error);
 
-    // After IO error, reset and retry with error cleared should succeed.
+    // After IO error, retry with error cleared should succeed (stateless).
     readFile->clearReadError();
-    input->reset();
-    std::vector<nimble::MetadataHandle> handles;
-    for (const auto& section : sections) {
-      handles.push_back(input->enqueue(section));
-    }
-    input->load();
-    for (uint32_t i = 0; i < handles.size(); ++i) {
-      EXPECT_EQ(handles[i].read()->content(), testData.specs[i].data);
+    auto results = input->load(sections);
+    for (uint32_t i = 0; i < results.size(); ++i) {
+      EXPECT_EQ(results[i]->content(), testData.specs[i].data);
     }
   }
 }
@@ -1295,9 +1058,8 @@ DEBUG_ONLY_TEST_P(CachedMetadataInputTest, ssdIoError) {
   // Populate cache, flush to SSD, clear RAM.
   {
     auto input = createCachedInput(readFile.get());
-    auto handle = input->enqueue(section);
-    input->load();
-    EXPECT_EQ(handle.read()->content(), data);
+    auto results = input->load(std::array{section});
+    EXPECT_EQ(results[0]->content(), data);
   }
   ASSERT_TRUE(cache_->ssdCache()->startWrite());
   cache_->saveToSsd(/*saveAll=*/true);
@@ -1313,8 +1075,8 @@ DEBUG_ONLY_TEST_P(CachedMetadataInputTest, ssdIoError) {
           }));
   {
     auto input = createCachedInput(readFile.get());
-    input->enqueue(section);
-    VELOX_ASSERT_THROW(input->load(), "injected SSD IO error");
+    VELOX_ASSERT_THROW(
+        input->load(std::array{section}), "injected SSD IO error");
   }
 }
 
@@ -1329,11 +1091,10 @@ TEST_P(CachedMetadataInputTest, cachePinRetention) {
   auto readFile = std::make_shared<velox::InMemoryReadFile>(fileContent);
   cache_->clear();
 
-  // Load and read — MetadataBuffer holds the cache pin reference.
+  // Load — MetadataBuffer holds the cache pin reference.
   auto input = createCachedInput(readFile.get());
-  auto handle = input->enqueue(section);
-  input->load();
-  auto buffer = handle.read();
+  auto results = input->load(std::array{section});
+  auto buffer = std::move(results[0]);
   ASSERT_NE(buffer, nullptr);
   EXPECT_EQ(buffer->content(), data);
 
@@ -1349,11 +1110,9 @@ TEST_P(CachedMetadataInputTest, cachePinRetention) {
   const auto ramHitBefore = metadataIoStats_->ramHit().count();
   {
     auto input2 = createCachedInput(readFile.get());
-    auto handle2 = input2->enqueue(section);
-    input2->load();
-    auto buffer2 = handle2.read();
-    ASSERT_NE(buffer2, nullptr);
-    EXPECT_EQ(buffer2->content(), data);
+    auto results2 = input2->load(std::array{section});
+    ASSERT_NE(results2[0], nullptr);
+    EXPECT_EQ(results2[0]->content(), data);
   }
   EXPECT_GT(metadataIoStats_->ramHit().count(), ramHitBefore);
 
@@ -1369,40 +1128,13 @@ TEST_P(CachedMetadataInputTest, cachePinRetention) {
       metadataIoStats_->storageReadLatencyUs().count();
   {
     auto input3 = createCachedInput(readFile.get());
-    auto handle3 = input3->enqueue(section);
-    input3->load();
-    auto buffer3 = handle3.read();
-    ASSERT_NE(buffer3, nullptr);
-    EXPECT_EQ(buffer3->content(), data);
+    auto results3 = input3->load(std::array{section});
+    ASSERT_NE(results3[0], nullptr);
+    EXPECT_EQ(results3[0]->content(), data);
   }
   EXPECT_EQ(metadataIoStats_->ramHit().count(), ramHitBefore2);
   EXPECT_GT(
       metadataIoStats_->storageReadLatencyUs().count(), storageLatencyBefore);
-}
-
-TEST_P(CachedMetadataInputTest, loadGuard) {
-  NIMBLE_ASSERT_THROW(nimble::MetadataInput::LoadGuard(nullptr), "");
-
-  std::string sectionData(64, 'B');
-  nimble::MetadataSection section{0, 64, nimble::CompressionType::Uncompressed};
-  auto fileContent = buildFileContent({section}, {sectionData});
-  auto readFile =
-      std::make_shared<velox::InMemoryReadFile>(std::move(fileContent));
-  auto input = createCachedInput(readFile.get());
-
-  auto handle = input->enqueue(section);
-  nimble::test::MetadataInputTestHelper helper(input.get());
-  EXPECT_FALSE(helper.testingLoaded());
-
-  {
-    nimble::MetadataInput::LoadGuard guard(input.get());
-    EXPECT_TRUE(helper.testingLoaded());
-    auto result = handle.read();
-    ASSERT_NE(result, nullptr);
-    EXPECT_EQ(result->content(), sectionData);
-  }
-  EXPECT_FALSE(helper.testingLoaded());
-  EXPECT_EQ(helper.testingSectionCount(), 0);
 }
 
 TEST_F(DirectMetadataInputTest, cacheMethodsThrow) {


### PR DESCRIPTION
Summary:
CONTEXT: MetadataInput used a stateful enqueue/load/reset lifecycle that required external mutex synchronization in TabletReader for thread safety.

WHAT: Replace the multi-step stateful API with a single stateless `load(span<MetadataSection>) -> vector<shared_ptr<MetadataBuffer>>` method. All per-call state (sections, buffers, cache pins) is now local to each `load()` call, making it inherently thread-safe. This removes `MetadataHandle`, `LoadGuard`, `enqueue()`, `reset()`, member state (`sections_`, `loaded_`, `buffers_`, `readRanges_`, `cachePins_`), and `metadataInputMutex_` from TabletReader.

The base class `loadFromFile()` is preserved as a shared helper for IO coalescing (sort + compute groups + execute preadv). Each subclass implements `load()` end-to-end with subclass-specific buffer preparation and post-processing.

Differential Revision: D105407705


