### PR TITLE
fix(nimble): Assert non-empty row range after clipping in NimbleIndexProjector

### DIFF
--- a/dwio/nimble/velox/index/NimbleIndexProjector.cpp
+++ b/dwio/nimble/velox/index/NimbleIndexProjector.cpp
@@ -368,14 +368,7 @@ bool NimbleIndexProjector::buildStripeResult(
         rowRange.endRow = rowRange.startRow + static_cast<uint32_t>(remaining);
       }
     }
-
-    // Defensive guard: clipping above could in principle produce an empty
-    // range (rowRange.numRows() == 0). The upstream NIMBLE_CHECK_GT keeps
-    // `remaining > 0` today, but skipping empty ranges keeps the chunk
-    // slice list free of zero-row entries if that invariant ever drifts.
-    if (rowRange.numRows() == 0) {
-      continue;
-    }
+    NIMBLE_CHECK_GT(rowRange.numRows(), 0);
 
     // Queue a per-slice clone of the shared body+trailer. The header node
     // (version + rowCount + row range + resume-key-length [+ resume key])


### PR DESCRIPTION
Summary:
Follow-up to D105789279. Replaces the defensive `if (rowRange.numRows() == 0) continue;` skip with `NIMBLE_CHECK_GT(rowRange.numRows(), 0)` to assert the invariant explicitly.

The clipping block above is gated by `options_->maxRowsPerRequest > 0` and `NIMBLE_CHECK_GT(maxRowsPerRequest, rowsPerRequest_[request.requestIndex])` guarantees `remaining > 0`. Combined with the earlier `NIMBLE_CHECK(!request.rowRange.empty())`, the clipped `rowRange` is always non-empty, so silently skipping zero-row ranges hides a contract violation rather than handling a real case. An assertion documents the invariant and surfaces a regression loudly if the upstream guard ever drifts.

Differential Revision: D106216200


