### PR TITLE
feat: Initialize ColumnReaderOptions before column readers are built

### DIFF
--- a/dwio/nimble/velox/selective/FlatMapColumnReader.cpp
+++ b/dwio/nimble/velox/selective/FlatMapColumnReader.cpp
@@ -229,7 +229,12 @@ class FlatMapColumnReader
       const std::shared_ptr<const dwio::common::TypeWithId>& fileType,
       NimbleParams& params,
       common::ScanSpec& scanSpec)
-      : SelectiveFlatMapColumnReader(requestedType, fileType, params, scanSpec),
+      : SelectiveFlatMapColumnReader(
+            dwio::common::ColumnReaderOptions{},
+            requestedType,
+            fileType,
+            params,
+            scanSpec),
         keyNodes_(
             makeKeyNodes<T>(
                 requestedType,

--- a/dwio/nimble/velox/selective/StructColumnReader.h
+++ b/dwio/nimble/velox/selective/StructColumnReader.h
@@ -33,6 +33,7 @@ class StructColumnReaderBase
       velox::common::ScanSpec& scanSpec,
       bool isRoot)
       : SelectiveStructColumnReaderBase(
+            velox::dwio::common::ColumnReaderOptions{},
             requestedType,
             fileType,
             params,


### PR DESCRIPTION
Summary:
The default behavior of the schema evolution for row type is matching by index. 
This PR supports subfield rename and deletion for ORC file format, controlled by
configuration `useColumnNamesForColumnMapping`.
Missing subfields are identified by matching the file type and requested type on
the names of subfields, and NULL occupies the position of the missing subfields. 
Below table summarizes the results for difference cases.

| Column schema | Requested output schema | ORC result |
| ------------- | ------------- |  ------------- |
| row({"a", "c"}) | row({"a", "b", "c"})  |  row(a_val, NULL, c_val) |
| row({"a", "c"}) | row({"b"})  | row(NULL) |
| row({"a", "c"}) | row({"b", "d"})  | row(NULL, NULL) |
| row({"a", "c"}) | row({})  | row() |

This PR also fixes a pre-existing bug where `columnReaderOptions_` wasn't initialized
before `getUnitLoader()` built the column readers.

Replaces: https://github.com/facebookincubator/velox/pull/15848.
Part of: https://github.com/facebookincubator/velox/pull/17555.

X-link: https://github.com/facebookincubator/velox/pull/17551

Reviewed By: kevinwilfong

Differential Revision: D106508443

Pulled By: kKPulla


