### PR TITLE
refactor(nimble): Extract trailer decode/estimate cases and compression cases into helper functions

### DIFF
--- a/dwio/nimble/serializer/SerializerImpl.cpp
+++ b/dwio/nimble/serializer/SerializerImpl.cpp
@@ -32,6 +32,54 @@ namespace facebook::nimble::serde::detail {
 
 namespace {
 
+std::vector<uint32_t> decodeTrivialTrailer(
+    const char*& payload,
+    uint32_t payloadSize) {
+  const uint32_t count = payloadSize / sizeof(uint32_t);
+  std::vector<uint32_t> sizes(count);
+  if (count > 0) {
+    std::memcpy(sizes.data(), payload, count * sizeof(uint32_t));
+    payload += count * sizeof(uint32_t);
+  }
+  return sizes;
+}
+
+std::vector<uint32_t> decodeVarintTrailer(const char*& payload) {
+  const uint32_t count = varint::readVarint32(&payload);
+  std::vector<uint32_t> sizes(count);
+  for (uint32_t i = 0; i < count; ++i) {
+    sizes[i] = varint::readVarint32(&payload);
+  }
+  return sizes;
+}
+
+std::vector<uint32_t> decodeDeltaTrailer(const char*& payload) {
+  const uint32_t count = varint::readVarint32(&payload);
+  std::vector<uint32_t> sizes(count);
+  if (count > 0) {
+    sizes[0] = varint::readVarint32(&payload);
+    for (uint32_t i = 1; i < count; ++i) {
+      const auto delta = varint::readVarint32(&payload);
+      sizes[i] = sizes[i - 1] + delta;
+    }
+  }
+  return sizes;
+}
+
+std::vector<uint32_t> decodeFixedBitWidthTrailer(const char*& payload) {
+  const uint8_t bitWidth = static_cast<uint8_t>(*payload++);
+  const uint32_t count = varint::readVarint32(&payload);
+  std::vector<uint32_t> sizes(count);
+  if (bitWidth > 0 && count > 0) {
+    const uint32_t packedBytes =
+        static_cast<uint32_t>(FixedBitArray::bufferSize(count, bitWidth));
+    FixedBitArray arr{const_cast<char*>(payload), static_cast<int>(bitWidth)};
+    arr.bulkGet32(0, count, sizes.data());
+    payload += packedBytes;
+  }
+  return sizes;
+}
+
 std::vector<uint32_t> decodeMainlyConstantTrailer(const char*& payload) {
   const uint32_t streamCount = varint::readVarint32(&payload);
   const uint32_t nonZeroCount = varint::readVarint32(&payload);
@@ -77,8 +125,83 @@ std::vector<uint32_t> decodeMainlyConstantTrailer(const char*& payload) {
   return sizes;
 }
 
-// Upper bound on the MainlyConstant trailer payload size for a stream of
-// 'numStreams' values. idxBitWidth matches the writer's formula (max(1,
+// Upper-bound payload-size estimators (one per trailer encoding). Each
+// returns the payload bytes between the encoding-type byte and the trailing
+// trailer_size u32. estimateTrailerSize() adds the encoding-type byte and
+// the trailer_size suffix.
+
+// Compresses 'input' into 'compPos' (which already has the compression-type
+// byte written). Returns the number of bytes written if compression was
+// beneficial; std::nullopt if the caller should fall back to uncompressed.
+
+std::optional<uint32_t> compressZstd(
+    const SerializerOptions& options,
+    std::string_view input,
+    char* compPos,
+    uint32_t size) {
+  const auto ret = ZSTD_compress(
+      compPos, size, input.data(), size, options.compressionLevel);
+  if (ZSTD_isError(ret)) {
+    NIMBLE_CHECK_EQ(
+        static_cast<int>(ZSTD_getErrorCode(ret)),
+        static_cast<int>(ZSTD_error_dstSize_tooSmall),
+        "zstd error");
+    return std::nullopt;
+  }
+  return static_cast<uint32_t>(ret);
+}
+
+std::optional<uint32_t> compressLz4(
+    const SerializerOptions& options,
+    std::string_view input,
+    char* compPos,
+    uint32_t size) {
+  // LZ4 block mode is not self-descriptive (unlike ZSTD frames), so we
+  // prepend the uncompressed size as a uint32 before the compressed data.
+  // Wire format: [size:u32][compType:i8=3][origSize:u32][lz4_data...]
+  const auto origSize = static_cast<uint32_t>(input.size());
+  encoding::writeUint32(origSize, compPos);
+  constexpr int kMinHcLevel = LZ4HC_CLEVEL_MIN;
+  const auto compressedSize = options.compressionLevel >= kMinHcLevel
+      ? LZ4_compress_HC(
+            input.data(),
+            compPos,
+            static_cast<int>(input.size()),
+            static_cast<int>(size),
+            options.compressionLevel)
+      : LZ4_compress_default(
+            input.data(),
+            compPos,
+            static_cast<int>(input.size()),
+            static_cast<int>(size));
+  if (compressedSize == 0 ||
+      static_cast<uint32_t>(compressedSize) >= origSize) {
+    return std::nullopt;
+  }
+  return sizeof(uint32_t) + static_cast<uint32_t>(compressedSize);
+}
+
+size_t estimateTrivialTrailerPayloadSize(size_t numStreams) {
+  return numStreams * sizeof(uint32_t);
+}
+
+size_t estimateVarintTrailerPayloadSize(size_t numStreams) {
+  // count varint + N varints (max 5 bytes each).
+  return 5 + numStreams * 5;
+}
+
+size_t estimateDeltaTrailerPayloadSize(size_t numStreams) {
+  // count varint + first offset varint + (N-1) delta varints (max 5 bytes
+  // each).
+  return 5 + numStreams * 5;
+}
+
+size_t estimateFixedBitWidthTrailerPayloadSize(size_t numStreams) {
+  // bitWidth:1B + count varint + bufferSize (32 bits per element max).
+  return 1 + 5 + FixedBitArray::bufferSize(numStreams, /*bitWidth=*/32);
+}
+
+// MainlyConstant: idxBitWidth matches the writer's formula (max(1,
 // bit_width(numStreams - 1)) when there are indices); valBitWidth is
 // unbounded up to 32 since values are uint32_t.
 size_t estimateMainlyConstantTrailerPayloadSize(size_t numStreams) {
@@ -102,53 +225,21 @@ std::vector<uint32_t> decodeTrailerStreamSizes(
   std::vector<uint32_t> sizes;
 
   switch (encodingType) {
-    case EncodingType::Trivial: {
-      const uint32_t count = payloadSize / sizeof(uint32_t);
-      sizes.resize(count);
-      if (count > 0) {
-        std::memcpy(sizes.data(), payload, count * sizeof(uint32_t));
-        payload += count * sizeof(uint32_t);
-      }
+    case EncodingType::Trivial:
+      sizes = decodeTrivialTrailer(payload, payloadSize);
       break;
-    }
-    case EncodingType::Varint: {
-      const uint32_t count = varint::readVarint32(&payload);
-      sizes.resize(count);
-      for (uint32_t i = 0; i < count; ++i) {
-        sizes[i] = varint::readVarint32(&payload);
-      }
+    case EncodingType::Varint:
+      sizes = decodeVarintTrailer(payload);
       break;
-    }
-    case EncodingType::Delta: {
-      const uint32_t count = varint::readVarint32(&payload);
-      sizes.resize(count);
-      if (count > 0) {
-        sizes[0] = varint::readVarint32(&payload);
-        for (uint32_t i = 1; i < count; ++i) {
-          const auto delta = varint::readVarint32(&payload);
-          sizes[i] = sizes[i - 1] + delta;
-        }
-      }
+    case EncodingType::Delta:
+      sizes = decodeDeltaTrailer(payload);
       break;
-    }
-    case EncodingType::FixedBitWidth: {
-      const uint8_t bitWidth = static_cast<uint8_t>(*payload++);
-      const uint32_t count = varint::readVarint32(&payload);
-      sizes.resize(count);
-      if (bitWidth > 0 && count > 0) {
-        const uint32_t packedBytes =
-            static_cast<uint32_t>(FixedBitArray::bufferSize(count, bitWidth));
-        FixedBitArray arr{
-            const_cast<char*>(payload), static_cast<int>(bitWidth)};
-        arr.bulkGet32(0, count, sizes.data());
-        payload += packedBytes;
-      }
+    case EncodingType::FixedBitWidth:
+      sizes = decodeFixedBitWidthTrailer(payload);
       break;
-    }
-    case EncodingType::MainlyConstant: {
+    case EncodingType::MainlyConstant:
       sizes = decodeMainlyConstantTrailer(payload);
       break;
-    }
     default:
       NIMBLE_FAIL(
           "Unsupported EncodingType for stream sizes trailer: {}",
@@ -198,53 +289,20 @@ encode(const SerializerOptions& options, std::string_view input, char* output) {
       size >= options.compressionThreshold) {
     auto* compPos = output + sizeof(uint32_t);
     encoding::writeChar(static_cast<int8_t>(compression), compPos);
-    // TODO: share compression implementation
+    std::optional<uint32_t> compressedSize;
     switch (compression) {
-      case CompressionType::Zstd: {
-        const auto ret = ZSTD_compress(
-            compPos, size, input.data(), size, options.compressionLevel);
-        if (ZSTD_isError(ret)) {
-          NIMBLE_CHECK_EQ(
-              static_cast<int>(ZSTD_getErrorCode(ret)),
-              static_cast<int>(ZSTD_error_dstSize_tooSmall),
-              "zstd error");
-          // Fall back to uncompressed
-        } else {
-          size = ret;
-          writeUncompressed = false;
-        }
+      case CompressionType::Zstd:
+        compressedSize = compressZstd(options, input, compPos, size);
         break;
-      }
-      case CompressionType::Lz4: {
-        // LZ4 block mode is not self-descriptive (unlike ZSTD frames), so we
-        // prepend the uncompressed size as a uint32 before the compressed data.
-        // Wire format: [size:u32][compType:i8=3][origSize:u32][lz4_data...]
-        const auto origSize = static_cast<uint32_t>(input.size());
-        encoding::writeUint32(origSize, compPos);
-        constexpr int kMinHcLevel = LZ4HC_CLEVEL_MIN;
-        const auto compressedSize = options.compressionLevel >= kMinHcLevel
-            ? LZ4_compress_HC(
-                  input.data(),
-                  compPos,
-                  static_cast<int>(input.size()),
-                  static_cast<int>(size),
-                  options.compressionLevel)
-            : LZ4_compress_default(
-                  input.data(),
-                  compPos,
-                  static_cast<int>(input.size()),
-                  static_cast<int>(size));
-        if (compressedSize == 0 ||
-            static_cast<uint32_t>(compressedSize) >= origSize) {
-          // Fall back to uncompressed
-        } else {
-          size = sizeof(uint32_t) + compressedSize;
-          writeUncompressed = false;
-        }
+      case CompressionType::Lz4:
+        compressedSize = compressLz4(options, input, compPos, size);
         break;
-      }
       default:
         NIMBLE_UNSUPPORTED("Unsupported compression {}", toString(compression));
+    }
+    if (compressedSize.has_value()) {
+      size = *compressedSize;
+      writeUncompressed = false;
     }
   }
 
@@ -295,22 +353,16 @@ size_t estimateTrailerSize(size_t numStreams, EncodingType encodingType) {
   size_t payloadSize{0};
   switch (resolvedType) {
     case EncodingType::Trivial:
-      payloadSize = numStreams * sizeof(uint32_t);
+      payloadSize = estimateTrivialTrailerPayloadSize(numStreams);
       break;
     case EncodingType::Varint:
-      // Upper bound: count varint + N varints (max 5 bytes each).
-      payloadSize = 5 + numStreams * 5;
+      payloadSize = estimateVarintTrailerPayloadSize(numStreams);
       break;
     case EncodingType::Delta:
-      // Upper bound: count varint + first offset varint + (N-1) delta
-      // varints (max 5 bytes each).
-      payloadSize = 5 + numStreams * 5;
+      payloadSize = estimateDeltaTrailerPayloadSize(numStreams);
       break;
     case EncodingType::FixedBitWidth:
-      // Upper bound: bitWidth:1B + count varint + bufferSize (32 bits per
-      // element max).
-      payloadSize =
-          1 + 5 + FixedBitArray::bufferSize(numStreams, /*bitWidth=*/32);
+      payloadSize = estimateFixedBitWidthTrailerPayloadSize(numStreams);
       break;
     case EncodingType::MainlyConstant:
       payloadSize = estimateMainlyConstantTrailerPayloadSize(numStreams);


### PR DESCRIPTION
Summary:
Followup to D106901951. Refactors SerializerImpl.cpp to extract each switch case body into a separate file-private helper in the anonymous namespace, leaving the dispatchers as simple lookup tables.

Three switches are refactored:
- `decodeTrailerStreamSizes` — extracts `decodeTrivialTrailer`, `decodeVarintTrailer`, `decodeDeltaTrailer`, `decodeFixedBitWidthTrailer` (`decodeMainlyConstantTrailer` already existed from the parent diff).
- `estimateTrailerSize` — extracts `estimateTrivialTrailerPayloadSize`, `estimateVarintTrailerPayloadSize`, `estimateDeltaTrailerPayloadSize`, `estimateFixedBitWidthTrailerPayloadSize` (`estimateMainlyConstantTrailerPayloadSize` already existed).
- `encode` — extracts `compressZstd` and `compressLz4`. Each returns `std::optional<uint32_t>` (compressed-size or `nullopt` to fall back to uncompressed).

Pure refactor — no wire-format or behavioral changes.

Differential Revision: D106975099


