### PR TITLE
Coalesce exact duplicate IO ranges

### DIFF
--- a/dwio/nimble/tablet/DataInput.cpp
+++ b/dwio/nimble/tablet/DataInput.cpp
@@ -99,11 +99,45 @@ uint32_t DirectDataInput::enqueue(Region region) {
   for (auto& group : ioGroups) {
     group.bufferOffset = readBytes;
     readBytes += group.readSize;
-    for (const auto& enqueued : group.regions) {
-      payloadBytes += enqueued.region.length;
-    }
+    payloadBytes += group.payloadSize;
   }
   return {readBytes, payloadBytes};
+}
+
+/*static*/ std::pair<uint64_t, uint64_t> DirectDataInput::computePayloadSize(
+    std::span<const EnqueuedRegion> sortedRegions) {
+  NIMBLE_CHECK(!sortedRegions.empty(), "IO group must contain a region");
+
+  const auto& firstRegion = sortedRegions.front().region;
+  uint64_t prevRegionEnd{firstRegion.offset + firstRegion.length};
+  uint64_t payloadSize{firstRegion.length};
+  for (size_t i = 1; i < sortedRegions.size(); ++i) {
+    const auto& region = sortedRegions[i].region;
+    const auto regionEnd = region.offset + region.length;
+    if (regionEnd == prevRegionEnd) {
+      const auto& prevRegion = sortedRegions[i - 1].region;
+      // coalesceIo only keeps exact duplicate ranges in the same IO group so
+      // they can share the physical read. Contained and partially overlapping
+      // ranges are emitted as separate groups.
+      NIMBLE_CHECK_EQ(
+          region.offset,
+          prevRegion.offset,
+          "Only exact duplicate ranges can end at the previous range end");
+      NIMBLE_CHECK_EQ(
+          region.length,
+          prevRegion.length,
+          "Only exact duplicate ranges can end at the previous range end");
+      continue;
+    }
+
+    NIMBLE_CHECK_GE(
+        region.offset,
+        prevRegionEnd,
+        "IO group cannot contain overlapping ranges");
+    payloadSize += region.length;
+    prevRegionEnd = regionEnd;
+  }
+  return {payloadSize, prevRegionEnd};
 }
 
 std::vector<DirectDataInput::IoGroup> DirectDataInput::computeIoGroups(
@@ -112,62 +146,57 @@ std::vector<DirectDataInput::IoGroup> DirectDataInput::computeIoGroups(
   std::iota(items.begin(), items.end(), 0);
 
   int64_t coalescedBytes = 0;
-  std::vector<int32_t> groupEnds;
+  std::vector<IoGroup> ioGroups;
+  ioGroups.reserve(sortedRegions.size());
 
-  const auto coalesceStats = velox::coalesceIo<int32_t, char>(
-      items,
-      /*maxGap=*/maxCoalesceDistance_,
-      /*rangesPerIo=*/std::numeric_limits<int32_t>::max(),
-      /*offsetFunc=*/
-      [&](int32_t i) -> uint64_t { return sortedRegions[i].region.offset; },
-      /*sizeFunc=*/
-      [&](int32_t i) -> int32_t {
-        return static_cast<int32_t>(sortedRegions[i].region.length);
-      },
-      /*numRanges=*/
-      [&](int32_t i) -> int32_t {
-        const auto size = static_cast<int64_t>(sortedRegions[i].region.length);
-        if (coalescedBytes + size > maxCoalesceBytes_) {
-          coalescedBytes = 0;
-          return velox::kNoCoalesce;
-        }
-        coalescedBytes += size;
-        return 1;
-      },
-      /*addRanges=*/
-      [](const int32_t& /*i*/, std::vector<char>& ranges) {
-        ranges.push_back(0);
-      },
-      /*skipRange=*/
-      [](int32_t /*gap*/, std::vector<char>& /*ranges*/) {},
-      /*ioFunc=*/
-      [&](const std::vector<int32_t>& /*items*/,
-          int32_t /*begin*/,
-          int32_t end,
-          uint64_t /*offset*/,
-          const std::vector<char>& /*ranges*/) {
-        coalescedBytes = 0;
-        groupEnds.push_back(end);
-      });
+  const auto coalesceStats =
+      velox::coalesceIo<int32_t, char, /*coalesceDuplicateRanges=*/true>(
+          items,
+          /*maxGap=*/maxCoalesceDistance_,
+          /*rangesPerIo=*/std::numeric_limits<int32_t>::max(),
+          /*offsetFunc=*/
+          [&](int32_t i) -> uint64_t { return sortedRegions[i].region.offset; },
+          /*sizeFunc=*/
+          [&](int32_t i) -> int32_t {
+            return static_cast<int32_t>(sortedRegions[i].region.length);
+          },
+          /*numRanges=*/
+          [&](int32_t i) -> int32_t {
+            const auto size =
+                static_cast<int64_t>(sortedRegions[i].region.length);
+            if (coalescedBytes + size > maxCoalesceBytes_) {
+              coalescedBytes = 0;
+              return velox::kNoCoalesce;
+            }
+            coalescedBytes += size;
+            return 1;
+          },
+          /*addRanges=*/
+          [](const int32_t& /*i*/, std::vector<char>& ranges) {
+            ranges.push_back(0);
+          },
+          /*skipRange=*/
+          [](int32_t /*gap*/, std::vector<char>& /*ranges*/) {},
+          /*ioFunc=*/
+          [&](const std::vector<int32_t>& /*items*/,
+              int32_t begin,
+              int32_t end,
+              uint64_t /*offset*/,
+              const std::vector<char>& /*ranges*/) {
+            coalescedBytes = 0;
+            IoGroup group;
+            const auto groupRegions = std::span<const EnqueuedRegion>(
+                &sortedRegions[begin], static_cast<size_t>(end - begin));
+            const auto [payloadSize, lastEnd] =
+                computePayloadSize(groupRegions);
+            group.readOffset = alignDown(sortedRegions[begin].region.offset);
+            group.readSize = alignUp(lastEnd) - group.readOffset;
+            group.payloadSize = payloadSize;
+            group.regions = groupRegions;
+            ioGroups.emplace_back(group);
+          });
 
   ioStats_->readGap().merge(coalesceStats.gaps);
-
-  std::vector<IoGroup> ioGroups;
-  ioGroups.reserve(groupEnds.size());
-  int32_t groupStart = 0;
-  for (const auto groupEnd : groupEnds) {
-    IoGroup group;
-    const auto firstOffset = sortedRegions[groupStart].region.offset;
-    const auto& lastRegion = sortedRegions[groupEnd - 1].region;
-    const auto lastEnd = lastRegion.offset + lastRegion.length;
-    group.readOffset = alignDown(firstOffset);
-    group.readSize = alignUp(lastEnd) - group.readOffset;
-    group.regions = {
-        &sortedRegions[groupStart], static_cast<size_t>(groupEnd - groupStart)};
-
-    ioGroups.emplace_back(group);
-    groupStart = groupEnd;
-  }
   return ioGroups;
 }
 
@@ -186,6 +215,8 @@ void DirectDataInput::populateBufferRefs(
 
 std::pair<char*, DataInput::Handle> DirectDataInput::allocateBuffer(
     uint64_t bytes) {
+  velox::common::testutil::TestValue::adjust(
+      "facebook::nimble::DirectDataInput::allocateBuffer", &bytes);
   auto* buffer = static_cast<char*>(
       pool_->allocateAligned(static_cast<int64_t>(bytes), allocAlignment_));
   NIMBLE_DCHECK(
@@ -255,20 +286,33 @@ DataInput::Handle DirectDataInput::load() {
   NIMBLE_CHECK(!bufferRefs_.empty(), "No regions enqueued");
   state_ = State::kLoaded;
 
-  // Sort within each group segment in-place, then the flat vector is
-  // globally sorted (groups are already in relative file order).
+  // Sort within each group segment in-place. Groups are expected to be
+  // enqueued in non-overlapping file order, so boundary checks ensure the
+  // flat vector remains globally sorted without sorting across groups.
   const auto numGroups = groupOffsets_.size();
+  uint64_t prevGroupEnd{0};
   for (size_t i = 0; i < numGroups; ++i) {
     const auto start = groupOffsets_[i];
     const auto end = (i + 1 < numGroups)
         ? groupOffsets_[i + 1]
         : static_cast<uint32_t>(regions_.size());
+    NIMBLE_CHECK_LT(start, end, "Read group must contain a region");
     std::sort(
         regions_.begin() + start,
         regions_.begin() + end,
         [](const EnqueuedRegion& a, const EnqueuedRegion& b) {
           return a.region.offset < b.region.offset;
         });
+
+    if (i > 0) {
+      NIMBLE_CHECK_GE(
+          regions_[start].region.offset,
+          prevGroupEnd,
+          "Read groups must be sorted and non-overlapping by file offset");
+    }
+
+    const auto& lastRegion = regions_[end - 1].region;
+    prevGroupEnd = lastRegion.offset + lastRegion.length;
   }
 
   auto ioGroups = computeIoGroups(regions_);
@@ -286,13 +330,9 @@ DataInput::Handle DirectDataInput::load() {
   }
 
   for (const auto& group : ioGroups) {
-    uint64_t groupPayload = 0;
-    for (const auto& region : group.regions) {
-      groupPayload += region.region.length;
-    }
     ioStats_->read().increment(group.readSize);
-    ioStats_->incRawBytesRead(groupPayload);
-    ioStats_->incRawOverreadBytes(group.readSize - groupPayload);
+    ioStats_->incRawBytesRead(group.payloadSize);
+    ioStats_->incRawOverreadBytes(group.readSize - group.payloadSize);
   }
   ioStats_->storageReadLatencyUs().increment(ioUs);
   ioStats_->incTotalScanTimeNs(ioUs * 1'000);

--- a/dwio/nimble/tablet/DataInput.h
+++ b/dwio/nimble/tablet/DataInput.h
@@ -140,24 +140,41 @@ class DirectDataInput : public DataInput {
     // Aligned file offset and size for the coalesced read.
     uint64_t readOffset{0};
     uint64_t readSize{0};
+    // Unique physical bytes requested by the logical regions, excluding
+    // exact duplicate ranges and alignment/coalescing overread.
+    uint64_t payloadSize{0};
     // Byte offset within the shared read buffer.
     uint64_t bufferOffset{0};
     std::span<const EnqueuedRegion> regions;
   };
 
+  // Coalesces sorted regions into physical IO groups. Exact duplicate ranges
+  // can share one physical read when the caller maps them to the same bytes.
   std::vector<IoGroup> computeIoGroups(
       const std::vector<EnqueuedRegion>& sortedRegions);
 
-  // Returns {totalBytes, payloadBytes}.
+  // Computes the unique payload size for a sorted span of regions. Exact
+  // duplicate ranges do not add payload bytes. Returns {payloadSize, lastEnd}
+  // where lastEnd is the end offset of the last accepted range.
+  static std::pair<uint64_t, uint64_t> computePayloadSize(
+      std::span<const EnqueuedRegion> sortedRegions);
+
+  // Computes total read and payload bytes, and sets each group's buffer offset
+  // in the shared read buffer. Returns {readBytes, payloadBytes}.
   static std::pair<uint64_t, uint64_t> computeIoSizes(
       std::vector<IoGroup>& ioGroups);
 
+  // Points each logical buffer ref at its slice inside the shared read buffer.
   void populateBufferRefs(
       const std::vector<IoGroup>& ioGroups,
       const char* buffer);
 
+  // Allocates the shared aligned read buffer and returns a handle that frees
+  // it.
   std::pair<char*, Handle> allocateBuffer(uint64_t bytes);
 
+  // Executes all physical IO groups, batching executor tasks to reduce
+  // scheduling overhead.
   void executeIoGroups(std::vector<IoGroup>& ioGroups, char* buffer);
 
   uint64_t alignDown(uint64_t value) const {

--- a/dwio/nimble/tablet/MetadataInput.cpp
+++ b/dwio/nimble/tablet/MetadataInput.cpp
@@ -118,45 +118,46 @@ std::vector<MetadataInput::IoGroup> MetadataInput::computeIoGroups(
   int64_t coalescedBytes = 0;
   std::vector<int32_t> groupEnds;
 
-  const auto ioStats = velox::coalesceIo<int32_t, char>(
-      items,
-      /*maxGap=*/maxCoalesceDistance_,
-      /*rangesPerIo=*/std::numeric_limits<int32_t>::max(),
-      /*offsetFunc=*/
-      [&](int32_t i) -> uint64_t {
-        return sections[loadIndices[i]].section.offset();
-      },
-      /*sizeFunc=*/
-      [&](int32_t i) -> int32_t {
-        return sections[loadIndices[i]].section.size();
-      },
-      /*numRanges=*/
-      [&](int32_t i) -> int32_t {
-        const auto size = sections[loadIndices[i]].section.size();
-        if (coalescedBytes + size > maxCoalesceBytes_) {
-          coalescedBytes = 0;
-          return velox::kNoCoalesce;
-        }
-        coalescedBytes += size;
-        return 1;
-      },
-      /*addRanges=*/
-      [&](const int32_t& /*i*/, std::vector<char>& ranges) {
-        // Dummy range so coalesceIo sees non-empty ranges for kNoCoalesce
-        // flush check.
-        ranges.push_back(0);
-      },
-      /*skipRange=*/
-      [&](int32_t /*gap*/, std::vector<char>& /*ranges*/) {},
-      /*ioFunc=*/
-      [&](const std::vector<int32_t>& /*items*/,
-          int32_t /*begin*/,
-          int32_t end,
-          uint64_t /*offset*/,
-          const std::vector<char>& /*ranges*/) {
-        coalescedBytes = 0;
-        groupEnds.push_back(end);
-      });
+  const auto ioStats =
+      velox::coalesceIo<int32_t, char, /*coalesceDuplicateRanges=*/false>(
+          items,
+          /*maxGap=*/maxCoalesceDistance_,
+          /*rangesPerIo=*/std::numeric_limits<int32_t>::max(),
+          /*offsetFunc=*/
+          [&](int32_t i) -> uint64_t {
+            return sections[loadIndices[i]].section.offset();
+          },
+          /*sizeFunc=*/
+          [&](int32_t i) -> int32_t {
+            return sections[loadIndices[i]].section.size();
+          },
+          /*numRanges=*/
+          [&](int32_t i) -> int32_t {
+            const auto size = sections[loadIndices[i]].section.size();
+            if (coalescedBytes + size > maxCoalesceBytes_) {
+              coalescedBytes = 0;
+              return velox::kNoCoalesce;
+            }
+            coalescedBytes += size;
+            return 1;
+          },
+          /*addRanges=*/
+          [&](const int32_t& /*i*/, std::vector<char>& ranges) {
+            // Dummy range so coalesceIo sees non-empty ranges for kNoCoalesce
+            // flush check.
+            ranges.push_back(0);
+          },
+          /*skipRange=*/
+          [&](int32_t /*gap*/, std::vector<char>& /*ranges*/) {},
+          /*ioFunc=*/
+          [&](const std::vector<int32_t>& /*items*/,
+              int32_t /*begin*/,
+              int32_t end,
+              uint64_t /*offset*/,
+              const std::vector<char>& /*ranges*/) {
+            coalescedBytes = 0;
+            groupEnds.push_back(end);
+          });
 
   recordCoalescedIoStats(ioStats);
   velox::common::testutil::TestValue::adjust(

--- a/dwio/nimble/tablet/tests/DataInputTest.cpp
+++ b/dwio/nimble/tablet/tests/DataInputTest.cpp
@@ -16,6 +16,7 @@
 #include "dwio/nimble/tablet/DataInput.h"
 
 #include <gtest/gtest.h>
+#include <algorithm>
 #include <random>
 
 #include "dwio/nimble/common/Exceptions.h"
@@ -161,7 +162,7 @@ TEST_P(DataInputParamTest, multipleGroups) {
       {{{500, 100}, {100, 200}, {800, 50}},
        {{50'500, 300}, {50'000, 400}, {60'000, 100}}},
       {{{100, 50}}, {{200, 50}}, {{300, 50}}},
-      {{{500, 50}, {100, 50}}, {{150, 50}, {600, 50}}},
+      {{{500, 50}, {100, 50}}, {{550, 50}, {600, 50}}},
       {{{0, 100}}, {{98'000, 100}}},
   };
 
@@ -245,15 +246,18 @@ TEST_P(DataInputParamTest, fuzz) {
     const int numGroups = 1 + rng() % 5;
     uint32_t totalRegions = 0;
     std::vector<std::vector<std::pair<uint64_t, uint64_t>>> groups(numGroups);
+    uint64_t nextOffset = rng() % 100;
     for (int group = 0; group < numGroups; ++group) {
       const int numRegions = 1 + rng() % 10;
+      uint64_t offset = nextOffset;
       for (int region = 0; region < numRegions; ++region) {
-        const auto maxOffset = fileSize - 4'096;
-        const auto offset = rng() % maxOffset;
-        const auto maxLen = std::min<uint64_t>(4'096, fileSize - offset);
+        const auto maxLen = std::min<uint64_t>(512, fileSize - offset);
         const auto length = 1 + rng() % maxLen;
         groups[group].emplace_back(offset, length);
+        offset += length + rng() % 128;
       }
+      std::shuffle(groups[group].begin(), groups[group].end(), rng);
+      nextOffset = offset + 4'096;
       totalRegions += groups[group].size();
     }
 
@@ -446,6 +450,40 @@ TEST_F(DataInputTest, intraGroupCoalescing) {
   }
 }
 
+DEBUG_ONLY_TEST_F(DataInputTest, coalescesDuplicateRegions) {
+  std::string data(1'000, '\0');
+  for (int i = 0; i < 1'000; ++i) {
+    data[i] = static_cast<char>(i % 256);
+  }
+  auto file = createFile(data);
+
+  DirectDataInput input(file.get(), makeOptions(/*alignment=*/1));
+  input.reserve(4);
+  input.startGroup();
+  const auto duplicate0 = input.enqueue({100, 50});
+  const auto duplicate1 = input.enqueue({100, 50});
+  const auto adjacent0 = input.enqueue({150, 50});
+  const auto adjacent1 = input.enqueue({200, 25});
+
+  uint64_t allocatedBytes = 0;
+  SCOPED_TESTVALUE_SET(
+      "facebook::nimble::DirectDataInput::allocateBuffer",
+      std::function<void(uint64_t*)>(
+          [&](uint64_t* bytes) { allocatedBytes = *bytes; }));
+  auto handle = input.load();
+  EXPECT_EQ(allocatedBytes, 125);
+
+  EXPECT_EQ(refData(input.bufferRef(duplicate0)), data.substr(100, 50));
+  EXPECT_EQ(refData(input.bufferRef(duplicate1)), data.substr(100, 50));
+  EXPECT_EQ(refData(input.bufferRef(adjacent0)), data.substr(150, 50));
+  EXPECT_EQ(refData(input.bufferRef(adjacent1)), data.substr(200, 25));
+  EXPECT_EQ(input.bufferRef(duplicate0).data, input.bufferRef(duplicate1).data);
+  EXPECT_EQ(ioStats_->read().count(), 1);
+  EXPECT_EQ(ioStats_->read().sum(), 125);
+  EXPECT_EQ(ioStats_->rawBytesRead(), 125);
+  EXPECT_EQ(ioStats_->rawOverreadBytes(), 0);
+}
+
 TEST_F(DataInputTest, crossGroupCoalescing) {
   std::string data(10'000, '\0');
   for (int i = 0; i < 10'000; ++i) {
@@ -477,13 +515,6 @@ TEST_F(DataInputTest, crossGroupCoalescing) {
       // Groups in file order but far apart → 2 reads.
       {.groups = {{{100, 50}}, {{5'000, 50}}},
        .maxCoalesceDistance = 100,
-       .expectedReadCount = 2},
-
-      // Groups with interleaved offsets: after intra-group sort,
-      // concatenation is [100, 500, 150, 600] — not globally sorted.
-      // 500→150 goes backward so coalescing breaks → 2+ reads.
-      {.groups = {{{500, 50}, {100, 50}}, {{150, 50}, {600, 50}}},
-       .maxCoalesceDistance = 1'000,
        .expectedReadCount = 2},
 
       // Three groups, all nearby → 1 read.
@@ -527,6 +558,46 @@ TEST_F(DataInputTest, crossGroupCoalescing) {
           data.substr(region.first, region.second));
     }
     EXPECT_EQ(stats->read().count(), testData.expectedReadCount);
+  }
+}
+
+TEST_F(DataInputTest, rejectsInvalidGroupBoundaries) {
+  std::string data(10'000, '\0');
+  auto file = createFile(data);
+
+  using Groups = std::vector<std::vector<std::pair<uint64_t, uint64_t>>>;
+  struct TestParam {
+    std::string name;
+    Groups groups;
+  };
+  std::vector<TestParam> testSettings = {
+      {"interleavedGroups", {{{500, 50}, {100, 50}}, {{150, 50}, {600, 50}}}},
+      {"overlappingGroups", {{{100, 100}}, {{150, 50}}}},
+      {"backwardGroups", {{{500, 50}}, {{100, 50}}}},
+  };
+
+  for (const auto& testData : testSettings) {
+    SCOPED_TRACE(testData.name);
+    DirectDataInput input(
+        file.get(),
+        makeOptions(/*alignment=*/1, /*maxCoalesceDistance=*/1'000));
+
+    uint32_t totalRegions = 0;
+    for (const auto& group : testData.groups) {
+      totalRegions += group.size();
+    }
+    input.reserve(totalRegions);
+
+    for (const auto& group : testData.groups) {
+      input.startGroup();
+      for (const auto& [offset, length] : group) {
+        input.enqueue({offset, length});
+      }
+    }
+
+    NIMBLE_ASSERT_THROW(
+        input.load(),
+        "Read groups must be sorted and non-overlapping by file offset");
   }
 }
 
@@ -611,6 +682,14 @@ TEST_F(DataInputTest, emptyGroup) {
 
   EXPECT_EQ(refData(input.bufferRef(idx)), data.substr(100, 50));
   EXPECT_EQ(refData(input.bufferRef(idx2)), data.substr(500, 50));
+
+  DirectDataInput emptyFinalGroup(file.get(), makeOptions());
+  emptyFinalGroup.reserve(1);
+  emptyFinalGroup.startGroup();
+  emptyFinalGroup.enqueue({100, 50});
+  emptyFinalGroup.startGroup();
+  NIMBLE_ASSERT_THROW(
+      emptyFinalGroup.load(), "Read group must contain a region");
 }
 
 TEST_F(DataInputTest, handleOutlivesDataInput) {

--- a/dwio/nimble/velox/index/tests/NimbleIndexProjectorTest.cpp
+++ b/dwio/nimble/velox/index/tests/NimbleIndexProjectorTest.cpp
@@ -112,13 +112,15 @@ class NimbleIndexProjectorTest : public ::testing::TestWithParam<TestParam> {
       const std::vector<std::string>& indexColumns,
       const folly::F14FastMap<std::string, std::set<std::string>>&
           flatMapColumns = {},
-      uint64_t stripeSize = 4 << 10 /* 4KB */) {
+      uint64_t stripeSize = 4 << 10 /* 4KB */,
+      bool enableStreamDeduplication = true) {
     sinkData_.clear();
     auto writeFile = std::make_unique<InMemoryWriteFile>(&sinkData_);
 
     VeloxWriterOptions options;
     options.enableChunking = true;
     options.flatMapColumns = flatMapColumns;
+    options.enableStreamDeduplication = enableStreamDeduplication;
     ClusterIndexConfig clusterIndexConfig;
     clusterIndexConfig.columns = indexColumns;
     clusterIndexConfig.sortOrders = std::vector<SortOrder>(
@@ -534,6 +536,50 @@ TEST_P(NimbleIndexProjectorTest, overlappingRequestsShareBody) {
   // refcount-shared.
   EXPECT_GT(slice0.computeChainDataLength(), slice0.length());
   EXPECT_GT(slice0.prev()->length(), 0u);
+}
+
+TEST_P(NimbleIndexProjectorTest, deduplicatedProjectedStreamsReadOnce) {
+  auto rowType =
+      ROW({"key", "dup_a", "dup_b"}, {BIGINT(), INTEGER(), INTEGER()});
+
+  constexpr int numRows = 1'024;
+  std::vector<int64_t> keys(numRows);
+  std::vector<int32_t> values(numRows);
+  for (int i = 0; i < numRows; ++i) {
+    keys[i] = i;
+    values[i] = i % 17;
+  }
+
+  auto batch = vectorMaker_->rowVector(
+      {"key", "dup_a", "dup_b"},
+      {vectorMaker_->flatVector<int64_t>(keys),
+       vectorMaker_->flatVector<int32_t>(values),
+       vectorMaker_->flatVector<int32_t>(values)});
+
+  writeData(
+      {batch},
+      {"key"},
+      {},
+      /*stripeSize=*/1 << 20,
+      /*enableStreamDeduplication=*/true);
+
+  std::vector<Subfield> subfields;
+  subfields.emplace_back("dup_a");
+  subfields.emplace_back("dup_b");
+  auto projector = createProjector(subfields);
+
+  auto bounds = makeRangeLookup(rowType, {"key"}, 0, numRows);
+  NimbleIndexProjector::Request request;
+  request.keyBounds = {bounds};
+  auto result = projector->project(request, {});
+
+  ASSERT_EQ(result.responses.size(), 1);
+  ASSERT_EQ(result.responses[0].slices.size(), 1);
+  EXPECT_EQ(projector->stats().numReadStripes, 1);
+  EXPECT_EQ(dataIoStats_->read().count(), 1);
+  EXPECT_LE(dataIoStats_->rawBytesRead() * 2, projector->stats().numOutputBytes)
+      << "The physical payload should be one deduplicated stream while the "
+         "projected output still contains both logical streams";
 }
 
 // Round-trips a single-batch deserialize over a key range. The Deserializer


### PR DESCRIPTION
Summary: Teach shared `velox::coalesceIo` to keep adjacent exact duplicate ranges in the same coalesced IO instead of treating the negative gap as a hard split. Nimble stream deduplication can produce repeated logical streams with the same physical `{offset, length}` and no non-identical overlap; this special case lets `DirectDataInput` issue one physical read for the duplicate stream while preserving the existing split behavior for non-identical overlaps and decreasing ranges. `DirectDataInput` now uses the shared helper again, keeps a global non-decreasing-region check, and the regression coverage verifies both the base coalescer duplicate case and the direct data input duplicate-stream repro.

Differential Revision: D107566265


