### PR TITLE
feat: Parameterize string-buffer tests across disableSharedStringBuffers (#750)

### DIFF
--- a/dwio/nimble/velox/tests/FieldWriterStatsTest.cpp
+++ b/dwio/nimble/velox/tests/FieldWriterStatsTest.cpp
@@ -23,7 +23,7 @@
 using namespace facebook;
 using nimble::ColumnStats;
 
-class FieldWriterStatsTests : public ::testing::Test {
+class FieldWriterStatsTests : public ::testing::TestWithParam<bool> {
  protected:
   static void SetUpTestCase() {
     velox::memory::initializeMemoryManager(
@@ -84,7 +84,7 @@ class FieldWriterStatsTests : public ::testing::Test {
       rowType = input->type();
     }
     options.enableChunking = true;
-    options.disableSharedStringBuffers = true;
+    options.disableSharedStringBuffers = GetParam();
     nimble::VeloxWriter writer(
         rowType, std::move(writeFile), *rootPool_, options);
     writer.write(input);
@@ -147,7 +147,7 @@ class FieldWriterStatsTests : public ::testing::Test {
   std::unique_ptr<velox::test::VectorMaker> vectorMaker_;
 };
 
-TEST_F(FieldWriterStatsTests, simpleFieldWriterStats) {
+TEST_P(FieldWriterStatsTests, simpleFieldWriterStats) {
   {
     // String and int flat columns with nulls.
     auto c1 = vectorMaker_->flatVector<int32_t>({1, 2, 3});
@@ -270,7 +270,7 @@ TEST_F(FieldWriterStatsTests, simpleFieldWriterStats) {
   }
 }
 
-TEST_F(FieldWriterStatsTests, varbinaryFieldWriterStats) {
+TEST_P(FieldWriterStatsTests, varbinaryFieldWriterStats) {
   {
     // Varbinary and int flat columns with nulls.
     // Mirrors the first case of simpleFieldWriterStats but uses VARBINARY
@@ -319,7 +319,7 @@ TEST_F(FieldWriterStatsTests, varbinaryFieldWriterStats) {
   }
 }
 
-TEST_F(FieldWriterStatsTests, arrayFieldWriterStats) {
+TEST_P(FieldWriterStatsTests, arrayFieldWriterStats) {
   auto simpleArrayVector =
       vectorMaker_->arrayVector<int8_t>({{0, 1, 2}, {0, 1, 2}, {0, 1, 2}});
   simpleArrayVector->setNull(1, true);
@@ -405,7 +405,7 @@ TEST_F(FieldWriterStatsTests, arrayFieldWriterStats) {
        elementsStat4});
 }
 
-TEST_F(FieldWriterStatsTests, arrayWithOffsetFieldWriterStats) {
+TEST_P(FieldWriterStatsTests, arrayWithOffsetFieldWriterStats) {
   auto simpleArrayVector =
       vectorMaker_->arrayVector<int8_t>({{0, 1, 2}, {0, 1, 2}, {0, 1, 2}});
   // Note: root row 0 is set to null (line 436), so only 2 non-null rows.
@@ -516,7 +516,7 @@ TEST_F(FieldWriterStatsTests, arrayWithOffsetFieldWriterStats) {
       });
 }
 
-TEST_F(FieldWriterStatsTests, mapFieldWriterStats) {
+TEST_P(FieldWriterStatsTests, mapFieldWriterStats) {
   auto mapVector = vectorMaker_->mapVector<int8_t, int32_t>(
       {{{0, 1}, {2, 3}},
        {{0, 1}, {2, 3}},
@@ -557,7 +557,7 @@ TEST_F(FieldWriterStatsTests, mapFieldWriterStats) {
 }
 
 // A simplified scenario for flatmap writer for issue isolation
-TEST_F(FieldWriterStatsTests, flatmapFieldWriterStatsStableKeySet) {
+TEST_P(FieldWriterStatsTests, flatmapFieldWriterStatsStableKeySet) {
   // Input MapVector where every row has the same keys (0 and 2):
   //   row 0: {0->1, 2->2}
   //   row 1: {0->3, 2->4}
@@ -616,7 +616,7 @@ TEST_F(FieldWriterStatsTests, flatmapFieldWriterStatsStableKeySet) {
       {.flatMapColumns = {{"c0", {}}}});
 }
 
-TEST_F(FieldWriterStatsTests, flatMapFieldWriterStats) {
+TEST_P(FieldWriterStatsTests, flatMapFieldWriterStats) {
   // Input MapVector with 6 rows:
   //   row 0: {0->1, 2->3}  (2 entries)
   //   row 1: {0->1}        (1 entry)
@@ -716,7 +716,7 @@ TEST_F(FieldWriterStatsTests, flatMapFieldWriterStats) {
       {.flatMapColumns = {{"c0", {}}}});
 }
 
-TEST_F(FieldWriterStatsTests, flatMapPassThroughValueFieldWriterStats) {
+TEST_P(FieldWriterStatsTests, flatMapPassThroughValueFieldWriterStats) {
   // Passthrough flatmap using ROW vector input.
   // Each feature column is a child of the ROW vector.
   //
@@ -840,7 +840,7 @@ TEST_F(FieldWriterStatsTests, flatMapPassThroughValueFieldWriterStats) {
       velox::ROW({{"c0", velox::MAP(velox::TINYINT(), velox::INTEGER())}}));
 }
 
-TEST_F(FieldWriterStatsTests, flatMapWithNullValuesFieldWriterStats) {
+TEST_P(FieldWriterStatsTests, flatMapWithNullValuesFieldWriterStats) {
   // Input MapVector with 6 rows where some keys have null values:
   //   row 0: {0->1, 2->null}        (key 0 has value, key 2 has null)
   //   row 1: {0->null, 2->3}        (key 0 has null, key 2 has value)
@@ -944,7 +944,7 @@ TEST_F(FieldWriterStatsTests, flatMapWithNullValuesFieldWriterStats) {
       {.flatMapColumns = {{"c0", {}}}});
 }
 
-TEST_F(
+TEST_P(
     FieldWriterStatsTests,
     flatMapPassThroughWithNullValuesFieldWriterStats) {
   // Passthrough flatmap using ROW vector input with null values.
@@ -1037,7 +1037,7 @@ TEST_F(
       velox::ROW({{"c0", velox::MAP(velox::TINYINT(), velox::INTEGER())}}));
 }
 
-TEST_F(FieldWriterStatsTests, flatMapVarbinaryKeyFieldWriterStats) {
+TEST_P(FieldWriterStatsTests, flatMapVarbinaryKeyFieldWriterStats) {
   // Flatmap with VARBINARY keys via MAP vector ingestion.
   // This exercises the ingestMap code path where VARBINARY keys must use
   // collectMapStringKeyStatistics (actual string lengths) instead of
@@ -1106,7 +1106,7 @@ TEST_F(FieldWriterStatsTests, flatMapVarbinaryKeyFieldWriterStats) {
       {.flatMapColumns = {{"c0", {}}}});
 }
 
-TEST_F(FieldWriterStatsTests, flatMapPassThroughVarbinaryKeyFieldWriterStats) {
+TEST_P(FieldWriterStatsTests, flatMapPassThroughVarbinaryKeyFieldWriterStats) {
   // Passthrough flatmap with VARBINARY keys via ROW vector ingestion.
   // This exercises the ingestPassthrough code path where VARBINARY keys must
   // use collectPassthroughStringKeyStatistics (actual string lengths) instead
@@ -1176,7 +1176,7 @@ TEST_F(FieldWriterStatsTests, flatMapPassThroughVarbinaryKeyFieldWriterStats) {
       velox::ROW({{"c0", velox::MAP(velox::VARBINARY(), velox::INTEGER())}}));
 }
 
-TEST_F(FieldWriterStatsTests, slidingWindowMapFieldWriterStats) {
+TEST_P(FieldWriterStatsTests, slidingWindowMapFieldWriterStats) {
   uint64_t columnSize = 6;
   auto mapVector = vectorMaker_->mapVector<int8_t, int32_t>(
       {{{0, 1}, {2, 3}},
@@ -1268,7 +1268,7 @@ TEST_F(FieldWriterStatsTests, slidingWindowMapFieldWriterStats) {
       {.deduplicatedMapColumns = {"c0"}});
 }
 
-TEST_F(FieldWriterStatsTests, mixedColumnsFieldWriterStats) {
+TEST_P(FieldWriterStatsTests, mixedColumnsFieldWriterStats) {
   // Create test data with scalar columns + array + map (all non-deduped).
   // Data uses similar patterns to arrayWithOffsetFieldWriterStats and
   // slidingWindowMapFieldWriterStats tests.
@@ -1426,7 +1426,7 @@ TEST_F(FieldWriterStatsTests, mixedColumnsFieldWriterStats) {
 
 // Test for deduplicated types (array with offset and sliding window map) nested
 // inside a flatmap column. Uses MAP input vectors with a stable set of 3 keys.
-TEST_F(FieldWriterStatsTests, flatmapWithDeduplicatedValuesStats) {
+TEST_P(FieldWriterStatsTests, flatmapWithDeduplicatedValuesStats) {
   // Schema: MAP(INTEGER, ARRAY(INT8)) - flatmap with array values
   // We'll use 3 stable keys: 1, 2, 3
   // The array values will be deduplicated (dictionaryArrayColumns)
@@ -1521,7 +1521,7 @@ TEST_F(FieldWriterStatsTests, flatmapWithDeduplicatedValuesStats) {
 }
 
 // Test for sliding window map (deduplicatedMapColumns) nested inside a flatmap.
-TEST_F(FieldWriterStatsTests, flatmapWithSlidingWindowMapStats) {
+TEST_P(FieldWriterStatsTests, flatmapWithSlidingWindowMapStats) {
   // Schema: MAP(INTEGER, MAP(INT8, INT32)) - flatmap with nested map values
   // We'll use 3 stable keys: 1, 2, 3
   // The inner maps will use sliding window deduplication
@@ -1608,7 +1608,7 @@ TEST_F(FieldWriterStatsTests, flatmapWithSlidingWindowMapStats) {
       << "Raw size should match stats logical size";
 }
 
-TEST_F(FieldWriterStatsTests, rowFieldWriterStats) {
+TEST_P(FieldWriterStatsTests, rowFieldWriterStats) {
   auto c1 = vectorMaker_->rowVector({
       vectorMaker_->flatVectorNullable<int8_t>({0, 0, 0, 1, 1, std::nullopt}),
       vectorMaker_->flatVector<velox::StringView>(
@@ -1681,3 +1681,8 @@ TEST_F(FieldWriterStatsTests, rowFieldWriterStats) {
        c3SubFieldStat1,
        c3SubFieldStat2});
 }
+
+INSTANTIATE_TEST_SUITE_P(
+    DisableSharedStringBuffers,
+    FieldWriterStatsTests,
+    ::testing::Bool());

--- a/dwio/nimble/velox/tests/VeloxWriterTest.cpp
+++ b/dwio/nimble/velox/tests/VeloxWriterTest.cpp
@@ -2523,71 +2523,74 @@ TEST_F(VeloxWriterTest, fuzzComplex) {
                                                     : folly::Random::rand32();
   LOG(INFO) << "seed: " << seed;
   std::mt19937 rng{seed};
-  for (auto parallelismFactor : {0U, 1U, folly::available_concurrency()}) {
-    std::shared_ptr<folly::CPUThreadPoolExecutor> executor;
-    nimble::VeloxWriterOptions writerOptions;
-    writerOptions.enableChunking = true;
-    writerOptions.disableSharedStringBuffers = true;
-    writerOptions.flushPolicyFactory =
-        []() -> std::unique_ptr<nimble::FlushPolicy> {
-      return std::make_unique<nimble::ChunkFlushPolicy>(
-          nimble::ChunkFlushPolicyConfig{
-              .writerMemoryHighThresholdBytes = 200 << 10,
-              .writerMemoryLowThresholdBytes = 100 << 10,
-              .targetStripeSizeBytes = 100 << 10,
-              .estimatedCompressionFactor = 1.7,
-          });
-    };
+  for (bool disableSharedStringBuffers : {true, false}) {
+    LOG(INFO) << "disableSharedStringBuffers: " << disableSharedStringBuffers;
+    for (auto parallelismFactor : {0U, 1U, folly::available_concurrency()}) {
+      std::shared_ptr<folly::CPUThreadPoolExecutor> executor;
+      nimble::VeloxWriterOptions writerOptions;
+      writerOptions.enableChunking = true;
+      writerOptions.disableSharedStringBuffers = disableSharedStringBuffers;
+      writerOptions.flushPolicyFactory =
+          []() -> std::unique_ptr<nimble::FlushPolicy> {
+        return std::make_unique<nimble::ChunkFlushPolicy>(
+            nimble::ChunkFlushPolicyConfig{
+                .writerMemoryHighThresholdBytes = 200 << 10,
+                .writerMemoryLowThresholdBytes = 100 << 10,
+                .targetStripeSizeBytes = 100 << 10,
+                .estimatedCompressionFactor = 1.7,
+            });
+      };
 
-    LOG(INFO) << "Parallelism Factor: " << parallelismFactor;
-    writerOptions.dictionaryArrayColumns.insert("nested_map_array1");
-    writerOptions.dictionaryArrayColumns.insert("nested_map_array2");
-    writerOptions.dictionaryArrayColumns.insert("dict_array");
-    writerOptions.deduplicatedMapColumns.insert("dict_map");
+      LOG(INFO) << "Parallelism Factor: " << parallelismFactor;
+      writerOptions.dictionaryArrayColumns.insert("nested_map_array1");
+      writerOptions.dictionaryArrayColumns.insert("nested_map_array2");
+      writerOptions.dictionaryArrayColumns.insert("dict_array");
+      writerOptions.deduplicatedMapColumns.insert("dict_map");
 
-    if (parallelismFactor > 0) {
-      executor =
-          std::make_shared<folly::CPUThreadPoolExecutor>(parallelismFactor);
-      writerOptions.encodingExecutor = folly::getKeepAliveToken(*executor);
-    }
-
-    const auto iterations = 20;
-    // provide sufficient buffer between min and max chunk size thresholds
-    constexpr uint64_t chunkThresholdBuffer =
-        sizeof(std::string_view) + sizeof(bool);
-    for (auto i = 0; i < iterations; ++i) {
-      writerOptions.minStreamChunkRawSize =
-          std::uniform_int_distribution<uint64_t>(10, 4096)(rng);
-      writerOptions.maxStreamChunkRawSize =
-          std::uniform_int_distribution<uint64_t>(
-              writerOptions.minStreamChunkRawSize + chunkThresholdBuffer,
-              8192)(rng);
-      const auto batchSize =
-          std::uniform_int_distribution<uint32_t>(10, 400)(rng);
-      const auto batchCount = 5;
-
-      std::string file;
-      auto writeFile = std::make_unique<velox::InMemoryWriteFile>(&file);
-      nimble::VeloxWriter writer(
-          type, std::move(writeFile), *leafPool_.get(), writerOptions);
-      const auto batches = generateBatches(
-          type,
-          /*batchCount=*/batchCount,
-          /*size=*/batchSize,
-          /*seed=*/seed,
-          *leafPool_);
-
-      for (const auto& batch : batches) {
-        writer.write(batch);
+      if (parallelismFactor > 0) {
+        executor =
+            std::make_shared<folly::CPUThreadPoolExecutor>(parallelismFactor);
+        writerOptions.encodingExecutor = folly::getKeepAliveToken(*executor);
       }
-      writer.close();
 
-      velox::InMemoryReadFile readFile(file);
-      nimble::VeloxReader reader(&readFile, *leafPool_);
-      validateChunkSize(
-          reader,
-          writerOptions.minStreamChunkRawSize,
-          writerOptions.maxStreamChunkRawSize);
+      const auto iterations = 20;
+      // provide sufficient buffer between min and max chunk size thresholds
+      constexpr uint64_t chunkThresholdBuffer =
+          sizeof(std::string_view) + sizeof(bool);
+      for (auto i = 0; i < iterations; ++i) {
+        writerOptions.minStreamChunkRawSize =
+            std::uniform_int_distribution<uint64_t>(10, 4096)(rng);
+        writerOptions.maxStreamChunkRawSize =
+            std::uniform_int_distribution<uint64_t>(
+                writerOptions.minStreamChunkRawSize + chunkThresholdBuffer,
+                8192)(rng);
+        const auto batchSize =
+            std::uniform_int_distribution<uint32_t>(10, 400)(rng);
+        const auto batchCount = 5;
+
+        std::string file;
+        auto writeFile = std::make_unique<velox::InMemoryWriteFile>(&file);
+        nimble::VeloxWriter writer(
+            type, std::move(writeFile), *leafPool_.get(), writerOptions);
+        const auto batches = generateBatches(
+            type,
+            /*batchCount=*/batchCount,
+            /*size=*/batchSize,
+            /*seed=*/seed,
+            *leafPool_);
+
+        for (const auto& batch : batches) {
+          writer.write(batch);
+        }
+        writer.close();
+
+        velox::InMemoryReadFile readFile(file);
+        nimble::VeloxReader reader(&readFile, *leafPool_);
+        validateChunkSize(
+            reader,
+            writerOptions.minStreamChunkRawSize,
+            writerOptions.maxStreamChunkRawSize);
+      }
     }
   }
 }
@@ -2605,83 +2608,93 @@ TEST_F(VeloxWriterTest, batchedChunkingRelievesMemoryPressure) {
   const auto stringColumn = fuzzer.fuzzFlat(velox::VARCHAR());
   const auto intColumn = fuzzer.fuzzFlat(velox::INTEGER());
 
-  nimble::RawSizeContext context;
-  nimble::OrderedRanges ranges;
-  ranges.add(0, rowCount);
-  const uint64_t stringColumnRawSize =
-      nimble::getRawSizeFromVector(stringColumn, ranges, context) +
-      sizeof(uint64_t) * rowCount;
-  const uint64_t intColumnRawSize =
-      nimble::getRawSizeFromVector(intColumn, ranges, context);
+  for (bool disableSharedStringBuffers : {true, false}) {
+    LOG(INFO) << "disableSharedStringBuffers: " << disableSharedStringBuffers;
+    nimble::RawSizeContext context;
+    nimble::OrderedRanges ranges;
+    ranges.add(0, rowCount);
+    // When shared string buffers are disabled, each row contributes the size
+    // of a uint64_t offset; otherwise it contributes the size of a
+    // std::string_view.
+    const uint64_t perRowOverhead = disableSharedStringBuffers
+        ? sizeof(uint64_t)
+        : sizeof(std::string_view);
+    const uint64_t stringColumnRawSize =
+        nimble::getRawSizeFromVector(stringColumn, ranges, context) +
+        perRowOverhead * rowCount;
+    const uint64_t intColumnRawSize =
+        nimble::getRawSizeFromVector(intColumn, ranges, context);
 
-  constexpr size_t kColumnCount = 20;
-  constexpr size_t kBatchSize = 4;
-  std::vector<velox::VectorPtr> children(kColumnCount);
-  std::vector<std::string> columnNames(kColumnCount);
-  uint64_t totalRawSize = 0;
-  for (size_t i = 0; i < kColumnCount; i += 2) {
-    columnNames[i] = fmt::format("string_column_{}", i);
-    columnNames[i + 1] = fmt::format("int_column_{}", i);
-    children[i] = stringColumn;
-    children[i + 1] = intColumn;
-    totalRawSize += intColumnRawSize + stringColumnRawSize;
+    constexpr size_t kColumnCount = 20;
+    constexpr size_t kBatchSize = 4;
+    std::vector<velox::VectorPtr> children(kColumnCount);
+    std::vector<std::string> columnNames(kColumnCount);
+    uint64_t totalRawSize = 0;
+    for (size_t i = 0; i < kColumnCount; i += 2) {
+      columnNames[i] = fmt::format("string_column_{}", i);
+      columnNames[i + 1] = fmt::format("int_column_{}", i);
+      children[i] = stringColumn;
+      children[i + 1] = intColumn;
+      totalRawSize += intColumnRawSize + stringColumnRawSize;
+    }
+
+    velox::test::VectorMaker vectorMaker{leafPool_.get()};
+    const auto rowVector = vectorMaker.rowVector(columnNames, children);
+
+    // Ensure we can chunk the integer streams into multiple chunks
+    const uint64_t minChunkSize = intColumnRawSize / 2;
+    // In the aggresive stage, we chunk large streams in the first batch. We set
+    // the memoryPressureThreshold with the assumption of at least once max
+    // chunk being produced for each stream in that batch.
+    const uint64_t maxChunkSize = stringColumnRawSize / 2;
+    uint64_t memoryPressureThreshold =
+        totalRawSize - (kBatchSize * maxChunkSize);
+
+    std::vector<bool> actualChunkingDecisions;
+    nimble::VeloxWriterOptions writerOptions;
+    writerOptions.chunkedStreamBatchSize = kBatchSize;
+    writerOptions.enableChunking = true;
+    writerOptions.disableSharedStringBuffers = disableSharedStringBuffers;
+    writerOptions.minStreamChunkRawSize = minChunkSize;
+    writerOptions.maxStreamChunkRawSize = maxChunkSize;
+    writerOptions.flushPolicyFactory =
+        [&]() -> std::unique_ptr<nimble::FlushPolicy> {
+      return std::make_unique<nimble::LambdaFlushPolicy>(
+          /* shouldFlush */ [](const auto&) { return true; },
+          /* shouldChunk */
+          [&](const nimble::StripeProgress& stripeProgress) {
+            bool shouldChunk =
+                stripeProgress.stripeRawSize > memoryPressureThreshold;
+            actualChunkingDecisions.push_back(shouldChunk);
+            if (!shouldChunk) {
+              // Force memory pressure after the initial aggressive stage.
+              memoryPressureThreshold = 0;
+              // Force beginning of the non-aggressive chunking stage.
+              shouldChunk = true;
+            }
+            return shouldChunk;
+          });
+    };
+
+    std::string file;
+    auto writeFile = std::make_unique<velox::InMemoryWriteFile>(&file);
+    nimble::VeloxWriter writer(
+        rowVector->type(), std::move(writeFile), *rootPool_, writerOptions);
+    writer.write(rowVector);
+    writer.close();
+
+    // We expect true and then false for the aggressive stage.
+    EXPECT_GE(actualChunkingDecisions.size(), 2);
+    EXPECT_TRUE(actualChunkingDecisions[0]);
+    EXPECT_FALSE(actualChunkingDecisions[1]);
+
+    velox::InMemoryReadFile readFile(file);
+    nimble::VeloxReader reader(&readFile, *leafPool_);
+    validateChunkSize(
+        reader,
+        writerOptions.minStreamChunkRawSize,
+        writerOptions.maxStreamChunkRawSize);
   }
-
-  velox::test::VectorMaker vectorMaker{leafPool_.get()};
-  const auto rowVector = vectorMaker.rowVector(columnNames, children);
-
-  // Ensure we can chunk the integer streams into multiple chunks
-  const uint64_t minChunkSize = intColumnRawSize / 2;
-  // In the aggresive stage, we chunk large streams in the first batch. We set
-  // the memoryPressureThreshold with the assumption of at least once max
-  // chunk being produced for each stream in that batch.
-  const uint64_t maxChunkSize = stringColumnRawSize / 2;
-  uint64_t memoryPressureThreshold = totalRawSize - (kBatchSize * maxChunkSize);
-
-  std::vector<bool> actualChunkingDecisions;
-  nimble::VeloxWriterOptions writerOptions;
-  writerOptions.chunkedStreamBatchSize = kBatchSize;
-  writerOptions.enableChunking = true;
-  writerOptions.disableSharedStringBuffers = true;
-  writerOptions.minStreamChunkRawSize = minChunkSize;
-  writerOptions.maxStreamChunkRawSize = maxChunkSize;
-  writerOptions.flushPolicyFactory =
-      [&]() -> std::unique_ptr<nimble::FlushPolicy> {
-    return std::make_unique<nimble::LambdaFlushPolicy>(
-        /* shouldFlush */ [](const auto&) { return true; },
-        /* shouldChunk */
-        [&](const nimble::StripeProgress& stripeProgress) {
-          bool shouldChunk =
-              stripeProgress.stripeRawSize > memoryPressureThreshold;
-          actualChunkingDecisions.push_back(shouldChunk);
-          if (!shouldChunk) {
-            // Force memory pressure after the initial aggressive stage.
-            memoryPressureThreshold = 0;
-            // Force beginning of the non-aggressive chunking stage.
-            shouldChunk = true;
-          }
-          return shouldChunk;
-        });
-  };
-
-  std::string file;
-  auto writeFile = std::make_unique<velox::InMemoryWriteFile>(&file);
-  nimble::VeloxWriter writer(
-      rowVector->type(), std::move(writeFile), *rootPool_, writerOptions);
-  writer.write(rowVector);
-  writer.close();
-
-  // We expect true and then false for the aggressive stage.
-  EXPECT_GE(actualChunkingDecisions.size(), 2);
-  EXPECT_TRUE(actualChunkingDecisions[0]);
-  EXPECT_FALSE(actualChunkingDecisions[1]);
-
-  velox::InMemoryReadFile readFile(file);
-  nimble::VeloxReader reader(&readFile, *leafPool_);
-  validateChunkSize(
-      reader,
-      writerOptions.minStreamChunkRawSize,
-      writerOptions.maxStreamChunkRawSize);
 }
 
 TEST_F(VeloxWriterTest, ignoreTopLevelNulls) {


### PR DESCRIPTION
Summary:

T251697567 (follow-up to D89938211). Two nimble velox tests
hard-coded `writerOptions.disableSharedStringBuffers = true`, leaving
the `false` branch (shared string buffers enabled) un-exercised:

- `FieldWriterStatsTests` (17 TEST_F cases in
  `dwio/nimble/velox/tests/FieldWriterStatsTest.cpp`). Converted the
  fixture to `::testing::TestWithParam<bool>`, switched all 17 to
  `TEST_P`, replaced the hard-coded `true` with `GetParam()`, and
  appended `INSTANTIATE_TEST_SUITE_P(DisableSharedStringBuffers, ...,
  ::testing::Bool())`. Coverage doubles to 34 cases (17 x 2).
- `VeloxWriterTest.fuzzComplex` and
  `VeloxWriterTest.batchedChunkingRelievesMemoryPressure` in
  `dwio/nimble/velox/tests/VeloxWriterTest.cpp`. Both wrapped in
  `for (bool disableSharedStringBuffers : {true, false}) { ... }`. For
  `batchedChunkingRelievesMemoryPressure`, the per-row raw-size
  contribution on VARCHAR columns is now derived from the buffer mode
  (`sizeof(uint64_t)` when disabled vs `sizeof(std::string_view)` when
  enabled) so the chunking thresholds remain accurate in both
  configurations.

No production code change. BUCK targets already set
`supports_static_listing = False`, so no BUCK edits required.

___

overriding_review_checks_triggers_an_audit_and_retroactive_review
Oncall Short Name: presto_interactive

Differential Revision: D105608293


