### PR TITLE
feat(writer): Add comprehensive writer CPU metrics for performance accounting (#786)

### DIFF
--- a/dwio/nimble/velox/VeloxWriter.cpp
+++ b/dwio/nimble/velox/VeloxWriter.cpp
@@ -92,6 +92,34 @@ class WriterContext : public FieldWriterContext {
     stripeFlushTiming_.add(timing);
   }
 
+  velox::CpuWallTiming& encodingTiming() {
+    return encodingTiming_;
+  }
+
+  const velox::CpuWallTiming& encodingTiming() const {
+    return encodingTiming_;
+  }
+
+  velox::CpuWallTiming& writeTiming() {
+    return writeTiming_;
+  }
+
+  const velox::CpuWallTiming& writeTiming() const {
+    return writeTiming_;
+  }
+
+  velox::CpuWallTiming& ingestionTiming() {
+    return ingestionTiming_;
+  }
+
+  const velox::CpuWallTiming& ingestionTiming() const {
+    return ingestionTiming_;
+  }
+
+  velox::CpuWallTiming& encodingSelectionTiming() {
+    return encodingSelectionTiming_;
+  }
+
   const velox::CpuWallTiming& encodingSelectionTiming() const {
     return encodingSelectionTiming_;
   }
@@ -192,6 +220,9 @@ class WriterContext : public FieldWriterContext {
   const VeloxWriterOptions options_;
   velox::CpuWallTiming totalFlushTiming_;
   velox::CpuWallTiming stripeFlushTiming_;
+  velox::CpuWallTiming encodingTiming_;
+  velox::CpuWallTiming writeTiming_;
+  velox::CpuWallTiming ingestionTiming_;
   velox::CpuWallTiming encodingSelectionTiming_;
   std::shared_ptr<MetricsLogger> logger_;
   uint64_t memoryUsed_{0};
@@ -788,7 +819,10 @@ bool VeloxWriter::write(const velox::VectorPtr& input) {
       context_->updateFileRawSize(rawSize);
     }
 
-    rootWriter_->write(input, OrderedRanges::of(0, numRows));
+    {
+      velox::CpuWallTimer ingestionTimer{context_->ingestionTiming()};
+      rootWriter_->write(input, OrderedRanges::of(0, numRows));
+    }
     addIndexKey(input);
 
     uint64_t memoryUsed{0};
@@ -987,14 +1021,14 @@ void VeloxWriter::close() {
       file_->close();
       context_->setBytesWritten(file_->size());
 
-      auto stats = this->stats();
+      const auto stats = this->stats();
       // TODO: compute and populate input size.
       FileCloseMetrics metrics{
           .rowCount = context_->rowsInFile(),
           .stripeCount = context_->getStripeIndex(),
           .fileSize = context_->bytesWritten(),
-          .totalFlushCpuUsec = stats.flushCpuTimeUs,
-          .totalFlushWallTimeUsec = stats.flushWallTimeUs};
+          .totalFlushCpuUsec = stats.encodingCpuTimeNs / 1'000,
+          .totalFlushWallTimeUsec = stats.encodingWallTimeNs / 1'000};
       context_->logger()->logFileClose(metrics);
       file_ = nullptr;
     } catch (const std::exception& e) {
@@ -1094,6 +1128,7 @@ void VeloxWriter::writeStreams() {
   }
 
   context_->addStripeFlushTiming(flushTiming);
+  context_->encodingTiming().add(flushTiming);
   VLOG(1) << "writeChunk time: " << velox::succinctNanos(flushTiming.wallNanos)
           << ", chunk size: " << velox::succinctBytes(chunkSize);
 }
@@ -1288,6 +1323,7 @@ bool VeloxWriter::writeChunks(
   }
 
   context_->addStripeFlushTiming(flushTiming);
+  context_->encodingTiming().add(flushTiming);
   if (writtenChunk) {
     context_->recordChunkSize(chunkBytes);
   }
@@ -1350,8 +1386,11 @@ bool VeloxWriter::writeStripe() {
     encodedStreams_.resize(nonEmptyCount);
 
     const uint64_t startSize = tabletWriter_->size();
-    tabletWriter_->writeStripe(
-        context_->rowsInStripe(), std::move(encodedStreams_));
+    {
+      velox::CpuWallTimer writeTimer{context_->writeTiming()};
+      tabletWriter_->writeStripe(
+          context_->rowsInStripe(), std::move(encodedStreams_));
+    }
     stripeSize = tabletWriter_->size() - startSize;
     clearEncodingBuffer();
     // TODO: once chunked string fields are supported, move string buffer
@@ -1434,14 +1473,20 @@ bool VeloxWriter::evaluateFlushPolicy() {
 
 VeloxWriter::Stats VeloxWriter::stats() const {
   return Stats{
-      .bytesWritten = context_->bytesWritten(),
+      .writtenBytes = context_->bytesWritten(),
       .stripeCount = folly::to<uint32_t>(context_->getStripeIndex()),
-      .rawSize = context_->fileRawSize(),
+      .inputBytes = context_->fileRawSize(),
       .rowsPerStripe = context_->rowsPerStripe(),
-      .flushCpuTimeUs = context_->totalFlushTiming().cpuNanos / 1'000,
-      .flushWallTimeUs = context_->totalFlushTiming().wallNanos / 1'000,
-      .encodingSelectionCpuTimeUs =
-          context_->encodingSelectionTiming().cpuNanos / 1'000,
+      .writeCpuTimeNs = context_->writeTiming().cpuNanos,
+      .writeWallTimeNs = context_->writeTiming().wallNanos,
+      .ingestionCpuTimeNs = context_->ingestionTiming().cpuNanos,
+      .ingestionWallTimeNs = context_->ingestionTiming().wallNanos,
+      .encodingCpuTimeNs = context_->encodingTiming().cpuNanos,
+      .encodingWallTimeNs = context_->encodingTiming().wallNanos,
+      .encodingSelectionCpuTimeNs =
+          context_->encodingSelectionTiming().cpuNanos,
+      .encodingSelectionWallTimeNs =
+          context_->encodingSelectionTiming().wallNanos,
       .inputBufferReallocCount = context_->inputBufferGrowthStats().count,
       .inputBufferReallocItemCount =
           context_->inputBufferGrowthStats().itemCount,

--- a/dwio/nimble/velox/VeloxWriter.h
+++ b/dwio/nimble/velox/VeloxWriter.h
@@ -59,23 +59,37 @@ class VeloxWriter {
 
   struct Stats {
     /// Total bytes written to the file.
-    uint64_t bytesWritten;
+    uint64_t writtenBytes;
     /// Number of stripes written to the file.
     uint32_t stripeCount;
     /// Uncompressed size of data written to the file.
-    uint64_t rawSize;
-    /// Number of rows in each stripe.
+    uint64_t inputBytes;
+    // TODO: Remove rowsPerStripe — replaced by nimble.rowsPerStripe runtime
+    // stat (RuntimeMetric with count/min/max/avg).
     std::vector<uint64_t> rowsPerStripe;
-    /// CPU time spent flushing data in microseconds.
-    uint64_t flushCpuTimeUs;
-    /// Wall clock time spent flushing data in microseconds.
-    uint64_t flushWallTimeUs;
-    /// CPU time spent on encoding selection in microseconds.
-    uint64_t encodingSelectionCpuTimeUs;
-    /// Number of input buffer reallocations. These 2 stats should be from
-    /// memory pool and have better coverage in the future.
+    /// CPU time spent in tabletWriter write in nanoseconds.
+    uint64_t writeCpuTimeNs;
+    /// Wall clock time spent in tabletWriter write in nanoseconds.
+    uint64_t writeWallTimeNs;
+    /// CPU time spent ingesting vectors into field writer buffers in
+    /// nanoseconds.
+    uint64_t ingestionCpuTimeNs;
+    /// Wall clock time spent ingesting vectors into field writer buffers in
+    /// nanoseconds.
+    uint64_t ingestionWallTimeNs;
+    /// CPU time spent on encoding and compression in nanoseconds.
+    // TODO: Separate encoding and compression costs.
+    uint64_t encodingCpuTimeNs;
+    /// Wall clock time spent on encoding and compression in nanoseconds.
+    uint64_t encodingWallTimeNs;
+    /// CPU time spent on encoding selection in nanoseconds. Subset of
+    /// encoding timing.
+    uint64_t encodingSelectionCpuTimeNs;
+    /// Wall clock time spent on encoding selection in nanoseconds. Subset of
+    /// encoding timing.
+    uint64_t encodingSelectionWallTimeNs;
+    // TODO: Remove inputBufferReallocCount and inputBufferReallocItemCount.
     uint64_t inputBufferReallocCount;
-    /// Number of items moved during input buffer reallocations.
     uint64_t inputBufferReallocItemCount;
     /// Cumulative encoded size distribution across all chunks written under
     /// memory pressure. Empty when chunking is not triggered.

--- a/dwio/nimble/velox/tests/VeloxWriterTest.cpp
+++ b/dwio/nimble/velox/tests/VeloxWriterTest.cpp
@@ -4583,7 +4583,7 @@ TEST_F(VeloxWriterTest, disableStatsCollectionWithChunking) {
   auto stats = writer.stats();
   EXPECT_TRUE(stats.columnStats.empty());
   EXPECT_EQ(stats.stripeCount, 1);
-  EXPECT_GT(stats.bytesWritten, 0);
+  EXPECT_GT(stats.writtenBytes, 0);
 }
 
 namespace {


### PR DESCRIPTION
Summary:

Add comprehensive CPU and wall time metrics to the Nimble writer for performance accounting. All timings are reported in nanoseconds via Velox runtime stats.

  New metrics enable full CPU breakdown of the write path:

  Operator addInputTiming ≈ ingestionCpuNanos + flushCpuNanos + overhead
    flushCpuNanos = encodingCpuNanos + ioCpuNanos + stripe finalization
      encodingCpuNanos ⊃ encodingSelectionCpuNanos

  Runtime stats added:
  - nimble.flushCpuNanos / nimble.flushWallNanos — total flush (inclusive of encoding, IO, stripe finalization)
  - nimble.encodingCpuNanos / nimble.encodingWallNanos — encoding + compression
  - nimble.ioCpuNanos / nimble.ioWallNanos — tabletWriter::writeStripe() I/O
  - nimble.ingestionCpuNanos / nimble.ingestionWallNanos — rootWriter_->write() (vector serialization into field writer buffers)
  - nimble.encodingSelectionCpuNanos / nimble.encodingSelectionWallNanos — encoding model evaluation
  - nimble.stripeCount — number of stripes written per file
  - nimble.writerRawInputBytes — raw uncompressed input size
  - nimble.writerCpuPerByteNanos — (ingestion + flush) / rawInputBytes

  VeloxWriter::Stats struct fields renamed from *Us (microseconds) to *Ns (nanoseconds) and now store nanoseconds directly without lossy division.

  Also fixes the incremental IO stats reporting in NimbleWriterAdapter to use ioWallTimeNs instead of flushWallTimeUs (previously reported total flush wall time
  as IO time)

Reviewed By: xiaoxmeng

Differential Revision: D106147104
