### PR TITLE
refactor: Rename SerializationVersion::kTabletRaw to kTablet

### DIFF
--- a/dwio/nimble/serializer/Deserializer.cpp
+++ b/dwio/nimble/serializer/Deserializer.cpp
@@ -760,14 +760,14 @@ void Deserializer::deserialize(
   // from a batch will have gaps that are filled later during reading.
   //
   // We decode the full cumulative stream below — over-fetching rows outside
-  // any per-batch row range. For kTabletRaw inputs from NimbleIndexProjector
+  // any per-batch row range. For kTablet inputs from NimbleIndexProjector
   // (the producer of row-range-bearing slices), this over-fetch is bounded
   // by stripe boundaries and never crosses users: each chunk slice covers
-  // exactly one (request × stripe) intersection. For non-kTabletRaw inputs
+  // exactly one (request × stripe) intersection. For non-kTablet inputs
   // (kCompactRaw/kLegacy) there's no embedded row range, so
   // "over-fetch" doesn't apply — the full batch is decoded as intended.
   //
-  // Callers that want only the in-range rows of a kTabletRaw slice can read
+  // Callers that want only the in-range rows of a kTablet slice can read
   // the range via rocks::readResultRowRange and slice the output themselves.
   //
   // TODO: optimize by pushing the row range into the FieldReader::skip

--- a/dwio/nimble/serializer/DeserializerImpl.cpp
+++ b/dwio/nimble/serializer/DeserializerImpl.cpp
@@ -52,7 +52,7 @@ StreamData::StreamData(
     : kind_{kind},
       pool_{pool},
       encodingEnabled_{nonLegacyFormat(options.version)},
-      useVarintRowCount_{!isTabletRawFormat(options.version)},
+      useVarintRowCount_{!isTabletVersion(options.version)},
       bufferPool_{options.bufferPool},
       decompressionBuffer_{options.decompressionBuffer},
       stringBuffers_{&stringBuffers} {
@@ -86,7 +86,7 @@ void StreamData::reset(std::string_view data, SerializationVersion version) {
   readRows_ = 0;
   encoding_.reset();
   encodingEnabled_ = nonLegacyFormat(version);
-  useVarintRowCount_ = !isTabletRawFormat(version);
+  useVarintRowCount_ = !isTabletVersion(version);
   // Re-initialize with new data.
   init(data);
 }
@@ -269,16 +269,16 @@ void StreamDataReader::iterateStreams(
     const std::function<void(uint32_t offset, std::string_view data)>&
         callback) {
   if (nonLegacyFormat(version_)) {
-    // kCompactRaw/kTabletRaw format: read stream sizes from trailer.
+    // kCompactRaw/kTablet format: read stream sizes from trailer.
     const auto streamSizes = detail::readTrailerStreamSizes(end_);
-    const bool tabletRaw = isTabletRawFormat(version_);
+    const bool isTablet = isTabletVersion(version_);
 
     for (uint32_t i = 0; i < streamSizes.size(); ++i) {
       std::string_view streamData(pos_, streamSizes[i]);
       pos_ += streamSizes[i];
       if (!streamData.empty()) {
-        if (tabletRaw) {
-          // kTabletRaw: stream data includes tablet chunk headers:
+        if (isTablet) {
+          // kTablet: stream data includes tablet chunk headers:
           // [chunkSize:u32][compressionType:1B][encoded_data...]
           // Strip headers and decompress if needed before passing to callback.
           callback(i, stripChunkHeaders(streamData));

--- a/dwio/nimble/serializer/DeserializerImpl.h
+++ b/dwio/nimble/serializer/DeserializerImpl.h
@@ -150,7 +150,7 @@ class StreamData {
   // Whether nimble encoding is enabled. Non-const to allow reset() to change.
   bool encodingEnabled_{false};
   // Whether encoding headers use varint row counts (true for kCompactRaw) or
-  // fixed u32 (false for kTabletRaw). Non-const to allow
+  // fixed u32 (false for kTablet). Non-const to allow
   // reset() to change.
   bool useVarintRowCount_{true};
   // Optional pool for encoding scratch buffers. Owned externally
@@ -191,7 +191,7 @@ class StreamDataReader {
   /// Returns number of rows serialized.
   /// Validates that the version in serialized data matches options.
   ///
-  /// PRECONDITION (kTabletRaw only): the per-slice header
+  /// PRECONDITION (kTablet only): the per-slice header
   /// (`[version][rowCount:varint][startRow:varint][endRow:varint]`
   /// `[resumeKeyLength:varint][resumeKey]`) must live contiguously within
   /// `data`. The projector emits the header in a single allocation; consumers
@@ -215,8 +215,8 @@ class StreamDataReader {
     return nonLegacyFormat(version_);
   }
 
-  /// Returns the row range embedded in the per-slice header for kTabletRaw
-  /// chunks (always present on the wire for kTabletRaw). nullopt for all
+  /// Returns the row range embedded in the per-slice header for kTablet
+  /// chunks (always present on the wire for kTablet). nullopt for all
   /// other serialization versions. Only valid after initialize() has been
   /// called.
   const std::optional<RowRange>& rowRange() const {
@@ -224,7 +224,7 @@ class StreamDataReader {
   }
 
  private:
-  // Strips tablet chunk headers from stream data for kTabletRaw format.
+  // Strips tablet chunk headers from stream data for kTablet format.
   // Each chunk is: [chunkSize:u32][compressionType:1B][encoded_data...]
   // Returns a view into the original data for single uncompressed chunks
   // (zero-copy), or a view into chunkStrippingBuffer_ for compressed/
@@ -253,8 +253,8 @@ class StreamDataReader {
   // header, this is read from the first byte; otherwise defaults to kLegacy.
   // When options specify a version, the data version is validated against it.
   SerializationVersion version_{SerializationVersion::kLegacy};
-  // Per-request row range embedded in the kTabletRaw header (post-rowCount,
-  // before stream data). nullopt for non-kTabletRaw formats or when the
+  // Per-request row range embedded in the kTablet header (post-rowCount,
+  // before stream data). nullopt for non-kTablet formats or when the
   // producer did not embed a row range.
   std::optional<RowRange> rowRange_;
   const char* pos_{nullptr};

--- a/dwio/nimble/serializer/Options.cpp
+++ b/dwio/nimble/serializer/Options.cpp
@@ -26,8 +26,8 @@ std::string toString(SerializationVersion version) {
       return "kLegacy";
     case SerializationVersion::kCompactRaw:
       return "kCompactRaw";
-    case SerializationVersion::kTabletRaw:
-      return "kTabletRaw";
+    case SerializationVersion::kTablet:
+      return "kTablet";
     default:
       NIMBLE_FAIL(
           "Unknown SerializationVersion: {}", static_cast<int>(version));

--- a/dwio/nimble/serializer/Options.h
+++ b/dwio/nimble/serializer/Options.h
@@ -48,7 +48,7 @@ namespace facebook::nimble {
 ///   Supported EncodingTypes: Trivial, Varint, Delta, FixedBitWidth.
 ///   See getTrailerEncodingType() for validation.
 ///
-/// - kTabletRaw: Raw tablet stream passthrough format. Like kCompactRaw but:
+/// - kTablet: Tablet stream passthrough format. Like kCompactRaw but:
 ///   (1) Each stream's data includes tablet chunk headers:
 ///       [chunkSize:u32][compressionType:1B][encoded_data...]
 ///       which the Deserializer strips before decoding.
@@ -59,29 +59,29 @@ namespace facebook::nimble {
 enum class SerializationVersion : uint8_t {
   kLegacy = 0,
   kCompactRaw = 2,
-  kTabletRaw = 3,
+  kTablet = 3,
 };
 
 std::string toString(SerializationVersion version);
 
 /// Returns true if the version is any non-legacy format (kCompactRaw or
-/// kTabletRaw). All non-legacy formats have a version header, encoded streams,
+/// kTablet). All non-legacy formats have a version header, encoded streams,
 /// and a stream sizes trailer.
 inline bool nonLegacyFormat(SerializationVersion version) {
   return version != SerializationVersion::kLegacy;
 }
 
 /// Returns true if the version uses compact encoding (kCompactRaw).
-/// Note: kTabletRaw is NOT a compact format (has chunk headers in streams).
+/// Note: kTablet is NOT a compact format (has chunk headers in streams).
 inline bool isCompactFormat(SerializationVersion version) {
   return version == SerializationVersion::kCompactRaw;
 }
 
 /// Returns true if the version uses raw stream sizes (kCompactRaw or
-/// kTabletRaw) instead of nimble-encoded stream sizes.
+/// kTablet) instead of nimble-encoded stream sizes.
 inline bool isRawFormat(SerializationVersion version) {
   return version == SerializationVersion::kCompactRaw ||
-      version == SerializationVersion::kTabletRaw;
+      version == SerializationVersion::kTablet;
 }
 
 /// Returns true if the optional version uses raw stream sizes.
@@ -89,14 +89,14 @@ inline bool isRawFormat(std::optional<SerializationVersion> version) {
   return version.has_value() && isRawFormat(version.value());
 }
 
-/// Returns true if the version is the tablet raw passthrough format.
-inline bool isTabletRawFormat(SerializationVersion version) {
-  return version == SerializationVersion::kTabletRaw;
+/// Returns true if the version is the tablet passthrough format.
+inline bool isTabletVersion(SerializationVersion version) {
+  return version == SerializationVersion::kTablet;
 }
 
-/// Returns true if the version is the tablet raw passthrough format.
-inline bool isTabletRawFormat(std::optional<SerializationVersion> version) {
-  return version.has_value() && isTabletRawFormat(version.value());
+/// Returns true if the version is the tablet passthrough format.
+inline bool isTabletVersion(std::optional<SerializationVersion> version) {
+  return version.has_value() && isTabletVersion(version.value());
 }
 
 /// Returns true if the optional version uses compact encoding.
@@ -105,8 +105,8 @@ inline bool isCompactFormat(std::optional<SerializationVersion> version) {
 }
 
 /// Returns true if the version uses varint for the header row count.
-/// All non-legacy versioned formats (kCompactRaw, kTabletRaw) use varint row
-/// counts in the header. The raw stream bodies inside kTabletRaw may use fixed
+/// All non-legacy versioned formats (kCompactRaw, kTablet) use varint row
+/// counts in the header. The raw stream bodies inside kTablet may use fixed
 /// u32 row counts in their encoding headers.
 inline bool usesVarintRowCount(SerializationVersion version) {
   return version != SerializationVersion::kLegacy;

--- a/dwio/nimble/serializer/SerializationHeader.cpp
+++ b/dwio/nimble/serializer/SerializationHeader.cpp
@@ -62,13 +62,13 @@ readSerializationHeader(const char*& pos, const char* end, bool hasHeader) {
     NIMBLE_CHECK(
         header.version == SerializationVersion::kLegacy ||
             header.version == SerializationVersion::kCompactRaw ||
-            header.version == SerializationVersion::kTabletRaw,
+            header.version == SerializationVersion::kTablet,
         "Unsupported version {}",
         static_cast<uint8_t>(header.version));
     ++pos;
   }
 
-  if (isTabletRawFormat(header.version)) {
+  if (isTabletVersion(header.version)) {
     auto tablet = extractTabletChunkHeader(pos, end);
     header.rowCount = tablet.rowCount;
     // TODO: consider setting rowRange to nullopt when it covers the full
@@ -107,7 +107,7 @@ folly::IOBuf createTabletChunkHeader(const TabletChunkHeader& header) {
 
   auto buf = folly::IOBuf::create(headerBytes);
   auto* pos = reinterpret_cast<char*>(buf->writableData());
-  *pos++ = static_cast<char>(SerializationVersion::kTabletRaw);
+  *pos++ = static_cast<char>(SerializationVersion::kTablet);
   varint::writeVarint(/*val=*/header.rowCount, &pos);
   varint::writeVarint(/*val=*/header.rowRange.startRow, &pos);
   varint::writeVarint(/*val=*/header.rowRange.endRow, &pos);
@@ -133,9 +133,7 @@ TabletChunkHeader readTabletChunkHeader(const char*& pos, const char* end) {
   NIMBLE_CHECK_GE(end - pos, 1, "Truncated chunk header (version)");
   const auto version = static_cast<SerializationVersion>(*pos++);
   NIMBLE_CHECK(
-      isTabletRawFormat(version),
-      "Expected kTabletRaw version, got: {}",
-      version);
+      isTabletVersion(version), "Expected kTablet version, got: {}", version);
   return extractTabletChunkHeader(pos, end);
 }
 

--- a/dwio/nimble/serializer/SerializationHeader.h
+++ b/dwio/nimble/serializer/SerializationHeader.h
@@ -35,7 +35,7 @@ namespace facebook::nimble::serde {
 struct SerializationHeader {
   SerializationVersion version{SerializationVersion::kLegacy};
   uint32_t rowCount{0};
-  /// Row range embedded in kTabletRaw headers. nullopt for other versions.
+  /// Row range embedded in kTablet headers. nullopt for other versions.
   std::optional<RowRange> rowRange;
 };
 
@@ -52,7 +52,7 @@ char* extend(T& buffer, uint32_t size) {
 
 /// Reads the serialization header from `*pos`, detecting the version from the
 /// first byte when `hasHeader` is true (otherwise defaults to kLegacy).
-/// Advances `*pos` past all header fields. For kTabletRaw, also reads the
+/// Advances `*pos` past all header fields. For kTablet, also reads the
 /// row range and resume key length fields.
 SerializationHeader
 readSerializationHeader(const char*& pos, const char* end, bool hasHeader);
@@ -60,15 +60,15 @@ readSerializationHeader(const char*& pos, const char* end, bool hasHeader);
 /// Writes a serialization header to buffer.
 /// For kLegacy: writes [optional_version:1B][rowCount:u32]
 /// For kCompactRaw: writes [version:1B][rowCount:varint]
-/// kTabletRaw headers must use createTabletChunkHeader() instead.
+/// kTablet headers must use createTabletChunkHeader() instead.
 template <typename T>
 void writeSerializationHeader(
     T& buffer,
     std::optional<SerializationVersion> version,
     uint32_t rowCount) {
   NIMBLE_CHECK(
-      !isTabletRawFormat(version),
-      "kTabletRaw headers must use createTabletChunkHeader()");
+      !isTabletVersion(version),
+      "kTablet headers must use createTabletChunkHeader()");
 
   if (version.has_value()) {
     auto* versionPos = detail::extend(buffer, 1);
@@ -85,13 +85,13 @@ void writeSerializationHeader(
 }
 
 /// Returns the exact byte size of the serialization header.
-/// Not valid for kTabletRaw — use createTabletChunkHeader() instead.
+/// Not valid for kTablet — use createTabletChunkHeader() instead.
 inline size_t estimateSerializationHeaderSize(
     std::optional<SerializationVersion> version,
     uint32_t rowCount) {
   NIMBLE_CHECK(
-      !isTabletRawFormat(version),
-      "kTabletRaw headers must use createTabletChunkHeader()");
+      !isTabletVersion(version),
+      "kTablet headers must use createTabletChunkHeader()");
   const size_t versionBytes = version.has_value() ? sizeof(uint8_t) : 0;
   const size_t rowCountBytes = usesVarintRowCount(version)
       ? varint::varintSize(rowCount)
@@ -99,19 +99,19 @@ inline size_t estimateSerializationHeaderSize(
   return versionBytes + rowCountBytes;
 }
 
-// ---- Tablet chunk header (kTabletRaw only) ----
+// ---- Tablet chunk header (kTablet only) ----
 
-/// Parsed fields of a kTabletRaw chunk slice header.
+/// Parsed fields of a kTablet chunk slice header.
 struct TabletChunkHeader {
   uint32_t rowCount{0};
   RowRange rowRange;
   std::optional<std::string> resumeKey;
 };
 
-/// Builds the kTabletRaw chunk slice header as a freshly-allocated IOBuf.
+/// Builds the kTablet chunk slice header as a freshly-allocated IOBuf.
 folly::IOBuf createTabletChunkHeader(const TabletChunkHeader& header);
 
-/// Reads a kTabletRaw chunk slice header including the version byte.
+/// Reads a kTablet chunk slice header including the version byte.
 TabletChunkHeader readTabletChunkHeader(const char*& pos, const char* end);
 
 } // namespace facebook::nimble::serde

--- a/dwio/nimble/serializer/Serializer.cpp
+++ b/dwio/nimble/serializer/Serializer.cpp
@@ -42,12 +42,9 @@ Serializer::Serializer(
       pool_{pool},
       context_{*pool_},
       buffer_{context_.bufferMemoryPool().get()} {
-  if (options_.version.has_value()) {
-    NIMBLE_CHECK_NE(
-        options_.serializationVersion(),
-        SerializationVersion::kTabletRaw,
-        "kTabletRaw is not supported by the serializer. It is only used in projection.");
-  }
+  NIMBLE_CHECK(
+      !isTabletVersion(options_.version),
+      "kTablet is not supported by the serializer. It is only used in projection.");
   // streamSizesEncodingType is ignored for kLegacy (no trailer).
   const std::shared_ptr<const velox::dwio::common::TypeWithId> typeWithId =
       velox::dwio::common::TypeWithId::create(type);

--- a/dwio/nimble/serializer/tests/OptionsTest.cpp
+++ b/dwio/nimble/serializer/tests/OptionsTest.cpp
@@ -25,25 +25,25 @@ TEST(OptionsTest, serializationVersionEnumValues) {
   // Verify enum underlying values match expected wire format versions.
   EXPECT_EQ(static_cast<uint8_t>(SerializationVersion::kLegacy), 0);
   EXPECT_EQ(static_cast<uint8_t>(SerializationVersion::kCompactRaw), 2);
-  EXPECT_EQ(static_cast<uint8_t>(SerializationVersion::kTabletRaw), 3);
+  EXPECT_EQ(static_cast<uint8_t>(SerializationVersion::kTablet), 3);
 }
 
 TEST(OptionsTest, toStringVersion) {
   EXPECT_EQ(toString(SerializationVersion::kLegacy), "kLegacy");
   EXPECT_EQ(toString(SerializationVersion::kCompactRaw), "kCompactRaw");
-  EXPECT_EQ(toString(SerializationVersion::kTabletRaw), "kTabletRaw");
+  EXPECT_EQ(toString(SerializationVersion::kTablet), "kTablet");
 }
 
 TEST(OptionsTest, streamOperator) {
   std::ostringstream os;
-  os << SerializationVersion::kTabletRaw;
-  EXPECT_EQ(os.str(), "kTabletRaw");
+  os << SerializationVersion::kTablet;
+  EXPECT_EQ(os.str(), "kTablet");
 }
 
 TEST(OptionsTest, fmtFormatter) {
   EXPECT_EQ(
       fmt::format("{}", SerializationVersion::kCompactRaw), "kCompactRaw");
-  EXPECT_EQ(fmt::format("{}", SerializationVersion::kTabletRaw), "kTabletRaw");
+  EXPECT_EQ(fmt::format("{}", SerializationVersion::kTablet), "kTablet");
 }
 
 TEST(OptionsTest, serializerOptionsDefaults) {
@@ -122,13 +122,13 @@ TEST(OptionsTest, serializerOptionsWithCompactRawVersion) {
 TEST(OptionsTest, nonLegacyFormat) {
   EXPECT_FALSE(nonLegacyFormat(SerializationVersion::kLegacy));
   EXPECT_TRUE(nonLegacyFormat(SerializationVersion::kCompactRaw));
-  EXPECT_TRUE(nonLegacyFormat(SerializationVersion::kTabletRaw));
+  EXPECT_TRUE(nonLegacyFormat(SerializationVersion::kTablet));
 }
 
 TEST(OptionsTest, isCompactFormat) {
   EXPECT_FALSE(isCompactFormat(SerializationVersion::kLegacy));
   EXPECT_TRUE(isCompactFormat(SerializationVersion::kCompactRaw));
-  EXPECT_FALSE(isCompactFormat(SerializationVersion::kTabletRaw));
+  EXPECT_FALSE(isCompactFormat(SerializationVersion::kTablet));
 }
 
 TEST(OptionsTest, isCompactFormatOptional) {
@@ -136,29 +136,27 @@ TEST(OptionsTest, isCompactFormatOptional) {
   EXPECT_FALSE(isCompactFormat(std::optional{SerializationVersion::kLegacy}));
   EXPECT_TRUE(
       isCompactFormat(std::optional{SerializationVersion::kCompactRaw}));
-  EXPECT_FALSE(
-      isCompactFormat(std::optional{SerializationVersion::kTabletRaw}));
+  EXPECT_FALSE(isCompactFormat(std::optional{SerializationVersion::kTablet}));
 }
 
-TEST(OptionsTest, isTabletRawFormat) {
-  EXPECT_FALSE(isTabletRawFormat(SerializationVersion::kLegacy));
-  EXPECT_FALSE(isTabletRawFormat(SerializationVersion::kCompactRaw));
-  EXPECT_TRUE(isTabletRawFormat(SerializationVersion::kTabletRaw));
+TEST(OptionsTest, isTabletVersion) {
+  EXPECT_FALSE(isTabletVersion(SerializationVersion::kLegacy));
+  EXPECT_FALSE(isTabletVersion(SerializationVersion::kCompactRaw));
+  EXPECT_TRUE(isTabletVersion(SerializationVersion::kTablet));
 }
 
-TEST(OptionsTest, isTabletRawFormatOptional) {
-  EXPECT_FALSE(isTabletRawFormat(std::nullopt));
-  EXPECT_FALSE(isTabletRawFormat(std::optional{SerializationVersion::kLegacy}));
+TEST(OptionsTest, isTabletVersionOptional) {
+  EXPECT_FALSE(isTabletVersion(std::nullopt));
+  EXPECT_FALSE(isTabletVersion(std::optional{SerializationVersion::kLegacy}));
   EXPECT_FALSE(
-      isTabletRawFormat(std::optional{SerializationVersion::kCompactRaw}));
-  EXPECT_TRUE(
-      isTabletRawFormat(std::optional{SerializationVersion::kTabletRaw}));
+      isTabletVersion(std::optional{SerializationVersion::kCompactRaw}));
+  EXPECT_TRUE(isTabletVersion(std::optional{SerializationVersion::kTablet}));
 }
 
 TEST(OptionsTest, usesVarintRowCount) {
   EXPECT_FALSE(usesVarintRowCount(SerializationVersion::kLegacy));
   EXPECT_TRUE(usesVarintRowCount(SerializationVersion::kCompactRaw));
-  EXPECT_TRUE(usesVarintRowCount(SerializationVersion::kTabletRaw));
+  EXPECT_TRUE(usesVarintRowCount(SerializationVersion::kTablet));
 }
 
 TEST(OptionsTest, usesVarintRowCountOptional) {
@@ -167,8 +165,7 @@ TEST(OptionsTest, usesVarintRowCountOptional) {
       usesVarintRowCount(std::optional{SerializationVersion::kLegacy}));
   EXPECT_TRUE(
       usesVarintRowCount(std::optional{SerializationVersion::kCompactRaw}));
-  EXPECT_TRUE(
-      usesVarintRowCount(std::optional{SerializationVersion::kTabletRaw}));
+  EXPECT_TRUE(usesVarintRowCount(std::optional{SerializationVersion::kTablet}));
 }
 
 TEST(OptionsTest, getTrailerEncodingTypeBasic) {

--- a/dwio/nimble/serializer/tests/ProjectorTest.cpp
+++ b/dwio/nimble/serializer/tests/ProjectorTest.cpp
@@ -650,27 +650,27 @@ TEST_F(ProjectorTest, incompatibleFormatsRejected) {
           {.projectVersion = SerializationVersion::kLegacy}),
       "Projection output version must be kCompactRaw");
 
-  // Test kTabletRaw output version — rejected in constructor.
+  // Test kTablet output version — rejected in constructor.
   NIMBLE_ASSERT_THROW(
       Projector(
           inputSchema,
           subfields,
           pool_.get(),
-          {.projectVersion = SerializationVersion::kTabletRaw}),
+          {.projectVersion = SerializationVersion::kTablet}),
       "Projection output version must be kCompactRaw");
 
-  // Test kTabletRaw input — rejected at projection time.
+  // Test kTablet input — rejected at projection time.
   {
     auto serialized =
         serialize(vec, type, {.version = SerializationVersion::kCompactRaw});
     Projector projector(inputSchema, subfields, pool_.get(), {});
 
-    // Patch the version byte to kTabletRaw.
-    std::string tabletRawInput = serialized;
-    tabletRawInput[0] = static_cast<char>(SerializationVersion::kTabletRaw);
+    // Patch the version byte to kTablet.
+    std::string tabletInput = serialized;
+    tabletInput[0] = static_cast<char>(SerializationVersion::kTablet);
 
     NIMBLE_ASSERT_THROW(
-        projector.project(std::string_view(tabletRawInput)),
+        projector.project(std::string_view(tabletInput)),
         "Input must be kCompactRaw format");
   }
 }

--- a/dwio/nimble/serializer/tests/SerializationHeaderTest.cpp
+++ b/dwio/nimble/serializer/tests/SerializationHeaderTest.cpp
@@ -59,14 +59,14 @@ TEST(SerializationHeaderTest, writeReadRoundtripNoHeader) {
   EXPECT_FALSE(header.rowRange.has_value());
 }
 
-TEST(SerializationHeaderTest, readTabletRawHeader) {
+TEST(SerializationHeaderTest, readTabletHeader) {
   auto iobuf =
       createTabletChunkHeader({.rowCount = 500, .rowRange = RowRange{10, 200}});
   const char* pos = reinterpret_cast<const char*>(iobuf.data());
   const char* end = pos + iobuf.length();
 
   auto header = readSerializationHeader(pos, end, true);
-  EXPECT_EQ(header.version, SerializationVersion::kTabletRaw);
+  EXPECT_EQ(header.version, SerializationVersion::kTablet);
   EXPECT_EQ(header.rowCount, 500);
   ASSERT_TRUE(header.rowRange.has_value());
   EXPECT_EQ(header.rowRange->startRow, 10);
@@ -82,17 +82,17 @@ TEST(SerializationHeaderTest, readRejectsUnsupportedVersion) {
       "Unsupported version");
 }
 
-TEST(SerializationHeaderTest, writeRejectsTabletRaw) {
+TEST(SerializationHeaderTest, writeRejectsTablet) {
   std::string buffer;
   NIMBLE_ASSERT_THROW(
-      writeSerializationHeader(buffer, SerializationVersion::kTabletRaw, 100),
-      "kTabletRaw headers must use createTabletChunkHeader()");
+      writeSerializationHeader(buffer, SerializationVersion::kTablet, 100),
+      "kTablet headers must use createTabletChunkHeader()");
 }
 
-TEST(SerializationHeaderTest, estimateRejectsTabletRaw) {
+TEST(SerializationHeaderTest, estimateRejectsTablet) {
   NIMBLE_ASSERT_THROW(
-      estimateSerializationHeaderSize(SerializationVersion::kTabletRaw, 100),
-      "kTabletRaw headers must use createTabletChunkHeader()");
+      estimateSerializationHeaderSize(SerializationVersion::kTablet, 100),
+      "kTablet headers must use createTabletChunkHeader()");
 }
 
 TEST(SerializationHeaderTest, estimateSizeMatchesActual) {
@@ -212,7 +212,7 @@ TEST(TabletChunkHeaderTest, exactBoundaryEndRowEqualsRowCount) {
 
 TEST(TabletChunkHeaderTest, rejectsRowRangeExceedingRowCount) {
   std::string buf;
-  buf.push_back(static_cast<char>(SerializationVersion::kTabletRaw));
+  buf.push_back(static_cast<char>(SerializationVersion::kTablet));
   buf.push_back(0x05); // rowCount = 5
   buf.push_back(0x00); // startRow = 0
   buf.push_back(0x64); // endRow = 100 (> rowCount)
@@ -224,7 +224,7 @@ TEST(TabletChunkHeaderTest, rejectsRowRangeExceedingRowCount) {
 
 TEST(TabletChunkHeaderTest, rejectsInvertedRowRange) {
   std::string buf;
-  buf.push_back(static_cast<char>(SerializationVersion::kTabletRaw));
+  buf.push_back(static_cast<char>(SerializationVersion::kTablet));
   buf.push_back(0x0a); // rowCount = 10
   buf.push_back(0x05); // startRow = 5
   buf.push_back(0x03); // endRow = 3 (< startRow)

--- a/dwio/nimble/serializer/tests/SerializationTest.cpp
+++ b/dwio/nimble/serializer/tests/SerializationTest.cpp
@@ -99,25 +99,25 @@ class SerializationTest : public ::testing::TestWithParam<TestParams> {
 
   // Result of serializing input vectors.
   struct SerializeResult {
-    // One serialized buffer per input vector (or per stripe for kTabletRaw).
+    // One serialized buffer per input vector (or per stripe for kTablet).
     std::vector<std::string> serialized;
     // Nimble schema for deserialization.
     std::shared_ptr<const Type> schema;
   };
 
   // Serializes input vectors using the current test parameter's version.
-  // For kTabletRaw, writes a Nimble file and assembles kTabletRaw buffers.
+  // For kTablet, writes a Nimble file and assembles kTablet buffers.
   // For other versions, uses the Serializer directly.
   SerializeResult serialize(
       const velox::TypePtr& type,
       const std::vector<velox::VectorPtr>& inputs);
 
   // Writes vectors to a Nimble file, reads raw tablet streams, and assembles
-  // kTabletRaw buffers. Each input vector becomes part of a single-stripe file.
+  // kTablet buffers. Each input vector becomes part of a single-stripe file.
   // When enableChunking is true, streams include chunk headers (the actual
-  // kTabletRaw format); when false, streams are raw encoded data without chunk
+  // kTablet format); when false, streams are raw encoded data without chunk
   // headers.
-  SerializeResult serializeTabletRaw(
+  SerializeResult serializeTablet(
       const velox::TypePtr& type,
       const std::vector<velox::VectorPtr>& inputs,
       bool enableChunking);
@@ -441,8 +441,8 @@ std::string formatName(const ::testing::TestParamInfo<TestParams>& info) {
       case SerializationVersion::kCompactRaw:
         name = "CompactRawFormat";
         break;
-      case SerializationVersion::kTabletRaw:
-        name = "TabletRawFormat";
+      case SerializationVersion::kTablet:
+        name = "TabletFormat";
         break;
     }
   }
@@ -464,8 +464,8 @@ std::string formatName(const ::testing::TestParamInfo<TestParams>& info) {
 SerializationTest::SerializeResult SerializationTest::serialize(
     const velox::TypePtr& type,
     const std::vector<velox::VectorPtr>& inputs) {
-  if (version() == SerializationVersion::kTabletRaw) {
-    return serializeTabletRaw(type, inputs, /*enableChunking=*/true);
+  if (version() == SerializationVersion::kTablet) {
+    return serializeTablet(type, inputs, /*enableChunking=*/true);
   }
 
   SerializerOptions options{
@@ -487,7 +487,7 @@ SerializationTest::SerializeResult SerializationTest::serialize(
   return result;
 }
 
-SerializationTest::SerializeResult SerializationTest::serializeTabletRaw(
+SerializationTest::SerializeResult SerializationTest::serializeTablet(
     const velox::TypePtr& type,
     const std::vector<velox::VectorPtr>& inputs,
     bool enableChunking) {
@@ -524,7 +524,7 @@ SerializationTest::SerializeResult SerializationTest::serializeTabletRaw(
   collectStreamOffsets(*nimbleSchema, offsetSet);
   std::vector<uint32_t> streamOffsets(offsetSet.begin(), offsetSet.end());
 
-  // Assemble kTabletRaw buffer for each stripe.
+  // Assemble kTablet buffer for each stripe.
   SerializeResult result;
   result.schema = nimbleSchema;
   for (uint32_t stripeIdx = 0; stripeIdx < tablet->stripeCount(); ++stripeIdx) {
@@ -532,7 +532,7 @@ SerializationTest::SerializeResult SerializationTest::serializeTabletRaw(
     auto streamLoaders = tablet->load(stripeId, streamOffsets);
     const auto stripeRows = tablet->stripeRowCount(stripeIdx);
 
-    // Build kTabletRaw: [header][raw stream data...][trailer].
+    // Build kTablet: [header][raw stream data...][trailer].
     auto headerIOBuf = serde::createTabletChunkHeader(
         {.rowCount = stripeRows, .rowRange = RowRange{0, stripeRows}});
     std::string headerBuf(
@@ -1834,12 +1834,12 @@ TEST_P(SerializationTest, versionMismatch) {
       deserializer.deserialize(serialized, output), "Unsupported version");
 }
 
-TEST_P(SerializationTest, tabletRawVersionRejected) {
+TEST_P(SerializationTest, tabletVersionRejected) {
   auto type = velox::ROW({{"int_val", velox::INTEGER()}});
-  SerializerOptions options{.version = SerializationVersion::kTabletRaw};
+  SerializerOptions options{.version = SerializationVersion::kTablet};
   NIMBLE_ASSERT_THROW(
       Serializer(options, type, pool_.get()),
-      "kTabletRaw is not supported by the serializer");
+      "kTablet is not supported by the serializer");
 }
 
 TEST_P(SerializationTest, streamSizesEncodingIgnoredForLegacy) {
@@ -2932,12 +2932,12 @@ TEST_P(SerializationTest, flatMapAsStructWithMissingKeys) {
   }
 }
 
-// Standalone test for kTabletRaw deserialization.
-// kTabletRaw is not produced by the Serializer — it's constructed by reading
+// Standalone test for kTablet deserialization.
+// kTablet is not produced by the Serializer — it's constructed by reading
 // raw tablet stream bytes from a Nimble file and assembling them with a header
 // and trailer. This test writes a Nimble file, reads raw streams, assembles
-// kTabletRaw format, and verifies that Deserializer correctly handles it.
-TEST_F(SerializationTest, tabletRawDeserialization) {
+// kTablet format, and verifies that Deserializer correctly handles it.
+TEST_F(SerializationTest, tabletDeserialization) {
   auto rowType = velox::ROW(
       {{"col_a", velox::INTEGER()},
        {"col_b", velox::BIGINT()},
@@ -2952,14 +2952,13 @@ TEST_F(SerializationTest, tabletRawDeserialization) {
       pool_.get());
   auto input = fuzzer.fuzzInputRow(rowType);
 
-  auto tabletRaw =
-      serializeTabletRaw(rowType, {input}, /*enableChunking=*/true);
+  auto tablet = serializeTablet(rowType, {input}, /*enableChunking=*/true);
 
   nimble::Deserializer deserializer(
-      tabletRaw.schema, pool_.get(), DeserializerOptions{.hasHeader = true});
+      tablet.schema, pool_.get(), DeserializerOptions{.hasHeader = true});
 
   velox::VectorPtr deserialized;
-  for (const auto& assembled : tabletRaw.serialized) {
+  for (const auto& assembled : tablet.serialized) {
     velox::VectorPtr stripeOutput;
     deserializer.deserialize(std::string_view(assembled), stripeOutput);
     ASSERT_NE(stripeOutput, nullptr);
@@ -2985,7 +2984,7 @@ TEST_F(SerializationTest, tabletRawDeserialization) {
 
 // Verifies ZSTD decompression round-trips correctly with the thread-local
 // ZSTD_DCtx reuse (always-on). Exercises the StreamDataReader and StreamData
-// decompress paths with kTabletRaw chunked format.
+// decompress paths with kTablet chunked format.
 TEST_F(SerializationTest, zstdThreadLocalDCtxRoundTrip) {
   auto rowType = velox::ROW(
       {{"col_a", velox::INTEGER()},
@@ -3001,14 +3000,13 @@ TEST_F(SerializationTest, zstdThreadLocalDCtxRoundTrip) {
       pool_.get());
   auto input = fuzzer.fuzzInputRow(rowType);
 
-  auto tabletRaw =
-      serializeTabletRaw(rowType, {input}, /*enableChunking=*/true);
+  auto tablet = serializeTablet(rowType, {input}, /*enableChunking=*/true);
 
   nimble::Deserializer deserializer(
-      tabletRaw.schema, pool_.get(), DeserializerOptions{.hasHeader = true});
+      tablet.schema, pool_.get(), DeserializerOptions{.hasHeader = true});
 
   velox::VectorPtr deserialized;
-  for (const auto& assembled : tabletRaw.serialized) {
+  for (const auto& assembled : tablet.serialized) {
     velox::VectorPtr stripeOutput;
     deserializer.deserialize(std::string_view(assembled), stripeOutput);
     ASSERT_NE(stripeOutput, nullptr);
@@ -3049,12 +3047,11 @@ TEST_F(SerializationTest, zstdThreadLocalDCtxWithParallelDecode) {
       pool_.get());
   auto input = fuzzer.fuzzInputRow(rowType);
 
-  auto tabletRaw =
-      serializeTabletRaw(rowType, {input}, /*enableChunking=*/true);
+  auto tablet = serializeTablet(rowType, {input}, /*enableChunking=*/true);
 
   folly::CPUThreadPoolExecutor executor(2);
   nimble::Deserializer deserializer(
-      tabletRaw.schema,
+      tablet.schema,
       pool_.get(),
       DeserializerOptions{
           .hasHeader = true,
@@ -3063,7 +3060,7 @@ TEST_F(SerializationTest, zstdThreadLocalDCtxWithParallelDecode) {
       });
 
   velox::VectorPtr deserialized;
-  for (const auto& assembled : tabletRaw.serialized) {
+  for (const auto& assembled : tablet.serialized) {
     velox::VectorPtr stripeOutput;
     deserializer.deserialize(std::string_view(assembled), stripeOutput);
     ASSERT_NE(stripeOutput, nullptr);

--- a/dwio/nimble/serializer/tests/SerializerImplTest.cpp
+++ b/dwio/nimble/serializer/tests/SerializerImplTest.cpp
@@ -1247,19 +1247,19 @@ TEST_F(EncodeTypedCompressionTest, defaultFactoryNoCompression) {
       CompressionType::Uncompressed);
 }
 
-// Tests for kTabletRaw chunk header stripping in StreamDataReader.
-// kTabletRaw streams contain chunk headers:
+// Tests for kTablet chunk header stripping in StreamDataReader.
+// kTablet streams contain chunk headers:
 //   [chunkSize:u32][compressionType:1B][encoded_data...]
 // StreamDataReader must strip these headers and decompress as needed.
 
-class TabletRawChunkStripTest : public ::testing::Test {
+class TabletChunkStripTest : public ::testing::Test {
  protected:
   static void SetUpTestSuite() {
     memory::MemoryManager::testingSetInstance(memory::MemoryManager::Options{});
   }
 
   void SetUp() override {
-    pool_ = memory::memoryManager()->addLeafPool("tablet_raw_chunk_test");
+    pool_ = memory::memoryManager()->addLeafPool("tablet_chunk_test");
   }
 
   // Builds a single uncompressed chunk: [length:u32][Uncompressed:1B][data].
@@ -1298,10 +1298,10 @@ class TabletRawChunkStripTest : public ::testing::Test {
     return result;
   }
 
-  // Assembles a kTabletRaw buffer from streams and returns the data collected
+  // Assembles a kTablet buffer from streams and returns the data collected
   // by iterateStreams.
   // Each entry in 'streams' is the raw stream bytes (with chunk headers).
-  std::vector<std::pair<uint32_t, std::string>> deserializeTabletRaw(
+  std::vector<std::pair<uint32_t, std::string>> deserializeTablet(
       uint32_t rowCount,
       const std::vector<std::pair<uint32_t, std::string>>& streams) {
     // Build dense sizes array.
@@ -1341,27 +1341,27 @@ class TabletRawChunkStripTest : public ::testing::Test {
   std::shared_ptr<memory::MemoryPool> pool_;
 };
 
-TEST_F(TabletRawChunkStripTest, singleChunkUncompressed) {
+TEST_F(TabletChunkStripTest, singleChunkUncompressed) {
   std::string payload = "hello world test data";
   auto stream = buildUncompressedChunk(payload);
-  auto result = deserializeTabletRaw(10, {{0, stream}});
+  auto result = deserializeTablet(10, {{0, stream}});
 
   ASSERT_EQ(result.size(), 1);
   EXPECT_EQ(result[0].first, 0);
   EXPECT_EQ(result[0].second, payload);
 }
 
-TEST_F(TabletRawChunkStripTest, singleChunkCompressed) {
+TEST_F(TabletChunkStripTest, singleChunkCompressed) {
   std::string payload = "compressed data that should be zstd encoded";
   auto stream = buildCompressedChunk(payload);
-  auto result = deserializeTabletRaw(10, {{0, stream}});
+  auto result = deserializeTablet(10, {{0, stream}});
 
   ASSERT_EQ(result.size(), 1);
   EXPECT_EQ(result[0].first, 0);
   EXPECT_EQ(result[0].second, payload);
 }
 
-TEST_F(TabletRawChunkStripTest, multipleChunksAllUncompressed) {
+TEST_F(TabletChunkStripTest, multipleChunksAllUncompressed) {
   std::string part1 = "first chunk data";
   std::string part2 = "second chunk data";
   std::string part3 = "third chunk data";
@@ -1369,26 +1369,26 @@ TEST_F(TabletRawChunkStripTest, multipleChunksAllUncompressed) {
       {buildUncompressedChunk(part1),
        buildUncompressedChunk(part2),
        buildUncompressedChunk(part3)});
-  auto result = deserializeTabletRaw(10, {{0, stream}});
+  auto result = deserializeTablet(10, {{0, stream}});
 
   ASSERT_EQ(result.size(), 1);
   EXPECT_EQ(result[0].first, 0);
   EXPECT_EQ(result[0].second, part1 + part2 + part3);
 }
 
-TEST_F(TabletRawChunkStripTest, multipleChunksAllCompressed) {
+TEST_F(TabletChunkStripTest, multipleChunksAllCompressed) {
   std::string part1 = "first chunk of compressed data here";
   std::string part2 = "second chunk of compressed data here";
   auto stream =
       concatChunks({buildCompressedChunk(part1), buildCompressedChunk(part2)});
-  auto result = deserializeTabletRaw(10, {{0, stream}});
+  auto result = deserializeTablet(10, {{0, stream}});
 
   ASSERT_EQ(result.size(), 1);
   EXPECT_EQ(result[0].first, 0);
   EXPECT_EQ(result[0].second, part1 + part2);
 }
 
-TEST_F(TabletRawChunkStripTest, multipleChunksMixed) {
+TEST_F(TabletChunkStripTest, multipleChunksMixed) {
   std::string part1 = "uncompressed chunk one";
   std::string part2 = "compressed chunk two with some data";
   std::string part3 = "another uncompressed chunk three";
@@ -1396,20 +1396,20 @@ TEST_F(TabletRawChunkStripTest, multipleChunksMixed) {
       {buildUncompressedChunk(part1),
        buildCompressedChunk(part2),
        buildUncompressedChunk(part3)});
-  auto result = deserializeTabletRaw(10, {{0, stream}});
+  auto result = deserializeTablet(10, {{0, stream}});
 
   ASSERT_EQ(result.size(), 1);
   EXPECT_EQ(result[0].first, 0);
   EXPECT_EQ(result[0].second, part1 + part2 + part3);
 }
 
-TEST_F(TabletRawChunkStripTest, multipleStreams) {
+TEST_F(TabletChunkStripTest, multipleStreams) {
   std::string payload1 = "stream zero payload";
   std::string payload2 = "stream two payload data";
   auto stream0 = buildUncompressedChunk(payload1);
   auto stream2 = buildCompressedChunk(payload2);
   // Stream offsets 0 and 2 (gap at 1).
-  auto result = deserializeTabletRaw(10, {{0, stream0}, {2, stream2}});
+  auto result = deserializeTablet(10, {{0, stream0}, {2, stream2}});
 
   ASSERT_EQ(result.size(), 2);
   EXPECT_EQ(result[0].first, 0);
@@ -1418,7 +1418,7 @@ TEST_F(TabletRawChunkStripTest, multipleStreams) {
   EXPECT_EQ(result[1].second, payload2);
 }
 
-TEST_F(TabletRawChunkStripTest, multipleStreamsMultipleChunks) {
+TEST_F(TabletChunkStripTest, multipleStreamsMultipleChunks) {
   // Stream 0: two uncompressed chunks.
   std::string s0p1 = "stream0 part1";
   std::string s0p2 = "stream0 part2";
@@ -1436,7 +1436,7 @@ TEST_F(TabletRawChunkStripTest, multipleStreamsMultipleChunks) {
       concatChunks({buildUncompressedChunk(s2p1), buildCompressedChunk(s2p2)});
 
   auto result =
-      deserializeTabletRaw(10, {{0, stream0}, {1, stream1}, {2, stream2}});
+      deserializeTablet(10, {{0, stream0}, {1, stream1}, {2, stream2}});
 
   ASSERT_EQ(result.size(), 3);
   EXPECT_EQ(result[0].first, 0);
@@ -1447,18 +1447,18 @@ TEST_F(TabletRawChunkStripTest, multipleStreamsMultipleChunks) {
   EXPECT_EQ(result[2].second, s2p1 + s2p2);
 }
 
-TEST_F(TabletRawChunkStripTest, emptyPayloadChunk) {
+TEST_F(TabletChunkStripTest, emptyPayloadChunk) {
   // Single uncompressed chunk with empty payload.
   // The chunk header is still present (5 bytes), so iterateStreams calls the
   // callback with the stripped (empty) data.
   auto stream = buildUncompressedChunk("");
-  auto result = deserializeTabletRaw(10, {{0, stream}});
+  auto result = deserializeTablet(10, {{0, stream}});
   ASSERT_EQ(result.size(), 1);
   EXPECT_EQ(result[0].first, 0);
   EXPECT_TRUE(result[0].second.empty());
 }
 
-TEST_F(TabletRawChunkStripTest, largePayload) {
+TEST_F(TabletChunkStripTest, largePayload) {
   // Large payload to exercise buffer growth.
   std::string payload(100'000, 'x');
   for (size_t i = 0; i < payload.size(); ++i) {
@@ -1467,12 +1467,12 @@ TEST_F(TabletRawChunkStripTest, largePayload) {
 
   // Test single compressed chunk with large data.
   auto stream = buildCompressedChunk(payload);
-  auto result = deserializeTabletRaw(10, {{0, stream}});
+  auto result = deserializeTablet(10, {{0, stream}});
   ASSERT_EQ(result.size(), 1);
   EXPECT_EQ(result[0].second, payload);
 }
 
-TEST_F(TabletRawChunkStripTest, largePayloadMultipleChunks) {
+TEST_F(TabletChunkStripTest, largePayloadMultipleChunks) {
   // Split large payload across multiple chunks of different types.
   std::string payload(50'000, '\0');
   for (size_t i = 0; i < payload.size(); ++i) {
@@ -1487,17 +1487,17 @@ TEST_F(TabletRawChunkStripTest, largePayloadMultipleChunks) {
       {buildUncompressedChunk(part1),
        buildCompressedChunk(part2),
        buildCompressedChunk(part3)});
-  auto result = deserializeTabletRaw(10, {{0, stream}});
+  auto result = deserializeTablet(10, {{0, stream}});
 
   ASSERT_EQ(result.size(), 1);
   EXPECT_EQ(result[0].second, payload);
 }
 
 // Tests for ZSTD_DCtx reuse in StreamData and StreamDataReader.
-// Inherits from TabletRawChunkStripTest for shared helpers
+// Inherits from TabletChunkStripTest for shared helpers
 // (buildCompressedChunk, pool_, etc.).
 
-class ZstdDCtxReuseTest : public TabletRawChunkStripTest {
+class ZstdDCtxReuseTest : public TabletChunkStripTest {
  protected:
   static std::string buildLegacyCompressedData(std::string_view payload) {
     std::string result;
@@ -1512,9 +1512,9 @@ class ZstdDCtxReuseTest : public TabletRawChunkStripTest {
     return result;
   }
 
-  // Like TabletRawChunkStripTest::deserializeTabletRaw, but passes
+  // Like TabletChunkStripTest::deserializeTablet, but passes
   // the fixture's shared dctx to StreamDataReader.
-  std::vector<std::pair<uint32_t, std::string>> deserializeTabletRawWithDCtx(
+  std::vector<std::pair<uint32_t, std::string>> deserializeTabletWithDCtx(
       uint32_t rowCount,
       const std::vector<std::pair<uint32_t, std::string>>& streams) {
     uint32_t maxOffset = 0;
@@ -1616,7 +1616,7 @@ TEST_F(ZstdDCtxReuseTest, streamDataDCtxReusedAcrossReset) {
 TEST_F(ZstdDCtxReuseTest, streamDataReaderCompressedChunkWithDCtx) {
   std::string payload = "compressed data that should be zstd encoded for test";
   auto chunk = buildCompressedChunk(payload);
-  auto result = deserializeTabletRawWithDCtx(10, {{0, chunk}});
+  auto result = deserializeTabletWithDCtx(10, {{0, chunk}});
 
   ASSERT_EQ(result.size(), 1);
   EXPECT_EQ(result[0].first, 0);
@@ -1629,14 +1629,14 @@ TEST_F(ZstdDCtxReuseTest, streamDataReaderDCtxReusedAcrossStreams) {
   auto chunk1 = buildCompressedChunk(payload1);
   auto chunk2 = buildCompressedChunk(payload2);
 
-  auto result = deserializeTabletRawWithDCtx(10, {{0, chunk1}, {1, chunk2}});
+  auto result = deserializeTabletWithDCtx(10, {{0, chunk1}, {1, chunk2}});
 
   ASSERT_EQ(result.size(), 2);
   EXPECT_EQ(result[0].second, payload1);
   EXPECT_EQ(result[1].second, payload2);
 }
 
-class LZ4RoundtripTest : public TabletRawChunkStripTest {
+class LZ4RoundtripTest : public TabletChunkStripTest {
  protected:
   static std::string buildLegacyLZ4CompressedData(std::string_view payload) {
     std::string result;
@@ -1751,7 +1751,7 @@ TEST_F(LZ4RoundtripTest, streamDataLZ4ReusedAcrossReset) {
 TEST_F(LZ4RoundtripTest, streamDataReaderLZ4CompressedChunk) {
   std::string payload = "compressed data that should be lz4 encoded for test";
   auto chunk = buildLZ4CompressedChunk(payload);
-  auto result = deserializeTabletRaw(10, {{0, chunk}});
+  auto result = deserializeTablet(10, {{0, chunk}});
 
   ASSERT_EQ(result.size(), 1);
   EXPECT_EQ(result[0].first, 0);
@@ -1764,7 +1764,7 @@ TEST_F(LZ4RoundtripTest, streamDataReaderLZ4ReusedAcrossStreams) {
   auto chunk1 = buildLZ4CompressedChunk(payload1);
   auto chunk2 = buildLZ4CompressedChunk(payload2);
 
-  auto result = deserializeTabletRaw(10, {{0, chunk1}, {1, chunk2}});
+  auto result = deserializeTablet(10, {{0, chunk1}, {1, chunk2}});
 
   ASSERT_EQ(result.size(), 2);
   EXPECT_EQ(result[0].second, payload1);
@@ -1776,7 +1776,7 @@ TEST_F(LZ4RoundtripTest, streamDataReaderLZ4MultipleChunks) {
   std::string part2 = "second chunk of lz4 compressed data here";
   auto stream = concatChunks(
       {buildLZ4CompressedChunk(part1), buildLZ4CompressedChunk(part2)});
-  auto result = deserializeTabletRaw(10, {{0, stream}});
+  auto result = deserializeTablet(10, {{0, stream}});
 
   ASSERT_EQ(result.size(), 1);
   EXPECT_EQ(result[0].first, 0);
@@ -1791,7 +1791,7 @@ TEST_F(LZ4RoundtripTest, streamDataReaderLZ4MixedWithUncompressed) {
       {buildUncompressedChunk(part1),
        buildLZ4CompressedChunk(part2),
        buildUncompressedChunk(part3)});
-  auto result = deserializeTabletRaw(10, {{0, stream}});
+  auto result = deserializeTablet(10, {{0, stream}});
 
   ASSERT_EQ(result.size(), 1);
   EXPECT_EQ(result[0].first, 0);
@@ -1901,9 +1901,9 @@ TEST_F(LZ4RoundtripTest, encodeDecodeLZ4HighCompression) {
 }
 
 // Exercises the StreamDataReader::initialize path (delegates to the shared
-// readTabletChunkFieldsAfterVersion helper) on forged kTabletRaw input.
+// readTabletChunkFieldsAfterVersion helper) on forged kTablet input.
 // Uses the WriteHeaderTest fixture purely for its initialized MemoryPool.
-class StreamDataReaderTabletRawTest : public WriteHeaderTest {
+class StreamDataReaderTabletTest : public WriteHeaderTest {
  protected:
   void expectInitializeThrows(const std::string& buf) {
     DeserializerOptions options;
@@ -1915,9 +1915,9 @@ class StreamDataReaderTabletRawTest : public WriteHeaderTest {
   }
 };
 
-TEST_F(StreamDataReaderTabletRawTest, rejectsRowRangeExceedingRowCount) {
+TEST_F(StreamDataReaderTabletTest, rejectsRowRangeExceedingRowCount) {
   std::string buf;
-  buf.push_back(static_cast<char>(SerializationVersion::kTabletRaw));
+  buf.push_back(static_cast<char>(SerializationVersion::kTablet));
   buf.push_back(0x05); // rowCount = 5
   buf.push_back(0x00); // startRow = 0
   buf.push_back(0x64); // endRow = 100 (> rowCount)
@@ -1925,9 +1925,9 @@ TEST_F(StreamDataReaderTabletRawTest, rejectsRowRangeExceedingRowCount) {
   expectInitializeThrows(buf);
 }
 
-TEST_F(StreamDataReaderTabletRawTest, rejectsInvertedRowRange) {
+TEST_F(StreamDataReaderTabletTest, rejectsInvertedRowRange) {
   std::string buf;
-  buf.push_back(static_cast<char>(SerializationVersion::kTabletRaw));
+  buf.push_back(static_cast<char>(SerializationVersion::kTablet));
   buf.push_back(0x0a); // rowCount = 10
   buf.push_back(0x05); // startRow = 5
   buf.push_back(0x03); // endRow = 3
@@ -1935,11 +1935,11 @@ TEST_F(StreamDataReaderTabletRawTest, rejectsInvertedRowRange) {
   expectInitializeThrows(buf);
 }
 
-TEST_F(StreamDataReaderTabletRawTest, rejectsTruncatedResumeKey) {
+TEST_F(StreamDataReaderTabletTest, rejectsTruncatedResumeKey) {
   // Valid version + rowCount + row range + resumeKeyLength=4 (declares a
   // 3-byte key), but only 1 byte of resume key follows.
   std::string buf;
-  buf.push_back(static_cast<char>(SerializationVersion::kTabletRaw));
+  buf.push_back(static_cast<char>(SerializationVersion::kTablet));
   buf.push_back(0x0a); // rowCount = 10
   buf.push_back(0x00); // startRow = 0
   buf.push_back(0x05); // endRow = 5

--- a/dwio/nimble/velox/index/NimbleIndexProjector.cpp
+++ b/dwio/nimble/velox/index/NimbleIndexProjector.cpp
@@ -461,7 +461,7 @@ void NimbleIndexProjector::setResumeKeys(
 
 namespace {
 
-/// Builds a kTabletRaw IOBuf chain: [header] -> [shared body+trailer].
+/// Builds a kTablet IOBuf chain: [header] -> [shared body+trailer].
 folly::IOBuf assembleChunk(
     uint32_t numRows,
     RowRange rowRange,

--- a/dwio/nimble/velox/index/NimbleIndexProjector.h
+++ b/dwio/nimble/velox/index/NimbleIndexProjector.h
@@ -43,7 +43,7 @@ using Subfield = velox::common::Subfield;
 /// Nimble cluster index to locate relevant stripes and row ranges, then reads
 /// and serializes the projected columns for transport.
 ///
-/// The output uses kTabletRaw serialization format with a fixed-shape
+/// The output uses kTablet serialization format with a fixed-shape
 /// per-slice header in front of the stripe body+trailer:
 ///   NODE 1 (per-slice header):
 ///     [version:1B=3][rowCount:varint]
@@ -64,7 +64,7 @@ using Subfield = velox::common::Subfield;
 ///   for (size_t i = 0; i < result.responses.size(); ++i) {
 ///     const auto& response = result.responses[i];
 ///     for (const auto& chunkSlice : response.chunks) {
-///       // `chunkSlice` is a self-describing kTabletRaw IOBuf chain with
+///       // `chunkSlice` is a self-describing kTablet IOBuf chain with
 ///       // the request's row range and (on the last slice of a truncated
 ///       // response) the resume key embedded in the header.
 ///     }
@@ -112,7 +112,7 @@ class NimbleIndexProjector {
 
   /// Response for a single request.
   struct Response {
-    /// One self-describing kTabletRaw IOBuf chain per (request × stripe)
+    /// One self-describing kTablet IOBuf chain per (request × stripe)
     /// intersection. Each entry covers a contiguous row range within one
     /// stripe; the row range is embedded in the chain's header. Empty for
     /// miss. Chunk slices for overlapping requests share the body+trailer
@@ -186,7 +186,7 @@ class NimbleIndexProjector {
     velox::CpuWallTiming lookupTiming;
     /// Time spent loading stripe stream data from tablet.
     velox::CpuWallTiming scanTiming;
-    /// Time spent serializing projected streams into kTabletRaw format.
+    /// Time spent serializing projected streams into kTablet format.
     velox::CpuWallTiming projectionTiming;
 
     std::string toString() const;
@@ -261,7 +261,7 @@ class NimbleIndexProjector {
   // maxRowsPerRequest budget. Returns false if no active requests remain.
   bool pruneStripeRowRanges(std::span<const StripeRowRange> stripeRowRanges);
 
-  // Loads projected streams for the stripe, serializes them into kTabletRaw
+  // Loads projected streams for the stripe, serializes them into kTablet
   // format, and maps the result to per-request row ranges. Returns false if
   // a global limit (maxRows or maxBytes) was hit, signaling the caller to
   // stop and set resume keys.
@@ -287,7 +287,7 @@ class NimbleIndexProjector {
     RowRange rowRange;
   };
 
-  // Stitches loaded raw stream bytes into the shared kTabletRaw body+trailer
+  // Stitches loaded raw stream bytes into the shared kTablet body+trailer
   // (stream data + trailer) without decode/re-encode. The returned chunk has
   // a default-constructed rowRange that buildStripeResult fills in per request.
   ResultChunk serializeStripe(uint32_t stripeIndex, InputStreams& inputStreams);

--- a/dwio/nimble/velox/index/tests/NimbleIndexProjectorTest.cpp
+++ b/dwio/nimble/velox/index/tests/NimbleIndexProjectorTest.cpp
@@ -465,7 +465,7 @@ TEST_P(NimbleIndexProjectorTest, multipleRequests) {
 
 TEST_P(NimbleIndexProjectorTest, overlappingRequestsShareBody) {
   // Two range scans that hit the same single stripe with different row ranges.
-  // Verify that the per-request kTabletRaw chunk slices share the body+trailer
+  // Verify that the per-request kTablet chunk slices share the body+trailer
   // IOBuf bytes via cloneOne() and carry distinct per-slice header nodes.
   auto rowType = ROW({"key", "value"}, {BIGINT(), INTEGER()});
 
@@ -755,7 +755,7 @@ TEST_P(NimbleIndexProjectorTest, deserializerMultiBatchMixedRanges) {
 }
 
 TEST_P(NimbleIndexProjectorTest, deserializerMultiBatchMixedVersions) {
-  // Mix a kTabletRaw chunk slice (projector output, narrow row range) with
+  // Mix a kTablet chunk slice (projector output, narrow row range) with
   // a kCompactRaw chunk (Serializer output, no row range) in one deserialize
   // call. Verifies the no-range branch of the per-batch loop: when
   // batchRanges[i] is nullopt, numRowsInBatch falls back to batchRows
@@ -779,13 +779,13 @@ TEST_P(NimbleIndexProjectorTest, deserializerMultiBatchMixedVersions) {
   subfields.emplace_back("value");
   auto projector = createProjector(subfields);
 
-  // kTabletRaw batch: range [10, 40) = 30 rows.
+  // kTablet batch: range [10, 40) = 30 rows.
   auto bounds = makeRangeLookup(rowType, {"key"}, 10, 40);
   NimbleIndexProjector::Request request;
   request.keyBounds = {bounds};
   auto result = projector->project(request, {});
   ASSERT_EQ(result.responses[0].chunks.size(), 1u);
-  auto tabletRawOwned = result.responses[0].chunks[0].cloneCoalescedAsValue();
+  auto tabletOwned = result.responses[0].chunks[0].cloneCoalescedAsValue();
 
   // kCompactRaw batch: serialize a 5-row Row<INTEGER> vector matching the
   // projected schema. The Serializer is constructed against the same velox
@@ -814,23 +814,23 @@ TEST_P(NimbleIndexProjectorTest, deserializerMultiBatchMixedVersions) {
 
   std::vector<std::string_view> batches{
       std::string_view(
-          reinterpret_cast<const char*>(tabletRawOwned.data()),
-          tabletRawOwned.length()),
+          reinterpret_cast<const char*>(tabletOwned.data()),
+          tabletOwned.length()),
       kCompactRawBytes,
   };
   VectorPtr output;
   deserializer.deserialize(batches, output);
 
-  // Over-fetch: kTabletRaw batch decodes its full 100 stripe rows;
+  // Over-fetch: kTablet batch decodes its full 100 stripe rows;
   // kCompactRaw batch contributes 5 rows. Concatenation = 105 rows. The
-  // in-range subset of the kTabletRaw batch (positions [10, 40) within the
+  // in-range subset of the kTablet batch (positions [10, 40) within the
   // first 100) carries values[10..39]; the kCompactRaw batch's 5 rows follow.
   ASSERT_EQ(output->size(), 105u);
   auto* rowVec = output->as<velox::RowVector>();
   auto* valueVec = rowVec->childAt(0)->as<velox::FlatVector<int32_t>>();
   for (uint32_t i = 10; i < 40; ++i) {
     EXPECT_EQ(valueVec->valueAt(i), static_cast<int32_t>(i * 10))
-        << "kTabletRaw i=" << i;
+        << "kTablet i=" << i;
   }
   for (uint32_t i = 0; i < 5; ++i) {
     EXPECT_EQ(valueVec->valueAt(100 + i), kCompactRawValues[i])


### PR DESCRIPTION
Summary:

Renames the `kTabletRaw` serialization format to `kTablet` across the nimble serde stack, plus all related identifiers, comments, and docs. The old `kTabletRaw` name created false symmetry with `kCompactRaw` — both ended in "Raw" but meant very different things: `kCompactRaw` is a regular serialization output using raw-encoded stream sizes, while `kTabletRaw` is a projection-only passthrough format with per-slice headers and chunk metadata preserved.

The rename signals "this is structurally different from the other formats" by breaking the parallel — the other names describe an encoding choice (`Legacy`, `Compact`, `CompactRaw`), while `Tablet` describes what the bytes are (passthrough tablet stream content).

This is a comment-and-name change only. The wire format byte stays `3` and on-disk/over-the-wire compatibility is preserved.

Identifier renames:
- `SerializationVersion::kTabletRaw` → `SerializationVersion::kTablet`
- `isTabletRawFormat()` → `isTabletFormat()` (both overloads)
- `TabletRawChunkStripTest` → `TabletChunkStripTest` (test class)
- `serializeTabletRaw()` → `serializeTablet()` (test helper)
- `deserializeTabletRaw()` / `deserializeTabletRawWithDCtx()` → `deserializeTablet()` / `deserializeTabletWithDCtx()` (test helpers)
- `tabletRawVersionRejected`, `tabletRawDeserialization`, `Serializer_TabletRaw` → `tabletVersionRejected`, `tabletDeserialization`, `Serializer_Tablet` (test names)
- `"TabletRawFormat"` test-parameter string → `"TabletFormat"`
- `tabletRaw` / `tabletRawInput` / `tabletRawOwned` local variables → `tablet` / `tabletInput` / `tabletOwned`
- `"tablet_raw_chunk_test"` memory pool name → `"tablet_chunk_test"`
- All comment and doc references to `kTabletRaw` / "tablet raw" updated to `kTablet`.
- `Options.cpp::toString()` returns `"kTablet"` to match the new enum name.
- `Serializer.cpp` error message updated: "kTablet is not supported by the serializer..."

Out of scope: the configerator-side thrift comment at `configerator/structs/datainfra/joiner/sequence_storage_config.thrift:141` ("V3 (tabletRaw):") is an auto-generated mirror and must be updated from the configerator source repo in a separate diff.

Reviewed By: xiaoxmeng

Differential Revision: D106206709


