### PR TITLE
Remove const from std::optional<const EncodingLayout> to restore copy assignability

### DIFF
--- a/dwio/nimble/encodings/EncodingLayout.cpp
+++ b/dwio/nimble/encodings/EncodingLayout.cpp
@@ -39,7 +39,7 @@ EncodingLayout::EncodingLayout(
     EncodingType encodingType,
     Config encodingConfig,
     CompressionType compressionType,
-    std::vector<std::optional<const EncodingLayout>> children)
+    std::vector<std::optional<EncodingLayout>> children)
     : encodingType_{encodingType},
       encodingConfig_{std::move(encodingConfig)},
       compressionType_{compressionType},
@@ -103,7 +103,7 @@ std::pair<EncodingLayout, uint32_t> EncodingLayout::create(
   NIMBLE_DCHECK_EQ(extraDataSize, 0, "Extra data currently not supported.");
 
   uint32_t offset = kMinEncodingLayoutBufferSize;
-  std::vector<std::optional<const EncodingLayout>> children;
+  std::vector<std::optional<EncodingLayout>> children;
   children.reserve(childrenCount);
   for (auto i = 0; i < childrenCount; ++i) {
     auto childExists = encoding::peek<uint8_t>(encoding.data() + offset);
@@ -132,7 +132,7 @@ uint8_t EncodingLayout::childrenCount() const {
   return children_.size();
 }
 
-const std::optional<const EncodingLayout>& EncodingLayout::child(
+const std::optional<EncodingLayout>& EncodingLayout::child(
     NestedEncodingIdentifier identifier) const {
   NIMBLE_DCHECK_LT(
       identifier,
@@ -166,7 +166,7 @@ EncodingLayout EncodingLayoutCapture::capture(std::string_view encoding) {
         encoding.data() + kEncodingPrefixSize);
   }
 
-  std::vector<std::optional<const EncodingLayout>> children;
+  std::vector<std::optional<EncodingLayout>> children;
   switch (encodingType) {
     case EncodingType::FixedBitWidth:
     case EncodingType::Varint:

--- a/dwio/nimble/encodings/EncodingLayout.h
+++ b/dwio/nimble/encodings/EncodingLayout.h
@@ -47,7 +47,7 @@ class EncodingLayout {
       EncodingType encodingType,
       Config encodingConfig,
       CompressionType compressionType,
-      std::vector<std::optional<const EncodingLayout>> children = {});
+      std::vector<std::optional<EncodingLayout>> children = {});
 
   EncodingType encodingType() const;
 
@@ -55,7 +55,7 @@ class EncodingLayout {
 
   uint8_t childrenCount() const;
 
-  const std::optional<const EncodingLayout>& child(
+  const std::optional<EncodingLayout>& child(
       NestedEncodingIdentifier identifier) const;
 
   // Returns the encoding-specific configuration.
@@ -72,7 +72,7 @@ class EncodingLayout {
 
   CompressionType compressionType_;
 
-  std::vector<std::optional<const EncodingLayout>> children_;
+  std::vector<std::optional<EncodingLayout>> children_;
 };
 
 class EncodingLayoutCapture {

--- a/dwio/nimble/encodings/tests/EncodingLayoutTest.cpp
+++ b/dwio/nimble/encodings/tests/EncodingLayoutTest.cpp
@@ -23,8 +23,8 @@ using namespace facebook;
 namespace {
 
 void verifyEncodingLayout(
-    const std::optional<const nimble::EncodingLayout>& expected,
-    const std::optional<const nimble::EncodingLayout>& actual) {
+    const std::optional<nimble::EncodingLayout>& expected,
+    const std::optional<nimble::EncodingLayout>& actual) {
   ASSERT_EQ(expected.has_value(), actual.has_value());
 
   if (!expected.has_value()) {

--- a/dwio/nimble/encodings/tests/EncodingLayoutTestHelper.cpp
+++ b/dwio/nimble/encodings/tests/EncodingLayoutTestHelper.cpp
@@ -69,7 +69,7 @@ DeltaEnc::operator EncodingLayout() const {
   constexpr auto kIsRestatements = EncodingIdentifiers::Delta::IsRestatements;
   static_assert(kDeltas == 0 && kRestatements == 1 && kIsRestatements == 2);
 
-  std::vector<std::optional<const EncodingLayout>> children;
+  std::vector<std::optional<EncodingLayout>> children;
   children.reserve(3);
   children.emplace_back(deltas);
   children.emplace_back(restatements);
@@ -90,7 +90,7 @@ RLEEnc::operator EncodingLayout() const {
   constexpr auto kRunValues = EncodingIdentifiers::RunLength::RunValues;
   static_assert(kRunLengths == 0 && kRunValues == 1);
 
-  std::vector<std::optional<const EncodingLayout>> children;
+  std::vector<std::optional<EncodingLayout>> children;
   children.reserve(2);
   children.emplace_back(runLengths);
   children.emplace_back(runValues);
@@ -106,7 +106,7 @@ DictionaryEnc::operator EncodingLayout() const {
   constexpr auto kIndices = EncodingIdentifiers::Dictionary::Indices;
   static_assert(kAlphabet == 0 && kIndices == 1);
 
-  std::vector<std::optional<const EncodingLayout>> children;
+  std::vector<std::optional<EncodingLayout>> children;
   children.reserve(2);
   children.emplace_back(alphabet);
   children.emplace_back(indices);
@@ -123,7 +123,7 @@ MainlyConstantEnc::operator EncodingLayout() const {
       EncodingIdentifiers::MainlyConstant::OtherValues;
   static_assert(kIsCommon == 0 && kOtherValues == 1);
 
-  std::vector<std::optional<const EncodingLayout>> children;
+  std::vector<std::optional<EncodingLayout>> children;
   children.reserve(2);
   children.emplace_back(isCommon);
   children.emplace_back(otherValues);
@@ -139,7 +139,7 @@ NullableEnc::operator EncodingLayout() const {
   constexpr auto kNulls = EncodingIdentifiers::Nullable::Nulls;
   static_assert(kData == 0 && kNulls == 1);
 
-  std::vector<std::optional<const EncodingLayout>> children;
+  std::vector<std::optional<EncodingLayout>> children;
   children.reserve(2);
   children.emplace_back(data);
   children.emplace_back(nulls);

--- a/dwio/nimble/encodings/tests/EncodingSelectionTest.cpp
+++ b/dwio/nimble/encodings/tests/EncodingSelectionTest.cpp
@@ -1158,7 +1158,7 @@ TEST(ReplayedEncodingSelectionPolicyTest, encodingRoundTrip) {
     std::vector<uint32_t> data;
     // Children layouts for compound encodings (e.g., RLE needs RunLengths
     // and RunValues slots). nullopt children fall back to policyFactory.
-    std::vector<std::optional<const nimble::EncodingLayout>> children;
+    std::vector<std::optional<nimble::EncodingLayout>> children;
     std::string debugString() const {
       return fmt::format(
           "encodingType {}, compress {}",

--- a/dwio/nimble/velox/EncodingLayoutTree.h
+++ b/dwio/nimble/velox/EncodingLayoutTree.h
@@ -74,10 +74,10 @@ class EncodingLayoutTree {
   std::vector<StreamIdentifier> encodingLayoutIdentifiers() const;
 
  private:
-  const Kind schemaKind_;
-  const std::unordered_map<StreamIdentifier, EncodingLayout> encodingLayouts_;
-  const std::string name_;
-  const std::vector<EncodingLayoutTree> children_;
+  Kind schemaKind_;
+  std::unordered_map<StreamIdentifier, EncodingLayout> encodingLayouts_;
+  std::string name_;
+  std::vector<EncodingLayoutTree> children_;
 };
 
 } // namespace facebook::nimble

--- a/dwio/nimble/velox/selective/tests/ChunkedDecoderTest.cpp
+++ b/dwio/nimble/velox/selective/tests/ChunkedDecoderTest.cpp
@@ -376,7 +376,7 @@ class ChunkedDecoderDataTest : public index::test::ClusterIndexTestBase,
   template <typename T>
   std::unique_ptr<EncodingSelectionPolicy<T>> createEncodingSelectionPolicy(
       EncodingType encodingType) {
-    std::vector<std::optional<const EncodingLayout>> children;
+    std::vector<std::optional<EncodingLayout>> children;
     if (encodingType == EncodingType::Nullable) {
       // Nullable encoding needs child encodings for:
       // 0: nulls bitmap (bool)

--- a/dwio/nimble/velox/selective/tests/E2EIndexTest.cpp
+++ b/dwio/nimble/velox/selective/tests/E2EIndexTest.cpp
@@ -63,7 +63,7 @@ EncodingLayout makeIndexEncodingLayout(
     EncodingType encodingType,
     CompressionType compressionType,
     std::optional<uint32_t> prefixRestartInterval) {
-  std::vector<std::optional<const EncodingLayout>> children;
+  std::vector<std::optional<EncodingLayout>> children;
   if (encodingType == EncodingType::Trivial) {
     // Trivial encoding for string data needs a child encoding for lengths.
     children.emplace_back(


### PR DESCRIPTION
Summary:
`std::optional<const T>` has its copy assignment operator implicitly deleted because assigning to a `const` value is ill-formed. This makes `EncodingLayout` non-copy-assignable, which cascades to `ClusterIndexConfig`, `VeloxWriterOptions`, and any other type that contains an `EncodingLayout` member.

The `const` inside `std::optional` is unnecessary — immutability is already enforced by:
- `children_` being a private member
- The `child()` accessor returning `const std::optional<EncodingLayout>&`

Similarly, `EncodingLayoutTree` had `const`-qualified private members (`schemaKind_`, `encodingLayouts_`, `name_`, `children_`), which also delete copy/move assignment. Since these members are private with only const accessors, the `const` qualifier is redundant.

This change removes the inner `const` from all `std::optional<const EncodingLayout>` usages and the `const` qualifiers from `EncodingLayoutTree` private members, restoring copy and move assignability for the entire type hierarchy.

Differential Revision: D105497240


