### PR TITLE
fix: Fix cached footer size check for compressed footers

### DIFF
--- a/dwio/nimble/tablet/TabletReader.cpp
+++ b/dwio/nimble/tablet/TabletReader.cpp
@@ -424,10 +424,17 @@ bool TabletReader::loadFooterFromCache() {
       content.substr(content.size() - Postscript::kSize, Postscript::kSize));
 
   const auto footerSize = content.size() - Postscript::kSize;
-  NIMBLE_CHECK_EQ(
-      ps_.footerSize(),
-      footerSize,
-      "Cached footer size mismatch with postscript");
+  if (ps_.footerCompressionType() == CompressionType::Uncompressed) {
+    NIMBLE_CHECK_EQ(
+        ps_.footerSize(),
+        footerSize,
+        "Cached footer size mismatch with postscript");
+  } else {
+    NIMBLE_CHECK_LE(
+        ps_.footerSize(),
+        footerSize,
+        "Cached compressed footer size exceeds decompressed size");
+  }
 
   footer_ = cachedFooter->slice(0, footerSize);
   return true;


### PR DESCRIPTION
Summary:
`loadFooterFromCache` checks that `ps_.footerSize()` equals the cached content size minus the postscript size. However, `cacheMetadata` intentionally stores the decompressed footer content (so the cache consumer can skip decompression), while `ps_.footerSize()` stores the compressed on-disk size. When footer compression is enabled, these sizes differ, causing a spurious `NIMBLE_CHECK_EQ` failure.

Fix by making the exact equality check conditional on the footer being uncompressed. When compressed, check that the compressed size does not exceed the decompressed size instead.

Differential Revision: D106763086


