### PR TITLE
perf: Call reserve() upfront to avoid unnecessary reallocation (#765)

### DIFF
--- a/dwio/nimble/velox/VeloxReader.cpp
+++ b/dwio/nimble/velox/VeloxReader.cpp
@@ -328,6 +328,7 @@ void VeloxReader::loadNextStripe() {
       metrics.totalStreamSize = nimbleUnit->getIoSize();
 
       auto streams = nimbleUnit->extractStreamLoaders();
+      decoders_.reserve(streams.size());
       for (uint32_t i = 0; i < streams.size(); ++i) {
         if (!streams[i]) {
           // As this stream is not present in current stripe (might be present


### PR DESCRIPTION
Summary:

This change was generated by pointing an AI agent at hot functions showing up in our internal profiles. It was reviewed by a human (outside the velox team):

Added `decoders_.reserve(streams.size())` before the loop in `VeloxReader::loadNextStripe()` that populates the `folly::F14FastMap<offset_size, std::unique_ptr<Decoder>> decoders_` container. The map is cleared right before this loop, so reserving `streams.size()` buckets upfront avoids expensive rehashing during the insertion loop. No functionality changes were made.

Reviewed By: yuxuanchen1997

Differential Revision: D100823409


