### PR TITLE
misc: Add StreamLocation/locateStreams API and fix ParallelTaskExecutor exception handling

### DIFF
--- a/dwio/nimble/velox/selective/ReaderBase.cpp
+++ b/dwio/nimble/velox/selective/ReaderBase.cpp
@@ -148,6 +148,31 @@ std::unique_ptr<dwio::common::SeekableInputStream> StripeStreams::enqueue(
   return readerBase_->input().enqueue(*region, &sid);
 }
 
+std::vector<std::optional<StreamLocation>> StripeStreams::locateStreams(
+    std::span<const uint32_t> streamIds) const {
+  NIMBLE_CHECK(stripeIdentifier_.has_value());
+
+  const auto& tablet = readerBase_->tablet();
+  const auto streamCount = tablet.streamCount(*stripeIdentifier_);
+  // File offset where this stripe's data begins.
+  const auto stripeOffset = tablet.stripeOffset(stripe_);
+  const auto& streamOffsets = tablet.streamOffsets(*stripeIdentifier_);
+  const auto& streamSizes = tablet.streamSizes(*stripeIdentifier_);
+
+  std::vector<std::optional<StreamLocation>> locations(streamIds.size());
+  for (size_t i = 0; i < streamIds.size(); ++i) {
+    const auto streamId = streamIds[i];
+    if (streamId >= streamCount || streamSizes[streamId] == 0) {
+      continue;
+    }
+    locations[i] = StreamLocation{
+        streamId,
+        common::Region{
+            stripeOffset + streamOffsets[streamId], streamSizes[streamId]}};
+  }
+  return locations;
+}
+
 std::shared_ptr<index::StreamIndex> StripeStreams::streamIndex(
     int streamId) const {
   NIMBLE_CHECK(stripeIdentifier_.has_value());

--- a/dwio/nimble/velox/selective/ReaderBase.h
+++ b/dwio/nimble/velox/selective/ReaderBase.h
@@ -16,6 +16,10 @@
 
 #pragma once
 
+#include <optional>
+#include <span>
+#include <vector>
+
 #include "dwio/nimble/index/ChunkIndexGroup.h"
 #include "dwio/nimble/index/ClusterIndex.h"
 #include "dwio/nimble/tablet/Constants.h"
@@ -138,6 +142,14 @@ class ReaderBase {
       fileSchemaWithId_;
 };
 
+/// Physical file location of a stream within a stripe. Used to plan IO
+/// without immediately enqueueing reads, enabling callers to collect regions
+/// across multiple stripes for a single coalesced load.
+struct StreamLocation {
+  uint32_t streamId{};
+  velox::common::Region region;
+};
+
 class StripeStreams {
  public:
   explicit StripeStreams(const std::shared_ptr<ReaderBase>& readerBase)
@@ -159,6 +171,12 @@ class StripeStreams {
 
   std::unique_ptr<velox::dwio::common::SeekableInputStream> enqueue(
       int streamId);
+
+  /// Returns the physical file location of each requested stream in the
+  /// current stripe. Streams that do not exist or have zero size return
+  /// nullopt at the corresponding index. Does not enqueue IO.
+  std::vector<std::optional<StreamLocation>> locateStreams(
+      std::span<const uint32_t> streamIds) const;
 
   void load() {
     readerBase_->input().load(velox::dwio::common::LogType::STREAM_BUNDLE);

--- a/dwio/nimble/velox/selective/tests/ReaderBaseTest.cpp
+++ b/dwio/nimble/velox/selective/tests/ReaderBaseTest.cpp
@@ -18,13 +18,17 @@
 
 #include <gtest/gtest.h>
 
+#include "dwio/nimble/tablet/FileLayout.h"
 #include "dwio/nimble/tablet/TabletReaderCache.h"
+#include "dwio/nimble/velox/FlushPolicy.h"
 #include "dwio/nimble/velox/VeloxWriter.h"
 #include "folly/executors/CPUThreadPoolExecutor.h"
 #include "velox/common/file/File.h"
 #include "velox/common/memory/Memory.h"
 #include "velox/dwio/common/BufferedInput.h"
 #include "velox/vector/tests/utils/VectorMaker.h"
+
+#include <fmt/core.h>
 
 using namespace facebook::nimble;
 using namespace facebook;
@@ -171,6 +175,46 @@ TEST_P(ReaderBaseTest, equivalentAcrossModes) {
       direct->tablet().tabletRowCount(), fromCache->tablet().tabletRowCount());
 }
 
+TEST_P(ReaderBaseTest, locateStreams) {
+  auto reader = createReaderBase();
+  StripeStreams streams(reader);
+  streams.setStripe(0);
+
+  const auto numStreams = reader->nimbleSchema()->asRow().childrenCount() + 1;
+
+  struct TestCase {
+    std::vector<uint32_t> streamIds;
+    std::string debugString() const {
+      return fmt::format("streamIds=[{}]", fmt::join(streamIds, ","));
+    }
+  };
+
+  std::vector<uint32_t> allStreamIds;
+  for (uint32_t i = 0; i < numStreams; ++i) {
+    allStreamIds.push_back(i);
+  }
+
+  std::vector<TestCase> testCases = {
+      {allStreamIds},
+      {{9999}},
+      {{}},
+  };
+
+  for (const auto& testCase : testCases) {
+    SCOPED_TRACE(testCase.debugString());
+    auto locations = streams.locateStreams(testCase.streamIds);
+    ASSERT_EQ(locations.size(), testCase.streamIds.size());
+
+    for (size_t i = 0; i < locations.size(); ++i) {
+      SCOPED_TRACE(fmt::format("streamId={}", testCase.streamIds[i]));
+      if (locations[i].has_value()) {
+        EXPECT_EQ(locations[i]->streamId, testCase.streamIds[i]);
+        EXPECT_GT(locations[i]->region.length, 0);
+      }
+    }
+  }
+}
+
 INSTANTIATE_TEST_CASE_P(
     AllCreationModes,
     ReaderBaseTest,
@@ -178,3 +222,111 @@ INSTANTIATE_TEST_CASE_P(
     [](const ::testing::TestParamInfo<CreationMode>& info) {
       return info.param == CreationMode::kDirect ? "direct" : "cached";
     });
+
+class StripeStreamsMultiStripeTest : public ::testing::Test {
+ protected:
+  static void SetUpTestSuite() {
+    velox::memory::MemoryManager::testingSetInstance({});
+  }
+
+  void SetUp() override {
+    pool_ = velox::memory::memoryManager()->addLeafPool("test");
+    fileData_ = writeMultiStripeFile();
+  }
+
+  std::string writeMultiStripeFile() {
+    std::string file;
+    velox::test::VectorMaker vectorMaker(pool_.get());
+
+    VeloxWriterOptions writerOptions;
+    writerOptions.flushPolicyFactory = []() {
+      return std::make_unique<LambdaFlushPolicy>(
+          [](const StripeProgress&) { return true; });
+    };
+
+    auto writer = std::make_unique<VeloxWriter>(
+        kSchema,
+        std::make_unique<velox::InMemoryWriteFile>(&file),
+        *pool_,
+        std::move(writerOptions));
+
+    for (int stripe = 0; stripe < 3; ++stripe) {
+      const auto offset = stripe * 100;
+      auto vector = vectorMaker.rowVector(
+          {"a", "b"},
+          {vectorMaker.flatVector<int64_t>(
+               100, [offset](auto i) { return offset + i; }),
+           vectorMaker.flatVector<velox::StringView>(100, [offset](auto i) {
+             return velox::StringView::makeInline(
+                 "v" + std::to_string(offset + i));
+           })});
+      writer->write(vector);
+    }
+    writer->close();
+    return file;
+  }
+
+  static inline const velox::RowTypePtr kSchema =
+      velox::ROW({"a", "b"}, {velox::BIGINT(), velox::VARCHAR()});
+
+  velox::dwio::common::ReaderOptions makeReaderOptions() {
+    velox::dwio::common::ReaderOptions opts(pool_.get());
+    opts.setDataIoStats(dataIoStats_);
+    opts.setMetadataIoStats(metadataIoStats_);
+    opts.setIndexIoStats(indexIoStats_);
+    return opts;
+  }
+
+  std::shared_ptr<velox::memory::MemoryPool> pool_;
+  std::string fileData_;
+  const std::shared_ptr<velox::io::IoStatistics> dataIoStats_{
+      std::make_shared<velox::io::IoStatistics>()};
+  const std::shared_ptr<velox::io::IoStatistics> metadataIoStats_{
+      std::make_shared<velox::io::IoStatistics>()};
+  const std::shared_ptr<velox::io::IoStatistics> indexIoStats_{
+      std::make_shared<velox::io::IoStatistics>()};
+};
+
+TEST_F(StripeStreamsMultiStripeTest, locateStreams) {
+  auto readFile = std::make_shared<velox::InMemoryReadFile>(fileData_);
+  auto opts = makeReaderOptions();
+
+  auto input =
+      std::make_unique<velox::dwio::common::BufferedInput>(readFile, *pool_);
+  auto reader = ReaderBase::create(std::move(input), opts);
+  const auto& tablet = reader->tablet();
+  ASSERT_EQ(tablet.stripeCount(), 3);
+
+  const auto layout = FileLayout::create(readFile, pool_.get());
+  ASSERT_EQ(layout.stripesInfo.size(), 3);
+
+  StripeStreams streams(reader);
+  std::vector<uint32_t> streamIds = {1, 2};
+
+  for (uint32_t stripe = 0; stripe < 3; ++stripe) {
+    SCOPED_TRACE(fmt::format("stripe={}", stripe));
+    streams.setStripe(stripe);
+    auto locations = streams.locateStreams(streamIds);
+    ASSERT_EQ(locations.size(), streamIds.size());
+
+    const auto stripeId = tablet.stripeIdentifier(stripe);
+    const auto stripeOffset = tablet.stripeOffset(stripe);
+    const auto& streamOffsets = tablet.streamOffsets(stripeId);
+    const auto& streamSizes = tablet.streamSizes(stripeId);
+    const auto& stripeInfo = layout.stripesInfo[stripe];
+
+    for (size_t i = 0; i < locations.size(); ++i) {
+      SCOPED_TRACE(fmt::format("streamId={}", streamIds[i]));
+      ASSERT_TRUE(locations[i].has_value());
+      EXPECT_EQ(locations[i]->streamId, streamIds[i]);
+      EXPECT_EQ(
+          locations[i]->region.offset,
+          stripeOffset + streamOffsets[streamIds[i]]);
+      EXPECT_EQ(locations[i]->region.length, streamSizes[streamIds[i]]);
+      EXPECT_GE(locations[i]->region.offset, stripeInfo.offset);
+      EXPECT_LE(
+          locations[i]->region.offset + locations[i]->region.length,
+          stripeInfo.offset + stripeInfo.size);
+    }
+  }
+}


### PR DESCRIPTION
Summary:
Adds `StreamLocation` struct and `StripeStreams::locateStreams()` method to look up physical file regions for a set of stream IDs in a stripe without enqueueing IO. This enables callers to plan cross-stripe coalesced reads by collecting stream regions before loading.

Also fixes `ParallelTaskExecutor::apply()` to propagate exceptions from worker threads instead of silently hanging. Previously, if a task threw (e.g., FILE_NOT_FOUND), `numDone` was never incremented and the caller blocked forever on `numDoneCv.wait()`.

Differential Revision: D107156080


