### PR TITLE
fix: Track speculative footer read bytes and latency in metadataIoStats (#842)

### DIFF
--- a/dwio/nimble/tablet/MetadataInput.cpp
+++ b/dwio/nimble/tablet/MetadataInput.cpp
@@ -70,6 +70,19 @@ std::vector<std::shared_ptr<MetadataBuffer>> MetadataInput::extractResults(
   return results;
 }
 
+void MetadataInput::readRaw(uint64_t offset, uint64_t size, void* dest) {
+  uint64_t storageReadUs{0};
+  {
+    velox::MicrosecondTimer timer{&storageReadUs};
+    file_->pread(offset, size, static_cast<char*>(dest));
+  }
+  ioStats_->queryThreadIoLatencyUs().increment(storageReadUs);
+  ioStats_->storageReadLatencyUs().increment(storageReadUs);
+  ioStats_->incTotalScanTimeNs(storageReadUs * 1'000);
+  ioStats_->read().increment(size);
+  ioStats_->incRawBytesRead(size);
+}
+
 std::unique_ptr<MetadataBuffer> MetadataInput::findCachedMetadata(
     uint64_t /*offset*/) {
   NIMBLE_UNREACHABLE("findCachedMetadata requires CachedMetadataInput");

--- a/dwio/nimble/tablet/MetadataInput.h
+++ b/dwio/nimble/tablet/MetadataInput.h
@@ -83,6 +83,11 @@ class MetadataInput {
   /// DirectMetadataInput always returns nullptr.
   virtual std::unique_ptr<MetadataBuffer> findCachedMetadata(uint64_t offset);
 
+  /// Raw tracked read for bootstrap IO (e.g. speculative footer read)
+  /// before section boundaries are known. Records bytes and latency into
+  /// the same ioStats used by load().
+  void readRaw(uint64_t offset, uint64_t size, void* dest);
+
   /// Caches data at the given offset from multiple contiguous ranges.
   /// Ranges are written sequentially into a single cache entry.
   virtual void cacheMetadata(

--- a/dwio/nimble/tablet/TabletReader.cpp
+++ b/dwio/nimble/tablet/TabletReader.cpp
@@ -67,15 +67,6 @@ void ensureBuffer(
   }
 }
 
-// Reads raw bytes from file into a caller-provided destination.
-void rawRead(
-    velox::ReadFile* file,
-    uint64_t offset,
-    uint64_t size,
-    void* dest) {
-  file->pread(offset, size, dest);
-}
-
 } // namespace
 
 TabletReader::Options TabletReader::configureOptions(
@@ -354,11 +345,8 @@ void TabletReader::loadFooter(
     footerIoSize = std::min(maxFooterIoBytes, fileSize_);
     footerOffset = fileSize_ - footerIoSize;
     ensureBuffer(footerBuf, footerIoSize, pool_);
-    rawRead(
-        file_.get(),
-        footerOffset,
-        footerBuf->size(),
-        footerBuf->asMutable<char>());
+    metadataInput_->readRaw(
+        footerOffset, footerBuf->size(), footerBuf->asMutable<char>());
 
     ps_ = Postscript::parse(
         std::string_view{
@@ -373,11 +361,8 @@ void TabletReader::loadFooter(
       footerIoSize = requiredSize;
       footerOffset = fileSize_ - footerIoSize;
       ensureBuffer(footerBuf, footerIoSize, pool_);
-      rawRead(
-          file_.get(),
-          footerOffset,
-          footerBuf->size(),
-          footerBuf->asMutable<char>());
+      metadataInput_->readRaw(
+          footerOffset, footerBuf->size(), footerBuf->asMutable<char>());
     } else {
       stats_.footerBufferOverread =
           static_cast<int64_t>(footerIoSize - requiredSize);
@@ -393,8 +378,7 @@ void TabletReader::loadFooter(
   } else {
     // Adaptive mode: read PS first, then footer.
     ensureBuffer(footerBuf, Postscript::kSize, pool_);
-    rawRead(
-        file_.get(),
+    metadataInput_->readRaw(
         fileSize_ - Postscript::kSize,
         Postscript::kSize,
         footerBuf->asMutable<char>());
@@ -405,11 +389,8 @@ void TabletReader::loadFooter(
     footerOffset = fileSize_ - footerIoSize;
 
     ensureBuffer(footerBuf, ps_.footerSize(), pool_);
-    rawRead(
-        file_.get(),
-        footerOffset,
-        ps_.footerSize(),
-        footerBuf->asMutable<char>());
+    metadataInput_->readRaw(
+        footerOffset, ps_.footerSize(), footerBuf->asMutable<char>());
     footer_ = std::make_unique<MetadataBuffer>(MetadataBuffer::decompress(
         std::move(footerBuf), ps_.footerCompressionType(), pool_));
   }
@@ -570,11 +551,8 @@ void TabletReader::loadStripes(
     footerIoSize = requiredSize;
     footerOffset = fileSize_ - footerIoSize;
     ensureBuffer(footerBuf, footerIoSize, pool_);
-    rawRead(
-        file_.get(),
-        footerOffset,
-        footerBuf->size(),
-        footerBuf->asMutable<char>());
+    metadataInput_->readRaw(
+        footerOffset, footerBuf->size(), footerBuf->asMutable<char>());
   }
   const auto footerView = footerBuf != nullptr
       ? std::string_view{footerBuf->as<char>(), footerBuf->size()}

--- a/dwio/nimble/tablet/tests/MetadataInputTest.cpp
+++ b/dwio/nimble/tablet/tests/MetadataInputTest.cpp
@@ -511,6 +511,45 @@ TEST_F(DirectMetadataInputTest, ioError) {
   }
 }
 
+TEST_F(DirectMetadataInputTest, readRawTracksIoStats) {
+  const std::string fileContent(4096, 'Z');
+  auto innerFile = std::make_shared<velox::InMemoryReadFile>(fileContent);
+  auto readFile =
+      std::make_shared<nimble::testing::TrackingReadFile>(innerFile);
+  constexpr uint64_t kInjectedDelayUs = 5'000;
+  readFile->setReadDelayUs(kInjectedDelayUs);
+
+  const auto options = makeMetadataInputOptions();
+  auto input = nimble::MetadataInput::create(readFile.get(), options);
+
+  const auto readCountBefore = metadataIoStats_->read().count();
+  const auto rawBytesBefore = metadataIoStats_->rawBytesRead();
+  const auto totalScanTimeBefore = metadataIoStats_->totalScanTimeNs();
+  const auto storageLatencyCountBefore =
+      metadataIoStats_->storageReadLatencyUs().count();
+  const auto queryIoLatencyCountBefore =
+      metadataIoStats_->queryThreadIoLatencyUs().count();
+
+  std::vector<char> dest(1024);
+  input->readRaw(0, dest.size(), dest.data());
+
+  EXPECT_EQ(metadataIoStats_->read().count() - readCountBefore, 1);
+  EXPECT_EQ(metadataIoStats_->rawBytesRead() - rawBytesBefore, dest.size());
+  EXPECT_GE(
+      metadataIoStats_->totalScanTimeNs() - totalScanTimeBefore,
+      kInjectedDelayUs * 1'000);
+  EXPECT_GT(
+      metadataIoStats_->storageReadLatencyUs().count(),
+      storageLatencyCountBefore);
+  EXPECT_GT(
+      metadataIoStats_->queryThreadIoLatencyUs().count(),
+      queryIoLatencyCountBefore);
+
+  EXPECT_EQ(
+      std::string(dest.data(), dest.size()),
+      fileContent.substr(0, dest.size()));
+}
+
 // --- CachedMetadataInput tests ---
 // Parameterized by whether SSD cache is enabled.
 

--- a/dwio/nimble/tablet/tests/TabletTest.cpp
+++ b/dwio/nimble/tablet/tests/TabletTest.cpp
@@ -3657,7 +3657,12 @@ TEST_P(TabletWithIndexTest, loadClusterIndex) {
       EXPECT_EQ(indexIoStats_->rawBytesRead(), indexBytesReadBefore);
     } else {
       EXPECT_EQ(tablet->clusterIndex(), nullptr);
-      EXPECT_EQ(metadataIoStats_->rawBytesRead(), metadataBytesReadBefore);
+      // The speculative footer read is now tracked in metadataIoStats. With no
+      // cluster index requested, that single tail read (covering this small
+      // file in full) is the only metadata IO; no index section is read.
+      EXPECT_EQ(
+          metadataIoStats_->rawBytesRead() - metadataBytesReadBefore,
+          file.size());
       EXPECT_EQ(indexIoStats_->rawBytesRead(), indexBytesReadBefore);
     }
   }
@@ -3726,7 +3731,13 @@ TEST_P(TabletWithIndexTest, preloadClusterIndex) {
     options.preloadIndex = true;
     auto tablet = TabletTest::createTabletReader(readFile, options);
     EXPECT_EQ(tablet->clusterIndex(), nullptr);
-    EXPECT_EQ(metadataIoStats_->rawBytesRead(), metadataBytesReadBefore);
+    // loadClusterIndex=false performs no index IO. The only metadata IO is the
+    // speculative footer read (now tracked), which is served from the metadata
+    // cache (no IO) when caching is enabled.
+    const uint64_t expectedMetadataBytes = expectHasCache() ? 0 : file.size();
+    EXPECT_EQ(
+        metadataIoStats_->rawBytesRead() - metadataBytesReadBefore,
+        expectedMetadataBytes);
     EXPECT_EQ(indexIoStats_->rawBytesRead(), indexBytesReadBefore);
   }
 }
@@ -5142,6 +5153,69 @@ TEST_P(TabletWithIndexTest, metadataSectionUncompressedSize) {
     ASSERT_TRUE(section.uncompressedSize().has_value());
     EXPECT_GT(section.uncompressedSize().value(), 0);
     EXPECT_GE(section.uncompressedSize().value(), section.size());
+  }
+}
+
+TEST_P(TabletTest, footerReadTrackedInMetadataIoStats) {
+  // Write a simple Nimble file using TabletWriter.
+  std::string file;
+  {
+    velox::InMemoryWriteFile writeFile(&file);
+    std::mt19937 rng(42);
+    nimble::Buffer buffer(*pool_);
+    auto stripesData = createStripesData(
+        rng,
+        {{.rowCount = 100, .streamOffsets = {0, 1, 2}},
+         {.rowCount = 200, .streamOffsets = {0, 1, 2}}},
+        buffer);
+    auto writer =
+        nimble::TabletWriter::create(&writeFile, *pool_, /*options=*/{});
+    for (auto& stripe : stripesData) {
+      writer->writeStripe(stripe.rowCount, stripe.streams);
+    }
+    writer->close();
+  }
+
+  auto readFile = std::make_shared<velox::InMemoryReadFile>(file);
+
+  // Speculative mode (default 8MB): single tail read covers everything.
+  {
+    auto ioStats = std::make_shared<velox::io::IoStatistics>();
+    nimble::TabletReader::Options options;
+    options.ioOptions.emplace(pool_.get()).setMetadataIoStats(ioStats);
+    auto tablet = nimble::TabletReader::create(readFile, pool_.get(), options);
+    EXPECT_GT(ioStats->read().count(), 0);
+    EXPECT_GT(ioStats->read().sum(), 0);
+    EXPECT_GT(ioStats->rawBytesRead(), 0);
+    EXPECT_GT(ioStats->storageReadLatencyUs().count(), 0);
+    EXPECT_GT(ioStats->queryThreadIoLatencyUs().count(), 0);
+    EXPECT_GT(ioStats->totalScanTimeNs(), 0);
+  }
+
+  // Adaptive mode (maxFooterIoBytes=0): two separate reads (PS + footer).
+  {
+    auto ioStats = std::make_shared<velox::io::IoStatistics>();
+    nimble::TabletReader::Options options;
+    options.maxFooterIoBytes = 0;
+    options.ioOptions.emplace(pool_.get()).setMetadataIoStats(ioStats);
+    auto tablet = nimble::TabletReader::create(readFile, pool_.get(), options);
+    EXPECT_GE(ioStats->read().count(), 2);
+    EXPECT_GT(ioStats->read().sum(), 0);
+    EXPECT_GT(ioStats->rawBytesRead(), 0);
+    EXPECT_GT(ioStats->storageReadLatencyUs().count(), 0);
+    EXPECT_GT(ioStats->queryThreadIoLatencyUs().count(), 0);
+  }
+
+  // Speculative read bytes equals min(maxFooterIoBytes, fileSize) for
+  // files smaller than the speculative buffer.
+  {
+    auto ioStats = std::make_shared<velox::io::IoStatistics>();
+    nimble::TabletReader::Options options;
+    options.maxFooterIoBytes = 8 * 1024 * 1024;
+    options.ioOptions.emplace(pool_.get()).setMetadataIoStats(ioStats);
+    auto tablet = nimble::TabletReader::create(readFile, pool_.get(), options);
+    EXPECT_EQ(ioStats->read().count(), 1);
+    EXPECT_EQ(ioStats->read().sum(), file.size());
   }
 }
 


### PR DESCRIPTION
Summary:

The speculative footer read in TabletReader::loadFooter calls rawRead (file->pread) without any IoStatistics tracking. This read (2-8MB per file open, controlled by nimble.footer-speculative-io-size) is not captured in metadata.storageReadBytes or metadata.storageReadWallNanos.

**Why this is needed**: 
Every time we open a Nimble file we speculatively read the last few MB (8MB by default) to get the footer. That buffer is not just the footer -- the reader immediately reuses it to parse the stripes metadata, the stripe group(s), and the optional sections (schema, stats), so a single read usually covers the file's entire metadata region. Those are all genuinely metadata bytes.

Before this change, `metadata.storageReadBytes` only counted the metadata reads the speculative buffer did NOT cover -- the leftover stripe groups / sections fetched on demand by MetadataInput. The big speculative footer read itself was in no metadata counter at all. So we never had the total metadata I/O: in the common case where the 8MB read covers everything, `metadata.storageReadBytes` showed nothing even though we really pulled MBs per file off Warm Storage -- and there was no way to **reason about footer-size choices/optimization efforts gain**, because the very read the size controls was invisible.

**What**
This change folds the speculative footer read into the same counter, so `metadata.storageReadBytes` is now a single value that represents ALL metadata I/O -- footer read plus the on-demand reads -- for every Nimble scan. One complete metadata-I/O number is the foundation for measuring footer reads, spotting over-read, and tuning nimble.footer-speculative-io-size -- a building block for the broader Nimble read-I/O optimization.

Add trackedRead() that wraps rawRead with MicrosecondTimer and records bytes and latency into the same metadataIoStats used by MetadataInput. After this change, metadata.storageReadBytes captures the full metadata I/O: speculative footer reads (previously untracked) + MetadataInput overflow reads (already tracked)

Reviewed By: xiaoxmeng

Differential Revision: D107348553


