### PR TITLE
feat(buffer): Expose bufferPoolCapacity in DeserializerOptions (#805)

### DIFF
--- a/dwio/nimble/encodings/tests/EncodingTest.cpp
+++ b/dwio/nimble/encodings/tests/EncodingTest.cpp
@@ -191,7 +191,7 @@ class TestTrivialEncodingSelectionPolicy
 
 TEST(EncodingBufferPoolTest, getBufferUsesMinimumCapacity) {
   auto pool = velox::memory::deprecatedAddDefaultLeafMemoryPool();
-  velox::BufferPool bufferPool;
+  velox::BufferPool bufferPool{velox::BufferPool::kDefaultCapacity};
   const auto data = makeEncodingData();
   TestEncoding encoding{
       *pool,
@@ -227,7 +227,7 @@ TEST(EncodingBufferPoolTest, getBufferUsesMinimumCapacity) {
 
 TEST(EncodingBufferPoolTest, getVectorBufferFromPool) {
   auto pool = velox::memory::deprecatedAddDefaultLeafMemoryPool();
-  velox::BufferPool bufferPool;
+  velox::BufferPool bufferPool{velox::BufferPool::kDefaultCapacity};
   const auto data = makeEncodingData();
   TestEncoding encoding{
       *pool,
@@ -262,7 +262,7 @@ TEST(EncodingBufferPoolTest, getVectorBufferWithoutPool) {
 
 TEST(EncodingBufferPoolTest, getVectorBufferFromEmptyPool) {
   auto pool = velox::memory::deprecatedAddDefaultLeafMemoryPool();
-  velox::BufferPool bufferPool;
+  velox::BufferPool bufferPool{velox::BufferPool::kDefaultCapacity};
   const auto data = makeEncodingData();
   TestEncoding encoding{
       *pool,
@@ -282,7 +282,7 @@ TEST(EncodingBufferPoolTest, getVectorBufferFromEmptyPool) {
 
 TEST(EncodingBufferPoolTest, releaseVectorBufferToPool) {
   auto pool = velox::memory::deprecatedAddDefaultLeafMemoryPool();
-  velox::BufferPool bufferPool;
+  velox::BufferPool bufferPool{velox::BufferPool::kDefaultCapacity};
   const auto data = makeEncodingData();
   TestEncoding encoding{
       *pool,
@@ -320,7 +320,7 @@ TEST(EncodingBufferPoolTest, releaseVectorBufferWithoutPool) {
 
 TEST(EncodingBufferPoolTest, getVectorBufferRoundTrip) {
   auto pool = velox::memory::deprecatedAddDefaultLeafMemoryPool();
-  velox::BufferPool bufferPool;
+  velox::BufferPool bufferPool{velox::BufferPool::kDefaultCapacity};
   const auto data = makeEncodingData();
   TestEncoding encoding{
       *pool,

--- a/dwio/nimble/encodings/tests/ZstdCompressorTest.cpp
+++ b/dwio/nimble/encodings/tests/ZstdCompressorTest.cpp
@@ -160,7 +160,8 @@ TEST(ZstdCompressorTest, MinCompressionSizeSkipsSmallData) {
 
 TEST(ZstdCompressorTest, AllocateBufferFromPool) {
   auto pool = facebook::velox::memory::deprecatedAddDefaultLeafMemoryPool();
-  facebook::velox::BufferPool bufferPool;
+  facebook::velox::BufferPool bufferPool{
+      facebook::velox::BufferPool::kDefaultCapacity};
 
   // Pool is empty — should fall back to MemoryPool allocation.
   auto buf1 = allocateBuffer(*pool, &bufferPool, 100);
@@ -194,7 +195,8 @@ TEST(ZstdCompressorTest, UncompressWithBufferPool) {
   auto pool = facebook::velox::memory::deprecatedAddDefaultLeafMemoryPool();
   ZstdCompressor compressor;
   TestCompressionPolicy policy;
-  facebook::velox::BufferPool bufferPool;
+  facebook::velox::BufferPool bufferPool{
+      facebook::velox::BufferPool::kDefaultCapacity};
 
   std::vector<char> original(1024);
   for (size_t i = 0; i < original.size(); ++i) {
@@ -231,7 +233,8 @@ TEST(ZstdCompressorTest, BufferPoolReuseAcrossMultipleCycles) {
   auto pool = facebook::velox::memory::deprecatedAddDefaultLeafMemoryPool();
   ZstdCompressor compressor;
   TestCompressionPolicy policy;
-  facebook::velox::BufferPool bufferPool;
+  facebook::velox::BufferPool bufferPool{
+      facebook::velox::BufferPool::kDefaultCapacity};
 
   std::vector<char> original(512);
   for (size_t i = 0; i < original.size(); ++i) {

--- a/dwio/nimble/serializer/Deserializer.cpp
+++ b/dwio/nimble/serializer/Deserializer.cpp
@@ -114,7 +114,7 @@ class DeserializerImpl : public Decoder {
   DeserializerImpl(
       const Type* type,
       bool inMapStream,
-      bool enableBufferPool,
+      size_t bufferPoolCapacity,
       velox::memory::MemoryPool* pool)
       : type_{type},
         pool_{pool},
@@ -122,8 +122,9 @@ class DeserializerImpl : public Decoder {
         scalarKind_{getScalarKindForType(*type)},
         typeStorageWidth_{getTypeStorageWidth(*type)},
         bufferPool_{
-            enableBufferPool ? std::make_unique<velox::BufferPool>()
-                             : nullptr} {}
+            bufferPoolCapacity > 0
+                ? std::make_unique<velox::BufferPool>(bufferPoolCapacity)
+                : nullptr} {}
 
   uint32_t next(
       uint32_t count,
@@ -719,7 +720,7 @@ void Deserializer::createDeserializersForType(
       std::make_unique<DeserializerImpl>(
           &type,
           /*inMapStream=*/false,
-          options_.enableBufferPool,
+          options_.bufferPoolCapacity,
           pool_);
   // FlatMap is only supported at depth 1 (top-level columns). FlatMap keys can
   // vary across batches, causing gaps in nulls/inMap streams. Gap detection is
@@ -733,7 +734,7 @@ void Deserializer::createDeserializersForType(
       deserializerMap_[inMapOffset] = std::make_unique<DeserializerImpl>(
           &type,
           /*inMapStream=*/true,
-          options_.enableBufferPool,
+          options_.bufferPoolCapacity,
           pool_);
       inMapChildTypes_[inMapOffset] = flatMap.childAt(i).get();
     }

--- a/dwio/nimble/serializer/Options.h
+++ b/dwio/nimble/serializer/Options.h
@@ -28,6 +28,7 @@
 #include "folly/Executor.h"
 #include "folly/container/F14Map.h"
 #include "folly/container/F14Set.h"
+#include "velox/buffer/BufferPool.h"
 
 #include <set>
 #include "velox/type/Type.h"
@@ -204,11 +205,11 @@ struct DeserializerOptions {
   /// When nullopt (default), all flatmap columns are deserialized as maps.
   velox::RowTypePtr outputType{};
 
-  /// Whether to enable BufferPool for recycling encoding scratch buffers.
-  /// When true, a BufferPool is created per DeserializerImpl to cache and
-  /// reuse buffers across encoding lifetimes, reducing MemoryPool allocation
-  /// overhead.
-  bool enableBufferPool{true};
+  /// Maximum number of scratch buffers each per-stream BufferPool retains
+  /// for reuse across encoding lifetimes. Higher values reduce MemoryPool
+  /// allocation churn at the cost of resident memory. 0 disables the pool
+  /// entirely (every encoding allocates and frees through MemoryPool).
+  size_t bufferPoolCapacity{velox::BufferPool::kDefaultCapacity};
 
   /// Executor for parallel decoding of child fields.
   /// When set, RowFieldReader and StructFlatMapFieldReader dispatch child reads

--- a/dwio/nimble/serializer/benchmarks/SerializerBenchmark.cpp
+++ b/dwio/nimble/serializer/benchmarks/SerializerBenchmark.cpp
@@ -210,7 +210,7 @@ struct DeserializeStats {
 
 DeserializeStats runDeserializeWithStats(
     const BenchmarkState& state,
-    bool enableBufferPool,
+    size_t bufferPoolCapacity,
     uint32_t iters) {
   auto pool = velox::memory::memoryManager()->addLeafPool("deser_stats");
   Deserializer deserializer{
@@ -218,7 +218,7 @@ DeserializeStats runDeserializeWithStats(
       pool.get(),
       DeserializerOptions{
           .hasHeader = true,
-          .enableBufferPool = enableBufferPool,
+          .bufferPoolCapacity = bufferPoolCapacity,
       }};
   velox::VectorPtr output;
 
@@ -237,7 +237,7 @@ DeserializeStats runDeserializeWithStats(
 
 void runDeserialize(
     const BenchmarkState& state,
-    bool enableBufferPool,
+    size_t bufferPoolCapacity,
     uint32_t iters) {
   auto pool = velox::memory::memoryManager()->addLeafPool("deser_bench");
   Deserializer deserializer{
@@ -245,7 +245,7 @@ void runDeserialize(
       pool.get(),
       DeserializerOptions{
           .hasHeader = true,
-          .enableBufferPool = enableBufferPool,
+          .bufferPoolCapacity = bufferPoolCapacity,
       }};
   velox::VectorPtr output;
   while (iters--) {
@@ -263,9 +263,12 @@ void printMemoryReport(
   auto state = prepareBenchmark(numRows, numKeys, dataPattern, forcedEncoding);
 
   auto withPool = runDeserializeWithStats(
-      state, /*enableBufferPool=*/true, kMemoryReportIters);
+      state,
+      /*bufferPoolCapacity=*/
+      velox::BufferPool::kDefaultCapacity,
+      kMemoryReportIters);
   auto noPool = runDeserializeWithStats(
-      state, /*enableBufferPool=*/false, kMemoryReportIters);
+      state, /*bufferPoolCapacity=*/0, kMemoryReportIters);
 
   double allocSavings = noPool.numAllocs > 0 ? 100.0 *
           (1.0 - static_cast<double>(withPool.numAllocs) / noPool.numAllocs)
@@ -289,11 +292,14 @@ void printMemoryReport(
 #define DESER_BENCH(Name, Rows, Keys, Pattern, ...)                           \
   BENCHMARK(Deser_##Name##_Pool, iters) {                                     \
     static auto state = prepareBenchmark(Rows, Keys, Pattern, ##__VA_ARGS__); \
-    runDeserialize(state, true, iters);                                       \
+    runDeserialize(                                                           \
+        state, /*bufferPoolCapacity=*/                                        \
+        velox::BufferPool::kDefaultCapacity,                                  \
+        iters);                                                               \
   }                                                                           \
   BENCHMARK_RELATIVE(Deser_##Name##_NoPool, iters) {                          \
     static auto state = prepareBenchmark(Rows, Keys, Pattern, ##__VA_ARGS__); \
-    runDeserialize(state, false, iters);                                      \
+    runDeserialize(state, /*bufferPoolCapacity=*/0, iters);                   \
   }
 
 // --- Forced encoding types ---

--- a/dwio/nimble/serializer/tests/ProjectorTest.cpp
+++ b/dwio/nimble/serializer/tests/ProjectorTest.cpp
@@ -57,7 +57,7 @@ struct FormatParam {
   SerializationVersion inputVersion;
   SerializationVersion projectVersion;
   EncodingType streamSizesEncodingType{EncodingType::Trivial};
-  bool enableBufferPool{true};
+  size_t bufferPoolCapacity{velox::BufferPool::kDefaultCapacity};
 
   std::string name() const {
     auto base =
@@ -65,8 +65,10 @@ struct FormatParam {
     if (streamSizesEncodingType != EncodingType::Trivial) {
       base += fmt::format("_{}StreamSizes", toString(streamSizesEncodingType));
     }
-    if (!enableBufferPool) {
+    if (bufferPoolCapacity == 0) {
       base += "_NoBufferPool";
+    } else if (bufferPoolCapacity != velox::BufferPool::kDefaultCapacity) {
+      base += "_BufferPool" + std::to_string(bufferPoolCapacity);
     }
     return base;
   }
@@ -87,15 +89,15 @@ std::vector<FormatParam> allFormatCombinations() {
       {SerializationVersion::kCompactRaw,
        SerializationVersion::kCompactRaw,
        EncodingType::Trivial,
-       /*enableBufferPool=*/false},
+       /*bufferPoolCapacity=*/0},
       {SerializationVersion::kCompactRaw,
        SerializationVersion::kCompactRaw,
        EncodingType::Delta,
-       /*enableBufferPool=*/false},
+       /*bufferPoolCapacity=*/0},
       {SerializationVersion::kCompactRaw,
        SerializationVersion::kCompactRaw,
        EncodingType::MainlyConstant,
-       /*enableBufferPool=*/false},
+       /*bufferPoolCapacity=*/0},
   };
 }
 
@@ -313,7 +315,7 @@ class ProjectorFormatTest : public ProjectorTestBase,
   DeserializerOptions outputDeserializerOptions() const {
     return {
         .hasHeader = true,
-        .enableBufferPool = GetParam().enableBufferPool,
+        .bufferPoolCapacity = GetParam().bufferPoolCapacity,
     };
   }
 };

--- a/dwio/nimble/serializer/tests/SerializationTest.cpp
+++ b/dwio/nimble/serializer/tests/SerializationTest.cpp
@@ -54,8 +54,8 @@ struct TestParams {
   std::optional<CompressionOptions> compressionOptions{};
   // Encoding type for stream sizes in compact trailer.
   EncodingType streamSizesEncodingType{EncodingType::Trivial};
-  // Whether to enable buffer pool for encoding scratch buffer reuse.
-  bool enableBufferPool{true};
+  // Max cached buffers per per-stream BufferPool. 0 disables pooling.
+  size_t bufferPoolCapacity{velox::BufferPool::kDefaultCapacity};
 };
 
 class SerializationTest : public ::testing::TestWithParam<TestParams> {
@@ -86,14 +86,14 @@ class SerializationTest : public ::testing::TestWithParam<TestParams> {
     return GetParam().compressionOptions;
   }
 
-  bool enableBufferPool() const {
-    return GetParam().enableBufferPool;
+  size_t bufferPoolCapacity() const {
+    return GetParam().bufferPoolCapacity;
   }
 
   DeserializerOptions deserializerOptions() const {
     return DeserializerOptions{
         .hasHeader = hasHeader(),
-        .enableBufferPool = enableBufferPool(),
+        .bufferPoolCapacity = bufferPoolCapacity(),
     };
   }
 
@@ -453,8 +453,11 @@ std::string formatName(const ::testing::TestParamInfo<TestParams>& info) {
   if (info.param.streamSizesEncodingType != EncodingType::Trivial) {
     name += "_" + toString(info.param.streamSizesEncodingType) + "StreamSizes";
   }
-  if (!info.param.enableBufferPool) {
+  if (info.param.bufferPoolCapacity == 0) {
     name += "_NoBufferPool";
+  } else if (
+      info.param.bufferPoolCapacity != velox::BufferPool::kDefaultCapacity) {
+    name += "_BufferPool" + std::to_string(info.param.bufferPoolCapacity);
   }
   return name;
 }
@@ -5100,27 +5103,27 @@ INSTANTIATE_TEST_SUITE_P(
             .version = SerializationVersion::kCompactRaw,
             .streamSizesEncodingType = EncodingType::MainlyConstant},
         // Buffer pool disabled variants.
-        TestParams{.version = std::nullopt, .enableBufferPool = false},
+        TestParams{.version = std::nullopt, .bufferPoolCapacity = 0},
         TestParams{
             .version = SerializationVersion::kCompactRaw,
-            .enableBufferPool = false},
+            .bufferPoolCapacity = 0},
         TestParams{
             .version = SerializationVersion::kCompactRaw,
             .compressionOptions =
                 CompressionOptions{
                     .compressionAcceptRatio = 1.0f,
                     .zstdMinCompressionSize = 0},
-            .enableBufferPool = false},
+            .bufferPoolCapacity = 0},
         TestParams{
             .version = SerializationVersion::kCompactRaw,
             .streamSizesEncodingType = EncodingType::Delta,
-            .enableBufferPool = false},
+            .bufferPoolCapacity = 0},
         TestParams{
             .version = SerializationVersion::kCompactRaw,
             .streamSizesEncodingType = EncodingType::FixedBitWidth,
-            .enableBufferPool = false},
+            .bufferPoolCapacity = 0},
         TestParams{
             .version = SerializationVersion::kCompactRaw,
             .streamSizesEncodingType = EncodingType::MainlyConstant,
-            .enableBufferPool = false}),
+            .bufferPoolCapacity = 0}),
     formatName);


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebookincubator/velox/pull/17684


Turns the previously hardcoded cap-of-32 into a constructor parameter (size_t capacity = kDefaultCapacity, default 32, 0 = disable)

Reviewed By: xiaoxmeng

Differential Revision: D107014477


