### PR TITLE
feat: Pin DecodedChunks per partition when pinIndex is set

### DIFF
--- a/dwio/nimble/index/ChunkIndexGroup.cpp
+++ b/dwio/nimble/index/ChunkIndexGroup.cpp
@@ -131,16 +131,17 @@ ChunkLocation StreamIndex::lookupChunk(uint32_t rowId) const {
       rowId,
       streamId_);
 
-  const uint32_t chunkOffset = it - chunkRows->begin();
+  const uint32_t chunkIndex = it - chunkRows->begin();
   const auto* chunkOffsets = root->stream_chunk_offsets();
   NIMBLE_CHECK_NOT_NULL(chunkOffsets);
   const uint32_t rowOffset =
-      chunkOffset == startChunkOffset_ ? 0 : chunkRows->Get(chunkOffset - 1);
-  const uint32_t streamOffset = chunkOffsets->Get(chunkOffset);
-  const uint32_t nextOffset = (chunkOffset + 1 < endChunkOffset_)
-      ? chunkOffsets->Get(chunkOffset + 1)
+      chunkIndex == startChunkOffset_ ? 0 : chunkRows->Get(chunkIndex - 1);
+  const uint32_t streamOffset = chunkOffsets->Get(chunkIndex);
+  const uint32_t nextOffset = (chunkIndex + 1 < endChunkOffset_)
+      ? chunkOffsets->Get(chunkIndex + 1)
       : streamSize_;
-  return ChunkLocation{streamOffset, nextOffset - streamOffset, rowOffset};
+  return ChunkLocation{
+      chunkIndex, streamOffset, nextOffset - streamOffset, rowOffset};
 }
 
 uint32_t StreamIndex::rowCount() const {

--- a/dwio/nimble/index/ClusterIndex.cpp
+++ b/dwio/nimble/index/ClusterIndex.cpp
@@ -146,16 +146,18 @@ std::unique_ptr<ClusterIndex> ClusterIndex::create(
       "ioOptions pool must match the provided pool");
   return std::unique_ptr<ClusterIndex>(new ClusterIndex(
       std::move(rootSection),
-      pool,
       createIndexMetadataInput(options),
-      createIndexDataInput(options)));
+      createIndexDataInput(options),
+      options.pinIndex,
+      pool));
 }
 
 ClusterIndex::ClusterIndex(
     Section rootSection,
-    velox::memory::MemoryPool* pool,
     std::shared_ptr<MetadataInput> metadataInput,
-    std::shared_ptr<velox::dwio::common::BufferedInput> dataInput)
+    std::shared_ptr<velox::dwio::common::BufferedInput> dataInput,
+    bool pinIndex,
+    velox::memory::MemoryPool* pool)
     : IndexLookup{IndexType::Cluster},
       rootSection_{std::move(rootSection)},
       indexRoot_{getIndexRoot(rootSection_)},
@@ -170,6 +172,7 @@ ClusterIndex::ClusterIndex(
       metadataInput_{std::move(metadataInput)},
       dataInput_{std::move(dataInput)},
       pool_{pool},
+      pinIndex_{pinIndex},
       partitions_(numPartitions_) {
   NIMBLE_CHECK(!indexColumns_.empty());
   NIMBLE_CHECK_EQ(indexColumns_.size(), sortOrders_.size());
@@ -368,7 +371,8 @@ MetadataSection ClusterIndex::partitionSection(uint32_t partitionId) const {
 
 ClusterIndex::IndexPartition::IndexPartition(
     uint32_t _id,
-    std::unique_ptr<MetadataBuffer> _metadata)
+    std::unique_ptr<MetadataBuffer> _metadata,
+    bool pinIndex)
     : id{_id},
       metadata{std::move(_metadata)},
       index{flatbuffers::GetRoot<serialization::ClusterIndexPartition>(
@@ -381,6 +385,10 @@ ClusterIndex::IndexPartition::IndexPartition(
   const auto* chunkOffsets = index->chunk_offsets();
   NIMBLE_CHECK_NOT_NULL(chunkOffsets);
   NIMBLE_CHECK_EQ(chunkOffsets->size(), chunkKeys->size());
+  // Allocate the cache slot vector. When pinIndex is true, size to the
+  // number of chunks so every chunk has a dedicated slot. When false,
+  // allocate a single scratch slot that retains at most one decoded chunk.
+  decodedChunks.resize(pinIndex ? numChunks() : 1);
 }
 
 uint32_t ClusterIndex::IndexPartition::chunkIndex(
@@ -405,18 +413,6 @@ velox::common::Region ClusterIndex::IndexPartition::chunkStreamRegion(
   return velox::common::Region{offset, chunkLocation.chunkSize};
 }
 
-char* ClusterIndex::IndexPartition::ensureDataBuffer(
-    uint32_t bytes,
-    velox::memory::MemoryPool* pool) const {
-  if (dataBuffer == nullptr) {
-    dataBuffer = velox::AlignedBuffer::allocate<char>(bytes, pool);
-  } else if (dataBuffer->capacity() < bytes) {
-    NIMBLE_CHECK(dataBuffer->unique());
-    velox::AlignedBuffer::reallocate<char>(&dataBuffer, bytes);
-  }
-  return dataBuffer->asMutable<char>();
-}
-
 const ClusterIndex::IndexPartition* ClusterIndex::loadPartition(
     uint32_t partitionId) const {
   NIMBLE_CHECK_LT(partitionId, numPartitions_);
@@ -427,7 +423,8 @@ const ClusterIndex::IndexPartition* ClusterIndex::loadPartition(
     NIMBLE_CHECK_EQ(results.size(), 1);
     partition = std::make_unique<IndexPartition>(
         partitionId,
-        std::make_unique<MetadataBuffer>(std::move(*results.front())));
+        std::make_unique<MetadataBuffer>(std::move(*results.front())),
+        pinIndex_);
   }
   return partition.get();
 }
@@ -438,6 +435,7 @@ ChunkLocation ClusterIndex::lookupChunk(
   NIMBLE_DCHECK_NOT_NULL(partition);
   const uint32_t idx = partition->chunkIndex(encodedKey);
   return ChunkLocation{
+      idx,
       partition->chunkOffset(idx),
       partition->chunkSize(idx),
       partition->rowOffset(idx)};
@@ -479,32 +477,42 @@ ClusterIndex::Layout ClusterIndex::layout(bool detail) const {
 // ClusterIndex::DecodedChunk
 // ---------------------------------------------------------------------------
 
-const ClusterIndex::DecodedChunk& ClusterIndex::getDecodedChunk(
+ClusterIndex::DecodedChunk ClusterIndex::getDecodedChunk(
     const IndexPartition* partition,
     const ChunkLocation& chunkLocation) const {
   NIMBLE_DCHECK_NOT_NULL(partition);
-  auto& decodedChunk = partition->decodedChunk;
-  if (decodedChunk.data != nullptr &&
-      decodedChunk.chunkOffset == chunkLocation.chunkOffset) {
-    return decodedChunk;
+  // Resolve the cache slot. When pinned, every chunk has a dedicated slot
+  // indexed by chunkIndex. When unpinned, a single shared slot holds at most
+  // one decoded chunk; treat it as a hit only when chunkOffset matches.
+  const uint32_t slotIdx = pinIndex_ ? chunkLocation.chunkIndex : 0;
+  NIMBLE_CHECK_LT(slotIdx, partition->decodedChunks.size());
+  auto& slot = partition->decodedChunks.at(slotIdx);
+  if (slot.data != nullptr &&
+      (pinIndex_ || slot.chunkOffset == chunkLocation.chunkOffset)) {
+    return slot;
   }
 
-  decodedChunk.reset(chunkLocation.chunkOffset);
-
+  // Cache miss: decode from dataInput_ into a local DecodedChunk, then move
+  // it into the slot. The returned copy bumps the shared_ptr refcount so
+  // the underlying DecodedKeyChunk (and its owned buffer in stringBuffers)
+  // stays alive past this call.
+  DecodedChunk decodedChunk;
   const auto region = partition->chunkStreamRegion(chunkLocation);
+  decodedChunk.chunkOffset = chunkLocation.chunkOffset;
+  velox::BufferPtr scratch;
   decodedChunk.data = decodeKeyChunk(
       dataInput_->read(
           region.offset,
           region.length,
           velox::dwio::common::LogType::GROUP_INDEX),
       *pool_,
-      partition->dataBuffer);
+      scratch);
   NIMBLE_CHECK_EQ(
       decodedChunk.data->encoding->dataType(),
       DataType::String,
       "Expected String data type");
-
-  return decodedChunk;
+  slot = std::move(decodedChunk);
+  return slot;
 }
 
 uint32_t ClusterIndex::seekInChunk(
@@ -512,7 +520,7 @@ uint32_t ClusterIndex::seekInChunk(
     const ChunkLocation& chunkLocation,
     std::string_view encodedKey,
     bool inclusive) const {
-  const auto& chunk = getDecodedChunk(partition, chunkLocation);
+  const auto chunk = getDecodedChunk(partition, chunkLocation);
   const auto rowInChunk = chunk.data->encoding->seek(&encodedKey, inclusive);
   if (!rowInChunk.has_value()) {
     // For exclusive seek (inclusive=false), no row > key means the end is
@@ -542,6 +550,7 @@ ChunkLocation ClusterIndex::lookupChunk(
       partition->id);
   const uint32_t idx = it - chunkRows->begin();
   return ChunkLocation{
+      idx,
       partition->chunkOffset(idx),
       partition->chunkSize(idx),
       partition->rowOffset(idx)};
@@ -567,8 +576,12 @@ std::string ClusterIndex::keyAtRow(uint32_t row) const {
     return std::string(chunkKeys->Get(chunkIdx)->string_view());
   }
 
-  const auto chunkLocation = lookupChunk(partition, partitionRow);
-  const auto& decodedChunk = getDecodedChunk(partition, chunkLocation);
+  const ChunkLocation chunkLocation{
+      chunkIdx,
+      partition->chunkOffset(chunkIdx),
+      partition->chunkSize(chunkIdx),
+      partition->rowOffset(chunkIdx)};
+  const auto decodedChunk = getDecodedChunk(partition, chunkLocation);
   const uint32_t rowInChunk = partitionRow - chunkLocation.rowOffset;
 
   std::string_view value;

--- a/dwio/nimble/index/ClusterIndex.h
+++ b/dwio/nimble/index/ClusterIndex.h
@@ -19,7 +19,6 @@
 #include <functional>
 #include <memory>
 #include <string_view>
-#include <unordered_map>
 #include <vector>
 
 #include "dwio/nimble/index/IndexLookup.h"
@@ -150,17 +149,16 @@ class ClusterIndex : public IndexLookup {
  private:
   ClusterIndex(
       Section rootSection,
-      velox::memory::MemoryPool* pool,
       std::shared_ptr<MetadataInput> metadataInput,
-      std::shared_ptr<velox::dwio::common::BufferedInput> dataInput);
+      std::shared_ptr<velox::dwio::common::BufferedInput> dataInput,
+      bool pinIndex,
+      velox::memory::MemoryPool* pool);
 
-  // Cached decoded chunk, one per IndexPartition.
+  // Cached decoded chunk. The DecodedKeyChunk owns its own backing buffer
+  // (decodeKeyChunk appends it to DecodedKeyChunk::stringBuffers when no
+  // external reuse buffer is provided), so each cached entry is fully
+  // self-contained.
   struct DecodedChunk {
-    void reset(uint32_t newChunkOffset) {
-      chunkOffset = newChunkOffset;
-      data.reset();
-    }
-
     uint32_t chunkOffset{0};
     std::shared_ptr<DecodedKeyChunk> data;
   };
@@ -171,12 +169,21 @@ class ClusterIndex : public IndexLookup {
     const std::unique_ptr<MetadataBuffer> metadata;
     const serialization::ClusterIndexPartition* const index;
 
-    // One cached decoded chunk. Replaced when a different chunk is requested.
-    mutable DecodedChunk decodedChunk;
-    // Reusable buffer for chunk data that spans multiple stream buffers.
-    mutable velox::BufferPtr dataBuffer;
+    // Lazily-populated decoded chunks. Sized to numChunks() when
+    // pinIndex_=true (each slot indexed by chunkIndex, retained across
+    // lookups). Sized to 1 when pinIndex_=false (a single shared scratch
+    // slot, evicted on every different-chunk lookup). Each slot starts
+    // empty (data == nullptr) and is filled on first access.
+    mutable std::vector<DecodedChunk> decodedChunks;
 
-    IndexPartition(uint32_t id, std::unique_ptr<MetadataBuffer> metadata);
+    // Constructs the partition and allocates the decoded chunks vector.
+    // When pinIndex=true, allocates one slot per chunk for full caching;
+    // when false, allocates a single scratch slot that retains at most one
+    // decoded chunk.
+    IndexPartition(
+        uint32_t id,
+        std::unique_ptr<MetadataBuffer> metadata,
+        bool pinIndex);
 
     uint32_t numChunks() const {
       return index->chunk_keys()->size();
@@ -204,11 +211,6 @@ class ClusterIndex : public IndexLookup {
 
     velox::common::Region chunkStreamRegion(
         const ChunkLocation& chunkLocation) const;
-
-    // Ensures dataBuffer has at least the requested capacity.
-    // Only grows, never shrinks, to avoid repeated allocations.
-    char* ensureDataBuffer(uint32_t bytes, velox::memory::MemoryPool* pool)
-        const;
   };
 
   // Resolves an encoded key to a file-level row number within a partition.
@@ -267,21 +269,27 @@ class ClusterIndex : public IndexLookup {
   // Builds the flat LookupResult from scratchRanges_.
   LookupResult buildLookupResult(const LookupOptions& options) const;
 
-  // Binary searches chunk keys in the partition.
+  // Binary searches chunk keys in the partition. The returned ChunkLocation
+  // carries the chunkIndex for indexing into per-chunk arrays.
   ChunkLocation lookupChunk(
       const IndexPartition* partition,
       std::string_view encodedKey) const;
 
   // Finds the chunk containing the given partition-relative row via binary
-  // search on chunk_rows. Returns a ChunkLocation with the chunk's offset,
-  // size, and row offset within the partition.
+  // search on chunk_rows.
   ChunkLocation lookupChunk(
       const IndexPartition* partition,
       uint32_t partitionRow) const;
 
-  // Loads or returns cached decoded chunk for the given location.
-  // Reuses partition-level buffers to avoid repeated allocations.
-  const DecodedChunk& getDecodedChunk(
+  // Returns the decoded chunk for the given chunk location. When
+  // pinIndex_=true, lazily fills the per-chunk slot in
+  // IndexPartition::decodedChunks (indexed by chunkIndex) and returns a copy.
+  // When pinIndex_=false, uses a single shared scratch slot — a hit only
+  // when the requested chunk matches the cached chunkOffset, otherwise the
+  // slot is evicted and refilled. The returned DecodedChunk owns its
+  // underlying buffer via shared_ptr / BufferPtr so it is safe to use past
+  // the call.
+  DecodedChunk getDecodedChunk(
       const IndexPartition* partition,
       const ChunkLocation& chunkLocation) const;
 
@@ -324,6 +332,10 @@ class ClusterIndex : public IndexLookup {
   const std::shared_ptr<MetadataInput> metadataInput_;
   const std::shared_ptr<velox::dwio::common::BufferedInput> dataInput_;
   velox::memory::MemoryPool* const pool_;
+
+  // When true, every decoded chunk stays pinned in IndexPartition::
+  // decodedChunks. When false, decodedChunks holds at most one entry.
+  const bool pinIndex_;
 
   // --- Mutable state ---
 

--- a/dwio/nimble/index/ClusterIndexGroup.cpp
+++ b/dwio/nimble/index/ClusterIndexGroup.cpp
@@ -87,7 +87,7 @@ std::optional<ChunkLocation> ClusterIndexGroup::lookupChunk(
   // location at offset 0.
   const auto* chunkIndex = root->chunk_index();
   if (chunkIndex == nullptr) {
-    return ChunkLocation{0, 0, 0};
+    return ChunkLocation{0, 0, 0, 0};
   }
 
   // Get chunk counts to determine the search range for this stripe.
@@ -132,7 +132,11 @@ std::optional<ChunkLocation> ClusterIndexGroup::lookupChunk(
   // Return the found chunk location.
   const uint32_t rowOffset =
       chunkOffset == startChunkIndex ? 0 : chunkRows->Get(chunkOffset - 1);
-  return ChunkLocation{chunkOffsets->Get(chunkOffset), 0, rowOffset};
+  return ChunkLocation{
+      chunkOffset - startChunkIndex,
+      chunkOffsets->Get(chunkOffset),
+      0,
+      rowOffset};
 }
 
 velox::common::Region ClusterIndexGroup::keyStreamRegion(

--- a/dwio/nimble/index/IndexTypes.h
+++ b/dwio/nimble/index/IndexTypes.h
@@ -20,18 +20,31 @@
 namespace facebook::nimble::index {
 
 /// Represents the location of a chunk within a stream.
-/// Both offsets are relative to the containing unit:
+/// Offsets are relative to the containing unit:
 /// - For chunk index: relative to the stripe (stream start offset and stripe
 ///   start row).
 /// - For cluster index: relative to the index partition (key data blob offset
 ///   and partition start row).
+/// chunkIndex is the absolute position within the FlatBuffers array searched
+/// during lookup:
+/// - For chunk index: position in the stripe-scoped chunkRows array (offset
+///   by the number of chunks belonging to earlier streams in the stripe).
+/// - For cluster index: position in the partition-scoped chunk_keys array
+///   (equivalently, partition-relative since the array is per-partition);
+///   used to index into the partition's per-chunk cache.
 struct ChunkLocation {
+  uint32_t chunkIndex;
   uint32_t chunkOffset;
   uint32_t chunkSize;
   uint32_t rowOffset;
 
-  ChunkLocation(uint32_t _chunkOffset, uint32_t _chunkSize, uint32_t _rowOffset)
-      : chunkOffset(_chunkOffset),
+  ChunkLocation(
+      uint32_t _chunkIndex,
+      uint32_t _chunkOffset,
+      uint32_t _chunkSize,
+      uint32_t _rowOffset)
+      : chunkIndex(_chunkIndex),
+        chunkOffset(_chunkOffset),
         chunkSize(_chunkSize),
         rowOffset(_rowOffset) {}
 };

--- a/dwio/nimble/index/KeyChunkDecoder.cpp
+++ b/dwio/nimble/index/KeyChunkDecoder.cpp
@@ -49,6 +49,10 @@ std::shared_ptr<DecodedKeyChunk> decodeKeyChunk(
     result->dataStream = std::move(inputStream);
     chunkData = header;
   } else {
+    // Reuse the caller's buffer when it has sufficient capacity; otherwise
+    // allocate fresh and write it back into the slot. The destination buffer
+    // is appended to stringBuffers so the returned DecodedKeyChunk holds its
+    // own reference (co-owned with the caller's slot).
     if (dataBuffer == nullptr || dataBuffer->capacity() < dataLen) {
       dataBuffer = velox::AlignedBuffer::allocate<char>(dataLen, &pool);
     }
@@ -63,6 +67,7 @@ std::shared_ptr<DecodedKeyChunk> decodeKeyChunk(
       copied += toCopy;
     }
     chunkData = dest;
+    result->stringBuffers.push_back(dataBuffer);
   }
 
   auto* raw = result.get();

--- a/dwio/nimble/index/KeyChunkDecoder.h
+++ b/dwio/nimble/index/KeyChunkDecoder.h
@@ -41,10 +41,16 @@ struct DecodedKeyChunk {
 /// captures a pointer to the DecodedKeyChunk) remains valid when the caller
 /// moves or reassigns the shared_ptr.
 ///
-/// @param dataBuffer Reusable buffer for multi-buffer reads. When the data
-///        spans multiple stream buffers, this buffer is resized and reused
-///        instead of allocating a new one. The caller retains ownership and the
-///        buffer must outlive the returned DecodedKeyChunk.
+/// @param dataBuffer Caller-owned reuse slot for multi-buffer reads. When
+///        the existing buffer has sufficient capacity it is reused;
+///        otherwise a fresh buffer is allocated and written back into the
+///        slot. The destination buffer (reused or freshly allocated) is
+///        always appended to DecodedKeyChunk::stringBuffers, so the
+///        returned DecodedKeyChunk holds its own reference and the caller
+///        may independently reassign or destroy dataBuffer without
+///        affecting the returned DecodedKeyChunk. Callers that don't want
+///        cross-call reuse can pass a local BufferPtr that goes out of
+///        scope after the call.
 std::shared_ptr<DecodedKeyChunk> decodeKeyChunk(
     std::unique_ptr<velox::dwio::common::SeekableInputStream> inputStream,
     velox::memory::MemoryPool& pool,

--- a/dwio/nimble/index/tests/ChunkIndexTest.cpp
+++ b/dwio/nimble/index/tests/ChunkIndexTest.cpp
@@ -167,6 +167,65 @@ TEST_F(ChunkIndexTest, lookupChunkWithRowId) {
   NIMBLE_ASSERT_THROW(s11->lookupChunk(650), "beyond the last chunk");
 }
 
+TEST_F(ChunkIndexTest, lookupChunkPopulatesChunkIndex) {
+  // Single stripe, two streams. chunkIndex is the absolute position in the
+  // stripe's chunkRows FlatBuffers array — i.e., it is offset by the number
+  // of chunks belonging to earlier streams in the stripe.
+  std::vector<std::string> indexColumns = {"col1"};
+  std::string minKey = "aaa";
+  std::vector<Stripe> stripes = {
+      {.streams =
+           {// Stream 0: 3 chunks at rows {100, 250, 400}, offsets {0, 50, 120}
+            {.numChunks = 3,
+             .chunkRows = {100, 250, 400},
+             .chunkOffsets = {0, 50, 120}},
+            // Stream 1: 2 chunks at rows {150, 300}, offsets {0, 80}
+            {.numChunks = 2, .chunkRows = {150, 300}, .chunkOffsets = {0, 80}}},
+       .keyStream = {
+           .streamOffset = 0,
+           .streamSize = 100,
+           .stream = {.numChunks = 1, .chunkRows = {400}, .chunkOffsets = {0}},
+           .chunkKeys = {"bbb"}}}};
+  std::vector<int> stripeGroups = {1};
+
+  auto indexBuffers =
+      createTestClusterIndex(indexColumns, minKey, stripes, stripeGroups);
+  auto chunkIndex = createChunkIndex(indexBuffers, 0);
+  ASSERT_NE(chunkIndex, nullptr);
+
+  struct {
+    uint32_t streamId;
+    uint32_t rowId;
+    uint32_t expectedChunkIndex;
+  } testCases[] = {
+      // Stream 0 has startChunkOffset_ == 0. Cumulative row counts
+      // {100, 350, 750} → chunk 0 covers [0, 99], chunk 1 covers [100, 349],
+      // chunk 2 covers [350, 749]. Stripe-absolute chunkIndex == 0, 1, 2.
+      {0, 0, 0},
+      {0, 99, 0},
+      {0, 100, 1},
+      {0, 349, 1},
+      {0, 350, 2},
+      {0, 749, 2},
+      // Stream 1 has startChunkOffset_ == 3 (stream 0 contributed 3 chunks).
+      // Cumulative row counts {150, 450} → chunk 0 covers [0, 149], chunk 1
+      // covers [150, 449]. Stripe-absolute chunkIndex == 3, 4.
+      {1, 0, 3},
+      {1, 149, 3},
+      {1, 150, 4},
+      {1, 449, 4},
+  };
+
+  for (const auto& tc : testCases) {
+    SCOPED_TRACE(fmt::format("streamId {} rowId {}", tc.streamId, tc.rowId));
+    auto streamIndex = chunkIndex->createStreamIndex(
+        /*stripe=*/0, tc.streamId, /*streamSize=*/1000);
+    ASSERT_NE(streamIndex, nullptr);
+    const auto result = streamIndex->lookupChunk(tc.rowId);
+    EXPECT_EQ(result.chunkIndex, tc.expectedChunkIndex);
+  }
+}
+
 TEST_F(ChunkIndexTest, createStreamIndex) {
   std::vector<std::string> indexColumns = {"col1"};
   std::string minKey = "aaa";

--- a/dwio/nimble/index/tests/ClusterIndexTest.cpp
+++ b/dwio/nimble/index/tests/ClusterIndexTest.cpp
@@ -605,12 +605,14 @@ TEST_F(ClusterIndexTest, lookupWithKeyStreamMultiplePartitions) {
 }
 
 TEST_F(ClusterIndexTest, chunkLocation) {
-  ChunkLocation loc1{100, 50, 200};
+  ChunkLocation loc1{3, 100, 50, 200};
+  EXPECT_EQ(loc1.chunkIndex, 3);
   EXPECT_EQ(loc1.chunkOffset, 100);
   EXPECT_EQ(loc1.chunkSize, 50);
   EXPECT_EQ(loc1.rowOffset, 200);
 
-  ChunkLocation loc2{0, 0, 0};
+  ChunkLocation loc2{0, 0, 0, 0};
+  EXPECT_EQ(loc2.chunkIndex, 0);
   EXPECT_EQ(loc2.chunkOffset, 0);
   EXPECT_EQ(loc2.chunkSize, 0);
   EXPECT_EQ(loc2.rowOffset, 0);
@@ -1319,6 +1321,11 @@ TEST_F(ClusterIndexTest, indexDataReuseWithSameReader) {
     TabletReader::Options options;
     options.loadClusterIndex = true;
     options.cacheIndex = testCase.cacheIndex;
+    // pinIndex=true so the ClusterIndex retains decoded chunks across
+    // lookups. Without pinning, !pin decodes via the scratch slot every
+    // call and would always issue fresh dataInput_->read() calls (modulo
+    // AsyncDataCache hits in the cacheIndex=true + provideCache case).
+    options.pinIndex = true;
     options.ioOptions.emplace(pool_.get())
         .setMetadataIoStats(metadataIoStats_)
         .setIndexIoStats(indexIoStats_);
@@ -1502,6 +1509,118 @@ TEST_F(ClusterIndexTest, indexDataReuseCrossReaders) {
   }
 
   cache->shutdown();
+}
+
+// Writes a tablet with three single-key stripes that all fall into the same
+// partition (no mid-write stripe-group flush), producing one partition with
+// three key chunks.
+namespace {
+std::shared_ptr<velox::ReadFile> writeThreeChunkPartitionFile(
+    velox::memory::MemoryPool& pool,
+    std::string& fileBacking) {
+  velox::InMemoryWriteFile writeFile(&fileBacking);
+  Buffer buffer{pool};
+
+  TestClusterIndexMetadataWriter indexHelper(
+      pool,
+      {"col1"},
+      {SortOrder{.ascending = true}},
+      /*enforceKeyOrder=*/true);
+
+  auto tabletWriter = TabletWriter::create(
+      &writeFile,
+      pool,
+      {
+          .metadataFlushThreshold = 1024 * 1024 * 1024,
+          .streamDeduplicationEnabled = false,
+          .enableChunkIndex = true,
+          .stripeGroupFlushCallback =
+              indexHelper.createStripeGroupFlushCallback(),
+          .closeCallback = indexHelper.createCloseCallback(),
+      });
+
+  const std::vector<std::string> keys = {"bbb", "ddd", "fff"};
+  for (const auto& key : keys) {
+    auto* pos = buffer.reserve(50);
+    std::memset(pos, 'A', 50);
+    std::vector<nimble::Stream> tabletStreams;
+    tabletStreams.push_back(
+        {.offset = 0, .chunks = {{.rowCount = 100, .content = {{pos, 50}}}}});
+    indexHelper.addStripe({{.rowCount = 100, .key = key}});
+    tabletWriter->writeStripe(100, std::move(tabletStreams));
+  }
+  tabletWriter->close();
+  writeFile.close();
+
+  return std::make_shared<velox::InMemoryReadFile>(fileBacking);
+}
+} // namespace
+
+TEST_F(ClusterIndexTest, pinIndexEnabledRetainsChunks) {
+  std::string file;
+  auto readFile = writeThreeChunkPartitionFile(*pool_, file);
+
+  TabletReader::Options options;
+  options.loadClusterIndex = true;
+  options.pinIndex = true;
+  options.ioOptions.emplace(pool_.get())
+      .setMetadataIoStats(metadataIoStats_)
+      .setIndexIoStats(indexIoStats_);
+
+  auto reader = TabletReader::create(readFile, pool_.get(), options);
+  ASSERT_NE(reader->clusterIndex(), nullptr);
+  ClusterIndexTestHelper helper(reader->clusterIndex());
+
+  reader->clusterIndex()->lookup(makeRangeScanRequest("bbb"));
+  EXPECT_EQ(helper.decodedChunkCount(0), 1);
+  const auto bytesAfterChunk0 = indexIoStats_->rawBytesRead();
+  EXPECT_GT(bytesAfterChunk0, 0);
+
+  reader->clusterIndex()->lookup(makeRangeScanRequest("fff"));
+  EXPECT_EQ(helper.decodedChunkCount(0), 2);
+
+  reader->clusterIndex()->lookup(makeRangeScanRequest("ddd"));
+  EXPECT_EQ(helper.decodedChunkCount(0), 3);
+
+  const auto bytesAfterAllChunks = indexIoStats_->rawBytesRead();
+  reader->clusterIndex()->lookup(makeRangeScanRequest("bbb"));
+  EXPECT_EQ(helper.decodedChunkCount(0), 3);
+  EXPECT_EQ(indexIoStats_->rawBytesRead(), bytesAfterAllChunks)
+      << "Re-lookup of pinned chunk must not trigger new index IO";
+}
+
+TEST_F(ClusterIndexTest, pinIndexDisabledDoesNotRetainChunks) {
+  std::string file;
+  auto readFile = writeThreeChunkPartitionFile(*pool_, file);
+
+  TabletReader::Options options;
+  options.loadClusterIndex = true;
+  options.pinIndex = false;
+  options.ioOptions.emplace(pool_.get())
+      .setMetadataIoStats(metadataIoStats_)
+      .setIndexIoStats(indexIoStats_);
+
+  auto reader = TabletReader::create(readFile, pool_.get(), options);
+  ASSERT_NE(reader->clusterIndex(), nullptr);
+  ClusterIndexTestHelper helper(reader->clusterIndex());
+
+  // Unpinned decodes share a single scratch slot — at most one decoded
+  // chunk is retained at a time, evicted whenever a different chunk is
+  // requested. Each lookup that lands on a different chunk issues fresh IO.
+  const auto bytesBefore = indexIoStats_->rawBytesRead();
+  reader->clusterIndex()->lookup(makeRangeScanRequest("bbb"));
+  EXPECT_EQ(helper.decodedChunkCount(0), 1);
+  const auto bytesAfter1 = indexIoStats_->rawBytesRead();
+  EXPECT_GT(bytesAfter1, bytesBefore);
+
+  reader->clusterIndex()->lookup(makeRangeScanRequest("fff"));
+  EXPECT_EQ(helper.decodedChunkCount(0), 1);
+  const auto bytesAfter2 = indexIoStats_->rawBytesRead();
+  EXPECT_GT(bytesAfter2, bytesAfter1);
+
+  reader->clusterIndex()->lookup(makeRangeScanRequest("ddd"));
+  EXPECT_EQ(helper.decodedChunkCount(0), 1);
+  EXPECT_GT(indexIoStats_->rawBytesRead(), bytesAfter2);
 }
 
 } // namespace

--- a/dwio/nimble/index/tests/ClusterIndexTestUtils.h
+++ b/dwio/nimble/index/tests/ClusterIndexTestUtils.h
@@ -16,6 +16,7 @@
 
 #pragma once
 
+#include <algorithm>
 #include <functional>
 #include <memory>
 #include <string>
@@ -171,12 +172,14 @@ class ClusterIndexTestHelper {
       Section rootSection,
       velox::memory::MemoryPool* pool,
       std::shared_ptr<MetadataInput> metadataInput,
-      std::shared_ptr<velox::dwio::common::BufferedInput> dataInput) {
+      std::shared_ptr<velox::dwio::common::BufferedInput> dataInput,
+      bool pinIndex = false) {
     return std::unique_ptr<ClusterIndex>(new ClusterIndex(
         std::move(rootSection),
-        pool,
         std::move(metadataInput),
-        std::move(dataInput)));
+        std::move(dataInput),
+        pinIndex,
+        pool));
   }
 
   explicit ClusterIndexTestHelper(const ClusterIndex* clusterIndex)
@@ -207,6 +210,19 @@ class ClusterIndexTestHelper {
     return velox::common::Region{
         partition->index->key_stream_offset(),
         partition->index->key_stream_size()};
+  }
+
+  /// Returns the number of decoded chunks currently cached for the partition.
+  /// Counts populated slots in the per-chunk vector. With pinIndex=true the
+  /// vector has numChunks slots, one per chunk. With pinIndex=false the
+  /// vector has a single shared scratch slot, so the count is at most 1.
+  size_t decodedChunkCount(uint32_t partitionIndex) const {
+    const auto& decodedChunks =
+        clusterIndex_->loadPartition(partitionIndex)->decodedChunks;
+    return std::count_if(
+        decodedChunks.begin(), decodedChunks.end(), [](const auto& c) {
+          return c.data != nullptr;
+        });
   }
 
  private:


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebookincubator/velox/pull/17544


Diff D105465252 added `IndexLookup::Options::pinIndex` but only `DenseIndexRegistry` honored it. This wires `pinIndex` into `ClusterIndex`'s per-partition `DecodedChunk` cache so callers can elect to keep every decoded key chunk in memory.

`IndexPartition`'s single-slot `decodedChunk` is replaced by a `folly::F14NodeMap<uint32_t, DecodedChunk>` keyed by `chunkOffset`. Each entry owns its own `velox::BufferPtr dataBuffer` because `decodeKeyChunk()` resizes the buffer in place — a shared buffer would corrupt previously pinned encodings. When `pinIndex_` is true the map grows unbounded; when false it is cleared before each insert (size cap of 1, preserving the previous single-slot behavior).

The unused `ensureDataBuffer` helper is removed.

### Test plan
buck2 test //dwio/nimble/index/tests/... //dwio/nimble/tablet/tests:tests — 473 pass, 0 fail.

New tests in `ClusterIndexTest.cpp`:
- `pinIndexEnabledRetainsChunks` — three lookups touching different chunks in one partition leave `decodedChunks.size() == 3`; re-lookup of an already-decoded chunk triggers no new index IO.
- `pinIndexDisabledEvictsOnDifferentChunk` — the cap-at-1 single-slot cache keeps `decodedChunks.size() == 1` after any number of lookups, evicting the previous chunk on each different-chunk load.

`arc f` and `arc lint` clean.

Reviewed By: xiaoxmeng

Differential Revision: D105741977


