### PR TITLE
build: Fix OSS CMake link error for `nimble_index_tests` (#781)

### DIFF
--- a/dwio/nimble/index/tests/CMakeLists.txt
+++ b/dwio/nimble/index/tests/CMakeLists.txt
@@ -52,6 +52,7 @@ add_test(nimble_index_tests nimble_index_tests)
 target_link_libraries(
   nimble_index_tests
   nimble_index
+  nimble_index_test_utils
   nimble_tablet_reader
   nimble_tablet_writer
   nimble_velox_reader


### PR DESCRIPTION
Summary:

Link `nimble_index_test_utils` into `nimble_index_tests` in the CMake build. `ClusterIndexTest.cpp` uses `TestClusterIndexMetadataWriter` which is defined in `ClusterIndexTestUtils.cpp` (built as the `nimble_index_test_utils` library), but the test executable was missing this link dependency, causing undefined reference errors in the OSS CI build.

Differential Revision: D106260102
