### PR TITLE
refactor(dwio): Add column mapping mode

### DIFF
--- a/dwio/nimble/velox/selective/ReaderBase.cpp
+++ b/dwio/nimble/velox/selective/ReaderBase.cpp
@@ -38,7 +38,8 @@ std::shared_ptr<const facebook::nimble::Type> loadSchema(
 TypePtr getFileSchema(
     const dwio::common::ReaderOptions& options,
     const TypePtr& fileSchema) {
-  if (options.useColumnNamesForColumnMapping() || !options.fileSchema()) {
+  if (options.columnMappingMode() == dwio::common::ColumnMappingMode::kName ||
+      !options.fileSchema()) {
     return fileSchema;
   }
   return dwio::common::Reader::updateColumnNames(


### PR DESCRIPTION
Summary:
Reader options now represent column matching as `ColumnMappingMode` instead of a boolean name mapping flag. The existing position and name modes keep the current Hive, DWRF, ORC, and Parquet behavior, while `kParquetFieldId` reserves the Parquet field-ID path needed by Iceberg schema evolution.

This PR also moves `ParquetFieldId` into `dwio/common` so `ReaderOptions` can refer to it without depending on a Parquet-layer header. The Parquet namespace keeps an alias, so existing writer and Iceberg code can continue using `parquet::ParquetFieldId`.

`kParquetFieldId` is intentionally not implemented in this prep PR. The Parquet reader rejects it with `Parquet field ID column mapping is not implemented yet.`, and DWRF rejects it as an invalid Parquet-only mode.

X-link: https://github.com/facebookincubator/velox/pull/17634

Reviewed By: mbasmanova

Differential Revision: D106508395

Pulled By: kKPulla
