### PR TITLE
perf(nimble): Add per-encoding compression accept ratio overrides (#789)

### DIFF
--- a/dwio/nimble/encodings/legacy/EncodingSelectionPolicy.h
+++ b/dwio/nimble/encodings/legacy/EncodingSelectionPolicy.h
@@ -109,6 +109,7 @@ struct CompressionOptions {
   uint32_t internalDecompressionLevel = 2;
   bool useVariableBitWidthCompressor = false;
   MetaInternalCompressionKey metaInternalCompressionKey;
+  std::vector<std::pair<EncodingType, float>> compressionAcceptRatioOverrides;
 };
 
 // This is the manual encoding selection implementation.
@@ -200,8 +201,11 @@ class ManualEncodingSelectionPolicy : public EncodingSelectionPolicy<T> {
     // bandwidth).
     class AlwaysCompressPolicy : public CompressionPolicy {
      public:
-      explicit AlwaysCompressPolicy(CompressionOptions compressionOptions)
-          : compressionOptions_{std::move(compressionOptions)} {}
+      AlwaysCompressPolicy(
+          CompressionOptions compressionOptions,
+          EncodingType encodingType)
+          : compressionOptions_{std::move(compressionOptions)},
+            effectiveAcceptRatio_{getAcceptRatio(encodingType)} {}
 
       CompressionInformation compression() const override {
 #ifndef DISABLE_META_INTERNAL_COMPRESSOR
@@ -232,8 +236,7 @@ class ManualEncodingSelectionPolicy : public EncodingSelectionPolicy<T> {
           CompressionType compressionType,
           uint64_t uncompressedSize,
           uint64_t compressedSize) const override {
-        if (uncompressedSize * compressionOptions_.compressionAcceptRatio <
-            compressedSize) {
+        if (uncompressedSize * effectiveAcceptRatio_ < compressedSize) {
           NIMBLE_SELECTION_LOG(
               BLUE << compressionType
                    << " compression rejected. Original size: "
@@ -250,7 +253,18 @@ class ManualEncodingSelectionPolicy : public EncodingSelectionPolicy<T> {
       }
 
      private:
+      float getAcceptRatio(EncodingType encodingType) const {
+        for (const auto& [enc, ratio] :
+             compressionOptions_.compressionAcceptRatioOverrides) {
+          if (enc == encodingType) {
+            return ratio;
+          }
+        }
+        return compressionOptions_.compressionAcceptRatio;
+      }
+
       const CompressionOptions compressionOptions_;
+      const float effectiveAcceptRatio_;
     };
 
     NIMBLE_SELECTION_LOG(
@@ -277,8 +291,10 @@ class ManualEncodingSelectionPolicy : public EncodingSelectionPolicy<T> {
     return {
         .encodingType = selectedEncoding,
         .compressionPolicyFactory = [compressionOptions =
-                                         compressionOptions_.value()]() {
-          return std::make_unique<AlwaysCompressPolicy>(compressionOptions);
+                                         compressionOptions_.value(),
+                                     selectedEncoding]() {
+          return std::make_unique<AlwaysCompressPolicy>(
+              compressionOptions, selectedEncoding);
         }};
   }
 

--- a/dwio/nimble/encodings/selection/EncodingSelectionPolicy.h
+++ b/dwio/nimble/encodings/selection/EncodingSelectionPolicy.h
@@ -116,6 +116,8 @@ struct CompressionOptions {
   uint32_t internalDecompressionLevel = 2;
   bool useVariableBitWidthCompressor = false;
   MetaInternalCompressionKey metaInternalCompressionKey;
+  // Per-encoding overrides for compressionAcceptRatio.
+  std::vector<std::pair<EncodingType, float>> compressionAcceptRatioOverrides;
 };
 
 // This is the manual encoding selection implementation.
@@ -215,8 +217,11 @@ class ManualEncodingSelectionPolicy : public EncodingSelectionPolicy<T> {
     // bandwidth).
     class AlwaysCompressPolicy : public CompressionPolicy {
      public:
-      explicit AlwaysCompressPolicy(CompressionOptions compressionOptions)
-          : compressionOptions_{std::move(compressionOptions)} {}
+      AlwaysCompressPolicy(
+          CompressionOptions compressionOptions,
+          EncodingType encodingType)
+          : compressionOptions_{std::move(compressionOptions)},
+            effectiveAcceptRatio_{getAcceptRatio(encodingType)} {}
 
       CompressionInformation compression() const override {
         if (compressionOptions_.compressionType == CompressionType::Zstd) {
@@ -254,8 +259,7 @@ class ManualEncodingSelectionPolicy : public EncodingSelectionPolicy<T> {
           CompressionType compressionType,
           uint64_t uncompressedSize,
           uint64_t compressedSize) const override {
-        if (uncompressedSize * compressionOptions_.compressionAcceptRatio <
-            compressedSize) {
+        if (uncompressedSize * effectiveAcceptRatio_ < compressedSize) {
           NIMBLE_SELECTION_LOG(
               BLUE << compressionType
                    << " compression rejected. Original size: "
@@ -272,7 +276,18 @@ class ManualEncodingSelectionPolicy : public EncodingSelectionPolicy<T> {
       }
 
      private:
+      float getAcceptRatio(EncodingType encodingType) const {
+        for (const auto& [enc, ratio] :
+             compressionOptions_.compressionAcceptRatioOverrides) {
+          if (enc == encodingType) {
+            return ratio;
+          }
+        }
+        return compressionOptions_.compressionAcceptRatio;
+      }
+
       const CompressionOptions compressionOptions_;
+      const float effectiveAcceptRatio_;
     };
 
     NIMBLE_SELECTION_LOG(
@@ -299,8 +314,10 @@ class ManualEncodingSelectionPolicy : public EncodingSelectionPolicy<T> {
     return {
         .encodingType = selectedEncoding,
         .compressionPolicyFactory = [compressionOptions =
-                                         compressionOptions_.value()]() {
-          return std::make_unique<AlwaysCompressPolicy>(compressionOptions);
+                                         compressionOptions_.value(),
+                                     selectedEncoding]() {
+          return std::make_unique<AlwaysCompressPolicy>(
+              compressionOptions, selectedEncoding);
         }};
   }
 

--- a/dwio/nimble/encodings/tests/EncodingSelectionTest.cpp
+++ b/dwio/nimble/encodings/tests/EncodingSelectionTest.cpp
@@ -1495,3 +1495,95 @@ TEST(ManualEncodingSelectionPolicyTest, compressionTypeRoundTrip) {
   encoding->materialize(static_cast<uint32_t>(data.size()), decoded.data());
   EXPECT_EQ(decoded, data);
 }
+
+TEST(ManualEncodingSelectionPolicyTest, compressionAcceptRatioOverride) {
+  std::vector<uint32_t> data(1000, 42);
+
+  nimble::CompressionOptions options{
+      .compressionAcceptRatioOverrides =
+          {
+              {nimble::EncodingType::Constant, 0.0f},
+          },
+  };
+  auto policy =
+      std::make_unique<nimble::ManualEncodingSelectionPolicy<uint32_t>>(
+          nimble::ManualEncodingSelectionPolicyFactory::defaultReadFactors(),
+          options,
+          std::nullopt);
+  auto result =
+      policy->select(data, nimble::Statistics<uint32_t>::create(data));
+
+  // Data is all-constant, so Constant encoding is selected.
+  EXPECT_EQ(result.encodingType, nimble::EncodingType::Constant);
+
+  auto compressionPolicy = result.compressionPolicyFactory();
+  // Constant encoding has override ratio=0.0, so compression is attempted but
+  // shouldAccept() will always reject (0 < compressedSize).
+  EXPECT_NE(
+      compressionPolicy->compression().compressionType,
+      nimble::CompressionType::Uncompressed);
+  EXPECT_FALSE(compressionPolicy->shouldAccept(
+      nimble::CompressionType::Zstd,
+      /*uncompressedSize=*/100,
+      /*compressedSize=*/1));
+}
+
+TEST(
+    ManualEncodingSelectionPolicyTest,
+    compressionAcceptRatioOverrideFallback) {
+  std::vector<uint32_t> data(1000, 42);
+
+  nimble::CompressionOptions options{
+      .compressionAcceptRatioOverrides =
+          {
+              {nimble::EncodingType::Trivial, 0.0f},
+          },
+  };
+  auto policy =
+      std::make_unique<nimble::ManualEncodingSelectionPolicy<uint32_t>>(
+          nimble::ManualEncodingSelectionPolicyFactory::defaultReadFactors(),
+          options,
+          std::nullopt);
+  auto result =
+      policy->select(data, nimble::Statistics<uint32_t>::create(data));
+
+  // Data is all-constant, so Constant encoding is selected — not Trivial.
+  EXPECT_EQ(result.encodingType, nimble::EncodingType::Constant);
+
+  auto compressionPolicy = result.compressionPolicyFactory();
+  // No override for Constant, so the global ratio applies — compression
+  // should be attempted.
+  EXPECT_NE(
+      compressionPolicy->compression().compressionType,
+      nimble::CompressionType::Uncompressed);
+}
+
+TEST(
+    ManualEncodingSelectionPolicyTest,
+    compressionAcceptRatioOverrideShouldAccept) {
+  std::vector<uint32_t> data(1000, 42);
+
+  // Override with a very strict ratio that will reject most compression.
+  nimble::CompressionOptions options{
+      .compressionAcceptRatioOverrides =
+          {
+              {nimble::EncodingType::Constant, 0.01f},
+          },
+  };
+  auto policy =
+      std::make_unique<nimble::ManualEncodingSelectionPolicy<uint32_t>>(
+          nimble::ManualEncodingSelectionPolicyFactory::defaultReadFactors(),
+          options,
+          std::nullopt);
+  auto result =
+      policy->select(data, nimble::Statistics<uint32_t>::create(data));
+  EXPECT_EQ(result.encodingType, nimble::EncodingType::Constant);
+
+  auto compressionPolicy = result.compressionPolicyFactory();
+  // With ratio=0.01, compressed size must be < 1% of original — even 50%
+  // compression (100→50) is rejected.
+  EXPECT_FALSE(compressionPolicy->shouldAccept(
+      nimble::CompressionType::Zstd,
+      /*uncompressedSize=*/100,
+      /*compressedSize=*/50));
+}

--- a/dwio/nimble/velox/NimbleConfig.cpp
+++ b/dwio/nimble/velox/NimbleConfig.cpp
@@ -156,6 +156,28 @@ std::map<uint64_t, float> parseGrowthConfigMap(const std::string& str) {
         "alpha.encodingselection.compression.accept.ratio",
         FLAGS_nimble_selection_compression_accept_ratio);
 
+/* static */ Config::Entry<const std::vector<std::pair<EncodingType, float>>>
+    Config::COMPRESSION_ACCEPT_RATIO_OVERRIDES(
+        "alpha.encodingselection.compression.accept.ratio.overrides",
+        {},
+        [](const std::vector<std::pair<EncodingType, float>>& val) {
+          std::vector<std::string> parts;
+          std::transform(
+              val.cbegin(),
+              val.cend(),
+              std::back_inserter(parts),
+              [](const auto& p) {
+                return fmt::format("{}={}", toString(p.first), p.second);
+              });
+          return folly::join(";", parts);
+        },
+        [](const std::string& /* key */, const std::string& val) {
+          if (val.empty()) {
+            return std::vector<std::pair<EncodingType, float>>{};
+          }
+          return ManualEncodingSelectionPolicyFactory::parseReadFactors(val);
+        });
+
 // Attempt to compress the data only if the data size is equal or greater than
 // this threshold.
 /* static */ Config::Entry<uint64_t> Config::ZSTD_COMPRESSION_MIN_SIZE(

--- a/dwio/nimble/velox/NimbleConfig.h
+++ b/dwio/nimble/velox/NimbleConfig.h
@@ -37,6 +37,8 @@ class Config : public velox::config::ConfigBase {
   static Entry<const std::vector<std::pair<EncodingType, float>>>
       MANUAL_ENCODING_SELECTION_READ_FACTORS;
   static Entry<float> ENCODING_SELECTION_COMPRESSION_ACCEPT_RATIO;
+  static Entry<const std::vector<std::pair<EncodingType, float>>>
+      COMPRESSION_ACCEPT_RATIO_OVERRIDES;
   static Entry<uint64_t> ZSTD_COMPRESSION_MIN_SIZE;
   static Entry<uint64_t> ZSTRONG_COMPRESSION_MIN_SIZE;
   static Entry<uint32_t> ZSTRONG_COMPRESSION_LEVEL;


### PR DESCRIPTION
Summary:

CONTEXT: Nimble currently applies a single global `compressionAcceptRatio` to all encoding types. Some encodings (e.g., future ChunkedBitPacking) may benefit from different compression thresholds.

WHAT: Adds per-encoding compression accept ratio overrides to `CompressionOptions`. Each encoding type can have its own accept ratio, falling back to the global `compressionAcceptRatio`. Configurable via metastore serde param `alpha.encodingselection.compression.accept.ratio.overrides` (format: `EncodingType=ratio;...`).

Reviewed By: HuamengJiang

Differential Revision: D105890685


