### PR TITLE
Use batched local reads for index projector (#845)

### DIFF
--- a/dwio/nimble/tablet/DataInput.cpp
+++ b/dwio/nimble/tablet/DataInput.cpp
@@ -16,10 +16,10 @@
 #include "dwio/nimble/tablet/DataInput.h"
 
 #include <algorithm>
+#include <limits>
 #include <numeric>
 
 #include "dwio/nimble/common/Exceptions.h"
-#include "folly/synchronization/Latch.h"
 #include "velox/common/base/BitUtil.h"
 #include "velox/common/base/CoalesceIo.h"
 #include "velox/common/memory/MemoryAllocator.h"
@@ -29,6 +29,20 @@
 namespace facebook::nimble {
 
 // --- DirectDataInput ---
+
+namespace {
+
+velox::ReadFile* checkedFile(velox::ReadFile* file) {
+  NIMBLE_CHECK_NOT_NULL(file);
+  return file;
+}
+
+uint64_t readAlignment(const velox::ReadFile& file) {
+  uint64_t alignment{0};
+  return file.directIo(/*alignment=*/alignment) ? alignment : 1;
+}
+
+} // namespace
 
 /*static*/ std::string_view DirectDataInput::stateName(State state) {
   switch (state) {
@@ -45,22 +59,18 @@ namespace facebook::nimble {
 }
 
 DirectDataInput::DirectDataInput(velox::ReadFile* file, const Options& options)
-    : file_{file},
+    : file_{checkedFile(file)},
       pool_{options.pool},
-      executor_{options.executor},
       ioStats_{options.ioStats},
-      alignment_{options.alignment},
+      alignment_{readAlignment(*file_)},
       allocAlignment_{std::max(
           alignment_,
           static_cast<uint64_t>(
               velox::memory::MemoryAllocator::kMinAlignment))},
       maxCoalesceDistance_{
           std::min(options.maxCoalesceDistance, kMaxCoalesceDistance)},
-      maxCoalesceBytes_{options.maxCoalesceBytes},
-      minIoGroupsPerTask_{std::max(1, options.minIoGroupsPerTask)} {
-  NIMBLE_CHECK_NOT_NULL(file_);
+      maxCoalesceBytes_{options.maxCoalesceBytes} {
   NIMBLE_CHECK_NOT_NULL(pool_);
-  NIMBLE_CHECK_NOT_NULL(executor_);
   NIMBLE_CHECK_NOT_NULL(ioStats_);
   NIMBLE_CHECK_GT(alignment_, 0, "alignment must be positive");
   NIMBLE_CHECK(
@@ -230,54 +240,24 @@ std::pair<char*, DataInput::Handle> DirectDataInput::allocateBuffer(
 
 void DirectDataInput::executeIoGroups(
     std::vector<IoGroup>& ioGroups,
-    char* buffer) {
+    char* buffer,
+    uint64_t bufferSize) {
   NIMBLE_CHECK(!ioGroups.empty());
-  const auto numGroups = ioGroups.size();
-
-  // Batch IO groups into tasks. Each task reads multiple groups
-  // sequentially to reduce executor overhead.
-  const auto batchSize = static_cast<size_t>(minIoGroupsPerTask_);
-  const auto numTasks = velox::bits::divRoundUp(numGroups, batchSize);
-
-  std::exception_ptr readError;
-  std::mutex errorMutex;
-  folly::Latch latch(numTasks);
-
-  for (size_t t = 0; t < numTasks; ++t) {
-    const auto start = t * batchSize;
-    const auto end = std::min(start + batchSize, numGroups);
-    executor_->add([this,
-                    &ioGroups,
-                    buffer,
-                    start,
-                    end,
-                    &readError,
-                    &errorMutex,
-                    &latch]() {
-      try {
-        for (size_t i = start; i < end; ++i) {
-          velox::common::testutil::TestValue::adjust(
-              "facebook::nimble::DirectDataInput::executeIoGroups", this);
-          file_->pread(
-              ioGroups[i].readOffset,
-              ioGroups[i].readSize,
-              buffer + ioGroups[i].bufferOffset);
-        }
-      } catch (...) {
-        std::lock_guard<std::mutex> lock(errorMutex);
-        if (readError == nullptr) {
-          readError = std::current_exception();
-        }
-      }
-      latch.count_down();
-    });
+  std::vector<velox::common::Region> readRegions;
+  readRegions.reserve(ioGroups.size());
+  std::vector<folly::Range<char*>> readBuffers;
+  readBuffers.reserve(ioGroups.size());
+  for (const auto& ioGroup : ioGroups) {
+    readRegions.emplace_back(ioGroup.readOffset, ioGroup.readSize);
+    readBuffers.emplace_back(
+        buffer + ioGroup.bufferOffset, static_cast<size_t>(ioGroup.readSize));
   }
-
-  latch.wait();
-
-  if (readError != nullptr) {
-    std::rethrow_exception(readError);
-  }
+  const auto bytesRead = file_->preadv(
+      folly::Range<const velox::common::Region*>(
+          readRegions.data(), readRegions.size()),
+      folly::Range<const folly::Range<char*>*>(
+          readBuffers.data(), readBuffers.size()));
+  NIMBLE_CHECK_EQ(bytesRead, bufferSize, "preadv returned a short read");
 }
 
 DataInput::Handle DirectDataInput::load() {
@@ -325,7 +305,7 @@ DataInput::Handle DirectDataInput::load() {
   uint64_t ioUs{0};
   {
     velox::MicrosecondTimer ioTimer(&ioUs);
-    executeIoGroups(ioGroups, buffer);
+    executeIoGroups(ioGroups, buffer, readBytes);
   }
 
   for (const auto& group : ioGroups) {

--- a/dwio/nimble/tablet/DataInput.h
+++ b/dwio/nimble/tablet/DataInput.h
@@ -27,10 +27,6 @@
 #include "velox/common/io/Options.h"
 #include "velox/common/memory/Memory.h"
 
-namespace folly {
-class Executor;
-} // namespace folly
-
 namespace facebook::nimble {
 
 /// Base class for data I/O with an enqueue + batch load pattern.
@@ -84,12 +80,11 @@ class DataInput {
   virtual void clear() = 0;
 };
 
-/// Direct data loading with IO coalescing, alignment for direct I/O,
-/// and optional parallel reads via executor.
+/// Direct data loading with IO coalescing and alignment for direct I/O.
 ///
 /// After coalescing, each I/O group is backed by a non-contiguous
-/// Allocation (page-aligned runs). Reads are parallelized across
-/// I/O groups via the executor.
+/// Allocation (page-aligned runs). Reads are submitted through the file's
+/// positioned vector read API.
 ///
 /// NOTE: DirectDataInput is not thread-safe. Each thread must use its
 /// own instance.
@@ -100,15 +95,9 @@ class DirectDataInput : public DataInput {
 
   struct Options {
     velox::memory::MemoryPool* pool{nullptr};
-    folly::Executor* executor{nullptr};
     std::shared_ptr<velox::io::IoStatistics> ioStats;
-    uint64_t alignment{1};
     int32_t maxCoalesceDistance{kDefaultCoalesceDistance};
     int64_t maxCoalesceBytes{velox::io::ReaderOptions::kDefaultCoalesceBytes};
-    /// Minimum number of IO groups per executor task. Batching multiple
-    /// pread calls into one task reduces executor overhead (task timing,
-    /// lambda allocation, scheduling) at the cost of less parallelism.
-    int32_t minIoGroupsPerTask{4};
   };
 
   DirectDataInput(velox::ReadFile* file, const Options& options);
@@ -173,9 +162,11 @@ class DirectDataInput : public DataInput {
   // it.
   std::pair<char*, Handle> allocateBuffer(uint64_t bytes);
 
-  // Executes all physical IO groups, batching executor tasks to reduce
-  // scheduling overhead.
-  void executeIoGroups(std::vector<IoGroup>& ioGroups, char* buffer);
+  // Executes all physical IO groups through ReadFile's positioned vector API.
+  void executeIoGroups(
+      std::vector<IoGroup>& ioGroups,
+      char* buffer,
+      uint64_t bufferSize);
 
   uint64_t alignDown(uint64_t value) const {
     return value & ~(alignment_ - 1);
@@ -189,8 +180,6 @@ class DirectDataInput : public DataInput {
   velox::ReadFile* const file_;
   // Memory pool for allocating the read buffer.
   velox::memory::MemoryPool* const pool_;
-  // Executor for parallel I/O across coalesced groups.
-  folly::Executor* const executor_;
   // IO statistics for tracking read bytes, latency, and gaps.
   const std::shared_ptr<velox::io::IoStatistics> ioStats_;
   // I/O alignment for file offsets and read sizes.
@@ -202,8 +191,6 @@ class DirectDataInput : public DataInput {
   const int32_t maxCoalesceDistance_;
   // Max total bytes per coalesced I/O group.
   const int64_t maxCoalesceBytes_;
-  // Min IO groups per executor task.
-  const int32_t minIoGroupsPerTask_;
 
   State state_{State::kInit};
 

--- a/dwio/nimble/tablet/TabletReaderCache.h
+++ b/dwio/nimble/tablet/TabletReaderCache.h
@@ -97,8 +97,8 @@ class TabletReaderCache {
 
   /// Returns a cached or newly created CachedTabletReader for the given file.
   /// Uses readFile->getName() as the cache key. On cache miss, creates the
-  /// TabletReader and deserializes the schema using a sharded system pool
-  /// (keyed by filename hash) and the provided readFile/options.
+  /// TabletReader and deserializes the schema using a sharded system pool and
+  /// the provided readFile/options.
   CachedTabletReader get(
       const std::shared_ptr<velox::ReadFile>& readFile,
       const TabletReader::Options& tabletOptions);

--- a/dwio/nimble/tablet/tests/DataInputTest.cpp
+++ b/dwio/nimble/tablet/tests/DataInputTest.cpp
@@ -22,28 +22,47 @@
 #include "dwio/nimble/common/Exceptions.h"
 #include "dwio/nimble/common/tests/GTestUtils.h"
 
-#include "folly/executors/CPUThreadPoolExecutor.h"
 #include "velox/common/file/File.h"
+#include "velox/common/file/IoUringReader.h"
+#include "velox/common/file/LocalFile.h"
 #include "velox/common/io/IoStatistics.h"
+#include "velox/common/memory/Allocation.h"
 #include "velox/common/memory/Memory.h"
+#include "velox/common/testutil/TempFilePath.h"
 #include "velox/common/testutil/TestValue.h"
 
 namespace facebook::nimble {
 namespace {
 
 struct OptionParams {
-  uint64_t alignment;
   int32_t maxCoalesceDistance;
   int64_t maxCoalesceBytes;
-  int32_t minIoGroupsPerTask;
 
   std::string toString() const {
-    return fmt::format(
-        "align{}_dist{}_bytes{}_batch{}",
-        alignment,
-        maxCoalesceDistance,
-        maxCoalesceBytes,
-        minIoGroupsPerTask);
+    return fmt::format("dist{}_bytes{}", maxCoalesceDistance, maxCoalesceBytes);
+  }
+};
+
+class DirectIoInMemoryReadFile : public velox::InMemoryReadFile {
+ public:
+  using velox::InMemoryReadFile::InMemoryReadFile;
+
+  bool directIo(uint64_t& alignment) const override {
+    alignment = velox::memory::AllocationTraits::kPageSize;
+    return true;
+  }
+};
+
+class FailingPreadvInMemoryReadFile : public velox::InMemoryReadFile {
+ public:
+  using velox::InMemoryReadFile::InMemoryReadFile;
+  using velox::InMemoryReadFile::preadv;
+
+  uint64_t preadv(
+      folly::Range<const velox::common::Region*> /*regions*/,
+      folly::Range<const folly::Range<char*>*> /*buffers*/,
+      const velox::FileIoContext& /*context*/ = {}) const override {
+    NIMBLE_FAIL("Injected preadv failure");
   }
 };
 
@@ -56,7 +75,6 @@ class DataInputTest : public ::testing::Test {
 
   void SetUp() override {
     pool_ = velox::memory::memoryManager()->addLeafPool("DataInputTest");
-    executor_ = std::make_unique<folly::CPUThreadPoolExecutor>(2);
     ioStats_ = std::make_shared<velox::io::IoStatistics>();
   }
 
@@ -66,14 +84,11 @@ class DataInputTest : public ::testing::Test {
   }
 
   DirectDataInput::Options makeOptions(
-      uint64_t alignment = 1,
       int32_t maxCoalesceDistance = 1'000'000,
       int64_t maxCoalesceBytes = 128 << 20) {
     DirectDataInput::Options options;
     options.pool = pool_.get();
-    options.executor = executor_.get();
     options.ioStats = ioStats_;
-    options.alignment = alignment;
     options.maxCoalesceDistance = maxCoalesceDistance;
     options.maxCoalesceBytes = maxCoalesceBytes;
     return options;
@@ -82,12 +97,9 @@ class DataInputTest : public ::testing::Test {
   DirectDataInput::Options makeOptions(const OptionParams& params) {
     DirectDataInput::Options options;
     options.pool = pool_.get();
-    options.executor = executor_.get();
     options.ioStats = ioStats_;
-    options.alignment = params.alignment;
     options.maxCoalesceDistance = params.maxCoalesceDistance;
     options.maxCoalesceBytes = params.maxCoalesceBytes;
-    options.minIoGroupsPerTask = params.minIoGroupsPerTask;
     return options;
   }
 
@@ -96,7 +108,6 @@ class DataInputTest : public ::testing::Test {
   }
 
   std::shared_ptr<velox::memory::MemoryPool> pool_;
-  std::unique_ptr<folly::CPUThreadPoolExecutor> executor_;
   std::shared_ptr<velox::io::IoStatistics> ioStats_;
 };
 
@@ -285,15 +296,10 @@ INSTANTIATE_TEST_SUITE_P(
     DataInputOptions,
     DataInputParamTest,
     ::testing::Values(
-        OptionParams{1, 100, 128 << 20, 1},
-        OptionParams{1, 100, 128 << 20, 4},
-        OptionParams{1, 100, 128 << 20, 32},
-        OptionParams{1, 1'000'000, 128 << 20, 1},
-        OptionParams{1, 100, 1'024, 1},
-        OptionParams{1, 100, 512, 4},
-        OptionParams{4'096, 100, 128 << 20, 1},
-        OptionParams{4'096, 100, 128 << 20, 4},
-        OptionParams{4'096, 1'000'000, 128 << 20, 1}),
+        OptionParams{100, 128 << 20},
+        OptionParams{1'000'000, 128 << 20},
+        OptionParams{100, 1'024},
+        OptionParams{100, 512}),
     [](const auto& info) { return info.param.toString(); });
 
 // --- Non-parameterized tests ---
@@ -303,18 +309,17 @@ TEST_F(DataInputTest, alignment) {
   for (int i = 0; i < 16'384; ++i) {
     data[i] = static_cast<char>(i % 256);
   }
-  auto file = createFile(data);
 
   struct TestParam {
-    uint64_t alignment;
+    bool directIo;
     uint64_t offset;
     uint64_t length;
     uint64_t expectedOverread;
 
     std::string debugString() const {
       return fmt::format(
-          "alignment {} offset {} length {} expectedOverread {}",
-          alignment,
+          "directIo {} offset {} length {} expectedOverread {}",
+          directIo,
           offset,
           length,
           expectedOverread);
@@ -333,31 +338,32 @@ TEST_F(DataInputTest, alignment) {
     return alignUp(offset + length, align) - alignDown(offset, align) - length;
   };
 
+  constexpr uint64_t kPageSize = velox::memory::AllocationTraits::kPageSize;
   std::vector<TestParam> testSettings = {
-      // offset 4100 → alignDown=4096, alignUp(4300)=8192 → read=4096,
-      // overread=8192-4096-200=3896
-      {4'096, 4'100, 200, expectedOverread(4'096, 4'100, 200)},
+      // O_DIRECT files are page-aligned. offset 4100 -> alignDown=4096,
+      // alignUp(4300)=8192 -> overread=8192-4096-200=3896.
+      {true, 4'100, 200, expectedOverread(kPageSize, 4'100, 200)},
 
-      // offset already aligned → alignDown=4096, alignUp(4296)=8192 →
-      // overread=8192-4096-200=3896
-      {4'096, 4'096, 200, expectedOverread(4'096, 4'096, 200)},
+      // Offset already aligned.
+      {true, 4'096, 200, expectedOverread(kPageSize, 4'096, 200)},
 
-      // offset 0, length 100 → alignDown=0, alignUp(100)=4096 →
-      // overread=3996
-      {4'096, 0, 100, expectedOverread(4'096, 0, 100)},
+      // Offset 0, short length.
+      {true, 0, 100, expectedOverread(kPageSize, 0, 100)},
 
-      // alignment=1 → no padding, overread=0.
-      {1, 4'100, 200, 0},
-
-      // alignment=512, offset 600 → alignDown=512, alignUp(800)=1024 →
-      // overread=1024-512-200=312
-      {512, 600, 200, expectedOverread(512, 600, 200)},
+      // Buffered files use byte alignment and do not overread for alignment.
+      {false, 4'100, 200, 0},
   };
 
   for (const auto& testData : testSettings) {
     SCOPED_TRACE(testData.debugString());
+    std::unique_ptr<velox::InMemoryReadFile> file;
+    if (testData.directIo) {
+      file = std::make_unique<DirectIoInMemoryReadFile>(data);
+    } else {
+      file = createFile(data);
+    }
     auto stats = std::make_shared<velox::io::IoStatistics>();
-    auto options = makeOptions(testData.alignment);
+    auto options = makeOptions();
     options.ioStats = stats;
 
     DirectDataInput input(file.get(), options);
@@ -427,7 +433,7 @@ TEST_F(DataInputTest, intraGroupCoalescing) {
   for (const auto& testData : testSettings) {
     SCOPED_TRACE(testData.debugString());
     auto stats = std::make_shared<velox::io::IoStatistics>();
-    auto options = makeOptions(/*alignment=*/1, testData.maxCoalesceDistance);
+    auto options = makeOptions(testData.maxCoalesceDistance);
     options.ioStats = stats;
     DirectDataInput input(file.get(), options);
 
@@ -457,7 +463,7 @@ DEBUG_ONLY_TEST_F(DataInputTest, coalescesDuplicateRegions) {
   }
   auto file = createFile(data);
 
-  DirectDataInput input(file.get(), makeOptions(/*alignment=*/1));
+  DirectDataInput input(file.get(), makeOptions());
   input.reserve(4);
   input.startGroup();
   const auto duplicate0 = input.enqueue({100, 50});
@@ -533,7 +539,7 @@ TEST_F(DataInputTest, crossGroupCoalescing) {
   for (const auto& testData : testSettings) {
     SCOPED_TRACE(testData.debugString());
     auto stats = std::make_shared<velox::io::IoStatistics>();
-    auto options = makeOptions(/*alignment=*/1, testData.maxCoalesceDistance);
+    auto options = makeOptions(testData.maxCoalesceDistance);
     options.ioStats = stats;
     DirectDataInput input(file.get(), options);
 
@@ -581,8 +587,7 @@ TEST_F(DataInputTest, rejectsInvalidGroupBoundaries) {
   for (const auto& testData : testSettings) {
     SCOPED_TRACE(testData.name);
     DirectDataInput input(
-        file.get(),
-        makeOptions(/*alignment=*/1, /*maxCoalesceDistance=*/1'000));
+        file.get(), makeOptions(/*maxCoalesceDistance=*/1'000));
 
     uint32_t totalRegions = 0;
     for (const auto& group : testData.groups) {
@@ -774,8 +779,7 @@ TEST_F(DataInputTest, noCoalesceDistantRequests) {
   }
   auto file = createFile(data);
 
-  DirectDataInput input(
-      file.get(), makeOptions(/*alignment=*/1, /*maxCoalesceDistance=*/10));
+  DirectDataInput input(file.get(), makeOptions(/*maxCoalesceDistance=*/10));
   input.reserve(2);
   input.startGroup();
   input.enqueue({100, 50});
@@ -801,7 +805,6 @@ TEST_F(DataInputTest, maxCoalesceDistanceCap) {
   auto stats = std::make_shared<velox::io::IoStatistics>();
   DirectDataInput::Options options;
   options.pool = pool_.get();
-  options.executor = executor_.get();
   options.ioStats = stats;
   options.maxCoalesceDistance = 1'000'000;
 
@@ -830,19 +833,11 @@ TEST_F(DataInputTest, invalidOptions) {
   nullPool.pool = nullptr;
   NIMBLE_ASSERT_THROW(DirectDataInput(file.get(), nullPool), "");
 
-  auto nullExecutor = validOptions;
-  nullExecutor.executor = nullptr;
-  NIMBLE_ASSERT_THROW(DirectDataInput(file.get(), nullExecutor), "");
-
   auto nullIoStats = validOptions;
   nullIoStats.ioStats = nullptr;
   NIMBLE_ASSERT_THROW(DirectDataInput(file.get(), nullIoStats), "");
 
   NIMBLE_ASSERT_THROW(DirectDataInput(nullptr, validOptions), "");
-
-  auto badAlignment = validOptions;
-  badAlignment.alignment = 3;
-  NIMBLE_ASSERT_THROW(DirectDataInput(file.get(), badAlignment), "power of 2");
 }
 
 DEBUG_ONLY_TEST_F(DataInputTest, readError) {
@@ -850,26 +845,143 @@ DEBUG_ONLY_TEST_F(DataInputTest, readError) {
   for (int i = 0; i < 10'000; ++i) {
     data[i] = static_cast<char>(i % 256);
   }
-  auto file = createFile(data);
+  auto file = std::make_unique<FailingPreadvInMemoryReadFile>(data);
 
-  DirectDataInput input(
-      file.get(), makeOptions(/*alignment=*/1, /*maxCoalesceDistance=*/10));
+  DirectDataInput input(file.get(), makeOptions(/*maxCoalesceDistance=*/10));
   input.reserve(2);
   input.startGroup();
   input.enqueue({100, 50});
   input.startGroup();
   input.enqueue({5'000, 50});
 
-  std::atomic_bool injected{false};
-  SCOPED_TESTVALUE_SET(
-      "facebook::nimble::DirectDataInput::executeIoGroups",
-      std::function<void(DirectDataInput*)>([&](DirectDataInput*) {
-        if (!injected.exchange(true)) {
-          NIMBLE_FAIL("Injected pread failure");
-        }
-      }));
+  NIMBLE_ASSERT_THROW(input.load(), "Injected preadv failure");
+}
 
-  NIMBLE_ASSERT_THROW(input.load(), "Injected pread failure");
+TEST_F(DataInputTest, loadTracksLocalReadModeStats) {
+  constexpr uint64_t kPageSize = velox::memory::AllocationTraits::kPageSize;
+  std::string data(8 * kPageSize, '\0');
+  for (size_t i = 0; i < data.size(); ++i) {
+    data[i] = static_cast<char>((i * 131) % 256);
+  }
+  auto tempFile = velox::common::testutil::TempFilePath::create();
+  {
+    velox::LocalWriteFile writeFile(
+        tempFile->getPath(),
+        /*shouldCreateParentDirectories=*/false,
+        /*shouldThrowOnFileAlreadyExists=*/false);
+    writeFile.append(data);
+    writeFile.close();
+  }
+
+  const std::vector<std::vector<std::pair<uint64_t, uint64_t>>> groups = {
+      {{100, 200}},
+      {{kPageSize + 10, 1'000}},
+      {{3 * kPageSize, 4'096}},
+      {{7 * kPageSize, 100}},
+  };
+  constexpr uint64_t kPayloadBytes = 200 + 1'000 + 4'096 + 100;
+  constexpr uint64_t kDirectReadBytes = 4 * kPageSize;
+
+  struct TestCase {
+    const char* name;
+    bool bufferIo;
+    bool useIoUring;
+    uint64_t expectedReadBytes;
+    uint64_t expectedOverreadBytes;
+    uint64_t expectedIoUringReadCalls;
+    uint64_t expectedIoUringRegions;
+  };
+
+  const std::vector<TestCase> testCases = {
+      {
+          "buffered",
+          /*bufferIo=*/true,
+          /*useIoUring=*/false,
+          /*expectedReadBytes=*/kPayloadBytes,
+          /*expectedOverreadBytes=*/0,
+          /*expectedIoUringReadCalls=*/0,
+          /*expectedIoUringRegions=*/0,
+      },
+      {
+          "direct",
+          /*bufferIo=*/false,
+          /*useIoUring=*/false,
+          /*expectedReadBytes=*/kDirectReadBytes,
+          /*expectedOverreadBytes=*/kDirectReadBytes - kPayloadBytes,
+          /*expectedIoUringReadCalls=*/0,
+          /*expectedIoUringRegions=*/0,
+      },
+      {
+          "directIoUring",
+          /*bufferIo=*/false,
+          /*useIoUring=*/true,
+          /*expectedReadBytes=*/kDirectReadBytes,
+          /*expectedOverreadBytes=*/kDirectReadBytes - kPayloadBytes,
+          /*expectedIoUringReadCalls=*/1,
+          /*expectedIoUringRegions=*/groups.size(),
+      },
+  };
+
+  for (const auto& testCase : testCases) {
+    SCOPED_TRACE(testCase.name);
+    velox::ThreadLocalIoUringReader::testingClear();
+    uint64_t numIoUringReaders{0};
+    ASSERT_EQ(velox::getIoUringReaderStats(numIoUringReaders).readCalls, 0);
+    ASSERT_EQ(numIoUringReaders, 0);
+
+    auto file = std::make_unique<velox::LocalReadFile>(
+        tempFile->getPath(),
+        /*executor=*/nullptr,
+        testCase.bufferIo,
+        testCase.useIoUring);
+
+    auto stats = std::make_shared<velox::io::IoStatistics>();
+    auto options = makeOptions(/*maxCoalesceDistance=*/0);
+    options.ioStats = stats;
+    DirectDataInput input(file.get(), options);
+    uint32_t totalRegions = 0;
+    for (const auto& group : groups) {
+      totalRegions += group.size();
+    }
+    input.reserve(totalRegions);
+    std::vector<std::pair<uint32_t, std::pair<uint64_t, uint64_t>>> indices;
+    for (const auto& group : groups) {
+      input.startGroup();
+      for (const auto& [offset, length] : group) {
+        indices.emplace_back(
+            input.enqueue({offset, length}), std::make_pair(offset, length));
+      }
+    }
+
+    auto handle = input.load();
+
+    for (const auto& [idx, region] : indices) {
+      EXPECT_EQ(
+          refData(input.bufferRef(idx)),
+          data.substr(region.first, region.second));
+    }
+    EXPECT_EQ(file->bytesRead(), testCase.expectedReadBytes);
+    EXPECT_EQ(stats->rawBytesRead(), kPayloadBytes);
+    EXPECT_EQ(stats->rawOverreadBytes(), testCase.expectedOverreadBytes);
+    EXPECT_EQ(stats->read().count(), groups.size());
+    EXPECT_EQ(stats->read().sum(), testCase.expectedReadBytes);
+
+    const auto ioUringStats = velox::getIoUringReaderStats(numIoUringReaders);
+    EXPECT_EQ(ioUringStats.readCalls, testCase.expectedIoUringReadCalls);
+    EXPECT_EQ(ioUringStats.regions, testCase.expectedIoUringRegions);
+    if (testCase.useIoUring) {
+      EXPECT_EQ(numIoUringReaders, 1);
+      EXPECT_EQ(ioUringStats.batches, 1);
+      EXPECT_EQ(ioUringStats.minRegionsPerRead, groups.size());
+      EXPECT_EQ(ioUringStats.maxRegionsPerRead, groups.size());
+      EXPECT_EQ(ioUringStats.minBatchSize, groups.size());
+      EXPECT_EQ(ioUringStats.maxBatchSize, groups.size());
+    } else {
+      EXPECT_EQ(numIoUringReaders, 0);
+      EXPECT_EQ(ioUringStats.batches, 0);
+    }
+  }
+  velox::ThreadLocalIoUringReader::testingClear();
 }
 
 } // namespace

--- a/dwio/nimble/velox/index/NimbleIndexProjector.cpp
+++ b/dwio/nimble/velox/index/NimbleIndexProjector.cpp
@@ -66,7 +66,8 @@ std::unique_ptr<DataInput> createDataInput(
   DirectDataInput::Options dataInputOptions;
   dataInputOptions.pool = &options.memoryPool();
   dataInputOptions.ioStats = options.dataIoStats();
-  dataInputOptions.executor = options.ioExecutor().get();
+  dataInputOptions.maxCoalesceDistance = options.maxCoalesceDistance();
+  dataInputOptions.maxCoalesceBytes = options.maxCoalesceBytes();
   return std::make_unique<DirectDataInput>(
       fileHandle.file.get(), dataInputOptions);
 }

--- a/dwio/nimble/velox/index/NimbleIndexProjector.h
+++ b/dwio/nimble/velox/index/NimbleIndexProjector.h
@@ -275,8 +275,8 @@ class NimbleIndexProjector {
   // metadata for selected stripes, and populates ctx_.plan.
   void prepareStripes();
 
-  // Enqueues all projected streams from ctx_.plan into DataInput
-  // and issues a single coalesced load() call.
+  // Enqueues all projected streams from ctx_.plan into DataInput and issues a
+  // single coalesced load() call.
   void loadStripes();
 
   // Serializes each stripe's loaded streams, builds per-request results,

--- a/dwio/nimble/velox/index/tests/NimbleIndexProjectorTest.cpp
+++ b/dwio/nimble/velox/index/tests/NimbleIndexProjectorTest.cpp
@@ -32,8 +32,11 @@
 #include "dwio/nimble/velox/VeloxWriter.h"
 
 #include "velox/common/caching/FileIds.h"
+#include "velox/common/file/IoUringReader.h"
+#include "velox/common/file/LocalFile.h"
 #include "velox/common/io/IoStatistics.h"
 #include "velox/common/memory/Memory.h"
+#include "velox/common/testutil/TempFilePath.h"
 #include "velox/serializers/KeyEncoder.h"
 #include "velox/vector/tests/utils/VectorMaker.h"
 
@@ -160,10 +163,16 @@ class NimbleIndexProjectorTest : public ::testing::TestWithParam<TestParam> {
   velox::FileHandle makeFileHandle() {
     auto readFile =
         std::make_shared<InMemoryReadFile>(std::string_view(sinkData_));
+    return makeFileHandle(std::move(readFile), "test_file");
+  }
+
+  velox::FileHandle makeFileHandle(
+      std::shared_ptr<velox::ReadFile> readFile,
+      std::string_view id) {
     return velox::FileHandle{
         std::move(readFile),
-        velox::StringIdLease(velox::fileIds(), "test_file"),
-        velox::StringIdLease(velox::fileIds(), "test_group")};
+        velox::StringIdLease(velox::fileIds(), id),
+        velox::StringIdLease(velox::fileIds(), id)};
   }
 
   std::unique_ptr<NimbleIndexProjector> createProjector(
@@ -171,10 +180,23 @@ class NimbleIndexProjectorTest : public ::testing::TestWithParam<TestParam> {
       bool setDataIoStats = true,
       bool setMetadataIoStats = true,
       bool setIndexIoStats = true) {
+    return createProjectorWithFileHandle(
+        projectedSubfields,
+        makeFileHandle(),
+        setDataIoStats,
+        setMetadataIoStats,
+        setIndexIoStats);
+  }
+
+  std::unique_ptr<NimbleIndexProjector> createProjectorWithFileHandle(
+      const std::vector<Subfield>& projectedSubfields,
+      velox::FileHandle fileHandle,
+      bool setDataIoStats = true,
+      bool setMetadataIoStats = true,
+      bool setIndexIoStats = true) {
     dataIoStats_ = std::make_shared<velox::io::IoStatistics>();
     metadataIoStats_ = std::make_shared<velox::io::IoStatistics>();
     indexIoStats_ = std::make_shared<velox::io::IoStatistics>();
-    auto fileHandle = makeFileHandle();
     dwio::common::ReaderOptions readerOptions(leafPool_.get());
     if (setDataIoStats) {
       readerOptions.setDataIoStats(dataIoStats_);
@@ -976,6 +998,166 @@ TEST_P(NimbleIndexProjectorTest, stats) {
     EXPECT_EQ(proj->stats().numProjectedRows, 0);
     EXPECT_EQ(dataIoStats_->rawBytesRead(), 0);
   }
+}
+
+TEST_P(NimbleIndexProjectorTest, localReadModeStats) {
+  auto rowType = ROW({"key", "value"}, {BIGINT(), INTEGER()});
+
+  constexpr int numBatches = 4;
+  constexpr int rowsPerBatch = 128;
+  constexpr int numRows = numBatches * rowsPerBatch;
+  std::vector<RowVectorPtr> inputBatches;
+  inputBatches.reserve(numBatches);
+  for (int batch = 0; batch < numBatches; ++batch) {
+    std::vector<int64_t> keys(rowsPerBatch);
+    std::vector<int32_t> values(rowsPerBatch);
+    for (int row = 0; row < rowsPerBatch; ++row) {
+      const auto key = batch * rowsPerBatch + row;
+      keys[row] = key;
+      values[row] = key * 10;
+    }
+    inputBatches.emplace_back(vectorMaker_->rowVector(
+        {"key", "value"},
+        {vectorMaker_->flatVector<int64_t>(keys),
+         vectorMaker_->flatVector<int32_t>(values)}));
+  }
+  writeData(inputBatches, {"key"}, {}, /*stripeSize=*/1);
+
+  auto tempFile = velox::common::testutil::TempFilePath::create();
+  {
+    velox::LocalWriteFile writeFile(
+        tempFile->getPath(),
+        /*shouldCreateParentDirectories=*/false,
+        /*shouldThrowOnFileAlreadyExists=*/false);
+    writeFile.append(sinkData_);
+    writeFile.close();
+  }
+
+  std::vector<Subfield> subfields;
+  subfields.emplace_back("value");
+
+  struct TestCase {
+    const char* name;
+    bool bufferIo;
+    bool useIoUring;
+  };
+  const std::vector<TestCase> testCases = {
+      {"buffered", /*bufferIo=*/true, /*useIoUring=*/false},
+      {"direct", /*bufferIo=*/false, /*useIoUring=*/false},
+      {"directIoUring", /*bufferIo=*/false, /*useIoUring=*/true},
+  };
+
+  for (const auto& testCase : testCases) {
+    SCOPED_TRACE(testCase.name);
+    velox::ThreadLocalIoUringReader::testingClear();
+    uint64_t numIoUringReaders{0};
+    EXPECT_EQ(velox::getIoUringReaderStats(numIoUringReaders).readCalls, 0);
+    EXPECT_EQ(numIoUringReaders, 0);
+
+    auto tabletReadFile = std::make_shared<velox::LocalReadFile>(
+        tempFile->getPath(),
+        /*executor=*/nullptr,
+        /*bufferIo=*/true,
+        /*useIoUring=*/false);
+    auto dataReadFile = std::make_shared<velox::LocalReadFile>(
+        tempFile->getPath(),
+        /*executor=*/nullptr,
+        testCase.bufferIo,
+        testCase.useIoUring);
+    const auto fileName = dataReadFile->getName();
+    dwio::common::ReaderOptions tabletReaderOptions(leafPool_.get());
+    tabletReaderOptions.setFileFormat(FileFormat::NIMBLE);
+    tabletReaderOptions.setLoadClusterIndex(true);
+    tabletReaderOptions.setCacheData(false);
+    tabletReaderOptions.setCacheMetadata(GetParam().cacheMetadata);
+    tabletReaderOptions.setPinMetadata(GetParam().pinMetadata);
+    tabletReaderOptions.setIOExecutor(ioExecutor_);
+    ensureTabletReaderCache();
+    (void)tabletReaderCache_->get(
+        tabletReadFile, TabletReader::configureOptions(tabletReaderOptions));
+    auto projector = createProjectorWithFileHandle(
+        subfields, makeFileHandle(dataReadFile, fileName));
+    const auto fileBytesBeforeProject = dataReadFile->bytesRead();
+
+    NimbleIndexProjector::Request request;
+    request.keyBounds = {makeRangeLookup(rowType, {"key"}, 0, numRows)};
+    auto result = projector->project(request, {});
+
+    ASSERT_EQ(result.responses.size(), 1);
+    ASSERT_EQ(result.responses[0].slices.size(), numBatches);
+    std::vector<folly::IOBuf> ownedSlices;
+    std::vector<std::string_view> serializedBatches;
+    ownedSlices.reserve(numBatches);
+    serializedBatches.reserve(numBatches);
+    for (const auto& slice : result.responses[0].slices) {
+      const auto rowRange = readEmbeddedRowRange(slice);
+      EXPECT_EQ(rowRange, RowRange(0, rowsPerBatch));
+      ownedSlices.push_back(slice.cloneCoalescedAsValue());
+      serializedBatches.emplace_back(
+          reinterpret_cast<const char*>(ownedSlices.back().data()),
+          ownedSlices.back().length());
+    }
+
+    DeserializerOptions deserOptions;
+    deserOptions.hasHeader = true;
+    Deserializer deserializer(
+        projector->projectedNimbleType(), leafPool_.get(), deserOptions);
+    VectorPtr output;
+    deserializer.deserialize(serializedBatches, output);
+    ASSERT_EQ(output->size(), static_cast<uint32_t>(numRows));
+    auto* rowVec = output->as<RowVector>();
+    auto* valueVec = rowVec->childAt(0)->as<FlatVector<int32_t>>();
+    for (uint32_t row = 0; row < numRows; ++row) {
+      EXPECT_EQ(valueVec->valueAt(row), static_cast<int32_t>(row * 10))
+          << "row=" << row;
+    }
+
+    EXPECT_EQ(projector->stats().numReadStripes, numBatches);
+    EXPECT_EQ(projector->stats().numReadRows, numRows);
+    EXPECT_EQ(projector->stats().numProjectedRows, numRows);
+    EXPECT_GT(projector->stats().numOutputBytes, 0);
+
+    const auto physicalBytes = dataIoStats_->read().sum();
+    const auto payloadBytes = dataIoStats_->rawBytesRead();
+    EXPECT_GT(dataIoStats_->read().count(), 0);
+    EXPECT_GT(payloadBytes, 0);
+    EXPECT_EQ(
+        dataReadFile->bytesRead() - fileBytesBeforeProject, physicalBytes);
+    EXPECT_EQ(dataIoStats_->rawOverreadBytes(), physicalBytes - payloadBytes);
+    EXPECT_GE(physicalBytes, payloadBytes);
+    uint64_t alignment{0};
+    EXPECT_EQ(dataReadFile->directIo(alignment), !testCase.bufferIo);
+    if (!testCase.bufferIo) {
+      EXPECT_EQ(physicalBytes % alignment, 0);
+      EXPECT_GE(physicalBytes, payloadBytes);
+    } else {
+      EXPECT_EQ(alignment, 1);
+    }
+    uint64_t tabletAlignment{0};
+    EXPECT_FALSE(tabletReadFile->directIo(tabletAlignment));
+    EXPECT_EQ(tabletAlignment, 1);
+
+    const auto ioUringStats = velox::getIoUringReaderStats(numIoUringReaders);
+    if (testCase.useIoUring) {
+      EXPECT_EQ(numIoUringReaders, 1);
+      EXPECT_EQ(ioUringStats.readCalls, 1);
+      EXPECT_EQ(ioUringStats.regions, dataIoStats_->read().count());
+      EXPECT_EQ(ioUringStats.batches, 1);
+      EXPECT_EQ(ioUringStats.minRegionsPerRead, dataIoStats_->read().count());
+      EXPECT_EQ(ioUringStats.maxRegionsPerRead, dataIoStats_->read().count());
+      EXPECT_EQ(ioUringStats.minBatchSize, dataIoStats_->read().count());
+      EXPECT_EQ(ioUringStats.maxBatchSize, dataIoStats_->read().count());
+    } else {
+      EXPECT_EQ(numIoUringReaders, 0);
+      EXPECT_EQ(ioUringStats.readCalls, 0);
+      EXPECT_EQ(ioUringStats.regions, 0);
+      EXPECT_EQ(ioUringStats.batches, 0);
+    }
+  }
+  velox::ThreadLocalIoUringReader::testingClear();
+  EXPECT_EQ(tabletReaderCache_->stats().numElements, 1);
+  EXPECT_EQ(tabletReaderCache_->stats().numLookups, 2 * testCases.size());
+  EXPECT_EQ(tabletReaderCache_->stats().numHits, 2 * testCases.size() - 1);
 }
 
 TEST_P(NimbleIndexProjectorTest, statsToString) {


### PR DESCRIPTION
Summary:

Use the positioned `ReadFile::preadv(...)` batch overload from `DirectDataInput` so local direct-I/O files can take the native io_uring batch path and other files fall back to the default loop over `pread`. Split `TabletReader` data and metadata/index read handles so direct data reads can use direct I/O and io_uring while footer, metadata, and index reads use a buffered handle. Add benchmark plumbing for `--use_io_uring` and update focused unit coverage.

Reviewed By: tanjialiang

Differential Revision: D107930292


