### PR TITLE
feat: Add SimdForBitpackEncoding (#810)

### DIFF
--- a/dwio/nimble/common/Types.cpp
+++ b/dwio/nimble/common/Types.cpp
@@ -53,6 +53,8 @@ std::string toString(EncodingType encodingType) {
       return "ALP";
     case EncodingType::PFOR:
       return "PFOR";
+    case EncodingType::SimdForBitpack:
+      return "SimdForBitpack";
   }
   return fmt::format(
       "Unknown encoding type: {}", static_cast<int32_t>(encodingType));

--- a/dwio/nimble/common/Types.h
+++ b/dwio/nimble/common/Types.h
@@ -109,7 +109,10 @@ enum class EncodingType {
   // Patched Frame-of-Reference. Subtracts a min baseline, bitpacks ~90% of
   // residuals at a narrow base bit width, and stores the remaining outliers
   // ("exceptions") as a parallel position+value array.
-  PFOR = 15,
+  PFOR = 13,
+  // SIMD Frame-of-Reference bitpacking. Subtracts baseline (global min),
+  // packs residuals in groups of 32 via Lemire FastPFor SIMD bitpacking.
+  SimdForBitpack = 14,
 };
 std::string toString(EncodingType encodingType);
 std::ostream& operator<<(std::ostream& out, EncodingType encodingType);

--- a/dwio/nimble/encodings/CMakeLists.txt
+++ b/dwio/nimble/encodings/CMakeLists.txt
@@ -34,6 +34,7 @@ target_link_libraries(
   nimble_compression
   nimble_common
   velox_common_base
+  velox_fastpforlib
   Folly::folly
   absl::flat_hash_map
   protobuf::libprotobuf

--- a/dwio/nimble/encodings/SimdForBitpackEncoding.h
+++ b/dwio/nimble/encodings/SimdForBitpackEncoding.h
@@ -1,0 +1,393 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <algorithm>
+#include <array>
+#include <cstring>
+#include <span>
+#include <type_traits>
+
+#include "dwio/nimble/common/Buffer.h"
+#include "dwio/nimble/common/Exceptions.h"
+#include "dwio/nimble/common/Types.h"
+#include "dwio/nimble/encodings/common/Encoding.h"
+#include "dwio/nimble/encodings/common/EncodingPrimitives.h"
+#include "dwio/nimble/encodings/selection/EncodingSelection.h"
+#include "folly/Likely.h"
+#include "velox/common/base/BitUtil.h"
+#include "velox/dwio/common/Lemire/BitPacking/bitpackinghelpers.h"
+
+// SIMD Frame-of-Reference bitpacking: value = baseline + residual.
+// Packs residuals in groups of 32 via Lemire FastPFor (fastpack/fastunpack).
+// Ported from AusList SIMD_FOR_BITPACKED (D97646777).
+
+namespace facebook::nimble {
+
+/// SIMD Frame-of-Reference bitpacking for integer streams.
+///
+/// Wire format (after Encoding prefix):
+///   [baseline: sizeof(T)] [bitWidth: 1B] [packed groups]
+///   Each group = bitWidth * 4 bytes (32 values). Omitted when bitWidth == 0.
+///   Narrow types (uint8/16) widen to uint32 for packing.
+template <typename T>
+class SimdForBitpackEncoding final
+    : public TypedEncoding<T, typename TypeTraits<T>::physicalType> {
+  static_assert(
+      isIntegralType<typename TypeTraits<T>::physicalType>(),
+      "SimdForBitpack only supports integral data types.");
+
+ public:
+  using cppDataType = T;
+  using physicalType = typename TypeTraits<T>::physicalType;
+
+  SimdForBitpackEncoding(
+      velox::memory::MemoryPool& pool,
+      std::string_view data,
+      const std::function<void*(uint32_t)>& stringBufferFactory,
+      const Encoding::Options& options = {});
+
+  void reset() final;
+  void skip(uint32_t rowCount) final;
+  void materialize(uint32_t rowCount, void* buffer) final;
+
+  template <typename DecoderVisitor>
+  void readWithVisitor(DecoderVisitor& visitor, ReadWithVisitorParams& params);
+
+  static std::string_view encode(
+      EncodingSelection<physicalType>& selection,
+      std::span<const physicalType> values,
+      Buffer& buffer,
+      const Encoding::Options& options = {});
+
+  std::string debugString(int offset) const final;
+
+  static constexpr uint32_t kGroupSize =
+      facebook::velox::fastpforlib::BITPACKING_ALGORITHM_GROUP_SIZE;
+
+  /// Return the number of FastPFor groups needed to cover `rowCount` values.
+  static constexpr uint64_t numGroups(uint64_t rowCount) {
+    return velox::bits::divRoundUp(rowCount, kGroupSize);
+  }
+
+  /// Return the total packed data size in bytes.
+  /// FastPFor emits `bitWidth` uint32_t words per 32-value group.
+  static constexpr uint64_t packedDataSize(
+      uint64_t rowCount,
+      uint8_t bitWidth) {
+    return numGroups(rowCount) * bitWidth * sizeof(uint32_t);
+  }
+
+ private:
+  static constexpr int kPrefixSize = sizeof(physicalType) + 1;
+
+  // Unpack a single group at the given group index into `output`.
+  // `output` must have room for kGroupSize elements.
+  void unpackGroup(uint32_t groupIndex, physicalType* output) const;
+
+  // Materialize a slice from one packed group into `output`.
+  inline void materializePartialGroup(
+      uint32_t groupIndex,
+      uint32_t offsetInGroup,
+      uint32_t count,
+      physicalType* output) const;
+
+  physicalType baseline_{};
+  uint8_t bitWidth_{0};
+  const char* packedData_{nullptr};
+  uint32_t row_{0};
+
+  // Avoid re-unpacking when consecutive rows hit the same group.
+  mutable uint32_t cachedGroupIndex_{~0u};
+  mutable std::array<physicalType, kGroupSize> cachedGroup_{};
+};
+
+//
+// End of public API. Implementations follow.
+//
+
+template <typename T>
+SimdForBitpackEncoding<T>::SimdForBitpackEncoding(
+    velox::memory::MemoryPool& pool,
+    std::string_view data,
+    const std::function<void*(uint32_t)>& /* stringBufferFactory */,
+    const Encoding::Options& options)
+    : TypedEncoding<T, physicalType>{pool, data, options} {
+  if constexpr (!isIntegralType<physicalType>()) {
+    NIMBLE_INCOMPATIBLE_ENCODING(
+        "SimdForBitpack encoding only supports integral data types.");
+  } else {
+    const char* pos = data.data() + this->dataOffset();
+    baseline_ = encoding::read<physicalType>(pos);
+    bitWidth_ = static_cast<uint8_t>(encoding::readChar(pos));
+    constexpr uint8_t kMaxBits = static_cast<uint8_t>(sizeof(physicalType) * 8);
+    NIMBLE_CHECK_LE(
+        bitWidth_,
+        kMaxBits,
+        "SimdForBitpack bit width exceeds physical type size.");
+
+    if (bitWidth_ > 0) {
+      const uint64_t expectedSize = packedDataSize(this->rowCount_, bitWidth_);
+      NIMBLE_CHECK_GE(
+          static_cast<size_t>(data.end() - pos),
+          expectedSize,
+          "SimdForBitpack packed region underruns wire data.");
+      packedData_ = pos;
+    }
+  }
+  reset();
+}
+
+template <typename T>
+void SimdForBitpackEncoding<T>::reset() {
+  row_ = 0;
+  cachedGroupIndex_ = ~0u;
+}
+
+template <typename T>
+void SimdForBitpackEncoding<T>::skip(uint32_t rowCount) {
+  row_ += rowCount;
+}
+
+template <typename T>
+void SimdForBitpackEncoding<T>::unpackGroup(
+    uint32_t groupIndex,
+    physicalType* output) const {
+  const uint32_t* groupStart = reinterpret_cast<const uint32_t*>(packedData_) +
+      static_cast<uint64_t>(groupIndex) * bitWidth_;
+  if constexpr (isFourByteIntegralType<physicalType>()) {
+    facebook::velox::fastpforlib::fastunpack(
+        groupStart, reinterpret_cast<uint32_t*>(output), bitWidth_);
+  } else if constexpr (isEightByteIntegralType<physicalType>()) {
+    facebook::velox::fastpforlib::fastunpack(
+        groupStart, reinterpret_cast<uint64_t*>(output), bitWidth_);
+  } else {
+    // Narrow types: unpack to uint32 temp then downcast.
+    std::array<uint32_t, kGroupSize> temp{};
+    facebook::velox::fastpforlib::fastunpack(
+        groupStart, temp.data(), bitWidth_);
+    for (uint32_t i = 0; i < kGroupSize; ++i) {
+      output[i] = static_cast<physicalType>(temp[i]);
+    }
+  }
+}
+
+template <typename T>
+inline void SimdForBitpackEncoding<T>::materializePartialGroup(
+    uint32_t groupIndex,
+    uint32_t offsetInGroup,
+    uint32_t count,
+    physicalType* output) const {
+  std::array<physicalType, kGroupSize> temp{};
+  unpackGroup(groupIndex, temp.data());
+  for (uint32_t i = 0; i < count; ++i) {
+    output[i] = static_cast<physicalType>(temp[offsetInGroup + i] + baseline_);
+  }
+}
+
+template <typename T>
+void SimdForBitpackEncoding<T>::materialize(uint32_t rowCount, void* buffer) {
+  if (FOLLY_UNLIKELY(rowCount == 0)) {
+    return;
+  }
+  auto* output = static_cast<physicalType*>(buffer);
+
+  if (bitWidth_ == 0) {
+    // All values match the baseline, so there are no residual bits to unpack.
+    std::fill(output, output + rowCount, baseline_);
+    row_ += rowCount;
+    return;
+  }
+
+  uint32_t remaining = rowCount;
+  uint32_t outputIndex = 0;
+
+  // Partial first group.
+  const uint32_t offsetInGroup = row_ % kGroupSize;
+  if (offsetInGroup != 0) {
+    const uint32_t groupIndex = row_ / kGroupSize;
+    const uint32_t available = kGroupSize - offsetInGroup;
+    const uint32_t toCopy = std::min(available, remaining);
+    materializePartialGroup(
+        groupIndex, offsetInGroup, toCopy, output + outputIndex);
+    outputIndex += toCopy;
+    remaining -= toCopy;
+  }
+
+  // Full groups.
+  while (remaining >= kGroupSize) {
+    const uint32_t groupIndex = (row_ + outputIndex) / kGroupSize;
+    unpackGroup(groupIndex, output + outputIndex);
+    for (uint32_t i = 0; i < kGroupSize; ++i) {
+      output[outputIndex + i] += baseline_;
+    }
+    outputIndex += kGroupSize;
+    remaining -= kGroupSize;
+  }
+
+  // Partial last group.
+  if (remaining > 0) {
+    const uint32_t groupIndex = (row_ + outputIndex) / kGroupSize;
+    materializePartialGroup(groupIndex, 0, remaining, output + outputIndex);
+    outputIndex += remaining;
+  }
+
+  row_ += rowCount;
+}
+
+template <typename T>
+template <typename V>
+void SimdForBitpackEncoding<T>::readWithVisitor(
+    V& visitor,
+    ReadWithVisitorParams& params) {
+  detail::readWithVisitorSlow(
+      visitor,
+      params,
+      [&](auto toSkip) { skip(toSkip); },
+      [&]() {
+        physicalType value;
+        if (bitWidth_ == 0) {
+          value = baseline_;
+        } else {
+          const uint32_t groupIndex = row_ / kGroupSize;
+          const uint32_t offsetInGroup = row_ % kGroupSize;
+          if (groupIndex != cachedGroupIndex_) {
+            unpackGroup(groupIndex, cachedGroup_.data());
+            cachedGroupIndex_ = groupIndex;
+          }
+          value = static_cast<physicalType>(
+              cachedGroup_[offsetInGroup] + baseline_);
+        }
+        ++row_;
+        return value;
+      });
+}
+
+template <typename T>
+std::string_view SimdForBitpackEncoding<T>::encode(
+    EncodingSelection<typename TypeTraits<T>::physicalType>& selection,
+    std::span<const typename TypeTraits<T>::physicalType> values,
+    Buffer& buffer,
+    const Encoding::Options& options) {
+  if constexpr (!isIntegralType<physicalType>()) {
+    NIMBLE_INCOMPATIBLE_ENCODING(
+        "SimdForBitpack encoding only supports integral data types.");
+  } else {
+    static_assert(
+        std::is_same_v<
+            typename std::make_unsigned<physicalType>::type,
+            physicalType>,
+        "SimdForBitpack physical type must be unsigned.");
+    const bool useVarint = options.useVarintRowCount;
+    if (values.empty()) {
+      NIMBLE_INCOMPATIBLE_ENCODING(
+          "SimdForBitpack encoding cannot be used with 0 rows.");
+    }
+    const uint32_t rowCount = static_cast<uint32_t>(values.size());
+    const physicalType baseline = selection.statistics().min();
+    const physicalType maxValue = selection.statistics().max();
+    const physicalType fullRange =
+        static_cast<physicalType>(maxValue - baseline);
+    const uint8_t bitWidth = fullRange == 0
+        ? uint8_t{0}
+        : static_cast<uint8_t>(velox::bits::bitsRequired(fullRange));
+
+    const uint32_t numGroupsTotal = static_cast<uint32_t>(numGroups(rowCount));
+    const uint64_t packedSize = packedDataSize(rowCount, bitWidth);
+
+    const uint32_t encodingSize =
+        Encoding::serializePrefixSize(rowCount, useVarint) + kPrefixSize +
+        static_cast<uint32_t>(packedSize);
+
+    char* reserved = buffer.reserve(encodingSize);
+    char* pos = reserved;
+    Encoding::serializePrefix(
+        EncodingType::SimdForBitpack,
+        TypeTraits<T>::dataType,
+        rowCount,
+        useVarint,
+        pos);
+    encoding::write(baseline, pos);
+    encoding::writeChar(static_cast<char>(bitWidth), pos);
+
+    if (bitWidth > 0) {
+      auto* packedOut = reinterpret_cast<uint32_t*>(pos);
+      std::array<physicalType, kGroupSize> residuals{};
+
+      // FastPFor packs one group of 32 residuals at a time:
+      //
+      //   32 values * bitWidth bits/value = bitWidth uint32_t words
+      //
+      // The last group is zero-padded before packing when rowCount is not a
+      // multiple of 32.
+      for (uint32_t group = 0; group < numGroupsTotal; ++group) {
+        const uint32_t groupStart = group * kGroupSize;
+        const uint32_t groupEnd = std::min(groupStart + kGroupSize, rowCount);
+        const uint32_t groupLen = groupEnd - groupStart;
+
+        // Only zero-fill the last partial group; full groups overwrite all 32.
+        if (groupLen < kGroupSize) {
+          std::fill(residuals.begin(), residuals.end(), physicalType{0});
+        }
+        for (uint32_t i = 0; i < groupLen; ++i) {
+          residuals[i] =
+              static_cast<physicalType>(values[groupStart + i] - baseline);
+        }
+
+        if constexpr (isFourByteIntegralType<physicalType>()) {
+          facebook::velox::fastpforlib::fastpack(
+              reinterpret_cast<const uint32_t*>(residuals.data()),
+              packedOut,
+              bitWidth);
+        } else if constexpr (isEightByteIntegralType<physicalType>()) {
+          facebook::velox::fastpforlib::fastpack(
+              reinterpret_cast<const uint64_t*>(residuals.data()),
+              packedOut,
+              bitWidth);
+        } else {
+          // Narrow types: widen to uint32 for packing.
+          std::array<uint32_t, kGroupSize> widenedResiduals{};
+          for (uint32_t i = 0; i < kGroupSize; ++i) {
+            widenedResiduals[i] = static_cast<uint32_t>(residuals[i]);
+          }
+          facebook::velox::fastpforlib::fastpack(
+              widenedResiduals.data(), packedOut, bitWidth);
+        }
+        // `packedOut` is a uint32_t pointer. One packed group occupies
+        // `bitWidth` uint32_t words.
+        packedOut += bitWidth;
+      }
+      pos += packedSize;
+    }
+
+    NIMBLE_CHECK_EQ(
+        pos - reserved, encodingSize, "SimdForBitpack encoding size mismatch.");
+    return {reserved, encodingSize};
+  }
+}
+
+template <typename T>
+std::string SimdForBitpackEncoding<T>::debugString(int offset) const {
+  return fmt::format(
+      "{}{}<{}> rowCount={} bitWidth={}",
+      std::string(offset, ' '),
+      Encoding::encodingType(),
+      Encoding::dataType(),
+      Encoding::rowCount(),
+      static_cast<int>(bitWidth_));
+}
+
+} // namespace facebook::nimble

--- a/dwio/nimble/encodings/common/EncodingFactory.cpp
+++ b/dwio/nimble/encodings/common/EncodingFactory.cpp
@@ -24,6 +24,7 @@
 #include "dwio/nimble/encodings/PFOREncoding.h"
 #include "dwio/nimble/encodings/PrefixEncoding.h"
 #include "dwio/nimble/encodings/RLEEncoding.h"
+#include "dwio/nimble/encodings/SimdForBitpackEncoding.h"
 #include "dwio/nimble/encodings/SparseBoolEncoding.h"
 #include "dwio/nimble/encodings/TrivialEncoding.h"
 #include "dwio/nimble/encodings/VarintEncoding.h"
@@ -253,6 +254,9 @@ std::unique_ptr<Encoding> EncodingFactory::create(
     case EncodingType::PFOR: {
       RETURN_ENCODING_BY_NUMERIC_TYPE(PFOREncoding, dataType);
     }
+    case EncodingType::SimdForBitpack: {
+      RETURN_ENCODING_BY_NUMERIC_TYPE(SimdForBitpackEncoding, dataType);
+    }
     default: {
       NIMBLE_UNREACHABLE(
           "Trying to deserialize invalid EncodingType:{} -- garbage input?",
@@ -397,6 +401,16 @@ std::string_view EncodingFactory::encode(
         NIMBLE_INCOMPATIBLE_ENCODING(
             "PFOR encoding should not be selected for non-integral data type: {}.",
             toString(TypeTraits<T>::dataType));
+      }
+    }
+    case EncodingType::SimdForBitpack: {
+      if constexpr (isIntegralType<physicalType>()) {
+        return SimdForBitpackEncoding<T>::encode(
+            selection, castedValues, buffer, options);
+      } else {
+        NIMBLE_INCOMPATIBLE_ENCODING(
+            "SimdForBitpack encoding only supports integral data types, got {}.",
+            TypeTraits<T>::dataType);
       }
     }
     default: {

--- a/dwio/nimble/encodings/common/EncodingLayout.cpp
+++ b/dwio/nimble/encodings/common/EncodingLayout.cpp
@@ -173,7 +173,8 @@ EncodingLayout EncodingLayoutCapture::capture(std::string_view encoding) {
     case EncodingType::Constant:
     case EncodingType::Prefix:
     case EncodingType::ALP:
-    case EncodingType::PFOR: {
+    case EncodingType::PFOR:
+    case EncodingType::SimdForBitpack: {
       // Non nested encodings have zero children
       break;
     }

--- a/dwio/nimble/encodings/common/EncodingUtils.h
+++ b/dwio/nimble/encodings/common/EncodingUtils.h
@@ -25,6 +25,7 @@
 #include "dwio/nimble/encodings/PFOREncoding.h"
 #include "dwio/nimble/encodings/PrefixEncoding.h"
 #include "dwio/nimble/encodings/RLEEncoding.h"
+#include "dwio/nimble/encodings/SimdForBitpackEncoding.h"
 #include "dwio/nimble/encodings/SparseBoolEncoding.h"
 #include "dwio/nimble/encodings/TrivialEncoding.h"
 #include "dwio/nimble/encodings/VarintEncoding.h"
@@ -131,6 +132,12 @@ auto encodingTypeDispatchNonString(Encoding& encoding, F&& f) {
     case EncodingType::PFOR:
       if constexpr (isIntegralType<T>()) {
         return f(static_cast<PFOREncoding<T>&>(encoding));
+      } else {
+        NIMBLE_UNREACHABLE("{}", encoding.dataType());
+      }
+    case EncodingType::SimdForBitpack:
+      if constexpr (isIntegralType<T>()) {
+        return f(static_cast<SimdForBitpackEncoding<T>&>(encoding));
       } else {
         NIMBLE_UNREACHABLE("{}", encoding.dataType());
       }

--- a/dwio/nimble/encodings/legacy/EncodingFactory.cpp
+++ b/dwio/nimble/encodings/legacy/EncodingFactory.cpp
@@ -15,6 +15,7 @@
  */
 #include "dwio/nimble/encodings/legacy/EncodingFactory.h"
 #include "dwio/nimble/encodings/PFOREncoding.h"
+#include "dwio/nimble/encodings/SimdForBitpackEncoding.h"
 #include "dwio/nimble/encodings/legacy/ConstantEncoding.h"
 #include "dwio/nimble/encodings/legacy/DeltaEncoding.h"
 #include "dwio/nimble/encodings/legacy/DictionaryEncoding.h"
@@ -251,6 +252,10 @@ std::unique_ptr<Encoding> EncodingFactory::create(
     }
     case EncodingType::PFOR: {
       RETURN_ENCODING_BY_NUMERIC_TYPE(PFOREncoding, dataType);
+    }
+    case EncodingType::SimdForBitpack: {
+      RETURN_ENCODING_BY_NUMERIC_TYPE(
+          ::facebook::nimble::SimdForBitpackEncoding, dataType);
     }
     default: {
       NIMBLE_UNREACHABLE(

--- a/dwio/nimble/encodings/legacy/EncodingUtils.h
+++ b/dwio/nimble/encodings/legacy/EncodingUtils.h
@@ -16,6 +16,7 @@
 #pragma once
 
 #include "dwio/nimble/encodings/PFOREncoding.h"
+#include "dwio/nimble/encodings/SimdForBitpackEncoding.h"
 #include "dwio/nimble/encodings/common/EncodingUtils.h"
 #include "dwio/nimble/encodings/legacy/ConstantEncoding.h"
 #include "dwio/nimble/encodings/legacy/DeltaEncoding.h"
@@ -112,6 +113,14 @@ auto encodingTypeDispatchNonString(Encoding& encoding, F&& f) {
     case EncodingType::PFOR:
       if constexpr (isIntegralType<T>()) {
         return f(static_cast<::facebook::nimble::PFOREncoding<T>&>(encoding));
+      } else {
+        NIMBLE_UNREACHABLE("{}", encoding.dataType());
+      }
+    case EncodingType::SimdForBitpack:
+      if constexpr (isIntegralType<T>()) {
+        return f(
+            static_cast<::facebook::nimble::SimdForBitpackEncoding<T>&>(
+                encoding));
       } else {
         NIMBLE_UNREACHABLE("{}", encoding.dataType());
       }

--- a/dwio/nimble/encodings/selection/EncodingSizeEstimation.h
+++ b/dwio/nimble/encodings/selection/EncodingSizeEstimation.h
@@ -22,7 +22,9 @@
 #include "dwio/nimble/common/FixedBitArray.h"
 #include "dwio/nimble/common/Types.h"
 #include "dwio/nimble/encodings/PFOREncoding.h"
+#include "dwio/nimble/encodings/SimdForBitpackEncoding.h"
 #include "velox/common/base/BitUtil.h"
+#include "velox/dwio/common/Lemire/BitPacking/bitpackinghelpers.h"
 
 namespace facebook::nimble {
 namespace detail {
@@ -166,16 +168,34 @@ struct EncodingSizeEstimation {
           const uint64_t bitpackedSize = baseBitWidth == 0
               ? 0
               : FixedBitArray::bufferSize(entryCount, baseBitWidth);
-          // Per-exception: position varint (max 5B for uint32 positions)
-          // + value varint (ceil(maxBitWidth/7) bytes, capped at 10 because
-          // varint64 encodes at most 64 bits in ceil(64/7) = 10 bytes).
+          // Per-exception: position varint (max 5B) + value varint (max
+          // ceil(maxBitWidth/7) bytes, capped at 10).
           const uint64_t valueVarintBytes = std::min<uint64_t>(
               (static_cast<uint64_t>(maxBitWidth) + 6) / 7, 10);
           const uint64_t exceptionsSize =
               numExceptions * (5 + valueVarintBytes);
-          constexpr uint32_t overhead =
-              6 + sizeof(physicalType) + 1 + sizeof(uint32_t);
-          return overhead + bitpackedSize + exceptionsSize;
+
+          return getEncodingOverhead<EncodingType::PFOR, physicalType>() +
+              bitpackedSize + exceptionsSize;
+        } else {
+          return std::nullopt;
+        }
+      }
+      case EncodingType::SimdForBitpack: {
+        if constexpr (isIntegralType<physicalType>()) {
+          const auto fullRange =
+              static_cast<physicalType>(statistics.max() - statistics.min());
+          const uint8_t bitWidth = fullRange == 0
+              ? uint8_t{0}
+              : static_cast<uint8_t>(velox::bits::bitsRequired(fullRange));
+          const uint64_t packedSize =
+              SimdForBitpackEncoding<physicalType>::packedDataSize(
+                  entryCount, bitWidth);
+
+          return getEncodingOverhead<
+                     EncodingType::SimdForBitpack,
+                     physicalType>() +
+              packedSize;
         } else {
           return std::nullopt;
         }
@@ -449,6 +469,12 @@ struct EncodingSizeEstimation {
       return commonPrefixSize + sizeof(dataType); // Baseline (size of dataType)
     } else if constexpr (encodingType == EncodingType::Nullable) {
       return commonPrefixSize + sizeof(uint32_t); // Data size (4 bytes)
+    } else if constexpr (encodingType == EncodingType::PFOR) {
+      // Baseline (sizeof(dataType)) + baseBitWidth (1) + exceptionCount (4)
+      return commonPrefixSize + sizeof(dataType) + 1 + sizeof(uint32_t);
+    } else if constexpr (encodingType == EncodingType::SimdForBitpack) {
+      // Baseline (sizeof(dataType)) + bitWidth (1)
+      return commonPrefixSize + sizeof(dataType) + 1;
     }
   }
 

--- a/dwio/nimble/encodings/tests/EncodingSizeEstimationTest.cpp
+++ b/dwio/nimble/encodings/tests/EncodingSizeEstimationTest.cpp
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 #include <gtest/gtest.h>
+#include <limits>
+
 #include "dwio/nimble/common/Types.h"
 #include "dwio/nimble/common/Vector.h"
 #include "dwio/nimble/encodings/common/EncodingType.h"
@@ -27,6 +29,52 @@ class EncodingSizeEstimationTest : public ::testing::Test {
  protected:
   void SetUp() override {
     pool_ = velox::memory::deprecatedAddDefaultLeafMemoryPool();
+  }
+
+  template <typename T>
+  void verifySimdForBitpackEstimateVsActualSize() {
+    using Est = detail::EncodingSizeEstimation<T, false>;
+
+    const T min = std::numeric_limits<T>::min();
+    const T max = std::numeric_limits<T>::max();
+    const T base = static_cast<T>(max / 4);
+    const std::vector<std::vector<T>> testCases = {
+        std::vector<T>(1000, min),
+        std::vector<T>(1000, max),
+        {min, max},
+        [&] {
+          std::vector<T> data;
+          data.reserve(1000);
+          for (uint32_t i = 0; i < 1000; ++i) {
+            data.push_back(static_cast<T>(base + i % 50));
+          }
+          return data;
+        }(),
+    };
+
+    for (const auto& data : testCases) {
+      SCOPED_TRACE(static_cast<uint64_t>(max));
+      SCOPED_TRACE(static_cast<uint64_t>(data.front()));
+      auto stats = Statistics<T>::create(data);
+      const uint32_t numValues = static_cast<uint32_t>(data.size());
+
+      auto estimated = Est::estimateNumericSize(
+          EncodingType::SimdForBitpack, numValues, stats);
+      ASSERT_TRUE(estimated.has_value());
+
+      nimble::Buffer buffer{*pool_};
+      auto encoded =
+          nimble::test::Encoder<nimble::SimdForBitpackEncoding<T>>::encode(
+              buffer, nimble::Vector<T>(pool_.get(), data.begin(), data.end()));
+      const uint64_t actualSize = encoded.size();
+
+      EXPECT_GT(estimated.value(), actualSize / 2)
+          << "estimate too low: " << estimated.value() << " vs actual "
+          << actualSize;
+      EXPECT_LT(estimated.value(), actualSize * 2)
+          << "estimate too high: " << estimated.value() << " vs actual "
+          << actualSize;
+    }
   }
 
   std::shared_ptr<velox::memory::MemoryPool> pool_;
@@ -386,4 +434,11 @@ TEST_F(EncodingSizeEstimationTest, pforEstimateVsActualSize) {
   EXPECT_LT(estimated.value(), actualSize * 2)
       << "estimate too high: " << estimated.value() << " vs actual "
       << actualSize;
+}
+
+TEST_F(EncodingSizeEstimationTest, simdForBitpackEstimateVsActualSize) {
+  verifySimdForBitpackEstimateVsActualSize<uint8_t>();
+  verifySimdForBitpackEstimateVsActualSize<uint16_t>();
+  verifySimdForBitpackEstimateVsActualSize<uint32_t>();
+  verifySimdForBitpackEstimateVsActualSize<uint64_t>();
 }

--- a/dwio/nimble/encodings/tests/ReadWithVisitorTest.cpp
+++ b/dwio/nimble/encodings/tests/ReadWithVisitorTest.cpp
@@ -3917,6 +3917,84 @@ TEST_P(ReadWithVisitorTest, readSparseMaterializedIndicesWithNulls) {
   }
 }
 
+// ===========================================================================
+// SimdForBitpack column-reader coverage.
+// ===========================================================================
+TEST_P(ReadWithVisitorTest, encodingLevelSimdForBitpackBigintRangeSparse) {
+  auto runForType = [&]<typename T>(T) {
+    SCOPED_TRACE(fmt::format("type size = {}", sizeof(T)));
+    constexpr int kRows = 500;
+    constexpr int64_t kMinFilter = 20;
+    constexpr int64_t kMaxFilter = 40;
+
+    std::vector<T> data(kRows);
+    for (int i = 0; i < kRows; ++i) {
+      data[i] = static_cast<T>(10 + i % 64);
+    }
+
+    auto input = makeRowVector({makeFlatVector<T>(
+        kRows, [](auto i) { return static_cast<T>(10 + i % 64); })});
+    auto rowType = asRowType(input->type());
+    auto ctx = makeFileContext(input);
+    auto scanSpec = std::make_shared<common::ScanSpec>("root");
+    scanSpec->addAllChildFields(*rowType);
+    scanSpec->childByName("c0")->setFilter(
+        std::make_unique<common::BigintRange>(kMinFilter, kMaxFilter, false));
+    auto root = buildReader(*ctx, rowType, *scanSpec);
+
+    auto* structReader =
+        dynamic_cast<dwio::common::SelectiveStructColumnReaderBase*>(
+            root.get());
+    auto* reader = static_cast<IntegerColumnReaderTestAccessor*>(
+        dynamic_cast<IntegerColumnReader*>(structReader->children()[0]));
+    ASSERT_NE(reader, nullptr);
+
+    std::vector<vector_size_t> rowVec;
+    for (int i = 0; i < kRows; i += 2) {
+      rowVec.push_back(i);
+    }
+    RowSet rows(rowVec.data(), rowVec.size());
+
+    reader->doPrepareRead<T>(0, rows, nullptr);
+
+    Buffer buffer(*pool());
+    const EncodingLayout layout{
+        EncodingType::SimdForBitpack, {}, CompressionType::Uncompressed};
+    auto encoding = createFromCustomLayout<T>(layout, data, *pool(), buffer);
+
+    common::BigintRange filter(kMinFilter, kMaxFilter, false);
+    dwio::common::ExtractToReader extractValues(reader);
+    constexpr bool kIsDense = false;
+    DecoderVisitor<
+        T,
+        common::BigintRange,
+        dwio::common::ExtractToReader,
+        kIsDense>
+        visitor(filter, reader, rows, extractValues);
+    auto params = makeReadWithVisitorParams(visitor, rows, pool());
+
+    dispatchCallReadWithVisitor(*encoding, visitor, params);
+
+    int expected = 0;
+    for (int i = 0; i < kRows; i += 2) {
+      if (data[i] >= kMinFilter && data[i] <= kMaxFilter) {
+        ++expected;
+      }
+    }
+    EXPECT_EQ(reader->numValues(), expected);
+
+    auto values = getValues<T>(reader);
+    for (int i = 0; i < reader->numValues(); ++i) {
+      EXPECT_GE(values[i], static_cast<T>(kMinFilter));
+      EXPECT_LE(values[i], static_cast<T>(kMaxFilter));
+    }
+  };
+
+  runForType(int16_t{});
+  runForType(int32_t{});
+  runForType(int64_t{});
+}
+
 INSTANTIATE_TEST_SUITE_P(
     NonLegacyAndLegacy,
     ReadWithVisitorTest,

--- a/dwio/nimble/encodings/tests/SimdForBitpackEncodingTest.cpp
+++ b/dwio/nimble/encodings/tests/SimdForBitpackEncodingTest.cpp
@@ -1,0 +1,345 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "dwio/nimble/encodings/SimdForBitpackEncoding.h"
+
+#include <fmt/core.h>
+#include <gtest/gtest.h>
+#include <random>
+
+#include "dwio/nimble/common/Buffer.h"
+#include "dwio/nimble/common/tests/GTestUtils.h"
+#include "dwio/nimble/encodings/common/EncodingFactory.h"
+#include "dwio/nimble/encodings/common/EncodingLayout.h"
+#include "dwio/nimble/encodings/selection/EncodingSelection.h"
+#include "dwio/nimble/encodings/selection/EncodingSelectionPolicy.h"
+#include "velox/common/memory/Memory.h"
+
+using namespace ::facebook;
+
+namespace facebook::nimble::test {
+
+template <typename T>
+class SimdForBitpackEncodingTest : public ::testing::Test {
+ protected:
+  static void SetUpTestCase() {
+    velox::memory::MemoryManager::testingSetInstance({});
+  }
+
+  void SetUp() override {
+    pool_ = velox::memory::deprecatedAddDefaultLeafMemoryPool();
+  }
+
+  std::unique_ptr<EncodingSelectionPolicy<T>> createSelectionPolicy() {
+    EncodingLayout layout{
+        EncodingType::SimdForBitpack, {}, CompressionType::Uncompressed};
+    return std::make_unique<ReplayedEncodingSelectionPolicy<T>>(
+        std::move(layout),
+        CompressionOptions{},
+        encodingSelectionPolicyFactory_);
+  }
+
+  std::unique_ptr<Encoding> encodeAndCreate(const std::vector<T>& values) {
+    Buffer buffer{*pool_};
+    auto encoded = EncodingFactory::encode<T>(
+        createSelectionPolicy(),
+        std::span<const T>{values.data(), values.size()},
+        buffer);
+    encodedStorage_.assign(encoded.begin(), encoded.end());
+    return EncodingFactory().create(
+        *pool_, {encodedStorage_.data(), encodedStorage_.size()}, nullptr);
+  }
+
+  void roundTripAndExpect(const std::vector<T>& values) {
+    auto encoding = encodeAndCreate(values);
+    EXPECT_EQ(encoding->encodingType(), EncodingType::SimdForBitpack);
+    EXPECT_EQ(encoding->dataType(), TypeTraits<T>::dataType);
+    EXPECT_EQ(encoding->rowCount(), values.size());
+
+    std::vector<T> decoded(values.size());
+    encoding->materialize(static_cast<uint32_t>(values.size()), decoded.data());
+    for (size_t i = 0; i < values.size(); ++i) {
+      EXPECT_EQ(decoded[i], values[i]) << "mismatch at index " << i;
+    }
+  }
+
+  std::shared_ptr<velox::memory::MemoryPool> pool_;
+  std::vector<char> encodedStorage_;
+  ManualEncodingSelectionPolicyFactory manualPolicyFactory_;
+  EncodingSelectionPolicyFactory encodingSelectionPolicyFactory_ =
+      [this](DataType dataType) {
+        return manualPolicyFactory_.createPolicy(dataType);
+      };
+};
+
+using SimdForBitpackTypes =
+    ::testing::Types<uint32_t, uint64_t, uint8_t, uint16_t>;
+TYPED_TEST_SUITE(SimdForBitpackEncodingTest, SimdForBitpackTypes);
+
+TYPED_TEST(SimdForBitpackEncodingTest, singleElement) {
+  this->roundTripAndExpect({TypeParam{42}});
+}
+
+TYPED_TEST(SimdForBitpackEncodingTest, allSameValues) {
+  std::vector<TypeParam> values(64, TypeParam{7});
+  this->roundTripAndExpect(values);
+}
+
+TYPED_TEST(SimdForBitpackEncodingTest, exactlyOneGroup) {
+  std::vector<TypeParam> values;
+  values.reserve(32);
+  for (uint32_t i = 0; i < 32; ++i) {
+    values.push_back(static_cast<TypeParam>(100 + i));
+  }
+  this->roundTripAndExpect(values);
+}
+
+TYPED_TEST(SimdForBitpackEncodingTest, partialLastGroup) {
+  for (uint32_t n : {1u, 15u, 31u, 33u, 63u, 65u, 100u}) {
+    SCOPED_TRACE(fmt::format("n={}", n));
+    std::vector<TypeParam> values;
+    values.reserve(n);
+    for (uint32_t i = 0; i < n; ++i) {
+      values.push_back(static_cast<TypeParam>(10 + i % 50));
+    }
+    this->roundTripAndExpect(values);
+  }
+}
+
+TYPED_TEST(SimdForBitpackEncodingTest, bitWidthZero) {
+  std::vector<TypeParam> values(100, TypeParam{42});
+  auto encoding = this->encodeAndCreate(values);
+  std::vector<TypeParam> decoded(100);
+  encoding->materialize(100, decoded.data());
+  for (size_t i = 0; i < 100; ++i) {
+    EXPECT_EQ(decoded[i], TypeParam{42});
+  }
+}
+
+TYPED_TEST(SimdForBitpackEncodingTest, fullBitWidthRange) {
+  std::vector<TypeParam> values;
+  values.reserve(100);
+  for (uint32_t i = 0; i < 100; ++i) {
+    values.push_back(static_cast<TypeParam>(i));
+  }
+  values.push_back(std::numeric_limits<TypeParam>::max());
+  this->roundTripAndExpect(values);
+}
+
+TYPED_TEST(SimdForBitpackEncodingTest, nonZeroBaseline) {
+  std::vector<TypeParam> values;
+  values.reserve(200);
+  const TypeParam base =
+      static_cast<TypeParam>(std::numeric_limits<TypeParam>::max() / 2);
+  for (uint32_t i = 0; i < 200; ++i) {
+    values.push_back(static_cast<TypeParam>(base + i % 30));
+  }
+  this->roundTripAndExpect(values);
+}
+
+TYPED_TEST(SimdForBitpackEncodingTest, skipAndMaterialize) {
+  std::vector<TypeParam> values;
+  values.reserve(300);
+  for (uint32_t i = 0; i < 300; ++i) {
+    values.push_back(static_cast<TypeParam>(50 + (i % 100)));
+  }
+  auto encoding = this->encodeAndCreate(values);
+
+  encoding->reset();
+  std::vector<TypeParam> chunk(50);
+  encoding->materialize(50, chunk.data());
+  for (uint32_t i = 0; i < 50; ++i) {
+    EXPECT_EQ(chunk[i], values[i]);
+  }
+
+  encoding->skip(75);
+  encoding->materialize(50, chunk.data());
+  for (uint32_t i = 0; i < 50; ++i) {
+    EXPECT_EQ(chunk[i], values[125 + i]) << "i=" << i;
+  }
+
+  encoding->skip(75);
+  encoding->materialize(50, chunk.data());
+  for (uint32_t i = 0; i < 50; ++i) {
+    EXPECT_EQ(chunk[i], values[250 + i]) << "i=" << i;
+  }
+
+  encoding->reset();
+  std::vector<TypeParam> all(values.size());
+  encoding->materialize(static_cast<uint32_t>(values.size()), all.data());
+  for (size_t i = 0; i < values.size(); ++i) {
+    EXPECT_EQ(all[i], values[i]) << "after-reset i=" << i;
+  }
+}
+
+TYPED_TEST(SimdForBitpackEncodingTest, skipAcrossGroupBoundary) {
+  std::vector<TypeParam> values;
+  values.reserve(128);
+  for (uint32_t i = 0; i < 128; ++i) {
+    values.push_back(static_cast<TypeParam>(i % 64));
+  }
+  auto encoding = this->encodeAndCreate(values);
+
+  encoding->skip(30);
+  std::vector<TypeParam> chunk(4);
+  encoding->materialize(4, chunk.data());
+  for (uint32_t i = 0; i < 4; ++i) {
+    EXPECT_EQ(chunk[i], values[30 + i]) << "i=" << i;
+  }
+}
+
+TYPED_TEST(SimdForBitpackEncodingTest, debugString) {
+  std::vector<TypeParam> values;
+  values.reserve(8);
+  for (uint32_t i = 0; i < 8; ++i) {
+    values.push_back(static_cast<TypeParam>(i + 1));
+  }
+  auto encoding = this->encodeAndCreate(values);
+  const std::string debug = encoding->debugString();
+  EXPECT_NE(debug.find("SimdForBitpack"), std::string::npos);
+  EXPECT_NE(debug.find("bitWidth="), std::string::npos);
+}
+
+class SimdForBitpackFuzzerTest : public ::testing::Test {
+ protected:
+  static void SetUpTestCase() {
+    velox::memory::MemoryManager::testingSetInstance({});
+  }
+
+  void SetUp() override {
+    pool_ = velox::memory::deprecatedAddDefaultLeafMemoryPool();
+  }
+
+  template <typename T>
+  void runFuzzer(uint32_t seed, uint32_t numIterations) {
+    std::mt19937 rng(seed);
+
+    ManualEncodingSelectionPolicyFactory manualFactory;
+    EncodingSelectionPolicyFactory factory =
+        [&manualFactory](DataType dataType) {
+          return manualFactory.createPolicy(dataType);
+        };
+
+    for (uint32_t iter = 0; iter < numIterations; ++iter) {
+      SCOPED_TRACE(fmt::format("iteration {}", iter));
+
+      std::uniform_int_distribution<uint32_t> sizeDist(1, 1000);
+      const uint32_t numValues = sizeDist(rng);
+
+      std::uniform_int_distribution<uint32_t> valueDist(
+          0, sizeof(T) >= 4 ? (1u << 20) : std::numeric_limits<T>::max());
+      std::vector<T> values;
+      values.reserve(numValues);
+      const T offset = static_cast<T>(1000);
+      for (uint32_t i = 0; i < numValues; ++i) {
+        values.push_back(static_cast<T>(offset + valueDist(rng)));
+      }
+
+      Buffer buffer{*pool_};
+      EncodingLayout layout{
+          EncodingType::SimdForBitpack, {}, CompressionType::Uncompressed};
+      auto policy = std::make_unique<ReplayedEncodingSelectionPolicy<T>>(
+          std::move(layout), CompressionOptions{}, factory);
+      auto encoded = EncodingFactory::encode<T>(
+          std::move(policy),
+          std::span<const T>{values.data(), values.size()},
+          buffer);
+      std::vector<char> storage(encoded.begin(), encoded.end());
+      auto encoding = EncodingFactory().create(
+          *pool_, {storage.data(), storage.size()}, nullptr);
+
+      ASSERT_EQ(encoding->encodingType(), EncodingType::SimdForBitpack);
+      ASSERT_EQ(encoding->rowCount(), values.size());
+      std::vector<T> decoded(values.size());
+      encoding->materialize(
+          static_cast<uint32_t>(values.size()), decoded.data());
+      for (size_t i = 0; i < values.size(); ++i) {
+        ASSERT_EQ(decoded[i], values[i])
+            << "iter=" << iter << " i=" << i << " size=" << numValues;
+      }
+
+      encoding->reset();
+      std::uniform_int_distribution<uint32_t> stepDist(0, numValues);
+      uint32_t cursor = 0;
+      while (cursor < numValues) {
+        const uint32_t remaining = numValues - cursor;
+        const uint32_t skipCount = stepDist(rng) % (remaining + 1);
+        if (skipCount > 0) {
+          encoding->skip(skipCount);
+          cursor += skipCount;
+        }
+        if (cursor >= numValues) {
+          break;
+        }
+        const uint32_t matCount =
+            std::max<uint32_t>(1, stepDist(rng) % (numValues - cursor + 1));
+        std::vector<T> chunk(matCount);
+        encoding->materialize(matCount, chunk.data());
+        for (uint32_t i = 0; i < matCount; ++i) {
+          ASSERT_EQ(chunk[i], values[cursor + i])
+              << "iter=" << iter << " cursor=" << cursor << " i=" << i;
+        }
+        cursor += matCount;
+      }
+    }
+  }
+
+  std::shared_ptr<velox::memory::MemoryPool> pool_;
+};
+
+TEST_F(SimdForBitpackFuzzerTest, fuzzerUint8) {
+  runFuzzer<uint8_t>(/*seed=*/11111, /*numIterations=*/30);
+}
+
+TEST_F(SimdForBitpackFuzzerTest, fuzzerUint16) {
+  runFuzzer<uint16_t>(/*seed=*/22222, /*numIterations=*/30);
+}
+
+TEST_F(SimdForBitpackFuzzerTest, fuzzerUint32) {
+  runFuzzer<uint32_t>(/*seed=*/33333, /*numIterations=*/30);
+}
+
+TEST_F(SimdForBitpackFuzzerTest, fuzzerUint64) {
+  runFuzzer<uint64_t>(/*seed=*/44444, /*numIterations=*/30);
+}
+
+TEST_F(SimdForBitpackFuzzerTest, fuzzerInt32) {
+  runFuzzer<int32_t>(/*seed=*/55555, /*numIterations=*/30);
+}
+
+TEST_F(SimdForBitpackFuzzerTest, fuzzerInt64) {
+  runFuzzer<int64_t>(/*seed=*/66666, /*numIterations=*/30);
+}
+
+TEST_F(SimdForBitpackFuzzerTest, encodeRejectsEmpty) {
+  Buffer buffer{*pool_};
+  EncodingLayout layout{
+      EncodingType::SimdForBitpack, {}, CompressionType::Uncompressed};
+  ManualEncodingSelectionPolicyFactory manualFactory;
+  EncodingSelectionPolicyFactory factory = [&manualFactory](DataType dataType) {
+    return manualFactory.createPolicy(dataType);
+  };
+  auto policy = std::make_unique<ReplayedEncodingSelectionPolicy<uint32_t>>(
+      std::move(layout), CompressionOptions{}, factory);
+  std::vector<uint32_t> empty;
+  NIMBLE_ASSERT_THROW(
+      EncodingFactory::encode<uint32_t>(
+          std::move(policy),
+          std::span<const uint32_t>{empty.data(), empty.size()},
+          buffer),
+      "SimdForBitpack encoding cannot be used with 0 rows.");
+}
+
+} // namespace facebook::nimble::test

--- a/dwio/nimble/encodings/tests/TestUtils.h
+++ b/dwio/nimble/encodings/tests/TestUtils.h
@@ -24,6 +24,7 @@
 #include "dwio/nimble/encodings/NullableEncoding.h"
 #include "dwio/nimble/encodings/PFOREncoding.h"
 #include "dwio/nimble/encodings/RLEEncoding.h"
+#include "dwio/nimble/encodings/SimdForBitpackEncoding.h"
 #include "dwio/nimble/encodings/SparseBoolEncoding.h"
 #include "dwio/nimble/encodings/TrivialEncoding.h"
 #include "dwio/nimble/encodings/VarintEncoding.h"
@@ -186,6 +187,12 @@ class Encoder {
   struct EncodingTypeTraits<nimble::PFOREncoding<T>> {
     static constexpr inline nimble::EncodingType encodingType =
         nimble::EncodingType::PFOR;
+  };
+
+  template <>
+  struct EncodingTypeTraits<nimble::SimdForBitpackEncoding<T>> {
+    static constexpr inline nimble::EncodingType encodingType =
+        nimble::EncodingType::SimdForBitpack;
   };
 
  public:

--- a/dwio/nimble/fuzzer/encoding/EncodingFuzzerTest.cpp
+++ b/dwio/nimble/fuzzer/encoding/EncodingFuzzerTest.cpp
@@ -32,6 +32,7 @@
 #include "dwio/nimble/encodings/FixedBitWidthEncoding.h"
 #include "dwio/nimble/encodings/MainlyConstantEncoding.h"
 #include "dwio/nimble/encodings/RLEEncoding.h"
+#include "dwio/nimble/encodings/SimdForBitpackEncoding.h"
 #include "dwio/nimble/encodings/SparseBoolEncoding.h"
 #include "dwio/nimble/encodings/TrivialEncoding.h"
 #include "dwio/nimble/encodings/VarintEncoding.h"
@@ -170,6 +171,26 @@ class DeltaFuzzerTest : public ::testing::Test {};
 TYPED_TEST_SUITE(DeltaFuzzerTest, DeltaTypes);
 
 TYPED_TEST(DeltaFuzzerTest, correctness) {
+  EncodingFuzzer<TypeParam> fuzzer(
+      FLAGS_fuzzer_iterations,
+      FLAGS_fuzzer_max_rows,
+      FLAGS_fuzzer_seed,
+      FLAGS_fuzzer_compression);
+  fuzzer.run();
+}
+
+// SimdForBitpack: unsigned integer types
+using SimdForBitpackTypes = ::testing::Types<
+    SimdForBitpackEncoding<uint8_t>,
+    SimdForBitpackEncoding<uint16_t>,
+    SimdForBitpackEncoding<uint32_t>,
+    SimdForBitpackEncoding<uint64_t>>;
+
+template <typename E>
+class SimdForBitpackFuzzerTest : public ::testing::Test {};
+TYPED_TEST_SUITE(SimdForBitpackFuzzerTest, SimdForBitpackTypes);
+
+TYPED_TEST(SimdForBitpackFuzzerTest, correctness) {
   EncodingFuzzer<TypeParam> fuzzer(
       FLAGS_fuzzer_iterations,
       FLAGS_fuzzer_max_rows,

--- a/dwio/nimble/serializer/tests/SerializationTest.cpp
+++ b/dwio/nimble/serializer/tests/SerializationTest.cpp
@@ -33,7 +33,7 @@
 #include "folly/container/F14Set.h"
 #include "velox/common/testutil/TestValue.h"
 #include "velox/dwio/common/BufferedInput.h"
-#include "velox/dwio/common/MetricsLog.h"
+
 #include "velox/vector/BaseVector.h"
 #include "velox/vector/ComplexVector.h"
 #include "velox/vector/DecodedVector.h"
@@ -2146,6 +2146,79 @@ TEST_P(SerializationTest, pforColumnarRoundTrip) {
         i, i % 10 == 0 ? 1'000'000 + i : i % 100);
     longVals->asFlatVector<int64_t>()->set(
         i, i % 10 == 0 ? 9'000'000'000LL + i : i * 60);
+  }
+
+  auto input = std::make_shared<velox::RowVector>(
+      pool_.get(),
+      type,
+      nullptr,
+      numRows,
+      std::vector<velox::VectorPtr>{intVals, longVals});
+
+  auto serialized =
+      serializer.serialize(input, OrderedRanges::of(0, input->size()));
+
+  Deserializer deserializer{
+      SchemaReader::getSchema(serializer.schemaBuilder().schemaNodes()),
+      pool_.get(),
+      deserializerOptions()};
+
+  velox::VectorPtr output;
+  deserializer.deserialize(serialized, output);
+
+  ASSERT_EQ(output->size(), input->size());
+  for (velox::vector_size_t i = 0; i < input->size(); ++i) {
+    ASSERT_TRUE(vectorEquals(output, input, i))
+        << "Content mismatch at index " << i;
+  }
+}
+
+// Columnar reader-level round-trip for SimdForBitpackEncoding. Forces
+// SimdForBitpack via EncodingLayoutTree on integer columns and verifies data
+// integrity through the full Serializer → Deserializer path.
+TEST_P(SerializationTest, simdForBitpackColumnarRoundTrip) {
+  auto type = velox::ROW({
+      {"int_val", velox::INTEGER()},
+      {"long_val", velox::BIGINT()},
+  });
+
+  EncodingLayoutTree layoutTree{
+      Kind::Row,
+      {},
+      "",
+      {
+          {Kind::Scalar,
+           {{EncodingLayoutTree::StreamIdentifiers::Scalar::ScalarStream,
+             EncodingLayout{
+                 EncodingType::SimdForBitpack,
+                 {},
+                 CompressionType::Uncompressed}}},
+           ""},
+          {Kind::Scalar,
+           {{EncodingLayoutTree::StreamIdentifiers::Scalar::ScalarStream,
+             EncodingLayout{
+                 EncodingType::SimdForBitpack,
+                 {},
+                 CompressionType::Uncompressed}}},
+           ""},
+      }};
+
+  SerializerOptions options{
+      .version = version(),
+      .encodingLayoutTree = layoutTree,
+      .compressionOptions = compressionOptions(),
+  };
+
+  Serializer serializer{options, type, pool_.get()};
+
+  const velox::vector_size_t numRows = 100;
+  auto intVals =
+      velox::BaseVector::create(velox::INTEGER(), numRows, pool_.get());
+  auto longVals =
+      velox::BaseVector::create(velox::BIGINT(), numRows, pool_.get());
+  for (velox::vector_size_t i = 0; i < numRows; ++i) {
+    intVals->asFlatVector<int32_t>()->set(i, 1000 + i % 50);
+    longVals->asFlatVector<int64_t>()->set(i, 5000LL + i * 3);
   }
 
   auto input = std::make_shared<velox::RowVector>(

--- a/dwio/nimble/tools/EncodingUtilities.cpp
+++ b/dwio/nimble/tools/EncodingUtilities.cpp
@@ -51,6 +51,7 @@ void extractCompressionType(
     case EncodingType::Prefix:
     case EncodingType::ALP:
     case EncodingType::PFOR:
+    case EncodingType::SimdForBitpack:
       break;
   }
 }
@@ -105,7 +106,8 @@ void traverseEncodings(
     case EncodingType::Constant:
     case EncodingType::Prefix:
     case EncodingType::ALP:
-    case EncodingType::PFOR: {
+    case EncodingType::PFOR:
+    case EncodingType::SimdForBitpack: {
       // don't have any nested encoding
       break;
     }


### PR DESCRIPTION
Summary:

SIMD Frame-of-Reference bitpacking for integer streams. Subtracts baseline (min), packs residuals in groups of 32 using Lemire FastPFor `fastpack/fastunpack`. Decode is faster than FixedBitWidth because the word-aligned group format avoids cross-word bit extraction.

Wire format: `[encPrefix][baseline:sizeof(T)B][bitWidth:1B][packed groups]` where each group is `bitWidth * sizeof(uint32_t)` bytes. Last group zero-padded if partial.

Reviewed By: tanjialiang, xiaoxmeng

Differential Revision: D106108703


