### PR TITLE
feat(selective): Support RLE nested dictionary encoding (#776)

### DIFF
--- a/dwio/nimble/encodings/BufferedEncoding.h
+++ b/dwio/nimble/encodings/BufferedEncoding.h
@@ -1,0 +1,119 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <array>
+#include "dwio/nimble/encodings/common/Encoding.h"
+
+namespace facebook::nimble::detail {
+
+/// Buffers values from an encoding, reading in pages of BufferSize.
+template <typename T, uint16_t BufferSize>
+class BufferedEncoding {
+ public:
+  explicit BufferedEncoding(std::unique_ptr<Encoding> encoding)
+      : encoding_{std::move(encoding)} {}
+
+  T nextValue() {
+    if (UNLIKELY(bufferPosition_ == BufferSize)) {
+      refill();
+    }
+    ++encodingPosition_;
+    return buffer_[bufferPosition_++];
+  }
+
+  void reset() {
+    bufferPosition_ = BufferSize;
+    encodingPosition_ = 0;
+    encoding_->reset();
+  }
+
+ private:
+  FOLLY_ALWAYS_INLINE void refill() {
+    auto numRows = std::min<uint32_t>(
+        BufferSize, encoding_->rowCount() - encodingPosition_);
+    encoding_->materialize(numRows, buffer_.data());
+    bufferPosition_ = 0;
+  }
+
+  const std::unique_ptr<Encoding> encoding_;
+  // Position within the current page buffer (0..BufferSize-1).
+  // Reset to BufferSize to trigger a refill on the next read.
+  uint16_t bufferPosition_{BufferSize};
+  // Number of values consumed from the encoding so far.
+  uint32_t encodingPosition_{0};
+  std::array<T, BufferSize> buffer_;
+};
+
+/// Buffers dictionary indices from an encoding, reading in pages of BufferSize.
+/// Exposes nextIndex() for dictionary index access and forwards dictionary
+/// metadata to the inner encoding.
+template <typename T, uint16_t BufferSize>
+class BufferedDictEncoding {
+ public:
+  explicit BufferedDictEncoding(std::unique_ptr<Encoding> encoding)
+      : encoding_{std::move(encoding)} {}
+
+  /// Advances position and returns the next dictionary index.
+  uint32_t nextIndex() {
+    if (UNLIKELY(bufferPosition_ == BufferSize)) {
+      refill();
+    }
+    ++encodingPosition_;
+    return indicesBuffer_[bufferPosition_++];
+  }
+
+  void reset() {
+    bufferPosition_ = BufferSize;
+    encodingPosition_ = 0;
+    encoding_->reset();
+  }
+
+  uint32_t dictionarySize() const noexcept {
+    return encoding_->dictionarySize();
+  }
+
+  const void* dictionaryEntries() const noexcept {
+    return encoding_->dictionaryEntries();
+  }
+
+ private:
+  FOLLY_ALWAYS_INLINE void refill() {
+    auto numRows = std::min<uint32_t>(
+        BufferSize, encoding_->rowCount() - encodingPosition_);
+    encoding_->materializeIndices(numRows, indicesBuffer_.data());
+    // Zero-fill unused positions so the RLE base class's one-run-ahead
+    // read produces a valid index (0) instead of uninitialized garbage.
+    // When the last page is partial, positions [numRows, BufferSize) are
+    // uninitialized. The base class skip/materialize may read one position
+    // ahead of the last consumed value, so these must be safe to read.
+    if (numRows < BufferSize) {
+      std::fill(
+          indicesBuffer_.begin() + numRows, indicesBuffer_.end(), uint32_t{0});
+    }
+    bufferPosition_ = 0;
+  }
+
+  const std::unique_ptr<Encoding> encoding_;
+  // Position within the current page buffer (0..BufferSize-1).
+  // Reset to BufferSize to trigger a refill on the next read.
+  uint16_t bufferPosition_{BufferSize};
+  // Number of values consumed from the encoding so far.
+  uint32_t encodingPosition_{0};
+  std::array<uint32_t, BufferSize> indicesBuffer_;
+};
+
+} // namespace facebook::nimble::detail

--- a/dwio/nimble/encodings/RleEncoding.h
+++ b/dwio/nimble/encodings/RleEncoding.h
@@ -21,6 +21,8 @@
 #include "dwio/nimble/common/Buffer.h"
 #include "dwio/nimble/common/FixedBitArray.h"
 #include "dwio/nimble/common/Vector.h"
+#include "dwio/nimble/encodings/BufferedEncoding.h"
+#include "dwio/nimble/encodings/DictionaryEncoding.h"
 #include "dwio/nimble/encodings/common/Encoding.h"
 #include "dwio/nimble/encodings/common/EncodingFactory.h"
 #include "dwio/nimble/encodings/common/EncodingPrimitives.h"
@@ -96,14 +98,14 @@ class RLEEncodingBase
                  data.data() + this->dataOffset())},
             stringBufferFactory)} {}
 
-  void reset() {
+  void reset() override {
     materializedRunLengths_.reset();
     derived().resetValues();
     copiesRemaining_ = materializedRunLengths_.nextValue();
     currentValue_ = nextValue();
   }
 
-  void skip(uint32_t rowCount) final {
+  void skip(uint32_t rowCount) override {
     uint32_t rowsLeft = rowCount;
     // TODO: We should have skip blocks.
     while (rowsLeft) {
@@ -118,7 +120,7 @@ class RLEEncodingBase
     }
   }
 
-  void materialize(uint32_t rowCount, void* buffer) final {
+  void materialize(uint32_t rowCount, void* buffer) override {
     uint32_t rowsLeft = rowCount;
     physicalType* output = static_cast<physicalType*>(buffer);
     while (rowsLeft) {
@@ -230,8 +232,18 @@ class RLEEncoding final : public internal::RLEEncodingBase<T, RLEEncoding<T>> {
       std::function<void*(uint32_t)> stringBufferFactory,
       const Encoding::Options& options = {});
 
+  void reset() final;
+
+  void skip(uint32_t rowCount) final;
+
+  void materialize(uint32_t rowCount, void* buffer) final;
+
   physicalType nextValue();
+
+  uint32_t nextIndex();
+
   void resetValues();
+
   static std::string_view getSerializedRunValues(
       EncodingSelection<physicalType>& selection,
       const Vector<physicalType>& runValues,
@@ -252,7 +264,101 @@ class RLEEncoding final : public internal::RLEEncodingBase<T, RLEEncoding<T>> {
       vector_size_t numSelected,
       const vector_size_t* scatterRows);
 
+  /// RLE wraps an inner Dictionary encoding. The dictionary is identical
+  /// to the inner encoding's dictionary.
+  bool dictionaryEnabled() const override {
+    return dictValues_ != nullptr;
+  }
+
+  uint32_t dictionarySize() const override {
+    NIMBLE_CHECK_NOT_NULL(dictValues_);
+    return dictValues_->dictionarySize();
+  }
+
+  const void* dictionaryEntry(uint32_t index) const override {
+    NIMBLE_CHECK_NOT_NULL(dictValues_);
+    return static_cast<const physicalType*>(dictionaryEntries()) + index;
+  }
+
+  const void* dictionaryEntries() const override {
+    NIMBLE_CHECK_NOT_NULL(dictValues_);
+    return dictValues_->dictionaryEntries();
+  }
+
+  /// Materializes composed dictionary indices for rowCount dense non-null rows.
+  /// For each RLE run, looks up the run value's dictionary index via the
+  /// value→index map, then fills the buffer with that index repeated for
+  /// the run length.
+  void materializeIndices(uint32_t rowCount, uint32_t* buffer) override {
+    NIMBLE_CHECK_NOT_NULL(dictValues_);
+    NIMBLE_CHECK_NULL(values_);
+    uint32_t rowsLeft = rowCount;
+    uint32_t numOutputRows = 0;
+    uint32_t runIndex = 0;
+    while (rowsLeft > 0) {
+      if (this->copiesRemaining_ == 0) {
+        this->copiesRemaining_ = this->materializedRunLengths_.nextValue();
+        runIndex = this->nextIndex();
+        this->currentValue_ = alphabet_[runIndex];
+      }
+      const auto numRows = std::min(rowsLeft, this->copiesRemaining_);
+      velox::simd::simdFill(buffer + numOutputRows, runIndex, numRows);
+      numOutputRows += numRows;
+      rowsLeft -= numRows;
+      this->copiesRemaining_ -= numRows;
+    }
+  }
+
+  /// Reads dictionary indices through an RLE wrapper using the standard
+  /// materializeIndices + dense/sparse helper pattern.
+  template <typename IndicesVisitor>
+  void readIndicesWithVisitor(
+      IndicesVisitor& visitor,
+      ReadWithVisitorParams& params) {
+    NIMBLE_CHECK(
+        this->dictionaryEnabled(),
+        "readIndicesWithVisitor requires dictionary-enabled inner encoding");
+    NIMBLE_CHECK(
+        !IndicesVisitor::kHasFilter && !IndicesVisitor::kHasHook,
+        "readIndicesWithVisitor should only be invoked in dictionary fast path");
+    const auto numReadRows =
+        visitor.rowAt(visitor.numRows() - 1) - params.numScanned + 1;
+    auto* rawNulls = visitor.reader().rawNullsInReadRange();
+    const auto numNonNulls = rawNulls != nullptr
+        ? velox::bits::countNonNulls(
+              rawNulls, params.numScanned, params.numScanned + numReadRows)
+        : numReadRows;
+
+    if (IndicesVisitor::dense) {
+      NIMBLE_CHECK_EQ(
+          visitor.rowAt(visitor.numRows() - 1),
+          visitor.rowAt(0) + visitor.numRows() - 1,
+          "Dense visitor must have contiguous rows");
+      detail::readDenseMaterializedIndices(
+          *this,
+          visitor,
+          rawNulls,
+          params.numScanned,
+          numReadRows,
+          numNonNulls);
+      return;
+    }
+
+    indicesBuffer_.resize(numNonNulls);
+    detail::readSparseMaterializedIndices(
+        *this,
+        visitor,
+        params.numScanned,
+        params.prepareResultNulls,
+        rawNulls,
+        numReadRows,
+        numNonNulls,
+        indicesBuffer_.data());
+  }
+
  private:
+  void advanceRunValue();
+
   template <bool kDense>
   vector_size_t findNumInRun(
       const vector_size_t* rows,
@@ -260,7 +366,14 @@ class RLEEncoding final : public internal::RLEEncodingBase<T, RLEEncoding<T>> {
       vector_size_t numRows,
       vector_size_t currentRow) const;
 
-  detail::BufferedEncoding<physicalType, 128> values_;
+  // Exactly one of values_ or dictValues_ is active. When the inner
+  // encoding is dictionary-enabled, dictValues_ loads indices in pages
+  // and reconstructs values from the alphabet. Otherwise values_ loads
+  // values directly via materialize().
+  std::unique_ptr<detail::BufferedEncoding<physicalType, 128>> values_;
+  std::unique_ptr<detail::BufferedDictEncoding<physicalType, 128>> dictValues_;
+  const physicalType* alphabet_{nullptr};
+  Vector<uint32_t> indicesBuffer_;
 };
 
 // For the bool case we know the values will alternate between true
@@ -304,33 +417,138 @@ class RLEEncoding<bool> final
 
 template <typename T>
 RLEEncoding<T>::RLEEncoding(
-    velox::memory::MemoryPool& memoryPool,
+    velox::memory::MemoryPool& pool,
     std::string_view data,
     std::function<void*(uint32_t)> stringBufferFactory,
     const Encoding::Options& options)
     : internal::RLEEncodingBase<T, RLEEncoding<T>>(
-          memoryPool,
+          pool,
           data,
           stringBufferFactory,
           options),
-      values_{EncodingFactory(options).create(
-          memoryPool,
-          {internal::RLEEncodingBase<T, RLEEncoding<T>>::getValuesStart(),
-           static_cast<size_t>(
-               data.end() -
-               internal::RLEEncodingBase<T, RLEEncoding<T>>::getValuesStart())},
-          stringBufferFactory)} {
-  internal::RLEEncodingBase<T, RLEEncoding<T>>::reset();
+      indicesBuffer_(&pool) {
+  auto valuesView = std::string_view{
+      internal::RLEEncodingBase<T, RLEEncoding<T>>::getValuesStart(),
+      static_cast<size_t>(
+          data.end() -
+          internal::RLEEncodingBase<T, RLEEncoding<T>>::getValuesStart())};
+  auto valuesEncoding =
+      EncodingFactory(options).create(pool, valuesView, stringBufferFactory);
+  if (valuesEncoding->dictionaryEnabled()) {
+    dictValues_ =
+        std::make_unique<detail::BufferedDictEncoding<physicalType, 128>>(
+            std::move(valuesEncoding));
+    alphabet_ =
+        static_cast<const physicalType*>(dictValues_->dictionaryEntries());
+  } else {
+    values_ = std::make_unique<detail::BufferedEncoding<physicalType, 128>>(
+        std::move(valuesEncoding));
+  }
+  this->reset();
+}
+
+// Advances to the next run value, setting currentValue_ from either
+// the values buffer (non-dict) or the alphabet via dictionary index (dict).
+template <typename T>
+void RLEEncoding<T>::advanceRunValue() {
+  if (dictValues_ != nullptr) {
+    if constexpr (isStringType<physicalType>()) {
+      NIMBLE_CHECK_NULL(values_);
+    } else {
+      NIMBLE_DCHECK_NULL(values_);
+    }
+    this->currentValue_ = alphabet_[dictValues_->nextIndex()];
+  } else {
+    if constexpr (isStringType<physicalType>()) {
+      NIMBLE_CHECK_NOT_NULL(values_);
+    } else {
+      NIMBLE_DCHECK_NOT_NULL(values_);
+    }
+    this->currentValue_ = values_->nextValue();
+  }
+}
+
+template <typename T>
+void RLEEncoding<T>::reset() {
+  this->materializedRunLengths_.reset();
+  this->resetValues();
+  this->copiesRemaining_ = this->materializedRunLengths_.nextValue();
+  advanceRunValue();
+}
+
+template <typename T>
+void RLEEncoding<T>::skip(uint32_t rowCount) {
+  uint32_t rowsLeft = rowCount;
+  while (rowsLeft > 0) {
+    if (rowsLeft < this->copiesRemaining_) {
+      this->copiesRemaining_ -= rowsLeft;
+      return;
+    }
+    rowsLeft -= this->copiesRemaining_;
+    this->copiesRemaining_ = this->materializedRunLengths_.nextValue();
+    advanceRunValue();
+  }
+}
+
+template <typename T>
+void RLEEncoding<T>::materialize(uint32_t rowCount, void* buffer) {
+  uint32_t rowsLeft = rowCount;
+  auto* output = static_cast<physicalType*>(buffer);
+  while (rowsLeft > 0) {
+    if (rowsLeft < this->copiesRemaining_) {
+      velox::simd::simdFill(output, this->currentValue_, rowsLeft);
+      this->copiesRemaining_ -= rowsLeft;
+      return;
+    }
+    velox::simd::simdFill(output, this->currentValue_, this->copiesRemaining_);
+    output += this->copiesRemaining_;
+    rowsLeft -= this->copiesRemaining_;
+    this->copiesRemaining_ = this->materializedRunLengths_.nextValue();
+    advanceRunValue();
+  }
 }
 
 template <typename T>
 typename RLEEncoding<T>::physicalType RLEEncoding<T>::nextValue() {
-  return values_.nextValue();
+  if constexpr (isStringType<physicalType>()) {
+    NIMBLE_CHECK_NOT_NULL(values_);
+    NIMBLE_CHECK_NULL(dictValues_);
+  } else {
+    NIMBLE_DCHECK_NOT_NULL(values_);
+    NIMBLE_DCHECK_NULL(dictValues_);
+  }
+  return values_->nextValue();
+}
+
+template <typename T>
+uint32_t RLEEncoding<T>::nextIndex() {
+  if constexpr (isStringType<physicalType>()) {
+    NIMBLE_CHECK_NOT_NULL(dictValues_);
+    NIMBLE_CHECK_NULL(values_);
+  } else {
+    NIMBLE_DCHECK_NOT_NULL(dictValues_);
+    NIMBLE_DCHECK_NULL(values_);
+  }
+  return dictValues_->nextIndex();
 }
 
 template <typename T>
 void RLEEncoding<T>::resetValues() {
-  values_.reset();
+  if (dictValues_ != nullptr) {
+    if constexpr (isStringType<physicalType>()) {
+      NIMBLE_CHECK_NULL(values_);
+    } else {
+      NIMBLE_DCHECK_NULL(values_);
+    }
+    dictValues_->reset();
+  } else {
+    if constexpr (isStringType<physicalType>()) {
+      NIMBLE_CHECK_NOT_NULL(values_);
+    } else {
+      NIMBLE_DCHECK_NOT_NULL(values_);
+    }
+    values_->reset();
+  }
 }
 
 template <typename T>
@@ -380,7 +598,7 @@ void RLEEncoding<T>::bulkScan(
   for (;;) {
     if (this->copiesRemaining_ == 0) {
       this->copiesRemaining_ = this->materializedRunLengths_.nextValue();
-      this->currentValue_ = nextValue();
+      advanceRunValue();
     }
     const auto numInRun = findNumInRun<V::dense>(
         selectedRows, selectedRowIndex, numSelected, currentRow);
@@ -450,8 +668,18 @@ void RLEEncoding<T>::readWithVisitor(
   if (velox::dwio::common::useFastPath(visitor, nulls)) {
     detail::readWithVisitorFast(*this, visitor, params, nulls);
   } else {
-    internal::RLEEncodingBase<T, RLEEncoding<T>>::readWithVisitor(
-        visitor, params);
+    detail::readWithVisitorSlow(
+        visitor,
+        params,
+        [&](auto toSkip) { this->skip(toSkip); },
+        [&] {
+          if (this->copiesRemaining_ == 0) {
+            this->copiesRemaining_ = this->materializedRunLengths_.nextValue();
+            advanceRunValue();
+          }
+          --this->copiesRemaining_;
+          return this->currentValue_;
+        });
   }
 }
 

--- a/dwio/nimble/encodings/SparseBoolEncoding.h
+++ b/dwio/nimble/encodings/SparseBoolEncoding.h
@@ -18,6 +18,7 @@
 #include <span>
 #include "dwio/nimble/common/Buffer.h"
 #include "dwio/nimble/common/FixedBitArray.h"
+#include "dwio/nimble/encodings/BufferedEncoding.h"
 #include "dwio/nimble/encodings/common/Encoding.h"
 #include "dwio/nimble/encodings/selection/EncodingIdentifier.h"
 #include "dwio/nimble/encodings/selection/EncodingSelection.h"

--- a/dwio/nimble/encodings/common/Encoding.h
+++ b/dwio/nimble/encodings/common/Encoding.h
@@ -391,46 +391,6 @@ void callReadWithVisitor(
 
 namespace detail {
 
-template <typename T, uint16_t BufferSize>
-class BufferedEncoding {
- public:
-  explicit BufferedEncoding(std::unique_ptr<Encoding> encoding)
-      : bufferPosition_{BufferSize},
-        encodingPosition_{0},
-        encoding_{std::move(encoding)} {}
-
-  T nextValue() {
-    if (UNLIKELY(bufferPosition_ == BufferSize)) {
-      auto rows = std::min<uint32_t>(
-          BufferSize, encoding_->rowCount() - encodingPosition_);
-      encoding_->materialize(rows, buffer_.data());
-      bufferPosition_ = 0;
-    }
-    ++encodingPosition_;
-    return buffer_[bufferPosition_++];
-  }
-
-  void reset() {
-    bufferPosition_ = BufferSize;
-    encodingPosition_ = 0;
-    encoding_->reset();
-  }
-
-  uint32_t position() const noexcept {
-    return encodingPosition_ - 1;
-  }
-
-  uint32_t rowCount() const noexcept {
-    return encoding_->rowCount();
-  }
-
- private:
-  uint16_t bufferPosition_;
-  uint32_t encodingPosition_;
-  std::unique_ptr<Encoding> encoding_;
-  std::array<T, BufferSize> buffer_;
-};
-
 template <typename T, typename PhysicalType>
 T castFromPhysicalType(const PhysicalType& value) {
   if constexpr (isFloatingPointType<T>()) {

--- a/dwio/nimble/encodings/common/EncodingUtils.h
+++ b/dwio/nimble/encodings/common/EncodingUtils.h
@@ -200,6 +200,11 @@ void callReadIndicesWithVisitor(
           .readIndicesWithVisitor(visitor, params);
       return;
     }
+    case EncodingType::RLE: {
+      static_cast<RLEEncoding<std::string_view>&>(encoding)
+          .readIndicesWithVisitor(visitor, params);
+      return;
+    }
     default:
       NIMBLE_UNREACHABLE(
           "Dictionary indices dispatch on unsupported encoding: {}",

--- a/dwio/nimble/encodings/legacy/Encoding.h
+++ b/dwio/nimble/encodings/legacy/Encoding.h
@@ -15,6 +15,7 @@
  */
 #pragma once
 
+#include "dwio/nimble/encodings/BufferedEncoding.h"
 #include "dwio/nimble/encodings/common/Encoding.h"
 
 // Legacy encoding headers use qualified names like detail::readWithVisitorSlow.
@@ -38,6 +39,7 @@ void callReadWithVisitor(
 
 namespace detail {
 
+using ::facebook::nimble::detail::BufferedDictEncoding;
 using ::facebook::nimble::detail::BufferedEncoding;
 using ::facebook::nimble::detail::castFromPhysicalType;
 using ::facebook::nimble::detail::dataToValue;

--- a/dwio/nimble/encodings/tests/BufferedEncodingTest.cpp
+++ b/dwio/nimble/encodings/tests/BufferedEncodingTest.cpp
@@ -1,0 +1,235 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "dwio/nimble/encodings/BufferedEncoding.h"
+#include <gtest/gtest.h>
+#include <span>
+#include <vector>
+#include "dwio/nimble/common/Buffer.h"
+#include "dwio/nimble/encodings/DictionaryEncoding.h"
+#include "dwio/nimble/encodings/TrivialEncoding.h"
+#include "dwio/nimble/encodings/common/EncodingFactory.h"
+#include "dwio/nimble/encodings/selection/EncodingSelectionPolicy.h"
+#include "velox/buffer/Buffer.h"
+#include "velox/common/memory/Memory.h"
+
+using namespace facebook;
+
+namespace {
+
+template <typename T>
+class NoOpEncodingSelectionPolicy : public nimble::EncodingSelectionPolicy<T> {
+  using physicalType = typename nimble::TypeTraits<T>::physicalType;
+
+ public:
+  nimble::EncodingSelectionResult select(
+      std::span<const physicalType>,
+      const nimble::Statistics<physicalType>&) override {
+    return {.encodingType = nimble::EncodingType::Trivial};
+  }
+
+  nimble::EncodingSelectionResult selectNullable(
+      std::span<const physicalType>,
+      std::span<const bool>,
+      const nimble::Statistics<physicalType>&) override {
+    return {.encodingType = nimble::EncodingType::Nullable};
+  }
+
+  std::unique_ptr<nimble::EncodingSelectionPolicyBase> createImpl(
+      nimble::EncodingType,
+      nimble::NestedEncodingIdentifier,
+      nimble::DataType type) override {
+    UNIQUE_PTR_FACTORY(type, NoOpEncodingSelectionPolicy);
+  }
+};
+
+class BufferedEncodingTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    pool_ = facebook::velox::memory::deprecatedAddDefaultLeafMemoryPool();
+    buffer_ = std::make_unique<nimble::Buffer>(*pool_);
+  }
+
+  std::unique_ptr<nimble::Encoding> createDictEncoding(
+      const std::vector<uint32_t>& data) {
+    auto span = std::span<const uint32_t>(data.data(), data.size());
+    nimble::EncodingSelection<uint32_t> sel{
+        {.encodingType = nimble::EncodingType::Dictionary},
+        nimble::Statistics<uint32_t>::create(span),
+        std::make_unique<NoOpEncodingSelectionPolicy<uint32_t>>()};
+    auto serialized =
+        nimble::DictionaryEncoding<uint32_t>::encode(sel, span, *buffer_);
+    return nimble::EncodingFactory().create(
+        *pool_, serialized, [](uint32_t) -> void* { return nullptr; });
+  }
+
+  std::unique_ptr<nimble::Encoding> createTrivialEncoding(
+      const std::vector<uint32_t>& data) {
+    auto span = std::span<const uint32_t>(data.data(), data.size());
+    nimble::EncodingSelection<uint32_t> sel{
+        {.encodingType = nimble::EncodingType::Trivial},
+        nimble::Statistics<uint32_t>::create(span),
+        std::make_unique<NoOpEncodingSelectionPolicy<uint32_t>>()};
+    auto serialized =
+        nimble::TrivialEncoding<uint32_t>::encode(sel, span, *buffer_);
+    return nimble::EncodingFactory().create(
+        *pool_, serialized, [](uint32_t) -> void* { return nullptr; });
+  }
+
+  std::shared_ptr<velox::memory::MemoryPool> pool_;
+  std::unique_ptr<nimble::Buffer> buffer_;
+};
+
+TEST_F(BufferedEncodingTest, valueModeRead) {
+  std::vector<uint32_t> data = {1, 2, 3, 1, 2, 3, 1, 2, 3, 1};
+  auto encoding = createDictEncoding(data);
+
+  // Small page size (4) to trigger multiple refills across 10 values.
+  nimble::detail::BufferedEncoding<uint32_t, 4> buf(std::move(encoding));
+  for (size_t i = 0; i < data.size(); ++i) {
+    EXPECT_EQ(buf.nextValue(), data[i]) << "row " << i;
+  }
+}
+
+TEST_F(BufferedEncodingTest, valueModeNotDictionaryEnabled) {
+  // Trivial encoding is not dictionary-enabled.
+  std::vector<uint32_t> data = {1, 2, 3, 4, 5};
+  auto encoding = createTrivialEncoding(data);
+
+  nimble::detail::BufferedEncoding<uint32_t, 128> buf(std::move(encoding));
+  for (size_t i = 0; i < data.size(); ++i) {
+    EXPECT_EQ(buf.nextValue(), data[i]) << "row " << i;
+  }
+}
+
+TEST_F(BufferedEncodingTest, dictionaryModeRead) {
+  std::vector<uint32_t> data = {10, 20, 30, 10, 20, 30, 10, 20, 30, 10};
+  auto encoding = createDictEncoding(data);
+  ASSERT_TRUE(encoding->dictionaryEnabled());
+  const auto dictSize = encoding->dictionarySize();
+
+  // Small page size to test multi-page index loading.
+  nimble::detail::BufferedDictEncoding<uint32_t, 4> buf(std::move(encoding));
+  const auto* entries = static_cast<const uint32_t*>(buf.dictionaryEntries());
+  for (size_t i = 0; i < data.size(); ++i) {
+    auto idx = buf.nextIndex();
+    EXPECT_LT(idx, dictSize) << "row " << i;
+    EXPECT_EQ(entries[idx], data[i]) << "row " << i;
+  }
+}
+
+TEST_F(BufferedEncodingTest, dictionaryModeDictionaryAPI) {
+  std::vector<uint32_t> data = {100, 200, 100, 200, 100};
+  auto encoding = createDictEncoding(data);
+  ASSERT_TRUE(encoding->dictionaryEnabled());
+  const auto* entries =
+      static_cast<const uint32_t*>(encoding->dictionaryEntries());
+  const auto dictSize = encoding->dictionarySize();
+
+  nimble::detail::BufferedDictEncoding<uint32_t, 128> buf(std::move(encoding));
+  for (size_t i = 0; i < data.size(); ++i) {
+    auto idx = buf.nextIndex();
+    ASSERT_LT(idx, dictSize);
+    EXPECT_EQ(entries[idx], data[i]) << "row " << i;
+  }
+}
+
+TEST_F(BufferedEncodingTest, dictionaryModeReset) {
+  std::vector<uint32_t> data = {5, 10, 15, 5, 10};
+  auto encoding = createDictEncoding(data);
+
+  nimble::detail::BufferedDictEncoding<uint32_t, 128> buf(std::move(encoding));
+  const auto* entries = static_cast<const uint32_t*>(buf.dictionaryEntries());
+
+  for (size_t i = 0; i < data.size(); ++i) {
+    EXPECT_EQ(entries[buf.nextIndex()], data[i]);
+  }
+
+  buf.reset();
+  for (size_t i = 0; i < data.size(); ++i) {
+    EXPECT_EQ(entries[buf.nextIndex()], data[i]) << "after reset, row " << i;
+  }
+}
+
+TEST_F(BufferedEncodingTest, dictionaryModeStringValues) {
+  std::vector<std::string> owned = {"alpha", "bravo", "charlie"};
+  std::vector<std::string_view> data;
+  for (const auto& s : owned) {
+    for (int i = 0; i < 3; ++i) {
+      data.push_back(s);
+    }
+  }
+  auto span = std::span<const std::string_view>(data.data(), data.size());
+  nimble::EncodingSelection<std::string_view> sel{
+      {.encodingType = nimble::EncodingType::Dictionary},
+      nimble::Statistics<std::string_view>::create(span),
+      std::make_unique<NoOpEncodingSelectionPolicy<std::string_view>>()};
+  nimble::Buffer encBuf{*pool_};
+  auto serialized =
+      nimble::DictionaryEncoding<std::string_view>::encode(sel, span, encBuf);
+  std::vector<velox::BufferPtr> stringBufs;
+  auto encoding =
+      nimble::EncodingFactory().create(*pool_, serialized, [&](uint32_t size) {
+        auto& buf = stringBufs.emplace_back(
+            velox::AlignedBuffer::allocate<char>(size, pool_.get()));
+        return buf->asMutable<void>();
+      });
+
+  ASSERT_TRUE(encoding->dictionaryEnabled());
+  const auto* entries =
+      static_cast<const std::string_view*>(encoding->dictionaryEntries());
+  const auto dictSize = encoding->dictionarySize();
+
+  nimble::detail::BufferedDictEncoding<std::string_view, 4> buf(
+      std::move(encoding));
+
+  for (size_t i = 0; i < data.size(); ++i) {
+    auto idx = buf.nextIndex();
+    ASSERT_LT(idx, dictSize) << "row " << i;
+    EXPECT_EQ(entries[idx], data[i]) << "row " << i;
+  }
+}
+
+TEST_F(BufferedEncodingTest, dictionaryModeValueAndIndexInterleaved) {
+  std::vector<uint32_t> data = {10, 20, 30, 10, 20, 30, 10, 20};
+  auto encoding = createDictEncoding(data);
+  ASSERT_TRUE(encoding->dictionaryEnabled());
+  const auto* entries =
+      static_cast<const uint32_t*>(encoding->dictionaryEntries());
+  const auto dictSize = encoding->dictionarySize();
+
+  // Page size 3 forces multiple refills across 8 values, exercising
+  // index access across page boundaries.
+  nimble::detail::BufferedDictEncoding<uint32_t, 3> buf(std::move(encoding));
+  for (size_t i = 0; i < data.size(); ++i) {
+    auto idx = buf.nextIndex();
+    ASSERT_LT(idx, dictSize) << "row " << i;
+    EXPECT_EQ(entries[idx], data[i]) << "row " << i;
+  }
+}
+
+TEST_F(BufferedEncodingTest, dictionaryModeDictionaryMetadata) {
+  std::vector<uint32_t> data = {10, 20, 30, 10, 20, 30};
+  auto encoding = createDictEncoding(data);
+  ASSERT_TRUE(encoding->dictionaryEnabled());
+  const auto expectedSize = encoding->dictionarySize();
+  const auto* expectedEntries = encoding->dictionaryEntries();
+
+  nimble::detail::BufferedDictEncoding<uint32_t, 128> buf(std::move(encoding));
+  EXPECT_EQ(buf.dictionarySize(), expectedSize);
+  EXPECT_EQ(buf.dictionaryEntries(), expectedEntries);
+}
+
+} // namespace

--- a/dwio/nimble/encodings/tests/CMakeLists.txt
+++ b/dwio/nimble/encodings/tests/CMakeLists.txt
@@ -19,6 +19,7 @@ target_link_libraries(nimble_encoding_layout_test_helper nimble_encodings)
 
 add_executable(
   nimble_encodings_tests
+  BufferedEncodingTest.cpp
   ConstantEncodingTest.cpp
   EncodingLayoutTest.cpp
   EncodingSelectionTest.cpp

--- a/dwio/nimble/encodings/tests/EncodingTest.cpp
+++ b/dwio/nimble/encodings/tests/EncodingTest.cpp
@@ -966,6 +966,68 @@ class DictionaryApiTypedTest : public ::testing::Test {
     return decodeEncoding(std::string_view(reserved, encodingSize));
   }
 
+  /// Serializes values as RLE wrapping Dictionary into outputBuffer.
+  /// Computes runs, encodes run lengths as Trivial<uint32_t>, encodes
+  /// run values as Dictionary<T>.
+  std::string_view serializeRleDictionary(
+      const std::vector<T>& values,
+      nimble::Buffer& outputBuffer) {
+    NIMBLE_CHECK(!values.empty());
+    const uint32_t rowCount = values.size();
+
+    nimble::Vector<uint32_t> runLengths{pool_.get()};
+    nimble::Vector<PhysicalType> runValues{pool_.get()};
+    auto span = std::span<const PhysicalType>(
+        reinterpret_cast<const PhysicalType*>(values.data()), values.size());
+    nimble::rle::computeRuns(span, &runLengths, &runValues);
+
+    // Encode run lengths as Trivial<uint32_t>.
+    auto runLengthSpan =
+        std::span<const uint32_t>(runLengths.data(), runLengths.size());
+    nimble::Buffer rlBuf{*pool_};
+    nimble::EncodingSelection<uint32_t> rlSel{
+        {.encodingType = nimble::EncodingType::Trivial},
+        nimble::Statistics<uint32_t>::create(runLengthSpan),
+        std::make_unique<TestTrivialEncodingSelectionPolicy<uint32_t>>(
+            false, false)};
+    auto serializedRunLengths =
+        nimble::TrivialEncoding<uint32_t>::encode(rlSel, runLengthSpan, rlBuf);
+
+    // Encode run values as Dictionary<T>.
+    auto rvSpan =
+        std::span<const PhysicalType>(runValues.data(), runValues.size());
+    nimble::Buffer rvBuf{*pool_};
+    nimble::EncodingSelection<PhysicalType> rvSel{
+        {.encodingType = nimble::EncodingType::Dictionary},
+        nimble::Statistics<PhysicalType>::create(rvSpan),
+        std::make_unique<TestTrivialEncodingSelectionPolicy<T>>(false, false)};
+    auto serializedRunValues =
+        nimble::DictionaryEncoding<T>::encode(rvSel, rvSpan, rvBuf);
+
+    // Assemble RLE binary: prefix | writeString(runLengths) |
+    // writeBytes(runValues)
+    const uint32_t encodingSize = nimble::Encoding::kPrefixSize + 4 +
+        serializedRunLengths.size() + serializedRunValues.size();
+    char* reserved = outputBuffer.reserve(encodingSize);
+    char* pos = reserved;
+    nimble::encoding::writeChar(
+        static_cast<char>(nimble::EncodingType::RLE), pos);
+    nimble::encoding::writeChar(
+        static_cast<char>(nimble::TypeTraits<T>::dataType), pos);
+    nimble::encoding::writeUint32(rowCount, pos);
+    nimble::encoding::writeString(serializedRunLengths, pos);
+    nimble::encoding::writeBytes(serializedRunValues, pos);
+
+    return std::string_view(reserved, encodingSize);
+  }
+
+  /// Encodes data as RLE wrapping Dictionary.
+  std::unique_ptr<nimble::Encoding> encodeRleDictionary(
+      const std::vector<T>& values) {
+    auto serialized = serializeRleDictionary(values, *buffer_);
+    return decodeEncoding(serialized);
+  }
+
   std::shared_ptr<velox::memory::MemoryPool> pool_;
   std::unique_ptr<nimble::Buffer> buffer_;
   std::vector<velox::BufferPtr> stringBuffers_;
@@ -1807,6 +1869,172 @@ TYPED_TEST(
         EXPECT_EQ(indices[i], commonValueIndex) << "row=" << i;
       }
     }
+  }
+}
+
+TYPED_TEST(DictionaryApiTypedTest, rleDictionaryBasics) {
+  using T = TypeParam;
+  std::vector<T> data;
+  if constexpr (std::is_same_v<T, std::string_view>) {
+    this->stringPool_ = {"alpha", "bravo", "charlie"};
+    // 5x alpha, 3x bravo, 4x charlie, 3x alpha
+    for (int i = 0; i < 5; ++i) {
+      data.push_back(std::string_view(this->stringPool_[0]));
+    }
+    for (int i = 0; i < 3; ++i) {
+      data.push_back(std::string_view(this->stringPool_[1]));
+    }
+    for (int i = 0; i < 4; ++i) {
+      data.push_back(std::string_view(this->stringPool_[2]));
+    }
+    for (int i = 0; i < 3; ++i) {
+      data.push_back(std::string_view(this->stringPool_[0]));
+    }
+  } else {
+    // 5x 10, 3x 20, 4x 30, 3x 10
+    for (int i = 0; i < 5; ++i) {
+      data.push_back(T(10));
+    }
+    for (int i = 0; i < 3; ++i) {
+      data.push_back(T(20));
+    }
+    for (int i = 0; i < 4; ++i) {
+      data.push_back(T(30));
+    }
+    for (int i = 0; i < 3; ++i) {
+      data.push_back(T(10));
+    }
+  }
+
+  auto encoding = this->encodeRleDictionary(data);
+  EXPECT_TRUE(encoding->dictionaryEnabled());
+  EXPECT_EQ(encoding->dictionarySize(), 3);
+
+  std::set<T> entries;
+  for (uint32_t i = 0; i < encoding->dictionarySize(); ++i) {
+    const auto* entry = static_cast<const T*>(encoding->dictionaryEntry(i));
+    entries.insert(*entry);
+  }
+
+  if constexpr (std::is_same_v<T, std::string_view>) {
+    EXPECT_THAT(
+        entries, ::testing::UnorderedElementsAre("alpha", "bravo", "charlie"));
+  } else {
+    EXPECT_THAT(entries, ::testing::UnorderedElementsAre(T(10), T(20), T(30)));
+  }
+
+  // Verify materializeIndices round-trips through the dictionary.
+  const auto dictSize = encoding->dictionarySize();
+  std::vector<uint32_t> indices(data.size());
+  encoding->materializeIndices(data.size(), indices.data());
+
+  const auto* allEntries = static_cast<const T*>(encoding->dictionaryEntries());
+  for (size_t i = 0; i < data.size(); ++i) {
+    SCOPED_TRACE(fmt::format("row {}", i));
+    ASSERT_LT(indices[i], dictSize);
+    EXPECT_EQ(allEntries[indices[i]], data[i]);
+  }
+}
+
+TYPED_TEST(DictionaryApiTypedTest, materializeIndicesRleDictionaryFuzz) {
+  using T = TypeParam;
+
+  for (int run = 0; run < 20; ++run) {
+    auto seed = folly::Random::rand32();
+    std::mt19937 rng(seed);
+    const auto numRows = 50 + rng() % 500;
+    const auto cardinality = 2 + rng() % 10;
+    const auto maxRunLength = 1 + rng() % 20;
+
+    SCOPED_TRACE(
+        fmt::format(
+            "run={} seed={} numRows={} cardinality={} maxRunLength={}",
+            run,
+            seed,
+            numRows,
+            cardinality,
+            maxRunLength));
+
+    std::vector<T> data;
+    data.reserve(numRows);
+    std::vector<T> alphabet;
+    if constexpr (std::is_same_v<T, std::string_view>) {
+      this->stringPool_.clear();
+      for (size_t i = 0; i < cardinality; ++i) {
+        this->stringPool_.push_back("val_" + std::to_string(i));
+      }
+      for (size_t i = 0; i < cardinality; ++i) {
+        alphabet.push_back(std::string_view(this->stringPool_[i]));
+      }
+    } else {
+      for (size_t i = 0; i < cardinality; ++i) {
+        alphabet.push_back(static_cast<T>(i + 1));
+      }
+    }
+
+    // Build data with runs.
+    while (data.size() < static_cast<size_t>(numRows)) {
+      auto value = alphabet[rng() % cardinality];
+      auto runLen =
+          std::min<size_t>(1 + rng() % maxRunLength, numRows - data.size());
+      for (size_t j = 0; j < runLen; ++j) {
+        data.push_back(value);
+      }
+    }
+
+    auto encoding = this->encodeRleDictionary(data);
+    ASSERT_TRUE(encoding->dictionaryEnabled());
+
+    const auto dictSize = encoding->dictionarySize();
+    std::vector<uint32_t> indices(data.size());
+    encoding->materializeIndices(data.size(), indices.data());
+
+    const auto* entries = static_cast<const T*>(encoding->dictionaryEntries());
+    for (size_t i = 0; i < data.size(); ++i) {
+      ASSERT_LT(indices[i], dictSize) << "row " << i;
+      EXPECT_EQ(entries[indices[i]], data[i]) << "row " << i;
+    }
+  }
+}
+
+TYPED_TEST(DictionaryApiTypedTest, buildAlphabetRleDictionary) {
+  using T = TypeParam;
+  std::vector<T> data;
+  if constexpr (std::is_same_v<T, std::string_view>) {
+    this->stringPool_ = {"alpha", "bravo", "charlie"};
+    for (int i = 0; i < 4; ++i) {
+      data.push_back(std::string_view(this->stringPool_[0]));
+    }
+    for (int i = 0; i < 3; ++i) {
+      data.push_back(std::string_view(this->stringPool_[1]));
+    }
+    for (int i = 0; i < 2; ++i) {
+      data.push_back(std::string_view(this->stringPool_[2]));
+    }
+  } else {
+    for (int i = 0; i < 4; ++i) {
+      data.push_back(T(10));
+    }
+    for (int i = 0; i < 3; ++i) {
+      data.push_back(T(20));
+    }
+    for (int i = 0; i < 2; ++i) {
+      data.push_back(T(30));
+    }
+  }
+
+  auto encoding = this->encodeRleDictionary(data);
+  auto alphabet = nimble::buildEncodingDictionaryAlphabet<T>(encoding.get());
+  EXPECT_EQ(alphabet.size(), 3);
+
+  std::set<T> alphabetSet(alphabet.begin(), alphabet.end());
+  if constexpr (std::is_same_v<T, std::string_view>) {
+    EXPECT_THAT(
+        alphabetSet,
+        ::testing::UnorderedElementsAre("alpha", "bravo", "charlie"));
+  } else {
+    EXPECT_THAT(
+        alphabetSet, ::testing::UnorderedElementsAre(T(10), T(20), T(30)));
   }
 }
 

--- a/dwio/nimble/velox/selective/tests/E2EFilterTest.cpp
+++ b/dwio/nimble/velox/selective/tests/E2EFilterTest.cpp
@@ -89,14 +89,14 @@ class E2EFilterTest
     batchSize_ = 2003;
     batchCount_ = 5;
     testRowGroupSkip_ = false;
+    dataIoStats_ = std::make_shared<io::IoStatistics>();
+    metadataIoStats_ = std::make_shared<io::IoStatistics>();
     indexIoStats_ = std::make_shared<io::IoStatistics>();
     if (param().enableCache) {
       allocator_ = std::make_shared<memory::MallocAllocator>(
           memory::MemoryAllocator::Options{
               .capacity = 512 << 20, .reservationByteLimit = 0});
       cache_ = cache::AsyncDataCache::create(allocator_.get());
-      dataIoStats_ = std::make_shared<io::IoStatistics>();
-      metadataIoStats_ = std::make_shared<io::IoStatistics>();
       scanTracker_ = std::make_shared<cache::ScanTracker>(
           "testTracker", nullptr, 256 << 10);
       ioExecutor_ = std::make_unique<folly::CPUThreadPoolExecutor>(10);
@@ -476,6 +476,40 @@ class E2EFilterTest
                 {{EncodingLayoutTree::StreamIdentifiers::Scalar::ScalarStream,
                   EncodingLayout{
                       EncodingType::MainlyConstant,
+                      {},
+                      CompressionType::Uncompressed,
+                      {std::nullopt, std::move(dictLayout)}}}},
+                std::string(childName)});
+      } else {
+        children.push_back(
+            EncodingLayoutTree{Kind::Scalar, {}, std::string(childName)});
+      }
+    }
+    return EncodingLayoutTree{Kind::Row, {}, "", std::move(children)};
+  }
+
+  /// Builds a layout tree that forces string columns into RLE→Dictionary
+  /// encoding to exercise the RLE dictionary vector path in E2E tests.
+  EncodingLayoutTree buildForcedRleDictionaryEncodingLayoutTree() {
+    std::vector<EncodingLayoutTree> children;
+    for (column_index_t i = 0;
+         i < static_cast<column_index_t>(rowType_->size());
+         ++i) {
+      const auto& childType = rowType_->childAt(i);
+      const auto& childName = rowType_->nameOf(i);
+
+      if (childType->isVarchar() || childType->isVarbinary()) {
+        EncodingLayout dictLayout{
+            EncodingType::Dictionary,
+            {},
+            CompressionType::Uncompressed,
+            {std::nullopt, std::nullopt}};
+        children.push_back(
+            EncodingLayoutTree{
+                Kind::Scalar,
+                {{EncodingLayoutTree::StreamIdentifiers::Scalar::ScalarStream,
+                  EncodingLayout{
+                      EncodingType::RLE,
                       {},
                       CompressionType::Uncompressed,
                       {std::nullopt, std::move(dictLayout)}}}},
@@ -2110,11 +2144,9 @@ TEST_P(E2EFilterTest, nestedMainlyConstantWithDictionary) {
       *leafPool_,
       velox::dwio::common::MetricsLog::voidLog());
 
-  auto dataIoStats = std::make_shared<velox::io::IoStatistics>();
-  auto metadataIoStats = std::make_shared<velox::io::IoStatistics>();
   velox::dwio::common::ReaderOptions readerOpts(leafPool_.get());
-  readerOpts.setDataIoStats(dataIoStats);
-  readerOpts.setMetadataIoStats(metadataIoStats);
+  readerOpts.setDataIoStats(dataIoStats_);
+  readerOpts.setMetadataIoStats(metadataIoStats_);
   auto reader = makeReader(readerOpts, std::move(input));
   auto scanSpec = std::make_shared<velox::common::ScanSpec>("root");
   scanSpec->addAllChildFields(*type);
@@ -2300,11 +2332,124 @@ TEST_P(E2EFilterTest, fuzzMainlyConstantDictionaryVector) {
       *leafPool_,
       velox::dwio::common::MetricsLog::voidLog());
 
-  auto dataIoStats = std::make_shared<velox::io::IoStatistics>();
-  auto metadataIoStats = std::make_shared<velox::io::IoStatistics>();
   velox::dwio::common::ReaderOptions readerOpts(leafPool_.get());
-  readerOpts.setDataIoStats(dataIoStats);
-  readerOpts.setMetadataIoStats(metadataIoStats);
+  readerOpts.setDataIoStats(dataIoStats_);
+  readerOpts.setMetadataIoStats(metadataIoStats_);
+  auto reader = makeReader(readerOpts, std::move(input));
+  auto scanSpec = std::make_shared<velox::common::ScanSpec>("root");
+  scanSpec->addAllChildFields(*type);
+  velox::dwio::common::RowReaderOptions rowReaderOptions;
+  rowReaderOptions.setScanSpec(scanSpec);
+  rowReaderOptions.setStringDecoderZeroCopy(param().stringDecoderZeroCopy);
+  rowReaderOptions.setNimblePreserveDictionaryEncoding(
+      param().stringDecoderZeroCopy);
+  auto rowReader = reader->createRowReader(rowReaderOptions);
+
+  auto result = BaseVector::create(type, 0, leafPool_.get());
+  size_t totalRows = 0;
+  size_t globalRow = 0;
+  while (rowReader->next(kRowCount, result)) {
+    auto* rowResult = result->as<RowVector>();
+    ASSERT_NE(rowResult, nullptr);
+    totalRows += rowResult->size();
+
+    auto stringChild = rowResult->childAt(0)->loadedVector();
+    DecodedVector decoded(*stringChild);
+    for (size_t i = 0; i < rowResult->size(); ++i) {
+      if (withNulls && globalRow % 7 == 0) {
+        ASSERT_TRUE(decoded.isNullAt(i))
+            << "Expected null at row=" << globalRow;
+      } else {
+        ASSERT_FALSE(decoded.isNullAt(i))
+            << "Unexpected null at row=" << globalRow;
+        ASSERT_EQ(decoded.valueAt<StringView>(i).str(), stringData[globalRow])
+            << "Mismatch at row=" << globalRow;
+      }
+      ++globalRow;
+    }
+  }
+  EXPECT_EQ(totalRows, kRowCount);
+}
+
+TEST_P(E2EFilterTest, fuzzRleDictionaryVector) {
+  auto seed = folly::Random::rand32();
+  LOG(INFO) << "fuzzRleDictionaryVector seed: " << seed;
+  std::mt19937 rng(seed);
+
+  const int kRowCount = 50 + rng() % 500;
+  const int numDistinct = 2 + rng() % 8;
+  const int maxRunLength = 2 + rng() % 20;
+  const bool withNulls = rng() % 3 == 0;
+
+  SCOPED_TRACE(
+      fmt::format(
+          "seed={} rows={} numDistinct={} maxRunLength={} withNulls={}",
+          seed,
+          kRowCount,
+          numDistinct,
+          maxRunLength,
+          withNulls));
+
+  std::vector<std::string> alphabet(numDistinct);
+  for (int j = 0; j < numDistinct; ++j) {
+    auto len = 1 + rng() % 30;
+    alphabet[j].resize(len);
+    for (auto& c : alphabet[j]) {
+      c = 'a' + rng() % 26;
+    }
+  }
+
+  std::vector<std::string> stringData;
+  stringData.reserve(kRowCount);
+  while (static_cast<int>(stringData.size()) < kRowCount) {
+    auto value = alphabet[rng() % numDistinct];
+    auto runLen =
+        std::min<int>(1 + rng() % maxRunLength, kRowCount - stringData.size());
+    for (int j = 0; j < runLen; ++j) {
+      stringData.push_back(value);
+    }
+  }
+
+  rowType_ = ROW({"string_val", "long_val"}, {VARCHAR(), BIGINT()});
+
+  auto type = asRowType(rowType_);
+  auto stringVector =
+      velox::test::VectorMaker(leafPool_.get())
+          .flatVector<velox::StringView>(
+              kRowCount,
+              [&](auto row) { return velox::StringView(stringData[row]); },
+              withNulls ? velox::test::VectorMaker::nullEvery(7) : nullptr);
+  auto longVector =
+      velox::test::VectorMaker(leafPool_.get())
+          .flatVector<int64_t>(kRowCount, [](auto row) { return row; });
+
+  auto batch = std::make_shared<RowVector>(
+      leafPool_.get(),
+      type,
+      nullptr,
+      kRowCount,
+      std::vector<VectorPtr>{stringVector, longVector});
+
+  sinkData_.clear();
+  {
+    auto writeFile = std::make_unique<InMemoryWriteFile>(&sinkData_);
+    VeloxWriterOptions writerOptions;
+    writerOptions.encodingLayoutTree.emplace(
+        buildForcedRleDictionaryEncodingLayoutTree());
+    VeloxWriter writer(
+        type, std::move(writeFile), *rootPool_, std::move(writerOptions));
+    writer.write(batch);
+    writer.close();
+  }
+
+  auto input = std::make_unique<velox::dwio::common::BufferedInput>(
+      std::make_shared<velox::InMemoryReadFile>(sinkData_),
+      *leafPool_,
+      velox::dwio::common::MetricsLog::voidLog());
+
+  velox::dwio::common::ReaderOptions readerOpts(leafPool_.get());
+  readerOpts.setDataIoStats(dataIoStats_);
+  readerOpts.setMetadataIoStats(metadataIoStats_);
   auto reader = makeReader(readerOpts, std::move(input));
   auto scanSpec = std::make_shared<velox::common::ScanSpec>("root");
   scanSpec->addAllChildFields(*type);
@@ -2433,11 +2578,9 @@ TEST_P(E2EFilterTest, crossChunkEncodingChange) {
       *leafPool_,
       velox::dwio::common::MetricsLog::voidLog());
 
-  auto dataIoStats = std::make_shared<velox::io::IoStatistics>();
-  auto metadataIoStats = std::make_shared<velox::io::IoStatistics>();
   velox::dwio::common::ReaderOptions crossChunkReaderOpts(leafPool_.get());
-  crossChunkReaderOpts.setDataIoStats(dataIoStats);
-  crossChunkReaderOpts.setMetadataIoStats(metadataIoStats);
+  crossChunkReaderOpts.setDataIoStats(dataIoStats_);
+  crossChunkReaderOpts.setMetadataIoStats(metadataIoStats_);
   auto reader = makeReader(crossChunkReaderOpts, std::move(input));
   auto scanSpec = std::make_shared<velox::common::ScanSpec>("root");
   scanSpec->addAllChildFields(*type);

--- a/dwio/nimble/velox/selective/tests/StringColumnReaderTest.cpp
+++ b/dwio/nimble/velox/selective/tests/StringColumnReaderTest.cpp
@@ -1425,6 +1425,59 @@ TEST_P(StringColumnReaderTest, mainlyConstantDictionaryAlignedChunksWithNulls) {
       pool());
 }
 
+// RLE→Dictionary string column returns DictionaryVector. Uses forced
+// encoding layout to create RLE wrapping Dictionary for string values
+// with repeated patterns (natural RLE runs).
+TEST_P(StringColumnReaderTest, rleDictionaryVector) {
+  const bool stringDecoderZeroCopy = GetParam();
+  if (!stringDecoderZeroCopy) {
+    GTEST_SKIP() << "Dictionary path requires stringDecoderZeroCopy";
+  }
+
+  constexpr int kStripeRows = 300;
+  const std::string values[] = {"alpha", "bravo", "charlie"};
+  // Create data with repeated runs to produce natural RLE encoding.
+  auto data = makeRowVector({
+      makeFlatVector<std::string>(
+          kStripeRows, [&](auto i) { return values[(i / 10) % 3]; }),
+  });
+
+  // Force RLE→Dictionary encoding layout.
+  EncodingLayout dictLayout{
+      EncodingType::Dictionary,
+      {},
+      CompressionType::Uncompressed,
+      {std::nullopt, std::nullopt}};
+  EncodingLayout rleLayout{
+      EncodingType::RLE,
+      {},
+      CompressionType::Uncompressed,
+      {std::nullopt, std::move(dictLayout)}};
+  VeloxWriterOptions writerOptions;
+  writerOptions.encodingLayoutTree.emplace(
+      Kind::Row,
+      std::
+          unordered_map<EncodingLayoutTree::StreamIdentifier, EncodingLayout>{},
+      "",
+      std::vector<EncodingLayoutTree>{
+          EncodingLayoutTree{Kind::Scalar, {{0, std::move(rleLayout)}}, "c0"}});
+  auto file = test::createNimbleFile(
+      *rootPool(), std::vector<VectorPtr>{data}, writerOptions);
+
+  auto scanSpec = std::make_shared<common::ScanSpec>("root");
+  scanSpec->addAllChildFields(*data->type());
+  auto readers = makeReaders(data, file, scanSpec, stringDecoderZeroCopy);
+  using E = VectorEncoding::Simple;
+  validateWithEncodingChecks(
+      *data->childAt(0),
+      *readers.rowReader,
+      100,
+      /*totalRows=*/kStripeRows,
+      {E::DICTIONARY, E::DICTIONARY, E::DICTIONARY},
+      asRowType(data->type()),
+      pool());
+}
+
 INSTANTIATE_TEST_CASE_P(
     StringColumnReaderTestSuite,
     StringColumnReaderTest,


### PR DESCRIPTION
Summary:

Goal: Enable the dictionary vector optimization for RLE→Dict encoded string columns.

  BufferedEncoding (Encoding.h)

  Added kDictionaryEnabled template parameter (defaults to false). When true:
  - refill() calls materializeIndices() instead of materialize(), loading dictionary indices in pages
  - nextValue() returns alphabet_[index] by looking up the index in the dictionary entries
  - currentIndex() exposes the raw dictionary index for materializeIndices callers
  - Unused buffer positions are zero-filled to handle RLE's one-run-ahead look-ahead pattern

  RLEEncoding (RleEncoding.h)

  - Dictionary metadata: dictionaryEnabled(), dictionarySize(), dictionaryEntry(), dictionaryEntries() delegate to the inner encoding
  - Dual BufferedEncoding: values_ (non-dict) or dictValues_ (dict-aware) — only one is alive, chosen at construction based on innerEncoding->dictionaryEnabled()
  - nextValue() branches: dict mode returns value from dictValues_->nextValue() and caches currentIndex_; non-dict mode returns from values_->nextValue()
  - materializeIndices() loops through runs, calling nextValue() per new run (which sets currentIndex_), then fills output with repeated index
  - readIndicesWithVisitor() uses the standard dense/sparse helper pattern (same as Dict/MC)
  - skip() stays final — base class skip calls nextValue() via CRTP, which correctly advances dictValues_ in dict mode
  - resetValues() resets whichever BufferedEncoding is active

  EncodingUtils.h

  - Added EncodingType::RLE case to callReadIndicesWithVisitor dispatch

Brings the following savings for locally sampled file with RLE<Dict> encodings:

  ┌───────────────────────────────┬───────────────┬──────────────┐
  │             Path              │ P50 Wall (ms) │ P50 CPU (ms) │
  ├───────────────────────────────┼───────────────┼──────────────┤
  │ Dict (string cols 9,10,14,15) │ 2062          │ 1774         │
  ├───────────────────────────────┼───────────────┼──────────────┤
  │ Flat (string cols 9,10,14,15) │ 2228          │ 2145         │
  └───────────────────────────────┴───────────────┴──────────────┘

Reviewed By: xiaoxmeng

Differential Revision: D105110354


