### PR TITLE
feat(nimble): Embed per-request row range in kTabletRaw header

### DIFF
--- a/dwio/nimble/serializer/Deserializer.cpp
+++ b/dwio/nimble/serializer/Deserializer.cpp
@@ -756,8 +756,25 @@ void Deserializer::deserialize(
   const bool hasInMapChildren = !inMapChildTypes_.empty();
   const auto maxStreamOffset = deserializers_.size() - 1;
 
-  // Iterate batches and add stream data with row offsets. Streams missing from
-  // a batch will have gaps that are filled later during reading.
+  // Iterate batches and add stream data with row offsets. Streams missing
+  // from a batch will have gaps that are filled later during reading.
+  //
+  // We decode the full cumulative stream below — over-fetching rows outside
+  // any per-batch row range. For kTabletRaw inputs from NimbleIndexProjector
+  // (the producer of row-range-bearing slices), this over-fetch is bounded
+  // by stripe boundaries and never crosses users: each chunk slice covers
+  // exactly one (request × stripe) intersection. For non-kTabletRaw inputs
+  // (kCompact/kCompactRaw/kLegacy) there's no embedded row range, so
+  // "over-fetch" doesn't apply — the full batch is decoded as intended.
+  //
+  // Callers that want only the in-range rows of a kTabletRaw slice can read
+  // the range via rocks::readResultRowRange and slice the output themselves.
+  //
+  // TODO: optimize by pushing the row range into the FieldReader::skip
+  // cascade so the decode pass produces only the in-range rows. Correct for
+  // nested-nullable types because the cascade goes through FieldReader
+  // (parent nulls/lengths are read and translated to child counts). Avoids
+  // the over-fetch CPU entirely.
   uint32_t rowOffset{0};
   serde::StreamDataReader reader{pool_, options_};
   for (auto sv : data) {
@@ -803,6 +820,7 @@ void Deserializer::deserialize(
     DeserializerImpl::toDecoderImpl(decoder.get())->setTopLevelRows(rowOffset);
   }
 
+  // Single-pass decode of all batches concatenated.
   rootReader_->next(rowOffset, vector, /*scatterBitmap=*/nullptr);
 }
 

--- a/dwio/nimble/serializer/DeserializerImpl.cpp
+++ b/dwio/nimble/serializer/DeserializerImpl.cpp
@@ -255,11 +255,74 @@ StreamDataReader::StreamDataReader(
   NIMBLE_CHECK_NOT_NULL(pool_);
 }
 
+namespace {
+
+// Reads the kTabletRaw chunk fields that follow the version byte:
+//   [rowCount:varint][startRow:varint][endRow:varint]
+//   [resumeKeyLength:varint][resumeKey bytes]
+// Caller has already consumed the version byte. Used by both
+// readTabletChunkHeader (which validates version then delegates) and
+// StreamDataReader::initialize (which reads version via readVersion() then
+// delegates).
+TabletChunkHeader readTabletChunkFieldsAfterVersion(
+    const char*& pos,
+    const char* end) {
+  TabletChunkHeader header;
+  header.rowCount = varint::readVarint32(&pos);
+
+  const uint32_t startRow = varint::readVarint32(&pos);
+  const uint32_t endRow = varint::readVarint32(&pos);
+  NIMBLE_CHECK_LE(
+      startRow, endRow, "Row range startRow must not exceed endRow");
+  NIMBLE_CHECK_LE(
+      endRow,
+      header.rowCount,
+      "Row range endRow must not exceed stripe rowCount");
+  header.rowRange = RowRange{startRow, endRow};
+
+  const uint32_t resumeKeyLength = varint::readVarint32(&pos);
+  if (resumeKeyLength > 0) {
+    const uint32_t resumeKeyBytes = resumeKeyLength - 1;
+    NIMBLE_CHECK_GE(
+        end - pos,
+        static_cast<ptrdiff_t>(resumeKeyBytes),
+        "Truncated resume key payload");
+    header.resumeKey = std::string(pos, resumeKeyBytes);
+    pos += resumeKeyBytes;
+  }
+  return header;
+}
+
+} // namespace
+
+TabletChunkHeader readTabletChunkHeader(const char*& pos, const char* end) {
+  NIMBLE_CHECK_GE(end - pos, 1, "Truncated chunk header (version)");
+  const auto version = static_cast<SerializationVersion>(*pos++);
+  NIMBLE_CHECK_EQ(
+      version,
+      SerializationVersion::kTabletRaw,
+      "Unsupported version for kTabletRaw chunk header");
+  return readTabletChunkFieldsAfterVersion(pos, end);
+}
+
 uint32_t StreamDataReader::initialize(std::string_view data) {
+  // For kTabletRaw inputs, the caller is expected to pass a coalesced or
+  // single-node view of the chunk slice: the per-slice header
+  // (version + rowCount + row range + resume-key-length [+ resume key])
+  // must live contiguously within `data` so the reads below see all of it.
+  // The projector emits the header in a single allocation; consumers that
+  // hand chunk slices to this method should coalesce the IOBuf chain first.
   pos_ = data.data();
   end_ = data.end();
+  rowRange_.reset();
   readVersion();
-  // All non-legacy formats use varint row count.
+
+  if (version_ == SerializationVersion::kTabletRaw) {
+    auto header = readTabletChunkFieldsAfterVersion(pos_, end_);
+    rowRange_ = header.rowRange;
+    return header.rowCount;
+  }
+  // All other non-legacy formats use varint row count; kLegacy uses fixed u32.
   if (usesVarintRowCount(version_)) {
     return varint::readVarint32(&pos_);
   }

--- a/dwio/nimble/serializer/DeserializerImpl.h
+++ b/dwio/nimble/serializer/DeserializerImpl.h
@@ -24,12 +24,25 @@
 #include "dwio/nimble/common/Vector.h"
 #include "dwio/nimble/encodings/common/Encoding.h"
 #include "dwio/nimble/serializer/Options.h"
+#include "dwio/nimble/serializer/SerializerImpl.h"
+#include "dwio/nimble/velox/RowRange.h"
 #include "dwio/nimble/velox/SchemaTypes.h"
 #include "velox/buffer/Buffer.h"
 #include "velox/buffer/BufferPool.h"
 #include "velox/common/memory/Memory.h"
 
 namespace facebook::nimble::serde {
+
+/// Reads the kTabletRaw chunk slice header starting at `*pos` and advances
+/// `*pos` past it (including any resume key bytes). NIMBLE_CHECKs that the
+/// version is kTabletRaw and that the row range satisfies
+/// startRow <= endRow <= rowCount.
+///
+/// Counterpart to the writer-side `createTabletChunkHeader` in
+/// SerializerImpl.h. Used both by NimbleTable.h helpers (extract row range /
+/// resume key from a chunk slice) and by StreamDataReader::initialize (when
+/// the data is kTabletRaw).
+TabletChunkHeader readTabletChunkHeader(const char*& pos, const char* end);
 
 class StreamData {
  public:
@@ -187,6 +200,13 @@ class StreamDataReader {
 
   /// Returns number of rows serialized.
   /// Validates that the version in serialized data matches options.
+  ///
+  /// PRECONDITION (kTabletRaw only): the per-slice header
+  /// (`[version][rowCount:varint][startRow:varint][endRow:varint]`
+  /// `[resumeKeyLength:varint][resumeKey]`) must live contiguously within
+  /// `data`. The projector emits the header in a single allocation; consumers
+  /// that hand chunk slices to this method should coalesce the IOBuf chain
+  /// first (`folly::IOBuf::cloneCoalescedAsValue()`).
   uint32_t initialize(std::string_view data);
 
   void iterateStreams(
@@ -203,6 +223,14 @@ class StreamDataReader {
   /// version. Only valid after initialize() has been called.
   bool encodingEnabled() const {
     return nonLegacyFormat(version_);
+  }
+
+  /// Returns the row range embedded in the per-slice header for kTabletRaw
+  /// chunks (always present on the wire for kTabletRaw). nullopt for all
+  /// other serialization versions. Only valid after initialize() has been
+  /// called.
+  const std::optional<RowRange>& rowRange() const {
+    return rowRange_;
   }
 
  private:
@@ -240,6 +268,10 @@ class StreamDataReader {
   // header, this is read from the first byte; otherwise defaults to kLegacy.
   // When options specify a version, the data version is validated against it.
   SerializationVersion version_{SerializationVersion::kLegacy};
+  // Per-request row range embedded in the kTabletRaw header (post-rowCount,
+  // before stream data). nullopt for non-kTabletRaw formats or when the
+  // producer did not embed a row range.
+  std::optional<RowRange> rowRange_;
   const char* pos_{nullptr};
   const char* end_{nullptr};
   // Reusable buffer for chunk header stripping (compressed/multi-chunk case).

--- a/dwio/nimble/serializer/SerializerImpl.cpp
+++ b/dwio/nimble/serializer/SerializerImpl.cpp
@@ -286,3 +286,47 @@ std::vector<std::string_view> parseStreams(
 }
 
 } // namespace facebook::nimble::serde::detail
+
+namespace facebook::nimble::serde {
+
+folly::IOBuf createTabletChunkHeader(const TabletChunkHeader& header) {
+  // resumeKeyLength is varint-encoded as (key.size() + 1) when present so 0
+  // signals absent without a separate flag. Guard the (size + 1) narrowing
+  // to uint32 — a key at SIZE_MAX would silently encode as 0 and decode as
+  // "absent", dropping the key on the wire.
+  if (header.resumeKey.has_value()) {
+    NIMBLE_CHECK_LT(
+        header.resumeKey->size(),
+        std::numeric_limits<uint32_t>::max(),
+        "Resume key too large to fit in uint32 length sentinel");
+  }
+  const uint32_t resumeKeyLength = header.resumeKey.has_value()
+      ? static_cast<uint32_t>(header.resumeKey->size() + 1)
+      : 0;
+  size_t totalSize = sizeof(uint8_t) /* version */ +
+      varint::varintSize(header.rowCount) +
+      varint::varintSize(header.rowRange.startRow) +
+      varint::varintSize(header.rowRange.endRow) +
+      varint::varintSize(resumeKeyLength);
+  if (header.resumeKey.has_value()) {
+    totalSize += header.resumeKey->size();
+  }
+
+  auto buf = folly::IOBuf::create(totalSize);
+  auto* pos = reinterpret_cast<char*>(buf->writableData());
+  *pos++ = static_cast<char>(SerializationVersion::kTabletRaw);
+  varint::writeVarint(/*val=*/header.rowCount, &pos);
+  varint::writeVarint(/*val=*/header.rowRange.startRow, &pos);
+  varint::writeVarint(/*val=*/header.rowRange.endRow, &pos);
+  varint::writeVarint(/*val=*/resumeKeyLength, &pos);
+  if (header.resumeKey.has_value() && !header.resumeKey->empty()) {
+    // The destination IOBuf was allocated with totalSize bytes which include
+    // exactly resumeKey->size() bytes at this position — no overflow.
+    // NOLINTNEXTLINE(facebook-security-vulnerable-memcpy)
+    std::memcpy(pos, header.resumeKey->data(), header.resumeKey->size());
+  }
+  buf->append(totalSize);
+  return std::move(*buf);
+}
+
+} // namespace facebook::nimble::serde

--- a/dwio/nimble/serializer/SerializerImpl.h
+++ b/dwio/nimble/serializer/SerializerImpl.h
@@ -18,7 +18,9 @@
 
 #include <algorithm>
 #include <bit>
+#include <cstring>
 #include <optional>
+#include <string>
 
 #include "dwio/nimble/common/Buffer.h"
 #include "dwio/nimble/common/FixedBitArray.h"
@@ -28,6 +30,7 @@
 #include "dwio/nimble/encodings/common/EncodingPrimitives.h"
 #include "dwio/nimble/encodings/selection/EncodingSelectionPolicy.h"
 #include "dwio/nimble/serializer/Options.h"
+#include "dwio/nimble/velox/RowRange.h"
 #include "dwio/nimble/velox/StreamData.h"
 #include "folly/io/Cursor.h"
 #include "folly/io/IOBuf.h"
@@ -130,10 +133,20 @@ inline size_t rowCountSize(
 
 /// Returns the exact byte size of the serialization header.
 /// Use to pre-allocate buffers before calling writeHeader().
+/// For kTabletRaw, includes the required row range (2 × varint) and the
+/// resume-key-length sentinel (varint of 0 = absent) that writeHeader
+/// auto-emits — see writeHeader docs.
 inline size_t estimateHeaderSize(
     std::optional<SerializationVersion> version,
     uint32_t rowCount) {
-  return versionSize(version) + rowCountSize(version, rowCount);
+  size_t size = versionSize(version) + rowCountSize(version, rowCount);
+  if (version.has_value() &&
+      version.value() == SerializationVersion::kTabletRaw) {
+    // [startRow:varint=0][endRow:varint=rowCount][resumeKeyLength:varint=0]
+    size += varint::varintSize(uint32_t{0}) + varint::varintSize(rowCount) +
+        varint::varintSize(uint32_t{0});
+  }
+  return size;
 }
 
 /// Writes serialization header to buffer.
@@ -146,7 +159,13 @@ inline size_t estimateHeaderSize(
 ///   [version:1B][rowCount:varint][stream_data_0][stream_data_1]...[encoded_stream_sizes][stream_sizes_encoded_size:u32]
 ///
 /// For kLegacy: writes [optional_version:1B][rowCount:u32]
-/// For kCompact/kCompactRaw/kTabletRaw: writes [version:1B][rowCount:varint]
+/// For kCompact/kCompactRaw: writes [version:1B][rowCount:varint]
+/// For kTabletRaw: writes
+///   [version:1B][rowCount:varint][startRow:varint=0][endRow:varint=rowCount]
+///   [resumeKeyLength:varint=0]
+///   The default row range covers the whole stripe; resumeKeyLength=0 means
+///   no resume key. Producers that need a narrower range or a resume key use
+///   serde::createTabletChunkHeader instead of writeHeader.
 ///
 /// @param buffer Output buffer (std::string, velox::Buffer, etc.)
 /// @param version Serialization format version (nullopt = no version byte)
@@ -168,6 +187,26 @@ void writeHeader(
   } else {
     auto* rowCountPos = extend(buffer, sizeof(uint32_t));
     encoding::writeUint32(rowCount, rowCountPos);
+  }
+
+  // kTabletRaw requires a row range and a resume-key-length varint; the
+  // default row range covers the whole stripe and resumeKeyLength=0 signals
+  // no key. Producers that need narrower ranges or a resume key use
+  // serde::createTabletChunkHeader directly instead.
+  //
+  // WIRE-FORMAT INVARIANT: the bytes emitted here MUST stay in lockstep with
+  // serde::createTabletChunkHeader (see SerializerImpl.cpp). Both produce
+  // the kTabletRaw chunk slice header; any field added to one must be added
+  // to the other, and to readTabletChunkHeader + StreamDataReader::initialize.
+  if (version.has_value() &&
+      version.value() == SerializationVersion::kTabletRaw) {
+    constexpr uint32_t kStartRow = 0;
+    auto* startRowPos = extend(buffer, varint::varintSize(kStartRow));
+    varint::writeVarint(kStartRow, &startRowPos);
+    auto* endRowPos = extend(buffer, varint::varintSize(rowCount));
+    varint::writeVarint(rowCount, &endRowPos);
+    auto* resumeKeyLenPos = extend(buffer, varint::varintSize(uint32_t{0}));
+    varint::writeVarint(uint32_t{0}, &resumeKeyLenPos);
   }
 }
 
@@ -469,6 +508,44 @@ std::string_view encodeScalar(
   }
 }
 } // namespace detail
+
+/// Parsed fields of a kTabletRaw chunk slice header. Row range is required;
+/// resume key is optional (length-0 sentinel encoded on the wire).
+struct TabletChunkHeader {
+  uint32_t rowCount{0};
+  RowRange rowRange;
+  std::optional<std::string> resumeKey;
+};
+
+/// Minimum byte size of a kTabletRaw chunk slice header: version byte +
+/// 1-byte varint rowCount + 1-byte varint startRow + 1-byte varint endRow +
+/// 1-byte varint resumeKeyLength=0. All fields use varint, so larger values
+/// (or a present resume key) add bytes; callers track the extras separately
+/// for byte accounting.
+constexpr size_t kMinTabletChunkHeaderSize = sizeof(uint8_t) /* version */ +
+    1 /* rowCount varint (lower bound) */ +
+    1 /* startRow varint (lower bound) */ +
+    1 /* endRow varint (lower bound) */ +
+    1 /* resumeKeyLength varint (0 = no key) */;
+
+/// Builds the kTabletRaw chunk slice header as a freshly-allocated IOBuf.
+/// Used by NimbleIndexProjector to emit the per-slice header that prefixes
+/// each chunk slice's IOBuf chain. Wire layout:
+///   [version:1B = kTabletRaw][rowCount:varint]
+///   [startRow:varint][endRow:varint]
+///   [resumeKeyLength:varint][resumeKey]
+///
+/// `resumeKeyLength` is varint-encoded as `key.size() + 1` when a resume key
+/// is present (so 1 means an empty key, N>0 means a key of length N-1), and
+/// 0 when no resume key is present. This distinguishes "no key" from "empty
+/// key" without a separate flag.
+///
+/// The returned IOBuf is sized exactly to the header bytes (no headroom or
+/// trailing capacity).
+folly::IOBuf createTabletChunkHeader(const TabletChunkHeader& header);
+
+// Reader-side counterpart `readTabletChunkHeader(pos, end)` lives in
+// DeserializerImpl.h.
 
 template <typename T>
 class StreamDataWriter {

--- a/dwio/nimble/serializer/tests/CMakeLists.txt
+++ b/dwio/nimble/serializer/tests/CMakeLists.txt
@@ -24,6 +24,7 @@ target_link_libraries(
   nimble_serializer_tests
   nimble_serializer
   nimble_deserializer
+  nimble_deserializer_impl
   nimble_serializer_impl
   nimble_serializer_options
   nimble_projector

--- a/dwio/nimble/serializer/tests/SerializerImplTest.cpp
+++ b/dwio/nimble/serializer/tests/SerializerImplTest.cpp
@@ -14,11 +14,14 @@
  * limitations under the License.
  */
 
+#include <limits>
+
 #include <gtest/gtest.h>
 #include <lz4.h>
 #include <zstd.h>
 
 #include "dwio/nimble/common/ChunkHeader.h"
+#include "dwio/nimble/common/Exceptions.h"
 #include "dwio/nimble/common/Varint.h"
 #include "dwio/nimble/encodings/common/EncodingFactory.h"
 #include "dwio/nimble/encodings/common/EncodingLayout.h"
@@ -1959,4 +1962,182 @@ TEST_F(LZ4RoundtripTest, encodeDecodeLZ4HighCompression) {
       reinterpret_cast<char*>(output.data()),
       static_cast<uint32_t>(output.size() * sizeof(int32_t)));
   EXPECT_EQ(output, expected);
+}
+
+namespace {
+
+TabletChunkHeader roundTripTabletChunkHeader(const TabletChunkHeader& in) {
+  auto buf = createTabletChunkHeader(in);
+  const char* pos = reinterpret_cast<const char*>(buf.data());
+  const char* end = pos + buf.length();
+  auto out = readTabletChunkHeader(pos, end);
+  EXPECT_EQ(pos, end) << "Unexpected trailing bytes after header";
+  return out;
+}
+
+} // namespace
+
+TEST(TabletChunkHeaderTest, noResumeKey) {
+  TabletChunkHeader in{.rowCount = 100, .rowRange = RowRange{0, 100}};
+  const auto out = roundTripTabletChunkHeader(in);
+  EXPECT_EQ(out.rowCount, 100u);
+  EXPECT_EQ(out.rowRange, RowRange(0, 100));
+  EXPECT_FALSE(out.resumeKey.has_value());
+}
+
+TEST(TabletChunkHeaderTest, narrowRowRange) {
+  TabletChunkHeader in{.rowCount = 100, .rowRange = RowRange{10, 40}};
+  const auto out = roundTripTabletChunkHeader(in);
+  EXPECT_EQ(out.rowCount, 100u);
+  EXPECT_EQ(out.rowRange.startRow, 10u);
+  EXPECT_EQ(out.rowRange.endRow, 40u);
+  EXPECT_FALSE(out.resumeKey.has_value());
+}
+
+TEST(TabletChunkHeaderTest, withResumeKey) {
+  TabletChunkHeader in{
+      .rowCount = 100,
+      .rowRange = RowRange{0, 100},
+      .resumeKey = std::string{"my-resume-key"}};
+  const auto out = roundTripTabletChunkHeader(in);
+  EXPECT_EQ(out.rowCount, 100u);
+  EXPECT_EQ(out.rowRange, RowRange(0, 100));
+  ASSERT_TRUE(out.resumeKey.has_value());
+  EXPECT_EQ(*out.resumeKey, "my-resume-key");
+}
+
+TEST(TabletChunkHeaderTest, narrowRangeAndResumeKey) {
+  TabletChunkHeader in{
+      .rowCount = 4096,
+      .rowRange = RowRange{500, 1000},
+      .resumeKey = std::string{"\x00\x01\x02", 3}};
+  const auto out = roundTripTabletChunkHeader(in);
+  EXPECT_EQ(out.rowCount, 4096u);
+  EXPECT_EQ(out.rowRange, RowRange(500, 1000));
+  ASSERT_TRUE(out.resumeKey.has_value());
+  EXPECT_EQ(*out.resumeKey, (std::string{"\x00\x01\x02", 3}));
+}
+
+TEST(TabletChunkHeaderTest, emptyResumeKey) {
+  // An empty string resume key is distinct from "no resume key": the wire
+  // length is 1 (varint of size+1) vs 0 for absent.
+  TabletChunkHeader in{
+      .rowCount = 1, .rowRange = RowRange{0, 1}, .resumeKey = std::string{}};
+  const auto out = roundTripTabletChunkHeader(in);
+  EXPECT_EQ(out.rowCount, 1u);
+  ASSERT_TRUE(out.resumeKey.has_value());
+  EXPECT_TRUE(out.resumeKey->empty());
+}
+
+TEST(TabletChunkHeaderTest, rejectsUnknownVersion) {
+  // Forge bytes with an unsupported version byte.
+  std::string buf;
+  buf.push_back(static_cast<char>(SerializationVersion::kCompact));
+  buf.push_back(0x01); // rowCount = 1 (varint)
+  const char* pos = buf.data();
+  EXPECT_THROW(
+      readTabletChunkHeader(pos, pos + buf.size()), NimbleInternalError);
+}
+
+TEST(TabletChunkHeaderTest, truncatedVersionByte) {
+  std::string buf;
+  const char* pos = buf.data();
+  EXPECT_THROW(readTabletChunkHeader(pos, pos), NimbleInternalError);
+}
+
+TEST(TabletChunkHeaderTest, roundTripsMaxUint32RowCount) {
+  // Exercises the 5-byte varint encoding path for rowCount and endRow.
+  TabletChunkHeader in{
+      .rowCount = std::numeric_limits<uint32_t>::max(),
+      .rowRange = RowRange{0, std::numeric_limits<uint32_t>::max()},
+  };
+  const auto out = roundTripTabletChunkHeader(in);
+  EXPECT_EQ(out.rowCount, std::numeric_limits<uint32_t>::max());
+  EXPECT_EQ(out.rowRange.startRow, 0u);
+  EXPECT_EQ(out.rowRange.endRow, std::numeric_limits<uint32_t>::max());
+}
+
+TEST(TabletChunkHeaderTest, exactBoundaryEndRowEqualsRowCount) {
+  // Round-trip a row range whose endRow exactly equals rowCount (last-row
+  // boundary). NIMBLE_CHECK_LE permits equality; this exercises the
+  // boundary explicitly.
+  TabletChunkHeader in{.rowCount = 100, .rowRange = RowRange{99, 100}};
+  const auto out = roundTripTabletChunkHeader(in);
+  EXPECT_EQ(out.rowCount, 100u);
+  EXPECT_EQ(out.rowRange, RowRange(99, 100));
+}
+
+TEST(TabletChunkHeaderTest, rejectsRowRangeExceedingRowCount) {
+  // Forge a row range whose endRow exceeds the stripe's rowCount. All
+  // fields are 1-byte varints (values < 128).
+  std::string buf;
+  buf.push_back(static_cast<char>(SerializationVersion::kTabletRaw));
+  buf.push_back(0x05); // rowCount = 5
+  buf.push_back(0x00); // startRow = 0
+  buf.push_back(0x64); // endRow = 100 (> rowCount)
+  buf.push_back(0x00); // resumeKeyLength = 0
+  const char* pos = buf.data();
+  EXPECT_THROW(
+      readTabletChunkHeader(pos, pos + buf.size()), NimbleInternalError);
+}
+
+TEST(TabletChunkHeaderTest, rejectsInvertedRowRange) {
+  // startRow > endRow is invalid. All fields are 1-byte varints.
+  std::string buf;
+  buf.push_back(static_cast<char>(SerializationVersion::kTabletRaw));
+  buf.push_back(0x0a); // rowCount = 10
+  buf.push_back(0x05); // startRow = 5
+  buf.push_back(0x03); // endRow = 3 (< startRow)
+  buf.push_back(0x00); // resumeKeyLength = 0
+  const char* pos = buf.data();
+  EXPECT_THROW(
+      readTabletChunkHeader(pos, pos + buf.size()), NimbleInternalError);
+}
+
+// Exercises the StreamDataReader::initialize path (delegates to the shared
+// readTabletChunkFieldsAfterVersion helper) on forged kTabletRaw input.
+// Uses the WriteHeaderTest fixture purely for its initialized MemoryPool.
+class StreamDataReaderTabletRawTest : public WriteHeaderTest {
+ protected:
+  void expectInitializeThrows(const std::string& buf) {
+    DeserializerOptions options;
+    options.hasHeader = true;
+    StreamDataReader reader{pool_.get(), options};
+    EXPECT_THROW(
+        reader.initialize(std::string_view(buf.data(), buf.size())),
+        NimbleInternalError);
+  }
+};
+
+TEST_F(StreamDataReaderTabletRawTest, rejectsRowRangeExceedingRowCount) {
+  std::string buf;
+  buf.push_back(static_cast<char>(SerializationVersion::kTabletRaw));
+  buf.push_back(0x05); // rowCount = 5
+  buf.push_back(0x00); // startRow = 0
+  buf.push_back(0x64); // endRow = 100 (> rowCount)
+  buf.push_back(0x00); // resumeKeyLength = 0
+  expectInitializeThrows(buf);
+}
+
+TEST_F(StreamDataReaderTabletRawTest, rejectsInvertedRowRange) {
+  std::string buf;
+  buf.push_back(static_cast<char>(SerializationVersion::kTabletRaw));
+  buf.push_back(0x0a); // rowCount = 10
+  buf.push_back(0x05); // startRow = 5
+  buf.push_back(0x03); // endRow = 3
+  buf.push_back(0x00); // resumeKeyLength = 0
+  expectInitializeThrows(buf);
+}
+
+TEST_F(StreamDataReaderTabletRawTest, rejectsTruncatedResumeKey) {
+  // Valid version + rowCount + row range + resumeKeyLength=4 (declares a
+  // 3-byte key), but only 1 byte of resume key follows.
+  std::string buf;
+  buf.push_back(static_cast<char>(SerializationVersion::kTabletRaw));
+  buf.push_back(0x0a); // rowCount = 10
+  buf.push_back(0x00); // startRow = 0
+  buf.push_back(0x05); // endRow = 5
+  buf.push_back(0x04); // resumeKeyLength = 4 → declares 3 key bytes
+  buf.push_back('a'); // only 1 key byte present
+  expectInitializeThrows(buf);
 }

--- a/dwio/nimble/velox/index/NimbleIndexProjector.cpp
+++ b/dwio/nimble/velox/index/NimbleIndexProjector.cpp
@@ -126,12 +126,13 @@ NimbleIndexProjector::Result NimbleIndexProjector::project(
     if (!pruneStripeRowRanges(stripeRowRanges)) {
       continue;
     }
-    if (!processStripe(stripeIndex, stripeRowRanges_, result)) {
+    if (!processStripe(stripeIndex, stripeRowRanges_)) {
       setResumeKeys(stripeIndex, stripeRowRanges_, result);
       break;
     }
   }
 
+  finalizeResultChunks(result);
   updateIoStats();
   return result;
 }
@@ -148,6 +149,7 @@ void NimbleIndexProjector::initRequest(
   numReadRows_ = 0;
   numReadBytes_ = 0;
   rowsPerRequest_.assign(numRequests_, 0);
+  resultChunks_.assign(numRequests_, {});
 }
 
 void NimbleIndexProjector::clearRequest() {
@@ -155,6 +157,7 @@ void NimbleIndexProjector::clearRequest() {
   options_ = nullptr;
   numRequests_ = 0;
   rowsPerRequest_.clear();
+  resultChunks_.clear();
   stripeRowRanges_.clear();
   stripeRangeMap_.clear();
 }
@@ -268,8 +271,7 @@ bool NimbleIndexProjector::pruneStripeRowRanges(
 
 bool NimbleIndexProjector::processStripe(
     uint32_t stripeIndex,
-    std::span<const StripeRowRange> stripeRowRanges,
-    Result& result) {
+    std::span<const StripeRowRange> stripeRowRanges) {
   streams_.setStripe(stripeIndex);
 
   // TODO: Support fine-grained row range fetches from a stripe. For now, we
@@ -277,8 +279,7 @@ bool NimbleIndexProjector::processStripe(
   // values. The result references a portion of it based on the row range.
   auto inputStreams = loadStripe();
   auto stripeChunk = serializeStripe(stripeIndex, inputStreams);
-  return buildStripeResult(
-      stripeIndex, stripeRowRanges, std::move(stripeChunk), result);
+  return buildStripeResult(stripeRowRanges, std::move(stripeChunk));
 }
 
 NimbleIndexProjector::InputStreams NimbleIndexProjector::loadStripe() {
@@ -293,28 +294,23 @@ NimbleIndexProjector::InputStreams NimbleIndexProjector::loadStripe() {
   return inputStreams;
 }
 
-NimbleIndexProjector::Chunk NimbleIndexProjector::serializeStripe(
+NimbleIndexProjector::ResultChunk NimbleIndexProjector::serializeStripe(
     uint32_t stripeIndex,
     InputStreams& inputStreams) {
   velox::CpuWallTimer timer(stats_.projectionTiming);
 
   const auto numStripeRows = stripeRowCount(stripeIndex);
 
-  // Build kTabletRaw output as chained IOBufs:
-  // [header] → [raw stream data...] → [trailer].
-  // kTabletRaw passes raw tablet bytes through including chunk headers.
-  // The Deserializer handles chunk header stripping on the client side.
-  std::string headerBuf;
-  serde::detail::writeHeader(
-      headerBuf, SerializationVersion::kTabletRaw, numStripeRows);
-  auto output = folly::IOBuf::copyBuffer(headerBuf.data(), headerBuf.size());
+  // Build the shared body+trailer for this stripe:
+  //   [stream_data...][encodingType][stream_sizes][trailer_size:u32].
+  // The version/rowCount/row-range/resume-key header is per-slice and is
+  // built later by finalizeResultChunks().
 
-  // Read all stream data into a single contiguous buffer to avoid
-  // per-segment IOBuf allocations (one IOBuf::create instead of many
-  // IOBuf::copyBuffer calls).
+  // Collect raw stream segments without copying. Sizes are needed for the
+  // trailer.
   std::vector<uint32_t> streamSizes(projectedStreamOffsets_.size(), 0);
   std::vector<std::pair<const void*, int>> segments;
-  uint32_t totalBytes = 0;
+  uint32_t totalStreamBytes = 0;
   for (size_t i = 0; i < inputStreams.size(); ++i) {
     if (inputStreams[i] == nullptr) {
       continue;
@@ -324,20 +320,17 @@ NimbleIndexProjector::Chunk NimbleIndexProjector::serializeStripe(
     while (inputStreams[i]->Next(&data, &size)) {
       segments.emplace_back(data, size);
       streamSizes[i] += static_cast<uint32_t>(size);
-      totalBytes += static_cast<uint32_t>(size);
+      totalStreamBytes += static_cast<uint32_t>(size);
     }
   }
 
   std::string trailerBuf;
   serde::detail::writeTrailer(streamSizes, EncodingType::Trivial, trailerBuf);
 
-  // Single allocation for header + data + trailer.
-  const size_t totalSize = headerBuf.size() + totalBytes + trailerBuf.size();
-  output = folly::IOBuf::create(totalSize);
-  auto* dest = output->writableData();
-
-  std::memcpy(dest, headerBuf.data(), headerBuf.size());
-  dest += headerBuf.size();
+  // Single allocation for stream data + trailer.
+  const size_t bodySize = totalStreamBytes + trailerBuf.size();
+  auto body = folly::IOBuf::create(bodySize);
+  auto* dest = body->writableData();
 
   for (const auto& [data, size] : segments) {
     std::memcpy(dest, data, size);
@@ -345,25 +338,22 @@ NimbleIndexProjector::Chunk NimbleIndexProjector::serializeStripe(
   }
 
   std::memcpy(dest, trailerBuf.data(), trailerBuf.size());
-  output->append(totalSize);
+  body->append(bodySize);
 
-  Chunk chunk;
-  chunk.data = std::move(*output);
-  chunk.numRows = numStripeRows;
+  ResultChunk stripeChunk;
+  stripeChunk.sharedData = std::move(*body);
+  stripeChunk.numStripeRows = numStripeRows;
 
   stats_.numScannedRows += numStripeRows;
   stats_.numProjectedRows += numStripeRows;
-  stats_.numReadBytes += chunk.data.computeChainDataLength();
-  return chunk;
+  stats_.numReadBytes += stripeChunk.sharedData.length();
+  return stripeChunk;
 }
 
 bool NimbleIndexProjector::buildStripeResult(
-    uint32_t stripeIndex,
     std::span<const StripeRowRange> stripeRowRanges,
-    Chunk&& chunk,
-    Result& result) {
-  const auto chunkIndex = static_cast<uint32_t>(result.chunks.size());
-
+    ResultChunk&& stripeChunk) {
+  size_t numEmittedSlices = 0;
   for (const auto& request : stripeRowRanges) {
     NIMBLE_CHECK(!request.rowRange.empty());
     auto rowRange = request.rowRange;
@@ -379,15 +369,44 @@ bool NimbleIndexProjector::buildStripeResult(
       }
     }
 
+    // Defensive guard: clipping above could in principle produce an empty
+    // range (rowRange.numRows() == 0). The upstream NIMBLE_CHECK_GT keeps
+    // `remaining > 0` today, but skipping empty ranges keeps the chunk
+    // slice list free of zero-row entries if that invariant ever drifts.
+    if (rowRange.numRows() == 0) {
+      continue;
+    }
+
+    // Queue a per-slice clone of the shared body+trailer. The header node
+    // (version + rowCount + row range + resume-key-length [+ resume key])
+    // is materialized and chained on top in finalizeResultChunks().
     stats_.numReadRows += rowRange.numRows();
     numReadRows_ += rowRange.numRows();
-    result.responses[request.requestIndex].slices.emplace_back(
-        ChunkSlice{chunkIndex, rowRange});
+    resultChunks_[request.requestIndex].emplace_back(
+        stripeChunk.sharedData.cloneOneAsValue(),
+        stripeChunk.numStripeRows,
+        rowRange);
     rowsPerRequest_[request.requestIndex] += rowRange.numRows();
+    ++numEmittedSlices;
   }
 
-  numReadBytes_ += chunk.data.computeChainDataLength();
-  result.chunks.emplace_back(std::move(chunk));
+  // Account for body+trailer bytes (per stripe, shared) plus a lower-bound
+  // for the per-slice header bytes — one min-sized header per emitted slice
+  // (skipped zero-row ranges are excluded). finalizeResultChunks() tops up
+  // to the actual header size per slice. serializeStripe already added body
+  // bytes to stats_; numReadBytes_ tracks the running total used by maxBytes
+  // enforcement.
+  //
+  // NOTE: bodyBytes is added once per stripe even though every per-request
+  // chunk slice clones the shared body. maxBytes therefore caps "stripe
+  // bytes assembled" (in-process memory growth), not "wire bytes returned"
+  // — a single hot stripe served to N requests transmits ~N×bodyBytes over
+  // RPC. Callers wanting wire-bytes semantics should set maxBytes lower or
+  // post-process Result to compute total chunkSlices length.
+  const auto bodyBytes = stripeChunk.sharedData.length();
+  const auto headerBytes = serde::kMinTabletChunkHeaderSize * numEmittedSlices;
+  numReadBytes_ += bodyBytes + headerBytes;
+  stats_.numReadBytes += headerBytes;
 
   return !checkOutputLimit();
 }
@@ -424,11 +443,13 @@ void NimbleIndexProjector::setResumeKeys(
     }
   }
 
-  // For requests that were never started (empty slices, no resume key),
-  // set resume key to their original lower key so the caller can retry.
+  // For requests that were never started (no result chunks for this scan,
+  // no resume key), set resume key to their original lower key so the
+  // caller can retry. Note: response.chunkSlices is populated later by
+  // finalizeResultChunks(), so we check resultChunks_ here.
   for (size_t i = 0; i < result.responses.size(); ++i) {
     auto& response = result.responses[i];
-    if (response.slices.empty() && !response.resumeKey.has_value()) {
+    if (resultChunks_[i].empty() && !response.resumeKey.has_value()) {
       const auto& keyBounds = request_->keyBounds[i];
       NIMBLE_CHECK(
           keyBounds.lowerKey.has_value(),
@@ -436,6 +457,48 @@ void NimbleIndexProjector::setResumeKeys(
           "stripe 0 and should have been processed before truncation",
           i);
       response.resumeKey = *keyBounds.lowerKey;
+    }
+  }
+}
+
+void NimbleIndexProjector::finalizeResultChunks(Result& result) {
+  NIMBLE_CHECK_EQ(resultChunks_.size(), result.responses.size());
+
+  for (size_t responseIdx = 0; responseIdx < result.responses.size();
+       ++responseIdx) {
+    auto& response = result.responses[responseIdx];
+    auto& chunks = resultChunks_[responseIdx];
+    const auto numChunks = chunks.size();
+    response.chunkSlices.reserve(numChunks);
+
+    for (size_t chunkIdx = 0; chunkIdx < numChunks; ++chunkIdx) {
+      auto& chunk = chunks[chunkIdx];
+
+      serde::TabletChunkHeader header{
+          .rowCount = chunk.numStripeRows,
+          .rowRange = chunk.rowRange,
+      };
+      // Resume key is only encoded on the last slice when present.
+      if (chunkIdx + 1 == numChunks && response.resumeKey.has_value()) {
+        header.resumeKey = response.resumeKey;
+      }
+
+      auto headerNode = std::make_unique<folly::IOBuf>(
+          serde::createTabletChunkHeader(header));
+      const auto headerSize = headerNode->length();
+
+      // Chain: [per-slice header] -> [shared body+trailer].
+      headerNode->appendToChain(
+          std::make_unique<folly::IOBuf>(std::move(chunk.sharedData)));
+
+      // Top up the lower-bound accounting from buildStripeResult to the
+      // actual header size (rowCount/range/resumeKeyLength varints may be
+      // larger than 1 byte; resume key bytes are also counted here).
+      const auto extra = headerSize - serde::kMinTabletChunkHeaderSize;
+      stats_.numReadBytes += extra;
+      numReadBytes_ += extra;
+
+      response.chunkSlices.emplace_back(std::move(*headerNode));
     }
   }
 }

--- a/dwio/nimble/velox/index/NimbleIndexProjector.h
+++ b/dwio/nimble/velox/index/NimbleIndexProjector.h
@@ -43,18 +43,30 @@ using Subfield = velox::common::Subfield;
 /// Nimble cluster index to locate relevant stripes and row ranges, then reads
 /// and serializes the projected columns for transport.
 ///
-/// The output uses kTabletRaw serialization format, which passes raw tablet
-/// stream bytes through (including chunk headers). The Deserializer handles
-/// chunk header stripping on the client side, shifting CPU cost from the
-/// centralized server to distributed clients.
+/// The output uses kTabletRaw serialization format with a fixed-shape
+/// per-slice header in front of the stripe body+trailer:
+///   NODE 1 (per-slice header):
+///     [version:1B=3][rowCount:varint]
+///     [startRow:varint][endRow:varint]
+///     [resumeKeyLength:varint]   0 = no key; N>0 = key of length N-1
+///     [resumeKey bytes]          present when resumeKeyLength > 0
+///   NODE 2 (shared stripe body + trailer):
+///     [stream_data_0...][encodingType:1B][stream_sizes][trailer_size:u32]
+///
+/// The chunk slice IOBuf is a 2-node chain: a per-slice header node and a
+/// shared body+trailer node. Multiple requests that hit the same stripe with
+/// different row ranges share the body+trailer bytes via
+/// `folly::IOBuf::cloneOne` (refcounted SharedInfo); only the header node
+/// is unique per slice.
 ///
 /// Usage:
 ///   auto result = projector.project(request, options);
 ///   for (size_t i = 0; i < result.responses.size(); ++i) {
 ///     const auto& response = result.responses[i];
-///     for (const auto& slice : response.slices) {
-///       const auto& chunk = result.chunks[slice.chunkIndex];
-///       // process chunk.data (IOBuf), rows slice.rows
+///     for (const auto& chunkSlice : response.chunkSlices) {
+///       // `chunkSlice` is a self-describing kTabletRaw IOBuf chain with
+///       // the request's row range and (on the last slice of a truncated
+///       // response) the resume key embedded in the header.
 ///     }
 ///   }
 /// NOTE: NimbleIndexProjector is not thread-safe. Each thread must use its
@@ -98,37 +110,31 @@ class NimbleIndexProjector {
     std::vector<velox::serializer::EncodedKeyBounds> keyBounds;
   };
 
-  /// Serialized data for a contiguous row range.
-  struct Chunk {
-    /// kTabletRaw serialized data containing projected columns.
-    folly::IOBuf data;
-    /// Number of rows in this chunk.
-    uint32_t numRows{0};
-  };
-
-  /// Slice into a shared chunk for a specific request.
-  struct ChunkSlice {
-    /// Index into Result::chunks.
-    uint32_t chunkIndex{0};
-    /// Row range within the chunk.
-    RowRange rows;
-  };
-
   /// Response for a single request.
   struct Response {
-    /// Slices into Result::chunks for this request. Empty for miss.
-    std::vector<ChunkSlice> slices;
+    /// One self-describing kTabletRaw IOBuf chain per (request × stripe)
+    /// intersection. Each entry covers a contiguous row range within one
+    /// stripe; the row range is embedded in the chain's header. Empty for
+    /// miss. Chunk slices for overlapping requests share the body+trailer
+    /// bytes via refcounted SharedInfo on the second IOBuf node.
+    ///
+    /// If the response is truncated and has a resume key, it is embedded in
+    /// the header of the last slice. Use `rocks::readResultResumeKey()` on
+    /// the last slice to extract it.
+    std::vector<folly::IOBuf> chunkSlices;
 
     /// If the result was truncated by maxRows or maxBytes, the encoded resume
     /// key for continuation. The caller constructs new key bounds using this
     /// as lowerKey with their original upperKey. nullopt if complete or miss.
+    ///
+    /// Also embedded in the last slice's per-slice header (when chunkSlices
+    /// is non-empty) so consumers that hold an IOBuf can recover the key
+    /// without keeping the Response struct around.
     std::optional<std::string> resumeKey;
   };
 
   /// Result of a project() call.
   struct Result {
-    /// Serialized chunks (shared across requests that overlap).
-    std::vector<Chunk> chunks;
     /// One entry per request, in request order.
     std::vector<Response> responses;
   };
@@ -261,8 +267,7 @@ class NimbleIndexProjector {
   // stop and set resume keys.
   bool processStripe(
       uint32_t stripeIndex,
-      std::span<const StripeRowRange> stripeRowRanges,
-      Result& result);
+      std::span<const StripeRowRange> stripeRowRanges);
 
   using InputStreams =
       std::vector<std::unique_ptr<velox::dwio::common::SeekableInputStream>>;
@@ -270,19 +275,38 @@ class NimbleIndexProjector {
   // Enqueues projected streams into StripeStreams and loads them from disk.
   InputStreams loadStripe();
 
-  // Stitches loaded raw stream bytes into a single kTabletRaw chunk
-  // (header + data + trailer) without decode/re-encode.
-  Chunk serializeStripe(uint32_t stripeIndex, InputStreams& inputStreams);
+  // Per-slice info needed at finalization time to build the chunk slice
+  // IOBuf chain (header node + shared body+trailer clone).
+  //
+  // Reused as the producer-side container returned by serializeStripe(): the
+  // shared body+trailer bytes are produced once per stripe and referenced by
+  // every per-request chunk slice for that stripe via cloneOne(). On that
+  // producer side, rowRange is default-constructed and unused;
+  // buildStripeResult fills it in when materializing each per-request clone.
+  //
+  // Layout of sharedData:
+  //   [stream_data...][encodingType][stream_sizes][trailer_size:u32].
+  struct ResultChunk {
+    folly::IOBuf sharedData;
+    uint32_t numStripeRows{0};
+    RowRange rowRange;
+  };
 
-  // Assigns the serialized chunk to per-request results based on row ranges.
-  // Applies maxRowsPerRequest hard clipping and accumulates numReadRows_.
-  // Returns false if a global limit (maxRows or maxBytes) was hit after this
-  // stripe.
+  // Stitches loaded raw stream bytes into the shared kTabletRaw body+trailer
+  // (stream data + trailer) without decode/re-encode. The returned chunk has
+  // a default-constructed rowRange that buildStripeResult fills in per request.
+  ResultChunk serializeStripe(uint32_t stripeIndex, InputStreams& inputStreams);
+
+  // Queues per-request result chunks for the stripe. Each chunk captures a
+  // cloneOne() of the shared body+trailer, the stripe row count, and the
+  // per-request row range. The chunk slice IOBuf chain is finalized later by
+  // finalizeResultChunks() once we know whether the response carries a
+  // resume key. Applies maxRowsPerRequest hard clipping and accumulates
+  // numReadRows_. Returns false if a global limit (maxRows or maxBytes) was
+  // hit after this stripe.
   bool buildStripeResult(
-      uint32_t stripeIndex,
       std::span<const StripeRowRange> stripeRowRanges,
-      Chunk&& chunk,
-      Result& result);
+      ResultChunk&& stripeChunk);
 
   // Sets resume keys on all truncated requests that have data in the next
   // unprocessed stripe.
@@ -290,6 +314,12 @@ class NimbleIndexProjector {
       uint32_t stripeIndex,
       std::span<const StripeRowRange> stripeRowRanges,
       Result& result);
+
+  // Materializes the per-slice header node for every queued chunk and
+  // assembles the final chunk slice IOBuf chain (header -> body+trailer).
+  // The resume key is folded into the header of the last slice of any
+  // truncated response.
+  void finalizeResultChunks(Result& result);
 
   inline uint32_t stripeRowCount(uint32_t stripe) const {
     return static_cast<uint32_t>(readerBase_->tablet().stripeRowCount(stripe));
@@ -341,6 +371,9 @@ class NimbleIndexProjector {
   uint64_t numReadBytes_{0};
   // Accumulated rows per request for maxRowsPerRequest enforcement.
   std::vector<uint64_t> rowsPerRequest_;
+
+  // Per-response, per-slice chunks awaiting finalization.
+  std::vector<std::vector<ResultChunk>> resultChunks_;
   // Current stripe's row ranges after pruning saturated requests.
   std::vector<StripeRowRange> stripeRowRanges_;
   // CSR mapping from stripes to request row ranges. Populated by

--- a/dwio/nimble/velox/index/tests/CMakeLists.txt
+++ b/dwio/nimble/velox/index/tests/CMakeLists.txt
@@ -18,6 +18,9 @@ target_link_libraries(
   nimble_index_projector_test
   nimble_index_projector
   nimble_deserializer
+  nimble_deserializer_impl
+  nimble_serializer
+  nimble_serializer_impl
   nimble_velox_common
   nimble_velox_writer
   nimble_velox_selective

--- a/dwio/nimble/velox/index/tests/NimbleIndexProjectorTest.cpp
+++ b/dwio/nimble/velox/index/tests/NimbleIndexProjectorTest.cpp
@@ -21,6 +21,9 @@
 #include "dwio/nimble/common/tests/GTestUtils.h"
 #include "dwio/nimble/common/tests/TestUtils.h"
 #include "dwio/nimble/serializer/Deserializer.h"
+#include "dwio/nimble/serializer/DeserializerImpl.h"
+#include "dwio/nimble/serializer/Serializer.h"
+#include "dwio/nimble/serializer/SerializerImpl.h"
 #include "dwio/nimble/tablet/TabletReader.h"
 #include "dwio/nimble/tablet/tests/TabletTestUtils.h"
 #include "dwio/nimble/velox/SchemaUtils.h"
@@ -39,6 +42,38 @@ namespace facebook::nimble::test {
 using namespace velox;
 using namespace velox::dwio::common;
 using Subfield = velox::common::Subfield;
+
+namespace {
+
+// Test-local mirrors of `rocks::readResultRowRange` and
+// `rocks::readResultResumeKey`.
+// The dwio/nimble layer cannot depend on rocks/nimble (the dependency runs
+// the other way — rocks/nimble's NimbleTable depends on the projector), so
+// these tests cannot include `rocks/nimble/NimbleTable.h`. Both helpers call
+// the same underlying `serde::readTabletChunkHeader` as the production rocks::
+// helpers, so behavior is in lockstep.
+RowRange readEmbeddedRowRange(const folly::IOBuf& chunkSlice) {
+  const char* pos = reinterpret_cast<const char*>(chunkSlice.data());
+  const char* end = pos + chunkSlice.length();
+  return serde::readTabletChunkHeader(pos, end).rowRange;
+}
+
+std::optional<std::string> readEmbeddedResumeKey(
+    const folly::IOBuf& chunkSlice) {
+  const char* pos = reinterpret_cast<const char*>(chunkSlice.data());
+  const char* end = pos + chunkSlice.length();
+  return serde::readTabletChunkHeader(pos, end).resumeKey;
+}
+
+// Coalesces the chunk slice IOBuf chain into a single contiguous buffer for
+// passing to Deserializer. The Deserializer reads the per-slice header
+// natively (consuming the row range and resume-key fields) but does not
+// slice its output — it over-fetches by decoding the full stripe.
+folly::IOBuf coalesceChunkSlice(const folly::IOBuf& chunkSlice) {
+  return chunkSlice.cloneCoalescedAsValue();
+}
+
+} // namespace
 
 struct TestParam {
   bool enableCache;
@@ -292,15 +327,16 @@ TEST_P(NimbleIndexProjectorTest, basicColumnProjection) {
 
   ASSERT_EQ(result.responses.size(), 1);
   const auto& response = result.responses[0];
-  ASSERT_FALSE(response.slices.empty());
+  ASSERT_FALSE(response.chunkSlices.empty());
   EXPECT_FALSE(response.resumeKey.has_value());
 
-  const auto& slice = response.slices[0];
-  const auto& chunk = result.chunks[slice.chunkIndex];
-  ASSERT_GT(chunk.numRows, 0);
+  const auto& chunkSlice = response.chunkSlices[0];
+  const auto rowRange = readEmbeddedRowRange(chunkSlice);
+  ASSERT_GT(rowRange.numRows(), 0);
 
-  // Clone and coalesce chained IOBuf for deserialization.
-  auto coalesced = chunk.data.cloneCoalescedAsValue();
+  // Coalesce the chunk slice IOBuf chain into a contiguous buffer that the
+  // Deserializer can read end-to-end.
+  auto coalesced = coalesceChunkSlice(chunkSlice);
 
   // Deserialize using nimble Deserializer with nimble schema.
   auto projectedVeloxType = ROW({"col_a", "col_b"}, {INTEGER(), VARCHAR()});
@@ -319,11 +355,13 @@ TEST_P(NimbleIndexProjectorTest, basicColumnProjection) {
 
   auto* rowResult = deserialized->as<RowVector>();
   ASSERT_NE(rowResult, nullptr);
-  ASSERT_LT(slice.rows.startRow, rowResult->size());
+  // Over-fetch: Deserializer returns the full stripe; the requested row
+  // sits at position rowRange.startRow within the output.
+  ASSERT_GE(rowResult->size(), rowRange.endRow);
   auto* colAResult = rowResult->childAt(0)->as<FlatVector<int32_t>>();
   ASSERT_NE(colAResult, nullptr);
   // key=50 -> colA=500
-  EXPECT_EQ(colAResult->valueAt(slice.rows.startRow), 500);
+  EXPECT_EQ(colAResult->valueAt(rowRange.startRow), 500);
 }
 
 TEST_P(NimbleIndexProjectorTest, emptyResult) {
@@ -356,9 +394,8 @@ TEST_P(NimbleIndexProjectorTest, emptyResult) {
   auto result = projector->project(request, {});
 
   ASSERT_EQ(result.responses.size(), 1);
-  EXPECT_TRUE(result.responses[0].slices.empty());
+  EXPECT_TRUE(result.responses[0].chunkSlices.empty());
   EXPECT_FALSE(result.responses[0].resumeKey.has_value());
-  EXPECT_TRUE(result.chunks.empty());
 
   // All stats should be zero for a miss.
   EXPECT_EQ(projector->stats().numReadStripes, 0);
@@ -402,15 +439,394 @@ TEST_P(NimbleIndexProjectorTest, multipleRequests) {
 
   ASSERT_EQ(result.responses.size(), 3);
   uint64_t totalBytes = 0;
-  for (const auto& chunk : result.chunks) {
-    totalBytes += chunk.data.length();
+  for (const auto& response : result.responses) {
+    for (const auto& chunkSlice : response.chunkSlices) {
+      totalBytes += chunkSlice.computeChainDataLength();
+    }
   }
   EXPECT_GT(totalBytes, 0);
 
   // All requests should have results (no misses).
   for (const auto& response : result.responses) {
-    EXPECT_FALSE(response.slices.empty());
+    EXPECT_FALSE(response.chunkSlices.empty());
     EXPECT_FALSE(response.resumeKey.has_value());
+  }
+}
+
+TEST_P(NimbleIndexProjectorTest, overlappingRequestsShareBody) {
+  // Two range scans that hit the same single stripe with different row ranges.
+  // Verify that the per-request kTabletRaw chunk slices share the body+trailer
+  // IOBuf bytes via cloneOne() and carry distinct per-slice header nodes.
+  auto rowType = ROW({"key", "value"}, {BIGINT(), INTEGER()});
+
+  const int numRows = 100;
+  std::vector<int64_t> keys(numRows);
+  std::vector<int32_t> values(numRows);
+  for (int i = 0; i < numRows; ++i) {
+    keys[i] = i;
+    values[i] = i * 10;
+  }
+  auto batch = vectorMaker_->rowVector(
+      {"key", "value"},
+      {vectorMaker_->flatVector<int64_t>(keys),
+       vectorMaker_->flatVector<int32_t>(values)});
+
+  // Single stripe with all 100 rows (default 4KB stripe size easily fits).
+  writeData({batch}, {"key"});
+
+  std::vector<Subfield> subfields;
+  subfields.emplace_back("value");
+  auto projector = createProjector(subfields);
+
+  // Two overlapping range scans into the same stripe.
+  auto bounds0 = makeRangeLookup(rowType, {"key"}, 10, 40); // 30 rows
+  auto bounds1 = makeRangeLookup(rowType, {"key"}, 25, 70); // 45 rows
+
+  NimbleIndexProjector::Request request;
+  request.keyBounds = {bounds0, bounds1};
+  auto result = projector->project(request, {});
+
+  ASSERT_EQ(result.responses.size(), 2);
+  ASSERT_EQ(result.responses[0].chunkSlices.size(), 1);
+  ASSERT_EQ(result.responses[1].chunkSlices.size(), 1);
+
+  const auto& chunkSlice0 = result.responses[0].chunkSlices[0];
+  const auto& chunkSlice1 = result.responses[1].chunkSlices[0];
+
+  // Each chunk slice is a 2-node chain: per-slice header + shared body+trailer.
+  ASSERT_TRUE(chunkSlice0.isChained());
+  ASSERT_TRUE(chunkSlice1.isChained());
+
+  // Header nodes (first node in each chunk slice) must be DISTINCT
+  // allocations since they carry per-request row range bytes.
+  EXPECT_NE(chunkSlice0.data(), chunkSlice1.data());
+
+  // Body nodes (second node in each chunk slice) must point to the same
+  // underlying memory because they are cloneOne() copies of the shared
+  // per-stripe body+trailer.
+  EXPECT_EQ(chunkSlice0.prev()->data(), chunkSlice1.prev()->data());
+  EXPECT_EQ(chunkSlice0.prev()->length(), chunkSlice1.prev()->length());
+
+  // Embedded row ranges match the (stripe-relative) request ranges.
+  const auto range0 = readEmbeddedRowRange(chunkSlice0);
+  const auto range1 = readEmbeddedRowRange(chunkSlice1);
+  EXPECT_EQ(range0, RowRange(10, 40));
+  EXPECT_EQ(range1, RowRange(25, 70));
+
+  // Neither response is truncated, so neither slice carries a resume key.
+  EXPECT_FALSE(readEmbeddedResumeKey(chunkSlice0).has_value());
+  EXPECT_FALSE(readEmbeddedResumeKey(chunkSlice1).has_value());
+
+  // The shared body dominates each chunk slice size — assert that
+  // computeChainDataLength reflects header + body and that the body is
+  // refcount-shared.
+  EXPECT_GT(chunkSlice0.computeChainDataLength(), chunkSlice0.length());
+  EXPECT_GT(chunkSlice0.prev()->length(), 0u);
+}
+
+// Round-trips a single-batch deserialize over a key range. The Deserializer
+// over-fetches (decodes the full stripe rather than slicing to the row
+// range), so output->size() is the stripe rowCount and we verify the
+// in-range subset has the correct values. Used by the four positional range
+// tests below (start / middle / end / full).
+//
+// Defined as a macro (rather than a function) so it can access the protected
+// fixture members from inside the TEST_P body.
+#define RUN_DESERIALIZER_RANGE_TEST(lowerKey_, upperKey_)                      \
+  do {                                                                         \
+    auto rowType = ROW({"key", "value"}, {BIGINT(), INTEGER()});               \
+    const int numRows = 100;                                                   \
+    std::vector<int64_t> keys(numRows);                                        \
+    std::vector<int32_t> values(numRows);                                      \
+    for (int i = 0; i < numRows; ++i) {                                        \
+      keys[i] = i;                                                             \
+      values[i] = i * 10;                                                      \
+    }                                                                          \
+    auto batch = vectorMaker_->rowVector(                                      \
+        {"key", "value"},                                                      \
+        {vectorMaker_->flatVector<int64_t>(keys),                              \
+         vectorMaker_->flatVector<int32_t>(values)});                          \
+    writeData({batch}, {"key"});                                               \
+    std::vector<Subfield> subfields;                                           \
+    subfields.emplace_back("value");                                           \
+    auto projector = createProjector(subfields);                               \
+    auto bounds = makeRangeLookup(rowType, {"key"}, (lowerKey_), (upperKey_)); \
+    NimbleIndexProjector::Request request;                                     \
+    request.keyBounds = {bounds};                                              \
+    auto result = projector->project(request, {});                             \
+    ASSERT_EQ(result.responses[0].chunkSlices.size(), 1);                      \
+    auto coalesced =                                                           \
+        result.responses[0].chunkSlices[0].cloneCoalescedAsValue();            \
+    auto bytes = std::string_view(                                             \
+        reinterpret_cast<const char*>(coalesced.data()), coalesced.length());  \
+    DeserializerOptions deserOptions;                                          \
+    deserOptions.hasHeader = true;                                             \
+    Deserializer deserializer(                                                 \
+        projector->projectedNimbleType(), leafPool_.get(), deserOptions);      \
+    std::vector<std::string_view> singleBatch{bytes};                          \
+    VectorPtr output;                                                          \
+    deserializer.deserialize(singleBatch, output);                             \
+    ASSERT_EQ(output->size(), static_cast<uint32_t>(numRows));                 \
+    auto* rowVec = output->as<velox::RowVector>();                             \
+    auto* valueVec = rowVec->childAt(0)->as<velox::FlatVector<int32_t>>();     \
+    /* Verify the in-range subset has expected values. */                      \
+    for (uint32_t i = static_cast<uint32_t>(lowerKey_);                        \
+         i < static_cast<uint32_t>(upperKey_);                                 \
+         ++i) {                                                                \
+      EXPECT_EQ(valueVec->valueAt(i), static_cast<int32_t>(i * 10))            \
+          << "i=" << i;                                                        \
+    }                                                                          \
+  } while (0)
+
+TEST_P(NimbleIndexProjectorTest, deserializerRangeAtStart) {
+  // Range covers the first 30 rows of a 100-row stripe: [0, 30).
+  RUN_DESERIALIZER_RANGE_TEST(0, 30);
+}
+
+TEST_P(NimbleIndexProjectorTest, deserializerRangeInMiddle) {
+  // Range covers a 30-row window strictly inside the stripe: [30, 60).
+  RUN_DESERIALIZER_RANGE_TEST(30, 60);
+}
+
+TEST_P(NimbleIndexProjectorTest, deserializerRangeAtEnd) {
+  // Range covers the last 30 rows of a 100-row stripe: [70, 100).
+  RUN_DESERIALIZER_RANGE_TEST(70, 100);
+}
+
+TEST_P(NimbleIndexProjectorTest, deserializerRangeFullStripe) {
+  // Range spans the entire stripe: [0, 100). Validates round-trip on a
+  // full-stripe row range (boundary case where the in-range subset equals
+  // the over-fetched stripe).
+  RUN_DESERIALIZER_RANGE_TEST(0, 100);
+}
+
+#undef RUN_DESERIALIZER_RANGE_TEST
+
+TEST_P(NimbleIndexProjectorTest, deserializerMultiBatchWithRowRange) {
+  // Each input batch's embedded row range is applied per-segment by the
+  // Deserializer; the output is the concatenation of each batch's in-range
+  // rows. Same chunk slice passed twice yields 2 × range.numRows() output
+  // rows, with values[10..39] repeated.
+  auto rowType = ROW({"key", "value"}, {BIGINT(), INTEGER()});
+
+  const int numRows = 100;
+  std::vector<int64_t> keys(numRows);
+  std::vector<int32_t> values(numRows);
+  for (int i = 0; i < numRows; ++i) {
+    keys[i] = i;
+    values[i] = i * 10;
+  }
+  auto batch = vectorMaker_->rowVector(
+      {"key", "value"},
+      {vectorMaker_->flatVector<int64_t>(keys),
+       vectorMaker_->flatVector<int32_t>(values)});
+  writeData({batch}, {"key"});
+
+  std::vector<Subfield> subfields;
+  subfields.emplace_back("value");
+  auto projector = createProjector(subfields);
+
+  auto bounds = makeRangeLookup(rowType, {"key"}, 10, 40);
+  NimbleIndexProjector::Request request;
+  request.keyBounds = {bounds};
+  auto result = projector->project(request, {});
+  ASSERT_EQ(result.responses[0].chunkSlices.size(), 1);
+
+  auto coalesced = result.responses[0].chunkSlices[0].cloneCoalescedAsValue();
+  auto bytes = std::string_view(
+      reinterpret_cast<const char*>(coalesced.data()), coalesced.length());
+
+  DeserializerOptions deserOptions;
+  deserOptions.hasHeader = true;
+  Deserializer deserializer(
+      projector->projectedNimbleType(), leafPool_.get(), deserOptions);
+
+  std::vector<std::string_view> multiBatch{bytes, bytes};
+  VectorPtr output;
+  deserializer.deserialize(multiBatch, output);
+
+  // Over-fetch: each batch decodes its full 100 stripe rows; concatenation
+  // gives 200 rows. The in-range subset (positions [10, 40) within each
+  // batch) carries values[10..39].
+  ASSERT_EQ(output->size(), 200u);
+  auto* rowVec = output->as<velox::RowVector>();
+  auto* valueVec = rowVec->childAt(0)->as<velox::FlatVector<int32_t>>();
+  for (uint32_t i = 10; i < 40; ++i) {
+    EXPECT_EQ(valueVec->valueAt(i), static_cast<int32_t>(i * 10))
+        << "batch=0 i=" << i;
+    EXPECT_EQ(valueVec->valueAt(100 + i), static_cast<int32_t>(i * 10))
+        << "batch=1 i=" << i;
+  }
+}
+
+TEST_P(NimbleIndexProjectorTest, deserializerMultiBatchMixedRanges) {
+  // Multi-batch deserialize where each batch carries a different positional
+  // row range: start [0, 20), middle [30, 50), end [80, 100), and full
+  // [0, 100). Output is the concatenation of in-range rows from each batch,
+  // preserving order.
+  auto rowType = ROW({"key", "value"}, {BIGINT(), INTEGER()});
+
+  const int numRows = 100;
+  std::vector<int64_t> keys(numRows);
+  std::vector<int32_t> values(numRows);
+  for (int i = 0; i < numRows; ++i) {
+    keys[i] = i;
+    values[i] = i * 10;
+  }
+  auto batch = vectorMaker_->rowVector(
+      {"key", "value"},
+      {vectorMaker_->flatVector<int64_t>(keys),
+       vectorMaker_->flatVector<int32_t>(values)});
+  writeData({batch}, {"key"});
+
+  std::vector<Subfield> subfields;
+  subfields.emplace_back("value");
+  auto projector = createProjector(subfields);
+
+  // One projector call with four independent range requests; each produces
+  // its own chunk slice (one per request × stripe intersection).
+  NimbleIndexProjector::Request request;
+  request.keyBounds = {
+      makeRangeLookup(rowType, {"key"}, 0, 20),
+      makeRangeLookup(rowType, {"key"}, 30, 50),
+      makeRangeLookup(rowType, {"key"}, 80, 100),
+      makeRangeLookup(rowType, {"key"}, 0, 100),
+  };
+  auto result = projector->project(request, {});
+  ASSERT_EQ(result.responses.size(), 4);
+
+  // Coalesce each response's chunk slice into a contiguous buffer the
+  // deserializer can read from. The owned IOBufs must outlive the
+  // string_views below — keep them in a parallel vector.
+  std::vector<folly::IOBuf> ownedSlices;
+  ownedSlices.reserve(4);
+  std::vector<std::string_view> batches;
+  batches.reserve(4);
+  for (auto& response : result.responses) {
+    ASSERT_EQ(response.chunkSlices.size(), 1u);
+    ownedSlices.push_back(response.chunkSlices[0].cloneCoalescedAsValue());
+    batches.emplace_back(
+        reinterpret_cast<const char*>(ownedSlices.back().data()),
+        ownedSlices.back().length());
+  }
+
+  DeserializerOptions deserOptions;
+  deserOptions.hasHeader = true;
+  Deserializer deserializer(
+      projector->projectedNimbleType(), leafPool_.get(), deserOptions);
+  VectorPtr output;
+  deserializer.deserialize(batches, output);
+
+  // Over-fetch: each batch decodes its full 100 stripe rows; concatenation
+  // gives 400 rows = 4 × 100. Verify each batch's in-range subset has the
+  // expected values at its position within the cumulative output.
+  ASSERT_EQ(output->size(), 400u);
+  auto* rowVec = output->as<velox::RowVector>();
+  auto* valueVec = rowVec->childAt(0)->as<velox::FlatVector<int32_t>>();
+  // Batch 0: range [0, 20), batch starts at output offset 0.
+  for (uint32_t i = 0; i < 20; ++i) {
+    EXPECT_EQ(valueVec->valueAt(i), static_cast<int32_t>(i * 10))
+        << "batch=0 i=" << i;
+  }
+  // Batch 1: range [30, 50), batch starts at output offset 100.
+  for (uint32_t i = 30; i < 50; ++i) {
+    EXPECT_EQ(valueVec->valueAt(100 + i), static_cast<int32_t>(i * 10))
+        << "batch=1 i=" << i;
+  }
+  // Batch 2: range [80, 100), batch starts at output offset 200.
+  for (uint32_t i = 80; i < 100; ++i) {
+    EXPECT_EQ(valueVec->valueAt(200 + i), static_cast<int32_t>(i * 10))
+        << "batch=2 i=" << i;
+  }
+  // Batch 3: range [0, 100) (full), batch starts at output offset 300.
+  for (uint32_t i = 0; i < 100; ++i) {
+    EXPECT_EQ(valueVec->valueAt(300 + i), static_cast<int32_t>(i * 10))
+        << "batch=3 i=" << i;
+  }
+}
+
+TEST_P(NimbleIndexProjectorTest, deserializerMultiBatchMixedVersions) {
+  // Mix a kTabletRaw chunk slice (projector output, narrow row range) with
+  // a kCompact chunk (Serializer output, no row range) in one deserialize
+  // call. Verifies the no-range branch of the per-batch loop: when
+  // batchRanges[i] is nullopt, numRowsInBatch falls back to batchRows
+  // (the full kCompact batch).
+  auto rowType = ROW({"key", "value"}, {BIGINT(), INTEGER()});
+
+  const int numRows = 100;
+  std::vector<int64_t> keys(numRows);
+  std::vector<int32_t> values(numRows);
+  for (int i = 0; i < numRows; ++i) {
+    keys[i] = i;
+    values[i] = i * 10;
+  }
+  auto batch = vectorMaker_->rowVector(
+      {"key", "value"},
+      {vectorMaker_->flatVector<int64_t>(keys),
+       vectorMaker_->flatVector<int32_t>(values)});
+  writeData({batch}, {"key"});
+
+  std::vector<Subfield> subfields;
+  subfields.emplace_back("value");
+  auto projector = createProjector(subfields);
+
+  // kTabletRaw batch: range [10, 40) = 30 rows.
+  auto bounds = makeRangeLookup(rowType, {"key"}, 10, 40);
+  NimbleIndexProjector::Request request;
+  request.keyBounds = {bounds};
+  auto result = projector->project(request, {});
+  ASSERT_EQ(result.responses[0].chunkSlices.size(), 1u);
+  auto tabletRawOwned =
+      result.responses[0].chunkSlices[0].cloneCoalescedAsValue();
+
+  // kCompact batch: serialize a 5-row Row<INTEGER> vector matching the
+  // projected schema. The Serializer is constructed against the same velox
+  // type the Deserializer will use, so the streams encode in lockstep.
+  auto projectedVeloxType =
+      convertToVeloxType(*projector->projectedNimbleType());
+  std::vector<int32_t> kCompactValues = {1000, 2000, 3000, 4000, 5000};
+  auto kCompactRow = vectorMaker_->rowVector(
+      {"value"}, {vectorMaker_->flatVector<int32_t>(kCompactValues)});
+  SerializerOptions serOptions{
+      .version = SerializationVersion::kCompact,
+  };
+  Serializer ser{
+      serOptions,
+      projectedVeloxType,
+      leafPool_.get(),
+  };
+  auto kCompactBytes = ser.serialize(
+      kCompactRow,
+      OrderedRanges::of(0, static_cast<uint32_t>(kCompactValues.size())));
+
+  DeserializerOptions deserOptions;
+  deserOptions.hasHeader = true;
+  Deserializer deserializer(
+      projector->projectedNimbleType(), leafPool_.get(), deserOptions);
+
+  std::vector<std::string_view> batches{
+      std::string_view(
+          reinterpret_cast<const char*>(tabletRawOwned.data()),
+          tabletRawOwned.length()),
+      kCompactBytes,
+  };
+  VectorPtr output;
+  deserializer.deserialize(batches, output);
+
+  // Over-fetch: kTabletRaw batch decodes its full 100 stripe rows; kCompact
+  // batch contributes 5 rows. Concatenation = 105 rows. The in-range
+  // subset of the kTabletRaw batch (positions [10, 40) within the first
+  // 100) carries values[10..39]; the kCompact batch's 5 rows follow.
+  ASSERT_EQ(output->size(), 105u);
+  auto* rowVec = output->as<velox::RowVector>();
+  auto* valueVec = rowVec->childAt(0)->as<velox::FlatVector<int32_t>>();
+  for (uint32_t i = 10; i < 40; ++i) {
+    EXPECT_EQ(valueVec->valueAt(i), static_cast<int32_t>(i * 10))
+        << "kTabletRaw i=" << i;
+  }
+  for (uint32_t i = 0; i < 5; ++i) {
+    EXPECT_EQ(valueVec->valueAt(100 + i), kCompactValues[i])
+        << "kCompact i=" << i;
   }
 }
 
@@ -581,15 +997,15 @@ TEST_P(NimbleIndexProjectorTest, flatMapProjection) {
 
   ASSERT_EQ(result.responses.size(), 1);
   const auto& response = result.responses[0];
-  ASSERT_FALSE(response.slices.empty());
+  ASSERT_FALSE(response.chunkSlices.empty());
 
-  const auto& slice = response.slices[0];
-  const auto& chunk = result.chunks[slice.chunkIndex];
-  ASSERT_GT(chunk.numRows, 0);
+  const auto& chunkSlice = response.chunkSlices[0];
+  const auto rowRange = readEmbeddedRowRange(chunkSlice);
+  ASSERT_GT(rowRange.numRows(), 0);
 
   // Deserialize using the projector's projected nimble type which accounts
   // for FlatMap key sorting (keys sorted alphabetically: "b", "d", "e").
-  auto coalesced = chunk.data.cloneCoalescedAsValue();
+  auto coalesced = coalesceChunkSlice(chunkSlice);
   DeserializerOptions deserOptions;
   deserOptions.hasHeader = true;
   Deserializer deserializer(
@@ -607,12 +1023,14 @@ TEST_P(NimbleIndexProjectorTest, flatMapProjection) {
   ASSERT_EQ(rowResult->childrenSize(), 1);
 
   // FlatMap is deserialized as a MapVector. Extract keys and values at the
-  // target row to verify correctness.
+  // target row to verify correctness. The Deserializer over-fetches (decodes
+  // the full stripe rather than slicing), so the requested row sits at
+  // position rowRange.startRow within the output.
   auto* mapResult = rowResult->childAt(0)->as<MapVector>();
   ASSERT_NE(mapResult, nullptr);
+  ASSERT_GE(mapResult->size(), rowRange.endRow);
 
-  const auto targetRow = slice.rows.startRow;
-  ASSERT_LT(targetRow, mapResult->size());
+  const vector_size_t targetRow = rowRange.startRow;
 
   auto* mapKeyResults = mapResult->mapKeys()->as<FlatVector<StringView>>();
   auto* mapValues = mapResult->mapValues()->as<FlatVector<int64_t>>();
@@ -635,6 +1053,98 @@ TEST_P(NimbleIndexProjectorTest, flatMapProjection) {
   EXPECT_EQ(kvPairs["b"], 501); // 5*100 + 1
   EXPECT_EQ(kvPairs["d"], 503); // 5*100 + 3
   EXPECT_EQ(kvPairs["e"], 504); // 5*100 + 4
+}
+
+TEST_P(NimbleIndexProjectorTest, flatMapProjectionWithNarrowRowRange) {
+  // Schema: key (int64, sorted), features (MAP<VARCHAR, BIGINT> as FlatMap).
+  // Range scan over keys [50, 100) — 5 rows starting at row index 5 (since
+  // keys are row*10). The Deserializer over-fetches and returns the full
+  // 200-row stripe; we verify the in-range subset at positions [5, 10).
+  auto rowType = ROW({"key", "features"}, {BIGINT(), MAP(VARCHAR(), BIGINT())});
+
+  const int numRows = 200;
+  const std::vector<std::string> mapKeys = {"a", "b", "c"};
+  const auto numMapKeys = static_cast<vector_size_t>(mapKeys.size());
+
+  std::vector<StringView> mapKeyViews;
+  mapKeyViews.reserve(mapKeys.size());
+  for (const auto& k : mapKeys) {
+    mapKeyViews.emplace_back(k);
+  }
+
+  auto batch = vectorMaker_->rowVector(
+      {"key", "features"},
+      {vectorMaker_->flatVector<int64_t>(
+           numRows, [](auto row) { return row * 10; }),
+       vectorMaker_->mapVector<StringView, int64_t>(
+           numRows,
+           /*sizeAt*/ [&](auto /*row*/) { return numMapKeys; },
+           /*keyAt*/
+           [&](auto /*row*/, auto mapIndex) { return mapKeyViews[mapIndex]; },
+           /*valueAt*/
+           [](auto row, auto mapIndex) {
+             return static_cast<int64_t>(row * 100 + mapIndex);
+           })});
+
+  writeData({batch}, {"key"}, {{"features", {}}});
+
+  std::vector<Subfield> subfields;
+  subfields.emplace_back("features[\"a\"]");
+  subfields.emplace_back("features[\"c\"]");
+  auto projector = createProjector(subfields);
+
+  // Range [50, 100) → rows 5..9 (5 rows).
+  auto bounds = makeRangeLookup(rowType, {"key"}, 50, 100);
+  NimbleIndexProjector::Request request;
+  request.keyBounds = {bounds};
+  auto result = projector->project(request, {});
+  ASSERT_EQ(result.responses.size(), 1);
+  ASSERT_EQ(result.responses[0].chunkSlices.size(), 1u);
+
+  const auto& chunkSlice = result.responses[0].chunkSlices[0];
+  const auto rowRange = readEmbeddedRowRange(chunkSlice);
+  ASSERT_EQ(rowRange.numRows(), 5u);
+
+  auto coalesced = coalesceChunkSlice(chunkSlice);
+  DeserializerOptions deserOptions;
+  deserOptions.hasHeader = true;
+  Deserializer deserializer(
+      projector->projectedNimbleType(), leafPool_.get(), deserOptions);
+
+  VectorPtr deserialized;
+  deserializer.deserialize(
+      std::string_view(
+          reinterpret_cast<const char*>(coalesced.data()), coalesced.length()),
+      deserialized);
+  ASSERT_NE(deserialized, nullptr);
+  // Over-fetch: full stripe is decoded.
+  ASSERT_EQ(deserialized->size(), 200u);
+
+  auto* rowResult = deserialized->as<RowVector>();
+  ASSERT_NE(rowResult, nullptr);
+  auto* mapResult = rowResult->childAt(0)->as<MapVector>();
+  ASSERT_NE(mapResult, nullptr);
+  ASSERT_EQ(mapResult->size(), 200u);
+
+  auto* mapKeyResults = mapResult->mapKeys()->as<FlatVector<StringView>>();
+  auto* mapValues = mapResult->mapValues()->as<FlatVector<int64_t>>();
+  ASSERT_NE(mapKeyResults, nullptr);
+  ASSERT_NE(mapValues, nullptr);
+
+  // Verify the in-range subset (rows 5..9): both projected FlatMap keys
+  // "a" (idx 0) and "c" (idx 2) are present with values row*100 + index.
+  for (vector_size_t row = 5; row < 10; ++row) {
+    const auto mapOffset = mapResult->offsetAt(row);
+    const auto mapSize = mapResult->sizeAt(row);
+    ASSERT_EQ(mapSize, 2) << "row=" << row;
+    std::map<std::string, int64_t> kv;
+    for (vector_size_t k = 0; k < mapSize; ++k) {
+      kv[std::string(mapKeyResults->valueAt(mapOffset + k))] =
+          mapValues->valueAt(mapOffset + k);
+    }
+    EXPECT_EQ(kv["a"], row * 100 + 0) << "row=" << row;
+    EXPECT_EQ(kv["c"], row * 100 + 2) << "row=" << row;
+  }
 }
 
 TEST_P(NimbleIndexProjectorTest, flatMapFullColumnProjection) {
@@ -732,11 +1242,10 @@ TEST_P(NimbleIndexProjectorTest, flatMapKeyProjectionSchemaComparison) {
   auto result = projector->project(request, {});
 
   ASSERT_EQ(result.responses.size(), 1);
-  ASSERT_FALSE(result.responses[0].slices.empty());
+  ASSERT_FALSE(result.responses[0].chunkSlices.empty());
 
-  const auto& slice = result.responses[0].slices[0];
-  const auto& chunk = result.chunks[slice.chunkIndex];
-  auto coalesced = chunk.data.cloneCoalescedAsValue();
+  const auto& chunkSlice = result.responses[0].chunkSlices[0];
+  auto coalesced = coalesceChunkSlice(chunkSlice);
   auto data = std::string_view(
       reinterpret_cast<const char*>(coalesced.data()), coalesced.length());
 
@@ -793,14 +1302,14 @@ TEST_P(NimbleIndexProjectorTest, flatMapIntKeyProjection) {
 
   ASSERT_EQ(result.responses.size(), 1);
   const auto& response = result.responses[0];
-  ASSERT_FALSE(response.slices.empty());
+  ASSERT_FALSE(response.chunkSlices.empty());
 
-  const auto& slice = response.slices[0];
-  const auto& chunk = result.chunks[slice.chunkIndex];
-  ASSERT_GT(chunk.numRows, 0);
+  const auto& chunkSlice = response.chunkSlices[0];
+  const auto rowRange = readEmbeddedRowRange(chunkSlice);
+  ASSERT_GT(rowRange.numRows(), 0);
 
   // Deserialize using the projector's projected nimble type.
-  auto coalesced = chunk.data.cloneCoalescedAsValue();
+  auto coalesced = coalesceChunkSlice(chunkSlice);
   DeserializerOptions deserOptions;
   deserOptions.hasHeader = true;
   Deserializer deserializer(
@@ -819,9 +1328,11 @@ TEST_P(NimbleIndexProjectorTest, flatMapIntKeyProjection) {
 
   auto* mapResult = rowResult->childAt(0)->as<MapVector>();
   ASSERT_NE(mapResult, nullptr);
+  // Over-fetch: full stripe is decoded.
+  ASSERT_GE(mapResult->size(), rowRange.endRow);
 
-  const auto targetRow = slice.rows.startRow;
-  ASSERT_LT(targetRow, mapResult->size());
+  // Target row sits at position rowRange.startRow within the output.
+  const vector_size_t targetRow = rowRange.startRow;
 
   auto* mapKeyResults = mapResult->mapKeys()->as<FlatVector<int32_t>>();
   auto* mapValues = mapResult->mapValues()->as<FlatVector<int64_t>>();
@@ -898,7 +1409,7 @@ TEST_P(NimbleIndexProjectorTest, flatMapMissingKeys) {
     request.keyBounds = {pointBounds};
     auto result = projector->project(request, {});
     ASSERT_EQ(result.responses.size(), 1);
-    ASSERT_FALSE(result.responses[0].slices.empty());
+    ASSERT_FALSE(result.responses[0].chunkSlices.empty());
   }
 
   // All requested keys missing — should fail.
@@ -1072,7 +1583,7 @@ TEST_P(NimbleIndexProjectorTest, featureReorderingStorageReads) {
     auto result = projector->project(request, {});
 
     ASSERT_EQ(result.responses.size(), 1);
-    ASSERT_FALSE(result.responses[0].slices.empty());
+    ASSERT_FALSE(result.responses[0].chunkSlices.empty());
 
     storageReads[param.debugString()] = projector->stats().numStorageReads;
   }
@@ -1198,18 +1709,30 @@ TEST_P(NimbleIndexProjectorTest, resumeKeyOnTruncation) {
 
   ASSERT_EQ(result.responses.size(), 1);
   const auto& response = result.responses[0];
-  ASSERT_FALSE(response.slices.empty());
+  ASSERT_FALSE(response.chunkSlices.empty());
 
   // Soft limit: first stripe (100 rows) included fully.
   uint64_t totalRows = 0;
-  for (const auto& slice : response.slices) {
-    totalRows += slice.rows.numRows();
+  for (const auto& chunkSlice : response.chunkSlices) {
+    totalRows += readEmbeddedRowRange(chunkSlice).numRows();
   }
   EXPECT_EQ(totalRows, 100);
 
   // Resume key must be set since the request spans more stripes.
   ASSERT_TRUE(response.resumeKey.has_value());
   EXPECT_FALSE(response.resumeKey->empty());
+
+  // The resume key is embedded only on the last slice; earlier slices carry
+  // an empty resume key marker.
+  const auto numSlices = response.chunkSlices.size();
+  for (size_t i = 0; i + 1 < numSlices; ++i) {
+    EXPECT_FALSE(readEmbeddedResumeKey(response.chunkSlices[i]).has_value())
+        << "non-last slice " << i << " unexpectedly carries a resume key";
+  }
+  const auto embeddedResumeKey =
+      readEmbeddedResumeKey(response.chunkSlices.back());
+  ASSERT_TRUE(embeddedResumeKey.has_value());
+  EXPECT_EQ(*embeddedResumeKey, *response.resumeKey);
 }
 
 TEST_P(NimbleIndexProjectorTest, resumeKeyNotSetWithoutTruncation) {
@@ -1277,8 +1800,8 @@ TEST_P(NimbleIndexProjectorTest, softLimitAtStripeBoundary) {
 
     ASSERT_EQ(result.responses.size(), 1);
     uint64_t totalRows = 0;
-    for (const auto& slice : result.responses[0].slices) {
-      totalRows += slice.rows.numRows();
+    for (const auto& chunkSlice : result.responses[0].chunkSlices) {
+      totalRows += readEmbeddedRowRange(chunkSlice).numRows();
     }
     EXPECT_EQ(totalRows, 100);
     EXPECT_TRUE(result.responses[0].resumeKey.has_value());
@@ -1296,8 +1819,8 @@ TEST_P(NimbleIndexProjectorTest, softLimitAtStripeBoundary) {
 
     ASSERT_EQ(result.responses.size(), 1);
     uint64_t totalRows = 0;
-    for (const auto& slice : result.responses[0].slices) {
-      totalRows += slice.rows.numRows();
+    for (const auto& chunkSlice : result.responses[0].chunkSlices) {
+      totalRows += readEmbeddedRowRange(chunkSlice).numRows();
     }
     EXPECT_EQ(totalRows, 100);
     EXPECT_TRUE(result.responses[0].resumeKey.has_value());
@@ -1316,8 +1839,8 @@ TEST_P(NimbleIndexProjectorTest, softLimitAtStripeBoundary) {
 
     ASSERT_EQ(result.responses.size(), 1);
     uint64_t totalRows = 0;
-    for (const auto& slice : result.responses[0].slices) {
-      totalRows += slice.rows.numRows();
+    for (const auto& chunkSlice : result.responses[0].chunkSlices) {
+      totalRows += readEmbeddedRowRange(chunkSlice).numRows();
     }
     EXPECT_EQ(totalRows, 200);
     EXPECT_TRUE(result.responses[0].resumeKey.has_value());
@@ -1355,8 +1878,8 @@ TEST_P(NimbleIndexProjectorTest, resumeKeyPagination) {
     const auto& response = result.responses[0];
 
     uint64_t pageRows = 0;
-    for (const auto& slice : response.slices) {
-      pageRows += slice.rows.numRows();
+    for (const auto& chunkSlice : response.chunkSlices) {
+      pageRows += readEmbeddedRowRange(chunkSlice).numRows();
     }
     EXPECT_GT(pageRows, 0) << "Page " << pageCount << " returned no rows";
     totalRowsRead += pageRows;
@@ -1404,8 +1927,8 @@ TEST_P(NimbleIndexProjectorTest, maxRowsTotalAcrossRequests) {
   {
     const auto& response = result.responses[0];
     uint64_t totalRows = 0;
-    for (const auto& slice : response.slices) {
-      totalRows += slice.rows.numRows();
+    for (const auto& chunkSlice : response.chunkSlices) {
+      totalRows += readEmbeddedRowRange(chunkSlice).numRows();
     }
     EXPECT_EQ(totalRows, 100);
     EXPECT_TRUE(response.resumeKey.has_value());
@@ -1414,7 +1937,7 @@ TEST_P(NimbleIndexProjectorTest, maxRowsTotalAcrossRequests) {
   // Request 1: stripe 9 was never processed, resume key = original lower key.
   {
     const auto& response = result.responses[1];
-    EXPECT_TRUE(response.slices.empty());
+    EXPECT_TRUE(response.chunkSlices.empty());
     ASSERT_TRUE(response.resumeKey.has_value());
     EXPECT_EQ(response.resumeKey.value(), bounds1.lowerKey);
   }
@@ -1446,14 +1969,14 @@ TEST_P(NimbleIndexProjectorTest, noResumeKeyWhenRequestFullySatisfied) {
   // Request 0: fully satisfied within stripe 0 — no resume key.
   {
     const auto& response = result.responses[0];
-    ASSERT_FALSE(response.slices.empty());
+    ASSERT_FALSE(response.chunkSlices.empty());
     EXPECT_FALSE(response.resumeKey.has_value());
   }
 
   // Request 1: spans beyond stripe 0, truncated — has resume key.
   {
     const auto& response = result.responses[1];
-    ASSERT_FALSE(response.slices.empty());
+    ASSERT_FALSE(response.chunkSlices.empty());
     EXPECT_TRUE(response.resumeKey.has_value());
   }
 }
@@ -1477,8 +2000,8 @@ TEST_P(NimbleIndexProjectorTest, maxRowsExceedsTotal) {
 
   ASSERT_EQ(result.responses.size(), 1);
   uint64_t totalRows = 0;
-  for (const auto& slice : result.responses[0].slices) {
-    totalRows += slice.rows.numRows();
+  for (const auto& chunkSlice : result.responses[0].chunkSlices) {
+    totalRows += readEmbeddedRowRange(chunkSlice).numRows();
   }
   EXPECT_EQ(totalRows, 300);
   EXPECT_FALSE(result.responses[0].resumeKey.has_value());
@@ -1501,8 +2024,8 @@ TEST_P(NimbleIndexProjectorTest, maxRowsZeroMeansUnlimited) {
 
   ASSERT_EQ(result.responses.size(), 1);
   uint64_t totalRows = 0;
-  for (const auto& slice : result.responses[0].slices) {
-    totalRows += slice.rows.numRows();
+  for (const auto& chunkSlice : result.responses[0].chunkSlices) {
+    totalRows += readEmbeddedRowRange(chunkSlice).numRows();
   }
   EXPECT_EQ(totalRows, 1000);
   EXPECT_FALSE(result.responses[0].resumeKey.has_value());
@@ -1527,8 +2050,8 @@ TEST_P(NimbleIndexProjectorTest, maxRowsSingleRowStripes) {
 
   ASSERT_EQ(result.responses.size(), 1);
   uint64_t totalRows = 0;
-  for (const auto& slice : result.responses[0].slices) {
-    totalRows += slice.rows.numRows();
+  for (const auto& chunkSlice : result.responses[0].chunkSlices) {
+    totalRows += readEmbeddedRowRange(chunkSlice).numRows();
   }
   EXPECT_EQ(totalRows, 3);
   EXPECT_TRUE(result.responses[0].resumeKey.has_value());
@@ -1570,9 +2093,9 @@ TEST_P(NimbleIndexProjectorTest, maxRowsPerRequestClipping) {
     const auto& response = result.responses[0];
     EXPECT_FALSE(response.resumeKey.has_value());
     EXPECT_EQ(projector->stats().numReadRows, 150);
-    ASSERT_EQ(response.slices.size(), 2);
-    EXPECT_EQ(response.slices[0].rows.numRows(), 100);
-    EXPECT_EQ(response.slices[1].rows.numRows(), 50);
+    ASSERT_EQ(response.chunkSlices.size(), 2);
+    EXPECT_EQ(readEmbeddedRowRange(response.chunkSlices[0]).numRows(), 100);
+    EXPECT_EQ(readEmbeddedRowRange(response.chunkSlices[1]).numRows(), 50);
   }
 }
 
@@ -1601,8 +2124,8 @@ TEST_P(NimbleIndexProjectorTest, maxRowsPerRequestIndependentPruning) {
   {
     const auto& response = result.responses[0];
     uint64_t totalRows = 0;
-    for (const auto& slice : response.slices) {
-      totalRows += slice.rows.numRows();
+    for (const auto& chunkSlice : response.chunkSlices) {
+      totalRows += readEmbeddedRowRange(chunkSlice).numRows();
     }
     EXPECT_EQ(totalRows, 100);
     EXPECT_FALSE(response.resumeKey.has_value());
@@ -1611,8 +2134,8 @@ TEST_P(NimbleIndexProjectorTest, maxRowsPerRequestIndependentPruning) {
   {
     const auto& response = result.responses[1];
     uint64_t totalRows = 0;
-    for (const auto& slice : response.slices) {
-      totalRows += slice.rows.numRows();
+    for (const auto& chunkSlice : response.chunkSlices) {
+      totalRows += readEmbeddedRowRange(chunkSlice).numRows();
     }
     EXPECT_EQ(totalRows, 100);
     EXPECT_FALSE(response.resumeKey.has_value());
@@ -1634,8 +2157,9 @@ TEST_P(NimbleIndexProjectorTest, maxBytesTruncation) {
     NimbleIndexProjector::Request request;
     request.keyBounds = {bounds};
     auto result = projector->project(request, {});
-    ASSERT_EQ(result.chunks.size(), 1);
-    bytesPerStripe = result.chunks[0].data.computeChainDataLength();
+    ASSERT_EQ(result.responses[0].chunkSlices.size(), 1);
+    bytesPerStripe =
+        result.responses[0].chunkSlices[0].computeChainDataLength();
     ASSERT_GT(bytesPerStripe, 0);
   }
 
@@ -1708,8 +2232,9 @@ TEST_P(NimbleIndexProjectorTest, maxBytesPagination) {
     NimbleIndexProjector::Request request;
     request.keyBounds = {bounds};
     auto result = projector->project(request, {});
-    ASSERT_EQ(result.chunks.size(), 1);
-    bytesPerStripe = result.chunks[0].data.computeChainDataLength();
+    ASSERT_EQ(result.responses[0].chunkSlices.size(), 1);
+    bytesPerStripe =
+        result.responses[0].chunkSlices[0].computeChainDataLength();
   }
 
   // Paginate through the full range using byte limits.
@@ -1767,8 +2292,9 @@ TEST_P(NimbleIndexProjectorTest, maxBytesAndMaxRowsInteraction) {
     NimbleIndexProjector::Request request;
     request.keyBounds = {bounds};
     auto result = projector->project(request, {});
-    ASSERT_EQ(result.chunks.size(), 1);
-    bytesPerStripe = result.chunks[0].data.computeChainDataLength();
+    ASSERT_EQ(result.responses[0].chunkSlices.size(), 1);
+    bytesPerStripe =
+        result.responses[0].chunkSlices[0].computeChainDataLength();
   }
 
   // Range [0, 500) = 5 stripes, 500 rows.
@@ -1895,14 +2421,14 @@ TEST_P(
     SCOPED_TRACE(fmt::format("request {}", i));
     const auto& response = result.responses[i];
     uint64_t totalRows = 0;
-    for (const auto& slice : response.slices) {
-      totalRows += slice.rows.numRows();
+    for (const auto& chunkSlice : response.chunkSlices) {
+      totalRows += readEmbeddedRowRange(chunkSlice).numRows();
     }
     EXPECT_EQ(totalRows, 150);
     EXPECT_FALSE(response.resumeKey.has_value());
-    ASSERT_EQ(response.slices.size(), 2);
-    EXPECT_EQ(response.slices[0].rows.numRows(), 100);
-    EXPECT_EQ(response.slices[1].rows.numRows(), 50);
+    ASSERT_EQ(response.chunkSlices.size(), 2);
+    EXPECT_EQ(readEmbeddedRowRange(response.chunkSlices[0]).numRows(), 100);
+    EXPECT_EQ(readEmbeddedRowRange(response.chunkSlices[1]).numRows(), 50);
   }
 }
 
@@ -1928,8 +2454,8 @@ TEST_P(NimbleIndexProjectorTest, maxRowsPerRequestSingleRow) {
   const auto& response = result.responses[0];
   EXPECT_FALSE(response.resumeKey.has_value());
   EXPECT_EQ(projector->stats().numReadRows, 1);
-  ASSERT_EQ(response.slices.size(), 1);
-  EXPECT_EQ(response.slices[0].rows.numRows(), 1);
+  ASSERT_EQ(response.chunkSlices.size(), 1);
+  EXPECT_EQ(readEmbeddedRowRange(response.chunkSlices[0]).numRows(), 1);
 }
 
 TEST_P(NimbleIndexProjectorTest, maxRowsLargeScale) {
@@ -2001,19 +2527,19 @@ TEST_P(NimbleIndexProjectorTest, maxRowsMultiRequestMixedSatisfaction) {
   ASSERT_EQ(result.responses.size(), 4);
 
   // Request 0: 50 rows, fully satisfied, no resume key.
-  EXPECT_FALSE(result.responses[0].slices.empty());
+  EXPECT_FALSE(result.responses[0].chunkSlices.empty());
   EXPECT_FALSE(result.responses[0].resumeKey.has_value());
 
   // Request 1: 100 rows, fully satisfied (ends at stripe boundary), no resume.
-  EXPECT_FALSE(result.responses[1].slices.empty());
+  EXPECT_FALSE(result.responses[1].chunkSlices.empty());
   EXPECT_FALSE(result.responses[1].resumeKey.has_value());
 
   // Request 2: 100 rows from stripe 0, has data in stripes 1-4, resume key.
-  EXPECT_FALSE(result.responses[2].slices.empty());
+  EXPECT_FALSE(result.responses[2].chunkSlices.empty());
   EXPECT_TRUE(result.responses[2].resumeKey.has_value());
 
   // Request 3: stripe 9 never processed, resume key = original lower key.
-  EXPECT_TRUE(result.responses[3].slices.empty());
+  EXPECT_TRUE(result.responses[3].chunkSlices.empty());
   ASSERT_TRUE(result.responses[3].resumeKey.has_value());
   EXPECT_EQ(result.responses[3].resumeKey.value(), bounds3.lowerKey);
 }
@@ -2033,8 +2559,9 @@ TEST_P(NimbleIndexProjectorTest, maxBytesAndMaxRowsPerRequestInteraction) {
     NimbleIndexProjector::Request request;
     request.keyBounds = {bounds};
     auto result = projector->project(request, {});
-    ASSERT_EQ(result.chunks.size(), 1);
-    bytesPerStripe = result.chunks[0].data.computeChainDataLength();
+    ASSERT_EQ(result.responses[0].chunkSlices.size(), 1);
+    bytesPerStripe =
+        result.responses[0].chunkSlices[0].computeChainDataLength();
   }
 
   // maxRowsPerRequest clips to 150 rows (mid-stripe), maxBytes allows 5
@@ -2089,8 +2616,9 @@ TEST_P(NimbleIndexProjectorTest, maxBytesLargeScale) {
     NimbleIndexProjector::Request request;
     request.keyBounds = {bounds};
     auto result = projector->project(request, {});
-    ASSERT_EQ(result.chunks.size(), 1);
-    bytesPerStripe = result.chunks[0].data.computeChainDataLength();
+    ASSERT_EQ(result.responses[0].chunkSlices.size(), 1);
+    bytesPerStripe =
+        result.responses[0].chunkSlices[0].computeChainDataLength();
   }
 
   // Paginate all 10,000 rows with byte limit of ~3 stripes per page.
@@ -2174,7 +2702,7 @@ TEST_P(NimbleIndexProjectorTest, cacheDataReadStats) {
       request.keyBounds.push_back(std::move(bounds));
       auto result = projector->project(request, {});
       ASSERT_EQ(result.responses.size(), 1);
-      EXPECT_FALSE(result.responses[0].slices.empty());
+      EXPECT_FALSE(result.responses[0].chunkSlices.empty());
 
       const auto& stats = projector->stats();
       EXPECT_GT(stats.numStorageReads, 0);
@@ -2192,7 +2720,7 @@ TEST_P(NimbleIndexProjectorTest, cacheDataReadStats) {
       request.keyBounds.push_back(std::move(bounds));
       auto result = projector->project(request, {});
       ASSERT_EQ(result.responses.size(), 1);
-      EXPECT_FALSE(result.responses[0].slices.empty());
+      EXPECT_FALSE(result.responses[0].chunkSlices.empty());
 
       const auto& stats = projector->stats();
       if (testCase.expectCacheHitsOnSecondPass) {


### PR DESCRIPTION
Summary:
Adds per-request row range and optional resume key to the kTabletRaw chunk slice format emitted by `NimbleIndexProjector`, and updates the Nimble Deserializer to read them.

## Wire format

Each chunk slice is a 2-node `folly::IOBuf` chain:
- **Head node (per-slice header)**: `[version:1B=kTabletRaw][rowCount:varint][startRow:varint][endRow:varint][resumeKeyLength:varint][resumeKey]`. Unique allocation per (request × stripe).
- **Tail node (shared body + trailer)**: `[stream_data...][encodingType:1B][stream_sizes][trailer_size:u32]`. Refcount-shared across overlapping requests on the same stripe via `folly::IOBuf::cloneOne`.

`resumeKeyLength` uses a `+1` sentinel: 0 = no key, N>0 = key of length N-1. This distinguishes "no key" from "empty key" without a separate flag.

## API surface

New / renamed in `dwio/nimble/serializer/SerializerImpl.h`:
- `struct serde::TabletChunkHeader { uint32_t rowCount; RowRange rowRange; std::optional<std::string> resumeKey; }`
- `constexpr size_t serde::kMinTabletChunkHeaderSize` (5 bytes)
- `folly::IOBuf serde::createTabletChunkHeader(const TabletChunkHeader&)` — writer
- `writeHeader` for kTabletRaw auto-emits a full-stripe default header `[startRow=0][endRow=rowCount][resumeKeyLength=0]` so non-projector callers still produce valid bytes

New in `dwio/nimble/serializer/DeserializerImpl.h`:
- `serde::TabletChunkHeader serde::readTabletChunkHeader(const char*& pos, const char* end)` — reader; lives on the deserializer side and is shared with `StreamDataReader::initialize`

`rocks/nimble/NimbleTable.h` helpers (signatures unchanged):
- `readResultChunkRowCount(chunkSlice)`, `readResultRowRange(chunkSlice)`, `readResultResumeKey(chunkSlice)` — read from the head IOBuf node
- `GetNimbleResultIOBuf(slice)` (borrowed pointer alias) and `CloneNimbleResultIOBuf(slice)` (independent refcount-shared clone)

## Deserializer behavior

`Deserializer::deserialize` reads the per-slice header (consuming version + rowCount + row range + resume key length, advancing past resume key bytes) and **over-fetches**: it decodes the full cumulative stream without slicing to the row range. Rationale: each chunk slice covers exactly one (request × stripe) intersection in the projector path, so over-fetch never crosses users. Callers that want only the in-range rows can read the range via `rocks::readResultRowRange` and slice the output themselves.

A TODO points to the follow-up: push the row range into the `FieldReader::skip` cascade so the decode pass produces only the in-range rows (correct for nested-nullable types because the cascade goes through `FieldReader`).

## Producer-side changes

- `NimbleIndexProjector` queues `ResultChunk` records per (request × stripe), materializes each per-slice header via `createTabletChunkHeader` in `finalizeResultChunks`, and chains it onto a refcount-shared body+trailer clone via `appendToChain`.
- Byte accounting in `numReadBytes_`: caps in-process memory growth (shared body counted once per stripe; per-slice header bytes counted per emitted slice with top-up for resume-key-bearing slices).
- Resume key is folded into the last slice of any truncated response.

## Followup (xiaoxmeng explicit request)

Drop the `Raw` suffix from `SerializationVersion::kTabletRaw` → `kTablet`; add `isTabletVersion`. Separate diff.


Reviewed By: xingbowang, xiaoxmeng

Differential Revision: D105789279


