### PR TITLE
misc(nimble): Bump Velox submodule version

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ Nimble integrates Velox as a Git submodule, referencing a specific commit of the
 Velox repository. The Velox badge at the top of this README shows the current
 commit and how far behind it is from Velox main.
 
-[See what changed since the current Velox commit.](https://github.com/facebookincubator/velox/compare/61aa7b808b293fdd4670c581f073cf839cda4a8d...main)
+[See what changed since the current Velox commit.](https://github.com/facebookincubator/velox/compare/8092d7ea27999c48ca4966c9e32863cc9bf91dec...main)
 <!-- pre-commit check-velox-readme validates the SHA above matches the submodule -->
 
 Advance Velox when your changes depend on code in Velox that


### PR DESCRIPTION
Summary: Bump Nimble's Velox submodule to `8092d7ea27999c48ca4966c9e32863cc9bf91dec` so OSS Nimble picks up the latest Velox changes. Update the README compare link to match the new pinned Velox commit.

Differential Revision: D107561597
