### PR TITLE
fix: Fix intermittent deadlock in decodeChunkFirstWins test

### DIFF
--- a/dwio/nimble/index/tests/ClusterIndexTest.cpp
+++ b/dwio/nimble/index/tests/ClusterIndexTest.cpp
@@ -1816,17 +1816,19 @@ DEBUG_ONLY_TEST_F(ClusterIndexTest, decodeChunkFirstWins) {
 
   std::thread t1(
       [&]() { clusterIndex->lookup(makeRangeScanRequest("key_a")); });
+
+  firstDecodeReady.wait();
+
   std::thread t2(
       [&]() { clusterIndex->lookup(makeRangeScanRequest("key_b")); });
 
-  firstDecodeReady.wait();
   secondDecodeReady.wait();
 
   EXPECT_NE(firstDecoded, nullptr);
   EXPECT_NE(secondDecoded, nullptr);
   EXPECT_NE(firstDecoded, secondDecoded);
 
-  // Release thread 1 first — it wins the install.
+  // Release t1 first — it wins the install.
   firstProceed.post();
   t1.join();
 
@@ -1834,7 +1836,7 @@ DEBUG_ONLY_TEST_F(ClusterIndexTest, decodeChunkFirstWins) {
       helper.decodedChunkData(/*partitionIndex=*/0, /*chunkIndex=*/0),
       firstDecoded);
 
-  // Release thread 2 — its install is skipped (slot already filled).
+  // Release t2 — its install is skipped (slot already filled).
   secondProceed.post();
   t2.join();
 


### PR DESCRIPTION
Summary:
The `decodeChunkFirstWins` test assumed `t1` (first `std::thread` created) would always be the first to reach the TestValue callback. Thread scheduling is non-deterministic — when `t2` arrived first, it got `count==1` and blocked on `firstProceed`, while `t1` got `count==2` and blocked on `secondProceed`. The main thread then posted `firstProceed` (releasing `t2`), but called `t1.join()` — deadlocking because `t1` was waiting on `secondProceed` which the main thread could never reach.

Fix: track which physical thread arrived first via `std::atomic<std::thread::id>`, then join threads in actual arrival order instead of assuming `t1` is always first.

Differential Revision: D107146530


