### PR TITLE
feat: Replace Nimble encoding framework with FixedBitWidth for stream sizes trailer (#763)

### DIFF
--- a/dwio/nimble/serializer/DeserializerImpl.cpp
+++ b/dwio/nimble/serializer/DeserializerImpl.cpp
@@ -287,7 +287,7 @@ void StreamDataReader::iterateStreams(
         callback) {
   if (nonLegacyFormat(version_)) {
     // kCompact/kCompactRaw/kTabletRaw format: read stream sizes from trailer.
-    const auto streamSizes = detail::readStreamSizes(end_, version_, pool_);
+    const auto streamSizes = detail::readTrailerStreamSizes(end_);
     const bool tabletRaw = isTabletRawFormat(version_);
 
     for (uint32_t i = 0; i < streamSizes.size(); ++i) {

--- a/dwio/nimble/serializer/Options.cpp
+++ b/dwio/nimble/serializer/Options.cpp
@@ -36,14 +36,17 @@ std::string toString(SerializationVersion version) {
   }
 }
 
-EncodingType getRawEncodingType(EncodingType encodingType) {
+EncodingType getTrailerEncodingType(EncodingType encodingType) {
   switch (encodingType) {
     case EncodingType::Trivial:
     case EncodingType::Varint:
     case EncodingType::Delta:
+    case EncodingType::FixedBitWidth:
       return encodingType;
     default:
-      NIMBLE_FAIL("Unsupported EncodingType for kCompactRaw: {}", encodingType);
+      NIMBLE_FAIL(
+          "Unsupported EncodingType for stream sizes trailer: {}",
+          encodingType);
   }
 }
 

--- a/dwio/nimble/serializer/Options.h
+++ b/dwio/nimble/serializer/Options.h
@@ -52,8 +52,8 @@ namespace facebook::nimble {
 ///   Wire: [version:1B][rowCount:varint][stream_data_0]...[stream_data_N]
 ///         [encodingType:1B][raw_sizes_payload][trailer_size:u32]
 ///   trailer_size = 1 + len(raw_sizes_payload).
-///   Supported EncodingTypes: Trivial, Varint, Delta.
-///   See getRawEncodingType() for validation.
+///   Supported EncodingTypes: Trivial, Varint, Delta, FixedBitWidth.
+///   See getTrailerEncodingType() for validation.
 ///
 /// - kTabletRaw: Raw tablet stream passthrough format. Like kCompactRaw but:
 ///   (1) Each stream's data includes tablet chunk headers:
@@ -126,9 +126,9 @@ inline bool usesVarintRowCount(std::optional<SerializationVersion> version) {
   return version.has_value() && usesVarintRowCount(version.value());
 }
 
-/// Validates and returns the EncodingType for kCompactRaw stream sizes.
-/// Supported: Trivial, Varint, Delta.
-EncodingType getRawEncodingType(EncodingType encodingType);
+/// Validates and returns the EncodingType for stream sizes trailer.
+/// Supported: Trivial, Varint, Delta, FixedBitWidth.
+EncodingType getTrailerEncodingType(EncodingType encodingType);
 
 inline std::ostream& operator<<(
     std::ostream& os,
@@ -186,9 +186,9 @@ struct SerializerOptions {
   /// replay. When nullopt (default), compression is disabled.
   std::optional<CompressionOptions> compressionOptions{};
 
-  /// Encoding type for stream sizes in the sizes header.
-  /// Defaults to Trivial encoding.
-  EncodingType streamSizesEncodingType{EncodingType::Trivial};
+  /// Encoding type for stream sizes in the trailer.
+  /// Supported types: Trivial, Varint, Delta, FixedBitWidth.
+  EncodingType streamSizesEncodingType{EncodingType::FixedBitWidth};
 
   /// Returns true if the serialized data has a version header byte.
   bool hasVersionHeader() const;

--- a/dwio/nimble/serializer/Projector.cpp
+++ b/dwio/nimble/serializer/Projector.cpp
@@ -258,7 +258,6 @@ Projector::Projector(
     Options options)
     : pool_(pool),
       options_(std::move(options)),
-      streamSizesEncodingBuffer_(*pool, /*initialChunkSize=*/4096),
       inputSchema_(std::move(inputSchema)) {
   NIMBLE_CHECK_NOT_NULL(pool_, "Memory pool cannot be null");
   NIMBLE_CHECK_NOT_NULL(inputSchema_, "Input schema cannot be null");
@@ -574,11 +573,7 @@ folly::IOBuf Projector::buildProjectedOutput(
           outputStreamSizes.size(),
           options_.streamSizesEncodingType));
   detail::writeTrailer(
-      options_.projectVersion,
-      outputStreamSizes,
-      options_.streamSizesEncodingType,
-      streamSizesEncodingBuffer_,
-      trailer);
+      outputStreamSizes, options_.streamSizesEncodingType, trailer);
   output->appendToChain(std::move(trailer).build());
   return std::move(*output);
 }
@@ -606,8 +601,7 @@ folly::IOBuf Projector::projectContiguous(
   detail::writeHeader(header, options_.projectVersion, rowCount);
   auto output = std::move(header).build();
 
-  const auto inputStreamSizes =
-      detail::readStreamSizes(input, inputVersion, pool_);
+  const auto inputStreamSizes = detail::readTrailerStreamSizes(input);
 
   // Extract selected streams as zero-copy sub-range clones.
   const auto dataOffset = static_cast<size_t>(pos - data);
@@ -634,8 +628,7 @@ folly::IOBuf Projector::projectChained(
   detail::writeHeader(header, options_.projectVersion, rowCount);
   auto output = std::move(header).build();
 
-  const auto inputStreamSizes =
-      detail::readStreamSizes(input, inputVersion, pool_);
+  const auto inputStreamSizes = detail::readTrailerStreamSizes(input);
 
   // Extract selected streams as zero-copy clones via cursor.
   auto outputStreamSizes = inputStreamsSorted_

--- a/dwio/nimble/serializer/Projector.h
+++ b/dwio/nimble/serializer/Projector.h
@@ -72,11 +72,9 @@ class Projector {
     /// Output serialization format version. Must be kCompact or kCompactRaw.
     SerializationVersion projectVersion{SerializationVersion::kCompact};
 
-    /// Encoding type for stream sizes in the sizes header.
-    /// For kCompact: forces nimble encoding to this type.
-    /// For kCompactRaw: only Trivial and Varint are supported.
-    /// Defaults to Trivial.
-    EncodingType streamSizesEncodingType{EncodingType::Trivial};
+    /// Encoding type for stream sizes in the trailer.
+    /// Supported types: Trivial, Varint, Delta, FixedBitWidth.
+    EncodingType streamSizesEncodingType{EncodingType::FixedBitWidth};
 
     /// Optional velox type with up-to-date column names from the current
     /// table schema. After schema evolution (e.g., column renames), the
@@ -197,9 +195,6 @@ class Projector {
 
   velox::memory::MemoryPool* const pool_;
   const Options options_;
-
-  // Reusable encoding buffer for stream sizes trailer. Reset before each use.
-  mutable nimble::Buffer streamSizesEncodingBuffer_;
 
   std::shared_ptr<const Type> inputSchema_;
   // Built during construction.

--- a/dwio/nimble/serializer/Serializer.cpp
+++ b/dwio/nimble/serializer/Serializer.cpp
@@ -48,10 +48,7 @@ Serializer::Serializer(
         SerializationVersion::kTabletRaw,
         "kTabletRaw is not supported by the serializer. It is only used in projection.");
   }
-  NIMBLE_CHECK(
-      options_.streamSizesEncodingType == EncodingType::Trivial ||
-          options_.enableEncoding(),
-      "Non-trivial streamSizesEncodingType requires a non-legacy version");
+  // streamSizesEncodingType is ignored for kLegacy (no trailer).
   const std::shared_ptr<const velox::dwio::common::TypeWithId> typeWithId =
       velox::dwio::common::TypeWithId::create(type);
 

--- a/dwio/nimble/serializer/SerializerImpl.cpp
+++ b/dwio/nimble/serializer/SerializerImpl.cpp
@@ -28,19 +28,7 @@
 namespace facebook::nimble::serde::detail {
 namespace {
 
-std::vector<uint32_t> decodeCompactStreamSizes(
-    std::string_view encodedSizes,
-    velox::memory::MemoryPool* pool) {
-  NIMBLE_CHECK_NOT_NULL(pool);
-  auto encoding = EncodingFactory(Encoding::Options{.useVarintRowCount = true})
-                      .create(*pool, encodedSizes, nullptr);
-  const uint32_t count = encoding->rowCount();
-  std::vector<uint32_t> values(count);
-  encoding->materialize(count, values.data());
-  return values;
-}
-
-std::vector<uint32_t> decodeRawStreamSizes(
+std::vector<uint32_t> decodeTrailerStreamSizes(
     const char* trailerStart,
     uint32_t trailerSize) {
   const auto* end = trailerStart + trailerSize;
@@ -80,14 +68,30 @@ std::vector<uint32_t> decodeRawStreamSizes(
       }
       break;
     }
+    case EncodingType::FixedBitWidth: {
+      const uint8_t bitWidth = static_cast<uint8_t>(*payload++);
+      const uint32_t count = varint::readVarint32(&payload);
+      sizes.resize(count);
+      if (bitWidth > 0 && count > 0) {
+        const uint32_t packedBytes =
+            static_cast<uint32_t>(FixedBitArray::bufferSize(count, bitWidth));
+        FixedBitArray arr{
+            const_cast<char*>(payload), static_cast<int>(bitWidth)};
+        arr.bulkGet32(0, count, sizes.data());
+        payload += packedBytes;
+      }
+      break;
+    }
     default:
-      NIMBLE_FAIL("Unsupported EncodingType for kCompactRaw: {}", encodingType);
+      NIMBLE_FAIL(
+          "Unsupported EncodingType for stream sizes trailer: {}",
+          encodingType);
   }
 
   NIMBLE_CHECK_EQ(
       payload,
       end,
-      "Raw trailer size mismatch: read {} bytes, expected {}",
+      "Trailer size mismatch: read {} bytes, expected {}",
       payload - trailerStart,
       trailerSize);
   return sizes;
@@ -187,22 +191,13 @@ encode(const SerializerOptions& options, std::string_view input, char* output) {
   return size + sizeof(uint32_t) + 1;
 }
 
-std::vector<uint32_t> readStreamSizes(
-    const char* end,
-    SerializationVersion version,
-    velox::memory::MemoryPool* pool) {
+std::vector<uint32_t> readTrailerStreamSizes(const char* end) {
   const uint32_t trailerSize = readTrailerSize(end);
   const char* trailerStart = end - sizeof(uint32_t) - trailerSize;
-  if (isRawFormat(version)) {
-    return decodeRawStreamSizes(trailerStart, trailerSize);
-  }
-  return decodeCompactStreamSizes({trailerStart, trailerSize}, pool);
+  return decodeTrailerStreamSizes(trailerStart, trailerSize);
 }
 
-std::vector<uint32_t> readStreamSizes(
-    const folly::IOBuf& input,
-    SerializationVersion version,
-    velox::memory::MemoryPool* pool) {
+std::vector<uint32_t> readTrailerStreamSizes(const folly::IOBuf& input) {
   // Fast path: trailer fits in the tail segment.
   const auto* tail = input.prev();
   if (tail->length() >= sizeof(uint32_t)) {
@@ -210,7 +205,7 @@ std::vector<uint32_t> readStreamSizes(
         reinterpret_cast<const char*>(tail->data()) + tail->length();
     const uint32_t trailerSize = readTrailerSize(tailEnd);
     if (tail->length() >= sizeof(uint32_t) + trailerSize) {
-      return readStreamSizes(tailEnd, version, pool);
+      return readTrailerStreamSizes(tailEnd);
     }
   }
 
@@ -224,14 +219,11 @@ std::vector<uint32_t> readStreamSizes(
   sizesCursor.skip(totalLength - sizeof(uint32_t) - trailerSize);
   std::string trailerBuf(trailerSize, '\0');
   sizesCursor.pull(trailerBuf.data(), trailerSize);
-  if (isRawFormat(version)) {
-    return decodeRawStreamSizes(trailerBuf.data(), trailerSize);
-  }
-  return decodeCompactStreamSizes(trailerBuf, pool);
+  return decodeTrailerStreamSizes(trailerBuf.data(), trailerSize);
 }
 
-size_t estimateRawTrailerSize(size_t numStreams, EncodingType encodingType) {
-  const auto resolvedType = getRawEncodingType(encodingType);
+size_t estimateTrailerSize(size_t numStreams, EncodingType encodingType) {
+  const auto resolvedType = getTrailerEncodingType(encodingType);
   // [encodingType:1B][payload][trailer_size:u32]
   size_t payloadSize{0};
   switch (resolvedType) {
@@ -247,8 +239,16 @@ size_t estimateRawTrailerSize(size_t numStreams, EncodingType encodingType) {
       // varints (max 5 bytes each).
       payloadSize = 5 + numStreams * 5;
       break;
+    case EncodingType::FixedBitWidth:
+      // Upper bound: bitWidth:1B + count varint + bufferSize (32 bits per
+      // element max).
+      payloadSize =
+          1 + 5 + FixedBitArray::bufferSize(numStreams, /*bitWidth=*/32);
+      break;
     default:
-      NIMBLE_FAIL("Unsupported EncodingType for kCompactRaw: {}", resolvedType);
+      NIMBLE_FAIL(
+          "Unsupported EncodingType for stream sizes trailer: {}",
+          resolvedType);
   }
   return sizeof(uint8_t) + payloadSize + sizeof(uint32_t);
 }
@@ -263,7 +263,7 @@ std::vector<std::string_view> parseStreams(
   std::vector<std::string_view> streams;
 
   if (isCompactFormat(version)) {
-    const auto streamSizes = readStreamSizes(end, version, pool);
+    const auto streamSizes = readTrailerStreamSizes(end);
     streams.resize(streamSizes.size());
 
     for (uint32_t i = 0; i < streamSizes.size(); ++i) {

--- a/dwio/nimble/serializer/SerializerImpl.h
+++ b/dwio/nimble/serializer/SerializerImpl.h
@@ -17,9 +17,11 @@
 #pragma once
 
 #include <algorithm>
+#include <bit>
 #include <optional>
 
 #include "dwio/nimble/common/Buffer.h"
+#include "dwio/nimble/common/FixedBitArray.h"
 #include "dwio/nimble/common/Varint.h"
 #include "dwio/nimble/common/Zigzag.h"
 #include "dwio/nimble/encodings/common/EncodingFactory.h"
@@ -107,8 +109,6 @@ std::string_view encodeTyped(
 }
 
 /// Reads the trailer size (u32) from the last 4 bytes of the buffer.
-/// For kCompact: the encoded stream sizes byte count.
-/// For kCompactRaw: the raw trailer byte count (including encodingType).
 inline uint32_t readTrailerSize(const char* end) {
   const char* pos = end - sizeof(uint32_t);
   return encoding::readUint32(pos);
@@ -171,180 +171,142 @@ void writeHeader(
   }
 }
 
-/// Returns an upper-bound estimate of the kCompact trailer size.
-/// The actual size depends on the encoding selected for stream sizes, so
-/// this is a conservative estimate (trivial encoding = raw uint32 values +
-/// encoding header overhead + trailing u32).
-///
-/// @param numStreams Number of streams (size of the streamSizes array).
-inline size_t estimateCompactTrailerSize(size_t numStreams) {
-  // Encoding header overhead (encoding type, row count varint, nested headers).
-  constexpr size_t kEncodingHeaderOverhead = 32;
-  // Trivial encoding: raw uint32 values.
-  // Trailing u32: stores the encoded sizes byte count.
-  return numStreams * sizeof(uint32_t) + kEncodingHeaderOverhead +
-      sizeof(uint32_t);
-}
+/// Returns an upper-bound estimate of the trailer size.
+size_t estimateTrailerSize(size_t numStreams, EncodingType encodingType);
 
-/// Returns the exact byte size of the kCompactRaw trailer.
-size_t estimateRawTrailerSize(size_t numStreams, EncodingType encodingType);
-
-/// Returns an upper-bound estimate of the trailer size for the given
-/// serialization version (kCompact, kCompactRaw, or kTabletRaw).
+/// Overload that accepts SerializationVersion for API compatibility.
 inline size_t estimateTrailerSize(
-    SerializationVersion outputVersion,
+    SerializationVersion /* outputVersion */,
     size_t numStreams,
     std::optional<EncodingType> encodingType = std::nullopt) {
-  if (isRawFormat(outputVersion)) {
-    return estimateRawTrailerSize(
-        numStreams, encodingType.value_or(EncodingType::Trivial));
-  }
-  return estimateCompactTrailerSize(numStreams);
+  return estimateTrailerSize(
+      numStreams, encodingType.value_or(EncodingType::FixedBitWidth));
 }
 
-/// Writes the kCompactRaw trailer: appends
-/// [encodingType:1B][payload][trailer_size:u32] to buffer.
-///
-/// @param streamSizes Dense stream sizes array. sizes[i] = byte size of
-///        stream i (0 for missing).
-/// @param encodingType Encoding type for stream sizes.
-/// @param buffer Output buffer.
+/// Writes the Trivial trailer: raw u32 memcpy.
+/// Wire: [encodingType:1B][size_0:u32]...[size_N:u32][trailer_size:u32]
 template <typename T>
-void writeRawTrailer(
-    const std::vector<uint32_t>& streamSizes,
-    EncodingType encodingType,
-    T& buffer) {
-  const auto resolvedType = getRawEncodingType(encodingType);
+void writeTrivialTrailer(const std::vector<uint32_t>& streamSizes, T& buffer) {
   const auto streamCount = streamSizes.size();
-
-  switch (resolvedType) {
-    case EncodingType::Trivial: {
-      const uint32_t payloadSize = streamCount * sizeof(uint32_t);
-      const uint32_t trailerSize = sizeof(uint8_t) + payloadSize;
-      // [encodingType:1B][size_0:u32]...[size_N:u32][trailer_size:u32]
-      auto* pos = extend(buffer, trailerSize + sizeof(uint32_t));
-      *pos++ = static_cast<char>(resolvedType);
-      if (payloadSize > 0) {
-        std::memcpy(pos, streamSizes.data(), payloadSize);
-        pos += payloadSize;
-      }
-      encoding::writeUint32(trailerSize, pos);
-      break;
-    }
-    case EncodingType::Varint: {
-      const auto countVarintSize =
-          varint::varintSize(static_cast<uint32_t>(streamCount));
-      const auto dataVarintSize = varint::bulkVarintSize32(streamSizes);
-      const uint32_t trailerSize =
-          sizeof(uint8_t) + countVarintSize + dataVarintSize;
-      auto* pos = extend(buffer, trailerSize + sizeof(uint32_t));
-      *pos++ = static_cast<char>(resolvedType);
-      varint::writeVarint(static_cast<uint32_t>(streamCount), &pos);
-      for (const auto size : streamSizes) {
-        varint::writeVarint(size, &pos);
-      }
-      encoding::writeUint32(trailerSize, pos);
-      break;
-    }
-    case EncodingType::Delta: {
-      // Delta encoding: store first size as varint, then deltas as varints.
-      // Wire: [encodingType:1B][count:varint][first:varint]
-      //       [delta_1:varint]...[delta_N:varint][trailer_size:u32]
-      const auto countVarintSize =
-          varint::varintSize(static_cast<uint32_t>(streamCount));
-      uint64_t dataVarintSize = 0;
-      if (streamCount > 0) {
-        dataVarintSize = varint::varintSize(streamSizes[0]);
-        for (size_t i = 1; i < streamCount; ++i) {
-          const auto delta = streamSizes[i] - streamSizes[i - 1];
-          dataVarintSize += varint::varintSize(delta);
-        }
-      }
-      const uint32_t trailerSize =
-          sizeof(uint8_t) + countVarintSize + dataVarintSize;
-      auto* pos = extend(buffer, trailerSize + sizeof(uint32_t));
-      *pos++ = static_cast<char>(resolvedType);
-      varint::writeVarint(static_cast<uint32_t>(streamCount), &pos);
-      if (streamCount > 0) {
-        varint::writeVarint(streamSizes[0], &pos);
-        for (size_t i = 1; i < streamCount; ++i) {
-          const auto delta = streamSizes[i] - streamSizes[i - 1];
-          varint::writeVarint(delta, &pos);
-        }
-      }
-      encoding::writeUint32(trailerSize, pos);
-      break;
-    }
-    default:
-      NIMBLE_FAIL("Unsupported EncodingType for kCompactRaw: {}", resolvedType);
+  const uint32_t payloadSize = streamCount * sizeof(uint32_t);
+  const uint32_t trailerSize = sizeof(uint8_t) + payloadSize;
+  auto* pos = extend(buffer, trailerSize + sizeof(uint32_t));
+  *pos++ = static_cast<char>(EncodingType::Trivial);
+  if (payloadSize > 0) {
+    std::memcpy(pos, streamSizes.data(), payloadSize);
+    pos += payloadSize;
   }
+  encoding::writeUint32(trailerSize, pos);
 }
 
-/// Writes the kCompact trailer: appends
-/// [encoded_stream_sizes][stream_sizes_encoded_size:u32] to buffer.
-///
-/// @param streamSizes Dense stream sizes array. sizes[i] = byte size of
-///        stream i (0 for missing).
-/// @param encodingType Encoding type for stream sizes.
-/// @param encodingBuffer Encoding buffer for nimble encoding output.
-/// @param buffer Output buffer.
+/// Writes the Varint trailer: each stream size as a varint.
+/// Wire: [encodingType:1B][count:varint][v_0:varint]...[trailer_size:u32]
 template <typename T>
-void writeCompactTrailer(
-    const std::vector<uint32_t>& streamSizes,
-    EncodingType encodingType,
-    nimble::Buffer& encodingBuffer,
-    T& buffer) {
-  encodingBuffer.reset();
-
-  EncodingLayout layout{encodingType, {}, CompressionType::Uncompressed};
-  auto policy = std::make_unique<ReplayedEncodingSelectionPolicy<uint32_t>>(
-      std::move(layout),
-      /*compressionOptions=*/std::nullopt,
-      createDefaultEncodingPolicy);
-  auto encodedStreamSizes = EncodingFactory::encode<uint32_t>(
-      std::move(policy),
-      std::span<const uint32_t>(streamSizes),
-      encodingBuffer,
-      Encoding::Options{.useVarintRowCount = true});
-
-  const uint32_t encodedSize = encodedStreamSizes.size();
-  auto* encodedPos = extend(buffer, encodedSize);
-  std::memcpy(encodedPos, encodedStreamSizes.data(), encodedSize);
-
-  auto* encodedSizePos = extend(buffer, sizeof(uint32_t));
-  encoding::writeUint32(encodedSize, encodedSizePos);
+void writeVarintTrailer(const std::vector<uint32_t>& streamSizes, T& buffer) {
+  const auto streamCount = streamSizes.size();
+  const auto countVarintSize =
+      varint::varintSize(static_cast<uint32_t>(streamCount));
+  const auto dataVarintSize = varint::bulkVarintSize32(streamSizes);
+  const uint32_t trailerSize =
+      sizeof(uint8_t) + countVarintSize + dataVarintSize;
+  auto* pos = extend(buffer, trailerSize + sizeof(uint32_t));
+  *pos++ = static_cast<char>(EncodingType::Varint);
+  varint::writeVarint(static_cast<uint32_t>(streamCount), &pos);
+  for (const auto size : streamSizes) {
+    varint::writeVarint(size, &pos);
+  }
+  encoding::writeUint32(trailerSize, pos);
 }
 
-/// Writes the stream sizes trailer for the given serialization version.
-/// Dispatches to writeRawTrailer (kCompactRaw/kTabletRaw) or
-/// writeCompactTrailer (kCompact) based on outputVersion.
-///
-/// @param outputVersion Must be kCompact, kCompactRaw, or kTabletRaw.
-/// @param streamSizes Dense stream sizes array.
-/// @param encodingType Encoding type for stream sizes.
-/// @param encodingBuffer Encoding buffer for kCompact nimble encoding.
-/// @param buffer Output buffer.
-/// @param encodingLayout Optional encoding layout for replaying captured
-///        encoding. Only used for kCompact. Ignored for kCompactRaw/kTabletRaw.
+/// Writes the Delta trailer: first value + deltas as varints.
+/// Wire: [encodingType:1B][count:varint][first:varint]
+///       [delta_1:varint]...[delta_N:varint][trailer_size:u32]
+template <typename T>
+void writeDeltaTrailer(const std::vector<uint32_t>& streamSizes, T& buffer) {
+  const auto streamCount = streamSizes.size();
+  const auto countVarintSize =
+      varint::varintSize(static_cast<uint32_t>(streamCount));
+  uint64_t dataVarintSize = 0;
+  if (streamCount > 0) {
+    dataVarintSize = varint::varintSize(streamSizes[0]);
+    for (size_t i = 1; i < streamCount; ++i) {
+      const auto delta = streamSizes[i] - streamSizes[i - 1];
+      dataVarintSize += varint::varintSize(delta);
+    }
+  }
+  const uint32_t trailerSize =
+      sizeof(uint8_t) + countVarintSize + dataVarintSize;
+  auto* pos = extend(buffer, trailerSize + sizeof(uint32_t));
+  *pos++ = static_cast<char>(EncodingType::Delta);
+  varint::writeVarint(static_cast<uint32_t>(streamCount), &pos);
+  if (streamCount > 0) {
+    varint::writeVarint(streamSizes[0], &pos);
+    for (size_t i = 1; i < streamCount; ++i) {
+      const auto delta = streamSizes[i] - streamSizes[i - 1];
+      varint::writeVarint(delta, &pos);
+    }
+  }
+  encoding::writeUint32(trailerSize, pos);
+}
+
+/// Writes the FixedBitWidth trailer: bit-packed stream sizes.
+/// Wire: [encodingType:1B][bitWidth:1B][count:varint]
+///       [bit-packed data][trailer_size:u32]
+template <typename T>
+void writeFixedBitWidthTrailer(
+    const std::vector<uint32_t>& streamSizes,
+    T& buffer) {
+  const auto streamCount = streamSizes.size();
+  uint32_t maxVal = 0;
+  for (const auto size : streamSizes) {
+    maxVal = std::max(maxVal, size);
+  }
+  const uint8_t bitWidth =
+      maxVal == 0 ? 0 : static_cast<uint8_t>(std::bit_width(maxVal));
+  const uint32_t packedBytes = (bitWidth > 0 && streamCount > 0)
+      ? static_cast<uint32_t>(FixedBitArray::bufferSize(streamCount, bitWidth))
+      : 0;
+  const auto countVarintSize =
+      varint::varintSize(static_cast<uint32_t>(streamCount));
+  const uint32_t trailerSize =
+      sizeof(uint8_t) + sizeof(uint8_t) + countVarintSize + packedBytes;
+  auto* pos = extend(buffer, trailerSize + sizeof(uint32_t));
+  *pos++ = static_cast<char>(EncodingType::FixedBitWidth);
+  *pos++ = static_cast<char>(bitWidth);
+  varint::writeVarint(static_cast<uint32_t>(streamCount), &pos);
+  if (bitWidth > 0 && streamCount > 0) {
+    std::memset(pos, 0, packedBytes);
+    FixedBitArray arr{pos, static_cast<int>(bitWidth)};
+    arr.bulkSet32(0, streamCount, streamSizes.data());
+    pos += packedBytes;
+  }
+  encoding::writeUint32(trailerSize, pos);
+}
+
+/// Writes the stream sizes trailer using the specified encoding type.
 template <typename T>
 void writeTrailer(
-    SerializationVersion outputVersion,
     const std::vector<uint32_t>& streamSizes,
     EncodingType encodingType,
-    nimble::Buffer& encodingBuffer,
-    T& buffer,
-    const EncodingLayout* encodingLayout = nullptr) {
-  if (isRawFormat(outputVersion)) {
-    writeRawTrailer(streamSizes, encodingType, buffer);
-    return;
+    T& buffer) {
+  switch (getTrailerEncodingType(encodingType)) {
+    case EncodingType::Trivial:
+      writeTrivialTrailer(streamSizes, buffer);
+      break;
+    case EncodingType::Varint:
+      writeVarintTrailer(streamSizes, buffer);
+      break;
+    case EncodingType::Delta:
+      writeDeltaTrailer(streamSizes, buffer);
+      break;
+    case EncodingType::FixedBitWidth:
+      writeFixedBitWidthTrailer(streamSizes, buffer);
+      break;
+    default:
+      NIMBLE_FAIL(
+          "Unsupported EncodingType for stream sizes trailer: {}",
+          encodingType);
   }
-
-  NIMBLE_CHECK_EQ(
-      outputVersion,
-      SerializationVersion::kCompact,
-      "writeTrailer requires kCompact, kCompactRaw, or kTabletRaw, got {}",
-      outputVersion);
-  writeCompactTrailer(streamSizes, encodingType, encodingBuffer, buffer);
 }
 
 /// Writes a single stream to the buffer.
@@ -407,22 +369,16 @@ void skipStream(const char*& pos) {
   pos += size;
 }
 
-/// Reads stream sizes from the trailer for kCompact or kCompactRaw format.
-/// The last 4 bytes store the trailer size. For kCompact, the trailer is
-/// nimble-encoded. For kCompactRaw, it starts with an EncodingType byte.
-std::vector<uint32_t> readStreamSizes(
-    const char* end,
-    SerializationVersion version,
-    velox::memory::MemoryPool* pool);
+/// Reads stream sizes from the trailer. The last 4 bytes store the trailer
+/// size. The trailer starts with an EncodingType byte followed by the
+/// encoding-specific payload.
+std::vector<uint32_t> readTrailerStreamSizes(const char* end);
 
 /// IOBuf overload: reads stream sizes from the trailer of a (possibly
 /// chained) IOBuf. Tries the fast path first: if the tail segment contains the
-/// entire trailer, delegates to the contiguous readStreamSizes. Falls back to
+/// entire trailer, delegates to the contiguous overload. Falls back to
 /// cursor + pull() when the trailer spans a chain boundary.
-std::vector<uint32_t> readStreamSizes(
-    const folly::IOBuf& input,
-    SerializationVersion version,
-    velox::memory::MemoryPool* pool);
+std::vector<uint32_t> readTrailerStreamSizes(const folly::IOBuf& input);
 
 /// Parses all streams from a serialized buffer.
 /// Returns a vector of stream data indexed by their original offset.
@@ -585,12 +541,7 @@ StreamDataWriter<T>::StreamDataWriter(
   NIMBLE_CHECK(
       streamEncodingLayouts_ == nullptr || options_.enableEncoding(),
       "streamEncodingLayouts can only be set when encoding is enabled");
-  NIMBLE_CHECK(
-      options_.streamSizesEncodingType == EncodingType::Trivial ||
-          options_.enableEncoding(),
-      "Non-trivial streamSizesEncodingType requires a non-legacy version");
   NIMBLE_CHECK_NOT_NULL(pool, "Memory pool cannot be null");
-
   std::optional<SerializationVersion> version;
   if (options_.hasVersionHeader()) {
     version = options_.serializationVersion();
@@ -679,11 +630,7 @@ template <typename T>
 void StreamDataWriter<T>::close(uint32_t nodeCount) {
   if (options_.enableEncoding()) {
     detail::writeTrailer(
-        options_.serializationVersion(),
-        streamSizes_,
-        options_.streamSizesEncodingType,
-        *encodingBuffer_,
-        buffer_);
+        streamSizes_, options_.streamSizesEncodingType, buffer_);
   } else {
     // kLegacy: fill trailing zeros up to nodeCount.
     detail::writeMissingStreams(buffer_, lastStream_, nodeCount);

--- a/dwio/nimble/serializer/tests/OptionsTest.cpp
+++ b/dwio/nimble/serializer/tests/OptionsTest.cpp
@@ -192,20 +192,21 @@ TEST(OptionsTest, usesVarintRowCountOptional) {
       usesVarintRowCount(std::optional{SerializationVersion::kTabletRaw}));
 }
 
-TEST(OptionsTest, getRawEncodingTypeBasic) {
-  EXPECT_EQ(getRawEncodingType(EncodingType::Trivial), EncodingType::Trivial);
-  EXPECT_EQ(getRawEncodingType(EncodingType::Varint), EncodingType::Varint);
-  EXPECT_EQ(getRawEncodingType(EncodingType::Delta), EncodingType::Delta);
+TEST(OptionsTest, getTrailerEncodingTypeBasic) {
+  EXPECT_EQ(
+      getTrailerEncodingType(EncodingType::Trivial), EncodingType::Trivial);
+  EXPECT_EQ(getTrailerEncodingType(EncodingType::Varint), EncodingType::Varint);
+  EXPECT_EQ(getTrailerEncodingType(EncodingType::Delta), EncodingType::Delta);
 }
 
-TEST(OptionsTest, getRawEncodingTypeError) {
+TEST(OptionsTest, getTrailerEncodingTypeError) {
   NIMBLE_ASSERT_THROW(
-      getRawEncodingType(EncodingType::RLE),
-      "Unsupported EncodingType for kCompactRaw");
+      getTrailerEncodingType(EncodingType::RLE),
+      "Unsupported EncodingType for stream sizes trailer");
   NIMBLE_ASSERT_THROW(
-      getRawEncodingType(EncodingType::Dictionary),
-      "Unsupported EncodingType for kCompactRaw");
-  NIMBLE_ASSERT_THROW(
-      getRawEncodingType(EncodingType::FixedBitWidth),
-      "Unsupported EncodingType for kCompactRaw");
+      getTrailerEncodingType(EncodingType::Dictionary),
+      "Unsupported EncodingType for stream sizes trailer");
+  EXPECT_EQ(
+      getTrailerEncodingType(EncodingType::FixedBitWidth),
+      EncodingType::FixedBitWidth);
 }

--- a/dwio/nimble/serializer/tests/ProjectorTest.cpp
+++ b/dwio/nimble/serializer/tests/ProjectorTest.cpp
@@ -2646,20 +2646,10 @@ TEST_F(ProjectorTest, projectedTrailerNoCompression) {
   auto projected = projector.project(std::string_view(serialized));
   auto projectedStr = toString(projected);
 
-  // Extract the trailer from the projected output.
+  // Verify the projected output has a valid trailer.
   const auto* end = projectedStr.data() + projectedStr.size();
-  const uint32_t trailerSize = detail::readTrailerSize(end);
-  const auto* trailerStart = end - sizeof(uint32_t) - trailerSize;
-
-  // Decode the encoded stream sizes and check the compression type.
-  auto encoding = EncodingFactory(Encoding::Options{.useVarintRowCount = true})
-                      .create(*pool_, {trailerStart, trailerSize}, nullptr);
-  EXPECT_GT(encoding->rowCount(), 0);
-
-  // Verify the compression byte in the encoding is Uncompressed.
-  const auto compressionByte =
-      static_cast<CompressionType>(trailerStart[encoding->dataOffset()]);
-  EXPECT_EQ(compressionByte, CompressionType::Uncompressed);
+  auto streamSizes = detail::readTrailerStreamSizes(end);
+  EXPECT_GT(streamSizes.size(), 0);
 }
 
 // Fuzz test: serialize batches with different versions, project, and verify

--- a/dwio/nimble/serializer/tests/SerializationTest.cpp
+++ b/dwio/nimble/serializer/tests/SerializationTest.cpp
@@ -454,7 +454,7 @@ std::string formatName(const ::testing::TestParamInfo<TestParams>& info) {
     name += "_Compressed";
   }
   if (info.param.streamSizesEncodingType != EncodingType::Trivial) {
-    name += "_DeltaStreamSizes";
+    name += "_" + toString(info.param.streamSizesEncodingType) + "StreamSizes";
   }
   if (!info.param.enableBufferPool) {
     name += "_NoBufferPool";
@@ -553,7 +553,7 @@ SerializationTest::SerializeResult SerializationTest::serializeTabletRaw(
     }
 
     std::string trailerBuf;
-    serde::detail::writeRawTrailer(
+    serde::detail::writeTrailer(
         streamSizes, nimble::EncodingType::Trivial, trailerBuf);
 
     std::string assembled;
@@ -1843,20 +1843,12 @@ TEST_P(SerializationTest, tabletRawVersionRejected) {
       "kTabletRaw is not supported by the serializer");
 }
 
-TEST_P(SerializationTest, nonTrivialStreamSizesEncodingWithLegacyRejected) {
+TEST_P(SerializationTest, streamSizesEncodingIgnoredForLegacy) {
   auto type = velox::ROW({{"int_val", velox::INTEGER()}});
-  // Default version (nullopt) resolves to kLegacy, which doesn't support
-  // non-trivial stream sizes encoding.
+  // Legacy format does not use stream sizes trailer, so non-trivial
+  // encoding types are accepted (and ignored).
   SerializerOptions options{.streamSizesEncodingType = EncodingType::Delta};
-  NIMBLE_ASSERT_THROW(
-      Serializer(options, type, pool_.get()),
-      "Non-trivial streamSizesEncodingType requires a non-legacy version");
-
-  // Explicit kCompact with non-trivial encoding is fine.
-  SerializerOptions compactOptions{
-      .version = SerializationVersion::kCompact,
-      .streamSizesEncodingType = EncodingType::Delta};
-  EXPECT_NO_THROW(Serializer(compactOptions, type, pool_.get()));
+  EXPECT_NO_THROW(Serializer(options, type, pool_.get()));
 }
 
 // Test encoding layout tree for non-FlatMap types.
@@ -3169,7 +3161,7 @@ TEST_F(SerializationTest, zstdThreadLocalDCtxHighParallelism) {
     }
 
     std::string trailerBuf;
-    serde::detail::writeRawTrailer(
+    serde::detail::writeTrailer(
         streamSizes, nimble::EncodingType::Trivial, trailerBuf);
 
     std::string assembled;
@@ -3290,7 +3282,7 @@ TEST_F(SerializationTest, zstdThreadLocalDCtxConcurrentDeserializers) {
       }
 
       std::string trailerBuf;
-      serde::detail::writeRawTrailer(
+      serde::detail::writeTrailer(
           streamSizes, nimble::EncodingType::Trivial, trailerBuf);
 
       std::string assembled;
@@ -3460,7 +3452,7 @@ TEST_F(SerializationTest, zstdThreadLocalDCtxFlatMapWithParallelDecode) {
     }
 
     std::string trailerBuf;
-    serde::detail::writeRawTrailer(
+    serde::detail::writeTrailer(
         streamSizes, nimble::EncodingType::Trivial, trailerBuf);
 
     std::string assembled;
@@ -3579,7 +3571,7 @@ TEST_F(SerializationTest, zstdThreadLocalDCtxRepeatedBatches) {
     }
 
     std::string trailerBuf;
-    serde::detail::writeRawTrailer(
+    serde::detail::writeTrailer(
         streamSizes, nimble::EncodingType::Trivial, trailerBuf);
 
     std::string assembled;
@@ -5020,12 +5012,20 @@ INSTANTIATE_TEST_SUITE_P(
                 CompressionOptions{
                     .compressionAcceptRatio = 1.0f,
                     .zstdMinCompressionSize = 0}},
+        // kCompact format with FixedBitWidth stream sizes encoding.
+        TestParams{
+            .version = SerializationVersion::kCompact,
+            .streamSizesEncodingType = EncodingType::FixedBitWidth},
         // kCompactRaw format without compression.
         TestParams{.version = SerializationVersion::kCompactRaw},
         // kCompactRaw format with Delta stream sizes encoding.
         TestParams{
             .version = SerializationVersion::kCompactRaw,
             .streamSizesEncodingType = EncodingType::Delta},
+        // kCompactRaw format with FixedBitWidth stream sizes encoding.
+        TestParams{
+            .version = SerializationVersion::kCompactRaw,
+            .streamSizesEncodingType = EncodingType::FixedBitWidth},
         // Buffer pool disabled variants.
         TestParams{.version = std::nullopt, .enableBufferPool = false},
         TestParams{
@@ -5044,5 +5044,9 @@ INSTANTIATE_TEST_SUITE_P(
         TestParams{
             .version = SerializationVersion::kCompactRaw,
             .streamSizesEncodingType = EncodingType::Delta,
+            .enableBufferPool = false},
+        TestParams{
+            .version = SerializationVersion::kCompactRaw,
+            .streamSizesEncodingType = EncodingType::FixedBitWidth,
             .enableBufferPool = false}),
     formatName);

--- a/dwio/nimble/serializer/tests/SerializerImplTest.cpp
+++ b/dwio/nimble/serializer/tests/SerializerImplTest.cpp
@@ -49,9 +49,7 @@ class WriteHeaderTest : public ::testing::Test {
     std::string buffer;
     serde::detail::writeHeader(
         buffer, SerializationVersion::kCompact, rowCount);
-    facebook::nimble::Buffer encodingBuffer{*pool_};
-    serde::detail::writeCompactTrailer(
-        sizes, encodingType, encodingBuffer, buffer);
+    serde::detail::writeTrailer(sizes, encodingType, buffer);
     return buffer;
   }
 
@@ -63,7 +61,7 @@ class WriteHeaderTest : public ::testing::Test {
     std::string buffer;
     serde::detail::writeHeader(
         buffer, SerializationVersion::kCompactRaw, rowCount);
-    serde::detail::writeRawTrailer(sizes, encodingType, buffer);
+    serde::detail::writeTrailer(sizes, encodingType, buffer);
     return buffer;
   }
 
@@ -93,8 +91,7 @@ class WriteHeaderTest : public ::testing::Test {
 
     // For kCompact/kCompactRaw, verify stream sizes from trailer.
     if (isCompactFormat(expectedVersion)) {
-      auto actualSizes =
-          serde::detail::readStreamSizes(end, expectedVersion, pool_.get());
+      auto actualSizes = serde::detail::readTrailerStreamSizes(end);
       EXPECT_EQ(actualSizes, expectedSizes);
     }
   }
@@ -333,9 +330,9 @@ TEST_F(WriteHeaderTest, estimateHeaderSizeNoVersion) {
       serde::detail::estimateHeaderSize(std::nullopt, 100), buffer.size());
 }
 
-// Tests for estimateCompactTrailerSize
+// Tests for estimateTrailerSize
 
-TEST_F(WriteHeaderTest, estimateCompactTrailerSize) {
+TEST_F(WriteHeaderTest, estimateTrailerSize) {
   struct TestParam {
     std::vector<uint32_t> sizes;
     std::string debugString() const {
@@ -352,11 +349,10 @@ TEST_F(WriteHeaderTest, estimateCompactTrailerSize) {
   for (const auto& testData : testSettings) {
     SCOPED_TRACE(testData.debugString());
     std::string buffer;
-    facebook::nimble::Buffer encodingBuffer{*pool_};
-    serde::detail::writeCompactTrailer(
-        testData.sizes, EncodingType::Trivial, encodingBuffer, buffer);
+    serde::detail::writeTrailer(testData.sizes, EncodingType::Trivial, buffer);
     EXPECT_GE(
-        serde::detail::estimateCompactTrailerSize(testData.sizes.size()),
+        serde::detail::estimateTrailerSize(
+            testData.sizes.size(), EncodingType::Trivial),
         buffer.size())
         << "Estimate must be >= actual trailer size";
   }
@@ -579,9 +575,7 @@ TEST_F(ParseStreamsTest, denseFormatEmpty) {
   // Write header + trailer with empty sizes array, then parse.
   std::string buffer;
   serde::detail::writeHeader(buffer, SerializationVersion::kCompact, 10);
-  facebook::nimble::Buffer encodingBuffer{*pool_};
-  serde::detail::writeCompactTrailer(
-      {}, EncodingType::Trivial, encodingBuffer, buffer);
+  serde::detail::writeTrailer({}, EncodingType::Trivial, buffer);
 
   auto streams = serde::detail::parseStreams(
       // Skip version byte and row count varint.
@@ -605,9 +599,7 @@ TEST_F(ParseStreamsTest, denseFormatSequential) {
   for (const auto& d : data) {
     buffer.append(d);
   }
-  facebook::nimble::Buffer encodingBuffer{*pool_};
-  serde::detail::writeCompactTrailer(
-      sizes, EncodingType::Trivial, encodingBuffer, buffer);
+  serde::detail::writeTrailer(sizes, EncodingType::Trivial, buffer);
 
   // Skip version byte + varint row count.
   const char* pos = buffer.data() + 1;
@@ -635,9 +627,7 @@ TEST_F(ParseStreamsTest, denseFormatWithGaps) {
   buffer.append("zero");
   buffer.append("two");
   buffer.append("five");
-  facebook::nimble::Buffer encodingBuffer{*pool_};
-  serde::detail::writeCompactTrailer(
-      sizes, EncodingType::Trivial, encodingBuffer, buffer);
+  serde::detail::writeTrailer(sizes, EncodingType::Trivial, buffer);
 
   const char* pos = buffer.data() + 1;
   varint::readVarint32(&pos);
@@ -665,9 +655,7 @@ TEST_F(ParseStreamsTest, denseFormatOnlyLastStream) {
   std::string buffer;
   serde::detail::writeHeader(buffer, SerializationVersion::kCompact, 100);
   buffer.append("hello");
-  facebook::nimble::Buffer encodingBuffer{*pool_};
-  serde::detail::writeCompactTrailer(
-      sizes, EncodingType::Trivial, encodingBuffer, buffer);
+  serde::detail::writeTrailer(sizes, EncodingType::Trivial, buffer);
 
   const char* pos = buffer.data() + 1;
   varint::readVarint32(&pos);
@@ -686,7 +674,7 @@ TEST_F(ParseStreamsTest, denseFormatOnlyLastStream) {
   EXPECT_EQ(streams[4], "hello");
 }
 
-// Tests for readStreamSizes roundtrip (kCompact).
+// Tests for readTrailerStreamSizes roundtrip (kCompact).
 
 class EncodeDecodeTest : public ::testing::Test {
  protected:
@@ -701,16 +689,14 @@ class EncodeDecodeTest : public ::testing::Test {
   // Helper to build a kCompact trailer (encoded sizes + trailer size u32).
   std::string buildCompactTrailer(const std::vector<uint32_t>& values) {
     std::string buffer;
-    facebook::nimble::Buffer encodingBuffer{*pool_};
-    serde::detail::writeCompactTrailer(
-        values, EncodingType::Trivial, encodingBuffer, buffer);
+    serde::detail::writeTrailer(values, EncodingType::Trivial, buffer);
     return buffer;
   }
 
   std::shared_ptr<memory::MemoryPool> pool_;
 };
 
-TEST_F(EncodeDecodeTest, readStreamSizesRoundtrip) {
+TEST_F(EncodeDecodeTest, readTrailerStreamSizesRoundtrip) {
   struct TestParam {
     std::vector<uint32_t> values;
     std::string debugString() const {
@@ -728,25 +714,21 @@ TEST_F(EncodeDecodeTest, readStreamSizesRoundtrip) {
     SCOPED_TRACE(testData.debugString());
 
     auto buffer = buildCompactTrailer(testData.values);
-    auto decoded = serde::detail::readStreamSizes(
-        buffer.data() + buffer.size(),
-        SerializationVersion::kCompact,
-        pool_.get());
+    auto decoded =
+        serde::detail::readTrailerStreamSizes(buffer.data() + buffer.size());
     EXPECT_EQ(decoded, testData.values);
   }
 }
 
-TEST_F(EncodeDecodeTest, readStreamSizesLargeValues) {
+TEST_F(EncodeDecodeTest, readTrailerStreamSizesLargeValues) {
   std::vector<uint32_t> values;
   for (uint32_t i = 0; i < 1000; ++i) {
     values.emplace_back(i * 3);
   }
 
   auto buffer = buildCompactTrailer(values);
-  auto decoded = serde::detail::readStreamSizes(
-      buffer.data() + buffer.size(),
-      SerializationVersion::kCompact,
-      pool_.get());
+  auto decoded =
+      serde::detail::readTrailerStreamSizes(buffer.data() + buffer.size());
   EXPECT_EQ(decoded, values);
 }
 
@@ -764,9 +746,7 @@ TEST_F(EncodeDecodeTest, streamSizesEncodingType) {
     buffer.append("s0");
     buffer.append("s1");
     buffer.append("s2");
-    facebook::nimble::Buffer encodingBuffer{*pool_};
-    serde::detail::writeCompactTrailer(
-        sizes, encodingType, encodingBuffer, buffer);
+    serde::detail::writeTrailer(sizes, encodingType, buffer);
 
     const char* pos = buffer.data() + 1;
     varint::readVarint32(&pos);
@@ -791,9 +771,7 @@ TEST_F(EncodeDecodeTest, streamSizesEncodingTypeDefault) {
   buffer.append("a");
   buffer.append("b");
   buffer.append("c");
-  facebook::nimble::Buffer encodingBuffer{*pool_};
-  serde::detail::writeCompactTrailer(
-      sizes, EncodingType::Trivial, encodingBuffer, buffer);
+  serde::detail::writeTrailer(sizes, EncodingType::Trivial, buffer);
 
   const char* pos = buffer.data() + 1;
   varint::readVarint32(&pos);
@@ -821,7 +799,7 @@ TEST_F(EncodeDecodeTest, streamSizesEncodingTypeCompactRaw) {
     buffer.append(std::string(10, 'a'));
     buffer.append(std::string(20, 'b'));
     buffer.append(std::string(30, 'c'));
-    serde::detail::writeRawTrailer(sizes, encodingType, buffer);
+    serde::detail::writeTrailer(sizes, encodingType, buffer);
 
     const char* pos = buffer.data() + 1;
     varint::readVarint32(&pos);
@@ -864,7 +842,7 @@ std::vector<ProjectedStream> projectStreams(
   streams.reserve(selectedStreamIndices.size());
 
   if (isCompactFormat(version)) {
-    auto streamSizes = serde::detail::readStreamSizes(end, version, pool);
+    auto streamSizes = serde::detail::readTrailerStreamSizes(end);
     const char* dataStart = pos;
 
     uint32_t dataOffset = 0;
@@ -939,9 +917,7 @@ class ProjectStreamsTest : public ParseStreamsTest {
     }
 
     // Write trailer with encoded sizes.
-    facebook::nimble::Buffer encodingBuffer{*pool_};
-    serde::detail::writeCompactTrailer(
-        sizes, EncodingType::Trivial, encodingBuffer, buffer);
+    serde::detail::writeTrailer(sizes, EncodingType::Trivial, buffer);
 
     // Skip version byte + varint row count to get to streams position.
     const char* pos = buffer.data() + 1;
@@ -1156,45 +1132,19 @@ TEST_F(ProjectStreamsTest, denseSelectFirstAndLast) {
   EXPECT_EQ(streams[1].data, "two");
 }
 
-// Verifies that writeCompactTrailer does not compress stream sizes,
-// even when the default encoding selection policy enables compression.
-TEST_F(EncodeDecodeTest, compactTrailerNoCompression) {
-  // Generate enough stream sizes that compression would normally be applied.
+// Verifies that writeTrailer roundtrips correctly.
+TEST_F(EncodeDecodeTest, rawTrailerRoundtrip) {
   std::vector<uint32_t> sizes(500);
   for (uint32_t i = 0; i < sizes.size(); ++i) {
     sizes[i] = i * 7 + 1;
   }
 
   std::string buffer;
-  facebook::nimble::Buffer encodingBuffer{*pool_};
-  serde::detail::writeCompactTrailer(
-      sizes, EncodingType::Trivial, encodingBuffer, buffer);
+  serde::detail::writeTrailer(sizes, EncodingType::Trivial, buffer);
 
-  // Read the trailer: last 4 bytes are trailerSize, preceding bytes are
-  // the encoded stream sizes.
   const auto* end = buffer.data() + buffer.size();
-  const uint32_t trailerSize = serde::detail::readTrailerSize(end);
-  const auto* trailerStart = end - sizeof(uint32_t) - trailerSize;
-
-  // The encoded stream sizes use nimble encoding. The encoding prefix is:
-  //   EncodingType (1B) + DataType (1B) + rowCount (varint)
-  // For TrivialEncoding, the next byte after the prefix is the compression
-  // type. Verify it is Uncompressed regardless of encoding type.
-  auto encoding = EncodingFactory(Encoding::Options{.useVarintRowCount = true})
-                      .create(*pool_, {trailerStart, trailerSize}, nullptr);
-  EXPECT_EQ(encoding->rowCount(), sizes.size());
-
-  // Verify roundtrip produces correct values (ensuring the encoding works).
-  std::vector<uint32_t> decoded(sizes.size());
-  encoding->materialize(sizes.size(), decoded.data());
+  auto decoded = serde::detail::readTrailerStreamSizes(end);
   EXPECT_EQ(decoded, sizes);
-
-  // Verify the compression byte in the raw encoding is Uncompressed.
-  // After the encoding prefix (EncodingType + DataType + varint rowCount),
-  // TrivialEncoding stores a 1-byte compression type.
-  const auto compressionByte =
-      static_cast<CompressionType>(trailerStart[encoding->dataOffset()]);
-  EXPECT_EQ(compressionByte, CompressionType::Uncompressed);
 }
 
 TEST_F(ProjectStreamsTest, denseSkipsEmptyStreams) {
@@ -1436,7 +1386,7 @@ class TabletRawChunkStripTest : public ::testing::Test {
     serde::detail::writeHeader(
         buffer, SerializationVersion::kTabletRaw, rowCount);
     buffer.append(streamData);
-    serde::detail::writeRawTrailer(sizes, EncodingType::Trivial, buffer);
+    serde::detail::writeTrailer(sizes, EncodingType::Trivial, buffer);
 
     // Parse via StreamDataReader.
     DeserializerOptions options{.hasHeader = true};
@@ -1645,7 +1595,7 @@ class ZstdDCtxReuseTest : public TabletRawChunkStripTest {
     serde::detail::writeHeader(
         buffer, SerializationVersion::kTabletRaw, rowCount);
     buffer.append(streamData);
-    serde::detail::writeRawTrailer(sizes, EncodingType::Trivial, buffer);
+    serde::detail::writeTrailer(sizes, EncodingType::Trivial, buffer);
 
     DeserializerOptions options{.hasHeader = true};
     StreamDataReader reader(pool_.get(), options);

--- a/dwio/nimble/tools/SerializerDumpLib.cpp
+++ b/dwio/nimble/tools/SerializerDumpLib.cpp
@@ -71,7 +71,7 @@ SerializationDump::SerializationStats SerializationDump::serializationStats(
   info.rowCount = varint::readVarint32(&pos);
 
   // Parse stream sizes from trailer.
-  auto streamSizes = serde::detail::readStreamSizes(end, info.version, pool_);
+  auto streamSizes = serde::detail::readTrailerStreamSizes(end);
 
   // Walk streams and extract encoding info.
   info.streams.reserve(streamSizes.size());

--- a/dwio/nimble/velox/index/NimbleIndexProjector.cpp
+++ b/dwio/nimble/velox/index/NimbleIndexProjector.cpp
@@ -296,8 +296,7 @@ NimbleIndexProjector::Chunk NimbleIndexProjector::serializeStripe(
   }
 
   std::string trailerBuf;
-  serde::detail::writeRawTrailer(
-      streamSizes, EncodingType::Trivial, trailerBuf);
+  serde::detail::writeTrailer(streamSizes, EncodingType::Trivial, trailerBuf);
 
   // Single allocation for header + data + trailer.
   const size_t totalSize = headerBuf.size() + totalBytes + trailerBuf.size();


### PR DESCRIPTION
Summary:

Add `FixedBitWidth` as a new encoding type for `kCompactRaw` stream sizes trailers, selectable via `--nimble_stream_sizes_encoding=FixedBitWidth`. 

Remove the writeCompactTrailer function, now  writeTrailer doesn't leverage nimble encoding framework. Consolidate all  writeRawTrailer/writeTrailer to writeTrailer

From the benchmark test https://docs.google.com/spreadsheets/d/1nhQojgVrsyEmmyTBrhJLYAfOZON77rVrliAWW1WEpGk/edit?gid=0#gid=0 

The Nimble encoding framework introduced a non-negligible CPU regression in projection (~5.7ms vs ~4.7ms per  batch, +21%), due to EncodingFactory::create object allocation and virtual dispatch overhead in the trailer decode path. We removed the Nimble encoding framework trailer path and unified all serialization versions to use the lightweight inline writeTrailer/decodeRawStreamSizes

Reviewed By: xiaoxmeng

Differential Revision: D105915954


