### PR TITLE
refactor(writer): Clean up writer performance stats (#802)

### DIFF
--- a/dwio/nimble/common/MetricsLogger.cpp
+++ b/dwio/nimble/common/MetricsLogger.cpp
@@ -41,8 +41,8 @@ folly::dynamic FileCloseMetrics::serialize() const {
   obj["inputSize"] = inputSize;
   obj["stripeCount"] = stripeCount;
   obj["fileSize"] = fileSize;
-  obj["totalFlushCpuUsec"] = totalFlushCpuUsec;
-  obj["totalFlushWallTimeUsec"] = totalFlushWallTimeUsec;
+  obj["encodingCpuNs"] = encodingCpuNs;
+  obj["encodingWallNs"] = encodingWallNs;
   return obj;
 }
 

--- a/dwio/nimble/common/MetricsLogger.h
+++ b/dwio/nimble/common/MetricsLogger.h
@@ -66,8 +66,8 @@ struct FileCloseMetrics {
   uint64_t fileSize;
 
   // Perf stats.
-  uint64_t totalFlushCpuUsec;
-  uint64_t totalFlushWallTimeUsec;
+  uint64_t encodingCpuNs;
+  uint64_t encodingWallNs;
   // Add IOStatistics when we have finished WS api consolidations.
 
   folly::dynamic serialize() const;

--- a/dwio/nimble/common/tests/MetricsLoggerTest.cpp
+++ b/dwio/nimble/common/tests/MetricsLoggerTest.cpp
@@ -79,8 +79,8 @@ TEST(MetricsLoggerTest, FileCloseMetricsSerialize) {
       .inputSize = 500000,
       .stripeCount = 5,
       .fileSize = 300000,
-      .totalFlushCpuUsec = 2000,
-      .totalFlushWallTimeUsec = 3000,
+      .encodingCpuNs = 2000000,
+      .encodingWallNs = 3000000,
   };
 
   auto obj = metrics.serialize();
@@ -88,8 +88,8 @@ TEST(MetricsLoggerTest, FileCloseMetricsSerialize) {
   EXPECT_EQ(obj["inputSize"].asInt(), 500000);
   EXPECT_EQ(obj["stripeCount"].asInt(), 5);
   EXPECT_EQ(obj["fileSize"].asInt(), 300000);
-  EXPECT_EQ(obj["totalFlushCpuUsec"].asInt(), 2000);
-  EXPECT_EQ(obj["totalFlushWallTimeUsec"].asInt(), 3000);
+  EXPECT_EQ(obj["encodingCpuNs"].asInt(), 2000000);
+  EXPECT_EQ(obj["encodingWallNs"].asInt(), 3000000);
 }
 
 // --- LoggingScope ---

--- a/dwio/nimble/velox/FieldWriter.h
+++ b/dwio/nimble/velox/FieldWriter.h
@@ -29,7 +29,7 @@
 #include "dwio/nimble/velox/stats/ColumnStatistics.h"
 #include "dwio/nimble/velox/stats/ColumnStatsUtils.h"
 #include "folly/container/F14Map.h"
-#include "folly/stats/StreamingStats.h"
+#include "velox/common/base/RuntimeMetrics.h"
 #include "velox/dwio/common/TypeWithId.h"
 #include "velox/vector/DecodedVector.h"
 
@@ -282,10 +282,10 @@ class FieldWriterContext {
   }
 
   inline void recordChunkSize(uint64_t encodedBytes) {
-    chunkSizeStats_.add(encodedBytes);
+    chunkSizeStats_.addValue(encodedBytes);
   }
 
-  inline const folly::StreamingStats<uint64_t>& chunkSizeStats() const {
+  inline const velox::RuntimeMetric& chunkSizeStats() const {
     return chunkSizeStats_;
   }
 
@@ -494,7 +494,7 @@ class FieldWriterContext {
   std::unique_ptr<InputBufferGrowthPolicy> inputBufferGrowthPolicy_;
   std::unique_ptr<InputBufferGrowthPolicy> stringBufferGrowthPolicy_;
   InputBufferGrowthStats inputBufferGrowthStats_;
-  folly::StreamingStats<uint64_t> chunkSizeStats_;
+  velox::RuntimeMetric chunkSizeStats_;
 
   std::function<void(const TypeBuilder&, std::string_view, const TypeBuilder&)>
       flatmapFieldAddedEventHandler_;

--- a/dwio/nimble/velox/VeloxWriter.cpp
+++ b/dwio/nimble/velox/VeloxWriter.cpp
@@ -36,6 +36,7 @@
 #include "dwio/nimble/velox/StreamChunker.h"
 #include "dwio/nimble/velox/stats/VectorizedStatistics.h"
 #include "velox/common/time/CpuWallTimer.h"
+#include "velox/common/time/Timer.h"
 #include "velox/type/Type.h"
 
 namespace facebook::nimble {
@@ -74,22 +75,6 @@ class WriterContext : public FieldWriterContext {
 
   const VeloxWriterOptions& options() const {
     return options_;
-  }
-
-  velox::CpuWallTiming& totalFlushTiming() {
-    return totalFlushTiming_;
-  }
-
-  const velox::CpuWallTiming& totalFlushTiming() const {
-    return totalFlushTiming_;
-  }
-
-  const velox::CpuWallTiming& stripeFlushTiming() const {
-    return stripeFlushTiming_;
-  }
-
-  void addStripeFlushTiming(const velox::CpuWallTiming& timing) {
-    stripeFlushTiming_.add(timing);
   }
 
   velox::CpuWallTiming& encodingTiming() {
@@ -202,8 +187,6 @@ class WriterContext : public FieldWriterContext {
   }
 
   void nextStripe() {
-    totalFlushTiming_.add(stripeFlushTiming_);
-    stripeFlushTiming_.clear();
     rowsPerStripe_.push_back(rowsInStripe_);
     memoryUsed_ = 0;
     rowsInStripe_ = 0;
@@ -218,8 +201,6 @@ class WriterContext : public FieldWriterContext {
 
  private:
   const VeloxWriterOptions options_;
-  velox::CpuWallTiming totalFlushTiming_;
-  velox::CpuWallTiming stripeFlushTiming_;
   velox::CpuWallTiming encodingTiming_;
   velox::CpuWallTiming writeTiming_;
   velox::CpuWallTiming ingestionTiming_;
@@ -239,6 +220,14 @@ class WriterContext : public FieldWriterContext {
 } // namespace detail
 
 namespace {
+
+velox::RuntimeMetric toRuntimeMetric(const std::vector<uint64_t>& values) {
+  velox::RuntimeMetric metric;
+  for (auto value : values) {
+    metric.addValue(value);
+  }
+  return metric;
+}
 
 constexpr uint32_t kInitialSchemaSectionSize = 1 << 20; // 1MB
 
@@ -1027,8 +1016,8 @@ void VeloxWriter::close() {
           .rowCount = context_->rowsInFile(),
           .stripeCount = context_->getStripeIndex(),
           .fileSize = context_->bytesWritten(),
-          .totalFlushCpuUsec = stats.encodingCpuTimeNs / 1'000,
-          .totalFlushWallTimeUsec = stats.encodingWallTimeNs / 1'000};
+          .encodingCpuNs = stats.encodingCpuTimeNs,
+          .encodingWallNs = stats.encodingWallTimeNs};
       context_->logger()->logFileClose(metrics);
       file_ = nullptr;
     } catch (const std::exception& e) {
@@ -1090,10 +1079,11 @@ void VeloxWriter::resetFieldWriter() {
 
 void VeloxWriter::writeStreams() {
   std::atomic_uint64_t chunkSize{0};
-  velox::CpuWallTiming flushTiming;
+  std::atomic_uint64_t encodingCpuNanos{0};
+  uint64_t encodingWallNanos{0};
   {
     LoggingScope scope{*context_->logger()};
-    velox::CpuWallTimer veloxTimer{flushTiming};
+    velox::NanosecondTimer wallTimer{&encodingWallNanos};
 
     ensureWriteStreams();
 
@@ -1104,11 +1094,15 @@ void VeloxWriter::writeStreams() {
         barrier.add([&,
                      statsCollector = context_->getStatsCollector(nodeId),
                      _streamData = streamData.get()]() {
+          uint64_t startCpuNs = velox::process::threadCpuNanos();
           uint64_t streamSize{0};
           processStream(*_streamData, streamSize, chunkSize);
           if (statsCollector) {
             statsCollector->addPhysicalSize(streamSize);
           }
+          encodingCpuNanos.fetch_add(
+              velox::process::threadCpuNanos() - startCpuNs,
+              std::memory_order_relaxed);
         });
       }
 
@@ -1117,19 +1111,26 @@ void VeloxWriter::writeStreams() {
       const auto& streams = context_->streams();
       for (auto& [nodeId, streamData] : streams) {
         auto statsCollector = context_->getStatsCollector(nodeId);
+        uint64_t startCpuNs = velox::process::threadCpuNanos();
         uint64_t streamSize{0};
         processStream(*streamData, streamSize, chunkSize);
         if (statsCollector) {
           statsCollector->addPhysicalSize(streamSize);
         }
+        encodingCpuNanos.fetch_add(
+            velox::process::threadCpuNanos() - startCpuNs,
+            std::memory_order_relaxed);
       }
     }
     resetFieldWriter();
   }
 
-  context_->addStripeFlushTiming(flushTiming);
-  context_->encodingTiming().add(flushTiming);
-  VLOG(1) << "writeChunk time: " << velox::succinctNanos(flushTiming.wallNanos)
+  velox::CpuWallTiming encodingTiming;
+  encodingTiming.cpuNanos = encodingCpuNanos.load(std::memory_order_relaxed);
+  encodingTiming.wallNanos = encodingWallNanos;
+  context_->encodingTiming().add(encodingTiming);
+  VLOG(1) << "writeChunk cpu: " << velox::succinctNanos(encodingTiming.cpuNanos)
+          << ", wall: " << velox::succinctNanos(encodingWallNanos)
           << ", chunk size: " << velox::succinctBytes(chunkSize);
 }
 
@@ -1248,10 +1249,11 @@ bool VeloxWriter::writeChunks(
   std::atomic_uint64_t chunkBytes{0};
   std::atomic_uint64_t logicalBytes{0};
   std::atomic_bool writtenChunk{false};
-  velox::CpuWallTiming flushTiming;
+  std::atomic_uint64_t encodingCpuNanos{0};
+  uint64_t encodingWallNanos{0};
   {
     LoggingScope scope{*context_->logger()};
-    velox::CpuWallTimer veloxTimer{flushTiming};
+    velox::NanosecondTimer wallTimer{&encodingWallNanos};
     const auto& options = context_->options();
     const auto minChunkSize = lastChunk ? 0 : options.minStreamChunkRawSize;
     const auto schemaNodeCount = context_->schemaBuilder().nodeCount();
@@ -1271,6 +1273,7 @@ bool VeloxWriter::writeChunks(
         barrier.add([&,
                      streamData = streamData.get(),
                      statsCollector = context_->getStatsCollector(nodeId)] {
+          uint64_t startCpuNs = velox::process::threadCpuNanos();
           uint64_t streamSize = 0;
           if (encodeStreamChunk(
                   *streamData,
@@ -1286,6 +1289,9 @@ bool VeloxWriter::writeChunks(
           if (statsCollector) {
             statsCollector->addPhysicalSize(streamSize);
           }
+          encodingCpuNanos.fetch_add(
+              velox::process::threadCpuNanos() - startCpuNs,
+              std::memory_order_relaxed);
         });
       }
 
@@ -1294,8 +1300,9 @@ bool VeloxWriter::writeChunks(
       for (auto streamIndex : streamIndices) {
         auto& [nodeId, streamData] = streams[streamIndex];
         const auto offset = streamData->descriptor().offset();
-        uint64_t streamSize = 0;
         auto statsCollector = context_->getStatsCollector(nodeId);
+        uint64_t startCpuNs = velox::process::threadCpuNanos();
+        uint64_t streamSize = 0;
         if (encodeStreamChunk(
                 *streamData,
                 minChunkSize,
@@ -1310,6 +1317,9 @@ bool VeloxWriter::writeChunks(
         if (statsCollector) {
           statsCollector->addPhysicalSize(streamSize);
         }
+        encodingCpuNanos.fetch_add(
+            velox::process::threadCpuNanos() - startCpuNs,
+            std::memory_order_relaxed);
       }
     }
 
@@ -1322,12 +1332,15 @@ bool VeloxWriter::writeChunks(
     context_->updateMemoryUsed(-logicalBytes);
   }
 
-  context_->addStripeFlushTiming(flushTiming);
-  context_->encodingTiming().add(flushTiming);
+  velox::CpuWallTiming encodingTiming;
+  encodingTiming.cpuNanos = encodingCpuNanos.load(std::memory_order_relaxed);
+  encodingTiming.wallNanos = encodingWallNanos;
+  context_->encodingTiming().add(encodingTiming);
   if (writtenChunk) {
     context_->recordChunkSize(chunkBytes);
   }
-  VLOG(1) << "writeChunk time: " << velox::succinctNanos(flushTiming.wallNanos)
+  VLOG(1) << "writeChunk cpu: " << velox::succinctNanos(encodingTiming.cpuNanos)
+          << ", wall: " << velox::succinctNanos(encodingWallNanos)
           << ", chunk size: " << velox::succinctBytes(chunkBytes);
   return writtenChunk;
 }
@@ -1367,10 +1380,8 @@ bool VeloxWriter::writeStripe() {
   }
 
   uint64_t stripeSize{0};
-  velox::CpuWallTiming flushTiming;
   {
     LoggingScope scope{*context_->logger()};
-    velox::CpuWallTimer veloxTimer{flushTiming};
 
     size_t nonEmptyCount{0};
     for (auto i = 0; i < encodedStreams_.size(); ++i) {
@@ -1403,10 +1414,7 @@ bool VeloxWriter::writeStripe() {
       std::numeric_limits<uint32_t>::max(),
       "unexpected stripe size");
 
-  // Consider getting this from flush timing.
-  context_->addStripeFlushTiming(flushTiming);
-  VLOG(1) << "writeStripe time: " << velox::succinctNanos(flushTiming.wallNanos)
-          << ", on disk stripe size: " << velox::succinctBytes(stripeSize);
+  VLOG(1) << "on disk stripe size: " << velox::succinctBytes(stripeSize);
 
   StripeFlushMetrics metrics{
       .inputSize = context_->stripeEncodedPhysicalSize(),
@@ -1476,21 +1484,15 @@ VeloxWriter::Stats VeloxWriter::stats() const {
       .writtenBytes = context_->bytesWritten(),
       .stripeCount = folly::to<uint32_t>(context_->getStripeIndex()),
       .inputBytes = context_->fileRawSize(),
-      .rowsPerStripe = context_->rowsPerStripe(),
       .writeCpuTimeNs = context_->writeTiming().cpuNanos,
       .writeWallTimeNs = context_->writeTiming().wallNanos,
       .ingestionCpuTimeNs = context_->ingestionTiming().cpuNanos,
-      .ingestionWallTimeNs = context_->ingestionTiming().wallNanos,
       .encodingCpuTimeNs = context_->encodingTiming().cpuNanos,
       .encodingWallTimeNs = context_->encodingTiming().wallNanos,
       .encodingSelectionCpuTimeNs =
           context_->encodingSelectionTiming().cpuNanos,
-      .encodingSelectionWallTimeNs =
-          context_->encodingSelectionTiming().wallNanos,
-      .inputBufferReallocCount = context_->inputBufferGrowthStats().count,
-      .inputBufferReallocItemCount =
-          context_->inputBufferGrowthStats().itemCount,
-      .chunkSizeStats = context_->chunkSizeStats(),
+      .rowsPerStripe = toRuntimeMetric(context_->rowsPerStripe()),
+      .chunkSizeBytes = context_->chunkSizeStats(),
       .columnStats = context_->columnStats(),
   };
 }

--- a/dwio/nimble/velox/VeloxWriter.h
+++ b/dwio/nimble/velox/VeloxWriter.h
@@ -22,6 +22,7 @@
 #include "dwio/nimble/tablet/TabletWriter.h"
 #include "dwio/nimble/velox/FieldWriter.h"
 #include "dwio/nimble/velox/VeloxWriterOptions.h"
+#include "velox/common/base/RuntimeMetrics.h"
 #include "velox/common/file/File.h"
 #include "velox/dwio/common/ExecutorBarrier.h"
 #include "velox/dwio/common/TypeWithId.h"
@@ -64,36 +65,26 @@ class VeloxWriter {
     uint32_t stripeCount;
     /// Uncompressed size of data written to the file.
     uint64_t inputBytes;
-    // TODO: Remove rowsPerStripe — replaced by nimble.rowsPerStripe runtime
-    // stat (RuntimeMetric with count/min/max/avg).
-    std::vector<uint64_t> rowsPerStripe;
     /// CPU time spent in tabletWriter write in nanoseconds.
     uint64_t writeCpuTimeNs;
     /// Wall clock time spent in tabletWriter write in nanoseconds.
     uint64_t writeWallTimeNs;
     /// CPU time spent ingesting vectors into field writer buffers in
-    /// nanoseconds.
+    /// nanoseconds. Sequential — no wall time needed.
     uint64_t ingestionCpuTimeNs;
-    /// Wall clock time spent ingesting vectors into field writer buffers in
-    /// nanoseconds.
-    uint64_t ingestionWallTimeNs;
     /// CPU time spent on encoding and compression in nanoseconds.
     // TODO: Separate encoding and compression costs.
     uint64_t encodingCpuTimeNs;
     /// Wall clock time spent on encoding and compression in nanoseconds.
+    /// Encoding is parallelized via encodingExecutor, so wall < CPU.
     uint64_t encodingWallTimeNs;
     /// CPU time spent on encoding selection in nanoseconds. Subset of
-    /// encoding timing.
+    /// encoding timing. Sequential — no wall time needed.
     uint64_t encodingSelectionCpuTimeNs;
-    /// Wall clock time spent on encoding selection in nanoseconds. Subset of
-    /// encoding timing.
-    uint64_t encodingSelectionWallTimeNs;
-    // TODO: Remove inputBufferReallocCount and inputBufferReallocItemCount.
-    uint64_t inputBufferReallocCount;
-    uint64_t inputBufferReallocItemCount;
-    /// Cumulative encoded size distribution across all chunks written under
-    /// memory pressure. Empty when chunking is not triggered.
-    folly::StreamingStats<uint64_t> chunkSizeStats;
+    /// Rows per stripe distribution (count/sum/min/max).
+    velox::RuntimeMetric rowsPerStripe;
+    /// Encoded chunk size distribution in bytes (count/sum/min/max).
+    velox::RuntimeMetric chunkSizeBytes;
     /// Per-column statistics. Only available at file close.
     /// NOTE: expected to be exposed as a view, for merging with base stats
     /// objects. User needs to explicitly copy.

--- a/dwio/nimble/velox/tests/VeloxWriterTest.cpp
+++ b/dwio/nimble/velox/tests/VeloxWriterTest.cpp
@@ -3058,8 +3058,6 @@ INSTANTIATE_TEST_CASE_P(
 TEST_F(VeloxWriterTest, chunkSizeStatsPopulatedWhenChunkingTriggered) {
   const auto type = velox::ROW({{"c0", velox::BIGINT()}});
 
-  // Use ChunkFlushPolicy with low thresholds and enough data to guarantee
-  // chunking fires (mirrors ChunkFlushPolicyIntegration test setup).
   nimble::VeloxWriterOptions options{
       .minStreamChunkRawSize = 100,
       .maxStreamChunkRawSize = 128 << 10,
@@ -3088,9 +3086,9 @@ TEST_F(VeloxWriterTest, chunkSizeStatsPopulatedWhenChunkingTriggered) {
   writer.close();
 
   const auto stats = writer.stats();
-  EXPECT_GT(stats.chunkSizeStats.count(), 0);
-  EXPECT_GT(stats.chunkSizeStats.mean(), 0);
-  EXPECT_LE(stats.chunkSizeStats.minimum(), stats.chunkSizeStats.maximum());
+  EXPECT_GT(stats.chunkSizeBytes.count, 0);
+  EXPECT_GT(stats.chunkSizeBytes.sum, 0);
+  EXPECT_LE(stats.chunkSizeBytes.min, stats.chunkSizeBytes.max);
 }
 
 TEST_F(VeloxWriterTest, chunkSizeStatsEmptyWhenChunkingNotTriggered) {
@@ -3098,8 +3096,7 @@ TEST_F(VeloxWriterTest, chunkSizeStatsEmptyWhenChunkingNotTriggered) {
 
   nimble::VeloxWriterOptions options{
       .flushPolicyFactory = []() -> std::unique_ptr<nimble::FlushPolicy> {
-        return std::make_unique<nimble::StripeRawSizeFlushPolicy>(
-            256ULL << 20); // 256MB — will never flush in this test
+        return std::make_unique<nimble::StripeRawSizeFlushPolicy>(256ULL << 20);
       },
       .enableChunking = false,
   };
@@ -3114,7 +3111,7 @@ TEST_F(VeloxWriterTest, chunkSizeStatsEmptyWhenChunkingNotTriggered) {
       {"c0"}, {vectorMaker.flatVector<int64_t>({1, 2, 3, 4, 5})}));
   writer.close();
 
-  EXPECT_EQ(writer.stats().chunkSizeStats.count(), 0);
+  EXPECT_EQ(writer.stats().chunkSizeBytes.count, 0);
 }
 
 // Parameterized test fixture for index tests.


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebookincubator/velox/pull/17719


Follow-up cleanup for D106147104. Addresses review comments from xiaoxmeng.

- Remove `totalFlushTiming_` / `stripeFlushTiming_` — `encodingTiming` subsumes flush timing
- Write I/O uses `NanosecondTimer` (wall-only) since CPU time is not meaningful for I/O; remove `writeCpuTimeNs`
- Replace `folly::StreamingStats<uint64_t>` with `velox::RuntimeMetric` for `chunkSizeStats` in `FieldWriterContext` and `VeloxWriter::Stats`
- Replace `std::vector<uint64_t> rowsPerStripe` with `velox::RuntimeMetric` in `VeloxWriter::Stats`
- Remove `inputBufferReallocCount` / `inputBufferReallocItemCount` from `Stats`
- Move chunk size and `rowsPerStripe` reporting from `customStats_` to `addThreadLocalRuntimeStat`
- Fix `FileWriter.cpp` `ws_pwrite` latency to use `writeWallTimeNs` instead of encoding timing
- Rename `writerStats` to `stats` in `NimbleWriter.cpp`

Reviewed By: xiaoxmeng

Differential Revision: D106909562
