### PR TITLE
feat: Implement ConstantEncoding::get for row-level value lookup

### DIFF
--- a/dwio/nimble/encodings/ConstantEncoding.h
+++ b/dwio/nimble/encodings/ConstantEncoding.h
@@ -55,6 +55,10 @@ class ConstantEncodingBase
     }
   }
 
+  void get(uint32_t /* row */, void* buffer) final {
+    *static_cast<physicalType*>(buffer) = value_;
+  }
+
   void materializeBoolsAsBits(
       uint32_t /*rowCount*/,
       uint64_t* /*buffer*/,

--- a/dwio/nimble/encodings/common/Encoding.h
+++ b/dwio/nimble/encodings/common/Encoding.h
@@ -167,7 +167,7 @@ class Encoding {
   }
 
   /// Materializes the value at the given row index into buffer.
-  /// Only supported by Trivial and Prefix encodings.
+  /// Only supported by Constant, Trivial, and Prefix encodings.
   virtual void get(uint32_t /*row*/, void* /*buffer*/) {
     NIMBLE_NOT_IMPLEMENTED("get is not supported by this encoding type");
   }

--- a/dwio/nimble/encodings/tests/ConstantEncodingTest.cpp
+++ b/dwio/nimble/encodings/tests/ConstantEncodingTest.cpp
@@ -196,3 +196,41 @@ TYPED_TEST(ConstantEncodingTest, NonConstantFailure) {
     }
   }
 }
+
+TYPED_TEST(ConstantEncodingTest, getReturnsConstantValueAtAnyRow) {
+  using D = typename TypeParam::data_type;
+  const nimble::Encoding::Options options{
+      .useVarintRowCount = TypeParam::useVarint};
+
+  auto valueGroups = this->template prepareValues<D>();
+  std::vector<velox::BufferPtr> newStringBuffers;
+  const auto stringBufferFactory = [&](uint32_t totalLength) {
+    auto& buffer = newStringBuffers.emplace_back(
+        velox::AlignedBuffer::allocate<char>(totalLength, this->pool_.get()));
+    return buffer->template asMutable<void>();
+  };
+  for (const auto& values : valueGroups) {
+    auto encoding =
+        nimble::test::Encoder<nimble::ConstantEncoding<D>>::createEncoding(
+            *this->buffer_,
+            values,
+            stringBufferFactory,
+            nimble::CompressionType::Uncompressed,
+            options);
+
+    // Probe first, middle, and last rows. The encoding stores a single value
+    // shared by all rows, so every probe must return the same constant.
+    const uint32_t rowCount = values.size();
+    std::vector<uint32_t> probeRows = {0};
+    if (rowCount >= 2) {
+      probeRows.push_back(rowCount / 2);
+      probeRows.push_back(rowCount - 1);
+    }
+    for (const auto row : probeRows) {
+      SCOPED_TRACE("row=" + std::to_string(row));
+      D result{};
+      encoding->get(row, &result);
+      EXPECT_TRUE(nimble::NimbleCompare<D>::equals(result, values[0]));
+    }
+  }
+}


### PR DESCRIPTION
Summary:
Adds row-level random-access via Encoding::get(uint32_t row, void* buffer) to ConstantEncoding<T>. Since ConstantEncoding stores a single value shared by all rows, the implementation is a one-line memcpy that ignores the row argument.

This brings ConstantEncoding to parity with Prefix and Trivial encodings, which already implement get() (added in D105225824 to support ClusterIndex::keyAtRow). The base Encoding::get default still throws NIMBLE_NOT_IMPLEMENTED for encodings that have not implemented row-level random access (RLE, Dictionary, Delta, MainlyConstant, etc.).

This diff is encoding-layer only; it does not change which encodings any caller accepts. Whether to allow Constant in a particular call site (e.g. ClusterIndex key stream) is a separate decision and left for follow-up diffs as concrete needs arise.

Reviewed By: xiaoxmeng

Differential Revision: D105856233


