### PR TITLE
misc: Address review comments on MetadataInput stateless API

### DIFF
--- a/dwio/nimble/index/ClusterIndex.cpp
+++ b/dwio/nimble/index/ClusterIndex.cpp
@@ -426,7 +426,8 @@ const ClusterIndex::IndexPartition* ClusterIndex::loadPartition(
     auto results = metadataInput_->load({&section, 1});
     NIMBLE_CHECK_EQ(results.size(), 1);
     partition = std::make_unique<IndexPartition>(
-        partitionId, std::make_unique<MetadataBuffer>(std::move(*results[0])));
+        partitionId,
+        std::make_unique<MetadataBuffer>(std::move(*results.front())));
   }
   return partition.get();
 }

--- a/dwio/nimble/index/DenseIndexRegistry.cpp
+++ b/dwio/nimble/index/DenseIndexRegistry.cpp
@@ -143,7 +143,7 @@ void DenseIndexRegistry::registerHashIndices(
         auto results = metadataInput->load({&descriptor.section, 1});
         NIMBLE_CHECK_EQ(results.size(), 1);
         auto indexMetadata =
-            std::make_unique<MetadataBuffer>(std::move(*results[0]));
+            std::make_unique<MetadataBuffer>(std::move(*results.front()));
         return HashIndex::create(
             descriptor.columns, std::move(indexMetadata), metadataInput, pool);
       },
@@ -165,7 +165,7 @@ void DenseIndexRegistry::registerSortedIndices(
         auto results = metadataInput->load({&descriptor.section, 1});
         NIMBLE_CHECK_EQ(results.size(), 1);
         auto indexMetadata =
-            std::make_unique<MetadataBuffer>(std::move(*results[0]));
+            std::make_unique<MetadataBuffer>(std::move(*results.front()));
         return SortedIndex::create(
             descriptor.columns, std::move(indexMetadata), dataInput, pool);
       },

--- a/dwio/nimble/index/HashIndex.cpp
+++ b/dwio/nimble/index/HashIndex.cpp
@@ -154,7 +154,7 @@ HashIndex::HashIndex(
             auto results = metadataInput_->load({&descriptor.section, 1});
             NIMBLE_CHECK_EQ(results.size(), 1);
             return Partition::create(
-                std::make_unique<MetadataBuffer>(std::move(*results[0])));
+                std::make_unique<MetadataBuffer>(std::move(*results.front())));
           }} {}
 
 // static

--- a/dwio/nimble/tablet/MetadataInput.cpp
+++ b/dwio/nimble/tablet/MetadataInput.cpp
@@ -23,7 +23,7 @@
 #include "dwio/nimble/common/Exceptions.h"
 #include "dwio/nimble/tablet/Compression.h"
 #include "folly/Range.h"
-#include "folly/ScopeGuard.h"
+
 #include "folly/executors/QueuedImmediateExecutor.h"
 #include "folly/io/Cursor.h"
 #include "velox/common/base/AsyncSource.h"
@@ -296,12 +296,12 @@ DirectMetadataInput::DirectMetadataInput(
     : MetadataInput(file, options) {}
 
 void DirectMetadataInput::prepareBuffers(
-    const std::vector<LoadedSection>& loadSections,
+    const std::vector<LoadedSection>& sections,
     ReadBuffers& readBuffers) {
-  readBuffers.buffers.resize(loadSections.size());
-  readBuffers.readRanges.resize(loadSections.size());
-  for (size_t i = 0; i < loadSections.size(); ++i) {
-    const auto size = loadSections[i].section.size();
+  readBuffers.buffers.resize(sections.size());
+  readBuffers.readRanges.resize(sections.size());
+  for (size_t i = 0; i < sections.size(); ++i) {
+    const auto size = sections[i].section.size();
     readBuffers.buffers[i] =
         velox::AlignedBuffer::allocateExact<char>(size, pool_);
     readBuffers.readRanges[i] = {
@@ -411,7 +411,6 @@ std::shared_ptr<MetadataBuffer> CachedMetadataInput::promoteCachePin(
 
 void CachedMetadataInput::loadFromSsd(
     std::vector<LoadedSection>& sections,
-    std::vector<std::optional<velox::cache::CachePin>>& cachePins,
     std::vector<uint32_t>& loadIndices) {
   if (loadIndices.empty()) {
     return;
@@ -516,7 +515,7 @@ std::vector<uint32_t> CachedMetadataInput::loadFromCache(
 }
 
 void CachedMetadataInput::prepareBuffers(
-    const std::vector<LoadedSection>& loadSections,
+    const std::vector<LoadedSection>& sections,
     const std::vector<uint32_t>& loadIndices,
     const std::vector<std::optional<velox::cache::CachePin>>& cachePins,
     ReadBuffers& readBuffers) {
@@ -524,7 +523,7 @@ void CachedMetadataInput::prepareBuffers(
   readBuffers.readRanges.resize(loadIndices.size());
   for (size_t i = 0; i < loadIndices.size(); ++i) {
     const auto sectionIndex = loadIndices[i];
-    const auto& section = loadSections[sectionIndex].section;
+    const auto& section = sections[sectionIndex].section;
     const auto& pin = cachePins[sectionIndex];
     if (pin.has_value() &&
         section.compressionType() == CompressionType::Uncompressed) {
@@ -543,13 +542,13 @@ void CachedMetadataInput::prepareBuffers(
 }
 
 void CachedMetadataInput::processLoadedBuffers(
-    std::vector<LoadedSection>& loadSections,
     const std::vector<uint32_t>& loadIndices,
+    std::vector<LoadedSection>& sections,
     std::vector<std::optional<velox::cache::CachePin>>& cachePins,
     ReadBuffers& readBuffers) {
   for (size_t i = 0; i < loadIndices.size(); ++i) {
     const auto sectionIndex = loadIndices[i];
-    auto& loaded = loadSections[sectionIndex];
+    auto& loaded = sections[sectionIndex];
     auto& pin = cachePins[sectionIndex];
     if (pin.has_value()) {
       if (loaded.section.compressionType() != CompressionType::Uncompressed) {
@@ -586,14 +585,14 @@ std::vector<std::shared_ptr<MetadataBuffer>> CachedMetadataInput::load(
 
   std::vector<std::optional<velox::cache::CachePin>> cachePins;
   auto missIndices = loadFromCache(loadSections, cachePins);
-  loadFromSsd(loadSections, cachePins, missIndices);
+  loadFromSsd(loadSections, missIndices);
 
   if (!missIndices.empty()) {
     ReadBuffers readBuffers;
     prepareBuffers(loadSections, missIndices, cachePins, readBuffers);
 
     loadFromFile(loadSections, missIndices, readBuffers.readRanges);
-    processLoadedBuffers(loadSections, missIndices, cachePins, readBuffers);
+    processLoadedBuffers(missIndices, loadSections, cachePins, readBuffers);
   }
 
   return extractResults(loadSections);

--- a/dwio/nimble/tablet/MetadataInput.h
+++ b/dwio/nimble/tablet/MetadataInput.h
@@ -202,7 +202,7 @@ class DirectMetadataInput : public MetadataInput {
 
  private:
   void prepareBuffers(
-      const std::vector<LoadedSection>& loadSections,
+      const std::vector<LoadedSection>& sections,
       ReadBuffers& readBuffers);
 
   friend class MetadataInput;
@@ -247,22 +247,21 @@ class CachedMetadataInput : public MetadataInput {
   // memory cache. Removes loaded indices from loadIndices in-place.
   void loadFromSsd(
       std::vector<LoadedSection>& sections,
-      std::vector<std::optional<velox::cache::CachePin>>& cachePins,
       std::vector<uint32_t>& loadIndices);
 
-  // Decompresses loaded buffers and stores results into loadSections.
+  // Decompresses loaded buffers and stores results into sections.
   // For sections with cache pins, decompresses into the pin and promotes
   // to shared. For sections without pins, uses decompressAndStore.
   void processLoadedBuffers(
-      std::vector<LoadedSection>& loadSections,
       const std::vector<uint32_t>& loadIndices,
+      std::vector<LoadedSection>& sections,
       std::vector<std::optional<velox::cache::CachePin>>& cachePins,
       ReadBuffers& readBuffers);
 
   // For uncompressed sections with cache pins, reads directly into the
   // pin's contiguous data. Otherwise allocates a temp buffer.
   void prepareBuffers(
-      const std::vector<LoadedSection>& loadSections,
+      const std::vector<LoadedSection>& sections,
       const std::vector<uint32_t>& loadIndices,
       const std::vector<std::optional<velox::cache::CachePin>>& cachePins,
       ReadBuffers& readBuffers);


### PR DESCRIPTION
Summary:
CONTEXT: D105407705 received reviewer feedback.

WHAT:
- Use `results.front()` instead of `results[0]` for single-element access after `NIMBLE_CHECK_EQ(results.size(), 1)`
- Rename `loadSections` to `sections` in `DirectMetadataInput::prepareBuffers` and `CachedMetadataInput::prepareBuffers`/`processLoadedBuffers` for consistency
- Reorder `processLoadedBuffers` params: const/input params first
- Remove unused `cachePins` param from `loadFromSsd`
- Remove unused `folly/ScopeGuard.h` include

Differential Revision: D105438228


