### PR TITLE
feat: Add PforEncoding (Patched FOR for data with rare outliers) (#784)

### DIFF
--- a/dwio/nimble/common/Types.cpp
+++ b/dwio/nimble/common/Types.cpp
@@ -51,6 +51,8 @@ std::string toString(EncodingType encodingType) {
       return "Prefix";
     case EncodingType::ALP:
       return "ALP";
+    case EncodingType::Pfor:
+      return "Pfor";
   }
   return fmt::format(
       "Unknown encoding type: {}", static_cast<int32_t>(encodingType));

--- a/dwio/nimble/common/Types.h
+++ b/dwio/nimble/common/Types.h
@@ -106,6 +106,10 @@ enum class EncodingType {
   Prefix = 11,
   // Adaptive Lossless floating-Point compression for numeric types.
   ALP = 12,
+  // Patched Frame-of-Reference. Subtracts a min baseline, bitpacks ~90% of
+  // residuals at a narrow base bit width, and stores the remaining outliers
+  // ("exceptions") as a parallel position+value array.
+  Pfor = 15,
 };
 std::string toString(EncodingType encodingType);
 std::ostream& operator<<(std::ostream& out, EncodingType encodingType);

--- a/dwio/nimble/encodings/PforEncoding.h
+++ b/dwio/nimble/encodings/PforEncoding.h
@@ -1,0 +1,483 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <algorithm>
+#include <cstring>
+#include <span>
+
+#include "dwio/nimble/common/Buffer.h"
+#include "dwio/nimble/common/Exceptions.h"
+#include "dwio/nimble/common/FixedBitArray.h"
+#include "dwio/nimble/common/Types.h"
+#include "dwio/nimble/common/Varint.h"
+#include "dwio/nimble/common/Vector.h"
+#include "dwio/nimble/encodings/common/Encoding.h"
+#include "dwio/nimble/encodings/common/EncodingPrimitives.h"
+#include "dwio/nimble/encodings/selection/EncodingSelection.h"
+#include "velox/common/base/BitUtil.h"
+
+// PforEncoding stores integer data using Patched Frame-of-Reference (slot 15).
+// Each value is decomposed as `value = baseline + residual`, where the
+// residuals are bitpacked at a base bit width chosen so that ~90% of the
+// residuals fit. Values whose residual overflows the base width are recorded
+// as (position, value) "exceptions" stored separately as varints.
+//
+// Decode uses a branchless two-pass strategy (ported from AusIntListPfor):
+//   Pass 1: Unpack all base residuals in a tight branchless loop.
+//   Pass 2: Patch the ~10% exception positions with their full values.
+// This eliminates per-element branches from the hot loop.
+//
+// Pfor wins over plain FixedBitWidth on dense numeric streams that contain a
+// small fraction of large outliers -- FixedBitWidth would have to widen every
+// slot to the worst case, while Pfor pays the wide cost only for the outliers.
+
+namespace facebook::nimble {
+
+/// Data layout (after the standard Encoding prefix):
+///
+///   sizeof(physicalType) bytes : baseline (a.k.a. min value)
+///   1 byte                    : baseBitWidth (bits per bitpacked residual;
+///                               range [0, 64])
+///   4 bytes                   : numExceptions (uint32_t, fixed width)
+///   numExceptions varints     : exception positions, strictly ascending
+///   numExceptions varints     : exception values (full residual, i.e.
+///                               value - baseline)
+///   FixedBitArray::bufferSize(rowCount, baseBitWidth) bytes:
+///                               bitpacked base residuals (omitted when
+///                               baseBitWidth == 0)
+template <typename T>
+class PforEncoding final
+    : public TypedEncoding<T, typename TypeTraits<T>::physicalType> {
+ public:
+  using cppDataType = T;
+  using physicalType = typename TypeTraits<T>::physicalType;
+
+  PforEncoding(
+      velox::memory::MemoryPool& pool,
+      std::string_view data,
+      const std::function<void*(uint32_t)>& stringBufferFactory,
+      const Encoding::Options& options = {});
+
+  void reset() final;
+  void skip(uint32_t rowCount) final;
+  void materialize(uint32_t rowCount, void* buffer) final;
+
+  template <typename DecoderVisitor>
+  void readWithVisitor(DecoderVisitor& visitor, ReadWithVisitorParams& params);
+
+  static std::string_view encode(
+      EncodingSelection<physicalType>& selection,
+      std::span<const physicalType> values,
+      Buffer& buffer,
+      const Encoding::Options& options = {});
+
+  std::string debugString(int offset) const final;
+
+  /// Selects the base bit width from the bucket histogram, targeting 90%
+  /// coverage. Returns {baseBitWidth, numExceptions}.
+  /// Shared by encode() and EncodingSizeEstimation to keep the two in sync.
+  ///
+  /// Note: buckets have 7-bit granularity, so the selected baseBitWidth may
+  /// overestimate by up to 6 bits. This is deliberate — the encode() path
+  /// uses the exact bitsRequired() on each residual, so the actual wire
+  /// format is tight. The overestimate only affects size estimation.
+  template <typename BucketArray>
+  static std::pair<uint8_t, uint64_t> selectBaseBitWidth(
+      const BucketArray& bucketCounts,
+      uint32_t rowCount,
+      uint8_t maxBitWidth) {
+    constexpr double kCoverageThreshold = 0.9;
+    if (maxBitWidth == 0) {
+      return {0, 0};
+    }
+    const uint64_t threshold = static_cast<uint64_t>(
+        static_cast<double>(rowCount) * kCoverageThreshold);
+    uint64_t cumulative = 0;
+    for (size_t k = 0; k < bucketCounts.size(); ++k) {
+      cumulative += bucketCounts[k];
+      if (cumulative >= threshold) {
+        const uint8_t bucketEndBitWidth =
+            static_cast<uint8_t>(std::min<size_t>((k + 1) * 7, 64));
+        return {
+            std::min(bucketEndBitWidth, maxBitWidth), rowCount - cumulative};
+      }
+    }
+    return {maxBitWidth, 0};
+  }
+
+ private:
+  /// Fixed-size header: baseline + baseBitWidth(1) + numExceptions(4).
+  static constexpr int kPrefixSize =
+      sizeof(physicalType) + 1 + sizeof(uint32_t);
+  // Patches any exceptions whose absolute position falls inside
+  // [row_, row_ + count) onto `output`, where output[k] corresponds to
+  // absolute position row_ + k. Advances exceptionCursor_ past consumed
+  // exceptions.
+  void patchExceptions(uint32_t count, physicalType* output);
+
+  // Advances exceptionCursor_ past any exception positions that fall before
+  // `targetRow`. Uses binary search for efficient seeking during skip()
+  // and reset().
+  void seekExceptionsTo(uint32_t targetRow);
+
+  // Wire-format header values, populated in the constructor.
+  physicalType baseline_{};
+  uint8_t baseBitWidth_{0};
+  uint32_t numExceptions_{0};
+
+  // Decoded exception side-channel. Eagerly decoded and stored at
+  // construction time since numExceptions_ is bounded by ~10% of rowCount
+  // in the typical case. Positions are in strictly ascending order.
+  Vector<uint32_t> exceptionPositions_;
+  Vector<physicalType> exceptionValues_;
+
+  // Bitpacked base-residual region. Default-constructed (empty) when
+  // baseBitWidth_ == 0.
+  FixedBitArray fixedBitArray_{};
+
+  // Current absolute row position in the stream.
+  uint32_t row_{0};
+
+  // Index of the next unconsumed exception in exceptionPositions_ /
+  // exceptionValues_. Monotonically increases as rows are consumed.
+  uint32_t exceptionCursor_{0};
+};
+
+//
+// End of public API. Implementations follow.
+//
+
+template <typename T>
+PforEncoding<T>::PforEncoding(
+    velox::memory::MemoryPool& pool,
+    std::string_view data,
+    const std::function<void*(uint32_t)>& /* stringBufferFactory */,
+    const Encoding::Options& options)
+    : TypedEncoding<T, physicalType>{pool, data, options},
+      exceptionPositions_{this->pool_},
+      exceptionValues_{this->pool_} {
+  if constexpr (!isIntegralType<physicalType>()) {
+    NIMBLE_INCOMPATIBLE_ENCODING(
+        "Pfor encoding only supports integral data types.");
+  } else {
+    const char* pos = data.data() + this->dataOffset();
+
+    // Parse the fixed-size header: baseline, baseBitWidth, numExceptions.
+    baseline_ = encoding::read<physicalType>(pos);
+    baseBitWidth_ = static_cast<uint8_t>(encoding::readChar(pos));
+    NIMBLE_CHECK_LE(
+        baseBitWidth_, 64, "Pfor base bit width must be in [0, 64].");
+    numExceptions_ = encoding::readUint32(pos);
+    NIMBLE_CHECK_LE(
+        numExceptions_,
+        this->rowCount_,
+        "Pfor exception count exceeds row count.");
+
+    // Eagerly decode exception positions (varint-encoded, ascending order).
+    exceptionPositions_.resize(numExceptions_);
+    for (uint32_t i = 0; i < numExceptions_; ++i) {
+      exceptionPositions_[i] = varint::readVarint32(&pos);
+      NIMBLE_CHECK_LT(
+          exceptionPositions_[i],
+          this->rowCount_,
+          "Pfor exception position out of range.");
+      if (i > 0) {
+        NIMBLE_CHECK_GT(
+            exceptionPositions_[i],
+            exceptionPositions_[i - 1],
+            "Pfor exception positions must be strictly ascending.");
+      }
+    }
+
+    // Eagerly decode exception values (varint-encoded full residuals).
+    exceptionValues_.resize(numExceptions_);
+    for (uint32_t i = 0; i < numExceptions_; ++i) {
+      if constexpr (
+          isFourByteIntegralType<physicalType>() || sizeof(physicalType) < 4) {
+        exceptionValues_[i] =
+            static_cast<physicalType>(varint::readVarint32(&pos));
+      } else {
+        exceptionValues_[i] =
+            static_cast<physicalType>(varint::readVarint64(&pos));
+      }
+    }
+
+    // Map the bitpacked residual region. Verify the wire data has
+    // enough bytes remaining to prevent out-of-bounds reads during decode.
+    // baseBitWidth_ == 0 when all values are identical (range == 0).
+    // No bitpacked region is stored in that case.
+    if (baseBitWidth_ > 0) {
+      const size_t bitpackedSize =
+          FixedBitArray::bufferSize(this->rowCount_, baseBitWidth_);
+      NIMBLE_CHECK_GE(
+          static_cast<size_t>(data.end() - pos),
+          bitpackedSize,
+          "Pfor bitpacked region underruns wire data.");
+      fixedBitArray_ = FixedBitArray{
+          {pos, static_cast<size_t>(data.end() - pos)}, baseBitWidth_};
+    }
+  }
+  reset();
+}
+
+template <typename T>
+void PforEncoding<T>::reset() {
+  row_ = 0;
+  exceptionCursor_ = 0;
+}
+
+template <typename T>
+void PforEncoding<T>::seekExceptionsTo(uint32_t targetRow) {
+  // Linear scan for small exception counts, binary search for large counts.
+  const uint32_t remaining = numExceptions_ - exceptionCursor_;
+  constexpr uint32_t kLinearScanThreshold{64};
+  if (remaining < kLinearScanThreshold) {
+    while (exceptionCursor_ < numExceptions_ &&
+           exceptionPositions_[exceptionCursor_] < targetRow) {
+      ++exceptionCursor_;
+    }
+  } else {
+    const auto begin = exceptionPositions_.begin();
+    const auto it = std::lower_bound(
+        begin + exceptionCursor_, exceptionPositions_.end(), targetRow);
+    exceptionCursor_ = static_cast<uint32_t>(it - begin);
+  }
+}
+
+template <typename T>
+void PforEncoding<T>::skip(uint32_t rowCount) {
+  row_ += rowCount;
+  seekExceptionsTo(row_);
+}
+
+template <typename T>
+void PforEncoding<T>::patchExceptions(uint32_t count, physicalType* output) {
+  // Overwrite exception slots with their full values. Exceptions are
+  // in ascending position order, so this is a forward linear scan.
+  const auto endRow = row_ + count;
+  while (exceptionCursor_ < numExceptions_ &&
+         exceptionPositions_[exceptionCursor_] < endRow) {
+    const auto row = exceptionPositions_[exceptionCursor_];
+    output[row - row_] = static_cast<physicalType>(
+        baseline_ + exceptionValues_[exceptionCursor_]);
+    ++exceptionCursor_;
+  }
+}
+
+template <typename T>
+void PforEncoding<T>::materialize(uint32_t rowCount, void* buffer) {
+  if (rowCount == 0) {
+    return;
+  }
+
+  // Unpack all base residuals (branchless bulk decode).
+  auto* output = static_cast<physicalType*>(buffer);
+  if (baseBitWidth_ == 0) {
+    // All residuals are zero; every value equals baseline.
+    std::fill(output, output + rowCount, baseline_);
+  } else if constexpr (isFourByteIntegralType<physicalType>()) {
+    fixedBitArray_.bulkGetWithBaseline32(
+        /*start=*/row_,
+        /*length=*/rowCount,
+        reinterpret_cast<uint32_t*>(output),
+        static_cast<uint32_t>(baseline_));
+  } else if constexpr (isEightByteIntegralType<physicalType>()) {
+    fixedBitArray_.bulkGet64WithBaseline(
+        /*start=*/row_,
+        /*length=*/rowCount,
+        reinterpret_cast<uint64_t*>(output),
+        static_cast<uint64_t>(baseline_));
+  } else {
+    // Narrow integral path (1- or 2-byte types). The bulk paths require
+    // 4- or 8-byte outputs; per-element get is acceptable for rare narrow
+    // streams.
+    for (auto i = 0; i < rowCount; ++i) {
+      output[i] =
+          static_cast<physicalType>(fixedBitArray_.get(row_ + i) + baseline_);
+    }
+  }
+
+  // Patch exception positions with their full values.
+  patchExceptions(rowCount, output);
+  row_ += rowCount;
+}
+
+template <typename T>
+template <typename V>
+void PforEncoding<T>::readWithVisitor(
+    V& visitor,
+    ReadWithVisitorParams& params) {
+  // TODO: Add a bulkScan / readWithVisitorFast path for 4-byte and 8-byte
+  // integral types once Pfor is used on hot read paths. The challenge is
+  // interleaving exception patching with the bulk scan framework. For now
+  // the slow path is sufficient since Pfor is a niche encoding.
+  detail::readWithVisitorSlow(
+      visitor,
+      params,
+      [&](auto toSkip) { skip(toSkip); },
+      [&]() {
+        physicalType value;
+        if (baseBitWidth_ == 0) {
+          value = baseline_;
+        } else {
+          value =
+              static_cast<physicalType>(fixedBitArray_.get(row_) + baseline_);
+        }
+        // Override with the exception value if one lands exactly on this row.
+        if (exceptionCursor_ < numExceptions_ &&
+            exceptionPositions_[exceptionCursor_] == row_) {
+          value = static_cast<physicalType>(
+              baseline_ + exceptionValues_[exceptionCursor_]);
+          ++exceptionCursor_;
+        }
+        ++row_;
+        return value;
+      });
+}
+
+template <typename T>
+std::string_view PforEncoding<T>::encode(
+    EncodingSelection<typename TypeTraits<T>::physicalType>& selection,
+    std::span<const typename TypeTraits<T>::physicalType> values,
+    Buffer& buffer,
+    const Encoding::Options& options) {
+  if constexpr (!isIntegralType<physicalType>()) {
+    NIMBLE_INCOMPATIBLE_ENCODING(
+        "Pfor encoding only supports integral data types.");
+  } else {
+    static_assert(
+        std::is_same_v<
+            typename std::make_unsigned<physicalType>::type,
+            physicalType>,
+        "Pfor physical type must be unsigned.");
+    const bool useVarint = options.useVarintRowCount;
+    NIMBLE_CHECK(!values.empty(), "Pfor encoding cannot be used with 0 rows.");
+
+    const uint32_t rowCount = static_cast<uint32_t>(values.size());
+    const physicalType baseline = selection.statistics().min();
+    const physicalType maxValue = selection.statistics().max();
+    const physicalType fullRange =
+        static_cast<physicalType>(maxValue - baseline);
+    const uint8_t maxBitWidth =
+        static_cast<uint8_t>(velox::bits::bitsRequired(fullRange));
+
+    const auto [baseBitWidth, expectedExceptions] = selectBaseBitWidth(
+        selection.statistics().bucketCounts(), rowCount, maxBitWidth);
+
+    // Single pass: compute residuals, identify exceptions that overflow
+    // baseBitWidth, and zero-mask exception slots in the residual array.
+    constexpr uint32_t kBitsPerPhysicalType = sizeof(physicalType) * 8;
+    const physicalType baseMask = baseBitWidth == 0
+        ? physicalType{0}
+        : static_cast<physicalType>(velox::bits::lowMask(baseBitWidth));
+
+    Vector<uint32_t> exceptionPositions{&buffer.getMemoryPool()};
+    Vector<physicalType> exceptionValues{&buffer.getMemoryPool()};
+    // Reserve for expected exceptions based on the 90% coverage threshold.
+    exceptionPositions.reserve(expectedExceptions);
+    exceptionValues.reserve(expectedExceptions);
+
+    Vector<physicalType> maskedResiduals{&buffer.getMemoryPool()};
+    maskedResiduals.resize(rowCount);
+    for (auto i = 0; i < rowCount; ++i) {
+      const physicalType residual =
+          static_cast<physicalType>(values[i] - baseline);
+      if (baseBitWidth < kBitsPerPhysicalType && residual > baseMask) {
+        exceptionPositions.emplace_back(i);
+        exceptionValues.emplace_back(residual);
+        maskedResiduals[i] = physicalType{0};
+      } else {
+        maskedResiduals[i] = residual;
+      }
+    }
+    const uint32_t numExceptions =
+        static_cast<uint32_t>(exceptionPositions.size());
+
+    // Compute varint sizes for the exception side-channel.
+    uint64_t exceptionPositionBytes{0};
+    uint64_t exceptionValueBytes{0};
+    for (uint32_t i = 0; i < numExceptions; ++i) {
+      exceptionPositionBytes += varint::varintSize(exceptionPositions[i]);
+      exceptionValueBytes += varint::varintSize(exceptionValues[i]);
+    }
+    const uint64_t bitpackedSize = baseBitWidth == 0
+        ? 0
+        : FixedBitArray::bufferSize(rowCount, baseBitWidth);
+    const uint32_t encodingSize =
+        Encoding::serializePrefixSize(rowCount, useVarint) +
+        PforEncoding<T>::kPrefixSize +
+        static_cast<uint32_t>(
+            exceptionPositionBytes + exceptionValueBytes + bitpackedSize);
+
+    // Serialize into the output buffer.
+    char* reserved = buffer.reserve(encodingSize);
+    char* pos = reserved;
+    Encoding::serializePrefix(
+        EncodingType::Pfor, TypeTraits<T>::dataType, rowCount, useVarint, pos);
+    encoding::write(baseline, pos);
+    encoding::writeChar(static_cast<char>(baseBitWidth), pos);
+    encoding::writeUint32(numExceptions, pos);
+
+    // Write exception positions (ascending varint sequence).
+    for (uint32_t i = 0; i < numExceptions; ++i) {
+      varint::writeVarint(exceptionPositions[i], &pos);
+    }
+    // Write exception values (full residual varints).
+    for (uint32_t i = 0; i < numExceptions; ++i) {
+      varint::writeVarint(exceptionValues[i], &pos);
+    }
+
+    // Bitpack the masked residuals.
+    if (baseBitWidth > 0) {
+      char* bitpackedStart = pos;
+      std::memset(bitpackedStart, 0, bitpackedSize);
+      FixedBitArray fba(bitpackedStart, baseBitWidth);
+      if constexpr (isFourByteIntegralType<physicalType>()) {
+        fba.bulkSet32WithBaseline(
+            /*start=*/0,
+            /*length=*/rowCount,
+            reinterpret_cast<const uint32_t*>(maskedResiduals.data()),
+            /*baseline=*/0);
+      } else {
+        // TODO: Add a bulkSet64 path to FixedBitArray and use it here
+        // for 8-byte types to match the 4-byte bulk path above.
+        for (uint32_t i = 0; i < rowCount; ++i) {
+          fba.set(i, static_cast<uint64_t>(maskedResiduals[i]));
+        }
+      }
+      pos += bitpackedSize;
+    }
+
+    NIMBLE_CHECK_EQ(
+        pos - reserved, encodingSize, "Pfor encoding size mismatch.");
+    return {reserved, encodingSize};
+  }
+}
+
+template <typename T>
+std::string PforEncoding<T>::debugString(int offset) const {
+  return fmt::format(
+      "{}{}<{}> rowCount={} baseBitWidth={} numExceptions={}",
+      std::string(offset, ' '),
+      toString(Encoding::encodingType()),
+      toString(Encoding::dataType()),
+      Encoding::rowCount(),
+      static_cast<int>(baseBitWidth_),
+      numExceptions_);
+}
+
+} // namespace facebook::nimble

--- a/dwio/nimble/encodings/common/EncodingFactory.cpp
+++ b/dwio/nimble/encodings/common/EncodingFactory.cpp
@@ -21,6 +21,7 @@
 #include "dwio/nimble/encodings/FixedBitWidthEncoding.h"
 #include "dwio/nimble/encodings/MainlyConstantEncoding.h"
 #include "dwio/nimble/encodings/NullableEncoding.h"
+#include "dwio/nimble/encodings/PforEncoding.h"
 #include "dwio/nimble/encodings/PrefixEncoding.h"
 #include "dwio/nimble/encodings/RleEncoding.h"
 #include "dwio/nimble/encodings/SparseBoolEncoding.h"
@@ -249,6 +250,9 @@ std::unique_ptr<Encoding> EncodingFactory::create(
       // is implemented. ALP only supports float and double.
       NIMBLE_UNSUPPORTED("ALP encoding is not yet implemented.");
     }
+    case EncodingType::Pfor: {
+      RETURN_ENCODING_BY_NUMERIC_TYPE(PforEncoding, dataType);
+    }
     default: {
       NIMBLE_UNREACHABLE(
           "Trying to deserialize invalid EncodingType:{} -- garbage input?",
@@ -383,9 +387,17 @@ std::string_view EncodingFactory::encode(
       }
     }
     case EncodingType::ALP: {
-      // TODO: Wire up ALPEncoding::encode once the actual ALP algorithm is
-      // implemented. ALP only supports float and double.
       NIMBLE_UNSUPPORTED("ALP encoding is not yet implemented.");
+    }
+    case EncodingType::Pfor: {
+      if constexpr (isIntegralType<physicalType>()) {
+        return PforEncoding<T>::encode(
+            selection, castedValues, buffer, options);
+      } else {
+        NIMBLE_INCOMPATIBLE_ENCODING(
+            "Pfor encoding should not be selected for non-integral data type: {}.",
+            toString(TypeTraits<T>::dataType));
+      }
     }
     default: {
       NIMBLE_UNSUPPORTED(

--- a/dwio/nimble/encodings/common/EncodingLayout.cpp
+++ b/dwio/nimble/encodings/common/EncodingLayout.cpp
@@ -172,7 +172,8 @@ EncodingLayout EncodingLayoutCapture::capture(std::string_view encoding) {
     case EncodingType::Varint:
     case EncodingType::Constant:
     case EncodingType::Prefix:
-    case EncodingType::ALP: {
+    case EncodingType::ALP:
+    case EncodingType::Pfor: {
       // Non nested encodings have zero children
       break;
     }

--- a/dwio/nimble/encodings/common/EncodingUtils.h
+++ b/dwio/nimble/encodings/common/EncodingUtils.h
@@ -22,6 +22,7 @@
 #include "dwio/nimble/encodings/FixedBitWidthEncoding.h"
 #include "dwio/nimble/encodings/MainlyConstantEncoding.h"
 #include "dwio/nimble/encodings/NullableEncoding.h"
+#include "dwio/nimble/encodings/PforEncoding.h"
 #include "dwio/nimble/encodings/PrefixEncoding.h"
 #include "dwio/nimble/encodings/RleEncoding.h"
 #include "dwio/nimble/encodings/SparseBoolEncoding.h"
@@ -126,9 +127,13 @@ auto encodingTypeDispatchNonString(Encoding& encoding, F&& f) {
     case EncodingType::Delta:
       return f(static_cast<DeltaEncoding<T>&>(encoding));
     case EncodingType::ALP:
-      // TODO: Wire up ALPEncoding readWithVisitor dispatch once the actual
-      // ALP algorithm is implemented. ALP only supports float and double.
       NIMBLE_UNSUPPORTED("ALP encoding is not yet implemented.");
+    case EncodingType::Pfor:
+      if constexpr (isIntegralType<T>()) {
+        return f(static_cast<PforEncoding<T>&>(encoding));
+      } else {
+        NIMBLE_UNREACHABLE("{}", encoding.dataType());
+      }
     default:
       NIMBLE_UNSUPPORTED("{}", encoding.encodingType());
   }

--- a/dwio/nimble/encodings/legacy/EncodingFactory.cpp
+++ b/dwio/nimble/encodings/legacy/EncodingFactory.cpp
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 #include "dwio/nimble/encodings/legacy/EncodingFactory.h"
+#include "dwio/nimble/encodings/PforEncoding.h"
 #include "dwio/nimble/encodings/legacy/ConstantEncoding.h"
 #include "dwio/nimble/encodings/legacy/DeltaEncoding.h"
 #include "dwio/nimble/encodings/legacy/DictionaryEncoding.h"
@@ -247,6 +248,9 @@ std::unique_ptr<Encoding> EncodingFactory::create(
           "Trying to deserialize a PrefixEncoding with a non-string data type.");
       return std::make_unique<PrefixEncoding>(
           memoryPool, data, stringBufferFactory);
+    }
+    case EncodingType::Pfor: {
+      RETURN_ENCODING_BY_NUMERIC_TYPE(PforEncoding, dataType);
     }
     default: {
       NIMBLE_UNREACHABLE(

--- a/dwio/nimble/encodings/legacy/EncodingUtils.h
+++ b/dwio/nimble/encodings/legacy/EncodingUtils.h
@@ -15,6 +15,7 @@
  */
 #pragma once
 
+#include "dwio/nimble/encodings/PforEncoding.h"
 #include "dwio/nimble/encodings/common/EncodingUtils.h"
 #include "dwio/nimble/encodings/legacy/ConstantEncoding.h"
 #include "dwio/nimble/encodings/legacy/DeltaEncoding.h"
@@ -106,8 +107,16 @@ auto encodingTypeDispatchNonString(Encoding& encoding, F&& f) {
       return f(static_cast<MainlyConstantEncoding<T>&>(encoding));
     case EncodingType::Delta:
       return f(static_cast<DeltaEncoding<T>&>(encoding));
+    // New Encoding has no legacy-specialised class; legacy reads dispatch into
+    // the modern Encoding classes
+    case EncodingType::Pfor:
+      if constexpr (isIntegralType<T>()) {
+        return f(static_cast<::facebook::nimble::PforEncoding<T>&>(encoding));
+      } else {
+        NIMBLE_UNREACHABLE("{}", encoding.dataType());
+      }
     default:
-      NIMBLE_UNSUPPORTED(toString(encoding.encodingType()));
+      NIMBLE_UNSUPPORTED("{}", encoding.encodingType());
   }
 }
 

--- a/dwio/nimble/encodings/selection/EncodingSizeEstimation.h
+++ b/dwio/nimble/encodings/selection/EncodingSizeEstimation.h
@@ -21,6 +21,7 @@
 #include "dwio/nimble/common/Exceptions.h"
 #include "dwio/nimble/common/FixedBitArray.h"
 #include "dwio/nimble/common/Types.h"
+#include "dwio/nimble/encodings/PforEncoding.h"
 #include "velox/common/base/BitUtil.h"
 
 namespace facebook::nimble {
@@ -149,6 +150,32 @@ struct EncodingSizeEstimation {
               });
           return getEncodingOverhead<EncodingType::Varint, physicalType>() +
               dataSize;
+        } else {
+          return std::nullopt;
+        }
+      }
+      case EncodingType::Pfor: {
+        if constexpr (isIntegralType<physicalType>()) {
+          const auto fullRange =
+              static_cast<physicalType>(statistics.max() - statistics.min());
+          const uint8_t maxBitWidth =
+              static_cast<uint8_t>(velox::bits::bitsRequired(fullRange));
+          const auto [baseBitWidth, numExceptions] =
+              PforEncoding<physicalType>::selectBaseBitWidth(
+                  statistics.bucketCounts(), entryCount, maxBitWidth);
+          const uint64_t bitpackedSize = baseBitWidth == 0
+              ? 0
+              : FixedBitArray::bufferSize(entryCount, baseBitWidth);
+          // Per-exception: position varint (max 5B for uint32 positions)
+          // + value varint (ceil(maxBitWidth/7) bytes, capped at 10 because
+          // varint64 encodes at most 64 bits in ceil(64/7) = 10 bytes).
+          const uint64_t valueVarintBytes = std::min<uint64_t>(
+              (static_cast<uint64_t>(maxBitWidth) + 6) / 7, 10);
+          const uint64_t exceptionsSize =
+              numExceptions * (5 + valueVarintBytes);
+          constexpr uint32_t overhead =
+              6 + sizeof(physicalType) + 1 + sizeof(uint32_t);
+          return overhead + bitpackedSize + exceptionsSize;
         } else {
           return std::nullopt;
         }

--- a/dwio/nimble/encodings/tests/CMakeLists.txt
+++ b/dwio/nimble/encodings/tests/CMakeLists.txt
@@ -29,6 +29,7 @@ add_executable(
   Lz4CompressorTest.cpp
   MainlyConstantEncodingTest.cpp
   NullableEncodingTest.cpp
+  PforEncodingTest.cpp
   PrefixEncodingTest.cpp
   RleEncodingTest.cpp
   SentinelEncodingTest.cpp

--- a/dwio/nimble/encodings/tests/EncodingSizeEstimationTest.cpp
+++ b/dwio/nimble/encodings/tests/EncodingSizeEstimationTest.cpp
@@ -354,3 +354,36 @@ TEST_F(EncodingSizeEstimationTest, uint64AllEncodings) {
   ASSERT_TRUE(
       Est::estimateNumericSize(EncodingType::Varint, 100, stats).has_value());
 }
+
+TEST_F(EncodingSizeEstimationTest, pforEstimateVsActualSize) {
+  using Est = detail::EncodingSizeEstimation<uint32_t, false>;
+
+  // ~90% values in [0, 100], ~10% outliers near max — Pfor's sweet spot.
+  std::vector<uint32_t> data;
+  for (uint32_t i = 0; i < 900; ++i) {
+    data.push_back(i % 100);
+  }
+  for (uint32_t i = 0; i < 100; ++i) {
+    data.push_back(1'000'000 + i);
+  }
+  auto stats = Statistics<uint32_t>::create(data);
+  const uint32_t numValues = static_cast<uint32_t>(data.size());
+
+  auto estimated =
+      Est::estimateNumericSize(EncodingType::Pfor, numValues, stats);
+  ASSERT_TRUE(estimated.has_value());
+
+  // Actually encode and measure real size.
+  nimble::Buffer buffer{*pool_};
+  auto encoded = nimble::test::Encoder<nimble::PforEncoding<uint32_t>>::encode(
+      buffer, nimble::Vector<uint32_t>(pool_.get(), data.begin(), data.end()));
+  const uint64_t actualSize = encoded.size();
+
+  // Estimate should be in the same ballpark as actual — within 2x.
+  EXPECT_GT(estimated.value(), actualSize / 2)
+      << "estimate too low: " << estimated.value() << " vs actual "
+      << actualSize;
+  EXPECT_LT(estimated.value(), actualSize * 2)
+      << "estimate too high: " << estimated.value() << " vs actual "
+      << actualSize;
+}

--- a/dwio/nimble/encodings/tests/PforEncodingTest.cpp
+++ b/dwio/nimble/encodings/tests/PforEncodingTest.cpp
@@ -1,0 +1,369 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "dwio/nimble/encodings/PforEncoding.h"
+
+#include <fmt/core.h>
+#include <gtest/gtest.h>
+#include <random>
+
+#include "dwio/nimble/common/Buffer.h"
+#include "dwio/nimble/common/tests/GTestUtils.h"
+#include "dwio/nimble/encodings/common/EncodingFactory.h"
+#include "dwio/nimble/encodings/common/EncodingLayout.h"
+#include "dwio/nimble/encodings/selection/EncodingSelection.h"
+#include "dwio/nimble/encodings/selection/EncodingSelectionPolicy.h"
+#include "velox/common/memory/Memory.h"
+
+using namespace ::facebook;
+
+namespace facebook::nimble::test {
+
+// The Pfor wire format is byte-identical for a signed cpp type and its
+// matching unsigned physical type, so the per-type tests run on the unsigned
+// physical types directly. Signed-input coverage is exercised end-to-end by
+// the fuzzer test below, which routes int32/int64 through the standard
+// EncodingFactory::encode<T> path.
+template <typename T>
+class PforEncodingTest : public ::testing::Test {
+ protected:
+  static void SetUpTestCase() {
+    velox::memory::MemoryManager::testingSetInstance({});
+  }
+
+  void SetUp() override {
+    pool_ = velox::memory::deprecatedAddDefaultLeafMemoryPool();
+  }
+
+  std::unique_ptr<EncodingSelectionPolicy<T>> createSelectionPolicy() {
+    EncodingLayout layout{
+        EncodingType::Pfor, {}, CompressionType::Uncompressed};
+    return std::make_unique<ReplayedEncodingSelectionPolicy<T>>(
+        std::move(layout),
+        CompressionOptions{},
+        encodingSelectionPolicyFactory_);
+  }
+
+  std::unique_ptr<Encoding> encodeAndCreate(const std::vector<T>& values) {
+    Buffer buffer{*pool_};
+    auto encoded = EncodingFactory::encode<T>(
+        createSelectionPolicy(),
+        std::span<const T>{values.data(), values.size()},
+        buffer);
+    encodedStorage_.assign(encoded.begin(), encoded.end());
+    return EncodingFactory().create(
+        *pool_, {encodedStorage_.data(), encodedStorage_.size()}, nullptr);
+  }
+
+  void roundTripAndExpect(const std::vector<T>& values) {
+    auto encoding = encodeAndCreate(values);
+    EXPECT_EQ(encoding->encodingType(), EncodingType::Pfor);
+    EXPECT_EQ(encoding->dataType(), TypeTraits<T>::dataType);
+    EXPECT_EQ(encoding->rowCount(), values.size());
+
+    std::vector<T> decoded(values.size());
+    encoding->materialize(static_cast<uint32_t>(values.size()), decoded.data());
+    for (size_t i = 0; i < values.size(); ++i) {
+      EXPECT_EQ(decoded[i], values[i]) << "mismatch at index " << i;
+    }
+  }
+
+  std::shared_ptr<velox::memory::MemoryPool> pool_;
+  std::vector<char> encodedStorage_;
+  ManualEncodingSelectionPolicyFactory manualPolicyFactory_;
+  EncodingSelectionPolicyFactory encodingSelectionPolicyFactory_ =
+      [this](DataType dataType) {
+        return manualPolicyFactory_.createPolicy(dataType);
+      };
+};
+
+using PforTypes = ::testing::Types<uint32_t, uint64_t, uint8_t, uint16_t>;
+TYPED_TEST_SUITE(PforEncodingTest, PforTypes);
+
+TYPED_TEST(PforEncodingTest, singleElement) {
+  using T = TypeParam;
+  this->roundTripAndExpect({T{42}});
+}
+
+TYPED_TEST(PforEncodingTest, allSameValues) {
+  using T = TypeParam;
+  std::vector<T> values(64, T{7});
+  this->roundTripAndExpect(values);
+}
+
+TYPED_TEST(PforEncodingTest, denseSmallValuesNoExceptions) {
+  // Residuals all fit comfortably in the smallest 7-bit bucket; the encoder
+  // should pick baseBitWidth=7 and emit zero exceptions.
+  using T = TypeParam;
+  std::vector<T> values;
+  values.reserve(200);
+  for (uint32_t i = 0; i < 200; ++i) {
+    values.push_back(static_cast<T>(100 + (i % 64)));
+  }
+  this->roundTripAndExpect(values);
+}
+
+TYPED_TEST(PforEncodingTest, sparseOutliers) {
+  // 90% small residuals + 10% large outliers — Pfor's sweet spot. Skip on
+  // narrow types where outliers would not be representable.
+  using T = TypeParam;
+  if constexpr (sizeof(T) < 4) {
+    return;
+  } else {
+    std::vector<T> values;
+    values.reserve(500);
+    for (uint32_t i = 0; i < 500; ++i) {
+      if (i % 10 == 7) {
+        values.push_back(static_cast<T>(100000 + i));
+      } else {
+        values.push_back(static_cast<T>(50 + (i % 50)));
+      }
+    }
+    this->roundTripAndExpect(values);
+  }
+}
+
+TYPED_TEST(PforEncodingTest, residualsAtBitWidthBoundary) {
+  // Residuals exactly at the (1<<7)-1 = 127 boundary — verifies the
+  // base-mask comparison treats the boundary residual as a fitting value.
+  using T = TypeParam;
+  std::vector<T> values;
+  values.reserve(50);
+  for (uint32_t i = 0; i < 50; ++i) {
+    values.push_back(static_cast<T>(i * 2 % 128));
+  }
+  this->roundTripAndExpect(values);
+}
+
+TYPED_TEST(PforEncodingTest, mixedSizes) {
+  using T = TypeParam;
+  for (uint32_t n : {1u, 7u, 15u, 16u, 17u, 33u, 64u, 100u, 257u, 1024u}) {
+    SCOPED_TRACE(fmt::format("n={}", n));
+    std::vector<T> values;
+    values.reserve(n);
+    for (uint32_t i = 0; i < n; ++i) {
+      values.push_back(static_cast<T>((i * 31 + 1) % 256));
+    }
+    this->roundTripAndExpect(values);
+  }
+}
+
+TYPED_TEST(PforEncodingTest, skipAndMaterialize) {
+  using T = TypeParam;
+  std::vector<T> values;
+  values.reserve(300);
+  for (uint32_t i = 0; i < 300; ++i) {
+    if constexpr (sizeof(T) >= 4) {
+      values.push_back(
+          static_cast<T>(i % 17 == 0 ? 100000 + i : 50 + (i % 30)));
+    } else {
+      values.push_back(static_cast<T>(50 + (i % 30)));
+    }
+  }
+  auto encoding = this->encodeAndCreate(values);
+
+  // Materialize a few prefixes interleaved with skips — hits the exception
+  // cursor and the bitpacked cursor in the same pass.
+  encoding->reset();
+  std::vector<T> chunk(50);
+  encoding->materialize(50, chunk.data());
+  for (uint32_t i = 0; i < 50; ++i) {
+    EXPECT_EQ(chunk[i], values[i]);
+  }
+  encoding->skip(75);
+  encoding->materialize(50, chunk.data());
+  for (uint32_t i = 0; i < 50; ++i) {
+    EXPECT_EQ(chunk[i], values[125 + i]) << "i=" << i;
+  }
+  // 50 read + 75 skip + 50 read + 75 skip + 50 read == 300 == values.size()
+  encoding->skip(75);
+  encoding->materialize(50, chunk.data());
+  for (uint32_t i = 0; i < 50; ++i) {
+    EXPECT_EQ(chunk[i], values[250 + i]) << "i=" << i;
+  }
+
+  // Reset must restore all cursors so a second pass produces identical output.
+  encoding->reset();
+  std::vector<T> all(values.size());
+  encoding->materialize(static_cast<uint32_t>(values.size()), all.data());
+  for (size_t i = 0; i < values.size(); ++i) {
+    EXPECT_EQ(all[i], values[i]) << "after-reset i=" << i;
+  }
+}
+
+TYPED_TEST(PforEncodingTest, exceptionAtFirstAndLastRow) {
+  // Edge case: exceptions land on the first row, the last row, and a
+  // middle row. Verifies cursor handling at the bounds.
+  using T = TypeParam;
+  if constexpr (sizeof(T) < 4) {
+    return;
+  } else {
+    std::vector<T> values;
+    values.reserve(100);
+    for (uint32_t i = 0; i < 100; ++i) {
+      values.push_back(static_cast<T>(10));
+    }
+    values[0] = static_cast<T>(50000);
+    values[50] = static_cast<T>(60000);
+    values[99] = static_cast<T>(70000);
+    this->roundTripAndExpect(values);
+  }
+}
+
+TYPED_TEST(PforEncodingTest, debugString) {
+  using T = TypeParam;
+  std::vector<T> values;
+  values.reserve(8);
+  for (uint32_t i = 0; i < 8; ++i) {
+    values.push_back(static_cast<T>(i + 1));
+  }
+  auto encoding = this->encodeAndCreate(values);
+  const std::string debug = encoding->debugString();
+  EXPECT_NE(debug.find("Pfor"), std::string::npos);
+  EXPECT_NE(debug.find("baseBitWidth="), std::string::npos);
+  EXPECT_NE(debug.find("numExceptions="), std::string::npos);
+}
+
+class PforEncodingFuzzerTest : public ::testing::Test {
+ protected:
+  static void SetUpTestCase() {
+    velox::memory::MemoryManager::testingSetInstance({});
+  }
+
+  void SetUp() override {
+    pool_ = velox::memory::deprecatedAddDefaultLeafMemoryPool();
+  }
+
+  // Run the fuzzer against the cpp type T (signed or unsigned) by going
+  // through EncodingFactory::encode<T>. Verifies the signed-input wire path,
+  // materialization, and skip/materialize interleaving over many seeds.
+  template <typename T>
+  void runFuzzer(uint32_t seed, uint32_t numIterations) {
+    std::mt19937 rng(seed);
+
+    ManualEncodingSelectionPolicyFactory manualFactory;
+    EncodingSelectionPolicyFactory factory =
+        [&manualFactory](DataType dataType) {
+          return manualFactory.createPolicy(dataType);
+        };
+
+    for (uint32_t iter = 0; iter < numIterations; ++iter) {
+      SCOPED_TRACE(fmt::format("iteration {}", iter));
+
+      std::uniform_int_distribution<uint32_t> sizeDist(1, 1000);
+      const uint32_t numValues = sizeDist(rng);
+
+      std::uniform_int_distribution<int32_t> baseDist(0, 64);
+      std::uniform_int_distribution<int32_t> outlierDist(0, 1 << 20);
+      std::uniform_real_distribution<double> outlierProb(0.0, 1.0);
+      std::vector<T> values;
+      values.reserve(numValues);
+      const T offset = static_cast<T>(1000);
+      for (uint32_t i = 0; i < numValues; ++i) {
+        const bool isOutlier = outlierProb(rng) < 0.05;
+        values.push_back(
+            static_cast<T>(
+                offset + (isOutlier ? outlierDist(rng) : baseDist(rng))));
+      }
+
+      Buffer buffer{*pool_};
+      EncodingLayout layout{
+          EncodingType::Pfor, {}, CompressionType::Uncompressed};
+      auto policy = std::make_unique<ReplayedEncodingSelectionPolicy<T>>(
+          std::move(layout), CompressionOptions{}, factory);
+      auto encoded = EncodingFactory::encode<T>(
+          std::move(policy),
+          std::span<const T>{values.data(), values.size()},
+          buffer);
+      std::vector<char> storage(encoded.begin(), encoded.end());
+      auto encoding = EncodingFactory().create(
+          *pool_, {storage.data(), storage.size()}, nullptr);
+
+      ASSERT_EQ(encoding->encodingType(), EncodingType::Pfor);
+      ASSERT_EQ(encoding->dataType(), TypeTraits<T>::dataType);
+      ASSERT_EQ(encoding->rowCount(), values.size());
+      std::vector<T> decoded(values.size());
+      encoding->materialize(
+          static_cast<uint32_t>(values.size()), decoded.data());
+      for (size_t i = 0; i < values.size(); ++i) {
+        ASSERT_EQ(decoded[i], values[i])
+            << "iter=" << iter << " i=" << i << " size=" << numValues;
+      }
+
+      // Random skip/materialize sequence.
+      encoding->reset();
+      std::uniform_int_distribution<uint32_t> stepDist(0, numValues);
+      uint32_t cursor = 0;
+      while (cursor < numValues) {
+        const uint32_t remaining = numValues - cursor;
+        const uint32_t skipCount = stepDist(rng) % (remaining + 1);
+        if (skipCount > 0) {
+          encoding->skip(skipCount);
+          cursor += skipCount;
+        }
+        if (cursor >= numValues) {
+          break;
+        }
+        const uint32_t matCount =
+            std::max<uint32_t>(1, stepDist(rng) % (numValues - cursor + 1));
+        std::vector<T> chunk(matCount);
+        encoding->materialize(matCount, chunk.data());
+        for (uint32_t i = 0; i < matCount; ++i) {
+          ASSERT_EQ(chunk[i], values[cursor + i])
+              << "iter=" << iter << " cursor=" << cursor << " i=" << i;
+        }
+        cursor += matCount;
+      }
+    }
+  }
+
+  std::shared_ptr<velox::memory::MemoryPool> pool_;
+};
+
+TEST_F(PforEncodingFuzzerTest, fuzzerInt32) {
+  runFuzzer<int32_t>(/*seed=*/12345, /*numIterations=*/30);
+}
+
+TEST_F(PforEncodingFuzzerTest, fuzzerInt64) {
+  runFuzzer<int64_t>(/*seed=*/67890, /*numIterations=*/30);
+}
+
+TEST_F(PforEncodingFuzzerTest, fuzzerUint32) {
+  runFuzzer<uint32_t>(/*seed=*/24680, /*numIterations=*/30);
+}
+
+TEST_F(PforEncodingFuzzerTest, fuzzerUint64) {
+  runFuzzer<uint64_t>(/*seed=*/13579, /*numIterations=*/30);
+}
+
+TEST_F(PforEncodingFuzzerTest, encodeRejectsEmpty) {
+  Buffer buffer{*pool_};
+  EncodingLayout layout{EncodingType::Pfor, {}, CompressionType::Uncompressed};
+  ManualEncodingSelectionPolicyFactory manualFactory;
+  EncodingSelectionPolicyFactory factory = [&manualFactory](DataType dataType) {
+    return manualFactory.createPolicy(dataType);
+  };
+  auto policy = std::make_unique<ReplayedEncodingSelectionPolicy<uint32_t>>(
+      std::move(layout), CompressionOptions{}, factory);
+  std::vector<uint32_t> empty;
+  NIMBLE_ASSERT_THROW(
+      EncodingFactory::encode<uint32_t>(
+          std::move(policy),
+          std::span<const uint32_t>{empty.data(), empty.size()},
+          buffer),
+      "Pfor encoding cannot be used with 0 rows.");
+}
+
+} // namespace facebook::nimble::test

--- a/dwio/nimble/encodings/tests/TestUtils.h
+++ b/dwio/nimble/encodings/tests/TestUtils.h
@@ -22,6 +22,7 @@
 #include "dwio/nimble/encodings/FixedBitWidthEncoding.h"
 #include "dwio/nimble/encodings/MainlyConstantEncoding.h"
 #include "dwio/nimble/encodings/NullableEncoding.h"
+#include "dwio/nimble/encodings/PforEncoding.h"
 #include "dwio/nimble/encodings/RleEncoding.h"
 #include "dwio/nimble/encodings/SparseBoolEncoding.h"
 #include "dwio/nimble/encodings/TrivialEncoding.h"
@@ -179,6 +180,12 @@ class Encoder {
   struct EncodingTypeTraits<nimble::NullableEncoding<T>> {
     static constexpr inline nimble::EncodingType encodingType =
         nimble::EncodingType::Nullable;
+  };
+
+  template <>
+  struct EncodingTypeTraits<nimble::PforEncoding<T>> {
+    static constexpr inline nimble::EncodingType encodingType =
+        nimble::EncodingType::Pfor;
   };
 
  public:

--- a/dwio/nimble/serializer/tests/SerializationTest.cpp
+++ b/dwio/nimble/serializer/tests/SerializationTest.cpp
@@ -2098,6 +2098,78 @@ TEST_P(SerializationTest, encodingLayoutTree) {
   }
 }
 
+// Columnar reader-level round-trip for PforEncoding. Forces Pfor via
+// EncodingLayoutTree and verifies data integrity through the full
+// Serializer → Deserializer path.
+TEST_P(SerializationTest, pforColumnarRoundTrip) {
+  auto type = velox::ROW({
+      {"int_val", velox::INTEGER()},
+      {"long_val", velox::BIGINT()},
+  });
+
+  EncodingLayoutTree layoutTree{
+      Kind::Row,
+      {},
+      "",
+      {
+          {Kind::Scalar,
+           {{EncodingLayoutTree::StreamIdentifiers::Scalar::ScalarStream,
+             EncodingLayout{
+                 EncodingType::Pfor, {}, CompressionType::Uncompressed}}},
+           ""},
+          {Kind::Scalar,
+           {{EncodingLayoutTree::StreamIdentifiers::Scalar::ScalarStream,
+             EncodingLayout{
+                 EncodingType::Pfor, {}, CompressionType::Uncompressed}}},
+           ""},
+      }};
+
+  SerializerOptions options{
+      .version = version(),
+      .encodingLayoutTree = layoutTree,
+      .compressionOptions = compressionOptions(),
+  };
+
+  Serializer serializer{options, type, pool_.get()};
+
+  const velox::vector_size_t numRows = 100;
+  auto intVals =
+      velox::BaseVector::create(velox::INTEGER(), numRows, pool_.get());
+  auto longVals =
+      velox::BaseVector::create(velox::BIGINT(), numRows, pool_.get());
+  for (velox::vector_size_t i = 0; i < numRows; ++i) {
+    // ~90% narrow values, ~10% outliers — Pfor's sweet spot.
+    intVals->asFlatVector<int32_t>()->set(
+        i, i % 10 == 0 ? 1'000'000 + i : i % 100);
+    longVals->asFlatVector<int64_t>()->set(
+        i, i % 10 == 0 ? 9'000'000'000LL + i : i * 60);
+  }
+
+  auto input = std::make_shared<velox::RowVector>(
+      pool_.get(),
+      type,
+      nullptr,
+      numRows,
+      std::vector<velox::VectorPtr>{intVals, longVals});
+
+  auto serialized =
+      serializer.serialize(input, OrderedRanges::of(0, input->size()));
+
+  Deserializer deserializer{
+      SchemaReader::getSchema(serializer.schemaBuilder().schemaNodes()),
+      pool_.get(),
+      deserializerOptions()};
+
+  velox::VectorPtr output;
+  deserializer.deserialize(serialized, output);
+
+  ASSERT_EQ(output->size(), input->size());
+  for (velox::vector_size_t i = 0; i < input->size(); ++i) {
+    ASSERT_TRUE(vectorEquals(output, input, i))
+        << "Content mismatch at index " << i;
+  }
+}
+
 // Test encoding layout tree for FlatMap with dynamic key discovery and nested
 // types.
 TEST_P(SerializationTest, encodingLayoutTreeFlatMap) {

--- a/dwio/nimble/tools/EncodingUtilities.cpp
+++ b/dwio/nimble/tools/EncodingUtilities.cpp
@@ -50,6 +50,7 @@ void extractCompressionType(
     case EncodingType::MainlyConstant:
     case EncodingType::Prefix:
     case EncodingType::ALP:
+    case EncodingType::Pfor:
       break;
   }
 }
@@ -103,7 +104,8 @@ void traverseEncodings(
     case EncodingType::Varint:
     case EncodingType::Constant:
     case EncodingType::Prefix:
-    case EncodingType::ALP: {
+    case EncodingType::ALP:
+    case EncodingType::Pfor: {
       // don't have any nested encoding
       break;
     }


### PR DESCRIPTION
Summary:

X-link: https://github.com/facebookincubator/velox/pull/17622

Pull requests resolved:  
- https://github.com/facebookincubator/nimble/pull/784  
- https://github.com/facebookincubator/velox/pull/17622  

Pfor decomposes integer streams into a baseline plus residuals. It bit-packs ~90% of residuals using a narrow base bit width, and stores the remaining outliers in a varint side-channel. This outperforms FixedBitWidth on datasets where only a small fraction of values are large outliers.


  Wire format (after common prefix):
  [sizeof(T): baseline] [1B: baseBitWidth] [4B: numExceptions]
  [numExceptions varints: exception positions (ascending)]
  [numExceptions varints: exception values (full residuals)]
  [FixedBitArray: baseBitWidth bits × rowCount, omitted when baseBitWidth=0]

- Branchless, two-pass decode:  
  - **Pass 1:** bulk-unpack all residuals via `FixedBitArray::bulkGetWithBaseline32/64`  
  - **Pass 2:** patch the exception positions

Reviewed By: xiaoxmeng, HuamengJiang, tanjialiang

Differential Revision: D105270894


