### PR TITLE
fix(index): Add explicit constructors to ResultChunk for clang-15 compatibility (#780)

### DIFF
--- a/dwio/nimble/velox/index/NimbleIndexProjector.cpp
+++ b/dwio/nimble/velox/index/NimbleIndexProjector.cpp
@@ -419,9 +419,9 @@ bool NimbleIndexProjector::buildStripeResult(
     numReadRows_ += rowRange.numRows();
     resultChunks_[request.requestIndex].push_back(
         ResultChunk{
-            .sharedBody = stripeChunk.sharedBody.cloneOneAsValue(),
-            .numRows = stripeChunk.numRows,
-            .rowRange = rowRange});
+            stripeChunk.sharedBody.cloneOneAsValue(),
+            stripeChunk.numRows,
+            rowRange});
     rowsPerRequest_[request.requestIndex] += rowRange.numRows();
   }
 

--- a/dwio/nimble/velox/index/NimbleIndexProjector.h
+++ b/dwio/nimble/velox/index/NimbleIndexProjector.h
@@ -293,6 +293,13 @@ class NimbleIndexProjector {
   // finalizeResult() prepends a per-request header with the row range via
   // assembleChunk().
   struct ResultChunk {
+    ResultChunk() = default;
+
+    ResultChunk(folly::IOBuf sharedBody, uint32_t numRows, RowRange rowRange)
+        : sharedBody{std::move(sharedBody)},
+          numRows{numRows},
+          rowRange{rowRange} {}
+
     folly::IOBuf sharedBody;
     uint32_t numRows{0};
     RowRange rowRange;


### PR DESCRIPTION
Summary:

`NimbleIndexProjector::ResultChunk` is an aggregate with a default member initializer (`numStripeRows{0}`), which prevents aggregate initialization via `emplace_back(IOBuf, uint32_t, RowRange)` under clang-15's stricter C++20 aggregate rules in the OSS CMake build. The compiler cannot find a matching constructor because aggregates with default member initializers are not considered aggregates in certain C++17/20 standard interpretations.

Add explicit default and 3-arg constructors so `emplace_back` resolves correctly on all supported compilers.

Reviewed By: xiaoxmeng

Differential Revision: D106257397


