### PR TITLE
feat(nimble): Add MainlyConstant trailer encoding for sparse stream sizes

### DIFF
--- a/dwio/nimble/serializer/Options.cpp
+++ b/dwio/nimble/serializer/Options.cpp
@@ -40,6 +40,7 @@ EncodingType getTrailerEncodingType(EncodingType encodingType) {
     case EncodingType::Varint:
     case EncodingType::Delta:
     case EncodingType::FixedBitWidth:
+    case EncodingType::MainlyConstant:
       return encodingType;
     default:
       NIMBLE_FAIL(

--- a/dwio/nimble/serializer/Options.h
+++ b/dwio/nimble/serializer/Options.h
@@ -45,8 +45,8 @@ namespace facebook::nimble {
 ///   Wire: [version:1B][rowCount:varint][stream_data_0]...[stream_data_N]
 ///         [encodingType:1B][raw_sizes_payload][trailer_size:u32]
 ///   trailer_size = 1 + len(raw_sizes_payload).
-///   Supported EncodingTypes: Trivial, Varint, Delta, FixedBitWidth.
-///   See getTrailerEncodingType() for validation.
+///   Supported EncodingTypes: Trivial, Varint, Delta, FixedBitWidth,
+///   MainlyConstant. See getTrailerEncodingType() for validation.
 ///
 /// - kTablet: Tablet stream passthrough format. Like kCompactRaw but:
 ///   (1) Each stream's data includes tablet chunk headers:
@@ -118,7 +118,7 @@ inline bool usesVarintRowCount(std::optional<SerializationVersion> version) {
 }
 
 /// Validates and returns the EncodingType for stream sizes trailer.
-/// Supported: Trivial, Varint, Delta, FixedBitWidth.
+/// Supported: Trivial, Varint, Delta, FixedBitWidth, MainlyConstant.
 EncodingType getTrailerEncodingType(EncodingType encodingType);
 
 inline std::ostream& operator<<(
@@ -177,7 +177,7 @@ struct SerializerOptions {
   std::optional<CompressionOptions> compressionOptions{};
 
   /// Encoding type for stream sizes in the trailer.
-  /// Supported types: Trivial, Varint, Delta, FixedBitWidth.
+  /// Supported types: Trivial, Varint, Delta, FixedBitWidth, MainlyConstant.
   EncodingType streamSizesEncodingType{EncodingType::FixedBitWidth};
 
   /// Returns true if the serialized data has a version header byte.

--- a/dwio/nimble/serializer/Projector.h
+++ b/dwio/nimble/serializer/Projector.h
@@ -73,7 +73,7 @@ class Projector {
     SerializationVersion projectVersion{SerializationVersion::kCompactRaw};
 
     /// Encoding type for stream sizes in the trailer.
-    /// Supported types: Trivial, Varint, Delta, FixedBitWidth.
+    /// Supported types: Trivial, Varint, Delta, FixedBitWidth, MainlyConstant.
     EncodingType streamSizesEncodingType{EncodingType::FixedBitWidth};
 
     /// Optional velox type with up-to-date column names from the current

--- a/dwio/nimble/serializer/SerializerImpl.cpp
+++ b/dwio/nimble/serializer/SerializerImpl.cpp
@@ -16,6 +16,7 @@
 
 #include "dwio/nimble/serializer/SerializerImpl.h"
 
+#include <bit>
 #include <limits>
 
 #include "dwio/nimble/serializer/SerializationHeader.h"
@@ -28,7 +29,67 @@
 #include <folly/io/Cursor.h>
 
 namespace facebook::nimble::serde::detail {
+
 namespace {
+
+std::vector<uint32_t> decodeMainlyConstantTrailer(const char*& payload) {
+  const uint32_t streamCount = varint::readVarint32(&payload);
+  const uint32_t nonZeroCount = varint::readVarint32(&payload);
+  NIMBLE_CHECK_LE(
+      nonZeroCount,
+      streamCount,
+      "MainlyConstant nonZeroCount exceeds streamCount");
+  // Constant is fixed at 0 and not stored on the wire.
+  std::vector<uint32_t> sizes(streamCount, 0);
+  if (nonZeroCount == 0) {
+    // idxBitWidth/valBitWidth bytes and packed arrays are omitted when
+    // there are no non-zero entries.
+    return sizes;
+  }
+
+  const uint8_t idxBitWidth = static_cast<uint8_t>(*payload++);
+  NIMBLE_CHECK_LE(
+      idxBitWidth, 32, "MainlyConstant idxBitWidth exceeds 32 bits");
+  std::vector<uint32_t> indices(nonZeroCount);
+  const uint32_t packedIndicesBytes = static_cast<uint32_t>(
+      FixedBitArray::bufferSize(nonZeroCount, idxBitWidth));
+  FixedBitArray idxArr{
+      const_cast<char*>(payload), static_cast<int>(idxBitWidth)};
+  idxArr.bulkGet32(0, nonZeroCount, indices.data());
+  payload += packedIndicesBytes;
+
+  const uint8_t valBitWidth = static_cast<uint8_t>(*payload++);
+  NIMBLE_CHECK_LE(
+      valBitWidth, 32, "MainlyConstant valBitWidth exceeds 32 bits");
+  std::vector<uint32_t> values(nonZeroCount);
+  const uint32_t packedValuesBytes = static_cast<uint32_t>(
+      FixedBitArray::bufferSize(nonZeroCount, valBitWidth));
+  FixedBitArray valArr{
+      const_cast<char*>(payload), static_cast<int>(valBitWidth)};
+  valArr.bulkGet32(0, nonZeroCount, values.data());
+  payload += packedValuesBytes;
+
+  for (uint32_t i = 0; i < nonZeroCount; ++i) {
+    NIMBLE_CHECK_LT(
+        indices[i], streamCount, "MainlyConstant trailer index out of range");
+    sizes[indices[i]] = values[i];
+  }
+  return sizes;
+}
+
+// Upper bound on the MainlyConstant trailer payload size for a stream of
+// 'numStreams' values. idxBitWidth matches the writer's formula (max(1,
+// bit_width(numStreams - 1)) when there are indices); valBitWidth is
+// unbounded up to 32 since values are uint32_t.
+size_t estimateMainlyConstantTrailerPayloadSize(size_t numStreams) {
+  const size_t idxBitWidth =
+      numStreams == 0 ? 0 : std::max<size_t>(1, std::bit_width(numStreams - 1));
+  // 5 (streamCount varint) + 5 (nonZeroCount varint) + 1 (idxBitWidth) +
+  // packed indices + 1 (valBitWidth) + packed values.
+  return 5 + 5 + 1 +
+      FixedBitArray::bufferSize(numStreams, static_cast<int>(idxBitWidth)) + 1 +
+      FixedBitArray::bufferSize(numStreams, /*bitWidth=*/32);
+}
 
 std::vector<uint32_t> decodeTrailerStreamSizes(
     const char* trailerStart,
@@ -82,6 +143,10 @@ std::vector<uint32_t> decodeTrailerStreamSizes(
         arr.bulkGet32(0, count, sizes.data());
         payload += packedBytes;
       }
+      break;
+    }
+    case EncodingType::MainlyConstant: {
+      sizes = decodeMainlyConstantTrailer(payload);
       break;
     }
     default:
@@ -246,6 +311,9 @@ size_t estimateTrailerSize(size_t numStreams, EncodingType encodingType) {
       // element max).
       payloadSize =
           1 + 5 + FixedBitArray::bufferSize(numStreams, /*bitWidth=*/32);
+      break;
+    case EncodingType::MainlyConstant:
+      payloadSize = estimateMainlyConstantTrailerPayloadSize(numStreams);
       break;
     default:
       NIMBLE_FAIL(

--- a/dwio/nimble/serializer/SerializerImpl.h
+++ b/dwio/nimble/serializer/SerializerImpl.h
@@ -21,6 +21,8 @@
 #include <cstring>
 #include <optional>
 #include <string>
+#include <unordered_map>
+#include <vector>
 
 #include "dwio/nimble/common/Buffer.h"
 #include "dwio/nimble/common/FixedBitArray.h"
@@ -223,6 +225,102 @@ void writeFixedBitWidthTrailer(
   encoding::writeUint32(trailerSize, pos);
 }
 
+/// Writes the MainlyConstant trailer: assumes 0 is the dominant value and
+/// writes a sparse list of (index, value) pairs for non-zero slots. Optimized
+/// for trailers dominated by zero (e.g., empty slots in flat-map schemas with
+/// many absent keys). Callers should pick a different trailer encoding for
+/// inputs not dominated by zero.
+///
+/// Wire (when nonZeroCount > 0):
+///   [encodingType:1B][streamCount:varint][nonZeroCount:varint]
+///   [idxBitWidth:1B][indices packed nonZeroCount*idxBitWidth bits]
+///   [valBitWidth:1B][values packed nonZeroCount*valBitWidth bits]
+///   [trailer_size:u32]
+///
+/// Wire (when nonZeroCount == 0):
+///   [encodingType:1B][streamCount:varint][nonZeroCount=0:varint]
+///   [trailer_size:u32]
+///
+/// Where nonZeroCount = number of slots whose size != 0. The constant is
+/// fixed at 0 and not stored on the wire.
+template <typename T>
+void writeMainlyConstantTrailer(
+    const std::vector<uint32_t>& streamSizes,
+    T& buffer) {
+  const auto streamCount = static_cast<uint32_t>(streamSizes.size());
+
+  // Collect non-zero (index, value) pairs. Reserve the upper bound
+  // (streamCount) so the emplace_back loop never reallocates.
+  std::vector<uint32_t> indices;
+  std::vector<uint32_t> values;
+  indices.reserve(streamCount);
+  values.reserve(streamCount);
+  for (uint32_t i = 0; i < streamCount; ++i) {
+    if (streamSizes[i] != 0) {
+      indices.emplace_back(i);
+      values.emplace_back(streamSizes[i]);
+    }
+  }
+  const uint32_t nonZeroCount = static_cast<uint32_t>(indices.size());
+
+  // idxBitWidth covers indices in [0, streamCount). When nonZeroCount == 0
+  // there are no indices to pack, so width is 0. Otherwise clamp to a
+  // minimum of 1 because FixedBitArray::bulkSet32 LOG(FATAL)s on bitWidth=0
+  // (this only matters for streamCount == 1, where bit_width(0) would be 0).
+  const uint8_t idxBitWidth = (nonZeroCount == 0)
+      ? 0
+      : static_cast<uint8_t>(
+            std::max<size_t>(1, std::bit_width(streamCount - 1)));
+
+  auto maxValues = [](const std::vector<uint32_t>& vals) {
+    uint32_t maxVal = 0;
+    for (const auto v : vals) {
+      maxVal = std::max(maxVal, v);
+    }
+    return maxVal;
+  };
+  const uint32_t maxValue = nonZeroCount == 0 ? 0 : maxValues(values);
+  const uint8_t valBitWidth =
+      nonZeroCount == 0 ? 0 : static_cast<uint8_t>(std::bit_width(maxValue));
+
+  const auto streamCountVarintSize = varint::varintSize(streamCount);
+  const auto nonZeroCountVarintSize = varint::varintSize(nonZeroCount);
+  const uint32_t packedIndicesBytes = (nonZeroCount == 0)
+      ? 0
+      : static_cast<uint32_t>(
+            FixedBitArray::bufferSize(nonZeroCount, idxBitWidth));
+  const uint32_t packedValuesBytes = (nonZeroCount == 0)
+      ? 0
+      : static_cast<uint32_t>(
+            FixedBitArray::bufferSize(nonZeroCount, valBitWidth));
+
+  // When nonZeroCount == 0 the idxBitWidth/valBitWidth bytes and packed
+  // arrays are all omitted from the wire.
+  const uint32_t trailerSize = /*encodingType=*/sizeof(uint8_t) +
+      streamCountVarintSize + nonZeroCountVarintSize +
+      (nonZeroCount == 0 ? 0 : /*idxBitWidth=*/sizeof(uint8_t) +
+               packedIndicesBytes +
+               /*valBitWidth=*/sizeof(uint8_t) + packedValuesBytes);
+
+  auto* pos = extend(buffer, trailerSize + sizeof(uint32_t));
+  *pos++ = static_cast<char>(EncodingType::MainlyConstant);
+  varint::writeVarint(streamCount, &pos);
+  varint::writeVarint(nonZeroCount, &pos);
+  if (nonZeroCount > 0) {
+    *pos++ = static_cast<char>(idxBitWidth);
+    std::memset(pos, 0, packedIndicesBytes);
+    FixedBitArray idxArr{pos, static_cast<int>(idxBitWidth)};
+    idxArr.bulkSet32(0, nonZeroCount, indices.data());
+    pos += packedIndicesBytes;
+    *pos++ = static_cast<char>(valBitWidth);
+    std::memset(pos, 0, packedValuesBytes);
+    FixedBitArray valArr{pos, static_cast<int>(valBitWidth)};
+    valArr.bulkSet32(0, nonZeroCount, values.data());
+    pos += packedValuesBytes;
+  }
+  encoding::writeUint32(trailerSize, pos);
+}
+
 /// Writes the stream sizes trailer using the specified encoding type.
 template <typename T>
 void writeTrailer(
@@ -241,6 +339,9 @@ void writeTrailer(
       break;
     case EncodingType::FixedBitWidth:
       writeFixedBitWidthTrailer(streamSizes, buffer);
+      break;
+    case EncodingType::MainlyConstant:
+      writeMainlyConstantTrailer(streamSizes, buffer);
       break;
     default:
       NIMBLE_FAIL(

--- a/dwio/nimble/serializer/tests/ProjectorTest.cpp
+++ b/dwio/nimble/serializer/tests/ProjectorTest.cpp
@@ -63,7 +63,7 @@ struct FormatParam {
     auto base =
         fmt::format("{}To{}", toString(inputVersion), toString(projectVersion));
     if (streamSizesEncodingType != EncodingType::Trivial) {
-      base += "_DeltaStreamSizes";
+      base += fmt::format("_{}StreamSizes", toString(streamSizesEncodingType));
     }
     if (!enableBufferPool) {
       base += "_NoBufferPool";
@@ -76,10 +76,13 @@ struct FormatParam {
 std::vector<FormatParam> allFormatCombinations() {
   return {
       {SerializationVersion::kCompactRaw, SerializationVersion::kCompactRaw},
-      // Delta stream sizes encoding for kCompactRaw output.
+      // Non-default stream sizes encodings for kCompactRaw output.
       {SerializationVersion::kCompactRaw,
        SerializationVersion::kCompactRaw,
        EncodingType::Delta},
+      {SerializationVersion::kCompactRaw,
+       SerializationVersion::kCompactRaw,
+       EncodingType::MainlyConstant},
       // Buffer pool disabled variants.
       {SerializationVersion::kCompactRaw,
        SerializationVersion::kCompactRaw,
@@ -88,6 +91,10 @@ std::vector<FormatParam> allFormatCombinations() {
       {SerializationVersion::kCompactRaw,
        SerializationVersion::kCompactRaw,
        EncodingType::Delta,
+       /*enableBufferPool=*/false},
+      {SerializationVersion::kCompactRaw,
+       SerializationVersion::kCompactRaw,
+       EncodingType::MainlyConstant,
        /*enableBufferPool=*/false},
   };
 }
@@ -2661,6 +2668,8 @@ TEST_F(ProjectorTest, fuzzMixedVersionProjection) {
       {.version = SerializationVersion::kCompactRaw},
       {.version = SerializationVersion::kCompactRaw,
        .streamSizesEncodingType = EncodingType::Delta},
+      {.version = SerializationVersion::kCompactRaw,
+       .streamSizesEncodingType = EncodingType::MainlyConstant},
   };
 
   // Output projection versions.
@@ -2669,6 +2678,8 @@ TEST_F(ProjectorTest, fuzzMixedVersionProjection) {
       {.projectVersion = SerializationVersion::kCompactRaw},
       {.projectVersion = SerializationVersion::kCompactRaw,
        .streamSizesEncodingType = EncodingType::Delta},
+      {.projectVersion = SerializationVersion::kCompactRaw,
+       .streamSizesEncodingType = EncodingType::MainlyConstant},
   };
 
   // Columns to project (subset of the full schema).

--- a/dwio/nimble/serializer/tests/SerializationTest.cpp
+++ b/dwio/nimble/serializer/tests/SerializationTest.cpp
@@ -5095,6 +5095,10 @@ INSTANTIATE_TEST_SUITE_P(
         TestParams{
             .version = SerializationVersion::kCompactRaw,
             .streamSizesEncodingType = EncodingType::FixedBitWidth},
+        // kCompactRaw format with MainlyConstant stream sizes encoding.
+        TestParams{
+            .version = SerializationVersion::kCompactRaw,
+            .streamSizesEncodingType = EncodingType::MainlyConstant},
         // Buffer pool disabled variants.
         TestParams{.version = std::nullopt, .enableBufferPool = false},
         TestParams{
@@ -5114,5 +5118,9 @@ INSTANTIATE_TEST_SUITE_P(
         TestParams{
             .version = SerializationVersion::kCompactRaw,
             .streamSizesEncodingType = EncodingType::FixedBitWidth,
+            .enableBufferPool = false},
+        TestParams{
+            .version = SerializationVersion::kCompactRaw,
+            .streamSizesEncodingType = EncodingType::MainlyConstant,
             .enableBufferPool = false}),
     formatName);

--- a/dwio/nimble/serializer/tests/SerializerImplTest.cpp
+++ b/dwio/nimble/serializer/tests/SerializerImplTest.cpp
@@ -15,6 +15,7 @@
  */
 
 #include <limits>
+#include <random>
 
 #include <gtest/gtest.h>
 #include <lz4.h>
@@ -663,13 +664,227 @@ TEST_F(EncodeDecodeTest, readTrailerStreamSizesLargeValues) {
   EXPECT_EQ(decoded, values);
 }
 
+// MainlyConstant trailer roundtrip — encoding assumes 0 is the dominant value
+// and writes a sparse list of (index, value) pairs for non-zero slots.
+TEST_F(EncodeDecodeTest, readTrailerStreamSizesMainlyConstant) {
+  struct TestParam {
+    std::vector<uint32_t> values;
+    std::string label;
+  };
+  std::vector<TestParam> cases = {
+      {{}, "empty"},
+      {{0}, "single-zero"},
+      {{42}, "single-nonzero"},
+      {{0, 0, 0, 0, 0}, "all-zero"},
+      // Sparse cases (encoding's sweet spot).
+      {{0, 0, 0, 5, 0, 0, 0, 0, 0, 0}, "mostly-zero-one-nonzero"},
+      {{0, 0, 11, 0, 0, 22, 0, 0, 33, 0}, "mostly-zero-scattered"},
+      // nonConstantCount == count (all non-zero): degenerate path — still
+      // roundtrips even though MainlyConstant is the wrong choice for this
+      // input.
+      {{1, 2, 3, 4, 5}, "all-nonzero-degenerate"},
+      // UINT32_MAX as a stream size — exercises 5-byte varint and
+      // 32-bit valBitWidth.
+      {{0, 0, std::numeric_limits<uint32_t>::max(), 0}, "uint32-max-value"},
+      // Mixed near-max values exercise full valBitWidth=32.
+      {{0,
+        std::numeric_limits<uint32_t>::max(),
+        std::numeric_limits<uint32_t>::max() - 1,
+        0},
+       "max-and-near-max"},
+      // Trailer typical of full-projected hybrid blob: 1000 slots, 5 non-zero.
+      {[] {
+         std::vector<uint32_t> v(1000, 0);
+         v[50] = 11;
+         v[123] = 22;
+         v[456] = 33;
+         v[789] = 44;
+         v[999] = 55;
+         return v;
+       }(),
+       "sparse-1000-slots"},
+      // Smallest count where idxBitWidth > 0 (count=2 needs 1 bit).
+      {{0, 7}, "count2-nonzero-at-end-idxBitWidth1"},
+      {{7, 0}, "count2-nonzero-at-start-idxBitWidth1"},
+      // count=3 with non-zero at last index (idx=2 needs 2 bits).
+      {{0, 0, 9}, "count3-nonzero-at-end-idxBitWidth2"},
+      // idxBitWidth byte boundaries: 256 needs 8 bits, 257 needs 9 bits.
+      {[] {
+         std::vector<uint32_t> v(256, 0);
+         v[255] = 42;
+         return v;
+       }(),
+       "count256-nonzero-at-end-idxBitWidth8"},
+      {[] {
+         std::vector<uint32_t> v(257, 0);
+         v[256] = 42;
+         return v;
+       }(),
+       "count257-nonzero-at-end-idxBitWidth9"},
+      // streamCount=1 with the only non-zero value at UINT32_MAX exercises the
+      // idxBitWidth=0 fast path together with a 32-bit valBitWidth.
+      {{std::numeric_limits<uint32_t>::max()}, "single-uint32-max"},
+      // streamCount=2 with both slots non-zero (nonConstantCount == count):
+      // exercises the idxBitWidth=1 path with both indices populated.
+      {{5, 7}, "count2-both-nonzero"},
+      // Alternating zero/non-zero pattern exercises K=count/2 with indices
+      // densely covering half the slot space.
+      {{1, 0, 2, 0, 3, 0, 4, 0}, "alternating-zero-nonzero"},
+      // idxBitWidth=16 boundary: count=65537 needs 17 bits for indices.
+      {[] {
+         std::vector<uint32_t> v(65537, 0);
+         v[65536] = 1;
+         return v;
+       }(),
+       "count65537-nonzero-at-end-idxBitWidth17"},
+      // valBitWidth byte boundary: max value = 255 fits in 8 bits, 256 needs 9.
+      {{0, 0, 255, 0}, "valBitWidth8-boundary"},
+      {{0, 0, 256, 0}, "valBitWidth9-boundary"},
+  };
+  for (const auto& tc : cases) {
+    SCOPED_TRACE(tc.label);
+    std::string buffer;
+    serde::detail::writeTrailer(
+        tc.values, EncodingType::MainlyConstant, buffer);
+    auto decoded =
+        serde::detail::readTrailerStreamSizes(buffer.data() + buffer.size());
+    EXPECT_EQ(decoded, tc.values);
+  }
+}
+
+// Verify the MainlyConstant trailer wire format omits the `constant` field
+// (always 0) and additionally omits the idxBitWidth/valBitWidth bytes (plus
+// any packed arrays) when nonZeroCount == 0. For all-zero input the trailer
+// is exactly:
+//   encType(1) + streamCountVarint + nonZeroCountVarint(=1 for empty)
+//   + trailer_size(4)
+TEST_F(EncodeDecodeTest, mainlyConstantWireFormatAllZeroIsMinimal) {
+  // All-zero: nonZeroCount=0, no idxBitWidth/valBitWidth bytes, no packed
+  // bytes. streamCount=4 → varintSize=1. nonZeroCount=0 → varintSize=1.
+  // Expected: 1 + 1 + 1 + 4 = 7 bytes.
+  std::vector<uint32_t> sizes = {0, 0, 0, 0};
+  std::string buffer;
+  serde::detail::writeTrailer(sizes, EncodingType::MainlyConstant, buffer);
+  EXPECT_EQ(buffer.size(), 7u);
+
+  // Roundtrip must produce the exact input.
+  auto decoded =
+      serde::detail::readTrailerStreamSizes(buffer.data() + buffer.size());
+  EXPECT_EQ(decoded, sizes);
+}
+
+// Estimate must be an upper bound (>= actual) for representative inputs.
+TEST_F(EncodeDecodeTest, mainlyConstantEstimateIsUpperBound) {
+  std::vector<std::vector<uint32_t>> cases = {
+      {},
+      {0},
+      {42},
+      {0, 0, 0, 0, 0},
+      {0, 5, 0, 0, 9, 0, 0, 0, 0, 3},
+      {1, 2, 3, 4, 5},
+      [] {
+        std::vector<uint32_t> v(1000, 0);
+        v[100] = 50;
+        v[500] = 80;
+        v[999] = 30;
+        return v;
+      }(),
+      [] {
+        std::vector<uint32_t> v(257, 0);
+        v[256] = std::numeric_limits<uint32_t>::max();
+        return v;
+      }(),
+  };
+  for (const auto& tc : cases) {
+    SCOPED_TRACE(fmt::format("size={}", tc.size()));
+    std::string buffer;
+    serde::detail::writeTrailer(tc, EncodingType::MainlyConstant, buffer);
+    const auto estimate = serde::detail::estimateTrailerSize(
+        tc.size(), EncodingType::MainlyConstant);
+    EXPECT_LE(buffer.size(), estimate);
+  }
+}
+
+// Verify MainlyConstant produces a much smaller trailer than FixedBitWidth and
+// Varint when the input is dominated by a single value.
+TEST_F(EncodeDecodeTest, mainlyConstantSparseSize) {
+  // 1000 slots, mostly zeros, with 5 small non-zero values.
+  std::vector<uint32_t> sizes(1000, 0);
+  sizes[100] = 50;
+  sizes[200] = 80;
+  sizes[300] = 30;
+  sizes[400] = 12;
+  sizes[500] = 7;
+
+  std::string trivialBuf, fbwBuf, varintBuf, mcBuf;
+  serde::detail::writeTrailer(sizes, EncodingType::Trivial, trivialBuf);
+  serde::detail::writeTrailer(sizes, EncodingType::FixedBitWidth, fbwBuf);
+  serde::detail::writeTrailer(sizes, EncodingType::Varint, varintBuf);
+  serde::detail::writeTrailer(sizes, EncodingType::MainlyConstant, mcBuf);
+
+  // MainlyConstant should beat all others on this sparse input.
+  EXPECT_LT(mcBuf.size(), trivialBuf.size());
+  EXPECT_LT(mcBuf.size(), fbwBuf.size());
+  EXPECT_LT(mcBuf.size(), varintBuf.size());
+
+  // All four should roundtrip to the same values.
+  for (const auto* buf : {&trivialBuf, &fbwBuf, &varintBuf, &mcBuf}) {
+    auto decoded =
+        serde::detail::readTrailerStreamSizes(buf->data() + buf->size());
+    EXPECT_EQ(decoded, sizes);
+  }
+}
+
+// Randomized roundtrip: encode then decode a fuzzed stream-sizes vector.
+// Length is drawn uniformly from [0, kMaxStreamCount], values are drawn
+// uniformly across uint32_t. Seed is fixed so the test is fully
+// deterministic and reproducible.
+TEST_F(EncodeDecodeTest, mainlyConstantRandomRoundtrip) {
+  constexpr uint32_t kSeed = 0xC0FFEE;
+  std::mt19937 rng(kSeed);
+
+  constexpr uint32_t kMaxStreamCount = 5'000;
+  constexpr int kIterations = 200;
+  std::uniform_int_distribution<uint32_t> lengthDist(0, kMaxStreamCount);
+  std::uniform_int_distribution<uint32_t> valueDist(
+      0, std::numeric_limits<uint32_t>::max());
+  // Per iteration, draw a fresh nonzero density so we cover both
+  // sparse (MainlyConstant's sweet spot) and dense inputs.
+  std::uniform_int_distribution<int> densityDist(0, 100);
+
+  for (int iter = 0; iter < kIterations; ++iter) {
+    const uint32_t streamCount = lengthDist(rng);
+    const int nonzeroPercent = densityDist(rng);
+    SCOPED_TRACE(
+        fmt::format(
+            "iter={} streamCount={} nonzeroPercent={}",
+            iter,
+            streamCount,
+            nonzeroPercent));
+
+    std::vector<uint32_t> sizes;
+    sizes.reserve(streamCount);
+    std::uniform_int_distribution<int> coinDist(0, 99);
+    for (uint32_t i = 0; i < streamCount; ++i) {
+      sizes.push_back(coinDist(rng) < nonzeroPercent ? valueDist(rng) : 0);
+    }
+
+    std::string buffer;
+    serde::detail::writeTrailer(sizes, EncodingType::MainlyConstant, buffer);
+    const auto decoded =
+        serde::detail::readTrailerStreamSizes(buffer.data() + buffer.size());
+    EXPECT_EQ(decoded, sizes);
+  }
+}
+
 TEST_F(EncodeDecodeTest, streamSizesEncodingType) {
   std::vector<uint32_t> sizes = {2, 2, 2};
 
   for (auto encodingType :
        {EncodingType::Trivial,
         EncodingType::FixedBitWidth,
-        EncodingType::Varint}) {
+        EncodingType::Varint,
+        EncodingType::MainlyConstant}) {
     SCOPED_TRACE(toString(encodingType));
 
     std::string buffer;


### PR DESCRIPTION
Summary:

Sketch / RFC implementation of a new trailer encoding for `kCompactRaw` Nimble serialization, designed to compress trailers dominated by a single value (typically zero — empty stream slots).

Motivation: hybrid-nimble's flat-map schema persists every key ever seen by the Serializer. A blob with ~20 active features but a 2,960-slot schema pays for all 2,940 empty slots in the trailer. Measured per-batch overhead in our EBF benchmark: ~40 MB of projected output bytes goes entirely to empty-slot trailer entries (verified by `projection_dump` probe in the prior debug commit).

### New format

Reuses `EncodingType::MainlyConstant` (value 10). Added to the allow-list in `getTrailerEncodingType`.

Wire format (`writeMainlyConstantTrailer` in fbcode/dwio/nimble/serializer/SerializerImpl.h):

```
[encType:1B] [count:varint] [constant:varint] [K:varint]
[idxBitWidth:1B] [idx_packed: K * idxBitWidth bits]
[valBitWidth:1B] [val_packed: K * valBitWidth bits]
[trailer_size:u32]
```

- `count` = total number of stream slots (needed at decode for allocation)
- `constant` = most common stream size (mode; ties broken by smaller value, which favors 0)
- `K` = number of slots whose size != `constant`
- `idx_packed` = FBW-packed sorted indices of non-constant slots
- `val_packed` = FBW-packed values at those indices

Decode: allocate `count` slots filled with `constant`, then patch K positions from the packed arrays. O(N) fill + O(K) patch.

### Sizing math (compared to existing encodings)

For 1000 slots with 5 non-zero entries (typical hybrid full-projection blob):
- Trivial:        ~4005 bytes
- FixedBitWidth:  ~877 bytes  (bitWidth=7 to fit max non-const)
- Varint:         ~1010 bytes (1 byte per zero)
- MainlyConstant: **~24 bytes**  (1 + 2 + 1 + 1 + 1 + ceil(5*10/8) + 1 + ceil(5*7/8))

Verified by the new `mainlyConstantSparseSize` gtest, which asserts MainlyConstant < {Trivial, FixedBitWidth, Varint} on a 1000-slot sparse input.

### Selector

The trailer encoding is still chosen via `streamSizesEncodingType` in `SerializerOptions`. Caller must opt in by passing `EncodingType::MainlyConstant`. Auto-selection by smallest size is left for a follow-up.

`estimateTrailerSize` returns a conservative upper bound assuming worst-case K=numStreams and 32-bit values.

### Backwards compatibility

Old readers (binaries without this code) will hit the `NIMBLE_FAIL` in `decodeTrailerStreamSizes` if they see an unknown trailer encoding type. Recommended rollout:
1. Land + roll out to all reader binaries first
2. Only flip writer default after readers are updated
3. Existing writers continue using the explicitly-configured encoding (default: FixedBitWidth) — no behavior change unless user opts in

### Tests

fbcode/dwio/nimble/serializer/tests/SerializerImplTest.cpp:
- `readTrailerStreamSizesMainlyConstant`: roundtrip over 10 cases (empty, single value, all-same, all-distinct, scattered sparse, large constant, 1000-slot sparse matching the hybrid benchmark workload)
- `streamSizesEncodingType`: extended to include MainlyConstant alongside Trivial/FixedBitWidth/Varint
- `mainlyConstantSparseSize`: asserts MainlyConstant produces strictly smaller output than the other three encodings on a sparse input

Reviewed By: xiaoxmeng

Differential Revision: D106901951


