### PR TITLE
perf: Refactor NimbleIndexProjector to separate planning from IO and result building

### DIFF
--- a/dwio/nimble/velox/index/NimbleIndexProjector.cpp
+++ b/dwio/nimble/velox/index/NimbleIndexProjector.cpp
@@ -49,14 +49,13 @@ void validateReaderOptions(const velox::dwio::common::ReaderOptions& options) {
 
 std::string NimbleIndexProjector::Stats::toString() const {
   return fmt::format(
-      "Stats(numReadStripes={}, numScannedRows={}, numProjectedRows={}, numReadRows={}, "
-      "numReadBytes={}, "
+      "Stats(numReadStripes={}, numReadRows={}, numProjectedRows={}, "
+      "numOutputBytes={}, "
       "lookupTiming=[{}], scanTiming=[{}], projectionTiming=[{}])",
       numReadStripes,
-      numScannedRows,
-      numProjectedRows,
       numReadRows,
-      velox::succinctBytes(numReadBytes),
+      numProjectedRows,
+      velox::succinctBytes(numOutputBytes),
       lookupTiming.toString(),
       scanTiming.toString(),
       projectionTiming.toString());
@@ -137,6 +136,7 @@ NimbleIndexProjector::NimbleIndexProjector(
       streams_{readerBase_} {
   NIMBLE_CHECK_NOT_NULL(
       clusterIndex_, "NimbleIndexProjector requires a tablet with an index");
+  NIMBLE_CHECK_GT(numStripes_, 0, "NimbleIndexProjector requires stripes");
 
   projectedNimbleType_ = buildProjectedNimbleType(
       readerBase_->nimbleSchema().get(),
@@ -153,194 +153,239 @@ NimbleIndexProjector::Result NimbleIndexProjector::project(
   };
 
   lookupStripes();
+  prepareStripes();
+  loadStripes();
+  return processStripes();
+}
 
-  Result result;
-  result.responses.resize(numRequests_);
+void NimbleIndexProjector::pruneStripeRanges(
+    std::vector<StripeRange>& stripeRanges,
+    const std::vector<uint64_t>& rowsPerRequest) {
+  if (ctx_.options->maxRowsPerRequest > 0) {
+    std::erase_if(stripeRanges, [&](const auto& range) {
+      return rowsPerRequest[range.requestIndex] >=
+          ctx_.options->maxRowsPerRequest;
+    });
+  }
+}
 
-  for (uint32_t i = 0; i < stripeRangeMap_.numStripes; ++i) {
-    const uint32_t stripeIndex = stripeRangeMap_.startStripe + i;
-    const auto stripeRowRanges = stripeRangeMap_.stripeRowRanges(stripeIndex);
-    if (!pruneStripeRowRanges(stripeRowRanges)) {
+void NimbleIndexProjector::prepareStripes() {
+  uint64_t totalRows{0};
+  uint64_t totalBytes{0};
+  std::vector<uint64_t> rowsPerRequest(ctx_.numRequests, 0);
+  ctx_.hasStripeRanges.assign(ctx_.numRequests, false);
+
+  for (uint32_t offset = 0; offset < ctx_.stripeRanges.numStripes; ++offset) {
+    auto spanRanges = ctx_.stripeRanges.getRanges(offset);
+    std::vector<StripeRange> stripeRanges(spanRanges.begin(), spanRanges.end());
+    pruneStripeRanges(stripeRanges, rowsPerRequest);
+    if (stripeRanges.empty()) {
       continue;
     }
-    if (!processStripe(stripeIndex, stripeRowRanges_)) {
-      setResumeKeys(stripeIndex, stripeRowRanges_, result);
+
+    uint64_t stripeRows{0};
+    for (auto& stripeRange : stripeRanges) {
+      const auto numRows =
+          static_cast<uint64_t>(stripeRange.rowRange.numRows());
+      if (ctx_.options->maxRowsPerRequest > 0) {
+        const auto remaining = ctx_.options->maxRowsPerRequest -
+            rowsPerRequest[stripeRange.requestIndex];
+        const auto rowsToRead = std::min(numRows, remaining);
+        rowsPerRequest[stripeRange.requestIndex] += rowsToRead;
+        stripeRows += rowsToRead;
+        if (rowsToRead < numRows) {
+          stripeRange.rowRange.endRow =
+              stripeRange.rowRange.startRow + static_cast<uint32_t>(rowsToRead);
+        }
+      } else {
+        stripeRows += numRows;
+      }
+    }
+
+    for (const auto& range : stripeRanges) {
+      ctx_.hasStripeRanges[range.requestIndex] = true;
+    }
+
+    const uint32_t stripeIndex = ctx_.stripeRanges.startStripe + offset;
+    StripePlan stripePlan;
+    stripePlan.stripeIndex = stripeIndex;
+    stripePlan.stripeRanges = std::move(stripeRanges);
+    locateStripeStreams(stripePlan);
+
+    totalRows += stripeRows;
+    totalBytes += stripePlan.projectedBytes;
+    ctx_.plan.stripePlans.push_back(std::move(stripePlan));
+    if ((ctx_.options->maxRows > 0 && totalRows >= ctx_.options->maxRows) ||
+        (ctx_.options->maxBytes > 0 && totalBytes >= ctx_.options->maxBytes)) {
+      ctx_.plan.truncated = true;
       break;
     }
   }
-
-  finalizeResult(result);
-  return result;
 }
 
 void NimbleIndexProjector::initRequest(
     const Request& request,
     const Options& options) {
-  NIMBLE_CHECK_NULL(request_, "project() is not reentrant");
-  NIMBLE_CHECK_NULL(options_, "project() is not reentrant");
+  NIMBLE_CHECK_NULL(ctx_.request, "project() is not reentrant");
+  NIMBLE_CHECK_NULL(ctx_.options, "project() is not reentrant");
   NIMBLE_CHECK_GT(request.keyBounds.size(), 0, "keyBounds must not be empty");
-  request_ = &request;
-  options_ = &options;
-  numRequests_ = static_cast<uint32_t>(request.keyBounds.size());
-  numReadRows_ = 0;
-  numReadBytes_ = 0;
-  rowsPerRequest_.assign(numRequests_, 0);
-  resultChunks_.assign(numRequests_, {});
+  ctx_.request = &request;
+  ctx_.options = &options;
+  ctx_.numRequests = static_cast<uint32_t>(request.keyBounds.size());
 }
 
 void NimbleIndexProjector::clearRequest() {
-  request_ = nullptr;
-  options_ = nullptr;
-  numRequests_ = 0;
-  rowsPerRequest_.clear();
-  resultChunks_.clear();
-  stripeRowRanges_.clear();
-  stripeRangeMap_.clear();
+  ctx_ = {};
+}
+
+RowRange NimbleIndexProjector::stripeRowRange(
+    uint32_t stripe,
+    const RowRange& rowRangeLimit) const {
+  const auto stripeStart =
+      static_cast<uint32_t>(readerBase_->tablet().stripeStartRow(stripe));
+  const auto stripeEnd = stripeStart + stripeRowCount(stripe);
+  const auto startRow = std::max(rowRangeLimit.startRow, stripeStart);
+  const auto endRow = std::min(rowRangeLimit.endRow, stripeEnd);
+  if (startRow >= endRow) {
+    return RowRange{};
+  }
+  return RowRange(startRow - stripeStart, endRow - stripeStart);
 }
 
 void NimbleIndexProjector::lookupStripes() {
   velox::CpuWallTimer timer(stats_.lookupTiming);
 
   const auto result = clusterIndex_->lookup(
-      index::IndexLookup::LookupRequest::rangeScan(request_->keyBounds));
+      index::IndexLookup::LookupRequest::rangeScan(ctx_.request->keyBounds));
 
-  // Find the stripe range across all requests.
-  uint32_t minStripe = numStripes_;
-  uint32_t maxStripe = 0;
-
-  struct RequestStripeRange {
+  struct ResolvedRequest {
+    uint32_t requestIndex;
     uint32_t startStripe;
     uint32_t endStripe;
-    // File-level row range from the cluster index lookup.
     RowRange rowRange;
-
-    bool empty() const {
-      return startStripe >= endStripe;
-    }
   };
-  std::vector<RequestStripeRange> requestRanges;
-  requestRanges.reserve(numRequests_);
 
-  uint32_t numRowRanges = 0;
+  uint32_t minStripe = numStripes_;
+  uint32_t maxStripe = 0;
+  std::vector<ResolvedRequest> resolvedRequests;
+  resolvedRequests.reserve(ctx_.numRequests);
   const auto& tablet = readerBase_->tablet();
-  for (size_t requestIdx = 0; requestIdx < numRequests_; ++requestIdx) {
-    const auto rowRanges = result[requestIdx];
-    if (rowRanges.empty()) {
-      requestRanges.emplace_back(RequestStripeRange{0, 0, {}});
+  for (uint32_t requestIndex = 0; requestIndex < ctx_.numRequests;
+       ++requestIndex) {
+    const auto& ranges = result[requestIndex];
+    if (ranges.empty()) {
       continue;
     }
-    NIMBLE_CHECK_EQ(
-        rowRanges.size(), 1, "Expected single row range per lookup");
-    const auto& rowRange = rowRanges[0];
-    NIMBLE_CHECK(!rowRange.empty());
+    NIMBLE_CHECK_EQ(ranges.size(), 1, "Expected single row range per lookup");
+    const auto& range = ranges[0];
+    NIMBLE_CHECK(!range.empty());
 
-    const uint32_t startStripe = tablet.rowToStripe(rowRange.startRow);
-    const uint32_t endStripe = tablet.rowToStripe(rowRange.endRow - 1) + 1;
+    const uint32_t startStripe = tablet.rowToStripe(range.startRow);
+    const uint32_t endStripe = tablet.rowToStripe(range.endRow - 1) + 1;
     NIMBLE_CHECK_LE(endStripe, numStripes_);
     NIMBLE_CHECK_LT(startStripe, endStripe);
-    requestRanges.emplace_back(
-        RequestStripeRange{startStripe, endStripe, rowRange});
 
-    numRowRanges += endStripe - startStripe;
+    resolvedRequests.push_back({requestIndex, startStripe, endStripe, range});
     minStripe = std::min(minStripe, startStripe);
     maxStripe = std::max(maxStripe, endStripe);
   }
 
-  if (numRowRanges == 0) {
+  if (resolvedRequests.empty()) {
     return;
   }
 
-  stripeRangeMap_.startStripe = minStripe;
-  stripeRangeMap_.numStripes = maxStripe - minStripe;
+  ctx_.stripeRanges.startStripe = minStripe;
+  ctx_.stripeRanges.numStripes = maxStripe - minStripe;
 
-  // Build CSR layout: count entries per stripe, then fill.
-  stripeRangeMap_.stripeOffsets.resize(stripeRangeMap_.numStripes + 1, 0);
-  for (const auto& requestRange : requestRanges) {
-    if (requestRange.empty()) {
-      continue;
-    }
-    for (uint32_t stripe = requestRange.startStripe;
-         stripe < requestRange.endStripe;
-         ++stripe) {
-      ++stripeRangeMap_.stripeOffsets[stripe - minStripe + 1];
-    }
-  }
+  std::vector<std::vector<StripeRange>> rangesByStripe(
+      ctx_.stripeRanges.numStripes);
+  ctx_.stripeRanges.offsets.resize(ctx_.stripeRanges.numStripes + 1, 0);
 
-  // Convert counts to prefix sums.
-  for (uint32_t i = 1; i <= stripeRangeMap_.numStripes; ++i) {
-    stripeRangeMap_.stripeOffsets[i] += stripeRangeMap_.stripeOffsets[i - 1];
-  }
-
-  // Fill entries using a copy of offsets as write cursors.
-  stripeRangeMap_.rowRanges.resize(numRowRanges);
-  auto writeCursors = stripeRangeMap_.stripeOffsets;
-  for (size_t requestIdx = 0; requestIdx < numRequests_; ++requestIdx) {
-    const auto& requestRange = requestRanges[requestIdx];
-    if (requestRange.empty()) {
-      continue;
-    }
-    for (uint32_t stripe = requestRange.startStripe;
-         stripe < requestRange.endStripe;
+  for (const auto& request : resolvedRequests) {
+    for (uint32_t stripe = request.startStripe; stripe < request.endStripe;
          ++stripe) {
       const auto stripeOffset = stripe - minStripe;
-      stripeRangeMap_.rowRanges[writeCursors[stripeOffset]++] = StripeRowRange{
-          static_cast<uint32_t>(requestIdx),
-          stripeRowRange(stripe, requestRange.rowRange)};
+      rangesByStripe[stripeOffset].push_back(
+          StripeRange{
+              request.requestIndex, stripeRowRange(stripe, request.rowRange)});
+    }
+  }
+
+  uint32_t numRanges = 0;
+  for (uint32_t i = 0; i < ctx_.stripeRanges.numStripes; ++i) {
+    numRanges += static_cast<uint32_t>(rangesByStripe[i].size());
+    ctx_.stripeRanges.offsets[i + 1] = numRanges;
+  }
+
+  ctx_.stripeRanges.ranges.reserve(numRanges);
+  for (const auto& ranges : rangesByStripe) {
+    ctx_.stripeRanges.ranges.insert(
+        ctx_.stripeRanges.ranges.end(), ranges.begin(), ranges.end());
+  }
+}
+
+void NimbleIndexProjector::loadStripes() {
+  const auto& stripePlans = ctx_.plan.stripePlans;
+  velox::CpuWallTimer timer(stats_.scanTiming);
+
+  ctx_.loadedStripes.resize(stripePlans.size());
+  for (size_t stripeOffset = 0; stripeOffset < stripePlans.size();
+       ++stripeOffset) {
+    ctx_.loadedStripes[stripeOffset].resize(projectedStreamOffsets_.size());
+    const auto& streams = stripePlans[stripeOffset].projectedStreams;
+    for (size_t streamIndex = 0; streamIndex < streams.size(); ++streamIndex) {
+      const auto& stream = streams[streamIndex];
+      if (!stream.has_value()) {
+        continue;
+      }
+      dwio::common::StreamIdentifier sid(stream->streamId);
+      ctx_.loadedStripes[stripeOffset][streamIndex] =
+          readerBase_->input().enqueue(stream->region, &sid);
+    }
+  }
+
+  readerBase_->input().load(velox::dwio::common::LogType::STREAM_BUNDLE);
+}
+
+NimbleIndexProjector::Result NimbleIndexProjector::processStripes() {
+  velox::CpuWallTimer timer(stats_.projectionTiming);
+  Result result;
+  result.responses.resize(ctx_.numRequests);
+  ctx_.stripeBodies.resize(ctx_.plan.stripePlans.size());
+  for (size_t i = 0; i < ctx_.plan.stripePlans.size(); ++i) {
+    const auto& stripePlan = ctx_.plan.stripePlans[i];
+    ++stats_.numReadStripes;
+    ctx_.stripeBodies[i] =
+        serializeStripe(stripePlan.stripeIndex, ctx_.loadedStripes[i]);
+  }
+  setResumeKeys(result);
+  buildResult(result);
+  return result;
+}
+
+void NimbleIndexProjector::locateStripeStreams(StripePlan& stripePlan) {
+  NIMBLE_CHECK(
+      stripePlan.projectedStreams.empty() && stripePlan.projectedBytes == 0,
+      "StripePlan already has located streams");
+  stripePlan.numRows = stripeRowCount(stripePlan.stripeIndex);
+  streams_.setStripe(stripePlan.stripeIndex);
+  stripePlan.projectedStreams = streams_.locateStreams(projectedStreamOffsets_);
+  for (const auto& stream : stripePlan.projectedStreams) {
+    if (stream.has_value()) {
+      stripePlan.projectedBytes += stream->region.length;
     }
   }
 }
 
-bool NimbleIndexProjector::pruneStripeRowRanges(
-    std::span<const StripeRowRange> stripeRowRanges) {
-  stripeRowRanges_.assign(stripeRowRanges.begin(), stripeRowRanges.end());
-  if (stripeRowRanges_.empty()) {
-    return false;
-  }
-  if (options_->maxRowsPerRequest > 0) {
-    std::erase_if(stripeRowRanges_, [&](const auto& rowRange) {
-      return rowsPerRequest_[rowRange.requestIndex] >=
-          options_->maxRowsPerRequest;
-    });
-  }
-  return !stripeRowRanges_.empty();
-}
-
-bool NimbleIndexProjector::processStripe(
-    uint32_t stripeIndex,
-    std::span<const StripeRowRange> stripeRowRanges) {
-  streams_.setStripe(stripeIndex);
-
-  // TODO: Support fine-grained row range fetches from a stripe. For now, we
-  // always fetch entire projected column streams and build the serialized
-  // values. The result references a portion of it based on the row range.
-  auto inputStreams = loadStripe();
-  auto stripeChunk = serializeStripe(stripeIndex, inputStreams);
-  return buildStripeResult(stripeRowRanges, std::move(stripeChunk));
-}
-
-NimbleIndexProjector::InputStreams NimbleIndexProjector::loadStripe() {
-  velox::CpuWallTimer timer(stats_.scanTiming);
-  ++stats_.numReadStripes;
-  InputStreams inputStreams;
-  inputStreams.reserve(projectedStreamOffsets_.size());
-  for (const auto streamId : projectedStreamOffsets_) {
-    inputStreams.emplace_back(streams_.enqueue(streamId));
-  }
-  streams_.load();
-  return inputStreams;
-}
-
-NimbleIndexProjector::ResultChunk NimbleIndexProjector::serializeStripe(
+folly::IOBuf NimbleIndexProjector::serializeStripe(
     uint32_t stripeIndex,
     InputStreams& inputStreams) {
-  velox::CpuWallTimer timer(stats_.projectionTiming);
-
   const auto numRows = stripeRowCount(stripeIndex);
 
   // Build the shared body+trailer for this stripe:
   //   [stream_data...][encodingType][stream_sizes][trailer_size:u32].
   // The version/rowCount/row-range/resume-key header is per-slice and is
-  // built later by finalizeResult().
+  // built later by buildResult().
 
   // Collect raw stream segments without copying. Sizes are needed for the
   // trailer.
@@ -376,63 +421,23 @@ NimbleIndexProjector::ResultChunk NimbleIndexProjector::serializeStripe(
   std::memcpy(dest, trailerBuf.data(), trailerBuf.size());
   body->append(bodySize);
 
-  ResultChunk stripeChunk;
-  stripeChunk.sharedBody = std::move(*body);
-  stripeChunk.numRows = numRows;
-
-  stats_.numScannedRows += numRows;
-  stats_.numProjectedRows += numRows;
-  stats_.numReadBytes += stripeChunk.sharedBody.length();
-  return stripeChunk;
+  stats_.numReadRows += numRows;
+  stats_.numOutputBytes += bodySize;
+  return std::move(*body);
 }
 
-bool NimbleIndexProjector::buildStripeResult(
-    std::span<const StripeRowRange> stripeRowRanges,
-    ResultChunk&& stripeChunk) {
-  for (const auto& request : stripeRowRanges) {
-    NIMBLE_CHECK(!request.rowRange.empty());
-    auto rowRange = request.rowRange;
-
-    // Saturated requests are filtered out by the caller in project().
-    if (options_->maxRowsPerRequest > 0) {
-      NIMBLE_CHECK_GT(
-          options_->maxRowsPerRequest, rowsPerRequest_[request.requestIndex]);
-      const auto remaining =
-          options_->maxRowsPerRequest - rowsPerRequest_[request.requestIndex];
-      if (static_cast<uint64_t>(rowRange.numRows()) > remaining) {
-        rowRange.endRow = rowRange.startRow + static_cast<uint32_t>(remaining);
-      }
-    }
-    NIMBLE_CHECK_GT(rowRange.numRows(), 0);
-
-    // Queue a per-slice clone of the shared body+trailer. The header node
-    // (version + rowCount + row range + resume-key-length [+ resume key])
-    // is materialized and chained on top in finalizeResult().
-    stats_.numReadRows += rowRange.numRows();
-    numReadRows_ += rowRange.numRows();
-    resultChunks_[request.requestIndex].push_back(
-        ResultChunk{
-            stripeChunk.sharedBody.cloneOneAsValue(),
-            stripeChunk.numRows,
-            rowRange});
-    rowsPerRequest_[request.requestIndex] += rowRange.numRows();
+void NimbleIndexProjector::setResumeKeys(Result& result) {
+  if (!ctx_.plan.truncated) {
+    return;
   }
+  const auto& lastPlan = ctx_.plan.stripePlans.back();
+  const auto stripeIndex = lastPlan.stripeIndex;
+  const auto& stripeRanges = lastPlan.stripeRanges;
 
-  // Track body bytes only. Header bytes are small relative to stream data
-  // and are not worth the accounting complexity.
-  const auto bodyBytes = stripeChunk.sharedBody.length();
-  numReadBytes_ += bodyBytes;
-
-  return !checkOutputLimit();
-}
-
-void NimbleIndexProjector::setResumeKeys(
-    uint32_t stripeIndex,
-    std::span<const StripeRowRange> stripeRowRanges,
-    Result& result) {
   // No next stripe in the range map — all mapped requests end at this stripe.
   const auto nextStripe = stripeIndex + 1;
-  if (nextStripe >= stripeRangeMap_.startStripe + stripeRangeMap_.numStripes) {
+  if (nextStripe >=
+      ctx_.stripeRanges.startStripe + ctx_.stripeRanges.numStripes) {
     return;
   }
 
@@ -445,9 +450,10 @@ void NimbleIndexProjector::setResumeKeys(
   }
 
   auto resumeKey = clusterIndex_->keyAtRow(nextStripeStartRow);
-  const auto nextRanges = stripeRangeMap_.stripeRowRanges(nextStripe);
+  const auto nextRanges =
+      ctx_.stripeRanges.getRanges(nextStripe - ctx_.stripeRanges.startStripe);
 
-  for (const auto& request : stripeRowRanges) {
+  for (const auto& request : stripeRanges) {
     auto& response = result.responses[request.requestIndex];
     NIMBLE_CHECK(!response.resumeKey.has_value());
     if (std::any_of(
@@ -458,14 +464,12 @@ void NimbleIndexProjector::setResumeKeys(
     }
   }
 
-  // For requests that were never started (no result chunks for this scan,
-  // no resume key), set resume key to their original lower key so the
-  // caller can retry. Note: response.chunks is populated later by
-  // finalizeResult(), so we check resultChunks_ here.
+  // For requests that were never started (no stripe ranges in any plan),
+  // set resume key to their original lower key so the caller can retry.
   for (size_t i = 0; i < result.responses.size(); ++i) {
     auto& response = result.responses[i];
-    if (resultChunks_[i].empty() && !response.resumeKey.has_value()) {
-      const auto& keyBounds = request_->keyBounds[i];
+    if (!ctx_.hasStripeRanges[i] && !response.resumeKey.has_value()) {
+      const auto& keyBounds = ctx_.request->keyBounds[i];
       NIMBLE_CHECK(
           keyBounds.lowerKey.has_value(),
           "Request {} has no lowerKey: unbounded lower requests start from "
@@ -479,7 +483,7 @@ void NimbleIndexProjector::setResumeKeys(
 namespace {
 
 /// Builds a kTablet IOBuf chain: [header] -> [shared body+trailer].
-folly::IOBuf assembleChunk(
+folly::IOBuf assembleStripeSlice(
     uint32_t numRows,
     RowRange rowRange,
     folly::IOBuf body,
@@ -498,26 +502,39 @@ folly::IOBuf assembleChunk(
 
 } // namespace
 
-void NimbleIndexProjector::finalizeResult(Result& result) {
-  NIMBLE_CHECK_EQ(resultChunks_.size(), result.responses.size());
-
-  for (size_t responseIdx = 0; responseIdx < result.responses.size();
-       ++responseIdx) {
-    auto& response = result.responses[responseIdx];
-    auto& chunks = resultChunks_[responseIdx];
-    const auto numChunks = chunks.size();
-    response.chunks.reserve(numChunks);
-
-    for (size_t chunkIdx = 0; chunkIdx < numChunks; ++chunkIdx) {
-      auto& chunk = chunks[chunkIdx];
-      const bool isLastChunk = chunkIdx + 1 == numChunks;
-      response.chunks.emplace_back(assembleChunk(
-          chunk.numRows,
-          chunk.rowRange,
-          std::move(chunk.sharedBody),
-          isLastChunk ? response.resumeKey : std::nullopt));
+void NimbleIndexProjector::buildResult(Result& result) {
+  // Build per-response slice counts for reserve.
+  std::vector<size_t> sliceCounts(ctx_.numRequests, 0);
+  for (size_t i = 0; i < ctx_.plan.stripePlans.size(); ++i) {
+    for (const auto& range : ctx_.plan.stripePlans[i].stripeRanges) {
+      ++sliceCounts[range.requestIndex];
     }
-    chunks.clear();
+  }
+  for (size_t i = 0; i < ctx_.numRequests; ++i) {
+    result.responses[i].slices.reserve(sliceCounts[i]);
+  }
+
+  // Track per-response how many slices have been emitted so we know when
+  // we're at the last one (for embedding the resume key).
+  std::vector<size_t> slicesEmitted(ctx_.numRequests, 0);
+
+  for (size_t i = 0; i < ctx_.plan.stripePlans.size(); ++i) {
+    const auto& stripePlan = ctx_.plan.stripePlans[i];
+    auto& stripeBody = ctx_.stripeBodies[i];
+
+    for (const auto& range : stripePlan.stripeRanges) {
+      NIMBLE_CHECK(!range.rowRange.empty());
+      stats_.numProjectedRows += range.rowRange.numRows();
+      ++slicesEmitted[range.requestIndex];
+      const bool isLastSlice =
+          slicesEmitted[range.requestIndex] == sliceCounts[range.requestIndex];
+      auto& response = result.responses[range.requestIndex];
+      response.slices.emplace_back(assembleStripeSlice(
+          stripePlan.numRows,
+          range.rowRange,
+          stripeBody.cloneOneAsValue(),
+          isLastSlice ? response.resumeKey : std::nullopt));
+    }
   }
 }
 

--- a/dwio/nimble/velox/index/NimbleIndexProjector.h
+++ b/dwio/nimble/velox/index/NimbleIndexProjector.h
@@ -55,7 +55,7 @@ using Subfield = velox::common::Subfield;
 ///   NODE 2 (shared stripe body + trailer):
 ///     [stream_data_0...][encodingType:1B][stream_sizes][trailer_size:u32]
 ///
-/// The chunk slice IOBuf is a 2-node chain: a per-slice header node and a
+/// The stripe slice IOBuf is a 2-node chain: a per-slice header node and a
 /// shared body+trailer node. Multiple requests that hit the same stripe with
 /// different row ranges share the body+trailer bytes via
 /// `folly::IOBuf::cloneOne` (refcounted SharedInfo); only the header node
@@ -65,8 +65,8 @@ using Subfield = velox::common::Subfield;
 ///   auto result = projector.project(request, options);
 ///   for (size_t i = 0; i < result.responses.size(); ++i) {
 ///     const auto& response = result.responses[i];
-///     for (const auto& chunkSlice : response.chunks) {
-///       // `chunkSlice` is a self-describing kTablet IOBuf chain with
+///     for (const auto& slice : response.slices) {
+///       // `slice` is a self-describing kTablet IOBuf chain with
 ///       // the request's row range and (on the last slice of a truncated
 ///       // response) the resume key embedded in the header.
 ///     }
@@ -126,19 +126,19 @@ class NimbleIndexProjector {
     /// One self-describing kTablet IOBuf chain per (request × stripe)
     /// intersection. Each entry covers a contiguous row range within one
     /// stripe; the row range is embedded in the chain's header. Empty for
-    /// miss. Chunk slices for overlapping requests share the body+trailer
-    /// bytes via refcounted SharedInfo on the second IOBuf node.
+    /// miss. Slices for overlapping requests share the body+trailer bytes
+    /// via refcounted SharedInfo on the second IOBuf node.
     ///
     /// If the response is truncated and has a resume key, it is embedded in
     /// the header of the last slice. Use `rocks::readResultResumeKey()` on
     /// the last slice to extract it.
-    std::vector<folly::IOBuf> chunks;
+    std::vector<folly::IOBuf> slices;
 
     /// If the result was truncated by maxRows or maxBytes, the encoded resume
     /// key for continuation. The caller constructs new key bounds using this
     /// as lowerKey with their original upperKey. nullopt if complete or miss.
     ///
-    /// Also embedded in the last slice's per-slice header (when chunks
+    /// Also embedded in the last slice's per-slice header (when slices
     /// is non-empty) so consumers that hold an IOBuf can recover the key
     /// without keeping the Response struct around.
     std::optional<std::string> resumeKey;
@@ -166,18 +166,15 @@ class NimbleIndexProjector {
   struct Stats {
     /// Number of stripes read from the tablet.
     uint32_t numReadStripes{0};
-    /// Number of rows scanned from stripes (entire stripe row counts).
-    uint64_t numScannedRows{0};
-    /// Number of rows in the projected result. Currently equals
-    /// numScannedRows since we project entire stripes. With fine-grained
-    /// row range fetches (value fetch), this will be smaller.
-    uint64_t numProjectedRows{0};
-    /// Number of rows read by request row ranges (may exceed maxRows due to
-    /// stripe-boundary soft limit).
+    /// Total rows read from storage (entire stripe row counts). Includes
+    /// rows outside the requested row ranges that are read because we
+    /// fetch entire projected streams per stripe.
     uint64_t numReadRows{0};
-    /// Total bytes read from tablet stream data (raw encoded bytes, excluding
-    /// serialization overhead like headers and trailers).
-    uint64_t numReadBytes{0};
+    /// Total rows in the output result (only the requested row ranges).
+    /// The difference numReadRows - numProjectedRows is over-fetched rows.
+    uint64_t numProjectedRows{0};
+    /// Total serialized output bytes.
+    uint64_t numOutputBytes{0};
 
     /// Time spent looking up stripes and row ranges via the tablet index.
     velox::CpuWallTiming lookupTiming;
@@ -201,124 +198,115 @@ class NimbleIndexProjector {
       const velox::dwio::common::ReaderOptions& options);
 
   // A request index paired with its stripe-relative row range.
-  struct StripeRowRange {
+  struct StripeRange {
     uint32_t requestIndex{};
     // Stripe-relative row range, already intersected with stripe boundaries.
     RowRange rowRange;
   };
 
   // CSR (compressed sparse row) layout mapping stripes to request row ranges.
-  // All StripeRowRanges stored in a single flat vector, with stripeOffsets
-  // indicating where each stripe's entries begin.
-  struct StripeRangeMap {
+  // All StripeRange entries are stored in a single flat vector (`entries`),
+  // with `offsets[i]` marking where stripe i's entries begin.
+  struct StripeRanges {
     uint32_t startStripe{0};
     uint32_t numStripes{0};
-    // All stripe row ranges, grouped by stripe in order.
-    std::vector<StripeRowRange> rowRanges;
-    // stripeOffsets[i] = start index in rowRanges for stripe (startStripe + i).
-    // Size = numStripes + 1.
-    std::vector<uint32_t> stripeOffsets;
+    // Flat storage of all per-stripe row ranges, grouped by stripe.
+    std::vector<StripeRange> ranges;
+    // offsets[i] = start index in ranges for stripe i (relative to
+    // startStripe). Size = numStripes + 1.
+    std::vector<uint32_t> offsets;
 
-    std::span<const StripeRowRange> stripeRowRanges(uint32_t stripeIdx) const {
-      NIMBLE_CHECK_GE(stripeIdx, startStripe);
-      NIMBLE_CHECK_LT(stripeIdx, startStripe + numStripes);
-      const auto stripeOffset = stripeIdx - startStripe;
+    std::span<const StripeRange> getRanges(uint32_t stripeIndex) const {
+      NIMBLE_CHECK_LT(stripeIndex, numStripes);
       return {
-          rowRanges.data() + stripeOffsets[stripeOffset],
-          stripeOffsets[stripeOffset + 1] - stripeOffsets[stripeOffset]};
+          ranges.data() + offsets[stripeIndex],
+          offsets[stripeIndex + 1] - offsets[stripeIndex]};
     }
 
     void clear() {
       startStripe = 0;
       numStripes = 0;
-      rowRanges.clear();
-      stripeOffsets.clear();
+      ranges.clear();
+      offsets.clear();
     }
   };
 
-  // Initializes per-project() state: stores request/options pointers, sizes
-  // rowsPerRequest_, and resets running totals. Caches numRequests_.
+  // Initializes per-project() state: stores request/options pointers and
+  // resets running totals.
   void initRequest(const Request& request, const Options& options);
 
   // Clears all per-project() state set by initRequest(). Invoked on scope
   // exit so a subsequent project() call starts from a clean slate.
   void clearRequest();
 
-  // Returns true if a global output limit (maxRows or maxBytes) has been hit.
-  bool checkOutputLimit() const {
-    return (options_->maxRows > 0 && numReadRows_ >= options_->maxRows) ||
-        (options_->maxBytes > 0 && numReadBytes_ >= options_->maxBytes);
-  }
-
   // Looks up all requests via the cluster index and maps them to stripes.
-  // Populates stripeRangeMap_.
+  // Populates ctx_.stripeRanges.
   void lookupStripes();
-
-  // Prunes stripe row ranges for requests that have exceeded their
-  // maxRowsPerRequest budget. Returns false if no active requests remain.
-  bool pruneStripeRowRanges(std::span<const StripeRowRange> stripeRowRanges);
-
-  // Loads projected streams for the stripe, serializes them into kTablet
-  // format, and maps the result to per-request row ranges. Returns false if
-  // a global limit (maxRows or maxBytes) was hit, signaling the caller to
-  // stop and set resume keys.
-  bool processStripe(
-      uint32_t stripeIndex,
-      std::span<const StripeRowRange> stripeRowRanges);
 
   using InputStreams =
       std::vector<std::unique_ptr<velox::dwio::common::SeekableInputStream>>;
 
-  // Enqueues projected streams into StripeStreams and loads them from disk.
-  InputStreams loadStripe();
-
-  // Collected data from one stripe for one request. sharedBody holds the
-  // projected stream data and trailer (no header), shared across requests
-  // for the same stripe via refcounted IOBuf clones:
-  //   [stream_data...][encodingType][stream_sizes][trailer_size:u32]
-  // finalizeResult() prepends a per-request header with the row range via
-  // assembleChunk().
-  struct ResultChunk {
-    ResultChunk() = default;
-
-    ResultChunk(folly::IOBuf sharedBody, uint32_t numRows, RowRange rowRange)
-        : sharedBody{std::move(sharedBody)},
-          numRows{numRows},
-          rowRange{rowRange} {}
-
-    folly::IOBuf sharedBody;
+  // Per-stripe plan produced by prepareStripes(). Contains the stripe's
+  // projected stream locations (for IO) and the per-request row ranges
+  // (for result building).
+  struct StripePlan {
+    uint32_t stripeIndex{};
+    // Total rows in this stripe.
     uint32_t numRows{0};
-    RowRange rowRange;
+    // Total bytes across all projected streams in this stripe.
+    uint64_t projectedBytes{0};
+    // Stream locations for projected columns. Indexed by projected stream
+    // offset; nullopt for streams absent in this stripe.
+    std::vector<std::optional<StreamLocation>> projectedStreams;
+    // Per-request row ranges intersected with this stripe, after pruning
+    // saturated requests.
+    std::vector<StripeRange> stripeRanges;
   };
 
+  // Output of prepareStripes(): the set of stripes to process and whether
+  // global limits (maxRows/maxBytes) caused early termination.
+  struct ProjectionPlan {
+    std::vector<StripePlan> stripePlans;
+    bool truncated{false};
+  };
+
+  // Locates projected streams for the stripe and populates projectedStreams
+  // and projectedBytes.
+  void locateStripeStreams(StripePlan& stripePlan);
+
+  // Removes row ranges for requests that have reached their maxRowsPerRequest
+  // budget.
+  void pruneStripeRanges(
+      std::vector<StripeRange>& stripeRanges,
+      const std::vector<uint64_t>& rowsPerRequest);
+
+  // Applies row and byte limits to the looked-up stripe ranges, computes stream
+  // metadata for selected stripes, and populates ctx_.plan.
+  void prepareStripes();
+
+  // Enqueues all projected streams from ctx_.plan into BufferedInput
+  // and issues a single coalesced load() call. Populates ctx_.loadedStripes.
+  void loadStripes();
+
+  // Serializes each stripe's loaded streams, builds per-request results,
+  // and finalizes the result.
+  Result processStripes();
+
   // Stitches loaded raw stream bytes into the shared kTablet body+trailer
-  // (stream data + trailer) without decode/re-encode. The returned chunk has
-  // a default-constructed rowRange that buildStripeResult fills in per request.
-  ResultChunk serializeStripe(uint32_t stripeIndex, InputStreams& inputStreams);
-
-  // Queues per-request result chunks for the stripe. Each chunk captures a
-  // cloneOne() of the shared body+trailer, the stripe row count, and the
-  // per-request row range. The chunk slice IOBuf chain is finalized later by
-  // finalizeResult() once we know whether the response carries a
-  // resume key. Applies maxRowsPerRequest hard clipping and accumulates
-  // numReadRows_. Returns false if a global limit (maxRows or maxBytes) was
-  // hit after this stripe.
-  bool buildStripeResult(
-      std::span<const StripeRowRange> stripeRowRanges,
-      ResultChunk&& stripeChunk);
-
-  // Sets resume keys on all truncated requests that have data in the next
-  // unprocessed stripe.
-  void setResumeKeys(
+  // (stream data + trailer) without decode/re-encode.
+  folly::IOBuf serializeStripe(
       uint32_t stripeIndex,
-      std::span<const StripeRowRange> stripeRowRanges,
-      Result& result);
+      InputStreams& inputStreams);
 
-  // Materializes the per-slice header node for every queued chunk and
-  // assembles the final chunk slice IOBuf chain (header -> body+trailer).
-  // The resume key is folded into the header of the last slice of any
-  // truncated response.
-  void finalizeResult(Result& result);
+  // If ctx_.plan.truncated, sets resume keys on requests that have data in the
+  // next unprocessed stripe.
+  void setResumeKeys(Result& result);
+
+  // Iterates ctx_.plan.stripePlans and ctx_.stripeBodies to build per-request
+  // output slices. Each slice clones the shared stripe body and prepends a
+  // per-request header with the row range and (on the last slice of a
+  // truncated response) the resume key.
+  void buildResult(Result& result);
 
   inline uint32_t stripeRowCount(uint32_t stripe) const {
     return static_cast<uint32_t>(readerBase_->tablet().stripeRowCount(stripe));
@@ -326,18 +314,7 @@ class NimbleIndexProjector {
 
   // Computes the stripe-relative row range by intersecting the file-level
   // rowRangeLimit with the stripe boundaries.
-  RowRange stripeRowRange(uint32_t stripe, const RowRange& rowRangeLimit)
-      const {
-    const auto stripeStart =
-        static_cast<uint32_t>(readerBase_->tablet().stripeStartRow(stripe));
-    const auto stripeEnd = stripeStart + stripeRowCount(stripe);
-    const auto startRow = std::max(rowRangeLimit.startRow, stripeStart);
-    const auto endRow = std::min(rowRangeLimit.endRow, stripeEnd);
-    if (startRow >= endRow) {
-      return RowRange{};
-    }
-    return RowRange(startRow - stripeStart, endRow - stripeStart);
-  }
+  RowRange stripeRowRange(uint32_t stripe, const RowRange& rowRangeLimit) const;
 
   const std::shared_ptr<ReaderBase> readerBase_;
   const std::shared_ptr<velox::io::IoStatistics> ioStats_;
@@ -352,30 +329,30 @@ class NimbleIndexProjector {
 
   StripeStreams streams_;
 
+  // Per-project() call state. Set by initRequest(), populated through the
+  // pipeline (lookupStripes → prepareStripes → loadStripes → processStripes),
+  // and reset on return.
+  struct ProjectionContext {
+    const Request* request{nullptr};
+    const Options* options{nullptr};
+    uint32_t numRequests{0};
+    // CSR mapping from stripes to request row ranges. Populated by
+    // lookupStripes(), read-only during stripe processing.
+    StripeRanges stripeRanges;
+    // Populated by prepareStripes().
+    ProjectionPlan plan;
+    // Per-request flag: true if the request has ranges in any StripePlan.
+    // Set by prepareStripes(), used by setResumeKeys().
+    std::vector<bool> hasStripeRanges;
+    // Populated by loadStripes(), consumed during processStripes().
+    std::vector<InputStreams> loadedStripes;
+    // Serialized stripe bodies, one per StripePlan. Populated by
+    // processStripes(), consumed during buildResult().
+    std::vector<folly::IOBuf> stripeBodies;
+  };
+  ProjectionContext ctx_;
+
   Stats stats_;
-
-  // Set during project() and cleared on return.
-  const Request* request_{nullptr};
-  const Options* options_{nullptr};
-  // Number of requests in the current project() call. Cached from
-  // request_->keyBounds.size() to avoid repeated pointer chases.
-  uint32_t numRequests_{0};
-
-  // Running total of rows read across all requests for maxRows enforcement.
-  uint64_t numReadRows_{0};
-  // Running total of serialized bytes across all stripes for maxBytes
-  // enforcement.
-  uint64_t numReadBytes_{0};
-  // Accumulated rows per request for maxRowsPerRequest enforcement.
-  std::vector<uint64_t> rowsPerRequest_;
-
-  // Per-response, per-slice chunks awaiting finalization.
-  std::vector<std::vector<ResultChunk>> resultChunks_;
-  // Current stripe's row ranges after pruning saturated requests.
-  std::vector<StripeRowRange> stripeRowRanges_;
-  // CSR mapping from stripes to request row ranges. Populated by
-  // lookupStripes(), read-only during stripe processing.
-  StripeRangeMap stripeRangeMap_;
 };
 
 } // namespace facebook::nimble

--- a/dwio/nimble/velox/index/tests/NimbleIndexProjectorTest.cpp
+++ b/dwio/nimble/velox/index/tests/NimbleIndexProjectorTest.cpp
@@ -53,16 +53,15 @@ namespace {
 // these tests cannot include `rocks/nimble/NimbleTable.h`. Both helpers call
 // the same underlying `serde::readTabletChunkHeader` as the production rocks::
 // helpers, so behavior is in lockstep.
-RowRange readEmbeddedRowRange(const folly::IOBuf& chunkSlice) {
-  const char* pos = reinterpret_cast<const char*>(chunkSlice.data());
-  const char* end = pos + chunkSlice.length();
+RowRange readEmbeddedRowRange(const folly::IOBuf& slice) {
+  const char* pos = reinterpret_cast<const char*>(slice.data());
+  const char* end = pos + slice.length();
   return serde::readTabletChunkHeader(pos, end).rowRange;
 }
 
-std::optional<std::string> readEmbeddedResumeKey(
-    const folly::IOBuf& chunkSlice) {
-  const char* pos = reinterpret_cast<const char*>(chunkSlice.data());
-  const char* end = pos + chunkSlice.length();
+std::optional<std::string> readEmbeddedResumeKey(const folly::IOBuf& slice) {
+  const char* pos = reinterpret_cast<const char*>(slice.data());
+  const char* end = pos + slice.length();
   return serde::readTabletChunkHeader(pos, end).resumeKey;
 }
 
@@ -70,8 +69,8 @@ std::optional<std::string> readEmbeddedResumeKey(
 // passing to Deserializer. The Deserializer reads the per-slice header
 // natively (consuming the row range and resume-key fields) but does not
 // slice its output — it over-fetches by decoding the full stripe.
-folly::IOBuf coalesceChunkSlice(const folly::IOBuf& chunkSlice) {
-  return chunkSlice.cloneCoalescedAsValue();
+folly::IOBuf coalesceChunkSlice(const folly::IOBuf& slice) {
+  return slice.cloneCoalescedAsValue();
 }
 
 } // namespace
@@ -362,16 +361,16 @@ TEST_P(NimbleIndexProjectorTest, basicColumnProjection) {
 
   ASSERT_EQ(result.responses.size(), 1);
   const auto& response = result.responses[0];
-  ASSERT_FALSE(response.chunks.empty());
+  ASSERT_FALSE(response.slices.empty());
   EXPECT_FALSE(response.resumeKey.has_value());
 
-  const auto& chunkSlice = response.chunks[0];
-  const auto rowRange = readEmbeddedRowRange(chunkSlice);
+  const auto& slice = response.slices[0];
+  const auto rowRange = readEmbeddedRowRange(slice);
   ASSERT_GT(rowRange.numRows(), 0);
 
   // Coalesce the chunk slice IOBuf chain into a contiguous buffer that the
   // Deserializer can read end-to-end.
-  auto coalesced = coalesceChunkSlice(chunkSlice);
+  auto coalesced = coalesceChunkSlice(slice);
 
   // Deserialize using nimble Deserializer with nimble schema.
   auto projectedVeloxType = ROW({"col_a", "col_b"}, {INTEGER(), VARCHAR()});
@@ -429,14 +428,13 @@ TEST_P(NimbleIndexProjectorTest, emptyResult) {
   auto result = projector->project(request, {});
 
   ASSERT_EQ(result.responses.size(), 1);
-  EXPECT_TRUE(result.responses[0].chunks.empty());
+  EXPECT_TRUE(result.responses[0].slices.empty());
   EXPECT_FALSE(result.responses[0].resumeKey.has_value());
 
   // All stats should be zero for a miss.
   EXPECT_EQ(projector->stats().numReadStripes, 0);
-  EXPECT_EQ(projector->stats().numScannedRows, 0);
-  EXPECT_EQ(projector->stats().numProjectedRows, 0);
   EXPECT_EQ(projector->stats().numReadRows, 0);
+  EXPECT_EQ(projector->stats().numProjectedRows, 0);
   EXPECT_EQ(dataIoStats_->rawBytesRead(), 0);
   EXPECT_EQ(dataIoStats_->rawOverreadBytes(), 0);
   EXPECT_EQ(dataIoStats_->read().count(), 0);
@@ -477,15 +475,15 @@ TEST_P(NimbleIndexProjectorTest, multipleRequests) {
   ASSERT_EQ(result.responses.size(), 3);
   uint64_t totalBytes = 0;
   for (const auto& response : result.responses) {
-    for (const auto& chunkSlice : response.chunks) {
-      totalBytes += chunkSlice.computeChainDataLength();
+    for (const auto& slice : response.slices) {
+      totalBytes += slice.computeChainDataLength();
     }
   }
   EXPECT_GT(totalBytes, 0);
 
   // All requests should have results (no misses).
   for (const auto& response : result.responses) {
-    EXPECT_FALSE(response.chunks.empty());
+    EXPECT_FALSE(response.slices.empty());
     EXPECT_FALSE(response.resumeKey.has_value());
   }
 }
@@ -524,41 +522,41 @@ TEST_P(NimbleIndexProjectorTest, overlappingRequestsShareBody) {
   auto result = projector->project(request, {});
 
   ASSERT_EQ(result.responses.size(), 2);
-  ASSERT_EQ(result.responses[0].chunks.size(), 1);
-  ASSERT_EQ(result.responses[1].chunks.size(), 1);
+  ASSERT_EQ(result.responses[0].slices.size(), 1);
+  ASSERT_EQ(result.responses[1].slices.size(), 1);
 
-  const auto& chunkSlice0 = result.responses[0].chunks[0];
-  const auto& chunkSlice1 = result.responses[1].chunks[0];
+  const auto& slice0 = result.responses[0].slices[0];
+  const auto& slice1 = result.responses[1].slices[0];
 
   // Each chunk slice is a 2-node chain: per-slice header + shared body+trailer.
-  ASSERT_TRUE(chunkSlice0.isChained());
-  ASSERT_TRUE(chunkSlice1.isChained());
+  ASSERT_TRUE(slice0.isChained());
+  ASSERT_TRUE(slice1.isChained());
 
   // Header nodes (first node in each chunk slice) must be DISTINCT
   // allocations since they carry per-request row range bytes.
-  EXPECT_NE(chunkSlice0.data(), chunkSlice1.data());
+  EXPECT_NE(slice0.data(), slice1.data());
 
   // Body nodes (second node in each chunk slice) must point to the same
   // underlying memory because they are cloneOne() copies of the shared
   // per-stripe body+trailer.
-  EXPECT_EQ(chunkSlice0.prev()->data(), chunkSlice1.prev()->data());
-  EXPECT_EQ(chunkSlice0.prev()->length(), chunkSlice1.prev()->length());
+  EXPECT_EQ(slice0.prev()->data(), slice1.prev()->data());
+  EXPECT_EQ(slice0.prev()->length(), slice1.prev()->length());
 
   // Embedded row ranges match the (stripe-relative) request ranges.
-  const auto range0 = readEmbeddedRowRange(chunkSlice0);
-  const auto range1 = readEmbeddedRowRange(chunkSlice1);
+  const auto range0 = readEmbeddedRowRange(slice0);
+  const auto range1 = readEmbeddedRowRange(slice1);
   EXPECT_EQ(range0, RowRange(10, 40));
   EXPECT_EQ(range1, RowRange(25, 70));
 
   // Neither response is truncated, so neither slice carries a resume key.
-  EXPECT_FALSE(readEmbeddedResumeKey(chunkSlice0).has_value());
-  EXPECT_FALSE(readEmbeddedResumeKey(chunkSlice1).has_value());
+  EXPECT_FALSE(readEmbeddedResumeKey(slice0).has_value());
+  EXPECT_FALSE(readEmbeddedResumeKey(slice1).has_value());
 
   // The shared body dominates each chunk slice size — assert that
   // computeChainDataLength reflects header + body and that the body is
   // refcount-shared.
-  EXPECT_GT(chunkSlice0.computeChainDataLength(), chunkSlice0.length());
-  EXPECT_GT(chunkSlice0.prev()->length(), 0u);
+  EXPECT_GT(slice0.computeChainDataLength(), slice0.length());
+  EXPECT_GT(slice0.prev()->length(), 0u);
 }
 
 // Round-trips a single-batch deserialize over a key range. The Deserializer
@@ -591,8 +589,8 @@ TEST_P(NimbleIndexProjectorTest, overlappingRequestsShareBody) {
     NimbleIndexProjector::Request request;                                     \
     request.keyBounds = {bounds};                                              \
     auto result = projector->project(request, {});                             \
-    ASSERT_EQ(result.responses[0].chunks.size(), 1);                           \
-    auto coalesced = result.responses[0].chunks[0].cloneCoalescedAsValue();    \
+    ASSERT_EQ(result.responses[0].slices.size(), 1);                           \
+    auto coalesced = result.responses[0].slices[0].cloneCoalescedAsValue();    \
     auto bytes = std::string_view(                                             \
         reinterpret_cast<const char*>(coalesced.data()), coalesced.length());  \
     DeserializerOptions deserOptions;                                          \
@@ -666,9 +664,9 @@ TEST_P(NimbleIndexProjectorTest, deserializerMultiBatchWithRowRange) {
   NimbleIndexProjector::Request request;
   request.keyBounds = {bounds};
   auto result = projector->project(request, {});
-  ASSERT_EQ(result.responses[0].chunks.size(), 1);
+  ASSERT_EQ(result.responses[0].slices.size(), 1);
 
-  auto coalesced = result.responses[0].chunks[0].cloneCoalescedAsValue();
+  auto coalesced = result.responses[0].slices[0].cloneCoalescedAsValue();
   auto bytes = std::string_view(
       reinterpret_cast<const char*>(coalesced.data()), coalesced.length());
 
@@ -739,8 +737,8 @@ TEST_P(NimbleIndexProjectorTest, deserializerMultiBatchMixedRanges) {
   std::vector<std::string_view> batches;
   batches.reserve(4);
   for (auto& response : result.responses) {
-    ASSERT_EQ(response.chunks.size(), 1u);
-    ownedSlices.push_back(response.chunks[0].cloneCoalescedAsValue());
+    ASSERT_EQ(response.slices.size(), 1u);
+    ownedSlices.push_back(response.slices[0].cloneCoalescedAsValue());
     batches.emplace_back(
         reinterpret_cast<const char*>(ownedSlices.back().data()),
         ownedSlices.back().length());
@@ -811,8 +809,8 @@ TEST_P(NimbleIndexProjectorTest, deserializerMultiBatchMixedVersions) {
   NimbleIndexProjector::Request request;
   request.keyBounds = {bounds};
   auto result = projector->project(request, {});
-  ASSERT_EQ(result.responses[0].chunks.size(), 1u);
-  auto tabletOwned = result.responses[0].chunks[0].cloneCoalescedAsValue();
+  ASSERT_EQ(result.responses[0].slices.size(), 1u);
+  auto tabletOwned = result.responses[0].slices[0].cloneCoalescedAsValue();
 
   // kCompactRaw batch: serialize a 5-row Row<INTEGER> vector matching the
   // projected schema. The Serializer is constructed against the same velox
@@ -910,9 +908,8 @@ TEST_P(NimbleIndexProjectorTest, stats) {
     proj->project(request, {});
 
     EXPECT_EQ(proj->stats().numReadStripes, 1);
-    EXPECT_EQ(proj->stats().numScannedRows, rowsPerBatch);
-    EXPECT_EQ(proj->stats().numProjectedRows, proj->stats().numScannedRows);
-    EXPECT_EQ(proj->stats().numReadRows, 1);
+    EXPECT_EQ(proj->stats().numReadRows, rowsPerBatch);
+    EXPECT_EQ(proj->stats().numProjectedRows, 1);
 
     // Timings should be non-zero for a hit.
     EXPECT_GT(proj->stats().lookupTiming.count, 0);
@@ -936,9 +933,8 @@ TEST_P(NimbleIndexProjectorTest, stats) {
 
     EXPECT_EQ(proj->stats().numReadStripes, 2);
     EXPECT_EQ(
-        proj->stats().numScannedRows, static_cast<uint64_t>(2 * rowsPerBatch));
-    EXPECT_EQ(proj->stats().numProjectedRows, proj->stats().numScannedRows);
-    EXPECT_EQ(proj->stats().numReadRows, 2);
+        proj->stats().numReadRows, static_cast<uint64_t>(2 * rowsPerBatch));
+    EXPECT_EQ(proj->stats().numProjectedRows, 2);
 
     // IO stats should reflect more data read than single lookup.
     EXPECT_GT(dataIoStats_->rawBytesRead(), 0);
@@ -953,9 +949,8 @@ TEST_P(NimbleIndexProjectorTest, stats) {
     proj->project(request, {});
 
     EXPECT_EQ(proj->stats().numReadStripes, 0);
-    EXPECT_EQ(proj->stats().numScannedRows, 0);
-    EXPECT_EQ(proj->stats().numProjectedRows, 0);
     EXPECT_EQ(proj->stats().numReadRows, 0);
+    EXPECT_EQ(proj->stats().numProjectedRows, 0);
     EXPECT_EQ(dataIoStats_->rawBytesRead(), 0);
   }
 }
@@ -963,14 +958,13 @@ TEST_P(NimbleIndexProjectorTest, stats) {
 TEST_P(NimbleIndexProjectorTest, statsToString) {
   NimbleIndexProjector::Stats stats;
   stats.numReadStripes = 3;
-  stats.numScannedRows = 1'000;
-  stats.numProjectedRows = 1'000;
-  stats.numReadRows = 42;
-  stats.numReadBytes = 8'192;
+  stats.numReadRows = 1'000;
+  stats.numProjectedRows = 800;
+  stats.numOutputBytes = 8'192;
   EXPECT_EQ(
       stats.toString(),
-      "Stats(numReadStripes=3, numScannedRows=1000, numProjectedRows=1000, numReadRows=42, "
-      "numReadBytes=8.00KB, "
+      "Stats(numReadStripes=3, numReadRows=1000, numProjectedRows=800, "
+      "numOutputBytes=8.00KB, "
       "lookupTiming=[count: 0, wallTime: 0ns, cpuTime: 0ns], "
       "scanTiming=[count: 0, wallTime: 0ns, cpuTime: 0ns], "
       "projectionTiming=[count: 0, wallTime: 0ns, cpuTime: 0ns])");
@@ -1024,15 +1018,15 @@ TEST_P(NimbleIndexProjectorTest, flatMapProjection) {
 
   ASSERT_EQ(result.responses.size(), 1);
   const auto& response = result.responses[0];
-  ASSERT_FALSE(response.chunks.empty());
+  ASSERT_FALSE(response.slices.empty());
 
-  const auto& chunkSlice = response.chunks[0];
-  const auto rowRange = readEmbeddedRowRange(chunkSlice);
+  const auto& slice = response.slices[0];
+  const auto rowRange = readEmbeddedRowRange(slice);
   ASSERT_GT(rowRange.numRows(), 0);
 
   // Deserialize using the projector's projected nimble type which accounts
   // for FlatMap key sorting (keys sorted alphabetically: "b", "d", "e").
-  auto coalesced = coalesceChunkSlice(chunkSlice);
+  auto coalesced = coalesceChunkSlice(slice);
   DeserializerOptions deserOptions;
   deserOptions.hasHeader = true;
   Deserializer deserializer(
@@ -1126,13 +1120,13 @@ TEST_P(NimbleIndexProjectorTest, flatMapProjectionWithNarrowRowRange) {
   request.keyBounds = {bounds};
   auto result = projector->project(request, {});
   ASSERT_EQ(result.responses.size(), 1);
-  ASSERT_EQ(result.responses[0].chunks.size(), 1u);
+  ASSERT_EQ(result.responses[0].slices.size(), 1u);
 
-  const auto& chunkSlice = result.responses[0].chunks[0];
-  const auto rowRange = readEmbeddedRowRange(chunkSlice);
+  const auto& slice = result.responses[0].slices[0];
+  const auto rowRange = readEmbeddedRowRange(slice);
   ASSERT_EQ(rowRange.numRows(), 5u);
 
-  auto coalesced = coalesceChunkSlice(chunkSlice);
+  auto coalesced = coalesceChunkSlice(slice);
   DeserializerOptions deserOptions;
   deserOptions.hasHeader = true;
   Deserializer deserializer(
@@ -1269,10 +1263,10 @@ TEST_P(NimbleIndexProjectorTest, flatMapKeyProjectionSchemaComparison) {
   auto result = projector->project(request, {});
 
   ASSERT_EQ(result.responses.size(), 1);
-  ASSERT_FALSE(result.responses[0].chunks.empty());
+  ASSERT_FALSE(result.responses[0].slices.empty());
 
-  const auto& chunkSlice = result.responses[0].chunks[0];
-  auto coalesced = coalesceChunkSlice(chunkSlice);
+  const auto& slice = result.responses[0].slices[0];
+  auto coalesced = coalesceChunkSlice(slice);
   auto data = std::string_view(
       reinterpret_cast<const char*>(coalesced.data()), coalesced.length());
 
@@ -1329,14 +1323,14 @@ TEST_P(NimbleIndexProjectorTest, flatMapIntKeyProjection) {
 
   ASSERT_EQ(result.responses.size(), 1);
   const auto& response = result.responses[0];
-  ASSERT_FALSE(response.chunks.empty());
+  ASSERT_FALSE(response.slices.empty());
 
-  const auto& chunkSlice = response.chunks[0];
-  const auto rowRange = readEmbeddedRowRange(chunkSlice);
+  const auto& slice = response.slices[0];
+  const auto rowRange = readEmbeddedRowRange(slice);
   ASSERT_GT(rowRange.numRows(), 0);
 
   // Deserialize using the projector's projected nimble type.
-  auto coalesced = coalesceChunkSlice(chunkSlice);
+  auto coalesced = coalesceChunkSlice(slice);
   DeserializerOptions deserOptions;
   deserOptions.hasHeader = true;
   Deserializer deserializer(
@@ -1436,7 +1430,7 @@ TEST_P(NimbleIndexProjectorTest, flatMapMissingKeys) {
     request.keyBounds = {pointBounds};
     auto result = projector->project(request, {});
     ASSERT_EQ(result.responses.size(), 1);
-    ASSERT_FALSE(result.responses[0].chunks.empty());
+    ASSERT_FALSE(result.responses[0].slices.empty());
   }
 
   // All requested keys missing — should fail.
@@ -1615,7 +1609,7 @@ TEST_P(NimbleIndexProjectorTest, featureReorderingStorageReads) {
     auto result = projector->project(request, {});
 
     ASSERT_EQ(result.responses.size(), 1);
-    ASSERT_FALSE(result.responses[0].chunks.empty());
+    ASSERT_FALSE(result.responses[0].slices.empty());
 
     storageReads[param.debugString()] = dataIoStats_->read().count();
 
@@ -1815,12 +1809,12 @@ TEST_P(NimbleIndexProjectorTest, resumeKeyOnTruncation) {
 
   ASSERT_EQ(result.responses.size(), 1);
   const auto& response = result.responses[0];
-  ASSERT_FALSE(response.chunks.empty());
+  ASSERT_FALSE(response.slices.empty());
 
   // Soft limit: first stripe (100 rows) included fully.
   uint64_t totalRows = 0;
-  for (const auto& chunkSlice : response.chunks) {
-    totalRows += readEmbeddedRowRange(chunkSlice).numRows();
+  for (const auto& slice : response.slices) {
+    totalRows += readEmbeddedRowRange(slice).numRows();
   }
   EXPECT_EQ(totalRows, 100);
 
@@ -1830,12 +1824,12 @@ TEST_P(NimbleIndexProjectorTest, resumeKeyOnTruncation) {
 
   // The resume key is embedded only on the last slice; earlier slices carry
   // an empty resume key marker.
-  const auto numSlices = response.chunks.size();
+  const auto numSlices = response.slices.size();
   for (size_t i = 0; i + 1 < numSlices; ++i) {
-    EXPECT_FALSE(readEmbeddedResumeKey(response.chunks[i]).has_value())
+    EXPECT_FALSE(readEmbeddedResumeKey(response.slices[i]).has_value())
         << "non-last slice " << i << " unexpectedly carries a resume key";
   }
-  const auto embeddedResumeKey = readEmbeddedResumeKey(response.chunks.back());
+  const auto embeddedResumeKey = readEmbeddedResumeKey(response.slices.back());
   ASSERT_TRUE(embeddedResumeKey.has_value());
   EXPECT_EQ(*embeddedResumeKey, *response.resumeKey);
 }
@@ -1905,8 +1899,8 @@ TEST_P(NimbleIndexProjectorTest, softLimitAtStripeBoundary) {
 
     ASSERT_EQ(result.responses.size(), 1);
     uint64_t totalRows = 0;
-    for (const auto& chunkSlice : result.responses[0].chunks) {
-      totalRows += readEmbeddedRowRange(chunkSlice).numRows();
+    for (const auto& slice : result.responses[0].slices) {
+      totalRows += readEmbeddedRowRange(slice).numRows();
     }
     EXPECT_EQ(totalRows, 100);
     EXPECT_TRUE(result.responses[0].resumeKey.has_value());
@@ -1924,8 +1918,8 @@ TEST_P(NimbleIndexProjectorTest, softLimitAtStripeBoundary) {
 
     ASSERT_EQ(result.responses.size(), 1);
     uint64_t totalRows = 0;
-    for (const auto& chunkSlice : result.responses[0].chunks) {
-      totalRows += readEmbeddedRowRange(chunkSlice).numRows();
+    for (const auto& slice : result.responses[0].slices) {
+      totalRows += readEmbeddedRowRange(slice).numRows();
     }
     EXPECT_EQ(totalRows, 100);
     EXPECT_TRUE(result.responses[0].resumeKey.has_value());
@@ -1944,8 +1938,8 @@ TEST_P(NimbleIndexProjectorTest, softLimitAtStripeBoundary) {
 
     ASSERT_EQ(result.responses.size(), 1);
     uint64_t totalRows = 0;
-    for (const auto& chunkSlice : result.responses[0].chunks) {
-      totalRows += readEmbeddedRowRange(chunkSlice).numRows();
+    for (const auto& slice : result.responses[0].slices) {
+      totalRows += readEmbeddedRowRange(slice).numRows();
     }
     EXPECT_EQ(totalRows, 200);
     EXPECT_TRUE(result.responses[0].resumeKey.has_value());
@@ -1983,8 +1977,8 @@ TEST_P(NimbleIndexProjectorTest, resumeKeyPagination) {
     const auto& response = result.responses[0];
 
     uint64_t pageRows = 0;
-    for (const auto& chunkSlice : response.chunks) {
-      pageRows += readEmbeddedRowRange(chunkSlice).numRows();
+    for (const auto& slice : response.slices) {
+      pageRows += readEmbeddedRowRange(slice).numRows();
     }
     EXPECT_GT(pageRows, 0) << "Page " << pageCount << " returned no rows";
     totalRowsRead += pageRows;
@@ -2032,8 +2026,8 @@ TEST_P(NimbleIndexProjectorTest, maxRowsTotalAcrossRequests) {
   {
     const auto& response = result.responses[0];
     uint64_t totalRows = 0;
-    for (const auto& chunkSlice : response.chunks) {
-      totalRows += readEmbeddedRowRange(chunkSlice).numRows();
+    for (const auto& slice : response.slices) {
+      totalRows += readEmbeddedRowRange(slice).numRows();
     }
     EXPECT_EQ(totalRows, 100);
     EXPECT_TRUE(response.resumeKey.has_value());
@@ -2042,7 +2036,7 @@ TEST_P(NimbleIndexProjectorTest, maxRowsTotalAcrossRequests) {
   // Request 1: stripe 9 was never processed, resume key = original lower key.
   {
     const auto& response = result.responses[1];
-    EXPECT_TRUE(response.chunks.empty());
+    EXPECT_TRUE(response.slices.empty());
     ASSERT_TRUE(response.resumeKey.has_value());
     EXPECT_EQ(response.resumeKey.value(), bounds1.lowerKey);
   }
@@ -2074,14 +2068,14 @@ TEST_P(NimbleIndexProjectorTest, noResumeKeyWhenRequestFullySatisfied) {
   // Request 0: fully satisfied within stripe 0 — no resume key.
   {
     const auto& response = result.responses[0];
-    ASSERT_FALSE(response.chunks.empty());
+    ASSERT_FALSE(response.slices.empty());
     EXPECT_FALSE(response.resumeKey.has_value());
   }
 
   // Request 1: spans beyond stripe 0, truncated — has resume key.
   {
     const auto& response = result.responses[1];
-    ASSERT_FALSE(response.chunks.empty());
+    ASSERT_FALSE(response.slices.empty());
     EXPECT_TRUE(response.resumeKey.has_value());
   }
 }
@@ -2105,8 +2099,8 @@ TEST_P(NimbleIndexProjectorTest, maxRowsExceedsTotal) {
 
   ASSERT_EQ(result.responses.size(), 1);
   uint64_t totalRows = 0;
-  for (const auto& chunkSlice : result.responses[0].chunks) {
-    totalRows += readEmbeddedRowRange(chunkSlice).numRows();
+  for (const auto& slice : result.responses[0].slices) {
+    totalRows += readEmbeddedRowRange(slice).numRows();
   }
   EXPECT_EQ(totalRows, 300);
   EXPECT_FALSE(result.responses[0].resumeKey.has_value());
@@ -2129,8 +2123,8 @@ TEST_P(NimbleIndexProjectorTest, maxRowsZeroMeansUnlimited) {
 
   ASSERT_EQ(result.responses.size(), 1);
   uint64_t totalRows = 0;
-  for (const auto& chunkSlice : result.responses[0].chunks) {
-    totalRows += readEmbeddedRowRange(chunkSlice).numRows();
+  for (const auto& slice : result.responses[0].slices) {
+    totalRows += readEmbeddedRowRange(slice).numRows();
   }
   EXPECT_EQ(totalRows, 1000);
   EXPECT_FALSE(result.responses[0].resumeKey.has_value());
@@ -2155,8 +2149,8 @@ TEST_P(NimbleIndexProjectorTest, maxRowsSingleRowStripes) {
 
   ASSERT_EQ(result.responses.size(), 1);
   uint64_t totalRows = 0;
-  for (const auto& chunkSlice : result.responses[0].chunks) {
-    totalRows += readEmbeddedRowRange(chunkSlice).numRows();
+  for (const auto& slice : result.responses[0].slices) {
+    totalRows += readEmbeddedRowRange(slice).numRows();
   }
   EXPECT_EQ(totalRows, 3);
   EXPECT_TRUE(result.responses[0].resumeKey.has_value());
@@ -2181,7 +2175,7 @@ TEST_P(NimbleIndexProjectorTest, maxRowsPerRequestClipping) {
 
     ASSERT_EQ(result.responses.size(), 1);
     EXPECT_FALSE(result.responses[0].resumeKey.has_value());
-    EXPECT_EQ(projector->stats().numReadRows, 200);
+    EXPECT_EQ(projector->stats().numProjectedRows, 200);
   }
 
   // Mid-stripe hard cut: 150 rows = 1 full stripe (100) + 50 from stripe 2.
@@ -2197,10 +2191,10 @@ TEST_P(NimbleIndexProjectorTest, maxRowsPerRequestClipping) {
     ASSERT_EQ(result.responses.size(), 1);
     const auto& response = result.responses[0];
     EXPECT_FALSE(response.resumeKey.has_value());
-    EXPECT_EQ(projector->stats().numReadRows, 150);
-    ASSERT_EQ(response.chunks.size(), 2);
-    EXPECT_EQ(readEmbeddedRowRange(response.chunks[0]).numRows(), 100);
-    EXPECT_EQ(readEmbeddedRowRange(response.chunks[1]).numRows(), 50);
+    EXPECT_EQ(projector->stats().numProjectedRows, 150);
+    ASSERT_EQ(response.slices.size(), 2);
+    EXPECT_EQ(readEmbeddedRowRange(response.slices[0]).numRows(), 100);
+    EXPECT_EQ(readEmbeddedRowRange(response.slices[1]).numRows(), 50);
   }
 }
 
@@ -2229,8 +2223,8 @@ TEST_P(NimbleIndexProjectorTest, maxRowsPerRequestIndependentPruning) {
   {
     const auto& response = result.responses[0];
     uint64_t totalRows = 0;
-    for (const auto& chunkSlice : response.chunks) {
-      totalRows += readEmbeddedRowRange(chunkSlice).numRows();
+    for (const auto& slice : response.slices) {
+      totalRows += readEmbeddedRowRange(slice).numRows();
     }
     EXPECT_EQ(totalRows, 100);
     EXPECT_FALSE(response.resumeKey.has_value());
@@ -2239,8 +2233,8 @@ TEST_P(NimbleIndexProjectorTest, maxRowsPerRequestIndependentPruning) {
   {
     const auto& response = result.responses[1];
     uint64_t totalRows = 0;
-    for (const auto& chunkSlice : response.chunks) {
-      totalRows += readEmbeddedRowRange(chunkSlice).numRows();
+    for (const auto& slice : response.slices) {
+      totalRows += readEmbeddedRowRange(slice).numRows();
     }
     EXPECT_EQ(totalRows, 100);
     EXPECT_FALSE(response.resumeKey.has_value());
@@ -2262,8 +2256,8 @@ TEST_P(NimbleIndexProjectorTest, maxBytesTruncation) {
     NimbleIndexProjector::Request request;
     request.keyBounds = {bounds};
     auto result = projector->project(request, {});
-    ASSERT_EQ(result.responses[0].chunks.size(), 1);
-    bytesPerStripe = projector->stats().numReadBytes;
+    ASSERT_EQ(result.responses[0].slices.size(), 1);
+    bytesPerStripe = projector->stats().numOutputBytes;
     ASSERT_GT(bytesPerStripe, 0);
   }
 
@@ -2283,9 +2277,10 @@ TEST_P(NimbleIndexProjectorTest, maxBytesTruncation) {
     // Should be truncated with a resume key.
     ASSERT_TRUE(response.resumeKey.has_value());
 
-    // Should have read exactly 2 stripes (byte budget consumed after 2).
-    EXPECT_EQ(projector->stats().numReadStripes, 2);
-    EXPECT_EQ(projector->stats().numReadRows, 200);
+    // Soft byte limit — at most 3 stripes (planning uses raw stream sizes
+    // which underestimate serialized output, so one extra stripe may fit).
+    EXPECT_LE(projector->stats().numReadStripes, 3);
+    EXPECT_LT(projector->stats().numReadStripes, 5);
   }
 }
 
@@ -2336,8 +2331,8 @@ TEST_P(NimbleIndexProjectorTest, maxBytesPagination) {
     NimbleIndexProjector::Request request;
     request.keyBounds = {bounds};
     auto result = projector->project(request, {});
-    ASSERT_EQ(result.responses[0].chunks.size(), 1);
-    bytesPerStripe = projector->stats().numReadBytes;
+    ASSERT_EQ(result.responses[0].slices.size(), 1);
+    bytesPerStripe = projector->stats().numOutputBytes;
   }
 
   // Paginate through the full range using byte limits.
@@ -2358,7 +2353,7 @@ TEST_P(NimbleIndexProjectorTest, maxBytesPagination) {
 
       auto result = projector->project(request, options);
       EXPECT_EQ(result.responses.size(), 1);
-      totalReadRows += projector->stats().numReadRows;
+      totalReadRows += projector->stats().numProjectedRows;
 
       const auto& response = result.responses[0];
       if (!response.resumeKey.has_value()) {
@@ -2395,8 +2390,8 @@ TEST_P(NimbleIndexProjectorTest, maxBytesAndMaxRowsInteraction) {
     NimbleIndexProjector::Request request;
     request.keyBounds = {bounds};
     auto result = projector->project(request, {});
-    ASSERT_EQ(result.responses[0].chunks.size(), 1);
-    bytesPerStripe = projector->stats().numReadBytes;
+    ASSERT_EQ(result.responses[0].slices.size(), 1);
+    bytesPerStripe = projector->stats().numOutputBytes;
   }
 
   // Range [0, 500) = 5 stripes, 500 rows.
@@ -2418,7 +2413,9 @@ TEST_P(NimbleIndexProjectorTest, maxBytesAndMaxRowsInteraction) {
     EXPECT_EQ(projector->stats().numReadRows, 100);
   }
 
-  // Case 2: Byte limit is tighter (1 stripe < 500 rows).
+  // Case 2: Byte limit is tighter (1 stripe of bytes < 500 rows).
+  // Soft byte limit — planning uses raw stream sizes, so may include
+  // one extra stripe beyond the serialized-byte budget.
   {
     auto projector = createProjector(subfields);
     NimbleIndexProjector::Request request;
@@ -2430,8 +2427,8 @@ TEST_P(NimbleIndexProjectorTest, maxBytesAndMaxRowsInteraction) {
     auto result = projector->project(request, options);
     ASSERT_EQ(result.responses.size(), 1);
     ASSERT_TRUE(result.responses[0].resumeKey.has_value());
-    EXPECT_EQ(projector->stats().numReadStripes, 1);
-    EXPECT_EQ(projector->stats().numReadRows, 100);
+    EXPECT_LE(projector->stats().numReadStripes, 2);
+    EXPECT_LT(projector->stats().numReadStripes, 5);
   }
 }
 
@@ -2456,7 +2453,7 @@ TEST_P(NimbleIndexProjectorTest, maxRowsPerRequestAndGlobalMaxRows) {
     auto result = projector->project(request, options);
     ASSERT_EQ(result.responses.size(), 1);
     EXPECT_FALSE(result.responses[0].resumeKey.has_value());
-    EXPECT_EQ(projector->stats().numReadRows, 100);
+    EXPECT_EQ(projector->stats().numProjectedRows, 100);
   }
 
   // Global limit is tighter: 50 rows global vs 300 rows/request.
@@ -2491,7 +2488,7 @@ TEST_P(NimbleIndexProjectorTest, maxRowsPerRequestAndGlobalMaxRows) {
     auto result = projector->project(request, options);
     ASSERT_EQ(result.responses.size(), 1);
     EXPECT_FALSE(result.responses[0].resumeKey.has_value());
-    EXPECT_EQ(projector->stats().numReadRows, 50);
+    EXPECT_EQ(projector->stats().numProjectedRows, 50);
   }
 }
 
@@ -2523,14 +2520,14 @@ TEST_P(
     SCOPED_TRACE(fmt::format("request {}", i));
     const auto& response = result.responses[i];
     uint64_t totalRows = 0;
-    for (const auto& chunkSlice : response.chunks) {
-      totalRows += readEmbeddedRowRange(chunkSlice).numRows();
+    for (const auto& slice : response.slices) {
+      totalRows += readEmbeddedRowRange(slice).numRows();
     }
     EXPECT_EQ(totalRows, 150);
     EXPECT_FALSE(response.resumeKey.has_value());
-    ASSERT_EQ(response.chunks.size(), 2);
-    EXPECT_EQ(readEmbeddedRowRange(response.chunks[0]).numRows(), 100);
-    EXPECT_EQ(readEmbeddedRowRange(response.chunks[1]).numRows(), 50);
+    ASSERT_EQ(response.slices.size(), 2);
+    EXPECT_EQ(readEmbeddedRowRange(response.slices[0]).numRows(), 100);
+    EXPECT_EQ(readEmbeddedRowRange(response.slices[1]).numRows(), 50);
   }
 }
 
@@ -2555,9 +2552,9 @@ TEST_P(NimbleIndexProjectorTest, maxRowsPerRequestSingleRow) {
   ASSERT_EQ(result.responses.size(), 1);
   const auto& response = result.responses[0];
   EXPECT_FALSE(response.resumeKey.has_value());
-  EXPECT_EQ(projector->stats().numReadRows, 1);
-  ASSERT_EQ(response.chunks.size(), 1);
-  EXPECT_EQ(readEmbeddedRowRange(response.chunks[0]).numRows(), 1);
+  EXPECT_EQ(projector->stats().numProjectedRows, 1);
+  ASSERT_EQ(response.slices.size(), 1);
+  EXPECT_EQ(readEmbeddedRowRange(response.slices[0]).numRows(), 1);
 }
 
 TEST_P(NimbleIndexProjectorTest, maxRowsLargeScale) {
@@ -2584,7 +2581,7 @@ TEST_P(NimbleIndexProjectorTest, maxRowsLargeScale) {
       options.maxRows = maxRows;
       auto result = projector->project(request, options);
       EXPECT_EQ(result.responses.size(), 1);
-      totalReadRows += projector->stats().numReadRows;
+      totalReadRows += projector->stats().numProjectedRows;
       if (!result.responses[0].resumeKey.has_value()) {
         break;
       }
@@ -2629,19 +2626,19 @@ TEST_P(NimbleIndexProjectorTest, maxRowsMultiRequestMixedSatisfaction) {
   ASSERT_EQ(result.responses.size(), 4);
 
   // Request 0: 50 rows, fully satisfied, no resume key.
-  EXPECT_FALSE(result.responses[0].chunks.empty());
+  EXPECT_FALSE(result.responses[0].slices.empty());
   EXPECT_FALSE(result.responses[0].resumeKey.has_value());
 
   // Request 1: 100 rows, fully satisfied (ends at stripe boundary), no resume.
-  EXPECT_FALSE(result.responses[1].chunks.empty());
+  EXPECT_FALSE(result.responses[1].slices.empty());
   EXPECT_FALSE(result.responses[1].resumeKey.has_value());
 
   // Request 2: 100 rows from stripe 0, has data in stripes 1-4, resume key.
-  EXPECT_FALSE(result.responses[2].chunks.empty());
+  EXPECT_FALSE(result.responses[2].slices.empty());
   EXPECT_TRUE(result.responses[2].resumeKey.has_value());
 
   // Request 3: stripe 9 never processed, resume key = original lower key.
-  EXPECT_TRUE(result.responses[3].chunks.empty());
+  EXPECT_TRUE(result.responses[3].slices.empty());
   ASSERT_TRUE(result.responses[3].resumeKey.has_value());
   EXPECT_EQ(result.responses[3].resumeKey.value(), bounds3.lowerKey);
 }
@@ -2661,8 +2658,8 @@ TEST_P(NimbleIndexProjectorTest, maxBytesAndMaxRowsPerRequestInteraction) {
     NimbleIndexProjector::Request request;
     request.keyBounds = {bounds};
     auto result = projector->project(request, {});
-    ASSERT_EQ(result.responses[0].chunks.size(), 1);
-    bytesPerStripe = projector->stats().numReadBytes;
+    ASSERT_EQ(result.responses[0].slices.size(), 1);
+    bytesPerStripe = projector->stats().numOutputBytes;
   }
 
   // maxRowsPerRequest clips to 150 rows (mid-stripe), maxBytes allows 5
@@ -2679,10 +2676,10 @@ TEST_P(NimbleIndexProjectorTest, maxBytesAndMaxRowsPerRequestInteraction) {
     auto result = projector->project(request, options);
     ASSERT_EQ(result.responses.size(), 1);
     EXPECT_FALSE(result.responses[0].resumeKey.has_value());
-    EXPECT_EQ(projector->stats().numReadRows, 150);
+    EXPECT_EQ(projector->stats().numProjectedRows, 150);
   }
 
-  // maxBytes allows 1 stripe (100 rows), maxRowsPerRequest allows 300.
+  // maxBytes allows ~1 stripe of bytes, maxRowsPerRequest allows 300.
   // maxBytes is tighter — sets resume key.
   {
     auto projector = createProjector(subfields);
@@ -2696,8 +2693,8 @@ TEST_P(NimbleIndexProjectorTest, maxBytesAndMaxRowsPerRequestInteraction) {
     auto result = projector->project(request, options);
     ASSERT_EQ(result.responses.size(), 1);
     EXPECT_TRUE(result.responses[0].resumeKey.has_value());
-    EXPECT_EQ(projector->stats().numReadStripes, 1);
-    EXPECT_EQ(projector->stats().numReadRows, 100);
+    EXPECT_LE(projector->stats().numReadStripes, 2);
+    EXPECT_LT(projector->stats().numReadStripes, 5);
   }
 }
 
@@ -2717,8 +2714,8 @@ TEST_P(NimbleIndexProjectorTest, maxBytesLargeScale) {
     NimbleIndexProjector::Request request;
     request.keyBounds = {bounds};
     auto result = projector->project(request, {});
-    ASSERT_EQ(result.responses[0].chunks.size(), 1);
-    bytesPerStripe = projector->stats().numReadBytes;
+    ASSERT_EQ(result.responses[0].slices.size(), 1);
+    bytesPerStripe = projector->stats().numOutputBytes;
   }
 
   // Paginate all 10,000 rows with byte limit of ~3 stripes per page.
@@ -2734,7 +2731,7 @@ TEST_P(NimbleIndexProjectorTest, maxBytesLargeScale) {
     options.maxBytes = bytesPerStripe * 3;
     auto result = projector->project(request, options);
     EXPECT_EQ(result.responses.size(), 1);
-    totalReadRows += projector->stats().numReadRows;
+    totalReadRows += projector->stats().numProjectedRows;
     if (!result.responses[0].resumeKey.has_value()) {
       break;
     }
@@ -2796,7 +2793,7 @@ TEST_P(NimbleIndexProjectorTest, cacheDataReadStats) {
       request.keyBounds.push_back(std::move(bounds));
       auto result = projector->project(request, {});
       ASSERT_EQ(result.responses.size(), 1);
-      EXPECT_FALSE(result.responses[0].chunks.empty());
+      EXPECT_FALSE(result.responses[0].slices.empty());
 
       EXPECT_GT(dataIoStats_->read().count(), 0);
       EXPECT_GT(dataIoStats_->rawBytesRead(), 0);
@@ -2810,7 +2807,7 @@ TEST_P(NimbleIndexProjectorTest, cacheDataReadStats) {
       request.keyBounds.push_back(std::move(bounds));
       auto result = projector->project(request, {});
       ASSERT_EQ(result.responses.size(), 1);
-      EXPECT_FALSE(result.responses[0].chunks.empty());
+      EXPECT_FALSE(result.responses[0].slices.empty());
 
       if (testCase.expectCacheHitsOnSecondPass) {
         EXPECT_GT(dataIoStats_->ramHit().count(), 0)


### PR DESCRIPTION
Summary:
Refactors `NimbleIndexProjector::project()` into a clean 5-step pipeline: `initRequest` → `lookupStripes` → `prepareStripes` → `loadStripes` → `processStripes`, with all per-call state grouped into a `ProjectionContext` struct.

Key changes:
- **Separate planning from execution**: `prepareStripes()` pre-computes all stripe work by applying per-request and global row/byte limits upfront, locates stream positions via `locateStripeStreams()` for byte-based `maxBytes` planning, and clips row ranges to `maxRowsPerRequest` budgets — all before any IO.
- **Coalesced IO**: `loadStripes()` enqueues all projected streams across all planned stripes into `BufferedInput` and issues a single coalesced `load()` call, replacing the previous per-stripe load loop.
- **Simplified result building**: Eliminated `buildStripeResult` and `StripeSlice` intermediate struct. `processStripes()` serializes stripe bodies into `ctx_.stripeBodies`, then `buildResult()` iterates the projection plan to clone shared bodies per request and assemble output slices directly.
- **Planning-only row budget**: `rowsPerRequest` is now a local variable in `prepareStripes()` (was a class member with dual semantics). Row range clipping happens during planning; result building trusts pre-clipped ranges.
- **Global limits enforced at planning time**: Removed runtime `checkOutputLimit()` from the processing loop. `maxRows`/`maxBytes` are soft limits enforced during `prepareStripes()` using `projectedBytes` estimates. `numReadRows_`/`numReadBytes_` members eliminated.
- **ProjectionContext**: All per-`project()` call state bundled into one struct, cleared with `ctx_ = {}`.
- **Naming cleanup**: `StripeRowRange` → `StripeRange`, `StripeRangeMap` → `StripeRanges` (CSR layout with `ranges`/`offsets`/`getRanges()`), `ResultChunk` → eliminated, `response.chunks` → `response.slices`, `numReadBytes` → `numOutputBytes`, `numScannedRows` → `numReadRows` (storage rows) vs `numProjectedRows` (output rows), `StripePlan`/`ProjectionPlan` for planning structs.

This isolates the cross-stripe coalesced read path from the coroutine/io_uring work in the follow-up diff.

Reviewed By: tanjialiang

Differential Revision: D107034047


