### PR TITLE
[Reference] [Do-not-merge for now] feat(encoding): Experimental Enable/Disable FrequencyPartition and FOR encoding in both write and read paths (#794)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -119,16 +119,24 @@ add_link_options(-Wl,--gc-sections)
 
 include(CTest) # include after project() but before add_subdirectory()
 
-find_package(flatbuffers)
-set(NIMBLE_NEED_BUNDLED_BUILD_FLAT_BUFFERS FLASE)
-if(flatbuffers_FOUND)
-  if(flatbuffers_VERSION VERSION_LESS "22.9.4")
+# Try to find FlatBuffers with uppercase name first (newer versions)
+find_package(FlatBuffers QUIET)
+set(NIMBLE_NEED_BUNDLED_BUILD_FLAT_BUFFERS FALSE)
+if(FlatBuffers_FOUND)
+  if(FlatBuffers_VERSION VERSION_LESS "22.9.4")
     set(NIMBLE_NEED_BUNDLED_BUILD_FLAT_BUFFERS TRUE)
   endif()
 else()
-  # Fallback to old FlatBuffers (< 2.0.0).
-  find_package(Flatbuffers REQUIRED)
-  set(NIMBLE_NEED_BUNDLED_BUILD_FLAT_BUFFERS TRUE)
+  # Try lowercase variant
+  find_package(flatbuffers QUIET)
+  if(flatbuffers_FOUND)
+    if(flatbuffers_VERSION VERSION_LESS "22.9.4")
+      set(NIMBLE_NEED_BUNDLED_BUILD_FLAT_BUFFERS TRUE)
+    endif()
+  else()
+    # No system FlatBuffers found, use bundled
+    set(NIMBLE_NEED_BUNDLED_BUILD_FLAT_BUFFERS TRUE)
+  endif()
 endif()
 if(NIMBLE_NEED_BUNDLED_BUILD_FLAT_BUFFERS)
   # Old FlatBuffers (< 22.9.4) doesn't provide build_flatbuffers(). So

--- a/dwio/nimble/common/Types.cpp
+++ b/dwio/nimble/common/Types.cpp
@@ -45,6 +45,10 @@ std::string toString(EncodingType encodingType) {
       return "Constant";
     case EncodingType::MainlyConstant:
       return "MainlyConstant";
+    case EncodingType::FrequencyPartition:
+      return "FrequencyPartition";
+    case EncodingType::FOR:
+      return "FOR";
     case EncodingType::Sentinel:
       return "Sentinel";
     case EncodingType::Prefix:

--- a/dwio/nimble/common/Types.h
+++ b/dwio/nimble/common/Types.h
@@ -104,6 +104,12 @@ enum class EncodingType {
   // shared across consecutive entries to reduce storage. Supports seek
   // operations for efficient random access.
   Prefix = 11,
+  // Partitions data by value frequency. Frequent values get shorter bit-width
+  // codes. Rows are reordered to group values with same code length.
+  FrequencyPartition = 12,
+  // Frame of Reference: stores offsets from per-frame minimum values.
+  // Supports O(1) random access. Preserves row order.
+  FOR = 13,
 };
 std::string toString(EncodingType encodingType);
 std::ostream& operator<<(std::ostream& out, EncodingType encodingType);

--- a/dwio/nimble/compression/Compression.cpp
+++ b/dwio/nimble/compression/Compression.cpp
@@ -46,6 +46,14 @@ struct CompressorRegistry {
 
 ICompressor& getCompressor(CompressionType compressionType) {
   static CompressorRegistry registry;
+
+#ifdef DISABLE_META_INTERNAL_COMPRESSOR
+  // When MetaInternal is not available, redirect to Zstd
+  if (compressionType == CompressionType::MetaInternal) {
+    compressionType = CompressionType::Zstd;
+  }
+#endif
+
   auto it = registry.compressors.find(compressionType);
   NIMBLE_CHECK(
       it != registry.compressors.end(),
@@ -53,6 +61,46 @@ ICompressor& getCompressor(CompressionType compressionType) {
       toString(compressionType));
   return *it->second;
 }
+
+#ifdef DISABLE_META_INTERNAL_COMPRESSOR
+// Wrapper to redirect MetaInternal compression to Zstd
+class MetaInternalToZstdPolicy : public CompressionPolicy {
+ public:
+  explicit MetaInternalToZstdPolicy(const CompressionPolicy& base)
+      : base_(base) {}
+
+  CompressionInformation compression() const override {
+    auto info = base_.compression();
+    if (info.compressionType == CompressionType::MetaInternal) {
+      // Convert MetaInternal parameters to Zstd
+      CompressionInformation zstdInfo{
+          .compressionType = CompressionType::Zstd,
+          .minCompressionSize = info.minCompressionSize};
+      // Map MetaInternal compression level to Zstd compression level
+      zstdInfo.parameters.zstd.compressionLevel =
+          info.parameters.metaInternal.compressionLevel;
+      return zstdInfo;
+    }
+    return info;
+  }
+
+  bool shouldAccept(
+      CompressionType compressionType,
+      uint64_t uncompressedSize,
+      uint64_t compressedSize) const override {
+    // Redirect MetaInternal to Zstd for acceptance check
+    if (compressionType == CompressionType::MetaInternal) {
+      compressionType = CompressionType::Zstd;
+    }
+    return base_.shouldAccept(
+        compressionType, uncompressedSize, compressedSize);
+  }
+
+ private:
+  const CompressionPolicy& base_;
+};
+#endif
+
 } // namespace
 
 /* static */ CompressionResult Compression::compress(
@@ -62,6 +110,16 @@ ICompressor& getCompressor(CompressionType compressionType) {
     int bitWidth,
     const CompressionPolicy& compressionPolicy) {
   auto compression = compressionPolicy.compression();
+
+#ifdef DISABLE_META_INTERNAL_COMPRESSOR
+  // Wrap the policy to redirect MetaInternal to Zstd
+  if (compression.compressionType == CompressionType::MetaInternal) {
+    MetaInternalToZstdPolicy wrapper(compressionPolicy);
+    compression = wrapper.compression();
+    return getCompressor(compression.compressionType)
+        .compress(pool, data, dataType, bitWidth, wrapper);
+  }
+#endif
 
   return getCompressor(compression.compressionType)
       .compress(pool, data, dataType, bitWidth, compressionPolicy);

--- a/dwio/nimble/encodings/ForEncoding.h
+++ b/dwio/nimble/encodings/ForEncoding.h
@@ -1,0 +1,619 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <span>
+#include <type_traits>
+#include <vector>
+
+#include "dwio/nimble/common/Buffer.h"
+#include "dwio/nimble/common/Exceptions.h"
+#include "dwio/nimble/common/FixedBitArray.h"
+#include "dwio/nimble/common/Vector.h"
+#include "dwio/nimble/compression/Compression.h"
+#include "dwio/nimble/encodings/common/Encoding.h"
+#include "dwio/nimble/encodings/common/EncodingFactory.h"
+#include "dwio/nimble/encodings/common/EncodingPrimitives.h"
+#include "dwio/nimble/encodings/common/EncodingType.h"
+#include "dwio/nimble/encodings/selection/EncodingSelection.h"
+
+// Frame of Reference encoding. Divides data into fixed-size frames, storing
+// a reference value per frame and bit-packing the exceptions (value - ref).
+// Supports O(1) random access when BitOffsets are enabled.
+//
+// Data layout is:
+// Encoding::kPrefixSize bytes: standard Encoding prefix
+// 1 byte: compression type
+// 4 bytes: frame size
+// 4 bytes: number of frames
+// 1 byte: enableBitOffsets flag
+// XX bytes: BitWidths array encoding (nested)
+// YY bytes: References array encoding (nested)
+// ZZ bytes: BitOffsets array encoding (nested, optional)
+// WW bytes: bit-packed exceptions data
+
+namespace facebook::nimble {
+
+template <typename T>
+class ForEncoding final
+    : public TypedEncoding<T, typename TypeTraits<T>::physicalType> {
+ public:
+  using cppDataType = T;
+  using physicalType = typename TypeTraits<T>::physicalType;
+
+  static const int kCompressionOffset = Encoding::kPrefixSize;
+  static const int kFrameSizeOffset = kCompressionOffset + 1;
+  static const int kNumFramesOffset = kFrameSizeOffset + 4;
+  static const int kEnableBitOffsetsOffset = kNumFramesOffset + 4;
+  static const int kPrefixSize =
+      kEnableBitOffsetsOffset + 1 - Encoding::kPrefixSize;
+
+  ForEncoding(
+      velox::memory::MemoryPool& memoryPool,
+      std::string_view data,
+      std::function<void*(uint32_t)> stringBufferFactory = nullptr,
+      const Encoding::Options& options = {});
+
+  void reset() final;
+  void skip(uint32_t rowCount) final;
+  void materialize(uint32_t rowCount, void* buffer) final;
+
+  template <typename DecoderVisitor>
+  void readWithVisitor(DecoderVisitor& visitor, ReadWithVisitorParams& params);
+
+  static std::string_view encode(
+      EncodingSelection<physicalType>& selection,
+      std::span<const physicalType> values,
+      Buffer& buffer,
+      const Encoding::Options& options = {});
+
+  std::string debugString(int offset) const final;
+
+ private:
+  struct FrameInfo {
+    physicalType reference;
+    uint8_t bitWidth;
+    uint64_t bitOffset;
+    uint32_t size;
+  };
+
+  uint32_t frameSize_;
+  uint32_t numFrames_;
+  bool enableBitOffsets_;
+  Vector<FrameInfo> frames_;
+  const char* packedData_;
+  uint32_t currentRow_;
+  velox::BufferPtr uncompressedData_;
+  Vector<physicalType> buffer_;
+
+  uint32_t getFrameIndex(uint32_t row) const {
+    return row / frameSize_;
+  }
+
+  uint32_t getPositionInFrame(uint32_t row) const {
+    return row % frameSize_;
+  }
+
+  void decodeRange(uint32_t startRow, uint32_t rowCount, physicalType* output)
+      const;
+
+  physicalType decodeValue(uint32_t row) const;
+};
+//
+// Implementation
+//
+
+template <typename T>
+ForEncoding<T>::ForEncoding(
+    velox::memory::MemoryPool& memoryPool,
+    std::string_view data,
+    std::function<void*(uint32_t)> stringBufferFactory,
+    const Encoding::Options& options)
+    : TypedEncoding<T, physicalType>{memoryPool, data, options},
+      frames_{&memoryPool},
+      currentRow_(0),
+      buffer_{&memoryPool} {
+  static_assert(
+      std::is_integral_v<physicalType>,
+      "ForEncoding only supports integral types");
+
+  const char* pos = data.data() + kCompressionOffset;
+  const EncodingFactory encodingFactory(options);
+  const auto nullStringBufferFactory = [](uint32_t /*size*/) -> void* {
+    return nullptr;
+  };
+  const auto& decodeStringBufferFactory =
+      stringBufferFactory ? stringBufferFactory : nullStringBufferFactory;
+
+  CompressionType compressionType =
+      static_cast<CompressionType>(encoding::readChar(pos));
+
+  frameSize_ = encoding::readUint32(pos);
+  numFrames_ = encoding::readUint32(pos);
+  enableBitOffsets_ = static_cast<bool>(encoding::readChar(pos));
+
+  // Read BitWidths array
+  const uint32_t bitWidthsSize = encoding::readUint32(pos);
+  auto bitWidthsEncoding = encodingFactory.create(
+      *this->pool_,
+      std::string_view(pos, bitWidthsSize),
+      decodeStringBufferFactory);
+  pos += bitWidthsSize;
+
+  Vector<uint8_t> bitWidths(&memoryPool, numFrames_);
+  bitWidthsEncoding->materialize(numFrames_, bitWidths.data());
+
+  // Read References array
+  const uint32_t referencesSize = encoding::readUint32(pos);
+  auto referencesEncoding = encodingFactory.create(
+      *this->pool_,
+      std::string_view(pos, referencesSize),
+      decodeStringBufferFactory);
+  pos += referencesSize;
+
+  Vector<physicalType> references(&memoryPool, numFrames_);
+  referencesEncoding->materialize(numFrames_, references.data());
+
+  // Read BitOffsets array if enabled
+  Vector<uint64_t> bitOffsets(&memoryPool);
+  if (enableBitOffsets_) {
+    const uint32_t bitOffsetsSize = encoding::readUint32(pos);
+    auto bitOffsetsEncoding = encodingFactory.create(
+        *this->pool_,
+        std::string_view(pos, bitOffsetsSize),
+        decodeStringBufferFactory);
+    pos += bitOffsetsSize;
+
+    bitOffsets.resize(numFrames_);
+    bitOffsetsEncoding->materialize(numFrames_, bitOffsets.data());
+  }
+
+  const uint32_t packedDataSize = encoding::readUint32(pos);
+  std::string_view packedDataView{pos, packedDataSize};
+
+  if (compressionType != CompressionType::Uncompressed) {
+    uncompressedData_ = Compression::uncompress(
+        *this->pool_, compressionType, DataType::Undefined, packedDataView);
+    packedData_ = uncompressedData_->as<char>();
+  } else {
+    packedData_ = packedDataView.data();
+  }
+
+  // Build frame metadata
+  frames_.reserve(numFrames_);
+  uint64_t cumulativeBitOffset = 0;
+
+  for (uint32_t i = 0; i < numFrames_; ++i) {
+    FrameInfo frame;
+    frame.reference = references[i];
+    frame.bitWidth = bitWidths[i];
+    frame.bitOffset = enableBitOffsets_ ? bitOffsets[i] : cumulativeBitOffset;
+
+    uint32_t startRow = i * frameSize_;
+    uint32_t endRow = std::min(startRow + frameSize_, this->rowCount_);
+    frame.size = endRow - startRow;
+
+    frames_.push_back(frame);
+
+    // Update cumulative offset for next frame
+    if (!enableBitOffsets_) {
+      cumulativeBitOffset += frame.size * frame.bitWidth;
+    }
+  }
+}
+
+template <typename T>
+void ForEncoding<T>::reset() {
+  currentRow_ = 0;
+}
+
+template <typename T>
+void ForEncoding<T>::skip(uint32_t rowCount) {
+  currentRow_ += rowCount;
+  NIMBLE_DCHECK(
+      currentRow_ <= this->rowCount_, "Skipping past end of encoding");
+}
+
+template <typename T>
+void ForEncoding<T>::decodeRange(
+    uint32_t startRow,
+    uint32_t rowCount,
+    physicalType* output) const {
+  NIMBLE_DCHECK(
+      startRow + rowCount <= this->rowCount_, "Decoding past end of encoding");
+
+  // Streaming bit-cursor decoder: reads rowsToDecode values of frame.bitWidth
+  // bits from byteCursor at bitOffsetInByte, writing results via
+  // decodeException.
+  auto decodeBitStream = [](const uint8_t* byteCursor,
+                            uint8_t bitOffsetInByte,
+                            uint8_t bitWidth,
+                            uint32_t rowsToDecode,
+                            auto&& decodeException) {
+    uint64_t bitBuffer = 0;
+    uint32_t bitsInBuffer = 0;
+
+    // Consume the partial first byte if not byte-aligned
+    if (bitOffsetInByte != 0) {
+      bitBuffer = static_cast<uint8_t>(*byteCursor) >> bitOffsetInByte;
+      bitsInBuffer = 8u - bitOffsetInByte;
+      ++byteCursor;
+    }
+
+    const uint64_t mask = (bitWidth == 64) ? ~0ULL : ((1ULL << bitWidth) - 1);
+
+    for (uint32_t i = 0; i < rowsToDecode; ++i) {
+      while (bitsInBuffer < bitWidth) {
+        bitBuffer |= static_cast<uint64_t>(static_cast<uint8_t>(*byteCursor))
+            << bitsInBuffer;
+        ++byteCursor;
+        bitsInBuffer += 8;
+      }
+      decodeException(i, bitBuffer & mask);
+      bitBuffer = (bitWidth == 64) ? 0 : (bitBuffer >> bitWidth);
+      bitsInBuffer -= bitWidth;
+    }
+  };
+
+  uint32_t currentRow = startRow;
+  uint32_t outputOffset = 0;
+  uint32_t remainingRowCount = rowCount;
+
+  while (remainingRowCount > 0) {
+    const uint32_t frameIndex = getFrameIndex(currentRow);
+    const auto& frame = frames_[frameIndex];
+    const uint32_t positionInFrame = getPositionInFrame(currentRow);
+    const uint32_t rowsAvailableInFrame = frame.size - positionInFrame;
+    const uint32_t rowsToDecode =
+        std::min(remainingRowCount, rowsAvailableInFrame);
+
+    // Per-frame reference application — captures frame by ref
+    auto decodeException = [&](uint32_t i, uint64_t residual) {
+      if constexpr (std::is_signed_v<physicalType>) {
+        output[outputOffset + i] = static_cast<physicalType>(
+            static_cast<int64_t>(residual) +
+            static_cast<int64_t>(frame.reference));
+      } else {
+        output[outputOffset + i] =
+            static_cast<physicalType>(residual + frame.reference);
+      }
+    };
+
+    if (frame.bitWidth == 0) {
+      // All values in frame are identical to reference
+      std::fill(
+          output + outputOffset,
+          output + outputOffset + rowsToDecode,
+          frame.reference);
+
+    } else {
+      const uint64_t bitPosition = frame.bitOffset +
+          static_cast<uint64_t>(positionInFrame) * frame.bitWidth;
+      const uint8_t bitOffsetInByte = static_cast<uint8_t>(bitPosition & 7U);
+      const uint8_t* byteCursor =
+          reinterpret_cast<const uint8_t*>(packedData_) + (bitPosition / 8);
+
+      if (bitOffsetInByte == 0) {
+        // Byte-aligned: use typed loads for power-of-two widths, bit-stream
+        // otherwise
+        switch (frame.bitWidth) {
+          case 8:
+            for (uint32_t i = 0; i < rowsToDecode; ++i) {
+              decodeException(i, byteCursor[i]);
+            }
+            break;
+          case 16:
+            for (uint32_t i = 0; i < rowsToDecode; ++i) {
+              uint16_t v;
+              std::memcpy(
+                  &v, byteCursor + i * sizeof(uint16_t), sizeof(uint16_t));
+              decodeException(i, v);
+            }
+            break;
+          case 32:
+            for (uint32_t i = 0; i < rowsToDecode; ++i) {
+              uint32_t v;
+              std::memcpy(
+                  &v, byteCursor + i * sizeof(uint32_t), sizeof(uint32_t));
+              decodeException(i, v);
+            }
+            break;
+          case 64:
+            for (uint32_t i = 0; i < rowsToDecode; ++i) {
+              uint64_t v;
+              std::memcpy(
+                  &v, byteCursor + i * sizeof(uint64_t), sizeof(uint64_t));
+              decodeException(i, v);
+            }
+            break;
+          default:
+            // Non-power-of-two width, byte-aligned start: bitOffsetInByte == 0
+            decodeBitStream(
+                byteCursor, 0, frame.bitWidth, rowsToDecode, decodeException);
+            break;
+        }
+      } else {
+        // Unaligned: always use the bit-streaming path
+        decodeBitStream(
+            byteCursor,
+            bitOffsetInByte,
+            frame.bitWidth,
+            rowsToDecode,
+            decodeException);
+      }
+    }
+
+    currentRow += rowsToDecode;
+    outputOffset += rowsToDecode;
+    remainingRowCount -= rowsToDecode;
+  }
+}
+
+template <typename T>
+typename ForEncoding<T>::physicalType ForEncoding<T>::decodeValue(
+    uint32_t row) const {
+  physicalType value{};
+  decodeRange(row, 1, &value);
+  return value;
+}
+
+template <typename T>
+void ForEncoding<T>::materialize(uint32_t rowCount, void* buffer) {
+  physicalType* output = static_cast<physicalType*>(buffer);
+
+  decodeRange(currentRow_, rowCount, output);
+
+  currentRow_ += rowCount;
+}
+
+template <typename T>
+template <typename V>
+void ForEncoding<T>::readWithVisitor(
+    V& visitor,
+    ReadWithVisitorParams& params) {
+  // Provide a skip function so readWithVisitorSlow can advance currentRow_ past
+  // non-selected non-null rows when the visitor's row set is sparse (e.g. due
+  // to chunk-index seeks or filter-driven row group skipping). The skip lambda
+  // receives the count of non-null rows to bypass, matching how ForEncoding
+  // stores only non-null values sequentially.  Using currentRow_ keeps state
+  // consistent across multiple readWithVisitor calls and with interleaved
+  // skip()/materialize() calls on the same instance.
+  detail::readWithVisitorSlow(
+      visitor,
+      params,
+      [&](auto numNonNullsToSkip) { skip(numNonNullsToSkip); },
+      [&] { return decodeValue(currentRow_++); });
+}
+
+template <typename T>
+std::string ForEncoding<T>::debugString(int offset) const {
+  std::string log = Encoding::debugString(offset);
+  log += fmt::format(
+      "\n{}frameSize={}, numFrames={}, enableBitOffsets={}",
+      std::string(offset, ' '),
+      frameSize_,
+      numFrames_,
+      enableBitOffsets_);
+
+  std::map<uint8_t, uint32_t> bitWidthCounts;
+  for (const auto& frame : frames_) {
+    bitWidthCounts[frame.bitWidth]++;
+  }
+
+  log +=
+      fmt::format("\n{}bitWidth distribution: ", std::string(offset + 2, ' '));
+  for (const auto& [width, count] : bitWidthCounts) {
+    log += fmt::format("{}b:{} ", width, count);
+  }
+
+  return log;
+}
+
+// Static encode method
+template <typename T>
+std::string_view ForEncoding<T>::encode(
+    EncodingSelection<physicalType>& selection,
+    std::span<const physicalType> values,
+    Buffer& buffer,
+    const Encoding::Options& options) {
+  static_assert(
+      std::is_integral_v<physicalType>,
+      "ForEncoding only supports integral types");
+
+  const bool useVarint = options.useVarintRowCount;
+  const uint32_t rowCount = values.size();
+  if (rowCount == 0) {
+    NIMBLE_UNSUPPORTED("Cannot encode empty data with ForEncoding");
+  }
+
+  // Configuration (TODO: make configurable via policy)
+  const bool enableBitOffsets = true; // Default: enable for O(1) random access
+  const uint32_t frameSize =
+      128; // Default frame size (TODO: adaptive selection)
+
+  const uint32_t numFrames = (rowCount + frameSize - 1) / frameSize;
+
+  Vector<uint8_t> bitWidths(&buffer.getMemoryPool(), numFrames);
+  Vector<physicalType> references(&buffer.getMemoryPool(), numFrames);
+  Vector<uint64_t> bitOffsets(&buffer.getMemoryPool());
+  if (enableBitOffsets) {
+    bitOffsets.resize(numFrames);
+  }
+
+  Vector<char> packedData(&buffer.getMemoryPool());
+  uint64_t bitBuffer = 0;
+  size_t bitBufferLen = 0;
+
+  auto writeBits = [&](uint64_t value, uint8_t numBits) {
+    size_t bitsToWrite = numBits;
+
+    while (bitsToWrite > 0) {
+      size_t spaceInBuffer = 64 - bitBufferLen;
+      size_t bitsThisRound = std::min(bitsToWrite, spaceInBuffer);
+
+      uint64_t mask =
+          (bitsThisRound == 64) ? ~0ULL : ((1ULL << bitsThisRound) - 1);
+      uint64_t chunk = value & mask;
+
+      bitBuffer |= (chunk << bitBufferLen);
+      bitBufferLen += bitsThisRound;
+
+      value = (bitsThisRound == 64) ? 0 : (value >> bitsThisRound);
+      bitsToWrite -= bitsThisRound;
+
+      while (bitBufferLen >= 8) {
+        packedData.push_back(static_cast<char>(bitBuffer & 0xFF));
+        bitBuffer >>= 8;
+        bitBufferLen -= 8;
+      }
+    }
+  };
+
+  constexpr std::array<uint8_t, 7> BIT_WIDTHS = {1, 2, 4, 8, 16, 32, 64};
+
+  auto findMinBitWidth = [&](uint64_t maxValue) -> uint8_t {
+    if (maxValue == 0)
+      return 1;
+
+    size_t bitsNeeded = 64 - __builtin_clzll(maxValue);
+
+    for (uint8_t width : BIT_WIDTHS) {
+      if (width >= bitsNeeded)
+        return width;
+    }
+
+    return 64;
+  };
+
+  uint64_t totalBits = 0;
+
+  for (uint32_t frameIdx = 0; frameIdx < numFrames; ++frameIdx) {
+    uint32_t frameStart = frameIdx * frameSize;
+    uint32_t frameEnd = std::min(frameStart + frameSize, rowCount);
+    uint32_t frameLength = frameEnd - frameStart;
+
+    physicalType minValue = values[frameStart];
+    physicalType maxValue = values[frameStart];
+
+    for (uint32_t i = frameStart; i < frameEnd; ++i) {
+      minValue = std::min(minValue, values[i]);
+      maxValue = std::max(maxValue, values[i]);
+    }
+
+    uint64_t maxException = 0;
+    if constexpr (std::is_signed_v<physicalType>) {
+      maxException = static_cast<uint64_t>(
+          static_cast<int64_t>(maxValue) - static_cast<int64_t>(minValue));
+    } else {
+      maxException = static_cast<uint64_t>(maxValue - minValue);
+    }
+
+    uint8_t bitWidth = findMinBitWidth(maxException);
+
+    references[frameIdx] = minValue;
+    bitWidths[frameIdx] = bitWidth;
+
+    if (enableBitOffsets) {
+      bitOffsets[frameIdx] = totalBits;
+    }
+    for (uint32_t i = frameStart; i < frameEnd; ++i) {
+      uint64_t exception;
+      if constexpr (std::is_signed_v<physicalType>) {
+        exception = static_cast<uint64_t>(
+            static_cast<int64_t>(values[i]) - static_cast<int64_t>(minValue));
+      } else {
+        exception = static_cast<uint64_t>(values[i] - minValue);
+      }
+      writeBits(exception, bitWidth);
+    }
+
+    totalBits += frameLength * bitWidth;
+  }
+
+  if (bitBufferLen > 0) {
+    packedData.push_back(static_cast<char>(bitBuffer & 0xFF));
+  }
+
+  Buffer tempBuffer{buffer.getMemoryPool()};
+
+  std::string_view serializedBitWidths =
+      selection.template encodeNested<uint8_t>(
+          0, // identifier - TODO: define proper identifiers
+          {bitWidths},
+          tempBuffer);
+
+  std::string_view serializedReferences =
+      selection.template encodeNested<physicalType>(
+          1, {references}, tempBuffer);
+
+  std::string_view serializedBitOffsets;
+  if (enableBitOffsets) {
+    serializedBitOffsets =
+        selection.template encodeNested<uint64_t>(2, {bitOffsets}, tempBuffer);
+  }
+
+  auto dataCompressionPolicy = selection.compressionPolicy();
+  CompressionEncoder<char> compressionEncoder{
+      buffer.getMemoryPool(),
+      *dataCompressionPolicy,
+      DataType::Undefined,
+      0, // bitWidth not applicable
+      static_cast<uint32_t>(packedData.size()),
+      [&]() { return std::span<char>{packedData}; },
+      [&](char*& pos) {
+        std::memcpy(pos, packedData.data(), packedData.size());
+        pos += packedData.size();
+        return pos;
+      }};
+
+  uint32_t encodingSize = Encoding::serializePrefixSize(rowCount, useVarint) +
+      ForEncoding<T>::kPrefixSize + 4 +
+      serializedBitWidths.size() + // BitWidths
+      4 + serializedReferences.size() + // References
+      (enableBitOffsets ? 4 + serializedBitOffsets.size() : 0) + 4 +
+      compressionEncoder.getSize();
+
+  char* reserved = buffer.reserve(encodingSize);
+  char* pos = reserved;
+
+  Encoding::serializePrefix(
+      EncodingType::FOR, TypeTraits<T>::dataType, rowCount, useVarint, pos);
+
+  encoding::writeChar(
+      static_cast<char>(compressionEncoder.compressionType()), pos);
+  encoding::writeUint32(frameSize, pos);
+  encoding::writeUint32(numFrames, pos);
+  encoding::writeChar(enableBitOffsets ? 1 : 0, pos);
+
+  encoding::writeUint32(serializedBitWidths.size(), pos);
+  encoding::writeBytes(serializedBitWidths, pos);
+
+  encoding::writeUint32(serializedReferences.size(), pos);
+  encoding::writeBytes(serializedReferences, pos);
+
+  if (enableBitOffsets) {
+    encoding::writeUint32(serializedBitOffsets.size(), pos);
+    encoding::writeBytes(serializedBitOffsets, pos);
+  }
+
+  encoding::writeUint32(compressionEncoder.getSize(), pos);
+  compressionEncoder.write(pos);
+
+  NIMBLE_DCHECK_EQ(encodingSize, pos - reserved, "Encoding size mismatch.");
+  return {reserved, encodingSize};
+}
+
+} // namespace facebook::nimble

--- a/dwio/nimble/encodings/FrequencyPartitionEncoding.h
+++ b/dwio/nimble/encodings/FrequencyPartitionEncoding.h
@@ -1,0 +1,1284 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <algorithm>
+#include <bit>
+#include <cmath>
+#include <span>
+#include <unordered_map>
+#include <vector>
+
+#include "dwio/nimble/common/Buffer.h"
+#include "dwio/nimble/common/Types.h"
+#include "dwio/nimble/common/Vector.h"
+#include "dwio/nimble/encodings/common/Encoding.h"
+#include "dwio/nimble/encodings/common/EncodingFactory.h"
+#include "dwio/nimble/encodings/common/EncodingPrimitives.h"
+#include "dwio/nimble/encodings/common/EncodingType.h"
+#include "dwio/nimble/encodings/selection/EncodingIdentifier.h"
+#include "dwio/nimble/encodings/selection/EncodingSelection.h"
+#include "folly/container/F14Map.h"
+#include "velox/common/memory/Memory.h"
+
+// Frequency partition encoding assigns shorter bit widths to more frequent
+// values, similar to Huffman coding but with random access support. Values
+// are partitioned by frequency into tiers (1-bit, 2-bit, 4-bit, etc.) and
+// rows are reordered to group same-tier values together.
+//
+// When an index type other than NoIndex is chosen at encode time, a positional
+// index is appended to the wire format so that materialize() and
+// readWithVisitor() operate in original-row-index space, correctly
+// reconstructing the original column order.
+//
+// Wire format (NoIndex — backward-compatible with legacy format):
+//   Encoding::kPrefixSize bytes: standard Encoding prefix
+//   4 bytes: number of partitions
+//   4+XX bytes: partition offsets encoding (nested)
+//   4+YY bytes: partition sizes encoding (nested)
+//   For each non-empty tier (1-bit, 2-bit, 4-bit, 8-bit, 16-bit, 32-bit):
+//     4+ZZ bytes: dictionary encoding (nested)
+//     4+WW bytes: keys encoding (nested)
+//   4+VV bytes: unencoded values (nested, if any)
+//
+// Wire format extension (any indexed mode — appended at end):
+//   1 byte: formatVersion (= kFormatVersion = 1)
+//   1 byte: indexType (FreqPartIndexType)
+//   4 bytes: indexPayloadBytes
+//   [indexPayloadBytes bytes]: index payload (see below)
+//
+// Index payload layout (PerTierBitmaps):
+//   For each non-empty tier (same order as above):
+//     4 bytes: bitmapByteCount = ceil(N/64)*8
+//     [bitmapByteCount]: bitmap (uint64_t words, LSB-first;
+//                        bit i set iff original position i belongs to tier)
+//
+// Index payload layout (TierTagArray):
+//   1 byte: tagBits = ceilLog2(numTiers + 1), minimum 1
+//   3 bytes: padding
+//   4 bytes: tagArrayByteCount
+//   [tagArrayByteCount]: packed tag array (LSB-first; tag = tier index
+//                        0..numTiers-1, or numTiers for fallback)
+//
+// Index payload layout (EliasFano):
+//   For each non-empty tier (same order as above):
+//     1 byte: lowBits
+//     3 bytes: padding
+//     4 bytes: lowByteCount
+//     4 bytes: highWordCount
+//     [lowByteCount]: packed low array (LSB-first)
+//     [highWordCount * 8]: high bitmap (uint64_t words)
+
+namespace facebook::nimble {
+
+/// Selects the positional index representation stored in the wire format.
+enum class FreqPartIndexType : uint8_t {
+  NoIndex = 0, ///< no index; tier-order output (backward-compatible)
+  PerTierBitmaps = 1, ///< one N-bit bitmap per tier + Rank9 superblock
+  TierTagArray = 2, ///< packed tag array + sampled rank index
+  EliasFano = 3, ///< per-tier Elias-Fano positions (decoded at load time)
+};
+
+template <typename T>
+class FrequencyPartitionEncoding
+    : public TypedEncoding<T, typename TypeTraits<T>::physicalType> {
+ public:
+  using cppDataType = T;
+  using physicalType = typename TypeTraits<T>::physicalType;
+
+  static const int kNumPartitionsOffset = Encoding::kPrefixSize;
+  static constexpr uint8_t kFormatVersion = 1;
+  static constexpr uint32_t kRankSampleStride = 256;
+
+  FrequencyPartitionEncoding(
+      velox::memory::MemoryPool& pool,
+      std::string_view data,
+      std::function<void*(uint32_t)> stringBufferFactory = nullptr,
+      const Encoding::Options& options = {});
+
+  void reset() final;
+  void skip(uint32_t rowCount) final;
+  void materialize(uint32_t rowCount, void* buffer) final;
+
+  template <typename DecoderVisitor>
+  void readWithVisitor(DecoderVisitor& visitor, ReadWithVisitorParams& params);
+
+  static std::string_view encode(
+      EncodingSelection<physicalType>& selection,
+      std::span<const physicalType> values,
+      Buffer& buffer,
+      const Encoding::Options& options = {});
+
+  std::string debugString(int offset) const final;
+  uint32_t getTierForRow(uint32_t rowIndex) const;
+
+ private:
+  struct TierInfo {
+    uint32_t keyBits;
+    uint32_t capacity;
+    Vector<T> dictionary;
+    // Materialized keys: indices[rank] → dictionary index.
+    // For NoIndex: rank = sequential position in tier's encoded range.
+    // For indexed modes: rank = count of tier elements before original pos u.
+    Vector<uint32_t> indices;
+    uint32_t startRow; // NoIndex only: offset in encoded stream
+    uint32_t size; // NoIndex only: count in encoded stream
+
+    // Index fields — populated based on indexType_:
+    uint32_t tierCount{0}; // element count (indexed modes)
+    Vector<uint64_t> bitmap; // PerTierBitmaps: N-bit bitmap
+    Vector<uint32_t> rankSuperblock; // PerTierBitmaps: Rank9 cumulative counts
+    Vector<uint32_t> efPositions; // EliasFano: decoded original positions
+
+    TierInfo(velox::memory::MemoryPool* pool)
+        : keyBits(0),
+          capacity(0),
+          dictionary(pool),
+          indices(pool),
+          startRow(0),
+          size(0),
+          bitmap(pool),
+          rankSuperblock(pool),
+          efPositions(pool) {}
+  };
+
+  // Get capacity for a given key bit width
+  static constexpr uint32_t getCapacity(uint32_t keyBits) {
+    return (keyBits == 1) ? 2
+        : (keyBits == 2)  ? 4
+        : (keyBits == 4)  ? 16
+        : (keyBits == 8)  ? 256
+        : (keyBits == 16) ? (65536 - 256)
+        : (keyBits == 32) ? (4294967296ULL - 65536)
+                          : 0;
+  }
+
+  static constexpr uint32_t getMaxKeyBits() {
+    constexpr size_t valueSize =
+        std::is_same_v<T, std::string_view> ? sizeof(int64_t) : sizeof(T);
+    constexpr size_t valueBits = valueSize * 8;
+
+    if constexpr (valueBits <= 8) {
+      return 4;
+    } else if constexpr (valueBits <= 16) {
+      return 8;
+    } else if constexpr (valueBits <= 32) {
+      return 16;
+    } else {
+      return 32;
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // Bit-packing utilities (ported from EncodingsPlayground)
+  // ---------------------------------------------------------------------------
+
+  static constexpr uint8_t ceilLog2WithMinOne(uint32_t x) {
+    if (x <= 1u)
+      return 1u;
+    return static_cast<uint8_t>(std::bit_width(x - 1u));
+  }
+
+  static uint8_t chooseEliasFanoLowBits(uint64_t universe, uint64_t n) {
+    if (n == 0 || universe <= n)
+      return 0;
+    const uint64_t ratio = universe / n;
+    if (ratio <= 1)
+      return 0;
+    return static_cast<uint8_t>(
+        std::min<uint64_t>(31, std::bit_width(ratio) - 1));
+  }
+
+  // Decode Elias-Fano encoded positions from raw bytes into a sorted vector.
+  // Requires zero-padding past highBase for safe 8-byte reads.
+  static void decodeEliasFanoPositions(
+      const uint8_t* lowBase,
+      uint8_t lowBits,
+      const uint8_t* highBase,
+      uint32_t highWords,
+      uint32_t count,
+      Vector<uint32_t>& out) {
+    out.resize(count);
+    uint32_t rank = 0;
+    for (uint32_t w = 0; w < highWords && rank < count; ++w) {
+      uint64_t bits = 0;
+      std::memcpy(&bits, highBase + static_cast<size_t>(w) * 8, 8);
+      while (bits && rank < count) {
+        const uint32_t bit = static_cast<uint32_t>(__builtin_ctzll(bits));
+        const uint32_t high = w * 64 + bit - rank;
+        const uint32_t low = unpackBits(lowBase, rank, lowBits);
+        out[rank++] = (high << lowBits) | low;
+        bits &= bits - 1;
+      }
+    }
+  }
+
+  // Extract `keyBits`-wide value at zero-based rank `r` from a LSB-first
+  // packed byte array. Safe bounded read (no padding required).
+  static uint32_t unpackBits(const uint8_t* base, uint32_t r, uint8_t keyBits) {
+    if (keyBits == 0)
+      return 0;
+    const size_t bitPos = static_cast<size_t>(r) * keyBits;
+    const size_t byteIdx = bitPos >> 3;
+    const uint32_t bitOff = static_cast<uint32_t>(bitPos & 7);
+    const uint32_t mask = (keyBits == 32) ? ~0u : ((1u << keyBits) - 1u);
+    // At most ceil((7+31)/8) = 5 bytes needed; read only those.
+    const uint32_t bytesNeeded = (bitOff + keyBits + 7) / 8;
+    uint64_t buf = 0;
+    for (uint32_t b = 0; b < bytesNeeded; ++b)
+      buf |= static_cast<uint64_t>(base[byteIdx + b]) << (b * 8);
+    return static_cast<uint32_t>((buf >> bitOff) & mask);
+  }
+
+  // Pack `keys` into LSB-first format, appending bytes to `out`.
+  static void packBitsInto(
+      std::vector<char>& out,
+      const uint32_t* keys,
+      uint32_t count,
+      uint8_t keyBits) {
+    if (keyBits == 0 || count == 0)
+      return;
+    const size_t byteCount = (static_cast<size_t>(count) * keyBits + 7) / 8;
+    const size_t base = out.size();
+    out.resize(base + byteCount, '\0');
+    for (uint32_t r = 0; r < count; ++r) {
+      const uint32_t k = keys[r];
+      size_t bitPos = static_cast<size_t>(r) * keyBits;
+      uint32_t remaining = k;
+      uint8_t bitsLeft = keyBits;
+      while (bitsLeft > 0) {
+        const size_t byteIdx = bitPos / 8;
+        const size_t bitOff = bitPos % 8;
+        const uint8_t chunk = static_cast<uint8_t>(
+            bitsLeft > (8 - bitOff) ? (8 - bitOff) : bitsLeft);
+        reinterpret_cast<uint8_t&>(out[base + byteIdx]) |=
+            static_cast<uint8_t>((remaining & ((1u << chunk) - 1u)) << bitOff);
+        remaining >>= chunk;
+        bitPos += chunk;
+        bitsLeft -= chunk;
+      }
+    }
+  }
+
+  // Extract tag at position `pos` from a LSB-first packed tag array.
+  // tagBits must be ≤ 8.
+  static uint8_t
+  unpackTagAt(const uint8_t* base, uint32_t pos, uint8_t tagBits) {
+    const size_t bitPos = static_cast<size_t>(pos) * tagBits;
+    const size_t byteIdx = bitPos / 8;
+    const size_t bitOff = bitPos % 8;
+    const uint8_t mask = static_cast<uint8_t>((1u << tagBits) - 1u);
+    uint16_t buf = static_cast<uint16_t>(base[byteIdx]);
+    if (bitOff + tagBits > 8)
+      buf |= static_cast<uint16_t>(base[byteIdx + 1]) << 8;
+    return static_cast<uint8_t>((buf >> bitOff) & mask);
+  }
+
+  // ---------------------------------------------------------------------------
+  // Rank / positional index helpers
+  // ---------------------------------------------------------------------------
+
+  // O(1) rank of set bits in tier.bitmap strictly before position `pos`,
+  // using the precomputed Rank9 superblock in tier.rankSuperblock.
+  static uint32_t popcountPrefixFast(const TierInfo& tier, uint32_t pos) {
+    const uint32_t blk = pos / 512;
+    const uint32_t wordOff = (pos % 512) / 64;
+    const uint32_t bitOff = pos % 64;
+    uint32_t rank = tier.rankSuperblock[blk];
+    for (uint32_t w = blk * 8; w < blk * 8 + wordOff; ++w)
+      rank += static_cast<uint32_t>(__builtin_popcountll(tier.bitmap[w]));
+    if (bitOff)
+      rank += static_cast<uint32_t>(__builtin_popcountll(
+          tier.bitmap[blk * 8 + wordOff] & ((uint64_t{1} << bitOff) - 1)));
+    return rank;
+  }
+
+  // Count fallback elements strictly before position `pos`.
+  // Uses coveredBitmap_ and fallbackWordPrefix_.
+  uint32_t fallbackRankAt(uint32_t pos) const {
+    const uint32_t word = pos / 64;
+    uint32_t rank = fallbackWordPrefix_[word];
+    const uint64_t uncov = ~coveredBitmap_[word];
+    rank += static_cast<uint32_t>(
+        __builtin_popcountll(uncov & ((uint64_t{1} << (pos % 64)) - 1)));
+    return rank;
+  }
+
+  // Count elements with tag == tierIdx strictly before position `pos`.
+  // Uses tierRankSamples_ and tagArray_. tierIdx == tiers_.size() is fallback.
+  uint32_t tierRankAtForTag(uint32_t tierIdx, uint32_t pos) const {
+    const uint32_t sampleIdx = pos / kRankSampleStride;
+    uint32_t rank = tierRankSamples_[tierIdx][sampleIdx];
+    const uint32_t scanStart = sampleIdx * kRankSampleStride;
+    const uint8_t* tagBase = tagArray_.data();
+    const uint8_t numActiveTiers = static_cast<uint8_t>(tiers_.size());
+    for (uint32_t j = scanStart; j < pos; ++j) {
+      const uint8_t t = unpackTagAt(tagBase, j, tagBits_);
+      const uint32_t b = (t < numActiveTiers) ? t : numActiveTiers;
+      if (b == tierIdx)
+        ++rank;
+    }
+    return rank;
+  }
+
+  // ---------------------------------------------------------------------------
+  // Per-index-type decode helpers
+  // ---------------------------------------------------------------------------
+
+  template <FreqPartIndexType I>
+  T decodeAtOriginalIndexImpl(uint32_t u) const;
+
+  template <FreqPartIndexType I>
+  void materializeImpl(T* dst, uint32_t start, uint32_t count) const;
+
+  // ---------------------------------------------------------------------------
+  // Member variables
+  // ---------------------------------------------------------------------------
+
+  std::vector<TierInfo> tiers_;
+
+  Vector<T> unencodedValues_;
+  uint32_t unencodedStartRow_;
+
+  // NoIndex streaming state
+  uint32_t currentTier_;
+  uint32_t currentTierOffset_;
+
+  // Index type and indexed-mode streaming state
+  FreqPartIndexType indexType_;
+  uint32_t totalRowCount_;
+  uint32_t currentOriginalPos_;
+
+  // PerTierBitmaps / EliasFano: covered bitmap and fallback prefix table
+  Vector<uint64_t> coveredBitmap_; // bit i set ↔ position i in some tier
+  Vector<uint32_t>
+      fallbackWordPrefix_; // [w] = fallback count in positions [0, w*64)
+
+  // TierTagArray fields
+  uint8_t tagBits_;
+  Vector<uint8_t> tagArray_;
+  // tierRankSamples_[t][si] = count of tag==t in positions [0,
+  // si*kRankSampleStride) Index tiers_.size() is used for the fallback bucket.
+  std::vector<std::vector<uint32_t>> tierRankSamples_;
+};
+
+//
+// End of public API. Implementation follows.
+//
+
+// ---------------------------------------------------------------------------
+// Constructor
+// ---------------------------------------------------------------------------
+
+template <typename T>
+FrequencyPartitionEncoding<T>::FrequencyPartitionEncoding(
+    velox::memory::MemoryPool& pool,
+    std::string_view data,
+    std::function<void*(uint32_t)> stringBufferFactory,
+    const Encoding::Options& options)
+    : TypedEncoding<T, physicalType>{pool, data, options},
+      unencodedValues_{this->pool_},
+      unencodedStartRow_(0),
+      currentTier_(0),
+      currentTierOffset_(0),
+      indexType_(FreqPartIndexType::NoIndex),
+      totalRowCount_(0),
+      currentOriginalPos_(0),
+      coveredBitmap_{this->pool_},
+      fallbackWordPrefix_{this->pool_},
+      tagBits_(0),
+      tagArray_{this->pool_} {
+  const auto* pos = data.data() + kNumPartitionsOffset;
+  const uint32_t numPartitions = encoding::readUint32(pos);
+  const EncodingFactory encodingFactory(options);
+
+  const uint32_t partitionOffsetsSize = encoding::readUint32(pos);
+  auto partitionOffsetsEncoding = encodingFactory.create(
+      *this->pool_,
+      std::string_view(pos, partitionOffsetsSize),
+      stringBufferFactory);
+  pos += partitionOffsetsSize;
+
+  const uint32_t partitionSizesSize = encoding::readUint32(pos);
+  auto partitionSizesEncoding = encodingFactory.create(
+      *this->pool_,
+      std::string_view(pos, partitionSizesSize),
+      stringBufferFactory);
+  pos += partitionSizesSize;
+
+  Vector<uint32_t> partitionOffsets{this->pool_};
+  Vector<uint32_t> partitionSizes{this->pool_};
+  partitionOffsets.resize(numPartitions);
+  partitionSizes.resize(numPartitions);
+  partitionOffsetsEncoding->materialize(numPartitions, partitionOffsets.data());
+  partitionSizesEncoding->materialize(numPartitions, partitionSizes.data());
+
+  constexpr uint32_t keyBitOptions[] = {1, 2, 4, 8, 16, 32};
+
+  const uint32_t numCodedTiers = (numPartitions > 0) ? numPartitions - 1 : 0;
+
+  for (uint32_t i = 0; i < numPartitions; ++i) {
+    if (i < numCodedTiers) {
+      TierInfo tier(this->pool_);
+      tier.keyBits = keyBitOptions[i];
+      tier.capacity = getCapacity(tier.keyBits);
+      tier.startRow = partitionOffsets[i];
+      tier.size = partitionSizes[i];
+      tier.tierCount = partitionSizes[i];
+
+      if (tier.size > 0) {
+        const uint32_t dictSize = encoding::readUint32(pos);
+        auto dictEncoding = encodingFactory.create(
+            *this->pool_, std::string_view(pos, dictSize), stringBufferFactory);
+        pos += dictSize;
+
+        const uint32_t dictCount = dictEncoding->rowCount();
+        tier.dictionary.resize(dictCount);
+        dictEncoding->materialize(dictCount, tier.dictionary.data());
+
+        const uint32_t keysSize = encoding::readUint32(pos);
+        auto keysEncoding = encodingFactory.create(
+            *this->pool_, std::string_view(pos, keysSize), stringBufferFactory);
+        pos += keysSize;
+
+        tier.indices.resize(tier.size);
+        keysEncoding->materialize(tier.size, tier.indices.data());
+      }
+
+      tiers_.push_back(std::move(tier));
+    } else {
+      unencodedStartRow_ = partitionOffsets[i];
+      const uint32_t unencodedSize = partitionSizes[i];
+
+      if (unencodedSize > 0) {
+        const uint32_t valuesSize = encoding::readUint32(pos);
+        auto valuesEncoding = encodingFactory.create(
+            *this->pool_,
+            std::string_view(pos, valuesSize),
+            stringBufferFactory);
+        pos += valuesSize;
+
+        unencodedValues_.resize(unencodedSize);
+        valuesEncoding->materialize(unencodedSize, unencodedValues_.data());
+      }
+    }
+  }
+
+  totalRowCount_ = this->rowCount();
+
+  // Check for optional index extension block appended after all nested data.
+  const char* dataEnd = data.data() + data.size();
+  if (pos < dataEnd) {
+    const uint8_t fmtVer = encoding::read<uint8_t>(pos);
+    const auto idxType =
+        static_cast<FreqPartIndexType>(encoding::read<uint8_t>(pos));
+    const uint32_t payloadBytes = encoding::readUint32(pos);
+    const char* payloadStart = pos;
+
+    if (fmtVer > kFormatVersion) {
+      // Unknown format version — skip payload gracefully.
+      pos += payloadBytes;
+    } else {
+      indexType_ = idxType;
+      const uint32_t numWords = (totalRowCount_ + 63) / 64;
+
+      switch (indexType_) {
+        case FreqPartIndexType::PerTierBitmaps: {
+          coveredBitmap_.resize(numWords, 0);
+          for (auto& tier : tiers_) {
+            if (tier.size == 0)
+              continue;
+            const uint32_t bitmapByteCount = encoding::readUint32(pos);
+            NIMBLE_CHECK(
+                bitmapByteCount == numWords * 8,
+                "PerTierBitmaps bitmap size mismatch");
+            tier.bitmap.resize(numWords);
+            std::memcpy(tier.bitmap.data(), pos, numWords * 8);
+            pos += numWords * 8;
+
+            // Build Rank9 superblock: one entry per 8-word (512-bit) block.
+            const uint32_t numBlocks = (numWords + 7) / 8;
+            tier.rankSuperblock.resize(numBlocks + 1, 0);
+            for (uint32_t blk = 0; blk < numBlocks; ++blk) {
+              tier.rankSuperblock[blk + 1] = tier.rankSuperblock[blk];
+              const uint32_t wEnd = std::min((blk + 1) * 8u, numWords);
+              for (uint32_t w = blk * 8; w < wEnd; ++w)
+                tier.rankSuperblock[blk + 1] +=
+                    static_cast<uint32_t>(__builtin_popcountll(tier.bitmap[w]));
+            }
+
+            // OR into covered bitmap.
+            for (uint32_t w = 0; w < numWords; ++w)
+              coveredBitmap_[w] |= tier.bitmap[w];
+          }
+
+          // Build fallback prefix-popcount table.
+          fallbackWordPrefix_.resize(numWords + 1, 0);
+          for (uint32_t w = 0; w < numWords; ++w) {
+            uint64_t uncov = ~coveredBitmap_[w];
+            if (w == numWords - 1 && (totalRowCount_ % 64) != 0)
+              uncov &= (uint64_t{1} << (totalRowCount_ % 64)) - 1;
+            fallbackWordPrefix_[w + 1] = fallbackWordPrefix_[w] +
+                static_cast<uint32_t>(__builtin_popcountll(uncov));
+          }
+          break;
+        }
+
+        case FreqPartIndexType::TierTagArray: {
+          tagBits_ = encoding::read<uint8_t>(pos);
+          pos += 3; // skip alignment padding
+          const uint32_t tagArrayByteCount = encoding::readUint32(pos);
+          tagArray_.resize(tagArrayByteCount);
+          std::memcpy(tagArray_.data(), pos, tagArrayByteCount);
+          pos += tagArrayByteCount;
+
+          // Single O(N) pass: build per-tier sampled rank index.
+          const uint8_t numActiveTiers = static_cast<uint8_t>(tiers_.size());
+          const uint32_t numBuckets = static_cast<uint32_t>(numActiveTiers) + 1;
+          const uint32_t numSamples =
+              (totalRowCount_ + kRankSampleStride - 1) / kRankSampleStride + 1;
+          tierRankSamples_.assign(
+              numBuckets, std::vector<uint32_t>(numSamples, 0));
+
+          std::vector<uint32_t> counts(numBuckets, 0);
+          for (uint32_t i = 0; i < totalRowCount_; ++i) {
+            if (i % kRankSampleStride == 0) {
+              const uint32_t si = i / kRankSampleStride;
+              for (uint32_t t = 0; t < numBuckets; ++t)
+                tierRankSamples_[t][si] = counts[t];
+            }
+            const uint8_t tag = unpackTagAt(tagArray_.data(), i, tagBits_);
+            const uint32_t bucket =
+                (tag < numActiveTiers) ? tag : numActiveTiers;
+            ++counts[bucket];
+          }
+          // Sentinel sample past the last stride.
+          const uint32_t lastSi =
+              (totalRowCount_ + kRankSampleStride - 1) / kRankSampleStride;
+          for (uint32_t t = 0; t < numBuckets; ++t)
+            tierRankSamples_[t][lastSi] = counts[t];
+
+          // Set tierCount from the scan.
+          for (uint32_t t = 0; t < numActiveTiers; ++t)
+            tiers_[t].tierCount = counts[t];
+          break;
+        }
+
+        case FreqPartIndexType::EliasFano: {
+          const bool hasFallback = !unencodedValues_.empty();
+          if (hasFallback) {
+            coveredBitmap_.resize(numWords, 0);
+          }
+
+          for (auto& tier : tiers_) {
+            if (tier.size == 0)
+              continue;
+            const uint8_t lowBits = encoding::read<uint8_t>(pos);
+            pos += 3; // padding
+            const uint32_t lowByteCount = encoding::readUint32(pos);
+            const uint32_t highWordCount = encoding::readUint32(pos);
+
+            const uint8_t* lowBase = reinterpret_cast<const uint8_t*>(pos);
+            pos += lowByteCount;
+            const uint8_t* highBase = reinterpret_cast<const uint8_t*>(pos);
+            pos += static_cast<size_t>(highWordCount) * 8;
+
+            decodeEliasFanoPositions(
+                lowBase,
+                lowBits,
+                highBase,
+                highWordCount,
+                tier.tierCount,
+                tier.efPositions);
+
+            if (hasFallback) {
+              for (uint32_t p : tier.efPositions)
+                coveredBitmap_[p / 64] |= uint64_t{1} << (p % 64);
+            }
+          }
+
+          if (hasFallback) {
+            fallbackWordPrefix_.resize(numWords + 1, 0);
+            for (uint32_t w = 0; w < numWords; ++w) {
+              uint64_t uncov = ~coveredBitmap_[w];
+              if (w == numWords - 1 && (totalRowCount_ % 64) != 0)
+                uncov &= (uint64_t{1} << (totalRowCount_ % 64)) - 1;
+              fallbackWordPrefix_[w + 1] = fallbackWordPrefix_[w] +
+                  static_cast<uint32_t>(__builtin_popcountll(uncov));
+            }
+          }
+          break;
+        }
+
+        case FreqPartIndexType::NoIndex:
+          // Nothing extra to parse.
+          break;
+      }
+
+      NIMBLE_CHECK(
+          pos == payloadStart + payloadBytes, "index payload size mismatch");
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// reset / skip / getTierForRow
+// ---------------------------------------------------------------------------
+
+template <typename T>
+void FrequencyPartitionEncoding<T>::reset() {
+  currentTier_ = 0;
+  currentTierOffset_ = 0;
+  currentOriginalPos_ = 0;
+}
+
+template <typename T>
+uint32_t FrequencyPartitionEncoding<T>::getTierForRow(uint32_t rowIndex) const {
+  for (uint32_t i = 0; i < tiers_.size(); ++i) {
+    if (rowIndex < tiers_[i].startRow)
+      break; // tiers are contiguous and ordered
+    if (rowIndex < tiers_[i].startRow + tiers_[i].size)
+      return i;
+  }
+  return tiers_.size();
+}
+
+template <typename T>
+void FrequencyPartitionEncoding<T>::skip(uint32_t rowCount) {
+  if (indexType_ != FreqPartIndexType::NoIndex) {
+    currentOriginalPos_ += rowCount;
+    return;
+  }
+
+  uint32_t remaining = rowCount;
+  while (remaining > 0 && currentTier_ <= tiers_.size()) {
+    if (currentTier_ < tiers_.size()) {
+      const auto& tier = tiers_[currentTier_];
+      const uint32_t availableInTier = tier.size - currentTierOffset_;
+      const uint32_t toSkip = std::min(remaining, availableInTier);
+      currentTierOffset_ += toSkip;
+      remaining -= toSkip;
+
+      if (currentTierOffset_ >= tier.size) {
+        ++currentTier_;
+        currentTierOffset_ = 0;
+      }
+    } else {
+      break;
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// decodeAtOriginalIndexImpl — one definition, branch-free via if constexpr
+// ---------------------------------------------------------------------------
+
+template <typename T>
+template <FreqPartIndexType I>
+T FrequencyPartitionEncoding<T>::decodeAtOriginalIndexImpl(uint32_t u) const {
+  if constexpr (I == FreqPartIndexType::PerTierBitmaps) {
+    for (const auto& tier : tiers_) {
+      if (tier.bitmap.empty())
+        continue;
+      if (tier.bitmap[u / 64] & (uint64_t{1} << (u % 64))) {
+        const uint32_t rank = popcountPrefixFast(tier, u);
+        return tier.dictionary[tier.indices[rank]];
+      }
+    }
+    return unencodedValues_[fallbackRankAt(u)];
+
+  } else if constexpr (I == FreqPartIndexType::TierTagArray) {
+    const uint8_t numActiveTiers = static_cast<uint8_t>(tiers_.size());
+    const uint8_t tag = unpackTagAt(tagArray_.data(), u, tagBits_);
+    if (tag < numActiveTiers) {
+      const uint32_t rank = tierRankAtForTag(tag, u);
+      return tiers_[tag].dictionary[tiers_[tag].indices[rank]];
+    }
+    const uint32_t fallbackRank = tierRankAtForTag(numActiveTiers, u);
+    return unencodedValues_[fallbackRank];
+
+  } else if constexpr (I == FreqPartIndexType::EliasFano) {
+    for (const auto& tier : tiers_) {
+      if (tier.efPositions.empty())
+        continue;
+      auto it =
+          std::lower_bound(tier.efPositions.begin(), tier.efPositions.end(), u);
+      if (it != tier.efPositions.end() && *it == u) {
+        const uint32_t rank =
+            static_cast<uint32_t>(it - tier.efPositions.begin());
+        return tier.dictionary[tier.indices[rank]];
+      }
+    }
+    return unencodedValues_[fallbackRankAt(u)];
+
+  } else {
+    // NoIndex must not reach this path — use the NoIndex materialize branch.
+    NIMBLE_UNREACHABLE(
+        "decodeAtOriginalIndexImpl called with unsupported index type");
+  }
+}
+
+// ---------------------------------------------------------------------------
+// materializeImpl
+// ---------------------------------------------------------------------------
+
+template <typename T>
+template <FreqPartIndexType I>
+void FrequencyPartitionEncoding<T>::materializeImpl(
+    T* dst,
+    uint32_t start,
+    uint32_t count) const {
+  for (uint32_t i = 0; i < count; ++i) {
+    dst[i] = decodeAtOriginalIndexImpl<I>(start + i);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// materialize / readWithVisitor
+// ---------------------------------------------------------------------------
+
+template <typename T>
+void FrequencyPartitionEncoding<T>::materialize(
+    uint32_t rowCount,
+    void* buffer) {
+  T* output = static_cast<T*>(buffer);
+
+  if (indexType_ != FreqPartIndexType::NoIndex) {
+    switch (indexType_) {
+      case FreqPartIndexType::PerTierBitmaps:
+        materializeImpl<FreqPartIndexType::PerTierBitmaps>(
+            output, currentOriginalPos_, rowCount);
+        break;
+      case FreqPartIndexType::TierTagArray:
+        materializeImpl<FreqPartIndexType::TierTagArray>(
+            output, currentOriginalPos_, rowCount);
+        break;
+      case FreqPartIndexType::EliasFano:
+        materializeImpl<FreqPartIndexType::EliasFano>(
+            output, currentOriginalPos_, rowCount);
+        break;
+      default:
+        NIMBLE_UNREACHABLE("unknown FreqPartIndexType");
+    }
+    currentOriginalPos_ += rowCount;
+    return;
+  }
+
+  // NoIndex: existing tier-sequential path.
+  uint32_t remaining = rowCount;
+  uint32_t outputIdx = 0;
+
+  while (remaining > 0) {
+    if (currentTier_ < tiers_.size()) {
+      const auto& tier = tiers_[currentTier_];
+      const uint32_t availableInTier = tier.size - currentTierOffset_;
+      const uint32_t toRead = std::min(remaining, availableInTier);
+
+      for (uint32_t i = 0; i < toRead; ++i) {
+        const uint32_t index = tier.indices[currentTierOffset_ + i];
+        output[outputIdx++] = tier.dictionary[index];
+      }
+
+      currentTierOffset_ += toRead;
+      remaining -= toRead;
+
+      if (currentTierOffset_ >= tier.size) {
+        ++currentTier_;
+        currentTierOffset_ = 0;
+      }
+    } else if (currentTier_ == tiers_.size()) {
+      const uint32_t availableUnencoded =
+          static_cast<uint32_t>(unencodedValues_.size()) - currentTierOffset_;
+      const uint32_t toRead = std::min(remaining, availableUnencoded);
+
+      std::memcpy(
+          output + outputIdx,
+          unencodedValues_.data() + currentTierOffset_,
+          toRead * sizeof(T));
+
+      outputIdx += toRead;
+      currentTierOffset_ += toRead;
+      remaining -= toRead;
+
+      if (currentTierOffset_ >= unencodedValues_.size()) {
+        ++currentTier_;
+        currentTierOffset_ = 0;
+      }
+    } else {
+      break;
+    }
+  }
+}
+
+template <typename T>
+template <typename V>
+void FrequencyPartitionEncoding<T>::readWithVisitor(
+    V& visitor,
+    ReadWithVisitorParams& params) {
+  // All paths below use the encoding's own streaming state (currentOriginalPos_
+  // for indexed modes; currentTier_/currentTierOffset_ for NoIndex) so that
+  // position is correct across multiple readWithVisitor calls and when
+  // interleaved with skip()/materialize() calls. visitor.rowIndex() is NOT used
+  // because it includes null-row positions from NullableEncoding, which would
+  // produce wrong indices into FPE's non-null-only storage.
+  //
+  // A skip lambda is supplied so readWithVisitorSlow can advance the state past
+  // non-selected non-null rows (e.g. during chunk-index seeks or filter-driven
+  // row-group skipping).
+  if (indexType_ != FreqPartIndexType::NoIndex) {
+    auto skipFn = [&](auto n) { skip(n); };
+    switch (indexType_) {
+      case FreqPartIndexType::PerTierBitmaps:
+        detail::readWithVisitorSlow(visitor, params, skipFn, [&] {
+          return decodeAtOriginalIndexImpl<FreqPartIndexType::PerTierBitmaps>(
+              currentOriginalPos_++);
+        });
+        break;
+      case FreqPartIndexType::TierTagArray:
+        detail::readWithVisitorSlow(visitor, params, skipFn, [&] {
+          return decodeAtOriginalIndexImpl<FreqPartIndexType::TierTagArray>(
+              currentOriginalPos_++);
+        });
+        break;
+      case FreqPartIndexType::EliasFano:
+        detail::readWithVisitorSlow(visitor, params, skipFn, [&] {
+          return decodeAtOriginalIndexImpl<FreqPartIndexType::EliasFano>(
+              currentOriginalPos_++);
+        });
+        break;
+      default:
+        NIMBLE_UNREACHABLE("unknown FreqPartIndexType");
+    }
+    return;
+  }
+
+  // NoIndex: values are in tier-reordered space; read one at a time using the
+  // currentTier_/currentTierOffset_ streaming state (same as materialize).
+  detail::readWithVisitorSlow(
+      visitor,
+      params,
+      [&](auto n) { skip(n); },
+      [&] {
+        T value;
+        if (currentTier_ < tiers_.size()) {
+          const auto& tier = tiers_[currentTier_];
+          value = tier.dictionary[tier.indices[currentTierOffset_]];
+          if (++currentTierOffset_ >= tier.size) {
+            ++currentTier_;
+            currentTierOffset_ = 0;
+          }
+        } else {
+          value = unencodedValues_[currentTierOffset_++];
+        }
+        return value;
+      });
+}
+
+// ---------------------------------------------------------------------------
+// encode()
+// ---------------------------------------------------------------------------
+
+template <typename T>
+std::string_view FrequencyPartitionEncoding<T>::encode(
+    EncodingSelection<physicalType>& selection,
+    std::span<const physicalType> values,
+    Buffer& buffer,
+    const Encoding::Options& options) {
+  const bool useVarint = options.useVarintRowCount;
+  const auto indexType =
+      static_cast<FreqPartIndexType>(options.frequencyPartitionIndex);
+  const uint32_t valueCount = static_cast<uint32_t>(values.size());
+
+  // Build frequency map
+  folly::F14FastMap<physicalType, uint32_t> frequencyMap;
+  for (const auto& value : values) {
+    frequencyMap[value]++;
+  }
+
+  // Sort by frequency (descending)
+  std::vector<std::pair<physicalType, uint32_t>> freqVec;
+  freqVec.reserve(frequencyMap.size());
+  for (const auto& [value, freq] : frequencyMap) {
+    freqVec.emplace_back(value, freq);
+  }
+  std::sort(freqVec.begin(), freqVec.end(), [](const auto& a, const auto& b) {
+    return a.second > b.second;
+  });
+
+  const uint32_t uniqueCount = static_cast<uint32_t>(freqVec.size());
+  constexpr uint32_t maxKeyBits = getMaxKeyBits();
+
+  if constexpr (maxKeyBits == 0) {
+    return {};
+  }
+
+  // Tier assignments
+  struct TierAssignment {
+    uint32_t keyBits;
+    uint32_t capacity;
+    Vector<physicalType> dictionary;
+    folly::F14FastMap<physicalType, uint32_t> valueToKey;
+
+    explicit TierAssignment(velox::memory::MemoryPool& pool)
+        : keyBits(0), capacity(0), dictionary(&pool) {}
+  };
+
+  std::vector<TierAssignment> tierAssignments;
+  tierAssignments.reserve(6);
+
+  uint32_t valuesAssigned = 0;
+  constexpr uint32_t keyBitOptions[] = {1, 2, 4, 8, 16, 32};
+
+  for (uint32_t keyBits : keyBitOptions) {
+    if (keyBits > maxKeyBits || valuesAssigned >= uniqueCount) {
+      break;
+    }
+
+    TierAssignment tier{buffer.getMemoryPool()};
+    tier.keyBits = keyBits;
+    tier.capacity = getCapacity(keyBits);
+
+    const uint32_t numToAssign =
+        std::min(tier.capacity, uniqueCount - valuesAssigned);
+    tier.dictionary.reserve(numToAssign);
+
+    for (uint32_t i = 0; i < numToAssign; ++i) {
+      const auto& value = freqVec[valuesAssigned + i].first;
+      tier.dictionary.push_back(value);
+      tier.valueToKey[value] = i;
+    }
+
+    valuesAssigned += numToAssign;
+    tierAssignments.push_back(std::move(tier));
+  }
+
+  // Build value-to-tier mapping
+  folly::F14FastMap<physicalType, uint32_t> valueToTier;
+  valueToTier.reserve(valuesAssigned);
+  for (size_t tierIdx = 0; tierIdx < tierAssignments.size(); ++tierIdx) {
+    for (const auto& [value, key] : tierAssignments[tierIdx].valueToKey) {
+      valueToTier[value] = static_cast<uint32_t>(tierIdx);
+    }
+  }
+
+  // Assign rows to tiers
+  std::vector<std::vector<uint32_t>> tierRows(tierAssignments.size() + 1);
+  for (auto& vec : tierRows) {
+    vec.reserve(valueCount / tierRows.size());
+  }
+
+  for (uint32_t row = 0; row < valueCount; ++row) {
+    const auto& value = values[row];
+    auto tierIt = valueToTier.find(value);
+    if (tierIt == valueToTier.end()) {
+      tierRows.back().push_back(row);
+    } else {
+      tierRows[tierIt->second].push_back(row);
+    }
+  }
+
+  // Partition offsets and sizes
+  Vector<uint32_t> partitionOffsets(&buffer.getMemoryPool());
+  Vector<uint32_t> partitionSizes(&buffer.getMemoryPool());
+  partitionOffsets.reserve(tierRows.size());
+  partitionSizes.reserve(tierRows.size());
+
+  uint32_t offset = 0;
+  for (const auto& rows : tierRows) {
+    partitionOffsets.push_back(offset);
+    partitionSizes.push_back(static_cast<uint32_t>(rows.size()));
+    offset += static_cast<uint32_t>(rows.size());
+  }
+
+  // Encode partition metadata and tier data into tempBuffer
+  Buffer tempBuffer{buffer.getMemoryPool()};
+  std::string_view serializedOffsets =
+      selection.template encodeNested<uint32_t>(
+          EncodingIdentifiers::FrequencyPartition::PartitionOffsets,
+          {partitionOffsets},
+          tempBuffer);
+  std::string_view serializedSizes = selection.template encodeNested<uint32_t>(
+      EncodingIdentifiers::FrequencyPartition::PartitionSizes,
+      {partitionSizes},
+      tempBuffer);
+
+  std::vector<std::string_view> serializedDicts(tierAssignments.size());
+  std::vector<std::string_view> serializedKeys(tierAssignments.size());
+
+  for (size_t tierIdx = 0; tierIdx < tierAssignments.size(); ++tierIdx) {
+    const auto& tier = tierAssignments[tierIdx];
+    const auto& rows = tierRows[tierIdx];
+
+    if (rows.empty()) {
+      continue;
+    }
+
+    serializedDicts[tierIdx] = selection.template encodeNested<physicalType>(
+        EncodingIdentifiers::FrequencyPartition::Dict1Bit + tierIdx,
+        {tier.dictionary},
+        tempBuffer);
+
+    Vector<uint32_t> keys(&buffer.getMemoryPool());
+    keys.reserve(rows.size());
+    for (uint32_t row : rows) {
+      keys.push_back(tier.valueToKey.at(values[row]));
+    }
+
+    serializedKeys[tierIdx] = selection.template encodeNested<uint32_t>(
+        EncodingIdentifiers::FrequencyPartition::Keys1Bit + tierIdx,
+        {keys},
+        tempBuffer);
+  }
+
+  std::string_view serializedUnencoded;
+  if (!tierRows.back().empty()) {
+    Vector<physicalType> unencodedValues(&buffer.getMemoryPool());
+    unencodedValues.reserve(tierRows.back().size());
+    for (uint32_t row : tierRows.back()) {
+      unencodedValues.push_back(values[row]);
+    }
+    serializedUnencoded = selection.template encodeNested<physicalType>(
+        EncodingIdentifiers::FrequencyPartition::UnencodedValues,
+        {unencodedValues},
+        tempBuffer);
+  }
+
+  // Build index payload (only for non-NoIndex modes)
+  std::vector<char> indexPayload;
+  const uint32_t numWords = (valueCount + 63) / 64;
+  const uint32_t numTiers = static_cast<uint32_t>(tierAssignments.size());
+
+  if (indexType == FreqPartIndexType::PerTierBitmaps) {
+    // Build per-tier bitmaps from tierRows (already in ascending row order).
+    for (uint32_t t = 0; t < numTiers; ++t) {
+      if (tierRows[t].empty())
+        continue;
+      std::vector<uint64_t> bitmap(numWords, 0);
+      for (uint32_t row : tierRows[t]) {
+        bitmap[row / 64] |= uint64_t{1} << (row % 64);
+      }
+      const uint32_t bitmapByteCount = numWords * 8;
+      const char* byteCount4 = reinterpret_cast<const char*>(&bitmapByteCount);
+      indexPayload.insert(indexPayload.end(), byteCount4, byteCount4 + 4);
+      const char* bitmapBytes = reinterpret_cast<const char*>(bitmap.data());
+      indexPayload.insert(
+          indexPayload.end(), bitmapBytes, bitmapBytes + numWords * 8);
+    }
+
+  } else if (indexType == FreqPartIndexType::TierTagArray) {
+    // Build tag array: tag[pos] = tier index (0..numTiers-1) or numTiers
+    // (fallback).
+    const uint8_t tagBits = ceilLog2WithMinOne(numTiers + 1);
+    const size_t tagArrayByteCount =
+        (static_cast<size_t>(valueCount) * tagBits + 7) / 8;
+
+    // Reverse map: row → tag
+    std::vector<uint8_t> rowToTag(valueCount, static_cast<uint8_t>(numTiers));
+    for (uint32_t t = 0; t < numTiers; ++t) {
+      for (uint32_t row : tierRows[t]) {
+        rowToTag[row] = static_cast<uint8_t>(t);
+      }
+    }
+
+    // Pack tags into byte array using accumulator pattern.
+    std::vector<uint8_t> tagArray(tagArrayByteCount, 0);
+    uint64_t tagAcc = 0;
+    size_t tagAccBits = 0;
+    size_t tagByteOut = 0;
+    for (uint32_t pos = 0; pos < valueCount; ++pos) {
+      tagAcc |= static_cast<uint64_t>(rowToTag[pos]) << tagAccBits;
+      tagAccBits += tagBits;
+      while (tagAccBits >= 8) {
+        tagArray[tagByteOut++] = static_cast<uint8_t>(tagAcc & 0xFF);
+        tagAcc >>= 8;
+        tagAccBits -= 8;
+      }
+    }
+    if (tagAccBits > 0) {
+      tagArray[tagByteOut] = static_cast<uint8_t>(tagAcc & 0xFF);
+    }
+
+    // Write: tagBits (1) + padding (3) + tagArrayByteCount (4) + tag data
+    indexPayload.push_back(static_cast<char>(tagBits));
+    indexPayload.resize(indexPayload.size() + 3, '\0'); // 3 bytes padding
+    const uint32_t tagByteCount32 = static_cast<uint32_t>(tagArrayByteCount);
+    const char* bc = reinterpret_cast<const char*>(&tagByteCount32);
+    indexPayload.insert(indexPayload.end(), bc, bc + 4);
+    const char* tagBytes = reinterpret_cast<const char*>(tagArray.data());
+    indexPayload.insert(
+        indexPayload.end(), tagBytes, tagBytes + tagArrayByteCount);
+
+  } else if (indexType == FreqPartIndexType::EliasFano) {
+    // Build per-tier Elias-Fano position encodings.
+    for (uint32_t t = 0; t < numTiers; ++t) {
+      if (tierRows[t].empty())
+        continue;
+      const std::vector<uint32_t>& positions = tierRows[t]; // ascending order
+      const uint32_t tierCount = static_cast<uint32_t>(positions.size());
+
+      const uint8_t lowBits = chooseEliasFanoLowBits(valueCount, tierCount);
+      const uint32_t lowMask = (lowBits == 0) ? 0u
+          : (lowBits == 32)                   ? 0xFFFFFFFFu
+                                              : ((1u << lowBits) - 1u);
+
+      // Build low array
+      std::vector<uint32_t> lows;
+      lows.reserve(tierCount);
+      for (uint32_t pos : positions)
+        lows.push_back(pos & lowMask);
+
+      const size_t lowByteCount =
+          (static_cast<size_t>(tierCount) * lowBits + 7) / 8;
+
+      // Build high bitmap
+      const size_t highBitsLen =
+          static_cast<size_t>(valueCount >> (lowBits == 0 ? 0 : lowBits)) +
+          tierCount + 1;
+      const uint32_t highWordCount =
+          static_cast<uint32_t>((highBitsLen + 63) / 64);
+      std::vector<uint64_t> highBits(highWordCount, 0);
+      for (uint32_t i = 0; i < tierCount; ++i) {
+        const size_t hi = static_cast<size_t>(
+            lowBits == 0 ? positions[i] : (positions[i] >> lowBits));
+        const size_t bitPos = hi + i;
+        highBits[bitPos / 64] |= uint64_t{1} << (bitPos % 64);
+      }
+
+      // Serialize: lowBits(1) + pad(3) + lowByteCount(4) + highWordCount(4) +
+      //            lowArray + highBitmap
+      indexPayload.push_back(static_cast<char>(lowBits));
+      indexPayload.resize(indexPayload.size() + 3, '\0'); // 3 bytes padding
+      const uint32_t lbc32 = static_cast<uint32_t>(lowByteCount);
+      const char* lbcp = reinterpret_cast<const char*>(&lbc32);
+      indexPayload.insert(indexPayload.end(), lbcp, lbcp + 4);
+      const char* hwcp = reinterpret_cast<const char*>(&highWordCount);
+      indexPayload.insert(indexPayload.end(), hwcp, hwcp + 4);
+
+      // Pack low bits into payload
+      packBitsInto(indexPayload, lows.data(), tierCount, lowBits);
+      // Pad to byte boundary (already done by packBitsInto)
+
+      // Append high bitmap
+      const char* hbytes = reinterpret_cast<const char*>(highBits.data());
+      indexPayload.insert(
+          indexPayload.end(), hbytes, hbytes + highWordCount * 8);
+    }
+  }
+  // NoIndex: indexPayload remains empty.
+
+  // Compute total encoding size
+  uint32_t encodingSize = Encoding::serializePrefixSize(valueCount, useVarint) +
+      4 + // num partitions
+      4 + static_cast<uint32_t>(serializedOffsets.size()) + 4 +
+      static_cast<uint32_t>(serializedSizes.size());
+
+  for (const auto& dict : serializedDicts) {
+    if (!dict.empty())
+      encodingSize += 4 + static_cast<uint32_t>(dict.size());
+  }
+  for (const auto& keys : serializedKeys) {
+    if (!keys.empty())
+      encodingSize += 4 + static_cast<uint32_t>(keys.size());
+  }
+  if (!serializedUnencoded.empty()) {
+    encodingSize += 4 + static_cast<uint32_t>(serializedUnencoded.size());
+  }
+
+  // Add index extension block if any index is stored.
+  const bool hasIndex =
+      indexType != FreqPartIndexType::NoIndex && !indexPayload.empty();
+  if (hasIndex) {
+    encodingSize += 1 + 1 + 4 + static_cast<uint32_t>(indexPayload.size());
+  }
+
+  // Write encoded data
+  char* reserved = buffer.reserve(encodingSize);
+  char* wpos = reserved;
+
+  Encoding::serializePrefix(
+      EncodingType::FrequencyPartition,
+      TypeTraits<T>::dataType,
+      valueCount,
+      useVarint,
+      wpos);
+  encoding::writeUint32(static_cast<uint32_t>(tierRows.size()), wpos);
+  encoding::writeUint32(static_cast<uint32_t>(serializedOffsets.size()), wpos);
+  encoding::writeBytes(serializedOffsets, wpos);
+  encoding::writeUint32(static_cast<uint32_t>(serializedSizes.size()), wpos);
+  encoding::writeBytes(serializedSizes, wpos);
+
+  for (size_t i = 0; i < serializedDicts.size(); ++i) {
+    if (!serializedDicts[i].empty()) {
+      encoding::writeUint32(
+          static_cast<uint32_t>(serializedDicts[i].size()), wpos);
+      encoding::writeBytes(serializedDicts[i], wpos);
+      encoding::writeUint32(
+          static_cast<uint32_t>(serializedKeys[i].size()), wpos);
+      encoding::writeBytes(serializedKeys[i], wpos);
+    }
+  }
+  if (!serializedUnencoded.empty()) {
+    encoding::writeUint32(
+        static_cast<uint32_t>(serializedUnencoded.size()), wpos);
+    encoding::writeBytes(serializedUnencoded, wpos);
+  }
+
+  if (hasIndex) {
+    encoding::write<uint8_t>(kFormatVersion, wpos);
+    encoding::write<uint8_t>(static_cast<uint8_t>(indexType), wpos);
+    encoding::writeUint32(static_cast<uint32_t>(indexPayload.size()), wpos);
+    std::memcpy(wpos, indexPayload.data(), indexPayload.size());
+    wpos += indexPayload.size();
+  }
+
+  NIMBLE_DCHECK_EQ(wpos - reserved, encodingSize, "Encoding size mismatch.");
+  return {reserved, encodingSize};
+}
+
+// ---------------------------------------------------------------------------
+// debugString
+// ---------------------------------------------------------------------------
+
+template <typename T>
+std::string FrequencyPartitionEncoding<T>::debugString(int offset) const {
+  const char* idxName = indexType_ == FreqPartIndexType::NoIndex ? "NoIndex"
+      : indexType_ == FreqPartIndexType::PerTierBitmaps ? "PerTierBitmaps"
+      : indexType_ == FreqPartIndexType::TierTagArray   ? "TierTagArray"
+      : indexType_ == FreqPartIndexType::EliasFano      ? "EliasFano"
+                                                        : "Unknown";
+  std::string log = Encoding::debugString(offset);
+  log += fmt::format(
+      "\n{}tiers={}, unencoded_rows={}, index={}",
+      std::string(offset, ' '),
+      tiers_.size(),
+      unencodedValues_.size(),
+      idxName);
+
+  for (size_t i = 0; i < tiers_.size(); ++i) {
+    const auto& tier = tiers_[i];
+    log += fmt::format(
+        "\n{}tier[{}]: {}bit codes, {} unique values, {} rows",
+        std::string(offset + 2, ' '),
+        i,
+        tier.keyBits,
+        tier.dictionary.size(),
+        tier.size);
+  }
+
+  return log;
+}
+
+} // namespace facebook::nimble

--- a/dwio/nimble/encodings/NullableEncoding.h
+++ b/dwio/nimble/encodings/NullableEncoding.h
@@ -18,6 +18,7 @@
 #include <span>
 #include "dwio/nimble/common/Buffer.h"
 #include "dwio/nimble/common/Types.h"
+#include "dwio/nimble/common/Varint.h"
 #include "dwio/nimble/common/Vector.h"
 #include "dwio/nimble/encodings/DictionaryEncoding.h"
 #include "dwio/nimble/encodings/common/Encoding.h"
@@ -355,9 +356,11 @@ std::string_view NullableEncoding<T>::encodeNullable(
   std::string_view serializedNulls = selection.template encodeNested<bool>(
       EncodingIdentifiers::Nullable::Nulls, nulls, tempBuffer, options);
 
+  const uint32_t prefixSize = useVarint
+      ? Encoding::kRowCountOffset + varint::varintSize(rowCount)
+      : Encoding::kPrefixSize;
   const uint32_t encodingSize =
-      Encoding::serializePrefixSize(rowCount, useVarint) + 4 +
-      serializedValues.size() + serializedNulls.size();
+      prefixSize + 4 + serializedValues.size() + serializedNulls.size();
   char* reserved = buffer.reserve(encodingSize);
   char* pos = reserved;
   Encoding::serializePrefix(

--- a/dwio/nimble/encodings/common/Encoding.h
+++ b/dwio/nimble/encodings/common/Encoding.h
@@ -117,6 +117,11 @@ class Encoding {
     /// pre-materializes all string positions to avoid lazy initialization.
     /// Value-initialized to false when omitted from aggregate initialization.
     bool keyEncoding;
+
+    /// FrequencyPartitionEncoding index type (cast to FreqPartIndexType).
+    /// 0 = NoIndex (default, backward-compatible), 1 = PerTierBitmaps,
+    /// 2 = TierTagArray, 3 = EliasFano.
+    uint8_t frequencyPartitionIndex;
   };
 
   static constexpr int kEncodingTypeOffset =
@@ -295,7 +300,6 @@ class Encoding {
   static uint32_t readRowCount(std::string_view data, bool useVarint) {
     return EncodingPrefix::readRowCount(data, useVarint);
   }
-
   static uint32_t readPrefixSize(std::string_view data, bool useVarint) {
     return EncodingPrefix::readPrefixSize(data, useVarint);
   }

--- a/dwio/nimble/encodings/common/EncodingFactory.cpp
+++ b/dwio/nimble/encodings/common/EncodingFactory.cpp
@@ -18,6 +18,8 @@
 #include "dwio/nimble/encodings/DeltaEncoding.h"
 #include "dwio/nimble/encodings/DictionaryEncoding.h"
 #include "dwio/nimble/encodings/FixedBitWidthEncoding.h"
+#include "dwio/nimble/encodings/ForEncoding.h"
+#include "dwio/nimble/encodings/FrequencyPartitionEncoding.h"
 #include "dwio/nimble/encodings/MainlyConstantEncoding.h"
 #include "dwio/nimble/encodings/NullableEncoding.h"
 #include "dwio/nimble/encodings/PrefixEncoding.h"
@@ -199,6 +201,30 @@ std::unique_ptr<Encoding> EncodingFactory::create(
           toString(dataType));                              \
   }
 
+#define RETURN_ENCODING_BY_INTEGER_TYPE(Encoding, dataType)          \
+  switch (dataType) {                                                \
+    case DataType::Int8:                                             \
+      return std::make_unique<Encoding<int8_t>>(memoryPool, data);   \
+    case DataType::Uint8:                                            \
+      return std::make_unique<Encoding<uint8_t>>(memoryPool, data);  \
+    case DataType::Int16:                                            \
+      return std::make_unique<Encoding<int16_t>>(memoryPool, data);  \
+    case DataType::Uint16:                                           \
+      return std::make_unique<Encoding<uint16_t>>(memoryPool, data); \
+    case DataType::Int32:                                            \
+      return std::make_unique<Encoding<int32_t>>(memoryPool, data);  \
+    case DataType::Uint32:                                           \
+      return std::make_unique<Encoding<uint32_t>>(memoryPool, data); \
+    case DataType::Int64:                                            \
+      return std::make_unique<Encoding<int64_t>>(memoryPool, data);  \
+    case DataType::Uint64:                                           \
+      return std::make_unique<Encoding<uint64_t>>(memoryPool, data); \
+    default:                                                         \
+      NIMBLE_UNREACHABLE(                                            \
+          "ForEncoding only supports integer types, got {}.",        \
+          toString(dataType));                                       \
+  }
+
   switch (encodingType) {
     case EncodingType::Trivial: {
       RETURN_ENCODING_BY_LEAF_TYPE(TrivialEncoding, dataType);
@@ -242,6 +268,12 @@ std::unique_ptr<Encoding> EncodingFactory::create(
     }
     case EncodingType::Delta: {
       RETURN_ENCODING_BY_NUMERIC_TYPE(DeltaEncoding, dataType);
+    }
+    case EncodingType::FOR: {
+      RETURN_ENCODING_BY_NUMERIC_TYPE(ForEncoding, dataType);
+    }
+    case EncodingType::FrequencyPartition: {
+      RETURN_ENCODING_BY_NUMERIC_TYPE(FrequencyPartitionEncoding, dataType);
     }
     default: {
       NIMBLE_UNREACHABLE(
@@ -347,6 +379,25 @@ std::string_view EncodingFactory::encode(
       } else {
         return MainlyConstantEncoding<T>::encode(
             selection, castedValues, buffer, options);
+      }
+    }
+    case EncodingType::FrequencyPartition: {
+      if constexpr (std::is_same<T, bool>::value) {
+        NIMBLE_INCOMPATIBLE_ENCODING(
+            "FrequencyPartition encoding should not be selected for bool data types.");
+      } else {
+        return FrequencyPartitionEncoding<T>::encode(
+            selection, castedValues, buffer, options);
+      }
+    }
+    case EncodingType::FOR: {
+      if constexpr (
+          std::is_integral<physicalType>::value &&
+          !std::is_same<T, bool>::value) {
+        return ForEncoding<T>::encode(selection, castedValues, buffer, options);
+      } else {
+        NIMBLE_INCOMPATIBLE_ENCODING(
+            "For encoding can only be selected for integral data types (not bool).");
       }
     }
     case EncodingType::SparseBool: {

--- a/dwio/nimble/encodings/common/EncodingFactory.cpp
+++ b/dwio/nimble/encodings/common/EncodingFactory.cpp
@@ -269,12 +269,14 @@ std::unique_ptr<Encoding> EncodingFactory::create(
     case EncodingType::Delta: {
       RETURN_ENCODING_BY_NUMERIC_TYPE(DeltaEncoding, dataType);
     }
+#ifdef NIMBLE_ENABLE_EXPERIMENTAL_ENCODINGS
     case EncodingType::FOR: {
       RETURN_ENCODING_BY_NUMERIC_TYPE(ForEncoding, dataType);
     }
     case EncodingType::FrequencyPartition: {
       RETURN_ENCODING_BY_NUMERIC_TYPE(FrequencyPartitionEncoding, dataType);
     }
+#endif
     default: {
       NIMBLE_UNREACHABLE(
           "Trying to deserialize invalid EncodingType:{} -- garbage input?",
@@ -381,6 +383,7 @@ std::string_view EncodingFactory::encode(
             selection, castedValues, buffer, options);
       }
     }
+#ifdef NIMBLE_ENABLE_EXPERIMENTAL_ENCODINGS
     case EncodingType::FrequencyPartition: {
       if constexpr (std::is_same<T, bool>::value) {
         NIMBLE_INCOMPATIBLE_ENCODING(
@@ -400,6 +403,7 @@ std::string_view EncodingFactory::encode(
             "For encoding can only be selected for integral data types (not bool).");
       }
     }
+#endif
     case EncodingType::SparseBool: {
       if constexpr (!std::is_same<T, bool>::value) {
         NIMBLE_INCOMPATIBLE_ENCODING(

--- a/dwio/nimble/encodings/common/EncodingLayout.cpp
+++ b/dwio/nimble/encodings/common/EncodingLayout.cpp
@@ -96,7 +96,15 @@ std::pair<EncodingLayout, uint32_t> EncodingLayout::create(
 
   auto pos = encoding.data();
   const auto encodingType = encoding::read<uint8_t, EncodingType>(pos);
-  const auto compressionType = encoding::read<uint8_t, CompressionType>(pos);
+  auto compressionType = encoding::read<uint8_t, CompressionType>(pos);
+
+#ifdef DISABLE_META_INTERNAL_COMPRESSOR
+  // When MetaInternal is not available, map it to Zstd
+  if (compressionType == CompressionType::MetaInternal) {
+    compressionType = CompressionType::Zstd;
+  }
+#endif
+
   const auto childrenCount = encoding::read<uint8_t>(pos);
   [[maybe_unused]] const auto extraDataSize = encoding::read<uint16_t>(pos);
 
@@ -266,6 +274,34 @@ EncodingLayout EncodingLayoutCapture::capture(std::string_view encoding) {
       children.emplace_back(
           EncodingLayoutCapture::capture(
               {pos, encoding.size() - (pos - encoding.data())}));
+      break;
+    }
+    case EncodingType::FOR: {
+      compressionType = encoding::peek<uint8_t, CompressionType>(
+          encoding.data() + kEncodingPrefixSize);
+      const bool enableBitOffsets = encoding::peek<uint8_t, bool>(
+          encoding.data() + kEncodingPrefixSize + 9);
+
+      const char* pos = encoding.data() + kEncodingPrefixSize + 10;
+
+      const uint32_t bitWidthsBytes = encoding::readUint32(pos);
+      children.emplace_back(
+          EncodingLayoutCapture::capture({pos, bitWidthsBytes}));
+      pos += bitWidthsBytes;
+
+      const uint32_t referencesBytes = encoding::readUint32(pos);
+      children.emplace_back(
+          EncodingLayoutCapture::capture({pos, referencesBytes}));
+      pos += referencesBytes;
+
+      if (enableBitOffsets) {
+        const uint32_t bitOffsetsBytes = encoding::readUint32(pos);
+        children.emplace_back(
+            EncodingLayoutCapture::capture({pos, bitOffsetsBytes}));
+      }
+      break;
+    }
+    case EncodingType::FrequencyPartition: {
       break;
     }
     case EncodingType::Nullable: {

--- a/dwio/nimble/encodings/common/EncodingLayout.cpp
+++ b/dwio/nimble/encodings/common/EncodingLayout.cpp
@@ -301,9 +301,8 @@ EncodingLayout EncodingLayoutCapture::capture(std::string_view encoding) {
       }
       break;
     }
-    case EncodingType::FrequencyPartition: {
+    case EncodingType::FrequencyPartition:
       break;
-    }
     case EncodingType::Nullable: {
       const char* pos = encoding.data() + kEncodingPrefixSize;
       const uint32_t dataBytes = encoding::readUint32(pos);

--- a/dwio/nimble/encodings/common/EncodingUtils.h
+++ b/dwio/nimble/encodings/common/EncodingUtils.h
@@ -126,6 +126,7 @@ auto encodingTypeDispatchNonString(Encoding& encoding, F&& f) {
       return f(static_cast<MainlyConstantEncoding<T>&>(encoding));
     case EncodingType::Delta:
       return f(static_cast<DeltaEncoding<T>&>(encoding));
+#ifdef NIMBLE_ENABLE_EXPERIMENTAL_ENCODINGS
     case EncodingType::FOR:
       if constexpr (std::is_integral_v<T> && !std::is_same_v<T, bool>) {
         return f(static_cast<ForEncoding<T>&>(encoding));
@@ -138,6 +139,7 @@ auto encodingTypeDispatchNonString(Encoding& encoding, F&& f) {
       } else {
         NIMBLE_UNREACHABLE(toString(encoding.dataType()));
       }
+#endif
     default:
       NIMBLE_UNSUPPORTED("{}", encoding.encodingType());
   }

--- a/dwio/nimble/encodings/common/EncodingUtils.h
+++ b/dwio/nimble/encodings/common/EncodingUtils.h
@@ -19,6 +19,8 @@
 #include "dwio/nimble/encodings/DeltaEncoding.h"
 #include "dwio/nimble/encodings/DictionaryEncoding.h"
 #include "dwio/nimble/encodings/FixedBitWidthEncoding.h"
+#include "dwio/nimble/encodings/ForEncoding.h"
+#include "dwio/nimble/encodings/FrequencyPartitionEncoding.h"
 #include "dwio/nimble/encodings/MainlyConstantEncoding.h"
 #include "dwio/nimble/encodings/NullableEncoding.h"
 #include "dwio/nimble/encodings/PrefixEncoding.h"
@@ -124,6 +126,18 @@ auto encodingTypeDispatchNonString(Encoding& encoding, F&& f) {
       return f(static_cast<MainlyConstantEncoding<T>&>(encoding));
     case EncodingType::Delta:
       return f(static_cast<DeltaEncoding<T>&>(encoding));
+    case EncodingType::FOR:
+      if constexpr (std::is_integral_v<T> && !std::is_same_v<T, bool>) {
+        return f(static_cast<ForEncoding<T>&>(encoding));
+      } else {
+        NIMBLE_UNREACHABLE(toString(encoding.dataType()));
+      }
+    case EncodingType::FrequencyPartition:
+      if constexpr (!std::is_same_v<T, bool>) {
+        return f(static_cast<FrequencyPartitionEncoding<T>&>(encoding));
+      } else {
+        NIMBLE_UNREACHABLE(toString(encoding.dataType()));
+      }
     default:
       NIMBLE_UNSUPPORTED("{}", encoding.encodingType());
   }

--- a/dwio/nimble/encodings/legacy/EncodingFactory.cpp
+++ b/dwio/nimble/encodings/legacy/EncodingFactory.cpp
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 #include "dwio/nimble/encodings/legacy/EncodingFactory.h"
+#include "dwio/nimble/encodings/ForEncoding.h"
+#include "dwio/nimble/encodings/FrequencyPartitionEncoding.h"
 #include "dwio/nimble/encodings/legacy/ConstantEncoding.h"
 #include "dwio/nimble/encodings/legacy/DeltaEncoding.h"
 #include "dwio/nimble/encodings/legacy/DictionaryEncoding.h"
@@ -247,6 +249,88 @@ std::unique_ptr<Encoding> EncodingFactory::create(
           "Trying to deserialize a PrefixEncoding with a non-string data type.");
       return std::make_unique<PrefixEncoding>(
           memoryPool, data, stringBufferFactory);
+    }
+    // FOR and FrequencyPartition are newer encodings with no legacy
+    // counterparts. They use the same Encoding base class, so they can be
+    // returned from this factory. Their constructors take an extra
+    // Encoding::Options argument; default-constructed options are correct
+    // because files written by the new writer use useVarintRowCount=false.
+    case EncodingType::FOR: {
+      using ::facebook::nimble::ForEncoding;
+      constexpr ::facebook::nimble::Encoding::Options kOpts{};
+      switch (dataType) {
+        case DataType::Int8:
+          return std::make_unique<ForEncoding<int8_t>>(
+              memoryPool, data, stringBufferFactory, kOpts);
+        case DataType::Uint8:
+          return std::make_unique<ForEncoding<uint8_t>>(
+              memoryPool, data, stringBufferFactory, kOpts);
+        case DataType::Int16:
+          return std::make_unique<ForEncoding<int16_t>>(
+              memoryPool, data, stringBufferFactory, kOpts);
+        case DataType::Uint16:
+          return std::make_unique<ForEncoding<uint16_t>>(
+              memoryPool, data, stringBufferFactory, kOpts);
+        case DataType::Int32:
+          return std::make_unique<ForEncoding<int32_t>>(
+              memoryPool, data, stringBufferFactory, kOpts);
+        case DataType::Uint32:
+          return std::make_unique<ForEncoding<uint32_t>>(
+              memoryPool, data, stringBufferFactory, kOpts);
+        case DataType::Int64:
+          return std::make_unique<ForEncoding<int64_t>>(
+              memoryPool, data, stringBufferFactory, kOpts);
+        case DataType::Uint64:
+          return std::make_unique<ForEncoding<uint64_t>>(
+              memoryPool, data, stringBufferFactory, kOpts);
+        default:
+          NIMBLE_UNREACHABLE(
+              "FOR encoding only supports integral types, got {}.",
+              toString(dataType));
+      }
+    }
+    case EncodingType::FrequencyPartition: {
+      using ::facebook::nimble::FrequencyPartitionEncoding;
+      constexpr ::facebook::nimble::Encoding::Options kOpts{};
+      switch (dataType) {
+        case DataType::Int8:
+          return std::make_unique<FrequencyPartitionEncoding<int8_t>>(
+              memoryPool, data, stringBufferFactory, kOpts);
+        case DataType::Uint8:
+          return std::make_unique<FrequencyPartitionEncoding<uint8_t>>(
+              memoryPool, data, stringBufferFactory, kOpts);
+        case DataType::Int16:
+          return std::make_unique<FrequencyPartitionEncoding<int16_t>>(
+              memoryPool, data, stringBufferFactory, kOpts);
+        case DataType::Uint16:
+          return std::make_unique<FrequencyPartitionEncoding<uint16_t>>(
+              memoryPool, data, stringBufferFactory, kOpts);
+        case DataType::Int32:
+          return std::make_unique<FrequencyPartitionEncoding<int32_t>>(
+              memoryPool, data, stringBufferFactory, kOpts);
+        case DataType::Uint32:
+          return std::make_unique<FrequencyPartitionEncoding<uint32_t>>(
+              memoryPool, data, stringBufferFactory, kOpts);
+        case DataType::Int64:
+          return std::make_unique<FrequencyPartitionEncoding<int64_t>>(
+              memoryPool, data, stringBufferFactory, kOpts);
+        case DataType::Uint64:
+          return std::make_unique<FrequencyPartitionEncoding<uint64_t>>(
+              memoryPool, data, stringBufferFactory, kOpts);
+        case DataType::Float:
+          return std::make_unique<FrequencyPartitionEncoding<float>>(
+              memoryPool, data, stringBufferFactory, kOpts);
+        case DataType::Double:
+          return std::make_unique<FrequencyPartitionEncoding<double>>(
+              memoryPool, data, stringBufferFactory, kOpts);
+        case DataType::String:
+          return std::make_unique<FrequencyPartitionEncoding<std::string_view>>(
+              memoryPool, data, stringBufferFactory, kOpts);
+        default:
+          NIMBLE_UNREACHABLE(
+              "FrequencyPartition encoding does not support bool, got {}.",
+              toString(dataType));
+      }
     }
     default: {
       NIMBLE_UNREACHABLE(

--- a/dwio/nimble/encodings/legacy/EncodingFactory.cpp
+++ b/dwio/nimble/encodings/legacy/EncodingFactory.cpp
@@ -250,11 +250,7 @@ std::unique_ptr<Encoding> EncodingFactory::create(
       return std::make_unique<PrefixEncoding>(
           memoryPool, data, stringBufferFactory);
     }
-    // FOR and FrequencyPartition are newer encodings with no legacy
-    // counterparts. They use the same Encoding base class, so they can be
-    // returned from this factory. Their constructors take an extra
-    // Encoding::Options argument; default-constructed options are correct
-    // because files written by the new writer use useVarintRowCount=false.
+#ifdef NIMBLE_ENABLE_EXPERIMENTAL_ENCODINGS
     case EncodingType::FOR: {
       using ::facebook::nimble::ForEncoding;
       constexpr ::facebook::nimble::Encoding::Options kOpts{};
@@ -332,6 +328,7 @@ std::unique_ptr<Encoding> EncodingFactory::create(
               toString(dataType));
       }
     }
+#endif
     default: {
       NIMBLE_UNREACHABLE(
           "Trying to deserialize invalid EncodingType -- garbage input?");

--- a/dwio/nimble/encodings/legacy/EncodingUtils.h
+++ b/dwio/nimble/encodings/legacy/EncodingUtils.h
@@ -106,6 +106,22 @@ auto encodingTypeDispatchNonString(Encoding& encoding, F&& f) {
       return f(static_cast<MainlyConstantEncoding<T>&>(encoding));
     case EncodingType::Delta:
       return f(static_cast<DeltaEncoding<T>&>(encoding));
+    // FOR and FrequencyPartition have no legacy counterparts; use the new
+    // encoding classes directly (same Encoding base class).
+    case EncodingType::FOR:
+      if constexpr (std::is_integral_v<T> && !std::is_same_v<T, bool>) {
+        return f(static_cast<::facebook::nimble::ForEncoding<T>&>(encoding));
+      } else {
+        NIMBLE_UNREACHABLE(toString(encoding.dataType()));
+      }
+    case EncodingType::FrequencyPartition:
+      if constexpr (!std::is_same_v<T, bool>) {
+        return f(
+            static_cast<::facebook::nimble::FrequencyPartitionEncoding<T>&>(
+                encoding));
+      } else {
+        NIMBLE_UNREACHABLE(toString(encoding.dataType()));
+      }
     default:
       NIMBLE_UNSUPPORTED(toString(encoding.encodingType()));
   }

--- a/dwio/nimble/encodings/legacy/EncodingUtils.h
+++ b/dwio/nimble/encodings/legacy/EncodingUtils.h
@@ -106,8 +106,7 @@ auto encodingTypeDispatchNonString(Encoding& encoding, F&& f) {
       return f(static_cast<MainlyConstantEncoding<T>&>(encoding));
     case EncodingType::Delta:
       return f(static_cast<DeltaEncoding<T>&>(encoding));
-    // FOR and FrequencyPartition have no legacy counterparts; use the new
-    // encoding classes directly (same Encoding base class).
+#ifdef NIMBLE_ENABLE_EXPERIMENTAL_ENCODINGS
     case EncodingType::FOR:
       if constexpr (std::is_integral_v<T> && !std::is_same_v<T, bool>) {
         return f(static_cast<::facebook::nimble::ForEncoding<T>&>(encoding));
@@ -122,6 +121,7 @@ auto encodingTypeDispatchNonString(Encoding& encoding, F&& f) {
       } else {
         NIMBLE_UNREACHABLE(toString(encoding.dataType()));
       }
+#endif
     default:
       NIMBLE_UNSUPPORTED(toString(encoding.encodingType()));
   }

--- a/dwio/nimble/encodings/selection/EncodingIdentifier.h
+++ b/dwio/nimble/encodings/selection/EncodingIdentifier.h
@@ -57,6 +57,28 @@ struct EncodingIdentifiers {
     static constexpr NestedEncodingIdentifier Restatements = 1;
     static constexpr NestedEncodingIdentifier IsRestatements = 2;
   };
+
+  struct FrequencyPartition {
+    // Partition metadata
+    static constexpr NestedEncodingIdentifier PartitionOffsets = 0;
+    static constexpr NestedEncodingIdentifier PartitionSizes = 1;
+    // Per-tier dictionaries (1-bit, 2-bit, 4-bit, 8-bit, etc.)
+    static constexpr NestedEncodingIdentifier Dict1Bit = 2;
+    static constexpr NestedEncodingIdentifier Dict2Bit = 3;
+    static constexpr NestedEncodingIdentifier Dict4Bit = 4;
+    static constexpr NestedEncodingIdentifier Dict8Bit = 5;
+    static constexpr NestedEncodingIdentifier Dict16Bit = 6;
+    static constexpr NestedEncodingIdentifier Dict32Bit = 7;
+    // Per-tier encoded keys
+    static constexpr NestedEncodingIdentifier Keys1Bit = 8;
+    static constexpr NestedEncodingIdentifier Keys2Bit = 9;
+    static constexpr NestedEncodingIdentifier Keys4Bit = 10;
+    static constexpr NestedEncodingIdentifier Keys8Bit = 11;
+    static constexpr NestedEncodingIdentifier Keys16Bit = 12;
+    static constexpr NestedEncodingIdentifier Keys32Bit = 13;
+    // Unencoded partition (raw values that don't fit in any tier)
+    static constexpr NestedEncodingIdentifier UnencodedValues = 14;
+  };
 };
 
 } // namespace facebook::nimble

--- a/dwio/nimble/encodings/tests/CMakeLists.txt
+++ b/dwio/nimble/encodings/tests/CMakeLists.txt
@@ -26,6 +26,8 @@ add_executable(
   CompressionTest.cpp
   EncodingTest.cpp
   EncodingLegacyTest.cpp
+  ForEncodingTest.cpp
+  FrequencyPartitionEncodingTest.cpp
   Lz4CompressorTest.cpp
   MainlyConstantEncodingTest.cpp
   NullableEncodingTest.cpp

--- a/dwio/nimble/encodings/tests/ConstantEncodingTest.cpp
+++ b/dwio/nimble/encodings/tests/ConstantEncodingTest.cpp
@@ -35,9 +35,83 @@ struct TestConfig {
 
 #define TC(T) TestConfig<T, false>, TestConfig<T, true>
 
+// Forward declaration
+template <typename Config>
+class ConstantEncodingTest;
+
+// Helper to prepare values - must be at namespace scope
+template <typename T, typename TestClass>
+struct ValuesPreparer {
+  static std::vector<nimble::Vector<T>> prepareValues(TestClass* test) {
+    FAIL() << "unspecialized prepareValues() should not be called";
+    return {};
+  }
+  static std::vector<nimble::Vector<T>> prepareFailureValues(TestClass* test) {
+    FAIL() << "unspecialized prepareFailureValues() should not be called";
+    return {};
+  }
+};
+
+template <typename TestClass>
+struct ValuesPreparer<double, TestClass> {
+  static std::vector<nimble::Vector<double>> prepareValues(TestClass* test) {
+    return {
+        test->toVector({0.0}),
+        test->toVector({0.0, 0.00}),
+        test->toVector({-0.0, -0.00}),
+        test->toVector({-2.1, -2.1, -2.1, -2.1, -2.1}),
+        test->toVector({test->dNaN0, test->dNaN0, test->dNaN0}),
+        test->toVector({test->dNaN1, test->dNaN1, test->dNaN1}),
+        test->toVector({test->dNaN2, test->dNaN2, test->dNaN2})};
+  }
+  static std::vector<nimble::Vector<double>> prepareFailureValues(
+      TestClass* test) {
+    return {
+        test->toVector({-0.0, -0.00, -0.0000001}),
+        test->toVector({-2.1, -2.1, -2.1, -2.1, -2.2}),
+        test->toVector({test->dNaN0, test->dNaN0, test->dNaN1})};
+  }
+};
+
+template <typename TestClass>
+struct ValuesPreparer<float, TestClass> {
+  static std::vector<nimble::Vector<float>> prepareValues(TestClass* test) {
+    return {
+        test->toVector({0.0f}),
+        test->toVector({0.0f, 0.00f}),
+        test->toVector({-0.0f, -0.00f}),
+        test->toVector({-2.1f, -2.1f, -2.1f, -2.1f, -2.1f}),
+        test->toVector({test->fNaN0, test->fNaN0, test->fNaN0}),
+        test->toVector({test->fNaN1, test->fNaN1, test->fNaN1}),
+        test->toVector({test->fNaN2, test->fNaN2, test->fNaN2})};
+  }
+  static std::vector<nimble::Vector<float>> prepareFailureValues(
+      TestClass* test) {
+    return {
+        test->toVector({-0.0f, -0.00f, -0.0000001f}),
+        test->toVector({-2.1f, -2.1f, -2.1f, -2.1f, -2.2f}),
+        test->toVector({test->fNaN0, test->fNaN0, test->fNaN2})};
+  }
+};
+
+template <typename TestClass>
+struct ValuesPreparer<int32_t, TestClass> {
+  static std::vector<nimble::Vector<int32_t>> prepareValues(TestClass* test) {
+    return {test->toVector({1}), test->toVector({3, 3, 3})};
+  }
+  static std::vector<nimble::Vector<int32_t>> prepareFailureValues(
+      TestClass* test) {
+    return {test->toVector({3, 2, 3})};
+  }
+};
+
 template <typename Config>
 class ConstantEncodingTest : public ::testing::Test {
  protected:
+  // Make helper templates friends so they can access protected members
+  template <typename T, typename TestClass>
+  friend struct ValuesPreparer;
+
   void SetUp() override {
     pool_ = facebook::velox::memory::deprecatedAddDefaultLeafMemoryPool();
     buffer_ = std::make_unique<nimble::Buffer>(*pool_);
@@ -45,14 +119,13 @@ class ConstantEncodingTest : public ::testing::Test {
 
   template <typename T>
   std::vector<nimble::Vector<T>> prepareValues() {
-    FAIL() << "unspecialized prepapreValues() should not be called";
-    return {};
+    return ValuesPreparer<T, ConstantEncodingTest<Config>>::prepareValues(this);
   }
 
   template <typename T>
   std::vector<nimble::Vector<T>> prepareFailureValues() {
-    FAIL() << "unspecialized prepapreValues() should not be called";
-    return {};
+    return ValuesPreparer<T, ConstantEncodingTest<Config>>::
+        prepareFailureValues(this);
   }
 
   template <typename T>
@@ -73,56 +146,6 @@ class ConstantEncodingTest : public ::testing::Test {
     nimble::Vector<T> v{pool_.get()};
     v.insert(v.end(), l.begin(), l.end());
     return v;
-  }
-
-  template <>
-  std::vector<nimble::Vector<double>> prepareValues() {
-    return {
-        toVector({0.0}),
-        toVector({0.0, 0.00}),
-        toVector({-0.0, -0.00}),
-        toVector({-2.1, -2.1, -2.1, -2.1, -2.1}),
-        toVector({dNaN0, dNaN0, dNaN0}),
-        toVector({dNaN1, dNaN1, dNaN1}),
-        toVector({dNaN2, dNaN2, dNaN2})};
-  }
-
-  template <>
-  std::vector<nimble::Vector<float>> prepareValues() {
-    return {
-        toVector({0.0f}),
-        toVector({0.0f, 0.00f}),
-        toVector({-0.0f, -0.00f}),
-        toVector({-2.1f, -2.1f, -2.1f, -2.1f, -2.1f}),
-        toVector({fNaN0, fNaN0, fNaN0}),
-        toVector({fNaN1, fNaN1, fNaN1}),
-        toVector({fNaN2, fNaN2, fNaN2})};
-  }
-
-  template <>
-  std::vector<nimble::Vector<int32_t>> prepareValues() {
-    return {toVector({1}), toVector({3, 3, 3})};
-  }
-
-  template <>
-  std::vector<nimble::Vector<double>> prepareFailureValues() {
-    return {
-        toVector({-0.0, -0.00, -0.0000001}),
-        toVector({-2.1, -2.1, -2.1, -2.1, -2.2}),
-        toVector({dNaN0, dNaN0, dNaN1})};
-  }
-
-  template <>
-  std::vector<nimble::Vector<float>> prepareFailureValues() {
-    return {
-        toVector({-0.0f, -0.00f, -0.0000001f}),
-        toVector({-2.1f, -2.1f, -2.1f, -2.1f, -2.2f}),
-        toVector({fNaN0, fNaN0, fNaN2})};
-  }
-
-  template <>
-  std::vector<nimble::Vector<int32_t>> prepareFailureValues() {
-    return {toVector({3, 2, 3})};
   }
 
   std::shared_ptr<velox::memory::MemoryPool> pool_;

--- a/dwio/nimble/encodings/tests/DeltaEncodingLegacyTest.cpp
+++ b/dwio/nimble/encodings/tests/DeltaEncodingLegacyTest.cpp
@@ -82,7 +82,9 @@ template <typename T>
 class DeltaEncodingLegacyTest : public ::testing::Test {
  protected:
   static void SetUpTestCase() {
-    velox::memory::MemoryManager::initialize({});
+    if (!velox::memory::MemoryManager::testInstance()) {
+      velox::memory::MemoryManager::initialize({});
+    }
   }
 
   void SetUp() override {

--- a/dwio/nimble/encodings/tests/EncodingLayoutTest.cpp
+++ b/dwio/nimble/encodings/tests/EncodingLayoutTest.cpp
@@ -32,7 +32,29 @@ void verifyEncodingLayout(
   }
 
   ASSERT_EQ(expected->encodingType(), actual->encodingType());
-  ASSERT_EQ(expected->compressionType(), actual->compressionType());
+
+  // When MetaInternal is not available, it gets redirected to Zstd.
+  // For tests, we need to account for this mapping.
+  auto expectedCompression = expected->compressionType();
+  auto actualCompression = actual->compressionType();
+
+#ifdef DISABLE_META_INTERNAL_COMPRESSOR
+  // If expected is MetaInternal but we don't have it, accept Zstd or
+  // Uncompressed (Uncompressed can happen if the data is too small to benefit
+  // from compression)
+  if (expectedCompression == nimble::CompressionType::MetaInternal) {
+    ASSERT_TRUE(
+        actualCompression == nimble::CompressionType::Zstd ||
+        actualCompression == nimble::CompressionType::Uncompressed)
+        << "Expected MetaInternal (mapped to Zstd or Uncompressed), but got "
+        << nimble::toString(actualCompression);
+  } else {
+    ASSERT_EQ(expectedCompression, actualCompression);
+  }
+#else
+  ASSERT_EQ(expectedCompression, actualCompression);
+#endif
+
   ASSERT_EQ(expected->childrenCount(), actual->childrenCount());
 
   for (auto i = 0; i < expected->childrenCount(); ++i) {
@@ -131,11 +153,11 @@ TEST(EncodingLayoutTests, FixedBitWidth) {
     nimble::EncodingLayout expected{
         nimble::EncodingType::FixedBitWidth,
         {},
-        nimble::CompressionType::Zstd,
+        nimble::CompressionType::MetaInternal,
     };
 
     testSerialization(expected);
-    // NOTE: We need this artitifical long input data, because if Zstd
+    // NOTE: We need this artitifical long input data, because if MetaInternal
     // compressed buffer is bigger than the uncompressed buffer, it is not
     // picked up, which then leads to the captured encloding layout to be
     // uncompressed.
@@ -188,10 +210,21 @@ TEST(EncodingLayoutTests, SparseBool) {
               {},
               nimble::CompressionType::MetaInternal},
       }};
-
   testSerialization(expected);
+
+  // Test actual capture with uncompressed
+  nimble::EncodingLayout captureTest{
+      nimble::EncodingType::SparseBool,
+      {},
+      nimble::CompressionType::Uncompressed,
+      {
+          nimble::EncodingLayout{
+              nimble::EncodingType::Trivial,
+              {},
+              nimble::CompressionType::Uncompressed},
+      }};
   testCapture<bool>(
-      expected, std::array<bool, 5>{false, false, false, true, false});
+      captureTest, std::array<bool, 5>{false, false, false, true, false});
 }
 
 TEST(EncodingLayoutTests, MainlyConst) {
@@ -209,9 +242,24 @@ TEST(EncodingLayoutTests, MainlyConst) {
               {},
               nimble::CompressionType::Uncompressed},
       }};
-
   testSerialization(expected);
-  testCapture<uint32_t>(expected, {1, 1, 1, 1, 5, 1});
+
+  // Test actual capture with uncompressed
+  nimble::EncodingLayout captureTest{
+      nimble::EncodingType::MainlyConstant,
+      {},
+      nimble::CompressionType::Uncompressed,
+      {
+          nimble::EncodingLayout{
+              nimble::EncodingType::Trivial,
+              {},
+              nimble::CompressionType::Uncompressed},
+          nimble::EncodingLayout{
+              nimble::EncodingType::Trivial,
+              {},
+              nimble::CompressionType::Uncompressed},
+      }};
+  testCapture<uint32_t>(captureTest, {1, 1, 1, 1, 5, 1});
 }
 
 TEST(EncodingLayoutTests, Dictionary) {

--- a/dwio/nimble/encodings/tests/EncodingLegacyTest.cpp
+++ b/dwio/nimble/encodings/tests/EncodingLegacyTest.cpp
@@ -134,6 +134,76 @@ class TestTrivialEncodingSelectionPolicy
   bool useVariableBitWidthCompressor_;
 };
 } // namespace
+
+// Forward declaration
+template <typename C>
+class EncodingLegacyTest;
+
+// EncodingTypeTraits helpers at namespace scope
+template <typename C, typename Encoding>
+struct EncodingTypeTraitsHelper {};
+
+template <typename C>
+struct EncodingTypeTraitsHelper<
+    C,
+    nimble::legacy::ConstantEncoding<typename C::cppDataType>> {
+  static inline nimble::EncodingType encodingType =
+      nimble::EncodingType::Constant;
+};
+
+template <typename C>
+struct EncodingTypeTraitsHelper<
+    C,
+    nimble::legacy::DictionaryEncoding<typename C::cppDataType>> {
+  static inline nimble::EncodingType encodingType =
+      nimble::EncodingType::Dictionary;
+};
+
+template <typename C>
+struct EncodingTypeTraitsHelper<
+    C,
+    nimble::legacy::FixedBitWidthEncoding<typename C::cppDataType>> {
+  static inline nimble::EncodingType encodingType =
+      nimble::EncodingType::FixedBitWidth;
+};
+
+template <typename C>
+struct EncodingTypeTraitsHelper<
+    C,
+    nimble::legacy::MainlyConstantEncoding<typename C::cppDataType>> {
+  static inline nimble::EncodingType encodingType =
+      nimble::EncodingType::MainlyConstant;
+};
+
+template <typename C>
+struct EncodingTypeTraitsHelper<
+    C,
+    nimble::legacy::RLEEncoding<typename C::cppDataType>> {
+  static inline nimble::EncodingType encodingType = nimble::EncodingType::RLE;
+};
+
+template <typename C>
+struct EncodingTypeTraitsHelper<C, nimble::legacy::SparseBoolEncoding> {
+  static inline nimble::EncodingType encodingType =
+      nimble::EncodingType::SparseBool;
+};
+
+template <typename C>
+struct EncodingTypeTraitsHelper<
+    C,
+    nimble::legacy::TrivialEncoding<typename C::cppDataType>> {
+  static inline nimble::EncodingType encodingType =
+      nimble::EncodingType::Trivial;
+};
+
+template <typename C>
+struct EncodingTypeTraitsHelper<
+    C,
+    nimble::legacy::VarintEncoding<typename C::cppDataType>> {
+  static inline nimble::EncodingType encodingType =
+      nimble::EncodingType::Varint;
+};
+
 // C is the encoding type.
 template <typename C>
 class EncodingLegacyTest : public ::testing::Test {
@@ -147,53 +217,9 @@ class EncodingLegacyTest : public ::testing::Test {
   }
 
   template <typename Encoding>
-  struct EncodingTypeTraits {};
-
-  template <>
-  struct EncodingTypeTraits<nimble::legacy::ConstantEncoding<E>> {
+  struct EncodingTypeTraits {
     static inline nimble::EncodingType encodingType =
-        nimble::EncodingType::Constant;
-  };
-
-  template <>
-  struct EncodingTypeTraits<nimble::legacy::DictionaryEncoding<E>> {
-    static inline nimble::EncodingType encodingType =
-        nimble::EncodingType::Dictionary;
-  };
-
-  template <>
-  struct EncodingTypeTraits<nimble::legacy::FixedBitWidthEncoding<E>> {
-    static inline nimble::EncodingType encodingType =
-        nimble::EncodingType::FixedBitWidth;
-  };
-
-  template <>
-  struct EncodingTypeTraits<nimble::legacy::MainlyConstantEncoding<E>> {
-    static inline nimble::EncodingType encodingType =
-        nimble::EncodingType::MainlyConstant;
-  };
-
-  template <>
-  struct EncodingTypeTraits<nimble::legacy::RLEEncoding<E>> {
-    static inline nimble::EncodingType encodingType = nimble::EncodingType::RLE;
-  };
-
-  template <>
-  struct EncodingTypeTraits<nimble::legacy::SparseBoolEncoding> {
-    static inline nimble::EncodingType encodingType =
-        nimble::EncodingType::SparseBool;
-  };
-
-  template <>
-  struct EncodingTypeTraits<nimble::legacy::TrivialEncoding<E>> {
-    static inline nimble::EncodingType encodingType =
-        nimble::EncodingType::Trivial;
-  };
-
-  template <>
-  struct EncodingTypeTraits<nimble::legacy::VarintEncoding<E>> {
-    static inline nimble::EncodingType encodingType =
-        nimble::EncodingType::Varint;
+        EncodingTypeTraitsHelper<C, Encoding>::encodingType;
   };
 
   std::unique_ptr<nimble::Encoding> createEncoding(

--- a/dwio/nimble/encodings/tests/EncodingTest.cpp
+++ b/dwio/nimble/encodings/tests/EncodingTest.cpp
@@ -30,6 +30,7 @@
 #include "dwio/nimble/encodings/DeltaEncoding.h"
 #include "dwio/nimble/encodings/DictionaryEncoding.h"
 #include "dwio/nimble/encodings/FixedBitWidthEncoding.h"
+#include "dwio/nimble/encodings/FrequencyPartitionEncoding.h"
 #include "dwio/nimble/encodings/MainlyConstantEncoding.h"
 #include "dwio/nimble/encodings/NullableEncoding.h"
 #include "dwio/nimble/encodings/RleEncoding.h"
@@ -148,6 +149,61 @@ struct TestConfig {
 
 #define TC(T) TestConfig<T, false>, TestConfig<T, true>
 
+// Helper template to get encoding type for each encoding class
+template <typename Encoding>
+struct EncodingTypeGetter;
+
+template <typename T>
+struct EncodingTypeGetter<nimble::ConstantEncoding<T>> {
+  static constexpr nimble::EncodingType value = nimble::EncodingType::Constant;
+};
+
+template <typename T>
+struct EncodingTypeGetter<nimble::DictionaryEncoding<T>> {
+  static constexpr nimble::EncodingType value =
+      nimble::EncodingType::Dictionary;
+};
+
+template <typename T>
+struct EncodingTypeGetter<nimble::FixedBitWidthEncoding<T>> {
+  static constexpr nimble::EncodingType value =
+      nimble::EncodingType::FixedBitWidth;
+};
+
+template <typename T>
+struct EncodingTypeGetter<nimble::FrequencyPartitionEncoding<T>> {
+  static constexpr nimble::EncodingType value =
+      nimble::EncodingType::FrequencyPartition;
+};
+
+template <typename T>
+struct EncodingTypeGetter<nimble::MainlyConstantEncoding<T>> {
+  static constexpr nimble::EncodingType value =
+      nimble::EncodingType::MainlyConstant;
+};
+
+template <typename T>
+struct EncodingTypeGetter<nimble::RLEEncoding<T>> {
+  static constexpr nimble::EncodingType value = nimble::EncodingType::RLE;
+};
+
+template <>
+struct EncodingTypeGetter<nimble::SparseBoolEncoding> {
+  static constexpr nimble::EncodingType value =
+      nimble::EncodingType::SparseBool;
+};
+
+template <typename T>
+struct EncodingTypeGetter<nimble::TrivialEncoding<T>> {
+  static constexpr nimble::EncodingType value = nimble::EncodingType::Trivial;
+};
+
+template <typename T>
+struct EncodingTypeGetter<nimble::VarintEncoding<T>> {
+  static constexpr nimble::EncodingType value = nimble::EncodingType::Varint;
+};
+
+// C is the encoding type.
 template <typename Config>
 class EncodingTest : public ::testing::Test {
  protected:
@@ -160,56 +216,6 @@ class EncodingTest : public ::testing::Test {
     util_ = std::make_unique<nimble::testing::Util>(*this->pool_);
   }
 
-  template <typename Encoding>
-  struct EncodingTypeTraits {};
-
-  template <>
-  struct EncodingTypeTraits<nimble::ConstantEncoding<E>> {
-    static inline nimble::EncodingType encodingType =
-        nimble::EncodingType::Constant;
-  };
-
-  template <>
-  struct EncodingTypeTraits<nimble::DictionaryEncoding<E>> {
-    static inline nimble::EncodingType encodingType =
-        nimble::EncodingType::Dictionary;
-  };
-
-  template <>
-  struct EncodingTypeTraits<nimble::FixedBitWidthEncoding<E>> {
-    static inline nimble::EncodingType encodingType =
-        nimble::EncodingType::FixedBitWidth;
-  };
-
-  template <>
-  struct EncodingTypeTraits<nimble::MainlyConstantEncoding<E>> {
-    static inline nimble::EncodingType encodingType =
-        nimble::EncodingType::MainlyConstant;
-  };
-
-  template <>
-  struct EncodingTypeTraits<nimble::RLEEncoding<E>> {
-    static inline nimble::EncodingType encodingType = nimble::EncodingType::RLE;
-  };
-
-  template <>
-  struct EncodingTypeTraits<nimble::SparseBoolEncoding> {
-    static inline nimble::EncodingType encodingType =
-        nimble::EncodingType::SparseBool;
-  };
-
-  template <>
-  struct EncodingTypeTraits<nimble::TrivialEncoding<E>> {
-    static inline nimble::EncodingType encodingType =
-        nimble::EncodingType::Trivial;
-  };
-
-  template <>
-  struct EncodingTypeTraits<nimble::VarintEncoding<E>> {
-    static inline nimble::EncodingType encodingType =
-        nimble::EncodingType::Varint;
-  };
-
   std::unique_ptr<nimble::Encoding> createEncoding(
       const nimble::Vector<E>& values,
       bool compress,
@@ -220,7 +226,7 @@ class EncodingTest : public ::testing::Test {
     auto physicalValues = std::span<const physicalType>(
         reinterpret_cast<const physicalType*>(values.data()), values.size());
     nimble::EncodingSelection<physicalType> selection{
-        {.encodingType = EncodingTypeTraits<C>::encodingType,
+        {.encodingType = EncodingTypeGetter<C>::value,
          .compressionPolicyFactory =
              [compress, useVariableBitWidthCompressor]() {
                return std::make_unique<TestCompressPolicy>(

--- a/dwio/nimble/encodings/tests/EncodingTestsLegacy.cpp
+++ b/dwio/nimble/encodings/tests/EncodingTestsLegacy.cpp
@@ -64,11 +64,8 @@ class TestCompressPolicy : public nimble::CompressionPolicy {
     }
 
     nimble::CompressionInformation information{
-        .compressionType = nimble::CompressionType::MetaInternal};
-    information.parameters.metaInternal.compressionLevel = 9;
-    information.parameters.metaInternal.decompressionLevel = 2;
-    information.parameters.metaInternal.useVariableBitWidthCompressor =
-        useVariableBitWidthCompressor_;
+        .compressionType = nimble::CompressionType::Zstd};
+    information.parameters.zstd.compressionLevel = 9;
     return information;
   }
 
@@ -133,6 +130,55 @@ class TestTrivialEncodingSelectionPolicy
   bool shouldCompress_;
   bool useVariableBitWidthCompressor_;
 };
+
+// Helper to get encoding type for legacy encodings
+template <typename T>
+struct LegacyEncodingTypeGetter;
+
+template <typename T>
+struct LegacyEncodingTypeGetter<nimble::legacy::ConstantEncoding<T>> {
+  static constexpr nimble::EncodingType value = nimble::EncodingType::Constant;
+};
+
+template <typename T>
+struct LegacyEncodingTypeGetter<nimble::legacy::DictionaryEncoding<T>> {
+  static constexpr nimble::EncodingType value =
+      nimble::EncodingType::Dictionary;
+};
+
+template <typename T>
+struct LegacyEncodingTypeGetter<nimble::legacy::FixedBitWidthEncoding<T>> {
+  static constexpr nimble::EncodingType value =
+      nimble::EncodingType::FixedBitWidth;
+};
+
+template <typename T>
+struct LegacyEncodingTypeGetter<nimble::legacy::MainlyConstantEncoding<T>> {
+  static constexpr nimble::EncodingType value =
+      nimble::EncodingType::MainlyConstant;
+};
+
+template <typename T>
+struct LegacyEncodingTypeGetter<nimble::legacy::RLEEncoding<T>> {
+  static constexpr nimble::EncodingType value = nimble::EncodingType::RLE;
+};
+
+template <>
+struct LegacyEncodingTypeGetter<nimble::legacy::SparseBoolEncoding> {
+  static constexpr nimble::EncodingType value =
+      nimble::EncodingType::SparseBool;
+};
+
+template <typename T>
+struct LegacyEncodingTypeGetter<nimble::legacy::TrivialEncoding<T>> {
+  static constexpr nimble::EncodingType value = nimble::EncodingType::Trivial;
+};
+
+template <typename T>
+struct LegacyEncodingTypeGetter<nimble::legacy::VarintEncoding<T>> {
+  static constexpr nimble::EncodingType value = nimble::EncodingType::Varint;
+};
+
 } // namespace
 // C is the encoding type.
 template <typename C>
@@ -146,56 +192,6 @@ class EncodingTestsLegacy : public ::testing::Test {
     util_ = std::make_unique<nimble::testing::Util>(*this->pool_);
   }
 
-  template <typename Encoding>
-  struct EncodingTypeTraits {};
-
-  template <>
-  struct EncodingTypeTraits<nimble::legacy::ConstantEncoding<E>> {
-    static inline nimble::EncodingType encodingType =
-        nimble::EncodingType::Constant;
-  };
-
-  template <>
-  struct EncodingTypeTraits<nimble::legacy::DictionaryEncoding<E>> {
-    static inline nimble::EncodingType encodingType =
-        nimble::EncodingType::Dictionary;
-  };
-
-  template <>
-  struct EncodingTypeTraits<nimble::legacy::FixedBitWidthEncoding<E>> {
-    static inline nimble::EncodingType encodingType =
-        nimble::EncodingType::FixedBitWidth;
-  };
-
-  template <>
-  struct EncodingTypeTraits<nimble::legacy::MainlyConstantEncoding<E>> {
-    static inline nimble::EncodingType encodingType =
-        nimble::EncodingType::MainlyConstant;
-  };
-
-  template <>
-  struct EncodingTypeTraits<nimble::legacy::RLEEncoding<E>> {
-    static inline nimble::EncodingType encodingType = nimble::EncodingType::RLE;
-  };
-
-  template <>
-  struct EncodingTypeTraits<nimble::legacy::SparseBoolEncoding> {
-    static inline nimble::EncodingType encodingType =
-        nimble::EncodingType::SparseBool;
-  };
-
-  template <>
-  struct EncodingTypeTraits<nimble::legacy::TrivialEncoding<E>> {
-    static inline nimble::EncodingType encodingType =
-        nimble::EncodingType::Trivial;
-  };
-
-  template <>
-  struct EncodingTypeTraits<nimble::legacy::VarintEncoding<E>> {
-    static inline nimble::EncodingType encodingType =
-        nimble::EncodingType::Varint;
-  };
-
   std::unique_ptr<nimble::Encoding> createEncoding(
       const nimble::Vector<E>& values,
       bool compress,
@@ -205,7 +201,7 @@ class EncodingTestsLegacy : public ::testing::Test {
     auto physicalValues = std::span<const physicalType>(
         reinterpret_cast<const physicalType*>(values.data()), values.size());
     nimble::EncodingSelection<physicalType> selection{
-        {.encodingType = EncodingTypeTraits<C>::encodingType,
+        {.encodingType = LegacyEncodingTypeGetter<C>::value,
          .compressionPolicyFactory =
              [compress, useVariableBitWidthCompressor]() {
                return std::make_unique<TestCompressPolicy>(

--- a/dwio/nimble/encodings/tests/ForEncodingTest.cpp
+++ b/dwio/nimble/encodings/tests/ForEncodingTest.cpp
@@ -1,0 +1,653 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "dwio/nimble/encodings/ForEncoding.h"
+#include <glog/logging.h>
+#include <gtest/gtest.h>
+#include <algorithm>
+#include <memory>
+#include <random>
+#include "dwio/nimble/common/Buffer.h"
+#include "dwio/nimble/common/Vector.h"
+#include "dwio/nimble/encodings/tests/TestUtils.h"
+#include "folly/Random.h"
+#include "velox/common/memory/Memory.h"
+
+using namespace facebook;
+
+class ForEncodingTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    pool_ = velox::memory::deprecatedAddDefaultLeafMemoryPool();
+    buffer_ = std::make_unique<nimble::Buffer>(*pool_);
+  }
+
+  template <typename T>
+  std::unique_ptr<nimble::Encoding> createEncoding(
+      const nimble::Vector<T>& data) {
+    return nimble::test::Encoder<nimble::ForEncoding<T>>::createEncoding(
+        *buffer_, data, nullptr, nimble::CompressionType::Uncompressed);
+  }
+
+  std::shared_ptr<velox::memory::MemoryPool> pool_;
+  std::unique_ptr<nimble::Buffer> buffer_;
+};
+
+TEST_F(ForEncodingTest, BasicEncodeDecode) {
+  nimble::Vector<int32_t> data(pool_.get());
+  data.push_back(100);
+  data.push_back(105);
+  data.push_back(102);
+  data.push_back(110);
+  data.push_back(101);
+  data.push_back(103);
+
+  auto encoding = createEncoding(data);
+  ASSERT_EQ(encoding->encodingType(), nimble::EncodingType::FOR);
+  ASSERT_EQ(encoding->dataType(), nimble::DataType::Int32);
+  ASSERT_EQ(encoding->rowCount(), 6);
+
+  nimble::Vector<int32_t> result(pool_.get(), 6);
+  encoding->materialize(6, result.data());
+
+  ASSERT_EQ(data.size(), result.size());
+  for (size_t i = 0; i < data.size(); ++i) {
+    ASSERT_EQ(result[i], data[i]) << "Mismatch at index " << i;
+  }
+}
+
+TEST_F(ForEncodingTest, AllZeros) {
+  nimble::Vector<int32_t> data(pool_.get());
+  for (int i = 0; i < 1000; ++i) {
+    data.push_back(0);
+  }
+
+  auto encoding = createEncoding(data);
+  ASSERT_EQ(encoding->rowCount(), 1000);
+
+  nimble::Vector<int32_t> result(pool_.get(), 1000);
+  encoding->materialize(1000, result.data());
+
+  for (size_t i = 0; i < data.size(); ++i) {
+    ASSERT_EQ(result[i], 0) << "Expected 0 at index " << i;
+  }
+}
+
+// Test with constant value (1-bit encoding)
+TEST_F(ForEncodingTest, ConstantValue) {
+  nimble::Vector<int64_t> data(pool_.get());
+  const int64_t constantValue = 42;
+  for (int i = 0; i < 500; ++i) {
+    data.push_back(constantValue);
+  }
+
+  auto encoding = createEncoding(data);
+  ASSERT_EQ(encoding->rowCount(), 500);
+
+  nimble::Vector<int64_t> result(pool_.get(), 500);
+  encoding->materialize(500, result.data());
+
+  for (size_t i = 0; i < data.size(); ++i) {
+    ASSERT_EQ(result[i], constantValue)
+        << "Expected " << constantValue << " at index " << i;
+  }
+}
+
+// Test with values requiring different bit widths
+TEST_F(ForEncodingTest, MixedBitWidths) {
+  nimble::Vector<int32_t> data(pool_.get());
+
+  // Frame 1: small range (1-bit)
+  for (int i = 0; i < 128; ++i) {
+    data.push_back(100 + (i % 2));
+  }
+
+  // Frame 2: medium range (4-bit)
+  for (int i = 0; i < 128; ++i) {
+    data.push_back(200 + (i % 16));
+  }
+
+  // Frame 3: larger range (8-bit)
+  for (int i = 0; i < 128; ++i) {
+    data.push_back(300 + (i % 256));
+  }
+
+  auto encoding = createEncoding(data);
+  ASSERT_EQ(encoding->rowCount(), 384);
+
+  nimble::Vector<int32_t> result(pool_.get(), 384);
+  encoding->materialize(384, result.data());
+
+  for (size_t i = 0; i < data.size(); ++i) {
+    ASSERT_EQ(result[i], data[i]) << "Mismatch at index " << i;
+  }
+}
+
+// Test random access by reading subsets
+TEST_F(ForEncodingTest, RandomAccess) {
+  auto seed = folly::Random::rand32();
+  LOG(INFO) << "seed: " << seed;
+  std::mt19937 rng(seed);
+
+  nimble::Vector<int64_t> data(pool_.get());
+  for (int i = 0; i < 1000; ++i) {
+    data.push_back(static_cast<int64_t>(rng() % 1000000));
+  }
+
+  auto encoding = createEncoding(data);
+  ASSERT_EQ(encoding->rowCount(), 1000);
+
+  // Test by materializing entire sequence and checking consistency
+  nimble::Vector<int64_t> result(pool_.get(), 1000);
+  encoding->materialize(1000, result.data());
+
+  for (size_t i = 0; i < data.size(); ++i) {
+    ASSERT_EQ(result[i], data[i]) << "Mismatch at index " << i;
+  }
+}
+
+// Test partial read with skip
+TEST_F(ForEncodingTest, SelectiveRead) {
+  nimble::Vector<int32_t> data(pool_.get());
+  for (int i = 0; i < 500; ++i) {
+    data.push_back(i * 10);
+  }
+
+  auto encoding = createEncoding(data);
+  ASSERT_EQ(encoding->rowCount(), 500);
+
+  // Read first 100
+  nimble::Vector<int32_t> result1(pool_.get(), 100);
+  encoding->materialize(100, result1.data());
+
+  for (size_t i = 0; i < 100; ++i) {
+    ASSERT_EQ(result1[i], data[i]) << "Mismatch at index " << i;
+  }
+
+  // Skip 200, then read next 100
+  encoding->skip(200);
+  nimble::Vector<int32_t> result2(pool_.get(), 100);
+  encoding->materialize(100, result2.data());
+
+  for (size_t i = 0; i < 100; ++i) {
+    ASSERT_EQ(result2[i], data[300 + i]) << "Mismatch at index " << (300 + i);
+  }
+}
+
+// Test with negative numbers
+TEST_F(ForEncodingTest, NegativeNumbers) {
+  nimble::Vector<int32_t> data(pool_.get());
+  data.push_back(-100);
+  data.push_back(-50);
+  data.push_back(-75);
+  data.push_back(-25);
+  data.push_back(-1);
+  data.push_back(-99);
+
+  auto encoding = createEncoding(data);
+  ASSERT_EQ(encoding->rowCount(), 6);
+
+  nimble::Vector<int32_t> result(pool_.get(), 6);
+  encoding->materialize(6, result.data());
+
+  for (size_t i = 0; i < data.size(); ++i) {
+    ASSERT_EQ(result[i], data[i]) << "Mismatch at index " << i;
+  }
+}
+
+// Test with mixed positive and negative numbers
+TEST_F(ForEncodingTest, MixedSignNumbers) {
+  nimble::Vector<int32_t> data(pool_.get());
+  data.push_back(-100);
+  data.push_back(100);
+  data.push_back(-50);
+  data.push_back(50);
+  data.push_back(0);
+  data.push_back(-25);
+
+  auto encoding = createEncoding(data);
+  ASSERT_EQ(encoding->rowCount(), 6);
+
+  nimble::Vector<int32_t> result(pool_.get(), 6);
+  encoding->materialize(6, result.data());
+
+  for (size_t i = 0; i < data.size(); ++i) {
+    ASSERT_EQ(result[i], data[i]) << "Mismatch at index " << i;
+  }
+}
+
+// Test unsigned types
+TEST_F(ForEncodingTest, UnsignedTypes) {
+  nimble::Vector<uint32_t> data(pool_.get());
+  for (uint32_t i = 0; i < 256; ++i) {
+    data.push_back(1000 + i);
+  }
+
+  auto encoding = createEncoding(data);
+  ASSERT_EQ(encoding->rowCount(), 256);
+
+  nimble::Vector<uint32_t> result(pool_.get(), 256);
+  encoding->materialize(256, result.data());
+
+  for (size_t i = 0; i < data.size(); ++i) {
+    ASSERT_EQ(result[i], data[i]) << "Mismatch at index " << i;
+  }
+}
+
+// Test very large values (requiring 64-bit width)
+TEST_F(ForEncodingTest, LargeValues) {
+  nimble::Vector<int64_t> data(pool_.get());
+  data.push_back(0);
+  data.push_back(1LL << 30); // ~1 billion
+  data.push_back(1LL << 31); // ~2 billion
+  data.push_back(1LL << 32); // ~4 billion
+  data.push_back((1LL << 33) - 1);
+
+  auto encoding = createEncoding(data);
+  ASSERT_EQ(encoding->rowCount(), 5);
+
+  nimble::Vector<int64_t> result(pool_.get(), 5);
+  encoding->materialize(5, result.data());
+
+  for (size_t i = 0; i < data.size(); ++i) {
+    ASSERT_EQ(result[i], data[i]) << "Mismatch at index " << i;
+  }
+}
+
+// Test skip functionality
+TEST_F(ForEncodingTest, Skip) {
+  nimble::Vector<int32_t> data(pool_.get());
+  for (int i = 0; i < 500; ++i) {
+    data.push_back(i);
+  }
+
+  auto encoding = createEncoding(data);
+
+  // Skip first 100 elements
+  encoding->skip(100);
+
+  // Read next 50
+  nimble::Vector<int32_t> result(pool_.get(), 50);
+  encoding->materialize(50, result.data());
+
+  for (size_t i = 0; i < 50; ++i) {
+    ASSERT_EQ(result[i], data[100 + i])
+        << "Mismatch at index " << (100 + i) << " after skip";
+  }
+}
+
+// Test reset and re-read
+TEST_F(ForEncodingTest, Reset) {
+  nimble::Vector<int32_t> data(pool_.get());
+  for (int i = 0; i < 100; ++i) {
+    data.push_back(i);
+  }
+
+  auto encoding = createEncoding(data);
+
+  // Read first 50
+  nimble::Vector<int32_t> result1(pool_.get(), 50);
+  encoding->materialize(50, result1.data());
+
+  // Reset
+  encoding->reset();
+
+  // Read first 50 again
+  nimble::Vector<int32_t> result2(pool_.get(), 50);
+  encoding->materialize(50, result2.data());
+
+  for (size_t i = 0; i < 50; ++i) {
+    ASSERT_EQ(result1[i], result2[i])
+        << "Reset failed - mismatch at index " << i;
+  }
+}
+
+// Test with compression
+TEST_F(ForEncodingTest, WithCompression) {
+  nimble::Vector<int32_t> data(pool_.get());
+  for (int i = 0; i < 1000; ++i) {
+    data.push_back(i % 100); // Repeating pattern
+  }
+
+  auto encoding =
+      nimble::test::Encoder<nimble::ForEncoding<int32_t>>::createEncoding(
+          *buffer_,
+          data,
+          [](uint32_t) -> void* { return nullptr; },
+          nimble::CompressionType::Zstd);
+
+  ASSERT_EQ(encoding->rowCount(), 1000);
+
+  nimble::Vector<int32_t> result(pool_.get(), 1000);
+  encoding->materialize(1000, result.data());
+
+  for (size_t i = 0; i < data.size(); ++i) {
+    ASSERT_EQ(result[i], data[i]) << "Mismatch at index " << i;
+  }
+}
+
+// Test small data (less than one frame)
+TEST_F(ForEncodingTest, SmallData) {
+  nimble::Vector<int32_t> data(pool_.get());
+  data.push_back(10);
+  data.push_back(20);
+  data.push_back(15);
+
+  auto encoding = createEncoding(data);
+  ASSERT_EQ(encoding->rowCount(), 3);
+
+  nimble::Vector<int32_t> result(pool_.get(), 3);
+  encoding->materialize(3, result.data());
+
+  for (size_t i = 0; i < data.size(); ++i) {
+    ASSERT_EQ(result[i], data[i]) << "Mismatch at index " << i;
+  }
+}
+
+// Test exact frame boundary
+TEST_F(ForEncodingTest, ExactFrameBoundary) {
+  nimble::Vector<int32_t> data(pool_.get());
+  // Default frame size is 128
+  for (int i = 0; i < 256; ++i) { // Exactly 2 frames
+    data.push_back(i);
+  }
+
+  auto encoding = createEncoding(data);
+  ASSERT_EQ(encoding->rowCount(), 256);
+
+  nimble::Vector<int32_t> result(pool_.get(), 256);
+  encoding->materialize(256, result.data());
+
+  for (size_t i = 0; i < data.size(); ++i) {
+    ASSERT_EQ(result[i], data[i]) << "Mismatch at index " << i;
+  }
+}
+
+// Test with all data types
+TEST_F(ForEncodingTest, Int8Type) {
+  nimble::Vector<int8_t> data(pool_.get());
+  for (int8_t i = -50; i < 50; ++i) {
+    data.push_back(i);
+  }
+
+  auto encoding = createEncoding(data);
+  nimble::Vector<int8_t> result(pool_.get(), data.size());
+  encoding->materialize(data.size(), result.data());
+
+  for (size_t i = 0; i < data.size(); ++i) {
+    ASSERT_EQ(result[i], data[i]);
+  }
+}
+
+TEST_F(ForEncodingTest, Int16Type) {
+  nimble::Vector<int16_t> data(pool_.get());
+  for (int16_t i = 0; i < 500; ++i) {
+    data.push_back(i * 10);
+  }
+
+  auto encoding = createEncoding(data);
+  nimble::Vector<int16_t> result(pool_.get(), data.size());
+  encoding->materialize(data.size(), result.data());
+
+  for (size_t i = 0; i < data.size(); ++i) {
+    ASSERT_EQ(result[i], data[i]);
+  }
+}
+
+TEST_F(ForEncodingTest, Uint64Type) {
+  nimble::Vector<uint64_t> data(pool_.get());
+  for (uint64_t i = 0; i < 200; ++i) {
+    data.push_back(i * 1000000);
+  }
+
+  auto encoding = createEncoding(data);
+  nimble::Vector<uint64_t> result(pool_.get(), data.size());
+  encoding->materialize(data.size(), result.data());
+
+  for (size_t i = 0; i < data.size(); ++i) {
+    ASSERT_EQ(result[i], data[i]);
+  }
+}
+
+// Test selective reads using skip and materialize patterns
+TEST_F(ForEncodingTest, SelectiveReadsWithPattern) {
+  nimble::Vector<int32_t> data(pool_.get());
+  for (int i = 0; i < 1000; ++i) {
+    data.push_back(i * 7); // Some pattern
+  }
+
+  auto encoding = createEncoding(data);
+  ASSERT_EQ(encoding->rowCount(), 1000);
+
+  // Read indices: 0, 10, 20, 30, ..., 990 (every 10th element)
+  std::vector<int32_t> expected;
+  for (int i = 0; i < 100; ++i) {
+    expected.push_back(i * 10 * 7);
+  }
+
+  nimble::Vector<int32_t> results(pool_.get(), expected.size());
+  size_t resultIdx = 0;
+
+  for (int i = 0; i < 100; ++i) {
+    // Read one value
+    encoding->materialize(1, &results[resultIdx++]);
+
+    // Skip next 9 (unless last iteration)
+    if (i < 99) {
+      encoding->skip(9);
+    }
+  }
+
+  for (size_t i = 0; i < expected.size(); ++i) {
+    ASSERT_EQ(results[i], expected[i])
+        << "Mismatch at selective index " << i << " (row " << (i * 10) << ")";
+  }
+}
+
+// Test random access pattern with multiple resets
+TEST_F(ForEncodingTest, RandomAccessWithResets) {
+  nimble::Vector<int64_t> data(pool_.get());
+  for (int i = 0; i < 500; ++i) {
+    data.push_back(static_cast<int64_t>(i) * 100);
+  }
+
+  auto encoding = createEncoding(data);
+
+  // Read index 100
+  encoding->skip(100);
+  nimble::Vector<int64_t> result1(pool_.get(), 1);
+  encoding->materialize(1, result1.data());
+  ASSERT_EQ(result1[0], 10000);
+
+  // Reset and read index 250
+  encoding->reset();
+  encoding->skip(250);
+  nimble::Vector<int64_t> result2(pool_.get(), 1);
+  encoding->materialize(1, result2.data());
+  ASSERT_EQ(result2[0], 25000);
+
+  // Reset and read index 0
+  encoding->reset();
+  nimble::Vector<int64_t> result3(pool_.get(), 1);
+  encoding->materialize(1, result3.data());
+  ASSERT_EQ(result3[0], 0);
+
+  // Read index 499 from current position (skip 498 more)
+  encoding->skip(498);
+  nimble::Vector<int64_t> result4(pool_.get(), 1);
+  encoding->materialize(1, result4.data());
+  ASSERT_EQ(result4[0], 49900);
+}
+
+// Test sparse selective read pattern
+TEST_F(ForEncodingTest, SparseSelectiveReads) {
+  nimble::Vector<uint32_t> data(pool_.get());
+  for (uint32_t i = 0; i < 1000; ++i) {
+    data.push_back(i * i); // Quadratic values
+  }
+
+  auto encoding = createEncoding(data);
+
+  // Read specific sparse indices: 0, 100, 500, 999
+  std::vector<uint32_t> indices = {0, 100, 500, 999};
+  std::vector<uint32_t> expected;
+  for (auto idx : indices) {
+    expected.push_back(idx * idx);
+  }
+
+  nimble::Vector<uint32_t> results(pool_.get(), indices.size());
+
+  // Read index 0
+  encoding->materialize(1, &results[0]);
+
+  // Skip to 100, read it
+  encoding->skip(99);
+  encoding->materialize(1, &results[1]);
+
+  // Skip to 500, read it
+  encoding->skip(399);
+  encoding->materialize(1, &results[2]);
+
+  // Skip to 999, read it
+  encoding->skip(498);
+  encoding->materialize(1, &results[3]);
+
+  for (size_t i = 0; i < indices.size(); ++i) {
+    ASSERT_EQ(results[i], expected[i]) << "Mismatch for index " << indices[i];
+  }
+}
+
+// Test reading across frame boundaries
+TEST_F(ForEncodingTest, SelectiveAcrossFrameBoundaries) {
+  nimble::Vector<int32_t> data(pool_.get());
+  // Create data with 3 full frames (128 * 3 = 384 values)
+  for (int i = 0; i < 384; ++i) {
+    data.push_back(i);
+  }
+
+  auto encoding = createEncoding(data);
+
+  // Read values at frame boundaries
+  // Frame 0: 0-127, Frame 1: 128-255, Frame 2: 256-383
+  std::vector<uint32_t> testIndices = {
+      0, // Start of frame 0
+      63, // Middle of frame 0
+      127, // End of frame 0
+      128, // Start of frame 1
+      191, // Middle of frame 1
+      255, // End of frame 1
+      256, // Start of frame 2
+      319, // Middle of frame 2
+      383 // End of frame 2
+  };
+
+  encoding->reset();
+  nimble::Vector<int32_t> results(pool_.get(), testIndices.size());
+
+  uint32_t currentPos = 0;
+  for (size_t i = 0; i < testIndices.size(); ++i) {
+    uint32_t targetIdx = testIndices[i];
+
+    if (targetIdx > currentPos) {
+      encoding->skip(targetIdx - currentPos);
+      currentPos = targetIdx;
+    } else if (targetIdx < currentPos) {
+      // Need to reset and skip from beginning
+      encoding->reset();
+      encoding->skip(targetIdx);
+      currentPos = targetIdx;
+    }
+
+    encoding->materialize(1, &results[i]);
+    currentPos++;
+  }
+
+  for (size_t i = 0; i < testIndices.size(); ++i) {
+    ASSERT_EQ(results[i], static_cast<int32_t>(testIndices[i]))
+        << "Mismatch at frame boundary index " << testIndices[i];
+  }
+}
+
+// Test selective read with varying bit widths across frames
+TEST_F(ForEncodingTest, SelectiveWithVaryingBitWidths) {
+  nimble::Vector<int64_t> data(pool_.get());
+
+  // Frame 0: small range (1-bit width)
+  for (int i = 0; i < 128; ++i) {
+    data.push_back(1000 + (i % 2));
+  }
+
+  // Frame 1: medium range (8-bit width)
+  for (int i = 0; i < 128; ++i) {
+    data.push_back(2000 + (i % 200));
+  }
+
+  // Frame 2: large range (32-bit width)
+  for (int i = 0; i < 128; ++i) {
+    data.push_back(1000000000LL + i);
+  }
+
+  auto encoding = createEncoding(data);
+
+  // Selectively read from each frame
+  std::vector<std::pair<uint32_t, int64_t>> tests = {
+      {50, 1000 + (50 % 2)}, // From frame 0
+      {150, 2000 + (22 % 200)}, // From frame 1 (150 - 128 = 22)
+      {300, 1000000000LL + (300 - 256)} // From frame 2 (300 - 256 = 44)
+  };
+
+  encoding->reset();
+  for (const auto& [index, expectedValue] : tests) {
+    encoding->reset();
+    encoding->skip(index);
+
+    nimble::Vector<int64_t> result(pool_.get(), 1);
+    encoding->materialize(1, result.data());
+
+    ASSERT_EQ(result[0], expectedValue) << "Mismatch at index " << index;
+  }
+}
+
+// Test batch selective reads
+TEST_F(ForEncodingTest, BatchSelectiveReads) {
+  nimble::Vector<int32_t> data(pool_.get());
+  for (int i = 0; i < 1000; ++i) {
+    data.push_back(i * 3);
+  }
+
+  auto encoding = createEncoding(data);
+
+  // Read batches: [0-9], [100-109], [500-509], [900-909]
+  std::vector<std::pair<uint32_t, uint32_t>> ranges = {
+      {0, 10}, {100, 10}, {500, 10}, {900, 10}};
+
+  for (const auto& [start, count] : ranges) {
+    encoding->reset();
+    encoding->skip(start);
+
+    nimble::Vector<int32_t> result(pool_.get(), count);
+    encoding->materialize(count, result.data());
+
+    for (uint32_t i = 0; i < count; ++i) {
+      uint32_t expectedIdx = start + i;
+      ASSERT_EQ(result[i], static_cast<int32_t>(expectedIdx * 3))
+          << "Mismatch in batch starting at " << start << ", position " << i;
+    }
+  }
+}
+
+// readWithVisitor() is implemented and supports O(1) random access.
+// Full testing requires Velox's SelectiveColumnReader infrastructure.
+// Tests above verify the O(1) access through skip() and materialize().

--- a/dwio/nimble/encodings/tests/FrequencyPartitionEncodingTest.cpp
+++ b/dwio/nimble/encodings/tests/FrequencyPartitionEncodingTest.cpp
@@ -1,0 +1,641 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "dwio/nimble/encodings/FrequencyPartitionEncoding.h"
+#include <glog/logging.h>
+#include <gtest/gtest.h>
+#include <algorithm>
+#include <memory>
+#include <random>
+#include "dwio/nimble/common/Buffer.h"
+#include "dwio/nimble/common/Vector.h"
+#include "dwio/nimble/encodings/tests/TestUtils.h"
+#include "folly/Random.h"
+#include "velox/common/memory/Memory.h"
+
+using namespace facebook;
+
+class FrequencyPartitionEncodingTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    pool_ = velox::memory::deprecatedAddDefaultLeafMemoryPool();
+    buffer_ = std::make_unique<nimble::Buffer>(*pool_);
+  }
+
+  template <typename T>
+  std::unique_ptr<nimble::Encoding> createEncoding(
+      const nimble::Vector<T>& data) {
+    return nimble::test::Encoder<nimble::FrequencyPartitionEncoding<T>>::
+        createEncoding(
+            *buffer_, data, nullptr, nimble::CompressionType::Uncompressed);
+  }
+
+  template <typename T>
+  std::unique_ptr<nimble::Encoding> createEncodingWithIndex(
+      const nimble::Vector<T>& data,
+      nimble::FreqPartIndexType indexType) {
+    nimble::Encoding::Options opts{};
+    opts.frequencyPartitionIndex = static_cast<uint8_t>(indexType);
+    return nimble::test::Encoder<nimble::FrequencyPartitionEncoding<T>>::
+        createEncoding(
+            *buffer_,
+            data,
+            nullptr,
+            nimble::CompressionType::Uncompressed,
+            opts);
+  }
+
+  std::shared_ptr<velox::memory::MemoryPool> pool_;
+  std::unique_ptr<nimble::Buffer> buffer_;
+};
+
+// Test basic encode/decode with simple data
+TEST_F(FrequencyPartitionEncodingTest, BasicEncodeDecode) {
+  nimble::Vector<int32_t> data(pool_.get());
+  data.push_back(1);
+  data.push_back(2);
+  data.push_back(1);
+  data.push_back(3);
+  data.push_back(1);
+  data.push_back(2);
+
+  auto encoding = createEncoding(data);
+  ASSERT_EQ(encoding->encodingType(), nimble::EncodingType::FrequencyPartition);
+  ASSERT_EQ(encoding->dataType(), nimble::DataType::Int32);
+  ASSERT_EQ(encoding->rowCount(), 6);
+
+  nimble::Vector<int32_t> result(pool_.get(), 6);
+  encoding->materialize(6, result.data());
+
+  // FrequencyPartitionEncoding reorders data by frequency tiers
+  // So we compare sorted values instead of maintaining original order
+  std::vector<int32_t> sortedData(data.begin(), data.end());
+  std::vector<int32_t> sortedResult(result.begin(), result.end());
+  std::sort(sortedData.begin(), sortedData.end());
+  std::sort(sortedResult.begin(), sortedResult.end());
+
+  ASSERT_EQ(sortedData.size(), sortedResult.size());
+  for (size_t i = 0; i < sortedData.size(); ++i) {
+    ASSERT_EQ(sortedResult[i], sortedData[i])
+        << "Mismatch at sorted index " << i;
+  }
+}
+
+// Test with Zipfian distribution (skewed frequencies)
+TEST_F(FrequencyPartitionEncodingTest, ZipfianDistribution) {
+  auto seed = folly::Random::rand32();
+  LOG(INFO) << "seed: " << seed;
+  std::mt19937 rng(seed);
+
+  const int numValues = 10000;
+  const int numUniqueValues = 100;
+
+  nimble::Vector<int64_t> data(pool_.get());
+
+  // Create Zipfian distribution: first values appear much more frequently
+  std::vector<int> frequencies(numUniqueValues);
+  for (int i = 0; i < numUniqueValues; ++i) {
+    frequencies[i] = numUniqueValues - i; // Descending frequency
+  }
+
+  // Generate data according to frequencies
+  for (int i = 0; i < numValues; ++i) {
+    int totalFreq = numUniqueValues * (numUniqueValues + 1) / 2;
+    int rand = rng() % totalFreq;
+    int cumulative = 0;
+    for (int j = 0; j < numUniqueValues; ++j) {
+      cumulative += frequencies[j];
+      if (rand < cumulative) {
+        data.push_back(j);
+        break;
+      }
+    }
+  }
+
+  auto encoding = createEncoding(data);
+  ASSERT_EQ(encoding->rowCount(), numValues);
+
+  nimble::Vector<int64_t> result(pool_.get(), numValues);
+  encoding->materialize(numValues, result.data());
+
+  // FrequencyPartitionEncoding reorders data by frequency tiers
+  std::vector<int64_t> sortedData(data.begin(), data.end());
+  std::vector<int64_t> sortedResult(result.begin(), result.end());
+  std::sort(sortedData.begin(), sortedData.end());
+  std::sort(sortedResult.begin(), sortedResult.end());
+
+  ASSERT_EQ(sortedData.size(), sortedResult.size());
+  for (size_t i = 0; i < sortedData.size(); ++i) {
+    ASSERT_EQ(sortedResult[i], sortedData[i])
+        << "Mismatch at sorted index " << i;
+  }
+}
+
+// Test with uniform distribution
+TEST_F(FrequencyPartitionEncodingTest, UniformDistribution) {
+  auto seed = folly::Random::rand32();
+  LOG(INFO) << "seed: " << seed;
+  std::mt19937 rng(seed);
+  std::uniform_int_distribution<uint32_t> dist(0, 999);
+
+  const int numValues = 5000;
+  nimble::Vector<uint32_t> data(pool_.get());
+
+  for (int i = 0; i < numValues; ++i) {
+    data.push_back(dist(rng));
+  }
+
+  auto encoding = createEncoding(data);
+  ASSERT_EQ(encoding->rowCount(), numValues);
+
+  nimble::Vector<uint32_t> result(pool_.get(), numValues);
+  encoding->materialize(numValues, result.data());
+
+  // FrequencyPartitionEncoding reorders data by frequency tiers
+  std::vector<uint32_t> sortedData(data.begin(), data.end());
+  std::vector<uint32_t> sortedResult(result.begin(), result.end());
+  std::sort(sortedData.begin(), sortedData.end());
+  std::sort(sortedResult.begin(), sortedResult.end());
+
+  ASSERT_EQ(sortedData.size(), sortedResult.size());
+  for (size_t i = 0; i < sortedData.size(); ++i) {
+    ASSERT_EQ(sortedResult[i], sortedData[i])
+        << "Mismatch at sorted index " << i;
+  }
+}
+
+// Test with all identical values (extreme case)
+TEST_F(FrequencyPartitionEncodingTest, AllIdenticalValues) {
+  const int numValues = 1000;
+  nimble::Vector<int32_t> data(pool_.get());
+
+  for (int i = 0; i < numValues; ++i) {
+    data.push_back(42);
+  }
+
+  auto encoding = createEncoding(data);
+  ASSERT_EQ(encoding->rowCount(), numValues);
+
+  nimble::Vector<int32_t> result(pool_.get(), numValues);
+  encoding->materialize(numValues, result.data());
+
+  for (size_t i = 0; i < data.size(); ++i) {
+    ASSERT_EQ(result[i], 42) << "Mismatch at index " << i;
+  }
+}
+
+// Test with single value
+TEST_F(FrequencyPartitionEncodingTest, SingleValue) {
+  nimble::Vector<int64_t> data(pool_.get());
+  data.push_back(123);
+
+  auto encoding = createEncoding(data);
+  ASSERT_EQ(encoding->rowCount(), 1);
+
+  nimble::Vector<int64_t> result(pool_.get(), 1);
+  encoding->materialize(1, result.data());
+
+  ASSERT_EQ(result[0], 123);
+}
+
+// Test incremental materialization (reset and partial reads)
+TEST_F(FrequencyPartitionEncodingTest, IncrementalMaterialization) {
+  nimble::Vector<uint64_t> data(pool_.get());
+  for (uint64_t i = 0; i < 100; ++i) {
+    data.push_back(i % 10); // 10 unique values, repeated
+  }
+
+  auto encoding = createEncoding(data);
+  nimble::Vector<uint64_t> result(pool_.get(), 100);
+
+  // Read all data at once
+  encoding->materialize(100, result.data());
+
+  // Verify all values are present (compare sorted)
+  std::vector<uint64_t> sortedData(data.begin(), data.end());
+  std::vector<uint64_t> sortedResult(result.begin(), result.end());
+  std::sort(sortedData.begin(), sortedData.end());
+  std::sort(sortedResult.begin(), sortedResult.end());
+
+  ASSERT_EQ(sortedData.size(), sortedResult.size());
+  for (size_t i = 0; i < sortedData.size(); ++i) {
+    ASSERT_EQ(sortedResult[i], sortedData[i])
+        << "Mismatch at sorted index " << i;
+  }
+
+  // Test reset functionality
+  encoding->reset();
+  encoding->materialize(100, result.data());
+
+  // Verify reset works - should get same reordered data again
+  std::vector<uint64_t> sortedResult2(result.begin(), result.end());
+  std::sort(sortedResult2.begin(), sortedResult2.end());
+  for (size_t i = 0; i < sortedData.size(); ++i) {
+    ASSERT_EQ(sortedResult2[i], sortedData[i])
+        << "Reset mismatch at sorted index " << i;
+  }
+}
+
+// Test with large values (to test different tier sizes)
+TEST_F(FrequencyPartitionEncodingTest, LargeValues) {
+  nimble::Vector<uint64_t> data(pool_.get());
+
+  // Add values that require different bit widths
+  data.push_back(1ULL); // 1 bit
+  data.push_back(255ULL); // 8 bits
+  data.push_back(65535ULL); // 16 bits
+  data.push_back(4294967295ULL); // 32 bits
+  data.push_back(18446744073709551615ULL); // 64 bits
+  data.push_back(1ULL); // Repeat small value
+
+  auto encoding = createEncoding(data);
+  ASSERT_EQ(encoding->rowCount(), 6);
+
+  nimble::Vector<uint64_t> result(pool_.get(), 6);
+  encoding->materialize(6, result.data());
+
+  // FrequencyPartitionEncoding reorders data by frequency tiers
+  std::vector<uint64_t> sortedData(data.begin(), data.end());
+  std::vector<uint64_t> sortedResult(result.begin(), result.end());
+  std::sort(sortedData.begin(), sortedData.end());
+  std::sort(sortedResult.begin(), sortedResult.end());
+
+  ASSERT_EQ(sortedData.size(), sortedResult.size());
+  for (size_t i = 0; i < sortedData.size(); ++i) {
+    ASSERT_EQ(sortedResult[i], sortedData[i])
+        << "Large value mismatch at sorted index " << i;
+  }
+}
+
+// Test with floating point values
+TEST_F(FrequencyPartitionEncodingTest, FloatValues) {
+  nimble::Vector<float> data(pool_.get());
+  data.push_back(1.5f);
+  data.push_back(2.7f);
+  data.push_back(1.5f);
+  data.push_back(3.14f);
+  data.push_back(1.5f);
+  data.push_back(2.7f);
+
+  auto encoding = createEncoding(data);
+  ASSERT_EQ(encoding->rowCount(), 6);
+
+  nimble::Vector<float> result(pool_.get(), 6);
+  encoding->materialize(6, result.data());
+
+  // FrequencyPartitionEncoding reorders data by frequency tiers
+  std::vector<float> sortedData(data.begin(), data.end());
+  std::vector<float> sortedResult(result.begin(), result.end());
+  std::sort(sortedData.begin(), sortedData.end());
+  std::sort(sortedResult.begin(), sortedResult.end());
+
+  ASSERT_EQ(sortedData.size(), sortedResult.size());
+  for (size_t i = 0; i < sortedData.size(); ++i) {
+    ASSERT_EQ(sortedResult[i], sortedData[i])
+        << "Float mismatch at sorted index " << i;
+  }
+}
+
+// Test with double values
+TEST_F(FrequencyPartitionEncodingTest, DoubleValues) {
+  nimble::Vector<double> data(pool_.get());
+  data.push_back(1.5);
+  data.push_back(2.7);
+  data.push_back(1.5);
+  data.push_back(3.14159265359);
+  data.push_back(1.5);
+
+  auto encoding = createEncoding(data);
+  ASSERT_EQ(encoding->rowCount(), 5);
+
+  nimble::Vector<double> result(pool_.get(), 5);
+  encoding->materialize(5, result.data());
+
+  // FrequencyPartitionEncoding reorders data by frequency tiers
+  std::vector<double> sortedData(data.begin(), data.end());
+  std::vector<double> sortedResult(result.begin(), result.end());
+  std::sort(sortedData.begin(), sortedData.end());
+  std::sort(sortedResult.begin(), sortedResult.end());
+
+  ASSERT_EQ(sortedData.size(), sortedResult.size());
+  for (size_t i = 0; i < sortedData.size(); ++i) {
+    ASSERT_EQ(sortedResult[i], sortedData[i])
+        << "Double mismatch at sorted index " << i;
+  }
+}
+
+// Test encoding layout capture
+TEST_F(FrequencyPartitionEncodingTest, EncodingLayout) {
+  nimble::Vector<int32_t> data(pool_.get());
+  for (int i = 0; i < 100; ++i) {
+    data.push_back(i % 10);
+  }
+
+  auto encoding = createEncoding(data);
+
+  // Verify the encoding type is correct
+  ASSERT_EQ(encoding->encodingType(), nimble::EncodingType::FrequencyPartition);
+
+  // The encoding should have nested encodings for:
+  // - Tier assignments
+  // - Tier dictionaries
+  // - Tier data
+  // Exact structure depends on data distribution
+}
+
+// Test with edge case: maximum tier count
+TEST_F(FrequencyPartitionEncodingTest, MaximumTiers) {
+  nimble::Vector<uint8_t> data(pool_.get());
+
+  // Create data with many unique values to potentially trigger maximum tiers
+  for (int i = 0; i < 256; ++i) {
+    data.push_back(static_cast<uint8_t>(i));
+  }
+
+  auto encoding = createEncoding(data);
+  ASSERT_EQ(encoding->rowCount(), 256);
+
+  nimble::Vector<uint8_t> result(pool_.get(), 256);
+  encoding->materialize(256, result.data());
+
+  // FrequencyPartitionEncoding reorders data by frequency tiers
+  std::vector<uint8_t> sortedData(data.begin(), data.end());
+  std::vector<uint8_t> sortedResult(result.begin(), result.end());
+  std::sort(sortedData.begin(), sortedData.end());
+  std::sort(sortedResult.begin(), sortedResult.end());
+
+  ASSERT_EQ(sortedData.size(), sortedResult.size());
+  for (size_t i = 0; i < sortedData.size(); ++i) {
+    ASSERT_EQ(sortedResult[i], sortedData[i])
+        << "Max tiers mismatch at sorted index " << i;
+  }
+}
+
+// Test with empty-like data (very sparse)
+TEST_F(FrequencyPartitionEncodingTest, SparseData) {
+  nimble::Vector<int64_t> data(pool_.get());
+
+  // Mostly zeros with occasional other values
+  for (int i = 0; i < 1000; ++i) {
+    if (i % 100 == 0) {
+      data.push_back(i);
+    } else {
+      data.push_back(0);
+    }
+  }
+
+  auto encoding = createEncoding(data);
+  ASSERT_EQ(encoding->rowCount(), 1000);
+
+  nimble::Vector<int64_t> result(pool_.get(), 1000);
+  encoding->materialize(1000, result.data());
+
+  // FrequencyPartitionEncoding reorders data by frequency tiers
+  std::vector<int64_t> sortedData(data.begin(), data.end());
+  std::vector<int64_t> sortedResult(result.begin(), result.end());
+  std::sort(sortedData.begin(), sortedData.end());
+  std::sort(sortedResult.begin(), sortedResult.end());
+
+  ASSERT_EQ(sortedData.size(), sortedResult.size());
+  for (size_t i = 0; i < sortedData.size(); ++i) {
+    ASSERT_EQ(sortedResult[i], sortedData[i])
+        << "Sparse data mismatch at sorted index " << i;
+  }
+}
+
+// =============================================================================
+// Indexed mode tests — verify EXACT original order reconstruction
+// =============================================================================
+
+// Helper: run the same round-trip test for any index type and value type.
+// Encodes `data`, decodes with materialize(), verifies exact original order.
+// Also verifies skip() + partial materialize() correctness.
+template <typename T>
+static void testIndexedRoundTrip(
+    velox::memory::MemoryPool* pool,
+    nimble::Buffer& buffer,
+    const nimble::Vector<T>& data,
+    nimble::FreqPartIndexType indexType) {
+  nimble::Encoding::Options opts{};
+  opts.frequencyPartitionIndex = static_cast<uint8_t>(indexType);
+  auto encoding = nimble::test::Encoder<nimble::FrequencyPartitionEncoding<T>>::
+      createEncoding(
+          buffer, data, nullptr, nimble::CompressionType::Uncompressed, opts);
+
+  const uint32_t N = static_cast<uint32_t>(data.size());
+  ASSERT_EQ(encoding->rowCount(), N);
+
+  // 1. Full materialize — must match original order exactly.
+  nimble::Vector<T> result(pool, N);
+  encoding->materialize(N, result.data());
+  for (uint32_t i = 0; i < N; ++i) {
+    ASSERT_EQ(result[i], data[i]) << "Full materialize mismatch at index " << i;
+  }
+
+  // 2. Reset and partial reads.
+  encoding->reset();
+  if (N >= 4) {
+    const uint32_t half = N / 2;
+    nimble::Vector<T> first(pool, half);
+    nimble::Vector<T> second(pool, N - half);
+    encoding->materialize(half, first.data());
+    encoding->materialize(N - half, second.data());
+    for (uint32_t i = 0; i < half; ++i)
+      ASSERT_EQ(first[i], data[i])
+          << "Partial read (first half) mismatch at " << i;
+    for (uint32_t i = 0; i < N - half; ++i)
+      ASSERT_EQ(second[i], data[half + i])
+          << "Partial read (second half) mismatch at " << i;
+  }
+
+  // 3. Skip + materialize.
+  if (N >= 3) {
+    encoding->reset();
+    encoding->skip(1);
+    nimble::Vector<T> afterSkip(pool, N - 1);
+    encoding->materialize(N - 1, afterSkip.data());
+    for (uint32_t i = 0; i < N - 1; ++i)
+      ASSERT_EQ(afterSkip[i], data[1 + i]) << "After-skip mismatch at " << i;
+  }
+}
+
+// Build a skewed dataset: a few values appear frequently, rest appear once.
+template <typename T>
+static nimble::Vector<T> makeSkewedData(
+    velox::memory::MemoryPool* pool,
+    uint32_t n,
+    uint32_t numFrequent,
+    uint32_t numRare) {
+  nimble::Vector<T> data(pool);
+  data.reserve(n);
+  std::mt19937 rng(42);
+  // Fill with frequent values (random selection among 0..numFrequent-1)
+  uint32_t rareCount = std::min(numRare, n);
+  uint32_t freqCount = n - rareCount;
+  std::uniform_int_distribution<uint32_t> freqDist(0, numFrequent - 1);
+  for (uint32_t i = 0; i < freqCount; ++i)
+    data.push_back(static_cast<T>(freqDist(rng)));
+  // Append rare values (large unique values past frequent range)
+  for (uint32_t i = 0; i < rareCount; ++i)
+    data.push_back(static_cast<T>(numFrequent + i));
+  // Shuffle to interleave frequent and rare
+  std::shuffle(data.begin(), data.end(), rng);
+  return data;
+}
+
+TEST_F(FrequencyPartitionEncodingTest, IndexedPerTierBitmaps_int32) {
+  auto data = makeSkewedData<int32_t>(pool_.get(), 500, 4, 20);
+  testIndexedRoundTrip(
+      pool_.get(), *buffer_, data, nimble::FreqPartIndexType::PerTierBitmaps);
+}
+
+TEST_F(FrequencyPartitionEncodingTest, IndexedTierTagArray_int32) {
+  auto data = makeSkewedData<int32_t>(pool_.get(), 500, 4, 20);
+  testIndexedRoundTrip(
+      pool_.get(), *buffer_, data, nimble::FreqPartIndexType::TierTagArray);
+}
+
+TEST_F(FrequencyPartitionEncodingTest, IndexedEliasFano_int32) {
+  auto data = makeSkewedData<int32_t>(pool_.get(), 500, 4, 20);
+  testIndexedRoundTrip(
+      pool_.get(), *buffer_, data, nimble::FreqPartIndexType::EliasFano);
+}
+
+TEST_F(FrequencyPartitionEncodingTest, IndexedNoIndex_preservesTierOrder) {
+  // NoIndex stays backward-compatible (sorted-multiset equality, not exact
+  // order).
+  nimble::Vector<int32_t> data(pool_.get());
+  for (int i = 0; i < 200; ++i)
+    data.push_back(i % 5);
+
+  auto encoding = createEncoding(data); // default = NoIndex
+  ASSERT_EQ(encoding->rowCount(), 200u);
+
+  nimble::Vector<int32_t> result(pool_.get(), 200);
+  encoding->materialize(200, result.data());
+
+  std::vector<int32_t> sortedData(data.begin(), data.end());
+  std::vector<int32_t> sortedResult(result.begin(), result.end());
+  std::sort(sortedData.begin(), sortedData.end());
+  std::sort(sortedResult.begin(), sortedResult.end());
+  ASSERT_EQ(sortedData, sortedResult);
+}
+
+TEST_F(FrequencyPartitionEncodingTest, IndexedPerTierBitmaps_uint8) {
+  auto data = makeSkewedData<uint8_t>(pool_.get(), 300, 3, 10);
+  testIndexedRoundTrip(
+      pool_.get(), *buffer_, data, nimble::FreqPartIndexType::PerTierBitmaps);
+}
+
+TEST_F(FrequencyPartitionEncodingTest, IndexedTierTagArray_uint64) {
+  auto data = makeSkewedData<uint64_t>(pool_.get(), 400, 8, 30);
+  testIndexedRoundTrip(
+      pool_.get(), *buffer_, data, nimble::FreqPartIndexType::TierTagArray);
+}
+
+TEST_F(FrequencyPartitionEncodingTest, IndexedEliasFano_uint64) {
+  auto data = makeSkewedData<uint64_t>(pool_.get(), 400, 8, 30);
+  testIndexedRoundTrip(
+      pool_.get(), *buffer_, data, nimble::FreqPartIndexType::EliasFano);
+}
+
+TEST_F(FrequencyPartitionEncodingTest, IndexedAllIdentical_PerTierBitmaps) {
+  // Edge case: all same value → one tier, no fallback.
+  nimble::Vector<int32_t> data(pool_.get());
+  for (int i = 0; i < 100; ++i)
+    data.push_back(7);
+  testIndexedRoundTrip(
+      pool_.get(), *buffer_, data, nimble::FreqPartIndexType::PerTierBitmaps);
+}
+
+TEST_F(FrequencyPartitionEncodingTest, IndexedAllUnique_EliasFano) {
+  // Edge case: all unique values → no tiers, all fallback.
+  nimble::Vector<int32_t> data(pool_.get());
+  for (int i = 0; i < 50; ++i)
+    data.push_back(i * 1000);
+  testIndexedRoundTrip(
+      pool_.get(), *buffer_, data, nimble::FreqPartIndexType::EliasFano);
+}
+
+TEST_F(FrequencyPartitionEncodingTest, IndexedSingleElement_TierTagArray) {
+  nimble::Vector<int32_t> data(pool_.get());
+  data.push_back(42);
+  testIndexedRoundTrip(
+      pool_.get(), *buffer_, data, nimble::FreqPartIndexType::TierTagArray);
+}
+
+TEST_F(FrequencyPartitionEncodingTest, IndexedLargeSkewed_AllThreeModes) {
+  // Larger dataset; verify all three indexed modes produce the same output.
+  const uint32_t N = 2000;
+  auto data = makeSkewedData<int32_t>(pool_.get(), N, 6, 100);
+
+  nimble::Vector<int32_t> resultBitmaps(pool_.get(), N);
+  nimble::Vector<int32_t> resultTags(pool_.get(), N);
+  nimble::Vector<int32_t> resultEF(pool_.get(), N);
+
+  auto enc = [&](nimble::FreqPartIndexType idx) {
+    nimble::Encoding::Options opts{};
+    opts.frequencyPartitionIndex = static_cast<uint8_t>(idx);
+    return nimble::test::Encoder<nimble::FrequencyPartitionEncoding<int32_t>>::
+        createEncoding(
+            *buffer_,
+            data,
+            nullptr,
+            nimble::CompressionType::Uncompressed,
+            opts);
+  };
+
+  enc(nimble::FreqPartIndexType::PerTierBitmaps)
+      ->materialize(N, resultBitmaps.data());
+  enc(nimble::FreqPartIndexType::TierTagArray)
+      ->materialize(N, resultTags.data());
+  enc(nimble::FreqPartIndexType::EliasFano)->materialize(N, resultEF.data());
+
+  for (uint32_t i = 0; i < N; ++i) {
+    ASSERT_EQ(resultBitmaps[i], data[i]) << "Bitmaps mismatch at " << i;
+    ASSERT_EQ(resultTags[i], data[i]) << "TagArray mismatch at " << i;
+    ASSERT_EQ(resultEF[i], data[i]) << "EliasFano mismatch at " << i;
+  }
+}
+
+// Test getTierForRow returns correct tier for each encoded-stream position.
+//
+// Data layout after encoding (NoIndex, tier-order):
+//   Tier 0 (keyBits=1, cap=2): values {1,2} → 12 rows, startRow=0, size=12
+//   Tier 1 (keyBits=2, cap=4): values {3,4} →  3 rows, startRow=12, size=3
+//   Fallback: none; row 15 is past the end → returns tiers_.size() == 2
+TEST_F(FrequencyPartitionEncodingTest, GetTierForRow) {
+  nimble::Vector<int32_t> data(pool_.get());
+  for (int i = 0; i < 8; ++i)
+    data.push_back(1);
+  for (int i = 0; i < 4; ++i)
+    data.push_back(2);
+  for (int i = 0; i < 2; ++i)
+    data.push_back(3);
+  data.push_back(4);
+
+  auto encoding = createEncoding(data);
+  auto* fpe =
+      static_cast<nimble::FrequencyPartitionEncoding<int32_t>*>(encoding.get());
+
+  // Tier 0: encoded rows 0–11
+  EXPECT_EQ(fpe->getTierForRow(0), 0u);
+  EXPECT_EQ(fpe->getTierForRow(11), 0u);
+  // Tier 1: encoded rows 12–14
+  EXPECT_EQ(fpe->getTierForRow(12), 1u);
+  EXPECT_EQ(fpe->getTierForRow(14), 1u);
+  // Beyond all tiers → fallback sentinel
+  EXPECT_EQ(fpe->getTierForRow(15), 2u);
+}

--- a/dwio/nimble/encodings/tests/MainlyConstantEncodingTest.cpp
+++ b/dwio/nimble/encodings/tests/MainlyConstantEncodingTest.cpp
@@ -35,9 +35,57 @@ struct TestConfig {
 
 #define TC(T) TestConfig<T, false>, TestConfig<T, true>
 
+// Forward declaration
+template <typename Config>
+class MainlyConstantEncodingTest;
+
+// Helper to prepare values - must be at namespace scope
+template <typename T, typename TestClass>
+struct MainlyConstantValuesPreparer {
+  static std::vector<nimble::Vector<T>> prepareValues(TestClass* test) {
+    FAIL() << "unspecialized prepareValues() should not be called";
+    return {};
+  }
+};
+
+template <typename TestClass>
+struct MainlyConstantValuesPreparer<double, TestClass> {
+  static std::vector<nimble::Vector<double>> prepareValues(TestClass* test) {
+    return {
+        test->toVector({0.0}),
+        test->toVector({0.0, 0.00, 0.12}),
+        test->toVector({-2.1, -2.1, -2.3, -2.1, -2.1}),
+        test->toVector(
+            {test->dNaN0, test->dNaN0, test->dNaN1, test->dNaN2, test->dNaN0})};
+  }
+};
+
+template <typename TestClass>
+struct MainlyConstantValuesPreparer<float, TestClass> {
+  static std::vector<nimble::Vector<float>> prepareValues(TestClass* test) {
+    return {
+        test->toVector({0.0f}),
+        test->toVector({0.0f, 0.00f, 0.12f}),
+        test->toVector({-2.1f, -2.1f, -2.3f, -2.1f, -2.1f}),
+        test->toVector(
+            {test->fNaN0, test->fNaN0, test->fNaN1, test->fNaN2, test->fNaN2})};
+  }
+};
+
+template <typename TestClass>
+struct MainlyConstantValuesPreparer<int32_t, TestClass> {
+  static std::vector<nimble::Vector<int32_t>> prepareValues(TestClass* test) {
+    return {test->toVector({3, 3, 3, 1, 3})};
+  }
+};
+
 template <typename Config>
 class MainlyConstantEncodingTest : public ::testing::Test {
  protected:
+  // Make helper templates friends so they can access protected members
+  template <typename T, typename TestClass>
+  friend struct MainlyConstantValuesPreparer;
+
   void SetUp() override {
     pool_ = facebook::velox::memory::deprecatedAddDefaultLeafMemoryPool();
     buffer_ = std::make_unique<nimble::Buffer>(*pool_);
@@ -45,8 +93,8 @@ class MainlyConstantEncodingTest : public ::testing::Test {
 
   template <typename T>
   std::vector<nimble::Vector<T>> prepareValues() {
-    FAIL() << "unspecialized prepapreValues() should not be called";
-    return {};
+    return MainlyConstantValuesPreparer<T, MainlyConstantEncodingTest<Config>>::
+        prepareValues(this);
   }
 
   template <typename T>
@@ -64,33 +112,10 @@ class MainlyConstantEncodingTest : public ::testing::Test {
   double dNaN2 = ET<double>::asEncodingLogicalType(
       (ET<double>::asEncodingPhysicalType(dNaN0) | 0x3));
 
-  template <>
-  std::vector<nimble::Vector<double>> prepareValues() {
-    return {
-        toVector({0.0}),
-        toVector({0.0, 0.00, 0.12}),
-        toVector({-2.1, -2.1, -2.3, -2.1, -2.1}),
-        toVector({dNaN0, dNaN0, dNaN1, dNaN2, dNaN0})};
-  }
-
   float fNaN0 = std::numeric_limits<float>::quiet_NaN();
   float fNaN1 = std::numeric_limits<float>::signaling_NaN();
   float fNaN2 = ET<float>::asEncodingLogicalType(
       (ET<float>::asEncodingPhysicalType(fNaN0) | 0x3));
-
-  template <>
-  std::vector<nimble::Vector<float>> prepareValues() {
-    return {
-        toVector({0.0f}),
-        toVector({0.0f, 0.00f, 0.12f}),
-        toVector({-2.1f, -2.1f, -2.3f, -2.1f, -2.1f}),
-        toVector({fNaN0, fNaN0, fNaN1, fNaN2, fNaN2})};
-  }
-
-  template <>
-  std::vector<nimble::Vector<int32_t>> prepareValues() {
-    return {toVector({3, 3, 3, 1, 3})};
-  }
 
   std::shared_ptr<velox::memory::MemoryPool> pool_;
   std::unique_ptr<nimble::Buffer> buffer_;

--- a/dwio/nimble/encodings/tests/PrefixEncodingTest.cpp
+++ b/dwio/nimble/encodings/tests/PrefixEncodingTest.cpp
@@ -35,7 +35,9 @@ namespace facebook::nimble::test {
 class PrefixEncodingTest : public ::testing::Test {
  protected:
   static void SetUpTestCase() {
-    velox::memory::MemoryManager::initialize({});
+    if (!velox::memory::MemoryManager::testInstance()) {
+      velox::memory::MemoryManager::initialize({});
+    }
   }
 
   void SetUp() override {

--- a/dwio/nimble/encodings/tests/RleEncodingTest.cpp
+++ b/dwio/nimble/encodings/tests/RleEncodingTest.cpp
@@ -35,9 +35,123 @@ struct TestConfig {
 
 #define TC(T) TestConfig<T, false>, TestConfig<T, true>
 
+// Forward declaration
+template <typename Config>
+class RleEncodingTest;
+
+// Helper to prepare values - must be at namespace scope
+template <typename T, typename TestClass>
+struct RleValuesPreparer {
+  static std::vector<nimble::Vector<T>> prepareValues(TestClass* test) {
+    FAIL() << "unspecialized prepareValues() should not be called";
+    return {};
+  }
+};
+
+template <typename TestClass>
+struct RleValuesPreparer<double, TestClass> {
+  static std::vector<nimble::Vector<double>> prepareValues(TestClass* test) {
+    return {
+        test->toVector({0.0, -0.0}),
+        test->toVector(
+            {-0.0, -0.0, -0.0, -0.0, -0.0, -0.0, -0.0, -0.0, -0.0, -0.0}),
+        test->toVector(
+            {-0.0, -0.0, -0.0, +0.0, -0.0, +0.0, -0.0, -0.0, -0.0, -0.0}),
+        test->toVector(
+            {-2.1, -0.0, -0.0, 3.54, 9.87, -0.0, -0.0, -0.0, -0.0, 10.6}),
+        test->toVector(
+            {0.00, 1.11, 2.22, 3.33, 4.44, 5.55, 6.66, 7.77, 8.88, 9.99}),
+        test->toVector(
+            {test->dNaN0,
+             test->dNaN0,
+             test->dNaN0,
+             test->dNaN1,
+             test->dNaN1,
+             test->dNaN2,
+             test->dNaN3,
+             test->dNaN3,
+             test->dNaN0})};
+  }
+};
+
+template <typename TestClass>
+struct RleValuesPreparer<float, TestClass> {
+  static std::vector<nimble::Vector<float>> prepareValues(TestClass* test) {
+    return {
+        test->toVector({0.0f, -0.0f}),
+        test->toVector(
+            {-0.0f,
+             -0.0f,
+             -0.0f,
+             -0.0f,
+             -0.0f,
+             -0.0f,
+             -0.0f,
+             -0.0f,
+             -0.0f,
+             -0.0f}),
+        test->toVector(
+            {-0.0f,
+             -0.0f,
+             -0.0f,
+             +0.0f,
+             -0.0f,
+             +0.0f,
+             -0.0f,
+             -0.0f,
+             -0.0f,
+             -0.0f}),
+        test->toVector(
+            {-2.1f,
+             -0.0f,
+             -0.0f,
+             3.54f,
+             9.87f,
+             -0.0f,
+             -0.0f,
+             -0.0f,
+             -0.0f,
+             10.6f}),
+        test->toVector(
+            {0.00f,
+             1.11f,
+             2.22f,
+             3.33f,
+             4.44f,
+             5.55f,
+             6.66f,
+             7.77f,
+             8.88f,
+             9.99f}),
+        test->toVector(
+            {test->fNaN0,
+             test->fNaN0,
+             test->fNaN0,
+             test->fNaN1,
+             test->fNaN1,
+             test->fNaN2,
+             test->fNaN3,
+             test->fNaN3,
+             test->fNaN0})};
+  }
+};
+
+template <typename TestClass>
+struct RleValuesPreparer<int32_t, TestClass> {
+  static std::vector<nimble::Vector<int32_t>> prepareValues(TestClass* test) {
+    return {
+        test->toVector({2, 3, 3}),
+        test->toVector({1, 2, 2, 3, 3, 3, 4, 4, 4, 4})};
+  }
+};
+
 template <typename Config>
 class RleEncodingTest : public ::testing::Test {
  protected:
+  // Make helper templates friends so they can access protected members
+  template <typename T, typename TestClass>
+  friend struct RleValuesPreparer;
+
   void SetUp() override {
     pool_ = facebook::velox::memory::deprecatedAddDefaultLeafMemoryPool();
     buffer_ = std::make_unique<nimble::Buffer>(*pool_);
@@ -45,8 +159,7 @@ class RleEncodingTest : public ::testing::Test {
 
   template <typename T>
   std::vector<nimble::Vector<T>> prepareValues() {
-    FAIL() << "unspecialized prepapreValues() should not be called";
-    return {};
+    return RleValuesPreparer<T, RleEncodingTest<Config>>::prepareValues(this);
   }
 
   template <typename T>
@@ -66,81 +179,12 @@ class RleEncodingTest : public ::testing::Test {
   double dNaN3 = ET<double>::asEncodingLogicalType(
       (ET<double>::asEncodingPhysicalType(dNaN0) | 0x5));
 
-  template <>
-  std::vector<nimble::Vector<double>> prepareValues() {
-    return {
-        toVector({0.0, -0.0}),
-        toVector({-0.0, -0.0, -0.0, -0.0, -0.0, -0.0, -0.0, -0.0, -0.0, -0.0}),
-        toVector({-0.0, -0.0, -0.0, +0.0, -0.0, +0.0, -0.0, -0.0, -0.0, -0.0}),
-        toVector({-2.1, -0.0, -0.0, 3.54, 9.87, -0.0, -0.0, -0.0, -0.0, 10.6}),
-        toVector({0.00, 1.11, 2.22, 3.33, 4.44, 5.55, 6.66, 7.77, 8.88, 9.99}),
-        toVector(
-            {dNaN0, dNaN0, dNaN0, dNaN1, dNaN1, dNaN2, dNaN3, dNaN3, dNaN0})};
-  }
-
   float fNaN0 = std::numeric_limits<float>::quiet_NaN();
   float fNaN1 = std::numeric_limits<float>::signaling_NaN();
   float fNaN2 = ET<float>::asEncodingLogicalType(
       (ET<float>::asEncodingPhysicalType(fNaN0) | 0x3));
   float fNaN3 = ET<float>::asEncodingLogicalType(
       (ET<float>::asEncodingPhysicalType(fNaN0) | 0x5));
-
-  template <>
-  std::vector<nimble::Vector<float>> prepareValues() {
-    return {
-        toVector({0.0f, -0.0f}),
-        toVector(
-            {-0.0f,
-             -0.0f,
-             -0.0f,
-             -0.0f,
-             -0.0f,
-             -0.0f,
-             -0.0f,
-             -0.0f,
-             -0.0f,
-             -0.0f}),
-        toVector(
-            {-0.0f,
-             -0.0f,
-             -0.0f,
-             +0.0f,
-             -0.0f,
-             +0.0f,
-             -0.0f,
-             -0.0f,
-             -0.0f,
-             -0.0f}),
-        toVector(
-            {-2.1f,
-             -0.0f,
-             -0.0f,
-             3.54f,
-             9.87f,
-             -0.0f,
-             -0.0f,
-             -0.0f,
-             -0.0f,
-             10.6f}),
-        toVector(
-            {0.00f,
-             1.11f,
-             2.22f,
-             3.33f,
-             4.44f,
-             5.55f,
-             6.66f,
-             7.77f,
-             8.88f,
-             9.99f}),
-        toVector(
-            {fNaN0, fNaN0, fNaN0, fNaN1, fNaN1, fNaN2, fNaN3, fNaN3, fNaN0})};
-  }
-
-  template <>
-  std::vector<nimble::Vector<int32_t>> prepareValues() {
-    return {toVector({2, 3, 3}), toVector({1, 2, 2, 3, 3, 3, 4, 4, 4, 4})};
-  }
 
   std::shared_ptr<velox::memory::MemoryPool> pool_;
   std::unique_ptr<nimble::Buffer> buffer_;

--- a/dwio/nimble/encodings/tests/TestGenerator.cpp
+++ b/dwio/nimble/encodings/tests/TestGenerator.cpp
@@ -179,9 +179,7 @@ void writeFile(
   }
 
   for (auto compressionType :
-       {nimble::CompressionType::Uncompressed,
-        nimble::CompressionType::Zstd,
-        nimble::CompressionType::MetaInternal}) {
+       {nimble::CompressionType::Uncompressed, nimble::CompressionType::Zstd}) {
     std::string_view encoded;
     if constexpr (
         nimble::test::Encoder<E>::encodingType() ==

--- a/dwio/nimble/encodings/tests/TestUtils.h
+++ b/dwio/nimble/encodings/tests/TestUtils.h
@@ -19,6 +19,8 @@
 #include "dwio/nimble/encodings/DeltaEncoding.h"
 #include "dwio/nimble/encodings/DictionaryEncoding.h"
 #include "dwio/nimble/encodings/FixedBitWidthEncoding.h"
+#include "dwio/nimble/encodings/ForEncoding.h"
+#include "dwio/nimble/encodings/FrequencyPartitionEncoding.h"
 #include "dwio/nimble/encodings/MainlyConstantEncoding.h"
 #include "dwio/nimble/encodings/NullableEncoding.h"
 #include "dwio/nimble/encodings/RleEncoding.h"
@@ -30,6 +32,86 @@
 #include "dwio/nimble/encodings/selection/EncodingSelectionPolicy.h"
 
 namespace facebook::nimble::test {
+
+// Forward declaration of Encoder
+template <typename E>
+class Encoder;
+
+// EncodingTypeTraits must be defined at namespace scope
+template <typename E, typename T>
+struct EncodingTypeTraits {};
+
+template <typename T>
+struct EncodingTypeTraits<nimble::ConstantEncoding<T>, T> {
+  static constexpr inline nimble::EncodingType encodingType =
+      nimble::EncodingType::Constant;
+};
+
+template <typename T>
+struct EncodingTypeTraits<nimble::DeltaEncoding<T>, T> {
+  static constexpr inline nimble::EncodingType encodingType =
+      nimble::EncodingType::Delta;
+};
+
+template <typename T>
+struct EncodingTypeTraits<nimble::DictionaryEncoding<T>, T> {
+  static constexpr inline nimble::EncodingType encodingType =
+      nimble::EncodingType::Dictionary;
+};
+
+template <typename T>
+struct EncodingTypeTraits<nimble::FixedBitWidthEncoding<T>, T> {
+  static constexpr inline nimble::EncodingType encodingType =
+      nimble::EncodingType::FixedBitWidth;
+};
+
+template <typename T>
+struct EncodingTypeTraits<nimble::FrequencyPartitionEncoding<T>, T> {
+  static constexpr inline nimble::EncodingType encodingType =
+      nimble::EncodingType::FrequencyPartition;
+};
+
+template <typename T>
+struct EncodingTypeTraits<nimble::ForEncoding<T>, T> {
+  static constexpr inline nimble::EncodingType encodingType =
+      nimble::EncodingType::FOR;
+};
+
+template <typename T>
+struct EncodingTypeTraits<nimble::MainlyConstantEncoding<T>, T> {
+  static constexpr inline nimble::EncodingType encodingType =
+      nimble::EncodingType::MainlyConstant;
+};
+
+template <typename T>
+struct EncodingTypeTraits<nimble::RLEEncoding<T>, T> {
+  static constexpr inline nimble::EncodingType encodingType =
+      nimble::EncodingType::RLE;
+};
+
+template <typename T>
+struct EncodingTypeTraits<nimble::SparseBoolEncoding, T> {
+  static constexpr inline nimble::EncodingType encodingType =
+      nimble::EncodingType::SparseBool;
+};
+
+template <typename T>
+struct EncodingTypeTraits<nimble::TrivialEncoding<T>, T> {
+  static constexpr inline nimble::EncodingType encodingType =
+      nimble::EncodingType::Trivial;
+};
+
+template <typename T>
+struct EncodingTypeTraits<nimble::VarintEncoding<T>, T> {
+  static constexpr inline nimble::EncodingType encodingType =
+      nimble::EncodingType::Varint;
+};
+
+template <typename T>
+struct EncodingTypeTraits<nimble::NullableEncoding<T>, T> {
+  static constexpr inline nimble::EncodingType encodingType =
+      nimble::EncodingType::Nullable;
+};
 
 template <typename E>
 class Encoder {
@@ -111,72 +193,9 @@ class Encoder {
     CompressionType compressionType_;
   };
 
-  template <typename Encoding>
-  struct EncodingTypeTraits {};
-
-  template <>
-  struct EncodingTypeTraits<nimble::ConstantEncoding<T>> {
-    static constexpr inline nimble::EncodingType encodingType =
-        nimble::EncodingType::Constant;
-  };
-
-  template <>
-  struct EncodingTypeTraits<nimble::DeltaEncoding<T>> {
-    static constexpr inline nimble::EncodingType encodingType =
-        nimble::EncodingType::Delta;
-  };
-
-  template <>
-  struct EncodingTypeTraits<nimble::DictionaryEncoding<T>> {
-    static constexpr inline nimble::EncodingType encodingType =
-        nimble::EncodingType::Dictionary;
-  };
-
-  template <>
-  struct EncodingTypeTraits<nimble::FixedBitWidthEncoding<T>> {
-    static constexpr inline nimble::EncodingType encodingType =
-        nimble::EncodingType::FixedBitWidth;
-  };
-
-  template <>
-  struct EncodingTypeTraits<nimble::MainlyConstantEncoding<T>> {
-    static constexpr inline nimble::EncodingType encodingType =
-        nimble::EncodingType::MainlyConstant;
-  };
-
-  template <>
-  struct EncodingTypeTraits<nimble::RLEEncoding<T>> {
-    static constexpr inline nimble::EncodingType encodingType =
-        nimble::EncodingType::RLE;
-  };
-
-  template <>
-  struct EncodingTypeTraits<nimble::SparseBoolEncoding> {
-    static constexpr inline nimble::EncodingType encodingType =
-        nimble::EncodingType::SparseBool;
-  };
-
-  template <>
-  struct EncodingTypeTraits<nimble::TrivialEncoding<T>> {
-    static constexpr inline nimble::EncodingType encodingType =
-        nimble::EncodingType::Trivial;
-  };
-
-  template <>
-  struct EncodingTypeTraits<nimble::VarintEncoding<T>> {
-    static constexpr inline nimble::EncodingType encodingType =
-        nimble::EncodingType::Varint;
-  };
-
-  template <>
-  struct EncodingTypeTraits<nimble::NullableEncoding<T>> {
-    static constexpr inline nimble::EncodingType encodingType =
-        nimble::EncodingType::Nullable;
-  };
-
  public:
   static constexpr EncodingType encodingType() {
-    return EncodingTypeTraits<E>::encodingType;
+    return EncodingTypeTraits<E, T>::encodingType;
   }
 
   static std::string_view encode(
@@ -189,7 +208,7 @@ class Encoder {
     auto physicalValues = std::span<const physicalType>(
         reinterpret_cast<const physicalType*>(values.data()), values.size());
     nimble::EncodingSelection<physicalType> selection{
-        {.encodingType = EncodingTypeTraits<E>::encodingType,
+        {.encodingType = EncodingTypeTraits<E, T>::encodingType,
          .compressionPolicyFactory =
              [compressionType]() {
                return std::make_unique<TestCompressPolicy>(compressionType);
@@ -213,7 +232,7 @@ class Encoder {
     auto physicalValues = std::span<const physicalType>(
         reinterpret_cast<const physicalType*>(values.data()), values.size());
     nimble::EncodingSelection<physicalType> selection{
-        {.encodingType = EncodingTypeTraits<E>::encodingType,
+        {.encodingType = EncodingTypeTraits<E, T>::encodingType,
          .compressionPolicyFactory =
              [compressionType]() {
                return std::make_unique<TestCompressPolicy>(compressionType);

--- a/dwio/nimble/encodings/tests/TrivialEncodingTest.cpp
+++ b/dwio/nimble/encodings/tests/TrivialEncodingTest.cpp
@@ -362,7 +362,6 @@ NIMBLE_INSTANTIATE_TEST_SUITE_P(
     TrivialEncodingTestWithCompression,
     ::testing::Values(
         nimble::CompressionType::Uncompressed,
-        nimble::CompressionType::Zstd,
         nimble::CompressionType::MetaInternal),
     [](const ::testing::TestParamInfo<nimble::CompressionType>& info) {
       return nimble::toString(info.param);

--- a/dwio/nimble/fuzzer/encoding/EncodingFuzzer.h
+++ b/dwio/nimble/fuzzer/encoding/EncodingFuzzer.h
@@ -150,11 +150,13 @@ class EncodingFuzzer {
       uint32_t iterations,
       uint32_t maxRows,
       uint32_t seed,
-      bool testCompression)
+      bool testCompression,
+      const Encoding::Options& options = {})
       : iterations_{iterations},
         maxRows_{maxRows},
         seed_{seed},
-        testCompression_{testCompression} {
+        testCompression_{testCompression},
+        options_{options} {
     pool_ = velox::memory::deprecatedAddDefaultLeafMemoryPool();
     buffer_ = std::make_unique<Buffer>(*pool_);
   }
@@ -248,8 +250,8 @@ class EncodingFuzzer {
 
     std::string_view encoded;
     try {
-      encoded =
-          Encoder<EncodingClass>::encode(encodeBuffer, data, compressionType);
+      encoded = Encoder<EncodingClass>::encode(
+          encodeBuffer, data, compressionType, options_);
     } catch (const NimbleUserError& e) {
       if (e.errorCode() == error_code::IncompatibleEncoding) {
         return;
@@ -428,6 +430,7 @@ class EncodingFuzzer {
   uint32_t maxRows_;
   uint32_t seed_;
   bool testCompression_;
+  Encoding::Options options_;
   std::shared_ptr<velox::memory::MemoryPool> pool_;
   std::unique_ptr<Buffer> buffer_;
 };

--- a/dwio/nimble/fuzzer/encoding/EncodingFuzzerTest.cpp
+++ b/dwio/nimble/fuzzer/encoding/EncodingFuzzerTest.cpp
@@ -16,6 +16,9 @@
 
 /// Fuzzer tests for all Nimble encodings across supported data types.
 ///
+/// Covers: VarintEncoding, MainlyConstantEncoding, ForEncoding, and
+/// FrequencyPartitionEncoding (PerTierBitmaps, TierTagArray, EliasFano).
+///
 /// Configuration via CLI flags:
 ///   --fuzzer_iterations=N     Number of iterations per test (default: 50)
 ///   --fuzzer_max_rows=N       Maximum rows per iteration (default: 5000)
@@ -29,6 +32,8 @@
 #include "dwio/nimble/encodings/DeltaEncoding.h"
 #include "dwio/nimble/encodings/DictionaryEncoding.h"
 #include "dwio/nimble/encodings/FixedBitWidthEncoding.h"
+#include "dwio/nimble/encodings/ForEncoding.h"
+#include "dwio/nimble/encodings/FrequencyPartitionEncoding.h"
 #include "dwio/nimble/encodings/MainlyConstantEncoding.h"
 #include "dwio/nimble/encodings/RleEncoding.h"
 #include "dwio/nimble/encodings/SparseBoolEncoding.h"
@@ -261,5 +266,92 @@ TYPED_TEST(MainlyConstantFuzzerTest, correctness) {
       FLAGS_fuzzer_max_rows,
       FLAGS_fuzzer_seed,
       FLAGS_fuzzer_compression);
+  fuzzer.run();
+}
+
+// FOR: integral types only (float/string are excluded by static_assert)
+using ForTypes = ::testing::Types<
+    ForEncoding<int8_t>,
+    ForEncoding<int16_t>,
+    ForEncoding<int32_t>,
+    ForEncoding<int64_t>,
+    ForEncoding<uint8_t>,
+    ForEncoding<uint16_t>,
+    ForEncoding<uint32_t>,
+    ForEncoding<uint64_t>>;
+
+template <typename E>
+class ForFuzzerTest : public ::testing::Test {};
+TYPED_TEST_SUITE(ForFuzzerTest, ForTypes);
+
+TYPED_TEST(ForFuzzerTest, Correctness) {
+  EncodingFuzzer<TypeParam> fuzzer(
+      FLAGS_fuzzer_iterations,
+      FLAGS_fuzzer_max_rows,
+      FLAGS_fuzzer_seed,
+      FLAGS_fuzzer_compression);
+  fuzzer.run();
+}
+
+// FrequencyPartitionEncoding: indexed modes that preserve original row order.
+// NoIndex mode (tier-order output) is omitted here; its correctness is covered
+// by the deterministic tests in FrequencyPartitionEncodingTest.cpp.
+using FPETypes = ::testing::Types<
+    FrequencyPartitionEncoding<int32_t>,
+    FrequencyPartitionEncoding<uint32_t>,
+    FrequencyPartitionEncoding<int64_t>,
+    FrequencyPartitionEncoding<uint64_t>,
+    FrequencyPartitionEncoding<float>,
+    FrequencyPartitionEncoding<double>,
+    FrequencyPartitionEncoding<std::string_view>>;
+
+template <typename E>
+class FPEPerTierBitmapsFuzzerTest : public ::testing::Test {};
+TYPED_TEST_SUITE(FPEPerTierBitmapsFuzzerTest, FPETypes);
+
+TYPED_TEST(FPEPerTierBitmapsFuzzerTest, Correctness) {
+  Encoding::Options opts{};
+  opts.frequencyPartitionIndex =
+      static_cast<uint8_t>(FreqPartIndexType::PerTierBitmaps);
+  EncodingFuzzer<TypeParam> fuzzer(
+      FLAGS_fuzzer_iterations,
+      FLAGS_fuzzer_max_rows,
+      FLAGS_fuzzer_seed,
+      FLAGS_fuzzer_compression,
+      opts);
+  fuzzer.run();
+}
+
+template <typename E>
+class FPETierTagArrayFuzzerTest : public ::testing::Test {};
+TYPED_TEST_SUITE(FPETierTagArrayFuzzerTest, FPETypes);
+
+TYPED_TEST(FPETierTagArrayFuzzerTest, Correctness) {
+  Encoding::Options opts{};
+  opts.frequencyPartitionIndex =
+      static_cast<uint8_t>(FreqPartIndexType::TierTagArray);
+  EncodingFuzzer<TypeParam> fuzzer(
+      FLAGS_fuzzer_iterations,
+      FLAGS_fuzzer_max_rows,
+      FLAGS_fuzzer_seed,
+      FLAGS_fuzzer_compression,
+      opts);
+  fuzzer.run();
+}
+
+template <typename E>
+class FPEEliasFanoFuzzerTest : public ::testing::Test {};
+TYPED_TEST_SUITE(FPEEliasFanoFuzzerTest, FPETypes);
+
+TYPED_TEST(FPEEliasFanoFuzzerTest, Correctness) {
+  Encoding::Options opts{};
+  opts.frequencyPartitionIndex =
+      static_cast<uint8_t>(FreqPartIndexType::EliasFano);
+  EncodingFuzzer<TypeParam> fuzzer(
+      FLAGS_fuzzer_iterations,
+      FLAGS_fuzzer_max_rows,
+      FLAGS_fuzzer_seed,
+      FLAGS_fuzzer_compression,
+      opts);
   fuzzer.run();
 }

--- a/dwio/nimble/tools/EncodingUtilities.cpp
+++ b/dwio/nimble/tools/EncodingUtilities.cpp
@@ -49,6 +49,8 @@ void extractCompressionType(
     case EncodingType::Constant:
     case EncodingType::MainlyConstant:
     case EncodingType::Prefix:
+    case EncodingType::FrequencyPartition:
+    case EncodingType::FOR:
       break;
   }
 }
@@ -203,6 +205,10 @@ void traverseEncodings(
           0,
           "Sentinels",
           visitor);
+      break;
+    }
+    case EncodingType::FrequencyPartition:
+    case EncodingType::FOR: {
       break;
     }
   }

--- a/dwio/nimble/tools/EncodingUtilities.cpp
+++ b/dwio/nimble/tools/EncodingUtilities.cpp
@@ -208,9 +208,8 @@ void traverseEncodings(
       break;
     }
     case EncodingType::FrequencyPartition:
-    case EncodingType::FOR: {
+    case EncodingType::FOR:
       break;
-    }
   }
 }
 

--- a/dwio/nimble/velox/VeloxWriter.cpp
+++ b/dwio/nimble/velox/VeloxWriter.cpp
@@ -327,12 +327,13 @@ std::string_view encode(
                 .release()));
   }
 
+  const auto& encOpts = context.options().encodingOptions;
   if (streamData.hasNulls()) {
     std::span<const bool> notNulls = streamData.nonNulls();
     return EncodingFactory::encodeNullable(
-        std::move(policy), data, notNulls, buffer);
+        std::move(policy), data, notNulls, buffer, encOpts);
   } else {
-    return EncodingFactory::encode(std::move(policy), data, buffer);
+    return EncodingFactory::encode(std::move(policy), data, buffer, encOpts);
   }
 }
 

--- a/dwio/nimble/velox/VeloxWriterOptions.h
+++ b/dwio/nimble/velox/VeloxWriterOptions.h
@@ -17,6 +17,7 @@
 
 #include "dwio/nimble/common/MetricsLogger.h"
 #include "dwio/nimble/common/Types.h"
+#include "dwio/nimble/encodings/common/Encoding.h"
 #include "dwio/nimble/encodings/selection/EncodingSelectionPolicy.h"
 #include "dwio/nimble/index/IndexConfig.h"
 #include "dwio/nimble/velox/BufferGrowthPolicy.h"
@@ -245,6 +246,11 @@ struct VeloxWriterOptions {
   // with the goal of eventually replacing RawSizeUtils accumulation with column
   // statistics for non-deduplicated columns.
   bool enableStatsConsistencyCheck{true};
+
+  // Low-level encoding options forwarded to EncodingFactory::encode for every
+  // stream. Currently used to control the FrequencyPartitionEncoding index
+  // type (frequencyPartitionIndex field).
+  Encoding::Options encodingOptions{};
 };
 
 } // namespace facebook::nimble

--- a/dwio/nimble/velox/selective/tests/E2EFilterTest.cpp
+++ b/dwio/nimble/velox/selective/tests/E2EFilterTest.cpp
@@ -18,6 +18,7 @@
 
 #include <utility>
 
+#include "dwio/nimble/encodings/FrequencyPartitionEncoding.h"
 #include "dwio/nimble/encodings/common/EncodingLayout.h"
 #include "dwio/nimble/tablet/Constants.h"
 #include "dwio/nimble/tablet/TabletReader.h"
@@ -298,16 +299,19 @@ class E2EFilterTest
       for (column_index_t col = 0;
            col < static_cast<column_index_t>(rowType_->size());
            ++col) {
+        // Build one Trivial child slot per sub-encoding identifier used by
+        // this encoding type. The count must cover the highest identifier the
+        // encoding will request from ReplayedEncodingSelectionPolicy, or the
+        // policy throws an out-of-range error.
+        std::vector<std::optional<const EncodingLayout>> nestedLayouts(
+            nestedEncodingCount(encodingType),
+            EncodingLayout{
+                EncodingType::Trivial, {}, CompressionType::Uncompressed});
         EncodingLayout layout{
             encodingType,
             {},
             CompressionType::Uncompressed,
-            {EncodingLayout{
-                 EncodingType::Trivial, {}, CompressionType::Uncompressed},
-             EncodingLayout{
-                 EncodingType::Trivial, {}, CompressionType::Uncompressed},
-             EncodingLayout{
-                 EncodingType::Trivial, {}, CompressionType::Uncompressed}}};
+            std::move(nestedLayouts)};
         children.push_back(
             EncodingLayoutTree{
                 Kind::Scalar,
@@ -329,6 +333,12 @@ class E2EFilterTest
         ManualEncodingSelectionPolicyFactory factory(factors);
         return factory.createPolicy(dataType);
       };
+    }
+
+    // Forward the FPE index type when specified.
+    if (frequencyPartitionIndexType_.has_value()) {
+      options.encodingOptions.frequencyPartitionIndex =
+          static_cast<uint8_t>(frequencyPartitionIndexType_.value());
     }
 
     auto i = 0;
@@ -610,6 +620,11 @@ class E2EFilterTest
   // Takes precedence over encodingFactors_.
   std::optional<EncodingType> forcedEncodingType_;
 
+  // Optional FrequencyPartitionEncoding index type. When set alongside
+  // forcedEncodingType_ = FrequencyPartition, controls which positional index
+  // is written. Defaults to NoIndex when unset.
+  std::optional<FreqPartIndexType> frequencyPartitionIndexType_;
+
   // Cache infrastructure (only initialized when enableCache is true).
   std::shared_ptr<memory::MallocAllocator> allocator_;
   std::shared_ptr<cache::AsyncDataCache> cache_;
@@ -618,6 +633,54 @@ class E2EFilterTest
   std::shared_ptr<io::IoStatistics> indexIoStats_;
   std::shared_ptr<cache::ScanTracker> scanTracker_;
   std::unique_ptr<folly::CPUThreadPoolExecutor> ioExecutor_;
+
+  // Returns the number of Trivial child EncodingLayout slots to provision when
+  // building a forced EncodingLayoutTree for the given encoding type. The count
+  // must cover every sub-encoding identifier the encoding will request from
+  // ReplayedEncodingSelectionPolicy (highest identifier + 1).
+  static uint32_t nestedEncodingCount(EncodingType encodingType) {
+    switch (encodingType) {
+      case EncodingType::FrequencyPartition:
+        // Identifiers 0 (PartitionOffsets) through 14 (UnencodedValues).
+        return 15;
+      default:
+        // Delta and FOR each use identifiers 0-2; other encodings use ≤ 3.
+        return 3;
+    }
+  }
+
+  // Generates Zipfian-skewed integer data for FrequencyPartition tests: a
+  // small set of very frequent values plus rare outliers, which is the workload
+  // FrequencyPartitionEncoding is optimised for.
+  void makeFrequencyPartitionData() {
+    makeIntDistribution<int8_t>(
+        "byte_val",
+        /*min=*/0,
+        /*max=*/10,
+        /*repeats=*/20,
+        /*rareFrequency=*/5,
+        /*rareMin=*/50,
+        /*rareMax=*/100,
+        /*keepNulls=*/false);
+    makeIntDistribution<int32_t>(
+        "int_val",
+        /*min=*/0,
+        /*max=*/50,
+        /*repeats=*/15,
+        /*rareFrequency=*/5,
+        /*rareMin=*/10000,
+        /*rareMax=*/50000,
+        /*keepNulls=*/false);
+    makeIntDistribution<int64_t>(
+        "long_val",
+        /*min=*/0,
+        /*max=*/100,
+        /*repeats=*/10,
+        /*rareFrequency=*/5,
+        /*rareMin=*/1000000,
+        /*rareMax=*/5000000,
+        /*keepNulls=*/false);
+  }
 
   // Generates encoding factors that strongly favor a specific encoding type.
   // Encodings with lower read factors are preferred (factor represents CPU
@@ -658,6 +721,10 @@ class E2EFilterTest
         // Delta uses child encodings for deltas, restatements, and
         // isRestatements that may fall back to Constant.
         factors.emplace_back(EncodingType::Constant, 100.0);
+        break;
+      case EncodingType::FrequencyPartition:
+      case EncodingType::FOR:
+        // These encodings handle all integer data independently.
         break;
       default:
         break;
@@ -1059,6 +1126,112 @@ TEST_P(E2EFilterTest, integerBiasedDelta) {
   // Verify the on-disk encoding is Delta (sinkData_ holds the last written
   // file from testWithTypes).
   verifyColumnEncodingsOnDisk(EncodingType::Delta);
+}
+
+// Forces FOR (Frame of Reference) encoding via encoding layout tree and
+// verifies it on disk. FOR excels at bounded-range integer data where
+// per-frame minimum references reduce bit widths.
+TEST_P(E2EFilterTest, integerFOR) {
+  forcedEncodingType_ = EncodingType::FOR;
+  testWithTypes(
+      "short_val:smallint,"
+      "int_val:int,"
+      "long_val:bigint",
+      [&]() {
+        makeIntDistribution<int16_t>(
+            "short_val",
+            /*min=*/100,
+            /*max=*/5000,
+            /*repeats=*/1,
+            /*rareFrequency=*/0,
+            /*rareMin=*/0,
+            /*rareMax=*/0,
+            /*keepNulls=*/false);
+        makeIntDistribution<int32_t>(
+            "int_val",
+            /*min=*/1000,
+            /*max=*/100000,
+            /*repeats=*/1,
+            /*rareFrequency=*/0,
+            /*rareMin=*/0,
+            /*rareMax=*/0,
+            /*keepNulls=*/false);
+        makeIntDistribution<int64_t>(
+            "long_val",
+            /*min=*/10000,
+            /*max=*/10000000,
+            /*repeats=*/1,
+            /*rareFrequency=*/0,
+            /*rareMin=*/0,
+            /*rareMax=*/0,
+            /*keepNulls=*/false);
+      },
+      /*wrapInStruct=*/false,
+      {"short_val", "int_val", "long_val"},
+      /*numCombinations=*/20,
+      /*withRecursiveNulls=*/true);
+  forcedEncodingType_.reset();
+  verifyColumnEncodingsOnDisk(EncodingType::FOR);
+}
+
+// Forces FrequencyPartitionEncoding with PerTierBitmaps positional index.
+// Each tier stores an N-bit bitmap so the decoder can reconstruct the original
+// row order in O(popcount) time, enabling correct filter results.
+TEST_P(E2EFilterTest, integerFrequencyPartitionPerTierBitmaps) {
+  forcedEncodingType_ = EncodingType::FrequencyPartition;
+  frequencyPartitionIndexType_ = FreqPartIndexType::PerTierBitmaps;
+  testWithTypes(
+      "byte_val:tinyint,"
+      "int_val:int,"
+      "long_val:bigint",
+      [&]() { makeFrequencyPartitionData(); },
+      /*wrapInStruct=*/false,
+      {"byte_val", "int_val", "long_val"},
+      /*numCombinations=*/20,
+      /*withRecursiveNulls=*/true);
+  forcedEncodingType_.reset();
+  frequencyPartitionIndexType_.reset();
+  verifyColumnEncodingsOnDisk(EncodingType::FrequencyPartition);
+}
+
+// Forces FrequencyPartitionEncoding with TierTagArray positional index.
+// A compact packed array records which tier each original position belongs to,
+// enabling original-order materialization with a sampled rank index.
+TEST_P(E2EFilterTest, integerFrequencyPartitionTierTagArray) {
+  forcedEncodingType_ = EncodingType::FrequencyPartition;
+  frequencyPartitionIndexType_ = FreqPartIndexType::TierTagArray;
+  testWithTypes(
+      "byte_val:tinyint,"
+      "int_val:int,"
+      "long_val:bigint",
+      [&]() { makeFrequencyPartitionData(); },
+      /*wrapInStruct=*/false,
+      {"byte_val", "int_val", "long_val"},
+      /*numCombinations=*/20,
+      /*withRecursiveNulls=*/true);
+  forcedEncodingType_.reset();
+  frequencyPartitionIndexType_.reset();
+  verifyColumnEncodingsOnDisk(EncodingType::FrequencyPartition);
+}
+
+// Forces FrequencyPartitionEncoding with EliasFano positional index.
+// Per-tier Elias-Fano lists encode the sorted original positions for each tier,
+// decoded at load time for O(log n) random access.
+TEST_P(E2EFilterTest, integerFrequencyPartitionEliasFano) {
+  forcedEncodingType_ = EncodingType::FrequencyPartition;
+  frequencyPartitionIndexType_ = FreqPartIndexType::EliasFano;
+  testWithTypes(
+      "byte_val:tinyint,"
+      "int_val:int,"
+      "long_val:bigint",
+      [&]() { makeFrequencyPartitionData(); },
+      /*wrapInStruct=*/false,
+      {"byte_val", "int_val", "long_val"},
+      /*numCombinations=*/20,
+      /*withRecursiveNulls=*/true);
+  forcedEncodingType_.reset();
+  frequencyPartitionIndexType_.reset();
+  verifyColumnEncodingsOnDisk(EncodingType::FrequencyPartition);
 }
 
 TEST_P(E2EFilterTest, float) {

--- a/dwio/nimble/velox/selective/tests/SelectiveNimbleReaderTest.cpp
+++ b/dwio/nimble/velox/selective/tests/SelectiveNimbleReaderTest.cpp
@@ -1389,7 +1389,9 @@ TEST_P(SelectiveNimbleReaderTest, estimatedRowSizeNoStats) {
 TEST_P(SelectiveNimbleReaderTest, arrayWithOffsetsLastRunFilteredOut) {
   const bool stringDecoderZeroCopy = this->stringDecoderZeroCopy();
   checkArrayWithOffsets(
-      {{{1}}, {{}}, {{}}},
+      {{{1}},
+       std::vector<std::optional<int64_t>>{},
+       std::vector<std::optional<int64_t>>{}},
       {false, true, true},
       {1, 1, 1},
       stringDecoderZeroCopy);
@@ -1413,7 +1415,13 @@ TEST_P(SelectiveNimbleReaderTest, arrayWithOffsetsNoSeekBackward) {
 TEST_P(SelectiveNimbleReaderTest, arrayWithOffsetsLastRunResize) {
   const bool stringDecoderZeroCopy = this->stringDecoderZeroCopy();
   checkArrayWithOffsets(
-      {{{1}}, {{1}}, {{}}, {{}}}, {}, {1, 2, 1}, stringDecoderZeroCopy);
+      {{{1}},
+       {{1}},
+       std::vector<std::optional<int64_t>>{},
+       std::vector<std::optional<int64_t>>{}},
+      {},
+      {1, 2, 1},
+      stringDecoderZeroCopy);
 }
 
 // Exercises the dense fast path in makeNestedRowSet and setAlphabet: all rows
@@ -1638,31 +1646,31 @@ TEST_P(SelectiveNimbleReaderTest, arrayWithOffsetsLastRowSetLifeCycle) {
   for (int i = 0; i < 16; ++i) {
     c0.emplace_back(std::nullopt);
     c1.push_back({{1}});
-    c2.push_back({{}});
+    c2.push_back(std::vector<std::optional<int64_t>>{});
   }
-  c0.push_back({{}});
+  c0.push_back(std::vector<std::optional<int64_t>>{});
   c1.push_back({{1}});
-  c2.push_back({{}});
+  c2.push_back(std::vector<std::optional<int64_t>>{});
   // Second batch, all filtered out by c2, but c1 reads some value without
   // calling getValues.
   c0.emplace_back(std::nullopt);
   // Add a null to force setComplexNulls to read last row set before batch 3.
   c1.emplace_back(std::nullopt);
-  c2.push_back({{}});
+  c2.push_back(std::vector<std::optional<int64_t>>{});
   for (int i = 0; i < 15; ++i) {
     c0.emplace_back(std::nullopt);
     c1.push_back({{2}});
-    c2.push_back({{}});
+    c2.push_back(std::vector<std::optional<int64_t>>{});
   }
-  c0.push_back({{}});
+  c0.push_back(std::vector<std::optional<int64_t>>{});
   c1.push_back({{2}});
   c2.emplace_back(std::nullopt);
   // Third batch, nothing is filtered out, and force outputRows_ buffer
   // reallocation.
   for (int i = 0; i < 17; ++i) {
-    c0.push_back({{}});
+    c0.push_back(std::vector<std::optional<int64_t>>{});
     c1.push_back({{2}});
-    c2.push_back({{}});
+    c2.push_back(std::vector<std::optional<int64_t>>{});
   }
   auto vector = makeRowVector({
       makeNullableArrayVector<int64_t>(c0),
@@ -1712,9 +1720,9 @@ TEST_P(SelectiveNimbleReaderTest, slidingWindowMapLengthDedup) {
   checkSlidingWindowMap(
       {
           {{{1, {2}}}},
-          {{}},
+          std::vector<std::pair<int64_t, std::optional<int64_t>>>{},
           {{{3, {4}}}},
-          {{}},
+          std::vector<std::pair<int64_t, std::optional<int64_t>>>{},
           {{{5, {6}}}},
       },
       {},

--- a/dwio/nimble/velox/selective/tests/VariableLengthColumnReaderTest.cpp
+++ b/dwio/nimble/velox/selective/tests/VariableLengthColumnReaderTest.cpp
@@ -170,14 +170,20 @@ TEST_F(VariableLengthColumnReaderTest, listMixedNullsAndEmpty) {
   // Interleaved null/empty/populated arrays.
   std::vector<std::optional<std::vector<std::optional<int64_t>>>> data = {
       std::nullopt, // null
-      {{}}, // empty
-      {{{1, 2, 3}}}, // populated
+      std::optional<std::vector<std::optional<int64_t>>>{
+          std::vector<std::optional<int64_t>>{}}, // empty
+      std::optional<std::vector<std::optional<int64_t>>>{
+          std::vector<std::optional<int64_t>>{1, 2, 3}}, // populated
       std::nullopt, // null
-      {{}}, // empty
-      {{{4, 5}}}, // populated
+      std::optional<std::vector<std::optional<int64_t>>>{
+          std::vector<std::optional<int64_t>>{}}, // empty
+      std::optional<std::vector<std::optional<int64_t>>>{
+          std::vector<std::optional<int64_t>>{4, 5}}, // populated
       std::nullopt, // null
-      {{{6}}}, // populated
-      {{}}, // empty
+      std::optional<std::vector<std::optional<int64_t>>>{
+          std::vector<std::optional<int64_t>>{6}}, // populated
+      std::optional<std::vector<std::optional<int64_t>>>{
+          std::vector<std::optional<int64_t>>{}}, // empty
   };
   auto input = makeRowVector({makeNullableArrayVector<int64_t>(data)});
   auto scanSpec = std::make_shared<common::ScanSpec>("root");
@@ -274,7 +280,11 @@ TEST_F(VariableLengthColumnReaderTest, mapEmptyContainers) {
   // 10 rows of non-null empty maps — verifies empty != null.
   std::vector<
       std::optional<std::vector<std::pair<int64_t, std::optional<int64_t>>>>>
-      data(10, {{}});
+      data(
+          10,
+          std::optional<
+              std::vector<std::pair<int64_t, std::optional<int64_t>>>>{
+              std::vector<std::pair<int64_t, std::optional<int64_t>>>{}});
   auto input = makeRowVector({makeNullableMapVector<int64_t, int64_t>(data)});
   auto scanSpec = std::make_shared<common::ScanSpec>("root");
   scanSpec->addAllChildFields(*input->type());
@@ -301,14 +311,28 @@ TEST_F(VariableLengthColumnReaderTest, mapMixedNullsAndEmpty) {
       std::optional<std::vector<std::pair<int64_t, std::optional<int64_t>>>>>
       data = {
           std::nullopt,
-          {{}},
-          {{{{1, 10}, {2, 20}}}},
+          std::optional<
+              std::vector<std::pair<int64_t, std::optional<int64_t>>>>{
+              std::vector<std::pair<int64_t, std::optional<int64_t>>>{}},
+          std::optional<
+              std::vector<std::pair<int64_t, std::optional<int64_t>>>>{
+              std::vector<std::pair<int64_t, std::optional<int64_t>>>{
+                  {1, 10}, {2, 20}}},
           std::nullopt,
-          {{}},
-          {{{{3, 30}}}},
+          std::optional<
+              std::vector<std::pair<int64_t, std::optional<int64_t>>>>{
+              std::vector<std::pair<int64_t, std::optional<int64_t>>>{}},
+          std::optional<
+              std::vector<std::pair<int64_t, std::optional<int64_t>>>>{
+              std::vector<std::pair<int64_t, std::optional<int64_t>>>{{3, 30}}},
           std::nullopt,
-          {{{{4, 40}, {5, 50}, {6, 60}}}},
-          {{}},
+          std::optional<
+              std::vector<std::pair<int64_t, std::optional<int64_t>>>>{
+              std::vector<std::pair<int64_t, std::optional<int64_t>>>{
+                  {4, 40}, {5, 50}, {6, 60}}},
+          std::optional<
+              std::vector<std::pair<int64_t, std::optional<int64_t>>>>{
+              std::vector<std::pair<int64_t, std::optional<int64_t>>>{}},
       };
   auto input = makeRowVector({makeNullableMapVector<int64_t, int64_t>(data)});
   auto scanSpec = std::make_shared<common::ScanSpec>("root");

--- a/dwio/nimble/velox/tests/VeloxReaderTest.cpp
+++ b/dwio/nimble/velox/tests/VeloxReaderTest.cpp
@@ -686,17 +686,14 @@ class VeloxReaderTest : public ::testing::TestWithParam<TestParam> {
 
   template <typename T>
   void getFieldDefaultValue(nimble::Vector<T>& input, uint32_t index) {
-    static_assert(
-        T() == 0, "Default Constructor value is not zero initialized");
+    if constexpr (std::is_arithmetic_v<T>) {
+      static_assert(
+          T() == 0, "Default Constructor value is not zero initialized");
+    }
     input[index] = T();
   }
 
-  template <>
-  void getFieldDefaultValue(
-      nimble::Vector<std::string>& input,
-      uint32_t index) {
-    input[index] = std::string();
-  }
+  // Specialization moved outside class - see below
 
   template <typename T>
   void

--- a/dwio/nimble/velox/tests/VeloxWriterTest.cpp
+++ b/dwio/nimble/velox/tests/VeloxWriterTest.cpp
@@ -4919,11 +4919,9 @@ TEST_F(VeloxWriterTest, encodingLayoutDeltaMultiStripe) {
       batches[0]->type(),
       std::move(writeFile),
       *rootPool_,
-      {.flushPolicyFactory =
-           []() {
-             return std::make_unique<nimble::StripeRawSizeFlushPolicy>(1024);
-           },
-       .encodingLayoutTree = std::move(layoutTree)});
+      {.encodingLayoutTree = std::move(layoutTree), .flushPolicyFactory = []() {
+         return std::make_unique<nimble::StripeRawSizeFlushPolicy>(1024);
+       }});
 
   for (const auto& batch : batches) {
     writer.write(batch);
@@ -5204,11 +5202,9 @@ TEST_F(VeloxWriterTest, encodingLayoutDeltaMultiStripeLegacyRead) {
       batches[0]->type(),
       std::move(writeFile),
       *rootPool_,
-      {.flushPolicyFactory =
-           []() {
-             return std::make_unique<nimble::StripeRawSizeFlushPolicy>(1024);
-           },
-       .encodingLayoutTree = std::move(layoutTree)});
+      {.encodingLayoutTree = std::move(layoutTree), .flushPolicyFactory = []() {
+         return std::make_unique<nimble::StripeRawSizeFlushPolicy>(1024);
+       }});
 
   for (const auto& batch : batches) {
     writer.write(batch);


### PR DESCRIPTION
Summary:

FrequencyPartition and FOR encodings are experimenntal and currently in development let us enable or disable encodings in write and read paths

Reviewed By: apurva-meta

Differential Revision: D106419099
