### PR TITLE
refactor: Move keyAtRow from IndexLookup to ClusterIndex only (#760)

### DIFF
--- a/dwio/nimble/index/ClusterIndex.h
+++ b/dwio/nimble/index/ClusterIndex.h
@@ -101,7 +101,9 @@ class ClusterIndex : public IndexLookup {
   /// Returns the encoded key at the given file-level row position.
   /// Requires loadData to have been provided at construction.
   /// Used to compute resume keys when lookup results are truncated.
-  std::string keyAtRow(uint32_t row) const override;
+  /// This is ClusterIndex-specific because it relies on the data being
+  /// physically sorted by the indexed key
+  std::string keyAtRow(uint32_t row) const;
 
   /// Returns the number of partitions in the index.
   uint32_t numPartitions() const {

--- a/dwio/nimble/index/IndexLookup.h
+++ b/dwio/nimble/index/IndexLookup.h
@@ -251,12 +251,6 @@ class IndexLookup {
   /// Returns the maximum key in this index.
   virtual std::string_view maxKey() const = 0;
 
-  /// Returns the encoded key at the given file-level row position.
-  /// Not all index types support this — the default throws.
-  virtual std::string keyAtRow(uint32_t /*row*/) const {
-    NIMBLE_NOT_IMPLEMENTED("keyAtRow is not supported by this index type");
-  }
-
   /// Returns runtime statistics accumulated during lookups.
   virtual folly::F14FastMap<std::string, velox::RuntimeMetric> stats() const {
     return {};


### PR DESCRIPTION
Summary:

keyAtRow is fundamentally tied to ClusterIndex's design: it relies on the dedicated key stream written when data is physically sorted by key.

HashIndex and SortedIndex inherited a method they are meaningless to support.

Differential Revision: D105885845


