### PR TITLE
fix(nimble): Deprecate unused Stripes.sizes field in tablet footer

### DIFF
--- a/dwio/nimble/tablet/Footer.fbs
+++ b/dwio/nimble/tablet/Footer.fbs
@@ -25,7 +25,12 @@ enum CompressionType:uint8 {
 table Stripes {
   row_counts:[uint32];
   offsets:[uint64];
-  sizes:[uint32];
+  // Reserved for backward wire compatibility with files written before this
+  // field was retired. Marker `(deprecated)` preserves the vtable slot so
+  // pre-existing files still parse without shifting later fields. Generated
+  // accessors are suppressed; new writers no longer populate it and new
+  // readers no longer reference it.
+  sizes:[uint32] (deprecated);
   group_indices:[uint32];
 }
 

--- a/dwio/nimble/tablet/TabletReader.cpp
+++ b/dwio/nimble/tablet/TabletReader.cpp
@@ -672,8 +672,6 @@ void TabletReader::initStripes(
   NIMBLE_CHECK_EQ(
       stripeCount_, stripes->offsets()->size(), "Unexpected stripe count");
   NIMBLE_CHECK_EQ(
-      stripeCount_, stripes->sizes()->size(), "Unexpected stripe count");
-  NIMBLE_CHECK_EQ(
       stripeCount_,
       stripes->group_indices()->size(),
       "Unexpected stripe count");

--- a/dwio/nimble/tablet/TabletWriter.cpp
+++ b/dwio/nimble/tablet/TabletWriter.cpp
@@ -180,8 +180,7 @@ void TabletWriter::close() {
   checkNotClosed();
   const auto stripeCount = stripeOffsets_.size();
   NIMBLE_CHECK(
-      stripeCount == stripeSizes_.size() &&
-          stripeCount == stripeRowCounts_.size() &&
+      stripeCount == stripeRowCounts_.size() &&
           stripeCount == stripeGroupIndices_.size(),
       "Stripe count mismatch.");
 
@@ -398,8 +397,6 @@ void TabletWriter::writeStripe(uint32_t rowCount, std::vector<Stream> streams) {
     }
   }
 
-  stripeSizes_.push_back(file_->size() - stripeOffsets_.back());
-
   stripeGroupIndices_.push_back(stripeGroupIndex_);
   // Write stripe group if size of column offsets/sizes is too large.
   tryWriteStripeGroup();
@@ -520,7 +517,6 @@ MetadataSection TabletWriter::writeStripes(size_t stripeCount) {
           stripesBuilder,
           stripesBuilder.CreateVector(stripeRowCounts_),
           stripesBuilder.CreateVector(stripeOffsets_),
-          stripesBuilder.CreateVector(stripeSizes_),
           stripesBuilder.CreateVector(stripeGroupIndices_)));
   return createMetadataSection(asView(stripesBuilder));
 }

--- a/dwio/nimble/tablet/TabletWriter.h
+++ b/dwio/nimble/tablet/TabletWriter.h
@@ -204,8 +204,6 @@ class TabletWriter {
   std::vector<uint32_t> stripeRowCounts_;
   // Offsets from start of file to first byte in each stripe.
   std::vector<uint64_t> stripeOffsets_;
-  // Sizes of the stripes
-  std::vector<uint32_t> stripeSizes_;
 
   // For each stripe, which stripe group it belongs to.
   std::vector<uint32_t> stripeGroupIndices_;


### PR DESCRIPTION
Summary:
`Stripes.sizes:[uint32]` in `dwio/nimble/tablet/Footer.fbs` is written by `TabletWriter` but is **never read at runtime** — the only place anything touches it is a length-validation check in `TabletReader` (`stripeCount_ == stripes->sizes()->size()`), which compares the array's length, not its values. Exhaustive search across `dwio/`, `fb_velox/dwio/`, and Nimble tools confirms no code path reads the per-stripe byte sizes stored in this field. It's been dead storage in the wire format.

Marks the field `(deprecated)` so the FlatBuffers vtable slot is preserved — pre-existing files continue to parse correctly under the new reader (later fields don't shift), while generated accessors are suppressed so the writer can no longer populate it and the reader can no longer reference it.

- `Footer.fbs` — `sizes:[uint32]` becomes `sizes:[uint32] (deprecated);`.
- `TabletReader.cpp` — remove the tautological `sizes()` length check; remaining checks against `offsets()` and `group_indices()` still validate per-array length consistency.
- `TabletWriter.{h,cpp}` — remove the `stripeSizes_` member, the per-stripe accumulation (`stripeSizes_.push_back(file_->size() - stripeOffsets_.back())`), the close-time `stripeCount == stripeSizes_.size()` invariant, and the `CreateVector(stripeSizes_)` arg that flatc no longer accepts.

Wire-format compatibility: **new reader on old files works** (vtable slot stays at the original offset). **Old reader on new files no longer reads valid sizes data** (writer no longer populates it; old reader's `stripeCount_ == sizes()->size()` check would fail). End-to-end backward compatibility for older deployed binaries is intentionally out of scope here and will be addressed in a separate feature-compatible release.

If a future consumer needs per-stripe byte sizes, they can be reconstructed at read time as `(stripeOffset(i+1) - stripeOffset(i))` for non-terminal stripes plus the trailing footer offset for the final stripe — no need to persist redundant state.

Reviewed By: xiaoxmeng

Differential Revision: D106669785


