### PR TITLE
feat(selective): Extend dictionary encoding optimization to more nested encoding layouts (#744)

### DIFF
--- a/dwio/nimble/encodings/DictionaryEncoding.h
+++ b/dwio/nimble/encodings/DictionaryEncoding.h
@@ -66,6 +66,10 @@ class DictionaryEncoding
   template <typename V>
   void readIndicesWithVisitor(V& visitor, ReadWithVisitorParams& params);
 
+  void materializeIndices(uint32_t rowCount, uint32_t* buffer) override {
+    indicesEncoding_->materialize(rowCount, buffer);
+  }
+
   static std::string_view encode(
       EncodingSelection<physicalType>& selection,
       std::span<const physicalType> values,
@@ -230,14 +234,52 @@ void DictionaryEncoding<T>::readWithVisitor(
 
 /// Reads indices only without looking up values from the alphabet.
 /// This is used for dictionary-aware readers that return DictionaryVector.
+/// Uses materializeIndices to avoid recursing through the visitor machinery,
+/// which would incorrectly call addNumValues from the inner encoding.
 template <typename T>
 template <typename V>
 void DictionaryEncoding<T>::readIndicesWithVisitor(
     V& visitor,
     ReadWithVisitorParams& params) {
-  // Call readWithVisitor on the indices encoding directly.
-  // The visitor is expected to handle int32_t values (dictionary indices).
-  callReadWithVisitor(*indicesEncoding_, visitor, params);
+  NIMBLE_CHECK(this->dictionaryEnabled());
+  NIMBLE_CHECK(
+      !V::kHasFilter && !V::kHasHook,
+      "readIndicesWithVisitor should only be invoked in dictionary fast path");
+  const auto numReadRows =
+      visitor.rowAt(visitor.numRows() - 1) - params.numScanned + 1;
+  auto* rawNulls = visitor.reader().rawNullsInReadRange();
+  const auto numNonNulls = rawNulls != nullptr
+      ? velox::bits::countNonNulls(
+            rawNulls, params.numScanned, params.numScanned + numReadRows)
+      : numReadRows;
+
+  // Dense fast path: materialize directly into rawValues_, scatter for nulls.
+  if (V::dense) {
+    NIMBLE_CHECK_EQ(
+        visitor.rowAt(visitor.numRows() - 1),
+        visitor.rowAt(0) + visitor.numRows() - 1,
+        "Dense visitor must have contiguous rows");
+    detail::readDenseMaterializedIndices(
+        *this, visitor, rawNulls, params.numScanned, numReadRows, numNonNulls);
+    return;
+  }
+
+  // Sparse path: materialize all rows into buffer, gather only the
+  // requested positions into rawValues_.
+  // TODO: Use FBW's random-access fixedBitArray_.get() to avoid
+  // materializing unrequested rows. Requires templated
+  // materializeIndices — see commented-out API mock-ups in this file
+  // and EncodingUtils.h.
+  indicesBuffer_.resize(numNonNulls);
+  detail::readSparseMaterializedIndices(
+      *this,
+      visitor,
+      params.numScanned,
+      params.prepareResultNulls,
+      rawNulls,
+      numReadRows,
+      numNonNulls,
+      indicesBuffer_.data());
 }
 
 template <typename T>

--- a/dwio/nimble/encodings/Encoding.h
+++ b/dwio/nimble/encodings/Encoding.h
@@ -22,8 +22,10 @@
 #include "dwio/nimble/encodings/EncodingPrefix.h"
 #include "velox/buffer/BufferPool.h"
 #include "velox/common/base/BitUtil.h"
+#include "velox/common/base/SimdUtil.h"
 #include "velox/common/memory/Memory.h"
 #include "velox/dwio/common/ColumnVisitors.h"
+#include "velox/dwio/common/DecoderUtil.h"
 
 #include <type_traits>
 
@@ -254,11 +256,10 @@ class Encoding {
     NIMBLE_UNREACHABLE("dictionaryEntries on non-dictionary encoding");
   }
 
-  /// Materializes the next |rowCount| dictionary indices into buffer.
-  /// Advances the row pointer |rowCount|.
-  virtual void materializeIndices(
-      uint32_t /* rowCount */,
-      uint32_t* /* buffer */) {
+  /// Materializes raw dictionary indices for rowCount dense consecutive
+  /// non-null rows. Does not touch any visitor/reader state.
+  /// Overridden by DictionaryEncoding and MainlyConstantEncoding.
+  virtual void materializeIndices(uint32_t /*rowCount*/, uint32_t* /*buffer*/) {
     NIMBLE_UNREACHABLE("materializeIndices on non-dictionary encoding");
   }
 
@@ -438,6 +439,128 @@ T castFromPhysicalType(const PhysicalType& value) {
   } else {
     return value;
   }
+}
+
+// Materializes dictionary indices into the reader's rawValues_ and scatters
+// for null gaps. Used by DictionaryEncoding and MainlyConstantEncoding
+// readIndicesWithVisitor as the dense no-filter fast path.
+// Updates visitor state (addNumValues/setRowIndex) to mark all rows consumed.
+//
+// @param encoding The encoding to call materializeIndices on.
+// @param visitor The visitor (used for outerNonNullRows scratch buffer).
+// @param rawNulls The null bitmap from nullsInReadRange (may be nullptr).
+// @param readOffset Bit offset into rawNulls for the current read range.
+// @param numReadRows Total rows in the read range (including nulls).
+// @param numNonNulls Count of non-null rows in the range.
+template <typename V>
+void readDenseMaterializedIndices(
+    Encoding& encoding,
+    V& visitor,
+    const uint64_t* rawNulls,
+    vector_size_t readOffset,
+    uint32_t numReadRows,
+    uint32_t numNonNulls) {
+  auto* rawOutputValues =
+      reinterpret_cast<int32_t*>(visitor.reader().rawValues());
+  const auto valueOutputOffset = visitor.reader().numValues();
+  encoding.materializeIndices(
+      numNonNulls,
+      reinterpret_cast<uint32_t*>(rawOutputValues + valueOutputOffset));
+  if (numNonNulls == numReadRows) {
+    visitor.addNumValues(numReadRows);
+    visitor.setRowIndex(visitor.numRows());
+    return;
+  }
+  auto& outerNonNullRows = visitor.outerNonNullRows();
+  outerNonNullRows.resize(numNonNulls);
+  auto* rawOuterNonNullRows = outerNonNullRows.data();
+  velox::simd::indicesOfSetBits(
+      rawNulls, readOffset, readOffset + numReadRows, rawOuterNonNullRows);
+  for (auto& row : outerNonNullRows) {
+    row = row - readOffset + valueOutputOffset;
+  }
+  velox::dwio::common::scatterNonNulls(
+      /*targetBegin=*/0,
+      numNonNulls,
+      /*sourceBegin=*/valueOutputOffset,
+      rawOuterNonNullRows,
+      rawOutputValues);
+  visitor.addNumValues(numReadRows);
+  visitor.setRowIndex(visitor.numRows());
+}
+
+// Gathers dictionary indices from a pre-materialized buffer into rawValues_
+// for sparse (non-dense) row sets. The buffer contains dense indices for all
+// non-null rows in the range [numScanned, numScanned + numReadRows).
+// The visitor's row set determines which positions to gather.
+// Updates visitor state (addNumValues/setRowIndex) to mark all rows consumed.
+//
+// Walks non-null positions and the visitor's row set in lockstep so the
+// encoding-space index is tracked incrementally — O(numReadRows)
+// instead of O(numVisitorRows * numReadRows).
+//
+// @param encoding The encoding to call materializeIndices on.
+// @param visitor The visitor with the sparse row set.
+// @param readOffset Bit offset into rawNulls for the current read range.
+// @param prepareResultNulls Callback to allocate resultNulls_ on first null.
+// @param rawNulls The null bitmap from nullsInReadRange (may be nullptr).
+// @param numReadRows Total rows in the read range.
+// @param numNonNulls Count of non-null rows in the range.
+// @param indicesBuffer Scratch buffer with at least numNonNulls entries.
+template <typename V>
+void readSparseMaterializedIndices(
+    Encoding& encoding,
+    V& visitor,
+    vector_size_t readOffset,
+    const std::function<void()>& prepareResultNulls,
+    const uint64_t* rawNulls,
+    uint32_t numReadRows,
+    uint32_t numNonNulls,
+    uint32_t* indicesBuffer) {
+  encoding.materializeIndices(numNonNulls, indicesBuffer);
+  auto* rawOutputValues =
+      reinterpret_cast<int32_t*>(visitor.reader().rawValues());
+  const auto valueOutputOffset = visitor.reader().numValues();
+
+  const auto startRowIndex = visitor.rowIndex();
+  uint32_t indexOffset = 0;
+  auto readRowIndex = startRowIndex;
+  bool nullsEmitted = false;
+  for (uint32_t row = 0; row < numReadRows && readRowIndex < visitor.numRows();
+       ++row) {
+    const bool isReadRow =
+        row == static_cast<uint32_t>(visitor.rowAt(readRowIndex) - readOffset);
+    const bool isNull = rawNulls != nullptr &&
+        !velox::bits::isBitSet(rawNulls, readOffset + row);
+    if (isNull) {
+      if (isReadRow) {
+        // In the sparse case, returnReaderNulls_ is false
+        // (initReturnReaderNulls only sets it for dense rows). resultNulls()
+        // then returns resultNulls_ instead of nullsInReadRange_. We must
+        // explicitly write null bits to resultNulls_ so
+        // DictionaryVector::validate() knows to skip these positions. Also
+        // write 0 as a safe placeholder index.
+        if (!nullsEmitted) {
+          nullsEmitted = true;
+          prepareResultNulls();
+          visitor.reader().setHasNulls();
+        }
+        const auto outputPos = valueOutputOffset + readRowIndex - startRowIndex;
+        rawOutputValues[outputPos] = 0;
+        velox::bits::setNull(visitor.reader().rawResultNulls(), outputPos);
+        ++readRowIndex;
+      }
+      continue;
+    }
+    if (isReadRow) {
+      rawOutputValues[valueOutputOffset + readRowIndex - startRowIndex] =
+          static_cast<int32_t>(indicesBuffer[indexOffset]);
+      ++readRowIndex;
+    }
+    ++indexOffset;
+  }
+  visitor.addNumValues(visitor.numRows() - visitor.rowIndex());
+  visitor.setRowIndex(visitor.numRows());
 }
 
 template <typename DecoderVisitor, typename Skip, typename F>

--- a/dwio/nimble/encodings/EncodingUtils.h
+++ b/dwio/nimble/encodings/EncodingUtils.h
@@ -175,31 +175,51 @@ struct DefaultEncodingTrait {
   }
 };
 
-/// Dispatches readIndicesWithVisitor to the correct encoding type.
-/// Supports DictionaryEncoding and NullableEncoding wrapping Dictionary.
+/// Reads dictionary indices (not decoded values) from an encoding.
+/// Supports DictionaryEncoding, NullableEncoding, and MainlyConstantEncoding
+/// wrapping DictionaryEncoding. Currently only supports string
+/// (std::string_view) dictionary encodings. Non-legacy encodings only.
 template <typename V>
 void callReadIndicesWithVisitor(
     Encoding& encoding,
     V& visitor,
     ReadWithVisitorParams& params) {
-  if (encoding.encodingType() == EncodingType::Dictionary) {
-    static_cast<DictionaryEncoding<std::string_view>&>(encoding)
-        .readIndicesWithVisitor(visitor, params);
-  } else if (encoding.encodingType() == EncodingType::Nullable) {
-    static_cast<NullableEncoding<std::string_view>&>(encoding)
-        .readIndicesWithVisitor(visitor, params);
-  } else {
-    NIMBLE_UNREACHABLE(
-        "Dictionary indices dispatch on unsupported encoding: {}",
-        encoding.encodingType());
+  switch (encoding.encodingType()) {
+    case EncodingType::Dictionary: {
+      static_cast<DictionaryEncoding<std::string_view>&>(encoding)
+          .readIndicesWithVisitor(visitor, params);
+      return;
+    }
+    case EncodingType::Nullable: {
+      static_cast<NullableEncoding<std::string_view>&>(encoding)
+          .readIndicesWithVisitor(visitor, params);
+      return;
+    }
+    case EncodingType::MainlyConstant: {
+      static_cast<MainlyConstantEncoding<std::string_view>&>(encoding)
+          .readIndicesWithVisitor(visitor, params);
+      return;
+    }
+    default:
+      NIMBLE_UNREACHABLE(
+          "Dictionary indices dispatch on unsupported encoding: {}",
+          encoding.encodingType());
   }
 }
 
-/// Extracts the dictionary alphabet from an encoding as a vector of values.
-/// Works through Nullable wrappers via virtual dictionaryEntries().
+/// Builds the dictionary alphabet from any dictionary-enabled encoding.
+/// Uses dictionaryEntries() which returns a contiguous array for all
+/// encoding types (Dict, Nullable→Dict, MC→Dict).
 template <typename T>
 inline std::vector<T> buildEncodingDictionaryAlphabet(
     const Encoding* encoding) {
+  NIMBLE_CHECK(
+      encoding->dictionaryEnabled(),
+      "buildEncodingDictionaryAlphabet requires a dictionary-enabled encoding");
+  if (encoding->encodingType() == EncodingType::Nullable) {
+    return buildEncodingDictionaryAlphabet<T>(
+        static_cast<const NullableEncoding<T>*>(encoding)->nonNulls());
+  }
   const auto size = encoding->dictionarySize();
   const auto* entries = static_cast<const T*>(encoding->dictionaryEntries());
   return {entries, entries + size};

--- a/dwio/nimble/encodings/MainlyConstantEncoding.h
+++ b/dwio/nimble/encodings/MainlyConstantEncoding.h
@@ -25,6 +25,7 @@
 #include "dwio/nimble/common/Exceptions.h"
 #include "dwio/nimble/common/Types.h"
 #include "dwio/nimble/common/Vector.h"
+#include "dwio/nimble/encodings/DictionaryEncoding.h"
 #include "dwio/nimble/encodings/Encoding.h"
 #include "dwio/nimble/encodings/EncodingFactory.h"
 #include "dwio/nimble/encodings/selection/EncodingIdentifier.h"
@@ -97,7 +98,9 @@ class MainlyConstantEncodingBase
         otherValuesBuffer_(
             detail::getPooledBuffer<physicalType>(
                 pool,
-                this->options_.bufferPool)) {}
+                this->options_.bufferPool)),
+        dictionaryIndicesBuffer_(&pool),
+        dictionaryAlphabet_(&pool) {}
 
   ~MainlyConstantEncodingBase() override {
     auto* bufferPool = this->options_.bufferPool;
@@ -121,7 +124,7 @@ class MainlyConstantEncodingBase
     // implemented.
     isCommon_->materializeBoolsAsBits(rowCount, isCommon, 0);
 
-    // Mask tail bits once so the count loop is branchless.
+    // Mask tail bits to 1 (common) so countNonCommon is branchless.
     const auto tailBits = rowCount & 63;
     if (tailBits != 0) {
       isCommon[numWords - 1] |= ~((1ULL << tailBits) - 1);
@@ -142,7 +145,8 @@ class MainlyConstantEncodingBase
     auto* isCommon = reinterpret_cast<uint64_t*>(isCommonBuffer_.data());
     isCommon_->materializeBoolsAsBits(rowCount, isCommon, 0);
 
-    // Mask tail bits once so both count and scatter loops are branchless.
+    // Mask tail bits to 1 (common) so countNonCommon and the scatter
+    // loop (~isCommon) are branchless.
     const auto tailBits = rowCount & 63;
     if (tailBits != 0) {
       isCommon[numWords - 1] |= ~((1ULL << tailBits) - 1);
@@ -195,6 +199,64 @@ class MainlyConstantEncodingBase
           otherValues_->materialize(1, &otherValue);
           return otherValue;
         });
+  }
+
+  /// Reads dictionary indices through a MainlyConstant wrapper.
+  /// Materializes inner dict indices into dictionaryIndicesBuffer_, then
+  /// scatters them and commonValueIndex directly into rawValues_.
+  ///
+  /// The combined alphabet is [innerAlphabet[0], ..., commonValue].
+  /// Common rows → commonValueIndex, non-common rows → inner dict index.
+  template <typename IndicesVisitor>
+  void readIndicesWithVisitor(
+      IndicesVisitor& visitor,
+      ReadWithVisitorParams& params) {
+    NIMBLE_CHECK(
+        this->dictionaryEnabled(),
+        "readIndicesWithVisitor requires dictionary-enabled inner encoding");
+    NIMBLE_CHECK(
+        !IndicesVisitor::kHasFilter && !IndicesVisitor::kHasHook,
+        "readIndicesWithVisitor should only be invoked in dictionary fast path");
+    const auto numReadRows =
+        visitor.rowAt(visitor.numRows() - 1) - params.numScanned + 1;
+
+    auto* rawNulls = visitor.reader().rawNullsInReadRange();
+    const auto numNonNulls = rawNulls != nullptr
+        ? velox::bits::countNonNulls(
+              rawNulls, params.numScanned, params.numScanned + numReadRows)
+        : numReadRows;
+
+    // Dense fast path: materialize directly into rawValues_, scatter for nulls.
+    if (IndicesVisitor::dense) {
+      NIMBLE_CHECK_EQ(
+          visitor.rowAt(visitor.numRows() - 1),
+          visitor.rowAt(0) + visitor.numRows() - 1,
+          "Dense visitor must have contiguous rows");
+      detail::readDenseMaterializedIndices(
+          *this,
+          visitor,
+          rawNulls,
+          params.numScanned,
+          numReadRows,
+          numNonNulls);
+      return;
+    }
+
+    // Sparse path: materialize all rows into buffer, gather only the
+    // requested positions into rawValues_.
+    // TODO: Use templated materializeIndices to avoid materializing
+    // unrequested rows — see commented-out API mock-ups below and in
+    // EncodingUtils.h.
+    dictionaryIndicesBuffer_.resize(numNonNulls);
+    detail::readSparseMaterializedIndices(
+        *this,
+        visitor,
+        params.numScanned,
+        params.prepareResultNulls,
+        rawNulls,
+        numReadRows,
+        numNonNulls,
+        reinterpret_cast<uint32_t*>(dictionaryIndicesBuffer_.data()));
   }
 
   template <bool kScatter, typename V>
@@ -344,6 +406,77 @@ class MainlyConstantEncodingBase
     return log;
   }
 
+  // MC wraps an inner Dictionary encoding. The combined alphabet is
+  // [innerAlphabet..., commonValue], so dictionarySize is inner + 1.
+  bool dictionaryEnabled() const override {
+    return otherValues_->dictionaryEnabled();
+  }
+
+  // MainlyConstantEncoding pads the inner dictionary by the common value.
+  // Hence adds 1 to the inner dictionary size.
+  uint32_t dictionarySize() const override {
+    return otherValues_->dictionarySize() + 1;
+  }
+
+  const void* dictionaryEntry(uint32_t index) const override {
+    if (index < otherValues_->dictionarySize()) {
+      return otherValues_->dictionaryEntry(index);
+    }
+    return &commonValue_;
+  }
+
+  const void* dictionaryEntries() const override {
+    if (dictionaryAlphabet_.empty()) {
+      const auto numOtherValues = otherValues_->dictionarySize();
+      dictionaryAlphabet_.resize(numOtherValues + 1);
+      const auto* otherValues =
+          static_cast<const physicalType*>(otherValues_->dictionaryEntries());
+      std::copy(
+          otherValues,
+          otherValues + numOtherValues,
+          dictionaryAlphabet_.data());
+      dictionaryAlphabet_[numOtherValues] = commonValue_;
+    }
+    return dictionaryAlphabet_.data();
+  }
+
+  /// Materializes composed dictionary indices for rowCount dense non-null rows.
+  /// Reads isCommon, delegates to inner encoding's materializeIndices for
+  /// non-common rows, fills common positions with commonValueIndex.
+  void materializeIndices(uint32_t rowCount, uint32_t* buffer) override {
+    const auto numWords = velox::bits::nwords(rowCount);
+    isCommonBuffer_.resize(numWords * sizeof(uint64_t));
+    auto* isCommon = reinterpret_cast<uint64_t*>(isCommonBuffer_.data());
+    // Set the last word to all-ones so tail bits beyond rowCount are treated
+    // as common, making countNonCommon branchless without post-masking.
+    // materializeBoolsAsBits only overwrites bits [0, rowCount).
+    isCommon[numWords - 1] = ~0ULL;
+    isCommon_->materializeBoolsAsBits(rowCount, isCommon, /*bitOffset=*/0);
+
+    const uint32_t numNonCommon = countNonCommon(isCommon, numWords);
+    const auto commonValueIndex =
+        static_cast<uint32_t>(otherValues_->dictionarySize());
+
+    if (numNonCommon == 0) {
+      std::fill(buffer, buffer + rowCount, commonValueIndex);
+      return;
+    }
+
+    // Materialize inner indices densely at the front of buffer, then
+    // reverse-scatter interleaving with commonValueIndex.
+    otherValues_->materializeIndices(numNonCommon, buffer);
+
+    uint32_t index = numNonCommon;
+    for (int32_t i = static_cast<int32_t>(rowCount) - 1; i >= 0; --i) {
+      if (velox::bits::isBitSet(isCommon, i)) {
+        buffer[i] = commonValueIndex;
+      } else {
+        buffer[i] = buffer[--index];
+      }
+    }
+    NIMBLE_CHECK_EQ(index, 0);
+  }
+
  protected:
   // Counts unset bits across all words. Caller must mask tail bits
   // before calling (set garbage tail bits to 1 in the last word).
@@ -362,6 +495,8 @@ class MainlyConstantEncodingBase
   physicalType commonValue_;
   Vector<bool> isCommonBuffer_;
   Vector<physicalType> otherValuesBuffer_;
+  Vector<int32_t> dictionaryIndicesBuffer_;
+  mutable Vector<physicalType> dictionaryAlphabet_;
 };
 
 template <typename T>

--- a/dwio/nimble/encodings/NullableEncoding.h
+++ b/dwio/nimble/encodings/NullableEncoding.h
@@ -328,15 +328,14 @@ template <typename V>
 void NullableEncoding<T>::readIndicesWithVisitor(
     V& visitor,
     ReadWithVisitorParams& params) {
+  NIMBLE_CHECK(
+      this->dictionaryEnabled(),
+      "readIndicesWithVisitor requires dictionary-enabled inner encoding");
+  NIMBLE_CHECK(
+      !V::kHasFilter && !V::kHasHook,
+      "readIndicesWithVisitor should only be invoked in dictionary fast path");
   materializeNullsForVisitor(visitor, params);
-  NIMBLE_CHECK_EQ(
-      nonNullValues_->encodingType(),
-      EncodingType::Dictionary,
-      "readIndicesWithVisitor called on NullableEncoding with non-dictionary "
-      "inner encoding: {}",
-      nonNullValues_->encodingType());
-  auto& dictEnc = static_cast<DictionaryEncoding<T>&>(*nonNullValues_);
-  dictEnc.readIndicesWithVisitor(visitor, params);
+  callReadIndicesWithVisitor(*nonNullValues_, visitor, params);
 }
 
 template <typename T>

--- a/dwio/nimble/encodings/tests/CMakeLists.txt
+++ b/dwio/nimble/encodings/tests/CMakeLists.txt
@@ -14,6 +14,9 @@
 add_library(nimble_encodings_tests_utils TestUtils.cpp)
 target_link_libraries(nimble_encodings_tests_utils nimble_encodings)
 
+add_library(nimble_encoding_layout_test_helper EncodingLayoutTestHelper.cpp)
+target_link_libraries(nimble_encoding_layout_test_helper nimble_encodings)
+
 add_executable(
   nimble_encodings_tests
   ConstantEncodingTest.cpp

--- a/dwio/nimble/encodings/tests/EncodingLayoutTestHelper.cpp
+++ b/dwio/nimble/encodings/tests/EncodingLayoutTestHelper.cpp
@@ -29,6 +29,20 @@ TrivialEnc::operator EncodingLayout() const {
       EncodingType::Trivial, {}, CompressionType::Uncompressed);
 }
 
+StringTrivialEnc::operator EncodingLayout() const {
+  constexpr auto kLengths = EncodingIdentifiers::Trivial::Lengths;
+  static_assert(kLengths == 0);
+
+  std::vector<std::optional<const EncodingLayout>> children;
+  children.reserve(1);
+  children.emplace_back(lengths);
+  return EncodingLayout(
+      EncodingType::Trivial,
+      {},
+      CompressionType::Uncompressed,
+      std::move(children));
+}
+
 ConstantEnc::operator EncodingLayout() const {
   return EncodingLayout(
       EncodingType::Constant, {}, CompressionType::Uncompressed);

--- a/dwio/nimble/encodings/tests/EncodingLayoutTestHelper.h
+++ b/dwio/nimble/encodings/tests/EncodingLayoutTestHelper.h
@@ -30,6 +30,14 @@ struct TrivialEnc {
   operator EncodingLayout() const;
 };
 
+// TrivialEncoding<std::string_view> has a nested Lengths sub-encoding
+// (EncodingIdentifiers::Trivial::Lengths = 0). Use this instead of TrivialEnc
+// when encoding string types.
+struct StringTrivialEnc {
+  EncodingLayout lengths = TrivialEnc{};
+  operator EncodingLayout() const;
+};
+
 struct ConstantEnc {
   operator EncodingLayout() const;
 };

--- a/dwio/nimble/encodings/tests/EncodingTest.cpp
+++ b/dwio/nimble/encodings/tests/EncodingTest.cpp
@@ -821,6 +821,151 @@ class DictionaryApiTypedTest : public ::testing::Test {
         });
   }
 
+  /// Creates an Encoding from serialized bytes using EncodingFactory.
+  std::unique_ptr<nimble::Encoding> decodeEncoding(std::string_view data) {
+    return nimble::EncodingFactory().create(
+        *pool_, data, [this](uint32_t size) {
+          stringBuffers_.push_back(
+              velox::AlignedBuffer::allocate<char>(size, pool_.get()));
+          return stringBuffers_.back()->asMutable<void>();
+        });
+  }
+
+  /// Serializes values as MainlyConstant wrapping Dictionary into outputBuffer.
+  /// The common value is the most frequent element. Returns a string_view of
+  /// the serialized bytes in outputBuffer.
+  std::string_view serializeMainlyConstantDictionary(
+      const std::vector<T>& values,
+      nimble::Buffer& outputBuffer) {
+    NIMBLE_CHECK(!values.empty());
+    const uint32_t rowCount = values.size();
+
+    // Find the most common value.
+    std::unordered_map<PhysicalType, uint32_t> counts;
+    for (const auto& v : values) {
+      ++counts[reinterpret_cast<const PhysicalType&>(v)];
+    }
+    PhysicalType commonValue{};
+    uint32_t maxCount = 0;
+    for (const auto& [val, cnt] : counts) {
+      if (cnt > maxCount) {
+        maxCount = cnt;
+        commonValue = val;
+      }
+    }
+
+    // Build isCommon bools and other (non-common) values.
+    nimble::Vector<bool> isCommon{pool_.get(), rowCount, false};
+    nimble::Vector<T> otherVec{pool_.get()};
+    for (size_t i = 0; i < values.size(); ++i) {
+      if (reinterpret_cast<const PhysicalType&>(values[i]) == commonValue) {
+        isCommon[i] = true;
+      } else {
+        otherVec.push_back(values[i]);
+      }
+    }
+
+    // Encode isCommon as Trivial<bool>.
+    auto isCommonSpan = std::span<const bool>(isCommon.data(), isCommon.size());
+    nimble::Buffer isCommonBuf{*pool_};
+    nimble::EncodingSelection<bool> isCommonSel{
+        {.encodingType = nimble::EncodingType::Trivial},
+        nimble::Statistics<bool>::create(isCommonSpan),
+        std::make_unique<TestTrivialEncodingSelectionPolicy<bool>>(
+            false, false)};
+    auto serializedIsCommon = nimble::TrivialEncoding<bool>::encode(
+        isCommonSel, isCommonSpan, isCommonBuf);
+
+    // Encode other values as Dictionary.
+    auto otherSpan = std::span<const PhysicalType>(
+        reinterpret_cast<const PhysicalType*>(otherVec.data()),
+        otherVec.size());
+    nimble::Buffer otherBuf{*pool_};
+    nimble::EncodingSelection<PhysicalType> otherSel{
+        {.encodingType = nimble::EncodingType::Dictionary},
+        nimble::Statistics<PhysicalType>::create(otherSpan),
+        std::make_unique<TestTrivialEncodingSelectionPolicy<T>>(false, false)};
+    auto serializedOther =
+        nimble::DictionaryEncoding<T>::encode(otherSel, otherSpan, otherBuf);
+
+    // Assemble MainlyConstant binary: prefix | isCommon | otherValues |
+    // commonValue
+    uint32_t encodingSize = nimble::Encoding::kPrefixSize + 8 +
+        serializedIsCommon.size() + serializedOther.size();
+    if constexpr (nimble::isNumericType<PhysicalType>()) {
+      encodingSize += sizeof(PhysicalType);
+    } else {
+      encodingSize += 4 + commonValue.size();
+    }
+    char* reserved = outputBuffer.reserve(encodingSize);
+    char* pos = reserved;
+    nimble::encoding::writeChar(
+        static_cast<char>(nimble::EncodingType::MainlyConstant), pos);
+    nimble::encoding::writeChar(
+        static_cast<char>(nimble::TypeTraits<T>::dataType), pos);
+    nimble::encoding::writeUint32(rowCount, pos);
+    nimble::encoding::writeString(serializedIsCommon, pos);
+    nimble::encoding::writeString(serializedOther, pos);
+    nimble::encoding::write<PhysicalType>(commonValue, pos);
+
+    return std::string_view(reserved, encodingSize);
+  }
+
+  /// Encodes data as MainlyConstant wrapping Dictionary for the other-values
+  /// child. The common value is the most frequent element.
+  std::unique_ptr<nimble::Encoding> encodeMainlyConstantDictionary(
+      const std::vector<T>& values) {
+    auto serialized = serializeMainlyConstantDictionary(values, *buffer_);
+    return decodeEncoding(serialized);
+  }
+
+  /// Encodes data as Nullable wrapping MainlyConstant wrapping Dictionary.
+  std::unique_ptr<nimble::Encoding> encodeNullableMainlyConstantDictionary(
+      const std::vector<T>& values,
+      const nimble::Vector<bool>& nulls) {
+    NIMBLE_CHECK_EQ(values.size(), nulls.size());
+    const uint32_t rowCount = values.size();
+
+    // Collect non-null values.
+    std::vector<T> nonNullValues;
+    for (size_t i = 0; i < values.size(); ++i) {
+      if (nulls[i]) {
+        nonNullValues.push_back(values[i]);
+      }
+    }
+
+    // Serialize MC→Dict for non-null values.
+    nimble::Buffer mcBuffer{*pool_};
+    auto serializedMC =
+        serializeMainlyConstantDictionary(nonNullValues, mcBuffer);
+
+    // Encode nulls as Trivial<bool>.
+    auto nullSpan = std::span<const bool>(nulls.data(), nulls.size());
+    nimble::Buffer nullBuffer{*pool_};
+    nimble::EncodingSelection<bool> nullSelection{
+        {.encodingType = nimble::EncodingType::Trivial},
+        nimble::Statistics<bool>::create(nullSpan),
+        std::make_unique<TestTrivialEncodingSelectionPolicy<bool>>(
+            false, false)};
+    auto serializedNulls = nimble::TrivialEncoding<bool>::encode(
+        nullSelection, nullSpan, nullBuffer);
+
+    // Assemble Nullable: prefix | MC bytes | null bytes
+    const uint32_t encodingSize = nimble::Encoding::kPrefixSize + 4 +
+        serializedMC.size() + serializedNulls.size();
+    char* reserved = buffer_->reserve(encodingSize);
+    char* pos = reserved;
+    nimble::encoding::writeChar(
+        static_cast<char>(nimble::EncodingType::Nullable), pos);
+    nimble::encoding::writeChar(
+        static_cast<char>(nimble::TypeTraits<T>::dataType), pos);
+    nimble::encoding::writeUint32(rowCount, pos);
+    nimble::encoding::writeString(serializedMC, pos);
+    nimble::encoding::writeBytes(serializedNulls, pos);
+
+    return decodeEncoding(std::string_view(reserved, encodingSize));
+  }
+
   std::shared_ptr<velox::memory::MemoryPool> pool_;
   std::unique_ptr<nimble::Buffer> buffer_;
   std::vector<velox::BufferPtr> stringBuffers_;
@@ -1237,6 +1382,431 @@ TYPED_TEST(DictionaryApiTypedTest, buildAlphabetNullableFuzz) {
     EXPECT_EQ(alphabet.size(), expectedUniques.size());
     std::set<T> actual(alphabet.begin(), alphabet.end());
     EXPECT_EQ(actual, expectedUniques);
+  }
+}
+
+TYPED_TEST(DictionaryApiTypedTest, mainlyConstantDictionaryBasics) {
+  using T = TypeParam;
+  std::vector<T> data;
+  if constexpr (std::is_same_v<T, std::string_view>) {
+    this->stringPool_ = {"alpha", "bravo"};
+    std::string_view common = "common_value";
+    this->stringPool_.push_back(std::string(common));
+    data.resize(20, std::string_view(this->stringPool_[2]));
+    data[3] = std::string_view(this->stringPool_[0]);
+    data[7] = std::string_view(this->stringPool_[1]);
+    data[15] = std::string_view(this->stringPool_[0]);
+  } else {
+    T common = T(99);
+    data.resize(20, common);
+    data[3] = T(1);
+    data[7] = T(2);
+    data[15] = T(1);
+  }
+
+  auto encoding = this->encodeMainlyConstantDictionary(data);
+  EXPECT_TRUE(encoding->dictionaryEnabled());
+  EXPECT_EQ(encoding->dictionarySize(), 3);
+
+  std::set<T> entries;
+  for (uint32_t i = 0; i < encoding->dictionarySize(); ++i) {
+    const auto* entry = static_cast<const T*>(encoding->dictionaryEntry(i));
+    entries.insert(*entry);
+  }
+
+  if constexpr (std::is_same_v<T, std::string_view>) {
+    EXPECT_THAT(
+        entries,
+        ::testing::UnorderedElementsAre("alpha", "bravo", "common_value"));
+  } else {
+    EXPECT_THAT(entries, ::testing::UnorderedElementsAre(T(1), T(2), T(99)));
+  }
+}
+
+TYPED_TEST(DictionaryApiTypedTest, mainlyConstantDictionaryFuzz) {
+  using T = TypeParam;
+  for (int run = 0; run < 20; ++run) {
+    auto seed = folly::Random::rand32();
+    std::mt19937 rng(seed);
+    const auto numRows = 50 + rng() % 500;
+    const auto cardinality = 2 + rng() % 50;
+    const int commonPct = 55 + rng() % 40;
+
+    if constexpr (std::is_same_v<T, std::string_view>) {
+      this->stringPool_.clear();
+      for (int j = 0; j < cardinality; ++j) {
+        const int len = 1 + rng() % 20;
+        std::string s = fmt::format("{}:", j);
+        for (int k = 0; k < len; ++k) {
+          s += static_cast<char>('a' + rng() % 26);
+        }
+        this->stringPool_.push_back(std::move(s));
+      }
+    }
+
+    T commonValue;
+    if constexpr (std::is_same_v<T, std::string_view>) {
+      commonValue = std::string_view(this->stringPool_[0]);
+    } else {
+      commonValue = static_cast<T>(cardinality + 1);
+    }
+
+    std::vector<T> data;
+    std::set<T> expectedUniques;
+    expectedUniques.insert(commonValue);
+    data.reserve(numRows);
+    for (int i = 0; i < numRows; ++i) {
+      if (static_cast<int>(rng() % 100) < commonPct) {
+        data.push_back(commonValue);
+      } else {
+        T val;
+        if constexpr (std::is_same_v<T, std::string_view>) {
+          val = std::string_view(
+              this->stringPool_[1 + rng() % (cardinality - 1)]);
+        } else {
+          val = static_cast<T>(1 + rng() % cardinality);
+        }
+        data.push_back(val);
+        expectedUniques.insert(val);
+      }
+    }
+
+    SCOPED_TRACE(fmt::format("run={} seed={} numRows={}", run, seed, numRows));
+
+    auto encoding = this->encodeMainlyConstantDictionary(data);
+    ASSERT_TRUE(encoding->dictionaryEnabled());
+    ASSERT_EQ(encoding->dictionarySize(), expectedUniques.size());
+
+    std::set<T> actualEntries;
+    for (uint32_t i = 0; i < encoding->dictionarySize(); ++i) {
+      const auto* entry = static_cast<const T*>(encoding->dictionaryEntry(i));
+      actualEntries.insert(*entry);
+    }
+    EXPECT_EQ(actualEntries, expectedUniques);
+  }
+}
+
+TYPED_TEST(DictionaryApiTypedTest, buildAlphabetMainlyConstantDictionary) {
+  using T = TypeParam;
+  std::vector<T> data;
+  if constexpr (std::is_same_v<T, std::string_view>) {
+    this->stringPool_ = {"alpha", "bravo"};
+    std::string_view common = "common";
+    this->stringPool_.push_back(std::string(common));
+    data.resize(20, std::string_view(this->stringPool_[2]));
+    data[3] = std::string_view(this->stringPool_[0]);
+    data[7] = std::string_view(this->stringPool_[1]);
+    data[15] = std::string_view(this->stringPool_[0]);
+  } else {
+    data.resize(20, T(99));
+    data[3] = T(1);
+    data[7] = T(2);
+    data[15] = T(1);
+  }
+
+  auto encoding = this->encodeMainlyConstantDictionary(data);
+  auto alphabet = nimble::buildEncodingDictionaryAlphabet<T>(encoding.get());
+  EXPECT_EQ(alphabet.size(), 3);
+  std::set<T> actual(alphabet.begin(), alphabet.end());
+  if constexpr (std::is_same_v<T, std::string_view>) {
+    EXPECT_EQ(actual, (std::set<T>{"alpha", "bravo", "common"}));
+  } else {
+    EXPECT_EQ(actual, (std::set<T>{T(1), T(2), T(99)}));
+  }
+}
+
+TYPED_TEST(DictionaryApiTypedTest, buildAlphabetMainlyConstantDictionaryFuzz) {
+  using T = TypeParam;
+  for (int run = 0; run < 20; ++run) {
+    auto seed = folly::Random::rand32();
+    std::mt19937 rng(seed);
+    const auto numRows = 50 + rng() % 500;
+    const auto cardinality = 2 + rng() % 50;
+    const int commonPct = 55 + rng() % 40;
+
+    if constexpr (std::is_same_v<T, std::string_view>) {
+      this->stringPool_.clear();
+      for (int j = 0; j < cardinality; ++j) {
+        const int len = 1 + rng() % 20;
+        std::string s = fmt::format("{}:", j);
+        for (int k = 0; k < len; ++k) {
+          s += static_cast<char>('a' + rng() % 26);
+        }
+        this->stringPool_.push_back(std::move(s));
+      }
+    }
+
+    T commonValue;
+    if constexpr (std::is_same_v<T, std::string_view>) {
+      commonValue = std::string_view(this->stringPool_[0]);
+    } else {
+      commonValue = static_cast<T>(cardinality + 1);
+    }
+
+    std::vector<T> data;
+    std::set<T> expectedUniques;
+    expectedUniques.insert(commonValue);
+    data.reserve(numRows);
+    for (int i = 0; i < numRows; ++i) {
+      if (static_cast<int>(rng() % 100) < commonPct) {
+        data.push_back(commonValue);
+      } else {
+        T val;
+        if constexpr (std::is_same_v<T, std::string_view>) {
+          val = std::string_view(
+              this->stringPool_[1 + rng() % (cardinality - 1)]);
+        } else {
+          val = static_cast<T>(1 + rng() % cardinality);
+        }
+        data.push_back(val);
+        expectedUniques.insert(val);
+      }
+    }
+
+    SCOPED_TRACE(fmt::format("run={} seed={} numRows={}", run, seed, numRows));
+
+    auto encoding = this->encodeMainlyConstantDictionary(data);
+    auto alphabet = nimble::buildEncodingDictionaryAlphabet<T>(encoding.get());
+    EXPECT_EQ(alphabet.size(), expectedUniques.size());
+    std::set<T> actual(alphabet.begin(), alphabet.end());
+    EXPECT_EQ(actual, expectedUniques);
+  }
+}
+
+TYPED_TEST(DictionaryApiTypedTest, nullableMainlyConstantDictionaryBasics) {
+  using T = TypeParam;
+  std::vector<T> data;
+  if constexpr (std::is_same_v<T, std::string_view>) {
+    this->stringPool_ = {"alpha", "bravo"};
+    std::string_view common = "common";
+    this->stringPool_.push_back(std::string(common));
+    data = {
+        std::string_view(this->stringPool_[2]),
+        std::string_view(this->stringPool_[0]),
+        std::string_view(this->stringPool_[2]),
+        std::string_view(this->stringPool_[1]),
+        std::string_view(this->stringPool_[2]),
+        std::string_view(this->stringPool_[2]),
+        std::string_view(this->stringPool_[2])};
+  } else {
+    data = {T(99), T(1), T(99), T(2), T(99), T(99), T(99)};
+  }
+  nimble::Vector<bool> nulls{this->pool_.get()};
+  for (bool n : {true, true, false, true, true, true, true}) {
+    nulls.push_back(n);
+  }
+
+  auto encoding = this->encodeNullableMainlyConstantDictionary(data, nulls);
+  EXPECT_TRUE(encoding->dictionaryEnabled());
+  EXPECT_EQ(encoding->dictionarySize(), 3);
+}
+
+TYPED_TEST(DictionaryApiTypedTest, materializeIndicesDictionary) {
+  using T = TypeParam;
+  std::vector<T> data;
+  if constexpr (std::is_same_v<T, std::string_view>) {
+    this->stringPool_ = {"alpha", "bravo", "charlie"};
+    data = {
+        std::string_view(this->stringPool_[0]),
+        std::string_view(this->stringPool_[1]),
+        std::string_view(this->stringPool_[0]),
+        std::string_view(this->stringPool_[2]),
+        std::string_view(this->stringPool_[1])};
+  } else {
+    data = {T(1), T(2), T(1), T(3), T(2)};
+  }
+
+  auto encoding = this->encodeDictionary(data);
+  ASSERT_TRUE(encoding->dictionaryEnabled());
+  const uint32_t rowCount = data.size();
+
+  nimble::Vector<uint32_t> indices{this->pool_.get(), rowCount};
+  encoding->materializeIndices(rowCount, indices.data());
+
+  // Every materialized index must be in range and map to the correct value.
+  for (uint32_t i = 0; i < rowCount; ++i) {
+    ASSERT_LT(indices[i], encoding->dictionarySize());
+    const auto* entry =
+        static_cast<const T*>(encoding->dictionaryEntry(indices[i]));
+    EXPECT_EQ(*entry, data[i]) << "row=" << i;
+  }
+}
+
+TYPED_TEST(DictionaryApiTypedTest, materializeIndicesDictionaryFuzz) {
+  using T = TypeParam;
+
+  for (int run = 0; run < 20; ++run) {
+    auto seed = folly::Random::rand32();
+    std::mt19937 rng(seed);
+    const int numRows = 2 + rng() % 300;
+    const int cardinality = 2 + rng() % 10;
+
+    if constexpr (std::is_same_v<T, std::string_view>) {
+      this->stringPool_.clear();
+      for (int j = 0; j < cardinality; ++j) {
+        const int len = rng() % 30;
+        std::string s = fmt::format("{}:", j);
+        for (int k = 0; k < len; ++k) {
+          s += static_cast<char>('a' + rng() % 26);
+        }
+        this->stringPool_.push_back(std::move(s));
+      }
+    }
+
+    std::vector<T> data;
+    data.reserve(numRows);
+    for (int i = 0; i < numRows; ++i) {
+      T val;
+      if constexpr (std::is_same_v<T, std::string_view>) {
+        val = std::string_view(this->stringPool_[rng() % cardinality]);
+      } else {
+        val = static_cast<T>(rng() % cardinality);
+      }
+      data.push_back(val);
+    }
+
+    SCOPED_TRACE(fmt::format("run={} seed={} numRows={}", run, seed, numRows));
+
+    auto encoding = this->encodeDictionary(data);
+    ASSERT_TRUE(encoding->dictionaryEnabled());
+
+    nimble::Vector<uint32_t> indices{
+        this->pool_.get(), static_cast<uint32_t>(numRows)};
+    encoding->materializeIndices(numRows, indices.data());
+
+    for (int i = 0; i < numRows; ++i) {
+      ASSERT_LT(indices[i], encoding->dictionarySize()) << "row=" << i;
+      const auto* entry =
+          static_cast<const T*>(encoding->dictionaryEntry(indices[i]));
+      EXPECT_EQ(*entry, data[i]) << "row=" << i;
+    }
+  }
+}
+
+TYPED_TEST(DictionaryApiTypedTest, materializeIndicesMainlyConstantDictionary) {
+  using T = TypeParam;
+  std::vector<T> data;
+  if constexpr (std::is_same_v<T, std::string_view>) {
+    this->stringPool_ = {"alpha", "bravo"};
+    std::string_view common = "common_value";
+    this->stringPool_.push_back(std::string(common));
+    data.resize(20, std::string_view(this->stringPool_[2]));
+    data[3] = std::string_view(this->stringPool_[0]);
+    data[7] = std::string_view(this->stringPool_[1]);
+    data[15] = std::string_view(this->stringPool_[0]);
+  } else {
+    T common = T(99);
+    data.resize(20, common);
+    data[3] = T(1);
+    data[7] = T(2);
+    data[15] = T(1);
+  }
+
+  auto encoding = this->encodeMainlyConstantDictionary(data);
+  ASSERT_TRUE(encoding->dictionaryEnabled());
+  const uint32_t rowCount = data.size();
+  const uint32_t commonValueIndex = encoding->dictionarySize() - 1;
+
+  nimble::Vector<uint32_t> indices{this->pool_.get(), rowCount};
+  encoding->materializeIndices(rowCount, indices.data());
+
+  // Build a lookup from alphabet entry value to index.
+  std::unordered_map<T, uint32_t> valueToIndex;
+  for (uint32_t i = 0; i < encoding->dictionarySize(); ++i) {
+    const auto* entry = static_cast<const T*>(encoding->dictionaryEntry(i));
+    valueToIndex[*entry] = i;
+  }
+
+  for (uint32_t i = 0; i < rowCount; ++i) {
+    ASSERT_LT(indices[i], encoding->dictionarySize()) << "row=" << i;
+    const auto* entry =
+        static_cast<const T*>(encoding->dictionaryEntry(indices[i]));
+    EXPECT_EQ(*entry, data[i]) << "row=" << i;
+  }
+
+  // Common-value rows should all map to the commonValueIndex.
+  T commonValue;
+  if constexpr (std::is_same_v<T, std::string_view>) {
+    commonValue = std::string_view(this->stringPool_[2]);
+  } else {
+    commonValue = T(99);
+  }
+  for (uint32_t i = 0; i < rowCount; ++i) {
+    if (data[i] == commonValue) {
+      EXPECT_EQ(indices[i], commonValueIndex) << "row=" << i;
+    }
+  }
+}
+
+TYPED_TEST(
+    DictionaryApiTypedTest,
+    materializeIndicesMainlyConstantDictionaryFuzz) {
+  using T = TypeParam;
+
+  for (int run = 0; run < 20; ++run) {
+    auto seed = folly::Random::rand32();
+    std::mt19937 rng(seed);
+    const auto numRows = 50 + rng() % 500;
+    const auto cardinality = 2 + rng() % 50;
+    const int commonPct = 55 + rng() % 40;
+
+    if constexpr (std::is_same_v<T, std::string_view>) {
+      this->stringPool_.clear();
+      for (int j = 0; j < cardinality; ++j) {
+        const int len = 1 + rng() % 20;
+        std::string s = fmt::format("{}:", j);
+        for (int k = 0; k < len; ++k) {
+          s += static_cast<char>('a' + rng() % 26);
+        }
+        this->stringPool_.push_back(std::move(s));
+      }
+    }
+
+    T commonValue;
+    if constexpr (std::is_same_v<T, std::string_view>) {
+      commonValue = std::string_view(this->stringPool_[0]);
+    } else {
+      commonValue = static_cast<T>(cardinality + 1);
+    }
+
+    std::vector<T> data;
+    data.reserve(numRows);
+    for (int i = 0; i < numRows; ++i) {
+      if (static_cast<int>(rng() % 100) < commonPct) {
+        data.push_back(commonValue);
+      } else {
+        T val;
+        if constexpr (std::is_same_v<T, std::string_view>) {
+          val = std::string_view(
+              this->stringPool_[1 + rng() % (cardinality - 1)]);
+        } else {
+          val = static_cast<T>(1 + rng() % cardinality);
+        }
+        data.push_back(val);
+      }
+    }
+
+    SCOPED_TRACE(fmt::format("run={} seed={} numRows={}", run, seed, numRows));
+
+    auto encoding = this->encodeMainlyConstantDictionary(data);
+    ASSERT_TRUE(encoding->dictionaryEnabled());
+    const uint32_t commonValueIndex = encoding->dictionarySize() - 1;
+
+    nimble::Vector<uint32_t> indices{
+        this->pool_.get(), static_cast<uint32_t>(numRows)};
+    encoding->materializeIndices(numRows, indices.data());
+
+    for (int i = 0; i < numRows; ++i) {
+      ASSERT_LT(indices[i], encoding->dictionarySize()) << "row=" << i;
+      const auto* entry =
+          static_cast<const T*>(encoding->dictionaryEntry(indices[i]));
+      EXPECT_EQ(*entry, data[i]) << "row=" << i;
+
+      // Common-value rows must map to the last alphabet entry.
+      if (data[i] == commonValue) {
+        EXPECT_EQ(indices[i], commonValueIndex) << "row=" << i;
+      }
+    }
   }
 }
 

--- a/dwio/nimble/encodings/tests/ReadWithVisitorTest.cpp
+++ b/dwio/nimble/encodings/tests/ReadWithVisitorTest.cpp
@@ -227,6 +227,87 @@ class ReadWithVisitorTest : public ::testing::TestWithParam<bool>,
     return decodeEncoding(encoded, memPool);
   }
 
+  /// Manually encode data as MainlyConstant wrapping Dictionary.
+  /// Works for all types including string_view (unlike createFromCustomLayout
+  /// which fails for string_view due to nested sub-encoding depth).
+  template <typename T>
+  std::unique_ptr<Encoding> encodeMainlyConstantDictionary(
+      const std::vector<T>& values) {
+    using PhysicalType = typename TypeTraits<T>::physicalType;
+    NIMBLE_CHECK(!values.empty());
+    const uint32_t rowCount = values.size();
+
+    std::unordered_map<PhysicalType, uint32_t> counts;
+    for (const auto& v : values) {
+      ++counts[reinterpret_cast<const PhysicalType&>(v)];
+    }
+    PhysicalType commonValue{};
+    uint32_t maxCount = 0;
+    for (const auto& [val, cnt] : counts) {
+      if (cnt > maxCount) {
+        maxCount = cnt;
+        commonValue = val;
+      }
+    }
+
+    nimble::Vector<bool> isCommon{pool(), rowCount, false};
+    nimble::Vector<T> otherVec{pool()};
+    for (size_t i = 0; i < values.size(); ++i) {
+      if (reinterpret_cast<const PhysicalType&>(values[i]) == commonValue) {
+        isCommon[i] = true;
+      } else {
+        otherVec.push_back(values[i]);
+      }
+    }
+
+    auto isCommonSpan = std::span<const bool>(isCommon.data(), isCommon.size());
+    Buffer isCommonBuf{*pool()};
+    EncodingSelection<bool> isCommonSel{
+        {.encodingType = EncodingType::Trivial},
+        Statistics<bool>::create(isCommonSpan),
+        std::make_unique<TrivialNestedPolicy<bool>>()};
+    auto serializedIsCommon =
+        TrivialEncoding<bool>::encode(isCommonSel, isCommonSpan, isCommonBuf);
+
+    auto otherSpan = std::span<const PhysicalType>(
+        reinterpret_cast<const PhysicalType*>(otherVec.data()),
+        otherVec.size());
+    Buffer otherBuf{*pool()};
+    EncodingSelection<PhysicalType> otherSel{
+        {.encodingType = EncodingType::Dictionary},
+        Statistics<PhysicalType>::create(otherSpan),
+        std::make_unique<TrivialNestedPolicy<T>>()};
+    auto serializedOther =
+        DictionaryEncoding<T>::encode(otherSel, otherSpan, otherBuf);
+
+    uint32_t encodingSize = Encoding::kPrefixSize + 8 +
+        serializedIsCommon.size() + serializedOther.size();
+    if constexpr (isNumericType<PhysicalType>()) {
+      encodingSize += sizeof(PhysicalType);
+    } else {
+      encodingSize += 4 + commonValue.size();
+    }
+    auto& buf = mcDictBuffer_;
+    buf = std::make_unique<Buffer>(*pool());
+    char* reserved = buf->reserve(encodingSize);
+    char* pos = reserved;
+    encoding::writeChar(static_cast<char>(EncodingType::MainlyConstant), pos);
+    encoding::writeChar(static_cast<char>(TypeTraits<T>::dataType), pos);
+    encoding::writeUint32(rowCount, pos);
+    encoding::writeString(serializedIsCommon, pos);
+    encoding::writeString(serializedOther, pos);
+    encoding::write<PhysicalType>(commonValue, pos);
+
+    return EncodingFactory().create(
+        *pool(),
+        std::string_view(reserved, encodingSize),
+        [this](uint32_t size) {
+          mcDictStringBuffers_.push_back(
+              velox::AlignedBuffer::allocate<char>(size, pool()));
+          return mcDictStringBuffers_.back()->asMutable<void>();
+        });
+  }
+
   // Build root reader, get its first child, call read(), return child.
   // Caller inspects outputRows / numValues / rawValues / hasNulls on it.
   dwio::common::SelectiveColumnReader* readColumn(
@@ -258,6 +339,8 @@ class ReadWithVisitorTest : public ::testing::TestWithParam<bool>,
       std::make_shared<io::IoStatistics>()};
   const std::shared_ptr<io::IoStatistics> metadataIoStats_{
       std::make_shared<io::IoStatistics>()};
+  std::unique_ptr<Buffer> mcDictBuffer_;
+  std::vector<velox::BufferPtr> mcDictStringBuffers_;
 };
 
 // ===========================================================================
@@ -696,7 +779,7 @@ TEST_P(ReadWithVisitorTest, filterOnOneColumnInspectState) {
 // ===========================================================================
 
 // Explicit readWithVisitor: BigintRange filter, dense rows, ExtractToReader.
-TEST_P(ReadWithVisitorTest, explicitReadWithVisitor_BigintRange_Dense) {
+TEST_P(ReadWithVisitorTest, explicitReadWithVisitorBigintRangeDense) {
   constexpr int kRows = 500;
   auto input = makeRowVector({makeFlatVector<int64_t>(kRows, folly::identity)});
   auto rowType = asRowType(input->type());
@@ -757,7 +840,7 @@ TEST_P(ReadWithVisitorTest, explicitReadWithVisitor_BigintRange_Dense) {
 }
 
 // Explicit readWithVisitor: AlwaysTrue filter (no filtering), dense rows.
-TEST_P(ReadWithVisitorTest, explicitReadWithVisitor_AlwaysTrue_Dense) {
+TEST_P(ReadWithVisitorTest, explicitReadWithVisitorAlwaysTrueDense) {
   constexpr int kRows = 200;
   auto input = makeRowVector(
       {makeFlatVector<int64_t>(kRows, [](auto i) { return i * 3; })});
@@ -803,7 +886,7 @@ TEST_P(ReadWithVisitorTest, explicitReadWithVisitor_AlwaysTrue_Dense) {
 }
 
 // Explicit readWithVisitor: BigintRange filter, sparse rows (non-dense).
-TEST_P(ReadWithVisitorTest, explicitReadWithVisitor_BigintRange_Sparse) {
+TEST_P(ReadWithVisitorTest, explicitReadWithVisitorBigintRangeSparse) {
   constexpr int kRows = 500;
   auto input = makeRowVector({makeFlatVector<int64_t>(kRows, folly::identity)});
   auto rowType = asRowType(input->type());
@@ -852,7 +935,7 @@ TEST_P(ReadWithVisitorTest, explicitReadWithVisitor_BigintRange_Sparse) {
 }
 
 // Explicit readWithVisitor: IsNotNull filter on nullable data.
-TEST_P(ReadWithVisitorTest, explicitReadWithVisitor_IsNotNull_Nullable) {
+TEST_P(ReadWithVisitorTest, explicitReadWithVisitorIsNotNullNullable) {
   constexpr int kRows = 300;
   auto input = makeRowVector(
       {makeFlatVector<int64_t>(kRows, folly::identity, nullEvery(5))});
@@ -936,7 +1019,7 @@ ReadWithVisitorParams makeReadWithVisitorParams(
 // ---------------------------------------------------------------------------
 // 1. TrivialEncoding<int64_t> + BigintRange + dense
 // ---------------------------------------------------------------------------
-TEST_P(ReadWithVisitorTest, encodingLevel_Trivial_BigintRange_Dense) {
+TEST_P(ReadWithVisitorTest, encodingLevelTrivialBigintRangeDense) {
   constexpr int kRows = 500;
 
   // Sequential data [0..499].
@@ -997,7 +1080,7 @@ TEST_P(ReadWithVisitorTest, encodingLevel_Trivial_BigintRange_Dense) {
 // ---------------------------------------------------------------------------
 // 2. ConstantEncoding<int64_t> + AlwaysTrue + dense
 // ---------------------------------------------------------------------------
-TEST_P(ReadWithVisitorTest, encodingLevel_Constant_AlwaysTrue_Dense) {
+TEST_P(ReadWithVisitorTest, encodingLevelConstantAlwaysTrueDense) {
   constexpr int kRows = 300;
 
   // All-same data.
@@ -1052,7 +1135,7 @@ TEST_P(ReadWithVisitorTest, encodingLevel_Constant_AlwaysTrue_Dense) {
 // ---------------------------------------------------------------------------
 // 3. FixedBitWidthEncoding<int64_t> + BigintRange + sparse
 // ---------------------------------------------------------------------------
-TEST_P(ReadWithVisitorTest, encodingLevel_FixedBitWidth_BigintRange_Sparse) {
+TEST_P(ReadWithVisitorTest, encodingLevelFixedBitWidthBigintRangeSparse) {
   constexpr int kRows = 500;
 
   // Small-range data [0..15] that fits in fixed-bit-width encoding.
@@ -1122,7 +1205,7 @@ TEST_P(ReadWithVisitorTest, encodingLevel_FixedBitWidth_BigintRange_Sparse) {
 // ---------------------------------------------------------------------------
 // 4. RLEEncoding<int64_t> + AlwaysTrue + dense
 // ---------------------------------------------------------------------------
-TEST_P(ReadWithVisitorTest, encodingLevel_RLE_AlwaysTrue_Dense) {
+TEST_P(ReadWithVisitorTest, encodingLevelRleAlwaysTrueDense) {
   constexpr int kRows = 500;
 
   // Repeated-run data: 50 copies of each value [0..9].
@@ -1182,7 +1265,7 @@ TEST_P(ReadWithVisitorTest, encodingLevel_RLE_AlwaysTrue_Dense) {
 // 5. TrivialEncoding<int64_t> + AlwaysTrue + dense + SLOW PATH
 //    hasBulkPath=false forces readWithVisitorSlow regardless of CPU features.
 // ---------------------------------------------------------------------------
-TEST_P(ReadWithVisitorTest, encodingLevel_Trivial_AlwaysTrue_Dense_SlowPath) {
+TEST_P(ReadWithVisitorTest, encodingLevelTrivialAlwaysTrueDenseSlowPath) {
   constexpr int kRows = 500;
 
   std::vector<int64_t> data(kRows);
@@ -1238,7 +1321,7 @@ TEST_P(ReadWithVisitorTest, encodingLevel_Trivial_AlwaysTrue_Dense_SlowPath) {
 // ---------------------------------------------------------------------------
 // 6. RLEEncoding<int64_t> + AlwaysTrue + dense + SLOW PATH
 // ---------------------------------------------------------------------------
-TEST_P(ReadWithVisitorTest, encodingLevel_RLE_AlwaysTrue_Dense_SlowPath) {
+TEST_P(ReadWithVisitorTest, encodingLevelRleAlwaysTrueDenseSlowPath) {
   constexpr int kRows = 500;
 
   std::vector<int64_t> data(kRows);
@@ -1297,7 +1380,7 @@ TEST_P(ReadWithVisitorTest, encodingLevel_RLE_AlwaysTrue_Dense_SlowPath) {
 // ---------------------------------------------------------------------------
 // 7. MainlyConstantEncoding<int64_t> + AlwaysTrue + dense (FAST path)
 // ---------------------------------------------------------------------------
-TEST_P(ReadWithVisitorTest, encodingLevel_MainlyConstant_AlwaysTrue_Dense) {
+TEST_P(ReadWithVisitorTest, encodingLevelMainlyConstantAlwaysTrueDense) {
   constexpr int kRows = 500;
 
   std::vector<int64_t> data(kRows, 42);
@@ -1358,7 +1441,7 @@ TEST_P(ReadWithVisitorTest, encodingLevel_MainlyConstant_AlwaysTrue_Dense) {
 // ---------------------------------------------------------------------------
 TEST_P(
     ReadWithVisitorTest,
-    encodingLevel_MainlyConstant_AlwaysTrue_Dense_SlowPath) {
+    encodingLevelMainlyConstantAlwaysTrueDenseSlowPath) {
   constexpr int kRows = 500;
 
   std::vector<int64_t> data(kRows, 42);
@@ -1420,7 +1503,7 @@ TEST_P(
 // 9. DictionaryEncoding<int64_t> + AlwaysTrue + dense
 //    Dictionary always uses slow path (no bulkScan).
 // ---------------------------------------------------------------------------
-TEST_P(ReadWithVisitorTest, encodingLevel_Dictionary_AlwaysTrue_Dense) {
+TEST_P(ReadWithVisitorTest, encodingLevelDictionaryAlwaysTrueDense) {
   constexpr int kRows = 500;
 
   std::vector<int64_t> data(kRows);
@@ -1477,7 +1560,7 @@ TEST_P(ReadWithVisitorTest, encodingLevel_Dictionary_AlwaysTrue_Dense) {
 // ---------------------------------------------------------------------------
 // 10. DictionaryEncoding<int64_t> + BigintRange + sparse
 // ---------------------------------------------------------------------------
-TEST_P(ReadWithVisitorTest, encodingLevel_Dictionary_BigintRange_Sparse) {
+TEST_P(ReadWithVisitorTest, encodingLevelDictionaryBigintRangeSparse) {
   constexpr int kRows = 500;
 
   std::vector<int64_t> data(kRows);
@@ -1546,7 +1629,7 @@ TEST_P(ReadWithVisitorTest, encodingLevel_Dictionary_BigintRange_Sparse) {
 // ---------------------------------------------------------------------------
 TEST_P(
     ReadWithVisitorTest,
-    encodingLevel_MainlyConstant_Dictionary_AlwaysTrue_Dense) {
+    encodingLevelMainlyConstantDictionaryAlwaysTrueDense) {
   constexpr int kRows = 500;
 
   // Mostly 42; non-common values cycle through {100, 101, 102}.
@@ -1605,7 +1688,7 @@ TEST_P(
 // ---------------------------------------------------------------------------
 TEST_P(
     ReadWithVisitorTest,
-    encodingLevel_MainlyConstant_Dictionary_AlwaysTrue_Dense_SlowPath) {
+    encodingLevelMainlyConstantDictionaryAlwaysTrueDenseSlowPath) {
   constexpr int kRows = 500;
 
   std::vector<int64_t> data(kRows, 42);
@@ -1671,7 +1754,7 @@ TEST_P(
 // ---------------------------------------------------------------------------
 TEST_P(
     ReadWithVisitorTest,
-    encodingLevel_FixedBitWidth_AlwaysTrue_Dense_Int32_FastPath) {
+    encodingLevelFixedBitWidthAlwaysTrueDenseInt32FastPath) {
   constexpr int kRows = 500;
 
   // Small-range int32 data that fits in fixed-bit-width encoding.
@@ -1739,7 +1822,7 @@ TEST_P(
 // ---------------------------------------------------------------------------
 TEST_P(
     ReadWithVisitorTest,
-    encodingLevel_FixedBitWidth_AlwaysTrue_Dense_Int32_FastPath_WithNulls) {
+    encodingLevelFixedBitWidthAlwaysTrueDenseInt32FastPathWithNulls) {
   constexpr int kRows = 500;
 
   // Build null bitmap: every 5th row is null.
@@ -1827,7 +1910,7 @@ TEST_P(
 // ---------------------------------------------------------------------------
 TEST_P(
     ReadWithVisitorTest,
-    encodingLevel_FixedBitWidth_AlwaysTrue_Sparse_Int32_FastPath) {
+    encodingLevelFixedBitWidthAlwaysTrueSparseInt32FastPath) {
   constexpr int kTotalRows = 500;
 
   // Small-range int32 data.
@@ -1893,7 +1976,7 @@ TEST_P(
 // ---------------------------------------------------------------------------
 TEST_P(
     ReadWithVisitorTest,
-    encodingLevel_FixedBitWidth_BigintRange_Dense_Int32_FastPath) {
+    encodingLevelFixedBitWidthBigintRangeDenseInt32FastPath) {
   constexpr int kRows = 500;
 
   std::vector<int32_t> data(kRows);
@@ -1962,7 +2045,7 @@ TEST_P(
 // ---------------------------------------------------------------------------
 TEST_P(
     ReadWithVisitorTest,
-    encodingLevel_FixedBitWidth_BigintRange_Sparse_Int32_FastPath) {
+    encodingLevelFixedBitWidthBigintRangeSparseInt32FastPath) {
   constexpr int kTotalRows = 500;
 
   std::vector<int32_t> data(kTotalRows);
@@ -2035,7 +2118,7 @@ TEST_P(
 // ---------------------------------------------------------------------------
 TEST_P(
     ReadWithVisitorTest,
-    encodingLevel_FixedBitWidth_BigintRange_Dense_Int32_FastPath_WithNulls) {
+    encodingLevelFixedBitWidthBigintRangeDenseInt32FastPathWithNulls) {
   constexpr int kRows = 500;
 
   // Build null bitmap: every 5th row is null.
@@ -2124,7 +2207,7 @@ TEST_P(
 // 14. DeltaEncoding<int64_t> + AlwaysTrue + dense
 //     Delta always uses slow path (no bulkScan).
 // ---------------------------------------------------------------------------
-TEST_P(ReadWithVisitorTest, encodingLevel_Delta_AlwaysTrue_Dense) {
+TEST_P(ReadWithVisitorTest, encodingLevelDeltaAlwaysTrueDense) {
   constexpr int kRows = 500;
 
   // Monotonically increasing data suitable for delta encoding.
@@ -2182,7 +2265,7 @@ TEST_P(ReadWithVisitorTest, encodingLevel_Delta_AlwaysTrue_Dense) {
 // ---------------------------------------------------------------------------
 // 15. DeltaEncoding<int64_t> + BigintRange + sparse
 // ---------------------------------------------------------------------------
-TEST_P(ReadWithVisitorTest, encodingLevel_Delta_BigintRange_Sparse) {
+TEST_P(ReadWithVisitorTest, encodingLevelDeltaBigintRangeSparse) {
   constexpr int kRows = 500;
 
   // Monotonically increasing data with occasional restatements.
@@ -2251,7 +2334,7 @@ TEST_P(ReadWithVisitorTest, encodingLevel_Delta_BigintRange_Sparse) {
 // ---------------------------------------------------------------------------
 // 16. DeltaEncoding<int64_t> + AlwaysTrue + dense + SLOW PATH
 // ---------------------------------------------------------------------------
-TEST_P(ReadWithVisitorTest, encodingLevel_Delta_AlwaysTrue_Dense_SlowPath) {
+TEST_P(ReadWithVisitorTest, encodingLevelDeltaAlwaysTrueDenseSlowPath) {
   constexpr int kRows = 500;
 
   std::vector<int64_t> data(kRows);
@@ -3181,6 +3264,656 @@ TEST_P(ReadWithVisitorTest, fuzzStringDictionaryEncoded) {
           std::string_view(expected.data(), expected.size()))
           << "row " << i;
     }
+  }
+}
+
+// ===========================================================================
+// MainlyConstant dictionary API tests
+// ===========================================================================
+
+// Verifies dictionaryEnabled/dictionarySize/dictionaryEntry on
+// MC<Dict<string>>. The combined alphabet is [innerAlphabet..., commonValue].
+TEST_P(ReadWithVisitorTest, mainlyConstantDictionaryApiString) {
+  if (!useNonLegacy()) {
+    GTEST_SKIP() << "MC dictionary API requires non-legacy encoding";
+  }
+  constexpr int kRows = 100;
+  const std::string_view commonValue = "common_value_long_string";
+  const std::string_view otherValues[] = {"alpha", "bravo", "charlie"};
+
+  std::vector<std::string_view> data(kRows, commonValue);
+  for (int i = 0; i < kRows; i += 10) {
+    data[i] = otherValues[(i / 10) % 3];
+  }
+
+  auto encoding = encodeMainlyConstantDictionary<std::string_view>(data);
+
+  ASSERT_EQ(encoding->encodingType(), EncodingType::MainlyConstant);
+  ASSERT_TRUE(encoding->dictionaryEnabled());
+
+  const auto alphabetSize = encoding->dictionarySize();
+  EXPECT_EQ(alphabetSize, 4);
+
+  std::set<std::string> entries;
+  for (uint32_t i = 0; i < alphabetSize; ++i) {
+    const auto* entry =
+        static_cast<const std::string_view*>(encoding->dictionaryEntry(i));
+    entries.insert(std::string(*entry));
+  }
+  EXPECT_TRUE(entries.count("alpha"));
+  EXPECT_TRUE(entries.count("bravo"));
+  EXPECT_TRUE(entries.count("charlie"));
+  EXPECT_TRUE(entries.count(std::string(commonValue)));
+}
+
+// Verifies dictionaryEnabled/dictionarySize/dictionaryEntry on MC<Dict<int64>>.
+TEST_P(ReadWithVisitorTest, mainlyConstantDictionaryApiInteger) {
+  if (!useNonLegacy()) {
+    GTEST_SKIP() << "MC dictionary API requires non-legacy encoding";
+  }
+  constexpr int kRows = 100;
+  constexpr int64_t commonValue = 42;
+
+  std::vector<int64_t> data(kRows, commonValue);
+  for (int i = 0; i < kRows; i += 10) {
+    data[i] = 100 + (i / 10) % 3;
+  }
+
+  Buffer buffer(*pool());
+  auto encoding = createFromCustomLayout<int64_t>(
+      MainlyConstantEnc{.otherValues = DictionaryEnc{}}, data, *pool(), buffer);
+
+  ASSERT_EQ(encoding->encodingType(), EncodingType::MainlyConstant);
+  ASSERT_TRUE(encoding->dictionaryEnabled());
+
+  const auto alphabetSize = encoding->dictionarySize();
+  EXPECT_EQ(alphabetSize, 4);
+
+  std::set<int64_t> entries;
+  for (uint32_t i = 0; i < alphabetSize; ++i) {
+    const auto* entry =
+        static_cast<const int64_t*>(encoding->dictionaryEntry(i));
+    entries.insert(*entry);
+  }
+  EXPECT_TRUE(entries.count(100));
+  EXPECT_TRUE(entries.count(101));
+  EXPECT_TRUE(entries.count(102));
+  EXPECT_TRUE(entries.count(commonValue));
+}
+
+// Verifies that MC without Dict inner encoding returns dictionaryEnabled=false.
+TEST_P(ReadWithVisitorTest, mainlyConstantNoDictionaryApi) {
+  constexpr int kRows = 100;
+  std::vector<int64_t> data(kRows, 42);
+  for (int i = 0; i < kRows; i += 10) {
+    data[i] = 100 + i;
+  }
+
+  Buffer buffer(*pool());
+  auto encoding = createFromCustomLayout<int64_t>(
+      MainlyConstantEnc{}, data, *pool(), buffer);
+
+  ASSERT_EQ(encoding->encodingType(), EncodingType::MainlyConstant);
+  EXPECT_FALSE(encoding->dictionaryEnabled());
+}
+
+// Fuzz readIndicesWithVisitor for MC→Dict string encoding.
+TEST_P(ReadWithVisitorTest, fuzzReadIndicesWithVisitorMainlyConstantString) {
+  if (!useNonLegacy()) {
+    GTEST_SKIP() << "readIndicesWithVisitor requires non-legacy encoding";
+  }
+  auto seed = folly::Random::rand32();
+  LOG(INFO) << "seed: " << seed;
+  std::mt19937 rng(seed);
+
+  constexpr int kNumRuns = 10;
+
+  for (int run = 0; run < kNumRuns; ++run) {
+    const int numRows = 20 + rng() % 200;
+    const int cardinality = 2 + rng() % 6;
+    const int commonPct = 70 + rng() % 25;
+
+    SCOPED_TRACE(
+        fmt::format(
+            "run={} seed={} numRows={} cardinality={} commonPct={}",
+            run,
+            seed,
+            numRows,
+            cardinality,
+            commonPct));
+
+    std::vector<std::string> otherPool;
+    for (int j = 0; j < cardinality; ++j) {
+      int len = 1 + rng() % 20;
+      std::string s;
+      for (int k = 0; k < len; ++k) {
+        s += static_cast<char>('a' + rng() % 26);
+      }
+      otherPool.push_back(std::move(s));
+    }
+    int commonLen = 10 + rng() % 40;
+    std::string commonValue(commonLen, 'x' + rng() % 3);
+
+    std::vector<std::string_view> data;
+    std::vector<std::string> storage;
+    storage.reserve(numRows);
+    data.reserve(numRows);
+    for (int i = 0; i < numRows; ++i) {
+      if (static_cast<int>(rng() % 100) < commonPct) {
+        storage.push_back(commonValue);
+      } else {
+        storage.push_back(otherPool[rng() % otherPool.size()]);
+      }
+      data.push_back(storage.back());
+    }
+
+    auto input = makeRowVector({makeFlatVector<StringView>(
+        numRows, [&](auto i) { return StringView(data[i]); })});
+    auto rowType = asRowType(input->type());
+    auto ctx = makeFileContext(input);
+    auto scanSpec = std::make_shared<common::ScanSpec>("root");
+    scanSpec->addAllChildFields(*rowType);
+    auto root = buildReader(*ctx, rowType, *scanSpec);
+
+    auto* structReader =
+        dynamic_cast<dwio::common::SelectiveStructColumnReaderBase*>(
+            root.get());
+    auto* reader = static_cast<StringColumnReaderTestAccessor*>(
+        structReader->children()[0]);
+
+    std::vector<vector_size_t> rowVec(numRows);
+    std::iota(rowVec.begin(), rowVec.end(), 0);
+    RowSet rows(rowVec.data(), rowVec.size());
+    reader->doPrepareReadAsIndices(0, rows, nullptr);
+
+    auto encoding = encodeMainlyConstantDictionary<std::string_view>(
+        std::vector<std::string_view>(data.begin(), data.end()));
+
+    ASSERT_TRUE(encoding->dictionaryEnabled());
+    auto alphabet =
+        buildEncodingDictionaryAlphabet<std::string_view>(encoding.get());
+
+    common::AlwaysTrue filter;
+    dwio::common::ExtractToReader extractValues(reader);
+    DecoderVisitor<
+        int32_t,
+        common::AlwaysTrue,
+        dwio::common::ExtractToReader,
+        /*isDense=*/true>
+        visitor(filter, reader, rows, extractValues);
+    auto params = makeReadWithVisitorParams(visitor, rows, pool());
+
+    callReadIndicesWithVisitor(*encoding, visitor, params);
+
+    ASSERT_EQ(reader->numValues(), numRows);
+    const auto* indices = reader->rawIndices();
+    for (int i = 0; i < numRows; ++i) {
+      ASSERT_GE(indices[i], 0) << "row " << i;
+      ASSERT_LT(indices[i], static_cast<int32_t>(alphabet.size()))
+          << "row " << i;
+      EXPECT_EQ(alphabet[indices[i]], data[i]) << "row " << i;
+    }
+  }
+}
+
+// Verifies that numValues() after readIndicesWithVisitor on MC→Dict equals
+// the total row count, not just the inner non-common count. The inner
+// encoding's bulkScan calls addNumValues with the non-common count; MC must
+// adjust to the full count.
+TEST_P(ReadWithVisitorTest, numValuesAfterMainlyConstantReadIndices) {
+  if (!useNonLegacy()) {
+    GTEST_SKIP() << "readIndicesWithVisitor requires non-legacy encoding";
+  }
+  constexpr int kRows = 50;
+  const std::string_view commonValue = "COMMON_VALUE_STRING";
+  const std::string_view otherValues[] = {"alpha", "bravo", "charlie"};
+
+  std::vector<std::string_view> data;
+  data.reserve(kRows);
+  int numCommon = 0;
+  for (int i = 0; i < kRows; ++i) {
+    if (i % 5 != 0) {
+      data.push_back(commonValue);
+      ++numCommon;
+    } else {
+      data.push_back(otherValues[i % 3]);
+    }
+  }
+  const int numNonCommon = kRows - numCommon;
+  ASSERT_GT(numCommon, 0);
+  ASSERT_GT(numNonCommon, 0);
+
+  auto input = makeRowVector({makeFlatVector<StringView>(
+      kRows, [&](auto i) { return StringView(data[i]); })});
+  auto rowType = asRowType(input->type());
+  auto ctx = makeFileContext(input);
+  auto scanSpec = std::make_shared<common::ScanSpec>("root");
+  scanSpec->addAllChildFields(*rowType);
+  auto root = buildReader(*ctx, rowType, *scanSpec);
+
+  auto* structReader =
+      dynamic_cast<dwio::common::SelectiveStructColumnReaderBase*>(root.get());
+  auto* reader =
+      static_cast<StringColumnReaderTestAccessor*>(structReader->children()[0]);
+
+  std::vector<vector_size_t> rowVec(kRows);
+  std::iota(rowVec.begin(), rowVec.end(), 0);
+  RowSet rows(rowVec.data(), rowVec.size());
+  reader->doPrepareReadAsIndices(0, rows, nullptr);
+
+  auto encoding = encodeMainlyConstantDictionary<std::string_view>(
+      std::vector<std::string_view>(data.begin(), data.end()));
+  ASSERT_TRUE(encoding->dictionaryEnabled());
+
+  common::AlwaysTrue filter;
+  dwio::common::ExtractToReader extractValues(reader);
+  DecoderVisitor<
+      int32_t,
+      common::AlwaysTrue,
+      dwio::common::ExtractToReader,
+      /*isDense=*/true>
+      visitor(filter, reader, rows, extractValues);
+  auto params = makeReadWithVisitorParams(visitor, rows, pool());
+
+  ASSERT_EQ(reader->numValues(), 0);
+  callReadIndicesWithVisitor(*encoding, visitor, params);
+
+  // numValues must equal kRows (all rows), not just numNonCommon
+  // (what the inner Dict encoding's bulkScan wrote via addNumValues).
+  EXPECT_EQ(reader->numValues(), kRows)
+      << "numValues should be total rows (" << kRows
+      << "), not just non-common rows (" << numNonCommon << ")";
+}
+
+// ===========================================================================
+// Tests for detail::readDenseMaterializedIndices and
+// detail::readSparseMaterializedIndices helper functions.
+// ===========================================================================
+
+// Verifies that readDenseMaterializedIndices writes correct dictionary indices
+// to rawValues_ and updates visitor state (numValues, rowIndex).
+TEST_P(ReadWithVisitorTest, readDenseMaterializedIndicesNoNulls) {
+  if (!useNonLegacy()) {
+    GTEST_SKIP() << "readDenseMaterializedIndices requires non-legacy encoding";
+  }
+  constexpr int kRows = 100;
+  constexpr int64_t kDistinct[] = {10, 20, 30};
+
+  // Build data with 3 distinct values cycling.
+  std::vector<int64_t> data(kRows);
+  for (int i = 0; i < kRows; ++i) {
+    data[i] = kDistinct[i % 3];
+  }
+
+  // Create reader infrastructure.
+  auto input = makeRowVector(
+      {makeFlatVector<int64_t>(kRows, [&](auto i) { return data[i]; })});
+  auto rowType = asRowType(input->type());
+  auto ctx = makeFileContext(input);
+  auto scanSpec = std::make_shared<common::ScanSpec>("root");
+  scanSpec->addAllChildFields(*rowType);
+  scanSpec->childByName("c0")->setFilter(
+      std::make_unique<common::AlwaysTrue>());
+  auto root = buildReader(*ctx, rowType, *scanSpec);
+
+  auto* structReader =
+      dynamic_cast<dwio::common::SelectiveStructColumnReaderBase*>(root.get());
+  auto* reader = static_cast<IntegerColumnReaderTestAccessor*>(
+      dynamic_cast<IntegerColumnReader*>(structReader->children()[0]));
+  ASSERT_NE(reader, nullptr);
+
+  std::vector<vector_size_t> rowVec(kRows);
+  std::iota(rowVec.begin(), rowVec.end(), 0);
+  RowSet rows(rowVec.data(), rowVec.size());
+  reader->doPrepareRead<int32_t>(0, rows, nullptr);
+
+  // Encode as DictionaryEncoding independently.
+  Buffer buffer(*pool());
+  auto encoding =
+      createFromCustomLayout<int64_t>(DictionaryEnc{}, data, *pool(), buffer);
+  ASSERT_TRUE(encoding->dictionaryEnabled());
+  const auto* alphabet =
+      static_cast<const int64_t*>(encoding->dictionaryEntries());
+  const auto alphabetSize = encoding->dictionarySize();
+
+  // Build visitor.
+  common::AlwaysTrue filter;
+  dwio::common::ExtractToReader extractValues(reader);
+  constexpr bool kIsDense = true;
+  DecoderVisitor<
+      int32_t,
+      common::AlwaysTrue,
+      dwio::common::ExtractToReader,
+      kIsDense>
+      visitor(filter, reader, rows, extractValues);
+
+  // Verify numValues is 0 before the call.
+  ASSERT_EQ(reader->numValues(), 0);
+
+  // Call the helper with no nulls.
+  detail::readDenseMaterializedIndices(
+      *encoding,
+      visitor,
+      /*rawNulls=*/nullptr,
+      /*readOffset=*/0,
+      /*numReadRows=*/kRows,
+      /*numNonNulls=*/kRows);
+
+  // Verify numValues was updated by the helper.
+  EXPECT_EQ(reader->numValues(), kRows);
+
+  // Verify indices in rawValues_.
+  const auto* indices = reader->rawIndices();
+  for (int i = 0; i < kRows; ++i) {
+    SCOPED_TRACE(fmt::format("row {}", i));
+    ASSERT_GE(indices[i], 0);
+    ASSERT_LT(indices[i], static_cast<int32_t>(alphabetSize));
+    EXPECT_EQ(alphabet[indices[i]], data[i]);
+  }
+}
+
+// Verifies that readDenseMaterializedIndices correctly scatters indices when
+// a null bitmap is present (every 5th row null). Non-null positions should
+// have correct indices; null positions are gaps.
+TEST_P(ReadWithVisitorTest, readDenseMaterializedIndicesWithNulls) {
+  if (!useNonLegacy()) {
+    GTEST_SKIP() << "readDenseMaterializedIndices requires non-legacy encoding";
+  }
+  constexpr int kRows = 100;
+  constexpr int64_t kDistinct[] = {10, 20, 30};
+
+  // Build data with 3 distinct values cycling.
+  std::vector<int64_t> data(kRows);
+  for (int i = 0; i < kRows; ++i) {
+    data[i] = kDistinct[i % 3];
+  }
+
+  // Build null bitmap: every 5th row is null.
+  auto nulls = velox::allocateNulls(kRows, pool(), velox::bits::kNotNull);
+  auto* rawNulls = nulls->asMutable<uint64_t>();
+  int numNonNull = 0;
+  for (int i = 0; i < kRows; ++i) {
+    if (i % 5 == 0) {
+      velox::bits::setNull(rawNulls, i);
+    } else {
+      ++numNonNull;
+    }
+  }
+
+  // Build non-null-only data for encoding.
+  std::vector<int64_t> nonNullData;
+  nonNullData.reserve(numNonNull);
+  for (int i = 0; i < kRows; ++i) {
+    if (i % 5 != 0) {
+      nonNullData.push_back(data[i]);
+    }
+  }
+
+  // Create reader infrastructure.
+  auto input = makeRowVector(
+      {makeFlatVector<int64_t>(kRows, [&](auto i) { return data[i]; })});
+  auto rowType = asRowType(input->type());
+  auto ctx = makeFileContext(input);
+  auto scanSpec = std::make_shared<common::ScanSpec>("root");
+  scanSpec->addAllChildFields(*rowType);
+  scanSpec->childByName("c0")->setFilter(
+      std::make_unique<common::AlwaysTrue>());
+  auto root = buildReader(*ctx, rowType, *scanSpec);
+
+  auto* structReader =
+      dynamic_cast<dwio::common::SelectiveStructColumnReaderBase*>(root.get());
+  auto* reader = static_cast<IntegerColumnReaderTestAccessor*>(
+      dynamic_cast<IntegerColumnReader*>(structReader->children()[0]));
+  ASSERT_NE(reader, nullptr);
+
+  std::vector<vector_size_t> rowVec(kRows);
+  std::iota(rowVec.begin(), rowVec.end(), 0);
+  RowSet rows(rowVec.data(), rowVec.size());
+  reader->doPrepareRead<int32_t>(0, rows, nullptr);
+
+  // Encode only non-null values as DictionaryEncoding.
+  Buffer buffer(*pool());
+  auto encoding = createFromCustomLayout<int64_t>(
+      DictionaryEnc{}, nonNullData, *pool(), buffer);
+  ASSERT_TRUE(encoding->dictionaryEnabled());
+  const auto* alphabet =
+      static_cast<const int64_t*>(encoding->dictionaryEntries());
+  const auto alphabetSize = encoding->dictionarySize();
+
+  // Build visitor.
+  common::AlwaysTrue filter;
+  dwio::common::ExtractToReader extractValues(reader);
+  constexpr bool kIsDense = true;
+  DecoderVisitor<
+      int32_t,
+      common::AlwaysTrue,
+      dwio::common::ExtractToReader,
+      kIsDense>
+      visitor(filter, reader, rows, extractValues);
+
+  ASSERT_EQ(reader->numValues(), 0);
+
+  // Call the helper with nulls.
+  detail::readDenseMaterializedIndices(
+      *encoding,
+      visitor,
+      rawNulls,
+      /*readOffset=*/0,
+      /*numReadRows=*/kRows,
+      /*numNonNulls=*/numNonNull);
+
+  // Verify numValues was updated by the helper.
+  EXPECT_EQ(reader->numValues(), kRows);
+
+  // Verify non-null positions have correct indices.
+  const auto* indices = reader->rawIndices();
+  for (int i = 0; i < kRows; ++i) {
+    if (i % 5 == 0) {
+      continue;
+    }
+    SCOPED_TRACE(fmt::format("row {}", i));
+    ASSERT_GE(indices[i], 0);
+    ASSERT_LT(indices[i], static_cast<int32_t>(alphabetSize));
+    EXPECT_EQ(alphabet[indices[i]], data[i]);
+  }
+}
+
+// Verifies that readSparseMaterializedIndices materializes and gathers the
+// correct indices for a sparse (non-dense) row set, and updates visitor state.
+TEST_P(ReadWithVisitorTest, readSparseMaterializedIndices) {
+  if (!useNonLegacy()) {
+    GTEST_SKIP()
+        << "readSparseMaterializedIndices requires non-legacy encoding";
+  }
+  constexpr int kTotalRows = 30;
+  constexpr int64_t kDistinct[] = {10, 20, 30};
+
+  // Build data with 3 distinct values cycling.
+  std::vector<int64_t> data(kTotalRows);
+  for (int i = 0; i < kTotalRows; ++i) {
+    data[i] = kDistinct[i % 3];
+  }
+
+  // Create reader infrastructure.
+  auto input = makeRowVector(
+      {makeFlatVector<int64_t>(kTotalRows, [&](auto i) { return data[i]; })});
+  auto rowType = asRowType(input->type());
+  auto ctx = makeFileContext(input);
+  auto scanSpec = std::make_shared<common::ScanSpec>("root");
+  scanSpec->addAllChildFields(*rowType);
+  scanSpec->childByName("c0")->setFilter(
+      std::make_unique<common::AlwaysTrue>());
+  auto root = buildReader(*ctx, rowType, *scanSpec);
+
+  auto* structReader =
+      dynamic_cast<dwio::common::SelectiveStructColumnReaderBase*>(root.get());
+  auto* reader = static_cast<IntegerColumnReaderTestAccessor*>(
+      dynamic_cast<IntegerColumnReader*>(structReader->children()[0]));
+  ASSERT_NE(reader, nullptr);
+
+  // Sparse row set: rows [2, 5, 8].
+  std::vector<vector_size_t> sparseRows = {2, 5, 8};
+  RowSet rows(sparseRows.data(), sparseRows.size());
+  reader->doPrepareRead<int32_t>(0, rows, nullptr);
+
+  // Encode as DictionaryEncoding.
+  Buffer buffer(*pool());
+  auto encoding =
+      createFromCustomLayout<int64_t>(DictionaryEnc{}, data, *pool(), buffer);
+  ASSERT_TRUE(encoding->dictionaryEnabled());
+  const auto* alphabet =
+      static_cast<const int64_t*>(encoding->dictionaryEntries());
+  const auto alphabetSize = encoding->dictionarySize();
+
+  // Build visitor with sparse (non-dense) rows.
+  common::AlwaysTrue filter;
+  dwio::common::ExtractToReader extractValues(reader);
+  constexpr bool kIsDense = false;
+  DecoderVisitor<
+      int32_t,
+      common::AlwaysTrue,
+      dwio::common::ExtractToReader,
+      kIsDense>
+      visitor(filter, reader, rows, extractValues);
+  auto params = makeReadWithVisitorParams(visitor, rows, pool());
+
+  ASSERT_EQ(reader->numValues(), 0);
+
+  // Call the helper.
+  std::vector<uint32_t> scratchBuffer(kTotalRows);
+  detail::readSparseMaterializedIndices(
+      *encoding,
+      visitor,
+      params.numScanned,
+      params.prepareResultNulls,
+      /*rawNulls=*/nullptr,
+      /*numReadRows=*/kTotalRows,
+      /*numNonNulls=*/kTotalRows,
+      scratchBuffer.data());
+
+  // Verify numValues was updated by the helper.
+  EXPECT_EQ(reader->numValues(), static_cast<int32_t>(sparseRows.size()));
+
+  // Verify gathered indices match the selected rows.
+  const auto* indices = reader->rawIndices();
+  for (int i = 0; i < static_cast<int>(sparseRows.size()); ++i) {
+    SCOPED_TRACE(fmt::format("sparse index {} (row {})", i, sparseRows[i]));
+    ASSERT_GE(indices[i], 0);
+    ASSERT_LT(indices[i], static_cast<int32_t>(alphabetSize));
+    EXPECT_EQ(alphabet[indices[i]], data[sparseRows[i]]);
+  }
+}
+
+// Verifies that readSparseMaterializedIndices correctly skips null rows in a
+// sparse row set. Null rows should not produce output values.
+TEST_P(ReadWithVisitorTest, readSparseMaterializedIndicesWithNulls) {
+  if (!useNonLegacy()) {
+    GTEST_SKIP()
+        << "readSparseMaterializedIndices requires non-legacy encoding";
+  }
+  constexpr int kTotalRows = 30;
+  constexpr int64_t kDistinct[] = {10, 20, 30};
+
+  // Build data with 3 distinct values cycling.
+  std::vector<int64_t> data(kTotalRows);
+  for (int i = 0; i < kTotalRows; ++i) {
+    data[i] = kDistinct[i % 3];
+  }
+
+  // Build null bitmap: rows 0, 5, 10, 15, 20, 25 are null.
+  auto nulls = velox::allocateNulls(kTotalRows, pool(), velox::bits::kNotNull);
+  auto* rawNulls = nulls->asMutable<uint64_t>();
+  int numNonNull = 0;
+  for (int i = 0; i < kTotalRows; ++i) {
+    if (i % 5 == 0) {
+      velox::bits::setNull(rawNulls, i);
+    } else {
+      ++numNonNull;
+    }
+  }
+
+  // Build non-null-only data for encoding.
+  std::vector<int64_t> nonNullData;
+  nonNullData.reserve(numNonNull);
+  for (int i = 0; i < kTotalRows; ++i) {
+    if (i % 5 != 0) {
+      nonNullData.push_back(data[i]);
+    }
+  }
+
+  // Create reader infrastructure.
+  auto input = makeRowVector(
+      {makeFlatVector<int64_t>(kTotalRows, [&](auto i) { return data[i]; })});
+  auto rowType = asRowType(input->type());
+  auto ctx = makeFileContext(input);
+  auto scanSpec = std::make_shared<common::ScanSpec>("root");
+  scanSpec->addAllChildFields(*rowType);
+  scanSpec->childByName("c0")->setFilter(
+      std::make_unique<common::AlwaysTrue>());
+  auto root = buildReader(*ctx, rowType, *scanSpec);
+
+  auto* structReader =
+      dynamic_cast<dwio::common::SelectiveStructColumnReaderBase*>(root.get());
+  auto* reader = static_cast<IntegerColumnReaderTestAccessor*>(
+      dynamic_cast<IntegerColumnReader*>(structReader->children()[0]));
+  ASSERT_NE(reader, nullptr);
+
+  // Sparse row set: rows [2, 5, 8, 10, 13].
+  // Row 5 and 10 are null; rows 2, 8, 13 are non-null.
+  std::vector<vector_size_t> sparseRows = {2, 5, 8, 10, 13};
+  RowSet rows(sparseRows.data(), sparseRows.size());
+  reader->doPrepareRead<int32_t>(0, rows, nullptr);
+
+  // Encode only non-null values as DictionaryEncoding.
+  Buffer buffer(*pool());
+  auto encoding = createFromCustomLayout<int64_t>(
+      DictionaryEnc{}, nonNullData, *pool(), buffer);
+  ASSERT_TRUE(encoding->dictionaryEnabled());
+  const auto* alphabet =
+      static_cast<const int64_t*>(encoding->dictionaryEntries());
+  const auto alphabetSize = encoding->dictionarySize();
+
+  // Build visitor with sparse (non-dense) rows.
+  common::AlwaysTrue filter;
+  dwio::common::ExtractToReader extractValues(reader);
+  constexpr bool kIsDense = false;
+  DecoderVisitor<
+      int32_t,
+      common::AlwaysTrue,
+      dwio::common::ExtractToReader,
+      kIsDense>
+      visitor(filter, reader, rows, extractValues);
+  auto params = makeReadWithVisitorParams(visitor, rows, pool());
+
+  ASSERT_EQ(reader->numValues(), 0);
+
+  // Call the helper.
+  std::vector<uint32_t> scratchBuffer(numNonNull);
+  detail::readSparseMaterializedIndices(
+      *encoding,
+      visitor,
+      params.numScanned,
+      params.prepareResultNulls,
+      rawNulls,
+      /*numReadRows=*/kTotalRows,
+      /*numNonNulls=*/numNonNull,
+      scratchBuffer.data());
+
+  // Verify numValues was updated by the helper.
+  EXPECT_EQ(reader->numValues(), static_cast<int32_t>(sparseRows.size()));
+
+  // Verify gathered indices for non-null rows.
+  const auto* indices = reader->rawIndices();
+  for (int i = 0; i < static_cast<int>(sparseRows.size()); ++i) {
+    const auto row = sparseRows[i];
+    if (row % 5 == 0) {
+      // Null row — skipped by readSparseMaterializedIndices.
+      continue;
+    }
+    SCOPED_TRACE(fmt::format("sparse index {} (row {})", i, row));
+    ASSERT_GE(indices[i], 0);
+    ASSERT_LT(indices[i], static_cast<int32_t>(alphabetSize));
+    EXPECT_EQ(alphabet[indices[i]], data[row]);
   }
 }
 

--- a/dwio/nimble/velox/selective/ChunkedDecoder.cpp
+++ b/dwio/nimble/velox/selective/ChunkedDecoder.cpp
@@ -372,10 +372,9 @@ std::optional<size_t> ChunkedDecoder::estimateStringDataSize() const {
   return stringDataSizeEstimate_;
 }
 
-bool ChunkedDecoder::dictionaryConvertible() {
+bool ChunkedDecoder::dictionaryConvertible() const {
   NIMBLE_CHECK_NOT_NULL(
       encoding_, "Call ensureLoaded() before dictionaryConvertible()");
   return encoding_->dictionaryEnabled();
 }
-
 } // namespace facebook::nimble

--- a/dwio/nimble/velox/selective/ChunkedDecoder.h
+++ b/dwio/nimble/velox/selective/ChunkedDecoder.h
@@ -19,6 +19,7 @@
 #include "dwio/nimble/common/ChunkHeader.h"
 #include "dwio/nimble/encodings/DictionaryEncoding.h"
 #include "dwio/nimble/encodings/EncodingUtils.h"
+#include "dwio/nimble/encodings/MainlyConstantEncoding.h"
 #include "dwio/nimble/encodings/NullableEncoding.h"
 #include "dwio/nimble/encodings/legacy/EncodingTrait.h"
 #include "dwio/nimble/index/ChunkIndexGroup.h"
@@ -228,7 +229,7 @@ class ChunkedDecoder {
   /// Ensures a chunk with remaining values is loaded. Loads the first chunk
   /// if none has been loaded yet, or advances to the next chunk if the current
   /// one is fully consumed. Called before inspecting the current encoding
-  /// (e.g., dictionaryConvertible, currentEncoding) so that the caller sees
+  /// (e.g., currentEncoding, dictionaryConvertible) so that the caller sees
   /// the encoding and remainingValues of the chunk that will actually be read.
   void ensureLoaded() {
     if (encoding_ != nullptr && remainingValues_ != 0) {
@@ -245,10 +246,11 @@ class ChunkedDecoder {
     return encoding_.get();
   }
 
-  /// Returns true if the current chunk's encoding is convertible to dictionary
-  /// indices (Dictionary or Nullable wrapping Dictionary).
+  /// Returns true if the current chunk's encoding supports dictionary index
+  /// reading. Delegates to Encoding::dictionaryEnabled() which handles Dict,
+  /// Nullable→Dict, and MC→Dict via virtual dispatch.
   /// Caller must call ensureLoaded() first.
-  bool dictionaryConvertible();
+  bool dictionaryConvertible() const;
 
   int64_t remainingValues() const {
     return remainingValues_;
@@ -258,6 +260,10 @@ class ChunkedDecoder {
   /// Non-legacy encodings only: requires stringDecoderZeroCopy_ == true.
   template <typename DictionaryVisitor>
   void readDictionaryIndices(DictionaryVisitor& visitor) {
+    // Dictionary indices reading requires the non-legacy encoding path.
+    // callReadIndicesWithVisitor static_casts to DictionaryEncoding /
+    // NullableEncoding / MainlyConstantEncoding which only exist in the
+    // non-legacy path (stringDecoderZeroCopy_ == true).
     NIMBLE_CHECK(
         stringDecoderZeroCopy_,
         "Dictionary indices reading requires non-legacy encoding path");
@@ -643,8 +649,8 @@ class ChunkedDecoder {
   // Tracks the current row position in the stream.
   uint32_t rowPosition_{0};
 
-  // Callback invoked at the start of loadNextChunk(). Used by
-  // StringColumnReader to invalidate dictionary state on chunk transitions.
+  // Callback invoked on chunk transitions. Used to clear cached state
+  // (e.g., alphabet, dictionaryValues) in the owning column reader.
   std::function<void()> onChunkLoad_;
 
   friend class ChunkedDecoderTestHelper;

--- a/dwio/nimble/velox/selective/tests/CMakeLists.txt
+++ b/dwio/nimble/velox/selective/tests/CMakeLists.txt
@@ -35,6 +35,7 @@ target_link_libraries(
   nimble_velox_selective_tests
   nimble_velox_selective
   nimble_common_file_writer
+  nimble_encoding_layout_test_helper
   nimble_index_test_base
   velox_vector_test_lib
   velox_vector_fuzzer

--- a/dwio/nimble/velox/selective/tests/ChunkedDecoderTest.cpp
+++ b/dwio/nimble/velox/selective/tests/ChunkedDecoderTest.cpp
@@ -25,6 +25,7 @@
 #include "dwio/nimble/encodings/legacy/EncodingUtils.h"
 #include "dwio/nimble/encodings/selection/EncodingSelection.h"
 #include "dwio/nimble/encodings/selection/EncodingSelectionPolicy.h"
+#include "dwio/nimble/encodings/tests/EncodingLayoutTestHelper.h"
 #include "dwio/nimble/index/tests/ClusterIndexTestBase.h"
 #include "dwio/nimble/velox/ChunkedStreamWriter.h"
 #include "velox/common/base/Nulls.h"
@@ -1443,6 +1444,126 @@ TEST_P(ChunkedDecoderDataTest, ensureLoadedFiresOnChunkLoadOnReload) {
   decoder.ensureLoaded();
   EXPECT_EQ(callbackCount, 2);
   EXPECT_EQ(decoder.remainingValues(), 3);
+}
+
+// DictionaryEnc with StringTrivialEnc for the alphabet, suitable for
+// encoding std::string_view data.
+DictionaryEnc stringDictEnc() {
+  return DictionaryEnc{.alphabet = StringTrivialEnc{}};
+}
+
+class ChunkedDecoderDictTest : public ChunkedDecoderTest {
+ protected:
+  // Encodes string values into a chunked stream using the given encoding
+  // layout. Returns the encoded stream data.
+  std::string encodeStringChunkedStream(
+      const std::vector<std::vector<std::string_view>>& chunks,
+      const EncodingLayout& layout) {
+    Buffer buffer{pool()};
+    std::string streamData;
+
+    for (const auto& chunk : chunks) {
+      // The factory must outlive the policy because
+      // ReplayedEncodingSelectionPolicy stores it by reference.
+      EncodingSelectionPolicyFactory factory =
+          [](DataType type) -> std::unique_ptr<EncodingSelectionPolicyBase> {
+        UNIQUE_PTR_FACTORY(type, TrivialNestedPolicy);
+      };
+      auto policy =
+          std::make_unique<ReplayedEncodingSelectionPolicy<std::string_view>>(
+              layout, CompressionOptions{}, factory);
+      auto encoded = EncodingFactory::encode<std::string_view>(
+          std::move(policy),
+          std::span<const std::string_view>(chunk.data(), chunk.size()),
+          buffer);
+
+      ChunkedStreamWriter writer{
+          buffer, {.type = CompressionType::Uncompressed}};
+      for (const auto& segment : writer.encode(encoded)) {
+        streamData += segment;
+      }
+    }
+    return streamData;
+  }
+
+  // Encodes nullable string values into a chunked stream.
+  std::string encodeNullableStringChunkedStream(
+      const std::vector<std::vector<std::optional<std::string_view>>>& chunks,
+      const EncodingLayout& dataLayout) {
+    Buffer buffer{pool()};
+    std::string streamData;
+
+    for (const auto& chunk : chunks) {
+      std::vector<std::string_view> nonNullValues;
+      Vector<bool> nulls(&pool());
+      nulls.resize(chunk.size());
+      for (size_t i = 0; i < chunk.size(); ++i) {
+        nulls[i] = chunk[i].has_value();
+        if (chunk[i].has_value()) {
+          nonNullValues.push_back(*chunk[i]);
+        }
+      }
+
+      // Pass just the data layout; ReplayedEncodingSelectionPolicy::
+      // selectNullable() will automatically wrap it in a Nullable layout.
+      // The factory must outlive the policy because
+      // ReplayedEncodingSelectionPolicy stores it by reference.
+      EncodingSelectionPolicyFactory factory =
+          [](DataType type) -> std::unique_ptr<EncodingSelectionPolicyBase> {
+        UNIQUE_PTR_FACTORY(type, TrivialNestedPolicy);
+      };
+      auto policy =
+          std::make_unique<ReplayedEncodingSelectionPolicy<std::string_view>>(
+              dataLayout, CompressionOptions{}, factory);
+
+      auto encoded = EncodingFactory::encodeNullable<std::string_view>(
+          std::move(policy),
+          std::span<const std::string_view>(
+              nonNullValues.data(), nonNullValues.size()),
+          std::span<const bool>(nulls.data(), nulls.size()),
+          buffer);
+
+      ChunkedStreamWriter writer{
+          buffer, {.type = CompressionType::Uncompressed}};
+      for (const auto& segment : writer.encode(encoded)) {
+        streamData += segment;
+      }
+    }
+    return streamData;
+  }
+
+  // Creates a ChunkedDecoder from encoded string stream data.
+  ChunkedDecoder createStringDecoder(const std::string& streamData) {
+    return ChunkedDecoder(
+        std::make_unique<dwio::common::SeekableArrayInputStream>(
+            streamData.data(), streamData.size()),
+        /*streamIndex=*/nullptr,
+        /*decodeValuesWithNulls=*/false,
+        &encodingFactory(),
+        &pool(),
+        /*stringDecoderZeroCopy=*/true);
+  }
+};
+
+// Verify buildAlphabet for a simple Dictionary encoding.
+// Verify string buffers keep alphabet data alive after reading a
+// dictionary-encoded string chunk.
+TEST_F(ChunkedDecoderDictTest, stringBuffersAfterChunkLoad) {
+  std::vector<std::string_view> data = {"hello", "world", "hello"};
+  auto streamData = encodeStringChunkedStream({data}, stringDictEnc());
+
+  auto decoder = createStringDecoder(streamData);
+  decoder.ensureLoaded();
+  ASSERT_TRUE(decoder.dictionaryConvertible());
+
+  // Build the alphabet — string_views point into the encoding's string
+  // buffers that were allocated during loadNextChunk.
+  auto alphabet = buildEncodingDictionaryAlphabet<std::string_view>(
+      decoder.currentEncoding());
+  ASSERT_EQ(alphabet.size(), 2);
+  std::set<std::string> entries(alphabet.begin(), alphabet.end());
+  EXPECT_TRUE(entries.count("hello"));
+  EXPECT_TRUE(entries.count("world"));
 }
 
 } // namespace

--- a/dwio/nimble/velox/selective/tests/E2EFilterTest.cpp
+++ b/dwio/nimble/velox/selective/tests/E2EFilterTest.cpp
@@ -358,7 +358,6 @@ class E2EFilterTest
     // Branch on whether we need forced dictionary encoding, since
     // EncodingLayoutTree is not move-assignable due to const members.
     if (useForcedDictionaryEncoding_) {
-      // Need to set encodingLayoutTree at construction time.
       options.encodingLayoutTree.emplace(
           buildForcedDictionaryEncodingLayoutTree());
     }
@@ -378,7 +377,8 @@ class E2EFilterTest
     if (param().enableCache) {
       auto readFile = std::make_shared<InMemoryReadFile>(sinkData_);
       auto& ids = fileIds();
-      StringIdLease fileId(ids, "testFile");
+      StringIdLease fileId(
+          ids, fmt::format("testFile_{}", reinterpret_cast<uintptr_t>(this)));
       StringIdLease groupId(ids, "testGroup");
       io::ReaderOptions cacheReaderOpts(&readerOpts.memoryPool());
       cacheReaderOpts.setDataIoStats(dataIoStats_);
@@ -432,6 +432,8 @@ class E2EFilterTest
                   EncodingLayout{
                       EncodingType::Dictionary,
                       {},
+                      // Required by EncodingLayout constructor; does not
+                      // override the encoding selection policy's choice.
                       CompressionType::Uncompressed,
                       {
                           // Alphabet (id=0): let writer decide
@@ -446,6 +448,118 @@ class E2EFilterTest
       }
     }
     return EncodingLayoutTree{Kind::Row, {}, "", std::move(children)};
+  }
+
+  EncodingLayoutTree buildForcedMainlyConstantDictionaryEncodingLayoutTree() {
+    std::vector<EncodingLayoutTree> children;
+    for (column_index_t i = 0;
+         i < static_cast<column_index_t>(rowType_->size());
+         ++i) {
+      const auto& childType = rowType_->childAt(i);
+      const auto& childName = rowType_->nameOf(i);
+
+      if (childType->isVarchar() || childType->isVarbinary()) {
+        // CompressionType::Uncompressed is required by EncodingLayout
+        // constructor; does not override the encoding selection policy.
+        EncodingLayout dictLayout{
+            EncodingType::Dictionary,
+            {},
+            CompressionType::Uncompressed,
+            {std::nullopt, std::nullopt}};
+        children.push_back(
+            EncodingLayoutTree{
+                Kind::Scalar,
+                {{EncodingLayoutTree::StreamIdentifiers::Scalar::ScalarStream,
+                  EncodingLayout{
+                      EncodingType::MainlyConstant,
+                      {},
+                      CompressionType::Uncompressed,
+                      {std::nullopt, std::move(dictLayout)}}}},
+                std::string(childName)});
+      } else {
+        children.push_back(
+            EncodingLayoutTree{Kind::Scalar, {}, std::string(childName)});
+      }
+    }
+    return EncodingLayoutTree{Kind::Row, {}, "", std::move(children)};
+  }
+
+  void verifyDictionaryVectorReturned(
+      EncodingLayoutTree layoutTree,
+      const std::vector<std::string>& stringData) {
+    auto type = asRowType(rowType_);
+    const auto kRowCount = static_cast<vector_size_t>(stringData.size());
+
+    auto stringVector =
+        velox::test::VectorMaker(leafPool_.get())
+            .flatVector<velox::StringView>(kRowCount, [&](auto row) {
+              return velox::StringView(stringData[row]);
+            });
+    auto longVector = velox::test::VectorMaker(leafPool_.get())
+                          .flatVector<int64_t>(kRowCount, [](auto row) {
+                            return static_cast<int64_t>(row);
+                          });
+
+    auto batch = std::make_shared<RowVector>(
+        leafPool_.get(),
+        type,
+        nullptr,
+        kRowCount,
+        std::vector<VectorPtr>{stringVector, longVector});
+
+    {
+      auto writeFile = std::make_unique<InMemoryWriteFile>(&sinkData_);
+      VeloxWriterOptions writerOptions;
+      writerOptions.encodingLayoutTree.emplace(std::move(layoutTree));
+      VeloxWriter writer(
+          type, std::move(writeFile), *rootPool_, std::move(writerOptions));
+      writer.write(batch);
+      writer.close();
+    }
+
+    auto input = std::make_unique<velox::dwio::common::BufferedInput>(
+        std::make_shared<velox::InMemoryReadFile>(sinkData_),
+        *leafPool_,
+        velox::dwio::common::MetricsLog::voidLog());
+
+    auto dataIoStats = std::make_shared<velox::io::IoStatistics>();
+    auto metadataIoStats = std::make_shared<velox::io::IoStatistics>();
+    velox::dwio::common::ReaderOptions readerOpts(leafPool_.get());
+    readerOpts.setDataIoStats(dataIoStats);
+    readerOpts.setMetadataIoStats(metadataIoStats);
+    auto reader = makeReader(readerOpts, std::move(input));
+    auto scanSpec = std::make_shared<velox::common::ScanSpec>("root");
+    scanSpec->addAllChildFields(*type);
+    velox::dwio::common::RowReaderOptions rowReaderOptions;
+    rowReaderOptions.setScanSpec(scanSpec);
+    rowReaderOptions.setStringDecoderZeroCopy(param().stringDecoderZeroCopy);
+    rowReaderOptions.setNimblePreserveDictionaryEncoding(
+        param().stringDecoderZeroCopy);
+    auto rowReader = reader->createRowReader(rowReaderOptions);
+
+    auto result = BaseVector::create(type, 0, leafPool_.get());
+    size_t totalRows = 0;
+    size_t globalRow = 0;
+    while (rowReader->next(1000, result)) {
+      auto* rowResult = result->as<RowVector>();
+      ASSERT_NE(rowResult, nullptr);
+      totalRows += rowResult->size();
+
+      auto stringChild = rowResult->childAt(0)->loadedVector();
+      if (param().stringDecoderZeroCopy) {
+        ASSERT_EQ(stringChild->encoding(), VectorEncoding::Simple::DICTIONARY)
+            << "Expected DICTIONARY encoding for string column";
+      }
+
+      DecodedVector decoded(*stringChild);
+      for (size_t i = 0; i < rowResult->size(); ++i) {
+        ASSERT_EQ(decoded.valueAt<StringView>(i).str(), stringData[globalRow])
+            << "Mismatch at row=" << globalRow;
+        ++globalRow;
+      }
+    }
+
+    EXPECT_EQ(totalRows, kRowCount);
   }
 
   // Optional encoding factors for ManualEncodingSelectionPolicyFactory.
@@ -1888,9 +2002,9 @@ TEST_P(E2EFilterTest, stringFilterOnBothColumnsCrossStripeNested) {
 // 2. Forcing the otherValues_ child to use Dictionary encoding via
 // EncodingLayoutTree
 //
-// This scenario is challenging because dictionaryEncoding() may only check
-// for direct Dictionary or Nullable→Dictionary, not deeper nesting like
-// MainlyConstant→Dictionary.
+// This scenario is challenging because isDictionaryCompatible() must handle
+// deeper nesting like MainlyConstant→Dictionary, not just direct Dictionary
+// or Nullable→Dictionary.
 TEST_P(E2EFilterTest, nestedMainlyConstantWithDictionary) {
   // Create data where most values are a constant string.
   // ~90% of values will be the constant, ~10% will be "other" values.
@@ -1941,6 +2055,8 @@ TEST_P(E2EFilterTest, nestedMainlyConstantWithDictionary) {
   //   Row
   //     -> Scalar (string_val): MainlyConstant
   //         -> OtherValues (child 1): Dictionary
+  //             -> Alphabet (child 0): let writer decide
+  //             -> Indices (child 1): let writer decide
   //     -> Scalar (long_val): default
   EncodingLayoutTree encodingLayoutTree{
       Kind::Row,
@@ -1958,6 +2074,8 @@ TEST_P(E2EFilterTest, nestedMainlyConstantWithDictionary) {
                         // Child 0: IsCommon (let the writer decide)
                         std::nullopt,
                         // Child 1: OtherValues -> Dictionary
+                        // Dictionary encoding needs children for alphabet and
+                        // indices.
                         EncodingLayout{
                             EncodingType::Dictionary,
                             {},
@@ -2007,8 +2125,11 @@ TEST_P(E2EFilterTest, nestedMainlyConstantWithDictionary) {
     ASSERT_NE(rowResult, nullptr);
     totalRows += rowResult->size();
 
-    DecodedVector decodedString(*rowResult->childAt(0));
-    DecodedVector decodedLong(*rowResult->childAt(1));
+    // Use DecodedVector to handle both flat and dictionary-encoded vectors.
+    // The string column might be wrapped in a DictionaryVector when using
+    // dictionary encoding path.
+    velox::DecodedVector decodedString(*rowResult->childAt(0));
+    velox::DecodedVector decodedLong(*rowResult->childAt(1));
 
     for (size_t i = 0; i < rowResult->size(); ++i) {
       auto rowIdx = decodedLong.valueAt<int64_t>(i);
@@ -2018,7 +2139,7 @@ TEST_P(E2EFilterTest, nestedMainlyConstantWithDictionary) {
       } else {
         expected = kConstantValue;
       }
-      ASSERT_EQ(decodedString.valueAt<StringView>(i).str(), expected)
+      ASSERT_EQ(decodedString.valueAt<velox::StringView>(i).str(), expected)
           << "Mismatch at row=" << rowIdx;
     }
   }
@@ -2026,30 +2147,129 @@ TEST_P(E2EFilterTest, nestedMainlyConstantWithDictionary) {
   EXPECT_EQ(totalRows, kRowCount);
 }
 
-// Verifies that the reader returns DictionaryVector<StringView> for
-// dictionary-encoded string columns when stringBufferOptimized is enabled.
-// The dictionary path is only taken for simple encoding shapes:
-//   - Dictionary (top-level)
-//   - Nullable -> Dictionary (dictionary with nulls)
+// Writes string data with a forced encoding layout, reads back, and verifies
+// dictionary vector return and data correctness.
 TEST_P(E2EFilterTest, dictionaryVectorReturned) {
-  useForcedDictionaryEncoding_ = true;
-  auto type = ROW({"string_val", "long_val"}, {VARCHAR(), BIGINT()});
-
   const vector_size_t kRowCount = 1000;
-  // Use low cardinality to ensure dictionary encoding is chosen.
-  std::vector<std::string> stringStorage(kRowCount);
-  for (vector_size_t i = 0; i < kRowCount; ++i) {
-    stringStorage[i] = fmt::format("VAL_{}", i % 10);
+  std::mt19937 gen(42);
+  const int numDistinct = 5 + gen() % 20;
+  std::vector<std::string> alphabet(numDistinct);
+  for (int i = 0; i < numDistinct; ++i) {
+    auto len = 3 + gen() % 30;
+    alphabet[i].resize(len);
+    for (auto& c : alphabet[i]) {
+      c = 'a' + gen() % 26;
+    }
   }
+  std::vector<std::string> stringData(kRowCount);
+  for (vector_size_t i = 0; i < kRowCount; ++i) {
+    stringData[i] = alphabet[gen() % numDistinct];
+  }
+
+  rowType_ = ROW({"string_val", "long_val"}, {VARCHAR(), BIGINT()});
+  verifyDictionaryVectorReturned(
+      buildForcedDictionaryEncodingLayoutTree(), stringData);
+}
+
+TEST_P(E2EFilterTest, mainlyConstantDictionaryVectorReturned) {
+  const vector_size_t kRowCount = 1000;
+  std::mt19937 gen(123);
+  const int numOther = 3 + gen() % 10;
+  std::vector<std::string> otherAlphabet(numOther);
+  for (int i = 0; i < numOther; ++i) {
+    auto len = 3 + gen() % 20;
+    otherAlphabet[i].resize(len);
+    for (auto& c : otherAlphabet[i]) {
+      c = 'a' + gen() % 26;
+    }
+  }
+  auto commonLen = 20 + gen() % 40;
+  std::string commonValue(commonLen, 'x' + gen() % 3);
+
+  std::vector<std::string> stringData(kRowCount);
+  for (vector_size_t i = 0; i < kRowCount; ++i) {
+    stringData[i] =
+        (gen() % 10 == 0) ? otherAlphabet[gen() % numOther] : commonValue;
+  }
+
+  rowType_ = ROW({"string_val", "long_val"}, {VARCHAR(), BIGINT()});
+  verifyDictionaryVectorReturned(
+      buildForcedMainlyConstantDictionaryEncodingLayoutTree(), stringData);
+}
+
+// Fuzz test: exercises MC→Dict readIndicesWithVisitor with randomized data
+// shapes. Runs 10000 iterations with varying row counts, alphabet sizes,
+// common percentages, and null rates to catch subtle scattering/composition
+// bugs in materializeIndices and readIndicesWithVisitor.
+TEST_P(E2EFilterTest, fuzzMainlyConstantDictionaryVector) {
+  auto seed = folly::Random::rand32();
+  LOG(INFO) << "fuzzMainlyConstantDictionaryVector seed: " << seed;
+  std::mt19937 rng(seed);
+
+  const int kRowCount = 50 + rng() % 500;
+  const int numOther = 1 + rng() % 8;
+  const int commonPct = 50 + rng() % 45;
+  const bool withNulls = rng() % 3 == 0;
+
+  SCOPED_TRACE(
+      fmt::format(
+          "seed={} rows={} numOther={} commonPct={} withNulls={}",
+          seed,
+          kRowCount,
+          numOther,
+          commonPct,
+          withNulls));
+
+  std::vector<std::string> otherAlphabet(numOther);
+  for (int j = 0; j < numOther; ++j) {
+    auto len = 1 + rng() % 30;
+    otherAlphabet[j].resize(len);
+    for (auto& c : otherAlphabet[j]) {
+      c = 'a' + rng() % 26;
+    }
+  }
+  // Use a prefix that won't appear in otherAlphabet (which uses 'a'-'z').
+  auto commonLen = 5 + rng() % 50;
+  std::string commonValue(commonLen, '0' + rng() % 3);
+
+  std::vector<std::string> stringData(kRowCount);
+  for (int i = 0; i < kRowCount; ++i) {
+    stringData[i] = (static_cast<int>(rng() % 100) < commonPct)
+        ? commonValue
+        : otherAlphabet[rng() % numOther];
+  }
+  // Ensure at least one non-common value at a non-null position so the Dict
+  // child isn't empty. With nullEvery(7), position i is null when i % 7 == 0.
+  {
+    bool hasNonCommonAtNonNull = false;
+    for (int i = 0; i < kRowCount; ++i) {
+      if ((!withNulls || i % 7 != 0) && stringData[i] != commonValue) {
+        hasNonCommonAtNonNull = true;
+        break;
+      }
+    }
+    if (!hasNonCommonAtNonNull) {
+      // Place a non-common value at a position that won't be null.
+      int pos = 1;
+      while (withNulls && pos % 7 == 0) {
+        ++pos;
+      }
+      stringData[pos] = otherAlphabet[0];
+    }
+  }
+
+  rowType_ = ROW({"string_val", "long_val"}, {VARCHAR(), BIGINT()});
+
+  auto type = asRowType(rowType_);
   auto stringVector =
       velox::test::VectorMaker(leafPool_.get())
-          .flatVector<velox::StringView>(kRowCount, [&](auto row) {
-            return velox::StringView(stringStorage[row]);
-          });
-  auto longVector = velox::test::VectorMaker(leafPool_.get())
-                        .flatVector<int64_t>(kRowCount, [](auto row) {
-                          return static_cast<int64_t>(row);
-                        });
+          .flatVector<velox::StringView>(
+              kRowCount,
+              [&](auto row) { return velox::StringView(stringData[row]); },
+              withNulls ? velox::test::VectorMaker::nullEvery(7) : nullptr);
+  auto longVector =
+      velox::test::VectorMaker(leafPool_.get())
+          .flatVector<int64_t>(kRowCount, [](auto row) { return row; });
 
   auto batch = std::make_shared<RowVector>(
       leafPool_.get(),
@@ -2058,17 +2278,12 @@ TEST_P(E2EFilterTest, dictionaryVectorReturned) {
       kRowCount,
       std::vector<VectorPtr>{stringVector, longVector});
 
-  // Write directly (without writeToMemory) to avoid the default chunking
-  // policy that splits the data into multiple chunks. The dictionary path
-  // requires all requested rows to fit in a single chunk.
+  sinkData_.clear();
   {
     auto writeFile = std::make_unique<InMemoryWriteFile>(&sinkData_);
     VeloxWriterOptions writerOptions;
-    if (useForcedDictionaryEncoding_) {
-      rowType_ = asRowType(type);
-      writerOptions.encodingLayoutTree.emplace(
-          buildForcedDictionaryEncodingLayoutTree());
-    }
+    writerOptions.encodingLayoutTree.emplace(
+        buildForcedMainlyConstantDictionaryEncodingLayoutTree());
     VeloxWriter writer(
         type, std::move(writeFile), *rootPool_, std::move(writerOptions));
     writer.write(batch);
@@ -2092,35 +2307,32 @@ TEST_P(E2EFilterTest, dictionaryVectorReturned) {
   rowReaderOptions.setScanSpec(scanSpec);
   rowReaderOptions.setStringDecoderZeroCopy(param().stringDecoderZeroCopy);
   rowReaderOptions.setNimblePreserveDictionaryEncoding(
-      param().nimblePreserveDictionaryEncoding);
+      param().stringDecoderZeroCopy);
   auto rowReader = reader->createRowReader(rowReaderOptions);
 
   auto result = BaseVector::create(type, 0, leafPool_.get());
   size_t totalRows = 0;
-  while (rowReader->next(1000, result)) {
+  size_t globalRow = 0;
+  while (rowReader->next(kRowCount, result)) {
     auto* rowResult = result->as<RowVector>();
     ASSERT_NE(rowResult, nullptr);
     totalRows += rowResult->size();
 
     auto stringChild = rowResult->childAt(0)->loadedVector();
-    if (param().stringDecoderZeroCopy &&
-        param().nimblePreserveDictionaryEncoding) {
-      // With both flags enabled, the dictionary path should return
-      // a DictionaryVector wrapping a FlatVector alphabet.
-      ASSERT_EQ(stringChild->encoding(), VectorEncoding::Simple::DICTIONARY)
-          << "Expected DICTIONARY encoding for string column, got "
-          << stringChild->encoding();
-    }
-
-    // Verify values are correct regardless of encoding.
     DecodedVector decoded(*stringChild);
     for (size_t i = 0; i < rowResult->size(); ++i) {
-      auto expected = fmt::format("VAL_{}", i % 10);
-      ASSERT_EQ(decoded.valueAt<StringView>(i).str(), expected)
-          << "Mismatch at row=" << i;
+      if (withNulls && globalRow % 7 == 0) {
+        ASSERT_TRUE(decoded.isNullAt(i))
+            << "Expected null at row=" << globalRow;
+      } else {
+        ASSERT_FALSE(decoded.isNullAt(i))
+            << "Unexpected null at row=" << globalRow;
+        ASSERT_EQ(decoded.valueAt<StringView>(i).str(), stringData[globalRow])
+            << "Mismatch at row=" << globalRow;
+      }
+      ++globalRow;
     }
   }
-
   EXPECT_EQ(totalRows, kRowCount);
 }
 
@@ -2238,9 +2450,10 @@ TEST_P(E2EFilterTest, crossChunkEncodingChange) {
     totalRows += rowResult->size();
 
     // Verify the string values are correct.
-    DecodedVector decodedString(*rowResult->childAt(0));
-    DecodedVector decodedString2(*rowResult->childAt(1));
-    DecodedVector decodedLong(*rowResult->childAt(2));
+    // Use DecodedVector to handle both flat and dictionary-encoded vectors.
+    velox::DecodedVector decodedString(*rowResult->childAt(0));
+    velox::DecodedVector decodedString2(*rowResult->childAt(1));
+    velox::DecodedVector decodedLong(*rowResult->childAt(2));
 
     for (size_t i = 0; i < rowResult->size(); ++i) {
       auto globalRow = decodedLong.valueAt<int64_t>(i);
@@ -2259,9 +2472,10 @@ TEST_P(E2EFilterTest, crossChunkEncodingChange) {
             "UNIQUE2_VAL_BATCH{}_ROW{}_MORE_PADDING", batchIdx, rowInBatch);
       }
 
-      ASSERT_EQ(decodedString.valueAt<StringView>(i).str(), expectedStr)
+      ASSERT_EQ(decodedString.valueAt<velox::StringView>(i).str(), expectedStr)
           << "Mismatch at globalRow=" << globalRow;
-      ASSERT_EQ(decodedString2.valueAt<StringView>(i).str(), expectedStr2)
+      ASSERT_EQ(
+          decodedString2.valueAt<velox::StringView>(i).str(), expectedStr2)
           << "Mismatch at globalRow=" << globalRow;
     }
   }

--- a/dwio/nimble/velox/selective/tests/StringColumnReaderTest.cpp
+++ b/dwio/nimble/velox/selective/tests/StringColumnReaderTest.cpp
@@ -17,11 +17,13 @@
 #include "dwio/nimble/velox/selective/SelectiveNimbleReader.h"
 
 #include "dwio/nimble/common/tests/NimbleFileWriter.h"
+#include "dwio/nimble/velox/EncodingLayoutTree.h"
 #include "dwio/nimble/velox/FlushPolicy.h"
 #include "dwio/nimble/velox/VeloxWriter.h"
 #include "velox/common/base/tests/GTestUtils.h"
 #include "velox/common/io/IoStatistics.h"
 #include "velox/common/testutil/TestValue.h"
+#include "velox/vector/DictionaryVector.h"
 #include "velox/vector/tests/utils/VectorTestBase.h"
 
 #include <gtest/gtest.h>
@@ -1153,6 +1155,274 @@ DEBUG_ONLY_TEST_P(StringColumnReaderTest, dictionaryPathAlphabetSize) {
       asRowType(input->type()),
       pool());
   EXPECT_EQ(dictPathEntries, 1);
+}
+
+// Basic mainly-constant string read: ~95% common value with a small other
+// alphabet. Naturally triggers Nullable<MainlyConstant<Dictionary>> encoding.
+TEST_P(StringColumnReaderTest, mainlyConstantDictionary) {
+  const bool stringDecoderZeroCopy = GetParam();
+  if (!stringDecoderZeroCopy) {
+    GTEST_SKIP() << "Dictionary path requires stringDecoderZeroCopy";
+  }
+
+  constexpr int kRows = 500;
+  const std::string commonValue(50, 'x');
+  const std::string otherValues[] = {"alpha", "bravo", "charlie"};
+  auto input = makeRowVector({
+      makeFlatVector<std::string>(
+          kRows,
+          [&](auto i) {
+            return i % 20 == 0 ? otherValues[i % 3] : commonValue;
+          }),
+  });
+
+  auto scanSpec = std::make_shared<common::ScanSpec>("root");
+  scanSpec->addAllChildFields(*input->type());
+  auto readers = makeReaders(input, scanSpec, stringDecoderZeroCopy);
+  validateWithEncodingChecks(
+      *input->childAt(0),
+      *readers.rowReader,
+      kRows,
+      /*totalRows=*/kRows,
+      {VectorEncoding::Simple::DICTIONARY},
+      asRowType(input->type()),
+      pool());
+}
+
+// Mainly-constant string with nulls.
+TEST_P(StringColumnReaderTest, mainlyConstantDictionaryWithNulls) {
+  const bool stringDecoderZeroCopy = GetParam();
+  if (!stringDecoderZeroCopy) {
+    GTEST_SKIP() << "Dictionary path requires stringDecoderZeroCopy";
+  }
+
+  constexpr int kRows = 500;
+  const std::string commonValue(50, 'x');
+  const std::string otherValues[] = {"alpha", "bravo", "charlie"};
+  auto input = makeRowVector({
+      makeFlatVector<std::string>(
+          kRows,
+          [&](auto i) {
+            return i % 20 == 0 ? otherValues[i % 3] : commonValue;
+          },
+          nullEvery(7)),
+  });
+
+  auto scanSpec = std::make_shared<common::ScanSpec>("root");
+  scanSpec->addAllChildFields(*input->type());
+  auto readers = makeReaders(input, scanSpec, stringDecoderZeroCopy);
+  validateWithEncodingChecks(
+      *input->childAt(0),
+      *readers.rowReader,
+      kRows,
+      /*totalRows=*/kRows,
+      {VectorEncoding::Simple::DICTIONARY},
+      asRowType(input->type()),
+      pool());
+}
+
+// Mainly-constant across stripe boundaries: two stripes with different
+// common values and different "other" alphabets.
+TEST_P(StringColumnReaderTest, mainlyConstantDictionaryAcrossStripes) {
+  const bool stringDecoderZeroCopy = GetParam();
+  if (!stringDecoderZeroCopy) {
+    GTEST_SKIP() << "Dictionary path requires stringDecoderZeroCopy";
+  }
+
+  constexpr int kStripeRows = 200;
+  const std::string common1(50, 'x');
+  const std::string common2(50, 'y');
+  const std::string others1[] = {"alpha", "bravo", "charlie"};
+  const std::string others2[] = {"delta", "echo", "foxtrot"};
+  auto stripe1 = makeRowVector({
+      makeFlatVector<std::string>(
+          kStripeRows,
+          [&](auto i) { return i % 20 == 0 ? others1[i % 3] : common1; }),
+  });
+  auto stripe2 = makeRowVector({
+      makeFlatVector<std::string>(
+          kStripeRows,
+          [&](auto i) { return i % 20 == 0 ? others2[i % 3] : common2; }),
+  });
+
+  // Force MC→Dict via encoding layout tree. The writer wraps in
+  // Nullable automatically for nullable columns.
+  EncodingLayout dictLayout{
+      EncodingType::Dictionary,
+      {},
+      CompressionType::Uncompressed,
+      {std::nullopt, std::nullopt}};
+  EncodingLayout mainlyConstLayout{
+      EncodingType::MainlyConstant,
+      {},
+      CompressionType::Uncompressed,
+      {std::nullopt, std::move(dictLayout)}};
+  VeloxWriterOptions writerOptions;
+  writerOptions.enableChunking = true;
+  writerOptions.encodingLayoutTree.emplace(
+      Kind::Row,
+      std::
+          unordered_map<EncodingLayoutTree::StreamIdentifier, EncodingLayout>{},
+      "",
+      std::vector<EncodingLayoutTree>{EncodingLayoutTree{
+          Kind::Scalar, {{0, std::move(mainlyConstLayout)}}, "c0"}});
+  auto file = test::createNimbleFile(
+      *rootPool(),
+      {stripe1, stripe2},
+      writerOptions,
+      /*flushAfterWrite=*/true);
+
+  auto expected = makeRowVector({
+      makeFlatVector<std::string>(
+          kStripeRows * 2,
+          [&](auto i) {
+            if (i < kStripeRows) {
+              return i % 20 == 0 ? others1[i % 3] : common1;
+            }
+            auto j = i - kStripeRows;
+            return j % 20 == 0 ? others2[j % 3] : common2;
+          }),
+  });
+
+  auto scanSpec = std::make_shared<common::ScanSpec>("root");
+  scanSpec->addAllChildFields(*expected->type());
+  auto readers = makeReaders(expected, file, scanSpec, stringDecoderZeroCopy);
+  using E = VectorEncoding::Simple;
+  validateWithEncodingChecks(
+      *expected->childAt(0),
+      *readers.rowReader,
+      100,
+      /*totalRows=*/2 * kStripeRows,
+      {E::DICTIONARY, E::DICTIONARY, E::DICTIONARY, E::DICTIONARY},
+      asRowType(expected->type()),
+      pool());
+}
+
+// Mainly-constant string column with chunking where read batches align with
+// chunk boundaries. This exercises the non-fallback dictionary fast path for
+// chunked layouts: each batch fits within a single chunk, so the dictionary
+// state (alphabet, indices) remains valid for the entire read.
+TEST_P(StringColumnReaderTest, mainlyConstantDictionaryAlignedChunks) {
+  const bool stringDecoderZeroCopy = GetParam();
+  if (!stringDecoderZeroCopy) {
+    GTEST_SKIP() << "Dictionary path requires stringDecoderZeroCopy";
+  }
+
+  const int numRows = 10000;
+  const std::string commonValue(50, 'x');
+  const std::string otherValues[] = {"alpha", "bravo", "charlie"};
+  auto input = makeRowVector({
+      makeFlatVector<std::string>(
+          numRows,
+          [&](auto i) {
+            return i % 20 == 0 ? otherValues[i % 3] : commonValue;
+          }),
+  });
+
+  VeloxWriterOptions writerOptions;
+  writerOptions.enableChunking = true;
+  writerOptions.minStreamChunkRawSize = 0;
+  auto writeCount = std::make_shared<int>(0);
+  writerOptions.flushPolicyFactory = [writeCount] {
+    return std::make_unique<LambdaFlushPolicy>(
+        [](const StripeProgress&) { return false; },
+        [writeCount](const StripeProgress&) {
+          return ++(*writeCount) % 2 == 0;
+        });
+  };
+
+  std::string file;
+  {
+    auto writeFile = std::make_unique<velox::InMemoryWriteFile>(&file);
+    VeloxWriter writer(
+        input->type(),
+        std::move(writeFile),
+        *rootPool(),
+        std::move(writerOptions));
+    const int batchWriteSize = 500;
+    for (int i = 0; i < numRows; i += batchWriteSize) {
+      writer.write(input->slice(i, std::min(batchWriteSize, numRows - i)));
+    }
+    writer.close();
+  }
+
+  auto scanSpec = std::make_shared<common::ScanSpec>("root");
+  scanSpec->addAllChildFields(*input->type());
+  auto readers = makeReaders(input, file, scanSpec, stringDecoderZeroCopy);
+  // Batch size fits within a single chunk (1000 rows per chunk), so all
+  // batches use the dictionary path. With 10 chunks of 1000 rows and
+  // batch size 500, we get 20 batches — each within a single chunk.
+  std::vector<VectorEncoding::Simple> expectedEncodings(
+      20, VectorEncoding::Simple::DICTIONARY);
+  validateWithEncodingChecks(
+      *input->childAt(0),
+      *readers.rowReader,
+      /*batchSize=*/500,
+      /*totalRows=*/numRows,
+      expectedEncodings,
+      asRowType(input->type()),
+      pool());
+}
+
+// Same as mainlyConstantDictionaryAlignedChunks but with nulls.
+TEST_P(StringColumnReaderTest, mainlyConstantDictionaryAlignedChunksWithNulls) {
+  const bool stringDecoderZeroCopy = GetParam();
+  if (!stringDecoderZeroCopy) {
+    GTEST_SKIP() << "Dictionary path requires stringDecoderZeroCopy";
+  }
+
+  const int numRows = 10000;
+  const std::string commonValue(50, 'x');
+  const std::string otherValues[] = {"alpha", "bravo", "charlie"};
+  auto input = makeRowVector({
+      makeFlatVector<std::string>(
+          numRows,
+          [&](auto i) {
+            return i % 20 == 0 ? otherValues[i % 3] : commonValue;
+          },
+          nullEvery(7)),
+  });
+
+  VeloxWriterOptions writerOptions;
+  writerOptions.enableChunking = true;
+  writerOptions.minStreamChunkRawSize = 0;
+  auto writeCount = std::make_shared<int>(0);
+  writerOptions.flushPolicyFactory = [writeCount] {
+    return std::make_unique<LambdaFlushPolicy>(
+        [](const StripeProgress&) { return false; },
+        [writeCount](const StripeProgress&) {
+          return ++(*writeCount) % 2 == 0;
+        });
+  };
+
+  std::string file;
+  {
+    auto writeFile = std::make_unique<velox::InMemoryWriteFile>(&file);
+    VeloxWriter writer(
+        input->type(),
+        std::move(writeFile),
+        *rootPool(),
+        std::move(writerOptions));
+    const int batchWriteSize = 500;
+    for (int i = 0; i < numRows; i += batchWriteSize) {
+      writer.write(input->slice(i, std::min(batchWriteSize, numRows - i)));
+    }
+    writer.close();
+  }
+
+  auto scanSpec = std::make_shared<common::ScanSpec>("root");
+  scanSpec->addAllChildFields(*input->type());
+  auto readers = makeReaders(input, file, scanSpec, stringDecoderZeroCopy);
+  std::vector<VectorEncoding::Simple> expectedEncodings(
+      20, VectorEncoding::Simple::DICTIONARY);
+  validateWithEncodingChecks(
+      *input->childAt(0),
+      *readers.rowReader,
+      /*batchSize=*/500,
+      /*totalRows=*/numRows,
+      expectedEncodings,
+      asRowType(input->type()),
+      pool());
 }
 
 INSTANTIATE_TEST_CASE_P(


### PR DESCRIPTION
Summary:

Replaces the `NestedDictionaryDecoder` / `EncodingLayerHandler` hierarchy with direct dictionary index reading through `callReadIndicesWithVisitor` dispatch. This eliminates heap allocations, buffer copies, and the 3-phase composition pipeline that ran on every `read()` call.

Key changes:
- **`ChunkedDecoder`**: `readDictionaryIndices()` now calls `callReadIndicesWithVisitor()` which dispatches to `DictionaryEncoding::readIndicesWithVisitor`, `NullableEncoding::readIndicesWithVisitor`, or `MainlyConstantEncoding::readIndicesWithVisitor` directly. Alphabet is built by standalone `buildAlphabet()` (recursive tree walk) and cached per chunk (`getCachedCombinedAlphabet()`).
- **`MainlyConstantEncoding`**: New `readIndicesWithVisitor()` method. Batch-reads isCommon bits and inner dictionary indices using the non-null count from `rawNullsInReadRange()`, then iterates with array lookups via `readWithVisitorSlow`. Common rows → index 0, non-common rows → `innerIndex + 1`. The combined alphabet is `[commonValue, innerAlphabet[0], ...]`.
- **`NullableEncoding`**: New `readIndicesWithVisitor()` that materializes nulls and delegates to the inner encoding's `readIndicesWithVisitor`.
- **`EncodingUtils.h`**: `callReadIndicesWithVisitor()` extended with `MainlyConstant` case.
- **`StringColumnReader`**: Simplified to use `ChunkedDecoder::readDictionaryIndices()` directly. Removed `NestedDictionaryDecoder` usage and the single-chunk guard (`remainingValues >= requestedRows`).

The `NestedDictionaryDecoder` and `EncodingLayerHandler` hierarchy is now dead code.

Reviewed By: xiaoxmeng

Differential Revision: D99015323
