### PR TITLE
refactor: Remove kCompact and clean up serialization header (#775)

### DIFF
--- a/dwio/nimble/serializer/CMakeLists.txt
+++ b/dwio/nimble/serializer/CMakeLists.txt
@@ -22,9 +22,19 @@ target_link_libraries(
   Folly::folly
 )
 
+add_library(nimble_serialization_header SerializationHeader.cpp)
+target_link_libraries(
+  nimble_serialization_header
+  nimble_serializer_options
+  nimble_common
+  nimble_velox_common
+  Folly::folly
+)
+
 add_library(nimble_serializer_impl SerializerImpl.cpp)
 target_link_libraries(
   nimble_serializer_impl
+  nimble_serialization_header
   nimble_serializer_options
   nimble_common
   nimble_encodings
@@ -35,6 +45,7 @@ target_link_libraries(
 add_library(nimble_deserializer_impl DeserializerImpl.cpp)
 target_link_libraries(
   nimble_deserializer_impl
+  nimble_serialization_header
   nimble_serializer_impl
   nimble_serializer_options
   nimble_encodings
@@ -70,6 +81,7 @@ target_link_libraries(
 add_library(nimble_projector Projector.cpp)
 target_link_libraries(
   nimble_projector
+  nimble_serialization_header
   nimble_serializer_options
   nimble_serializer_impl
   nimble_velox_schema_reader

--- a/dwio/nimble/serializer/Deserializer.cpp
+++ b/dwio/nimble/serializer/Deserializer.cpp
@@ -764,7 +764,7 @@ void Deserializer::deserialize(
   // (the producer of row-range-bearing slices), this over-fetch is bounded
   // by stripe boundaries and never crosses users: each chunk slice covers
   // exactly one (request × stripe) intersection. For non-kTabletRaw inputs
-  // (kCompact/kCompactRaw/kLegacy) there's no embedded row range, so
+  // (kCompactRaw/kLegacy) there's no embedded row range, so
   // "over-fetch" doesn't apply — the full batch is decoded as intended.
   //
   // Callers that want only the in-range rows of a kTabletRaw slice can read

--- a/dwio/nimble/serializer/DeserializerImpl.cpp
+++ b/dwio/nimble/serializer/DeserializerImpl.cpp
@@ -24,6 +24,7 @@
 #include "dwio/nimble/common/Varint.h"
 #include "dwio/nimble/encodings/common/EncodingFactory.h"
 #include "dwio/nimble/encodings/common/EncodingPrimitives.h"
+#include "dwio/nimble/serializer/SerializationHeader.h"
 #include "dwio/nimble/serializer/SerializerImpl.h"
 
 namespace facebook::nimble::serde {
@@ -255,101 +256,20 @@ StreamDataReader::StreamDataReader(
   NIMBLE_CHECK_NOT_NULL(pool_);
 }
 
-namespace {
-
-// Reads the kTabletRaw chunk fields that follow the version byte:
-//   [rowCount:varint][startRow:varint][endRow:varint]
-//   [resumeKeyLength:varint][resumeKey bytes]
-// Caller has already consumed the version byte. Used by both
-// readTabletChunkHeader (which validates version then delegates) and
-// StreamDataReader::initialize (which reads version via readVersion() then
-// delegates).
-TabletChunkHeader readTabletChunkFieldsAfterVersion(
-    const char*& pos,
-    const char* end) {
-  TabletChunkHeader header;
-  header.rowCount = varint::readVarint32(&pos);
-
-  const uint32_t startRow = varint::readVarint32(&pos);
-  const uint32_t endRow = varint::readVarint32(&pos);
-  NIMBLE_CHECK_LE(
-      startRow, endRow, "Row range startRow must not exceed endRow");
-  NIMBLE_CHECK_LE(
-      endRow,
-      header.rowCount,
-      "Row range endRow must not exceed stripe rowCount");
-  header.rowRange = RowRange{startRow, endRow};
-
-  const uint32_t resumeKeyLength = varint::readVarint32(&pos);
-  if (resumeKeyLength > 0) {
-    const uint32_t resumeKeyBytes = resumeKeyLength - 1;
-    NIMBLE_CHECK_GE(
-        end - pos,
-        static_cast<ptrdiff_t>(resumeKeyBytes),
-        "Truncated resume key payload");
-    header.resumeKey = std::string(pos, resumeKeyBytes);
-    pos += resumeKeyBytes;
-  }
-  return header;
-}
-
-} // namespace
-
-TabletChunkHeader readTabletChunkHeader(const char*& pos, const char* end) {
-  NIMBLE_CHECK_GE(end - pos, 1, "Truncated chunk header (version)");
-  const auto version = static_cast<SerializationVersion>(*pos++);
-  NIMBLE_CHECK_EQ(
-      version,
-      SerializationVersion::kTabletRaw,
-      "Unsupported version for kTabletRaw chunk header");
-  return readTabletChunkFieldsAfterVersion(pos, end);
-}
-
 uint32_t StreamDataReader::initialize(std::string_view data) {
-  // For kTabletRaw inputs, the caller is expected to pass a coalesced or
-  // single-node view of the chunk slice: the per-slice header
-  // (version + rowCount + row range + resume-key-length [+ resume key])
-  // must live contiguously within `data` so the reads below see all of it.
-  // The projector emits the header in a single allocation; consumers that
-  // hand chunk slices to this method should coalesce the IOBuf chain first.
   pos_ = data.data();
   end_ = data.end();
-  rowRange_.reset();
-  readVersion();
-
-  if (version_ == SerializationVersion::kTabletRaw) {
-    auto header = readTabletChunkFieldsAfterVersion(pos_, end_);
-    rowRange_ = header.rowRange;
-    return header.rowCount;
-  }
-  // All other non-legacy formats use varint row count; kLegacy uses fixed u32.
-  if (usesVarintRowCount(version_)) {
-    return varint::readVarint32(&pos_);
-  }
-  return encoding::readUint32(pos_);
-}
-
-void StreamDataReader::readVersion() {
-  if (!options_.hasHeader) {
-    version_ = SerializationVersion::kLegacy;
-    return;
-  }
-  version_ = static_cast<SerializationVersion>(*pos_);
-  NIMBLE_CHECK(
-      version_ == SerializationVersion::kLegacy ||
-          version_ == SerializationVersion::kCompact ||
-          version_ == SerializationVersion::kCompactRaw ||
-          version_ == SerializationVersion::kTabletRaw,
-      "Unsupported version {}",
-      static_cast<uint8_t>(version_));
-  ++pos_;
+  auto header = readSerializationHeader(pos_, end_, options_.hasHeader);
+  version_ = header.version;
+  rowRange_ = header.rowRange;
+  return header.rowCount;
 }
 
 void StreamDataReader::iterateStreams(
     const std::function<void(uint32_t offset, std::string_view data)>&
         callback) {
   if (nonLegacyFormat(version_)) {
-    // kCompact/kCompactRaw/kTabletRaw format: read stream sizes from trailer.
+    // kCompactRaw/kTabletRaw format: read stream sizes from trailer.
     const auto streamSizes = detail::readTrailerStreamSizes(end_);
     const bool tabletRaw = isTabletRawFormat(version_);
 

--- a/dwio/nimble/serializer/DeserializerImpl.h
+++ b/dwio/nimble/serializer/DeserializerImpl.h
@@ -24,6 +24,7 @@
 #include "dwio/nimble/common/Vector.h"
 #include "dwio/nimble/encodings/common/Encoding.h"
 #include "dwio/nimble/serializer/Options.h"
+#include "dwio/nimble/serializer/SerializationHeader.h"
 #include "dwio/nimble/serializer/SerializerImpl.h"
 #include "dwio/nimble/velox/RowRange.h"
 #include "dwio/nimble/velox/SchemaTypes.h"
@@ -32,17 +33,6 @@
 #include "velox/common/memory/Memory.h"
 
 namespace facebook::nimble::serde {
-
-/// Reads the kTabletRaw chunk slice header starting at `*pos` and advances
-/// `*pos` past it (including any resume key bytes). NIMBLE_CHECKs that the
-/// version is kTabletRaw and that the row range satisfies
-/// startRow <= endRow <= rowCount.
-///
-/// Counterpart to the writer-side `createTabletChunkHeader` in
-/// SerializerImpl.h. Used both by NimbleTable.h helpers (extract row range /
-/// resume key from a chunk slice) and by StreamDataReader::initialize (when
-/// the data is kTabletRaw).
-TabletChunkHeader readTabletChunkHeader(const char*& pos, const char* end);
 
 class StreamData {
  public:
@@ -159,8 +149,8 @@ class StreamData {
   velox::memory::MemoryPool* const pool_{nullptr};
   // Whether nimble encoding is enabled. Non-const to allow reset() to change.
   bool encodingEnabled_{false};
-  // Whether encoding headers use varint row counts (true for kCompact/
-  // kCompactRaw) or fixed u32 (false for kTabletRaw). Non-const to allow
+  // Whether encoding headers use varint row counts (true for kCompactRaw) or
+  // fixed u32 (false for kTabletRaw). Non-const to allow
   // reset() to change.
   bool useVarintRowCount_{true};
   // Optional pool for encoding scratch buffers. Owned externally
@@ -234,11 +224,6 @@ class StreamDataReader {
   }
 
  private:
-  // Reads and validates the serialization version from the data header.
-  // Sets version_ from the first byte if hasHeader is true, otherwise defaults
-  // to kLegacy. Advances pos_ past the version byte.
-  void readVersion();
-
   // Strips tablet chunk headers from stream data for kTabletRaw format.
   // Each chunk is: [chunkSize:u32][compressionType:1B][encoded_data...]
   // Returns a view into the original data for single uncompressed chunks

--- a/dwio/nimble/serializer/Options.cpp
+++ b/dwio/nimble/serializer/Options.cpp
@@ -24,8 +24,6 @@ std::string toString(SerializationVersion version) {
   switch (version) {
     case SerializationVersion::kLegacy:
       return "kLegacy";
-    case SerializationVersion::kCompact:
-      return "kCompact";
     case SerializationVersion::kCompactRaw:
       return "kCompactRaw";
     case SerializationVersion::kTabletRaw:

--- a/dwio/nimble/serializer/Options.h
+++ b/dwio/nimble/serializer/Options.h
@@ -40,15 +40,8 @@ namespace facebook::nimble {
 ///   Wire:
 ///   [version:1B][rowCount:u32][size_0:u32][stream_data_0]...[size_N:u32][stream_data_N]
 ///
-/// - kCompact: Nimble encoding with a dense sizes trailer.
-///   Wire: [version:1B][rowCount:varint][stream_data_0]...[stream_data_N]
-///         [encoded_stream_sizes][stream_sizes_encoded_size:u32]
-///   The trailer contains nimble-encoded stream sizes (sizes[i] = byte size
-///   of stream i, 0 for missing) followed by the encoded sizes length (u32).
-///
-/// - kCompactRaw: Same as kCompact but uses raw encoding for stream sizes
-///   instead of the nimble encoding framework. Stream values still use
-///   nimble encoding.
+/// - kCompactRaw: Nimble encoding with raw-encoded stream sizes trailer.
+///   Stream values use nimble encoding; stream sizes use a raw encoding.
 ///   Wire: [version:1B][rowCount:varint][stream_data_0]...[stream_data_N]
 ///         [encodingType:1B][raw_sizes_payload][trailer_size:u32]
 ///   trailer_size = 1 + len(raw_sizes_payload).
@@ -65,25 +58,23 @@ namespace facebook::nimble {
 ///         [encodingType:1B][raw_sizes_payload][trailer_size:u32]
 enum class SerializationVersion : uint8_t {
   kLegacy = 0,
-  kCompact = 1,
   kCompactRaw = 2,
   kTabletRaw = 3,
 };
 
 std::string toString(SerializationVersion version);
 
-/// Returns true if the version is any non-legacy format (kCompact, kCompactRaw,
-/// or kTabletRaw). All non-legacy formats have a version header, encoded
-/// streams, and a stream sizes trailer.
+/// Returns true if the version is any non-legacy format (kCompactRaw or
+/// kTabletRaw). All non-legacy formats have a version header, encoded streams,
+/// and a stream sizes trailer.
 inline bool nonLegacyFormat(SerializationVersion version) {
   return version != SerializationVersion::kLegacy;
 }
 
-/// Returns true if the version uses compact encoding (kCompact or kCompactRaw).
+/// Returns true if the version uses compact encoding (kCompactRaw).
 /// Note: kTabletRaw is NOT a compact format (has chunk headers in streams).
 inline bool isCompactFormat(SerializationVersion version) {
-  return version == SerializationVersion::kCompact ||
-      version == SerializationVersion::kCompactRaw;
+  return version == SerializationVersion::kCompactRaw;
 }
 
 /// Returns true if the version uses raw stream sizes (kCompactRaw or
@@ -114,9 +105,9 @@ inline bool isCompactFormat(std::optional<SerializationVersion> version) {
 }
 
 /// Returns true if the version uses varint for the header row count.
-/// All non-legacy versioned formats (kCompact, kCompactRaw, kTabletRaw) use
-/// varint row counts in the header. The raw stream bodies inside kTabletRaw
-/// may use fixed u32 row counts in their encoding headers.
+/// All non-legacy versioned formats (kCompactRaw, kTabletRaw) use varint row
+/// counts in the header. The raw stream bodies inside kTabletRaw may use fixed
+/// u32 row counts in their encoding headers.
 inline bool usesVarintRowCount(SerializationVersion version) {
   return version != SerializationVersion::kLegacy;
 }
@@ -138,7 +129,7 @@ inline std::ostream& operator<<(
 
 struct SerializerOptions {
   /// Legacy (kLegacy) compression settings. These only apply when version is
-  /// kLegacy or nullopt. For kCompact, compression is controlled by
+  /// kLegacy or nullopt. For kCompactRaw, compression is controlled by
   /// 'compressionOptions' below.
   CompressionType compressionType{CompressionType::Uncompressed};
   uint32_t compressionThreshold{0};
@@ -147,7 +138,7 @@ struct SerializerOptions {
   /// Serialization format version.
   /// - nullopt (default): Legacy format with no version header (kLegacy).
   /// - kLegacy: Legacy compression format.
-  /// - kCompact: Nimble encoding format with dense sizes header.
+  /// - kCompactRaw: Nimble encoding format with raw sizes trailer.
   std::optional<SerializationVersion> version{};
 
   /// Columns that should be encoded as flat maps. Maps column name to a set
@@ -159,7 +150,7 @@ struct SerializerOptions {
   folly::F14FastMap<std::string, std::set<std::string>> flatMapColumns{};
 
   /// Factory for creating encoding selection policies.
-  /// Only used when version is kCompact.
+  /// Only used when version is kCompactRaw.
   /// When encodingLayoutTree is specified, used as fallback for streams or
   /// nested encodings not captured in the layout tree. When encodingLayoutTree
   /// is not specified, used directly for all streams.
@@ -196,8 +187,7 @@ struct SerializerOptions {
   /// Returns the effective serialization version.
   SerializationVersion serializationVersion() const;
 
-  /// Returns true if nimble encoding is enabled (version is kCompact or
-  /// kCompactRaw).
+  /// Returns true if nimble encoding is enabled (version is kCompactRaw).
   bool enableEncoding() const;
 };
 

--- a/dwio/nimble/serializer/Projector.cpp
+++ b/dwio/nimble/serializer/Projector.cpp
@@ -33,8 +33,8 @@ namespace {
 
 // Lightweight adapter for writing small sections (header, trailer) directly
 // into an IOBuf. Satisfies the size()/resize()/data() interface required by
-// detail::extend/writeHeader/writeTrailer. Avoids the std::string → IOBuf
-// copy that would occur if writing into a temporary std::string first.
+// detail::extend/writeSerializationHeader/writeTrailer. Avoids the std::string
+// → IOBuf copy that would occur if writing into a temporary std::string first.
 class IOBufSection {
  public:
   explicit IOBufSection(size_t initialCapacity)
@@ -268,7 +268,7 @@ Projector::Projector(
   NIMBLE_CHECK(!projectSubfields.empty(), "Must project at least one subfield");
   NIMBLE_CHECK(
       isCompactFormat(options_.projectVersion),
-      "Projection output version must be kCompact or kCompactRaw, got: {}",
+      "Projection output version must be kCompactRaw, got: {}",
       options_.projectVersion);
 
   // Update inputSchema_ with projectType names for schema evolution.
@@ -302,12 +302,12 @@ Projector::Projector(
 
 namespace {
 
-// Validates the input version header is kCompact or kCompactRaw.
+// Validates the input version header is kCompactRaw.
 SerializationVersion getAndValidateInputVersion(const folly::IOBuf& input) {
   const auto version = static_cast<SerializationVersion>(*input.data());
   NIMBLE_CHECK(
       isCompactFormat(version),
-      "Input must be kCompact or kCompactRaw format, got: {}",
+      "Input must be kCompactRaw format, got: {}",
       version);
   return version;
 }
@@ -597,8 +597,8 @@ folly::IOBuf Projector::projectContiguous(
 
   // Build header: [version byte][varint rowCount].
   IOBufSection header(
-      detail::estimateHeaderSize(options_.projectVersion, rowCount));
-  detail::writeHeader(header, options_.projectVersion, rowCount);
+      estimateSerializationHeaderSize(options_.projectVersion, rowCount));
+  writeSerializationHeader(header, options_.projectVersion, rowCount);
   auto output = std::move(header).build();
 
   const auto inputStreamSizes = detail::readTrailerStreamSizes(input);
@@ -624,8 +624,8 @@ folly::IOBuf Projector::projectChained(
 
   // Build header: [version byte][varint rowCount].
   IOBufSection header(
-      detail::estimateHeaderSize(options_.projectVersion, rowCount));
-  detail::writeHeader(header, options_.projectVersion, rowCount);
+      estimateSerializationHeaderSize(options_.projectVersion, rowCount));
+  writeSerializationHeader(header, options_.projectVersion, rowCount);
   auto output = std::move(header).build();
 
   const auto inputStreamSizes = detail::readTrailerStreamSizes(input);

--- a/dwio/nimble/serializer/Projector.h
+++ b/dwio/nimble/serializer/Projector.h
@@ -69,8 +69,8 @@ using Subfield = velox::common::Subfield;
 class Projector {
  public:
   struct Options {
-    /// Output serialization format version. Must be kCompact or kCompactRaw.
-    SerializationVersion projectVersion{SerializationVersion::kCompact};
+    /// Output serialization format version. Must be kCompactRaw.
+    SerializationVersion projectVersion{SerializationVersion::kCompactRaw};
 
     /// Encoding type for stream sizes in the trailer.
     /// Supported types: Trivial, Varint, Delta, FixedBitWidth.

--- a/dwio/nimble/serializer/SerializationHeader.cpp
+++ b/dwio/nimble/serializer/SerializationHeader.cpp
@@ -1,0 +1,142 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "dwio/nimble/serializer/SerializationHeader.h"
+
+#include "dwio/nimble/common/Exceptions.h"
+
+namespace facebook::nimble::serde {
+
+namespace {
+
+TabletChunkHeader extractTabletChunkHeader(const char*& pos, const char* end) {
+  TabletChunkHeader header;
+  header.rowCount = varint::readVarint32(&pos);
+
+  const uint32_t startRow = varint::readVarint32(&pos);
+  const uint32_t endRow = varint::readVarint32(&pos);
+  NIMBLE_CHECK_LE(
+      startRow, endRow, "Row range startRow must not exceed endRow");
+  NIMBLE_CHECK_LE(
+      endRow,
+      header.rowCount,
+      "Row range endRow must not exceed stripe rowCount");
+  header.rowRange = RowRange{startRow, endRow};
+
+  const uint32_t resumeKeyLength = varint::readVarint32(&pos);
+  if (resumeKeyLength > 0) {
+    const uint32_t resumeKeyBytes = resumeKeyLength - 1;
+    NIMBLE_CHECK_GE(
+        end - pos,
+        static_cast<ptrdiff_t>(resumeKeyBytes),
+        "Truncated resume key payload");
+    header.resumeKey = std::string(pos, resumeKeyBytes);
+    pos += resumeKeyBytes;
+  }
+  return header;
+}
+
+} // namespace
+
+// ---- Generic serialization header ----
+
+SerializationHeader
+readSerializationHeader(const char*& pos, const char* end, bool hasHeader) {
+  SerializationHeader header;
+
+  if (hasHeader) {
+    header.version = static_cast<SerializationVersion>(*pos);
+    NIMBLE_CHECK(
+        header.version == SerializationVersion::kLegacy ||
+            header.version == SerializationVersion::kCompactRaw ||
+            header.version == SerializationVersion::kTabletRaw,
+        "Unsupported version {}",
+        static_cast<uint8_t>(header.version));
+    ++pos;
+  }
+
+  if (isTabletRawFormat(header.version)) {
+    auto tablet = extractTabletChunkHeader(pos, end);
+    header.rowCount = tablet.rowCount;
+    // TODO: consider setting rowRange to nullopt when it covers the full
+    // stripe (startRow==0 && endRow==rowCount) to let consumers skip the
+    // range check.
+    header.rowRange = tablet.rowRange;
+  } else if (usesVarintRowCount(header.version)) {
+    header.rowCount = varint::readVarint32(&pos);
+  } else {
+    header.rowCount = encoding::readUint32(pos);
+  }
+
+  return header;
+}
+
+// ---- Tablet chunk header ----
+
+folly::IOBuf createTabletChunkHeader(const TabletChunkHeader& header) {
+  if (header.resumeKey.has_value()) {
+    NIMBLE_CHECK_LT(
+        header.resumeKey->size(),
+        std::numeric_limits<uint32_t>::max(),
+        "Resume key too large to fit in uint32 length sentinel");
+  }
+  const uint32_t resumeKeyLength = header.resumeKey.has_value()
+      ? static_cast<uint32_t>(header.resumeKey->size() + 1)
+      : 0;
+  size_t headerBytes = /*version=*/sizeof(uint8_t) +
+      varint::varintSize(header.rowCount) +
+      varint::varintSize(header.rowRange.startRow) +
+      varint::varintSize(header.rowRange.endRow) +
+      varint::varintSize(resumeKeyLength);
+  if (resumeKeyLength > 0) {
+    headerBytes += header.resumeKey->size();
+  }
+
+  auto buf = folly::IOBuf::create(headerBytes);
+  auto* pos = reinterpret_cast<char*>(buf->writableData());
+  *pos++ = static_cast<char>(SerializationVersion::kTabletRaw);
+  varint::writeVarint(/*val=*/header.rowCount, &pos);
+  varint::writeVarint(/*val=*/header.rowRange.startRow, &pos);
+  varint::writeVarint(/*val=*/header.rowRange.endRow, &pos);
+  varint::writeVarint(/*val=*/resumeKeyLength, &pos);
+  // resumeKeyLength is encoded as (key.size() + 1) so that 0 means "absent"
+  // and 1 means "present but empty". When resumeKeyLength == 1 the key is
+  // empty and there are zero payload bytes to copy — only the length sentinel
+  // was written above.
+  if (resumeKeyLength > 0) {
+    NIMBLE_CHECK(
+        header.resumeKey.has_value(),
+        "resumeKeyLength > 0 but resumeKey is absent");
+    if (!header.resumeKey->empty()) {
+      // NOLINTNEXTLINE(facebook-security-vulnerable-memcpy)
+      std::memcpy(pos, header.resumeKey->data(), header.resumeKey->size());
+    }
+  }
+  buf->append(headerBytes);
+  return std::move(*buf);
+}
+
+TabletChunkHeader readTabletChunkHeader(const char*& pos, const char* end) {
+  NIMBLE_CHECK_GE(end - pos, 1, "Truncated chunk header (version)");
+  const auto version = static_cast<SerializationVersion>(*pos++);
+  NIMBLE_CHECK(
+      isTabletRawFormat(version),
+      "Expected kTabletRaw version, got: {}",
+      version);
+  return extractTabletChunkHeader(pos, end);
+}
+
+} // namespace facebook::nimble::serde

--- a/dwio/nimble/serializer/SerializationHeader.h
+++ b/dwio/nimble/serializer/SerializationHeader.h
@@ -1,0 +1,117 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <cstdint>
+#include <optional>
+#include <string>
+
+#include "dwio/nimble/common/Exceptions.h"
+#include "dwio/nimble/common/Varint.h"
+#include "dwio/nimble/encodings/common/EncodingPrimitives.h"
+#include "dwio/nimble/serializer/Options.h"
+#include "dwio/nimble/velox/RowRange.h"
+#include "folly/io/IOBuf.h"
+
+namespace facebook::nimble::serde {
+
+// ---- Generic serialization header (all versions) ----
+
+/// Parsed serialization header common to all versions.
+struct SerializationHeader {
+  SerializationVersion version{SerializationVersion::kLegacy};
+  uint32_t rowCount{0};
+  /// Row range embedded in kTabletRaw headers. nullopt for other versions.
+  std::optional<RowRange> rowRange;
+};
+
+namespace detail {
+
+template <typename T>
+char* extend(T& buffer, uint32_t size) {
+  const auto oldSize = buffer.size();
+  buffer.resize(oldSize + size);
+  return buffer.data() + oldSize;
+}
+
+} // namespace detail
+
+/// Reads the serialization header from `*pos`, detecting the version from the
+/// first byte when `hasHeader` is true (otherwise defaults to kLegacy).
+/// Advances `*pos` past all header fields. For kTabletRaw, also reads the
+/// row range and resume key length fields.
+SerializationHeader
+readSerializationHeader(const char*& pos, const char* end, bool hasHeader);
+
+/// Writes a serialization header to buffer.
+/// For kLegacy: writes [optional_version:1B][rowCount:u32]
+/// For kCompactRaw: writes [version:1B][rowCount:varint]
+/// kTabletRaw headers must use createTabletChunkHeader() instead.
+template <typename T>
+void writeSerializationHeader(
+    T& buffer,
+    std::optional<SerializationVersion> version,
+    uint32_t rowCount) {
+  NIMBLE_CHECK(
+      !isTabletRawFormat(version),
+      "kTabletRaw headers must use createTabletChunkHeader()");
+
+  if (version.has_value()) {
+    auto* versionPos = detail::extend(buffer, 1);
+    *versionPos = static_cast<char>(version.value());
+  }
+
+  if (usesVarintRowCount(version)) {
+    auto* rowCountPos = detail::extend(buffer, varint::varintSize(rowCount));
+    varint::writeVarint(rowCount, &rowCountPos);
+  } else {
+    auto* rowCountPos = detail::extend(buffer, sizeof(uint32_t));
+    encoding::writeUint32(rowCount, rowCountPos);
+  }
+}
+
+/// Returns the exact byte size of the serialization header.
+/// Not valid for kTabletRaw — use createTabletChunkHeader() instead.
+inline size_t estimateSerializationHeaderSize(
+    std::optional<SerializationVersion> version,
+    uint32_t rowCount) {
+  NIMBLE_CHECK(
+      !isTabletRawFormat(version),
+      "kTabletRaw headers must use createTabletChunkHeader()");
+  const size_t versionBytes = version.has_value() ? sizeof(uint8_t) : 0;
+  const size_t rowCountBytes = usesVarintRowCount(version)
+      ? varint::varintSize(rowCount)
+      : sizeof(uint32_t);
+  return versionBytes + rowCountBytes;
+}
+
+// ---- Tablet chunk header (kTabletRaw only) ----
+
+/// Parsed fields of a kTabletRaw chunk slice header.
+struct TabletChunkHeader {
+  uint32_t rowCount{0};
+  RowRange rowRange;
+  std::optional<std::string> resumeKey;
+};
+
+/// Builds the kTabletRaw chunk slice header as a freshly-allocated IOBuf.
+folly::IOBuf createTabletChunkHeader(const TabletChunkHeader& header);
+
+/// Reads a kTabletRaw chunk slice header including the version byte.
+TabletChunkHeader readTabletChunkHeader(const char*& pos, const char* end);
+
+} // namespace facebook::nimble::serde

--- a/dwio/nimble/serializer/SerializerImpl.cpp
+++ b/dwio/nimble/serializer/SerializerImpl.cpp
@@ -18,6 +18,8 @@
 
 #include <limits>
 
+#include "dwio/nimble/serializer/SerializationHeader.h"
+
 #include <lz4.h>
 #include <lz4hc.h>
 #include <zstd.h>
@@ -286,47 +288,3 @@ std::vector<std::string_view> parseStreams(
 }
 
 } // namespace facebook::nimble::serde::detail
-
-namespace facebook::nimble::serde {
-
-folly::IOBuf createTabletChunkHeader(const TabletChunkHeader& header) {
-  // resumeKeyLength is varint-encoded as (key.size() + 1) when present so 0
-  // signals absent without a separate flag. Guard the (size + 1) narrowing
-  // to uint32 — a key at SIZE_MAX would silently encode as 0 and decode as
-  // "absent", dropping the key on the wire.
-  if (header.resumeKey.has_value()) {
-    NIMBLE_CHECK_LT(
-        header.resumeKey->size(),
-        std::numeric_limits<uint32_t>::max(),
-        "Resume key too large to fit in uint32 length sentinel");
-  }
-  const uint32_t resumeKeyLength = header.resumeKey.has_value()
-      ? static_cast<uint32_t>(header.resumeKey->size() + 1)
-      : 0;
-  size_t totalSize = sizeof(uint8_t) /* version */ +
-      varint::varintSize(header.rowCount) +
-      varint::varintSize(header.rowRange.startRow) +
-      varint::varintSize(header.rowRange.endRow) +
-      varint::varintSize(resumeKeyLength);
-  if (header.resumeKey.has_value()) {
-    totalSize += header.resumeKey->size();
-  }
-
-  auto buf = folly::IOBuf::create(totalSize);
-  auto* pos = reinterpret_cast<char*>(buf->writableData());
-  *pos++ = static_cast<char>(SerializationVersion::kTabletRaw);
-  varint::writeVarint(/*val=*/header.rowCount, &pos);
-  varint::writeVarint(/*val=*/header.rowRange.startRow, &pos);
-  varint::writeVarint(/*val=*/header.rowRange.endRow, &pos);
-  varint::writeVarint(/*val=*/resumeKeyLength, &pos);
-  if (header.resumeKey.has_value() && !header.resumeKey->empty()) {
-    // The destination IOBuf was allocated with totalSize bytes which include
-    // exactly resumeKey->size() bytes at this position — no overflow.
-    // NOLINTNEXTLINE(facebook-security-vulnerable-memcpy)
-    std::memcpy(pos, header.resumeKey->data(), header.resumeKey->size());
-  }
-  buf->append(totalSize);
-  return std::move(*buf);
-}
-
-} // namespace facebook::nimble::serde

--- a/dwio/nimble/serializer/SerializerImpl.h
+++ b/dwio/nimble/serializer/SerializerImpl.h
@@ -30,6 +30,7 @@
 #include "dwio/nimble/encodings/common/EncodingPrimitives.h"
 #include "dwio/nimble/encodings/selection/EncodingSelectionPolicy.h"
 #include "dwio/nimble/serializer/Options.h"
+#include "dwio/nimble/serializer/SerializationHeader.h"
 #include "dwio/nimble/velox/RowRange.h"
 #include "dwio/nimble/velox/StreamData.h"
 #include "folly/io/Cursor.h"
@@ -75,13 +76,6 @@ void writeMissingStreams(T& buffer, uint32_t lastStream, uint32_t nextStream) {
   }
 }
 
-template <typename T>
-char* extend(T& buffer, uint32_t size) {
-  const auto oldSize = buffer.size();
-  buffer.resize(oldSize + size);
-  return buffer.data() + oldSize;
-}
-
 /// Encode typed values using a given encoding selection policy factory.
 /// When encodingLayout is provided, replays the captured encoding with
 /// compressionOptions. policyFactory is used as fallback for nested encodings
@@ -115,99 +109,6 @@ std::string_view encodeTyped(
 inline uint32_t readTrailerSize(const char* end) {
   const char* pos = end - sizeof(uint32_t);
   return encoding::readUint32(pos);
-}
-
-/// Returns the byte size of the version header (0 or 1).
-inline size_t versionSize(std::optional<SerializationVersion> version) {
-  return version.has_value() ? sizeof(uint8_t) : 0;
-}
-
-/// Returns the byte size of the row count encoding for the given version.
-/// All non-legacy formats use varint; kLegacy uses fixed u32.
-inline size_t rowCountSize(
-    std::optional<SerializationVersion> version,
-    uint32_t rowCount) {
-  return usesVarintRowCount(version) ? varint::varintSize(rowCount)
-                                     : sizeof(uint32_t);
-}
-
-/// Returns the exact byte size of the serialization header.
-/// Use to pre-allocate buffers before calling writeHeader().
-/// For kTabletRaw, includes the required row range (2 × varint) and the
-/// resume-key-length sentinel (varint of 0 = absent) that writeHeader
-/// auto-emits — see writeHeader docs.
-inline size_t estimateHeaderSize(
-    std::optional<SerializationVersion> version,
-    uint32_t rowCount) {
-  size_t size = versionSize(version) + rowCountSize(version, rowCount);
-  if (version.has_value() &&
-      version.value() == SerializationVersion::kTabletRaw) {
-    // [startRow:varint=0][endRow:varint=rowCount][resumeKeyLength:varint=0]
-    size += varint::varintSize(uint32_t{0}) + varint::varintSize(rowCount) +
-        varint::varintSize(uint32_t{0});
-  }
-  return size;
-}
-
-/// Writes serialization header to buffer.
-/// Works with any buffer type that has size(), resize(), and data() methods.
-///
-/// kLegacy wire format:
-///   [version:1B][rowCount:u32][size_0:u32][stream_data_0]...[size_N:u32][stream_data_N]
-///
-/// kCompact wire format:
-///   [version:1B][rowCount:varint][stream_data_0][stream_data_1]...[encoded_stream_sizes][stream_sizes_encoded_size:u32]
-///
-/// For kLegacy: writes [optional_version:1B][rowCount:u32]
-/// For kCompact/kCompactRaw: writes [version:1B][rowCount:varint]
-/// For kTabletRaw: writes
-///   [version:1B][rowCount:varint][startRow:varint=0][endRow:varint=rowCount]
-///   [resumeKeyLength:varint=0]
-///   The default row range covers the whole stripe; resumeKeyLength=0 means
-///   no resume key. Producers that need a narrower range or a resume key use
-///   serde::createTabletChunkHeader instead of writeHeader.
-///
-/// @param buffer Output buffer (std::string, velox::Buffer, etc.)
-/// @param version Serialization format version (nullopt = no version byte)
-/// @param rowCount Number of rows
-template <typename T>
-void writeHeader(
-    T& buffer,
-    std::optional<SerializationVersion> version,
-    uint32_t rowCount) {
-  // Write version byte if provided.
-  if (version.has_value()) {
-    auto* versionPos = extend(buffer, 1);
-    *versionPos = static_cast<char>(version.value());
-  }
-
-  if (usesVarintRowCount(version)) {
-    auto* rowCountPos = extend(buffer, varint::varintSize(rowCount));
-    varint::writeVarint(rowCount, &rowCountPos);
-  } else {
-    auto* rowCountPos = extend(buffer, sizeof(uint32_t));
-    encoding::writeUint32(rowCount, rowCountPos);
-  }
-
-  // kTabletRaw requires a row range and a resume-key-length varint; the
-  // default row range covers the whole stripe and resumeKeyLength=0 signals
-  // no key. Producers that need narrower ranges or a resume key use
-  // serde::createTabletChunkHeader directly instead.
-  //
-  // WIRE-FORMAT INVARIANT: the bytes emitted here MUST stay in lockstep with
-  // serde::createTabletChunkHeader (see SerializerImpl.cpp). Both produce
-  // the kTabletRaw chunk slice header; any field added to one must be added
-  // to the other, and to readTabletChunkHeader + StreamDataReader::initialize.
-  if (version.has_value() &&
-      version.value() == SerializationVersion::kTabletRaw) {
-    constexpr uint32_t kStartRow = 0;
-    auto* startRowPos = extend(buffer, varint::varintSize(kStartRow));
-    varint::writeVarint(kStartRow, &startRowPos);
-    auto* endRowPos = extend(buffer, varint::varintSize(rowCount));
-    varint::writeVarint(rowCount, &endRowPos);
-    auto* resumeKeyLenPos = extend(buffer, varint::varintSize(uint32_t{0}));
-    varint::writeVarint(uint32_t{0}, &resumeKeyLenPos);
-  }
 }
 
 /// Returns an upper-bound estimate of the trailer size.
@@ -423,7 +324,7 @@ std::vector<uint32_t> readTrailerStreamSizes(const folly::IOBuf& input);
 /// Returns a vector of stream data indexed by their original offset.
 ///
 /// For kLegacy: Returns streams in order with inline u32 sizes.
-/// For kCompact: Returns streams indexed by their offset from sizes header.
+/// For kCompactRaw: Returns streams indexed by their offset from sizes header.
 ///
 /// @param pos Pointer past the header (version + rowCount already read)
 /// @param end End of buffer
@@ -509,48 +410,10 @@ std::string_view encodeScalar(
 }
 } // namespace detail
 
-/// Parsed fields of a kTabletRaw chunk slice header. Row range is required;
-/// resume key is optional (length-0 sentinel encoded on the wire).
-struct TabletChunkHeader {
-  uint32_t rowCount{0};
-  RowRange rowRange;
-  std::optional<std::string> resumeKey;
-};
-
-/// Minimum byte size of a kTabletRaw chunk slice header: version byte +
-/// 1-byte varint rowCount + 1-byte varint startRow + 1-byte varint endRow +
-/// 1-byte varint resumeKeyLength=0. All fields use varint, so larger values
-/// (or a present resume key) add bytes; callers track the extras separately
-/// for byte accounting.
-constexpr size_t kMinTabletChunkHeaderSize = sizeof(uint8_t) /* version */ +
-    1 /* rowCount varint (lower bound) */ +
-    1 /* startRow varint (lower bound) */ +
-    1 /* endRow varint (lower bound) */ +
-    1 /* resumeKeyLength varint (0 = no key) */;
-
-/// Builds the kTabletRaw chunk slice header as a freshly-allocated IOBuf.
-/// Used by NimbleIndexProjector to emit the per-slice header that prefixes
-/// each chunk slice's IOBuf chain. Wire layout:
-///   [version:1B = kTabletRaw][rowCount:varint]
-///   [startRow:varint][endRow:varint]
-///   [resumeKeyLength:varint][resumeKey]
-///
-/// `resumeKeyLength` is varint-encoded as `key.size() + 1` when a resume key
-/// is present (so 1 means an empty key, N>0 means a key of length N-1), and
-/// 0 when no resume key is present. This distinguishes "no key" from "empty
-/// key" without a separate flag.
-///
-/// The returned IOBuf is sized exactly to the header bytes (no headroom or
-/// trailing capacity).
-folly::IOBuf createTabletChunkHeader(const TabletChunkHeader& header);
-
-// Reader-side counterpart `readTabletChunkHeader(pos, end)` lives in
-// DeserializerImpl.h.
-
 template <typename T>
 class StreamDataWriter {
  public:
-  /// Constructor. For kLegacy, writes the header immediately. For kCompact,
+  /// Constructor. For kLegacy, writes the header immediately. For kCompactRaw,
   /// writes the header prefix (version + rowCount).
   ///
   /// @param pool Memory pool for encoding buffer allocation.
@@ -567,11 +430,11 @@ class StreamDataWriter {
 
   /// Write encoded data for a single stream.
   /// For both formats, writes directly to buffer.
-  /// For kCompact, also tracks stream sizes for the trailer.
+  /// For kCompactRaw, also tracks stream sizes for the trailer.
   void writeData(const nimble::StreamData& streamData);
 
   /// Close the writer. For kLegacy, fills trailing zeros up to nodeCount.
-  /// For kCompact, writes the trailer (encoded sizes).
+  /// For kCompactRaw, writes the trailer (encoded sizes).
   void close(uint32_t nodeCount = 0);
 
  private:
@@ -623,7 +486,7 @@ StreamDataWriter<T>::StreamDataWriter(
   if (options_.hasVersionHeader()) {
     version = options_.serializationVersion();
   }
-  detail::writeHeader(buffer_, version, rowCount);
+  writeSerializationHeader(buffer_, version, rowCount);
 }
 
 template <typename T>

--- a/dwio/nimble/serializer/tests/CMakeLists.txt
+++ b/dwio/nimble/serializer/tests/CMakeLists.txt
@@ -15,6 +15,7 @@ add_executable(
   nimble_serializer_tests
   OptionsTest.cpp
   ProjectorTest.cpp
+  SerializationHeaderTest.cpp
   SerializationTest.cpp
   SerializerImplTest.cpp
 )
@@ -22,6 +23,7 @@ add_test(nimble_serializer_tests nimble_serializer_tests)
 
 target_link_libraries(
   nimble_serializer_tests
+  nimble_serialization_header
   nimble_serializer
   nimble_deserializer
   nimble_deserializer_impl

--- a/dwio/nimble/serializer/tests/OptionsTest.cpp
+++ b/dwio/nimble/serializer/tests/OptionsTest.cpp
@@ -24,14 +24,12 @@ using namespace facebook::nimble;
 TEST(OptionsTest, serializationVersionEnumValues) {
   // Verify enum underlying values match expected wire format versions.
   EXPECT_EQ(static_cast<uint8_t>(SerializationVersion::kLegacy), 0);
-  EXPECT_EQ(static_cast<uint8_t>(SerializationVersion::kCompact), 1);
   EXPECT_EQ(static_cast<uint8_t>(SerializationVersion::kCompactRaw), 2);
   EXPECT_EQ(static_cast<uint8_t>(SerializationVersion::kTabletRaw), 3);
 }
 
 TEST(OptionsTest, toStringVersion) {
   EXPECT_EQ(toString(SerializationVersion::kLegacy), "kLegacy");
-  EXPECT_EQ(toString(SerializationVersion::kCompact), "kCompact");
   EXPECT_EQ(toString(SerializationVersion::kCompactRaw), "kCompactRaw");
   EXPECT_EQ(toString(SerializationVersion::kTabletRaw), "kTabletRaw");
 }
@@ -83,21 +81,11 @@ TEST(OptionsTest, serializerOptionsWithLegacyVersion) {
   EXPECT_FALSE(options.enableEncoding());
 }
 
-TEST(OptionsTest, serializerOptionsWithDenseVersion) {
-  SerializerOptions options{.version = SerializationVersion::kCompact};
-
-  EXPECT_TRUE(options.version.has_value());
-  EXPECT_EQ(*options.version, SerializationVersion::kCompact);
-  EXPECT_TRUE(options.hasVersionHeader());
-  EXPECT_EQ(options.serializationVersion(), SerializationVersion::kCompact);
-  EXPECT_TRUE(options.enableEncoding());
-}
-
 TEST(OptionsTest, serializerOptionsWithFlatMapColumns) {
   SerializerOptions options{
       .compressionType = CompressionType::Zstd,
       .compressionLevel = 3,
-      .version = SerializationVersion::kCompact,
+      .version = SerializationVersion::kCompactRaw,
       .flatMapColumns = {{"col1", {}}, {"col2", {}}},
   };
 
@@ -133,14 +121,12 @@ TEST(OptionsTest, serializerOptionsWithCompactRawVersion) {
 
 TEST(OptionsTest, nonLegacyFormat) {
   EXPECT_FALSE(nonLegacyFormat(SerializationVersion::kLegacy));
-  EXPECT_TRUE(nonLegacyFormat(SerializationVersion::kCompact));
   EXPECT_TRUE(nonLegacyFormat(SerializationVersion::kCompactRaw));
   EXPECT_TRUE(nonLegacyFormat(SerializationVersion::kTabletRaw));
 }
 
 TEST(OptionsTest, isCompactFormat) {
   EXPECT_FALSE(isCompactFormat(SerializationVersion::kLegacy));
-  EXPECT_TRUE(isCompactFormat(SerializationVersion::kCompact));
   EXPECT_TRUE(isCompactFormat(SerializationVersion::kCompactRaw));
   EXPECT_FALSE(isCompactFormat(SerializationVersion::kTabletRaw));
 }
@@ -148,7 +134,6 @@ TEST(OptionsTest, isCompactFormat) {
 TEST(OptionsTest, isCompactFormatOptional) {
   EXPECT_FALSE(isCompactFormat(std::nullopt));
   EXPECT_FALSE(isCompactFormat(std::optional{SerializationVersion::kLegacy}));
-  EXPECT_TRUE(isCompactFormat(std::optional{SerializationVersion::kCompact}));
   EXPECT_TRUE(
       isCompactFormat(std::optional{SerializationVersion::kCompactRaw}));
   EXPECT_FALSE(
@@ -157,7 +142,6 @@ TEST(OptionsTest, isCompactFormatOptional) {
 
 TEST(OptionsTest, isTabletRawFormat) {
   EXPECT_FALSE(isTabletRawFormat(SerializationVersion::kLegacy));
-  EXPECT_FALSE(isTabletRawFormat(SerializationVersion::kCompact));
   EXPECT_FALSE(isTabletRawFormat(SerializationVersion::kCompactRaw));
   EXPECT_TRUE(isTabletRawFormat(SerializationVersion::kTabletRaw));
 }
@@ -166,8 +150,6 @@ TEST(OptionsTest, isTabletRawFormatOptional) {
   EXPECT_FALSE(isTabletRawFormat(std::nullopt));
   EXPECT_FALSE(isTabletRawFormat(std::optional{SerializationVersion::kLegacy}));
   EXPECT_FALSE(
-      isTabletRawFormat(std::optional{SerializationVersion::kCompact}));
-  EXPECT_FALSE(
       isTabletRawFormat(std::optional{SerializationVersion::kCompactRaw}));
   EXPECT_TRUE(
       isTabletRawFormat(std::optional{SerializationVersion::kTabletRaw}));
@@ -175,7 +157,6 @@ TEST(OptionsTest, isTabletRawFormatOptional) {
 
 TEST(OptionsTest, usesVarintRowCount) {
   EXPECT_FALSE(usesVarintRowCount(SerializationVersion::kLegacy));
-  EXPECT_TRUE(usesVarintRowCount(SerializationVersion::kCompact));
   EXPECT_TRUE(usesVarintRowCount(SerializationVersion::kCompactRaw));
   EXPECT_TRUE(usesVarintRowCount(SerializationVersion::kTabletRaw));
 }
@@ -184,8 +165,6 @@ TEST(OptionsTest, usesVarintRowCountOptional) {
   EXPECT_FALSE(usesVarintRowCount(std::nullopt));
   EXPECT_FALSE(
       usesVarintRowCount(std::optional{SerializationVersion::kLegacy}));
-  EXPECT_TRUE(
-      usesVarintRowCount(std::optional{SerializationVersion::kCompact}));
   EXPECT_TRUE(
       usesVarintRowCount(std::optional{SerializationVersion::kCompactRaw}));
   EXPECT_TRUE(

--- a/dwio/nimble/serializer/tests/ProjectorTest.cpp
+++ b/dwio/nimble/serializer/tests/ProjectorTest.cpp
@@ -75,39 +75,17 @@ struct FormatParam {
 // Generate all legal input × output version combinations.
 std::vector<FormatParam> allFormatCombinations() {
   return {
-      {SerializationVersion::kCompact, SerializationVersion::kCompact},
-      {SerializationVersion::kCompact, SerializationVersion::kCompactRaw},
-      {SerializationVersion::kCompactRaw, SerializationVersion::kCompact},
       {SerializationVersion::kCompactRaw, SerializationVersion::kCompactRaw},
       // Delta stream sizes encoding for kCompactRaw output.
       {SerializationVersion::kCompactRaw,
        SerializationVersion::kCompactRaw,
        EncodingType::Delta},
-      {SerializationVersion::kCompact,
-       SerializationVersion::kCompactRaw,
-       EncodingType::Delta},
       // Buffer pool disabled variants.
-      {SerializationVersion::kCompact,
-       SerializationVersion::kCompact,
-       EncodingType::Trivial,
-       /*enableBufferPool=*/false},
-      {SerializationVersion::kCompact,
-       SerializationVersion::kCompactRaw,
-       EncodingType::Trivial,
-       /*enableBufferPool=*/false},
-      {SerializationVersion::kCompactRaw,
-       SerializationVersion::kCompact,
-       EncodingType::Trivial,
-       /*enableBufferPool=*/false},
       {SerializationVersion::kCompactRaw,
        SerializationVersion::kCompactRaw,
        EncodingType::Trivial,
        /*enableBufferPool=*/false},
       {SerializationVersion::kCompactRaw,
-       SerializationVersion::kCompactRaw,
-       EncodingType::Delta,
-       /*enableBufferPool=*/false},
-      {SerializationVersion::kCompact,
        SerializationVersion::kCompactRaw,
        EncodingType::Delta,
        /*enableBufferPool=*/false},
@@ -661,7 +639,7 @@ TEST_F(ProjectorTest, incompatibleFormatsRejected) {
   auto subfields = makeSubfields({"a"});
 
   auto inputSchema =
-      getNimbleSchema(type, {.version = SerializationVersion::kCompact});
+      getNimbleSchema(type, {.version = SerializationVersion::kCompactRaw});
 
   // Test kLegacy output version — rejected in constructor.
   NIMBLE_ASSERT_THROW(
@@ -670,7 +648,7 @@ TEST_F(ProjectorTest, incompatibleFormatsRejected) {
           subfields,
           pool_.get(),
           {.projectVersion = SerializationVersion::kLegacy}),
-      "Projection output version must be kCompact");
+      "Projection output version must be kCompactRaw");
 
   // Test kTabletRaw output version — rejected in constructor.
   NIMBLE_ASSERT_THROW(
@@ -679,12 +657,12 @@ TEST_F(ProjectorTest, incompatibleFormatsRejected) {
           subfields,
           pool_.get(),
           {.projectVersion = SerializationVersion::kTabletRaw}),
-      "Projection output version must be kCompact");
+      "Projection output version must be kCompactRaw");
 
   // Test kTabletRaw input — rejected at projection time.
   {
     auto serialized =
-        serialize(vec, type, {.version = SerializationVersion::kCompact});
+        serialize(vec, type, {.version = SerializationVersion::kCompactRaw});
     Projector projector(inputSchema, subfields, pool_.get(), {});
 
     // Patch the version byte to kTabletRaw.
@@ -693,7 +671,7 @@ TEST_F(ProjectorTest, incompatibleFormatsRejected) {
 
     NIMBLE_ASSERT_THROW(
         projector.project(std::string_view(tabletRawInput)),
-        "Input must be kCompact or kCompactRaw");
+        "Input must be kCompactRaw format");
   }
 }
 
@@ -704,7 +682,7 @@ TEST_F(ProjectorTest, emptyProjectionInvalid) {
       {"b", BIGINT()},
   });
 
-  SerializerOptions serOpts{.version = SerializationVersion::kCompact};
+  SerializerOptions serOpts{.version = SerializationVersion::kCompactRaw};
   auto inputSchema = getNimbleSchema(type, serOpts);
 
   // Empty subfields should throw.
@@ -714,7 +692,7 @@ TEST_F(ProjectorTest, emptyProjectionInvalid) {
           inputSchema,
           emptySubfields,
           pool_.get(),
-          {.projectVersion = SerializationVersion::kCompact}),
+          {.projectVersion = SerializationVersion::kCompactRaw}),
       "Must project at least one subfield");
 }
 
@@ -734,7 +712,7 @@ TEST_F(ProjectorTest, fullProjectionPassThrough) {
           makeStringVector({"x", "y", "z"}),
       });
 
-  SerializerOptions serOpts{.version = SerializationVersion::kCompact};
+  SerializerOptions serOpts{.version = SerializationVersion::kCompactRaw};
   auto serialized = serialize(vec, type, serOpts);
   auto inputSchema = getNimbleSchema(type, serOpts);
 
@@ -773,7 +751,7 @@ TEST_F(ProjectorTest, fullProjectionPassThrough) {
 TEST_F(ProjectorTest, unsupportedArraySubscript) {
   auto type = ROW({{"arr", ARRAY(INTEGER())}});
 
-  SerializerOptions serOpts{.version = SerializationVersion::kCompact};
+  SerializerOptions serOpts{.version = SerializationVersion::kCompactRaw};
   auto inputSchema = getNimbleSchema(type, serOpts);
 
   // Array subscripts are not supported.
@@ -784,7 +762,7 @@ TEST_F(ProjectorTest, unsupportedArraySubscript) {
           inputSchema,
           subfields,
           pool_.get(),
-          {.projectVersion = SerializationVersion::kCompact}),
+          {.projectVersion = SerializationVersion::kCompactRaw}),
       "only supported on FlatMap");
 }
 
@@ -792,7 +770,7 @@ TEST_F(ProjectorTest, unsupportedArraySubscript) {
 TEST_F(ProjectorTest, unsupportedMapKeyProjection) {
   auto type = ROW({{"m", MAP(VARCHAR(), INTEGER())}});
 
-  SerializerOptions serOpts{.version = SerializationVersion::kCompact};
+  SerializerOptions serOpts{.version = SerializationVersion::kCompactRaw};
   auto inputSchema = getNimbleSchema(type, serOpts);
 
   // Regular map subscripts are not supported (would need re-encoding).
@@ -803,7 +781,7 @@ TEST_F(ProjectorTest, unsupportedMapKeyProjection) {
           inputSchema,
           subfields,
           pool_.get(),
-          {.projectVersion = SerializationVersion::kCompact}),
+          {.projectVersion = SerializationVersion::kCompactRaw}),
       "only supported on FlatMap");
 }
 
@@ -859,7 +837,7 @@ TEST_F(ProjectorTest, flatMapSerializeDeserializeNoProjction) {
 
   // Serialize with FlatMap encoding.
   SerializerOptions serOpts{
-      .version = SerializationVersion::kCompact,
+      .version = SerializationVersion::kCompactRaw,
       .flatMapColumns = {{"features", {}}},
   };
   auto [serialized, inputSchema] = serializeWithSchema(vec, type, serOpts);
@@ -927,7 +905,7 @@ TEST_F(ProjectorTest, projectEntireFlatMapColumn) {
       std::vector<VectorPtr>{ids, mapVector});
 
   SerializerOptions serOpts{
-      .version = SerializationVersion::kCompact,
+      .version = SerializationVersion::kCompactRaw,
       .flatMapColumns = {{"features", {}}},
   };
   auto [serialized, inputSchema] = serializeWithSchema(vec, type, serOpts);
@@ -939,7 +917,7 @@ TEST_F(ProjectorTest, projectEntireFlatMapColumn) {
           inputSchema,
           subfields,
           pool_.get(),
-          {.projectVersion = SerializationVersion::kCompact}),
+          {.projectVersion = SerializationVersion::kCompactRaw}),
       "Cannot project entire FlatMap column without key subscripts");
 }
 
@@ -995,7 +973,7 @@ TEST_F(ProjectorTest, projectFlatMapAllKeys) {
 
   // Serialize with FlatMap encoding.
   SerializerOptions serOpts{
-      .version = SerializationVersion::kCompact,
+      .version = SerializationVersion::kCompactRaw,
       .flatMapColumns = {{"features", {}}},
   };
   auto [serialized, inputSchema] = serializeWithSchema(vec, type, serOpts);
@@ -1007,7 +985,7 @@ TEST_F(ProjectorTest, projectFlatMapAllKeys) {
       inputSchema,
       subfields,
       pool_.get(),
-      {.projectVersion = SerializationVersion::kCompact});
+      {.projectVersion = SerializationVersion::kCompactRaw});
 
   auto outputSchema = projector.projectedSchema();
   DeserializerOptions deserOpts{.hasHeader = true};
@@ -1085,7 +1063,7 @@ TEST_F(ProjectorTest, flatMapKeyProjectionSchemaComparison) {
       std::vector<VectorPtr>{ids, mapVector});
 
   SerializerOptions serOpts{
-      .version = SerializationVersion::kCompact,
+      .version = SerializationVersion::kCompactRaw,
       .flatMapColumns = {{"features", {}}},
   };
   auto [serialized, inputSchema] = serializeWithSchema(vec, type, serOpts);
@@ -1096,7 +1074,7 @@ TEST_F(ProjectorTest, flatMapKeyProjectionSchemaComparison) {
       inputSchema,
       subfields,
       pool_.get(),
-      {.projectVersion = SerializationVersion::kCompact});
+      {.projectVersion = SerializationVersion::kCompactRaw});
   auto projectorSchema = projector.projectedSchema();
 
   // buildProjectedNimbleType should produce matching FlatMap schema.
@@ -1196,7 +1174,7 @@ TEST_F(ProjectorTest, flatMapFullProjectionSchemaTypeMismatch) {
       std::vector<VectorPtr>{ids, mapVector});
 
   SerializerOptions serOpts{
-      .version = SerializationVersion::kCompact,
+      .version = SerializationVersion::kCompactRaw,
       .flatMapColumns = {{"features", {}}},
   };
   auto [serialized, inputSchema] = serializeWithSchema(vec, type, serOpts);
@@ -1208,7 +1186,7 @@ TEST_F(ProjectorTest, flatMapFullProjectionSchemaTypeMismatch) {
           inputSchema,
           subfields,
           pool_.get(),
-          {.projectVersion = SerializationVersion::kCompact}),
+          {.projectVersion = SerializationVersion::kCompactRaw}),
       "Cannot project entire FlatMap column without key subscripts");
 }
 
@@ -1264,7 +1242,7 @@ TEST_F(ProjectorTest, flatMapStreamIndices) {
 
   // Serialize with FlatMap encoding.
   SerializerOptions serOpts{
-      .version = SerializationVersion::kCompact,
+      .version = SerializationVersion::kCompactRaw,
       .flatMapColumns = {{"features", {}}},
   };
   auto [serialized, inputSchema] = serializeWithSchema(vec, type, serOpts);
@@ -1299,7 +1277,7 @@ TEST_F(ProjectorTest, flatMapStreamIndices) {
       inputSchema,
       subfields,
       pool_.get(),
-      {.projectVersion = SerializationVersion::kCompact});
+      {.projectVersion = SerializationVersion::kCompactRaw});
 
   const auto& indices = projector.testingInputStreamIndices();
   LOG(INFO) << "Projected stream indices: ";
@@ -1388,7 +1366,7 @@ TEST_F(ProjectorTest, projectFlatMapSingleKey) {
   // Use serializeWithSchema to get schema AFTER serialization (when FlatMap
   // keys are discovered).
   SerializerOptions serOpts{
-      .version = SerializationVersion::kCompact,
+      .version = SerializationVersion::kCompactRaw,
       .flatMapColumns = {{"features", {}}},
   };
   auto [serialized, inputSchema] = serializeWithSchema(vec, type, serOpts);
@@ -1399,7 +1377,7 @@ TEST_F(ProjectorTest, projectFlatMapSingleKey) {
       inputSchema,
       subfields,
       pool_.get(),
-      {.projectVersion = SerializationVersion::kCompact});
+      {.projectVersion = SerializationVersion::kCompactRaw});
 
   auto outputSchema = projector.projectedSchema();
 
@@ -1489,7 +1467,7 @@ TEST_F(ProjectorTest, projectFlatMapMultipleKeys) {
   // Serialize with FlatMap encoding.
   // Use serializeWithSchema to get schema AFTER serialization.
   SerializerOptions serOpts{
-      .version = SerializationVersion::kCompact,
+      .version = SerializationVersion::kCompactRaw,
       .flatMapColumns = {{"features", {}}},
   };
   auto [serialized, inputSchema] = serializeWithSchema(vec, type, serOpts);
@@ -1500,7 +1478,7 @@ TEST_F(ProjectorTest, projectFlatMapMultipleKeys) {
       inputSchema,
       subfields,
       pool_.get(),
-      {.projectVersion = SerializationVersion::kCompact});
+      {.projectVersion = SerializationVersion::kCompactRaw});
 
   auto outputSchema = projector.projectedSchema();
 
@@ -1586,7 +1564,7 @@ TEST_F(ProjectorTest, projectFlatMapNonExistentKey) {
 
   // Serialize with FlatMap encoding to discover keys 1, 2, 3.
   SerializerOptions serOpts{
-      .version = SerializationVersion::kCompact,
+      .version = SerializationVersion::kCompactRaw,
       .flatMapColumns = {{"features", {}}},
   };
   auto [serialized, inputSchema] = serializeWithSchema(vec, type, serOpts);
@@ -1600,7 +1578,7 @@ TEST_F(ProjectorTest, projectFlatMapNonExistentKey) {
           inputSchema,
           subfields,
           pool_.get(),
-          {.projectVersion = SerializationVersion::kCompact}),
+          {.projectVersion = SerializationVersion::kCompactRaw}),
       "Cannot project entire FlatMap column without key subscripts");
 }
 
@@ -1613,7 +1591,7 @@ TEST_F(ProjectorTest, streamIndicesCorrect) {
   });
   // Stream 0 is root row nulls.
 
-  SerializerOptions serOpts{.version = SerializationVersion::kCompact};
+  SerializerOptions serOpts{.version = SerializationVersion::kCompactRaw};
   auto inputSchema = getNimbleSchema(type, serOpts);
 
   // Project "b" only - should include streams 0 (root nulls) and 2 (b data).
@@ -1622,7 +1600,7 @@ TEST_F(ProjectorTest, streamIndicesCorrect) {
       inputSchema,
       subfields,
       pool_.get(),
-      {.projectVersion = SerializationVersion::kCompact});
+      {.projectVersion = SerializationVersion::kCompactRaw});
 
   const auto& indices = projector.testingInputStreamIndices();
   ASSERT_EQ(indices.size(), 2);
@@ -1667,7 +1645,7 @@ TEST_F(ProjectorTest, projectWithUpdatedRowType) {
       std::vector<VectorPtr>{ids, names, values});
 
   // Serialize with old column names.
-  SerializerOptions serOpts{.version = SerializationVersion::kCompact};
+  SerializerOptions serOpts{.version = SerializationVersion::kCompactRaw};
   auto [serialized, inputSchema] = serializeWithSchema(vec, inputType, serOpts);
 
   // Query uses new column names from projectType.
@@ -1679,12 +1657,12 @@ TEST_F(ProjectorTest, projectWithUpdatedRowType) {
           inputSchema,
           subfields,
           pool_.get(),
-          {.projectVersion = SerializationVersion::kCompact}),
+          {.projectVersion = SerializationVersion::kCompactRaw}),
       "Field 'new_id' not found in RowType");
 
   // With projectType, name mapping is auto-computed and projection succeeds.
   Projector::Options opts{
-      .projectVersion = SerializationVersion::kCompact,
+      .projectVersion = SerializationVersion::kCompactRaw,
       .projectType = projectType,
   };
   Projector projector(inputSchema, subfields, pool_.get(), opts);
@@ -1778,7 +1756,7 @@ TEST_F(ProjectorTest, projectWithUpdatedNestedRowType) {
 
   // Serialize with FlatMap to discover keys.
   SerializerOptions serOpts{
-      .version = SerializationVersion::kCompact,
+      .version = SerializationVersion::kCompactRaw,
       .flatMapColumns = {{"features", {}}},
   };
   auto [serialized, inputSchema] = serializeWithSchema(vec, inputType, serOpts);
@@ -1792,7 +1770,7 @@ TEST_F(ProjectorTest, projectWithUpdatedNestedRowType) {
         inputSchema,
         subfields,
         pool_.get(),
-        {.projectVersion = SerializationVersion::kCompact});
+        {.projectVersion = SerializationVersion::kCompactRaw});
     const auto& nestedRow = projectorNoType.projectedSchema()
                                 ->asRow()
                                 .childAt(0)
@@ -1804,7 +1782,7 @@ TEST_F(ProjectorTest, projectWithUpdatedNestedRowType) {
 
   // With projectType, nested row field is renamed.
   Projector::Options opts{
-      .projectVersion = SerializationVersion::kCompact,
+      .projectVersion = SerializationVersion::kCompactRaw,
       .projectType = projectType,
   };
   Projector projector(inputSchema, subfields, pool_.get(), opts);
@@ -1896,7 +1874,7 @@ TEST_F(ProjectorTest, projectNestedFieldUnderFlatMapValue) {
       std::vector<VectorPtr>{ids, mapVector});
 
   SerializerOptions serOpts{
-      .version = SerializationVersion::kCompact,
+      .version = SerializationVersion::kCompactRaw,
       .flatMapColumns = {{"features", {}}},
   };
   auto [serialized, inputSchema] = serializeWithSchema(vec, inputType, serOpts);
@@ -1910,7 +1888,7 @@ TEST_F(ProjectorTest, projectNestedFieldUnderFlatMapValue) {
           inputSchema,
           subfields,
           pool_.get(),
-          {.projectVersion = SerializationVersion::kCompact}),
+          {.projectVersion = SerializationVersion::kCompactRaw}),
       "Field 'new_value' not found in RowType");
 
   // With projectType, nested field is renamed and projection succeeds.
@@ -1918,7 +1896,7 @@ TEST_F(ProjectorTest, projectNestedFieldUnderFlatMapValue) {
       inputSchema,
       subfields,
       pool_.get(),
-      {.projectVersion = SerializationVersion::kCompact,
+      {.projectVersion = SerializationVersion::kCompactRaw,
        .projectType = projectType});
 
   for (bool useIOBuf : {false, true}) {
@@ -2018,7 +1996,7 @@ TEST_F(ProjectorTest, projectMultipleFlatMapColumns) {
 
   // Serialize both maps as FlatMaps.
   SerializerOptions serOpts{
-      .version = SerializationVersion::kCompact,
+      .version = SerializationVersion::kCompactRaw,
       .flatMapColumns = {{"map_a", {}}, {"map_b", {}}},
   };
   auto [serialized, inputSchema] = serializeWithSchema(vec, type, serOpts);
@@ -2043,7 +2021,7 @@ TEST_F(ProjectorTest, projectMultipleFlatMapColumns) {
       inputSchema,
       subfields,
       pool_.get(),
-      {.projectVersion = SerializationVersion::kCompact});
+      {.projectVersion = SerializationVersion::kCompactRaw});
 
   auto outputSchema = projector.projectedSchema();
 
@@ -2153,7 +2131,7 @@ TEST_F(ProjectorTestBase, flatMapInMapStreamSkipping) {
   };
 
   SerializerOptions serOpts{
-      .version = SerializationVersion::kCompact,
+      .version = SerializationVersion::kCompactRaw,
       .flatMapColumns = {{"flat_map", {}}},
   };
 
@@ -2283,7 +2261,7 @@ TEST_F(ProjectorTest, chainedIOBufInput) {
           makeStringVector({"x", "y", "z"}),
       });
 
-  SerializerOptions serOpts{.version = SerializationVersion::kCompact};
+  SerializerOptions serOpts{.version = SerializationVersion::kCompactRaw};
   auto serialized = serialize(vec, type, serOpts);
   auto inputSchema = getNimbleSchema(type, serOpts);
 
@@ -2336,7 +2314,7 @@ TEST_F(ProjectorTest, sortedStreamIndicesFastPath) {
           makeStringVector({"x", "y", "z"}),
       });
 
-  SerializerOptions serOpts{.version = SerializationVersion::kCompact};
+  SerializerOptions serOpts{.version = SerializationVersion::kCompactRaw};
   auto serialized = serialize(vec, type, serOpts);
   auto inputSchema = getNimbleSchema(type, serOpts);
 
@@ -2463,7 +2441,7 @@ TEST_F(ProjectorTest, unsortedStreamIndicesReorderPath) {
       pool_.get(), type, nullptr, numRows, std::vector<VectorPtr>{mapA, mapB});
 
   SerializerOptions serOpts{
-      .version = SerializationVersion::kCompact,
+      .version = SerializationVersion::kCompactRaw,
       .flatMapColumns = {{"map_a", {}}, {"map_b", {}}},
   };
   auto [serialized, inputSchema] = serializeWithSchema(vec, type, serOpts);
@@ -2475,7 +2453,7 @@ TEST_F(ProjectorTest, unsortedStreamIndicesReorderPath) {
       inputSchema,
       subfields,
       pool_.get(),
-      {.projectVersion = SerializationVersion::kCompact});
+      {.projectVersion = SerializationVersion::kCompactRaw});
 
   EXPECT_FALSE(projector.testingInputStreamsSorted());
   const auto& indices = projector.testingInputStreamIndices();
@@ -2588,7 +2566,7 @@ TEST_F(ProjectorTest, singleFlatMapSortedFastPath) {
       pool_.get(), type, nullptr, numRows, std::vector<VectorPtr>{ids, mapVec});
 
   SerializerOptions serOpts{
-      .version = SerializationVersion::kCompact,
+      .version = SerializationVersion::kCompactRaw,
       .flatMapColumns = {{"features", {}}},
   };
   auto [serialized, inputSchema] = serializeWithSchema(vec, type, serOpts);
@@ -2599,7 +2577,7 @@ TEST_F(ProjectorTest, singleFlatMapSortedFastPath) {
       inputSchema,
       subfields,
       pool_.get(),
-      {.projectVersion = SerializationVersion::kCompact});
+      {.projectVersion = SerializationVersion::kCompactRaw});
 
   // Single FlatMap with alphabetical keys — indices should be sorted.
   EXPECT_TRUE(projector.testingInputStreamsSorted());
@@ -2634,8 +2612,8 @@ TEST_F(ProjectorTest, projectedTrailerNoCompression) {
   auto type = ROW(std::vector<std::string>(names), extractTypes(children));
   auto vec = makeSimpleRowVector(names, children);
 
-  // Serialize with kCompact.
-  SerializerOptions serOpts{.version = SerializationVersion::kCompact};
+  // Serialize with kCompactRaw.
+  SerializerOptions serOpts{.version = SerializationVersion::kCompactRaw};
   auto serialized = serialize(vec, type, serOpts);
   auto inputSchema = getNimbleSchema(type, serOpts);
 
@@ -2679,7 +2657,7 @@ TEST_F(ProjectorTest, fuzzMixedVersionProjection) {
 
   // Versions to cycle through for each batch.
   const std::vector<SerializerOptions> inputVersions = {
-      {.version = SerializationVersion::kCompact},
+      {.version = SerializationVersion::kCompactRaw},
       {.version = SerializationVersion::kCompactRaw},
       {.version = SerializationVersion::kCompactRaw,
        .streamSizesEncodingType = EncodingType::Delta},
@@ -2687,7 +2665,7 @@ TEST_F(ProjectorTest, fuzzMixedVersionProjection) {
 
   // Output projection versions.
   const std::vector<Projector::Options> outputVersions = {
-      {.projectVersion = SerializationVersion::kCompact},
+      {.projectVersion = SerializationVersion::kCompactRaw},
       {.projectVersion = SerializationVersion::kCompactRaw},
       {.projectVersion = SerializationVersion::kCompactRaw,
        .streamSizesEncodingType = EncodingType::Delta},

--- a/dwio/nimble/serializer/tests/SerializationHeaderTest.cpp
+++ b/dwio/nimble/serializer/tests/SerializationHeaderTest.cpp
@@ -1,0 +1,235 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <limits>
+
+#include <gtest/gtest.h>
+
+#include "dwio/nimble/common/tests/GTestUtils.h"
+#include "dwio/nimble/serializer/SerializationHeader.h"
+
+using namespace facebook::nimble;
+using namespace facebook::nimble::serde;
+
+// ---- SerializationHeader tests ----
+
+TEST(SerializationHeaderTest, writeReadRoundtripLegacy) {
+  std::string buffer;
+  writeSerializationHeader(buffer, SerializationVersion::kLegacy, 42);
+
+  const char* pos = buffer.data();
+  auto header = readSerializationHeader(pos, pos + buffer.size(), true);
+  EXPECT_EQ(header.version, SerializationVersion::kLegacy);
+  EXPECT_EQ(header.rowCount, 42);
+  EXPECT_FALSE(header.rowRange.has_value());
+}
+
+TEST(SerializationHeaderTest, writeReadRoundtripCompactRaw) {
+  std::string buffer;
+  writeSerializationHeader(buffer, SerializationVersion::kCompactRaw, 1000);
+
+  const char* pos = buffer.data();
+  auto header = readSerializationHeader(pos, pos + buffer.size(), true);
+  EXPECT_EQ(header.version, SerializationVersion::kCompactRaw);
+  EXPECT_EQ(header.rowCount, 1000);
+  EXPECT_FALSE(header.rowRange.has_value());
+}
+
+TEST(SerializationHeaderTest, writeReadRoundtripNoHeader) {
+  std::string buffer;
+  writeSerializationHeader(buffer, std::nullopt, 100);
+
+  const char* pos = buffer.data();
+  auto header = readSerializationHeader(pos, pos + buffer.size(), false);
+  EXPECT_EQ(header.version, SerializationVersion::kLegacy);
+  EXPECT_EQ(header.rowCount, 100);
+  EXPECT_FALSE(header.rowRange.has_value());
+}
+
+TEST(SerializationHeaderTest, readTabletRawHeader) {
+  auto iobuf =
+      createTabletChunkHeader({.rowCount = 500, .rowRange = RowRange{10, 200}});
+  const char* pos = reinterpret_cast<const char*>(iobuf.data());
+  const char* end = pos + iobuf.length();
+
+  auto header = readSerializationHeader(pos, end, true);
+  EXPECT_EQ(header.version, SerializationVersion::kTabletRaw);
+  EXPECT_EQ(header.rowCount, 500);
+  ASSERT_TRUE(header.rowRange.has_value());
+  EXPECT_EQ(header.rowRange->startRow, 10);
+  EXPECT_EQ(header.rowRange->endRow, 200);
+}
+
+TEST(SerializationHeaderTest, readRejectsUnsupportedVersion) {
+  std::string buffer;
+  buffer.push_back(static_cast<char>(99));
+  const char* pos = buffer.data();
+  NIMBLE_ASSERT_THROW(
+      readSerializationHeader(pos, pos + buffer.size(), true),
+      "Unsupported version");
+}
+
+TEST(SerializationHeaderTest, writeRejectsTabletRaw) {
+  std::string buffer;
+  NIMBLE_ASSERT_THROW(
+      writeSerializationHeader(buffer, SerializationVersion::kTabletRaw, 100),
+      "kTabletRaw headers must use createTabletChunkHeader()");
+}
+
+TEST(SerializationHeaderTest, estimateRejectsTabletRaw) {
+  NIMBLE_ASSERT_THROW(
+      estimateSerializationHeaderSize(SerializationVersion::kTabletRaw, 100),
+      "kTabletRaw headers must use createTabletChunkHeader()");
+}
+
+TEST(SerializationHeaderTest, estimateSizeMatchesActual) {
+  for (auto version :
+       {std::optional<SerializationVersion>{std::nullopt},
+        std::optional{SerializationVersion::kLegacy},
+        std::optional{SerializationVersion::kCompactRaw}}) {
+    for (uint32_t rowCount : {0u, 1u, 127u, 128u, 16383u, 1000000u}) {
+      std::string buffer;
+      writeSerializationHeader(buffer, version, rowCount);
+      EXPECT_EQ(
+          estimateSerializationHeaderSize(version, rowCount), buffer.size())
+          << "version="
+          << (version.has_value() ? toString(*version) : "nullopt")
+          << " rowCount=" << rowCount;
+    }
+  }
+}
+
+// ---- TabletChunkHeader tests ----
+
+namespace {
+
+TabletChunkHeader roundTripTabletChunkHeader(const TabletChunkHeader& in) {
+  auto buf = createTabletChunkHeader(in);
+  const char* pos = reinterpret_cast<const char*>(buf.data());
+  const char* end = pos + buf.length();
+  auto out = readTabletChunkHeader(pos, end);
+  EXPECT_EQ(pos, end) << "Unexpected trailing bytes after header";
+  return out;
+}
+
+} // namespace
+
+TEST(TabletChunkHeaderTest, noResumeKey) {
+  TabletChunkHeader in{.rowCount = 100, .rowRange = RowRange{0, 100}};
+  const auto out = roundTripTabletChunkHeader(in);
+  EXPECT_EQ(out.rowCount, 100u);
+  EXPECT_EQ(out.rowRange, RowRange(0, 100));
+  EXPECT_FALSE(out.resumeKey.has_value());
+}
+
+TEST(TabletChunkHeaderTest, narrowRowRange) {
+  TabletChunkHeader in{.rowCount = 100, .rowRange = RowRange{10, 40}};
+  const auto out = roundTripTabletChunkHeader(in);
+  EXPECT_EQ(out.rowCount, 100u);
+  EXPECT_EQ(out.rowRange.startRow, 10u);
+  EXPECT_EQ(out.rowRange.endRow, 40u);
+  EXPECT_FALSE(out.resumeKey.has_value());
+}
+
+TEST(TabletChunkHeaderTest, withResumeKey) {
+  TabletChunkHeader in{
+      .rowCount = 100,
+      .rowRange = RowRange{0, 100},
+      .resumeKey = std::string{"my-resume-key"}};
+  const auto out = roundTripTabletChunkHeader(in);
+  EXPECT_EQ(out.rowCount, 100u);
+  EXPECT_EQ(out.rowRange, RowRange(0, 100));
+  ASSERT_TRUE(out.resumeKey.has_value());
+  EXPECT_EQ(*out.resumeKey, "my-resume-key");
+}
+
+TEST(TabletChunkHeaderTest, narrowRangeAndResumeKey) {
+  TabletChunkHeader in{
+      .rowCount = 4096,
+      .rowRange = RowRange{500, 1000},
+      .resumeKey = std::string{"\x00\x01\x02", 3}};
+  const auto out = roundTripTabletChunkHeader(in);
+  EXPECT_EQ(out.rowCount, 4096u);
+  EXPECT_EQ(out.rowRange, RowRange(500, 1000));
+  ASSERT_TRUE(out.resumeKey.has_value());
+  EXPECT_EQ(*out.resumeKey, (std::string{"\x00\x01\x02", 3}));
+}
+
+TEST(TabletChunkHeaderTest, emptyResumeKey) {
+  TabletChunkHeader in{
+      .rowCount = 1, .rowRange = RowRange{0, 1}, .resumeKey = std::string{}};
+  const auto out = roundTripTabletChunkHeader(in);
+  EXPECT_EQ(out.rowCount, 1u);
+  ASSERT_TRUE(out.resumeKey.has_value());
+  EXPECT_TRUE(out.resumeKey->empty());
+}
+
+TEST(TabletChunkHeaderTest, rejectsUnknownVersion) {
+  std::string buf;
+  buf.push_back(static_cast<char>(1));
+  buf.push_back(0x01);
+  const char* pos = buf.data();
+  EXPECT_THROW(
+      readTabletChunkHeader(pos, pos + buf.size()), NimbleInternalError);
+}
+
+TEST(TabletChunkHeaderTest, truncatedVersionByte) {
+  std::string buf;
+  const char* pos = buf.data();
+  EXPECT_THROW(readTabletChunkHeader(pos, pos), NimbleInternalError);
+}
+
+TEST(TabletChunkHeaderTest, roundTripsMaxUint32RowCount) {
+  TabletChunkHeader in{
+      .rowCount = std::numeric_limits<uint32_t>::max(),
+      .rowRange = RowRange{0, std::numeric_limits<uint32_t>::max()},
+  };
+  const auto out = roundTripTabletChunkHeader(in);
+  EXPECT_EQ(out.rowCount, std::numeric_limits<uint32_t>::max());
+  EXPECT_EQ(out.rowRange.startRow, 0u);
+  EXPECT_EQ(out.rowRange.endRow, std::numeric_limits<uint32_t>::max());
+}
+
+TEST(TabletChunkHeaderTest, exactBoundaryEndRowEqualsRowCount) {
+  TabletChunkHeader in{.rowCount = 100, .rowRange = RowRange{99, 100}};
+  const auto out = roundTripTabletChunkHeader(in);
+  EXPECT_EQ(out.rowCount, 100u);
+  EXPECT_EQ(out.rowRange, RowRange(99, 100));
+}
+
+TEST(TabletChunkHeaderTest, rejectsRowRangeExceedingRowCount) {
+  std::string buf;
+  buf.push_back(static_cast<char>(SerializationVersion::kTabletRaw));
+  buf.push_back(0x05); // rowCount = 5
+  buf.push_back(0x00); // startRow = 0
+  buf.push_back(0x64); // endRow = 100 (> rowCount)
+  buf.push_back(0x00); // resumeKeyLength = 0
+  const char* pos = buf.data();
+  EXPECT_THROW(
+      readTabletChunkHeader(pos, pos + buf.size()), NimbleInternalError);
+}
+
+TEST(TabletChunkHeaderTest, rejectsInvertedRowRange) {
+  std::string buf;
+  buf.push_back(static_cast<char>(SerializationVersion::kTabletRaw));
+  buf.push_back(0x0a); // rowCount = 10
+  buf.push_back(0x05); // startRow = 5
+  buf.push_back(0x03); // endRow = 3 (< startRow)
+  buf.push_back(0x00); // resumeKeyLength = 0
+  const char* pos = buf.data();
+  EXPECT_THROW(
+      readTabletChunkHeader(pos, pos + buf.size()), NimbleInternalError);
+}

--- a/dwio/nimble/serializer/tests/SerializationTest.cpp
+++ b/dwio/nimble/serializer/tests/SerializationTest.cpp
@@ -45,8 +45,8 @@ using namespace facebook::nimble;
 using facebook::nimble::test::makeTestTabletOptions;
 
 // Test parameters for parameterized tests.
-// For kCompact mode, we test both with and without compression to exercise the
-// compressionOptions path in ReplayedEncodingSelectionPolicy.
+// For kCompactRaw mode, we test both with and without compression to exercise
+// the compressionOptions path in ReplayedEncodingSelectionPolicy.
 struct TestParams {
   std::optional<SerializationVersion> version;
   // Compression options used with encodingLayoutTree.
@@ -438,9 +438,6 @@ std::string formatName(const ::testing::TestParamInfo<TestParams>& info) {
       case SerializationVersion::kLegacy:
         name = "LegacyFormat";
         break;
-      case SerializationVersion::kCompact:
-        name = "DenseFormat";
-        break;
       case SerializationVersion::kCompactRaw:
         name = "CompactRawFormat";
         break;
@@ -536,9 +533,11 @@ SerializationTest::SerializeResult SerializationTest::serializeTabletRaw(
     const auto stripeRows = tablet->stripeRowCount(stripeIdx);
 
     // Build kTabletRaw: [header][raw stream data...][trailer].
-    std::string headerBuf;
-    serde::detail::writeHeader(
-        headerBuf, nimble::SerializationVersion::kTabletRaw, stripeRows);
+    auto headerIOBuf = serde::createTabletChunkHeader(
+        {.rowCount = stripeRows, .rowRange = RowRange{0, stripeRows}});
+    std::string headerBuf(
+        reinterpret_cast<const char*>(headerIOBuf.data()),
+        headerIOBuf.length());
 
     const auto maxOffset = streamOffsets.back();
     std::string streamData;
@@ -1599,7 +1598,7 @@ TEST_P(SerializationTest, nullsNotSupported) {
         "nulls not supported");
   }
 
-  // Test 4: FlatMap with null value (only for kCompact format).
+  // Test 4: FlatMap with null value (only for kCompactRaw format).
   if (SerializerOptions{.version = version()}.enableEncoding()) {
     auto type = velox::ROW({
         {"id", velox::BIGINT()},
@@ -1822,7 +1821,7 @@ TEST_P(SerializationTest, versionMismatch) {
   auto serialized =
       serializer.serialize(input, OrderedRanges::of(0, input->size()));
 
-  // Try to deserialize with kCompact (expects version header).
+  // Try to deserialize with kCompactRaw (expects version header).
   // The first byte is rowCount (not version), so it will be read as version
   // and fail the version check.
   Deserializer deserializer{
@@ -3144,9 +3143,11 @@ TEST_F(SerializationTest, zstdThreadLocalDCtxHighParallelism) {
     auto streamLoaders = tablet->load(stripeId, streamOffsets);
     const auto stripeRows = tablet->stripeRowCount(stripeIdx);
 
-    std::string headerBuf;
-    serde::detail::writeHeader(
-        headerBuf, nimble::SerializationVersion::kTabletRaw, stripeRows);
+    auto headerIOBuf = serde::createTabletChunkHeader(
+        {.rowCount = stripeRows, .rowRange = RowRange{0, stripeRows}});
+    std::string headerBuf(
+        reinterpret_cast<const char*>(headerIOBuf.data()),
+        headerIOBuf.length());
 
     const auto maxOffset = streamOffsets.back();
     std::string streamData;
@@ -3265,9 +3266,11 @@ TEST_F(SerializationTest, zstdThreadLocalDCtxConcurrentDeserializers) {
       auto streamLoaders = tablet->load(stripeId, streamOffsets);
       const auto stripeRows = tablet->stripeRowCount(si);
 
-      std::string headerBuf;
-      serde::detail::writeHeader(
-          headerBuf, nimble::SerializationVersion::kTabletRaw, stripeRows);
+      auto headerIOBuf = serde::createTabletChunkHeader(
+          {.rowCount = stripeRows, .rowRange = RowRange{0, stripeRows}});
+      std::string headerBuf(
+          reinterpret_cast<const char*>(headerIOBuf.data()),
+          headerIOBuf.length());
 
       const auto maxOffset = streamOffsets.back();
       std::string streamData;
@@ -3435,9 +3438,11 @@ TEST_F(SerializationTest, zstdThreadLocalDCtxFlatMapWithParallelDecode) {
     auto streamLoaders = tablet->load(stripeId, streamOffsets);
     const auto stripeRows = tablet->stripeRowCount(stripeIdx);
 
-    std::string headerBuf;
-    serde::detail::writeHeader(
-        headerBuf, nimble::SerializationVersion::kTabletRaw, stripeRows);
+    auto headerIOBuf = serde::createTabletChunkHeader(
+        {.rowCount = stripeRows, .rowRange = RowRange{0, stripeRows}});
+    std::string headerBuf(
+        reinterpret_cast<const char*>(headerIOBuf.data()),
+        headerIOBuf.length());
 
     const auto maxOffset = streamOffsets.back();
     std::string streamData;
@@ -3554,9 +3559,11 @@ TEST_F(SerializationTest, zstdThreadLocalDCtxRepeatedBatches) {
     auto streamLoaders = tablet->load(stripeId, streamOffsets);
     const auto stripeRows = tablet->stripeRowCount(stripeIdx);
 
-    std::string headerBuf;
-    serde::detail::writeHeader(
-        headerBuf, nimble::SerializationVersion::kTabletRaw, stripeRows);
+    auto headerIOBuf = serde::createTabletChunkHeader(
+        {.rowCount = stripeRows, .rowRange = RowRange{0, stripeRows}});
+    std::string headerBuf(
+        reinterpret_cast<const char*>(headerIOBuf.data()),
+        headerIOBuf.length());
 
     const auto maxOffset = streamOffsets.back();
     std::string streamData;
@@ -4247,7 +4254,7 @@ TEST_P(SerializationTest, flatmapColumnsKeysRejectsRowIngestion) {
 }
 
 // Fuzz test that serializes batches with different versions (cycling through
-// kCompact, kCompactRaw, kCompactRaw+Delta), deserializes each batch, and
+// kCompactRaw, kCompactRaw+Delta), deserializes each batch, and
 // verifies round-trip correctness.
 TEST_F(SerializationTest, fuzzMixedVersionSerialization) {
   auto type = velox::ROW({
@@ -4274,7 +4281,6 @@ TEST_F(SerializationTest, fuzzMixedVersionSerialization) {
 
   // Versions to cycle through for each batch.
   const std::vector<SerializerOptions> serializerVersions = {
-      {.version = SerializationVersion::kCompact},
       {.version = SerializationVersion::kCompactRaw},
       {.version = SerializationVersion::kCompactRaw,
        .streamSizesEncodingType = EncodingType::Delta},
@@ -5002,22 +5008,16 @@ INSTANTIATE_TEST_SUITE_P(
     ::testing::Values(
         // Legacy format (no nimble encoding).
         TestParams{.version = std::nullopt},
-        // kCompact format without compression.
-        TestParams{.version = SerializationVersion::kCompact},
-        // kCompact format with compression enabled (for encodingLayoutTree
+        // kCompactRaw format without compression.
+        TestParams{.version = SerializationVersion::kCompactRaw},
+        // kCompactRaw format with compression enabled (for encodingLayoutTree
         // tests).
         TestParams{
-            .version = SerializationVersion::kCompact,
+            .version = SerializationVersion::kCompactRaw,
             .compressionOptions =
                 CompressionOptions{
                     .compressionAcceptRatio = 1.0f,
                     .zstdMinCompressionSize = 0}},
-        // kCompact format with FixedBitWidth stream sizes encoding.
-        TestParams{
-            .version = SerializationVersion::kCompact,
-            .streamSizesEncodingType = EncodingType::FixedBitWidth},
-        // kCompactRaw format without compression.
-        TestParams{.version = SerializationVersion::kCompactRaw},
         // kCompactRaw format with Delta stream sizes encoding.
         TestParams{
             .version = SerializationVersion::kCompactRaw,
@@ -5029,17 +5029,14 @@ INSTANTIATE_TEST_SUITE_P(
         // Buffer pool disabled variants.
         TestParams{.version = std::nullopt, .enableBufferPool = false},
         TestParams{
-            .version = SerializationVersion::kCompact,
+            .version = SerializationVersion::kCompactRaw,
             .enableBufferPool = false},
         TestParams{
-            .version = SerializationVersion::kCompact,
+            .version = SerializationVersion::kCompactRaw,
             .compressionOptions =
                 CompressionOptions{
                     .compressionAcceptRatio = 1.0f,
                     .zstdMinCompressionSize = 0},
-            .enableBufferPool = false},
-        TestParams{
-            .version = SerializationVersion::kCompactRaw,
             .enableBufferPool = false},
         TestParams{
             .version = SerializationVersion::kCompactRaw,

--- a/dwio/nimble/serializer/tests/SerializerImplTest.cpp
+++ b/dwio/nimble/serializer/tests/SerializerImplTest.cpp
@@ -44,32 +44,20 @@ class WriteHeaderTest : public ::testing::Test {
     pool_ = memory::memoryManager()->addLeafPool("write_header_test");
   }
 
-  // Helper to build a complete kCompact buffer: header + data + trailer.
-  std::string buildCompactHeaderTrailer(
-      uint32_t rowCount,
-      const std::vector<uint32_t>& sizes,
-      EncodingType encodingType = EncodingType::Trivial) {
-    std::string buffer;
-    serde::detail::writeHeader(
-        buffer, SerializationVersion::kCompact, rowCount);
-    serde::detail::writeTrailer(sizes, encodingType, buffer);
-    return buffer;
-  }
-
   // Helper to build a complete kCompactRaw buffer: header + raw trailer.
   std::string buildCompactRawHeaderTrailer(
       uint32_t rowCount,
       const std::vector<uint32_t>& sizes,
       EncodingType encodingType = EncodingType::Trivial) {
     std::string buffer;
-    serde::detail::writeHeader(
+    serde::writeSerializationHeader(
         buffer, SerializationVersion::kCompactRaw, rowCount);
     serde::detail::writeTrailer(sizes, encodingType, buffer);
     return buffer;
   }
 
   // Helper to verify header by writing and parsing back using roundtrip.
-  // For kCompact format, verifies the dense offsets array from trailer.
+  // For kCompactRaw format, verifies the dense offsets array from trailer.
   void verifyHeader(
       const std::string& buffer,
       SerializationVersion expectedVersion,
@@ -82,7 +70,7 @@ class WriteHeaderTest : public ::testing::Test {
     auto actualVersion = static_cast<SerializationVersion>(*pos++);
     EXPECT_EQ(actualVersion, expectedVersion);
 
-    // Read row count. kCompact uses varint, kLegacy uses u32.
+    // Read row count. kCompactRaw uses varint, kLegacy uses u32.
     const bool isCompact = isCompactFormat(expectedVersion);
     uint32_t actualRowCount;
     if (isCompact) {
@@ -92,7 +80,7 @@ class WriteHeaderTest : public ::testing::Test {
     }
     EXPECT_EQ(actualRowCount, expectedRowCount);
 
-    // For kCompact/kCompactRaw, verify stream sizes from trailer.
+    // For kCompactRaw, verify stream sizes from trailer.
     if (isCompactFormat(expectedVersion)) {
       auto actualSizes = serde::detail::readTrailerStreamSizes(end);
       EXPECT_EQ(actualSizes, expectedSizes);
@@ -104,29 +92,8 @@ class WriteHeaderTest : public ::testing::Test {
 
 TEST_F(WriteHeaderTest, legacyFormat) {
   std::string buffer;
-  serde::detail::writeHeader(buffer, SerializationVersion::kLegacy, 100);
+  serde::writeSerializationHeader(buffer, SerializationVersion::kLegacy, 100);
   verifyHeader(buffer, SerializationVersion::kLegacy, 100, {});
-}
-
-TEST_F(WriteHeaderTest, compactFormatWithSizes) {
-  std::vector<uint32_t> sizes = {10, 20, 30};
-  auto buffer = buildCompactHeaderTrailer(200, sizes);
-  verifyHeader(buffer, SerializationVersion::kCompact, 200, sizes);
-}
-
-TEST_F(WriteHeaderTest, compactFormatEmptySizes) {
-  auto buffer = buildCompactHeaderTrailer(10, {});
-  verifyHeader(buffer, SerializationVersion::kCompact, 10, {});
-}
-
-TEST_F(WriteHeaderTest, compactFormatManySizes) {
-  // Sizes array with 200 entries (100 non-zero interleaved with zeros).
-  std::vector<uint32_t> sizes(200, 0);
-  for (uint32_t i = 0; i < 100; ++i) {
-    sizes[i * 2] = i + 1;
-  }
-  auto buffer = buildCompactHeaderTrailer(1000, sizes);
-  verifyHeader(buffer, SerializationVersion::kCompact, 1000, sizes);
 }
 
 TEST_F(WriteHeaderTest, compactRawFormatTrivial) {
@@ -184,13 +151,8 @@ TEST_F(WriteHeaderTest, zeroRowCount) {
   {
     SCOPED_TRACE("kLegacy");
     std::string buffer;
-    serde::detail::writeHeader(buffer, SerializationVersion::kLegacy, 0);
+    serde::writeSerializationHeader(buffer, SerializationVersion::kLegacy, 0);
     verifyHeader(buffer, SerializationVersion::kLegacy, 0, {});
-  }
-  {
-    SCOPED_TRACE("kCompact");
-    auto buffer = buildCompactHeaderTrailer(0, {});
-    verifyHeader(buffer, SerializationVersion::kCompact, 0, {});
   }
   {
     SCOPED_TRACE("kCompactRaw");
@@ -203,23 +165,13 @@ TEST_F(WriteHeaderTest, maxRowCount) {
   {
     SCOPED_TRACE("kLegacy");
     std::string buffer;
-    serde::detail::writeHeader(
+    serde::writeSerializationHeader(
         buffer,
         SerializationVersion::kLegacy,
         std::numeric_limits<uint32_t>::max());
     verifyHeader(
         buffer,
         SerializationVersion::kLegacy,
-        std::numeric_limits<uint32_t>::max(),
-        {});
-  }
-  {
-    SCOPED_TRACE("kCompact");
-    auto buffer =
-        buildCompactHeaderTrailer(std::numeric_limits<uint32_t>::max(), {});
-    verifyHeader(
-        buffer,
-        SerializationVersion::kCompact,
         std::numeric_limits<uint32_t>::max(),
         {});
   }
@@ -237,7 +189,7 @@ TEST_F(WriteHeaderTest, maxRowCount) {
 
 TEST_F(WriteHeaderTest, noVersionHeader) {
   std::string buffer;
-  serde::detail::writeHeader(buffer, std::nullopt, 100);
+  serde::writeSerializationHeader(buffer, std::nullopt, 100);
 
   // No version byte - only row count.
   EXPECT_EQ(buffer.size(), sizeof(uint32_t));
@@ -248,34 +200,6 @@ TEST_F(WriteHeaderTest, noVersionHeader) {
 }
 
 // Tests for estimateHeaderSize
-
-TEST_F(WriteHeaderTest, estimateHeaderSizeCompact) {
-  struct TestParam {
-    uint32_t rowCount;
-    std::string debugString() const {
-      return fmt::format("rowCount {}", rowCount);
-    }
-  };
-  std::vector<TestParam> testSettings = {
-      {0},
-      {1},
-      {127},
-      {128},
-      {16383},
-      {16384},
-      {1000000},
-      {std::numeric_limits<uint32_t>::max()}};
-  for (const auto& testData : testSettings) {
-    SCOPED_TRACE(testData.debugString());
-    std::string buffer;
-    serde::detail::writeHeader(
-        buffer, SerializationVersion::kCompact, testData.rowCount);
-    EXPECT_EQ(
-        serde::detail::estimateHeaderSize(
-            SerializationVersion::kCompact, testData.rowCount),
-        buffer.size());
-  }
-}
 
 TEST_F(WriteHeaderTest, estimateHeaderSizeLegacy) {
   struct TestParam {
@@ -289,10 +213,10 @@ TEST_F(WriteHeaderTest, estimateHeaderSizeLegacy) {
   for (const auto& testData : testSettings) {
     SCOPED_TRACE(testData.debugString());
     std::string buffer;
-    serde::detail::writeHeader(
+    serde::writeSerializationHeader(
         buffer, SerializationVersion::kLegacy, testData.rowCount);
     EXPECT_EQ(
-        serde::detail::estimateHeaderSize(
+        serde::estimateSerializationHeaderSize(
             SerializationVersion::kLegacy, testData.rowCount),
         buffer.size());
   }
@@ -317,10 +241,10 @@ TEST_F(WriteHeaderTest, estimateHeaderSizeCompactRaw) {
   for (const auto& testData : testSettings) {
     SCOPED_TRACE(testData.debugString());
     std::string buffer;
-    serde::detail::writeHeader(
+    serde::writeSerializationHeader(
         buffer, SerializationVersion::kCompactRaw, testData.rowCount);
     EXPECT_EQ(
-        serde::detail::estimateHeaderSize(
+        serde::estimateSerializationHeaderSize(
             SerializationVersion::kCompactRaw, testData.rowCount),
         buffer.size());
   }
@@ -328,9 +252,9 @@ TEST_F(WriteHeaderTest, estimateHeaderSizeCompactRaw) {
 
 TEST_F(WriteHeaderTest, estimateHeaderSizeNoVersion) {
   std::string buffer;
-  serde::detail::writeHeader(buffer, std::nullopt, 100);
+  serde::writeSerializationHeader(buffer, std::nullopt, 100);
   EXPECT_EQ(
-      serde::detail::estimateHeaderSize(std::nullopt, 100), buffer.size());
+      serde::estimateSerializationHeaderSize(std::nullopt, 100), buffer.size());
 }
 
 // Tests for estimateTrailerSize
@@ -571,20 +495,21 @@ TEST_F(ParseStreamsTest, legacyFormatMultipleStreams) {
   EXPECT_EQ(streams[2], "third");
 }
 
-// kCompact format tests use writeHeader/parseStreams roundtrip since
+// kCompactRaw format tests use writeHeader/parseStreams roundtrip since
 // the size encoding is now opaque (nimble-encoded).
 
 TEST_F(ParseStreamsTest, denseFormatEmpty) {
   // Write header + trailer with empty sizes array, then parse.
   std::string buffer;
-  serde::detail::writeHeader(buffer, SerializationVersion::kCompact, 10);
+  serde::writeSerializationHeader(
+      buffer, SerializationVersion::kCompactRaw, 10);
   serde::detail::writeTrailer({}, EncodingType::Trivial, buffer);
 
   auto streams = serde::detail::parseStreams(
       // Skip version byte and row count varint.
       buffer.data() + 1 + varint::varintSize(10),
       buffer.data() + buffer.size(),
-      SerializationVersion::kCompact,
+      SerializationVersion::kCompactRaw,
       pool_.get());
   EXPECT_TRUE(streams.empty());
 }
@@ -598,7 +523,8 @@ TEST_F(ParseStreamsTest, denseFormatSequential) {
   }
 
   std::string buffer;
-  serde::detail::writeHeader(buffer, SerializationVersion::kCompact, 100);
+  serde::writeSerializationHeader(
+      buffer, SerializationVersion::kCompactRaw, 100);
   for (const auto& d : data) {
     buffer.append(d);
   }
@@ -611,7 +537,7 @@ TEST_F(ParseStreamsTest, denseFormatSequential) {
   auto streams = serde::detail::parseStreams(
       pos,
       buffer.data() + buffer.size(),
-      SerializationVersion::kCompact,
+      SerializationVersion::kCompactRaw,
       pool_.get());
 
   ASSERT_EQ(streams.size(), 3);
@@ -626,7 +552,8 @@ TEST_F(ParseStreamsTest, denseFormatWithGaps) {
   std::vector<uint32_t> sizes = {4, 0, 3, 0, 0, 4};
 
   std::string buffer;
-  serde::detail::writeHeader(buffer, SerializationVersion::kCompact, 100);
+  serde::writeSerializationHeader(
+      buffer, SerializationVersion::kCompactRaw, 100);
   buffer.append("zero");
   buffer.append("two");
   buffer.append("five");
@@ -638,7 +565,7 @@ TEST_F(ParseStreamsTest, denseFormatWithGaps) {
   auto streams = serde::detail::parseStreams(
       pos,
       buffer.data() + buffer.size(),
-      SerializationVersion::kCompact,
+      SerializationVersion::kCompactRaw,
       pool_.get());
 
   ASSERT_EQ(streams.size(), 6);
@@ -656,7 +583,8 @@ TEST_F(ParseStreamsTest, denseFormatOnlyLastStream) {
   std::vector<uint32_t> sizes = {0, 0, 0, 0, 5};
 
   std::string buffer;
-  serde::detail::writeHeader(buffer, SerializationVersion::kCompact, 100);
+  serde::writeSerializationHeader(
+      buffer, SerializationVersion::kCompactRaw, 100);
   buffer.append("hello");
   serde::detail::writeTrailer(sizes, EncodingType::Trivial, buffer);
 
@@ -666,7 +594,7 @@ TEST_F(ParseStreamsTest, denseFormatOnlyLastStream) {
   auto streams = serde::detail::parseStreams(
       pos,
       buffer.data() + buffer.size(),
-      SerializationVersion::kCompact,
+      SerializationVersion::kCompactRaw,
       pool_.get());
 
   ASSERT_EQ(streams.size(), 5);
@@ -677,7 +605,7 @@ TEST_F(ParseStreamsTest, denseFormatOnlyLastStream) {
   EXPECT_EQ(streams[4], "hello");
 }
 
-// Tests for readTrailerStreamSizes roundtrip (kCompact).
+// Tests for readTrailerStreamSizes roundtrip (kCompactRaw).
 
 class EncodeDecodeTest : public ::testing::Test {
  protected:
@@ -689,7 +617,7 @@ class EncodeDecodeTest : public ::testing::Test {
     pool_ = memory::memoryManager()->addLeafPool("encode_decode_test");
   }
 
-  // Helper to build a kCompact trailer (encoded sizes + trailer size u32).
+  // Helper to build a kCompactRaw trailer (encoded sizes + trailer size u32).
   std::string buildCompactTrailer(const std::vector<uint32_t>& values) {
     std::string buffer;
     serde::detail::writeTrailer(values, EncodingType::Trivial, buffer);
@@ -745,7 +673,8 @@ TEST_F(EncodeDecodeTest, streamSizesEncodingType) {
     SCOPED_TRACE(toString(encodingType));
 
     std::string buffer;
-    serde::detail::writeHeader(buffer, SerializationVersion::kCompact, 100);
+    serde::writeSerializationHeader(
+        buffer, SerializationVersion::kCompactRaw, 100);
     buffer.append("s0");
     buffer.append("s1");
     buffer.append("s2");
@@ -756,7 +685,7 @@ TEST_F(EncodeDecodeTest, streamSizesEncodingType) {
     auto streams = serde::detail::parseStreams(
         pos,
         buffer.data() + buffer.size(),
-        SerializationVersion::kCompact,
+        SerializationVersion::kCompactRaw,
         pool_.get());
 
     ASSERT_EQ(streams.size(), 3);
@@ -770,7 +699,8 @@ TEST_F(EncodeDecodeTest, streamSizesEncodingTypeDefault) {
   std::vector<uint32_t> sizes = {1, 1, 1};
 
   std::string buffer;
-  serde::detail::writeHeader(buffer, SerializationVersion::kCompact, 100);
+  serde::writeSerializationHeader(
+      buffer, SerializationVersion::kCompactRaw, 100);
   buffer.append("a");
   buffer.append("b");
   buffer.append("c");
@@ -781,7 +711,7 @@ TEST_F(EncodeDecodeTest, streamSizesEncodingTypeDefault) {
   auto streams = serde::detail::parseStreams(
       pos,
       buffer.data() + buffer.size(),
-      SerializationVersion::kCompact,
+      SerializationVersion::kCompactRaw,
       pool_.get());
 
   ASSERT_EQ(streams.size(), 3);
@@ -798,7 +728,8 @@ TEST_F(EncodeDecodeTest, streamSizesEncodingTypeCompactRaw) {
     SCOPED_TRACE(toString(encodingType));
 
     std::string buffer;
-    serde::detail::writeHeader(buffer, SerializationVersion::kCompactRaw, 100);
+    serde::writeSerializationHeader(
+        buffer, SerializationVersion::kCompactRaw, 100);
     buffer.append(std::string(10, 'a'));
     buffer.append(std::string(20, 'b'));
     buffer.append(std::string(30, 'c'));
@@ -893,7 +824,7 @@ std::vector<ProjectedStream> projectStreams(
 
 class ProjectStreamsTest : public ParseStreamsTest {
  protected:
-  // Helper to build a kCompact buffer using writeHeader + raw data.
+  // Helper to build a kCompactRaw buffer using writeHeader + raw data.
   // Takes (streamIndex, data) pairs and builds a dense sizes array.
   // Returns buffer starting after version byte + row count (streams position).
   std::string buildDenseBuffer(
@@ -909,7 +840,8 @@ class ProjectStreamsTest : public ParseStreamsTest {
     }
 
     std::string buffer;
-    serde::detail::writeHeader(buffer, SerializationVersion::kCompact, 100);
+    serde::writeSerializationHeader(
+        buffer, SerializationVersion::kCompactRaw, 100);
 
     // Append raw stream data in index order (only non-zero sizes).
     // Sort by index to ensure correct order.
@@ -1033,7 +965,7 @@ TEST_F(ProjectStreamsTest, denseSelectAll) {
   auto streams = projectStreams(
       buffer.data(),
       buffer.data() + buffer.size(),
-      SerializationVersion::kCompact,
+      SerializationVersion::kCompactRaw,
       selected,
       pool_.get());
 
@@ -1054,7 +986,7 @@ TEST_F(ProjectStreamsTest, denseSelectSubset) {
   auto streams = projectStreams(
       buffer.data(),
       buffer.data() + buffer.size(),
-      SerializationVersion::kCompact,
+      SerializationVersion::kCompactRaw,
       selected,
       pool_.get());
 
@@ -1073,7 +1005,7 @@ TEST_F(ProjectStreamsTest, denseWithGaps) {
   auto streams = projectStreams(
       buffer.data(),
       buffer.data() + buffer.size(),
-      SerializationVersion::kCompact,
+      SerializationVersion::kCompactRaw,
       selected,
       pool_.get());
 
@@ -1092,7 +1024,7 @@ TEST_F(ProjectStreamsTest, denseSelectedNotInInput) {
   auto streams = projectStreams(
       buffer.data(),
       buffer.data() + buffer.size(),
-      SerializationVersion::kCompact,
+      SerializationVersion::kCompactRaw,
       selected,
       pool_.get());
 
@@ -1111,7 +1043,7 @@ TEST_F(ProjectStreamsTest, denseEmpty) {
   auto streams = projectStreams(
       buffer.data(),
       buffer.data() + buffer.size(),
-      SerializationVersion::kCompact,
+      SerializationVersion::kCompactRaw,
       selected,
       pool_.get());
   EXPECT_TRUE(streams.empty());
@@ -1124,7 +1056,7 @@ TEST_F(ProjectStreamsTest, denseSelectFirstAndLast) {
   auto streams = projectStreams(
       buffer.data(),
       buffer.data() + buffer.size(),
-      SerializationVersion::kCompact,
+      SerializationVersion::kCompactRaw,
       selected,
       pool_.get());
 
@@ -1157,7 +1089,7 @@ TEST_F(ProjectStreamsTest, denseSkipsEmptyStreams) {
   auto streams = projectStreams(
       buffer.data(),
       buffer.data() + buffer.size(),
-      SerializationVersion::kCompact,
+      SerializationVersion::kCompactRaw,
       selected,
       pool_.get());
 
@@ -1385,9 +1317,11 @@ class TabletRawChunkStripTest : public ::testing::Test {
     }
 
     // Assemble: [header][stream data][trailer].
-    std::string buffer;
-    serde::detail::writeHeader(
-        buffer, SerializationVersion::kTabletRaw, rowCount);
+    auto headerIOBuf = serde::createTabletChunkHeader(
+        {.rowCount = rowCount, .rowRange = RowRange{0, rowCount}});
+    std::string buffer(
+        reinterpret_cast<const char*>(headerIOBuf.data()),
+        headerIOBuf.length());
     buffer.append(streamData);
     serde::detail::writeTrailer(sizes, EncodingType::Trivial, buffer);
 
@@ -1594,9 +1528,11 @@ class ZstdDCtxReuseTest : public TabletRawChunkStripTest {
       streamData.append(data);
     }
 
-    std::string buffer;
-    serde::detail::writeHeader(
-        buffer, SerializationVersion::kTabletRaw, rowCount);
+    auto headerIOBuf = serde::createTabletChunkHeader(
+        {.rowCount = rowCount, .rowRange = RowRange{0, rowCount}});
+    std::string buffer(
+        reinterpret_cast<const char*>(headerIOBuf.data()),
+        headerIOBuf.length());
     buffer.append(streamData);
     serde::detail::writeTrailer(sizes, EncodingType::Trivial, buffer);
 
@@ -1962,136 +1898,6 @@ TEST_F(LZ4RoundtripTest, encodeDecodeLZ4HighCompression) {
       reinterpret_cast<char*>(output.data()),
       static_cast<uint32_t>(output.size() * sizeof(int32_t)));
   EXPECT_EQ(output, expected);
-}
-
-namespace {
-
-TabletChunkHeader roundTripTabletChunkHeader(const TabletChunkHeader& in) {
-  auto buf = createTabletChunkHeader(in);
-  const char* pos = reinterpret_cast<const char*>(buf.data());
-  const char* end = pos + buf.length();
-  auto out = readTabletChunkHeader(pos, end);
-  EXPECT_EQ(pos, end) << "Unexpected trailing bytes after header";
-  return out;
-}
-
-} // namespace
-
-TEST(TabletChunkHeaderTest, noResumeKey) {
-  TabletChunkHeader in{.rowCount = 100, .rowRange = RowRange{0, 100}};
-  const auto out = roundTripTabletChunkHeader(in);
-  EXPECT_EQ(out.rowCount, 100u);
-  EXPECT_EQ(out.rowRange, RowRange(0, 100));
-  EXPECT_FALSE(out.resumeKey.has_value());
-}
-
-TEST(TabletChunkHeaderTest, narrowRowRange) {
-  TabletChunkHeader in{.rowCount = 100, .rowRange = RowRange{10, 40}};
-  const auto out = roundTripTabletChunkHeader(in);
-  EXPECT_EQ(out.rowCount, 100u);
-  EXPECT_EQ(out.rowRange.startRow, 10u);
-  EXPECT_EQ(out.rowRange.endRow, 40u);
-  EXPECT_FALSE(out.resumeKey.has_value());
-}
-
-TEST(TabletChunkHeaderTest, withResumeKey) {
-  TabletChunkHeader in{
-      .rowCount = 100,
-      .rowRange = RowRange{0, 100},
-      .resumeKey = std::string{"my-resume-key"}};
-  const auto out = roundTripTabletChunkHeader(in);
-  EXPECT_EQ(out.rowCount, 100u);
-  EXPECT_EQ(out.rowRange, RowRange(0, 100));
-  ASSERT_TRUE(out.resumeKey.has_value());
-  EXPECT_EQ(*out.resumeKey, "my-resume-key");
-}
-
-TEST(TabletChunkHeaderTest, narrowRangeAndResumeKey) {
-  TabletChunkHeader in{
-      .rowCount = 4096,
-      .rowRange = RowRange{500, 1000},
-      .resumeKey = std::string{"\x00\x01\x02", 3}};
-  const auto out = roundTripTabletChunkHeader(in);
-  EXPECT_EQ(out.rowCount, 4096u);
-  EXPECT_EQ(out.rowRange, RowRange(500, 1000));
-  ASSERT_TRUE(out.resumeKey.has_value());
-  EXPECT_EQ(*out.resumeKey, (std::string{"\x00\x01\x02", 3}));
-}
-
-TEST(TabletChunkHeaderTest, emptyResumeKey) {
-  // An empty string resume key is distinct from "no resume key": the wire
-  // length is 1 (varint of size+1) vs 0 for absent.
-  TabletChunkHeader in{
-      .rowCount = 1, .rowRange = RowRange{0, 1}, .resumeKey = std::string{}};
-  const auto out = roundTripTabletChunkHeader(in);
-  EXPECT_EQ(out.rowCount, 1u);
-  ASSERT_TRUE(out.resumeKey.has_value());
-  EXPECT_TRUE(out.resumeKey->empty());
-}
-
-TEST(TabletChunkHeaderTest, rejectsUnknownVersion) {
-  // Forge bytes with an unsupported version byte.
-  std::string buf;
-  buf.push_back(static_cast<char>(SerializationVersion::kCompact));
-  buf.push_back(0x01); // rowCount = 1 (varint)
-  const char* pos = buf.data();
-  EXPECT_THROW(
-      readTabletChunkHeader(pos, pos + buf.size()), NimbleInternalError);
-}
-
-TEST(TabletChunkHeaderTest, truncatedVersionByte) {
-  std::string buf;
-  const char* pos = buf.data();
-  EXPECT_THROW(readTabletChunkHeader(pos, pos), NimbleInternalError);
-}
-
-TEST(TabletChunkHeaderTest, roundTripsMaxUint32RowCount) {
-  // Exercises the 5-byte varint encoding path for rowCount and endRow.
-  TabletChunkHeader in{
-      .rowCount = std::numeric_limits<uint32_t>::max(),
-      .rowRange = RowRange{0, std::numeric_limits<uint32_t>::max()},
-  };
-  const auto out = roundTripTabletChunkHeader(in);
-  EXPECT_EQ(out.rowCount, std::numeric_limits<uint32_t>::max());
-  EXPECT_EQ(out.rowRange.startRow, 0u);
-  EXPECT_EQ(out.rowRange.endRow, std::numeric_limits<uint32_t>::max());
-}
-
-TEST(TabletChunkHeaderTest, exactBoundaryEndRowEqualsRowCount) {
-  // Round-trip a row range whose endRow exactly equals rowCount (last-row
-  // boundary). NIMBLE_CHECK_LE permits equality; this exercises the
-  // boundary explicitly.
-  TabletChunkHeader in{.rowCount = 100, .rowRange = RowRange{99, 100}};
-  const auto out = roundTripTabletChunkHeader(in);
-  EXPECT_EQ(out.rowCount, 100u);
-  EXPECT_EQ(out.rowRange, RowRange(99, 100));
-}
-
-TEST(TabletChunkHeaderTest, rejectsRowRangeExceedingRowCount) {
-  // Forge a row range whose endRow exceeds the stripe's rowCount. All
-  // fields are 1-byte varints (values < 128).
-  std::string buf;
-  buf.push_back(static_cast<char>(SerializationVersion::kTabletRaw));
-  buf.push_back(0x05); // rowCount = 5
-  buf.push_back(0x00); // startRow = 0
-  buf.push_back(0x64); // endRow = 100 (> rowCount)
-  buf.push_back(0x00); // resumeKeyLength = 0
-  const char* pos = buf.data();
-  EXPECT_THROW(
-      readTabletChunkHeader(pos, pos + buf.size()), NimbleInternalError);
-}
-
-TEST(TabletChunkHeaderTest, rejectsInvertedRowRange) {
-  // startRow > endRow is invalid. All fields are 1-byte varints.
-  std::string buf;
-  buf.push_back(static_cast<char>(SerializationVersion::kTabletRaw));
-  buf.push_back(0x0a); // rowCount = 10
-  buf.push_back(0x05); // startRow = 5
-  buf.push_back(0x03); // endRow = 3 (< startRow)
-  buf.push_back(0x00); // resumeKeyLength = 0
-  const char* pos = buf.data();
-  EXPECT_THROW(
-      readTabletChunkHeader(pos, pos + buf.size()), NimbleInternalError);
 }
 
 // Exercises the StreamDataReader::initialize path (delegates to the shared

--- a/dwio/nimble/tools/SerializerDumpLib.cpp
+++ b/dwio/nimble/tools/SerializerDumpLib.cpp
@@ -67,7 +67,7 @@ SerializationDump::SerializationStats SerializationDump::serializationStats(
   info.version =
       static_cast<SerializationVersion>(static_cast<uint8_t>(*pos++));
 
-  // Read row count (varint for kCompact).
+  // Read row count (varint for kCompactRaw).
   info.rowCount = varint::readVarint32(&pos);
 
   // Parse stream sizes from trailer.

--- a/dwio/nimble/tools/tests/SerializerDumpLibTest.cpp
+++ b/dwio/nimble/tools/tests/SerializerDumpLibTest.cpp
@@ -46,7 +46,7 @@ TEST_F(SerializerDumpLibTest, BasicStats) {
   auto type = velox::ROW({"a", "b"}, {velox::INTEGER(), velox::BIGINT()});
 
   SerializerOptions options{
-      .version = SerializationVersion::kCompact,
+      .version = SerializationVersion::kCompactRaw,
   };
   Serializer serializer{options, type, leafPool_.get()};
 
@@ -99,7 +99,7 @@ TEST_F(SerializerDumpLibTest, MultipleSerializations) {
   auto type = velox::ROW({"x"}, {velox::INTEGER()});
 
   SerializerOptions options{
-      .version = SerializationVersion::kCompact,
+      .version = SerializationVersion::kCompactRaw,
   };
   Serializer serializer{options, type, leafPool_.get()};
 
@@ -142,7 +142,7 @@ TEST_F(SerializerDumpLibTest, Reset) {
   auto type = velox::ROW({"v"}, {velox::INTEGER()});
 
   SerializerOptions options{
-      .version = SerializationVersion::kCompact,
+      .version = SerializationVersion::kCompactRaw,
   };
   Serializer serializer{options, type, leafPool_.get()};
 
@@ -170,14 +170,14 @@ TEST_F(SerializerDumpLibTest, Reset) {
 }
 
 // Verifies that SerializationDump handles varying stream counts across
-// serializations. With flat maps in kCompact format, different rows can have
+// serializations. With flat maps in kCompactRaw format, different rows can have
 // different keys, producing different numbers of streams per serialization.
 TEST_F(SerializerDumpLibTest, varyingStreamCountsWithFlatMap) {
   auto type =
       velox::ROW({{"features", velox::MAP(velox::INTEGER(), velox::BIGINT())}});
 
   const SerializerOptions options{
-      .version = SerializationVersion::kCompact,
+      .version = SerializationVersion::kCompactRaw,
       .flatMapColumns = {{"features", {}}},
   };
   Serializer serializer{options, type, leafPool_.get()};

--- a/dwio/nimble/velox/index/NimbleIndexProjector.cpp
+++ b/dwio/nimble/velox/index/NimbleIndexProjector.cpp
@@ -151,7 +151,7 @@ NimbleIndexProjector::Result NimbleIndexProjector::project(
     }
   }
 
-  finalizeResultChunks(result);
+  finalizeResult(result);
   updateIoStats();
   return result;
 }
@@ -318,12 +318,12 @@ NimbleIndexProjector::ResultChunk NimbleIndexProjector::serializeStripe(
     InputStreams& inputStreams) {
   velox::CpuWallTimer timer(stats_.projectionTiming);
 
-  const auto numStripeRows = stripeRowCount(stripeIndex);
+  const auto numRows = stripeRowCount(stripeIndex);
 
   // Build the shared body+trailer for this stripe:
   //   [stream_data...][encodingType][stream_sizes][trailer_size:u32].
   // The version/rowCount/row-range/resume-key header is per-slice and is
-  // built later by finalizeResultChunks().
+  // built later by finalizeResult().
 
   // Collect raw stream segments without copying. Sizes are needed for the
   // trailer.
@@ -360,19 +360,18 @@ NimbleIndexProjector::ResultChunk NimbleIndexProjector::serializeStripe(
   body->append(bodySize);
 
   ResultChunk stripeChunk;
-  stripeChunk.sharedData = std::move(*body);
-  stripeChunk.numStripeRows = numStripeRows;
+  stripeChunk.sharedBody = std::move(*body);
+  stripeChunk.numRows = numRows;
 
-  stats_.numScannedRows += numStripeRows;
-  stats_.numProjectedRows += numStripeRows;
-  stats_.numReadBytes += stripeChunk.sharedData.length();
+  stats_.numScannedRows += numRows;
+  stats_.numProjectedRows += numRows;
+  stats_.numReadBytes += stripeChunk.sharedBody.length();
   return stripeChunk;
 }
 
 bool NimbleIndexProjector::buildStripeResult(
     std::span<const StripeRowRange> stripeRowRanges,
     ResultChunk&& stripeChunk) {
-  size_t numEmittedSlices = 0;
   for (const auto& request : stripeRowRanges) {
     NIMBLE_CHECK(!request.rowRange.empty());
     auto rowRange = request.rowRange;
@@ -391,34 +390,21 @@ bool NimbleIndexProjector::buildStripeResult(
 
     // Queue a per-slice clone of the shared body+trailer. The header node
     // (version + rowCount + row range + resume-key-length [+ resume key])
-    // is materialized and chained on top in finalizeResultChunks().
+    // is materialized and chained on top in finalizeResult().
     stats_.numReadRows += rowRange.numRows();
     numReadRows_ += rowRange.numRows();
-    resultChunks_[request.requestIndex].emplace_back(
-        stripeChunk.sharedData.cloneOneAsValue(),
-        stripeChunk.numStripeRows,
-        rowRange);
+    resultChunks_[request.requestIndex].push_back(
+        ResultChunk{
+            .sharedBody = stripeChunk.sharedBody.cloneOneAsValue(),
+            .numRows = stripeChunk.numRows,
+            .rowRange = rowRange});
     rowsPerRequest_[request.requestIndex] += rowRange.numRows();
-    ++numEmittedSlices;
   }
 
-  // Account for body+trailer bytes (per stripe, shared) plus a lower-bound
-  // for the per-slice header bytes — one min-sized header per emitted slice
-  // (skipped zero-row ranges are excluded). finalizeResultChunks() tops up
-  // to the actual header size per slice. serializeStripe already added body
-  // bytes to stats_; numReadBytes_ tracks the running total used by maxBytes
-  // enforcement.
-  //
-  // NOTE: bodyBytes is added once per stripe even though every per-request
-  // chunk slice clones the shared body. maxBytes therefore caps "stripe
-  // bytes assembled" (in-process memory growth), not "wire bytes returned"
-  // — a single hot stripe served to N requests transmits ~N×bodyBytes over
-  // RPC. Callers wanting wire-bytes semantics should set maxBytes lower or
-  // post-process Result to compute total chunkSlices length.
-  const auto bodyBytes = stripeChunk.sharedData.length();
-  const auto headerBytes = serde::kMinTabletChunkHeaderSize * numEmittedSlices;
-  numReadBytes_ += bodyBytes + headerBytes;
-  stats_.numReadBytes += headerBytes;
+  // Track body bytes only. Header bytes are small relative to stream data
+  // and are not worth the accounting complexity.
+  const auto bodyBytes = stripeChunk.sharedBody.length();
+  numReadBytes_ += bodyBytes;
 
   return !checkOutputLimit();
 }
@@ -457,8 +443,8 @@ void NimbleIndexProjector::setResumeKeys(
 
   // For requests that were never started (no result chunks for this scan,
   // no resume key), set resume key to their original lower key so the
-  // caller can retry. Note: response.chunkSlices is populated later by
-  // finalizeResultChunks(), so we check resultChunks_ here.
+  // caller can retry. Note: response.chunks is populated later by
+  // finalizeResult(), so we check resultChunks_ here.
   for (size_t i = 0; i < result.responses.size(); ++i) {
     auto& response = result.responses[i];
     if (resultChunks_[i].empty() && !response.resumeKey.has_value()) {
@@ -473,7 +459,29 @@ void NimbleIndexProjector::setResumeKeys(
   }
 }
 
-void NimbleIndexProjector::finalizeResultChunks(Result& result) {
+namespace {
+
+/// Builds a kTabletRaw IOBuf chain: [header] -> [shared body+trailer].
+folly::IOBuf assembleChunk(
+    uint32_t numRows,
+    RowRange rowRange,
+    folly::IOBuf body,
+    std::optional<std::string> resumeKey = std::nullopt) {
+  serde::TabletChunkHeader header{
+      .rowCount = numRows,
+      .rowRange = rowRange,
+      .resumeKey = std::move(resumeKey),
+  };
+  auto serializedHeader =
+      std::make_unique<folly::IOBuf>(serde::createTabletChunkHeader(header));
+  serializedHeader->appendToChain(
+      std::make_unique<folly::IOBuf>(std::move(body)));
+  return std::move(*serializedHeader);
+}
+
+} // namespace
+
+void NimbleIndexProjector::finalizeResult(Result& result) {
   NIMBLE_CHECK_EQ(resultChunks_.size(), result.responses.size());
 
   for (size_t responseIdx = 0; responseIdx < result.responses.size();
@@ -481,37 +489,18 @@ void NimbleIndexProjector::finalizeResultChunks(Result& result) {
     auto& response = result.responses[responseIdx];
     auto& chunks = resultChunks_[responseIdx];
     const auto numChunks = chunks.size();
-    response.chunkSlices.reserve(numChunks);
+    response.chunks.reserve(numChunks);
 
     for (size_t chunkIdx = 0; chunkIdx < numChunks; ++chunkIdx) {
       auto& chunk = chunks[chunkIdx];
-
-      serde::TabletChunkHeader header{
-          .rowCount = chunk.numStripeRows,
-          .rowRange = chunk.rowRange,
-      };
-      // Resume key is only encoded on the last slice when present.
-      if (chunkIdx + 1 == numChunks && response.resumeKey.has_value()) {
-        header.resumeKey = response.resumeKey;
-      }
-
-      auto headerNode = std::make_unique<folly::IOBuf>(
-          serde::createTabletChunkHeader(header));
-      const auto headerSize = headerNode->length();
-
-      // Chain: [per-slice header] -> [shared body+trailer].
-      headerNode->appendToChain(
-          std::make_unique<folly::IOBuf>(std::move(chunk.sharedData)));
-
-      // Top up the lower-bound accounting from buildStripeResult to the
-      // actual header size (rowCount/range/resumeKeyLength varints may be
-      // larger than 1 byte; resume key bytes are also counted here).
-      const auto extra = headerSize - serde::kMinTabletChunkHeaderSize;
-      stats_.numReadBytes += extra;
-      numReadBytes_ += extra;
-
-      response.chunkSlices.emplace_back(std::move(*headerNode));
+      const bool isLastChunk = chunkIdx + 1 == numChunks;
+      response.chunks.emplace_back(assembleChunk(
+          chunk.numRows,
+          chunk.rowRange,
+          std::move(chunk.sharedBody),
+          isLastChunk ? response.resumeKey : std::nullopt));
     }
+    chunks.clear();
   }
 }
 

--- a/dwio/nimble/velox/index/NimbleIndexProjector.h
+++ b/dwio/nimble/velox/index/NimbleIndexProjector.h
@@ -63,7 +63,7 @@ using Subfield = velox::common::Subfield;
 ///   auto result = projector.project(request, options);
 ///   for (size_t i = 0; i < result.responses.size(); ++i) {
 ///     const auto& response = result.responses[i];
-///     for (const auto& chunkSlice : response.chunkSlices) {
+///     for (const auto& chunkSlice : response.chunks) {
 ///       // `chunkSlice` is a self-describing kTabletRaw IOBuf chain with
 ///       // the request's row range and (on the last slice of a truncated
 ///       // response) the resume key embedded in the header.
@@ -121,13 +121,13 @@ class NimbleIndexProjector {
     /// If the response is truncated and has a resume key, it is embedded in
     /// the header of the last slice. Use `rocks::readResultResumeKey()` on
     /// the last slice to extract it.
-    std::vector<folly::IOBuf> chunkSlices;
+    std::vector<folly::IOBuf> chunks;
 
     /// If the result was truncated by maxRows or maxBytes, the encoded resume
     /// key for continuation. The caller constructs new key bounds using this
     /// as lowerKey with their original upperKey. nullopt if complete or miss.
     ///
-    /// Also embedded in the last slice's per-slice header (when chunkSlices
+    /// Also embedded in the last slice's per-slice header (when chunks
     /// is non-empty) so consumers that hold an IOBuf can recover the key
     /// without keeping the Response struct around.
     std::optional<std::string> resumeKey;
@@ -275,20 +275,15 @@ class NimbleIndexProjector {
   // Enqueues projected streams into StripeStreams and loads them from disk.
   InputStreams loadStripe();
 
-  // Per-slice info needed at finalization time to build the chunk slice
-  // IOBuf chain (header node + shared body+trailer clone).
-  //
-  // Reused as the producer-side container returned by serializeStripe(): the
-  // shared body+trailer bytes are produced once per stripe and referenced by
-  // every per-request chunk slice for that stripe via cloneOne(). On that
-  // producer side, rowRange is default-constructed and unused;
-  // buildStripeResult fills it in when materializing each per-request clone.
-  //
-  // Layout of sharedData:
-  //   [stream_data...][encodingType][stream_sizes][trailer_size:u32].
+  // Collected data from one stripe for one request. sharedBody holds the
+  // projected stream data and trailer (no header), shared across requests
+  // for the same stripe via refcounted IOBuf clones:
+  //   [stream_data...][encodingType][stream_sizes][trailer_size:u32]
+  // finalizeResult() prepends a per-request header with the row range via
+  // assembleChunk().
   struct ResultChunk {
-    folly::IOBuf sharedData;
-    uint32_t numStripeRows{0};
+    folly::IOBuf sharedBody;
+    uint32_t numRows{0};
     RowRange rowRange;
   };
 
@@ -300,7 +295,7 @@ class NimbleIndexProjector {
   // Queues per-request result chunks for the stripe. Each chunk captures a
   // cloneOne() of the shared body+trailer, the stripe row count, and the
   // per-request row range. The chunk slice IOBuf chain is finalized later by
-  // finalizeResultChunks() once we know whether the response carries a
+  // finalizeResult() once we know whether the response carries a
   // resume key. Applies maxRowsPerRequest hard clipping and accumulates
   // numReadRows_. Returns false if a global limit (maxRows or maxBytes) was
   // hit after this stripe.
@@ -319,7 +314,7 @@ class NimbleIndexProjector {
   // assembles the final chunk slice IOBuf chain (header -> body+trailer).
   // The resume key is folded into the header of the last slice of any
   // truncated response.
-  void finalizeResultChunks(Result& result);
+  void finalizeResult(Result& result);
 
   inline uint32_t stripeRowCount(uint32_t stripe) const {
     return static_cast<uint32_t>(readerBase_->tablet().stripeRowCount(stripe));

--- a/dwio/nimble/velox/index/tests/NimbleIndexProjectorTest.cpp
+++ b/dwio/nimble/velox/index/tests/NimbleIndexProjectorTest.cpp
@@ -337,10 +337,10 @@ TEST_P(NimbleIndexProjectorTest, basicColumnProjection) {
 
   ASSERT_EQ(result.responses.size(), 1);
   const auto& response = result.responses[0];
-  ASSERT_FALSE(response.chunkSlices.empty());
+  ASSERT_FALSE(response.chunks.empty());
   EXPECT_FALSE(response.resumeKey.has_value());
 
-  const auto& chunkSlice = response.chunkSlices[0];
+  const auto& chunkSlice = response.chunks[0];
   const auto rowRange = readEmbeddedRowRange(chunkSlice);
   ASSERT_GT(rowRange.numRows(), 0);
 
@@ -404,7 +404,7 @@ TEST_P(NimbleIndexProjectorTest, emptyResult) {
   auto result = projector->project(request, {});
 
   ASSERT_EQ(result.responses.size(), 1);
-  EXPECT_TRUE(result.responses[0].chunkSlices.empty());
+  EXPECT_TRUE(result.responses[0].chunks.empty());
   EXPECT_FALSE(result.responses[0].resumeKey.has_value());
 
   // All stats should be zero for a miss.
@@ -450,7 +450,7 @@ TEST_P(NimbleIndexProjectorTest, multipleRequests) {
   ASSERT_EQ(result.responses.size(), 3);
   uint64_t totalBytes = 0;
   for (const auto& response : result.responses) {
-    for (const auto& chunkSlice : response.chunkSlices) {
+    for (const auto& chunkSlice : response.chunks) {
       totalBytes += chunkSlice.computeChainDataLength();
     }
   }
@@ -458,7 +458,7 @@ TEST_P(NimbleIndexProjectorTest, multipleRequests) {
 
   // All requests should have results (no misses).
   for (const auto& response : result.responses) {
-    EXPECT_FALSE(response.chunkSlices.empty());
+    EXPECT_FALSE(response.chunks.empty());
     EXPECT_FALSE(response.resumeKey.has_value());
   }
 }
@@ -497,11 +497,11 @@ TEST_P(NimbleIndexProjectorTest, overlappingRequestsShareBody) {
   auto result = projector->project(request, {});
 
   ASSERT_EQ(result.responses.size(), 2);
-  ASSERT_EQ(result.responses[0].chunkSlices.size(), 1);
-  ASSERT_EQ(result.responses[1].chunkSlices.size(), 1);
+  ASSERT_EQ(result.responses[0].chunks.size(), 1);
+  ASSERT_EQ(result.responses[1].chunks.size(), 1);
 
-  const auto& chunkSlice0 = result.responses[0].chunkSlices[0];
-  const auto& chunkSlice1 = result.responses[1].chunkSlices[0];
+  const auto& chunkSlice0 = result.responses[0].chunks[0];
+  const auto& chunkSlice1 = result.responses[1].chunks[0];
 
   // Each chunk slice is a 2-node chain: per-slice header + shared body+trailer.
   ASSERT_TRUE(chunkSlice0.isChained());
@@ -564,9 +564,8 @@ TEST_P(NimbleIndexProjectorTest, overlappingRequestsShareBody) {
     NimbleIndexProjector::Request request;                                     \
     request.keyBounds = {bounds};                                              \
     auto result = projector->project(request, {});                             \
-    ASSERT_EQ(result.responses[0].chunkSlices.size(), 1);                      \
-    auto coalesced =                                                           \
-        result.responses[0].chunkSlices[0].cloneCoalescedAsValue();            \
+    ASSERT_EQ(result.responses[0].chunks.size(), 1);                           \
+    auto coalesced = result.responses[0].chunks[0].cloneCoalescedAsValue();    \
     auto bytes = std::string_view(                                             \
         reinterpret_cast<const char*>(coalesced.data()), coalesced.length());  \
     DeserializerOptions deserOptions;                                          \
@@ -640,9 +639,9 @@ TEST_P(NimbleIndexProjectorTest, deserializerMultiBatchWithRowRange) {
   NimbleIndexProjector::Request request;
   request.keyBounds = {bounds};
   auto result = projector->project(request, {});
-  ASSERT_EQ(result.responses[0].chunkSlices.size(), 1);
+  ASSERT_EQ(result.responses[0].chunks.size(), 1);
 
-  auto coalesced = result.responses[0].chunkSlices[0].cloneCoalescedAsValue();
+  auto coalesced = result.responses[0].chunks[0].cloneCoalescedAsValue();
   auto bytes = std::string_view(
       reinterpret_cast<const char*>(coalesced.data()), coalesced.length());
 
@@ -713,8 +712,8 @@ TEST_P(NimbleIndexProjectorTest, deserializerMultiBatchMixedRanges) {
   std::vector<std::string_view> batches;
   batches.reserve(4);
   for (auto& response : result.responses) {
-    ASSERT_EQ(response.chunkSlices.size(), 1u);
-    ownedSlices.push_back(response.chunkSlices[0].cloneCoalescedAsValue());
+    ASSERT_EQ(response.chunks.size(), 1u);
+    ownedSlices.push_back(response.chunks[0].cloneCoalescedAsValue());
     batches.emplace_back(
         reinterpret_cast<const char*>(ownedSlices.back().data()),
         ownedSlices.back().length());
@@ -757,10 +756,10 @@ TEST_P(NimbleIndexProjectorTest, deserializerMultiBatchMixedRanges) {
 
 TEST_P(NimbleIndexProjectorTest, deserializerMultiBatchMixedVersions) {
   // Mix a kTabletRaw chunk slice (projector output, narrow row range) with
-  // a kCompact chunk (Serializer output, no row range) in one deserialize
+  // a kCompactRaw chunk (Serializer output, no row range) in one deserialize
   // call. Verifies the no-range branch of the per-batch loop: when
   // batchRanges[i] is nullopt, numRowsInBatch falls back to batchRows
-  // (the full kCompact batch).
+  // (the full kCompactRaw batch).
   auto rowType = ROW({"key", "value"}, {BIGINT(), INTEGER()});
 
   const int numRows = 100;
@@ -785,29 +784,28 @@ TEST_P(NimbleIndexProjectorTest, deserializerMultiBatchMixedVersions) {
   NimbleIndexProjector::Request request;
   request.keyBounds = {bounds};
   auto result = projector->project(request, {});
-  ASSERT_EQ(result.responses[0].chunkSlices.size(), 1u);
-  auto tabletRawOwned =
-      result.responses[0].chunkSlices[0].cloneCoalescedAsValue();
+  ASSERT_EQ(result.responses[0].chunks.size(), 1u);
+  auto tabletRawOwned = result.responses[0].chunks[0].cloneCoalescedAsValue();
 
-  // kCompact batch: serialize a 5-row Row<INTEGER> vector matching the
+  // kCompactRaw batch: serialize a 5-row Row<INTEGER> vector matching the
   // projected schema. The Serializer is constructed against the same velox
   // type the Deserializer will use, so the streams encode in lockstep.
   auto projectedVeloxType =
       convertToVeloxType(*projector->projectedNimbleType());
-  std::vector<int32_t> kCompactValues = {1000, 2000, 3000, 4000, 5000};
-  auto kCompactRow = vectorMaker_->rowVector(
-      {"value"}, {vectorMaker_->flatVector<int32_t>(kCompactValues)});
+  std::vector<int32_t> kCompactRawValues = {1000, 2000, 3000, 4000, 5000};
+  auto kCompactRawRow = vectorMaker_->rowVector(
+      {"value"}, {vectorMaker_->flatVector<int32_t>(kCompactRawValues)});
   SerializerOptions serOptions{
-      .version = SerializationVersion::kCompact,
+      .version = SerializationVersion::kCompactRaw,
   };
   Serializer ser{
       serOptions,
       projectedVeloxType,
       leafPool_.get(),
   };
-  auto kCompactBytes = ser.serialize(
-      kCompactRow,
-      OrderedRanges::of(0, static_cast<uint32_t>(kCompactValues.size())));
+  auto kCompactRawBytes = ser.serialize(
+      kCompactRawRow,
+      OrderedRanges::of(0, static_cast<uint32_t>(kCompactRawValues.size())));
 
   DeserializerOptions deserOptions;
   deserOptions.hasHeader = true;
@@ -818,15 +816,15 @@ TEST_P(NimbleIndexProjectorTest, deserializerMultiBatchMixedVersions) {
       std::string_view(
           reinterpret_cast<const char*>(tabletRawOwned.data()),
           tabletRawOwned.length()),
-      kCompactBytes,
+      kCompactRawBytes,
   };
   VectorPtr output;
   deserializer.deserialize(batches, output);
 
-  // Over-fetch: kTabletRaw batch decodes its full 100 stripe rows; kCompact
-  // batch contributes 5 rows. Concatenation = 105 rows. The in-range
-  // subset of the kTabletRaw batch (positions [10, 40) within the first
-  // 100) carries values[10..39]; the kCompact batch's 5 rows follow.
+  // Over-fetch: kTabletRaw batch decodes its full 100 stripe rows;
+  // kCompactRaw batch contributes 5 rows. Concatenation = 105 rows. The
+  // in-range subset of the kTabletRaw batch (positions [10, 40) within the
+  // first 100) carries values[10..39]; the kCompactRaw batch's 5 rows follow.
   ASSERT_EQ(output->size(), 105u);
   auto* rowVec = output->as<velox::RowVector>();
   auto* valueVec = rowVec->childAt(0)->as<velox::FlatVector<int32_t>>();
@@ -835,8 +833,8 @@ TEST_P(NimbleIndexProjectorTest, deserializerMultiBatchMixedVersions) {
         << "kTabletRaw i=" << i;
   }
   for (uint32_t i = 0; i < 5; ++i) {
-    EXPECT_EQ(valueVec->valueAt(100 + i), kCompactValues[i])
-        << "kCompact i=" << i;
+    EXPECT_EQ(valueVec->valueAt(100 + i), kCompactRawValues[i])
+        << "kCompactRaw i=" << i;
   }
 }
 
@@ -1007,9 +1005,9 @@ TEST_P(NimbleIndexProjectorTest, flatMapProjection) {
 
   ASSERT_EQ(result.responses.size(), 1);
   const auto& response = result.responses[0];
-  ASSERT_FALSE(response.chunkSlices.empty());
+  ASSERT_FALSE(response.chunks.empty());
 
-  const auto& chunkSlice = response.chunkSlices[0];
+  const auto& chunkSlice = response.chunks[0];
   const auto rowRange = readEmbeddedRowRange(chunkSlice);
   ASSERT_GT(rowRange.numRows(), 0);
 
@@ -1109,9 +1107,9 @@ TEST_P(NimbleIndexProjectorTest, flatMapProjectionWithNarrowRowRange) {
   request.keyBounds = {bounds};
   auto result = projector->project(request, {});
   ASSERT_EQ(result.responses.size(), 1);
-  ASSERT_EQ(result.responses[0].chunkSlices.size(), 1u);
+  ASSERT_EQ(result.responses[0].chunks.size(), 1u);
 
-  const auto& chunkSlice = result.responses[0].chunkSlices[0];
+  const auto& chunkSlice = result.responses[0].chunks[0];
   const auto rowRange = readEmbeddedRowRange(chunkSlice);
   ASSERT_EQ(rowRange.numRows(), 5u);
 
@@ -1252,9 +1250,9 @@ TEST_P(NimbleIndexProjectorTest, flatMapKeyProjectionSchemaComparison) {
   auto result = projector->project(request, {});
 
   ASSERT_EQ(result.responses.size(), 1);
-  ASSERT_FALSE(result.responses[0].chunkSlices.empty());
+  ASSERT_FALSE(result.responses[0].chunks.empty());
 
-  const auto& chunkSlice = result.responses[0].chunkSlices[0];
+  const auto& chunkSlice = result.responses[0].chunks[0];
   auto coalesced = coalesceChunkSlice(chunkSlice);
   auto data = std::string_view(
       reinterpret_cast<const char*>(coalesced.data()), coalesced.length());
@@ -1312,9 +1310,9 @@ TEST_P(NimbleIndexProjectorTest, flatMapIntKeyProjection) {
 
   ASSERT_EQ(result.responses.size(), 1);
   const auto& response = result.responses[0];
-  ASSERT_FALSE(response.chunkSlices.empty());
+  ASSERT_FALSE(response.chunks.empty());
 
-  const auto& chunkSlice = response.chunkSlices[0];
+  const auto& chunkSlice = response.chunks[0];
   const auto rowRange = readEmbeddedRowRange(chunkSlice);
   ASSERT_GT(rowRange.numRows(), 0);
 
@@ -1419,7 +1417,7 @@ TEST_P(NimbleIndexProjectorTest, flatMapMissingKeys) {
     request.keyBounds = {pointBounds};
     auto result = projector->project(request, {});
     ASSERT_EQ(result.responses.size(), 1);
-    ASSERT_FALSE(result.responses[0].chunkSlices.empty());
+    ASSERT_FALSE(result.responses[0].chunks.empty());
   }
 
   // All requested keys missing — should fail.
@@ -1593,7 +1591,7 @@ TEST_P(NimbleIndexProjectorTest, featureReorderingStorageReads) {
     auto result = projector->project(request, {});
 
     ASSERT_EQ(result.responses.size(), 1);
-    ASSERT_FALSE(result.responses[0].chunkSlices.empty());
+    ASSERT_FALSE(result.responses[0].chunks.empty());
 
     storageReads[param.debugString()] = projector->stats().numStorageReads;
   }
@@ -1719,11 +1717,11 @@ TEST_P(NimbleIndexProjectorTest, resumeKeyOnTruncation) {
 
   ASSERT_EQ(result.responses.size(), 1);
   const auto& response = result.responses[0];
-  ASSERT_FALSE(response.chunkSlices.empty());
+  ASSERT_FALSE(response.chunks.empty());
 
   // Soft limit: first stripe (100 rows) included fully.
   uint64_t totalRows = 0;
-  for (const auto& chunkSlice : response.chunkSlices) {
+  for (const auto& chunkSlice : response.chunks) {
     totalRows += readEmbeddedRowRange(chunkSlice).numRows();
   }
   EXPECT_EQ(totalRows, 100);
@@ -1734,13 +1732,12 @@ TEST_P(NimbleIndexProjectorTest, resumeKeyOnTruncation) {
 
   // The resume key is embedded only on the last slice; earlier slices carry
   // an empty resume key marker.
-  const auto numSlices = response.chunkSlices.size();
+  const auto numSlices = response.chunks.size();
   for (size_t i = 0; i + 1 < numSlices; ++i) {
-    EXPECT_FALSE(readEmbeddedResumeKey(response.chunkSlices[i]).has_value())
+    EXPECT_FALSE(readEmbeddedResumeKey(response.chunks[i]).has_value())
         << "non-last slice " << i << " unexpectedly carries a resume key";
   }
-  const auto embeddedResumeKey =
-      readEmbeddedResumeKey(response.chunkSlices.back());
+  const auto embeddedResumeKey = readEmbeddedResumeKey(response.chunks.back());
   ASSERT_TRUE(embeddedResumeKey.has_value());
   EXPECT_EQ(*embeddedResumeKey, *response.resumeKey);
 }
@@ -1810,7 +1807,7 @@ TEST_P(NimbleIndexProjectorTest, softLimitAtStripeBoundary) {
 
     ASSERT_EQ(result.responses.size(), 1);
     uint64_t totalRows = 0;
-    for (const auto& chunkSlice : result.responses[0].chunkSlices) {
+    for (const auto& chunkSlice : result.responses[0].chunks) {
       totalRows += readEmbeddedRowRange(chunkSlice).numRows();
     }
     EXPECT_EQ(totalRows, 100);
@@ -1829,7 +1826,7 @@ TEST_P(NimbleIndexProjectorTest, softLimitAtStripeBoundary) {
 
     ASSERT_EQ(result.responses.size(), 1);
     uint64_t totalRows = 0;
-    for (const auto& chunkSlice : result.responses[0].chunkSlices) {
+    for (const auto& chunkSlice : result.responses[0].chunks) {
       totalRows += readEmbeddedRowRange(chunkSlice).numRows();
     }
     EXPECT_EQ(totalRows, 100);
@@ -1849,7 +1846,7 @@ TEST_P(NimbleIndexProjectorTest, softLimitAtStripeBoundary) {
 
     ASSERT_EQ(result.responses.size(), 1);
     uint64_t totalRows = 0;
-    for (const auto& chunkSlice : result.responses[0].chunkSlices) {
+    for (const auto& chunkSlice : result.responses[0].chunks) {
       totalRows += readEmbeddedRowRange(chunkSlice).numRows();
     }
     EXPECT_EQ(totalRows, 200);
@@ -1888,7 +1885,7 @@ TEST_P(NimbleIndexProjectorTest, resumeKeyPagination) {
     const auto& response = result.responses[0];
 
     uint64_t pageRows = 0;
-    for (const auto& chunkSlice : response.chunkSlices) {
+    for (const auto& chunkSlice : response.chunks) {
       pageRows += readEmbeddedRowRange(chunkSlice).numRows();
     }
     EXPECT_GT(pageRows, 0) << "Page " << pageCount << " returned no rows";
@@ -1937,7 +1934,7 @@ TEST_P(NimbleIndexProjectorTest, maxRowsTotalAcrossRequests) {
   {
     const auto& response = result.responses[0];
     uint64_t totalRows = 0;
-    for (const auto& chunkSlice : response.chunkSlices) {
+    for (const auto& chunkSlice : response.chunks) {
       totalRows += readEmbeddedRowRange(chunkSlice).numRows();
     }
     EXPECT_EQ(totalRows, 100);
@@ -1947,7 +1944,7 @@ TEST_P(NimbleIndexProjectorTest, maxRowsTotalAcrossRequests) {
   // Request 1: stripe 9 was never processed, resume key = original lower key.
   {
     const auto& response = result.responses[1];
-    EXPECT_TRUE(response.chunkSlices.empty());
+    EXPECT_TRUE(response.chunks.empty());
     ASSERT_TRUE(response.resumeKey.has_value());
     EXPECT_EQ(response.resumeKey.value(), bounds1.lowerKey);
   }
@@ -1979,14 +1976,14 @@ TEST_P(NimbleIndexProjectorTest, noResumeKeyWhenRequestFullySatisfied) {
   // Request 0: fully satisfied within stripe 0 — no resume key.
   {
     const auto& response = result.responses[0];
-    ASSERT_FALSE(response.chunkSlices.empty());
+    ASSERT_FALSE(response.chunks.empty());
     EXPECT_FALSE(response.resumeKey.has_value());
   }
 
   // Request 1: spans beyond stripe 0, truncated — has resume key.
   {
     const auto& response = result.responses[1];
-    ASSERT_FALSE(response.chunkSlices.empty());
+    ASSERT_FALSE(response.chunks.empty());
     EXPECT_TRUE(response.resumeKey.has_value());
   }
 }
@@ -2010,7 +2007,7 @@ TEST_P(NimbleIndexProjectorTest, maxRowsExceedsTotal) {
 
   ASSERT_EQ(result.responses.size(), 1);
   uint64_t totalRows = 0;
-  for (const auto& chunkSlice : result.responses[0].chunkSlices) {
+  for (const auto& chunkSlice : result.responses[0].chunks) {
     totalRows += readEmbeddedRowRange(chunkSlice).numRows();
   }
   EXPECT_EQ(totalRows, 300);
@@ -2034,7 +2031,7 @@ TEST_P(NimbleIndexProjectorTest, maxRowsZeroMeansUnlimited) {
 
   ASSERT_EQ(result.responses.size(), 1);
   uint64_t totalRows = 0;
-  for (const auto& chunkSlice : result.responses[0].chunkSlices) {
+  for (const auto& chunkSlice : result.responses[0].chunks) {
     totalRows += readEmbeddedRowRange(chunkSlice).numRows();
   }
   EXPECT_EQ(totalRows, 1000);
@@ -2060,7 +2057,7 @@ TEST_P(NimbleIndexProjectorTest, maxRowsSingleRowStripes) {
 
   ASSERT_EQ(result.responses.size(), 1);
   uint64_t totalRows = 0;
-  for (const auto& chunkSlice : result.responses[0].chunkSlices) {
+  for (const auto& chunkSlice : result.responses[0].chunks) {
     totalRows += readEmbeddedRowRange(chunkSlice).numRows();
   }
   EXPECT_EQ(totalRows, 3);
@@ -2103,9 +2100,9 @@ TEST_P(NimbleIndexProjectorTest, maxRowsPerRequestClipping) {
     const auto& response = result.responses[0];
     EXPECT_FALSE(response.resumeKey.has_value());
     EXPECT_EQ(projector->stats().numReadRows, 150);
-    ASSERT_EQ(response.chunkSlices.size(), 2);
-    EXPECT_EQ(readEmbeddedRowRange(response.chunkSlices[0]).numRows(), 100);
-    EXPECT_EQ(readEmbeddedRowRange(response.chunkSlices[1]).numRows(), 50);
+    ASSERT_EQ(response.chunks.size(), 2);
+    EXPECT_EQ(readEmbeddedRowRange(response.chunks[0]).numRows(), 100);
+    EXPECT_EQ(readEmbeddedRowRange(response.chunks[1]).numRows(), 50);
   }
 }
 
@@ -2134,7 +2131,7 @@ TEST_P(NimbleIndexProjectorTest, maxRowsPerRequestIndependentPruning) {
   {
     const auto& response = result.responses[0];
     uint64_t totalRows = 0;
-    for (const auto& chunkSlice : response.chunkSlices) {
+    for (const auto& chunkSlice : response.chunks) {
       totalRows += readEmbeddedRowRange(chunkSlice).numRows();
     }
     EXPECT_EQ(totalRows, 100);
@@ -2144,7 +2141,7 @@ TEST_P(NimbleIndexProjectorTest, maxRowsPerRequestIndependentPruning) {
   {
     const auto& response = result.responses[1];
     uint64_t totalRows = 0;
-    for (const auto& chunkSlice : response.chunkSlices) {
+    for (const auto& chunkSlice : response.chunks) {
       totalRows += readEmbeddedRowRange(chunkSlice).numRows();
     }
     EXPECT_EQ(totalRows, 100);
@@ -2167,9 +2164,8 @@ TEST_P(NimbleIndexProjectorTest, maxBytesTruncation) {
     NimbleIndexProjector::Request request;
     request.keyBounds = {bounds};
     auto result = projector->project(request, {});
-    ASSERT_EQ(result.responses[0].chunkSlices.size(), 1);
-    bytesPerStripe =
-        result.responses[0].chunkSlices[0].computeChainDataLength();
+    ASSERT_EQ(result.responses[0].chunks.size(), 1);
+    bytesPerStripe = projector->stats().numReadBytes;
     ASSERT_GT(bytesPerStripe, 0);
   }
 
@@ -2242,9 +2238,8 @@ TEST_P(NimbleIndexProjectorTest, maxBytesPagination) {
     NimbleIndexProjector::Request request;
     request.keyBounds = {bounds};
     auto result = projector->project(request, {});
-    ASSERT_EQ(result.responses[0].chunkSlices.size(), 1);
-    bytesPerStripe =
-        result.responses[0].chunkSlices[0].computeChainDataLength();
+    ASSERT_EQ(result.responses[0].chunks.size(), 1);
+    bytesPerStripe = projector->stats().numReadBytes;
   }
 
   // Paginate through the full range using byte limits.
@@ -2302,9 +2297,8 @@ TEST_P(NimbleIndexProjectorTest, maxBytesAndMaxRowsInteraction) {
     NimbleIndexProjector::Request request;
     request.keyBounds = {bounds};
     auto result = projector->project(request, {});
-    ASSERT_EQ(result.responses[0].chunkSlices.size(), 1);
-    bytesPerStripe =
-        result.responses[0].chunkSlices[0].computeChainDataLength();
+    ASSERT_EQ(result.responses[0].chunks.size(), 1);
+    bytesPerStripe = projector->stats().numReadBytes;
   }
 
   // Range [0, 500) = 5 stripes, 500 rows.
@@ -2431,14 +2425,14 @@ TEST_P(
     SCOPED_TRACE(fmt::format("request {}", i));
     const auto& response = result.responses[i];
     uint64_t totalRows = 0;
-    for (const auto& chunkSlice : response.chunkSlices) {
+    for (const auto& chunkSlice : response.chunks) {
       totalRows += readEmbeddedRowRange(chunkSlice).numRows();
     }
     EXPECT_EQ(totalRows, 150);
     EXPECT_FALSE(response.resumeKey.has_value());
-    ASSERT_EQ(response.chunkSlices.size(), 2);
-    EXPECT_EQ(readEmbeddedRowRange(response.chunkSlices[0]).numRows(), 100);
-    EXPECT_EQ(readEmbeddedRowRange(response.chunkSlices[1]).numRows(), 50);
+    ASSERT_EQ(response.chunks.size(), 2);
+    EXPECT_EQ(readEmbeddedRowRange(response.chunks[0]).numRows(), 100);
+    EXPECT_EQ(readEmbeddedRowRange(response.chunks[1]).numRows(), 50);
   }
 }
 
@@ -2464,8 +2458,8 @@ TEST_P(NimbleIndexProjectorTest, maxRowsPerRequestSingleRow) {
   const auto& response = result.responses[0];
   EXPECT_FALSE(response.resumeKey.has_value());
   EXPECT_EQ(projector->stats().numReadRows, 1);
-  ASSERT_EQ(response.chunkSlices.size(), 1);
-  EXPECT_EQ(readEmbeddedRowRange(response.chunkSlices[0]).numRows(), 1);
+  ASSERT_EQ(response.chunks.size(), 1);
+  EXPECT_EQ(readEmbeddedRowRange(response.chunks[0]).numRows(), 1);
 }
 
 TEST_P(NimbleIndexProjectorTest, maxRowsLargeScale) {
@@ -2537,19 +2531,19 @@ TEST_P(NimbleIndexProjectorTest, maxRowsMultiRequestMixedSatisfaction) {
   ASSERT_EQ(result.responses.size(), 4);
 
   // Request 0: 50 rows, fully satisfied, no resume key.
-  EXPECT_FALSE(result.responses[0].chunkSlices.empty());
+  EXPECT_FALSE(result.responses[0].chunks.empty());
   EXPECT_FALSE(result.responses[0].resumeKey.has_value());
 
   // Request 1: 100 rows, fully satisfied (ends at stripe boundary), no resume.
-  EXPECT_FALSE(result.responses[1].chunkSlices.empty());
+  EXPECT_FALSE(result.responses[1].chunks.empty());
   EXPECT_FALSE(result.responses[1].resumeKey.has_value());
 
   // Request 2: 100 rows from stripe 0, has data in stripes 1-4, resume key.
-  EXPECT_FALSE(result.responses[2].chunkSlices.empty());
+  EXPECT_FALSE(result.responses[2].chunks.empty());
   EXPECT_TRUE(result.responses[2].resumeKey.has_value());
 
   // Request 3: stripe 9 never processed, resume key = original lower key.
-  EXPECT_TRUE(result.responses[3].chunkSlices.empty());
+  EXPECT_TRUE(result.responses[3].chunks.empty());
   ASSERT_TRUE(result.responses[3].resumeKey.has_value());
   EXPECT_EQ(result.responses[3].resumeKey.value(), bounds3.lowerKey);
 }
@@ -2569,9 +2563,8 @@ TEST_P(NimbleIndexProjectorTest, maxBytesAndMaxRowsPerRequestInteraction) {
     NimbleIndexProjector::Request request;
     request.keyBounds = {bounds};
     auto result = projector->project(request, {});
-    ASSERT_EQ(result.responses[0].chunkSlices.size(), 1);
-    bytesPerStripe =
-        result.responses[0].chunkSlices[0].computeChainDataLength();
+    ASSERT_EQ(result.responses[0].chunks.size(), 1);
+    bytesPerStripe = projector->stats().numReadBytes;
   }
 
   // maxRowsPerRequest clips to 150 rows (mid-stripe), maxBytes allows 5
@@ -2626,9 +2619,8 @@ TEST_P(NimbleIndexProjectorTest, maxBytesLargeScale) {
     NimbleIndexProjector::Request request;
     request.keyBounds = {bounds};
     auto result = projector->project(request, {});
-    ASSERT_EQ(result.responses[0].chunkSlices.size(), 1);
-    bytesPerStripe =
-        result.responses[0].chunkSlices[0].computeChainDataLength();
+    ASSERT_EQ(result.responses[0].chunks.size(), 1);
+    bytesPerStripe = projector->stats().numReadBytes;
   }
 
   // Paginate all 10,000 rows with byte limit of ~3 stripes per page.
@@ -2712,7 +2704,7 @@ TEST_P(NimbleIndexProjectorTest, cacheDataReadStats) {
       request.keyBounds.push_back(std::move(bounds));
       auto result = projector->project(request, {});
       ASSERT_EQ(result.responses.size(), 1);
-      EXPECT_FALSE(result.responses[0].chunkSlices.empty());
+      EXPECT_FALSE(result.responses[0].chunks.empty());
 
       const auto& stats = projector->stats();
       EXPECT_GT(stats.numStorageReads, 0);
@@ -2730,7 +2722,7 @@ TEST_P(NimbleIndexProjectorTest, cacheDataReadStats) {
       request.keyBounds.push_back(std::move(bounds));
       auto result = projector->project(request, {});
       ASSERT_EQ(result.responses.size(), 1);
-      EXPECT_FALSE(result.responses[0].chunkSlices.empty());
+      EXPECT_FALSE(result.responses[0].chunks.empty());
 
       const auto& stats = projector->stats();
       if (testCase.expectCacheHitsOnSecondPass) {


### PR DESCRIPTION
Summary:

Remove the unused `SerializationVersion::kCompact` (value 1) from the serializer, and restructure the serialization header code for clarity.

**kCompact removal:**
- Remove `kCompact = 1` from the `SerializationVersion` enum (wire values 0, 2, 3 are preserved)
- Update `isCompactFormat()` to check only `kCompactRaw`
- Remove `kCompact` from version validation, test params, and string mappings across all consumers (dwio, datainfra, rexdb, zippydb)
- Change `Projector::Options::projectVersion` default from `kCompact` to `kCompactRaw`

**Extract `SerializationHeader.h/cpp`:**
- Move `TabletChunkHeader`, `createTabletChunkHeader`, `readTabletChunkHeader`, `extractTabletChunkHeader`, and `estimateTabletChunkHeaderSize` out of `SerializerImpl.h/cpp` and `DeserializerImpl.h/cpp` into a new `SerializationHeader.h/cpp`
- Add `SerializationHeader` struct and `readSerializationHeader()` to consolidate version detection + row count parsing across all formats
- Add `writeSerializationHeader()` (moved from `SerializerImpl.h`) and `estimateSerializationHeaderSize()`
- Remove kTabletRaw branch from `writeSerializationHeader` / `estimateSerializationHeaderSize` with `NIMBLE_CHECK` guards
- Simplify `StreamDataReader::initialize()` to a single `readSerializationHeader()` call, remove `readVersion()`

**NimbleIndexProjector cleanup:**
- Extract `assembleChunk()` free function for building chunk IOBuf chains
- Simplify byte tracking to body bytes only (remove header byte accounting)
- Rename: `chunkSlices` -> `chunks`, `finalizeResultChunks` -> `finalizeResult`, `sharedData` -> `sharedBody`, `numStripeRows` -> `numRows`
- Use `isTabletRawFormat()` helper instead of inline version comparisons
- Clear `resultChunks_` eagerly in `finalizeResult()`

**Style cleanup:**
- Use `/*param=*/value` annotation style for tablet chunk header size constants
- Rename `totalSize` -> `headerBytes` in `createTabletChunkHeader`
- Use `resumeKeyLength > 0` check with sanity assertion

Reviewed By: tanjialiang, duxiao1212

Differential Revision: D106214145


