### PR TITLE
perf: Optimize FixedBitArray bulk get for 64-bit values (#833)

### DIFF
--- a/dwio/nimble/common/FixedBitArray.cpp
+++ b/dwio/nimble/common/FixedBitArray.cpp
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 #include "dwio/nimble/common/FixedBitArray.h"
+
 #include <glog/logging.h>
 
 namespace facebook::nimble {
@@ -21,8 +22,8 @@ namespace facebook::nimble {
 // Warning: do not change this function or lots of horrible data corruption
 // will probably happen.
 uint64_t FixedBitArray::bufferSize(uint64_t elementCount, int bitWidth) {
-  // We may read up to 7 bytes beyond the last theoretically needed byte,
-  // as we access whole machine words.
+  // We may read or write up to 7 bytes beyond the last theoretically needed
+  // byte, as we access whole machine words.
   constexpr int kSlopSize = 7;
   return velox::bits::nbytes(elementCount * bitWidth) + kSlopSize;
 }
@@ -105,7 +106,7 @@ void FixedBitArray::zeroAndSet(uint64_t index, uint64_t value) {
   word |= value << remainder;
 }
 
-namespace internal {
+namespace {
 
 // T is the output data types, namely uint32_t or uint64_t.
 template <typename T, int bitWidth, int loopPosition, bool withBaseline>
@@ -322,20 +323,52 @@ void bulkGet32Internal(
   return;
 }
 
-} // namespace internal
+template <int byteWidth>
+inline void bulkSetByteAlignedWithBaseline(
+    char* buffer,
+    uint64_t start,
+    uint64_t length,
+    const uint64_t* values,
+    uint64_t baseline) {
+  static_assert(byteWidth >= 4 && byteWidth <= 8);
+  char* next = buffer + start * byteWidth;
+  const uint64_t* nextValue = values;
+  for (uint64_t i = 0; i < length; ++i) {
+    const uint64_t residual{*nextValue++ - baseline};
+    if constexpr (byteWidth == 4) {
+      *reinterpret_cast<uint32_t*>(next) = static_cast<uint32_t>(residual);
+    } else if constexpr (byteWidth == 5) {
+      *reinterpret_cast<uint32_t*>(next) = static_cast<uint32_t>(residual);
+      next[4] = static_cast<char>(residual >> 32);
+    } else if constexpr (byteWidth == 6) {
+      *reinterpret_cast<uint32_t*>(next) = static_cast<uint32_t>(residual);
+      *reinterpret_cast<uint16_t*>(next + 4) =
+          static_cast<uint16_t>(residual >> 32);
+    } else if constexpr (byteWidth == 7) {
+      *reinterpret_cast<uint32_t*>(next) = static_cast<uint32_t>(residual);
+      *reinterpret_cast<uint16_t*>(next + 4) =
+          static_cast<uint16_t>(residual >> 32);
+      next[6] = static_cast<char>(residual >> 48);
+    } else {
+      static_assert(byteWidth == 8);
+      *reinterpret_cast<uint64_t*>(next) = residual;
+    }
+    next += byteWidth;
+  }
+}
+
+} // namespace
 
 void FixedBitArray::bulkGet32(uint64_t start, uint64_t length, uint32_t* values)
     const {
-  internal::bulkGet32Internal<uint32_t, false>(
-      *this, buffer_, start, length, values, 0);
+  bulkGet32Internal<uint32_t, false>(*this, buffer_, start, length, values, 0);
 }
 
 void FixedBitArray::bulkGet32Into64(
     uint64_t start,
     uint64_t length,
     uint64_t* values) const {
-  internal::bulkGet32Internal<uint64_t, false>(
-      *this, buffer_, start, length, values, 0);
+  bulkGet32Internal<uint64_t, false>(*this, buffer_, start, length, values, 0);
 }
 
 void FixedBitArray::bulkGetWithBaseline32(
@@ -343,7 +376,7 @@ void FixedBitArray::bulkGetWithBaseline32(
     uint64_t length,
     uint32_t* values,
     uint32_t baseline) const {
-  internal::bulkGet32Internal<uint32_t, true>(
+  bulkGet32Internal<uint32_t, true>(
       *this, buffer_, start, length, values, baseline);
 }
 
@@ -352,7 +385,7 @@ void FixedBitArray::bulkGetWithBaseline32Into64(
     uint64_t length,
     uint64_t* values,
     uint64_t baseline) const {
-  internal::bulkGet32Internal<uint64_t, true>(
+  bulkGet32Internal<uint64_t, true>(
       *this, buffer_, start, length, values, baseline);
 }
 
@@ -386,11 +419,17 @@ void FixedBitArray::bulkGet64WithBaseline(
   }
 }
 
-template <int bitWidth, int loopPosition, bool withBaseline>
+namespace {
+
+template <
+    int bitWidth,
+    int loopPosition,
+    bool withBaseline,
+    typename InputT = uint32_t>
 void bulkSet32Loop(
     uint64_t** nextWord,
-    const uint32_t** values,
-    uint32_t baseline) {
+    const InputT** values,
+    InputT baseline) {
   // Some bits for the next value may need to put be in the current word.
   constexpr int spillover = (loopPosition * bitWidth) % 64 == 0
       ? 0
@@ -427,19 +466,26 @@ void bulkSet32Loop(
     ++(*values);
   }
   constexpr int nextLoopPosition = loopPosition + valueCount + (spillover > 0);
-  bulkSet32Loop<bitWidth, nextLoopPosition, withBaseline>(
+  bulkSet32Loop<bitWidth, nextLoopPosition, withBaseline, InputT>(
       nextWord, values, baseline);
 }
 
 // Unfortunately we cannot partially specialize the template for the
 // terminal case of loopPosition = 64 so we must explicitly specify them.
+// Only the (uint32_t, false/true) and (uint64_t, true) cases are
+// instantiated; bulkSet64WithBaseline always uses withBaseline=true, so
+// the (uint64_t, false) case is intentionally omitted to avoid unused
+// function lints.
 #define BULK_SET32_LOOP_TERMINAL_CASE(bitWidth)                           \
   template <>                                                             \
-  void bulkSet32Loop<bitWidth, 64, false>(                                \
+  void bulkSet32Loop<bitWidth, 64, false, uint32_t>(                      \
       uint64_t** nextWord, const uint32_t** values, uint32_t baseline) {} \
   template <>                                                             \
-  void bulkSet32Loop<bitWidth, 64, true>(                                 \
-      uint64_t** nextWord, const uint32_t** values, uint32_t baseline) {}
+  void bulkSet32Loop<bitWidth, 64, true, uint32_t>(                       \
+      uint64_t** nextWord, const uint32_t** values, uint32_t baseline) {} \
+  template <>                                                             \
+  void bulkSet32Loop<bitWidth, 64, true, uint64_t>(                       \
+      uint64_t** nextWord, const uint64_t** values, uint64_t baseline) {}
 
 BULK_SET32_LOOP_TERMINAL_CASE(1)
 BULK_SET32_LOOP_TERMINAL_CASE(2)
@@ -476,55 +522,56 @@ BULK_SET32_LOOP_TERMINAL_CASE(32)
 
 #undef BULK_SET32_LOOP_TERMINAL_CASE
 
-template <bool withBaseline>
+template <bool withBaseline, typename InputT = uint32_t>
 void bulkSetInternal32(
     FixedBitArray& fixedBitArray,
     char* buffer,
     uint64_t start,
     uint64_t length,
-    const uint32_t* values,
-    uint32_t baseline) {
+    const InputT* values,
+    InputT baseline) {
   // Same general logic as BulkGet32. See the comments there.
   switch (fixedBitArray.bitWidth()) {
-#define BULK_SET32_SWITCH_CASE(bitWidth)                                      \
-  case bitWidth: {                                                            \
-    const uint64_t alignedStart = velox::bits::divRoundUp(start, 64) << 6;    \
-    if (start + length < alignedStart) {                                      \
-      for (uint64_t i = start; i < start + length; ++i) {                     \
-        if constexpr (withBaseline) {                                         \
-          fixedBitArray.set32(i, (*values) - baseline);                       \
-        } else {                                                              \
-          fixedBitArray.set32(i, *values);                                    \
-        }                                                                     \
-        ++values;                                                             \
-      }                                                                       \
-      return;                                                                 \
-    }                                                                         \
-    for (uint64_t i = start; i < alignedStart; ++i) {                         \
-      if constexpr (withBaseline) {                                           \
-        fixedBitArray.set32(i, (*values) - baseline);                         \
-      } else {                                                                \
-        fixedBitArray.set32(i, *values);                                      \
-      }                                                                       \
-      ++values;                                                               \
-    }                                                                         \
-    const uint64_t loopCount = (length - (alignedStart - start)) >> 6;        \
-    uint64_t* nextWord = reinterpret_cast<uint64_t*>(                         \
-        buffer + ((alignedStart * bitWidth) >> 3) - 8);                       \
-    for (uint64_t i = 0; i < loopCount; ++i) {                                \
-      bulkSet32Loop<bitWidth, 0, withBaseline>(&nextWord, &values, baseline); \
-    }                                                                         \
-    const uint64_t remainderStart = alignedStart + (loopCount << 6);          \
-    const uint64_t remainderEnd = start + length;                             \
-    for (uint64_t i = remainderStart; i < remainderEnd; ++i) {                \
-      if constexpr (withBaseline) {                                           \
-        fixedBitArray.set32(i, (*values) - baseline);                         \
-      } else {                                                                \
-        fixedBitArray.set32(i, *values);                                      \
-      }                                                                       \
-      ++values;                                                               \
-    }                                                                         \
-    return;                                                                   \
+#define BULK_SET32_SWITCH_CASE(bitWidth)                                     \
+  case bitWidth: {                                                           \
+    const uint64_t alignedStart = velox::bits::divRoundUp(start, 64) << 6;   \
+    if (start + length < alignedStart) {                                     \
+      for (uint64_t i = start; i < start + length; ++i) {                    \
+        if constexpr (withBaseline) {                                        \
+          fixedBitArray.set32(i, static_cast<uint32_t>(*values - baseline)); \
+        } else {                                                             \
+          fixedBitArray.set32(i, static_cast<uint32_t>(*values));            \
+        }                                                                    \
+        ++values;                                                            \
+      }                                                                      \
+      return;                                                                \
+    }                                                                        \
+    for (uint64_t i = start; i < alignedStart; ++i) {                        \
+      if constexpr (withBaseline) {                                          \
+        fixedBitArray.set32(i, static_cast<uint32_t>(*values - baseline));   \
+      } else {                                                               \
+        fixedBitArray.set32(i, static_cast<uint32_t>(*values));              \
+      }                                                                      \
+      ++values;                                                              \
+    }                                                                        \
+    const uint64_t loopCount = (length - (alignedStart - start)) >> 6;       \
+    uint64_t* nextWord = reinterpret_cast<uint64_t*>(                        \
+        buffer + ((alignedStart * bitWidth) >> 3) - 8);                      \
+    for (uint64_t i = 0; i < loopCount; ++i) {                               \
+      bulkSet32Loop<bitWidth, 0, withBaseline, InputT>(                      \
+          &nextWord, &values, baseline);                                     \
+    }                                                                        \
+    const uint64_t remainderStart = alignedStart + (loopCount << 6);         \
+    const uint64_t remainderEnd = start + length;                            \
+    for (uint64_t i = remainderStart; i < remainderEnd; ++i) {               \
+      if constexpr (withBaseline) {                                          \
+        fixedBitArray.set32(i, static_cast<uint32_t>(*values - baseline));   \
+      } else {                                                               \
+        fixedBitArray.set32(i, static_cast<uint32_t>(*values));              \
+      }                                                                      \
+      ++values;                                                              \
+    }                                                                        \
+    return;                                                                  \
   }
 
     BULK_SET32_SWITCH_CASE(1)
@@ -568,11 +615,13 @@ void bulkSetInternal32(
   }
 }
 
+} // namespace
+
 void FixedBitArray::bulkSet32(
     uint64_t start,
     uint64_t length,
     const uint32_t* values) {
-  bulkSetInternal32<false>(*this, buffer_, start, length, values, 0);
+  bulkSetInternal32<false, uint32_t>(*this, buffer_, start, length, values, 0);
 }
 
 void FixedBitArray::bulkSet32WithBaseline(
@@ -582,6 +631,91 @@ void FixedBitArray::bulkSet32WithBaseline(
     uint32_t baseline) {
   bulkSetInternal32<true>(*this, buffer_, start, length, values, baseline);
 }
+
+void FixedBitArray::bulkSet64WithBaseline(
+    uint64_t start,
+    uint64_t length,
+    const uint64_t* values,
+    uint64_t baseline) {
+  const int bitWidth = bitWidth_;
+  if (bitWidth < 32) {
+    bulkSetInternal32<true, uint64_t>(
+        *this, buffer_, start, length, values, baseline);
+    return;
+  }
+
+  switch (bitWidth) {
+    case 32: {
+      bulkSetByteAlignedWithBaseline<4>(
+          buffer_, start, length, values, baseline);
+      return;
+    }
+    case 40: {
+      bulkSetByteAlignedWithBaseline<5>(
+          buffer_, start, length, values, baseline);
+      return;
+    }
+    case 48: {
+      bulkSetByteAlignedWithBaseline<6>(
+          buffer_, start, length, values, baseline);
+      return;
+    }
+    case 56: {
+      bulkSetByteAlignedWithBaseline<7>(
+          buffer_, start, length, values, baseline);
+      return;
+    }
+    case 64: {
+      if (baseline == 0) {
+        std::memcpy(
+            buffer_ + start * sizeof(uint64_t),
+            values,
+            length * sizeof(uint64_t));
+        return;
+      }
+      bulkSetByteAlignedWithBaseline<8>(
+          buffer_, start, length, values, baseline);
+      return;
+    }
+    default:
+      break;
+  }
+
+  char* const buffer = buffer_;
+  uint64_t bits = start * static_cast<uint64_t>(bitWidth);
+  if (bitWidth <= 58) {
+    const uint64_t* nextValue = values;
+    for (uint64_t i = 0; i < length; ++i) {
+      const uint64_t residual = *nextValue++ - baseline;
+      const uint64_t offset = bits >> 3;
+      const uint64_t remainder = bits & 7;
+      uint64_t& word = *reinterpret_cast<uint64_t*>(buffer + offset);
+      word |= residual << remainder;
+      bits += bitWidth;
+    }
+    return;
+  }
+
+  // For wide values, the residual can straddle two 64-bit words when the
+  // starting bit offset is not byte/word aligned. Write the low bits into the
+  // current word and spill the remaining high bits into the next word.
+  const uint64_t* nextValue = values;
+  for (uint64_t i = 0; i < length; ++i) {
+    const uint64_t residual = *nextValue++ - baseline;
+    const uint64_t offset = bits >> 3;
+    const uint64_t remainder = bits & 7;
+    uint64_t& word = *reinterpret_cast<uint64_t*>(buffer + offset);
+    word |= residual << remainder;
+    const int overflow = bitWidth + static_cast<int>(remainder) - 64;
+    if (overflow > 0) {
+      uint64_t& nextWord = *reinterpret_cast<uint64_t*>(buffer + offset + 8);
+      nextWord |= residual >> (bitWidth - overflow);
+    }
+    bits += bitWidth;
+  }
+}
+
+namespace {
 
 template <int bitWidth, int loopPosition>
 void equals32Loop(
@@ -665,6 +799,8 @@ EQUALS32_TERMINAL_CASE(31)
 EQUALS32_TERMINAL_CASE(32)
 
 #undef EQUALS32_TERMINAL_CASE
+
+} // namespace
 
 void FixedBitArray::equals32(
     uint64_t start,

--- a/dwio/nimble/common/FixedBitArray.cpp
+++ b/dwio/nimble/common/FixedBitArray.cpp
@@ -324,6 +324,44 @@ void bulkGet32Internal(
 }
 
 template <int byteWidth>
+inline uint64_t loadByteAlignedResidual(const char* next) {
+  static_assert(byteWidth >= 4 && byteWidth <= 8);
+  if constexpr (byteWidth == 4) {
+    return *reinterpret_cast<const uint32_t*>(next);
+  } else if constexpr (byteWidth == 5) {
+    return *reinterpret_cast<const uint32_t*>(next) |
+        (static_cast<uint64_t>(static_cast<unsigned char>(next[4])) << 32);
+  } else if constexpr (byteWidth == 6) {
+    return *reinterpret_cast<const uint32_t*>(next) |
+        (static_cast<uint64_t>(*reinterpret_cast<const uint16_t*>(next + 4))
+         << 32);
+  } else if constexpr (byteWidth == 7) {
+    return *reinterpret_cast<const uint32_t*>(next) |
+        (static_cast<uint64_t>(*reinterpret_cast<const uint16_t*>(next + 4))
+         << 32) |
+        (static_cast<uint64_t>(static_cast<unsigned char>(next[6])) << 48);
+  } else {
+    static_assert(byteWidth == 8);
+    return *reinterpret_cast<const uint64_t*>(next);
+  }
+}
+
+template <int byteWidth>
+inline void bulkGetByteAlignedWithBaseline(
+    const char* buffer,
+    uint64_t start,
+    uint64_t length,
+    uint64_t* values,
+    uint64_t baseline) {
+  const char* next = buffer + start * byteWidth;
+  uint64_t* nextValue = values;
+  for (uint64_t i = 0; i < length; ++i) {
+    *nextValue++ = loadByteAlignedResidual<byteWidth>(next) + baseline;
+    next += byteWidth;
+  }
+}
+
+template <int byteWidth>
 inline void bulkSetByteAlignedWithBaseline(
     char* buffer,
     uint64_t start,
@@ -394,28 +432,82 @@ void FixedBitArray::bulkGet64WithBaseline(
     uint64_t length,
     uint64_t* values,
     uint64_t baseline) const {
-  if (bitWidth_ <= 32) {
+  const int bitWidth = bitWidth_;
+  if (bitWidth < 32) {
     // Delegate to the optimized template-unrolled 32-bit path.
     bulkGetWithBaseline32Into64(start, length, values, baseline);
     return;
   }
-  if (bitWidth_ <= 57) {
-    // Branchless byte-aligned loads: since the sub-byte offset is at most 7,
-    // bitWidth + remainder <= 57 + 7 = 64, so each value fits in a single
-    // 64-bit load — no cross-word boundary branch needed.
+
+  switch (bitWidth) {
+    case 32: {
+      bulkGetByteAlignedWithBaseline<4>(
+          buffer_, start, length, values, baseline);
+      return;
+    }
+    case 40: {
+      bulkGetByteAlignedWithBaseline<5>(
+          buffer_, start, length, values, baseline);
+      return;
+    }
+    case 48: {
+      bulkGetByteAlignedWithBaseline<6>(
+          buffer_, start, length, values, baseline);
+      return;
+    }
+    case 56: {
+      bulkGetByteAlignedWithBaseline<7>(
+          buffer_, start, length, values, baseline);
+      return;
+    }
+    case 64: {
+      bulkGetByteAlignedWithBaseline<8>(
+          buffer_, start, length, values, baseline);
+      return;
+    }
+    default:
+      break;
+  }
+
+  // Hoist members to prevent reload on every iteration -- the compiler
+  // cannot prove that writes to values[] don't alias this->buffer_ etc.
+  const char* const buffer = buffer_;
+  const uint64_t mask = mask_;
+  // Absolute bit offset of the next value from the beginning of the packed
+  // buffer.
+  uint64_t bitsOffset = start * static_cast<uint64_t>(bitWidth);
+  // A single 64-bit load is safe when bitWidth + bitsRemainder <= 64. For
+  // bitWidth 58, bitsRemainder is always even because bitsOffset advances by
+  // 58 bits, so the maximum possible bitsRemainder is 6, not 7.
+  if (bitWidth <= 58) {
     for (uint64_t i = 0; i < length; ++i) {
-      const uint64_t bits = (start + i) * bitWidth_;
-      const uint64_t offset = bits >> 3;
-      const uint64_t remainder = bits & 7;
+      const uint64_t byteOffset = bitsOffset >> 3;
+      const uint64_t bitsRemainder = bitsOffset & 7;
       const uint64_t word =
-          *reinterpret_cast<const uint64_t*>(buffer_ + offset);
-      values[i] = ((word >> remainder) & mask_) + baseline;
+          *reinterpret_cast<const uint64_t*>(buffer + byteOffset);
+      values[i] = ((word >> bitsRemainder) & mask) + baseline;
+      bitsOffset += bitWidth;
     }
-  } else {
-    // Wide bit widths (> 57): need cross-word boundary handling.
-    for (uint64_t i = 0; i < length; ++i) {
-      values[i] = get(start + i) + baseline;
+    return;
+  }
+
+  for (uint64_t i = 0; i < length; ++i) {
+    const uint64_t byteOffset = bitsOffset >> 3;
+    const uint64_t bitsRemainder = bitsOffset & 7;
+    const uint64_t word =
+        *reinterpret_cast<const uint64_t*>(buffer + byteOffset);
+    const int overflow = bitWidth + static_cast<int>(bitsRemainder) - 64;
+    if (overflow > 0) {
+      const uint64_t nextWord =
+          *reinterpret_cast<const uint64_t*>(buffer + byteOffset + 8);
+      values[i] =
+          (((word >> bitsRemainder) | (nextWord << (bitWidth - overflow))) &
+           mask) +
+          baseline;
+    } else {
+      values[i] = ((word >> bitsRemainder) & mask) + baseline;
     }
+    bitsOffset += bitWidth;
   }
 }
 
@@ -682,16 +774,18 @@ void FixedBitArray::bulkSet64WithBaseline(
   }
 
   char* const buffer = buffer_;
-  uint64_t bits = start * static_cast<uint64_t>(bitWidth);
+  // Absolute bit offset of the next value from the beginning of the packed
+  // buffer.
+  uint64_t bitsOffset = start * static_cast<uint64_t>(bitWidth);
   if (bitWidth <= 58) {
     const uint64_t* nextValue = values;
     for (uint64_t i = 0; i < length; ++i) {
-      const uint64_t residual = *nextValue++ - baseline;
-      const uint64_t offset = bits >> 3;
-      const uint64_t remainder = bits & 7;
-      uint64_t& word = *reinterpret_cast<uint64_t*>(buffer + offset);
-      word |= residual << remainder;
-      bits += bitWidth;
+      const uint64_t residualValue = *nextValue++ - baseline;
+      const uint64_t byteOffset = bitsOffset >> 3;
+      const uint64_t bitsRemainder = bitsOffset & 7;
+      uint64_t& word = *reinterpret_cast<uint64_t*>(buffer + byteOffset);
+      word |= residualValue << bitsRemainder;
+      bitsOffset += bitWidth;
     }
     return;
   }
@@ -701,17 +795,18 @@ void FixedBitArray::bulkSet64WithBaseline(
   // current word and spill the remaining high bits into the next word.
   const uint64_t* nextValue = values;
   for (uint64_t i = 0; i < length; ++i) {
-    const uint64_t residual = *nextValue++ - baseline;
-    const uint64_t offset = bits >> 3;
-    const uint64_t remainder = bits & 7;
-    uint64_t& word = *reinterpret_cast<uint64_t*>(buffer + offset);
-    word |= residual << remainder;
-    const int overflow = bitWidth + static_cast<int>(remainder) - 64;
+    const uint64_t residualValue = *nextValue++ - baseline;
+    const uint64_t byteOffset = bitsOffset >> 3;
+    const uint64_t bitsRemainder = bitsOffset & 7;
+    uint64_t& word = *reinterpret_cast<uint64_t*>(buffer + byteOffset);
+    word |= residualValue << bitsRemainder;
+    const int overflow = bitWidth + static_cast<int>(bitsRemainder) - 64;
     if (overflow > 0) {
-      uint64_t& nextWord = *reinterpret_cast<uint64_t*>(buffer + offset + 8);
-      nextWord |= residual >> (bitWidth - overflow);
+      uint64_t& nextWord =
+          *reinterpret_cast<uint64_t*>(buffer + byteOffset + 8);
+      nextWord |= residualValue >> (bitWidth - overflow);
     }
-    bits += bitWidth;
+    bitsOffset += bitWidth;
   }
 }
 

--- a/dwio/nimble/common/FixedBitArray.h
+++ b/dwio/nimble/common/FixedBitArray.h
@@ -17,119 +17,134 @@
 
 #include "velox/common/base/BitUtil.h"
 
-// Packs integers into a fixed number (1-64) of bits and retrieves them.
-// The 'bulk' API provided is particularly efficient at setting/getting
-// ranges of values with small bit widths.
-//
-// Typical usage:
-//   std::vector<uint32_t> data = ...
-//   int bitsRequired = BitsRequired(*maxElement(data.begin(), data.end());
-//   auto buffer = std::make_unique<char[]>(
-//        FixedBitArray::BufferSize(data.size(), bitsRequired));
-//   FixedBitArray fixedBitArray(buffer.get(), bitsRequired);
-//   fixedBitArray.bulkSet32(0, data.size(), data.data());
-//
-// And then you'd store the buffer somewhere, and later read the values back,
-// recovering the info stored in data. Note that the FBA does not own
-// any data.
+/// Packs integers into a fixed number (1-64) of bits and retrieves them.
+/// The 'bulk' API provided is particularly efficient at setting/getting
+/// ranges of values with small bit widths.
+///
+/// Typical usage:
+///   std::vector<uint32_t> data = ...
+///   int bitsRequired = BitsRequired(*maxElement(data.begin(), data.end());
+///   auto buffer = std::make_unique<char[]>(
+///        FixedBitArray::BufferSize(data.size(), bitsRequired));
+///   FixedBitArray fixedBitArray(buffer.get(), bitsRequired);
+///   fixedBitArray.bulkSet32(0, data.size(), data.data());
+///
+/// And then you'd store the buffer somewhere, and later read the values back,
+/// recovering the info stored in data. Note that the FBA does not own
+/// any data.
 
 namespace facebook::nimble {
 
 class FixedBitArray {
  public:
-  // Computes the buffer size needed to hold |elementCount| values with the
-  // specified |bitWidth|. Note that we allocate a few bytes of 'slop' space
-  // beyond what is mathematically required to speed things up.
+  /// Computes the buffer size needed to hold |elementCount| values with the
+  /// specified |bitWidth|. Note that we allocate a few bytes of 'slop' space
+  /// beyond what is mathematically required to speed things up.
   static uint64_t bufferSize(uint64_t elementCount, int bitWidth);
 
-  // Not legal to use; included so we can default construct on the stack.
+  /// Not legal to use; included so we can default construct on the stack.
   FixedBitArray() = default;
 
-  // Creates a fixed bit array stored at buffer whose elements can lie within
-  // the range [0, 2^|bitWidth|). The |buffer| must already be preallocated to
-  // the appropriate size, as given by BufferSize.
+  /// Creates a fixed bit array stored at buffer whose elements can lie within
+  /// the range [0, 2^|bitWidth|). The |buffer| must already be preallocated to
+  /// the appropriate size, as given by BufferSize.
   FixedBitArray(char* buffer, int bitWidth);
 
-  // Convenience constructor for reading read-only data. Note that you are NOT
-  // prevented by the code from using the non-const calls on a FBA constructed
-  // via this method, but to do so is undefined behavior.
+  /// Convenience constructor for reading read-only data. Note that you are NOT
+  /// prevented by the code from using the non-const calls on a FBA constructed
+  /// via this method, but to do so is undefined behavior.
   FixedBitArray(std::string_view buffer, int bitWidth)
       : FixedBitArray(const_cast<char*>(buffer.data()), bitWidth) {}
 
-  // Sets the |index|'th slot to the given |value|. If value
-  // is >= 2^|bitWidth| behavior is undefined.
-  //
-  // IMPORTANT NOTE: this does NOT function as normal assignment.
-  // We do NOT first 0 out the slot, i.e. we use or semantics.
-  // If you need to first 0 it out, use ZeroAndSet.
+  /// Sets the |index|'th slot to the given |value|. If value
+  /// is >= 2^|bitWidth| behavior is undefined.
+  ///
+  /// IMPORTANT NOTE: this does NOT function as normal assignment.
+  /// We do NOT first 0 out the slot, i.e. we use or semantics.
+  /// If you need to first 0 it out, use ZeroAndSet.
   void set(uint64_t index, uint64_t value);
 
-  // Zeroes a slot and then sets it (like normal assignment).
+  /// Zeroes a slot and then sets it (like normal assignment).
   void zeroAndSet(uint64_t index, uint64_t value);
 
-  // Gets the |index|'th value.
+  /// Gets the |index|'th value.
   uint64_t get(uint64_t index) const;
 
-  // Versions of set/get that only work with bitWidth <= 32, but are slightly
-  // faster. Same assignment caveat applies to set32 as to set.
+  /// Versions of set/get that only work with bitWidth <= 32, but are slightly
+  /// faster. Same assignment caveat applies to set32 as to set.
   void set32(uint64_t index, uint32_t value);
+
   uint32_t get32(uint64_t index) const;
 
-  // Retrieves a contiguous subarray from slots [start, start + length).
-  // Considerably faster than looping a get call. Only callable when
-  // bit width <= 32.
+  /// Retrieves a contiguous subarray from slots [start, start + length).
+  /// Considerably faster than looping a get call. Only callable when
+  /// bit width <= 32.
   void bulkGet32(uint64_t start, uint64_t length, uint32_t* values) const;
 
-  // Same as above, but outputs into 8-bytes values. Still requires that bit
-  // width <= 32.
+  /// Same as above, but outputs into 8-bytes values. Still requires that bit
+  /// width <= 32.
   void bulkGet32Into64(uint64_t start, uint64_t length, uint64_t* values) const;
 
-  // Same as above. Add baseline to every value.
+  /// Same as above. Add baseline to every value.
   void bulkGetWithBaseline32(
       uint64_t start,
       uint64_t length,
       uint32_t* values,
       uint32_t baseline) const;
 
-  // Same as above. Add baseline to every value.
+  /// Same as above. Add baseline to every value.
   void bulkGetWithBaseline32Into64(
       uint64_t start,
       uint64_t length,
       uint64_t* values,
       uint64_t baseline) const;
 
-  // Retrieves a contiguous subarray from slots [start, start + length) into
-  // 64-bit output values, adding baseline to each. Supports any bit width
-  // up to 64. For bitWidth <= 32, delegates to the optimized bulkGet32 path.
-  // For bitWidth 33-57, uses branchless byte-aligned loads (single 64-bit
-  // load per value). For bitWidth > 57, handles cross-word boundary overflow.
+  /// Retrieves a contiguous subarray from slots [start, start + length) into
+  /// 64-bit output values, adding baseline to each. Supports any bit width
+  /// up to 64. For bitWidth <= 32, delegates to the optimized bulkGet32 path.
+  /// For bitWidth 33-57, uses branchless byte-aligned loads (single 64-bit
+  /// load per value). For bitWidth > 57, handles cross-word boundary overflow.
   void bulkGet64WithBaseline(
       uint64_t start,
       uint64_t length,
       uint64_t* values,
       uint64_t baseline) const;
 
-  // Sets a contiguous subarray of slots from [start, start + length).
-  // Considerably faster than looping/ a get call. Only callable when bitWidth
-  // <= 32. Same semantics as set -- see the warning there.
+  /// Sets a contiguous subarray of slots from [start, start + length).
+  /// Considerably faster than looping set calls. Only callable when bitWidth
+  /// <= 32. Same semantics as set -- see the warning there.
   void bulkSet32(uint64_t start, uint64_t length, const uint32_t* values);
 
-  // Same as above. Subtracts baseline from every value.
+  /// Same as above. Subtracts baseline from every value.
   void bulkSet32WithBaseline(
       uint64_t start,
       uint64_t length,
       const uint32_t* values,
       uint32_t baseline);
 
-  // Fills in the bit-packed |bitVector| with whether each value in
-  // [start, start + length) equals |value|. Should be faster than
-  // doing bulkGet32 and then doing your own equality check + bitpack.
-  //
-  // bitVector must point to a buffer of at least size BufferSize(length, 1);
-  //
-  // REQUIRES: start is a multiple of 64. If you need to run equals on
-  // a range where that isn't true, you'll have to manually do the part
-  // up to the first multiple of 64 yourself + adjust the results accordingly.
+  /// Sets a contiguous subarray of slots from [start, start + length),
+  /// subtracting baseline from each 64-bit value before packing. Supports any
+  /// value where values[i] >= baseline and values[i] - baseline fits in the
+  /// bit width up to 64. For bitWidth < 32, delegates to the optimized
+  /// bulkSet32 path. For byte-aligned bit widths 32, 40, 48, 56, and 64, uses
+  /// direct stores. Other bit widths up to 58 use a single 64-bit OR per
+  /// value. For bitWidth 59-63, handles cross-word boundary overflow.
+  /// Requires the same zeroed-buffer precondition as set.
+  void bulkSet64WithBaseline(
+      uint64_t start,
+      uint64_t length,
+      const uint64_t* values,
+      uint64_t baseline);
+
+  /// Fills in the bit-packed |bitVector| with whether each value in
+  /// [start, start + length) equals |value|. Should be faster than
+  /// doing bulkGet32 and then doing your own equality check + bitpack.
+  ///
+  /// bitVector must point to a buffer of at least size BufferSize(length, 1);
+  ///
+  /// REQUIRES: start is a multiple of 64. If you need to run equals on
+  /// a range where that isn't true, you'll have to manually do the part
+  /// up to the first multiple of 64 yourself + adjust the results accordingly.
   void equals32(
       uint64_t start,
       uint64_t length,

--- a/dwio/nimble/common/FixedBitArray.h
+++ b/dwio/nimble/common/FixedBitArray.h
@@ -101,9 +101,10 @@ class FixedBitArray {
 
   /// Retrieves a contiguous subarray from slots [start, start + length) into
   /// 64-bit output values, adding baseline to each. Supports any bit width
-  /// up to 64. For bitWidth <= 32, delegates to the optimized bulkGet32 path.
-  /// For bitWidth 33-57, uses branchless byte-aligned loads (single 64-bit
-  /// load per value). For bitWidth > 57, handles cross-word boundary overflow.
+  /// up to 64. For bitWidth < 32, delegates to the optimized bulkGet32 path.
+  /// For byte-aligned bit widths 32, 40, 48, 56, and 64, uses direct loads.
+  /// Other bit widths up to 58 use a single 64-bit load per value. For
+  /// bitWidth 59-63, handles cross-word boundary overflow.
   void bulkGet64WithBaseline(
       uint64_t start,
       uint64_t length,

--- a/dwio/nimble/common/benchmarks/FixedBitArrayBenchmark.cpp
+++ b/dwio/nimble/common/benchmarks/FixedBitArrayBenchmark.cpp
@@ -1,0 +1,176 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include <cstring>
+#include <memory>
+#include <vector>
+
+#include "dwio/nimble/common/FixedBitArray.h"
+#include "folly/Benchmark.h"
+#include "folly/init/Init.h"
+
+using namespace ::facebook;
+
+namespace {
+
+constexpr uint64_t kNumElements = 1000 * 1000;
+constexpr uint64_t kBaseline = 12345;
+constexpr uint64_t kStartOffset = 37;
+
+uint64_t maskForBitWidth(int bitWidth) {
+  return bitWidth == 64 ? ~0ULL : ((1ULL << bitWidth) - 1);
+}
+
+std::vector<uint64_t> makeValues(int bitWidth) {
+  const uint64_t mask = maskForBitWidth(bitWidth);
+  const uint64_t baseline = bitWidth == 64 ? 0 : kBaseline;
+  std::vector<uint64_t> values(kNumElements);
+  for (uint64_t i = 0; i < kNumElements; ++i) {
+    const uint64_t residual = (i * 1000003ULL) & mask;
+    values[i] = residual + baseline;
+  }
+  return values;
+}
+
+void clearBuffer(char* _Nonnull buffer, uint64_t bufferBytes) {
+  std::memset(buffer, 0, bufferBytes);
+}
+
+void observeWrittenBuffer(
+    const char* buffer,
+    uint64_t elementCount,
+    int bitWidth) {
+  const uint64_t writtenBytes =
+      ((elementCount * static_cast<uint64_t>(bitWidth)) + 7) >> 3;
+  folly::doNotOptimizeAway(buffer[writtenBytes - 1]);
+}
+
+#define FIXED_BIT_ARRAY_BENCHMARKS(bitWidth)                                   \
+  BENCHMARK(BulkSet64WithBaseline_##bitWidth, iters) {                         \
+    std::vector<uint64_t> values;                                              \
+    std::unique_ptr<char[]> buffer;                                            \
+    uint64_t bufferBytes;                                                      \
+    BENCHMARK_SUSPEND {                                                        \
+      values = makeValues(bitWidth);                                           \
+      bufferBytes = nimble::FixedBitArray::bufferSize(kNumElements, bitWidth); \
+      buffer = std::make_unique<char[]>(bufferBytes);                          \
+    }                                                                          \
+    nimble::FixedBitArray fixedBitArray(buffer.get(), bitWidth);               \
+    const uint64_t baseline = bitWidth == 64 ? 0 : kBaseline;                  \
+    while (iters--) {                                                          \
+      BENCHMARK_SUSPEND {                                                      \
+        clearBuffer(buffer.get(), bufferBytes);                                \
+      }                                                                        \
+      fixedBitArray.bulkSet64WithBaseline(                                     \
+          0, kNumElements, values.data(), baseline);                           \
+      observeWrittenBuffer(buffer.get(), kNumElements, bitWidth);              \
+    }                                                                          \
+  }                                                                            \
+  BENCHMARK_RELATIVE(ScalarSetWithBaseline_##bitWidth, iters) {                \
+    std::vector<uint64_t> values;                                              \
+    std::unique_ptr<char[]> buffer;                                            \
+    uint64_t bufferBytes;                                                      \
+    BENCHMARK_SUSPEND {                                                        \
+      values = makeValues(bitWidth);                                           \
+      bufferBytes = nimble::FixedBitArray::bufferSize(kNumElements, bitWidth); \
+      buffer = std::make_unique<char[]>(bufferBytes);                          \
+    }                                                                          \
+    nimble::FixedBitArray fixedBitArray(buffer.get(), bitWidth);               \
+    const uint64_t baseline = bitWidth == 64 ? 0 : kBaseline;                  \
+    while (iters--) {                                                          \
+      BENCHMARK_SUSPEND {                                                      \
+        clearBuffer(buffer.get(), bufferBytes);                                \
+      }                                                                        \
+      const uint64_t* nextValue = values.data();                               \
+      for (uint64_t i = 0; i < kNumElements; ++i) {                            \
+        fixedBitArray.set(i, *nextValue - baseline);                           \
+        ++nextValue;                                                           \
+      }                                                                        \
+      observeWrittenBuffer(buffer.get(), kNumElements, bitWidth);              \
+    }                                                                          \
+  }
+
+#define FIXED_BIT_ARRAY_OFFSET_SET_BENCHMARKS(bitWidth)               \
+  BENCHMARK(BulkSet64WithBaselineOffset_##bitWidth, iters) {          \
+    std::vector<uint64_t> values;                                     \
+    std::unique_ptr<char[]> buffer;                                   \
+    uint64_t bufferBytes;                                             \
+    BENCHMARK_SUSPEND {                                               \
+      values = makeValues(bitWidth);                                  \
+      bufferBytes = nimble::FixedBitArray::bufferSize(                \
+          kStartOffset + kNumElements, bitWidth);                     \
+      buffer = std::make_unique<char[]>(bufferBytes);                 \
+    }                                                                 \
+    nimble::FixedBitArray fixedBitArray(buffer.get(), bitWidth);      \
+    const uint64_t baseline = bitWidth == 64 ? 0 : kBaseline;         \
+    while (iters--) {                                                 \
+      BENCHMARK_SUSPEND {                                             \
+        clearBuffer(buffer.get(), bufferBytes);                       \
+      }                                                               \
+      fixedBitArray.bulkSet64WithBaseline(                            \
+          kStartOffset, kNumElements, values.data(), baseline);       \
+      observeWrittenBuffer(                                           \
+          buffer.get(), kStartOffset + kNumElements, bitWidth);       \
+    }                                                                 \
+  }                                                                   \
+  BENCHMARK_RELATIVE(ScalarSetWithBaselineOffset_##bitWidth, iters) { \
+    std::vector<uint64_t> values;                                     \
+    std::unique_ptr<char[]> buffer;                                   \
+    uint64_t bufferBytes;                                             \
+    BENCHMARK_SUSPEND {                                               \
+      values = makeValues(bitWidth);                                  \
+      bufferBytes = nimble::FixedBitArray::bufferSize(                \
+          kStartOffset + kNumElements, bitWidth);                     \
+      buffer = std::make_unique<char[]>(bufferBytes);                 \
+    }                                                                 \
+    nimble::FixedBitArray fixedBitArray(buffer.get(), bitWidth);      \
+    const uint64_t baseline = bitWidth == 64 ? 0 : kBaseline;         \
+    while (iters--) {                                                 \
+      BENCHMARK_SUSPEND {                                             \
+        clearBuffer(buffer.get(), bufferBytes);                       \
+      }                                                               \
+      const uint64_t* nextValue = values.data();                      \
+      for (uint64_t i = 0; i < kNumElements; ++i) {                   \
+        fixedBitArray.set(kStartOffset + i, *nextValue - baseline);   \
+        ++nextValue;                                                  \
+      }                                                               \
+      observeWrittenBuffer(                                           \
+          buffer.get(), kStartOffset + kNumElements, bitWidth);       \
+    }                                                                 \
+  }
+
+FIXED_BIT_ARRAY_BENCHMARKS(16)
+FIXED_BIT_ARRAY_BENCHMARKS(32)
+FIXED_BIT_ARRAY_BENCHMARKS(33)
+FIXED_BIT_ARRAY_BENCHMARKS(40)
+FIXED_BIT_ARRAY_BENCHMARKS(48)
+FIXED_BIT_ARRAY_BENCHMARKS(56)
+FIXED_BIT_ARRAY_BENCHMARKS(57)
+FIXED_BIT_ARRAY_BENCHMARKS(58)
+FIXED_BIT_ARRAY_BENCHMARKS(60)
+FIXED_BIT_ARRAY_BENCHMARKS(64)
+
+FIXED_BIT_ARRAY_OFFSET_SET_BENCHMARKS(32)
+FIXED_BIT_ARRAY_OFFSET_SET_BENCHMARKS(40)
+FIXED_BIT_ARRAY_OFFSET_SET_BENCHMARKS(48)
+FIXED_BIT_ARRAY_OFFSET_SET_BENCHMARKS(56)
+FIXED_BIT_ARRAY_OFFSET_SET_BENCHMARKS(64)
+
+} // namespace
+
+int main(int argc, char** argv) {
+  folly::Init init(&argc, &argv);
+  folly::runBenchmarks();
+}

--- a/dwio/nimble/common/benchmarks/FixedBitArrayBenchmark.cpp
+++ b/dwio/nimble/common/benchmarks/FixedBitArrayBenchmark.cpp
@@ -100,6 +100,57 @@ void observeWrittenBuffer(
       }                                                                        \
       observeWrittenBuffer(buffer.get(), kNumElements, bitWidth);              \
     }                                                                          \
+  }                                                                            \
+  BENCHMARK(BulkGet64WithBaseline_##bitWidth, iters) {                         \
+    std::vector<uint64_t> values;                                              \
+    std::unique_ptr<char[]> buffer;                                            \
+    std::vector<uint64_t> output;                                              \
+    BENCHMARK_SUSPEND {                                                        \
+      values = makeValues(bitWidth);                                           \
+      const uint64_t bufferBytes =                                             \
+          nimble::FixedBitArray::bufferSize(kNumElements, bitWidth);           \
+      buffer = std::make_unique<char[]>(bufferBytes);                          \
+      clearBuffer(buffer.get(), bufferBytes);                                  \
+      output.resize(kNumElements);                                             \
+      nimble::FixedBitArray fixedBitArray(buffer.get(), bitWidth);             \
+      const uint64_t baseline = bitWidth == 64 ? 0 : kBaseline;                \
+      fixedBitArray.bulkSet64WithBaseline(                                     \
+          0, kNumElements, values.data(), baseline);                           \
+    }                                                                          \
+    nimble::FixedBitArray fixedBitArray(buffer.get(), bitWidth);               \
+    const uint64_t baseline = bitWidth == 64 ? 0 : kBaseline;                  \
+    while (iters--) {                                                          \
+      fixedBitArray.bulkGet64WithBaseline(                                     \
+          0, kNumElements, output.data(), baseline);                           \
+      folly::doNotOptimizeAway(*(output.data() + kNumElements - 1));           \
+    }                                                                          \
+  }                                                                            \
+  BENCHMARK_RELATIVE(ScalarGetWithBaseline_##bitWidth, iters) {                \
+    std::vector<uint64_t> values;                                              \
+    std::unique_ptr<char[]> buffer;                                            \
+    std::vector<uint64_t> output;                                              \
+    BENCHMARK_SUSPEND {                                                        \
+      values = makeValues(bitWidth);                                           \
+      const uint64_t bufferBytes =                                             \
+          nimble::FixedBitArray::bufferSize(kNumElements, bitWidth);           \
+      buffer = std::make_unique<char[]>(bufferBytes);                          \
+      clearBuffer(buffer.get(), bufferBytes);                                  \
+      output.resize(kNumElements);                                             \
+      nimble::FixedBitArray fixedBitArray(buffer.get(), bitWidth);             \
+      const uint64_t baseline = bitWidth == 64 ? 0 : kBaseline;                \
+      fixedBitArray.bulkSet64WithBaseline(                                     \
+          0, kNumElements, values.data(), baseline);                           \
+    }                                                                          \
+    nimble::FixedBitArray fixedBitArray(buffer.get(), bitWidth);               \
+    const uint64_t baseline = bitWidth == 64 ? 0 : kBaseline;                  \
+    while (iters--) {                                                          \
+      uint64_t* nextOutput = output.data();                                    \
+      for (uint64_t i = 0; i < kNumElements; ++i) {                            \
+        *nextOutput = fixedBitArray.get(i) + baseline;                         \
+        ++nextOutput;                                                          \
+      }                                                                        \
+      folly::doNotOptimizeAway(*(output.data() + kNumElements - 1));           \
+    }                                                                          \
   }
 
 #define FIXED_BIT_ARRAY_OFFSET_SET_BENCHMARKS(bitWidth)               \

--- a/dwio/nimble/common/tests/FixedBitArrayTests.cpp
+++ b/dwio/nimble/common/tests/FixedBitArrayTests.cpp
@@ -460,3 +460,103 @@ TEST(FixedBitArrayTests, Equals32Random) {
     }
   }
 }
+
+TEST(FixedBitArrayTests, bulkSet64WithBaseline) {
+  auto seed = folly::Random::rand32();
+  LOG(INFO) << "seed: " << seed;
+  std::mt19937 rng(seed);
+
+  // Test all three code paths:
+  // - bitWidth <= 32: delegates to template-unrolled bulkSetInternal32
+  // - bitWidth 33-58: branchless byte-aligned stores
+  // - bitWidth > 58: inline cross-word boundary handling
+  for (int bitWidth = 1; bitWidth <= 64; ++bitWidth) {
+    SCOPED_TRACE(fmt::format("bitWidth={}", bitWidth));
+    const uint64_t maxElement = bitWidth == 64
+        ? std::numeric_limits<uint64_t>::max()
+        : (1ULL << bitWidth) - 1;
+    const uint64_t baseline = folly::Random::rand64(rng) % (maxElement / 2 + 1);
+    const uint64_t valueRange = maxElement - baseline;
+
+    for (int test = 0; test < kNumTestsPerBitWidth; ++test) {
+      const int elementCount = 1 + folly::Random::rand32(rng) % kMaxElements;
+      const auto bufferBytes =
+          nimble::FixedBitArray::bufferSize(elementCount, bitWidth);
+      auto buffer = std::make_unique<char[]>(bufferBytes);
+      std::memset(buffer.get(), 0, bufferBytes);
+      nimble::FixedBitArray fixedBitArray(buffer.get(), bitWidth);
+
+      std::vector<uint64_t> inputValues(elementCount);
+      std::vector<uint64_t> expectedResiduals(elementCount);
+      for (int i = 0; i < elementCount; ++i) {
+        expectedResiduals[i] =
+            valueRange == std::numeric_limits<uint64_t>::max()
+            ? folly::Random::rand64(rng)
+            : folly::Random::rand64(rng) % (valueRange + 1);
+        inputValues[i] = expectedResiduals[i] + baseline;
+      }
+
+      fixedBitArray.bulkSet64WithBaseline(
+          0, elementCount, inputValues.data(), baseline);
+
+      for (int i = 0; i < elementCount; ++i) {
+        ASSERT_EQ(fixedBitArray.get(i), expectedResiduals[i]) << "i=" << i;
+      }
+
+      std::vector<uint64_t> recovered(elementCount);
+      fixedBitArray.bulkGet64WithBaseline(
+          0, elementCount, recovered.data(), baseline);
+      ASSERT_EQ(recovered, inputValues);
+    }
+  }
+}
+
+TEST(FixedBitArrayTests, bulkSet64WithBaselinePartialRange) {
+  auto seed = folly::Random::rand32();
+  LOG(INFO) << "seed: " << seed;
+  std::mt19937 rng(seed);
+
+  for (int bitWidth : {4, 16, 32, 33, 40, 48, 56, 57, 58, 64}) {
+    SCOPED_TRACE(fmt::format("bitWidth={}", bitWidth));
+    const uint64_t maxElement = bitWidth == 64
+        ? std::numeric_limits<uint64_t>::max()
+        : (1ULL << bitWidth) - 1;
+    const uint64_t baseline = folly::Random::rand64(rng) % (maxElement / 2 + 1);
+    const uint64_t valueRange = maxElement - baseline;
+
+    const int elementCount = 200;
+    const auto bufferBytes =
+        nimble::FixedBitArray::bufferSize(elementCount, bitWidth);
+    auto buffer = std::make_unique<char[]>(bufferBytes);
+    std::memset(buffer.get(), 0, bufferBytes);
+    nimble::FixedBitArray fixedBitArray(buffer.get(), bitWidth);
+
+    const int offset = 50;
+    const int count = 100;
+    std::vector<uint64_t> inputValues(count);
+    for (int i = 0; i < count; ++i) {
+      const uint64_t residual =
+          valueRange == std::numeric_limits<uint64_t>::max()
+          ? folly::Random::rand64(rng)
+          : folly::Random::rand64(rng) % (valueRange + 1);
+      inputValues[i] = residual + baseline;
+    }
+
+    fixedBitArray.bulkSet64WithBaseline(
+        offset, count, inputValues.data(), baseline);
+
+    for (int i = 0; i < count; ++i) {
+      ASSERT_EQ(fixedBitArray.get(offset + i), inputValues[i] - baseline)
+          << "i=" << i;
+    }
+
+    for (int i = 0; i < offset; ++i) {
+      ASSERT_EQ(fixedBitArray.get(i), 0)
+          << "pre-range slot " << i << " should be zero";
+    }
+    for (int i = offset + count; i < elementCount; ++i) {
+      ASSERT_EQ(fixedBitArray.get(i), 0)
+          << "post-range slot " << i << " should be zero";
+    }
+  }
+}

--- a/dwio/nimble/common/tests/FixedBitArrayTests.cpp
+++ b/dwio/nimble/common/tests/FixedBitArrayTests.cpp
@@ -266,8 +266,8 @@ TEST(FixedBitArrayTests, bulkGet64WithBaseline) {
 
   // Test all three code paths:
   // - bitWidth <= 32: delegates to bulkGetWithBaseline32Into64
-  // - bitWidth 33-56: branchless byte-aligned loads
-  // - bitWidth > 56: per-element get() fallback
+  // - bitWidth 33-58: branchless byte-aligned loads
+  // - bitWidth > 58: inline cross-word boundary handling
   for (int bitWidth = 1; bitWidth <= 64; ++bitWidth) {
     SCOPED_TRACE(fmt::format("bitWidth={}", bitWidth));
     const uint64_t maxElement = bitWidth == 64
@@ -278,13 +278,10 @@ TEST(FixedBitArrayTests, bulkGet64WithBaseline) {
 
     for (int test = 0; test < kNumTestsPerBitWidth; ++test) {
       const int elementCount = folly::Random::rand32(rng) % kMaxElements;
-      auto buffer = std::make_unique<char[]>(
-          nimble::FixedBitArray::bufferSize(elementCount, bitWidth));
-      // Zero-initialize buffer since set() uses OR semantics.
-      std::memset(
-          buffer.get(),
-          0,
-          nimble::FixedBitArray::bufferSize(elementCount, bitWidth));
+      const auto bufferBytes =
+          nimble::FixedBitArray::bufferSize(elementCount, bitWidth);
+      auto buffer = std::make_unique<char[]>(bufferBytes);
+      std::memset(buffer.get(), 0, bufferBytes);
       nimble::FixedBitArray fixedBitArray(buffer.get(), bitWidth);
 
       std::vector<uint64_t> randomValues(elementCount);
@@ -334,18 +331,16 @@ TEST(FixedBitArrayTests, bulkGet64WithBaselineZeroBaseline) {
   LOG(INFO) << "seed: " << seed;
   std::mt19937 rng(seed);
 
-  for (int bitWidth : {1, 8, 16, 32, 40, 48, 56, 60, 64}) {
+  for (int bitWidth : {1, 8, 16, 32, 33, 40, 48, 56, 57, 58, 60, 64}) {
     SCOPED_TRACE(fmt::format("bitWidth={}", bitWidth));
     const int elementCount = 100 + folly::Random::rand32(rng) % 200;
     const uint64_t maxElement = bitWidth == 64
         ? std::numeric_limits<uint64_t>::max()
         : (1ULL << bitWidth) - 1;
-    auto buffer = std::make_unique<char[]>(
-        nimble::FixedBitArray::bufferSize(elementCount, bitWidth));
-    std::memset(
-        buffer.get(),
-        0,
-        nimble::FixedBitArray::bufferSize(elementCount, bitWidth));
+    const auto bufferBytes =
+        nimble::FixedBitArray::bufferSize(elementCount, bitWidth);
+    auto buffer = std::make_unique<char[]>(bufferBytes);
+    std::memset(buffer.get(), 0, bufferBytes);
     nimble::FixedBitArray fixedBitArray(buffer.get(), bitWidth);
 
     for (int i = 0; i < elementCount; ++i) {
@@ -459,6 +454,28 @@ TEST(FixedBitArrayTests, Equals32Random) {
       }
     }
   }
+}
+
+TEST(FixedBitArrayTests, bulkGet64WithBaselineBitWidth58Boundary) {
+  constexpr int bitWidth = 58;
+  constexpr int elementCount = 5;
+  constexpr int start = 3;
+  constexpr uint64_t baseline = 17;
+  constexpr uint64_t maxElement = (1ULL << bitWidth) - 1;
+
+  const auto bufferBytes =
+      nimble::FixedBitArray::bufferSize(elementCount, bitWidth);
+  auto buffer = std::make_unique<char[]>(bufferBytes);
+  std::memset(buffer.get(), 0, bufferBytes);
+  nimble::FixedBitArray fixedBitArray(buffer.get(), bitWidth);
+
+  // start * bitWidth leaves a bit remainder of 6. For bitWidth 58 this is the
+  // highest possible remainder, and 58 + 6 exactly fills one 64-bit load.
+  fixedBitArray.set(start, maxElement);
+
+  uint64_t value = 0;
+  fixedBitArray.bulkGet64WithBaseline(start, 1, &value, baseline);
+  ASSERT_EQ(value, maxElement + baseline);
 }
 
 TEST(FixedBitArrayTests, bulkSet64WithBaseline) {

--- a/dwio/nimble/encodings/tests/FixedBitWidthEncodingTest.cpp
+++ b/dwio/nimble/encodings/tests/FixedBitWidthEncodingTest.cpp
@@ -345,6 +345,66 @@ TYPED_TEST(FixedBitWidthEncodingTest, wideRange) {
   }
 }
 
+TYPED_TEST(FixedBitWidthEncodingTest, uint64MaterializeWideBitWidths) {
+  const nimble::Encoding::Options options{
+      .useVarintRowCount = TypeParam::useVarint};
+
+  auto roundTripAfterSkip = [&](const std::vector<uint64_t>& values) {
+    nimble::Vector<uint64_t> nimbleValues{
+        this->pool_.get(), values.begin(), values.end()};
+    auto encoding = nimble::test::
+        Encoder<nimble::FixedBitWidthEncoding<uint64_t>>::createEncoding(
+            *this->buffer_,
+            nimbleValues,
+            this->stringBufferFactory(),
+            nimble::CompressionType::Uncompressed,
+            options);
+
+    constexpr uint32_t skipCount = 3;
+    encoding->skip(skipCount);
+
+    std::vector<uint64_t> result(values.size() - skipCount);
+    encoding->materialize(static_cast<uint32_t>(result.size()), result.data());
+
+    const std::vector<uint64_t> expected{
+        values.begin() + skipCount, values.end()};
+    EXPECT_EQ(result, expected);
+  };
+
+  roundTripAfterSkip(
+      {100,
+       101,
+       102,
+       103,
+       100 + (uint64_t{1} << 40) - 1,
+       100 + (uint64_t{1} << 39),
+       100 + 17});
+  roundTripAfterSkip(
+      {17,
+       18,
+       19,
+       20,
+       17 + (uint64_t{1} << 58) - 1,
+       17 + (uint64_t{1} << 57),
+       17 + 42});
+  roundTripAfterSkip(
+      {29,
+       30,
+       31,
+       32,
+       29 + (uint64_t{1} << 60) - 1,
+       29 + (uint64_t{1} << 59),
+       29 + 99});
+  roundTripAfterSkip(
+      {0,
+       1,
+       2,
+       3,
+       std::numeric_limits<uint64_t>::max(),
+       uint64_t{1} << 63,
+       42});
+}
+
 TYPED_TEST(FixedBitWidthEncodingTest, skipToEnd) {
   const nimble::Encoding::Options options{
       .useVarintRowCount = TypeParam::useVarint};

--- a/dwio/nimble/encodings/tests/ReadWithVisitorTest.cpp
+++ b/dwio/nimble/encodings/tests/ReadWithVisitorTest.cpp
@@ -1746,11 +1746,11 @@ TEST_P(
 // ---------------------------------------------------------------------------
 // 13. FixedBitWidthEncoding<int32_t> + AlwaysTrue + dense + FAST PATH
 //     The FixedBitWidth fast path (bulkScan) requires:
-//       - isFourByteIntegralType (int32_t/uint32_t only, NOT int64_t)
+//       - 4-byte or 8-byte integral physical type
 //       - No filter (!kHasFilter → AlwaysTrue)
 //       - No hook (!kHasHook → ExtractToReader)
 //       - kExtractToReader && (kSameType || kIsWidening)
-//     This test uses int32_t data to satisfy all conditions.
+//     This test uses int32_t data to exercise the 4-byte path.
 // ---------------------------------------------------------------------------
 TEST_P(
     ReadWithVisitorTest,
@@ -1811,6 +1811,84 @@ TEST_P(
   auto values = getValues<int32_t>(reader);
   for (int i = 0; i < kRows; ++i) {
     EXPECT_EQ(values[i], i % 16) << "row " << i;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// 13a. FixedBitWidthEncoding<int64_t> + AlwaysTrue + dense + FAST PATH
+//      Exercises the 8-byte bulkScan path, which decodes through
+//      FixedBitArray::bulkGet64WithBaseline.
+// ---------------------------------------------------------------------------
+TEST_P(
+    ReadWithVisitorTest,
+    encodingLevelFixedBitWidthAlwaysTrueDenseInt64FastPath) {
+  constexpr int kRows = 500;
+  constexpr int64_t kBaseline = 1000;
+  constexpr int64_t kLargeResidual = (int64_t{1} << 60) - 1;
+
+  std::vector<int64_t> data(kRows);
+  for (int i = 0; i < kRows; ++i) {
+    int64_t residual = 0;
+    switch (i % 4) {
+      case 0:
+        residual = 0;
+        break;
+      case 1:
+        residual = 17;
+        break;
+      case 2:
+        residual = int64_t{1} << 59;
+        break;
+      default:
+        residual = kLargeResidual - (i % 17);
+        break;
+    }
+    data[i] = kBaseline + residual;
+  }
+
+  auto input = makeRowVector(
+      {makeFlatVector<int64_t>(kRows, [&data](auto i) { return data[i]; })});
+  auto rowType = asRowType(input->type());
+  auto ctx = makeFileContext(input);
+  auto scanSpec = std::make_shared<common::ScanSpec>("root");
+  scanSpec->addAllChildFields(*rowType);
+  scanSpec->childByName("c0")->setFilter(
+      std::make_unique<common::AlwaysTrue>());
+  auto root = buildReader(*ctx, rowType, *scanSpec);
+
+  auto* structReader =
+      dynamic_cast<dwio::common::SelectiveStructColumnReaderBase*>(root.get());
+  auto* reader = static_cast<IntegerColumnReaderTestAccessor*>(
+      dynamic_cast<IntegerColumnReader*>(structReader->children()[0]));
+  ASSERT_NE(reader, nullptr);
+
+  std::vector<vector_size_t> rowVec(kRows);
+  std::iota(rowVec.begin(), rowVec.end(), 0);
+  RowSet rows(rowVec.data(), rowVec.size());
+
+  reader->doPrepareRead<int64_t>(0, rows, nullptr);
+
+  Buffer buffer(*pool());
+  auto encoding = createFromCustomLayout<int64_t>(
+      FixedBitWidthEnc{}, data, *pool(), buffer);
+
+  common::AlwaysTrue filter;
+  dwio::common::ExtractToReader extractValues(reader);
+  constexpr bool kIsDense = true;
+  DecoderVisitor<
+      int64_t,
+      common::AlwaysTrue,
+      dwio::common::ExtractToReader,
+      kIsDense>
+      visitor(filter, reader, rows, extractValues);
+  auto params = makeReadWithVisitorParams(visitor, rows, pool());
+
+  dispatchCallReadWithVisitor(*encoding, visitor, params);
+
+  EXPECT_EQ(reader->numValues(), kRows);
+  auto values = getValues<int64_t>(reader);
+  for (int i = 0; i < kRows; ++i) {
+    EXPECT_EQ(values[i], data[i]) << "row " << i;
   }
 }
 


### PR DESCRIPTION
Summary:

Extracts the `bulkGet64WithBaseline` optimization from D106527148 into a standalone diff. This keeps the original `bulkSet64WithBaseline` diff focused on set-side packing while preserving the get-side direct-load and inline cross-word handling work separately.

Reviewed By: xiaoxmeng

Differential Revision: D107572590


