### PR TITLE
test(encoding): Onboard all Nimble encodings to encoding fuzzer

### DIFF
--- a/dwio/nimble/encodings/benchmarks/BenchmarkUtils.h
+++ b/dwio/nimble/encodings/benchmarks/BenchmarkUtils.h
@@ -1,0 +1,241 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <algorithm>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "dwio/nimble/common/Buffer.h"
+#include "dwio/nimble/common/Vector.h"
+#include "dwio/nimble/encodings/common/EncodingFactory.h"
+#include "dwio/nimble/encodings/selection/EncodingSelection.h"
+#include "dwio/nimble/encodings/selection/EncodingSelectionPolicy.h"
+#include "dwio/nimble/encodings/selection/Statistics.h"
+#include "folly/Random.h"
+#include "velox/common/memory/Memory.h"
+
+namespace facebook::nimble::benchmarks {
+
+inline constexpr uint32_t kNumElements = 100000;
+
+inline std::shared_ptr<velox::memory::MemoryPool>& benchmarkPool() {
+  static auto pool = velox::memory::memoryManager()->addLeafPool("benchmark");
+  return pool;
+}
+
+inline auto nullFactory() {
+  return [](uint32_t) -> void* { return nullptr; };
+}
+
+// Random uniform data — worst case for most specialized encodings.
+template <typename T>
+Vector<T> makeRandom(uint32_t n = kNumElements) {
+  auto& pool = benchmarkPool();
+  Vector<T> data{pool.get()};
+  data.resize(n);
+  for (uint32_t i = 0; i < n; ++i) {
+    if constexpr (sizeof(T) <= 4) {
+      data[i] = static_cast<T>(folly::Random::secureRand32());
+    } else {
+      data[i] = static_cast<T>(folly::Random::secureRand64());
+    }
+  }
+  return data;
+}
+
+// Narrow bit-width data — values fit in bitWidth bits.
+template <typename T>
+Vector<T> makeNarrow(int bitWidth, uint32_t n = kNumElements) {
+  auto& pool = benchmarkPool();
+  Vector<T> data{pool.get()};
+  data.resize(n);
+  using U = std::make_unsigned_t<T>;
+  U mask = (bitWidth >= static_cast<int>(sizeof(T) * 8))
+      ? static_cast<U>(~U{0})
+      : (static_cast<U>(1) << bitWidth) - 1;
+  for (uint32_t i = 0; i < n; ++i) {
+    if constexpr (sizeof(T) <= 4) {
+      data[i] = static_cast<T>(folly::Random::secureRand32() & mask);
+    } else {
+      data[i] = static_cast<T>(folly::Random::secureRand64() & mask);
+    }
+  }
+  return data;
+}
+
+// All values identical.
+template <typename T>
+Vector<T> makeConstant(T value, uint32_t n = kNumElements) {
+  auto& pool = benchmarkPool();
+  Vector<T> data{pool.get()};
+  data.resize(n);
+  for (uint32_t i = 0; i < n; ++i) {
+    data[i] = value;
+  }
+  return data;
+}
+
+// 95% one dominant value, 5% random outliers.
+template <typename T>
+Vector<T> makeMainlyConstant(T dominant, uint32_t n = kNumElements) {
+  auto& pool = benchmarkPool();
+  Vector<T> data{pool.get()};
+  data.resize(n);
+  for (uint32_t i = 0; i < n; ++i) {
+    if constexpr (sizeof(T) <= 4) {
+      data[i] = (folly::Random::secureRand32() % 100 < 95)
+          ? dominant
+          : static_cast<T>(folly::Random::secureRand32());
+    } else {
+      data[i] = (folly::Random::secureRand32() % 100 < 95)
+          ? dominant
+          : static_cast<T>(folly::Random::secureRand64());
+    }
+  }
+  return data;
+}
+
+// Runs of 10-60 identical values — ideal for RLE.
+template <typename T>
+Vector<T> makeRunLength(uint32_t n = kNumElements) {
+  auto& pool = benchmarkPool();
+  Vector<T> data{pool.get()};
+  data.resize(n);
+  T val = static_cast<T>(folly::Random::secureRand32() % 1000);
+  uint32_t i = 0;
+  while (i < n) {
+    uint32_t runLen =
+        std::min<uint32_t>(10 + folly::Random::secureRand32() % 50, n - i);
+    for (uint32_t j = 0; j < runLen; ++j) {
+      data[i + j] = val;
+    }
+    i += runLen;
+    val = static_cast<T>(folly::Random::secureRand32() % 1000);
+  }
+  return data;
+}
+
+// Monotonically increasing with small random deltas — ideal for Delta/FOR.
+template <typename T>
+Vector<T> makeIncreasing(uint32_t n = kNumElements) {
+  auto& pool = benchmarkPool();
+  Vector<T> data{pool.get()};
+  data.resize(n);
+  T val = 0;
+  for (uint32_t i = 0; i < n; ++i) {
+    val += static_cast<T>(folly::Random::secureRand32() % 10);
+    data[i] = val;
+  }
+  return data;
+}
+
+// Low cardinality — ideal for Dictionary.
+template <typename T>
+Vector<T> makeLowCardinality(uint32_t cardinality, uint32_t n = kNumElements) {
+  auto& pool = benchmarkPool();
+  Vector<T> data{pool.get()};
+  data.resize(n);
+  for (uint32_t i = 0; i < n; ++i) {
+    data[i] = static_cast<T>(folly::Random::secureRand32() % cardinality);
+  }
+  return data;
+}
+
+// Sparse bool — 5% true, 95% false.
+inline Vector<bool> makeSparseBool(uint32_t n = kNumElements) {
+  auto& pool = benchmarkPool();
+  Vector<bool> data{pool.get()};
+  data.resize(n);
+  for (uint32_t i = 0; i < n; ++i) {
+    data[i] = (folly::Random::secureRand32() % 100 < 5);
+  }
+  return data;
+}
+
+// Dense bool — 50% true, 50% false.
+inline Vector<bool> makeDenseBool(uint32_t n = kNumElements) {
+  auto& pool = benchmarkPool();
+  Vector<bool> data{pool.get()};
+  data.resize(n);
+  for (uint32_t i = 0; i < n; ++i) {
+    data[i] = (folly::Random::secureRand32() % 2 == 0);
+  }
+  return data;
+}
+
+inline std::unique_ptr<EncodingSelectionPolicyBase> makeDefaultPolicy(
+    DataType dataType) {
+  static ManualEncodingSelectionPolicyFactory factory{
+      ManualEncodingSelectionPolicyFactory::defaultReadFactors(), std::nullopt};
+  return factory.createPolicy(dataType);
+}
+
+// Encode helper: encode data with a specific encoding type.
+template <typename EncodingT, typename T>
+std::string encodeData(
+    EncodingType encodingType,
+    const Vector<T>& data,
+    const Encoding::Options& options = {}) {
+  using P = typename TypeTraits<T>::physicalType;
+  auto& pool = benchmarkPool();
+  Buffer buffer{*pool};
+  auto values =
+      std::span<const P>(reinterpret_cast<const P*>(data.data()), data.size());
+  EncodingSelectionResult result{.encodingType = encodingType};
+  auto selection = EncodingSelection<P>{
+      std::move(result),
+      Statistics<P>::create(values),
+      makeDefaultPolicy(TypeTraits<T>::dataType)};
+  auto enc = EncodingT::encode(selection, values, buffer, options);
+  return std::string{enc.data(), enc.size()};
+}
+
+// Decode benchmark loop.
+template <typename T>
+void decodeBenchmark(const std::string& encoded, uint32_t n, uint32_t iters) {
+  auto& pool = benchmarkPool();
+  std::vector<T> output(n);
+  while (iters--) {
+    auto encoding = EncodingFactory{}.create(*pool, encoded, nullFactory());
+    encoding->materialize(n, output.data());
+  }
+}
+
+// Encode benchmark loop.
+template <typename EncodingT, typename T>
+void encodeBenchmark(
+    EncodingType encodingType,
+    const Vector<T>& data,
+    uint32_t iters,
+    const Encoding::Options& options = {}) {
+  using P = typename TypeTraits<T>::physicalType;
+  auto& pool = benchmarkPool();
+  auto values =
+      std::span<const P>(reinterpret_cast<const P*>(data.data()), data.size());
+  while (iters--) {
+    Buffer buffer{*pool};
+    EncodingSelectionResult result{.encodingType = encodingType};
+    auto selection = EncodingSelection<P>{
+        std::move(result),
+        Statistics<P>::create(values),
+        makeDefaultPolicy(TypeTraits<T>::dataType)};
+    EncodingT::encode(selection, values, buffer, options);
+  }
+}
+
+} // namespace facebook::nimble::benchmarks

--- a/dwio/nimble/encodings/benchmarks/ConstantBenchmark.cpp
+++ b/dwio/nimble/encodings/benchmarks/ConstantBenchmark.cpp
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "dwio/nimble/encodings/ConstantEncoding.h"
+#include "dwio/nimble/encodings/benchmarks/BenchmarkUtils.h"
+#include "folly/Benchmark.h"
+
+using namespace facebook::nimble;
+using namespace facebook::nimble::benchmarks;
+
+// ConstantEncoding requires all values to be identical, so only the Constant
+// pattern produces valid encoded output. We benchmark encode on Constant data
+// and decode on the same.
+
+BENCHMARK(Constant_Encode, iters) {
+  Vector<uint32_t> data{benchmarkPool().get()};
+  BENCHMARK_SUSPEND {
+    data = makeConstant<uint32_t>(42);
+  }
+  encodeBenchmark<ConstantEncoding<uint32_t>>(
+      EncodingType::Constant, data, iters);
+}
+
+BENCHMARK(Constant_Decode, iters) {
+  std::string encoded;
+  BENCHMARK_SUSPEND {
+    auto data = makeConstant<uint32_t>(42);
+    encoded =
+        encodeData<ConstantEncoding<uint32_t>>(EncodingType::Constant, data);
+  }
+  decodeBenchmark<uint32_t>(encoded, kNumElements, iters);
+}
+
+int main() {
+  facebook::velox::memory::MemoryManager::initialize({});
+  folly::runBenchmarks();
+}

--- a/dwio/nimble/encodings/benchmarks/DeltaBenchmark.cpp
+++ b/dwio/nimble/encodings/benchmarks/DeltaBenchmark.cpp
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "dwio/nimble/encodings/DeltaEncoding.h"
+#include "dwio/nimble/encodings/benchmarks/BenchmarkUtils.h"
+#include "folly/Benchmark.h"
+
+using namespace facebook::nimble;
+using namespace facebook::nimble::benchmarks;
+
+#define DELTA_BENCH(Pattern, DataExpr)                                    \
+  BENCHMARK(Delta_Encode_##Pattern, iters) {                              \
+    Vector<uint32_t> data{benchmarkPool().get()};                         \
+    BENCHMARK_SUSPEND {                                                   \
+      data = DataExpr;                                                    \
+    }                                                                     \
+    encodeBenchmark<DeltaEncoding<uint32_t>>(                             \
+        EncodingType::Delta, data, iters);                                \
+  }                                                                       \
+  BENCHMARK(Delta_Decode_##Pattern, iters) {                              \
+    std::string encoded;                                                  \
+    BENCHMARK_SUSPEND {                                                   \
+      auto data = DataExpr;                                               \
+      encoded =                                                           \
+          encodeData<DeltaEncoding<uint32_t>>(EncodingType::Delta, data); \
+    }                                                                     \
+    decodeBenchmark<uint32_t>(encoded, kNumElements, iters);              \
+  }                                                                       \
+  BENCHMARK_DRAW_LINE()
+
+DELTA_BENCH(Random, makeRandom<uint32_t>());
+DELTA_BENCH(Narrow8bit, makeNarrow<uint32_t>(8));
+DELTA_BENCH(Constant, makeConstant<uint32_t>(42));
+DELTA_BENCH(MainlyConstant, makeMainlyConstant<uint32_t>(42));
+DELTA_BENCH(RunLength, makeRunLength<uint32_t>());
+DELTA_BENCH(Increasing, makeIncreasing<uint32_t>());
+DELTA_BENCH(LowCardinality, makeLowCardinality<uint32_t>(64));
+
+#undef DELTA_BENCH
+
+int main() {
+  facebook::velox::memory::MemoryManager::initialize({});
+  folly::runBenchmarks();
+}

--- a/dwio/nimble/encodings/benchmarks/DictionaryBenchmark.cpp
+++ b/dwio/nimble/encodings/benchmarks/DictionaryBenchmark.cpp
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "dwio/nimble/encodings/DictionaryEncoding.h"
+#include "dwio/nimble/encodings/benchmarks/BenchmarkUtils.h"
+#include "folly/Benchmark.h"
+
+using namespace facebook::nimble;
+using namespace facebook::nimble::benchmarks;
+
+#define DICT_BENCH(Pattern, DataExpr)                        \
+  BENCHMARK(Dict_Encode_##Pattern, iters) {                  \
+    Vector<uint32_t> data{benchmarkPool().get()};            \
+    BENCHMARK_SUSPEND {                                      \
+      data = DataExpr;                                       \
+    }                                                        \
+    encodeBenchmark<DictionaryEncoding<uint32_t>>(           \
+        EncodingType::Dictionary, data, iters);              \
+  }                                                          \
+  BENCHMARK(Dict_Decode_##Pattern, iters) {                  \
+    std::string encoded;                                     \
+    BENCHMARK_SUSPEND {                                      \
+      auto data = DataExpr;                                  \
+      encoded = encodeData<DictionaryEncoding<uint32_t>>(    \
+          EncodingType::Dictionary, data);                   \
+    }                                                        \
+    decodeBenchmark<uint32_t>(encoded, kNumElements, iters); \
+  }                                                          \
+  BENCHMARK_DRAW_LINE()
+
+DICT_BENCH(Random, makeRandom<uint32_t>());
+DICT_BENCH(Narrow8bit, makeNarrow<uint32_t>(8));
+DICT_BENCH(Constant, makeConstant<uint32_t>(42));
+DICT_BENCH(MainlyConstant, makeMainlyConstant<uint32_t>(42));
+DICT_BENCH(RunLength, makeRunLength<uint32_t>());
+DICT_BENCH(Increasing, makeIncreasing<uint32_t>());
+DICT_BENCH(LowCardinality64, makeLowCardinality<uint32_t>(64));
+DICT_BENCH(LowCardinality1024, makeLowCardinality<uint32_t>(1024));
+
+#undef DICT_BENCH
+
+int main() {
+  facebook::velox::memory::MemoryManager::initialize({});
+  folly::runBenchmarks();
+}

--- a/dwio/nimble/encodings/benchmarks/EncodingComparison.cpp
+++ b/dwio/nimble/encodings/benchmarks/EncodingComparison.cpp
@@ -1,0 +1,193 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <chrono>
+#include <functional>
+#include <iomanip>
+#include <iostream>
+#include <string>
+#include <vector>
+
+#include "dwio/nimble/common/Buffer.h"
+#include "dwio/nimble/common/Vector.h"
+#include "dwio/nimble/encodings/ConstantEncoding.h"
+#include "dwio/nimble/encodings/DeltaEncoding.h"
+#include "dwio/nimble/encodings/DictionaryEncoding.h"
+#include "dwio/nimble/encodings/FixedBitWidthEncoding.h"
+#include "dwio/nimble/encodings/MainlyConstantEncoding.h"
+#include "dwio/nimble/encodings/RleEncoding.h"
+#include "dwio/nimble/encodings/TrivialEncoding.h"
+#include "dwio/nimble/encodings/VarintEncoding.h"
+#include "dwio/nimble/encodings/benchmarks/BenchmarkUtils.h"
+#include "dwio/nimble/encodings/common/EncodingFactory.h"
+#include "velox/common/memory/Memory.h"
+
+using namespace facebook::nimble;
+using namespace facebook::nimble::benchmarks;
+
+namespace {
+
+constexpr int kDecodeIters = 100;
+
+struct Result {
+  std::string encoding;
+  std::string pattern;
+  uint32_t rawBytes;
+  uint32_t encodedBytes;
+  double decodeNsPerElement;
+};
+
+template <typename EncodingT, typename T>
+Result measure(
+    const std::string& encodingName,
+    const std::string& patternName,
+    EncodingType encodingType,
+    const Vector<T>& data) {
+  auto& pool = benchmarkPool();
+  uint32_t rawBytes = data.size() * sizeof(T);
+
+  std::string encoded;
+  try {
+    encoded = encodeData<EncodingT>(encodingType, data);
+  } catch (...) {
+    return {encodingName, patternName, rawBytes, 0, -1.0};
+  }
+
+  uint32_t encodedBytes = static_cast<uint32_t>(encoded.size());
+
+  std::vector<T> output(data.size());
+  auto start = std::chrono::high_resolution_clock::now();
+  for (int i = 0; i < kDecodeIters; ++i) {
+    auto enc = EncodingFactory{}.create(*pool, encoded, nullFactory());
+    enc->materialize(data.size(), output.data());
+  }
+  auto end = std::chrono::high_resolution_clock::now();
+  double totalNs =
+      std::chrono::duration_cast<std::chrono::nanoseconds>(end - start).count();
+  double nsPerElement = totalNs / (kDecodeIters * data.size());
+
+  return {encodingName, patternName, rawBytes, encodedBytes, nsPerElement};
+}
+
+void printHeader() {
+  std::cout << std::left << std::setw(22) << "Encoding" << std::setw(18)
+            << "Pattern" << std::right << std::setw(10) << "Raw(KB)"
+            << std::setw(12) << "Encoded(KB)" << std::setw(10) << "Ratio"
+            << std::setw(14) << "Decode(ns/el)" << "\n";
+  std::cout << std::string(86, '-') << "\n";
+}
+
+void printResult(const Result& r) {
+  std::cout << std::left << std::setw(22) << r.encoding << std::setw(18)
+            << r.pattern << std::right << std::setw(10) << std::fixed
+            << std::setprecision(1) << (r.rawBytes / 1024.0);
+  if (r.decodeNsPerElement < 0) {
+    std::cout << std::setw(12) << "SKIP" << std::setw(10) << "N/A"
+              << std::setw(14) << "N/A" << "\n";
+  } else {
+    double ratio = static_cast<double>(r.encodedBytes) / r.rawBytes;
+    std::cout << std::setw(12) << std::fixed << std::setprecision(1)
+              << (r.encodedBytes / 1024.0) << std::setw(9) << std::fixed
+              << std::setprecision(3) << ratio << "x" << std::setw(14)
+              << std::fixed << std::setprecision(1) << r.decodeNsPerElement
+              << "\n";
+  }
+}
+
+void printSeparator() {
+  std::cout << std::string(86, '-') << "\n";
+}
+
+template <typename T>
+struct PatternDef {
+  std::string name;
+  std::function<Vector<T>()> generator;
+};
+
+template <typename T>
+std::vector<PatternDef<T>> makePatterns() {
+  return {
+      {"Random", [] { return makeRandom<T>(); }},
+      {"Narrow8bit", [] { return makeNarrow<T>(8); }},
+      {"Constant", [] { return makeConstant<T>(T{42}); }},
+      {"MainlyConst", [] { return makeMainlyConstant<T>(T{42}); }},
+      {"RunLength", [] { return makeRunLength<T>(); }},
+      {"Increasing", [] { return makeIncreasing<T>(); }},
+      {"LowCard64", [] { return makeLowCardinality<T>(64); }},
+  };
+}
+
+template <typename EncodingT, typename T>
+void runEncoding(
+    const std::string& name,
+    EncodingType type,
+    const std::vector<PatternDef<T>>& patterns) {
+  for (const auto& p : patterns) {
+    auto data = p.generator();
+    auto result = measure<EncodingT, T>(name, p.name, type, data);
+    printResult(result);
+  }
+  printSeparator();
+}
+
+} // namespace
+
+int main() {
+  facebook::velox::memory::MemoryManager::initialize({});
+
+  std::cout << "\n=== Nimble Encoding Comparison (uint32_t, " << kNumElements
+            << " elements, decode averaged over " << kDecodeIters
+            << " iterations) ===\n\n";
+
+  auto patterns = makePatterns<uint32_t>();
+  printHeader();
+
+  runEncoding<TrivialEncoding<uint32_t>>(
+      "Trivial", EncodingType::Trivial, patterns);
+  runEncoding<FixedBitWidthEncoding<uint32_t>>(
+      "FixedBitWidth", EncodingType::FixedBitWidth, patterns);
+  runEncoding<RLEEncoding<uint32_t>>("RLE", EncodingType::RLE, patterns);
+  runEncoding<DictionaryEncoding<uint32_t>>(
+      "Dictionary", EncodingType::Dictionary, patterns);
+  runEncoding<DeltaEncoding<uint32_t>>("Delta", EncodingType::Delta, patterns);
+  runEncoding<ConstantEncoding<uint32_t>>(
+      "Constant", EncodingType::Constant, patterns);
+  runEncoding<MainlyConstantEncoding<uint32_t>>(
+      "MainlyConstant", EncodingType::MainlyConstant, patterns);
+  runEncoding<VarintEncoding<uint32_t>>(
+      "Varint", EncodingType::Varint, patterns);
+
+  std::cout << "\n=== Nimble Encoding Comparison (uint64_t, " << kNumElements
+            << " elements, decode averaged over " << kDecodeIters
+            << " iterations) ===\n\n";
+
+  auto patterns64 = makePatterns<uint64_t>();
+  printHeader();
+
+  runEncoding<TrivialEncoding<uint64_t>>(
+      "Trivial", EncodingType::Trivial, patterns64);
+  runEncoding<FixedBitWidthEncoding<uint64_t>>(
+      "FixedBitWidth", EncodingType::FixedBitWidth, patterns64);
+  runEncoding<RLEEncoding<uint64_t>>("RLE", EncodingType::RLE, patterns64);
+  runEncoding<DictionaryEncoding<uint64_t>>(
+      "Dictionary", EncodingType::Dictionary, patterns64);
+  runEncoding<DeltaEncoding<uint64_t>>(
+      "Delta", EncodingType::Delta, patterns64);
+  runEncoding<VarintEncoding<uint64_t>>(
+      "Varint", EncodingType::Varint, patterns64);
+
+  return 0;
+}

--- a/dwio/nimble/encodings/benchmarks/MainlyConstantBenchmark.cpp
+++ b/dwio/nimble/encodings/benchmarks/MainlyConstantBenchmark.cpp
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "dwio/nimble/encodings/MainlyConstantEncoding.h"
+#include "dwio/nimble/encodings/benchmarks/BenchmarkUtils.h"
+#include "folly/Benchmark.h"
+
+using namespace facebook::nimble;
+using namespace facebook::nimble::benchmarks;
+
+#define MC_BENCH(Pattern, DataExpr)                           \
+  BENCHMARK(MainlyConst_Encode_##Pattern, iters) {            \
+    Vector<uint32_t> data{benchmarkPool().get()};             \
+    BENCHMARK_SUSPEND {                                       \
+      data = DataExpr;                                        \
+    }                                                         \
+    encodeBenchmark<MainlyConstantEncoding<uint32_t>>(        \
+        EncodingType::MainlyConstant, data, iters);           \
+  }                                                           \
+  BENCHMARK(MainlyConst_Decode_##Pattern, iters) {            \
+    std::string encoded;                                      \
+    BENCHMARK_SUSPEND {                                       \
+      auto data = DataExpr;                                   \
+      encoded = encodeData<MainlyConstantEncoding<uint32_t>>( \
+          EncodingType::MainlyConstant, data);                \
+    }                                                         \
+    decodeBenchmark<uint32_t>(encoded, kNumElements, iters);  \
+  }                                                           \
+  BENCHMARK_DRAW_LINE()
+
+MC_BENCH(Random, makeRandom<uint32_t>());
+MC_BENCH(Narrow8bit, makeNarrow<uint32_t>(8));
+MC_BENCH(Constant, makeConstant<uint32_t>(42));
+MC_BENCH(MainlyConstant, makeMainlyConstant<uint32_t>(42));
+MC_BENCH(RunLength, makeRunLength<uint32_t>());
+MC_BENCH(Increasing, makeIncreasing<uint32_t>());
+MC_BENCH(LowCardinality, makeLowCardinality<uint32_t>(64));
+
+#undef MC_BENCH
+
+int main() {
+  facebook::velox::memory::MemoryManager::initialize({});
+  folly::runBenchmarks();
+}

--- a/dwio/nimble/encodings/benchmarks/NullableBenchmark.cpp
+++ b/dwio/nimble/encodings/benchmarks/NullableBenchmark.cpp
@@ -1,0 +1,107 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "dwio/nimble/encodings/NullableEncoding.h"
+#include "dwio/nimble/encodings/benchmarks/BenchmarkUtils.h"
+#include "folly/Benchmark.h"
+
+using namespace facebook::nimble;
+using namespace facebook::nimble::benchmarks;
+
+namespace {
+
+struct NullableData {
+  Vector<uint32_t> values;
+  Vector<bool> nulls;
+};
+
+NullableData makeNullable(Vector<uint32_t> values, uint32_t nonNullPct) {
+  auto& pool = benchmarkPool();
+  Vector<bool> nulls{pool.get()};
+  nulls.resize(values.size());
+  for (uint32_t i = 0; i < values.size(); ++i) {
+    nulls[i] = (folly::Random::secureRand32() % 100 < nonNullPct);
+  }
+  return {std::move(values), std::move(nulls)};
+}
+
+std::string encodeNullable(const NullableData& nd) {
+  using P = typename TypeTraits<uint32_t>::physicalType;
+  auto& pool = benchmarkPool();
+  Buffer buffer{*pool};
+  auto values = std::span<const P>(
+      reinterpret_cast<const P*>(nd.values.data()), nd.values.size());
+  auto nulls = std::span<const bool>(nd.nulls.data(), nd.nulls.size());
+  EncodingSelectionResult result{.encodingType = EncodingType::Nullable};
+  auto selection = EncodingSelection<P>{
+      std::move(result), Statistics<P>::create(values), nullptr};
+  auto enc = NullableEncoding<uint32_t>::encodeNullable(
+      selection, values, nulls, buffer);
+  return std::string{enc.data(), enc.size()};
+}
+
+void encodeNullableBench(const NullableData& nd, uint32_t iters) {
+  using P = typename TypeTraits<uint32_t>::physicalType;
+  auto& pool = benchmarkPool();
+  auto values = std::span<const P>(
+      reinterpret_cast<const P*>(nd.values.data()), nd.values.size());
+  auto nulls = std::span<const bool>(nd.nulls.data(), nd.nulls.size());
+  while (iters--) {
+    Buffer buffer{*pool};
+    EncodingSelectionResult result{.encodingType = EncodingType::Nullable};
+    auto selection = EncodingSelection<P>{
+        std::move(result), Statistics<P>::create(values), nullptr};
+    NullableEncoding<uint32_t>::encodeNullable(
+        selection, values, nulls, buffer);
+  }
+}
+
+} // namespace
+
+#define NULLABLE_BENCH(Pattern, DataExpr, NullPct)                      \
+  BENCHMARK(Nullable_Encode_##Pattern##_##NullPct##pctNonNull, iters) { \
+    NullableData nd{                                                    \
+        Vector<uint32_t>(benchmarkPool().get()),                        \
+        Vector<bool>(benchmarkPool().get())};                           \
+    BENCHMARK_SUSPEND {                                                 \
+      nd = makeNullable(DataExpr, NullPct);                             \
+    }                                                                   \
+    encodeNullableBench(nd, iters);                                     \
+  }                                                                     \
+  BENCHMARK(Nullable_Decode_##Pattern##_##NullPct##pctNonNull, iters) { \
+    std::string encoded;                                                \
+    BENCHMARK_SUSPEND {                                                 \
+      auto nd = makeNullable(DataExpr, NullPct);                        \
+      encoded = encodeNullable(nd);                                     \
+    }                                                                   \
+    decodeBenchmark<uint32_t>(encoded, kNumElements, iters);            \
+  }                                                                     \
+  BENCHMARK_DRAW_LINE()
+
+NULLABLE_BENCH(Random, makeRandom<uint32_t>(), 80);
+NULLABLE_BENCH(Random, makeRandom<uint32_t>(), 50);
+NULLABLE_BENCH(Random, makeRandom<uint32_t>(), 10);
+NULLABLE_BENCH(Narrow8bit, makeNarrow<uint32_t>(8), 80);
+NULLABLE_BENCH(Constant, makeConstant<uint32_t>(42), 80);
+NULLABLE_BENCH(RunLength, makeRunLength<uint32_t>(), 80);
+NULLABLE_BENCH(Increasing, makeIncreasing<uint32_t>(), 80);
+
+#undef NULLABLE_BENCH
+
+int main() {
+  facebook::velox::memory::MemoryManager::initialize({});
+  folly::runBenchmarks();
+}

--- a/dwio/nimble/encodings/benchmarks/README.md
+++ b/dwio/nimble/encodings/benchmarks/README.md
@@ -1,0 +1,77 @@
+# Nimble Encoding Microbenchmarks
+
+Per-encoding microbenchmarks measuring encode and decode (materialize) throughput on 100K elements across multiple data patterns.
+
+## Running
+
+```bash
+# Run the encoding comparison (storage + decode time table for all encodings × all patterns)
+buck run fbcode//dwio/nimble/encodings/benchmarks:encoding_comparison
+
+# Run a single encoding's folly::Benchmark microbenchmarks
+buck run fbcode//dwio/nimble/encodings/benchmarks:trivial_benchmark
+
+# Run with minimum iterations
+buck run fbcode//dwio/nimble/encodings/benchmarks:rle_benchmark -- --bm_min_iters=10
+
+# Build all benchmarks
+buck build fbcode//dwio/nimble/encodings/benchmarks:
+```
+
+## Encoding Comparison
+
+The `encoding_comparison` binary prints a consolidated table of storage size and decode time for every encoding across all data patterns, for both uint32 and uint64:
+
+```bash
+buck run fbcode//dwio/nimble/encodings/benchmarks:encoding_comparison
+```
+
+Output columns:
+- **Raw(KB)** — unencoded data size
+- **Encoded(KB)** — encoded size on disk
+- **Ratio** — encoded/raw (lower = better compression)
+- **Decode(ns/el)** — decode time per element, averaged over 100 iterations
+- **SKIP** — encoding cannot handle this data pattern (e.g., Constant on non-constant data)
+
+## Per-Encoding Benchmark Targets
+
+| Target | Encoding | Supported Types |
+|--------|----------|-----------------|
+| `encoding_comparison` | All encodings | uint32, uint64 |
+| `trivial_benchmark` | Trivial | All |
+| `fixed_bit_width_benchmark` | FixedBitWidth | Numeric |
+| `rle_benchmark` | RLE | All |
+| `dictionary_benchmark` | Dictionary | All except bool |
+| `delta_benchmark` | Delta | Integer |
+| `constant_benchmark` | Constant | All |
+| `mainly_constant_benchmark` | MainlyConstant | All except bool |
+| `varint_benchmark` | Varint | 32/64-bit numeric |
+| `sparse_bool_benchmark` | SparseBool | bool |
+| `for_benchmark` | FOR (Frame of Reference) | Integer |
+| `frequency_partition_benchmark` | FrequencyPartition | All hashable |
+| `sub_int_split_benchmark` | SubIntSplit | 32/64-bit numeric |
+| `nullable_benchmark` | Nullable (wraps Trivial) | All |
+
+## Data Patterns
+
+Each encoding is tested against all applicable patterns to show how it performs on both ideal and adversarial inputs:
+
+| Pattern | Description | Ideal For |
+|---------|-------------|-----------|
+| `Random` | Uniform random values | Baseline / worst case |
+| `Narrow8bit` | Values fit in 8 bits | FixedBitWidth, Varint |
+| `Constant` | All identical values | Constant |
+| `MainlyConstant` | 95% dominant value, 5% random | MainlyConstant |
+| `RunLength` | Runs of 10–60 repeated values | RLE |
+| `Increasing` | Monotonically increasing, small deltas | Delta, FOR |
+| `LowCardinality` | 64 unique values | Dictionary, FrequencyPartition |
+
+SparseBool additionally tests sparse (5% true), dense (50% true), and all-false.
+Nullable varies null density (80%, 50%, 10% non-null) across patterns.
+
+## Adding a New Encoding Benchmark
+
+1. Create `<Encoding>Benchmark.cpp` in this directory.
+2. Include `BenchmarkUtils.h` for shared data generators and encode/decode helpers.
+3. Use the macro pattern (see existing files) to generate encode+decode benchmarks for each data pattern.
+4. Add a `cpp_benchmark` target in `BUCK` with `deps = _COMMON_DEPS`.

--- a/dwio/nimble/encodings/benchmarks/RleBenchmark.cpp
+++ b/dwio/nimble/encodings/benchmarks/RleBenchmark.cpp
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "dwio/nimble/encodings/RleEncoding.h"
+#include "dwio/nimble/encodings/benchmarks/BenchmarkUtils.h"
+#include "folly/Benchmark.h"
+
+using namespace facebook::nimble;
+using namespace facebook::nimble::benchmarks;
+
+#define RLE_BENCH(Pattern, DataExpr)                                        \
+  BENCHMARK(RLE_Encode_##Pattern, iters) {                                  \
+    Vector<uint32_t> data{benchmarkPool().get()};                           \
+    BENCHMARK_SUSPEND {                                                     \
+      data = DataExpr;                                                      \
+    }                                                                       \
+    encodeBenchmark<RLEEncoding<uint32_t>>(EncodingType::RLE, data, iters); \
+  }                                                                         \
+  BENCHMARK(RLE_Decode_##Pattern, iters) {                                  \
+    std::string encoded;                                                    \
+    BENCHMARK_SUSPEND {                                                     \
+      auto data = DataExpr;                                                 \
+      encoded = encodeData<RLEEncoding<uint32_t>>(EncodingType::RLE, data); \
+    }                                                                       \
+    decodeBenchmark<uint32_t>(encoded, kNumElements, iters);                \
+  }                                                                         \
+  BENCHMARK_DRAW_LINE()
+
+RLE_BENCH(Random, makeRandom<uint32_t>());
+RLE_BENCH(Narrow8bit, makeNarrow<uint32_t>(8));
+RLE_BENCH(Constant, makeConstant<uint32_t>(42));
+RLE_BENCH(MainlyConstant, makeMainlyConstant<uint32_t>(42));
+RLE_BENCH(RunLength, makeRunLength<uint32_t>());
+RLE_BENCH(Increasing, makeIncreasing<uint32_t>());
+RLE_BENCH(LowCardinality, makeLowCardinality<uint32_t>(64));
+
+#undef RLE_BENCH
+
+int main() {
+  facebook::velox::memory::MemoryManager::initialize({});
+  folly::runBenchmarks();
+}

--- a/dwio/nimble/encodings/benchmarks/SparseBoolBenchmark.cpp
+++ b/dwio/nimble/encodings/benchmarks/SparseBoolBenchmark.cpp
@@ -1,0 +1,126 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "dwio/nimble/encodings/SparseBoolEncoding.h"
+#include "dwio/nimble/encodings/benchmarks/BenchmarkUtils.h"
+#include "folly/Benchmark.h"
+
+using namespace facebook::nimble;
+using namespace facebook::nimble::benchmarks;
+
+namespace {
+
+std::string encodeBool(const Vector<bool>& data) {
+  auto& pool = benchmarkPool();
+  Buffer buffer{*pool};
+  auto values = std::span<const bool>(data.data(), data.size());
+  EncodingSelectionResult result{.encodingType = EncodingType::SparseBool};
+  auto selection = EncodingSelection<bool>{
+      std::move(result), Statistics<bool>::create(values), nullptr};
+  auto enc = SparseBoolEncoding::encode(selection, values, buffer);
+  return std::string{enc.data(), enc.size()};
+}
+
+void encodeBoolBenchmark(const Vector<bool>& data, uint32_t iters) {
+  auto& pool = benchmarkPool();
+  auto values = std::span<const bool>(data.data(), data.size());
+  while (iters--) {
+    Buffer buffer{*pool};
+    EncodingSelectionResult result{.encodingType = EncodingType::SparseBool};
+    auto selection = EncodingSelection<bool>{
+        std::move(result), Statistics<bool>::create(values), nullptr};
+    SparseBoolEncoding::encode(selection, values, buffer);
+  }
+}
+
+void decodeBoolBenchmark(const std::string& encoded, uint32_t iters) {
+  auto& pool = benchmarkPool();
+  Vector<bool> output{pool.get()};
+  output.resize(kNumElements);
+  while (iters--) {
+    auto encoding = EncodingFactory{}.create(*pool, encoded, nullFactory());
+    encoding->materialize(kNumElements, output.data());
+  }
+}
+
+} // namespace
+
+BENCHMARK(SparseBool_Encode_Sparse5pct, iters) {
+  Vector<bool> data{benchmarkPool().get()};
+  BENCHMARK_SUSPEND {
+    data = makeSparseBool();
+  }
+  encodeBoolBenchmark(data, iters);
+}
+
+BENCHMARK(SparseBool_Decode_Sparse5pct, iters) {
+  std::string encoded;
+  BENCHMARK_SUSPEND {
+    auto data = makeSparseBool();
+    encoded = encodeBool(data);
+  }
+  decodeBoolBenchmark(encoded, iters);
+}
+
+BENCHMARK_DRAW_LINE();
+
+BENCHMARK(SparseBool_Encode_Dense50pct, iters) {
+  Vector<bool> data{benchmarkPool().get()};
+  BENCHMARK_SUSPEND {
+    data = makeDenseBool();
+  }
+  encodeBoolBenchmark(data, iters);
+}
+
+BENCHMARK(SparseBool_Decode_Dense50pct, iters) {
+  std::string encoded;
+  BENCHMARK_SUSPEND {
+    auto data = makeDenseBool();
+    encoded = encodeBool(data);
+  }
+  decodeBoolBenchmark(encoded, iters);
+}
+
+BENCHMARK_DRAW_LINE();
+
+BENCHMARK(SparseBool_Encode_AllFalse, iters) {
+  Vector<bool> data{benchmarkPool().get()};
+  BENCHMARK_SUSPEND {
+    data.resize(kNumElements);
+    for (uint32_t i = 0; i < kNumElements; ++i) {
+      data[i] = false;
+    }
+  }
+  encodeBoolBenchmark(data, iters);
+}
+
+BENCHMARK(SparseBool_Decode_AllFalse, iters) {
+  std::string encoded;
+  BENCHMARK_SUSPEND {
+    Vector<bool> data{benchmarkPool().get()};
+    data.resize(kNumElements);
+    for (uint32_t i = 0; i < kNumElements; ++i) {
+      data[i] = false;
+    }
+    encoded = encodeBool(data);
+  }
+  decodeBoolBenchmark(encoded, iters);
+}
+
+int main() {
+  facebook::velox::memory::MemoryManager::initialize({});
+  folly::runBenchmarks();
+}

--- a/dwio/nimble/encodings/benchmarks/TrivialBenchmark.cpp
+++ b/dwio/nimble/encodings/benchmarks/TrivialBenchmark.cpp
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "dwio/nimble/encodings/TrivialEncoding.h"
+#include "dwio/nimble/encodings/benchmarks/BenchmarkUtils.h"
+#include "folly/Benchmark.h"
+
+using namespace facebook::nimble;
+using namespace facebook::nimble::benchmarks;
+
+#define TRIVIAL_BENCH(Pattern, DataExpr)                                      \
+  BENCHMARK(Trivial_Encode_##Pattern, iters) {                                \
+    Vector<uint32_t> data{benchmarkPool().get()};                             \
+    BENCHMARK_SUSPEND {                                                       \
+      data = DataExpr;                                                        \
+    }                                                                         \
+    encodeBenchmark<TrivialEncoding<uint32_t>>(                               \
+        EncodingType::Trivial, data, iters);                                  \
+  }                                                                           \
+  BENCHMARK(Trivial_Decode_##Pattern, iters) {                                \
+    std::string encoded;                                                      \
+    BENCHMARK_SUSPEND {                                                       \
+      auto data = DataExpr;                                                   \
+      encoded =                                                               \
+          encodeData<TrivialEncoding<uint32_t>>(EncodingType::Trivial, data); \
+    }                                                                         \
+    decodeBenchmark<uint32_t>(encoded, kNumElements, iters);                  \
+  }                                                                           \
+  BENCHMARK_DRAW_LINE()
+
+TRIVIAL_BENCH(Random, makeRandom<uint32_t>());
+TRIVIAL_BENCH(Narrow8bit, makeNarrow<uint32_t>(8));
+TRIVIAL_BENCH(Constant, makeConstant<uint32_t>(42));
+TRIVIAL_BENCH(MainlyConstant, makeMainlyConstant<uint32_t>(42));
+TRIVIAL_BENCH(RunLength, makeRunLength<uint32_t>());
+TRIVIAL_BENCH(Increasing, makeIncreasing<uint32_t>());
+TRIVIAL_BENCH(LowCardinality, makeLowCardinality<uint32_t>(64));
+
+#undef TRIVIAL_BENCH
+
+int main() {
+  facebook::velox::memory::MemoryManager::initialize({});
+  folly::runBenchmarks();
+}

--- a/dwio/nimble/encodings/benchmarks/VarintBenchmark.cpp
+++ b/dwio/nimble/encodings/benchmarks/VarintBenchmark.cpp
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "dwio/nimble/encodings/VarintEncoding.h"
+#include "dwio/nimble/encodings/benchmarks/BenchmarkUtils.h"
+#include "folly/Benchmark.h"
+
+using namespace facebook::nimble;
+using namespace facebook::nimble::benchmarks;
+
+#define VARINT_BENCH(Pattern, DataExpr)                                     \
+  BENCHMARK(Varint_Encode_##Pattern, iters) {                               \
+    Vector<uint32_t> data{benchmarkPool().get()};                           \
+    BENCHMARK_SUSPEND {                                                     \
+      data = DataExpr;                                                      \
+    }                                                                       \
+    encodeBenchmark<VarintEncoding<uint32_t>>(                              \
+        EncodingType::Varint, data, iters);                                 \
+  }                                                                         \
+  BENCHMARK(Varint_Decode_##Pattern, iters) {                               \
+    std::string encoded;                                                    \
+    BENCHMARK_SUSPEND {                                                     \
+      auto data = DataExpr;                                                 \
+      encoded =                                                             \
+          encodeData<VarintEncoding<uint32_t>>(EncodingType::Varint, data); \
+    }                                                                       \
+    decodeBenchmark<uint32_t>(encoded, kNumElements, iters);                \
+  }                                                                         \
+  BENCHMARK_DRAW_LINE()
+
+VARINT_BENCH(Random, makeRandom<uint32_t>());
+VARINT_BENCH(Narrow8bit, makeNarrow<uint32_t>(8));
+VARINT_BENCH(Constant, makeConstant<uint32_t>(42));
+VARINT_BENCH(MainlyConstant, makeMainlyConstant<uint32_t>(42));
+VARINT_BENCH(RunLength, makeRunLength<uint32_t>());
+VARINT_BENCH(Increasing, makeIncreasing<uint32_t>());
+VARINT_BENCH(LowCardinality, makeLowCardinality<uint32_t>(64));
+
+#undef VARINT_BENCH
+
+int main() {
+  facebook::velox::memory::MemoryManager::initialize({});
+  folly::runBenchmarks();
+}

--- a/dwio/nimble/fuzzer/encoding/EncodingFuzzerTest.cpp
+++ b/dwio/nimble/fuzzer/encoding/EncodingFuzzerTest.cpp
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-/// Fuzzer tests for Varint encoding across supported data types.
+/// Fuzzer tests for all Nimble encodings across supported data types.
 ///
 /// Configuration via CLI flags:
 ///   --fuzzer_iterations=N     Number of iterations per test (default: 50)
@@ -25,7 +25,14 @@
 #include <gflags/gflags.h>
 #include <gtest/gtest.h>
 
+#include "dwio/nimble/encodings/ConstantEncoding.h"
+#include "dwio/nimble/encodings/DeltaEncoding.h"
+#include "dwio/nimble/encodings/DictionaryEncoding.h"
+#include "dwio/nimble/encodings/FixedBitWidthEncoding.h"
 #include "dwio/nimble/encodings/MainlyConstantEncoding.h"
+#include "dwio/nimble/encodings/RleEncoding.h"
+#include "dwio/nimble/encodings/SparseBoolEncoding.h"
+#include "dwio/nimble/encodings/TrivialEncoding.h"
 #include "dwio/nimble/encodings/VarintEncoding.h"
 #include "dwio/nimble/fuzzer/encoding/EncodingFuzzer.h"
 
@@ -36,6 +43,177 @@ DEFINE_bool(fuzzer_compression, true, "Test with compression enabled");
 
 using namespace facebook::nimble;
 using namespace facebook::nimble::test;
+
+// Trivial: all types
+using TrivialTypes = ::testing::Types<
+    TrivialEncoding<bool>,
+    TrivialEncoding<int8_t>,
+    TrivialEncoding<uint8_t>,
+    TrivialEncoding<int16_t>,
+    TrivialEncoding<uint16_t>,
+    TrivialEncoding<int32_t>,
+    TrivialEncoding<uint32_t>,
+    TrivialEncoding<int64_t>,
+    TrivialEncoding<uint64_t>,
+    TrivialEncoding<float>,
+    TrivialEncoding<double>,
+    TrivialEncoding<std::string_view>>;
+
+template <typename E>
+class TrivialFuzzerTest : public ::testing::Test {};
+TYPED_TEST_SUITE(TrivialFuzzerTest, TrivialTypes);
+
+TYPED_TEST(TrivialFuzzerTest, correctness) {
+  EncodingFuzzer<TypeParam> fuzzer(
+      FLAGS_fuzzer_iterations,
+      FLAGS_fuzzer_max_rows,
+      FLAGS_fuzzer_seed,
+      FLAGS_fuzzer_compression);
+  fuzzer.run();
+}
+
+// RLE: all types
+using RleTypes = ::testing::Types<
+    RLEEncoding<bool>,
+    RLEEncoding<int8_t>,
+    RLEEncoding<uint8_t>,
+    RLEEncoding<int16_t>,
+    RLEEncoding<uint16_t>,
+    RLEEncoding<int32_t>,
+    RLEEncoding<uint32_t>,
+    RLEEncoding<int64_t>,
+    RLEEncoding<uint64_t>,
+    RLEEncoding<float>,
+    RLEEncoding<double>,
+    RLEEncoding<std::string_view>>;
+
+template <typename E>
+class RleFuzzerTest : public ::testing::Test {};
+TYPED_TEST_SUITE(RleFuzzerTest, RleTypes);
+
+TYPED_TEST(RleFuzzerTest, correctness) {
+  EncodingFuzzer<TypeParam> fuzzer(
+      FLAGS_fuzzer_iterations,
+      FLAGS_fuzzer_max_rows,
+      FLAGS_fuzzer_seed,
+      FLAGS_fuzzer_compression);
+  fuzzer.run();
+}
+
+// Dictionary: all types except bool
+using DictionaryTypes = ::testing::Types<
+    DictionaryEncoding<int8_t>,
+    DictionaryEncoding<uint8_t>,
+    DictionaryEncoding<int16_t>,
+    DictionaryEncoding<uint16_t>,
+    DictionaryEncoding<int32_t>,
+    DictionaryEncoding<uint32_t>,
+    DictionaryEncoding<int64_t>,
+    DictionaryEncoding<uint64_t>,
+    DictionaryEncoding<float>,
+    DictionaryEncoding<double>,
+    DictionaryEncoding<std::string_view>>;
+
+template <typename E>
+class DictionaryFuzzerTest : public ::testing::Test {};
+TYPED_TEST_SUITE(DictionaryFuzzerTest, DictionaryTypes);
+
+TYPED_TEST(DictionaryFuzzerTest, correctness) {
+  EncodingFuzzer<TypeParam> fuzzer(
+      FLAGS_fuzzer_iterations,
+      FLAGS_fuzzer_max_rows,
+      FLAGS_fuzzer_seed,
+      FLAGS_fuzzer_compression);
+  fuzzer.run();
+}
+
+// FixedBitWidth: all numeric types
+using FixedBitWidthTypes = ::testing::Types<
+    FixedBitWidthEncoding<int8_t>,
+    FixedBitWidthEncoding<uint8_t>,
+    FixedBitWidthEncoding<int16_t>,
+    FixedBitWidthEncoding<uint16_t>,
+    FixedBitWidthEncoding<int32_t>,
+    FixedBitWidthEncoding<uint32_t>,
+    FixedBitWidthEncoding<int64_t>,
+    FixedBitWidthEncoding<uint64_t>,
+    FixedBitWidthEncoding<float>,
+    FixedBitWidthEncoding<double>>;
+
+template <typename E>
+class FixedBitWidthFuzzerTest : public ::testing::Test {};
+TYPED_TEST_SUITE(FixedBitWidthFuzzerTest, FixedBitWidthTypes);
+
+TYPED_TEST(FixedBitWidthFuzzerTest, correctness) {
+  EncodingFuzzer<TypeParam> fuzzer(
+      FLAGS_fuzzer_iterations,
+      FLAGS_fuzzer_max_rows,
+      FLAGS_fuzzer_seed,
+      FLAGS_fuzzer_compression);
+  fuzzer.run();
+}
+
+// Delta: integer types
+using DeltaTypes = ::testing::Types<
+    DeltaEncoding<int8_t>,
+    DeltaEncoding<uint8_t>,
+    DeltaEncoding<int16_t>,
+    DeltaEncoding<uint16_t>,
+    DeltaEncoding<int32_t>,
+    DeltaEncoding<uint32_t>,
+    DeltaEncoding<int64_t>,
+    DeltaEncoding<uint64_t>>;
+
+template <typename E>
+class DeltaFuzzerTest : public ::testing::Test {};
+TYPED_TEST_SUITE(DeltaFuzzerTest, DeltaTypes);
+
+TYPED_TEST(DeltaFuzzerTest, correctness) {
+  EncodingFuzzer<TypeParam> fuzzer(
+      FLAGS_fuzzer_iterations,
+      FLAGS_fuzzer_max_rows,
+      FLAGS_fuzzer_seed,
+      FLAGS_fuzzer_compression);
+  fuzzer.run();
+}
+
+// Constant: all types
+using ConstantTypes = ::testing::Types<
+    ConstantEncoding<bool>,
+    ConstantEncoding<int8_t>,
+    ConstantEncoding<uint8_t>,
+    ConstantEncoding<int16_t>,
+    ConstantEncoding<uint16_t>,
+    ConstantEncoding<int32_t>,
+    ConstantEncoding<uint32_t>,
+    ConstantEncoding<int64_t>,
+    ConstantEncoding<uint64_t>,
+    ConstantEncoding<float>,
+    ConstantEncoding<double>,
+    ConstantEncoding<std::string_view>>;
+
+template <typename E>
+class ConstantFuzzerTest : public ::testing::Test {};
+TYPED_TEST_SUITE(ConstantFuzzerTest, ConstantTypes);
+
+TYPED_TEST(ConstantFuzzerTest, correctness) {
+  EncodingFuzzer<TypeParam> fuzzer(
+      FLAGS_fuzzer_iterations,
+      FLAGS_fuzzer_max_rows,
+      FLAGS_fuzzer_seed,
+      FLAGS_fuzzer_compression);
+  fuzzer.run();
+}
+
+// SparseBool: bool only
+TEST(SparseBoolFuzzerTest, correctness) {
+  EncodingFuzzer<SparseBoolEncoding> fuzzer(
+      FLAGS_fuzzer_iterations,
+      FLAGS_fuzzer_max_rows,
+      FLAGS_fuzzer_seed,
+      FLAGS_fuzzer_compression);
+  fuzzer.run();
+}
 
 // Varint: 4+ byte types
 using VarintTypes = ::testing::Types<
@@ -50,7 +228,7 @@ template <typename E>
 class VarintFuzzerTest : public ::testing::Test {};
 TYPED_TEST_SUITE(VarintFuzzerTest, VarintTypes);
 
-TYPED_TEST(VarintFuzzerTest, Correctness) {
+TYPED_TEST(VarintFuzzerTest, correctness) {
   EncodingFuzzer<TypeParam> fuzzer(
       FLAGS_fuzzer_iterations,
       FLAGS_fuzzer_max_rows,
@@ -61,6 +239,10 @@ TYPED_TEST(VarintFuzzerTest, Correctness) {
 
 // MainlyConstant: all types except bool
 using MainlyConstantTypes = ::testing::Types<
+    MainlyConstantEncoding<int8_t>,
+    MainlyConstantEncoding<uint8_t>,
+    MainlyConstantEncoding<int16_t>,
+    MainlyConstantEncoding<uint16_t>,
     MainlyConstantEncoding<int32_t>,
     MainlyConstantEncoding<uint32_t>,
     MainlyConstantEncoding<int64_t>,
@@ -73,7 +255,7 @@ template <typename E>
 class MainlyConstantFuzzerTest : public ::testing::Test {};
 TYPED_TEST_SUITE(MainlyConstantFuzzerTest, MainlyConstantTypes);
 
-TYPED_TEST(MainlyConstantFuzzerTest, Correctness) {
+TYPED_TEST(MainlyConstantFuzzerTest, correctness) {
   EncodingFuzzer<TypeParam> fuzzer(
       FLAGS_fuzzer_iterations,
       FLAGS_fuzzer_max_rows,


### PR DESCRIPTION
Summary:
Adds fuzzer coverage for all Nimble encoding types. Previously only `VarintEncoding` and `MainlyConstantEncoding` were fuzzed. Now covers:
- `TrivialEncoding` (all types)
- `RLEEncoding` (all types)
- `DictionaryEncoding` (all non-bool types)
- `FixedBitWidthEncoding` (all numeric types)
- `DeltaEncoding` (integer types)
- `ConstantEncoding` (all types)
- `SparseBoolEncoding` (bool)

Also expands `MainlyConstantEncoding` coverage from 4+ byte types to all non-bool types (adds int8/uint8/int16/uint16).

Differential Revision: D105904214


