### PR TITLE
build: Extern instantiate template processFilter of IntegerColumnReader (#816)

### DIFF
--- a/dwio/nimble/velox/selective/CMakeLists.txt
+++ b/dwio/nimble/velox/selective/CMakeLists.txt
@@ -17,6 +17,8 @@ add_library(
   ColumnReader.cpp
   FlatMapColumnReader.cpp
   IntegerColumnReader.cpp
+  IntegerColumnReader_processFilter_DropValues.cpp
+  IntegerColumnReader_processFilter_ExtractToReader.cpp
   NimbleData.cpp
   ReaderBase.cpp
   RowSizeTracker.cpp

--- a/dwio/nimble/velox/selective/IntegerColumnReader.h
+++ b/dwio/nimble/velox/selective/IntegerColumnReader.h
@@ -56,3 +56,25 @@ class IntegerColumnReader
 };
 
 } // namespace facebook::nimble
+
+namespace facebook::velox::dwio::common {
+
+#define INTEGER_COLUMN_READER_PROCESS_FILTER(IsDense, ExtractValues) \
+  template void SelectiveIntegerColumnReader::processFilter<         \
+      nimble::IntegerColumnReader,                                   \
+      IsDense,                                                       \
+      false /* kEncodingHasNulls*/,                                  \
+      ExtractValues>(                                                \
+      const velox::common::Filter* filter,                           \
+      ExtractValues extractValues,                                   \
+      const RowSet& rows)
+
+// External template instantiations to speed up build time by parallelizing.
+// `SelectiveIntegerColumnReader::processFilter` is expensive to compile because
+// it and the functions it calls are template heavy.
+extern INTEGER_COLUMN_READER_PROCESS_FILTER(true, ExtractToReader);
+extern INTEGER_COLUMN_READER_PROCESS_FILTER(false, ExtractToReader);
+extern INTEGER_COLUMN_READER_PROCESS_FILTER(true, DropValues);
+extern INTEGER_COLUMN_READER_PROCESS_FILTER(false, DropValues);
+
+} // namespace facebook::velox::dwio::common

--- a/dwio/nimble/velox/selective/IntegerColumnReader_processFilter_DropValues.cpp
+++ b/dwio/nimble/velox/selective/IntegerColumnReader_processFilter_DropValues.cpp
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "dwio/nimble/velox/selective/IntegerColumnReader.h"
+
+#include "dwio/nimble/encodings/legacy/EncodingUtils.h" // NOLINT(facebook-unused-include-check)
+
+namespace facebook::velox::dwio::common {
+
+INTEGER_COLUMN_READER_PROCESS_FILTER(true, DropValues);
+INTEGER_COLUMN_READER_PROCESS_FILTER(false, DropValues);
+} // namespace facebook::velox::dwio::common

--- a/dwio/nimble/velox/selective/IntegerColumnReader_processFilter_ExtractToReader.cpp
+++ b/dwio/nimble/velox/selective/IntegerColumnReader_processFilter_ExtractToReader.cpp
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "dwio/nimble/velox/selective/IntegerColumnReader.h"
+
+#include "dwio/nimble/encodings/legacy/EncodingUtils.h" // NOLINT(facebook-unused-include-check)
+
+namespace facebook::velox::dwio::common {
+INTEGER_COLUMN_READER_PROCESS_FILTER(true, ExtractToReader);
+INTEGER_COLUMN_READER_PROCESS_FILTER(false, ExtractToReader);
+} // namespace facebook::velox::dwio::common


### PR DESCRIPTION
Summary:

This externally instantiates `processFilter` of `IntegerColumnReader` into separate TUs to speed up the build.

`processFilter` and the functions it calls are heavily templated across multiple template parameters.

Before the change, compiling `IntegerColumnReader.cpp` takes 1m34s. 


After the change, `IntegerColumnReader.cpp`, `IntegerColumnReader_processFilter_ExtractToReader.cpp`, and `IntegerColumnReader_processFilter_DropValues.cpp` run in parallel and take 24s, 41s, and 43s respectively. The new long pole is `ColumnReader.cpp` and it takes 1m13s.

Differential Revision: D107179537


