### PR TITLE
feat(selective): Multi-chunk dictionary index reading

### DIFF
--- a/dwio/nimble/encodings/common/EncodingUtils.h
+++ b/dwio/nimble/encodings/common/EncodingUtils.h
@@ -212,7 +212,7 @@ struct DefaultEncodingTrait {
   }
 };
 
-/// Reads dictionary indices (not decoded values) from an encoding.
+/// Dispatches readIndicesWithVisitor to the correct encoding type.
 /// Supports DictionaryEncoding, NullableEncoding, and MainlyConstantEncoding
 /// wrapping DictionaryEncoding. Currently only supports string
 /// (std::string_view) dictionary encodings. Non-legacy encodings only.

--- a/dwio/nimble/encodings/tests/EncodingTest.cpp
+++ b/dwio/nimble/encodings/tests/EncodingTest.cpp
@@ -1234,7 +1234,7 @@ class DictionaryApiTypedTest : public ::testing::Test {
   std::unique_ptr<nimble::Encoding> encodeMainlyConstantDictionary(
       const std::vector<T>& values) {
     auto serialized = serializeMainlyConstantDictionary(values, *buffer_);
-    return decodeEncoding(serialized);
+    return decodeEncoding(serialized, /*preserveDictionaryEncoding=*/true);
   }
 
   /// Encodes data as Nullable wrapping MainlyConstant wrapping Dictionary.
@@ -1281,7 +1281,9 @@ class DictionaryApiTypedTest : public ::testing::Test {
     nimble::encoding::writeString(serializedMC, pos);
     nimble::encoding::writeBytes(serializedNulls, pos);
 
-    return decodeEncoding(std::string_view(reserved, encodingSize));
+    return decodeEncoding(
+        std::string_view(reserved, encodingSize),
+        /*preserveDictionaryEncoding=*/true);
   }
 
   /// Serializes values as RLE wrapping Dictionary into outputBuffer.
@@ -2468,6 +2470,54 @@ TYPED_TEST(DictionaryApiTypedTest, rleSkipAndMaterializeAlternating) {
   }
 }
 
+// Verifies that preserveDictionaryEncoding=false forces the flat values path
+// when the inner encoding is dictionary-enabled. The encoding should behave
+// identically to a non-dict RLE — materialize returns correct values but
+// dictionaryEnabled() is false.
+TYPED_TEST(DictionaryApiTypedTest, rleDictionaryDisabledByOption) {
+  using T = TypeParam;
+  std::vector<T> data;
+  if constexpr (std::is_same_v<T, std::string_view>) {
+    this->stringPool_ = {"alpha", "bravo"};
+    for (int i = 0; i < 5; ++i) {
+      data.push_back(std::string_view(this->stringPool_[0]));
+    }
+    for (int i = 0; i < 3; ++i) {
+      data.push_back(std::string_view(this->stringPool_[1]));
+    }
+  } else {
+    for (int i = 0; i < 5; ++i) {
+      data.push_back(T(10));
+    }
+    for (int i = 0; i < 3; ++i) {
+      data.push_back(T(20));
+    }
+  }
+
+  // Serialize as RLE→Dictionary.
+  auto serialized = this->serializeRleDictionary(data, *this->buffer_);
+
+  // Decode without preserveDictionaryEncoding — should use flat values path.
+  nimble::Encoding::Options options{};
+  auto encoding = nimble::EncodingFactory(options).create(
+      *this->pool_, serialized, [this](uint32_t size) {
+        this->stringBuffers_.push_back(
+            velox::AlignedBuffer::allocate<char>(size, this->pool_.get()));
+        return this->stringBuffers_.back()->template asMutable<void>();
+      });
+
+  EXPECT_FALSE(encoding->dictionaryEnabled());
+
+  // Materialize should still produce correct values.
+  using PhysicalType = typename nimble::TypeTraits<T>::physicalType;
+  std::vector<PhysicalType> materialized(data.size());
+  encoding->materialize(data.size(), materialized.data());
+  for (size_t i = 0; i < data.size(); ++i) {
+    EXPECT_EQ(materialized[i], reinterpret_cast<const PhysicalType&>(data[i]))
+        << "row " << i;
+  }
+}
+
 TYPED_TEST(DictionaryApiTypedTest, materializeIndicesRleDictionaryFuzz) {
   using T = TypeParam;
 
@@ -2592,7 +2642,8 @@ TYPED_TEST(DictionaryApiTypedTest, constantDictionaryBasics) {
           span),
       std::make_unique<TestTrivialEncodingSelectionPolicy<T>>(false, false)};
   auto serialized = nimble::ConstantEncoding<T>::encode(sel, span, encBuf);
-  auto encoding = this->decodeEncoding(serialized);
+  auto encoding =
+      this->decodeEncoding(serialized, /*preserveDictionaryEncoding=*/true);
 
   EXPECT_TRUE(encoding->dictionaryEnabled());
   EXPECT_EQ(encoding->dictionarySize(), 1);
@@ -2631,7 +2682,8 @@ TYPED_TEST(DictionaryApiTypedTest, buildAlphabetConstant) {
           span),
       std::make_unique<TestTrivialEncodingSelectionPolicy<T>>(false, false)};
   auto serialized = nimble::ConstantEncoding<T>::encode(sel, span, encBuf);
-  auto encoding = this->decodeEncoding(serialized);
+  auto encoding =
+      this->decodeEncoding(serialized, /*preserveDictionaryEncoding=*/true);
 
   auto alphabet = nimble::buildEncodingDictionaryAlphabet<T>(encoding.get());
   ASSERT_EQ(alphabet.size(), 1);
@@ -2674,7 +2726,8 @@ TYPED_TEST(DictionaryApiTypedTest, mainlyConstantWithSingleOtherValue) {
     } else {
       auto serialized =
           this->serializeMainlyConstantWithConstantOthers(data, mcBuffer);
-      encoding = this->decodeEncoding(serialized);
+      encoding =
+          this->decodeEncoding(serialized, /*preserveDictionaryEncoding=*/true);
     }
 
     ASSERT_TRUE(encoding->dictionaryEnabled());
@@ -2819,7 +2872,8 @@ TYPED_TEST(DictionaryApiTypedTest, mainlyConstantWithConstantLeafFuzz) {
     nimble::Buffer mcBuffer{*this->pool_};
     auto serialized =
         this->serializeMainlyConstantWithConstantOthers(data, mcBuffer);
-    auto encoding = this->decodeEncoding(serialized);
+    auto encoding =
+        this->decodeEncoding(serialized, /*preserveDictionaryEncoding=*/true);
 
     ASSERT_TRUE(encoding->dictionaryEnabled());
     ASSERT_EQ(encoding->dictionarySize(), 2);

--- a/dwio/nimble/velox/selective/ChunkedDecoder.cpp
+++ b/dwio/nimble/velox/selective/ChunkedDecoder.cpp
@@ -24,14 +24,14 @@
 
 #include <cstddef>
 
-using facebook::velox::common::testutil::TestValue;
-
 namespace facebook::nimble {
 
 using namespace facebook::velox;
+using velox::common::testutil::TestValue;
 
-void ChunkedDecoder::loadNextChunk(bool preserveDictionaryEncoding) {
-  invokeOnChunkLoad();
+bool ChunkedDecoder::loadNextChunk(
+    bool preserveDictionaryEncoding,
+    const ChunkBoundaryCallback& onChunkLoaded) {
   auto ret = ensureInput(kChunkHeaderSize);
   NIMBLE_CHECK(ret, "Failed to read chunk header");
   const auto [length, compressionType] = readChunkHeader(inputData_);
@@ -58,7 +58,8 @@ void ChunkedDecoder::loadNextChunk(bool preserveDictionaryEncoding) {
   };
   auto data = std::string_view(chunkData, chunkSize);
   if (preserveDictionaryEncoding) {
-    Encoding::Options options{.preserveDictionaryEncoding = true};
+    auto options = encodingFactory_->options();
+    options.preserveDictionaryEncoding = true;
     encoding_ =
         EncodingFactory(options).create(*pool_, data, stringBufferFactory);
   } else {
@@ -67,6 +68,7 @@ void ChunkedDecoder::loadNextChunk(bool preserveDictionaryEncoding) {
   remainingValues_ = encoding_->rowCount();
   NIMBLE_CHECK_GT(remainingValues_, 0);
   VLOG(1) << encoding_->debugString();
+  return onChunkLoaded();
 }
 
 bool ChunkedDecoder::ensureInput(int size) {
@@ -190,20 +192,24 @@ void ChunkedDecoder::nextIndices(
       incomingNulls);
 }
 
-void ChunkedDecoder::skip(int64_t numValues) {
-  NIMBLE_DCHECK_GE(numValues, 0);
+void ChunkedDecoder::skip(
+    int64_t numValues,
+    const ChunkBoundaryCallback& onChunkBoundary) {
+  NIMBLE_CHECK_GE(numValues, 0);
   if (numValues == 0) {
     return;
   }
 
   if (streamIndex_ != nullptr) {
-    skipWithIndex(numValues);
+    skipWithIndex(numValues, onChunkBoundary);
   } else {
-    skipWithoutIndex(numValues);
+    skipWithoutIndex(numValues, onChunkBoundary);
   }
 }
 
-void ChunkedDecoder::skipWithIndex(int64_t numValues) {
+void ChunkedDecoder::skipWithIndex(
+    int64_t numValues,
+    const ChunkBoundaryCallback& onChunkBoundary) {
   TestValue::adjust("facebook::nimble::ChunkedDecoder::skipWithIndex", this);
   NIMBLE_CHECK_GT(numValues, 0);
   // If we can skip within the current chunk, do so without seeking.
@@ -228,11 +234,10 @@ void ChunkedDecoder::skipWithIndex(int64_t numValues) {
     encoding_ = nullptr;
     remainingValues_ = 0;
     rowPosition_ = targetRow;
-    // Advance input buffer to the end.
     inputData_ += inputSize_;
     inputSize_ = 0;
-    // Exhaust the underlying input stream.
     input_->SkipInt64(std::numeric_limits<int64_t>::max());
+    onChunkBoundary();
     return;
   }
 
@@ -240,7 +245,7 @@ void ChunkedDecoder::skipWithIndex(int64_t numValues) {
   const auto location = streamIndex_->lookupChunk(targetRow);
 
   // Seek to the chunk and skip within it.
-  seekToChunk(location.chunkOffset);
+  seekToChunk(location.chunkOffset, onChunkBoundary);
   rowPosition_ = location.rowOffset;
 
   const uint32_t rowsToSkipInChunk = targetRow - rowPosition_;
@@ -249,10 +254,12 @@ void ChunkedDecoder::skipWithIndex(int64_t numValues) {
   advancePosition(rowsToSkipInChunk);
 }
 
-void ChunkedDecoder::skipWithoutIndex(int64_t numValues) {
+void ChunkedDecoder::skipWithoutIndex(
+    int64_t numValues,
+    const ChunkBoundaryCallback& onChunkBoundary) {
   while (numValues > 0) {
     if (FOLLY_UNLIKELY(remainingValues_ == 0)) {
-      loadNextChunk();
+      loadNextChunk(/*preserveDictionaryEncoding=*/false, onChunkBoundary);
     }
     if (numValues < remainingValues_) {
       encoding_->skip(numValues);
@@ -265,7 +272,9 @@ void ChunkedDecoder::skipWithoutIndex(int64_t numValues) {
   }
 }
 
-void ChunkedDecoder::seekToChunk(uint32_t offset) {
+void ChunkedDecoder::seekToChunk(
+    uint32_t offset,
+    const ChunkBoundaryCallback& onChunkBoundary) {
   // Use position provider to seek to the chunk offset
   const std::vector<uint64_t> offsets{offset};
   velox::dwio::common::PositionProvider positionProvider(offsets);
@@ -277,7 +286,7 @@ void ChunkedDecoder::seekToChunk(uint32_t offset) {
   remainingValues_ = 0;
 
   // Load the chunk at this position
-  loadNextChunk();
+  loadNextChunk(/*preserveDictionaryEncoding=*/false, onChunkBoundary);
 }
 
 std::optional<size_t> ChunkedDecoder::estimateRowCount() const {

--- a/dwio/nimble/velox/selective/ChunkedDecoder.h
+++ b/dwio/nimble/velox/selective/ChunkedDecoder.h
@@ -16,6 +16,8 @@
 
 #pragma once
 
+#include <functional>
+#include <optional>
 #include "dwio/nimble/common/ChunkHeader.h"
 #include "dwio/nimble/encodings/DictionaryEncoding.h"
 #include "dwio/nimble/encodings/MainlyConstantEncoding.h"
@@ -25,8 +27,27 @@
 #include "dwio/nimble/index/ChunkIndexGroup.h"
 #include "dwio/nimble/velox/selective/NimbleData.h"
 #include "velox/dwio/common/SeekableInputStream.h"
+#include "velox/dwio/common/SelectiveColumnReader.h"
 
 namespace facebook::nimble {
+
+/// Invoked when a chunk boundary is crossed during skip, ensureLoaded, or
+/// multi-chunk dictionary index reads. Returns true to continue processing
+/// subsequent chunks, or false to stop (e.g., when the new chunk's encoding
+/// is not dictionary-compatible and requires flat fallback).
+using ChunkBoundaryCallback = std::function<bool()>;
+
+/// Default chunk boundary callback that always returns true (continue
+/// processing). Used when the caller does not need to react to chunk
+/// transitions.
+inline const ChunkBoundaryCallback kNoopAtChunkBoundary = [] { return true; };
+
+/// Controls how accumulated string buffers are delivered to the reader after
+/// a chunk read. By default (nullptr), replaces the reader's string buffers.
+/// Callers that need to preserve existing string buffers (e.g., reactive
+/// fallback from dict to flat mid-read) pass an appending handler.
+using SaveStringBufferCallback =
+    std::function<void(std::vector<velox::BufferPtr>&&)>;
 
 class ChunkedDecoderTestHelper;
 
@@ -52,21 +73,12 @@ class ChunkedDecoder {
     NIMBLE_CHECK_NOT_NULL(encodingFactory_);
   }
 
-  /// Registers a callback invoked whenever loadNextChunk() loads a new chunk.
-  /// Used by StringColumnReader to invalidate dictionary state that is tied
-  /// to the current chunk's encoding and string buffers.
-  void setOnChunkLoad(std::function<void()> callback) {
-    onChunkLoad_ = std::move(callback);
-  }
-
-  /// Skip non null values.
-  void skip(int64_t numValues);
-
-  /// Skip non null values using index-based acceleration.
-  void skipWithIndex(int64_t numValues);
-
-  /// Skip non null values using sequential skipping.
-  void skipWithoutIndex(int64_t numValues);
+  /// Skips non-null values. The optional onChunkBoundary callback is invoked
+  /// whenever the skip crosses into a new chunk. This allows callers (e.g.,
+  /// StringColumnReader) to invalidate cached state like mergedAlphabet_.
+  void skip(
+      int64_t numValues,
+      const ChunkBoundaryCallback& onChunkBoundary = kNoopAtChunkBoundary);
 
   /// Decode nulls or in-map buffer values.
   void nextBools(uint64_t* data, int64_t count, const uint64_t* incomingNulls);
@@ -81,26 +93,56 @@ class ChunkedDecoder {
     return nullableValues_;
   }
 
+  /// Reads values using a visitor pattern, handling chunk transitions
+  /// automatically. The optional saveStringBuffersFn callback controls how
+  /// accumulated string buffers are delivered to the reader. By default,
+  /// replaces the reader's string buffers. Callers that need to preserve
+  /// existing string buffers (e.g., flat encoding fallback after a partial dict
+  /// read, where abandonDictionaryEncoding already placed string buffers)
+  /// pass an appending handler. readDictionaryIndices does not need this
+  /// because it reads dict indices (int32_t), not string values — no string
+  /// buffers are produced during dict index reads.
+  /// @param readOffset Starting position in nullsInReadRange_ for
+  ///   reading from the middle of a batch (e.g., flat encoding fallback after a
+  ///   partial dict read). Defaults to 0.
   template <typename DecoderVisitor>
-  void readWithVisitor(DecoderVisitor& visitor) {
+  void readWithVisitor(
+      DecoderVisitor& visitor,
+      velox::vector_size_t readOffset = 0,
+      const SaveStringBufferCallback& saveStringBuffersFn = nullptr) {
+    NIMBLE_CHECK(
+        readOffset == 0 || stringDecoderZeroCopy_,
+        "readOffset is only valid for dict→flat encoding fallback reads");
     const velox::RowSet rows(visitor.rows(), visitor.numRows());
     NIMBLE_DCHECK(std::is_sorted(rows.begin(), rows.end()));
     const auto numRows = visitor.numRows();
     ReadWithVisitorParams params{};
+    params.numScanned = readOffset;
     bool resultNullsPrepared{false};
-    // Allocate one extra byte (8 bits) for nulls to handle multi-chunk
-    // reading, where each chunk we need to align the result nulls to byte
-    // boundary then shift.
-    params.prepareResultNulls = [&resultNullsPrepared, &visitor, &rows] {
-      if (FOLLY_UNLIKELY(!resultNullsPrepared)) {
-        visitor.reader().prepareNulls(
-            rows, /*mayResize=*/true, /*extraBits=*/8);
-        resultNullsPrepared = true;
-      }
-    };
-    params.initReturnReaderNulls = [&visitor, &rows] {
-      visitor.reader().initReturnReaderNulls(rows);
-    };
+    if (readOffset > 0) {
+      // Flat encoding fallback (resuming mid-batch after an abandoned
+      // dictionary read). The dictionary phase already prepared the result
+      // null buffer and the return-nulls mode for the full output; this read
+      // only appends. Re-preparing here would clear/re-base the shared null
+      // buffer (wiping the dict portion's nulls) and re-evaluate the mode on
+      // the non-dense continuation row set. So both are no-ops — prepare once.
+      params.prepareResultNulls = [] {};
+      params.initReturnReaderNulls = [] {};
+    } else {
+      // Allocate one extra byte (8 bits) for nulls to handle multi-chunk
+      // reading, where each chunk we need to align the result nulls to byte
+      // boundary then shift.
+      params.prepareResultNulls = [&resultNullsPrepared, &visitor, &rows] {
+        if (FOLLY_UNLIKELY(!resultNullsPrepared)) {
+          visitor.reader().prepareNulls(
+              rows, /*hasNulls=*/true, /*extraRows=*/8);
+          resultNullsPrepared = true;
+        }
+      };
+      params.initReturnReaderNulls = [&visitor, &rows] {
+        visitor.reader().initReturnReaderNulls(rows);
+      };
+    }
     bool readerNullsMade{false};
     if (auto& nulls = visitor.reader().nullsInReadRange()) {
       // For flat map child columns, NimbleData::readNulls() may alias inMap_
@@ -125,7 +167,7 @@ class ChunkedDecoder {
         };
       }
       dispatchReadWithVisitorImpl<true>(
-          visitor, nulls->template as<uint64_t>(), params);
+          visitor, nulls->template as<uint64_t>(), params, saveStringBuffersFn);
     } else {
       params.makeReaderNulls = [&readerNullsMade, this, numRows, &visitor] {
         if (FOLLY_UNLIKELY(!readerNullsMade)) {
@@ -142,7 +184,8 @@ class ChunkedDecoder {
             .nullsInReadRange()
             ->template asMutable<uint64_t>();
       };
-      dispatchReadWithVisitorImpl<false>(visitor, /*nulls=*/nullptr, params);
+      dispatchReadWithVisitorImpl<false>(
+          visitor, /*nulls=*/nullptr, params, saveStringBuffersFn);
     }
   }
 
@@ -226,18 +269,21 @@ class ChunkedDecoder {
   /// TODO: Remove after column statistics are added.
   std::optional<size_t> estimateStringDataSize() const;
 
-  /// Ensures a chunk with remaining values is loaded. Loads the first chunk
-  /// if none has been loaded yet, or advances to the next chunk if the current
-  /// one is fully consumed. Called before inspecting the current encoding
-  /// (e.g., currentEncoding, dictionaryConvertible) so that the caller sees
-  /// the encoding and remainingValues of the chunk that will actually be read.
-  void ensureLoaded(bool preserveDictionaryEncoding = false) {
+  // Ensures a chunk with remaining values is loaded in the chunked decoder.
+  // Loads the first chunk if none has been loaded yet, or advances to the
+  // next chunk if the current one is fully consumed. Called before inspecting
+  // the current encoding (e.g., currentEncoding, dictionaryConvertible) so
+  // that the caller sees the encoding and remainingValues of the chunk that
+  // will actually be read.
+  void ensureLoaded(
+      bool preserveDictionaryEncoding = false,
+      const ChunkBoundaryCallback& onChunkBoundary = kNoopAtChunkBoundary) {
     if (encoding_ != nullptr && remainingValues_ != 0) {
       return;
     }
 
     if (hasMoreChunks()) {
-      loadNextChunk(preserveDictionaryEncoding);
+      loadNextChunk(preserveDictionaryEncoding, onChunkBoundary);
     }
   }
 
@@ -256,17 +302,29 @@ class ChunkedDecoder {
     return remainingValues_;
   }
 
-  /// Reads dictionary indices from the current chunk's encoding.
-  /// Non-legacy encodings only: requires stringDecoderZeroCopy_ == true.
+  // Reads dictionary indices across chunks, invoking onChunkBoundary at each
+  // chunk transition. The callback can extend the merged alphabet and refresh
+  // cached state. The callback returns true to continue reading with the new
+  // chunk's dictionary, or false to stop (e.g., when the new chunk is not
+  // dictionary-compatible and requires flat fallback).
+  //
+  // Uses a dedicated loop instead of readWithVisitorImpl to avoid the
+  // testNulls-based chunk transition in computeNextRowIndex, which counts
+  // non-nulls across chunk boundaries and produces incorrect index reads.
+  //
+  // Returns true if all requested rows were consumed. Returns false if
+  // reading stopped early at a chunk boundary (the callback returned false);
+  // in that case it advances the reader's readOffset_ to the boundary so the
+  // flat encoding fallback resumes the decode there.
   template <typename DictionaryVisitor>
-  void readDictionaryIndices(DictionaryVisitor& visitor) {
-    // Dictionary indices reading requires the non-legacy encoding path.
-    // callReadIndicesWithVisitor static_casts to DictionaryEncoding /
-    // NullableEncoding / MainlyConstantEncoding which only exist in the
-    // non-legacy path (stringDecoderZeroCopy_ == true).
+  bool readDictionaryIndices(
+      DictionaryVisitor& visitor,
+      const ChunkBoundaryCallback& onChunkBoundary) {
     NIMBLE_CHECK(
         stringDecoderZeroCopy_,
         "Dictionary indices reading requires non-legacy encoding path");
+    NIMBLE_CHECK_NOT_NULL(encoding_);
+
     const velox::RowSet rows(visitor.rows(), visitor.numRows());
     NIMBLE_DCHECK(std::is_sorted(rows.begin(), rows.end()));
     ReadWithVisitorParams params{};
@@ -276,8 +334,7 @@ class ChunkedDecoder {
     // boundary then shift.
     params.prepareResultNulls = [&resultNullsPrepared, &visitor, &rows] {
       if (FOLLY_UNLIKELY(!resultNullsPrepared)) {
-        visitor.reader().prepareNulls(
-            rows, /*mayResize=*/true, /*extraBits=*/8);
+        visitor.reader().prepareNulls(rows, /*hasNulls=*/true, /*extraRows=*/8);
         resultNullsPrepared = true;
       }
     };
@@ -307,15 +364,16 @@ class ChunkedDecoder {
           return nulls->template asMutable<uint64_t>();
         };
       }
-      readDictionaryIndicesImpl<true>(
-          visitor, nulls->template as<uint64_t>(), params);
+      return readDictionaryIndicesImpl<true>(
+          visitor, nulls->template as<uint64_t>(), onChunkBoundary, params);
     } else {
-      params.makeReaderNulls = [&readerNullsMade, this, &visitor] {
+      const auto numRows = visitor.numRows();
+      params.makeReaderNulls = [&readerNullsMade, this, numRows, &visitor] {
         if (FOLLY_UNLIKELY(!readerNullsMade)) {
           auto& nulls = visitor.reader().nullsInReadRange();
           if (!nulls) {
             nulls = velox::AlignedBuffer::allocate<bool>(
-                visitor.rowAt(visitor.numRows() - 1) + 1,
+                visitor.rowAt(numRows - 1) + 1,
                 pool_,
                 /*value=*/velox::bits::kNotNull);
           }
@@ -325,7 +383,8 @@ class ChunkedDecoder {
             .nullsInReadRange()
             ->template asMutable<uint64_t>();
       };
-      readDictionaryIndicesImpl<false>(visitor, /*nulls=*/nullptr, params);
+      return readDictionaryIndicesImpl<false>(
+          visitor, /*nulls=*/nullptr, onChunkBoundary, params);
     }
   }
 
@@ -335,51 +394,97 @@ class ChunkedDecoder {
   // streams are not part of the data stream but interact with the value
   // streams just like nulls. Not using this parameter causes a bug for
   // flatmap data shapes.
+
+  // Dedicated chunk iteration loop for dictionary index reads. Unlike
+  // readWithVisitorImpl, this handles chunk transitions explicitly at the
+  // top of the loop (for both kHasNulls and !kHasNulls paths) instead of
+  // relying on testNulls which counts non-nulls across chunk boundaries.
   template <bool kHasNulls, typename V>
-  void readDictionaryIndicesImpl(
+  bool readDictionaryIndicesImpl(
       V& visitor,
       const uint64_t* nulls,
+      const ChunkBoundaryCallback& onChunkBoundary,
       ReadWithVisitorParams& params) {
     constexpr bool kExtractToReader = std::
         is_same_v<typename V::Extract, velox::dwio::common::ExtractToReader>;
-    NIMBLE_CHECK_GT(remainingValues_, 0);
-    params.numScanned = 0;
     const auto numRows = visitor.numRows();
-    velox::vector_size_t numNulls{0};
-    velox::vector_size_t numNonNulls{0};
-    const auto endRowIndex = computeNextRowIndex<kHasNulls>(
-        visitor, nulls, params, numRows, numNulls, numNonNulls);
-    if (visitor.rowIndex() < endRowIndex) {
-      visitor.setRows(velox::RowSet(visitor.rows(), endRowIndex));
-      if (numNonNulls > 0) {
-        callReadIndicesWithVisitor(*encoding_, visitor, params);
-      } else if (!visitor.allowNulls()) {
-        visitor.setRowIndex(endRowIndex);
-      } else {
-        bool emitNullsRowByRow = true;
-        if constexpr (kExtractToReader) {
-          params.prepareResultNulls();
-          if (visitor.reader().returnReaderNulls()) {
-            auto numValues = endRowIndex - visitor.rowIndex();
-            visitor.setRowIndex(endRowIndex);
-            visitor.addNumValues(numValues);
-            emitNullsRowByRow = false;
+
+    std::vector<velox::BufferPtr> stringBuffers;
+    SCOPE_EXIT {
+      if (stringDecoderZeroCopy_) {
+        visitor.reader().setStringBuffers(std::move(stringBuffers));
+      }
+    };
+
+    while (visitor.rowIndex() < numRows) {
+      // Check for chunk exhaustion before computing the next row range.
+      // This is done unconditionally (for both kHasNulls and !kHasNulls)
+      // to avoid the testNulls path in computeNextRowIndex loading a new
+      // chunk mid-count, which would produce numNonNulls spanning two
+      // chunks and incorrect index reads.
+      if (FOLLY_UNLIKELY(remainingValues_ == 0)) {
+        loadNextChunk(/*preserveDictionaryEncoding=*/true);
+        if (!onChunkBoundary()) {
+          // The new chunk is not dictionary-compatible. readOffset_ has not
+          // moved during this read, so it still holds the read's start offset;
+          // adding params.numScanned (the rows consumed up to this chunk
+          // boundary) advances it to the boundary, where the flat encoding
+          // fallback resumes the decode.
+          //
+          // TODO: Make the decoder the single owner of readOffset_ — also
+          // advance it on the full-read path here instead of readWithDictionary
+          // doing readOffset_ += endReadRow, so the update is not split across
+          // the reader and the decoder.
+          visitor.reader().setReadOffset(
+              visitor.reader().readOffset() + params.numScanned);
+          return false;
+        }
+      }
+
+      velox::vector_size_t numNulls{0};
+      velox::vector_size_t numNonNulls{0};
+      const auto endRowIndex =
+          computeNextRowIndex<kHasNulls, /*kReadAllChunks=*/false>(
+              visitor, nulls, params, numRows, numNulls, numNonNulls);
+
+      if (visitor.rowIndex() < endRowIndex) {
+        visitor.setRows(velox::RowSet(visitor.rows(), endRowIndex));
+        if (numNonNulls > 0) {
+          callReadIndicesWithVisitor(*encoding_, visitor, params);
+        } else if (!visitor.allowNulls()) {
+          visitor.setRowIndex(endRowIndex);
+        } else {
+          bool emitNullsRowByRow = true;
+          if constexpr (kExtractToReader) {
+            params.prepareResultNulls();
+            if (visitor.reader().returnReaderNulls()) {
+              auto numValues = endRowIndex - visitor.rowIndex();
+              visitor.setRowIndex(endRowIndex);
+              visitor.addNumValues(numValues);
+              emitNullsRowByRow = false;
+            }
+          }
+          if (emitNullsRowByRow) {
+            bool atEnd = false;
+            while (!atEnd) {
+              visitor.processNull(atEnd);
+            }
           }
         }
-        if (emitNullsRowByRow) {
-          bool atEnd = false;
-          while (!atEnd) {
-            visitor.processNull(atEnd);
-          }
+        NIMBLE_CHECK_EQ(visitor.rowIndex(), endRowIndex);
+      }
+      advancePosition(numNonNulls);
+      params.numScanned += numNulls + numNonNulls;
+
+      if (stringDecoderZeroCopy_) {
+        stringBuffers.reserve(
+            stringBuffers.size() + currentStringBuffers_.size());
+        for (const auto& buf : currentStringBuffers_) {
+          stringBuffers.emplace_back(buf);
         }
       }
     }
-    advancePosition(numNonNulls);
-    params.numScanned += numNulls + numNonNulls;
-    if (stringDecoderZeroCopy_) {
-      visitor.reader().setStringBuffers(
-          {currentStringBuffers_.begin(), currentStringBuffers_.end()});
-    }
+    return true;
   }
 
   template <bool kHasMask>
@@ -440,7 +545,19 @@ class ChunkedDecoder {
     return allConsumed ? end - 1 : index;
   }
 
-  template <bool kHasNulls, typename V>
+  // Computes the end row index for the current chunk's read range.
+  //
+  // When kReadAllChunks is true (default, used by readWithVisitorImpl),
+  // the kHasNulls path calls lastNonNullIndex which may load new chunks via
+  // testNulls when remainingValues_ reaches 0. This allows the flat read
+  // path to transparently span chunks.
+  //
+  // When kReadAllChunks is false (used by readDictionaryIndicesImpl),
+  // the kHasNulls path caps at the current chunk's boundary using
+  // countNonNulls + findSetBit instead of lastNonNullIndex. This prevents
+  // testNulls from loading new chunks, which would bypass the dict path's
+  // onChunkBoundary callback.
+  template <bool kHasNulls, bool kReadAllChunks = true, typename V>
   velox::vector_size_t computeNextRowIndex(
       const V& visitor,
       const uint64_t* nulls,
@@ -450,49 +567,96 @@ class ChunkedDecoder {
       velox::vector_size_t& numNonNulls) {
     numNulls = 0;
     numNonNulls = 0;
+
     if constexpr (V::dense) {
+      // Dense: row positions equal indices, so endRowIndex is computed
+      // directly from numScanned without lower_bound.
       NIMBLE_DCHECK_EQ(visitor.currentRow(), params.numScanned);
       if constexpr (!kHasNulls) {
         numNonNulls =
             std::min<int64_t>(numRows - visitor.rowIndex(), remainingValues_);
         return visitor.rowIndex() + numNonNulls;
       }
-      return 1 +
-          lastNonNullIndex(
-                 nulls, params.numScanned, numRows, numNulls, numNonNulls);
-    }
-    auto end = visitor.rowAt(numRows - 1) + 1;
-    velox::vector_size_t chunkEnd;
-    if constexpr (kHasNulls) {
-      chunkEnd = 1 +
-          lastNonNullIndex(
-                     nulls, params.numScanned, end, numNulls, numNonNulls);
+      // Absolute end in the null bitmap. For a row set starting at 0 this
+      // equals numRows. For continuation reads (numScanned > 0 at start),
+      // this accounts for the offset so the bitmap is scanned correctly.
+      const auto nullsEnd = params.numScanned + (numRows - visitor.rowIndex());
+      if constexpr (kReadAllChunks) {
+        return 1 +
+            lastNonNullIndex(
+                   nulls, params.numScanned, nullsEnd, numNulls, numNonNulls);
+      }
+      // !kReadAllChunks: cap at the current chunk boundary.
+      numNonNulls = static_cast<velox::vector_size_t>(
+          velox::bits::countNonNulls(nulls, params.numScanned, nullsEnd));
+      velox::vector_size_t chunkEnd{0};
+      if (numNonNulls <= remainingValues_) {
+        chunkEnd = nullsEnd;
+      } else {
+        numNonNulls = remainingValues_;
+        chunkEnd = static_cast<velox::vector_size_t>(
+            1 +
+            velox::bits::findSetBit(
+                reinterpret_cast<const char*>(nulls),
+                params.numScanned,
+                nullsEnd,
+                remainingValues_));
+      }
+      numNulls = (chunkEnd - params.numScanned) - numNonNulls;
+      return visitor.rowIndex() + (chunkEnd - params.numScanned);
     } else {
-      chunkEnd = params.numScanned + remainingValues_;
-      numNonNulls =
-          std::min<int64_t>(end - params.numScanned, remainingValues_);
+      // Sparse: row positions are non-contiguous, so we need lower_bound
+      // to map chunkEnd back to a row index.
+      const auto endRow = visitor.rowAt(numRows - 1) + 1;
+      velox::vector_size_t chunkEnd{0};
+      if constexpr (!kHasNulls) {
+        chunkEnd = params.numScanned + remainingValues_;
+        numNonNulls =
+            std::min<int64_t>(endRow - params.numScanned, remainingValues_);
+      } else if constexpr (kReadAllChunks) {
+        chunkEnd = 1 +
+            lastNonNullIndex(
+                       nulls, params.numScanned, endRow, numNulls, numNonNulls);
+      } else {
+        // !kReadAllChunks: cap at the current chunk boundary.
+        numNonNulls = static_cast<velox::vector_size_t>(
+            velox::bits::countNonNulls(nulls, params.numScanned, endRow));
+        if (numNonNulls <= remainingValues_) {
+          chunkEnd = endRow;
+        } else {
+          numNonNulls = remainingValues_;
+          chunkEnd = static_cast<velox::vector_size_t>(
+              1 +
+              velox::bits::findSetBit(
+                  reinterpret_cast<const char*>(nulls),
+                  params.numScanned,
+                  endRow,
+                  remainingValues_));
+        }
+        numNulls = (chunkEnd - params.numScanned) - numNonNulls;
+      }
+      return std::lower_bound(
+                 visitor.rows() + visitor.rowIndex(),
+                 visitor.rows() + numRows,
+                 chunkEnd) -
+          visitor.rows();
     }
-
-    return std::lower_bound(
-               visitor.rows() + visitor.rowIndex(),
-               visitor.rows() + numRows,
-               chunkEnd) -
-        visitor.rows();
   }
 
-  /// Selects the encoding trait based on stringDecoderZeroCopy_ and
-  /// forwards to the fully-monomorphic readWithVisitorImpl.
+  // Selects the encoding trait based on stringDecoderZeroCopy_ and
+  // forwards to the fully-monomorphic readWithVisitorImpl.
   template <bool kHasNulls, typename V>
   void dispatchReadWithVisitorImpl(
       V& visitor,
       const uint64_t* nulls,
-      ReadWithVisitorParams& params) {
+      ReadWithVisitorParams& params,
+      const SaveStringBufferCallback& saveStringBuffersFn) {
     if (stringDecoderZeroCopy_) {
       readWithVisitorImpl<kHasNulls, DefaultEncodingTrait>(
-          visitor, nulls, params);
+          visitor, nulls, params, saveStringBuffersFn);
     } else {
       readWithVisitorImpl<kHasNulls, legacy::LegacyEncodingTrait>(
-          visitor, nulls, params);
+          visitor, nulls, params, saveStringBuffersFn);
     }
   }
 
@@ -500,12 +664,14 @@ class ChunkedDecoder {
   void readWithVisitorImpl(
       V& visitor,
       const uint64_t* nulls,
-      ReadWithVisitorParams& params) {
+      ReadWithVisitorParams& params,
+      const SaveStringBufferCallback& saveStringBuffersFn) {
     constexpr bool kExtractToReader = std::
         is_same_v<typename V::Extract, velox::dwio::common::ExtractToReader>;
     const auto numRows = visitor.numRows();
 
     std::vector<velox::BufferPtr> stringBuffers;
+
     while (visitor.rowIndex() < numRows) {
       if constexpr (!kHasNulls) {
         if (FOLLY_UNLIKELY(remainingValues_ == 0)) {
@@ -516,6 +682,7 @@ class ChunkedDecoder {
       velox::vector_size_t numNonNulls;
       const auto endRowIndex = computeNextRowIndex<kHasNulls>(
           visitor, nulls, params, numRows, numNulls, numNonNulls);
+
       VLOG(1) << visitor.reader().fileType().fullName() << ":"
               << " rowIndex=" << visitor.rowIndex()
               << " endRowIndex=" << endRowIndex << " numNulls=" << numNulls
@@ -558,17 +725,23 @@ class ChunkedDecoder {
       advancePosition(numNonNulls);
       params.numScanned += numNulls + numNonNulls;
 
+      // Accumulate string buffers from each chunk. For non-string types,
+      // currentStringBuffers_ will be empty.
       // Note: we can over queue the current string buffers by exactly
       // once, but that doesn't change the life cycle of the buffers for now.
       // Keeping this pattern for simplicity.
-      // For non-string types, currentStringBuffers_ will be empty
       for (const auto& buf : currentStringBuffers_) {
         stringBuffers.push_back(buf);
       }
     }
 
-    if (visitor.reader().formatData().stringDecoderZeroCopy()) {
-      visitor.reader().setStringBuffers(std::move(stringBuffers));
+    // Flush accumulated string buffers to the reader.
+    if (stringDecoderZeroCopy_) {
+      if (saveStringBuffersFn) {
+        saveStringBuffersFn(std::move(stringBuffers));
+      } else {
+        visitor.reader().setStringBuffers(std::move(stringBuffers));
+      }
     }
   }
 
@@ -589,13 +762,18 @@ class ChunkedDecoder {
   // TODO: remove with row size estimate hacks.
   bool ensureInputIncremental_hack(int size, const char*& pos);
 
-  void invokeOnChunkLoad() {
-    if (onChunkLoad_) {
-      onChunkLoad_();
-    }
-  }
-
-  void loadNextChunk(bool preserveDictionaryEncoding = false);
+  // Loads the next chunk from the input stream and creates a new encoding.
+  //
+  // @param preserveDictionaryEncoding When true, creates the encoding with
+  //   dictionary mode enabled so that RLE enters dict index mode. Only the
+  //   string dictionary reader passes true; all other callers use the
+  //   default (false).
+  // @param onChunkLoaded Callback invoked after loading. Returns true to
+  //   continue reading, false to stop (e.g., the new chunk is not
+  //   dictionary-compatible). Defaults to kNoopAtChunkBoundary.
+  bool loadNextChunk(
+      bool preserveDictionaryEncoding = false,
+      const ChunkBoundaryCallback& onChunkLoaded = kNoopAtChunkBoundary);
 
   void prepareInputBuffer(int32_t size);
 
@@ -613,7 +791,9 @@ class ChunkedDecoder {
   // Positions the decoder at the beginning of the chunk at the given offset.
   // The caller is responsible for updating rowPosition_ after this call.
   // @param offset The byte offset of the chunk in the stream
-  void seekToChunk(uint32_t offset);
+  void seekToChunk(
+      uint32_t offset,
+      const ChunkBoundaryCallback& onChunkBoundary = kNoopAtChunkBoundary);
 
   // Advances the position by the given number of values.
   // Updates both remainingValues_ and currentRow_.
@@ -625,6 +805,14 @@ class ChunkedDecoder {
         rowPosition_,
         streamRowCount_.value_or(std::numeric_limits<uint32_t>::max()));
   }
+
+  void skipWithIndex(
+      int64_t numValues,
+      const ChunkBoundaryCallback& onChunkBoundary);
+
+  void skipWithoutIndex(
+      int64_t numValues,
+      const ChunkBoundaryCallback& onChunkBoundary);
 
   const std::unique_ptr<velox::dwio::common::SeekableInputStream> input_;
   velox::memory::MemoryPool* const pool_;
@@ -656,10 +844,6 @@ class ChunkedDecoder {
 
   // Tracks the current row position in the stream.
   uint32_t rowPosition_{0};
-
-  // Callback invoked on chunk transitions. Used to clear cached state
-  // (e.g., alphabet, dictionaryValues) in the owning column reader.
-  std::function<void()> onChunkLoad_;
 
   friend class ChunkedDecoderTestHelper;
 };

--- a/dwio/nimble/velox/selective/StringColumnReader.cpp
+++ b/dwio/nimble/velox/selective/StringColumnReader.cpp
@@ -16,6 +16,7 @@
 
 #include "dwio/nimble/velox/selective/StringColumnReader.h"
 
+#include <algorithm>
 #include "dwio/nimble/encodings/legacy/EncodingUtils.h"
 #include "dwio/nimble/velox/selective/NimbleData.h"
 #include "velox/common/testutil/TestValue.h"
@@ -28,7 +29,12 @@ using namespace facebook::velox;
 
 uint64_t StringColumnReader::skip(uint64_t numValues) {
   numValues = SelectiveColumnReader::skip(numValues);
-  decoder_.skip(numValues);
+  // Clear cached dictionary state when skip crosses a chunk boundary,
+  // since the new chunk may have a different alphabet.
+  decoder_.skip(numValues, [this] {
+    clearDictionaryState();
+    return true;
+  });
   return numValues;
 }
 
@@ -36,11 +42,52 @@ void StringColumnReader::ensureDictionaryState() {
   if (hasDictionaryState()) {
     return;
   }
-  // Invalidate dictionary state when a new chunk is loaded, since the new
-  // chunk may have a different encoding or dictionary alphabet.
-  decoder_.setOnChunkLoad([this] { dictionaryState_.clear(); });
   dictionaryState_.alphabet = buildEncodingDictionaryAlphabet<std::string_view>(
       decoder_.currentEncoding());
+}
+
+void StringColumnReader::updateDictionaryIndices(
+    vector_size_t alphabetSize,
+    vector_size_t valueOffset) {
+  if (alphabetSize > 0) {
+    auto* values = reinterpret_cast<int32_t*>(rawValues_);
+    for (auto i = valueOffset; i < numValues_; ++i) {
+      values[i] += alphabetSize;
+    }
+  }
+}
+
+bool StringColumnReader::tryExtendDictionaryAtChunkBoundary(
+    int32_t& alphabetOffset,
+    vector_size_t& valueOffset) {
+  // Offset the indices written by the previous chunk so they reference the
+  // merged alphabet instead of the per-chunk alphabet. numValues_ is
+  // incremented by the visitor (via process() / processNull()) as
+  // readDictionaryIndices reads each row. At this point, numValues_ reflects
+  // all rows read so far across chunks, and [valueOffset, numValues_) are
+  // the indices from the just-completed chunk that need offsetting.
+  updateDictionaryIndices(alphabetOffset, valueOffset);
+  valueOffset = numValues_;
+
+  // Check if the new chunk's encoding supports dictionary index reading.
+  // If not, return false to signal the caller to abandon the dict path.
+  if (!decoder_.dictionaryConvertible()) {
+    return false;
+  }
+
+  // Extend the merged alphabet with the new chunk's dictionary entries.
+  // alphabetOffset tracks the cumulative size so that the next chunk's
+  // indices can be offset correctly.
+  alphabetOffset = static_cast<int32_t>(dictionaryState_.alphabet.size());
+  auto chunkAlphabet = buildEncodingDictionaryAlphabet<std::string_view>(
+      decoder_.currentEncoding());
+  dictionaryState_.alphabet.insert(
+      dictionaryState_.alphabet.end(),
+      chunkAlphabet.begin(),
+      chunkAlphabet.end());
+  dictionaryState_.alphabetVector.reset();
+  crossChunkRead_ = true;
+  return true;
 }
 
 bool StringColumnReader::readWithDictionary(
@@ -48,42 +95,87 @@ bool StringColumnReader::readWithDictionary(
     const RowSet& rows,
     const uint64_t* incomingNulls) {
   // Dictionary path requires: no filter pushdown, no value hook, non-legacy
-  // encoding path (zero-copy), session property enabled, single-chunk read,
-  // and dictionary-convertible encoding.
+  // encoding path (zero-copy), session property enabled, and
+  // dictionary-convertible encoding.
   if (scanSpec_->hasFilter() || scanSpec_->valueHook() ||
       !formatData().stringDecoderZeroCopy() ||
       !static_cast<const NimbleData&>(formatData())
            .nimblePreserveDictionaryEncoding()) {
+    clearDictionaryState();
     return false;
   }
-  decoder_.ensureLoaded(/*preserveDictionaryEncoding=*/true);
-  const auto numRequestedRows = rows.back() + 1;
-  // The decoder must have enough remaining values in the current chunk to
-  // cover both the skip (from readOffset_ to offset, executed by prepareRead
-  // → seekTo → skip) and the read range (rows 0 through rows.back()). If
-  // this total exceeds remainingValues, the skip or read would cross a chunk
-  // boundary, invalidating the dictionary state built below.
-  const auto numValuesNeeded = offset - readOffset_ + numRequestedRows;
-  if (decoder_.remainingValues() < numValuesNeeded ||
-      !decoder_.dictionaryConvertible()) {
+
+  // When the previous batch's readDictionaryIndices consumed the last row of
+  // a chunk (remainingValues_ == 0), ensureLoaded loads the next chunk. The
+  // callback clears stale dictionary state so ensureDictionaryState rebuilds
+  // from the new encoding.
+  decoder_.ensureLoaded(
+      /*preserveDictionaryEncoding=*/true, [this] {
+        clearDictionaryState();
+        return true;
+      });
+  if (!decoder_.dictionaryConvertible()) {
+    clearDictionaryState();
     return false;
   }
-  // NOTE: ensureDictionaryState must move back after readDictionaryIndices
-  // when nested encodings (MC, RLE) are supported, since the dictionary
-  // alphabet may not be available until the encoding is actually read.
+
+  prepareRead<int32_t>(offset, rows, incomingNulls);
   ensureDictionaryState();
   velox::common::testutil::TestValue::adjust(
       "facebook::nimble::StringColumnReader::readWithDictionary",
       &dictionaryState_.alphabet);
-  prepareRead<int32_t>(offset, rows, incomingNulls);
+  const auto endReadRow = rows.back() + 1;
+  // Set to true when the dictionary read is abandoned at a non-dict chunk;
+  // false when the whole range is read in dictionary mode. On abandon,
+  // readDictionaryIndices has already advanced readOffset_ to the decoder's
+  // parked position (the chunk boundary), where the flat fallback resumes.
+  bool abandonDictionary = false;
+
+  // Read dictionary indices, potentially across multiple chunks. At each
+  // chunk boundary, onChunkBoundary checks if the new chunk is also
+  // dictionary-convertible:
+  //   - Returns true: the new chunk's alphabet is appended to the merged
+  //     alphabet and reading continues in dict mode.
+  //   - Returns false: the new chunk is not dict-compatible, so
+  //     readDictionaryIndices stops and the reactive flat fallback below
+  //     takes over.
   dwio::common::StringColumnReadWithVisitorHelper<
-      /*kEncodingHasNulls=*/false,
-      /*kDictionary=*/true>(*this, rows)([&](auto visitor) {
+      /*kEncodingHasNulls=*/true,
+      /*kDictionary=*/false>(*this, rows)([&](auto visitor) {
     auto dictVisitor = visitor.toStringDictionaryColumnVisitor();
-    decoder_.readDictionaryIndices(dictVisitor);
+
+    int32_t alphabetOffset = 0;
+    velox::vector_size_t valueOffset = numValues_;
+
+    // At each chunk boundary, try to extend the merged alphabet with the
+    // new chunk's dictionary. Returns true if the new chunk is
+    // dict-compatible (alphabet extended, continue reading). Returns false
+    // if the new chunk is not dict-compatible (stop, fall back to flat).
+    auto onChunkBoundary = [&]() -> bool {
+      return tryExtendDictionaryAtChunkBoundary(alphabetOffset, valueOffset);
+    };
+
+    // readDictionaryIndices returns false when the onChunkBoundary callback
+    // returns false (new chunk is not dict-compatible), meaning the
+    // dictionary path must be abandoned for the remaining rows.
+    abandonDictionary =
+        !decoder_.readDictionaryIndices(dictVisitor, onChunkBoundary);
+
+    // Offset the final chunk's indices into the merged alphabet.
+    updateDictionaryIndices(alphabetOffset, valueOffset);
   });
-  readOffset_ += numRequestedRows;
-  return true;
+
+  if (!abandonDictionary) {
+    readOffset_ += endReadRow;
+    return true;
+  }
+
+  // Partial dict read: a non-dict chunk was encountered mid-read. Convert
+  // the already-read dict indices to flat StringViews. readOffset_ already
+  // points at the chunk boundary (set by readDictionaryIndices), so read()
+  // resumes the flat read there and slices the remaining rows past it.
+  abandonDictionaryEncoding(endReadRow);
+  return false;
 }
 
 void StringColumnReader::read(
@@ -93,13 +185,60 @@ void StringColumnReader::read(
   if (readWithDictionary(offset, rows, incomingNulls)) {
     return;
   }
-  dictionaryState_.clear();
-  prepareRead<std::string_view>(offset, rows, incomingNulls);
+
+  const auto endReadRow = rows.back() + 1;
+  // readWithDictionary returns false for two reasons:
+  // 1. Preconditions not met (e.g., zeroCopy disabled) — readOffset_
+  //    unchanged, numReadRows == 0. Full flat read via prepareRead below.
+  // 2. Dict abandoned mid-read — readOffset_ advanced to the chunk boundary,
+  //    numReadRows > 0. Flat encoding fallback for the remaining rows only.
+  // Both the return value (false) and numReadRows > 0 are needed to
+  // distinguish abandoned dict (case 2) from dict path not taken (case 1).
+  const auto numReadRows = readOffset_ > offset
+      ? static_cast<velox::vector_size_t>(readOffset_ - offset)
+      : 0;
+  NIMBLE_CHECK_LE(numReadRows, endReadRow);
+
+  // Build the row set for the flat read.
+  // - Fresh read (numReadRows == 0): use the original rows directly.
+  // - Continuation after an abandoned dict read: numReadRows is the chunk
+  //   boundary where the decoder is parked. The remaining rows are the
+  //   suffix of the (sorted) original rows at positions >= the boundary — a
+  //   contiguous subrange we reference in place (no copy). The flat read
+  //   resumes the decode at numReadRows and skips to the first such row.
+  velox::RowSet readRowSet;
+  if (numReadRows == 0) {
+    prepareRead<std::string_view>(offset, rows, incomingNulls);
+    readRowSet = rows;
+  } else {
+    const auto* remainingRowStart =
+        std::lower_bound(rows.data(), rows.data() + rows.size(), numReadRows);
+    readRowSet = velox::RowSet(
+        remainingRowStart,
+        static_cast<size_t>(rows.data() + rows.size() - remainingRowStart));
+  }
+
   dwio::common::StringColumnReadWithVisitorHelper<
       /*kEncodingHasNulls=*/false,
-      /*kDictionary=*/false>(
-      *this, rows)([&](auto visitor) { decoder_.readWithVisitor(visitor); });
-  readOffset_ += rows.back() + 1;
+      /*kDictionary=*/false>(*this, readRowSet)([&](auto visitor) {
+    if (numReadRows == 0) {
+      decoder_.readWithVisitor(visitor);
+    } else {
+      // Append string buffers from the flat read to the existing ones
+      // (which include the dict portion's string buffer from
+      // abandonDictionaryEncoding).
+      decoder_.readWithVisitor(
+          visitor,
+          /*readOffset=*/numReadRows,
+          [this](std::vector<velox::BufferPtr>&& buffers) {
+            for (auto& buffer : buffers) {
+              stringBuffers_.push_back(std::move(buffer));
+            }
+          });
+    }
+  });
+
+  readOffset_ = offset + endReadRow;
 }
 
 void StringColumnReader::ensureAlphabetVector() {
@@ -125,22 +264,75 @@ void StringColumnReader::ensureAlphabetVector() {
       std::move(buffers));
 }
 
-void StringColumnReader::getValues(const RowSet& rows, VectorPtr* result) {
-  if (hasDictionaryState()) {
-    compactScalarValues<int32_t, int32_t>(rows, /*isFinal=*/false);
-    ensureAlphabetVector();
+void StringColumnReader::abandonDictionaryEncoding(vector_size_t endReadRow) {
+  NIMBLE_CHECK(!dictionaryState_.alphabet.empty());
 
-    *result = std::make_shared<DictionaryVector<StringView>>(
-        pool_,
-        resultNulls(),
-        numValues_,
-        dictionaryState_.alphabetVector,
-        values_);
-  } else {
+  // Resolve dictionary indices to flat StringViews. The underlying string
+  // data lives in the encoding's string buffers, which the reader already
+  // holds via stringBuffers_ (set by readDictionaryIndices). No string
+  // byte copying is needed. Null positions contain uninitialized indices
+  // and are skipped — they get StringView() (empty) by the allocate default.
+  const auto* indices = reinterpret_cast<const int32_t*>(rawValues_);
+  auto flatValues =
+      AlignedBuffer::allocate<StringView>(endReadRow, pool_, StringView());
+  auto* rawFlatValues = flatValues->asMutable<StringView>();
+  // The dict indices in rawValues_ are at output positions [0, numValues_).
+  // resultNulls() is the single source of truth for the output-indexed null
+  // bitmap: it selects nullsInReadRange_ for dense reads and resultNulls_ for
+  // sparse, and returns an empty buffer when there are no nulls. Use it
+  // directly rather than re-deriving the selection here.
+  const auto& resultNullsBuffer = resultNulls();
+  const auto* nulls =
+      resultNullsBuffer ? resultNullsBuffer->as<uint64_t>() : nullptr;
+
+  for (vector_size_t i = 0; i < numValues_; ++i) {
+    if (nulls != nullptr && velox::bits::isBitNull(nulls, i)) {
+      continue;
+    }
+    const auto idx = indices[i];
+    NIMBLE_DCHECK_LT(idx, dictionaryState_.alphabet.size());
+    const auto& sv = dictionaryState_.alphabet[idx];
+    rawFlatValues[i] = StringView(sv.data(), sv.size());
+  }
+
+  values_ = std::move(flatValues);
+  rawValues_ = values_->asMutable<char>();
+
+  // prepareRead<int32_t> set valueSize_=4 for dict indices. After
+  // converting to StringView values, update valueSize_ so that the
+  // flat encoding fallback's addNull/addValue writes at correct byte offsets.
+  valueSize_ = sizeof(StringView);
+  clearDictionaryState();
+  crossChunkRead_ = false;
+}
+
+void StringColumnReader::getValues(const RowSet& rows, VectorPtr* result) {
+  if (!hasDictionaryState()) {
     rawStringBuffer_ = nullptr;
     rawStringSize_ = 0;
     rawStringUsed_ = 0;
     getFlatValues<StringView, StringView>(rows, result, fileType_->type());
+    return;
+  }
+
+  compactScalarValues<int32_t, int32_t>(rows, /*isFinal=*/false);
+  ensureAlphabetVector();
+
+  *result = std::make_shared<DictionaryVector<StringView>>(
+      pool_,
+      resultNulls(),
+      numValues_,
+      dictionaryState_.alphabetVector,
+      values_);
+  numValues_ = 0;
+  // If this batch crossed chunk boundaries, clear the merged alphabet
+  // to free memory from previous chunks that are no longer needed for
+  // the next read range. Single-chunk batches keep the cached alphabet
+  // for reuse. The DictionaryVector holds a shared_ptr to
+  // alphabetVector, so the data survives after clearing.
+  if (crossChunkRead_) {
+    clearDictionaryState();
+    crossChunkRead_ = false;
   }
 }
 

--- a/dwio/nimble/velox/selective/StringColumnReader.h
+++ b/dwio/nimble/velox/selective/StringColumnReader.h
@@ -45,12 +45,19 @@ class StringColumnReader : public velox::dwio::common::SelectiveColumnReader {
       const override;
 
  protected:
-  // Cached dictionary alphabet and materialized vector for the current chunk's
-  // encoding. Cleared on chunk transitions via the onChunkLoad callback.
+  ChunkedDecoder decoder_;
+
+ private:
+  bool readsNullsOnly() const final {
+    return false;
+  }
+
+  // Merged alphabet accumulated across chunks for multi-chunk dictionary
+  // reads. Each chunk's alphabet is appended, and indices are offset to
+  // reference this merged alphabet. Cleared when skip crosses a chunk
+  // boundary (via the skip callback) to invalidate stale state.
   struct DictionaryState {
-    // Raw alphabet entries extracted from the encoding's dictionary.
     std::vector<std::string_view> alphabet;
-    // Materialized FlatVector wrapping alphabet for DictionaryVector output.
     velox::VectorPtr alphabetVector;
 
     void clear() {
@@ -59,32 +66,82 @@ class StringColumnReader : public velox::dwio::common::SelectiveColumnReader {
     }
   };
 
-  ChunkedDecoder decoder_;
-  DictionaryState dictionaryState_;
-
- private:
-  bool readsNullsOnly() const final {
-    return false;
-  }
-
-  // Populates dictionaryState_ from the current chunk's encoding if not
-  // already set. Registers the onChunkLoad callback on first call.
-  void ensureDictionaryState();
-
   // Materializes the alphabet FlatVector from dictionaryState_.alphabet
   // for use in DictionaryVector output.
   void ensureAlphabetVector();
 
-  // Attempts to read using the dictionary index path. Returns true if the
-  // dict path was taken, false if the caller should fall back to flat read.
+  // Populates dictionaryState_ from the current chunk's encoding if not
+  // already set.
+  void ensureDictionaryState();
+
+  void clearDictionaryState() {
+    dictionaryState_.clear();
+  }
+
+  // Attempts to extend the merged dictionary alphabet when a chunk boundary
+  // is crossed during multi-chunk dictionary index reading. Offsets the
+  // indices written since valueOffset by alphabetOffset (to reference the
+  // merged alphabet), then checks whether the new chunk is
+  // dictionary-convertible.
+  //
+  // Returns true if the new chunk's alphabet was appended and reading
+  // should continue. Returns false if the new chunk is not
+  // dictionary-convertible, signaling the caller to fall back to flat
+  // decoding for the remaining rows.
+  //
+  // @param alphabetOffset Running offset into the merged alphabet. Updated
+  //   to the new alphabet size when a chunk is appended. Tracked to produce
+  //   the correct indices in the merged alphabets.
+  // @param valueOffset Index into rawValues_ marking where the current
+  //   chunk's indices start. Updated to numValues_ after offsetting.
+  // Offsets dictionary indices in rawValues_ by alphabetSize, starting
+  // from position 'valueOffset' up to numValues_. Used to remap per-chunk
+  // indices into the merged alphabet's index space.
+  void updateDictionaryIndices(
+      velox::vector_size_t alphabetSize,
+      velox::vector_size_t valueOffset);
+
+  bool tryExtendDictionaryAtChunkBoundary(
+      int32_t& alphabetOffset,
+      velox::vector_size_t& valueOffset);
+
+  // Converts the dict indices in rawValues_ to flat StringView values by
+  // resolving each index against the merged alphabet. The StringViews point
+  // into the encoding's string buffers already held by stringBuffers_. Null
+  // positions (uninitialized indices) are skipped. Called during reactive
+  // fallback when a non-dictionary chunk is encountered mid-read.
+  //
+  // @param endReadRow End row of the read range (for output buffer sizing).
+  void abandonDictionaryEncoding(velox::vector_size_t endReadRow);
+
+  bool hasDictionaryState() const {
+    return !dictionaryState_.alphabet.empty();
+  }
+
+  // Attempts to read all rows using the dictionary index path.
+  //
+  // Returns true if all rows were consumed via dictionary encoding.
+  //
+  // Returns false if the dict path could not handle the entire batch.
+  // readOffset_ indicates how many rows were consumed:
+  //   - readOffset_ == offset: dict path not taken at all. The caller
+  //     should do a full flat read starting with prepareRead.
+  //   - readOffset_ > offset: partial dict read stopped at a non-dict
+  //     chunk. The dict rows are expanded to flat StringViews via
+  //     abandonDictionaryEncoding, nulls are set up, and the decoder is
+  //     at the continuation point. The caller reads the remaining rows
+  //     as flat without calling prepareRead.
   bool readWithDictionary(
       int64_t offset,
       const velox::RowSet& rows,
       const uint64_t* incomingNulls);
 
-  bool hasDictionaryState() const {
-    return !dictionaryState_.alphabet.empty();
-  }
+  DictionaryState dictionaryState_;
+
+  // Set when the current batch's read crossed chunk boundaries.
+  // Consumed by getValues to clear the merged alphabet after the
+  // DictionaryVector is constructed.
+  bool crossChunkRead_{false};
 };
 
 } // namespace facebook::nimble

--- a/dwio/nimble/velox/selective/tests/ChunkedDecoderTest.cpp
+++ b/dwio/nimble/velox/selective/tests/ChunkedDecoderTest.cpp
@@ -1367,7 +1367,7 @@ TEST_P(ChunkedDecoderDataTest, ensureLoadedAndAccessors) {
   EXPECT_FALSE(decoder.dictionaryConvertible());
 }
 
-TEST_P(ChunkedDecoderDataTest, onChunkLoadCallback) {
+TEST_P(ChunkedDecoderDataTest, skipChunkBoundaryCallback) {
   auto [streamData, chunkInfos] =
       encodeChunkedStream<uint32_t>({{1, 2, 3}, {4, 5, 6}});
   auto streamIndex = createTestStreamIndex(chunkInfos);
@@ -1376,15 +1376,15 @@ TEST_P(ChunkedDecoderDataTest, onChunkLoadCallback) {
   ChunkedDecoder decoder(
       std::move(input), streamIndex, false, &encodingFactory(), pool_.get());
 
-  int callbackCount = 0;
-  decoder.setOnChunkLoad([&] { ++callbackCount; });
-
   decoder.ensureLoaded();
-  EXPECT_EQ(callbackCount, 1);
 
-  // Skip past chunk 1 (3 values) into chunk 2, triggering a second load.
-  decoder.skip(4);
-  EXPECT_EQ(callbackCount, 2);
+  int callbackCount = 0;
+  // Skip past chunk 1 (3 values) into chunk 2, triggering the callback.
+  decoder.skip(4, [&] {
+    ++callbackCount;
+    return true;
+  });
+  EXPECT_EQ(callbackCount, 1);
 }
 
 TEST_P(ChunkedDecoderDataTest, hasMoreChunks) {
@@ -1417,9 +1417,31 @@ TEST_P(ChunkedDecoderDataTest, hasMoreChunks) {
   EXPECT_EQ(decoder.remainingValues(), 0);
 }
 
-// Verifies that ensureLoaded fires onChunkLoad when reloading an exhausted
-// chunk, allowing the caller to invalidate cached state.
-TEST_P(ChunkedDecoderDataTest, ensureLoadedFiresOnChunkLoadOnReload) {
+TEST_P(ChunkedDecoderDataTest, ensureLoadedReloadsExhaustedChunk) {
+  auto [streamData, chunkInfos] =
+      encodeChunkedStream<uint32_t>({{1, 2, 3}, {4, 5, 6}});
+  auto streamIndex = createTestStreamIndex(chunkInfos);
+  auto input = std::make_unique<velox::dwio::common::SeekableArrayInputStream>(
+      streamData.data(), streamData.size());
+  ChunkedDecoder decoder(
+      std::move(input), streamIndex, false, &encodingFactory(), pool_.get());
+
+  decoder.ensureLoaded();
+  EXPECT_EQ(decoder.remainingValues(), 3);
+
+  // Consume chunk 1.
+  decoder.skip(3);
+  EXPECT_EQ(decoder.remainingValues(), 0);
+
+  // ensureLoaded reloads chunk 2.
+  decoder.ensureLoaded();
+  EXPECT_EQ(decoder.remainingValues(), 3);
+}
+
+// Verifies that ensureLoaded fires its onChunkBoundary callback when
+// reloading an exhausted chunk, allowing the caller to invalidate cached
+// state (e.g., dictionary alphabet).
+TEST_P(ChunkedDecoderDataTest, ensureLoadedFiresCallbackOnReload) {
   auto [streamData, chunkInfos] =
       encodeChunkedStream<uint32_t>({{1, 2, 3}, {4, 5, 6}});
   auto streamIndex = createTestStreamIndex(chunkInfos);
@@ -1429,19 +1451,26 @@ TEST_P(ChunkedDecoderDataTest, ensureLoadedFiresOnChunkLoadOnReload) {
       std::move(input), streamIndex, false, &encodingFactory(), pool_.get());
 
   int callbackCount = 0;
-  decoder.setOnChunkLoad([&] { ++callbackCount; });
+  auto onChunkBoundary = [&] {
+    ++callbackCount;
+    return true;
+  };
 
-  // First load.
-  decoder.ensureLoaded();
+  // First load fires the callback.
+  decoder.ensureLoaded(/*preserveDictionaryEncoding=*/false, onChunkBoundary);
   EXPECT_EQ(callbackCount, 1);
   EXPECT_EQ(decoder.remainingValues(), 3);
+
+  // ensureLoaded with remaining > 0 does not fire.
+  decoder.ensureLoaded(/*preserveDictionaryEncoding=*/false, onChunkBoundary);
+  EXPECT_EQ(callbackCount, 1);
 
   // Consume chunk 1.
   decoder.skip(3);
   EXPECT_EQ(decoder.remainingValues(), 0);
 
   // ensureLoaded reloads chunk 2, firing the callback.
-  decoder.ensureLoaded();
+  decoder.ensureLoaded(/*preserveDictionaryEncoding=*/false, onChunkBoundary);
   EXPECT_EQ(callbackCount, 2);
   EXPECT_EQ(decoder.remainingValues(), 3);
 }
@@ -1545,9 +1574,122 @@ class ChunkedDecoderDictTest : public ChunkedDecoderTest {
   }
 };
 
-// Verify buildAlphabet for a simple Dictionary encoding.
-// Verify string buffers keep alphabet data alive after reading a
-// dictionary-encoded string chunk.
+// Verify dictionaryConvertible() returns true for Dictionary encoding and
+// eagerly loads the first chunk when encoding_ is null.
+// Verifies dictionaryConvertible() for standalone (non-nested) encodings:
+// Dictionary (true), Nullable→Dictionary (true), and Trivial (false).
+TEST_F(ChunkedDecoderDictTest, dictionaryConvertibleLeafEncodings) {
+  // Dictionary encoding.
+  {
+    SCOPED_TRACE("Dictionary");
+    std::vector<std::string_view> data = {"apple", "banana", "apple", "cherry"};
+    auto streamData = encodeStringChunkedStream({data}, stringDictEnc());
+    auto decoder = createStringDecoder(streamData);
+    decoder.ensureLoaded();
+    EXPECT_TRUE(decoder.dictionaryConvertible());
+    EXPECT_EQ(decoder.currentEncoding()->dataType(), DataType::String);
+  }
+
+  // Nullable→Dictionary.
+  {
+    SCOPED_TRACE("Nullable→Dictionary");
+    std::vector<std::optional<std::string_view>> data = {
+        "apple", std::nullopt, "banana", "apple"};
+    auto streamData =
+        encodeNullableStringChunkedStream({data}, stringDictEnc());
+    auto decoder = createStringDecoder(streamData);
+    decoder.ensureLoaded();
+    EXPECT_TRUE(decoder.dictionaryConvertible());
+    EXPECT_EQ(
+        decoder.currentEncoding()->encodingType(), EncodingType::Nullable);
+  }
+
+  // Trivial — not dictionary-convertible.
+  {
+    SCOPED_TRACE("Trivial");
+    std::vector<std::string_view> data = {"hello", "world"};
+    auto streamData = encodeStringChunkedStream({data}, StringTrivialEnc{});
+    auto decoder = createStringDecoder(streamData);
+    decoder.ensureLoaded();
+    EXPECT_FALSE(decoder.dictionaryConvertible());
+  }
+}
+
+// Verifies dictionaryConvertible() for nested encodings:
+// MainlyConstant→Dictionary (true) and Nullable→MainlyConstant→Dictionary
+// (true).
+TEST_F(ChunkedDecoderDictTest, dictionaryConvertibleNestedEncodings) {
+  // MainlyConstant→Dictionary.
+  {
+    SCOPED_TRACE("MainlyConstant→Dictionary");
+    std::vector<std::string_view> data;
+    data.reserve(100);
+    for (int i = 0; i < 100; ++i) {
+      data.emplace_back("common");
+    }
+    data[10] = "rare";
+    data[20] = "rare";
+    auto streamData = encodeStringChunkedStream(
+        {data}, MainlyConstantEnc{.otherValues = stringDictEnc()});
+    auto decoder = createStringDecoder(streamData);
+    decoder.ensureLoaded();
+    EXPECT_TRUE(decoder.dictionaryConvertible());
+  }
+
+  // Nullable→MainlyConstant→Dictionary.
+  {
+    SCOPED_TRACE("Nullable→MainlyConstant→Dictionary");
+    std::vector<std::optional<std::string_view>> data;
+    data.reserve(100);
+    for (int i = 0; i < 100; ++i) {
+      data.emplace_back("common");
+    }
+    data[10] = "rare";
+    data[20] = "rare";
+    data[30] = std::nullopt;
+    data[60] = std::nullopt;
+    auto streamData = encodeNullableStringChunkedStream(
+        {data}, MainlyConstantEnc{.otherValues = stringDictEnc()});
+    auto decoder = createStringDecoder(streamData);
+    decoder.ensureLoaded();
+    EXPECT_TRUE(decoder.dictionaryConvertible());
+    EXPECT_EQ(
+        decoder.currentEncoding()->encodingType(), EncodingType::Nullable);
+  }
+}
+
+// Verifies dictionaryConvertible() is re-evaluated per chunk and that
+// multi-chunk navigation works correctly.
+TEST_F(ChunkedDecoderDictTest, dictionaryConvertibleAcrossChunks) {
+  std::vector<std::string_view> chunk1 = {"a", "b", "c", "a"};
+  std::vector<std::string_view> chunk2 = {"x", "y", "z", "x", "y"};
+
+  auto streamData =
+      encodeStringChunkedStream({chunk1, chunk2}, stringDictEnc());
+
+  auto decoder = createStringDecoder(streamData);
+
+  // First chunk is dictionary.
+  decoder.ensureLoaded();
+  EXPECT_TRUE(decoder.dictionaryConvertible());
+  EXPECT_EQ(decoder.remainingValues(), 4);
+
+  // Calling again with remaining > 0 returns cached result.
+  EXPECT_TRUE(decoder.dictionaryConvertible());
+
+  // Skip 3 values within chunk 1.
+  decoder.skip(3);
+  EXPECT_EQ(decoder.remainingValues(), 1);
+
+  // Skip past the chunk boundary into chunk 2.
+  decoder.skip(2);
+  EXPECT_EQ(decoder.remainingValues(), 4);
+  // Second chunk is also dictionary — re-evaluated after chunk load.
+  EXPECT_TRUE(decoder.dictionaryConvertible());
+}
+
+// Verifies that alphabet string_views built from the encoding's dictionary
+// point into valid string buffers allocated during loadNextChunk.
 TEST_F(ChunkedDecoderDictTest, stringBuffersAfterChunkLoad) {
   std::vector<std::string_view> data = {"hello", "world", "hello"};
   auto streamData = encodeStringChunkedStream({data}, stringDictEnc());
@@ -1556,8 +1698,6 @@ TEST_F(ChunkedDecoderDictTest, stringBuffersAfterChunkLoad) {
   decoder.ensureLoaded();
   ASSERT_TRUE(decoder.dictionaryConvertible());
 
-  // Build the alphabet — string_views point into the encoding's string
-  // buffers that were allocated during loadNextChunk.
   auto alphabet = buildEncodingDictionaryAlphabet<std::string_view>(
       decoder.currentEncoding());
   ASSERT_EQ(alphabet.size(), 2);

--- a/dwio/nimble/velox/selective/tests/StringColumnReaderTest.cpp
+++ b/dwio/nimble/velox/selective/tests/StringColumnReaderTest.cpp
@@ -28,6 +28,8 @@
 
 #include <gtest/gtest.h>
 
+#include "folly/Random.h"
+
 namespace facebook::nimble {
 namespace {
 
@@ -360,40 +362,27 @@ TEST_P(StringColumnReaderTest, stringSkipAndRead) {
   validate(*input, *readers.rowReader, 7);
 }
 
-// Verifies that dictionary state is correctly invalidated when a decoder-level
-// skip crosses a chunk boundary. Uses a two-column schema where a filter on c0
-// rejects all rows in chunk 1, causing c1 (string, lazy-loaded) to remain
-// unread during batch 1. When batch 2 loads c1 via ColumnLoader, seekTo
-// triggers skip(500) across the chunk boundary.
+// Verifies that dictionary state is correctly invalidated when skip crosses
+// a chunk boundary. Without the onChunkLoad callback, alphabet_ would retain
+// stale string_views from the previous chunk, producing corrupted output.
 TEST_P(StringColumnReaderTest, skipAcrossChunkBoundary) {
-  const bool passStringBuffersFromDecoder = GetParam();
-  if (!passStringBuffersFromDecoder) {
+  const bool stringDecoderZeroCopy = GetParam();
+  if (!stringDecoderZeroCopy) {
+    // Dict vector path requires stringDecoderZeroCopy.
     return;
   }
 
-  constexpr int kChunkRows = 500;
-
-  // Chunk 1: c0 = [0..499], c1 = {"aaa","bbb","ccc"} repeating.
-  auto chunk1 = makeRowVector({
-      makeFlatVector<int64_t>(kChunkRows, [](auto i) { return i; }),
-      makeFlatVector<std::string>(
-          kChunkRows,
-          [](auto i) {
-            return std::vector<std::string>{"aaa", "bbb", "ccc"}[i % 3];
-          }),
-  });
-  // Chunk 2: c0 = [500..999], c1 = {"xxx","yyy"} repeating.
-  auto chunk2 = makeRowVector({
-      makeFlatVector<int64_t>(
-          kChunkRows, [](auto i) { return kChunkRows + i; }),
-      makeFlatVector<std::string>(
-          kChunkRows,
-          [](auto i) { return std::vector<std::string>{"xxx", "yyy"}[i % 2]; }),
-  });
+  // Chunk 1: 500 rows with alphabet {"aaa", "bbb", "ccc"}.
+  auto chunk1 = makeRowVector({makeFlatVector<std::string>(500, [](auto i) {
+    return std::vector<std::string>{"aaa", "bbb", "ccc"}[i % 3];
+  })});
+  // Chunk 2: 500 rows with a completely different alphabet {"xxx", "yyy"}.
+  auto chunk2 = makeRowVector({makeFlatVector<std::string>(500, [](auto i) {
+    return std::vector<std::string>{"xxx", "yyy"}[i % 2];
+  })});
 
   VeloxWriterOptions writerOptions;
   writerOptions.enableChunking = true;
-  writerOptions.minStreamChunkRawSize = 0;
   writerOptions.flushPolicyFactory = [] {
     return std::make_unique<LambdaFlushPolicy>(
         /*flushLambda=*/[](const StripeProgress&) { return false; },
@@ -402,50 +391,84 @@ TEST_P(StringColumnReaderTest, skipAcrossChunkBoundary) {
   auto file = test::createNimbleFile(
       *rootPool(), {chunk1, chunk2}, writerOptions, /*flushAfterWrite=*/false);
 
-  // Filter on c0 rejects chunk 1 ([0,499]), accepts chunk 2 ([500,999]).
-  auto readType = ROW({"c0", "c1"}, {BIGINT(), VARCHAR()});
+  // Build expected vector by concatenating both chunks.
+  auto expected = makeRowVector({makeFlatVector<std::string>(1000, [](auto i) {
+    if (i < 500) {
+      return std::vector<std::string>{"aaa", "bbb", "ccc"}[i % 3];
+    }
+    return std::vector<std::string>{"xxx", "yyy"}[(i - 500) % 2];
+  })});
+
   auto scanSpec = std::make_shared<common::ScanSpec>("root");
-  scanSpec->addAllChildFields(*readType);
-  scanSpec->childByName("c0")->setFilter(
-      std::make_unique<common::BigintRange>(
-          kChunkRows, 2 * kChunkRows - 1, /*nullAllowed=*/false));
+  scanSpec->addAllChildFields(*expected->type());
+  auto readers = makeReaders(expected, file, scanSpec, stringDecoderZeroCopy);
 
-  auto expectedStrings = makeFlatVector<std::string>(kChunkRows, [](auto i) {
-    return std::vector<std::string>{"xxx", "yyy"}[i % 2];
-  });
-
-  auto readers =
-      makeReaders(chunk1, file, scanSpec, passStringBuffersFromDecoder);
-
-  // Batch 1 (rows 0-499): c0 filter rejects all → c1 lazy, not loaded.
-  // Batch 2 (rows 500-999): c1 loaded via ColumnLoader → seekTo(500) →
-  //   skip(500) across chunk boundary → flat fallback.
-  using E = VectorEncoding::Simple;
-  validateWithEncodingChecks(
-      *expectedStrings,
-      *readers.rowReader,
-      kChunkRows,
-      /*totalRows=*/2 * kChunkRows,
-      {E::FLAT},
-      readType,
-      pool(),
-      /*childIndex=*/1);
+  // Use a batch size that forces the reader to skip across the chunk boundary.
+  // Read batch 1 (rows 0-199) from chunk 1, then skip to batch 3 (rows 400+)
+  // which crosses the chunk boundary at row 500.
+  validate(*expected, *readers.rowReader, 200);
 }
 
-// Verifies skip and dictionary behavior when the filter creates a gap in the
-// middle of the file. The filter accepts rows [0,249] and [600,900], creating
-// a skip that crosses the chunk boundary (at row 500) mid-file.
-//
-// Batch layout (batch size 250, 1000 total rows, chunk boundary at 500):
-//   Batch 0 (offset=0):   c0 accepts 0-249, c1 loaded at readOffset=0 → dict
-//   Batch 1 (offset=250): c0 rejects all    → c1 lazy, not loaded
-//   Batch 2 (offset=500): c0 accepts 600-749, c1 loaded, readOffset=250 →
-//     seekTo(500), skip(250) crosses chunk boundary → flat
-//   Batch 3 (offset=750): c0 accepts 750-900, readOffset=750 → dict
-TEST_P(StringColumnReaderTest, skipAcrossChunkBoundaryMidFile) {
-  const bool passStringBuffersFromDecoder = GetParam();
-  if (!passStringBuffersFromDecoder) {
+// Verifies that dictionary state is invalidated when the remainingValues gate
+// forces a flat-path fallback mid-file. With 2 chunks of 300 rows and batch
+// size 200:
+//   Read 1 (rows 0-199): chunk 1 has 300 remaining >= 200, dict path taken,
+//     alphabet built from chunk 1.
+//   Read 2 (rows 200-399): chunk 1 has only 100 remaining < 200, falls to flat
+//     path which must clear dictionary state.
+//   Read 3 (rows 400-599): chunk 2 has enough rows, dict path re-entered.
+//     Must rebuild alphabet from chunk 2, not reuse stale chunk 1 alphabet.
+TEST_P(StringColumnReaderTest, flatFallbackClearsDictionaryState) {
+  const bool stringDecoderZeroCopy = GetParam();
+  if (!stringDecoderZeroCopy) {
     return;
+  }
+
+  auto chunk1 = makeRowVector({makeFlatVector<std::string>(300, [](auto i) {
+    return std::vector<std::string>{"aaa", "bbb"}[i % 2];
+  })});
+  auto chunk2 = makeRowVector({makeFlatVector<std::string>(300, [](auto i) {
+    return std::vector<std::string>{"xxx", "yyy"}[i % 2];
+  })});
+
+  VeloxWriterOptions writerOptions;
+  writerOptions.enableChunking = true;
+  writerOptions.flushPolicyFactory = [] {
+    return std::make_unique<LambdaFlushPolicy>(
+        /*flushLambda=*/[](const StripeProgress&) { return false; },
+        /*chunkLambda=*/[](const StripeProgress&) { return true; });
+  };
+  auto file = test::createNimbleFile(
+      *rootPool(), {chunk1, chunk2}, writerOptions, /*flushAfterWrite=*/false);
+
+  auto expected = makeRowVector({makeFlatVector<std::string>(600, [](auto i) {
+    if (i < 300) {
+      return std::vector<std::string>{"aaa", "bbb"}[i % 2];
+    }
+    return std::vector<std::string>{"xxx", "yyy"}[(i - 300) % 2];
+  })});
+
+  auto scanSpec = std::make_shared<common::ScanSpec>("root");
+  scanSpec->addAllChildFields(*expected->type());
+  auto readers = makeReaders(expected, file, scanSpec, stringDecoderZeroCopy);
+  using E = VectorEncoding::Simple;
+  validateWithEncodingChecks(
+      *expected->childAt(0),
+      *readers.rowReader,
+      200,
+      /*totalRows=*/600,
+      {E::DICTIONARY, E::DICTIONARY, E::DICTIONARY},
+      asRowType(expected->type()),
+      pool());
+}
+
+// When the skip in prepareRead crosses a chunk boundary mid-file, the
+// decoder loads a new chunk. The dictionary state must be rebuilt from
+// the new chunk's encoding.
+TEST_P(StringColumnReaderTest, skipAcrossChunkBoundaryMidFile) {
+  const bool stringDecoderZeroCopy = GetParam();
+  if (!stringDecoderZeroCopy) {
+    GTEST_SKIP() << "Dictionary path requires stringDecoderZeroCopy";
   }
 
   constexpr int kChunkRows = 500;
@@ -478,7 +501,7 @@ TEST_P(StringColumnReaderTest, skipAcrossChunkBoundaryMidFile) {
   auto file = test::createNimbleFile(
       *rootPool(), {chunk1, chunk2}, writerOptions, /*flushAfterWrite=*/false);
 
-  // Filter: accept [0, 249] ∪ [600, 900].
+  // Filter on c0: accept [0, 249] ∪ [600, 900]. c1 has no filter.
   auto readType = ROW({"c0", "c1"}, {BIGINT(), VARCHAR()});
   auto scanSpec = std::make_shared<common::ScanSpec>("root");
   scanSpec->addAllChildFields(*readType);
@@ -492,274 +515,16 @@ TEST_P(StringColumnReaderTest, skipAcrossChunkBoundaryMidFile) {
       std::make_unique<common::BigintMultiRange>(
           std::move(ranges), /*nullAllowed=*/false));
 
-  // Expected string output: rows 0-249 from chunk 1, rows 600-900 from chunk 2.
-  // 250 + 150 + 151 = 551 total qualifying rows.
   auto expectedStrings = makeFlatVector<std::string>(551, [](auto i) {
     if (i < 250) {
       return std::vector<std::string>{"aaa", "bbb", "ccc"}[i % 3];
     }
-    // Rows 600-900 in the file → offset 100-400 within chunk 2.
     int chunk2Offset = (i - 250) + 100;
     return std::vector<std::string>{"xxx", "yyy"}[chunk2Offset % 2];
   });
 
-  auto readers =
-      makeReaders(chunk1, file, scanSpec, passStringBuffersFromDecoder);
+  auto readers = makeReaders(chunk1, file, scanSpec, stringDecoderZeroCopy);
 
-  using E = VectorEncoding::Simple;
-  validateWithEncodingChecks(
-      *expectedStrings,
-      *readers.rowReader,
-      kBatchSize,
-      /*totalRows=*/2 * kChunkRows,
-      {E::DICTIONARY, E::FLAT, E::DICTIONARY},
-      readType,
-      pool(),
-      /*childIndex=*/1);
-}
-
-// Verifies that the dictionary path is entered when a skip stays within the
-// same chunk. Uses a single large chunk so there is no chunk boundary. A filter
-// on c0 rejects batch 0, causing c1 to be lazy. When batch 1 loads c1, seekTo
-// skips 500 values — but all within the same 1000-value chunk. The tighter
-// remainingValues gate (offset + numRequestedRows - readOffset_ <=
-// remainingValues) allows the dict path here, unlike the conservative
-// readOffset_ != offset gate which would bail.
-//
-// The filter also creates gaps (accepts only even rows) so the first dictionary
-// batch exercises the visitor's gap-skipping logic.
-TEST_P(StringColumnReaderTest, skipWithinChunkReturnsDictionary) {
-  const bool passStringBuffersFromDecoder = GetParam();
-  if (!passStringBuffersFromDecoder) {
-    return;
-  }
-
-  constexpr int kChunkRows = 1000;
-  constexpr int kBatchSize = 500;
-
-  auto input = makeRowVector({
-      makeFlatVector<int64_t>(kChunkRows, [](auto i) { return i; }),
-      makeFlatVector<std::string>(
-          kChunkRows,
-          [](auto i) {
-            return std::vector<std::string>{"aaa", "bbb", "ccc"}[i % 3];
-          }),
-  });
-
-  VeloxWriterOptions writerOptions;
-  writerOptions.enableChunking = true;
-  writerOptions.minStreamChunkRawSize = 0;
-  writerOptions.flushPolicyFactory = [] {
-    return std::make_unique<LambdaFlushPolicy>(
-        /*flushLambda=*/[](const StripeProgress&) { return false; },
-        /*chunkLambda=*/[](const StripeProgress&) { return false; });
-  };
-  auto file = test::createNimbleFile(*rootPool(), input, writerOptions);
-
-  // Filter: accept [600, 700] ∪ [800, 900]. Rejects all of batch 0 and
-  // creates a gap (rows 701-799) in batch 1's qualifying rows.
-  auto readType = ROW({"c0", "c1"}, {BIGINT(), VARCHAR()});
-  auto scanSpec = std::make_shared<common::ScanSpec>("root");
-  scanSpec->addAllChildFields(*readType);
-  std::vector<std::unique_ptr<common::BigintRange>> ranges;
-  ranges.push_back(
-      std::make_unique<common::BigintRange>(600, 700, /*nullAllowed=*/false));
-  ranges.push_back(
-      std::make_unique<common::BigintRange>(800, 900, /*nullAllowed=*/false));
-  scanSpec->childByName("c0")->setFilter(
-      std::make_unique<common::BigintMultiRange>(
-          std::move(ranges), /*nullAllowed=*/false));
-
-  // 101 rows from [600,700] + 101 rows from [800,900] = 202 qualifying rows.
-  auto expectedStrings = makeFlatVector<std::string>(202, [](auto i) {
-    int row = i < 101 ? 600 + i : 800 + (i - 101);
-    return std::vector<std::string>{"aaa", "bbb", "ccc"}[row % 3];
-  });
-
-  auto readers =
-      makeReaders(input, file, scanSpec, passStringBuffersFromDecoder);
-
-  // Batch 0 (offset=0): c0 rejects all → c1 lazy, readOffset stays 0.
-  // Batch 1 (offset=500): c0 accepts [600,700] ∪ [800,900] → c1 loaded via
-  //   ColumnLoader, readOffset=0, offset=500. Skip 500 within single
-  //   1000-value chunk. remainingValues (1000) >= 500 + 901 - 0 = 1401? No...
-  //   rows = outputRows relative to offset 500: [100..200, 300..400].
-  //   numRequestedRows = 401. totalValuesNeeded = 500 + 401 = 901 <= 1000.
-  //   Dict path with gapped rows.
-  using E = VectorEncoding::Simple;
-  validateWithEncodingChecks(
-      *expectedStrings,
-      *readers.rowReader,
-      kBatchSize,
-      /*totalRows=*/kChunkRows,
-      {E::DICTIONARY},
-      readType,
-      pool(),
-      /*childIndex=*/1);
-}
-
-// Verifies that the dictionary path recovers after a flat fallback mid-file.
-// Two chunks of 400 rows, batch size 250, filter accepts [0,349] ∪ [600,799].
-//
-//   Batch 0 (offset=0):   c0 accepts [0,249]. c1 readOffset=0, no skip.
-//     remainingValues=400 >= 250. DICT. readOffset → 250.
-//   Batch 1 (offset=250): c0 accepts [250,349], outputRows=[0..99].
-//     readOffset=250, no skip. remainingValues=150 >= 100. DICT.
-//     readOffset → 350.
-//   Batch 2 (offset=500): c0 accepts [600,749], outputRows=[100..249].
-//     readOffset=350, skip=150. totalNeeded=150+250=400 > remaining=50.
-//     Skip crosses chunk boundary → FLAT. readOffset → 750.
-//   Batch 3 (offset=750): c0 accepts [750,799], outputRows=[0..49].
-//     readOffset=750, no skip. remainingValues=50 >= 50. DICT.
-TEST_P(StringColumnReaderTest, skipCrossesChunkButNextBatchRecoversDictionary) {
-  const bool passStringBuffersFromDecoder = GetParam();
-  if (!passStringBuffersFromDecoder) {
-    return;
-  }
-
-  constexpr int kChunkRows = 400;
-  constexpr int kBatchSize = 250;
-
-  auto chunk1 = makeRowVector({
-      makeFlatVector<int64_t>(kChunkRows, [](auto i) { return i; }),
-      makeFlatVector<std::string>(
-          kChunkRows,
-          [](auto i) {
-            return std::vector<std::string>{"aaa", "bbb", "ccc"}[i % 3];
-          }),
-  });
-  auto chunk2 = makeRowVector({
-      makeFlatVector<int64_t>(
-          kChunkRows, [](auto i) { return kChunkRows + i; }),
-      makeFlatVector<std::string>(
-          kChunkRows,
-          [](auto i) { return std::vector<std::string>{"xxx", "yyy"}[i % 2]; }),
-  });
-
-  VeloxWriterOptions writerOptions;
-  writerOptions.enableChunking = true;
-  writerOptions.minStreamChunkRawSize = 0;
-  writerOptions.flushPolicyFactory = [] {
-    return std::make_unique<LambdaFlushPolicy>(
-        /*flushLambda=*/[](const StripeProgress&) { return false; },
-        /*chunkLambda=*/[](const StripeProgress&) { return true; });
-  };
-  auto file = test::createNimbleFile(
-      *rootPool(), {chunk1, chunk2}, writerOptions, /*flushAfterWrite=*/false);
-
-  auto readType = ROW({"c0", "c1"}, {BIGINT(), VARCHAR()});
-  auto scanSpec = std::make_shared<common::ScanSpec>("root");
-  scanSpec->addAllChildFields(*readType);
-  std::vector<std::unique_ptr<common::BigintRange>> ranges;
-  ranges.push_back(
-      std::make_unique<common::BigintRange>(0, 349, /*nullAllowed=*/false));
-  ranges.push_back(
-      std::make_unique<common::BigintRange>(
-          600, 2 * kChunkRows - 1, /*nullAllowed=*/false));
-  scanSpec->childByName("c0")->setFilter(
-      std::make_unique<common::BigintMultiRange>(
-          std::move(ranges), /*nullAllowed=*/false));
-
-  // 350 rows from chunk 1 (rows 0-349) + 200 rows from chunk 2 (rows 600-799).
-  auto expectedStrings = makeFlatVector<std::string>(550, [](auto i) {
-    if (i < 350) {
-      return std::vector<std::string>{"aaa", "bbb", "ccc"}[i % 3];
-    }
-    int chunk2Offset = (i - 350) + 200;
-    return std::vector<std::string>{"xxx", "yyy"}[chunk2Offset % 2];
-  });
-
-  auto readers =
-      makeReaders(chunk1, file, scanSpec, passStringBuffersFromDecoder);
-
-  using E = VectorEncoding::Simple;
-  validateWithEncodingChecks(
-      *expectedStrings,
-      *readers.rowReader,
-      kBatchSize,
-      /*totalRows=*/2 * kChunkRows,
-      {E::DICTIONARY, E::DICTIONARY, E::FLAT, E::DICTIONARY},
-      readType,
-      pool(),
-      /*childIndex=*/1);
-}
-
-// Verifies dictionary recovery after a chunk boundary crossing. The decoder
-// fully consumes chunk 1 in batches 0-1, then batch 2 is lazy (c1 not
-// loaded). When batch 3 loads c1, ensureLoaded() advances to chunk 2 (firing
-// onChunkLoad to clear stale state), then ensureDictionaryState() rebuilds
-// the alphabet from chunk 2. The skip stays within chunk 2.
-TEST_P(StringColumnReaderTest, skipAcrossChunkBoundaryDictRecovery) {
-  const bool passStringBuffersFromDecoder = GetParam();
-  if (!passStringBuffersFromDecoder) {
-    return;
-  }
-
-  constexpr int kChunkRows = 500;
-  constexpr int kBatchSize = 250;
-
-  auto chunk1 = makeRowVector({
-      makeFlatVector<int64_t>(kChunkRows, [](auto i) { return i; }),
-      makeFlatVector<std::string>(
-          kChunkRows,
-          [](auto i) {
-            return std::vector<std::string>{"aaa", "bbb", "ccc"}[i % 3];
-          }),
-  });
-  auto chunk2 = makeRowVector({
-      makeFlatVector<int64_t>(
-          kChunkRows, [](auto i) { return kChunkRows + i; }),
-      makeFlatVector<std::string>(
-          kChunkRows,
-          [](auto i) { return std::vector<std::string>{"xxx", "yyy"}[i % 2]; }),
-  });
-
-  VeloxWriterOptions writerOptions;
-  writerOptions.enableChunking = true;
-  writerOptions.minStreamChunkRawSize = 0;
-  writerOptions.flushPolicyFactory = [] {
-    return std::make_unique<LambdaFlushPolicy>(
-        /*flushLambda=*/[](const StripeProgress&) { return false; },
-        /*chunkLambda=*/[](const StripeProgress&) { return true; });
-  };
-  auto file = test::createNimbleFile(
-      *rootPool(), {chunk1, chunk2}, writerOptions, /*flushAfterWrite=*/false);
-
-  // Filter: accept [0, 499] and [750, 999]. Rejects batch 2 (rows 500-749).
-  auto readType = ROW({"c0", "c1"}, {BIGINT(), VARCHAR()});
-  auto scanSpec = std::make_shared<common::ScanSpec>("root");
-  scanSpec->addAllChildFields(*readType);
-  std::vector<std::unique_ptr<common::BigintRange>> ranges;
-  ranges.push_back(
-      std::make_unique<common::BigintRange>(
-          0, kChunkRows - 1, /*nullAllowed=*/false));
-  ranges.push_back(
-      std::make_unique<common::BigintRange>(
-          750, 2 * kChunkRows - 1, /*nullAllowed=*/false));
-  scanSpec->childByName("c0")->setFilter(
-      std::make_unique<common::BigintMultiRange>(
-          std::move(ranges), /*nullAllowed=*/false));
-
-  // Expected: 500 rows from chunk 1 + 250 rows from chunk 2 (rows 750-999).
-  auto expectedStrings = makeFlatVector<std::string>(750, [](auto i) {
-    if (i < 500) {
-      return std::vector<std::string>{"aaa", "bbb", "ccc"}[i % 3];
-    }
-    int chunk2Offset = (i - 500) + 250;
-    return std::vector<std::string>{"xxx", "yyy"}[chunk2Offset % 2];
-  });
-
-  auto readers =
-      makeReaders(chunk1, file, scanSpec, passStringBuffersFromDecoder);
-
-  // Batch 0 (offset=0, rows 0-249): chunk 1, 500 remaining >= 250 → dict
-  // Batch 1 (offset=250, rows 250-499): chunk 1, 250 remaining >= 250 → dict
-  //   After this batch, decoder has consumed all 500 values in chunk 1.
-  // Batch 2 (offset=500, rows 500-749): c0 rejects all → c1 lazy, not loaded.
-  //   readOffset stays at 500, decoder remainingValues=0.
-  // Batch 3 (offset=750, rows 750-999): c1 loaded via ColumnLoader.
-  //   ensureLoaded() loads chunk 2 (remainingValues=500). readOffset=500,
-  //   offset=750, skip=250 within chunk 2. 500 >= 250+250=500 → dict.
   using E = VectorEncoding::Simple;
   validateWithEncodingChecks(
       *expectedStrings,
@@ -772,19 +537,219 @@ TEST_P(StringColumnReaderTest, skipAcrossChunkBoundaryDictRecovery) {
       /*childIndex=*/1);
 }
 
-// Verifies that the remainingValues gate
-// forces a flat-path fallback mid-file. With 2 chunks of 300 rows and batch
-// size 200:
-//   Read 1 (rows 0-199): chunk 1 has 300 remaining >= 200, dict path taken,
-//     alphabet built from chunk 1.
-//   Read 2 (rows 200-399): chunk 1 has only 100 remaining < 200, falls to flat
-//     path which must clear dictionary state.
-//   Read 3 (rows 400-599): chunk 2 has enough rows, dict path re-entered.
-//     Must rebuild alphabet from chunk 2, not reuse stale chunk 1 alphabet.
+// Within-chunk dict read with a filter on a sibling column that creates
+// row gaps. The string column takes the dict path (no filter on its own
+// scanSpec), and the visitor's gap-skipping logic is exercised.
+TEST_P(StringColumnReaderTest, skipWithinChunkReturnsDictionary) {
+  const bool stringDecoderZeroCopy = GetParam();
+  if (!stringDecoderZeroCopy) {
+    GTEST_SKIP() << "Dictionary path requires stringDecoderZeroCopy";
+  }
+
+  constexpr int kRows = 500;
+  auto input = makeRowVector({
+      makeFlatVector<int64_t>(kRows, [](auto i) { return i; }),
+      makeFlatVector<std::string>(
+          kRows,
+          [](auto i) {
+            return std::vector<std::string>{"aaa", "bbb", "ccc"}[i % 3];
+          }),
+  });
+
+  auto file = test::createNimbleFile(*rootPool(), input);
+
+  // Filter on c0: accept first 300 rows only (creating a gap at end).
+  auto readType = ROW({"c0", "c1"}, {BIGINT(), VARCHAR()});
+  auto scanSpec = std::make_shared<common::ScanSpec>("root");
+  scanSpec->addAllChildFields(*readType);
+  scanSpec->childByName("c0")->setFilter(
+      std::make_unique<common::BigintRange>(0, 299, /*nullAllowed=*/false));
+
+  auto expectedStrings = makeFlatVector<std::string>(300, [](auto i) {
+    return std::vector<std::string>{"aaa", "bbb", "ccc"}[i % 3];
+  });
+
+  auto readers = makeReaders(input, file, scanSpec, stringDecoderZeroCopy);
+
+  using E = VectorEncoding::Simple;
+  validateWithEncodingChecks(
+      *expectedStrings,
+      *readers.rowReader,
+      /*batchSize=*/100,
+      /*totalRows=*/kRows,
+      {E::DICTIONARY, E::DICTIONARY, E::DICTIONARY},
+      readType,
+      pool(),
+      /*childIndex=*/1);
+}
+
+// Dict recovery after skip crosses a chunk boundary via filter gaps.
+// Two scenarios: (1) skip within a batch crosses the boundary, (2) entire
+// batch rejected by filter causes a between-batch skip across the boundary.
+TEST_P(StringColumnReaderTest, skipAcrossChunkBoundaryDictRecovery) {
+  const bool stringDecoderZeroCopy = GetParam();
+  if (!stringDecoderZeroCopy) {
+    GTEST_SKIP() << "Dictionary path requires stringDecoderZeroCopy";
+  }
+
+  // Scenario 1: mid-batch filter gap crosses chunk boundary.
+  // 2 chunks of 400 rows. Filter accepts [0,349] + [600,799].
+  // Batch 2 (rows 250-499): accepts 250-349, then skip from 350 to 600
+  // crosses chunk boundary → flat. Batch 3 (rows 600+): dict recovery.
+  {
+    constexpr int kChunkRows = 400;
+    auto chunk1 = makeRowVector({
+        makeFlatVector<int64_t>(kChunkRows, [](auto i) { return i; }),
+        makeFlatVector<std::string>(
+            kChunkRows,
+            [](auto i) {
+              return std::vector<std::string>{"aaa", "bbb", "ccc"}[i % 3];
+            }),
+    });
+    auto chunk2 = makeRowVector({
+        makeFlatVector<int64_t>(
+            kChunkRows, [](auto i) { return kChunkRows + i; }),
+        makeFlatVector<std::string>(
+            kChunkRows,
+            [](auto i) {
+              return std::vector<std::string>{"xxx", "yyy"}[i % 2];
+            }),
+    });
+
+    VeloxWriterOptions writerOptions;
+    writerOptions.enableChunking = true;
+    writerOptions.minStreamChunkRawSize = 0;
+    writerOptions.flushPolicyFactory = [] {
+      return std::make_unique<LambdaFlushPolicy>(
+          /*flushLambda=*/[](const StripeProgress&) { return false; },
+          /*chunkLambda=*/[](const StripeProgress&) { return true; });
+    };
+    auto file = test::createNimbleFile(
+        *rootPool(),
+        {chunk1, chunk2},
+        writerOptions,
+        /*flushAfterWrite=*/false);
+
+    auto readType = ROW({"c0", "c1"}, {BIGINT(), VARCHAR()});
+    auto scanSpec = std::make_shared<common::ScanSpec>("root");
+    scanSpec->addAllChildFields(*readType);
+    std::vector<std::unique_ptr<common::BigintRange>> ranges;
+    ranges.push_back(
+        std::make_unique<common::BigintRange>(0, 349, /*nullAllowed=*/false));
+    ranges.push_back(
+        std::make_unique<common::BigintRange>(
+            600, 2 * kChunkRows - 1, /*nullAllowed=*/false));
+    scanSpec->childByName("c0")->setFilter(
+        std::make_unique<common::BigintMultiRange>(
+            std::move(ranges), /*nullAllowed=*/false));
+
+    using E = VectorEncoding::Simple;
+    auto expectedStrings = makeFlatVector<std::string>(550, [](auto i) {
+      if (i < 350) {
+        return std::vector<std::string>{"aaa", "bbb", "ccc"}[i % 3];
+      }
+      int chunk2Offset = (i - 350) + 200;
+      return std::vector<std::string>{"xxx", "yyy"}[chunk2Offset % 2];
+    });
+
+    auto readers = makeReaders(chunk1, file, scanSpec, stringDecoderZeroCopy);
+    validateWithEncodingChecks(
+        *expectedStrings,
+        *readers.rowReader,
+        /*batchSize=*/250,
+        /*totalRows=*/2 * kChunkRows,
+        {E::DICTIONARY, E::DICTIONARY, E::DICTIONARY, E::DICTIONARY},
+        readType,
+        pool(),
+        /*childIndex=*/1);
+  }
+
+  // Scenario 2: entire batch rejected by filter, between-batch skip crosses
+  // chunk boundary. 2 chunks of 500 rows. Filter accepts [0,499] + [750,999].
+  // Batch 3 (rows 500-749): all rejected → c1 not loaded. Batch 4 (rows
+  // 750+): ensureLoaded loads chunk 2, skip 250 within chunk 2 → dict.
+  {
+    constexpr int kChunkRows = 500;
+    auto chunk1 = makeRowVector({
+        makeFlatVector<int64_t>(kChunkRows, [](auto i) { return i; }),
+        makeFlatVector<std::string>(
+            kChunkRows,
+            [](auto i) {
+              return std::vector<std::string>{"aaa", "bbb", "ccc"}[i % 3];
+            }),
+    });
+    auto chunk2 = makeRowVector({
+        makeFlatVector<int64_t>(
+            kChunkRows, [](auto i) { return kChunkRows + i; }),
+        makeFlatVector<std::string>(
+            kChunkRows,
+            [](auto i) {
+              return std::vector<std::string>{"xxx", "yyy"}[i % 2];
+            }),
+    });
+
+    VeloxWriterOptions writerOptions;
+    writerOptions.enableChunking = true;
+    writerOptions.minStreamChunkRawSize = 0;
+    writerOptions.flushPolicyFactory = [] {
+      return std::make_unique<LambdaFlushPolicy>(
+          /*flushLambda=*/[](const StripeProgress&) { return false; },
+          /*chunkLambda=*/[](const StripeProgress&) { return true; });
+    };
+    auto file = test::createNimbleFile(
+        *rootPool(),
+        {chunk1, chunk2},
+        writerOptions,
+        /*flushAfterWrite=*/false);
+
+    auto readType = ROW({"c0", "c1"}, {BIGINT(), VARCHAR()});
+    auto scanSpec = std::make_shared<common::ScanSpec>("root");
+    scanSpec->addAllChildFields(*readType);
+    std::vector<std::unique_ptr<common::BigintRange>> ranges;
+    ranges.push_back(
+        std::make_unique<common::BigintRange>(
+            0, kChunkRows - 1, /*nullAllowed=*/false));
+    ranges.push_back(
+        std::make_unique<common::BigintRange>(
+            750, 2 * kChunkRows - 1, /*nullAllowed=*/false));
+    scanSpec->childByName("c0")->setFilter(
+        std::make_unique<common::BigintMultiRange>(
+            std::move(ranges), /*nullAllowed=*/false));
+
+    using E = VectorEncoding::Simple;
+    auto expectedStrings = makeFlatVector<std::string>(750, [](auto i) {
+      if (i < 500) {
+        return std::vector<std::string>{"aaa", "bbb", "ccc"}[i % 3];
+      }
+      int chunk2Offset = (i - 500) + 250;
+      return std::vector<std::string>{"xxx", "yyy"}[chunk2Offset % 2];
+    });
+
+    auto readers = makeReaders(chunk1, file, scanSpec, stringDecoderZeroCopy);
+    validateWithEncodingChecks(
+        *expectedStrings,
+        *readers.rowReader,
+        /*batchSize=*/250,
+        /*totalRows=*/2 * kChunkRows,
+        {E::DICTIONARY, E::DICTIONARY, E::DICTIONARY},
+        readType,
+        pool(),
+        /*childIndex=*/1);
+  }
+}
+
+// Flatmap string column read via dictionary path.
+// When a string column is inside a flatmap, rows where the key is absent have
+// inMap=0 (null). The encoding only has data for in-map rows. The dictionary
+// path must account for these nulls when reading indices. If kHasNulls is
+// ignored in readWithVisitorImpl, the encoding will try to read more
+// values than it contains.
+// Read batch spans chunk boundary. With multi-chunk dictionary support,
+// the batch crosses the boundary and merges alphabets from both chunks.
 TEST_P(StringColumnReaderTest, readAcrossChunkBoundary) {
-  const bool passStringBuffersFromDecoder = GetParam();
-  if (!passStringBuffersFromDecoder) {
-    return;
+  const bool stringDecoderZeroCopy = GetParam();
+  if (!stringDecoderZeroCopy) {
+    GTEST_SKIP() << "Dictionary path requires stringDecoderZeroCopy";
   }
 
   auto chunk1 = makeRowVector({makeFlatVector<std::string>(300, [](auto i) {
@@ -814,29 +779,73 @@ TEST_P(StringColumnReaderTest, readAcrossChunkBoundary) {
 
   auto scanSpec = std::make_shared<common::ScanSpec>("root");
   scanSpec->addAllChildFields(*expected->type());
-  auto readers =
-      makeReaders(expected, file, scanSpec, passStringBuffersFromDecoder);
-  // 600 rows, batch_size=200, chunk boundary at 300:
-  //   Batch 0 (0-199): 300 remaining >= 200 → dict
-  //   Batch 1 (200-399): 100 remaining < 200 → flat (crosses boundary)
-  //   Batch 2 (400-599): chunk 2, 300 remaining >= 200 → dict
+  auto readers = makeReaders(expected, file, scanSpec, stringDecoderZeroCopy);
   using E = VectorEncoding::Simple;
   validateWithEncodingChecks(
       *expected->childAt(0),
       *readers.rowReader,
       200,
       /*totalRows=*/600,
-      {E::DICTIONARY, E::FLAT, E::DICTIONARY},
+      {E::DICTIONARY, E::DICTIONARY, E::DICTIONARY},
       asRowType(expected->type()),
       pool());
 }
 
-// Flatmap string column read via dictionary path.
-// When a string column is inside a flatmap, rows where the key is absent have
-// inMap=0 (null). The encoding only has data for in-map rows. The dictionary
-// path must account for these nulls when reading indices. If kHasNulls is
-// ignored in readDictionaryIndicesImpl, the encoding will try to read more
-// values than it contains.
+// Read across stripe boundary with pure Dictionary encoding (MC excluded).
+// Each stripe has a different alphabet. The reader must rebuild dictionary
+// state when crossing stripes.
+TEST_P(StringColumnReaderTest, readAcrossStripeBoundary) {
+  const bool stringDecoderZeroCopy = GetParam();
+  if (!stringDecoderZeroCopy) {
+    GTEST_SKIP() << "Dictionary path requires stringDecoderZeroCopy";
+  }
+
+  constexpr int kStripeRows = 150;
+  auto stripe1 =
+      makeRowVector({makeFlatVector<std::string>(kStripeRows, [](auto i) {
+        return std::vector<std::string>{"alpha", "bravo", "charlie"}[i % 3];
+      })});
+  auto stripe2 =
+      makeRowVector({makeFlatVector<std::string>(kStripeRows, [](auto i) {
+        return std::vector<std::string>{"delta", "echo"}[i % 2];
+      })});
+
+  auto readFactors = ManualEncodingSelectionPolicyFactory::defaultReadFactors();
+  std::erase_if(readFactors, [](const auto& pair) {
+    return pair.first == EncodingType::MainlyConstant;
+  });
+  VeloxWriterOptions writerOptions;
+  writerOptions.enableChunking = true;
+  writerOptions.encodingSelectionPolicyFactory =
+      [readFactors](DataType dataType) {
+        return ManualEncodingSelectionPolicyFactory(readFactors)
+            .createPolicy(dataType);
+      };
+  auto file = test::createNimbleFile(
+      *rootPool(), {stripe1, stripe2}, writerOptions, /*flushAfterWrite=*/true);
+
+  auto expected =
+      makeRowVector({makeFlatVector<std::string>(kStripeRows * 2, [](auto i) {
+        if (i < kStripeRows) {
+          return std::vector<std::string>{"alpha", "bravo", "charlie"}[i % 3];
+        }
+        return std::vector<std::string>{"delta", "echo"}[(i - kStripeRows) % 2];
+      })});
+
+  auto scanSpec = std::make_shared<common::ScanSpec>("root");
+  scanSpec->addAllChildFields(*expected->type());
+  auto readers = makeReaders(expected, file, scanSpec, stringDecoderZeroCopy);
+  using E = VectorEncoding::Simple;
+  validateWithEncodingChecks(
+      *expected->childAt(0),
+      *readers.rowReader,
+      100,
+      /*totalRows=*/2 * kStripeRows,
+      {E::DICTIONARY, E::DICTIONARY, E::DICTIONARY, E::DICTIONARY},
+      asRowType(expected->type()),
+      pool());
+}
+
 TEST_P(StringColumnReaderTest, flatMapStringDictionaryPath) {
   const bool stringDecoderZeroCopy = GetParam();
   if (!stringDecoderZeroCopy) {
@@ -936,225 +945,246 @@ TEST_P(StringColumnReaderTest, flatMapStringDictionaryPath) {
   ASSERT_EQ(0, rowReader->next(1, result));
 }
 
-// Verifies that dictionary state is invalidated via onChunkLoad when a flat
-// path read triggers a chunk transition, and the next dict-path read must
-// rebuild its alphabet from the new chunk.
-//
-// Verifies that dictionary state is invalidated via onChunkLoad when
-// consecutive reads consume exactly aligned chunks.
-//
-// Layout: chunk 1 and chunk 2 both have exactly kBatchSize rows.
-// With the ensureLoaded() fix (reload when remainingValues_==0):
-//   Read 1: ensureLoaded() loads chunk 1, remainingValues==kBatchSize,
-//     dict path entered, alphabet built from chunk 1 (2 entries).
-//   Read 2: remainingValues==0, ensureLoaded() loads chunk 2 via
-//     loadNextChunk() which fires onChunkLoad → clears dictionaryState_.
-//     Dict path re-entered, alphabet rebuilt from chunk 2 (3 entries).
-// Without onChunkLoad: stale 2-entry alphabet is reused for chunk 2's
-// 3-entry dictionary, producing wrong values or index-out-of-bounds.
-DEBUG_ONLY_TEST_P(
-    StringColumnReaderTest,
-    chunkTransitionInvalidatesDictionaryState) {
+// Multi-chunk flatmap string dictionary path. Tests kHasNulls=true dict
+// index reading across chunk boundaries with inMap nulls. Key 2 is absent
+// in some rows (inMap=0), and the batch spans two chunks.
+TEST_P(StringColumnReaderTest, flatMapStringDictionaryPathMultiChunk) {
   const bool stringDecoderZeroCopy = GetParam();
   if (!stringDecoderZeroCopy) {
     GTEST_SKIP() << "Dictionary path requires stringDecoderZeroCopy";
   }
 
-  constexpr int kBatchSize = 500;
-  // Chunk 1: 3-entry alphabet {"aaa", "bbb", "ccc"}.
-  auto chunk1 =
-      makeRowVector({makeFlatVector<std::string>(kBatchSize, [](auto i) {
-        return std::vector<std::string>{"aaa", "bbb", "ccc"}[i % 3];
-      })});
-  // Chunk 2: completely different 5-entry alphabet.
-  auto chunk2 =
-      makeRowVector({makeFlatVector<std::string>(kBatchSize, [](auto i) {
-        return std::vector<std::string>{"pp", "qq", "rr", "ss", "tt"}[i % 5];
-      })});
+  constexpr int kRowsPerChunk = 200;
+  constexpr int kTotalRows = 2 * kRowsPerChunk;
 
-  // Write chunks manually so each write() produces exactly one chunk.
-  // Set minStreamChunkRawSize=0 to prevent the chunker from merging small
-  // writes into a single chunk.
+  auto buildMapVector = [&](int startRow, int numRows) {
+    std::vector<int8_t> keys;
+    std::vector<std::string> vals;
+    std::vector<vector_size_t> offsets;
+    std::vector<vector_size_t> sizes;
+    for (int i = 0; i < numRows; ++i) {
+      int globalRow = startRow + i;
+      offsets.push_back(keys.size());
+      keys.push_back(1);
+      vals.push_back("val_" + std::to_string(globalRow % 5));
+      if (globalRow % 3 != 0) {
+        keys.push_back(2);
+        vals.push_back("key2_" + std::to_string(globalRow % 4));
+      }
+      sizes.push_back(keys.size() - offsets.back());
+    }
+    auto keysFv = makeFlatVector<int8_t>(keys);
+    auto valsFv = makeFlatVector<std::string>(vals);
+    auto offBuf = allocateOffsets(numRows, pool());
+    auto sizBuf = allocateSizes(numRows, pool());
+    auto* rawOff = offBuf->asMutable<vector_size_t>();
+    auto* rawSiz = sizBuf->asMutable<vector_size_t>();
+    for (int i = 0; i < numRows; ++i) {
+      rawOff[i] = offsets[i];
+      rawSiz[i] = sizes[i];
+    }
+    return makeRowVector({std::make_shared<MapVector>(
+        pool(),
+        MAP(TINYINT(), VARCHAR()),
+        nullptr,
+        numRows,
+        offBuf,
+        sizBuf,
+        keysFv,
+        valsFv)});
+  };
+
+  auto chunk1 = buildMapVector(0, kRowsPerChunk);
+  auto chunk2 = buildMapVector(kRowsPerChunk, kRowsPerChunk);
+
   VeloxWriterOptions writerOptions;
   writerOptions.enableChunking = true;
   writerOptions.minStreamChunkRawSize = 0;
+  writerOptions.flatMapColumns = {{"c0", {}}};
   writerOptions.flushPolicyFactory = [] {
     return std::make_unique<LambdaFlushPolicy>(
         /*flushLambda=*/[](const StripeProgress&) { return false; },
         /*chunkLambda=*/[](const StripeProgress&) { return true; });
   };
+  auto file = test::createNimbleFile(
+      *rootPool(), {chunk1, chunk2}, writerOptions, /*flushAfterWrite=*/false);
+
+  auto outType = ROW({"c0"}, {ROW({"1", "2"}, {VARCHAR(), VARCHAR()})});
+  auto scanSpec = std::make_shared<common::ScanSpec>("root");
+  scanSpec->addAllChildFields(*outType);
+  scanSpec->childByName("c0")->setFlatMapAsStruct(true);
+
+  auto readFile = std::make_shared<InMemoryReadFile>(file);
+  auto factory =
+      dwio::common::getReaderFactory(dwio::common::FileFormat::NIMBLE);
+  dwio::common::ReaderOptions options(pool());
+  options.setDataIoStats(dataIoStats_);
+  options.setMetadataIoStats(metadataIoStats_);
+  options.setScanSpec(scanSpec);
+  auto reader = factory->createReader(
+      std::make_unique<dwio::common::BufferedInput>(readFile, *pool()),
+      options);
+  dwio::common::RowReaderOptions rowOptions;
+  rowOptions.setScanSpec(scanSpec);
+  rowOptions.setRequestedType(asRowType(chunk1->type()));
+  rowOptions.setStringDecoderZeroCopy(true);
+  rowOptions.setNimblePreserveDictionaryEncoding(true);
+  auto rowReader = reader->createRowReader(rowOptions);
+
+  auto expected = makeRowVector({makeRowVector(
+      {"1", "2"},
+      {
+          makeFlatVector<std::string>(
+              kTotalRows,
+              [](auto i) { return "val_" + std::to_string(i % 5); }),
+          makeFlatVector<std::string>(
+              kTotalRows,
+              [](auto i) { return "key2_" + std::to_string(i % 4); },
+              [](auto i) { return i % 3 == 0; }),
+      })});
+
+  // Batch size 300 spans the chunk boundary at row 200.
+  auto result = BaseVector::create(outType, 0, pool());
+  int numScanned = 0;
+  int offset = 0;
+  while (numScanned < kTotalRows) {
+    numScanned += rowReader->next(300, result);
+    result->validate();
+    for (int j = 0; j < result->size(); ++j) {
+      ASSERT_TRUE(result->equalValueAt(expected.get(), j, offset + j))
+          << "Mismatch at row " << (offset + j);
+    }
+    offset += result->size();
+  }
+  ASSERT_EQ(numScanned, kTotalRows);
+  ASSERT_EQ(0, rowReader->next(1, result));
+}
+
+// Mainly-constant string column with chunking. The data shape naturally
+// triggers MainlyConstant→Dictionary encoding: a long dominant common value
+// with a small repeating "other" alphabet. The read batch spans multiple
+// chunks, exercising readIndicesWithVisitor across chunk boundaries in
+// ChunkedDecoder's loop.
+TEST_P(StringColumnReaderTest, mainlyConstantDictionaryMultiChunk) {
+  const bool stringDecoderZeroCopy = GetParam();
+  if (!stringDecoderZeroCopy) {
+    GTEST_SKIP() << "Dictionary path requires stringDecoderZeroCopy";
+  }
+  const int numRows = 10000;
+  // ~95% common value, ~5% cycling through 3 other values.
+  // The long common string makes MC encoding strongly preferred over plain
+  // Dictionary. The repeating small "other" alphabet ensures Dictionary is
+  // selected for the sub-encoding.
+  const std::string commonValue(50, 'x');
+  const std::string otherValues[] = {"alpha", "bravo", "charlie"};
+  auto input = makeRowVector({
+      makeFlatVector<std::string>(
+          numRows,
+          [&](auto i) {
+            return i % 20 == 0 ? otherValues[i % 3] : commonValue;
+          }),
+  });
+
+  VeloxWriterOptions writerOptions;
+  writerOptions.enableChunking = true;
+  // Chunk every other write: 1000 rows per chunk.
+  auto writeCount = std::make_shared<int>(0);
+  writerOptions.flushPolicyFactory = [writeCount] {
+    return std::make_unique<LambdaFlushPolicy>(
+        [](const StripeProgress&) { return false; },
+        [writeCount](const StripeProgress&) {
+          return ++(*writeCount) % 2 == 0;
+        });
+  };
+
+  // Write 500 rows per batch → chunks of 1000 rows (2 writes per chunk).
+  // Each chunk has ~50 "other" values (3 distinct, ~17 repeats each),
+  // enough for Dictionary to be selected for the sub-encoding.
   std::string file;
   {
     auto writeFile = std::make_unique<velox::InMemoryWriteFile>(&file);
     VeloxWriter writer(
-        chunk1->type(),
+        input->type(),
         std::move(writeFile),
         *rootPool(),
         std::move(writerOptions));
-    writer.write(chunk1);
-    writer.write(chunk2);
+    const int batchWriteSize = 500;
+    for (int i = 0; i < numRows; i += batchWriteSize) {
+      writer.write(input->slice(i, std::min(batchWriteSize, numRows - i)));
+    }
     writer.close();
   }
 
-  auto expected =
-      makeRowVector({makeFlatVector<std::string>(kBatchSize * 2, [](auto i) {
-        if (i < kBatchSize) {
-          return std::vector<std::string>{"aaa", "bbb", "ccc"}[i % 3];
-        }
-        return std::vector<std::string>{
-            "pp", "qq", "rr", "ss", "tt"}[(i - kBatchSize) % 5];
-      })});
-
-  auto scanSpec = std::make_shared<common::ScanSpec>("root");
-  scanSpec->addAllChildFields(*expected->type());
-  auto readers = makeReaders(expected, file, scanSpec, stringDecoderZeroCopy);
-
-  int dictPathEntries = 0;
-  SCOPED_TESTVALUE_SET(
-      "facebook::nimble::StringColumnReader::readWithDictionary",
-      std::function<void(const std::vector<std::string_view>*)>(
-          [&](const std::vector<std::string_view>* alphabet) {
-            std::set<std::string> entries;
-            for (const auto& sv : *alphabet) {
-              entries.insert(std::string(sv));
-            }
-            if (dictPathEntries == 0) {
-              // Chunk 1 alphabet should contain chunk 1 values only.
-              EXPECT_TRUE(entries.count("aaa"));
-              EXPECT_FALSE(entries.count("pp"))
-                  << "Chunk 1 alphabet contains stale chunk 2 values";
-            } else {
-              // Chunk 2 alphabet should contain chunk 2 values only.
-              EXPECT_TRUE(entries.count("pp"));
-              EXPECT_FALSE(entries.count("aaa"))
-                  << "Chunk 2 alphabet contains stale chunk 1 values";
-            }
-            ++dictPathEntries;
-          }));
-
-  validateWithEncodingChecks(
-      *expected->childAt(0),
-      *readers.rowReader,
-      kBatchSize,
-      /*totalRows=*/2 * kBatchSize,
-      {VectorEncoding::Simple::DICTIONARY, VectorEncoding::Simple::DICTIONARY},
-      asRowType(expected->type()),
-      pool());
-  // Both reads should enter the dict path: one per chunk. The validate call
-  // verifies data correctness and DictionaryVector output — if the
-  // onChunkLoad callback didn't clear stale dictionary state, the second
-  // read would use chunk 1's alphabet to decode chunk 2's indices.
-  EXPECT_EQ(dictPathEntries, 2)
-      << "Expected dict path to be entered for both chunks";
-}
-
-// Verifies correctness when reads cross stripe boundaries in a non-chunked
-// layout. We always break reads at the stripe boundaries, so there are no chunk
-// transitions, thus we can always read with dictionary encoding.
-TEST_P(StringColumnReaderTest, readAcrossStripeBoundary) {
-  const bool stringDecoderZeroCopy = GetParam();
-  if (!stringDecoderZeroCopy) {
-    GTEST_SKIP() << "Dictionary path requires stringDecoderZeroCopy";
-  }
-
-  constexpr int kStripeRows = 150;
-  // Stripe 1: alphabet {"alpha", "bravo", "charlie"}.
-  auto stripe1 =
-      makeRowVector({makeFlatVector<std::string>(kStripeRows, [](auto i) {
-        return std::vector<std::string>{"alpha", "bravo", "charlie"}[i % 3];
-      })});
-  // Stripe 2: different alphabet {"delta", "echo"}.
-  auto stripe2 =
-      makeRowVector({makeFlatVector<std::string>(kStripeRows, [](auto i) {
-        return std::vector<std::string>{"delta", "echo"}[i % 2];
-      })});
-
-  // Each write call becomes a separate stripe. Remove MainlyConstant from
-  // read factors to force Dictionary as top-level encoding.
-  auto readFactors = ManualEncodingSelectionPolicyFactory::defaultReadFactors();
-  std::erase_if(readFactors, [](const auto& pair) {
-    return pair.first == EncodingType::MainlyConstant;
-  });
-  VeloxWriterOptions writerOptions;
-  writerOptions.enableChunking = true;
-  writerOptions.encodingSelectionPolicyFactory =
-      [readFactors](DataType dataType) {
-        return ManualEncodingSelectionPolicyFactory(readFactors)
-            .createPolicy(dataType);
-      };
-  auto file = test::createNimbleFile(
-      *rootPool(), {stripe1, stripe2}, writerOptions, /*flushAfterWrite=*/true);
-
-  auto expected =
-      makeRowVector({makeFlatVector<std::string>(kStripeRows * 2, [](auto i) {
-        if (i < kStripeRows) {
-          return std::vector<std::string>{"alpha", "bravo", "charlie"}[i % 3];
-        }
-        return std::vector<std::string>{"delta", "echo"}[(i - kStripeRows) % 2];
-      })});
-
-  auto scanSpec = std::make_shared<common::ScanSpec>("root");
-  scanSpec->addAllChildFields(*expected->type());
-  auto readers = makeReaders(expected, file, scanSpec, stringDecoderZeroCopy);
-  // 300 rows, batch_size=100, stripe boundary at 150:
-  //   Batch 0 (0-99): stripe 1, 150 remaining >= 100 → dict
-  //   Batch 1 (100-149): stripe 1, 50 remaining >= 50 → dict
-  //   Batch 2 (0-99): stripe 2 (fresh reader), 150 remaining >= 100 → dict
-  //   Batch 3 (100-149): stripe 2, 50 remaining >= 50 → dict
-  using E = VectorEncoding::Simple;
-  validateWithEncodingChecks(
-      *expected->childAt(0),
-      *readers.rowReader,
-      100,
-      /*totalRows=*/2 * kStripeRows,
-      {E::DICTIONARY, E::DICTIONARY, E::DICTIONARY, E::DICTIONARY},
-      asRowType(expected->type()),
-      pool());
-}
-
-// Verifies that the dictionary path is entered and the alphabet has the
-// expected size for single-chunk reads. Uses TestValue to inspect internal
-// reader state without exposing private members.
-DEBUG_ONLY_TEST_P(StringColumnReaderTest, dictionaryPathAlphabetSize) {
-  const bool stringDecoderZeroCopy = GetParam();
-  if (!stringDecoderZeroCopy) {
-    GTEST_SKIP() << "Dictionary path requires stringDecoderZeroCopy";
-  }
-
-  constexpr int kRows = 500;
-  // 3-entry alphabet with high repetition to trigger Dictionary encoding.
-  auto input = makeRowVector({makeFlatVector<std::string>(kRows, [](auto i) {
-    return std::vector<std::string>{"alpha", "bravo", "charlie"}[i % 3];
-  })});
-
   auto scanSpec = std::make_shared<common::ScanSpec>("root");
   scanSpec->addAllChildFields(*input->type());
-  auto readers = makeReaders(input, scanSpec, stringDecoderZeroCopy);
-
-  int dictPathEntries = 0;
-  SCOPED_TESTVALUE_SET(
-      "facebook::nimble::StringColumnReader::readWithDictionary",
-      std::function<void(const std::vector<std::string_view>*)>(
-          [&](const std::vector<std::string_view>* alphabet) {
-            ++dictPathEntries;
-            std::set<std::string> entries;
-            for (const auto& sv : *alphabet) {
-              entries.insert(std::string(sv));
-            }
-            EXPECT_TRUE(entries.count("alpha"));
-            EXPECT_TRUE(entries.count("bravo"));
-            EXPECT_TRUE(entries.count("charlie"));
-          }));
-
+  auto readers = makeReaders(input, file, scanSpec, stringDecoderZeroCopy);
+  using E = VectorEncoding::Simple;
   validateWithEncodingChecks(
       *input->childAt(0),
       *readers.rowReader,
-      kRows,
-      /*totalRows=*/kRows,
-      {VectorEncoding::Simple::DICTIONARY},
+      /*batchSize=*/5000,
+      /*totalRows=*/numRows,
+      {E::DICTIONARY, E::DICTIONARY},
       asRowType(input->type()),
       pool());
-  EXPECT_EQ(dictPathEntries, 1);
+}
+
+// Same as above but with nulls.
+TEST_P(StringColumnReaderTest, mainlyConstantDictionaryMultiChunkWithNulls) {
+  const bool stringDecoderZeroCopy = GetParam();
+  if (!stringDecoderZeroCopy) {
+    GTEST_SKIP() << "Dictionary path requires stringDecoderZeroCopy";
+  }
+  const int numRows = 10000;
+  const std::string commonValue(50, 'x');
+  const std::string otherValues[] = {"alpha", "bravo", "charlie"};
+  auto input = makeRowVector({
+      makeFlatVector<std::string>(
+          numRows,
+          [&](auto i) {
+            return i % 20 == 0 ? otherValues[i % 3] : commonValue;
+          },
+          nullEvery(7)),
+  });
+
+  VeloxWriterOptions writerOptions;
+  writerOptions.enableChunking = true;
+  auto writeCount = std::make_shared<int>(0);
+  writerOptions.flushPolicyFactory = [writeCount] {
+    return std::make_unique<LambdaFlushPolicy>(
+        [](const StripeProgress&) { return false; },
+        [writeCount](const StripeProgress&) {
+          return ++(*writeCount) % 2 == 0;
+        });
+  };
+
+  std::string file;
+  {
+    auto writeFile = std::make_unique<velox::InMemoryWriteFile>(&file);
+    VeloxWriter writer(
+        input->type(),
+        std::move(writeFile),
+        *rootPool(),
+        std::move(writerOptions));
+    const int batchWriteSize = 500;
+    for (int i = 0; i < numRows; i += batchWriteSize) {
+      writer.write(input->slice(i, std::min(batchWriteSize, numRows - i)));
+    }
+    writer.close();
+  }
+
+  auto scanSpec = std::make_shared<common::ScanSpec>("root");
+  scanSpec->addAllChildFields(*input->type());
+  auto readers = makeReaders(input, file, scanSpec, stringDecoderZeroCopy);
+  using E = VectorEncoding::Simple;
+  validateWithEncodingChecks(
+      *input->childAt(0),
+      *readers.rowReader,
+      /*batchSize=*/5000,
+      /*totalRows=*/numRows,
+      {E::DICTIONARY, E::DICTIONARY},
+      asRowType(input->type()),
+      pool());
 }
 
 // Basic mainly-constant string read: ~95% common value with a small other
@@ -1629,12 +1659,795 @@ TEST_P(StringColumnReaderTest, filterOnlyMultiChunkNumValuesSync) {
   ASSERT_EQ(readRows(/*projectOut=*/false), expected);
 }
 
+// Verifies that the dictionary alphabet is rebuilt when crossing chunk
+// boundaries. Uses TestValue injection to inspect the alphabet at the
+// readWithDictionary entry point.
+DEBUG_ONLY_TEST_P(
+    StringColumnReaderTest,
+    chunkTransitionInvalidatesDictionaryState) {
+  const bool stringDecoderZeroCopy = GetParam();
+  if (!stringDecoderZeroCopy) {
+    GTEST_SKIP() << "Dictionary path requires stringDecoderZeroCopy";
+  }
+
+  constexpr int kBatchSize = 500;
+  auto chunk1 =
+      makeRowVector({makeFlatVector<std::string>(kBatchSize, [](auto i) {
+        return std::vector<std::string>{"aaa", "bbb", "ccc"}[i % 3];
+      })});
+  auto chunk2 =
+      makeRowVector({makeFlatVector<std::string>(kBatchSize, [](auto i) {
+        return std::vector<std::string>{"pp", "qq", "rr", "ss", "tt"}[i % 5];
+      })});
+
+  VeloxWriterOptions writerOptions;
+  writerOptions.enableChunking = true;
+  writerOptions.minStreamChunkRawSize = 0;
+  writerOptions.flushPolicyFactory = [] {
+    return std::make_unique<LambdaFlushPolicy>(
+        /*flushLambda=*/[](const StripeProgress&) { return false; },
+        /*chunkLambda=*/[](const StripeProgress&) { return true; });
+  };
+  std::string file;
+  {
+    auto writeFile = std::make_unique<velox::InMemoryWriteFile>(&file);
+    VeloxWriter writer(
+        chunk1->type(),
+        std::move(writeFile),
+        *rootPool(),
+        std::move(writerOptions));
+    writer.write(chunk1);
+    writer.write(chunk2);
+    writer.close();
+  }
+
+  auto expected =
+      makeRowVector({makeFlatVector<std::string>(kBatchSize * 2, [](auto i) {
+        if (i < kBatchSize) {
+          return std::vector<std::string>{"aaa", "bbb", "ccc"}[i % 3];
+        }
+        return std::vector<std::string>{
+            "pp", "qq", "rr", "ss", "tt"}[(i - kBatchSize) % 5];
+      })});
+
+  auto scanSpec = std::make_shared<common::ScanSpec>("root");
+  scanSpec->addAllChildFields(*expected->type());
+  auto readers = makeReaders(expected, file, scanSpec, stringDecoderZeroCopy);
+
+  int dictPathEntries = 0;
+  SCOPED_TESTVALUE_SET(
+      "facebook::nimble::StringColumnReader::readWithDictionary",
+      std::function<void(const std::vector<std::string_view>*)>(
+          [&](const std::vector<std::string_view>* alphabet) {
+            std::set<std::string> entries;
+            for (const auto& sv : *alphabet) {
+              entries.insert(std::string(sv));
+            }
+            if (dictPathEntries == 0) {
+              EXPECT_TRUE(entries.count("aaa"));
+              EXPECT_FALSE(entries.count("pp"))
+                  << "Chunk 1 alphabet contains stale chunk 2 values";
+            } else {
+              EXPECT_TRUE(entries.count("pp"));
+              EXPECT_FALSE(entries.count("aaa"))
+                  << "Chunk 2 alphabet contains stale chunk 1 values";
+            }
+            ++dictPathEntries;
+          }));
+
+  using E = VectorEncoding::Simple;
+  validateWithEncodingChecks(
+      *expected->childAt(0),
+      *readers.rowReader,
+      kBatchSize,
+      /*totalRows=*/2 * kBatchSize,
+      {E::DICTIONARY, E::DICTIONARY},
+      asRowType(expected->type()),
+      pool());
+  EXPECT_EQ(dictPathEntries, 2);
+}
+
+// Verifies the dictionary alphabet size via TestValue injection.
+DEBUG_ONLY_TEST_P(StringColumnReaderTest, dictionaryPathAlphabetSize) {
+  const bool stringDecoderZeroCopy = GetParam();
+  if (!stringDecoderZeroCopy) {
+    GTEST_SKIP() << "Dictionary path requires stringDecoderZeroCopy";
+  }
+
+  constexpr int kRows = 500;
+  auto input = makeRowVector({makeFlatVector<std::string>(kRows, [](auto i) {
+    return std::vector<std::string>{"alpha", "bravo", "charlie"}[i % 3];
+  })});
+
+  auto scanSpec = std::make_shared<common::ScanSpec>("root");
+  scanSpec->addAllChildFields(*input->type());
+  auto readers = makeReaders(input, scanSpec, stringDecoderZeroCopy);
+
+  int dictPathEntries = 0;
+  SCOPED_TESTVALUE_SET(
+      "facebook::nimble::StringColumnReader::readWithDictionary",
+      std::function<void(const std::vector<std::string_view>*)>(
+          [&](const std::vector<std::string_view>* alphabet) {
+            ++dictPathEntries;
+            std::set<std::string> entries;
+            for (const auto& sv : *alphabet) {
+              entries.insert(std::string(sv));
+            }
+            EXPECT_TRUE(entries.count("alpha"));
+            EXPECT_TRUE(entries.count("bravo"));
+            EXPECT_TRUE(entries.count("charlie"));
+          }));
+
+  using E = VectorEncoding::Simple;
+  validateWithEncodingChecks(
+      *input->childAt(0),
+      *readers.rowReader,
+      kRows,
+      /*totalRows=*/kRows,
+      {E::DICTIONARY},
+      asRowType(input->type()),
+      pool());
+  EXPECT_EQ(dictPathEntries, 1);
+}
+
+// Reactive fallback: chunk 1 is dictionary-encoded, chunk 2 is trivial.
+// A batch spanning both chunks starts on the dict path, encounters the
+// non-dict chunk at the boundary, and must expand already-read dict
+// indices to flat StringViews before reading the rest as flat.
+TEST_P(StringColumnReaderTest, flatEncodingFallback) {
+  const bool stringDecoderZeroCopy = GetParam();
+  if (!stringDecoderZeroCopy) {
+    GTEST_SKIP() << "Dictionary path requires stringDecoderZeroCopy";
+  }
+
+  // Chunk 1: low-cardinality → dictionary encoding.
+  auto chunk1 = makeRowVector({makeFlatVector<std::string>(500, [](auto i) {
+    return std::vector<std::string>{"aaa", "bbb", "ccc"}[i % 3];
+  })});
+  // Chunk 2: all unique → trivial encoding.
+  auto chunk2 = makeRowVector({makeFlatVector<std::string>(500, [](auto i) {
+    return fmt::format("unique_value_row_{}_padding_to_avoid_inline", i);
+  })});
+
+  VeloxWriterOptions writerOptions;
+  writerOptions.enableChunking = true;
+  writerOptions.minStreamChunkRawSize = 0;
+  writerOptions.flushPolicyFactory = [] {
+    return std::make_unique<LambdaFlushPolicy>(
+        /*flushLambda=*/[](const StripeProgress&) { return false; },
+        /*chunkLambda=*/[](const StripeProgress&) { return true; });
+  };
+  auto file = test::createNimbleFile(
+      *rootPool(), {chunk1, chunk2}, writerOptions, /*flushAfterWrite=*/false);
+
+  auto expected = makeRowVector({makeFlatVector<std::string>(1000, [](auto i) {
+    if (i < 500) {
+      return std::vector<std::string>{"aaa", "bbb", "ccc"}[i % 3];
+    }
+    return fmt::format("unique_value_row_{}_padding_to_avoid_inline", i - 500);
+  })});
+
+  auto scanSpec = std::make_shared<common::ScanSpec>("root");
+  scanSpec->addAllChildFields(*expected->type());
+  auto readers = makeReaders(expected, file, scanSpec, stringDecoderZeroCopy);
+  // Batch size 1000 spans both chunks. The reader starts with dict,
+  // hits the trivial chunk, and must fall back to flat for the whole batch.
+  validate(*expected, *readers.rowReader, 1000);
+}
+
+// Verifies that the reactive fallback from dict to flat preserves nulls
+// correctly. When nullsInReadRange_ covers the full batch, the flat
+// continuation must read from the correct offset without corrupting the
+// bitmap. Regression test for a bug where shifting nullsInReadRange_ in
+// place would corrupt the result nulls returned by getValues.
+TEST_P(StringColumnReaderTest, flatEncodingFallbackWithNulls) {
+  const bool stringDecoderZeroCopy = GetParam();
+  if (!stringDecoderZeroCopy) {
+    GTEST_SKIP() << "Dictionary path requires stringDecoderZeroCopy";
+  }
+
+  // Chunk 1: low-cardinality with nulls → dictionary encoding.
+  auto chunk1 = makeRowVector({makeFlatVector<std::string>(
+      500,
+      [](auto i) {
+        return std::vector<std::string>{"aaa", "bbb", "ccc"}[i % 3];
+      },
+      velox::test::VectorMaker::nullEvery(7))});
+
+  // Chunk 2: all unique → trivial encoding, with nulls.
+  auto chunk2 = makeRowVector({makeFlatVector<std::string>(
+      500,
+      [](auto i) {
+        return fmt::format("unique_value_row_{}_padding_to_avoid_inline", i);
+      },
+      velox::test::VectorMaker::nullEvery(11))});
+
+  VeloxWriterOptions writerOptions;
+  writerOptions.enableChunking = true;
+  writerOptions.minStreamChunkRawSize = 0;
+  writerOptions.flushPolicyFactory = [] {
+    return std::make_unique<LambdaFlushPolicy>(
+        /*flushLambda=*/[](const StripeProgress&) { return false; },
+        /*chunkLambda=*/[](const StripeProgress&) { return true; });
+  };
+  auto file = test::createNimbleFile(
+      *rootPool(), {chunk1, chunk2}, writerOptions, /*flushAfterWrite=*/false);
+
+  auto expected = makeRowVector({makeFlatVector<std::string>(
+      1000,
+      [](auto i) {
+        if (i < 500) {
+          return std::vector<std::string>{"aaa", "bbb", "ccc"}[i % 3];
+        }
+        return fmt::format(
+            "unique_value_row_{}_padding_to_avoid_inline", i - 500);
+      },
+      [](auto i) -> bool {
+        return i < 500 ? (i % 7 == 0) : ((i - 500) % 11 == 0);
+      })});
+
+  auto scanSpec = std::make_shared<common::ScanSpec>("root");
+  scanSpec->addAllChildFields(*expected->type());
+  auto readers = makeReaders(expected, file, scanSpec, stringDecoderZeroCopy);
+  validate(*expected, *readers.rowReader, 1000);
+}
+
+// Variable read range scenarios testing transitions between multi-chunk
+// dict reads, mid-chunk dict reads, and flat reads.
+TEST_P(StringColumnReaderTest, variableReadRangeTransitions) {
+  const bool stringDecoderZeroCopy = GetParam();
+  if (!stringDecoderZeroCopy) {
+    GTEST_SKIP() << "Dictionary path requires stringDecoderZeroCopy";
+  }
+
+  using E = VectorEncoding::Simple;
+
+  // Scenario 1: multi-chunk dict → mid-chunk dict.
+  // 3 chunks of 500 rows (MC pattern: ~95% common, ~5% other), batch 750.
+  // Batch 1 (0-749): spans chunk 1 (500) + chunk 2 (250) → multi-chunk dict.
+  // Batch 2 (750-1499): mid-chunk 2 (250) + chunk 3 (500) → multi-chunk dict.
+  {
+    const std::string commonValues[] = {
+        std::string(50, 'a'), std::string(50, 'x'), std::string(50, 'm')};
+    const std::string otherValues[] = {"alpha", "bravo", "charlie"};
+
+    std::vector<velox::VectorPtr> chunks;
+    chunks.reserve(3);
+    for (int c = 0; c < 3; ++c) {
+      chunks.push_back(
+          makeRowVector({makeFlatVector<std::string>(500, [&](auto i) {
+            return i % 20 == 0 ? otherValues[i % 3] : commonValues[c];
+          })}));
+    }
+
+    VeloxWriterOptions writerOptions;
+    writerOptions.enableChunking = true;
+    writerOptions.minStreamChunkRawSize = 0;
+    writerOptions.flushPolicyFactory = [] {
+      return std::make_unique<LambdaFlushPolicy>(
+          /*flushLambda=*/[](const StripeProgress&) { return false; },
+          /*chunkLambda=*/[](const StripeProgress&) { return true; });
+    };
+    auto file = test::createNimbleFile(
+        *rootPool(), chunks, writerOptions, /*flushAfterWrite=*/false);
+
+    auto expected =
+        makeRowVector({makeFlatVector<std::string>(1500, [&](auto i) {
+          int c = i / 500;
+          int r = i % 500;
+          return r % 20 == 0 ? otherValues[r % 3] : commonValues[c];
+        })});
+
+    auto scanSpec = std::make_shared<common::ScanSpec>("root");
+    scanSpec->addAllChildFields(*expected->type());
+    auto readers = makeReaders(expected, file, scanSpec, stringDecoderZeroCopy);
+    validateWithEncodingChecks(
+        *expected->childAt(0),
+        *readers.rowReader,
+        /*batchSize=*/750,
+        /*totalRows=*/1500,
+        {E::DICTIONARY, E::DICTIONARY},
+        asRowType(expected->type()),
+        pool());
+  }
+
+  // Scenario 2: single-chunk dict → mid-chunk dict (no boundary crossing).
+  // 1 chunk of 1000 rows (MC pattern), batch 200.
+  // All 5 batches stay within the same chunk → dict, alphabet reused.
+  {
+    const std::string commonValue(50, 'x');
+    const std::string otherValues[] = {"alpha", "bravo", "charlie"};
+    auto input = makeRowVector({makeFlatVector<std::string>(1000, [&](auto i) {
+      return i % 20 == 0 ? otherValues[i % 3] : commonValue;
+    })});
+
+    VeloxWriterOptions writerOptions;
+    writerOptions.enableChunking = true;
+    writerOptions.minStreamChunkRawSize = 0;
+    writerOptions.flushPolicyFactory = [] {
+      return std::make_unique<LambdaFlushPolicy>(
+          /*flushLambda=*/[](const StripeProgress&) { return false; },
+          /*chunkLambda=*/[](const StripeProgress&) { return true; });
+    };
+    auto file = test::createNimbleFile(
+        *rootPool(), input, writerOptions, /*flushAfterWrite=*/false);
+
+    auto scanSpec = std::make_shared<common::ScanSpec>("root");
+    scanSpec->addAllChildFields(*input->type());
+    auto readers = makeReaders(input, file, scanSpec, stringDecoderZeroCopy);
+    validateWithEncodingChecks(
+        *input->childAt(0),
+        *readers.rowReader,
+        /*batchSize=*/200,
+        /*totalRows=*/1000,
+        {E::DICTIONARY,
+         E::DICTIONARY,
+         E::DICTIONARY,
+         E::DICTIONARY,
+         E::DICTIONARY},
+        asRowType(input->type()),
+        pool());
+  }
+
+  // Scenario 3: flat multi-chunk read (non-dict chunks) → mid-chunk dict read.
+  // Chunk 1: unique strings (trivial encoding). Chunk 2: low-cardinality
+  // (dict). Batch 1 (0-399): spans chunk 1 (300) + chunk 2 (100) — chunk 1 is
+  // non-dict,
+  //   so the dict path fails at the start and falls to flat for the whole
+  //   batch.
+  // Batch 2 (400-599): mid-chunk 2, dict-compatible → dict path.
+  {
+    auto chunk1 = makeRowVector({makeFlatVector<std::string>(300, [](auto i) {
+      return fmt::format("unique_row_{}_padding_to_avoid_inline", i);
+    })});
+    const std::string commonValue(50, 'x');
+    const std::string otherValues[] = {"alpha", "bravo", "charlie"};
+    auto chunk2 = makeRowVector({makeFlatVector<std::string>(300, [&](auto i) {
+      return i % 20 == 0 ? otherValues[i % 3] : commonValue;
+    })});
+
+    VeloxWriterOptions writerOptions;
+    writerOptions.enableChunking = true;
+    writerOptions.minStreamChunkRawSize = 0;
+    writerOptions.flushPolicyFactory = [] {
+      return std::make_unique<LambdaFlushPolicy>(
+          /*flushLambda=*/[](const StripeProgress&) { return false; },
+          /*chunkLambda=*/[](const StripeProgress&) { return true; });
+    };
+    auto file = test::createNimbleFile(
+        *rootPool(),
+        {chunk1, chunk2},
+        writerOptions,
+        /*flushAfterWrite=*/false);
+
+    auto expected =
+        makeRowVector({makeFlatVector<std::string>(600, [&](auto i) {
+          if (i < 300) {
+            return fmt::format("unique_row_{}_padding_to_avoid_inline", i);
+          }
+          auto r = i - 300;
+          return r % 20 == 0 ? otherValues[r % 3] : commonValue;
+        })});
+
+    auto scanSpec = std::make_shared<common::ScanSpec>("root");
+    scanSpec->addAllChildFields(*expected->type());
+    auto readers = makeReaders(expected, file, scanSpec, stringDecoderZeroCopy);
+    // Batch 1: flat (chunk 1 is trivial). Batch 2: dict (mid-chunk 2).
+    validateWithEncodingChecks(
+        *expected->childAt(0),
+        *readers.rowReader,
+        /*batchSize=*/400,
+        /*totalRows=*/600,
+        {E::FLAT, E::DICTIONARY},
+        asRowType(expected->type()),
+        pool());
+  }
+
+  // Scenario 4: multi-chunk dict → reactive fallback flat → dict recovery.
+  // Chunk 1: dict (MC). Chunk 2: unique (trivial). Chunk 3: dict (MC).
+  // Batch 1 (0-399): spans chunk 1 (400 of 500) → dict.
+  // Batch 2 (400-799): chunk 1 (100) → chunk 2 (300). Chunk 2 non-dict
+  //   → reactive fallback, batch is flat.
+  // Batch 3 (800-1199): chunk 2 (200) → chunk 3 (200). Chunk 2 non-dict
+  //   at start → flat.
+  // Batch 4 (1200-1499): mid-chunk 3, dict → dict recovery.
+  {
+    const std::string commonValue1(50, 'a');
+    const std::string commonValue3(50, 'm');
+    const std::string otherValues[] = {"alpha", "bravo", "charlie"};
+
+    auto chunk1 = makeRowVector({makeFlatVector<std::string>(500, [&](auto i) {
+      return i % 20 == 0 ? otherValues[i % 3] : commonValue1;
+    })});
+    auto chunk2 = makeRowVector({makeFlatVector<std::string>(500, [](auto i) {
+      return fmt::format("unique_chunk2_row_{}_pad_to_avoid_inline", i);
+    })});
+    auto chunk3 = makeRowVector({makeFlatVector<std::string>(500, [&](auto i) {
+      return i % 20 == 0 ? otherValues[i % 3] : commonValue3;
+    })});
+
+    VeloxWriterOptions writerOptions;
+    writerOptions.enableChunking = true;
+    writerOptions.minStreamChunkRawSize = 0;
+    writerOptions.flushPolicyFactory = [] {
+      return std::make_unique<LambdaFlushPolicy>(
+          /*flushLambda=*/[](const StripeProgress&) { return false; },
+          /*chunkLambda=*/[](const StripeProgress&) { return true; });
+    };
+    auto file = test::createNimbleFile(
+        *rootPool(),
+        {chunk1, chunk2, chunk3},
+        writerOptions,
+        /*flushAfterWrite=*/false);
+
+    auto expected =
+        makeRowVector({makeFlatVector<std::string>(1500, [&](auto i) {
+          if (i < 500) {
+            return i % 20 == 0 ? otherValues[i % 3] : commonValue1;
+          }
+          if (i < 1000) {
+            return fmt::format(
+                "unique_chunk2_row_{}_pad_to_avoid_inline", i - 500);
+          }
+          auto r = i - 1000;
+          return r % 20 == 0 ? otherValues[r % 3] : commonValue3;
+        })});
+
+    auto scanSpec = std::make_shared<common::ScanSpec>("root");
+    scanSpec->addAllChildFields(*expected->type());
+    auto readers = makeReaders(expected, file, scanSpec, stringDecoderZeroCopy);
+    validateWithEncodingChecks(
+        *expected->childAt(0),
+        *readers.rowReader,
+        /*batchSize=*/400,
+        /*totalRows=*/1500,
+        {E::DICTIONARY, E::FLAT, E::FLAT, E::DICTIONARY},
+        asRowType(expected->type()),
+        pool());
+  }
+}
+
+// Repro for the sparse-row dict-abandon bug. When a projected dict-encoded
+// string column receives a non-dense row set (from a sibling column's
+// filter) and the dictionary read is abandoned mid-batch at a non-dict
+// chunk, the flat encoding fallback must preserve the dict portion's nulls
+// and produce the correct remaining rows. The fallback continuation
+// (readOffset_ advance and the continuation row set) assumed dense rows,
+// and the flat fallback's prepareNulls cleared the dict portion's nulls,
+// which the sparse path writes into resultNulls_.
+TEST_P(StringColumnReaderTest, sparseRowsAcrossChunkAbandonPreservesNulls) {
+  const bool stringDecoderZeroCopy = GetParam();
+  if (!stringDecoderZeroCopy) {
+    GTEST_SKIP() << "Dictionary path requires stringDecoderZeroCopy";
+  }
+
+  // chunk1: low cardinality with nulls → Nullable→Dictionary (dict path).
+  auto chunk1 = makeRowVector({
+      makeFlatVector<int64_t>(300, [](auto i) { return i; }),
+      makeFlatVector<std::string>(
+          300,
+          [](auto i) { return std::vector<std::string>{"aaa", "bbb"}[i % 2]; },
+          nullEvery(7)),
+  });
+  // chunk2: all-unique long strings → Trivial (non-dict) → forces abandon.
+  auto chunk2 = makeRowVector({
+      makeFlatVector<int64_t>(300, [](auto i) { return 300 + i; }),
+      makeFlatVector<std::string>(
+          300,
+          [](auto i) {
+            return fmt::format("unique_chunk2_row_{}_pad_to_avoid_inline", i);
+          }),
+  });
+
+  VeloxWriterOptions writerOptions;
+  writerOptions.enableChunking = true;
+  writerOptions.minStreamChunkRawSize = 0;
+  writerOptions.flushPolicyFactory = [] {
+    return std::make_unique<LambdaFlushPolicy>(
+        /*flushLambda=*/[](const StripeProgress&) { return false; },
+        /*chunkLambda=*/[](const StripeProgress&) { return true; });
+  };
+  auto file = test::createNimbleFile(
+      *rootPool(), {chunk1, chunk2}, writerOptions, /*flushAfterWrite=*/false);
+
+  // Sibling filter on c0 selects a non-dense set spanning both chunks:
+  // [50,199] in chunk1 (dict, with nulls) and [400,549] in chunk2 (non-dict).
+  auto readType = ROW({"c0", "c1"}, {BIGINT(), VARCHAR()});
+  auto scanSpec = std::make_shared<common::ScanSpec>("root");
+  scanSpec->addAllChildFields(*readType);
+  std::vector<std::unique_ptr<common::BigintRange>> ranges;
+  ranges.push_back(
+      std::make_unique<common::BigintRange>(50, 199, /*nullAllowed=*/false));
+  ranges.push_back(
+      std::make_unique<common::BigintRange>(400, 549, /*nullAllowed=*/false));
+  scanSpec->childByName("c0")->setFilter(
+      std::make_unique<common::BigintMultiRange>(
+          std::move(ranges), /*nullAllowed=*/false));
+
+  // Full 600-row content for comparison (nulls only in chunk1's c1).
+  auto expected = makeRowVector({
+      makeFlatVector<int64_t>(600, [](auto i) { return i; }),
+      makeFlatVector<std::string>(
+          600,
+          [](auto i) {
+            if (i < 300) {
+              return std::vector<std::string>{"aaa", "bbb"}[i % 2];
+            }
+            return fmt::format(
+                "unique_chunk2_row_{}_pad_to_avoid_inline", i - 300);
+          },
+          [](auto i) { return i < 300 && i % 7 == 0; }),
+  });
+
+  auto readers = makeReaders(expected, file, scanSpec, stringDecoderZeroCopy);
+  // Single batch spans both chunks → the dict read is abandoned mid-batch on
+  // a sparse row set.
+  validateWithFilter(*expected, *readers.rowReader, 600, [](int i) {
+    return (i >= 50 && i <= 199) || (i >= 400 && i <= 549);
+  });
+}
+
+// Like sparseRowsAcrossChunkAbandonPreservesNulls, but the non-dict chunk
+// (the flat encoding fallback portion) ALSO has nulls. This exercises the
+// flat fallback emitting nulls into the shared result null buffer at the
+// output offset left by the dict portion (numValues_), on top of preserving
+// the dict portion's nulls.
+TEST_P(StringColumnReaderTest, sparseRowsAcrossChunkAbandonNullsBothPortions) {
+  const bool stringDecoderZeroCopy = GetParam();
+  if (!stringDecoderZeroCopy) {
+    GTEST_SKIP() << "Dictionary path requires stringDecoderZeroCopy";
+  }
+
+  // chunk1: low cardinality with nulls → Nullable→Dictionary (dict path).
+  auto chunk1 = makeRowVector({
+      makeFlatVector<int64_t>(300, [](auto i) { return i; }),
+      makeFlatVector<std::string>(
+          300,
+          [](auto i) { return std::vector<std::string>{"aaa", "bbb"}[i % 2]; },
+          nullEvery(7)),
+  });
+  // chunk2: all-unique long strings (non-dict → forces abandon) WITH nulls →
+  // Nullable→Trivial. The flat encoding fallback must emit these nulls.
+  auto chunk2 = makeRowVector({
+      makeFlatVector<int64_t>(300, [](auto i) { return 300 + i; }),
+      makeFlatVector<std::string>(
+          300,
+          [](auto i) {
+            return fmt::format("unique_chunk2_row_{}_pad_to_avoid_inline", i);
+          },
+          nullEvery(5)),
+  });
+
+  VeloxWriterOptions writerOptions;
+  writerOptions.enableChunking = true;
+  writerOptions.minStreamChunkRawSize = 0;
+  writerOptions.flushPolicyFactory = [] {
+    return std::make_unique<LambdaFlushPolicy>(
+        /*flushLambda=*/[](const StripeProgress&) { return false; },
+        /*chunkLambda=*/[](const StripeProgress&) { return true; });
+  };
+  auto file = test::createNimbleFile(
+      *rootPool(), {chunk1, chunk2}, writerOptions, /*flushAfterWrite=*/false);
+
+  // Sibling filter on c0 selects a non-dense set spanning both chunks:
+  // [50,199] in chunk1 (dict, with nulls) and [400,549] in chunk2 (non-dict,
+  // with nulls).
+  auto readType = ROW({"c0", "c1"}, {BIGINT(), VARCHAR()});
+  auto scanSpec = std::make_shared<common::ScanSpec>("root");
+  scanSpec->addAllChildFields(*readType);
+  std::vector<std::unique_ptr<common::BigintRange>> ranges;
+  ranges.push_back(
+      std::make_unique<common::BigintRange>(50, 199, /*nullAllowed=*/false));
+  ranges.push_back(
+      std::make_unique<common::BigintRange>(400, 549, /*nullAllowed=*/false));
+  scanSpec->childByName("c0")->setFilter(
+      std::make_unique<common::BigintMultiRange>(
+          std::move(ranges), /*nullAllowed=*/false));
+
+  // Full 600-row content. Nulls in chunk1 (i % 7 == 0) and chunk2
+  // (chunk2-local index (i - 300) % 5 == 0).
+  auto expected = makeRowVector({
+      makeFlatVector<int64_t>(600, [](auto i) { return i; }),
+      makeFlatVector<std::string>(
+          600,
+          [](auto i) {
+            if (i < 300) {
+              return std::vector<std::string>{"aaa", "bbb"}[i % 2];
+            }
+            return fmt::format(
+                "unique_chunk2_row_{}_pad_to_avoid_inline", i - 300);
+          },
+          [](auto i) {
+            return (i < 300 && i % 7 == 0) || (i >= 300 && (i - 300) % 5 == 0);
+          }),
+  });
+
+  auto readers = makeReaders(expected, file, scanSpec, stringDecoderZeroCopy);
+  validateWithFilter(*expected, *readers.rowReader, 600, [](int i) {
+    return (i >= 50 && i <= 199) || (i >= 400 && i <= 549);
+  });
+}
+
+// Fuzz test: randomizes the number of chunks, rows per chunk, batch size,
+// and null probability. Exercises multi-chunk dict reads with merged
+// alphabets across chunk boundaries.
+// TODO: Add mixed dict/non-dict chunks once the reactive fallback is
+// validated (seed 1373641041).
+TEST_P(StringColumnReaderTest, fuzzMultiChunkDictionary) {
+  const bool stringDecoderZeroCopy = GetParam();
+  if (!stringDecoderZeroCopy) {
+    GTEST_SKIP() << "Dictionary path requires stringDecoderZeroCopy";
+  }
+
+  for (int run = 0; run < 20; ++run) {
+    auto seed = folly::Random::rand32();
+    std::mt19937 rng(seed);
+    const int numChunks = 2 + rng() % 6;
+    const int rowsPerChunk = 100 + rng() % 900;
+    const int batchSize = 50 + rng() % (numChunks * rowsPerChunk);
+    const bool hasNulls = rng() % 3 == 0;
+
+    SCOPED_TRACE(
+        fmt::format(
+            "run={} seed={} numChunks={} rowsPerChunk={} batchSize={} hasNulls={}",
+            run,
+            seed,
+            numChunks,
+            rowsPerChunk,
+            batchSize,
+            hasNulls));
+
+    int totalRows = 0;
+    std::vector<std::vector<std::string>> chunkValues;
+
+    for (int c = 0; c < numChunks; ++c) {
+      std::vector<std::string> values;
+      values.reserve(rowsPerChunk);
+      for (int r = 0; r < rowsPerChunk; ++r) {
+        // All chunks use dict-compatible data (low cardinality) so the
+        // multi-chunk merged-alphabet path is exercised. Per-chunk alphabet
+        // varies to test alphabet merging with different entries.
+        // FIXME: Add mixed dict/non-dict chunks once the reactive fallback
+        // bug (seed 1373641041) is fixed.
+        const std::string dictValues[] = {
+            fmt::format("dict_alpha_chunk{}_pad", c),
+            fmt::format("dict_bravo_chunk{}_pad", c),
+            fmt::format("dict_charlie_chunk{}_pad", c)};
+        values.push_back(dictValues[rng() % 3]);
+      }
+      chunkValues.push_back(std::move(values));
+      totalRows += rowsPerChunk;
+    }
+
+    // Build the expected flat vector from all chunks.
+    auto expected = makeRowVector({makeFlatVector<std::string>(
+        totalRows,
+        [&](auto i) {
+          int chunkIdx = i / rowsPerChunk;
+          int rowIdx = i % rowsPerChunk;
+          return chunkValues[chunkIdx][rowIdx];
+        },
+        hasNulls ? nullEvery(7) : nullptr)});
+
+    // Build chunk vectors for writing. Use global null indices so the
+    // null pattern matches the expected vector.
+    std::vector<velox::VectorPtr> chunkVectors;
+    for (int c = 0; c < numChunks; ++c) {
+      const auto& vals = chunkValues[c];
+      const auto chunkStart = c * rowsPerChunk;
+      auto nullFunc = [&](auto i) { return (chunkStart + i) % 7 == 0; };
+      chunkVectors.push_back(makeRowVector({makeFlatVector<std::string>(
+          rowsPerChunk,
+          [&](auto i) { return vals[i]; },
+          hasNulls ? std::function<bool(velox::vector_size_t)>(nullFunc)
+                   : nullptr)}));
+    }
+
+    VeloxWriterOptions writerOptions;
+    writerOptions.enableChunking = true;
+    writerOptions.minStreamChunkRawSize = 0;
+    writerOptions.flushPolicyFactory = [] {
+      return std::make_unique<LambdaFlushPolicy>(
+          /*flushLambda=*/[](const StripeProgress&) { return false; },
+          /*chunkLambda=*/[](const StripeProgress&) { return true; });
+    };
+    auto file = test::createNimbleFile(
+        *rootPool(), chunkVectors, writerOptions, /*flushAfterWrite=*/false);
+
+    auto scanSpec = std::make_shared<common::ScanSpec>("root");
+    scanSpec->addAllChildFields(*expected->type());
+    auto readers = makeReaders(expected, file, scanSpec, stringDecoderZeroCopy);
+    validate(*expected, *readers.rowReader, batchSize);
+  }
+}
+
+// Fuzz test for both legacy and zero-copy paths. Verifies data correctness
+// with randomized chunk shapes, batch sizes, and null patterns. Runs for
+// both param values (legacy does flat reads, zero-copy may take dict path).
+TEST_P(StringColumnReaderTest, fuzzMultiChunkReadCorrectness) {
+  const bool stringDecoderZeroCopy = GetParam();
+
+  for (int run = 0; run < 20; ++run) {
+    auto seed = folly::Random::rand32();
+    std::mt19937 rng(seed);
+    const int numChunks = 2 + rng() % 5;
+    const int rowsPerChunk = 100 + rng() % 500;
+    const int batchSize = 50 + rng() % (numChunks * rowsPerChunk);
+    const bool hasNulls = rng() % 3 == 0;
+
+    SCOPED_TRACE(
+        fmt::format(
+            "run={} seed={} numChunks={} rowsPerChunk={} batchSize={} "
+            "hasNulls={} zeroCopy={}",
+            run,
+            seed,
+            numChunks,
+            rowsPerChunk,
+            batchSize,
+            hasNulls,
+            stringDecoderZeroCopy));
+
+    int totalRows = 0;
+    std::vector<std::vector<std::string>> chunkValues;
+
+    for (int c = 0; c < numChunks; ++c) {
+      std::vector<std::string> values;
+      values.reserve(rowsPerChunk);
+      for (int r = 0; r < rowsPerChunk; ++r) {
+        // Unique strings per row so both legacy and zero-copy paths use
+        // the flat read path. This verifies chunking correctness
+        // independent of the dictionary optimization.
+        values.push_back(fmt::format("val_c{}_r{}_pad_to_avoid_inline", c, r));
+      }
+      chunkValues.push_back(std::move(values));
+      totalRows += rowsPerChunk;
+    }
+
+    auto expected = makeRowVector({makeFlatVector<std::string>(
+        totalRows,
+        [&](auto i) {
+          int chunkIdx = i / rowsPerChunk;
+          int rowIdx = i % rowsPerChunk;
+          return chunkValues[chunkIdx][rowIdx];
+        },
+        hasNulls ? nullEvery(7) : nullptr)});
+
+    std::vector<velox::VectorPtr> chunkVectors;
+    for (int c = 0; c < numChunks; ++c) {
+      const auto& vals = chunkValues[c];
+      const auto chunkStart = c * rowsPerChunk;
+      auto nullFunc = [&](auto i) { return (chunkStart + i) % 7 == 0; };
+      chunkVectors.push_back(makeRowVector({makeFlatVector<std::string>(
+          rowsPerChunk,
+          [&](auto i) { return vals[i]; },
+          hasNulls ? std::function<bool(velox::vector_size_t)>(nullFunc)
+                   : nullptr)}));
+    }
+
+    VeloxWriterOptions writerOptions;
+    writerOptions.enableChunking = true;
+    writerOptions.minStreamChunkRawSize = 0;
+    writerOptions.flushPolicyFactory = [] {
+      return std::make_unique<LambdaFlushPolicy>(
+          /*flushLambda=*/[](const StripeProgress&) { return false; },
+          /*chunkLambda=*/[](const StripeProgress&) { return true; });
+    };
+    auto file = test::createNimbleFile(
+        *rootPool(), chunkVectors, writerOptions, /*flushAfterWrite=*/false);
+
+    auto scanSpec = std::make_shared<common::ScanSpec>("root");
+    scanSpec->addAllChildFields(*expected->type());
+    auto readers = makeReaders(expected, file, scanSpec, stringDecoderZeroCopy);
+    validate(*expected, *readers.rowReader, batchSize);
+  }
+}
+
 INSTANTIATE_TEST_CASE_P(
     StringColumnReaderTestSuite,
     StringColumnReaderTest,
     testing::Values(false, true),
     [](const testing::TestParamInfo<bool>& info) {
-      return info.param ? "passStringBuffers" : "noPassStringBuffers";
+      return info.param ? "zeroCopy" : "legacy";
     });
 
 } // namespace


### PR DESCRIPTION
Summary:
Enable dictionary string reads across chunk boundaries by merging alphabets. Previously, dictionary reads were limited to a single chunk; if the remaining values in the current chunk couldn't serve the entire batch, the reader fell back to flat string reads.

**Multi-chunk dictionary reading:**
- `readDictionaryIndicesImpl`: dedicated chunk iteration loop for dictionary index reads with `OnChunkBoundary` callback. Handles chunk transitions at the top of the loop for both `kHasNulls` and `!kHasNulls` paths, avoiding the `testNulls`-based transitions in `computeNextRowIndex` that count non-nulls across chunk boundaries.
- For `kHasNulls` (flatmap inMap nulls): caps the scan range at `remainingValues_`-th non-null using `findSetBit`, since `remainingValues_` counts encoding values (in-map only), not total rows.
- Alphabet merging via `onChunkBoundary` callback: extends the merged alphabet at each chunk transition and offsets newly written indices by the previous alphabet size.
- `crossedChunkBoundary_` flag: cleared in `getValues` after building `DictionaryVector`, so the next batch rebuilds from the current chunk's encoding rather than reusing a stale merged alphabet.

**Reactive fallback (dict → flat mid-read):**
- When a non-dictionary chunk is encountered, `expandDictionaryToFlat` copies dict indices to flat `StringView` values into an owned buffer (decoupled from encoding string buffers).
- Remaining rows read via flat `readWithVisitor` with an `onStringBuffers` callback that appends to existing string buffers rather than replacing them.

**ChunkedDecoder API additions:**
- `ensureLoaded` accepts `OnChunkBoundary` callback for dictionary state invalidation between batches.
- `readWithVisitor` accepts `OnStringBuffers` callback for custom string buffer delivery (append vs replace).
- Remove `setOnChunkLoad` / `invokeOnChunkLoad` / `onChunkLoad_` — chunk boundary handling via template callbacks.

**StringColumnReader:**
- `DictionaryState` struct consolidates `alphabet`, `alphabetVector`, and `clear()`.
- `hasDictionaryState()` returns `!dictionaryState_.alphabet.empty()` instead of a separate `isDictionary_` bool.
- Remove shadowing `stringBuffers_` member that hid `SelectiveColumnReader::stringBuffers_`.
- Rename `passStringBuffersFromDecoder` → `stringDecoderZeroCopy` in tests.

Reviewed By: xiaoxmeng

Differential Revision: D105823292


