### PR TITLE
feat: Add preloadIndex option to ClusterIndex for eager metadata + key-stream loading

### DIFF
--- a/dwio/nimble/index/ClusterIndex.cpp
+++ b/dwio/nimble/index/ClusterIndex.cpp
@@ -17,6 +17,7 @@
 #include "dwio/nimble/index/ClusterIndex.h"
 
 #include <algorithm>
+#include <numeric>
 
 #include "dwio/nimble/common/ChunkHeader.h"
 #include "dwio/nimble/common/Exceptions.h"
@@ -149,6 +150,7 @@ std::unique_ptr<ClusterIndex> ClusterIndex::create(
       createIndexMetadataInput(options),
       createIndexDataInput(options),
       options.pinIndex,
+      options.preloadIndex,
       pool));
 }
 
@@ -157,6 +159,7 @@ ClusterIndex::ClusterIndex(
     std::shared_ptr<MetadataInput> metadataInput,
     std::shared_ptr<velox::dwio::common::BufferedInput> dataInput,
     bool pinIndex,
+    bool preloadIndex,
     velox::memory::MemoryPool* pool)
     : IndexLookup{IndexType::Cluster},
       rootSection_{std::move(rootSection)},
@@ -182,6 +185,74 @@ ClusterIndex::ClusterIndex(
   NIMBLE_CHECK_NOT_NULL(metadataInput_);
   NIMBLE_CHECK_NOT_NULL(dataInput_);
   NIMBLE_CHECK_NOT_NULL(pool_);
+  if (!preloadIndex) {
+    return;
+  }
+  NIMBLE_CHECK(
+      pinIndex_,
+      "preloadIndex requires pinIndex=true to retain preloaded chunks");
+  this->preloadIndex();
+}
+
+void ClusterIndex::preloadIndex() {
+  NIMBLE_CHECK_GT(numPartitions_, 0);
+  std::vector<uint32_t> partitionIds(numPartitions_);
+  std::iota(partitionIds.begin(), partitionIds.end(), 0);
+  loadPartitions(partitionIds);
+
+  for (uint32_t partitionId = 0; partitionId < numPartitions_; ++partitionId) {
+    loadPartitionKeyStream(partitions_[partitionId].get());
+  }
+}
+
+void ClusterIndex::loadPartitionKeyStream(IndexPartition* partition) const {
+  const uint32_t numChunks = partition->numChunks();
+  NIMBLE_CHECK_GT(numChunks, 0, "Partition {} has no chunks", partition->id);
+  std::vector<std::unique_ptr<velox::dwio::common::SeekableInputStream>>
+      streams;
+  streams.reserve(numChunks);
+  for (uint32_t chunkIdx = 0; chunkIdx < numChunks; ++chunkIdx) {
+    const ChunkLocation chunkLocation{
+        chunkIdx,
+        partition->chunkOffset(chunkIdx),
+        partition->chunkSize(chunkIdx),
+        partition->rowOffset(chunkIdx)};
+    streams.push_back(
+        dataInput_->enqueue(partition->chunkStreamRegion(chunkLocation)));
+  }
+  dataInput_->load(velox::dwio::common::LogType::GROUP_INDEX);
+
+  for (uint32_t chunkIdx = 0; chunkIdx < numChunks; ++chunkIdx) {
+    auto& decodedChunk = partition->decodedChunks[chunkIdx];
+    decodedChunk.chunkOffset = partition->chunkOffset(chunkIdx);
+    // Per-iteration scratch so the previous chunk's buffer isn't aliased
+    // and overwritten if the next chunk fits in its capacity.
+    velox::BufferPtr scratch;
+    decodedChunk.data =
+        decodeKeyChunk(std::move(streams[chunkIdx]), *pool_, scratch);
+    NIMBLE_CHECK_EQ(
+        decodedChunk.data->encoding->dataType(),
+        DataType::String,
+        "Expected String data type");
+  }
+}
+
+void ClusterIndex::loadPartitions(
+    std::span<const uint32_t> partitionIds) const {
+  NIMBLE_CHECK(!partitionIds.empty(), "partitionIds must not be empty");
+  std::vector<MetadataSection> sections;
+  sections.reserve(partitionIds.size());
+  for (uint32_t id : partitionIds) {
+    NIMBLE_CHECK_LT(id, numPartitions_);
+    NIMBLE_CHECK_NULL(partitions_[id]);
+    sections.push_back(partitionSection(id));
+  }
+  auto buffers = metadataInput_->load(
+      std::span<const MetadataSection>{sections.data(), sections.size()});
+  NIMBLE_CHECK_EQ(buffers.size(), partitionIds.size());
+  for (size_t i = 0; i < partitionIds.size(); ++i) {
+    initializePartition(partitionIds[i], std::move(*buffers[i]));
+  }
 }
 
 std::optional<uint32_t> ClusterIndex::lookupPartition(
@@ -413,20 +484,26 @@ velox::common::Region ClusterIndex::IndexPartition::chunkStreamRegion(
   return velox::common::Region{offset, chunkLocation.chunkSize};
 }
 
+void ClusterIndex::initializePartition(
+    uint32_t partitionId,
+    MetadataBuffer&& buffer) const {
+  NIMBLE_CHECK_NULL(partitions_[partitionId]);
+  partitions_[partitionId] = std::make_unique<IndexPartition>(
+      partitionId,
+      std::make_unique<MetadataBuffer>(std::move(buffer)),
+      pinIndex_);
+}
+
 const ClusterIndex::IndexPartition* ClusterIndex::loadPartition(
     uint32_t partitionId) const {
   NIMBLE_CHECK_LT(partitionId, numPartitions_);
-  auto& partition = partitions_[partitionId];
-  if (partition == nullptr) {
+  if (partitions_[partitionId] == nullptr) {
     const auto section = partitionSection(partitionId);
     auto results = metadataInput_->load({&section, 1});
     NIMBLE_CHECK_EQ(results.size(), 1);
-    partition = std::make_unique<IndexPartition>(
-        partitionId,
-        std::make_unique<MetadataBuffer>(std::move(*results.front())),
-        pinIndex_);
+    initializePartition(partitionId, std::move(*results.front()));
   }
-  return partition.get();
+  return partitions_[partitionId].get();
 }
 
 ChunkLocation ClusterIndex::lookupChunk(

--- a/dwio/nimble/index/ClusterIndex.h
+++ b/dwio/nimble/index/ClusterIndex.h
@@ -18,6 +18,7 @@
 
 #include <functional>
 #include <memory>
+#include <span>
 #include <string_view>
 #include <vector>
 
@@ -152,7 +153,15 @@ class ClusterIndex : public IndexLookup {
       std::shared_ptr<MetadataInput> metadataInput,
       std::shared_ptr<velox::dwio::common::BufferedInput> dataInput,
       bool pinIndex,
+      bool preloadIndex,
       velox::memory::MemoryPool* pool);
+
+  // Eagerly loads all partition metadata via a single coalesced metadata IO,
+  // then decodes each partition's key-stream chunks via one coalesced data
+  // IO per partition. After this returns, subsequent lookups against any
+  // partition/chunk hit pure-memory state (assuming pinIndex_=true, which is
+  // enforced).
+  void preloadIndex();
 
   // Cached decoded chunk. The DecodedKeyChunk owns its own backing buffer
   // (decodeKeyChunk appends it to DecodedKeyChunk::stringBuffers when no
@@ -305,6 +314,21 @@ class ClusterIndex : public IndexLookup {
 
   // Returns the partition, loading on demand if needed. Never evicted.
   const IndexPartition* loadPartition(uint32_t partitionId) const;
+
+  // Batch-loads the metadata for the given partitionIds via a single
+  // coalesced IO. Caller guarantees each id is < numPartitions_ and not
+  // already loaded. Used by preloadIndex().
+  void loadPartitions(std::span<const uint32_t> partitionIds) const;
+
+  // Loads and decodes all key-stream chunks for a single partition via one
+  // coalesced data IO. Populates partition->decodedChunks. Called per
+  // partition from preloadIndex().
+  void loadPartitionKeyStream(IndexPartition* partition) const;
+
+  // Constructs IndexPartition for partitionId from the given metadata buffer
+  // and (when pinIndex_=true) pre-sizes its decodedChunks vector. Shared by
+  // loadPartition() (single IO) and loadPartitions() (batched IO).
+  void initializePartition(uint32_t partitionId, MetadataBuffer&& buffer) const;
 
   const Section rootSection_;
   const serialization::ClusterIndex* const indexRoot_;

--- a/dwio/nimble/index/IndexLookup.cpp
+++ b/dwio/nimble/index/IndexLookup.cpp
@@ -38,6 +38,9 @@ void IndexLookup::Options::validate() const {
         static_cast<const void*>(fileHandle->file.get()),
         "file and fileHandle->file must point to the same file");
   }
+  NIMBLE_USER_CHECK(
+      !preloadIndex || pinIndex,
+      "preloadIndex requires pinIndex=true to retain preloaded chunks");
 }
 
 std::shared_ptr<MetadataInput> createIndexMetadataInput(

--- a/dwio/nimble/index/IndexLookup.h
+++ b/dwio/nimble/index/IndexLookup.h
@@ -95,6 +95,12 @@ class IndexLookup {
     /// references so they are never evicted.
     bool pinIndex{false};
 
+    /// If true, eagerly loads all per-partition metadata and decodes all
+    /// per-partition key streams when the index is constructed. Requires
+    /// pinIndex=true; otherwise preloaded chunks would be evicted on the
+    /// first lookup.
+    bool preloadIndex{false};
+
     /// Validates options consistency.
     void validate() const;
   };

--- a/dwio/nimble/index/tests/ClusterIndexTest.cpp
+++ b/dwio/nimble/index/tests/ClusterIndexTest.cpp
@@ -1623,5 +1623,87 @@ TEST_F(ClusterIndexTest, pinIndexDisabledDoesNotRetainChunks) {
   EXPECT_GT(indexIoStats_->rawBytesRead(), bytesAfter2);
 }
 
+TEST_F(ClusterIndexTest, preloadIndexDecodesAllChunksAtConstruction) {
+  std::string file;
+  auto readFile = writeThreeChunkPartitionFile(*pool_, file);
+
+  TabletReader::Options options;
+  options.loadClusterIndex = true;
+  options.preloadIndex = true;
+  options.ioOptions.emplace(pool_.get())
+      .setMetadataIoStats(metadataIoStats_)
+      .setIndexIoStats(indexIoStats_);
+
+  auto reader = TabletReader::create(readFile, pool_.get(), options);
+  ASSERT_NE(reader->clusterIndex(), nullptr);
+  ClusterIndexTestHelper helper(reader->clusterIndex());
+
+  // All chunks must be decoded at construction time, before any lookup runs.
+  EXPECT_EQ(helper.decodedChunkCount(0), 3);
+  const auto bytesAfterPreload = indexIoStats_->rawBytesRead();
+  EXPECT_GT(bytesAfterPreload, 0)
+      << "Preload should have triggered key-stream IO";
+
+  // Subsequent lookups across all three chunks must not trigger any further
+  // index data IO.
+  reader->clusterIndex()->lookup(makeRangeScanRequest("bbb"));
+  reader->clusterIndex()->lookup(makeRangeScanRequest("ddd"));
+  reader->clusterIndex()->lookup(makeRangeScanRequest("fff"));
+  EXPECT_EQ(helper.decodedChunkCount(0), 3);
+  EXPECT_EQ(indexIoStats_->rawBytesRead(), bytesAfterPreload)
+      << "Lookups after preload must not trigger additional index IO";
+}
+
+TEST_F(ClusterIndexTest, preloadIndexRequiresPinIndex) {
+  // IndexLookup::Options::validate() must reject preloadIndex=true when
+  // pinIndex=false, because non-pinned chunks would be evicted on first
+  // lookup, defeating the purpose of preloading.
+  auto readFile = std::make_shared<velox::InMemoryReadFile>(std::string{});
+  velox::io::ReaderOptions ioOpts(pool_.get());
+  ioOpts.setIndexIoStats(indexIoStats_);
+  IndexLookup::Options opts{
+      .file = readFile,
+      .ioOptions = &ioOpts,
+      .pinIndex = false,
+      .preloadIndex = true,
+  };
+  EXPECT_THROW(opts.validate(), NimbleUserError);
+}
+
+TEST_F(ClusterIndexTest, preloadIndexAutoPromotesPinIndex) {
+  // At the TabletReader::Options level, setting preloadIndex=true together
+  // with pinIndex=false (apparently conflicting) must auto-promote pinIndex
+  // to true rather than failing — preloaded chunks must be retained for the
+  // preload to have any effect.
+  std::string file;
+  auto readFile = writeThreeChunkPartitionFile(*pool_, file);
+
+  TabletReader::Options options;
+  options.loadClusterIndex = true;
+  options.preloadIndex = true;
+  options.pinIndex = false; // intentionally conflicting; should be promoted.
+  options.ioOptions.emplace(pool_.get())
+      .setMetadataIoStats(metadataIoStats_)
+      .setIndexIoStats(indexIoStats_);
+
+  // Construction must succeed (no throw) despite the apparent conflict.
+  auto reader = TabletReader::create(readFile, pool_.get(), options);
+  ASSERT_NE(reader->clusterIndex(), nullptr);
+  ClusterIndexTestHelper helper(reader->clusterIndex());
+
+  // All chunks must be decoded and retained — proves pinIndex was promoted
+  // (otherwise decodedChunks would be capped at 1 entry).
+  EXPECT_EQ(helper.decodedChunkCount(0), 3);
+  const auto bytesAfterPreload = indexIoStats_->rawBytesRead();
+
+  // Lookups across all three chunks must not trigger additional index IO,
+  // confirming the chunks are pinned (not evicted between lookups).
+  reader->clusterIndex()->lookup(makeRangeScanRequest("bbb"));
+  reader->clusterIndex()->lookup(makeRangeScanRequest("ddd"));
+  reader->clusterIndex()->lookup(makeRangeScanRequest("fff"));
+  EXPECT_EQ(helper.decodedChunkCount(0), 3);
+  EXPECT_EQ(indexIoStats_->rawBytesRead(), bytesAfterPreload);
+}
+
 } // namespace
 } // namespace facebook::nimble::index::test

--- a/dwio/nimble/index/tests/ClusterIndexTestUtils.h
+++ b/dwio/nimble/index/tests/ClusterIndexTestUtils.h
@@ -173,12 +173,14 @@ class ClusterIndexTestHelper {
       velox::memory::MemoryPool* pool,
       std::shared_ptr<MetadataInput> metadataInput,
       std::shared_ptr<velox::dwio::common::BufferedInput> dataInput,
-      bool pinIndex = false) {
+      bool pinIndex = false,
+      bool preloadIndex = false) {
     return std::unique_ptr<ClusterIndex>(new ClusterIndex(
         std::move(rootSection),
         std::move(metadataInput),
         std::move(dataInput),
         pinIndex,
+        preloadIndex,
         pool));
   }
 

--- a/dwio/nimble/tablet/TabletReader.cpp
+++ b/dwio/nimble/tablet/TabletReader.cpp
@@ -88,6 +88,7 @@ TabletReader::Options TabletReader::configureOptions(
   if (tabletOptions.loadClusterIndex) {
     tabletOptions.preloadOptionalSections.emplace_back(kClusterIndexSection);
   }
+  tabletOptions.preloadIndex = options.preloadIndex();
   tabletOptions.loadChunkIndex = options.loadChunkIndex();
   if (tabletOptions.loadChunkIndex) {
     tabletOptions.preloadOptionalSections.emplace_back(kChunkIndexSection);
@@ -249,11 +250,14 @@ TabletReader::TabletReader(
           NIMBLE_CHECK_NOT_NULL(options.cache, "cacheIndex requires cache");
         }
         return index::IndexLookup::Options{
-            file_,
-            &ioOptions_,
-            cacheEnabled ? options.fileHandle : nullptr,
-            cacheEnabled ? options.cache : nullptr,
-            options.pinIndex};
+            .file = file_,
+            .ioOptions = &ioOptions_,
+            .fileHandle = cacheEnabled ? options.fileHandle : nullptr,
+            .cache = cacheEnabled ? options.cache : nullptr,
+            // preloadIndex requires pinIndex; auto-promote so the caller only
+            // needs to flip one knob.
+            .pinIndex = options.pinIndex || options.preloadIndex,
+            .preloadIndex = options.preloadIndex};
       }()},
       metadataInput_{[&]() {
         MetadataInput::Options metadataOptions{

--- a/dwio/nimble/tablet/TabletReader.h
+++ b/dwio/nimble/tablet/TabletReader.h
@@ -162,6 +162,13 @@ class TabletReader {
     /// Whether to load the cluster index during initialization. Default false.
     bool loadClusterIndex{false};
 
+    /// Whether to eagerly preload all per-partition metadata and decode all
+    /// per-partition key streams during ClusterIndex construction. Only
+    /// effective when loadClusterIndex is also true. Implies pinIndex=true
+    /// (chunks would otherwise be evicted before any lookup runs).
+    /// Default false.
+    bool preloadIndex{false};
+
     /// Whether to load the chunk index during initialization. Default true.
     bool loadChunkIndex{true};
 

--- a/dwio/nimble/tablet/tests/TabletTest.cpp
+++ b/dwio/nimble/tablet/tests/TabletTest.cpp
@@ -3639,6 +3639,74 @@ TEST_P(TabletWithIndexTest, loadClusterIndex) {
   }
 }
 
+TEST_P(TabletWithIndexTest, preloadClusterIndex) {
+  std::string file;
+  velox::InMemoryWriteFile writeFile(&file);
+
+  nimble::index::test::TestClusterIndexMetadataWriter indexHelper(
+      *pool_,
+      {"col1"},
+      {SortOrder{.ascending = true}},
+      /*enforceKeyOrder=*/true);
+
+  auto tabletWriter = nimble::TabletWriter::create(
+      &writeFile,
+      *pool_,
+      {
+          .metadataFlushThreshold = 1024 * 1024 * 1024,
+          .streamDeduplicationEnabled = false,
+          .enableChunkIndex = true,
+          .stripeGroupFlushCallback =
+              indexHelper.createStripeGroupFlushCallback(),
+          .closeCallback = indexHelper.createCloseCallback(),
+      });
+
+  nimble::Buffer buffer{*pool_};
+  auto streams = createStreams(
+      buffer, {{.offset = 0, .chunks = {{.rowCount = 100, .size = 10}}}});
+  indexHelper.addStripe({{.rowCount = 100, .key = "bbb"}});
+  tabletWriter->writeStripe(100, std::move(streams));
+  tabletWriter->close();
+
+  auto readFile = std::make_shared<velox::InMemoryReadFile>(file);
+
+  // Case 1: preloadIndex=true with loadClusterIndex=true forces eager
+  // key-stream IO at construction time. Subsequent lookups must perform zero
+  // additional index IO.
+  {
+    const auto indexBytesReadBefore = indexIoStats_->rawBytesRead();
+    nimble::TabletReader::Options options;
+    options.loadClusterIndex = true;
+    options.preloadIndex = true;
+    auto tablet = TabletTest::createTabletReader(readFile, options);
+    ASSERT_NE(tablet->clusterIndex(), nullptr);
+    const auto indexBytesAfterOpen = indexIoStats_->rawBytesRead();
+    EXPECT_GT(indexBytesAfterOpen, indexBytesReadBefore)
+        << "preloadIndex must trigger key-stream IO during open";
+
+    velox::serializer::EncodedKeyBounds bounds{
+        .lowerKey = std::string("bbb"), .upperKey = std::nullopt};
+    tablet->clusterIndex()->lookup(
+        nimble::index::IndexLookup::LookupRequest::rangeScan({bounds}));
+    EXPECT_EQ(indexIoStats_->rawBytesRead(), indexBytesAfterOpen)
+        << "Lookup after preload must not trigger additional index IO";
+  }
+
+  // Case 2: preloadIndex=true with loadClusterIndex=false is a no-op for
+  // the index (the cluster index section is not even loaded).
+  {
+    const auto metadataBytesReadBefore = metadataIoStats_->rawBytesRead();
+    const auto indexBytesReadBefore = indexIoStats_->rawBytesRead();
+    nimble::TabletReader::Options options;
+    options.loadClusterIndex = false;
+    options.preloadIndex = true;
+    auto tablet = TabletTest::createTabletReader(readFile, options);
+    EXPECT_EQ(tablet->clusterIndex(), nullptr);
+    EXPECT_EQ(metadataIoStats_->rawBytesRead(), metadataBytesReadBefore);
+    EXPECT_EQ(indexIoStats_->rawBytesRead(), indexBytesReadBefore);
+  }
+}
+
 TEST_P(TabletWithIndexTest, loadClusterIndexMissingIoStats) {
   std::string file;
   velox::InMemoryWriteFile writeFile(&file);


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebookincubator/velox/pull/17566


Add a new `preloadIndex` option to `velox::dwio::common::ReaderOptions` that, when set together with `loadClusterIndex`, eagerly loads all per-partition metadata and decodes all per-partition key streams at file-open time. After preload, every subsequent `lookup()` / `keyAtRow()` call hits only in-memory state — no further IO on the index.

Today the cluster index is fully lazy: the first lookup against each partition triggers a small metadata IO, and the first lookup against each chunk triggers another IO + decode. This produces irregular tail-latency spikes and prevents the index from being fully memory-resident even when `pinIndex=true` is set (`pinIndex` only retains chunks *after* they've been lazy-touched).

Implementation:
- `ReaderOptions::setPreloadIndex(bool)` → `TabletReader::Options::preloadIndex` → `IndexLookup::Options::preloadIndex` → consumed by `ClusterIndex` ctor.
- `ClusterIndex::preloadIndex()` does two batched IOs: (1) `metadataInput_->load(std::span<MetadataSection>)` for all partition metadata in one coalesced call, then (2) loops `dataInput_->enqueue(region)` for every chunk across all partitions followed by a single `dataInput_->load(LogType::GROUP_INDEX)` for coalesced IO, then decodes each chunk into the existing `IndexPartition::decodedChunks` map. No new data structures.
- Auto-promotes `pinIndex=true` when `preloadIndex=true` so the caller only needs to flip one knob. `IndexLookup::Options::validate()` rejects `preloadIndex=true && pinIndex=false` to guard against direct misuse.

No new public data structure is introduced — `IndexPartition::decodedChunks` already stores decoded chunks, and `DecodedKeyChunk::encoding->get(rowInChunk, &valueView)` gives O(1) random access.

This is the core API. Wiring `setPreloadIndex(true)` into `FileIndexReader.cpp` and `NimbleIndexBenchmarkReader.cpp` is a follow-up.

Reviewed By: xiaoxmeng

Differential Revision: D105779932


