### PR TITLE
misc: Bump Velox submodule to pick up new ReaderOptions fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ Nimble integrates Velox as a Git submodule, referencing a specific commit of the
 Velox repository. The Velox badge at the top of this README shows the current
 commit and how far behind it is from Velox main.
 
-[See what changed since the current Velox commit.](https://github.com/facebookincubator/velox/compare/d41a22889051fe65ec1ff2ebfa0ee7623c40c220...main)
+[See what changed since the current Velox commit.](https://github.com/facebookincubator/velox/compare/9c406e973b36c0139566ac3128130ebb43c0546c...main)
 <!-- pre-commit check-velox-readme validates the SHA above matches the submodule -->
 
 Advance Velox when your changes depend on code in Velox that


### PR DESCRIPTION
Summary:
Bumps `dwio/nimble/public_tld/velox.submodule.txt` from `d41a22889051fe65ec1ff2ebfa0ee7623c40c220` to `9c406e973b36c0139566ac3128130ebb43c0546c` so the OSS GitHub CI compiles `TabletReader.cpp::configureOptions()` against a Velox that exposes the new `ReaderOptions` accessors used by Nimble.

The OSS build at `nimble/dwio/nimble/tablet/TabletReader.cpp:91-99` was failing with:

```
error: no member named 'preloadIndex' in 'facebook::velox::dwio::common::ReaderOptions'
error: no member named 'pinMetadata' in 'facebook::velox::dwio::common::ReaderOptions'
error: no member named 'cacheMetadata' in 'facebook::velox::dwio::common::ReaderOptions'
error: no member named 'pinIndex' in 'facebook::velox::dwio::common::ReaderOptions'
error: no member named 'cacheIndex' in 'facebook::velox::dwio::common::ReaderOptions'
```

These accessors were added to fbcode Velox in `[nimble]feat: Separate metadata and index caching/pinning into independent controls` (2026-05-19) and `[nimble] Add preloadIndex option to ClusterIndex for eager metadata + key-stream loading` (2026-05-21), after the previous pin (2026-05-15). The new submodule SHA includes both.

README.md compare-link updated in lockstep (the `pre-commit check-velox-readme` hook validates the SHA above matches the submodule).

Note: there are two concurrent draft diffs (D106193640 and D106194168) doing the same bump. This SHA matches D106194168 (V3, vetted across three revisions). If one of those lands first, abandon this diff.

Differential Revision: D106213165
