### PR TITLE
feat: Add shared TabletReader and TabletReaderCache for memory-efficient index projection

### DIFF
--- a/dwio/nimble/tablet/CMakeLists.txt
+++ b/dwio/nimble/tablet/CMakeLists.txt
@@ -139,6 +139,23 @@ target_link_libraries(
     nimble_hash_index_fb
 )
 
+add_library(nimble_tablet_reader_cache TabletReaderCache.cpp)
+target_link_libraries(
+  nimble_tablet_reader_cache
+  PUBLIC
+    nimble_tablet_reader
+    nimble_velox_schema_reader
+    velox_caching
+    velox_memory
+    velox_type
+  PRIVATE
+    nimble_common
+    nimble_velox_common
+    nimble_velox_schema_serialization
+    glog::glog
+    Folly::folly
+)
+
 add_library(nimble_tablet_writer ChunkIndexWriter.cpp TabletWriter.cpp)
 target_link_libraries(
   nimble_tablet_writer

--- a/dwio/nimble/tablet/TabletReaderCache.cpp
+++ b/dwio/nimble/tablet/TabletReaderCache.cpp
@@ -1,0 +1,159 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "dwio/nimble/tablet/TabletReaderCache.h"
+
+#include <fmt/format.h>
+#include <glog/logging.h>
+
+#include "dwio/nimble/common/Exceptions.h"
+#include "dwio/nimble/tablet/Constants.h"
+#include "dwio/nimble/velox/SchemaSerialization.h"
+#include "dwio/nimble/velox/SchemaUtils.h"
+#include "velox/common/base/BitUtil.h"
+
+namespace facebook::nimble {
+
+TabletReaderCache::Generator::Generator(
+    std::vector<std::shared_ptr<velox::memory::MemoryPool>> pools,
+    std::shared_ptr<folly::Executor> executor)
+    : pools_{std::move(pools)},
+      executor_{std::move(executor)},
+      shardMask_{static_cast<uint32_t>(pools_.size()) - 1} {
+  NIMBLE_CHECK_GT(pools_.size(), 0);
+  NIMBLE_CHECK(
+      velox::bits::isPowerOfTwo(pools_.size()),
+      fmt::format(
+          "numShards must be a power of 2, but got: {}", pools_.size()));
+  NIMBLE_CHECK_NOT_NULL(executor_);
+}
+
+std::unique_ptr<CachedTabletReader> TabletReaderCache::Generator::operator()(
+    const std::string& filename,
+    const Properties* properties,
+    void* /*stats*/) {
+  NIMBLE_CHECK_NOT_NULL(properties);
+  const auto shardIdx = std::hash<std::string>{}(filename)&shardMask_;
+  auto options = properties->tabletOptions;
+  auto ioOptions = velox::io::ReaderOptions(pools_[shardIdx].get());
+  ioOptions.setMetadataIoStats(std::make_shared<velox::io::IoStatistics>());
+  ioOptions.setIndexIoStats(std::make_shared<velox::io::IoStatistics>());
+  ioOptions.setIOExecutor(executor_);
+  options.ioOptions = std::move(ioOptions);
+  auto tablet = TabletReader::create(
+      properties->readFile, pools_[shardIdx].get(), options);
+  auto section = tablet->loadOptionalSection(
+      std::string(kSchemaSection), /*keepCache=*/true);
+  NIMBLE_CHECK(section.has_value(), "Schema section not found in tablet");
+  auto nimbleSchema =
+      SchemaDeserializer::deserialize(section->content().data());
+  auto veloxSchema = asRowType(convertToVeloxType(*nimbleSchema));
+  return std::make_unique<CachedTabletReader>(CachedTabletReader{
+      std::move(tablet), std::move(nimbleSchema), std::move(veloxSchema)});
+}
+
+TabletReaderCache::Factory TabletReaderCache::createFactory(
+    const Options& opts) {
+  NIMBLE_CHECK_NOT_NULL(opts.executor);
+  NIMBLE_CHECK(
+      velox::bits::isPowerOfTwo(opts.numShards),
+      fmt::format(
+          "numShards must be a power of 2, but got: {}", opts.numShards));
+
+  std::vector<std::shared_ptr<velox::memory::MemoryPool>> pools;
+  pools.reserve(opts.numShards);
+  for (uint32_t i = 0; i < opts.numShards; ++i) {
+    pools.push_back(
+        velox::memory::memoryManager()->addLeafPool(
+            fmt::format("tablet_reader_cache_{}", i)));
+  }
+
+  auto cache = std::make_unique<TabletReaderCache::LRUCache>(
+      opts.maxEntries, opts.expireDurationMs);
+  auto generator = std::make_unique<TabletReaderCache::Generator>(
+      std::move(pools), opts.executor);
+  return Factory(std::move(cache), std::move(generator));
+}
+
+TabletReaderCache::TabletReaderCache(const Options& options)
+    : factory_{createFactory(options)} {
+  LOG(INFO) << "TabletReaderCache created: " << options.toString();
+}
+
+CachedTabletReader TabletReaderCache::get(
+    const std::shared_ptr<velox::ReadFile>& readFile,
+    const TabletReader::Options& tabletOptions) {
+  Properties properties{readFile, tabletOptions};
+  auto cached = factory_.generate(readFile->getName(), &properties);
+  return CachedTabletReader{
+      cached->tablet, cached->nimbleSchema, cached->veloxSchema};
+}
+
+velox::SimpleLRUCacheStats TabletReaderCache::stats() {
+  return factory_.cacheStats();
+}
+
+std::optional<CachedTabletReader> TabletReaderCache::testingGet(
+    const std::string& filename) {
+  auto cached = factory_.get(filename);
+  if (cached.get() == nullptr) {
+    return std::nullopt;
+  }
+  return CachedTabletReader{
+      cached->tablet, cached->nimbleSchema, cached->veloxSchema};
+}
+
+namespace {
+struct SingletonState {
+  ~SingletonState() {
+    delete instance.load(std::memory_order_acquire);
+  }
+
+  std::atomic<TabletReaderCache*> instance{nullptr};
+  std::mutex mutex;
+};
+
+SingletonState& singletonState() {
+  static SingletonState state;
+  return state;
+}
+} // namespace
+
+void TabletReaderCache::initialize(const Options& options) {
+  auto& state = singletonState();
+  std::lock_guard<std::mutex> lock(state.mutex);
+  NIMBLE_CHECK_NULL(
+      state.instance.load(std::memory_order_acquire),
+      "TabletReaderCache::initialize() must only be called once");
+  state.instance.store(
+      new TabletReaderCache(options), std::memory_order_release);
+}
+
+TabletReaderCache& TabletReaderCache::getInstance() {
+  auto* instance = singletonState().instance.load(std::memory_order_acquire);
+  NIMBLE_CHECK_NOT_NULL(
+      instance,
+      "TabletReaderCache::initialize() must be called before getInstance()");
+  return *instance;
+}
+
+void TabletReaderCache::testingReset() {
+  auto& state = singletonState();
+  std::lock_guard<std::mutex> lock(state.mutex);
+  delete state.instance.exchange(nullptr, std::memory_order_acq_rel);
+}
+
+} // namespace facebook::nimble

--- a/dwio/nimble/tablet/TabletReaderCache.h
+++ b/dwio/nimble/tablet/TabletReaderCache.h
@@ -1,0 +1,162 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <memory>
+#include <optional>
+#include <string>
+#include <vector>
+
+#include <fmt/format.h>
+#include <folly/executors/CPUThreadPoolExecutor.h>
+
+#include "dwio/nimble/tablet/TabletReader.h"
+#include "dwio/nimble/velox/SchemaReader.h"
+#include "velox/common/base/SuccinctPrinter.h"
+#include "velox/common/caching/CachedFactory.h"
+#include "velox/common/caching/SimpleLRUCache.h"
+#include "velox/common/memory/Memory.h"
+#include "velox/type/Type.h"
+
+namespace facebook::nimble {
+
+/// Wraps a shared_ptr<TabletReader> and its deserialized schemas so they can
+/// be managed by CachedFactory (which requires unique_ptr ownership of the
+/// value type). Both schemas are computed once at creation time and shared
+/// across all consumers, avoiding repeated FlatBuffers deserialization and
+/// nimble-to-velox type conversion.
+struct CachedTabletReader {
+  std::shared_ptr<TabletReader> tablet;
+  /// Nimble-native schema from the file footer.
+  std::shared_ptr<const facebook::nimble::Type> nimbleSchema;
+  /// Velox type converted from the nimble schema. This is the base file schema
+  /// before any per-consumer column name mapping (which depends on
+  /// ReaderOptions and is applied at ReaderBase creation time).
+  velox::RowTypePtr veloxSchema;
+};
+
+/// Process-wide cache for sharing TabletReader instances across multiple
+/// consumers (e.g., NimbleIndexProjectors reading the same file). Uses
+/// sharded system memory pools from MemoryManager for memory accounting,
+/// independent of any task/query pool.
+///
+/// Thread-safe. Concurrent lookups for the same filename only create the
+/// TabletReader once (deduplication via CachedFactory's pending set).
+///
+/// The cache assumes that the same filename always uses compatible
+/// TabletReader::Options. On cache hit, the stored options from the first
+/// creation are used; the caller's options are ignored.
+class TabletReaderCache {
+ public:
+  struct Options {
+    /// Number of cache shards. Each shard has its own system memory pool
+    /// and mutex. Must be a power of 2.
+    uint32_t numShards{32};
+
+    /// Maximum number of cached TabletReaders across all shards.
+    size_t maxEntries{4'096};
+
+    /// TTL in milliseconds. 0 means no expiration.
+    size_t expireDurationMs{0};
+
+    /// Executor for background IO during TabletReader construction
+    /// (e.g., parallel metadata loading).
+    std::shared_ptr<folly::Executor> executor;
+
+    std::string toString() const {
+      return fmt::format(
+          "numShards={}, maxEntries={}, expireDuration={}, executor={}",
+          numShards,
+          maxEntries,
+          velox::succinctMillis(expireDurationMs),
+          executor != nullptr ? "set" : "null");
+    }
+  };
+
+  /// Properties passed to the generator on cache miss.
+  struct Properties {
+    std::shared_ptr<velox::ReadFile> readFile;
+    TabletReader::Options tabletOptions;
+  };
+
+  explicit TabletReaderCache(const Options& options);
+
+  /// Returns a cached or newly created CachedTabletReader for the given file.
+  /// Uses readFile->getName() as the cache key. On cache miss, creates the
+  /// TabletReader and deserializes the schema using a sharded system pool
+  /// (keyed by filename hash) and the provided readFile/options.
+  CachedTabletReader get(
+      const std::shared_ptr<velox::ReadFile>& readFile,
+      const TabletReader::Options& tabletOptions);
+
+  /// Returns cache statistics (hits, misses, evictions, etc.).
+  velox::SimpleLRUCacheStats stats();
+
+  /// Initializes the process-wide TabletReaderCache singleton. Must be called
+  /// once before getInstance(). Throws if called more than once.
+  static void initialize(const Options& options);
+
+  /// Returns the process-wide TabletReaderCache singleton. Must call
+  /// initialize() first.
+  static TabletReaderCache& getInstance();
+
+  /// Resets the singleton to uninitialized state. Test-only.
+  static void testingReset();
+
+  /// Looks up a cached entry by filename without creating on miss. Test-only.
+  std::optional<CachedTabletReader> testingGet(const std::string& filename);
+
+ private:
+  class Generator {
+   public:
+    Generator(
+        std::vector<std::shared_ptr<velox::memory::MemoryPool>> pools,
+        std::shared_ptr<folly::Executor> executor);
+
+    std::unique_ptr<CachedTabletReader> operator()(
+        const std::string& filename,
+        const Properties* properties,
+        void* stats);
+
+   private:
+    const std::vector<std::shared_ptr<velox::memory::MemoryPool>> pools_;
+    const std::shared_ptr<folly::Executor> executor_;
+    const uint32_t shardMask_;
+  };
+
+  struct Sizer {
+    int64_t operator()(const CachedTabletReader& /*entry*/) const {
+      return 1;
+    }
+  };
+
+  using LRUCache = velox::SimpleLRUCache<std::string, CachedTabletReader>;
+
+  using Factory = velox::CachedFactory<
+      std::string,
+      CachedTabletReader,
+      Generator,
+      Properties,
+      void,
+      Sizer>;
+
+  static Factory createFactory(const Options& opts);
+
+  Factory factory_;
+};
+
+} // namespace facebook::nimble

--- a/dwio/nimble/tablet/tests/TabletReaderCacheTest.cpp
+++ b/dwio/nimble/tablet/tests/TabletReaderCacheTest.cpp
@@ -1,0 +1,346 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "dwio/nimble/tablet/TabletReaderCache.h"
+
+#include <random>
+#include <thread>
+
+#include <gtest/gtest.h>
+
+#include "dwio/nimble/common/Exceptions.h"
+#include "dwio/nimble/common/tests/GTestUtils.h"
+#include "dwio/nimble/velox/SchemaBuilder.h"
+#include "dwio/nimble/velox/SchemaSerialization.h"
+#include "dwio/nimble/velox/VeloxWriter.h"
+#include "folly/executors/CPUThreadPoolExecutor.h"
+#include "folly/synchronization/Latch.h"
+#include "velox/common/file/File.h"
+#include "velox/common/memory/Memory.h"
+#include "velox/vector/tests/utils/VectorMaker.h"
+
+using namespace facebook::nimble;
+using namespace facebook;
+
+namespace {
+// InMemoryReadFile with a configurable name for cache key differentiation.
+class NamedInMemoryReadFile : public velox::InMemoryReadFile {
+ public:
+  NamedInMemoryReadFile(std::string name, std::string_view data)
+      : velox::InMemoryReadFile(data), name_{std::move(name)} {}
+
+  std::string getName() const override {
+    return name_;
+  }
+
+ private:
+  const std::string name_;
+};
+} // namespace
+
+class TabletReaderCacheTest : public ::testing::Test {
+ protected:
+  // Default test schema: ROW({"col0"}, {BIGINT()}).
+  static inline const velox::RowTypePtr kVeloxSchema =
+      velox::ROW({"col0"}, {velox::BIGINT()});
+
+  static void SetUpTestSuite() {
+    velox::memory::MemoryManager::testingSetInstance({});
+  }
+
+  void SetUp() override {
+    pool_ = velox::memory::memoryManager()->addLeafPool("test");
+    executor_ = std::make_shared<folly::CPUThreadPoolExecutor>(4);
+  }
+
+  void TearDown() override {
+    TabletReaderCache::testingReset();
+  }
+
+  std::string writeTestFile(uint32_t numRows = 100) {
+    std::string file;
+    velox::test::VectorMaker vectorMaker(pool_.get());
+    auto vector = vectorMaker.rowVector(
+        {"col0"},
+        {vectorMaker.flatVector<int64_t>(numRows, [](auto i) { return i; })});
+
+    VeloxWriterOptions writerOptions;
+    auto writer = std::make_unique<VeloxWriter>(
+        kVeloxSchema,
+        std::make_unique<velox::InMemoryWriteFile>(&file),
+        *pool_,
+        std::move(writerOptions));
+    writer->write(vector);
+    writer->close();
+    return file;
+  }
+
+  void verifySchema(const CachedTabletReader& cached) {
+    ASSERT_NE(cached.nimbleSchema, nullptr);
+    EXPECT_TRUE(cached.nimbleSchema->isRow());
+    ASSERT_NE(cached.veloxSchema, nullptr);
+    EXPECT_TRUE(cached.veloxSchema->equivalent(*kVeloxSchema));
+  }
+
+  std::shared_ptr<NamedInMemoryReadFile> makeReadFile(
+      const std::string& name,
+      const std::string& data) {
+    return std::make_shared<NamedInMemoryReadFile>(name, data);
+  }
+
+  TabletReaderCache::Options makeOptions(
+      uint32_t numShards = 2,
+      size_t maxEntries = 100) {
+    return {
+        .numShards = numShards,
+        .maxEntries = maxEntries,
+        .executor = executor_,
+    };
+  }
+
+  std::shared_ptr<velox::memory::MemoryPool> pool_;
+  std::shared_ptr<folly::CPUThreadPoolExecutor> executor_;
+};
+
+TEST_F(TabletReaderCacheTest, optionsToString) {
+  TabletReaderCache::Options opts;
+  opts.numShards = 8;
+  opts.maxEntries = 2'000;
+  opts.expireDurationMs = 60'000;
+  opts.executor = executor_;
+  EXPECT_EQ(
+      opts.toString(),
+      "numShards=8, maxEntries=2000, expireDuration=60.00s, executor=set");
+
+  opts.executor = nullptr;
+  EXPECT_EQ(
+      opts.toString(),
+      "numShards=8, maxEntries=2000, expireDuration=60.00s, executor=null");
+}
+
+TEST_F(TabletReaderCacheTest, invalidOptions) {
+  NIMBLE_ASSERT_THROW(
+      TabletReaderCache(makeOptions(/*numShards=*/3)),
+      "numShards must be a power of 2");
+
+  TabletReaderCache::Options opts;
+  opts.numShards = 2;
+  opts.maxEntries = 100;
+  opts.executor = nullptr;
+  NIMBLE_ASSERT_THROW(TabletReaderCache(opts), "");
+}
+
+TEST_F(TabletReaderCacheTest, cacheHitAndMiss) {
+  TabletReaderCache cache(makeOptions());
+
+  const auto file1 = writeTestFile(100);
+  const auto file2 = writeTestFile(200);
+  auto readFile1 = makeReadFile("file1", file1);
+  auto readFile2 = makeReadFile("file2", file2);
+
+  // First get is a miss.
+  auto cached1 = cache.get(readFile1, {});
+  EXPECT_EQ(cache.stats().numLookups, 1);
+  EXPECT_EQ(cache.stats().numHits, 0);
+  EXPECT_EQ(cache.stats().numElements, 1);
+
+  // Same file is a hit — returns identical pointers.
+  auto cached2 = cache.get(readFile1, {});
+  EXPECT_EQ(cached1.tablet.get(), cached2.tablet.get());
+  EXPECT_EQ(cached1.nimbleSchema.get(), cached2.nimbleSchema.get());
+  EXPECT_EQ(cached1.veloxSchema.get(), cached2.veloxSchema.get());
+  EXPECT_EQ(cache.stats().numLookups, 2);
+  EXPECT_EQ(cache.stats().numHits, 1);
+  EXPECT_EQ(cache.stats().numElements, 1);
+
+  // Different file is a miss — returns different pointers.
+  auto cached3 = cache.get(readFile2, {});
+  EXPECT_NE(cached1.tablet.get(), cached3.tablet.get());
+  EXPECT_NE(cached1.nimbleSchema.get(), cached3.nimbleSchema.get());
+  EXPECT_NE(cached1.veloxSchema.get(), cached3.veloxSchema.get());
+  EXPECT_EQ(cache.stats().numLookups, 3);
+  EXPECT_EQ(cache.stats().numHits, 1);
+  EXPECT_EQ(cache.stats().numElements, 2);
+}
+
+TEST_F(TabletReaderCacheTest, eviction) {
+  TabletReaderCache cache(makeOptions(/*numShards=*/2, /*maxEntries=*/2));
+
+  const auto file = writeTestFile();
+
+  // Fill cache to capacity.
+  for (int i = 0; i < 2; ++i) {
+    auto readFile = makeReadFile("file" + std::to_string(i), file);
+    cache.get(readFile, {});
+  }
+  EXPECT_EQ(cache.stats().numElements, 2);
+
+  // Adding a third entry should evict the least-recently used one.
+  auto readFile = makeReadFile("file2", file);
+  cache.get(readFile, {});
+  EXPECT_EQ(cache.stats().numElements, 2);
+}
+
+TEST_F(TabletReaderCacheTest, expiration) {
+  constexpr size_t kTtlMs = 100;
+  TabletReaderCache::Options opts;
+  opts.numShards = 2;
+  opts.maxEntries = 100;
+  opts.expireDurationMs = kTtlMs;
+  opts.executor = executor_;
+  TabletReaderCache cache(opts);
+
+  const auto file = writeTestFile();
+  auto readFile = makeReadFile("file1", file);
+
+  auto cached1 = cache.get(readFile, {});
+  EXPECT_EQ(cache.stats().numElements, 1);
+  EXPECT_EQ(cache.stats().numHits, 0);
+
+  // Before expiration, same file is a cache hit.
+  auto cached2 = cache.get(readFile, {});
+  EXPECT_EQ(cached1.tablet.get(), cached2.tablet.get());
+  EXPECT_EQ(cache.stats().numHits, 1);
+
+  // Wait for TTL to expire.
+  std::this_thread::sleep_for(std::chrono::milliseconds(kTtlMs + 50));
+
+  // After expiration, same file is a cache miss — new tablet created.
+  auto cached3 = cache.get(readFile, {});
+  EXPECT_NE(cached1.tablet.get(), cached3.tablet.get());
+  EXPECT_EQ(cache.stats().numHits, 1);
+}
+
+TEST_F(TabletReaderCacheTest, concurrentGet) {
+  constexpr int kNumThreads = 32;
+  constexpr int kNumFiles = 64;
+  constexpr int kMaxCacheEntries = 16;
+  constexpr auto kTestDuration = std::chrono::seconds(10);
+
+  TabletReaderCache cache(
+      makeOptions(/*numShards=*/4, /*maxEntries=*/kMaxCacheEntries));
+
+  // Pre-generate file contents — each file has a distinct row count so
+  // we can verify identity via tabletRowCount().
+  std::vector<std::string> fileContents(kNumFiles);
+  for (int i = 0; i < kNumFiles; ++i) {
+    fileContents[i] = writeTestFile(/*numRows=*/100 + i);
+  }
+
+  std::atomic_bool stop{false};
+  std::atomic<uint64_t> totalGets{0};
+  folly::Latch latch(kNumThreads);
+
+  std::vector<std::thread> threads;
+  threads.reserve(kNumThreads);
+  for (int t = 0; t < kNumThreads; ++t) {
+    threads.emplace_back([&, t]() {
+      std::mt19937 rng(t);
+      std::uniform_int_distribution<int> dist(0, kNumFiles - 1);
+      latch.count_down();
+      latch.wait();
+      while (!stop.load(std::memory_order_relaxed)) {
+        const int fileIdx = dist(rng);
+        const auto name = "file" + std::to_string(fileIdx);
+        auto readFile = makeReadFile(name, fileContents[fileIdx]);
+        auto cached = cache.get(readFile, {});
+        ASSERT_NE(cached.tablet, nullptr);
+        ASSERT_EQ(
+            cached.tablet->tabletRowCount(),
+            static_cast<uint64_t>(100 + fileIdx));
+        ++totalGets;
+      }
+    });
+  }
+
+  std::this_thread::sleep_for(kTestDuration);
+  stop.store(true, std::memory_order_relaxed);
+  for (auto& t : threads) {
+    t.join();
+  }
+
+  const auto stats = cache.stats();
+  EXPECT_EQ(stats.maxSize, kMaxCacheEntries);
+  EXPECT_LE(stats.numElements, kMaxCacheEntries);
+  EXPECT_GT(stats.numLookups, 0);
+  EXPECT_GT(stats.numHits, 0);
+
+  // Verify all cached entries are valid.
+  size_t numCached = 0;
+  for (int i = 0; i < kNumFiles; ++i) {
+    const auto name = "file" + std::to_string(i);
+    auto entry = cache.testingGet(name);
+    if (!entry.has_value()) {
+      continue;
+    }
+    ++numCached;
+    ASSERT_NE(entry->tablet, nullptr);
+    EXPECT_EQ(entry->tablet->tabletRowCount(), static_cast<uint64_t>(100 + i));
+    verifySchema(*entry);
+  }
+  EXPECT_EQ(numCached, stats.numElements);
+
+  LOG(INFO) << "concurrentGet: " << totalGets.load() << " gets, "
+            << stats.numHits << "/" << stats.numLookups << " hits, "
+            << numCached << " cached";
+}
+
+TEST_F(TabletReaderCacheTest, singleton) {
+  // Ensure clean state.
+  TabletReaderCache::testingReset();
+
+  // getInstance() before initialize() should throw.
+  NIMBLE_ASSERT_THROW(
+      TabletReaderCache::getInstance(),
+      "TabletReaderCache::initialize() must be called before getInstance()");
+
+  // Initialize with specific options.
+  const auto opts = makeOptions(/*numShards=*/4, /*maxEntries=*/50);
+  TabletReaderCache::initialize(opts);
+
+  // getInstance() returns a functional instance.
+  auto& instance = TabletReaderCache::getInstance();
+  const auto file = writeTestFile();
+  auto readFile = makeReadFile("singleton_test", file);
+  {
+    auto cached = instance.get(readFile, {});
+    ASSERT_NE(cached.tablet, nullptr);
+    EXPECT_EQ(cached.tablet->fileSize(), readFile->size());
+    EXPECT_EQ(cached.tablet->stripeCount(), 1);
+    EXPECT_EQ(cached.tablet->tabletRowCount(), 100);
+    verifySchema(cached);
+  }
+
+  // Verify cache stats reflect the configured maxEntries.
+  EXPECT_EQ(instance.stats().maxSize, 50);
+
+  // Double initialize() should throw.
+  NIMBLE_ASSERT_THROW(
+      TabletReaderCache::initialize(makeOptions()),
+      "TabletReaderCache::initialize() must only be called once");
+
+  // Reset allows re-initialization.
+  TabletReaderCache::testingReset();
+  NIMBLE_ASSERT_THROW(
+      TabletReaderCache::getInstance(),
+      "TabletReaderCache::initialize() must be called before getInstance()");
+
+  TabletReaderCache::initialize(
+      makeOptions(/*numShards=*/2, /*maxEntries=*/200));
+  EXPECT_EQ(TabletReaderCache::getInstance().stats().maxSize, 200);
+
+  TabletReaderCache::testingReset();
+}

--- a/dwio/nimble/velox/index/CMakeLists.txt
+++ b/dwio/nimble/velox/index/CMakeLists.txt
@@ -16,6 +16,7 @@ target_link_libraries(
   nimble_index_projector
   nimble_index
   nimble_serializer_impl
+  nimble_tablet_reader_cache
   nimble_velox_common
   nimble_velox_selective
   velox_time

--- a/dwio/nimble/velox/index/NimbleIndexProjector.cpp
+++ b/dwio/nimble/velox/index/NimbleIndexProjector.cpp
@@ -20,6 +20,7 @@
 
 #include "dwio/nimble/index/ClusterIndex.h"
 #include "dwio/nimble/serializer/SerializerImpl.h"
+#include "dwio/nimble/tablet/TabletReaderCache.h"
 #include "dwio/nimble/velox/SchemaUtils.h"
 #include "folly/ScopeGuard.h"
 #include "velox/common/base/SuccinctPrinter.h"
@@ -67,17 +68,16 @@ std::string NimbleIndexProjector::Stats::toString() const {
       projectionTiming.toString());
 }
 
-std::unique_ptr<NimbleIndexProjector> NimbleIndexProjector::create(
+namespace {
+std::unique_ptr<velox::dwio::common::BufferedInput> createBufferedInput(
     const velox::FileHandle& fileHandle,
     velox::cache::AsyncDataCache* cache,
-    const std::vector<Subfield>& projectedSubfields,
     const velox::dwio::common::ReaderOptions& options) {
-  std::unique_ptr<velox::dwio::common::BufferedInput> bufferedInput;
   if (cache != nullptr && options.cacheData()) {
     NIMBLE_CHECK(
         fileHandle.uuid.hasValue() && fileHandle.groupId.hasValue(),
         "FileHandle must have valid uuid and groupId when cache is provided");
-    bufferedInput = std::make_unique<velox::dwio::common::CachedBufferedInput>(
+    return std::make_unique<velox::dwio::common::CachedBufferedInput>(
         fileHandle.file,
         velox::dwio::common::MetricsLog::voidLog(),
         fileHandle.uuid,
@@ -88,30 +88,54 @@ std::unique_ptr<NimbleIndexProjector> NimbleIndexProjector::create(
         /*ioStats=*/nullptr,
         /*executor=*/nullptr,
         options);
-  } else {
-    bufferedInput = std::make_unique<velox::dwio::common::DirectBufferedInput>(
-        fileHandle.file,
-        velox::dwio::common::MetricsLog::voidLog(),
-        fileHandle.uuid,
-        /*tracker=*/nullptr,
-        fileHandle.groupId,
-        options.dataIoStats(),
-        /*ioStats=*/nullptr,
-        /*executor=*/nullptr,
-        options);
   }
+  return std::make_unique<velox::dwio::common::DirectBufferedInput>(
+      fileHandle.file,
+      velox::dwio::common::MetricsLog::voidLog(),
+      fileHandle.uuid,
+      /*tracker=*/nullptr,
+      fileHandle.groupId,
+      options.dataIoStats(),
+      /*ioStats=*/nullptr,
+      /*executor=*/nullptr,
+      options);
+}
+} // namespace
+
+std::unique_ptr<NimbleIndexProjector> NimbleIndexProjector::create(
+    const velox::FileHandle& fileHandle,
+    velox::cache::AsyncDataCache* cache,
+    const std::vector<Subfield>& projectedSubfields,
+    const velox::dwio::common::ReaderOptions& options) {
+  validateReaderOptions(options);
+  auto bufferedInput = createBufferedInput(fileHandle, cache, options);
   return std::unique_ptr<NimbleIndexProjector>(new NimbleIndexProjector(
-      std::move(bufferedInput), projectedSubfields, options));
+      ReaderBase::create(std::move(bufferedInput), options),
+      projectedSubfields,
+      options));
+}
+
+std::unique_ptr<NimbleIndexProjector> NimbleIndexProjector::create(
+    TabletReaderCache& tabletReaderCache,
+    const velox::FileHandle& fileHandle,
+    velox::cache::AsyncDataCache* cache,
+    const std::vector<Subfield>& projectedSubfields,
+    const velox::dwio::common::ReaderOptions& options) {
+  validateReaderOptions(options);
+  auto cached = tabletReaderCache.get(
+      fileHandle.file, TabletReader::configureOptions(options));
+  auto bufferedInput = createBufferedInput(fileHandle, cache, options);
+  return std::unique_ptr<NimbleIndexProjector>(new NimbleIndexProjector(
+      ReaderBase::create(std::move(bufferedInput), std::move(cached), options),
+      projectedSubfields,
+      options));
 }
 
 NimbleIndexProjector::NimbleIndexProjector(
-    std::unique_ptr<velox::dwio::common::BufferedInput> bufferedInput,
+    std::shared_ptr<ReaderBase> readerBase,
     const std::vector<Subfield>& projectedSubfields,
     const velox::dwio::common::ReaderOptions& options)
-    : readerBase_{[&] {
-        validateReaderOptions(options);
-        return ReaderBase::create(std::move(bufferedInput), options);
-      }()},
+    : readerBase_{std::move(readerBase)},
       ioStats_{options.dataIoStats()},
       pool_{readerBase_->pool()},
       clusterIndex_{readerBase_->tablet().clusterIndex()},

--- a/dwio/nimble/velox/index/NimbleIndexProjector.h
+++ b/dwio/nimble/velox/index/NimbleIndexProjector.h
@@ -36,6 +36,8 @@
 
 namespace facebook::nimble {
 
+class TabletReaderCache;
+
 using Subfield = velox::common::Subfield;
 
 /// NimbleIndexProjector takes a batch of index lookup requests (point lookups
@@ -79,6 +81,15 @@ class NimbleIndexProjector {
   // TODO: projectedSubfields currently must match file schema column names.
   // Add table-to-file column name mapping for schema evolution support.
   static std::unique_ptr<NimbleIndexProjector> create(
+      const velox::FileHandle& fileHandle,
+      velox::cache::AsyncDataCache* cache,
+      const std::vector<Subfield>& projectedSubfields,
+      const velox::dwio::common::ReaderOptions& options);
+
+  /// Creates a NimbleIndexProjector sharing a TabletReader from the
+  /// provided TabletReaderCache.
+  static std::unique_ptr<NimbleIndexProjector> create(
+      TabletReaderCache& tabletReaderCache,
       const velox::FileHandle& fileHandle,
       velox::cache::AsyncDataCache* cache,
       const std::vector<Subfield>& projectedSubfields,
@@ -199,7 +210,7 @@ class NimbleIndexProjector {
 
  private:
   NimbleIndexProjector(
-      std::unique_ptr<velox::dwio::common::BufferedInput> bufferedInput,
+      std::shared_ptr<ReaderBase> readerBase,
       const std::vector<Subfield>& projectedSubfields,
       const velox::dwio::common::ReaderOptions& options);
 

--- a/dwio/nimble/velox/index/tests/CMakeLists.txt
+++ b/dwio/nimble/velox/index/tests/CMakeLists.txt
@@ -17,6 +17,7 @@ add_test(nimble_index_projector_test nimble_index_projector_test)
 target_link_libraries(
   nimble_index_projector_test
   nimble_index_projector
+  nimble_tablet_reader_cache
   nimble_deserializer
   nimble_deserializer_impl
   nimble_serializer

--- a/dwio/nimble/velox/index/tests/NimbleIndexProjectorTest.cpp
+++ b/dwio/nimble/velox/index/tests/NimbleIndexProjectorTest.cpp
@@ -25,6 +25,7 @@
 #include "dwio/nimble/serializer/Serializer.h"
 #include "dwio/nimble/serializer/SerializerImpl.h"
 #include "dwio/nimble/tablet/TabletReader.h"
+#include "dwio/nimble/tablet/TabletReaderCache.h"
 #include "dwio/nimble/tablet/tests/TabletTestUtils.h"
 #include "dwio/nimble/velox/SchemaUtils.h"
 #include "dwio/nimble/velox/VeloxReader.h"
@@ -78,10 +79,14 @@ folly::IOBuf coalesceChunkSlice(const folly::IOBuf& chunkSlice) {
 struct TestParam {
   bool enableCache;
   bool pinMetadata;
+  bool useTabletReaderCache;
 
   std::string debugString() const {
     return fmt::format(
-        "enableCache={}, pinMetadata={}", enableCache, pinMetadata);
+        "enableCache={}, pinMetadata={}, useTabletReaderCache={}",
+        enableCache,
+        pinMetadata,
+        useTabletReaderCache);
   }
 };
 
@@ -102,6 +107,7 @@ class NimbleIndexProjectorTest : public ::testing::TestWithParam<TestParam> {
     vectorMaker_.reset();
     leafPool_.reset();
     rootPool_.reset();
+    TabletReaderCache::testingReset();
   }
 
   // Writes sorted data with an index on the key column.
@@ -143,12 +149,15 @@ class NimbleIndexProjectorTest : public ::testing::TestWithParam<TestParam> {
 
  public:
   static std::vector<TestParam> getTestParams() {
-    return {
-        {false, false},
-        {false, true},
-        {true, false},
-        {true, true},
-    };
+    std::vector<TestParam> params;
+    for (bool enableCache : {false, true}) {
+      for (bool pinMetadata : {false, true}) {
+        for (bool useTabletReaderCache : {false, true}) {
+          params.push_back({enableCache, pinMetadata, useTabletReaderCache});
+        }
+      }
+    }
+    return params;
   }
 
  protected:
@@ -198,6 +207,17 @@ class NimbleIndexProjectorTest : public ::testing::TestWithParam<TestParam> {
     readerOptions.setPinMetadata(GetParam().pinMetadata);
     if (cacheData.has_value()) {
       readerOptions.setCacheData(*cacheData);
+    }
+    if (GetParam().useTabletReaderCache) {
+      ensureTabletReaderCache();
+      return {
+          NimbleIndexProjector::create(
+              *tabletReaderCache_,
+              fileHandle,
+              cache,
+              projectedSubfields,
+              readerOptions),
+          ioStats};
     }
     return {
         NimbleIndexProjector::create(
@@ -288,11 +308,22 @@ class NimbleIndexProjectorTest : public ::testing::TestWithParam<TestParam> {
   const std::shared_ptr<io::IoStatistics> indexIoStats_{
       std::make_shared<io::IoStatistics>()};
 
+  void ensureTabletReaderCache() {
+    if (tabletReaderCache_ == nullptr) {
+      TabletReaderCache::Options opts;
+      opts.numShards = 2;
+      opts.maxEntries = 100;
+      opts.executor = std::make_shared<folly::CPUThreadPoolExecutor>(4);
+      tabletReaderCache_ = std::make_unique<TabletReaderCache>(opts);
+    }
+  }
+
   std::shared_ptr<memory::MemoryPool> rootPool_;
   std::shared_ptr<memory::MemoryPool> leafPool_;
   std::unique_ptr<velox::test::VectorMaker> vectorMaker_;
   std::string sinkData_;
   std::unique_ptr<velox::serializer::KeyEncoder> keyEncoder_;
+  std::unique_ptr<TabletReaderCache> tabletReaderCache_;
 };
 
 TEST_P(NimbleIndexProjectorTest, basicColumnProjection) {
@@ -2833,9 +2864,10 @@ INSTANTIATE_TEST_CASE_P(
     ::testing::ValuesIn(NimbleIndexProjectorTest::getTestParams()),
     [](const ::testing::TestParamInfo<TestParam>& info) {
       return fmt::format(
-          "cache{}_pin{}",
+          "cache{}_pin{}_tabletCache{}",
           info.param.enableCache ? "On" : "Off",
-          info.param.pinMetadata ? "On" : "Off");
+          info.param.pinMetadata ? "On" : "Off",
+          info.param.useTabletReaderCache ? "On" : "Off");
     });
 
 } // namespace facebook::nimble::test

--- a/dwio/nimble/velox/selective/CMakeLists.txt
+++ b/dwio/nimble/velox/selective/CMakeLists.txt
@@ -31,6 +31,7 @@ add_library(
 )
 target_link_libraries(
   nimble_velox_selective
+  nimble_tablet_reader_cache
   nimble_velox_reader
   nimble_velox_writer
   nimble_velox_common

--- a/dwio/nimble/velox/selective/ReaderBase.cpp
+++ b/dwio/nimble/velox/selective/ReaderBase.cpp
@@ -71,6 +71,26 @@ std::shared_ptr<ReaderBase> ReaderBase::create(
       std::move(fileSchema)));
 }
 
+std::shared_ptr<ReaderBase> ReaderBase::create(
+    std::unique_ptr<velox::dwio::common::BufferedInput> input,
+    CachedTabletReader&& cachedTablet,
+    const velox::dwio::common::ReaderOptions& options) {
+  auto* pool = &options.memoryPool();
+  const auto& randomSkip = options.randomSkip();
+  const auto& scanSpec = options.scanSpec();
+  auto fileSchema =
+      asRowType(getFileSchema(options, std::move(cachedTablet.veloxSchema)));
+
+  return std::shared_ptr<ReaderBase>(new ReaderBase(
+      std::move(input),
+      std::move(cachedTablet.tablet),
+      pool,
+      randomSkip,
+      scanSpec,
+      std::move(cachedTablet.nimbleSchema),
+      std::move(fileSchema)));
+}
+
 ReaderBase::ReaderBase(
     std::unique_ptr<velox::dwio::common::BufferedInput> input,
     std::shared_ptr<TabletReader> tablet,

--- a/dwio/nimble/velox/selective/ReaderBase.h
+++ b/dwio/nimble/velox/selective/ReaderBase.h
@@ -20,6 +20,7 @@
 #include "dwio/nimble/index/ClusterIndex.h"
 #include "dwio/nimble/tablet/Constants.h"
 #include "dwio/nimble/tablet/TabletReader.h"
+#include "dwio/nimble/tablet/TabletReaderCache.h"
 #include "dwio/nimble/velox/RowRange.h"
 #include "dwio/nimble/velox/SchemaReader.h"
 #include "dwio/nimble/velox/stats/VectorizedStatistics.h"
@@ -32,6 +33,15 @@ class ReaderBase {
  public:
   static std::shared_ptr<ReaderBase> create(
       std::unique_ptr<velox::dwio::common::BufferedInput> input,
+      const velox::dwio::common::ReaderOptions& options);
+
+  /// Creates a ReaderBase sharing a cached TabletReader and pre-loaded
+  /// schemas. The tablet's metadata (footer, stripes, ClusterIndex) is shared
+  /// across all ReaderBase instances using the same tablet. Each ReaderBase
+  /// still owns its own BufferedInput for data IO.
+  static std::shared_ptr<ReaderBase> create(
+      std::unique_ptr<velox::dwio::common::BufferedInput> input,
+      CachedTabletReader&& cachedTablet,
       const velox::dwio::common::ReaderOptions& options);
 
   velox::dwio::common::BufferedInput& input() {

--- a/dwio/nimble/velox/selective/tests/ReaderBaseTest.cpp
+++ b/dwio/nimble/velox/selective/tests/ReaderBaseTest.cpp
@@ -1,0 +1,180 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "dwio/nimble/velox/selective/ReaderBase.h"
+
+#include <gtest/gtest.h>
+
+#include "dwio/nimble/tablet/TabletReaderCache.h"
+#include "dwio/nimble/velox/VeloxWriter.h"
+#include "folly/executors/CPUThreadPoolExecutor.h"
+#include "velox/common/file/File.h"
+#include "velox/common/memory/Memory.h"
+#include "velox/dwio/common/BufferedInput.h"
+#include "velox/vector/tests/utils/VectorMaker.h"
+
+using namespace facebook::nimble;
+using namespace facebook;
+
+namespace {
+
+enum class CreationMode { kDirect, kCached };
+
+} // namespace
+
+class ReaderBaseTest : public ::testing::TestWithParam<CreationMode> {
+ protected:
+  static inline const velox::RowTypePtr kSchema =
+      velox::ROW({"a", "b"}, {velox::BIGINT(), velox::VARCHAR()});
+
+  static void SetUpTestSuite() {
+    velox::memory::MemoryManager::testingSetInstance({});
+  }
+
+  void SetUp() override {
+    pool_ = velox::memory::memoryManager()->addLeafPool("test");
+    executor_ = std::make_shared<folly::CPUThreadPoolExecutor>(4);
+    fileData_ = writeTestFile();
+  }
+
+  void TearDown() override {
+    TabletReaderCache::testingReset();
+  }
+
+  std::string writeTestFile() {
+    std::string file;
+    velox::test::VectorMaker vectorMaker(pool_.get());
+    auto vector = vectorMaker.rowVector(
+        {"a", "b"},
+        {vectorMaker.flatVector<int64_t>(200, [](auto i) { return i; }),
+         vectorMaker.flatVector<velox::StringView>(200, [](auto i) {
+           return velox::StringView::makeInline("val" + std::to_string(i));
+         })});
+
+    VeloxWriterOptions writerOptions;
+    auto writer = std::make_unique<VeloxWriter>(
+        kSchema,
+        std::make_unique<velox::InMemoryWriteFile>(&file),
+        *pool_,
+        std::move(writerOptions));
+    writer->write(vector);
+    writer->close();
+    return file;
+  }
+
+  velox::dwio::common::ReaderOptions makeReaderOptions() {
+    velox::dwio::common::ReaderOptions opts(pool_.get());
+    opts.setDataIoStats(std::make_shared<velox::io::IoStatistics>());
+    opts.setMetadataIoStats(std::make_shared<velox::io::IoStatistics>());
+    opts.setIndexIoStats(std::make_shared<velox::io::IoStatistics>());
+    return opts;
+  }
+
+  std::shared_ptr<ReaderBase> createReaderBase() {
+    auto readFile = std::make_shared<velox::InMemoryReadFile>(fileData_);
+    auto readerOpts = makeReaderOptions();
+
+    switch (GetParam()) {
+      case CreationMode::kDirect: {
+        auto input = std::make_unique<velox::dwio::common::BufferedInput>(
+            readFile, *pool_);
+        return ReaderBase::create(std::move(input), readerOpts);
+      }
+      case CreationMode::kCached: {
+        ensureCache();
+        auto tabletOpts = TabletReader::configureOptions(readerOpts);
+        auto cached = cache_->get(readFile, tabletOpts);
+
+        auto input = std::make_unique<velox::dwio::common::BufferedInput>(
+            readFile, *pool_);
+        return ReaderBase::create(
+            std::move(input), std::move(cached), readerOpts);
+      }
+    }
+    VELOX_UNREACHABLE();
+  }
+
+  void ensureCache() {
+    if (cache_ == nullptr) {
+      TabletReaderCache::Options cacheOpts;
+      cacheOpts.numShards = 2;
+      cacheOpts.maxEntries = 10;
+      cacheOpts.executor = executor_;
+      cache_ = std::make_unique<TabletReaderCache>(cacheOpts);
+    }
+  }
+
+  std::shared_ptr<velox::memory::MemoryPool> pool_;
+  std::shared_ptr<folly::CPUThreadPoolExecutor> executor_;
+  std::string fileData_;
+  std::unique_ptr<TabletReaderCache> cache_;
+};
+
+TEST_P(ReaderBaseTest, basic) {
+  auto reader = createReaderBase();
+
+  EXPECT_TRUE(reader->fileSchema()->equivalent(*kSchema));
+  EXPECT_EQ(reader->fileSchema()->size(), 2);
+  EXPECT_EQ(reader->fileSchema()->nameOf(0), "a");
+  EXPECT_EQ(reader->fileSchema()->nameOf(1), "b");
+
+  ASSERT_NE(reader->nimbleSchema(), nullptr);
+  EXPECT_TRUE(reader->nimbleSchema()->isRow());
+  EXPECT_EQ(reader->nimbleSchema()->asRow().childrenCount(), 2);
+
+  EXPECT_EQ(reader->tablet().stripeCount(), 1);
+  EXPECT_EQ(reader->tablet().tabletRowCount(), 200);
+  EXPECT_EQ(reader->pool(), pool_.get());
+
+  const auto& schemaWithId = reader->fileSchemaWithId();
+  ASSERT_NE(schemaWithId, nullptr);
+  EXPECT_EQ(schemaWithId->size(), 2);
+  EXPECT_EQ(reader->fileSchemaWithId().get(), schemaWithId.get());
+}
+
+TEST_P(ReaderBaseTest, equivalentAcrossModes) {
+  auto readFile = std::make_shared<velox::InMemoryReadFile>(fileData_);
+  auto readerOpts = makeReaderOptions();
+
+  auto inputDirect =
+      std::make_unique<velox::dwio::common::BufferedInput>(readFile, *pool_);
+  auto direct = ReaderBase::create(std::move(inputDirect), readerOpts);
+
+  ensureCache();
+  auto tabletOpts = TabletReader::configureOptions(readerOpts);
+  auto cached = cache_->get(readFile, tabletOpts);
+
+  auto inputCached =
+      std::make_unique<velox::dwio::common::BufferedInput>(readFile, *pool_);
+  auto fromCache =
+      ReaderBase::create(std::move(inputCached), std::move(cached), readerOpts);
+
+  EXPECT_TRUE(direct->fileSchema()->equivalent(*fromCache->fileSchema()));
+  EXPECT_EQ(
+      direct->nimbleSchema()->asRow().childrenCount(),
+      fromCache->nimbleSchema()->asRow().childrenCount());
+  EXPECT_EQ(direct->tablet().stripeCount(), fromCache->tablet().stripeCount());
+  EXPECT_EQ(
+      direct->tablet().tabletRowCount(), fromCache->tablet().tabletRowCount());
+}
+
+INSTANTIATE_TEST_CASE_P(
+    AllCreationModes,
+    ReaderBaseTest,
+    ::testing::Values(CreationMode::kDirect, CreationMode::kCached),
+    [](const ::testing::TestParamInfo<CreationMode>& info) {
+      return info.param == CreationMode::kDirect ? "direct" : "cached";
+    });


### PR DESCRIPTION
Summary:
CONTEXT: Each `NimbleIndexProjector` currently creates its own `TabletReader`, duplicating footer metadata, stripes metadata, and ClusterIndex. When multiple projectors scan the same file with different column projections (e.g., in RocksDB `executeScan()`), this wastes memory and repeats expensive schema deserialization.

WHAT: Add a process-wide `TabletReaderCache` that shares `TabletReader`, nimble schema, and velox schema across all consumers reading the same file.

**`TabletReaderCache` (new):**
- Process-wide LRU cache using Velox `CachedFactory`, keyed by `readFile->getName()`.
- Caches `TabletReader` + deserialized nimble schema (`shared_ptr<const Type>`) + velox schema (`RowTypePtr`) in a `CachedTabletReader` struct, avoiding repeated FlatBuffers deserialization and nimble-to-velox type conversion per consumer.
- Sharded system memory pools via `MemoryManager::addLeafPool()`, independent of task/query pools.
- Thread-safe with concurrent dedup (only one thread creates per file; others wait).
- LRU eviction with configurable `maxEntries` (default 4096), `numShards` (default 32), and TTL.
- Singleton pattern via `initialize()`/`getInstance()` with `testingReset()` for tests.
- `testingGet(filename)` for cache inspection without creating on miss.

**`ReaderBase` changes:**
- New `create(BufferedInput, CachedTabletReader&&, ReaderOptions)` overload that accepts pre-loaded schemas from the cache, skipping redundant `loadSchema()` and `convertToVeloxType()`. Applies per-consumer column name mapping (`getFileSchema`) on top of the cached velox schema.
- Removed old `create(BufferedInput, TabletReader, ReaderOptions)` overload.

**`NimbleIndexProjector` changes:**
- New `create(TabletReaderCache&, FileHandle, cache, subfields, options)` overload that gets the `CachedTabletReader` from cache and passes it through to `ReaderBase::create`.

**`NimbleTableReader` changes:**
- All members marked `const` (set once in initializer list, never modified).
- Constructor uses `TabletReaderCache::getInstance().get()` with init-list lambdas for `minKey_`/`maxKey_`.
- Renamed `totalRowCount_` to `numRows_`.
- `friend class` moved to end of class body.

**Tests:**
- `TabletReaderCacheTest` (7 tests): options toString, invalid options, cache hit/miss with incremental stats, LRU eviction, TTL expiration, duration-based concurrent stress test (32 threads, 64 files, 16 max entries with `testingGet` validation), singleton lifecycle with `testingReset`.
- `ReaderBaseTest` (4 tests): parameterized with `direct`/`cached` creation modes — basic schema/metadata verification, cross-mode equivalence check.
- `NimbleIndexProjectorTest`: added `useTabletReaderCache` parameter (356 tests, doubled from 178).

**Follow-up:** Make `TabletReader` and `ClusterIndex` thread-safe so multiple `NimbleIndexProjector` instances can share the same tablet reader and cluster index concurrently without per-projector copies.

Reviewed By: HuamengJiang

Differential Revision: D106212703


