### PR TITLE
feat(nimble): Add BlockBitPacking encoding (EncodingType=13) (#809)

### DIFF
--- a/dwio/nimble/common/Constants.h
+++ b/dwio/nimble/common/Constants.h
@@ -46,4 +46,7 @@ constexpr uint64_t kChunkingWriterMaxChunkSize{20 << 20}; // 20MB
 /// Used in place of kChunkingWriterMaxChunkSize for tables with large schemas.
 constexpr uint64_t kChunkingWriterWideSchemaMaxChunkSize{2 << 20}; // 2MB
 
+/// Default block size for BlockBitPacking encoding and its statistics.
+constexpr uint16_t kBlockBitPackingBlockSize{1024};
+
 } // namespace facebook::nimble

--- a/dwio/nimble/common/Types.cpp
+++ b/dwio/nimble/common/Types.cpp
@@ -51,6 +51,8 @@ std::string toString(EncodingType encodingType) {
       return "Prefix";
     case EncodingType::ALP:
       return "ALP";
+    case EncodingType::BlockBitPacking:
+      return "BlockBitPacking";
     case EncodingType::PFOR:
       return "PFOR";
     case EncodingType::SimdForBitpack:

--- a/dwio/nimble/common/Types.h
+++ b/dwio/nimble/common/Types.h
@@ -106,6 +106,10 @@ enum class EncodingType {
   Prefix = 11,
   // Adaptive Lossless floating-Point compression for numeric types.
   ALP = 12,
+  // Stores integer data in fixed-size chunks (default 1024 rows), each with
+  // its own baseline and bit width. Adapts per-chunk variable bit widths for
+  // better compression on data with locally narrow value ranges.
+  BlockBitPacking = 15,
   // Patched Frame-of-Reference. Subtracts a min baseline, bitpacks ~90% of
   // residuals at a narrow base bit width, and stores the remaining outliers
   // ("exceptions") as a parallel position+value array.

--- a/dwio/nimble/common/tests/TypesTest.cpp
+++ b/dwio/nimble/common/tests/TypesTest.cpp
@@ -39,6 +39,7 @@ TEST(TypesTest, EncodingTypeToString) {
   EXPECT_EQ(toString(EncodingType::MainlyConstant), "MainlyConstant");
   EXPECT_EQ(toString(EncodingType::Prefix), "Prefix");
   EXPECT_EQ(toString(EncodingType::ALP), "ALP");
+  EXPECT_EQ(toString(EncodingType::BlockBitPacking), "BlockBitPacking");
 }
 
 TEST(TypesTest, EncodingTypeToStringUnknown) {

--- a/dwio/nimble/encodings/BlockBitPackingEncoding.h
+++ b/dwio/nimble/encodings/BlockBitPackingEncoding.h
@@ -1,0 +1,739 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <algorithm>
+#include <span>
+#include <type_traits>
+
+#include "dwio/nimble/common/Buffer.h"
+#include "dwio/nimble/common/Constants.h"
+#include "dwio/nimble/common/Exceptions.h"
+#include "dwio/nimble/common/FixedBitArray.h"
+#include "dwio/nimble/common/Vector.h"
+#include "dwio/nimble/compression/Compression.h"
+#include "dwio/nimble/encodings/common/Encoding.h"
+#include "dwio/nimble/encodings/common/EncodingPrimitives.h"
+#include "dwio/nimble/encodings/common/EncodingType.h"
+#include "dwio/nimble/encodings/selection/EncodingSelection.h"
+#include "velox/common/base/BitUtil.h"
+#include "velox/dwio/common/DecoderUtil.h"
+#include "velox/dwio/common/Lemire/BitPacking/bitpackinghelpers.h"
+
+// Stores integer data in fixed-size blocks (default 1024 rows), each with its
+// own baseline and bit width. Adapted from Impulse's per-block bitpacking
+// approach for better compression when value ranges vary across the stream.
+
+namespace facebook::nimble {
+
+template <typename T>
+class BlockBitPackingEncoding final
+    : public TypedEncoding<T, typename TypeTraits<T>::physicalType> {
+ public:
+  using cppDataType = T;
+  using physicalType = typename TypeTraits<T>::physicalType;
+
+  static constexpr uint16_t kMaxBlockSize = kBlockBitPackingBlockSize;
+
+  BlockBitPackingEncoding(
+      velox::memory::MemoryPool& pool,
+      std::string_view data,
+      const std::function<void*(uint32_t)>& stringBufferFactory,
+      const Encoding::Options& options = {});
+
+  ~BlockBitPackingEncoding() override {
+    this->releaseBuffer(uncompressedData_);
+    this->releaseVectorBuffer(buffer_);
+  }
+
+  void reset() final;
+  void skip(uint32_t rowCount) final;
+  void materialize(uint32_t rowCount, void* buffer) final;
+
+  template <typename DecoderVisitor>
+  void readWithVisitor(DecoderVisitor& visitor, ReadWithVisitorParams& params);
+
+  template <bool kScatter, typename Visitor>
+  void bulkScan(
+      Visitor& visitor,
+      vector_size_t currentRow,
+      const vector_size_t* selectedRows,
+      vector_size_t numSelected,
+      const vector_size_t* scatterRows);
+
+  static std::string_view encode(
+      EncodingSelection<physicalType>& selection,
+      std::span<const physicalType> values,
+      Buffer& buffer,
+      const Encoding::Options& options = {});
+
+  /// Returns the metadata overhead in bytes for the encoding header.
+  /// Shared by encode() and EncodingSizeEstimation to keep the two in sync.
+  static uint32_t encodingOverhead(uint32_t numBlocks) {
+    return 1 /* compressionType */ + 2 /* blockSize */ + 2 /* numBlocks */ +
+        numBlocks *
+        (sizeof(physicalType) + 1) /* per-block baseline + bitWidth */
+        + numBlocks * sizeof(uint32_t) /* per-block data offsets */;
+  }
+
+  std::string debugString(int offset) const final;
+
+ private:
+  /// Per-block metadata stored in the header: baseline (minimum) value,
+  /// bit width for the packed representation, and whether this block
+  /// falls back to storing raw uncompressed values.
+  struct BlockMeta {
+    /// Minimum value in the block; packed values are stored as
+    /// (value - baseline).
+    physicalType baseline;
+    /// Number of bits per packed value (0 when all values equal the baseline).
+    uint8_t bitWidth;
+    /// When true, this block stores raw values (packing was not beneficial).
+    bool skipEncoding;
+  };
+
+  /// Reads a single decoded value at the given absolute row index.
+  physicalType readSingleValue(uint32_t row) const;
+
+  /// Decodes a contiguous range within one block into 'output'.
+  void materializeBlockRange(
+      uint32_t blockIndex,
+      uint32_t blockValueOffset,
+      uint32_t blockValueCount,
+      physicalType* output) const;
+
+  /// Returns the number of rows in the given block (may be less than
+  /// blockSize_ for the last block).
+  uint32_t blockRowCount(uint32_t blockIndex) const;
+
+  /// Unpacks 'numRows' bit-packed values in fixed-size groups, falling
+  /// back to FixedBitArray for any trailing remainder.
+  static void fullUnpack(
+      const uint8_t* input,
+      physicalType* output,
+      uint32_t numRows,
+      uint8_t bitWidth,
+      physicalType baseline);
+
+  uint16_t blockSize_;
+  uint16_t numBlocks_;
+  Vector<BlockMeta> blocksMetadata_;
+  Vector<uint32_t> blockDataOffsets_;
+  const char* packedData_;
+  uint32_t row_ = 0;
+  velox::BufferPtr uncompressedData_;
+  Vector<physicalType> buffer_;
+};
+
+//
+// End of public API. Implementations follow.
+//
+
+template <typename T>
+BlockBitPackingEncoding<T>::BlockBitPackingEncoding(
+    velox::memory::MemoryPool& pool,
+    std::string_view data,
+    const std::function<void*(uint32_t)>& /* stringBufferFactory */,
+    const Encoding::Options& options)
+    : TypedEncoding<T, physicalType>{pool, data, options},
+      blocksMetadata_{&pool},
+      blockDataOffsets_{&pool},
+      packedData_{nullptr},
+      buffer_(this->template getVectorBuffer<physicalType>()) {
+  auto pos = data.data() + this->dataOffset();
+  auto compressionType = static_cast<CompressionType>(encoding::readChar(pos));
+  blockSize_ = encoding::read<const uint16_t>(pos);
+  numBlocks_ = encoding::read<const uint16_t>(pos);
+
+  NIMBLE_CHECK(blockSize_ > 0 && blockSize_ <= kMaxBlockSize);
+  NIMBLE_CHECK_EQ(numBlocks_, (this->rowCount() + blockSize_ - 1) / blockSize_);
+
+  blocksMetadata_.resize(numBlocks_);
+  for (uint16_t i = 0; i < numBlocks_; ++i) {
+    blocksMetadata_[i].baseline = encoding::read<const physicalType>(pos);
+    const auto bitWidth = static_cast<uint8_t>(encoding::readChar(pos));
+    blocksMetadata_[i].skipEncoding = (bitWidth == 255);
+    blocksMetadata_[i].bitWidth =
+        blocksMetadata_[i].skipEncoding ? 0 : bitWidth;
+  }
+
+  blockDataOffsets_.resize(numBlocks_);
+  for (uint16_t i = 0; i < numBlocks_; ++i) {
+    blockDataOffsets_[i] = encoding::read<const uint32_t>(pos);
+  }
+
+  if (compressionType != CompressionType::Uncompressed) {
+    uncompressedData_ = Compression::uncompress(
+        pool,
+        compressionType,
+        DataType::Undefined,
+        {pos, static_cast<size_t>(data.end() - pos)},
+        options.bufferPool);
+    packedData_ = uncompressedData_->as<char>();
+  } else {
+    packedData_ = pos;
+  }
+}
+
+template <typename T>
+void BlockBitPackingEncoding<T>::reset() {
+  row_ = 0;
+}
+
+template <typename T>
+void BlockBitPackingEncoding<T>::skip(uint32_t rowCount) {
+  row_ += rowCount;
+}
+
+template <typename T>
+uint32_t BlockBitPackingEncoding<T>::blockRowCount(uint32_t blockIndex) const {
+  const auto totalRows = this->rowCount();
+  const auto start = static_cast<uint32_t>(blockIndex) * blockSize_;
+  return std::min(static_cast<uint32_t>(blockSize_), totalRows - start);
+}
+
+template <typename T>
+typename BlockBitPackingEncoding<T>::physicalType
+BlockBitPackingEncoding<T>::readSingleValue(uint32_t row) const {
+  const auto blockIndex = row / blockSize_;
+  const auto blockOffset = row % blockSize_;
+  const auto& blockMetadata = blocksMetadata_[blockIndex];
+  if (blockMetadata.skipEncoding) {
+    const auto* rawValues = reinterpret_cast<const physicalType*>(
+        packedData_ + blockDataOffsets_[blockIndex]);
+    return rawValues[blockOffset];
+  }
+  if (blockMetadata.bitWidth == 0) {
+    return blockMetadata.baseline;
+  }
+  const auto numRows = blockRowCount(blockIndex);
+  FixedBitArray fba{
+      {packedData_ + blockDataOffsets_[blockIndex],
+       FixedBitArray::bufferSize(numRows, blockMetadata.bitWidth)},
+      blockMetadata.bitWidth};
+  return static_cast<physicalType>(fba.get(blockOffset)) +
+      blockMetadata.baseline;
+}
+
+template <typename T>
+void BlockBitPackingEncoding<T>::materializeBlockRange(
+    uint32_t blockIndex,
+    uint32_t blockValueOffset,
+    uint32_t blockValueCount,
+    physicalType* output) const {
+  const auto& blockMetadata = blocksMetadata_[blockIndex];
+  const auto* blockData = packedData_ + blockDataOffsets_[blockIndex];
+
+  if (blockMetadata.skipEncoding) {
+    const auto* rawValues = reinterpret_cast<const physicalType*>(blockData);
+    std::memcpy(
+        output,
+        rawValues + blockValueOffset,
+        blockValueCount * sizeof(physicalType));
+    return;
+  }
+
+  if (blockMetadata.bitWidth == 0) {
+    std::fill(output, output + blockValueCount, blockMetadata.baseline);
+    return;
+  }
+
+  const auto* inputBytes = reinterpret_cast<const uint8_t*>(blockData);
+
+  if (blockValueOffset == 0) {
+    fullUnpack(
+        inputBytes,
+        output,
+        blockValueCount,
+        blockMetadata.bitWidth,
+        blockMetadata.baseline);
+  } else {
+    physicalType tmp[kMaxBlockSize];
+    fullUnpack(
+        inputBytes,
+        tmp,
+        blockValueOffset + blockValueCount,
+        blockMetadata.bitWidth,
+        blockMetadata.baseline);
+    std::memcpy(
+        output, tmp + blockValueOffset, blockValueCount * sizeof(physicalType));
+  }
+}
+
+template <typename T>
+void BlockBitPackingEncoding<T>::fullUnpack(
+    const uint8_t* input,
+    physicalType* output,
+    uint32_t numRows,
+    uint8_t bitWidth,
+    physicalType baseline) {
+  constexpr uint32_t kGroupSize = [] {
+    if constexpr (sizeof(physicalType) == 1) {
+      return 8u;
+    } else if constexpr (sizeof(physicalType) == 2) {
+      return 16u;
+    } else {
+      return 32u;
+    }
+  }();
+
+  uint32_t currentRow = 0;
+
+  if constexpr (std::is_same_v<physicalType, uint8_t>) {
+    for (; currentRow + kGroupSize <= numRows; currentRow += kGroupSize) {
+      velox::fastpforlib::internal::fastunpack_quarter(
+          input, output + currentRow, bitWidth);
+      input += bitWidth;
+    }
+  } else if constexpr (std::is_same_v<physicalType, uint16_t>) {
+    for (; currentRow + kGroupSize <= numRows; currentRow += kGroupSize) {
+      velox::fastpforlib::internal::fastunpack_half(
+          reinterpret_cast<const uint16_t*>(input),
+          output + currentRow,
+          bitWidth);
+      input += bitWidth * 2;
+    }
+  } else if constexpr (isFourByteIntegralType<physicalType>()) {
+    for (; currentRow + kGroupSize <= numRows; currentRow += kGroupSize) {
+      velox::fastpforlib::fastunpack(
+          reinterpret_cast<const uint32_t*>(input),
+          reinterpret_cast<uint32_t*>(output + currentRow),
+          bitWidth);
+      input += bitWidth * 4;
+    }
+  } else if constexpr (isEightByteIntegralType<physicalType>()) {
+    for (; currentRow + kGroupSize <= numRows; currentRow += kGroupSize) {
+      velox::fastpforlib::fastunpack(
+          reinterpret_cast<const uint32_t*>(input),
+          reinterpret_cast<uint64_t*>(output + currentRow),
+          bitWidth);
+      input += bitWidth * 4;
+    }
+  }
+
+  if (currentRow < numRows) {
+    const auto tailCount = numRows - currentRow;
+    FixedBitArray fba(
+        {reinterpret_cast<const char*>(input),
+         FixedBitArray::bufferSize(tailCount, bitWidth)},
+        bitWidth);
+    for (uint32_t i = 0; i < tailCount; ++i) {
+      output[currentRow + i] = static_cast<physicalType>(fba.get(i));
+    }
+  }
+
+  if (baseline != 0) {
+    for (uint32_t i = 0; i < numRows; ++i) {
+      output[i] += baseline;
+    }
+  }
+}
+
+template <typename T>
+void BlockBitPackingEncoding<T>::materialize(uint32_t rowCount, void* buffer) {
+  auto* output = static_cast<physicalType*>(buffer);
+  uint32_t remaining = rowCount;
+  uint32_t currentRow = row_;
+
+  while (remaining > 0) {
+    const auto blockIndex = currentRow / blockSize_;
+    const auto blockOffset = currentRow % blockSize_;
+    const auto rowsInBlock = std::min(remaining, blockSize_ - blockOffset);
+
+    materializeBlockRange(blockIndex, blockOffset, rowsInBlock, output);
+
+    output += rowsInBlock;
+    currentRow += rowsInBlock;
+    remaining -= rowsInBlock;
+  }
+  row_ += rowCount;
+}
+
+template <typename T>
+template <typename V>
+void BlockBitPackingEncoding<T>::readWithVisitor(
+    V& visitor,
+    ReadWithVisitorParams& params) {
+  using OutputType = detail::ValueType<typename V::DataType>;
+  constexpr bool kIsSuitableWidth =
+      (isFourByteIntegralType<physicalType>() ||
+       isEightByteIntegralType<physicalType>());
+  constexpr bool kIsFluidCast = sizeof(OutputType) >= sizeof(physicalType) &&
+      std::is_integral_v<OutputType> && std::is_integral_v<physicalType>;
+  if constexpr (
+      kIsSuitableWidth &&
+      std::is_same_v<
+          typename V::Extract,
+          velox::dwio::common::ExtractToReader> &&
+      kIsFluidCast) {
+    auto* nulls = visitor.reader().rawNullsInReadRange();
+    if (velox::dwio::common::useFastPath(visitor, nulls)) {
+      detail::readWithVisitorFast(*this, visitor, params, nulls);
+      return;
+    }
+  }
+  detail::readWithVisitorSlow(
+      visitor,
+      params,
+      [&](auto toSkip) { skip(toSkip); },
+      [&] {
+        physicalType value = readSingleValue(row_++);
+        return value;
+      });
+}
+
+template <typename T>
+template <bool kScatter, typename V>
+void BlockBitPackingEncoding<T>::bulkScan(
+    V& visitor,
+    vector_size_t currentRow,
+    const vector_size_t* selectedRows,
+    vector_size_t numSelected,
+    const vector_size_t* scatterRows) {
+  using OutputType = detail::ValueType<typename V::DataType>;
+  static_assert(
+      isFourByteIntegralType<physicalType>() ||
+          isEightByteIntegralType<physicalType>(),
+      "bulkScan only supports 4-byte or 8-byte integral types");
+
+  if (numSelected == 0) {
+    return;
+  }
+
+  const auto numRows = visitor.numRows() - visitor.rowIndex();
+  const auto offset =
+      static_cast<int64_t>(row_) - static_cast<int64_t>(currentRow);
+
+  auto* values = detail::mutableValues<OutputType>(visitor, numRows);
+
+  constexpr bool kSameSize = sizeof(physicalType) == sizeof(OutputType);
+  constexpr bool kIsUpcast = sizeof(OutputType) > sizeof(physicalType) &&
+      std::is_integral_v<OutputType> && std::is_integral_v<physicalType>;
+
+  if constexpr (V::dense) {
+    const auto startRow = selectedRows[0] + offset;
+
+    if constexpr (kSameSize) {
+      // Materialize directly into output — no temp buffer needed.
+      auto* dst = reinterpret_cast<physicalType*>(values);
+      uint32_t decodedRows = 0;
+      uint32_t currentAbsRow = startRow;
+      while (decodedRows < static_cast<uint32_t>(numSelected)) {
+        const auto blockIndex = currentAbsRow / blockSize_;
+        const auto blockOffset = currentAbsRow % blockSize_;
+        const auto toDecode = std::min(
+            static_cast<uint32_t>(numSelected) - decodedRows,
+            blockSize_ - blockOffset);
+        materializeBlockRange(
+            blockIndex, blockOffset, toDecode, dst + decodedRows);
+        decodedRows += toDecode;
+        currentAbsRow += toDecode;
+      }
+    } else if constexpr (kIsUpcast) {
+      buffer_.resize(numSelected);
+      auto* rawBuf = buffer_.data();
+      uint32_t decodedRows = 0;
+      uint32_t currentAbsRow = startRow;
+      while (decodedRows < static_cast<uint32_t>(numSelected)) {
+        const auto blockIndex = currentAbsRow / blockSize_;
+        const auto blockOffset = currentAbsRow % blockSize_;
+        const auto toDecode = std::min(
+            static_cast<uint32_t>(numSelected) - decodedRows,
+            blockSize_ - blockOffset);
+        materializeBlockRange(
+            blockIndex, blockOffset, toDecode, rawBuf + decodedRows);
+        decodedRows += toDecode;
+        currentAbsRow += toDecode;
+      }
+      for (vector_size_t i = 0; i < numSelected; ++i) {
+        values[i] = static_cast<OutputType>(rawBuf[i]);
+      }
+    }
+  } else {
+    // Sparse: decode full block into tmp, then pick selected values.
+    // Simpler than per-element decode — no branching on block type.
+    vector_size_t i = 0;
+    while (i < numSelected) {
+      const auto absRow = static_cast<uint32_t>(selectedRows[i]) +
+          static_cast<uint32_t>(offset);
+      const auto blockIndex = absRow / blockSize_;
+      const auto blockStart = static_cast<uint32_t>(blockIndex) * blockSize_;
+
+      vector_size_t runEnd = i + 1;
+      while (runEnd < numSelected) {
+        const auto nextAbsRow = static_cast<uint32_t>(selectedRows[runEnd]) +
+            static_cast<uint32_t>(offset);
+        if (nextAbsRow / blockSize_ != blockIndex) {
+          break;
+        }
+        ++runEnd;
+      }
+
+      physicalType tmp[kMaxBlockSize];
+      const auto numRows = blockRowCount(blockIndex);
+      materializeBlockRange(blockIndex, 0, numRows, tmp);
+      for (vector_size_t j = i; j < runEnd; ++j) {
+        const auto blockOffset = static_cast<uint32_t>(selectedRows[j]) +
+            static_cast<uint32_t>(offset) - blockStart;
+        values[j] = static_cast<OutputType>(tmp[blockOffset]);
+      }
+      i = runEnd;
+    }
+  }
+
+  row_ += selectedRows[numSelected - 1] - currentRow + 1;
+
+  if constexpr (!kScatter && !V::kHasFilter && !V::kHasHook) {
+    visitor.addNumValues(numRows);
+    visitor.setRowIndex(visitor.numRows());
+    return;
+  }
+
+  if constexpr (!V::kHasHook) {
+    values = reinterpret_cast<OutputType*>(visitor.reader().rawValues());
+  }
+
+  auto numValues = visitor.reader().numValues();
+  int32_t* filterHits = nullptr;
+  if constexpr (V::kHasFilter) {
+    filterHits = visitor.outputRows(numSelected) - numValues;
+  }
+
+  velox::dwio::common::
+      processFixedWidthRun<OutputType, V::kFilterOnly, kScatter, V::dense>(
+          velox::RowSet(selectedRows, numSelected),
+          0,
+          numSelected,
+          scatterRows,
+          values,
+          filterHits,
+          numValues,
+          visitor.filter(),
+          visitor.hook());
+
+  if constexpr (!V::kHasHook) {
+    visitor.addNumValues(
+        V::kHasFilter ? numValues - visitor.reader().numValues() : numRows);
+  }
+  visitor.setRowIndex(visitor.numRows());
+}
+
+template <typename T>
+std::string_view BlockBitPackingEncoding<T>::encode(
+    EncodingSelection<physicalType>& selection,
+    std::span<const physicalType> values,
+    Buffer& buffer,
+    const Encoding::Options& options) {
+  const bool useVarint = options.useVarintRowCount;
+  static_assert(
+      std::is_unsigned_v<physicalType>, "Physical type must be unsigned.");
+
+  const uint16_t blockSize = selection.blockBitPackingBlockSize();
+  const auto rowCount = static_cast<uint32_t>(values.size());
+  const uint32_t numBlocks = (rowCount + blockSize - 1) / blockSize;
+  NIMBLE_CHECK_LE(
+      numBlocks,
+      std::numeric_limits<uint16_t>::max(),
+      "Row count too large for BlockBitPacking encoding.");
+
+  struct BlockInfo {
+    physicalType baseline;
+    uint8_t bitWidth;
+    uint32_t packedSize;
+    uint32_t start;
+    uint32_t count;
+    bool skipEncoding;
+  };
+
+  Vector<BlockInfo> blocks{&buffer.getMemoryPool()};
+  blocks.resize(numBlocks);
+
+  uint32_t totalPackedSize = 0;
+  for (uint16_t blockIndex = 0; blockIndex < numBlocks; ++blockIndex) {
+    const auto start = static_cast<uint32_t>(blockIndex) * blockSize;
+    const auto end = std::min(start + blockSize, rowCount);
+    const auto count = end - start;
+
+    auto blockValues = values.subspan(start, count);
+    auto [minIt, maxIt] =
+        std::minmax_element(blockValues.begin(), blockValues.end());
+    const auto minVal = *minIt;
+    const auto maxVal = *maxIt;
+
+    const auto range = maxVal - minVal;
+    const auto rawSize = count * sizeof(physicalType);
+
+    const auto bitsRequired =
+        (range == 0) ? 0 : velox::bits::bitsRequired(range);
+    NIMBLE_DCHECK_LE(
+        bitsRequired,
+        sizeof(physicalType) * 8,
+        "bitsRequired cannot exceed type width.");
+    if (bitsRequired == sizeof(physicalType) * 8) {
+      blocks[blockIndex] = {
+          0, 0, static_cast<uint32_t>(rawSize), start, count, true};
+      totalPackedSize += blocks[blockIndex].packedSize;
+      continue;
+    }
+
+    // Skip encoding when packing doesn't reduce size.
+    const auto packedSize =
+        static_cast<uint32_t>(FixedBitArray::bufferSize(count, bitsRequired));
+    if (packedSize >= rawSize) {
+      blocks[blockIndex] = {
+          0, 0, static_cast<uint32_t>(rawSize), start, count, true};
+    } else {
+      blocks[blockIndex] = {
+          minVal,
+          static_cast<uint8_t>(bitsRequired),
+          packedSize,
+          start,
+          count,
+          false};
+    }
+    totalPackedSize += blocks[blockIndex].packedSize;
+  }
+
+  const uint32_t metaOverhead = encodingOverhead(numBlocks);
+
+  // Note: if totalPackedSize + metaOverhead >= rawSize, this encoding is not
+  // beneficial. The encoding selection policy should avoid selecting it in that
+  // case. We still encode correctly so the round-trip contract holds.
+
+  Vector<char> packedVector{&buffer.getMemoryPool()};
+  auto dataCompressionPolicy = selection.compressionPolicy();
+  CompressionEncoder<T> compressionEncoder{
+      buffer.getMemoryPool(),
+      *dataCompressionPolicy,
+      DataType::Undefined,
+      /*bitWidth=*/8,
+      /*uncompressedSize=*/totalPackedSize,
+      [&]() {
+        packedVector.resize(totalPackedSize);
+        return std::span<char>{packedVector};
+      },
+      [&](char*& pos) {
+        std::memset(pos, 0, totalPackedSize);
+        uint32_t dataOffset = 0;
+        for (uint16_t blockIndex = 0; blockIndex < numBlocks; ++blockIndex) {
+          const auto& block = blocks[blockIndex];
+
+          if (block.skipEncoding) {
+            std::memcpy(
+                pos + dataOffset,
+                values.data() + block.start,
+                block.count * sizeof(physicalType));
+          } else if (block.bitWidth > 0) {
+            if constexpr (sizeof(physicalType) == 4) {
+              constexpr uint32_t kGroupSize = 32;
+              const auto bitWidth = block.bitWidth;
+              const auto baseline32 = static_cast<uint32_t>(block.baseline);
+              auto* dst = reinterpret_cast<uint32_t*>(pos + dataOffset);
+              const auto* src = reinterpret_cast<const uint32_t*>(
+                  values.data() + block.start);
+
+              const auto fullGroups = block.count / kGroupSize;
+              const auto remainder = block.count % kGroupSize;
+
+              uint32_t tmp[kGroupSize];
+              for (uint32_t group = 0; group < fullGroups; ++group) {
+                for (uint32_t i = 0; i < kGroupSize; ++i) {
+                  tmp[i] = src[group * kGroupSize + i] - baseline32;
+                }
+                velox::fastpforlib::fastpack(tmp, dst, bitWidth);
+                dst += bitWidth;
+              }
+              if (remainder > 0) {
+                const auto remainderOffset =
+                    fullGroups * kGroupSize * bitWidth / 8;
+                FixedBitArray fba(
+                    pos + dataOffset + remainderOffset, block.bitWidth);
+                for (uint32_t i = 0; i < remainder; ++i) {
+                  fba.set(
+                      i,
+                      values[block.start + fullGroups * kGroupSize + i] -
+                          block.baseline);
+                }
+              }
+            } else if constexpr (sizeof(physicalType) < 4) {
+              FixedBitArray fba(pos + dataOffset, block.bitWidth);
+              uint32_t tmp[kMaxBlockSize];
+              for (uint32_t i = 0; i < block.count; ++i) {
+                tmp[i] = static_cast<uint32_t>(values[block.start + i]);
+              }
+              fba.bulkSet32WithBaseline(
+                  0, block.count, tmp, static_cast<uint32_t>(block.baseline));
+            } else {
+              FixedBitArray fba(pos + dataOffset, block.bitWidth);
+              for (uint32_t i = 0; i < block.count; ++i) {
+                fba.set(i, values[block.start + i] - block.baseline);
+              }
+            }
+          }
+          dataOffset += block.packedSize;
+        }
+        pos += totalPackedSize;
+        return pos;
+      }};
+
+  const uint32_t encodingSize =
+      Encoding::serializePrefixSize(rowCount, useVarint) + metaOverhead +
+      compressionEncoder.getSize();
+
+  char* reserved = buffer.reserve(encodingSize);
+  char* pos = reserved;
+  Encoding::serializePrefix(
+      EncodingType::BlockBitPacking,
+      TypeTraits<T>::dataType,
+      rowCount,
+      useVarint,
+      pos);
+  encoding::writeChar(
+      static_cast<char>(compressionEncoder.compressionType()), pos);
+  encoding::write(blockSize, pos);
+  encoding::write(static_cast<uint16_t>(numBlocks), pos);
+
+  uint32_t runningOffset = 0;
+  for (uint16_t blockIndex = 0; blockIndex < numBlocks; ++blockIndex) {
+    encoding::write(blocks[blockIndex].baseline, pos);
+    const uint8_t bwOnDisk =
+        blocks[blockIndex].skipEncoding ? 255 : blocks[blockIndex].bitWidth;
+    encoding::writeChar(static_cast<char>(bwOnDisk), pos);
+  }
+  for (uint16_t blockIndex = 0; blockIndex < numBlocks; ++blockIndex) {
+    encoding::write(runningOffset, pos);
+    runningOffset += blocks[blockIndex].packedSize;
+  }
+
+  compressionEncoder.write(pos);
+
+  NIMBLE_DCHECK_EQ(encodingSize, pos - reserved, "Encoding size mismatch.");
+  return {reserved, encodingSize};
+}
+
+template <typename T>
+std::string BlockBitPackingEncoding<T>::debugString(int offset) const {
+  return fmt::format(
+      "{}{}<{}> rowCount={} blockSize={} numBlocks={}",
+      std::string(offset, ' '),
+      toString(Encoding::encodingType()),
+      toString(Encoding::dataType()),
+      Encoding::rowCount(),
+      blockSize_,
+      numBlocks_);
+}
+
+} // namespace facebook::nimble

--- a/dwio/nimble/encodings/benchmarks/BlockBitPackingBenchmark.cpp
+++ b/dwio/nimble/encodings/benchmarks/BlockBitPackingBenchmark.cpp
@@ -1,0 +1,360 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Benchmark: sparse decode — FBA per-element vs full block decode + pick.
+// Measures the crossover point where decoding the full block becomes
+// faster than per-element FixedBitArray::get().
+//
+// Run: buck2 run @//mode/opt
+// fbcode//dwio/nimble/encodings/benchmarks:block_bit_packing_benchmark
+//
+// Results (Release mode, bw=5, 1024-row block):
+//
+//  Rows  Selectivity     FBA      FullBlock   PerGroup    Winner
+//     5       0.5%       10ns       124ns       24ns      FBA (11x)
+//    50         5%       85ns       137ns      142ns      FBA (1.6x)
+//   100        10%      153ns       159ns      195ns      ~ crossover
+//   200        20%      294ns       222ns      290ns      FullBlock (1.3x)
+//   500        49%      702ns       324ns      453ns      FullBlock (2.2x)
+//   800        78%     1.12us       425ns      616ns      FullBlock (2.6x)
+//  1024       100%     1.42us       502ns      743ns      FullBlock (2.8x)
+//
+// Conclusion: FBA wins below ~10% selectivity, full block wins above.
+// Per-group fastunpack never wins at any selectivity.
+// BBP uses a hybrid threshold of kMaxBlockSize/10 (~102 rows).
+
+#include <algorithm>
+#include <numeric>
+#include <random>
+#include <vector>
+
+#include "dwio/nimble/common/FixedBitArray.h"
+#include "folly/Benchmark.h"
+#include "velox/dwio/common/Lemire/BitPacking/bitpackinghelpers.h"
+
+using namespace facebook::nimble;
+
+namespace {
+
+constexpr uint32_t kBlockSize = 1024;
+constexpr uint8_t kBitWidth = 5;
+
+std::vector<char> packedData;
+std::vector<uint32_t> output(kBlockSize);
+
+// Selected row indices within the block.
+std::vector<uint32_t> sparseRows5;
+std::vector<uint32_t> sparseRows50;
+std::vector<uint32_t> sparseRows100;
+std::vector<uint32_t> sparseRows200;
+std::vector<uint32_t> sparseRows500;
+std::vector<uint32_t> sparseRows800;
+std::vector<uint32_t> denseRows1024;
+
+std::vector<uint32_t> makeSelectedRows(uint32_t count, uint32_t blockSize) {
+  std::vector<uint32_t> all(blockSize);
+  std::iota(all.begin(), all.end(), 0);
+  std::mt19937 rng(42);
+  std::shuffle(all.begin(), all.end(), rng);
+  all.resize(count);
+  std::sort(all.begin(), all.end());
+  return all;
+}
+
+void setupData() {
+  auto bufSize = FixedBitArray::bufferSize(kBlockSize, kBitWidth);
+  packedData.resize(bufSize, 0);
+  FixedBitArray fba(packedData.data(), kBitWidth);
+  std::mt19937 rng(123);
+  uint32_t maxVal = (1u << kBitWidth) - 1;
+  for (uint32_t i = 0; i < kBlockSize; ++i) {
+    fba.set(i, rng() % (maxVal + 1));
+  }
+
+  sparseRows5 = makeSelectedRows(5, kBlockSize);
+  sparseRows50 = makeSelectedRows(50, kBlockSize);
+  sparseRows100 = makeSelectedRows(100, kBlockSize);
+  sparseRows200 = makeSelectedRows(200, kBlockSize);
+  sparseRows500 = makeSelectedRows(500, kBlockSize);
+  sparseRows800 = makeSelectedRows(800, kBlockSize);
+  denseRows1024.resize(kBlockSize);
+  std::iota(denseRows1024.begin(), denseRows1024.end(), 0);
+}
+
+// Option A: FBA::get() per selected row (current BBP sparse path)
+void decodeFBA(const std::vector<uint32_t>& rows) {
+  FixedBitArray fba{
+      {packedData.data(), FixedBitArray::bufferSize(kBlockSize, kBitWidth)},
+      kBitWidth};
+  for (uint32_t i = 0; i < rows.size(); ++i) {
+    output[i] = static_cast<uint32_t>(fba.get(rows[i]));
+  }
+  folly::doNotOptimizeAway(output[0]);
+}
+
+// Option B: fullUnpack entire block via Lemire, then pick rows (Impulse style)
+void decodeFullBlockThenPick(const std::vector<uint32_t>& rows) {
+  uint32_t decoded[kBlockSize];
+  const auto* input = reinterpret_cast<const uint32_t*>(packedData.data());
+  constexpr uint32_t kGroupSize = 32;
+  for (uint32_t r = 0; r < kBlockSize; r += kGroupSize) {
+    facebook::velox::fastpforlib::fastunpack(
+        input + r / kGroupSize * kBitWidth, decoded + r, kBitWidth);
+  }
+  for (uint32_t i = 0; i < rows.size(); ++i) {
+    output[i] = decoded[rows[i]];
+  }
+  folly::doNotOptimizeAway(output[0]);
+}
+
+// Option C: fastunpack only the groups that contain selected rows.
+// Decodes 32 values per group, picks only the needed ones.
+void decodePerGroup(const std::vector<uint32_t>& rows) {
+  constexpr uint32_t kGroupSize = 32;
+  const auto* input = reinterpret_cast<const uint32_t*>(packedData.data());
+  uint32_t tmp[kGroupSize];
+  uint32_t outIdx = 0;
+  uint32_t i = 0;
+  while (i < rows.size()) {
+    const auto groupIdx = rows[i] / kGroupSize;
+    facebook::velox::fastpforlib::fastunpack(
+        input + groupIdx * kBitWidth, tmp, kBitWidth);
+    while (i < rows.size() && rows[i] / kGroupSize == groupIdx) {
+      output[outIdx++] = tmp[rows[i] % kGroupSize];
+      ++i;
+    }
+  }
+  folly::doNotOptimizeAway(output[0]);
+}
+
+} // namespace
+
+// ============================================================================
+// 5 rows / 1024 (0.5% selectivity)
+// ============================================================================
+BENCHMARK(FBA_sparse_5) {
+  decodeFBA(sparseRows5);
+}
+BENCHMARK_RELATIVE(FullBlock_sparse_5) {
+  decodeFullBlockThenPick(sparseRows5);
+}
+BENCHMARK_RELATIVE(PerGroup_sparse_5) {
+  decodePerGroup(sparseRows5);
+}
+BENCHMARK_DRAW_LINE();
+
+// ============================================================================
+// 50 rows / 1024 (5% selectivity)
+// ============================================================================
+BENCHMARK(FBA_sparse_50) {
+  decodeFBA(sparseRows50);
+}
+BENCHMARK_RELATIVE(FullBlock_sparse_50) {
+  decodeFullBlockThenPick(sparseRows50);
+}
+BENCHMARK_RELATIVE(PerGroup_sparse_50) {
+  decodePerGroup(sparseRows50);
+}
+BENCHMARK_DRAW_LINE();
+
+// ============================================================================
+// 100 rows / 1024 (10% selectivity)
+// ============================================================================
+BENCHMARK(FBA_sparse_100) {
+  decodeFBA(sparseRows100);
+}
+BENCHMARK_RELATIVE(FullBlock_sparse_100) {
+  decodeFullBlockThenPick(sparseRows100);
+}
+BENCHMARK_RELATIVE(PerGroup_sparse_100) {
+  decodePerGroup(sparseRows100);
+}
+BENCHMARK_DRAW_LINE();
+
+// ============================================================================
+// 200 rows / 1024 (20% selectivity)
+// ============================================================================
+BENCHMARK(FBA_sparse_200) {
+  decodeFBA(sparseRows200);
+}
+BENCHMARK_RELATIVE(FullBlock_sparse_200) {
+  decodeFullBlockThenPick(sparseRows200);
+}
+BENCHMARK_RELATIVE(PerGroup_sparse_200) {
+  decodePerGroup(sparseRows200);
+}
+BENCHMARK_DRAW_LINE();
+
+// ============================================================================
+// 500 rows / 1024 (49% selectivity)
+// ============================================================================
+BENCHMARK(FBA_sparse_500) {
+  decodeFBA(sparseRows500);
+}
+BENCHMARK_RELATIVE(FullBlock_sparse_500) {
+  decodeFullBlockThenPick(sparseRows500);
+}
+BENCHMARK_RELATIVE(PerGroup_sparse_500) {
+  decodePerGroup(sparseRows500);
+}
+BENCHMARK_DRAW_LINE();
+
+// ============================================================================
+// 800 rows / 1024 (78% selectivity)
+// ============================================================================
+BENCHMARK(FBA_sparse_800) {
+  decodeFBA(sparseRows800);
+}
+BENCHMARK_RELATIVE(FullBlock_sparse_800) {
+  decodeFullBlockThenPick(sparseRows800);
+}
+BENCHMARK_RELATIVE(PerGroup_sparse_800) {
+  decodePerGroup(sparseRows800);
+}
+BENCHMARK_DRAW_LINE();
+
+// ============================================================================
+// 1024 rows / 1024 (100% — dense)
+// ============================================================================
+BENCHMARK(FBA_dense_1024) {
+  decodeFBA(denseRows1024);
+}
+BENCHMARK_RELATIVE(FullBlock_dense_1024) {
+  decodeFullBlockThenPick(denseRows1024);
+}
+BENCHMARK_RELATIVE(PerGroup_dense_1024) {
+  decodePerGroup(denseRows1024);
+}
+
+// ============================================================================
+// Section 2: uint8 decode — fastunpack_quarter vs fastunpack32 + narrow
+//
+// Option A: Lemire fastunpack_quarter — native 8-bit unpack, 8 values/call,
+//   outputs directly to uint8_t*.
+// Option B: Lemire fastunpack (32-bit) into uint32_t[32] temp buffer, then
+//   narrowing loop to uint8_t.
+//
+// Results (Release mode, ~8M values):
+//
+//  bw  Option A (8-bit)  Option B (32-bit+narrow)   A vs B
+//   1         2.24ms              3.36ms            A 1.5x faster
+//   2         2.14ms              3.73ms            A 1.7x faster
+//   3         2.68ms              3.55ms            A 1.3x faster
+//   4         1.39ms              3.97ms            A 2.9x faster
+//   5         3.02ms              3.60ms            A 1.2x faster
+//   6         2.73ms              3.77ms            A 1.4x faster
+//   7         2.59ms              3.79ms            A 1.5x faster
+//   8         1.39ms              3.99ms            A 2.9x faster
+//
+// Conclusion: Option A wins 1.3-2.9x across all bit widths.
+// ============================================================================
+
+namespace {
+
+constexpr uint32_t kUint8NumBlocks = 8192;
+constexpr uint32_t kUint8TotalValues = kBlockSize * kUint8NumBlocks;
+
+struct Uint8PackedData {
+  std::vector<char> bits;
+  uint32_t bytesPerBlock;
+};
+
+std::vector<uint8_t> uint8OutputA(kUint8TotalValues);
+std::vector<uint8_t> uint8OutputB(kUint8TotalValues);
+
+Uint8PackedData uint8PackedBw[9]; // index 1..8
+
+Uint8PackedData packUint8Data(uint8_t bitWidth) {
+  const auto blockBytes = FixedBitArray::bufferSize(kBlockSize, bitWidth);
+  const auto totalBytes = blockBytes * kUint8NumBlocks;
+  std::vector<char> bits(totalBytes, 0);
+  std::mt19937 rng(42);
+  const uint32_t maxVal = (1u << bitWidth) - 1;
+  for (uint32_t b = 0; b < kUint8NumBlocks; ++b) {
+    FixedBitArray fba(bits.data() + b * blockBytes, bitWidth);
+    for (uint32_t i = 0; i < kBlockSize; ++i) {
+      fba.set(i, rng() % (maxVal + 1));
+    }
+  }
+  return {std::move(bits), static_cast<uint32_t>(blockBytes)};
+}
+
+void decodeQuarter(const Uint8PackedData& data, uint8_t bitWidth) {
+  constexpr uint32_t kGroupSize = 8;
+  auto* out = uint8OutputA.data();
+  for (uint32_t b = 0; b < kUint8NumBlocks; ++b) {
+    const auto* input = reinterpret_cast<const uint8_t*>(
+        data.bits.data() + b * data.bytesPerBlock);
+    for (uint32_t r = 0; r < kBlockSize; r += kGroupSize) {
+      facebook::velox::fastpforlib::internal::fastunpack_quarter(
+          input, out + b * kBlockSize + r, bitWidth);
+      input += bitWidth;
+    }
+  }
+  folly::doNotOptimizeAway(uint8OutputA[0]);
+}
+
+void decode32Narrow(const Uint8PackedData& data, uint8_t bitWidth) {
+  constexpr uint32_t kGroupSize = 32;
+  auto* out = uint8OutputB.data();
+  uint32_t tmp[kGroupSize];
+  for (uint32_t b = 0; b < kUint8NumBlocks; ++b) {
+    const auto* input = reinterpret_cast<const uint32_t*>(
+        data.bits.data() + b * data.bytesPerBlock);
+    for (uint32_t r = 0; r < kBlockSize; r += kGroupSize) {
+      facebook::velox::fastpforlib::fastunpack(input, tmp, bitWidth);
+      for (uint32_t i = 0; i < kGroupSize; ++i) {
+        out[b * kBlockSize + r + i] = static_cast<uint8_t>(tmp[i]);
+      }
+      input += bitWidth;
+    }
+  }
+  folly::doNotOptimizeAway(uint8OutputB[0]);
+}
+
+void setupUint8Data() {
+  for (uint8_t bw = 1; bw <= 8; ++bw) {
+    uint8PackedBw[bw] = packUint8Data(bw);
+  }
+}
+
+} // namespace
+
+#define BENCHMARK_UINT8_BW(bw)             \
+  BENCHMARK(quarter_bw##bw) {              \
+    decodeQuarter(uint8PackedBw[bw], bw);  \
+  }                                        \
+  BENCHMARK_RELATIVE(narrow32_bw##bw) {    \
+    decode32Narrow(uint8PackedBw[bw], bw); \
+  }                                        \
+  BENCHMARK_DRAW_LINE();
+
+BENCHMARK_UINT8_BW(1)
+BENCHMARK_UINT8_BW(2)
+BENCHMARK_UINT8_BW(3)
+BENCHMARK_UINT8_BW(4)
+BENCHMARK_UINT8_BW(5)
+BENCHMARK_UINT8_BW(6)
+BENCHMARK_UINT8_BW(7)
+BENCHMARK_UINT8_BW(8)
+
+int main(int argc, char** argv) {
+  gflags::ParseCommandLineFlags(&argc, &argv, true);
+  setupData();
+  setupUint8Data();
+  folly::runBenchmarks();
+  return 0;
+}

--- a/dwio/nimble/encodings/common/EncodingFactory.cpp
+++ b/dwio/nimble/encodings/common/EncodingFactory.cpp
@@ -15,6 +15,7 @@
  */
 #include "dwio/nimble/encodings/common/EncodingFactory.h"
 #include "dwio/nimble/encodings/ALPEncoding.h"
+#include "dwio/nimble/encodings/BlockBitPackingEncoding.h"
 #include "dwio/nimble/encodings/ConstantEncoding.h"
 #include "dwio/nimble/encodings/DeltaEncoding.h"
 #include "dwio/nimble/encodings/DictionaryEncoding.h"
@@ -251,6 +252,9 @@ std::unique_ptr<Encoding> EncodingFactory::create(
       // is implemented. ALP only supports float and double.
       NIMBLE_UNSUPPORTED("ALP encoding is not yet implemented.");
     }
+    case EncodingType::BlockBitPacking: {
+      RETURN_ENCODING_BY_NUMERIC_TYPE(BlockBitPackingEncoding, dataType);
+    }
     case EncodingType::PFOR: {
       RETURN_ENCODING_BY_NUMERIC_TYPE(PFOREncoding, dataType);
     }
@@ -392,6 +396,15 @@ std::string_view EncodingFactory::encode(
     }
     case EncodingType::ALP: {
       NIMBLE_UNSUPPORTED("ALP encoding is not yet implemented.");
+    }
+    case EncodingType::BlockBitPacking: {
+      if constexpr (isNumericType<physicalType>()) {
+        return BlockBitPackingEncoding<T>::encode(
+            selection, castedValues, buffer, options);
+      } else {
+        NIMBLE_INCOMPATIBLE_ENCODING(
+            "BlockBitPacking encoding should not be selected for non-numeric data types.");
+      }
     }
     case EncodingType::PFOR: {
       if constexpr (isIntegralType<physicalType>()) {

--- a/dwio/nimble/encodings/common/EncodingLayout.cpp
+++ b/dwio/nimble/encodings/common/EncodingLayout.cpp
@@ -173,6 +173,7 @@ EncodingLayout EncodingLayoutCapture::capture(std::string_view encoding) {
     case EncodingType::Constant:
     case EncodingType::Prefix:
     case EncodingType::ALP:
+    case EncodingType::BlockBitPacking:
     case EncodingType::PFOR:
     case EncodingType::SimdForBitpack: {
       // Non nested encodings have zero children

--- a/dwio/nimble/encodings/common/EncodingPrimitives.h
+++ b/dwio/nimble/encodings/common/EncodingPrimitives.h
@@ -19,6 +19,7 @@
 #include <string_view>
 
 #include "folly/io/IOBuf.h"
+#include "velox/common/base/BitUtil.h"
 
 // Primitives for reading and writing to a stream of bytes.
 

--- a/dwio/nimble/encodings/common/EncodingUtils.h
+++ b/dwio/nimble/encodings/common/EncodingUtils.h
@@ -16,6 +16,7 @@
 #pragma once
 
 #include "dwio/nimble/encodings/ALPEncoding.h"
+#include "dwio/nimble/encodings/BlockBitPackingEncoding.h"
 #include "dwio/nimble/encodings/ConstantEncoding.h"
 #include "dwio/nimble/encodings/DeltaEncoding.h"
 #include "dwio/nimble/encodings/DictionaryEncoding.h"
@@ -129,6 +130,8 @@ auto encodingTypeDispatchNonString(Encoding& encoding, F&& f) {
       return f(static_cast<DeltaEncoding<T>&>(encoding));
     case EncodingType::ALP:
       NIMBLE_UNSUPPORTED("ALP encoding is not yet implemented.");
+    case EncodingType::BlockBitPacking:
+      return f(static_cast<BlockBitPackingEncoding<T>&>(encoding));
     case EncodingType::PFOR:
       if constexpr (isIntegralType<T>()) {
         return f(static_cast<PFOREncoding<T>&>(encoding));

--- a/dwio/nimble/encodings/legacy/EncodingFactory.cpp
+++ b/dwio/nimble/encodings/legacy/EncodingFactory.cpp
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 #include "dwio/nimble/encodings/legacy/EncodingFactory.h"
+#include "dwio/nimble/encodings/BlockBitPackingEncoding.h"
 #include "dwio/nimble/encodings/PFOREncoding.h"
 #include "dwio/nimble/encodings/SimdForBitpackEncoding.h"
 #include "dwio/nimble/encodings/legacy/ConstantEncoding.h"
@@ -241,6 +242,10 @@ std::unique_ptr<Encoding> EncodingFactory::create(
     }
     case EncodingType::Delta: {
       RETURN_ENCODING_BY_NUMERIC_TYPE(DeltaEncoding, dataType);
+    }
+    case EncodingType::BlockBitPacking: {
+      RETURN_ENCODING_BY_NUMERIC_TYPE(
+          facebook::nimble::BlockBitPackingEncoding, dataType);
     }
     case EncodingType::Prefix: {
       NIMBLE_CHECK_EQ(

--- a/dwio/nimble/encodings/legacy/EncodingUtils.h
+++ b/dwio/nimble/encodings/legacy/EncodingUtils.h
@@ -108,6 +108,9 @@ auto encodingTypeDispatchNonString(Encoding& encoding, F&& f) {
       return f(static_cast<MainlyConstantEncoding<T>&>(encoding));
     case EncodingType::Delta:
       return f(static_cast<DeltaEncoding<T>&>(encoding));
+    case EncodingType::BlockBitPacking:
+      return f(
+          static_cast<facebook::nimble::BlockBitPackingEncoding<T>&>(encoding));
     // New Encoding has no legacy-specialised class; legacy reads dispatch into
     // the modern Encoding classes
     case EncodingType::PFOR:

--- a/dwio/nimble/encodings/selection/EncodingSelection.h
+++ b/dwio/nimble/encodings/selection/EncodingSelection.h
@@ -19,6 +19,7 @@
 #include <span>
 #include <unordered_map>
 
+#include "dwio/nimble/common/Constants.h"
 #include "dwio/nimble/common/Exceptions.h"
 #include "dwio/nimble/common/Types.h"
 #include "dwio/nimble/compression/CompressionPolicy.h"
@@ -76,6 +77,7 @@ struct EncodingSelectionResult {
   EncodingLayout::Config encodingConfig;
   std::function<std::unique_ptr<CompressionPolicy>()> compressionPolicyFactory =
       []() { return std::make_unique<NoCompressionPolicy>(); };
+  uint16_t blockBitPackingBlockSize = kBlockBitPackingBlockSize;
 };
 
 /// The EncodingSelection class is passed in to the encode() method of each
@@ -103,6 +105,10 @@ class EncodingSelection {
   std::unique_ptr<CompressionPolicy> compressionPolicy() const noexcept {
     auto policy = selectionResult_.compressionPolicyFactory();
     return policy;
+  }
+
+  uint16_t blockBitPackingBlockSize() const noexcept {
+    return selectionResult_.blockBitPackingBlockSize;
   }
 
   /// Returns a config value for the given key, or std::nullopt if not found.

--- a/dwio/nimble/encodings/selection/EncodingSelectionPolicy.h
+++ b/dwio/nimble/encodings/selection/EncodingSelectionPolicy.h
@@ -131,10 +131,12 @@ class ManualEncodingSelectionPolicy : public EncodingSelectionPolicy<T> {
   ManualEncodingSelectionPolicy(
       std::vector<std::pair<EncodingType, float>> readFactors,
       std::optional<CompressionOptions> compressionOptions,
-      std::optional<NestedEncodingIdentifier> identifier)
+      std::optional<NestedEncodingIdentifier> identifier,
+      uint16_t blockBitPackingBlockSize = kBlockBitPackingBlockSize)
       : readFactors_{std::move(readFactors)},
         compressionOptions_{std::move(compressionOptions)},
-        identifier_{identifier} {}
+        identifier_{identifier},
+        blockBitPackingBlockSize_{blockBitPackingBlockSize} {}
 
   std::unique_ptr<EncodingSelectionPolicyBase> createImpl(
       EncodingType encodingType,
@@ -163,7 +165,8 @@ class ManualEncodingSelectionPolicy : public EncodingSelectionPolicy<T> {
         COMMA FixedByteWidth,
         std::move(filteredReadFactors),
         compressionOptions_,
-        identifier);
+        identifier,
+        blockBitPackingBlockSize_);
   }
 
   EncodingSelectionResult select(
@@ -309,16 +312,19 @@ class ManualEncodingSelectionPolicy : public EncodingSelectionPolicy<T> {
                 ? "..."
                 : ""));
     if (!compressionOptions_.has_value()) {
-      return {.encodingType = selectedEncoding};
+      return {
+          .encodingType = selectedEncoding,
+          .blockBitPackingBlockSize = blockBitPackingBlockSize_};
     }
     return {
         .encodingType = selectedEncoding,
-        .compressionPolicyFactory = [compressionOptions =
-                                         compressionOptions_.value(),
-                                     selectedEncoding]() {
-          return std::make_unique<AlwaysCompressPolicy>(
-              compressionOptions, selectedEncoding);
-        }};
+        .compressionPolicyFactory =
+            [compressionOptions = compressionOptions_.value(),
+             selectedEncoding]() {
+              return std::make_unique<AlwaysCompressPolicy>(
+                  compressionOptions, selectedEncoding);
+            },
+        .blockBitPackingBlockSize = blockBitPackingBlockSize_};
   }
 
   EncodingSelectionResult selectNullable(
@@ -346,6 +352,7 @@ class ManualEncodingSelectionPolicy : public EncodingSelectionPolicy<T> {
   // policies created from it.
   const std::optional<CompressionOptions> compressionOptions_;
   const std::optional<NestedEncodingIdentifier> identifier_;
+  const uint16_t blockBitPackingBlockSize_;
 };
 
 // This model is trained offline and parameters are updated here.
@@ -375,9 +382,11 @@ class ManualEncodingSelectionPolicyFactory {
       std::vector<std::pair<EncodingType, float>> readFactors =
           defaultReadFactors(),
       std::optional<CompressionOptions> compressionOptions =
-          CompressionOptions{})
+          CompressionOptions{},
+      uint16_t blockBitPackingBlockSize = kBlockBitPackingBlockSize)
       : readFactors_{std::move(readFactors)},
-        compressionOptions_{std::move(compressionOptions)} {}
+        compressionOptions_{std::move(compressionOptions)},
+        blockBitPackingBlockSize_{blockBitPackingBlockSize} {}
 
   std::unique_ptr<EncodingSelectionPolicyBase> createPolicy(
       DataType dataType) const {
@@ -386,7 +395,8 @@ class ManualEncodingSelectionPolicyFactory {
         ManualEncodingSelectionPolicy,
         readFactors_,
         compressionOptions_,
-        std::nullopt);
+        std::nullopt,
+        blockBitPackingBlockSize_);
   }
 
   // TODO: Add EncodingType::ALP here once the actual ALP algorithm is
@@ -474,6 +484,7 @@ class ManualEncodingSelectionPolicyFactory {
  private:
   const std::vector<std::pair<EncodingType, float>> readFactors_;
   const std::optional<CompressionOptions> compressionOptions_;
+  const uint16_t blockBitPackingBlockSize_;
 };
 
 // This is a learned encoding selection implementation.

--- a/dwio/nimble/encodings/tests/BlockBitPackingEncodingTest.cpp
+++ b/dwio/nimble/encodings/tests/BlockBitPackingEncodingTest.cpp
@@ -1,0 +1,689 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "dwio/nimble/encodings/BlockBitPackingEncoding.h"
+#include <gtest/gtest.h>
+#include <random>
+#include <vector>
+#include "dwio/nimble/common/Buffer.h"
+#include "dwio/nimble/common/Types.h"
+#include "dwio/nimble/encodings/SparseBoolEncoding.h"
+#include "dwio/nimble/encodings/tests/EncodingLayoutTestHelper.h"
+#include "dwio/nimble/encodings/tests/TestUtils.h"
+#include "velox/common/base/BitUtil.h"
+#include "velox/dwio/common/Lemire/BitPacking/bitpackinghelpers.h"
+
+using namespace facebook;
+
+class BlockBitPackingEncodingTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    pool_ = facebook::velox::memory::deprecatedAddDefaultLeafMemoryPool();
+    buffer_ = std::make_unique<nimble::Buffer>(*pool_);
+  }
+
+  template <typename T>
+  nimble::Vector<T> toVector(const std::vector<T>& v) {
+    nimble::Vector<T> nv{pool_.get()};
+    nv.insert(nv.end(), v.data(), v.data() + v.size());
+    return nv;
+  }
+
+  template <typename T>
+  void roundTrip(const std::vector<T>& input) {
+    auto values = toVector(input);
+    using Enc = nimble::BlockBitPackingEncoding<T>;
+    auto encoding =
+        nimble::test::Encoder<Enc>::createEncoding(*buffer_, values, nullptr);
+
+    const auto count = static_cast<uint32_t>(input.size());
+    std::vector<T> output(count);
+    encoding->materialize(count, output.data());
+    ASSERT_EQ(input, output);
+  }
+
+  template <typename T>
+  void roundTripWithSkip(
+      const std::vector<T>& input,
+      uint32_t skipRows,
+      uint32_t readRows) {
+    auto values = toVector(input);
+    using Enc = nimble::BlockBitPackingEncoding<T>;
+    auto encoding =
+        nimble::test::Encoder<Enc>::createEncoding(*buffer_, values, nullptr);
+
+    encoding->skip(skipRows);
+    std::vector<T> output(readRows);
+    encoding->materialize(readRows, output.data());
+    std::vector<T> expected(
+        input.begin() + skipRows, input.begin() + skipRows + readRows);
+    ASSERT_EQ(expected, output);
+  }
+
+  std::shared_ptr<velox::memory::MemoryPool> pool_;
+  std::unique_ptr<nimble::Buffer> buffer_;
+};
+
+TEST_F(BlockBitPackingEncodingTest, basicUint32) {
+  std::vector<uint32_t> values = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10};
+  roundTrip(values);
+}
+
+TEST_F(BlockBitPackingEncodingTest, basicUint64) {
+  std::vector<uint64_t> values = {100, 200, 300, 400, 500};
+  roundTrip(values);
+}
+
+TEST_F(BlockBitPackingEncodingTest, basicUint8) {
+  std::vector<uint8_t> values = {0, 1, 2, 3, 255, 128, 64};
+  roundTrip(values);
+}
+
+TEST_F(BlockBitPackingEncodingTest, basicUint16) {
+  std::vector<uint16_t> values = {0, 100, 200, 300, 65535, 32768};
+  roundTrip(values);
+}
+
+TEST_F(BlockBitPackingEncodingTest, multipleChunks) {
+  constexpr uint32_t chunkSize = 1024;
+  std::vector<uint32_t> values(chunkSize * 3);
+  for (uint32_t i = 0; i < values.size(); ++i) {
+    values[i] = i % 256;
+  }
+  roundTrip(values);
+}
+
+TEST_F(BlockBitPackingEncodingTest, variableBitWidthsPerChunk) {
+  constexpr uint32_t chunkSize = 1024;
+  std::vector<uint32_t> values(chunkSize * 3);
+  // Block 0: values [0, 7] — 3 bits
+  for (uint32_t i = 0; i < chunkSize; ++i) {
+    values[i] = i % 8;
+  }
+  // Block 1: values [0, 255] — 8 bits
+  for (uint32_t i = chunkSize; i < chunkSize * 2; ++i) {
+    values[i] = i % 256;
+  }
+  // Block 2: values [0, 65535] — 16 bits
+  for (uint32_t i = chunkSize * 2; i < chunkSize * 3; ++i) {
+    values[i] = i % 65536;
+  }
+  roundTrip(values);
+}
+
+TEST_F(BlockBitPackingEncodingTest, baselineSubtraction) {
+  constexpr uint32_t chunkSize = 1024;
+  std::vector<uint32_t> values(chunkSize * 2);
+  // Block 0: values [1000, 1003] — baseline=1000, 2 bits
+  for (uint32_t i = 0; i < chunkSize; ++i) {
+    values[i] = 1000 + (i % 4);
+  }
+  // Block 1: values [50000, 50001] — baseline=50000, 1 bit
+  for (uint32_t i = chunkSize; i < chunkSize * 2; ++i) {
+    values[i] = 50000 + (i % 2);
+  }
+  roundTrip(values);
+}
+
+TEST_F(BlockBitPackingEncodingTest, singleChunk) {
+  std::vector<uint32_t> values(100);
+  for (uint32_t i = 0; i < values.size(); ++i) {
+    values[i] = i;
+  }
+  roundTrip(values);
+}
+
+TEST_F(BlockBitPackingEncodingTest, constantChunk) {
+  constexpr uint32_t chunkSize = 1024;
+  std::vector<uint32_t> values(chunkSize);
+  std::fill(values.begin(), values.end(), 42);
+  roundTrip(values);
+}
+
+TEST_F(BlockBitPackingEncodingTest, mixedConstantAndVariable) {
+  constexpr uint32_t chunkSize = 1024;
+  std::vector<uint32_t> values(chunkSize * 2);
+  // Chunk 0: constant 42
+  std::fill(values.begin(), values.begin() + chunkSize, 42);
+  // Chunk 1: range [0, 255]
+  for (uint32_t i = chunkSize; i < chunkSize * 2; ++i) {
+    values[i] = i % 256;
+  }
+  roundTrip(values);
+}
+
+TEST_F(BlockBitPackingEncodingTest, skipAndMaterialize) {
+  constexpr uint32_t chunkSize = 1024;
+  std::vector<uint32_t> values(chunkSize * 3);
+  for (uint32_t i = 0; i < values.size(); ++i) {
+    values[i] = i;
+  }
+  // Skip into chunk 1, read across chunk boundary into chunk 2
+  roundTripWithSkip(values, chunkSize + 500, chunkSize);
+}
+
+TEST_F(BlockBitPackingEncodingTest, skipToChunkBoundary) {
+  constexpr uint32_t chunkSize = 1024;
+  std::vector<uint32_t> values(chunkSize * 2);
+  for (uint32_t i = 0; i < values.size(); ++i) {
+    values[i] = i % 100;
+  }
+  roundTripWithSkip(values, chunkSize, chunkSize);
+}
+
+TEST_F(BlockBitPackingEncodingTest, resetAndReread) {
+  std::vector<uint32_t> values = {10, 20, 30, 40, 50};
+  auto nv = toVector(values);
+  using Enc = nimble::BlockBitPackingEncoding<uint32_t>;
+  auto encoding =
+      nimble::test::Encoder<Enc>::createEncoding(*buffer_, nv, nullptr);
+
+  const auto count = static_cast<uint32_t>(values.size());
+  std::vector<uint32_t> output1(count);
+  encoding->materialize(count, output1.data());
+  ASSERT_EQ(values, output1);
+
+  encoding->reset();
+  std::vector<uint32_t> output2(count);
+  encoding->materialize(count, output2.data());
+  ASSERT_EQ(values, output2);
+}
+
+TEST_F(BlockBitPackingEncodingTest, sizeVsFixedBitWidth) {
+  constexpr uint32_t chunkSize = 1024;
+  std::vector<uint32_t> values(chunkSize * 4);
+  // Chunk 0: narrow range [100, 103]
+  for (uint32_t i = 0; i < chunkSize; ++i) {
+    values[i] = 100 + (i % 4);
+  }
+  // Chunk 1: narrow range [200, 201]
+  for (uint32_t i = chunkSize; i < chunkSize * 2; ++i) {
+    values[i] = 200 + (i % 2);
+  }
+  // Chunk 2: wide range [0, 65535]
+  for (uint32_t i = chunkSize * 2; i < chunkSize * 3; ++i) {
+    values[i] = i % 65536;
+  }
+  // Chunk 3: constant
+  for (uint32_t i = chunkSize * 3; i < chunkSize * 4; ++i) {
+    values[i] = 999;
+  }
+
+  auto nv = toVector(values);
+
+  // Encode with BlockBitPacking
+  nimble::Buffer cbpBuffer(*pool_);
+  auto cbpEncoded =
+      nimble::test::Encoder<nimble::BlockBitPackingEncoding<uint32_t>>::encode(
+          cbpBuffer, nv);
+
+  // Encode with FixedBitWidth
+  nimble::Buffer fbwBuffer(*pool_);
+  auto fbwEncoded =
+      nimble::test::Encoder<nimble::FixedBitWidthEncoding<uint32_t>>::encode(
+          fbwBuffer, nv);
+
+  EXPECT_LT(cbpEncoded.size(), fbwEncoded.size())
+      << "BlockBitPacking should produce smaller output for data with "
+         "locally narrow ranges";
+}
+
+TEST_F(BlockBitPackingEncodingTest, compressionRoundTrip) {
+  constexpr uint32_t chunkSize = 1024;
+  std::vector<uint32_t> values(chunkSize * 2);
+  for (uint32_t i = 0; i < values.size(); ++i) {
+    values[i] = i % 100;
+  }
+  auto nv = toVector(values);
+  using Enc = nimble::BlockBitPackingEncoding<uint32_t>;
+
+  // Round-trip works with Zstd compression requested.
+  auto encoding = nimble::test::Encoder<Enc>::createEncoding(
+      *buffer_, nv, nullptr, nimble::CompressionType::Zstd);
+  const auto count = static_cast<uint32_t>(values.size());
+  std::vector<uint32_t> output(count);
+  encoding->materialize(count, output.data());
+  ASSERT_EQ(values, output);
+}
+
+TEST_F(BlockBitPackingEncodingTest, uint64MultiChunk) {
+  constexpr uint32_t chunkSize = 1024;
+  std::vector<uint64_t> values(chunkSize * 2);
+  for (uint32_t i = 0; i < chunkSize; ++i) {
+    values[i] = 1000000ULL + (i % 10);
+  }
+  for (uint32_t i = chunkSize; i < chunkSize * 2; ++i) {
+    values[i] = 9000000ULL + (i % 5);
+  }
+  roundTrip(values);
+}
+
+TEST_F(BlockBitPackingEncodingTest, partialLastChunk) {
+  // 1500 rows: chunk 0 = 1024 rows, chunk 1 = 476 rows
+  std::vector<uint32_t> values(1500);
+  for (uint32_t i = 0; i < values.size(); ++i) {
+    values[i] = i % 50;
+  }
+  roundTrip(values);
+}
+
+TEST_F(BlockBitPackingEncodingTest, debugString) {
+  std::vector<uint32_t> values(2048);
+  for (uint32_t i = 0; i < values.size(); ++i) {
+    values[i] = i % 100;
+  }
+  auto nv = toVector(values);
+  using Enc = nimble::BlockBitPackingEncoding<uint32_t>;
+  auto encoding =
+      nimble::test::Encoder<Enc>::createEncoding(*buffer_, nv, nullptr);
+  auto debugStr = encoding->debugString(0);
+  EXPECT_NE(debugStr.find("BlockBitPacking"), std::string::npos);
+  EXPECT_NE(debugStr.find("numBlocks=2"), std::string::npos);
+}
+
+// Verifies that SparseBool with BlockBitPacking indices produces the same
+// null bitmap as SparseBool with Trivial indices. Regression test for a bug
+// where CBP indices caused incorrect null bitmaps, breaking filter pushdown
+// on sparse nullable columns.
+TEST_F(BlockBitPackingEncodingTest, sparseBoolWithCbpIndices) {
+  // Simulate a very sparse column: ~100 non-null positions out of 100,000 rows.
+  // Mimics the data pattern of first_action_date_ai_active in production
+  // (258K non-null out of 2.9B rows, ~11K gap between adjacent non-nulls).
+  constexpr uint32_t totalRows = 100000;
+  constexpr uint32_t nonNullCount = 100;
+  constexpr uint32_t gap = totalRows / nonNullCount;
+
+  nimble::Vector<bool> boolData{pool_.get()};
+  boolData.resize(totalRows, false);
+  for (uint32_t i = 0; i < nonNullCount; ++i) {
+    boolData[i * gap] = true;
+  }
+  std::span<const bool> boolSpan(boolData.data(), boolData.size());
+
+  // Encode with Trivial indices (baseline).
+  nimble::EncodingLayout trivialLayout{
+      nimble::EncodingType::SparseBool,
+      {},
+      nimble::CompressionType::Uncompressed,
+      {nimble::EncodingLayout{
+          nimble::EncodingType::Trivial,
+          {},
+          nimble::CompressionType::Uncompressed}}};
+  auto trivialPolicy =
+      std::make_unique<nimble::ReplayedEncodingSelectionPolicy<bool>>(
+          trivialLayout,
+          nimble::CompressionOptions{},
+          [](nimble::DataType type)
+              -> std::unique_ptr<nimble::EncodingSelectionPolicyBase> {
+            UNIQUE_PTR_FACTORY(type, nimble::TrivialNestedPolicy);
+          });
+  auto trivialEncoded = nimble::EncodingFactory::encode<bool>(
+      std::move(trivialPolicy), boolSpan, *buffer_);
+  auto trivialEncoding =
+      nimble::EncodingFactory().create(*pool_, trivialEncoded, nullptr);
+
+  // Encode with BlockBitPacking indices.
+  nimble::EncodingLayout cbpLayout{
+      nimble::EncodingType::SparseBool,
+      {},
+      nimble::CompressionType::Uncompressed,
+      {nimble::EncodingLayout{
+          nimble::EncodingType::BlockBitPacking,
+          {},
+          nimble::CompressionType::Uncompressed}}};
+  nimble::Buffer cbpBuffer(*pool_);
+  auto cbpPolicy =
+      std::make_unique<nimble::ReplayedEncodingSelectionPolicy<bool>>(
+          cbpLayout,
+          nimble::CompressionOptions{},
+          [](nimble::DataType type)
+              -> std::unique_ptr<nimble::EncodingSelectionPolicyBase> {
+            UNIQUE_PTR_FACTORY(type, nimble::TrivialNestedPolicy);
+          });
+  auto cbpEncoded = nimble::EncodingFactory::encode<bool>(
+      std::move(cbpPolicy), boolSpan, cbpBuffer);
+  auto cbpEncoding =
+      nimble::EncodingFactory().create(*pool_, cbpEncoded, nullptr);
+
+  // Compare materializeBoolsAsBits output.
+  auto* trivialSB =
+      dynamic_cast<nimble::SparseBoolEncoding*>(trivialEncoding.get());
+  auto* cbpSB = dynamic_cast<nimble::SparseBoolEncoding*>(cbpEncoding.get());
+  ASSERT_NE(trivialSB, nullptr);
+  ASSERT_NE(cbpSB, nullptr);
+
+  const auto numWords = velox::bits::nwords(totalRows);
+  std::vector<uint64_t> trivialBits(numWords, 0);
+  std::vector<uint64_t> cbpBits(numWords, 0);
+
+  trivialSB->materializeBoolsAsBits(totalRows, trivialBits.data(), 0);
+  cbpSB->materializeBoolsAsBits(totalRows, cbpBits.data(), 0);
+
+  for (uint32_t i = 0; i < totalRows; ++i) {
+    bool trivialVal = velox::bits::isBitSet(trivialBits.data(), i);
+    bool cbpVal = velox::bits::isBitSet(cbpBits.data(), i);
+    ASSERT_EQ(trivialVal, cbpVal)
+        << "Mismatch at row " << i << ": trivial=" << trivialVal
+        << " cbp=" << cbpVal;
+    ASSERT_EQ(trivialVal, boolData[i]) << "Wrong value at row " << i;
+  }
+}
+
+// Same test but with larger data and irregular gaps to stress chunk boundaries.
+TEST_F(BlockBitPackingEncodingTest, sparseBoolWithCbpIndicesLargeIrregular) {
+  constexpr uint32_t totalRows = 500000;
+  nimble::Vector<bool> boolData{pool_.get()};
+  boolData.resize(totalRows, false);
+
+  std::mt19937 rng(42);
+  uint32_t pos = 0;
+  uint32_t nonNullCount = 0;
+  while (pos < totalRows) {
+    boolData[pos] = true;
+    ++nonNullCount;
+    pos += 5000 + (rng() % 20000);
+  }
+  std::span<const bool> boolSpan(boolData.data(), boolData.size());
+
+  nimble::EncodingLayout trivialLayout{
+      nimble::EncodingType::SparseBool,
+      {},
+      nimble::CompressionType::Uncompressed,
+      {nimble::EncodingLayout{
+          nimble::EncodingType::Trivial,
+          {},
+          nimble::CompressionType::Uncompressed}}};
+  auto trivialPolicy =
+      std::make_unique<nimble::ReplayedEncodingSelectionPolicy<bool>>(
+          trivialLayout,
+          nimble::CompressionOptions{},
+          [](nimble::DataType type)
+              -> std::unique_ptr<nimble::EncodingSelectionPolicyBase> {
+            UNIQUE_PTR_FACTORY(type, nimble::TrivialNestedPolicy);
+          });
+  auto trivialEncoded = nimble::EncodingFactory::encode<bool>(
+      std::move(trivialPolicy), boolSpan, *buffer_);
+  auto trivialEncoding =
+      nimble::EncodingFactory().create(*pool_, trivialEncoded, nullptr);
+
+  nimble::EncodingLayout cbpLayout{
+      nimble::EncodingType::SparseBool,
+      {},
+      nimble::CompressionType::Uncompressed,
+      {nimble::EncodingLayout{
+          nimble::EncodingType::BlockBitPacking,
+          {},
+          nimble::CompressionType::Uncompressed}}};
+  nimble::Buffer cbpBuffer(*pool_);
+  auto cbpPolicy =
+      std::make_unique<nimble::ReplayedEncodingSelectionPolicy<bool>>(
+          cbpLayout,
+          nimble::CompressionOptions{},
+          [](nimble::DataType type)
+              -> std::unique_ptr<nimble::EncodingSelectionPolicyBase> {
+            UNIQUE_PTR_FACTORY(type, nimble::TrivialNestedPolicy);
+          });
+  auto cbpEncoded = nimble::EncodingFactory::encode<bool>(
+      std::move(cbpPolicy), boolSpan, cbpBuffer);
+  auto cbpEncoding =
+      nimble::EncodingFactory().create(*pool_, cbpEncoded, nullptr);
+
+  auto* trivialSB =
+      dynamic_cast<nimble::SparseBoolEncoding*>(trivialEncoding.get());
+  auto* cbpSB = dynamic_cast<nimble::SparseBoolEncoding*>(cbpEncoding.get());
+  ASSERT_NE(trivialSB, nullptr);
+  ASSERT_NE(cbpSB, nullptr);
+
+  const auto numWords = velox::bits::nwords(totalRows);
+  std::vector<uint64_t> trivialBits(numWords, 0);
+  std::vector<uint64_t> cbpBits(numWords, 0);
+
+  trivialSB->materializeBoolsAsBits(totalRows, trivialBits.data(), 0);
+  cbpSB->materializeBoolsAsBits(totalRows, cbpBits.data(), 0);
+
+  for (uint32_t i = 0; i < totalRows; ++i) {
+    bool trivialVal = velox::bits::isBitSet(trivialBits.data(), i);
+    bool cbpVal = velox::bits::isBitSet(cbpBits.data(), i);
+    ASSERT_EQ(trivialVal, cbpVal)
+        << "Mismatch at row " << i << ": trivial=" << trivialVal
+        << " cbp=" << cbpVal << " (nonNullCount=" << nonNullCount << ")";
+  }
+}
+
+// Exercises the skip-encoding path (bw=255 on disk) where packing is not
+// beneficial because values span the full type range within a block.
+TEST_F(BlockBitPackingEncodingTest, skipEncodingFullRange) {
+  constexpr uint32_t blockSize = 1024;
+  std::vector<uint32_t> values(blockSize);
+  // Range [0, 0xFFFFFFFF] → bw=32 → packedSize == rawSize → skip encoding.
+  for (uint32_t i = 0; i < blockSize; ++i) {
+    values[i] = i;
+  }
+  values[0] = 0;
+  values[blockSize - 1] = 0xFFFFFFFF;
+  roundTrip(values);
+}
+
+// Mix of skip-encoded and packed blocks in the same stream.
+TEST_F(BlockBitPackingEncodingTest, skipEncodingMixedWithPacked) {
+  constexpr uint32_t blockSize = 1024;
+  std::vector<uint32_t> values(blockSize * 2);
+  // Block 0: full range → skip encoding
+  for (uint32_t i = 0; i < blockSize; ++i) {
+    values[i] = i * 4194304;
+  }
+  values[blockSize - 1] = 0xFFFFFFFF;
+  // Block 1: narrow range [0, 15] → 4-bit packing
+  for (uint32_t i = blockSize; i < blockSize * 2; ++i) {
+    values[i] = i % 16;
+  }
+  roundTrip(values);
+}
+
+// uint64 with per-block range > 2^32, exercising wide bit widths on encode.
+TEST_F(BlockBitPackingEncodingTest, uint64WideBitWidth) {
+  constexpr uint32_t blockSize = 1024;
+  std::vector<uint64_t> values(blockSize);
+  // Range [0, 5 billion] → bw=33, exceeds 32-bit boundary.
+  for (uint32_t i = 0; i < blockSize; ++i) {
+    values[i] = static_cast<uint64_t>(i) * 5000000;
+  }
+  roundTrip(values);
+}
+
+// uint64 with partial last block, verifying 64-bit padding on encode.
+TEST_F(BlockBitPackingEncodingTest, uint64PartialLastBlock) {
+  std::vector<uint64_t> values(1500);
+  for (uint32_t i = 0; i < values.size(); ++i) {
+    values[i] = 1000000ULL + (i % 100);
+  }
+  roundTrip(values);
+}
+
+// uint64 partial last block with wide bit width (bw > 32).
+TEST_F(BlockBitPackingEncodingTest, uint64PartialLastBlockWideBitWidth) {
+  std::vector<uint64_t> values(1500);
+  for (uint32_t i = 0; i < values.size(); ++i) {
+    values[i] = static_cast<uint64_t>(i) * 3000000000ULL;
+  }
+  roundTrip(values);
+}
+
+// Every block is constant but with different baselines.
+TEST_F(BlockBitPackingEncodingTest, allConstantBlocksDifferentBaselines) {
+  constexpr uint32_t blockSize = 1024;
+  std::vector<uint32_t> values(blockSize * 3);
+  std::fill(values.begin(), values.begin() + blockSize, 100);
+  std::fill(values.begin() + blockSize, values.begin() + blockSize * 2, 999999);
+  std::fill(values.begin() + blockSize * 2, values.end(), 42);
+  roundTrip(values);
+}
+
+// ---------------------------------------------------------------------------
+// unpackTail coverage: row counts chosen so that rows-per-block is NOT a
+// multiple of kGroupSize, forcing the scalar tail path in fullUnpack.
+// kGroupSize: uint8→8, uint16→16, uint32/uint64→32.
+// ---------------------------------------------------------------------------
+
+// uint32: 1024+17 = 1041 rows. Block 0: 1024 (aligned), block 1: 17 rows.
+// 17 % 32 = 17 → Lemire does 0 full groups, tail handles all 17.
+TEST_F(BlockBitPackingEncodingTest, unpackTailUint32PureTail) {
+  std::vector<uint32_t> values(1024 + 17);
+  for (uint32_t i = 0; i < values.size(); ++i) {
+    values[i] = 100 + (i % 50);
+  }
+  roundTrip(values);
+}
+
+// uint32: 1024+45 = 1069 rows. Block 1: 45 rows.
+// 45 / 32 = 1 full group + 13 tail rows.
+TEST_F(BlockBitPackingEncodingTest, unpackTailUint32PartialGroup) {
+  std::vector<uint32_t> values(1024 + 45);
+  for (uint32_t i = 0; i < values.size(); ++i) {
+    values[i] = i % 1000;
+  }
+  roundTrip(values);
+}
+
+// uint64: 1024+7 rows. Block 1: 7 rows, all tail (7 < 32).
+// Exercises 64-bit tail path that Impulse's fullUnpack lacks entirely.
+TEST_F(BlockBitPackingEncodingTest, unpackTailUint64PureTail) {
+  std::vector<uint64_t> values(1024 + 7);
+  for (uint32_t i = 0; i < values.size(); ++i) {
+    values[i] = 500000ULL + (i % 200);
+  }
+  roundTrip(values);
+}
+
+// uint64 with wide bitWidth (bw > 32) and tail rows.
+// 1024+3 rows. Block 1: 3 rows with range requiring ~33 bits.
+// Exercises the cross-word branch (bitIdx + bitWidth > 64) in unpackTail.
+TEST_F(BlockBitPackingEncodingTest, unpackTailUint64WideBitWidthCrossWord) {
+  std::vector<uint64_t> values(1024 + 3);
+  for (uint32_t i = 0; i < values.size(); ++i) {
+    values[i] = static_cast<uint64_t>(i) * 5000000;
+  }
+  roundTrip(values);
+}
+
+// uint8: 1024+5 rows. Block 1: 5 rows (5 % 8 = 5 tail rows).
+TEST_F(BlockBitPackingEncodingTest, unpackTailUint8) {
+  std::vector<uint8_t> values(1024 + 5);
+  for (uint32_t i = 0; i < values.size(); ++i) {
+    values[i] = i % 7;
+  }
+  roundTrip(values);
+}
+
+// uint16: 1024+11 rows. Block 1: 11 rows (11 % 16 = 11 tail rows).
+TEST_F(BlockBitPackingEncodingTest, unpackTailUint16) {
+  std::vector<uint16_t> values(1024 + 11);
+  for (uint32_t i = 0; i < values.size(); ++i) {
+    values[i] = 300 + (i % 100);
+  }
+  roundTrip(values);
+}
+
+// Single row — entire decode is tail, no Lemire groups at all.
+TEST_F(BlockBitPackingEncodingTest, unpackTailSingleRow) {
+  std::vector<uint32_t> values = {42};
+  roundTrip(values);
+}
+
+// Exactly kGroupSize-1 rows (31 for uint32) — maximum tail, zero full groups.
+TEST_F(BlockBitPackingEncodingTest, unpackTailMaxTailUint32) {
+  std::vector<uint32_t> values(31);
+  for (uint32_t i = 0; i < values.size(); ++i) {
+    values[i] = i * 7;
+  }
+  roundTrip(values);
+}
+
+// Verifies that FixedBitArray packing produces a bit layout that fastUnpack32
+// can decode correctly. This ensures the two libraries agree on the bit-level
+// wire format.
+TEST_F(BlockBitPackingEncodingTest, fixedBitArrayLayoutMatchesFastUnpack) {
+  constexpr uint32_t kGroupSize = 32;
+  std::mt19937 rng(12345);
+
+  for (uint32_t bw = 1; bw <= 32; ++bw) {
+    const uint32_t maxVal = (bw == 32) ? 0xFFFFFFFF : ((1u << bw) - 1);
+    std::uniform_int_distribution<uint32_t> dist(0, maxVal);
+
+    // Generate 32 random values that fit in bw bits.
+    std::vector<uint32_t> values(kGroupSize);
+    for (auto& v : values) {
+      v = dist(rng);
+    }
+
+    // Pack with FixedBitArray.
+    const auto bufSize = nimble::FixedBitArray::bufferSize(kGroupSize, bw);
+    std::vector<char> packed(bufSize, 0);
+    nimble::FixedBitArray fba(packed.data(), bw);
+    fba.bulkSet32(0, kGroupSize, values.data());
+
+    // Unpack with fastUnpack32 (same library Impulse uses).
+    std::vector<uint32_t> decoded(kGroupSize, 0xDEADBEEF);
+    const auto* packedWords = reinterpret_cast<const uint32_t*>(packed.data());
+    velox::fastpforlib::fastunpack(packedWords, decoded.data(), bw);
+
+    // Verify every value matches.
+    for (uint32_t i = 0; i < kGroupSize; ++i) {
+      ASSERT_EQ(values[i], decoded[i])
+          << "Mismatch at index " << i << " with bitWidth=" << bw
+          << ": packed=" << values[i] << " unpacked=" << decoded[i];
+    }
+  }
+}
+
+// Same test with baseline subtraction: encode with bulkSet32WithBaseline,
+// decode with fastUnpack32 + manual baseline add.
+TEST_F(BlockBitPackingEncodingTest, fixedBitArrayBaselineMatchesFastUnpack) {
+  constexpr uint32_t kGroupSize = 32;
+  std::mt19937 rng(67890);
+
+  for (uint32_t bw = 1; bw <= 20; ++bw) {
+    const uint32_t maxRange = (bw == 32) ? 0xFFFFFFFF : ((1u << bw) - 1);
+    const uint32_t baseline = 1000;
+    std::uniform_int_distribution<uint32_t> dist(0, maxRange);
+
+    // Generate values = baseline + residual.
+    std::vector<uint32_t> values(kGroupSize);
+    for (auto& v : values) {
+      v = baseline + dist(rng);
+    }
+
+    // Pack with FixedBitArray (fused baseline subtraction).
+    const auto bufSize = nimble::FixedBitArray::bufferSize(kGroupSize, bw);
+    std::vector<char> packed(bufSize, 0);
+    nimble::FixedBitArray fba(packed.data(), bw);
+    fba.bulkSet32WithBaseline(0, kGroupSize, values.data(), baseline);
+
+    // Unpack with fastUnpack32 + manual baseline add.
+    std::vector<uint32_t> decoded(kGroupSize, 0xDEADBEEF);
+    const auto* packedWords = reinterpret_cast<const uint32_t*>(packed.data());
+    velox::fastpforlib::fastunpack(packedWords, decoded.data(), bw);
+    for (auto& v : decoded) {
+      v += baseline;
+    }
+
+    for (uint32_t i = 0; i < kGroupSize; ++i) {
+      ASSERT_EQ(values[i], decoded[i])
+          << "Mismatch at index " << i << " with bitWidth=" << bw
+          << " baseline=" << baseline << ": original=" << values[i]
+          << " decoded=" << decoded[i];
+    }
+  }
+}

--- a/dwio/nimble/encodings/tests/EncodingLayoutTestHelper.cpp
+++ b/dwio/nimble/encodings/tests/EncodingLayoutTestHelper.cpp
@@ -63,6 +63,11 @@ SparseBoolEnc::operator EncodingLayout() const {
       EncodingType::SparseBool, {}, CompressionType::Uncompressed);
 }
 
+BlockBitPackingEnc::operator EncodingLayout() const {
+  return EncodingLayout(
+      EncodingType::BlockBitPacking, {}, CompressionType::Uncompressed);
+}
+
 DeltaEnc::operator EncodingLayout() const {
   constexpr auto kDeltas = EncodingIdentifiers::Delta::Deltas;
   constexpr auto kRestatements = EncodingIdentifiers::Delta::Restatements;

--- a/dwio/nimble/encodings/tests/EncodingLayoutTestHelper.h
+++ b/dwio/nimble/encodings/tests/EncodingLayoutTestHelper.h
@@ -54,6 +54,10 @@ struct SparseBoolEnc {
   operator EncodingLayout() const;
 };
 
+struct BlockBitPackingEnc {
+  operator EncodingLayout() const;
+};
+
 struct DeltaEnc {
   EncodingLayout deltas = TrivialEnc{};
   EncodingLayout restatements = TrivialEnc{};

--- a/dwio/nimble/encodings/tests/ReadWithVisitorTest.cpp
+++ b/dwio/nimble/encodings/tests/ReadWithVisitorTest.cpp
@@ -3995,6 +3995,300 @@ TEST_P(ReadWithVisitorTest, encodingLevelSimdForBitpackBigintRangeSparse) {
   runForType(int64_t{});
 }
 
+// ---------------------------------------------------------------------------
+// BlockBitPackingEncoding<int32_t> + AlwaysTrue + dense + FAST PATH
+// Exercises the dense bulkScan path that materializes directly into the
+// output buffer (no temp buffer copy). Uses multi-chunk data (>1024 rows)
+// with variable bit widths per chunk.
+// ---------------------------------------------------------------------------
+TEST_P(
+    ReadWithVisitorTest,
+    encodingLevel_BlockBitPacking_AlwaysTrue_Dense_Int32_FastPath) {
+  constexpr int kChunkSize = 1024;
+  constexpr int kRows = kChunkSize * 3 + 500;
+
+  std::vector<int32_t> data(kRows);
+  // Chunk 0: narrow range [100, 103]
+  for (int i = 0; i < kChunkSize; ++i) {
+    data[i] = 100 + (i % 4);
+  }
+  // Chunk 1: wider range [0, 255]
+  for (int i = kChunkSize; i < kChunkSize * 2; ++i) {
+    data[i] = i % 256;
+  }
+  // Chunk 2: constant 42 (bitWidth=0)
+  for (int i = kChunkSize * 2; i < kChunkSize * 3; ++i) {
+    data[i] = 42;
+  }
+  // Chunk 3 (partial): range [0, 15]
+  for (int i = kChunkSize * 3; i < kRows; ++i) {
+    data[i] = i % 16;
+  }
+
+  auto input = makeRowVector(
+      {makeFlatVector<int32_t>(kRows, [&](auto i) { return data[i]; })});
+  auto rowType = asRowType(input->type());
+  auto ctx = makeFileContext(input);
+  auto scanSpec = std::make_shared<common::ScanSpec>("root");
+  scanSpec->addAllChildFields(*rowType);
+  scanSpec->childByName("c0")->setFilter(
+      std::make_unique<common::AlwaysTrue>());
+  auto root = buildReader(*ctx, rowType, *scanSpec);
+
+  auto* structReader =
+      dynamic_cast<dwio::common::SelectiveStructColumnReaderBase*>(root.get());
+  auto* reader = static_cast<IntegerColumnReaderTestAccessor*>(
+      dynamic_cast<IntegerColumnReader*>(structReader->children()[0]));
+  ASSERT_NE(reader, nullptr);
+
+  std::vector<vector_size_t> rowVec(kRows);
+  std::iota(rowVec.begin(), rowVec.end(), 0);
+  RowSet rows(rowVec.data(), rowVec.size());
+
+  reader->doPrepareRead<int32_t>(0, rows, nullptr);
+
+  Buffer buffer(*pool());
+  auto encoding = createFromCustomLayout<int32_t>(
+      BlockBitPackingEnc{}, data, *pool(), buffer);
+
+  common::AlwaysTrue filter;
+  dwio::common::ExtractToReader extractValues(reader);
+  constexpr bool kIsDense = true;
+  DecoderVisitor<
+      int32_t,
+      common::AlwaysTrue,
+      dwio::common::ExtractToReader,
+      kIsDense>
+      visitor(filter, reader, rows, extractValues);
+  auto params = makeReadWithVisitorParams(visitor, rows, pool());
+
+  dispatchCallReadWithVisitor(*encoding, visitor, params);
+
+  EXPECT_EQ(reader->numValues(), kRows);
+  auto values = getValues<int32_t>(reader);
+  for (int i = 0; i < kRows; ++i) {
+    EXPECT_EQ(values[i], data[i]) << "row " << i;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// BlockBitPackingEncoding<int32_t> + AlwaysTrue + sparse + FAST PATH
+// Exercises the sparse bulkScan path that batches selected rows by chunk,
+// materializes each touched chunk range once, then scatters values.
+// Selects every 3rd row across multiple chunks.
+// ---------------------------------------------------------------------------
+TEST_P(
+    ReadWithVisitorTest,
+    encodingLevel_BlockBitPacking_AlwaysTrue_Sparse_Int32_FastPath) {
+  constexpr int kChunkSize = 1024;
+  constexpr int kTotalRows = kChunkSize * 3;
+
+  std::vector<int32_t> data(kTotalRows);
+  // Chunk 0: narrow range
+  for (int i = 0; i < kChunkSize; ++i) {
+    data[i] = 1000 + (i % 8);
+  }
+  // Chunk 1: constant (bitWidth=0 path)
+  for (int i = kChunkSize; i < kChunkSize * 2; ++i) {
+    data[i] = 77;
+  }
+  // Chunk 2: wider range
+  for (int i = kChunkSize * 2; i < kTotalRows; ++i) {
+    data[i] = i % 512;
+  }
+
+  auto input = makeRowVector(
+      {makeFlatVector<int32_t>(kTotalRows, [&](auto i) { return data[i]; })});
+  auto rowType = asRowType(input->type());
+  auto ctx = makeFileContext(input);
+  auto scanSpec = std::make_shared<common::ScanSpec>("root");
+  scanSpec->addAllChildFields(*rowType);
+  scanSpec->childByName("c0")->setFilter(
+      std::make_unique<common::AlwaysTrue>());
+  auto root = buildReader(*ctx, rowType, *scanSpec);
+
+  auto* structReader =
+      dynamic_cast<dwio::common::SelectiveStructColumnReaderBase*>(root.get());
+  auto* reader = static_cast<IntegerColumnReaderTestAccessor*>(
+      dynamic_cast<IntegerColumnReader*>(structReader->children()[0]));
+  ASSERT_NE(reader, nullptr);
+
+  // Every 3rd row — sparse and crosses chunk boundaries.
+  std::vector<vector_size_t> rowVec;
+  for (int i = 0; i < kTotalRows; i += 3) {
+    rowVec.push_back(i);
+  }
+  RowSet rows(rowVec.data(), rowVec.size());
+
+  reader->doPrepareRead<int32_t>(0, rows, nullptr);
+
+  Buffer buffer(*pool());
+  auto encoding = createFromCustomLayout<int32_t>(
+      BlockBitPackingEnc{}, data, *pool(), buffer);
+
+  common::AlwaysTrue filter;
+  dwio::common::ExtractToReader extractValues(reader);
+  constexpr bool kIsDense = false;
+  DecoderVisitor<
+      int32_t,
+      common::AlwaysTrue,
+      dwio::common::ExtractToReader,
+      kIsDense>
+      visitor(filter, reader, rows, extractValues);
+  auto params = makeReadWithVisitorParams(visitor, rows, pool());
+
+  dispatchCallReadWithVisitor(*encoding, visitor, params);
+
+  auto numSelected = static_cast<int>(rowVec.size());
+  EXPECT_EQ(reader->numValues(), numSelected);
+  auto values = getValues<int32_t>(reader);
+  for (int i = 0; i < numSelected; ++i) {
+    EXPECT_EQ(values[i], data[rowVec[i]]) << "selected row index " << i;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// BlockBitPackingEncoding<int32_t> + BigintRange + dense + FAST PATH
+// Exercises the filter path in bulkScan: only values in [100, 103] pass.
+// Data spans multiple chunks with different ranges.
+// ---------------------------------------------------------------------------
+TEST_P(
+    ReadWithVisitorTest,
+    encodingLevel_BlockBitPacking_BigintRange_Dense_Int32_FastPath) {
+  constexpr int kChunkSize = 1024;
+  constexpr int kRows = kChunkSize * 2;
+
+  std::vector<int32_t> data(kRows);
+  // Chunk 0: values [100, 103] — all pass filter
+  for (int i = 0; i < kChunkSize; ++i) {
+    data[i] = 100 + (i % 4);
+  }
+  // Chunk 1: values [200, 207] — none pass filter
+  for (int i = kChunkSize; i < kRows; ++i) {
+    data[i] = 200 + (i % 8);
+  }
+
+  auto input = makeRowVector(
+      {makeFlatVector<int32_t>(kRows, [&](auto i) { return data[i]; })});
+  auto rowType = asRowType(input->type());
+  auto ctx = makeFileContext(input);
+  auto scanSpec = std::make_shared<common::ScanSpec>("root");
+  scanSpec->addAllChildFields(*rowType);
+  scanSpec->childByName("c0")->setFilter(
+      std::make_unique<common::BigintRange>(100, 103, false));
+  auto root = buildReader(*ctx, rowType, *scanSpec);
+
+  auto* structReader =
+      dynamic_cast<dwio::common::SelectiveStructColumnReaderBase*>(root.get());
+  auto* reader = static_cast<IntegerColumnReaderTestAccessor*>(
+      dynamic_cast<IntegerColumnReader*>(structReader->children()[0]));
+  ASSERT_NE(reader, nullptr);
+
+  std::vector<vector_size_t> rowVec(kRows);
+  std::iota(rowVec.begin(), rowVec.end(), 0);
+  RowSet rows(rowVec.data(), rowVec.size());
+
+  reader->doPrepareRead<int32_t>(0, rows, nullptr);
+
+  Buffer buffer(*pool());
+  auto encoding = createFromCustomLayout<int32_t>(
+      BlockBitPackingEnc{}, data, *pool(), buffer);
+
+  common::BigintRange filter(100, 103, false);
+  dwio::common::ExtractToReader extractValues(reader);
+  constexpr bool kIsDense = true;
+  DecoderVisitor<
+      int32_t,
+      common::BigintRange,
+      dwio::common::ExtractToReader,
+      kIsDense>
+      visitor(filter, reader, rows, extractValues);
+  auto params = makeReadWithVisitorParams(visitor, rows, pool());
+
+  dispatchCallReadWithVisitor(*encoding, visitor, params);
+
+  // Only chunk 0 values pass the filter [100, 103].
+  EXPECT_EQ(reader->numValues(), kChunkSize);
+  auto values = getValues<int32_t>(reader);
+  for (int i = 0; i < kChunkSize; ++i) {
+    EXPECT_GE(values[i], 100);
+    EXPECT_LE(values[i], 103);
+    EXPECT_EQ(values[i], data[i]) << "row " << i;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// BlockBitPackingEncoding<int32_t> + AlwaysTrue + sparse + FAST PATH
+// Very sparse selection: only a few rows per chunk, some chunks skipped
+// entirely. Exercises the chunk-batching optimization in the sparse path.
+// ---------------------------------------------------------------------------
+TEST_P(
+    ReadWithVisitorTest,
+    encodingLevel_BlockBitPacking_AlwaysTrue_VerySparse_Int32_FastPath) {
+  constexpr int kChunkSize = 1024;
+  constexpr int kTotalRows = kChunkSize * 4;
+
+  std::vector<int32_t> data(kTotalRows);
+  for (int i = 0; i < kTotalRows; ++i) {
+    data[i] = i;
+  }
+
+  auto input = makeRowVector(
+      {makeFlatVector<int32_t>(kTotalRows, [&](auto i) { return data[i]; })});
+  auto rowType = asRowType(input->type());
+  auto ctx = makeFileContext(input);
+  auto scanSpec = std::make_shared<common::ScanSpec>("root");
+  scanSpec->addAllChildFields(*rowType);
+  scanSpec->childByName("c0")->setFilter(
+      std::make_unique<common::AlwaysTrue>());
+  auto root = buildReader(*ctx, rowType, *scanSpec);
+
+  auto* structReader =
+      dynamic_cast<dwio::common::SelectiveStructColumnReaderBase*>(root.get());
+  auto* reader = static_cast<IntegerColumnReaderTestAccessor*>(
+      dynamic_cast<IntegerColumnReader*>(structReader->children()[0]));
+  ASSERT_NE(reader, nullptr);
+
+  // Pick specific rows: first, last, chunk boundaries, and mid-chunk.
+  std::vector<vector_size_t> rowVec = {
+      0, // chunk 0 first
+      512, // chunk 0 mid
+      kChunkSize - 1, // chunk 0 last
+      kChunkSize, // chunk 1 first
+      kChunkSize * 2 + 100, // chunk 2 mid (skip chunk 1 end)
+      kChunkSize * 3 - 1, // chunk 2 last
+      kChunkSize * 4 - 1, // chunk 3 last (overall last)
+  };
+  RowSet rows(rowVec.data(), rowVec.size());
+
+  reader->doPrepareRead<int32_t>(0, rows, nullptr);
+
+  Buffer buffer(*pool());
+  auto encoding = createFromCustomLayout<int32_t>(
+      BlockBitPackingEnc{}, data, *pool(), buffer);
+
+  common::AlwaysTrue filter;
+  dwio::common::ExtractToReader extractValues(reader);
+  constexpr bool kIsDense = false;
+  DecoderVisitor<
+      int32_t,
+      common::AlwaysTrue,
+      dwio::common::ExtractToReader,
+      kIsDense>
+      visitor(filter, reader, rows, extractValues);
+  auto params = makeReadWithVisitorParams(visitor, rows, pool());
+
+  dispatchCallReadWithVisitor(*encoding, visitor, params);
+
+  auto numSelected = static_cast<int>(rowVec.size());
+  EXPECT_EQ(reader->numValues(), numSelected);
+  auto values = getValues<int32_t>(reader);
+  for (int i = 0; i < numSelected; ++i) {
+    EXPECT_EQ(values[i], data[rowVec[i]])
+        << "selected row " << rowVec[i] << " at index " << i;
+  }
+}
+
 INSTANTIATE_TEST_SUITE_P(
     NonLegacyAndLegacy,
     ReadWithVisitorTest,

--- a/dwio/nimble/encodings/tests/TestUtils.h
+++ b/dwio/nimble/encodings/tests/TestUtils.h
@@ -16,6 +16,7 @@
 #pragma once
 
 #include "dwio/nimble/encodings/ALPEncoding.h"
+#include "dwio/nimble/encodings/BlockBitPackingEncoding.h"
 #include "dwio/nimble/encodings/ConstantEncoding.h"
 #include "dwio/nimble/encodings/DeltaEncoding.h"
 #include "dwio/nimble/encodings/DictionaryEncoding.h"
@@ -181,6 +182,12 @@ class Encoder {
   struct EncodingTypeTraits<nimble::NullableEncoding<T>> {
     static constexpr inline nimble::EncodingType encodingType =
         nimble::EncodingType::Nullable;
+  };
+
+  template <>
+  struct EncodingTypeTraits<nimble::BlockBitPackingEncoding<T>> {
+    static constexpr inline nimble::EncodingType encodingType =
+        nimble::EncodingType::BlockBitPacking;
   };
 
   template <>

--- a/dwio/nimble/fuzzer/encoding/EncodingFuzzerTest.cpp
+++ b/dwio/nimble/fuzzer/encoding/EncodingFuzzerTest.cpp
@@ -26,6 +26,7 @@
 #include <gtest/gtest.h>
 
 #include "dwio/nimble/encodings/ALPEncoding.h"
+#include "dwio/nimble/encodings/BlockBitPackingEncoding.h"
 #include "dwio/nimble/encodings/ConstantEncoding.h"
 #include "dwio/nimble/encodings/DeltaEncoding.h"
 #include "dwio/nimble/encodings/DictionaryEncoding.h"
@@ -278,6 +279,32 @@ class MainlyConstantFuzzerTest : public ::testing::Test {};
 TYPED_TEST_SUITE(MainlyConstantFuzzerTest, MainlyConstantTypes);
 
 TYPED_TEST(MainlyConstantFuzzerTest, correctness) {
+  EncodingFuzzer<TypeParam> fuzzer(
+      FLAGS_fuzzer_iterations,
+      FLAGS_fuzzer_max_rows,
+      FLAGS_fuzzer_seed,
+      FLAGS_fuzzer_compression);
+  fuzzer.run();
+}
+
+// BlockBitPacking: all numeric types
+using BlockBitPackingTypes = ::testing::Types<
+    BlockBitPackingEncoding<int8_t>,
+    BlockBitPackingEncoding<uint8_t>,
+    BlockBitPackingEncoding<int16_t>,
+    BlockBitPackingEncoding<uint16_t>,
+    BlockBitPackingEncoding<int32_t>,
+    BlockBitPackingEncoding<uint32_t>,
+    BlockBitPackingEncoding<int64_t>,
+    BlockBitPackingEncoding<uint64_t>,
+    BlockBitPackingEncoding<float>,
+    BlockBitPackingEncoding<double>>;
+
+template <typename E>
+class BlockBitPackingFuzzerTest : public ::testing::Test {};
+TYPED_TEST_SUITE(BlockBitPackingFuzzerTest, BlockBitPackingTypes);
+
+TYPED_TEST(BlockBitPackingFuzzerTest, correctness) {
   EncodingFuzzer<TypeParam> fuzzer(
       FLAGS_fuzzer_iterations,
       FLAGS_fuzzer_max_rows,

--- a/dwio/nimble/tools/EncodingUtilities.cpp
+++ b/dwio/nimble/tools/EncodingUtilities.cpp
@@ -29,7 +29,8 @@ void extractCompressionType(
     // Compression type is the byte right after the encoding header for both
     // encodings.
     case EncodingType::Trivial:
-    case EncodingType::FixedBitWidth: {
+    case EncodingType::FixedBitWidth:
+    case EncodingType::BlockBitPacking: {
       auto pos = stream.data() + kEncodingPrefixSize;
       properties.insert(
           {EncodingPropertyType::Compression,
@@ -106,6 +107,7 @@ void traverseEncodings(
     case EncodingType::Constant:
     case EncodingType::Prefix:
     case EncodingType::ALP:
+    case EncodingType::BlockBitPacking:
     case EncodingType::PFOR:
     case EncodingType::SimdForBitpack: {
       // don't have any nested encoding

--- a/dwio/nimble/velox/NimbleConfig.cpp
+++ b/dwio/nimble/velox/NimbleConfig.cpp
@@ -339,6 +339,10 @@ std::map<uint64_t, float> parseGrowthConfigMap(const std::string& str) {
     "nimble.index.encoding_type",
     "prefix");
 
+/* static */ Config::Entry<uint16_t> Config::BLOCK_BIT_PACKING_BLOCK_SIZE(
+    "nimble.blockbitpacking.block.size",
+    kBlockBitPackingBlockSize);
+
 /* static */ Config::Entry<bool> Config::ENABLE_STATS_COLLECTION(
     "nimble.stats.enable",
     true);

--- a/dwio/nimble/velox/NimbleConfig.h
+++ b/dwio/nimble/velox/NimbleConfig.h
@@ -80,6 +80,8 @@ class Config : public velox::config::ConfigBase {
   /// Valid values: "prefix" (default), "trivial".
   static Entry<std::string> INDEX_ENCODING_TYPE;
 
+  static Entry<uint16_t> BLOCK_BIT_PACKING_BLOCK_SIZE;
+
   /// Enable column statistics collection during writing.
   static Entry<bool> ENABLE_STATS_COLLECTION;
 

--- a/dwio/nimble/velox/VeloxWriterOptions.h
+++ b/dwio/nimble/velox/VeloxWriterOptions.h
@@ -130,6 +130,9 @@ struct VeloxWriterOptions {
   // Compression settings to be used when encoding and compressing data streams
   CompressionOptions compressionOptions;
 
+  // Block size for BlockBitPacking encoding.
+  uint16_t blockBitPackingBlockSize{kBlockBitPackingBlockSize};
+
   // In low-memory mode, the writer is trying to perform smaller (and more
   // precise) buffer allocations. This means that overall, the writer will
   // consume less memory, but will come with an additional cost, of more


### PR DESCRIPTION
Summary:

Adds `BlockBitPackingEncoding` (EncodingType=13) — per-block bitpacking adapted from Impulse. Divides data into 1024-row blocks, each with its own baseline and bit width. O(1) random access via precomputed block offsets.

Key design:
- `fullUnpack`: Lemire fastunpack per type width + `unpackTail` scalar fallback
- `bulkScan` dense: materializes directly into output buffer (zero-copy for same-width types)
- `bulkScan` sparse: full-block decode + pick (benchmarked vs FBA and per-group — see below)
- Exact bit widths, no encode-side rounding
- Wired into both modern and legacy `EncodingFactory`, `EncodingLayout`, `EncodingUtils`, `Types`

Benchmark-informed decisions (`BlockBitPackingBenchmark.cpp`):
- Sparse decode: FBA wins <10% selectivity, full-block wins above, per-group never wins
- uint8/16 decode: native Lemire (`fastunpack_quarter`/`half`) beats 32-bit+narrow by 1.3-2.9x
- Int-width fast paths (bw=8/16/32) removed: not beneficial without encode-side rounding (Nimble uses exact bit widths). Simplifies `fullUnpack` for future shared utility with Impulse

Reviewed By: xiaoxmeng

Differential Revision: D107142858


