### PR TITLE
test(encoding): Add missing dedicated encoding tests

### DIFF
--- a/dwio/nimble/encodings/tests/EncodingSizeEstimationTest.cpp
+++ b/dwio/nimble/encodings/tests/EncodingSizeEstimationTest.cpp
@@ -1,0 +1,356 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include <gtest/gtest.h>
+#include "dwio/nimble/common/EncodingType.h"
+#include "dwio/nimble/common/Types.h"
+#include "dwio/nimble/common/Vector.h"
+#include "dwio/nimble/encodings/tests/TestUtils.h"
+#include "velox/common/memory/Memory.h"
+
+using namespace facebook;
+using namespace facebook::nimble;
+
+class EncodingSizeEstimationTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    pool_ = velox::memory::deprecatedAddDefaultLeafMemoryPool();
+  }
+
+  std::shared_ptr<velox::memory::MemoryPool> pool_;
+};
+
+TEST_F(EncodingSizeEstimationTest, numericConstant) {
+  using Est = detail::EncodingSizeEstimation<uint32_t, true>;
+
+  std::vector<uint32_t> data(100, 42);
+  auto stats = Statistics<uint32_t>::create(data);
+
+  auto size = Est::estimateNumericSize(EncodingType::Constant, 100, stats);
+  ASSERT_TRUE(size.has_value());
+  EXPECT_GT(size.value(), 0);
+  EXPECT_LT(size.value(), 100 * sizeof(uint32_t));
+}
+
+TEST_F(EncodingSizeEstimationTest, numericConstantNonConstantData) {
+  using Est = detail::EncodingSizeEstimation<uint32_t, true>;
+
+  std::vector<uint32_t> data = {1, 2, 3};
+  auto stats = Statistics<uint32_t>::create(data);
+
+  auto size = Est::estimateNumericSize(EncodingType::Constant, 3, stats);
+  EXPECT_FALSE(size.has_value());
+}
+
+TEST_F(EncodingSizeEstimationTest, numericTrivial) {
+  using Est = detail::EncodingSizeEstimation<uint32_t, true>;
+
+  std::vector<uint32_t> data = {1, 2, 3, 4, 5};
+  auto stats = Statistics<uint32_t>::create(data);
+
+  auto size = Est::estimateNumericSize(EncodingType::Trivial, 5, stats);
+  ASSERT_TRUE(size.has_value());
+  EXPECT_GE(size.value(), 5 * sizeof(uint32_t));
+}
+
+TEST_F(EncodingSizeEstimationTest, numericFixedBitWidth) {
+  using Est = detail::EncodingSizeEstimation<uint32_t, true>;
+
+  std::vector<uint32_t> data = {100, 101, 102, 103, 104};
+  auto stats = Statistics<uint32_t>::create(data);
+
+  auto size = Est::estimateNumericSize(EncodingType::FixedBitWidth, 5, stats);
+  ASSERT_TRUE(size.has_value());
+  EXPECT_LT(size.value(), 5 * sizeof(uint32_t));
+}
+
+TEST_F(EncodingSizeEstimationTest, numericDictionary) {
+  using Est = detail::EncodingSizeEstimation<uint32_t, true>;
+
+  std::vector<uint32_t> data = {1, 2, 1, 2, 1, 2, 1, 2, 1, 2};
+  auto stats = Statistics<uint32_t>::create(data);
+
+  auto size = Est::estimateNumericSize(EncodingType::Dictionary, 10, stats);
+  ASSERT_TRUE(size.has_value());
+  EXPECT_GT(size.value(), 0);
+}
+
+TEST_F(EncodingSizeEstimationTest, numericMainlyConstant) {
+  using Est = detail::EncodingSizeEstimation<uint32_t, true>;
+
+  std::vector<uint32_t> data(100, 42);
+  data[50] = 99;
+  auto stats = Statistics<uint32_t>::create(data);
+
+  auto size =
+      Est::estimateNumericSize(EncodingType::MainlyConstant, 100, stats);
+  ASSERT_TRUE(size.has_value());
+  EXPECT_LT(size.value(), 100 * sizeof(uint32_t));
+}
+
+TEST_F(EncodingSizeEstimationTest, numericRle) {
+  using Est = detail::EncodingSizeEstimation<uint32_t, true>;
+
+  std::vector<uint32_t> data;
+  for (int i = 0; i < 50; ++i) {
+    data.push_back(1);
+  }
+  for (int i = 0; i < 50; ++i) {
+    data.push_back(2);
+  }
+  auto stats = Statistics<uint32_t>::create(data);
+
+  auto size = Est::estimateNumericSize(EncodingType::RLE, 100, stats);
+  ASSERT_TRUE(size.has_value());
+  EXPECT_LT(size.value(), 100 * sizeof(uint32_t));
+}
+
+TEST_F(EncodingSizeEstimationTest, numericVarint32) {
+  using Est = detail::EncodingSizeEstimation<uint32_t, true>;
+
+  std::vector<uint32_t> data = {0, 1, 127, 128, 255, 256, 1000};
+  auto stats = Statistics<uint32_t>::create(data);
+
+  auto size = Est::estimateNumericSize(EncodingType::Varint, 7, stats);
+  ASSERT_TRUE(size.has_value());
+  EXPECT_GT(size.value(), 0);
+}
+
+TEST_F(EncodingSizeEstimationTest, numericVarint64) {
+  using Est = detail::EncodingSizeEstimation<uint64_t, true>;
+
+  std::vector<uint64_t> data = {0, 1, 127, 128, 16384, 1000000};
+  auto stats = Statistics<uint64_t>::create(data);
+
+  auto size = Est::estimateNumericSize(EncodingType::Varint, 6, stats);
+  ASSERT_TRUE(size.has_value());
+  EXPECT_GT(size.value(), 0);
+}
+
+TEST_F(EncodingSizeEstimationTest, numericUnsupportedEncoding) {
+  using Est = detail::EncodingSizeEstimation<uint32_t, true>;
+
+  std::vector<uint32_t> data = {1, 2, 3};
+  auto stats = Statistics<uint32_t>::create(data);
+
+  auto size = Est::estimateNumericSize(EncodingType::SparseBool, 3, stats);
+  EXPECT_FALSE(size.has_value());
+}
+
+TEST_F(EncodingSizeEstimationTest, numericEstimateSizeDispatches) {
+  using Est = detail::EncodingSizeEstimation<uint32_t, true>;
+
+  std::vector<uint32_t> data = {1, 2, 3, 4, 5};
+  auto stats = Statistics<uint32_t>::create(data);
+
+  auto size = Est::estimateSize(EncodingType::Trivial, 5, stats);
+  ASSERT_TRUE(size.has_value());
+
+  auto directSize = Est::estimateNumericSize(EncodingType::Trivial, 5, stats);
+  EXPECT_EQ(size.value(), directSize.value());
+}
+
+TEST_F(EncodingSizeEstimationTest, bitPackedBytesZeroRange) {
+  using EstNonFixed = detail::EncodingSizeEstimation<uint32_t, false>;
+  auto result = EstNonFixed::bitPackedBytes(0, 0, 100);
+  EXPECT_GT(result, 0u);
+
+  using EstFixed = detail::EncodingSizeEstimation<uint32_t, true>;
+  auto fixedResult = EstFixed::bitPackedBytes(0, 0, 100);
+  EXPECT_GE(fixedResult, result);
+}
+
+TEST_F(EncodingSizeEstimationTest, bitPackedBytesSmallRange) {
+  using EstNonFixed = detail::EncodingSizeEstimation<uint32_t, false>;
+  EXPECT_EQ(EstNonFixed::bitPackedBytes(0, 1, 8), 1);
+
+  using EstFixed = detail::EncodingSizeEstimation<uint32_t, true>;
+  auto fixedResult = EstFixed::bitPackedBytes(0, 1, 8);
+  EXPECT_GE(fixedResult, 1u);
+}
+
+TEST_F(EncodingSizeEstimationTest, bitPackedBytesLargeRange) {
+  using Est = detail::EncodingSizeEstimation<uint32_t, true>;
+  EXPECT_GT(Est::bitPackedBytes(0, 255, 100), 0u);
+  EXPECT_GT(Est::bitPackedBytes(0, 65535, 100), 0u);
+}
+
+TEST_F(EncodingSizeEstimationTest, bitPackedBytesWithBaseline) {
+  using Est = detail::EncodingSizeEstimation<uint32_t, true>;
+  auto sizeFromZero = Est::bitPackedBytes(0, 4, 100);
+  auto sizeWithBaseline = Est::bitPackedBytes(100, 104, 100);
+  EXPECT_EQ(sizeFromZero, sizeWithBaseline);
+}
+
+TEST_F(EncodingSizeEstimationTest, bitPackedBytesFixedVsNonFixed) {
+  using EstFixed = detail::EncodingSizeEstimation<uint32_t, true>;
+  using EstNonFixed = detail::EncodingSizeEstimation<uint32_t, false>;
+
+  auto fixed = EstFixed::bitPackedBytes(0, 5, 100);
+  auto nonFixed = EstNonFixed::bitPackedBytes(0, 5, 100);
+  EXPECT_GE(fixed, nonFixed);
+}
+
+TEST_F(EncodingSizeEstimationTest, getEncodingOverheadAllTypes) {
+  using Est = detail::EncodingSizeEstimation<uint32_t, true>;
+
+  EXPECT_GT(
+      (Est::template getEncodingOverhead<EncodingType::Trivial, uint32_t>()),
+      0u);
+  EXPECT_GT(
+      (Est::template getEncodingOverhead<EncodingType::Constant, uint32_t>()),
+      0u);
+  EXPECT_GT(
+      (Est::template getEncodingOverhead<
+          EncodingType::FixedBitWidth,
+          uint32_t>()),
+      0u);
+  EXPECT_GT(
+      (Est::template getEncodingOverhead<EncodingType::Dictionary, uint32_t>()),
+      0u);
+  EXPECT_GT(
+      (Est::template getEncodingOverhead<EncodingType::RLE, uint32_t>()), 0u);
+  EXPECT_GT(
+      (Est::template getEncodingOverhead<EncodingType::Varint, uint32_t>()),
+      0u);
+  EXPECT_GT(
+      (Est::template getEncodingOverhead<
+          EncodingType::MainlyConstant,
+          uint32_t>()),
+      0u);
+  EXPECT_GT(
+      (Est::template getEncodingOverhead<EncodingType::SparseBool, bool>()),
+      0u);
+  EXPECT_GT(
+      (Est::template getEncodingOverhead<EncodingType::Nullable, uint32_t>()),
+      0u);
+}
+
+TEST_F(EncodingSizeEstimationTest, trivialSmallerThanDictionaryForUnique) {
+  using Est = detail::EncodingSizeEstimation<uint32_t, true>;
+
+  std::vector<uint32_t> data;
+  for (uint32_t i = 0; i < 100; ++i) {
+    data.push_back(i);
+  }
+  auto stats = Statistics<uint32_t>::create(data);
+
+  auto trivialSize =
+      Est::estimateNumericSize(EncodingType::Trivial, 100, stats);
+  auto dictSize =
+      Est::estimateNumericSize(EncodingType::Dictionary, 100, stats);
+
+  ASSERT_TRUE(trivialSize.has_value());
+  ASSERT_TRUE(dictSize.has_value());
+  EXPECT_LT(trivialSize.value(), dictSize.value());
+}
+
+TEST_F(EncodingSizeEstimationTest, dictionarySmallerForHighRepetition) {
+  using Est = detail::EncodingSizeEstimation<uint32_t, true>;
+
+  std::vector<uint32_t> data;
+  for (int i = 0; i < 1000; ++i) {
+    data.push_back(i % 3);
+  }
+  auto stats = Statistics<uint32_t>::create(data);
+
+  auto trivialSize =
+      Est::estimateNumericSize(EncodingType::Trivial, 1000, stats);
+  auto dictSize =
+      Est::estimateNumericSize(EncodingType::Dictionary, 1000, stats);
+
+  ASSERT_TRUE(trivialSize.has_value());
+  ASSERT_TRUE(dictSize.has_value());
+  EXPECT_LT(dictSize.value(), trivialSize.value());
+}
+
+TEST_F(EncodingSizeEstimationTest, constantSmallestForConstantData) {
+  using Est = detail::EncodingSizeEstimation<uint32_t, true>;
+
+  std::vector<uint32_t> data(1000, 42);
+  auto stats = Statistics<uint32_t>::create(data);
+
+  auto constantSize =
+      Est::estimateNumericSize(EncodingType::Constant, 1000, stats);
+  auto trivialSize =
+      Est::estimateNumericSize(EncodingType::Trivial, 1000, stats);
+
+  ASSERT_TRUE(constantSize.has_value());
+  ASSERT_TRUE(trivialSize.has_value());
+  EXPECT_LT(constantSize.value(), trivialSize.value());
+}
+
+TEST_F(EncodingSizeEstimationTest, rleSmallForLongRuns) {
+  using Est = detail::EncodingSizeEstimation<uint32_t, true>;
+
+  std::vector<uint32_t> data;
+  for (int i = 0; i < 500; ++i) {
+    data.push_back(1);
+  }
+  for (int i = 0; i < 500; ++i) {
+    data.push_back(2);
+  }
+  auto stats = Statistics<uint32_t>::create(data);
+
+  auto rleSize = Est::estimateNumericSize(EncodingType::RLE, 1000, stats);
+  auto trivialSize =
+      Est::estimateNumericSize(EncodingType::Trivial, 1000, stats);
+
+  ASSERT_TRUE(rleSize.has_value());
+  ASSERT_TRUE(trivialSize.has_value());
+  EXPECT_LT(rleSize.value(), trivialSize.value());
+}
+
+TEST_F(EncodingSizeEstimationTest, fbwSmallForNarrowRange) {
+  using Est = detail::EncodingSizeEstimation<uint32_t, true>;
+
+  std::vector<uint32_t> data;
+  for (uint32_t i = 0; i < 1000; ++i) {
+    data.push_back(1000 + (i % 4));
+  }
+  auto stats = Statistics<uint32_t>::create(data);
+
+  auto fbwSize =
+      Est::estimateNumericSize(EncodingType::FixedBitWidth, 1000, stats);
+  auto trivialSize =
+      Est::estimateNumericSize(EncodingType::Trivial, 1000, stats);
+
+  ASSERT_TRUE(fbwSize.has_value());
+  ASSERT_TRUE(trivialSize.has_value());
+  EXPECT_LT(fbwSize.value(), trivialSize.value());
+}
+
+TEST_F(EncodingSizeEstimationTest, uint64AllEncodings) {
+  using Est = detail::EncodingSizeEstimation<uint64_t, true>;
+
+  std::vector<uint64_t> data;
+  for (uint64_t i = 0; i < 100; ++i) {
+    data.push_back(i);
+  }
+  auto stats = Statistics<uint64_t>::create(data);
+
+  ASSERT_TRUE(
+      Est::estimateNumericSize(EncodingType::Trivial, 100, stats).has_value());
+  ASSERT_TRUE(
+      Est::estimateNumericSize(EncodingType::FixedBitWidth, 100, stats)
+          .has_value());
+  ASSERT_TRUE(
+      Est::estimateNumericSize(EncodingType::Dictionary, 100, stats)
+          .has_value());
+  ASSERT_TRUE(
+      Est::estimateNumericSize(EncodingType::RLE, 100, stats).has_value());
+  ASSERT_TRUE(
+      Est::estimateNumericSize(EncodingType::Varint, 100, stats).has_value());
+}

--- a/dwio/nimble/encodings/tests/FixedBitWidthEncodingTest.cpp
+++ b/dwio/nimble/encodings/tests/FixedBitWidthEncodingTest.cpp
@@ -1,0 +1,360 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include <glog/logging.h>
+#include <gtest/gtest.h>
+#include "dwio/nimble/common/Buffer.h"
+#include "dwio/nimble/common/EncodingType.h"
+#include "dwio/nimble/common/Types.h"
+#include "dwio/nimble/common/Vector.h"
+#include "dwio/nimble/encodings/tests/TestUtils.h"
+#include "folly/Random.h"
+#include "velox/common/memory/Memory.h"
+
+using namespace facebook;
+
+template <bool UseVarint>
+struct FBWTestConfig {
+  static constexpr bool useVarint = UseVarint;
+};
+
+template <typename Config>
+class FixedBitWidthEncodingTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    pool_ = facebook::velox::memory::deprecatedAddDefaultLeafMemoryPool();
+    buffer_ = std::make_unique<nimble::Buffer>(*pool_);
+  }
+
+  nimble::Vector<uint32_t> toVector(std::initializer_list<uint32_t> l) {
+    nimble::Vector<uint32_t> v{pool_.get()};
+    v.insert(v.end(), l.begin(), l.end());
+    return v;
+  }
+
+  std::unique_ptr<nimble::Encoding> createEncoding(
+      const nimble::Vector<uint32_t>& values,
+      const nimble::Encoding::Options& options = {}) {
+    return nimble::test::Encoder<nimble::FixedBitWidthEncoding<uint32_t>>::
+        createEncoding(
+            *buffer_,
+            values,
+            stringBufferFactory(),
+            nimble::CompressionType::Uncompressed,
+            options);
+  }
+
+  std::function<void*(uint32_t)> stringBufferFactory() {
+    return [this](uint32_t totalLength) {
+      auto& buf = stringBuffers_.emplace_back(
+          velox::AlignedBuffer::allocate<char>(totalLength, pool_.get()));
+      return buf->template asMutable<void>();
+    };
+  }
+
+  std::shared_ptr<velox::memory::MemoryPool> pool_;
+  std::unique_ptr<nimble::Buffer> buffer_;
+  std::vector<velox::BufferPtr> stringBuffers_;
+};
+
+using TestTypes = ::testing::Types<FBWTestConfig<false>, FBWTestConfig<true>>;
+
+TYPED_TEST_CASE(FixedBitWidthEncodingTest, TestTypes);
+
+TYPED_TEST(FixedBitWidthEncodingTest, serializeThenDeserialize) {
+  const nimble::Encoding::Options options{
+      .useVarintRowCount = TypeParam::useVarint};
+
+  auto values = this->toVector({0, 1, 2, 3, 4, 5, 6, 7, 8, 9});
+  auto encoding = this->createEncoding(values, options);
+
+  EXPECT_EQ(encoding->encodingType(), nimble::EncodingType::FixedBitWidth);
+  EXPECT_EQ(encoding->dataType(), nimble::TypeTraits<uint32_t>::dataType);
+  EXPECT_EQ(encoding->rowCount(), 10);
+
+  nimble::Vector<uint32_t> result(this->pool_.get(), 10);
+  encoding->materialize(10, result.data());
+  for (uint32_t i = 0; i < 10; ++i) {
+    EXPECT_EQ(result[i], values[i]) << "index " << i;
+  }
+}
+
+TYPED_TEST(FixedBitWidthEncodingTest, singleValue) {
+  const nimble::Encoding::Options options{
+      .useVarintRowCount = TypeParam::useVarint};
+
+  auto values = this->toVector({42});
+  auto encoding = this->createEncoding(values, options);
+
+  EXPECT_EQ(encoding->rowCount(), 1);
+
+  nimble::Vector<uint32_t> result(this->pool_.get(), 1);
+  encoding->materialize(1, result.data());
+  EXPECT_EQ(result[0], 42u);
+}
+
+TYPED_TEST(FixedBitWidthEncodingTest, allZeros) {
+  const nimble::Encoding::Options options{
+      .useVarintRowCount = TypeParam::useVarint};
+
+  auto values = this->toVector({0, 0, 0, 0, 0});
+  auto encoding = this->createEncoding(values, options);
+
+  nimble::Vector<uint32_t> result(this->pool_.get(), 5);
+  encoding->materialize(5, result.data());
+  for (uint32_t i = 0; i < 5; ++i) {
+    EXPECT_EQ(result[i], 0u) << "index " << i;
+  }
+}
+
+TYPED_TEST(FixedBitWidthEncodingTest, allSameNonZero) {
+  const nimble::Encoding::Options options{
+      .useVarintRowCount = TypeParam::useVarint};
+
+  auto values = this->toVector({100, 100, 100, 100});
+  auto encoding = this->createEncoding(values, options);
+
+  nimble::Vector<uint32_t> result(this->pool_.get(), 4);
+  encoding->materialize(4, result.data());
+  for (uint32_t i = 0; i < 4; ++i) {
+    EXPECT_EQ(result[i], 100u) << "index " << i;
+  }
+}
+
+TYPED_TEST(FixedBitWidthEncodingTest, largeValues) {
+  const nimble::Encoding::Options options{
+      .useVarintRowCount = TypeParam::useVarint};
+
+  uint32_t maxVal = std::numeric_limits<uint32_t>::max();
+  uint32_t halfMax = maxVal / 2;
+  auto values = this->toVector({maxVal, halfMax, 0, halfMax, maxVal});
+  auto encoding = this->createEncoding(values, options);
+
+  nimble::Vector<uint32_t> result(this->pool_.get(), 5);
+  encoding->materialize(5, result.data());
+  for (uint32_t i = 0; i < 5; ++i) {
+    EXPECT_EQ(result[i], values[i]) << "index " << i;
+  }
+}
+
+TYPED_TEST(FixedBitWidthEncodingTest, skipThenMaterialize) {
+  const nimble::Encoding::Options options{
+      .useVarintRowCount = TypeParam::useVarint};
+
+  auto values = this->toVector({10, 20, 30, 40, 50, 60, 70, 80});
+  auto encoding = this->createEncoding(values, options);
+
+  encoding->skip(3);
+
+  nimble::Vector<uint32_t> result(this->pool_.get(), 3);
+  encoding->materialize(3, result.data());
+  for (uint32_t i = 0; i < 3; ++i) {
+    EXPECT_EQ(result[i], values[i + 3]) << "index " << i;
+  }
+}
+
+TYPED_TEST(FixedBitWidthEncodingTest, resetAndRematerialize) {
+  const nimble::Encoding::Options options{
+      .useVarintRowCount = TypeParam::useVarint};
+
+  auto values = this->toVector({5, 15, 25, 35, 45});
+  auto encoding = this->createEncoding(values, options);
+
+  nimble::Vector<uint32_t> result1(this->pool_.get(), 5);
+  encoding->materialize(5, result1.data());
+
+  encoding->reset();
+
+  nimble::Vector<uint32_t> result2(this->pool_.get(), 5);
+  encoding->materialize(5, result2.data());
+
+  for (uint32_t i = 0; i < 5; ++i) {
+    EXPECT_EQ(result1[i], result2[i]) << "index " << i;
+  }
+}
+
+TYPED_TEST(FixedBitWidthEncodingTest, incrementalMaterialize) {
+  const nimble::Encoding::Options options{
+      .useVarintRowCount = TypeParam::useVarint};
+
+  auto values = this->toVector({1, 2, 3, 4, 5, 6, 7, 8, 9, 10});
+  auto encoding = this->createEncoding(values, options);
+
+  nimble::Vector<uint32_t> result(this->pool_.get(), 10);
+  encoding->materialize(4, result.data());
+  encoding->materialize(3, result.data() + 4);
+  encoding->materialize(3, result.data() + 7);
+
+  for (uint32_t i = 0; i < 10; ++i) {
+    EXPECT_EQ(result[i], values[i]) << "index " << i;
+  }
+}
+
+TYPED_TEST(FixedBitWidthEncodingTest, materializeZeroRows) {
+  const nimble::Encoding::Options options{
+      .useVarintRowCount = TypeParam::useVarint};
+
+  auto values = this->toVector({10, 20, 30});
+  auto encoding = this->createEncoding(values, options);
+
+  nimble::Vector<uint32_t> result(this->pool_.get(), 3);
+  encoding->materialize(0, result.data());
+
+  encoding->materialize(3, result.data());
+  for (uint32_t i = 0; i < 3; ++i) {
+    EXPECT_EQ(result[i], values[i]) << "index " << i;
+  }
+}
+
+TYPED_TEST(FixedBitWidthEncodingTest, narrowBitWidth) {
+  const nimble::Encoding::Options options{
+      .useVarintRowCount = TypeParam::useVarint};
+
+  auto values = this->toVector({0, 1, 0, 1, 0, 1, 0, 1});
+  auto encoding = this->createEncoding(values, options);
+
+  nimble::Vector<uint32_t> result(this->pool_.get(), 8);
+  encoding->materialize(8, result.data());
+  for (uint32_t i = 0; i < 8; ++i) {
+    EXPECT_EQ(result[i], values[i]) << "index " << i;
+  }
+}
+
+TYPED_TEST(FixedBitWidthEncodingTest, baselineOffset) {
+  const nimble::Encoding::Options options{
+      .useVarintRowCount = TypeParam::useVarint};
+
+  auto values = this->toVector({1000, 1001, 1002, 1003, 1004});
+  auto encoding = this->createEncoding(values, options);
+
+  nimble::Vector<uint32_t> result(this->pool_.get(), 5);
+  encoding->materialize(5, result.data());
+  for (uint32_t i = 0; i < 5; ++i) {
+    EXPECT_EQ(result[i], values[i]) << "index " << i;
+  }
+}
+
+TYPED_TEST(FixedBitWidthEncodingTest, fuzz) {
+  const nimble::Encoding::Options options{
+      .useVarintRowCount = TypeParam::useVarint};
+
+  auto seed = folly::Random::rand32();
+  LOG(INFO) << "seed: " << seed;
+  std::mt19937 rng(seed);
+
+  for (int trial = 0; trial < 20; ++trial) {
+    uint32_t rowCount = folly::Random::rand32(1, 500, rng);
+    uint32_t maxBits = folly::Random::rand32(1, 32, rng);
+    uint32_t mask = maxBits >= 32 ? std::numeric_limits<uint32_t>::max()
+                                  : (uint32_t{1} << maxBits) - 1;
+    uint32_t baseline = folly::Random::rand32(rng) & ~mask;
+
+    nimble::Vector<uint32_t> values{this->pool_.get()};
+    for (uint32_t i = 0; i < rowCount; ++i) {
+      values.push_back(baseline + (folly::Random::rand32(rng) & mask));
+    }
+
+    auto encoding = this->createEncoding(values, options);
+
+    EXPECT_EQ(encoding->rowCount(), rowCount);
+
+    nimble::Vector<uint32_t> result(this->pool_.get(), rowCount);
+    encoding->materialize(rowCount, result.data());
+
+    for (uint32_t i = 0; i < rowCount; ++i) {
+      EXPECT_EQ(result[i], values[i]) << "trial " << trial << " index " << i;
+    }
+  }
+}
+
+TYPED_TEST(FixedBitWidthEncodingTest, withZstdCompression) {
+  const nimble::Encoding::Options options{
+      .useVarintRowCount = TypeParam::useVarint};
+
+  nimble::Vector<uint32_t> values{this->pool_.get()};
+  for (uint32_t i = 0; i < 200; ++i) {
+    values.push_back(i);
+  }
+
+  auto encoding = nimble::test::
+      Encoder<nimble::FixedBitWidthEncoding<uint32_t>>::createEncoding(
+          *this->buffer_,
+          values,
+          this->stringBufferFactory(),
+          nimble::CompressionType::Zstd,
+          options);
+
+  nimble::Vector<uint32_t> result(this->pool_.get(), 200);
+  encoding->materialize(200, result.data());
+  for (uint32_t i = 0; i < 200; ++i) {
+    EXPECT_EQ(result[i], values[i]) << "index " << i;
+  }
+}
+
+TYPED_TEST(FixedBitWidthEncodingTest, largeDataset) {
+  const nimble::Encoding::Options options{
+      .useVarintRowCount = TypeParam::useVarint};
+
+  nimble::Vector<uint32_t> values{this->pool_.get()};
+  for (uint32_t i = 0; i < 10000; ++i) {
+    values.push_back(1000 + (i % 256));
+  }
+
+  auto encoding = this->createEncoding(values, options);
+  EXPECT_EQ(encoding->rowCount(), 10000);
+
+  nimble::Vector<uint32_t> result(this->pool_.get(), 10000);
+  encoding->materialize(10000, result.data());
+  for (uint32_t i = 0; i < 10000; ++i) {
+    EXPECT_EQ(result[i], values[i]) << "index " << i;
+  }
+}
+
+TYPED_TEST(FixedBitWidthEncodingTest, wideRange) {
+  const nimble::Encoding::Options options{
+      .useVarintRowCount = TypeParam::useVarint};
+
+  auto values = this->toVector(
+      {0,
+       1,
+       255,
+       256,
+       65535,
+       65536,
+       16777215,
+       16777216,
+       std::numeric_limits<uint32_t>::max()});
+  auto encoding = this->createEncoding(values, options);
+
+  nimble::Vector<uint32_t> result(this->pool_.get(), values.size());
+  encoding->materialize(values.size(), result.data());
+  for (uint32_t i = 0; i < values.size(); ++i) {
+    EXPECT_EQ(result[i], values[i]) << "index " << i;
+  }
+}
+
+TYPED_TEST(FixedBitWidthEncodingTest, skipToEnd) {
+  const nimble::Encoding::Options options{
+      .useVarintRowCount = TypeParam::useVarint};
+
+  auto values = this->toVector({10, 20, 30, 40, 50});
+  auto encoding = this->createEncoding(values, options);
+
+  encoding->skip(4);
+
+  nimble::Vector<uint32_t> result(this->pool_.get(), 1);
+  encoding->materialize(1, result.data());
+  EXPECT_EQ(result[0], 50u);
+}

--- a/dwio/nimble/encodings/tests/SparseBoolEncodingTest.cpp
+++ b/dwio/nimble/encodings/tests/SparseBoolEncodingTest.cpp
@@ -1,0 +1,359 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "dwio/nimble/encodings/SparseBoolEncoding.h"
+#include <glog/logging.h>
+#include <gtest/gtest.h>
+#include "dwio/nimble/common/Buffer.h"
+#include "dwio/nimble/common/EncodingType.h"
+#include "dwio/nimble/common/Types.h"
+#include "dwio/nimble/common/Vector.h"
+#include "dwio/nimble/encodings/tests/TestUtils.h"
+#include "folly/Random.h"
+#include "velox/common/memory/Memory.h"
+
+using namespace facebook;
+
+template <bool UseVarint>
+struct SparseBoolTestConfig {
+  static constexpr bool useVarint = UseVarint;
+};
+
+template <typename Config>
+class SparseBoolEncodingTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    pool_ = facebook::velox::memory::deprecatedAddDefaultLeafMemoryPool();
+    buffer_ = std::make_unique<nimble::Buffer>(*pool_);
+  }
+
+  nimble::Vector<bool> toVector(std::initializer_list<bool> l) {
+    nimble::Vector<bool> v{pool_.get()};
+    v.insert(v.end(), l.begin(), l.end());
+    return v;
+  }
+
+  std::unique_ptr<nimble::Encoding> createEncoding(
+      const nimble::Vector<bool>& values,
+      const nimble::Encoding::Options& options = {}) {
+    return nimble::test::Encoder<nimble::SparseBoolEncoding>::createEncoding(
+        *buffer_,
+        values,
+        stringBufferFactory(),
+        nimble::CompressionType::Uncompressed,
+        options);
+  }
+
+  std::function<void*(uint32_t)> stringBufferFactory() {
+    return [this](uint32_t totalLength) {
+      auto& buf = stringBuffers_.emplace_back(
+          velox::AlignedBuffer::allocate<char>(totalLength, pool_.get()));
+      return buf->template asMutable<void>();
+    };
+  }
+
+  std::shared_ptr<velox::memory::MemoryPool> pool_;
+  std::unique_ptr<nimble::Buffer> buffer_;
+  std::vector<velox::BufferPtr> stringBuffers_;
+};
+
+using TestTypes =
+    ::testing::Types<SparseBoolTestConfig<false>, SparseBoolTestConfig<true>>;
+
+TYPED_TEST_CASE(SparseBoolEncodingTest, TestTypes);
+
+TYPED_TEST(SparseBoolEncodingTest, allFalse) {
+  const nimble::Encoding::Options options{
+      .useVarintRowCount = TypeParam::useVarint};
+  auto values = this->toVector({false, false, false, false, false});
+  auto encoding = this->createEncoding(values, options);
+
+  EXPECT_EQ(encoding->encodingType(), nimble::EncodingType::SparseBool);
+  EXPECT_EQ(encoding->dataType(), nimble::DataType::Bool);
+  EXPECT_EQ(encoding->rowCount(), 5);
+
+  nimble::Vector<bool> result(this->pool_.get(), 5);
+  encoding->materialize(5, result.data());
+  for (uint32_t i = 0; i < 5; ++i) {
+    EXPECT_EQ(result[i], false) << "index " << i;
+  }
+}
+
+TYPED_TEST(SparseBoolEncodingTest, allTrue) {
+  const nimble::Encoding::Options options{
+      .useVarintRowCount = TypeParam::useVarint};
+  auto values = this->toVector({true, true, true, true, true});
+  auto encoding = this->createEncoding(values, options);
+
+  EXPECT_EQ(encoding->encodingType(), nimble::EncodingType::SparseBool);
+  EXPECT_EQ(encoding->rowCount(), 5);
+
+  nimble::Vector<bool> result(this->pool_.get(), 5);
+  encoding->materialize(5, result.data());
+  for (uint32_t i = 0; i < 5; ++i) {
+    EXPECT_EQ(result[i], true) << "index " << i;
+  }
+}
+
+TYPED_TEST(SparseBoolEncodingTest, sparseTrue) {
+  const nimble::Encoding::Options options{
+      .useVarintRowCount = TypeParam::useVarint};
+  auto values = this->toVector(
+      {false, false, true, false, false, false, false, false, false, false});
+  auto encoding = this->createEncoding(values, options);
+
+  EXPECT_EQ(encoding->rowCount(), 10);
+
+  nimble::Vector<bool> result(this->pool_.get(), 10);
+  encoding->materialize(10, result.data());
+  for (uint32_t i = 0; i < 10; ++i) {
+    EXPECT_EQ(result[i], values[i]) << "index " << i;
+  }
+}
+
+TYPED_TEST(SparseBoolEncodingTest, sparseFalse) {
+  const nimble::Encoding::Options options{
+      .useVarintRowCount = TypeParam::useVarint};
+  auto values = this->toVector(
+      {true, true, false, true, true, true, true, true, true, true});
+  auto encoding = this->createEncoding(values, options);
+
+  EXPECT_EQ(encoding->rowCount(), 10);
+
+  nimble::Vector<bool> result(this->pool_.get(), 10);
+  encoding->materialize(10, result.data());
+  for (uint32_t i = 0; i < 10; ++i) {
+    EXPECT_EQ(result[i], values[i]) << "index " << i;
+  }
+}
+
+TYPED_TEST(SparseBoolEncodingTest, singleElement) {
+  const nimble::Encoding::Options options{
+      .useVarintRowCount = TypeParam::useVarint};
+  for (bool val : {true, false}) {
+    nimble::Vector<bool> values{this->pool_.get()};
+    values.push_back(val);
+    auto encoding = this->createEncoding(values, options);
+
+    EXPECT_EQ(encoding->rowCount(), 1);
+
+    nimble::Vector<bool> result(this->pool_.get(), 1);
+    encoding->materialize(1, result.data());
+    EXPECT_EQ(result[0], val);
+  }
+}
+
+TYPED_TEST(SparseBoolEncodingTest, skipThenMaterialize) {
+  const nimble::Encoding::Options options{
+      .useVarintRowCount = TypeParam::useVarint};
+  auto values = this->toVector(
+      {false, false, true, false, true, false, false, true, false, false});
+  auto encoding = this->createEncoding(values, options);
+
+  encoding->skip(3);
+
+  nimble::Vector<bool> result(this->pool_.get(), 4);
+  encoding->materialize(4, result.data());
+  for (uint32_t i = 0; i < 4; ++i) {
+    EXPECT_EQ(result[i], values[i + 3]) << "index " << i;
+  }
+}
+
+TYPED_TEST(SparseBoolEncodingTest, resetAndRematerialize) {
+  const nimble::Encoding::Options options{
+      .useVarintRowCount = TypeParam::useVarint};
+  auto values = this->toVector({true, false, true, false, true});
+  auto encoding = this->createEncoding(values, options);
+
+  nimble::Vector<bool> result1(this->pool_.get(), 5);
+  encoding->materialize(5, result1.data());
+
+  encoding->reset();
+
+  nimble::Vector<bool> result2(this->pool_.get(), 5);
+  encoding->materialize(5, result2.data());
+
+  for (uint32_t i = 0; i < 5; ++i) {
+    EXPECT_EQ(result1[i], result2[i]) << "index " << i;
+  }
+}
+
+TYPED_TEST(SparseBoolEncodingTest, materializeZeroRows) {
+  const nimble::Encoding::Options options{
+      .useVarintRowCount = TypeParam::useVarint};
+  auto values = this->toVector({true, false, true});
+  auto encoding = this->createEncoding(values, options);
+
+  nimble::Vector<bool> result(this->pool_.get(), 3);
+  encoding->materialize(0, result.data());
+
+  encoding->materialize(3, result.data());
+  for (uint32_t i = 0; i < 3; ++i) {
+    EXPECT_EQ(result[i], values[i]) << "index " << i;
+  }
+}
+
+TYPED_TEST(SparseBoolEncodingTest, materializeBoolsAsBits) {
+  const nimble::Encoding::Options options{
+      .useVarintRowCount = TypeParam::useVarint};
+  auto values = this->toVector(
+      {false, false, true, false, true, false, false, true, false, false});
+  auto encoding = this->createEncoding(values, options);
+
+  uint64_t buffer[1] = {0};
+  auto* typedEncoding =
+      dynamic_cast<nimble::SparseBoolEncoding*>(encoding.get());
+  ASSERT_NE(typedEncoding, nullptr);
+  typedEncoding->materializeBoolsAsBits(10, buffer, 0);
+
+  for (uint32_t i = 0; i < 10; ++i) {
+    EXPECT_EQ(velox::bits::isBitSet(buffer, i), values[i]) << "index " << i;
+  }
+}
+
+TYPED_TEST(SparseBoolEncodingTest, materializeBoolsAsBitsWithOffset) {
+  const nimble::Encoding::Options options{
+      .useVarintRowCount = TypeParam::useVarint};
+  auto values = this->toVector({true, false, true, false});
+  auto encoding = this->createEncoding(values, options);
+
+  uint64_t buffer[1] = {0};
+  auto* typedEncoding =
+      dynamic_cast<nimble::SparseBoolEncoding*>(encoding.get());
+  ASSERT_NE(typedEncoding, nullptr);
+  typedEncoding->materializeBoolsAsBits(4, buffer, 3);
+
+  for (uint32_t i = 0; i < 4; ++i) {
+    EXPECT_EQ(velox::bits::isBitSet(buffer, i + 3), values[i]) << "index " << i;
+  }
+}
+
+TYPED_TEST(SparseBoolEncodingTest, incrementalMaterialize) {
+  const nimble::Encoding::Options options{
+      .useVarintRowCount = TypeParam::useVarint};
+  auto values = this->toVector(
+      {true, false, true, false, true, false, true, false, true, false});
+  auto encoding = this->createEncoding(values, options);
+
+  nimble::Vector<bool> result(this->pool_.get(), 10);
+  encoding->materialize(3, result.data());
+  encoding->materialize(4, result.data() + 3);
+  encoding->materialize(3, result.data() + 7);
+
+  for (uint32_t i = 0; i < 10; ++i) {
+    EXPECT_EQ(result[i], values[i]) << "index " << i;
+  }
+}
+
+TYPED_TEST(SparseBoolEncodingTest, fuzz) {
+  const nimble::Encoding::Options options{
+      .useVarintRowCount = TypeParam::useVarint};
+  auto seed = folly::Random::rand32();
+  LOG(INFO) << "seed: " << seed;
+  std::mt19937 rng(seed);
+
+  for (int trial = 0; trial < 20; ++trial) {
+    uint32_t rowCount = folly::Random::rand32(1, 500, rng);
+    double sparsity = folly::Random::randDouble01(rng) * 0.1;
+
+    nimble::Vector<bool> values{this->pool_.get()};
+    for (uint32_t i = 0; i < rowCount; ++i) {
+      values.push_back(folly::Random::randDouble01(rng) < sparsity);
+    }
+
+    auto encoding = this->createEncoding(values, options);
+
+    EXPECT_EQ(encoding->rowCount(), rowCount);
+
+    nimble::Vector<bool> result(this->pool_.get(), rowCount);
+    encoding->materialize(rowCount, result.data());
+
+    for (uint32_t i = 0; i < rowCount; ++i) {
+      EXPECT_EQ(result[i], values[i]) << "trial " << trial << " index " << i;
+    }
+  }
+}
+
+TYPED_TEST(SparseBoolEncodingTest, withZstdCompression) {
+  const nimble::Encoding::Options options{
+      .useVarintRowCount = TypeParam::useVarint};
+  auto values = this->toVector({false, false, true,  false, false, false, false,
+                                false, true,  false, false, false, false, false,
+                                false, false, false, false, false, false});
+
+  auto encoding =
+      nimble::test::Encoder<nimble::SparseBoolEncoding>::createEncoding(
+          *this->buffer_,
+          values,
+          this->stringBufferFactory(),
+          nimble::CompressionType::Zstd,
+          options);
+
+  nimble::Vector<bool> result(this->pool_.get(), values.size());
+  encoding->materialize(values.size(), result.data());
+  for (uint32_t i = 0; i < values.size(); ++i) {
+    EXPECT_EQ(result[i], values[i]) << "index " << i;
+  }
+}
+
+TYPED_TEST(SparseBoolEncodingTest, largeDataset) {
+  const nimble::Encoding::Options options{
+      .useVarintRowCount = TypeParam::useVarint};
+  nimble::Vector<bool> values{this->pool_.get()};
+  for (uint32_t i = 0; i < 10000; ++i) {
+    values.push_back(i % 100 == 0);
+  }
+
+  auto encoding = this->createEncoding(values, options);
+  EXPECT_EQ(encoding->rowCount(), 10000);
+
+  nimble::Vector<bool> result(this->pool_.get(), 10000);
+  encoding->materialize(10000, result.data());
+  for (uint32_t i = 0; i < 10000; ++i) {
+    EXPECT_EQ(result[i], values[i]) << "index " << i;
+  }
+}
+
+TYPED_TEST(SparseBoolEncodingTest, alternatingPattern) {
+  const nimble::Encoding::Options options{
+      .useVarintRowCount = TypeParam::useVarint};
+  nimble::Vector<bool> values{this->pool_.get()};
+  for (uint32_t i = 0; i < 200; ++i) {
+    values.push_back(i % 2 == 0);
+  }
+
+  auto encoding = this->createEncoding(values, options);
+
+  nimble::Vector<bool> result(this->pool_.get(), 200);
+  encoding->materialize(200, result.data());
+  for (uint32_t i = 0; i < 200; ++i) {
+    EXPECT_EQ(result[i], values[i]) << "index " << i;
+  }
+}
+
+TYPED_TEST(SparseBoolEncodingTest, skipAllThenMaterializeRemaining) {
+  const nimble::Encoding::Options options{
+      .useVarintRowCount = TypeParam::useVarint};
+  auto values = this->toVector(
+      {false, false, true, false, true, false, false, true, false, true});
+  auto encoding = this->createEncoding(values, options);
+
+  encoding->skip(8);
+
+  nimble::Vector<bool> result(this->pool_.get(), 2);
+  encoding->materialize(2, result.data());
+  EXPECT_EQ(result[0], values[8]);
+  EXPECT_EQ(result[1], values[9]);
+}

--- a/dwio/nimble/encodings/tests/VarintEncodingTest.cpp
+++ b/dwio/nimble/encodings/tests/VarintEncodingTest.cpp
@@ -1,0 +1,340 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include <glog/logging.h>
+#include <gtest/gtest.h>
+#include "dwio/nimble/common/Buffer.h"
+#include "dwio/nimble/common/EncodingType.h"
+#include "dwio/nimble/common/Types.h"
+#include "dwio/nimble/common/Vector.h"
+#include "dwio/nimble/encodings/tests/TestUtils.h"
+#include "folly/Random.h"
+#include "velox/common/memory/Memory.h"
+
+using namespace facebook;
+
+template <bool UseVarint>
+struct VarintTestConfig {
+  static constexpr bool useVarint = UseVarint;
+};
+
+template <typename Config>
+class VarintEncodingTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    pool_ = facebook::velox::memory::deprecatedAddDefaultLeafMemoryPool();
+    buffer_ = std::make_unique<nimble::Buffer>(*pool_);
+  }
+
+  nimble::Vector<uint32_t> toVector(std::initializer_list<uint32_t> l) {
+    nimble::Vector<uint32_t> v{pool_.get()};
+    v.insert(v.end(), l.begin(), l.end());
+    return v;
+  }
+
+  std::unique_ptr<nimble::Encoding> createEncoding(
+      const nimble::Vector<uint32_t>& values,
+      const nimble::Encoding::Options& options = {}) {
+    return nimble::test::Encoder<nimble::VarintEncoding<uint32_t>>::
+        createEncoding(
+            *buffer_,
+            values,
+            stringBufferFactory(),
+            nimble::CompressionType::Uncompressed,
+            options);
+  }
+
+  std::function<void*(uint32_t)> stringBufferFactory() {
+    return [this](uint32_t totalLength) {
+      auto& buf = stringBuffers_.emplace_back(
+          velox::AlignedBuffer::allocate<char>(totalLength, pool_.get()));
+      return buf->template asMutable<void>();
+    };
+  }
+
+  std::shared_ptr<velox::memory::MemoryPool> pool_;
+  std::unique_ptr<nimble::Buffer> buffer_;
+  std::vector<velox::BufferPtr> stringBuffers_;
+};
+
+using TestTypes =
+    ::testing::Types<VarintTestConfig<false>, VarintTestConfig<true>>;
+
+TYPED_TEST_CASE(VarintEncodingTest, TestTypes);
+
+TYPED_TEST(VarintEncodingTest, serializeThenDeserialize) {
+  const nimble::Encoding::Options options{
+      .useVarintRowCount = TypeParam::useVarint};
+
+  auto values = this->toVector({0, 1, 127, 128, 255, 256, 1000});
+  auto encoding = this->createEncoding(values, options);
+
+  EXPECT_EQ(encoding->encodingType(), nimble::EncodingType::Varint);
+  EXPECT_EQ(encoding->dataType(), nimble::TypeTraits<uint32_t>::dataType);
+  EXPECT_EQ(encoding->rowCount(), 7);
+
+  nimble::Vector<uint32_t> result(this->pool_.get(), 7);
+  encoding->materialize(7, result.data());
+  for (uint32_t i = 0; i < 7; ++i) {
+    EXPECT_EQ(result[i], values[i]) << "index " << i;
+  }
+}
+
+TYPED_TEST(VarintEncodingTest, singleValue) {
+  const nimble::Encoding::Options options{
+      .useVarintRowCount = TypeParam::useVarint};
+
+  auto values = this->toVector({42});
+  auto encoding = this->createEncoding(values, options);
+
+  EXPECT_EQ(encoding->rowCount(), 1);
+
+  nimble::Vector<uint32_t> result(this->pool_.get(), 1);
+  encoding->materialize(1, result.data());
+  EXPECT_EQ(result[0], 42u);
+}
+
+TYPED_TEST(VarintEncodingTest, allZeros) {
+  const nimble::Encoding::Options options{
+      .useVarintRowCount = TypeParam::useVarint};
+
+  auto values = this->toVector({0, 0, 0, 0, 0});
+  auto encoding = this->createEncoding(values, options);
+
+  nimble::Vector<uint32_t> result(this->pool_.get(), 5);
+  encoding->materialize(5, result.data());
+  for (uint32_t i = 0; i < 5; ++i) {
+    EXPECT_EQ(result[i], 0u) << "index " << i;
+  }
+}
+
+TYPED_TEST(VarintEncodingTest, allSameNonZero) {
+  const nimble::Encoding::Options options{
+      .useVarintRowCount = TypeParam::useVarint};
+
+  auto values = this->toVector({12345, 12345, 12345, 12345});
+  auto encoding = this->createEncoding(values, options);
+
+  nimble::Vector<uint32_t> result(this->pool_.get(), 4);
+  encoding->materialize(4, result.data());
+  for (uint32_t i = 0; i < 4; ++i) {
+    EXPECT_EQ(result[i], 12345u) << "index " << i;
+  }
+}
+
+TYPED_TEST(VarintEncodingTest, varintBoundaryValues) {
+  const nimble::Encoding::Options options{
+      .useVarintRowCount = TypeParam::useVarint};
+
+  auto values = this->toVector({0, 127, 128, 16383, 16384, 2097151, 2097152});
+  auto encoding = this->createEncoding(values, options);
+
+  nimble::Vector<uint32_t> result(this->pool_.get(), values.size());
+  encoding->materialize(values.size(), result.data());
+  for (uint32_t i = 0; i < values.size(); ++i) {
+    EXPECT_EQ(result[i], values[i]) << "index " << i;
+  }
+}
+
+TYPED_TEST(VarintEncodingTest, largeValues) {
+  const nimble::Encoding::Options options{
+      .useVarintRowCount = TypeParam::useVarint};
+
+  uint32_t maxVal = std::numeric_limits<uint32_t>::max();
+  uint32_t halfMax = maxVal / 2;
+  auto values = this->toVector({maxVal, halfMax, 0, halfMax, maxVal});
+  auto encoding = this->createEncoding(values, options);
+
+  nimble::Vector<uint32_t> result(this->pool_.get(), 5);
+  encoding->materialize(5, result.data());
+  for (uint32_t i = 0; i < 5; ++i) {
+    EXPECT_EQ(result[i], values[i]) << "index " << i;
+  }
+}
+
+TYPED_TEST(VarintEncodingTest, skipThenMaterialize) {
+  const nimble::Encoding::Options options{
+      .useVarintRowCount = TypeParam::useVarint};
+
+  auto values = this->toVector({10, 20, 30, 40, 50, 60, 70, 80});
+  auto encoding = this->createEncoding(values, options);
+
+  encoding->skip(3);
+
+  nimble::Vector<uint32_t> result(this->pool_.get(), 3);
+  encoding->materialize(3, result.data());
+  for (uint32_t i = 0; i < 3; ++i) {
+    EXPECT_EQ(result[i], values[i + 3]) << "index " << i;
+  }
+}
+
+TYPED_TEST(VarintEncodingTest, resetAndRematerialize) {
+  const nimble::Encoding::Options options{
+      .useVarintRowCount = TypeParam::useVarint};
+
+  auto values = this->toVector({5, 15, 25, 35, 45});
+  auto encoding = this->createEncoding(values, options);
+
+  nimble::Vector<uint32_t> result1(this->pool_.get(), 5);
+  encoding->materialize(5, result1.data());
+
+  encoding->reset();
+
+  nimble::Vector<uint32_t> result2(this->pool_.get(), 5);
+  encoding->materialize(5, result2.data());
+
+  for (uint32_t i = 0; i < 5; ++i) {
+    EXPECT_EQ(result1[i], result2[i]) << "index " << i;
+  }
+}
+
+TYPED_TEST(VarintEncodingTest, incrementalMaterialize) {
+  const nimble::Encoding::Options options{
+      .useVarintRowCount = TypeParam::useVarint};
+
+  auto values = this->toVector({1, 2, 3, 4, 5, 6, 7, 8, 9, 10});
+  auto encoding = this->createEncoding(values, options);
+
+  nimble::Vector<uint32_t> result(this->pool_.get(), 10);
+  encoding->materialize(4, result.data());
+  encoding->materialize(3, result.data() + 4);
+  encoding->materialize(3, result.data() + 7);
+
+  for (uint32_t i = 0; i < 10; ++i) {
+    EXPECT_EQ(result[i], values[i]) << "index " << i;
+  }
+}
+
+TYPED_TEST(VarintEncodingTest, materializeZeroRows) {
+  const nimble::Encoding::Options options{
+      .useVarintRowCount = TypeParam::useVarint};
+
+  auto values = this->toVector({10, 20, 30});
+  auto encoding = this->createEncoding(values, options);
+
+  nimble::Vector<uint32_t> result(this->pool_.get(), 3);
+  encoding->materialize(0, result.data());
+
+  encoding->materialize(3, result.data());
+  for (uint32_t i = 0; i < 3; ++i) {
+    EXPECT_EQ(result[i], values[i]) << "index " << i;
+  }
+}
+
+TYPED_TEST(VarintEncodingTest, fuzz) {
+  const nimble::Encoding::Options options{
+      .useVarintRowCount = TypeParam::useVarint};
+
+  auto seed = folly::Random::rand32();
+  LOG(INFO) << "seed: " << seed;
+  std::mt19937 rng(seed);
+
+  for (int trial = 0; trial < 20; ++trial) {
+    uint32_t rowCount = folly::Random::rand32(1, 500, rng);
+
+    nimble::Vector<uint32_t> values{this->pool_.get()};
+    for (uint32_t i = 0; i < rowCount; ++i) {
+      values.push_back(folly::Random::rand32(rng));
+    }
+
+    auto encoding = this->createEncoding(values, options);
+
+    EXPECT_EQ(encoding->rowCount(), rowCount);
+
+    nimble::Vector<uint32_t> result(this->pool_.get(), rowCount);
+    encoding->materialize(rowCount, result.data());
+
+    for (uint32_t i = 0; i < rowCount; ++i) {
+      EXPECT_EQ(result[i], values[i]) << "trial " << trial << " index " << i;
+    }
+  }
+}
+
+TYPED_TEST(VarintEncodingTest, largeDataset) {
+  const nimble::Encoding::Options options{
+      .useVarintRowCount = TypeParam::useVarint};
+
+  nimble::Vector<uint32_t> values{this->pool_.get()};
+  for (uint32_t i = 0; i < 10000; ++i) {
+    values.push_back(i * 7);
+  }
+
+  auto encoding = this->createEncoding(values, options);
+  EXPECT_EQ(encoding->rowCount(), 10000);
+
+  nimble::Vector<uint32_t> result(this->pool_.get(), 10000);
+  encoding->materialize(10000, result.data());
+  for (uint32_t i = 0; i < 10000; ++i) {
+    EXPECT_EQ(result[i], values[i]) << "index " << i;
+  }
+}
+
+TYPED_TEST(VarintEncodingTest, multiByteVarintValues) {
+  const nimble::Encoding::Options options{
+      .useVarintRowCount = TypeParam::useVarint};
+
+  auto values = this->toVector(
+      {0,
+       (1u << 7) - 1,
+       1u << 7,
+       (1u << 14) - 1,
+       1u << 14,
+       (1u << 21) - 1,
+       1u << 21,
+       (1u << 28) - 1,
+       1u << 28,
+       std::numeric_limits<uint32_t>::max()});
+  auto encoding = this->createEncoding(values, options);
+
+  nimble::Vector<uint32_t> result(this->pool_.get(), values.size());
+  encoding->materialize(values.size(), result.data());
+  for (uint32_t i = 0; i < values.size(); ++i) {
+    EXPECT_EQ(result[i], values[i]) << "index " << i;
+  }
+}
+
+TYPED_TEST(VarintEncodingTest, skipToEnd) {
+  const nimble::Encoding::Options options{
+      .useVarintRowCount = TypeParam::useVarint};
+
+  auto values = this->toVector({10, 20, 30, 40, 50});
+  auto encoding = this->createEncoding(values, options);
+
+  encoding->skip(4);
+
+  nimble::Vector<uint32_t> result(this->pool_.get(), 1);
+  encoding->materialize(1, result.data());
+  EXPECT_EQ(result[0], 50u);
+}
+
+TYPED_TEST(VarintEncodingTest, monotonicallyIncreasing) {
+  const nimble::Encoding::Options options{
+      .useVarintRowCount = TypeParam::useVarint};
+
+  nimble::Vector<uint32_t> values{this->pool_.get()};
+  uint32_t val = 0;
+  for (uint32_t i = 0; i < 100; ++i) {
+    val += i;
+    values.push_back(val);
+  }
+
+  auto encoding = this->createEncoding(values, options);
+
+  nimble::Vector<uint32_t> result(this->pool_.get(), 100);
+  encoding->materialize(100, result.data());
+  for (uint32_t i = 0; i < 100; ++i) {
+    EXPECT_EQ(result[i], values[i]) << "index " << i;
+  }
+}


### PR DESCRIPTION
Summary: The `dwio/nimble/encodings/` directory had three encoding implementations without dedicated test files (`SparseBoolEncoding`, `FixedBitWidthEncoding`, `VarintEncoding`) and the `EncodingSizeEstimation` utility class was entirely untested. This diff adds 117 new tests bringing the total from 1,550 to 1,667, improving encoding-level test coverage from 82% (14/17) to 100% (17/17).

Differential Revision: D105440002


