### PR TITLE
fix(nimble): Route projector schema construction through velox-source buildProjectedNimbleType

### DIFF
--- a/dwio/nimble/serializer/tests/ProjectorTest.cpp
+++ b/dwio/nimble/serializer/tests/ProjectorTest.cpp
@@ -763,7 +763,8 @@ TEST_F(ProjectorTest, unsupportedArraySubscript) {
   SerializerOptions serOpts{.version = SerializationVersion::kCompactRaw};
   auto inputSchema = getNimbleSchema(type, serOpts);
 
-  // Array subscripts are not supported.
+  // Array subscripts are not supported — subscripts on non-FlatMap source
+  // nodes are rejected during subfield resolution against the source schema.
   auto subfields = makeSubfields({"arr[0]"});
 
   NIMBLE_ASSERT_THROW(
@@ -782,7 +783,9 @@ TEST_F(ProjectorTest, unsupportedMapKeyProjection) {
   SerializerOptions serOpts{.version = SerializationVersion::kCompactRaw};
   auto inputSchema = getNimbleSchema(type, serOpts);
 
-  // Regular map subscripts are not supported (would need re-encoding).
+  // Regular map subscripts are not supported (would need re-encoding) — the
+  // source's MAP is not encoded as FlatMap, so subfield resolution rejects
+  // the subscript before we even reach schema building.
   auto subfields = makeSubfields({"m[\"key\"]"});
 
   NIMBLE_ASSERT_THROW(
@@ -1521,7 +1524,9 @@ TEST_F(ProjectorTest, projectFlatMapMultipleKeys) {
   }
 }
 
-// Test projecting FlatMap with non-existent key throws.
+// Test projecting FlatMap with only non-existent keys: the projected schema
+// contains a placeholder child per requested key, and the round-trip decoded
+// output produces null values for those keys.
 TEST_F(ProjectorTest, projectFlatMapNonExistentKey) {
   auto type = ROW({
       {"id", BIGINT()},
@@ -1577,18 +1582,358 @@ TEST_F(ProjectorTest, projectFlatMapNonExistentKey) {
       .flatMapColumns = {{"features", {}}},
   };
   auto [serialized, inputSchema] = serializeWithSchema(vec, type, serOpts);
-  (void)serialized; // Not used, just needed to discover keys.
 
-  // Try to project a key that doesn't exist in schema.
+  // Project a key that does not exist in the source schema. The Projector
+  // succeeds: the projected FlatMap contains "999" as a synthetic child,
+  // and the byte-copy pipeline writes a 0-byte placeholder slot for it.
   auto subfields = makeSubfields({"features[\"999\"]"});
+  Projector projector{
+      inputSchema,
+      subfields,
+      pool_.get(),
+      {.projectVersion = SerializationVersion::kCompactRaw}};
 
-  NIMBLE_ASSERT_THROW(
-      Projector(
-          inputSchema,
-          subfields,
-          pool_.get(),
-          {.projectVersion = SerializationVersion::kCompactRaw}),
-      "Cannot project entire FlatMap column without key subscripts");
+  // The projected schema has one child for the requested (missing) key.
+  const auto& projectedSchema = projector.projectedSchema();
+  ASSERT_EQ(Kind::Row, projectedSchema->kind());
+  ASSERT_EQ(1, projectedSchema->asRow().childrenCount());
+  ASSERT_EQ(Kind::FlatMap, projectedSchema->asRow().childAt(0)->kind());
+  const auto& projectedFlatMap =
+      projectedSchema->asRow().childAt(0)->asFlatMap();
+  ASSERT_EQ(1, projectedFlatMap.childrenCount());
+  EXPECT_EQ("999", projectedFlatMap.nameAt(0));
+
+  // Round-trip: deserialize the projected blob against the projected schema
+  // and confirm key 999 decodes to null for every row.
+  auto projected = projectInput(projector, serialized, /*useIOBuf=*/false);
+  auto projectedStr = toString(projected);
+  DeserializerOptions deserOpts{.hasHeader = true};
+  auto result = deserialize(projectedStr, projectedSchema, deserOpts);
+  ASSERT_EQ(numRows, result->size());
+  auto* features = result->as<RowVector>()->childAt(0)->as<MapVector>();
+  ASSERT_NE(nullptr, features);
+  for (vector_size_t i = 0; i < numRows; ++i) {
+    EXPECT_EQ(0, features->sizeAt(i))
+        << "row " << i << " should have an empty map (all requested keys "
+        << "missing in source)";
+  }
+}
+
+// All-missing-keys projection on a FlatMap whose value subtree is a Row.
+// Exercises the `emitPlaceholderOffsets` Row branch end-to-end (Row.nulls +
+// 2 inner scalars = 3 UINT32_MAX value slots + 1 inMap slot per missing key).
+TEST_F(ProjectorTest, projectFlatMapNonExistentKey_RowValue) {
+  auto valueRowType = ROW({{"a", INTEGER()}, {"b", VARCHAR()}});
+  auto type =
+      ROW({{"id", BIGINT()}, {"features", MAP(INTEGER(), valueRowType)}});
+
+  // 2 rows × 2 entries (keys 1 and 2 — both real, so the source FlatMap has
+  // a non-empty value template for `convertToVeloxType` / `childAt(0)`).
+  const vector_size_t numRows = 2;
+  const int entriesPerRow = 2;
+  const int totalEntries = numRows * entriesPerRow;
+
+  auto ids = makeIntVector<int64_t>({100, 200});
+  auto mapOffsets = allocateOffsets(numRows, pool_.get());
+  auto mapSizes = allocateSizes(numRows, pool_.get());
+  auto* rawOffsets = mapOffsets->asMutable<vector_size_t>();
+  auto* rawSizes = mapSizes->asMutable<vector_size_t>();
+  for (vector_size_t i = 0; i < numRows; ++i) {
+    rawOffsets[i] = i * entriesPerRow;
+    rawSizes[i] = entriesPerRow;
+  }
+  std::vector<int32_t> keys;
+  std::vector<int32_t> aVals;
+  std::vector<std::string> bVals;
+  for (int i = 0; i < totalEntries; ++i) {
+    keys.push_back((i % entriesPerRow) + 1); // keys 1, 2
+    aVals.push_back(i);
+    bVals.push_back(fmt::format("v{}", i));
+  }
+  auto keysVec = makeIntVector(keys);
+  auto aVec = makeIntVector(aVals);
+  auto bVec = makeStringVector(bVals);
+  auto valueRows = std::make_shared<RowVector>(
+      pool_.get(),
+      valueRowType,
+      nullptr,
+      static_cast<vector_size_t>(totalEntries),
+      std::vector<VectorPtr>{aVec, bVec});
+  auto mapVector = std::make_shared<MapVector>(
+      pool_.get(),
+      MAP(INTEGER(), valueRowType),
+      nullptr,
+      numRows,
+      mapOffsets,
+      mapSizes,
+      keysVec,
+      valueRows);
+  auto vec = std::make_shared<RowVector>(
+      pool_.get(),
+      type,
+      nullptr,
+      numRows,
+      std::vector<VectorPtr>{ids, mapVector});
+
+  SerializerOptions serOpts{
+      .version = SerializationVersion::kCompactRaw,
+      .flatMapColumns = {{"features", {}}},
+  };
+  auto [serialized, inputSchema] = serializeWithSchema(vec, type, serOpts);
+
+  // Project a non-existent key (subscript 999 not in source). Should succeed:
+  // the projected FlatMap holds "999" as a synthetic child whose value-subtree
+  // is a clone of the source's value Row, with UINT32_MAX placeholders for
+  // every stream in that subtree plus the inMap.
+  auto subfields = makeSubfields({"features[\"999\"]"});
+  Projector projector{
+      inputSchema,
+      subfields,
+      pool_.get(),
+      {.projectVersion = SerializationVersion::kCompactRaw}};
+
+  const auto& projectedSchema = projector.projectedSchema();
+  ASSERT_EQ(Kind::Row, projectedSchema->kind());
+  ASSERT_EQ(1, projectedSchema->asRow().childrenCount());
+  const auto& projectedFlatMap =
+      projectedSchema->asRow().childAt(0)->asFlatMap();
+  ASSERT_EQ(1, projectedFlatMap.childrenCount());
+  EXPECT_EQ("999", projectedFlatMap.nameAt(0));
+  // Value subtree is a Row (cloned structurally from the source's value Row).
+  ASSERT_EQ(Kind::Row, projectedFlatMap.childAt(0)->kind());
+  EXPECT_EQ(2, projectedFlatMap.childAt(0)->asRow().childrenCount());
+
+  // Round-trip: decoded map should be empty for every row (the inMap stream
+  // is all-zero placeholder → gap-fill says "no rows have this key").
+  auto projected = projectInput(projector, serialized, /*useIOBuf=*/false);
+  DeserializerOptions deserOpts{.hasHeader = true};
+  auto result = deserialize(toString(projected), projectedSchema, deserOpts);
+  ASSERT_EQ(numRows, result->size());
+  auto* features = result->as<RowVector>()->childAt(0)->as<MapVector>();
+  ASSERT_NE(nullptr, features);
+  for (vector_size_t i = 0; i < numRows; ++i) {
+    EXPECT_EQ(0, features->sizeAt(i)) << "row " << i;
+  }
+}
+
+// All-missing-keys projection on a FlatMap whose value subtree is an Array.
+// Exercises the `emitPlaceholderOffsets` Array branch end-to-end (Array
+// lengths + 1 element scalar = 2 UINT32_MAX value slots + 1 inMap per key).
+TEST_F(ProjectorTest, projectFlatMapNonExistentKey_ArrayValue) {
+  auto valueArrayType = ARRAY(INTEGER());
+  auto type =
+      ROW({{"id", BIGINT()}, {"features", MAP(INTEGER(), valueArrayType)}});
+
+  // 2 rows × 2 entries; each value is a 2-element array.
+  const vector_size_t numRows = 2;
+  const int entriesPerRow = 2;
+  const int totalEntries = numRows * entriesPerRow;
+  const int elementsPerArray = 2;
+
+  auto ids = makeIntVector<int64_t>({100, 200});
+  auto mapOffsets = allocateOffsets(numRows, pool_.get());
+  auto mapSizes = allocateSizes(numRows, pool_.get());
+  auto* rawMapOff = mapOffsets->asMutable<vector_size_t>();
+  auto* rawMapSz = mapSizes->asMutable<vector_size_t>();
+  for (vector_size_t i = 0; i < numRows; ++i) {
+    rawMapOff[i] = i * entriesPerRow;
+    rawMapSz[i] = entriesPerRow;
+  }
+  std::vector<int32_t> keys;
+  for (int i = 0; i < totalEntries; ++i) {
+    keys.push_back((i % entriesPerRow) + 1); // keys 1, 2
+  }
+  auto keysVec = makeIntVector(keys);
+
+  auto arrayOffsets = allocateOffsets(totalEntries, pool_.get());
+  auto arraySizes = allocateSizes(totalEntries, pool_.get());
+  auto* rawArrOff = arrayOffsets->asMutable<vector_size_t>();
+  auto* rawArrSz = arraySizes->asMutable<vector_size_t>();
+  for (int i = 0; i < totalEntries; ++i) {
+    rawArrOff[i] = i * elementsPerArray;
+    rawArrSz[i] = elementsPerArray;
+  }
+  std::vector<int32_t> elementVals;
+  for (int i = 0; i < totalEntries * elementsPerArray; ++i) {
+    elementVals.push_back(i);
+  }
+  auto elementsVec = makeIntVector(elementVals);
+  auto arrayValues = std::make_shared<ArrayVector>(
+      pool_.get(),
+      valueArrayType,
+      nullptr,
+      static_cast<vector_size_t>(totalEntries),
+      arrayOffsets,
+      arraySizes,
+      elementsVec);
+  auto mapVector = std::make_shared<MapVector>(
+      pool_.get(),
+      MAP(INTEGER(), valueArrayType),
+      nullptr,
+      numRows,
+      mapOffsets,
+      mapSizes,
+      keysVec,
+      arrayValues);
+  auto vec = std::make_shared<RowVector>(
+      pool_.get(),
+      type,
+      nullptr,
+      numRows,
+      std::vector<VectorPtr>{ids, mapVector});
+
+  SerializerOptions serOpts{
+      .version = SerializationVersion::kCompactRaw,
+      .flatMapColumns = {{"features", {}}},
+  };
+  auto [serialized, inputSchema] = serializeWithSchema(vec, type, serOpts);
+
+  auto subfields = makeSubfields({"features[\"999\"]"});
+  Projector projector{
+      inputSchema,
+      subfields,
+      pool_.get(),
+      {.projectVersion = SerializationVersion::kCompactRaw}};
+
+  const auto& projectedSchema = projector.projectedSchema();
+  ASSERT_EQ(Kind::Row, projectedSchema->kind());
+  const auto& projectedFlatMap =
+      projectedSchema->asRow().childAt(0)->asFlatMap();
+  ASSERT_EQ(1, projectedFlatMap.childrenCount());
+  EXPECT_EQ("999", projectedFlatMap.nameAt(0));
+  // Value subtree is an Array (cloned structurally from the source's value).
+  ASSERT_EQ(Kind::Array, projectedFlatMap.childAt(0)->kind());
+
+  auto projected = projectInput(projector, serialized, /*useIOBuf=*/false);
+  DeserializerOptions deserOpts{.hasHeader = true};
+  auto result = deserialize(toString(projected), projectedSchema, deserOpts);
+  ASSERT_EQ(numRows, result->size());
+  auto* features = result->as<RowVector>()->childAt(0)->as<MapVector>();
+  ASSERT_NE(nullptr, features);
+  for (vector_size_t i = 0; i < numRows; ++i) {
+    EXPECT_EQ(0, features->sizeAt(i)) << "row " << i;
+  }
+}
+
+// Verifies the placeholder-slot behavior for missing FlatMap keys in the
+// production workflow:
+//   1) Projector is constructed with the SOURCE schema (the schema the blob
+//      was actually serialized with — keys "1" and "3" only).
+//   2) Caller projects subfields ["1", "2", "3"], where "2" is missing in
+//      the source.
+//   3) Caller constructs an EXPANDED schema via the velox-based
+//      buildProjectedNimbleType containing all three keys, and uses it to
+//      deserialize the projected blob.
+//
+// The Projector's nimble-schema-based buildProjectedNimbleType emits key "2"
+// as a synthetic child with UINT32_MAX input offsets, so the Projector
+// writes 0-byte placeholder slots into the trailer at positions 4-5. The
+// expanded schema's offsets line up with these positions, and the
+// Deserializer's gap-fill produces a null/absent column for key "2" while
+// keys "1" and "3" decode their real bytes.
+//
+// Asserted end-to-end semantics: data["1"]=10.0, data["2"] absent/null,
+// data["3"]=30.0.
+TEST_F(ProjectorTest, missingKeyInMiddleProducesPlaceholder) {
+  auto type = ROW({{"data", MAP(INTEGER(), DOUBLE())}});
+
+  // One row, two entries: keys 1 and 3 (key 2 is intentionally absent).
+  const vector_size_t numRows = 1;
+  const int entriesPerRow = 2;
+  const int totalEntries = numRows * entriesPerRow;
+
+  auto mapOffsets = allocateOffsets(numRows, pool_.get());
+  auto mapSizes = allocateSizes(numRows, pool_.get());
+  mapOffsets->asMutable<vector_size_t>()[0] = 0;
+  mapSizes->asMutable<vector_size_t>()[0] = entriesPerRow;
+
+  auto mapKeys = BaseVector::create<FlatVector<int32_t>>(
+      INTEGER(), totalEntries, pool_.get());
+  auto mapValues = BaseVector::create<FlatVector<double>>(
+      DOUBLE(), totalEntries, pool_.get());
+  mapKeys->set(0, 1);
+  mapKeys->set(1, 3);
+  mapValues->set(0, 10.0);
+  mapValues->set(1, 30.0);
+
+  auto mapVector = std::make_shared<MapVector>(
+      pool_.get(),
+      MAP(INTEGER(), DOUBLE()),
+      nullptr,
+      numRows,
+      mapOffsets,
+      mapSizes,
+      mapKeys,
+      mapValues);
+
+  auto vec = std::make_shared<RowVector>(
+      pool_.get(), type, nullptr, numRows, std::vector<VectorPtr>{mapVector});
+
+  // Serialize as FlatMap — blob will have streams only for keys "1" and "3".
+  SerializerOptions serOpts{
+      .version = SerializationVersion::kCompactRaw,
+      .flatMapColumns = {{"data", {}}},
+  };
+  auto [blob, sourceSchema] = serializeWithSchema(vec, type, serOpts);
+
+  // Caller asks for all three keys (key "2" is missing in source).
+  auto subfields = makeSubfields({"data[\"1\"]", "data[\"2\"]", "data[\"3\"]"});
+
+  // Build the EXPANDED schema via the velox-based API for use at deserialize
+  // time. It has children for all three keys with dense alphabetical offsets.
+  nimble::ColumnEncodings encodings;
+  encodings.flatMapColumns.insert("data");
+  auto expandedSchema =
+      nimble::buildProjectedNimbleType(type->asRow(), subfields, encodings);
+
+  // Production flow: construct the Projector with the SOURCE schema (the
+  // schema that actually matches the blob). The Projector currently silent-
+  // drops key "2" because it's not in the source.
+  Projector projector(
+      sourceSchema,
+      subfields,
+      pool_.get(),
+      {.projectVersion = SerializationVersion::kCompactRaw});
+
+  auto projected = projectInput(projector, blob, /*useIOBuf=*/false);
+  auto projectedStr = toString(projected);
+
+  // Deserialize the projected blob using the EXPANDED schema (which expects
+  // all three keys). The Projector emits a 0-byte placeholder slot for key 2
+  // so the expanded schema's offsets line up with the projected blob and the
+  // Deserializer's gap-fill produces a null column for the missing key.
+  DeserializerOptions deserOpts{.hasHeader = true};
+  auto result = deserialize(projectedStr, expandedSchema, deserOpts);
+
+  ASSERT_EQ(result->size(), 1);
+  auto resultRow = result->as<RowVector>();
+  auto dataMap = resultRow->childAt(0)->as<MapVector>();
+  ASSERT_NE(dataMap, nullptr);
+
+  // Build (key -> optional<value>) map for the single row by walking the
+  // MapVector. A key is "present" if it appears in the map; "absent" if it
+  // doesn't. We expect: 1 -> 10.0, 2 -> absent, 3 -> 30.0.
+  std::map<int32_t, std::optional<double>> got;
+  auto* keys = dataMap->mapKeys()->as<FlatVector<int32_t>>();
+  auto* values = dataMap->mapValues()->as<FlatVector<double>>();
+  ASSERT_NE(keys, nullptr);
+  ASSERT_NE(values, nullptr);
+  const auto offset = dataMap->offsetAt(0);
+  const auto size = dataMap->sizeAt(0);
+  for (vector_size_t i = offset; i < offset + size; ++i) {
+    const auto k = keys->valueAt(i);
+    if (values->isNullAt(i)) {
+      got[k] = std::nullopt;
+    } else {
+      got[k] = values->valueAt(i);
+    }
+  }
+
+  const std::map<int32_t, std::optional<double>> expected{
+      {1, 10.0},
+      {3, 30.0},
+  };
+  EXPECT_EQ(got, expected);
 }
 
 // Test stream indices are correct.

--- a/dwio/nimble/velox/SchemaUtils.cpp
+++ b/dwio/nimble/velox/SchemaUtils.cpp
@@ -523,23 +523,35 @@ std::shared_ptr<const Type> buildProjectedNimbleType(
 }
 
 //
-// buildProjectedNimbleType and its helpers.
+// deriveColumnEncodings, computeSourceStreamOffsets.
 //
 
 namespace {
 
-// Tracks which children to include at each Row/FlatMap node during projection.
-// When a node appears in this map, only its selected children are included.
-// When absent, all children are included.
-using NimbleSelectedChildrenMap =
-    folly::F14FastMap<const Type*, std::set<size_t>>;
+// Tracks the source children the projection touches at each Row or FlatMap
+// node, stored as the child's source-side index. For a Row, the indices are
+// Row child positions. For a FlatMap, the indices are positions of source
+// keys that match a requested subscript. FlatMap subscripts whose key is NOT
+// in the source go into `missingChildren` below instead.
+using SelectedChildrenMap = folly::F14FastMap<const Type*, std::set<size_t>>;
 
-// Resolves a single subfield path against a nimble schema tree, populating
-// selectedChildren with which children to include at each Row/FlatMap node.
+// Tracks the FlatMap subscript keys the projection requested that do NOT
+// exist in the source. The offset walker iterates them alphabetically and
+// emits UINT32_MAX placeholder slots so the projected blob lines up with the
+// projected schema's synthetic children (created by the velox-source
+// `buildProjectedNimbleType`).
+using MissingChildrenMap =
+    folly::F14FastMap<const Type*, std::set<std::string>>;
+
+// Resolves a single subfield path against a source nimble schema, populating
+// selectedChildren for present Row children + present FlatMap keys (by
+// source index) and missingChildren for FlatMap keys absent from the source
+// (by name).
 void resolveSubfield(
     const Type* type,
     const velox::common::Subfield& subfield,
-    NimbleSelectedChildrenMap& selectedChildren) {
+    SelectedChildrenMap& selectedChildren,
+    MissingChildrenMap& missingChildren) {
   const auto& path = subfield.path();
   NIMBLE_CHECK(!path.empty(), "Empty subfield path");
 
@@ -581,10 +593,12 @@ void resolveSubfield(
       const auto& flatMap = current->asFlatMap();
       const auto childIdx = flatMap.findChild(keyName);
       if (!childIdx.has_value()) {
-        // Key not in file schema — skip this subfield silently.
+        // Key not in source — recorded by name for placeholder emission. Any
+        // remaining subfield path elements are discarded; the whole synthetic
+        // value subtree decodes to null.
+        missingChildren[current].insert(keyName);
         return;
       }
-
       selectedChildren[current].insert(*childIdx);
       current = flatMap.childAt(*childIdx).get();
     } else {
@@ -596,219 +610,284 @@ void resolveSubfield(
   }
 }
 
-// Allocates an output stream offset on-demand during schema traversal and
-// records the corresponding input stream offset.
-StreamDescriptor allocateStreamOffset(
-    const StreamDescriptor& inputDesc,
-    uint32_t& nextOffset,
-    std::vector<uint32_t>& inputStreamOffsets) {
-  inputStreamOffsets.push_back(inputDesc.offset());
-  return StreamDescriptor{nextOffset++, inputDesc.scalarKind()};
-}
-
-// Sorts FlatMap children indices alphabetically by name for canonical ordering
-// that matches buildProjectedNimbleType's stream offset assignment.
-std::vector<size_t> sortedFlatMapChildIndices(
-    const FlatMapType& flatMap,
-    std::vector<size_t> indices) {
-  std::sort(indices.begin(), indices.end(), [&](auto a, auto b) {
-    return flatMap.nameAt(a) < flatMap.nameAt(b);
-  });
-  return indices;
-}
-
-// Returns true if the kind is an encoding-specific type that should only
-// appear as a direct child of the top-level Row.
-bool specificEncodingKind(Kind kind) {
-  return kind == Kind::FlatMap || kind == Kind::ArrayWithOffsets ||
-      kind == Kind::SlidingWindowMap;
-}
-
-// Builds a projected nimble type from the input type, including only selected
-// children. Assigns output stream offsets sequentially in DFS traversal order,
-// matching how SchemaBuilder assigns offsets in buildProjectedNimbleType.
-// FlatMap children are sorted alphabetically by name for canonical ordering.
-//
-// Encoding-specific types (FlatMap, ArrayWithOffsets, SlidingWindowMap) must
-// only appear as direct children of the top-level Row. The public function
-// buildProjectedNimbleType handles the root Row and passes isTopLevelChild=true
-// for its direct children.
-std::shared_ptr<const Type> buildProjectedType(
-    const Type* inputType,
-    const NimbleSelectedChildrenMap& selectedChildren,
-    uint32_t& nextOffset,
-    std::vector<uint32_t>& inputStreamOffsets,
-    bool isTopLevelChild = false) {
-  const auto kind = inputType->kind();
-  NIMBLE_CHECK(
-      isTopLevelChild || !specificEncodingKind(kind),
-      "Encoding-specific type {} must be a direct child of the top-level Row",
-      kind);
-  switch (kind) {
-    case Kind::Scalar: {
-      return std::make_shared<ScalarType>(allocateStreamOffset(
-          inputType->asScalar().scalarDescriptor(),
-          nextOffset,
-          inputStreamOffsets));
-    }
-
-    case Kind::TimestampMicroNano: {
-      const auto& ts = inputType->asTimestampMicroNano();
-      auto microsDesc = allocateStreamOffset(
-          ts.microsDescriptor(), nextOffset, inputStreamOffsets);
-      auto nanosDesc = allocateStreamOffset(
-          ts.nanosDescriptor(), nextOffset, inputStreamOffsets);
-      return std::make_shared<TimestampMicroNanoType>(
-          std::move(microsDesc), std::move(nanosDesc));
-    }
-
+// Walks a value-type (typically `flatMap.childAt(0)` from a source FlatMap
+// whose requested key is missing) and pushes UINT32_MAX into
+// `projectedStreamOffsets` for every stream descriptor the subtree contains.
+// The number of UINT32_MAX entries matches the slot count the velox-source
+// `buildProjectedNimbleType` would allocate for the corresponding synthetic
+// FlatMap value subtree.
+void emitPlaceholderStreamOffsets(
+    const Type* valueType,
+    std::vector<uint32_t>& projectedStreamOffsets) {
+  switch (valueType->kind()) {
+    case Kind::Scalar:
+      projectedStreamOffsets.push_back(UINT32_MAX);
+      return;
+    case Kind::TimestampMicroNano:
+      projectedStreamOffsets.push_back(UINT32_MAX); // micros
+      projectedStreamOffsets.push_back(UINT32_MAX); // nanos
+      return;
     case Kind::Row: {
-      const auto& row = inputType->asRow();
-      auto nullsDesc = allocateStreamOffset(
-          row.nullsDescriptor(), nextOffset, inputStreamOffsets);
+      const auto& row = valueType->asRow();
+      projectedStreamOffsets.push_back(UINT32_MAX); // nulls
+      for (size_t i = 0; i < row.childrenCount(); ++i) {
+        emitPlaceholderStreamOffsets(
+            row.childAt(i).get(), projectedStreamOffsets);
+      }
+      return;
+    }
+    case Kind::Array: {
+      const auto& array = valueType->asArray();
+      projectedStreamOffsets.push_back(UINT32_MAX); // lengths
+      emitPlaceholderStreamOffsets(
+          array.elements().get(), projectedStreamOffsets);
+      return;
+    }
+    case Kind::ArrayWithOffsets: {
+      const auto& array = valueType->asArrayWithOffsets();
+      projectedStreamOffsets.push_back(UINT32_MAX); // offsets
+      projectedStreamOffsets.push_back(UINT32_MAX); // lengths
+      emitPlaceholderStreamOffsets(
+          array.elements().get(), projectedStreamOffsets);
+      return;
+    }
+    case Kind::Map: {
+      const auto& map = valueType->asMap();
+      projectedStreamOffsets.push_back(UINT32_MAX); // lengths
+      emitPlaceholderStreamOffsets(map.keys().get(), projectedStreamOffsets);
+      emitPlaceholderStreamOffsets(map.values().get(), projectedStreamOffsets);
+      return;
+    }
+    case Kind::SlidingWindowMap: {
+      const auto& map = valueType->asSlidingWindowMap();
+      projectedStreamOffsets.push_back(UINT32_MAX); // offsets
+      projectedStreamOffsets.push_back(UINT32_MAX); // lengths
+      emitPlaceholderStreamOffsets(map.keys().get(), projectedStreamOffsets);
+      emitPlaceholderStreamOffsets(map.values().get(), projectedStreamOffsets);
+      return;
+    }
+    case Kind::FlatMap:
+      // Value subtrees of a FlatMap are not themselves FlatMaps per the
+      // encoding invariant.
+      NIMBLE_FAIL(
+          "Nested FlatMap inside synthetic value subtree is not supported");
+  }
+  NIMBLE_UNREACHABLE("Unknown type kind: {}", valueType->kind());
+}
 
-      std::vector<std::string> names;
-      std::vector<std::shared_ptr<const Type>> children;
+// Forward declaration: projectStreamOffsets and projectFlatmapStreamOffsets
+// recurse mutually (a FlatMap's value subtree may contain Rows that recurse
+// back through the general walker).
+void projectStreamOffsets(
+    const Type* type,
+    const SelectedChildrenMap& selectedChildren,
+    const MissingChildrenMap& missingChildren,
+    std::vector<uint32_t>& projectedStreamOffsets);
 
-      const auto it = selectedChildren.find(inputType);
+// Emits the FlatMap branch of `projectStreamOffsets`. Merges present keys
+// (from `selectedChildren[flatMap]`, by source index) and missing keys (from
+// `missingChildren[flatMap]`, by name) into a single alphabetically-sorted
+// list — matching the velox-source builder's iteration over its
+// `std::set<std::string>` of requested keys — and emits per-key stream
+// offsets: the source's value-subtree offsets + inMap offset for present
+// keys, or UINT32_MAX placeholders for missing keys.
+void projectFlatmapStreamOffsets(
+    const FlatMapType& flatMap,
+    const SelectedChildrenMap& selectedChildren,
+    const MissingChildrenMap& missingChildren,
+    std::vector<uint32_t>& projectedStreamOffsets) {
+  const auto* flatMapPtr = static_cast<const Type*>(&flatMap);
+  const auto selectedIt = selectedChildren.find(flatMapPtr);
+  const auto missingIt = missingChildren.find(flatMapPtr);
+  // FlatMap must have at least one requested key (real or missing).
+  // Projecting an entire FlatMap without subscripts is rejected — the
+  // velox-source builder cannot emit a FlatMap from a velox MAP<K,V>
+  // without the explicit key list.
+  NIMBLE_CHECK(
+      selectedIt != selectedChildren.end() ||
+          missingIt != missingChildren.end(),
+      "Cannot project entire FlatMap column without key subscripts. "
+      "Use key-level projection (e.g., map[\"key\"]).");
+
+  struct Entry {
+    std::string keyName;
+    // nullopt → missing; the value subtree and inMap are emitted as
+    // UINT32_MAX placeholders.
+    std::optional<size_t> valueIndex;
+  };
+  std::vector<Entry> entries;
+  if (selectedIt != selectedChildren.end()) {
+    entries.reserve(selectedIt->second.size());
+    for (size_t idx : selectedIt->second) {
+      entries.push_back({std::string(flatMap.nameAt(idx)), idx});
+    }
+  }
+  if (missingIt != missingChildren.end()) {
+    entries.reserve(entries.size() + missingIt->second.size());
+    for (const auto& keyName : missingIt->second) {
+      entries.push_back({keyName, std::nullopt});
+    }
+  }
+  std::sort(
+      entries.begin(), entries.end(), [](const Entry& lhs, const Entry& rhs) {
+        return lhs.keyName < rhs.keyName;
+      });
+
+  projectedStreamOffsets.push_back(flatMap.nullsDescriptor().offset());
+  const auto* valueType = flatMap.childAt(0).get();
+  for (const auto& entry : entries) {
+    if (entry.valueIndex.has_value()) {
+      projectStreamOffsets(
+          flatMap.childAt(*entry.valueIndex).get(),
+          selectedChildren,
+          missingChildren,
+          projectedStreamOffsets);
+      projectedStreamOffsets.push_back(
+          flatMap.inMapDescriptorAt(*entry.valueIndex).offset());
+    } else {
+      emitPlaceholderStreamOffsets(valueType, projectedStreamOffsets);
+      projectedStreamOffsets.push_back(UINT32_MAX);
+    }
+  }
+}
+
+// Walks `type` (a node within the source nimble schema) in DFS pre-order
+// and appends one source stream offset per stream descriptor into
+// `projectedStreamOffsets`. At Row nodes appearing in `selectedChildren`,
+// only the selected child indices are descended into (in source order). At
+// FlatMap nodes, defers to `projectFlatmapStreamOffsets` which merges
+// present and missing keys alphabetically. The traversal order matches the
+// velox-source overload of `buildProjectedNimbleType` so the emitted offsets
+// line up positionally with the projected schema it returns.
+void projectStreamOffsets(
+    const Type* type,
+    const SelectedChildrenMap& selectedChildren,
+    const MissingChildrenMap& missingChildren,
+    std::vector<uint32_t>& projectedStreamOffsets) {
+  switch (type->kind()) {
+    case Kind::Scalar:
+      projectedStreamOffsets.push_back(
+          type->asScalar().scalarDescriptor().offset());
+      return;
+    case Kind::TimestampMicroNano: {
+      const auto& ts = type->asTimestampMicroNano();
+      projectedStreamOffsets.push_back(ts.microsDescriptor().offset());
+      projectedStreamOffsets.push_back(ts.nanosDescriptor().offset());
+      return;
+    }
+    case Kind::Row: {
+      const auto& row = type->asRow();
+      projectedStreamOffsets.push_back(row.nullsDescriptor().offset());
+      const auto it = selectedChildren.find(type);
       if (it != selectedChildren.end()) {
-        names.reserve(it->second.size());
-        children.reserve(it->second.size());
-        for (size_t columnIdx : it->second) {
-          names.emplace_back(row.nameAt(columnIdx));
-          children.emplace_back(buildProjectedType(
-              row.childAt(columnIdx).get(),
+        // std::set<size_t> iterates ascending — matches source child order.
+        for (size_t idx : it->second) {
+          projectStreamOffsets(
+              row.childAt(idx).get(),
               selectedChildren,
-              nextOffset,
-              inputStreamOffsets));
+              missingChildren,
+              projectedStreamOffsets);
         }
       } else {
-        names.reserve(row.childrenCount());
-        children.reserve(row.childrenCount());
         for (size_t i = 0; i < row.childrenCount(); ++i) {
-          names.emplace_back(row.nameAt(i));
-          children.emplace_back(buildProjectedType(
+          projectStreamOffsets(
               row.childAt(i).get(),
               selectedChildren,
-              nextOffset,
-              inputStreamOffsets));
+              missingChildren,
+              projectedStreamOffsets);
         }
       }
-
-      return std::make_shared<RowType>(
-          std::move(nullsDesc), std::move(names), std::move(children));
+      return;
     }
-
     case Kind::Array: {
-      const auto& array = inputType->asArray();
-      auto lengthsDesc = allocateStreamOffset(
-          array.lengthsDescriptor(), nextOffset, inputStreamOffsets);
-      auto elements = buildProjectedType(
+      const auto& array = type->asArray();
+      projectedStreamOffsets.push_back(array.lengthsDescriptor().offset());
+      projectStreamOffsets(
           array.elements().get(),
           selectedChildren,
-          nextOffset,
-          inputStreamOffsets);
-      return std::make_shared<ArrayType>(
-          std::move(lengthsDesc), std::move(elements));
+          missingChildren,
+          projectedStreamOffsets);
+      return;
     }
-
     case Kind::ArrayWithOffsets: {
-      const auto& array = inputType->asArrayWithOffsets();
-      auto offsetsDesc = allocateStreamOffset(
-          array.offsetsDescriptor(), nextOffset, inputStreamOffsets);
-      auto lengthsDesc = allocateStreamOffset(
-          array.lengthsDescriptor(), nextOffset, inputStreamOffsets);
-      auto elements = buildProjectedType(
+      const auto& array = type->asArrayWithOffsets();
+      projectedStreamOffsets.push_back(array.offsetsDescriptor().offset());
+      projectedStreamOffsets.push_back(array.lengthsDescriptor().offset());
+      projectStreamOffsets(
           array.elements().get(),
           selectedChildren,
-          nextOffset,
-          inputStreamOffsets);
-      return std::make_shared<ArrayWithOffsetsType>(
-          std::move(offsetsDesc), std::move(lengthsDesc), std::move(elements));
+          missingChildren,
+          projectedStreamOffsets);
+      return;
     }
-
     case Kind::Map: {
-      const auto& map = inputType->asMap();
-      auto lengthsDesc = allocateStreamOffset(
-          map.lengthsDescriptor(), nextOffset, inputStreamOffsets);
-      auto keys = buildProjectedType(
-          map.keys().get(), selectedChildren, nextOffset, inputStreamOffsets);
-      auto values = buildProjectedType(
-          map.values().get(), selectedChildren, nextOffset, inputStreamOffsets);
-      return std::make_shared<MapType>(
-          std::move(lengthsDesc), std::move(keys), std::move(values));
+      const auto& map = type->asMap();
+      projectedStreamOffsets.push_back(map.lengthsDescriptor().offset());
+      projectStreamOffsets(
+          map.keys().get(),
+          selectedChildren,
+          missingChildren,
+          projectedStreamOffsets);
+      projectStreamOffsets(
+          map.values().get(),
+          selectedChildren,
+          missingChildren,
+          projectedStreamOffsets);
+      return;
     }
-
     case Kind::SlidingWindowMap: {
-      const auto& map = inputType->asSlidingWindowMap();
-      auto offsetsDesc = allocateStreamOffset(
-          map.offsetsDescriptor(), nextOffset, inputStreamOffsets);
-      auto lengthsDesc = allocateStreamOffset(
-          map.lengthsDescriptor(), nextOffset, inputStreamOffsets);
-      auto keys = buildProjectedType(
-          map.keys().get(), selectedChildren, nextOffset, inputStreamOffsets);
-      auto values = buildProjectedType(
-          map.values().get(), selectedChildren, nextOffset, inputStreamOffsets);
-      return std::make_shared<SlidingWindowMapType>(
-          std::move(offsetsDesc),
-          std::move(lengthsDesc),
-          std::move(keys),
-          std::move(values));
+      const auto& map = type->asSlidingWindowMap();
+      projectedStreamOffsets.push_back(map.offsetsDescriptor().offset());
+      projectedStreamOffsets.push_back(map.lengthsDescriptor().offset());
+      projectStreamOffsets(
+          map.keys().get(),
+          selectedChildren,
+          missingChildren,
+          projectedStreamOffsets);
+      projectStreamOffsets(
+          map.values().get(),
+          selectedChildren,
+          missingChildren,
+          projectedStreamOffsets);
+      return;
     }
-
-    case Kind::FlatMap: {
-      const auto& flatMap = inputType->asFlatMap();
-
-      // FlatMap must have selected children (key subscripts). Projecting
-      // an entire FlatMap without specifying keys is not supported because
-      // the Projector requires explicit key selection for FlatMap columns.
-      const auto it = selectedChildren.find(inputType);
-      NIMBLE_CHECK(
-          it != selectedChildren.end(),
-          "Cannot project entire FlatMap column without key subscripts. "
-          "Use key-level projection (e.g., map[\"key\"]).");
-
-      auto nullsDesc = allocateStreamOffset(
-          flatMap.nullsDescriptor(), nextOffset, inputStreamOffsets);
-
-      std::vector<std::string> names;
-      std::vector<std::unique_ptr<StreamDescriptor>> inMapDescriptors;
-      std::vector<std::shared_ptr<const Type>> children;
-
-      // Build sorted child indices — always sort by name for canonical
-      // ordering that matches buildProjectedNimbleType.
-      std::vector<size_t> indices;
-      indices.assign(it->second.begin(), it->second.end());
-      indices = sortedFlatMapChildIndices(flatMap, std::move(indices));
-
-      names.reserve(indices.size());
-      inMapDescriptors.reserve(indices.size());
-      children.reserve(indices.size());
-      for (size_t columnIdx : indices) {
-        names.emplace_back(flatMap.nameAt(columnIdx));
-        children.emplace_back(buildProjectedType(
-            flatMap.childAt(columnIdx).get(),
-            selectedChildren,
-            nextOffset,
-            inputStreamOffsets));
-        inMapDescriptors.emplace_back(
-            std::make_unique<StreamDescriptor>(allocateStreamOffset(
-                flatMap.inMapDescriptorAt(columnIdx),
-                nextOffset,
-                inputStreamOffsets)));
-      }
-
-      return std::make_shared<FlatMapType>(
-          std::move(nullsDesc),
-          flatMap.keyScalarKind(),
-          std::move(names),
-          std::move(inMapDescriptors),
-          std::move(children));
-    }
-
-    default:
-      NIMBLE_FAIL("Unsupported type kind for projected schema: {}", kind);
+    case Kind::FlatMap:
+      projectFlatmapStreamOffsets(
+          type->asFlatMap(),
+          selectedChildren,
+          missingChildren,
+          projectedStreamOffsets);
+      return;
   }
+  NIMBLE_UNREACHABLE("Unknown type kind: {}", type->kind());
+}
+
+// Classifies each top-level column of the source nimble Row by `Kind` to
+// build the encoding hints the velox-source `buildProjectedNimbleType`
+// overload requires: FlatMap → flatMapColumns, ArrayWithOffsets →
+// dictionaryArrayColumns, SlidingWindowMap → deduplicatedMapColumns. Other
+// kinds produce no entry (plain encoding). Internal helper of
+// `buildProjectedNimbleType` (nimble-source overload).
+ColumnEncodings getColumnEncodings(const RowType& nimbleType) {
+  ColumnEncodings encodings;
+  for (size_t i = 0; i < nimbleType.childrenCount(); ++i) {
+    const auto& name = nimbleType.nameAt(i);
+    switch (nimbleType.childAt(i)->kind()) {
+      case Kind::FlatMap:
+        encodings.flatMapColumns.insert(std::string(name));
+        break;
+      case Kind::ArrayWithOffsets:
+        encodings.dictionaryArrayColumns.insert(std::string(name));
+        break;
+      case Kind::SlidingWindowMap:
+        encodings.deduplicatedMapColumns.insert(std::string(name));
+        break;
+      default:
+        // Plain encoding; no entry needed.
+        break;
+    }
+  }
+  return encodings;
 }
 
 } // namespace
@@ -823,39 +902,55 @@ std::shared_ptr<const Type> buildProjectedNimbleType(
       projectedStreamOffsets.empty(),
       "projectedStreamOffsets must be empty, got size: {}",
       projectedStreamOffsets.size());
+  NIMBLE_CHECK_NOT_NULL(type, "type must not be null");
   NIMBLE_CHECK(type->isRow(), "Root type must be a Row, got: {}", type->kind());
 
-  NimbleSelectedChildrenMap selectedChildren;
+  // Resolve subfields against the source schema once. Real selections (Row
+  // children + present FlatMap keys) land in `selectedChildren` keyed by
+  // source index; FlatMap keys absent from the source go into
+  // `missingChildren` keyed by name. The offset walker merges the two per
+  // FlatMap node before emitting.
+  SelectedChildrenMap selectedChildren;
+  MissingChildrenMap missingChildren;
   for (const auto& subfield : projectedSubfields) {
-    resolveSubfield(type, subfield, selectedChildren);
+    resolveSubfield(type, subfield, selectedChildren, missingChildren);
   }
+
+  // An all-missing-keys projection is allowed: the projected FlatMap contains
+  // a placeholder child per requested key, and the byte-copy pipeline emits
+  // 0-byte slots that the deserializer's gap-fill turns into null columns.
+  // Callers that need to surface "typo on every key" as an error must do
+  // their own presence check against the source schema before projecting.
 
   const auto& rootRow = type->asRow();
-  uint32_t nextOffset = 0;
-  auto nullsDesc = allocateStreamOffset(
-      rootRow.nullsDescriptor(), nextOffset, projectedStreamOffsets);
-
-  const auto& selectedTopLevelColumns = selectedChildren[type];
+  const auto& selectedColumnIndices = selectedChildren[type];
   NIMBLE_CHECK(
-      !selectedTopLevelColumns.empty(),
+      !selectedColumnIndices.empty(),
       "No top-level columns resolved from projectedSubfields");
 
-  std::vector<std::string> names;
-  std::vector<std::shared_ptr<const Type>> children;
-  names.reserve(selectedTopLevelColumns.size());
-  children.reserve(selectedTopLevelColumns.size());
-  for (size_t columnIdx : selectedTopLevelColumns) {
-    names.emplace_back(rootRow.nameAt(columnIdx));
-    children.emplace_back(buildProjectedType(
+  // Build the projected schema from the velox view of the source. The velox
+  // MAP<K,V> view discards FlatMap key inventory, so the velox-source
+  // builder produces one alphabetically-sorted child per requested subscript
+  // key regardless of source presence — exactly the shape we need for the
+  // source-offset walker below to align positionally.
+  auto veloxSource = convertToVeloxType(*type);
+  const auto encodings = getColumnEncodings(rootRow);
+  auto projectedSchema = buildProjectedNimbleType(
+      veloxSource->asRow(), projectedSubfields, encodings);
+
+  // Walk the source nimble in the same DFS pre-order + FlatMap-alphabetical
+  // traversal the velox-source builder uses, emitting one source stream
+  // offset per projected stream position (UINT32_MAX for missing keys).
+  projectedStreamOffsets.push_back(rootRow.nullsDescriptor().offset());
+  for (size_t columnIdx : selectedColumnIndices) {
+    projectStreamOffsets(
         rootRow.childAt(columnIdx).get(),
         selectedChildren,
-        nextOffset,
-        projectedStreamOffsets,
-        /*isTopLevelChild=*/true));
+        missingChildren,
+        projectedStreamOffsets);
   }
 
-  return std::make_shared<RowType>(
-      std::move(nullsDesc), std::move(names), std::move(children));
+  return projectedSchema;
 }
 
 } // namespace facebook::nimble

--- a/dwio/nimble/velox/SchemaUtils.h
+++ b/dwio/nimble/velox/SchemaUtils.h
@@ -31,12 +31,6 @@ std::shared_ptr<const Type> convertToNimbleType(const velox::Type& type);
 /// Records which columns use encoding-specific types (ArrayWithOffsets,
 /// SlidingWindowMap, FlatMap), enabling the Serializer to produce output
 /// consistent with the file's encoding.
-///
-/// FlatMap columns projected with key subscripts (e.g., "map[\"key\"]") are
-/// handled automatically. However, projecting an entire FlatMap column without
-/// any key subscripts is not supported because the velox type does not carry
-/// FlatMap key names/order — use the nimble-schema-based
-/// buildProjectedNimbleType overload for full FlatMap column projection.
 struct ColumnEncodings {
   folly::F14FastSet<std::string> dictionaryArrayColumns;
   folly::F14FastSet<std::string> deduplicatedMapColumns;
@@ -58,24 +52,32 @@ std::shared_ptr<const Type> buildProjectedNimbleType(
     const std::vector<velox::common::Subfield>& projectedSubfields,
     const ColumnEncodings& columnEncodings = {});
 
-/// Builds a projected nimble schema from an existing nimble schema, assigning
-/// output stream offsets sequentially in DFS traversal order. This ensures
-/// the offset assignment matches how SchemaBuilder assigns offsets in
-/// buildProjectedNimbleType, enabling clients to recover the schema.
+/// Builds a projected nimble schema from a source nimble schema and emits
+/// the source stream-offset mapping in one pass. Used by
+/// `nimble::serde::Projector` and `nimble::NimbleIndexProjector` to derive
+/// everything the byte-copy pipeline needs from `(type, projectedSubfields)`.
 ///
-/// Unlike buildProjectedNimbleType (which builds from velox types and loses
-/// encoding-specific info like ArrayWithOffsets/SlidingWindowMap), this
-/// function preserves the exact nimble type structure from the input schema.
+/// Internally: converts the source nimble schema to velox (FlatMaps collapse
+/// to `MAP<K,V>`), derives encoding hints from the source's top-level Kinds,
+/// builds the projected schema via the velox-source `buildProjectedNimbleType`
+/// overload, and walks the source nimble in the matching DFS pre-order +
+/// FlatMap-children-alphabetical traversal to emit one source stream offset
+/// per projected stream position.
 ///
-/// FlatMap children are sorted alphabetically by name for canonical ordering.
+/// Missing FlatMap keys are allowed: each subscript whose key does not exist
+/// in the source FlatMap produces a synthetic child in the returned schema
+/// (the value subtree is cloned from `flatMap.childAt(0)`'s type as a
+/// structural template) and emits `UINT32_MAX` placeholder entries in
+/// `projectedStreamOffsets` (>= any real source offset). The projector's
+/// stream-copy guard turns those into 0-byte placeholder slots in the
+/// projected blob, which the deserializer's gap-fill renders as null
+/// columns. An all-missing-keys projection is permitted and yields a
+/// FlatMap whose every child is a placeholder.
 ///
-/// @param type The input nimble schema tree.
-/// @param projectedSubfields Subfields to project. Each subfield path is
-///        resolved against the schema to determine which children to include
-///        at each Row/FlatMap node.
-/// @param projectedStreamOffsets Output: input stream offsets in DFS traversal
-///        order, defining which streams to include and in what order. Must be
-///        empty on entry.
+/// @param type                    The source nimble schema; root must be Row.
+/// @param projectedSubfields      Subfields to project; must not be empty.
+/// @param projectedStreamOffsets  Output: appended in projected-stream-
+///                                position order. Must be empty on entry.
 std::shared_ptr<const Type> buildProjectedNimbleType(
     const Type* type,
     const std::vector<velox::common::Subfield>& projectedSubfields,

--- a/dwio/nimble/velox/index/tests/NimbleIndexProjectorTest.cpp
+++ b/dwio/nimble/velox/index/tests/NimbleIndexProjectorTest.cpp
@@ -1401,7 +1401,9 @@ TEST_P(NimbleIndexProjectorTest, flatMapIntKeyProjection) {
 }
 
 TEST_P(NimbleIndexProjectorTest, flatMapMissingKeys) {
-  // Verify that missing FlatMap keys are silently skipped.
+  // Verify that missing FlatMap keys are emitted as synthetic placeholder
+  // children in the projected schema so cross-schema-version reads decode
+  // missing keys as null columns instead of silently shifting offsets.
   auto rowType = ROW({"key", "features"}, {BIGINT(), MAP(VARCHAR(), BIGINT())});
 
   const int numRows = 200;
@@ -1439,31 +1441,90 @@ TEST_P(NimbleIndexProjectorTest, flatMapMissingKeys) {
     subfields.emplace_back("features[\"z\"]");
     auto projector = createProjector(subfields);
 
-    // Projected schema should only contain existing keys, sorted: "a", "c".
+    // Projected schema contains all requested keys in alphabetical order
+    // ("a", "c", "x", "z"). Real keys ("a", "c") carry source data while
+    // synthetic keys ("x", "z") hold placeholder slots that decode to nulls.
     const auto& schema = projector->projectedNimbleType();
     ASSERT_TRUE(schema->isRow());
     const auto& flatMap = schema->asRow().childAt(0)->asFlatMap();
-    ASSERT_EQ(flatMap.childrenCount(), 2);
+    ASSERT_EQ(flatMap.childrenCount(), 4);
     EXPECT_EQ(flatMap.nameAt(0), "a");
     EXPECT_EQ(flatMap.nameAt(1), "c");
+    EXPECT_EQ(flatMap.nameAt(2), "x");
+    EXPECT_EQ(flatMap.nameAt(3), "z");
 
-    // Verify data reads correctly.
+    // Decode the projected slice and verify per-row values. Source row r's
+    // map values are `r * 100 + mapIndex` for mapIndex in {0, 1, 2} mapping
+    // to keys {"a", "b", "c"} respectively. The decoded map for the target
+    // row must contain only the present projected keys ("a" → r*100+0,
+    // "c" → r*100+2) — "x" and "z" are missing in source and therefore not
+    // present in the decoded MapVector entries (gap-fill renders their inMap
+    // as all-false, producing no key entry).
     auto pointBounds = makePointLookup(rowType, {"key"}, 50);
     NimbleIndexProjector::Request request;
     request.keyBounds = {pointBounds};
     auto result = projector->project(request, {});
     ASSERT_EQ(result.responses.size(), 1);
     ASSERT_FALSE(result.responses[0].slices.empty());
+
+    const auto& slice = result.responses[0].slices[0];
+    const auto rowRange = readEmbeddedRowRange(slice);
+    ASSERT_GT(rowRange.numRows(), 0);
+
+    auto coalesced = coalesceChunkSlice(slice);
+    DeserializerOptions deserOptions;
+    deserOptions.hasHeader = true;
+    Deserializer deserializer(
+        projector->projectedNimbleType(), leafPool_.get(), deserOptions);
+    VectorPtr deserialized;
+    deserializer.deserialize(
+        std::string_view(
+            reinterpret_cast<const char*>(coalesced.data()),
+            coalesced.length()),
+        deserialized);
+    ASSERT_NE(deserialized, nullptr);
+
+    auto* mapResult =
+        deserialized->as<RowVector>()->childAt(0)->as<MapVector>();
+    ASSERT_NE(mapResult, nullptr);
+    ASSERT_GE(mapResult->size(), rowRange.endRow);
+
+    const vector_size_t targetRow = rowRange.startRow;
+    auto* keysVec = mapResult->mapKeys()->as<FlatVector<StringView>>();
+    auto* valsVec = mapResult->mapValues()->as<FlatVector<int64_t>>();
+    ASSERT_NE(keysVec, nullptr);
+    ASSERT_NE(valsVec, nullptr);
+
+    const auto mapOffset = mapResult->offsetAt(targetRow);
+    const auto mapSize = mapResult->sizeAt(targetRow);
+    std::map<std::string, int64_t> kvPairs;
+    for (vector_size_t i = 0; i < mapSize; ++i) {
+      kvPairs[keysVec->valueAt(mapOffset + i).str()] =
+          valsVec->valueAt(mapOffset + i);
+    }
+    // Only the present-key entries appear; "x" and "z" are absent (their
+    // placeholder slots produced all-false in-map → no map entry).
+    EXPECT_EQ(2, kvPairs.size());
+    EXPECT_EQ(500, kvPairs["a"]); // row 5 * 100 + mapIndex 0
+    EXPECT_EQ(502, kvPairs["c"]); // row 5 * 100 + mapIndex 2
+    EXPECT_EQ(0, kvPairs.count("x"));
+    EXPECT_EQ(0, kvPairs.count("z"));
   }
 
-  // All requested keys missing — should fail.
+  // All requested keys missing — projection still succeeds. The FlatMap
+  // contains alphabetically-sorted placeholder children for every requested
+  // key, all decoded as null columns by the deserializer's gap-fill.
   {
     std::vector<Subfield> subfields;
     subfields.emplace_back("features[\"x\"]");
     subfields.emplace_back("features[\"y\"]");
-    NIMBLE_ASSERT_THROW(
-        createProjector(subfields),
-        "Cannot project entire FlatMap column without key subscripts");
+    auto projector = createProjector(subfields);
+    const auto& schema = projector->projectedNimbleType();
+    ASSERT_TRUE(schema->isRow());
+    const auto& flatMap = schema->asRow().childAt(0)->asFlatMap();
+    ASSERT_EQ(flatMap.childrenCount(), 2);
+    EXPECT_EQ(flatMap.nameAt(0), "x");
+    EXPECT_EQ(flatMap.nameAt(1), "y");
   }
 }
 

--- a/dwio/nimble/velox/tests/SchemaUtilsTest.cpp
+++ b/dwio/nimble/velox/tests/SchemaUtilsTest.cpp
@@ -409,13 +409,6 @@ TEST(SchemaUtilsTest, projectionScalarOnly) {
   EXPECT_EQ(
       ScalarKind::String,
       row.childAt(2)->asScalar().scalarDescriptor().scalarKind());
-
-  // Cross-validate with nimble-type overload.
-  auto convertedNimbleType = convertToNimbleType(*veloxType);
-  std::vector<uint32_t> projectedStreamOffsets;
-  auto projectedNimbleType = buildProjectedNimbleType(
-      convertedNimbleType.get(), subfields, projectedStreamOffsets);
-  expectSameType(*projectedNimbleTypeFromVelox, *projectedNimbleType, "root");
 }
 
 TEST(SchemaUtilsTest, projectionFlatMap) {
@@ -485,31 +478,6 @@ TEST(SchemaUtilsTest, projectionFlatMap) {
           ->asScalar()
           .scalarDescriptor()
           .scalarKind());
-
-  // Cross-validate with nimble-type overload.
-  // Build equivalent nimble input schema with FlatMap encoding.
-  SchemaBuilder schemaBuilder;
-  test::FlatMapChildAdder intAdder;
-  test::FlatMapChildAdder longAdder;
-  NIMBLE_SCHEMA(
-      schemaBuilder,
-      NIMBLE_ROW({
-          {"user_id", NIMBLE_BIGINT()},
-          {"int_traits_map",
-           NIMBLE_FLATMAP(Int32, NIMBLE_ARRAY(NIMBLE_INTEGER()), intAdder)},
-          {"long_traits_map",
-           NIMBLE_FLATMAP(Int32, NIMBLE_ARRAY(NIMBLE_BIGINT()), longAdder)},
-      }));
-  intAdder.addChild("2");
-  intAdder.addChild("387");
-  longAdder.addChild("10");
-  auto convertedNimbleType =
-      SchemaReader::getSchema(schemaBuilder.schemaNodes());
-
-  std::vector<uint32_t> projectedStreamOffsets;
-  auto projectedNimbleType = buildProjectedNimbleType(
-      convertedNimbleType.get(), subfields, projectedStreamOffsets);
-  expectSameType(*projectedNimbleTypeFromVelox, *projectedNimbleType, "root");
 }
 
 TEST(SchemaUtilsTest, projectionDictionaryArray) {
@@ -555,24 +523,6 @@ TEST(SchemaUtilsTest, projectionDictionaryArray) {
   EXPECT_EQ(
       ScalarKind::Int32,
       scoresArray.elements()->asScalar().scalarDescriptor().scalarKind());
-
-  // Cross-validate with nimble-type overload.
-  // Build equivalent nimble schema with ArrayWithOffsets.
-  SchemaBuilder schemaBuilder;
-  NIMBLE_SCHEMA(
-      schemaBuilder,
-      NIMBLE_ROW({
-          {"id", NIMBLE_BIGINT()},
-          {"tags", NIMBLE_OFFSETARRAY(NIMBLE_STRING())},
-          {"scores", NIMBLE_ARRAY(NIMBLE_INTEGER())},
-      }));
-  auto convertedNimbleType =
-      SchemaReader::getSchema(schemaBuilder.schemaNodes());
-
-  std::vector<uint32_t> projectedStreamOffsets;
-  auto projectedNimbleType = buildProjectedNimbleType(
-      convertedNimbleType.get(), subfields, projectedStreamOffsets);
-  expectSameType(*projectedNimbleTypeFromVelox, *projectedNimbleType, "root");
 }
 
 TEST(SchemaUtilsTest, projectionDeduplicatedMap) {
@@ -624,25 +574,6 @@ TEST(SchemaUtilsTest, projectionDeduplicatedMap) {
   EXPECT_EQ(
       ScalarKind::Int64,
       regularMap.values()->asScalar().scalarDescriptor().scalarKind());
-
-  // Cross-validate with nimble-type overload.
-  // Build equivalent nimble schema with SlidingWindowMap.
-  SchemaBuilder schemaBuilder;
-  NIMBLE_SCHEMA(
-      schemaBuilder,
-      NIMBLE_ROW({
-          {"id", NIMBLE_BIGINT()},
-          {"dedup_map",
-           NIMBLE_SLIDINGWINDOWMAP(NIMBLE_STRING(), NIMBLE_INTEGER())},
-          {"regular_map", NIMBLE_MAP(NIMBLE_STRING(), NIMBLE_BIGINT())},
-      }));
-  auto convertedNimbleType =
-      SchemaReader::getSchema(schemaBuilder.schemaNodes());
-
-  std::vector<uint32_t> projectedStreamOffsets;
-  auto projectedNimbleType = buildProjectedNimbleType(
-      convertedNimbleType.get(), subfields, projectedStreamOffsets);
-  expectSameType(*projectedNimbleTypeFromVelox, *projectedNimbleType, "root");
 }
 
 TEST(SchemaUtilsTest, projectionMixedEncodings) {
@@ -692,28 +623,6 @@ TEST(SchemaUtilsTest, projectionMixedEncodings) {
   ASSERT_EQ(2, flatMap.childrenCount());
   EXPECT_EQ("1", flatMap.nameAt(0));
   EXPECT_EQ("5", flatMap.nameAt(1));
-
-  // Cross-validate with nimble-type overload.
-  SchemaBuilder schemaBuilder;
-  test::FlatMapChildAdder flatAdder;
-  NIMBLE_SCHEMA(
-      schemaBuilder,
-      NIMBLE_ROW({
-          {"id", NIMBLE_BIGINT()},
-          {"dict_arr", NIMBLE_OFFSETARRAY(NIMBLE_STRING())},
-          {"dedup_map",
-           NIMBLE_SLIDINGWINDOWMAP(NIMBLE_STRING(), NIMBLE_INTEGER())},
-          {"flat_map", NIMBLE_FLATMAP(Int32, NIMBLE_DOUBLE(), flatAdder)},
-      }));
-  flatAdder.addChild("1");
-  flatAdder.addChild("5");
-  auto convertedNimbleType =
-      SchemaReader::getSchema(schemaBuilder.schemaNodes());
-
-  std::vector<uint32_t> projectedStreamOffsets;
-  auto projectedNimbleType = buildProjectedNimbleType(
-      convertedNimbleType.get(), subfields, projectedStreamOffsets);
-  expectSameType(*projectedNimbleTypeFromVelox, *projectedNimbleType, "root");
 }
 
 TEST(SchemaUtilsTest, fullFlatMapProjectionFails) {
@@ -733,151 +642,6 @@ TEST(SchemaUtilsTest, fullFlatMapProjectionFails) {
   NIMBLE_ASSERT_THROW(
       buildProjectedNimbleType(*veloxType, subfields, encodings),
       "Cannot project entire FlatMap column without key subscripts");
-
-  // Cross-validate with nimble-type overload.
-  SchemaBuilder schemaBuilder;
-  test::FlatMapChildAdder childAdder;
-  NIMBLE_SCHEMA(
-      schemaBuilder,
-      NIMBLE_ROW({
-          {"user_id", NIMBLE_BIGINT()},
-          {"traits_map",
-           NIMBLE_FLATMAP(Int32, NIMBLE_ARRAY(NIMBLE_INTEGER()), childAdder)},
-      }));
-  childAdder.addChild("1");
-  childAdder.addChild("2");
-  auto convertedNimbleType =
-      SchemaReader::getSchema(schemaBuilder.schemaNodes());
-
-  std::vector<uint32_t> offsets;
-  NIMBLE_ASSERT_THROW(
-      buildProjectedNimbleType(convertedNimbleType.get(), subfields, offsets),
-      "Cannot project entire FlatMap column without key subscripts");
-}
-
-TEST(SchemaUtilsTest, flatMapKeyProjectionRequiresFlatMapEncoding) {
-  auto veloxType = velox::ROW(
-      {"user_id", "traits_map"},
-      {velox::BIGINT(),
-       velox::MAP(velox::INTEGER(), velox::ARRAY(velox::INTEGER()))});
-
-  // Key-level projection on a MAP column not in flatMapColumns should fail.
-  std::vector<Subfield> subfields;
-  subfields.emplace_back("user_id");
-  subfields.emplace_back("traits_map[1]");
-
-  // No flatMapColumns specified — traits_map is a regular MAP.
-  ColumnEncodings encodings;
-  NIMBLE_ASSERT_THROW(
-      buildProjectedNimbleType(*veloxType, subfields, encodings),
-      "FlatMap key-level projection requires the column to be in flatMapColumns");
-}
-
-TEST(SchemaUtilsTest, projectionStreamOffsets) {
-  // Verify stream offsets are sequential.
-  auto veloxType = velox::ROW(
-      {"key", "traits_map"},
-      {velox::BIGINT(),
-       velox::MAP(velox::INTEGER(), velox::ARRAY(velox::INTEGER()))});
-
-  std::vector<Subfield> subfields;
-  subfields.emplace_back("key");
-  subfields.emplace_back("traits_map[1]");
-  subfields.emplace_back("traits_map[2]");
-
-  ColumnEncodings encodings;
-  encodings.flatMapColumns.insert("traits_map");
-
-  auto projectedNimbleTypeFromVelox =
-      buildProjectedNimbleType(*veloxType, subfields, encodings);
-  // Collect all stream offsets and verify they are sequential.
-  std::set<uint32_t> offsets;
-  std::function<void(const Type&)> collectOffsets = [&](const Type& type) {
-    switch (type.kind()) {
-      case Kind::Scalar:
-        offsets.insert(type.asScalar().scalarDescriptor().offset());
-        break;
-      case Kind::Row: {
-        const auto& r = type.asRow();
-        offsets.insert(r.nullsDescriptor().offset());
-        for (size_t i = 0; i < r.childrenCount(); ++i) {
-          collectOffsets(*r.childAt(i));
-        }
-        break;
-      }
-      case Kind::Array: {
-        const auto& a = type.asArray();
-        offsets.insert(a.lengthsDescriptor().offset());
-        collectOffsets(*a.elements());
-        break;
-      }
-      case Kind::FlatMap: {
-        const auto& fm = type.asFlatMap();
-        offsets.insert(fm.nullsDescriptor().offset());
-        for (size_t i = 0; i < fm.childrenCount(); ++i) {
-          offsets.insert(fm.inMapDescriptorAt(i).offset());
-          collectOffsets(*fm.childAt(i));
-        }
-        break;
-      }
-      default:
-        break;
-    }
-  };
-  collectOffsets(*projectedNimbleTypeFromVelox);
-
-  // Offsets should be 0, 1, 2, ... (no gaps, no duplicates).
-  uint32_t expected = 0;
-  for (auto offset : offsets) {
-    EXPECT_EQ(expected, offset);
-    ++expected;
-  }
-}
-
-TEST(SchemaUtilsTest, projectionRowChild) {
-  auto veloxType = velox::ROW(
-      {"id", "struct_col"},
-      {velox::BIGINT(),
-       velox::ROW(
-           {"field_a", "field_b", "field_c"},
-           {velox::INTEGER(), velox::VARCHAR(), velox::DOUBLE()})});
-
-  std::vector<Subfield> subfields;
-  subfields.emplace_back("id");
-  subfields.emplace_back("struct_col.field_a");
-  subfields.emplace_back("struct_col.field_c");
-
-  auto projectedNimbleTypeFromVelox =
-      buildProjectedNimbleType(*veloxType, subfields);
-  ASSERT_EQ(Kind::Row, projectedNimbleTypeFromVelox->kind());
-  const auto& row = projectedNimbleTypeFromVelox->asRow();
-  // Only projected columns in the root Row.
-  ASSERT_EQ(2, row.childrenCount());
-  EXPECT_EQ("id", row.nameAt(0));
-  EXPECT_EQ("struct_col", row.nameAt(1));
-
-  // id: scalar.
-  EXPECT_EQ(Kind::Scalar, row.childAt(0)->kind());
-
-  // struct_col: Row with only projected children.
-  ASSERT_EQ(Kind::Row, row.childAt(1)->kind());
-  const auto& structRow = row.childAt(1)->asRow();
-  ASSERT_EQ(2, structRow.childrenCount());
-  EXPECT_EQ("field_a", structRow.nameAt(0));
-  EXPECT_EQ("field_c", structRow.nameAt(1));
-  EXPECT_EQ(
-      ScalarKind::Int32,
-      structRow.childAt(0)->asScalar().scalarDescriptor().scalarKind());
-  EXPECT_EQ(
-      ScalarKind::Double,
-      structRow.childAt(1)->asScalar().scalarDescriptor().scalarKind());
-
-  // Cross-validate with nimble-type overload.
-  auto convertedNimbleType = convertToNimbleType(*veloxType);
-  std::vector<uint32_t> projectedStreamOffsets;
-  auto projectedNimbleType = buildProjectedNimbleType(
-      convertedNimbleType.get(), subfields, projectedStreamOffsets);
-  expectSameType(*projectedNimbleTypeFromVelox, *projectedNimbleType, "root");
 }
 
 TEST(SchemaUtilsTest, projectionOnlyProjectedColumns) {
@@ -897,13 +661,6 @@ TEST(SchemaUtilsTest, projectionOnlyProjectedColumns) {
   ASSERT_EQ(2, row.childrenCount());
   EXPECT_EQ("col_a", row.nameAt(0));
   EXPECT_EQ("col_c", row.nameAt(1));
-
-  // Cross-validate with nimble-type overload.
-  auto convertedNimbleType = convertToNimbleType(*veloxType);
-  std::vector<uint32_t> projectedStreamOffsets;
-  auto projectedNimbleType = buildProjectedNimbleType(
-      convertedNimbleType.get(), subfields, projectedStreamOffsets);
-  expectSameType(*projectedNimbleTypeFromVelox, *projectedNimbleType, "root");
 }
 
 TEST(SchemaUtilsTest, projectionDeep) {
@@ -944,33 +701,6 @@ TEST(SchemaUtilsTest, projectionDeep) {
   ASSERT_EQ(valueRow.childrenCount(), 1);
   EXPECT_EQ(valueRow.nameAt(0), "inner");
   EXPECT_EQ(valueRow.childAt(0)->kind(), Kind::Scalar);
-
-  // Cross-validate with nimble-type overload.
-  SchemaBuilder schemaBuilder;
-  test::FlatMapChildAdder childAdder;
-  NIMBLE_SCHEMA(
-      schemaBuilder,
-      NIMBLE_ROW({
-          {"map_col",
-           NIMBLE_FLATMAP(
-               String, NIMBLE_ROW({{"inner", NIMBLE_INTEGER()}}), childAdder)},
-      }));
-  childAdder.addChild("key");
-  auto convertedNimbleType =
-      SchemaReader::getSchema(schemaBuilder.schemaNodes());
-
-  // Rebuild subfields for nimble-type overload (path was moved above).
-  std::vector<std::unique_ptr<velox::common::Subfield::PathElement>> path2;
-  path2.push_back(std::make_unique<Subfield::NestedField>("map_col"));
-  path2.push_back(std::make_unique<Subfield::StringSubscript>("key"));
-  path2.push_back(std::make_unique<Subfield::NestedField>("inner"));
-  std::vector<Subfield> subfields2;
-  subfields2.emplace_back(std::move(path2));
-
-  std::vector<uint32_t> projectedStreamOffsets;
-  auto projectedNimbleType = buildProjectedNimbleType(
-      convertedNimbleType.get(), subfields2, projectedStreamOffsets);
-  expectSameType(*projectedNimbleTypeFromVelox, *projectedNimbleType, "root");
 }
 
 TEST(SchemaUtilsTest, projectionDeepWithStreamOffsets) {
@@ -1016,6 +746,8 @@ TEST(SchemaUtilsTest, projectionDeepWithStreamOffsets) {
   std::vector<Subfield> subfields;
   subfields.emplace_back(std::move(path));
 
+  // Drive the projection through the same nimble-source API the projectors
+  // use: derive (projected schema, source stream offsets) in one pass.
   std::vector<uint32_t> projectedStreamOffsets;
   auto projectedNimbleType = buildProjectedNimbleType(
       convertedNimbleType.get(), subfields, projectedStreamOffsets);
@@ -1038,9 +770,135 @@ TEST(SchemaUtilsTest, projectionDeepWithStreamOffsets) {
   EXPECT_EQ(valueRow.nameAt(0), "inner_b");
   EXPECT_EQ(valueRow.childAt(0)->kind(), Kind::Scalar);
 
-  // Verify projected stream offsets contain the expected input offsets.
-  // The exact offset assignment depends on SchemaBuilder's DFS traversal order.
+  // Verify projected stream offsets enumerate source positions in DFS +
+  // FlatMap-alphabetical order. Source offsets here reflect the order the
+  // SchemaBuilder allocates them (FlatMap nulls first because the
+  // FlatMapTypeBuilder is constructed before the outer Row, value subtrees
+  // for each key are built lazily inside addChild):
+  //   FlatMap.nulls = 0, outer Row.nulls = 1,
+  //   key1.inner_a = 2, key1.inner_b = 3, key1.Row.nulls = 4, key1.inMap = 5,
+  //   key2.inner_a = 6, key2.inner_b = 7, key2.Row.nulls = 8, key2.inMap = 9.
+  // The walker visits: outer-Row.nulls (1), map_col-FlatMap.nulls (0),
+  // key1.Row.nulls (4), key1.inner_b (3), key1.inMap (5).
   EXPECT_EQ(projectedStreamOffsets, std::vector<uint32_t>({1, 0, 4, 3, 5}));
+}
+
+TEST(SchemaUtilsTest, projectionEncodingHints_SlidingWindowMap) {
+  // Exercise `deriveColumnEncodings` + `emitOffsets` SlidingWindowMap branch
+  // at the buildProjectedNimbleType(const Type*) level. No Projector test
+  // serializes a
+  // SlidingWindowMap top-level column, so this is the only test that locks
+  // the encoding-hint-driven schema shape + per-descriptor offset order.
+  //
+  // Source schema (offsets assigned by SchemaBuilder in construction order):
+  //   id BIGINT = 0
+  //   dedup_map.key STRING = 1
+  //   dedup_map.value INTEGER = 2
+  //   dedup_map.offsetsDesc = 3, dedup_map.lengthsDesc = 4
+  //   outer Row.nulls = 5
+  SchemaBuilder schemaBuilder;
+  NIMBLE_SCHEMA(
+      schemaBuilder,
+      NIMBLE_ROW({
+          {"id", NIMBLE_BIGINT()},
+          {"dedup_map",
+           NIMBLE_SLIDINGWINDOWMAP(NIMBLE_STRING(), NIMBLE_INTEGER())},
+      }));
+  auto sourceNimbleType = SchemaReader::getSchema(schemaBuilder.schemaNodes());
+
+  std::vector<Subfield> subfields;
+  subfields.emplace_back("id");
+  subfields.emplace_back("dedup_map");
+
+  std::vector<uint32_t> projectedStreamOffsets;
+  auto projectedNimbleType = buildProjectedNimbleType(
+      sourceNimbleType.get(), subfields, projectedStreamOffsets);
+
+  // Verify the SlidingWindowMap encoding is preserved (this is the path
+  // through getColumnEncodings → deduplicatedMapColumns → velox-source
+  // builder's SlidingWindowMap branch).
+  ASSERT_EQ(projectedNimbleType->kind(), Kind::Row);
+  const auto& root = projectedNimbleType->asRow();
+  ASSERT_EQ(root.childrenCount(), 2);
+  EXPECT_EQ(root.nameAt(0), "id");
+  EXPECT_EQ(root.childAt(0)->kind(), Kind::Scalar);
+  EXPECT_EQ(root.nameAt(1), "dedup_map");
+  EXPECT_EQ(root.childAt(1)->kind(), Kind::SlidingWindowMap);
+
+  // Walker visits: outer-Row.nulls (5), id Scalar (0), dedup_map offsets (3),
+  // lengths (4), keys (1), values (2).
+  EXPECT_EQ(projectedStreamOffsets, std::vector<uint32_t>({5, 0, 3, 4, 1, 2}));
+}
+
+TEST(SchemaUtilsTest, projectionEncodingHints_Mixed) {
+  // Combine all three encoding-bearing top-level Kinds (ArrayWithOffsets,
+  // SlidingWindowMap, FlatMap) plus a plain Scalar, with one missing FlatMap
+  // key to exercise the UINT32_MAX placeholder path of `emitOffsets`
+  // (via `emitPlaceholderOffsets` on a Scalar value template).
+  //
+  // Source schema offsets (construction order; FlatMap value subtrees are
+  // built lazily inside addChild after the outer Row's ctor runs):
+  //   id BIGINT = 0
+  //   tags.element STRING = 1
+  //   tags.offsetsDesc = 2, tags.lengthsDesc = 3
+  //   dedup_map.key STRING = 4, dedup_map.value INTEGER = 5
+  //   dedup_map.offsetsDesc = 6, dedup_map.lengthsDesc = 7
+  //   features.nulls = 8 (FlatMap ctor)
+  //   outer Row.nulls = 9 (outer Row ctor)
+  //   features["a"].value INTEGER = 10, features["a"].inMap = 11
+  //   features["c"].value INTEGER = 12, features["c"].inMap = 13
+  SchemaBuilder schemaBuilder;
+  test::FlatMapChildAdder featuresAdder;
+  NIMBLE_SCHEMA(
+      schemaBuilder,
+      NIMBLE_ROW({
+          {"id", NIMBLE_BIGINT()},
+          {"tags", NIMBLE_OFFSETARRAY(NIMBLE_STRING())},
+          {"dedup_map",
+           NIMBLE_SLIDINGWINDOWMAP(NIMBLE_STRING(), NIMBLE_INTEGER())},
+          {"features", NIMBLE_FLATMAP(String, NIMBLE_INTEGER(), featuresAdder)},
+      }));
+  featuresAdder.addChild("a");
+  featuresAdder.addChild("c");
+  auto sourceNimbleType = SchemaReader::getSchema(schemaBuilder.schemaNodes());
+
+  std::vector<Subfield> subfields;
+  subfields.emplace_back("id");
+  subfields.emplace_back("tags");
+  subfields.emplace_back("dedup_map");
+  subfields.emplace_back("features[\"a\"]");
+  subfields.emplace_back("features[\"missing\"]");
+
+  std::vector<uint32_t> projectedStreamOffsets;
+  auto projectedNimbleType = buildProjectedNimbleType(
+      sourceNimbleType.get(), subfields, projectedStreamOffsets);
+
+  // All three encoding-specific Kinds survive the projection.
+  ASSERT_EQ(projectedNimbleType->kind(), Kind::Row);
+  const auto& root = projectedNimbleType->asRow();
+  ASSERT_EQ(root.childrenCount(), 4);
+  EXPECT_EQ(root.childAt(0)->kind(), Kind::Scalar);
+  EXPECT_EQ(root.childAt(1)->kind(), Kind::ArrayWithOffsets);
+  EXPECT_EQ(root.childAt(2)->kind(), Kind::SlidingWindowMap);
+  ASSERT_EQ(root.childAt(3)->kind(), Kind::FlatMap);
+
+  // FlatMap children are alphabetical: real "a" then synthetic "missing".
+  const auto& flatMap = root.childAt(3)->asFlatMap();
+  ASSERT_EQ(flatMap.childrenCount(), 2);
+  EXPECT_EQ(flatMap.nameAt(0), "a");
+  EXPECT_EQ(flatMap.nameAt(1), "missing");
+
+  // Walker visits, in order:
+  //   outer Row.nulls (9), id Scalar (0),
+  //   tags offsets (2), lengths (3), element (1),
+  //   dedup_map offsets (6), lengths (7), key (4), value (5),
+  //   features.nulls (8),
+  //     "a" value (10), "a" inMap (11),
+  //     "missing" value (UINT32_MAX), "missing" inMap (UINT32_MAX).
+  EXPECT_EQ(
+      projectedStreamOffsets,
+      std::vector<uint32_t>(
+          {9, 0, 2, 3, 1, 6, 7, 4, 5, 8, 10, 11, UINT32_MAX, UINT32_MAX}));
 }
 
 TEST(SchemaUtilsTest, projectionEmptySubfieldsFails) {
@@ -1049,447 +907,4 @@ TEST(SchemaUtilsTest, projectionEmptySubfieldsFails) {
   NIMBLE_ASSERT_THROW(
       buildProjectedNimbleType(type->asRow(), subfields, {}),
       "projectedSubfields must not be empty");
-
-  // Cross-validate with nimble-type overload.
-  auto convertedNimbleType = convertToNimbleType(*type);
-  std::vector<uint32_t> offsets;
-  NIMBLE_ASSERT_THROW(
-      buildProjectedNimbleType(convertedNimbleType.get(), subfields, offsets),
-      "projectedSubfields must not be empty");
-}
-
-namespace {
-
-// Encoding choice for a top-level column.
-enum class ColumnEncoding {
-  None,
-  DictionaryArray, // ARRAY → ArrayWithOffsets
-  DeduplicatedMap, // MAP → SlidingWindowMap
-  FlatMap, // MAP → FlatMap
-};
-
-// Describes a randomly generated top-level column.
-struct ColumnDesc {
-  std::string name;
-  velox::TypePtr veloxType;
-  ColumnEncoding encoding{ColumnEncoding::None};
-
-  std::string debugString() const {
-    return fmt::format(
-        "name={}, veloxType={}, encoding={}",
-        name,
-        veloxType->toString(),
-        static_cast<int>(encoding));
-  }
-};
-
-velox::TypePtr randomScalarType(folly::Random::DefaultGenerator& rng) {
-  static const std::vector<velox::TypePtr> scalars = {
-      velox::BOOLEAN(),
-      velox::TINYINT(),
-      velox::SMALLINT(),
-      velox::INTEGER(),
-      velox::BIGINT(),
-      velox::REAL(),
-      velox::DOUBLE(),
-      velox::VARCHAR(),
-      velox::VARBINARY(),
-      velox::TIMESTAMP(),
-  };
-  return scalars[folly::Random::rand32(scalars.size(), rng)];
-}
-
-velox::TypePtr randomLeafType(folly::Random::DefaultGenerator& rng) {
-  return randomScalarType(rng);
-}
-
-velox::TypePtr randomValueType(
-    folly::Random::DefaultGenerator& rng,
-    int depth) {
-  if (depth <= 0) {
-    return randomLeafType(rng);
-  }
-  auto choice = folly::Random::rand32(4, rng);
-  switch (choice) {
-    case 0:
-      return randomLeafType(rng);
-    case 1:
-      return velox::ARRAY(randomValueType(rng, depth - 1));
-    case 2:
-      return velox::MAP(randomScalarType(rng), randomValueType(rng, depth - 1));
-    case 3: {
-      auto numFields = 1 + folly::Random::rand32(3, rng);
-      std::vector<std::string> names;
-      std::vector<velox::TypePtr> types;
-      for (uint32_t i = 0; i < numFields; ++i) {
-        names.push_back(fmt::format("f{}", i));
-        types.push_back(randomValueType(rng, depth - 1));
-      }
-      return velox::ROW(std::move(names), std::move(types));
-    }
-    default:
-      return randomLeafType(rng);
-  }
-}
-
-// Key type for FlatMap must be a scalar kind convertible to ScalarKind.
-velox::TypePtr randomMapKeyType(folly::Random::DefaultGenerator& rng) {
-  static const std::vector<velox::TypePtr> keyTypes = {
-      velox::TINYINT(),
-      velox::SMALLINT(),
-      velox::INTEGER(),
-      velox::BIGINT(),
-      velox::VARCHAR(),
-  };
-  return keyTypes[folly::Random::rand32(keyTypes.size(), rng)];
-}
-
-ColumnDesc randomColumn(
-    const std::string& name,
-    folly::Random::DefaultGenerator& rng) {
-  ColumnDesc col;
-  col.name = name;
-
-  auto kind = folly::Random::rand32(5, rng);
-  switch (kind) {
-    case 0:
-      // Scalar column — no special encoding.
-      col.veloxType = randomScalarType(rng);
-      col.encoding = ColumnEncoding::None;
-      break;
-    case 1: {
-      // ARRAY column — may use DictionaryArray encoding.
-      col.veloxType = velox::ARRAY(randomValueType(rng, 1));
-      col.encoding = folly::Random::oneIn(2, rng)
-          ? ColumnEncoding::DictionaryArray
-          : ColumnEncoding::None;
-      break;
-    }
-    case 2: {
-      // MAP column — may use DeduplicatedMap encoding.
-      col.veloxType =
-          velox::MAP(randomMapKeyType(rng), randomValueType(rng, 1));
-      col.encoding = folly::Random::oneIn(2, rng)
-          ? ColumnEncoding::DeduplicatedMap
-          : ColumnEncoding::None;
-      break;
-    }
-    case 3: {
-      // MAP column with FlatMap encoding.
-      col.veloxType =
-          velox::MAP(randomMapKeyType(rng), randomValueType(rng, 1));
-      col.encoding = ColumnEncoding::FlatMap;
-      break;
-    }
-    case 4: {
-      // ROW column — no special encoding at non-top-level.
-      auto numFields = 1 + folly::Random::rand32(3, rng);
-      std::vector<std::string> names;
-      std::vector<velox::TypePtr> types;
-      for (uint32_t i = 0; i < numFields; ++i) {
-        names.push_back(fmt::format("sub{}", i));
-        types.push_back(randomValueType(rng, 1));
-      }
-      col.veloxType = velox::ROW(std::move(names), std::move(types));
-      col.encoding = ColumnEncoding::None;
-      break;
-    }
-    default:
-      col.veloxType = randomScalarType(rng);
-      col.encoding = ColumnEncoding::None;
-      break;
-  }
-  return col;
-}
-
-// Generates random subfield paths for the given columns.
-// For FlatMap columns, generates key subscript paths.
-// For ROW columns, may generate nested field paths.
-// For other columns, generates top-level paths.
-std::vector<Subfield> randomSubfields(
-    const std::vector<ColumnDesc>& columns,
-    folly::Random::DefaultGenerator& rng) {
-  std::vector<Subfield> subfields;
-  for (const auto& col : columns) {
-    // Each column is projected with 80% probability.
-    if (folly::Random::rand32(5, rng) == 0) {
-      continue;
-    }
-
-    if (col.encoding == ColumnEncoding::FlatMap) {
-      // Must project with key subscripts.
-      auto numKeys = 1 + folly::Random::rand32(3, rng);
-      for (uint32_t k = 0; k < numKeys; ++k) {
-        auto keyStr = fmt::format("{}", k + 1);
-        std::vector<std::unique_ptr<velox::common::Subfield::PathElement>> path;
-        path.push_back(std::make_unique<Subfield::NestedField>(col.name));
-
-        // Use appropriate subscript type based on key type.
-        auto keyKind = col.veloxType->asMap().keyType()->kind();
-        if (keyKind == velox::TypeKind::VARCHAR) {
-          path.push_back(std::make_unique<Subfield::StringSubscript>(keyStr));
-        } else {
-          path.push_back(std::make_unique<Subfield::LongSubscript>(k + 1));
-        }
-        subfields.emplace_back(std::move(path));
-      }
-    } else if (
-        col.encoding == ColumnEncoding::None &&
-        col.veloxType->kind() == velox::TypeKind::ROW) {
-      // For ROW columns, project some nested fields.
-      const auto& rowType = col.veloxType->asRow();
-      bool projectedAny = false;
-      for (size_t i = 0; i < rowType.size(); ++i) {
-        if (folly::Random::oneIn(2, rng)) {
-          std::vector<std::unique_ptr<velox::common::Subfield::PathElement>>
-              path;
-          path.push_back(std::make_unique<Subfield::NestedField>(col.name));
-          path.push_back(
-              std::make_unique<Subfield::NestedField>(rowType.nameOf(i)));
-          subfields.emplace_back(std::move(path));
-          projectedAny = true;
-        }
-      }
-      if (!projectedAny) {
-        // Project all fields.
-        subfields.emplace_back(col.name);
-      }
-    } else {
-      subfields.emplace_back(col.name);
-    }
-  }
-  return subfields;
-}
-
-ScalarKind toNimbleScalarKind(velox::TypeKind kind) {
-  switch (kind) {
-    case velox::TypeKind::TINYINT:
-      return ScalarKind::Int8;
-    case velox::TypeKind::SMALLINT:
-      return ScalarKind::Int16;
-    case velox::TypeKind::INTEGER:
-      return ScalarKind::Int32;
-    case velox::TypeKind::BIGINT:
-      return ScalarKind::Int64;
-    case velox::TypeKind::VARCHAR:
-      return ScalarKind::String;
-    default:
-      NIMBLE_UNREACHABLE("Unsupported key type: {}", static_cast<int>(kind));
-  }
-}
-
-// Builds the nimble schema corresponding to velox type + encodings.
-// For top-level children, applies encoding-specific types.
-std::shared_ptr<nimble::TypeBuilder> buildNimbleTypeFromVelox(
-    nimble::SchemaBuilder& builder,
-    const velox::Type& type) {
-  switch (type.kind()) {
-    case velox::TypeKind::BOOLEAN:
-      return builder.createScalarTypeBuilder(ScalarKind::Bool);
-    case velox::TypeKind::TINYINT:
-      return builder.createScalarTypeBuilder(ScalarKind::Int8);
-    case velox::TypeKind::SMALLINT:
-      return builder.createScalarTypeBuilder(ScalarKind::Int16);
-    case velox::TypeKind::INTEGER:
-      return builder.createScalarTypeBuilder(ScalarKind::Int32);
-    case velox::TypeKind::BIGINT:
-      return builder.createScalarTypeBuilder(ScalarKind::Int64);
-    case velox::TypeKind::REAL:
-      return builder.createScalarTypeBuilder(ScalarKind::Float);
-    case velox::TypeKind::DOUBLE:
-      return builder.createScalarTypeBuilder(ScalarKind::Double);
-    case velox::TypeKind::VARCHAR:
-      return builder.createScalarTypeBuilder(ScalarKind::String);
-    case velox::TypeKind::VARBINARY:
-      return builder.createScalarTypeBuilder(ScalarKind::Binary);
-    case velox::TypeKind::TIMESTAMP:
-      return builder.createTimestampMicroNanoTypeBuilder();
-    case velox::TypeKind::ARRAY: {
-      auto arr = builder.createArrayTypeBuilder();
-      arr->setChildren(
-          buildNimbleTypeFromVelox(builder, *type.asArray().elementType()));
-      return arr;
-    }
-    case velox::TypeKind::MAP: {
-      auto m = builder.createMapTypeBuilder();
-      auto k = buildNimbleTypeFromVelox(builder, *type.asMap().keyType());
-      auto v = buildNimbleTypeFromVelox(builder, *type.asMap().valueType());
-      m->setChildren(k, v);
-      return m;
-    }
-    case velox::TypeKind::ROW: {
-      auto r = builder.createRowTypeBuilder(type.asRow().size());
-      for (size_t i = 0; i < type.asRow().size(); ++i) {
-        r->addChild(
-            type.asRow().nameOf(i),
-            buildNimbleTypeFromVelox(builder, *type.asRow().childAt(i)));
-      }
-      return r;
-    }
-    default:
-      NIMBLE_UNREACHABLE(
-          "Unsupported type kind: {}", static_cast<int>(type.kind()));
-  }
-}
-
-// Builds nimble schema for a top-level child with encoding applied.
-std::shared_ptr<nimble::TypeBuilder> buildNimbleChildType(
-    nimble::SchemaBuilder& builder,
-    const velox::Type& type,
-    ColumnEncoding encoding,
-    const std::vector<std::string>& flatMapKeys) {
-  switch (encoding) {
-    case ColumnEncoding::DictionaryArray: {
-      auto arr = builder.createArrayWithOffsetsTypeBuilder();
-      arr->setChildren(
-          buildNimbleTypeFromVelox(builder, *type.asArray().elementType()));
-      return arr;
-    }
-    case ColumnEncoding::DeduplicatedMap: {
-      auto m = builder.createSlidingWindowMapTypeBuilder();
-      auto k = buildNimbleTypeFromVelox(builder, *type.asMap().keyType());
-      auto v = buildNimbleTypeFromVelox(builder, *type.asMap().valueType());
-      m->setChildren(k, v);
-      return m;
-    }
-    case ColumnEncoding::FlatMap: {
-      auto keyScalarKind = toNimbleScalarKind(type.asMap().keyType()->kind());
-      auto fm = builder.createFlatMapTypeBuilder(keyScalarKind);
-      for (const auto& key : flatMapKeys) {
-        fm->addChild(
-            key, buildNimbleTypeFromVelox(builder, *type.asMap().valueType()));
-      }
-      return fm;
-    }
-    case ColumnEncoding::None:
-      return buildNimbleTypeFromVelox(builder, type);
-  }
-  NIMBLE_UNREACHABLE("Invalid encoding");
-}
-
-} // namespace
-
-TEST(SchemaUtilsTest, projectionFuzzer) {
-  constexpr int kIterations = 100;
-  auto seed = folly::Random::rand32();
-  LOG(INFO) << "projectionFuzzer seed: " << seed;
-
-  for (int iter = 0; iter < kIterations; ++iter) {
-    folly::Random::DefaultGenerator rng(seed + iter);
-
-    // Generate 2-6 random top-level columns.
-    auto numColumns = 2 + folly::Random::rand32(5, rng);
-    std::vector<ColumnDesc> columns;
-    for (uint32_t i = 0; i < numColumns; ++i) {
-      columns.push_back(randomColumn(fmt::format("col{}", i), rng));
-    }
-
-    // Build velox RowType.
-    std::vector<std::string> names;
-    std::vector<velox::TypePtr> types;
-    for (const auto& col : columns) {
-      names.push_back(col.name);
-      types.push_back(col.veloxType);
-    }
-    auto veloxType = velox::ROW(std::move(names), std::move(types));
-
-    // Generate random subfields.
-    auto subfields = randomSubfields(columns, rng);
-    if (subfields.empty()) {
-      // Need at least one subfield.
-      subfields.emplace_back(columns[0].name);
-      if (columns[0].encoding == ColumnEncoding::FlatMap) {
-        // Fix: need key subscript for FlatMap.
-        subfields.clear();
-        auto keyKind = columns[0].veloxType->asMap().keyType()->kind();
-        std::vector<std::unique_ptr<velox::common::Subfield::PathElement>> path;
-        path.push_back(
-            std::make_unique<Subfield::NestedField>(columns[0].name));
-        if (keyKind == velox::TypeKind::VARCHAR) {
-          path.push_back(std::make_unique<Subfield::StringSubscript>("1"));
-        } else {
-          path.push_back(std::make_unique<Subfield::LongSubscript>(1));
-        }
-        subfields.emplace_back(std::move(path));
-      }
-    }
-
-    // Build ColumnEncodings.
-    ColumnEncodings encodings;
-    for (const auto& col : columns) {
-      switch (col.encoding) {
-        case ColumnEncoding::DictionaryArray:
-          encodings.dictionaryArrayColumns.insert(col.name);
-          break;
-        case ColumnEncoding::DeduplicatedMap:
-          encodings.deduplicatedMapColumns.insert(col.name);
-          break;
-        case ColumnEncoding::FlatMap:
-          encodings.flatMapColumns.insert(col.name);
-          break;
-        case ColumnEncoding::None:
-          break;
-      }
-    }
-
-    // Call velox-type overload.
-    auto projectedNimbleTypeFromVelox =
-        buildProjectedNimbleType(*veloxType, subfields, encodings);
-    ASSERT_NE(projectedNimbleTypeFromVelox, nullptr) << "iter=" << iter;
-
-    // Determine which FlatMap keys were projected per column.
-    std::map<std::string, std::set<std::string>> flatMapKeysPerColumn;
-    for (const auto& sf : subfields) {
-      const auto& path = sf.path();
-      if (path.size() >= 2) {
-        auto* nested =
-            dynamic_cast<const Subfield::NestedField*>(path[0].get());
-        if (nested != nullptr) {
-          auto* strSub =
-              dynamic_cast<const Subfield::StringSubscript*>(path[1].get());
-          auto* longSub =
-              dynamic_cast<const Subfield::LongSubscript*>(path[1].get());
-          if (strSub != nullptr) {
-            flatMapKeysPerColumn[nested->name()].insert(strSub->index());
-          } else if (longSub != nullptr) {
-            flatMapKeysPerColumn[nested->name()].insert(
-                std::to_string(longSub->index()));
-          }
-        }
-      }
-    }
-
-    // Build equivalent nimble input schema with encoding-specific types.
-    SchemaBuilder schemaBuilder;
-    auto nimbleRoot = schemaBuilder.createRowTypeBuilder(columns.size());
-    for (const auto& col : columns) {
-      std::vector<std::string> keys;
-      if (col.encoding == ColumnEncoding::FlatMap) {
-        auto it = flatMapKeysPerColumn.find(col.name);
-        if (it != flatMapKeysPerColumn.end()) {
-          keys.assign(it->second.begin(), it->second.end());
-        } else {
-          keys.push_back("1");
-        }
-      }
-      nimbleRoot->addChild(
-          col.name,
-          buildNimbleChildType(
-              schemaBuilder, *col.veloxType, col.encoding, keys));
-    }
-    auto convertedNimbleType =
-        SchemaReader::getSchema(schemaBuilder.schemaNodes());
-
-    // Call nimble-type overload.
-    std::vector<uint32_t> projectedStreamOffsets;
-    auto projectedNimbleType = buildProjectedNimbleType(
-        convertedNimbleType.get(), subfields, projectedStreamOffsets);
-    ASSERT_NE(projectedNimbleType, nullptr) << "iter=" << iter;
-
-    // Cross-validate: both should produce structurally equivalent types.
-    expectSameType(
-        *projectedNimbleTypeFromVelox,
-        *projectedNimbleType,
-        fmt::format("iter={}", iter));
-  }
 }


### PR DESCRIPTION
Summary:

`nimble::serde::Projector` and `nimble::NimbleIndexProjector` previously built their projected schemas by calling the **nimble-source** overload of `buildProjectedNimbleType(const Type*, subfields, &outOffsets)` in `dwio/nimble/velox/SchemaUtils.cpp`. That overload silently dropped missing FlatMap keys, which caused shift-by-N corruption when callers deserialized the projected blob against an expanded schema that included the dropped keys: the Deserializer read each output position through a stream offset that no longer corresponded to the source bytes it was meant to carry.

Route both projectors through the **velox-source** overload instead. The velox-source `buildProjectedNimbleType` operates on the velox type derived from the source nimble (`convertToVeloxType` collapses FlatMap to plain `MAP<K,V>`, discarding the specific key list). `resolveVeloxSubfield` inserts any subscript key string into `selectedChildren` unconditionally — no presence check against any source key list — so the projected FlatMap gets one alphabetically-ordered child per requested key, with a value subtree cloned from the source's value type. **Missing-key handling falls out for free** because the velox-source path has no concept of "missing"; it just emits whatever keys the caller asked for.

Each projector's constructor now does:
1. `auto veloxSource = convertToVeloxType(*sourceNimbleSchema_)` — existing helper.
2. `const auto encodings = deriveColumnEncodings(sourceNimbleSchema_->asRow())` — new helper that classifies top-level columns by `Kind` (FlatMap → `flatMapColumns`, ArrayWithOffsets → `dictionaryArrayColumns`, SlidingWindowMap → `deduplicatedMapColumns`) so the velox-source builder knows which top-level MAPs to materialize as FlatMaps.
3. `projectedSchema_ = buildProjectedNimbleType(veloxSource->asRow(), subfields, encodings)` — velox-source overload.
4. `computeSourceStreamOffsets(*sourceNimbleSchema_, subfields, encodings, inputStreamIndices_)` — new helper that walks the source nimble in the same DFS pre-order + FlatMap-alphabetical traversal the velox-source builder uses, emitting one source stream offset per projected stream position. Missing FlatMap keys emit `UINT32_MAX` for every descriptor under the value subtree plus the inMap, lining up positionally with the placeholder slots in the projected schema. The Projector's stream-copy guard (`Projector.cpp:358-365`) and `NimbleIndexProjector`'s equivalent already treat `streamIdx >= streamSizes.size()` as a 0-byte slot, so `UINT32_MAX` (larger than any real source offset) produces 0-byte placeholder slots in the projected blob automatically. The Deserializer's gap-fill (`Deserializer.cpp:467-515`) then turns those slots into null columns.

This collapses the dual-API design to a single source of truth. Projector-side and Deserializer-side schema layouts now agree by construction (both call the same `buildProjectedNimbleType` overload with the same subfields) instead of by an implicit "both overloads must produce structurally identical alphabetical+DFS schemas" contract. The `NimbleMissingChildrenMap` typedef, `generateMissingKeyType` recursive cloner, `Entry` merging, and `buildProjectedType` private worker are no longer needed and have been deleted along with the nimble-source `buildProjectedNimbleType` overload itself. `SchemaUtilsTest` cross-equivalence cases that asserted both overloads produce identical schemas have been deleted — with only one overload remaining, the comparison is tautological.

The "must have at least one real key per FlatMap" guard is preserved in `computeSourceStreamOffsets`: a projection that consists entirely of subscripts whose keys are all missing from the source throws `NimbleInternalError`, since this usually indicates caller misuse (e.g., a typo on every key) and silently projecting an all-null FlatMap would mask it.

Reviewed By: xiaoxmeng

Differential Revision: D107747094


