### PR TITLE
fix: Fix CachedMetadataInput tests (#793)

### DIFF
--- a/dwio/nimble/tablet/MetadataInput.cpp
+++ b/dwio/nimble/tablet/MetadataInput.cpp
@@ -385,10 +385,16 @@ std::shared_ptr<MetadataBuffer> CachedMetadataInput::promoteCachePin(
 
 void CachedMetadataInput::loadFromSsd(
     std::vector<LoadedSection>& sections,
-    std::vector<uint32_t>& loadIndices) {
+    std::vector<uint32_t>& loadIndices,
+    std::vector<std::optional<velox::cache::CachePin>>& cachePins) {
   if (loadIndices.empty()) {
     return;
   }
+  NIMBLE_CHECK_EQ(
+      cachePins.size(),
+      sections.size(),
+      "cachePins size must match sections size");
+
   auto* ssdCache = cache_->ssdCache();
   if (ssdCache == nullptr) {
     return;
@@ -424,7 +430,13 @@ void CachedMetadataInput::loadFromSsd(
           "SSD entry size mismatch with expected uncompressed size");
     }
 
-    auto pin = acquireCachePin(key, ssdSize);
+    velox::cache::CachePin pin;
+    if (cachePins[index].has_value()) {
+      pin = std::move(*cachePins[index]);
+      cachePins[index].reset();
+    } else {
+      pin = acquireCachePin(key, ssdSize);
+    }
     auto buffer = tryCacheHit(ssdSize, pin);
     if (buffer != nullptr) {
       loaded.buffer = std::move(buffer);
@@ -554,7 +566,7 @@ std::vector<std::shared_ptr<MetadataBuffer>> CachedMetadataInput::load(
   std::vector<LoadedSection> loadSections(sections.begin(), sections.end());
   std::vector<std::optional<velox::cache::CachePin>> cachePins;
   auto missIndices = loadFromCache(loadSections, cachePins);
-  loadFromSsd(loadSections, missIndices);
+  loadFromSsd(loadSections, missIndices, cachePins);
 
   if (!missIndices.empty()) {
     ReadBuffers readBuffers;

--- a/dwio/nimble/tablet/MetadataInput.h
+++ b/dwio/nimble/tablet/MetadataInput.h
@@ -243,7 +243,8 @@ class CachedMetadataInput : public MetadataInput {
   // memory cache. Removes loaded indices from loadIndices in-place.
   void loadFromSsd(
       std::vector<LoadedSection>& sections,
-      std::vector<uint32_t>& loadIndices);
+      std::vector<uint32_t>& loadIndices,
+      std::vector<std::optional<velox::cache::CachePin>>& cachePins);
 
   // Decompresses loaded buffers and stores results into sections.
   // For sections with cache pins, decompresses into the pin and promotes

--- a/dwio/nimble/tablet/tests/MetadataInputTest.cpp
+++ b/dwio/nimble/tablet/tests/MetadataInputTest.cpp
@@ -631,6 +631,9 @@ TEST_P(CachedMetadataInputTest, loadWithCache) {
   for (const auto& testData : enqueueLoadReadTestSettings()) {
     SCOPED_TRACE(testData.debugString());
     cache_->clear();
+    if (enableSsd()) {
+      cache_->ssdCache()->clear();
+    }
 
     std::vector<nimble::MetadataSection> sections;
     std::vector<std::string> fileDataParts;
@@ -766,6 +769,9 @@ DEBUG_ONLY_TEST_P(CachedMetadataInputTest, ioCoalescing) {
   for (const auto& testData : testSettings) {
     SCOPED_TRACE(testData.debugString());
     cache_->clear();
+    if (enableSsd()) {
+      cache_->ssdCache()->clear();
+    }
 
     uint64_t fileSize = 0;
     std::vector<std::string> sectionData;


### PR DESCRIPTION
Summary:

Root Cause

  Single-thread self-deadlock in CachedMetadataInput::load() (dwio/nimble/tablet/MetadataInput.cpp:550).

  The load() method does a 3-tier lookup: RAM cache → SSD cache → file I/O. The problem was in the handoff between the first two tiers:

  1. loadFromCache() (tier 1) calls acquireCachePin(key, size) for the section. Since the RAM cache was cleared, this creates a new cache entry in exclusive mode and stores the pin in cachePins[index]. The section is reported as a miss.
  2. loadFromSsd() (tier 2) finds the same key on SSD. It then calls acquireCachePin() on the same key to get a pin to load the SSD data into.
  3. acquireCachePin() has an infinite for(;;) loop that blocks until the entry is no longer exclusively held. But the exclusive hold is from step 1's pin, sitting in cachePins on the same call stack. It will never be released until load()
  returns — which it can't, because it's stuck waiting. Deadlock.

  load()
    └─ loadFromCache()       → acquires exclusive pin on key {fileId, 0}
    └─ loadFromSsd()
         └─ acquireCachePin() → waits for that same exclusive pin → BLOCKED FOREVER
The Fix

  Pass cachePins into loadFromSsd(). When an SSD hit is found for a section that already has a pre-claimed pin from loadFromCache, reuse that pin instead of trying to acquire a new one:

  velox::cache::CachePin pin;
  if (cachePins[index].has_value()) {
    pin = std::move(*cachePins[index]);
    cachePins[index].reset();
  } else {
    pin = acquireCachePin(key, ssdSize);
  }

  The consumed pin is reset in cachePins so it isn't accidentally reused later in the file-IO fallback path. Sections without a pre-claimed pin (older files without uncompressedSize) still acquire a fresh pin via the existing path — no deadlock
  there since loadFromCache doesn't pre-claim pins for those sections.

Differential Revision: D106600640


