### PR TITLE
perf: Add FixedBitArray::bulkSet64WithBaseline for 64-bit bulk packing (#821)

### DIFF
--- a/dwio/nimble/common/FixedBitArray.cpp
+++ b/dwio/nimble/common/FixedBitArray.cpp
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 #include "dwio/nimble/common/FixedBitArray.h"
+
 #include <glog/logging.h>
 
 namespace facebook::nimble {
@@ -21,8 +22,8 @@ namespace facebook::nimble {
 // Warning: do not change this function or lots of horrible data corruption
 // will probably happen.
 uint64_t FixedBitArray::bufferSize(uint64_t elementCount, int bitWidth) {
-  // We may read up to 7 bytes beyond the last theoretically needed byte,
-  // as we access whole machine words.
+  // We may read or write up to 7 bytes beyond the last theoretically needed
+  // byte, as we access whole machine words.
   constexpr int kSlopSize = 7;
   return velox::bits::nbytes(elementCount * bitWidth) + kSlopSize;
 }
@@ -105,7 +106,7 @@ void FixedBitArray::zeroAndSet(uint64_t index, uint64_t value) {
   word |= value << remainder;
 }
 
-namespace internal {
+namespace {
 
 // T is the output data types, namely uint32_t or uint64_t.
 template <typename T, int bitWidth, int loopPosition, bool withBaseline>
@@ -322,20 +323,52 @@ void bulkGet32Internal(
   return;
 }
 
-} // namespace internal
+template <int byteWidth>
+inline void bulkSetByteAlignedWithBaseline(
+    char* buffer,
+    uint64_t start,
+    uint64_t length,
+    const uint64_t* values,
+    uint64_t baseline) {
+  static_assert(byteWidth >= 4 && byteWidth <= 8);
+  char* next = buffer + start * byteWidth;
+  const uint64_t* nextValue = values;
+  for (uint64_t i = 0; i < length; ++i) {
+    const uint64_t residual{*nextValue++ - baseline};
+    if constexpr (byteWidth == 4) {
+      *reinterpret_cast<uint32_t*>(next) = static_cast<uint32_t>(residual);
+    } else if constexpr (byteWidth == 5) {
+      *reinterpret_cast<uint32_t*>(next) = static_cast<uint32_t>(residual);
+      next[4] = static_cast<char>(residual >> 32);
+    } else if constexpr (byteWidth == 6) {
+      *reinterpret_cast<uint32_t*>(next) = static_cast<uint32_t>(residual);
+      *reinterpret_cast<uint16_t*>(next + 4) =
+          static_cast<uint16_t>(residual >> 32);
+    } else if constexpr (byteWidth == 7) {
+      *reinterpret_cast<uint32_t*>(next) = static_cast<uint32_t>(residual);
+      *reinterpret_cast<uint16_t*>(next + 4) =
+          static_cast<uint16_t>(residual >> 32);
+      next[6] = static_cast<char>(residual >> 48);
+    } else {
+      static_assert(byteWidth == 8);
+      *reinterpret_cast<uint64_t*>(next) = residual;
+    }
+    next += byteWidth;
+  }
+}
+
+} // namespace
 
 void FixedBitArray::bulkGet32(uint64_t start, uint64_t length, uint32_t* values)
     const {
-  internal::bulkGet32Internal<uint32_t, false>(
-      *this, buffer_, start, length, values, 0);
+  bulkGet32Internal<uint32_t, false>(*this, buffer_, start, length, values, 0);
 }
 
 void FixedBitArray::bulkGet32Into64(
     uint64_t start,
     uint64_t length,
     uint64_t* values) const {
-  internal::bulkGet32Internal<uint64_t, false>(
-      *this, buffer_, start, length, values, 0);
+  bulkGet32Internal<uint64_t, false>(*this, buffer_, start, length, values, 0);
 }
 
 void FixedBitArray::bulkGetWithBaseline32(
@@ -343,7 +376,7 @@ void FixedBitArray::bulkGetWithBaseline32(
     uint64_t length,
     uint32_t* values,
     uint32_t baseline) const {
-  internal::bulkGet32Internal<uint32_t, true>(
+  bulkGet32Internal<uint32_t, true>(
       *this, buffer_, start, length, values, baseline);
 }
 
@@ -352,7 +385,7 @@ void FixedBitArray::bulkGetWithBaseline32Into64(
     uint64_t length,
     uint64_t* values,
     uint64_t baseline) const {
-  internal::bulkGet32Internal<uint64_t, true>(
+  bulkGet32Internal<uint64_t, true>(
       *this, buffer_, start, length, values, baseline);
 }
 
@@ -386,11 +419,17 @@ void FixedBitArray::bulkGet64WithBaseline(
   }
 }
 
-template <int bitWidth, int loopPosition, bool withBaseline>
+namespace {
+
+template <
+    int bitWidth,
+    int loopPosition,
+    bool withBaseline,
+    typename InputT = uint32_t>
 void bulkSet32Loop(
     uint64_t** nextWord,
-    const uint32_t** values,
-    uint32_t baseline) {
+    const InputT** values,
+    InputT baseline) {
   // Some bits for the next value may need to put be in the current word.
   constexpr int spillover = (loopPosition * bitWidth) % 64 == 0
       ? 0
@@ -427,19 +466,26 @@ void bulkSet32Loop(
     ++(*values);
   }
   constexpr int nextLoopPosition = loopPosition + valueCount + (spillover > 0);
-  bulkSet32Loop<bitWidth, nextLoopPosition, withBaseline>(
+  bulkSet32Loop<bitWidth, nextLoopPosition, withBaseline, InputT>(
       nextWord, values, baseline);
 }
 
 // Unfortunately we cannot partially specialize the template for the
 // terminal case of loopPosition = 64 so we must explicitly specify them.
+// Only the (uint32_t, false/true) and (uint64_t, true) cases are
+// instantiated; bulkSet64WithBaseline always uses withBaseline=true, so
+// the (uint64_t, false) case is intentionally omitted to avoid unused
+// function lints.
 #define BULK_SET32_LOOP_TERMINAL_CASE(bitWidth)                           \
   template <>                                                             \
-  void bulkSet32Loop<bitWidth, 64, false>(                                \
+  void bulkSet32Loop<bitWidth, 64, false, uint32_t>(                      \
       uint64_t** nextWord, const uint32_t** values, uint32_t baseline) {} \
   template <>                                                             \
-  void bulkSet32Loop<bitWidth, 64, true>(                                 \
-      uint64_t** nextWord, const uint32_t** values, uint32_t baseline) {}
+  void bulkSet32Loop<bitWidth, 64, true, uint32_t>(                       \
+      uint64_t** nextWord, const uint32_t** values, uint32_t baseline) {} \
+  template <>                                                             \
+  void bulkSet32Loop<bitWidth, 64, true, uint64_t>(                       \
+      uint64_t** nextWord, const uint64_t** values, uint64_t baseline) {}
 
 BULK_SET32_LOOP_TERMINAL_CASE(1)
 BULK_SET32_LOOP_TERMINAL_CASE(2)
@@ -476,55 +522,56 @@ BULK_SET32_LOOP_TERMINAL_CASE(32)
 
 #undef BULK_SET32_LOOP_TERMINAL_CASE
 
-template <bool withBaseline>
+template <bool withBaseline, typename InputT = uint32_t>
 void bulkSetInternal32(
     FixedBitArray& fixedBitArray,
     char* buffer,
     uint64_t start,
     uint64_t length,
-    const uint32_t* values,
-    uint32_t baseline) {
+    const InputT* values,
+    InputT baseline) {
   // Same general logic as BulkGet32. See the comments there.
   switch (fixedBitArray.bitWidth()) {
-#define BULK_SET32_SWITCH_CASE(bitWidth)                                      \
-  case bitWidth: {                                                            \
-    const uint64_t alignedStart = velox::bits::divRoundUp(start, 64) << 6;    \
-    if (start + length < alignedStart) {                                      \
-      for (uint64_t i = start; i < start + length; ++i) {                     \
-        if constexpr (withBaseline) {                                         \
-          fixedBitArray.set32(i, (*values) - baseline);                       \
-        } else {                                                              \
-          fixedBitArray.set32(i, *values);                                    \
-        }                                                                     \
-        ++values;                                                             \
-      }                                                                       \
-      return;                                                                 \
-    }                                                                         \
-    for (uint64_t i = start; i < alignedStart; ++i) {                         \
-      if constexpr (withBaseline) {                                           \
-        fixedBitArray.set32(i, (*values) - baseline);                         \
-      } else {                                                                \
-        fixedBitArray.set32(i, *values);                                      \
-      }                                                                       \
-      ++values;                                                               \
-    }                                                                         \
-    const uint64_t loopCount = (length - (alignedStart - start)) >> 6;        \
-    uint64_t* nextWord = reinterpret_cast<uint64_t*>(                         \
-        buffer + ((alignedStart * bitWidth) >> 3) - 8);                       \
-    for (uint64_t i = 0; i < loopCount; ++i) {                                \
-      bulkSet32Loop<bitWidth, 0, withBaseline>(&nextWord, &values, baseline); \
-    }                                                                         \
-    const uint64_t remainderStart = alignedStart + (loopCount << 6);          \
-    const uint64_t remainderEnd = start + length;                             \
-    for (uint64_t i = remainderStart; i < remainderEnd; ++i) {                \
-      if constexpr (withBaseline) {                                           \
-        fixedBitArray.set32(i, (*values) - baseline);                         \
-      } else {                                                                \
-        fixedBitArray.set32(i, *values);                                      \
-      }                                                                       \
-      ++values;                                                               \
-    }                                                                         \
-    return;                                                                   \
+#define BULK_SET32_SWITCH_CASE(bitWidth)                                     \
+  case bitWidth: {                                                           \
+    const uint64_t alignedStart = velox::bits::divRoundUp(start, 64) << 6;   \
+    if (start + length < alignedStart) {                                     \
+      for (uint64_t i = start; i < start + length; ++i) {                    \
+        if constexpr (withBaseline) {                                        \
+          fixedBitArray.set32(i, static_cast<uint32_t>(*values - baseline)); \
+        } else {                                                             \
+          fixedBitArray.set32(i, static_cast<uint32_t>(*values));            \
+        }                                                                    \
+        ++values;                                                            \
+      }                                                                      \
+      return;                                                                \
+    }                                                                        \
+    for (uint64_t i = start; i < alignedStart; ++i) {                        \
+      if constexpr (withBaseline) {                                          \
+        fixedBitArray.set32(i, static_cast<uint32_t>(*values - baseline));   \
+      } else {                                                               \
+        fixedBitArray.set32(i, static_cast<uint32_t>(*values));              \
+      }                                                                      \
+      ++values;                                                              \
+    }                                                                        \
+    const uint64_t loopCount = (length - (alignedStart - start)) >> 6;       \
+    uint64_t* nextWord = reinterpret_cast<uint64_t*>(                        \
+        buffer + ((alignedStart * bitWidth) >> 3) - 8);                      \
+    for (uint64_t i = 0; i < loopCount; ++i) {                               \
+      bulkSet32Loop<bitWidth, 0, withBaseline, InputT>(                      \
+          &nextWord, &values, baseline);                                     \
+    }                                                                        \
+    const uint64_t remainderStart = alignedStart + (loopCount << 6);         \
+    const uint64_t remainderEnd = start + length;                            \
+    for (uint64_t i = remainderStart; i < remainderEnd; ++i) {               \
+      if constexpr (withBaseline) {                                          \
+        fixedBitArray.set32(i, static_cast<uint32_t>(*values - baseline));   \
+      } else {                                                               \
+        fixedBitArray.set32(i, static_cast<uint32_t>(*values));              \
+      }                                                                      \
+      ++values;                                                              \
+    }                                                                        \
+    return;                                                                  \
   }
 
     BULK_SET32_SWITCH_CASE(1)
@@ -568,11 +615,13 @@ void bulkSetInternal32(
   }
 }
 
+} // namespace
+
 void FixedBitArray::bulkSet32(
     uint64_t start,
     uint64_t length,
     const uint32_t* values) {
-  bulkSetInternal32<false>(*this, buffer_, start, length, values, 0);
+  bulkSetInternal32<false, uint32_t>(*this, buffer_, start, length, values, 0);
 }
 
 void FixedBitArray::bulkSet32WithBaseline(
@@ -582,6 +631,91 @@ void FixedBitArray::bulkSet32WithBaseline(
     uint32_t baseline) {
   bulkSetInternal32<true>(*this, buffer_, start, length, values, baseline);
 }
+
+void FixedBitArray::bulkSet64WithBaseline(
+    uint64_t start,
+    uint64_t length,
+    const uint64_t* values,
+    uint64_t baseline) {
+  const int bitWidth = bitWidth_;
+  if (bitWidth < 32) {
+    bulkSetInternal32<true, uint64_t>(
+        *this, buffer_, start, length, values, baseline);
+    return;
+  }
+
+  switch (bitWidth) {
+    case 32: {
+      bulkSetByteAlignedWithBaseline<4>(
+          buffer_, start, length, values, baseline);
+      return;
+    }
+    case 40: {
+      bulkSetByteAlignedWithBaseline<5>(
+          buffer_, start, length, values, baseline);
+      return;
+    }
+    case 48: {
+      bulkSetByteAlignedWithBaseline<6>(
+          buffer_, start, length, values, baseline);
+      return;
+    }
+    case 56: {
+      bulkSetByteAlignedWithBaseline<7>(
+          buffer_, start, length, values, baseline);
+      return;
+    }
+    case 64: {
+      if (baseline == 0) {
+        std::memcpy(
+            buffer_ + start * sizeof(uint64_t),
+            values,
+            length * sizeof(uint64_t));
+        return;
+      }
+      bulkSetByteAlignedWithBaseline<8>(
+          buffer_, start, length, values, baseline);
+      return;
+    }
+    default:
+      break;
+  }
+
+  char* const buffer = buffer_;
+  uint64_t bits = start * static_cast<uint64_t>(bitWidth);
+  if (bitWidth <= 58) {
+    const uint64_t* nextValue = values;
+    for (uint64_t i = 0; i < length; ++i) {
+      const uint64_t residual = *nextValue++ - baseline;
+      const uint64_t offset = bits >> 3;
+      const uint64_t remainder = bits & 7;
+      uint64_t& word = *reinterpret_cast<uint64_t*>(buffer + offset);
+      word |= residual << remainder;
+      bits += bitWidth;
+    }
+    return;
+  }
+
+  // For wide values, the residual can straddle two 64-bit words when the
+  // starting bit offset is not byte/word aligned. Write the low bits into the
+  // current word and spill the remaining high bits into the next word.
+  const uint64_t* nextValue = values;
+  for (uint64_t i = 0; i < length; ++i) {
+    const uint64_t residual = *nextValue++ - baseline;
+    const uint64_t offset = bits >> 3;
+    const uint64_t remainder = bits & 7;
+    uint64_t& word = *reinterpret_cast<uint64_t*>(buffer + offset);
+    word |= residual << remainder;
+    const int overflow = bitWidth + static_cast<int>(remainder) - 64;
+    if (overflow > 0) {
+      uint64_t& nextWord = *reinterpret_cast<uint64_t*>(buffer + offset + 8);
+      nextWord |= residual >> (bitWidth - overflow);
+    }
+    bits += bitWidth;
+  }
+}
+
+namespace {
 
 template <int bitWidth, int loopPosition>
 void equals32Loop(
@@ -665,6 +799,8 @@ EQUALS32_TERMINAL_CASE(31)
 EQUALS32_TERMINAL_CASE(32)
 
 #undef EQUALS32_TERMINAL_CASE
+
+} // namespace
 
 void FixedBitArray::equals32(
     uint64_t start,

--- a/dwio/nimble/common/FixedBitArray.h
+++ b/dwio/nimble/common/FixedBitArray.h
@@ -17,119 +17,134 @@
 
 #include "velox/common/base/BitUtil.h"
 
-// Packs integers into a fixed number (1-64) of bits and retrieves them.
-// The 'bulk' API provided is particularly efficient at setting/getting
-// ranges of values with small bit widths.
-//
-// Typical usage:
-//   std::vector<uint32_t> data = ...
-//   int bitsRequired = BitsRequired(*maxElement(data.begin(), data.end());
-//   auto buffer = std::make_unique<char[]>(
-//        FixedBitArray::BufferSize(data.size(), bitsRequired));
-//   FixedBitArray fixedBitArray(buffer.get(), bitsRequired);
-//   fixedBitArray.bulkSet32(0, data.size(), data.data());
-//
-// And then you'd store the buffer somewhere, and later read the values back,
-// recovering the info stored in data. Note that the FBA does not own
-// any data.
+/// Packs integers into a fixed number (1-64) of bits and retrieves them.
+/// The 'bulk' API provided is particularly efficient at setting/getting
+/// ranges of values with small bit widths.
+///
+/// Typical usage:
+///   std::vector<uint32_t> data = ...
+///   int bitsRequired = BitsRequired(*maxElement(data.begin(), data.end());
+///   auto buffer = std::make_unique<char[]>(
+///        FixedBitArray::BufferSize(data.size(), bitsRequired));
+///   FixedBitArray fixedBitArray(buffer.get(), bitsRequired);
+///   fixedBitArray.bulkSet32(0, data.size(), data.data());
+///
+/// And then you'd store the buffer somewhere, and later read the values back,
+/// recovering the info stored in data. Note that the FBA does not own
+/// any data.
 
 namespace facebook::nimble {
 
 class FixedBitArray {
  public:
-  // Computes the buffer size needed to hold |elementCount| values with the
-  // specified |bitWidth|. Note that we allocate a few bytes of 'slop' space
-  // beyond what is mathematically required to speed things up.
+  /// Computes the buffer size needed to hold |elementCount| values with the
+  /// specified |bitWidth|. Note that we allocate a few bytes of 'slop' space
+  /// beyond what is mathematically required to speed things up.
   static uint64_t bufferSize(uint64_t elementCount, int bitWidth);
 
-  // Not legal to use; included so we can default construct on the stack.
+  /// Not legal to use; included so we can default construct on the stack.
   FixedBitArray() = default;
 
-  // Creates a fixed bit array stored at buffer whose elements can lie within
-  // the range [0, 2^|bitWidth|). The |buffer| must already be preallocated to
-  // the appropriate size, as given by BufferSize.
+  /// Creates a fixed bit array stored at buffer whose elements can lie within
+  /// the range [0, 2^|bitWidth|). The |buffer| must already be preallocated to
+  /// the appropriate size, as given by BufferSize.
   FixedBitArray(char* buffer, int bitWidth);
 
-  // Convenience constructor for reading read-only data. Note that you are NOT
-  // prevented by the code from using the non-const calls on a FBA constructed
-  // via this method, but to do so is undefined behavior.
+  /// Convenience constructor for reading read-only data. Note that you are NOT
+  /// prevented by the code from using the non-const calls on a FBA constructed
+  /// via this method, but to do so is undefined behavior.
   FixedBitArray(std::string_view buffer, int bitWidth)
       : FixedBitArray(const_cast<char*>(buffer.data()), bitWidth) {}
 
-  // Sets the |index|'th slot to the given |value|. If value
-  // is >= 2^|bitWidth| behavior is undefined.
-  //
-  // IMPORTANT NOTE: this does NOT function as normal assignment.
-  // We do NOT first 0 out the slot, i.e. we use or semantics.
-  // If you need to first 0 it out, use ZeroAndSet.
+  /// Sets the |index|'th slot to the given |value|. If value
+  /// is >= 2^|bitWidth| behavior is undefined.
+  ///
+  /// IMPORTANT NOTE: this does NOT function as normal assignment.
+  /// We do NOT first 0 out the slot, i.e. we use or semantics.
+  /// If you need to first 0 it out, use ZeroAndSet.
   void set(uint64_t index, uint64_t value);
 
-  // Zeroes a slot and then sets it (like normal assignment).
+  /// Zeroes a slot and then sets it (like normal assignment).
   void zeroAndSet(uint64_t index, uint64_t value);
 
-  // Gets the |index|'th value.
+  /// Gets the |index|'th value.
   uint64_t get(uint64_t index) const;
 
-  // Versions of set/get that only work with bitWidth <= 32, but are slightly
-  // faster. Same assignment caveat applies to set32 as to set.
+  /// Versions of set/get that only work with bitWidth <= 32, but are slightly
+  /// faster. Same assignment caveat applies to set32 as to set.
   void set32(uint64_t index, uint32_t value);
+
   uint32_t get32(uint64_t index) const;
 
-  // Retrieves a contiguous subarray from slots [start, start + length).
-  // Considerably faster than looping a get call. Only callable when
-  // bit width <= 32.
+  /// Retrieves a contiguous subarray from slots [start, start + length).
+  /// Considerably faster than looping a get call. Only callable when
+  /// bit width <= 32.
   void bulkGet32(uint64_t start, uint64_t length, uint32_t* values) const;
 
-  // Same as above, but outputs into 8-bytes values. Still requires that bit
-  // width <= 32.
+  /// Same as above, but outputs into 8-bytes values. Still requires that bit
+  /// width <= 32.
   void bulkGet32Into64(uint64_t start, uint64_t length, uint64_t* values) const;
 
-  // Same as above. Add baseline to every value.
+  /// Same as above. Add baseline to every value.
   void bulkGetWithBaseline32(
       uint64_t start,
       uint64_t length,
       uint32_t* values,
       uint32_t baseline) const;
 
-  // Same as above. Add baseline to every value.
+  /// Same as above. Add baseline to every value.
   void bulkGetWithBaseline32Into64(
       uint64_t start,
       uint64_t length,
       uint64_t* values,
       uint64_t baseline) const;
 
-  // Retrieves a contiguous subarray from slots [start, start + length) into
-  // 64-bit output values, adding baseline to each. Supports any bit width
-  // up to 64. For bitWidth <= 32, delegates to the optimized bulkGet32 path.
-  // For bitWidth 33-57, uses branchless byte-aligned loads (single 64-bit
-  // load per value). For bitWidth > 57, handles cross-word boundary overflow.
+  /// Retrieves a contiguous subarray from slots [start, start + length) into
+  /// 64-bit output values, adding baseline to each. Supports any bit width
+  /// up to 64. For bitWidth <= 32, delegates to the optimized bulkGet32 path.
+  /// For bitWidth 33-57, uses branchless byte-aligned loads (single 64-bit
+  /// load per value). For bitWidth > 57, handles cross-word boundary overflow.
   void bulkGet64WithBaseline(
       uint64_t start,
       uint64_t length,
       uint64_t* values,
       uint64_t baseline) const;
 
-  // Sets a contiguous subarray of slots from [start, start + length).
-  // Considerably faster than looping/ a get call. Only callable when bitWidth
-  // <= 32. Same semantics as set -- see the warning there.
+  /// Sets a contiguous subarray of slots from [start, start + length).
+  /// Considerably faster than looping set calls. Only callable when bitWidth
+  /// <= 32. Same semantics as set -- see the warning there.
   void bulkSet32(uint64_t start, uint64_t length, const uint32_t* values);
 
-  // Same as above. Subtracts baseline from every value.
+  /// Same as above. Subtracts baseline from every value.
   void bulkSet32WithBaseline(
       uint64_t start,
       uint64_t length,
       const uint32_t* values,
       uint32_t baseline);
 
-  // Fills in the bit-packed |bitVector| with whether each value in
-  // [start, start + length) equals |value|. Should be faster than
-  // doing bulkGet32 and then doing your own equality check + bitpack.
-  //
-  // bitVector must point to a buffer of at least size BufferSize(length, 1);
-  //
-  // REQUIRES: start is a multiple of 64. If you need to run equals on
-  // a range where that isn't true, you'll have to manually do the part
-  // up to the first multiple of 64 yourself + adjust the results accordingly.
+  /// Sets a contiguous subarray of slots from [start, start + length),
+  /// subtracting baseline from each 64-bit value before packing. Supports any
+  /// value where values[i] >= baseline and values[i] - baseline fits in the
+  /// bit width up to 64. For bitWidth < 32, delegates to the optimized
+  /// bulkSet32 path. For byte-aligned bit widths 32, 40, 48, 56, and 64, uses
+  /// direct stores. Other bit widths up to 58 use a single 64-bit OR per
+  /// value. For bitWidth 59-63, handles cross-word boundary overflow.
+  /// Requires the same zeroed-buffer precondition as set.
+  void bulkSet64WithBaseline(
+      uint64_t start,
+      uint64_t length,
+      const uint64_t* values,
+      uint64_t baseline);
+
+  /// Fills in the bit-packed |bitVector| with whether each value in
+  /// [start, start + length) equals |value|. Should be faster than
+  /// doing bulkGet32 and then doing your own equality check + bitpack.
+  ///
+  /// bitVector must point to a buffer of at least size BufferSize(length, 1);
+  ///
+  /// REQUIRES: start is a multiple of 64. If you need to run equals on
+  /// a range where that isn't true, you'll have to manually do the part
+  /// up to the first multiple of 64 yourself + adjust the results accordingly.
   void equals32(
       uint64_t start,
       uint64_t length,

--- a/dwio/nimble/common/benchmarks/FixedBitArrayBenchmark.cpp
+++ b/dwio/nimble/common/benchmarks/FixedBitArrayBenchmark.cpp
@@ -1,0 +1,176 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include <cstring>
+#include <memory>
+#include <vector>
+
+#include "dwio/nimble/common/FixedBitArray.h"
+#include "folly/Benchmark.h"
+#include "folly/init/Init.h"
+
+using namespace ::facebook;
+
+namespace {
+
+constexpr uint64_t kNumElements = 1000 * 1000;
+constexpr uint64_t kBaseline = 12345;
+constexpr uint64_t kStartOffset = 37;
+
+uint64_t maskForBitWidth(int bitWidth) {
+  return bitWidth == 64 ? ~0ULL : ((1ULL << bitWidth) - 1);
+}
+
+std::vector<uint64_t> makeValues(int bitWidth) {
+  const uint64_t mask = maskForBitWidth(bitWidth);
+  const uint64_t baseline = bitWidth == 64 ? 0 : kBaseline;
+  std::vector<uint64_t> values(kNumElements);
+  for (uint64_t i = 0; i < kNumElements; ++i) {
+    const uint64_t residual = (i * 1000003ULL) & mask;
+    values[i] = residual + baseline;
+  }
+  return values;
+}
+
+void clearBuffer(char* _Nonnull buffer, uint64_t bufferBytes) {
+  std::memset(buffer, 0, bufferBytes);
+}
+
+void observeWrittenBuffer(
+    const char* buffer,
+    uint64_t elementCount,
+    int bitWidth) {
+  const uint64_t writtenBytes =
+      ((elementCount * static_cast<uint64_t>(bitWidth)) + 7) >> 3;
+  folly::doNotOptimizeAway(buffer[writtenBytes - 1]);
+}
+
+#define FIXED_BIT_ARRAY_BENCHMARKS(bitWidth)                                   \
+  BENCHMARK(BulkSet64WithBaseline_##bitWidth, iters) {                         \
+    std::vector<uint64_t> values;                                              \
+    std::unique_ptr<char[]> buffer;                                            \
+    uint64_t bufferBytes;                                                      \
+    BENCHMARK_SUSPEND {                                                        \
+      values = makeValues(bitWidth);                                           \
+      bufferBytes = nimble::FixedBitArray::bufferSize(kNumElements, bitWidth); \
+      buffer = std::make_unique<char[]>(bufferBytes);                          \
+    }                                                                          \
+    nimble::FixedBitArray fixedBitArray(buffer.get(), bitWidth);               \
+    const uint64_t baseline = bitWidth == 64 ? 0 : kBaseline;                  \
+    while (iters--) {                                                          \
+      BENCHMARK_SUSPEND {                                                      \
+        clearBuffer(buffer.get(), bufferBytes);                                \
+      }                                                                        \
+      fixedBitArray.bulkSet64WithBaseline(                                     \
+          0, kNumElements, values.data(), baseline);                           \
+      observeWrittenBuffer(buffer.get(), kNumElements, bitWidth);              \
+    }                                                                          \
+  }                                                                            \
+  BENCHMARK_RELATIVE(ScalarSetWithBaseline_##bitWidth, iters) {                \
+    std::vector<uint64_t> values;                                              \
+    std::unique_ptr<char[]> buffer;                                            \
+    uint64_t bufferBytes;                                                      \
+    BENCHMARK_SUSPEND {                                                        \
+      values = makeValues(bitWidth);                                           \
+      bufferBytes = nimble::FixedBitArray::bufferSize(kNumElements, bitWidth); \
+      buffer = std::make_unique<char[]>(bufferBytes);                          \
+    }                                                                          \
+    nimble::FixedBitArray fixedBitArray(buffer.get(), bitWidth);               \
+    const uint64_t baseline = bitWidth == 64 ? 0 : kBaseline;                  \
+    while (iters--) {                                                          \
+      BENCHMARK_SUSPEND {                                                      \
+        clearBuffer(buffer.get(), bufferBytes);                                \
+      }                                                                        \
+      const uint64_t* nextValue = values.data();                               \
+      for (uint64_t i = 0; i < kNumElements; ++i) {                            \
+        fixedBitArray.set(i, *nextValue - baseline);                           \
+        ++nextValue;                                                           \
+      }                                                                        \
+      observeWrittenBuffer(buffer.get(), kNumElements, bitWidth);              \
+    }                                                                          \
+  }
+
+#define FIXED_BIT_ARRAY_OFFSET_SET_BENCHMARKS(bitWidth)               \
+  BENCHMARK(BulkSet64WithBaselineOffset_##bitWidth, iters) {          \
+    std::vector<uint64_t> values;                                     \
+    std::unique_ptr<char[]> buffer;                                   \
+    uint64_t bufferBytes;                                             \
+    BENCHMARK_SUSPEND {                                               \
+      values = makeValues(bitWidth);                                  \
+      bufferBytes = nimble::FixedBitArray::bufferSize(                \
+          kStartOffset + kNumElements, bitWidth);                     \
+      buffer = std::make_unique<char[]>(bufferBytes);                 \
+    }                                                                 \
+    nimble::FixedBitArray fixedBitArray(buffer.get(), bitWidth);      \
+    const uint64_t baseline = bitWidth == 64 ? 0 : kBaseline;         \
+    while (iters--) {                                                 \
+      BENCHMARK_SUSPEND {                                             \
+        clearBuffer(buffer.get(), bufferBytes);                       \
+      }                                                               \
+      fixedBitArray.bulkSet64WithBaseline(                            \
+          kStartOffset, kNumElements, values.data(), baseline);       \
+      observeWrittenBuffer(                                           \
+          buffer.get(), kStartOffset + kNumElements, bitWidth);       \
+    }                                                                 \
+  }                                                                   \
+  BENCHMARK_RELATIVE(ScalarSetWithBaselineOffset_##bitWidth, iters) { \
+    std::vector<uint64_t> values;                                     \
+    std::unique_ptr<char[]> buffer;                                   \
+    uint64_t bufferBytes;                                             \
+    BENCHMARK_SUSPEND {                                               \
+      values = makeValues(bitWidth);                                  \
+      bufferBytes = nimble::FixedBitArray::bufferSize(                \
+          kStartOffset + kNumElements, bitWidth);                     \
+      buffer = std::make_unique<char[]>(bufferBytes);                 \
+    }                                                                 \
+    nimble::FixedBitArray fixedBitArray(buffer.get(), bitWidth);      \
+    const uint64_t baseline = bitWidth == 64 ? 0 : kBaseline;         \
+    while (iters--) {                                                 \
+      BENCHMARK_SUSPEND {                                             \
+        clearBuffer(buffer.get(), bufferBytes);                       \
+      }                                                               \
+      const uint64_t* nextValue = values.data();                      \
+      for (uint64_t i = 0; i < kNumElements; ++i) {                   \
+        fixedBitArray.set(kStartOffset + i, *nextValue - baseline);   \
+        ++nextValue;                                                  \
+      }                                                               \
+      observeWrittenBuffer(                                           \
+          buffer.get(), kStartOffset + kNumElements, bitWidth);       \
+    }                                                                 \
+  }
+
+FIXED_BIT_ARRAY_BENCHMARKS(16)
+FIXED_BIT_ARRAY_BENCHMARKS(32)
+FIXED_BIT_ARRAY_BENCHMARKS(33)
+FIXED_BIT_ARRAY_BENCHMARKS(40)
+FIXED_BIT_ARRAY_BENCHMARKS(48)
+FIXED_BIT_ARRAY_BENCHMARKS(56)
+FIXED_BIT_ARRAY_BENCHMARKS(57)
+FIXED_BIT_ARRAY_BENCHMARKS(58)
+FIXED_BIT_ARRAY_BENCHMARKS(60)
+FIXED_BIT_ARRAY_BENCHMARKS(64)
+
+FIXED_BIT_ARRAY_OFFSET_SET_BENCHMARKS(32)
+FIXED_BIT_ARRAY_OFFSET_SET_BENCHMARKS(40)
+FIXED_BIT_ARRAY_OFFSET_SET_BENCHMARKS(48)
+FIXED_BIT_ARRAY_OFFSET_SET_BENCHMARKS(56)
+FIXED_BIT_ARRAY_OFFSET_SET_BENCHMARKS(64)
+
+} // namespace
+
+int main(int argc, char** argv) {
+  folly::Init init(&argc, &argv);
+  folly::runBenchmarks();
+}

--- a/dwio/nimble/common/tests/FixedBitArrayTests.cpp
+++ b/dwio/nimble/common/tests/FixedBitArrayTests.cpp
@@ -460,3 +460,103 @@ TEST(FixedBitArrayTests, Equals32Random) {
     }
   }
 }
+
+TEST(FixedBitArrayTests, bulkSet64WithBaseline) {
+  auto seed = folly::Random::rand32();
+  LOG(INFO) << "seed: " << seed;
+  std::mt19937 rng(seed);
+
+  // Test all three code paths:
+  // - bitWidth <= 32: delegates to template-unrolled bulkSetInternal32
+  // - bitWidth 33-58: branchless byte-aligned stores
+  // - bitWidth > 58: inline cross-word boundary handling
+  for (int bitWidth = 1; bitWidth <= 64; ++bitWidth) {
+    SCOPED_TRACE(fmt::format("bitWidth={}", bitWidth));
+    const uint64_t maxElement = bitWidth == 64
+        ? std::numeric_limits<uint64_t>::max()
+        : (1ULL << bitWidth) - 1;
+    const uint64_t baseline = folly::Random::rand64(rng) % (maxElement / 2 + 1);
+    const uint64_t valueRange = maxElement - baseline;
+
+    for (int test = 0; test < kNumTestsPerBitWidth; ++test) {
+      const int elementCount = 1 + folly::Random::rand32(rng) % kMaxElements;
+      const auto bufferBytes =
+          nimble::FixedBitArray::bufferSize(elementCount, bitWidth);
+      auto buffer = std::make_unique<char[]>(bufferBytes);
+      std::memset(buffer.get(), 0, bufferBytes);
+      nimble::FixedBitArray fixedBitArray(buffer.get(), bitWidth);
+
+      std::vector<uint64_t> inputValues(elementCount);
+      std::vector<uint64_t> expectedResiduals(elementCount);
+      for (int i = 0; i < elementCount; ++i) {
+        expectedResiduals[i] =
+            valueRange == std::numeric_limits<uint64_t>::max()
+            ? folly::Random::rand64(rng)
+            : folly::Random::rand64(rng) % (valueRange + 1);
+        inputValues[i] = expectedResiduals[i] + baseline;
+      }
+
+      fixedBitArray.bulkSet64WithBaseline(
+          0, elementCount, inputValues.data(), baseline);
+
+      for (int i = 0; i < elementCount; ++i) {
+        ASSERT_EQ(fixedBitArray.get(i), expectedResiduals[i]) << "i=" << i;
+      }
+
+      std::vector<uint64_t> recovered(elementCount);
+      fixedBitArray.bulkGet64WithBaseline(
+          0, elementCount, recovered.data(), baseline);
+      ASSERT_EQ(recovered, inputValues);
+    }
+  }
+}
+
+TEST(FixedBitArrayTests, bulkSet64WithBaselinePartialRange) {
+  auto seed = folly::Random::rand32();
+  LOG(INFO) << "seed: " << seed;
+  std::mt19937 rng(seed);
+
+  for (int bitWidth : {4, 16, 32, 33, 40, 48, 56, 57, 58, 64}) {
+    SCOPED_TRACE(fmt::format("bitWidth={}", bitWidth));
+    const uint64_t maxElement = bitWidth == 64
+        ? std::numeric_limits<uint64_t>::max()
+        : (1ULL << bitWidth) - 1;
+    const uint64_t baseline = folly::Random::rand64(rng) % (maxElement / 2 + 1);
+    const uint64_t valueRange = maxElement - baseline;
+
+    const int elementCount = 200;
+    const auto bufferBytes =
+        nimble::FixedBitArray::bufferSize(elementCount, bitWidth);
+    auto buffer = std::make_unique<char[]>(bufferBytes);
+    std::memset(buffer.get(), 0, bufferBytes);
+    nimble::FixedBitArray fixedBitArray(buffer.get(), bitWidth);
+
+    const int offset = 50;
+    const int count = 100;
+    std::vector<uint64_t> inputValues(count);
+    for (int i = 0; i < count; ++i) {
+      const uint64_t residual =
+          valueRange == std::numeric_limits<uint64_t>::max()
+          ? folly::Random::rand64(rng)
+          : folly::Random::rand64(rng) % (valueRange + 1);
+      inputValues[i] = residual + baseline;
+    }
+
+    fixedBitArray.bulkSet64WithBaseline(
+        offset, count, inputValues.data(), baseline);
+
+    for (int i = 0; i < count; ++i) {
+      ASSERT_EQ(fixedBitArray.get(offset + i), inputValues[i] - baseline)
+          << "i=" << i;
+    }
+
+    for (int i = 0; i < offset; ++i) {
+      ASSERT_EQ(fixedBitArray.get(i), 0)
+          << "pre-range slot " << i << " should be zero";
+    }
+    for (int i = offset + count; i < elementCount; ++i) {
+      ASSERT_EQ(fixedBitArray.get(i), 0)
+          << "post-range slot " << i << " should be zero";
+    }
+  }
+}


### PR DESCRIPTION
Summary:

Adds `bulkSet64WithBaseline()` — the set-side counterpart to the existing `bulkGet64WithBaseline()`. Subtracts a baseline from each 64-bit value and bitpacks the residuals.

Three-tier strategy (mirrors the get path):
- **bitWidth <= 32**: Per-element `set32()` (residuals guaranteed to fit in uint32).
- **bitWidth 33-58**: Branchless byte-aligned stores. Each residual fits in a single 64-bit OR (`bitWidth + remainder <= 64`).
- **bitWidth > 58**: Per-element `set()` with cross-word boundary handling.

This eliminates the scalar `set()` loop that Pfor, CompactFor, and other int64 encodings currently use in their encode paths. Those encodings can adopt this API in follow-up diffs.

Reviewed By: xiaoxmeng

Differential Revision: D106527148


