### PR TITLE
[Reference][Do-not-merge for now] feat(encoding): Experimental - Enable/Disable SubIntSplit encoding in both write and read paths

### DIFF
--- a/dwio/nimble/common/Types.cpp
+++ b/dwio/nimble/common/Types.cpp
@@ -49,6 +49,8 @@ std::string toString(EncodingType encodingType) {
       return "Sentinel";
     case EncodingType::Prefix:
       return "Prefix";
+    case EncodingType::SubIntSplit:
+      return "SubIntSplit";
   }
   return fmt::format(
       "Unknown encoding type: {}", static_cast<int32_t>(encodingType));

--- a/dwio/nimble/common/Types.h
+++ b/dwio/nimble/common/Types.h
@@ -104,6 +104,10 @@ enum class EncodingType {
   // shared across consecutive entries to reduce storage. Supports seek
   // operations for efficient random access.
   Prefix = 11,
+  // Decomposes each value into bit-range sub-streams and encodes each
+  // independently. Optimal splits are chosen via a sample-driven DP algorithm.
+  // Only supported for 32- and 64-bit numeric types.
+  SubIntSplit = 12,
 };
 std::string toString(EncodingType encodingType);
 std::ostream& operator<<(std::ostream& out, EncodingType encodingType);

--- a/dwio/nimble/encodings/FixedBitWidthEncoding.h
+++ b/dwio/nimble/encodings/FixedBitWidthEncoding.h
@@ -36,6 +36,9 @@
 
 namespace facebook::nimble {
 
+template <typename T>
+class EncodingSelection;
+
 // Data layout is:
 // EncodingPrefix::kFixedPrefixSize bytes: standard Encoding prefix
 // 1 byte: compression type

--- a/dwio/nimble/encodings/SubIntSplitConfig.h
+++ b/dwio/nimble/encodings/SubIntSplitConfig.h
@@ -1,0 +1,117 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <charconv>
+#include <optional>
+#include <span>
+#include <string>
+#include <string_view>
+#include <unordered_map>
+#include <vector>
+
+#include "dwio/nimble/encodings/SubIntSplitSelector.h"
+
+namespace facebook::nimble::detail::subintsplit {
+
+inline constexpr std::string_view kSplitModeConfigKey = "subintsplit.mode";
+inline constexpr std::string_view kSplitBoundariesConfigKey =
+    "subintsplit.boundaries";
+inline constexpr std::string_view kSplitModeRecompute = "recompute";
+inline constexpr std::string_view kSplitModePreserve = "preserve";
+
+inline std::string serializeSplitBoundaries(
+    std::span<const SegmentPlan> segments) {
+  std::string result;
+  for (size_t i = 0; i < segments.size(); ++i) {
+    if (i > 0) {
+      result.push_back(';');
+    }
+    result += std::to_string(segments[i].bitStart);
+    result.push_back('-');
+    result += std::to_string(segments[i].bitEnd);
+  }
+  return result;
+}
+
+inline std::optional<std::vector<SegmentPlan>> parseSplitBoundaries(
+    std::string_view value,
+    int kBits) {
+  if (value.empty() || kBits <= 0) {
+    return std::nullopt;
+  }
+
+  std::vector<SegmentPlan> segments;
+  segments.reserve(8);
+
+  int expectedStart = 0;
+  size_t cursor = 0;
+  while (cursor < value.size()) {
+    const auto dashPos = value.find('-', cursor);
+    if (dashPos == std::string_view::npos) {
+      return std::nullopt;
+    }
+
+    const auto semiPos = value.find(';', dashPos + 1);
+    const std::string_view startText = value.substr(cursor, dashPos - cursor);
+    const std::string_view endText = value.substr(
+        dashPos + 1,
+        semiPos == std::string_view::npos ? value.size() - (dashPos + 1)
+                                          : semiPos - (dashPos + 1));
+
+    int bitStart = 0;
+    int bitEnd = 0;
+    const auto startResult = std::from_chars(
+        startText.data(), startText.data() + startText.size(), bitStart);
+    const auto endResult = std::from_chars(
+        endText.data(), endText.data() + endText.size(), bitEnd);
+    if (startResult.ec != std::errc{} ||
+        startResult.ptr != startText.data() + startText.size() ||
+        endResult.ec != std::errc{} ||
+        endResult.ptr != endText.data() + endText.size()) {
+      return std::nullopt;
+    }
+
+    if (bitStart != expectedStart || bitStart < 0 || bitEnd < bitStart ||
+        bitEnd >= kBits) {
+      return std::nullopt;
+    }
+
+    segments.push_back({.bitStart = bitStart, .bitEnd = bitEnd});
+    expectedStart = bitEnd + 1;
+    if (semiPos == std::string_view::npos) {
+      break;
+    }
+    cursor = semiPos + 1;
+  }
+
+  if (segments.empty() || expectedStart != kBits) {
+    return std::nullopt;
+  }
+
+  return segments;
+}
+
+inline std::unordered_map<std::string, std::string> makePreserveSplitConfig(
+    std::span<const SegmentPlan> segments) {
+  return {
+      {std::string(kSplitModeConfigKey), std::string(kSplitModePreserve)},
+      {std::string(kSplitBoundariesConfigKey),
+       serializeSplitBoundaries(segments)},
+  };
+}
+
+} // namespace facebook::nimble::detail::subintsplit

--- a/dwio/nimble/encodings/SubIntSplitCostModels.h
+++ b/dwio/nimble/encodings/SubIntSplitCostModels.h
@@ -1,0 +1,234 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <bit>
+#include <cmath>
+#include <cstddef>
+#include <cstdint>
+#include <limits>
+
+#include "dwio/nimble/common/Types.h"
+#include "dwio/nimble/encodings/SubIntSplitMetrics.h"
+
+// Per-segment cost models for SubIntSplitEncoding's DP selector.
+//
+// Each function estimates the compressed size in bits for encoding numValues
+// items from a bit-range sub-stream of logical width bitWidth. The models
+// correspond to nimble's present encodings and are derived from the same
+// assumptions used in EncodingSizeEstimation.h (common prefix 6 bytes, nested
+// encoding overhead, etc.).
+//
+// Deliberately avoids HLL cardinality estimation, entropy, and frame-residual
+// tracking — the simplified SegmentMetrics provides enough signal for the DP
+// to make directionally correct split decisions.
+
+namespace facebook::nimble::detail::subintsplit {
+
+// Smallest storage width in bits for a logical value of `bw` bits.
+// Matches nimble's physical type selection: uint8/16/32/64.
+inline constexpr uint8_t storageWidthBits(int bw) noexcept {
+  if (bw <= 8) {
+    return 8;
+  }
+  if (bw <= 16) {
+    return 16;
+  }
+  if (bw <= 32) {
+    return 32;
+  }
+  return 64;
+}
+
+// Union of MetricFlags needed across all cost models below.
+inline MetricFlags allCostModelRequiredFlags() noexcept {
+  return MetricFlag::MinMax | MetricFlag::RunStats | MetricFlag::UniqueCount;
+}
+
+// Trivial: store each value at its native storage width.
+inline double trivialCostBits(
+    const SegmentMetrics& /*m*/,
+    size_t numValues,
+    int bitWidth) noexcept {
+  constexpr double kHeaderBits = 7.0 * 8.0; // prefix(6) + compressionType(1)
+  return kHeaderBits +
+      static_cast<double>(numValues) *
+      static_cast<double>(storageWidthBits(bitWidth));
+}
+
+// FixedBitWidth: bit-pack using observed range, rounded to byte boundary.
+// Required: MinMax
+inline double fixedBitWidthCostBits(
+    const SegmentMetrics& m,
+    size_t numValues,
+    int bitWidth) noexcept {
+  if (numValues == 0) {
+    return 0.0;
+  }
+  // prefix(6) + compressionType(1) + baseline(storageBytes) + bitWidth(1)
+  const double baselineBytes =
+      static_cast<double>(storageWidthBits(bitWidth)) / 8.0;
+  const double headerBits = (7.0 + baselineBytes + 1.0) * 8.0;
+
+  const uint8_t rangeWidth =
+      m.range == 0 ? uint8_t{0} : static_cast<uint8_t>(std::bit_width(m.range));
+  const uint8_t packedBits =
+      std::min<uint8_t>(static_cast<uint8_t>(bitWidth), rangeWidth);
+  // Round up to byte boundary (matches nimble's current FixedBitWidth impl).
+  const uint8_t roundedBits = (packedBits + 7u) & ~7u;
+
+  return headerBits +
+      static_cast<double>(roundedBits) * static_cast<double>(numValues);
+}
+
+// Constant: zero cost when all values are equal, infinity otherwise.
+// Required: MinMax
+inline double constantCostBits(
+    const SegmentMetrics& m,
+    size_t numValues,
+    int bitWidth) noexcept {
+  if (numValues == 0) {
+    return 0.0;
+  }
+  if (m.min != m.max) {
+    return std::numeric_limits<double>::infinity();
+  }
+  // prefix(6) + stored value
+  const double headerBits =
+      (6.0 + static_cast<double>(storageWidthBits(bitWidth)) / 8.0) * 8.0;
+  return headerBits;
+}
+
+// Dictionary: unique value table + bit-packed indices.
+// Uses observed uniqueCount directly (no HLL blending). Directionally correct
+// for the DP's purposes.
+// Required: UniqueCount, MinMax
+inline double dictionaryCostBits(
+    const SegmentMetrics& m,
+    size_t numValues,
+    int bitWidth) noexcept {
+  if (m.uniqueCount == 0 || numValues == 0) {
+    return 0.0;
+  }
+  const size_t uniques = m.uniqueCount;
+  const uint8_t valueBits = storageWidthBits(bitWidth);
+  const double dictBits =
+      static_cast<double>(uniques) * static_cast<double>(valueBits);
+  // Index width: ceil(log2(uniques)), clamped to 32
+  const uint32_t indexWidth = (uniques <= 1)
+      ? 1u
+      : std::min(32u, static_cast<uint32_t>(std::bit_width(uniques - 1)));
+  // Bit-packed indices rounded up to byte boundary
+  const double roundedIndexBits = static_cast<double>((indexWidth + 7u) & ~7u);
+  const double indexBits = roundedIndexBits * static_cast<double>(numValues);
+  // prefix(6) + alphabetSize(4) + nested header overhead (~15 bytes)
+  const double headerBits = (6.0 + 4.0 + 15.0) * 8.0;
+
+  // Penalise when index width ≥ value width (dictionary doesn't compress).
+  const double penalty = (indexWidth >= valueBits)
+      ? 1.0 + 0.15 * (static_cast<double>(indexWidth) / valueBits - 1.0)
+      : 1.0;
+
+  return headerBits + penalty * (dictBits + indexBits);
+}
+
+// RLE: run values + bit-packed run lengths.
+// Required: RunStats, MinMax
+inline double
+rleCostBits(const SegmentMetrics& m, size_t numValues, int bitWidth) noexcept {
+  if (numValues == 0 || m.avgRunLength <= 0.0) {
+    return 0.0;
+  }
+  // avgRunLength is scale-invariant, so extrapolate run count to full stream.
+  const double estimatedRuns = static_cast<double>(numValues) / m.avgRunLength;
+  // prefix(6) + runLengthsSize(4) + nested encoding overhead (~16 bytes)
+  const double headerBits = (6.0 + 4.0 + 16.0) * 8.0;
+  const double runValuesBits =
+      estimatedRuns * static_cast<double>(storageWidthBits(bitWidth));
+  // Assume 16-bit run lengths (conservative)
+  const double runLengthsBits = estimatedRuns * 16.0;
+  return headerBits + runValuesBits + runLengthsBits;
+}
+
+// Varint: variable-length integer storage. Only useful for ≥32-bit sections.
+// Required: MinMax (max value determines byte width)
+inline double varintCostBits(
+    const SegmentMetrics& m,
+    size_t numValues,
+    int bitWidth) noexcept {
+  if (numValues == 0 || bitWidth < 32) {
+    return std::numeric_limits<double>::infinity();
+  }
+  const uint64_t maxVal = m.max;
+  uint8_t varintBytes;
+  if (maxVal < (1ULL << 7)) {
+    varintBytes = 1;
+  } else if (maxVal < (1ULL << 14)) {
+    varintBytes = 2;
+  } else if (maxVal < (1ULL << 21)) {
+    varintBytes = 3;
+  } else if (maxVal < (1ULL << 28)) {
+    varintBytes = 4;
+  } else if (maxVal < (1ULL << 35)) {
+    varintBytes = 5;
+  } else if (maxVal < (1ULL << 42)) {
+    varintBytes = 6;
+  } else if (maxVal < (1ULL << 49)) {
+    varintBytes = 7;
+  } else if (maxVal < (1ULL << 56)) {
+    varintBytes = 8;
+  } else {
+    varintBytes = 9;
+  }
+  // prefix(6) + baseline
+  const double headerBits =
+      (6.0 + static_cast<double>(storageWidthBits(bitWidth)) / 8.0) * 8.0;
+  return headerBits +
+      static_cast<double>(varintBytes) * 8.0 * static_cast<double>(numValues);
+}
+
+// Evaluate all cost models and return the minimum cost in bits.
+// Also sets `bestEncoding` to the winning EncodingType.
+inline double bestCostBits(
+    const SegmentMetrics& m,
+    size_t numValues,
+    int bitWidth,
+    EncodingType& bestEncoding) noexcept {
+  double best = std::numeric_limits<double>::infinity();
+  auto consider = [&](double cost, EncodingType type) noexcept {
+    if (cost < best) {
+      best = cost;
+      bestEncoding = type;
+    }
+  };
+
+  consider(trivialCostBits(m, numValues, bitWidth), EncodingType::Trivial);
+  consider(
+      fixedBitWidthCostBits(m, numValues, bitWidth),
+      EncodingType::FixedBitWidth);
+  consider(constantCostBits(m, numValues, bitWidth), EncodingType::Constant);
+  consider(rleCostBits(m, numValues, bitWidth), EncodingType::RLE);
+  consider(varintCostBits(m, numValues, bitWidth), EncodingType::Varint);
+  // Dictionary only when cardinality << numValues
+  if (m.uniqueCount > 0 &&
+      (m.uniqueCountCapped || m.uniqueCount < numValues / 2)) {
+    consider(
+        dictionaryCostBits(m, numValues, bitWidth), EncodingType::Dictionary);
+  }
+  return best;
+}
+
+} // namespace facebook::nimble::detail::subintsplit

--- a/dwio/nimble/encodings/SubIntSplitEncoding.h
+++ b/dwio/nimble/encodings/SubIntSplitEncoding.h
@@ -1,0 +1,750 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <algorithm>
+#include <cstdint>
+#include <cstring>
+#include <memory>
+#include <span>
+#include <string_view>
+#include <vector>
+
+#include "dwio/nimble/common/Buffer.h"
+#include "dwio/nimble/common/Exceptions.h"
+#include "dwio/nimble/common/Types.h"
+#include "dwio/nimble/common/Vector.h"
+#include "dwio/nimble/encodings/SubIntSplitConfig.h"
+#include "dwio/nimble/encodings/SubIntSplitSampler.h"
+#include "dwio/nimble/encodings/SubIntSplitSelector.h"
+#include "dwio/nimble/encodings/common/Encoding.h"
+#include "dwio/nimble/encodings/common/EncodingFactory.h"
+#include "dwio/nimble/encodings/common/EncodingPrimitives.h"
+#include "dwio/nimble/encodings/common/EncodingType.h"
+#include "dwio/nimble/encodings/selection/EncodingIdentifier.h"
+#include "dwio/nimble/encodings/selection/EncodingSelection.h"
+#include "velox/common/memory/Memory.h"
+#ifdef __AVX2__
+#include <immintrin.h>
+#endif
+
+// SubIntSplitEncoding: decomposes each value in a 32- or 64-bit integer stream
+// into bit-range sub-streams, selects an optimal encoding for each sub-stream
+// via a sample-driven DP algorithm, and stitches the encoded sub-streams back
+// together for efficient decoding.
+//
+// Only supported for 32- and 64-bit types (int32_t, uint32_t, int64_t,
+// uint64_t, float, double). The physical type for float is uint32_t and for
+// double is uint64_t; bit patterns are preserved across encode/decode.
+//
+// Each section is encoded as the narrowest unsigned integer type that fits its
+// bit width (uint8_t for 1-8 bits, uint16_t for 9-16, uint32_t for 17-32,
+// uint64_t for 33-64). This avoids paying an 8-byte-per-value penalty for
+// narrow sections when they land in e.g. Dictionary or Trivial encoding.
+//
+// Binary layout (after the standard Encoding prefix):
+//   [1 byte]  splitCount (number of sections, 1..64)
+//   [1 byte]  reserved (future: BitSplitOrder; currently 0)
+//   [splitCount × 6 bytes]  {bitStart(1B), bitEnd(1B), encodedSize(4B)}
+//   [section_0_bytes][section_1_bytes]...[section_{N-1}_bytes]
+//
+// Sections are stored in LSB-first order (section 0 covers the lowest bits).
+// Section identifiers equal the section index (0, 1, …, splitCount-1).
+
+namespace facebook::nimble {
+
+template <typename T>
+class SubIntSplitEncoding
+    : public TypedEncoding<T, typename TypeTraits<T>::physicalType> {
+ public:
+  using cppDataType = T;
+  using physicalType = typename TypeTraits<T>::physicalType;
+
+  static_assert(
+      sizeof(physicalType) == 4 || sizeof(physicalType) == 8,
+      "SubIntSplitEncoding only supports 32- and 64-bit types");
+  static_assert(
+      isNumericType<physicalType>(),
+      "SubIntSplitEncoding only supports numeric types");
+
+  SubIntSplitEncoding(
+      velox::memory::MemoryPool& pool,
+      std::string_view data,
+      std::function<void*(uint32_t)> stringBufferFactory,
+      const Encoding::Options& options = {});
+
+  void reset() final;
+  void skip(uint32_t rowCount) final;
+  void materialize(uint32_t rowCount, void* buffer) final;
+
+  template <typename DecoderVisitor>
+  void readWithVisitor(DecoderVisitor& visitor, ReadWithVisitorParams& params);
+
+  static std::string_view encode(
+      EncodingSelection<physicalType>& selection,
+      std::span<const physicalType> values,
+      Buffer& buffer,
+      const Encoding::Options& options = {});
+
+  std::string debugString(int offset) const final;
+
+ private:
+  struct SectionInfo {
+    int bitStart{0};
+    int bitEnd{0};
+    uint64_t mask{0}; // (1 << width) - 1, or ~0 for full 64-bit section
+    uint8_t storageBytes{8}; // 1, 2, 4, or 8 — matches the section's DataType
+    std::unique_ptr<Encoding> encoding;
+  };
+
+  std::vector<SectionInfo> sections_;
+
+  // Persistent scratch buffer reused across materialize() calls. Sized to
+  // kMaterializeChunkSize * sizeof(physicalType) bytes on first use.
+  Vector<uint8_t> scratchBuf_;
+
+  // Return the storage byte width for a section of the given bit width.
+  static constexpr uint8_t sectionStorageBytes(int bitWidth) noexcept {
+    if (bitWidth <= 8)
+      return 1;
+    if (bitWidth <= 16)
+      return 2;
+    if (bitWidth <= 32)
+      return 4;
+    return 8;
+  }
+
+  // Number of output elements processed per chunk in materialize(). Chosen so
+  // that the output slice (kMaterializeChunkSize * sizeof(physicalType)) and
+  // the scratch buffer (kMaterializeChunkSize * storageBytes) together fit
+  // comfortably in L2 cache across all sections for a given chunk.
+  //   uint64 output + uint64 scratch: 4096 * 8 * 2 = 64 KB  (fits 256 KB L2)
+  //   uint64 output + uint8  scratch: 4096 * 8 + 4096 * 1 = 36 KB (fits L1)
+  static constexpr uint32_t kMaterializeChunkSize = 4096;
+
+  // Accumulate one section's decoded values into the output buffer.
+  // IsFirst=true: pure write (initialises the output element).
+  // IsFirst=false: read-modify-write OR into the existing output element.
+  // __restrict__ informs the compiler that src and dst do not alias, enabling
+  // auto-vectorisation for same-width cases and providing correct alias
+  // semantics for the AVX2 widening paths below.
+  template <typename SectionT, bool IsFirst>
+  static void accumulateSection(
+      const SectionT* __restrict__ src,
+      physicalType* __restrict__ dst,
+      uint32_t count,
+      uint64_t mask,
+      int shift) noexcept;
+};
+
+//
+// End of public API. Implementation follows.
+//
+
+namespace detail {
+inline constexpr uint32_t kSubIntSplitSectionHeaderSize =
+    6; // bitStart+bitEnd+size
+
+inline uint32_t subIntSplitSpecificHeaderSize(uint8_t splitCount) noexcept {
+  return 2u + static_cast<uint32_t>(splitCount) * kSubIntSplitSectionHeaderSize;
+}
+} // namespace detail
+
+template <typename T>
+SubIntSplitEncoding<T>::SubIntSplitEncoding(
+    velox::memory::MemoryPool& pool,
+    std::string_view data,
+    std::function<void*(uint32_t)> stringBufferFactory,
+    const Encoding::Options& options)
+    : TypedEncoding<T, physicalType>{pool, data, options},
+      sections_{},
+      scratchBuf_{&pool} {
+  const EncodingFactory factory{options};
+  const auto* pos = data.data() + this->dataOffset();
+
+  const uint8_t splitCount = encoding::read<uint8_t>(pos);
+  encoding::read<uint8_t>(pos); // reserved order byte
+
+  struct SectionMeta {
+    uint8_t bitStart;
+    uint8_t bitEnd;
+    uint32_t encodedSize;
+  };
+  std::vector<SectionMeta> meta(splitCount);
+  for (uint8_t s = 0; s < splitCount; ++s) {
+    meta[s].bitStart = encoding::read<uint8_t>(pos);
+    meta[s].bitEnd = encoding::read<uint8_t>(pos);
+    meta[s].encodedSize = encoding::readUint32(pos);
+  }
+
+  sections_.resize(splitCount);
+  for (uint8_t s = 0; s < splitCount; ++s) {
+    auto& sec = sections_[s];
+    sec.bitStart = meta[s].bitStart;
+    sec.bitEnd = meta[s].bitEnd;
+    const int width = sec.bitEnd - sec.bitStart + 1;
+    sec.mask = (width >= 64) ? ~uint64_t{0} : ((uint64_t{1} << width) - 1);
+    sec.storageBytes = sectionStorageBytes(width);
+    sec.encoding = factory.create(
+        *this->pool_, {pos, meta[s].encodedSize}, stringBufferFactory);
+    pos += meta[s].encodedSize;
+  }
+}
+
+template <typename T>
+void SubIntSplitEncoding<T>::reset() {
+  for (auto& sec : sections_) {
+    sec.encoding->reset();
+  }
+}
+
+template <typename T>
+void SubIntSplitEncoding<T>::skip(uint32_t rowCount) {
+  for (auto& sec : sections_) {
+    sec.encoding->skip(rowCount);
+  }
+}
+
+// accumulateSection: widen narrow section values into the physicalType output.
+//
+// For narrow→wide cases (SectionT smaller than physicalType) an AVX2 path uses
+// zero-extending widening intrinsics (_mm256_cvtepu*_epi*) followed by a
+// variable left-shift and optional OR-accumulate.  An L2 prefetch hint keeps
+// both src and dst warm across successive section loops in a chunk.
+//
+// For same-width cases (SectionT == physicalType) the __restrict__ qualifiers
+// and the compile-time IsFirst branch produce auto-vectoriser-friendly loops.
+template <typename T>
+template <typename SectionT, bool IsFirst>
+void SubIntSplitEncoding<T>::accumulateSection(
+    const SectionT* __restrict__ src,
+    physicalType* __restrict__ dst,
+    uint32_t count,
+    uint64_t mask,
+    int shift) noexcept {
+  const SectionT narrowMask = static_cast<SectionT>(mask);
+
+#ifdef __AVX2__
+  if constexpr (sizeof(SectionT) < sizeof(physicalType)) {
+    if constexpr (sizeof(physicalType) == 8) {
+      // ----------------------------------------------------------------
+      // Widening into 64-bit output
+      // ----------------------------------------------------------------
+      const __m128i vshift = _mm_cvtsi64_si128(static_cast<int64_t>(shift));
+      const __m256i vmask = _mm256_set1_epi64x(static_cast<int64_t>(mask));
+
+      if constexpr (sizeof(SectionT) == 1) {
+        // uint8 → uint64: _mm256_cvtepu8_epi64 processes 4 elements.
+        uint32_t i = 0;
+        for (; i + 4 <= count; i += 4) {
+          _mm_prefetch(
+              reinterpret_cast<const char*>(src + i + 32), _MM_HINT_T1);
+          _mm_prefetch(
+              reinterpret_cast<const char*>(dst + i + 32), _MM_HINT_T1);
+          int32_t tmp;
+          std::memcpy(&tmp, src + i, 4);
+          __m256i vs = _mm256_cvtepu8_epi64(_mm_cvtsi32_si128(tmp));
+          vs = _mm256_and_si256(vs, vmask);
+          if (shift)
+            vs = _mm256_sll_epi64(vs, vshift);
+          if constexpr (IsFirst) {
+            _mm256_storeu_si256(reinterpret_cast<__m256i*>(dst + i), vs);
+          } else {
+            __m256i vd =
+                _mm256_loadu_si256(reinterpret_cast<const __m256i*>(dst + i));
+            _mm256_storeu_si256(
+                reinterpret_cast<__m256i*>(dst + i), _mm256_or_si256(vd, vs));
+          }
+        }
+        for (; i < count; ++i) {
+          if constexpr (IsFirst)
+            dst[i] = static_cast<physicalType>(src[i] & narrowMask) << shift;
+          else
+            dst[i] |= static_cast<physicalType>(src[i] & narrowMask) << shift;
+        }
+        return;
+
+      } else if constexpr (sizeof(SectionT) == 2) {
+        // uint16 → uint64: _mm256_cvtepu16_epi64 processes 4 elements.
+        uint32_t i = 0;
+        for (; i + 4 <= count; i += 4) {
+          _mm_prefetch(
+              reinterpret_cast<const char*>(src + i + 32), _MM_HINT_T1);
+          _mm_prefetch(
+              reinterpret_cast<const char*>(dst + i + 32), _MM_HINT_T1);
+          __m256i vs = _mm256_cvtepu16_epi64(
+              _mm_loadl_epi64(reinterpret_cast<const __m128i*>(src + i)));
+          vs = _mm256_and_si256(vs, vmask);
+          if (shift)
+            vs = _mm256_sll_epi64(vs, vshift);
+          if constexpr (IsFirst) {
+            _mm256_storeu_si256(reinterpret_cast<__m256i*>(dst + i), vs);
+          } else {
+            __m256i vd =
+                _mm256_loadu_si256(reinterpret_cast<const __m256i*>(dst + i));
+            _mm256_storeu_si256(
+                reinterpret_cast<__m256i*>(dst + i), _mm256_or_si256(vd, vs));
+          }
+        }
+        for (; i < count; ++i) {
+          if constexpr (IsFirst)
+            dst[i] = static_cast<physicalType>(src[i] & narrowMask) << shift;
+          else
+            dst[i] |= static_cast<physicalType>(src[i] & narrowMask) << shift;
+        }
+        return;
+
+      } else if constexpr (sizeof(SectionT) == 4) {
+        // uint32 → uint64: _mm256_cvtepu32_epi64 processes 4 elements.
+        uint32_t i = 0;
+        for (; i + 4 <= count; i += 4) {
+          _mm_prefetch(
+              reinterpret_cast<const char*>(src + i + 16), _MM_HINT_T1);
+          _mm_prefetch(
+              reinterpret_cast<const char*>(dst + i + 32), _MM_HINT_T1);
+          __m256i vs = _mm256_cvtepu32_epi64(
+              _mm_loadu_si128(reinterpret_cast<const __m128i*>(src + i)));
+          vs = _mm256_and_si256(vs, vmask);
+          if (shift)
+            vs = _mm256_sll_epi64(vs, vshift);
+          if constexpr (IsFirst) {
+            _mm256_storeu_si256(reinterpret_cast<__m256i*>(dst + i), vs);
+          } else {
+            __m256i vd =
+                _mm256_loadu_si256(reinterpret_cast<const __m256i*>(dst + i));
+            _mm256_storeu_si256(
+                reinterpret_cast<__m256i*>(dst + i), _mm256_or_si256(vd, vs));
+          }
+        }
+        for (; i < count; ++i) {
+          if constexpr (IsFirst)
+            dst[i] = static_cast<physicalType>(src[i] & narrowMask) << shift;
+          else
+            dst[i] |= static_cast<physicalType>(src[i] & narrowMask) << shift;
+        }
+        return;
+      }
+
+    } else if constexpr (sizeof(physicalType) == 4) {
+      // ----------------------------------------------------------------
+      // Widening into 32-bit output
+      // ----------------------------------------------------------------
+      const __m128i vshift = _mm_cvtsi32_si128(static_cast<int32_t>(shift));
+      const __m256i vmask = _mm256_set1_epi32(static_cast<int32_t>(mask));
+
+      if constexpr (sizeof(SectionT) == 1) {
+        // uint8 → uint32: _mm256_cvtepu8_epi32 processes 8 elements.
+        uint32_t i = 0;
+        for (; i + 8 <= count; i += 8) {
+          _mm_prefetch(
+              reinterpret_cast<const char*>(src + i + 64), _MM_HINT_T1);
+          _mm_prefetch(
+              reinterpret_cast<const char*>(dst + i + 32), _MM_HINT_T1);
+          int64_t tmp;
+          std::memcpy(&tmp, src + i, 8);
+          __m256i vs = _mm256_cvtepu8_epi32(_mm_cvtsi64_si128(tmp));
+          vs = _mm256_and_si256(vs, vmask);
+          if (shift)
+            vs = _mm256_sll_epi32(vs, vshift);
+          if constexpr (IsFirst) {
+            _mm256_storeu_si256(reinterpret_cast<__m256i*>(dst + i), vs);
+          } else {
+            __m256i vd =
+                _mm256_loadu_si256(reinterpret_cast<const __m256i*>(dst + i));
+            _mm256_storeu_si256(
+                reinterpret_cast<__m256i*>(dst + i), _mm256_or_si256(vd, vs));
+          }
+        }
+        for (; i < count; ++i) {
+          if constexpr (IsFirst)
+            dst[i] = static_cast<physicalType>(src[i] & narrowMask) << shift;
+          else
+            dst[i] |= static_cast<physicalType>(src[i] & narrowMask) << shift;
+        }
+        return;
+
+      } else if constexpr (sizeof(SectionT) == 2) {
+        // uint16 → uint32: _mm256_cvtepu16_epi32 processes 8 elements.
+        uint32_t i = 0;
+        for (; i + 8 <= count; i += 8) {
+          _mm_prefetch(
+              reinterpret_cast<const char*>(src + i + 32), _MM_HINT_T1);
+          _mm_prefetch(
+              reinterpret_cast<const char*>(dst + i + 32), _MM_HINT_T1);
+          __m256i vs = _mm256_cvtepu16_epi32(
+              _mm_loadu_si128(reinterpret_cast<const __m128i*>(src + i)));
+          vs = _mm256_and_si256(vs, vmask);
+          if (shift)
+            vs = _mm256_sll_epi32(vs, vshift);
+          if constexpr (IsFirst) {
+            _mm256_storeu_si256(reinterpret_cast<__m256i*>(dst + i), vs);
+          } else {
+            __m256i vd =
+                _mm256_loadu_si256(reinterpret_cast<const __m256i*>(dst + i));
+            _mm256_storeu_si256(
+                reinterpret_cast<__m256i*>(dst + i), _mm256_or_si256(vd, vs));
+          }
+        }
+        for (; i < count; ++i) {
+          if constexpr (IsFirst)
+            dst[i] = static_cast<physicalType>(src[i] & narrowMask) << shift;
+          else
+            dst[i] |= static_cast<physicalType>(src[i] & narrowMask) << shift;
+        }
+        return;
+      }
+    }
+  }
+#endif // __AVX2__
+
+  // Scalar path: same-width sections (SectionT == physicalType), or builds
+  // without AVX2, or narrow cases not covered by the AVX2 specialisations
+  // above.
+  // __restrict__ on the parameters allows the compiler to auto-vectorise this
+  // loop for same-width cases (e.g. uint32_t → uint32_t, uint64_t → uint64_t).
+  if constexpr (IsFirst) {
+    for (uint32_t i = 0; i < count; ++i)
+      dst[i] = static_cast<physicalType>(src[i] & narrowMask) << shift;
+  } else {
+    for (uint32_t i = 0; i < count; ++i)
+      dst[i] |= static_cast<physicalType>(src[i] & narrowMask) << shift;
+  }
+}
+
+template <typename T>
+void SubIntSplitEncoding<T>::materialize(uint32_t rowCount, void* buffer) {
+  physicalType* output = static_cast<physicalType*>(buffer);
+
+  // Lazily size the scratch buffer on the first call. The scratch must hold one
+  // chunk's worth of section values at the widest possible storage type.
+  constexpr uint32_t kScratchBytes =
+      kMaterializeChunkSize * static_cast<uint32_t>(sizeof(physicalType));
+  if (scratchBuf_.size() < kScratchBytes) [[unlikely]] {
+    scratchBuf_.resize(kScratchBytes);
+  }
+
+  // Outer loop: advance through the output in kMaterializeChunkSize-element
+  // chunks.  For each chunk, all sections are accumulated before moving to the
+  // next chunk, so the output slice and the scratch buffer both stay in L2/L1
+  // cache across the entire section inner-loop.
+  for (uint32_t chunkStart = 0; chunkStart < rowCount;
+       chunkStart += kMaterializeChunkSize) {
+    const uint32_t chunkCount =
+        std::min(kMaterializeChunkSize, rowCount - chunkStart);
+    physicalType* chunkOutput = output + chunkStart;
+
+    for (size_t s = 0; s < sections_.size(); ++s) {
+      const auto& sec = sections_[s];
+      const int shift = sec.bitStart;
+      const uint64_t mask = sec.mask;
+      // Section 0 initialises each output element (pure write); subsequent
+      // sections OR their bits in.  This avoids a separate std::fill pass.
+      const bool isFirst = (s == 0);
+
+      switch (sec.storageBytes) {
+        case 1: {
+          auto* scratch = reinterpret_cast<uint8_t*>(scratchBuf_.data());
+          sec.encoding->materialize(chunkCount, scratch);
+          if (isFirst)
+            accumulateSection<uint8_t, true>(
+                scratch, chunkOutput, chunkCount, mask, shift);
+          else
+            accumulateSection<uint8_t, false>(
+                scratch, chunkOutput, chunkCount, mask, shift);
+          break;
+        }
+        case 2: {
+          auto* scratch = reinterpret_cast<uint16_t*>(scratchBuf_.data());
+          sec.encoding->materialize(chunkCount, scratch);
+          if (isFirst)
+            accumulateSection<uint16_t, true>(
+                scratch, chunkOutput, chunkCount, mask, shift);
+          else
+            accumulateSection<uint16_t, false>(
+                scratch, chunkOutput, chunkCount, mask, shift);
+          break;
+        }
+        case 4: {
+          auto* scratch = reinterpret_cast<uint32_t*>(scratchBuf_.data());
+          sec.encoding->materialize(chunkCount, scratch);
+          if (isFirst)
+            accumulateSection<uint32_t, true>(
+                scratch, chunkOutput, chunkCount, mask, shift);
+          else
+            accumulateSection<uint32_t, false>(
+                scratch, chunkOutput, chunkCount, mask, shift);
+          break;
+        }
+        case 8: {
+          auto* scratch = reinterpret_cast<uint64_t*>(scratchBuf_.data());
+          sec.encoding->materialize(chunkCount, scratch);
+          if (isFirst)
+            accumulateSection<uint64_t, true>(
+                scratch, chunkOutput, chunkCount, mask, shift);
+          else
+            accumulateSection<uint64_t, false>(
+                scratch, chunkOutput, chunkCount, mask, shift);
+          break;
+        }
+        default:
+          NIMBLE_UNREACHABLE("Invalid SubIntSplit section storage width.");
+      }
+    }
+  }
+}
+
+template <typename T>
+template <typename DecoderVisitor>
+void SubIntSplitEncoding<T>::readWithVisitor(
+    DecoderVisitor& visitor,
+    ReadWithVisitorParams& params) {
+  detail::readWithVisitorSlow(
+      visitor,
+      params,
+      [&](auto toSkip) { skip(toSkip); },
+      [&] {
+        physicalType value = 0;
+        for (const auto& sec : sections_) {
+          switch (sec.storageBytes) {
+            case 1: {
+              uint8_t sectionValue = 0;
+              sec.encoding->materialize(1, &sectionValue);
+              value |= static_cast<physicalType>(sectionValue & sec.mask)
+                  << sec.bitStart;
+              break;
+            }
+            case 2: {
+              uint16_t sectionValue = 0;
+              sec.encoding->materialize(1, &sectionValue);
+              value |= static_cast<physicalType>(sectionValue & sec.mask)
+                  << sec.bitStart;
+              break;
+            }
+            case 4: {
+              uint32_t sectionValue = 0;
+              sec.encoding->materialize(1, &sectionValue);
+              value |= static_cast<physicalType>(sectionValue & sec.mask)
+                  << sec.bitStart;
+              break;
+            }
+            case 8: {
+              uint64_t sectionValue = 0;
+              sec.encoding->materialize(1, &sectionValue);
+              value |= static_cast<physicalType>(sectionValue & sec.mask)
+                  << sec.bitStart;
+              break;
+            }
+            default: {
+              NIMBLE_UNREACHABLE("Invalid SubIntSplit section storage width.");
+            }
+          }
+        }
+        return value;
+      });
+}
+
+template <typename T>
+std::string_view SubIntSplitEncoding<T>::encode(
+    EncodingSelection<physicalType>& selection,
+    std::span<const physicalType> values,
+    Buffer& buffer,
+    const Encoding::Options& options) {
+  const bool useVarint = options.useVarintRowCount;
+  const uint32_t valueCount = static_cast<uint32_t>(values.size());
+
+  if (values.empty()) {
+    NIMBLE_INCOMPATIBLE_ENCODING("SubIntSplitEncoding cannot be empty.");
+  }
+
+  constexpr int kBits = static_cast<int>(sizeof(physicalType) * 8);
+
+  std::vector<detail::subintsplit::SegmentPlan> segments;
+  const auto modeConfig = selection.getConfig(
+      std::string(detail::subintsplit::kSplitModeConfigKey));
+  if (modeConfig.has_value() &&
+      *modeConfig == detail::subintsplit::kSplitModePreserve) {
+    const auto boundaryConfig = selection.getConfig(
+        std::string(detail::subintsplit::kSplitBoundariesConfigKey));
+    NIMBLE_CHECK(
+        boundaryConfig.has_value(),
+        "SubIntSplit preserve mode requires boundaries config.");
+    auto parsed =
+        detail::subintsplit::parseSplitBoundaries(*boundaryConfig, kBits);
+    NIMBLE_CHECK(parsed.has_value(), "Invalid SubIntSplit boundaries config.");
+    segments = std::move(parsed.value());
+  } else {
+    // Default behavior: recompute the split boundaries from the sampled data.
+    std::vector<uint64_t> sampleBuf;
+    detail::subintsplit::sampleIntoU64<physicalType>(
+        values, sampleBuf, detail::subintsplit::defaultSamplerConfig());
+
+    auto selectorResult = detail::subintsplit::selectSplits(
+        sampleBuf,
+        kBits,
+        valueCount,
+        detail::subintsplit::defaultSelectorConfig());
+
+    segments = std::move(selectorResult.segments);
+  }
+
+  NIMBLE_CHECK(
+      !segments.empty(), "SubIntSplitEncoding: selector returned no segments");
+  const uint8_t splitCount = static_cast<uint8_t>(segments.size());
+
+  // --- Step 2: Encode each section into a temporary buffer ---
+  // Each section is encoded as the narrowest unsigned integer type that fits
+  // its bit width, so narrow sections don't pay an 8-byte-per-value penalty.
+  Buffer tempBuffer{buffer.getMemoryPool()};
+  std::vector<std::string_view> sectionData;
+  sectionData.reserve(splitCount);
+
+  for (uint8_t s = 0; s < splitCount; ++s) {
+    const auto& seg = segments[s];
+    const int bitStart = seg.bitStart;
+    const int bitEnd = seg.bitEnd;
+    const int width = bitEnd - bitStart + 1;
+    const uint64_t mask =
+        (width >= 64) ? ~uint64_t{0} : ((uint64_t{1} << width) - 1);
+    const uint8_t sb = sectionStorageBytes(width);
+
+    std::string_view encoded;
+    switch (sb) {
+      case 1: {
+        Vector<uint8_t> sectionValues{&tempBuffer.getMemoryPool(), valueCount};
+        for (uint32_t i = 0; i < valueCount; ++i) {
+          uint64_t v = 0;
+          __builtin_memcpy(&v, &values[i], sizeof(physicalType));
+          sectionValues[i] = static_cast<uint8_t>((v >> bitStart) & mask);
+        }
+        encoded = selection.template encodeNested<uint8_t>(
+            static_cast<NestedEncodingIdentifier>(s),
+            std::span<const uint8_t>(
+                sectionValues.data(), sectionValues.size()),
+            tempBuffer,
+            options);
+        break;
+      }
+      case 2: {
+        Vector<uint16_t> sectionValues{&tempBuffer.getMemoryPool(), valueCount};
+        for (uint32_t i = 0; i < valueCount; ++i) {
+          uint64_t v = 0;
+          __builtin_memcpy(&v, &values[i], sizeof(physicalType));
+          sectionValues[i] = static_cast<uint16_t>((v >> bitStart) & mask);
+        }
+        encoded = selection.template encodeNested<uint16_t>(
+            static_cast<NestedEncodingIdentifier>(s),
+            std::span<const uint16_t>(
+                sectionValues.data(), sectionValues.size()),
+            tempBuffer,
+            options);
+        break;
+      }
+      case 4: {
+        Vector<uint32_t> sectionValues{&tempBuffer.getMemoryPool(), valueCount};
+        for (uint32_t i = 0; i < valueCount; ++i) {
+          uint64_t v = 0;
+          __builtin_memcpy(&v, &values[i], sizeof(physicalType));
+          sectionValues[i] = static_cast<uint32_t>((v >> bitStart) & mask);
+        }
+        encoded = selection.template encodeNested<uint32_t>(
+            static_cast<NestedEncodingIdentifier>(s),
+            std::span<const uint32_t>(
+                sectionValues.data(), sectionValues.size()),
+            tempBuffer,
+            options);
+        break;
+      }
+      case 8: {
+        Vector<uint64_t> sectionValues{&tempBuffer.getMemoryPool(), valueCount};
+        for (uint32_t i = 0; i < valueCount; ++i) {
+          uint64_t v = 0;
+          __builtin_memcpy(&v, &values[i], sizeof(physicalType));
+          sectionValues[i] = (v >> bitStart) & mask;
+        }
+        encoded = selection.template encodeNested<uint64_t>(
+            static_cast<NestedEncodingIdentifier>(s),
+            std::span<const uint64_t>(
+                sectionValues.data(), sectionValues.size()),
+            tempBuffer,
+            options);
+        break;
+      }
+      default: {
+        NIMBLE_UNREACHABLE("Invalid SubIntSplit section storage width.");
+      }
+    }
+    sectionData.push_back(encoded);
+  }
+
+  // --- Step 3: Write final encoding to main buffer ---
+  const uint32_t prefixSize =
+      Encoding::serializePrefixSize(valueCount, useVarint);
+  const uint32_t specificHeader =
+      detail::subIntSplitSpecificHeaderSize(splitCount);
+  uint32_t sectionsSize = 0;
+  for (const auto& sv : sectionData) {
+    sectionsSize += static_cast<uint32_t>(sv.size());
+  }
+  const uint32_t encodingSize = prefixSize + specificHeader + sectionsSize;
+
+  char* reserved = buffer.reserve(encodingSize);
+  char* pos = reserved;
+
+  Encoding::serializePrefix(
+      EncodingType::SubIntSplit,
+      TypeTraits<T>::dataType,
+      valueCount,
+      useVarint,
+      pos);
+
+  encoding::write<uint8_t>(splitCount, pos);
+  encoding::write<uint8_t>(uint8_t{0}, pos); // reserved / order
+
+  for (uint8_t s = 0; s < splitCount; ++s) {
+    const auto& seg = segments[s];
+    encoding::write<uint8_t>(static_cast<uint8_t>(seg.bitStart), pos);
+    encoding::write<uint8_t>(static_cast<uint8_t>(seg.bitEnd), pos);
+    encoding::writeUint32(static_cast<uint32_t>(sectionData[s].size()), pos);
+  }
+  for (const auto& sv : sectionData) {
+    encoding::writeBytes(sv, pos);
+  }
+
+  NIMBLE_DCHECK_EQ(
+      static_cast<uint32_t>(pos - reserved),
+      encodingSize,
+      "SubIntSplitEncoding: encoding size mismatch");
+
+  return {reserved, encodingSize};
+}
+
+template <typename T>
+std::string SubIntSplitEncoding<T>::debugString(int offset) const {
+  std::string indent(offset, ' ');
+  std::string result = indent +
+      "SubIntSplitEncoding sections=" + std::to_string(sections_.size()) + "\n";
+  for (size_t s = 0; s < sections_.size(); ++s) {
+    const auto& sec = sections_[s];
+    result += indent + "  [" + std::to_string(sec.bitStart) + ".." +
+        std::to_string(sec.bitEnd) +
+        "] storageBytes=" + std::to_string(sec.storageBytes) + "\n";
+    result += sec.encoding->debugString(offset + 4);
+    result += "\n";
+  }
+  return result;
+}
+
+} // namespace facebook::nimble

--- a/dwio/nimble/encodings/SubIntSplitMetrics.h
+++ b/dwio/nimble/encodings/SubIntSplitMetrics.h
@@ -1,0 +1,141 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+#include <limits>
+#include <vector>
+
+#include "absl/container/flat_hash_map.h" // @manual=fbsource//third-party/abseil-cpp:container__flat_hash_map
+
+// Lightweight per-segment metric collection for SubIntSplitEncoding's DP
+// planner. Deliberately minimal: only the statistics needed by the cost
+// models are computed, with no HLL, no entropy, and no residual-frame
+// tracking. Nimble's Statistics<T> class already handles those heavier
+// computations for full-stream outer selection; this collector handles the
+// 64×64 bit-range grid on a small sample.
+
+namespace facebook::nimble::detail::subintsplit {
+
+enum class MetricFlag : uint32_t {
+  None = 0,
+  MinMax = 1u << 0, // min, max, range
+  RunStats = 1u << 1, // runCount, avgRunLength
+  UniqueCount = 1u << 2, // uniqueCount (raw, capped)
+  All = (1u << 3) - 1,
+};
+using MetricFlags = uint32_t;
+
+inline constexpr MetricFlags operator|(MetricFlag a, MetricFlag b) noexcept {
+  return static_cast<MetricFlags>(a) | static_cast<MetricFlags>(b);
+}
+inline constexpr MetricFlags operator|(MetricFlags a, MetricFlag b) noexcept {
+  return a | static_cast<MetricFlags>(b);
+}
+inline constexpr bool hasFlag(MetricFlags flags, MetricFlag f) noexcept {
+  return (flags & static_cast<MetricFlags>(f)) != 0;
+}
+
+struct SegmentMetrics {
+  uint64_t min{0};
+  uint64_t max{0};
+  uint64_t range{0};
+
+  size_t uniqueCount{0};
+  bool uniqueCountCapped{false};
+
+  size_t runCount{0};
+  double avgRunLength{0.0};
+};
+
+// Single-pass metric collector for extracted bit-range values.
+// Allocates a small hash set for unique counting (capped at kUniqueCountCap)
+// and uses a running prev-value comparison for run counting.
+class MetricCollector {
+ public:
+  static constexpr size_t kUniqueCountCap = 1
+      << 14; // 16K cap (lighter than full HLL)
+
+  SegmentMetrics compute(
+      const std::vector<uint64_t>& values,
+      MetricFlags flags = static_cast<MetricFlags>(MetricFlag::All)) const {
+    const bool doMin = hasFlag(flags, MetricFlag::MinMax);
+    const bool doRun = hasFlag(flags, MetricFlag::RunStats);
+    const bool doUniq = hasFlag(flags, MetricFlag::UniqueCount);
+
+    SegmentMetrics out;
+    const size_t n = values.size();
+    if (n == 0) {
+      return out;
+    }
+
+    const uint64_t v0 = values[0];
+    if (doMin) {
+      out.min = v0;
+      out.max = v0;
+    }
+    if (doRun) {
+      out.runCount = 1;
+    }
+
+    absl::flat_hash_map<uint64_t, uint8_t> uniqSet;
+    bool capped = false;
+    if (doUniq) {
+      uniqSet.reserve(std::min(n, kUniqueCountCap));
+      uniqSet.emplace(v0, 1);
+    }
+
+    uint64_t prev = v0;
+    for (size_t i = 1; i < n; ++i) {
+      const uint64_t v = values[i];
+      if (doMin) {
+        if (v < out.min) {
+          out.min = v;
+        }
+        if (v > out.max) {
+          out.max = v;
+        }
+      }
+      if (doRun && v != prev) {
+        ++out.runCount;
+      }
+      if (doUniq && !capped) {
+        uniqSet.emplace(v, 1);
+        if (uniqSet.size() > kUniqueCountCap) {
+          capped = true;
+        }
+      }
+      prev = v;
+    }
+
+    if (doMin) {
+      out.range = out.max - out.min;
+    }
+    if (doRun) {
+      out.avgRunLength =
+          static_cast<double>(n) / static_cast<double>(out.runCount);
+    }
+    if (doUniq) {
+      out.uniqueCount = capped ? (kUniqueCountCap + 1) : uniqSet.size();
+      out.uniqueCountCapped = capped;
+    }
+
+    return out;
+  }
+};
+
+} // namespace facebook::nimble::detail::subintsplit

--- a/dwio/nimble/encodings/SubIntSplitSampler.h
+++ b/dwio/nimble/encodings/SubIntSplitSampler.h
@@ -1,0 +1,94 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <algorithm>
+#include <cstddef>
+#include <cstdint>
+#include <span>
+#include <vector>
+
+// Stream sampler for SubIntSplitEncoding's DP planner.
+//
+// Writes into a caller-supplied std::vector<uint64_t> so the allocation can
+// be reused across multiple encode() calls or DP iterations. Values are
+// stored as uint64_t (physical bit pattern, zero-extended for <64-bit types).
+//
+// Config is passed explicitly; callers obtain a default via
+// defaultSamplerConfig() and may override fields before calling.
+
+namespace facebook::nimble::detail::subintsplit {
+
+struct SamplerConfig {
+  // Maximum number of samples to draw.
+  size_t maxSamples{10'000};
+  // Contiguous block size for block-stratified sampling.
+  // 0 → use uniform stride sampling instead.
+  size_t blockSize{128};
+};
+
+inline SamplerConfig defaultSamplerConfig() noexcept {
+  return SamplerConfig{.maxSamples = 10'000, .blockSize = 128};
+}
+
+// Fill `out` with up to cfg.maxSamples uint64_t values drawn from `values`.
+// Block-stratified sampling (when cfg.blockSize > 0) preserves local temporal
+// structure, which is important for accurate run-length and frame-residual
+// metrics. Stride sampling (blockSize == 0) spreads samples uniformly.
+//
+// Writes directly into `out` (which is resized); no heap allocation occurs if
+// `out` already has sufficient capacity.
+template <typename physicalType>
+void sampleIntoU64(
+    std::span<const physicalType> values,
+    std::vector<uint64_t>& out,
+    const SamplerConfig& cfg = defaultSamplerConfig()) {
+  static_assert(sizeof(physicalType) <= 8);
+
+  const size_t n = values.size();
+  out.clear();
+  if (n == 0) {
+    return;
+  }
+
+  const size_t target = std::min(cfg.maxSamples > 0 ? cfg.maxSamples : n, n);
+  out.reserve(target);
+
+  if (cfg.blockSize > 0) {
+    // Block-stratified: evenly-spaced contiguous windows.
+    const size_t numBlocks = std::max<size_t>(1, target / cfg.blockSize);
+    const size_t blockStride = std::max<size_t>(1, n / numBlocks);
+    for (size_t b = 0; b < numBlocks && out.size() < target; ++b) {
+      const size_t start = b * blockStride;
+      const size_t end = std::min(start + cfg.blockSize, n);
+      for (size_t i = start; i < end && out.size() < target; ++i) {
+        uint64_t bits = 0;
+        __builtin_memcpy(&bits, &values[i], sizeof(physicalType));
+        out.push_back(bits);
+      }
+    }
+  } else {
+    // Uniform stride sampling.
+    const size_t stride = std::max<size_t>(1, n / target);
+    for (size_t i = 0; i < n; i += stride) {
+      uint64_t bits = 0;
+      __builtin_memcpy(&bits, &values[i], sizeof(physicalType));
+      out.push_back(bits);
+    }
+  }
+}
+
+} // namespace facebook::nimble::detail::subintsplit

--- a/dwio/nimble/encodings/SubIntSplitSelector.h
+++ b/dwio/nimble/encodings/SubIntSplitSelector.h
@@ -1,0 +1,224 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <algorithm>
+#include <array>
+#include <cmath>
+#include <cstddef>
+#include <cstdint>
+#include <limits>
+#include <vector>
+
+#include "dwio/nimble/common/Types.h"
+#include "dwio/nimble/encodings/SubIntSplitCostModels.h"
+#include "dwio/nimble/encodings/SubIntSplitMetrics.h"
+
+// DP-based bit-range split selector for SubIntSplitEncoding.
+//
+// Adapted from
+// EncodingsPlayground/Source/encoders/selectors/IDSubStreamEncodingSelector.hpp.
+// Evaluates a grid of bit ranges [l..r] on a sample of uint64_t values,
+// runs dynamic programming over bit positions 0..kBits to find the minimum-cost
+// partition, and returns a list of SegmentPlan entries.
+
+namespace facebook::nimble::detail::subintsplit {
+
+struct SegmentPlan {
+  int bitStart{0};
+  int bitEnd{0};
+  EncodingType encoding{EncodingType::Trivial};
+  double cost{0.0}; // estimated total bits for the full stream
+};
+
+struct SelectorConfig {
+  int minSegmentWidth{1};
+  double splitPenalty{10.0}; // extra bits charged per additional split boundary
+};
+
+inline SelectorConfig defaultSelectorConfig() noexcept {
+  return SelectorConfig{.minSegmentWidth = 1, .splitPenalty = 10.0};
+}
+
+// Incremental bit-range value extractor.
+// Builds values[i] = bits [bitStart..bitEnd] of sample[i], extending one bit
+// at a time to reuse work across the inner loop of the segment-evaluation grid.
+class BitRangeExtractor {
+ public:
+  explicit BitRangeExtractor(const std::vector<uint64_t>& samples)
+      : samples_(samples),
+        values_(samples.size(), uint64_t{0}),
+        bitStart_(-1),
+        bitEnd_(-1) {}
+
+  void reset(int bitStart) {
+    bitStart_ = bitStart;
+    bitEnd_ = bitStart;
+    const size_t n = samples_.size();
+    for (size_t i = 0; i < n; ++i) {
+      values_[i] = (samples_[i] >> bitStart_) & uint64_t{1};
+    }
+  }
+
+  void extend(int bitEnd) {
+    if (bitEnd <= bitEnd_) {
+      return;
+    }
+    const size_t n = samples_.size();
+    for (int b = bitEnd_ + 1; b <= bitEnd; ++b) {
+      const int shift = b - bitStart_;
+      const uint64_t maskShift = uint64_t{1} << shift;
+      for (size_t i = 0; i < n; ++i) {
+        const uint64_t bit = (samples_[i] >> b) & uint64_t{1};
+        values_[i] |= bit * maskShift;
+      }
+    }
+    bitEnd_ = bitEnd;
+  }
+
+  const std::vector<uint64_t>& values() const noexcept {
+    return values_;
+  }
+
+ private:
+  const std::vector<uint64_t>& samples_;
+  std::vector<uint64_t> values_;
+  int bitStart_;
+  int bitEnd_;
+};
+
+struct SelectorResult {
+  std::vector<SegmentPlan> segments;
+  double totalCost{0.0};
+};
+
+// Run the DP split selector on `samples` (uint64_t values drawn from a
+// physical-type stream of `kBits` width).
+//
+// `fullCount` is the total element count of the *full* stream; cost model
+// scores are scaled from the sample size to the full stream so the DP
+// produces estimates in the right units.
+inline SelectorResult selectSplits(
+    const std::vector<uint64_t>& samples,
+    int kBits, // number of bits in the physical type (32 or 64)
+    size_t fullCount,
+    const SelectorConfig& cfg = defaultSelectorConfig()) {
+  if (samples.empty() || kBits <= 0) {
+    return {};
+  }
+  kBits = std::min(kBits, 64);
+
+  const MetricFlags requiredFlags = allCostModelRequiredFlags();
+  const MetricCollector collector;
+
+  // bestCost[l][r] = {min cost in bits for full stream, best EncodingType}
+  // Only lower-triangular (r >= l) entries are valid.
+  struct SegmentChoice {
+    double cost{std::numeric_limits<double>::infinity()};
+    EncodingType encoding{EncodingType::Trivial};
+  };
+
+  // Use flat vector for cache friendliness (kBits can be 32 or 64)
+  const int sz = kBits;
+  std::vector<SegmentChoice> bestCost(sz * sz);
+
+  BitRangeExtractor extractor(samples);
+  const size_t numSamples = samples.size();
+
+  for (int l = 0; l < sz; ++l) {
+    extractor.reset(l);
+    for (int r = l; r < sz; ++r) {
+      extractor.extend(r);
+      const std::vector<uint64_t>& segValues = extractor.values();
+      const SegmentMetrics metrics =
+          collector.compute(segValues, requiredFlags);
+      const int bitWidth = r - l + 1;
+
+      EncodingType bestEnc = EncodingType::Trivial;
+      const double perSampleCost =
+          bestCostBits(metrics, numSamples, bitWidth, bestEnc);
+
+      // Scale to full stream
+      const double fullCost = perSampleCost * static_cast<double>(fullCount) /
+          static_cast<double>(numSamples);
+
+      bestCost[l * sz + r] = {fullCost, bestEnc};
+    }
+  }
+
+  // DP over bit positions [0..kBits].
+  // dp[i] = minimum cost to cover bits [0..i).
+  std::vector<double> dp(sz + 1, std::numeric_limits<double>::infinity());
+  std::vector<int> prev(sz + 1, -1);
+  std::vector<EncodingType> chosen(sz + 1, EncodingType::Trivial);
+  dp[0] = 0.0;
+
+  for (int i = 1; i <= sz; ++i) {
+    for (int j = 0; j < i; ++j) {
+      const int width = i - j;
+      if (width < cfg.minSegmentWidth) {
+        continue;
+      }
+      const auto& choice = bestCost[j * sz + (i - 1)];
+      if (!std::isfinite(choice.cost)) {
+        continue;
+      }
+      const double splitCost = (j == 0) ? 0.0 : cfg.splitPenalty;
+      const double candidate = dp[j] + choice.cost + splitCost;
+      if (candidate < dp[i]) {
+        dp[i] = candidate;
+        prev[i] = j;
+        chosen[i] = choice.encoding;
+      }
+    }
+  }
+
+  SelectorResult result;
+  result.totalCost = dp[sz];
+
+  if (!std::isfinite(result.totalCost)) {
+    // Fallback: single segment covering all bits, Trivial encoding
+    SegmentPlan fallback;
+    fallback.bitStart = 0;
+    fallback.bitEnd = sz - 1;
+    fallback.encoding = EncodingType::Trivial;
+    fallback.cost = bestCost[0 * sz + (sz - 1)].cost;
+    result.segments.push_back(fallback);
+    result.totalCost = fallback.cost;
+    return result;
+  }
+
+  // Backtrack to reconstruct segment plan
+  int idx = sz;
+  while (idx > 0) {
+    const int start = prev[idx];
+    if (start < 0) {
+      break;
+    }
+    SegmentPlan plan;
+    plan.bitStart = start;
+    plan.bitEnd = idx - 1;
+    plan.encoding = chosen[idx];
+    plan.cost = bestCost[start * sz + (idx - 1)].cost;
+    result.segments.push_back(plan);
+    idx = start;
+  }
+
+  std::reverse(result.segments.begin(), result.segments.end());
+  return result;
+}
+
+} // namespace facebook::nimble::detail::subintsplit

--- a/dwio/nimble/encodings/benchmarks/FixedBitWidthBenchmark.cpp
+++ b/dwio/nimble/encodings/benchmarks/FixedBitWidthBenchmark.cpp
@@ -23,7 +23,9 @@
 #include "dwio/nimble/common/Buffer.h"
 #include "dwio/nimble/common/FixedBitArray.h"
 #include "dwio/nimble/common/Vector.h"
-#include "dwio/nimble/encodings/tests/TestUtils.h"
+#include "dwio/nimble/encodings/FixedBitWidthEncoding.h"
+#include "dwio/nimble/encodings/selection/EncodingSelection.h"
+#include "dwio/nimble/encodings/selection/Statistics.h"
 #include "folly/Benchmark.h"
 #include "folly/Random.h"
 #include "velox/common/memory/Memory.h"
@@ -56,15 +58,25 @@ Vector<T> makeData(int bitWidth, int n = kNumElements) {
 }
 
 /// Encodes data and returns (encoded string, encoding).
-template <typename EncodingType>
-std::pair<std::string, std::unique_ptr<Encoding>> encodeAndCreate(
+template <typename T>
+std::string encodeFixedBitWidth(
     Buffer& buffer,
-    const Vector<typename EncodingType::cppDataType>& data) {
-  auto encoded = test::Encoder<EncodingType>::encode(buffer, data);
-  std::string encodedStr{encoded.data(), encoded.size()};
-  auto encoding = EncodingFactory{}.create(
-      *pool, encodedStr, [](uint32_t) -> void* { return nullptr; });
-  return {std::move(encodedStr), std::move(encoding)};
+    const Vector<T>& data,
+    const Encoding::Options& options = {}) {
+  using physicalType = typename TypeTraits<T>::physicalType;
+
+  auto physicalValues = std::span<const physicalType>(
+      reinterpret_cast<const physicalType*>(data.data()), data.size());
+  EncodingSelectionResult selectionResult{
+      .encodingType = EncodingType::FixedBitWidth};
+  auto selection = EncodingSelection<physicalType>{
+      std::move(selectionResult),
+      Statistics<physicalType>::create(physicalValues),
+      nullptr};
+
+  auto encoded = FixedBitWidthEncoding<T>::encode(
+      selection, physicalValues, buffer, options);
+  return std::string{encoded.data(), encoded.size()};
 }
 
 } // namespace
@@ -79,9 +91,7 @@ BENCHMARK(FBW_Materialize_uint32_8bit, iters) {
   BENCHMARK_SUSPEND {
     Buffer buffer{*pool};
     auto data = makeData<uint32_t>(8);
-    encoded =
-        test::Encoder<FixedBitWidthEncoding<uint32_t>>::encode(buffer, data);
-    encoded = std::string{encoded.data(), encoded.size()};
+    encoded = encodeFixedBitWidth(buffer, data);
   }
   while (iters--) {
     auto encoding = EncodingFactory{}.create(
@@ -96,9 +106,7 @@ BENCHMARK(FBW_Materialize_uint32_16bit, iters) {
   BENCHMARK_SUSPEND {
     Buffer buffer{*pool};
     auto data = makeData<uint32_t>(16);
-    auto sv =
-        test::Encoder<FixedBitWidthEncoding<uint32_t>>::encode(buffer, data);
-    encoded = std::string{sv.data(), sv.size()};
+    encoded = encodeFixedBitWidth(buffer, data);
   }
   while (iters--) {
     auto encoding = EncodingFactory{}.create(
@@ -120,9 +128,7 @@ BENCHMARK(FBW_Materialize_uint64_8bit, iters) {
   BENCHMARK_SUSPEND {
     Buffer buffer{*pool};
     auto data = makeData<uint64_t>(8);
-    auto sv =
-        test::Encoder<FixedBitWidthEncoding<uint64_t>>::encode(buffer, data);
-    encoded = std::string{sv.data(), sv.size()};
+    encoded = encodeFixedBitWidth(buffer, data);
   }
   while (iters--) {
     auto encoding = EncodingFactory{}.create(
@@ -137,9 +143,7 @@ BENCHMARK(FBW_Materialize_uint64_16bit, iters) {
   BENCHMARK_SUSPEND {
     Buffer buffer{*pool};
     auto data = makeData<uint64_t>(16);
-    auto sv =
-        test::Encoder<FixedBitWidthEncoding<uint64_t>>::encode(buffer, data);
-    encoded = std::string{sv.data(), sv.size()};
+    encoded = encodeFixedBitWidth(buffer, data);
   }
   while (iters--) {
     auto encoding = EncodingFactory{}.create(
@@ -154,9 +158,7 @@ BENCHMARK(FBW_Materialize_uint64_32bit, iters) {
   BENCHMARK_SUSPEND {
     Buffer buffer{*pool};
     auto data = makeData<uint64_t>(32);
-    auto sv =
-        test::Encoder<FixedBitWidthEncoding<uint64_t>>::encode(buffer, data);
-    encoded = std::string{sv.data(), sv.size()};
+    encoded = encodeFixedBitWidth(buffer, data);
   }
   while (iters--) {
     auto encoding = EncodingFactory{}.create(
@@ -171,9 +173,7 @@ BENCHMARK(FBW_Materialize_uint64_48bit, iters) {
   BENCHMARK_SUSPEND {
     Buffer buffer{*pool};
     auto data = makeData<uint64_t>(48);
-    auto sv =
-        test::Encoder<FixedBitWidthEncoding<uint64_t>>::encode(buffer, data);
-    encoded = std::string{sv.data(), sv.size()};
+    encoded = encodeFixedBitWidth(buffer, data);
   }
   while (iters--) {
     auto encoding = EncodingFactory{}.create(

--- a/dwio/nimble/encodings/common/EncodingFactory.cpp
+++ b/dwio/nimble/encodings/common/EncodingFactory.cpp
@@ -23,6 +23,7 @@
 #include "dwio/nimble/encodings/PrefixEncoding.h"
 #include "dwio/nimble/encodings/RleEncoding.h"
 #include "dwio/nimble/encodings/SparseBoolEncoding.h"
+#include "dwio/nimble/encodings/SubIntSplitEncoding.h"
 #include "dwio/nimble/encodings/TrivialEncoding.h"
 #include "dwio/nimble/encodings/VarintEncoding.h"
 #include "dwio/nimble/encodings/selection/EncodingSelection.h"
@@ -243,6 +244,9 @@ std::unique_ptr<Encoding> EncodingFactory::create(
     case EncodingType::Delta: {
       RETURN_ENCODING_BY_NUMERIC_TYPE(DeltaEncoding, dataType);
     }
+    case EncodingType::SubIntSplit: {
+      RETURN_ENCODING_BY_VARINT_TYPE(SubIntSplitEncoding, dataType);
+    }
     default: {
       NIMBLE_UNREACHABLE(
           "Trying to deserialize invalid EncodingType:{} -- garbage input?",
@@ -374,6 +378,17 @@ std::string_view EncodingFactory::encode(
         NIMBLE_INCOMPATIBLE_ENCODING(
             "Delta encoding should not be selected for non-numeric data type: {}.",
             toString(TypeTraits<T>::dataType));
+      }
+    }
+    case EncodingType::SubIntSplit: {
+      if constexpr (
+          isNumericType<physicalType>() &&
+          (sizeof(physicalType) == 4 || sizeof(physicalType) == 8)) {
+        return SubIntSplitEncoding<T>::encode(
+            selection, castedValues, buffer, options);
+      } else {
+        NIMBLE_INCOMPATIBLE_ENCODING(
+            "SubIntSplit encoding only supports 32- and 64-bit numeric types.");
       }
     }
     default: {

--- a/dwio/nimble/encodings/common/EncodingFactory.cpp
+++ b/dwio/nimble/encodings/common/EncodingFactory.cpp
@@ -244,9 +244,11 @@ std::unique_ptr<Encoding> EncodingFactory::create(
     case EncodingType::Delta: {
       RETURN_ENCODING_BY_NUMERIC_TYPE(DeltaEncoding, dataType);
     }
+#ifdef NIMBLE_ENABLE_EXPERIMENTAL_ENCODINGS
     case EncodingType::SubIntSplit: {
       RETURN_ENCODING_BY_VARINT_TYPE(SubIntSplitEncoding, dataType);
     }
+#endif
     default: {
       NIMBLE_UNREACHABLE(
           "Trying to deserialize invalid EncodingType:{} -- garbage input?",
@@ -380,6 +382,7 @@ std::string_view EncodingFactory::encode(
             toString(TypeTraits<T>::dataType));
       }
     }
+#ifdef NIMBLE_ENABLE_EXPERIMENTAL_ENCODINGS
     case EncodingType::SubIntSplit: {
       if constexpr (
           isNumericType<physicalType>() &&
@@ -391,6 +394,7 @@ std::string_view EncodingFactory::encode(
             "SubIntSplit encoding only supports 32- and 64-bit numeric types.");
       }
     }
+#endif
     default: {
       NIMBLE_UNSUPPORTED(
           "Encoding {} is not supported.", toString(selection.encodingType()));

--- a/dwio/nimble/encodings/common/EncodingLayout.cpp
+++ b/dwio/nimble/encodings/common/EncodingLayout.cpp
@@ -14,17 +14,105 @@
  * limitations under the License.
  */
 #include "dwio/nimble/encodings/common/EncodingLayout.h"
+#include <algorithm>
 #include <cstdint>
+#include <limits>
 #include <memory>
 #include <vector>
 #include "dwio/nimble/common/Exceptions.h"
+#include "dwio/nimble/encodings/SubIntSplitConfig.h"
 #include "dwio/nimble/encodings/common/EncodingPrimitives.h"
 
 namespace facebook::nimble {
 
 namespace {
 constexpr uint32_t kMinEncodingLayoutBufferSize = 5;
+
+uint32_t serializedConfigSize(const EncodingLayout::Config& config) {
+  if (config.values().empty()) {
+    return 0;
+  }
+
+  uint32_t size = sizeof(uint16_t);
+  for (const auto& [key, value] : config.values()) {
+    size += sizeof(uint16_t) + static_cast<uint32_t>(key.size());
+    size += sizeof(uint16_t) + static_cast<uint32_t>(value.size());
+  }
+  NIMBLE_CHECK_LE(
+      size,
+      std::numeric_limits<uint16_t>::max(),
+      "EncodingLayout config too large.");
+  return size;
 }
+
+void serializeConfig(const EncodingLayout::Config& config, char*& pos) {
+  std::vector<std::pair<std::string_view, std::string_view>> entries;
+  entries.reserve(config.values().size());
+  for (const auto& [key, value] : config.values()) {
+    entries.emplace_back(key, value);
+  }
+  std::sort(
+      entries.begin(), entries.end(), [](const auto& left, const auto& right) {
+        return left.first < right.first;
+      });
+
+  encoding::write<uint16_t>(static_cast<uint16_t>(entries.size()), pos);
+  for (const auto& [key, value] : entries) {
+    encoding::write<uint16_t>(static_cast<uint16_t>(key.size()), pos);
+    encoding::writeBytes(key, pos);
+    encoding::write<uint16_t>(static_cast<uint16_t>(value.size()), pos);
+    encoding::writeBytes(value, pos);
+  }
+}
+
+EncodingLayout::Config deserializeConfig(std::string_view extraData) {
+  if (extraData.empty()) {
+    return {};
+  }
+
+  const char* pos = extraData.data();
+  const char* const end = extraData.data() + extraData.size();
+  std::unordered_map<std::string, std::string> configs;
+
+  NIMBLE_CHECK_LE(
+      static_cast<size_t>(end - pos),
+      extraData.size(),
+      "Invalid encoding layout config.");
+  const uint16_t configCount = encoding::read<uint16_t>(pos);
+  configs.reserve(configCount);
+
+  for (uint16_t i = 0; i < configCount; ++i) {
+    NIMBLE_CHECK_LE(
+        sizeof(uint16_t),
+        static_cast<size_t>(end - pos),
+        "Invalid encoding layout config.");
+    const uint16_t keySize = encoding::read<uint16_t>(pos);
+    NIMBLE_CHECK_LE(
+        keySize,
+        static_cast<size_t>(end - pos),
+        "Invalid encoding layout config.");
+    std::string key(pos, keySize);
+    pos += keySize;
+
+    NIMBLE_CHECK_LE(
+        sizeof(uint16_t),
+        static_cast<size_t>(end - pos),
+        "Invalid encoding layout config.");
+    const uint16_t valueSize = encoding::read<uint16_t>(pos);
+    NIMBLE_CHECK_LE(
+        valueSize,
+        static_cast<size_t>(end - pos),
+        "Invalid encoding layout config.");
+    std::string value(pos, valueSize);
+    pos += valueSize;
+
+    configs.emplace(std::move(key), std::move(value));
+  }
+
+  NIMBLE_CHECK_EQ(pos, end, "Invalid encoding layout config length.");
+  return EncodingLayout::Config{std::move(configs)};
+}
+} // namespace
 
 std::optional<std::string> EncodingLayout::Config::get(
     const std::string& key) const {
@@ -62,17 +150,25 @@ int32_t EncodingLayout::serialize(std::span<char> output) const {
   // We store at least kMinEncodingLayoutBufferSize bytes: encoding type,
   // compression type, children count and extra data size (2 bytes), plus one
   // byte per child.
+  const uint32_t extraDataSize = serializedConfigSize(encodingConfig_);
   NIMBLE_CHECK(
-      output.size() >= kMinEncodingLayoutBufferSize + children_.size(),
+      output.size() >=
+          kMinEncodingLayoutBufferSize + extraDataSize + children_.size(),
       "Captured encoding layout buffer too small.");
 
-  output[0] = static_cast<char>(encodingType_);
-  output[1] = static_cast<char>(compressionType_);
-  output[2] = static_cast<char>(children_.size());
-  // Currently, extra data is not used and always set to zero.
-  output[3] = output[4] = 0;
+  char* pos = output.data();
+  pos[0] = static_cast<char>(encodingType_);
+  pos[1] = static_cast<char>(compressionType_);
+  pos[2] = static_cast<char>(children_.size());
+  pos += 3;
+  encoding::write<uint16_t>(static_cast<uint16_t>(extraDataSize), pos);
 
-  int32_t size = kMinEncodingLayoutBufferSize;
+  int32_t size = static_cast<int32_t>(pos - output.data());
+  if (extraDataSize > 0) {
+    char* extraPos = output.data() + size;
+    serializeConfig(encodingConfig_, extraPos);
+    size += extraDataSize;
+  }
 
   for (auto i = 0; i < children_.size(); ++i) {
     const auto& child = children_[i];
@@ -98,11 +194,17 @@ std::pair<EncodingLayout, uint32_t> EncodingLayout::create(
   const auto encodingType = encoding::read<uint8_t, EncodingType>(pos);
   const auto compressionType = encoding::read<uint8_t, CompressionType>(pos);
   const auto childrenCount = encoding::read<uint8_t>(pos);
-  [[maybe_unused]] const auto extraDataSize = encoding::read<uint16_t>(pos);
+  const auto extraDataSize = encoding::read<uint16_t>(pos);
 
-  NIMBLE_DCHECK_EQ(extraDataSize, 0, "Extra data currently not supported.");
+  NIMBLE_CHECK_GE(
+      encoding.size(),
+      kMinEncodingLayoutBufferSize + extraDataSize,
+      "Invalid captured encoding layout. Buffer too small.");
 
-  uint32_t offset = kMinEncodingLayoutBufferSize;
+  const auto encodingConfig = deserializeConfig(
+      {encoding.data() + kMinEncodingLayoutBufferSize, extraDataSize});
+
+  uint32_t offset = kMinEncodingLayoutBufferSize + extraDataSize;
   std::vector<std::optional<const EncodingLayout>> children;
   children.reserve(childrenCount);
   for (auto i = 0; i < childrenCount; ++i) {
@@ -117,7 +219,12 @@ std::pair<EncodingLayout, uint32_t> EncodingLayout::create(
     }
   }
 
-  return {{encodingType, {}, compressionType, std::move(children)}, offset};
+  return {
+      {encodingType,
+       std::move(encodingConfig),
+       compressionType,
+       std::move(children)},
+      offset};
 }
 
 EncodingType EncodingLayout::encodingType() const {
@@ -267,6 +374,51 @@ EncodingLayout EncodingLayoutCapture::capture(std::string_view encoding) {
           EncodingLayoutCapture::capture(
               {pos, encoding.size() - (pos - encoding.data())}));
       break;
+    }
+    case EncodingType::SubIntSplit: {
+      // Layout after the standard prefix:
+      //   [splitCount(1)][reserved(1)][{bitStart(1),bitEnd(1),encodedSize(4)} ×
+      //   N] [section_0_bytes][section_1_bytes]...
+      const char* pos = encoding.data() + kEncodingPrefixSize;
+      const uint8_t splitCount = encoding::read<uint8_t>(pos);
+      encoding::read<uint8_t>(pos); // reserved
+
+      struct SectionMeta {
+        uint8_t bitStart;
+        uint8_t bitEnd;
+        uint32_t encodedSize;
+      };
+
+      std::vector<SectionMeta> sectionMeta;
+      sectionMeta.reserve(splitCount);
+      for (uint8_t s = 0; s < splitCount; ++s) {
+        SectionMeta meta{};
+        meta.bitStart = encoding::read<uint8_t>(pos);
+        meta.bitEnd = encoding::read<uint8_t>(pos);
+        meta.encodedSize = encoding::readUint32(pos);
+        sectionMeta.push_back(meta);
+      }
+
+      children.reserve(splitCount);
+      for (uint8_t s = 0; s < splitCount; ++s) {
+        children.emplace_back(
+            EncodingLayoutCapture::capture({pos, sectionMeta[s].encodedSize}));
+        pos += sectionMeta[s].encodedSize;
+      }
+      std::vector<detail::subintsplit::SegmentPlan> boundaryPlans;
+      boundaryPlans.reserve(splitCount);
+      for (uint8_t s = 0; s < splitCount; ++s) {
+        detail::subintsplit::SegmentPlan segment{};
+        segment.bitStart = static_cast<int>(sectionMeta[s].bitStart);
+        segment.bitEnd = static_cast<int>(sectionMeta[s].bitEnd);
+        boundaryPlans.push_back(segment);
+      }
+      return {
+          EncodingType::SubIntSplit,
+          EncodingLayout::Config{
+              detail::subintsplit::makePreserveSplitConfig(boundaryPlans)},
+          compressionType,
+          std::move(children)};
     }
     case EncodingType::Nullable: {
       const char* pos = encoding.data() + kEncodingPrefixSize;

--- a/dwio/nimble/encodings/common/EncodingLayout.cpp
+++ b/dwio/nimble/encodings/common/EncodingLayout.cpp
@@ -20,7 +20,9 @@
 #include <memory>
 #include <vector>
 #include "dwio/nimble/common/Exceptions.h"
+#ifdef NIMBLE_ENABLE_EXPERIMENTAL_ENCODINGS
 #include "dwio/nimble/encodings/SubIntSplitConfig.h"
+#endif
 #include "dwio/nimble/encodings/common/EncodingPrimitives.h"
 
 namespace facebook::nimble {
@@ -278,8 +280,11 @@ EncodingLayout EncodingLayoutCapture::capture(std::string_view encoding) {
     case EncodingType::FixedBitWidth:
     case EncodingType::Varint:
     case EncodingType::Constant:
-    case EncodingType::Prefix: {
-      // Non nested encodings have zero children
+    case EncodingType::Prefix:
+#ifndef NIMBLE_ENABLE_EXPERIMENTAL_ENCODINGS
+    case EncodingType::SubIntSplit:
+#endif
+    {
       break;
     }
     case EncodingType::Trivial: {
@@ -375,10 +380,8 @@ EncodingLayout EncodingLayoutCapture::capture(std::string_view encoding) {
               {pos, encoding.size() - (pos - encoding.data())}));
       break;
     }
+#ifdef NIMBLE_ENABLE_EXPERIMENTAL_ENCODINGS
     case EncodingType::SubIntSplit: {
-      // Layout after the standard prefix:
-      //   [splitCount(1)][reserved(1)][{bitStart(1),bitEnd(1),encodedSize(4)} ×
-      //   N] [section_0_bytes][section_1_bytes]...
       const char* pos = encoding.data() + kEncodingPrefixSize;
       const uint8_t splitCount = encoding::read<uint8_t>(pos);
       encoding::read<uint8_t>(pos); // reserved
@@ -419,7 +422,9 @@ EncodingLayout EncodingLayoutCapture::capture(std::string_view encoding) {
               detail::subintsplit::makePreserveSplitConfig(boundaryPlans)},
           compressionType,
           std::move(children)};
+      break;
     }
+#endif
     case EncodingType::Nullable: {
       const char* pos = encoding.data() + kEncodingPrefixSize;
       const uint32_t dataBytes = encoding::readUint32(pos);

--- a/dwio/nimble/encodings/common/EncodingLayout.h
+++ b/dwio/nimble/encodings/common/EncodingLayout.h
@@ -39,6 +39,10 @@ class EncodingLayout {
     /// Returns a config value for the given key, or std::nullopt if not found.
     std::optional<std::string> get(const std::string& key) const;
 
+    const std::unordered_map<std::string, std::string>& values() const {
+      return configs_;
+    }
+
    private:
     std::unordered_map<std::string, std::string> configs_;
   };

--- a/dwio/nimble/encodings/common/EncodingUtils.h
+++ b/dwio/nimble/encodings/common/EncodingUtils.h
@@ -125,12 +125,14 @@ auto encodingTypeDispatchNonString(Encoding& encoding, F&& f) {
       return f(static_cast<MainlyConstantEncoding<T>&>(encoding));
     case EncodingType::Delta:
       return f(static_cast<DeltaEncoding<T>&>(encoding));
+#ifdef NIMBLE_ENABLE_EXPERIMENTAL_ENCODINGS
     case EncodingType::SubIntSplit:
       if constexpr (isNumericType<T>() && sizeof(T) >= 4) {
         return f(static_cast<SubIntSplitEncoding<T>&>(encoding));
       } else {
         NIMBLE_UNREACHABLE(toString(encoding.dataType()));
       }
+#endif
     default:
       NIMBLE_UNSUPPORTED("{}", encoding.encodingType());
   }

--- a/dwio/nimble/encodings/common/EncodingUtils.h
+++ b/dwio/nimble/encodings/common/EncodingUtils.h
@@ -24,6 +24,7 @@
 #include "dwio/nimble/encodings/PrefixEncoding.h"
 #include "dwio/nimble/encodings/RleEncoding.h"
 #include "dwio/nimble/encodings/SparseBoolEncoding.h"
+#include "dwio/nimble/encodings/SubIntSplitEncoding.h"
 #include "dwio/nimble/encodings/TrivialEncoding.h"
 #include "dwio/nimble/encodings/VarintEncoding.h"
 
@@ -124,6 +125,12 @@ auto encodingTypeDispatchNonString(Encoding& encoding, F&& f) {
       return f(static_cast<MainlyConstantEncoding<T>&>(encoding));
     case EncodingType::Delta:
       return f(static_cast<DeltaEncoding<T>&>(encoding));
+    case EncodingType::SubIntSplit:
+      if constexpr (isNumericType<T>() && sizeof(T) >= 4) {
+        return f(static_cast<SubIntSplitEncoding<T>&>(encoding));
+      } else {
+        NIMBLE_UNREACHABLE(toString(encoding.dataType()));
+      }
     default:
       NIMBLE_UNSUPPORTED("{}", encoding.encodingType());
   }

--- a/dwio/nimble/encodings/legacy/EncodingFactory.cpp
+++ b/dwio/nimble/encodings/legacy/EncodingFactory.cpp
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 #include "dwio/nimble/encodings/legacy/EncodingFactory.h"
+#include "dwio/nimble/encodings/SubIntSplitEncoding.h"
 #include "dwio/nimble/encodings/legacy/ConstantEncoding.h"
 #include "dwio/nimble/encodings/legacy/DeltaEncoding.h"
 #include "dwio/nimble/encodings/legacy/DictionaryEncoding.h"
@@ -239,6 +240,9 @@ std::unique_ptr<Encoding> EncodingFactory::create(
     }
     case EncodingType::Delta: {
       RETURN_ENCODING_BY_NUMERIC_TYPE(DeltaEncoding, dataType);
+    }
+    case EncodingType::SubIntSplit: {
+      RETURN_ENCODING_BY_VARINT_TYPE(SubIntSplitEncoding, dataType);
     }
     case EncodingType::Prefix: {
       NIMBLE_CHECK_EQ(

--- a/dwio/nimble/encodings/legacy/EncodingFactory.cpp
+++ b/dwio/nimble/encodings/legacy/EncodingFactory.cpp
@@ -241,9 +241,11 @@ std::unique_ptr<Encoding> EncodingFactory::create(
     case EncodingType::Delta: {
       RETURN_ENCODING_BY_NUMERIC_TYPE(DeltaEncoding, dataType);
     }
+#ifdef NIMBLE_ENABLE_EXPERIMENTAL_ENCODINGS
     case EncodingType::SubIntSplit: {
       RETURN_ENCODING_BY_VARINT_TYPE(SubIntSplitEncoding, dataType);
     }
+#endif
     case EncodingType::Prefix: {
       NIMBLE_CHECK_EQ(
           dataType,

--- a/dwio/nimble/encodings/legacy/EncodingUtils.h
+++ b/dwio/nimble/encodings/legacy/EncodingUtils.h
@@ -15,6 +15,7 @@
  */
 #pragma once
 
+#include "dwio/nimble/encodings/SubIntSplitEncoding.h"
 #include "dwio/nimble/encodings/common/EncodingUtils.h"
 #include "dwio/nimble/encodings/legacy/ConstantEncoding.h"
 #include "dwio/nimble/encodings/legacy/DeltaEncoding.h"
@@ -106,6 +107,15 @@ auto encodingTypeDispatchNonString(Encoding& encoding, F&& f) {
       return f(static_cast<MainlyConstantEncoding<T>&>(encoding));
     case EncodingType::Delta:
       return f(static_cast<DeltaEncoding<T>&>(encoding));
+    // SubIntSplit has no legacy counterpart; use the new encoding class
+    // directly (same Encoding base class).
+    case EncodingType::SubIntSplit:
+      if constexpr (isNumericType<T>() && (sizeof(T) == 4 || sizeof(T) == 8)) {
+        return f(
+            static_cast<::facebook::nimble::SubIntSplitEncoding<T>&>(encoding));
+      } else {
+        NIMBLE_UNREACHABLE(toString(encoding.dataType()));
+      }
     default:
       NIMBLE_UNSUPPORTED(toString(encoding.encodingType()));
   }

--- a/dwio/nimble/encodings/legacy/EncodingUtils.h
+++ b/dwio/nimble/encodings/legacy/EncodingUtils.h
@@ -107,8 +107,7 @@ auto encodingTypeDispatchNonString(Encoding& encoding, F&& f) {
       return f(static_cast<MainlyConstantEncoding<T>&>(encoding));
     case EncodingType::Delta:
       return f(static_cast<DeltaEncoding<T>&>(encoding));
-    // SubIntSplit has no legacy counterpart; use the new encoding class
-    // directly (same Encoding base class).
+#ifdef NIMBLE_ENABLE_EXPERIMENTAL_ENCODINGS
     case EncodingType::SubIntSplit:
       if constexpr (isNumericType<T>() && (sizeof(T) == 4 || sizeof(T) == 8)) {
         return f(
@@ -116,6 +115,7 @@ auto encodingTypeDispatchNonString(Encoding& encoding, F&& f) {
       } else {
         NIMBLE_UNREACHABLE(toString(encoding.dataType()));
       }
+#endif
     default:
       NIMBLE_UNSUPPORTED(toString(encoding.encodingType()));
   }

--- a/dwio/nimble/encodings/selection/EncodingIdentifier.h
+++ b/dwio/nimble/encodings/selection/EncodingIdentifier.h
@@ -57,6 +57,13 @@ struct EncodingIdentifiers {
     static constexpr NestedEncodingIdentifier Restatements = 1;
     static constexpr NestedEncodingIdentifier IsRestatements = 2;
   };
+
+  struct SubIntSplit {
+    // Section identifiers equal the section index (0..splitCount-1).
+    // Maximum 64 sections (one per bit of a 64-bit integer).
+    // The identifier is written directly as section_index, so no named
+    // constants are defined here; callers use the index directly.
+  };
 };
 
 } // namespace facebook::nimble

--- a/dwio/nimble/encodings/selection/EncodingSelectionPolicy.h
+++ b/dwio/nimble/encodings/selection/EncodingSelectionPolicy.h
@@ -382,6 +382,7 @@ class ManualEncodingSelectionPolicyFactory {
         EncodingType::Dictionary,
         EncodingType::RLE,
         EncodingType::Varint,
+        EncodingType::SubIntSplit,
     };
   }
 
@@ -395,6 +396,14 @@ class ManualEncodingSelectionPolicyFactory {
         {EncodingType::Dictionary, 1.0},
         {EncodingType::RLE, 1.0},
         {EncodingType::Varint, 1.0},
+        // SubIntSplit decomposes structured wide integers into bit-range
+        // sub-streams; each section is encoded independently. The read factor
+        // is slightly higher than Trivial (0.7) to reflect the extra OR-combine
+        // work at decode time, but lower than FixedBitWidth (0.9) to signal
+        // preference when the range filter in estimateSize passes.
+        // estimateSize returns nullopt for random-looking data (range ≥ 3/4 of
+        // type width), so SubIntSplit is only considered for structured values.
+        {EncodingType::SubIntSplit, 0.85},
     };
   }
 

--- a/dwio/nimble/encodings/selection/EncodingSelectionPolicy.h
+++ b/dwio/nimble/encodings/selection/EncodingSelectionPolicy.h
@@ -382,7 +382,9 @@ class ManualEncodingSelectionPolicyFactory {
         EncodingType::Dictionary,
         EncodingType::RLE,
         EncodingType::Varint,
+#ifdef NIMBLE_ENABLE_EXPERIMENTAL_ENCODINGS
         EncodingType::SubIntSplit,
+#endif
     };
   }
 
@@ -396,14 +398,9 @@ class ManualEncodingSelectionPolicyFactory {
         {EncodingType::Dictionary, 1.0},
         {EncodingType::RLE, 1.0},
         {EncodingType::Varint, 1.0},
-        // SubIntSplit decomposes structured wide integers into bit-range
-        // sub-streams; each section is encoded independently. The read factor
-        // is slightly higher than Trivial (0.7) to reflect the extra OR-combine
-        // work at decode time, but lower than FixedBitWidth (0.9) to signal
-        // preference when the range filter in estimateSize passes.
-        // estimateSize returns nullopt for random-looking data (range ≥ 3/4 of
-        // type width), so SubIntSplit is only considered for structured values.
+#ifdef NIMBLE_ENABLE_EXPERIMENTAL_ENCODINGS
         {EncodingType::SubIntSplit, 0.85},
+#endif
     };
   }
 

--- a/dwio/nimble/encodings/selection/EncodingSizeEstimation.h
+++ b/dwio/nimble/encodings/selection/EncodingSizeEstimation.h
@@ -17,6 +17,7 @@
 
 #include <glog/logging.h>
 #include <algorithm>
+#include <cmath>
 #include <optional>
 #include "dwio/nimble/common/Exceptions.h"
 #include "dwio/nimble/common/FixedBitArray.h"
@@ -147,6 +148,49 @@ struct EncodingSizeEstimation {
               });
           return getEncodingOverhead<EncodingType::Varint, physicalType>() +
               dataSize;
+        } else {
+          return std::nullopt;
+        }
+      }
+      case EncodingType::SubIntSplit: {
+        // Heuristic estimate — EncodingSizeEstimation only has Statistics, not
+        // raw values, so we cannot run the DP here without either re-reading
+        // the data or adding a raw-data accessor to Statistics. Instead, we
+        // use the FixedBitWidth estimate as a conservative proxy: SubIntSplit
+        // can do at least as well as FixedBitWidth and often better (constant
+        // bit ranges become free; low-cardinality ranges get Dictionary). We
+        // apply a small discount to make SubIntSplit a genuine competitor so
+        // the policy will actually try it. The actual DP runs at encode time.
+        //
+        // Filter: if the observed range already fills ≥ 3/4 of the type's bit
+        // width, the values look random and SubIntSplit is unlikely to help —
+        // skip it to avoid wasting encode-time DP work on unstructured data.
+        if constexpr (
+            isNumericType<physicalType>() &&
+            (sizeof(physicalType) == 4 || sizeof(physicalType) == 8)) {
+          constexpr uint64_t kTypeWidthBits =
+              static_cast<uint64_t>(sizeof(physicalType)) * 8u;
+          const uint64_t rangeBits =
+              velox::bits::bitsRequired(statistics.max() - statistics.min());
+          if (rangeBits > (kTypeWidthBits * 3) / 4) {
+            // Full-range data: SubIntSplit won't improve over FixedBitWidth.
+            return std::nullopt;
+          }
+          const auto fbwEst = estimateNumericSize(
+              EncodingType::FixedBitWidth, entryCount, statistics);
+          if (!fbwEst.has_value()) {
+            return std::nullopt;
+          }
+          // Conservative overhead: prefix(6) + splitCount(1) + reserved(1) +
+          // 4 section headers (6 B each) + ~8 B per nested encoding header.
+          constexpr uint64_t kOverheadBytes = 6u + 2u + 4u * 6u + 4u * 8u;
+          // Apply a 10% discount on the FixedBitWidth estimate to signal that
+          // SubIntSplit can compress constant/low-cardinality ranges for free.
+          const uint64_t estimate =
+              static_cast<uint64_t>(
+                  static_cast<double>(fbwEst.value()) * 0.90) +
+              kOverheadBytes;
+          return estimate;
         } else {
           return std::nullopt;
         }

--- a/dwio/nimble/encodings/selection/EncodingSizeEstimation.h
+++ b/dwio/nimble/encodings/selection/EncodingSizeEstimation.h
@@ -152,19 +152,8 @@ struct EncodingSizeEstimation {
           return std::nullopt;
         }
       }
+#ifdef NIMBLE_ENABLE_EXPERIMENTAL_ENCODINGS
       case EncodingType::SubIntSplit: {
-        // Heuristic estimate — EncodingSizeEstimation only has Statistics, not
-        // raw values, so we cannot run the DP here without either re-reading
-        // the data or adding a raw-data accessor to Statistics. Instead, we
-        // use the FixedBitWidth estimate as a conservative proxy: SubIntSplit
-        // can do at least as well as FixedBitWidth and often better (constant
-        // bit ranges become free; low-cardinality ranges get Dictionary). We
-        // apply a small discount to make SubIntSplit a genuine competitor so
-        // the policy will actually try it. The actual DP runs at encode time.
-        //
-        // Filter: if the observed range already fills ≥ 3/4 of the type's bit
-        // width, the values look random and SubIntSplit is unlikely to help —
-        // skip it to avoid wasting encode-time DP work on unstructured data.
         if constexpr (
             isNumericType<physicalType>() &&
             (sizeof(physicalType) == 4 || sizeof(physicalType) == 8)) {
@@ -173,7 +162,6 @@ struct EncodingSizeEstimation {
           const uint64_t rangeBits =
               velox::bits::bitsRequired(statistics.max() - statistics.min());
           if (rangeBits > (kTypeWidthBits * 3) / 4) {
-            // Full-range data: SubIntSplit won't improve over FixedBitWidth.
             return std::nullopt;
           }
           const auto fbwEst = estimateNumericSize(
@@ -181,11 +169,7 @@ struct EncodingSizeEstimation {
           if (!fbwEst.has_value()) {
             return std::nullopt;
           }
-          // Conservative overhead: prefix(6) + splitCount(1) + reserved(1) +
-          // 4 section headers (6 B each) + ~8 B per nested encoding header.
           constexpr uint64_t kOverheadBytes = 6u + 2u + 4u * 6u + 4u * 8u;
-          // Apply a 10% discount on the FixedBitWidth estimate to signal that
-          // SubIntSplit can compress constant/low-cardinality ranges for free.
           const uint64_t estimate =
               static_cast<uint64_t>(
                   static_cast<double>(fbwEst.value()) * 0.90) +
@@ -195,6 +179,7 @@ struct EncodingSizeEstimation {
           return std::nullopt;
         }
       }
+#endif
       default: {
         return std::nullopt;
       }

--- a/dwio/nimble/encodings/tests/ConstantEncodingTest.cpp
+++ b/dwio/nimble/encodings/tests/ConstantEncodingTest.cpp
@@ -23,6 +23,7 @@
 #include "dwio/nimble/encodings/tests/TestUtils.h"
 
 #include <limits>
+#include <type_traits>
 #include <vector>
 
 using namespace facebook;

--- a/dwio/nimble/encodings/tests/DeltaEncodingTest.cpp
+++ b/dwio/nimble/encodings/tests/DeltaEncodingTest.cpp
@@ -17,6 +17,7 @@
 #include <gtest/gtest.h>
 #include <array>
 #include <limits>
+#include <type_traits>
 #include <vector>
 #include "dwio/nimble/common/Buffer.h"
 #include "dwio/nimble/common/Exceptions.h"
@@ -51,96 +52,73 @@ class DeltaEncodingTest : public ::testing::Test {
 
   template <typename T>
   std::vector<nimble::Vector<T>> prepareValues() {
-    FAIL() << "unspecialized prepareValues() should not be called";
-    return {};
-  }
-
-  template <>
-  std::vector<nimble::Vector<int32_t>> prepareValues() {
-    return {
-        // Monotonically increasing — all deltas, no restatements.
-        toVector({1, 2, 3, 4, 5, 6, 7, 8, 9, 10}),
-        // Non-monotonic — triggers restatements on decrease.
-        toVector({1, 2, 4, 1, 2, 3, 4, 1, 2, 4, 8, 8}),
-        // Single element.
-        toVector({42}),
-        // Constant — all same values, deltas are all 0.
-        toVector({5, 5, 5, 5, 5}),
-        // Signed: negative to positive — triggers zero-crossing restatement.
-        toVector({-5, -3, -1, 2, 4, 6}),
-        // Signed: all negative, increasing (toward zero).
-        toVector({-10, -8, -6, -4, -2}),
-        // Signed: decreasing from positive to negative.
-        toVector({5, 3, 1, -1, -3, -5}),
-        // Large gaps.
-        toVector({0, 1000, 2000, 3000, 100, 200, 300}),
-    };
-  }
-
-  template <>
-  std::vector<nimble::Vector<uint32_t>> prepareValues() {
-    return {
-        // Monotonically increasing.
-        toVector<uint32_t>({1, 2, 3, 4, 5, 6, 7, 8, 9, 10}),
-        // Non-monotonic.
-        toVector<uint32_t>({10, 20, 30, 5, 15, 25}),
-        // Single element.
-        toVector<uint32_t>({99}),
-        // Constant.
-        toVector<uint32_t>({7, 7, 7, 7}),
-    };
-  }
-
-  template <>
-  std::vector<nimble::Vector<int64_t>> prepareValues() {
-    return {
-        // Monotonically increasing.
-        toVector<int64_t>({100, 200, 300, 400, 500}),
-        // Non-monotonic with restatements.
-        toVector<int64_t>({100, 200, 50, 150, 250}),
-        // Signed zero-crossing.
-        toVector<int64_t>({-100, -50, 0, 50, 100}),
-    };
-  }
-
-  template <>
-  std::vector<nimble::Vector<uint64_t>> prepareValues() {
-    return {
-        toVector<uint64_t>({10, 20, 30, 40, 50}),
-        toVector<uint64_t>({100, 200, 50, 75, 300}),
-    };
-  }
-
-  template <>
-  std::vector<nimble::Vector<int16_t>> prepareValues() {
-    return {
-        toVector<int16_t>({1, 2, 3, 4, 5}),
-        toVector<int16_t>({5, 3, 1, -1, -3}),
-    };
-  }
-
-  template <>
-  std::vector<nimble::Vector<uint16_t>> prepareValues() {
-    return {
-        toVector<uint16_t>({1, 2, 3, 4, 5}),
-        toVector<uint16_t>({10, 5, 15, 3, 20}),
-    };
-  }
-
-  template <>
-  std::vector<nimble::Vector<int8_t>> prepareValues() {
-    return {
-        toVector<int8_t>({1, 2, 3, 4, 5}),
-        toVector<int8_t>({-5, -3, -1, 1, 3}),
-    };
-  }
-
-  template <>
-  std::vector<nimble::Vector<uint8_t>> prepareValues() {
-    return {
-        toVector<uint8_t>({1, 2, 3, 4, 5}),
-        toVector<uint8_t>({10, 5, 15, 3, 20}),
-    };
+    if constexpr (std::is_same_v<T, int32_t>) {
+      return {
+          // Monotonically increasing — all deltas, no restatements.
+          toVector({1, 2, 3, 4, 5, 6, 7, 8, 9, 10}),
+          // Non-monotonic — triggers restatements on decrease.
+          toVector({1, 2, 4, 1, 2, 3, 4, 1, 2, 4, 8, 8}),
+          // Single element.
+          toVector({42}),
+          // Constant — all same values, deltas are all 0.
+          toVector({5, 5, 5, 5, 5}),
+          // Signed: negative to positive — triggers zero-crossing restatement.
+          toVector({-5, -3, -1, 2, 4, 6}),
+          // Signed: all negative, increasing (toward zero).
+          toVector({-10, -8, -6, -4, -2}),
+          // Signed: decreasing from positive to negative.
+          toVector({5, 3, 1, -1, -3, -5}),
+          // Large gaps.
+          toVector({0, 1000, 2000, 3000, 100, 200, 300}),
+      };
+    } else if constexpr (std::is_same_v<T, uint32_t>) {
+      return {
+          // Monotonically increasing.
+          toVector<uint32_t>({1, 2, 3, 4, 5, 6, 7, 8, 9, 10}),
+          // Non-monotonic.
+          toVector<uint32_t>({10, 20, 30, 5, 15, 25}),
+          // Single element.
+          toVector<uint32_t>({99}),
+          // Constant.
+          toVector<uint32_t>({7, 7, 7, 7}),
+      };
+    } else if constexpr (std::is_same_v<T, int64_t>) {
+      return {
+          // Monotonically increasing.
+          toVector<int64_t>({100, 200, 300, 400, 500}),
+          // Non-monotonic with restatements.
+          toVector<int64_t>({100, 200, 50, 150, 250}),
+          // Signed zero-crossing.
+          toVector<int64_t>({-100, -50, 0, 50, 100}),
+      };
+    } else if constexpr (std::is_same_v<T, uint64_t>) {
+      return {
+          toVector<uint64_t>({10, 20, 30, 40, 50}),
+          toVector<uint64_t>({100, 200, 50, 75, 300}),
+      };
+    } else if constexpr (std::is_same_v<T, int16_t>) {
+      return {
+          toVector<int16_t>({1, 2, 3, 4, 5}),
+          toVector<int16_t>({5, 3, 1, -1, -3}),
+      };
+    } else if constexpr (std::is_same_v<T, uint16_t>) {
+      return {
+          toVector<uint16_t>({1, 2, 3, 4, 5}),
+          toVector<uint16_t>({10, 5, 15, 3, 20}),
+      };
+    } else if constexpr (std::is_same_v<T, int8_t>) {
+      return {
+          toVector<int8_t>({1, 2, 3, 4, 5}),
+          toVector<int8_t>({-5, -3, -1, 1, 3}),
+      };
+    } else if constexpr (std::is_same_v<T, uint8_t>) {
+      return {
+          toVector<uint8_t>({1, 2, 3, 4, 5}),
+          toVector<uint8_t>({10, 5, 15, 3, 20}),
+      };
+    } else {
+      static_assert(!std::is_same_v<T, T>, "Unsupported test type");
+    }
   }
 
   std::shared_ptr<velox::memory::MemoryPool> pool_;

--- a/dwio/nimble/encodings/tests/EncodingLayoutTest.cpp
+++ b/dwio/nimble/encodings/tests/EncodingLayoutTest.cpp
@@ -16,7 +16,9 @@
 #include <gtest/gtest.h>
 #include "dwio/nimble/common/Buffer.h"
 #include "dwio/nimble/common/Exceptions.h"
+#ifdef NIMBLE_ENABLE_EXPERIMENTAL_ENCODINGS
 #include "dwio/nimble/encodings/SubIntSplitConfig.h"
+#endif
 #include "dwio/nimble/encodings/selection/EncodingSelectionPolicy.h"
 #include "dwio/nimble/tools/EncodingUtilities.h"
 #include "velox/common/memory/Memory.h"
@@ -78,6 +80,7 @@ void testCapture(nimble::EncodingLayout expected, TCollection data) {
   verifyEncodingLayout(expected, actual);
 }
 
+#ifdef NIMBLE_ENABLE_EXPERIMENTAL_ENCODINGS
 template <typename T>
 class ForceSubIntSplitPolicy final : public nimble::EncodingSelectionPolicy<T> {
   using physicalType = typename nimble::TypeTraits<T>::physicalType;
@@ -106,6 +109,7 @@ class ForceSubIntSplitPolicy final : public nimble::EncodingSelectionPolicy<T> {
     return factory.createPolicy(type);
   }
 };
+#endif
 
 } // namespace
 
@@ -359,6 +363,7 @@ TEST(EncodingLayoutTests, Nullable) {
       actual.first);
 }
 
+#ifdef NIMBLE_ENABLE_EXPERIMENTAL_ENCODINGS
 // SubIntSplitEncoding layout tests -------------------------------------------
 
 // Verify that an EncodingLayout tree with a SubIntSplit root and two named
@@ -561,6 +566,7 @@ TEST(EncodingLayoutTests, SubIntSplitPreserveBoundariesReplay) {
   EXPECT_EQ(*replayedMode, nimble::detail::subintsplit::kSplitModePreserve);
   EXPECT_EQ(*replayedBoundaries, preserveBoundaries);
 }
+#endif
 
 TEST(EncodingLayoutTests, SizeTooSmall) {
   {

--- a/dwio/nimble/encodings/tests/EncodingLayoutTest.cpp
+++ b/dwio/nimble/encodings/tests/EncodingLayoutTest.cpp
@@ -1,7 +1,6 @@
 /*
  * Copyright (c) Meta Platforms, Inc. and affiliates.
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
@@ -15,8 +14,14 @@
  */
 #include "dwio/nimble/encodings/common/EncodingLayout.h"
 #include <gtest/gtest.h>
+#include "dwio/nimble/common/Buffer.h"
 #include "dwio/nimble/common/Exceptions.h"
+#include "dwio/nimble/encodings/SubIntSplitConfig.h"
 #include "dwio/nimble/encodings/selection/EncodingSelectionPolicy.h"
+#include "dwio/nimble/tools/EncodingUtilities.h"
+#include "velox/common/memory/Memory.h"
+
+#include <unordered_map>
 
 using namespace facebook;
 
@@ -72,6 +77,35 @@ void testCapture(nimble::EncodingLayout expected, TCollection data) {
   auto actual = nimble::EncodingLayoutCapture::capture(encoding);
   verifyEncodingLayout(expected, actual);
 }
+
+template <typename T>
+class ForceSubIntSplitPolicy final : public nimble::EncodingSelectionPolicy<T> {
+  using physicalType = typename nimble::TypeTraits<T>::physicalType;
+
+ public:
+  nimble::EncodingSelectionResult select(
+      std::span<const physicalType> /* values */,
+      const nimble::Statistics<physicalType>& /* statistics */) override {
+    return {.encodingType = nimble::EncodingType::SubIntSplit};
+  }
+
+  nimble::EncodingSelectionResult selectNullable(
+      std::span<const physicalType> /* values */,
+      std::span<const bool> /* nulls */,
+      const nimble::Statistics<physicalType>& /* statistics */) override {
+    return {.encodingType = nimble::EncodingType::Nullable};
+  }
+
+  std::unique_ptr<nimble::EncodingSelectionPolicyBase> createImpl(
+      nimble::EncodingType /* encodingType */,
+      nimble::NestedEncodingIdentifier /* identifier */,
+      nimble::DataType type) override {
+    nimble::ManualEncodingSelectionPolicyFactory factory{
+        nimble::ManualEncodingSelectionPolicyFactory::defaultReadFactors(),
+        std::nullopt};
+    return factory.createPolicy(type);
+  }
+};
 
 } // namespace
 
@@ -323,6 +357,209 @@ TEST(EncodingLayoutTests, Nullable) {
   verifyEncodingLayout(
       expected.child(nimble::EncodingIdentifiers::Nullable::Data),
       actual.first);
+}
+
+// SubIntSplitEncoding layout tests -------------------------------------------
+
+// Verify that an EncodingLayout tree with a SubIntSplit root and two named
+// child sections can be serialized and deserialized correctly.
+TEST(EncodingLayoutTests, SubIntSplitSerialization) {
+  nimble::EncodingLayout layout{
+      nimble::EncodingType::SubIntSplit,
+      {},
+      nimble::CompressionType::Uncompressed,
+      {
+          // section 0: lower bits — typically FixedBitWidth or Trivial
+          nimble::EncodingLayout{
+              nimble::EncodingType::FixedBitWidth,
+              {},
+              nimble::CompressionType::Uncompressed},
+          // section 1: upper bits — often Constant for structured IDs
+          nimble::EncodingLayout{
+              nimble::EncodingType::Constant,
+              {},
+              nimble::CompressionType::Uncompressed},
+      }};
+
+  testSerialization(layout);
+
+  // Three sections
+  nimble::EncodingLayout layout3{
+      nimble::EncodingType::SubIntSplit,
+      {},
+      nimble::CompressionType::Uncompressed,
+      {
+          nimble::EncodingLayout{
+              nimble::EncodingType::Trivial,
+              {},
+              nimble::CompressionType::Uncompressed},
+          nimble::EncodingLayout{
+              nimble::EncodingType::Dictionary,
+              {},
+              nimble::CompressionType::Uncompressed,
+              {
+                  nimble::EncodingLayout{
+                      nimble::EncodingType::Trivial,
+                      {},
+                      nimble::CompressionType::Uncompressed},
+                  nimble::EncodingLayout{
+                      nimble::EncodingType::FixedBitWidth,
+                      {},
+                      nimble::CompressionType::Uncompressed},
+              }},
+          nimble::EncodingLayout{
+              nimble::EncodingType::Constant,
+              {},
+              nimble::CompressionType::Uncompressed},
+      }};
+
+  testSerialization(layout3);
+}
+
+// Verify that EncodingLayoutCapture correctly reads the SubIntSplit binary
+// format and that the captured tree round-trips through serialize/deserialize.
+TEST(EncodingLayoutTests, SubIntSplitCapture) {
+  nimble::EncodingSelectionPolicyFactory encodingSelectionPolicyFactory =
+      [encodingFactory = nimble::ManualEncodingSelectionPolicyFactory{}](
+          nimble::DataType dataType)
+      -> std::unique_ptr<nimble::EncodingSelectionPolicyBase> {
+    return encodingFactory.createPolicy(dataType);
+  };
+
+  auto defaultPool = velox::memory::deprecatedAddDefaultLeafMemoryPool();
+  nimble::Buffer buffer{*defaultPool};
+
+  // Structured int64 values: upper 40 bits are a fixed datacenter/timestamp
+  // prefix; lower 24 bits are a monotone counter. This should trigger
+  // SubIntSplit selection (range << typeWidth) and produce a multi-section
+  // encoding where the upper section is Constant or FixedBitWidth with small
+  // range and the lower section is FixedBitWidth or Trivial.
+  std::vector<int64_t> data;
+  data.reserve(300);
+  for (int64_t i = 0; i < 300; ++i) {
+    data.push_back(static_cast<int64_t>(0x1234567890000000LL) | i);
+  }
+
+  auto encoding = nimble::EncodingFactory::encode<int64_t>(
+      std::make_unique<ForceSubIntSplitPolicy<int64_t>>(), data, buffer);
+
+  // Capture must succeed and not throw.
+  auto captured = nimble::EncodingLayoutCapture::capture(encoding);
+  ASSERT_EQ(captured.encodingType(), nimble::EncodingType::SubIntSplit);
+  ASSERT_GT(captured.childrenCount(), 0u);
+  EXPECT_EQ(
+      captured.config().get(
+          std::string(nimble::detail::subintsplit::kSplitModeConfigKey)),
+      nimble::detail::subintsplit::kSplitModePreserve);
+  ASSERT_TRUE(
+      captured.config()
+          .get(
+              std::string(
+                  nimble::detail::subintsplit::kSplitBoundariesConfigKey))
+          .has_value());
+
+  // The encoded stream must round-trip through the encoding factory.
+  auto decoded = nimble::EncodingFactory().create(
+      *defaultPool, encoding, [](uint32_t) { return nullptr; });
+  nimble::Vector<int64_t> decodedValues{defaultPool.get()};
+  decodedValues.resize(data.size());
+  decoded->materialize(data.size(), decodedValues.data());
+  for (size_t i = 0; i < data.size(); ++i) {
+    EXPECT_EQ(data[i], decodedValues[i]) << i;
+  }
+
+  std::vector<nimble::EncodingType> traversedTypes;
+  nimble::tools::traverseEncodings(
+      encoding,
+      [&](nimble::EncodingType encodingType,
+          nimble::DataType dataType,
+          uint32_t level,
+          uint32_t /* index */,
+          std::string nestedEncodingName,
+          std::unordered_map<
+              nimble::tools::EncodingPropertyType,
+              nimble::tools::EncodingProperty> /* properties */) {
+        if (level == 0) {
+          EXPECT_EQ(encodingType, nimble::EncodingType::SubIntSplit);
+          EXPECT_EQ(dataType, nimble::DataType::Int64);
+          EXPECT_TRUE(nestedEncodingName.empty());
+        }
+        traversedTypes.push_back(encodingType);
+        return true;
+      });
+  ASSERT_GE(traversedTypes.size(), 2u);
+
+  // The captured layout must round-trip through serialize → deserialize.
+  std::string output(4096, '\0');
+  const auto serializedSize = captured.serialize(output);
+  ASSERT_GT(serializedSize, 0);
+  auto [deserialized, bytesRead] = nimble::EncodingLayout::create(
+      {output.data(), static_cast<size_t>(serializedSize)});
+  verifyEncodingLayout(captured, deserialized);
+  auto preserveMode = deserialized.config().get(
+      std::string(nimble::detail::subintsplit::kSplitModeConfigKey));
+  ASSERT_TRUE(preserveMode.has_value());
+  EXPECT_EQ(*preserveMode, nimble::detail::subintsplit::kSplitModePreserve);
+
+  auto deserializedBoundaries = deserialized.config().get(
+      std::string(nimble::detail::subintsplit::kSplitBoundariesConfigKey));
+  auto capturedBoundaries = captured.config().get(
+      std::string(nimble::detail::subintsplit::kSplitBoundariesConfigKey));
+  ASSERT_TRUE(deserializedBoundaries.has_value());
+  ASSERT_TRUE(capturedBoundaries.has_value());
+  EXPECT_EQ(*deserializedBoundaries, *capturedBoundaries);
+
+  // Each child must be non-nullopt (all sections were encoded).
+  for (nimble::NestedEncodingIdentifier id = 0; id < captured.childrenCount();
+       ++id) {
+    EXPECT_TRUE(captured.child(id).has_value());
+  }
+}
+
+TEST(EncodingLayoutTests, SubIntSplitPreserveBoundariesReplay) {
+  nimble::EncodingSelectionPolicyFactory encodingSelectionPolicyFactory =
+      [encodingFactory = nimble::ManualEncodingSelectionPolicyFactory{}](
+          nimble::DataType dataType)
+      -> std::unique_ptr<nimble::EncodingSelectionPolicyBase> {
+    return encodingFactory.createPolicy(dataType);
+  };
+
+  auto defaultPool = velox::memory::deprecatedAddDefaultLeafMemoryPool();
+  nimble::Buffer buffer{*defaultPool};
+
+  std::vector<int64_t> data;
+  data.reserve(300);
+  for (int64_t i = 0; i < 300; ++i) {
+    data.push_back(static_cast<int64_t>(0x1234567890000000LL) | i);
+  }
+
+  const std::string preserveBoundaries = "0-15;16-47;48-63";
+  nimble::EncodingLayout preserveLayout{
+      nimble::EncodingType::SubIntSplit,
+      nimble::EncodingLayout::Config{
+          {{std::string(nimble::detail::subintsplit::kSplitModeConfigKey),
+            std::string(nimble::detail::subintsplit::kSplitModePreserve)},
+           {std::string(nimble::detail::subintsplit::kSplitBoundariesConfigKey),
+            preserveBoundaries}}},
+      nimble::CompressionType::Uncompressed,
+      {std::nullopt, std::nullopt, std::nullopt}};
+
+  auto encoding = nimble::EncodingFactory::encode<int64_t>(
+      std::make_unique<nimble::ReplayedEncodingSelectionPolicy<int64_t>>(
+          preserveLayout, std::nullopt, encodingSelectionPolicyFactory),
+      data,
+      buffer);
+
+  auto captured = nimble::EncodingLayoutCapture::capture(encoding);
+  ASSERT_EQ(captured.encodingType(), nimble::EncodingType::SubIntSplit);
+  auto replayedMode = captured.config().get(
+      std::string(nimble::detail::subintsplit::kSplitModeConfigKey));
+  auto replayedBoundaries = captured.config().get(
+      std::string(nimble::detail::subintsplit::kSplitBoundariesConfigKey));
+  ASSERT_TRUE(replayedMode.has_value());
+  ASSERT_TRUE(replayedBoundaries.has_value());
+  EXPECT_EQ(*replayedMode, nimble::detail::subintsplit::kSplitModePreserve);
+  EXPECT_EQ(*replayedBoundaries, preserveBoundaries);
 }
 
 TEST(EncodingLayoutTests, SizeTooSmall) {

--- a/dwio/nimble/encodings/tests/EncodingLegacyTest.cpp
+++ b/dwio/nimble/encodings/tests/EncodingLegacyTest.cpp
@@ -133,6 +133,57 @@ class TestTrivialEncodingSelectionPolicy
   bool shouldCompress_;
   bool useVariableBitWidthCompressor_;
 };
+
+template <typename Encoding>
+struct EncodingTypeTraits;
+
+template <typename T>
+struct EncodingTypeTraits<nimble::legacy::ConstantEncoding<T>> {
+  static constexpr inline nimble::EncodingType encodingType =
+      nimble::EncodingType::Constant;
+};
+
+template <typename T>
+struct EncodingTypeTraits<nimble::legacy::DictionaryEncoding<T>> {
+  static constexpr inline nimble::EncodingType encodingType =
+      nimble::EncodingType::Dictionary;
+};
+
+template <typename T>
+struct EncodingTypeTraits<nimble::legacy::FixedBitWidthEncoding<T>> {
+  static constexpr inline nimble::EncodingType encodingType =
+      nimble::EncodingType::FixedBitWidth;
+};
+
+template <typename T>
+struct EncodingTypeTraits<nimble::legacy::MainlyConstantEncoding<T>> {
+  static constexpr inline nimble::EncodingType encodingType =
+      nimble::EncodingType::MainlyConstant;
+};
+
+template <typename T>
+struct EncodingTypeTraits<nimble::legacy::RLEEncoding<T>> {
+  static constexpr inline nimble::EncodingType encodingType =
+      nimble::EncodingType::RLE;
+};
+
+template <>
+struct EncodingTypeTraits<nimble::legacy::SparseBoolEncoding> {
+  static constexpr inline nimble::EncodingType encodingType =
+      nimble::EncodingType::SparseBool;
+};
+
+template <typename T>
+struct EncodingTypeTraits<nimble::legacy::TrivialEncoding<T>> {
+  static constexpr inline nimble::EncodingType encodingType =
+      nimble::EncodingType::Trivial;
+};
+
+template <typename T>
+struct EncodingTypeTraits<nimble::legacy::VarintEncoding<T>> {
+  static constexpr inline nimble::EncodingType encodingType =
+      nimble::EncodingType::Varint;
+};
 } // namespace
 // C is the encoding type.
 template <typename C>

--- a/dwio/nimble/encodings/tests/EncodingTest.cpp
+++ b/dwio/nimble/encodings/tests/EncodingTest.cpp
@@ -138,6 +138,57 @@ class TestTrivialEncodingSelectionPolicy
   bool useVariableBitWidthCompressor_;
 };
 
+template <typename Encoding>
+struct EncodingTypeTraits;
+
+template <typename T>
+struct EncodingTypeTraits<nimble::ConstantEncoding<T>> {
+  static constexpr inline nimble::EncodingType encodingType =
+      nimble::EncodingType::Constant;
+};
+
+template <typename T>
+struct EncodingTypeTraits<nimble::DictionaryEncoding<T>> {
+  static constexpr inline nimble::EncodingType encodingType =
+      nimble::EncodingType::Dictionary;
+};
+
+template <typename T>
+struct EncodingTypeTraits<nimble::FixedBitWidthEncoding<T>> {
+  static constexpr inline nimble::EncodingType encodingType =
+      nimble::EncodingType::FixedBitWidth;
+};
+
+template <typename T>
+struct EncodingTypeTraits<nimble::MainlyConstantEncoding<T>> {
+  static constexpr inline nimble::EncodingType encodingType =
+      nimble::EncodingType::MainlyConstant;
+};
+
+template <typename T>
+struct EncodingTypeTraits<nimble::RLEEncoding<T>> {
+  static constexpr inline nimble::EncodingType encodingType =
+      nimble::EncodingType::RLE;
+};
+
+template <>
+struct EncodingTypeTraits<nimble::SparseBoolEncoding> {
+  static constexpr inline nimble::EncodingType encodingType =
+      nimble::EncodingType::SparseBool;
+};
+
+template <typename T>
+struct EncodingTypeTraits<nimble::TrivialEncoding<T>> {
+  static constexpr inline nimble::EncodingType encodingType =
+      nimble::EncodingType::Trivial;
+};
+
+template <typename T>
+struct EncodingTypeTraits<nimble::VarintEncoding<T>> {
+  static constexpr inline nimble::EncodingType encodingType =
+      nimble::EncodingType::Varint;
+};
+
 } // namespace
 
 template <typename EncodingType, bool UseVarint>

--- a/dwio/nimble/encodings/tests/MainlyConstantEncodingTest.cpp
+++ b/dwio/nimble/encodings/tests/MainlyConstantEncodingTest.cpp
@@ -23,6 +23,7 @@
 #include "dwio/nimble/encodings/tests/TestUtils.h"
 
 #include <limits>
+#include <type_traits>
 #include <vector>
 
 using namespace facebook;

--- a/dwio/nimble/encodings/tests/RleEncodingTest.cpp
+++ b/dwio/nimble/encodings/tests/RleEncodingTest.cpp
@@ -23,6 +23,7 @@
 #include "dwio/nimble/encodings/tests/TestUtils.h"
 
 #include <limits>
+#include <type_traits>
 #include <vector>
 
 using namespace facebook;

--- a/dwio/nimble/encodings/tests/SubIntSplitEncodingTest.cpp
+++ b/dwio/nimble/encodings/tests/SubIntSplitEncodingTest.cpp
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+#ifdef NIMBLE_ENABLE_EXPERIMENTAL_ENCODINGS
+
 #include <algorithm>
 #include <bit>
 #include <string>
@@ -402,3 +404,5 @@ TEST(SubIntSplitEncodingTests, FullWidthSingleSectionRoundTrip) {
   const auto decoded = decodeAll<uint64_t>(encoded, *pool);
   expectBitwiseEqual(values, decoded);
 }
+
+#endif

--- a/dwio/nimble/encodings/tests/SubIntSplitEncodingTest.cpp
+++ b/dwio/nimble/encodings/tests/SubIntSplitEncodingTest.cpp
@@ -1,0 +1,404 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <algorithm>
+#include <bit>
+#include <string>
+#include <type_traits>
+
+#include <gtest/gtest.h>
+
+#include "dwio/nimble/common/Buffer.h"
+#include "dwio/nimble/common/Types.h"
+#include "dwio/nimble/encodings/SubIntSplitConfig.h"
+#include "dwio/nimble/encodings/common/EncodingFactory.h"
+#include "dwio/nimble/encodings/common/EncodingLayout.h"
+#include "dwio/nimble/encodings/common/EncodingType.h"
+#include "dwio/nimble/encodings/selection/EncodingSelectionPolicy.h"
+#include "velox/common/memory/Memory.h"
+
+using namespace facebook;
+
+namespace {
+
+template <typename T>
+using PhysicalType = typename nimble::TypeTraits<T>::physicalType;
+
+template <typename T>
+using UnsignedPhysicalType = std::make_unsigned_t<PhysicalType<T>>;
+
+template <typename T>
+std::vector<T> makeStructuredValues() {
+  std::vector<T> values;
+  values.reserve(300);
+
+  UnsignedPhysicalType<T> prefix{};
+  if constexpr (sizeof(PhysicalType<T>) == 4) {
+    prefix = static_cast<UnsignedPhysicalType<T>>(0x12340000u);
+  } else {
+    prefix = static_cast<UnsignedPhysicalType<T>>(0x1234567890000000ULL);
+  }
+
+  for (UnsignedPhysicalType<T> i = 0; i < 300; ++i) {
+    const auto bits = static_cast<UnsignedPhysicalType<T>>(prefix + i);
+    values.push_back(std::bit_cast<T>(bits));
+  }
+
+  return values;
+}
+
+template <typename T>
+std::vector<nimble::detail::subintsplit::SegmentPlan> makePreserveSegments() {
+  if constexpr (sizeof(PhysicalType<T>) == 4) {
+    return {{0, 7}, {8, 15}, {16, 31}};
+  } else {
+    return {{0, 7}, {8, 15}, {16, 31}, {32, 63}};
+  }
+}
+
+template <typename T>
+std::vector<nimble::detail::subintsplit::SegmentPlan> makeFullWidthSegments() {
+  return {{0, static_cast<int>(sizeof(PhysicalType<T>) * 8 - 1)}};
+}
+
+template <typename T>
+std::string_view encodeWithNonRecursiveSubIntSplit(
+    const std::vector<T>& values,
+    nimble::Buffer& buffer);
+
+nimble::EncodingSelectionPolicyFactory makeLeafPolicyFactory() {
+  return [](nimble::DataType type)
+             -> std::unique_ptr<nimble::EncodingSelectionPolicyBase> {
+    auto readFactors =
+        nimble::ManualEncodingSelectionPolicyFactory::defaultReadFactors();
+    readFactors.erase(
+        std::remove_if(
+            readFactors.begin(),
+            readFactors.end(),
+            [](const auto& factor) {
+              return factor.first == nimble::EncodingType::SubIntSplit;
+            }),
+        readFactors.end());
+    nimble::ManualEncodingSelectionPolicyFactory factory{
+        std::move(readFactors), std::nullopt};
+    return factory.createPolicy(type);
+  };
+}
+
+template <typename T>
+class NonRecursiveSubIntSplitPolicy final
+    : public nimble::EncodingSelectionPolicy<T> {
+  using physicalType = typename nimble::TypeTraits<T>::physicalType;
+
+ public:
+  nimble::EncodingSelectionResult select(
+      std::span<const physicalType> /* values */,
+      const nimble::Statistics<physicalType>& /* statistics */) override {
+    return {.encodingType = nimble::EncodingType::SubIntSplit};
+  }
+
+  nimble::EncodingSelectionResult selectNullable(
+      std::span<const physicalType> /* values */,
+      std::span<const bool> /* nulls */,
+      const nimble::Statistics<physicalType>& /* statistics */) override {
+    return {.encodingType = nimble::EncodingType::Nullable};
+  }
+
+  std::unique_ptr<nimble::EncodingSelectionPolicyBase> createImpl(
+      nimble::EncodingType /* encodingType */,
+      nimble::NestedEncodingIdentifier /* identifier */,
+      nimble::DataType type) override {
+    auto readFactors =
+        nimble::ManualEncodingSelectionPolicyFactory::defaultReadFactors();
+    readFactors.erase(
+        std::remove_if(
+            readFactors.begin(),
+            readFactors.end(),
+            [](const auto& factor) {
+              return factor.first == nimble::EncodingType::SubIntSplit;
+            }),
+        readFactors.end());
+    nimble::ManualEncodingSelectionPolicyFactory factory{
+        std::move(readFactors), std::nullopt};
+    return factory.createPolicy(type);
+  }
+};
+
+template <typename T>
+std::string_view encodeWithNonRecursiveSubIntSplit(
+    const std::vector<T>& values,
+    nimble::Buffer& buffer) {
+  return nimble::EncodingFactory::encode<T>(
+      std::make_unique<NonRecursiveSubIntSplitPolicy<T>>(), values, buffer);
+}
+
+template <typename T>
+std::string_view encodeWithReplayLayout(
+    const nimble::EncodingLayout& layout,
+    const std::vector<T>& values,
+    nimble::Buffer& buffer) {
+  auto leafFactory = makeLeafPolicyFactory();
+  return nimble::EncodingFactory::encode<T>(
+      std::make_unique<nimble::ReplayedEncodingSelectionPolicy<T>>(
+          layout, std::nullopt, leafFactory),
+      values,
+      buffer);
+}
+
+template <typename T>
+std::unique_ptr<nimble::Encoding> decodeEncoding(
+    std::string_view encoded,
+    velox::memory::MemoryPool& pool) {
+  return nimble::EncodingFactory().create(
+      pool, encoded, [](uint32_t) { return nullptr; });
+}
+
+template <typename T>
+std::vector<T> decodeAll(
+    std::string_view encoded,
+    velox::memory::MemoryPool& pool) {
+  auto encoding = decodeEncoding<T>(encoded, pool);
+  std::vector<T> result(encoding->rowCount());
+  encoding->materialize(encoding->rowCount(), result.data());
+  return result;
+}
+
+template <typename T>
+void expectBitwiseEqual(
+    const std::vector<T>& expected,
+    const std::vector<T>& actual) {
+  ASSERT_EQ(expected.size(), actual.size());
+  for (size_t i = 0; i < expected.size(); ++i) {
+    EXPECT_EQ(
+        nimble::EncodingPhysicalType<T>::asEncodingPhysicalType(expected[i]),
+        nimble::EncodingPhysicalType<T>::asEncodingPhysicalType(actual[i]))
+        << "row " << i;
+  }
+}
+
+template <typename T>
+nimble::EncodingLayout makePreserveLayout(
+    const std::vector<nimble::detail::subintsplit::SegmentPlan>& segments) {
+  std::vector<std::optional<const nimble::EncodingLayout>> children(
+      segments.size());
+  return nimble::EncodingLayout{
+      nimble::EncodingType::SubIntSplit,
+      nimble::EncodingLayout::Config{
+          nimble::detail::subintsplit::makePreserveSplitConfig(segments)},
+      nimble::CompressionType::Uncompressed,
+      std::move(children)};
+}
+
+void expectSegmentsEqual(
+    const std::vector<nimble::detail::subintsplit::SegmentPlan>& expected,
+    const std::vector<nimble::detail::subintsplit::SegmentPlan>& actual) {
+  ASSERT_EQ(expected.size(), actual.size());
+  for (size_t i = 0; i < expected.size(); ++i) {
+    EXPECT_EQ(expected[i].bitStart, actual[i].bitStart) << "segment " << i;
+    EXPECT_EQ(expected[i].bitEnd, actual[i].bitEnd) << "segment " << i;
+  }
+}
+
+void expectSameLayout(
+    const nimble::EncodingLayout& expected,
+    const nimble::EncodingLayout& actual) {
+  EXPECT_EQ(expected.encodingType(), actual.encodingType());
+  EXPECT_EQ(expected.compressionType(), actual.compressionType());
+  EXPECT_EQ(expected.config().values(), actual.config().values());
+  ASSERT_EQ(expected.childrenCount(), actual.childrenCount());
+  for (nimble::NestedEncodingIdentifier i = 0; i < expected.childrenCount();
+       ++i) {
+    const auto& expectedChild = expected.child(i);
+    const auto& actualChild = actual.child(i);
+    ASSERT_EQ(expectedChild.has_value(), actualChild.has_value())
+        << "child " << i;
+    if (expectedChild.has_value()) {
+      expectSameLayout(*expectedChild, *actualChild);
+    }
+  }
+}
+
+} // namespace
+
+TEST(SubIntSplitConfigTests, BoundarySerializationAndParsing) {
+  const std::vector<nimble::detail::subintsplit::SegmentPlan> segments{
+      {.bitStart = 0, .bitEnd = 7},
+      {.bitStart = 8, .bitEnd = 15},
+      {.bitStart = 16, .bitEnd = 31}};
+
+  const auto serialized =
+      nimble::detail::subintsplit::serializeSplitBoundaries(segments);
+  EXPECT_EQ(serialized, "0-7;8-15;16-31");
+
+  auto parsed =
+      nimble::detail::subintsplit::parseSplitBoundaries(serialized, 32);
+  ASSERT_TRUE(parsed.has_value());
+  expectSegmentsEqual(segments, *parsed);
+
+  EXPECT_FALSE(
+      nimble::detail::subintsplit::parseSplitBoundaries("", 32).has_value());
+  EXPECT_FALSE(
+      nimble::detail::subintsplit::parseSplitBoundaries("0-7;9-15", 16)
+          .has_value());
+  EXPECT_FALSE(
+      nimble::detail::subintsplit::parseSplitBoundaries("0-7;8-16", 16)
+          .has_value());
+  EXPECT_FALSE(
+      nimble::detail::subintsplit::parseSplitBoundaries("0-7;8-15", 8)
+          .has_value());
+}
+
+template <typename T>
+class SubIntSplitEncodingTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    pool_ = velox::memory::deprecatedAddDefaultLeafMemoryPool();
+    buffer_ = std::make_unique<nimble::Buffer>(*pool_);
+  }
+
+  std::shared_ptr<velox::memory::MemoryPool> pool_;
+  std::unique_ptr<nimble::Buffer> buffer_;
+};
+
+using SubIntSplitEncodingTypes =
+    ::testing::Types<int32_t, uint32_t, int64_t, uint64_t, float, double>;
+
+TYPED_TEST_CASE(SubIntSplitEncodingTest, SubIntSplitEncodingTypes);
+
+TYPED_TEST(SubIntSplitEncodingTest, RecomputeRoundTripAndReplay) {
+  using T = TypeParam;
+  const auto values = makeStructuredValues<T>();
+
+  const auto encoded =
+      encodeWithNonRecursiveSubIntSplit<T>(values, *this->buffer_);
+  const auto captured = nimble::EncodingLayoutCapture::capture(encoded);
+
+  ASSERT_EQ(captured.encodingType(), nimble::EncodingType::SubIntSplit);
+  ASSERT_GT(captured.childrenCount(), 1u);
+
+  const auto capturedMode = captured.config().get(
+      std::string(nimble::detail::subintsplit::kSplitModeConfigKey));
+  ASSERT_TRUE(capturedMode.has_value());
+  EXPECT_EQ(*capturedMode, nimble::detail::subintsplit::kSplitModePreserve);
+
+  const auto capturedBoundaries = captured.config().get(
+      std::string(nimble::detail::subintsplit::kSplitBoundariesConfigKey));
+  ASSERT_TRUE(capturedBoundaries.has_value());
+
+  const auto decoded = decodeAll<T>(encoded, *this->pool_);
+  expectBitwiseEqual(values, decoded);
+
+  const auto replayed =
+      encodeWithReplayLayout<T>(captured, values, *this->buffer_);
+  const auto replayCaptured = nimble::EncodingLayoutCapture::capture(replayed);
+  expectSameLayout(captured, replayCaptured);
+
+  auto encoding = decodeEncoding<T>(replayed, *this->pool_);
+  const size_t skipCount = 17;
+  ASSERT_GT(values.size(), skipCount);
+
+  encoding->skip(static_cast<uint32_t>(skipCount));
+  std::vector<T> suffix(values.size() - skipCount);
+  encoding->materialize(static_cast<uint32_t>(suffix.size()), suffix.data());
+  expectBitwiseEqual(
+      std::vector<T>(values.begin() + skipCount, values.end()), suffix);
+
+  encoding->reset();
+  std::vector<T> fullRoundTrip(values.size());
+  encoding->materialize(
+      static_cast<uint32_t>(values.size()), fullRoundTrip.data());
+  expectBitwiseEqual(values, fullRoundTrip);
+}
+
+TYPED_TEST(SubIntSplitEncodingTest, PreserveRoundTripExplicitBoundaries) {
+  using T = TypeParam;
+  const auto values = makeStructuredValues<T>();
+  const auto segments = makePreserveSegments<T>();
+  const auto layout = makePreserveLayout<T>(segments);
+
+  const auto encoded =
+      encodeWithReplayLayout<T>(layout, values, *this->buffer_);
+  const auto captured = nimble::EncodingLayoutCapture::capture(encoded);
+
+  ASSERT_EQ(captured.encodingType(), nimble::EncodingType::SubIntSplit);
+  ASSERT_EQ(captured.childrenCount(), segments.size());
+
+  const auto capturedMode = captured.config().get(
+      std::string(nimble::detail::subintsplit::kSplitModeConfigKey));
+  ASSERT_TRUE(capturedMode.has_value());
+  EXPECT_EQ(*capturedMode, nimble::detail::subintsplit::kSplitModePreserve);
+
+  const auto capturedBoundaries = captured.config().get(
+      std::string(nimble::detail::subintsplit::kSplitBoundariesConfigKey));
+  ASSERT_TRUE(capturedBoundaries.has_value());
+  EXPECT_EQ(
+      *capturedBoundaries,
+      nimble::detail::subintsplit::serializeSplitBoundaries(segments));
+
+  const auto decoded = decodeAll<T>(encoded, *this->pool_);
+  expectBitwiseEqual(values, decoded);
+}
+
+TEST(SubIntSplitEncodingTests, PreserveModeRequiresBoundaries) {
+  const std::vector<int64_t> values{
+      0x1234567890000000LL, 0x1234567890000001LL, 0x1234567890000002LL};
+
+  nimble::EncodingLayout layout{
+      nimble::EncodingType::SubIntSplit,
+      nimble::EncodingLayout::Config{{
+          {std::string(nimble::detail::subintsplit::kSplitModeConfigKey),
+           std::string(nimble::detail::subintsplit::kSplitModePreserve)},
+      }},
+      nimble::CompressionType::Uncompressed};
+
+  auto pool = velox::memory::deprecatedAddDefaultLeafMemoryPool();
+  nimble::Buffer buffer{*pool};
+
+  auto leafFactory = makeLeafPolicyFactory();
+  EXPECT_THROW(
+      (nimble::EncodingFactory::encode<int64_t>(
+          std::make_unique<nimble::ReplayedEncodingSelectionPolicy<int64_t>>(
+              layout, std::nullopt, leafFactory),
+          values,
+          buffer)),
+      nimble::NimbleInternalError);
+}
+
+TEST(SubIntSplitEncodingTests, FullWidthSingleSectionRoundTrip) {
+  const std::vector<uint64_t> values{
+      0x1234567890000000ULL,
+      0x1234567890000001ULL,
+      0x1234567890000002ULL,
+      0x1234567890000003ULL};
+  const auto segments = makeFullWidthSegments<uint64_t>();
+  const auto layout = makePreserveLayout<uint64_t>(segments);
+
+  auto pool = velox::memory::deprecatedAddDefaultLeafMemoryPool();
+  nimble::Buffer buffer{*pool};
+  const auto encoded = encodeWithReplayLayout<uint64_t>(layout, values, buffer);
+  const auto captured = nimble::EncodingLayoutCapture::capture(encoded);
+
+  ASSERT_EQ(captured.childrenCount(), 1u);
+  const auto capturedBoundaries = captured.config().get(
+      std::string(nimble::detail::subintsplit::kSplitBoundariesConfigKey));
+  ASSERT_TRUE(capturedBoundaries.has_value());
+  EXPECT_EQ(
+      *capturedBoundaries,
+      nimble::detail::subintsplit::serializeSplitBoundaries(segments));
+
+  const auto decoded = decodeAll<uint64_t>(encoded, *pool);
+  expectBitwiseEqual(values, decoded);
+}

--- a/dwio/nimble/encodings/tests/TestUtils.h
+++ b/dwio/nimble/encodings/tests/TestUtils.h
@@ -23,6 +23,7 @@
 #include "dwio/nimble/encodings/NullableEncoding.h"
 #include "dwio/nimble/encodings/RleEncoding.h"
 #include "dwio/nimble/encodings/SparseBoolEncoding.h"
+#include "dwio/nimble/encodings/SubIntSplitEncoding.h"
 #include "dwio/nimble/encodings/TrivialEncoding.h"
 #include "dwio/nimble/encodings/VarintEncoding.h"
 #include "dwio/nimble/encodings/common/Encoding.h"
@@ -30,6 +31,80 @@
 #include "dwio/nimble/encodings/selection/EncodingSelectionPolicy.h"
 
 namespace facebook::nimble::test {
+
+// Forward declaration of Encoder
+template <typename E>
+class Encoder;
+
+// EncodingTypeTraits must be defined at namespace scope
+template <typename E, typename T>
+struct EncodingTypeTraits {};
+
+template <typename T>
+struct EncodingTypeTraits<nimble::ConstantEncoding<T>, T> {
+  static constexpr inline nimble::EncodingType encodingType =
+      nimble::EncodingType::Constant;
+};
+
+template <typename T>
+struct EncodingTypeTraits<nimble::DeltaEncoding<T>, T> {
+  static constexpr inline nimble::EncodingType encodingType =
+      nimble::EncodingType::Delta;
+};
+
+template <typename T>
+struct EncodingTypeTraits<nimble::DictionaryEncoding<T>, T> {
+  static constexpr inline nimble::EncodingType encodingType =
+      nimble::EncodingType::Dictionary;
+};
+
+template <typename T>
+struct EncodingTypeTraits<nimble::FixedBitWidthEncoding<T>, T> {
+  static constexpr inline nimble::EncodingType encodingType =
+      nimble::EncodingType::FixedBitWidth;
+};
+
+template <typename T>
+struct EncodingTypeTraits<nimble::SubIntSplitEncoding<T>, T> {
+  static constexpr inline nimble::EncodingType encodingType =
+      nimble::EncodingType::SubIntSplit;
+};
+
+template <typename T>
+struct EncodingTypeTraits<nimble::MainlyConstantEncoding<T>, T> {
+  static constexpr inline nimble::EncodingType encodingType =
+      nimble::EncodingType::MainlyConstant;
+};
+
+template <typename T>
+struct EncodingTypeTraits<nimble::RLEEncoding<T>, T> {
+  static constexpr inline nimble::EncodingType encodingType =
+      nimble::EncodingType::RLE;
+};
+
+template <typename T>
+struct EncodingTypeTraits<nimble::SparseBoolEncoding, T> {
+  static constexpr inline nimble::EncodingType encodingType =
+      nimble::EncodingType::SparseBool;
+};
+
+template <typename T>
+struct EncodingTypeTraits<nimble::TrivialEncoding<T>, T> {
+  static constexpr inline nimble::EncodingType encodingType =
+      nimble::EncodingType::Trivial;
+};
+
+template <typename T>
+struct EncodingTypeTraits<nimble::VarintEncoding<T>, T> {
+  static constexpr inline nimble::EncodingType encodingType =
+      nimble::EncodingType::Varint;
+};
+
+template <typename T>
+struct EncodingTypeTraits<nimble::NullableEncoding<T>, T> {
+  static constexpr inline nimble::EncodingType encodingType =
+      nimble::EncodingType::Nullable;
+};
 
 template <typename E>
 class Encoder {
@@ -172,6 +247,12 @@ class Encoder {
   struct EncodingTypeTraits<nimble::NullableEncoding<T>> {
     static constexpr inline nimble::EncodingType encodingType =
         nimble::EncodingType::Nullable;
+  };
+
+  template <>
+  struct EncodingTypeTraits<nimble::SubIntSplitEncoding<T>> {
+    static constexpr inline nimble::EncodingType encodingType =
+        nimble::EncodingType::SubIntSplit;
   };
 
  public:

--- a/dwio/nimble/fuzzer/encoding/EncodingFuzzer.h
+++ b/dwio/nimble/fuzzer/encoding/EncodingFuzzer.h
@@ -15,6 +15,7 @@
  */
 #pragma once
 
+#include <bit>
 #include <cmath>
 #include <limits>
 #include <random>
@@ -122,6 +123,35 @@ Vector<T> makeMainlyConstantData(
   return data;
 }
 
+// Values with a fixed upper-half prefix and varying lower 16 bits.
+// This is the primary use case for SubIntSplitEncoding: e.g. small counters
+// stored in a 64-bit field, or timestamps where the high bits are constant.
+template <typename T, typename RNG>
+Vector<T> makeBitStructuredData(
+    velox::memory::MemoryPool& pool,
+    RNG& rng,
+    uint32_t rowCount,
+    [[maybe_unused]] Buffer* buffer) {
+  Vector<T> data(&pool);
+  data.reserve(rowCount);
+  if constexpr (std::is_arithmetic_v<T> && !std::is_same_v<T, bool>) {
+    for (uint32_t i = 0; i < rowCount; ++i) {
+      if constexpr (sizeof(T) <= 2) {
+        auto bits = static_cast<T>(folly::Random::rand32(rng) & 0xFFFF);
+        data.push_back(bits);
+      } else if constexpr (sizeof(T) == 4) {
+        uint32_t bits = 0x12340000u + (folly::Random::rand32(rng) & 0xFFFF);
+        data.push_back(std::bit_cast<T>(bits));
+      } else {
+        uint64_t bits =
+            0x1234567800000000ULL + (folly::Random::rand32(rng) & 0xFFFF);
+        data.push_back(std::bit_cast<T>(bits));
+      }
+    }
+  }
+  return data;
+}
+
 // ============================================================================
 // Fuzzer operations
 // ============================================================================
@@ -221,6 +251,12 @@ class EncodingFuzzer {
     // Mainly constant data (good for MainlyConstant encoding).
     datasets.push_back(
         makeMainlyConstantData<T>(*pool_, rng, rowCount, buffer_.get()));
+
+    // Bit-structured data (fixed upper-half prefix, varying low 16 bits).
+    if constexpr (std::is_arithmetic_v<T> && !std::is_same_v<T, bool>) {
+      datasets.push_back(
+          makeBitStructuredData<T>(*pool_, rng, rowCount, buffer_.get()));
+    }
 
     // Small data (1-3 rows) for edge cases.
     for (uint32_t sz : {1u, 2u, 3u}) {

--- a/dwio/nimble/fuzzer/encoding/EncodingFuzzerTest.cpp
+++ b/dwio/nimble/fuzzer/encoding/EncodingFuzzerTest.cpp
@@ -32,6 +32,7 @@
 #include "dwio/nimble/encodings/MainlyConstantEncoding.h"
 #include "dwio/nimble/encodings/RleEncoding.h"
 #include "dwio/nimble/encodings/SparseBoolEncoding.h"
+#include "dwio/nimble/encodings/SubIntSplitEncoding.h"
 #include "dwio/nimble/encodings/TrivialEncoding.h"
 #include "dwio/nimble/encodings/VarintEncoding.h"
 #include "dwio/nimble/fuzzer/encoding/EncodingFuzzer.h"
@@ -256,6 +257,28 @@ class MainlyConstantFuzzerTest : public ::testing::Test {};
 TYPED_TEST_SUITE(MainlyConstantFuzzerTest, MainlyConstantTypes);
 
 TYPED_TEST(MainlyConstantFuzzerTest, correctness) {
+  EncodingFuzzer<TypeParam> fuzzer(
+      FLAGS_fuzzer_iterations,
+      FLAGS_fuzzer_max_rows,
+      FLAGS_fuzzer_seed,
+      FLAGS_fuzzer_compression);
+  fuzzer.run();
+}
+
+// SubIntSplit: 32- and 64-bit numeric types (no bool, no string_view)
+using SubIntSplitTypes = ::testing::Types<
+    SubIntSplitEncoding<int32_t>,
+    SubIntSplitEncoding<uint32_t>,
+    SubIntSplitEncoding<int64_t>,
+    SubIntSplitEncoding<uint64_t>,
+    SubIntSplitEncoding<float>,
+    SubIntSplitEncoding<double>>;
+
+template <typename E>
+class SubIntSplitFuzzerTest : public ::testing::Test {};
+TYPED_TEST_SUITE(SubIntSplitFuzzerTest, SubIntSplitTypes);
+
+TYPED_TEST(SubIntSplitFuzzerTest, Correctness) {
   EncodingFuzzer<TypeParam> fuzzer(
       FLAGS_fuzzer_iterations,
       FLAGS_fuzzer_max_rows,

--- a/dwio/nimble/tools/EncodingUtilities.cpp
+++ b/dwio/nimble/tools/EncodingUtilities.cpp
@@ -49,6 +49,7 @@ void extractCompressionType(
     case EncodingType::Constant:
     case EncodingType::MainlyConstant:
     case EncodingType::Prefix:
+    case EncodingType::SubIntSplit:
       break;
   }
 }
@@ -193,6 +194,29 @@ void traverseEncodings(
           1,
           "Nulls",
           visitor);
+      break;
+    }
+    case EncodingType::SubIntSplit: {
+      const char* pos = stream.data() + kEncodingPrefixSize;
+      const uint8_t splitCount = encoding::read<uint8_t>(pos);
+      encoding::read<uint8_t>(pos); // reserved
+
+      std::vector<uint32_t> sectionBytes(splitCount);
+      for (uint8_t s = 0; s < splitCount; ++s) {
+        encoding::read<uint8_t>(pos); // bitStart
+        encoding::read<uint8_t>(pos); // bitEnd
+        sectionBytes[s] = encoding::readUint32(pos);
+      }
+
+      for (uint8_t s = 0; s < splitCount; ++s) {
+        traverseEncodings(
+            {pos, sectionBytes[s]},
+            level + 1,
+            s,
+            folly::to<std::string>("Section", static_cast<int>(s)),
+            visitor);
+        pos += sectionBytes[s];
+      }
       break;
     }
     case EncodingType::Sentinel: {

--- a/dwio/nimble/tools/NimbleDumpLib.cpp
+++ b/dwio/nimble/tools/NimbleDumpLib.cpp
@@ -27,6 +27,8 @@
 #include "dwio/nimble/common/Types.h"
 #include "dwio/nimble/encodings/common/EncodingFactory.h"
 #include "dwio/nimble/encodings/common/EncodingLayout.h"
+#include "dwio/nimble/encodings/common/EncodingPrimitives.h"
+#include "dwio/nimble/encodings/common/EncodingUtils.h"
 #include "dwio/nimble/encodings/tests/TestUtils.h"
 #include "dwio/nimble/tablet/Constants.h"
 #include "dwio/nimble/tablet/FileLayout.h"
@@ -59,6 +61,123 @@ namespace facebook::nimble::tools {
 namespace {
 
 constexpr uint32_t kBufferSize = 1000;
+constexpr int kRowCountOffset = 2;
+constexpr int kPrefixSize = 6;
+constexpr int kCompressionTypeSize = 1;
+
+uint64_t getRawDataSize(
+    velox::memory::MemoryPool& memoryPool,
+    std::string_view encodingStr) {
+  std::vector<velox::BufferPtr> newStringBuffers;
+  const auto stringBufferFactory = [&](uint32_t totalLength) {
+    auto& buffer = newStringBuffers.emplace_back(
+        velox::AlignedBuffer::allocate<char>(totalLength, &memoryPool));
+    return buffer->asMutable<void>();
+  };
+
+  auto encoding =
+      EncodingFactory().create(memoryPool, encodingStr, stringBufferFactory);
+  EncodingType encodingType = encoding->encodingType();
+  DataType dataType = encoding->dataType();
+  uint32_t rowCount = encoding->rowCount();
+
+  if (encodingType == EncodingType::Sentinel) {
+    NIMBLE_UNSUPPORTED("Sentinel encoding is not supported");
+  }
+
+  if (encodingType == EncodingType::Nullable) {
+    auto pos = encodingStr.data() + kPrefixSize;
+    auto nonNullsSize = encoding::readUint32(pos);
+    // Sum of the null count and size of the non-null child encoding.
+    return getRawDataSize(memoryPool, {pos, nonNullsSize}) + rowCount;
+  }
+
+  if (dataType != DataType::String) {
+    auto typeSize = nimble::detail::dataTypeSize(dataType);
+    return typeSize * rowCount;
+  }
+
+  auto pos = encodingStr.data() + kPrefixSize; // Skip the prefix.
+  uint64_t result = 0;
+
+  switch (encodingType) {
+    case EncodingType::Trivial: {
+      pos += kCompressionTypeSize;
+      auto lengthsSize = encoding::readUint32(pos);
+      auto lengths = EncodingFactory().create(
+          memoryPool, {pos, lengthsSize}, stringBufferFactory);
+      std::vector<uint32_t> buffer(rowCount);
+      lengths->materialize(rowCount, buffer.data());
+      result += std::accumulate(buffer.begin(), buffer.end(), 0u);
+      break;
+    }
+
+    case EncodingType::Constant: {
+      auto valueSize = encoding::readUint32(pos);
+      result += rowCount * valueSize;
+      break;
+    }
+
+    case EncodingType::MainlyConstant: {
+      auto isCommonSize = encoding::readUint32(pos);
+      pos += isCommonSize;
+      auto otherValuesSize = encoding::readUint32(pos);
+      auto otherValuesOffset = pos;
+      auto otherValuesCount = encoding::peek<uint32_t>(pos + kRowCountOffset);
+      pos += otherValuesSize;
+      auto constantValueSize = encoding::readUint32(pos);
+      result += (rowCount - otherValuesCount) * constantValueSize;
+      result +=
+          getRawDataSize(memoryPool, {otherValuesOffset, otherValuesSize});
+      break;
+    }
+
+    case EncodingType::Dictionary: {
+      auto alphabetSize = encoding::readUint32(pos);
+      auto alphabetCount = encoding::peek<uint32_t>(pos + kRowCountOffset);
+      auto alphabet = EncodingFactory().create(
+          memoryPool, {pos, alphabetSize}, stringBufferFactory);
+      std::vector<std::string_view> alphabetBuffer(alphabetCount);
+      alphabet->materialize(alphabetCount, alphabetBuffer.data());
+
+      pos += alphabetSize;
+      auto indicesSize = encodingStr.length() - (pos - encodingStr.data());
+      auto indices = EncodingFactory().create(
+          memoryPool, {pos, indicesSize}, stringBufferFactory);
+      std::vector<uint32_t> indicesBuffer(rowCount);
+      indices->materialize(rowCount, indicesBuffer.data());
+      for (int i = 0; i < rowCount; ++i) {
+        result += alphabetBuffer[indicesBuffer[i]].size();
+      }
+      break;
+    }
+
+    case EncodingType::RLE: {
+      auto runLengthsSize = encoding::readUint32(pos);
+      auto runLengthsCount = encoding::peek<uint32_t>(pos + kRowCountOffset);
+      auto runLengths = EncodingFactory().create(
+          memoryPool, {pos, runLengthsSize}, stringBufferFactory);
+      std::vector<uint32_t> runLengthsBuffer(runLengthsCount);
+      runLengths->materialize(runLengthsCount, runLengthsBuffer.data());
+
+      pos += runLengthsSize;
+      auto runValuesSize = encodingStr.length() - (pos - encodingStr.data());
+      auto runValues = EncodingFactory().create(
+          memoryPool, {pos, runValuesSize}, stringBufferFactory);
+      std::vector<std::string_view> runValuesBuffer(runLengthsCount);
+      runValues->materialize(runLengthsCount, runValuesBuffer.data());
+
+      for (int i = 0; i < runLengthsCount; ++i) {
+        result += runLengthsBuffer[i] * runValuesBuffer[i].size();
+      }
+      break;
+    }
+
+    default:
+      NIMBLE_UNSUPPORTED("Encoding type does not support strings.");
+  }
+  return result;
+}
 
 struct GroupingKey {
   EncodingType encodingType;
@@ -585,8 +704,7 @@ void NimbleDumpLib::emitStreams(
           auto chunk = stream.nextChunk();
           itemCount += *reinterpret_cast<const uint32_t*>(chunk.data() + 2);
           if (showStreamRawSize) {
-            rawStreamSize +=
-                nimble::test::TestUtils::getRawDataSize(*pool_, chunk);
+            rawStreamSize += getRawDataSize(*pool_, chunk);
           }
         }
 

--- a/dwio/nimble/velox/selective/tests/E2EFilterTest.cpp
+++ b/dwio/nimble/velox/selective/tests/E2EFilterTest.cpp
@@ -1149,6 +1149,7 @@ TEST_P(E2EFilterTest, floatBiasedSubIntSplit) {
       biasedEncodingFactors(EncodingType::SubIntSplit));
 }
 
+#ifdef NIMBLE_ENABLE_EXPERIMENTAL_ENCODINGS
 // Forces SubIntSplit via EncodingLayoutTree and verifies the on-disk encoding
 // matches. Schema uses only 32/64-bit types (SubIntSplit requires
 // sizeof(T)>=4).
@@ -1184,6 +1185,7 @@ TEST_P(E2EFilterTest, integerForcedSubIntSplit) {
   forcedEncodingType_.reset();
   verifyColumnEncodingsOnDisk(EncodingType::SubIntSplit);
 }
+#endif
 
 TEST_P(E2EFilterTest, float) {
   testWithTypes(

--- a/dwio/nimble/velox/selective/tests/E2EFilterTest.cpp
+++ b/dwio/nimble/velox/selective/tests/E2EFilterTest.cpp
@@ -659,6 +659,10 @@ class E2EFilterTest
         // isRestatements that may fall back to Constant.
         factors.emplace_back(EncodingType::Constant, 100.0);
         break;
+      case EncodingType::SubIntSplit:
+        // SubIntSplit may fall back to Constant for fully-constant data.
+        factors.emplace_back(EncodingType::Constant, 100.0);
+        break;
       default:
         break;
     }
@@ -1059,6 +1063,126 @@ TEST_P(E2EFilterTest, integerBiasedDelta) {
   // Verify the on-disk encoding is Delta (sinkData_ holds the last written
   // file from testWithTypes).
   verifyColumnEncodingsOnDisk(EncodingType::Delta);
+}
+
+// Biased variant that forces SubIntSplit encoding selection.
+// SubIntSplit only applies to 32- and 64-bit types; smallint is excluded.
+TEST_P(E2EFilterTest, integerBiasedSubIntSplit) {
+  testWithTypes(
+      "int_val:int,"
+      "long_val:bigint",
+      [&]() {
+        makeIntDistribution<int32_t>(
+            "int_val",
+            /*min=*/100,
+            /*max=*/100000,
+            /*repeats=*/1,
+            /*rareFrequency=*/0,
+            /*rareMin=*/0,
+            /*rareMax=*/0,
+            /*keepNulls=*/false);
+        makeIntDistribution<int64_t>(
+            "long_val",
+            /*min=*/1000,
+            /*max=*/1000000,
+            /*repeats=*/1,
+            /*rareFrequency=*/0,
+            /*rareMin=*/0,
+            /*rareMax=*/0,
+            /*keepNulls=*/false);
+      },
+      /*wrapInStruct=*/true,
+      {"int_val", "long_val"},
+      /*numCombinations=*/20,
+      /*withRecursiveNulls=*/true,
+      biasedEncodingFactors(EncodingType::SubIntSplit));
+}
+
+// Tests data with bit-structured distributions where SubIntSplit naturally
+// wins: values concentrated in the low-bit range of a wider type, so the
+// upper bit sections collapse to Constant encoding.
+TEST_P(E2EFilterTest, integerSubIntSplitBitStructured) {
+  testWithTypes(
+      "int_val:int,"
+      "long_val:bigint",
+      [&]() {
+        makeIntDistribution<int32_t>(
+            "int_val",
+            /*min=*/0,
+            /*max=*/65535, // only 16 low bits vary; upper 16 are zero
+            /*repeats=*/1,
+            /*rareFrequency=*/0,
+            /*rareMin=*/0,
+            /*rareMax=*/0,
+            /*keepNulls=*/false);
+        makeIntDistribution<int64_t>(
+            "long_val",
+            /*min=*/0,
+            /*max=*/4294967295, // only 32 low bits vary; upper 32 are zero
+            /*repeats=*/1,
+            /*rareFrequency=*/0,
+            /*rareMin=*/0,
+            /*rareMax=*/0,
+            /*keepNulls=*/false);
+      },
+      /*wrapInStruct=*/false,
+      {"int_val", "long_val"},
+      /*numCombinations=*/20,
+      /*withRecursiveNulls=*/true);
+}
+
+// Biased variant that forces SubIntSplit encoding for float/double columns.
+// SubIntSplit encodes float/double via their uint32/uint64 IEEE 754 bit
+// patterns; quantized data produces sections of differing entropy.
+TEST_P(E2EFilterTest, floatBiasedSubIntSplit) {
+  testWithTypes(
+      "float_val:float,"
+      "double_val:double",
+      [&]() {
+        makeQuantizedFloat<float>("float_val", 100, true);
+        makeQuantizedFloat<double>("double_val", 100, true);
+      },
+      /*wrapInStruct=*/false,
+      {"float_val", "double_val"},
+      /*numCombinations=*/20,
+      /*withRecursiveNulls=*/true,
+      biasedEncodingFactors(EncodingType::SubIntSplit));
+}
+
+// Forces SubIntSplit via EncodingLayoutTree and verifies the on-disk encoding
+// matches. Schema uses only 32/64-bit types (SubIntSplit requires
+// sizeof(T)>=4).
+TEST_P(E2EFilterTest, integerForcedSubIntSplit) {
+  forcedEncodingType_ = EncodingType::SubIntSplit;
+  testWithTypes(
+      "int_val:int,"
+      "long_val:bigint",
+      [&]() {
+        makeIntDistribution<int32_t>(
+            "int_val",
+            /*min=*/100,
+            /*max=*/100000,
+            /*repeats=*/1,
+            /*rareFrequency=*/0,
+            /*rareMin=*/0,
+            /*rareMax=*/0,
+            /*keepNulls=*/false);
+        makeIntDistribution<int64_t>(
+            "long_val",
+            /*min=*/1000,
+            /*max=*/1000000,
+            /*repeats=*/1,
+            /*rareFrequency=*/0,
+            /*rareMin=*/0,
+            /*rareMax=*/0,
+            /*keepNulls=*/false);
+      },
+      /*wrapInStruct=*/false,
+      {"int_val", "long_val"},
+      /*numCombinations=*/20,
+      /*withRecursiveNulls=*/true);
+  forcedEncodingType_.reset();
+  verifyColumnEncodingsOnDisk(EncodingType::SubIntSplit);
 }
 
 TEST_P(E2EFilterTest, float) {

--- a/dwio/nimble/velox/selective/tests/SelectiveNimbleReaderTest.cpp
+++ b/dwio/nimble/velox/selective/tests/SelectiveNimbleReaderTest.cpp
@@ -51,6 +51,43 @@ namespace {
 
 using namespace facebook::velox;
 
+struct NullableArrayData {
+  std::optional<std::vector<std::optional<int64_t>>> value;
+
+  NullableArrayData(std::nullopt_t) : value(std::nullopt) {}
+
+  NullableArrayData(std::initializer_list<int64_t> values)
+      : value(std::in_place) {
+    value->reserve(values.size());
+    for (auto element : values) {
+      value->emplace_back(element);
+    }
+  }
+
+  operator std::optional<std::vector<std::optional<int64_t>>>() const {
+    return value;
+  }
+};
+
+struct NullableMapData {
+  std::optional<std::vector<std::pair<int64_t, std::optional<int64_t>>>> value;
+
+  NullableMapData(std::nullopt_t) : value(std::nullopt) {}
+
+  NullableMapData(std::initializer_list<std::pair<int64_t, int64_t>> values)
+      : value(std::in_place) {
+    value->reserve(values.size());
+    for (const auto& [key, mapped] : values) {
+      value->emplace_back(key, mapped);
+    }
+  }
+
+  operator std::optional<
+      std::vector<std::pair<int64_t, std::optional<int64_t>>>>() const {
+    return value;
+  }
+};
+
 enum FilterType { kNone, kKeep, kDrop };
 auto format_as(FilterType filterType) {
   return fmt::underlying(filterType);
@@ -471,6 +508,27 @@ class SelectiveNimbleReaderTest
     ASSERT_EQ(readers.rowReader->next(1, result), 0);
   }
 
+  void checkArrayWithOffsets(
+      std::initializer_list<NullableArrayData> data,
+      const std::vector<bool>& filter,
+      const std::vector<int>& readSizes,
+      bool stringDecoderZeroCopy,
+      std::optional<int> maxArrayElementsCount = std::nullopt,
+      bool filterAfterRead = false) {
+    std::vector<std::optional<std::vector<std::optional<int64_t>>>> converted;
+    converted.reserve(data.size());
+    for (const auto& item : data) {
+      converted.push_back(item);
+    }
+    checkArrayWithOffsets(
+        converted,
+        filter,
+        readSizes,
+        stringDecoderZeroCopy,
+        maxArrayElementsCount,
+        filterAfterRead);
+  }
+
   void checkSlidingWindowMap(
       const std::vector<std::optional<
           std::vector<std::pair<int64_t, std::optional<int64_t>>>>>& data,
@@ -584,6 +642,29 @@ class SelectiveNimbleReaderTest
     }
     ASSERT_EQ(totalScanned, data.size());
     ASSERT_EQ(readers.rowReader->next(1, result), 0);
+  }
+
+  void checkSlidingWindowMap(
+      std::initializer_list<NullableMapData> data,
+      const std::vector<bool>& rowFilter,
+      const common::Filter* keyFilter,
+      const std::vector<int>& readSizes,
+      bool stringDecoderZeroCopy,
+      bool filterAfterRead = false) {
+    std::vector<
+        std::optional<std::vector<std::pair<int64_t, std::optional<int64_t>>>>>
+        converted;
+    converted.reserve(data.size());
+    for (const auto& item : data) {
+      converted.push_back(item);
+    }
+    checkSlidingWindowMap(
+        converted,
+        rowFilter,
+        keyFilter,
+        readSizes,
+        stringDecoderZeroCopy,
+        filterAfterRead);
   }
 
  private:
@@ -1389,7 +1470,7 @@ TEST_P(SelectiveNimbleReaderTest, estimatedRowSizeNoStats) {
 TEST_P(SelectiveNimbleReaderTest, arrayWithOffsetsLastRunFilteredOut) {
   const bool stringDecoderZeroCopy = this->stringDecoderZeroCopy();
   checkArrayWithOffsets(
-      {{{1}}, {{}}, {{}}},
+      {NullableArrayData{1}, NullableArrayData{}, NullableArrayData{}},
       {false, true, true},
       {1, 1, 1},
       stringDecoderZeroCopy);
@@ -1398,7 +1479,9 @@ TEST_P(SelectiveNimbleReaderTest, arrayWithOffsetsLastRunFilteredOut) {
 TEST_P(SelectiveNimbleReaderTest, arrayWithOffsetsLastRunNotLoaded) {
   const bool stringDecoderZeroCopy = this->stringDecoderZeroCopy();
   checkArrayWithOffsets(
-      {{{1}}, std::nullopt, {{1}}},
+      {std::vector<std::optional<int64_t>>{1},
+       std::nullopt,
+       std::vector<std::optional<int64_t>>{1}},
       {false, true, true},
       {1, 1, 1},
       stringDecoderZeroCopy);
@@ -1407,13 +1490,24 @@ TEST_P(SelectiveNimbleReaderTest, arrayWithOffsetsLastRunNotLoaded) {
 TEST_P(SelectiveNimbleReaderTest, arrayWithOffsetsNoSeekBackward) {
   const bool stringDecoderZeroCopy = this->stringDecoderZeroCopy();
   checkArrayWithOffsets(
-      {{{1}}, std::nullopt, {{1}}}, {}, {1, 1, 1}, stringDecoderZeroCopy);
+      {std::vector<std::optional<int64_t>>{1},
+       std::nullopt,
+       std::vector<std::optional<int64_t>>{1}},
+      {},
+      {1, 1, 1},
+      stringDecoderZeroCopy);
 }
 
 TEST_P(SelectiveNimbleReaderTest, arrayWithOffsetsLastRunResize) {
   const bool stringDecoderZeroCopy = this->stringDecoderZeroCopy();
   checkArrayWithOffsets(
-      {{{1}}, {{1}}, {{}}, {{}}}, {}, {1, 2, 1}, stringDecoderZeroCopy);
+      {NullableArrayData{1},
+       NullableArrayData{1},
+       NullableArrayData{},
+       NullableArrayData{}},
+      {},
+      {1, 2, 1},
+      stringDecoderZeroCopy);
 }
 
 // Exercises the dense fast path in makeNestedRowSet and setAlphabet: all rows
@@ -1428,7 +1522,12 @@ TEST_P(SelectiveNimbleReaderTest, arrayWithOffsetsDenseAllSelected) {
 TEST_P(SelectiveNimbleReaderTest, arrayWithOffsetsDenseMultiBatch) {
   const bool stringDecoderZeroCopy = this->stringDecoderZeroCopy();
   checkArrayWithOffsets(
-      {{{1}}, {{2}}, {{3}}, {{4}}, {{5}}, {{6}}},
+      {std::vector<std::optional<int64_t>>{1},
+       std::vector<std::optional<int64_t>>{2},
+       std::vector<std::optional<int64_t>>{3},
+       std::vector<std::optional<int64_t>>{4},
+       std::vector<std::optional<int64_t>>{5},
+       std::vector<std::optional<int64_t>>{6}},
       {},
       {2, 2, 2},
       stringDecoderZeroCopy);
@@ -1449,7 +1548,14 @@ TEST_P(SelectiveNimbleReaderTest, arrayWithOffsetsDenseWithNulls) {
 TEST_P(SelectiveNimbleReaderTest, arrayWithOffsetsDenseWithEmpties) {
   const bool stringDecoderZeroCopy = this->stringDecoderZeroCopy();
   checkArrayWithOffsets(
-      {{{}}, {{1}}, {{}}, {{2}}, {{}}}, {}, {5}, stringDecoderZeroCopy);
+      {std::vector<std::optional<int64_t>>{},
+       std::vector<std::optional<int64_t>>{1},
+       std::vector<std::optional<int64_t>>{},
+       std::vector<std::optional<int64_t>>{2},
+       std::vector<std::optional<int64_t>>{}},
+      {},
+      {5},
+      stringDecoderZeroCopy);
 }
 
 // When subfield pruning is enabled, the dense fast path in makeNestedRowSet is
@@ -1500,7 +1606,11 @@ TEST_P(SelectiveNimbleReaderTest, arrayWithOffsetsDenseContinuedRun) {
 TEST_P(SelectiveNimbleReaderTest, arrayWithOffsetsDenseSingleRowBatches) {
   const bool stringDecoderZeroCopy = this->stringDecoderZeroCopy();
   checkArrayWithOffsets(
-      {{{1}}, {{2}}, {{3}}, {{4}}, {{5}}},
+      {std::vector<std::optional<int64_t>>{1},
+       std::vector<std::optional<int64_t>>{2},
+       std::vector<std::optional<int64_t>>{3},
+       std::vector<std::optional<int64_t>>{4},
+       std::vector<std::optional<int64_t>>{5}},
       {},
       {1, 1, 1, 1, 1},
       stringDecoderZeroCopy);
@@ -1511,7 +1621,12 @@ TEST_P(SelectiveNimbleReaderTest, arrayWithOffsetsDenseSingleRowBatches) {
 TEST_P(SelectiveNimbleReaderTest, arrayWithOffsetsDenseSingleRowDuplicates) {
   const bool stringDecoderZeroCopy = this->stringDecoderZeroCopy();
   checkArrayWithOffsets(
-      {{{1}}, {{1}}, {{2}}, {{2}}, {{3}}, {{3}}},
+      {std::vector<std::optional<int64_t>>{1},
+       std::vector<std::optional<int64_t>>{1},
+       std::vector<std::optional<int64_t>>{2},
+       std::vector<std::optional<int64_t>>{2},
+       std::vector<std::optional<int64_t>>{3},
+       std::vector<std::optional<int64_t>>{3}},
       {},
       {1, 1, 1, 1, 1, 1},
       stringDecoderZeroCopy);
@@ -1537,7 +1652,13 @@ TEST_P(SelectiveNimbleReaderTest, arrayWithOffsetsDenseSkipLastRunTransition) {
 TEST_P(SelectiveNimbleReaderTest, arrayWithOffsetsDenseUnevenBatches) {
   const bool stringDecoderZeroCopy = this->stringDecoderZeroCopy();
   checkArrayWithOffsets(
-      {{{1}}, {{2}}, {{2}}, {{3}}, {{3}}, {{3}}, {{4}}},
+      {std::vector<std::optional<int64_t>>{1},
+       std::vector<std::optional<int64_t>>{2},
+       std::vector<std::optional<int64_t>>{2},
+       std::vector<std::optional<int64_t>>{3},
+       std::vector<std::optional<int64_t>>{3},
+       std::vector<std::optional<int64_t>>{3},
+       std::vector<std::optional<int64_t>>{4}},
       {},
       {1, 3, 2, 1},
       stringDecoderZeroCopy);
@@ -1549,7 +1670,11 @@ TEST_P(SelectiveNimbleReaderTest, arrayWithOffsetsDenseUnevenBatches) {
 TEST_P(SelectiveNimbleReaderTest, arrayWithOffsetsDenseNullAtBatchBoundary) {
   const bool stringDecoderZeroCopy = this->stringDecoderZeroCopy();
   checkArrayWithOffsets(
-      {{{1}}, {{2}}, std::nullopt, {{3}}, {{4}}},
+      {std::vector<std::optional<int64_t>>{1},
+       std::vector<std::optional<int64_t>>{2},
+       std::nullopt,
+       std::vector<std::optional<int64_t>>{3},
+       std::vector<std::optional<int64_t>>{4}},
       {},
       {2, 1, 2},
       stringDecoderZeroCopy);
@@ -1570,7 +1695,11 @@ TEST_P(SelectiveNimbleReaderTest, arrayWithOffsetsDenseMultiElementContinued) {
 TEST_P(SelectiveNimbleReaderTest, arrayWithOffsetsCopyLastRunAfterSkip) {
   const bool stringDecoderZeroCopy = this->stringDecoderZeroCopy();
   checkArrayWithOffsets(
-      {{{1}}, {{1}}, {{2}}, std::nullopt, {{3}}},
+      {std::vector<std::optional<int64_t>>{1},
+       std::vector<std::optional<int64_t>>{1},
+       std::vector<std::optional<int64_t>>{2},
+       std::nullopt,
+       std::vector<std::optional<int64_t>>{3}},
       {true, false, false, true, true},
       {1, 2, 1, 1},
       stringDecoderZeroCopy);
@@ -1579,7 +1708,11 @@ TEST_P(SelectiveNimbleReaderTest, arrayWithOffsetsCopyLastRunAfterSkip) {
 TEST_P(SelectiveNimbleReaderTest, arrayWithOffsetsSubfieldPruning) {
   const bool stringDecoderZeroCopy = this->stringDecoderZeroCopy();
   checkArrayWithOffsets(
-      {{{1, 2}}, {{1, 2}}, {{1}}, std::nullopt, {{1, 2, 3}}},
+      {std::vector<std::optional<int64_t>>{1, 2},
+       std::vector<std::optional<int64_t>>{1, 2},
+       std::vector<std::optional<int64_t>>{1},
+       std::nullopt,
+       std::vector<std::optional<int64_t>>{1, 2, 3}},
       {},
       {1, 1, 3},
       stringDecoderZeroCopy,
@@ -1589,7 +1722,8 @@ TEST_P(SelectiveNimbleReaderTest, arrayWithOffsetsSubfieldPruning) {
 TEST_P(SelectiveNimbleReaderTest, arrayWithOffsetsLastRunFilteredOutAfterRead) {
   const bool stringDecoderZeroCopy = this->stringDecoderZeroCopy();
   checkArrayWithOffsets(
-      {{{1}}, {{1}}},
+      {std::vector<std::optional<int64_t>>{1},
+       std::vector<std::optional<int64_t>>{1}},
       {false, true},
       {1, 1},
       stringDecoderZeroCopy,

--- a/dwio/nimble/velox/selective/tests/VariableLengthColumnReaderTest.cpp
+++ b/dwio/nimble/velox/selective/tests/VariableLengthColumnReaderTest.cpp
@@ -29,6 +29,25 @@ namespace {
 
 using namespace facebook::velox;
 
+template <typename T>
+using NullableArray = std::optional<std::vector<std::optional<T>>>;
+
+template <typename T>
+NullableArray<T> makeNullableArray(
+    std::initializer_list<std::optional<T>> values) {
+  return NullableArray<T>{std::in_place, values.begin(), values.end()};
+}
+
+template <typename T>
+using NullableMap =
+    std::optional<std::vector<std::pair<int64_t, std::optional<T>>>>;
+
+template <typename T>
+NullableMap<T> makeNullableMap(
+    std::initializer_list<std::pair<int64_t, std::optional<T>>> values) {
+  return NullableMap<T>{std::in_place, values.begin(), values.end()};
+}
+
 // Tests for ListColumnReader and MapColumnReader (variable-length containers).
 class VariableLengthColumnReaderTest : public ::testing::Test,
                                        public velox::test::VectorTestBase {


### PR DESCRIPTION
Summary:
Disables `SubIntSplit` encoding end-to-end. The encoding is no longer selected for new writes (removed from `possibleEncodings()` and `defaultReadFactors()` in `ManualEncodingSelectionPolicyFactory`) and can no longer decode existing SubIntSplit-encoded data (cases commented out in `EncodingFactory::decode`, `EncodingFactory::encode`, `EncodingLayout::capture`, `EncodingUtils::withEncoding`, and `EncodingSizeEstimation::estimateSize` across both common and legacy paths).

The `EncodingType::SubIntSplit` enum value and the `SubIntSplitEncoding` class remain in the codebase. Every commented-out site has a "To re-enable" comment pointing to the code to uncomment.

Reviewed By: apurva-meta

Differential Revision: D106302512
