### PR TITLE
fix(nimble): Require IO stats for index projector cache path

### DIFF
--- a/dwio/nimble/velox/index/NimbleIndexProjector.cpp
+++ b/dwio/nimble/velox/index/NimbleIndexProjector.cpp
@@ -30,6 +30,22 @@ namespace facebook::nimble {
 
 using namespace facebook::velox; // NOLINT(google-build-using-namespace)
 
+namespace {
+
+void validateReaderOptions(const velox::dwio::common::ReaderOptions& options) {
+  NIMBLE_CHECK_NOT_NULL(
+      options.dataIoStats(),
+      "NimbleIndexProjector requires ReaderOptions::dataIoStats to be set");
+  NIMBLE_CHECK_NOT_NULL(
+      options.metadataIoStats(),
+      "NimbleIndexProjector requires ReaderOptions::metadataIoStats to be set");
+  NIMBLE_CHECK_NOT_NULL(
+      options.indexIoStats(),
+      "NimbleIndexProjector requires ReaderOptions::indexIoStats to be set");
+}
+
+} // namespace
+
 std::string NimbleIndexProjector::Stats::toString() const {
   return fmt::format(
       "Stats(numReadStripes={}, numScannedRows={}, numProjectedRows={}, numReadRows={}, "
@@ -92,7 +108,10 @@ NimbleIndexProjector::NimbleIndexProjector(
     std::unique_ptr<velox::dwio::common::BufferedInput> bufferedInput,
     const std::vector<Subfield>& projectedSubfields,
     const velox::dwio::common::ReaderOptions& options)
-    : readerBase_{ReaderBase::create(std::move(bufferedInput), options)},
+    : readerBase_{[&] {
+        validateReaderOptions(options);
+        return ReaderBase::create(std::move(bufferedInput), options);
+      }()},
       ioStats_{options.dataIoStats()},
       pool_{readerBase_->pool()},
       clusterIndex_{readerBase_->tablet().clusterIndex()},

--- a/dwio/nimble/velox/index/tests/NimbleIndexProjectorTest.cpp
+++ b/dwio/nimble/velox/index/tests/NimbleIndexProjectorTest.cpp
@@ -174,14 +174,24 @@ class NimbleIndexProjectorTest : public ::testing::TestWithParam<TestParam> {
   ProjectorWithStats createProjectorWithStats(
       const std::vector<Subfield>& projectedSubfields,
       velox::cache::AsyncDataCache* cache = nullptr,
-      std::optional<bool> cacheData = std::nullopt) {
+      std::optional<bool> cacheData = std::nullopt,
+      bool setDataIoStats = true,
+      bool setMetadataIoStats = true,
+      bool setIndexIoStats = true) {
     auto fileHandle = makeFileHandle();
     auto ioStats = std::make_shared<velox::io::IoStatistics>();
     dwio::common::ReaderOptions readerOptions(leafPool_.get());
-    readerOptions.setDataIoStats(ioStats);
-    readerOptions.setMetadataIoStats(
-        std::make_shared<velox::io::IoStatistics>());
-    readerOptions.setIndexIoStats(std::make_shared<velox::io::IoStatistics>());
+    if (setDataIoStats) {
+      readerOptions.setDataIoStats(ioStats);
+    }
+    if (setMetadataIoStats) {
+      readerOptions.setMetadataIoStats(
+          std::make_shared<velox::io::IoStatistics>());
+    }
+    if (setIndexIoStats) {
+      readerOptions.setIndexIoStats(
+          std::make_shared<velox::io::IoStatistics>());
+    }
     readerOptions.setFileFormat(FileFormat::NIMBLE);
     readerOptions.setLoadClusterIndex(true);
     readerOptions.setCacheMetadata(GetParam().enableCache);
@@ -2742,6 +2752,53 @@ TEST_P(NimbleIndexProjectorTest, cacheDataReadStats) {
   }
 
   cache->shutdown();
+}
+
+TEST_P(NimbleIndexProjectorTest, requiresIoStats) {
+  auto batch = vectorMaker_->rowVector(
+      {"key", "value"},
+      {vectorMaker_->flatVector<int64_t>({1, 2, 3}),
+       vectorMaker_->flatVector<int32_t>({10, 20, 30})});
+  writeData({batch}, {"key"});
+
+  std::vector<Subfield> subfields;
+  subfields.emplace_back("value");
+
+  struct TestCase {
+    bool setDataIoStats;
+    bool setMetadataIoStats;
+    bool setIndexIoStats;
+    std::string expectedMessage;
+  };
+
+  const std::vector<TestCase> testCases = {
+      {false,
+       true,
+       true,
+       "NimbleIndexProjector requires ReaderOptions::dataIoStats to be set"},
+      {true,
+       false,
+       true,
+       "NimbleIndexProjector requires ReaderOptions::metadataIoStats to be "
+       "set"},
+      {true,
+       true,
+       false,
+       "NimbleIndexProjector requires ReaderOptions::indexIoStats to be set"},
+  };
+
+  for (const auto& testCase : testCases) {
+    SCOPED_TRACE(testCase.expectedMessage);
+    NIMBLE_ASSERT_THROW(
+        createProjectorWithStats(
+            subfields,
+            /*cache=*/nullptr,
+            /*cacheData=*/std::nullopt,
+            /*setDataIoStats=*/testCase.setDataIoStats,
+            /*setMetadataIoStats=*/testCase.setMetadataIoStats,
+            /*setIndexIoStats=*/testCase.setIndexIoStats),
+        testCase.expectedMessage);
+  }
 }
 
 TEST_P(NimbleIndexProjectorTest, invalidFileHandleWithCache) {


### PR DESCRIPTION
Summary: Enforce the IO statistics contract for Nimble index projection. `NimbleIndexProjector` now validates `ReaderOptions::dataIoStats`, `ReaderOptions::metadataIoStats`, and `ReaderOptions::indexIoStats` before constructing the buffered input/reader path, with a shared helper keeping the checks consistent. `NimbleTableReader` enforces the same caller-provided stats instead of creating fallback stats internally. The Rocks Nimble e2e tests and benchmark fixtures now provide all three stats and explicitly load the cluster index so the cache/index projector path is exercised correctly.

Reviewed By: xiaoxmeng

Differential Revision: D106193639


