### PR TITLE
perf: Extend BufferPool recycling to all scratch-buffer encodings

### DIFF
--- a/dwio/nimble/encodings/ALPEncoding.h
+++ b/dwio/nimble/encodings/ALPEncoding.h
@@ -169,11 +169,11 @@ class ALPEncoding final
   using physicalType = typename TypeTraits<T>::physicalType;
 
   ALPEncoding(
-      velox::memory::MemoryPool& memoryPool,
+      velox::memory::MemoryPool& pool,
       std::string_view data,
       std::function<void*(uint32_t)> /* stringBufferFactory */,
       const Encoding::Options& options = {})
-      : TypedEncoding<T, physicalType>(memoryPool, data, options), pos_(0) {
+      : TypedEncoding<T, physicalType>(pool, data, options), pos_(0) {
     const char* pos = data.data() + this->dataOffset();
 
     exponent_ = encoding::read<uint8_t>(pos);

--- a/dwio/nimble/encodings/ConstantEncoding.cpp
+++ b/dwio/nimble/encodings/ConstantEncoding.cpp
@@ -19,11 +19,11 @@
 namespace facebook::nimble {
 
 ConstantEncoding<std::string_view>::ConstantEncoding(
-    velox::memory::MemoryPool& memoryPool,
+    velox::memory::MemoryPool& pool,
     std::string_view data,
     std::function<void*(uint32_t)> stringBufferFactory,
     const Encoding::Options& options)
-    : ConstantEncodingBase<std::string_view>(memoryPool, data, options) {
+    : ConstantEncodingBase<std::string_view>(pool, data, options) {
   const char* pos = data.data() + this->dataOffset();
   value_ = encoding::read<physicalType>(pos);
   NIMBLE_CHECK(pos == data.end(), "Unexpected constant encoding end");

--- a/dwio/nimble/encodings/ConstantEncoding.h
+++ b/dwio/nimble/encodings/ConstantEncoding.h
@@ -39,10 +39,10 @@ class ConstantEncodingBase
   using physicalType = typename TypeTraits<T>::physicalType;
 
   ConstantEncodingBase(
-      velox::memory::MemoryPool& memoryPool,
+      velox::memory::MemoryPool& pool,
       std::string_view data,
       const Encoding::Options& options = {})
-      : TypedEncoding<T, physicalType>(memoryPool, data, options) {}
+      : TypedEncoding<T, physicalType>(pool, data, options) {}
 
   void reset() final {}
 
@@ -190,7 +190,7 @@ class ConstantEncoding : public ConstantEncodingBase<T> {
   using physicalType = typename TypeTraits<T>::physicalType;
 
   ConstantEncoding(
-      velox::memory::MemoryPool& memoryPool,
+      velox::memory::MemoryPool& pool,
       std::string_view data,
       std::function<void*(uint32_t)> stringBufferFactory,
       const Encoding::Options& options = {});
@@ -202,11 +202,11 @@ class ConstantEncoding : public ConstantEncodingBase<T> {
 
 template <typename T>
 ConstantEncoding<T>::ConstantEncoding(
-    velox::memory::MemoryPool& memoryPool,
+    velox::memory::MemoryPool& pool,
     std::string_view data,
     std::function<void*(uint32_t)> /* stringBufferFactory */,
     const Encoding::Options& options)
-    : ConstantEncodingBase<T>(memoryPool, data, options) {
+    : ConstantEncodingBase<T>(pool, data, options) {
   const char* pos = data.data() + this->dataOffset();
   this->value_ = encoding::read<physicalType>(pos);
   NIMBLE_CHECK_EQ(pos, data.end(), "Unexpected constant encoding end");
@@ -220,11 +220,11 @@ class ConstantEncoding<bool> final : public ConstantEncodingBase<bool> {
   using physicalType = bool;
 
   ConstantEncoding(
-      velox::memory::MemoryPool& memoryPool,
+      velox::memory::MemoryPool& pool,
       std::string_view data,
       std::function<void*(uint32_t)> /* stringBufferFactory */,
       const Encoding::Options& options = {})
-      : ConstantEncodingBase<bool>(memoryPool, data, options) {
+      : ConstantEncodingBase<bool>(pool, data, options) {
     const char* pos = data.data() + this->dataOffset();
     this->value_ = encoding::read<physicalType>(pos);
     NIMBLE_CHECK_EQ(pos, data.end(), "Unexpected constant encoding end");
@@ -244,7 +244,7 @@ class ConstantEncoding<std::string_view> final
   using physicalType = std::string_view;
 
   ConstantEncoding(
-      velox::memory::MemoryPool& memoryPool,
+      velox::memory::MemoryPool& pool,
       std::string_view data,
       std::function<void*(uint32_t)> stringBufferFactory,
       const Encoding::Options& options = {});

--- a/dwio/nimble/encodings/DeltaEncoding.h
+++ b/dwio/nimble/encodings/DeltaEncoding.h
@@ -72,6 +72,17 @@ class DeltaEncoding final
       std::function<void*(uint32_t)> stringBufferFactory,
       const Encoding::Options& options = {});
 
+  ~DeltaEncoding() override {
+    this->releaseVectorBuffer(deltasBuffer_);
+    this->releaseVectorBuffer(restatementsBuffer_);
+    this->releaseBuffer(isRestatementsBitmap_);
+  }
+
+  DeltaEncoding(const DeltaEncoding&) = delete;
+  DeltaEncoding& operator=(const DeltaEncoding&) = delete;
+  DeltaEncoding(DeltaEncoding&&) = delete;
+  DeltaEncoding& operator=(DeltaEncoding&&) = delete;
+
   void reset() final;
   void skip(uint32_t rowCount) final;
   void materialize(uint32_t rowCount, void* buffer) final;
@@ -94,8 +105,7 @@ class DeltaEncoding final
     const auto bitmapBytes = velox::bits::nwords(rowCount) * sizeof(uint64_t);
     if (isRestatementsBitmap_ == nullptr ||
         isRestatementsBitmap_->capacity() < bitmapBytes) {
-      isRestatementsBitmap_ =
-          velox::AlignedBuffer::allocate<char>(bitmapBytes, this->pool_);
+      isRestatementsBitmap_ = this->getBuffer(bitmapBytes);
     }
     return isRestatementsBitmap_->asMutable<uint64_t>();
   }
@@ -121,8 +131,8 @@ DeltaEncoding<T>::DeltaEncoding(
     std::function<void*(uint32_t)> stringBufferFactory,
     const Encoding::Options& options)
     : TypedEncoding<T, physicalType>(pool, data, options),
-      deltasBuffer_(&pool),
-      restatementsBuffer_(&pool) {
+      deltasBuffer_(this->template getVectorBuffer<physicalType>()),
+      restatementsBuffer_(this->template getVectorBuffer<physicalType>()) {
   const EncodingFactory factory{options};
   auto pos = data.data() + this->dataOffset();
   const uint32_t restatementsOffset = encoding::readUint32(pos);

--- a/dwio/nimble/encodings/DictionaryEncoding.h
+++ b/dwio/nimble/encodings/DictionaryEncoding.h
@@ -53,6 +53,15 @@ class DictionaryEncoding
       std::function<void*(uint32_t)> stringBufferFactory,
       const Encoding::Options& options = {});
 
+  ~DictionaryEncoding() override {
+    this->releaseBuffer(indicesBuffer_);
+  }
+
+  DictionaryEncoding(const DictionaryEncoding&) = delete;
+  DictionaryEncoding& operator=(const DictionaryEncoding&) = delete;
+  DictionaryEncoding(DictionaryEncoding&&) = delete;
+  DictionaryEncoding& operator=(DictionaryEncoding&&) = delete;
+
   void reset() final;
   void skip(uint32_t rowCount) final;
   void materialize(uint32_t rowCount, void* buffer) final;
@@ -100,11 +109,9 @@ class DictionaryEncoding
 
  private:
   uint32_t* ensureIndicesBuffer(uint32_t numElements) {
-    if (indicesBuffer_ == nullptr || !indicesBuffer_->unique()) {
-      indicesBuffer_ =
-          velox::AlignedBuffer::allocate<uint32_t>(numElements, this->pool_);
-    } else {
-      velox::AlignedBuffer::reallocate<uint32_t>(&indicesBuffer_, numElements);
+    const auto bytes = numElements * sizeof(uint32_t);
+    if (indicesBuffer_ == nullptr || indicesBuffer_->capacity() < bytes) {
+      indicesBuffer_ = this->getBuffer(bytes);
     }
     return indicesBuffer_->asMutable<uint32_t>();
   }

--- a/dwio/nimble/encodings/FixedBitWidthEncoding.h
+++ b/dwio/nimble/encodings/FixedBitWidthEncoding.h
@@ -59,6 +59,7 @@ class FixedBitWidthEncoding final
 
   ~FixedBitWidthEncoding() override {
     this->releaseBuffer(uncompressedData_);
+    this->releaseVectorBuffer(buffer_);
   }
 
   void reset() final;
@@ -106,7 +107,8 @@ FixedBitWidthEncoding<T>::FixedBitWidthEncoding(
     std::string_view data,
     std::function<void*(uint32_t)> /* stringBufferFactory */,
     const Encoding::Options& options)
-    : TypedEncoding<T, physicalType>{pool, data, options}, buffer_{&pool} {
+    : TypedEncoding<T, physicalType>{pool, data, options},
+      buffer_(this->template getVectorBuffer<physicalType>()) {
   auto pos = data.data() + this->dataOffset();
   auto compressionType = static_cast<CompressionType>(encoding::readChar(pos));
   baseline_ = encoding::read<const physicalType>(pos);

--- a/dwio/nimble/encodings/MainlyConstantEncoding.cpp
+++ b/dwio/nimble/encodings/MainlyConstantEncoding.cpp
@@ -19,11 +19,11 @@
 namespace facebook::nimble {
 
 MainlyConstantEncoding<std::string_view>::MainlyConstantEncoding(
-    velox::memory::MemoryPool& memoryPool,
+    velox::memory::MemoryPool& pool,
     std::string_view data,
     std::function<void*(uint32_t)> stringBufferFactory,
     const Encoding::Options& options)
-    : MainlyConstantEncodingBase<std::string_view>(memoryPool, data, options) {
+    : MainlyConstantEncodingBase<std::string_view>(pool, data, options) {
   const EncodingFactory factory{options};
   const char* pos = data.data() + this->dataOffset();
   const uint32_t isCommonBytes = encoding::readUint32(pos);

--- a/dwio/nimble/encodings/MainlyConstantEncoding.h
+++ b/dwio/nimble/encodings/MainlyConstantEncoding.h
@@ -57,22 +57,6 @@
 
 namespace facebook::nimble {
 
-namespace detail {
-
-template <typename V>
-Vector<V> getPooledBuffer(
-    velox::memory::MemoryPool& pool,
-    velox::BufferPool* bufferPool) {
-  if (bufferPool != nullptr) {
-    if (auto buf = bufferPool->get()) {
-      return Vector<V>(std::move(buf));
-    }
-  }
-  return Vector<V>(&pool);
-}
-
-} // namespace detail
-
 // Data layout is:
 // EncodingPrefix::kFixedPrefixSize bytes: standard Encoding prefix
 // 4 bytes: num isCommon encoding bytes (X)
@@ -93,20 +77,13 @@ class MainlyConstantEncodingBase
       std::string_view data,
       const Encoding::Options& options = {})
       : TypedEncoding<T, physicalType>(pool, data, options),
-        isCommonBuffer_(
-            detail::getPooledBuffer<bool>(pool, this->options_.bufferPool)),
-        otherValuesBuffer_(
-            detail::getPooledBuffer<physicalType>(
-                pool,
-                this->options_.bufferPool)),
+        isCommonBuffer_(this->template getVectorBuffer<bool>()),
+        otherValuesBuffer_(this->template getVectorBuffer<physicalType>()),
         dictionaryAlphabet_(&pool) {}
 
   ~MainlyConstantEncodingBase() override {
-    auto* bufferPool = this->options_.bufferPool;
-    if (bufferPool != nullptr) {
-      bufferPool->release(isCommonBuffer_.releaseBuffer());
-      bufferPool->release(otherValuesBuffer_.releaseBuffer());
-    }
+    this->releaseVectorBuffer(isCommonBuffer_);
+    this->releaseVectorBuffer(otherValuesBuffer_);
   }
 
   void reset() final {
@@ -493,11 +470,10 @@ class MainlyConstantEncodingBase
   std::unique_ptr<Encoding> otherValues_;
   physicalType commonValue_;
   uint32_t* ensureIndicesBuffer(uint32_t numElements) {
-    if (indicesBuffer_ == nullptr || !indicesBuffer_->unique()) {
+    if (indicesBuffer_ == nullptr ||
+        indicesBuffer_->capacity() < numElements * sizeof(uint32_t)) {
       indicesBuffer_ =
           velox::AlignedBuffer::allocate<uint32_t>(numElements, this->pool_);
-    } else {
-      velox::AlignedBuffer::reallocate<uint32_t>(&indicesBuffer_, numElements);
     }
     return indicesBuffer_->asMutable<uint32_t>();
   }
@@ -515,7 +491,7 @@ class MainlyConstantEncoding final : public MainlyConstantEncodingBase<T> {
   using physicalType = typename TypeTraits<T>::physicalType;
 
   MainlyConstantEncoding(
-      velox::memory::MemoryPool& memoryPool,
+      velox::memory::MemoryPool& pool,
       std::string_view data,
       std::function<void*(uint32_t)> stringBufferFactory,
       const Encoding::Options& options = {});
@@ -533,11 +509,11 @@ class MainlyConstantEncoding final : public MainlyConstantEncodingBase<T> {
 
 template <typename T>
 MainlyConstantEncoding<T>::MainlyConstantEncoding(
-    velox::memory::MemoryPool& memoryPool,
+    velox::memory::MemoryPool& pool,
     std::string_view data,
     std::function<void*(uint32_t)> stringBufferFactory,
     const Encoding::Options& options)
-    : MainlyConstantEncodingBase<T>(memoryPool, data, options) {
+    : MainlyConstantEncodingBase<T>(pool, data, options) {
   const EncodingFactory factory{options};
   const char* pos = data.data() + this->dataOffset();
   const uint32_t isCommonBytes = encoding::readUint32(pos);
@@ -630,7 +606,7 @@ class MainlyConstantEncoding<std::string_view> final
   using physicalType = std::string_view;
 
   MainlyConstantEncoding(
-      velox::memory::MemoryPool& memoryPool,
+      velox::memory::MemoryPool& pool,
       std::string_view data,
       std::function<void*(uint32_t)> stringBufferFactory,
       const Encoding::Options& options = {});

--- a/dwio/nimble/encodings/NullableEncoding.h
+++ b/dwio/nimble/encodings/NullableEncoding.h
@@ -44,10 +44,19 @@ class NullableEncoding final
   using physicalType = typename TypeTraits<T>::physicalType;
 
   NullableEncoding(
-      velox::memory::MemoryPool& memoryPool,
+      velox::memory::MemoryPool& pool,
       std::string_view data,
       std::function<void*(uint32_t)> stringBufferFactory,
       const Encoding::Options& options = {});
+
+  ~NullableEncoding() override {
+    this->releaseVectorBuffer(nullBuffer_);
+  }
+
+  NullableEncoding(const NullableEncoding&) = delete;
+  NullableEncoding& operator=(const NullableEncoding&) = delete;
+  NullableEncoding(NullableEncoding&&) = delete;
+  NullableEncoding& operator=(NullableEncoding&&) = delete;
 
   uint32_t nullCount() const final;
   bool isNullable() const final;
@@ -113,8 +122,7 @@ class NullableEncoding final
   std::unique_ptr<Encoding> nulls_;
   uint32_t row_ = 0;
 
-  // Temporary buffers.
-  Vector<uint32_t> indicesBuffer_;
+  /// Scratch buffer for null bitmap during decode.
   Vector<bool> nullBuffer_;
 };
 
@@ -124,13 +132,12 @@ class NullableEncoding final
 
 template <typename T>
 NullableEncoding<T>::NullableEncoding(
-    velox::memory::MemoryPool& memoryPool,
+    velox::memory::MemoryPool& pool,
     std::string_view data,
     std::function<void*(uint32_t)> stringBufferFactory,
     const Encoding::Options& options)
-    : TypedEncoding<T, physicalType>(memoryPool, data, options),
-      indicesBuffer_(this->pool_),
-      nullBuffer_(this->pool_) {
+    : TypedEncoding<T, physicalType>(pool, data, options),
+      nullBuffer_(this->template getVectorBuffer<bool>()) {
   const EncodingFactory factory{options};
   const char* pos = data.data() + this->dataOffset();
   const uint32_t nonNullsBytes = encoding::readUint32(pos);

--- a/dwio/nimble/encodings/RleEncoding.cpp
+++ b/dwio/nimble/encodings/RleEncoding.cpp
@@ -18,12 +18,12 @@
 namespace facebook::nimble {
 
 RLEEncoding<bool>::RLEEncoding(
-    velox::memory::MemoryPool& memoryPool,
+    velox::memory::MemoryPool& pool,
     std::string_view data,
     std::function<void*(uint32_t)> stringBufferFactory,
     const Encoding::Options& options)
     : internal::RLEEncodingBase<bool, RLEEncoding<bool>>(
-          memoryPool,
+          pool,
           data,
           stringBufferFactory,
           options) {

--- a/dwio/nimble/encodings/RleEncoding.h
+++ b/dwio/nimble/encodings/RleEncoding.h
@@ -86,13 +86,13 @@ class RLEEncodingBase
   using physicalType = typename TypeTraits<T>::physicalType;
 
   RLEEncodingBase(
-      velox::memory::MemoryPool& memoryPool,
+      velox::memory::MemoryPool& pool,
       std::string_view data,
       std::function<void*(uint32_t)> stringBufferFactory,
       const Encoding::Options& options = {})
-      : TypedEncoding<T, physicalType>(memoryPool, data, options),
+      : TypedEncoding<T, physicalType>(pool, data, options),
         materializedRunLengths_{EncodingFactory(options).create(
-            memoryPool,
+            pool,
             {data.data() + this->dataOffset() + 4,
              *reinterpret_cast<const uint32_t*>(
                  data.data() + this->dataOffset())},
@@ -227,10 +227,19 @@ class RLEEncoding final : public internal::RLEEncodingBase<T, RLEEncoding<T>> {
 
  public:
   explicit RLEEncoding(
-      velox::memory::MemoryPool& memoryPool,
+      velox::memory::MemoryPool& pool,
       std::string_view data,
       std::function<void*(uint32_t)> stringBufferFactory,
       const Encoding::Options& options = {});
+
+  ~RLEEncoding() override {
+    this->releaseBuffer(indicesBuffer_);
+  }
+
+  RLEEncoding(const RLEEncoding&) = delete;
+  RLEEncoding& operator=(const RLEEncoding&) = delete;
+  RLEEncoding(RLEEncoding&&) = delete;
+  RLEEncoding& operator=(RLEEncoding&&) = delete;
 
   void reset() final;
 
@@ -367,11 +376,9 @@ class RLEEncoding final : public internal::RLEEncodingBase<T, RLEEncoding<T>> {
       vector_size_t currentRow) const;
 
   uint32_t* ensureIndicesBuffer(uint32_t numElements) {
-    if (indicesBuffer_ == nullptr || !indicesBuffer_->unique()) {
-      indicesBuffer_ =
-          velox::AlignedBuffer::allocate<uint32_t>(numElements, this->pool_);
-    } else {
-      velox::AlignedBuffer::reallocate<uint32_t>(&indicesBuffer_, numElements);
+    const auto bytes = numElements * sizeof(uint32_t);
+    if (indicesBuffer_ == nullptr || indicesBuffer_->capacity() < bytes) {
+      indicesBuffer_ = this->getBuffer(bytes);
     }
     return indicesBuffer_->asMutable<uint32_t>();
   }
@@ -396,7 +403,7 @@ class RLEEncoding<bool> final
     : public internal::RLEEncodingBase<bool, RLEEncoding<bool>> {
  public:
   RLEEncoding(
-      velox::memory::MemoryPool& memoryPool,
+      velox::memory::MemoryPool& pool,
       std::string_view data,
       std::function<void*(uint32_t)> stringBufferFactory,
       const Encoding::Options& options = {});

--- a/dwio/nimble/encodings/SentinelEncoding.h
+++ b/dwio/nimble/encodings/SentinelEncoding.h
@@ -48,7 +48,7 @@ class SentinelEncoding final
   using physicalType = typename TypeTraits<T>::physicalType;
 
   SentinelEncoding(
-      velox::memory::MemoryPool& memoryPool,
+      velox::memory::MemoryPool& pool,
       std::string_view data,
       std::function<void*(uint32_t)> stringBufferFactory);
 
@@ -74,7 +74,7 @@ class SentinelEncoding final
   // //
   // // Note that nulls[i] is set to true if the ith value is NOT null.
   // static bool estimateSize(
-  //     velox::memory::MemoryPool& memoryPool,
+  //     velox::memory::MemoryPool& pool,
   //     std::span<const T> nonNullValues,
   //     std::span<const bool> nulls,
   //     OptimalSearchParams optimalSearchParams,
@@ -99,21 +99,19 @@ class SentinelEncoding final
  private:
   std::unique_ptr<Encoding> sentineledData_;
   physicalType sentinelValue_;
-  nimble::Vector<physicalType> buffer_;
   uint32_t nullCount_;
 };
 
 template <typename T>
 SentinelEncoding<T>::SentinelEncoding(
-    velox::memory::MemoryPool& memoryPool,
+    velox::memory::MemoryPool& pool,
     std::string_view data,
     std::function<void*(uint32_t)> /* stringBufferFactory */)
-    : TypedEncoding<T, physicalType>(memoryPool, data), buffer_(&memoryPool) {
+    : TypedEncoding<T, physicalType>(pool, data) {
   const char* pos = data.data() + EncodingPrefix::kFixedPrefixSize;
   nullCount_ = encoding::readUint32(pos);
   const uint32_t sentineledBytes = encoding::readUint32(pos);
-  sentineledData_ =
-      deserializeEncoding(this->memoryPool_, {pos, sentineledBytes});
+  sentineledData_ = deserializeEncoding(this->pool_, {pos, sentineledBytes});
   pos += sentineledBytes;
   sentinelValue_ = encoding::read<physicalType>(pos);
   NIMBLE_CHECK(pos == data.end(), "Unexpected sentinel encoding end");
@@ -280,11 +278,11 @@ loop_start:
 
 template <typename physicalType>
 Vector<physicalType> createSentineledData(
-    velox::memory::MemoryPool& memoryPool,
+    velox::memory::MemoryPool& pool,
     std::span<const physicalType> nonNullValues,
     std::span<const bool> nulls,
     physicalType sentinelValue) {
-  Vector<physicalType> sentineledData(&memoryPool, nulls.size());
+  Vector<physicalType> sentineledData(&pool, nulls.size());
   auto it = nonNullValues.begin();
   for (int i = 0; i < nulls.size(); ++i) {
     if (nulls[i]) {
@@ -323,9 +321,9 @@ Vector<physicalType> createSentineledData(
 //         "Cannot use SentinelEncoding when no value is left for sentinel.");
 //   }
 //   auto sentinelValue = sentinelOptional.value();
-//   auto& memoryPool = buffer->getMemoryPool();
+//   auto& pool = buffer->getMemoryPool();
 //   const Vector<physicalType> sentineledData =
-//       createSentineledData(memoryPool, nonNullValues, nulls, sentinelValue);
+//       createSentineledData(pool, nonNullValues, nulls, sentinelValue);
 //   const uint32_t nullCount =
 //       nulls.size() - std::accumulate(nulls.begin(), nulls.end(), 0u);
 //   std::string_view sentineledEncoding = serializeEncoding<physicalType>(
@@ -352,7 +350,7 @@ Vector<physicalType> createSentineledData(
 
 // template <typename T>
 // bool SentinelEncoding<T>::estimateSize(
-//     velox::memory::MemoryPool& memoryPool,
+//     velox::memory::MemoryPool& pool,
 //     std::span<const T> nonNullDataValues,
 //     std::span<const bool> nulls,
 //     OptimalSearchParams optimalSearchParams,
@@ -368,11 +366,11 @@ Vector<physicalType> createSentineledData(
 //   }
 //   auto sentinelValue = sentinelOptional.value();
 //   const Vector<physicalType> sentineledData =
-//       createSentineledData(memoryPool, nonNullValues, nulls, sentinelValue);
+//       createSentineledData(pool, nonNullValues, nulls, sentinelValue);
 //   uint32_t sentineledSize;
 //   auto& sentinelParameters = encodingParameters.set_sentinel();
 //   estimateOptimalEncodingSize<physicalType>(
-//       memoryPool,
+//       pool,
 //       sentineledData,
 //       optimalSearchParams,
 //       &sentineledSize,

--- a/dwio/nimble/encodings/SparseBoolEncoding.cpp
+++ b/dwio/nimble/encodings/SparseBoolEncoding.cpp
@@ -24,15 +24,15 @@
 namespace facebook::nimble {
 
 SparseBoolEncoding::SparseBoolEncoding(
-    velox::memory::MemoryPool& memoryPool,
+    velox::memory::MemoryPool& pool,
     std::string_view data,
     std::function<void*(uint32_t)> stringBufferFactory,
     const Encoding::Options& options)
-    : TypedEncoding<bool, bool>{memoryPool, data, options},
+    : TypedEncoding<bool, bool>{pool, data, options},
       sparseValue_{static_cast<bool>(data[this->dataOffset()])},
-      indicesUncompressed_{&memoryPool},
+      indicesUncompressed_{&pool},
       indices_{EncodingFactory(options).create(
-          memoryPool,
+          pool,
           {data.data() + this->dataOffset() + kPrefixSize,
            data.size() - this->dataOffset() - kPrefixSize},
           stringBufferFactory)} {

--- a/dwio/nimble/encodings/SparseBoolEncoding.h
+++ b/dwio/nimble/encodings/SparseBoolEncoding.h
@@ -51,7 +51,7 @@ class SparseBoolEncoding final : public TypedEncoding<bool, bool> {
   static constexpr int kPrefixSize = 1;
 
   SparseBoolEncoding(
-      velox::memory::MemoryPool& memoryPool,
+      velox::memory::MemoryPool& pool,
       std::string_view data,
       std::function<void*(uint32_t)> stringBufferFactory,
       const Encoding::Options& options = {});

--- a/dwio/nimble/encodings/VarintEncoding.h
+++ b/dwio/nimble/encodings/VarintEncoding.h
@@ -70,7 +70,6 @@ class VarintEncoding final
   const physicalType baseValue_;
   uint32_t row_{0};
   const char* pos_;
-  Vector<physicalType> buf_;
 };
 
 //
@@ -85,8 +84,7 @@ VarintEncoding<T>::VarintEncoding(
     const Encoding::Options& options)
     : TypedEncoding<T, physicalType>(pool, data, options),
       baseValue_{*reinterpret_cast<const physicalType*>(
-          data.data() + this->dataOffset())},
-      buf_{this->pool_} {
+          data.data() + this->dataOffset())} {
   reset();
 }
 

--- a/dwio/nimble/encodings/common/Encoding.h
+++ b/dwio/nimble/encodings/common/Encoding.h
@@ -106,9 +106,9 @@ class Encoding {
     bool useVarintRowCount;
 
     /// Optional buffer pool for reusing scratch buffers across encoding
-    /// lifetimes. When set, encodings like MainlyConstant will return their
-    /// scratch buffers to the pool on destruction and grab pre-allocated
-    /// buffers on construction, avoiding MemoryPool alloc/free overhead.
+    /// lifetimes. When set, encodings return their scratch buffers to the pool
+    /// on destruction and grab pre-allocated buffers on construction, avoiding
+    /// MemoryPool alloc/free overhead.
     /// Value-initialized to nullptr when omitted from aggregate initialization.
     velox::BufferPool* bufferPool;
   };
@@ -286,6 +286,36 @@ class Encoding {
     }
   }
 
+  /// Acquires a raw BufferPtr with at least bytes capacity. Uses the buffer
+  /// pool when it has a large enough buffer, otherwise allocates a new one.
+  velox::BufferPtr getBuffer(size_t bytes) {
+    if (auto* bufferPool = options_.bufferPool) {
+      if (auto buffer = bufferPool->get(bytes)) {
+        return buffer;
+      }
+    }
+    return velox::AlignedBuffer::allocate<char>(bytes, pool_);
+  }
+
+  /// Acquires a Vector backed by a buffer pool allocation if available.
+  /// Falls back to a fresh empty Vector from the memory pool.
+  template <typename V>
+  Vector<V> getVectorBuffer() {
+    if (auto* bufferPool = options_.bufferPool) {
+      if (auto buf = bufferPool->get()) {
+        return Vector<V>(std::move(buf));
+      }
+    }
+    return Vector<V>(pool_);
+  }
+
+  /// Releases a Vector's underlying buffer back to the buffer pool.
+  void releaseVectorBuffer(auto& vector) {
+    if (auto* bufferPool = options_.bufferPool) {
+      bufferPool->release(vector.releaseBuffer());
+    }
+  }
+
   velox::memory::MemoryPool* const pool_;
   const std::string_view data_;
   const EncodingType encodingType_;
@@ -306,10 +336,10 @@ class TypedEncoding : public Encoding {
 
  public:
   TypedEncoding(
-      velox::memory::MemoryPool& memoryPool,
+      velox::memory::MemoryPool& pool,
       std::string_view data,
       const Options& options = {})
-      : Encoding{memoryPool, data, options} {}
+      : Encoding{pool, data, options} {}
 
   // Similar to materialize(), but scatters values to output buffer according to
   // scatterBitmap. When scatterBitmap is nullptr or all 1's, the output

--- a/dwio/nimble/encodings/common/EncodingFactory.cpp
+++ b/dwio/nimble/encodings/common/EncodingFactory.cpp
@@ -44,7 +44,7 @@ static std::span<const typename TypeTraits<T>::physicalType> toPhysicalSpan(
 } // namespace
 
 std::unique_ptr<Encoding> EncodingFactory::create(
-    velox::memory::MemoryPool& memoryPool,
+    velox::memory::MemoryPool& pool,
     std::string_view data,
     std::function<void*(uint32_t)> stringBufferFactory) const {
   const auto& options = options_;
@@ -55,40 +55,40 @@ std::unique_ptr<Encoding> EncodingFactory::create(
   switch (dataType) {                                                     \
     case DataType::Int8:                                                  \
       return std::make_unique<Encoding<int8_t>>(                          \
-          memoryPool, data, stringBufferFactory, options);                \
+          pool, data, stringBufferFactory, options);                      \
     case DataType::Uint8:                                                 \
       return std::make_unique<Encoding<uint8_t>>(                         \
-          memoryPool, data, stringBufferFactory, options);                \
+          pool, data, stringBufferFactory, options);                      \
     case DataType::Int16:                                                 \
       return std::make_unique<Encoding<int16_t>>(                         \
-          memoryPool, data, stringBufferFactory, options);                \
+          pool, data, stringBufferFactory, options);                      \
     case DataType::Uint16:                                                \
       return std::make_unique<Encoding<uint16_t>>(                        \
-          memoryPool, data, stringBufferFactory, options);                \
+          pool, data, stringBufferFactory, options);                      \
     case DataType::Int32:                                                 \
       return std::make_unique<Encoding<int32_t>>(                         \
-          memoryPool, data, stringBufferFactory, options);                \
+          pool, data, stringBufferFactory, options);                      \
     case DataType::Uint32:                                                \
       return std::make_unique<Encoding<uint32_t>>(                        \
-          memoryPool, data, stringBufferFactory, options);                \
+          pool, data, stringBufferFactory, options);                      \
     case DataType::Int64:                                                 \
       return std::make_unique<Encoding<int64_t>>(                         \
-          memoryPool, data, stringBufferFactory, options);                \
+          pool, data, stringBufferFactory, options);                      \
     case DataType::Uint64:                                                \
       return std::make_unique<Encoding<uint64_t>>(                        \
-          memoryPool, data, stringBufferFactory, options);                \
+          pool, data, stringBufferFactory, options);                      \
     case DataType::Float:                                                 \
       return std::make_unique<Encoding<float>>(                           \
-          memoryPool, data, stringBufferFactory, options);                \
+          pool, data, stringBufferFactory, options);                      \
     case DataType::Double:                                                \
       return std::make_unique<Encoding<double>>(                          \
-          memoryPool, data, stringBufferFactory, options);                \
+          pool, data, stringBufferFactory, options);                      \
     case DataType::Bool:                                                  \
       return std::make_unique<Encoding<bool>>(                            \
-          memoryPool, data, stringBufferFactory, options);                \
+          pool, data, stringBufferFactory, options);                      \
     case DataType::String:                                                \
       return std::make_unique<Encoding<std::string_view>>(                \
-          memoryPool, data, stringBufferFactory, options);                \
+          pool, data, stringBufferFactory, options);                      \
     default:                                                              \
       NIMBLE_UNREACHABLE("Unknown encoding type {}.", toString(dataType)) \
   }
@@ -97,22 +97,22 @@ std::unique_ptr<Encoding> EncodingFactory::create(
   switch (dataType) {                                      \
     case DataType::Int32:                                  \
       return std::make_unique<Encoding<int32_t>>(          \
-          memoryPool, data, stringBufferFactory, options); \
+          pool, data, stringBufferFactory, options);       \
     case DataType::Uint32:                                 \
       return std::make_unique<Encoding<uint32_t>>(         \
-          memoryPool, data, stringBufferFactory, options); \
+          pool, data, stringBufferFactory, options);       \
     case DataType::Int64:                                  \
       return std::make_unique<Encoding<int64_t>>(          \
-          memoryPool, data, stringBufferFactory, options); \
+          pool, data, stringBufferFactory, options);       \
     case DataType::Uint64:                                 \
       return std::make_unique<Encoding<uint64_t>>(         \
-          memoryPool, data, stringBufferFactory, options); \
+          pool, data, stringBufferFactory, options);       \
     case DataType::Float:                                  \
       return std::make_unique<Encoding<float>>(            \
-          memoryPool, data, stringBufferFactory, options); \
+          pool, data, stringBufferFactory, options);       \
     case DataType::Double:                                 \
       return std::make_unique<Encoding<double>>(           \
-          memoryPool, data, stringBufferFactory, options); \
+          pool, data, stringBufferFactory, options);       \
     default:                                               \
       NIMBLE_UNREACHABLE(                                  \
           "Trying to deserialize a varint stream for "     \
@@ -124,37 +124,37 @@ std::unique_ptr<Encoding> EncodingFactory::create(
   switch (dataType) {                                        \
     case DataType::Int8:                                     \
       return std::make_unique<Encoding<int8_t>>(             \
-          memoryPool, data, stringBufferFactory, options);   \
+          pool, data, stringBufferFactory, options);         \
     case DataType::Uint8:                                    \
       return std::make_unique<Encoding<uint8_t>>(            \
-          memoryPool, data, stringBufferFactory, options);   \
+          pool, data, stringBufferFactory, options);         \
     case DataType::Int16:                                    \
       return std::make_unique<Encoding<int16_t>>(            \
-          memoryPool, data, stringBufferFactory, options);   \
+          pool, data, stringBufferFactory, options);         \
     case DataType::Uint16:                                   \
       return std::make_unique<Encoding<uint16_t>>(           \
-          memoryPool, data, stringBufferFactory, options);   \
+          pool, data, stringBufferFactory, options);         \
     case DataType::Int32:                                    \
       return std::make_unique<Encoding<int32_t>>(            \
-          memoryPool, data, stringBufferFactory, options);   \
+          pool, data, stringBufferFactory, options);         \
     case DataType::Uint32:                                   \
       return std::make_unique<Encoding<uint32_t>>(           \
-          memoryPool, data, stringBufferFactory, options);   \
+          pool, data, stringBufferFactory, options);         \
     case DataType::Int64:                                    \
       return std::make_unique<Encoding<int64_t>>(            \
-          memoryPool, data, stringBufferFactory, options);   \
+          pool, data, stringBufferFactory, options);         \
     case DataType::Uint64:                                   \
       return std::make_unique<Encoding<uint64_t>>(           \
-          memoryPool, data, stringBufferFactory, options);   \
+          pool, data, stringBufferFactory, options);         \
     case DataType::Float:                                    \
       return std::make_unique<Encoding<float>>(              \
-          memoryPool, data, stringBufferFactory, options);   \
+          pool, data, stringBufferFactory, options);         \
     case DataType::Double:                                   \
       return std::make_unique<Encoding<double>>(             \
-          memoryPool, data, stringBufferFactory, options);   \
+          pool, data, stringBufferFactory, options);         \
     case DataType::String:                                   \
       return std::make_unique<Encoding<std::string_view>>(   \
-          memoryPool, data, stringBufferFactory, options);   \
+          pool, data, stringBufferFactory, options);         \
     default:                                                 \
       NIMBLE_UNREACHABLE(                                    \
           "Trying to deserialize a non-bool stream for "     \
@@ -166,34 +166,34 @@ std::unique_ptr<Encoding> EncodingFactory::create(
   switch (dataType) {                                       \
     case DataType::Int8:                                    \
       return std::make_unique<Encoding<int8_t>>(            \
-          memoryPool, data, stringBufferFactory, options);  \
+          pool, data, stringBufferFactory, options);        \
     case DataType::Uint8:                                   \
       return std::make_unique<Encoding<uint8_t>>(           \
-          memoryPool, data, stringBufferFactory, options);  \
+          pool, data, stringBufferFactory, options);        \
     case DataType::Int16:                                   \
       return std::make_unique<Encoding<int16_t>>(           \
-          memoryPool, data, stringBufferFactory, options);  \
+          pool, data, stringBufferFactory, options);        \
     case DataType::Uint16:                                  \
       return std::make_unique<Encoding<uint16_t>>(          \
-          memoryPool, data, stringBufferFactory, options);  \
+          pool, data, stringBufferFactory, options);        \
     case DataType::Int32:                                   \
       return std::make_unique<Encoding<int32_t>>(           \
-          memoryPool, data, stringBufferFactory, options);  \
+          pool, data, stringBufferFactory, options);        \
     case DataType::Uint32:                                  \
       return std::make_unique<Encoding<uint32_t>>(          \
-          memoryPool, data, stringBufferFactory, options);  \
+          pool, data, stringBufferFactory, options);        \
     case DataType::Int64:                                   \
       return std::make_unique<Encoding<int64_t>>(           \
-          memoryPool, data, stringBufferFactory, options);  \
+          pool, data, stringBufferFactory, options);        \
     case DataType::Uint64:                                  \
       return std::make_unique<Encoding<uint64_t>>(          \
-          memoryPool, data, stringBufferFactory, options);  \
+          pool, data, stringBufferFactory, options);        \
     case DataType::Float:                                   \
       return std::make_unique<Encoding<float>>(             \
-          memoryPool, data, stringBufferFactory, options);  \
+          pool, data, stringBufferFactory, options);        \
     case DataType::Double:                                  \
       return std::make_unique<Encoding<double>>(            \
-          memoryPool, data, stringBufferFactory, options);  \
+          pool, data, stringBufferFactory, options);        \
     default:                                                \
       NIMBLE_UNREACHABLE(                                   \
           "Trying to deserialize a non-numeric stream for " \
@@ -223,7 +223,7 @@ std::unique_ptr<Encoding> EncodingFactory::create(
           DataType::Bool,
           "Trying to deserialize a SparseBoolEncoding with a non-bool data type.");
       return std::make_unique<SparseBoolEncoding>(
-          memoryPool, data, stringBufferFactory, options);
+          pool, data, stringBufferFactory, options);
     }
     case EncodingType::Varint: {
       RETURN_ENCODING_BY_VARINT_TYPE(VarintEncoding, dataType);
@@ -240,7 +240,7 @@ std::unique_ptr<Encoding> EncodingFactory::create(
           DataType::String,
           "Trying to deserialize a PrefixEncoding with a non-string data type.");
       return std::make_unique<PrefixEncoding>(
-          memoryPool, data, stringBufferFactory, options);
+          pool, data, stringBufferFactory, options);
     }
     case EncodingType::Delta: {
       RETURN_ENCODING_BY_NUMERIC_TYPE(DeltaEncoding, dataType);

--- a/dwio/nimble/encodings/common/EncodingFactory.h
+++ b/dwio/nimble/encodings/common/EncodingFactory.h
@@ -38,7 +38,7 @@ class EncodingFactory {
 
   /// Creates an Encoding from serialized data using this factory's options.
   virtual std::unique_ptr<Encoding> create(
-      velox::memory::MemoryPool& memoryPool,
+      velox::memory::MemoryPool& pool,
       std::string_view data,
       std::function<void*(uint32_t)> stringBufferFactory) const;
 

--- a/dwio/nimble/encodings/tests/EncodingTest.cpp
+++ b/dwio/nimble/encodings/tests/EncodingTest.cpp
@@ -90,6 +90,55 @@ class TestCompressPolicy : public nimble::CompressionPolicy {
   bool useVariableBitWidthCompressor_;
 };
 
+std::string makeEncodingData() {
+  std::string data(nimble::EncodingPrefix::kFixedPrefixSize, '\0');
+  auto* pos = data.data();
+  nimble::EncodingPrefix::serialize(
+      nimble::EncodingType::Trivial,
+      nimble::DataType::Int8,
+      /*rowCount=*/0,
+      /*useVarint=*/false,
+      pos);
+  return data;
+}
+
+class TestEncoding : public nimble::Encoding {
+ public:
+  TestEncoding(
+      velox::memory::MemoryPool& pool,
+      std::string_view data,
+      const Options& options)
+      : Encoding(pool, data, options) {}
+
+  velox::BufferPtr testingGetBuffer(size_t bytes) {
+    return getBuffer(bytes);
+  }
+
+  template <typename V>
+  nimble::Vector<V> testingGetVectorBuffer() {
+    return getVectorBuffer<V>();
+  }
+
+  void testingReleaseVectorBuffer(auto& vector) {
+    releaseVectorBuffer(vector);
+  }
+
+  void reset() override {}
+
+  void skip(uint32_t /*rowCount*/) override {}
+
+  void materialize(uint32_t /*rowCount*/, void* /*buffer*/) override {}
+
+  uint32_t materializeNullable(
+      uint32_t /*rowCount*/,
+      void* /*buffer*/,
+      std::function<void*()> /*nulls*/,
+      const velox::bits::Bitmap* /*scatterBitmap*/,
+      uint32_t /*offset*/) override {
+    return 0;
+  }
+};
+
 template <typename T>
 class TestTrivialEncodingSelectionPolicy
     : public nimble::EncodingSelectionPolicy<T> {
@@ -139,6 +188,159 @@ class TestTrivialEncodingSelectionPolicy
 };
 
 } // namespace
+
+TEST(EncodingBufferPoolTest, getBufferUsesMinimumCapacity) {
+  auto pool = velox::memory::deprecatedAddDefaultLeafMemoryPool();
+  velox::BufferPool bufferPool;
+  const auto data = makeEncodingData();
+  TestEncoding encoding{
+      *pool,
+      data,
+      nimble::Encoding::Options{
+          .useVarintRowCount = false,
+          .bufferPool = &bufferPool,
+      }};
+
+  auto smallBuffer = velox::AlignedBuffer::allocate<char>(128, pool.get());
+  auto* smallBufferPtr = smallBuffer.get();
+  bufferPool.release(std::move(smallBuffer));
+
+  auto allocatedBuffer = encoding.testingGetBuffer(1'024);
+  ASSERT_NE(allocatedBuffer, nullptr);
+  EXPECT_GE(allocatedBuffer->capacity(), 1'024);
+  EXPECT_EQ(bufferPool.size(), 1);
+
+  auto remainingSmallBuffer = bufferPool.get();
+  ASSERT_NE(remainingSmallBuffer, nullptr);
+  EXPECT_EQ(remainingSmallBuffer.get(), smallBufferPtr);
+  bufferPool.release(std::move(remainingSmallBuffer));
+
+  auto largeBuffer = velox::AlignedBuffer::allocate<char>(4'096, pool.get());
+  auto* largeBufferPtr = largeBuffer.get();
+  bufferPool.release(std::move(largeBuffer));
+
+  auto pooledBuffer = encoding.testingGetBuffer(1'024);
+  ASSERT_NE(pooledBuffer, nullptr);
+  EXPECT_EQ(pooledBuffer.get(), largeBufferPtr);
+  EXPECT_EQ(bufferPool.size(), 1);
+}
+
+TEST(EncodingBufferPoolTest, getVectorBufferFromPool) {
+  auto pool = velox::memory::deprecatedAddDefaultLeafMemoryPool();
+  velox::BufferPool bufferPool;
+  const auto data = makeEncodingData();
+  TestEncoding encoding{
+      *pool,
+      data,
+      nimble::Encoding::Options{
+          .useVarintRowCount = false,
+          .bufferPool = &bufferPool,
+      }};
+
+  auto buffer = velox::AlignedBuffer::allocate<char>(4'096, pool.get());
+  auto* bufferPtr = buffer.get();
+  bufferPool.release(std::move(buffer));
+  ASSERT_EQ(bufferPool.size(), 1);
+
+  auto vector = encoding.testingGetVectorBuffer<int32_t>();
+  EXPECT_EQ(vector.testingBuffer().get(), bufferPtr);
+  EXPECT_GE(vector.capacity(), 4'096 / sizeof(int32_t));
+  EXPECT_EQ(vector.size(), 0);
+  EXPECT_EQ(bufferPool.size(), 0);
+}
+
+TEST(EncodingBufferPoolTest, getVectorBufferWithoutPool) {
+  auto pool = velox::memory::deprecatedAddDefaultLeafMemoryPool();
+  const auto data = makeEncodingData();
+  TestEncoding encoding{
+      *pool, data, nimble::Encoding::Options{.useVarintRowCount = false}};
+
+  auto vector = encoding.testingGetVectorBuffer<int32_t>();
+  EXPECT_EQ(vector.size(), 0);
+  EXPECT_EQ(vector.capacity(), 0);
+}
+
+TEST(EncodingBufferPoolTest, getVectorBufferFromEmptyPool) {
+  auto pool = velox::memory::deprecatedAddDefaultLeafMemoryPool();
+  velox::BufferPool bufferPool;
+  const auto data = makeEncodingData();
+  TestEncoding encoding{
+      *pool,
+      data,
+      nimble::Encoding::Options{
+          .useVarintRowCount = false,
+          .bufferPool = &bufferPool,
+      }};
+
+  ASSERT_EQ(bufferPool.size(), 0);
+
+  auto vector = encoding.testingGetVectorBuffer<int32_t>();
+  EXPECT_EQ(vector.size(), 0);
+  EXPECT_EQ(vector.capacity(), 0);
+  EXPECT_EQ(bufferPool.size(), 0);
+}
+
+TEST(EncodingBufferPoolTest, releaseVectorBufferToPool) {
+  auto pool = velox::memory::deprecatedAddDefaultLeafMemoryPool();
+  velox::BufferPool bufferPool;
+  const auto data = makeEncodingData();
+  TestEncoding encoding{
+      *pool,
+      data,
+      nimble::Encoding::Options{
+          .useVarintRowCount = false,
+          .bufferPool = &bufferPool,
+      }};
+
+  auto vector = encoding.testingGetVectorBuffer<int32_t>();
+  vector.resize(100);
+  auto* bufferPtr = vector.testingBuffer().get();
+  ASSERT_EQ(bufferPool.size(), 0);
+
+  encoding.testingReleaseVectorBuffer(vector);
+  EXPECT_EQ(bufferPool.size(), 1);
+
+  auto recycled = bufferPool.get();
+  ASSERT_NE(recycled, nullptr);
+  EXPECT_EQ(recycled.get(), bufferPtr);
+}
+
+TEST(EncodingBufferPoolTest, releaseVectorBufferWithoutPool) {
+  auto pool = velox::memory::deprecatedAddDefaultLeafMemoryPool();
+  const auto data = makeEncodingData();
+  TestEncoding encoding{
+      *pool, data, nimble::Encoding::Options{.useVarintRowCount = false}};
+
+  auto vector = encoding.testingGetVectorBuffer<int32_t>();
+  vector.resize(100);
+
+  encoding.testingReleaseVectorBuffer(vector);
+  EXPECT_NE(vector.testingBuffer(), nullptr);
+}
+
+TEST(EncodingBufferPoolTest, getVectorBufferRoundTrip) {
+  auto pool = velox::memory::deprecatedAddDefaultLeafMemoryPool();
+  velox::BufferPool bufferPool;
+  const auto data = makeEncodingData();
+  TestEncoding encoding{
+      *pool,
+      data,
+      nimble::Encoding::Options{
+          .useVarintRowCount = false,
+          .bufferPool = &bufferPool,
+      }};
+
+  auto vector1 = encoding.testingGetVectorBuffer<int32_t>();
+  vector1.resize(100);
+  auto* bufferPtr = vector1.testingBuffer().get();
+
+  encoding.testingReleaseVectorBuffer(vector1);
+  ASSERT_EQ(bufferPool.size(), 1);
+
+  auto vector2 = encoding.testingGetVectorBuffer<int32_t>();
+  EXPECT_EQ(vector2.testingBuffer().get(), bufferPtr);
+  EXPECT_EQ(bufferPool.size(), 0);
+}
 
 template <typename EncodingType, bool UseVarint>
 struct TestConfig {

--- a/dwio/nimble/serializer/CMakeLists.txt
+++ b/dwio/nimble/serializer/CMakeLists.txt
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+add_subdirectory(benchmarks)
 add_subdirectory(tests)
 
 add_library(nimble_serializer_options Options.cpp)

--- a/dwio/nimble/serializer/benchmarks/CMakeLists.txt
+++ b/dwio/nimble/serializer/benchmarks/CMakeLists.txt
@@ -1,0 +1,28 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+add_executable(nimble_serializer_benchmark SerializerBenchmark.cpp)
+
+target_link_libraries(
+  nimble_serializer_benchmark
+  nimble_serializer
+  nimble_deserializer
+  nimble_encodings
+  nimble_velox_writer
+  nimble_velox_schema_reader
+  Folly::follybenchmark
+  Folly::folly
+  velox_memory
+  velox_vector
+  fmt::fmt
+)

--- a/dwio/nimble/serializer/benchmarks/SerializerBenchmark.cpp
+++ b/dwio/nimble/serializer/benchmarks/SerializerBenchmark.cpp
@@ -1,0 +1,392 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <fmt/core.h>
+#include <folly/Benchmark.h>
+#include <folly/Random.h>
+#include <folly/init/Init.h>
+
+#include "dwio/nimble/encodings/common/EncodingLayout.h"
+#include "dwio/nimble/serializer/Deserializer.h"
+#include "dwio/nimble/serializer/Serializer.h"
+#include "dwio/nimble/velox/EncodingLayoutTree.h"
+#include "dwio/nimble/velox/OrderedRanges.h"
+#include "dwio/nimble/velox/SchemaReader.h"
+#include "velox/common/memory/Memory.h"
+#include "velox/vector/BaseVector.h"
+#include "velox/vector/ComplexVector.h"
+
+using namespace facebook::nimble;
+namespace velox = facebook::velox;
+
+namespace {
+
+constexpr int kRandom = 0;
+constexpr int kMainlyConstant = 1;
+constexpr int kIncreasing = 2;
+constexpr int kLowCardinality = 3;
+constexpr int kRunLength = 4;
+constexpr velox::vector_size_t kNumRows = 10'000;
+constexpr int32_t kNumKeys = 100;
+constexpr uint32_t kMemoryReportIters = 10;
+
+velox::RowVectorPtr makeWideFlatMapBatch(
+    velox::vector_size_t numRows,
+    int32_t numKeys,
+    int dataPattern,
+    velox::memory::MemoryPool* pool) {
+  auto type = velox::ROW(
+      {{"id", velox::BIGINT()},
+       {"features", velox::MAP(velox::INTEGER(), velox::BIGINT())}});
+
+  auto ids = velox::BaseVector::create(velox::BIGINT(), numRows, pool);
+  for (velox::vector_size_t i = 0; i < numRows; ++i) {
+    ids->asFlatVector<int64_t>()->set(i, i);
+  }
+
+  const auto totalEntries =
+      static_cast<velox::vector_size_t>(numRows) * numKeys;
+  auto keys = velox::BaseVector::create(velox::INTEGER(), totalEntries, pool);
+  auto values = velox::BaseVector::create(velox::BIGINT(), totalEntries, pool);
+
+  auto* rawKeys = keys->asFlatVector<int32_t>();
+  auto* rawValues = values->asFlatVector<int64_t>();
+
+  velox::vector_size_t offset = 0;
+  int64_t runningValue = 0;
+  int64_t runValue = folly::Random::rand64();
+  int32_t runRemaining = 0;
+
+  for (velox::vector_size_t row = 0; row < numRows; ++row) {
+    for (int32_t k = 0; k < numKeys; ++k) {
+      rawKeys->set(offset, k);
+      int64_t v;
+      switch (dataPattern) {
+        case kRandom:
+          v = folly::Random::rand64();
+          break;
+        case kMainlyConstant:
+          v = (folly::Random::rand32() % 100 < 95)
+              ? 42
+              : static_cast<int64_t>(folly::Random::rand64());
+          break;
+        case kIncreasing:
+          runningValue += folly::Random::rand32() % 10;
+          v = runningValue;
+          break;
+        case kLowCardinality:
+          v = folly::Random::rand32() % 64;
+          break;
+        case kRunLength:
+          if (runRemaining == 0) {
+            runValue = folly::Random::rand64() % 1000;
+            runRemaining = 10 + folly::Random::rand32() % 50;
+          }
+          v = runValue;
+          --runRemaining;
+          break;
+        default:
+          v = 0;
+      }
+      rawValues->set(offset, v);
+      ++offset;
+    }
+  }
+
+  auto mapVector = std::make_shared<velox::MapVector>(
+      pool,
+      velox::MAP(velox::INTEGER(), velox::BIGINT()),
+      /*nulls=*/nullptr,
+      numRows,
+      velox::allocateOffsets(numRows, pool),
+      velox::allocateSizes(numRows, pool),
+      keys,
+      values);
+
+  auto* rawOffsets =
+      mapVector->mutableOffsets(numRows)->asMutable<velox::vector_size_t>();
+  auto* rawSizes =
+      mapVector->mutableSizes(numRows)->asMutable<velox::vector_size_t>();
+  for (velox::vector_size_t i = 0; i < numRows; ++i) {
+    rawOffsets[i] = i * numKeys;
+    rawSizes[i] = numKeys;
+  }
+
+  return std::make_shared<velox::RowVector>(
+      pool,
+      type,
+      /*nulls=*/nullptr,
+      numRows,
+      std::vector<velox::VectorPtr>{ids, mapVector});
+}
+
+/// Builds an EncodingLayoutTree that forces all flat map value streams to use
+/// the specified encoding type.
+EncodingLayoutTree buildForcedEncodingLayout(
+    int32_t numKeys,
+    EncodingType valueEncoding) {
+  using SI = EncodingLayoutTree::StreamIdentifiers;
+  EncodingLayout valueLayout{
+      valueEncoding,
+      /*encodingConfig=*/{},
+      CompressionType::Uncompressed,
+      {std::nullopt, std::nullopt, std::nullopt}};
+
+  std::vector<EncodingLayoutTree> flatMapChildren;
+  flatMapChildren.reserve(numKeys);
+  for (int32_t k = 0; k < numKeys; ++k) {
+    flatMapChildren.emplace_back(
+        Kind::Scalar,
+        std::unordered_map<uint8_t, EncodingLayout>{
+            {SI::Scalar::ScalarStream, valueLayout}},
+        std::to_string(k));
+  }
+
+  return EncodingLayoutTree{
+      Kind::Row,
+      {},
+      "",
+      {EncodingLayoutTree{Kind::Scalar, {}, ""},
+       EncodingLayoutTree{Kind::FlatMap, {}, "", std::move(flatMapChildren)}}};
+}
+
+struct BenchmarkState {
+  std::string serialized;
+  std::shared_ptr<const Type> schema;
+};
+
+BenchmarkState prepareBenchmark(
+    velox::vector_size_t numRows,
+    int32_t numKeys,
+    int dataPattern,
+    std::optional<EncodingType> forcedEncoding = std::nullopt) {
+  auto pool = velox::memory::memoryManager()->addLeafPool("prepare");
+  BenchmarkState state;
+
+  auto input = makeWideFlatMapBatch(numRows, numKeys, dataPattern, pool.get());
+
+  auto makeOptions = [&]() -> SerializerOptions {
+    if (forcedEncoding.has_value()) {
+      return SerializerOptions{
+          .version = SerializationVersion::kCompactRaw,
+          .flatMapColumns = {{"features", {}}},
+          .encodingLayoutTree =
+              buildForcedEncodingLayout(numKeys, forcedEncoding.value()),
+          .compressionOptions = CompressionOptions{},
+      };
+    }
+    return SerializerOptions{
+        .version = SerializationVersion::kCompactRaw,
+        .flatMapColumns = {{"features", {}}},
+    };
+  };
+
+  Serializer serializer{makeOptions(), input->type(), pool.get()};
+  auto sv = serializer.serialize(input, OrderedRanges::of(0, input->size()));
+  state.serialized = std::string(sv.data(), sv.size());
+  state.schema =
+      SchemaReader::getSchema(serializer.schemaBuilder().schemaNodes());
+  return state;
+}
+
+struct DeserializeStats {
+  int64_t peakMemoryBytes;
+  uint64_t cumulativeBytes;
+  uint64_t numAllocs;
+};
+
+DeserializeStats runDeserializeWithStats(
+    const BenchmarkState& state,
+    bool enableBufferPool,
+    uint32_t iters) {
+  auto pool = velox::memory::memoryManager()->addLeafPool("deser_stats");
+  Deserializer deserializer{
+      state.schema,
+      pool.get(),
+      DeserializerOptions{
+          .hasHeader = true,
+          .enableBufferPool = enableBufferPool,
+      }};
+  velox::VectorPtr output;
+
+  while (iters--) {
+    deserializer.deserialize(state.serialized, output);
+    output.reset();
+  }
+
+  auto s = pool->stats();
+  return DeserializeStats{
+      .peakMemoryBytes = pool->peakBytes(),
+      .cumulativeBytes = s.cumulativeBytes,
+      .numAllocs = s.numAllocs,
+  };
+}
+
+void runDeserialize(
+    const BenchmarkState& state,
+    bool enableBufferPool,
+    uint32_t iters) {
+  auto pool = velox::memory::memoryManager()->addLeafPool("deser_bench");
+  Deserializer deserializer{
+      state.schema,
+      pool.get(),
+      DeserializerOptions{
+          .hasHeader = true,
+          .enableBufferPool = enableBufferPool,
+      }};
+  velox::VectorPtr output;
+  while (iters--) {
+    deserializer.deserialize(state.serialized, output);
+    output.reset();
+  }
+}
+
+void printMemoryReport(
+    const char* label,
+    velox::vector_size_t numRows,
+    int32_t numKeys,
+    int dataPattern,
+    std::optional<EncodingType> forcedEncoding = std::nullopt) {
+  auto state = prepareBenchmark(numRows, numKeys, dataPattern, forcedEncoding);
+
+  auto withPool = runDeserializeWithStats(
+      state, /*enableBufferPool=*/true, kMemoryReportIters);
+  auto noPool = runDeserializeWithStats(
+      state, /*enableBufferPool=*/false, kMemoryReportIters);
+
+  double allocSavings = noPool.numAllocs > 0 ? 100.0 *
+          (1.0 - static_cast<double>(withPool.numAllocs) / noPool.numAllocs)
+                                             : 0.0;
+
+  fmt::print(
+      "  {:>20} | allocs: {:>6} vs {:>6} ({:>+6.1f}%)"
+      "  peak: {:>8} vs {:>8}\n",
+      label,
+      withPool.numAllocs,
+      noPool.numAllocs,
+      allocSavings,
+      fmt::format("{:.0f}KB", withPool.peakMemoryBytes / 1024.0),
+      fmt::format("{:.0f}KB", noPool.peakMemoryBytes / 1024.0));
+}
+
+} // namespace
+
+// === Deserialization throughput with forced encoding types ===
+
+#define DESER_BENCH(Name, Rows, Keys, Pattern, ...)                           \
+  BENCHMARK(Deser_##Name##_Pool, iters) {                                     \
+    static auto state = prepareBenchmark(Rows, Keys, Pattern, ##__VA_ARGS__); \
+    runDeserialize(state, true, iters);                                       \
+  }                                                                           \
+  BENCHMARK_RELATIVE(Deser_##Name##_NoPool, iters) {                          \
+    static auto state = prepareBenchmark(Rows, Keys, Pattern, ##__VA_ARGS__); \
+    runDeserialize(state, false, iters);                                      \
+  }
+
+// --- Forced encoding types ---
+DESER_BENCH(Trivial, kNumRows, kNumKeys, kRandom, EncodingType::Trivial)
+BENCHMARK_DRAW_LINE();
+DESER_BENCH(
+    Dictionary,
+    kNumRows,
+    kNumKeys,
+    kLowCardinality,
+    EncodingType::Dictionary)
+BENCHMARK_DRAW_LINE();
+DESER_BENCH(
+    MainlyConst,
+    kNumRows,
+    kNumKeys,
+    kMainlyConstant,
+    EncodingType::MainlyConstant)
+BENCHMARK_DRAW_LINE();
+DESER_BENCH(
+    FixedBitWidth,
+    kNumRows,
+    kNumKeys,
+    kRandom,
+    EncodingType::FixedBitWidth)
+BENCHMARK_DRAW_LINE();
+DESER_BENCH(Delta, kNumRows, kNumKeys, kIncreasing, EncodingType::Delta)
+BENCHMARK_DRAW_LINE();
+DESER_BENCH(RLE, kNumRows, kNumKeys, kRunLength, EncodingType::RLE)
+BENCHMARK_DRAW_LINE();
+
+// --- Auto-selected encoding ---
+DESER_BENCH(Auto_Random, kNumRows, kNumKeys, kRandom)
+BENCHMARK_DRAW_LINE();
+DESER_BENCH(Auto_MainlyConst, kNumRows, kNumKeys, kMainlyConstant)
+BENCHMARK_DRAW_LINE();
+
+// --- Width scaling ---
+DESER_BENCH(Auto_50Keys, kNumRows, 50, kRandom)
+BENCHMARK_DRAW_LINE();
+DESER_BENCH(Auto_200Keys, kNumRows, 200, kRandom)
+
+#undef DESER_BENCH
+
+int main(int argc, char** argv) {
+  folly::Init init(&argc, &argv);
+  facebook::velox::memory::MemoryManager::initialize({});
+
+  fmt::print(
+      "\n=== Allocation Count: BufferPool ON vs OFF ({} rows x {} keys, {} batches) ===\n\n",
+      kNumRows,
+      kNumKeys,
+      kMemoryReportIters);
+
+  fmt::print("  Forced encoding types:\n");
+  printMemoryReport(
+      "Trivial", kNumRows, kNumKeys, kRandom, EncodingType::Trivial);
+  printMemoryReport(
+      "Dictionary",
+      kNumRows,
+      kNumKeys,
+      kLowCardinality,
+      EncodingType::Dictionary);
+  printMemoryReport(
+      "MainlyConstant",
+      kNumRows,
+      kNumKeys,
+      kMainlyConstant,
+      EncodingType::MainlyConstant);
+  printMemoryReport(
+      "FixedBitWidth",
+      kNumRows,
+      kNumKeys,
+      kRandom,
+      EncodingType::FixedBitWidth);
+  printMemoryReport(
+      "Delta", kNumRows, kNumKeys, kIncreasing, EncodingType::Delta);
+  printMemoryReport("RLE", kNumRows, kNumKeys, kRunLength, EncodingType::RLE);
+
+  fmt::print("\n  Auto-selected encoding:\n");
+  printMemoryReport("Auto (Random)", kNumRows, kNumKeys, kRandom);
+  printMemoryReport("Auto (MainlyConst)", kNumRows, kNumKeys, kMainlyConstant);
+  printMemoryReport("Auto (Increasing)", kNumRows, kNumKeys, kIncreasing);
+  printMemoryReport("Auto (LowCard)", kNumRows, kNumKeys, kLowCardinality);
+  printMemoryReport("Auto (RunLength)", kNumRows, kNumKeys, kRunLength);
+
+  fmt::print("\n  Width scaling (auto-selected, random data):\n");
+  for (int numKeys : {50, 100, 200}) {
+    printMemoryReport(
+        fmt::format("{}keys", numKeys).c_str(), kNumRows, numKeys, kRandom);
+  }
+
+  fmt::print("\n=== Deserialization Throughput: BufferPool ON vs OFF ===\n\n");
+  folly::runBenchmarks();
+  return 0;
+}


### PR DESCRIPTION
Summary:
Previously only `MainlyConstantEncoding` used `BufferPool` to recycle scratch buffers across encoding lifetimes. This diff extends the pattern to `NullableEncoding`, `DeltaEncoding`, and `FixedBitWidthEncoding`, reducing MemoryPool allocation overhead during deserialization.

Changes:
- Added `getBuffer(bytes)`, `getVectorBuffer<V>()`, and `releaseVectorBuffer()` helpers to `Encoding` base class, replacing the local `detail::getPooledBuffer` in `MainlyConstantEncoding`
- `getBuffer(bytes)` uses `BufferPool::get(bytes)` so undersized cached buffers remain available instead of being popped and released back
- `NullableEncoding`: `nullBuffer_` now acquires/releases via BufferPool; removed dead `indicesBuffer_` member
- `DeltaEncoding`: `deltasBuffer_`, `restatementsBuffer_`, and `isRestatementsBitmap_` now use BufferPool
- `DictionaryEncoding` and `RLEEncoding`: dictionary-index scratch buffers now use BufferPool
- `FixedBitWidthEncoding`: `buffer_` now uses BufferPool
- `MainlyConstantEncoding`: refactored to use shared helpers (same behavior)
- Removed dead `Vector<>` members: `SentinelEncoding::buffer_`, `VarintEncoding::buf_`
- Added `EncodingBufferPoolTest.getBufferUsesMinimumCapacity`
- Added serializer benchmark at `dwio/nimble/serializer/benchmarks/` measuring deserialization throughput and allocation counts with wide flat maps (BufferPool vs no BufferPool)

Benchmark result highlight (10K rows x 100 keys, MainlyConstant data pattern):
- Allocations: 602 (pool) vs 2302 (no pool) = 73.8% fewer allocs

Differential Revision: D106908319


