### PR TITLE
feat: Add DoubleDelta encoding — claiming EncodingType::DoubleDelta = 16 (#785)

### DIFF
--- a/dwio/nimble/common/Types.cpp
+++ b/dwio/nimble/common/Types.cpp
@@ -53,6 +53,8 @@ std::string toString(EncodingType encodingType) {
       return "ALP";
     case EncodingType::Pfor:
       return "Pfor";
+    case EncodingType::DoubleDelta:
+      return "DoubleDelta";
   }
   return fmt::format(
       "Unknown encoding type: {}", static_cast<int32_t>(encodingType));

--- a/dwio/nimble/common/Types.h
+++ b/dwio/nimble/common/Types.h
@@ -110,6 +110,11 @@ enum class EncodingType {
   // residuals at a narrow base bit width, and stores the remaining outliers
   // ("exceptions") as a parallel position+value array.
   Pfor = 15,
+  // Delta-of-deltas encoding for int64/uint64. Instead of storing deltas
+  // between consecutive values, stores how much each delta *changes* from the
+  // previous one. For example, timestamps spaced ~60s apart have deltas of
+  // ~60 but double-deltas of ~0, which compresses extremely well.
+  DoubleDelta = 16,
 };
 std::string toString(EncodingType encodingType);
 std::ostream& operator<<(std::ostream& out, EncodingType encodingType);

--- a/dwio/nimble/encodings/DoubleDeltaEncoding.h
+++ b/dwio/nimble/encodings/DoubleDeltaEncoding.h
@@ -1,0 +1,606 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <algorithm>
+#include <cstring>
+#include <span>
+#include <type_traits>
+#include <vector>
+
+#include "dwio/nimble/common/Buffer.h"
+#include "dwio/nimble/common/Exceptions.h"
+#include "dwio/nimble/common/FixedBitArray.h"
+#include "dwio/nimble/common/Types.h"
+#include "dwio/nimble/encodings/common/Encoding.h"
+#include "dwio/nimble/encodings/common/EncodingPrimitives.h"
+#include "dwio/nimble/encodings/selection/EncodingSelection.h"
+#include "velox/common/base/BitUtil.h"
+
+// DoubleDeltaEncoding stores 64-bit integer streams using
+// second-order differencing (delta-of-deltas). Remaining values beyond the
+// first two are zigzag-encoded, shifted by a frame-of-reference minimum, and
+// bitpacked at a uniform bit width. Periodic checkpoints allow O(K) seek
+// instead of O(N) sequential decode.
+//
+// Targets monotone sequences with regular intervals (e.g. timestamps) where
+// the double-deltas collapse near zero -- perfectly regular timestamps encode
+// at bitWidth=0 and ~31 bytes regardless of row count.
+//
+// Ported from AusLongListDeltaOfDeltaEncoder (multifeed/datafm/encode/) with
+// bitpacking in place of GroupVarint, plus forward-decode checkpoints for
+// random access.
+//
+// TODO: Refactor to follow Nimble's cascading encoding philosophy. Currently
+// this encoding inlines zigzag + FOR + bitpack. In the Nimble model, the
+// double-delta values should be emitted as a child stream and the framework
+// should pick the optimal sub-encoding (e.g., FixedBitWidth, MainlyConstant,
+// Varint) via EncodingSelectionPolicy. This would also enable per-miniblock
+// adaptive bit widths (similar to Parquet's DELTA_BINARY_PACKED) for free.
+
+namespace facebook::nimble {
+
+/// Encodes 64-bit integer streams using double-delta bitpacking.
+///
+/// Data layout (after the standard Encoding prefix):
+///
+///   8 bytes  firstValue           -- raw int64 stored as uint64 wire bytes
+///   8 bytes  secondValue          -- raw int64 as uint64 (zero when N < 2)
+///   8 bytes  minZigzagDoubleDelta -- frame-of-reference floor (zero when
+///                                    N < 3)
+///   1 byte   bitWidth             -- bits per bitpacked residual [0, 64]
+///   variable bitpacked residuals  -- FixedBitArray::bufferSize(N - 2,
+///                                    bitWidth) bytes; omitted when
+///                                    bitWidth == 0 or N < 3
+///   4 bytes  checkpointCount      -- uint32, native byte order
+///   variable checkpoint entries   -- checkpointCount * 16 bytes, each is
+///                                    {uint64 lastValue, uint64 lastDelta}
+///                                    captured every kCheckpointStride
+///                                    residuals
+///
+/// The checkpoint segment is always present (even when checkpointCount == 0).
+template <typename T>
+class DoubleDeltaEncoding final
+    : public TypedEncoding<T, typename TypeTraits<T>::physicalType> {
+  static_assert(
+      std::is_same_v<T, int64_t> || std::is_same_v<T, uint64_t>,
+      "DoubleDelta only supports 64-bit integer types.");
+
+ public:
+  using cppDataType = T;
+  using physicalType = typename TypeTraits<T>::physicalType;
+
+  DoubleDeltaEncoding(
+      velox::memory::MemoryPool& pool,
+      std::string_view data,
+      const std::function<void*(uint32_t)>& stringBufferFactory,
+      const Encoding::Options& options = {});
+
+  /// Reset the read cursor to the beginning of the stream.
+  void reset() final;
+
+  /// Advance the read cursor by `rowCount` rows without emitting values.
+  void skip(uint32_t rowCount) final;
+
+  /// Decode the next `rowCount` values into `buffer`. The caller must
+  /// ensure `buffer` has room for at least rowCount * sizeof(physicalType).
+  void materialize(uint32_t rowCount, void* buffer) final;
+
+  /// Visitor-based read interface for selective/filtered reads.
+  template <typename DecoderVisitor>
+  void readWithVisitor(DecoderVisitor& visitor, ReadWithVisitorParams& params);
+
+  /// Encode `values` into the wire format, appending to `buffer`.
+  /// Returns a view into the buffer covering the encoded bytes.
+  static std::string_view encode(
+      EncodingSelection<physicalType>& selection,
+      std::span<const physicalType> values,
+      Buffer& buffer,
+      const Encoding::Options& options = {});
+
+  /// Return a human-readable description of this encoding for diagnostics.
+  std::string debugString(int offset) const final;
+
+ private:
+  // Checkpoint stride for O(K) seek. Every 64 residuals we snapshot
+  // {lastValue, lastDelta}.
+  static constexpr uint32_t kCheckpointStride{64};
+
+  // Decode the next bitpacked double-delta residual at the given index
+  // (residualIndex == row_ - 2). Accumulate into lastDelta_ and lastValue_
+  // and return the reconstructed value.
+  uint64_t advanceFromBitpacked(uint32_t residualIndex);
+
+  // Snapshot of decoder state captured every kCheckpointStride residuals
+  // during encode. Enables O(1) seek to any checkpoint boundary.
+  struct Checkpoint {
+    // Reconstructed value at the checkpoint boundary.
+    uint64_t lastValue{0};
+    // Delta from the previous to the checkpoint boundary value.
+    uint64_t lastDelta{0};
+  };
+  static_assert(sizeof(Checkpoint) == 16);
+
+  // Load checkpoint[i] from wire bytes. Use memcpy for alignment safety
+  // since the wire buffer may not be 8-byte aligned.
+  Checkpoint loadCheckpoint(uint32_t index) const {
+    Checkpoint checkpoint{};
+    std::memcpy(
+        &checkpoint,
+        checkpointStart_ + index * sizeof(Checkpoint),
+        sizeof(Checkpoint));
+    return checkpoint;
+  }
+
+  // Fast-forward decoder state to the best checkpoint covering `targetRow`.
+  // Skip when no checkpoint improves over the current row_ position. After
+  // seeking, at most kCheckpointStride - 1 rows remain to be walked by the
+  // per-row decode loop.
+  void seekToCheckpointFor(uint32_t targetRow);
+
+  // -- Wire-format fields, populated in the constructor --
+
+  // All wire bytes are stored as uint64 and re-cast to the signed/unsigned
+  // cpp type at emission time.
+  uint64_t firstWire_{0};
+  uint64_t secondWire_{0};
+  // Frame-of-reference floor subtracted from each zigzag-encoded
+  // double-delta before bitpacking.
+  uint64_t minZigzagDoubleDelta_{0};
+  // Uniform bit width of each bitpacked residual, range [0, 64].
+  uint8_t bitWidth_{0};
+
+  // Bitpacked double-delta residual region. Default-constructed (no backing
+  // buffer) when bitWidth_ == 0 or rowCount_ < 3.
+  FixedBitArray fixedBitArray_{};
+
+  // Pointer into wire bytes at the first checkpoint entry (immediately after
+  // the 4-byte count). nullptr when checkpointCount_ == 0.
+  const char* checkpointStart_{nullptr};
+  // Number of checkpoint entries in the wire data.
+  uint32_t checkpointCount_{0};
+
+  // -- Mutable decoder state --
+
+  // Absolute row position of the next value to be decoded.
+  uint32_t row_{0};
+  // Last decoded value at position (row_ - 1). Valid when row_ >= 1.
+  uint64_t lastValue_{0};
+  // Delta from position (row_ - 2) to (row_ - 1). Valid when row_ >= 2.
+  uint64_t lastDelta_{0};
+};
+
+namespace detail {
+// TODO: Move to a common place.
+// Zigzag-encode a 64-bit value using the standard interleave mapping:
+//   0 -> 0, -1 -> 1, 1 -> 2, -2 -> 3, 2 -> 4, ...
+// Accepts uint64 so callers can pass raw wire bytes; the arithmetic right
+// shift is performed via a signed cast to extend the sign bit. Both the
+// shift and the XOR are well-defined for every uint64 input, including
+// the bit pattern of INT64_MIN.
+inline uint64_t zigzagEncode64(uint64_t value) {
+  const auto signedValue = static_cast<int64_t>(value);
+  return (value << 1) ^ static_cast<uint64_t>(signedValue >> 63);
+}
+
+// Zigzag-decode a uint64 back to the original int64 bit pattern (returned
+// as uint64 for uniform wire handling). Inverse of zigzagEncode64 for all
+// 2^64 inputs.
+inline uint64_t zigzagDecode64(uint64_t value) {
+  return (value >> 1) ^ (~(value & 1) + 1);
+}
+
+} // namespace detail
+
+//
+// End of public API. Implementations follow.
+//
+
+template <typename T>
+DoubleDeltaEncoding<T>::DoubleDeltaEncoding(
+    velox::memory::MemoryPool& pool,
+    std::string_view data,
+    const std::function<void*(uint32_t)>& /* stringBufferFactory */,
+    const Encoding::Options& options)
+    : TypedEncoding<T, physicalType>{pool, data, options} {
+  const char* pos = data.data() + this->dataOffset();
+
+  // Read the fixed-size header fields.
+  firstWire_ = encoding::read<uint64_t>(pos);
+  secondWire_ = encoding::read<uint64_t>(pos);
+  minZigzagDoubleDelta_ = encoding::read<uint64_t>(pos);
+  bitWidth_ = static_cast<uint8_t>(encoding::readChar(pos));
+  NIMBLE_CHECK_LE(bitWidth_, 64, "DoubleDelta bit width must be in [0, 64].");
+
+  // Parse the bitpacked residual region when present.
+  size_t bitpackedSize = 0;
+  if (bitWidth_ > 0 && this->rowCount_ > 2) {
+    const uint32_t residualCount = this->rowCount_ - 2;
+    bitpackedSize = FixedBitArray::bufferSize(residualCount, bitWidth_);
+    // Guard against truncated wire data that would let the decoder read past
+    // the buffer boundary.
+    NIMBLE_CHECK_GE(
+        static_cast<size_t>(data.end() - pos),
+        bitpackedSize,
+        "DoubleDelta bitpacked region underruns wire data.");
+    fixedBitArray_ =
+        FixedBitArray{{pos, static_cast<size_t>(data.end() - pos)}, bitWidth_};
+  }
+  pos += bitpackedSize;
+
+  // Parse the trailing checkpoint segment: uint32 count followed by
+  // count * sizeof(Checkpoint) bytes of checkpoint entries.
+  NIMBLE_CHECK_GE(
+      static_cast<size_t>(data.end() - pos),
+      sizeof(uint32_t),
+      "DoubleDelta checkpoint count underruns wire data.");
+  checkpointCount_ = encoding::read<uint32_t>(pos);
+  NIMBLE_CHECK_GE(
+      static_cast<size_t>(data.end() - pos),
+      static_cast<size_t>(checkpointCount_) * sizeof(Checkpoint),
+      "DoubleDelta checkpoint array underruns wire data.");
+  checkpointStart_ = checkpointCount_ > 0 ? pos : nullptr;
+
+  reset();
+}
+
+template <typename T>
+void DoubleDeltaEncoding<T>::reset() {
+  row_ = 0;
+  lastValue_ = 0;
+  lastDelta_ = 0;
+}
+
+template <typename T>
+uint64_t DoubleDeltaEncoding<T>::advanceFromBitpacked(uint32_t residualIndex) {
+  // Recover the original double-delta:
+  //   stored residual = zigzag(doubleDelta) - minZigzagDoubleDelta
+  //   doubleDelta     = zigzagDecode(residual + minZigzagDoubleDelta)
+  const uint64_t residual =
+      bitWidth_ == 0 ? 0 : fixedBitArray_.get(residualIndex);
+  const uint64_t doubleDelta =
+      detail::zigzagDecode64(residual + minZigzagDoubleDelta_);
+
+  // Accumulate via unsigned wrap-around arithmetic. This preserves bit-exact
+  // recovery for int64 values whose true deltas span the signed range.
+  lastDelta_ += doubleDelta;
+  lastValue_ += lastDelta_;
+  return lastValue_;
+}
+
+template <typename T>
+void DoubleDeltaEncoding<T>::seekToCheckpointFor(uint32_t targetRow) {
+  if (checkpointCount_ == 0 || targetRow < kCheckpointStride + 2) {
+    return;
+  }
+  // checkpoint[i] captures state after residual (i+1)*K - 1 has been decoded,
+  // which corresponds to row (i+1)*K + 1 having been emitted. The next row
+  // to decode from that checkpoint is (i+1)*K + 2. Find the largest i such
+  // that this next-row is both <= targetRow and > row_ (never step backward).
+  const uint32_t checkpointIndex = (targetRow - 2) / kCheckpointStride - 1;
+  NIMBLE_CHECK_LT(
+      checkpointIndex, checkpointCount_, "Checkpoint index out of range.");
+  const uint32_t nextRow = (checkpointIndex + 1) * kCheckpointStride + 2;
+  if (nextRow <= row_) {
+    return;
+  }
+  const auto checkpoint = loadCheckpoint(checkpointIndex);
+  lastValue_ = checkpoint.lastValue;
+  lastDelta_ = checkpoint.lastDelta;
+  row_ = nextRow;
+}
+
+template <typename T>
+void DoubleDeltaEncoding<T>::skip(uint32_t rowCount) {
+  if (rowCount == 0) {
+    return;
+  }
+
+  const uint32_t end = row_ + rowCount;
+
+  // Jump to the best checkpoint when it saves work over sequential decode.
+  seekToCheckpointFor(end);
+
+  // Seed row 0: firstValue.
+  if (row_ == 0 && row_ < end) {
+    lastValue_ = firstWire_;
+    ++row_;
+  }
+  // Seed row 1: secondValue, establishes initial delta.
+  if (row_ == 1 && row_ < end) {
+    lastDelta_ = secondWire_ - firstWire_;
+    lastValue_ = secondWire_;
+    ++row_;
+  }
+
+  // Batch-decode remaining residuals. Bulk-extract into a temporary buffer
+  // and prefix-sum, avoiding per-element get() overhead.
+  const uint32_t residualCount = end - row_;
+  if (residualCount == 0) {
+    return;
+  }
+  if (bitWidth_ == 0) {
+    // All double-deltas are identical (minZigzagDoubleDelta_ after zigzag
+    // decode). Fast-forward with closed-form arithmetic.
+    const uint64_t doubleDelta = detail::zigzagDecode64(minZigzagDoubleDelta_);
+    const uint64_t n = residualCount;
+    // After n steps: lastDelta advances by n * doubleDelta,
+    // lastValue advances by sum_{k=1..n}(lastDelta + k * doubleDelta)
+    //   = n * lastDelta + doubleDelta * n*(n+1)/2
+    lastValue_ += lastDelta_ * n + doubleDelta * (n * (n + 1) / 2);
+    lastDelta_ += doubleDelta * n;
+    row_ = end;
+    return;
+  }
+  // After checkpoint seek, at most kCheckpointStride - 1 residuals remain.
+  NIMBLE_CHECK_LE(
+      residualCount,
+      kCheckpointStride,
+      "skip residualCount exceeds checkpoint stride.");
+  uint64_t zigzagBuf[kCheckpointStride];
+  const uint32_t residualStart = row_ - 2;
+  fixedBitArray_.bulkGet64WithBaseline(
+      /*start=*/residualStart,
+      /*length=*/residualCount,
+      zigzagBuf,
+      /*baseline=*/minZigzagDoubleDelta_);
+  for (uint32_t i = 0; i < residualCount; ++i) {
+    const uint64_t doubleDelta = detail::zigzagDecode64(zigzagBuf[i]);
+    lastDelta_ += doubleDelta;
+    lastValue_ += lastDelta_;
+  }
+  row_ = end;
+}
+
+template <typename T>
+void DoubleDeltaEncoding<T>::materialize(uint32_t rowCount, void* buffer) {
+  if (rowCount == 0) {
+    return;
+  }
+
+  auto* output = static_cast<physicalType*>(buffer);
+  const uint32_t end = row_ + rowCount;
+  uint32_t outputIndex = 0;
+
+  // firstValue.
+  if (row_ == 0 && row_ < end) {
+    lastValue_ = firstWire_;
+    output[outputIndex++] = static_cast<physicalType>(lastValue_);
+    ++row_;
+  }
+  // secondValue, establishes initial delta.
+  if (row_ == 1 && row_ < end) {
+    lastDelta_ = secondWire_ - firstWire_;
+    lastValue_ = secondWire_;
+    output[outputIndex++] = static_cast<physicalType>(lastValue_);
+    ++row_;
+  }
+
+  // Batch-decode residuals. Bulk-extract via bulkGet64WithBaseline (uses
+  // optimized template-unrolled paths for bitWidth <= 32 and branchless
+  // loads for 33-57), then reconstruct values via prefix sum.
+  if (row_ >= end) {
+    return;
+  }
+  const uint32_t residualCount = end - row_;
+  if (bitWidth_ == 0) {
+    // All double-deltas are identical. Unroll the prefix sum without any
+    // bitpacked extraction.
+    const uint64_t doubleDelta = detail::zigzagDecode64(minZigzagDoubleDelta_);
+    for (uint32_t i = 0; i < residualCount; ++i) {
+      lastDelta_ += doubleDelta;
+      lastValue_ += lastDelta_;
+      output[outputIndex++] = static_cast<physicalType>(lastValue_);
+    }
+    row_ = end;
+    return;
+  }
+  // Batch-extract residuals and prefix-sum reconstruct values.
+  constexpr uint32_t kBatchSize{256};
+  uint64_t zigzagBuf[kBatchSize];
+  uint32_t remaining = residualCount;
+  uint32_t residualStart = row_ - 2;
+  while (remaining > 0) {
+    const uint32_t batch = std::min(remaining, kBatchSize);
+    fixedBitArray_.bulkGet64WithBaseline(
+        /*start=*/residualStart,
+        /*length=*/batch,
+        zigzagBuf,
+        /*baseline=*/minZigzagDoubleDelta_);
+    for (uint32_t i = 0; i < batch; ++i) {
+      const uint64_t doubleDelta = detail::zigzagDecode64(zigzagBuf[i]);
+      lastDelta_ += doubleDelta;
+      lastValue_ += lastDelta_;
+      output[outputIndex++] = static_cast<physicalType>(lastValue_);
+    }
+    residualStart += batch;
+    remaining -= batch;
+  }
+  row_ = end;
+}
+
+template <typename T>
+template <typename V>
+void DoubleDeltaEncoding<T>::readWithVisitor(
+    V& visitor,
+    ReadWithVisitorParams& params) {
+  detail::readWithVisitorSlow(
+      visitor,
+      params,
+      [&](auto toSkip) { skip(toSkip); },
+      [&]() {
+        if (row_ == 0) {
+          lastValue_ = firstWire_;
+        } else if (row_ == 1) {
+          lastDelta_ = secondWire_ - firstWire_;
+          lastValue_ = secondWire_;
+        } else {
+          advanceFromBitpacked(/*residualIndex=*/row_ - 2);
+        }
+        ++row_;
+        return static_cast<physicalType>(lastValue_);
+      });
+}
+
+template <typename T>
+std::string_view DoubleDeltaEncoding<T>::encode(
+    EncodingSelection<typename TypeTraits<T>::physicalType>& /*selection*/,
+    std::span<const typename TypeTraits<T>::physicalType> values,
+    Buffer& buffer,
+    const Encoding::Options& options) {
+  const bool useVarint = options.useVarintRowCount;
+  NIMBLE_CHECK(
+      !values.empty(), "DoubleDelta encoding cannot be used with 0 rows.");
+  const uint32_t rowCount = static_cast<uint32_t>(values.size());
+
+  // Header fields that are always present. For N == 1 the second value is
+  // zeroed; for N <= 2 the minZigzag and bitWidth are zeroed (no residuals).
+  const uint64_t firstWire = static_cast<uint64_t>(values[0]);
+  const uint64_t secondWire =
+      rowCount >= 2 ? static_cast<uint64_t>(values[1]) : uint64_t{0};
+
+  uint64_t minZigzag{0};
+  uint8_t bitWidth{0};
+  uint64_t bitpackedSize{0};
+
+  // Scan all double-deltas to determine the zigzag range and the
+  // uniform bit width needed for frame-of-reference residuals.
+  if (rowCount >= 3) {
+    uint64_t minSeen{std::numeric_limits<uint64_t>::max()};
+    uint64_t maxSeen{0};
+    {
+      uint64_t previousDelta = secondWire - firstWire;
+      for (uint32_t i = 2; i < rowCount; ++i) {
+        const uint64_t delta = static_cast<uint64_t>(values[i]) -
+            static_cast<uint64_t>(values[i - 1]);
+        const uint64_t doubleDelta = delta - previousDelta;
+        const uint64_t zigzag = detail::zigzagEncode64(doubleDelta);
+        minSeen = std::min(minSeen, zigzag);
+        maxSeen = std::max(maxSeen, zigzag);
+        previousDelta = delta;
+      }
+    }
+    minZigzag = minSeen;
+    const uint64_t maxResidual = maxSeen - minSeen;
+    bitWidth = maxResidual == 0
+        ? uint8_t{0}
+        : static_cast<uint8_t>(velox::bits::bitsRequired(maxResidual));
+    if (bitWidth > 0) {
+      const uint32_t residualCount = rowCount - 2;
+      bitpackedSize = FixedBitArray::bufferSize(residualCount, bitWidth);
+    }
+  }
+
+  // Compute the number of forward-decode checkpoints. Skip checkpoints in
+  // the bitWidth == 0 fast path to preserve the "constant-stride timestamps
+  // encode to a few dozen bytes regardless of N" property -- the per-row
+  // loop is trivially cheap when bitWidth == 0.
+  const uint32_t checkpointCount = (rowCount >= 3 && bitWidth > 0)
+      ? (rowCount - 2) / kCheckpointStride
+      : uint32_t{0};
+  const uint64_t checkpointSegmentSize = sizeof(uint32_t) +
+      static_cast<uint64_t>(checkpointCount) * sizeof(Checkpoint);
+
+  const uint32_t encodingSize =
+      Encoding::serializePrefixSize(rowCount, useVarint) + 8 + 8 + 8 +
+      1 /* firstValue + secondValue + minZigzagDD + bitWidth */ +
+      static_cast<uint32_t>(bitpackedSize) +
+      static_cast<uint32_t>(checkpointSegmentSize);
+
+  // Serialize the encoding prefix and header fields.
+  char* reserved = buffer.reserve(encodingSize);
+  char* pos = reserved;
+  Encoding::serializePrefix(
+      EncodingType::DoubleDelta,
+      TypeTraits<T>::dataType,
+      rowCount,
+      useVarint,
+      pos);
+  encoding::write<uint64_t>(firstWire, pos);
+  encoding::write<uint64_t>(secondWire, pos);
+  encoding::write<uint64_t>(minZigzag, pos);
+  encoding::writeChar(static_cast<char>(bitWidth), pos);
+
+  // Bitpack residuals and capture checkpoints in a single O(N) walk
+  // of the input values. Checkpoints are buffered locally and flushed after
+  // the bitpacked region to maintain the wire layout:
+  //   [bitpacked region][checkpointCount][checkpoint entries...]
+  char* bitpackedStart = pos;
+  const bool hasBitpacked = bitWidth > 0;
+  if (hasBitpacked) {
+    std::memset(bitpackedStart, 0, bitpackedSize);
+  }
+  FixedBitArray fixedBitArray =
+      hasBitpacked ? FixedBitArray(bitpackedStart, bitWidth) : FixedBitArray{};
+
+  std::vector<Checkpoint> capturedCheckpoints;
+  capturedCheckpoints.reserve(checkpointCount);
+
+  if (rowCount >= 3) {
+    uint64_t previousDelta = secondWire - firstWire;
+    uint32_t checkpointCounter = 0;
+    for (uint32_t i = 2; i < rowCount; ++i) {
+      const auto currentValue = static_cast<uint64_t>(values[i]);
+      const auto delta = currentValue - static_cast<uint64_t>(values[i - 1]);
+      const auto doubleDelta = delta - previousDelta;
+      if (hasBitpacked) {
+        fixedBitArray.set(
+            i - 2, detail::zigzagEncode64(doubleDelta) - minZigzag);
+      }
+      previousDelta = delta;
+
+      // Capture a checkpoint every kCheckpointStride residuals. The
+      // checkpoint stores the reconstructed value and delta at that point
+      // so the decoder can resume from here without replaying earlier rows.
+      if (hasBitpacked && ++checkpointCounter == kCheckpointStride) {
+        capturedCheckpoints.emplace_back(Checkpoint{currentValue, delta});
+        checkpointCounter = 0;
+      }
+    }
+  }
+  NIMBLE_CHECK_EQ(
+      capturedCheckpoints.size(),
+      checkpointCount,
+      "DoubleDelta checkpoint count mismatch.");
+
+  // Flush the checkpoint segment after the bitpacked region.
+  if (hasBitpacked) {
+    pos += bitpackedSize;
+  }
+  encoding::write<uint32_t>(checkpointCount, pos);
+  for (const auto& checkpoint : capturedCheckpoints) {
+    encoding::write<uint64_t>(checkpoint.lastValue, pos);
+    encoding::write<uint64_t>(checkpoint.lastDelta, pos);
+  }
+
+  NIMBLE_CHECK_EQ(
+      pos - reserved, encodingSize, "DoubleDelta encoding size mismatch.");
+  return {reserved, encodingSize};
+}
+
+template <typename T>
+std::string DoubleDeltaEncoding<T>::debugString(int offset) const {
+  return fmt::format(
+      "{}{}<{}> rowCount={} bitWidth={} checkpoints={}",
+      std::string(offset, ' '),
+      toString(Encoding::encodingType()),
+      toString(Encoding::dataType()),
+      Encoding::rowCount(),
+      static_cast<int>(bitWidth_),
+      checkpointCount_);
+}
+
+} // namespace facebook::nimble

--- a/dwio/nimble/encodings/common/EncodingFactory.cpp
+++ b/dwio/nimble/encodings/common/EncodingFactory.cpp
@@ -18,6 +18,7 @@
 #include "dwio/nimble/encodings/ConstantEncoding.h"
 #include "dwio/nimble/encodings/DeltaEncoding.h"
 #include "dwio/nimble/encodings/DictionaryEncoding.h"
+#include "dwio/nimble/encodings/DoubleDeltaEncoding.h"
 #include "dwio/nimble/encodings/FixedBitWidthEncoding.h"
 #include "dwio/nimble/encodings/MainlyConstantEncoding.h"
 #include "dwio/nimble/encodings/NullableEncoding.h"
@@ -253,6 +254,20 @@ std::unique_ptr<Encoding> EncodingFactory::create(
     case EncodingType::Pfor: {
       RETURN_ENCODING_BY_NUMERIC_TYPE(PforEncoding, dataType);
     }
+    case EncodingType::DoubleDelta: {
+      switch (dataType) {
+        case DataType::Int64:
+          return std::make_unique<DoubleDeltaEncoding<int64_t>>(
+              memoryPool, data, stringBufferFactory, options);
+        case DataType::Uint64:
+          return std::make_unique<DoubleDeltaEncoding<uint64_t>>(
+              memoryPool, data, stringBufferFactory, options);
+        default:
+          NIMBLE_UNREACHABLE(
+              "DoubleDelta only supports 64-bit integer types, got {}.",
+              dataType);
+      }
+    }
     default: {
       NIMBLE_UNREACHABLE(
           "Trying to deserialize invalid EncodingType:{} -- garbage input?",
@@ -397,6 +412,17 @@ std::string_view EncodingFactory::encode(
         NIMBLE_INCOMPATIBLE_ENCODING(
             "Pfor encoding should not be selected for non-integral data type: {}.",
             toString(TypeTraits<T>::dataType));
+      }
+    }
+
+    case EncodingType::DoubleDelta: {
+      if constexpr (std::is_same_v<T, int64_t> || std::is_same_v<T, uint64_t>) {
+        return DoubleDeltaEncoding<T>::encode(
+            selection, castedValues, buffer, options);
+      } else {
+        NIMBLE_INCOMPATIBLE_ENCODING(
+            "DoubleDelta encoding only supports 64-bit integer types, got {}.",
+            TypeTraits<T>::dataType);
       }
     }
     default: {

--- a/dwio/nimble/encodings/common/EncodingLayout.cpp
+++ b/dwio/nimble/encodings/common/EncodingLayout.cpp
@@ -173,7 +173,8 @@ EncodingLayout EncodingLayoutCapture::capture(std::string_view encoding) {
     case EncodingType::Constant:
     case EncodingType::Prefix:
     case EncodingType::ALP:
-    case EncodingType::Pfor: {
+    case EncodingType::Pfor:
+    case EncodingType::DoubleDelta: {
       // Non nested encodings have zero children
       break;
     }

--- a/dwio/nimble/encodings/common/EncodingUtils.h
+++ b/dwio/nimble/encodings/common/EncodingUtils.h
@@ -19,6 +19,7 @@
 #include "dwio/nimble/encodings/ConstantEncoding.h"
 #include "dwio/nimble/encodings/DeltaEncoding.h"
 #include "dwio/nimble/encodings/DictionaryEncoding.h"
+#include "dwio/nimble/encodings/DoubleDeltaEncoding.h"
 #include "dwio/nimble/encodings/FixedBitWidthEncoding.h"
 #include "dwio/nimble/encodings/MainlyConstantEncoding.h"
 #include "dwio/nimble/encodings/NullableEncoding.h"
@@ -131,6 +132,12 @@ auto encodingTypeDispatchNonString(Encoding& encoding, F&& f) {
     case EncodingType::Pfor:
       if constexpr (isIntegralType<T>()) {
         return f(static_cast<PforEncoding<T>&>(encoding));
+      } else {
+        NIMBLE_UNREACHABLE("{}", encoding.dataType());
+      }
+    case EncodingType::DoubleDelta:
+      if constexpr (std::is_same_v<T, int64_t> || std::is_same_v<T, uint64_t>) {
+        return f(static_cast<DoubleDeltaEncoding<T>&>(encoding));
       } else {
         NIMBLE_UNREACHABLE("{}", encoding.dataType());
       }

--- a/dwio/nimble/encodings/legacy/EncodingFactory.cpp
+++ b/dwio/nimble/encodings/legacy/EncodingFactory.cpp
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 #include "dwio/nimble/encodings/legacy/EncodingFactory.h"
+#include "dwio/nimble/encodings/DoubleDeltaEncoding.h"
 #include "dwio/nimble/encodings/PforEncoding.h"
 #include "dwio/nimble/encodings/legacy/ConstantEncoding.h"
 #include "dwio/nimble/encodings/legacy/DeltaEncoding.h"
@@ -251,6 +252,22 @@ std::unique_ptr<Encoding> EncodingFactory::create(
     }
     case EncodingType::Pfor: {
       RETURN_ENCODING_BY_NUMERIC_TYPE(PforEncoding, dataType);
+    }
+    case EncodingType::DoubleDelta: {
+      switch (dataType) {
+        case DataType::Int64:
+          return std::make_unique<
+              ::facebook::nimble::DoubleDeltaEncoding<int64_t>>(
+              memoryPool, data, stringBufferFactory);
+        case DataType::Uint64:
+          return std::make_unique<
+              ::facebook::nimble::DoubleDeltaEncoding<uint64_t>>(
+              memoryPool, data, stringBufferFactory);
+        default:
+          NIMBLE_UNREACHABLE(
+              "DoubleDelta only supports 64-bit integer types, got {}.",
+              dataType);
+      }
     }
     default: {
       NIMBLE_UNREACHABLE(

--- a/dwio/nimble/encodings/legacy/EncodingUtils.h
+++ b/dwio/nimble/encodings/legacy/EncodingUtils.h
@@ -15,6 +15,7 @@
  */
 #pragma once
 
+#include "dwio/nimble/encodings/DoubleDeltaEncoding.h"
 #include "dwio/nimble/encodings/PforEncoding.h"
 #include "dwio/nimble/encodings/common/EncodingUtils.h"
 #include "dwio/nimble/encodings/legacy/ConstantEncoding.h"
@@ -112,6 +113,13 @@ auto encodingTypeDispatchNonString(Encoding& encoding, F&& f) {
     case EncodingType::Pfor:
       if constexpr (isIntegralType<T>()) {
         return f(static_cast<::facebook::nimble::PforEncoding<T>&>(encoding));
+      } else {
+        NIMBLE_UNREACHABLE("{}", encoding.dataType());
+      }
+    case EncodingType::DoubleDelta:
+      if constexpr (std::is_same_v<T, int64_t> || std::is_same_v<T, uint64_t>) {
+        return f(
+            static_cast<::facebook::nimble::DoubleDeltaEncoding<T>&>(encoding));
       } else {
         NIMBLE_UNREACHABLE("{}", encoding.dataType());
       }

--- a/dwio/nimble/encodings/selection/EncodingSizeEstimation.h
+++ b/dwio/nimble/encodings/selection/EncodingSizeEstimation.h
@@ -154,6 +154,42 @@ struct EncodingSizeEstimation {
           return std::nullopt;
         }
       }
+      case EncodingType::DoubleDelta: {
+        if constexpr (isEightByteIntegralType<physicalType>()) {
+          // Approximate bitWidth from average delta magnitude (×2 for
+          // double-delta wobble). Conservative: overestimates for irregular
+          // data
+          const physicalType range =
+              static_cast<physicalType>(statistics.max() - statistics.min());
+          uint64_t bitWidth{0};
+          if (range != 0 && entryCount >= 3) {
+            const uint64_t perStepMagnitude = std::max<uint64_t>(
+                1,
+                static_cast<uint64_t>(range) /
+                    std::max<uint64_t>(1, entryCount - 1));
+            bitWidth = velox::bits::bitsRequired(perStepMagnitude * 2);
+          }
+          const uint64_t residualCount =
+              entryCount >= 3 ? entryCount - 2 : uint64_t{0};
+          const uint64_t bitpackedSize = bitWidth == 0
+              ? 0
+              : FixedBitArray::bufferSize(residualCount, bitWidth);
+          // Trailing checkpoint segment: 4-byte count + 16B per checkpoint.
+          // The encoder skips checkpoint capture entirely in the bitWidth=0
+          constexpr uint64_t kCheckpointStride{64};
+          const uint64_t checkpointCount =
+              bitWidth == 0 ? 0 : residualCount / kCheckpointStride;
+          const uint64_t checkpointSegmentSize =
+              sizeof(uint32_t) + checkpointCount * 16u;
+          constexpr uint32_t commonPrefixSize{6};
+          // Common Encoding prefix (6) + first(8) + second(8) + minDD(8)
+          // + bitWidth(1).
+          const uint32_t overhead = commonPrefixSize + 8 + 8 + 8 + 1;
+          return overhead + bitpackedSize + checkpointSegmentSize;
+        } else {
+          return std::nullopt;
+        }
+      }
       case EncodingType::Pfor: {
         if constexpr (isIntegralType<physicalType>()) {
           const auto fullRange =

--- a/dwio/nimble/encodings/tests/CMakeLists.txt
+++ b/dwio/nimble/encodings/tests/CMakeLists.txt
@@ -26,6 +26,7 @@ add_executable(
   CompressionTest.cpp
   EncodingTest.cpp
   EncodingLegacyTest.cpp
+  DoubleDeltaEncodingTest.cpp
   Lz4CompressorTest.cpp
   MainlyConstantEncodingTest.cpp
   NullableEncodingTest.cpp

--- a/dwio/nimble/encodings/tests/DoubleDeltaEncodingTest.cpp
+++ b/dwio/nimble/encodings/tests/DoubleDeltaEncodingTest.cpp
@@ -1,0 +1,496 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "dwio/nimble/encodings/DoubleDeltaEncoding.h"
+
+#include <fmt/core.h>
+#include <gtest/gtest.h>
+#include <limits>
+#include <random>
+
+#include "dwio/nimble/common/Buffer.h"
+#include "dwio/nimble/common/tests/GTestUtils.h"
+#include "dwio/nimble/encodings/common/EncodingFactory.h"
+#include "dwio/nimble/encodings/common/EncodingLayout.h"
+#include "dwio/nimble/encodings/selection/EncodingSelection.h"
+#include "dwio/nimble/encodings/selection/EncodingSelectionPolicy.h"
+#include "velox/common/memory/Memory.h"
+
+using namespace ::facebook;
+
+namespace facebook::nimble::test {
+
+// DoubleDelta is templated on int64_t and uint64_t. Both share
+// the same wire format (the encoder works on the unsigned physical
+// representation), so the per-type tests run on the unsigned physical type
+// directly. End-to-end signed-input coverage is exercised by the fuzzer
+// below, which routes int64 through EncodingFactory::encode<int64_t>.
+template <typename T>
+class DoubleDeltaEncodingTest : public ::testing::Test {
+ protected:
+  static void SetUpTestCase() {
+    velox::memory::MemoryManager::testingSetInstance({});
+  }
+
+  void SetUp() override {
+    pool_ = velox::memory::deprecatedAddDefaultLeafMemoryPool();
+  }
+
+  std::unique_ptr<EncodingSelectionPolicy<T>> createSelectionPolicy() {
+    EncodingLayout layout{
+        EncodingType::DoubleDelta, {}, CompressionType::Uncompressed};
+    return std::make_unique<ReplayedEncodingSelectionPolicy<T>>(
+        std::move(layout),
+        CompressionOptions{},
+        encodingSelectionPolicyFactory_);
+  }
+
+  std::unique_ptr<Encoding> encodeAndCreate(const std::vector<T>& values) {
+    Buffer buffer{*pool_};
+    auto encoded = EncodingFactory::encode<T>(
+        createSelectionPolicy(),
+        std::span<const T>{values.data(), values.size()},
+        buffer);
+    encodedStorage_.assign(encoded.begin(), encoded.end());
+    return EncodingFactory().create(
+        *pool_, {encodedStorage_.data(), encodedStorage_.size()}, nullptr);
+  }
+
+  void roundTripAndExpect(const std::vector<T>& values) {
+    auto encoding = encodeAndCreate(values);
+    EXPECT_EQ(encoding->encodingType(), EncodingType::DoubleDelta);
+    EXPECT_EQ(encoding->dataType(), TypeTraits<T>::dataType);
+    EXPECT_EQ(encoding->rowCount(), values.size());
+
+    std::vector<T> decoded(values.size());
+    encoding->materialize(static_cast<uint32_t>(values.size()), decoded.data());
+    for (size_t i = 0; i < values.size(); ++i) {
+      EXPECT_EQ(decoded[i], values[i]) << "mismatch at index " << i;
+    }
+  }
+
+  std::shared_ptr<velox::memory::MemoryPool> pool_;
+  std::vector<char> encodedStorage_;
+  ManualEncodingSelectionPolicyFactory manualPolicyFactory_;
+  EncodingSelectionPolicyFactory encodingSelectionPolicyFactory_ =
+      [this](DataType dataType) {
+        return manualPolicyFactory_.createPolicy(dataType);
+      };
+};
+
+using LongDoubleDeltaTypes = ::testing::Types<int64_t, uint64_t>;
+TYPED_TEST_SUITE(DoubleDeltaEncodingTest, LongDoubleDeltaTypes);
+
+TYPED_TEST(DoubleDeltaEncodingTest, singleElement) {
+  using T = TypeParam;
+  this->roundTripAndExpect({T{42}});
+}
+
+TYPED_TEST(DoubleDeltaEncodingTest, twoElements) {
+  using T = TypeParam;
+  this->roundTripAndExpect({T{100}, T{250}});
+}
+
+TYPED_TEST(DoubleDeltaEncodingTest, allEqualCollapsesToBitWidthZero) {
+  // 64-element constant stream. Δ=0 → Δ²=0 → bitWidth=0 → no packed region
+  // and (because of the bitWidth=0 short-circuit in the encoder) no captured
+  // checkpoints either. Wire is just the 35-byte header + 4-byte cpCount=0.
+  using T = TypeParam;
+  std::vector<T> values(64, T{7});
+  this->roundTripAndExpect(values);
+  auto encoding = this->encodeAndCreate(values);
+  // 6 (Encoding prefix) + 25 (kPrefixSize) + 4 (cpCount=0). No packed region,
+  // no checkpoint entries.
+  EXPECT_EQ(this->encodedStorage_.size(), 6u + 25u + 4u);
+}
+
+TYPED_TEST(DoubleDeltaEncodingTest, regularIntervalTimestampsAreTiny) {
+  // The killer case: timestamps every 1000 units. Δ=1000 (constant) →
+  // Δ²=0 → bitWidth=0. Wire stays at 35B regardless of N because the
+  // bitWidth=0 fast path skips both the packed region and the checkpoint
+  // capture.
+  using T = TypeParam;
+  std::vector<T> values;
+  values.reserve(1024);
+  for (uint32_t i = 0; i < 1024; ++i) {
+    values.push_back(static_cast<T>(1'700'000'000 + i * 1000));
+  }
+  this->roundTripAndExpect(values);
+  auto encoding = this->encodeAndCreate(values);
+  EXPECT_EQ(this->encodedStorage_.size(), 6u + 25u + 4u);
+}
+
+TYPED_TEST(DoubleDeltaEncodingTest, monotoneWithRareGaps) {
+  // Mostly-regular intervals with a few large jumps. bitWidth must come up
+  // off zero to absorb the irregular Δ², but the encoded size still beats
+  // the FixedBitWidth ceiling.
+  using T = TypeParam;
+  std::vector<T> values;
+  values.reserve(500);
+  for (uint32_t i = 0; i < 500; ++i) {
+    T v = static_cast<T>(1'000'000 + i * 60);
+    if (i == 100 || i == 250 || i == 400) {
+      v = static_cast<T>(static_cast<uint64_t>(v) + 5'000'000ULL);
+    }
+    values.push_back(v);
+  }
+  this->roundTripAndExpect(values);
+}
+
+TYPED_TEST(DoubleDeltaEncodingTest, mixedSizes) {
+  using T = TypeParam;
+  for (uint32_t n :
+       {1u, 2u, 3u, 7u, 15u, 16u, 17u, 33u, 64u, 100u, 257u, 1024u}) {
+    SCOPED_TRACE(fmt::format("n={}", n));
+    std::vector<T> values;
+    values.reserve(n);
+    // A semi-regular sequence — gives a non-trivial bitWidth without being
+    // adversarial. The (i*31+1)%256 wobble prevents Δ² from being always 0.
+    for (uint32_t i = 0; i < n; ++i) {
+      values.push_back(static_cast<T>(1000 + i * 50 + (i * 31 + 1) % 17));
+    }
+    this->roundTripAndExpect(values);
+  }
+}
+
+TYPED_TEST(DoubleDeltaEncodingTest, skipAndMaterialize) {
+  using T = TypeParam;
+  std::vector<T> values;
+  values.reserve(300);
+  for (uint32_t i = 0; i < 300; ++i) {
+    values.push_back(static_cast<T>(2'000'000 + i * 17 + (i % 11)));
+  }
+  auto encoding = this->encodeAndCreate(values);
+
+  // Interleaved skips and materialises — exercises the wrap-around delta
+  // accumulator across non-trivial gaps.
+  encoding->reset();
+  std::vector<T> chunk(50);
+  encoding->materialize(50, chunk.data());
+  for (uint32_t i = 0; i < 50; ++i) {
+    EXPECT_EQ(chunk[i], values[i]);
+  }
+  encoding->skip(75);
+  encoding->materialize(50, chunk.data());
+  for (uint32_t i = 0; i < 50; ++i) {
+    EXPECT_EQ(chunk[i], values[125 + i]) << "i=" << i;
+  }
+  encoding->skip(75);
+  encoding->materialize(50, chunk.data());
+  for (uint32_t i = 0; i < 50; ++i) {
+    EXPECT_EQ(chunk[i], values[250 + i]) << "i=" << i;
+  }
+
+  // Reset must restore all cursors so a second pass produces identical output.
+  encoding->reset();
+  std::vector<T> all(values.size());
+  encoding->materialize(static_cast<uint32_t>(values.size()), all.data());
+  for (size_t i = 0; i < values.size(); ++i) {
+    EXPECT_EQ(all[i], values[i]) << "after-reset i=" << i;
+  }
+}
+
+TYPED_TEST(DoubleDeltaEncodingTest, rangeMaterializeViaSkip) {
+  // Range decode pattern: skip past a prefix, then materialize a window.
+  using T = TypeParam;
+  std::vector<T> values;
+  values.reserve(200);
+  for (uint32_t i = 0; i < 200; ++i) {
+    values.push_back(static_cast<T>(500'000 + i * 7));
+  }
+  auto encoding = this->encodeAndCreate(values);
+
+  for (uint32_t start :
+       {uint32_t{0}, uint32_t{1}, uint32_t{2}, uint32_t{50}, uint32_t{199}}) {
+    SCOPED_TRACE(fmt::format("start={}", start));
+    const uint32_t windowSize =
+        std::min<uint32_t>(13, static_cast<uint32_t>(values.size()) - start);
+    encoding->reset();
+    if (start > 0) {
+      encoding->skip(start);
+    }
+    std::vector<T> window(windowSize);
+    encoding->materialize(windowSize, window.data());
+    for (uint32_t i = 0; i < windowSize; ++i) {
+      EXPECT_EQ(window[i], values[start + i]) << "i=" << i;
+    }
+  }
+}
+
+TYPED_TEST(DoubleDeltaEncodingTest, checkpointSeekCoversBoundaries) {
+  // Exercise the checkpoint fast path at all the seek positions that the
+  // skip-then-materialize math has to get right: K-boundary anchors,
+  // mid-segment offsets, single-element windows, ranges that span multiple
+  // checkpoints, plus the L==0 and R==N-1 edges. Each window is compared
+  // against the corresponding slice of the full materialized output so the
+  // assertion holds regardless of decoder internals.
+  using T = TypeParam;
+  // 600 rows = 9 full strides of 64 residuals (9 checkpoints captured); needs
+  // bitWidth > 0 so the checkpoint segment actually exists. The (i % 13)
+  // wobble keeps Δ² off zero.
+  constexpr uint32_t kRows = 600;
+  std::vector<T> values;
+  values.reserve(kRows);
+  for (uint32_t i = 0; i < kRows; ++i) {
+    values.push_back(static_cast<T>(2'500'000 + i * 41 + (i * 7 % 13)));
+  }
+  // Full-decode once to get a ground-truth output.
+  auto fullEncoding = this->encodeAndCreate(values);
+  std::vector<T> expected(kRows);
+  fullEncoding->materialize(kRows, expected.data());
+  ASSERT_EQ(expected, values);
+
+  // (L, R) inclusive ranges. K=64 in the encoder.
+  const std::vector<std::pair<uint32_t, uint32_t>> ranges = {
+      {0, 0}, // single-element at the very start (no checkpoint usable)
+      {0, 10}, // small range at start
+      {66, 66}, // single-element on the first checkpoint boundary (L = K+2)
+      {66, 80}, // small range starting at the first checkpoint boundary
+      {100, 130}, // mid-segment, lands inside checkpoint #0's reach
+      {200, 250}, // window inside checkpoint #2's reach
+      {130, 400}, // window that spans multiple checkpoints
+      {64, 64}, // single-element just before the K+2 boundary
+      {500, 599}, // tail of the stream
+      {kRows - 1, kRows - 1}, // single-element at the very end
+  };
+
+  for (const auto& [l, r] : ranges) {
+    SCOPED_TRACE(fmt::format("range L={} R={}", l, r));
+    auto encoding = this->encodeAndCreate(values);
+    encoding->reset();
+    if (l > 0) {
+      encoding->skip(l);
+    }
+    const uint32_t windowSize = r - l + 1;
+    std::vector<T> got(windowSize);
+    encoding->materialize(windowSize, got.data());
+    const std::vector<T> want(expected.begin() + l, expected.begin() + r + 1);
+    EXPECT_EQ(got, want);
+  }
+}
+
+TYPED_TEST(DoubleDeltaEncodingTest, checkpointSeekMatchesFullDecodeAfterReset) {
+  // After a checkpoint-accelerated range-decode, calling reset() and a
+  // straight full materialize must still produce the original stream.
+  // Catches state-leak bugs in seekToCheckpointFor.
+  using T = TypeParam;
+  constexpr uint32_t kRows = 400;
+  std::vector<T> values;
+  values.reserve(kRows);
+  for (uint32_t i = 0; i < kRows; ++i) {
+    values.push_back(static_cast<T>(1'000'000'000 + i * 23 + (i * 11 % 7)));
+  }
+  auto encoding = this->encodeAndCreate(values);
+  encoding->skip(200);
+  std::vector<T> midChunk(50);
+  encoding->materialize(50, midChunk.data());
+  for (uint32_t i = 0; i < 50; ++i) {
+    EXPECT_EQ(midChunk[i], values[200 + i]);
+  }
+  encoding->reset();
+  std::vector<T> all(kRows);
+  encoding->materialize(kRows, all.data());
+  EXPECT_EQ(all, values);
+}
+
+TYPED_TEST(DoubleDeltaEncodingTest, checkpointSegmentSizesCorrectly) {
+  // 130 rows with bitWidth>0 => residuals = 128 => checkpointCount = 2.
+  // Verify the on-wire byte count includes the checkpoint segment.
+  using T = TypeParam;
+  constexpr uint32_t kRows = 130;
+  std::vector<T> values;
+  values.reserve(kRows);
+  for (uint32_t i = 0; i < kRows; ++i) {
+    values.push_back(static_cast<T>(7'000'000 + i * 13 + (i % 5)));
+  }
+  this->roundTripAndExpect(values);
+  auto encoding = this->encodeAndCreate(values);
+  // The exact bitpacked region width depends on bitsRequired(maxResidual),
+  // so this asserts on the delta added by the new checkpoint segment vs a
+  // baseline with no captured checkpoints. Two checkpoints * 16B + 4B
+  // count = 36B trailing.
+  EXPECT_GE(this->encodedStorage_.size(), 6u + 25u + 36u);
+}
+
+TYPED_TEST(DoubleDeltaEncodingTest, largeMagnitudeOverflowSafe) {
+  // Values near the type range exercise the wrap-around delta arithmetic
+  // (encoder and decoder both treat the underlying uint64 representation
+  // mod 2^64). A signed int64 overflow during delta computation would be UB
+  // if we used signed subtraction directly — verifies we do not.
+  using T = TypeParam;
+  std::vector<T> values;
+  values.reserve(8);
+  // Intentionally straddle zero / the signed boundary for int64; for
+  // uint64 these are simply very-large unsigned values.
+  values.push_back(static_cast<T>(std::numeric_limits<int64_t>::min()));
+  values.push_back(static_cast<T>(std::numeric_limits<int64_t>::min() + 17));
+  values.push_back(static_cast<T>(std::numeric_limits<int64_t>::min() + 42));
+  values.push_back(static_cast<T>(0));
+  values.push_back(static_cast<T>(100));
+  values.push_back(static_cast<T>(std::numeric_limits<int64_t>::max() - 5));
+  values.push_back(static_cast<T>(std::numeric_limits<int64_t>::max()));
+  values.push_back(static_cast<T>(std::numeric_limits<int64_t>::min() + 1));
+  this->roundTripAndExpect(values);
+}
+
+TYPED_TEST(DoubleDeltaEncodingTest, debugString) {
+  using T = TypeParam;
+  std::vector<T> values;
+  values.reserve(8);
+  for (uint32_t i = 0; i < 8; ++i) {
+    values.push_back(static_cast<T>(1000 + i * 5));
+  }
+  auto encoding = this->encodeAndCreate(values);
+  const std::string debug = encoding->debugString();
+  EXPECT_NE(debug.find("DoubleDelta"), std::string::npos);
+  EXPECT_NE(debug.find("bitWidth="), std::string::npos);
+  EXPECT_NE(debug.find("checkpoints="), std::string::npos);
+}
+
+class DoubleDeltaEncodingFuzzerTest : public ::testing::Test {
+ protected:
+  static void SetUpTestCase() {
+    velox::memory::MemoryManager::testingSetInstance({});
+  }
+
+  void SetUp() override {
+    pool_ = velox::memory::deprecatedAddDefaultLeafMemoryPool();
+  }
+
+  template <typename T>
+  void runFuzzer(uint32_t seed, uint32_t numIterations) {
+    std::mt19937_64 rng(seed);
+
+    ManualEncodingSelectionPolicyFactory manualFactory;
+    EncodingSelectionPolicyFactory factory =
+        [&manualFactory](DataType dataType) {
+          return manualFactory.createPolicy(dataType);
+        };
+
+    for (uint32_t iter = 0; iter < numIterations; ++iter) {
+      SCOPED_TRACE(fmt::format("iteration {}", iter));
+
+      std::uniform_int_distribution<uint32_t> sizeDist(1, 1000);
+      const uint32_t numValues = sizeDist(rng);
+
+      // Pick a random regularity profile per iteration to broadly cover the
+      // encoder's input space: perfectly regular, small wobble, and wide
+      // random jumps.
+      std::uniform_int_distribution<int32_t> profileDist(0, 2);
+      const int32_t profile = profileDist(rng);
+      std::uniform_int_distribution<int64_t> wobbleDist(-32, 32);
+      std::uniform_int_distribution<int64_t> jumpDist(
+          std::numeric_limits<int32_t>::min(),
+          std::numeric_limits<int32_t>::max());
+
+      std::vector<T> values;
+      values.reserve(numValues);
+      uint64_t cur = static_cast<uint64_t>(rng());
+      values.push_back(static_cast<T>(cur));
+      const int64_t baseStep = 1'000;
+      for (uint32_t i = 1; i < numValues; ++i) {
+        int64_t step = baseStep;
+        if (profile == 1) {
+          step += wobbleDist(rng);
+        } else if (profile == 2) {
+          step = jumpDist(rng);
+        }
+        cur += static_cast<uint64_t>(step);
+        values.push_back(static_cast<T>(cur));
+      }
+
+      Buffer buffer{*pool_};
+      EncodingLayout layout{
+          EncodingType::DoubleDelta, {}, CompressionType::Uncompressed};
+      auto policy = std::make_unique<ReplayedEncodingSelectionPolicy<T>>(
+          std::move(layout), CompressionOptions{}, factory);
+      auto encoded = EncodingFactory::encode<T>(
+          std::move(policy),
+          std::span<const T>{values.data(), values.size()},
+          buffer);
+      std::vector<char> storage(encoded.begin(), encoded.end());
+      auto encoding = EncodingFactory().create(
+          *pool_, {storage.data(), storage.size()}, nullptr);
+
+      ASSERT_EQ(encoding->encodingType(), EncodingType::DoubleDelta);
+      ASSERT_EQ(encoding->dataType(), TypeTraits<T>::dataType);
+      ASSERT_EQ(encoding->rowCount(), values.size());
+      std::vector<T> decoded(values.size());
+      encoding->materialize(
+          static_cast<uint32_t>(values.size()), decoded.data());
+      for (size_t i = 0; i < values.size(); ++i) {
+        ASSERT_EQ(decoded[i], values[i])
+            << "iter=" << iter << " i=" << i << " size=" << numValues
+            << " profile=" << profile;
+      }
+
+      // Random skip/materialize sequence — same churn as the PFOR fuzzer.
+      encoding->reset();
+      std::uniform_int_distribution<uint32_t> stepDist(0, numValues);
+      uint32_t cursor = 0;
+      while (cursor < numValues) {
+        const uint32_t remaining = numValues - cursor;
+        const uint32_t skipCount = stepDist(rng) % (remaining + 1);
+        if (skipCount > 0) {
+          encoding->skip(skipCount);
+          cursor += skipCount;
+        }
+        if (cursor >= numValues) {
+          break;
+        }
+        const uint32_t matCount =
+            std::max<uint32_t>(1, stepDist(rng) % (numValues - cursor + 1));
+        std::vector<T> chunk(matCount);
+        encoding->materialize(matCount, chunk.data());
+        for (uint32_t i = 0; i < matCount; ++i) {
+          ASSERT_EQ(chunk[i], values[cursor + i])
+              << "iter=" << iter << " cursor=" << cursor << " i=" << i;
+        }
+        cursor += matCount;
+      }
+    }
+  }
+
+  std::shared_ptr<velox::memory::MemoryPool> pool_;
+};
+
+TEST_F(DoubleDeltaEncodingFuzzerTest, fuzzerInt64) {
+  runFuzzer<int64_t>(/*seed=*/12345, /*numIterations=*/30);
+}
+
+TEST_F(DoubleDeltaEncodingFuzzerTest, fuzzerUint64) {
+  runFuzzer<uint64_t>(/*seed=*/67890, /*numIterations=*/30);
+}
+
+TEST_F(DoubleDeltaEncodingFuzzerTest, encodeRejectsEmpty) {
+  Buffer buffer{*pool_};
+  EncodingLayout layout{
+      EncodingType::DoubleDelta, {}, CompressionType::Uncompressed};
+  ManualEncodingSelectionPolicyFactory manualFactory;
+  EncodingSelectionPolicyFactory factory = [&manualFactory](DataType dataType) {
+    return manualFactory.createPolicy(dataType);
+  };
+  auto policy = std::make_unique<ReplayedEncodingSelectionPolicy<int64_t>>(
+      std::move(layout), CompressionOptions{}, factory);
+  std::vector<int64_t> empty;
+  NIMBLE_ASSERT_THROW(
+      EncodingFactory::encode<int64_t>(
+          std::move(policy),
+          std::span<const int64_t>{empty.data(), empty.size()},
+          buffer),
+      "DoubleDelta encoding cannot be used with 0 rows.");
+}
+
+} // namespace facebook::nimble::test

--- a/dwio/nimble/encodings/tests/EncodingSizeEstimationTest.cpp
+++ b/dwio/nimble/encodings/tests/EncodingSizeEstimationTest.cpp
@@ -387,3 +387,37 @@ TEST_F(EncodingSizeEstimationTest, pforEstimateVsActualSize) {
       << "estimate too high: " << estimated.value() << " vs actual "
       << actualSize;
 }
+
+TEST_F(EncodingSizeEstimationTest, doubleDeltaEstimateVsActualSize) {
+  using Est = detail::EncodingSizeEstimation<uint64_t, false>;
+
+  // Monotone timestamps with small jitter — DoubleDelta's sweet spot.
+  std::vector<uint64_t> data;
+  uint64_t current = 1'000'000;
+  for (uint32_t i = 0; i < 200; ++i) {
+    data.push_back(current);
+    current += 60 + (i % 3);
+  }
+  auto stats = Statistics<uint64_t>::create(data);
+  const uint32_t numValues = static_cast<uint32_t>(data.size());
+
+  auto estimated =
+      Est::estimateNumericSize(EncodingType::DoubleDelta, numValues, stats);
+  ASSERT_TRUE(estimated.has_value());
+
+  nimble::Buffer buffer{*pool_};
+  auto encoded =
+      nimble::test::Encoder<nimble::DoubleDeltaEncoding<uint64_t>>::encode(
+          buffer,
+          nimble::Vector<uint64_t>(pool_.get(), data.begin(), data.end()));
+  const uint64_t actualSize = encoded.size();
+
+  // DoubleDelta uses a conservative heuristic (perStepMagnitude × 2),
+  // so the estimate can be up to ~3x actual for regular-interval data.
+  EXPECT_GT(estimated.value(), actualSize / 3)
+      << "estimate too low: " << estimated.value() << " vs actual "
+      << actualSize;
+  EXPECT_LT(estimated.value(), actualSize * 3)
+      << "estimate too high: " << estimated.value() << " vs actual "
+      << actualSize;
+}

--- a/dwio/nimble/encodings/tests/TestUtils.h
+++ b/dwio/nimble/encodings/tests/TestUtils.h
@@ -19,6 +19,7 @@
 #include "dwio/nimble/encodings/ConstantEncoding.h"
 #include "dwio/nimble/encodings/DeltaEncoding.h"
 #include "dwio/nimble/encodings/DictionaryEncoding.h"
+#include "dwio/nimble/encodings/DoubleDeltaEncoding.h"
 #include "dwio/nimble/encodings/FixedBitWidthEncoding.h"
 #include "dwio/nimble/encodings/MainlyConstantEncoding.h"
 #include "dwio/nimble/encodings/NullableEncoding.h"
@@ -186,6 +187,12 @@ class Encoder {
   struct EncodingTypeTraits<nimble::PforEncoding<T>> {
     static constexpr inline nimble::EncodingType encodingType =
         nimble::EncodingType::Pfor;
+  };
+
+  template <>
+  struct EncodingTypeTraits<nimble::DoubleDeltaEncoding<T>> {
+    static constexpr inline nimble::EncodingType encodingType =
+        nimble::EncodingType::DoubleDelta;
   };
 
  public:

--- a/dwio/nimble/fuzzer/encoding/EncodingFuzzerTest.cpp
+++ b/dwio/nimble/fuzzer/encoding/EncodingFuzzerTest.cpp
@@ -29,6 +29,7 @@
 #include "dwio/nimble/encodings/ConstantEncoding.h"
 #include "dwio/nimble/encodings/DeltaEncoding.h"
 #include "dwio/nimble/encodings/DictionaryEncoding.h"
+#include "dwio/nimble/encodings/DoubleDeltaEncoding.h"
 #include "dwio/nimble/encodings/FixedBitWidthEncoding.h"
 #include "dwio/nimble/encodings/MainlyConstantEncoding.h"
 #include "dwio/nimble/encodings/RleEncoding.h"
@@ -273,6 +274,23 @@ class ALPFuzzerTest : public ::testing::Test {};
 TYPED_TEST_SUITE(ALPFuzzerTest, ALPTypes);
 
 TYPED_TEST(ALPFuzzerTest, correctness) {
+  EncodingFuzzer<TypeParam> fuzzer(
+      FLAGS_fuzzer_iterations,
+      FLAGS_fuzzer_max_rows,
+      FLAGS_fuzzer_seed,
+      FLAGS_fuzzer_compression);
+  fuzzer.run();
+}
+
+// DoubleDelta: int64/uint64 only
+using DoubleDeltaTypes = ::testing::
+    Types<DoubleDeltaEncoding<int64_t>, DoubleDeltaEncoding<uint64_t>>;
+
+template <typename E>
+class DoubleDeltaFuzzerTest : public ::testing::Test {};
+TYPED_TEST_SUITE(DoubleDeltaFuzzerTest, DoubleDeltaTypes);
+
+TYPED_TEST(DoubleDeltaFuzzerTest, correctness) {
   EncodingFuzzer<TypeParam> fuzzer(
       FLAGS_fuzzer_iterations,
       FLAGS_fuzzer_max_rows,

--- a/dwio/nimble/serializer/tests/SerializationTest.cpp
+++ b/dwio/nimble/serializer/tests/SerializationTest.cpp
@@ -2170,6 +2170,71 @@ TEST_P(SerializationTest, pforColumnarRoundTrip) {
   }
 }
 
+// Columnar reader-level round-trip for DoubleDeltaEncoding. Forces DoubleDelta
+// via EncodingLayoutTree on a monotone int64 column and verifies data integrity
+// through the full Serializer → Deserializer path.
+TEST_P(SerializationTest, doubleDeltaColumnarRoundTrip) {
+  auto type = velox::ROW({
+      {"timestamp_val", velox::BIGINT()},
+  });
+
+  EncodingLayoutTree layoutTree{
+      Kind::Row,
+      {},
+      "",
+      {
+          {Kind::Scalar,
+           {{EncodingLayoutTree::StreamIdentifiers::Scalar::ScalarStream,
+             EncodingLayout{
+                 EncodingType::DoubleDelta,
+                 {},
+                 CompressionType::Uncompressed}}},
+           ""},
+      }};
+
+  SerializerOptions options{
+      .version = version(),
+      .encodingLayoutTree = layoutTree,
+      .compressionOptions = compressionOptions(),
+  };
+
+  Serializer serializer{options, type, pool_.get()};
+
+  const velox::vector_size_t numRows = 200;
+  auto timestamps =
+      velox::BaseVector::create(velox::BIGINT(), numRows, pool_.get());
+  // Monotone timestamps with small jitter — DoubleDelta's sweet spot.
+  int64_t current = 1'716'835'200;
+  for (velox::vector_size_t i = 0; i < numRows; ++i) {
+    timestamps->asFlatVector<int64_t>()->set(i, current);
+    current += 60 + (i % 3);
+  }
+
+  auto input = std::make_shared<velox::RowVector>(
+      pool_.get(),
+      type,
+      nullptr,
+      numRows,
+      std::vector<velox::VectorPtr>{timestamps});
+
+  auto serialized =
+      serializer.serialize(input, OrderedRanges::of(0, input->size()));
+
+  Deserializer deserializer{
+      SchemaReader::getSchema(serializer.schemaBuilder().schemaNodes()),
+      pool_.get(),
+      deserializerOptions()};
+
+  velox::VectorPtr output;
+  deserializer.deserialize(serialized, output);
+
+  ASSERT_EQ(output->size(), input->size());
+  for (velox::vector_size_t i = 0; i < input->size(); ++i) {
+    ASSERT_TRUE(vectorEquals(output, input, i))
+        << "Content mismatch at index " << i;
+  }
+}
+
 // Test encoding layout tree for FlatMap with dynamic key discovery and nested
 // types.
 TEST_P(SerializationTest, encodingLayoutTreeFlatMap) {

--- a/dwio/nimble/tools/EncodingUtilities.cpp
+++ b/dwio/nimble/tools/EncodingUtilities.cpp
@@ -51,6 +51,7 @@ void extractCompressionType(
     case EncodingType::Prefix:
     case EncodingType::ALP:
     case EncodingType::Pfor:
+    case EncodingType::DoubleDelta:
       break;
   }
 }
@@ -105,7 +106,8 @@ void traverseEncodings(
     case EncodingType::Constant:
     case EncodingType::Prefix:
     case EncodingType::ALP:
-    case EncodingType::Pfor: {
+    case EncodingType::Pfor:
+    case EncodingType::DoubleDelta: {
       // don't have any nested encoding
       break;
     }


### PR DESCRIPTION
Summary:

DoubleDelta stores int64 streams by zigzag-encoding the second-order differences and bitpacking them. Targets monotone sequences with regular intervals — perfectly regular timestamps collapse to bitWidth=0 and ~31 bytes total regardless of N.

  Wire format (after common prefix):
  [8B: firstValue] [8B: secondValue] [8B: minZigzagDoubleDelta] [1B: bitWidth]
  [FixedBitArray: bitWidth bits × (N-2) zigzag double-delta residuals]
  [4B: checkpointCount]
  [checkpointCount × 16B: {uint64 lastValue, uint64 lastDelta} entries]

Periodic checkpoints every 64 residuals enable O(K) seek instead of O(N) sequential decode; skip() uses seekToCheckpointFor() to jump then walks at most 63 steps

Differential Revision: D105357210


