### PR TITLE
refactor(writer): Move the internal writer adapter into nimble

### DIFF
--- a/dwio/nimble/velox/NimbleConfig.cpp
+++ b/dwio/nimble/velox/NimbleConfig.cpp
@@ -1,0 +1,327 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include <folly/json/dynamic.h>
+#include <folly/json/json.h>
+
+#include "dwio/nimble/common/Constants.h"
+#include "dwio/nimble/encodings/selection/EncodingSelectionPolicy.h"
+#include "dwio/nimble/velox/NimbleConfig.h"
+
+DEFINE_string(
+    nimble_selection_read_factors,
+    "Constant=1.0;Trivial=0.5;FixedBitWidth=0.8;MainlyConstant=1.0;SparseBool=1.0;Dictionary=1.0;RLE=1.0",
+    "Encoding selection read factors, in the format: "
+    "<EncodingName>=<FactorFloatValue>;<EncodingName>=<FactorFloatValue>;...");
+
+DEFINE_double(
+    nimble_selection_compression_accept_ratio,
+    0.99,
+    "Encoding selection compression accept ratio.");
+
+DEFINE_bool(
+    nimble_zstrong_enable_variable_bit_width_compressor,
+    false,
+    "Enable zstrong variable bit width compressor at write time. Transparent at read time.");
+
+DEFINE_string(
+    nimble_writer_input_buffer_default_growth_config,
+    "{\"32\":4.0,\"512\":1.414,\"4096\":1.189}",
+    "Default growth config for writer input buffers, each entry in the format of {range_start,growth_factor}");
+
+DEFINE_string(
+    nimble_writer_string_buffer_growth_config,
+    "{\"32000\":4.0,\"2000000\":2.5,\"4000000\":1.5}",
+    "Growth config for string buffers when disableSharedStringBuffers is enabled. "
+    "Format: {range_start_bytes:growth_factor}. Ranges: 32KB->4X, 2MB->2.5X, 4MB->1.5X");
+
+namespace facebook::nimble {
+namespace {
+template <typename T>
+std::vector<T> parseVector(const std::string& str) {
+  std::vector<T> result;
+  if (!str.empty()) {
+    std::vector<folly::StringPiece> pieces;
+    folly::split(',', str, pieces, true);
+    for (auto& p : pieces) {
+      const auto& trimmedCol = folly::trimWhitespace(p);
+      if (!trimmedCol.empty()) {
+        result.push_back(folly::to<T>(trimmedCol));
+      }
+    }
+  }
+  return result;
+}
+
+std::map<uint64_t, float> parseGrowthConfigMap(const std::string& str) {
+  std::map<uint64_t, float> ret;
+  NIMBLE_CHECK(!str.empty(), "Can't supply an empty growth config.");
+  folly::dynamic json = folly::parseJson(str);
+  for (const auto& pair : json.items()) {
+    auto [_, inserted] = ret.emplace(
+        folly::to<uint64_t>(pair.first.asString()), pair.second.asDouble());
+    NIMBLE_CHECK(
+        inserted, fmt::format("Duplicate key: {}.", pair.first.asString()));
+  }
+  return ret;
+}
+} // namespace
+
+/* static */ Config::Entry<bool> Config::FLATTEN_MAP("orc.flatten.map", false);
+
+/* static */ Config::Entry<const std::vector<uint32_t>> Config::MAP_FLAT_COLS(
+    "orc.map.flat.cols",
+    {},
+    [](const std::vector<uint32_t>& val) { return folly::join(",", val); },
+    [](const std::string& /* key */, const std::string& val) {
+      return parseVector<uint32_t>(val);
+    });
+
+/* static */ Config::Entry<const std::vector<uint32_t>>
+    Config::DEDUPLICATED_COLS(
+        "alpha.map.deduplicated.cols",
+        {},
+        [](const std::vector<uint32_t>& val) { return folly::join(",", val); },
+        [](const std::string& /* key */, const std::string& val) {
+          return parseVector<uint32_t>(val);
+        });
+
+/* static */ Config::Entry<const std::vector<uint32_t>>
+    Config::BATCH_REUSE_COLS(
+        "alpha.dictionaryarray.cols",
+        {},
+        [](const std::vector<uint32_t>& val) { return folly::join(",", val); },
+        [](const std::string& /* key */, const std::string& val) {
+          return parseVector<uint32_t>(val);
+        });
+
+/// 384MB is a relatively good safe default, some tables might OOM during
+/// ingestion with higher stripe sizes.
+/// One downside of smaller stripe sizes is that tables with good compression
+/// ratio might get many small stripes resulting in higher IO. Second downside
+/// is that smaller stripes migh have worse dictionary utilization resulting in
+/// increased file size.
+/* static */ Config::Entry<uint64_t> Config::RAW_STRIPE_SIZE(
+    "alpha.raw.stripe.size",
+    384 * 1024L * 1024L);
+
+// currently sets the encoding executor to folly::globalCPUexecutor
+/* static */ Config::Entry<bool> Config::ENABLE_DEFAULT_ENCODING_EXECUTOR(
+    "alpha.encodingexecutor.enable.default",
+    false);
+
+/* static */ Config::Entry<bool> Config::ENABLE_STREAM_DEDUPLICATION(
+    "nimble.enable.stream.deduplication",
+    false);
+
+/* static */ Config::Entry<bool> Config::DISABLE_SHARED_STRING_BUFFERS(
+    "nimble.disable.shared.string.buffers",
+    false);
+
+/* static */ Config::Entry<const std::vector<std::pair<EncodingType, float>>>
+    Config::MANUAL_ENCODING_SELECTION_READ_FACTORS(
+        "alpha.encodingselection.read.factors",
+        ManualEncodingSelectionPolicyFactory::parseReadFactors(
+            FLAGS_nimble_selection_read_factors),
+        [](const std::vector<std::pair<EncodingType, float>>& val) {
+          std::vector<std::string> encodingFactorStrings;
+          std::transform(
+              val.cbegin(),
+              val.cend(),
+              std::back_inserter(encodingFactorStrings),
+              [](const auto& readFactor) {
+                return fmt::format(
+                    "{}={}", toString(readFactor.first), readFactor.second);
+              });
+          return folly::join(";", encodingFactorStrings);
+        },
+        [](const std::string& /* key */, const std::string& val) {
+          return ManualEncodingSelectionPolicyFactory::parseReadFactors(val);
+        });
+
+/* static */ Config::Entry<float>
+    Config::ENCODING_SELECTION_COMPRESSION_ACCEPT_RATIO(
+        "alpha.encodingselection.compression.accept.ratio",
+        FLAGS_nimble_selection_compression_accept_ratio);
+
+// Attempt to compress the data only if the data size is equal or greater than
+// this threshold.
+/* static */ Config::Entry<uint64_t> Config::ZSTD_COMPRESSION_MIN_SIZE(
+    "alpha.zstd.compression.size.min",
+    kZstdMinCompressionSize);
+
+// Attempt to compress the data only if the data size is equal or greater than
+// this threshold.
+/* static */ Config::Entry<uint64_t> Config::ZSTRONG_COMPRESSION_MIN_SIZE(
+    "alpha.zstrong.compression.size.min",
+    kMetaInternalMinCompressionSize);
+
+/* static */ Config::Entry<uint32_t> Config::ZSTRONG_COMPRESSION_LEVEL(
+    "alpha.zstrong.compression.level",
+    4);
+
+/* static */ Config::Entry<uint32_t> Config::ZSTRONG_DECOMPRESSION_LEVEL(
+    "alpha.zstrong.decompression.level",
+    2);
+
+/* static */ Config::Entry<bool>
+    Config::ENABLE_ZSTRONG_VARIABLE_BITWIDTH_COMPRESSOR(
+        "alpha.zstrong.enable.variable.bit.width.compressor",
+        FLAGS_nimble_zstrong_enable_variable_bit_width_compressor);
+
+/* static */ Config::Entry<bool> Config::USE_MANAGED_COMPRESSION(
+    "alpha.openzl.use.managed.compression",
+    false);
+
+/* static */ Config::Entry<MetaInternalCompressionKey>
+    Config::MANAGED_COMPRESSION_KEY(
+        "alpha.openzl.managed.compression.key",
+        MetaInternalCompressionKey{"", "", ""},
+        [](const MetaInternalCompressionKey& key) { return key.toString(); },
+        [](const std::string& /* key */, const std::string& val) {
+          return MetaInternalCompressionKey::fromString(val);
+        });
+
+/* static */ Config::Entry<const std::map<uint64_t, float>>
+    Config::INPUT_BUFFER_DEFAULT_GROWTH_CONFIGS(
+        "alpha.writer.input.buffer.default.growth.configs",
+        parseGrowthConfigMap(
+            FLAGS_nimble_writer_input_buffer_default_growth_config),
+        [](const std::map<uint64_t, float>& val) {
+          folly::dynamic obj = folly::dynamic::object;
+          for (const auto& [rangeStart, growthFactor] : val) {
+            obj[folly::to<std::string>(rangeStart)] = growthFactor;
+          }
+          return folly::toJson(obj);
+        },
+        [](const std::string& /* key */, const std::string& val) {
+          return parseGrowthConfigMap(val);
+        });
+
+/* static */ Config::Entry<const std::map<uint64_t, float>>
+    Config::STRING_BUFFER_GROWTH_CONFIGS(
+        "alpha.writer.string.buffer.growth.configs",
+        parseGrowthConfigMap(FLAGS_nimble_writer_string_buffer_growth_config),
+        [](const std::map<uint64_t, float>& val) {
+          folly::dynamic obj = folly::dynamic::object;
+          for (const auto& [rangeStart, growthFactor] : val) {
+            obj[folly::to<std::string>(rangeStart)] = growthFactor;
+          }
+          return folly::toJson(obj);
+        },
+        [](const std::string& /* key */, const std::string& val) {
+          return parseGrowthConfigMap(val);
+        });
+
+/// Enable chunking to manage writer and reader memory by splitting large data
+/// streams into smaller chunks. When enabled, streams are encoded incrementally
+/// instead of as single large blobs, reducing peak memory usage and OOMs.
+/* static */ Config::Entry<bool> Config::ENABLE_CHUNKING(
+    "nimble.chunking.enabled",
+    true);
+
+/// Enable chunk index for chunk-level seeking and per-chunk statistics
+/// for filter pushdown. When enabled, a chunk index optional section is
+/// written alongside chunk position data in the file.
+/* static */ Config::Entry<bool> Config::ENABLE_CHUNK_INDEX(
+    "nimble.chunk.index.enabled",
+    false);
+
+/// Threshold to trigger chunking to relieve memory pressure.
+/* static */ Config::Entry<uint64_t>
+    Config::CHUNKING_WRITER_MEMORY_HIGH_THRESHOLD(
+        "nimble.chunking.writer.memory.high.threshold",
+        kChunkingWriterMemoryHighThreshold);
+
+/// Threshold below which chunking stops and stripe size optimization resumes.
+/* static */ Config::Entry<uint64_t>
+    Config::CHUNKING_WRITER_MEMORY_LOW_THRESHOLD(
+        "nimble.chunking.writer.memory.low.threshold",
+        kChunkingWriterMemoryLowThreshold);
+
+/// Target physical size for encoded stripes.
+/* static */ Config::Entry<uint64_t>
+    Config::CHUNKING_WRITER_TARGET_STRIPE_STORAGE_SIZE(
+        "nimble.chunking.writer.target.stripe.storage.size",
+        kChunkingWriterTargetStripeStorageSize);
+
+/// Expected ratio of raw to encoded data.
+/* static */ Config::Entry<double>
+    Config::CHUNKING_WRITER_ESTIMATED_COMPRESSION_FACTOR(
+        "nimble.chunking.writer.estimated.compression.factor",
+        kChunkingWriterEstimatedCompressionFactor);
+
+/// When flushing data streams into chunks, streams with raw data size smaller
+/// than this threshold will not be flushed.
+/// Note: this threshold is ignored when it is time to flush a stripe.
+/* static */ Config::Entry<uint64_t> Config::CHUNKING_WRITER_MIN_CHUNK_SIZE(
+    "nimble.chunking.writer.min.chunk.size",
+    kChunkingWriterMinChunkSize);
+
+/// When flushing data streams into chunks, streams with raw data size larger
+/// than this threshold will be broken down into multiple smaller chunks. Each
+/// chunk will be at most this size.
+/* static */ Config::Entry<uint64_t> Config::CHUNKING_WRITER_MAX_CHUNK_SIZE(
+    "nimble.chunking.writer.max.chunk.size",
+    kChunkingWriterMaxChunkSize);
+
+/// Used in place of CHUNKING_WRITER_MAX_CHUNK_SIZE for large schema tables.
+/* static */ Config::Entry<uint64_t>
+    Config::CHUNKING_WRITER_WIDE_SCHEMA_MAX_CHUNK_SIZE(
+        "nimble.chunking.writer.wide.schema.max.chunk.size",
+        kChunkingWriterWideSchemaMaxChunkSize);
+
+/* static */ Config::Entry<const std::vector<std::string>>
+    Config::INDEX_COLUMNS(
+        "nimble.index.columns",
+        {},
+        [](const std::vector<std::string>& val) {
+          return folly::join(",", val);
+        },
+        [](const std::string& /* key */, const std::string& val) {
+          return parseVector<std::string>(val);
+        });
+
+/* static */ Config::Entry<const std::vector<std::string>>
+    Config::INDEX_SORT_ORDERS(
+        "nimble.index.sort_orders",
+        {},
+        [](const std::vector<std::string>& val) {
+          return folly::join(",", val);
+        },
+        [](const std::string& /* key */, const std::string& val) {
+          return parseVector<std::string>(val);
+        });
+
+/* static */ Config::Entry<bool> Config::INDEX_ENFORCE_KEY_ORDER(
+    "nimble.index.enforce_key_order",
+    false);
+
+/* static */ Config::Entry<bool> Config::INDEX_NO_DUPLICATE_KEY(
+    "nimble.index.no_duplicate_key",
+    false);
+
+/* static */ Config::Entry<std::string> Config::INDEX_ENCODING_TYPE(
+    "nimble.index.encoding_type",
+    "prefix");
+
+/* static */ Config::Entry<bool> Config::ENABLE_STATS_COLLECTION(
+    "nimble.stats.enable",
+    true);
+
+/* static */ Config::Entry<bool> Config::ENABLE_VECTORIZED_STATS(
+    "nimble.stats.enable_vectorized",
+    true);
+} // namespace facebook::nimble

--- a/dwio/nimble/velox/NimbleConfig.h
+++ b/dwio/nimble/velox/NimbleConfig.h
@@ -1,0 +1,106 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include "dwio/nimble/common/Types.h"
+#include "dwio/nimble/encodings/selection/EncodingSelection.h"
+#include "velox/common/config/Config.h"
+
+namespace facebook::nimble {
+
+class Config : public velox::config::ConfigBase {
+ public:
+  template <typename T>
+  using Entry = velox::config::ConfigBase::Entry<T>;
+
+  static Entry<bool> FLATTEN_MAP;
+  static Entry<const std::vector<uint32_t>> MAP_FLAT_COLS;
+  static Entry<const std::vector<uint32_t>> BATCH_REUSE_COLS;
+  static Entry<const std::vector<uint32_t>> DEDUPLICATED_COLS;
+  static Entry<uint64_t> RAW_STRIPE_SIZE;
+  static Entry<bool> ENABLE_DEFAULT_ENCODING_EXECUTOR;
+  static Entry<bool> ENABLE_STREAM_DEDUPLICATION;
+  static Entry<bool> DISABLE_SHARED_STRING_BUFFERS;
+  static Entry<const std::vector<std::pair<EncodingType, float>>>
+      MANUAL_ENCODING_SELECTION_READ_FACTORS;
+  static Entry<float> ENCODING_SELECTION_COMPRESSION_ACCEPT_RATIO;
+  static Entry<uint64_t> ZSTD_COMPRESSION_MIN_SIZE;
+  static Entry<uint64_t> ZSTRONG_COMPRESSION_MIN_SIZE;
+  static Entry<uint32_t> ZSTRONG_COMPRESSION_LEVEL;
+  static Entry<uint32_t> ZSTRONG_DECOMPRESSION_LEVEL;
+  static Entry<bool> ENABLE_ZSTRONG_VARIABLE_BITWIDTH_COMPRESSOR;
+  static Entry<bool> USE_MANAGED_COMPRESSION;
+  static Entry<MetaInternalCompressionKey> MANAGED_COMPRESSION_KEY;
+  static Entry<const std::map<uint64_t, float>>
+      INPUT_BUFFER_DEFAULT_GROWTH_CONFIGS;
+  static Entry<const std::map<uint64_t, float>> STRING_BUFFER_GROWTH_CONFIGS;
+  static Entry<bool> ENABLE_CHUNKING;
+  static Entry<bool> ENABLE_CHUNK_INDEX;
+  static Entry<uint64_t> CHUNKING_WRITER_MEMORY_HIGH_THRESHOLD;
+  static Entry<uint64_t> CHUNKING_WRITER_MEMORY_LOW_THRESHOLD;
+  static Entry<uint64_t> CHUNKING_WRITER_TARGET_STRIPE_STORAGE_SIZE;
+  static Entry<double> CHUNKING_WRITER_ESTIMATED_COMPRESSION_FACTOR;
+  static Entry<uint64_t> CHUNKING_WRITER_MIN_CHUNK_SIZE;
+  static Entry<uint64_t> CHUNKING_WRITER_MAX_CHUNK_SIZE;
+  static Entry<uint64_t> CHUNKING_WRITER_WIDE_SCHEMA_MAX_CHUNK_SIZE;
+
+  /// Index columns to build cluster index during writing.
+  /// Column names are separated by commas.
+  static Entry<const std::vector<std::string>> INDEX_COLUMNS;
+
+  /// Sort orders for each index column (one per column).
+  /// Format: "ASC_NULLS_FIRST,DESC_NULLS_LAST,..."
+  /// Valid values: ASC_NULLS_FIRST, ASC_NULLS_LAST, DESC_NULLS_FIRST,
+  /// DESC_NULLS_LAST. If empty, defaults to ASC_NULLS_FIRST for all columns.
+  static Entry<const std::vector<std::string>> INDEX_SORT_ORDERS;
+
+  /// Whether to enforce that encoded keys are in strictly ascending order.
+  static Entry<bool> INDEX_ENFORCE_KEY_ORDER;
+
+  /// Whether to enforce strictly ascending order with no duplicate keys.
+  /// When true, both enforceKeyOrder and noDuplicateKey are set in IndexConfig.
+  static Entry<bool> INDEX_NO_DUPLICATE_KEY;
+
+  /// Encoding type for the index key stream.
+  /// Valid values: "prefix" (default), "trivial".
+  static Entry<std::string> INDEX_ENCODING_TYPE;
+
+  /// Enable column statistics collection during writing.
+  static Entry<bool> ENABLE_STATS_COLLECTION;
+
+  /// Enable vectorized column statistics for row size estimation.
+  static Entry<bool> ENABLE_VECTORIZED_STATS;
+
+  static constexpr const char* kNimbleWriteTargetRawStripeSize =
+      "nimble_write_target_raw_stripe_size";
+
+  static std::shared_ptr<Config> fromMap(
+      const std::map<std::string, std::string>& map) {
+    auto config = std::make_shared<Config>();
+    for (const auto& pair : map) {
+      config->set(pair.first, pair.second);
+    }
+    return config;
+  }
+
+  Config() : velox::config::ConfigBase({}, true) {}
+
+  std::map<std::string, std::string> toSerdeParams() {
+    return std::map{configs_.cbegin(), configs_.cend()};
+  }
+};
+
+} // namespace facebook::nimble


### PR DESCRIPTION
Summary:
Move `NimbleWriter.h` and `NimbleWriter.cpp` from `fb_velox/dwio/nimble/writer/` to `dwio/nimble/velox/writer/`. This brings the Velox-level writer adapter (which wraps `VeloxWriter` for the `dwio::common::WriterFactory` interface) into the Nimble OSS tree, alongside the core writer it wraps.

Changes:
- Move `NimbleWriter.h/cpp` via `sl mv` (preserves rename history)
- Create new `dwio/nimble/velox/writer/BUCK` with `oncall("dwios")`
- Create `dwio/nimble/velox/writer/CMakeLists.txt` for OSS CMake build
- Add `add_subdirectory(writer)` to parent `CMakeLists.txt`
- Remove old `fb_velox/dwio/nimble/writer/BUCK`
- Update 17 source files with new include path
- Update 13 BUCK files with new dep target `//dwio/nimble/velox/writer:writer`

Reviewed By: xiaoxmeng

Differential Revision: D106220903
