### PR TITLE
feat(nimble): Add footerCacheHit and footerBufferUnderread to TabletReader::Stats

### DIFF
--- a/dwio/nimble/tablet/TabletReader.cpp
+++ b/dwio/nimble/tablet/TabletReader.cpp
@@ -303,6 +303,7 @@ void TabletReader::init(const Options& options) {
       velox::succinctBytes(Postscript::kSize));
 
   if (initFromCache(options)) {
+    stats_.footerCacheHit = true;
     return;
   }
 
@@ -367,6 +368,8 @@ void TabletReader::loadFooter(
     // If the speculative read didn't cover the full footer, re-read.
     const uint64_t requiredSize = ps_.footerSize() + Postscript::kSize;
     if (requiredSize > footerIoSize) {
+      stats_.footerBufferUnderread =
+          static_cast<int64_t>(requiredSize - footerIoSize);
       footerIoSize = requiredSize;
       footerOffset = fileSize_ - footerIoSize;
       ensureBuffer(footerBuf, footerIoSize, pool_);

--- a/dwio/nimble/tablet/TabletReader.cpp
+++ b/dwio/nimble/tablet/TabletReader.cpp
@@ -97,6 +97,8 @@ TabletReader::Options TabletReader::configureOptions(
   tabletOptions.cacheMetadata = options.cacheMetadata();
   tabletOptions.pinIndex = options.pinIndex();
   tabletOptions.cacheIndex = options.cacheIndex();
+  tabletOptions.fileHandle = options.fileHandle();
+  tabletOptions.cache = options.cache();
   tabletOptions.ioOptions = options;
   return tabletOptions;
 }

--- a/dwio/nimble/tablet/TabletReader.h
+++ b/dwio/nimble/tablet/TabletReader.h
@@ -308,6 +308,13 @@ class TabletReader {
     /// Bytes read beyond the footer + postscript in speculative mode.
     /// Zero in adaptive mode (exact-size read).
     int64_t footerBufferOverread{0};
+
+    /// Bytes short in speculative mode that required a second read.
+    /// Zero when the speculative read covered the full footer.
+    int64_t footerBufferUnderread{0};
+
+    /// Whether the footer was loaded from the metadata cache.
+    bool footerCacheHit{false};
   };
 
   const Stats& stats() const {

--- a/dwio/nimble/tablet/tests/TabletTest.cpp
+++ b/dwio/nimble/tablet/tests/TabletTest.cpp
@@ -4408,6 +4408,8 @@ TEST_P(TabletTest, readerOptionsAdaptiveMode) {
   EXPECT_EQ(tablet->stripeRowCount(0), 500);
   // Adaptive mode reads the exact footer size, so no bytes are wasted.
   EXPECT_EQ(tablet->stats().footerBufferOverread, 0);
+  EXPECT_EQ(tablet->stats().footerBufferUnderread, 0);
+  EXPECT_FALSE(tablet->stats().footerCacheHit);
 }
 
 TEST_P(TabletTest, readerOptionsSpeculativeMode) {
@@ -4445,6 +4447,8 @@ TEST_P(TabletTest, readerOptionsSpeculativeMode) {
   EXPECT_EQ(
       tablet->stats().footerBufferOverread,
       std::min<uint64_t>(1024, file.size()) - footerRequired);
+  EXPECT_EQ(tablet->stats().footerBufferUnderread, 0);
+  EXPECT_FALSE(tablet->stats().footerCacheHit);
 }
 
 TEST_P(TabletTest, configureOptionsIndexFlags) {

--- a/dwio/nimble/tablet/tests/TabletTest.cpp
+++ b/dwio/nimble/tablet/tests/TabletTest.cpp
@@ -4515,6 +4515,102 @@ TEST_P(TabletTest, configureOptionsIndexFlags) {
   }
 }
 
+TEST_P(TabletTest, configureOptionsCacheFields) {
+  // Verify configureOptions wires fileHandle and cache from
+  // ReaderOptions into TabletReader::Options, and that a TabletReader
+  // created via this path actually uses CachedMetadataInput (warm path
+  // reads from cache, not file). Guards against accidental removal of
+  // the cache wiring in configureOptions.
+
+  // Verify defaults are null.
+  {
+    velox::dwio::common::ReaderOptions defaults(pool_.get());
+    defaults.setDataIoStats(std::make_shared<velox::io::IoStatistics>());
+    defaults.setMetadataIoStats(std::make_shared<velox::io::IoStatistics>());
+    auto opts = nimble::TabletReader::configureOptions(defaults);
+    EXPECT_EQ(opts.fileHandle, nullptr);
+    EXPECT_EQ(opts.cache, nullptr);
+  }
+
+  // Write a simple file for the behavioral test.
+  std::string file;
+  {
+    velox::InMemoryWriteFile writeFile(&file);
+    nimble::Buffer buffer(*pool_);
+    auto tabletWriter = nimble::TabletWriter::create(&writeFile, *pool_, {});
+    std::vector<nimble::Stream> streams;
+    auto* pos = buffer.reserve(50);
+    std::memset(pos, 'a', 50);
+    streams.push_back(
+        {.offset = 0,
+         .chunks = {
+             {.rowCount = 100, .content = {std::string_view(pos, 50)}}}});
+    tabletWriter->writeStripe(100, std::move(streams));
+    tabletWriter->close();
+    writeFile.close();
+  }
+  auto readFile = std::make_shared<velox::InMemoryReadFile>(file);
+
+  auto allocator = std::make_shared<velox::memory::MallocAllocator>(
+      velox::memory::MemoryAllocator::Options{
+          .capacity = 1UL << 30, .reservationByteLimit = 0});
+  auto cache = velox::cache::AsyncDataCache::create(allocator.get());
+
+  velox::FileHandle fileHandle;
+  fileHandle.file = readFile;
+  auto& ids = velox::fileIds();
+  fileHandle.uuid =
+      velox::StringIdLease(ids, "configureOptionsCacheFieldsTest");
+  fileHandle.groupId = velox::StringIdLease(ids, "testGroup");
+
+  // Helper to create ReaderOptions with cache fields set.
+  auto makeReaderOptions =
+      [&](std::shared_ptr<velox::io::IoStatistics> metadataStats) {
+        velox::dwio::common::ReaderOptions opts(pool_.get());
+        opts.setDataIoStats(std::make_shared<velox::io::IoStatistics>());
+        opts.setMetadataIoStats(std::move(metadataStats));
+        opts.setFileHandle(&fileHandle);
+        opts.setCache(cache.get());
+        opts.setCacheMetadata(true);
+        return opts;
+      };
+
+  // Verify configureOptions propagates pointers.
+  {
+    auto readerOptions =
+        makeReaderOptions(std::make_shared<velox::io::IoStatistics>());
+    auto opts = nimble::TabletReader::configureOptions(readerOptions);
+    EXPECT_EQ(opts.fileHandle, &fileHandle);
+    EXPECT_EQ(opts.cache, cache.get());
+  }
+
+  // Cold path: first reader populates cache.
+  {
+    auto readerOptions =
+        makeReaderOptions(std::make_shared<velox::io::IoStatistics>());
+    auto opts = nimble::TabletReader::configureOptions(readerOptions);
+    auto tablet = nimble::TabletReader::create(readFile, pool_.get(), opts);
+    EXPECT_EQ(tablet->stripeCount(), 1);
+  }
+
+  auto coldStats = cache->refreshStats();
+  EXPECT_GT(coldStats.numEntries, 0);
+
+  // Warm path: second reader should initialize from cache, not file.
+  {
+    auto warmMetadataIoStats = std::make_shared<velox::io::IoStatistics>();
+    auto readerOptions = makeReaderOptions(warmMetadataIoStats);
+    auto opts = nimble::TabletReader::configureOptions(readerOptions);
+    auto tablet = nimble::TabletReader::create(readFile, pool_.get(), opts);
+    EXPECT_EQ(tablet->stripeCount(), 1);
+
+    EXPECT_GT(warmMetadataIoStats->ramHit().count(), 0);
+    EXPECT_EQ(warmMetadataIoStats->rawBytesRead(), 0);
+  }
+
+  cache->shutdown();
+}
+
 TEST_P(TabletTest, metadataInputReads) {
   std::string file;
   velox::InMemoryWriteFile writeFile(&file);

--- a/dwio/nimble/velox/selective/SelectiveNimbleReader.cpp
+++ b/dwio/nimble/velox/selective/SelectiveNimbleReader.cpp
@@ -328,8 +328,10 @@ uint64_t SelectiveNimbleRowReader::next(
 void SelectiveNimbleRowReader::updateRuntimeStats(
     dwio::common::RuntimeStatistics& stats) const {
   stats.skippedStrides += skippedStripes_;
-  stats.footerBufferOverread +=
-      readerBase_->tablet().stats().footerBufferOverread;
+  const auto& tabletStats = readerBase_->tablet().stats();
+  stats.footerBufferOverread += tabletStats.footerBufferOverread;
+  stats.footerBufferUnderread += tabletStats.footerBufferUnderread;
+  stats.footerCacheHit += tabletStats.footerCacheHit ? 1 : 0;
   stats.columnReaderStats.mergeFrom(columnReaderStatistics_);
 }
 


### PR DESCRIPTION
Summary: Wire `footerCacheHit` and `footerBufferUnderread` into `TabletReader::Stats` and propagate them to `RuntimeStatistics` via `SelectiveNimbleRowReader::updateRuntimeStats()`. `footerCacheHit` reports whether the footer was loaded from metadata cache. `footerBufferUnderread` reports the bytes short when a speculative read was too small, requiring a second read.

Reviewed By: xiaoxmeng

Differential Revision: D107174823


