### PR TITLE
refactor: Add MetadataInput::Options and track index metadata IO under indexIoStats

### DIFF
--- a/dwio/nimble/index/IndexLookup.cpp
+++ b/dwio/nimble/index/IndexLookup.cpp
@@ -42,10 +42,15 @@ void IndexLookup::Options::validate() const {
 
 std::shared_ptr<MetadataInput> createIndexMetadataInput(
     const IndexLookup::Options& options) {
-  return (options.fileHandle != nullptr)
-      ? MetadataInput::create(
-            options.fileHandle, options.cache, *options.ioOptions)
-      : MetadataInput::create(options.file.get(), *options.ioOptions);
+  MetadataInput::Options metadataOptions{
+      .pool = &options.ioOptions->memoryPool(),
+      .ioStats = options.ioOptions->indexIoStats(),
+      .maxCoalesceDistance = options.ioOptions->maxCoalesceDistance(),
+      .maxCoalesceBytes = options.ioOptions->maxCoalesceBytes(),
+      .executor = options.ioOptions->ioExecutor().get(),
+      .fileHandle = options.fileHandle,
+      .cache = options.cache};
+  return MetadataInput::create(options.file.get(), metadataOptions);
 }
 
 std::shared_ptr<velox::dwio::common::BufferedInput> createIndexDataInput(

--- a/dwio/nimble/index/tests/ClusterIndexTest.cpp
+++ b/dwio/nimble/index/tests/ClusterIndexTest.cpp
@@ -1495,9 +1495,8 @@ TEST_F(ClusterIndexTest, indexDataReuseCrossReaders) {
       EXPECT_EQ(secondResult[0][0], RowRange(0, 300));
 
       if (testCase.expectCrossReaderReuse) {
-        // Metadata (partition info) is served from AsyncDataCache.
-        EXPECT_GT(metadataIoStats_->ramHit().count(), 0)
-            << "Second reader should serve partition metadata from cache";
+        EXPECT_GT(indexIoStats_->ramHit().count(), 0)
+            << "Second reader should serve index data from cache";
       }
     }
   }

--- a/dwio/nimble/index/tests/ClusterIndexTestBase.cpp
+++ b/dwio/nimble/index/tests/ClusterIndexTestBase.cpp
@@ -353,11 +353,9 @@ std::unique_ptr<ClusterIndex> ClusterIndexTestBase::createClusterIndex(
   metadataFile_ =
       std::make_shared<velox::InMemoryReadFile>(indexBuffers.indexPartitions);
   ioStats_ = std::make_shared<velox::io::IoStatistics>();
-  velox::io::ReaderOptions readerOptions(pool_.get());
-  readerOptions.setMetadataIoStats(ioStats_);
-  readerOptions.setIndexIoStats(std::make_shared<velox::io::IoStatistics>());
-  auto metadataInput =
-      MetadataInput::create(metadataFile_.get(), readerOptions);
+  auto metadataInput = MetadataInput::create(
+      metadataFile_.get(),
+      MetadataInput::Options{.pool = pool_.get(), .ioStats = ioStats_});
 
   auto dataFile = keyStreamFile != nullptr
       ? std::shared_ptr<velox::ReadFile>(

--- a/dwio/nimble/index/tests/ClusterIndexWriterTest.cpp
+++ b/dwio/nimble/index/tests/ClusterIndexWriterTest.cpp
@@ -1122,10 +1122,9 @@ TEST_P(ClusterIndexWriterChunkTest, maxRowsPerKeyChunk) {
   auto metadataFile =
       std::make_shared<velox::InMemoryReadFile>(partitionMetadata[0]);
   auto ioStats = std::make_shared<velox::io::IoStatistics>();
-  velox::io::ReaderOptions readerOptions(pool_.get());
-  readerOptions.setMetadataIoStats(ioStats);
-  readerOptions.setIndexIoStats(std::make_shared<velox::io::IoStatistics>());
-  auto metadataInput = MetadataInput::create(metadataFile.get(), readerOptions);
+  auto metadataInput = MetadataInput::create(
+      metadataFile.get(),
+      MetadataInput::Options{.pool = pool_.get(), .ioStats = ioStats});
   auto dataInput = std::make_unique<velox::dwio::common::BufferedInput>(
       std::make_shared<velox::InMemoryReadFile>(keyStreamData), *pool_);
 

--- a/dwio/nimble/index/tests/HashIndexTest.cpp
+++ b/dwio/nimble/index/tests/HashIndexTest.cpp
@@ -701,9 +701,8 @@ TEST_F(HashIndexTest, indexDataReuseCrossReaders) {
       ASSERT_FALSE(secondResult[0].empty());
 
       if (testCase.expectCrossReaderReuse) {
-        // Metadata (hash index data) is served from AsyncDataCache.
-        EXPECT_GT(metadataIoStats_->ramHit().count(), 0)
-            << "Second reader should serve index metadata from cache";
+        EXPECT_GT(indexIoStats_->ramHit().count(), 0)
+            << "Second reader should serve index data from cache";
       }
     }
   }

--- a/dwio/nimble/index/tests/SortedIndexTest.cpp
+++ b/dwio/nimble/index/tests/SortedIndexTest.cpp
@@ -893,9 +893,8 @@ TEST_F(SortedIndexTest, indexDataReuseCrossReaders) {
       ASSERT_FALSE(secondResult[0].empty());
 
       if (testCase.expectCrossReaderReuse) {
-        // Metadata (index directory) is served from AsyncDataCache.
-        EXPECT_GT(metadataIoStats_->ramHit().count(), 0)
-            << "Second reader should serve index metadata from cache";
+        EXPECT_GT(indexIoStats_->ramHit().count(), 0)
+            << "Second reader should serve index data from cache";
       }
     }
   }

--- a/dwio/nimble/tablet/MetadataInput.cpp
+++ b/dwio/nimble/tablet/MetadataInput.cpp
@@ -37,33 +37,25 @@ namespace facebook::nimble {
 
 std::unique_ptr<MetadataInput> MetadataInput::create(
     velox::ReadFile* file,
-    const velox::io::ReaderOptions& readerOptions) {
+    const Options& options) {
   NIMBLE_CHECK_NOT_NULL(file);
-  return std::unique_ptr<MetadataInput>(
-      new DirectMetadataInput(file, readerOptions));
+  if (options.fileHandle != nullptr) {
+    NIMBLE_CHECK_NOT_NULL(
+        options.cache, "cache required when fileHandle is set");
+    return std::unique_ptr<MetadataInput>(new CachedMetadataInput(
+        file, options.fileHandle->uuid, options.cache, options));
+  }
+  return std::unique_ptr<MetadataInput>(new DirectMetadataInput(file, options));
 }
 
-std::unique_ptr<MetadataInput> MetadataInput::create(
-    const velox::FileHandle* fileHandle,
-    velox::cache::AsyncDataCache* cache,
-    const velox::io::ReaderOptions& readerOptions) {
-  NIMBLE_CHECK_NOT_NULL(fileHandle);
-  NIMBLE_CHECK_NOT_NULL(cache);
-  auto* file = fileHandle->file.get();
-  NIMBLE_CHECK_NOT_NULL(file);
-  return std::unique_ptr<MetadataInput>(
-      new CachedMetadataInput(file, fileHandle->uuid, cache, readerOptions));
-}
-
-MetadataInput::MetadataInput(
-    velox::ReadFile* file,
-    const velox::io::ReaderOptions& options)
+MetadataInput::MetadataInput(velox::ReadFile* file, const Options& options)
     : file_{file},
-      pool_{&options.memoryPool()},
-      maxCoalesceDistance_{options.maxCoalesceDistance()},
-      maxCoalesceBytes_{options.maxCoalesceBytes()},
-      executor_{options.ioExecutor().get()},
-      ioStats_{options.metadataIoStats()} {
+      pool_{options.pool},
+      maxCoalesceDistance_{options.maxCoalesceDistance},
+      maxCoalesceBytes_{options.maxCoalesceBytes},
+      executor_{options.executor},
+      ioStats_{options.ioStats} {
+  NIMBLE_CHECK_NOT_NULL(pool_);
   NIMBLE_CHECK_NOT_NULL(ioStats_.get());
 }
 
@@ -279,7 +271,7 @@ void MetadataInput::recordCoalescedIoStats(
 
 DirectMetadataInput::DirectMetadataInput(
     velox::ReadFile* file,
-    const velox::io::ReaderOptions& options)
+    const Options& options)
     : MetadataInput(file, options) {}
 
 void DirectMetadataInput::prepareBuffers(
@@ -326,7 +318,7 @@ CachedMetadataInput::CachedMetadataInput(
     velox::ReadFile* file,
     velox::StringIdLease fileId,
     velox::cache::AsyncDataCache* cache,
-    const velox::io::ReaderOptions& options)
+    const Options& options)
     : MetadataInput(file, options), cache_{cache}, fileId_{std::move(fileId)} {
   NIMBLE_CHECK_NOT_NULL(cache_);
 }

--- a/dwio/nimble/tablet/MetadataInput.h
+++ b/dwio/nimble/tablet/MetadataInput.h
@@ -49,16 +49,21 @@ namespace facebook::nimble {
 ///     metadata with memory/SSD tier support
 class MetadataInput {
  public:
-  /// Creates a DirectMetadataInput for non-cached reads.
+  struct Options {
+    velox::memory::MemoryPool* pool;
+    std::shared_ptr<velox::io::IoStatistics> ioStats;
+    int32_t maxCoalesceDistance{
+        velox::io::ReaderOptions::kDefaultCoalesceDistance};
+    int64_t maxCoalesceBytes{velox::io::ReaderOptions::kDefaultCoalesceBytes};
+    folly::Executor* executor{nullptr};
+    // When both fileHandle and cache are set, creates CachedMetadataInput.
+    const velox::FileHandle* fileHandle{nullptr};
+    velox::cache::AsyncDataCache* cache{nullptr};
+  };
+
   static std::unique_ptr<MetadataInput> create(
       velox::ReadFile* file,
-      const velox::io::ReaderOptions& readerOptions);
-
-  /// Creates a CachedMetadataInput using fileHandle->uuid as cache key.
-  static std::unique_ptr<MetadataInput> create(
-      const velox::FileHandle* fileHandle,
-      velox::cache::AsyncDataCache* cache,
-      const velox::io::ReaderOptions& readerOptions);
+      const Options& options);
 
   virtual ~MetadataInput() = default;
 
@@ -85,7 +90,7 @@ class MetadataInput {
       std::span<const std::string_view> ranges);
 
  protected:
-  MetadataInput(velox::ReadFile* file, const velox::io::ReaderOptions& options);
+  MetadataInput(velox::ReadFile* file, const Options& options);
 
   struct LoadedSection {
     explicit LoadedSection(MetadataSection _section) : section{_section} {}
@@ -200,9 +205,7 @@ class DirectMetadataInput : public MetadataInput {
 
   friend class MetadataInput;
 
-  DirectMetadataInput(
-      velox::ReadFile* file,
-      const velox::io::ReaderOptions& options);
+  DirectMetadataInput(velox::ReadFile* file, const Options& options);
 };
 
 /// Cached metadata loading with IO coalescing and AsyncDataCache.
@@ -284,7 +287,7 @@ class CachedMetadataInput : public MetadataInput {
       velox::ReadFile* file,
       velox::StringIdLease fileId,
       velox::cache::AsyncDataCache* cache,
-      const velox::io::ReaderOptions& options);
+      const Options& options);
 
   velox::cache::AsyncDataCache* const cache_;
   const velox::StringIdLease fileId_;

--- a/dwio/nimble/tablet/TabletReader.cpp
+++ b/dwio/nimble/tablet/TabletReader.cpp
@@ -256,14 +256,20 @@ TabletReader::TabletReader(
             options.pinIndex};
       }()},
       metadataInput_{[&]() {
+        MetadataInput::Options metadataOptions{
+            .pool = &pool,
+            .ioStats = ioOptions_.metadataIoStats(),
+            .maxCoalesceDistance = ioOptions_.maxCoalesceDistance(),
+            .maxCoalesceBytes = ioOptions_.maxCoalesceBytes(),
+            .executor = ioOptions_.ioExecutor().get()};
         // cacheMetadata takes effect only when fileHandle and cache are
         // provided.
         if (options.cacheMetadata && options.fileHandle != nullptr) {
           NIMBLE_CHECK_NOT_NULL(options.cache, "cacheMetadata requires cache");
-          return MetadataInput::create(
-              options.fileHandle, options.cache, ioOptions_);
+          metadataOptions.fileHandle = options.fileHandle;
+          metadataOptions.cache = options.cache;
         }
-        return MetadataInput::create(file_.get(), ioOptions_);
+        return MetadataInput::create(file_.get(), metadataOptions);
       }()},
       stripeGroupCache_{
           [this](uint32_t stripeGroupIndex) {

--- a/dwio/nimble/tablet/tests/MetadataInputTest.cpp
+++ b/dwio/nimble/tablet/tests/MetadataInputTest.cpp
@@ -71,15 +71,14 @@ std::string buildFileContent(
 
 class MetadataInputTestBase : public ::testing::Test {
  protected:
-  velox::io::ReaderOptions makeReaderOptions(
+  nimble::MetadataInput::Options makeMetadataInputOptions(
       int32_t maxCoalesceDistance = 1 << 20,
       int64_t maxCoalesceBytes = 128 << 20) {
-    velox::io::ReaderOptions options(pool_.get());
-    options.setDataIoStats(dataIoStats_);
-    options.setMetadataIoStats(metadataIoStats_);
-    options.setMaxCoalesceDistance(maxCoalesceDistance);
-    options.setMaxCoalesceBytes(maxCoalesceBytes);
-    return options;
+    return {
+        .pool = pool_.get(),
+        .ioStats = metadataIoStats_,
+        .maxCoalesceDistance = maxCoalesceDistance,
+        .maxCoalesceBytes = maxCoalesceBytes};
   }
 
   std::shared_ptr<velox::memory::MemoryPool> rootPool_;
@@ -196,7 +195,7 @@ TEST_F(DirectMetadataInputTest, loadSections) {
     const auto fileContent = buildFileContent(sections, fileDataParts);
     auto readFile = std::make_shared<velox::InMemoryReadFile>(fileContent);
 
-    const auto options = makeReaderOptions();
+    const auto options = makeMetadataInputOptions();
     auto input = nimble::MetadataInput::create(readFile.get(), options);
 
     auto results = input->load(sections);
@@ -230,7 +229,7 @@ TEST_F(DirectMetadataInputTest, reverseSectionOrder) {
       buildFileContent({section0, section1}, {data0, data1});
   auto readFile = std::make_shared<velox::InMemoryReadFile>(fileContent);
 
-  const auto options = makeReaderOptions();
+  const auto options = makeMetadataInputOptions();
   auto input = nimble::MetadataInput::create(readFile.get(), options);
 
   // Sections in reverse file order — should still work.
@@ -249,7 +248,7 @@ TEST_F(DirectMetadataInputTest, repeatedLoad) {
   const auto fileContent = buildFileContent({section}, {data});
   auto readFile = std::make_shared<velox::InMemoryReadFile>(fileContent);
 
-  const auto options = makeReaderOptions();
+  const auto options = makeMetadataInputOptions();
   auto input = nimble::MetadataInput::create(readFile.get(), options);
 
   // Stateless: can call load() multiple times without reset.
@@ -291,7 +290,7 @@ TEST_F(DirectMetadataInputTest, ioStats) {
   const auto queryIoLatencyCountBefore =
       metadataIoStats_->queryThreadIoLatencyUs().count();
 
-  const auto options = makeReaderOptions();
+  const auto options = makeMetadataInputOptions();
   auto input = nimble::MetadataInput::create(readFile.get(), options);
   input->load(std::array{section});
 
@@ -405,7 +404,7 @@ DEBUG_ONLY_TEST_F(DirectMetadataInputTest, ioCoalescing) {
               capturedStats = *stats;
             }));
 
-    const auto options = makeReaderOptions(
+    const auto options = makeMetadataInputOptions(
         testData.maxCoalesceDistance, testData.maxCoalesceBytes);
     auto input = nimble::MetadataInput::create(readFile.get(), options);
     input->load(sections);
@@ -480,7 +479,7 @@ TEST_F(DirectMetadataInputTest, ioError) {
     readFile->setReadError(
         std::make_exception_ptr(std::runtime_error("injected IO error")));
 
-    const auto options = makeReaderOptions(testData.maxCoalesceDistance);
+    const auto options = makeMetadataInputOptions(testData.maxCoalesceDistance);
     auto input = nimble::MetadataInput::create(readFile.get(), options);
     EXPECT_THROW(input->load(sections), std::runtime_error);
 
@@ -562,10 +561,11 @@ class CachedMetadataInputTest : public MetadataInputTestBase,
         std::shared_ptr<velox::ReadFile>{}, readFile);
     fileHandle_->uuid =
         velox::StringIdLease(velox::fileIds(), "CachedMetadataInputTest");
-    const auto options =
-        makeReaderOptions(maxCoalesceDistance, maxCoalesceBytes);
-    return nimble::MetadataInput::create(
-        fileHandle_.get(), cache_.get(), options);
+    auto options =
+        makeMetadataInputOptions(maxCoalesceDistance, maxCoalesceBytes);
+    options.fileHandle = fileHandle_.get();
+    options.cache = cache_.get();
+    return nimble::MetadataInput::create(readFile, options);
   }
 
   std::unique_ptr<velox::memory::MemoryManager> manager_;
@@ -1124,7 +1124,7 @@ TEST_P(CachedMetadataInputTest, cachePinRetention) {
 
 TEST_F(DirectMetadataInputTest, cacheMethodsThrow) {
   auto file = std::make_shared<velox::InMemoryReadFile>(std::string(100, 'x'));
-  auto options = makeReaderOptions();
+  auto options = makeMetadataInputOptions();
   auto input = nimble::MetadataInput::create(file.get(), options);
   EXPECT_FALSE(input->cached());
   NIMBLE_ASSERT_THROW(input->findCachedMetadata(0), "");

--- a/dwio/nimble/tablet/tests/TabletTest.cpp
+++ b/dwio/nimble/tablet/tests/TabletTest.cpp
@@ -3726,7 +3726,7 @@ TEST_P(TabletWithIndexTest, loadDenseIndexes) {
     if (loadDenseIndexes) {
       ASSERT_NE(tablet->denseIndex({"id"}), nullptr);
       ASSERT_NE(tablet->denseIndex({"value"}), nullptr);
-      EXPECT_GT(metadataIoStats->rawBytesRead(), metadataBytesAfterOpen);
+      EXPECT_GT(indexIoStats->rawBytesRead(), 0);
     } else {
       EXPECT_EQ(tablet->denseIndex({"id"}), nullptr);
       EXPECT_EQ(tablet->denseIndex({"value"}), nullptr);


### PR DESCRIPTION
Summary:
Previously, index MetadataInput (used by cluster, hash, and sorted indexes) was created with `metadataIoStats` from `ReaderOptions`, causing index metadata IO to be tracked under the tablet metadata stats instead of index stats. This made it impossible to distinguish index metadata IO from tablet metadata IO.

This diff introduces `MetadataInput::Options` struct to replace the `velox::io::ReaderOptions` dependency. The new struct gives callers explicit control over which `IoStatistics` instance to use. `createIndexMetadataInput` now passes `indexIoStats` so all index-related IO (both metadata and key stream data) is tracked under `indexIoStats_`.

Also updates cross-reader reuse tests to assert on `indexIoStats_->ramHit()` instead of `metadataIoStats_->ramHit()` for index cache verification.

Differential Revision: D105697299


