### PR TITLE
refactor(encoding): Stricter RLE dictionary mode separation

### DIFF
--- a/dwio/nimble/encodings/RleEncoding.h
+++ b/dwio/nimble/encodings/RleEncoding.h
@@ -306,9 +306,8 @@ class RLEEncoding final : public internal::RLEEncodingBase<T, RLEEncoding<T>> {
     uint32_t runIndex = 0;
     while (rowsLeft > 0) {
       if (this->copiesRemaining_ == 0) {
-        this->copiesRemaining_ = this->materializedRunLengths_.nextValue();
-        runIndex = this->nextIndex();
-        this->currentValue_ = alphabet_[runIndex];
+        advanceRunLength();
+        runIndex = advanceRunIndex();
       }
       const auto numRows = std::min(rowsLeft, this->copiesRemaining_);
       velox::simd::simdFill(buffer + numOutputRows, runIndex, numRows);
@@ -366,7 +365,15 @@ class RLEEncoding final : public internal::RLEEncodingBase<T, RLEEncoding<T>> {
   }
 
  private:
+  void advanceRunLength() {
+    this->copiesRemaining_ = this->materializedRunLengths_.nextValue();
+  }
+
   void advanceRunValue();
+
+  uint32_t advanceRunIndex() {
+    return dictValues_->nextIndex();
+  }
 
   template <bool kDense>
   vector_size_t findNumInRun(
@@ -450,7 +457,8 @@ RLEEncoding<T>::RLEEncoding(
           internal::RLEEncodingBase<T, RLEEncoding<T>>::getValuesStart())};
   auto valuesEncoding =
       EncodingFactory(options).create(pool, valuesView, stringBufferFactory);
-  if (valuesEncoding->dictionaryEnabled()) {
+  if (options.preserveDictionaryEncoding &&
+      valuesEncoding->dictionaryEnabled()) {
     dictValues_ =
         std::make_unique<detail::BufferedDictEncoding<physicalType, 128>>(
             std::move(valuesEncoding));
@@ -463,33 +471,33 @@ RLEEncoding<T>::RLEEncoding(
   this->reset();
 }
 
-// Advances to the next run value, setting currentValue_ from either
-// the values buffer (non-dict) or the alphabet via dictionary index (dict).
+// Advances to the next run value in flat (non-dict) mode by setting
+// currentValue_ from the values encoding. In dict mode,
+// advanceRunIndex() is used instead.
 template <typename T>
 void RLEEncoding<T>::advanceRunValue() {
-  if (dictValues_ != nullptr) {
-    if constexpr (isStringType<physicalType>()) {
-      NIMBLE_CHECK_NULL(values_);
-    } else {
-      NIMBLE_DCHECK_NULL(values_);
-    }
-    this->currentValue_ = alphabet_[dictValues_->nextIndex()];
+  if constexpr (isStringType<physicalType>()) {
+    NIMBLE_CHECK_NULL(dictValues_);
+    NIMBLE_CHECK_NOT_NULL(values_);
   } else {
-    if constexpr (isStringType<physicalType>()) {
-      NIMBLE_CHECK_NOT_NULL(values_);
-    } else {
-      NIMBLE_DCHECK_NOT_NULL(values_);
-    }
-    this->currentValue_ = values_->nextValue();
+    NIMBLE_DCHECK_NULL(dictValues_);
+    NIMBLE_DCHECK_NOT_NULL(values_);
   }
+  this->currentValue_ = values_->nextValue();
 }
 
 template <typename T>
 void RLEEncoding<T>::reset() {
   this->materializedRunLengths_.reset();
   this->resetValues();
-  this->copiesRemaining_ = this->materializedRunLengths_.nextValue();
-  advanceRunValue();
+  if (dictValues_ != nullptr) {
+    // In dict mode, don't consume the first run — materializeIndices
+    // manages its own run traversal starting from copiesRemaining_ == 0.
+    this->copiesRemaining_ = 0;
+  } else {
+    advanceRunLength();
+    advanceRunValue();
+  }
 }
 
 template <typename T>
@@ -501,8 +509,20 @@ void RLEEncoding<T>::skip(uint32_t rowCount) {
       return;
     }
     rowsLeft -= this->copiesRemaining_;
-    this->copiesRemaining_ = this->materializedRunLengths_.nextValue();
-    advanceRunValue();
+    // In dict mode, avoid consuming the next run when we've exactly
+    // exhausted the current one — materializeIndices uses a local runIndex
+    // that would go stale if advanceRunIndex() fires here. Non-dict mode
+    // keeps the eager advance so currentValue_ is always primed.
+    if (rowsLeft == 0 && dictValues_ != nullptr) {
+      this->copiesRemaining_ = 0;
+      return;
+    }
+    advanceRunLength();
+    if (dictValues_ != nullptr) {
+      advanceRunIndex();
+    } else {
+      advanceRunValue();
+    }
   }
 }
 
@@ -519,7 +539,7 @@ void RLEEncoding<T>::materialize(uint32_t rowCount, void* buffer) {
     velox::simd::simdFill(output, this->currentValue_, this->copiesRemaining_);
     output += this->copiesRemaining_;
     rowsLeft -= this->copiesRemaining_;
-    this->copiesRemaining_ = this->materializedRunLengths_.nextValue();
+    advanceRunLength();
     advanceRunValue();
   }
 }
@@ -601,6 +621,13 @@ void RLEEncoding<T>::bulkScan(
     const vector_size_t* selectedRows,
     vector_size_t numSelected,
     const vector_size_t* scatterRows) {
+  if constexpr (isStringType<physicalType>()) {
+    NIMBLE_CHECK_NULL(
+        dictValues_,
+        "bulkScan should not be called in dictionary mode for string types");
+  } else {
+    NIMBLE_DCHECK_NULL(dictValues_);
+  }
   using DataType = typename V::DataType;
   using ValueType = detail::ValueType<DataType>;
   constexpr bool kScatterValues = kScatter && !V::kHasFilter && !V::kHasHook;
@@ -613,7 +640,7 @@ void RLEEncoding<T>::bulkScan(
   vector_size_t selectedRowIndex = 0;
   for (;;) {
     if (this->copiesRemaining_ == 0) {
-      this->copiesRemaining_ = this->materializedRunLengths_.nextValue();
+      advanceRunLength();
       advanceRunValue();
     }
     const auto numInRun = findNumInRun<V::dense>(
@@ -680,6 +707,13 @@ template <typename V>
 void RLEEncoding<T>::readWithVisitor(
     V& visitor,
     ReadWithVisitorParams& params) {
+  if constexpr (isStringType<physicalType>()) {
+    NIMBLE_CHECK_NULL(
+        dictValues_,
+        "readWithVisitor should not be called in dictionary mode for string types");
+  } else {
+    NIMBLE_DCHECK_NULL(dictValues_);
+  }
   auto* nulls = visitor.reader().rawNullsInReadRange();
   if (velox::dwio::common::useFastPath(visitor, nulls)) {
     detail::readWithVisitorFast(*this, visitor, params, nulls);
@@ -690,7 +724,7 @@ void RLEEncoding<T>::readWithVisitor(
         [&](auto toSkip) { this->skip(toSkip); },
         [&] {
           if (this->copiesRemaining_ == 0) {
-            this->copiesRemaining_ = this->materializedRunLengths_.nextValue();
+            advanceRunLength();
             advanceRunValue();
           }
           --this->copiesRemaining_;

--- a/dwio/nimble/encodings/common/Encoding.h
+++ b/dwio/nimble/encodings/common/Encoding.h
@@ -111,6 +111,12 @@ class Encoding {
     /// MemoryPool alloc/free overhead.
     /// Value-initialized to nullptr when omitted from aggregate initialization.
     velox::BufferPool* bufferPool;
+
+    /// When true, encodings that support dictionary mode (e.g., RLE) will
+    /// use the dictionary index path when the inner encoding is
+    /// dictionary-enabled. False by default — only the selective
+    /// reader enables this for dictionary vector output.
+    bool preserveDictionaryEncoding;
   };
 
   static constexpr int kEncodingTypeOffset =

--- a/dwio/nimble/encodings/tests/EncodingTest.cpp
+++ b/dwio/nimble/encodings/tests/EncodingTest.cpp
@@ -1024,8 +1024,12 @@ class DictionaryApiTypedTest : public ::testing::Test {
   }
 
   /// Creates an Encoding from serialized bytes using EncodingFactory.
-  std::unique_ptr<nimble::Encoding> decodeEncoding(std::string_view data) {
-    return nimble::EncodingFactory().create(
+  std::unique_ptr<nimble::Encoding> decodeEncoding(
+      std::string_view data,
+      bool preserveDictionaryEncoding = false) {
+    nimble::Encoding::Options options{};
+    options.preserveDictionaryEncoding = preserveDictionaryEncoding;
+    return nimble::EncodingFactory(options).create(
         *pool_, data, [this](uint32_t size) {
           stringBuffers_.push_back(
               velox::AlignedBuffer::allocate<char>(size, pool_.get()));
@@ -1306,7 +1310,7 @@ class DictionaryApiTypedTest : public ::testing::Test {
   std::unique_ptr<nimble::Encoding> encodeRleDictionary(
       const std::vector<T>& values) {
     auto serialized = serializeRleDictionary(values, *buffer_);
-    return decodeEncoding(serialized);
+    return decodeEncoding(serialized, /*preserveDictionaryEncoding=*/true);
   }
 
   std::shared_ptr<velox::memory::MemoryPool> pool_;
@@ -2217,6 +2221,104 @@ TYPED_TEST(DictionaryApiTypedTest, rleDictionaryBasics) {
   }
 }
 
+// Verifies materializeIndices after skipping past the first run.
+// This catches off-by-one bugs where reset() or skip() consume a
+// run's index without storing it, causing materializeIndices to
+// use a stale index for the current run.
+TYPED_TEST(DictionaryApiTypedTest, rleDictionaryMaterializeAfterSkip) {
+  using T = TypeParam;
+  std::vector<T> data;
+  if constexpr (std::is_same_v<T, std::string_view>) {
+    this->stringPool_ = {"alpha", "bravo", "charlie"};
+    for (int i = 0; i < 5; ++i) {
+      data.push_back(std::string_view(this->stringPool_[0]));
+    }
+    for (int i = 0; i < 3; ++i) {
+      data.push_back(std::string_view(this->stringPool_[1]));
+    }
+    for (int i = 0; i < 4; ++i) {
+      data.push_back(std::string_view(this->stringPool_[2]));
+    }
+  } else {
+    for (int i = 0; i < 5; ++i) {
+      data.push_back(T(10));
+    }
+    for (int i = 0; i < 3; ++i) {
+      data.push_back(T(20));
+    }
+    for (int i = 0; i < 4; ++i) {
+      data.push_back(T(30));
+    }
+  }
+
+  auto encoding = this->encodeRleDictionary(data);
+  ASSERT_TRUE(encoding->dictionaryEnabled());
+
+  // Skip past the first run (5 rows) into the second run.
+  encoding->skip(5);
+
+  const auto remaining = data.size() - 5;
+  const auto dictSize = encoding->dictionarySize();
+  std::vector<uint32_t> indices(remaining);
+  encoding->materializeIndices(remaining, indices.data());
+
+  const auto* entries = static_cast<const T*>(encoding->dictionaryEntries());
+  for (size_t i = 0; i < remaining; ++i) {
+    SCOPED_TRACE(fmt::format("row {}", i));
+    ASSERT_LT(indices[i], dictSize);
+    EXPECT_EQ(entries[indices[i]], data[5 + i]);
+  }
+}
+
+// Verifies materialize after skipping exactly to a run boundary in
+// non-dict mode. This catches off-by-one bugs where skip() exits with
+// copiesRemaining_==0 after consuming a full run, and the subsequent
+// materialize produces wrong values from a stale currentValue_.
+TYPED_TEST(DictionaryApiTypedTest, rleMaterializeAfterSkip) {
+  using T = TypeParam;
+  using PhysicalType = typename nimble::TypeTraits<T>::physicalType;
+  std::vector<T> data;
+  if constexpr (std::is_same_v<T, std::string_view>) {
+    this->stringPool_ = {"alpha", "bravo", "charlie"};
+    for (int i = 0; i < 5; ++i) {
+      data.push_back(std::string_view(this->stringPool_[0]));
+    }
+    for (int i = 0; i < 3; ++i) {
+      data.push_back(std::string_view(this->stringPool_[1]));
+    }
+    for (int i = 0; i < 4; ++i) {
+      data.push_back(std::string_view(this->stringPool_[2]));
+    }
+  } else {
+    for (int i = 0; i < 5; ++i) {
+      data.push_back(T(10));
+    }
+    for (int i = 0; i < 3; ++i) {
+      data.push_back(T(20));
+    }
+    for (int i = 0; i < 4; ++i) {
+      data.push_back(T(30));
+    }
+  }
+
+  // Construct with dict mode disabled — uses flat values path.
+  auto serialized = this->serializeRleDictionary(data, *this->buffer_);
+  auto encoding = this->decodeEncoding(serialized);
+  ASSERT_FALSE(encoding->dictionaryEnabled());
+
+  // Skip exactly to the first run boundary (5 rows).
+  encoding->skip(5);
+
+  const auto remaining = data.size() - 5;
+  std::vector<PhysicalType> materialized(remaining);
+  encoding->materialize(remaining, materialized.data());
+  for (size_t i = 0; i < remaining; ++i) {
+    SCOPED_TRACE(fmt::format("row {}", i));
+    EXPECT_EQ(
+        materialized[i], reinterpret_cast<const PhysicalType&>(data[5 + i]));
+  }
+}
+
 TYPED_TEST(DictionaryApiTypedTest, materializeIndicesRleDictionaryFuzz) {
   using T = TypeParam;
 
@@ -2501,8 +2603,9 @@ TYPED_TEST(DictionaryApiTypedTest, rleWithConstantLeaf) {
   nimble::encoding::writeString(serializedRunLengths, pos);
   nimble::encoding::writeBytes(serializedRunValues, pos);
 
-  auto encoding =
-      this->decodeEncoding(std::string_view(reserved, encodingSize));
+  auto encoding = this->decodeEncoding(
+      std::string_view(reserved, encodingSize),
+      /*preserveDictionaryEncoding=*/true);
   ASSERT_TRUE(encoding->dictionaryEnabled());
   EXPECT_EQ(encoding->dictionarySize(), 1);
 
@@ -2660,8 +2763,9 @@ TYPED_TEST(DictionaryApiTypedTest, rleWithConstantLeafFuzz) {
     nimble::encoding::writeString(serializedRunLengths, pos);
     nimble::encoding::writeBytes(serializedRunValues, pos);
 
-    auto encoding =
-        this->decodeEncoding(std::string_view(reserved, encodingSize));
+    auto encoding = this->decodeEncoding(
+        std::string_view(reserved, encodingSize),
+        /*preserveDictionaryEncoding=*/true);
     ASSERT_TRUE(encoding->dictionaryEnabled());
     ASSERT_EQ(encoding->dictionarySize(), 1);
 

--- a/dwio/nimble/velox/selective/ChunkedDecoder.cpp
+++ b/dwio/nimble/velox/selective/ChunkedDecoder.cpp
@@ -30,7 +30,7 @@ namespace facebook::nimble {
 
 using namespace facebook::velox;
 
-void ChunkedDecoder::loadNextChunk() {
+void ChunkedDecoder::loadNextChunk(bool preserveDictionaryEncoding) {
   invokeOnChunkLoad();
   auto ret = ensureInput(kChunkHeaderSize);
   NIMBLE_CHECK(ret, "Failed to read chunk header");
@@ -51,14 +51,19 @@ void ChunkedDecoder::loadNextChunk() {
   inputData_ += length;
   inputSize_ -= length;
   currentStringBuffers_.clear();
-  encoding_ = encodingFactory_->create(
-      *pool_,
-      std::string_view(chunkData, chunkSize),
-      [&](uint32_t totalLength) {
-        auto& buffer = currentStringBuffers_.emplace_back(
-            velox::AlignedBuffer::allocate<char>(totalLength, pool_));
-        return buffer->asMutable<void>();
-      });
+  auto stringBufferFactory = [&](uint32_t totalLength) {
+    auto& buffer = currentStringBuffers_.emplace_back(
+        velox::AlignedBuffer::allocate<char>(totalLength, pool_));
+    return buffer->asMutable<void>();
+  };
+  auto data = std::string_view(chunkData, chunkSize);
+  if (preserveDictionaryEncoding) {
+    Encoding::Options options{.preserveDictionaryEncoding = true};
+    encoding_ =
+        EncodingFactory(options).create(*pool_, data, stringBufferFactory);
+  } else {
+    encoding_ = encodingFactory_->create(*pool_, data, stringBufferFactory);
+  }
   remainingValues_ = encoding_->rowCount();
   NIMBLE_CHECK_GT(remainingValues_, 0);
   VLOG(1) << encoding_->debugString();

--- a/dwio/nimble/velox/selective/ChunkedDecoder.h
+++ b/dwio/nimble/velox/selective/ChunkedDecoder.h
@@ -231,13 +231,13 @@ class ChunkedDecoder {
   /// one is fully consumed. Called before inspecting the current encoding
   /// (e.g., currentEncoding, dictionaryConvertible) so that the caller sees
   /// the encoding and remainingValues of the chunk that will actually be read.
-  void ensureLoaded() {
+  void ensureLoaded(bool preserveDictionaryEncoding = false) {
     if (encoding_ != nullptr && remainingValues_ != 0) {
       return;
     }
 
     if (hasMoreChunks()) {
-      loadNextChunk();
+      loadNextChunk(preserveDictionaryEncoding);
     }
   }
 
@@ -587,7 +587,7 @@ class ChunkedDecoder {
     }
   }
 
-  void loadNextChunk();
+  void loadNextChunk(bool preserveDictionaryEncoding = false);
 
   void prepareInputBuffer(int32_t size);
 

--- a/dwio/nimble/velox/selective/StringColumnReader.cpp
+++ b/dwio/nimble/velox/selective/StringColumnReader.cpp
@@ -56,7 +56,7 @@ bool StringColumnReader::readWithDictionary(
            .nimblePreserveDictionaryEncoding()) {
     return false;
   }
-  decoder_.ensureLoaded();
+  decoder_.ensureLoaded(/*preserveDictionaryEncoding=*/true);
   const auto numRequestedRows = rows.back() + 1;
   // The decoder must have enough remaining values in the current chunk to
   // cover both the skip (from readOffset_ to offset, executed by prepareRead


### PR DESCRIPTION
Summary:
Optimizes the RLE encoding's dictionary mode for string types by eliminating unnecessary alphabet lookups during run transitions.

Key changes:

- **`advanceRunValue()` skips `currentValue_` for string dict mode**: For string types in dict mode, only advances the inner encoding position without computing the value from the alphabet. For non-string dict mode, `currentValue_` is still set since `bulkScan`/`readWithVisitor` need it for flat value reads.
- **`readWithVisitor` and `bulkScan` gated for string dict mode**: Added `NIMBLE_CHECK_NULL(dictValues_)` for string types, enforcing that flat-value reads are not called on string dict-mode encodings. Non-string types are allowed through since they legitimately use these paths.
- **`disableDictEncoding` flag**: Added to `Encoding::Options`, `RLEEncoding` constructor, and `ChunkedDecoder` to support reactive fallback. When set, RLE uses the flat values path regardless of inner encoding's dictionary capability. This ensures the string-type guards in `readWithVisitor`/`bulkScan` are never violated during dict→flat transitions.

Reviewed By: xiaoxmeng

Differential Revision: D106353275
