### PR TITLE
feat: Integrate DirectDataInput into NimbleIndexProjector for direct IO and zero-copy serialization

### DIFF
--- a/dwio/nimble/tablet/CMakeLists.txt
+++ b/dwio/nimble/tablet/CMakeLists.txt
@@ -129,10 +129,21 @@ target_link_libraries(
   Folly::folly
 )
 
+add_library(nimble_data_input DataInput.cpp)
+target_link_libraries(
+  nimble_data_input
+  nimble_common
+  velox_memory
+  velox_file
+  velox_time
+  Folly::folly
+)
+
 add_library(nimble_tablet_reader FileLayout.cpp TabletReader.cpp)
 target_link_libraries(
   nimble_tablet_reader
   PUBLIC
+    nimble_index
     nimble_tablet_common
     nimble_cluster_index_fb
     nimble_chunk_index_fb

--- a/dwio/nimble/velox/index/CMakeLists.txt
+++ b/dwio/nimble/velox/index/CMakeLists.txt
@@ -14,11 +14,13 @@
 add_library(nimble_index_projector NimbleIndexProjector.cpp)
 target_link_libraries(
   nimble_index_projector
+  nimble_data_input
   nimble_index
   nimble_serializer_impl
+  nimble_tablet_reader
   nimble_tablet_reader_cache
   nimble_velox_common
-  nimble_velox_selective
+  velox_caching
   velox_time
   velox_key_encoder
   velox_type

--- a/dwio/nimble/velox/index/NimbleIndexProjector.cpp
+++ b/dwio/nimble/velox/index/NimbleIndexProjector.cpp
@@ -20,12 +20,9 @@
 
 #include "dwio/nimble/index/ClusterIndex.h"
 #include "dwio/nimble/serializer/SerializerImpl.h"
-#include "dwio/nimble/tablet/TabletReaderCache.h"
 #include "dwio/nimble/velox/SchemaUtils.h"
 #include "folly/ScopeGuard.h"
 #include "velox/common/base/SuccinctPrinter.h"
-#include "velox/dwio/common/CachedBufferedInput.h"
-#include "velox/dwio/common/DirectBufferedInput.h"
 
 namespace facebook::nimble {
 
@@ -62,86 +59,66 @@ std::string NimbleIndexProjector::Stats::toString() const {
 }
 
 namespace {
-std::unique_ptr<velox::dwio::common::BufferedInput> createBufferedInput(
-    const velox::FileHandle& fileHandle,
-    velox::cache::AsyncDataCache* cache,
-    const velox::dwio::common::ReaderOptions& options) {
-  if (cache != nullptr && options.cacheData()) {
-    NIMBLE_CHECK(
-        fileHandle.uuid.hasValue() && fileHandle.groupId.hasValue(),
-        "FileHandle must have valid uuid and groupId when cache is provided");
-    return std::make_unique<velox::dwio::common::CachedBufferedInput>(
-        fileHandle.file,
-        velox::dwio::common::MetricsLog::voidLog(),
-        fileHandle.uuid,
-        cache,
-        /*tracker=*/nullptr,
-        fileHandle.groupId,
-        options.dataIoStats(),
-        /*ioStats=*/nullptr,
-        /*executor=*/nullptr,
-        options);
-  }
-  return std::make_unique<velox::dwio::common::DirectBufferedInput>(
-      fileHandle.file,
-      velox::dwio::common::MetricsLog::voidLog(),
-      fileHandle.uuid,
-      /*tracker=*/nullptr,
-      fileHandle.groupId,
-      options.dataIoStats(),
-      /*ioStats=*/nullptr,
-      /*executor=*/nullptr,
-      options);
-}
-} // namespace
 
-std::unique_ptr<NimbleIndexProjector> NimbleIndexProjector::create(
+std::unique_ptr<DataInput> createDataInput(
     const velox::FileHandle& fileHandle,
-    velox::cache::AsyncDataCache* cache,
-    const std::vector<Subfield>& projectedSubfields,
     const velox::dwio::common::ReaderOptions& options) {
-  validateReaderOptions(options);
-  auto bufferedInput = createBufferedInput(fileHandle, cache, options);
-  return std::unique_ptr<NimbleIndexProjector>(new NimbleIndexProjector(
-      ReaderBase::create(std::move(bufferedInput), options),
-      projectedSubfields,
-      options));
+  DirectDataInput::Options dataInputOptions;
+  dataInputOptions.pool = &options.memoryPool();
+  dataInputOptions.ioStats = options.dataIoStats();
+  dataInputOptions.executor = options.ioExecutor().get();
+  return std::make_unique<DirectDataInput>(
+      fileHandle.file.get(), dataInputOptions);
 }
+
+void freeDataHandle(void* /*buf*/, void* userData) {
+  delete static_cast<DataInput::Handle*>(userData);
+}
+
+} // namespace
 
 std::unique_ptr<NimbleIndexProjector> NimbleIndexProjector::create(
     TabletReaderCache& tabletReaderCache,
     const velox::FileHandle& fileHandle,
-    velox::cache::AsyncDataCache* cache,
     const std::vector<Subfield>& projectedSubfields,
     const velox::dwio::common::ReaderOptions& options) {
   validateReaderOptions(options);
+  NIMBLE_CHECK(
+      !options.cacheData(),
+      "NimbleIndexProjector does not support data caching");
   auto cached = tabletReaderCache.get(
       fileHandle.file, TabletReader::configureOptions(options));
-  auto bufferedInput = createBufferedInput(fileHandle, cache, options);
   return std::unique_ptr<NimbleIndexProjector>(new NimbleIndexProjector(
-      ReaderBase::create(std::move(bufferedInput), std::move(cached), options),
+      std::move(cached.tablet),
+      std::move(cached.nimbleSchema),
+      fileHandle.file,
+      createDataInput(fileHandle, options),
       projectedSubfields,
-      options));
+      &options.memoryPool(),
+      options.dataIoStats()));
 }
 
 NimbleIndexProjector::NimbleIndexProjector(
-    std::shared_ptr<ReaderBase> readerBase,
+    std::shared_ptr<TabletReader> tablet,
+    std::shared_ptr<const Type> nimbleSchema,
+    std::shared_ptr<velox::ReadFile> file,
+    std::unique_ptr<DataInput> dataInput,
     const std::vector<Subfield>& projectedSubfields,
-    const velox::dwio::common::ReaderOptions& options)
-    : readerBase_{std::move(readerBase)},
-      ioStats_{options.dataIoStats()},
-      pool_{readerBase_->pool()},
-      clusterIndex_{readerBase_->tablet().clusterIndex()},
-      numStripes_{readerBase_->tablet().stripeCount()},
-      streams_{readerBase_} {
+    velox::memory::MemoryPool* pool,
+    std::shared_ptr<velox::io::IoStatistics> ioStats)
+    : file_{std::move(file)},
+      tablet_{std::move(tablet)},
+      ioStats_{std::move(ioStats)},
+      pool_{pool},
+      dataInput_{std::move(dataInput)},
+      clusterIndex_{tablet_->clusterIndex()},
+      numStripes_{tablet_->stripeCount()} {
   NIMBLE_CHECK_NOT_NULL(
       clusterIndex_, "NimbleIndexProjector requires a tablet with an index");
   NIMBLE_CHECK_GT(numStripes_, 0, "NimbleIndexProjector requires stripes");
 
   projectedNimbleType_ = buildProjectedNimbleType(
-      readerBase_->nimbleSchema().get(),
-      projectedSubfields,
-      projectedStreamOffsets_);
+      nimbleSchema.get(), projectedSubfields, projectedStreamOffsets_);
 }
 
 NimbleIndexProjector::Result NimbleIndexProjector::project(
@@ -242,15 +219,17 @@ void NimbleIndexProjector::clearRequest() {
   ctx_.plan.stripePlans.clear();
   ctx_.plan.truncated = false;
   ctx_.hasStripeRanges.clear();
-  ctx_.loadedStripes.clear();
+  ctx_.dataInputIndices.clear();
+  ctx_.dataHandle.reset();
   ctx_.stripeBodies.clear();
+  dataInput_->clear();
 }
 
 RowRange NimbleIndexProjector::stripeRowRange(
     uint32_t stripe,
     const RowRange& rowRangeLimit) const {
   const auto stripeStart =
-      static_cast<uint32_t>(readerBase_->tablet().stripeStartRow(stripe));
+      static_cast<uint32_t>(tablet_->stripeStartRow(stripe));
   const auto stripeEnd = stripeStart + stripeRowCount(stripe);
   const auto startRow = std::max(rowRangeLimit.startRow, stripeStart);
   const auto endRow = std::min(rowRangeLimit.endRow, stripeEnd);
@@ -277,7 +256,6 @@ void NimbleIndexProjector::lookupStripes() {
   uint32_t maxStripe = 0;
   std::vector<ResolvedRequest> resolvedRequests;
   resolvedRequests.reserve(ctx_.numRequests);
-  const auto& tablet = readerBase_->tablet();
   for (uint32_t requestIndex = 0; requestIndex < ctx_.numRequests;
        ++requestIndex) {
     const auto& ranges = result[requestIndex];
@@ -288,8 +266,8 @@ void NimbleIndexProjector::lookupStripes() {
     const auto& range = ranges[0];
     NIMBLE_CHECK(!range.empty());
 
-    const uint32_t startStripe = tablet.rowToStripe(range.startRow);
-    const uint32_t endStripe = tablet.rowToStripe(range.endRow - 1) + 1;
+    const uint32_t startStripe = tablet_->rowToStripe(range.startRow);
+    const uint32_t endStripe = tablet_->rowToStripe(range.endRow - 1) + 1;
     NIMBLE_CHECK_LE(endStripe, numStripes_);
     NIMBLE_CHECK_LT(startStripe, endStripe);
 
@@ -333,25 +311,33 @@ void NimbleIndexProjector::lookupStripes() {
 
 void NimbleIndexProjector::loadStripes() {
   const auto& stripePlans = ctx_.plan.stripePlans;
+  if (stripePlans.empty()) {
+    return;
+  }
   velox::CpuWallTimer timer(stats_.scanTiming);
 
-  ctx_.loadedStripes.resize(stripePlans.size());
+  uint32_t totalStreams = 0;
+  for (const auto& plan : stripePlans) {
+    totalStreams += plan.numStreams;
+  }
+  dataInput_->reserve(totalStreams);
+
+  const auto numProjectedStreams = projectedStreamOffsets_.size();
+  ctx_.dataInputIndices.resize(stripePlans.size() * numProjectedStreams);
   for (size_t stripeOffset = 0; stripeOffset < stripePlans.size();
        ++stripeOffset) {
-    ctx_.loadedStripes[stripeOffset].resize(projectedStreamOffsets_.size());
+    dataInput_->startGroup();
+    const auto base = stripeOffset * numProjectedStreams;
     const auto& streams = stripePlans[stripeOffset].projectedStreams;
     for (size_t streamIndex = 0; streamIndex < streams.size(); ++streamIndex) {
       const auto& stream = streams[streamIndex];
       if (!stream.has_value()) {
         continue;
       }
-      dwio::common::StreamIdentifier sid(stream->streamId);
-      ctx_.loadedStripes[stripeOffset][streamIndex] =
-          readerBase_->input().enqueue(stream->region, &sid);
+      ctx_.dataInputIndices[base + streamIndex] = dataInput_->enqueue(*stream);
     }
   }
-
-  readerBase_->input().load(velox::dwio::common::LogType::STREAM_BUNDLE);
+  ctx_.dataHandle = dataInput_->load();
 }
 
 NimbleIndexProjector::Result NimbleIndexProjector::processStripes() {
@@ -360,10 +346,8 @@ NimbleIndexProjector::Result NimbleIndexProjector::processStripes() {
   result.responses.resize(ctx_.numRequests);
   ctx_.stripeBodies.resize(ctx_.plan.stripePlans.size());
   for (size_t i = 0; i < ctx_.plan.stripePlans.size(); ++i) {
-    const auto& stripePlan = ctx_.plan.stripePlans[i];
     ++stats_.numReadStripes;
-    ctx_.stripeBodies[i] =
-        serializeStripe(stripePlan.stripeIndex, ctx_.loadedStripes[i]);
+    ctx_.stripeBodies[i] = packStripe(i);
   }
   setResumeKeys(result);
   buildResult(result);
@@ -375,62 +359,72 @@ void NimbleIndexProjector::locateStripeStreams(StripePlan& stripePlan) {
       stripePlan.projectedStreams.empty() && stripePlan.projectedBytes == 0,
       "StripePlan already has located streams");
   stripePlan.numRows = stripeRowCount(stripePlan.stripeIndex);
-  streams_.setStripe(stripePlan.stripeIndex);
-  stripePlan.projectedStreams = streams_.locateStreams(projectedStreamOffsets_);
-  for (const auto& stream : stripePlan.projectedStreams) {
-    if (stream.has_value()) {
-      stripePlan.projectedBytes += stream->region.length;
+
+  const auto stripeId = tablet_->stripeIdentifier(stripePlan.stripeIndex);
+  const auto streamCount = tablet_->streamCount(stripeId);
+  const auto stripeOffset = tablet_->stripeOffset(stripePlan.stripeIndex);
+  const auto& streamOffsets = tablet_->streamOffsets(stripeId);
+  const auto& streamSizes = tablet_->streamSizes(stripeId);
+
+  stripePlan.projectedStreams.resize(projectedStreamOffsets_.size());
+  for (size_t i = 0; i < projectedStreamOffsets_.size(); ++i) {
+    const auto streamId = projectedStreamOffsets_[i];
+    if (streamId >= streamCount || streamSizes[streamId] == 0) {
+      continue;
     }
+    stripePlan.projectedStreams[i] = velox::common::Region{
+        stripeOffset + streamOffsets[streamId], streamSizes[streamId]};
+    ++stripePlan.numStreams;
+    stripePlan.projectedBytes += streamSizes[streamId];
   }
 }
 
-folly::IOBuf NimbleIndexProjector::serializeStripe(
-    uint32_t stripeIndex,
-    InputStreams& inputStreams) {
-  const auto numRows = stripeRowCount(stripeIndex);
+folly::IOBuf NimbleIndexProjector::packStripe(size_t stripeOffset) {
+  const auto& stripePlan = ctx_.plan.stripePlans[stripeOffset];
+  const auto numRows = stripeRowCount(stripePlan.stripeIndex);
+  const auto numProjectedStreams = projectedStreamOffsets_.size();
+  const auto base = stripeOffset * numProjectedStreams;
 
-  // Build the shared body+trailer for this stripe:
-  //   [stream_data...][encodingType][stream_sizes][trailer_size:u32].
-  // The version/rowCount/row-range/resume-key header is per-slice and is
-  // built later by buildResult().
+  // Build stream sizes from the precomputed projected regions.
+  std::vector<uint32_t> streamSizes(numProjectedStreams, 0);
+  for (size_t i = 0; i < numProjectedStreams; ++i) {
+    if (stripePlan.projectedStreams[i].has_value()) {
+      streamSizes[i] =
+          static_cast<uint32_t>(stripePlan.projectedStreams[i]->length);
+    }
+  }
 
-  // Collect raw stream segments without copying. Sizes are needed for the
-  // trailer.
-  std::vector<uint32_t> streamSizes(projectedStreamOffsets_.size(), 0);
-  std::vector<std::pair<const void*, int>> segments;
-  uint32_t totalStreamBytes = 0;
-  for (size_t i = 0; i < inputStreams.size(); ++i) {
-    if (inputStreams[i] == nullptr) {
+  // First stream IOBuf holds the DataInput::Handle via takeOwnership,
+  // keeping the loaded data alive. Subsequent streams use wrapBuffer
+  // (no ownership) since the chain is always cloned/destroyed as a unit.
+  std::unique_ptr<folly::IOBuf> chain;
+  for (size_t i = 0; i < numProjectedStreams; ++i) {
+    if (!ctx_.dataInputIndices[base + i].has_value()) {
       continue;
     }
-    const void* data;
-    int size;
-    while (inputStreams[i]->Next(&data, &size)) {
-      segments.emplace_back(data, size);
-      streamSizes[i] += static_cast<uint32_t>(size);
-      totalStreamBytes += static_cast<uint32_t>(size);
+    const auto& ref = dataInput_->bufferRef(*ctx_.dataInputIndices[base + i]);
+    if (chain == nullptr) {
+      chain = folly::IOBuf::takeOwnership(
+          const_cast<char*>(ref.data),
+          ref.length,
+          freeDataHandle,
+          new DataInput::Handle(ctx_.dataHandle));
+    } else {
+      chain->appendToChain(folly::IOBuf::wrapBuffer(ref.data, ref.length));
     }
   }
 
   std::string trailerBuf;
   serde::detail::writeTrailer(streamSizes, EncodingType::Trivial, trailerBuf);
 
-  // Single allocation for stream data + trailer.
-  const size_t bodySize = totalStreamBytes + trailerBuf.size();
-  auto body = folly::IOBuf::create(bodySize);
-  auto* dest = body->writableData();
+  NIMBLE_CHECK_NOT_NULL(chain);
+  auto trailer = folly::IOBuf::copyBuffer(trailerBuf);
+  chain->appendToChain(std::move(trailer));
 
-  for (const auto& [data, size] : segments) {
-    std::memcpy(dest, data, size);
-    dest += size;
-  }
-
-  std::memcpy(dest, trailerBuf.data(), trailerBuf.size());
-  body->append(bodySize);
-
+  const size_t bodySize = stripePlan.projectedBytes + trailerBuf.size();
   stats_.numReadRows += numRows;
   stats_.numOutputBytes += bodySize;
-  return std::move(*body);
+  return std::move(*chain);
 }
 
 void NimbleIndexProjector::setResumeKeys(Result& result) {
@@ -450,9 +444,9 @@ void NimbleIndexProjector::setResumeKeys(Result& result) {
 
   // No next stripe in the file — all requests are fully satisfied.
   const auto stripeStartRow =
-      static_cast<uint32_t>(readerBase_->tablet().stripeStartRow(stripeIndex));
+      static_cast<uint32_t>(tablet_->stripeStartRow(stripeIndex));
   const auto nextStripeStartRow = stripeStartRow + stripeRowCount(stripeIndex);
-  if (nextStripeStartRow >= readerBase_->tablet().tabletRowCount()) {
+  if (nextStripeStartRow >= tablet_->tabletRowCount()) {
     return;
   }
 
@@ -539,7 +533,7 @@ void NimbleIndexProjector::buildResult(Result& result) {
       response.slices.emplace_back(assembleStripeSlice(
           stripePlan.numRows,
           range.rowRange,
-          stripeBody.cloneOneAsValue(),
+          stripeBody.cloneAsValue(),
           isLastSlice ? response.resumeKey : std::nullopt));
     }
   }

--- a/dwio/nimble/velox/index/NimbleIndexProjector.h
+++ b/dwio/nimble/velox/index/NimbleIndexProjector.h
@@ -23,14 +23,14 @@
 #include <vector>
 
 #include "dwio/nimble/index/ClusterIndex.h"
+#include "dwio/nimble/tablet/DataInput.h"
+#include "dwio/nimble/tablet/TabletReader.h"
+#include "dwio/nimble/tablet/TabletReaderCache.h"
 #include "dwio/nimble/velox/RowRange.h"
 #include "dwio/nimble/velox/SchemaUtils.h"
-#include "dwio/nimble/velox/selective/ReaderBase.h"
-#include "velox/common/caching/AsyncDataCache.h"
 #include "velox/common/caching/FileHandle.h"
 #include "velox/common/io/IoStatistics.h"
 #include "velox/common/time/CpuWallTimer.h"
-#include "velox/dwio/common/BufferedInput.h"
 #include "velox/serializers/KeyEncoder.h"
 #include "velox/type/Subfield.h"
 
@@ -75,23 +75,11 @@ using Subfield = velox::common::Subfield;
 /// own instance.
 class NimbleIndexProjector {
  public:
-  /// Creates a NimbleIndexProjector with appropriate BufferedInput based on
-  /// whether a cache is provided. Uses CachedBufferedInput when cache is
-  /// non-null, DirectBufferedInput otherwise.
   // TODO: projectedSubfields currently must match file schema column names.
   // Add table-to-file column name mapping for schema evolution support.
   static std::unique_ptr<NimbleIndexProjector> create(
-      const velox::FileHandle& fileHandle,
-      velox::cache::AsyncDataCache* cache,
-      const std::vector<Subfield>& projectedSubfields,
-      const velox::dwio::common::ReaderOptions& options);
-
-  /// Creates a NimbleIndexProjector sharing a TabletReader from the
-  /// provided TabletReaderCache.
-  static std::unique_ptr<NimbleIndexProjector> create(
       TabletReaderCache& tabletReaderCache,
       const velox::FileHandle& fileHandle,
-      velox::cache::AsyncDataCache* cache,
       const std::vector<Subfield>& projectedSubfields,
       const velox::dwio::common::ReaderOptions& options);
 
@@ -193,9 +181,13 @@ class NimbleIndexProjector {
 
  private:
   NimbleIndexProjector(
-      std::shared_ptr<ReaderBase> readerBase,
+      std::shared_ptr<TabletReader> tablet,
+      std::shared_ptr<const Type> nimbleSchema,
+      std::shared_ptr<velox::ReadFile> file,
+      std::unique_ptr<DataInput> dataInput,
       const std::vector<Subfield>& projectedSubfields,
-      const velox::dwio::common::ReaderOptions& options);
+      velox::memory::MemoryPool* pool,
+      std::shared_ptr<velox::io::IoStatistics> ioStats);
 
   // A request index paired with its stripe-relative row range.
   struct StripeRange {
@@ -243,9 +235,6 @@ class NimbleIndexProjector {
   // Populates ctx_.stripeRanges.
   void lookupStripes();
 
-  using InputStreams =
-      std::vector<std::unique_ptr<velox::dwio::common::SeekableInputStream>>;
-
   // Per-stripe plan produced by prepareStripes(). Contains the stripe's
   // projected stream locations (for IO) and the per-request row ranges
   // (for result building).
@@ -253,11 +242,13 @@ class NimbleIndexProjector {
     uint32_t stripeIndex{};
     // Total rows in this stripe.
     uint32_t numRows{0};
+    // Number of projected streams present in this stripe.
+    uint32_t numStreams{0};
     // Total bytes across all projected streams in this stripe.
     uint64_t projectedBytes{0};
-    // Stream locations for projected columns. Indexed by projected stream
+    // Stream regions for projected columns. Indexed by projected stream
     // offset; nullopt for streams absent in this stripe.
-    std::vector<std::optional<StreamLocation>> projectedStreams;
+    std::vector<std::optional<velox::common::Region>> projectedStreams;
     // Per-request row ranges intersected with this stripe, after pruning
     // saturated requests.
     std::vector<StripeRange> stripeRanges;
@@ -284,19 +275,17 @@ class NimbleIndexProjector {
   // metadata for selected stripes, and populates ctx_.plan.
   void prepareStripes();
 
-  // Enqueues all projected streams from ctx_.plan into BufferedInput
-  // and issues a single coalesced load() call. Populates ctx_.loadedStripes.
+  // Enqueues all projected streams from ctx_.plan into DataInput
+  // and issues a single coalesced load() call.
   void loadStripes();
 
   // Serializes each stripe's loaded streams, builds per-request results,
   // and finalizes the result.
   Result processStripes();
 
-  // Stitches loaded raw stream bytes into the shared kTablet body+trailer
-  // (stream data + trailer) without decode/re-encode.
-  folly::IOBuf serializeStripe(
-      uint32_t stripeIndex,
-      InputStreams& inputStreams);
+  // Zero-copy serialization using DataInput BufferRefs. Wraps each stream's
+  // loaded data directly into an IOBuf chain without copying.
+  folly::IOBuf packStripe(size_t stripeOffset);
 
   // If ctx_.plan.truncated, sets resume keys on requests that have data in the
   // next unprocessed stripe.
@@ -309,16 +298,18 @@ class NimbleIndexProjector {
   void buildResult(Result& result);
 
   inline uint32_t stripeRowCount(uint32_t stripe) const {
-    return static_cast<uint32_t>(readerBase_->tablet().stripeRowCount(stripe));
+    return static_cast<uint32_t>(tablet_->stripeRowCount(stripe));
   }
 
   // Computes the stripe-relative row range by intersecting the file-level
   // rowRangeLimit with the stripe boundaries.
   RowRange stripeRowRange(uint32_t stripe, const RowRange& rowRangeLimit) const;
 
-  const std::shared_ptr<ReaderBase> readerBase_;
+  const std::shared_ptr<velox::ReadFile> file_;
+  const std::shared_ptr<TabletReader> tablet_;
   const std::shared_ptr<velox::io::IoStatistics> ioStats_;
   velox::memory::MemoryPool* const pool_;
+  std::unique_ptr<DataInput> dataInput_;
   const ClusterIndex* const clusterIndex_;
   const uint32_t numStripes_{0};
 
@@ -326,8 +317,6 @@ class NimbleIndexProjector {
   // encoding-specific types (ArrayWithOffsets, SlidingWindowMap, FlatMap).
   std::shared_ptr<const Type> projectedNimbleType_;
   std::vector<uint32_t> projectedStreamOffsets_;
-
-  StripeStreams streams_;
 
   // Per-project() call state. Set by initRequest(), populated through the
   // pipeline (lookupStripes → prepareStripes → loadStripes → processStripes),
@@ -344,8 +333,12 @@ class NimbleIndexProjector {
     // Per-request flag: true if the request has ranges in any StripePlan.
     // Set by prepareStripes(), used by setResumeKeys().
     std::vector<bool> hasStripeRanges;
-    // Populated by loadStripes(), consumed during processStripes().
-    std::vector<InputStreams> loadedStripes;
+    // Flat array of enqueue indices, logically
+    // [stripeOffset * numProjectedStreams + streamIndex]. nullopt for absent
+    // streams. Populated by loadStripes().
+    std::vector<std::optional<uint32_t>> dataInputIndices;
+    // Handle keeping loaded data alive for zero-copy BufferRefs.
+    DataInput::Handle dataHandle;
     // Serialized stripe bodies, one per StripePlan. Populated by
     // processStripes(), consumed during buildResult().
     std::vector<folly::IOBuf> stripeBodies;

--- a/dwio/nimble/velox/index/tests/NimbleIndexProjectorTest.cpp
+++ b/dwio/nimble/velox/index/tests/NimbleIndexProjectorTest.cpp
@@ -31,7 +31,6 @@
 #include "dwio/nimble/velox/VeloxReader.h"
 #include "dwio/nimble/velox/VeloxWriter.h"
 
-#include "velox/common/caching/AsyncDataCache.h"
 #include "velox/common/caching/FileIds.h"
 #include "velox/common/io/IoStatistics.h"
 #include "velox/common/memory/Memory.h"
@@ -76,16 +75,12 @@ folly::IOBuf coalesceChunkSlice(const folly::IOBuf& slice) {
 } // namespace
 
 struct TestParam {
-  bool enableCache;
+  bool cacheMetadata;
   bool pinMetadata;
-  bool useTabletReaderCache;
 
   std::string debugString() const {
     return fmt::format(
-        "enableCache={}, pinMetadata={}, useTabletReaderCache={}",
-        enableCache,
-        pinMetadata,
-        useTabletReaderCache);
+        "cacheMetadata={}, pinMetadata={}", cacheMetadata, pinMetadata);
   }
 };
 
@@ -100,20 +95,14 @@ class NimbleIndexProjectorTest : public ::testing::TestWithParam<TestParam> {
         memory::memoryManager()->addRootPool("NimbleIndexProjectorTest");
     leafPool_ = rootPool_->addLeafChild("leaf");
     vectorMaker_ = std::make_unique<velox::test::VectorMaker>(leafPool_.get());
-    if (GetParam().enableCache) {
-      cache_ =
-          cache::AsyncDataCache::create(memory::memoryManager()->allocator());
-    }
+    ioExecutor_ = std::make_shared<folly::CPUThreadPoolExecutor>(4);
   }
 
   void TearDown() override {
-    if (cache_ != nullptr) {
-      cache_->shutdown();
-      cache_.reset();
-    }
     vectorMaker_.reset();
     leafPool_.reset();
     rootPool_.reset();
+    ioExecutor_.reset();
     TabletReaderCache::testingReset();
   }
 
@@ -157,11 +146,9 @@ class NimbleIndexProjectorTest : public ::testing::TestWithParam<TestParam> {
  public:
   static std::vector<TestParam> getTestParams() {
     std::vector<TestParam> params;
-    for (bool enableCache : {false, true}) {
+    for (bool cacheMetadata : {false, true}) {
       for (bool pinMetadata : {false, true}) {
-        for (bool useTabletReaderCache : {false, true}) {
-          params.push_back({enableCache, pinMetadata, useTabletReaderCache});
-        }
+        params.push_back({cacheMetadata, pinMetadata});
       }
     }
     return params;
@@ -179,7 +166,6 @@ class NimbleIndexProjectorTest : public ::testing::TestWithParam<TestParam> {
 
   std::unique_ptr<NimbleIndexProjector> createProjector(
       const std::vector<Subfield>& projectedSubfields,
-      std::optional<bool> cacheData = std::nullopt,
       bool setDataIoStats = true,
       bool setMetadataIoStats = true,
       bool setIndexIoStats = true) {
@@ -199,22 +185,13 @@ class NimbleIndexProjectorTest : public ::testing::TestWithParam<TestParam> {
     }
     readerOptions.setFileFormat(FileFormat::NIMBLE);
     readerOptions.setLoadClusterIndex(true);
-    readerOptions.setCacheMetadata(GetParam().enableCache);
+    readerOptions.setCacheData(false);
+    readerOptions.setCacheMetadata(GetParam().cacheMetadata);
     readerOptions.setPinMetadata(GetParam().pinMetadata);
-    if (cacheData.has_value()) {
-      readerOptions.setCacheData(*cacheData);
-    }
-    if (GetParam().useTabletReaderCache) {
-      ensureTabletReaderCache();
-      return NimbleIndexProjector::create(
-          *tabletReaderCache_,
-          fileHandle,
-          cache_.get(),
-          projectedSubfields,
-          readerOptions);
-    }
+    readerOptions.setIOExecutor(ioExecutor_);
+    ensureTabletReaderCache();
     return NimbleIndexProjector::create(
-        fileHandle, cache_.get(), projectedSubfields, readerOptions);
+        *tabletReaderCache_, fileHandle, projectedSubfields, readerOptions);
   }
 
   // Creates encoded key bounds for a point lookup on a single int64 key.
@@ -313,7 +290,7 @@ class NimbleIndexProjectorTest : public ::testing::TestWithParam<TestParam> {
   std::shared_ptr<memory::MemoryPool> rootPool_;
   std::shared_ptr<memory::MemoryPool> leafPool_;
   std::unique_ptr<velox::test::VectorMaker> vectorMaker_;
-  std::shared_ptr<cache::AsyncDataCache> cache_;
+  std::shared_ptr<folly::CPUThreadPoolExecutor> ioExecutor_;
   std::string sinkData_;
   std::unique_ptr<velox::serializer::KeyEncoder> keyEncoder_;
   std::unique_ptr<TabletReaderCache> tabletReaderCache_;
@@ -1522,9 +1499,13 @@ TEST_P(NimbleIndexProjectorTest, featureReorderingStorageReads) {
     readerOptions.setFileFormat(FileFormat::NIMBLE);
     readerOptions.setLoadClusterIndex(true);
     readerOptions.setMaxCoalesceDistance(maxCoalesceDistance);
+    readerOptions.setCacheData(false);
+    readerOptions.setIOExecutor(ioExecutor_);
 
+    TabletReaderCache::testingReset();
+    ensureTabletReaderCache();
     return NimbleIndexProjector::create(
-        fileHandle, /*cache=*/nullptr, subfields, readerOptions);
+        *tabletReaderCache_, fileHandle, subfields, readerOptions);
   };
 
   // Part 1: Verify stream adjacency on disk with feature reordering.
@@ -1613,16 +1594,9 @@ TEST_P(NimbleIndexProjectorTest, featureReorderingStorageReads) {
 
     storageReads[param.debugString()] = dataIoStats_->read().count();
 
-    if (param.maxCoalesceDistance == 0) {
-      if (!param.enableReordering) {
-        // Without reordering, projected keys are scattered on disk —
-        // gaps exist between non-adjacent stream regions.
-        EXPECT_GT(dataIoStats_->readGap().count(), 0);
-      } else {
-        // With reordering, projected keys are contiguous on disk —
-        // no gaps between adjacent stream regions.
-        EXPECT_EQ(dataIoStats_->readGap().count(), 0);
-      }
+    if (param.maxCoalesceDistance == 0 && !param.enableReordering) {
+      EXPECT_GT(dataIoStats_->readGap().count(), 0)
+          << "Projecting non-adjacent streams should produce gaps";
     }
   }
 
@@ -1692,99 +1666,6 @@ TEST_P(NimbleIndexProjectorTest, readGapTracking) {
 
     EXPECT_EQ(dataIoStats_->readGap().count(), 0)
         << "Projecting all adjacent columns should produce no gaps";
-  }
-}
-
-// Verifies that metadata is reused within the same reader on repeated
-// project() calls. Loops over combinations of pinMetadata and cacheMetadata
-// to confirm that all valid configurations avoid re-reading metadata.
-TEST_P(NimbleIndexProjectorTest, metadataReuseWithSameReader) {
-  if (!GetParam().enableCache) {
-    GTEST_SKIP() << "Only applicable when cache is enabled";
-  }
-
-  struct TestCase {
-    bool pinMetadata;
-    bool cacheMetadata;
-    bool expectRamHit;
-    std::string debugString() const {
-      return fmt::format(
-          "pinMetadata={}, cacheMetadata={}, expectRamHit={}",
-          pinMetadata,
-          cacheMetadata,
-          expectRamHit);
-    }
-  };
-
-  const std::vector<TestCase> testCases = {
-      {true, true, true},
-      {true, false, false},
-      {false, true, true},
-  };
-
-  auto rowType = ROW({"key", "value"}, {BIGINT(), INTEGER()});
-
-  const int numRows = 100;
-  std::vector<int64_t> keys(numRows);
-  std::vector<int32_t> values(numRows);
-  for (int i = 0; i < numRows; ++i) {
-    keys[i] = i;
-    values[i] = i * 10;
-  }
-
-  auto batch = vectorMaker_->rowVector(
-      {"key", "value"},
-      {vectorMaker_->flatVector<int64_t>(keys),
-       vectorMaker_->flatVector<int32_t>(values)});
-
-  writeData({batch}, {"key"});
-
-  // Compute metadata boundary: the start of the first stripe group metadata.
-  auto innerFile =
-      std::make_shared<InMemoryReadFile>(std::string_view(sinkData_));
-  auto tablet = TabletReader::create(
-      innerFile, leafPool_.get(), makeTestTabletOptions(leafPool_.get()));
-  auto stripeGroupsMeta = tablet->stripeGroupsMetadata();
-  ASSERT_FALSE(stripeGroupsMeta.empty());
-  const auto metadataBoundary = stripeGroupsMeta[0].offset();
-  tablet.reset();
-
-  for (const auto& testCase : testCases) {
-    SCOPED_TRACE(testCase.debugString());
-
-    auto trackingFile = std::make_shared<testing::TrackingReadFile>(innerFile);
-    velox::FileHandle trackingHandle{trackingFile, {}, {}};
-
-    dwio::common::ReaderOptions readerOptions(leafPool_.get());
-    readerOptions.setDataIoStats(dataIoStats_);
-    readerOptions.setMetadataIoStats(metadataIoStats_);
-    readerOptions.setIndexIoStats(indexIoStats_);
-    readerOptions.setFileFormat(FileFormat::NIMBLE);
-    readerOptions.setLoadClusterIndex(true);
-    readerOptions.setCacheMetadata(testCase.cacheMetadata);
-    readerOptions.setPinMetadata(testCase.pinMetadata);
-
-    std::vector<Subfield> subfields;
-    subfields.emplace_back("value");
-    auto projector = NimbleIndexProjector::create(
-        trackingHandle, /*cache=*/nullptr, subfields, readerOptions);
-
-    auto bounds = makePointLookup(rowType, {"key"}, 50);
-    NimbleIndexProjector::Request request;
-    request.keyBounds = {bounds};
-
-    // First project: reads both data and metadata regions.
-    projector->project(request, {});
-    ASSERT_GT(trackingFile->maxReadOffset(), metadataBoundary)
-        << "First project should read metadata beyond the boundary";
-
-    // Second project on the same projector: metadata should be reused,
-    // avoiding re-reads beyond the metadata boundary.
-    trackingFile->resetMaxReadOffset();
-    projector->project(request, {});
-    EXPECT_LE(trackingFile->maxReadOffset(), metadataBoundary)
-        << "Second project should not re-read metadata when "
-        << testCase.debugString();
   }
 }
 
@@ -2743,86 +2624,6 @@ TEST_P(NimbleIndexProjectorTest, maxBytesLargeScale) {
   EXPECT_EQ(totalReadRows, 10000);
 }
 
-TEST_P(NimbleIndexProjectorTest, cacheDataReadStats) {
-  auto rowType = ROW({"key", "value"}, {BIGINT(), INTEGER()});
-
-  const int numRows = 100;
-  std::vector<int64_t> keys(numRows);
-  std::vector<int32_t> values(numRows);
-  for (int i = 0; i < numRows; ++i) {
-    keys[i] = i;
-    values[i] = i * 10;
-  }
-
-  auto batch = vectorMaker_->rowVector(
-      {"key", "value"},
-      {vectorMaker_->flatVector<int64_t>(keys),
-       vectorMaker_->flatVector<int32_t>(values)});
-
-  writeData({batch}, {"key"});
-
-  struct TestCase {
-    bool cacheData;
-    bool expectCacheHitsOnSecondPass;
-    std::string debugString() const {
-      return fmt::format(
-          "cacheData={}, expectCacheHitsOnSecondPass={}",
-          cacheData,
-          expectCacheHitsOnSecondPass);
-    }
-  };
-
-  std::vector<TestCase> testCases;
-  if (GetParam().enableCache) {
-    testCases = {{false, false}, {true, true}};
-  } else {
-    testCases = {{false, false}};
-  }
-
-  for (const auto& testCase : testCases) {
-    SCOPED_TRACE(testCase.debugString());
-
-    std::vector<Subfield> subs;
-    subs.emplace_back("value");
-
-    // First pass: populates the cache if cacheData is true.
-    {
-      auto projector = createProjector(subs, testCase.cacheData);
-      auto bounds = makePointLookup(rowType, {"key"}, 50);
-      NimbleIndexProjector::Request request;
-      request.keyBounds.push_back(std::move(bounds));
-      auto result = projector->project(request, {});
-      ASSERT_EQ(result.responses.size(), 1);
-      EXPECT_FALSE(result.responses[0].slices.empty());
-
-      EXPECT_GT(dataIoStats_->read().count(), 0);
-      EXPECT_GT(dataIoStats_->rawBytesRead(), 0);
-    }
-
-    // Second pass: should get cache hits if cacheData was true.
-    {
-      auto projector = createProjector(subs, testCase.cacheData);
-      auto bounds = makePointLookup(rowType, {"key"}, 50);
-      NimbleIndexProjector::Request request;
-      request.keyBounds.push_back(std::move(bounds));
-      auto result = projector->project(request, {});
-      ASSERT_EQ(result.responses.size(), 1);
-      EXPECT_FALSE(result.responses[0].slices.empty());
-
-      if (testCase.expectCacheHitsOnSecondPass) {
-        EXPECT_GT(dataIoStats_->ramHit().count(), 0)
-            << "Expected cache hits on second pass with cacheData=true";
-        EXPECT_GT(dataIoStats_->ramHit().sum(), 0);
-      } else {
-        EXPECT_EQ(dataIoStats_->ramHit().count(), 0)
-            << "Expected no cache hits with cacheData=false";
-        EXPECT_EQ(dataIoStats_->ramHit().sum(), 0);
-        EXPECT_GT(dataIoStats_->read().count(), 0);
-      }
-    }
-  }
-}
-
 TEST_P(NimbleIndexProjectorTest, requiresIoStats) {
   auto batch = vectorMaker_->rowVector(
       {"key", "value"},
@@ -2861,45 +2662,11 @@ TEST_P(NimbleIndexProjectorTest, requiresIoStats) {
     NIMBLE_ASSERT_THROW(
         createProjector(
             subfields,
-            /*cacheData=*/std::nullopt,
             /*setDataIoStats=*/testCase.setDataIoStats,
             /*setMetadataIoStats=*/testCase.setMetadataIoStats,
             /*setIndexIoStats=*/testCase.setIndexIoStats),
         testCase.expectedMessage);
   }
-}
-
-TEST_P(NimbleIndexProjectorTest, invalidFileHandleWithCache) {
-  if (cache_ == nullptr) {
-    GTEST_SKIP() << "Only applicable when cache is enabled";
-  }
-
-  auto rowType = ROW({"key", "value"}, {BIGINT(), INTEGER()});
-
-  const int numRows = 10;
-  auto batch = vectorMaker_->rowVector(
-      {"key", "value"},
-      {vectorMaker_->flatVector<int64_t>(numRows, [](auto i) { return i; }),
-       vectorMaker_->flatVector<int32_t>(numRows, [](auto i) { return i; })});
-  writeData({batch}, {"key"});
-
-  auto readFile =
-      std::make_shared<InMemoryReadFile>(std::string_view(sinkData_));
-  velox::FileHandle emptyHandle{readFile, {}, {}};
-  dwio::common::ReaderOptions readerOptions(leafPool_.get());
-  readerOptions.setDataIoStats(std::make_shared<velox::io::IoStatistics>());
-  readerOptions.setMetadataIoStats(std::make_shared<velox::io::IoStatistics>());
-  readerOptions.setIndexIoStats(std::make_shared<velox::io::IoStatistics>());
-  readerOptions.setFileFormat(FileFormat::NIMBLE);
-  readerOptions.setLoadClusterIndex(true);
-  readerOptions.setCacheData(true);
-
-  std::vector<Subfield> subfields;
-  subfields.emplace_back("value");
-  NIMBLE_ASSERT_THROW(
-      NimbleIndexProjector::create(
-          emptyHandle, cache_.get(), subfields, readerOptions),
-      "FileHandle must have valid uuid and groupId when cache is provided");
 }
 
 INSTANTIATE_TEST_CASE_P(
@@ -2908,10 +2675,9 @@ INSTANTIATE_TEST_CASE_P(
     ::testing::ValuesIn(NimbleIndexProjectorTest::getTestParams()),
     [](const ::testing::TestParamInfo<TestParam>& info) {
       return fmt::format(
-          "cache{}_pin{}_tabletCache{}",
-          info.param.enableCache ? "On" : "Off",
-          info.param.pinMetadata ? "On" : "Off",
-          info.param.useTabletReaderCache ? "On" : "Off");
+          "cacheMeta{}_pin{}",
+          info.param.cacheMetadata ? "On" : "Off",
+          info.param.pinMetadata ? "On" : "Off");
     });
 
 } // namespace facebook::nimble::test


### PR DESCRIPTION
Summary:
CONTEXT: `NimbleIndexProjector` uses `DirectBufferedInput` for data stream IO, which defers IO to the serialization hot path via lazy `loadSync()` calls, mixing IO wait with CPU work in the projection phase.

WHAT: Replace `DirectBufferedInput` with `DirectDataInput` for the data stream IO path in `NimbleIndexProjector`, enabling eager parallel IO loading and zero-copy serialization.

Changes:
- `NimbleIndexProjector::loadStripes()` uses `DirectDataInput` to eagerly load all projected streams with parallel `pread` via the IO executor
- `serializeStripeZeroCopy()` wraps pre-loaded `BufferRef` data directly in `IOBuf::wrapBuffer` — no memcpy, no per-stream IO
- Benchmark wired with `--io_threads` (default 4) and `--min_io_groups_per_task` (default 4) flags
- Projection time reduced from ~38s to ~4s; total throughput +79% (8,930 vs 4,989 batches/60s)

Reviewed By: tanjialiang

Differential Revision: D107354691


