### PR TITLE
Return resume key string instead of EncodedKeyBounds from NimbleIndexProjector (#742)

### DIFF
--- a/dwio/nimble/velox/index/NimbleIndexProjector.cpp
+++ b/dwio/nimble/velox/index/NimbleIndexProjector.cpp
@@ -377,21 +377,22 @@ void NimbleIndexProjector::setResumeKeys(
             nextRanges.begin(), nextRanges.end(), [&](const auto& range) {
               return range.requestIndex == request.requestIndex;
             })) {
-      const auto& keyBounds = request_->keyBounds[request.requestIndex];
-      response.resumeKey = velox::serializer::EncodedKeyBounds{
-          .lowerKey = resumeKey, .upperKey = keyBounds.upperKey};
+      response.resumeKey = resumeKey;
     }
   }
 
   // For requests that were never started (empty slices, no resume key),
-  // set resume key to their original bounds so the caller can retry.
+  // set resume key to their original lower key so the caller can retry.
   for (size_t i = 0; i < result.responses.size(); ++i) {
     auto& response = result.responses[i];
     if (response.slices.empty() && !response.resumeKey.has_value()) {
       const auto& keyBounds = request_->keyBounds[i];
-      if (keyBounds.lowerKey.has_value()) {
-        response.resumeKey = keyBounds;
-      }
+      NIMBLE_CHECK(
+          keyBounds.lowerKey.has_value(),
+          "Request {} has no lowerKey: unbounded lower requests start from "
+          "stripe 0 and should have been processed before truncation",
+          i);
+      response.resumeKey = *keyBounds.lowerKey;
     }
   }
 }

--- a/dwio/nimble/velox/index/NimbleIndexProjector.h
+++ b/dwio/nimble/velox/index/NimbleIndexProjector.h
@@ -107,9 +107,10 @@ class NimbleIndexProjector {
     /// Slices into Result::chunks for this request. Empty for miss.
     std::vector<ChunkSlice> slices;
 
-    /// If the result was truncated (e.g. by maxResultBytes), the encoded
-    /// resume key for the next project() call. nullopt if complete or miss.
-    std::optional<velox::serializer::EncodedKeyBounds> resumeKey;
+    /// If the result was truncated by maxRows, the encoded resume key for
+    /// continuation. The caller constructs new key bounds using this as
+    /// lowerKey with their original upperKey. nullopt if complete or miss.
+    std::optional<std::string> resumeKey;
   };
 
   /// Result of a project() call.

--- a/dwio/nimble/velox/index/tests/NimbleIndexProjectorTest.cpp
+++ b/dwio/nimble/velox/index/tests/NimbleIndexProjectorTest.cpp
@@ -1157,8 +1157,7 @@ TEST_P(NimbleIndexProjectorTest, resumeKeyOnTruncation) {
 
   // Resume key must be set since the request spans more stripes.
   ASSERT_TRUE(response.resumeKey.has_value());
-  EXPECT_TRUE(response.resumeKey->lowerKey.has_value());
-  EXPECT_EQ(response.resumeKey->upperKey, bounds.upperKey);
+  EXPECT_FALSE(response.resumeKey->empty());
 }
 
 TEST_P(NimbleIndexProjectorTest, resumeKeyNotSetWithoutTruncation) {
@@ -1315,7 +1314,9 @@ TEST_P(NimbleIndexProjectorTest, resumeKeyPagination) {
       break;
     }
 
-    currentBounds = response.resumeKey.value();
+    currentBounds = velox::serializer::EncodedKeyBounds{
+        .lowerKey = response.resumeKey.value(),
+        .upperKey = currentBounds.upperKey};
     ASSERT_LT(pageCount, 100) << "Pagination loop exceeded safety limit";
   }
 
@@ -1358,13 +1359,12 @@ TEST_P(NimbleIndexProjectorTest, maxRowsTotalAcrossRequests) {
     EXPECT_TRUE(response.resumeKey.has_value());
   }
 
-  // Request 1: stripe 9 was never processed, resume key = original start key.
+  // Request 1: stripe 9 was never processed, resume key = original lower key.
   {
     const auto& response = result.responses[1];
     EXPECT_TRUE(response.slices.empty());
     ASSERT_TRUE(response.resumeKey.has_value());
-    EXPECT_EQ(response.resumeKey->lowerKey, bounds1.lowerKey);
-    EXPECT_EQ(response.resumeKey->upperKey, bounds1.upperKey);
+    EXPECT_EQ(response.resumeKey.value(), bounds1.lowerKey);
   }
 }
 
@@ -1721,7 +1721,9 @@ TEST_P(NimbleIndexProjectorTest, maxRowsLargeScale) {
       if (!result.responses[0].resumeKey.has_value()) {
         break;
       }
-      currentBounds = result.responses[0].resumeKey.value();
+      currentBounds = velox::serializer::EncodedKeyBounds{
+          .lowerKey = result.responses[0].resumeKey.value(),
+          .upperKey = currentBounds.upperKey};
     }
     EXPECT_LT(pages, 100);
     return totalReadRows;
@@ -1771,11 +1773,10 @@ TEST_P(NimbleIndexProjectorTest, maxRowsMultiRequestMixedSatisfaction) {
   EXPECT_FALSE(result.responses[2].slices.empty());
   EXPECT_TRUE(result.responses[2].resumeKey.has_value());
 
-  // Request 3: stripe 9 never processed, resume key = original start key.
+  // Request 3: stripe 9 never processed, resume key = original lower key.
   EXPECT_TRUE(result.responses[3].slices.empty());
   ASSERT_TRUE(result.responses[3].resumeKey.has_value());
-  EXPECT_EQ(result.responses[3].resumeKey->lowerKey, bounds3.lowerKey);
-  EXPECT_EQ(result.responses[3].resumeKey->upperKey, bounds3.upperKey);
+  EXPECT_EQ(result.responses[3].resumeKey.value(), bounds3.lowerKey);
 }
 
 INSTANTIATE_TEST_CASE_P(


### PR DESCRIPTION
Summary:

Simplify the `NimbleIndexProjector::Response::resumeKey` type from `std::optional<EncodedKeyBounds>` to `std::optional<std::string>`. The projector now returns just the encoded resume key string, and the caller constructs the new `EncodedKeyBounds` by combining the resume key (as `lowerKey`) with their original `upperKey`. This is a cleaner API because the response does not need to carry the original upper key -- the caller already has it.

Reviewed By: duxiao1212

Differential Revision: D105488554


