### PR TITLE
Support duplicate regions in CachedBufferedInput

### DIFF
--- a/dwio/nimble/tablet/DataInput.cpp
+++ b/dwio/nimble/tablet/DataInput.cpp
@@ -149,54 +149,53 @@ std::vector<DirectDataInput::IoGroup> DirectDataInput::computeIoGroups(
   std::vector<IoGroup> ioGroups;
   ioGroups.reserve(sortedRegions.size());
 
-  const auto coalesceStats =
-      velox::coalesceIo<int32_t, char, /*coalesceDuplicateRanges=*/true>(
-          items,
-          /*maxGap=*/maxCoalesceDistance_,
-          /*rangesPerIo=*/std::numeric_limits<int32_t>::max(),
-          /*offsetFunc=*/
-          [&](int32_t i) -> uint64_t { return sortedRegions[i].region.offset; },
-          /*sizeFunc=*/
-          [&](int32_t i) -> int32_t {
-            return static_cast<int32_t>(sortedRegions[i].region.length);
-          },
-          /*numRanges=*/
-          [&](int32_t i) -> int32_t {
-            const auto size =
-                static_cast<int64_t>(sortedRegions[i].region.length);
-            if (coalescedBytes + size > maxCoalesceBytes_) {
-              coalescedBytes = 0;
-              return velox::kNoCoalesce;
-            }
-            coalescedBytes += size;
-            return 1;
-          },
-          /*addRanges=*/
-          [](const int32_t& /*i*/, std::vector<char>& ranges) {
-            ranges.push_back(0);
-          },
-          /*skipRange=*/
-          [](int32_t /*gap*/, std::vector<char>& /*ranges*/) {},
-          /*ioFunc=*/
-          [&](const std::vector<int32_t>& /*items*/,
-              int32_t begin,
-              int32_t end,
-              uint64_t /*offset*/,
-              const std::vector<char>& /*ranges*/) {
-            coalescedBytes = 0;
-            IoGroup group;
-            const auto groupRegions = std::span<const EnqueuedRegion>(
-                &sortedRegions[begin], static_cast<size_t>(end - begin));
-            const auto [payloadSize, lastEnd] =
-                computePayloadSize(groupRegions);
-            group.readOffset = alignDown(sortedRegions[begin].region.offset);
-            group.readSize = alignUp(lastEnd) - group.readOffset;
-            group.payloadSize = payloadSize;
-            group.regions = groupRegions;
-            ioGroups.emplace_back(group);
-          });
+  const auto coalesceStats = velox::coalesceIo<int32_t, char>(
+      items,
+      /*maxGap=*/maxCoalesceDistance_,
+      /*rangesPerIo=*/std::numeric_limits<int32_t>::max(),
+      /*offsetFunc=*/
+      [&](int32_t i) -> uint64_t { return sortedRegions[i].region.offset; },
+      /*sizeFunc=*/
+      [&](int32_t i) -> int32_t {
+        return static_cast<int32_t>(sortedRegions[i].region.length);
+      },
+      /*numRanges=*/
+      [&](int32_t i) -> int32_t {
+        const auto size = static_cast<int64_t>(sortedRegions[i].region.length);
+        if (coalescedBytes + size > maxCoalesceBytes_) {
+          coalescedBytes = 0;
+          return velox::kNoCoalesce;
+        }
+        coalescedBytes += size;
+        return 1;
+      },
+      /*addRanges=*/
+      [](const int32_t& /*i*/, std::vector<char>& ranges) {
+        ranges.push_back(0);
+      },
+      /*skipRange=*/
+      [](int32_t /*gap*/, std::vector<char>& /*ranges*/) {},
+      /*ioFunc=*/
+      [&](const std::vector<int32_t>& /*items*/,
+          int32_t begin,
+          int32_t end,
+          uint64_t /*offset*/,
+          const std::vector<char>& /*ranges*/) {
+        coalescedBytes = 0;
+        IoGroup group;
+        const auto groupRegions = std::span<const EnqueuedRegion>(
+            &sortedRegions[begin], static_cast<size_t>(end - begin));
+        const auto [payloadSize, lastEnd] = computePayloadSize(groupRegions);
+        group.readOffset = alignDown(sortedRegions[begin].region.offset);
+        group.readSize = alignUp(lastEnd) - group.readOffset;
+        group.payloadSize = payloadSize;
+        group.regions = groupRegions;
+        ioGroups.emplace_back(group);
+      });
 
   ioStats_->readGap().merge(coalesceStats.gaps);
+  ioStats_->incDuplicateRead(
+      coalesceStats.duplicateRegions, coalesceStats.duplicateBytes);
   return ioGroups;
 }
 

--- a/dwio/nimble/tablet/MetadataInput.cpp
+++ b/dwio/nimble/tablet/MetadataInput.cpp
@@ -118,47 +118,50 @@ std::vector<MetadataInput::IoGroup> MetadataInput::computeIoGroups(
   int64_t coalescedBytes = 0;
   std::vector<int32_t> groupEnds;
 
-  const auto ioStats =
-      velox::coalesceIo<int32_t, char, /*coalesceDuplicateRanges=*/false>(
-          items,
-          /*maxGap=*/maxCoalesceDistance_,
-          /*rangesPerIo=*/std::numeric_limits<int32_t>::max(),
-          /*offsetFunc=*/
-          [&](int32_t i) -> uint64_t {
-            return sections[loadIndices[i]].section.offset();
-          },
-          /*sizeFunc=*/
-          [&](int32_t i) -> int32_t {
-            return sections[loadIndices[i]].section.size();
-          },
-          /*numRanges=*/
-          [&](int32_t i) -> int32_t {
-            const auto size = sections[loadIndices[i]].section.size();
-            if (coalescedBytes + size > maxCoalesceBytes_) {
-              coalescedBytes = 0;
-              return velox::kNoCoalesce;
-            }
-            coalescedBytes += size;
-            return 1;
-          },
-          /*addRanges=*/
-          [&](const int32_t& /*i*/, std::vector<char>& ranges) {
-            // Dummy range so coalesceIo sees non-empty ranges for kNoCoalesce
-            // flush check.
-            ranges.push_back(0);
-          },
-          /*skipRange=*/
-          [&](int32_t /*gap*/, std::vector<char>& /*ranges*/) {},
-          /*ioFunc=*/
-          [&](const std::vector<int32_t>& /*items*/,
-              int32_t /*begin*/,
-              int32_t end,
-              uint64_t /*offset*/,
-              const std::vector<char>& /*ranges*/) {
-            coalescedBytes = 0;
-            groupEnds.push_back(end);
-          });
+  const auto ioStats = velox::coalesceIo<int32_t, char>(
+      items,
+      /*maxGap=*/maxCoalesceDistance_,
+      /*rangesPerIo=*/std::numeric_limits<int32_t>::max(),
+      /*offsetFunc=*/
+      [&](int32_t i) -> uint64_t {
+        return sections[loadIndices[i]].section.offset();
+      },
+      /*sizeFunc=*/
+      [&](int32_t i) -> int32_t {
+        return sections[loadIndices[i]].section.size();
+      },
+      /*numRanges=*/
+      [&](int32_t i) -> int32_t {
+        const auto size = sections[loadIndices[i]].section.size();
+        if (coalescedBytes + size > maxCoalesceBytes_) {
+          coalescedBytes = 0;
+          return velox::kNoCoalesce;
+        }
+        coalescedBytes += size;
+        return 1;
+      },
+      /*addRanges=*/
+      [&](const int32_t& /*i*/, std::vector<char>& ranges) {
+        // Dummy range so coalesceIo sees non-empty ranges for kNoCoalesce
+        // flush check.
+        ranges.push_back(0);
+      },
+      /*skipRange=*/
+      [&](int32_t /*gap*/, std::vector<char>& /*ranges*/) {},
+      /*ioFunc=*/
+      [&](const std::vector<int32_t>& /*items*/,
+          int32_t /*begin*/,
+          int32_t end,
+          uint64_t /*offset*/,
+          const std::vector<char>& /*ranges*/) {
+        coalescedBytes = 0;
+        groupEnds.push_back(end);
+      });
 
+  NIMBLE_CHECK_EQ(
+      ioStats.duplicateRegions,
+      0,
+      "Metadata input must not contain duplicate regions");
   recordCoalescedIoStats(ioStats);
   velox::common::testutil::TestValue::adjust(
       "facebook::nimble::MetadataInput::computeIoGroups",

--- a/dwio/nimble/tablet/TabletWriter.cpp
+++ b/dwio/nimble/tablet/TabletWriter.cpp
@@ -353,6 +353,10 @@ void TabletWriter::writeStripe(uint32_t rowCount, std::vector<Stream> streams) {
       } else {
         // If we are here, this is a duplicate stream, so we need to reference
         // the original stream instead of this one.
+        ++stats_.duplicateStreamCount;
+        for (const auto& chunk : stream.chunks) {
+          stats_.duplicateStreamBytes += chunk.contentSize();
+        }
 
         // @lint-ignore CLANGTIDY facebook-hte-LocalUncheckedArrayBounds
         stripeStreamOffsets[index] = it.first->second.first;

--- a/dwio/nimble/tablet/TabletWriter.h
+++ b/dwio/nimble/tablet/TabletWriter.h
@@ -82,6 +82,11 @@ class TabletWriter {
     CloseCallback closeCallback;
   };
 
+  struct Stats {
+    uint64_t duplicateStreamCount{0};
+    uint64_t duplicateStreamBytes{0};
+  };
+
   static std::unique_ptr<TabletWriter> create(
       velox::WriteFile* file,
       velox::memory::MemoryPool& pool,
@@ -121,6 +126,10 @@ class TabletWriter {
   /// The number of bytes written so far.
   uint64_t size() const {
     return file_->size();
+  }
+
+  Stats stats() const {
+    return stats_;
   }
 
  private:
@@ -213,6 +222,7 @@ class TabletWriter {
   std::vector<MetadataSection> stripeGroups_;
   // Optional sections
   std::unordered_map<std::string, MetadataSection> optionalSections_;
+  Stats stats_;
 
   // Writer state.
   State state_{State::kActive};

--- a/dwio/nimble/tablet/tests/DataInputTest.cpp
+++ b/dwio/nimble/tablet/tests/DataInputTest.cpp
@@ -482,6 +482,8 @@ DEBUG_ONLY_TEST_F(DataInputTest, coalescesDuplicateRegions) {
   EXPECT_EQ(ioStats_->read().sum(), 125);
   EXPECT_EQ(ioStats_->rawBytesRead(), 125);
   EXPECT_EQ(ioStats_->rawOverreadBytes(), 0);
+  EXPECT_EQ(ioStats_->duplicateReadRegions(), 1);
+  EXPECT_EQ(ioStats_->duplicateReadBytes(), 50);
 }
 
 TEST_F(DataInputTest, crossGroupCoalescing) {

--- a/dwio/nimble/tablet/tests/MetadataInputTest.cpp
+++ b/dwio/nimble/tablet/tests/MetadataInputTest.cpp
@@ -238,6 +238,25 @@ TEST_F(DirectMetadataInputTest, reverseSectionOrder) {
   EXPECT_EQ(results[1]->content(), data0);
 }
 
+TEST_F(DirectMetadataInputTest, duplicateSectionsThrow) {
+  const std::string data = "duplicate-metadata";
+  nimble::MetadataSection section{
+      0,
+      static_cast<uint32_t>(data.size()),
+      nimble::CompressionType::Uncompressed,
+      static_cast<uint32_t>(data.size())};
+  const auto fileContent = buildFileContent({section}, {data});
+  auto readFile = std::make_shared<velox::InMemoryReadFile>(fileContent);
+
+  const auto options = makeMetadataInputOptions();
+  auto input = nimble::MetadataInput::create(readFile.get(), options);
+
+  const std::array sections{section, section};
+  NIMBLE_ASSERT_THROW(
+      input->load(sections),
+      "Metadata input must not contain duplicate regions");
+}
+
 TEST_F(DirectMetadataInputTest, repeatedLoad) {
   const std::string data = "repeat-test";
   nimble::MetadataSection section{

--- a/dwio/nimble/tablet/tests/TabletTest.cpp
+++ b/dwio/nimble/tablet/tests/TabletTest.cpp
@@ -1223,6 +1223,30 @@ TEST_P(TabletTest, deduplicateStreams) {
   }
 }
 
+TEST_P(TabletTest, duplicateStreamStats) {
+  std::string file;
+  velox::InMemoryWriteFile writeFile(&file);
+  auto tabletWriter = nimble::TabletWriter::create(
+      &writeFile, *pool_, {.streamDeduplicationEnabled = true});
+
+  const std::string data = "same-stream-data";
+  nimble::Stream stream0{.offset = 0};
+  nimble::Chunk chunk0;
+  chunk0.content = {data};
+  stream0.chunks.push_back(chunk0);
+  nimble::Stream stream1{.offset = 1};
+  nimble::Chunk chunk1;
+  chunk1.content = {data};
+  stream1.chunks.push_back(chunk1);
+
+  tabletWriter->writeStripe(10, {std::move(stream0), std::move(stream1)});
+  EXPECT_EQ(tabletWriter->stats().duplicateStreamCount, 1);
+  EXPECT_EQ(tabletWriter->stats().duplicateStreamBytes, data.size());
+  tabletWriter->close();
+  EXPECT_EQ(tabletWriter->stats().duplicateStreamCount, 1);
+  EXPECT_EQ(tabletWriter->stats().duplicateStreamBytes, data.size());
+}
+
 TEST_P(TabletTest, chunkContentSize) {
   nimble::Chunk chunk;
   EXPECT_EQ(chunk.contentSize(), 0);

--- a/dwio/nimble/velox/VeloxWriter.cpp
+++ b/dwio/nimble/velox/VeloxWriter.cpp
@@ -1493,6 +1493,8 @@ VeloxWriter::Stats VeloxWriter::stats() const {
           context_->encodingSelectionTiming().cpuNanos,
       .rowsPerStripe = toRuntimeMetric(context_->rowsPerStripe()),
       .chunkSizeBytes = context_->chunkSizeStats(),
+      .duplicateStreamCount = tabletWriter_->stats().duplicateStreamCount,
+      .duplicateStreamBytes = tabletWriter_->stats().duplicateStreamBytes,
       .columnStats = context_->columnStats(),
   };
 }

--- a/dwio/nimble/velox/VeloxWriter.h
+++ b/dwio/nimble/velox/VeloxWriter.h
@@ -85,6 +85,10 @@ class VeloxWriter {
     velox::RuntimeMetric rowsPerStripe;
     /// Encoded chunk size distribution in bytes (count/sum/min/max).
     velox::RuntimeMetric chunkSizeBytes;
+    /// Number of streams deduplicated by the tablet writer.
+    uint64_t duplicateStreamCount;
+    /// Encoded bytes deduplicated by the tablet writer.
+    uint64_t duplicateStreamBytes;
     /// Per-column statistics. Only available at file close.
     /// NOTE: expected to be exposed as a view, for merging with base stats
     /// objects. User needs to explicitly copy.

--- a/dwio/nimble/velox/tests/VeloxWriterTest.cpp
+++ b/dwio/nimble/velox/tests/VeloxWriterTest.cpp
@@ -17,6 +17,7 @@
 #include <folly/system/HardwareConcurrency.h>
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
+#include <map>
 #include <set>
 
 #include "velox/common/testutil/TestValue.h"
@@ -3444,6 +3445,34 @@ class VeloxWriterIndexTest
     }
   }
 
+  nimble::TabletWriter::Stats duplicateStreamStatsFromLayout(
+      const nimble::TabletReader& tablet) {
+    nimble::TabletWriter::Stats stats;
+    for (uint32_t stripeIndex = 0; stripeIndex < tablet.stripeCount();
+         ++stripeIndex) {
+      const auto stripeIdentifier = tablet.stripeIdentifier(stripeIndex);
+      const auto offsets = tablet.streamOffsets(stripeIdentifier);
+      const auto sizes = tablet.streamSizes(stripeIdentifier);
+
+      std::map<std::pair<uint32_t, uint32_t>, uint64_t> duplicateGroups;
+      for (size_t streamIndex = 0; streamIndex < sizes.size(); ++streamIndex) {
+        if (sizes[streamIndex] == 0) {
+          continue;
+        }
+        ++duplicateGroups[{offsets[streamIndex], sizes[streamIndex]}];
+      }
+
+      for (const auto& [offsetAndSize, count] : duplicateGroups) {
+        if (count > 1) {
+          const auto duplicateCount = count - 1;
+          stats.duplicateStreamCount += duplicateCount;
+          stats.duplicateStreamBytes += offsetAndSize.second * duplicateCount;
+        }
+      }
+    }
+    return stats;
+  }
+
   // Verifies that the value index correctly maps each key to its row
   // position. For each row in the input batches:
   // 1. Encodes the key using KeyEncoder
@@ -4217,7 +4246,11 @@ TEST_P(VeloxWriterIndexTest, streamDeduplication) {
   // writer. We create batches where string_col1 and string_col2 reference the
   // same underlying vector, which should result in identical stream content
   // that gets deduplicated.
-  auto type = defaultType();
+  auto type = velox::ROW({
+      {"key_col", velox::BIGINT()},
+      {"string_col1", velox::VARCHAR()},
+      {"string_col2", velox::VARCHAR()},
+  });
 
   nimble::ClusterIndexConfig clusterIndexConfig =
       createIndexConfig({"key_col"});
@@ -4227,7 +4260,6 @@ TEST_P(VeloxWriterIndexTest, streamDeduplication) {
 
   constexpr int kNumBatches = 5;
   constexpr int kBatchSize = 100;
-  constexpr uint32_t kSeed = 42;
 
   nimble::VeloxWriter writer(
       type,
@@ -4241,15 +4273,6 @@ TEST_P(VeloxWriterIndexTest, streamDeduplication) {
 
   velox::test::VectorMaker vectorMaker{leafPool_.get()};
 
-  // Configure fuzzer for generating non-string columns
-  velox::VectorFuzzer::Options fuzzerOpts;
-  fuzzerOpts.vectorSize = kBatchSize;
-  fuzzerOpts.nullRatio = 0.1;
-  fuzzerOpts.containerLength = 5;
-  fuzzerOpts.stringLength = 20;
-  fuzzerOpts.containerVariableLength = true;
-  velox::VectorFuzzer fuzzer(fuzzerOpts, leafPool_.get(), kSeed);
-
   // Generate pre-sorted batches where string_col1 and string_col2 share the
   // same underlying vector (to trigger stream deduplication)
   std::vector<velox::RowVectorPtr> batches;
@@ -4262,28 +4285,16 @@ TEST_P(VeloxWriterIndexTest, streamDeduplication) {
     }
 
     // Create the shared string vector that will be used for both string
-    // columns
-    auto sharedStringVector = fuzzer.fuzz(velox::VARCHAR());
+    // columns.
+    auto sharedStringVector =
+        vectorMaker.flatVector<std::string>(kBatchSize, [batch](auto row) {
+          return fmt::format("batch-{}-row-{}", batch, row);
+        });
 
-    // Build children: key column, fuzzed scalar columns, shared string
-    // columns, then fuzzed complex columns
     std::vector<velox::VectorPtr> children;
-    // Column 0: key_col
     children.push_back(vectorMaker.flatVector<int64_t>(keyValues));
-    // Column 1: int_col
-    children.push_back(fuzzer.fuzz(type->childAt(1)));
-    // Column 2: double_col
-    children.push_back(fuzzer.fuzz(type->childAt(2)));
-    // Column 3: string_col1 - use the shared string vector
     children.push_back(sharedStringVector);
-    // Column 4: string_col2 - use the SAME shared string vector
     children.push_back(sharedStringVector);
-    // Column 5: bool_col
-    children.push_back(fuzzer.fuzz(type->childAt(5)));
-    // Columns 6-8: complex types
-    for (size_t colIdx = 6; colIdx < type->size(); ++colIdx) {
-      children.push_back(fuzzer.fuzz(type->childAt(colIdx)));
-    }
 
     auto batchVec = std::make_shared<velox::RowVector>(
         leafPool_.get(),
@@ -4301,6 +4312,13 @@ TEST_P(VeloxWriterIndexTest, streamDeduplication) {
   auto tabletOptions = makeTestTabletOptions(leafPool_.get());
   auto tablet =
       nimble::TabletReader::create(readFile, leafPool_.get(), tabletOptions);
+  const auto expectedStats = duplicateStreamStatsFromLayout(*tablet);
+  EXPECT_EQ(
+      writer.stats().duplicateStreamCount, expectedStats.duplicateStreamCount);
+  EXPECT_EQ(
+      writer.stats().duplicateStreamBytes, expectedStats.duplicateStreamBytes);
+  EXPECT_EQ(expectedStats.duplicateStreamCount, kNumBatches);
+  EXPECT_GT(expectedStats.duplicateStreamBytes, 0);
 
   // Verify index exists
   const auto* index = tablet->clusterIndex();
@@ -4342,6 +4360,75 @@ TEST_P(VeloxWriterIndexTest, streamDeduplication) {
   verifyPositionIndex(*tablet);
 
   // Verify value index maps each key to correct row position
+  verifyValueIndex(*tablet, readFile.get(), type, batches, {"key_col"});
+}
+
+TEST_P(VeloxWriterIndexTest, streamStatsNoDuplicates) {
+  auto type = velox::ROW({
+      {"key_col", velox::BIGINT()},
+      {"string_col1", velox::VARCHAR()},
+      {"string_col2", velox::VARCHAR()},
+  });
+
+  nimble::ClusterIndexConfig clusterIndexConfig =
+      createIndexConfig({"key_col"});
+
+  std::string file;
+  auto writeFile = std::make_unique<velox::InMemoryWriteFile>(&file);
+
+  constexpr int kNumBatches = 5;
+  constexpr int kBatchSize = 100;
+
+  nimble::VeloxWriter writer(
+      type,
+      std::move(writeFile),
+      *rootPool_,
+      createWriterOptions(clusterIndexConfig, []() {
+        return std::make_unique<nimble::LambdaFlushPolicy>(
+            [](auto) { return true; }, [](auto) { return false; });
+      }));
+
+  velox::test::VectorMaker vectorMaker{leafPool_.get()};
+  std::vector<velox::RowVectorPtr> batches;
+  int64_t keyVal = 0;
+  for (int batch = 0; batch < kNumBatches; ++batch) {
+    std::vector<int64_t> keyValues;
+    keyValues.reserve(kBatchSize);
+    for (int i = 0; i < kBatchSize; ++i) {
+      keyValues.push_back(keyVal++);
+    }
+
+    std::vector<velox::VectorPtr> children;
+    children.push_back(vectorMaker.flatVector<int64_t>(keyValues));
+    children.push_back(vectorMaker.flatVector<std::string>(
+        kBatchSize,
+        [batch](auto row) { return fmt::format("left-{}-{}", batch, row); }));
+    children.push_back(vectorMaker.flatVector<std::string>(
+        kBatchSize,
+        [batch](auto row) { return fmt::format("right-{}-{}", batch, row); }));
+
+    auto batchVec = std::make_shared<velox::RowVector>(
+        leafPool_.get(),
+        type,
+        nullptr, // no nulls at top level
+        kBatchSize,
+        std::move(children));
+    batches.push_back(batchVec);
+    writer.write(batchVec);
+  }
+  writer.close();
+
+  auto readFile = std::make_shared<velox::InMemoryReadFile>(file);
+  auto tablet = nimble::TabletReader::create(
+      readFile, leafPool_.get(), makeTestTabletOptions(leafPool_.get()));
+  const auto expectedStats = duplicateStreamStatsFromLayout(*tablet);
+  EXPECT_EQ(writer.stats().duplicateStreamCount, 0);
+  EXPECT_EQ(writer.stats().duplicateStreamBytes, 0);
+  EXPECT_EQ(expectedStats.duplicateStreamCount, 0);
+  EXPECT_EQ(expectedStats.duplicateStreamBytes, 0);
+
+  verifyFileData(file, type, batches);
+  verifyPositionIndex(*tablet);
   verifyValueIndex(*tablet, readFile.get(), type, batches, {"key_col"});
 }
 


### PR DESCRIPTION
Summary:
Allow `CachedBufferedInput` to keep exact duplicate cache requests in the same coalesced load using `coalesceDuplicateRanges=true`. The cached path does not need duplicate buffer copies because each stream performs its normal cache lookup after the shared coalesced load populates the single cache entry.

Add coverage that enqueues two streams for the same region and verifies they share one coalesced load, perform one storage read, populate one cache entry, and both return the expected bytes.

Differential Revision: D107766691


