### PR TITLE
feat: Separate metadata and index caching/pinning into independent controls (#745)

### DIFF
--- a/dwio/nimble/index/ClusterIndex.cpp
+++ b/dwio/nimble/index/ClusterIndex.cpp
@@ -148,14 +148,14 @@ std::unique_ptr<ClusterIndex> ClusterIndex::create(
       std::move(rootSection),
       pool,
       createIndexMetadataInput(options),
-      createIndexDataInput(options, *pool)));
+      createIndexDataInput(options)));
 }
 
 ClusterIndex::ClusterIndex(
     Section rootSection,
     velox::memory::MemoryPool* pool,
     std::shared_ptr<MetadataInput> metadataInput,
-    std::unique_ptr<velox::dwio::common::BufferedInput> dataInput)
+    std::shared_ptr<velox::dwio::common::BufferedInput> dataInput)
     : IndexLookup{IndexType::Cluster},
       rootSection_{std::move(rootSection)},
       indexRoot_{getIndexRoot(rootSection_)},

--- a/dwio/nimble/index/ClusterIndex.h
+++ b/dwio/nimble/index/ClusterIndex.h
@@ -152,7 +152,7 @@ class ClusterIndex : public IndexLookup {
       Section rootSection,
       velox::memory::MemoryPool* pool,
       std::shared_ptr<MetadataInput> metadataInput,
-      std::unique_ptr<velox::dwio::common::BufferedInput> dataInput);
+      std::shared_ptr<velox::dwio::common::BufferedInput> dataInput);
 
   // Cached decoded chunk, one per IndexPartition.
   struct DecodedChunk {
@@ -322,7 +322,7 @@ class ClusterIndex : public IndexLookup {
   const uint32_t numRows_;
 
   const std::shared_ptr<MetadataInput> metadataInput_;
-  const std::unique_ptr<velox::dwio::common::BufferedInput> dataInput_;
+  const std::shared_ptr<velox::dwio::common::BufferedInput> dataInput_;
   velox::memory::MemoryPool* const pool_;
 
   // --- Mutable state ---

--- a/dwio/nimble/index/DenseIndexRegistry.cpp
+++ b/dwio/nimble/index/DenseIndexRegistry.cpp
@@ -101,10 +101,8 @@ std::unique_ptr<DenseIndexRegistry> DenseIndexRegistry::create(
   if (!hashSection.has_value() && !sortedSection.has_value()) {
     return nullptr;
   }
-  auto metadataInput =
-      std::shared_ptr<MetadataInput>(createIndexMetadataInput(options));
-  auto dataInput = std::shared_ptr<velox::dwio::common::BufferedInput>(
-      createIndexDataInput(options, *pool));
+  auto metadataInput = createIndexMetadataInput(options);
+  auto dataInput = createIndexDataInput(options);
   auto registry = std::unique_ptr<DenseIndexRegistry>(new DenseIndexRegistry());
   if (hashSection.has_value()) {
     registry->registerHashIndices(
@@ -136,6 +134,7 @@ void DenseIndexRegistry::registerHashIndices(
   hashDescriptors_ = parseDescriptors<serialization::HashIndexDirectory>(
       directorySection, "Hash index");
 
+  // Always pin: findHashIndex returns raw pointers, so entries must stay alive.
   hashIndexCache_ = std::make_unique<MetadataCache<uint32_t, HashIndex>>(
       [this, metadataInput, pool](
           uint32_t index) -> std::shared_ptr<HashIndex> {
@@ -158,6 +157,8 @@ void DenseIndexRegistry::registerSortedIndices(
   sortedDescriptors_ = parseDescriptors<serialization::SortedIndexDirectory>(
       directorySection, "Sorted index");
 
+  // Always pin: findSortedIndex returns raw pointers, so entries must stay
+  // alive.
   sortedIndexCache_ = std::make_unique<MetadataCache<uint32_t, SortedIndex>>(
       [this, metadataInput, dataInput, pool](
           uint32_t index) -> std::shared_ptr<SortedIndex> {

--- a/dwio/nimble/index/IndexLookup.cpp
+++ b/dwio/nimble/index/IndexLookup.cpp
@@ -27,8 +27,10 @@ namespace facebook::nimble::index {
 void IndexLookup::Options::validate() const {
   NIMBLE_CHECK_NOT_NULL(file.get());
   NIMBLE_CHECK_NOT_NULL(ioOptions);
-  NIMBLE_CHECK(
-      (fileHandle != nullptr) == (cache != nullptr),
+  NIMBLE_CHECK_NOT_NULL(ioOptions->indexIoStats(), "indexIoStats must be set");
+  NIMBLE_CHECK_EQ(
+      fileHandle != nullptr,
+      cache != nullptr,
       "fileHandle and cache must both be set or neither");
   if (fileHandle != nullptr) {
     NIMBLE_CHECK_EQ(
@@ -38,7 +40,7 @@ void IndexLookup::Options::validate() const {
   }
 }
 
-std::unique_ptr<MetadataInput> createIndexMetadataInput(
+std::shared_ptr<MetadataInput> createIndexMetadataInput(
     const IndexLookup::Options& options) {
   return (options.fileHandle != nullptr)
       ? MetadataInput::create(
@@ -46,16 +48,12 @@ std::unique_ptr<MetadataInput> createIndexMetadataInput(
       : MetadataInput::create(options.file.get(), *options.ioOptions);
 }
 
-std::unique_ptr<velox::dwio::common::BufferedInput> createIndexDataInput(
-    const IndexLookup::Options& options,
-    velox::memory::MemoryPool& pool) {
+std::shared_ptr<velox::dwio::common::BufferedInput> createIndexDataInput(
+    const IndexLookup::Options& options) {
   auto readFile = options.file;
   auto indexIoStats = options.ioOptions->indexIoStats();
-  if (indexIoStats == nullptr) {
-    indexIoStats = std::make_shared<velox::io::IoStatistics>();
-  }
   if (options.cache != nullptr) {
-    return std::make_unique<velox::dwio::common::CachedBufferedInput>(
+    return std::make_shared<velox::dwio::common::CachedBufferedInput>(
         std::move(readFile),
         velox::dwio::common::MetricsLog::voidLog(),
         options.fileHandle->uuid,
@@ -67,7 +65,7 @@ std::unique_ptr<velox::dwio::common::BufferedInput> createIndexDataInput(
         nullptr,
         *options.ioOptions);
   }
-  return std::make_unique<velox::dwio::common::DirectBufferedInput>(
+  return std::make_shared<velox::dwio::common::DirectBufferedInput>(
       std::move(readFile),
       velox::dwio::common::MetricsLog::voidLog(),
       velox::StringIdLease(),

--- a/dwio/nimble/index/IndexLookup.h
+++ b/dwio/nimble/index/IndexLookup.h
@@ -91,6 +91,9 @@ class IndexLookup {
     const velox::FileHandle* fileHandle{nullptr};
     /// Data cache for index metadata. Set with fileHandle for cached path.
     velox::cache::AsyncDataCache* cache{nullptr};
+    /// If true, pins parsed index objects in the index cache with strong
+    /// references so they are never evicted.
+    bool pinIndex{false};
 
     /// Validates options consistency.
     void validate() const;
@@ -267,13 +270,12 @@ class IndexLookup {
 };
 
 /// Creates a MetadataInput (cached or direct) from index options.
-std::unique_ptr<MetadataInput> createIndexMetadataInput(
+std::shared_ptr<MetadataInput> createIndexMetadataInput(
     const IndexLookup::Options& options);
 
 /// Creates a BufferedInput (cached or direct) from index options.
-std::unique_ptr<velox::dwio::common::BufferedInput> createIndexDataInput(
-    const IndexLookup::Options& options,
-    velox::memory::MemoryPool& pool);
+std::shared_ptr<velox::dwio::common::BufferedInput> createIndexDataInput(
+    const IndexLookup::Options& options);
 
 inline std::string toString(IndexLookup::LookupRequest::Mode mode) {
   switch (mode) {

--- a/dwio/nimble/index/tests/CMakeLists.txt
+++ b/dwio/nimble/index/tests/CMakeLists.txt
@@ -53,6 +53,7 @@ target_link_libraries(
   nimble_index_tests
   nimble_index
   nimble_tablet_reader
+  nimble_tablet_writer
   nimble_velox_reader
   nimble_velox_writer
   velox_core

--- a/dwio/nimble/index/tests/ClusterIndexTest.cpp
+++ b/dwio/nimble/index/tests/ClusterIndexTest.cpp
@@ -23,8 +23,14 @@
 #include "dwio/nimble/index/ClusterIndex.h"
 #include "dwio/nimble/index/tests/ClusterIndexTestBase.h"
 #include "dwio/nimble/index/tests/ClusterIndexTestUtils.h"
+#include "dwio/nimble/tablet/TabletReader.h"
+#include "dwio/nimble/tablet/TabletWriter.h"
 
 #include "dwio/nimble/velox/ChunkedStreamWriter.h"
+#include "velox/common/caching/AsyncDataCache.h"
+#include "velox/common/caching/FileHandle.h"
+#include "velox/common/caching/FileIds.h"
+#include "velox/common/memory/MallocAllocator.h"
 #include "velox/dwio/common/SeekableInputStream.h"
 #include "velox/serializers/KeyEncoder.h"
 
@@ -89,6 +95,10 @@ class ClusterIndexTest : public ClusterIndexTestBase {
   }
 
   std::shared_ptr<velox::ReadFile> keyStreamFile_;
+  std::shared_ptr<velox::io::IoStatistics> metadataIoStats_{
+      std::make_shared<velox::io::IoStatistics>()};
+  std::shared_ptr<velox::io::IoStatistics> indexIoStats_{
+      std::make_shared<velox::io::IoStatistics>()};
 
   // Creates a Stripe with only the keyStream specified.
   Stripe createStripeWithKeys(const KeyStream& keyStream) {
@@ -1222,6 +1232,277 @@ TEST_F(ClusterIndexTest, keyAtRowUnevenChunks) {
   EXPECT_EQ(clusterIndex->keyAtRow(4), "key_e");
 
   NIMBLE_ASSERT_THROW(clusterIndex->keyAtRow(6), "beyond file total rows");
+}
+
+// Verifies that the index caching mechanism works end-to-end when
+// ClusterIndex is created with IndexLookup::Options containing a cache
+// and fileHandle. The first open reads index data from the file; the
+TEST_F(ClusterIndexTest, indexDataReuseWithSameReader) {
+  std::string file;
+  velox::InMemoryWriteFile writeFile(&file);
+  Buffer buffer{*pool_};
+
+  TestClusterIndexMetadataWriter indexHelper(
+      *pool_,
+      {"col1"},
+      {SortOrder{.ascending = true}},
+      /*enforceKeyOrder=*/true);
+
+  auto tabletWriter = TabletWriter::create(
+      &writeFile,
+      *pool_,
+      {
+          .metadataFlushThreshold = 1024 * 1024 * 1024,
+          .streamDeduplicationEnabled = false,
+          .enableChunkIndex = true,
+          .stripeGroupFlushCallback =
+              indexHelper.createStripeGroupFlushCallback(),
+          .closeCallback = indexHelper.createCloseCallback(),
+      });
+
+  constexpr int kNumStripes = 3;
+  std::vector<std::string> keys = {"bbb", "ddd", "fff"};
+  for (int i = 0; i < kNumStripes; ++i) {
+    auto pos = buffer.reserve(50);
+    std::memset(pos, 'A', 50);
+    std::vector<nimble::Stream> tabletStreams;
+    tabletStreams.push_back(
+        {.offset = 0, .chunks = {{.rowCount = 100, .content = {{pos, 50}}}}});
+    indexHelper.addStripe({{.rowCount = 100, .key = keys[i]}});
+    tabletWriter->writeStripe(100, std::move(tabletStreams));
+  }
+  tabletWriter->close();
+  writeFile.close();
+
+  auto readFile = std::make_shared<velox::InMemoryReadFile>(file);
+
+  auto allocator = std::make_shared<velox::memory::MallocAllocator>(
+      velox::memory::MemoryAllocator::Options{
+          .capacity = 1UL << 30, .reservationByteLimit = 0});
+  auto cache = velox::cache::AsyncDataCache::create(allocator.get());
+
+  struct TestCase {
+    bool cacheIndex;
+    bool provideCache;
+    bool expectRamHit;
+
+    std::string debugString() const {
+      return fmt::format(
+          "cacheIndex={}, provideCache={}, expectRamHit={}",
+          cacheIndex,
+          provideCache,
+          expectRamHit);
+    }
+  };
+
+  std::vector<TestCase> testCases = {
+      {true, true, true},
+      {false, true, false},
+      {false, false, false},
+      // cacheIndex is set but cache is not provided — silently falls back
+      // to direct IO, so RAM hits are not expected.
+      {true, false, false},
+  };
+
+  for (const auto& testCase : testCases) {
+    SCOPED_TRACE(testCase.debugString());
+
+    metadataIoStats_ = std::make_shared<velox::io::IoStatistics>();
+    indexIoStats_ = std::make_shared<velox::io::IoStatistics>();
+
+    auto& ids = velox::fileIds();
+    auto fileIdStr = fmt::format(
+        "sameReaderTest_cache{}_provide{}",
+        testCase.cacheIndex,
+        testCase.provideCache);
+
+    TabletReader::Options options;
+    options.loadClusterIndex = true;
+    options.cacheIndex = testCase.cacheIndex;
+    options.ioOptions.emplace(pool_.get())
+        .setMetadataIoStats(metadataIoStats_)
+        .setIndexIoStats(indexIoStats_);
+
+    std::unique_ptr<velox::FileHandle> fileHandle;
+    if (testCase.provideCache) {
+      fileHandle = std::make_unique<velox::FileHandle>();
+      fileHandle->file = readFile;
+      fileHandle->uuid = velox::StringIdLease(ids, fileIdStr);
+      fileHandle->groupId = velox::StringIdLease(ids, fileIdStr + "_group");
+      options.cache = cache.get();
+      options.fileHandle = fileHandle.get();
+    }
+
+    auto reader = TabletReader::create(readFile, pool_.get(), options);
+    ASSERT_NE(reader->clusterIndex(), nullptr);
+
+    // First lookup loads partition metadata and key stream data lazily.
+    auto firstResult =
+        reader->clusterIndex()->lookup(makeRangeScanRequest("bbb"));
+    ASSERT_EQ(firstResult.size(), 1);
+    ASSERT_EQ(firstResult[0].size(), 1);
+    EXPECT_EQ(firstResult[0][0], RowRange(0, 300));
+
+    // Capture baseline after first lookup fully loads data.
+    const auto indexBytesAfterFirst = indexIoStats_->rawBytesRead();
+    EXPECT_GT(indexBytesAfterFirst, 0)
+        << "First lookup should read index data from file";
+
+    // Same-key lookup reuses DecodedChunk cache — no new index IO.
+    auto secondResult =
+        reader->clusterIndex()->lookup(makeRangeScanRequest("bbb"));
+    ASSERT_EQ(secondResult.size(), 1);
+    ASSERT_EQ(secondResult[0].size(), 1);
+    EXPECT_EQ(secondResult[0][0], RowRange(0, 300));
+    EXPECT_EQ(indexIoStats_->rawBytesRead(), indexBytesAfterFirst)
+        << "Same-key lookup should reuse cached data with no new IO";
+  }
+
+  cache->shutdown();
+}
+
+TEST_F(ClusterIndexTest, indexDataReuseCrossReaders) {
+  std::string file;
+  velox::InMemoryWriteFile writeFile(&file);
+  Buffer buffer{*pool_};
+
+  TestClusterIndexMetadataWriter indexHelper(
+      *pool_,
+      {"col1"},
+      {SortOrder{.ascending = true}},
+      /*enforceKeyOrder=*/true);
+
+  auto tabletWriter = TabletWriter::create(
+      &writeFile,
+      *pool_,
+      {
+          .metadataFlushThreshold = 1024 * 1024 * 1024,
+          .streamDeduplicationEnabled = false,
+          .enableChunkIndex = true,
+          .stripeGroupFlushCallback =
+              indexHelper.createStripeGroupFlushCallback(),
+          .closeCallback = indexHelper.createCloseCallback(),
+      });
+
+  constexpr int kNumStripes = 3;
+  std::vector<std::string> keys = {"bbb", "ddd", "fff"};
+  for (int i = 0; i < kNumStripes; ++i) {
+    auto pos = buffer.reserve(50);
+    std::memset(pos, 'A', 50);
+    std::vector<nimble::Stream> tabletStreams;
+    tabletStreams.push_back(
+        {.offset = 0, .chunks = {{.rowCount = 100, .content = {{pos, 50}}}}});
+    indexHelper.addStripe({{.rowCount = 100, .key = keys[i]}});
+    tabletWriter->writeStripe(100, std::move(tabletStreams));
+  }
+  tabletWriter->close();
+  writeFile.close();
+
+  auto readFile = std::make_shared<velox::InMemoryReadFile>(file);
+
+  auto allocator = std::make_shared<velox::memory::MallocAllocator>(
+      velox::memory::MemoryAllocator::Options{
+          .capacity = 1UL << 30, .reservationByteLimit = 0});
+  auto cache = velox::cache::AsyncDataCache::create(allocator.get());
+
+  struct TestCase {
+    bool cacheIndex;
+    bool provideCache;
+    bool expectCrossReaderReuse;
+    bool expectRamHit;
+
+    std::string debugString() const {
+      return fmt::format(
+          "cacheIndex={}, provideCache={}, "
+          "expectCrossReaderReuse={}, expectRamHit={}",
+          cacheIndex,
+          provideCache,
+          expectCrossReaderReuse,
+          expectRamHit);
+    }
+  };
+
+  std::vector<TestCase> testCases = {
+      {true, true, true, true},
+      {false, true, false, false},
+      {false, false, false, false},
+      // cacheIndex is set but cache is not provided — silently falls back
+      // to direct IO, so cross-reader reuse and RAM hits are not expected.
+      {true, false, false, false},
+  };
+
+  for (const auto& testCase : testCases) {
+    SCOPED_TRACE(testCase.debugString());
+
+    auto& ids = velox::fileIds();
+    auto fileIdStr = fmt::format(
+        "crossReaderTest_cache{}_provide{}",
+        testCase.cacheIndex,
+        testCase.provideCache);
+    velox::StringIdLease fileId(ids, fileIdStr);
+    velox::StringIdLease groupId(ids, fileIdStr + "_group");
+
+    auto createReader = [&]() {
+      metadataIoStats_ = std::make_shared<velox::io::IoStatistics>();
+      indexIoStats_ = std::make_shared<velox::io::IoStatistics>();
+
+      velox::io::ReaderOptions ioOpts(pool_.get());
+      ioOpts.setMetadataIoStats(metadataIoStats_);
+      ioOpts.setIndexIoStats(indexIoStats_);
+
+      TabletReader::Options options;
+      options.loadClusterIndex = true;
+      options.cacheIndex = testCase.cacheIndex;
+      options.ioOptions = ioOpts;
+
+      std::unique_ptr<velox::FileHandle> fileHandle;
+      if (testCase.provideCache) {
+        fileHandle = std::make_unique<velox::FileHandle>();
+        fileHandle->file = readFile;
+        fileHandle->uuid = fileId;
+        fileHandle->groupId = groupId;
+        options.cache = cache.get();
+        options.fileHandle = fileHandle.get();
+      }
+
+      auto reader = TabletReader::create(readFile, pool_.get(), options);
+      return std::make_pair(std::move(reader), std::move(fileHandle));
+    };
+
+    // First reader: cold path reads from file.
+    {
+      auto [reader1, fh1] = createReader();
+      ASSERT_NE(reader1->clusterIndex(), nullptr);
+
+      auto firstResult =
+          reader1->clusterIndex()->lookup(makeRangeScanRequest("bbb"));
+      ASSERT_EQ(firstResult.size(), 1);
+      ASSERT_EQ(firstResult[0].size(), 1);
+      EXPECT_EQ(firstResult[0][0], RowRange(0, 300));
+      EXPECT_GT(indexIoStats_->rawBytesRead(), 0)
+          << "First reader should read index data from file";
+    }
+
+    // Second reader: verify functional correctness with fresh IO stats.
+    {
+      auto [reader2, fh2] = createReader();
+      ASSERT_NE(reader2->clusterIndex(), nullptr);
+
+      auto secondResult =
+          reader2->clusterIndex()->lookup(makeRangeScanRequest("bbb"));
+      ASSERT_EQ(secondResult.size(), 1);
+      ASSERT_EQ(secondResult[0].size(), 1);
+      EXPECT_EQ(secondResult[0][0], RowRange(0, 300));
+
+      if (testCase.expectCrossReaderReuse) {
+        // Metadata (partition info) is served from AsyncDataCache.
+        EXPECT_GT(metadataIoStats_->ramHit().count(), 0)
+            << "Second reader should serve partition metadata from cache";
+      }
+    }
+  }
+
+  cache->shutdown();
 }
 
 } // namespace

--- a/dwio/nimble/index/tests/ClusterIndexTestBase.cpp
+++ b/dwio/nimble/index/tests/ClusterIndexTestBase.cpp
@@ -355,6 +355,7 @@ std::unique_ptr<ClusterIndex> ClusterIndexTestBase::createClusterIndex(
   ioStats_ = std::make_shared<velox::io::IoStatistics>();
   velox::io::ReaderOptions readerOptions(pool_.get());
   readerOptions.setMetadataIoStats(ioStats_);
+  readerOptions.setIndexIoStats(std::make_shared<velox::io::IoStatistics>());
   auto metadataInput =
       MetadataInput::create(metadataFile_.get(), readerOptions);
 

--- a/dwio/nimble/index/tests/ClusterIndexTestUtils.h
+++ b/dwio/nimble/index/tests/ClusterIndexTestUtils.h
@@ -171,7 +171,7 @@ class ClusterIndexTestHelper {
       Section rootSection,
       velox::memory::MemoryPool* pool,
       std::shared_ptr<MetadataInput> metadataInput,
-      std::unique_ptr<velox::dwio::common::BufferedInput> dataInput) {
+      std::shared_ptr<velox::dwio::common::BufferedInput> dataInput) {
     return std::unique_ptr<ClusterIndex>(new ClusterIndex(
         std::move(rootSection),
         pool,

--- a/dwio/nimble/index/tests/ClusterIndexWriterTest.cpp
+++ b/dwio/nimble/index/tests/ClusterIndexWriterTest.cpp
@@ -1124,6 +1124,7 @@ TEST_P(ClusterIndexWriterChunkTest, maxRowsPerKeyChunk) {
   auto ioStats = std::make_shared<velox::io::IoStatistics>();
   velox::io::ReaderOptions readerOptions(pool_.get());
   readerOptions.setMetadataIoStats(ioStats);
+  readerOptions.setIndexIoStats(std::make_shared<velox::io::IoStatistics>());
   auto metadataInput = MetadataInput::create(metadataFile.get(), readerOptions);
   auto dataInput = std::make_unique<velox::dwio::common::BufferedInput>(
       std::make_shared<velox::InMemoryReadFile>(keyStreamData), *pool_);

--- a/dwio/nimble/index/tests/DenseIndexRegistryTest.cpp
+++ b/dwio/nimble/index/tests/DenseIndexRegistryTest.cpp
@@ -101,7 +101,10 @@ class DenseIndexRegistryTest : public ::testing::Test {
     readerOptions_ =
         std::make_unique<velox::io::ReaderOptions>(leafPool_.get());
     readerOptions_->setMetadataIoStats(ioStats_);
+    readerOptions_->setIndexIoStats(
+        std::make_shared<velox::io::IoStatistics>());
     TabletReader::Options options;
+    options.loadDenseIndexes = true;
     options.ioOptions = *readerOptions_;
     return TabletReader::create(std::move(readFile), leafPool_.get(), options);
   }
@@ -123,6 +126,7 @@ TEST_F(DenseIndexRegistryTest, emptyRegistry) {
   auto ioStats = std::make_shared<velox::io::IoStatistics>();
   velox::io::ReaderOptions ioOptions(leafPool_.get());
   ioOptions.setMetadataIoStats(ioStats);
+  ioOptions.setIndexIoStats(std::make_shared<velox::io::IoStatistics>());
   IndexLookup::Options options{.file = file, .ioOptions = &ioOptions};
   auto registry = DenseIndexRegistry::create(
       std::nullopt, std::nullopt, options, leafPool_.get());
@@ -194,6 +198,30 @@ TEST_F(DenseIndexRegistryTest, hashAndSortedLookup) {
   EXPECT_EQ(sortedIdx->type(), IndexType::Sorted);
 
   // Non-existent columns should return null.
+  EXPECT_EQ(tablet->denseIndex({"nonexistent"}), nullptr);
+}
+
+TEST_F(DenseIndexRegistryTest, indexCacheRetention) {
+  std::vector<velox::VectorPtr> batches;
+  batches.push_back(makeBatch(0, 50));
+
+  const auto filePath = tempFilePath("cache_retention");
+  VeloxWriterOptions options;
+  options.hashIndexConfigs.push_back(HashIndexConfig{.columns = {"id"}});
+  writeFile(filePath, rowType(), batches, std::move(options));
+
+  auto tablet = openTablet(filePath);
+
+  auto* hashIdx = tablet->denseIndex({"id"});
+  ASSERT_NE(hashIdx, nullptr);
+  EXPECT_EQ(hashIdx->type(), IndexType::Hash);
+  EXPECT_EQ(hashIdx->indexColumns(), std::vector<std::string>{"id"});
+
+  // Repeated lookup returns the same pinned index object.
+  auto* hashIdx2 = tablet->denseIndex({"id"});
+  EXPECT_EQ(hashIdx, hashIdx2);
+
+  // Non-existent columns return null.
   EXPECT_EQ(tablet->denseIndex({"nonexistent"}), nullptr);
 }
 

--- a/dwio/nimble/index/tests/HashIndexTest.cpp
+++ b/dwio/nimble/index/tests/HashIndexTest.cpp
@@ -23,10 +23,16 @@
 #include "dwio/nimble/index/IndexLookup.h"
 
 #include "dwio/nimble/tablet/TabletReader.h"
+#include "dwio/nimble/tablet/TabletWriter.h"
 #include "dwio/nimble/tablet/tests/TabletTestUtils.h"
 #include "dwio/nimble/velox/VeloxReader.h"
 #include "dwio/nimble/velox/VeloxWriter.h"
+#include "velox/common/caching/AsyncDataCache.h"
+#include "velox/common/caching/FileHandle.h"
+#include "velox/common/caching/FileIds.h"
 #include "velox/common/file/FileSystems.h"
+#include "velox/common/io/IoStatistics.h"
+#include "velox/common/memory/MallocAllocator.h"
 #include "velox/common/memory/Memory.h"
 #include "velox/common/testutil/TempDirectoryPath.h"
 #include "velox/vector/FlatVector.h"
@@ -166,6 +172,10 @@ class HashIndexTestBase {
   // Deque for pointer stability across push_back calls, since StringViews
   // in FlatVector reference these strings.
   std::deque<std::string> valueStrings_;
+  std::shared_ptr<velox::io::IoStatistics> metadataIoStats_{
+      std::make_shared<velox::io::IoStatistics>()};
+  std::shared_ptr<velox::io::IoStatistics> indexIoStats_{
+      std::make_shared<velox::io::IoStatistics>()};
 };
 
 // Non-parameterized fixture.
@@ -504,6 +514,201 @@ TEST_F(HashIndexTest, noHashIndexConfig) {
     auto tablet = openTablet(filePath);
     EXPECT_EQ(tablet->denseIndex({"x"}), nullptr);
   }
+}
+
+TEST_F(HashIndexTest, indexDataReuseWithSameReader) {
+  std::vector<velox::VectorPtr> batches;
+  batches.push_back(makeBatch(0, 50));
+
+  const auto filePath = tempFilePath("same_reader_reuse");
+  writeFile(filePath, batches, HashIndexConfig{.columns = {"id"}});
+
+  auto allocator = std::make_shared<velox::memory::MallocAllocator>(
+      velox::memory::MemoryAllocator::Options{
+          .capacity = 1UL << 30, .reservationByteLimit = 0});
+  auto cache = velox::cache::AsyncDataCache::create(allocator.get());
+
+  struct TestCase {
+    bool cacheIndex;
+    bool provideCache;
+    bool expectRamHit;
+
+    std::string debugString() const {
+      return fmt::format(
+          "cacheIndex={}, provideCache={}, expectRamHit={}",
+          cacheIndex,
+          provideCache,
+          expectRamHit);
+    }
+  };
+
+  std::vector<TestCase> testCases = {
+      {true, true, true},
+      {false, true, false},
+      {false, false, false},
+      {true, false, false},
+  };
+
+  auto fs = velox::filesystems::getFileSystem(filePath, {});
+
+  for (const auto& testCase : testCases) {
+    SCOPED_TRACE(testCase.debugString());
+
+    metadataIoStats_ = std::make_shared<velox::io::IoStatistics>();
+    indexIoStats_ = std::make_shared<velox::io::IoStatistics>();
+
+    auto readFile =
+        std::shared_ptr<velox::ReadFile>(fs->openFileForRead(filePath));
+    auto& ids = velox::fileIds();
+    auto fileIdStr = fmt::format(
+        "hashSameReader_cache{}_provide{}",
+        testCase.cacheIndex,
+        testCase.provideCache);
+
+    TabletReader::Options options;
+    options.loadDenseIndexes = true;
+    options.cacheIndex = testCase.cacheIndex;
+    options.ioOptions.emplace(leafPool_.get())
+        .setMetadataIoStats(metadataIoStats_)
+        .setIndexIoStats(indexIoStats_);
+
+    std::unique_ptr<velox::FileHandle> fileHandle;
+    if (testCase.provideCache) {
+      fileHandle = std::make_unique<velox::FileHandle>();
+      fileHandle->file = readFile;
+      fileHandle->uuid = velox::StringIdLease(ids, fileIdStr);
+      fileHandle->groupId = velox::StringIdLease(ids, fileIdStr + "_group");
+      options.cache = cache.get();
+      options.fileHandle = fileHandle.get();
+    }
+
+    auto tablet =
+        TabletReader::create(std::move(readFile), leafPool_.get(), options);
+    ASSERT_NE(tablet->denseIndex({"id"}), nullptr);
+
+    // Both lookups should return correct results. The pinned HashIndex
+    // object is reused across lookups within the same reader.
+    auto firstResult = pointLookup(tablet->denseIndex({"id"}), {"id"}, 0);
+    ASSERT_EQ(firstResult.size(), 1);
+    ASSERT_FALSE(firstResult[0].empty());
+
+    auto secondResult = pointLookup(tablet->denseIndex({"id"}), {"id"}, 25);
+    ASSERT_EQ(secondResult.size(), 1);
+    ASSERT_FALSE(secondResult[0].empty());
+
+    // Verify the same index object is returned (pinned in MetadataCache).
+    EXPECT_EQ(tablet->denseIndex({"id"}), tablet->denseIndex({"id"}));
+  }
+
+  cache->shutdown();
+}
+
+TEST_F(HashIndexTest, indexDataReuseCrossReaders) {
+  std::vector<velox::VectorPtr> batches;
+  batches.push_back(makeBatch(0, 50));
+
+  const auto filePath = tempFilePath("cross_reader_reuse");
+  writeFile(filePath, batches, HashIndexConfig{.columns = {"id"}});
+
+  auto allocator = std::make_shared<velox::memory::MallocAllocator>(
+      velox::memory::MemoryAllocator::Options{
+          .capacity = 1UL << 30, .reservationByteLimit = 0});
+  auto cache = velox::cache::AsyncDataCache::create(allocator.get());
+
+  struct TestCase {
+    bool cacheIndex;
+    bool provideCache;
+    bool expectCrossReaderReuse;
+    bool expectRamHit;
+
+    std::string debugString() const {
+      return fmt::format(
+          "cacheIndex={}, provideCache={}, "
+          "expectCrossReaderReuse={}, expectRamHit={}",
+          cacheIndex,
+          provideCache,
+          expectCrossReaderReuse,
+          expectRamHit);
+    }
+  };
+
+  std::vector<TestCase> testCases = {
+      {true, true, true, true},
+      {false, true, false, false},
+      {false, false, false, false},
+      {true, false, false, false},
+  };
+
+  auto fs = velox::filesystems::getFileSystem(filePath, {});
+
+  for (const auto& testCase : testCases) {
+    SCOPED_TRACE(testCase.debugString());
+
+    auto& ids = velox::fileIds();
+    auto fileIdStr = fmt::format(
+        "hashCrossReader_cache{}_provide{}",
+        testCase.cacheIndex,
+        testCase.provideCache);
+    velox::StringIdLease fileId(ids, fileIdStr);
+    velox::StringIdLease groupId(ids, fileIdStr + "_group");
+
+    auto createReader = [&]() {
+      metadataIoStats_ = std::make_shared<velox::io::IoStatistics>();
+      indexIoStats_ = std::make_shared<velox::io::IoStatistics>();
+
+      auto readFile =
+          std::shared_ptr<velox::ReadFile>(fs->openFileForRead(filePath));
+
+      TabletReader::Options options;
+      options.loadDenseIndexes = true;
+      options.cacheIndex = testCase.cacheIndex;
+      options.ioOptions.emplace(leafPool_.get())
+          .setMetadataIoStats(metadataIoStats_)
+          .setIndexIoStats(indexIoStats_);
+
+      std::unique_ptr<velox::FileHandle> fileHandle;
+      if (testCase.provideCache) {
+        fileHandle = std::make_unique<velox::FileHandle>();
+        fileHandle->file = readFile;
+        fileHandle->uuid = fileId;
+        fileHandle->groupId = groupId;
+        options.cache = cache.get();
+        options.fileHandle = fileHandle.get();
+      }
+
+      auto reader =
+          TabletReader::create(std::move(readFile), leafPool_.get(), options);
+      return std::make_pair(std::move(reader), std::move(fileHandle));
+    };
+
+    // First reader: cold path reads from file.
+    {
+      auto [reader1, fh1] = createReader();
+      ASSERT_NE(reader1->denseIndex({"id"}), nullptr);
+
+      auto firstResult = pointLookup(reader1->denseIndex({"id"}), {"id"}, 0);
+      ASSERT_EQ(firstResult.size(), 1);
+      ASSERT_FALSE(firstResult[0].empty());
+    }
+
+    // Second reader: verify functional correctness with fresh IO stats.
+    {
+      auto [reader2, fh2] = createReader();
+      ASSERT_NE(reader2->denseIndex({"id"}), nullptr);
+
+      auto secondResult = pointLookup(reader2->denseIndex({"id"}), {"id"}, 0);
+      ASSERT_EQ(secondResult.size(), 1);
+      ASSERT_FALSE(secondResult[0].empty());
+
+      if (testCase.expectCrossReaderReuse) {
+        // Metadata (hash index data) is served from AsyncDataCache.
+        EXPECT_GT(metadataIoStats_->ramHit().count(), 0)
+            << "Second reader should serve index metadata from cache";
+      }
+    }
+  }
+
+  cache->shutdown();
 }
 
 } // namespace

--- a/dwio/nimble/index/tests/IndexLookupTest.cpp
+++ b/dwio/nimble/index/tests/IndexLookupTest.cpp
@@ -224,10 +224,20 @@ TEST_F(IndexLookupTest, optionsValidateRequiredFields) {
   }
 }
 
-TEST_F(IndexLookupTest, optionsValidateFileHandleAndCache) {
+TEST_F(IndexLookupTest, optionsValidateIndexIoStats) {
   auto file = std::make_shared<velox::InMemoryReadFile>(std::string{});
   auto pool = velox::memory::memoryManager()->addLeafPool();
   velox::io::ReaderOptions ioOptions(pool.get());
+  IndexLookup::Options options{.file = file, .ioOptions = &ioOptions};
+  NIMBLE_ASSERT_THROW(options.validate(), "indexIoStats must be set");
+}
+
+TEST_F(IndexLookupTest, optionsValidateFileHandleAndCache) {
+  auto file = std::make_shared<velox::InMemoryReadFile>(std::string{});
+  auto pool = velox::memory::memoryManager()->addLeafPool();
+  auto indexIoStats = std::make_shared<velox::io::IoStatistics>();
+  velox::io::ReaderOptions ioOptions(pool.get());
+  ioOptions.setIndexIoStats(indexIoStats);
 
   {
     SCOPED_TRACE("direct path (no fileHandle, no cache)");
@@ -280,9 +290,9 @@ TEST_F(IndexLookupTest, createIndexMetadataInput) {
     SCOPED_TRACE(testData.debugString());
     auto file = std::make_shared<velox::InMemoryReadFile>(std::string{});
     auto pool = velox::memory::memoryManager()->addLeafPool();
-    auto metadataIoStats = std::make_shared<velox::io::IoStatistics>();
     velox::io::ReaderOptions ioOptions(pool.get());
-    ioOptions.setMetadataIoStats(metadataIoStats);
+    ioOptions.setMetadataIoStats(std::make_shared<velox::io::IoStatistics>());
+    ioOptions.setIndexIoStats(std::make_shared<velox::io::IoStatistics>());
 
     std::shared_ptr<velox::memory::MallocAllocator> allocator;
     std::shared_ptr<velox::cache::AsyncDataCache> cache;
@@ -308,32 +318,18 @@ TEST_F(IndexLookupTest, createIndexMetadataInput) {
 }
 
 TEST_F(IndexLookupTest, createIndexDataInput) {
-  struct TestParam {
-    bool cached;
-    bool hasIndexIoStats;
-    std::string debugString() const {
-      return fmt::format(
-          "cached {}, hasIndexIoStats {}", cached, hasIndexIoStats);
-    }
-  };
-  std::vector<TestParam> testSettings = {
-      {false, true}, {false, false}, {true, true}};
-  for (const auto& testData : testSettings) {
-    SCOPED_TRACE(testData.debugString());
+  for (bool cached : {false, true}) {
+    SCOPED_TRACE(cached ? "cached" : "direct");
     auto file = std::make_shared<velox::InMemoryReadFile>(std::string{});
     auto pool = velox::memory::memoryManager()->addLeafPool();
-    auto metadataIoStats = std::make_shared<velox::io::IoStatistics>();
-    auto indexIoStats = std::make_shared<velox::io::IoStatistics>();
     velox::io::ReaderOptions ioOptions(pool.get());
-    ioOptions.setMetadataIoStats(metadataIoStats);
-    if (testData.hasIndexIoStats) {
-      ioOptions.setIndexIoStats(indexIoStats);
-    }
+    ioOptions.setMetadataIoStats(std::make_shared<velox::io::IoStatistics>());
+    ioOptions.setIndexIoStats(std::make_shared<velox::io::IoStatistics>());
 
     std::shared_ptr<velox::memory::MallocAllocator> allocator;
     std::shared_ptr<velox::cache::AsyncDataCache> cache;
     std::unique_ptr<velox::FileHandle> fileHandle;
-    if (testData.cached) {
+    if (cached) {
       allocator = std::make_shared<velox::memory::MallocAllocator>(
           velox::memory::MemoryAllocator::Options{.capacity = 1UL << 30});
       cache = velox::cache::AsyncDataCache::create(allocator.get());
@@ -347,7 +343,7 @@ TEST_F(IndexLookupTest, createIndexDataInput) {
         .ioOptions = &ioOptions,
         .fileHandle = fileHandle.get(),
         .cache = cache.get()};
-    auto dataInput = createIndexDataInput(options, *pool);
+    auto dataInput = createIndexDataInput(options);
     ASSERT_NE(dataInput, nullptr);
   }
 }

--- a/dwio/nimble/index/tests/SortedIndexTest.cpp
+++ b/dwio/nimble/index/tests/SortedIndexTest.cpp
@@ -26,10 +26,16 @@
 #include "velox/common/base/tests/GTestUtils.h"
 
 #include "dwio/nimble/tablet/TabletReader.h"
+#include "dwio/nimble/tablet/TabletWriter.h"
 #include "dwio/nimble/tablet/tests/TabletTestUtils.h"
 #include "dwio/nimble/velox/VeloxReader.h"
 #include "dwio/nimble/velox/VeloxWriter.h"
+#include "velox/common/caching/AsyncDataCache.h"
+#include "velox/common/caching/FileHandle.h"
+#include "velox/common/caching/FileIds.h"
 #include "velox/common/file/FileSystems.h"
+#include "velox/common/io/IoStatistics.h"
+#include "velox/common/memory/MallocAllocator.h"
 #include "velox/common/memory/Memory.h"
 #include "velox/common/testutil/TempDirectoryPath.h"
 #include "velox/vector/FlatVector.h"
@@ -171,6 +177,10 @@ class SortedIndexTestBase {
   std::shared_ptr<velox::memory::MemoryPool> leafPool_;
   std::shared_ptr<velox::common::testutil::TempDirectoryPath> tempDir_;
   std::deque<std::string> valueStrings_;
+  std::shared_ptr<velox::io::IoStatistics> metadataIoStats_{
+      std::make_shared<velox::io::IoStatistics>()};
+  std::shared_ptr<velox::io::IoStatistics> indexIoStats_{
+      std::make_shared<velox::io::IoStatistics>()};
 };
 
 class SortedIndexTest : public SortedIndexTestBase, public ::testing::Test {
@@ -691,6 +701,206 @@ TEST_F(SortedIndexTest, rowCountOverflow) {
 
   NIMBLE_ASSERT_USER_THROW(
       writer->write(batch), "Sorted index row count exceeds uint32 limit");
+}
+
+TEST_F(SortedIndexTest, indexDataReuseWithSameReader) {
+  std::vector<velox::VectorPtr> batches;
+  batches.push_back(makeBatch(0, 50));
+
+  const auto filePath = tempFilePath("same_reader_reuse");
+  writeFile(filePath, batches, SortedIndexConfig{.columns = {"value"}});
+
+  auto allocator = std::make_shared<velox::memory::MallocAllocator>(
+      velox::memory::MemoryAllocator::Options{
+          .capacity = 1UL << 30, .reservationByteLimit = 0});
+  auto cache = velox::cache::AsyncDataCache::create(allocator.get());
+
+  struct TestCase {
+    bool cacheIndex;
+    bool provideCache;
+    bool expectRamHit;
+
+    std::string debugString() const {
+      return fmt::format(
+          "cacheIndex={}, provideCache={}, expectRamHit={}",
+          cacheIndex,
+          provideCache,
+          expectRamHit);
+    }
+  };
+
+  std::vector<TestCase> testCases = {
+      {true, true, true},
+      {false, true, false},
+      {false, false, false},
+      {true, false, false},
+  };
+
+  auto fs = velox::filesystems::getFileSystem(filePath, {});
+
+  for (const auto& testCase : testCases) {
+    SCOPED_TRACE(testCase.debugString());
+
+    metadataIoStats_ = std::make_shared<velox::io::IoStatistics>();
+    indexIoStats_ = std::make_shared<velox::io::IoStatistics>();
+
+    auto readFile =
+        std::shared_ptr<velox::ReadFile>(fs->openFileForRead(filePath));
+    auto& ids = velox::fileIds();
+    auto fileIdStr = fmt::format(
+        "sortedSameReader_cache{}_provide{}",
+        testCase.cacheIndex,
+        testCase.provideCache);
+
+    TabletReader::Options options;
+    options.loadDenseIndexes = true;
+    options.cacheIndex = testCase.cacheIndex;
+    options.ioOptions.emplace(leafPool_.get())
+        .setMetadataIoStats(metadataIoStats_)
+        .setIndexIoStats(indexIoStats_);
+
+    std::unique_ptr<velox::FileHandle> fileHandle;
+    if (testCase.provideCache) {
+      fileHandle = std::make_unique<velox::FileHandle>();
+      fileHandle->file = readFile;
+      fileHandle->uuid = velox::StringIdLease(ids, fileIdStr);
+      fileHandle->groupId = velox::StringIdLease(ids, fileIdStr + "_group");
+      options.cache = cache.get();
+      options.fileHandle = fileHandle.get();
+    }
+
+    auto tablet =
+        TabletReader::create(std::move(readFile), leafPool_.get(), options);
+    ASSERT_NE(tablet->denseIndex({"value"}), nullptr);
+
+    // Both lookups should return correct results. The pinned SortedIndex
+    // object is reused across lookups within the same reader.
+    auto firstResult = pointLookup(tablet->denseIndex({"value"}), {"value"}, 0);
+    ASSERT_EQ(firstResult.size(), 1);
+    ASSERT_FALSE(firstResult[0].empty());
+
+    auto secondResult =
+        pointLookup(tablet->denseIndex({"value"}), {"value"}, 25);
+    ASSERT_EQ(secondResult.size(), 1);
+    ASSERT_FALSE(secondResult[0].empty());
+
+    // Verify the same index object is returned (pinned in MetadataCache).
+    EXPECT_EQ(tablet->denseIndex({"value"}), tablet->denseIndex({"value"}));
+  }
+
+  cache->shutdown();
+}
+
+TEST_F(SortedIndexTest, indexDataReuseCrossReaders) {
+  std::vector<velox::VectorPtr> batches;
+  batches.push_back(makeBatch(0, 50));
+
+  const auto filePath = tempFilePath("cross_reader_reuse");
+  writeFile(filePath, batches, SortedIndexConfig{.columns = {"value"}});
+
+  auto allocator = std::make_shared<velox::memory::MallocAllocator>(
+      velox::memory::MemoryAllocator::Options{
+          .capacity = 1UL << 30, .reservationByteLimit = 0});
+  auto cache = velox::cache::AsyncDataCache::create(allocator.get());
+
+  struct TestCase {
+    bool cacheIndex;
+    bool provideCache;
+    bool expectCrossReaderReuse;
+    bool expectRamHit;
+
+    std::string debugString() const {
+      return fmt::format(
+          "cacheIndex={}, provideCache={}, "
+          "expectCrossReaderReuse={}, expectRamHit={}",
+          cacheIndex,
+          provideCache,
+          expectCrossReaderReuse,
+          expectRamHit);
+    }
+  };
+
+  std::vector<TestCase> testCases = {
+      {true, true, true, true},
+      {false, true, false, false},
+      {false, false, false, false},
+      {true, false, false, false},
+  };
+
+  auto fs = velox::filesystems::getFileSystem(filePath, {});
+
+  for (const auto& testCase : testCases) {
+    SCOPED_TRACE(testCase.debugString());
+
+    auto& ids = velox::fileIds();
+    auto fileIdStr = fmt::format(
+        "sortedCrossReader_cache{}_provide{}",
+        testCase.cacheIndex,
+        testCase.provideCache);
+    velox::StringIdLease fileId(ids, fileIdStr);
+    velox::StringIdLease groupId(ids, fileIdStr + "_group");
+
+    auto createReader = [&]() {
+      metadataIoStats_ = std::make_shared<velox::io::IoStatistics>();
+      indexIoStats_ = std::make_shared<velox::io::IoStatistics>();
+
+      auto readFile =
+          std::shared_ptr<velox::ReadFile>(fs->openFileForRead(filePath));
+
+      TabletReader::Options options;
+      options.loadDenseIndexes = true;
+      options.cacheIndex = testCase.cacheIndex;
+      options.ioOptions.emplace(leafPool_.get())
+          .setMetadataIoStats(metadataIoStats_)
+          .setIndexIoStats(indexIoStats_);
+
+      std::unique_ptr<velox::FileHandle> fileHandle;
+      if (testCase.provideCache) {
+        fileHandle = std::make_unique<velox::FileHandle>();
+        fileHandle->file = readFile;
+        fileHandle->uuid = fileId;
+        fileHandle->groupId = groupId;
+        options.cache = cache.get();
+        options.fileHandle = fileHandle.get();
+      }
+
+      auto reader =
+          TabletReader::create(std::move(readFile), leafPool_.get(), options);
+      return std::make_pair(std::move(reader), std::move(fileHandle));
+    };
+
+    // First reader: cold path reads from file.
+    {
+      auto [reader1, fh1] = createReader();
+      ASSERT_NE(reader1->denseIndex({"value"}), nullptr);
+
+      auto firstResult =
+          pointLookup(reader1->denseIndex({"value"}), {"value"}, 0);
+      ASSERT_EQ(firstResult.size(), 1);
+      ASSERT_FALSE(firstResult[0].empty());
+      EXPECT_GT(indexIoStats_->rawBytesRead(), 0)
+          << "First reader should read index data from file";
+    }
+
+    // Second reader: verify functional correctness with fresh IO stats.
+    {
+      auto [reader2, fh2] = createReader();
+      ASSERT_NE(reader2->denseIndex({"value"}), nullptr);
+
+      auto secondResult =
+          pointLookup(reader2->denseIndex({"value"}), {"value"}, 0);
+      ASSERT_EQ(secondResult.size(), 1);
+      ASSERT_FALSE(secondResult[0].empty());
+
+      if (testCase.expectCrossReaderReuse) {
+        // Metadata (index directory) is served from AsyncDataCache.
+        EXPECT_GT(metadataIoStats_->ramHit().count(), 0)
+            << "Second reader should serve index metadata from cache";
+      }
+    }
+  }
+
+  cache->shutdown();
 }
 
 } // namespace

--- a/dwio/nimble/tablet/FileLayout.cpp
+++ b/dwio/nimble/tablet/FileLayout.cpp
@@ -35,6 +35,7 @@ FileLayout FileLayout::create(
   readerOptions.setMetadataIoStats(metadataStats);
   readerOptions.setIndexIoStats(indexStats);
   TabletReader::Options options;
+  options.loadClusterIndex = true;
   options.ioOptions = readerOptions;
   auto tablet = TabletReader::create(std::move(file), pool, options);
 

--- a/dwio/nimble/tablet/TabletReader.cpp
+++ b/dwio/nimble/tablet/TabletReader.cpp
@@ -92,7 +92,10 @@ TabletReader::Options TabletReader::configureOptions(
   if (tabletOptions.loadChunkIndex) {
     tabletOptions.preloadOptionalSections.emplace_back(kChunkIndexSection);
   }
-  tabletOptions.pinFileMetadata = options.pinFileMetadata();
+  tabletOptions.pinMetadata = options.pinMetadata();
+  tabletOptions.cacheMetadata = options.cacheMetadata();
+  tabletOptions.pinIndex = options.pinIndex();
+  tabletOptions.cacheIndex = options.cacheIndex();
   tabletOptions.ioOptions = options;
   return tabletOptions;
 }
@@ -238,14 +241,25 @@ TabletReader::TabletReader(
             options.ioOptions->metadataIoStats(), "metadataIoStats is null.");
         return *options.ioOptions;
       }()},
-      indexOptions_{index::IndexLookup::Options{
-          file_,
-          &ioOptions_,
-          options.fileHandle,
-          options.cache}},
+      indexOptions_{[&]() {
+        // cacheIndex takes effect only when fileHandle and cache are provided.
+        const bool cacheEnabled =
+            options.cacheIndex && options.fileHandle != nullptr;
+        if (cacheEnabled) {
+          NIMBLE_CHECK_NOT_NULL(options.cache, "cacheIndex requires cache");
+        }
+        return index::IndexLookup::Options{
+            file_,
+            &ioOptions_,
+            cacheEnabled ? options.fileHandle : nullptr,
+            cacheEnabled ? options.cache : nullptr,
+            options.pinIndex};
+      }()},
       metadataInput_{[&]() {
-        if (options.fileHandle != nullptr) {
-          NIMBLE_CHECK_NOT_NULL(options.cache);
+        // cacheMetadata takes effect only when fileHandle and cache are
+        // provided.
+        if (options.cacheMetadata && options.fileHandle != nullptr) {
+          NIMBLE_CHECK_NOT_NULL(options.cache, "cacheMetadata requires cache");
           return MetadataInput::create(
               options.fileHandle, options.cache, ioOptions_);
         }
@@ -255,12 +269,12 @@ TabletReader::TabletReader(
           [this](uint32_t stripeGroupIndex) {
             return loadStripeGroup(stripeGroupIndex);
           },
-          options.pinFileMetadata},
+          options.pinMetadata},
       chunkIndexCache_{
           [this](uint32_t stripeGroupIndex) {
             return loadChunkIndexGroup(stripeGroupIndex);
           },
-          options.pinFileMetadata} {
+          options.pinMetadata} {
   NIMBLE_CHECK_EQ(
       static_cast<const void*>(&ioOptions_.memoryPool()),
       static_cast<const void*>(pool_),

--- a/dwio/nimble/tablet/TabletReader.h
+++ b/dwio/nimble/tablet/TabletReader.h
@@ -159,20 +159,34 @@ class TabletReader {
     /// Optional sections to eagerly load during initialization.
     std::vector<std::string> preloadOptionalSections;
 
-    /// Whether to load the cluster index during initialization. Default true.
-    bool loadClusterIndex{true};
+    /// Whether to load the cluster index during initialization. Default false.
+    bool loadClusterIndex{false};
 
     /// Whether to load the chunk index during initialization. Default true.
     bool loadChunkIndex{true};
 
-    /// Whether to load the dense indexes during initialization. Default true.
-    bool loadDenseIndexes{true};
+    /// Whether to load the dense indexes during initialization. Default false.
+    bool loadDenseIndexes{false};
 
     /// If true, pins parsed metadata objects (StripeGroup, ChunkIndexGroup)
-    /// in the cache with strong references so they are never evicted. This
-    /// avoids re-reading and re-parsing metadata on every stripe access when
-    /// the weak-pointer cache entries would otherwise expire.
-    bool pinFileMetadata{false};
+    /// in the metadata cache with strong references so they are never evicted.
+    /// This avoids re-reading and re-parsing metadata on every stripe access
+    /// when the weak-pointer cache entries would otherwise expire. Works
+    /// independently of cacheMetadata.
+    bool pinMetadata{false};
+
+    /// If true, caches file metadata and index metadata in the async data
+    /// cache. Takes effect only when fileHandle and cache are provided.
+    bool cacheMetadata{false};
+
+    /// If true, pins parsed index objects in the index cache with strong
+    /// references.
+    bool pinIndex{false};
+
+    /// If true, caches index data (e.g., cluster index key stream) in the
+    /// async data cache. Takes effect only when fileHandle and cache are
+    /// provided.
+    bool cacheIndex{false};
 
     /// IO options providing pool, IO stats, coalescing params, and executor.
     /// Must be set with a non-null metadataIoStats; the constructor enforces

--- a/dwio/nimble/tablet/tests/TabletTest.cpp
+++ b/dwio/nimble/tablet/tests/TabletTest.cpp
@@ -31,6 +31,7 @@
 #include "dwio/nimble/common/tests/GTestUtils.h"
 #include "dwio/nimble/common/tests/TestUtils.h"
 #include "dwio/nimble/index/ChunkIndexGroup.h"
+#include "dwio/nimble/index/IndexConfig.h"
 #include "dwio/nimble/index/IndexLookup.h"
 #include "dwio/nimble/index/tests/ClusterIndexTestUtils.h"
 #include "dwio/nimble/tablet/Constants.h"
@@ -38,6 +39,7 @@
 #include "dwio/nimble/tablet/TabletReader.h"
 #include "dwio/nimble/tablet/TabletWriter.h"
 #include "dwio/nimble/tablet/tests/TabletTestUtils.h"
+#include "dwio/nimble/velox/VeloxWriter.h"
 #include "folly/FileUtil.h"
 #include "folly/Random.h"
 #include "folly/executors/CPUThreadPoolExecutor.h"
@@ -201,6 +203,8 @@ class TabletTest : public ::testing::TestWithParam<BufferedInputMode> {
       fileHandle_->groupId = velox::StringIdLease(ids, "testGroup");
       options.cache = cache_.get();
       options.fileHandle = fileHandle_.get();
+      options.cacheMetadata = true;
+      options.cacheIndex = true;
     }
   }
 
@@ -1319,6 +1323,16 @@ TEST_P(TabletTest, streamSize) {
 // It inherits the memory pool and helper methods from TabletTest.
 class TabletWithIndexTest : public TabletTest {
  protected:
+  // Override to enable index loading by default for index tests.
+  std::shared_ptr<nimble::TabletReader> createTabletReader(
+      std::shared_ptr<velox::ReadFile> readFile,
+      nimble::TabletReader::Options options = {}) {
+    options.loadClusterIndex = true;
+    options.loadDenseIndexes = true;
+    return TabletTest::createTabletReader(
+        std::move(readFile), std::move(options));
+  }
+
   // Use shared test data structs from ClusterIndexTestUtils.h
   using ChunkSpec = nimble::index::test::ChunkSpec;
   using KeyChunkSpec = nimble::index::test::KeyChunkSpec;
@@ -3573,6 +3587,185 @@ TEST_P(TabletWithIndexTest, noIndex) {
       tablet->hasOptionalSection(std::string(nimble::kChunkIndexSection)));
 }
 
+TEST_P(TabletWithIndexTest, loadClusterIndex) {
+  std::string file;
+  velox::InMemoryWriteFile writeFile(&file);
+
+  nimble::index::test::TestClusterIndexMetadataWriter indexHelper(
+      *pool_,
+      {"col1"},
+      {SortOrder{.ascending = true}},
+      /*enforceKeyOrder=*/true);
+
+  auto tabletWriter = nimble::TabletWriter::create(
+      &writeFile,
+      *pool_,
+      {
+          .metadataFlushThreshold = 1024 * 1024 * 1024,
+          .streamDeduplicationEnabled = false,
+          .enableChunkIndex = true,
+          .stripeGroupFlushCallback =
+              indexHelper.createStripeGroupFlushCallback(),
+          .closeCallback = indexHelper.createCloseCallback(),
+      });
+
+  nimble::Buffer buffer{*pool_};
+  auto streams = createStreams(
+      buffer, {{.offset = 0, .chunks = {{.rowCount = 100, .size = 10}}}});
+  indexHelper.addStripe({{.rowCount = 100, .key = "bbb"}});
+  tabletWriter->writeStripe(100, std::move(streams));
+  tabletWriter->close();
+
+  auto readFile = std::make_shared<velox::InMemoryReadFile>(file);
+
+  for (bool loadClusterIndex : {false, true}) {
+    SCOPED_TRACE(fmt::format("loadClusterIndex={}", loadClusterIndex));
+    const auto metadataBytesReadBefore = metadataIoStats_->rawBytesRead();
+    const auto indexBytesReadBefore = indexIoStats_->rawBytesRead();
+    nimble::TabletReader::Options options;
+    options.loadClusterIndex = loadClusterIndex;
+    auto tablet = TabletTest::createTabletReader(readFile, options);
+    if (loadClusterIndex) {
+      ASSERT_NE(tablet->clusterIndex(), nullptr);
+      EXPECT_GT(metadataIoStats_->rawBytesRead(), metadataBytesReadBefore);
+      // Index key stream data is lazy-loaded on first lookup, not during
+      // init. Only metadata IO (root section) happens here.
+      EXPECT_EQ(indexIoStats_->rawBytesRead(), indexBytesReadBefore);
+    } else {
+      EXPECT_EQ(tablet->clusterIndex(), nullptr);
+      EXPECT_EQ(metadataIoStats_->rawBytesRead(), metadataBytesReadBefore);
+      EXPECT_EQ(indexIoStats_->rawBytesRead(), indexBytesReadBefore);
+    }
+  }
+}
+
+TEST_P(TabletWithIndexTest, loadClusterIndexMissingIoStats) {
+  std::string file;
+  velox::InMemoryWriteFile writeFile(&file);
+
+  nimble::index::test::TestClusterIndexMetadataWriter indexHelper(
+      *pool_,
+      {"col1"},
+      {SortOrder{.ascending = true}},
+      /*enforceKeyOrder=*/true);
+
+  auto tabletWriter = nimble::TabletWriter::create(
+      &writeFile,
+      *pool_,
+      {
+          .metadataFlushThreshold = 1024 * 1024 * 1024,
+          .streamDeduplicationEnabled = false,
+          .enableChunkIndex = true,
+          .stripeGroupFlushCallback =
+              indexHelper.createStripeGroupFlushCallback(),
+          .closeCallback = indexHelper.createCloseCallback(),
+      });
+
+  nimble::Buffer buffer{*pool_};
+  auto streams = createStreams(
+      buffer, {{.offset = 0, .chunks = {{.rowCount = 100, .size = 10}}}});
+  indexHelper.addStripe({{.rowCount = 100, .key = "bbb"}});
+  tabletWriter->writeStripe(100, std::move(streams));
+  tabletWriter->close();
+
+  auto readFile = std::make_shared<velox::InMemoryReadFile>(file);
+  nimble::TabletReader::Options options;
+  options.loadClusterIndex = true;
+  options.ioOptions.emplace(pool_.get())
+      .setMetadataIoStats(std::make_shared<velox::io::IoStatistics>());
+  NIMBLE_ASSERT_THROW(
+      nimble::TabletReader::create(readFile, pool_.get(), options),
+      "indexIoStats must be set");
+}
+
+TEST_P(TabletWithIndexTest, loadDenseIndexes) {
+  auto type =
+      velox::ROW({{"id", velox::INTEGER()}, {"value", velox::VARCHAR()}});
+  auto ids = velox::BaseVector::create(velox::INTEGER(), 50, pool_.get());
+  auto values = velox::BaseVector::create(velox::VARCHAR(), 50, pool_.get());
+  auto* flatIds = ids->asFlatVector<int32_t>();
+  auto* flatValues = values->asFlatVector<velox::StringView>();
+  std::vector<std::string> valueStrings;
+  for (int i = 0; i < 50; ++i) {
+    flatIds->set(i, i);
+    valueStrings.push_back("v_" + std::to_string(i));
+    flatValues->set(i, velox::StringView(valueStrings.back()));
+  }
+  auto batch = std::make_shared<velox::RowVector>(
+      pool_.get(),
+      type,
+      nullptr,
+      50,
+      std::vector<velox::VectorPtr>{ids, values});
+
+  std::string file;
+  auto writeFile = std::make_unique<velox::InMemoryWriteFile>(&file);
+  nimble::VeloxWriterOptions writerOptions;
+  writerOptions.hashIndexConfigs.push_back(
+      nimble::HashIndexConfig{.columns = {"id"}});
+  writerOptions.sortedIndexConfigs.push_back(
+      nimble::SortedIndexConfig{.columns = {"value"}});
+  nimble::VeloxWriter writer(
+      type, std::move(writeFile), *pool_, std::move(writerOptions));
+  writer.write(batch);
+  writer.close();
+
+  auto readFile = std::make_shared<velox::InMemoryReadFile>(file);
+
+  for (bool loadDenseIndexes : {false, true}) {
+    SCOPED_TRACE(fmt::format("loadDenseIndexes={}", loadDenseIndexes));
+    auto metadataIoStats = std::make_shared<velox::io::IoStatistics>();
+    auto indexIoStats = std::make_shared<velox::io::IoStatistics>();
+    nimble::TabletReader::Options options;
+    options.loadDenseIndexes = loadDenseIndexes;
+    options.ioOptions.emplace(pool_.get())
+        .setMetadataIoStats(metadataIoStats)
+        .setIndexIoStats(indexIoStats);
+    auto tablet = nimble::TabletReader::create(readFile, pool_.get(), options);
+    const auto metadataBytesAfterOpen = metadataIoStats->rawBytesRead();
+    if (loadDenseIndexes) {
+      ASSERT_NE(tablet->denseIndex({"id"}), nullptr);
+      ASSERT_NE(tablet->denseIndex({"value"}), nullptr);
+      EXPECT_GT(metadataIoStats->rawBytesRead(), metadataBytesAfterOpen);
+    } else {
+      EXPECT_EQ(tablet->denseIndex({"id"}), nullptr);
+      EXPECT_EQ(tablet->denseIndex({"value"}), nullptr);
+      EXPECT_EQ(metadataIoStats->rawBytesRead(), metadataBytesAfterOpen);
+      EXPECT_EQ(indexIoStats->rawBytesRead(), 0);
+    }
+  }
+}
+
+TEST_P(TabletWithIndexTest, loadDenseIndexesMissingIoStats) {
+  auto type = velox::ROW({{"id", velox::INTEGER()}});
+  auto ids = velox::BaseVector::create(velox::INTEGER(), 50, pool_.get());
+  auto* flatIds = ids->asFlatVector<int32_t>();
+  for (int i = 0; i < 50; ++i) {
+    flatIds->set(i, i);
+  }
+  auto batch = std::make_shared<velox::RowVector>(
+      pool_.get(), type, nullptr, 50, std::vector<velox::VectorPtr>{ids});
+
+  std::string file;
+  auto writeFile = std::make_unique<velox::InMemoryWriteFile>(&file);
+  nimble::VeloxWriterOptions writerOptions;
+  writerOptions.hashIndexConfigs.push_back(
+      nimble::HashIndexConfig{.columns = {"id"}});
+  nimble::VeloxWriter writer(
+      type, std::move(writeFile), *pool_, std::move(writerOptions));
+  writer.write(batch);
+  writer.close();
+
+  auto readFile = std::make_shared<velox::InMemoryReadFile>(file);
+  nimble::TabletReader::Options options;
+  options.loadDenseIndexes = true;
+  options.ioOptions.emplace(pool_.get())
+      .setMetadataIoStats(std::make_shared<velox::io::IoStatistics>());
+  NIMBLE_ASSERT_THROW(
+      nimble::TabletReader::create(readFile, pool_.get(), options),
+      "indexIoStats must be set");
+}
+
 // Tests all four orthogonal config combinations of enableChunkIndex ×
 // cluster index (via indexHelper) to verify:
 // 1. Neither: no optional sections
@@ -3676,7 +3869,11 @@ TEST_F(TabletWithIndexTest, configCombinations) {
     auto readFile =
         std::make_shared<nimble::testing::InMemoryTrackableReadFile>(
             file, false);
-    auto tablet = createTabletReader(readFile, {}, BufferedInputMode::kNone);
+    nimble::TabletReader::Options readOptions;
+    readOptions.loadClusterIndex = true;
+    readOptions.loadDenseIndexes = true;
+    auto tablet = TabletTest::createTabletReader(
+        readFile, readOptions, BufferedInputMode::kNone);
     EXPECT_EQ(tablet->stripeCount(), 2);
 
     // Verify optional sections
@@ -4191,11 +4388,11 @@ TEST_P(TabletTest, configureOptionsIndexFlags) {
   {
     SCOPED_TRACE("defaults");
     auto opts = nimble::TabletReader::configureOptions(readerOptions);
-    EXPECT_TRUE(opts.loadClusterIndex);
+    EXPECT_FALSE(opts.loadClusterIndex);
     EXPECT_TRUE(opts.loadChunkIndex);
     EXPECT_TRUE(
         containsSection(opts.preloadOptionalSections, nimble::kSchemaSection));
-    EXPECT_TRUE(containsSection(
+    EXPECT_FALSE(containsSection(
         opts.preloadOptionalSections, nimble::kClusterIndexSection));
     EXPECT_TRUE(containsSection(
         opts.preloadOptionalSections, nimble::kChunkIndexSection));

--- a/dwio/nimble/tablet/tests/TabletTestUtils.h
+++ b/dwio/nimble/tablet/tests/TabletTestUtils.h
@@ -27,8 +27,11 @@ namespace facebook::nimble::test {
 inline TabletReader::Options makeTestTabletOptions(
     velox::memory::MemoryPool* pool) {
   TabletReader::Options options;
-  options.ioOptions.emplace(pool).setMetadataIoStats(
-      std::make_shared<velox::io::IoStatistics>());
+  options.loadClusterIndex = true;
+  options.loadDenseIndexes = true;
+  options.ioOptions.emplace(pool)
+      .setMetadataIoStats(std::make_shared<velox::io::IoStatistics>())
+      .setIndexIoStats(std::make_shared<velox::io::IoStatistics>());
   return options;
 }
 

--- a/dwio/nimble/tools/NimbleDumpLib.cpp
+++ b/dwio/nimble/tools/NimbleDumpLib.cpp
@@ -1166,8 +1166,10 @@ void NimbleDumpLib::emitOptionalSectionsMetadata(bool noHeader) {
 
 void NimbleDumpLib::emitIndex() {
   TabletReader::Options options;
+  options.loadClusterIndex = true;
   options.ioOptions.emplace(pool_.get())
-      .setMetadataIoStats(std::make_shared<velox::io::IoStatistics>());
+      .setMetadataIoStats(std::make_shared<velox::io::IoStatistics>())
+      .setIndexIoStats(std::make_shared<velox::io::IoStatistics>());
   auto tabletReader = TabletReader::create(file_, pool_.get(), options);
   if (!tabletReader->hasClusterIndex()) {
     ostream_ << "Index: Not configured" << std::endl;

--- a/dwio/nimble/velox/VeloxReader.cpp
+++ b/dwio/nimble/velox/VeloxReader.cpp
@@ -155,8 +155,9 @@ TabletReader::Options defaultTabletReaderOptions(
     velox::memory::MemoryPool* pool) {
   TabletReader::Options options;
   options.preloadOptionalSections = {std::string(kSchemaSection)};
-  options.ioOptions.emplace(pool).setMetadataIoStats(
-      std::make_shared<velox::io::IoStatistics>());
+  options.ioOptions.emplace(pool)
+      .setMetadataIoStats(std::make_shared<velox::io::IoStatistics>())
+      .setIndexIoStats(std::make_shared<velox::io::IoStatistics>());
   return options;
 }
 

--- a/dwio/nimble/velox/index/tests/NimbleIndexProjectorTest.cpp
+++ b/dwio/nimble/velox/index/tests/NimbleIndexProjectorTest.cpp
@@ -40,11 +40,11 @@ using Subfield = velox::common::Subfield;
 
 struct TestParam {
   bool enableCache;
-  bool pinFileMetadata;
+  bool pinMetadata;
 
   std::string debugString() const {
     return fmt::format(
-        "enableCache={}, pinFileMetadata={}", enableCache, pinFileMetadata);
+        "enableCache={}, pinMetadata={}", enableCache, pinMetadata);
   }
 };
 
@@ -122,9 +122,11 @@ class NimbleIndexProjectorTest : public ::testing::TestWithParam<TestParam> {
     dwio::common::ReaderOptions readerOptions(leafPool_.get());
     readerOptions.setDataIoStats(dataIoStats_);
     readerOptions.setMetadataIoStats(metadataIoStats_);
+    readerOptions.setIndexIoStats(indexIoStats_);
     readerOptions.setFileFormat(FileFormat::NIMBLE);
-    readerOptions.setFileMetadataCacheEnabled(GetParam().enableCache);
-    readerOptions.setPinFileMetadata(GetParam().pinFileMetadata);
+    readerOptions.setLoadClusterIndex(true);
+    readerOptions.setCacheMetadata(GetParam().enableCache);
+    readerOptions.setPinMetadata(GetParam().pinMetadata);
     return NimbleIndexProjector(
         std::move(readFile), projectedSubfields, readerOptions);
   }
@@ -208,6 +210,8 @@ class NimbleIndexProjectorTest : public ::testing::TestWithParam<TestParam> {
   const std::shared_ptr<io::IoStatistics> dataIoStats_{
       std::make_shared<io::IoStatistics>()};
   const std::shared_ptr<io::IoStatistics> metadataIoStats_{
+      std::make_shared<io::IoStatistics>()};
+  const std::shared_ptr<io::IoStatistics> indexIoStats_{
       std::make_shared<io::IoStatistics>()};
 
   std::shared_ptr<memory::MemoryPool> rootPool_;
@@ -942,7 +946,9 @@ TEST_P(NimbleIndexProjectorTest, featureReorderingStorageReads) {
     dwio::common::ReaderOptions readerOptions(leafPool_.get());
     readerOptions.setDataIoStats(dataIoStats_);
     readerOptions.setMetadataIoStats(metadataIoStats_);
+    readerOptions.setIndexIoStats(indexIoStats_);
     readerOptions.setFileFormat(FileFormat::NIMBLE);
+    readerOptions.setLoadClusterIndex(true);
     readerOptions.setMaxCoalesceDistance(maxCoalesceDistance);
 
     std::vector<Subfield> subfields;
@@ -1058,14 +1064,32 @@ TEST_P(NimbleIndexProjectorTest, featureReorderingStorageReads) {
       << ", without: " << readsNoReorderLarge;
 }
 
-// Verifies that pinFileMetadata prevents re-reading metadata on repeated
-// project() calls within the same projector. Cross-reader caching via
-// AsyncDataCache requires CachedBufferedInput support in
-// NimbleIndexProjector (followup).
-TEST_P(NimbleIndexProjectorTest, pinnedMetadataNoReread) {
-  if (!GetParam().pinFileMetadata) {
-    GTEST_SKIP() << "Only applicable when pinFileMetadata is enabled";
+// Verifies that metadata is reused within the same reader on repeated
+// project() calls. Loops over combinations of pinMetadata and cacheMetadata
+// to confirm that all valid configurations avoid re-reading metadata.
+TEST_P(NimbleIndexProjectorTest, metadataReuseWithSameReader) {
+  if (!GetParam().enableCache) {
+    GTEST_SKIP() << "Only applicable when cache is enabled";
   }
+
+  struct TestCase {
+    bool pinMetadata;
+    bool cacheMetadata;
+    bool expectRamHit;
+    std::string debugString() const {
+      return fmt::format(
+          "pinMetadata={}, cacheMetadata={}, expectRamHit={}",
+          pinMetadata,
+          cacheMetadata,
+          expectRamHit);
+    }
+  };
+
+  const std::vector<TestCase> testCases = {
+      {true, true, true},
+      {true, false, false},
+      {false, true, true},
+  };
 
   auto rowType = ROW({"key", "value"}, {BIGINT(), INTEGER()});
 
@@ -1084,11 +1108,9 @@ TEST_P(NimbleIndexProjectorTest, pinnedMetadataNoReread) {
 
   writeData({batch}, {"key"});
 
+  // Compute metadata boundary: the start of the first stripe group metadata.
   auto innerFile =
       std::make_shared<InMemoryReadFile>(std::string_view(sinkData_));
-  auto trackingFile = std::make_shared<testing::TrackingReadFile>(innerFile);
-
-  // Compute metadata boundary: the start of the first stripe group metadata.
   auto tablet = TabletReader::create(
       innerFile, leafPool_.get(), makeTestTabletOptions(leafPool_.get()));
   auto stripeGroupsMeta = tablet->stripeGroupsMetadata();
@@ -1096,33 +1118,41 @@ TEST_P(NimbleIndexProjectorTest, pinnedMetadataNoReread) {
   const auto metadataBoundary = stripeGroupsMeta[0].offset();
   tablet.reset();
 
-  dwio::common::ReaderOptions readerOptions(leafPool_.get());
-  readerOptions.setDataIoStats(dataIoStats_);
-  readerOptions.setMetadataIoStats(metadataIoStats_);
-  readerOptions.setFileFormat(FileFormat::NIMBLE);
-  readerOptions.setFileMetadataCacheEnabled(GetParam().enableCache);
-  readerOptions.setPinFileMetadata(GetParam().pinFileMetadata);
+  for (const auto& tc : testCases) {
+    SCOPED_TRACE(tc.debugString());
 
-  std::vector<Subfield> subfields;
-  subfields.emplace_back("value");
-  NimbleIndexProjector projector(trackingFile, subfields, readerOptions);
+    auto trackingFile = std::make_shared<testing::TrackingReadFile>(innerFile);
 
-  auto bounds = makePointLookup(rowType, {"key"}, 50);
-  NimbleIndexProjector::Request request;
-  request.keyBounds = {bounds};
+    dwio::common::ReaderOptions readerOptions(leafPool_.get());
+    readerOptions.setDataIoStats(dataIoStats_);
+    readerOptions.setMetadataIoStats(metadataIoStats_);
+    readerOptions.setIndexIoStats(indexIoStats_);
+    readerOptions.setFileFormat(FileFormat::NIMBLE);
+    readerOptions.setLoadClusterIndex(true);
+    readerOptions.setCacheMetadata(tc.cacheMetadata);
+    readerOptions.setPinMetadata(tc.pinMetadata);
 
-  // First project: reads both data and metadata regions.
-  projector.project(request, {});
-  ASSERT_GT(trackingFile->maxReadOffset(), metadataBoundary)
-      << "First project should read metadata beyond the boundary";
+    std::vector<Subfield> subfields;
+    subfields.emplace_back("value");
+    NimbleIndexProjector projector(trackingFile, subfields, readerOptions);
 
-  // Second project on the same projector: pinned metadata should avoid
-  // re-reading beyond the metadata boundary.
-  trackingFile->resetMaxReadOffset();
-  projector.project(request, {});
-  EXPECT_LE(trackingFile->maxReadOffset(), metadataBoundary)
-      << "Second project should not re-read metadata when "
-      << GetParam().debugString();
+    auto bounds = makePointLookup(rowType, {"key"}, 50);
+    NimbleIndexProjector::Request request;
+    request.keyBounds = {bounds};
+
+    // First project: reads both data and metadata regions.
+    projector.project(request, {});
+    ASSERT_GT(trackingFile->maxReadOffset(), metadataBoundary)
+        << "First project should read metadata beyond the boundary";
+
+    // Second project on the same projector: metadata should be reused,
+    // avoiding re-reads beyond the metadata boundary.
+    trackingFile->resetMaxReadOffset();
+    projector.project(request, {});
+    EXPECT_LE(trackingFile->maxReadOffset(), metadataBoundary)
+        << "Second project should not re-read metadata when "
+        << tc.debugString();
+  }
 }
 
 TEST_P(NimbleIndexProjectorTest, resumeKeyOnTruncation) {
@@ -1787,7 +1817,7 @@ INSTANTIATE_TEST_CASE_P(
       return fmt::format(
           "cache{}_pin{}",
           info.param.enableCache ? "On" : "Off",
-          info.param.pinFileMetadata ? "On" : "Off");
+          info.param.pinMetadata ? "On" : "Off");
     });
 
 } // namespace facebook::nimble::test

--- a/dwio/nimble/velox/selective/tests/E2EFilterTest.cpp
+++ b/dwio/nimble/velox/selective/tests/E2EFilterTest.cpp
@@ -49,7 +49,7 @@ struct E2EFilterTestParam {
   bool skipConstantFlatMapInMapStreams;
   bool enableChunkIndex;
   bool stringDecoderZeroCopy;
-  bool pinFileMetadata;
+  bool pinMetadata;
   bool enableCache;
   bool nimblePreserveDictionaryEncoding;
 
@@ -58,7 +58,7 @@ struct E2EFilterTestParam {
         skipConstantFlatMapInMapStreams{std::get<1>(t)},
         enableChunkIndex{std::get<2>(t)},
         stringDecoderZeroCopy{std::get<3>(t)},
-        pinFileMetadata{std::get<4>(t)},
+        pinMetadata{std::get<4>(t)},
         enableCache{std::get<5>(t)},
         nimblePreserveDictionaryEncoding{std::get<6>(t)} {}
 
@@ -69,7 +69,7 @@ struct E2EFilterTestParam {
         skipConstantFlatMapInMapStreams,
         enableChunkIndex,
         stringDecoderZeroCopy,
-        pinFileMetadata,
+        pinMetadata,
         enableCache,
         nimblePreserveDictionaryEncoding);
   }
@@ -89,6 +89,7 @@ class E2EFilterTest
     batchSize_ = 2003;
     batchCount_ = 5;
     testRowGroupSkip_ = false;
+    indexIoStats_ = std::make_shared<io::IoStatistics>();
     if (param().enableCache) {
       allocator_ = std::make_shared<memory::MallocAllocator>(
           memory::MemoryAllocator::Options{
@@ -373,7 +374,10 @@ class E2EFilterTest
       const dwio::common::ReaderOptions& opts,
       std::unique_ptr<dwio::common::BufferedInput> input) final {
     auto readerOpts = opts;
-    readerOpts.setPinFileMetadata(param().pinFileMetadata);
+    readerOpts.setLoadClusterIndex(true);
+    readerOpts.setPinMetadata(param().pinMetadata);
+    readerOpts.setCacheMetadata(param().enableCache);
+    readerOpts.setIndexIoStats(indexIoStats_);
     if (param().enableCache) {
       auto readFile = std::make_shared<InMemoryReadFile>(sinkData_);
       auto& ids = fileIds();
@@ -577,6 +581,7 @@ class E2EFilterTest
   std::shared_ptr<cache::AsyncDataCache> cache_;
   std::shared_ptr<io::IoStatistics> dataIoStats_;
   std::shared_ptr<io::IoStatistics> metadataIoStats_;
+  std::shared_ptr<io::IoStatistics> indexIoStats_;
   std::shared_ptr<cache::ScanTracker> scanTracker_;
   std::unique_ptr<folly::CPUThreadPoolExecutor> ioExecutor_;
 

--- a/dwio/nimble/velox/selective/tests/E2EIndexTest.cpp
+++ b/dwio/nimble/velox/selective/tests/E2EIndexTest.cpp
@@ -90,79 +90,75 @@ struct IndexEncodingParam {
   SortOrder sortOrder;
   std::optional<uint32_t> prefixRestartInterval;
   bool enableChunkIndex{false};
-  bool pinFileMetadata{false};
+  bool pinMetadata{false};
   bool enableCache{false};
 
   static IndexEncodingParam prefix(
       std::optional<uint32_t> prefixRestartInterval = std::nullopt,
       bool enableChunkIndex = false,
-      bool pinFileMetadata = false,
+      bool pinMetadata = false,
       bool enableCache = false) {
     return IndexEncodingParam{
         makePrefixEncodingName("Prefix", prefixRestartInterval) +
             (enableChunkIndex ? "_ChunkIndex" : "") +
-            (pinFileMetadata ? "_PinMetadata" : "") +
-            (enableCache ? "_Cache" : ""),
+            (pinMetadata ? "_PinMetadata" : "") + (enableCache ? "_Cache" : ""),
         EncodingType::Prefix,
         CompressionType::Uncompressed,
         SortOrder{.ascending = true},
         prefixRestartInterval,
         enableChunkIndex,
-        pinFileMetadata,
+        pinMetadata,
         enableCache};
   }
 
   static IndexEncodingParam trivialZstd(
       bool enableChunkIndex = false,
-      bool pinFileMetadata = false,
+      bool pinMetadata = false,
       bool enableCache = false) {
     return IndexEncodingParam{
         std::string("TrivialZstd") + (enableChunkIndex ? "_ChunkIndex" : "") +
-            (pinFileMetadata ? "_PinMetadata" : "") +
-            (enableCache ? "_Cache" : ""),
+            (pinMetadata ? "_PinMetadata" : "") + (enableCache ? "_Cache" : ""),
         EncodingType::Trivial,
         CompressionType::Zstd,
         SortOrder{.ascending = true},
         std::nullopt,
         enableChunkIndex,
-        pinFileMetadata,
+        pinMetadata,
         enableCache};
   }
 
   static IndexEncodingParam prefixDesc(
       std::optional<uint32_t> prefixRestartInterval = std::nullopt,
       bool enableChunkIndex = false,
-      bool pinFileMetadata = false,
+      bool pinMetadata = false,
       bool enableCache = false) {
     return IndexEncodingParam{
         makePrefixEncodingName("PrefixDesc", prefixRestartInterval) +
             (enableChunkIndex ? "_ChunkIndex" : "") +
-            (pinFileMetadata ? "_PinMetadata" : "") +
-            (enableCache ? "_Cache" : ""),
+            (pinMetadata ? "_PinMetadata" : "") + (enableCache ? "_Cache" : ""),
         EncodingType::Prefix,
         CompressionType::Uncompressed,
         SortOrder{.ascending = false},
         prefixRestartInterval,
         enableChunkIndex,
-        pinFileMetadata,
+        pinMetadata,
         enableCache};
   }
 
   static IndexEncodingParam trivialZstdDesc(
       bool enableChunkIndex = false,
-      bool pinFileMetadata = false,
+      bool pinMetadata = false,
       bool enableCache = false) {
     return IndexEncodingParam{
         std::string("TrivialZstdDesc") +
             (enableChunkIndex ? "_ChunkIndex" : "") +
-            (pinFileMetadata ? "_PinMetadata" : "") +
-            (enableCache ? "_Cache" : ""),
+            (pinMetadata ? "_PinMetadata" : "") + (enableCache ? "_Cache" : ""),
         EncodingType::Trivial,
         CompressionType::Zstd,
         SortOrder{.ascending = false},
         std::nullopt,
         enableChunkIndex,
-        pinFileMetadata,
+        pinMetadata,
         enableCache};
   }
 
@@ -201,6 +197,7 @@ class E2EIndexTestBase : public ::testing::Test {
     vectorMaker_ = std::make_unique<velox::test::VectorMaker>(leafPool_.get());
     dataIoStats_ = std::make_shared<io::IoStatistics>();
     metadataIoStats_ = std::make_shared<io::IoStatistics>();
+    indexIoStats_ = std::make_shared<io::IoStatistics>();
     scanTracker_ =
         std::make_shared<cache::ScanTracker>("testTracker", nullptr, 256 << 10);
     ioExecutor_ = std::make_unique<folly::CPUThreadPoolExecutor>(10);
@@ -341,7 +338,9 @@ class E2EIndexTestBase : public ::testing::Test {
     dwio::common::ReaderOptions readerOptions(leafPool_.get());
     readerOptions.setDataIoStats(dataIoStats_);
     readerOptions.setMetadataIoStats(metadataIoStats_);
+    readerOptions.setIndexIoStats(indexIoStats_);
     readerOptions.setFileFormat(FileFormat::NIMBLE);
+    readerOptions.setLoadClusterIndex(true);
     setUpReaderOptions(readerOptions);
 
     // Set up random skip if sample rate is less than 1.0.
@@ -387,7 +386,7 @@ class E2EIndexTestBase : public ::testing::Test {
     return factory->createReader(std::move(input), readerOptions);
   }
 
-  // Override to customize reader options (e.g., pinFileMetadata).
+  // Override to customize reader options (e.g., pinMetadata).
   virtual void setUpReaderOptions(dwio::common::ReaderOptions& /*opts*/) {}
 
   // Reads all rows with the given filters and optionally disables index.
@@ -521,6 +520,7 @@ class E2EIndexTestBase : public ::testing::Test {
   std::shared_ptr<cache::AsyncDataCache> cache_;
   std::shared_ptr<io::IoStatistics> dataIoStats_;
   std::shared_ptr<io::IoStatistics> metadataIoStats_;
+  std::shared_ptr<io::IoStatistics> indexIoStats_;
   std::shared_ptr<cache::ScanTracker> scanTracker_;
   std::unique_ptr<folly::CPUThreadPoolExecutor> ioExecutor_;
 };
@@ -536,7 +536,7 @@ class E2EIndexTest : public E2EIndexTestBase,
   }
 
   void setUpReaderOptions(dwio::common::ReaderOptions& opts) override {
-    opts.setPinFileMetadata(GetParam().pinFileMetadata);
+    opts.setPinMetadata(GetParam().pinMetadata);
   }
 
   // Returns the encoding layout from the test parameter.
@@ -2514,7 +2514,7 @@ INSTANTIATE_TEST_SUITE_P(
         IndexEncodingParam::trivialZstd(true),
         IndexEncodingParam::prefixDesc(std::nullopt, true),
         IndexEncodingParam::trivialZstdDesc(true),
-        // With pinFileMetadata enabled.
+        // With pinMetadata enabled.
         IndexEncodingParam::prefix(std::nullopt, false, true),
         IndexEncodingParam::prefixDesc(std::nullopt, false, true),
         IndexEncodingParam::prefix(std::nullopt, true, true),
@@ -2522,7 +2522,7 @@ INSTANTIATE_TEST_SUITE_P(
         // With cache enabled.
         IndexEncodingParam::prefix(std::nullopt, false, false, true),
         IndexEncodingParam::prefixDesc(std::nullopt, false, false, true),
-        // With cache and pinFileMetadata enabled.
+        // With cache and pinMetadata enabled.
         IndexEncodingParam::prefix(std::nullopt, false, true, true),
         IndexEncodingParam::prefixDesc(std::nullopt, false, true, true)),
     [](const ::testing::TestParamInfo<IndexEncodingParam>& info) {

--- a/dwio/nimble/velox/selective/tests/SelectiveNimbleReaderTest.cpp
+++ b/dwio/nimble/velox/selective/tests/SelectiveNimbleReaderTest.cpp
@@ -30,8 +30,10 @@
 #include "dwio/nimble/velox/ChunkedStream.h"
 #include "dwio/nimble/velox/EncodingLayoutTree.h"
 #include "dwio/nimble/velox/SchemaSerialization.h"
+#include "dwio/nimble/velox/VeloxReader.h"
 #include "velox/common/base/tests/GTestUtils.h"
 #include "velox/common/caching/AsyncDataCache.h"
+#include "velox/common/caching/FileHandle.h"
 #include "velox/common/caching/FileIds.h"
 #include "velox/common/caching/ScanTracker.h"
 #include "velox/common/io/IoStatistics.h"
@@ -57,14 +59,14 @@ auto format_as(FilterType filterType) {
 struct TestParam {
   bool stringDecoderZeroCopy;
   bool enableCache;
-  bool pinFileMetadata{false};
+  bool pinMetadata{false};
 
   std::string debugString() const {
     return fmt::format(
         "passStringBuffers_{}_cache_{}_pinMetadata_{}",
         stringDecoderZeroCopy,
         enableCache,
-        pinFileMetadata);
+        pinMetadata);
   }
 };
 
@@ -146,7 +148,8 @@ class SelectiveNimbleReaderTest
     options.setDataIoStats(dataIoStats_);
     options.setMetadataIoStats(metadataIoStats_);
     options.setScanSpec(scanSpec);
-    options.setPinFileMetadata(GetParam().pinFileMetadata);
+    options.setPinMetadata(GetParam().pinMetadata);
+    options.setCacheMetadata(GetParam().enableCache);
     std::unique_ptr<dwio::common::BufferedInput> input;
     auto& ids = fileIds();
     const auto readerId = readerIdCounter_++;
@@ -213,6 +216,8 @@ class SelectiveNimbleReaderTest
   const std::shared_ptr<io::IoStatistics> dataIoStats_{
       std::make_shared<io::IoStatistics>()};
   const std::shared_ptr<io::IoStatistics> metadataIoStats_{
+      std::make_shared<io::IoStatistics>()};
+  const std::shared_ptr<io::IoStatistics> indexIoStats_{
       std::make_shared<io::IoStatistics>()};
   std::shared_ptr<cache::ScanTracker> scanTracker_;
   std::unique_ptr<folly::CPUThreadPoolExecutor> ioExecutor_;
@@ -2437,7 +2442,7 @@ TEST_P(SelectiveNimbleReaderTest, fixedBitWidthFastPathUpcastNegative) {
   }
 }
 
-TEST_P(SelectiveNimbleReaderTest, pinFileMetadata) {
+TEST_P(SelectiveNimbleReaderTest, pinMetadata) {
   const bool stringDecoderZeroCopy = this->stringDecoderZeroCopy();
   auto data = makeFlatVector<int64_t>(100, [](auto i) { return i; });
   auto input = makeRowVector({data});
@@ -2456,9 +2461,9 @@ TEST_P(SelectiveNimbleReaderTest, pinFileMetadata) {
     options.setDataIoStats(dataIoStats_);
     options.setMetadataIoStats(metadataIoStats_);
     options.setScanSpec(scanSpec);
-    options.setPinFileMetadata(true);
+    options.setPinMetadata(true);
     if (enableCache) {
-      options.setFileMetadataCacheEnabled(true);
+      options.setCacheMetadata(true);
     }
     Readers readers;
     readers.reader = factory->createReader(
@@ -2474,110 +2479,270 @@ TEST_P(SelectiveNimbleReaderTest, pinFileMetadata) {
   }
 }
 
-// Verifies that when pinFileMetadata is true, the second pass of reading does
-// not re-read metadata from the file. Uses TrackingReadFile to record the max
-// read offset and checks it stays below the metadata boundary (stripe group
-// offset). When enableCache is true, uses CachedBufferedInput so
-// AsyncDataCache also caches raw metadata bytes.
-TEST_P(SelectiveNimbleReaderTest, pinnedMetadataNoReread) {
-  if (!GetParam().pinFileMetadata) {
-    GTEST_SKIP() << "Only applicable when pinFileMetadata is enabled";
+// Verifies that within the same TabletReader, the second VeloxReader pass
+// does not re-read metadata. The weak-pointer cache retains entries while the
+// tablet is alive, so metadata is always reused regardless of pinMetadata,
+// cacheMetadata, or whether cache infrastructure is provided.
+TEST_P(SelectiveNimbleReaderTest, metadataReuseWithSameReader) {
+  if (!GetParam().enableCache) {
+    GTEST_SKIP() << "Only applicable when cache is enabled";
   }
 
-  const bool stringDecoderZeroCopy = this->stringDecoderZeroCopy();
+  struct TestCase {
+    bool pinMetadata;
+    bool cacheMetadata;
+    bool provideCache;
+    bool expectRamHit;
 
-  // Write a small single-stripe file.
-  auto data = makeFlatVector<int64_t>(100, [](auto i) { return i; });
-  auto input = makeRowVector({data});
-  auto file = test::createNimbleFile(*rootPool(), input);
+    std::string debugString() const {
+      return fmt::format(
+          "pinMetadata={}, cacheMetadata={}, provideCache={}, "
+          "expectRamHit={}",
+          pinMetadata,
+          cacheMetadata,
+          provideCache,
+          expectRamHit);
+    }
+  };
 
-  auto delegate = std::make_shared<InMemoryReadFile>(file);
-  auto trackingFile =
-      std::make_shared<::facebook::nimble::testing::TrackingReadFile>(delegate);
+  std::vector<TestCase> testCases = {
+      {true, true, true, true},
+      {true, false, true, false},
+      {false, true, true, true},
+      {false, false, true, false},
+      {false, true, false, false},
+      {false, false, false, false},
+  };
 
-  auto factory =
-      dwio::common::getReaderFactory(dwio::common::FileFormat::NIMBLE);
-  auto scanSpec = std::make_shared<common::ScanSpec>("root");
-  scanSpec->addAllChildFields(*input->type());
-  dwio::common::ReaderOptions options(pool());
-  options.setDataIoStats(dataIoStats_);
-  options.setMetadataIoStats(metadataIoStats_);
-  options.setScanSpec(scanSpec);
-  options.setPinFileMetadata(true);
-  options.setFileMetadataCacheEnabled(GetParam().enableCache);
+  for (const auto& testCase : testCases) {
+    SCOPED_TRACE(testCase.debugString());
 
-  auto& ids = fileIds();
-  const auto readerId = readerIdCounter_++;
-  StringIdLease fileId(ids, fmt::format("testFile_{}", readerId));
-  StringIdLease groupId(ids, fmt::format("testGroup_{}", readerId));
-  io::ReaderOptions ioReaderOpts(pool());
-  ioReaderOpts.setDataIoStats(dataIoStats_);
-  ioReaderOpts.setMetadataIoStats(metadataIoStats_);
-  std::unique_ptr<dwio::common::BufferedInput> bufferedInput;
-  if (cache_ != nullptr) {
-    bufferedInput = std::make_unique<dwio::common::CachedBufferedInput>(
-        trackingFile,
-        dwio::common::MetricsLog::voidLog(),
-        std::move(fileId),
-        cache_.get(),
-        scanTracker_,
-        std::move(groupId),
-        dataIoStats_,
-        nullptr,
-        ioExecutor_.get(),
-        ioReaderOpts);
-  } else {
-    bufferedInput = std::make_unique<dwio::common::DirectBufferedInput>(
-        trackingFile,
-        dwio::common::MetricsLog::voidLog(),
-        std::move(fileId),
-        scanTracker_,
-        std::move(groupId),
-        dataIoStats_,
-        nullptr,
-        ioExecutor_.get(),
-        ioReaderOpts);
+    auto data = makeFlatVector<int64_t>(100, [](auto i) { return i; });
+    auto input = makeRowVector({data});
+    auto file = test::createNimbleFile(*rootPool(), input);
+
+    auto delegate = std::make_shared<InMemoryReadFile>(file);
+    auto trackingFile =
+        std::make_shared<::facebook::nimble::testing::TrackingReadFile>(
+            delegate);
+
+    auto selector = std::make_shared<dwio::common::ColumnSelector>(
+        std::dynamic_pointer_cast<const velox::RowType>(input->type()));
+
+    TabletReader::Options tabletOptions;
+    tabletOptions.pinMetadata = testCase.pinMetadata;
+    tabletOptions.cacheMetadata = testCase.cacheMetadata;
+    io::ReaderOptions ioOpts(pool());
+    ioOpts.setDataIoStats(dataIoStats_);
+    ioOpts.setMetadataIoStats(metadataIoStats_);
+    ioOpts.setIndexIoStats(indexIoStats_);
+    tabletOptions.ioOptions = ioOpts;
+    std::unique_ptr<FileHandle> fileHandle;
+    if (testCase.provideCache) {
+      auto& ids = fileIds();
+      auto fileIdStr = fmt::format(
+          "sameReaderSelectiveTest_pin{}_cache{}_provide{}",
+          testCase.pinMetadata,
+          testCase.cacheMetadata,
+          testCase.provideCache);
+      fileHandle = std::make_unique<FileHandle>();
+      fileHandle->file = trackingFile;
+      fileHandle->uuid = StringIdLease(ids, fileIdStr);
+      fileHandle->groupId = StringIdLease(ids, fileIdStr + "_group");
+      tabletOptions.cache = cache_.get();
+      tabletOptions.fileHandle = fileHandle.get();
+    }
+
+    auto tablet = TabletReader::create(trackingFile, pool(), tabletOptions);
+
+    nimble::VeloxReadParams readParams;
+    readParams.decodingExecutor =
+        std::make_shared<folly::CPUThreadPoolExecutor>(1);
+
+    auto reader1 = std::make_unique<nimble::VeloxReader>(
+        tablet, *pool(), selector, readParams);
+    VectorPtr result;
+    ASSERT_TRUE(reader1->next(100, result));
+    ASSERT_EQ(result->size(), 100);
+    ASSERT_FALSE(reader1->next(1, result));
+
+    const auto stripeGroupsMeta = tablet->stripeGroupsMetadata();
+    ASSERT_EQ(stripeGroupsMeta.size(), 1);
+    const auto metadataBoundary = stripeGroupsMeta[0].offset();
+
+    ASSERT_GT(trackingFile->maxReadOffset(), metadataBoundary)
+        << "First pass should read metadata from the file";
+
+    const auto ramHitsAfterFirstPass = metadataIoStats_->ramHit().count();
+
+    // Second pass: new VeloxReader on the same TabletReader. Metadata is
+    // always reused within the same tablet regardless of settings.
+    trackingFile->resetMaxReadOffset();
+    auto reader2 = std::make_unique<nimble::VeloxReader>(
+        tablet, *pool(), selector, readParams);
+    ASSERT_TRUE(reader2->next(100, result));
+    ASSERT_EQ(result->size(), 100);
+    ASSERT_FALSE(reader2->next(1, result));
+
+    ASSERT_LE(trackingFile->maxReadOffset(), metadataBoundary)
+        << "Second pass should not re-read metadata. "
+        << "maxReadOffset=" << trackingFile->maxReadOffset()
+        << " metadataBoundary=" << metadataBoundary;
+
+    if (testCase.expectRamHit) {
+      ASSERT_GT(metadataIoStats_->ramHit().count(), ramHitsAfterFirstPass)
+          << "Second pass should have RAM cache hits";
+    } else {
+      ASSERT_EQ(metadataIoStats_->ramHit().count(), ramHitsAfterFirstPass)
+          << "Second pass should have no new RAM cache hits";
+    }
+  }
+}
+
+// Tests metadata reuse across separate TabletReader instances. Only
+// cacheMetadata persists across TabletReader opens via AsyncDataCache.
+// pinMetadata only holds strong references within the same TabletReader.
+TEST_P(SelectiveNimbleReaderTest, metadataReuseCrossReaders) {
+  if (!GetParam().enableCache) {
+    GTEST_SKIP() << "Only applicable when cache is enabled";
   }
 
-  Readers readers;
-  readers.reader = factory->createReader(std::move(bufferedInput), options);
-  ASSERT_EQ(readers.reader->numberOfRows(), input->size());
-  auto type = asRowType(input->type());
-  dwio::common::RowReaderOptions rowOptions;
-  rowOptions.setScanSpec(scanSpec);
-  rowOptions.setRequestedType(type);
-  rowOptions.setStringDecoderZeroCopy(stringDecoderZeroCopy);
+  struct TestCase {
+    bool pinMetadata;
+    bool cacheMetadata;
+    bool provideCache;
+    bool expectCrossReaderReuse;
+    bool expectRamHit;
 
-  // First pass: reads both data and metadata from the file.
-  readers.rowReader = readers.reader->createRowReader(rowOptions);
-  validate(*input, *readers.rowReader, 100, [](auto) { return true; });
+    std::string debugString() const {
+      return fmt::format(
+          "pinMetadata={}, cacheMetadata={}, provideCache={}, "
+          "expectCrossReaderReuse={}, expectRamHit={}",
+          pinMetadata,
+          cacheMetadata,
+          provideCache,
+          expectCrossReaderReuse,
+          expectRamHit);
+    }
+  };
 
-  // Get the metadata boundary. Stripe group metadata starts right after the
-  // last stripe's data. Any read at or above this offset is a metadata read.
-  auto tablet = TabletReader::create(
-      delegate, pool(), test::makeTestTabletOptions(pool()));
-  const auto stripeGroupsMeta = tablet->stripeGroupsMetadata();
-  ASSERT_EQ(stripeGroupsMeta.size(), 1);
-  const auto metadataBoundary = stripeGroupsMeta[0].offset();
+  std::vector<TestCase> testCases = {
+      {true, true, true, true, true},
+      {true, false, true, false, false},
+      {false, true, true, true, true},
+      {false, false, true, false, false},
+      // cacheMetadata is set but cache is not provided — silently falls back
+      // to direct IO, so cross-reader reuse and RAM hits are not expected.
+      {false, true, false, false, false},
+  };
 
-  // Verify: first pass reads metadata (above boundary), confirming the file
-  // layout is correct and the tracking works.
-  ASSERT_GT(trackingFile->maxReadOffset(), metadataBoundary)
-      << "First pass should read metadata from the file. "
-      << "maxReadOffset=" << trackingFile->maxReadOffset()
-      << " metadataBoundary=" << metadataBoundary;
+  for (const auto& testCase : testCases) {
+    SCOPED_TRACE(testCase.debugString());
 
-  // Reset tracking and do a second pass.
-  trackingFile->resetMaxReadOffset();
-  readers.rowReader = readers.reader->createRowReader(rowOptions);
-  validate(*input, *readers.rowReader, 100, [](auto) { return true; });
+    auto data = makeFlatVector<int64_t>(100, [](auto i) { return i; });
+    auto input = makeRowVector({data});
+    auto file = test::createNimbleFile(*rootPool(), input);
 
-  // Verify: second-pass reads should only access data (below metadata
-  // boundary). With pinFileMetadata, all metadata is pinned in memory.
-  ASSERT_LE(trackingFile->maxReadOffset(), metadataBoundary)
-      << "Second pass should not re-read metadata from the file. "
-      << "maxReadOffset=" << trackingFile->maxReadOffset()
-      << " metadataBoundary=" << metadataBoundary;
+    auto delegate = std::make_shared<InMemoryReadFile>(file);
+    auto trackingFile =
+        std::make_shared<::facebook::nimble::testing::TrackingReadFile>(
+            delegate);
+
+    auto selector = std::make_shared<dwio::common::ColumnSelector>(
+        std::dynamic_pointer_cast<const velox::RowType>(input->type()));
+
+    auto& ids = fileIds();
+    auto fileIdStr = fmt::format(
+        "crossReaderSelectiveTest_pin{}_cache{}",
+        testCase.pinMetadata,
+        testCase.cacheMetadata);
+    StringIdLease fileId(ids, fileIdStr);
+    StringIdLease groupId(ids, fileIdStr + "_group");
+
+    auto makeTablet =
+        [&](const std::shared_ptr<io::IoStatistics>& metadataStats,
+            std::unique_ptr<FileHandle>& fileHandleOut) {
+          TabletReader::Options tabletOptions;
+          tabletOptions.pinMetadata = testCase.pinMetadata;
+          tabletOptions.cacheMetadata = testCase.cacheMetadata;
+          io::ReaderOptions ioOpts(pool());
+          ioOpts.setDataIoStats(dataIoStats_);
+          ioOpts.setMetadataIoStats(metadataStats);
+          ioOpts.setIndexIoStats(indexIoStats_);
+          tabletOptions.ioOptions = ioOpts;
+          if (testCase.provideCache) {
+            fileHandleOut = std::make_unique<FileHandle>();
+            fileHandleOut->file = trackingFile;
+            fileHandleOut->uuid = fileId;
+            fileHandleOut->groupId = groupId;
+            tabletOptions.cache = cache_.get();
+            tabletOptions.fileHandle = fileHandleOut.get();
+          }
+          return TabletReader::create(trackingFile, pool(), tabletOptions);
+        };
+
+    // First open + first pass.
+    auto metadataIoStats1 = std::make_shared<io::IoStatistics>();
+    std::unique_ptr<FileHandle> fh1;
+    auto tablet1 = makeTablet(metadataIoStats1, fh1);
+
+    const auto stripeGroupsMeta = tablet1->stripeGroupsMetadata();
+    ASSERT_EQ(stripeGroupsMeta.size(), 1);
+    const auto metadataBoundary = stripeGroupsMeta[0].offset();
+
+    nimble::VeloxReadParams readParams;
+    readParams.decodingExecutor =
+        std::make_shared<folly::CPUThreadPoolExecutor>(1);
+    auto reader1 = std::make_unique<nimble::VeloxReader>(
+        tablet1, *pool(), selector, readParams);
+    VectorPtr result;
+    ASSERT_TRUE(reader1->next(100, result));
+    ASSERT_EQ(result->size(), 100);
+    ASSERT_FALSE(reader1->next(1, result));
+
+    ASSERT_GT(trackingFile->maxReadOffset(), metadataBoundary)
+        << "First pass should read metadata from the file";
+    ASSERT_GT(metadataIoStats1->rawBytesRead(), 0)
+        << "First pass should record metadata IO";
+
+    // Cross-reader: destroy everything and open a new TabletReader.
+    reader1.reset();
+    tablet1.reset();
+    fh1.reset();
+    trackingFile->resetMaxReadOffset();
+
+    auto metadataIoStats2 = std::make_shared<io::IoStatistics>();
+    std::unique_ptr<FileHandle> fh2;
+    auto tablet2 = makeTablet(metadataIoStats2, fh2);
+    auto reader3 = std::make_unique<nimble::VeloxReader>(
+        tablet2, *pool(), selector, readParams);
+    ASSERT_TRUE(reader3->next(100, result));
+    ASSERT_EQ(result->size(), 100);
+
+    if (testCase.expectCrossReaderReuse) {
+      ASSERT_LE(trackingFile->maxReadOffset(), metadataBoundary)
+          << "Cross-reader should not re-read metadata. "
+          << "maxReadOffset=" << trackingFile->maxReadOffset()
+          << " metadataBoundary=" << metadataBoundary;
+      ASSERT_EQ(metadataIoStats2->rawBytesRead(), 0)
+          << "Cross-reader should not record any metadata IO";
+    } else {
+      ASSERT_GT(trackingFile->maxReadOffset(), metadataBoundary)
+          << "Cross-reader should re-read metadata. "
+          << "maxReadOffset=" << trackingFile->maxReadOffset()
+          << " metadataBoundary=" << metadataBoundary;
+      ASSERT_GT(metadataIoStats2->rawBytesRead(), 0)
+          << "Cross-reader should record metadata IO";
+    }
+
+    if (testCase.expectRamHit) {
+      ASSERT_GT(metadataIoStats2->ramHit().count(), 0)
+          << "Should have RAM cache hits";
+    } else {
+      ASSERT_EQ(metadataIoStats2->ramHit().count(), 0)
+          << "Should have no RAM cache hits";
+    }
+  }
 }
 
 // ---------------------------------------------------------------------------

--- a/dwio/nimble/velox/tests/VeloxReaderTest.cpp
+++ b/dwio/nimble/velox/tests/VeloxReaderTest.cpp
@@ -443,7 +443,7 @@ struct TestParam {
   bool optimizeStringBufferHandling;
   bool skipConstantFlatMapInMapStreams;
   bool enableCache{false};
-  bool pinFileMetadata{false};
+  bool pinMetadata{false};
 
   std::string debugString() const {
     return fmt::format(
@@ -451,7 +451,7 @@ struct TestParam {
         optimizeStringBufferHandling,
         skipConstantFlatMapInMapStreams,
         enableCache,
-        pinFileMetadata);
+        pinMetadata);
   }
 };
 
@@ -520,8 +520,8 @@ class VeloxReaderTest : public ::testing::TestWithParam<TestParam> {
     return GetParam().enableCache;
   }
 
-  bool pinFileMetadata() const {
-    return GetParam().pinFileMetadata;
+  bool pinMetadata() const {
+    return GetParam().pinMetadata;
   }
 
   // Creates a TabletReader with cache options applied.
@@ -529,22 +529,22 @@ class VeloxReaderTest : public ::testing::TestWithParam<TestParam> {
       std::shared_ptr<velox::ReadFile> readFile,
       velox::memory::MemoryPool* pool) {
     nimble::TabletReader::Options tabletOptions;
-    tabletOptions.pinFileMetadata = pinFileMetadata();
+    tabletOptions.pinMetadata = pinMetadata();
+    tabletOptions.cacheMetadata = enableCache();
     ioReaderOptions_ = std::make_unique<velox::io::ReaderOptions>(pool);
     ioReaderOptions_->setDataIoStats(dataIoStats_);
     ioReaderOptions_->setMetadataIoStats(metadataIoStats_);
+    ioReaderOptions_->setIndexIoStats(indexIoStats_);
     tabletOptions.ioOptions = *ioReaderOptions_;
-    if (enableCache() || pinFileMetadata()) {
+    if (enableCache()) {
       auto& ids = velox::fileIds();
       auto fileIdStr = fmt::format("testFile_{}", nextFileId_++);
       fileHandle_ = std::make_unique<velox::FileHandle>();
       fileHandle_->file = readFile;
       fileHandle_->uuid = velox::StringIdLease(ids, fileIdStr);
       fileHandle_->groupId = velox::StringIdLease(ids, "testGroup");
-      if (cache_ != nullptr) {
-        tabletOptions.cache = cache_.get();
-        tabletOptions.fileHandle = fileHandle_.get();
-      }
+      tabletOptions.cache = cache_.get();
+      tabletOptions.fileHandle = fileHandle_.get();
     }
     return nimble::TabletReader::create(readFile, pool, tabletOptions);
   }
@@ -557,7 +557,7 @@ class VeloxReaderTest : public ::testing::TestWithParam<TestParam> {
           nullptr,
       nimble::VeloxReadParams params = {}) {
     params = configureWithTestParam(std::move(params));
-    if (enableCache() || pinFileMetadata()) {
+    if (enableCache() || pinMetadata()) {
       auto tablet = createTablet(readFile, &pool);
       return std::make_unique<nimble::VeloxReader>(
           std::move(tablet), pool, std::move(selector), std::move(params));
@@ -1367,6 +1367,8 @@ class VeloxReaderTest : public ::testing::TestWithParam<TestParam> {
   const std::shared_ptr<velox::io::IoStatistics> dataIoStats_{
       std::make_shared<velox::io::IoStatistics>()};
   const std::shared_ptr<velox::io::IoStatistics> metadataIoStats_{
+      std::make_shared<velox::io::IoStatistics>()};
+  const std::shared_ptr<velox::io::IoStatistics> indexIoStats_{
       std::make_shared<velox::io::IoStatistics>()};
   std::shared_ptr<velox::cache::ScanTracker> scanTracker_;
   std::unique_ptr<folly::CPUThreadPoolExecutor> ioExecutor_;
@@ -7020,67 +7022,265 @@ TEST_P(VeloxReaderTest, timestampLargeRowCount) {
   ASSERT_EQ(totalReads, rowCount);
 }
 
-// Verifies that when pinFileMetadata is true and cache is disabled, the
-// second pass of reading does not re-read metadata from the file. Uses
-// TrackingReadFile to record the max read offset and checks it stays below the
-// metadata boundary (stripe group offset).
-TEST_P(VeloxReaderTest, pinnedMetadataNoReread) {
-  if (!pinFileMetadata()) {
-    GTEST_SKIP() << "Only applicable when pinFileMetadata is enabled";
+// Verifies that within the same TabletReader, the second VeloxReader pass
+// does not re-read metadata. The weak-pointer cache retains entries while the
+// tablet is alive, so metadata is always reused regardless of pinMetadata,
+// cacheMetadata, or whether cache infrastructure is provided.
+TEST_P(VeloxReaderTest, metadataReuseWithSameReader) {
+  if (!enableCache()) {
+    GTEST_SKIP() << "Only applicable when cache is enabled";
   }
 
-  velox::test::VectorMaker vectorMaker(leafPool_.get());
-  auto data = vectorMaker.flatVector<int64_t>(100, [](auto i) { return i; });
-  auto input = vectorMaker.rowVector({data});
-  auto file = nimble::test::createNimbleFile(*rootPool_, input);
+  struct TestCase {
+    bool pinMetadata;
+    bool cacheMetadata;
+    bool provideCache;
+    bool expectRamHit;
 
-  auto delegate = std::make_shared<velox::InMemoryReadFile>(file);
-  auto trackingFile = std::make_shared<TrackingReadFile>(delegate);
+    std::string debugString() const {
+      return fmt::format(
+          "pinMetadata={}, cacheMetadata={}, provideCache={}, "
+          "expectRamHit={}",
+          pinMetadata,
+          cacheMetadata,
+          provideCache,
+          expectRamHit);
+    }
+  };
 
-  auto selector = std::make_shared<velox::dwio::common::ColumnSelector>(
-      std::dynamic_pointer_cast<const velox::RowType>(input->type()));
+  std::vector<TestCase> testCases = {
+      {true, true, true, true},
+      {true, false, true, false},
+      {false, true, true, true},
+      {false, false, true, false},
+      {false, true, false, false},
+      {false, false, false, false},
+  };
 
-  // Create a single TabletReader with pinFileMetadata so metadata is pinned
-  // after first access and shared across readers.
-  auto tablet = createTablet(trackingFile, leafPool_.get());
-  auto readParams = createReadParams();
-  auto reader = std::make_unique<nimble::VeloxReader>(
-      tablet, *leafPool_, selector, readParams);
+  for (const auto& testCase : testCases) {
+    SCOPED_TRACE(testCase.debugString());
 
-  // First pass: reads both data and metadata from the file.
-  velox::VectorPtr result;
-  ASSERT_TRUE(reader->next(100, result));
-  ASSERT_EQ(result->size(), 100);
-  ASSERT_FALSE(reader->next(1, result));
+    velox::test::VectorMaker vectorMaker(leafPool_.get());
+    auto data = vectorMaker.flatVector<int64_t>(100, [](auto i) { return i; });
+    auto input = vectorMaker.rowVector({data});
+    auto file = nimble::test::createNimbleFile(*rootPool_, input);
 
-  // Get the metadata boundary. Stripe group metadata starts right after the
-  // last stripe's data. Any read at or above this offset is a metadata read.
-  const auto stripeGroupsMeta = tablet->stripeGroupsMetadata();
-  ASSERT_EQ(stripeGroupsMeta.size(), 1);
-  const auto metadataBoundary = stripeGroupsMeta[0].offset();
+    auto delegate = std::make_shared<velox::InMemoryReadFile>(file);
+    auto trackingFile = std::make_shared<TrackingReadFile>(delegate);
 
-  // Verify: first pass reads metadata (above boundary), confirming the file
-  // layout is correct and the tracking works.
-  ASSERT_GT(trackingFile->maxReadOffset(), metadataBoundary)
-      << "First pass should read metadata from the file. "
-      << "maxReadOffset=" << trackingFile->maxReadOffset()
-      << " metadataBoundary=" << metadataBoundary;
+    auto selector = std::make_shared<velox::dwio::common::ColumnSelector>(
+        std::dynamic_pointer_cast<const velox::RowType>(input->type()));
 
-  // Reset tracking and do a second pass with a new reader using the same
-  // tablet (metadata should already be pinned).
-  trackingFile->resetMaxReadOffset();
-  auto reader2 = std::make_unique<nimble::VeloxReader>(
-      tablet, *leafPool_, selector, readParams);
-  ASSERT_TRUE(reader2->next(100, result));
-  ASSERT_EQ(result->size(), 100);
-  ASSERT_FALSE(reader2->next(1, result));
+    nimble::TabletReader::Options tabletOptions;
+    tabletOptions.pinMetadata = testCase.pinMetadata;
+    tabletOptions.cacheMetadata = testCase.cacheMetadata;
+    velox::io::ReaderOptions ioOpts(leafPool_.get());
+    ioOpts.setDataIoStats(dataIoStats_);
+    ioOpts.setMetadataIoStats(metadataIoStats_);
+    ioOpts.setIndexIoStats(indexIoStats_);
+    tabletOptions.ioOptions = ioOpts;
+    std::unique_ptr<velox::FileHandle> fileHandle;
+    if (testCase.provideCache) {
+      auto& ids = velox::fileIds();
+      auto fileIdStr = fmt::format(
+          "sameReaderTest_pin{}_cache{}_provide{}",
+          testCase.pinMetadata,
+          testCase.cacheMetadata,
+          testCase.provideCache);
+      fileHandle = std::make_unique<velox::FileHandle>();
+      fileHandle->file = trackingFile;
+      fileHandle->uuid = velox::StringIdLease(ids, fileIdStr);
+      fileHandle->groupId = velox::StringIdLease(ids, fileIdStr + "_group");
+      tabletOptions.cache = cache_.get();
+      tabletOptions.fileHandle = fileHandle.get();
+    }
 
-  // Verify: second-pass reads should only access data (below metadata
-  // boundary). With pinFileMetadata, all metadata is pinned in memory.
-  ASSERT_LE(trackingFile->maxReadOffset(), metadataBoundary)
-      << "Second pass should not re-read metadata from the file. "
-      << "maxReadOffset=" << trackingFile->maxReadOffset()
-      << " metadataBoundary=" << metadataBoundary;
+    auto tablet = nimble::TabletReader::create(
+        trackingFile, leafPool_.get(), tabletOptions);
+    auto readParams = createReadParams();
+
+    auto reader1 = std::make_unique<nimble::VeloxReader>(
+        tablet, *leafPool_, selector, readParams);
+    velox::VectorPtr result;
+    ASSERT_TRUE(reader1->next(100, result));
+    ASSERT_EQ(result->size(), 100);
+    ASSERT_FALSE(reader1->next(1, result));
+
+    const auto stripeGroupsMeta = tablet->stripeGroupsMetadata();
+    ASSERT_EQ(stripeGroupsMeta.size(), 1);
+    const auto metadataBoundary = stripeGroupsMeta[0].offset();
+
+    ASSERT_GT(trackingFile->maxReadOffset(), metadataBoundary)
+        << "First pass should read metadata from the file";
+
+    const auto ramHitsAfterFirstPass = metadataIoStats_->ramHit().count();
+
+    // Second pass: new VeloxReader on the same TabletReader. Metadata is
+    // always reused within the same tablet regardless of settings.
+    trackingFile->resetMaxReadOffset();
+    auto reader2 = std::make_unique<nimble::VeloxReader>(
+        tablet, *leafPool_, selector, readParams);
+    ASSERT_TRUE(reader2->next(100, result));
+    ASSERT_EQ(result->size(), 100);
+    ASSERT_FALSE(reader2->next(1, result));
+
+    ASSERT_LE(trackingFile->maxReadOffset(), metadataBoundary)
+        << "Second pass should not re-read metadata. "
+        << "maxReadOffset=" << trackingFile->maxReadOffset()
+        << " metadataBoundary=" << metadataBoundary;
+
+    if (testCase.expectRamHit) {
+      ASSERT_GT(metadataIoStats_->ramHit().count(), ramHitsAfterFirstPass)
+          << "Second pass should have RAM cache hits";
+    } else {
+      ASSERT_EQ(metadataIoStats_->ramHit().count(), ramHitsAfterFirstPass)
+          << "Second pass should have no new RAM cache hits";
+    }
+  }
+}
+
+// Tests metadata reuse across separate TabletReader instances. Only
+// cacheMetadata persists across TabletReader opens via AsyncDataCache.
+// pinMetadata only holds strong references within the same TabletReader.
+TEST_P(VeloxReaderTest, metadataReuseCrossReaders) {
+  if (!enableCache()) {
+    GTEST_SKIP() << "Only applicable when cache is enabled";
+  }
+
+  struct TestCase {
+    bool pinMetadata;
+    bool cacheMetadata;
+    bool provideCache;
+    bool expectCrossReaderReuse;
+    bool expectRamHit;
+
+    std::string debugString() const {
+      return fmt::format(
+          "pinMetadata={}, cacheMetadata={}, provideCache={}, "
+          "expectCrossReaderReuse={}, expectRamHit={}",
+          pinMetadata,
+          cacheMetadata,
+          provideCache,
+          expectCrossReaderReuse,
+          expectRamHit);
+    }
+  };
+
+  std::vector<TestCase> testCases = {
+      {true, true, true, true, true},
+      {true, false, true, false, false},
+      {false, true, true, true, true},
+      {false, false, true, false, false},
+      // cacheMetadata is set but cache is not provided — silently falls back
+      // to direct IO, so cross-reader reuse and RAM hits are not expected.
+      {false, true, false, false, false},
+  };
+
+  for (const auto& testCase : testCases) {
+    SCOPED_TRACE(testCase.debugString());
+
+    velox::test::VectorMaker vectorMaker(leafPool_.get());
+    auto data = vectorMaker.flatVector<int64_t>(100, [](auto i) { return i; });
+    auto input = vectorMaker.rowVector({data});
+    auto file = nimble::test::createNimbleFile(*rootPool_, input);
+
+    auto delegate = std::make_shared<velox::InMemoryReadFile>(file);
+    auto trackingFile = std::make_shared<TrackingReadFile>(delegate);
+
+    auto selector = std::make_shared<velox::dwio::common::ColumnSelector>(
+        std::dynamic_pointer_cast<const velox::RowType>(input->type()));
+
+    auto& ids = velox::fileIds();
+    auto fileIdStr = fmt::format(
+        "metadataNoRereadTest_pin{}_cache{}",
+        testCase.pinMetadata,
+        testCase.cacheMetadata);
+    velox::StringIdLease fileId(ids, fileIdStr);
+    velox::StringIdLease groupId(ids, fileIdStr + "_group");
+
+    auto makeTablet =
+        [&](const std::shared_ptr<velox::io::IoStatistics>& metadataStats,
+            std::unique_ptr<velox::FileHandle>& fileHandleOut) {
+          nimble::TabletReader::Options tabletOptions;
+          tabletOptions.pinMetadata = testCase.pinMetadata;
+          tabletOptions.cacheMetadata = testCase.cacheMetadata;
+          velox::io::ReaderOptions ioOpts(leafPool_.get());
+          ioOpts.setDataIoStats(dataIoStats_);
+          ioOpts.setMetadataIoStats(metadataStats);
+          ioOpts.setIndexIoStats(indexIoStats_);
+          tabletOptions.ioOptions = ioOpts;
+          if (testCase.provideCache) {
+            fileHandleOut = std::make_unique<velox::FileHandle>();
+            fileHandleOut->file = trackingFile;
+            fileHandleOut->uuid = fileId;
+            fileHandleOut->groupId = groupId;
+            tabletOptions.cache = cache_.get();
+            tabletOptions.fileHandle = fileHandleOut.get();
+          }
+          return nimble::TabletReader::create(
+              trackingFile, leafPool_.get(), tabletOptions);
+        };
+
+    // First open + first pass.
+    auto metadataIoStats1 = std::make_shared<velox::io::IoStatistics>();
+    std::unique_ptr<velox::FileHandle> fh1;
+    auto tablet1 = makeTablet(metadataIoStats1, fh1);
+
+    const auto stripeGroupsMeta = tablet1->stripeGroupsMetadata();
+    ASSERT_EQ(stripeGroupsMeta.size(), 1);
+    const auto metadataBoundary = stripeGroupsMeta[0].offset();
+
+    auto readParams = createReadParams();
+    auto reader1 = std::make_unique<nimble::VeloxReader>(
+        tablet1, *leafPool_, selector, readParams);
+    velox::VectorPtr result;
+    ASSERT_TRUE(reader1->next(100, result));
+    ASSERT_EQ(result->size(), 100);
+    ASSERT_FALSE(reader1->next(1, result));
+
+    ASSERT_GT(trackingFile->maxReadOffset(), metadataBoundary)
+        << "First pass should read metadata from the file";
+    ASSERT_GT(metadataIoStats1->rawBytesRead(), 0)
+        << "First pass should record metadata IO";
+
+    // Cross-reader: destroy everything and open a new TabletReader.
+    reader1.reset();
+    tablet1.reset();
+    fh1.reset();
+    trackingFile->resetMaxReadOffset();
+
+    auto metadataIoStats2 = std::make_shared<velox::io::IoStatistics>();
+    std::unique_ptr<velox::FileHandle> fh2;
+    auto tablet2 = makeTablet(metadataIoStats2, fh2);
+    auto reader3 = std::make_unique<nimble::VeloxReader>(
+        tablet2, *leafPool_, selector, readParams);
+    ASSERT_TRUE(reader3->next(100, result));
+    ASSERT_EQ(result->size(), 100);
+
+    if (testCase.expectCrossReaderReuse) {
+      ASSERT_LE(trackingFile->maxReadOffset(), metadataBoundary)
+          << "Cross-reader should not re-read metadata. "
+          << "maxReadOffset=" << trackingFile->maxReadOffset()
+          << " metadataBoundary=" << metadataBoundary;
+      ASSERT_EQ(metadataIoStats2->rawBytesRead(), 0)
+          << "Cross-reader should not record any metadata IO";
+    } else {
+      ASSERT_GT(trackingFile->maxReadOffset(), metadataBoundary)
+          << "Cross-reader should re-read metadata. "
+          << "maxReadOffset=" << trackingFile->maxReadOffset()
+          << " metadataBoundary=" << metadataBoundary;
+      ASSERT_GT(metadataIoStats2->rawBytesRead(), 0)
+          << "Cross-reader should record metadata IO";
+    }
+
+    if (testCase.expectRamHit) {
+      ASSERT_GT(metadataIoStats2->ramHit().count(), 0)
+          << "Should have RAM cache hits";
+    } else {
+      ASSERT_EQ(metadataIoStats2->ramHit().count(), 0)
+          << "Should have no RAM cache hits";
+    }
+  }
 }
 
 // Regression test: string-keyed flatmap writers store StringView keys in

--- a/dwio/nimble/velox/tests/VeloxWriterTest.cpp
+++ b/dwio/nimble/velox/tests/VeloxWriterTest.cpp
@@ -3647,29 +3647,29 @@ TEST_P(VeloxWriterIndexTest, singleGroup) {
   writer.close();
 
   // Read and verify
-  velox::InMemoryReadFile readFile(file);
-  nimble::VeloxReader reader(&readFile, *leafPool_);
-
-  const auto& tablet = reader.tabletReader();
+  auto readFile = std::make_shared<velox::InMemoryReadFile>(file);
+  auto tabletOptions = makeTestTabletOptions(leafPool_.get());
+  auto tablet =
+      nimble::TabletReader::create(readFile, leafPool_.get(), tabletOptions);
 
   // Verify each batch triggered exactly one stripe
-  EXPECT_EQ(tablet.stripeCount(), kNumBatches)
+  EXPECT_EQ(tablet->stripeCount(), kNumBatches)
       << "Each batch should trigger exactly one stripe";
 
   // Verify all stripes are in the same stripe group (index 0)
   // Default metadataFlushThreshold is large, so all stripes stay in one group
-  for (uint32_t i = 0; i < tablet.stripeCount(); ++i) {
-    auto stripeId = tablet.stripeIdentifier(i);
+  for (uint32_t i = 0; i < tablet->stripeCount(); ++i) {
+    auto stripeId = tablet->stripeIdentifier(i);
     EXPECT_EQ(stripeId.stripeGroup()->index(), 0)
         << "Stripe " << i << " should be in stripe group 0";
   }
 
   // Verify index section exists
   EXPECT_TRUE(
-      tablet.hasOptionalSection(std::string(nimble::kClusterIndexSection)));
+      tablet->hasOptionalSection(std::string(nimble::kClusterIndexSection)));
 
   // Verify index is available
-  const auto* index = tablet.clusterIndex();
+  const auto* index = tablet->clusterIndex();
   ASSERT_NE(index, nullptr);
 
   // Verify index columns
@@ -3712,10 +3712,10 @@ TEST_P(VeloxWriterIndexTest, singleGroup) {
   verifyFileData(file, type, batches, kBatchSize);
 
   // Verify position index chunk row counts
-  verifyPositionIndex(tablet);
+  verifyPositionIndex(*tablet);
 
   // Verify value index maps each key to correct row position
-  verifyValueIndex(tablet, &readFile, type, batches, {"key_col"});
+  verifyValueIndex(*tablet, readFile.get(), type, batches, {"key_col"});
 }
 
 TEST_P(VeloxWriterIndexTest, multipleGroups) {
@@ -3751,30 +3751,30 @@ TEST_P(VeloxWriterIndexTest, multipleGroups) {
   writer.close();
 
   // Read and verify
-  velox::InMemoryReadFile readFile(file);
-  nimble::VeloxReader reader(&readFile, *leafPool_);
-
-  const auto& tablet = reader.tabletReader();
+  auto readFile = std::make_shared<velox::InMemoryReadFile>(file);
+  auto tabletOptions = makeTestTabletOptions(leafPool_.get());
+  auto tablet =
+      nimble::TabletReader::create(readFile, leafPool_.get(), tabletOptions);
 
   // Verify each batch triggered exactly one stripe
-  EXPECT_EQ(tablet.stripeCount(), kNumBatches)
+  EXPECT_EQ(tablet->stripeCount(), kNumBatches)
       << "Each batch should trigger exactly one stripe";
 
   // Note: Without controlling metadataFlushThreshold from VeloxWriterOptions,
   // all stripes end up in the same group (default threshold is 8MB).
   // This test verifies the default behavior where all stripes share group 0.
-  for (uint32_t i = 0; i < tablet.stripeCount(); ++i) {
-    auto stripeId = tablet.stripeIdentifier(i);
+  for (uint32_t i = 0; i < tablet->stripeCount(); ++i) {
+    auto stripeId = tablet->stripeIdentifier(i);
     EXPECT_EQ(stripeId.stripeGroup()->index(), 0)
         << "Stripe " << i << " should be in stripe group 0";
   }
 
   // Verify index section exists
   EXPECT_TRUE(
-      tablet.hasOptionalSection(std::string(nimble::kClusterIndexSection)));
+      tablet->hasOptionalSection(std::string(nimble::kClusterIndexSection)));
 
   // Verify index is available
-  const auto* index = tablet.clusterIndex();
+  const auto* index = tablet->clusterIndex();
   ASSERT_NE(index, nullptr);
 
   // Verify index columns
@@ -3809,8 +3809,8 @@ TEST_P(VeloxWriterIndexTest, multipleGroups) {
   EXPECT_GT(lastRanges[0].endRow, 0);
 
   // Verify stripeIdentifier returns index group
-  for (uint32_t i = 0; i < tablet.stripeCount(); ++i) {
-    auto stripeId = tablet.stripeIdentifier(i);
+  for (uint32_t i = 0; i < tablet->stripeCount(); ++i) {
+    auto stripeId = tablet->stripeIdentifier(i);
     EXPECT_NE(stripeId.stripeGroup(), nullptr);
   }
 
@@ -3818,10 +3818,10 @@ TEST_P(VeloxWriterIndexTest, multipleGroups) {
   verifyFileData(file, type, batches);
 
   // Verify position index chunk row counts
-  verifyPositionIndex(tablet);
+  verifyPositionIndex(*tablet);
 
   // Verify value index maps each key to correct row position
-  verifyValueIndex(tablet, &readFile, type, batches, {"key_col"});
+  verifyValueIndex(*tablet, readFile.get(), type, batches, {"key_col"});
 }
 
 TEST_P(VeloxWriterIndexTest, multipleIndexColumns) {
@@ -3881,11 +3881,11 @@ TEST_P(VeloxWriterIndexTest, multipleIndexColumns) {
   writer.close();
 
   // Read and verify
-  velox::InMemoryReadFile readFile(file);
-  nimble::VeloxReader reader(&readFile, *leafPool_);
-
-  const auto& tablet = reader.tabletReader();
-  const auto* index = tablet.clusterIndex();
+  auto readFile = std::make_shared<velox::InMemoryReadFile>(file);
+  auto tabletOptions = makeTestTabletOptions(leafPool_.get());
+  auto tablet =
+      nimble::TabletReader::create(readFile, leafPool_.get(), tabletOptions);
+  const auto* index = tablet->clusterIndex();
   ASSERT_NE(index, nullptr);
 
   // Verify both columns are indexed
@@ -3933,9 +3933,9 @@ TEST_P(VeloxWriterIndexTest, multipleIndexColumns) {
         }));
   }
   // Verify position index chunk row counts
-  verifyPositionIndex(tablet);
+  verifyPositionIndex(*tablet);
 
-  verifyValueIndex(tablet, &readFile, type, batches, {"key1", "key2"});
+  verifyValueIndex(*tablet, readFile.get(), type, batches, {"key1", "key2"});
 }
 
 TEST_F(VeloxWriterTest, indexEnforceKeyOrder) {
@@ -4114,12 +4114,12 @@ TEST_P(VeloxWriterIndexTest, duplicateKeys) {
       EXPECT_GT(layout.stripesInfo[i].size, 0);
     }
   }
-  nimble::VeloxReader reader(readFile.get(), *leafPool_);
-
-  const auto& tablet = reader.tabletReader();
+  auto tabletOptions = makeTestTabletOptions(leafPool_.get());
+  auto tablet =
+      nimble::TabletReader::create(readFile, leafPool_.get(), tabletOptions);
 
   // Verify index exists
-  const auto* index = tablet.clusterIndex();
+  const auto* index = tablet->clusterIndex();
   ASSERT_NE(index, nullptr);
   EXPECT_EQ(index->indexColumns().size(), 1);
   EXPECT_EQ(index->indexColumns()[0], "key_col");
@@ -4154,11 +4154,11 @@ TEST_P(VeloxWriterIndexTest, duplicateKeys) {
   verifyFileData(file, type, batches);
 
   // Verify position index chunk row counts
-  verifyPositionIndex(tablet);
+  verifyPositionIndex(*tablet);
 
   // Verify value index maps each key to correct row position
   // With duplicate keys, lookup should find the first occurrence
-  verifyValueIndex(tablet, readFile.get(), type, batches, {"key_col"});
+  verifyValueIndex(*tablet, readFile.get(), type, batches, {"key_col"});
 }
 
 TEST_P(VeloxWriterIndexTest, chunking) {
@@ -4192,13 +4192,13 @@ TEST_P(VeloxWriterIndexTest, chunking) {
   writer.close();
 
   // Read and verify
-  velox::InMemoryReadFile readFile(file);
-  nimble::VeloxReader reader(&readFile, *leafPool_);
-
-  const auto& tablet = reader.tabletReader();
+  auto readFile = std::make_shared<velox::InMemoryReadFile>(file);
+  auto tabletOptions = makeTestTabletOptions(leafPool_.get());
+  auto tablet =
+      nimble::TabletReader::create(readFile, leafPool_.get(), tabletOptions);
 
   // Verify index exists and works
-  const auto* index = tablet.clusterIndex();
+  const auto* index = tablet->clusterIndex();
   ASSERT_NE(index, nullptr);
   EXPECT_EQ(index->indexColumns().size(), 1);
   EXPECT_EQ(index->indexColumns()[0], "key_col");
@@ -4210,16 +4210,14 @@ TEST_P(VeloxWriterIndexTest, chunking) {
     EXPECT_LE(partitionKeys[i - 1], partitionKeys[i]);
   }
 
-  ASSERT_NE(tablet.clusterIndex(), nullptr);
-
   // Read back all data and verify row-by-row match with written batches
   verifyFileData(file, type, batches);
 
   // Verify position index chunk row counts
-  verifyPositionIndex(tablet);
+  verifyPositionIndex(*tablet);
 
   // Verify value index maps each key to correct row position
-  verifyValueIndex(tablet, &readFile, type, batches, {"key_col"});
+  verifyValueIndex(*tablet, readFile.get(), type, batches, {"key_col"});
 }
 
 TEST_P(VeloxWriterIndexTest, streamDeduplication) {
@@ -4307,13 +4305,13 @@ TEST_P(VeloxWriterIndexTest, streamDeduplication) {
   writer.close();
 
   // Read and verify
-  velox::InMemoryReadFile readFile(file);
-  nimble::VeloxReader reader(&readFile, *leafPool_);
-
-  const auto& tablet = reader.tabletReader();
+  auto readFile = std::make_shared<velox::InMemoryReadFile>(file);
+  auto tabletOptions = makeTestTabletOptions(leafPool_.get());
+  auto tablet =
+      nimble::TabletReader::create(readFile, leafPool_.get(), tabletOptions);
 
   // Verify index exists
-  const auto* index = tablet.clusterIndex();
+  const auto* index = tablet->clusterIndex();
   ASSERT_NE(index, nullptr);
   EXPECT_EQ(index->indexColumns().size(), 1);
   EXPECT_EQ(index->indexColumns()[0], "key_col");
@@ -4349,10 +4347,10 @@ TEST_P(VeloxWriterIndexTest, streamDeduplication) {
   verifyFileData(file, type, batches);
 
   // Verify position index chunk row counts
-  verifyPositionIndex(tablet);
+  verifyPositionIndex(*tablet);
 
   // Verify value index maps each key to correct row position
-  verifyValueIndex(tablet, &readFile, type, batches, {"key_col"});
+  verifyValueIndex(*tablet, readFile.get(), type, batches, {"key_col"});
 }
 
 // Test that custom prefixRestartInterval in ClusterIndexConfig flows through


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebookincubator/velox/pull/17544


Rename `TabletReader::Options::pinFileMetadata` to `pinMetadata` and separate file metadata vs index caching/pinning into four independent controls:

- `pinMetadata`: pins parsed file metadata objects (StripeGroup, ChunkIndexGroup) in the in-memory weak-pointer cache with strong references so they are never evicted within the same TabletReader.
- `cacheMetadata`: caches raw file metadata (footer, stripe groups) in the process-wide `AsyncDataCache`. Takes effect only when `fileHandle` and `cache` are provided; silently falls back to direct IO otherwise.
- `pinIndex`: pins parsed index objects (HashIndex, SortedIndex) in the `DenseIndexRegistry` cache with strong references. Previously hardcoded to `true`; now controllable via this flag (defaults to `false`).
- `cacheIndex`: caches index data (partition metadata, key streams) in `AsyncDataCache` via `IndexLookup::Options`. Takes effect only when `fileHandle` and `cache` are provided.

Also changes `loadClusterIndex` and `loadDenseIndexes` defaults from `true` to `false` in both `TabletReader::Options` and `ReaderOptions`. Callers that need these indexes now explicitly opt in. Updated all production callsites (`NimbleDumpLib::emitIndex`, `FileLayout::create`, rexdb cluster index dump) and test utilities (`makeTestTabletOptions`, `TabletWithIndexTest`).

Also cleans up `IndexLookup`:
- `createIndexDataInput`/`createIndexMetadataInput` now return `shared_ptr` (avoids casts at call sites)
- Removed unused `pool` parameter from `createIndexDataInput`
- `IndexLookup::Options::validate()` now requires `indexIoStats` to be set
- `ClusterIndex` holds `shared_ptr<BufferedInput>` instead of `unique_ptr`

Test cleanup:
- Added `indexIoStats_` class member to `VeloxReaderTest` and `SelectiveNimbleReaderTest` (consistent with existing `dataIoStats_`/`metadataIoStats_` pattern)
- `metadataReuseWithSameReader` tests now use class io stats members instead of creating locals

Unit tests:
- `VeloxReaderTest::metadataReuseWithSameReader`: 6 combinations of `{pinMetadata, cacheMetadata, provideCache}`, all expect within-reader metadata reuse with `expectRamHit` validation
- `VeloxReaderTest::metadataReuseCrossReaders`: 5 combinations with `expectCrossReaderReuse` and `expectRamHit`; only `cacheMetadata=true` with cache provided enables cross-reader reuse
- `SelectiveNimbleReaderTest::metadataReuseWithSameReader` and `metadataReuseCrossReaders`: matching tests for the selective reader path
- `NimbleIndexProjectorTest::metadataReuseWithSameReader`: matching test for the index projector path
- `DenseIndexRegistryTest::pinIndexEnabled`/`pinIndexDisabled`: verifies `pinIndex` flag wires through to `MetadataCache`
- `IndexLookupTest::optionsValidateIndexIoStats`: verifies `indexIoStats` null check

Reviewed By: HuamengJiang, tanjialiang

Differential Revision: D105465252


