### PR TITLE
perf(nimble): Reusable trailer-size buffer + sparse-native iteration for MainlyConstant

### DIFF
--- a/dwio/nimble/serializer/DeserializerImpl.h
+++ b/dwio/nimble/serializer/DeserializerImpl.h
@@ -217,21 +217,54 @@ class StreamDataReader {
   void iterateStreams(Callback&& callback) {
     if (nonLegacyFormat(version_)) {
       // kCompactRaw/kTablet: stream sizes are packed into a trailer at the
-      // end of the blob.
-      const auto streamSizes = detail::readTrailerStreamSizes(end_);
+      // end of the blob. Fill into reusable member buffers — either the
+      // dense form (most encodings) or the sparse (indices, sizes) form
+      // for MainlyConstant.
+      const bool usesSparseSizes = detail::readTrailerStreamSizes(
+          end_,
+          streamSizesBuf_,
+          sparseStreamIndicesBuf_,
+          sparseStreamSizesBuf_);
       const bool isTablet = isTabletVersion(version_);
 
-      for (uint32_t i = 0; i < streamSizes.size(); ++i) {
-        std::string_view streamData(pos_, streamSizes[i]);
-        pos_ += streamSizes[i];
-        if (!streamData.empty()) {
+      if (usesSparseSizes) {
+        // Sparse iteration: visit only the non-empty stream slots that
+        // MainlyConstant naturally encodes. No dense scatter, no empty-skip
+        // branch per stream — every iteration emits a callback.
+        const size_t numNonEmptyStreams = sparseStreamIndicesBuf_.size();
+        for (size_t entryIdx = 0; entryIdx < numNonEmptyStreams; ++entryIdx) {
+          const uint32_t streamOffset = sparseStreamIndicesBuf_[entryIdx];
+          const uint32_t streamSize = sparseStreamSizesBuf_[entryIdx];
+          // Defensive: writer should never emit a non-zero-indexed entry
+          // with size 0, but guard so the dense empty-skip semantics still
+          // hold if it ever did.
+          if (streamSize == 0) {
+            continue;
+          }
+          std::string_view streamData(pos_, streamSize);
+          pos_ += streamSize;
           if (isTablet) {
-            // kTablet: stream data includes tablet chunk headers:
-            // [chunkSize:u32][compressionType:1B][encoded_data...]
-            // Strip headers and decompress if needed before handing off.
-            callback(i, stripChunkHeaders(streamData));
+            callback(streamOffset, stripChunkHeaders(streamData));
           } else {
-            callback(i, streamData);
+            callback(streamOffset, streamData);
+          }
+        }
+      } else {
+        const uint32_t numStreams = streamSizesBuf_.size();
+        for (uint32_t streamOffset = 0; streamOffset < numStreams;
+             ++streamOffset) {
+          const uint32_t streamSize = streamSizesBuf_[streamOffset];
+          std::string_view streamData(pos_, streamSize);
+          pos_ += streamSize;
+          if (!streamData.empty()) {
+            if (isTablet) {
+              // kTablet: stream data includes tablet chunk headers:
+              // [chunkSize:u32][compressionType:1B][encoded_data...]
+              // Strip headers and decompress if needed before handing off.
+              callback(streamOffset, stripChunkHeaders(streamData));
+            } else {
+              callback(streamOffset, streamData);
+            }
           }
         }
       }
@@ -311,6 +344,17 @@ class StreamDataReader {
   const char* end_{nullptr};
   // Reusable buffer for chunk header stripping (compressed/multi-chunk case).
   Vector<char> chunkStrippingBuffer_;
+  // Reusable buffer for the per-blob trailer stream-size array. Repopulated
+  // by iterateStreams() on the kCompactRaw/kTablet path; cleared+filled in
+  // place to avoid the fresh malloc/free that the by-value
+  // readTrailerStreamSizes() overload would pay per blob.
+  //
+  // For MainlyConstant trailers, the sparse pair below is populated
+  // instead of `streamSizesBuf_`, letting iterateStreams visit only the
+  // non-empty stream slots directly off the wire encoding.
+  std::vector<uint32_t> streamSizesBuf_;
+  std::vector<uint32_t> sparseStreamIndicesBuf_;
+  std::vector<uint32_t> sparseStreamSizesBuf_;
 };
 
 } // namespace facebook::nimble::serde

--- a/dwio/nimble/serializer/SerializerImpl.cpp
+++ b/dwio/nimble/serializer/SerializerImpl.cpp
@@ -32,30 +32,29 @@ namespace facebook::nimble::serde::detail {
 
 namespace {
 
-std::vector<uint32_t> decodeTrivialTrailer(
+void decodeTrivialTrailer(
     const char*& payload,
-    uint32_t payloadSize) {
+    uint32_t payloadSize,
+    std::vector<uint32_t>& sizes) {
   const uint32_t count = payloadSize / sizeof(uint32_t);
-  std::vector<uint32_t> sizes(count);
+  sizes.resize(count);
   if (count > 0) {
     std::memcpy(sizes.data(), payload, count * sizeof(uint32_t));
     payload += count * sizeof(uint32_t);
   }
-  return sizes;
 }
 
-std::vector<uint32_t> decodeVarintTrailer(const char*& payload) {
+void decodeVarintTrailer(const char*& payload, std::vector<uint32_t>& sizes) {
   const uint32_t count = varint::readVarint32(&payload);
-  std::vector<uint32_t> sizes(count);
+  sizes.resize(count);
   for (uint32_t i = 0; i < count; ++i) {
     sizes[i] = varint::readVarint32(&payload);
   }
-  return sizes;
 }
 
-std::vector<uint32_t> decodeDeltaTrailer(const char*& payload) {
+void decodeDeltaTrailer(const char*& payload, std::vector<uint32_t>& sizes) {
   const uint32_t count = varint::readVarint32(&payload);
-  std::vector<uint32_t> sizes(count);
+  sizes.resize(count);
   if (count > 0) {
     sizes[0] = varint::readVarint32(&payload);
     for (uint32_t i = 1; i < count; ++i) {
@@ -63,13 +62,14 @@ std::vector<uint32_t> decodeDeltaTrailer(const char*& payload) {
       sizes[i] = sizes[i - 1] + delta;
     }
   }
-  return sizes;
 }
 
-std::vector<uint32_t> decodeFixedBitWidthTrailer(const char*& payload) {
+void decodeFixedBitWidthTrailer(
+    const char*& payload,
+    std::vector<uint32_t>& sizes) {
   const uint8_t bitWidth = static_cast<uint8_t>(*payload++);
   const uint32_t count = varint::readVarint32(&payload);
-  std::vector<uint32_t> sizes(count);
+  sizes.assign(count, 0);
   if (bitWidth > 0 && count > 0) {
     const uint32_t packedBytes =
         static_cast<uint32_t>(FixedBitArray::bufferSize(count, bitWidth));
@@ -77,10 +77,11 @@ std::vector<uint32_t> decodeFixedBitWidthTrailer(const char*& payload) {
     arr.bulkGet32(0, count, sizes.data());
     payload += packedBytes;
   }
-  return sizes;
 }
 
-std::vector<uint32_t> decodeMainlyConstantTrailer(const char*& payload) {
+void decodeMainlyConstantTrailer(
+    const char*& payload,
+    std::vector<uint32_t>& sizes) {
   const uint32_t streamCount = varint::readVarint32(&payload);
   const uint32_t nonZeroCount = varint::readVarint32(&payload);
   NIMBLE_CHECK_LE(
@@ -88,11 +89,11 @@ std::vector<uint32_t> decodeMainlyConstantTrailer(const char*& payload) {
       streamCount,
       "MainlyConstant nonZeroCount exceeds streamCount");
   // Constant is fixed at 0 and not stored on the wire.
-  std::vector<uint32_t> sizes(streamCount, 0);
+  sizes.assign(streamCount, 0);
   if (nonZeroCount == 0) {
     // idxBitWidth/valBitWidth bytes and packed arrays are omitted when
     // there are no non-zero entries.
-    return sizes;
+    return;
   }
 
   const uint8_t idxBitWidth = static_cast<uint8_t>(*payload++);
@@ -122,7 +123,55 @@ std::vector<uint32_t> decodeMainlyConstantTrailer(const char*& payload) {
         indices[i], streamCount, "MainlyConstant trailer index out of range");
     sizes[indices[i]] = values[i];
   }
-  return sizes;
+}
+
+// Sparse-native MainlyConstant trailer decode: fill (indices, sizes)
+// parallel arrays for only the non-zero stream slots, skipping the
+// streamCount-zero-filled dense expansion. Caller iterates the returned
+// indices/sizes directly to visit non-empty streams.
+void decodeMainlyConstantTrailerSparse(
+    const char*& payload,
+    std::vector<uint32_t>& indices,
+    std::vector<uint32_t>& sizes) {
+  const uint32_t streamCount = varint::readVarint32(&payload);
+  const uint32_t nonZeroCount = varint::readVarint32(&payload);
+  NIMBLE_CHECK_LE(
+      nonZeroCount,
+      streamCount,
+      "MainlyConstant nonZeroCount exceeds streamCount");
+  indices.resize(nonZeroCount);
+  sizes.resize(nonZeroCount);
+  if (nonZeroCount == 0) {
+    return;
+  }
+
+  const uint8_t idxBitWidth = static_cast<uint8_t>(*payload++);
+  NIMBLE_CHECK_LE(
+      idxBitWidth, 32, "MainlyConstant idxBitWidth exceeds 32 bits");
+  const uint32_t packedIndicesBytes = static_cast<uint32_t>(
+      FixedBitArray::bufferSize(nonZeroCount, idxBitWidth));
+  FixedBitArray idxArr{
+      const_cast<char*>(payload), static_cast<int>(idxBitWidth)};
+  idxArr.bulkGet32(0, nonZeroCount, indices.data());
+  payload += packedIndicesBytes;
+
+  // Validate decoded indices against streamCount for parity with the dense
+  // decoder's per-scatter NIMBLE_CHECK_LT. Catches trailer corruption that
+  // the downstream `offset <= maxStreamOffset` clamp would otherwise mask.
+  for (uint32_t i = 0; i < nonZeroCount; ++i) {
+    NIMBLE_CHECK_LT(
+        indices[i], streamCount, "MainlyConstant trailer index out of range");
+  }
+
+  const uint8_t valBitWidth = static_cast<uint8_t>(*payload++);
+  NIMBLE_CHECK_LE(
+      valBitWidth, 32, "MainlyConstant valBitWidth exceeds 32 bits");
+  const uint32_t packedValuesBytes = static_cast<uint32_t>(
+      FixedBitArray::bufferSize(nonZeroCount, valBitWidth));
+  FixedBitArray valArr{
+      const_cast<char*>(payload), static_cast<int>(valBitWidth)};
+  valArr.bulkGet32(0, nonZeroCount, sizes.data());
+  payload += packedValuesBytes;
 }
 
 // Upper-bound payload-size estimators (one per trailer encoding). Each
@@ -214,31 +263,31 @@ size_t estimateMainlyConstantTrailerPayloadSize(size_t numStreams) {
       FixedBitArray::bufferSize(numStreams, /*bitWidth=*/32);
 }
 
-std::vector<uint32_t> decodeTrailerStreamSizes(
+void decodeTrailerStreamSizes(
     const char* trailerStart,
-    uint32_t trailerSize) {
+    uint32_t trailerSize,
+    std::vector<uint32_t>& out) {
   const auto* end = trailerStart + trailerSize;
   const auto encodingType =
       static_cast<EncodingType>(static_cast<uint8_t>(*trailerStart));
   const char* payload = trailerStart + sizeof(uint8_t);
   const uint32_t payloadSize = trailerSize - sizeof(uint8_t);
-  std::vector<uint32_t> sizes;
 
   switch (encodingType) {
     case EncodingType::Trivial:
-      sizes = decodeTrivialTrailer(payload, payloadSize);
+      decodeTrivialTrailer(payload, payloadSize, out);
       break;
     case EncodingType::Varint:
-      sizes = decodeVarintTrailer(payload);
+      decodeVarintTrailer(payload, out);
       break;
     case EncodingType::Delta:
-      sizes = decodeDeltaTrailer(payload);
+      decodeDeltaTrailer(payload, out);
       break;
     case EncodingType::FixedBitWidth:
-      sizes = decodeFixedBitWidthTrailer(payload);
+      decodeFixedBitWidthTrailer(payload, out);
       break;
     case EncodingType::MainlyConstant:
-      sizes = decodeMainlyConstantTrailer(payload);
+      decodeMainlyConstantTrailer(payload, out);
       break;
     default:
       NIMBLE_FAIL(
@@ -252,6 +301,13 @@ std::vector<uint32_t> decodeTrailerStreamSizes(
       "Trailer size mismatch: read {} bytes, expected {}",
       payload - trailerStart,
       trailerSize);
+}
+
+std::vector<uint32_t> decodeTrailerStreamSizes(
+    const char* trailerStart,
+    uint32_t trailerSize) {
+  std::vector<uint32_t> sizes;
+  decodeTrailerStreamSizes(trailerStart, trailerSize, sizes);
   return sizes;
 }
 
@@ -320,6 +376,35 @@ std::vector<uint32_t> readTrailerStreamSizes(const char* end) {
   const uint32_t trailerSize = readTrailerSize(end);
   const char* trailerStart = end - sizeof(uint32_t) - trailerSize;
   return decodeTrailerStreamSizes(trailerStart, trailerSize);
+}
+
+bool readTrailerStreamSizes(
+    const char* end,
+    std::vector<uint32_t>& denseSizes,
+    std::vector<uint32_t>& sparseIndices,
+    std::vector<uint32_t>& sparseSizes) {
+  const uint32_t trailerSize = readTrailerSize(end);
+  const char* trailerStart = end - sizeof(uint32_t) - trailerSize;
+  const auto* trailerEnd = trailerStart + trailerSize;
+  const auto encodingType =
+      static_cast<EncodingType>(static_cast<uint8_t>(*trailerStart));
+  if (encodingType != EncodingType::MainlyConstant) {
+    // Fall back to dense for encodings whose wire format isn't naturally
+    // sparse. Caller iterates the dense vector and skips zeros inline.
+    decodeTrailerStreamSizes(trailerStart, trailerSize, denseSizes);
+    return false;
+  }
+  // MainlyConstant is sparse on the wire: fill (indices, sizes) directly
+  // and skip the streamCount-zero-filled dense expansion entirely.
+  const char* payload = trailerStart + sizeof(uint8_t);
+  decodeMainlyConstantTrailerSparse(payload, sparseIndices, sparseSizes);
+  NIMBLE_CHECK_EQ(
+      payload,
+      trailerEnd,
+      "Trailer size mismatch (sparse): read {} bytes, expected {}",
+      payload - trailerStart,
+      trailerSize);
+  return true;
 }
 
 std::vector<uint32_t> readTrailerStreamSizes(const folly::IOBuf& input) {

--- a/dwio/nimble/serializer/SerializerImpl.h
+++ b/dwio/nimble/serializer/SerializerImpl.h
@@ -415,6 +415,24 @@ void skipStream(const char*& pos) {
 /// encoding-specific payload.
 std::vector<uint32_t> readTrailerStreamSizes(const char* end);
 
+/// Caller-fills overload of readTrailerStreamSizes that picks a sparse or
+/// dense representation off the encoding-type byte:
+///   - MainlyConstant: fills `sparseIndices` + `sparseSizes` with only the
+///     non-zero stream slots and returns `true`. The dense
+///     `streamCount`-zero-filled scatter is skipped entirely; the caller
+///     iterates the sparse arrays to visit non-empty streams.
+///   - All other encodings (Trivial/Varint/Delta/FixedBitWidth): fills
+///     `denseSizes` and returns `false`. Caller iterates `denseSizes` as
+///     usual.
+/// All three out vectors must be reusable buffers owned by the caller
+/// (e.g. members on `StreamDataReader`) to keep the per-blob hot path
+/// alloc-free across invocations.
+bool readTrailerStreamSizes(
+    const char* end,
+    std::vector<uint32_t>& denseSizes,
+    std::vector<uint32_t>& sparseIndices,
+    std::vector<uint32_t>& sparseSizes);
+
 /// IOBuf overload: reads stream sizes from the trailer of a (possibly
 /// chained) IOBuf. Tries the fast path first: if the tail segment contains the
 /// entire trailer, delegates to the contiguous overload. Falls back to


### PR DESCRIPTION
Summary:

Two layered changes to `StreamDataReader::iterateStreams` cut per-blob
trailer-decode and stream-walking overhead on the rexdb hybrid-Nimble
EBF scan-all hot path. Validated −576 ms (−5.2%) end-to-end decode CPU
at batch=2500 (5 runs each, p<0.001 vs same-session baseline).

# Change 1 — Caller-fills `readTrailerStreamSizes` overload

Add `void readTrailerStreamSizes(const char* end, vector<uint32_t>& out)`
alongside the existing by-value overload. Each per-encoding decoder
(`decodeTrivialTrailer` / `Varint` / `Delta` / `FixedBitWidth` /
`MainlyConstant`) is refactored from `vector<uint32_t> decodeXxx(...)`
to `void decodeXxx(..., vector<uint32_t>& out)` filling the caller's
vector in place via `resize()` / `assign()`.

`StreamDataReader` gets a new `streamSizesBuf_` member; `iterateStreams`
calls the caller-fills overload so the per-blob malloc/free pair for
the returned vector goes away after the first call within a
`deserialize()` invocation. The first blob in each deserialize call
still allocates; the remaining ~2500 blobs reuse the capacity.

# Change 2 — Sparse-native iteration for MainlyConstant

MainlyConstant trailers store `(indices[], values[])` on the wire,
where `indices` lists the positions of non-zero stream sizes and
`values` lists their sizes; the implicit constant 0 fills everything
else. The pre-existing dense decoder expanded this to
`vector<uint32_t>(streamCount, 0)` and then scattered values into it,
forcing `iterateStreams` to loop over all `streamCount` slots and
empty-skip ~95% of them.

For EBF flatmap workloads (357 top-level keys × 2 streams each =
~715 stream slots, of which only ~40 are present per blob), this
was ~555M no-op zero iterations per benchmark run.

New `readTrailerStreamSizesPreferSparse(end, dense, sparseIndices,
sparseSizes)` overload picks the sparse path when the encoding type
is MainlyConstant: fills `sparseIndices` + `sparseSizes` directly off
the wire, no streamCount-zero scatter, and returns `true`. For all
other encodings (Trivial / Varint / Delta / FixedBitWidth) it falls
through to the dense decoder and returns `false`.

`iterateStreams` branches on the return value:
  - sparse path → iterate `sparseIndices.size()` entries (~40 per blob
    on this workload), every iteration emits a callback.
  - dense path → existing behavior (loop streamCount entries with
    empty-skip), unchanged.

# Test Plan

`buck2 test fbcode//dwio/nimble/serializer/tests:tests
            fbcode//dwio/nimble/velox/tests:tests
            fbcode//dwio/serializer/thrift/tests:encoder_test`
— 1584 + tests pass, 0 failed.

# Perf measurements

Same-session A/B, 5 runs each, batch=2500, scan-all-no-seek, sequential
decode, no block cache, MainlyConstant SST:

| Variant                           | Decode CPU mean | µs/row | Stddev |
|-----------------------------------|-----------------|--------|--------|
| Baseline (D107603051)             | 11.006 s        | 13.38  | 0.167  |
| + Change 1 only                   | 10.828 s        | 13.17  | 0.119  |
| + Change 1 + Change 2 (this diff) | 10.430 s        | 12.68  | 0.126  |

Change 1 alone: −178 ms (−1.6%, p ≈ 0.09, borderline)
Change 2 on top: −398 ms additional (p < 0.001)
Combined vs baseline: **−576 ms (−5.2%, p < 0.001)**

The sparse iteration directly attacks the ~555M zero loop iterations
per run; the trailer-buffer reuse compounds by removing the per-blob
malloc/free.

For non-MainlyConstant encodings, behavior is unchanged — the dense
path is still the default for them.

Reviewed By: duxiao1212

Differential Revision: D107608648


