### PR TITLE
refactor(encoding)!: Prefix bare AS/AS_CONST macros with NIMBLE_

### DIFF
--- a/dwio/nimble/encodings/ConstantEncoding.h
+++ b/dwio/nimble/encodings/ConstantEncoding.h
@@ -158,7 +158,7 @@ class ConstantEncodingBase
         toString(this->encodingType()),
         toString(this->dataType()),
         this->rowCount(),
-        AS_CONST(T, value_));
+        NIMBLE_AS_CONST(T, value_));
   }
 
   static std::string_view encode(

--- a/dwio/nimble/encodings/common/EncodingType.h
+++ b/dwio/nimble/encodings/common/EncodingType.h
@@ -49,7 +49,7 @@ struct EncodingPhysicalType {
   }
 };
 
-#define AS(D, v) *(reinterpret_cast<D*>(&(v)))
+#define NIMBLE_AS(D, v) *(reinterpret_cast<D*>(&(v)))
 
-#define AS_CONST(D, v) *(reinterpret_cast<const D*>(&(v)))
+#define NIMBLE_AS_CONST(D, v) *(reinterpret_cast<const D*>(&(v)))
 } // namespace facebook::nimble

--- a/dwio/nimble/encodings/legacy/ConstantEncoding.h
+++ b/dwio/nimble/encodings/legacy/ConstantEncoding.h
@@ -154,7 +154,7 @@ std::string ConstantEncoding<T>::debugString(int offset) const {
       toString(Encoding::encodingType()),
       toString(Encoding::dataType()),
       Encoding::rowCount(),
-      AS_CONST(T, value_));
+      NIMBLE_AS_CONST(T, value_));
 }
 
 } // namespace facebook::nimble::legacy


### PR DESCRIPTION
Summary:
EncodingType.h defined two bare, unprefixed function-like macros in the global
preprocessor namespace:

    #define AS(D, v)       *(reinterpret_cast<D*>(&(v)))
    #define AS_CONST(D, v) *(reinterpret_cast<const D*>(&(v)))

Anyone using nimble or pulling it transitively has these 2 macros camping the
global namespace

It would be better to prefix these with NIMBLE_ to avoid collisions (our service
is hitting this right now)

looking through these are only used internally so although this is a breaking
change (noted in footer) I think chance of real breakage is not high

BREAKING CHANGE: The helper macros AS and AS_CONST in
dwio/nimble/encodings/common/EncodingType.h are renamed to NIMBLE_AS and
NIMBLE_AS_CONST. They were undocumented internal helpers used only within
Nimble's own encodings, so external impact is expected to be none.

Differential Revision: D108165159


