### PR TITLE
refactor(nimble): Consolidate bulkSetWithBaseline func for all encodings (#837)

### DIFF
--- a/dwio/nimble/common/FixedBitArray.h
+++ b/dwio/nimble/common/FixedBitArray.h
@@ -15,6 +15,9 @@
  */
 #pragma once
 
+#include <cstdint>
+
+#include "dwio/nimble/common/Types.h"
 #include "velox/common/base/BitUtil.h"
 
 /// Packs integers into a fixed number (1-64) of bits and retrieves them.
@@ -116,26 +119,48 @@ class FixedBitArray {
   /// <= 32. Same semantics as set -- see the warning there.
   void bulkSet32(uint64_t start, uint64_t length, const uint32_t* values);
 
-  /// Same as above. Subtracts baseline from every value.
-  void bulkSet32WithBaseline(
+  /// Unified bulk set for any unsigned integral element type, subtracting
+  /// baseline from each value before packing. Dispatches at compile time to the
+  /// optimal path: 4-byte values reuse bulkSet32WithBaseline and 8-byte values
+  /// reuse bulkSet64WithBaseline (both zero-copy). Narrow 1- and 2-byte values
+  /// are widened in fixed-size stack chunks onto the bulkSet32 path -- faster
+  /// than per-element packing, with no heap allocation. Requires the same
+  /// zeroed-buffer precondition as set.
+  template <typename T>
+  void bulkSetWithBaseline(
       uint64_t start,
       uint64_t length,
-      const uint32_t* values,
-      uint32_t baseline);
-
-  /// Sets a contiguous subarray of slots from [start, start + length),
-  /// subtracting baseline from each 64-bit value before packing. Supports any
-  /// value where values[i] >= baseline and values[i] - baseline fits in the
-  /// bit width up to 64. For bitWidth < 32, delegates to the optimized
-  /// bulkSet32 path. For byte-aligned bit widths 32, 40, 48, 56, and 64, uses
-  /// direct stores. Other bit widths up to 58 use a single 64-bit OR per
-  /// value. For bitWidth 59-63, handles cross-word boundary overflow.
-  /// Requires the same zeroed-buffer precondition as set.
-  void bulkSet64WithBaseline(
-      uint64_t start,
-      uint64_t length,
-      const uint64_t* values,
-      uint64_t baseline);
+      const T* values,
+      uint64_t baseline) {
+    static_assert(
+        isUnsignedIntegralType<T>(),
+        "bulkSetWithBaseline requires an unsigned integral type.");
+    if constexpr (isFourByteIntegralType<T>()) {
+      bulkSet32WithBaseline(
+          start,
+          length,
+          reinterpret_cast<const uint32_t*>(values),
+          static_cast<uint32_t>(baseline));
+    } else if constexpr (isEightByteIntegralType<T>()) {
+      bulkSet64WithBaseline(
+          start, length, reinterpret_cast<const uint64_t*>(values), baseline);
+    } else {
+      // Narrow (1- or 2-byte) types cannot be reinterpreted as a wider array in
+      // place, so widen in fixed-size stack chunks and use the fast bulkSet32
+      // path -- no heap allocation regardless of length.
+      constexpr uint64_t kWidenChunk = 1024;
+      uint32_t widened[kWidenChunk];
+      const auto baseline32 = static_cast<uint32_t>(baseline);
+      for (uint64_t offset = 0; offset < length; offset += kWidenChunk) {
+        const uint64_t chunk =
+            length - offset < kWidenChunk ? length - offset : kWidenChunk;
+        for (uint64_t i = 0; i < chunk; ++i) {
+          widened[i] = static_cast<uint32_t>(values[offset + i]);
+        }
+        bulkSet32WithBaseline(start + offset, chunk, widened, baseline32);
+      }
+    }
+  }
 
   /// Fills in the bit-packed |bitVector| with whether each value in
   /// [start, start + length) equals |value|. Should be faster than
@@ -157,6 +182,27 @@ class FixedBitArray {
   }
 
  private:
+  // Width-specific bulk-set implementations. Callers use the public
+  // bulkSetWithBaseline, which dispatches to these by element type.
+
+  // Only callable when bitWidth <= 32; subtracts baseline from each value.
+  // Same zeroed-buffer precondition as set.
+  void bulkSet32WithBaseline(
+      uint64_t start,
+      uint64_t length,
+      const uint32_t* values,
+      uint32_t baseline);
+
+  // Packs 64-bit values, subtracting baseline; supports bit widths up to 64.
+  // For bitWidth < 32 delegates to bulkSet32; 32/40/48/56/64 use direct stores;
+  // up to 58 use a single 64-bit OR per value; 59-63 handle cross-word
+  // overflow. Same zeroed-buffer precondition as set.
+  void bulkSet64WithBaseline(
+      uint64_t start,
+      uint64_t length,
+      const uint64_t* values,
+      uint64_t baseline);
+
   char* buffer_;
   int bitWidth_;
   uint64_t mask_;

--- a/dwio/nimble/common/benchmarks/FixedBitArrayBenchmark.cpp
+++ b/dwio/nimble/common/benchmarks/FixedBitArrayBenchmark.cpp
@@ -73,7 +73,7 @@ void observeWrittenBuffer(
       BENCHMARK_SUSPEND {                                                      \
         clearBuffer(buffer.get(), bufferBytes);                                \
       }                                                                        \
-      fixedBitArray.bulkSet64WithBaseline(                                     \
+      fixedBitArray.bulkSetWithBaseline(                                       \
           0, kNumElements, values.data(), baseline);                           \
       observeWrittenBuffer(buffer.get(), kNumElements, bitWidth);              \
     }                                                                          \
@@ -114,7 +114,7 @@ void observeWrittenBuffer(
       output.resize(kNumElements);                                             \
       nimble::FixedBitArray fixedBitArray(buffer.get(), bitWidth);             \
       const uint64_t baseline = bitWidth == 64 ? 0 : kBaseline;                \
-      fixedBitArray.bulkSet64WithBaseline(                                     \
+      fixedBitArray.bulkSetWithBaseline(                                       \
           0, kNumElements, values.data(), baseline);                           \
     }                                                                          \
     nimble::FixedBitArray fixedBitArray(buffer.get(), bitWidth);               \
@@ -138,7 +138,7 @@ void observeWrittenBuffer(
       output.resize(kNumElements);                                             \
       nimble::FixedBitArray fixedBitArray(buffer.get(), bitWidth);             \
       const uint64_t baseline = bitWidth == 64 ? 0 : kBaseline;                \
-      fixedBitArray.bulkSet64WithBaseline(                                     \
+      fixedBitArray.bulkSetWithBaseline(                                       \
           0, kNumElements, values.data(), baseline);                           \
     }                                                                          \
     nimble::FixedBitArray fixedBitArray(buffer.get(), bitWidth);               \
@@ -170,7 +170,7 @@ void observeWrittenBuffer(
       BENCHMARK_SUSPEND {                                             \
         clearBuffer(buffer.get(), bufferBytes);                       \
       }                                                               \
-      fixedBitArray.bulkSet64WithBaseline(                            \
+      fixedBitArray.bulkSetWithBaseline(                              \
           kStartOffset, kNumElements, values.data(), baseline);       \
       observeWrittenBuffer(                                           \
           buffer.get(), kStartOffset + kNumElements, bitWidth);       \

--- a/dwio/nimble/common/tests/FixedBitArrayTests.cpp
+++ b/dwio/nimble/common/tests/FixedBitArrayTests.cpp
@@ -405,7 +405,7 @@ TEST(FixedBitArrayTests, BulkSet32WithBaselineRandom) {
       }
       const int offset = folly::Random::rand32(rng) % elementCount;
       const int size = elementCount - offset;
-      fixedBitArray.bulkSet32WithBaseline(
+      fixedBitArray.bulkSetWithBaseline(
           offset, size, randomValuesWithBaseline.data() + offset, baseline);
       for (int i = 0; i < size; ++i) {
         ASSERT_EQ(fixedBitArray.get32(offset + i), randomValues[offset + i])
@@ -513,7 +513,7 @@ TEST(FixedBitArrayTests, bulkSet64WithBaseline) {
         inputValues[i] = expectedResiduals[i] + baseline;
       }
 
-      fixedBitArray.bulkSet64WithBaseline(
+      fixedBitArray.bulkSetWithBaseline(
           0, elementCount, inputValues.data(), baseline);
 
       for (int i = 0; i < elementCount; ++i) {
@@ -559,7 +559,7 @@ TEST(FixedBitArrayTests, bulkSet64WithBaselinePartialRange) {
       inputValues[i] = residual + baseline;
     }
 
-    fixedBitArray.bulkSet64WithBaseline(
+    fixedBitArray.bulkSetWithBaseline(
         offset, count, inputValues.data(), baseline);
 
     for (int i = 0; i < count; ++i) {
@@ -576,4 +576,65 @@ TEST(FixedBitArrayTests, bulkSet64WithBaselinePartialRange) {
           << "post-range slot " << i << " should be zero";
     }
   }
+}
+
+// Packs random values of element type T through the unified
+// bulkSetWithBaseline and confirms the stored residuals round-trip. bitWidth is
+// chosen so values fit in T.
+template <typename T>
+void verifyBulkSetWithBaseline(
+    int bitWidth,
+    int elementCount,
+    std::mt19937& rng) {
+  SCOPED_TRACE(
+      fmt::format(
+          "typeBytes={} bitWidth={} elementCount={}",
+          sizeof(T),
+          bitWidth,
+          elementCount));
+  const auto bufferBytes =
+      nimble::FixedBitArray::bufferSize(elementCount, bitWidth);
+  auto buffer = std::make_unique<char[]>(bufferBytes);
+  std::memset(buffer.get(), 0, bufferBytes);
+  nimble::FixedBitArray fixedBitArray(buffer.get(), bitWidth);
+
+  const T baseline = static_cast<T>(folly::Random::rand32(rng) % 7);
+  const uint64_t residualMask =
+      bitWidth == 64 ? ~0ULL : ((1ULL << bitWidth) - 1);
+  std::vector<T> inputValues(elementCount);
+  std::vector<uint64_t> expectedResiduals(elementCount);
+  for (int i = 0; i < elementCount; ++i) {
+    expectedResiduals[i] = folly::Random::rand64(rng) & residualMask;
+    inputValues[i] = static_cast<T>(expectedResiduals[i] + baseline);
+  }
+
+  fixedBitArray.bulkSetWithBaseline(
+      0, elementCount, inputValues.data(), baseline);
+
+  std::vector<uint64_t> actualResiduals(elementCount);
+  for (int i = 0; i < elementCount; ++i) {
+    actualResiduals[i] = fixedBitArray.get(i);
+  }
+  EXPECT_EQ(actualResiduals, expectedResiduals);
+}
+
+TEST(FixedBitArrayTests, bulkSetWithBaselineDispatchesByElementWidth) {
+  auto seed = folly::Random::rand32();
+  LOG(INFO) << "seed: " << seed;
+  std::mt19937 rng(seed);
+
+  const int smallCount = 1 + folly::Random::rand32(rng) % kMaxElements;
+  // One element type per compile-time branch: 1- and 2-byte exercise the widen
+  // path, 4-byte delegates to bulkSet32, 8-byte to bulkSet64.
+  verifyBulkSetWithBaseline<uint8_t>(/*bitWidth=*/5, smallCount, rng);
+  verifyBulkSetWithBaseline<uint16_t>(/*bitWidth=*/12, smallCount, rng);
+  verifyBulkSetWithBaseline<uint32_t>(/*bitWidth=*/20, smallCount, rng);
+  verifyBulkSetWithBaseline<uint64_t>(/*bitWidth=*/40, smallCount, rng);
+
+  // Exercise the narrow widen path across multiple stack chunks
+  // (length > kWidenChunk = 1024), including a partial final chunk.
+  verifyBulkSetWithBaseline<uint8_t>(
+      /*bitWidth=*/5, /*elementCount=*/2500, rng);
+  verifyBulkSetWithBaseline<uint16_t>(
+      /*bitWidth=*/12, /*elementCount=*/2500, rng);
 }

--- a/dwio/nimble/encodings/BlockBitPackingEncoding.h
+++ b/dwio/nimble/encodings/BlockBitPackingEncoding.h
@@ -696,19 +696,13 @@ std::string_view BlockBitPackingEncoding<T>::encode(
                           block.baseline);
                 }
               }
-            } else if constexpr (sizeof(physicalType) < 4) {
-              FixedBitArray fba(pos + dataOffset, block.bitWidth);
-              uint32_t tmp[kMaxBlockSize];
-              for (uint32_t i = 0; i < block.count; ++i) {
-                tmp[i] = static_cast<uint32_t>(values[block.start + i]);
-              }
-              fba.bulkSet32WithBaseline(
-                  0, block.count, tmp, static_cast<uint32_t>(block.baseline));
             } else {
+              // 1-, 2-, and 8-byte types: the unified bulk path picks the
+              // optimal packing for the width (4-byte uses SIMD fastpack
+              // above).
               FixedBitArray fba(pos + dataOffset, block.bitWidth);
-              for (uint32_t i = 0; i < block.count; ++i) {
-                fba.set(i, values[block.start + i] - block.baseline);
-              }
+              fba.bulkSetWithBaseline(
+                  0, block.count, values.data() + block.start, block.baseline);
             }
           }
           dataOffset += block.packedSize;

--- a/dwio/nimble/encodings/FixedBitWidthEncoding.h
+++ b/dwio/nimble/encodings/FixedBitWidthEncoding.h
@@ -292,7 +292,7 @@ void FixedBitWidthEncoding<T>::bulkScan(
       }
     } else {
       // 8-byte path: use bulkGet64WithBaseline which handles all bit widths
-      // including branchless byte-aligned loads for bitWidth <= 56.
+      // including branchless byte-aligned loads for bitWidth <= 58.
       static_assert(isEightByteIntegralType<physicalType>());
       static_assert(kSameSize, "8-byte bulkScan requires same-size output");
       fixedBitArray_.bulkGet64WithBaseline(
@@ -401,19 +401,7 @@ std::string_view FixedBitWidthEncoding<T>::encode(
       [&, baseline = selection.statistics().min()](char*& pos) {
         memset(pos, 0, fixedBitArraySize);
         FixedBitArray fba(pos, bitsRequired);
-        if constexpr (sizeof(physicalType) == 4) {
-          fba.bulkSet32WithBaseline(
-              0,
-              rowCount,
-              reinterpret_cast<const uint32_t*>(values.data()),
-              baseline);
-        } else {
-          // TODO: We may want to support 32-bit mode with (u)int64 here as
-          // well.
-          for (uint32_t i = 0; i < values.size(); ++i) {
-            fba.set(i, values[i] - baseline);
-          }
-        }
+        fba.bulkSetWithBaseline(0, rowCount, values.data(), baseline);
         pos += fixedBitArraySize;
         return pos;
       }};

--- a/dwio/nimble/encodings/PFOREncoding.h
+++ b/dwio/nimble/encodings/PFOREncoding.h
@@ -472,19 +472,11 @@ std::string_view PFOREncoding<T>::encode(
       char* bitpackedStart = pos;
       std::memset(bitpackedStart, 0, bitpackedSize);
       FixedBitArray fba(bitpackedStart, baseBitWidth);
-      if constexpr (isFourByteIntegralType<physicalType>()) {
-        fba.bulkSet32WithBaseline(
-            /*start=*/0,
-            /*length=*/rowCount,
-            reinterpret_cast<const uint32_t*>(maskedResiduals.data()),
-            /*baseline=*/0);
-      } else {
-        // TODO: Add a bulkSet64 path to FixedBitArray and use it here
-        // for 8-byte types to match the 4-byte bulk path above.
-        for (uint32_t i = 0; i < rowCount; ++i) {
-          fba.set(i, static_cast<uint64_t>(maskedResiduals[i]));
-        }
-      }
+      fba.bulkSetWithBaseline(
+          /*start=*/0,
+          /*length=*/rowCount,
+          maskedResiduals.data(),
+          /*baseline=*/physicalType{0});
       pos += bitpackedSize;
     }
 

--- a/dwio/nimble/encodings/benchmarks/FixedBitWidthBenchmark.cpp
+++ b/dwio/nimble/encodings/benchmarks/FixedBitWidthBenchmark.cpp
@@ -17,6 +17,7 @@
 // Micro-benchmarks for FixedBitWidthEncoding decode paths.
 // Measures materialize() and bulkGet64WithBaseline() throughput.
 
+#include <cstring>
 #include <memory>
 #include <vector>
 
@@ -28,6 +29,7 @@
 #include "dwio/nimble/encodings/selection/Statistics.h"
 #include "folly/Benchmark.h"
 #include "folly/Random.h"
+#include "folly/init/Init.h"
 #include "velox/common/memory/Memory.h"
 
 using namespace facebook::nimble;
@@ -35,6 +37,7 @@ using namespace facebook::nimble;
 namespace {
 
 constexpr int kNumElements = 100000;
+constexpr uint64_t kBaseline = 12345;
 
 std::shared_ptr<facebook::velox::memory::MemoryPool> pool;
 
@@ -55,6 +58,41 @@ Vector<T> makeData(int bitWidth, int n = kNumElements) {
     }
   }
   return data;
+}
+
+Vector<uint64_t> makeDataWithBaseline(int bitWidth, int n = kNumElements) {
+  Vector<uint64_t> data{pool.get()};
+  data.resize(n);
+  const uint64_t mask = bitWidth == 64 ? ~0ULL : ((1ULL << bitWidth) - 1);
+  const uint64_t baseline = bitWidth == 64 ? 0 : kBaseline;
+  for (int i = 0; i < n; ++i) {
+    data[i] = ((static_cast<uint64_t>(i) * 1000003ULL) & mask) + baseline;
+  }
+  return data;
+}
+
+Vector<uint64_t> makePforMaskedResiduals(
+    int baseBitWidth,
+    int n = kNumElements) {
+  Vector<uint64_t> data{pool.get()};
+  data.resize(n);
+  const uint64_t mask =
+      baseBitWidth == 64 ? ~0ULL : ((1ULL << baseBitWidth) - 1);
+  for (int i = 0; i < n; ++i) {
+    // PFOR zeroes exception slots before bitpacking the base residual stream.
+    data[i] =
+        i % 10 == 0 ? 0 : ((static_cast<uint64_t>(i) * 1000003ULL) & mask);
+  }
+  return data;
+}
+
+void observeWrittenBuffer(
+    const std::vector<char>& buffer,
+    uint32_t elementCount,
+    int bitWidth) {
+  const uint64_t writtenBytes =
+      ((elementCount * static_cast<uint64_t>(bitWidth)) + 7) >> 3;
+  folly::doNotOptimizeAway(buffer[writtenBytes - 1]);
 }
 
 /// Encodes data and returns (encoded string, encoding).
@@ -80,6 +118,159 @@ std::string encodeFixedBitWidth(
 }
 
 } // namespace
+
+// ============================================================================
+// FixedBitWidthEncoding encode packing — 64-bit
+// Mirrors the packing portion of FixedBitWidthEncoding::encode(). The scalar
+// benchmark is the old path; the relative benchmark is the bulk path used by
+// D107301473.
+// ============================================================================
+
+#define FBW_PACK64_BENCHMARKS(bitWidth)                                 \
+  BENCHMARK(FBW_PackUint64_Scalar_##bitWidth##bit, iters) {             \
+    Vector<uint64_t> data{pool.get()};                                  \
+    std::vector<char> buffer;                                           \
+    BENCHMARK_SUSPEND {                                                 \
+      data = makeDataWithBaseline(bitWidth);                            \
+      buffer.resize(FixedBitArray::bufferSize(kNumElements, bitWidth)); \
+    }                                                                   \
+    const uint64_t baseline = bitWidth == 64 ? 0 : kBaseline;           \
+    while (iters--) {                                                   \
+      BENCHMARK_SUSPEND {                                               \
+        std::memset(buffer.data(), 0, buffer.size());                   \
+      }                                                                 \
+      FixedBitArray fba(buffer.data(), bitWidth);                       \
+      for (uint32_t i = 0; i < data.size(); ++i) {                      \
+        fba.set(i, data[i] - baseline);                                 \
+      }                                                                 \
+      observeWrittenBuffer(buffer, kNumElements, bitWidth);             \
+    }                                                                   \
+  }                                                                     \
+  BENCHMARK_RELATIVE(FBW_PackUint64_Bulk_##bitWidth##bit, iters) {      \
+    Vector<uint64_t> data{pool.get()};                                  \
+    std::vector<char> buffer;                                           \
+    BENCHMARK_SUSPEND {                                                 \
+      data = makeDataWithBaseline(bitWidth);                            \
+      buffer.resize(FixedBitArray::bufferSize(kNumElements, bitWidth)); \
+    }                                                                   \
+    const uint64_t baseline = bitWidth == 64 ? 0 : kBaseline;           \
+    while (iters--) {                                                   \
+      BENCHMARK_SUSPEND {                                               \
+        std::memset(buffer.data(), 0, buffer.size());                   \
+      }                                                                 \
+      FixedBitArray fba(buffer.data(), bitWidth);                       \
+      fba.bulkSetWithBaseline(0, kNumElements, data.data(), baseline);  \
+      observeWrittenBuffer(buffer, kNumElements, bitWidth);             \
+    }                                                                   \
+  }
+
+FBW_PACK64_BENCHMARKS(32)
+FBW_PACK64_BENCHMARKS(40)
+FBW_PACK64_BENCHMARKS(48)
+FBW_PACK64_BENCHMARKS(56)
+FBW_PACK64_BENCHMARKS(64)
+
+BENCHMARK_DRAW_LINE();
+
+// ============================================================================
+// FixedBitWidthEncoding encode packing — narrow (1-/2-byte) types
+// Scalar = old per-element set() path; Bulk = bulkSetWithBaseline, which widens
+// in fixed-size stack chunks onto the bulkSet32 path. Confirms the unified path
+// is not a regression for narrow types.
+// ============================================================================
+
+#define FBW_PACK_NARROW_BENCHMARKS(Type, bitWidth)                      \
+  BENCHMARK(FBW_Pack_##Type##_Scalar_##bitWidth##bit, iters) {          \
+    Vector<Type> data{pool.get()};                                      \
+    std::vector<char> buffer;                                           \
+    BENCHMARK_SUSPEND {                                                 \
+      data = makeData<Type>(bitWidth);                                  \
+      buffer.resize(FixedBitArray::bufferSize(kNumElements, bitWidth)); \
+    }                                                                   \
+    while (iters--) {                                                   \
+      BENCHMARK_SUSPEND {                                               \
+        std::memset(buffer.data(), 0, buffer.size());                   \
+      }                                                                 \
+      FixedBitArray fba(buffer.data(), bitWidth);                       \
+      for (uint32_t i = 0; i < data.size(); ++i) {                      \
+        fba.set(i, data[i]);                                            \
+      }                                                                 \
+      observeWrittenBuffer(buffer, kNumElements, bitWidth);             \
+    }                                                                   \
+  }                                                                     \
+  BENCHMARK_RELATIVE(FBW_Pack_##Type##_Bulk_##bitWidth##bit, iters) {   \
+    Vector<Type> data{pool.get()};                                      \
+    std::vector<char> buffer;                                           \
+    BENCHMARK_SUSPEND {                                                 \
+      data = makeData<Type>(bitWidth);                                  \
+      buffer.resize(FixedBitArray::bufferSize(kNumElements, bitWidth)); \
+    }                                                                   \
+    while (iters--) {                                                   \
+      BENCHMARK_SUSPEND {                                               \
+        std::memset(buffer.data(), 0, buffer.size());                   \
+      }                                                                 \
+      FixedBitArray fba(buffer.data(), bitWidth);                       \
+      fba.bulkSetWithBaseline(                                          \
+          0, kNumElements, data.data(), static_cast<Type>(0));          \
+      observeWrittenBuffer(buffer, kNumElements, bitWidth);             \
+    }                                                                   \
+  }
+
+FBW_PACK_NARROW_BENCHMARKS(uint8_t, 5)
+FBW_PACK_NARROW_BENCHMARKS(uint16_t, 12)
+
+BENCHMARK_DRAW_LINE();
+
+// ============================================================================
+// PFOREncoding base-residual packing — 64-bit
+// Mirrors the final bitpacking step in PFOREncoding::encode(). PFOR has already
+// materialized `maskedResiduals` with exception slots zeroed before this point.
+// ============================================================================
+
+#define PFOR_PACK64_BENCHMARKS(bitWidth)                                \
+  BENCHMARK(PFOR_PackUint64_Scalar_##bitWidth##bit, iters) {            \
+    Vector<uint64_t> maskedResiduals{pool.get()};                       \
+    std::vector<char> buffer;                                           \
+    BENCHMARK_SUSPEND {                                                 \
+      maskedResiduals = makePforMaskedResiduals(bitWidth);              \
+      buffer.resize(FixedBitArray::bufferSize(kNumElements, bitWidth)); \
+    }                                                                   \
+    while (iters--) {                                                   \
+      BENCHMARK_SUSPEND {                                               \
+        std::memset(buffer.data(), 0, buffer.size());                   \
+      }                                                                 \
+      FixedBitArray fba(buffer.data(), bitWidth);                       \
+      for (uint32_t i = 0; i < maskedResiduals.size(); ++i) {           \
+        fba.set(i, maskedResiduals[i]);                                 \
+      }                                                                 \
+      observeWrittenBuffer(buffer, kNumElements, bitWidth);             \
+    }                                                                   \
+  }                                                                     \
+  BENCHMARK_RELATIVE(PFOR_PackUint64_Bulk_##bitWidth##bit, iters) {     \
+    Vector<uint64_t> maskedResiduals{pool.get()};                       \
+    std::vector<char> buffer;                                           \
+    BENCHMARK_SUSPEND {                                                 \
+      maskedResiduals = makePforMaskedResiduals(bitWidth);              \
+      buffer.resize(FixedBitArray::bufferSize(kNumElements, bitWidth)); \
+    }                                                                   \
+    while (iters--) {                                                   \
+      BENCHMARK_SUSPEND {                                               \
+        std::memset(buffer.data(), 0, buffer.size());                   \
+      }                                                                 \
+      FixedBitArray fba(buffer.data(), bitWidth);                       \
+      fba.bulkSetWithBaseline(                                          \
+          0, kNumElements, maskedResiduals.data(), /*baseline=*/0);     \
+      observeWrittenBuffer(buffer, kNumElements, bitWidth);             \
+    }                                                                   \
+  }
+
+PFOR_PACK64_BENCHMARKS(32)
+PFOR_PACK64_BENCHMARKS(40)
+PFOR_PACK64_BENCHMARKS(48)
+PFOR_PACK64_BENCHMARKS(56)
+PFOR_PACK64_BENCHMARKS(64)
+
+BENCHMARK_DRAW_LINE();
 
 // ============================================================================
 // FixedBitWidthEncoding materialize() — 32-bit
@@ -345,7 +536,8 @@ BENCHMARK_RELATIVE(BulkGet64_vs_PerElem_57bit, iters) {
   }
 }
 
-int main() {
+int main(int argc, char** argv) {
+  folly::Init init(&argc, &argv);
   facebook::velox::memory::MemoryManager::initialize({});
   pool = facebook::velox::memory::memoryManager()->addLeafPool("benchmark");
   folly::runBenchmarks();

--- a/dwio/nimble/encodings/legacy/FixedBitWidthEncoding.h
+++ b/dwio/nimble/encodings/legacy/FixedBitWidthEncoding.h
@@ -199,19 +199,7 @@ std::string_view FixedBitWidthEncoding<T>::encode(
       [&, baseline = selection.statistics().min()](char*& pos) {
         memset(pos, 0, fixedBitArraySize);
         FixedBitArray fba(pos, bitsRequired);
-        if constexpr (sizeof(physicalType) == 4) {
-          fba.bulkSet32WithBaseline(
-              0,
-              rowCount,
-              reinterpret_cast<const uint32_t*>(values.data()),
-              baseline);
-        } else {
-          // TODO: We may want to support 32-bit mode with (u)int64 here as
-          // well.
-          for (uint32_t i = 0; i < values.size(); ++i) {
-            fba.set(i, values[i] - baseline);
-          }
-        }
+        fba.bulkSetWithBaseline(0, rowCount, values.data(), baseline);
         pos += fixedBitArraySize;
         return pos;
       }};

--- a/dwio/nimble/encodings/tests/BlockBitPackingEncodingTest.cpp
+++ b/dwio/nimble/encodings/tests/BlockBitPackingEncodingTest.cpp
@@ -669,7 +669,7 @@ TEST_F(BlockBitPackingEncodingTest, fixedBitArrayBaselineMatchesFastUnpack) {
     const auto bufSize = nimble::FixedBitArray::bufferSize(kGroupSize, bw);
     std::vector<char> packed(bufSize, 0);
     nimble::FixedBitArray fba(packed.data(), bw);
-    fba.bulkSet32WithBaseline(0, kGroupSize, values.data(), baseline);
+    fba.bulkSetWithBaseline(0, kGroupSize, values.data(), baseline);
 
     // Unpack with fastUnpack32 + manual baseline add.
     std::vector<uint32_t> decoded(kGroupSize, 0xDEADBEEF);


### PR DESCRIPTION
Summary:

Consolidate the  bulkSet64WithBaseline and  bulkSet32WithBaseline

Differential Revision: D107301473


