### PR TITLE
misc(nimble): Bump Velox submodule version

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ Nimble integrates Velox as a Git submodule, referencing a specific commit of the
 Velox repository. The Velox badge at the top of this README shows the current
 commit and how far behind it is from Velox main.
 
-[See what changed since the current Velox commit.](https://github.com/facebookincubator/velox/compare/18ec764e05f6cfbb3541578b681b5396f51095f3...main)
+[See what changed since the current Velox commit.](https://github.com/facebookincubator/velox/compare/d312eeda8b1db8820a785aaf0cc0ca0b6ae07e20...main)
 <!-- pre-commit check-velox-readme validates the SHA above matches the submodule -->
 
 Advance Velox when your changes depend on code in Velox that


### PR DESCRIPTION
Summary: Bump Nimble's Velox submodule to `d312eeda8b1db8820a785aaf0cc0ca0b6ae07e20` so OSS Nimble picks up the ReaderOptions `ColumnMappingMode` migration from https://github.com/facebookincubator/velox/pull/17634. Update the README compare link to match the new pinned Velox commit.

Differential Revision: D106870528
