### PR TITLE
feat(encoding): Add skeleton/registration ALP to handle floats in Tensors (#762)

### DIFF
--- a/dwio/nimble/common/Types.cpp
+++ b/dwio/nimble/common/Types.cpp
@@ -49,6 +49,8 @@ std::string toString(EncodingType encodingType) {
       return "Sentinel";
     case EncodingType::Prefix:
       return "Prefix";
+    case EncodingType::ALP:
+      return "ALP";
   }
   return fmt::format(
       "Unknown encoding type: {}", static_cast<int32_t>(encodingType));

--- a/dwio/nimble/common/Types.h
+++ b/dwio/nimble/common/Types.h
@@ -104,6 +104,8 @@ enum class EncodingType {
   // shared across consecutive entries to reduce storage. Supports seek
   // operations for efficient random access.
   Prefix = 11,
+  // Adaptive Lossless floating-Point compression for numeric types.
+  ALP = 12,
 };
 std::string toString(EncodingType encodingType);
 std::ostream& operator<<(std::ostream& out, EncodingType encodingType);

--- a/dwio/nimble/common/tests/TypesTest.cpp
+++ b/dwio/nimble/common/tests/TypesTest.cpp
@@ -38,6 +38,7 @@ TEST(TypesTest, EncodingTypeToString) {
   EXPECT_EQ(toString(EncodingType::Constant), "Constant");
   EXPECT_EQ(toString(EncodingType::MainlyConstant), "MainlyConstant");
   EXPECT_EQ(toString(EncodingType::Prefix), "Prefix");
+  EXPECT_EQ(toString(EncodingType::ALP), "ALP");
 }
 
 TEST(TypesTest, EncodingTypeToStringUnknown) {

--- a/dwio/nimble/encodings/ALPEncoding.h
+++ b/dwio/nimble/encodings/ALPEncoding.h
@@ -1,0 +1,133 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <cstring>
+#include <span>
+#include "dwio/nimble/common/Buffer.h"
+#include "dwio/nimble/common/Exceptions.h"
+#include "dwio/nimble/encodings/common/Encoding.h"
+#include "dwio/nimble/encodings/common/EncodingPrimitives.h"
+#include "dwio/nimble/encodings/common/EncodingType.h"
+#include "dwio/nimble/encodings/selection/EncodingSelection.h"
+
+// TODO: Replace this no-op passthrough with the actual ALP compression
+// algorithm. The current implementation stores raw bytes identically to
+// TrivialEncoding and provides no compression benefit.
+
+namespace facebook::nimble {
+
+// Data layout is:
+// Prefix bytes: standard Encoding prefix
+// rowCount * sizeof(physicalType) bytes: raw values (passthrough)
+
+template <typename T>
+class ALPEncoding final
+    : public TypedEncoding<T, typename TypeTraits<T>::physicalType> {
+  static_assert(
+      isFloatingPointType<T>(),
+      "ALPEncoding only supports float and double types.");
+
+ public:
+  using cppDataType = T;
+  using physicalType = typename TypeTraits<T>::physicalType;
+
+  ALPEncoding(
+      velox::memory::MemoryPool& memoryPool,
+      std::string_view data,
+      std::function<void*(uint32_t)> /* stringBufferFactory */,
+      const Encoding::Options& options = {})
+      : TypedEncoding<T, physicalType>(memoryPool, data, options),
+        data_(data.data() + this->dataOffset()),
+        pos_(0) {}
+
+  void reset() final {
+    pos_ = 0;
+  }
+
+  void skip(uint32_t rowCount) final {
+    pos_ += rowCount;
+  }
+
+  // TODO: Implement actual ALP decoding instead of raw memcpy.
+  void materialize(uint32_t rowCount, void* buffer) final {
+    auto* output = static_cast<physicalType*>(buffer);
+    std::memcpy(
+        output,
+        data_ + pos_ * sizeof(physicalType),
+        rowCount * sizeof(physicalType));
+    pos_ += rowCount;
+  }
+
+  void materializeBoolsAsBits(
+      uint32_t /*rowCount*/,
+      uint64_t* /*buffer*/,
+      int /*begin*/) final {
+    NIMBLE_UNREACHABLE("ALP encoding does not support bool type.");
+  }
+
+  template <typename DecoderVisitor>
+  void readWithVisitor(DecoderVisitor& visitor, ReadWithVisitorParams& params) {
+    auto skipFn = [&](auto toSkip) { pos_ += toSkip; };
+    auto decodeFn = [&] {
+      physicalType value;
+      std::memcpy(&value, data_ + pos_ * sizeof(physicalType), sizeof(value));
+      ++pos_;
+      return value;
+    };
+    detail::readWithVisitorSlow(visitor, params, skipFn, decodeFn);
+  }
+
+  std::string debugString(int offset) const final {
+    return fmt::format(
+        "{}{}<{}> rowCount={}",
+        std::string(offset, ' '),
+        toString(this->encodingType()),
+        toString(this->dataType()),
+        this->rowCount());
+  }
+
+  // TODO: Implement actual ALP encoding instead of raw memcpy passthrough.
+  static std::string_view encode(
+      EncodingSelection<physicalType>& /* selection */,
+      std::span<const physicalType> values,
+      Buffer& buffer,
+      const Encoding::Options& options = {}) {
+    const bool useVarint = options.useVarintRowCount;
+    if (values.empty()) {
+      NIMBLE_INCOMPATIBLE_ENCODING("ALP encoding cannot encode empty data.");
+    }
+
+    const uint32_t rowCount = values.size();
+    const uint32_t dataBytes = rowCount * sizeof(physicalType);
+    const uint32_t encodingSize =
+        Encoding::serializePrefixSize(rowCount, useVarint) + dataBytes;
+    char* reserved = buffer.reserve(encodingSize);
+    char* pos = reserved;
+    Encoding::serializePrefix(
+        EncodingType::ALP, TypeTraits<T>::dataType, rowCount, useVarint, pos);
+    std::memcpy(pos, values.data(), dataBytes);
+    pos += dataBytes;
+    NIMBLE_DCHECK_EQ(pos - reserved, encodingSize, "Encoding size mismatch.");
+    return {reserved, encodingSize};
+  }
+
+ private:
+  const char* data_;
+  uint32_t pos_;
+};
+
+} // namespace facebook::nimble

--- a/dwio/nimble/encodings/common/EncodingFactory.cpp
+++ b/dwio/nimble/encodings/common/EncodingFactory.cpp
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 #include "dwio/nimble/encodings/common/EncodingFactory.h"
+#include "dwio/nimble/encodings/ALPEncoding.h"
 #include "dwio/nimble/encodings/ConstantEncoding.h"
 #include "dwio/nimble/encodings/DeltaEncoding.h"
 #include "dwio/nimble/encodings/DictionaryEncoding.h"
@@ -243,6 +244,11 @@ std::unique_ptr<Encoding> EncodingFactory::create(
     case EncodingType::Delta: {
       RETURN_ENCODING_BY_NUMERIC_TYPE(DeltaEncoding, dataType);
     }
+    case EncodingType::ALP: {
+      // TODO: Wire up ALPEncoding deserialization once the actual ALP algorithm
+      // is implemented. ALP only supports float and double.
+      NIMBLE_UNSUPPORTED("ALP encoding is not yet implemented.");
+    }
     default: {
       NIMBLE_UNREACHABLE(
           "Trying to deserialize invalid EncodingType:{} -- garbage input?",
@@ -375,6 +381,11 @@ std::string_view EncodingFactory::encode(
             "Delta encoding should not be selected for non-numeric data type: {}.",
             toString(TypeTraits<T>::dataType));
       }
+    }
+    case EncodingType::ALP: {
+      // TODO: Wire up ALPEncoding::encode once the actual ALP algorithm is
+      // implemented. ALP only supports float and double.
+      NIMBLE_UNSUPPORTED("ALP encoding is not yet implemented.");
     }
     default: {
       NIMBLE_UNSUPPORTED(

--- a/dwio/nimble/encodings/common/EncodingLayout.cpp
+++ b/dwio/nimble/encodings/common/EncodingLayout.cpp
@@ -171,7 +171,8 @@ EncodingLayout EncodingLayoutCapture::capture(std::string_view encoding) {
     case EncodingType::FixedBitWidth:
     case EncodingType::Varint:
     case EncodingType::Constant:
-    case EncodingType::Prefix: {
+    case EncodingType::Prefix:
+    case EncodingType::ALP: {
       // Non nested encodings have zero children
       break;
     }

--- a/dwio/nimble/encodings/common/EncodingUtils.h
+++ b/dwio/nimble/encodings/common/EncodingUtils.h
@@ -15,6 +15,7 @@
  */
 #pragma once
 
+#include "dwio/nimble/encodings/ALPEncoding.h"
 #include "dwio/nimble/encodings/ConstantEncoding.h"
 #include "dwio/nimble/encodings/DeltaEncoding.h"
 #include "dwio/nimble/encodings/DictionaryEncoding.h"
@@ -124,6 +125,10 @@ auto encodingTypeDispatchNonString(Encoding& encoding, F&& f) {
       return f(static_cast<MainlyConstantEncoding<T>&>(encoding));
     case EncodingType::Delta:
       return f(static_cast<DeltaEncoding<T>&>(encoding));
+    case EncodingType::ALP:
+      // TODO: Wire up ALPEncoding readWithVisitor dispatch once the actual
+      // ALP algorithm is implemented. ALP only supports float and double.
+      NIMBLE_UNSUPPORTED("ALP encoding is not yet implemented.");
     default:
       NIMBLE_UNSUPPORTED("{}", encoding.encodingType());
   }

--- a/dwio/nimble/encodings/selection/EncodingSelectionPolicy.h
+++ b/dwio/nimble/encodings/selection/EncodingSelectionPolicy.h
@@ -372,6 +372,8 @@ class ManualEncodingSelectionPolicyFactory {
         std::nullopt);
   }
 
+  // TODO: Add EncodingType::ALP here once the actual ALP algorithm is
+  // implemented and size estimation is wired up in EncodingSizeEstimation.h.
   static std::vector<EncodingType> possibleEncodings() {
     return {
         EncodingType::Constant,
@@ -385,6 +387,8 @@ class ManualEncodingSelectionPolicyFactory {
     };
   }
 
+  // TODO: Add EncodingType::ALP with an appropriate read factor once the
+  // actual ALP algorithm is implemented.
   static std::vector<std::pair<EncodingType, float>> defaultReadFactors() {
     return {
         {EncodingType::Constant, 1.0},
@@ -536,6 +540,8 @@ class LearnedEncodingSelectionPolicy : public EncodingSelectionPolicy<T> {
   }
 
  private:
+  // TODO: Add EncodingType::ALP here once the actual ALP algorithm is
+  // implemented.
   static std::vector<EncodingType> possibleEncodingChoices() {
     return {
         EncodingType::Constant,

--- a/dwio/nimble/encodings/selection/EncodingSizeEstimation.h
+++ b/dwio/nimble/encodings/selection/EncodingSizeEstimation.h
@@ -33,6 +33,8 @@ template <typename T, bool FixedByteWidth>
 struct EncodingSizeEstimation {
   using physicalType = typename TypeTraits<T>::physicalType;
 
+  // TODO: Add EncodingType::ALP size estimation case once the actual ALP
+  // algorithm is implemented.
   static std::optional<uint64_t> estimateNumericSize(
       const EncodingType encodingType,
       const uint64_t entryCount,

--- a/dwio/nimble/encodings/tests/ALPEncodingTest.cpp
+++ b/dwio/nimble/encodings/tests/ALPEncodingTest.cpp
@@ -1,0 +1,180 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "dwio/nimble/encodings/ALPEncoding.h"
+#include <glog/logging.h>
+#include <gtest/gtest.h>
+#include "dwio/nimble/common/Buffer.h"
+#include "dwio/nimble/common/Types.h"
+#include "dwio/nimble/common/tests/NimbleCompare.h"
+#include "dwio/nimble/encodings/tests/TestUtils.h"
+
+#include <limits>
+#include <vector>
+
+using namespace facebook;
+
+template <typename DataType, bool UseVarint>
+struct TestConfig {
+  using data_type = DataType;
+  static constexpr bool useVarint = UseVarint;
+};
+
+#define TC(T) TestConfig<T, false>, TestConfig<T, true>
+
+template <typename Config>
+class ALPEncodingTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    pool_ = facebook::velox::memory::deprecatedAddDefaultLeafMemoryPool();
+    buffer_ = std::make_unique<nimble::Buffer>(*pool_);
+  }
+
+  template <typename T>
+  nimble::Vector<T> toVector(std::initializer_list<T> l) {
+    nimble::Vector<T> v{pool_.get()};
+    v.insert(v.end(), l.begin(), l.end());
+    return v;
+  }
+
+  std::shared_ptr<velox::memory::MemoryPool> pool_;
+  std::unique_ptr<nimble::Buffer> buffer_;
+};
+
+using TestTypes = ::testing::Types<TC(float), TC(double)>;
+
+TYPED_TEST_CASE(ALPEncodingTest, TestTypes);
+
+TYPED_TEST(ALPEncodingTest, roundTrip) {
+  using D = typename TypeParam::data_type;
+  const nimble::Encoding::Options options{
+      .useVarintRowCount = TypeParam::useVarint};
+
+  auto values = this->template toVector<D>({1, 2, 3, 4, 5});
+
+  std::vector<velox::BufferPtr> stringBuffers;
+  const auto stringBufferFactory = [&](uint32_t totalLength) {
+    auto& buf = stringBuffers.emplace_back(
+        velox::AlignedBuffer::allocate<char>(totalLength, this->pool_.get()));
+    return buf->template asMutable<void>();
+  };
+
+  auto encoding = nimble::test::Encoder<nimble::ALPEncoding<D>>::createEncoding(
+      *this->buffer_,
+      values,
+      stringBufferFactory,
+      nimble::CompressionType::Uncompressed,
+      options);
+
+  EXPECT_EQ(encoding->encodingType(), nimble::EncodingType::ALP);
+  EXPECT_EQ(encoding->dataType(), nimble::TypeTraits<D>::dataType);
+  EXPECT_EQ(encoding->rowCount(), values.size());
+
+  nimble::Vector<D> result(this->pool_.get(), values.size());
+  encoding->materialize(values.size(), result.data());
+
+  for (uint32_t i = 0; i < values.size(); ++i) {
+    EXPECT_TRUE(nimble::NimbleCompare<D>::equals(result[i], values[i]));
+  }
+}
+
+TYPED_TEST(ALPEncodingTest, skipAndMaterialize) {
+  using D = typename TypeParam::data_type;
+  const nimble::Encoding::Options options{
+      .useVarintRowCount = TypeParam::useVarint};
+
+  auto values = this->template toVector<D>({10, 20, 30, 40, 50, 60});
+
+  std::vector<velox::BufferPtr> stringBuffers;
+  const auto stringBufferFactory = [&](uint32_t totalLength) {
+    auto& buf = stringBuffers.emplace_back(
+        velox::AlignedBuffer::allocate<char>(totalLength, this->pool_.get()));
+    return buf->template asMutable<void>();
+  };
+
+  auto encoding = nimble::test::Encoder<nimble::ALPEncoding<D>>::createEncoding(
+      *this->buffer_,
+      values,
+      stringBufferFactory,
+      nimble::CompressionType::Uncompressed,
+      options);
+
+  encoding->skip(2);
+
+  nimble::Vector<D> result(this->pool_.get(), 3);
+  encoding->materialize(3, result.data());
+
+  EXPECT_TRUE(nimble::NimbleCompare<D>::equals(result[0], D{30}));
+  EXPECT_TRUE(nimble::NimbleCompare<D>::equals(result[1], D{40}));
+  EXPECT_TRUE(nimble::NimbleCompare<D>::equals(result[2], D{50}));
+}
+
+TYPED_TEST(ALPEncodingTest, resetAndRematerialize) {
+  using D = typename TypeParam::data_type;
+  const nimble::Encoding::Options options{
+      .useVarintRowCount = TypeParam::useVarint};
+
+  auto values = this->template toVector<D>({7, 8, 9});
+
+  std::vector<velox::BufferPtr> stringBuffers;
+  const auto stringBufferFactory = [&](uint32_t totalLength) {
+    auto& buf = stringBuffers.emplace_back(
+        velox::AlignedBuffer::allocate<char>(totalLength, this->pool_.get()));
+    return buf->template asMutable<void>();
+  };
+
+  auto encoding = nimble::test::Encoder<nimble::ALPEncoding<D>>::createEncoding(
+      *this->buffer_,
+      values,
+      stringBufferFactory,
+      nimble::CompressionType::Uncompressed,
+      options);
+
+  nimble::Vector<D> first(this->pool_.get(), values.size());
+  encoding->materialize(values.size(), first.data());
+
+  encoding->reset();
+
+  nimble::Vector<D> second(this->pool_.get(), values.size());
+  encoding->materialize(values.size(), second.data());
+
+  for (uint32_t i = 0; i < values.size(); ++i) {
+    EXPECT_TRUE(nimble::NimbleCompare<D>::equals(first[i], second[i]));
+  }
+}
+
+TYPED_TEST(ALPEncodingTest, emptyDataRejected) {
+  using D = typename TypeParam::data_type;
+  const nimble::Encoding::Options options{
+      .useVarintRowCount = TypeParam::useVarint};
+
+  nimble::Vector<D> empty{this->pool_.get()};
+
+  std::vector<velox::BufferPtr> stringBuffers;
+  const auto stringBufferFactory = [&](uint32_t totalLength) {
+    auto& buf = stringBuffers.emplace_back(
+        velox::AlignedBuffer::allocate<char>(totalLength, this->pool_.get()));
+    return buf->template asMutable<void>();
+  };
+
+  EXPECT_THROW(
+      nimble::test::Encoder<nimble::ALPEncoding<D>>::createEncoding(
+          *this->buffer_,
+          empty,
+          stringBufferFactory,
+          nimble::CompressionType::Uncompressed,
+          options),
+      nimble::NimbleUserError);
+}

--- a/dwio/nimble/encodings/tests/TestUtils.h
+++ b/dwio/nimble/encodings/tests/TestUtils.h
@@ -15,6 +15,7 @@
  */
 #pragma once
 
+#include "dwio/nimble/encodings/ALPEncoding.h"
 #include "dwio/nimble/encodings/ConstantEncoding.h"
 #include "dwio/nimble/encodings/DeltaEncoding.h"
 #include "dwio/nimble/encodings/DictionaryEncoding.h"
@@ -113,6 +114,12 @@ class Encoder {
 
   template <typename Encoding>
   struct EncodingTypeTraits {};
+
+  template <>
+  struct EncodingTypeTraits<nimble::ALPEncoding<T>> {
+    static constexpr inline nimble::EncodingType encodingType =
+        nimble::EncodingType::ALP;
+  };
 
   template <>
   struct EncodingTypeTraits<nimble::ConstantEncoding<T>> {

--- a/dwio/nimble/fuzzer/encoding/EncodingFuzzerTest.cpp
+++ b/dwio/nimble/fuzzer/encoding/EncodingFuzzerTest.cpp
@@ -25,6 +25,7 @@
 #include <gflags/gflags.h>
 #include <gtest/gtest.h>
 
+#include "dwio/nimble/encodings/ALPEncoding.h"
 #include "dwio/nimble/encodings/ConstantEncoding.h"
 #include "dwio/nimble/encodings/DeltaEncoding.h"
 #include "dwio/nimble/encodings/DictionaryEncoding.h"
@@ -256,6 +257,22 @@ class MainlyConstantFuzzerTest : public ::testing::Test {};
 TYPED_TEST_SUITE(MainlyConstantFuzzerTest, MainlyConstantTypes);
 
 TYPED_TEST(MainlyConstantFuzzerTest, correctness) {
+  EncodingFuzzer<TypeParam> fuzzer(
+      FLAGS_fuzzer_iterations,
+      FLAGS_fuzzer_max_rows,
+      FLAGS_fuzzer_seed,
+      FLAGS_fuzzer_compression);
+  fuzzer.run();
+}
+
+// ALP: float and double only
+using ALPTypes = ::testing::Types<ALPEncoding<float>, ALPEncoding<double>>;
+
+template <typename E>
+class ALPFuzzerTest : public ::testing::Test {};
+TYPED_TEST_SUITE(ALPFuzzerTest, ALPTypes);
+
+TYPED_TEST(ALPFuzzerTest, correctness) {
   EncodingFuzzer<TypeParam> fuzzer(
       FLAGS_fuzzer_iterations,
       FLAGS_fuzzer_max_rows,

--- a/dwio/nimble/tools/EncodingUtilities.cpp
+++ b/dwio/nimble/tools/EncodingUtilities.cpp
@@ -49,6 +49,7 @@ void extractCompressionType(
     case EncodingType::Constant:
     case EncodingType::MainlyConstant:
     case EncodingType::Prefix:
+    case EncodingType::ALP:
       break;
   }
 }
@@ -101,7 +102,8 @@ void traverseEncodings(
     case EncodingType::FixedBitWidth:
     case EncodingType::Varint:
     case EncodingType::Constant:
-    case EncodingType::Prefix: {
+    case EncodingType::Prefix:
+    case EncodingType::ALP: {
       // don't have any nested encoding
       break;
     }


### PR DESCRIPTION
Summary:

Adds a skeleton/registration-only ALP encoding type to the Nimble encoding system. The implementation is a no-op passthrough (stores raw bytes like `TrivialEncoding`) to be replaced with the actual ALP algorithm in a follow-up.

Reviewed By: apurva-meta

Differential Revision: D105906376
