### PR TITLE
refactor(dwio): Use ColumnMappingMode in Nimble reader

### DIFF
--- a/dwio/nimble/velox/selective/ReaderBase.cpp
+++ b/dwio/nimble/velox/selective/ReaderBase.cpp
@@ -38,7 +38,8 @@ std::shared_ptr<const facebook::nimble::Type> loadSchema(
 TypePtr getFileSchema(
     const dwio::common::ReaderOptions& options,
     const TypePtr& fileSchema) {
-  if (options.useColumnNamesForColumnMapping() || !options.fileSchema()) {
+  if (options.columnMappingMode() == dwio::common::ColumnMappingMode::kName ||
+      !options.fileSchema()) {
     return fileSchema;
   }
   return dwio::common::Reader::updateColumnNames(


### PR DESCRIPTION
Summary: Update the Nimble selective reader to use `ReaderOptions::columnMappingMode()` after the Velox ReaderOptions migration replaced the boolean name-mapping accessor. This keeps Nimble name-based schema matching behavior unchanged and is the Nimble export follow-up for Velox PR https://github.com/facebookincubator/velox/pull/17634.

Differential Revision: D106656925


