### PR TITLE
feat: Add dictionary filter cache to Nimble string column reader

### DIFF
--- a/dwio/nimble/encodings/DictionaryEncoding.h
+++ b/dwio/nimble/encodings/DictionaryEncoding.h
@@ -290,8 +290,7 @@ void DictionaryEncoding<T>::readIndicesWithVisitor(
     ReadWithVisitorParams& params) {
   NIMBLE_CHECK(this->dictionaryEnabled());
   NIMBLE_CHECK(
-      !V::kHasFilter && !V::kHasHook,
-      "readIndicesWithVisitor should only be invoked in dictionary fast path");
+      !V::kHasHook, "readIndicesWithVisitor does not support value hooks");
   const auto numReadRows =
       visitor.rowAt(visitor.numRows() - 1) - params.numScanned + 1;
   auto* rawNulls = visitor.reader().rawNullsInReadRange();
@@ -299,6 +298,18 @@ void DictionaryEncoding<T>::readIndicesWithVisitor(
       ? velox::bits::countNonNulls(
             rawNulls, params.numScanned, params.numScanned + numReadRows)
       : numReadRows;
+
+  if constexpr (V::kHasFilter) {
+    auto* rawIndices = ensureIndicesBuffer(numNonNulls);
+    this->materializeIndices(numNonNulls, rawIndices);
+    uint32_t indexOffset = 0;
+    detail::readWithVisitorSlow(
+        visitor,
+        params,
+        [&](uint32_t numNonNullsToSkip) { indexOffset += numNonNullsToSkip; },
+        [&]() -> int32_t { return rawIndices[indexOffset++]; });
+    return;
+  }
 
   // Dense fast path: materialize directly into rawValues_, scatter for nulls.
   if (V::dense) {

--- a/dwio/nimble/encodings/NullableEncoding.h
+++ b/dwio/nimble/encodings/NullableEncoding.h
@@ -339,8 +339,7 @@ void NullableEncoding<T>::readIndicesWithVisitor(
       this->dictionaryEnabled(),
       "readIndicesWithVisitor requires dictionary-enabled inner encoding");
   NIMBLE_CHECK(
-      !V::kHasFilter && !V::kHasHook,
-      "readIndicesWithVisitor should only be invoked in dictionary fast path");
+      !V::kHasHook, "readIndicesWithVisitor does not support value hooks");
   materializeNullsForVisitor(visitor, params);
   callReadIndicesWithVisitor(*nonNullValues_, visitor, params);
 }

--- a/dwio/nimble/velox/selective/StringColumnReader.cpp
+++ b/dwio/nimble/velox/selective/StringColumnReader.cpp
@@ -25,6 +25,8 @@
 namespace facebook::nimble {
 
 using namespace facebook::velox;
+using velox::dwio::common::DictionaryValues;
+using velox::dwio::common::FilterResult;
 
 uint64_t StringColumnReader::skip(uint64_t numValues) {
   numValues = SelectiveColumnReader::skip(numValues);
@@ -32,26 +34,60 @@ uint64_t StringColumnReader::skip(uint64_t numValues) {
   return numValues;
 }
 
+void StringColumnReader::clearDictionaryState() {
+  dictionaryState_.clear();
+  scanState_.dictionary.clear();
+  scanState_.updateRawState();
+}
+
+// TODO: Derive alphabetVector from scanState_.dictionary.values to eliminate
+// redundant alphabet storage.
 void StringColumnReader::ensureDictionaryState() {
   if (hasDictionaryState()) {
     return;
   }
   // Invalidate dictionary state when a new chunk is loaded, since the new
   // chunk may have a different encoding or dictionary alphabet.
-  decoder_.setOnChunkLoad([this] { dictionaryState_.clear(); });
+  decoder_.setOnChunkLoad([this] { clearDictionaryState(); });
   dictionaryState_.alphabet = buildEncodingDictionaryAlphabet<std::string_view>(
       decoder_.currentEncoding());
+
+  if (DictionaryValues::hasFilter(scanSpec_->filter())) {
+    const auto& alphabet = dictionaryState_.alphabet;
+    const auto alphabetSize = static_cast<int32_t>(alphabet.size());
+    int64_t totalBytes = 0;
+    for (const auto& entry : alphabet) {
+      totalBytes += entry.size();
+    }
+    scanState_.dictionary.numValues = alphabetSize;
+    scanState_.dictionary.strings =
+        AlignedBuffer::allocate<char>(totalBytes, pool_);
+    scanState_.dictionary.values =
+        AlignedBuffer::allocate<StringView>(alphabetSize, pool_);
+    auto* rawStrings = scanState_.dictionary.strings->asMutable<char>();
+    auto* rawValues = scanState_.dictionary.values->asMutable<StringView>();
+    int64_t offset = 0;
+    for (int32_t i = 0; i < alphabetSize; ++i) {
+      auto len = alphabet[i].size();
+      std::memcpy(rawStrings + offset, alphabet[i].data(), len);
+      rawValues[i] = StringView(rawStrings + offset, len);
+      offset += len;
+    }
+    scanState_.filterCache.resize(alphabetSize);
+    simd::memset(
+        scanState_.filterCache.data(), FilterResult::kUnknown, alphabetSize);
+    scanState_.updateRawState();
+  }
 }
 
 bool StringColumnReader::readWithDictionary(
     int64_t offset,
     const RowSet& rows,
     const uint64_t* incomingNulls) {
-  // Dictionary path requires: no filter pushdown, no value hook, non-legacy
-  // encoding path (zero-copy), session property enabled, single-chunk read,
-  // and dictionary-convertible encoding.
-  if (scanSpec_->hasFilter() || scanSpec_->valueHook() ||
-      !formatData().stringDecoderZeroCopy() ||
+  // Dictionary path requires: no value hook, non-legacy encoding path
+  // (zero-copy), session property enabled, single-chunk read, and
+  // dictionary-convertible encoding.
+  if (scanSpec_->valueHook() || !formatData().stringDecoderZeroCopy() ||
       !static_cast<const NimbleData&>(formatData())
            .nimblePreserveDictionaryEncoding()) {
     return false;
@@ -93,7 +129,7 @@ void StringColumnReader::read(
   if (readWithDictionary(offset, rows, incomingNulls)) {
     return;
   }
-  dictionaryState_.clear();
+  clearDictionaryState();
   prepareRead<std::string_view>(offset, rows, incomingNulls);
   dwio::common::StringColumnReadWithVisitorHelper<
       /*kEncodingHasNulls=*/false,

--- a/dwio/nimble/velox/selective/StringColumnReader.h
+++ b/dwio/nimble/velox/selective/StringColumnReader.h
@@ -67,6 +67,8 @@ class StringColumnReader : public velox::dwio::common::SelectiveColumnReader {
     return false;
   }
 
+  void clearDictionaryState();
+
   // Populates dictionaryState_ from the current chunk's encoding if not
   // already set. Registers the onChunkLoad callback on first call.
   void ensureDictionaryState();

--- a/dwio/nimble/velox/selective/tests/StringColumnReaderBenchmark.cpp
+++ b/dwio/nimble/velox/selective/tests/StringColumnReaderBenchmark.cpp
@@ -1,0 +1,335 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/// Benchmarks the dictionary filter cache optimization for Nimble string
+/// column reads. Varies filter type (BytesValues, BytesRange), selectivity
+/// (1%, 20%, 80%), and dictionary cardinality (5, 100, 1K, 10K).
+
+#include <folly/Benchmark.h>
+#include <folly/init/Init.h>
+
+#include "dwio/nimble/common/tests/NimbleFileWriter.h"
+#include "dwio/nimble/velox/selective/SelectiveNimbleReader.h"
+#include "velox/common/io/IoStatistics.h"
+#include "velox/vector/tests/utils/VectorTestBase.h"
+
+namespace facebook::nimble {
+namespace {
+
+using namespace facebook::velox;
+
+constexpr int kTotalRows = 1'000'000;
+constexpr int kBatchSize = 10'000;
+
+struct BenchmarkState : public velox::test::VectorTestBase {
+  BenchmarkState() {
+    registerSelectiveNimbleReaderFactory();
+  }
+
+  ~BenchmarkState() {
+    unregisterSelectiveNimbleReaderFactory();
+  }
+
+  std::string writeFile(int cardinality) {
+    auto alphabet = generateAlphabet(cardinality);
+    auto c0 = makeFlatVector<std::string>(
+        kTotalRows, [&](auto i) { return alphabet[i % cardinality]; });
+    return test::createNimbleFile(*pool()->parent(), makeRowVector({c0}));
+  }
+
+  void readNoFilter(const std::string& file) {
+    auto scanSpec = makeScanSpec();
+    auto readers = createReaders(file, scanSpec);
+    drainReader(*readers.rowReader);
+  }
+
+  void readBytesValues(const std::string& file, int cardinality, int percent) {
+    auto scanSpec = makeScanSpec();
+    auto alphabet = generateAlphabet(cardinality);
+    int acceptCount = std::max(1, cardinality * percent / 100);
+    std::vector<std::string> accepted(
+        alphabet.begin(), alphabet.begin() + acceptCount);
+    scanSpec->childByName("c0")->setFilter(
+        std::make_unique<common::BytesValues>(accepted, false));
+    auto readers = createReaders(file, scanSpec);
+    drainReader(*readers.rowReader);
+  }
+
+  void readBytesRange(
+      const std::string& file,
+      const std::string& lower,
+      const std::string& upper) {
+    auto scanSpec = makeScanSpec();
+    scanSpec->childByName("c0")->setFilter(
+        std::make_unique<common::BytesRange>(
+            lower, false, false, upper, false, false, false));
+    auto readers = createReaders(file, scanSpec);
+    drainReader(*readers.rowReader);
+  }
+
+ private:
+  struct Readers {
+    std::unique_ptr<dwio::common::Reader> reader;
+    std::unique_ptr<dwio::common::RowReader> rowReader;
+  };
+
+  std::shared_ptr<common::ScanSpec> makeScanSpec() {
+    auto type = ROW({"c0"}, {VARCHAR()});
+    auto scanSpec = std::make_shared<common::ScanSpec>("root");
+    scanSpec->addAllChildFields(*type);
+    return scanSpec;
+  }
+
+  Readers createReaders(
+      const std::string& file,
+      const std::shared_ptr<common::ScanSpec>& scanSpec) {
+    auto type = ROW({"c0"}, {VARCHAR()});
+    auto readFile = std::make_shared<InMemoryReadFile>(file);
+    auto factory =
+        dwio::common::getReaderFactory(dwio::common::FileFormat::NIMBLE);
+    dwio::common::ReaderOptions options(pool());
+    options.setScanSpec(scanSpec);
+    options.setDataIoStats(ioStats_);
+    options.setMetadataIoStats(ioStats_);
+
+    Readers readers;
+    readers.reader = factory->createReader(
+        std::make_unique<dwio::common::BufferedInput>(readFile, *pool()),
+        options);
+
+    dwio::common::RowReaderOptions rowOptions;
+    rowOptions.setScanSpec(scanSpec);
+    rowOptions.setRequestedType(type);
+    // Enable dictionary read path (nimble.string-decoder-zero-copy and
+    // nimble.preserve-dictionary-encoding in connector config).
+    rowOptions.setStringDecoderZeroCopy(true);
+    rowOptions.setNimblePreserveDictionaryEncoding(true);
+    readers.rowReader = readers.reader->createRowReader(rowOptions);
+    return readers;
+  }
+
+  void drainReader(dwio::common::RowReader& rowReader) {
+    auto type = ROW({"c0"}, {VARCHAR()});
+    auto result = BaseVector::create(type, 0, pool());
+    while (rowReader.next(kBatchSize, result) > 0) {
+      folly::doNotOptimizeAway(result);
+    }
+  }
+
+  std::shared_ptr<velox::io::IoStatistics> ioStats_ =
+      std::make_shared<velox::io::IoStatistics>();
+
+  std::vector<std::string> generateAlphabet(int cardinality) {
+    std::vector<std::string> alphabet;
+    alphabet.reserve(cardinality);
+    for (int i = 0; i < cardinality; ++i) {
+      alphabet.push_back("val_" + std::to_string(i));
+    }
+    return alphabet;
+  }
+};
+
+BenchmarkState& state() {
+  static BenchmarkState s;
+  return s;
+}
+
+std::string& fileCard5() {
+  static auto f = state().writeFile(5);
+  return f;
+}
+
+std::string& fileCard100() {
+  static auto f = state().writeFile(100);
+  return f;
+}
+
+std::string& fileCard1000() {
+  static auto f = state().writeFile(1000);
+  return f;
+}
+
+std::string& fileCard10000() {
+  static auto f = state().writeFile(10000);
+  return f;
+}
+
+// ============================================================
+// Cardinality 5
+// ============================================================
+
+BENCHMARK(Card5_NoFilter, iters) {
+  for (size_t i = 0; i < iters; ++i) {
+    state().readNoFilter(fileCard5());
+  }
+}
+
+BENCHMARK_RELATIVE(Card5_BytesValues_Select20pct, iters) {
+  for (size_t i = 0; i < iters; ++i) {
+    state().readBytesValues(fileCard5(), 5, 20);
+  }
+}
+
+BENCHMARK_RELATIVE(Card5_BytesValues_Select80pct, iters) {
+  for (size_t i = 0; i < iters; ++i) {
+    state().readBytesValues(fileCard5(), 5, 80);
+  }
+}
+
+BENCHMARK_RELATIVE(Card5_BytesRange, iters) {
+  for (size_t i = 0; i < iters; ++i) {
+    state().readBytesRange(fileCard5(), "val_0", "val_1");
+  }
+}
+
+BENCHMARK_DRAW_LINE();
+
+// ============================================================
+// Cardinality 100
+// ============================================================
+
+BENCHMARK(Card100_NoFilter, iters) {
+  for (size_t i = 0; i < iters; ++i) {
+    state().readNoFilter(fileCard100());
+  }
+}
+
+BENCHMARK_RELATIVE(Card100_BytesValues_Select1pct, iters) {
+  for (size_t i = 0; i < iters; ++i) {
+    state().readBytesValues(fileCard100(), 100, 1);
+  }
+}
+
+BENCHMARK_RELATIVE(Card100_BytesValues_Select20pct, iters) {
+  for (size_t i = 0; i < iters; ++i) {
+    state().readBytesValues(fileCard100(), 100, 20);
+  }
+}
+
+BENCHMARK_RELATIVE(Card100_BytesValues_Select80pct, iters) {
+  for (size_t i = 0; i < iters; ++i) {
+    state().readBytesValues(fileCard100(), 100, 80);
+  }
+}
+
+BENCHMARK_RELATIVE(Card100_BytesRange_Narrow, iters) {
+  for (size_t i = 0; i < iters; ++i) {
+    state().readBytesRange(fileCard100(), "val_40", "val_49");
+  }
+}
+
+BENCHMARK_RELATIVE(Card100_BytesRange_Wide, iters) {
+  for (size_t i = 0; i < iters; ++i) {
+    state().readBytesRange(fileCard100(), "val_0", "val_79");
+  }
+}
+
+BENCHMARK_DRAW_LINE();
+
+// ============================================================
+// Cardinality 1000
+// ============================================================
+
+BENCHMARK(Card1K_NoFilter, iters) {
+  for (size_t i = 0; i < iters; ++i) {
+    state().readNoFilter(fileCard1000());
+  }
+}
+
+BENCHMARK_RELATIVE(Card1K_BytesValues_Select1pct, iters) {
+  for (size_t i = 0; i < iters; ++i) {
+    state().readBytesValues(fileCard1000(), 1000, 1);
+  }
+}
+
+BENCHMARK_RELATIVE(Card1K_BytesValues_Select20pct, iters) {
+  for (size_t i = 0; i < iters; ++i) {
+    state().readBytesValues(fileCard1000(), 1000, 20);
+  }
+}
+
+BENCHMARK_RELATIVE(Card1K_BytesValues_Select80pct, iters) {
+  for (size_t i = 0; i < iters; ++i) {
+    state().readBytesValues(fileCard1000(), 1000, 80);
+  }
+}
+
+BENCHMARK_RELATIVE(Card1K_BytesRange_Narrow, iters) {
+  for (size_t i = 0; i < iters; ++i) {
+    state().readBytesRange(fileCard1000(), "val_400", "val_499");
+  }
+}
+
+BENCHMARK_RELATIVE(Card1K_BytesRange_Wide, iters) {
+  for (size_t i = 0; i < iters; ++i) {
+    state().readBytesRange(fileCard1000(), "val_0", "val_799");
+  }
+}
+
+BENCHMARK_DRAW_LINE();
+
+// ============================================================
+// Cardinality 10000
+// ============================================================
+
+BENCHMARK(Card10K_NoFilter, iters) {
+  for (size_t i = 0; i < iters; ++i) {
+    state().readNoFilter(fileCard10000());
+  }
+}
+
+BENCHMARK_RELATIVE(Card10K_BytesValues_Select1pct, iters) {
+  for (size_t i = 0; i < iters; ++i) {
+    state().readBytesValues(fileCard10000(), 10000, 1);
+  }
+}
+
+BENCHMARK_RELATIVE(Card10K_BytesValues_Select20pct, iters) {
+  for (size_t i = 0; i < iters; ++i) {
+    state().readBytesValues(fileCard10000(), 10000, 20);
+  }
+}
+
+BENCHMARK_RELATIVE(Card10K_BytesValues_Select80pct, iters) {
+  for (size_t i = 0; i < iters; ++i) {
+    state().readBytesValues(fileCard10000(), 10000, 80);
+  }
+}
+
+BENCHMARK_RELATIVE(Card10K_BytesRange_Narrow, iters) {
+  for (size_t i = 0; i < iters; ++i) {
+    state().readBytesRange(fileCard10000(), "val_5000", "val_5099");
+  }
+}
+
+BENCHMARK_RELATIVE(Card10K_BytesRange_Wide, iters) {
+  for (size_t i = 0; i < iters; ++i) {
+    state().readBytesRange(fileCard10000(), "val_0", "val_7999");
+  }
+}
+
+BENCHMARK_DRAW_LINE();
+
+} // namespace
+} // namespace facebook::nimble
+
+int main(int argc, char** argv) {
+  folly::Init init{&argc, &argv};
+  facebook::velox::memory::initializeMemoryManager(
+      facebook::velox::memory::MemoryManager::Options{});
+  folly::runBenchmarks();
+  return 0;
+}

--- a/dwio/nimble/velox/selective/tests/StringColumnReaderTest.cpp
+++ b/dwio/nimble/velox/selective/tests/StringColumnReaderTest.cpp
@@ -1629,6 +1629,178 @@ TEST_P(StringColumnReaderTest, filterOnlyMultiChunkNumValuesSync) {
   ASSERT_EQ(readRows(/*projectOut=*/false), expected);
 }
 
+// Dictionary path with BytesValues filter. The filter is evaluated once per
+// dictionary entry via the filter cache, and the output is a DictionaryVector
+// containing only rows that pass the filter.
+TEST_P(StringColumnReaderTest, dictionaryWithBytesValuesFilter) {
+  const bool stringDecoderZeroCopy = GetParam();
+  if (!stringDecoderZeroCopy) {
+    GTEST_SKIP() << "Dictionary path requires stringDecoderZeroCopy";
+  }
+
+  constexpr int kRows = 500;
+  auto c0 = makeFlatVector<std::string>(kRows, [](auto i) {
+    return std::vector<std::string>{
+        "alpha", "bravo", "charlie", "delta", "echo"}[i % 5];
+  });
+  auto input = makeRowVector({c0});
+
+  auto scanSpec = std::make_shared<common::ScanSpec>("root");
+  scanSpec->addAllChildFields(*input->type());
+  scanSpec->childByName("c0")->setFilter(
+      std::make_unique<common::BytesValues>(
+          std::vector<std::string>{"bravo", "delta"}, false));
+  auto readers = makeReaders(input, scanSpec, stringDecoderZeroCopy);
+
+  auto expectedStrings = makeFlatVector<std::string>(
+      200, [](auto i) { return i % 2 == 0 ? "bravo" : "delta"; });
+
+  using E = VectorEncoding::Simple;
+  validateWithEncodingChecks(
+      *expectedStrings,
+      *readers.rowReader,
+      kRows,
+      /*totalRows=*/kRows,
+      {E::DICTIONARY},
+      asRowType(input->type()),
+      pool());
+}
+
+// Dictionary path with BytesRange filter across chunk boundaries. The filter
+// cache is invalidated when the chunk changes and rebuilt from the new chunk's
+// dictionary.
+TEST_P(StringColumnReaderTest, dictionaryWithFilterAcrossChunks) {
+  const bool stringDecoderZeroCopy = GetParam();
+  if (!stringDecoderZeroCopy) {
+    GTEST_SKIP() << "Dictionary path requires stringDecoderZeroCopy";
+  }
+
+  constexpr int kChunkRows = 300;
+  auto chunk1 =
+      makeRowVector({makeFlatVector<std::string>(kChunkRows, [](auto i) {
+        return std::vector<std::string>{"aaa", "bbb", "ccc"}[i % 3];
+      })});
+  auto chunk2 =
+      makeRowVector({makeFlatVector<std::string>(kChunkRows, [](auto i) {
+        return std::vector<std::string>{"xxx", "yyy"}[i % 2];
+      })});
+
+  VeloxWriterOptions writerOptions;
+  writerOptions.enableChunking = true;
+  writerOptions.minStreamChunkRawSize = 0;
+  writerOptions.flushPolicyFactory = [] {
+    return std::make_unique<LambdaFlushPolicy>(
+        /*flushLambda=*/[](const StripeProgress&) { return false; },
+        /*chunkLambda=*/[](const StripeProgress&) { return true; });
+  };
+  auto file = test::createNimbleFile(
+      *rootPool(), {chunk1, chunk2}, writerOptions, /*flushAfterWrite=*/false);
+
+  auto scanSpec = std::make_shared<common::ScanSpec>("root");
+  scanSpec->addAllChildFields(*chunk1->type());
+  scanSpec->childByName("c0")->setFilter(
+      std::make_unique<common::BytesRange>(
+          "bbb", false, false, "bbb", false, false, false));
+  auto readers = makeReaders(chunk1, file, scanSpec, stringDecoderZeroCopy);
+
+  auto expectedStrings =
+      makeFlatVector<std::string>(100, [](auto) { return "bbb"; });
+
+  using E = VectorEncoding::Simple;
+  validateWithEncodingChecks(
+      *expectedStrings,
+      *readers.rowReader,
+      kChunkRows,
+      /*totalRows=*/2 * kChunkRows,
+      {E::DICTIONARY},
+      asRowType(chunk1->type()),
+      pool());
+}
+
+// Dictionary path with filter and nullable input. Exercises the null-skipping
+// logic in the readWithVisitorSlow path where indexOffset must correctly
+// advance past only non-null values.
+TEST_P(StringColumnReaderTest, dictionaryWithFilterAndNulls) {
+  const bool stringDecoderZeroCopy = GetParam();
+  if (!stringDecoderZeroCopy) {
+    GTEST_SKIP() << "Dictionary path requires stringDecoderZeroCopy";
+  }
+
+  constexpr int kRows = 500;
+  auto c0 = makeFlatVector<std::string>(
+      kRows,
+      [](auto i) {
+        return std::vector<std::string>{
+            "alpha", "bravo", "charlie", "delta", "echo"}[i % 5];
+      },
+      nullEvery(7));
+  auto input = makeRowVector({c0});
+
+  auto scanSpec = std::make_shared<common::ScanSpec>("root");
+  scanSpec->addAllChildFields(*input->type());
+  scanSpec->childByName("c0")->setFilter(
+      std::make_unique<common::BytesValues>(
+          std::vector<std::string>{"bravo", "delta"}, false));
+  auto readers = makeReaders(input, scanSpec, stringDecoderZeroCopy);
+
+  std::vector<std::optional<std::string>> expected;
+  for (int i = 0; i < kRows; ++i) {
+    if (i % 7 == 0) {
+      continue;
+    }
+    auto value = std::vector<std::string>{
+        "alpha", "bravo", "charlie", "delta", "echo"}[i % 5];
+    if (value == "bravo" || value == "delta") {
+      expected.push_back(value);
+    }
+  }
+  auto expectedStrings = makeFlatVector<std::string>(
+      expected.size(), [&](auto i) { return *expected[i]; });
+
+  using E = VectorEncoding::Simple;
+  validateWithEncodingChecks(
+      *expectedStrings,
+      *readers.rowReader,
+      kRows,
+      /*totalRows=*/kRows,
+      {E::DICTIONARY},
+      asRowType(input->type()),
+      pool());
+}
+
+// Dictionary path with a filter that accepts all entries. The filter cache
+// populates every entry as passing, and the output should contain all rows.
+TEST_P(StringColumnReaderTest, dictionaryWithFilterAllPass) {
+  const bool stringDecoderZeroCopy = GetParam();
+  if (!stringDecoderZeroCopy) {
+    GTEST_SKIP() << "Dictionary path requires stringDecoderZeroCopy";
+  }
+
+  constexpr int kRows = 500;
+  auto c0 = makeFlatVector<std::string>(kRows, [](auto i) {
+    return std::vector<std::string>{
+        "alpha", "bravo", "charlie", "delta", "echo"}[i % 5];
+  });
+  auto input = makeRowVector({c0});
+
+  auto scanSpec = std::make_shared<common::ScanSpec>("root");
+  scanSpec->addAllChildFields(*input->type());
+  scanSpec->childByName("c0")->setFilter(
+      std::make_unique<common::BytesRange>(
+          "a", false, false, "z", false, false, false));
+  auto readers = makeReaders(input, scanSpec, stringDecoderZeroCopy);
+
+  using E = VectorEncoding::Simple;
+  validateWithEncodingChecks(
+      *c0,
+      *readers.rowReader,
+      kRows,
+      /*totalRows=*/kRows,
+      {E::DICTIONARY},
+      asRowType(input->type()),
+      pool());
+}
+
 INSTANTIATE_TEST_CASE_P(
     StringColumnReaderTestSuite,
     StringColumnReaderTest,


### PR DESCRIPTION
Summary:
Nimble's `readWithDictionary()` bailed out when a filter existed, falling back to flat reads that decode and evaluate every row individually. DWRF and Parquet both avoid this with a dictionary filter cache that evaluates the filter once per unique dictionary entry. This diff adds the same mechanism to Nimble.

Key changes:
- Populate `scanState_.dictionary` and `filterCache` from the Nimble encoding alphabet in `ensureDictionaryState()`
- Add a filtered path in `DictionaryEncoding::readIndicesWithVisitor()` that feeds indices through `visitor.process()` for filter cache lookup
- Remove the `hasFilter()` bailout in `readWithDictionary()`
- Clear dictionary/filter cache state on chunk transitions

No-filter fast path is unchanged.

Differential Revision: D107909353


