### PR TITLE
refactor(encoding): Unify RLE run advancement logic to be more lazy (#823)

### DIFF
--- a/dwio/nimble/encodings/RLEEncoding.cpp
+++ b/dwio/nimble/encodings/RLEEncoding.cpp
@@ -50,19 +50,20 @@ void RLEEncoding<bool>::materializeBoolsAsBits(
     uint64_t* buffer,
     int begin) {
   auto rowsLeft = rowCount;
-  while (rowsLeft) {
+  while (rowsLeft > 0) {
+    if (copiesRemaining_ == 0) {
+      advanceRun();
+    }
     if (rowsLeft < copiesRemaining_) {
       velox::bits::fillBits(buffer, begin, begin + rowsLeft, currentValue_);
       copiesRemaining_ -= rowsLeft;
       return;
-    } else {
-      velox::bits::fillBits(
-          buffer, begin, begin + copiesRemaining_, currentValue_);
-      begin += copiesRemaining_;
-      rowsLeft -= copiesRemaining_;
-      copiesRemaining_ = materializedRunLengths_.nextValue();
-      currentValue_ = nextValue();
     }
+    velox::bits::fillBits(
+        buffer, begin, begin + copiesRemaining_, currentValue_);
+    begin += copiesRemaining_;
+    rowsLeft -= copiesRemaining_;
+    copiesRemaining_ = 0;
   }
 }
 

--- a/dwio/nimble/encodings/RLEEncoding.h
+++ b/dwio/nimble/encodings/RLEEncoding.h
@@ -101,40 +101,37 @@ class RLEEncodingBase
   void reset() override {
     materializedRunLengths_.reset();
     derived().resetValues();
-    copiesRemaining_ = materializedRunLengths_.nextValue();
-    currentValue_ = nextValue();
+    copiesRemaining_ = 0;
   }
 
   void skip(uint32_t rowCount) override {
     uint32_t rowsLeft = rowCount;
-    // TODO: We should have skip blocks.
-    while (rowsLeft) {
-      if (rowsLeft < copiesRemaining_) {
+    while (rowsLeft > 0) {
+      if (rowsLeft <= copiesRemaining_) {
         copiesRemaining_ -= rowsLeft;
         return;
-      } else {
-        rowsLeft -= copiesRemaining_;
-        copiesRemaining_ = materializedRunLengths_.nextValue();
-        currentValue_ = nextValue();
       }
+      rowsLeft -= copiesRemaining_;
+      advanceRun();
     }
   }
 
   void materialize(uint32_t rowCount, void* buffer) override {
     uint32_t rowsLeft = rowCount;
     physicalType* output = static_cast<physicalType*>(buffer);
-    while (rowsLeft) {
+    while (rowsLeft > 0) {
+      if (copiesRemaining_ == 0) {
+        advanceRun();
+      }
       if (rowsLeft < copiesRemaining_) {
         velox::simd::simdFill(output, currentValue_, rowsLeft);
         copiesRemaining_ -= rowsLeft;
         return;
-      } else {
-        velox::simd::simdFill(output, currentValue_, copiesRemaining_);
-        output += copiesRemaining_;
-        rowsLeft -= copiesRemaining_;
-        copiesRemaining_ = materializedRunLengths_.nextValue();
-        currentValue_ = nextValue();
       }
+      velox::simd::simdFill(output, currentValue_, copiesRemaining_);
+      output += copiesRemaining_;
+      rowsLeft -= copiesRemaining_;
+      copiesRemaining_ = 0;
     }
   }
 
@@ -146,8 +143,7 @@ class RLEEncodingBase
         [&](auto toSkip) { skip(toSkip); },
         [&] {
           if (copiesRemaining_ == 0) {
-            copiesRemaining_ = materializedRunLengths_.nextValue();
-            currentValue_ = nextValue();
+            advanceRun();
           }
           --copiesRemaining_;
           return currentValue_;
@@ -201,6 +197,21 @@ class RLEEncodingBase
   physicalType nextValue() {
     return derived().nextValue();
   }
+
+  void advanceRunLength() {
+    copiesRemaining_ = materializedRunLengths_.nextValue();
+  }
+
+  void advanceRunValue() {
+    currentValue_ = nextValue();
+  }
+
+  // Advances to the next run by loading both the run length and value.
+  void advanceRun() {
+    advanceRunLength();
+    advanceRunValue();
+  }
+
   static std::string_view getSerializedRunValues(
       EncodingSelection<physicalType>& selection,
       const Vector<physicalType>& runValues,
@@ -365,9 +376,7 @@ class RLEEncoding final : public internal::RLEEncodingBase<T, RLEEncoding<T>> {
   }
 
  private:
-  void advanceRunLength() {
-    this->copiesRemaining_ = this->materializedRunLengths_.nextValue();
-  }
+  using internal::RLEEncodingBase<T, RLEEncoding<T>>::advanceRunLength;
 
   void advanceRunValue();
 
@@ -488,35 +497,21 @@ void RLEEncoding<T>::advanceRunValue() {
 
 template <typename T>
 void RLEEncoding<T>::reset() {
-  this->materializedRunLengths_.reset();
-  this->resetValues();
-  if (dictValues_ != nullptr) {
-    // In dict mode, don't consume the first run — materializeIndices
-    // manages its own run traversal starting from copiesRemaining_ == 0.
-    this->copiesRemaining_ = 0;
-  } else {
-    advanceRunLength();
-    advanceRunValue();
-  }
+  // Delegate to base — copiesRemaining_ starts at 0. The first call to
+  // materialize/readWithVisitor/bulkScan/materializeIndices will load
+  // the first run on demand.
+  internal::RLEEncodingBase<T, RLEEncoding<T>>::reset();
 }
 
 template <typename T>
 void RLEEncoding<T>::skip(uint32_t rowCount) {
   uint32_t rowsLeft = rowCount;
   while (rowsLeft > 0) {
-    if (rowsLeft < this->copiesRemaining_) {
+    if (rowsLeft <= this->copiesRemaining_) {
       this->copiesRemaining_ -= rowsLeft;
       return;
     }
     rowsLeft -= this->copiesRemaining_;
-    // In dict mode, avoid consuming the next run when we've exactly
-    // exhausted the current one — materializeIndices uses a local runIndex
-    // that would go stale if advanceRunIndex() fires here. Non-dict mode
-    // keeps the eager advance so currentValue_ is always primed.
-    if (rowsLeft == 0 && dictValues_ != nullptr) {
-      this->copiesRemaining_ = 0;
-      return;
-    }
     advanceRunLength();
     if (dictValues_ != nullptr) {
       advanceRunIndex();
@@ -531,6 +526,9 @@ void RLEEncoding<T>::materialize(uint32_t rowCount, void* buffer) {
   uint32_t rowsLeft = rowCount;
   auto* output = static_cast<physicalType*>(buffer);
   while (rowsLeft > 0) {
+    if (this->copiesRemaining_ == 0) {
+      this->advanceRun();
+    }
     if (rowsLeft < this->copiesRemaining_) {
       velox::simd::simdFill(output, this->currentValue_, rowsLeft);
       this->copiesRemaining_ -= rowsLeft;
@@ -539,8 +537,7 @@ void RLEEncoding<T>::materialize(uint32_t rowCount, void* buffer) {
     velox::simd::simdFill(output, this->currentValue_, this->copiesRemaining_);
     output += this->copiesRemaining_;
     rowsLeft -= this->copiesRemaining_;
-    advanceRunLength();
-    advanceRunValue();
+    this->copiesRemaining_ = 0;
   }
 }
 

--- a/dwio/nimble/encodings/tests/EncodingTest.cpp
+++ b/dwio/nimble/encodings/tests/EncodingTest.cpp
@@ -588,6 +588,38 @@ TEST_F(SparseBoolZeroRowTest, materializeZeroRowsSparseValueFalse) {
   }
 }
 
+// Verifies materializeBoolsAsBits after skipping to an exact run boundary
+// in RLE<bool>. The lazy pattern means copiesRemaining_==0 after the skip,
+// and materializeBoolsAsBits must load the next run on demand.
+TEST_F(SparseBoolZeroRowTest, rleBoolMaterializeAfterSkip) {
+  // 3 runs: [true x 5] [false x 3] [true x 4]
+  nimble::Vector<bool> values{pool_.get()};
+  for (int i = 0; i < 5; ++i) {
+    values.push_back(true);
+  }
+  for (int i = 0; i < 3; ++i) {
+    values.push_back(false);
+  }
+  for (int i = 0; i < 4; ++i) {
+    values.push_back(true);
+  }
+
+  auto encoding =
+      nimble::test::Encoder<nimble::RLEEncoding<bool>>::createEncoding(
+          *buffer_, values, makeStringBufferFactory());
+
+  // Skip exactly past run 1 (5 rows).
+  encoding->skip(5);
+
+  // materializeBoolsAsBits for runs 2+3 (7 rows).
+  const auto remaining = values.size() - 5;
+  uint64_t bits = 0;
+  encoding->materializeBoolsAsBits(remaining, &bits, 0);
+  for (size_t i = 0; i < remaining; ++i) {
+    EXPECT_EQ(velox::bits::isBitSet(&bits, i), values[5 + i]) << "bit " << i;
+  }
+}
+
 TYPED_TEST(EncodingTest, materialize) {
   auto seed = folly::Random::rand32();
   LOG(INFO) << "seed: " << seed;
@@ -2316,6 +2348,122 @@ TYPED_TEST(DictionaryApiTypedTest, rleMaterializeAfterSkip) {
     SCOPED_TRACE(fmt::format("row {}", i));
     EXPECT_EQ(
         materialized[i], reinterpret_cast<const PhysicalType&>(data[5 + i]));
+  }
+}
+
+// Verifies that back-to-back materialize calls that each exactly exhaust
+// a run produce correct values. With the lazy pattern, each call ends with
+// copiesRemaining_==0 and the next call must load the next run on demand.
+TYPED_TEST(DictionaryApiTypedTest, rleMaterializeExactRunBoundaries) {
+  using T = TypeParam;
+  using PhysicalType = typename nimble::TypeTraits<T>::physicalType;
+
+  // 3 runs: [A x 5] [B x 3] [C x 4]
+  std::vector<T> data;
+  if constexpr (std::is_same_v<T, std::string_view>) {
+    this->stringPool_ = {"alpha", "bravo", "charlie"};
+    for (int i = 0; i < 5; ++i) {
+      data.push_back(std::string_view(this->stringPool_[0]));
+    }
+    for (int i = 0; i < 3; ++i) {
+      data.push_back(std::string_view(this->stringPool_[1]));
+    }
+    for (int i = 0; i < 4; ++i) {
+      data.push_back(std::string_view(this->stringPool_[2]));
+    }
+  } else {
+    for (int i = 0; i < 5; ++i) {
+      data.push_back(T(10));
+    }
+    for (int i = 0; i < 3; ++i) {
+      data.push_back(T(20));
+    }
+    for (int i = 0; i < 4; ++i) {
+      data.push_back(T(30));
+    }
+  }
+
+  auto serialized = this->serializeRleDictionary(data, *this->buffer_);
+  auto encoding = this->decodeEncoding(serialized);
+
+  // Materialize exactly run 1 (5 rows).
+  std::vector<PhysicalType> mat1(5);
+  encoding->materialize(5, mat1.data());
+  for (int i = 0; i < 5; ++i) {
+    EXPECT_EQ(mat1[i], reinterpret_cast<const PhysicalType&>(data[i]));
+  }
+
+  // Materialize exactly run 2 (3 rows).
+  std::vector<PhysicalType> mat2(3);
+  encoding->materialize(3, mat2.data());
+  for (int i = 0; i < 3; ++i) {
+    EXPECT_EQ(mat2[i], reinterpret_cast<const PhysicalType&>(data[5 + i]));
+  }
+
+  // Materialize exactly run 3 (4 rows).
+  std::vector<PhysicalType> mat3(4);
+  encoding->materialize(4, mat3.data());
+  for (int i = 0; i < 4; ++i) {
+    EXPECT_EQ(mat3[i], reinterpret_cast<const PhysicalType&>(data[8 + i]));
+  }
+}
+
+// Verifies skip to exact run boundary followed by materialize across
+// multiple skip+materialize cycles. Each skip lands exactly at a run
+// boundary (copiesRemaining_==0), and the subsequent materialize must
+// load the next run on demand.
+TYPED_TEST(DictionaryApiTypedTest, rleSkipAndMaterializeAlternating) {
+  using T = TypeParam;
+  using PhysicalType = typename nimble::TypeTraits<T>::physicalType;
+
+  // 4 runs: [A x 3] [B x 4] [C x 2] [D x 5]
+  std::vector<T> data;
+  if constexpr (std::is_same_v<T, std::string_view>) {
+    this->stringPool_ = {"alpha", "bravo", "charlie", "delta"};
+    for (int i = 0; i < 3; ++i) {
+      data.push_back(std::string_view(this->stringPool_[0]));
+    }
+    for (int i = 0; i < 4; ++i) {
+      data.push_back(std::string_view(this->stringPool_[1]));
+    }
+    for (int i = 0; i < 2; ++i) {
+      data.push_back(std::string_view(this->stringPool_[2]));
+    }
+    for (int i = 0; i < 5; ++i) {
+      data.push_back(std::string_view(this->stringPool_[3]));
+    }
+  } else {
+    for (int i = 0; i < 3; ++i) {
+      data.push_back(T(10));
+    }
+    for (int i = 0; i < 4; ++i) {
+      data.push_back(T(20));
+    }
+    for (int i = 0; i < 2; ++i) {
+      data.push_back(T(30));
+    }
+    for (int i = 0; i < 5; ++i) {
+      data.push_back(T(40));
+    }
+  }
+
+  auto serialized = this->serializeRleDictionary(data, *this->buffer_);
+  auto encoding = this->decodeEncoding(serialized);
+
+  // Skip run 1 (3 rows), materialize run 2 (4 rows).
+  encoding->skip(3);
+  std::vector<PhysicalType> mat1(4);
+  encoding->materialize(4, mat1.data());
+  for (int i = 0; i < 4; ++i) {
+    EXPECT_EQ(mat1[i], reinterpret_cast<const PhysicalType&>(data[3 + i]));
+  }
+
+  // Skip run 3 (2 rows), materialize run 4 (5 rows).
+  encoding->skip(2);
+  std::vector<PhysicalType> mat2(5);
+  encoding->materialize(5, mat2.data());
+  for (int i = 0; i < 5; ++i) {
+    EXPECT_EQ(mat2[i], reinterpret_cast<const PhysicalType&>(data[9 + i]));
   }
 }
 


### PR DESCRIPTION
Summary:

Replaces the eager priming pattern in `RLEEncodingBase::reset()` with a universal lazy initialization where `copiesRemaining_` starts at 0 and the first run is loaded on demand by each consumer (`materialize`, `readWithVisitor`, `bulkScan`, `materializeIndices`).

Previously, `reset()` eagerly called `materializedRunLengths_.nextValue()` and `nextValue()` to prime the first run. The derived `RLEEncoding<T>::reset()` had a separate dict-mode branch that set `copiesRemaining_ = 0` to avoid consuming the first index. This asymmetry was a source of off-by-one bugs (e.g., `skip()` would over-advance past a run boundary when `rowsLeft == 0` after consuming a run).

With the lazy pattern:
- `reset()` simply sets `copiesRemaining_ = 0` — no priming
- `skip()` handles the `rowsLeft == 0` boundary correctly with an early return
- `materialize()` / `materializeBoolsAsBits()` check `copiesRemaining_ == 0` at loop entry and advance on demand (matching the existing pattern in `readWithVisitor` and `bulkScan`)
- `RLEEncoding<T>::reset()` delegates to base — no more dict/non-dict branching

Reviewed By: xiaoxmeng

Differential Revision: D106993691
