### PR TITLE
feat(nimble): Preserve empty maps through passthrough flatmap ingestRow

### DIFF
--- a/dwio/nimble/velox/FieldWriter.cpp
+++ b/dwio/nimble/velox/FieldWriter.cpp
@@ -1594,34 +1594,33 @@ class FlatMapFieldWriter : public FieldWriter {
         totalKeyCount * sizeof(KeyType) + nullCount);
   }
 
-  // Collects key statistics for passthrough flatmap with VARCHAR keys.
-  // For passthrough flatmaps, keys are ROW field names, so we use the actual
-  // string lengths instead of sizeof(StringView).
+  // Collects key statistics for passthrough flatmap with VARCHAR/VARBINARY
+  // keys. For passthrough flatmaps, keys are ROW field names; the caller
+  // provides the per-key count of parent rows in which that key is present
+  // (inMap=1). Total key string size is Σᵢ name_size(i) * presentPerKey[i].
   void collectPassthroughStringKeyStatistics(
       const velox::RowVector* rowVector,
-      uint64_t nonNullCount,
+      const std::vector<uint64_t>& presentPerKey,
       uint64_t nullCount,
       uint64_t valueCount) {
     if (!keyStatisticsCollector_) {
       return;
     }
 
-    // For passthrough flatmaps, each non-null row has all keys present.
     const auto& rowType = rowVector->type()->asRow();
-    const auto numKeys = rowType.size();
-    const uint64_t totalKeyCount = numKeys * nonNullCount;
+    NIMBLE_CHECK(
+        presentPerKey.empty() || presentPerKey.size() == rowType.size(),
+        "presentPerKey size must match the number of ROW fields when non-empty");
 
-    keyStatisticsCollector_->addCounts(totalKeyCount, nullCount);
-
-    // Calculate the total key string size: sum of all key name lengths
-    // multiplied by the number of non-null rows.
+    uint64_t totalKeyCount = 0;
     uint64_t totalKeyStringSize = 0;
-    for (size_t i = 0; i < numKeys; ++i) {
-      totalKeyStringSize += rowType.nameOf(i).size();
+    for (size_t i = 0; i < presentPerKey.size(); ++i) {
+      totalKeyCount += presentPerKey[i];
+      totalKeyStringSize += rowType.nameOf(i).size() * presentPerKey[i];
     }
 
-    keyStatisticsCollector_->addLogicalSize(
-        totalKeyStringSize * nonNullCount + nullCount);
+    keyStatisticsCollector_->addCounts(totalKeyCount, nullCount);
+    keyStatisticsCollector_->addLogicalSize(totalKeyStringSize + nullCount);
   }
 
   void ingestFlatMap(
@@ -1794,20 +1793,65 @@ class FlatMapFieldWriter : public FieldWriter {
         [&](auto offset) { childRanges.add(offset, 1); });
 
     collectStatistics(size - nonNullCount, size);
+
+    // For passthrough flatmap ingestion, a NULL value in a per-feature child
+    // column means "this key is NOT present in the map" (inMap=0), not "this
+    // key is present with NULL value". This matches the Velox MapVector
+    // contract and how readFlatmapAsStruct reconstructs the map; without it,
+    // a non-null empty map row would be re-encoded as {key0:NULL, key1:NULL,
+    // ...} after a passthrough roundtrip (see T272275493).
+    //
+    // Decode each child once over the parent's non-null offsets to build a
+    // per-child inMap bitmap (indexed by absolute parent offset) and the
+    // per-child present count. These feed the key statistics and the
+    // with-inMap overload of FlatMapPassthroughValueFieldWriter::write below.
+    std::vector<velox::BufferPtr> inMapsPerChild(keys.size());
+    std::vector<uint64_t> presentPerChild(keys.size(), 0);
+    uint64_t totalKeyCount = 0;
+
+    if (childRanges.size() > 0) {
+      auto* pool = context_.bufferMemoryPool().get();
+      const auto bufferWords = velox::bits::nwords(rowVector->size());
+      for (velox::vector_size_t i = 0; i < keys.size(); ++i) {
+        auto inMaps =
+            velox::AlignedBuffer::allocate<uint64_t>(bufferWords, pool, 0);
+        auto* rawInMaps = inMaps->template asMutable<uint64_t>();
+        uint64_t present = 0;
+        auto decodingContext = context_.decodingContext();
+        auto& decoded = decodingContext.decode(values[i], childRanges);
+        if (decoded.mayHaveNulls()) {
+          childRanges.applyEach([&](auto offset) {
+            if (!decoded.isNullAt(offset)) {
+              velox::bits::setBit(rawInMaps, offset);
+              ++present;
+            }
+          });
+        } else {
+          childRanges.applyEach(
+              [&](auto offset) { velox::bits::setBit(rawInMaps, offset); });
+          present = childRanges.size();
+        }
+        presentPerChild[i] = present;
+        totalKeyCount += present;
+        inMapsPerChild[i] = std::move(inMaps);
+      }
+    }
+
     // For ROW vector ingestion (passthrough flatmaps), keys are ROW field
     // names. For VARCHAR/VARBINARY keys, use actual string lengths instead of
     // sizeof(StringView).
     if constexpr (
         K == velox::TypeKind::VARCHAR || K == velox::TypeKind::VARBINARY) {
-      collectPassthroughStringKeyStatistics(rowVector, nonNullCount, 0, size);
+      collectPassthroughStringKeyStatistics(
+          rowVector, presentPerChild, /*nullCount=*/0, size);
     } else {
-      // For non-string keys, all keys are present for all non-null rows.
-      // The total key count is: numKeys * numNonNullRows
-      // This matches DWRF behavior where key sizes are counted per key per row.
-      collectKeyStatistics(keys.size() * nonNullCount, 0, size);
+      // Total key count is the sum of per-child present entries (number of
+      // parent rows where that key has inMap=1).
+      collectKeyStatistics(totalKeyCount, /*nullCount=*/0, size);
     }
 
-    // Early bail out if no ranges at the top level row vector.
+    // Early bail out if no ranges at the top level row vector. Stats above
+    // have already recorded keys=0 / inMap=0 for this batch.
     if (childRanges.size() == 0) {
       return;
     }
@@ -1820,7 +1864,9 @@ class FlatMapFieldWriter : public FieldWriter {
       const auto& key = keys[i];
       auto& writer = populateMap ? createPassthroughValueFieldWriter(key)
                                  : findPassthroughValueFieldWriter(key);
-      writer.write(values[i], childRanges);
+      // Use the with-inMap overload so the underlying value writer only sees
+      // the offsets where the key is actually present.
+      writer.write(values[i], inMapsPerChild[i], childRanges);
     }
   }
 

--- a/dwio/nimble/velox/RawSizeUtils.cpp
+++ b/dwio/nimble/velox/RawSizeUtils.cpp
@@ -627,57 +627,70 @@ uint64_t getRawSizeFromPassthroughFlatMap(
   const auto& schemaValueType = type.childAt(1);
   auto keyTypeSize = getTypeSize(*schemaKeyType->type());
 
-  // For VARCHAR keys, compute the total string key size from ROW field names
-  size_t stringKeySize = 0;
-  if (!keyTypeSize.has_value() &&
-      (schemaKeyType->type()->kind() == velox::TypeKind::VARCHAR ||
-       schemaKeyType->type()->kind() == velox::TypeKind::VARBINARY)) {
-    const velox::RowVector* passthroughRow = nullptr;
-    if (encoding == velox::VectorEncoding::Simple::ROW) {
-      passthroughRow = vector->as<velox::RowVector>();
-    } else if (encoding == velox::VectorEncoding::Simple::DICTIONARY) {
-      auto localDecodedVector = DecodedVectorManager::LocalDecodedVector(
-          context.getDecodedVectorManager());
-      velox::DecodedVector& decodedVector = localDecodedVector.get();
-      decodedVector.decode(*vector);
-      passthroughRow = decodedVector.base()->as<velox::RowVector>();
-    }
-    if (passthroughRow) {
-      const auto& rowType = passthroughRow->type()->asRow();
-      for (size_t i = 0; i < rowType.size(); ++i) {
-        stringKeySize += rowType.nameOf(i).size();
-      }
-    }
+  // Validate the key type up front. For string keys, per-child name sizes are
+  // looked up below from the ROW type.
+  const bool stringKey = !keyTypeSize.has_value();
+  if (stringKey) {
+    NIMBLE_CHECK(
+        schemaKeyType->type()->kind() == velox::TypeKind::VARCHAR ||
+            schemaKeyType->type()->kind() == velox::TypeKind::VARBINARY,
+        "Encountered non-supported variable flatmap key type.");
   }
 
   uint64_t rawSize = 0;
   const auto nonNullCount = childRanges.size();
 
   if (nonNullCount > 0) {
-    // ROW children represent the "values" in the passthrough flatmap
-    // Each field in the ROW is a key-value pair
+    // ROW children represent the "values" in the passthrough flatmap.
+    // Each field in the ROW is a key-value pair.
+    //
+    // For passthrough flatmap ingestion, a NULL value in a child column means
+    // "this key is NOT present in the map" (inMap=0). Only present entries
+    // contribute to keys and values (matches writer-side ingestRow and the
+    // Velox MapVector contract). See T272275493.
     const auto childrenSize = rowVector->childrenSize();
-
-    // For passthrough flatmaps, keys are counted for ALL non-null flatmap rows,
-    // regardless of whether the individual value is null or not.
-    // This matches DWRF behavior where key sizes are counted per key per row.
-    // Key count = numKeys * numNonNullFlatmapRows
-    if (keyTypeSize.has_value()) {
-      rawSize += *keyTypeSize * childrenSize * nonNullCount;
-    } else {
-      NIMBLE_CHECK_GT(
-          stringKeySize,
-          0,
-          "Encountered non-supported variable flatmap key type.");
-      rawSize += stringKeySize * nonNullCount;
-    }
+    const auto& rowType = rowVector->type()->asRow();
 
     for (size_t i = 0; i < childrenSize; ++i) {
       const auto& child = rowVector->childAt(i);
 
-      // Compute value sizes using schema's value type
+      // Decode the child once to determine which offsets are present
+      // (inMap=true) over childRanges. Build a per-child filtered range so
+      // the recursive value-size call only counts present entries (no nulls
+      // get inflated into the value stream's null contribution).
+      velox::common::Ranges childPresentRanges;
+      uint64_t presentCount = 0;
+      {
+        auto localDecodedVector = DecodedVectorManager::LocalDecodedVector(
+            context.getDecodedVectorManager());
+        velox::DecodedVector& decodedChild = localDecodedVector.get();
+        decodedChild.decode(*child);
+        if (decodedChild.mayHaveNulls()) {
+          for (const auto& row : childRanges) {
+            if (!decodedChild.isNullAt(row)) {
+              childPresentRanges.add(row, row + 1);
+              ++presentCount;
+            }
+          }
+        } else {
+          for (const auto& row : childRanges) {
+            childPresentRanges.add(row, row + 1);
+          }
+          presentCount = childRanges.size();
+        }
+      }
+
+      // Key bytes for this child = key-type size (numeric) or per-key name
+      // size (string) times the number of rows in which this key is present.
+      if (stringKey) {
+        rawSize += rowType.nameOf(i).size() * presentCount;
+      } else {
+        rawSize += *keyTypeSize * presentCount;
+      }
+
+      // Value bytes for this child, recursed only over the present offsets.
       uint64_t childRawSize = getRawSizeFromVectorInternal(
-          child, childRanges, context, schemaValueType.get(), {});
+          child, childPresentRanges, context, schemaValueType.get(), {});
       rawSize += childRawSize;
 
       if (topLevel) {

--- a/dwio/nimble/velox/tests/FieldWriterStatsTest.cpp
+++ b/dwio/nimble/velox/tests/FieldWriterStatsTest.cpp
@@ -754,73 +754,60 @@ TEST_P(FieldWriterStatsTests, flatMapPassThroughValueFieldWriterStats) {
   //   2: Key (TINYINT)
   //   3: Value (INTEGER)
   //
-  // Per-key VALUE contributions (each key contributes to the merged value
-  // stat):
-  //   For passthrough flatmaps, each non-null value in a feature column
-  //   that is in a non-null flatmap row contributes to value stats.
-  //   - Key 0 (feature0): row0=1, row1=1 → 2 int32_t values
-  //   - Key 2 (feature2): row0=3 → 1 int32_t value
-  //   - Key 10 (feature10): row2=11 → 1 int32_t value
-  // Total: 4 values written
+  // Under passthrough flatmap semantics (see T272275493), a NULL value in a
+  // per-feature child column means "this key is NOT in the map" (inMap=0).
+  // Only present (non-NULL) entries reach the value writer.
   //
-  // Note: For passthrough flatmaps, null values in feature columns also
-  // contribute to null tracking, which affects logicalSize.
+  // Per-feature present counts over flatmap-non-null rows (0, 1, 2):
+  //   - feature0: row0=1, row1=1, row2=null → 2 present
+  //   - feature2: row0=3, row1=null, row2=null → 1 present
+  //   - feature10: row0=null, row1=null, row2=11 → 1 present
+  // totalKeyCount = 4 (was 9 under "all keys present per row" semantics).
 
+  // Per-key VALUE contributions. Under new semantics each key's value writer
+  // sees only the present offsets, so nullCount=0 and logicalSize is just
+  // sizeof(int32_t) * presentCount.
   auto key0ValueStat = ColumnStats{
-      .logicalSize =
-          sizeof(int32_t) * 2 + nimble::kNullSize, // 2 values + 1 null
-      .physicalSize = 40,
-      .nullCount = 1,
-      .valueCount = 3 - 1, // nonNullCount (1 null)
+      .logicalSize = sizeof(int32_t) * 2,
+      .nullCount = 0,
+      .valueCount = 2,
   };
   auto key2ValueStat = ColumnStats{
-      .logicalSize =
-          sizeof(int32_t) * 1 + 2 * nimble::kNullSize, // 1 value + 2 nulls
-      .physicalSize = 41,
-      .nullCount = 2,
-      .valueCount = 3 - 2, // nonNullCount (2 nulls)
+      .logicalSize = sizeof(int32_t) * 1,
+      .nullCount = 0,
+      .valueCount = 1,
   };
   auto key10ValueStat = ColumnStats{
-      .logicalSize =
-          sizeof(int32_t) * 1 + 2 * nimble::kNullSize, // 1 value + 2 nulls
-      .physicalSize = 41,
-      .nullCount = 2,
-      .valueCount = 3 - 2, // nonNullCount (2 nulls)
+      .logicalSize = sizeof(int32_t) * 1,
+      .nullCount = 0,
+      .valueCount = 1,
   };
 
-  // Merged value stat from all keys.
+  // Merged value stat from all keys. combineFlatmapValueStats only sums the
+  // physicalSize across keys; the empirically observed combined physicalSize
+  // is set directly here since the per-key physical breakdown is not asserted.
   auto valueStat =
       combineFlatmapValueStats({key0ValueStat, key2ValueStat, key10ValueStat});
+  valueStat.physicalSize = 47;
 
-  // Key statistics (tracked at flatmap level via collectKeyStatistics):
-  //   For passthrough flatmaps, totalKeyCount = numKeys *
-  //   numNonNullFlatmapRows.
-  //   - numKeys = 3 (feature0, feature2, feature10)
-  //   - numNonNullFlatmapRows = 3 (rows 0, 1, 2; rows 3,4 null, row 5 parent
-  //   null)
-  //   - totalKeyCount = 3 * 3 = 9
-  //   - nullCount = 0 (key stats don't include flatmap nulls)
-  //   - logicalSize = totalKeyCount * sizeof(KeyType) = 9 * 1 = 9
-  //   - valueCount = 9 (same as totalKeyCount)
-
-  // Key TypeWithId node (index 2) has no direct values.
+  // Key statistics for passthrough flatmap (new semantics):
+  //   - totalKeyCount = sum of per-child present entries = 4
+  //   - logicalSize = totalKeyCount * sizeof(KeyType) = 4
   auto keyStat = ColumnStats{
-      .logicalSize = 9 * sizeof(int8_t),
+      .logicalSize = 4 * sizeof(int8_t),
       .physicalSize = 0,
       .nullCount = 0,
-      .valueCount = 9,
+      .valueCount = 4,
   };
 
   // Flatmap stat.
-  // logicalSize = 2 (flatmap null bytes) + keyStat.logicalSize +
-  // valueStat.logicalSize nullCount = 2 (flatmap nulls) valueCount = 5
-  // (non-null flatmap rows including parent row)
-  // physicalSize includes overhead for key null streams (3 keys * ~18-19 bytes)
+  //   logicalSize = 2 (flatmap null bytes) + keyStat.logicalSize +
+  //                 valueStat.logicalSize
+  //   physical overhead is empirically observed.
   auto flatmapStat = ColumnStats{
       .logicalSize =
           2 * nimble::kNullSize + keyStat.logicalSize + valueStat.logicalSize,
-      .physicalSize =
-          valueStat.physicalSize + 56, // 3 key null streams overhead
+      .physicalSize = 127,
       .nullCount = 2,
       .valueCount = 5 - 2, // nonNullCount (flatmap has 2 nulls)
   };
@@ -968,66 +955,63 @@ TEST_P(
   auto vector = vectorMaker_->rowVector({flatmapVector});
   vector->setNull(5, true);
 
-  // Stats calculation for passthrough flatmap:
-  // For passthrough flatmaps, value stats are per-feature column (not merged).
-  // Per-key VALUE contributions:
-  //   - Key 0 (feature0): row0=1, row1=null, row2=5, row4=null → 2 values + 2
-  //   nulls
-  //   - Key 2 (feature2): row0=null, row1=3, row2=6, row4=null → 2 values + 2
-  //   nulls
-  // Total: 4 values, 4 nulls
+  // Under passthrough flatmap semantics (see T272275493), a NULL value in a
+  // per-feature child column means "this key is NOT in the map" (inMap=0).
+  // Only present (non-NULL) entries reach the value writer.
+  //
+  // Per-feature present counts over flatmap-non-null rows (0, 1, 2, 4):
+  //   - feature0: row0=1, row1=null, row2=5, row4=null → 2 present
+  //   - feature2: row0=null, row1=3, row2=6, row4=null → 2 present
+  // totalKeyCount = 4 (was 8 under "all keys present per row" semantics).
 
+  // Per-key VALUE contributions under the new semantics: only present entries
+  // reach the value writer, so nullCount=0 per key and logicalSize is just
+  // sizeof(int32_t) * presentCount.
   auto key0ValueStat = ColumnStats{
-      .logicalSize = sizeof(int32_t) * 2 + nimble::kNullSize * 2,
-      .physicalSize = 45, // 41 + 4 for null stream overhead
-      .nullCount = 2,
-      .valueCount = 2, // nonNullCount (actual from test)
+      .logicalSize = sizeof(int32_t) * 2,
+      .nullCount = 0,
+      .valueCount = 2,
   };
   auto key2ValueStat = ColumnStats{
-      .logicalSize = sizeof(int32_t) * 2 + nimble::kNullSize * 2,
-      .physicalSize = 45, // 41 + 4 for null stream overhead
-      .nullCount = 2,
-      .valueCount = 2, // nonNullCount (actual from test)
+      .logicalSize = sizeof(int32_t) * 2,
+      .nullCount = 0,
+      .valueCount = 2,
   };
 
-  // Merged value stat from all keys.
+  // Merged value stat from all keys; per-key physicalSize is not asserted
+  // individually, so set the combined physicalSize directly to the
+  // empirically observed value.
   auto valueStat = combineFlatmapValueStats({key0ValueStat, key2ValueStat});
+  valueStat.physicalSize = 40;
 
-  // Key statistics for passthrough flatmap:
-  //   For passthrough flatmaps, totalKeyCount = numKeys *
-  //   numNonNullFlatmapRows.
-  //   - numKeys = 2 (feature0, feature2)
-  //   - numNonNullFlatmapRows = 4 (rows 0, 1, 2, 4; row 3 is flatmap null, row
-  //   5 is parent null)
-  //   - totalKeyCount = 2 * 4 = 8
-  //   - nullCount = 0 (key stats don't include flatmap nulls; those are in
-  //   flatmap stats)
-  //   - logicalSize = totalKeyCount * sizeof(KeyType) = 8 * 1 = 8
+  // Key statistics (new semantics):
+  //   totalKeyCount = sum of per-child present entries = 4
+  //   logicalSize = totalKeyCount * sizeof(KeyType) = 4
   auto keyStat = ColumnStats{
-      .logicalSize = 8 * sizeof(int8_t),
+      .logicalSize = 4 * sizeof(int8_t),
       .physicalSize = 0,
       .nullCount = 0,
-      .valueCount = 8,
+      .valueCount = 4,
   };
 
   // Flatmap stat.
-  // physicalSize includes overhead for key null streams (2 keys * 20 bytes)
-  // plus flatmap null stream (20 bytes) = 44 additional bytes
+  //   logicalSize = keyStat.logicalSize + valueStat.logicalSize +
+  //                 1 flatmap null byte
+  //   physical overhead is empirically observed.
   auto flatmapStat = ColumnStats{
       .logicalSize =
-          1 * nimble::kNullSize + keyStat.logicalSize + valueStat.logicalSize,
-      .physicalSize = valueStat.physicalSize +
-          44, // 2 key null streams + flatmap null stream
+          keyStat.logicalSize + valueStat.logicalSize + 1 * nimble::kNullSize,
+      .physicalSize = 100,
       .nullCount = 1,
-      .valueCount = 4, // nonNullCount (actual from test)
+      .valueCount = 4, // nonNullCount (1 flatmap null in 5 iterated rows)
   };
 
-  // Root stat.
+  // Root stat: flatmap logicalSize + 1 null byte for row5.
   auto rootStat = ColumnStats{
       .logicalSize = flatmapStat.logicalSize + nimble::kNullSize,
       .physicalSize = flatmapStat.physicalSize + 20,
       .nullCount = 1,
-      .valueCount = 5, // nonNullCount (actual from test)
+      .valueCount = 5, // nonNullCount (root has 1 null)
   };
 
   verifyReturnedColumnStats(
@@ -1128,38 +1112,46 @@ TEST_P(FieldWriterStatsTests, flatMapPassThroughVarbinaryKeyFieldWriterStats) {
 
   auto vector = vectorMaker_->rowVector({flatmapVector});
 
-  // Per-key VALUE contributions:
-  //   - Key "ab": row0=1, row1=3, row2=null, row3=5 → 3 values + 1 null
-  //   - Key "cdef": row0=2, row1=null, row2=4, row3=6 → 3 values + 1 null
+  // Under passthrough flatmap semantics (see T272275493), a NULL value in a
+  // per-feature child column means "this key is NOT in the map" (inMap=0).
+  // Only present (non-NULL) entries reach the value writer.
+  //
+  // Per-key present counts:
+  //   - Key "ab": row0=1, row1=3, row2=null, row3=5 → 3 present
+  //   - Key "cdef": row0=2, row1=null, row2=4, row3=6 → 3 present
+  // totalKeyCount = 6 (was 8 under "all keys present per row" semantics).
+
+  // Per-key VALUE contributions (no nulls reach value writer under new
+  // semantics).
   auto keyAbValueStat = ColumnStats{
-      .logicalSize = sizeof(int32_t) * 3 + nimble::kNullSize,
-      .physicalSize = 43,
-      .nullCount = 1,
-      .valueCount = 3, // nonNullCount (4 total - 1 null)
+      .logicalSize = sizeof(int32_t) * 3,
+      .nullCount = 0,
+      .valueCount = 3,
   };
   auto keyCdefValueStat = ColumnStats{
-      .logicalSize = sizeof(int32_t) * 3 + nimble::kNullSize,
-      .physicalSize = 43,
-      .nullCount = 1,
-      .valueCount = 3, // nonNullCount (4 total - 1 null)
+      .logicalSize = sizeof(int32_t) * 3,
+      .nullCount = 0,
+      .valueCount = 3,
   };
+  // Per-key physicalSize is not asserted; set combined physicalSize directly
+  // to the empirically observed value.
   auto valueStat = combineFlatmapValueStats({keyAbValueStat, keyCdefValueStat});
+  valueStat.physicalSize = 36;
 
-  // Key statistics for passthrough flatmap with VARBINARY keys:
-  //   numKeys = 2, numNonNullFlatmapRows = 4
-  //   totalKeyCount = 2 * 4 = 8
-  //   totalKeyStringSize = ("ab".size() + "cdef".size()) * 4 = (2+4)*4 = 24
-  //   logicalSize = totalKeyStringSize = 24
-  // Without the fix, this would incorrectly be 8 * sizeof(StringView) = 128.
+  // Key statistics for passthrough flatmap with VARBINARY keys (new
+  // semantics):
+  //   totalKeyCount = Σᵢ presentᵢ = 6
+  //   totalKeyStringSize = "ab".size()*3 + "cdef".size()*3 = 2*3 + 4*3 = 18
+  //   logicalSize = totalKeyStringSize = 18
   auto keyStat = ColumnStats{
-      .logicalSize = (2 + 4) * 4, // 24
+      .logicalSize = 2 * 3 + 4 * 3, // 18
       .physicalSize = 0,
-      .valueCount = 8,
+      .valueCount = 6,
   };
 
   auto flatmapStat = ColumnStats{
       .logicalSize = keyStat.logicalSize + valueStat.logicalSize,
-      .physicalSize = valueStat.physicalSize + 24,
+      .physicalSize = 76,
       .valueCount = 4,
   };
 


### PR DESCRIPTION
Summary:
Fixes T272275493: a non-null empty map row written via Nimble's
passthrough flatmap path (`FlatMapFieldWriter<K>::ingestRow`) was
re-encoded as `{key0:NULL, key1:NULL, ...}` instead of preserved as
`{}`, so a `readFlatmapAsStruct` roundtrip diverged from the source
and DWIOS validation fired `CHECKSUM_MISMATCH` (alert
`dwrf_reader_checksum:<multiple>`, MAJOR/4) on 16 Instagram ML
training tables (`ig_muddler_generic_training_data_*`).

This is the deferred fix called out in D105703824. The previous code
treated every non-null parent row as having every key inMap=1 and used
the underlying value writer's null tracking to record per-key NULLs.
That doesn't match the Velox `MapVector` contract or what
`readFlatmapAsStruct` produces on read, so the post-rewrite checksum
diverged from the pre-rewrite checksum.

Semantic change for passthrough flatmap ingestion: a NULL value in a
per-feature child column now means "this key is NOT in the map"
(inMap=0). Only present (non-NULL) entries reach the value writer.
This brings `ingestRow` into parity with the read path and the
`MapVector` contract.

Code changes:

- `fbcode/dwio/nimble/velox/FieldWriter.cpp`:
  - `FlatMapFieldWriter<K>::ingestRow` decodes each child over the
    parent's non-null offsets, builds a per-child inMap bitmap, and
    calls the existing with-inMap overload of
    `FlatMapPassthroughValueFieldWriter::write` so the value writer
    only sees offsets where the key is present.
  - `collectPassthroughStringKeyStatistics` now takes a per-key
    present-count vector; total key string size is
    `Σᵢ name_size(i) * presentᵢ`.
  - Numeric-key path now passes `totalKeyCount = Σᵢ presentᵢ`
    instead of `numKeys × nonNullParentRows`.

- `fbcode/dwio/nimble/velox/RawSizeUtils.cpp`
  (`getRawSizeFromPassthroughFlatMap`): decodes each child, builds a
  per-child filtered range over present-only offsets, and recurses
  with the filtered range so the child raw size matches the writer's
  new per-key value stat (which has nullCount=0). Per-child key bytes
  are `keyTypeSize * presentᵢ` (numeric) or
  `nameSize(i) * presentᵢ` (string).

This keeps the `VeloxWriter::writeColumnStats` invariant
`fileRawSize == columnStats.front()->getLogicalSize()` green.

Test changes:

- `fbcode/dwio/nimble/velox/tests/FieldWriterStatsTest.cpp`:
  re-derived expected stats for the three affected passthrough tests
  (`flatMapPassThroughValueFieldWriterStats`,
  `flatMapPassThroughWithNullValuesFieldWriterStats`,
  `flatMapPassThroughVarbinaryKeyFieldWriterStats`).
- `fbcode/dwio/tools/test/TestFormatConverterFlatmapAsStruct.cpp`:
  added `EmptyMapRowsPreservedThroughIngestRow` which exercises
  ingestRow directly with a ROW input, then reads back as
  `MapVector` and asserts `sizeAt(emptyRow) == 0` (pre-fix this
  came back as 3 NULL-valued entries).

Rollback: pure write-path correctness fix. Files written with the new
semantics are still readable by old readers (inMap=false is the
standard Nimble encoding for "key not in this row's map"). To roll
back, revert this diff. No data migration required.

Differential Revision: D106161814


