### PR TITLE
Add CompactFor encoding — claiming EncodingType::CompactFor = 17 (#791)

### DIFF
--- a/dwio/nimble/common/Types.cpp
+++ b/dwio/nimble/common/Types.cpp
@@ -51,6 +51,8 @@ std::string toString(EncodingType encodingType) {
       return "Prefix";
     case EncodingType::ALP:
       return "ALP";
+    case EncodingType::Pfor:
+      return "Pfor";
   }
   return fmt::format(
       "Unknown encoding type: {}", static_cast<int32_t>(encodingType));

--- a/dwio/nimble/common/Types.cpp
+++ b/dwio/nimble/common/Types.cpp
@@ -55,6 +55,8 @@ std::string toString(EncodingType encodingType) {
       return "Pfor";
     case EncodingType::DoubleDelta:
       return "DoubleDelta";
+    case EncodingType::CompactFor:
+      return "CompactFor";
   }
   return fmt::format(
       "Unknown encoding type: {}", static_cast<int32_t>(encodingType));

--- a/dwio/nimble/common/Types.cpp
+++ b/dwio/nimble/common/Types.cpp
@@ -53,6 +53,8 @@ std::string toString(EncodingType encodingType) {
       return "ALP";
     case EncodingType::Pfor:
       return "Pfor";
+    case EncodingType::DoubleDelta:
+      return "DoubleDelta";
   }
   return fmt::format(
       "Unknown encoding type: {}", static_cast<int32_t>(encodingType));

--- a/dwio/nimble/common/Types.h
+++ b/dwio/nimble/common/Types.h
@@ -106,6 +106,10 @@ enum class EncodingType {
   Prefix = 11,
   // Adaptive Lossless floating-Point compression for numeric types.
   ALP = 12,
+  // Patched Frame-of-Reference. Subtracts a min baseline, bitpacks ~90% of
+  // residuals at a narrow base bit width, and stores the remaining outliers
+  // ("exceptions") as a parallel position+value array.
+  Pfor = 15,
 };
 std::string toString(EncodingType encodingType);
 std::ostream& operator<<(std::ostream& out, EncodingType encodingType);

--- a/dwio/nimble/common/Types.h
+++ b/dwio/nimble/common/Types.h
@@ -110,6 +110,12 @@ enum class EncodingType {
   // residuals at a narrow base bit width, and stores the remaining outliers
   // ("exceptions") as a parallel position+value array.
   Pfor = 15,
+  // Long Double-Delta Bitpack. 64-bit integer only. Stores the first two
+  // values explicitly, then bitpacks the second-order differences
+  // (delta-of-deltas) of the remaining values after FOR + zigzag. Wins on
+  // monotone sequences with regular intervals — perfectly regular timestamps
+  // collapse to bitWidth=0 and ~31 bytes total regardless of N.
+  DoubleDelta = 13,
 };
 std::string toString(EncodingType encodingType);
 std::ostream& operator<<(std::ostream& out, EncodingType encodingType);

--- a/dwio/nimble/common/Types.h
+++ b/dwio/nimble/common/Types.h
@@ -116,6 +116,13 @@ enum class EncodingType {
   // monotone sequences with regular intervals — perfectly regular timestamps
   // collapse to bitWidth=0 and ~31 bytes total regardless of N.
   DoubleDelta = 13,
+  // Long For Bitpack. 64-bit integer only. Subtracts a min baseline and
+  // bitpacks every residual at the smallest bit width that covers the full
+  // range. Same shape as FixedBitWidth but specialised for int64/uint64 with
+  // a varint-encoded baseline (compact when min is small) and no per-value
+  // exceptions. True O(1) random access; bit width <= 56 hits a byte-aligned
+  // single-load fast path inside FixedBitArray::bulkGet64WithBaseline.
+  CompactFor = 14,
 };
 std::string toString(EncodingType encodingType);
 std::ostream& operator<<(std::ostream& out, EncodingType encodingType);

--- a/dwio/nimble/encodings/CompactForEncoding.h
+++ b/dwio/nimble/encodings/CompactForEncoding.h
@@ -1,0 +1,371 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <algorithm>
+#include <cstring>
+#include <span>
+#include <type_traits>
+
+#include "dwio/nimble/common/Buffer.h"
+#include "dwio/nimble/common/Exceptions.h"
+#include "dwio/nimble/common/FixedBitArray.h"
+#include "dwio/nimble/common/Types.h"
+#include "dwio/nimble/common/Varint.h"
+#include "dwio/nimble/encodings/common/Encoding.h"
+#include "dwio/nimble/encodings/common/EncodingPrimitives.h"
+#include "dwio/nimble/encodings/selection/EncodingSelection.h"
+#include "velox/common/base/BitUtil.h"
+#include "velox/dwio/common/DecoderUtil.h"
+
+// CompactForEncoding (slot 17) stores 64-bit integer streams using the same
+// core algorithm as FixedBitWidthEncoding (slot 3): subtract a min baseline,
+// bitpack residuals via FixedBitArray. Two wire-format differences:
+//
+//   1. Baseline is varint-encoded (1-10 bytes) instead of fixed sizeof(T)
+//      (always 8 bytes for int64). Modest: saves up to 7B when baseline is
+//      small.
+//   2. BitWidth is exact (not rounded to byte boundary). FixedBitWidth
+//      rounds up to the next multiple of 8 via `(bw + 7) & ~7`
+//      (e.g., 4→8, 9→16, 17→24). CompactFor keeps the exact value
+//      (e.g., 4 stays 4), which can halve the bitpacked region.
+//
+//
+// Int64-only because the varint baseline savings diminish for smaller types:
+// int32 saves at most 3 bytes (and Pfor/SimdForBitpack dominate there),
+// int8/int16 save nothing.
+//
+// Ported from AUS LONG_LIST_FOR_BITPACKED.
+
+namespace facebook::nimble {
+
+/// Data layout (after the standard Encoding prefix):
+///   varint bytes : minimum baseline (varint-encoded uint64; 1..10 bytes)
+///   1 byte       : bitWidth -- bits per bitpacked residual; 0..64
+///   variable     : FixedBitArray::bufferSize(N, bitWidth) bytes of bitpacked
+///                  residuals.  Omitted entirely when bitWidth == 0.
+///                  bufferSize already includes the 7-byte tail slop so
+///                  loadU64 can safely read 8 bytes from the final element
+///                  offset.
+template <typename T>
+class CompactForEncoding final
+    : public TypedEncoding<T, typename TypeTraits<T>::physicalType> {
+  static_assert(
+      std::is_same_v<T, int64_t> || std::is_same_v<T, uint64_t>,
+      "CompactFor only supports 64-bit integer types.");
+
+ public:
+  using cppDataType = T;
+  using physicalType = typename TypeTraits<T>::physicalType;
+
+  /// Construct from wire data produced by encode().
+  CompactForEncoding(
+      velox::memory::MemoryPool& pool,
+      std::string_view data,
+      std::function<void*(uint32_t)> stringBufferFactory,
+      const Encoding::Options& options = {});
+
+  /// Reset the read cursor to the beginning of the stream.
+  void reset() final;
+
+  /// Advance the read cursor by `rowCount` rows without materializing.
+  void skip(uint32_t rowCount) final;
+
+  /// Decode `rowCount` consecutive rows into `buffer`.
+  void materialize(uint32_t rowCount, void* buffer) final;
+
+  /// Visitor-based row-at-a-time decode with an optional fast bulk path.
+  template <typename DecoderVisitor>
+  void readWithVisitor(DecoderVisitor& visitor, ReadWithVisitorParams& params);
+
+  /// Bulk scan method for the readWithVisitorFast path.
+  /// Reads multiple values at once and processes them through the visitor.
+  template <bool kScatter, typename Visitor>
+  void bulkScan(
+      Visitor& visitor,
+      vector_size_t currentRow,
+      const vector_size_t* selectedRows,
+      vector_size_t numSelected,
+      const vector_size_t* scatterRows);
+
+  /// Encode `values` into a self-contained wire-format blob.
+  static std::string_view encode(
+      EncodingSelection<physicalType>& selection,
+      std::span<const physicalType> values,
+      Buffer& buffer,
+      const Encoding::Options& options = {});
+
+  /// Return a human-readable summary for diagnostics.
+  std::string debugString(int offset) const final;
+
+ private:
+  // Minimum value subtracted from every element before bitpacking.
+  uint64_t baseline_{0};
+
+  // Number of bits per bitpacked residual (0..64).
+  uint8_t bitWidth_{0};
+
+  // Bitpacked residual region.  Default-constructed (null buffer) when
+  // bitWidth_ == 0 because no residuals are stored.
+  FixedBitArray fixedBitArray_{};
+
+  // Read cursor -- absolute row position within the stream.
+  uint32_t row_{0};
+};
+
+//
+// End of public API. Implementations follow.
+//
+
+template <typename T>
+CompactForEncoding<T>::CompactForEncoding(
+    velox::memory::MemoryPool& pool,
+    std::string_view data,
+    std::function<void*(uint32_t)> /* stringBufferFactory */,
+    const Encoding::Options& options)
+    : TypedEncoding<T, physicalType>{pool, data, options} {
+  const auto* pos = data.data() + this->dataOffset();
+  baseline_ = varint::readVarint64(&pos);
+  bitWidth_ = static_cast<uint8_t>(encoding::readChar(pos));
+  NIMBLE_CHECK_LE(bitWidth_, 64, "CompactFor bit width must be in [0, 64].");
+
+  if (bitWidth_ > 0) {
+    const size_t bitpackedSize =
+        FixedBitArray::bufferSize(this->rowCount_, bitWidth_);
+    NIMBLE_CHECK_GE(
+        static_cast<size_t>(data.end() - pos),
+        bitpackedSize,
+        "CompactFor bitpacked region underruns wire data.");
+    fixedBitArray_ =
+        FixedBitArray{{pos, static_cast<size_t>(data.end() - pos)}, bitWidth_};
+  }
+  reset();
+}
+
+template <typename T>
+void CompactForEncoding<T>::reset() {
+  row_ = 0;
+}
+
+template <typename T>
+void CompactForEncoding<T>::skip(uint32_t rowCount) {
+  row_ += rowCount;
+}
+
+template <typename T>
+void CompactForEncoding<T>::materialize(uint32_t rowCount, void* buffer) {
+  if (rowCount == 0) {
+    return;
+  }
+  auto* output = static_cast<physicalType*>(buffer);
+  if (bitWidth_ == 0) {
+    std::fill(output, output + rowCount, static_cast<physicalType>(baseline_));
+  } else {
+    fixedBitArray_.bulkGet64WithBaseline(
+        /*start=*/row_,
+        /*length=*/rowCount,
+        reinterpret_cast<uint64_t*>(output),
+        /*baseline=*/baseline_);
+  }
+  row_ += rowCount;
+}
+
+template <typename T>
+template <typename V>
+void CompactForEncoding<T>::readWithVisitor(
+    V& visitor,
+    ReadWithVisitorParams& params) {
+  using OutputType = detail::ValueType<typename V::DataType>;
+  // CompactFor only supports int64/uint64.
+  static_assert(
+      sizeof(OutputType) == sizeof(physicalType),
+      "CompactFor readWithVisitor: OutputType must be same size as physicalType (int64/uint64).");
+  static_assert(
+      std::is_integral_v<OutputType>,
+      "CompactFor readWithVisitor: OutputType must be integral.");
+
+  // Fast path: use bulkScan when the visitor supports ExtractToReader
+  // and useFastPath() passes.
+  if constexpr (std::is_same_v<
+                    typename V::Extract,
+                    velox::dwio::common::ExtractToReader>) {
+    auto* nulls = visitor.reader().rawNullsInReadRange();
+    if (velox::dwio::common::useFastPath(visitor, nulls)) {
+      detail::readWithVisitorFast(*this, visitor, params, nulls);
+      return;
+    }
+  }
+  // Slow path: process one value at a time. Only reached for
+  // non-ExtractToReader visitors or non-deterministic filters.
+  detail::readWithVisitorSlow(
+      visitor,
+      params,
+      [&](auto toSkip) { skip(toSkip); },
+      [&]() {
+        physicalType value;
+        if (bitWidth_ == 0) {
+          value = static_cast<physicalType>(baseline_);
+        } else {
+          value =
+              static_cast<physicalType>(fixedBitArray_.get(row_) + baseline_);
+        }
+        ++row_;
+        return value;
+      });
+}
+
+template <typename T>
+template <bool kScatter, typename V>
+void CompactForEncoding<T>::bulkScan(
+    V& visitor,
+    vector_size_t currentRow,
+    const vector_size_t* selectedRows,
+    vector_size_t numSelected,
+    const vector_size_t* scatterRows) {
+  using OutputType = detail::ValueType<typename V::DataType>;
+  static_assert(
+      sizeof(OutputType) == sizeof(physicalType),
+      "CompactFor bulkScan requires same-size output type.");
+
+  if (numSelected == 0) {
+    return;
+  }
+
+  const auto numRows = visitor.numRows() - visitor.rowIndex();
+
+  // Offset between internal position (row_) and the external row number
+  // (currentRow).  Handles cases where the encoding cursor differs from the
+  // logical row number.
+  const auto offset =
+      static_cast<int32_t>(row_) - static_cast<int32_t>(currentRow);
+
+  auto* values = detail::mutableValues<OutputType>(visitor, numRows);
+
+  if constexpr (V::dense) {
+    if (bitWidth_ == 0) {
+      std::fill(
+          values, values + numSelected, static_cast<OutputType>(baseline_));
+    } else {
+      fixedBitArray_.bulkGet64WithBaseline(
+          selectedRows[0] + offset,
+          numSelected,
+          reinterpret_cast<uint64_t*>(values),
+          baseline_);
+    }
+  } else {
+    // Sparse case: read individual values at specified positions.
+    if (bitWidth_ == 0) {
+      for (vector_size_t i = 0; i < numSelected; ++i) {
+        values[i] = static_cast<OutputType>(baseline_);
+      }
+    } else {
+      for (vector_size_t i = 0; i < numSelected; ++i) {
+        values[i] = static_cast<OutputType>(
+            fixedBitArray_.get(selectedRows[i] + offset) + baseline_);
+      }
+    }
+  }
+
+  row_ += selectedRows[numSelected - 1] - currentRow + 1;
+
+  detail::finalizeBulkScan<OutputType, kScatter>(
+      visitor, values, numRows, selectedRows, numSelected, scatterRows);
+}
+
+template <typename T>
+std::string_view CompactForEncoding<T>::encode(
+    EncodingSelection<typename TypeTraits<T>::physicalType>& selection,
+    std::span<const typename TypeTraits<T>::physicalType> values,
+    Buffer& buffer,
+    const Encoding::Options& options) {
+  static_assert(
+      std::is_same_v<
+          typename std::make_unsigned<physicalType>::type,
+          physicalType>,
+      "CompactFor physical type must be unsigned.");
+  const bool useVarint = options.useVarintRowCount;
+  if (values.empty()) {
+    NIMBLE_INCOMPATIBLE_ENCODING(
+        "CompactFor encoding cannot be used with 0 rows.");
+  }
+  const uint32_t rowCount = static_cast<uint32_t>(values.size());
+  const uint64_t baseline = static_cast<uint64_t>(selection.statistics().min());
+  const uint64_t maxValue = static_cast<uint64_t>(selection.statistics().max());
+  // Unsigned subtraction is safe: Statistics computes min/max on the same
+  // physical (unsigned 64-bit) representation, so the difference is the true
+  // non-negative range.
+  const uint64_t fullRange = maxValue - baseline;
+  const uint8_t bitWidth = fullRange == 0
+      ? uint8_t{0}
+      : static_cast<uint8_t>(velox::bits::bitsRequired(fullRange));
+  const uint64_t bitpackedSize =
+      bitWidth == 0 ? 0 : FixedBitArray::bufferSize(rowCount, bitWidth);
+
+  const uint32_t headerSize = varint::varintSize(baseline) + 1;
+  const uint32_t encodingSize =
+      Encoding::serializePrefixSize(rowCount, useVarint) + headerSize +
+      static_cast<uint32_t>(bitpackedSize);
+
+  char* reserved = buffer.reserve(encodingSize);
+  char* pos = reserved;
+  Encoding::serializePrefix(
+      EncodingType::CompactFor,
+      TypeTraits<T>::dataType,
+      rowCount,
+      useVarint,
+      pos);
+  varint::writeVarint(baseline, &pos);
+  encoding::writeChar(static_cast<char>(bitWidth), pos);
+
+  if (bitWidth > 0) {
+    char* bitpackedStart = pos;
+    std::memset(bitpackedStart, 0, bitpackedSize);
+    FixedBitArray fba(bitpackedStart, bitWidth);
+    if (bitWidth <= 32) {
+      // When the full range fits in 32 bits, narrow residuals to uint32
+      // and use the template-unrolled bulkSet32 path.
+      Vector<uint32_t> residuals32{&buffer.getMemoryPool()};
+      residuals32.resize(rowCount);
+      for (auto i = 0; i < rowCount; ++i) {
+        residuals32[i] =
+            static_cast<uint32_t>(static_cast<uint64_t>(values[i]) - baseline);
+      }
+      fba.bulkSet32(/*start=*/0, /*length=*/rowCount, residuals32.data());
+    } else {
+      for (auto i = 0; i < rowCount; ++i) {
+        fba.set(i, static_cast<uint64_t>(values[i]) - baseline);
+      }
+    }
+    pos += bitpackedSize;
+  }
+
+  NIMBLE_DCHECK_EQ(
+      pos - reserved, encodingSize, "CompactFor encoding size mismatch.");
+  return {reserved, encodingSize};
+}
+
+template <typename T>
+std::string CompactForEncoding<T>::debugString(int offset) const {
+  return fmt::format(
+      "{}{}<{}> rowCount={} bitWidth={}",
+      std::string(offset, ' '),
+      toString(Encoding::encodingType()),
+      toString(Encoding::dataType()),
+      Encoding::rowCount(),
+      static_cast<int>(bitWidth_));
+}
+
+} // namespace facebook::nimble

--- a/dwio/nimble/encodings/DoubleDeltaEncoding.h
+++ b/dwio/nimble/encodings/DoubleDeltaEncoding.h
@@ -1,0 +1,605 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <algorithm>
+#include <cstring>
+#include <span>
+#include <type_traits>
+#include <vector>
+
+#include "dwio/nimble/common/Buffer.h"
+#include "dwio/nimble/common/Exceptions.h"
+#include "dwio/nimble/common/FixedBitArray.h"
+#include "dwio/nimble/common/Types.h"
+#include "dwio/nimble/encodings/common/Encoding.h"
+#include "dwio/nimble/encodings/common/EncodingPrimitives.h"
+#include "dwio/nimble/encodings/selection/EncodingSelection.h"
+#include "velox/common/base/BitUtil.h"
+
+// DoubleDeltaEncoding stores 64-bit integer streams using
+// second-order differencing (delta-of-deltas). Remaining values beyond the
+// first two are zigzag-encoded, shifted by a frame-of-reference minimum, and
+// bitpacked at a uniform bit width. Periodic checkpoints allow O(K) seek
+// instead of O(N) sequential decode.
+//
+// Targets monotone sequences with regular intervals (e.g. timestamps) where
+// the double-deltas collapse near zero -- perfectly regular timestamps encode
+// at bitWidth=0 and ~31 bytes regardless of row count.
+//
+// Ported from AusLongListDeltaOfDeltaEncoder (multifeed/datafm/encode/) with
+// bitpacking in place of GroupVarint, plus forward-decode checkpoints for
+// random access.
+
+namespace facebook::nimble {
+
+/// Encodes 64-bit integer streams using double-delta bitpacking.
+///
+/// Data layout (after the standard Encoding prefix):
+///
+///   8 bytes  firstValue           -- raw int64 stored as uint64 wire bytes
+///   8 bytes  secondValue          -- raw int64 as uint64 (zero when N < 2)
+///   8 bytes  minZigzagDoubleDelta -- frame-of-reference floor (zero when
+///                                    N < 3)
+///   1 byte   bitWidth             -- bits per bitpacked residual [0, 64]
+///   variable bitpacked residuals  -- FixedBitArray::bufferSize(N - 2,
+///                                    bitWidth) bytes; omitted when
+///                                    bitWidth == 0 or N < 3
+///   4 bytes  checkpointCount      -- uint32, native byte order
+///   variable checkpoint entries   -- checkpointCount * 16 bytes, each is
+///                                    {uint64 lastValue, uint64 lastDelta}
+///                                    captured every kCheckpointStride
+///                                    residuals
+///
+/// The checkpoint segment is always present (even when checkpointCount == 0).
+template <typename T>
+class DoubleDeltaEncoding final
+    : public TypedEncoding<T, typename TypeTraits<T>::physicalType> {
+  static_assert(
+      std::is_same_v<T, int64_t> || std::is_same_v<T, uint64_t>,
+      "DoubleDelta only supports 64-bit integer types.");
+
+ public:
+  using cppDataType = T;
+  using physicalType = typename TypeTraits<T>::physicalType;
+
+  /// Fixed-size header following the standard Encoding prefix:
+  /// firstValue(8) + secondValue(8) + minZigzagDoubleDelta(8) + bitWidth(1).
+  static constexpr int kPrefixSize = 8 + 8 + 8 + 1;
+
+  /// Forward-decode anchor stride. Every kCheckpointStride residuals we
+  /// snapshot {lastValue, lastDelta} so seek-then-materialize costs
+  /// O(kCheckpointStride) instead of O(targetRow). Storage overhead is
+  /// 16 bytes per kCheckpointStride elements (~0.25% for 8-byte payloads).
+  static constexpr uint32_t kCheckpointStride = 64;
+
+  /// Construct a decoder from serialized wire bytes.
+  DoubleDeltaEncoding(
+      velox::memory::MemoryPool& pool,
+      std::string_view data,
+      const std::function<void*(uint32_t)>& stringBufferFactory,
+      const Encoding::Options& options = {});
+
+  /// Reset the read cursor to the beginning of the stream.
+  void reset() final;
+
+  /// Advance the read cursor by `rowCount` rows without emitting values.
+  void skip(uint32_t rowCount) final;
+
+  /// Decode the next `rowCount` values into `buffer`. The caller must
+  /// ensure `buffer` has room for at least rowCount * sizeof(physicalType).
+  void materialize(uint32_t rowCount, void* buffer) final;
+
+  /// Visitor-based read interface for selective/filtered reads.
+  template <typename DecoderVisitor>
+  void readWithVisitor(DecoderVisitor& visitor, ReadWithVisitorParams& params);
+
+  /// Encode `values` into the wire format, appending to `buffer`.
+  /// Returns a view into the buffer covering the encoded bytes.
+  static std::string_view encode(
+      EncodingSelection<physicalType>& selection,
+      std::span<const physicalType> values,
+      Buffer& buffer,
+      const Encoding::Options& options = {});
+
+  /// Return a human-readable description of this encoding for diagnostics.
+  std::string debugString(int offset) const final;
+
+ private:
+  // Decode the next bitpacked double-delta residual at the given index
+  // (residualIndex == row_ - 2). Accumulate into lastDelta_ and lastValue_
+  // and return the reconstructed value.
+  uint64_t advanceFromBitpacked(uint32_t residualIndex);
+
+  // Snapshot of decoder state captured every kCheckpointStride residuals
+  // during encode. Enables O(1) seek to any checkpoint boundary.
+  struct Checkpoint {
+    // Reconstructed value at the checkpoint boundary.
+    uint64_t lastValue{0};
+    // Delta from the previous to the checkpoint boundary value.
+    uint64_t lastDelta{0};
+  };
+  static_assert(sizeof(Checkpoint) == 16);
+
+  // Load checkpoint[i] from wire bytes. Use memcpy for alignment safety
+  // since the wire buffer may not be 8-byte aligned.
+  Checkpoint loadCheckpoint(uint32_t index) const {
+    Checkpoint checkpoint{};
+    std::memcpy(
+        &checkpoint,
+        checkpointStart_ + index * sizeof(Checkpoint),
+        sizeof(Checkpoint));
+    return checkpoint;
+  }
+
+  // Fast-forward decoder state to the best checkpoint covering `targetRow`.
+  // Skip when no checkpoint improves over the current row_ position. After
+  // seeking, at most kCheckpointStride - 1 rows remain to be walked by the
+  // per-row decode loop.
+  void seekToCheckpointFor(uint32_t targetRow);
+
+  // -- Wire-format fields, populated in the constructor --
+
+  // All wire bytes are stored as uint64 and re-cast to the signed/unsigned
+  // cpp type at emission time.
+  uint64_t firstWire_{0};
+  uint64_t secondWire_{0};
+  // Frame-of-reference floor subtracted from each zigzag-encoded
+  // double-delta before bitpacking.
+  uint64_t minZigzagDoubleDelta_{0};
+  // Uniform bit width of each bitpacked residual, range [0, 64].
+  uint8_t bitWidth_{0};
+
+  // Bitpacked double-delta residual region. Default-constructed (no backing
+  // buffer) when bitWidth_ == 0 or rowCount_ < 3.
+  FixedBitArray fixedBitArray_{};
+
+  // Pointer into wire bytes at the first checkpoint entry (immediately after
+  // the 4-byte count). nullptr when checkpointCount_ == 0.
+  const char* checkpointStart_{nullptr};
+  // Number of checkpoint entries in the wire data.
+  uint32_t checkpointCount_{0};
+
+  // -- Mutable decoder state --
+
+  // Absolute row position of the next value to be decoded.
+  uint32_t row_{0};
+  // Last decoded value at position (row_ - 1). Valid when row_ >= 1.
+  uint64_t lastValue_{0};
+  // Delta from position (row_ - 2) to (row_ - 1). Valid when row_ >= 2.
+  uint64_t lastDelta_{0};
+};
+
+namespace detail {
+// TODO: Move to a common place.
+// Zigzag-encode a 64-bit value using the standard interleave mapping:
+//   0 -> 0, -1 -> 1, 1 -> 2, -2 -> 3, 2 -> 4, ...
+// Accepts uint64 so callers can pass raw wire bytes; the arithmetic right
+// shift is performed via a signed cast to extend the sign bit. Both the
+// shift and the XOR are well-defined for every uint64 input, including
+// the bit pattern of INT64_MIN.
+inline uint64_t zigzagEncode64(uint64_t value) {
+  const auto signedValue = static_cast<int64_t>(value);
+  return (value << 1) ^ static_cast<uint64_t>(signedValue >> 63);
+}
+
+// Zigzag-decode a uint64 back to the original int64 bit pattern (returned
+// as uint64 for uniform wire handling). Inverse of zigzagEncode64 for all
+// 2^64 inputs.
+inline uint64_t zigzagDecode64(uint64_t value) {
+  return (value >> 1) ^ (~(value & 1) + 1);
+}
+
+} // namespace detail
+
+//
+// End of public API. Implementations follow.
+//
+
+template <typename T>
+DoubleDeltaEncoding<T>::DoubleDeltaEncoding(
+    velox::memory::MemoryPool& pool,
+    std::string_view data,
+    const std::function<void*(uint32_t)>& /* stringBufferFactory */,
+    const Encoding::Options& options)
+    : TypedEncoding<T, physicalType>{pool, data, options} {
+  const char* pos = data.data() + this->dataOffset();
+
+  // Read the fixed-size header fields.
+  firstWire_ = encoding::read<uint64_t>(pos);
+  secondWire_ = encoding::read<uint64_t>(pos);
+  minZigzagDoubleDelta_ = encoding::read<uint64_t>(pos);
+  bitWidth_ = static_cast<uint8_t>(encoding::readChar(pos));
+  NIMBLE_CHECK_LE(bitWidth_, 64, "DoubleDelta bit width must be in [0, 64].");
+
+  // Parse the bitpacked residual region when present.
+  size_t bitpackedSize = 0;
+  if (bitWidth_ > 0 && this->rowCount_ > 2) {
+    const uint32_t residualCount = this->rowCount_ - 2;
+    bitpackedSize = FixedBitArray::bufferSize(residualCount, bitWidth_);
+    // Guard against truncated wire data that would let the decoder read past
+    // the buffer boundary.
+    NIMBLE_CHECK_GE(
+        static_cast<size_t>(data.end() - pos),
+        bitpackedSize,
+        "DoubleDelta bitpacked region underruns wire data.");
+    fixedBitArray_ =
+        FixedBitArray{{pos, static_cast<size_t>(data.end() - pos)}, bitWidth_};
+  }
+  pos += bitpackedSize;
+
+  // Parse the trailing checkpoint segment: uint32 count followed by
+  // count * sizeof(Checkpoint) bytes of checkpoint entries.
+  NIMBLE_CHECK_GE(
+      static_cast<size_t>(data.end() - pos),
+      sizeof(uint32_t),
+      "DoubleDelta checkpoint count underruns wire data.");
+  checkpointCount_ = encoding::read<uint32_t>(pos);
+  NIMBLE_CHECK_GE(
+      static_cast<size_t>(data.end() - pos),
+      static_cast<size_t>(checkpointCount_) * sizeof(Checkpoint),
+      "DoubleDelta checkpoint array underruns wire data.");
+  checkpointStart_ = checkpointCount_ > 0 ? pos : nullptr;
+
+  reset();
+}
+
+template <typename T>
+void DoubleDeltaEncoding<T>::reset() {
+  row_ = 0;
+  lastValue_ = 0;
+  lastDelta_ = 0;
+}
+
+template <typename T>
+uint64_t DoubleDeltaEncoding<T>::advanceFromBitpacked(uint32_t residualIndex) {
+  // Recover the original double-delta:
+  //   stored residual = zigzag(doubleDelta) - minZigzagDoubleDelta
+  //   doubleDelta     = zigzagDecode(residual + minZigzagDoubleDelta)
+  const uint64_t residual =
+      bitWidth_ == 0 ? 0 : fixedBitArray_.get(residualIndex);
+  const uint64_t doubleDelta =
+      detail::zigzagDecode64(residual + minZigzagDoubleDelta_);
+
+  // Accumulate via unsigned wrap-around arithmetic. This preserves bit-exact
+  // recovery for int64 values whose true deltas span the signed range.
+  lastDelta_ += doubleDelta;
+  lastValue_ += lastDelta_;
+  return lastValue_;
+}
+
+template <typename T>
+void DoubleDeltaEncoding<T>::seekToCheckpointFor(uint32_t targetRow) {
+  if (checkpointCount_ == 0 || targetRow < kCheckpointStride + 2) {
+    return;
+  }
+  // checkpoint[i] captures state after residual (i+1)*K - 1 has been decoded,
+  // which corresponds to row (i+1)*K + 1 having been emitted. The next row
+  // to decode from that checkpoint is (i+1)*K + 2. Find the largest i such
+  // that this next-row is both <= targetRow and > row_ (never step backward).
+  const uint32_t checkpointIndex = (targetRow - 2) / kCheckpointStride - 1;
+  const uint32_t boundedIndex = std::min(checkpointIndex, checkpointCount_ - 1);
+  const uint32_t nextRow = (boundedIndex + 1) * kCheckpointStride + 2;
+  if (nextRow <= row_) {
+    return;
+  }
+  const auto checkpoint = loadCheckpoint(boundedIndex);
+  lastValue_ = checkpoint.lastValue;
+  lastDelta_ = checkpoint.lastDelta;
+  row_ = nextRow;
+}
+
+template <typename T>
+void DoubleDeltaEncoding<T>::skip(uint32_t rowCount) {
+  if (rowCount == 0) {
+    return;
+  }
+
+  const uint32_t end = row_ + rowCount;
+
+  // Jump to the best checkpoint when it saves work over sequential decode.
+  seekToCheckpointFor(end);
+
+  // Handle the first two seed rows individually.
+  while (row_ < end && row_ < 2) {
+    if (row_ == 0) {
+      lastValue_ = firstWire_;
+    } else {
+      lastDelta_ = secondWire_ - firstWire_;
+      lastValue_ = secondWire_;
+    }
+    ++row_;
+  }
+
+  // Batch-decode remaining residuals. Bulk-extract into a temporary buffer
+  // and prefix-sum, avoiding per-element get() overhead.
+  const uint32_t residualCount = end - row_;
+  if (residualCount == 0) {
+    return;
+  }
+  if (bitWidth_ == 0) {
+    // All double-deltas are identical (minZigzagDoubleDelta_ after zigzag
+    // decode). Fast-forward with closed-form arithmetic.
+    const uint64_t doubleDelta = detail::zigzagDecode64(minZigzagDoubleDelta_);
+    const uint64_t n = residualCount;
+    // After n steps: lastDelta advances by n * doubleDelta,
+    // lastValue advances by sum_{k=1..n}(lastDelta + k * doubleDelta)
+    //   = n * lastDelta + doubleDelta * n*(n+1)/2
+    lastValue_ += lastDelta_ * n + doubleDelta * (n * (n + 1) / 2);
+    lastDelta_ += doubleDelta * n;
+    row_ = end;
+    return;
+  }
+  // After checkpoint seek, at most kCheckpointStride - 1 residuals remain.
+  NIMBLE_DCHECK_LE(
+      residualCount,
+      kCheckpointStride,
+      "skip residualCount exceeds checkpoint stride.");
+  uint64_t zigzagBuf[kCheckpointStride];
+  const uint32_t residualStart = row_ - 2;
+  fixedBitArray_.bulkGet64WithBaseline(
+      /*start=*/residualStart,
+      /*length=*/residualCount,
+      zigzagBuf,
+      /*baseline=*/minZigzagDoubleDelta_);
+  for (uint32_t i = 0; i < residualCount; ++i) {
+    const uint64_t doubleDelta = detail::zigzagDecode64(zigzagBuf[i]);
+    lastDelta_ += doubleDelta;
+    lastValue_ += lastDelta_;
+  }
+  row_ = end;
+}
+
+template <typename T>
+void DoubleDeltaEncoding<T>::materialize(uint32_t rowCount, void* buffer) {
+  if (rowCount == 0) {
+    return;
+  }
+
+  auto* output = static_cast<physicalType*>(buffer);
+  const uint32_t end = row_ + rowCount;
+  uint32_t outputIndex = 0;
+
+  // Handle the first two seed rows individually.
+  while (row_ < end && row_ < 2) {
+    if (row_ == 0) {
+      lastValue_ = firstWire_;
+    } else {
+      lastDelta_ = secondWire_ - firstWire_;
+      lastValue_ = secondWire_;
+    }
+    output[outputIndex++] = static_cast<physicalType>(lastValue_);
+    ++row_;
+  }
+
+  // Batch-decode residuals. Bulk-extract via bulkGet64WithBaseline (uses
+  // optimized template-unrolled paths for bitWidth <= 32 and branchless
+  // loads for 33-57), then reconstruct values via prefix sum.
+  if (row_ >= end) {
+    return;
+  }
+  const uint32_t residualCount = end - row_;
+  if (bitWidth_ == 0) {
+    // All double-deltas are identical. Unroll the prefix sum without any
+    // bitpacked extraction.
+    const uint64_t doubleDelta = detail::zigzagDecode64(minZigzagDoubleDelta_);
+    for (uint32_t i = 0; i < residualCount; ++i) {
+      lastDelta_ += doubleDelta;
+      lastValue_ += lastDelta_;
+      output[outputIndex++] = static_cast<physicalType>(lastValue_);
+    }
+    row_ = end;
+    return;
+  }
+  // Batch-extract residuals and prefix-sum reconstruct values.
+  constexpr uint32_t kBatchSize{256};
+  uint64_t zigzagBuf[kBatchSize];
+  uint32_t remaining = residualCount;
+  uint32_t residualStart = row_ - 2;
+  while (remaining > 0) {
+    const uint32_t batch = std::min(remaining, kBatchSize);
+    fixedBitArray_.bulkGet64WithBaseline(
+        /*start=*/residualStart,
+        /*length=*/batch,
+        zigzagBuf,
+        /*baseline=*/minZigzagDoubleDelta_);
+    for (uint32_t i = 0; i < batch; ++i) {
+      const uint64_t doubleDelta = detail::zigzagDecode64(zigzagBuf[i]);
+      lastDelta_ += doubleDelta;
+      lastValue_ += lastDelta_;
+      output[outputIndex++] = static_cast<physicalType>(lastValue_);
+    }
+    residualStart += batch;
+    remaining -= batch;
+  }
+  row_ = end;
+}
+
+template <typename T>
+template <typename V>
+void DoubleDeltaEncoding<T>::readWithVisitor(
+    V& visitor,
+    ReadWithVisitorParams& params) {
+  detail::readWithVisitorSlow(
+      visitor,
+      params,
+      [&](auto toSkip) { skip(toSkip); },
+      [&]() {
+        if (row_ == 0) {
+          lastValue_ = firstWire_;
+        } else if (row_ == 1) {
+          lastDelta_ = secondWire_ - firstWire_;
+          lastValue_ = secondWire_;
+        } else {
+          advanceFromBitpacked(/*residualIndex=*/row_ - 2);
+        }
+        ++row_;
+        return static_cast<physicalType>(lastValue_);
+      });
+}
+
+template <typename T>
+std::string_view DoubleDeltaEncoding<T>::encode(
+    EncodingSelection<typename TypeTraits<T>::physicalType>& /*selectoin*/,
+    std::span<const typename TypeTraits<T>::physicalType> values,
+    Buffer& buffer,
+    const Encoding::Options& options) {
+  const bool useVarint = options.useVarintRowCount;
+  if (values.empty()) {
+    NIMBLE_INCOMPATIBLE_ENCODING(
+        "DoubleDelta encoding cannot be used with 0 rows.");
+  }
+  const uint32_t rowCount = static_cast<uint32_t>(values.size());
+
+  // Header fields that are always present. For N == 1 the second value is
+  // zeroed; for N <= 2 the minZigzag and bitWidth are zeroed (no residuals).
+  const uint64_t firstWire = static_cast<uint64_t>(values[0]);
+  const uint64_t secondWire =
+      rowCount >= 2 ? static_cast<uint64_t>(values[1]) : uint64_t{0};
+
+  uint64_t minZigzag{0};
+  uint8_t bitWidth{0};
+  uint64_t bitpackedSize{0};
+
+  // Pass 1: scan all double-deltas to determine the zigzag range and the
+  // uniform bit width needed for frame-of-reference residuals.
+  if (rowCount >= 3) {
+    uint64_t minSeen{std::numeric_limits<uint64_t>::max()};
+    uint64_t maxSeen{0};
+    {
+      uint64_t previousDelta = secondWire - firstWire;
+      for (uint32_t i = 2; i < rowCount; ++i) {
+        const uint64_t delta = static_cast<uint64_t>(values[i]) -
+            static_cast<uint64_t>(values[i - 1]);
+        const uint64_t doubleDelta = delta - previousDelta;
+        const uint64_t zigzag = detail::zigzagEncode64(doubleDelta);
+        minSeen = std::min(minSeen, zigzag);
+        maxSeen = std::max(maxSeen, zigzag);
+        previousDelta = delta;
+      }
+    }
+    minZigzag = minSeen;
+    const uint64_t maxResidual = maxSeen - minSeen;
+    bitWidth = maxResidual == 0
+        ? uint8_t{0}
+        : static_cast<uint8_t>(velox::bits::bitsRequired(maxResidual));
+    if (bitWidth > 0) {
+      const uint32_t residualCount = rowCount - 2;
+      bitpackedSize = FixedBitArray::bufferSize(residualCount, bitWidth);
+    }
+  }
+
+  // Compute the number of forward-decode checkpoints. Skip checkpoints in
+  // the bitWidth == 0 fast path to preserve the "constant-stride timestamps
+  // encode to a few dozen bytes regardless of N" property -- the per-row
+  // loop is trivially cheap when bitWidth == 0.
+  const uint32_t checkpointCount = (rowCount >= 3 && bitWidth > 0)
+      ? (rowCount - 2) / DoubleDeltaEncoding<T>::kCheckpointStride
+      : uint32_t{0};
+  const uint64_t checkpointSegmentSize = sizeof(uint32_t) +
+      static_cast<uint64_t>(checkpointCount) * sizeof(Checkpoint);
+
+  const uint32_t encodingSize =
+      Encoding::serializePrefixSize(rowCount, useVarint) +
+      DoubleDeltaEncoding<T>::kPrefixSize +
+      static_cast<uint32_t>(bitpackedSize) +
+      static_cast<uint32_t>(checkpointSegmentSize);
+
+  // Serialize the encoding prefix and header fields.
+  char* reserved = buffer.reserve(encodingSize);
+  char* pos = reserved;
+  Encoding::serializePrefix(
+      EncodingType::DoubleDelta,
+      TypeTraits<T>::dataType,
+      rowCount,
+      useVarint,
+      pos);
+  encoding::write<uint64_t>(firstWire, pos);
+  encoding::write<uint64_t>(secondWire, pos);
+  encoding::write<uint64_t>(minZigzag, pos);
+  encoding::writeChar(static_cast<char>(bitWidth), pos);
+
+  // Pass 2: bitpack residuals and capture checkpoints in a single O(N) walk
+  // of the input values. Checkpoints are buffered locally and flushed after
+  // the bitpacked region to maintain the wire layout:
+  //   [bitpacked region][checkpointCount][checkpoint entries...]
+  char* bitpackedStart = pos;
+  const bool hasBitpacked = bitWidth > 0;
+  if (hasBitpacked) {
+    std::memset(bitpackedStart, 0, bitpackedSize);
+  }
+  FixedBitArray fixedBitArray =
+      hasBitpacked ? FixedBitArray(bitpackedStart, bitWidth) : FixedBitArray{};
+
+  std::vector<Checkpoint> capturedCheckpoints;
+  capturedCheckpoints.reserve(checkpointCount);
+
+  if (rowCount >= 3) {
+    uint64_t previousDelta = secondWire - firstWire;
+    uint32_t checkpointCounter = 0;
+    for (auto i = 2; i < rowCount; ++i) {
+      const auto currentValue = static_cast<uint64_t>(values[i]);
+      const auto delta = currentValue - static_cast<uint64_t>(values[i - 1]);
+      const auto doubleDelta = delta - previousDelta;
+      if (hasBitpacked) {
+        fixedBitArray.set(
+            i - 2, detail::zigzagEncode64(doubleDelta) - minZigzag);
+      }
+      previousDelta = delta;
+
+      // Capture a checkpoint every kCheckpointStride residuals. The
+      // checkpoint stores the reconstructed value and delta at that point
+      // so the decoder can resume from here without replaying earlier rows.
+      if (hasBitpacked &&
+          ++checkpointCounter == DoubleDeltaEncoding<T>::kCheckpointStride) {
+        capturedCheckpoints.push_back({currentValue, delta});
+        checkpointCounter = 0;
+      }
+    }
+  }
+  NIMBLE_DCHECK_EQ(
+      capturedCheckpoints.size(),
+      checkpointCount,
+      "DoubleDelta checkpoint count mismatch.");
+
+  // Flush the checkpoint segment after the bitpacked region.
+  if (hasBitpacked) {
+    pos += bitpackedSize;
+  }
+  encoding::write<uint32_t>(checkpointCount, pos);
+  for (const auto& checkpoint : capturedCheckpoints) {
+    encoding::write<uint64_t>(checkpoint.lastValue, pos);
+    encoding::write<uint64_t>(checkpoint.lastDelta, pos);
+  }
+
+  NIMBLE_DCHECK_EQ(
+      pos - reserved, encodingSize, "DoubleDelta encoding size mismatch.");
+  return {reserved, encodingSize};
+}
+
+template <typename T>
+std::string DoubleDeltaEncoding<T>::debugString(int offset) const {
+  return fmt::format(
+      "{}{}<{}> rowCount={} bitWidth={} checkpoints={}",
+      std::string(offset, ' '),
+      toString(Encoding::encodingType()),
+      toString(Encoding::dataType()),
+      Encoding::rowCount(),
+      static_cast<int>(bitWidth_),
+      checkpointCount_);
+}
+
+} // namespace facebook::nimble

--- a/dwio/nimble/encodings/FixedBitWidthEncoding.h
+++ b/dwio/nimble/encodings/FixedBitWidthEncoding.h
@@ -269,45 +269,8 @@ void FixedBitWidthEncoding<T>::bulkScan(
 
   row_ += selectedRows[numSelected - 1] - currentRow + 1;
 
-  // No scatter, filter, or hook: values are already in the output buffer.
-  if constexpr (!kScatter && !V::kHasFilter && !V::kHasHook) {
-    visitor.addNumValues(numRows);
-    visitor.setRowIndex(visitor.numRows());
-    return;
-  }
-
-  // processFixedWidthRun handles scatter (null gaps), filter evaluation,
-  // and hook forwarding. For non-hook paths, values points to the reader's
-  // output buffer (rawValues). For hooks, values stays as the local decode
-  // buffer since hook.addValue() consumes values without writing to the reader.
-  if constexpr (!V::kHasHook) {
-    values = reinterpret_cast<OutputType*>(visitor.reader().rawValues());
-  }
-
-  auto numValues = visitor.reader().numValues();
-  int32_t* filterHits = nullptr;
-  if constexpr (V::kHasFilter) {
-    filterHits = visitor.outputRows(numSelected) - numValues;
-  }
-
-  velox::dwio::common::
-      processFixedWidthRun<OutputType, V::kFilterOnly, kScatter, V::dense>(
-          velox::RowSet(selectedRows, numSelected),
-          0,
-          numSelected,
-          scatterRows,
-          values,
-          filterHits,
-          numValues,
-          visitor.filter(),
-          visitor.hook());
-
-  if constexpr (!V::kHasHook) {
-    // Filter: count passing rows; no filter: all rows produce values.
-    visitor.addNumValues(
-        V::kHasFilter ? numValues - visitor.reader().numValues() : numRows);
-  }
-  visitor.setRowIndex(visitor.numRows());
+  detail::finalizeBulkScan<OutputType, kScatter>(
+      visitor, values, numRows, selectedRows, numSelected, scatterRows);
 }
 
 template <typename T>

--- a/dwio/nimble/encodings/PforEncoding.h
+++ b/dwio/nimble/encodings/PforEncoding.h
@@ -1,0 +1,478 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <algorithm>
+#include <cstring>
+#include <span>
+
+#include "dwio/nimble/common/Buffer.h"
+#include "dwio/nimble/common/Exceptions.h"
+#include "dwio/nimble/common/FixedBitArray.h"
+#include "dwio/nimble/common/Types.h"
+#include "dwio/nimble/common/Varint.h"
+#include "dwio/nimble/common/Vector.h"
+#include "dwio/nimble/encodings/common/Encoding.h"
+#include "dwio/nimble/encodings/common/EncodingPrimitives.h"
+#include "dwio/nimble/encodings/selection/EncodingSelection.h"
+#include "velox/common/base/BitUtil.h"
+
+// PforEncoding stores integer data using Patched Frame-of-Reference (slot 15).
+// Each value is decomposed as `value = baseline + residual`, where the
+// residuals are bitpacked at a base bit width chosen so that ~90% of the
+// residuals fit. Values whose residual overflows the base width are recorded
+// as (position, value) "exceptions" stored separately as varints.
+//
+// Decode uses a branchless two-pass strategy (ported from AusIntListPfor):
+//   Pass 1: Unpack all base residuals in a tight branchless loop.
+//   Pass 2: Patch the ~10% exception positions with their full values.
+// This eliminates per-element branches from the hot loop.
+//
+// Pfor wins over plain FixedBitWidth on dense numeric streams that contain a
+// small fraction of large outliers -- FixedBitWidth would have to widen every
+// slot to the worst case, while Pfor pays the wide cost only for the outliers.
+
+namespace facebook::nimble {
+
+/// Data layout (after the standard Encoding prefix):
+///
+///   sizeof(physicalType) bytes : baseline (a.k.a. min value)
+///   1 byte                    : baseBitWidth (bits per bitpacked residual;
+///                               range [0, 64])
+///   4 bytes                   : numExceptions (uint32_t, fixed width)
+///   numExceptions varints     : exception positions, strictly ascending
+///   numExceptions varints     : exception values (full residual, i.e.
+///                               value - baseline)
+///   FixedBitArray::bufferSize(rowCount, baseBitWidth) bytes:
+///                               bitpacked base residuals (omitted when
+///                               baseBitWidth == 0)
+template <typename T>
+class PforEncoding final
+    : public TypedEncoding<T, typename TypeTraits<T>::physicalType> {
+ public:
+  using cppDataType = T;
+  using physicalType = typename TypeTraits<T>::physicalType;
+
+  PforEncoding(
+      velox::memory::MemoryPool& pool,
+      std::string_view data,
+      const std::function<void*(uint32_t)>& stringBufferFactory,
+      const Encoding::Options& options = {});
+
+  void reset() final;
+  void skip(uint32_t rowCount) final;
+  void materialize(uint32_t rowCount, void* buffer) final;
+
+  template <typename DecoderVisitor>
+  void readWithVisitor(DecoderVisitor& visitor, ReadWithVisitorParams& params);
+
+  static std::string_view encode(
+      EncodingSelection<physicalType>& selection,
+      std::span<const physicalType> values,
+      Buffer& buffer,
+      const Encoding::Options& options = {});
+
+  std::string debugString(int offset) const final;
+
+  /// Selects the base bit width from the bucket histogram, targeting 90%
+  /// coverage. Returns {baseBitWidth, numExceptions}.
+  /// Shared by encode() and EncodingSizeEstimation to keep the two in sync.
+  template <typename BucketArray>
+  static std::pair<uint8_t, uint64_t> selectBaseBitWidth(
+      const BucketArray& bucketCounts,
+      uint32_t rowCount,
+      uint8_t maxBitWidth) {
+    constexpr double kCoverageThreshold = 0.9;
+    if (maxBitWidth == 0) {
+      return {0, 0};
+    }
+    const uint64_t threshold = static_cast<uint64_t>(
+        static_cast<double>(rowCount) * kCoverageThreshold);
+    uint64_t cumulative = 0;
+    for (size_t k = 0; k < bucketCounts.size(); ++k) {
+      cumulative += bucketCounts[k];
+      if (cumulative >= threshold) {
+        const uint8_t bucketEndBitWidth =
+            static_cast<uint8_t>(std::min<size_t>((k + 1) * 7, 64));
+        return {
+            std::min(bucketEndBitWidth, maxBitWidth), rowCount - cumulative};
+      }
+    }
+    return {maxBitWidth, 0};
+  }
+
+ private:
+  /// Fixed-size header: baseline + baseBitWidth(1) + numExceptions(4).
+  static constexpr int kPrefixSize =
+      sizeof(physicalType) + 1 + sizeof(uint32_t);
+  // Patches any exceptions whose absolute position falls inside
+  // [row_, row_ + count) onto `output`, where output[k] corresponds to
+  // absolute position row_ + k. Advances exceptionCursor_ past consumed
+  // exceptions.
+  void patchExceptions(uint32_t count, physicalType* output);
+
+  // Advances exceptionCursor_ past any exception positions that fall before
+  // `targetRow`. Uses binary search for efficient seeking during skip()
+  // and reset().
+  void seekExceptionsTo(uint32_t targetRow);
+
+  // Wire-format header values, populated in the constructor.
+  physicalType baseline_{};
+  uint8_t baseBitWidth_{0};
+  uint32_t numExceptions_{0};
+
+  // Decoded exception side-channel. Eagerly decoded and stored at
+  // construction time since numExceptions_ is bounded by ~10% of rowCount
+  // in the typical case. Positions are in strictly ascending order.
+  Vector<uint32_t> exceptionPositions_;
+  Vector<physicalType> exceptionValues_;
+
+  // Bitpacked base-residual region. Default-constructed (empty) when
+  // baseBitWidth_ == 0.
+  FixedBitArray fixedBitArray_{};
+
+  // Current absolute row position in the stream.
+  uint32_t row_{0};
+
+  // Index of the next unconsumed exception in exceptionPositions_ /
+  // exceptionValues_. Monotonically increases as rows are consumed.
+  uint32_t exceptionCursor_{0};
+};
+
+//
+// End of public API. Implementations follow.
+//
+
+template <typename T>
+PforEncoding<T>::PforEncoding(
+    velox::memory::MemoryPool& pool,
+    std::string_view data,
+    const std::function<void*(uint32_t)>& /* stringBufferFactory */,
+    const Encoding::Options& options)
+    : TypedEncoding<T, physicalType>{pool, data, options},
+      exceptionPositions_{this->pool_},
+      exceptionValues_{this->pool_} {
+  if constexpr (!isIntegralType<physicalType>()) {
+    NIMBLE_INCOMPATIBLE_ENCODING(
+        "Pfor encoding only supports integral data types.");
+  } else {
+    const char* pos = data.data() + this->dataOffset();
+
+    // Parse the fixed-size header: baseline, baseBitWidth, numExceptions.
+    baseline_ = encoding::read<physicalType>(pos);
+    baseBitWidth_ = static_cast<uint8_t>(encoding::readChar(pos));
+    NIMBLE_CHECK_LE(
+        baseBitWidth_, 64, "Pfor base bit width must be in [0, 64].");
+    numExceptions_ = encoding::readUint32(pos);
+    NIMBLE_CHECK_LE(
+        numExceptions_,
+        this->rowCount_,
+        "Pfor exception count exceeds row count.");
+
+    // Eagerly decode exception positions (varint-encoded, ascending order).
+    exceptionPositions_.resize(numExceptions_);
+    for (uint32_t i = 0; i < numExceptions_; ++i) {
+      exceptionPositions_[i] = varint::readVarint32(&pos);
+      NIMBLE_CHECK_LT(
+          exceptionPositions_[i],
+          this->rowCount_,
+          "Pfor exception position out of range.");
+      if (i > 0) {
+        NIMBLE_CHECK_GT(
+            exceptionPositions_[i],
+            exceptionPositions_[i - 1],
+            "Pfor exception positions must be strictly ascending.");
+      }
+    }
+
+    // Eagerly decode exception values (varint-encoded full residuals).
+    exceptionValues_.resize(numExceptions_);
+    for (uint32_t i = 0; i < numExceptions_; ++i) {
+      if constexpr (
+          isFourByteIntegralType<physicalType>() || sizeof(physicalType) < 4) {
+        exceptionValues_[i] =
+            static_cast<physicalType>(varint::readVarint32(&pos));
+      } else {
+        exceptionValues_[i] =
+            static_cast<physicalType>(varint::readVarint64(&pos));
+      }
+    }
+
+    // Map the bitpacked residual region. Verify the wire data has
+    // enough bytes remaining to prevent out-of-bounds reads during decode.
+    // baseBitWidth_ == 0 when all values are identical (range == 0).
+    // No bitpacked region is stored in that case.
+    if (baseBitWidth_ > 0) {
+      const size_t bitpackedSize =
+          FixedBitArray::bufferSize(this->rowCount_, baseBitWidth_);
+      NIMBLE_CHECK_GE(
+          static_cast<size_t>(data.end() - pos),
+          bitpackedSize,
+          "Pfor bitpacked region underruns wire data.");
+      fixedBitArray_ = FixedBitArray{
+          {pos, static_cast<size_t>(data.end() - pos)}, baseBitWidth_};
+    }
+  }
+  reset();
+}
+
+template <typename T>
+void PforEncoding<T>::reset() {
+  row_ = 0;
+  exceptionCursor_ = 0;
+}
+
+template <typename T>
+void PforEncoding<T>::seekExceptionsTo(uint32_t targetRow) {
+  // Linear scan for small exception counts, binary search for large counts.
+  const uint32_t remaining = numExceptions_ - exceptionCursor_;
+  constexpr uint32_t kLinearScanThreshold{64};
+  if (remaining < kLinearScanThreshold) {
+    while (exceptionCursor_ < numExceptions_ &&
+           exceptionPositions_[exceptionCursor_] < targetRow) {
+      ++exceptionCursor_;
+    }
+  } else {
+    const auto begin = exceptionPositions_.begin();
+    const auto it = std::lower_bound(
+        begin + exceptionCursor_, exceptionPositions_.end(), targetRow);
+    exceptionCursor_ = static_cast<uint32_t>(it - begin);
+  }
+}
+
+template <typename T>
+void PforEncoding<T>::skip(uint32_t rowCount) {
+  row_ += rowCount;
+  seekExceptionsTo(row_);
+}
+
+template <typename T>
+void PforEncoding<T>::patchExceptions(uint32_t count, physicalType* output) {
+  // Overwrite exception slots with their full values. Exceptions are
+  // in ascending position order, so this is a forward linear scan.
+  const auto endRow = row_ + count;
+  while (exceptionCursor_ < numExceptions_ &&
+         exceptionPositions_[exceptionCursor_] < endRow) {
+    const auto row = exceptionPositions_[exceptionCursor_];
+    output[row - row_] = static_cast<physicalType>(
+        baseline_ + exceptionValues_[exceptionCursor_]);
+    ++exceptionCursor_;
+  }
+}
+
+template <typename T>
+void PforEncoding<T>::materialize(uint32_t rowCount, void* buffer) {
+  if (rowCount == 0) {
+    return;
+  }
+
+  // Unpack all base residuals (branchless bulk decode).
+  auto* output = static_cast<physicalType*>(buffer);
+  if (baseBitWidth_ == 0) {
+    // All residuals are zero; every value equals baseline.
+    std::fill(output, output + rowCount, baseline_);
+  } else if constexpr (isFourByteIntegralType<physicalType>()) {
+    fixedBitArray_.bulkGetWithBaseline32(
+        /*start=*/row_,
+        /*length=*/rowCount,
+        reinterpret_cast<uint32_t*>(output),
+        static_cast<uint32_t>(baseline_));
+  } else if constexpr (isEightByteIntegralType<physicalType>()) {
+    fixedBitArray_.bulkGet64WithBaseline(
+        /*start=*/row_,
+        /*length=*/rowCount,
+        reinterpret_cast<uint64_t*>(output),
+        static_cast<uint64_t>(baseline_));
+  } else {
+    // Narrow integral path (1- or 2-byte types). The bulk paths require
+    // 4- or 8-byte outputs; per-element get is acceptable for rare narrow
+    // streams.
+    for (auto i = 0; i < rowCount; ++i) {
+      output[i] =
+          static_cast<physicalType>(fixedBitArray_.get(row_ + i) + baseline_);
+    }
+  }
+
+  // Patch exception positions with their full values.
+  patchExceptions(rowCount, output);
+  row_ += rowCount;
+}
+
+template <typename T>
+template <typename V>
+void PforEncoding<T>::readWithVisitor(
+    V& visitor,
+    ReadWithVisitorParams& params) {
+  // TODO: Add a bulkScan / readWithVisitorFast path for 4-byte and 8-byte
+  // integral types once Pfor is used on hot read paths. The challenge is
+  // interleaving exception patching with the bulk scan framework. For now
+  // the slow path is sufficient since Pfor is a niche encoding.
+  detail::readWithVisitorSlow(
+      visitor,
+      params,
+      [&](auto toSkip) { skip(toSkip); },
+      [&]() {
+        physicalType value;
+        if (baseBitWidth_ == 0) {
+          value = baseline_;
+        } else {
+          value =
+              static_cast<physicalType>(fixedBitArray_.get(row_) + baseline_);
+        }
+        // Override with the exception value if one lands exactly on this row.
+        if (exceptionCursor_ < numExceptions_ &&
+            exceptionPositions_[exceptionCursor_] == row_) {
+          value = static_cast<physicalType>(
+              baseline_ + exceptionValues_[exceptionCursor_]);
+          ++exceptionCursor_;
+        }
+        ++row_;
+        return value;
+      });
+}
+
+template <typename T>
+std::string_view PforEncoding<T>::encode(
+    EncodingSelection<typename TypeTraits<T>::physicalType>& selection,
+    std::span<const typename TypeTraits<T>::physicalType> values,
+    Buffer& buffer,
+    const Encoding::Options& options) {
+  if constexpr (!isIntegralType<physicalType>()) {
+    NIMBLE_INCOMPATIBLE_ENCODING(
+        "Pfor encoding only supports integral data types.");
+  } else {
+    static_assert(
+        std::is_same_v<
+            typename std::make_unsigned<physicalType>::type,
+            physicalType>,
+        "Pfor physical type must be unsigned.");
+    const bool useVarint = options.useVarintRowCount;
+    NIMBLE_CHECK(!values.empty(), "Pfor encoding cannot be used with 0 rows.");
+
+    const uint32_t rowCount = static_cast<uint32_t>(values.size());
+    const physicalType baseline = selection.statistics().min();
+    const physicalType maxValue = selection.statistics().max();
+    const physicalType fullRange =
+        static_cast<physicalType>(maxValue - baseline);
+    const uint8_t maxBitWidth =
+        static_cast<uint8_t>(velox::bits::bitsRequired(fullRange));
+
+    const auto [baseBitWidth, expectedExceptions] = selectBaseBitWidth(
+        selection.statistics().bucketCounts(), rowCount, maxBitWidth);
+
+    // Single pass: compute residuals, identify exceptions that overflow
+    // baseBitWidth, and zero-mask exception slots in the residual array.
+    constexpr uint32_t kBitsPerPhysicalType = sizeof(physicalType) * 8;
+    const physicalType baseMask = baseBitWidth == 0
+        ? physicalType{0}
+        : static_cast<physicalType>(velox::bits::lowMask(baseBitWidth));
+
+    Vector<uint32_t> exceptionPositions{&buffer.getMemoryPool()};
+    Vector<physicalType> exceptionValues{&buffer.getMemoryPool()};
+    // Pre-reserve for ~10% exceptions to avoid repeated reallocs.
+    exceptionPositions.reserve(rowCount / 10);
+    exceptionValues.reserve(rowCount / 10);
+
+    Vector<physicalType> maskedResiduals{&buffer.getMemoryPool()};
+    maskedResiduals.resize(rowCount);
+    for (auto i = 0; i < rowCount; ++i) {
+      const physicalType residual =
+          static_cast<physicalType>(values[i] - baseline);
+      if (baseBitWidth < kBitsPerPhysicalType && residual > baseMask) {
+        exceptionPositions.emplace_back(i);
+        exceptionValues.emplace_back(residual);
+        maskedResiduals[i] = physicalType{0};
+      } else {
+        maskedResiduals[i] = residual;
+      }
+    }
+    const uint32_t numExceptions =
+        static_cast<uint32_t>(exceptionPositions.size());
+
+    // Compute varint sizes for the exception side-channel.
+    uint64_t exceptionPositionBytes{0};
+    uint64_t exceptionValueBytes{0};
+    for (uint32_t i = 0; i < numExceptions; ++i) {
+      exceptionPositionBytes += varint::varintSize(exceptionPositions[i]);
+      exceptionValueBytes += varint::varintSize(exceptionValues[i]);
+    }
+    const uint64_t bitpackedSize = baseBitWidth == 0
+        ? 0
+        : FixedBitArray::bufferSize(rowCount, baseBitWidth);
+    const uint32_t encodingSize =
+        Encoding::serializePrefixSize(rowCount, useVarint) +
+        PforEncoding<T>::kPrefixSize +
+        static_cast<uint32_t>(
+            exceptionPositionBytes + exceptionValueBytes + bitpackedSize);
+
+    // Serialize into the output buffer.
+    char* reserved = buffer.reserve(encodingSize);
+    char* pos = reserved;
+    Encoding::serializePrefix(
+        EncodingType::Pfor, TypeTraits<T>::dataType, rowCount, useVarint, pos);
+    encoding::write(baseline, pos);
+    encoding::writeChar(static_cast<char>(baseBitWidth), pos);
+    encoding::writeUint32(numExceptions, pos);
+
+    // Write exception positions (ascending varint sequence).
+    for (uint32_t i = 0; i < numExceptions; ++i) {
+      varint::writeVarint(exceptionPositions[i], &pos);
+    }
+    // Write exception values (full residual varints).
+    for (uint32_t i = 0; i < numExceptions; ++i) {
+      varint::writeVarint(exceptionValues[i], &pos);
+    }
+
+    // Bitpack the masked residuals.
+    if (baseBitWidth > 0) {
+      char* bitpackedStart = pos;
+      std::memset(bitpackedStart, 0, bitpackedSize);
+      FixedBitArray fba(bitpackedStart, baseBitWidth);
+      if constexpr (isFourByteIntegralType<physicalType>()) {
+        fba.bulkSet32WithBaseline(
+            /*start=*/0,
+            /*length=*/rowCount,
+            reinterpret_cast<const uint32_t*>(maskedResiduals.data()),
+            /*baseline=*/0);
+      } else {
+        // TODO: Add a bulkSet64 path to FixedBitArray and use it here
+        // for 8-byte types to match the 4-byte bulk path above.
+        for (uint32_t i = 0; i < rowCount; ++i) {
+          fba.set(i, static_cast<uint64_t>(maskedResiduals[i]));
+        }
+      }
+      pos += bitpackedSize;
+    }
+
+    NIMBLE_CHECK_EQ(
+        pos - reserved, encodingSize, "Pfor encoding size mismatch.");
+    return {reserved, encodingSize};
+  }
+}
+
+template <typename T>
+std::string PforEncoding<T>::debugString(int offset) const {
+  return fmt::format(
+      "{}{}<{}> rowCount={} baseBitWidth={} numExceptions={}",
+      std::string(offset, ' '),
+      toString(Encoding::encodingType()),
+      toString(Encoding::dataType()),
+      Encoding::rowCount(),
+      static_cast<int>(baseBitWidth_),
+      numExceptions_);
+}
+
+} // namespace facebook::nimble

--- a/dwio/nimble/encodings/common/Encoding.h
+++ b/dwio/nimble/encodings/common/Encoding.h
@@ -694,6 +694,53 @@ T* mutableValues(const V& visitor, vector_size_t size) {
   return values;
 }
 
+/// Post-processing for bulkScan implementations. Handles the fast return
+/// path (no scatter/filter/hook) and delegates complex cases to
+/// processFixedWidthRun. Every encoding that implements bulkScan shares
+/// this identical finalization logic.
+template <typename OutputType, bool kScatter, typename V>
+void finalizeBulkScan(
+    V& visitor,
+    OutputType* values,
+    vector_size_t numRows,
+    const vector_size_t* selectedRows,
+    vector_size_t numSelected,
+    const vector_size_t* scatterRows) {
+  if constexpr (!kScatter && !V::kHasFilter && !V::kHasHook) {
+    visitor.addNumValues(numRows);
+    visitor.setRowIndex(visitor.numRows());
+    return;
+  }
+
+  if constexpr (!V::kHasHook) {
+    values = reinterpret_cast<OutputType*>(visitor.reader().rawValues());
+  }
+
+  auto numValues = visitor.reader().numValues();
+  int32_t* filterHits = nullptr;
+  if constexpr (V::kHasFilter) {
+    filterHits = visitor.outputRows(numSelected) - numValues;
+  }
+
+  velox::dwio::common::
+      processFixedWidthRun<OutputType, V::kFilterOnly, kScatter, V::dense>(
+          velox::RowSet(selectedRows, numSelected),
+          /*rowIndex=*/0,
+          numSelected,
+          scatterRows,
+          values,
+          filterHits,
+          numValues,
+          visitor.filter(),
+          visitor.hook());
+
+  if constexpr (!V::kHasHook) {
+    visitor.addNumValues(
+        V::kHasFilter ? numValues - visitor.reader().numValues() : numRows);
+  }
+  visitor.setRowIndex(visitor.numRows());
+}
+
 } // namespace detail
 
 } // namespace facebook::nimble

--- a/dwio/nimble/encodings/common/EncodingFactory.cpp
+++ b/dwio/nimble/encodings/common/EncodingFactory.cpp
@@ -18,6 +18,7 @@
 #include "dwio/nimble/encodings/ConstantEncoding.h"
 #include "dwio/nimble/encodings/DeltaEncoding.h"
 #include "dwio/nimble/encodings/DictionaryEncoding.h"
+#include "dwio/nimble/encodings/DoubleDeltaEncoding.h"
 #include "dwio/nimble/encodings/FixedBitWidthEncoding.h"
 #include "dwio/nimble/encodings/MainlyConstantEncoding.h"
 #include "dwio/nimble/encodings/NullableEncoding.h"
@@ -253,11 +254,27 @@ std::unique_ptr<Encoding> EncodingFactory::create(
     case EncodingType::Pfor: {
       RETURN_ENCODING_BY_NUMERIC_TYPE(PforEncoding, dataType);
     }
-  }
-  default: {
-    NIMBLE_UNREACHABLE(
-        "Trying to deserialize invalid EncodingType:{} -- garbage input?",
-        static_cast<int>(encodingType));
+    }
+    case EncodingType::DoubleDelta: {
+      switch (dataType) {
+        case DataType::Int64:
+          return std::make_unique<DoubleDeltaEncoding<int64_t>>(
+              memoryPool, data, stringBufferFactory, options);
+        case DataType::Uint64:
+          return std::make_unique<DoubleDeltaEncoding<uint64_t>>(
+              memoryPool, data, stringBufferFactory, options);
+        default:
+          NIMBLE_UNREACHABLE(
+              "DoubleDelta only supports 64-bit integer types, got {}.",
+              toString(dataType));
+      }
+    }
+    default: {
+      NIMBLE_UNREACHABLE(
+          "Trying to deserialize invalid EncodingType:{} -- garbage input?",
+          static_cast<int>(encodingType));
+    }
+
   }
 }
 }
@@ -400,6 +417,22 @@ std::string_view EncodingFactory::encode(
             toString(TypeTraits<T>::dataType));
       }
     }
+
+    case EncodingType::DoubleDelta: {
+      if constexpr (std::is_same_v<T, int64_t> || std::is_same_v<T, uint64_t>) {
+        return DoubleDeltaEncoding<T>::encode(
+            selection, castedValues, buffer, options);
+      } else {
+        NIMBLE_INCOMPATIBLE_ENCODING(
+            "DoubleDelta encoding only supports 64-bit integer types, got {}.",
+            toString(TypeTraits<T>::dataType));
+      }
+    }
+    default: {
+      NIMBLE_UNSUPPORTED(
+          "Encoding {} is not supported.", toString(selection.encodingType()));
+    }
+
   }
   default: {
     NIMBLE_UNSUPPORTED(

--- a/dwio/nimble/encodings/common/EncodingFactory.cpp
+++ b/dwio/nimble/encodings/common/EncodingFactory.cpp
@@ -21,6 +21,7 @@
 #include "dwio/nimble/encodings/FixedBitWidthEncoding.h"
 #include "dwio/nimble/encodings/MainlyConstantEncoding.h"
 #include "dwio/nimble/encodings/NullableEncoding.h"
+#include "dwio/nimble/encodings/PforEncoding.h"
 #include "dwio/nimble/encodings/PrefixEncoding.h"
 #include "dwio/nimble/encodings/RleEncoding.h"
 #include "dwio/nimble/encodings/SparseBoolEncoding.h"
@@ -249,12 +250,16 @@ std::unique_ptr<Encoding> EncodingFactory::create(
       // is implemented. ALP only supports float and double.
       NIMBLE_UNSUPPORTED("ALP encoding is not yet implemented.");
     }
-    default: {
-      NIMBLE_UNREACHABLE(
-          "Trying to deserialize invalid EncodingType:{} -- garbage input?",
-          static_cast<int>(encodingType));
+    case EncodingType::Pfor: {
+      RETURN_ENCODING_BY_NUMERIC_TYPE(PforEncoding, dataType);
     }
   }
+  default: {
+    NIMBLE_UNREACHABLE(
+        "Trying to deserialize invalid EncodingType:{} -- garbage input?",
+        static_cast<int>(encodingType));
+  }
+}
 }
 
 template <typename T>
@@ -383,15 +388,24 @@ std::string_view EncodingFactory::encode(
       }
     }
     case EncodingType::ALP: {
-      // TODO: Wire up ALPEncoding::encode once the actual ALP algorithm is
-      // implemented. ALP only supports float and double.
       NIMBLE_UNSUPPORTED("ALP encoding is not yet implemented.");
     }
-    default: {
-      NIMBLE_UNSUPPORTED(
-          "Encoding {} is not supported.", toString(selection.encodingType()));
+    case EncodingType::Pfor: {
+      if constexpr (isIntegralType<physicalType>()) {
+        return PforEncoding<T>::encode(
+            selection, castedValues, buffer, options);
+      } else {
+        NIMBLE_INCOMPATIBLE_ENCODING(
+            "Pfor encoding should not be selected for non-integral data type: {}.",
+            toString(TypeTraits<T>::dataType));
+      }
     }
   }
+  default: {
+    NIMBLE_UNSUPPORTED(
+        "Encoding {} is not supported.", toString(selection.encodingType()));
+  }
+}
 }
 
 template <typename T>

--- a/dwio/nimble/encodings/common/EncodingFactory.cpp
+++ b/dwio/nimble/encodings/common/EncodingFactory.cpp
@@ -15,6 +15,7 @@
  */
 #include "dwio/nimble/encodings/common/EncodingFactory.h"
 #include "dwio/nimble/encodings/ALPEncoding.h"
+#include "dwio/nimble/encodings/CompactForEncoding.h"
 #include "dwio/nimble/encodings/ConstantEncoding.h"
 #include "dwio/nimble/encodings/DeltaEncoding.h"
 #include "dwio/nimble/encodings/DictionaryEncoding.h"
@@ -269,6 +270,20 @@ std::unique_ptr<Encoding> EncodingFactory::create(
               toString(dataType));
       }
     }
+    case EncodingType::CompactFor: {
+      switch (dataType) {
+        case DataType::Int64:
+          return std::make_unique<CompactForEncoding<int64_t>>(
+              memoryPool, data, stringBufferFactory, options);
+        case DataType::Uint64:
+          return std::make_unique<CompactForEncoding<uint64_t>>(
+              memoryPool, data, stringBufferFactory, options);
+        default:
+          NIMBLE_UNREACHABLE(
+              "CompactFor only supports 64-bit integer types, got {}.",
+              toString(dataType));
+      }
+    }
     default: {
       NIMBLE_UNREACHABLE(
           "Trying to deserialize invalid EncodingType:{} -- garbage input?",
@@ -425,6 +440,16 @@ std::string_view EncodingFactory::encode(
       } else {
         NIMBLE_INCOMPATIBLE_ENCODING(
             "DoubleDelta encoding only supports 64-bit integer types, got {}.",
+            toString(TypeTraits<T>::dataType));
+      }
+    }
+    case EncodingType::CompactFor: {
+      if constexpr (std::is_same_v<T, int64_t> || std::is_same_v<T, uint64_t>) {
+        return CompactForEncoding<T>::encode(
+            selection, castedValues, buffer, options);
+      } else {
+        NIMBLE_INCOMPATIBLE_ENCODING(
+            "CompactFor encoding only supports 64-bit integer types, got {}.",
             toString(TypeTraits<T>::dataType));
       }
     }

--- a/dwio/nimble/encodings/common/EncodingLayout.cpp
+++ b/dwio/nimble/encodings/common/EncodingLayout.cpp
@@ -173,7 +173,8 @@ EncodingLayout EncodingLayoutCapture::capture(std::string_view encoding) {
     case EncodingType::Constant:
     case EncodingType::Prefix:
     case EncodingType::ALP:
-    case EncodingType::Pfor: {
+    case EncodingType::Pfor:
+    case EncodingType::DoubleDelta: {
       // Non nested encodings have zero children
       break;
     }

--- a/dwio/nimble/encodings/common/EncodingLayout.cpp
+++ b/dwio/nimble/encodings/common/EncodingLayout.cpp
@@ -172,7 +172,8 @@ EncodingLayout EncodingLayoutCapture::capture(std::string_view encoding) {
     case EncodingType::Varint:
     case EncodingType::Constant:
     case EncodingType::Prefix:
-    case EncodingType::ALP: {
+    case EncodingType::ALP:
+    case EncodingType::Pfor: {
       // Non nested encodings have zero children
       break;
     }

--- a/dwio/nimble/encodings/common/EncodingLayout.cpp
+++ b/dwio/nimble/encodings/common/EncodingLayout.cpp
@@ -174,7 +174,8 @@ EncodingLayout EncodingLayoutCapture::capture(std::string_view encoding) {
     case EncodingType::Prefix:
     case EncodingType::ALP:
     case EncodingType::Pfor:
-    case EncodingType::DoubleDelta: {
+    case EncodingType::DoubleDelta:
+    case EncodingType::CompactFor: {
       // Non nested encodings have zero children
       break;
     }

--- a/dwio/nimble/encodings/common/EncodingUtils.h
+++ b/dwio/nimble/encodings/common/EncodingUtils.h
@@ -16,6 +16,7 @@
 #pragma once
 
 #include "dwio/nimble/encodings/ALPEncoding.h"
+#include "dwio/nimble/encodings/CompactForEncoding.h"
 #include "dwio/nimble/encodings/ConstantEncoding.h"
 #include "dwio/nimble/encodings/DeltaEncoding.h"
 #include "dwio/nimble/encodings/DictionaryEncoding.h"
@@ -138,6 +139,12 @@ auto encodingTypeDispatchNonString(Encoding& encoding, F&& f) {
     case EncodingType::DoubleDelta:
       if constexpr (std::is_same_v<T, int64_t> || std::is_same_v<T, uint64_t>) {
         return f(static_cast<DoubleDeltaEncoding<T>&>(encoding));
+      } else {
+        NIMBLE_UNREACHABLE("{}", encoding.dataType());
+      }
+    case EncodingType::CompactFor:
+      if constexpr (std::is_same_v<T, int64_t> || std::is_same_v<T, uint64_t>) {
+        return f(static_cast<CompactForEncoding<T>&>(encoding));
       } else {
         NIMBLE_UNREACHABLE("{}", encoding.dataType());
       }

--- a/dwio/nimble/encodings/common/EncodingUtils.h
+++ b/dwio/nimble/encodings/common/EncodingUtils.h
@@ -19,6 +19,7 @@
 #include "dwio/nimble/encodings/ConstantEncoding.h"
 #include "dwio/nimble/encodings/DeltaEncoding.h"
 #include "dwio/nimble/encodings/DictionaryEncoding.h"
+#include "dwio/nimble/encodings/DoubleDeltaEncoding.h"
 #include "dwio/nimble/encodings/FixedBitWidthEncoding.h"
 #include "dwio/nimble/encodings/MainlyConstantEncoding.h"
 #include "dwio/nimble/encodings/NullableEncoding.h"
@@ -131,6 +132,12 @@ auto encodingTypeDispatchNonString(Encoding& encoding, F&& f) {
     case EncodingType::Pfor:
       if constexpr (isIntegralType<T>()) {
         return f(static_cast<PforEncoding<T>&>(encoding));
+      } else {
+        NIMBLE_UNREACHABLE("{}", encoding.dataType());
+      }
+    case EncodingType::DoubleDelta:
+      if constexpr (std::is_same_v<T, int64_t> || std::is_same_v<T, uint64_t>) {
+        return f(static_cast<DoubleDeltaEncoding<T>&>(encoding));
       } else {
         NIMBLE_UNREACHABLE("{}", encoding.dataType());
       }

--- a/dwio/nimble/encodings/common/EncodingUtils.h
+++ b/dwio/nimble/encodings/common/EncodingUtils.h
@@ -22,6 +22,7 @@
 #include "dwio/nimble/encodings/FixedBitWidthEncoding.h"
 #include "dwio/nimble/encodings/MainlyConstantEncoding.h"
 #include "dwio/nimble/encodings/NullableEncoding.h"
+#include "dwio/nimble/encodings/PforEncoding.h"
 #include "dwio/nimble/encodings/PrefixEncoding.h"
 #include "dwio/nimble/encodings/RleEncoding.h"
 #include "dwio/nimble/encodings/SparseBoolEncoding.h"
@@ -126,9 +127,13 @@ auto encodingTypeDispatchNonString(Encoding& encoding, F&& f) {
     case EncodingType::Delta:
       return f(static_cast<DeltaEncoding<T>&>(encoding));
     case EncodingType::ALP:
-      // TODO: Wire up ALPEncoding readWithVisitor dispatch once the actual
-      // ALP algorithm is implemented. ALP only supports float and double.
       NIMBLE_UNSUPPORTED("ALP encoding is not yet implemented.");
+    case EncodingType::Pfor:
+      if constexpr (isIntegralType<T>()) {
+        return f(static_cast<PforEncoding<T>&>(encoding));
+      } else {
+        NIMBLE_UNREACHABLE("{}", encoding.dataType());
+      }
     default:
       NIMBLE_UNSUPPORTED("{}", encoding.encodingType());
   }

--- a/dwio/nimble/encodings/legacy/EncodingFactory.cpp
+++ b/dwio/nimble/encodings/legacy/EncodingFactory.cpp
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 #include "dwio/nimble/encodings/legacy/EncodingFactory.h"
+#include "dwio/nimble/encodings/DoubleDeltaEncoding.h"
 #include "dwio/nimble/encodings/PforEncoding.h"
 #include "dwio/nimble/encodings/legacy/ConstantEncoding.h"
 #include "dwio/nimble/encodings/legacy/DeltaEncoding.h"
@@ -251,6 +252,22 @@ std::unique_ptr<Encoding> EncodingFactory::create(
     }
     case EncodingType::Pfor: {
       RETURN_ENCODING_BY_NUMERIC_TYPE(PforEncoding, dataType);
+    }
+    case EncodingType::DoubleDelta: {
+      switch (dataType) {
+        case DataType::Int64:
+          return std::make_unique<
+              ::facebook::nimble::DoubleDeltaEncoding<int64_t>>(
+              memoryPool, data, stringBufferFactory);
+        case DataType::Uint64:
+          return std::make_unique<
+              ::facebook::nimble::DoubleDeltaEncoding<uint64_t>>(
+              memoryPool, data, stringBufferFactory);
+        default:
+          NIMBLE_UNREACHABLE(
+              "DoubleDelta only supports 64-bit integer types, got {}.",
+              toString(dataType));
+      }
     }
     default: {
       NIMBLE_UNREACHABLE(

--- a/dwio/nimble/encodings/legacy/EncodingFactory.cpp
+++ b/dwio/nimble/encodings/legacy/EncodingFactory.cpp
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 #include "dwio/nimble/encodings/legacy/EncodingFactory.h"
+#include "dwio/nimble/encodings/CompactForEncoding.h"
 #include "dwio/nimble/encodings/DoubleDeltaEncoding.h"
 #include "dwio/nimble/encodings/PforEncoding.h"
 #include "dwio/nimble/encodings/legacy/ConstantEncoding.h"
@@ -266,6 +267,22 @@ std::unique_ptr<Encoding> EncodingFactory::create(
         default:
           NIMBLE_UNREACHABLE(
               "DoubleDelta only supports 64-bit integer types, got {}.",
+              toString(dataType));
+      }
+    }
+    case EncodingType::CompactFor: {
+      switch (dataType) {
+        case DataType::Int64:
+          return std::make_unique<
+              ::facebook::nimble::CompactForEncoding<int64_t>>(
+              memoryPool, data, stringBufferFactory);
+        case DataType::Uint64:
+          return std::make_unique<
+              ::facebook::nimble::CompactForEncoding<uint64_t>>(
+              memoryPool, data, stringBufferFactory);
+        default:
+          NIMBLE_UNREACHABLE(
+              "CompactFor only supports 64-bit integer types, got {}.",
               toString(dataType));
       }
     }

--- a/dwio/nimble/encodings/legacy/EncodingFactory.cpp
+++ b/dwio/nimble/encodings/legacy/EncodingFactory.cpp
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 #include "dwio/nimble/encodings/legacy/EncodingFactory.h"
+#include "dwio/nimble/encodings/PforEncoding.h"
 #include "dwio/nimble/encodings/legacy/ConstantEncoding.h"
 #include "dwio/nimble/encodings/legacy/DeltaEncoding.h"
 #include "dwio/nimble/encodings/legacy/DictionaryEncoding.h"
@@ -247,6 +248,9 @@ std::unique_ptr<Encoding> EncodingFactory::create(
           "Trying to deserialize a PrefixEncoding with a non-string data type.");
       return std::make_unique<PrefixEncoding>(
           memoryPool, data, stringBufferFactory);
+    }
+    case EncodingType::Pfor: {
+      RETURN_ENCODING_BY_NUMERIC_TYPE(PforEncoding, dataType);
     }
     default: {
       NIMBLE_UNREACHABLE(

--- a/dwio/nimble/encodings/legacy/EncodingUtils.h
+++ b/dwio/nimble/encodings/legacy/EncodingUtils.h
@@ -15,6 +15,7 @@
  */
 #pragma once
 
+#include "dwio/nimble/encodings/PforEncoding.h"
 #include "dwio/nimble/encodings/common/EncodingUtils.h"
 #include "dwio/nimble/encodings/legacy/ConstantEncoding.h"
 #include "dwio/nimble/encodings/legacy/DeltaEncoding.h"
@@ -106,6 +107,14 @@ auto encodingTypeDispatchNonString(Encoding& encoding, F&& f) {
       return f(static_cast<MainlyConstantEncoding<T>&>(encoding));
     case EncodingType::Delta:
       return f(static_cast<DeltaEncoding<T>&>(encoding));
+    // New Encoding has no legacy-specialised class; legacy reads dispatch into
+    // the modern Encoding classes
+    case EncodingType::Pfor:
+      if constexpr (isIntegralType<T>()) {
+        return f(static_cast<PforEncoding<T>&>(encoding));
+      } else {
+        NIMBLE_UNREACHABLE(toString(encoding.dataType()));
+      }
     default:
       NIMBLE_UNSUPPORTED(toString(encoding.encodingType()));
   }

--- a/dwio/nimble/encodings/legacy/EncodingUtils.h
+++ b/dwio/nimble/encodings/legacy/EncodingUtils.h
@@ -15,6 +15,7 @@
  */
 #pragma once
 
+#include "dwio/nimble/encodings/CompactForEncoding.h"
 #include "dwio/nimble/encodings/DoubleDeltaEncoding.h"
 #include "dwio/nimble/encodings/PforEncoding.h"
 #include "dwio/nimble/encodings/common/EncodingUtils.h"
@@ -119,6 +120,14 @@ auto encodingTypeDispatchNonString(Encoding& encoding, F&& f) {
     case EncodingType::DoubleDelta:
       if constexpr (std::is_same_v<T, int64_t> || std::is_same_v<T, uint64_t>) {
         return f(static_cast<DoubleDeltaEncoding<T>&>(encoding));
+      } else {
+        NIMBLE_UNREACHABLE(toString(encoding.dataType()));
+      }
+    case EncodingType::CompactFor:
+      // Same legacy-dispatches-to-modern story as Pfor.
+      if constexpr (std::is_same_v<T, int64_t> || std::is_same_v<T, uint64_t>) {
+        return f(
+            static_cast<::facebook::nimble::CompactForEncoding<T>&>(encoding));
       } else {
         NIMBLE_UNREACHABLE(toString(encoding.dataType()));
       }

--- a/dwio/nimble/encodings/legacy/EncodingUtils.h
+++ b/dwio/nimble/encodings/legacy/EncodingUtils.h
@@ -15,6 +15,7 @@
  */
 #pragma once
 
+#include "dwio/nimble/encodings/DoubleDeltaEncoding.h"
 #include "dwio/nimble/encodings/PforEncoding.h"
 #include "dwio/nimble/encodings/common/EncodingUtils.h"
 #include "dwio/nimble/encodings/legacy/ConstantEncoding.h"
@@ -112,6 +113,12 @@ auto encodingTypeDispatchNonString(Encoding& encoding, F&& f) {
     case EncodingType::Pfor:
       if constexpr (isIntegralType<T>()) {
         return f(static_cast<PforEncoding<T>&>(encoding));
+      } else {
+        NIMBLE_UNREACHABLE(toString(encoding.dataType()));
+      }
+    case EncodingType::DoubleDelta:
+      if constexpr (std::is_same_v<T, int64_t> || std::is_same_v<T, uint64_t>) {
+        return f(static_cast<DoubleDeltaEncoding<T>&>(encoding));
       } else {
         NIMBLE_UNREACHABLE(toString(encoding.dataType()));
       }

--- a/dwio/nimble/encodings/selection/EncodingSizeEstimation.h
+++ b/dwio/nimble/encodings/selection/EncodingSizeEstimation.h
@@ -21,6 +21,7 @@
 #include "dwio/nimble/common/Exceptions.h"
 #include "dwio/nimble/common/FixedBitArray.h"
 #include "dwio/nimble/common/Types.h"
+#include "dwio/nimble/encodings/PforEncoding.h"
 #include "velox/common/base/BitUtil.h"
 
 namespace facebook::nimble {
@@ -149,6 +150,31 @@ struct EncodingSizeEstimation {
               });
           return getEncodingOverhead<EncodingType::Varint, physicalType>() +
               dataSize;
+        } else {
+          return std::nullopt;
+        }
+      }
+      case EncodingType::Pfor: {
+        if constexpr (isIntegralType<physicalType>()) {
+          const auto fullRange =
+              static_cast<physicalType>(statistics.max() - statistics.min());
+          const uint8_t maxBitWidth =
+              static_cast<uint8_t>(velox::bits::bitsRequired(fullRange));
+          const auto [baseBitWidth, numExceptions] =
+              PforEncoding<physicalType>::selectBaseBitWidth(
+                  statistics.bucketCounts(), entryCount, maxBitWidth);
+          const uint64_t bitpackedSize = baseBitWidth == 0
+              ? 0
+              : FixedBitArray::bufferSize(entryCount, baseBitWidth);
+          // Per-exception: position varint (max 5B) + value varint (max
+          // ceil(maxBitWidth/7) bytes, capped at 10).
+          const uint64_t valueVarintBytes = std::min<uint64_t>(
+              (static_cast<uint64_t>(maxBitWidth) + 6) / 7, 10);
+          const uint64_t exceptionsSize =
+              numExceptions * (5 + valueVarintBytes);
+          constexpr uint32_t overhead =
+              6 + sizeof(physicalType) + 1 + sizeof(uint32_t);
+          return overhead + bitpackedSize + exceptionsSize;
         } else {
           return std::nullopt;
         }

--- a/dwio/nimble/encodings/selection/EncodingSizeEstimation.h
+++ b/dwio/nimble/encodings/selection/EncodingSizeEstimation.h
@@ -154,6 +154,46 @@ struct EncodingSizeEstimation {
           return std::nullopt;
         }
       }
+      case EncodingType::DoubleDelta: {
+        if constexpr (
+            isIntegralType<physicalType>() && sizeof(physicalType) == 8) {
+          // Approximate bitWidth from average delta magnitude (×2 for
+          // double-delta wobble). Conservative: overestimates for irregular
+          // data, exact for constant-interval (bitWidth=0).
+          const physicalType range =
+              static_cast<physicalType>(statistics.max() - statistics.min());
+          uint64_t bitWidth = 0;
+          if (range != 0 && entryCount >= 3) {
+            const uint64_t perStepMagnitude = std::max<uint64_t>(
+                1,
+                static_cast<uint64_t>(range) /
+                    std::max<uint64_t>(1, entryCount - 1));
+            bitWidth = velox::bits::bitsRequired(perStepMagnitude * 2);
+          }
+          const uint64_t residualCount =
+              entryCount >= 3 ? entryCount - 2 : uint64_t{0};
+          const uint64_t bitpackedSize = bitWidth == 0
+              ? 0
+              : FixedBitArray::bufferSize(residualCount, bitWidth);
+          // Trailing checkpoint segment: 4-byte count + 16B per checkpoint.
+          // The encoder skips checkpoint capture entirely in the bitWidth=0
+          // fast path (so wire size stays O(1) for regular-stride streams)
+          // and captures one entry per 64 residuals otherwise. The 64 stride
+          // matches DoubleDeltaEncoding::kCheckpointStride.
+          constexpr uint64_t kCheckpointStride = 64;
+          const uint64_t checkpointCount =
+              bitWidth == 0 ? 0 : residualCount / kCheckpointStride;
+          const uint64_t checkpointSegmentSize =
+              sizeof(uint32_t) + checkpointCount * 16u;
+          // Common Encoding prefix (6) + first(8) + second(8) + minDD(8)
+          // + bitWidth(1).
+          constexpr uint32_t commonPrefixSize = 6;
+          const uint32_t overhead = commonPrefixSize + 8 + 8 + 8 + 1;
+          return overhead + bitpackedSize + checkpointSegmentSize;
+        } else {
+          return std::nullopt;
+        }
+      }
       case EncodingType::Pfor: {
         if constexpr (isIntegralType<physicalType>()) {
           const auto fullRange =

--- a/dwio/nimble/encodings/selection/EncodingSizeEstimation.h
+++ b/dwio/nimble/encodings/selection/EncodingSizeEstimation.h
@@ -21,6 +21,7 @@
 #include "dwio/nimble/common/Exceptions.h"
 #include "dwio/nimble/common/FixedBitArray.h"
 #include "dwio/nimble/common/Types.h"
+#include "dwio/nimble/common/Varint.h"
 #include "dwio/nimble/encodings/PforEncoding.h"
 #include "velox/common/base/BitUtil.h"
 
@@ -215,6 +216,36 @@ struct EncodingSizeEstimation {
           constexpr uint32_t overhead =
               6 + sizeof(physicalType) + 1 + sizeof(uint32_t);
           return overhead + bitpackedSize + exceptionsSize;
+        } else {
+          return std::nullopt;
+        }
+      }
+      case EncodingType::CompactFor: {
+        // 64-bit integer only. Same shape as FixedBitWidth — every value pays
+        // the full bit width covering (max - min) — but with a varint-encoded
+        // baseline. The bitpacked region also includes the 7-byte tail slop.
+        if constexpr (
+            isIntegralType<physicalType>() && sizeof(physicalType) == 8) {
+          const uint64_t baseline = static_cast<uint64_t>(statistics.min());
+          const uint64_t fullRange =
+              static_cast<uint64_t>(statistics.max() - statistics.min());
+          const uint8_t bitWidth = fullRange == 0
+              ? uint8_t{0}
+              : static_cast<uint8_t>(velox::bits::bitsRequired(fullRange));
+          const uint64_t bitpackedSize = bitWidth == 0
+              ? 0
+              : ((static_cast<uint64_t>(bitWidth) * entryCount + 7) >> 3) + 7;
+          // Conservatively assume the varint baseline takes 10 bytes when we
+          // can't cheaply compute its exact size from Statistics; for small
+          // baselines (~0) the encoder will produce 1 byte and the actual wire
+          // will be smaller than this estimate, which keeps the selector
+          // honest.
+          const uint32_t baselineVarintBytes = varint::varintSize(baseline);
+          // Overhead: common Encoding prefix (6) + baseline varint
+          // + bitWidth (1 byte).
+          constexpr uint32_t commonPrefixSize = 6;
+          const uint32_t overhead = commonPrefixSize + baselineVarintBytes + 1;
+          return overhead + bitpackedSize;
         } else {
           return std::nullopt;
         }

--- a/dwio/nimble/encodings/tests/CMakeLists.txt
+++ b/dwio/nimble/encodings/tests/CMakeLists.txt
@@ -26,6 +26,7 @@ add_executable(
   CompressionTest.cpp
   EncodingTest.cpp
   EncodingLegacyTest.cpp
+  DoubleDeltaEncodingTest.cpp
   Lz4CompressorTest.cpp
   MainlyConstantEncodingTest.cpp
   NullableEncodingTest.cpp

--- a/dwio/nimble/encodings/tests/CMakeLists.txt
+++ b/dwio/nimble/encodings/tests/CMakeLists.txt
@@ -29,6 +29,7 @@ add_executable(
   Lz4CompressorTest.cpp
   MainlyConstantEncodingTest.cpp
   NullableEncodingTest.cpp
+  PforEncodingTest.cpp
   PrefixEncodingTest.cpp
   RleEncodingTest.cpp
   SentinelEncodingTest.cpp

--- a/dwio/nimble/encodings/tests/CMakeLists.txt
+++ b/dwio/nimble/encodings/tests/CMakeLists.txt
@@ -27,6 +27,7 @@ add_executable(
   EncodingTest.cpp
   EncodingLegacyTest.cpp
   DoubleDeltaEncodingTest.cpp
+  CompactForEncodingTest.cpp
   Lz4CompressorTest.cpp
   MainlyConstantEncodingTest.cpp
   NullableEncodingTest.cpp

--- a/dwio/nimble/encodings/tests/CompactForEncodingTest.cpp
+++ b/dwio/nimble/encodings/tests/CompactForEncodingTest.cpp
@@ -1,0 +1,403 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "dwio/nimble/encodings/CompactForEncoding.h"
+
+#include <fmt/core.h>
+#include <gtest/gtest.h>
+#include <limits>
+#include <random>
+
+#include "dwio/nimble/common/Buffer.h"
+#include "dwio/nimble/common/tests/GTestUtils.h"
+#include "dwio/nimble/encodings/common/EncodingFactory.h"
+#include "dwio/nimble/encodings/common/EncodingLayout.h"
+#include "dwio/nimble/encodings/selection/EncodingSelection.h"
+#include "dwio/nimble/encodings/selection/EncodingSelectionPolicy.h"
+#include "velox/common/memory/Memory.h"
+
+using namespace ::facebook;
+
+namespace facebook::nimble::test {
+
+// CompactFor is templated on int64_t and uint64_t. The encoder operates
+// on the unsigned physical representation; per-type tests therefore run on
+// the unsigned physical type directly. End-to-end signed-input coverage is
+// exercised by the fuzzer below, which routes int64 through
+// EncodingFactory::encode<int64_t>.
+template <typename T>
+class CompactForEncodingTest : public ::testing::Test {
+ protected:
+  static void SetUpTestCase() {
+    velox::memory::MemoryManager::testingSetInstance({});
+  }
+
+  void SetUp() override {
+    pool_ = velox::memory::deprecatedAddDefaultLeafMemoryPool();
+  }
+
+  std::unique_ptr<EncodingSelectionPolicy<T>> createSelectionPolicy() {
+    EncodingLayout layout{
+        EncodingType::CompactFor, {}, CompressionType::Uncompressed};
+    return std::make_unique<ReplayedEncodingSelectionPolicy<T>>(
+        std::move(layout),
+        CompressionOptions{},
+        encodingSelectionPolicyFactory_);
+  }
+
+  std::unique_ptr<Encoding> encodeAndCreate(const std::vector<T>& values) {
+    Buffer buffer{*pool_};
+    auto encoded = EncodingFactory::encode<T>(
+        createSelectionPolicy(),
+        std::span<const T>{values.data(), values.size()},
+        buffer);
+    encodedStorage_.assign(encoded.begin(), encoded.end());
+    return EncodingFactory().create(
+        *pool_, {encodedStorage_.data(), encodedStorage_.size()}, nullptr);
+  }
+
+  void roundTripAndExpect(const std::vector<T>& values) {
+    auto encoding = encodeAndCreate(values);
+    EXPECT_EQ(encoding->encodingType(), EncodingType::CompactFor);
+    EXPECT_EQ(encoding->dataType(), TypeTraits<T>::dataType);
+    EXPECT_EQ(encoding->rowCount(), values.size());
+
+    std::vector<T> decoded(values.size());
+    encoding->materialize(static_cast<uint32_t>(values.size()), decoded.data());
+    for (size_t i = 0; i < values.size(); ++i) {
+      EXPECT_EQ(decoded[i], values[i]) << "mismatch at index " << i;
+    }
+  }
+
+  std::shared_ptr<velox::memory::MemoryPool> pool_;
+  std::vector<char> encodedStorage_;
+  ManualEncodingSelectionPolicyFactory manualPolicyFactory_;
+  EncodingSelectionPolicyFactory encodingSelectionPolicyFactory_ =
+      [this](DataType dataType) {
+        return manualPolicyFactory_.createPolicy(dataType);
+      };
+};
+
+using CompactForTypes = ::testing::Types<int64_t, uint64_t>;
+TYPED_TEST_SUITE(CompactForEncodingTest, CompactForTypes);
+
+TYPED_TEST(CompactForEncodingTest, singleElement) {
+  using T = TypeParam;
+  this->roundTripAndExpect({T{42}});
+}
+
+TYPED_TEST(CompactForEncodingTest, allEqualCollapsesToBitWidthZero) {
+  // All values equal → range=0 → bitWidth=0 → wire is just the header
+  // (Encoding prefix + 1B baseline varint + 1B bitWidth). Verifies the
+  // bitWidth=0 fast path.
+  using T = TypeParam;
+  std::vector<T> values(64, T{7});
+  this->roundTripAndExpect(values);
+  auto encoding = this->encodeAndCreate(values);
+  // 6 (Encoding prefix) + 1 (baseline=7 varint, single byte) + 1 (bitWidth=0).
+  EXPECT_EQ(this->encodedStorage_.size(), 6u + 1u + 1u);
+}
+
+TYPED_TEST(CompactForEncodingTest, regularTimestampsBitWidthFits) {
+  // Timestamps stepping by 1000 from 1.7e9. min ~ 1.7e9, max ~ 1.7e9 +
+  // 1023*1000. Range ~ 1M → bitWidth = 20 — typical real-world long trait
+  // shape, well inside the bitWidth<=56 byte-aligned single-load fast path.
+  using T = TypeParam;
+  std::vector<T> values;
+  values.reserve(1024);
+  for (uint32_t i = 0; i < 1024; ++i) {
+    values.push_back(static_cast<T>(1'700'000'000ULL + i * 1000ULL));
+  }
+  this->roundTripAndExpect(values);
+}
+
+TYPED_TEST(CompactForEncodingTest, sparseOutliers) {
+  // Mostly-narrow stream with a few jumps. LFB has no exception path — every
+  // value pays the worst-case bit width. Tests that the bit width is correctly
+  // sized to cover the outliers.
+  using T = TypeParam;
+  std::vector<T> values;
+  values.reserve(500);
+  for (uint32_t i = 0; i < 500; ++i) {
+    T v = static_cast<T>(1'000'000ULL + i * 60ULL);
+    if (i == 100 || i == 250 || i == 400) {
+      v = static_cast<T>(static_cast<uint64_t>(v) + 5'000'000ULL);
+    }
+    values.push_back(v);
+  }
+  this->roundTripAndExpect(values);
+}
+
+TYPED_TEST(CompactForEncodingTest, mixedSizes) {
+  using T = TypeParam;
+  for (uint32_t n :
+       {1u, 2u, 3u, 7u, 8u, 9u, 16u, 17u, 64u, 100u, 257u, 1024u}) {
+    SCOPED_TRACE(fmt::format("n={}", n));
+    std::vector<T> values;
+    values.reserve(n);
+    for (uint32_t i = 0; i < n; ++i) {
+      values.push_back(static_cast<T>(1000ULL + i * 37ULL));
+    }
+    this->roundTripAndExpect(values);
+  }
+}
+
+TYPED_TEST(CompactForEncodingTest, fullBitWidth64) {
+  // Force bitWidth=64: a single max-range value pair. Exercises the bw>56
+  // cross-word fallback inside FixedBitArray::bulkGet64WithBaseline.
+  using T = TypeParam;
+  std::vector<T> values;
+  values.reserve(32);
+  values.push_back(static_cast<T>(0));
+  values.push_back(static_cast<T>(std::numeric_limits<uint64_t>::max()));
+  for (uint32_t i = 2; i < 32; ++i) {
+    values.push_back(static_cast<T>(i));
+  }
+  this->roundTripAndExpect(values);
+}
+
+TYPED_TEST(CompactForEncodingTest, rangeDecodeForwardAndReverse) {
+  // Forward and reverse range decode via skip(start) + materialize(window).
+  // Mirrors MRS's testEncoderRoundTrip fwd/rev triplet on a known shape.
+  using T = TypeParam;
+  std::vector<T> values;
+  values.reserve(200);
+  for (uint32_t i = 0; i < 200; ++i) {
+    values.push_back(static_cast<T>(500'000ULL + i * 7ULL));
+  }
+  auto encoding = this->encodeAndCreate(values);
+
+  // Forward range decode at several offsets.
+  for (uint32_t start :
+       {uint32_t{0}, uint32_t{1}, uint32_t{50}, uint32_t{150}, uint32_t{199}}) {
+    SCOPED_TRACE(fmt::format("fwd start={}", start));
+    const uint32_t windowSize =
+        std::min<uint32_t>(13, static_cast<uint32_t>(values.size()) - start);
+    encoding->reset();
+    if (start > 0) {
+      encoding->skip(start);
+    }
+    std::vector<T> window(windowSize);
+    encoding->materialize(windowSize, window.data());
+    for (uint32_t i = 0; i < windowSize; ++i) {
+      EXPECT_EQ(window[i], values[start + i]) << "i=" << i;
+    }
+  }
+
+  // Reverse range decode: walk the same offsets in descending order, each
+  // time resetting first. LFB has true O(1) random access so this should
+  // produce identical results to the forward pass.
+  for (int32_t start : {int32_t{199}, int32_t{150}, int32_t{50}, int32_t{1}}) {
+    SCOPED_TRACE(fmt::format("rev start={}", start));
+    const uint32_t windowSize = std::min<uint32_t>(
+        13,
+        static_cast<uint32_t>(values.size()) - static_cast<uint32_t>(start));
+    encoding->reset();
+    if (start > 0) {
+      encoding->skip(static_cast<uint32_t>(start));
+    }
+    std::vector<T> window(windowSize);
+    encoding->materialize(windowSize, window.data());
+    for (uint32_t i = 0; i < windowSize; ++i) {
+      EXPECT_EQ(window[i], values[static_cast<uint32_t>(start) + i])
+          << "i=" << i;
+    }
+  }
+}
+
+TYPED_TEST(CompactForEncodingTest, skipAndMaterializeInterleaved) {
+  using T = TypeParam;
+  std::vector<T> values;
+  values.reserve(300);
+  for (uint32_t i = 0; i < 300; ++i) {
+    values.push_back(static_cast<T>(2'000'000ULL + i * 17ULL + (i % 11)));
+  }
+  auto encoding = this->encodeAndCreate(values);
+
+  encoding->reset();
+  std::vector<T> chunk(50);
+  encoding->materialize(50, chunk.data());
+  for (uint32_t i = 0; i < 50; ++i) {
+    EXPECT_EQ(chunk[i], values[i]);
+  }
+  encoding->skip(75);
+  encoding->materialize(50, chunk.data());
+  for (uint32_t i = 0; i < 50; ++i) {
+    EXPECT_EQ(chunk[i], values[125 + i]) << "i=" << i;
+  }
+  encoding->skip(75);
+  encoding->materialize(50, chunk.data());
+  for (uint32_t i = 0; i < 50; ++i) {
+    EXPECT_EQ(chunk[i], values[250 + i]) << "i=" << i;
+  }
+
+  // Reset restores the cursor.
+  encoding->reset();
+  std::vector<T> all(values.size());
+  encoding->materialize(static_cast<uint32_t>(values.size()), all.data());
+  for (size_t i = 0; i < values.size(); ++i) {
+    EXPECT_EQ(all[i], values[i]) << "after-reset i=" << i;
+  }
+}
+
+TYPED_TEST(CompactForEncodingTest, debugString) {
+  using T = TypeParam;
+  std::vector<T> values;
+  values.reserve(8);
+  for (uint32_t i = 0; i < 8; ++i) {
+    values.push_back(static_cast<T>(1000 + i * 5));
+  }
+  auto encoding = this->encodeAndCreate(values);
+  const std::string debug = encoding->debugString();
+  EXPECT_NE(debug.find("CompactFor"), std::string::npos);
+  EXPECT_NE(debug.find("bitWidth="), std::string::npos);
+}
+
+class CompactForEncodingFuzzerTest : public ::testing::Test {
+ protected:
+  static void SetUpTestCase() {
+    velox::memory::MemoryManager::testingSetInstance({});
+  }
+
+  void SetUp() override {
+    pool_ = velox::memory::deprecatedAddDefaultLeafMemoryPool();
+  }
+
+  template <typename T>
+  void runFuzzer(uint32_t seed, uint32_t numIterations) {
+    std::mt19937_64 rng(seed);
+
+    ManualEncodingSelectionPolicyFactory manualFactory;
+    EncodingSelectionPolicyFactory factory =
+        [&manualFactory](DataType dataType) {
+          return manualFactory.createPolicy(dataType);
+        };
+
+    for (uint32_t iter = 0; iter < numIterations; ++iter) {
+      SCOPED_TRACE(fmt::format("iteration {}", iter));
+
+      std::uniform_int_distribution<uint32_t> sizeDist(1, 1000);
+      const uint32_t numValues = sizeDist(rng);
+
+      // Random profile per iteration. Profile 0 is a constant (bw=0 path),
+      // profile 1 is narrow-range (bw<=56 fast path), profile 2 is full-range
+      // (covers the cross-word fallback at bw>56).
+      std::uniform_int_distribution<int32_t> profileDist(0, 2);
+      const int32_t profile = profileDist(rng);
+
+      std::vector<T> values;
+      values.reserve(numValues);
+      if (profile == 0) {
+        const T constantValue = static_cast<T>(rng());
+        for (uint32_t i = 0; i < numValues; ++i) {
+          values.push_back(constantValue);
+        }
+      } else if (profile == 1) {
+        std::uniform_int_distribution<uint64_t> narrowDist(0, (1ULL << 30) - 1);
+        const uint64_t base = static_cast<uint64_t>(rng());
+        for (uint32_t i = 0; i < numValues; ++i) {
+          values.push_back(static_cast<T>(base + narrowDist(rng)));
+        }
+      } else {
+        std::uniform_int_distribution<uint64_t> wideDist(
+            0, std::numeric_limits<uint64_t>::max());
+        for (uint32_t i = 0; i < numValues; ++i) {
+          values.push_back(static_cast<T>(wideDist(rng)));
+        }
+      }
+
+      Buffer buffer{*pool_};
+      EncodingLayout layout{
+          EncodingType::CompactFor, {}, CompressionType::Uncompressed};
+      auto policy = std::make_unique<ReplayedEncodingSelectionPolicy<T>>(
+          std::move(layout), CompressionOptions{}, factory);
+      auto encoded = EncodingFactory::encode<T>(
+          std::move(policy),
+          std::span<const T>{values.data(), values.size()},
+          buffer);
+      std::vector<char> storage(encoded.begin(), encoded.end());
+      auto encoding = EncodingFactory().create(
+          *pool_, {storage.data(), storage.size()}, nullptr);
+
+      ASSERT_EQ(encoding->encodingType(), EncodingType::CompactFor);
+      ASSERT_EQ(encoding->dataType(), TypeTraits<T>::dataType);
+      ASSERT_EQ(encoding->rowCount(), values.size());
+      std::vector<T> decoded(values.size());
+      encoding->materialize(
+          static_cast<uint32_t>(values.size()), decoded.data());
+      for (size_t i = 0; i < values.size(); ++i) {
+        ASSERT_EQ(decoded[i], values[i])
+            << "iter=" << iter << " i=" << i << " size=" << numValues
+            << " profile=" << profile;
+      }
+
+      // Random skip/materialize sequence.
+      encoding->reset();
+      std::uniform_int_distribution<uint32_t> stepDist(0, numValues);
+      uint32_t cursor = 0;
+      while (cursor < numValues) {
+        const uint32_t remaining = numValues - cursor;
+        const uint32_t skipCount = stepDist(rng) % (remaining + 1);
+        if (skipCount > 0) {
+          encoding->skip(skipCount);
+          cursor += skipCount;
+        }
+        if (cursor >= numValues) {
+          break;
+        }
+        const uint32_t matCount =
+            std::max<uint32_t>(1, stepDist(rng) % (numValues - cursor + 1));
+        std::vector<T> chunk(matCount);
+        encoding->materialize(matCount, chunk.data());
+        for (uint32_t i = 0; i < matCount; ++i) {
+          ASSERT_EQ(chunk[i], values[cursor + i])
+              << "iter=" << iter << " cursor=" << cursor << " i=" << i;
+        }
+        cursor += matCount;
+      }
+    }
+  }
+
+  std::shared_ptr<velox::memory::MemoryPool> pool_;
+};
+
+TEST_F(CompactForEncodingFuzzerTest, fuzzerInt64) {
+  runFuzzer<int64_t>(/*seed=*/12345, /*numIterations=*/30);
+}
+
+TEST_F(CompactForEncodingFuzzerTest, fuzzerUint64) {
+  runFuzzer<uint64_t>(/*seed=*/67890, /*numIterations=*/30);
+}
+
+TEST_F(CompactForEncodingFuzzerTest, encodeRejectsEmpty) {
+  Buffer buffer{*pool_};
+  EncodingLayout layout{
+      EncodingType::CompactFor, {}, CompressionType::Uncompressed};
+  ManualEncodingSelectionPolicyFactory manualFactory;
+  EncodingSelectionPolicyFactory factory = [&manualFactory](DataType dataType) {
+    return manualFactory.createPolicy(dataType);
+  };
+  auto policy = std::make_unique<ReplayedEncodingSelectionPolicy<int64_t>>(
+      std::move(layout), CompressionOptions{}, factory);
+  std::vector<int64_t> empty;
+  NIMBLE_ASSERT_THROW(
+      EncodingFactory::encode<int64_t>(
+          std::move(policy),
+          std::span<const int64_t>{empty.data(), empty.size()},
+          buffer),
+      "CompactFor encoding cannot be used with 0 rows.");
+}
+
+} // namespace facebook::nimble::test

--- a/dwio/nimble/encodings/tests/DoubleDeltaEncodingTest.cpp
+++ b/dwio/nimble/encodings/tests/DoubleDeltaEncodingTest.cpp
@@ -1,0 +1,496 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "dwio/nimble/encodings/DoubleDeltaEncoding.h"
+
+#include <fmt/core.h>
+#include <gtest/gtest.h>
+#include <limits>
+#include <random>
+
+#include "dwio/nimble/common/Buffer.h"
+#include "dwio/nimble/common/tests/GTestUtils.h"
+#include "dwio/nimble/encodings/common/EncodingFactory.h"
+#include "dwio/nimble/encodings/common/EncodingLayout.h"
+#include "dwio/nimble/encodings/selection/EncodingSelection.h"
+#include "dwio/nimble/encodings/selection/EncodingSelectionPolicy.h"
+#include "velox/common/memory/Memory.h"
+
+using namespace ::facebook;
+
+namespace facebook::nimble::test {
+
+// DoubleDelta is templated on int64_t and uint64_t. Both share
+// the same wire format (the encoder works on the unsigned physical
+// representation), so the per-type tests run on the unsigned physical type
+// directly. End-to-end signed-input coverage is exercised by the fuzzer
+// below, which routes int64 through EncodingFactory::encode<int64_t>.
+template <typename T>
+class DoubleDeltaEncodingTest : public ::testing::Test {
+ protected:
+  static void SetUpTestCase() {
+    velox::memory::MemoryManager::testingSetInstance({});
+  }
+
+  void SetUp() override {
+    pool_ = velox::memory::deprecatedAddDefaultLeafMemoryPool();
+  }
+
+  std::unique_ptr<EncodingSelectionPolicy<T>> createSelectionPolicy() {
+    EncodingLayout layout{
+        EncodingType::DoubleDelta, {}, CompressionType::Uncompressed};
+    return std::make_unique<ReplayedEncodingSelectionPolicy<T>>(
+        std::move(layout),
+        CompressionOptions{},
+        encodingSelectionPolicyFactory_);
+  }
+
+  std::unique_ptr<Encoding> encodeAndCreate(const std::vector<T>& values) {
+    Buffer buffer{*pool_};
+    auto encoded = EncodingFactory::encode<T>(
+        createSelectionPolicy(),
+        std::span<const T>{values.data(), values.size()},
+        buffer);
+    encodedStorage_.assign(encoded.begin(), encoded.end());
+    return EncodingFactory().create(
+        *pool_, {encodedStorage_.data(), encodedStorage_.size()}, nullptr);
+  }
+
+  void roundTripAndExpect(const std::vector<T>& values) {
+    auto encoding = encodeAndCreate(values);
+    EXPECT_EQ(encoding->encodingType(), EncodingType::DoubleDelta);
+    EXPECT_EQ(encoding->dataType(), TypeTraits<T>::dataType);
+    EXPECT_EQ(encoding->rowCount(), values.size());
+
+    std::vector<T> decoded(values.size());
+    encoding->materialize(static_cast<uint32_t>(values.size()), decoded.data());
+    for (size_t i = 0; i < values.size(); ++i) {
+      EXPECT_EQ(decoded[i], values[i]) << "mismatch at index " << i;
+    }
+  }
+
+  std::shared_ptr<velox::memory::MemoryPool> pool_;
+  std::vector<char> encodedStorage_;
+  ManualEncodingSelectionPolicyFactory manualPolicyFactory_;
+  EncodingSelectionPolicyFactory encodingSelectionPolicyFactory_ =
+      [this](DataType dataType) {
+        return manualPolicyFactory_.createPolicy(dataType);
+      };
+};
+
+using LongDoubleDeltaTypes = ::testing::Types<int64_t, uint64_t>;
+TYPED_TEST_SUITE(DoubleDeltaEncodingTest, LongDoubleDeltaTypes);
+
+TYPED_TEST(DoubleDeltaEncodingTest, singleElement) {
+  using T = TypeParam;
+  this->roundTripAndExpect({T{42}});
+}
+
+TYPED_TEST(DoubleDeltaEncodingTest, twoElements) {
+  using T = TypeParam;
+  this->roundTripAndExpect({T{100}, T{250}});
+}
+
+TYPED_TEST(DoubleDeltaEncodingTest, allEqualCollapsesToBitWidthZero) {
+  // 64-element constant stream. Δ=0 → Δ²=0 → bitWidth=0 → no packed region
+  // and (because of the bitWidth=0 short-circuit in the encoder) no captured
+  // checkpoints either. Wire is just the 35-byte header + 4-byte cpCount=0.
+  using T = TypeParam;
+  std::vector<T> values(64, T{7});
+  this->roundTripAndExpect(values);
+  auto encoding = this->encodeAndCreate(values);
+  // 6 (Encoding prefix) + 25 (kPrefixSize) + 4 (cpCount=0). No packed region,
+  // no checkpoint entries.
+  EXPECT_EQ(this->encodedStorage_.size(), 6u + 25u + 4u);
+}
+
+TYPED_TEST(DoubleDeltaEncodingTest, regularIntervalTimestampsAreTiny) {
+  // The killer case: timestamps every 1000 units. Δ=1000 (constant) →
+  // Δ²=0 → bitWidth=0. Wire stays at 35B regardless of N because the
+  // bitWidth=0 fast path skips both the packed region and the checkpoint
+  // capture.
+  using T = TypeParam;
+  std::vector<T> values;
+  values.reserve(1024);
+  for (uint32_t i = 0; i < 1024; ++i) {
+    values.push_back(static_cast<T>(1'700'000'000 + i * 1000));
+  }
+  this->roundTripAndExpect(values);
+  auto encoding = this->encodeAndCreate(values);
+  EXPECT_EQ(this->encodedStorage_.size(), 6u + 25u + 4u);
+}
+
+TYPED_TEST(DoubleDeltaEncodingTest, monotoneWithRareGaps) {
+  // Mostly-regular intervals with a few large jumps. bitWidth must come up
+  // off zero to absorb the irregular Δ², but the encoded size still beats
+  // the FixedBitWidth ceiling.
+  using T = TypeParam;
+  std::vector<T> values;
+  values.reserve(500);
+  for (uint32_t i = 0; i < 500; ++i) {
+    T v = static_cast<T>(1'000'000 + i * 60);
+    if (i == 100 || i == 250 || i == 400) {
+      v = static_cast<T>(static_cast<uint64_t>(v) + 5'000'000ULL);
+    }
+    values.push_back(v);
+  }
+  this->roundTripAndExpect(values);
+}
+
+TYPED_TEST(DoubleDeltaEncodingTest, mixedSizes) {
+  using T = TypeParam;
+  for (uint32_t n :
+       {1u, 2u, 3u, 7u, 15u, 16u, 17u, 33u, 64u, 100u, 257u, 1024u}) {
+    SCOPED_TRACE(fmt::format("n={}", n));
+    std::vector<T> values;
+    values.reserve(n);
+    // A semi-regular sequence — gives a non-trivial bitWidth without being
+    // adversarial. The (i*31+1)%256 wobble prevents Δ² from being always 0.
+    for (uint32_t i = 0; i < n; ++i) {
+      values.push_back(static_cast<T>(1000 + i * 50 + (i * 31 + 1) % 17));
+    }
+    this->roundTripAndExpect(values);
+  }
+}
+
+TYPED_TEST(DoubleDeltaEncodingTest, skipAndMaterialize) {
+  using T = TypeParam;
+  std::vector<T> values;
+  values.reserve(300);
+  for (uint32_t i = 0; i < 300; ++i) {
+    values.push_back(static_cast<T>(2'000'000 + i * 17 + (i % 11)));
+  }
+  auto encoding = this->encodeAndCreate(values);
+
+  // Interleaved skips and materialises — exercises the wrap-around delta
+  // accumulator across non-trivial gaps.
+  encoding->reset();
+  std::vector<T> chunk(50);
+  encoding->materialize(50, chunk.data());
+  for (uint32_t i = 0; i < 50; ++i) {
+    EXPECT_EQ(chunk[i], values[i]);
+  }
+  encoding->skip(75);
+  encoding->materialize(50, chunk.data());
+  for (uint32_t i = 0; i < 50; ++i) {
+    EXPECT_EQ(chunk[i], values[125 + i]) << "i=" << i;
+  }
+  encoding->skip(75);
+  encoding->materialize(50, chunk.data());
+  for (uint32_t i = 0; i < 50; ++i) {
+    EXPECT_EQ(chunk[i], values[250 + i]) << "i=" << i;
+  }
+
+  // Reset must restore all cursors so a second pass produces identical output.
+  encoding->reset();
+  std::vector<T> all(values.size());
+  encoding->materialize(static_cast<uint32_t>(values.size()), all.data());
+  for (size_t i = 0; i < values.size(); ++i) {
+    EXPECT_EQ(all[i], values[i]) << "after-reset i=" << i;
+  }
+}
+
+TYPED_TEST(DoubleDeltaEncodingTest, rangeMaterializeViaSkip) {
+  // Range decode pattern: skip past a prefix, then materialize a window.
+  using T = TypeParam;
+  std::vector<T> values;
+  values.reserve(200);
+  for (uint32_t i = 0; i < 200; ++i) {
+    values.push_back(static_cast<T>(500'000 + i * 7));
+  }
+  auto encoding = this->encodeAndCreate(values);
+
+  for (uint32_t start :
+       {uint32_t{0}, uint32_t{1}, uint32_t{2}, uint32_t{50}, uint32_t{199}}) {
+    SCOPED_TRACE(fmt::format("start={}", start));
+    const uint32_t windowSize =
+        std::min<uint32_t>(13, static_cast<uint32_t>(values.size()) - start);
+    encoding->reset();
+    if (start > 0) {
+      encoding->skip(start);
+    }
+    std::vector<T> window(windowSize);
+    encoding->materialize(windowSize, window.data());
+    for (uint32_t i = 0; i < windowSize; ++i) {
+      EXPECT_EQ(window[i], values[start + i]) << "i=" << i;
+    }
+  }
+}
+
+TYPED_TEST(DoubleDeltaEncodingTest, checkpointSeekCoversBoundaries) {
+  // Exercise the checkpoint fast path at all the seek positions that the
+  // skip-then-materialize math has to get right: K-boundary anchors,
+  // mid-segment offsets, single-element windows, ranges that span multiple
+  // checkpoints, plus the L==0 and R==N-1 edges. Each window is compared
+  // against the corresponding slice of the full materialized output so the
+  // assertion holds regardless of decoder internals.
+  using T = TypeParam;
+  // 600 rows = 9 full strides of 64 residuals (9 checkpoints captured); needs
+  // bitWidth > 0 so the checkpoint segment actually exists. The (i % 13)
+  // wobble keeps Δ² off zero.
+  constexpr uint32_t kRows = 600;
+  std::vector<T> values;
+  values.reserve(kRows);
+  for (uint32_t i = 0; i < kRows; ++i) {
+    values.push_back(static_cast<T>(2'500'000 + i * 41 + (i * 7 % 13)));
+  }
+  // Full-decode once to get a ground-truth output.
+  auto fullEncoding = this->encodeAndCreate(values);
+  std::vector<T> expected(kRows);
+  fullEncoding->materialize(kRows, expected.data());
+  ASSERT_EQ(expected, values);
+
+  // (L, R) inclusive ranges. K=64 in the encoder.
+  const std::vector<std::pair<uint32_t, uint32_t>> ranges = {
+      {0, 0}, // single-element at the very start (no checkpoint usable)
+      {0, 10}, // small range at start
+      {66, 66}, // single-element on the first checkpoint boundary (L = K+2)
+      {66, 80}, // small range starting at the first checkpoint boundary
+      {100, 130}, // mid-segment, lands inside checkpoint #0's reach
+      {200, 250}, // window inside checkpoint #2's reach
+      {130, 400}, // window that spans multiple checkpoints
+      {64, 64}, // single-element just before the K+2 boundary
+      {500, 599}, // tail of the stream
+      {kRows - 1, kRows - 1}, // single-element at the very end
+  };
+
+  for (const auto& [l, r] : ranges) {
+    SCOPED_TRACE(fmt::format("range L={} R={}", l, r));
+    auto encoding = this->encodeAndCreate(values);
+    encoding->reset();
+    if (l > 0) {
+      encoding->skip(l);
+    }
+    const uint32_t windowSize = r - l + 1;
+    std::vector<T> got(windowSize);
+    encoding->materialize(windowSize, got.data());
+    const std::vector<T> want(expected.begin() + l, expected.begin() + r + 1);
+    EXPECT_EQ(got, want);
+  }
+}
+
+TYPED_TEST(DoubleDeltaEncodingTest, checkpointSeekMatchesFullDecodeAfterReset) {
+  // After a checkpoint-accelerated range-decode, calling reset() and a
+  // straight full materialize must still produce the original stream.
+  // Catches state-leak bugs in seekToCheckpointFor.
+  using T = TypeParam;
+  constexpr uint32_t kRows = 400;
+  std::vector<T> values;
+  values.reserve(kRows);
+  for (uint32_t i = 0; i < kRows; ++i) {
+    values.push_back(static_cast<T>(1'000'000'000 + i * 23 + (i * 11 % 7)));
+  }
+  auto encoding = this->encodeAndCreate(values);
+  encoding->skip(200);
+  std::vector<T> midChunk(50);
+  encoding->materialize(50, midChunk.data());
+  for (uint32_t i = 0; i < 50; ++i) {
+    EXPECT_EQ(midChunk[i], values[200 + i]);
+  }
+  encoding->reset();
+  std::vector<T> all(kRows);
+  encoding->materialize(kRows, all.data());
+  EXPECT_EQ(all, values);
+}
+
+TYPED_TEST(DoubleDeltaEncodingTest, checkpointSegmentSizesCorrectly) {
+  // 130 rows with bitWidth>0 => residuals = 128 => checkpointCount = 2.
+  // Verify the on-wire byte count includes the checkpoint segment.
+  using T = TypeParam;
+  constexpr uint32_t kRows = 130;
+  std::vector<T> values;
+  values.reserve(kRows);
+  for (uint32_t i = 0; i < kRows; ++i) {
+    values.push_back(static_cast<T>(7'000'000 + i * 13 + (i % 5)));
+  }
+  this->roundTripAndExpect(values);
+  auto encoding = this->encodeAndCreate(values);
+  // The exact bitpacked region width depends on bitsRequired(maxResidual),
+  // so this asserts on the delta added by the new checkpoint segment vs a
+  // baseline with no captured checkpoints. Two checkpoints * 16B + 4B
+  // count = 36B trailing.
+  EXPECT_GE(this->encodedStorage_.size(), 6u + 25u + 36u);
+}
+
+TYPED_TEST(DoubleDeltaEncodingTest, largeMagnitudeOverflowSafe) {
+  // Values near the type range exercise the wrap-around delta arithmetic
+  // (encoder and decoder both treat the underlying uint64 representation
+  // mod 2^64). A signed int64 overflow during delta computation would be UB
+  // if we used signed subtraction directly — verifies we do not.
+  using T = TypeParam;
+  std::vector<T> values;
+  values.reserve(8);
+  // Intentionally straddle zero / the signed boundary for int64; for
+  // uint64 these are simply very-large unsigned values.
+  values.push_back(static_cast<T>(std::numeric_limits<int64_t>::min()));
+  values.push_back(static_cast<T>(std::numeric_limits<int64_t>::min() + 17));
+  values.push_back(static_cast<T>(std::numeric_limits<int64_t>::min() + 42));
+  values.push_back(static_cast<T>(0));
+  values.push_back(static_cast<T>(100));
+  values.push_back(static_cast<T>(std::numeric_limits<int64_t>::max() - 5));
+  values.push_back(static_cast<T>(std::numeric_limits<int64_t>::max()));
+  values.push_back(static_cast<T>(std::numeric_limits<int64_t>::min() + 1));
+  this->roundTripAndExpect(values);
+}
+
+TYPED_TEST(DoubleDeltaEncodingTest, debugString) {
+  using T = TypeParam;
+  std::vector<T> values;
+  values.reserve(8);
+  for (uint32_t i = 0; i < 8; ++i) {
+    values.push_back(static_cast<T>(1000 + i * 5));
+  }
+  auto encoding = this->encodeAndCreate(values);
+  const std::string debug = encoding->debugString();
+  EXPECT_NE(debug.find("DoubleDelta"), std::string::npos);
+  EXPECT_NE(debug.find("bitWidth="), std::string::npos);
+  EXPECT_NE(debug.find("checkpoints="), std::string::npos);
+}
+
+class DoubleDeltaEncodingFuzzerTest : public ::testing::Test {
+ protected:
+  static void SetUpTestCase() {
+    velox::memory::MemoryManager::testingSetInstance({});
+  }
+
+  void SetUp() override {
+    pool_ = velox::memory::deprecatedAddDefaultLeafMemoryPool();
+  }
+
+  template <typename T>
+  void runFuzzer(uint32_t seed, uint32_t numIterations) {
+    std::mt19937_64 rng(seed);
+
+    ManualEncodingSelectionPolicyFactory manualFactory;
+    EncodingSelectionPolicyFactory factory =
+        [&manualFactory](DataType dataType) {
+          return manualFactory.createPolicy(dataType);
+        };
+
+    for (uint32_t iter = 0; iter < numIterations; ++iter) {
+      SCOPED_TRACE(fmt::format("iteration {}", iter));
+
+      std::uniform_int_distribution<uint32_t> sizeDist(1, 1000);
+      const uint32_t numValues = sizeDist(rng);
+
+      // Pick a random regularity profile per iteration to broadly cover the
+      // encoder's input space: perfectly regular, small wobble, and wide
+      // random jumps.
+      std::uniform_int_distribution<int32_t> profileDist(0, 2);
+      const int32_t profile = profileDist(rng);
+      std::uniform_int_distribution<int64_t> wobbleDist(-32, 32);
+      std::uniform_int_distribution<int64_t> jumpDist(
+          std::numeric_limits<int32_t>::min(),
+          std::numeric_limits<int32_t>::max());
+
+      std::vector<T> values;
+      values.reserve(numValues);
+      uint64_t cur = static_cast<uint64_t>(rng());
+      values.push_back(static_cast<T>(cur));
+      const int64_t baseStep = 1'000;
+      for (uint32_t i = 1; i < numValues; ++i) {
+        int64_t step = baseStep;
+        if (profile == 1) {
+          step += wobbleDist(rng);
+        } else if (profile == 2) {
+          step = jumpDist(rng);
+        }
+        cur += static_cast<uint64_t>(step);
+        values.push_back(static_cast<T>(cur));
+      }
+
+      Buffer buffer{*pool_};
+      EncodingLayout layout{
+          EncodingType::DoubleDelta, {}, CompressionType::Uncompressed};
+      auto policy = std::make_unique<ReplayedEncodingSelectionPolicy<T>>(
+          std::move(layout), CompressionOptions{}, factory);
+      auto encoded = EncodingFactory::encode<T>(
+          std::move(policy),
+          std::span<const T>{values.data(), values.size()},
+          buffer);
+      std::vector<char> storage(encoded.begin(), encoded.end());
+      auto encoding = EncodingFactory().create(
+          *pool_, {storage.data(), storage.size()}, nullptr);
+
+      ASSERT_EQ(encoding->encodingType(), EncodingType::DoubleDelta);
+      ASSERT_EQ(encoding->dataType(), TypeTraits<T>::dataType);
+      ASSERT_EQ(encoding->rowCount(), values.size());
+      std::vector<T> decoded(values.size());
+      encoding->materialize(
+          static_cast<uint32_t>(values.size()), decoded.data());
+      for (size_t i = 0; i < values.size(); ++i) {
+        ASSERT_EQ(decoded[i], values[i])
+            << "iter=" << iter << " i=" << i << " size=" << numValues
+            << " profile=" << profile;
+      }
+
+      // Random skip/materialize sequence — same churn as the PFOR fuzzer.
+      encoding->reset();
+      std::uniform_int_distribution<uint32_t> stepDist(0, numValues);
+      uint32_t cursor = 0;
+      while (cursor < numValues) {
+        const uint32_t remaining = numValues - cursor;
+        const uint32_t skipCount = stepDist(rng) % (remaining + 1);
+        if (skipCount > 0) {
+          encoding->skip(skipCount);
+          cursor += skipCount;
+        }
+        if (cursor >= numValues) {
+          break;
+        }
+        const uint32_t matCount =
+            std::max<uint32_t>(1, stepDist(rng) % (numValues - cursor + 1));
+        std::vector<T> chunk(matCount);
+        encoding->materialize(matCount, chunk.data());
+        for (uint32_t i = 0; i < matCount; ++i) {
+          ASSERT_EQ(chunk[i], values[cursor + i])
+              << "iter=" << iter << " cursor=" << cursor << " i=" << i;
+        }
+        cursor += matCount;
+      }
+    }
+  }
+
+  std::shared_ptr<velox::memory::MemoryPool> pool_;
+};
+
+TEST_F(DoubleDeltaEncodingFuzzerTest, fuzzerInt64) {
+  runFuzzer<int64_t>(/*seed=*/12345, /*numIterations=*/30);
+}
+
+TEST_F(DoubleDeltaEncodingFuzzerTest, fuzzerUint64) {
+  runFuzzer<uint64_t>(/*seed=*/67890, /*numIterations=*/30);
+}
+
+TEST_F(DoubleDeltaEncodingFuzzerTest, encodeRejectsEmpty) {
+  Buffer buffer{*pool_};
+  EncodingLayout layout{
+      EncodingType::DoubleDelta, {}, CompressionType::Uncompressed};
+  ManualEncodingSelectionPolicyFactory manualFactory;
+  EncodingSelectionPolicyFactory factory = [&manualFactory](DataType dataType) {
+    return manualFactory.createPolicy(dataType);
+  };
+  auto policy = std::make_unique<ReplayedEncodingSelectionPolicy<int64_t>>(
+      std::move(layout), CompressionOptions{}, factory);
+  std::vector<int64_t> empty;
+  NIMBLE_ASSERT_THROW(
+      EncodingFactory::encode<int64_t>(
+          std::move(policy),
+          std::span<const int64_t>{empty.data(), empty.size()},
+          buffer),
+      "DoubleDelta encoding cannot be used with 0 rows.");
+}
+
+} // namespace facebook::nimble::test

--- a/dwio/nimble/encodings/tests/EncodingSizeEstimationTest.cpp
+++ b/dwio/nimble/encodings/tests/EncodingSizeEstimationTest.cpp
@@ -354,3 +354,36 @@ TEST_F(EncodingSizeEstimationTest, uint64AllEncodings) {
   ASSERT_TRUE(
       Est::estimateNumericSize(EncodingType::Varint, 100, stats).has_value());
 }
+
+TEST_F(EncodingSizeEstimationTest, pforEstimateVsActualSize) {
+  using Est = detail::EncodingSizeEstimation<uint32_t, false>;
+
+  // ~90% values in [0, 100], ~10% outliers near max — Pfor's sweet spot.
+  std::vector<uint32_t> data;
+  for (uint32_t i = 0; i < 900; ++i) {
+    data.push_back(i % 100);
+  }
+  for (uint32_t i = 0; i < 100; ++i) {
+    data.push_back(1'000'000 + i);
+  }
+  auto stats = Statistics<uint32_t>::create(data);
+  const uint32_t numValues = static_cast<uint32_t>(data.size());
+
+  auto estimated =
+      Est::estimateNumericSize(EncodingType::Pfor, numValues, stats);
+  ASSERT_TRUE(estimated.has_value());
+
+  // Actually encode and measure real size.
+  nimble::Buffer buffer{*pool_};
+  auto encoded = nimble::test::Encoder<nimble::PforEncoding<uint32_t>>::encode(
+      buffer, nimble::Vector<uint32_t>(pool_.get(), data.begin(), data.end()));
+  const uint64_t actualSize = encoded.size();
+
+  // Estimate should be in the same ballpark as actual — within 2x.
+  EXPECT_GT(estimated.value(), actualSize / 2)
+      << "estimate too low: " << estimated.value() << " vs actual "
+      << actualSize;
+  EXPECT_LT(estimated.value(), actualSize * 2)
+      << "estimate too high: " << estimated.value() << " vs actual "
+      << actualSize;
+}

--- a/dwio/nimble/encodings/tests/PforEncodingTest.cpp
+++ b/dwio/nimble/encodings/tests/PforEncodingTest.cpp
@@ -1,0 +1,369 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "dwio/nimble/encodings/PforEncoding.h"
+
+#include <fmt/core.h>
+#include <gtest/gtest.h>
+#include <random>
+
+#include "dwio/nimble/common/Buffer.h"
+#include "dwio/nimble/common/tests/GTestUtils.h"
+#include "dwio/nimble/encodings/common/EncodingFactory.h"
+#include "dwio/nimble/encodings/common/EncodingLayout.h"
+#include "dwio/nimble/encodings/selection/EncodingSelection.h"
+#include "dwio/nimble/encodings/selection/EncodingSelectionPolicy.h"
+#include "velox/common/memory/Memory.h"
+
+using namespace ::facebook;
+
+namespace facebook::nimble::test {
+
+// The Pfor wire format is byte-identical for a signed cpp type and its
+// matching unsigned physical type, so the per-type tests run on the unsigned
+// physical types directly. Signed-input coverage is exercised end-to-end by
+// the fuzzer test below, which routes int32/int64 through the standard
+// EncodingFactory::encode<T> path.
+template <typename T>
+class PforEncodingTest : public ::testing::Test {
+ protected:
+  static void SetUpTestCase() {
+    velox::memory::MemoryManager::testingSetInstance({});
+  }
+
+  void SetUp() override {
+    pool_ = velox::memory::deprecatedAddDefaultLeafMemoryPool();
+  }
+
+  std::unique_ptr<EncodingSelectionPolicy<T>> createSelectionPolicy() {
+    EncodingLayout layout{
+        EncodingType::Pfor, {}, CompressionType::Uncompressed};
+    return std::make_unique<ReplayedEncodingSelectionPolicy<T>>(
+        std::move(layout),
+        CompressionOptions{},
+        encodingSelectionPolicyFactory_);
+  }
+
+  std::unique_ptr<Encoding> encodeAndCreate(const std::vector<T>& values) {
+    Buffer buffer{*pool_};
+    auto encoded = EncodingFactory::encode<T>(
+        createSelectionPolicy(),
+        std::span<const T>{values.data(), values.size()},
+        buffer);
+    encodedStorage_.assign(encoded.begin(), encoded.end());
+    return EncodingFactory().create(
+        *pool_, {encodedStorage_.data(), encodedStorage_.size()}, nullptr);
+  }
+
+  void roundTripAndExpect(const std::vector<T>& values) {
+    auto encoding = encodeAndCreate(values);
+    EXPECT_EQ(encoding->encodingType(), EncodingType::Pfor);
+    EXPECT_EQ(encoding->dataType(), TypeTraits<T>::dataType);
+    EXPECT_EQ(encoding->rowCount(), values.size());
+
+    std::vector<T> decoded(values.size());
+    encoding->materialize(static_cast<uint32_t>(values.size()), decoded.data());
+    for (size_t i = 0; i < values.size(); ++i) {
+      EXPECT_EQ(decoded[i], values[i]) << "mismatch at index " << i;
+    }
+  }
+
+  std::shared_ptr<velox::memory::MemoryPool> pool_;
+  std::vector<char> encodedStorage_;
+  ManualEncodingSelectionPolicyFactory manualPolicyFactory_;
+  EncodingSelectionPolicyFactory encodingSelectionPolicyFactory_ =
+      [this](DataType dataType) {
+        return manualPolicyFactory_.createPolicy(dataType);
+      };
+};
+
+using PforTypes = ::testing::Types<uint32_t, uint64_t, uint8_t, uint16_t>;
+TYPED_TEST_SUITE(PforEncodingTest, PforTypes);
+
+TYPED_TEST(PforEncodingTest, singleElement) {
+  using T = TypeParam;
+  this->roundTripAndExpect({T{42}});
+}
+
+TYPED_TEST(PforEncodingTest, allSameValues) {
+  using T = TypeParam;
+  std::vector<T> values(64, T{7});
+  this->roundTripAndExpect(values);
+}
+
+TYPED_TEST(PforEncodingTest, denseSmallValuesNoExceptions) {
+  // Residuals all fit comfortably in the smallest 7-bit bucket; the encoder
+  // should pick baseBitWidth=7 and emit zero exceptions.
+  using T = TypeParam;
+  std::vector<T> values;
+  values.reserve(200);
+  for (uint32_t i = 0; i < 200; ++i) {
+    values.push_back(static_cast<T>(100 + (i % 64)));
+  }
+  this->roundTripAndExpect(values);
+}
+
+TYPED_TEST(PforEncodingTest, sparseOutliers) {
+  // 90% small residuals + 10% large outliers — Pfor's sweet spot. Skip on
+  // narrow types where outliers would not be representable.
+  using T = TypeParam;
+  if constexpr (sizeof(T) < 4) {
+    return;
+  } else {
+    std::vector<T> values;
+    values.reserve(500);
+    for (uint32_t i = 0; i < 500; ++i) {
+      if (i % 10 == 7) {
+        values.push_back(static_cast<T>(100000 + i));
+      } else {
+        values.push_back(static_cast<T>(50 + (i % 50)));
+      }
+    }
+    this->roundTripAndExpect(values);
+  }
+}
+
+TYPED_TEST(PforEncodingTest, residualsAtBitWidthBoundary) {
+  // Residuals exactly at the (1<<7)-1 = 127 boundary — verifies the
+  // base-mask comparison treats the boundary residual as a fitting value.
+  using T = TypeParam;
+  std::vector<T> values;
+  values.reserve(50);
+  for (uint32_t i = 0; i < 50; ++i) {
+    values.push_back(static_cast<T>(i * 2 % 128));
+  }
+  this->roundTripAndExpect(values);
+}
+
+TYPED_TEST(PforEncodingTest, mixedSizes) {
+  using T = TypeParam;
+  for (uint32_t n : {1u, 7u, 15u, 16u, 17u, 33u, 64u, 100u, 257u, 1024u}) {
+    SCOPED_TRACE(fmt::format("n={}", n));
+    std::vector<T> values;
+    values.reserve(n);
+    for (uint32_t i = 0; i < n; ++i) {
+      values.push_back(static_cast<T>((i * 31 + 1) % 256));
+    }
+    this->roundTripAndExpect(values);
+  }
+}
+
+TYPED_TEST(PforEncodingTest, skipAndMaterialize) {
+  using T = TypeParam;
+  std::vector<T> values;
+  values.reserve(300);
+  for (uint32_t i = 0; i < 300; ++i) {
+    if constexpr (sizeof(T) >= 4) {
+      values.push_back(
+          static_cast<T>(i % 17 == 0 ? 100000 + i : 50 + (i % 30)));
+    } else {
+      values.push_back(static_cast<T>(50 + (i % 30)));
+    }
+  }
+  auto encoding = this->encodeAndCreate(values);
+
+  // Materialize a few prefixes interleaved with skips — hits the exception
+  // cursor and the bitpacked cursor in the same pass.
+  encoding->reset();
+  std::vector<T> chunk(50);
+  encoding->materialize(50, chunk.data());
+  for (uint32_t i = 0; i < 50; ++i) {
+    EXPECT_EQ(chunk[i], values[i]);
+  }
+  encoding->skip(75);
+  encoding->materialize(50, chunk.data());
+  for (uint32_t i = 0; i < 50; ++i) {
+    EXPECT_EQ(chunk[i], values[125 + i]) << "i=" << i;
+  }
+  // 50 read + 75 skip + 50 read + 75 skip + 50 read == 300 == values.size()
+  encoding->skip(75);
+  encoding->materialize(50, chunk.data());
+  for (uint32_t i = 0; i < 50; ++i) {
+    EXPECT_EQ(chunk[i], values[250 + i]) << "i=" << i;
+  }
+
+  // Reset must restore all cursors so a second pass produces identical output.
+  encoding->reset();
+  std::vector<T> all(values.size());
+  encoding->materialize(static_cast<uint32_t>(values.size()), all.data());
+  for (size_t i = 0; i < values.size(); ++i) {
+    EXPECT_EQ(all[i], values[i]) << "after-reset i=" << i;
+  }
+}
+
+TYPED_TEST(PforEncodingTest, exceptionAtFirstAndLastRow) {
+  // Edge case: exceptions land on the first row, the last row, and a
+  // middle row. Verifies cursor handling at the bounds.
+  using T = TypeParam;
+  if constexpr (sizeof(T) < 4) {
+    return;
+  } else {
+    std::vector<T> values;
+    values.reserve(100);
+    for (uint32_t i = 0; i < 100; ++i) {
+      values.push_back(static_cast<T>(10));
+    }
+    values[0] = static_cast<T>(50000);
+    values[50] = static_cast<T>(60000);
+    values[99] = static_cast<T>(70000);
+    this->roundTripAndExpect(values);
+  }
+}
+
+TYPED_TEST(PforEncodingTest, debugString) {
+  using T = TypeParam;
+  std::vector<T> values;
+  values.reserve(8);
+  for (uint32_t i = 0; i < 8; ++i) {
+    values.push_back(static_cast<T>(i + 1));
+  }
+  auto encoding = this->encodeAndCreate(values);
+  const std::string debug = encoding->debugString();
+  EXPECT_NE(debug.find("Pfor"), std::string::npos);
+  EXPECT_NE(debug.find("baseBitWidth="), std::string::npos);
+  EXPECT_NE(debug.find("numExceptions="), std::string::npos);
+}
+
+class PforEncodingFuzzerTest : public ::testing::Test {
+ protected:
+  static void SetUpTestCase() {
+    velox::memory::MemoryManager::testingSetInstance({});
+  }
+
+  void SetUp() override {
+    pool_ = velox::memory::deprecatedAddDefaultLeafMemoryPool();
+  }
+
+  // Run the fuzzer against the cpp type T (signed or unsigned) by going
+  // through EncodingFactory::encode<T>. Verifies the signed-input wire path,
+  // materialization, and skip/materialize interleaving over many seeds.
+  template <typename T>
+  void runFuzzer(uint32_t seed, uint32_t numIterations) {
+    std::mt19937 rng(seed);
+
+    ManualEncodingSelectionPolicyFactory manualFactory;
+    EncodingSelectionPolicyFactory factory =
+        [&manualFactory](DataType dataType) {
+          return manualFactory.createPolicy(dataType);
+        };
+
+    for (uint32_t iter = 0; iter < numIterations; ++iter) {
+      SCOPED_TRACE(fmt::format("iteration {}", iter));
+
+      std::uniform_int_distribution<uint32_t> sizeDist(1, 1000);
+      const uint32_t numValues = sizeDist(rng);
+
+      std::uniform_int_distribution<int32_t> baseDist(0, 64);
+      std::uniform_int_distribution<int32_t> outlierDist(0, 1 << 20);
+      std::uniform_real_distribution<double> outlierProb(0.0, 1.0);
+      std::vector<T> values;
+      values.reserve(numValues);
+      const T offset = static_cast<T>(1000);
+      for (uint32_t i = 0; i < numValues; ++i) {
+        const bool isOutlier = outlierProb(rng) < 0.05;
+        values.push_back(
+            static_cast<T>(
+                offset + (isOutlier ? outlierDist(rng) : baseDist(rng))));
+      }
+
+      Buffer buffer{*pool_};
+      EncodingLayout layout{
+          EncodingType::Pfor, {}, CompressionType::Uncompressed};
+      auto policy = std::make_unique<ReplayedEncodingSelectionPolicy<T>>(
+          std::move(layout), CompressionOptions{}, factory);
+      auto encoded = EncodingFactory::encode<T>(
+          std::move(policy),
+          std::span<const T>{values.data(), values.size()},
+          buffer);
+      std::vector<char> storage(encoded.begin(), encoded.end());
+      auto encoding = EncodingFactory().create(
+          *pool_, {storage.data(), storage.size()}, nullptr);
+
+      ASSERT_EQ(encoding->encodingType(), EncodingType::Pfor);
+      ASSERT_EQ(encoding->dataType(), TypeTraits<T>::dataType);
+      ASSERT_EQ(encoding->rowCount(), values.size());
+      std::vector<T> decoded(values.size());
+      encoding->materialize(
+          static_cast<uint32_t>(values.size()), decoded.data());
+      for (size_t i = 0; i < values.size(); ++i) {
+        ASSERT_EQ(decoded[i], values[i])
+            << "iter=" << iter << " i=" << i << " size=" << numValues;
+      }
+
+      // Random skip/materialize sequence.
+      encoding->reset();
+      std::uniform_int_distribution<uint32_t> stepDist(0, numValues);
+      uint32_t cursor = 0;
+      while (cursor < numValues) {
+        const uint32_t remaining = numValues - cursor;
+        const uint32_t skipCount = stepDist(rng) % (remaining + 1);
+        if (skipCount > 0) {
+          encoding->skip(skipCount);
+          cursor += skipCount;
+        }
+        if (cursor >= numValues) {
+          break;
+        }
+        const uint32_t matCount =
+            std::max<uint32_t>(1, stepDist(rng) % (numValues - cursor + 1));
+        std::vector<T> chunk(matCount);
+        encoding->materialize(matCount, chunk.data());
+        for (uint32_t i = 0; i < matCount; ++i) {
+          ASSERT_EQ(chunk[i], values[cursor + i])
+              << "iter=" << iter << " cursor=" << cursor << " i=" << i;
+        }
+        cursor += matCount;
+      }
+    }
+  }
+
+  std::shared_ptr<velox::memory::MemoryPool> pool_;
+};
+
+TEST_F(PforEncodingFuzzerTest, fuzzerInt32) {
+  runFuzzer<int32_t>(/*seed=*/12345, /*numIterations=*/30);
+}
+
+TEST_F(PforEncodingFuzzerTest, fuzzerInt64) {
+  runFuzzer<int64_t>(/*seed=*/67890, /*numIterations=*/30);
+}
+
+TEST_F(PforEncodingFuzzerTest, fuzzerUint32) {
+  runFuzzer<uint32_t>(/*seed=*/24680, /*numIterations=*/30);
+}
+
+TEST_F(PforEncodingFuzzerTest, fuzzerUint64) {
+  runFuzzer<uint64_t>(/*seed=*/13579, /*numIterations=*/30);
+}
+
+TEST_F(PforEncodingFuzzerTest, encodeRejectsEmpty) {
+  Buffer buffer{*pool_};
+  EncodingLayout layout{EncodingType::Pfor, {}, CompressionType::Uncompressed};
+  ManualEncodingSelectionPolicyFactory manualFactory;
+  EncodingSelectionPolicyFactory factory = [&manualFactory](DataType dataType) {
+    return manualFactory.createPolicy(dataType);
+  };
+  auto policy = std::make_unique<ReplayedEncodingSelectionPolicy<uint32_t>>(
+      std::move(layout), CompressionOptions{}, factory);
+  std::vector<uint32_t> empty;
+  NIMBLE_ASSERT_THROW(
+      EncodingFactory::encode<uint32_t>(
+          std::move(policy),
+          std::span<const uint32_t>{empty.data(), empty.size()},
+          buffer),
+      "Pfor encoding cannot be used with 0 rows.");
+}
+
+} // namespace facebook::nimble::test

--- a/dwio/nimble/encodings/tests/TestUtils.h
+++ b/dwio/nimble/encodings/tests/TestUtils.h
@@ -19,6 +19,7 @@
 #include "dwio/nimble/encodings/ConstantEncoding.h"
 #include "dwio/nimble/encodings/DeltaEncoding.h"
 #include "dwio/nimble/encodings/DictionaryEncoding.h"
+#include "dwio/nimble/encodings/DoubleDeltaEncoding.h"
 #include "dwio/nimble/encodings/FixedBitWidthEncoding.h"
 #include "dwio/nimble/encodings/MainlyConstantEncoding.h"
 #include "dwio/nimble/encodings/NullableEncoding.h"
@@ -186,6 +187,12 @@ class Encoder {
   struct EncodingTypeTraits<nimble::PforEncoding<T>> {
     static constexpr inline nimble::EncodingType encodingType =
         nimble::EncodingType::Pfor;
+  };
+
+  template <>
+  struct EncodingTypeTraits<nimble::DoubleDeltaEncoding<T>> {
+    static constexpr inline nimble::EncodingType encodingType =
+        nimble::EncodingType::DoubleDelta;
   };
 
  public:

--- a/dwio/nimble/encodings/tests/TestUtils.h
+++ b/dwio/nimble/encodings/tests/TestUtils.h
@@ -22,6 +22,7 @@
 #include "dwio/nimble/encodings/FixedBitWidthEncoding.h"
 #include "dwio/nimble/encodings/MainlyConstantEncoding.h"
 #include "dwio/nimble/encodings/NullableEncoding.h"
+#include "dwio/nimble/encodings/PforEncoding.h"
 #include "dwio/nimble/encodings/RleEncoding.h"
 #include "dwio/nimble/encodings/SparseBoolEncoding.h"
 #include "dwio/nimble/encodings/TrivialEncoding.h"
@@ -179,6 +180,12 @@ class Encoder {
   struct EncodingTypeTraits<nimble::NullableEncoding<T>> {
     static constexpr inline nimble::EncodingType encodingType =
         nimble::EncodingType::Nullable;
+  };
+
+  template <>
+  struct EncodingTypeTraits<nimble::PforEncoding<T>> {
+    static constexpr inline nimble::EncodingType encodingType =
+        nimble::EncodingType::Pfor;
   };
 
  public:

--- a/dwio/nimble/fuzzer/encoding/EncodingFuzzerTest.cpp
+++ b/dwio/nimble/fuzzer/encoding/EncodingFuzzerTest.cpp
@@ -29,6 +29,7 @@
 #include "dwio/nimble/encodings/ConstantEncoding.h"
 #include "dwio/nimble/encodings/DeltaEncoding.h"
 #include "dwio/nimble/encodings/DictionaryEncoding.h"
+#include "dwio/nimble/encodings/DoubleDeltaEncoding.h"
 #include "dwio/nimble/encodings/FixedBitWidthEncoding.h"
 #include "dwio/nimble/encodings/MainlyConstantEncoding.h"
 #include "dwio/nimble/encodings/RleEncoding.h"
@@ -273,6 +274,23 @@ class ALPFuzzerTest : public ::testing::Test {};
 TYPED_TEST_SUITE(ALPFuzzerTest, ALPTypes);
 
 TYPED_TEST(ALPFuzzerTest, correctness) {
+  EncodingFuzzer<TypeParam> fuzzer(
+      FLAGS_fuzzer_iterations,
+      FLAGS_fuzzer_max_rows,
+      FLAGS_fuzzer_seed,
+      FLAGS_fuzzer_compression);
+  fuzzer.run();
+}
+
+// DoubleDelta: int64/uint64 only
+using DoubleDeltaTypes = ::testing::
+    Types<DoubleDeltaEncoding<int64_t>, DoubleDeltaEncoding<uint64_t>>;
+
+template <typename E>
+class DoubleDeltaFuzzerTest : public ::testing::Test {};
+TYPED_TEST_SUITE(DoubleDeltaFuzzerTest, DoubleDeltaTypes);
+
+TYPED_TEST(DoubleDeltaFuzzerTest, correctness) {
   EncodingFuzzer<TypeParam> fuzzer(
       FLAGS_fuzzer_iterations,
       FLAGS_fuzzer_max_rows,

--- a/dwio/nimble/serializer/tests/SerializationTest.cpp
+++ b/dwio/nimble/serializer/tests/SerializationTest.cpp
@@ -2098,6 +2098,78 @@ TEST_P(SerializationTest, encodingLayoutTree) {
   }
 }
 
+// Columnar reader-level round-trip for PforEncoding. Forces Pfor via
+// EncodingLayoutTree and verifies data integrity through the full
+// Serializer → Deserializer path.
+TEST_P(SerializationTest, pforColumnarRoundTrip) {
+  auto type = velox::ROW({
+      {"int_val", velox::INTEGER()},
+      {"long_val", velox::BIGINT()},
+  });
+
+  EncodingLayoutTree layoutTree{
+      Kind::Row,
+      {},
+      "",
+      {
+          {Kind::Scalar,
+           {{EncodingLayoutTree::StreamIdentifiers::Scalar::ScalarStream,
+             EncodingLayout{
+                 EncodingType::Pfor, {}, CompressionType::Uncompressed}}},
+           ""},
+          {Kind::Scalar,
+           {{EncodingLayoutTree::StreamIdentifiers::Scalar::ScalarStream,
+             EncodingLayout{
+                 EncodingType::Pfor, {}, CompressionType::Uncompressed}}},
+           ""},
+      }};
+
+  SerializerOptions options{
+      .version = version(),
+      .encodingLayoutTree = layoutTree,
+      .compressionOptions = compressionOptions(),
+  };
+
+  Serializer serializer{options, type, pool_.get()};
+
+  const velox::vector_size_t numRows = 100;
+  auto intVals =
+      velox::BaseVector::create(velox::INTEGER(), numRows, pool_.get());
+  auto longVals =
+      velox::BaseVector::create(velox::BIGINT(), numRows, pool_.get());
+  for (velox::vector_size_t i = 0; i < numRows; ++i) {
+    // ~90% narrow values, ~10% outliers — Pfor's sweet spot.
+    intVals->asFlatVector<int32_t>()->set(
+        i, i % 10 == 0 ? 1'000'000 + i : i % 100);
+    longVals->asFlatVector<int64_t>()->set(
+        i, i % 10 == 0 ? 9'000'000'000LL + i : i * 60);
+  }
+
+  auto input = std::make_shared<velox::RowVector>(
+      pool_.get(),
+      type,
+      nullptr,
+      numRows,
+      std::vector<velox::VectorPtr>{intVals, longVals});
+
+  auto serialized =
+      serializer.serialize(input, OrderedRanges::of(0, input->size()));
+
+  Deserializer deserializer{
+      SchemaReader::getSchema(serializer.schemaBuilder().schemaNodes()),
+      pool_.get(),
+      deserializerOptions()};
+
+  velox::VectorPtr output;
+  deserializer.deserialize(serialized, output);
+
+  ASSERT_EQ(output->size(), input->size());
+  for (velox::vector_size_t i = 0; i < input->size(); ++i) {
+    ASSERT_TRUE(vectorEquals(output, input, i))
+        << "Content mismatch at index " << i;
+  }
+}
+
 // Test encoding layout tree for FlatMap with dynamic key discovery and nested
 // types.
 TEST_P(SerializationTest, encodingLayoutTreeFlatMap) {

--- a/dwio/nimble/tools/EncodingUtilities.cpp
+++ b/dwio/nimble/tools/EncodingUtilities.cpp
@@ -52,6 +52,7 @@ void extractCompressionType(
     case EncodingType::ALP:
     case EncodingType::Pfor:
     case EncodingType::DoubleDelta:
+    case EncodingType::CompactFor:
       break;
   }
 }
@@ -107,7 +108,8 @@ void traverseEncodings(
     case EncodingType::Prefix:
     case EncodingType::ALP:
     case EncodingType::Pfor:
-    case EncodingType::DoubleDelta: {
+    case EncodingType::DoubleDelta:
+    case EncodingType::CompactFor: {
       // don't have any nested encoding
       break;
     }

--- a/dwio/nimble/tools/EncodingUtilities.cpp
+++ b/dwio/nimble/tools/EncodingUtilities.cpp
@@ -50,6 +50,7 @@ void extractCompressionType(
     case EncodingType::MainlyConstant:
     case EncodingType::Prefix:
     case EncodingType::ALP:
+    case EncodingType::Pfor:
       break;
   }
 }
@@ -103,7 +104,8 @@ void traverseEncodings(
     case EncodingType::Varint:
     case EncodingType::Constant:
     case EncodingType::Prefix:
-    case EncodingType::ALP: {
+    case EncodingType::ALP:
+    case EncodingType::Pfor: {
       // don't have any nested encoding
       break;
     }

--- a/dwio/nimble/tools/EncodingUtilities.cpp
+++ b/dwio/nimble/tools/EncodingUtilities.cpp
@@ -51,6 +51,7 @@ void extractCompressionType(
     case EncodingType::Prefix:
     case EncodingType::ALP:
     case EncodingType::Pfor:
+    case EncodingType::DoubleDelta:
       break;
   }
 }
@@ -105,7 +106,8 @@ void traverseEncodings(
     case EncodingType::Constant:
     case EncodingType::Prefix:
     case EncodingType::ALP:
-    case EncodingType::Pfor: {
+    case EncodingType::Pfor:
+    case EncodingType::DoubleDelta: {
       // don't have any nested encoding
       break;
     }


### PR DESCRIPTION
Summary:

Space-efficient FOR encoder specialised for `int64`/`uint64` (slot 17).

**Relationship to `FixedBitWidth`**

Same core algorithm (subtract baseline, bitpack residuals via `FixedBitArray`), but two wire-format improvements:

| | `FixedBitWidth` | `CompactFor` | Savings |
|---|---|---|---|
| **Baseline** | Fixed `sizeof(T)` (8B for int64) | Varint (1-10B) | Up to 7B for int64; diminishes for smaller types (int32: max 3B, int8: ~0) |
| **BitWidth** | Rounded up to byte boundary (4→8) | Exact value (4 stays 4) | Depends on data; can halve the bitpacked region |

Everything else — `FixedBitArray::bulkGet64WithBaseline` decode, `FixedBitArray::bufferSize` sizing, `FixedBitArray::set`/`bulkSet32` encode — is identical shared infrastructure. No code is duplicated; only the 10-line wire-format header differs.

**Why int64 only (not all integer types)**

The varint baseline savings scale with `sizeof(T)`. For int64 (8B → 1-10B varint) the savings are substantial. For int32 (4B → 1-5B) they are moderate, and Pfor/SimdForBitpack already dominate those types in benchmarks (13/19 trait wins). For int8/int16 (1-2B) there is no savings at all. Extending to smaller types is trivial (remove `static_assert`, widen factory dispatch) but produces no practical benefit.

**Wire format** (after the standard 6-byte Encoding prefix):

```
[varint: baseline]      — min value (1-10 bytes)
[1 byte: bitWidth]      — bits per residual (0-64, exact)
[bitpacked residuals]   — FixedBitArray::bufferSize(N, bitWidth) bytes
                          (omitted when bitWidth == 0)
```

**Encode**: When `bitWidth <= 32` (common — most int64 ranges fit in 32 bits), uses the template-unrolled `FixedBitArray::bulkSet32` fast path. Falls back to per-element `set()` for wider bit widths.

**Decode**: `FixedBitArray::bulkGet64WithBaseline(row, count, output, baseline)` — the same branchless bulk path used by `FixedBitWidthEncoding`, with a single-load fast path for bitWidth ≤ 56.

**readWithVisitor**: Implements `bulkScan()` for the `readWithVisitorFast` path (unlike Pfor which uses the slow path). O(1) random access — no sequential state.

**Auto-selection**: Excluded from `possibleEncodings()` and `defaultReadFactors()`. Available only via explicit `EncodingLayoutTree` overrides until production bake-in.

Ported from AUS `LONG_LIST_FOR_BITPACKED`.

Differential Revision: D105755627
