### PR TITLE
fix: Move default policy capture out of direct member initialization (#767)

### DIFF
--- a/dwio/nimble/serializer/Options.cpp
+++ b/dwio/nimble/serializer/Options.cpp
@@ -48,6 +48,20 @@ EncodingType getTrailerEncodingType(EncodingType encodingType) {
   }
 }
 
+EncodingSelectionPolicyFactory defaultEncodingSelectionPolicyFactory() {
+  // Initialize the default factory once. It is const and createPolicy() does
+  // not mutate it, so a single instance can be safely shared across all default
+  // SerializerOptions instead of rebuilding the read-factor vector on every
+  // construction. The returned lambda is captureless and refers to the shared
+  // factory directly.
+  static const ManualEncodingSelectionPolicyFactory factory(
+      ManualEncodingSelectionPolicyFactory::defaultReadFactors(),
+      /*compressionOptions=*/std::nullopt);
+  return [](DataType dataType) -> std::unique_ptr<EncodingSelectionPolicyBase> {
+    return factory.createPolicy(dataType);
+  };
+}
+
 bool SerializerOptions::hasVersionHeader() const {
   return version.has_value();
 }

--- a/dwio/nimble/serializer/Options.h
+++ b/dwio/nimble/serializer/Options.h
@@ -127,6 +127,11 @@ inline std::ostream& operator<<(
   return os << toString(version);
 }
 
+/// Returns the default encoding selection policy factory. The underlying
+/// ManualEncodingSelectionPolicyFactory (and its default read-factor vector) is
+/// initialized once and shared across all returned factories.
+EncodingSelectionPolicyFactory defaultEncodingSelectionPolicyFactory();
+
 struct SerializerOptions {
   /// Legacy (kLegacy) compression settings. These only apply when version is
   /// kLegacy or nullopt. For kCompactRaw, compression is controlled by
@@ -155,13 +160,7 @@ struct SerializerOptions {
   /// nested encodings not captured in the layout tree. When encodingLayoutTree
   /// is not specified, used directly for all streams.
   EncodingSelectionPolicyFactory encodingSelectionPolicyFactory =
-      [factory =
-           ManualEncodingSelectionPolicyFactory{
-               ManualEncodingSelectionPolicyFactory::defaultReadFactors(),
-               /*compressionOptions=*/std::nullopt}](
-          DataType dataType) -> std::unique_ptr<EncodingSelectionPolicyBase> {
-    return factory.createPolicy(dataType);
-  };
+      defaultEncodingSelectionPolicyFactory();
 
   /// Optional captured encoding layout tree.
   /// When specified, encodings are replayed from this tree instead of using


### PR DESCRIPTION
Summary:

This works around https://github.com/llvm/llvm-project/issues/196469, a Clang lifetime bug where aggregate initialization using a default member initializer that contains a lambda init-capture can lose cleanup for the captured temporary. SerializerOptions hit that shape when callers aggregate-initialized it while omitting encodingSelectionPolicyFactory: the omitted member's DMI directly contained a lambda init-capture of ManualEncodingSelectionPolicyFactory, whose state owns the default read-factor vector.

Changing only ManualEncodingSelectionPolicyFactory{...} to ManualEncodingSelectionPolicyFactory(...) was not sufficient because the DMI still contained the lambda init-capture. This change moves the capturing lambda into defaultEncodingSelectionPolicyFactory(), so the DMI evaluated during aggregate initialization is only a helper call.

The workaround is intentionally minimal. It preserves the captured factory and default policy behavior, uses the explicit ManualEncodingSelectionPolicyFactory(...) constructor call inside the helper, and avoids touching call sites such as EBFEncoder.cpp.

Reviewed By: HighW4y2H3ll, xiaoxmeng

Differential Revision: D106147095


