### PR TITLE
perf: VisitValueStreamLeaves template; precompute Deserializer in-map anchors

### DIFF
--- a/dwio/nimble/serializer/Deserializer.cpp
+++ b/dwio/nimble/serializer/Deserializer.cpp
@@ -737,6 +737,24 @@ void Deserializer::createDeserializersForType(
           options_.bufferPoolCapacity,
           pool_);
       inMapChildTypes_[inMapOffset] = flatMap.childAt(i).get();
+      // Precompute the value-stream offsets that the per-batch in-map
+      // detection in deserialize() will probe. Built once here so the hot
+      // path is a flat bitmap scan instead of a recursive schema walk.
+      //
+      // Visits ALL value-stream offsets in the child subtree (Row recurses
+      // all children; FlatMap recurses all children). Relies on
+      // RowFieldWriter writing every field over the same OrderedRanges, so
+      // sibling Row children populate in lockstep — if any sibling's value
+      // stream is present in a batch, all are. If a future writer ever made
+      // Row children conditionally absent, the in-map inference below would
+      // over-attribute presence to keys whose first child was absent but a
+      // sibling was present.
+      auto& valueOffsets = inMapValueStreamOffsets_[inMapOffset];
+      visitValueStreamLeaves(
+          *flatMap.childAt(i), [&valueOffsets](offset_size offset) {
+            valueOffsets.push_back(offset);
+            return false;
+          });
     }
   }
 }
@@ -779,7 +797,7 @@ void Deserializer::deserialize(
   uint32_t rowOffset{0};
   serde::StreamDataReader reader{pool_, options_};
   for (auto sv : data) {
-    const auto batchRows = reader.initialize(sv);
+    const auto numRows = reader.initialize(sv);
     const auto version = reader.version();
     // Reset present tracking from previous batch.
     if (hasInMapChildren && !inMapPresentOffsetsList_.empty()) {
@@ -788,12 +806,19 @@ void Deserializer::deserialize(
       }
       inMapPresentOffsetsList_.clear();
     }
+    // iterateStreams() is a templated callback walker; the lambda body
+    // inlines into the loop, eliminating std::function dispatch on the
+    // per-batch flatmap deserialization hot path.
     reader.iterateStreams([&](uint32_t offset, std::string_view streamData) {
       if (offset <= maxStreamOffset) {
         if (hasInMapChildren) {
           inMapPresentOffsets_[offset] = true;
-          inMapPresentOffsetsList_.push_back(offset);
+          inMapPresentOffsetsList_.emplace_back(offset);
         }
+        // Null is possible: deserializers_ is sized to maxOffset+1 but only
+        // populated for offsets in deserializerMap_. Some serialized stream
+        // offsets (e.g., TimestampMicroNano's nanosDescriptor) are not in
+        // the map, so their slot stays null; skip them here.
         auto* decoder = deserializers_[offset];
         if (decoder != nullptr) {
           DeserializerImpl::toDecoderImpl(decoder)->addBatch(
@@ -802,18 +827,24 @@ void Deserializer::deserialize(
       }
     });
 
-    // Detect present in-map streams: in-map skipped + value streams present.
-    for (const auto& [inMapOffset, childType] : inMapChildTypes_) {
-      if (!inMapPresentOffsets_[inMapOffset] &&
-          hasValueStreams(*childType, [&](offset_size offset) {
-            return offset <= maxStreamOffset && inMapPresentOffsets_[offset];
-          })) {
-        DeserializerImpl::toDecoderImpl(deserializers_[inMapOffset])
-            ->addPresentInMapSegment(rowOffset, batchRows);
+    // Detect present in-map streams using the precomputed value-stream
+    // offsets table (built once in createDeserializersForType). Per-batch
+    // hot path is a flat bitmap scan; no recursive schema walk and no
+    // callback dispatch.
+    for (const auto& [inMapOffset, valueOffsets] : inMapValueStreamOffsets_) {
+      if (inMapPresentOffsets_[inMapOffset]) {
+        continue;
+      }
+      for (const auto offset : valueOffsets) {
+        if (offset <= maxStreamOffset && inMapPresentOffsets_[offset]) {
+          DeserializerImpl::toDecoderImpl(deserializers_[inMapOffset])
+              ->addPresentInMapSegment(rowOffset, numRows);
+          break;
+        }
       }
     }
 
-    rowOffset += batchRows;
+    rowOffset += numRows;
   }
 
   // Set total top-level rows so deserializers can fill missing FlatMap data.

--- a/dwio/nimble/serializer/Deserializer.h
+++ b/dwio/nimble/serializer/Deserializer.h
@@ -72,6 +72,14 @@ class Deserializer {
   // the serializer). Only populated for top-level FlatMap types (depth 1).
   folly::F14FastMap<uint32_t, const Type*> inMapChildTypes_;
 
+  // Precomputed value-stream offsets per top-level FlatMap child, keyed by
+  // the child's inMap stream offset. Populated alongside inMapChildTypes_
+  // via visitValueStreamLeaves(). Used by the per-batch in-map detection in
+  // deserialize() to check whether any of a child's value streams were
+  // present, without re-walking the schema on the hot path.
+  folly::F14FastMap<uint32_t, std::vector<offset_size>>
+      inMapValueStreamOffsets_;
+
   // Flat boolean vector indexed by stream offset for tracking which streams
   // are present in the current batch. Replaces F14FastSet for O(1) access.
   // Only used when inMapChildTypes_ is non-empty.

--- a/dwio/nimble/serializer/Serializer.h
+++ b/dwio/nimble/serializer/Serializer.h
@@ -111,7 +111,8 @@ void Serializer::serialize(
   for (auto& [_, streamData] : context_.streams()) {
     // Skip constant in-map boolean streams. When all-false (no row has this
     // key) or all-true (every row has this key), omit the stream. The
-    // deserializer uses hasValueStreams() to distinguish the two cases.
+    // deserializer uses the precomputed value-stream anchor list (built via
+    // visitValueStreamLeaves) to distinguish the two cases.
     if (!inMapStreamOffsets_.empty()) {
       const auto streamOffset = streamData->descriptor().offset();
       if (inMapStreamOffsets_.contains(streamOffset)) {

--- a/dwio/nimble/serializer/tests/SerializationTest.cpp
+++ b/dwio/nimble/serializer/tests/SerializationTest.cpp
@@ -2660,7 +2660,8 @@ TEST_P(SerializationTest, encodingLayoutTreeMapForFlatMap) {
 TEST_P(SerializationTest, flatMapInMapStreamSkipping) {
   // Test that serializer skips constant in-map boolean streams: both all-false
   // (key absent from a batch) and all-true (key present in every row). The
-  // deserializer uses hasValueStreams() to distinguish the two cases.
+  // deserializer uses visitValueStreamLeaves() to enumerate per-key value-
+  // stream anchors and probes a presence bitmap to distinguish the two cases.
   auto type = velox::ROW({
       {"id", velox::BIGINT()},
       {"flat_map", velox::MAP(velox::VARCHAR(), velox::DOUBLE())},

--- a/dwio/nimble/velox/FieldReader.cpp
+++ b/dwio/nimble/velox/FieldReader.cpp
@@ -2929,7 +2929,7 @@ class FlatMapFieldReaderFactoryBase : public FieldReaderFactory {
             valueTypes_.size(),
             "currentIdx out of range for valueTypes_");
         if (decoder != nullptr ||
-            hasValueStreams(
+            visitValueStreamLeaves(
                 *valueTypes_[currentIdx], [&decoders](offset_size offset) {
                   return hasDecoderStream(offset, decoders);
                 })) {

--- a/dwio/nimble/velox/SchemaReader.cpp
+++ b/dwio/nimble/velox/SchemaReader.cpp
@@ -646,45 +646,4 @@ std::ostream& operator<<(
   return out;
 }
 
-bool hasValueStreams(
-    const Type& type,
-    const std::function<bool(offset_size)>& hasStream) {
-  switch (type.kind()) {
-    case Kind::Scalar:
-      return hasStream(type.asScalar().scalarDescriptor().offset());
-    case Kind::TimestampMicroNano:
-      return hasStream(type.asTimestampMicroNano().microsDescriptor().offset());
-    case Kind::Array:
-      return hasStream(type.asArray().lengthsDescriptor().offset());
-    case Kind::ArrayWithOffsets:
-      return hasStream(type.asArrayWithOffsets().offsetsDescriptor().offset());
-    case Kind::Map:
-      return hasStream(type.asMap().lengthsDescriptor().offset());
-    case Kind::SlidingWindowMap:
-      return hasStream(type.asSlidingWindowMap().offsetsDescriptor().offset());
-    case Kind::Row:
-      // Null stream can be omitted when all non-null. Check first child.
-      NIMBLE_CHECK_GT(
-          type.asRow().childrenCount(),
-          0,
-          "Row type must have at least one child");
-      return hasValueStreams(*type.asRow().childAt(0), hasStream);
-    case Kind::FlatMap: {
-      // FlatMap children are independent keys — iterate all children.
-      NIMBLE_CHECK_GT(
-          type.asFlatMap().childrenCount(),
-          0,
-          "FlatMap type must have at least one child");
-      for (size_t i = 0; i < type.asFlatMap().childrenCount(); ++i) {
-        if (hasValueStreams(*type.asFlatMap().childAt(i), hasStream)) {
-          return true;
-        }
-      }
-      return false;
-    }
-    default:
-      NIMBLE_UNREACHABLE("Unsupported type kind: {}", type.kind());
-  }
-}
-
 } // namespace facebook::nimble

--- a/dwio/nimble/velox/SchemaReader.h
+++ b/dwio/nimble/velox/SchemaReader.h
@@ -256,16 +256,89 @@ std::ostream& operator<<(
     std::ostream& out,
     const std::shared_ptr<const Type>& root);
 
-/// Checks if a value type has data streams in the current stripe.
+/// Visits every value-stream anchor offset in the subtree of `type`, calling
+/// `visit(offset)` at each anchor leaf. Returns `true` iff any invocation of
+/// `visit` returned `true`; visitor returning `true` short-circuits the walk.
 ///
-/// For most types, probes a single stream that is guaranteed to exist when the
-/// type has data (e.g., scalar data stream, array lengths stream). For Row and
-/// FlatMap types whose nulls stream may be omitted, recurses into children.
+/// "Anchor leaves" are streams whose presence reliably proves the subtree
+/// contains data in the current stripe (e.g. Scalar data stream, Array
+/// lengths stream, Map lengths stream). Stream-bearing containers whose
+/// top-level stream may be omitted by the writer (Row's nulls, FlatMap's
+/// nulls) are NOT visited directly — instead the walk recurses into ALL
+/// their children, since any populated child proves the container has data.
 ///
-/// For FlatMap types, iterates all children because individual keys are
-/// independent — one child may have no data while another does.
-bool hasValueStreams(
-    const Type& type,
-    const std::function<bool(offset_size)>& hasStream);
+/// NOTE: Row recurses into ALL children, not just the first. This is a
+/// deliberate change from the legacy `hasValueStreams` walker, which
+/// short-circuited at Row's first child as an optimization that exploited
+/// Nimble's per-row "all-Row-fields-populate-together" writer invariant.
+/// Predicate-style callers may therefore probe additional siblings before
+/// the visitor returns true, which is harmless given the same writer
+/// invariant; collect-style callers receive every leaf, not just the
+/// first.
+///
+/// This is the single primitive for "tell me about this subtree's anchor
+/// streams"; callers compose it with whatever leaf action they need:
+///   - "does any anchor pass a predicate?"  → predicate returns true to stop.
+///   - "collect all anchor offsets"         → visitor pushes to a sink, returns
+///   false.
+///   - "mark each anchor in a bitmap"       → visitor sets a bit, returns
+///   false.
+///
+/// PERFORMANCE: This is a function template (not a function taking
+/// `std::function`/`folly::FunctionRef`) on purpose. The visitor's call type
+/// is concrete at the call site, so `visit(offset)` becomes a direct call
+/// the compiler can inline. Earlier `std::function`-based variants paid an
+/// indirect-call (`_Function_handler::_M_invoke`) per leaf, which showed up
+/// as a hotspot in the Deserializer's per-batch flatmap in-map detection
+/// over hundreds of keys. Concrete-typed callables remove that dispatch
+/// without forcing every caller to materialize an intermediate offset list.
+template <typename Visitor>
+bool visitValueStreamLeaves(const Type& type, Visitor&& visit) {
+  switch (type.kind()) {
+    case Kind::Scalar:
+      return visit(type.asScalar().scalarDescriptor().offset());
+    case Kind::TimestampMicroNano:
+      return visit(type.asTimestampMicroNano().microsDescriptor().offset());
+    case Kind::Array:
+      return visit(type.asArray().lengthsDescriptor().offset());
+    case Kind::ArrayWithOffsets:
+      return visit(type.asArrayWithOffsets().offsetsDescriptor().offset());
+    case Kind::Map:
+      return visit(type.asMap().lengthsDescriptor().offset());
+    case Kind::SlidingWindowMap:
+      return visit(type.asSlidingWindowMap().offsetsDescriptor().offset());
+    case Kind::Row: {
+      const auto& row = type.asRow();
+      NIMBLE_CHECK_GT(
+          row.childrenCount(), 0, "Row type must have at least one child");
+      // Recurse into ALL children. Row's own nulls stream may be omitted by
+      // the writer, so it is not a reliable anchor; children are. The
+      // visitor's return value short-circuits the walk on the first hit.
+      for (size_t i = 0; i < row.childrenCount(); ++i) {
+        if (visitValueStreamLeaves(*row.childAt(i), visit)) {
+          return true;
+        }
+      }
+      return false;
+    }
+    case Kind::FlatMap: {
+      const auto& flatMap = type.asFlatMap();
+      NIMBLE_CHECK_GT(
+          flatMap.childrenCount(),
+          0,
+          "FlatMap type must have at least one child");
+      // FlatMap children are independent keys; each may or may not carry
+      // data in the current stripe, so all must be visited.
+      for (size_t i = 0; i < flatMap.childrenCount(); ++i) {
+        if (visitValueStreamLeaves(*flatMap.childAt(i), visit)) {
+          return true;
+        }
+      }
+      return false;
+    }
+    default:
+      NIMBLE_UNREACHABLE("Unsupported type kind: {}", type.kind());
+  }
+}
 
 } // namespace facebook::nimble

--- a/dwio/nimble/velox/selective/FlatMapColumnReader.cpp
+++ b/dwio/nimble/velox/selective/FlatMapColumnReader.cpp
@@ -126,9 +126,7 @@ std::vector<KeyNode<T>> makeKeyNodes(
       // Missing in-map stream: either the writer skipped it because all rows
       // are in-map (value streams exist), or the key has no data in this
       // stripe (value streams also absent). Check value streams to distinguish.
-      // For FlatMap value types, iterate children since individual keys are
-      // independent and the first child may not have data.
-      if (!hasValueStreams(
+      if (!visitValueStreamLeaves(
               *nimbleType.childAt(i),
               [&streams = params.streams()](offset_size offset) {
                 return streams.hasStream(offset);

--- a/dwio/nimble/velox/tests/SchemaTest.cpp
+++ b/dwio/nimble/velox/tests/SchemaTest.cpp
@@ -713,7 +713,7 @@ TEST(SchemaTests, flatMapTypeFindChild) {
   EXPECT_FALSE(empty.has_value());
 }
 
-TEST(SchemaTests, hasValueStreamsScalar) {
+TEST(SchemaTests, visitValueStreamLeavesScalar) {
   nimble::SchemaBuilder builder;
   NIMBLE_SCHEMA(builder, NIMBLE_BIGINT());
 
@@ -723,18 +723,18 @@ TEST(SchemaTests, hasValueStreamsScalar) {
   for (bool streamExists : {true, false}) {
     SCOPED_TRACE(fmt::format("streamExists={}", streamExists));
     std::vector<nimble::offset_size> queriedOffsets;
-    auto hasStream = [&](nimble::offset_size offset) {
+    auto visit = [&](nimble::offset_size offset) {
       queriedOffsets.push_back(offset);
       return streamExists;
     };
 
-    EXPECT_EQ(nimble::hasValueStreams(*schema, hasStream), streamExists);
+    EXPECT_EQ(nimble::visitValueStreamLeaves(*schema, visit), streamExists);
     ASSERT_EQ(queriedOffsets.size(), 1);
     EXPECT_EQ(queriedOffsets[0], expectedOffset);
   }
 }
 
-TEST(SchemaTests, hasValueStreamsArray) {
+TEST(SchemaTests, visitValueStreamLeavesArray) {
   nimble::SchemaBuilder builder;
   NIMBLE_SCHEMA(builder, NIMBLE_ARRAY(NIMBLE_BIGINT()));
 
@@ -744,18 +744,18 @@ TEST(SchemaTests, hasValueStreamsArray) {
   for (bool streamExists : {true, false}) {
     SCOPED_TRACE(fmt::format("streamExists={}", streamExists));
     std::vector<nimble::offset_size> queriedOffsets;
-    auto hasStream = [&](nimble::offset_size offset) {
+    auto visit = [&](nimble::offset_size offset) {
       queriedOffsets.push_back(offset);
       return streamExists;
     };
 
-    EXPECT_EQ(nimble::hasValueStreams(*schema, hasStream), streamExists);
+    EXPECT_EQ(nimble::visitValueStreamLeaves(*schema, visit), streamExists);
     ASSERT_EQ(queriedOffsets.size(), 1);
     EXPECT_EQ(queriedOffsets[0], expectedOffset);
   }
 }
 
-TEST(SchemaTests, hasValueStreamsMap) {
+TEST(SchemaTests, visitValueStreamLeavesMap) {
   nimble::SchemaBuilder builder;
   NIMBLE_SCHEMA(builder, NIMBLE_MAP(NIMBLE_STRING(), NIMBLE_BIGINT()));
 
@@ -765,18 +765,18 @@ TEST(SchemaTests, hasValueStreamsMap) {
   for (bool streamExists : {true, false}) {
     SCOPED_TRACE(fmt::format("streamExists={}", streamExists));
     std::vector<nimble::offset_size> queriedOffsets;
-    auto hasStream = [&](nimble::offset_size offset) {
+    auto visit = [&](nimble::offset_size offset) {
       queriedOffsets.push_back(offset);
       return streamExists;
     };
 
-    EXPECT_EQ(nimble::hasValueStreams(*schema, hasStream), streamExists);
+    EXPECT_EQ(nimble::visitValueStreamLeaves(*schema, visit), streamExists);
     ASSERT_EQ(queriedOffsets.size(), 1);
     EXPECT_EQ(queriedOffsets[0], expectedOffset);
   }
 }
 
-TEST(SchemaTests, hasValueStreamsRowRecursesToFirstChild) {
+TEST(SchemaTests, visitValueStreamLeavesRowRecursesAllChildren) {
   nimble::SchemaBuilder builder;
   NIMBLE_SCHEMA(
       builder,
@@ -786,25 +786,51 @@ TEST(SchemaTests, hasValueStreamsRowRecursesToFirstChild) {
       }));
 
   auto schema = nimble::SchemaReader::getSchema(builder.schemaNodes());
-  const auto expectedOffset =
-      schema->asRow().childAt(0)->asScalar().scalarDescriptor().offset();
+  const std::vector<nimble::offset_size> childOffsets = {
+      schema->asRow().childAt(0)->asScalar().scalarDescriptor().offset(),
+      schema->asRow().childAt(1)->asScalar().scalarDescriptor().offset(),
+  };
 
-  for (bool streamExists : {true, false}) {
-    SCOPED_TRACE(fmt::format("streamExists={}", streamExists));
+  // Visitor never returns true -> walks ALL children of the Row.
+  {
     std::vector<nimble::offset_size> queriedOffsets;
-    auto hasStream = [&](nimble::offset_size offset) {
+    auto visit = [&](nimble::offset_size offset) {
       queriedOffsets.push_back(offset);
-      return streamExists;
+      return false;
     };
+    EXPECT_FALSE(nimble::visitValueStreamLeaves(*schema, visit));
+    EXPECT_EQ(queriedOffsets, childOffsets);
+  }
 
-    EXPECT_EQ(nimble::hasValueStreams(*schema, hasStream), streamExists);
-    // Row recurses to first child (c1 - BIGINT).
+  // First-child visitor returns true -> short-circuits after one query.
+  {
+    std::vector<nimble::offset_size> queriedOffsets;
+    auto visit = [&](nimble::offset_size offset) {
+      queriedOffsets.push_back(offset);
+      return true;
+    };
+    EXPECT_TRUE(nimble::visitValueStreamLeaves(*schema, visit));
     ASSERT_EQ(queriedOffsets.size(), 1);
-    EXPECT_EQ(queriedOffsets[0], expectedOffset);
+    EXPECT_EQ(queriedOffsets[0], childOffsets[0]);
+  }
+
+  // Visitor returns true only on the SECOND child -> the walker must visit
+  // c1 first, observe its `false`, then continue to c2 and stop. This pins
+  // the new walk-all-children semantics: a regression to the legacy
+  // first-child-only short-circuit would return false here and visit only
+  // c1, failing both assertions below.
+  {
+    std::vector<nimble::offset_size> queriedOffsets;
+    auto visit = [&](nimble::offset_size offset) {
+      queriedOffsets.push_back(offset);
+      return offset == childOffsets[1];
+    };
+    EXPECT_TRUE(nimble::visitValueStreamLeaves(*schema, visit));
+    EXPECT_EQ(queriedOffsets, childOffsets);
   }
 }
 
-TEST(SchemaTests, hasValueStreamsFlatMap) {
+TEST(SchemaTests, visitValueStreamLeavesFlatMap) {
   nimble::SchemaBuilder builder;
   nimble::test::FlatMapChildAdder fm;
   NIMBLE_SCHEMA(builder, NIMBLE_FLATMAP(String, NIMBLE_BIGINT(), fm));
@@ -817,19 +843,19 @@ TEST(SchemaTests, hasValueStreamsFlatMap) {
   for (bool streamExists : {true, false}) {
     SCOPED_TRACE(fmt::format("streamExists={}", streamExists));
     std::vector<nimble::offset_size> queriedOffsets;
-    auto hasStream = [&](nimble::offset_size offset) {
+    auto visit = [&](nimble::offset_size offset) {
       queriedOffsets.push_back(offset);
       return streamExists;
     };
 
-    EXPECT_EQ(nimble::hasValueStreams(*schema, hasStream), streamExists);
-    // FlatMap iterates children until one has stream.
+    EXPECT_EQ(nimble::visitValueStreamLeaves(*schema, visit), streamExists);
+    // FlatMap iterates children until one returns true (or all consumed).
     ASSERT_EQ(queriedOffsets.size(), 1);
     EXPECT_EQ(queriedOffsets[0], expectedOffset);
   }
 }
 
-TEST(SchemaTests, hasValueStreamsFlatMapIteratesAllChildren) {
+TEST(SchemaTests, visitValueStreamLeavesFlatMapIteratesAllChildren) {
   nimble::SchemaBuilder builder;
   nimble::test::FlatMapChildAdder fm;
   NIMBLE_SCHEMA(
@@ -849,52 +875,54 @@ TEST(SchemaTests, hasValueStreamsFlatMapIteratesAllChildren) {
   const auto& flatMap = schema->asFlatMap();
   ASSERT_EQ(flatMap.childrenCount(), 3);
 
-  // Collect expected offsets for each key's Row's first child.
-  std::vector<nimble::offset_size> expectedOffsets;
-  expectedOffsets.reserve(flatMap.childrenCount());
+  // For each key, the value type is Row{f1: BIGINT, f2: STRING}; Row now
+  // recurses into ALL children, so the per-key visit sequence is (f1, f2).
+  std::vector<std::array<nimble::offset_size, 2>> perKeyOffsets;
+  perKeyOffsets.reserve(flatMap.childrenCount());
   for (size_t i = 0; i < flatMap.childrenCount(); ++i) {
-    expectedOffsets.push_back(flatMap.childAt(i)
-                                  ->asRow()
-                                  .childAt(0)
-                                  ->asScalar()
-                                  .scalarDescriptor()
-                                  .offset());
+    const auto& row = flatMap.childAt(i)->asRow();
+    perKeyOffsets.push_back(
+        {row.childAt(0)->asScalar().scalarDescriptor().offset(),
+         row.childAt(1)->asScalar().scalarDescriptor().offset()});
   }
 
-  // All 3 children exist in the schema (have valid offsets). Test that when
-  // hasStream returns false for some children, the search continues until
-  // finding one where hasStream returns true.
-  // childWithStream=-1: hasStream returns false for all -> queries all 3,
-  // returns false childWithStream=0: hasStream returns true for key1 -> queries
-  // 1, returns true childWithStream=1: hasStream returns false for key1, true
-  // for key2 -> queries 2, returns true childWithStream=2: hasStream returns
-  // false for key1/key2, true for key3 -> queries 3, returns true
-  for (int childWithStream = -1; childWithStream < 3; ++childWithStream) {
-    SCOPED_TRACE(fmt::format("childWithStream={}", childWithStream));
+  // hitKey == -1: visitor never returns true; walks every leaf of every key.
+  // hitKey >=  0: visitor returns true on f1 of the chosen key (short-circuits
+  //               the rest of that key's leaves AND all subsequent keys).
+  for (int hitKey = -1; hitKey < 3; ++hitKey) {
+    SCOPED_TRACE(fmt::format("hitKey={}", hitKey));
     std::vector<nimble::offset_size> queriedOffsets;
-    auto hasStream = [&](nimble::offset_size offset) {
+    auto visit = [&](nimble::offset_size offset) {
       queriedOffsets.push_back(offset);
-      if (childWithStream < 0) {
+      if (hitKey < 0) {
         return false;
       }
-      return offset == expectedOffsets[childWithStream];
+      return offset == perKeyOffsets[hitKey][0];
     };
 
-    const bool expectedResult = childWithStream >= 0;
-    EXPECT_EQ(nimble::hasValueStreams(*schema, hasStream), expectedResult);
-    // When no stream exists, checks all children.
-    // When stream exists at position N, checks N+1 children (0..N).
-    const size_t expectedQueries =
-        childWithStream < 0 ? 3 : childWithStream + 1;
-    EXPECT_EQ(queriedOffsets.size(), expectedQueries);
-    // Verify queries are in order and match expected offsets.
-    for (size_t i = 0; i < queriedOffsets.size(); ++i) {
-      EXPECT_EQ(queriedOffsets[i], expectedOffsets[i]);
+    const bool expectedResult = hitKey >= 0;
+    EXPECT_EQ(nimble::visitValueStreamLeaves(*schema, visit), expectedResult);
+
+    std::vector<nimble::offset_size> expectedQueries;
+    if (hitKey < 0) {
+      // All keys fully walked: (f1, f2) per key.
+      for (const auto& off : perKeyOffsets) {
+        expectedQueries.push_back(off[0]);
+        expectedQueries.push_back(off[1]);
+      }
+    } else {
+      // Walk full (f1, f2) for keys before hitKey, then f1 of hitKey only.
+      for (int k = 0; k < hitKey; ++k) {
+        expectedQueries.push_back(perKeyOffsets[k][0]);
+        expectedQueries.push_back(perKeyOffsets[k][1]);
+      }
+      expectedQueries.push_back(perKeyOffsets[hitKey][0]);
     }
+    EXPECT_EQ(queriedOffsets, expectedQueries);
   }
 }
 
-TEST(SchemaTests, hasValueStreamsNestedRow) {
+TEST(SchemaTests, visitValueStreamLeavesNestedRow) {
   nimble::SchemaBuilder builder;
   NIMBLE_SCHEMA(
       builder,
@@ -917,13 +945,14 @@ TEST(SchemaTests, hasValueStreamsNestedRow) {
   for (bool streamExists : {true, false}) {
     SCOPED_TRACE(fmt::format("streamExists={}", streamExists));
     std::vector<nimble::offset_size> queriedOffsets;
-    auto hasStream = [&](nimble::offset_size offset) {
+    auto visit = [&](nimble::offset_size offset) {
       queriedOffsets.push_back(offset);
       return streamExists;
     };
 
-    EXPECT_EQ(nimble::hasValueStreams(*schema, hasStream), streamExists);
-    // Should recurse: outer Row -> inner Row -> BIGINT scalar.
+    EXPECT_EQ(nimble::visitValueStreamLeaves(*schema, visit), streamExists);
+    // Single-child outer/inner rows, so the recursion still reaches exactly
+    // one leaf (the BIGINT scalar).
     ASSERT_EQ(queriedOffsets.size(), 1);
     EXPECT_EQ(queriedOffsets[0], expectedOffset);
   }


### PR DESCRIPTION
Summary:
Two coupled changes that depend on the same new schema-walk primitive.

# (A) Replace hasValueStreams + collectValueStreamOffsets with one template

`hasValueStreams(type, std::function<bool(offset_size)>)` was the API for
"does any value-stream leaf in this subtree pass a predicate?" It walked
the type tree (Scalar/Array/Map anchor at the leaf; Row recurses; FlatMap
recurses) and probed via a `std::function` callback at each leaf. Two
problems:

1. The `std::function` dispatch (`_Function_handler::_M_invoke`) was
   indirect at every leaf — measurable on per-batch hot paths over
   hundreds of flatmap children.
2. The walk semantics ("recurse first child for Row, recurse all for
   FlatMap, anchor leaf for Scalar/Array/...") were quietly duplicated
   anywhere we needed the offset set without the predicate (e.g.
   "give me the offset list so I can cache it"). Two parallel walkers
   would drift over time.

Collapsed both into one template primitive:

```cpp
template <typename Visitor>
bool visitValueStreamLeaves(const Type& type, Visitor&& visit);
```

The visitor is called once per anchor leaf; returning `true` short-
circuits the walk (matching the old `hasValueStreams` behavior).
Templating eliminates the `std::function` dispatch on every caller —
not just the hot path — without forcing each caller to materialize an
intermediate offset list.

Semantic change: the `Row` case now recurses into **all** children
rather than the first child only. The first-child-only behavior was a
`hasValueStreams`-specific optimization (Row children populate in
lockstep in Nimble, so first-child-present implies any-child-present).
Once the primitive is named "visit every value-stream leaf in the
subtree", the honest implementation must walk every child. Existing
callers' observable behavior is unchanged:

  - Predicate-style callers ("does any leaf pass?"): the visitor
    returns true on the first present leaf, short-circuiting. Same
    answer; may probe additional siblings before short-circuiting when
    early children return false.
  - Sink-style callers (Deserializer construction below): collect every
    leaf offset in the subtree. For value types containing a nested
    `Row<A, B>`, anchor lists grow from 1 to 2 entries; the in-map
    inference still answers the same question via the same
    `break-on-first-hit` logic.

Updated callers:
  - `FlatMapColumnReader::buildColumnReader` (selective Velox reader)
  - `FieldReader::createReader`
  - `Deserializer::createDeserializersForType` — populates a new
    `inMapValueAnchors_` member directly via a sink lambda, no
    intermediate vector.

# (B) Precompute Deserializer in-map anchors at construction

Before: `Deserializer::deserialize()` ran a per-batch
`hasValueStreams(*childType, [&](offset){...})` call for every flatmap
child whose inMap stream was absent in the current batch. With 357
features that's 357 recursive schema walks per batch, each leaf probe
going through `std::function`.

After: the value-stream anchor offsets per flatmap child are
precomputed once at construction (using `visitValueStreamLeaves`) into a
new `inMapValueAnchors_: F14FastMap<uint32_t, vector<offset_size>>`
member. The per-batch in-map inference becomes a flat scan over the
precomputed list, probing the existing `inMapPresentOffsets_` bitmap:

```cpp
for (const auto& [inMapOffset, anchors] : inMapValueAnchors_) {
  if (inMapPresentOffsets_[inMapOffset]) continue;
  for (const auto offset : anchors) {
    if (offset <= maxStreamOffset && inMapPresentOffsets_[offset]) {
      deserializers_[inMapOffset]->addPresentInMapSegment(rowOffset, batchRows);
      break;
    }
  }
}
```

No schema walk on the hot path; no `std::function` dispatch on the hot
path. Combined with the iterateStreams template (preceding diff), this
removes both major sources of per-batch indirect-call dispatch from
flatmap deserialization.

Reviewed By: xiaoxmeng

Differential Revision: D107555413


