### PR TITLE
feat: Log selected flat map feature names in keySelectionCallback

### DIFF
--- a/dwio/nimble/velox/FieldReader.cpp
+++ b/dwio/nimble/velox/FieldReader.cpp
@@ -4081,6 +4081,19 @@ std::unique_ptr<FieldReaderFactory> createFieldReaderFactory(
                .selectedKeys = selectedChildren.size()});
         }
 
+        const auto& flatMapFeatureProjectionCallback =
+            parameters.flatMapFeatureProjectionCallback;
+        if (flatMapFeatureProjectionCallback != nullptr) {
+          std::vector<std::string> selectedFeatureNames;
+          selectedFeatureNames.reserve(selectedChildren.size());
+          for (auto childIdx : selectedChildren) {
+            selectedFeatureNames.emplace_back(nimbleFlatMap.nameAt(childIdx));
+          }
+          flatMapFeatureProjectionCallback(
+              {.columnName = (name != nullptr ? *name : std::string{}),
+               .selectedFeatureNames = std::move(selectedFeatureNames)});
+        }
+
         return createFlatMapReaderFactory(
             pool,
             veloxType->childAt(0)->type()->kind(),

--- a/dwio/nimble/velox/FieldReader.h
+++ b/dwio/nimble/velox/FieldReader.h
@@ -55,6 +55,22 @@ struct FieldReaderParams {
   std::function<void(velox::dwio::common::flatmap::FlatMapKeySelectionStats)>
       keySelectionCallback{nullptr};
 
+  /// Per-flat-map record of the features the reader actually projected (in the
+  /// caller-specified order). Reported alongside keySelectionCallback when a
+  /// flat map column is materialized. Intended for offline analyses that
+  /// inform write-time feature reordering (e.g. VeloxWriterOptions::
+  /// featureReordering / FeatureReorderingLayoutPlanner).
+  struct FlatMapFeatureProjection {
+    std::string columnName;
+    std::vector<std::string> selectedFeatureNames;
+  };
+
+  /// Callback invoked once per flat map column during reader factory creation.
+  /// Receives the column name and the names of the features that were
+  /// selected, in the order chosen by the reader. nullptr disables logging.
+  std::function<void(FlatMapFeatureProjection)>
+      flatMapFeatureProjectionCallback{nullptr};
+
   bool optimizeStringBufferHandling{false};
 
   /// Executor for parallel decoding of child fields.


### PR DESCRIPTION
Summary:
Adds a new optional `flatMapFeatureProjectionCallback` on Nimble's `FieldReaderParams` that, when set, is invoked once per flat map column during `createFieldReaderFactory()` with the column name and the names of the features that were actually projected (in the caller-specified order).

This gives loggers (e.g. Scuba/ODS pipelines) the information needed to inform write-time flat map feature reordering configurations (`VeloxWriterOptions::featureReordering` / `FeatureReorderingLayoutPlanner`), addressing the gap noted in T237389198 where the existing `keySelectionCallback` only reports aggregate `{totalKeys, selectedKeys}` counts.

The existing `keySelectionCallback` path is unchanged, and the new callback defaults to nullptr so all existing callers are unaffected. No Velox / DWRF / DWIO API headers are touched, so this is safe for the OSS Nimble build (which pins an older Velox snapshot).

Reviewed By: srsuryadev

Differential Revision: D105609449


