### PR TITLE
perf: Two-array sparse stream-sizes trailer with per-axis encoding

### DIFF
--- a/dwio/nimble/serializer/Deserializer.cpp
+++ b/dwio/nimble/serializer/Deserializer.cpp
@@ -783,7 +783,7 @@ void Deserializer::deserialize(
   // (the producer of row-range-bearing slices), this over-fetch is bounded
   // by stripe boundaries and never crosses users: each chunk slice covers
   // exactly one (request × stripe) intersection. For non-kTablet inputs
-  // (kCompactRaw/kLegacy) there's no embedded row range, so
+  // (kLegacyCompact/kLegacy) there's no embedded row range, so
   // "over-fetch" doesn't apply — the full batch is decoded as intended.
   //
   // Callers that want only the in-range rows of a kTablet slice can read

--- a/dwio/nimble/serializer/DeserializerImpl.h
+++ b/dwio/nimble/serializer/DeserializerImpl.h
@@ -149,7 +149,7 @@ class StreamData {
   velox::memory::MemoryPool* const pool_{nullptr};
   // Whether nimble encoding is enabled. Non-const to allow reset() to change.
   bool encodingEnabled_{false};
-  // Whether encoding headers use varint row counts (true for kCompactRaw) or
+  // Whether encoding headers use varint row counts (true for kLegacyCompact) or
   // fixed u32 (false for kTablet). Non-const to allow
   // reset() to change.
   bool useVarintRowCount_{true};
@@ -201,7 +201,7 @@ class StreamDataReader {
 
   /// Walks every non-empty stream in the current blob, invoking
   /// `callback(offset, data)` per stream. For kTablet, `data` is the
-  /// chunk-stripped (and decompressed, if needed) payload; for kCompactRaw
+  /// chunk-stripped (and decompressed, if needed) payload; for kLegacyCompact
   /// and kLegacy it is the raw stream bytes. Empty streams are skipped.
   /// Must be called at most once per `initialize()` (consumes the per-blob
   /// cursor).
@@ -217,18 +217,17 @@ class StreamDataReader {
   template <typename Callback>
   void iterateStreams(Callback&& callback) {
     if (nonLegacyFormat(version_)) {
-      // kCompactRaw/kTablet (and any future non-legacy versions): the
-      // stream-size trailer at the end of the blob is dispatched on the
-      // version byte. Today every defined non-legacy version returns true
-      // from `usesLegacyTrailer`, so all blobs flow through the frozen
-      // legacy reader; the else branch is scaffolding for the next diff,
-      // which will introduce a new wire format and a sibling reader.
-      // Reusable member buffers keep the hot path alloc-free across blobs.
+      // kLegacyCompact/kTablet/kSerialization/kProjection: stream sizes are
+      // packed into a sparse trailer at the end of the blob. Production blobs
+      // at kLegacyCompact are decoded via the legacy reader (frozen snapshot of
+      // the pre-two-array wire format); all newer versions go through the new
+      // two-array sparse trailer reader. Reusable member buffers keep this
+      // path alloc-free across blobs.
       if (usesLegacyTrailer(version_)) {
         legacy::readLegacyTrailerStreamMetadata(
             end_, streamIndices_, streamSizes_);
       } else {
-        NIMBLE_UNREACHABLE("unexpected non-legacy trailer version");
+        detail::readTrailerStreamMetadata(end_, streamIndices_, streamSizes_);
       }
       const bool isTablet = isTabletVersion(version_);
       const size_t numStreams = streamIndices_.size();
@@ -236,7 +235,8 @@ class StreamDataReader {
         const uint32_t streamOffset = streamIndices_[entryIdx];
         const uint32_t streamSize = streamSizes_[entryIdx];
         // Writer invariant: the sparse trailer only encodes non-zero stream
-        // slots. Debug-only assert documents that invariant; release elides it.
+        // slots (SerializerImpl.h writeTrailer skips streamSizes[i]==0).
+        // Debug-only assert documents that invariant; release elides it.
         NIMBLE_DCHECK_GT(
             streamSize, 0, "Sparse trailer must not encode zero-sized stream");
         std::string_view streamData(pos_, streamSize);
@@ -327,11 +327,11 @@ class StreamDataReader {
   // Reusable buffer for chunk header stripping (compressed/multi-chunk case).
   Vector<char> chunkStrippingBuffer_;
   // Reusable parallel buffers for the per-blob sparse trailer. Refilled by
-  // iterateStreams() on the kCompactRaw/kTablet path: streamIndices_ holds
-  // the offsets of non-zero stream slots (sorted ascending); streamSizes_
-  // holds the corresponding byte sizes. Sized to the same length, cleared
-  // and filled in place each blob to keep the hot path alloc-free across
-  // invocations.
+  // iterateStreams() on the kLegacyCompact/kTablet path: streamIndices_
+  // holds the offsets of non-zero stream slots (sorted ascending);
+  // streamSizes_ holds the corresponding byte sizes. Sized to the same
+  // length, cleared+filled in place each blob to keep the hot path
+  // alloc-free across invocations.
   std::vector<uint32_t> streamIndices_;
   std::vector<uint32_t> streamSizes_;
 };

--- a/dwio/nimble/serializer/Options.cpp
+++ b/dwio/nimble/serializer/Options.cpp
@@ -24,10 +24,14 @@ std::string toString(SerializationVersion version) {
   switch (version) {
     case SerializationVersion::kLegacy:
       return "kLegacy";
-    case SerializationVersion::kCompactRaw:
-      return "kCompactRaw";
+    case SerializationVersion::kLegacyCompact:
+      return "kLegacyCompact";
     case SerializationVersion::kTablet:
       return "kTablet";
+    case SerializationVersion::kSerialization:
+      return "kSerialization";
+    case SerializationVersion::kProjection:
+      return "kProjection";
     default:
       NIMBLE_FAIL(
           "Unknown SerializationVersion: {}", static_cast<int>(version));
@@ -40,7 +44,6 @@ EncodingType getTrailerEncodingType(EncodingType encodingType) {
     case EncodingType::Varint:
     case EncodingType::Delta:
     case EncodingType::FixedBitWidth:
-    case EncodingType::MainlyConstant:
       return encodingType;
     default:
       NIMBLE_FAIL(

--- a/dwio/nimble/serializer/Options.h
+++ b/dwio/nimble/serializer/Options.h
@@ -41,58 +41,92 @@ namespace facebook::nimble {
 ///   Wire:
 ///   [version:1B][rowCount:u32][size_0:u32][stream_data_0]...[size_N:u32][stream_data_N]
 ///
-/// - kCompactRaw: Nimble encoding with raw-encoded stream sizes trailer.
-///   Stream values use nimble encoding; stream sizes use a raw encoding.
+/// - kLegacyCompact: READ-ONLY post the two-array sparse trailer change.
+///   Existing production blobs at this version are decoded via the frozen
+///   legacy reader (`nimble::serde::legacy::`), whose wire format is:
 ///   Wire: [version:1B][rowCount:varint][stream_data_0]...[stream_data_N]
-///         [encodingType:1B][raw_sizes_payload][trailer_size:u32]
-///   trailer_size = 1 + len(raw_sizes_payload).
-///   Supported EncodingTypes: Trivial, Varint, Delta, FixedBitWidth,
-///   MainlyConstant. See getTrailerEncodingType() for validation.
+///         [encodingByte:1B][denseSizes:u32[]|sparsePair]
+///         [trailer_size:u32]
+///   New writers must NOT emit kLegacyCompact — Serializer rejects it; use
+///   kSerialization (Serializer default) or kProjection (Projector default).
 ///
-/// - kTablet: Tablet stream passthrough format. Like kCompactRaw but:
+/// - kTablet: Tablet stream passthrough format. Like kSerialization but:
 ///   (1) Each stream's data includes tablet chunk headers:
 ///       [chunkSize:u32][compressionType:1B][encoded_data...]
 ///       which the Deserializer strips before decoding.
 ///   (2) Encoding headers within streams use fixed u32 row counts
 ///       (useVarintRowCount=false), matching the tablet's default format.
-///   Wire: [version:1B][rowCount:varint][stream_data_0]...[stream_data_N]
-///         [encodingType:1B][raw_sizes_payload][trailer_size:u32]
+///   Wire: same two-array sparse trailer layout as kSerialization.
+///
+/// - kSerialization / kProjection: New writer versions using the two-array
+///   sparse trailer. Wire body identical to kLegacyCompact; trailer is:
+///   [indicesEncType:1B][indicesPayload]
+///   [sizesEncType:1B][sizesPayload]
+///   [trailer_size:u32]
+///   trailer_size = 2 + len(indicesPayload) + len(sizesPayload).
+///   Indices and sizes axes independently choose from EncodingTypes
+///   {Trivial, Varint, Delta, FixedBitWidth}. See getTrailerEncodingType()
+///   for validation. kSerialization is the Serializer's default writer
+///   version; kProjection is the Projector's. Same wire format today; the
+///   distinct version bytes let the two writers evolve independently.
 enum class SerializationVersion : uint8_t {
   kLegacy = 0,
+  // READ-ONLY post the two-array trailer change: production blobs with this
+  // version byte are still decoded via `nimble::serde::legacy::`, but writers
+  // must not emit it. New Serializer writers emit kSerialization;
+  // new Projector writers emit kProjection.
+  kLegacyCompact = 2,
+  // Deprecated alias for kLegacyCompact; kept so call sites that still spell
+  // the old name keep compiling while they migrate. Same numeric value as
+  // kLegacyCompact, so existing wire-format checks and read paths are
+  // unaffected. New code should use kLegacyCompact (read) or kSerialization /
+  // kProjection (write).
   kCompactRaw = 2,
-  kTablet = 3,
+  // Default writer version for the Serializer: two-array sparse trailer.
+  kSerialization = 3,
+  // Default writer version for the Projector: two-array sparse trailer.
+  // Same wire format as kSerialization today; the distinct version byte lets
+  // the two writers' formats evolve independently in the future.
+  kProjection = 4,
+  // Renumbered from 3 to 5: no production kTablet blobs existed at value 3,
+  // so the lower-numbered slots are reclaimed for the more common new writer
+  // versions (kSerialization / kProjection).
+  kTablet = 5,
 };
 
 std::string toString(SerializationVersion version);
 
-/// Returns true if the version is any non-legacy format (kCompactRaw or
+/// Returns true if the version is any non-legacy format (kLegacyCompact or
 /// kTablet). All non-legacy formats have a version header, encoded streams,
 /// and a stream sizes trailer.
 inline bool nonLegacyFormat(SerializationVersion version) {
   return version != SerializationVersion::kLegacy;
 }
 
-/// Returns true if the version uses compact encoding (kCompactRaw).
-/// Note: kTablet is NOT a compact format (has chunk headers in streams).
+/// Returns true if the version uses compact encoding (kLegacyCompact,
+/// kSerialization, or kProjection). Note: kTablet is NOT a compact format
+/// (has chunk headers in streams).
 inline bool isCompactFormat(SerializationVersion version) {
-  return version == SerializationVersion::kCompactRaw;
+  return version == SerializationVersion::kLegacyCompact ||
+      version == SerializationVersion::kSerialization ||
+      version == SerializationVersion::kProjection;
 }
 
-/// Returns true if the version uses raw stream sizes (kCompactRaw or
-/// kTablet) instead of nimble-encoded stream sizes.
+/// Returns true if the version uses raw stream sizes (kLegacyCompact, kTablet,
+/// kSerialization, or kProjection) instead of nimble-encoded stream sizes.
 inline bool isRawFormat(SerializationVersion version) {
-  return version == SerializationVersion::kCompactRaw ||
-      version == SerializationVersion::kTablet;
+  return version == SerializationVersion::kLegacyCompact ||
+      version == SerializationVersion::kTablet ||
+      version == SerializationVersion::kSerialization ||
+      version == SerializationVersion::kProjection;
 }
 
-/// Returns true if the version was written using the (now frozen) legacy
-/// trailer wire format decoded by `nimble::serde::legacy::`. All currently
-/// defined non-legacy versions (kCompactRaw, kTablet) share that format;
-/// future writer versions that emit a different trailer wire format will
-/// return false from this helper so dispatchers route them to a different
-/// reader.
+/// Returns true if the version was written using the legacy kLegacyCompact
+/// trailer format (decoded via `nimble::serde::legacy::`). All other
+/// non-legacy formats (kTablet, kSerialization, kProjection) use the new
+/// two-array sparse trailer.
 ///
-/// kTablet is included here today because in master kTablet and kCompactRaw
+/// kTablet is included here today because in master kTablet and kLegacyCompact
 /// produce byte-identical trailer layouts (single encoding-type byte +
 /// payload + trailer-size u32) and the same reader code path handles both.
 /// Treating kTablet as legacy in this diff keeps the refactor purely
@@ -101,12 +135,11 @@ inline bool isRawFormat(SerializationVersion version) {
 /// The next diff (the two-array sparse trailer change) migrates kTablet
 /// onto the new trailer wire format alongside the new kSerialization /
 /// kProjection versions, and this helper will be narrowed to return true
-/// only for kCompactRaw. kCompactRaw is the only version frozen forever
+/// only for kLegacyCompact. kLegacyCompact is the only version frozen forever
 /// here because it is the only one with existing production blobs that
 /// must remain readable.
 inline bool usesLegacyTrailer(SerializationVersion version) {
-  return version == SerializationVersion::kCompactRaw ||
-      version == SerializationVersion::kTablet;
+  return version == SerializationVersion::kLegacyCompact;
 }
 
 /// Returns true if the optional version uses raw stream sizes.
@@ -130,7 +163,7 @@ inline bool isCompactFormat(std::optional<SerializationVersion> version) {
 }
 
 /// Returns true if the version uses varint for the header row count.
-/// All non-legacy versioned formats (kCompactRaw, kTablet) use varint row
+/// All non-legacy versioned formats (kLegacyCompact, kTablet) use varint row
 /// counts in the header. The raw stream bodies inside kTablet may use fixed
 /// u32 row counts in their encoding headers.
 inline bool usesVarintRowCount(SerializationVersion version) {
@@ -142,8 +175,9 @@ inline bool usesVarintRowCount(std::optional<SerializationVersion> version) {
   return version.has_value() && usesVarintRowCount(version.value());
 }
 
-/// Validates and returns the EncodingType for stream sizes trailer.
-/// Supported: Trivial, Varint, Delta, FixedBitWidth, MainlyConstant.
+/// Validates and returns the EncodingType for a stream-sizes trailer section
+/// (used independently for both the indices and the sizes arrays).
+/// Supported: Trivial, Varint, Delta, FixedBitWidth.
 EncodingType getTrailerEncodingType(EncodingType encodingType);
 
 inline std::ostream& operator<<(
@@ -159,7 +193,7 @@ EncodingSelectionPolicyFactory defaultEncodingSelectionPolicyFactory();
 
 struct SerializerOptions {
   /// Legacy (kLegacy) compression settings. These only apply when version is
-  /// kLegacy or nullopt. For kCompactRaw, compression is controlled by
+  /// kLegacy or nullopt. For kLegacyCompact, compression is controlled by
   /// 'compressionOptions' below.
   CompressionType compressionType{CompressionType::Uncompressed};
   uint32_t compressionThreshold{0};
@@ -168,7 +202,13 @@ struct SerializerOptions {
   /// Serialization format version.
   /// - nullopt (default): Legacy format with no version header (kLegacy).
   /// - kLegacy: Legacy compression format.
-  /// - kCompactRaw: Nimble encoding format with raw sizes trailer.
+  /// - kSerialization: Default Serializer writer; two-array sparse trailer.
+  /// - kLegacyCompact: READ-ONLY post the two-array trailer change. Existing
+  ///   production blobs at this version are decoded via
+  ///   `nimble::serde::legacy::` but the Serializer constructor REJECTS this
+  ///   value for new writes — use kSerialization instead.
+  /// - kProjection / kTablet are not valid Serializer writer versions
+  ///   (Projector + tablet pipelines write them, respectively).
   std::optional<SerializationVersion> version{};
 
   /// Columns that should be encoded as flat maps. Maps column name to a set
@@ -180,7 +220,7 @@ struct SerializerOptions {
   folly::F14FastMap<std::string, std::set<std::string>> flatMapColumns{};
 
   /// Factory for creating encoding selection policies.
-  /// Only used when version is kCompactRaw.
+  /// Only used when version is kLegacyCompact.
   /// When encodingLayoutTree is specified, used as fallback for streams or
   /// nested encodings not captured in the layout tree. When encodingLayoutTree
   /// is not specified, used directly for all streams.
@@ -201,8 +241,15 @@ struct SerializerOptions {
   /// replay. When nullopt (default), compression is disabled.
   std::optional<CompressionOptions> compressionOptions{};
 
-  /// Encoding type for stream sizes in the trailer.
-  /// Supported types: Trivial, Varint, Delta, FixedBitWidth, MainlyConstant.
+  /// Encoding type for the indices array of the sparse stream-sizes trailer.
+  /// Indices are the offsets of non-zero stream slots in scan order
+  /// (sorted ascending). Supported types: Trivial, Varint, Delta,
+  /// FixedBitWidth.
+  EncodingType streamIndicesEncodingType{EncodingType::FixedBitWidth};
+
+  /// Encoding type for the sizes array of the sparse stream-sizes trailer.
+  /// Sizes are the byte sizes of non-zero streams, parallel to the indices
+  /// array. Supported types: Trivial, Varint, Delta, FixedBitWidth.
   EncodingType streamSizesEncodingType{EncodingType::FixedBitWidth};
 
   /// Returns true if the serialized data has a version header byte.
@@ -211,7 +258,7 @@ struct SerializerOptions {
   /// Returns the effective serialization version.
   SerializationVersion serializationVersion() const;
 
-  /// Returns true if nimble encoding is enabled (version is kCompactRaw).
+  /// Returns true if nimble encoding is enabled (version is kLegacyCompact).
   bool enableEncoding() const;
 };
 

--- a/dwio/nimble/serializer/Projector.cpp
+++ b/dwio/nimble/serializer/Projector.cpp
@@ -16,6 +16,8 @@
 
 #include "dwio/nimble/serializer/Projector.h"
 
+#include <glog/logging.h>
+
 #include <algorithm>
 #include <numeric>
 
@@ -250,6 +252,22 @@ std::shared_ptr<const Type> updateColumnNames(
   }
 }
 
+// kLegacyCompact is read-only post the two-array trailer change. Callers that
+// still pass it (e.g., not-yet-migrated tests or downstream code we can't
+// update in this diff due to directory branching) are silently upgraded to
+// kProjection so the round-trip still works on the new wire format. A
+// LOG(WARNING) flags the migration so the caller can switch.
+Projector::Options upgradeReadOnlyProjectVersion(Projector::Options options) {
+  if (options.projectVersion == SerializationVersion::kLegacyCompact) {
+    LOG_FIRST_N(WARNING, 10)
+        << "Projector constructed with projectVersion=kLegacyCompact "
+           "(read-only post the two-array trailer change); silently upgrading "
+           "to kProjection. Migrate the caller to pass kProjection explicitly.";
+    options.projectVersion = SerializationVersion::kProjection;
+  }
+  return options;
+}
+
 } // namespace
 
 Projector::Projector(
@@ -258,7 +276,7 @@ Projector::Projector(
     velox::memory::MemoryPool* pool,
     Options options)
     : pool_(pool),
-      options_(std::move(options)),
+      options_(upgradeReadOnlyProjectVersion(std::move(options))),
       inputSchema_(std::move(inputSchema)) {
   NIMBLE_CHECK_NOT_NULL(pool_, "Memory pool cannot be null");
   NIMBLE_CHECK_NOT_NULL(inputSchema_, "Input schema cannot be null");
@@ -268,8 +286,8 @@ Projector::Projector(
       inputSchema_->kind());
   NIMBLE_CHECK(!projectSubfields.empty(), "Must project at least one subfield");
   NIMBLE_CHECK(
-      isCompactFormat(options_.projectVersion),
-      "Projection output version must be kCompactRaw, got: {}",
+      options_.projectVersion == SerializationVersion::kProjection,
+      "Projection output version must be kProjection. Got: {}",
       options_.projectVersion);
 
   // Update inputSchema_ with projectType names for schema evolution.
@@ -303,12 +321,15 @@ Projector::Projector(
 
 namespace {
 
-// Validates the input version header is kCompactRaw.
+// Validates the input version header is a supported compact format
+// (kLegacyCompact via legacy reader, or kSerialization/kProjection via new
+// reader). kTablet is rejected — chunk headers are not handled by the
+// Projector.
 SerializationVersion getAndValidateInputVersion(const folly::IOBuf& input) {
   const auto version = static_cast<SerializationVersion>(*input.data());
   NIMBLE_CHECK(
       isCompactFormat(version),
-      "Input must be kCompactRaw format, got: {}",
+      "Input must be a compact format (kLegacyCompact/kSerialization/kProjection), got: {}",
       version);
   return version;
 }
@@ -316,26 +337,35 @@ SerializationVersion getAndValidateInputVersion(const folly::IOBuf& input) {
 } // namespace
 
 // Projects selected streams from a contiguous IOBuf into the output chain.
-// Streams are output in the order of selectedIndices (output stream order),
-// which may differ from sorted input order for interleaved schemas (e.g.,
-// multiple FlatMap columns). Merges adjacent output entries that are contiguous
-// in the input into a single zero-copy IOBuf clone to minimize IOBuf
-// allocations. The input IOBuf must outlive the output chain.
+// Streams are output in the order of selectedStreamIndices (output stream
+// order), which may differ from sorted input order for interleaved schemas
+// (e.g., multiple FlatMap columns). Walks selectedStreamIndices in output
+// order; for each selected input stream, binary-searches the sparse
+// (streamIndices, streamSizes) trailer for its position. Merges adjacent
+// output entries that are contiguous in the input into a single zero-copy
+// IOBuf clone to minimize IOBuf allocations. The input IOBuf must outlive the
+// output chain.
 // static
 std::vector<uint32_t> Projector::projectStreamsContiguousUnsorted(
     const folly::IOBuf& input,
     size_t dataOffset,
+    const std::vector<uint32_t>& streamIndices,
     const std::vector<uint32_t>& streamSizes,
-    const std::vector<uint32_t>& selectedIndices,
+    const std::vector<uint32_t>& selectedStreamIndices,
     std::unique_ptr<folly::IOBuf>& output) {
-  std::vector<uint32_t> outputSizes(selectedIndices.size(), 0);
+  std::vector<uint32_t> outputSizes(selectedStreamIndices.size(), 0);
 
-  // Pre-compute byte offset for each input stream.
-  std::vector<size_t> streamOffsets(streamSizes.size());
-  size_t streamOffset = dataOffset;
-  for (size_t i = 0; i < streamSizes.size(); ++i) {
-    streamOffsets[i] = streamOffset;
-    streamOffset += streamSizes[i];
+  // Precompute byte offset of each sparse pair (input-order prefix sum of
+  // sizes). streamOffsets[sparsePosition] is the byte offset of
+  // streamIndices[sparsePosition] within input.
+  std::vector<size_t> streamOffsets(streamIndices.size());
+  size_t offset = dataOffset;
+  for (size_t sparsePosition = 0; sparsePosition < streamIndices.size();
+       ++sparsePosition) {
+    // NOLINTBEGIN(facebook-hte-LocalUncheckedArrayBounds)
+    streamOffsets[sparsePosition] = offset;
+    offset += streamSizes[sparsePosition];
+    // NOLINTEND(facebook-hte-LocalUncheckedArrayBounds)
   }
 
   // Track the start offset and byte count of a contiguous run.
@@ -346,7 +376,6 @@ std::vector<uint32_t> Projector::projectStreamsContiguousUnsorted(
     if (numRunBytes == 0) {
       return;
     }
-    // Zero-copy: clone the input and trim to the run's sub-range.
     auto buf = input.cloneOne();
     buf->trimStart(runStart);
     buf->trimEnd(buf->length() - numRunBytes);
@@ -354,23 +383,30 @@ std::vector<uint32_t> Projector::projectStreamsContiguousUnsorted(
     numRunBytes = 0;
   };
 
-  // Output streams in output order, merging entries that are contiguous in
-  // input.
-  for (size_t i = 0; i < selectedIndices.size(); ++i) {
-    const auto streamIdx = selectedIndices[i];
-    // Streams beyond streamSizes are treated as empty. This happens when the
-    // serializer omits constant in-map boolean streams (all-true/all-false),
-    // making the serialized stream count smaller than the schema's max offset.
-    if (streamIdx >= streamSizes.size() || streamSizes[streamIdx] == 0) {
+  // Walk selectedStreamIndices in output order; binary-search sparse
+  // streamIndices for each. Selected streams absent from the sparse trailer
+  // keep outputSizes at 0 and contribute zero bytes, so they can sit inside
+  // a run without breaking byte-contiguity for the next present selected
+  // stream.
+  for (size_t i = 0; i < selectedStreamIndices.size(); ++i) {
+    const auto inputStreamIdx = selectedStreamIndices[i];
+    const auto it = std::lower_bound(
+        streamIndices.begin(), streamIndices.end(), inputStreamIdx);
+    if (it == streamIndices.end() || *it != inputStreamIdx) {
       continue;
     }
-    outputSizes[i] = streamSizes[streamIdx];
-    if (numRunBytes > 0 && streamOffsets[streamIdx] == runStart + numRunBytes) {
-      numRunBytes += streamSizes[streamIdx];
+    const auto sparsePosition = static_cast<size_t>(it - streamIndices.begin());
+    // NOLINTBEGIN(facebook-hte-LocalUncheckedArrayBounds)
+    const auto streamSize = streamSizes[sparsePosition];
+    const auto streamOffset = streamOffsets[sparsePosition];
+    outputSizes[i] = streamSize;
+    // NOLINTEND(facebook-hte-LocalUncheckedArrayBounds)
+    if (numRunBytes > 0 && streamOffset == runStart + numRunBytes) {
+      numRunBytes += streamSize;
     } else {
       flushRun();
-      runStart = streamOffsets[streamIdx];
-      numRunBytes = streamSizes[streamIdx];
+      runStart = streamOffset;
+      numRunBytes = streamSize;
     }
   }
   flushRun();
@@ -379,19 +415,19 @@ std::vector<uint32_t> Projector::projectStreamsContiguousUnsorted(
 }
 
 // Fast path for projectStreamsContiguousUnsorted when inputStreamIndices are
-// sorted (no FlatMap key reordering). Avoids pre-computing byte offsets for all
-// streams — instead uses a single forward scan tracking the current offset.
+// sorted (no FlatMap key reordering). Single forward two-pointer merge over
+// the sparse (streamIndices, streamSizes) trailer and selectedStreamIndices.
 // static
 std::vector<uint32_t> Projector::projectStreamsContiguousSorted(
     const folly::IOBuf& input,
     size_t dataOffset,
+    const std::vector<uint32_t>& streamIndices,
     const std::vector<uint32_t>& streamSizes,
-    const std::vector<uint32_t>& selectedIndices,
+    const std::vector<uint32_t>& selectedStreamIndices,
     std::unique_ptr<folly::IOBuf>& output) {
-  std::vector<uint32_t> outputSizes(selectedIndices.size(), 0);
+  std::vector<uint32_t> outputSizes(selectedStreamIndices.size(), 0);
 
-  size_t curOffset = dataOffset;
-  size_t nextSelected = 0;
+  size_t currentOffset = dataOffset;
 
   // Track the start offset and byte count of a contiguous run.
   size_t runStart = 0;
@@ -409,23 +445,40 @@ std::vector<uint32_t> Projector::projectStreamsContiguousSorted(
     numRunBytes = 0;
   };
 
-  for (size_t i = 0;
-       i < streamSizes.size() && nextSelected < selectedIndices.size();
-       ++i) {
-    if (i == selectedIndices[nextSelected]) {
-      if (streamSizes[i] > 0) {
-        outputSizes[nextSelected] = streamSizes[i];
-        if (numRunBytes > 0 && curOffset == runStart + numRunBytes) {
-          numRunBytes += streamSizes[i];
-        } else {
-          flushRun();
-          runStart = curOffset;
-          numRunBytes = streamSizes[i];
-        }
-      }
-      ++nextSelected;
+  size_t sparsePosition = 0;
+  size_t selectedPosition = 0;
+  while (sparsePosition < streamIndices.size() &&
+         selectedPosition < selectedStreamIndices.size()) {
+    if (selectedStreamIndices[selectedPosition] <
+        streamIndices[sparsePosition]) {
+      // Selected stream absent from sparse trailer (size 0); outputSizes
+      // already 0.
+      ++selectedPosition;
+      continue;
     }
-    curOffset += streamSizes[i];
+    if (selectedStreamIndices[selectedPosition] >
+        streamIndices[sparsePosition]) {
+      // Non-selected stream; advance past its bytes. The next match's
+      // run-extension check will detect the byte-gap and flush via its else
+      // branch, so no explicit flush is needed here.
+      currentOffset += streamSizes[sparsePosition];
+      ++sparsePosition;
+      continue;
+    }
+    // Match.
+    // NOLINTBEGIN(facebook-hte-LocalUncheckedArrayBounds)
+    outputSizes[selectedPosition] = streamSizes[sparsePosition];
+    if (numRunBytes > 0 && currentOffset == runStart + numRunBytes) {
+      numRunBytes += streamSizes[sparsePosition];
+    } else {
+      flushRun();
+      runStart = currentOffset;
+      numRunBytes = streamSizes[sparsePosition];
+    }
+    currentOffset += streamSizes[sparsePosition];
+    // NOLINTEND(facebook-hte-LocalUncheckedArrayBounds)
+    ++sparsePosition;
+    ++selectedPosition;
   }
   flushRun();
 
@@ -433,18 +486,19 @@ std::vector<uint32_t> Projector::projectStreamsContiguousSorted(
 }
 
 // Fast path for projectStreamsChainedUnsorted when inputStreamIndices are
-// sorted (no FlatMap key reordering). Single forward pass with run merging — no
-// sorting or reordering needed since input and output order already match.
+// sorted (no FlatMap key reordering). Two-pointer merge over the sparse
+// (streamIndices, streamSizes) trailer and selectedStreamIndices, with run
+// merging for contiguous-in-input selected streams.
 // static
 std::vector<uint32_t> Projector::projectStreamsChainedSorted(
     folly::io::Cursor& cursor,
+    const std::vector<uint32_t>& streamIndices,
     const std::vector<uint32_t>& streamSizes,
-    const std::vector<uint32_t>& selectedIndices,
+    const std::vector<uint32_t>& selectedStreamIndices,
     std::unique_ptr<folly::IOBuf>& output) {
-  std::vector<uint32_t> outputSizes(selectedIndices.size(), 0);
-  size_t nextSelected = 0;
+  std::vector<uint32_t> outputSizes(selectedStreamIndices.size(), 0);
 
-  // Track how many contiguous selected streams we can merge.
+  // Track how many contiguous selected stream bytes we can merge.
   size_t numRunBytes = 0;
 
   auto flushRun = [&](std::unique_ptr<folly::IOBuf>& out) {
@@ -457,22 +511,35 @@ std::vector<uint32_t> Projector::projectStreamsChainedSorted(
     numRunBytes = 0;
   };
 
-  for (size_t i = 0;
-       i < streamSizes.size() && nextSelected < selectedIndices.size();
-       ++i) {
-    if (i == selectedIndices[nextSelected]) {
-      outputSizes[nextSelected] = streamSizes[i];
-      if (streamSizes[i] > 0) {
-        numRunBytes += streamSizes[i];
-      }
-      ++nextSelected;
+  size_t sparsePosition = 0;
+  size_t selectedPosition = 0;
+  while (sparsePosition < streamIndices.size() &&
+         selectedPosition < selectedStreamIndices.size()) {
+    if (selectedStreamIndices[selectedPosition] <
+        streamIndices[sparsePosition]) {
+      // Selected stream absent from sparse trailer (size 0); outputSizes
+      // already 0.
+      ++selectedPosition;
       continue;
     }
-    // Not selected — flush any pending run and skip this stream.
-    flushRun(output);
-    if (streamSizes[i] > 0) {
-      cursor.skip(streamSizes[i]);
+    if (selectedStreamIndices[selectedPosition] >
+        streamIndices[sparsePosition]) {
+      // Non-selected stream; flush any pending run and skip its bytes via
+      // cursor. Flush is required for cursor correctness: cursor.skip moves
+      // the cursor forward, so we must clone the pending run bytes (which
+      // sit at the cursor's current position) before skipping past them.
+      flushRun(output);
+      cursor.skip(streamSizes[sparsePosition]);
+      ++sparsePosition;
+      continue;
     }
+    // Match: accumulate into the current run.
+    // NOLINTBEGIN(facebook-hte-LocalUncheckedArrayBounds)
+    outputSizes[selectedPosition] = streamSizes[sparsePosition];
+    numRunBytes += streamSizes[sparsePosition];
+    // NOLINTEND(facebook-hte-LocalUncheckedArrayBounds)
+    ++sparsePosition;
+    ++selectedPosition;
   }
   flushRun(output);
 
@@ -480,15 +547,15 @@ std::vector<uint32_t> Projector::projectStreamsChainedSorted(
 }
 
 // Projects selected streams from a chained IOBuf via cursor.
-// Streams are output in the order of selectedIndices (output stream order).
-// Uses a sorted forward pass to extract IOBufs via cursor, merging contiguous
-// runs that are also adjacent in output order into single zero-copy clones.
-// Non-mergeable streams are extracted individually and reordered in a second
-// pass.
-
+// Streams are output in the order of selectedStreamIndices (output stream
+// order). Walks the sparse (streamIndices, streamSizes) trailer in lockstep
+// with the sorted-by-input mapping; merges contiguous-in-input runs that are
+// also adjacent in output order into single zero-copy clones, then sorts and
+// chains by output index.
 // static
 std::vector<uint32_t> Projector::projectStreamsChainedUnsorted(
     folly::io::Cursor& cursor,
+    const std::vector<uint32_t>& streamIndices,
     const std::vector<uint32_t>& streamSizes,
     const std::vector<StreamMapping>& sortedStreamMappings,
     std::unique_ptr<folly::IOBuf>& output) {
@@ -502,54 +569,57 @@ std::vector<uint32_t> Projector::projectStreamsChainedUnsorted(
     std::unique_ptr<folly::IOBuf> buf;
   };
 
-  // Forward pass: extract selected streams via cursor in sorted input order.
-  // Merges contiguous input streams that are also adjacent in output order into
-  // a single cursor.clone() call, reducing allocations. Each merged run
-  // produces one OutputStreamBuffer entry — typically far fewer than the total
-  // number of selected streams.
   std::vector<OutputStreamBuffer> outputStreamBufs;
   outputStreamBufs.reserve(sortedStreamMappings.size());
-  size_t nextSortedIdx = 0;
-  for (size_t i = 0;
-       i < streamSizes.size() && nextSortedIdx < sortedStreamMappings.size();) {
-    if (i != sortedStreamMappings[nextSortedIdx].inputStreamIdx) {
-      if (streamSizes[i] > 0) {
-        cursor.skip(streamSizes[i]);
-      }
-      ++i;
+
+  size_t sparsePosition = 0;
+  size_t mappingPosition = 0;
+  while (sparsePosition < streamIndices.size() &&
+         mappingPosition < sortedStreamMappings.size()) {
+    const auto wantInputStreamIdx =
+        sortedStreamMappings[mappingPosition].inputStreamIdx;
+    if (wantInputStreamIdx < streamIndices[sparsePosition]) {
+      // Selected input stream absent from sparse trailer (size 0).
+      ++mappingPosition;
+      continue;
+    }
+    if (wantInputStreamIdx > streamIndices[sparsePosition]) {
+      // Non-selected input stream; skip its bytes via cursor.
+      cursor.skip(streamSizes[sparsePosition]);
+      ++sparsePosition;
       continue;
     }
 
-    // Found a selected stream. Try to extend a contiguous run: consecutive
-    // in input AND adjacent in output order.
+    // Match: try to extend a run while consecutive in input AND adjacent in
+    // output AND present in sparse.
     const auto runOutputStreamIdx =
-        sortedStreamMappings[nextSortedIdx].outputStreamIdx;
+        sortedStreamMappings[mappingPosition].outputStreamIdx;
     size_t numRunBytes = 0;
-    size_t numRunOutputStreams = 0;
-    while (nextSortedIdx + numRunOutputStreams < sortedStreamMappings.size() &&
-           sortedStreamMappings[nextSortedIdx + numRunOutputStreams]
-                   .inputStreamIdx == i + numRunOutputStreams &&
-           i + numRunOutputStreams < streamSizes.size() &&
-           sortedStreamMappings[nextSortedIdx + numRunOutputStreams]
-                   .outputStreamIdx ==
-               runOutputStreamIdx + numRunOutputStreams) {
-      const auto inputStreamIdx =
-          sortedStreamMappings[nextSortedIdx + numRunOutputStreams]
-              .inputStreamIdx;
-      outputSizes[runOutputStreamIdx + numRunOutputStreams] =
-          streamSizes[inputStreamIdx];
-      numRunBytes += streamSizes[inputStreamIdx];
-      ++numRunOutputStreams;
+    size_t numRunStreams = 0;
+    while (
+        mappingPosition + numRunStreams < sortedStreamMappings.size() &&
+        sparsePosition + numRunStreams < streamIndices.size() &&
+        streamIndices[sparsePosition + numRunStreams] ==
+            streamIndices[sparsePosition] + numRunStreams &&
+        sortedStreamMappings[mappingPosition + numRunStreams].inputStreamIdx ==
+            streamIndices[sparsePosition] + numRunStreams &&
+        sortedStreamMappings[mappingPosition + numRunStreams].outputStreamIdx ==
+            runOutputStreamIdx + numRunStreams) {
+      // NOLINTBEGIN(facebook-hte-LocalUncheckedArrayBounds)
+      const auto streamSize = streamSizes[sparsePosition + numRunStreams];
+      outputSizes[runOutputStreamIdx + numRunStreams] = streamSize;
+      // NOLINTEND(facebook-hte-LocalUncheckedArrayBounds)
+      numRunBytes += streamSize;
+      ++numRunStreams;
     }
 
     if (numRunBytes > 0) {
-      // Zero-copy: clone the merged run.
       std::unique_ptr<folly::IOBuf> buf;
       cursor.clone(buf, numRunBytes);
       outputStreamBufs.push_back({runOutputStreamIdx, std::move(buf)});
     }
-    nextSortedIdx += numRunOutputStreams;
-    i += numRunOutputStreams;
+    mappingPosition += numRunStreams;
+    sparsePosition += numRunStreams;
   }
 
   // Sort by output stream index and chain in order.
@@ -572,9 +642,13 @@ folly::IOBuf Projector::buildProjectedOutput(
       detail::estimateTrailerSize(
           options_.projectVersion,
           outputStreamSizes.size(),
+          options_.streamIndicesEncodingType,
           options_.streamSizesEncodingType));
   detail::writeTrailer(
-      outputStreamSizes, options_.streamSizesEncodingType, trailer);
+      outputStreamSizes,
+      options_.streamIndicesEncodingType,
+      options_.streamSizesEncodingType,
+      trailer);
   output->appendToChain(std::move(trailer).build());
   return std::move(*output);
 }
@@ -602,23 +676,30 @@ folly::IOBuf Projector::projectContiguous(
   writeSerializationHeader(header, options_.projectVersion, rowCount);
   auto output = std::move(header).build();
 
-  // Dispatch on the version byte: legacy kCompactRaw / kTablet blobs go
-  // through the frozen legacy reader; the else branch is scaffolding for the
-  // next change that will introduce a sibling reader for a new wire format.
-  std::vector<uint32_t> inputStreamSizes;
-  if (usesLegacyTrailer(inputVersion)) {
-    inputStreamSizes = legacy::readLegacyTrailerStreamSizesDense(input);
-  } else {
-    NIMBLE_UNREACHABLE("unexpected non-legacy trailer version");
-  }
+  // Dispatch on input version: legacy kLegacyCompact blobs are read via the
+  // frozen legacy reader (normalized to sparse pairs internally); all newer
+  // versions use the new two-array sparse trailer reader.
+  auto [streamIndices, streamSizes] = usesLegacyTrailer(inputVersion)
+      ? legacy::readLegacyTrailerStreamMetadata(input)
+      : detail::readTrailerStreamMetadata(input);
 
   // Extract selected streams as zero-copy sub-range clones.
   const auto dataOffset = static_cast<size_t>(pos - data);
   auto outputStreamSizes = inputStreamsSorted_
       ? projectStreamsContiguousSorted(
-            input, dataOffset, inputStreamSizes, inputStreamIndices_, output)
+            input,
+            dataOffset,
+            streamIndices,
+            streamSizes,
+            inputStreamIndices_,
+            output)
       : projectStreamsContiguousUnsorted(
-            input, dataOffset, inputStreamSizes, inputStreamIndices_, output);
+            input,
+            dataOffset,
+            streamIndices,
+            streamSizes,
+            inputStreamIndices_,
+            output);
 
   return buildProjectedOutput(outputStreamSizes, std::move(output));
 }
@@ -637,22 +718,19 @@ folly::IOBuf Projector::projectChained(
   writeSerializationHeader(header, options_.projectVersion, rowCount);
   auto output = std::move(header).build();
 
-  // Dispatch on the version byte: legacy kCompactRaw / kTablet blobs go
-  // through the frozen legacy reader; the else branch is scaffolding for the
-  // next change that will introduce a sibling reader for a new wire format.
-  std::vector<uint32_t> inputStreamSizes;
-  if (usesLegacyTrailer(inputVersion)) {
-    inputStreamSizes = legacy::readLegacyTrailerStreamSizesDense(input);
-  } else {
-    NIMBLE_UNREACHABLE("unexpected non-legacy trailer version");
-  }
+  // Dispatch on input version: legacy kLegacyCompact blobs are read via the
+  // frozen legacy reader (normalized to sparse pairs internally); all newer
+  // versions use the new two-array sparse trailer reader.
+  auto [streamIndices, streamSizes] = usesLegacyTrailer(inputVersion)
+      ? legacy::readLegacyTrailerStreamMetadata(input)
+      : detail::readTrailerStreamMetadata(input);
 
   // Extract selected streams as zero-copy clones via cursor.
   auto outputStreamSizes = inputStreamsSorted_
       ? projectStreamsChainedSorted(
-            cursor, inputStreamSizes, inputStreamIndices_, output)
+            cursor, streamIndices, streamSizes, inputStreamIndices_, output)
       : projectStreamsChainedUnsorted(
-            cursor, inputStreamSizes, sortedStreamMappings_, output);
+            cursor, streamIndices, streamSizes, sortedStreamMappings_, output);
 
   return buildProjectedOutput(outputStreamSizes, std::move(output));
 }

--- a/dwio/nimble/serializer/Projector.h
+++ b/dwio/nimble/serializer/Projector.h
@@ -69,11 +69,17 @@ using Subfield = velox::common::Subfield;
 class Projector {
  public:
   struct Options {
-    /// Output serialization format version. Must be kCompactRaw.
-    SerializationVersion projectVersion{SerializationVersion::kCompactRaw};
+    /// Output serialization format version. Defaults to kProjection (the
+    /// Projector-specific version byte for the two-array sparse trailer).
+    /// kLegacyCompact is read-only and rejected at construction.
+    SerializationVersion projectVersion{SerializationVersion::kProjection};
 
-    /// Encoding type for stream sizes in the trailer.
-    /// Supported types: Trivial, Varint, Delta, FixedBitWidth, MainlyConstant.
+    /// Encoding type for the indices array of the sparse stream-sizes
+    /// trailer. Supported types: Trivial, Varint, Delta, FixedBitWidth.
+    EncodingType streamIndicesEncodingType{EncodingType::FixedBitWidth};
+
+    /// Encoding type for the sizes array of the sparse stream-sizes
+    /// trailer. Supported types: Trivial, Varint, Delta, FixedBitWidth.
     EncodingType streamSizesEncodingType{EncodingType::FixedBitWidth};
 
     /// Optional velox type with up-to-date column names from the current
@@ -159,31 +165,45 @@ class Projector {
       SerializationVersion inputVersion) const;
 
   // Projects selected streams from a contiguous IOBuf in unsorted order.
+  // Walks selectedStreamIndices in output order; for each, binary-searches the
+  // sparse (streamIndices, streamSizes) trailer for the corresponding bytes.
+  // Output IOBufs are emitted in output order with run merging across
+  // contiguous-in-input selected streams.
   static std::vector<uint32_t> projectStreamsContiguousUnsorted(
       const folly::IOBuf& input,
       size_t dataOffset,
+      const std::vector<uint32_t>& streamIndices,
       const std::vector<uint32_t>& streamSizes,
-      const std::vector<uint32_t>& selectedIndices,
+      const std::vector<uint32_t>& selectedStreamIndices,
       std::unique_ptr<folly::IOBuf>& output);
 
   // Projects selected streams from a contiguous IOBuf in sorted order.
+  // Two-pointer merge over the sparse (streamIndices, streamSizes) trailer and
+  // the already-sorted selectedStreamIndices.
   static std::vector<uint32_t> projectStreamsContiguousSorted(
       const folly::IOBuf& input,
       size_t dataOffset,
+      const std::vector<uint32_t>& streamIndices,
       const std::vector<uint32_t>& streamSizes,
-      const std::vector<uint32_t>& selectedIndices,
+      const std::vector<uint32_t>& selectedStreamIndices,
       std::unique_ptr<folly::IOBuf>& output);
 
   // Projects selected streams from a chained IOBuf in sorted order.
+  // Two-pointer merge; cursor advances stay aligned to the sparse stream
+  // bytes only.
   static std::vector<uint32_t> projectStreamsChainedSorted(
       folly::io::Cursor& cursor,
+      const std::vector<uint32_t>& streamIndices,
       const std::vector<uint32_t>& streamSizes,
-      const std::vector<uint32_t>& selectedIndices,
+      const std::vector<uint32_t>& selectedStreamIndices,
       std::unique_ptr<folly::IOBuf>& output);
 
   // Projects selected streams from a chained IOBuf in unsorted order.
+  // Same merge-walk shape as the contiguous unsorted variant; output buffers
+  // are sorted by output stream index before chaining.
   static std::vector<uint32_t> projectStreamsChainedUnsorted(
       folly::io::Cursor& cursor,
+      const std::vector<uint32_t>& streamIndices,
       const std::vector<uint32_t>& streamSizes,
       const std::vector<StreamMapping>& sortedStreamMappings,
       std::unique_ptr<folly::IOBuf>& output);

--- a/dwio/nimble/serializer/SerializationHeader.cpp
+++ b/dwio/nimble/serializer/SerializationHeader.cpp
@@ -61,8 +61,10 @@ readSerializationHeader(const char*& pos, const char* end, bool hasHeader) {
     header.version = static_cast<SerializationVersion>(*pos);
     NIMBLE_CHECK(
         header.version == SerializationVersion::kLegacy ||
-            header.version == SerializationVersion::kCompactRaw ||
-            header.version == SerializationVersion::kTablet,
+            header.version == SerializationVersion::kLegacyCompact ||
+            header.version == SerializationVersion::kTablet ||
+            header.version == SerializationVersion::kSerialization ||
+            header.version == SerializationVersion::kProjection,
         "Unsupported version {}",
         static_cast<uint8_t>(header.version));
     ++pos;

--- a/dwio/nimble/serializer/SerializationHeader.h
+++ b/dwio/nimble/serializer/SerializationHeader.h
@@ -59,7 +59,7 @@ readSerializationHeader(const char*& pos, const char* end, bool hasHeader);
 
 /// Writes a serialization header to buffer.
 /// For kLegacy: writes [optional_version:1B][rowCount:u32]
-/// For kCompactRaw: writes [version:1B][rowCount:varint]
+/// For kLegacyCompact: writes [version:1B][rowCount:varint]
 /// kTablet headers must use createTabletChunkHeader() instead.
 template <typename T>
 void writeSerializationHeader(

--- a/dwio/nimble/serializer/Serializer.cpp
+++ b/dwio/nimble/serializer/Serializer.cpp
@@ -15,6 +15,8 @@
  */
 #include "dwio/nimble/serializer/Serializer.h"
 
+#include <glog/logging.h>
+
 namespace facebook::nimble {
 
 namespace {
@@ -32,13 +34,30 @@ class FlatmapEncodingLayoutContext : public TypeBuilderContext {
       keyEncodings_;
 };
 
+// kLegacyCompact is read-only post the two-array trailer change. Callers that
+// still pass it (e.g., not-yet-migrated tests or downstream code we can't
+// update in this diff due to directory branching) are silently upgraded to
+// kSerialization so the round-trip still works on the new wire format. A
+// LOG(WARNING) flags the migration so the caller can switch.
+SerializerOptions upgradeReadOnlyVersion(SerializerOptions options) {
+  if (options.version.has_value() &&
+      options.version.value() == SerializationVersion::kLegacyCompact) {
+    LOG_FIRST_N(WARNING, 10)
+        << "Serializer constructed with kLegacyCompact (read-only post the "
+           "two-array trailer change); silently upgrading to kSerialization. "
+           "Migrate the caller to pass kSerialization explicitly.";
+    options.version = SerializationVersion::kSerialization;
+  }
+  return options;
+}
+
 } // namespace
 
 Serializer::Serializer(
     SerializerOptions options,
     const std::shared_ptr<const velox::Type>& type,
     velox::memory::MemoryPool* pool)
-    : options_{std::move(options)},
+    : options_{upgradeReadOnlyVersion(std::move(options))},
       pool_{pool},
       context_{*pool_},
       buffer_{context_.bufferMemoryPool().get()} {

--- a/dwio/nimble/serializer/SerializerImpl.cpp
+++ b/dwio/nimble/serializer/SerializerImpl.cpp
@@ -16,11 +16,11 @@
 
 #include "dwio/nimble/serializer/SerializerImpl.h"
 
-#include <bit>
 #include <limits>
 
-#include "dwio/nimble/serializer/SerializationHeader.h"
 #include "dwio/nimble/serializer/legacy/TrailerReader.h"
+
+#include "dwio/nimble/serializer/SerializationHeader.h"
 
 #include <lz4.h>
 #include <lz4hc.h>
@@ -33,146 +33,124 @@ namespace facebook::nimble::serde::detail {
 
 namespace {
 
-void decodeTrivialTrailer(
+// Sanity cap on the trailing trailer-size u32 at the public reader entries.
+// Production trailers are well under this (typical low-MB at worst). Anything
+// past this is treated as buffer corruption rather than a legitimate
+// allocation request, so a single bit flip in the trailing u32 can't drive
+// a multi-GB allocation before the post-decode mismatch check fires.
+constexpr uint32_t kMaxTrailerBytes = 1u << 26; // 64 MiB.
+
+// Per-section decoders for the two-array sparse trailer layout. Each consumes
+// the encoding-specific payload (no encoding-type byte) and advances `payload`
+// past the bytes it read. The caller is responsible for reading the
+// encoding-type byte and dispatching to the right decoder.
+//
+// `remainingBytes` is the upper bound on payload bytes the decoder may
+// consume (i.e. `trailerEnd - payload` at entry). It is used only for a
+// single pre-loop sanity check on `count` so a corrupted count varint
+// cannot drive a multi-GB `resize`. Loop bodies remain free of
+// per-iteration bound checks to keep the hot path branch-free.
+
+void decodeTrivialSection(
     const char*& payload,
-    uint32_t payloadSize,
-    std::vector<uint32_t>& sizes) {
-  const uint32_t count = payloadSize / sizeof(uint32_t);
-  sizes.resize(count);
+    uint32_t remainingBytes,
+    std::vector<uint32_t>& values) {
+  const uint32_t count = varint::readVarint32(&payload);
+  NIMBLE_CHECK_LE(
+      count,
+      remainingBytes,
+      "Trivial section count exceeds remaining trailer bytes");
+  values.resize(count);
   if (count > 0) {
-    std::memcpy(sizes.data(), payload, count * sizeof(uint32_t));
+    std::memcpy(values.data(), payload, count * sizeof(uint32_t));
     payload += count * sizeof(uint32_t);
   }
 }
 
-void decodeVarintTrailer(const char*& payload, std::vector<uint32_t>& sizes) {
+void decodeVarintSection(
+    const char*& payload,
+    uint32_t remainingBytes,
+    std::vector<uint32_t>& values) {
   const uint32_t count = varint::readVarint32(&payload);
-  sizes.resize(count);
+  NIMBLE_CHECK_LE(
+      count,
+      remainingBytes,
+      "Varint section count exceeds remaining trailer bytes");
+  values.resize(count);
   for (uint32_t i = 0; i < count; ++i) {
-    sizes[i] = varint::readVarint32(&payload);
+    values[i] = varint::readVarint32(&payload);
   }
 }
 
-void decodeDeltaTrailer(const char*& payload, std::vector<uint32_t>& sizes) {
+void decodeDeltaSection(
+    const char*& payload,
+    uint32_t remainingBytes,
+    std::vector<uint32_t>& values) {
   const uint32_t count = varint::readVarint32(&payload);
-  sizes.resize(count);
+  NIMBLE_CHECK_LE(
+      count,
+      remainingBytes,
+      "Delta section count exceeds remaining trailer bytes");
+  values.resize(count);
   if (count > 0) {
-    sizes[0] = varint::readVarint32(&payload);
+    values[0] = varint::readVarint32(&payload);
     for (uint32_t i = 1; i < count; ++i) {
       const auto delta = varint::readVarint32(&payload);
-      sizes[i] = sizes[i - 1] + delta;
+      values[i] = values[i - 1] + delta;
     }
   }
 }
 
-void decodeFixedBitWidthTrailer(
+void decodeFixedBitWidthSection(
     const char*& payload,
-    std::vector<uint32_t>& sizes) {
+    uint32_t remainingBytes,
+    std::vector<uint32_t>& values) {
   const uint8_t bitWidth = static_cast<uint8_t>(*payload++);
+  NIMBLE_CHECK_LE(
+      bitWidth, 32, "FixedBitWidth section bitWidth exceeds 32 bits");
   const uint32_t count = varint::readVarint32(&payload);
-  sizes.assign(count, 0);
+  // Each value occupies >= 1 bit on the wire, so count <= remainingBytes * 8
+  // is a generous sanity ceiling. Cast to uint64_t to avoid overflow when
+  // remainingBytes is large.
+  NIMBLE_CHECK_LE(
+      static_cast<uint64_t>(count),
+      static_cast<uint64_t>(remainingBytes) * 8u,
+      "FixedBitWidth section count exceeds remaining trailer bit-capacity");
+  values.assign(count, 0);
   if (bitWidth > 0 && count > 0) {
     const uint32_t packedBytes =
         static_cast<uint32_t>(FixedBitArray::bufferSize(count, bitWidth));
     FixedBitArray arr{const_cast<char*>(payload), static_cast<int>(bitWidth)};
-    arr.bulkGet32(0, count, sizes.data());
+    arr.bulkGet32(0, count, values.data());
     payload += packedBytes;
   }
 }
 
-void decodeMainlyConstantTrailer(
+void decodeSection(
+    EncodingType encodingType,
     const char*& payload,
-    std::vector<uint32_t>& sizes) {
-  const uint32_t streamCount = varint::readVarint32(&payload);
-  const uint32_t nonZeroCount = varint::readVarint32(&payload);
-  NIMBLE_CHECK_LE(
-      nonZeroCount,
-      streamCount,
-      "MainlyConstant nonZeroCount exceeds streamCount");
-  // Constant is fixed at 0 and not stored on the wire.
-  sizes.assign(streamCount, 0);
-  if (nonZeroCount == 0) {
-    // idxBitWidth/valBitWidth bytes and packed arrays are omitted when
-    // there are no non-zero entries.
-    return;
+    const char* trailerEnd,
+    std::vector<uint32_t>& values) {
+  const auto remainingBytes = static_cast<uint32_t>(trailerEnd - payload);
+  // NOLINTNEXTLINE(clang-diagnostic-switch-enum)
+  switch (getTrailerEncodingType(encodingType)) {
+    case EncodingType::Trivial:
+      decodeTrivialSection(payload, remainingBytes, values);
+      break;
+    case EncodingType::Varint:
+      decodeVarintSection(payload, remainingBytes, values);
+      break;
+    case EncodingType::Delta:
+      decodeDeltaSection(payload, remainingBytes, values);
+      break;
+    case EncodingType::FixedBitWidth:
+      decodeFixedBitWidthSection(payload, remainingBytes, values);
+      break;
+    default:
+      NIMBLE_FAIL(
+          "Unsupported EncodingType for stream sizes trailer section: {}",
+          encodingType);
   }
-
-  const uint8_t idxBitWidth = static_cast<uint8_t>(*payload++);
-  NIMBLE_CHECK_LE(
-      idxBitWidth, 32, "MainlyConstant idxBitWidth exceeds 32 bits");
-  std::vector<uint32_t> indices(nonZeroCount);
-  const uint32_t packedIndicesBytes = static_cast<uint32_t>(
-      FixedBitArray::bufferSize(nonZeroCount, idxBitWidth));
-  FixedBitArray idxArr{
-      const_cast<char*>(payload), static_cast<int>(idxBitWidth)};
-  idxArr.bulkGet32(0, nonZeroCount, indices.data());
-  payload += packedIndicesBytes;
-
-  const uint8_t valBitWidth = static_cast<uint8_t>(*payload++);
-  NIMBLE_CHECK_LE(
-      valBitWidth, 32, "MainlyConstant valBitWidth exceeds 32 bits");
-  std::vector<uint32_t> values(nonZeroCount);
-  const uint32_t packedValuesBytes = static_cast<uint32_t>(
-      FixedBitArray::bufferSize(nonZeroCount, valBitWidth));
-  FixedBitArray valArr{
-      const_cast<char*>(payload), static_cast<int>(valBitWidth)};
-  valArr.bulkGet32(0, nonZeroCount, values.data());
-  payload += packedValuesBytes;
-
-  for (uint32_t i = 0; i < nonZeroCount; ++i) {
-    NIMBLE_CHECK_LT(
-        indices[i], streamCount, "MainlyConstant trailer index out of range");
-    sizes[indices[i]] = values[i];
-  }
-}
-
-// Sparse-native MainlyConstant trailer decode: fill (indices, sizes)
-// parallel arrays for only the non-zero stream slots, skipping the
-// streamCount-zero-filled dense expansion. Caller iterates the returned
-// indices/sizes directly to visit non-empty streams.
-void decodeMainlyConstantTrailerSparse(
-    const char*& payload,
-    std::vector<uint32_t>& indices,
-    std::vector<uint32_t>& sizes) {
-  const uint32_t streamCount = varint::readVarint32(&payload);
-  const uint32_t nonZeroCount = varint::readVarint32(&payload);
-  NIMBLE_CHECK_LE(
-      nonZeroCount,
-      streamCount,
-      "MainlyConstant nonZeroCount exceeds streamCount");
-  indices.resize(nonZeroCount);
-  sizes.resize(nonZeroCount);
-  if (nonZeroCount == 0) {
-    return;
-  }
-
-  const uint8_t idxBitWidth = static_cast<uint8_t>(*payload++);
-  NIMBLE_CHECK_LE(
-      idxBitWidth, 32, "MainlyConstant idxBitWidth exceeds 32 bits");
-  const uint32_t packedIndicesBytes = static_cast<uint32_t>(
-      FixedBitArray::bufferSize(nonZeroCount, idxBitWidth));
-  FixedBitArray idxArr{
-      const_cast<char*>(payload), static_cast<int>(idxBitWidth)};
-  idxArr.bulkGet32(0, nonZeroCount, indices.data());
-  payload += packedIndicesBytes;
-
-  // Validate decoded indices against streamCount for parity with the dense
-  // decoder's per-scatter NIMBLE_CHECK_LT. Catches trailer corruption that
-  // the downstream `offset <= maxStreamOffset` clamp would otherwise mask.
-  for (uint32_t i = 0; i < nonZeroCount; ++i) {
-    NIMBLE_CHECK_LT(
-        indices[i], streamCount, "MainlyConstant trailer index out of range");
-  }
-
-  const uint8_t valBitWidth = static_cast<uint8_t>(*payload++);
-  NIMBLE_CHECK_LE(
-      valBitWidth, 32, "MainlyConstant valBitWidth exceeds 32 bits");
-  const uint32_t packedValuesBytes = static_cast<uint32_t>(
-      FixedBitArray::bufferSize(nonZeroCount, valBitWidth));
-  FixedBitArray valArr{
-      const_cast<char*>(payload), static_cast<int>(valBitWidth)};
-  valArr.bulkGet32(0, nonZeroCount, sizes.data());
-  payload += packedValuesBytes;
 }
 
 // Upper-bound payload-size estimators (one per trailer encoding). Each
@@ -231,85 +209,76 @@ std::optional<uint32_t> compressLz4(
   return sizeof(uint32_t) + static_cast<uint32_t>(compressedSize);
 }
 
-size_t estimateTrivialTrailerPayloadSize(size_t numStreams) {
-  return numStreams * sizeof(uint32_t);
+// Upper-bound estimators for the encoded payload of one section. `count` is the
+// worst-case number of values to emit; `maxValue` is the largest value that
+// can appear (used by Delta/FixedBitWidth; Trivial/Varint ignore it).
+size_t estimateTrivialSectionSize(size_t count) {
+  // count varint (max 5 bytes) + N u32s.
+  return 5 + count * sizeof(uint32_t);
 }
 
-size_t estimateVarintTrailerPayloadSize(size_t numStreams) {
+size_t estimateVarintSectionSize(size_t count) {
   // count varint + N varints (max 5 bytes each).
-  return 5 + numStreams * 5;
+  return 5 + count * 5;
 }
 
-size_t estimateDeltaTrailerPayloadSize(size_t numStreams) {
-  // count varint + first offset varint + (N-1) delta varints (max 5 bytes
-  // each).
-  return 5 + numStreams * 5;
+size_t estimateDeltaSectionSize(size_t count) {
+  // count varint + first value varint + (N-1) delta varints (max 5 each).
+  return 5 + count * 5;
 }
 
-size_t estimateFixedBitWidthTrailerPayloadSize(size_t numStreams) {
+size_t estimateFixedBitWidthSectionSize(size_t count) {
   // bitWidth:1B + count varint + bufferSize (32 bits per element max).
-  return 1 + 5 + FixedBitArray::bufferSize(numStreams, /*bitWidth=*/32);
+  return 1 + 5 + FixedBitArray::bufferSize(count, /*bitWidth=*/32);
 }
 
-// MainlyConstant: idxBitWidth matches the writer's formula (max(1,
-// bit_width(numStreams - 1)) when there are indices); valBitWidth is
-// unbounded up to 32 since values are uint32_t.
-size_t estimateMainlyConstantTrailerPayloadSize(size_t numStreams) {
-  const size_t idxBitWidth =
-      numStreams == 0 ? 0 : std::max<size_t>(1, std::bit_width(numStreams - 1));
-  // 5 (streamCount varint) + 5 (nonZeroCount varint) + 1 (idxBitWidth) +
-  // packed indices + 1 (valBitWidth) + packed values.
-  return 5 + 5 + 1 +
-      FixedBitArray::bufferSize(numStreams, static_cast<int>(idxBitWidth)) + 1 +
-      FixedBitArray::bufferSize(numStreams, /*bitWidth=*/32);
-}
-
-void decodeTrailerStreamSizes(
-    const char* trailerStart,
-    uint32_t trailerSize,
-    std::vector<uint32_t>& out) {
-  const auto* end = trailerStart + trailerSize;
-  const auto encodingType =
-      static_cast<EncodingType>(static_cast<uint8_t>(*trailerStart));
-  const char* payload = trailerStart + sizeof(uint8_t);
-  const uint32_t payloadSize = trailerSize - sizeof(uint8_t);
-
-  switch (encodingType) {
+size_t estimateSectionSize(EncodingType encodingType, size_t count) {
+  // NOLINTNEXTLINE(clang-diagnostic-switch-enum)
+  switch (getTrailerEncodingType(encodingType)) {
     case EncodingType::Trivial:
-      decodeTrivialTrailer(payload, payloadSize, out);
-      break;
+      return estimateTrivialSectionSize(count);
     case EncodingType::Varint:
-      decodeVarintTrailer(payload, out);
-      break;
+      return estimateVarintSectionSize(count);
     case EncodingType::Delta:
-      decodeDeltaTrailer(payload, out);
-      break;
+      return estimateDeltaSectionSize(count);
     case EncodingType::FixedBitWidth:
-      decodeFixedBitWidthTrailer(payload, out);
-      break;
-    case EncodingType::MainlyConstant:
-      decodeMainlyConstantTrailer(payload, out);
-      break;
+      return estimateFixedBitWidthSectionSize(count);
     default:
       NIMBLE_FAIL(
-          "Unsupported EncodingType for stream sizes trailer: {}",
+          "Unsupported EncodingType for stream sizes trailer section: {}",
           encodingType);
   }
+}
 
+// Decodes a two-array sparse trailer into parallel `streamIndices` and
+// `streamSizes` arrays. Validates that the per-section decoders consume
+// exactly the trailer payload and that
+// `streamIndices.size() == streamSizes.size()`.
+void decodeTrailerStreamMetadata(
+    const char* trailerStart,
+    uint32_t trailerSize,
+    std::vector<uint32_t>& streamIndices,
+    std::vector<uint32_t>& streamSizes) {
+  const auto* trailerEnd = trailerStart + trailerSize;
+  const char* payload = trailerStart;
+  const auto indicesEncodingType =
+      static_cast<EncodingType>(static_cast<uint8_t>(*payload++));
+  decodeSection(indicesEncodingType, payload, trailerEnd, streamIndices);
+  const auto sizesEncodingType =
+      static_cast<EncodingType>(static_cast<uint8_t>(*payload++));
+  decodeSection(sizesEncodingType, payload, trailerEnd, streamSizes);
   NIMBLE_CHECK_EQ(
       payload,
-      end,
+      trailerEnd,
       "Trailer size mismatch: read {} bytes, expected {}",
       payload - trailerStart,
       trailerSize);
-}
-
-std::vector<uint32_t> decodeTrailerStreamSizes(
-    const char* trailerStart,
-    uint32_t trailerSize) {
-  std::vector<uint32_t> sizes;
-  decodeTrailerStreamSizes(trailerStart, trailerSize, sizes);
-  return sizes;
+  NIMBLE_CHECK_EQ(
+      streamIndices.size(),
+      streamSizes.size(),
+      "Trailer indices/sizes section count mismatch: indices={} sizes={}",
+      streamIndices.size(),
+      streamSizes.size());
 }
 
 } // namespace
@@ -373,42 +342,32 @@ encode(const SerializerOptions& options, std::string_view input, char* output) {
   return size + sizeof(uint32_t) + 1;
 }
 
-std::vector<uint32_t> readTrailerStreamSizes(const char* end) {
-  const uint32_t trailerSize = readTrailerSize(end);
-  const char* trailerStart = end - sizeof(uint32_t) - trailerSize;
-  return decodeTrailerStreamSizes(trailerStart, trailerSize);
-}
-
-bool readTrailerStreamSizes(
+void readTrailerStreamMetadata(
     const char* end,
-    std::vector<uint32_t>& denseSizes,
-    std::vector<uint32_t>& sparseIndices,
-    std::vector<uint32_t>& sparseSizes) {
+    std::vector<uint32_t>& streamIndices,
+    std::vector<uint32_t>& streamSizes) {
   const uint32_t trailerSize = readTrailerSize(end);
+  NIMBLE_CHECK_LE(
+      trailerSize,
+      kMaxTrailerBytes,
+      "Trailer size sanity cap exceeded (likely buffer corruption): {} > {}",
+      trailerSize,
+      kMaxTrailerBytes);
   const char* trailerStart = end - sizeof(uint32_t) - trailerSize;
-  const auto* trailerEnd = trailerStart + trailerSize;
-  const auto encodingType =
-      static_cast<EncodingType>(static_cast<uint8_t>(*trailerStart));
-  if (encodingType != EncodingType::MainlyConstant) {
-    // Fall back to dense for encodings whose wire format isn't naturally
-    // sparse. Caller iterates the dense vector and skips zeros inline.
-    decodeTrailerStreamSizes(trailerStart, trailerSize, denseSizes);
-    return false;
-  }
-  // MainlyConstant is sparse on the wire: fill (indices, sizes) directly
-  // and skip the streamCount-zero-filled dense expansion entirely.
-  const char* payload = trailerStart + sizeof(uint8_t);
-  decodeMainlyConstantTrailerSparse(payload, sparseIndices, sparseSizes);
-  NIMBLE_CHECK_EQ(
-      payload,
-      trailerEnd,
-      "Trailer size mismatch (sparse): read {} bytes, expected {}",
-      payload - trailerStart,
-      trailerSize);
-  return true;
+  decodeTrailerStreamMetadata(
+      trailerStart, trailerSize, streamIndices, streamSizes);
 }
 
-std::vector<uint32_t> readTrailerStreamSizes(const folly::IOBuf& input) {
+std::pair<std::vector<uint32_t>, std::vector<uint32_t>>
+readTrailerStreamMetadata(const char* end) {
+  std::vector<uint32_t> streamIndices;
+  std::vector<uint32_t> streamSizes;
+  readTrailerStreamMetadata(end, streamIndices, streamSizes);
+  return {std::move(streamIndices), std::move(streamSizes)};
+}
+
+std::pair<std::vector<uint32_t>, std::vector<uint32_t>>
+readTrailerStreamMetadata(const folly::IOBuf& input) {
   // Fast path: trailer fits in the tail segment.
   const auto* tail = input.prev();
   if (tail->length() >= sizeof(uint32_t)) {
@@ -416,7 +375,7 @@ std::vector<uint32_t> readTrailerStreamSizes(const folly::IOBuf& input) {
         reinterpret_cast<const char*>(tail->data()) + tail->length();
     const uint32_t trailerSize = readTrailerSize(tailEnd);
     if (tail->length() >= sizeof(uint32_t) + trailerSize) {
-      return readTrailerStreamSizes(tailEnd);
+      return readTrailerStreamMetadata(tailEnd);
     }
   }
 
@@ -425,40 +384,43 @@ std::vector<uint32_t> readTrailerStreamSizes(const folly::IOBuf& input) {
   folly::io::Cursor trailerCursor(&input);
   trailerCursor.skip(totalLength - sizeof(uint32_t));
   const uint32_t trailerSize = trailerCursor.read<uint32_t>();
+  NIMBLE_CHECK_LE(
+      trailerSize,
+      kMaxTrailerBytes,
+      "Trailer size sanity cap exceeded (likely buffer corruption): {} > {}",
+      trailerSize,
+      kMaxTrailerBytes);
+  // Bound trailerSize against the actual IOBuf chain length so a corrupted
+  // value cannot drive a huge std::string allocation.
+  NIMBLE_CHECK_LE(
+      static_cast<uint64_t>(trailerSize) + sizeof(uint32_t),
+      totalLength,
+      "Trailer size exceeds IOBuf chain length: trailerSize={}, chain={}",
+      trailerSize,
+      totalLength);
 
   folly::io::Cursor sizesCursor(&input);
   sizesCursor.skip(totalLength - sizeof(uint32_t) - trailerSize);
   std::string trailerBuf(trailerSize, '\0');
   sizesCursor.pull(trailerBuf.data(), trailerSize);
-  return decodeTrailerStreamSizes(trailerBuf.data(), trailerSize);
+  std::vector<uint32_t> streamIndices;
+  std::vector<uint32_t> streamSizes;
+  decodeTrailerStreamMetadata(
+      trailerBuf.data(), trailerSize, streamIndices, streamSizes);
+  return {std::move(streamIndices), std::move(streamSizes)};
 }
 
-size_t estimateTrailerSize(size_t numStreams, EncodingType encodingType) {
-  const auto resolvedType = getTrailerEncodingType(encodingType);
-  // [encodingType:1B][payload][trailer_size:u32]
-  size_t payloadSize{0};
-  switch (resolvedType) {
-    case EncodingType::Trivial:
-      payloadSize = estimateTrivialTrailerPayloadSize(numStreams);
-      break;
-    case EncodingType::Varint:
-      payloadSize = estimateVarintTrailerPayloadSize(numStreams);
-      break;
-    case EncodingType::Delta:
-      payloadSize = estimateDeltaTrailerPayloadSize(numStreams);
-      break;
-    case EncodingType::FixedBitWidth:
-      payloadSize = estimateFixedBitWidthTrailerPayloadSize(numStreams);
-      break;
-    case EncodingType::MainlyConstant:
-      payloadSize = estimateMainlyConstantTrailerPayloadSize(numStreams);
-      break;
-    default:
-      NIMBLE_FAIL(
-          "Unsupported EncodingType for stream sizes trailer: {}",
-          resolvedType);
-  }
-  return sizeof(uint8_t) + payloadSize + sizeof(uint32_t);
+size_t estimateTrailerSize(
+    size_t numStreams,
+    EncodingType indicesEncodingType,
+    EncodingType sizesEncodingType) {
+  // [indicesEncType:1B][indicesPayload][sizesEncType:1B][sizesPayload]
+  // [trailer_size:u32]
+  // Worst case: every stream slot is non-zero, so both axes carry numStreams
+  // entries.
+  return sizeof(uint8_t) +
+      estimateSectionSize(indicesEncodingType, numStreams) + sizeof(uint8_t) +
+      estimateSectionSize(sizesEncodingType, numStreams) + sizeof(uint32_t);
 }
 
 std::vector<std::string_view> parseStreams(
@@ -471,22 +433,16 @@ std::vector<std::string_view> parseStreams(
   std::vector<std::string_view> streams;
 
   if (isCompactFormat(version)) {
-    // Dispatch on the version byte: legacy kCompactRaw blobs go through the
-    // frozen reader; the else branch is scaffolding for the next diff, which
-    // will introduce a new wire format and a sibling reader.
-    std::vector<uint32_t> streamIndices;
-    std::vector<uint32_t> streamSizes;
-    if (usesLegacyTrailer(version)) {
-      std::tie(streamIndices, streamSizes) =
-          legacy::readLegacyTrailerStreamMetadata(end);
-    } else {
-      NIMBLE_UNREACHABLE("unexpected non-legacy trailer version");
-    }
-    // Sparse-place: streams[streamIndices[k]] = stream bytes; gaps remain
-    // empty string_views, matching master's dense-output behavior.
+    // Walk the sparse (streamIndices, streamSizes) trailer and place each
+    // stream at its offset slot. Gaps remain empty string_views. Legacy
+    // kLegacyCompact blobs are decoded via the frozen legacy reader.
+    auto [streamIndices, streamSizes] = usesLegacyTrailer(version)
+        ? legacy::readLegacyTrailerStreamMetadata(end)
+        : readTrailerStreamMetadata(end);
     if (!streamIndices.empty()) {
       streams.resize(streamIndices.back() + 1);
       for (size_t k = 0; k < streamIndices.size(); ++k) {
+        // NOLINTNEXTLINE(facebook-hte-LocalUncheckedArrayBounds)
         streams[streamIndices[k]] = std::string_view(pos, streamSizes[k]);
         pos += streamSizes[k];
       }

--- a/dwio/nimble/serializer/SerializerImpl.h
+++ b/dwio/nimble/serializer/SerializerImpl.h
@@ -113,241 +113,168 @@ inline uint32_t readTrailerSize(const char* end) {
   return encoding::readUint32(pos);
 }
 
-/// Returns an upper-bound estimate of the trailer size.
-size_t estimateTrailerSize(size_t numStreams, EncodingType encodingType);
+/// Returns an upper-bound estimate of the trailer size for the two-array
+/// sparse layout. Conservatively assumes every stream slot is non-zero
+/// (worst case for sparseness) and that sizes can be up to UINT32_MAX.
+size_t estimateTrailerSize(
+    size_t numStreams,
+    EncodingType indicesEncodingType,
+    EncodingType sizesEncodingType);
 
 /// Overload that accepts SerializationVersion for API compatibility.
 inline size_t estimateTrailerSize(
     SerializationVersion /* outputVersion */,
     size_t numStreams,
-    std::optional<EncodingType> encodingType = std::nullopt) {
+    std::optional<EncodingType> indicesEncodingType = std::nullopt,
+    std::optional<EncodingType> sizesEncodingType = std::nullopt) {
   return estimateTrailerSize(
-      numStreams, encodingType.value_or(EncodingType::FixedBitWidth));
+      numStreams,
+      indicesEncodingType.value_or(EncodingType::FixedBitWidth),
+      sizesEncodingType.value_or(EncodingType::FixedBitWidth));
 }
 
-/// Writes the Trivial trailer: raw u32 memcpy.
-/// Wire: [encodingType:1B][size_0:u32]...[size_N:u32][trailer_size:u32]
+/// Writes the Trivial section payload: count varint + raw u32 array.
+/// Wire: [count:varint][v_0:u32]...[v_N:u32]
 template <typename T>
-void writeTrivialTrailer(const std::vector<uint32_t>& streamSizes, T& buffer) {
-  const auto streamCount = streamSizes.size();
-  const uint32_t payloadSize = streamCount * sizeof(uint32_t);
-  const uint32_t trailerSize = sizeof(uint8_t) + payloadSize;
-  auto* pos = extend(buffer, trailerSize + sizeof(uint32_t));
-  *pos++ = static_cast<char>(EncodingType::Trivial);
-  if (payloadSize > 0) {
-    std::memcpy(pos, streamSizes.data(), payloadSize);
-    pos += payloadSize;
+void writeTrivialSection(const std::vector<uint32_t>& values, T& buffer) {
+  const auto count = static_cast<uint32_t>(values.size());
+  const auto countVarintSize = varint::varintSize(count);
+  const uint32_t payloadBytes = count * sizeof(uint32_t);
+  auto* pos = extend(buffer, countVarintSize + payloadBytes);
+  varint::writeVarint(count, &pos);
+  if (payloadBytes > 0) {
+    std::memcpy(pos, values.data(), payloadBytes);
   }
-  encoding::writeUint32(trailerSize, pos);
 }
 
-/// Writes the Varint trailer: each stream size as a varint.
-/// Wire: [encodingType:1B][count:varint][v_0:varint]...[trailer_size:u32]
+/// Writes the Varint section payload: count varint + each value as varint.
+/// Wire: [count:varint][v_0:varint]...[v_N:varint]
 template <typename T>
-void writeVarintTrailer(const std::vector<uint32_t>& streamSizes, T& buffer) {
-  const auto streamCount = streamSizes.size();
-  const auto countVarintSize =
-      varint::varintSize(static_cast<uint32_t>(streamCount));
-  const auto dataVarintSize = varint::bulkVarintSize32(streamSizes);
-  const uint32_t trailerSize =
-      sizeof(uint8_t) + countVarintSize + dataVarintSize;
-  auto* pos = extend(buffer, trailerSize + sizeof(uint32_t));
-  *pos++ = static_cast<char>(EncodingType::Varint);
-  varint::writeVarint(static_cast<uint32_t>(streamCount), &pos);
-  for (const auto size : streamSizes) {
-    varint::writeVarint(size, &pos);
+void writeVarintSection(const std::vector<uint32_t>& values, T& buffer) {
+  const auto count = static_cast<uint32_t>(values.size());
+  const auto countVarintSize = varint::varintSize(count);
+  const auto dataVarintSize =
+      static_cast<uint32_t>(varint::bulkVarintSize32(values));
+  auto* pos = extend(buffer, countVarintSize + dataVarintSize);
+  varint::writeVarint(count, &pos);
+  for (const auto v : values) {
+    varint::writeVarint(v, &pos);
   }
-  encoding::writeUint32(trailerSize, pos);
 }
 
-/// Writes the Delta trailer: first value + deltas as varints.
-/// Wire: [encodingType:1B][count:varint][first:varint]
-///       [delta_1:varint]...[delta_N:varint][trailer_size:u32]
+/// Writes the Delta section payload: count varint + first value + per-element
+/// deltas. Wire: [count:varint][first:varint][delta_1:varint]...
 template <typename T>
-void writeDeltaTrailer(const std::vector<uint32_t>& streamSizes, T& buffer) {
-  const auto streamCount = streamSizes.size();
-  const auto countVarintSize =
-      varint::varintSize(static_cast<uint32_t>(streamCount));
-  uint64_t dataVarintSize = 0;
-  if (streamCount > 0) {
-    dataVarintSize = varint::varintSize(streamSizes[0]);
-    for (size_t i = 1; i < streamCount; ++i) {
-      const auto delta = streamSizes[i] - streamSizes[i - 1];
+void writeDeltaSection(const std::vector<uint32_t>& values, T& buffer) {
+  const auto count = static_cast<uint32_t>(values.size());
+  const auto countVarintSize = varint::varintSize(count);
+  uint32_t dataVarintSize = 0;
+  if (count > 0) {
+    dataVarintSize = varint::varintSize(values[0]);
+    for (uint32_t i = 1; i < count; ++i) {
+      const auto delta = values[i] - values[i - 1];
       dataVarintSize += varint::varintSize(delta);
     }
   }
-  const uint32_t trailerSize =
-      sizeof(uint8_t) + countVarintSize + dataVarintSize;
-  auto* pos = extend(buffer, trailerSize + sizeof(uint32_t));
-  *pos++ = static_cast<char>(EncodingType::Delta);
-  varint::writeVarint(static_cast<uint32_t>(streamCount), &pos);
-  if (streamCount > 0) {
-    varint::writeVarint(streamSizes[0], &pos);
-    for (size_t i = 1; i < streamCount; ++i) {
-      const auto delta = streamSizes[i] - streamSizes[i - 1];
+  auto* pos = extend(buffer, countVarintSize + dataVarintSize);
+  varint::writeVarint(count, &pos);
+  if (count > 0) {
+    varint::writeVarint(values[0], &pos);
+    for (uint32_t i = 1; i < count; ++i) {
+      const auto delta = values[i] - values[i - 1];
       varint::writeVarint(delta, &pos);
     }
   }
-  encoding::writeUint32(trailerSize, pos);
 }
 
-/// Writes the FixedBitWidth trailer: bit-packed stream sizes.
-/// Wire: [encodingType:1B][bitWidth:1B][count:varint]
-///       [bit-packed data][trailer_size:u32]
+/// Writes the FixedBitWidth section payload: bitWidth + count + bit-packed.
+/// Wire: [bitWidth:1B][count:varint][bit-packed data]
 template <typename T>
-void writeFixedBitWidthTrailer(
-    const std::vector<uint32_t>& streamSizes,
-    T& buffer) {
-  const auto streamCount = streamSizes.size();
+void writeFixedBitWidthSection(const std::vector<uint32_t>& values, T& buffer) {
+  const auto count = static_cast<uint32_t>(values.size());
   uint32_t maxVal = 0;
-  for (const auto size : streamSizes) {
-    maxVal = std::max(maxVal, size);
+  for (const auto v : values) {
+    maxVal = std::max(maxVal, v);
   }
   const uint8_t bitWidth =
       maxVal == 0 ? 0 : static_cast<uint8_t>(std::bit_width(maxVal));
-  const uint32_t packedBytes = (bitWidth > 0 && streamCount > 0)
-      ? static_cast<uint32_t>(FixedBitArray::bufferSize(streamCount, bitWidth))
+  const uint32_t packedBytes = (bitWidth > 0 && count > 0)
+      ? static_cast<uint32_t>(FixedBitArray::bufferSize(count, bitWidth))
       : 0;
-  const auto countVarintSize =
-      varint::varintSize(static_cast<uint32_t>(streamCount));
-  const uint32_t trailerSize =
-      sizeof(uint8_t) + sizeof(uint8_t) + countVarintSize + packedBytes;
-  auto* pos = extend(buffer, trailerSize + sizeof(uint32_t));
-  *pos++ = static_cast<char>(EncodingType::FixedBitWidth);
+  const auto countVarintSize = varint::varintSize(count);
+  auto* pos = extend(buffer, sizeof(uint8_t) + countVarintSize + packedBytes);
   *pos++ = static_cast<char>(bitWidth);
-  varint::writeVarint(static_cast<uint32_t>(streamCount), &pos);
-  if (bitWidth > 0 && streamCount > 0) {
+  varint::writeVarint(count, &pos);
+  if (bitWidth > 0 && count > 0) {
     std::memset(pos, 0, packedBytes);
     FixedBitArray arr{pos, static_cast<int>(bitWidth)};
-    arr.bulkSet32(0, streamCount, streamSizes.data());
-    pos += packedBytes;
+    arr.bulkSet32(0, count, values.data());
   }
-  encoding::writeUint32(trailerSize, pos);
 }
 
-/// Writes the MainlyConstant trailer: assumes 0 is the dominant value and
-/// writes a sparse list of (index, value) pairs for non-zero slots. Optimized
-/// for trailers dominated by zero (e.g., empty slots in flat-map schemas with
-/// many absent keys). Callers should pick a different trailer encoding for
-/// inputs not dominated by zero.
-///
-/// Wire (when nonZeroCount > 0):
-///   [encodingType:1B][streamCount:varint][nonZeroCount:varint]
-///   [idxBitWidth:1B][indices packed nonZeroCount*idxBitWidth bits]
-///   [valBitWidth:1B][values packed nonZeroCount*valBitWidth bits]
-///   [trailer_size:u32]
-///
-/// Wire (when nonZeroCount == 0):
-///   [encodingType:1B][streamCount:varint][nonZeroCount=0:varint]
-///   [trailer_size:u32]
-///
-/// Where nonZeroCount = number of slots whose size != 0. The constant is
-/// fixed at 0 and not stored on the wire.
+/// Dispatches a section write to the encoding-specific writer.
 template <typename T>
-void writeMainlyConstantTrailer(
-    const std::vector<uint32_t>& streamSizes,
-    T& buffer) {
-  const auto streamCount = static_cast<uint32_t>(streamSizes.size());
-
-  // Collect non-zero (index, value) pairs. Reserve the upper bound
-  // (streamCount) so the emplace_back loop never reallocates.
-  std::vector<uint32_t> indices;
-  std::vector<uint32_t> values;
-  indices.reserve(streamCount);
-  values.reserve(streamCount);
-  for (uint32_t i = 0; i < streamCount; ++i) {
-    if (streamSizes[i] != 0) {
-      indices.emplace_back(i);
-      values.emplace_back(streamSizes[i]);
-    }
-  }
-  const uint32_t nonZeroCount = static_cast<uint32_t>(indices.size());
-
-  // idxBitWidth covers indices in [0, streamCount). When nonZeroCount == 0
-  // there are no indices to pack, so width is 0. Otherwise clamp to a
-  // minimum of 1 because FixedBitArray::bulkSet32 LOG(FATAL)s on bitWidth=0
-  // (this only matters for streamCount == 1, where bit_width(0) would be 0).
-  const uint8_t idxBitWidth = (nonZeroCount == 0)
-      ? 0
-      : static_cast<uint8_t>(
-            std::max<size_t>(1, std::bit_width(streamCount - 1)));
-
-  auto maxValues = [](const std::vector<uint32_t>& vals) {
-    uint32_t maxVal = 0;
-    for (const auto v : vals) {
-      maxVal = std::max(maxVal, v);
-    }
-    return maxVal;
-  };
-  const uint32_t maxValue = nonZeroCount == 0 ? 0 : maxValues(values);
-  const uint8_t valBitWidth =
-      nonZeroCount == 0 ? 0 : static_cast<uint8_t>(std::bit_width(maxValue));
-
-  const auto streamCountVarintSize = varint::varintSize(streamCount);
-  const auto nonZeroCountVarintSize = varint::varintSize(nonZeroCount);
-  const uint32_t packedIndicesBytes = (nonZeroCount == 0)
-      ? 0
-      : static_cast<uint32_t>(
-            FixedBitArray::bufferSize(nonZeroCount, idxBitWidth));
-  const uint32_t packedValuesBytes = (nonZeroCount == 0)
-      ? 0
-      : static_cast<uint32_t>(
-            FixedBitArray::bufferSize(nonZeroCount, valBitWidth));
-
-  // When nonZeroCount == 0 the idxBitWidth/valBitWidth bytes and packed
-  // arrays are all omitted from the wire.
-  const uint32_t trailerSize = /*encodingType=*/sizeof(uint8_t) +
-      streamCountVarintSize + nonZeroCountVarintSize +
-      (nonZeroCount == 0 ? 0 : /*idxBitWidth=*/sizeof(uint8_t) +
-               packedIndicesBytes +
-               /*valBitWidth=*/sizeof(uint8_t) + packedValuesBytes);
-
-  auto* pos = extend(buffer, trailerSize + sizeof(uint32_t));
-  *pos++ = static_cast<char>(EncodingType::MainlyConstant);
-  varint::writeVarint(streamCount, &pos);
-  varint::writeVarint(nonZeroCount, &pos);
-  if (nonZeroCount > 0) {
-    *pos++ = static_cast<char>(idxBitWidth);
-    std::memset(pos, 0, packedIndicesBytes);
-    FixedBitArray idxArr{pos, static_cast<int>(idxBitWidth)};
-    idxArr.bulkSet32(0, nonZeroCount, indices.data());
-    pos += packedIndicesBytes;
-    *pos++ = static_cast<char>(valBitWidth);
-    std::memset(pos, 0, packedValuesBytes);
-    FixedBitArray valArr{pos, static_cast<int>(valBitWidth)};
-    valArr.bulkSet32(0, nonZeroCount, values.data());
-    pos += packedValuesBytes;
-  }
-  encoding::writeUint32(trailerSize, pos);
-}
-
-/// Writes the stream sizes trailer using the specified encoding type.
-template <typename T>
-void writeTrailer(
-    const std::vector<uint32_t>& streamSizes,
+void writeSection(
     EncodingType encodingType,
+    const std::vector<uint32_t>& values,
     T& buffer) {
   switch (getTrailerEncodingType(encodingType)) {
     case EncodingType::Trivial:
-      writeTrivialTrailer(streamSizes, buffer);
+      writeTrivialSection(values, buffer);
       break;
     case EncodingType::Varint:
-      writeVarintTrailer(streamSizes, buffer);
+      writeVarintSection(values, buffer);
       break;
     case EncodingType::Delta:
-      writeDeltaTrailer(streamSizes, buffer);
+      writeDeltaSection(values, buffer);
       break;
     case EncodingType::FixedBitWidth:
-      writeFixedBitWidthTrailer(streamSizes, buffer);
-      break;
-    case EncodingType::MainlyConstant:
-      writeMainlyConstantTrailer(streamSizes, buffer);
+      writeFixedBitWidthSection(values, buffer);
       break;
     default:
       NIMBLE_FAIL(
-          "Unsupported EncodingType for stream sizes trailer: {}",
+          "Unsupported EncodingType for stream sizes trailer section: {}",
           encodingType);
   }
+}
+
+/// Writes the two-array sparse stream-sizes trailer. Walks
+/// `denseStreamSizes` once to collect the stream IDs of non-zero entries and
+/// their sizes, then encodes each section with the caller-specified encoding
+/// type.
+/// Wire: [indicesEncType:1B][indicesPayload]
+///       [sizesEncType:1B][sizesPayload][trailer_size:u32]
+template <typename T>
+void writeTrailer(
+    const std::vector<uint32_t>& denseStreamSizes,
+    EncodingType indicesEncodingType,
+    EncodingType sizesEncodingType,
+    T& buffer) {
+  const auto streamCount = denseStreamSizes.size();
+  std::vector<uint32_t> streamIds;
+  std::vector<uint32_t> streamSizes;
+  streamIds.reserve(streamCount);
+  streamSizes.reserve(streamCount);
+  for (uint32_t i = 0; i < streamCount; ++i) {
+    if (denseStreamSizes[i] != 0) {
+      streamIds.emplace_back(i);
+      streamSizes.emplace_back(denseStreamSizes[i]);
+    }
+  }
+
+  const auto trailerStartOffset = buffer.size();
+  auto* indicesTypePos = extend(buffer, sizeof(uint8_t));
+  *indicesTypePos = static_cast<char>(indicesEncodingType);
+  writeSection(indicesEncodingType, streamIds, buffer);
+
+  auto* sizesTypePos = extend(buffer, sizeof(uint8_t));
+  *sizesTypePos = static_cast<char>(sizesEncodingType);
+  writeSection(sizesEncodingType, streamSizes, buffer);
+
+  const uint32_t trailerSize =
+      static_cast<uint32_t>(buffer.size() - trailerStartOffset);
+  auto* sizePos = extend(buffer, sizeof(uint32_t));
+  encoding::writeUint32(trailerSize, sizePos);
 }
 
 /// Writes a single stream to the buffer.
@@ -410,40 +337,35 @@ void skipStream(const char*& pos) {
   pos += size;
 }
 
-/// Reads stream sizes from the trailer. The last 4 bytes store the trailer
-/// size. The trailer starts with an EncodingType byte followed by the
-/// encoding-specific payload.
-std::vector<uint32_t> readTrailerStreamSizes(const char* end);
-
-/// Caller-fills overload of readTrailerStreamSizes that picks a sparse or
-/// dense representation off the encoding-type byte:
-///   - MainlyConstant: fills `sparseIndices` + `sparseSizes` with only the
-///     non-zero stream slots and returns `true`. The dense
-///     `streamCount`-zero-filled scatter is skipped entirely; the caller
-///     iterates the sparse arrays to visit non-empty streams.
-///   - All other encodings (Trivial/Varint/Delta/FixedBitWidth): fills
-///     `denseSizes` and returns `false`. Caller iterates `denseSizes` as
-///     usual.
-/// All three out vectors must be reusable buffers owned by the caller
-/// (e.g. members on `StreamDataReader`) to keep the per-blob hot path
-/// alloc-free across invocations.
-bool readTrailerStreamSizes(
+/// Reads the two-array sparse stream-sizes trailer from the end of a
+/// contiguous buffer. Fills `streamIndices` (offsets of non-zero stream
+/// slots, sorted ascending) and `streamSizes` (their byte sizes), parallel
+/// arrays of identical length. Both vectors are reusable buffers owned by
+/// the caller (e.g. members on `StreamDataReader`) to keep the per-blob hot
+/// path alloc-free across invocations.
+void readTrailerStreamMetadata(
     const char* end,
-    std::vector<uint32_t>& denseSizes,
-    std::vector<uint32_t>& sparseIndices,
-    std::vector<uint32_t>& sparseSizes);
+    std::vector<uint32_t>& streamIndices,
+    std::vector<uint32_t>& streamSizes);
 
-/// IOBuf overload: reads stream sizes from the trailer of a (possibly
-/// chained) IOBuf. Tries the fast path first: if the tail segment contains the
-/// entire trailer, delegates to the contiguous overload. Falls back to
+/// Value-returning convenience overload for cold-path consumers
+/// (tests, dump tools). Returns parallel (streamIndices, streamSizes) arrays.
+std::pair<std::vector<uint32_t>, std::vector<uint32_t>>
+readTrailerStreamMetadata(const char* end);
+
+/// IOBuf overload: reads the trailer from a (possibly chained) IOBuf.
+/// Tries the fast path first: if the tail segment contains the entire
+/// trailer, delegates to the contiguous overload. Falls back to
 /// cursor + pull() when the trailer spans a chain boundary.
-std::vector<uint32_t> readTrailerStreamSizes(const folly::IOBuf& input);
+std::pair<std::vector<uint32_t>, std::vector<uint32_t>>
+readTrailerStreamMetadata(const folly::IOBuf& input);
 
 /// Parses all streams from a serialized buffer.
 /// Returns a vector of stream data indexed by their original offset.
 ///
 /// For kLegacy: Returns streams in order with inline u32 sizes.
-/// For kCompactRaw: Returns streams indexed by their offset from sizes header.
+/// For kLegacyCompact: Returns streams indexed by their offset from sizes
+/// header.
 ///
 /// @param pos Pointer past the header (version + rowCount already read)
 /// @param end End of buffer
@@ -532,8 +454,8 @@ std::string_view encodeScalar(
 template <typename T>
 class StreamDataWriter {
  public:
-  /// Constructor. For kLegacy, writes the header immediately. For kCompactRaw,
-  /// writes the header prefix (version + rowCount).
+  /// Constructor. For kLegacy, writes the header immediately. For
+  /// kLegacyCompact, writes the header prefix (version + rowCount).
   ///
   /// @param pool Memory pool for encoding buffer allocation.
   /// @param streamEncodingLayouts Optional encoding layouts for replaying
@@ -549,11 +471,11 @@ class StreamDataWriter {
 
   /// Write encoded data for a single stream.
   /// For both formats, writes directly to buffer.
-  /// For kCompactRaw, also tracks stream sizes for the trailer.
+  /// For kLegacyCompact, also tracks stream sizes for the trailer.
   void writeData(const nimble::StreamData& streamData);
 
   /// Close the writer. For kLegacy, fills trailing zeros up to nodeCount.
-  /// For kCompactRaw, writes the trailer (encoded sizes).
+  /// For kLegacyCompact, writes the trailer (encoded sizes).
   void close(uint32_t nodeCount = 0);
 
  private:
@@ -689,7 +611,10 @@ template <typename T>
 void StreamDataWriter<T>::close(uint32_t nodeCount) {
   if (options_.enableEncoding()) {
     detail::writeTrailer(
-        streamSizes_, options_.streamSizesEncodingType, buffer_);
+        streamSizes_,
+        options_.streamIndicesEncodingType,
+        options_.streamSizesEncodingType,
+        buffer_);
   } else {
     // kLegacy: fill trailing zeros up to nodeCount.
     detail::writeMissingStreams(buffer_, lastStream_, nodeCount);

--- a/dwio/nimble/serializer/benchmarks/SerializerBenchmark.cpp
+++ b/dwio/nimble/serializer/benchmarks/SerializerBenchmark.cpp
@@ -181,7 +181,7 @@ BenchmarkState prepareBenchmark(
   auto makeOptions = [&]() -> SerializerOptions {
     if (forcedEncoding.has_value()) {
       return SerializerOptions{
-          .version = SerializationVersion::kCompactRaw,
+          .version = SerializationVersion::kSerialization,
           .flatMapColumns = {{"features", {}}},
           .encodingLayoutTree =
               buildForcedEncodingLayout(numKeys, forcedEncoding.value()),
@@ -189,7 +189,7 @@ BenchmarkState prepareBenchmark(
       };
     }
     return SerializerOptions{
-        .version = SerializationVersion::kCompactRaw,
+        .version = SerializationVersion::kSerialization,
         .flatMapColumns = {{"features", {}}},
     };
   };

--- a/dwio/nimble/serializer/legacy/TrailerReader.h
+++ b/dwio/nimble/serializer/legacy/TrailerReader.h
@@ -22,7 +22,7 @@
 
 #include <folly/io/IOBuf.h>
 
-// Read-only legacy reader for the original kCompactRaw trailer wire format
+// Read-only legacy reader for the original kLegacyCompact trailer wire format
 // (single encoding-type byte + dense payload, or MainlyConstant-special-case
 // sparse pair). Used by callers that need to decode existing production hybrid
 // Nimble blobs after the main serializer trailer wire format evolves.
@@ -34,7 +34,7 @@
 
 namespace facebook::nimble::serde::legacy {
 
-/// Reads the legacy kCompactRaw trailer from the end of a contiguous buffer.
+/// Reads the legacy kLegacyCompact trailer from the end of a contiguous buffer.
 /// Fills `streamIndices` (offsets of non-zero stream slots, sorted ascending)
 /// and `streamSizes` (their byte sizes), parallel arrays of identical length.
 /// Both vectors are reusable buffers owned by the caller (e.g. members on

--- a/dwio/nimble/serializer/legacy/tests/TrailerReaderTest.cpp
+++ b/dwio/nimble/serializer/legacy/tests/TrailerReaderTest.cpp
@@ -28,7 +28,7 @@
 namespace facebook::nimble::serde::legacy {
 namespace {
 
-// Builds a legacy Trivial-encoded kCompactRaw trailer for the given sizes:
+// Builds a legacy Trivial-encoded kLegacyCompact trailer for the given sizes:
 //   [encodingByte=Trivial][raw u32 array][trailerSize:u32]
 std::string buildLegacyTrivialTrailer(const std::vector<uint32_t>& sizes) {
   std::string buffer;
@@ -79,7 +79,7 @@ std::string packFixedBitWidth(
   return buf;
 }
 
-// Builds a legacy MainlyConstant-encoded kCompactRaw trailer for the given
+// Builds a legacy MainlyConstant-encoded kLegacyCompact trailer for the given
 // (streamCount, indices, sizes) shape. Mirrors master's writer wire format:
 //   [encodingByte=MainlyConstant]
 //   [streamCount:varint][nonZeroCount:varint]
@@ -236,7 +236,7 @@ TEST(
   EXPECT_EQ(streamSizes, sizes);
 }
 
-// Builds a legacy Varint-encoded kCompactRaw trailer:
+// Builds a legacy Varint-encoded kLegacyCompact trailer:
 //   [encodingByte=Varint][count:varint][v_0:varint]...[v_N:varint]
 //   [trailerSize:u32]
 std::string buildLegacyVarintTrailer(const std::vector<uint32_t>& denseSizes) {
@@ -251,7 +251,7 @@ std::string buildLegacyVarintTrailer(const std::vector<uint32_t>& denseSizes) {
   return buffer;
 }
 
-// Builds a legacy Delta-encoded kCompactRaw trailer:
+// Builds a legacy Delta-encoded kLegacyCompact trailer:
 //   [encodingByte=Delta][count:varint][first:varint][delta_1:varint]...
 //   [trailerSize:u32]
 std::string buildLegacyDeltaTrailer(const std::vector<uint32_t>& denseSizes) {
@@ -269,7 +269,7 @@ std::string buildLegacyDeltaTrailer(const std::vector<uint32_t>& denseSizes) {
   return buffer;
 }
 
-// Builds a legacy FixedBitWidth-encoded kCompactRaw trailer:
+// Builds a legacy FixedBitWidth-encoded kLegacyCompact trailer:
 //   [encodingByte=FixedBitWidth][bitWidth:1B][count:varint][packed bytes]
 //   [trailerSize:u32]
 std::string buildLegacyFixedBitWidthTrailer(

--- a/dwio/nimble/serializer/tests/OptionsTest.cpp
+++ b/dwio/nimble/serializer/tests/OptionsTest.cpp
@@ -24,13 +24,15 @@ using namespace facebook::nimble;
 TEST(OptionsTest, serializationVersionEnumValues) {
   // Verify enum underlying values match expected wire format versions.
   EXPECT_EQ(static_cast<uint8_t>(SerializationVersion::kLegacy), 0);
-  EXPECT_EQ(static_cast<uint8_t>(SerializationVersion::kCompactRaw), 2);
-  EXPECT_EQ(static_cast<uint8_t>(SerializationVersion::kTablet), 3);
+  EXPECT_EQ(static_cast<uint8_t>(SerializationVersion::kLegacyCompact), 2);
+  EXPECT_EQ(static_cast<uint8_t>(SerializationVersion::kSerialization), 3);
+  EXPECT_EQ(static_cast<uint8_t>(SerializationVersion::kProjection), 4);
+  EXPECT_EQ(static_cast<uint8_t>(SerializationVersion::kTablet), 5);
 }
 
 TEST(OptionsTest, toStringVersion) {
   EXPECT_EQ(toString(SerializationVersion::kLegacy), "kLegacy");
-  EXPECT_EQ(toString(SerializationVersion::kCompactRaw), "kCompactRaw");
+  EXPECT_EQ(toString(SerializationVersion::kLegacyCompact), "kLegacyCompact");
   EXPECT_EQ(toString(SerializationVersion::kTablet), "kTablet");
 }
 
@@ -42,7 +44,8 @@ TEST(OptionsTest, streamOperator) {
 
 TEST(OptionsTest, fmtFormatter) {
   EXPECT_EQ(
-      fmt::format("{}", SerializationVersion::kCompactRaw), "kCompactRaw");
+      fmt::format("{}", SerializationVersion::kLegacyCompact),
+      "kLegacyCompact");
   EXPECT_EQ(fmt::format("{}", SerializationVersion::kTablet), "kTablet");
 }
 
@@ -85,7 +88,7 @@ TEST(OptionsTest, serializerOptionsWithFlatMapColumns) {
   SerializerOptions options{
       .compressionType = CompressionType::Zstd,
       .compressionLevel = 3,
-      .version = SerializationVersion::kCompactRaw,
+      .version = SerializationVersion::kLegacyCompact,
       .flatMapColumns = {{"col1", {}}, {"col2", {}}},
   };
 
@@ -112,22 +115,23 @@ TEST(OptionsTest, deserializerOptionsWithVersion) {
 }
 
 TEST(OptionsTest, serializerOptionsWithCompactRawVersion) {
-  SerializerOptions options{.version = SerializationVersion::kCompactRaw};
+  SerializerOptions options{.version = SerializationVersion::kLegacyCompact};
 
   EXPECT_TRUE(options.hasVersionHeader());
-  EXPECT_EQ(options.serializationVersion(), SerializationVersion::kCompactRaw);
+  EXPECT_EQ(
+      options.serializationVersion(), SerializationVersion::kLegacyCompact);
   EXPECT_TRUE(options.enableEncoding());
 }
 
 TEST(OptionsTest, nonLegacyFormat) {
   EXPECT_FALSE(nonLegacyFormat(SerializationVersion::kLegacy));
-  EXPECT_TRUE(nonLegacyFormat(SerializationVersion::kCompactRaw));
+  EXPECT_TRUE(nonLegacyFormat(SerializationVersion::kLegacyCompact));
   EXPECT_TRUE(nonLegacyFormat(SerializationVersion::kTablet));
 }
 
 TEST(OptionsTest, isCompactFormat) {
   EXPECT_FALSE(isCompactFormat(SerializationVersion::kLegacy));
-  EXPECT_TRUE(isCompactFormat(SerializationVersion::kCompactRaw));
+  EXPECT_TRUE(isCompactFormat(SerializationVersion::kLegacyCompact));
   EXPECT_FALSE(isCompactFormat(SerializationVersion::kTablet));
 }
 
@@ -135,13 +139,13 @@ TEST(OptionsTest, isCompactFormatOptional) {
   EXPECT_FALSE(isCompactFormat(std::nullopt));
   EXPECT_FALSE(isCompactFormat(std::optional{SerializationVersion::kLegacy}));
   EXPECT_TRUE(
-      isCompactFormat(std::optional{SerializationVersion::kCompactRaw}));
+      isCompactFormat(std::optional{SerializationVersion::kLegacyCompact}));
   EXPECT_FALSE(isCompactFormat(std::optional{SerializationVersion::kTablet}));
 }
 
 TEST(OptionsTest, isTabletVersion) {
   EXPECT_FALSE(isTabletVersion(SerializationVersion::kLegacy));
-  EXPECT_FALSE(isTabletVersion(SerializationVersion::kCompactRaw));
+  EXPECT_FALSE(isTabletVersion(SerializationVersion::kLegacyCompact));
   EXPECT_TRUE(isTabletVersion(SerializationVersion::kTablet));
 }
 
@@ -149,13 +153,13 @@ TEST(OptionsTest, isTabletVersionOptional) {
   EXPECT_FALSE(isTabletVersion(std::nullopt));
   EXPECT_FALSE(isTabletVersion(std::optional{SerializationVersion::kLegacy}));
   EXPECT_FALSE(
-      isTabletVersion(std::optional{SerializationVersion::kCompactRaw}));
+      isTabletVersion(std::optional{SerializationVersion::kLegacyCompact}));
   EXPECT_TRUE(isTabletVersion(std::optional{SerializationVersion::kTablet}));
 }
 
 TEST(OptionsTest, usesVarintRowCount) {
   EXPECT_FALSE(usesVarintRowCount(SerializationVersion::kLegacy));
-  EXPECT_TRUE(usesVarintRowCount(SerializationVersion::kCompactRaw));
+  EXPECT_TRUE(usesVarintRowCount(SerializationVersion::kLegacyCompact));
   EXPECT_TRUE(usesVarintRowCount(SerializationVersion::kTablet));
 }
 
@@ -164,7 +168,7 @@ TEST(OptionsTest, usesVarintRowCountOptional) {
   EXPECT_FALSE(
       usesVarintRowCount(std::optional{SerializationVersion::kLegacy}));
   EXPECT_TRUE(
-      usesVarintRowCount(std::optional{SerializationVersion::kCompactRaw}));
+      usesVarintRowCount(std::optional{SerializationVersion::kLegacyCompact}));
   EXPECT_TRUE(usesVarintRowCount(std::optional{SerializationVersion::kTablet}));
 }
 
@@ -173,6 +177,9 @@ TEST(OptionsTest, getTrailerEncodingTypeBasic) {
       getTrailerEncodingType(EncodingType::Trivial), EncodingType::Trivial);
   EXPECT_EQ(getTrailerEncodingType(EncodingType::Varint), EncodingType::Varint);
   EXPECT_EQ(getTrailerEncodingType(EncodingType::Delta), EncodingType::Delta);
+  EXPECT_EQ(
+      getTrailerEncodingType(EncodingType::FixedBitWidth),
+      EncodingType::FixedBitWidth);
 }
 
 TEST(OptionsTest, getTrailerEncodingTypeError) {
@@ -182,7 +189,7 @@ TEST(OptionsTest, getTrailerEncodingTypeError) {
   NIMBLE_ASSERT_THROW(
       getTrailerEncodingType(EncodingType::Dictionary),
       "Unsupported EncodingType for stream sizes trailer");
-  EXPECT_EQ(
-      getTrailerEncodingType(EncodingType::FixedBitWidth),
-      EncodingType::FixedBitWidth);
+  NIMBLE_ASSERT_THROW(
+      getTrailerEncodingType(EncodingType::MainlyConstant),
+      "Unsupported EncodingType for stream sizes trailer");
 }

--- a/dwio/nimble/serializer/tests/ProjectorTest.cpp
+++ b/dwio/nimble/serializer/tests/ProjectorTest.cpp
@@ -75,28 +75,34 @@ struct FormatParam {
 };
 
 // Generate all legal input × output version combinations.
+// Input is kSerialization (Serializer-written blobs); output is kProjection
+// (the Projector's default writer version).
 std::vector<FormatParam> allFormatCombinations() {
   return {
-      {SerializationVersion::kCompactRaw, SerializationVersion::kCompactRaw},
-      // Non-default stream sizes encodings for kCompactRaw output.
-      {SerializationVersion::kCompactRaw,
-       SerializationVersion::kCompactRaw,
+      {SerializationVersion::kSerialization, SerializationVersion::kProjection},
+      // Non-default stream sizes encodings for projected output.
+      {SerializationVersion::kSerialization,
+       SerializationVersion::kProjection,
        EncodingType::Delta},
-      {SerializationVersion::kCompactRaw,
-       SerializationVersion::kCompactRaw,
-       EncodingType::MainlyConstant},
+      {SerializationVersion::kSerialization,
+       SerializationVersion::kProjection,
+       EncodingType::Varint},
       // Buffer pool disabled variants.
-      {SerializationVersion::kCompactRaw,
-       SerializationVersion::kCompactRaw,
+      {SerializationVersion::kSerialization,
+       SerializationVersion::kProjection,
        EncodingType::Trivial,
        /*bufferPoolCapacity=*/0},
-      {SerializationVersion::kCompactRaw,
-       SerializationVersion::kCompactRaw,
+      {SerializationVersion::kSerialization,
+       SerializationVersion::kProjection,
        EncodingType::Delta,
        /*bufferPoolCapacity=*/0},
-      {SerializationVersion::kCompactRaw,
-       SerializationVersion::kCompactRaw,
-       EncodingType::MainlyConstant,
+      {SerializationVersion::kSerialization,
+       SerializationVersion::kProjection,
+       EncodingType::Varint,
+       /*bufferPoolCapacity=*/0},
+      {SerializationVersion::kSerialization,
+       SerializationVersion::kProjection,
+       EncodingType::FixedBitWidth,
        /*bufferPoolCapacity=*/0},
   };
 }
@@ -308,6 +314,7 @@ class ProjectorFormatTest : public ProjectorTestBase,
   Projector::Options projectorOptions() const {
     return Projector::Options{
         .projectVersion = GetParam().projectVersion,
+        .streamIndicesEncodingType = GetParam().streamSizesEncodingType,
         .streamSizesEncodingType = GetParam().streamSizesEncodingType};
   }
 
@@ -648,7 +655,7 @@ TEST_F(ProjectorTest, incompatibleFormatsRejected) {
   auto subfields = makeSubfields({"a"});
 
   auto inputSchema =
-      getNimbleSchema(type, {.version = SerializationVersion::kCompactRaw});
+      getNimbleSchema(type, {.version = SerializationVersion::kSerialization});
 
   // Test kLegacy output version — rejected in constructor.
   NIMBLE_ASSERT_THROW(
@@ -657,7 +664,7 @@ TEST_F(ProjectorTest, incompatibleFormatsRejected) {
           subfields,
           pool_.get(),
           {.projectVersion = SerializationVersion::kLegacy}),
-      "Projection output version must be kCompactRaw");
+      "Projection output version must be kProjection");
 
   // Test kTablet output version — rejected in constructor.
   NIMBLE_ASSERT_THROW(
@@ -666,12 +673,31 @@ TEST_F(ProjectorTest, incompatibleFormatsRejected) {
           subfields,
           pool_.get(),
           {.projectVersion = SerializationVersion::kTablet}),
-      "Projection output version must be kCompactRaw");
+      "Projection output version must be kProjection");
+
+  // Test kSerialization output version — also rejected (Projector writes
+  // kProjection, not kSerialization).
+  NIMBLE_ASSERT_THROW(
+      Projector(
+          inputSchema,
+          subfields,
+          pool_.get(),
+          {.projectVersion = SerializationVersion::kSerialization}),
+      "Projection output version must be kProjection");
+
+  // Test kLegacyCompact output version — silently upgraded to kProjection
+  // rather than rejected, so directory-branched callers that still pass the
+  // old enum value keep working while migrating.
+  EXPECT_NO_THROW(Projector(
+      inputSchema,
+      subfields,
+      pool_.get(),
+      {.projectVersion = SerializationVersion::kLegacyCompact}));
 
   // Test kTablet input — rejected at projection time.
   {
     auto serialized =
-        serialize(vec, type, {.version = SerializationVersion::kCompactRaw});
+        serialize(vec, type, {.version = SerializationVersion::kSerialization});
     Projector projector(inputSchema, subfields, pool_.get(), {});
 
     // Patch the version byte to kTablet.
@@ -680,7 +706,7 @@ TEST_F(ProjectorTest, incompatibleFormatsRejected) {
 
     NIMBLE_ASSERT_THROW(
         projector.project(std::string_view(tabletInput)),
-        "Input must be kCompactRaw format");
+        "Input must be a compact format");
   }
 }
 
@@ -691,7 +717,7 @@ TEST_F(ProjectorTest, emptyProjectionInvalid) {
       {"b", BIGINT()},
   });
 
-  SerializerOptions serOpts{.version = SerializationVersion::kCompactRaw};
+  SerializerOptions serOpts{.version = SerializationVersion::kSerialization};
   auto inputSchema = getNimbleSchema(type, serOpts);
 
   // Empty subfields should throw.
@@ -701,11 +727,14 @@ TEST_F(ProjectorTest, emptyProjectionInvalid) {
           inputSchema,
           emptySubfields,
           pool_.get(),
-          {.projectVersion = SerializationVersion::kCompactRaw}),
+          {.projectVersion = SerializationVersion::kProjection}),
       "Must project at least one subfield");
 }
 
-// Test full projection fast path - same format, pass through.
+// Test full projection - all columns selected, structurally roundtrips.
+// Note: this is no longer a byte-level pass-through because input is
+// kSerialization while the Projector's output is kProjection (different
+// version bytes for independent format evolution).
 TEST_F(ProjectorTest, fullProjectionPassThrough) {
   auto type = ROW({
       {"a", INTEGER()},
@@ -721,11 +750,11 @@ TEST_F(ProjectorTest, fullProjectionPassThrough) {
           makeStringVector({"x", "y", "z"}),
       });
 
-  SerializerOptions serOpts{.version = SerializationVersion::kCompactRaw};
+  SerializerOptions serOpts{.version = SerializationVersion::kSerialization};
   auto serialized = serialize(vec, type, serOpts);
   auto inputSchema = getNimbleSchema(type, serOpts);
 
-  // Full projection - all columns selected, same format.
+  // Full projection - all columns selected.
   auto subfields = makeSubfields({"a", "b", "c"});
   Projector projector(inputSchema, subfields, pool_.get(), {});
 
@@ -734,10 +763,7 @@ TEST_F(ProjectorTest, fullProjectionPassThrough) {
     SCOPED_TRACE(fmt::format("useIOBuf={}", useIOBuf));
     auto projected = projectInput(projector, serialized, useIOBuf);
 
-    // Fast path: output should be identical to input (pass through).
-    EXPECT_EQ(toString(projected), std::string_view(serialized));
-
-    // Verify can still deserialize correctly.
+    // Verify can deserialize correctly.
     auto result =
         deserialize(toString(projected), outputSchema, {.hasHeader = true});
     ASSERT_EQ(result->size(), 3);
@@ -760,7 +786,7 @@ TEST_F(ProjectorTest, fullProjectionPassThrough) {
 TEST_F(ProjectorTest, unsupportedArraySubscript) {
   auto type = ROW({{"arr", ARRAY(INTEGER())}});
 
-  SerializerOptions serOpts{.version = SerializationVersion::kCompactRaw};
+  SerializerOptions serOpts{.version = SerializationVersion::kSerialization};
   auto inputSchema = getNimbleSchema(type, serOpts);
 
   // Array subscripts are not supported — subscripts on non-FlatMap source
@@ -772,7 +798,7 @@ TEST_F(ProjectorTest, unsupportedArraySubscript) {
           inputSchema,
           subfields,
           pool_.get(),
-          {.projectVersion = SerializationVersion::kCompactRaw}),
+          {.projectVersion = SerializationVersion::kProjection}),
       "only supported on FlatMap");
 }
 
@@ -780,7 +806,7 @@ TEST_F(ProjectorTest, unsupportedArraySubscript) {
 TEST_F(ProjectorTest, unsupportedMapKeyProjection) {
   auto type = ROW({{"m", MAP(VARCHAR(), INTEGER())}});
 
-  SerializerOptions serOpts{.version = SerializationVersion::kCompactRaw};
+  SerializerOptions serOpts{.version = SerializationVersion::kSerialization};
   auto inputSchema = getNimbleSchema(type, serOpts);
 
   // Regular map subscripts are not supported (would need re-encoding) — the
@@ -793,7 +819,7 @@ TEST_F(ProjectorTest, unsupportedMapKeyProjection) {
           inputSchema,
           subfields,
           pool_.get(),
-          {.projectVersion = SerializationVersion::kCompactRaw}),
+          {.projectVersion = SerializationVersion::kProjection}),
       "only supported on FlatMap");
 }
 
@@ -849,7 +875,7 @@ TEST_F(ProjectorTest, flatMapSerializeDeserializeNoProjction) {
 
   // Serialize with FlatMap encoding.
   SerializerOptions serOpts{
-      .version = SerializationVersion::kCompactRaw,
+      .version = SerializationVersion::kSerialization,
       .flatMapColumns = {{"features", {}}},
   };
   auto [serialized, inputSchema] = serializeWithSchema(vec, type, serOpts);
@@ -917,7 +943,7 @@ TEST_F(ProjectorTest, projectEntireFlatMapColumn) {
       std::vector<VectorPtr>{ids, mapVector});
 
   SerializerOptions serOpts{
-      .version = SerializationVersion::kCompactRaw,
+      .version = SerializationVersion::kSerialization,
       .flatMapColumns = {{"features", {}}},
   };
   auto [serialized, inputSchema] = serializeWithSchema(vec, type, serOpts);
@@ -929,7 +955,7 @@ TEST_F(ProjectorTest, projectEntireFlatMapColumn) {
           inputSchema,
           subfields,
           pool_.get(),
-          {.projectVersion = SerializationVersion::kCompactRaw}),
+          {.projectVersion = SerializationVersion::kProjection}),
       "Cannot project entire FlatMap column without key subscripts");
 }
 
@@ -985,7 +1011,7 @@ TEST_F(ProjectorTest, projectFlatMapAllKeys) {
 
   // Serialize with FlatMap encoding.
   SerializerOptions serOpts{
-      .version = SerializationVersion::kCompactRaw,
+      .version = SerializationVersion::kSerialization,
       .flatMapColumns = {{"features", {}}},
   };
   auto [serialized, inputSchema] = serializeWithSchema(vec, type, serOpts);
@@ -997,7 +1023,7 @@ TEST_F(ProjectorTest, projectFlatMapAllKeys) {
       inputSchema,
       subfields,
       pool_.get(),
-      {.projectVersion = SerializationVersion::kCompactRaw});
+      {.projectVersion = SerializationVersion::kProjection});
 
   auto outputSchema = projector.projectedSchema();
   DeserializerOptions deserOpts{.hasHeader = true};
@@ -1075,7 +1101,7 @@ TEST_F(ProjectorTest, flatMapKeyProjectionSchemaComparison) {
       std::vector<VectorPtr>{ids, mapVector});
 
   SerializerOptions serOpts{
-      .version = SerializationVersion::kCompactRaw,
+      .version = SerializationVersion::kSerialization,
       .flatMapColumns = {{"features", {}}},
   };
   auto [serialized, inputSchema] = serializeWithSchema(vec, type, serOpts);
@@ -1086,7 +1112,7 @@ TEST_F(ProjectorTest, flatMapKeyProjectionSchemaComparison) {
       inputSchema,
       subfields,
       pool_.get(),
-      {.projectVersion = SerializationVersion::kCompactRaw});
+      {.projectVersion = SerializationVersion::kProjection});
   auto projectorSchema = projector.projectedSchema();
 
   // buildProjectedNimbleType should produce matching FlatMap schema.
@@ -1186,7 +1212,7 @@ TEST_F(ProjectorTest, flatMapFullProjectionSchemaTypeMismatch) {
       std::vector<VectorPtr>{ids, mapVector});
 
   SerializerOptions serOpts{
-      .version = SerializationVersion::kCompactRaw,
+      .version = SerializationVersion::kSerialization,
       .flatMapColumns = {{"features", {}}},
   };
   auto [serialized, inputSchema] = serializeWithSchema(vec, type, serOpts);
@@ -1198,7 +1224,7 @@ TEST_F(ProjectorTest, flatMapFullProjectionSchemaTypeMismatch) {
           inputSchema,
           subfields,
           pool_.get(),
-          {.projectVersion = SerializationVersion::kCompactRaw}),
+          {.projectVersion = SerializationVersion::kProjection}),
       "Cannot project entire FlatMap column without key subscripts");
 }
 
@@ -1254,7 +1280,7 @@ TEST_F(ProjectorTest, flatMapStreamIndices) {
 
   // Serialize with FlatMap encoding.
   SerializerOptions serOpts{
-      .version = SerializationVersion::kCompactRaw,
+      .version = SerializationVersion::kSerialization,
       .flatMapColumns = {{"features", {}}},
   };
   auto [serialized, inputSchema] = serializeWithSchema(vec, type, serOpts);
@@ -1289,7 +1315,7 @@ TEST_F(ProjectorTest, flatMapStreamIndices) {
       inputSchema,
       subfields,
       pool_.get(),
-      {.projectVersion = SerializationVersion::kCompactRaw});
+      {.projectVersion = SerializationVersion::kProjection});
 
   const auto& indices = projector.testingInputStreamIndices();
   LOG(INFO) << "Projected stream indices: ";
@@ -1378,7 +1404,7 @@ TEST_F(ProjectorTest, projectFlatMapSingleKey) {
   // Use serializeWithSchema to get schema AFTER serialization (when FlatMap
   // keys are discovered).
   SerializerOptions serOpts{
-      .version = SerializationVersion::kCompactRaw,
+      .version = SerializationVersion::kSerialization,
       .flatMapColumns = {{"features", {}}},
   };
   auto [serialized, inputSchema] = serializeWithSchema(vec, type, serOpts);
@@ -1389,7 +1415,7 @@ TEST_F(ProjectorTest, projectFlatMapSingleKey) {
       inputSchema,
       subfields,
       pool_.get(),
-      {.projectVersion = SerializationVersion::kCompactRaw});
+      {.projectVersion = SerializationVersion::kProjection});
 
   auto outputSchema = projector.projectedSchema();
 
@@ -1479,7 +1505,7 @@ TEST_F(ProjectorTest, projectFlatMapMultipleKeys) {
   // Serialize with FlatMap encoding.
   // Use serializeWithSchema to get schema AFTER serialization.
   SerializerOptions serOpts{
-      .version = SerializationVersion::kCompactRaw,
+      .version = SerializationVersion::kSerialization,
       .flatMapColumns = {{"features", {}}},
   };
   auto [serialized, inputSchema] = serializeWithSchema(vec, type, serOpts);
@@ -1490,7 +1516,7 @@ TEST_F(ProjectorTest, projectFlatMapMultipleKeys) {
       inputSchema,
       subfields,
       pool_.get(),
-      {.projectVersion = SerializationVersion::kCompactRaw});
+      {.projectVersion = SerializationVersion::kProjection});
 
   auto outputSchema = projector.projectedSchema();
 
@@ -1578,7 +1604,7 @@ TEST_F(ProjectorTest, projectFlatMapNonExistentKey) {
 
   // Serialize with FlatMap encoding to discover keys 1, 2, 3.
   SerializerOptions serOpts{
-      .version = SerializationVersion::kCompactRaw,
+      .version = SerializationVersion::kSerialization,
       .flatMapColumns = {{"features", {}}},
   };
   auto [serialized, inputSchema] = serializeWithSchema(vec, type, serOpts);
@@ -1591,7 +1617,7 @@ TEST_F(ProjectorTest, projectFlatMapNonExistentKey) {
       inputSchema,
       subfields,
       pool_.get(),
-      {.projectVersion = SerializationVersion::kCompactRaw}};
+      {.projectVersion = SerializationVersion::kProjection}};
 
   // The projected schema has one child for the requested (missing) key.
   const auto& projectedSchema = projector.projectedSchema();
@@ -1676,7 +1702,7 @@ TEST_F(ProjectorTest, projectFlatMapNonExistentKey_RowValue) {
       std::vector<VectorPtr>{ids, mapVector});
 
   SerializerOptions serOpts{
-      .version = SerializationVersion::kCompactRaw,
+      .version = SerializationVersion::kSerialization,
       .flatMapColumns = {{"features", {}}},
   };
   auto [serialized, inputSchema] = serializeWithSchema(vec, type, serOpts);
@@ -1690,7 +1716,7 @@ TEST_F(ProjectorTest, projectFlatMapNonExistentKey_RowValue) {
       inputSchema,
       subfields,
       pool_.get(),
-      {.projectVersion = SerializationVersion::kCompactRaw}};
+      {.projectVersion = SerializationVersion::kProjection}};
 
   const auto& projectedSchema = projector.projectedSchema();
   ASSERT_EQ(Kind::Row, projectedSchema->kind());
@@ -1783,7 +1809,7 @@ TEST_F(ProjectorTest, projectFlatMapNonExistentKey_ArrayValue) {
       std::vector<VectorPtr>{ids, mapVector});
 
   SerializerOptions serOpts{
-      .version = SerializationVersion::kCompactRaw,
+      .version = SerializationVersion::kSerialization,
       .flatMapColumns = {{"features", {}}},
   };
   auto [serialized, inputSchema] = serializeWithSchema(vec, type, serOpts);
@@ -1793,7 +1819,7 @@ TEST_F(ProjectorTest, projectFlatMapNonExistentKey_ArrayValue) {
       inputSchema,
       subfields,
       pool_.get(),
-      {.projectVersion = SerializationVersion::kCompactRaw}};
+      {.projectVersion = SerializationVersion::kProjection}};
 
   const auto& projectedSchema = projector.projectedSchema();
   ASSERT_EQ(Kind::Row, projectedSchema->kind());
@@ -1871,7 +1897,7 @@ TEST_F(ProjectorTest, missingKeyInMiddleProducesPlaceholder) {
 
   // Serialize as FlatMap — blob will have streams only for keys "1" and "3".
   SerializerOptions serOpts{
-      .version = SerializationVersion::kCompactRaw,
+      .version = SerializationVersion::kSerialization,
       .flatMapColumns = {{"data", {}}},
   };
   auto [blob, sourceSchema] = serializeWithSchema(vec, type, serOpts);
@@ -1893,7 +1919,7 @@ TEST_F(ProjectorTest, missingKeyInMiddleProducesPlaceholder) {
       sourceSchema,
       subfields,
       pool_.get(),
-      {.projectVersion = SerializationVersion::kCompactRaw});
+      {.projectVersion = SerializationVersion::kProjection});
 
   auto projected = projectInput(projector, blob, /*useIOBuf=*/false);
   auto projectedStr = toString(projected);
@@ -1945,7 +1971,7 @@ TEST_F(ProjectorTest, streamIndicesCorrect) {
   });
   // Stream 0 is root row nulls.
 
-  SerializerOptions serOpts{.version = SerializationVersion::kCompactRaw};
+  SerializerOptions serOpts{.version = SerializationVersion::kSerialization};
   auto inputSchema = getNimbleSchema(type, serOpts);
 
   // Project "b" only - should include streams 0 (root nulls) and 2 (b data).
@@ -1954,7 +1980,7 @@ TEST_F(ProjectorTest, streamIndicesCorrect) {
       inputSchema,
       subfields,
       pool_.get(),
-      {.projectVersion = SerializationVersion::kCompactRaw});
+      {.projectVersion = SerializationVersion::kProjection});
 
   const auto& indices = projector.testingInputStreamIndices();
   ASSERT_EQ(indices.size(), 2);
@@ -1999,7 +2025,7 @@ TEST_F(ProjectorTest, projectWithUpdatedRowType) {
       std::vector<VectorPtr>{ids, names, values});
 
   // Serialize with old column names.
-  SerializerOptions serOpts{.version = SerializationVersion::kCompactRaw};
+  SerializerOptions serOpts{.version = SerializationVersion::kSerialization};
   auto [serialized, inputSchema] = serializeWithSchema(vec, inputType, serOpts);
 
   // Query uses new column names from projectType.
@@ -2011,12 +2037,12 @@ TEST_F(ProjectorTest, projectWithUpdatedRowType) {
           inputSchema,
           subfields,
           pool_.get(),
-          {.projectVersion = SerializationVersion::kCompactRaw}),
+          {.projectVersion = SerializationVersion::kProjection}),
       "Field 'new_id' not found in RowType");
 
   // With projectType, name mapping is auto-computed and projection succeeds.
   Projector::Options opts{
-      .projectVersion = SerializationVersion::kCompactRaw,
+      .projectVersion = SerializationVersion::kProjection,
       .projectType = projectType,
   };
   Projector projector(inputSchema, subfields, pool_.get(), opts);
@@ -2110,7 +2136,7 @@ TEST_F(ProjectorTest, projectWithUpdatedNestedRowType) {
 
   // Serialize with FlatMap to discover keys.
   SerializerOptions serOpts{
-      .version = SerializationVersion::kCompactRaw,
+      .version = SerializationVersion::kSerialization,
       .flatMapColumns = {{"features", {}}},
   };
   auto [serialized, inputSchema] = serializeWithSchema(vec, inputType, serOpts);
@@ -2124,7 +2150,7 @@ TEST_F(ProjectorTest, projectWithUpdatedNestedRowType) {
         inputSchema,
         subfields,
         pool_.get(),
-        {.projectVersion = SerializationVersion::kCompactRaw});
+        {.projectVersion = SerializationVersion::kProjection});
     const auto& nestedRow = projectorNoType.projectedSchema()
                                 ->asRow()
                                 .childAt(0)
@@ -2136,7 +2162,7 @@ TEST_F(ProjectorTest, projectWithUpdatedNestedRowType) {
 
   // With projectType, nested row field is renamed.
   Projector::Options opts{
-      .projectVersion = SerializationVersion::kCompactRaw,
+      .projectVersion = SerializationVersion::kProjection,
       .projectType = projectType,
   };
   Projector projector(inputSchema, subfields, pool_.get(), opts);
@@ -2228,7 +2254,7 @@ TEST_F(ProjectorTest, projectNestedFieldUnderFlatMapValue) {
       std::vector<VectorPtr>{ids, mapVector});
 
   SerializerOptions serOpts{
-      .version = SerializationVersion::kCompactRaw,
+      .version = SerializationVersion::kSerialization,
       .flatMapColumns = {{"features", {}}},
   };
   auto [serialized, inputSchema] = serializeWithSchema(vec, inputType, serOpts);
@@ -2242,7 +2268,7 @@ TEST_F(ProjectorTest, projectNestedFieldUnderFlatMapValue) {
           inputSchema,
           subfields,
           pool_.get(),
-          {.projectVersion = SerializationVersion::kCompactRaw}),
+          {.projectVersion = SerializationVersion::kProjection}),
       "Field 'new_value' not found in RowType");
 
   // With projectType, nested field is renamed and projection succeeds.
@@ -2250,7 +2276,7 @@ TEST_F(ProjectorTest, projectNestedFieldUnderFlatMapValue) {
       inputSchema,
       subfields,
       pool_.get(),
-      {.projectVersion = SerializationVersion::kCompactRaw,
+      {.projectVersion = SerializationVersion::kProjection,
        .projectType = projectType});
 
   for (bool useIOBuf : {false, true}) {
@@ -2350,7 +2376,7 @@ TEST_F(ProjectorTest, projectMultipleFlatMapColumns) {
 
   // Serialize both maps as FlatMaps.
   SerializerOptions serOpts{
-      .version = SerializationVersion::kCompactRaw,
+      .version = SerializationVersion::kSerialization,
       .flatMapColumns = {{"map_a", {}}, {"map_b", {}}},
   };
   auto [serialized, inputSchema] = serializeWithSchema(vec, type, serOpts);
@@ -2375,7 +2401,7 @@ TEST_F(ProjectorTest, projectMultipleFlatMapColumns) {
       inputSchema,
       subfields,
       pool_.get(),
-      {.projectVersion = SerializationVersion::kCompactRaw});
+      {.projectVersion = SerializationVersion::kProjection});
 
   auto outputSchema = projector.projectedSchema();
 
@@ -2485,7 +2511,7 @@ TEST_F(ProjectorTestBase, flatMapInMapStreamSkipping) {
   };
 
   SerializerOptions serOpts{
-      .version = SerializationVersion::kCompactRaw,
+      .version = SerializationVersion::kSerialization,
       .flatMapColumns = {{"flat_map", {}}},
   };
 
@@ -2615,7 +2641,7 @@ TEST_F(ProjectorTest, chainedIOBufInput) {
           makeStringVector({"x", "y", "z"}),
       });
 
-  SerializerOptions serOpts{.version = SerializationVersion::kCompactRaw};
+  SerializerOptions serOpts{.version = SerializationVersion::kSerialization};
   auto serialized = serialize(vec, type, serOpts);
   auto inputSchema = getNimbleSchema(type, serOpts);
 
@@ -2643,11 +2669,15 @@ TEST_F(ProjectorTest, chainedIOBufInput) {
   EXPECT_EQ(bCol->valueAt(1), 200);
   EXPECT_EQ(bCol->valueAt(2), 300);
 
-  // Verify projecting all columns from chained IOBuf produces same result.
+  // Verify projecting all columns from chained IOBuf still deserializes back.
+  // Byte-level equality with `serialized` no longer holds because input is
+  // kSerialization and output is kProjection (different version bytes).
   auto allSubfields = makeSubfields({"a", "b", "c"});
   Projector allColumnsProjector(inputSchema, allSubfields, pool_.get(), {});
   auto allColumnsResult = allColumnsProjector.project(*chainedBuf);
-  EXPECT_EQ(toString(allColumnsResult), serialized);
+  auto allColumnsDeserialized = deserialize(
+      toString(allColumnsResult), outputSchema, {.hasHeader = true});
+  ASSERT_EQ(allColumnsDeserialized->size(), 3);
 }
 
 // Verifies inputStreamsSorted_ is true for non-FlatMap projections (stream
@@ -2668,7 +2698,7 @@ TEST_F(ProjectorTest, sortedStreamIndicesFastPath) {
           makeStringVector({"x", "y", "z"}),
       });
 
-  SerializerOptions serOpts{.version = SerializationVersion::kCompactRaw};
+  SerializerOptions serOpts{.version = SerializationVersion::kSerialization};
   auto serialized = serialize(vec, type, serOpts);
   auto inputSchema = getNimbleSchema(type, serOpts);
 
@@ -2795,7 +2825,7 @@ TEST_F(ProjectorTest, unsortedStreamIndicesReorderPath) {
       pool_.get(), type, nullptr, numRows, std::vector<VectorPtr>{mapA, mapB});
 
   SerializerOptions serOpts{
-      .version = SerializationVersion::kCompactRaw,
+      .version = SerializationVersion::kSerialization,
       .flatMapColumns = {{"map_a", {}}, {"map_b", {}}},
   };
   auto [serialized, inputSchema] = serializeWithSchema(vec, type, serOpts);
@@ -2807,7 +2837,7 @@ TEST_F(ProjectorTest, unsortedStreamIndicesReorderPath) {
       inputSchema,
       subfields,
       pool_.get(),
-      {.projectVersion = SerializationVersion::kCompactRaw});
+      {.projectVersion = SerializationVersion::kProjection});
 
   EXPECT_FALSE(projector.testingInputStreamsSorted());
   const auto& indices = projector.testingInputStreamIndices();
@@ -2920,7 +2950,7 @@ TEST_F(ProjectorTest, singleFlatMapSortedFastPath) {
       pool_.get(), type, nullptr, numRows, std::vector<VectorPtr>{ids, mapVec});
 
   SerializerOptions serOpts{
-      .version = SerializationVersion::kCompactRaw,
+      .version = SerializationVersion::kSerialization,
       .flatMapColumns = {{"features", {}}},
   };
   auto [serialized, inputSchema] = serializeWithSchema(vec, type, serOpts);
@@ -2931,7 +2961,7 @@ TEST_F(ProjectorTest, singleFlatMapSortedFastPath) {
       inputSchema,
       subfields,
       pool_.get(),
-      {.projectVersion = SerializationVersion::kCompactRaw});
+      {.projectVersion = SerializationVersion::kProjection});
 
   // Single FlatMap with alphabetical keys — indices should be sorted.
   EXPECT_TRUE(projector.testingInputStreamsSorted());
@@ -2966,8 +2996,8 @@ TEST_F(ProjectorTest, projectedTrailerNoCompression) {
   auto type = ROW(std::vector<std::string>(names), extractTypes(children));
   auto vec = makeSimpleRowVector(names, children);
 
-  // Serialize with kCompactRaw.
-  SerializerOptions serOpts{.version = SerializationVersion::kCompactRaw};
+  // Serialize with kLegacyCompact.
+  SerializerOptions serOpts{.version = SerializationVersion::kSerialization};
   auto serialized = serialize(vec, type, serOpts);
   auto inputSchema = getNimbleSchema(type, serOpts);
 
@@ -2980,8 +3010,9 @@ TEST_F(ProjectorTest, projectedTrailerNoCompression) {
 
   // Verify the projected output has a valid trailer.
   const auto* end = projectedStr.data() + projectedStr.size();
-  auto streamSizes = detail::readTrailerStreamSizes(end);
-  EXPECT_GT(streamSizes.size(), 0);
+  auto [indices, sizes] = detail::readTrailerStreamMetadata(end);
+  EXPECT_GT(indices.size(), 0);
+  EXPECT_EQ(indices.size(), sizes.size());
 }
 
 // Fuzz test: serialize batches with different versions, project, and verify
@@ -3011,22 +3042,26 @@ TEST_F(ProjectorTest, fuzzMixedVersionProjection) {
 
   // Versions to cycle through for each batch.
   const std::vector<SerializerOptions> inputVersions = {
-      {.version = SerializationVersion::kCompactRaw},
-      {.version = SerializationVersion::kCompactRaw},
-      {.version = SerializationVersion::kCompactRaw,
+      {.version = SerializationVersion::kSerialization},
+      {.version = SerializationVersion::kSerialization},
+      {.version = SerializationVersion::kSerialization,
+       .streamIndicesEncodingType = EncodingType::Delta,
        .streamSizesEncodingType = EncodingType::Delta},
-      {.version = SerializationVersion::kCompactRaw,
-       .streamSizesEncodingType = EncodingType::MainlyConstant},
+      {.version = SerializationVersion::kSerialization,
+       .streamIndicesEncodingType = EncodingType::FixedBitWidth,
+       .streamSizesEncodingType = EncodingType::Varint},
   };
 
   // Output projection versions.
   const std::vector<Projector::Options> outputVersions = {
-      {.projectVersion = SerializationVersion::kCompactRaw},
-      {.projectVersion = SerializationVersion::kCompactRaw},
-      {.projectVersion = SerializationVersion::kCompactRaw,
+      {.projectVersion = SerializationVersion::kProjection},
+      {.projectVersion = SerializationVersion::kProjection},
+      {.projectVersion = SerializationVersion::kProjection,
+       .streamIndicesEncodingType = EncodingType::Delta,
        .streamSizesEncodingType = EncodingType::Delta},
-      {.projectVersion = SerializationVersion::kCompactRaw,
-       .streamSizesEncodingType = EncodingType::MainlyConstant},
+      {.projectVersion = SerializationVersion::kProjection,
+       .streamIndicesEncodingType = EncodingType::FixedBitWidth,
+       .streamSizesEncodingType = EncodingType::Varint},
   };
 
   // Columns to project (subset of the full schema).

--- a/dwio/nimble/serializer/tests/SerializationHeaderTest.cpp
+++ b/dwio/nimble/serializer/tests/SerializationHeaderTest.cpp
@@ -39,11 +39,11 @@ TEST(SerializationHeaderTest, writeReadRoundtripLegacy) {
 
 TEST(SerializationHeaderTest, writeReadRoundtripCompactRaw) {
   std::string buffer;
-  writeSerializationHeader(buffer, SerializationVersion::kCompactRaw, 1000);
+  writeSerializationHeader(buffer, SerializationVersion::kLegacyCompact, 1000);
 
   const char* pos = buffer.data();
   auto header = readSerializationHeader(pos, pos + buffer.size(), true);
-  EXPECT_EQ(header.version, SerializationVersion::kCompactRaw);
+  EXPECT_EQ(header.version, SerializationVersion::kLegacyCompact);
   EXPECT_EQ(header.rowCount, 1000);
   EXPECT_FALSE(header.rowRange.has_value());
 }
@@ -99,7 +99,7 @@ TEST(SerializationHeaderTest, estimateSizeMatchesActual) {
   for (auto version :
        {std::optional<SerializationVersion>{std::nullopt},
         std::optional{SerializationVersion::kLegacy},
-        std::optional{SerializationVersion::kCompactRaw}}) {
+        std::optional{SerializationVersion::kLegacyCompact}}) {
     for (uint32_t rowCount : {0u, 1u, 127u, 128u, 16383u, 1000000u}) {
       std::string buffer;
       writeSerializationHeader(buffer, version, rowCount);

--- a/dwio/nimble/serializer/tests/SerializationTest.cpp
+++ b/dwio/nimble/serializer/tests/SerializationTest.cpp
@@ -45,8 +45,8 @@ using namespace facebook::nimble;
 using facebook::nimble::test::makeTestTabletOptions;
 
 // Test parameters for parameterized tests.
-// For kCompactRaw mode, we test both with and without compression to exercise
-// the compressionOptions path in ReplayedEncodingSelectionPolicy.
+// For kLegacyCompact mode, we test both with and without compression to
+// exercise the compressionOptions path in ReplayedEncodingSelectionPolicy.
 struct TestParams {
   std::optional<SerializationVersion> version;
   // Compression options used with encodingLayoutTree.
@@ -273,6 +273,7 @@ class SerializationTest : public ::testing::TestWithParam<TestParams> {
         .compressionThreshold = 32,
         .compressionLevel = 3,
         .version = version(),
+        .streamIndicesEncodingType = streamSizesEncodingType(),
         .streamSizesEncodingType = streamSizesEncodingType(),
     };
     Serializer serializer{options, type, pool};
@@ -438,11 +439,17 @@ std::string formatName(const ::testing::TestParamInfo<TestParams>& info) {
       case SerializationVersion::kLegacy:
         name = "LegacyFormat";
         break;
-      case SerializationVersion::kCompactRaw:
+      case SerializationVersion::kLegacyCompact:
         name = "CompactRawFormat";
         break;
       case SerializationVersion::kTablet:
         name = "TabletFormat";
+        break;
+      case SerializationVersion::kSerialization:
+        name = "SerializationFormat";
+        break;
+      case SerializationVersion::kProjection:
+        name = "ProjectionFormat";
         break;
     }
   }
@@ -476,6 +483,7 @@ SerializationTest::SerializeResult SerializationTest::serialize(
       .compressionThreshold = 32,
       .compressionLevel = 3,
       .version = version(),
+      .streamIndicesEncodingType = streamSizesEncodingType(),
       .streamSizesEncodingType = streamSizesEncodingType(),
   };
   Serializer serializer{options, type, pool_.get()};
@@ -556,7 +564,10 @@ SerializationTest::SerializeResult SerializationTest::serializeTablet(
 
     std::string trailerBuf;
     serde::detail::writeTrailer(
-        streamSizes, nimble::EncodingType::Trivial, trailerBuf);
+        streamSizes,
+        nimble::EncodingType::Trivial,
+        nimble::EncodingType::Trivial,
+        trailerBuf);
 
     std::string assembled;
     assembled.reserve(headerBuf.size() + streamData.size() + trailerBuf.size());
@@ -658,6 +669,7 @@ TEST_P(SerializationTest, flatMapEncodingFuzz) {
         .compressionLevel = 3,
         .version = version(),
         .flatMapColumns = testCase.flatMapColumns,
+        .streamIndicesEncodingType = streamSizesEncodingType(),
         .streamSizesEncodingType = streamSizesEncodingType(),
     };
     Serializer serializer{options, testCase.type, pool_.get()};
@@ -1601,7 +1613,7 @@ TEST_P(SerializationTest, nullsNotSupported) {
         "nulls not supported");
   }
 
-  // Test 4: FlatMap with null value (only for kCompactRaw format).
+  // Test 4: FlatMap with null value (only for kLegacyCompact format).
   if (SerializerOptions{.version = version()}.enableEncoding()) {
     auto type = velox::ROW({
         {"id", velox::BIGINT()},
@@ -1824,7 +1836,7 @@ TEST_P(SerializationTest, versionMismatch) {
   auto serialized =
       serializer.serialize(input, OrderedRanges::of(0, input->size()));
 
-  // Try to deserialize with kCompactRaw (expects version header).
+  // Try to deserialize with kLegacyCompact (expects version header).
   // The first byte is rowCount (not version), so it will be read as version
   // and fail the version check.
   Deserializer deserializer{
@@ -1849,7 +1861,9 @@ TEST_P(SerializationTest, streamSizesEncodingIgnoredForLegacy) {
   auto type = velox::ROW({{"int_val", velox::INTEGER()}});
   // Legacy format does not use stream sizes trailer, so non-trivial
   // encoding types are accepted (and ignored).
-  SerializerOptions options{.streamSizesEncodingType = EncodingType::Delta};
+  SerializerOptions options{
+      .streamIndicesEncodingType = EncodingType::Delta,
+      .streamSizesEncodingType = EncodingType::Delta};
   EXPECT_NO_THROW(Serializer(options, type, pool_.get()));
 }
 
@@ -3309,7 +3323,10 @@ TEST_F(SerializationTest, zstdThreadLocalDCtxHighParallelism) {
 
     std::string trailerBuf;
     serde::detail::writeTrailer(
-        streamSizes, nimble::EncodingType::Trivial, trailerBuf);
+        streamSizes,
+        nimble::EncodingType::Trivial,
+        nimble::EncodingType::Trivial,
+        trailerBuf);
 
     std::string assembled;
     assembled.reserve(headerBuf.size() + streamData.size() + trailerBuf.size());
@@ -3432,7 +3449,10 @@ TEST_F(SerializationTest, zstdThreadLocalDCtxConcurrentDeserializers) {
 
       std::string trailerBuf;
       serde::detail::writeTrailer(
-          streamSizes, nimble::EncodingType::Trivial, trailerBuf);
+          streamSizes,
+          nimble::EncodingType::Trivial,
+          nimble::EncodingType::Trivial,
+          trailerBuf);
 
       std::string assembled;
       assembled.reserve(
@@ -3604,7 +3624,10 @@ TEST_F(SerializationTest, zstdThreadLocalDCtxFlatMapWithParallelDecode) {
 
     std::string trailerBuf;
     serde::detail::writeTrailer(
-        streamSizes, nimble::EncodingType::Trivial, trailerBuf);
+        streamSizes,
+        nimble::EncodingType::Trivial,
+        nimble::EncodingType::Trivial,
+        trailerBuf);
 
     std::string assembled;
     assembled.reserve(headerBuf.size() + streamData.size() + trailerBuf.size());
@@ -3725,7 +3748,10 @@ TEST_F(SerializationTest, zstdThreadLocalDCtxRepeatedBatches) {
 
     std::string trailerBuf;
     serde::detail::writeTrailer(
-        streamSizes, nimble::EncodingType::Trivial, trailerBuf);
+        streamSizes,
+        nimble::EncodingType::Trivial,
+        nimble::EncodingType::Trivial,
+        trailerBuf);
 
     std::string assembled;
     assembled.reserve(headerBuf.size() + streamData.size() + trailerBuf.size());
@@ -4400,7 +4426,7 @@ TEST_P(SerializationTest, flatmapColumnsKeysRejectsRowIngestion) {
 }
 
 // Fuzz test that serializes batches with different versions (cycling through
-// kCompactRaw, kCompactRaw+Delta), deserializes each batch, and
+// kLegacyCompact, kLegacyCompact+Delta), deserializes each batch, and
 // verifies round-trip correctness.
 TEST_F(SerializationTest, fuzzMixedVersionSerialization) {
   auto type = velox::ROW({
@@ -4427,8 +4453,9 @@ TEST_F(SerializationTest, fuzzMixedVersionSerialization) {
 
   // Versions to cycle through for each batch.
   const std::vector<SerializerOptions> serializerVersions = {
-      {.version = SerializationVersion::kCompactRaw},
-      {.version = SerializationVersion::kCompactRaw,
+      {.version = SerializationVersion::kSerialization},
+      {.version = SerializationVersion::kSerialization,
+       .streamIndicesEncodingType = EncodingType::Delta,
        .streamSizesEncodingType = EncodingType::Delta},
   };
 
@@ -5148,56 +5175,182 @@ DEBUG_ONLY_TEST_P(SerializationTest, parallelDecodeDisabledFlatMap) {
   }
 }
 
+namespace {
+
+// Master-format legacy kLegacyCompact Trivial trailer.
+// Wire: [encodingByte:Trivial][denseSizes:u32[]][trailerSize:u32]
+std::string buildLegacyTrivialTrailer(const std::vector<uint32_t>& denseSizes) {
+  std::string trailer;
+  trailer.push_back(static_cast<char>(EncodingType::Trivial));
+  trailer.append(
+      reinterpret_cast<const char*>(denseSizes.data()),
+      denseSizes.size() * sizeof(uint32_t));
+  const auto trailerSize = static_cast<uint32_t>(trailer.size());
+  trailer.append(reinterpret_cast<const char*>(&trailerSize), sizeof(uint32_t));
+  return trailer;
+}
+
+// Rewrites a kSerialization blob to bytes a master-format kLegacyCompact writer
+// would have produced. The body wire format (varint row counts + per-stream
+// payloads) is byte-identical across the two versions; only the trailer
+// layout and the version byte differ. This lets us synthesize a production
+// kLegacyCompact blob without resurrecting the master writer.
+std::string rewriteAsLegacyCompactRaw(std::string_view kSerializationBlob) {
+  const char* end = kSerializationBlob.data() + kSerializationBlob.size();
+  auto [sparseIndices, sparseSizes] =
+      serde::detail::readTrailerStreamMetadata(end);
+  const auto newTrailerSize = serde::detail::readTrailerSize(end);
+
+  std::vector<uint32_t> denseSizes;
+  if (!sparseIndices.empty()) {
+    denseSizes.assign(sparseIndices.back() + 1, 0);
+    for (size_t i = 0; i < sparseIndices.size(); ++i) {
+      denseSizes[sparseIndices[i]] = sparseSizes[i];
+    }
+  }
+
+  std::string rewritten(kSerializationBlob.substr(
+      0, kSerializationBlob.size() - sizeof(uint32_t) - newTrailerSize));
+  rewritten[0] = static_cast<char>(SerializationVersion::kLegacyCompact);
+  rewritten.append(buildLegacyTrivialTrailer(denseSizes));
+  return rewritten;
+}
+
+} // namespace
+
+// End-to-end safety net: prove that production kLegacyCompact blobs (version=2,
+// legacy Trivial trailer) flow through the post-D108024182 dispatch path
+// (DeserializerImpl → legacy::readLegacyTrailerStreamSizes) and decode to the
+// same vector the writer produced. This is the load-bearing test for the
+// "kLegacyCompact stays readable" guarantee — without it, the legacy reader's
+// integration into the dispatch path is unverified.
+TEST_F(SerializationTest, compactRawProductionBlobRoundtrip) {
+  auto type = velox::ROW({
+      {"bool_val", velox::BOOLEAN()},
+      {"int_val", velox::INTEGER()},
+      {"long_val", velox::BIGINT()},
+      {"double_val", velox::DOUBLE()},
+      {"string_val", velox::VARCHAR()},
+  });
+
+  velox::VectorFuzzer fuzzer(
+      {
+          .vectorSize = 64,
+          .nullRatio = 0,
+          .stringLength = 16,
+          .stringVariableLength = true,
+      },
+      pool_.get(),
+      /*seed=*/12345);
+  auto input = fuzzer.fuzzInputRow(type);
+
+  SerializerOptions writerOptions{
+      .version = SerializationVersion::kSerialization,
+  };
+  Serializer serializer{writerOptions, type, pool_.get()};
+  const auto kSerializationBlob =
+      serializer.serialize(input, OrderedRanges::of(0, input->size()));
+
+  const std::string kLegacyCompactBlob =
+      rewriteAsLegacyCompactRaw(kSerializationBlob);
+
+  ASSERT_FALSE(kLegacyCompactBlob.empty());
+  ASSERT_EQ(
+      static_cast<uint8_t>(kLegacyCompactBlob[0]),
+      static_cast<uint8_t>(SerializationVersion::kLegacyCompact));
+
+  DeserializerOptions deserOptions{.hasHeader = true};
+  Deserializer deserializer{
+      SchemaReader::getSchema(serializer.schemaBuilder().schemaNodes()),
+      pool_.get(),
+      deserOptions};
+
+  velox::VectorPtr output;
+  deserializer.deserialize(kLegacyCompactBlob, output);
+
+  ASSERT_EQ(output->size(), input->size());
+  for (velox::vector_size_t i = 0; i < input->size(); ++i) {
+    EXPECT_TRUE(vectorEquals(input, output, i))
+        << "Row " << i << " mismatch:\n  expected: " << input->toString(i)
+        << "\n  actual:   " << output->toString(i);
+  }
+}
+
+// kLegacyCompact is read-only post the two-array trailer change. Existing
+// callers (especially directory-branched prod code we can't touch in this
+// diff) still pass kLegacyCompact for writes — the Serializer must silently
+// upgrade them to kSerialization rather than throw, so they keep working
+// while migrating.
+TEST_F(SerializationTest, serializerUpgradesKLegacyCompactToKSerialization) {
+  auto type = velox::ROW({{"x", velox::INTEGER()}});
+  SerializerOptions options{
+      .version = SerializationVersion::kLegacyCompact,
+  };
+  // Construction must not throw, and the produced blob must carry the
+  // kSerialization version byte (the silent-upgrade target).
+  Serializer serializer{options, type, pool_.get()};
+  auto col = velox::BaseVector::create(velox::INTEGER(), 1, pool_.get());
+  col->asFlatVector<int32_t>()->set(0, 42);
+  auto row = std::make_shared<velox::RowVector>(
+      pool_.get(), type, nullptr, 1, std::vector<velox::VectorPtr>{col});
+  std::string blob;
+  serializer.serialize(row, OrderedRanges::of(0, 1), blob);
+  ASSERT_FALSE(blob.empty());
+  EXPECT_EQ(
+      static_cast<uint8_t>(blob[0]),
+      static_cast<uint8_t>(SerializationVersion::kSerialization));
+}
+
 INSTANTIATE_TEST_SUITE_P(
     AllFormats,
     SerializationTest,
     ::testing::Values(
         // Legacy format (no nimble encoding).
         TestParams{.version = std::nullopt},
-        // kCompactRaw format without compression.
-        TestParams{.version = SerializationVersion::kCompactRaw},
-        // kCompactRaw format with compression enabled (for encodingLayoutTree
-        // tests).
+        // kLegacyCompact format without compression.
+        TestParams{.version = SerializationVersion::kSerialization},
+        // kLegacyCompact format with compression enabled (for
+        // encodingLayoutTree tests).
         TestParams{
-            .version = SerializationVersion::kCompactRaw,
+            .version = SerializationVersion::kSerialization,
             .compressionOptions =
                 CompressionOptions{
                     .compressionAcceptRatio = 1.0f,
                     .zstdMinCompressionSize = 0}},
-        // kCompactRaw format with Delta stream sizes encoding.
+        // kLegacyCompact format with Delta stream sizes encoding.
         TestParams{
-            .version = SerializationVersion::kCompactRaw,
+            .version = SerializationVersion::kSerialization,
             .streamSizesEncodingType = EncodingType::Delta},
-        // kCompactRaw format with FixedBitWidth stream sizes encoding.
+        // kLegacyCompact format with FixedBitWidth stream sizes encoding.
         TestParams{
-            .version = SerializationVersion::kCompactRaw,
+            .version = SerializationVersion::kSerialization,
             .streamSizesEncodingType = EncodingType::FixedBitWidth},
-        // kCompactRaw format with MainlyConstant stream sizes encoding.
+        // kLegacyCompact format with Varint stream sizes encoding.
         TestParams{
-            .version = SerializationVersion::kCompactRaw,
-            .streamSizesEncodingType = EncodingType::MainlyConstant},
+            .version = SerializationVersion::kSerialization,
+            .streamSizesEncodingType = EncodingType::Varint},
         // Buffer pool disabled variants.
         TestParams{.version = std::nullopt, .bufferPoolCapacity = 0},
         TestParams{
-            .version = SerializationVersion::kCompactRaw,
+            .version = SerializationVersion::kSerialization,
             .bufferPoolCapacity = 0},
         TestParams{
-            .version = SerializationVersion::kCompactRaw,
+            .version = SerializationVersion::kSerialization,
             .compressionOptions =
                 CompressionOptions{
                     .compressionAcceptRatio = 1.0f,
                     .zstdMinCompressionSize = 0},
             .bufferPoolCapacity = 0},
         TestParams{
-            .version = SerializationVersion::kCompactRaw,
+            .version = SerializationVersion::kSerialization,
             .streamSizesEncodingType = EncodingType::Delta,
             .bufferPoolCapacity = 0},
         TestParams{
-            .version = SerializationVersion::kCompactRaw,
+            .version = SerializationVersion::kSerialization,
             .streamSizesEncodingType = EncodingType::FixedBitWidth,
             .bufferPoolCapacity = 0},
         TestParams{
-            .version = SerializationVersion::kCompactRaw,
-            .streamSizesEncodingType = EncodingType::MainlyConstant,
+            .version = SerializationVersion::kSerialization,
+            .streamSizesEncodingType = EncodingType::Varint,
             .bufferPoolCapacity = 0}),
     formatName);

--- a/dwio/nimble/serializer/tests/SerializerImplTest.cpp
+++ b/dwio/nimble/serializer/tests/SerializerImplTest.cpp
@@ -35,6 +35,25 @@ using namespace facebook::nimble;
 using namespace facebook::nimble::serde;
 using namespace facebook::velox;
 
+namespace {
+
+// Test-only helper: scatter the sparse (indices, sizes) trailer into a dense
+// vector sized to max(indices) + 1, matching the legacy dense round-trip view
+// the tests below were written against.
+std::vector<uint32_t> readTrailerStreamMetadataDenseForTest(const char* end) {
+  auto [indices, sizes] = serde::detail::readTrailerStreamMetadata(end);
+  if (indices.empty()) {
+    return {};
+  }
+  std::vector<uint32_t> dense(indices.back() + 1, 0);
+  for (size_t k = 0; k < indices.size(); ++k) {
+    dense[indices[k]] = sizes[k];
+  }
+  return dense;
+}
+
+} // namespace
+
 class WriteHeaderTest : public ::testing::Test {
  protected:
   static void SetUpTestSuite() {
@@ -45,20 +64,26 @@ class WriteHeaderTest : public ::testing::Test {
     pool_ = memory::memoryManager()->addLeafPool("write_header_test");
   }
 
-  // Helper to build a complete kCompactRaw buffer: header + raw trailer.
+  // Helper to build a complete kLegacyCompact buffer: header + raw trailer.
+  // Uses the same encoding for both the indices and sizes axes of the
+  // two-array trailer.
   std::string buildCompactRawHeaderTrailer(
       uint32_t rowCount,
       const std::vector<uint32_t>& sizes,
       EncodingType encodingType = EncodingType::Trivial) {
     std::string buffer;
     serde::writeSerializationHeader(
-        buffer, SerializationVersion::kCompactRaw, rowCount);
-    serde::detail::writeTrailer(sizes, encodingType, buffer);
+        buffer, SerializationVersion::kSerialization, rowCount);
+    serde::detail::writeTrailer(sizes, encodingType, encodingType, buffer);
     return buffer;
   }
 
   // Helper to verify header by writing and parsing back using roundtrip.
-  // For kCompactRaw format, verifies the dense offsets array from trailer.
+  // For kLegacyCompact format, verifies the dense offsets array from trailer.
+  // The dense reconstruction may be shorter than expectedSizes when trailing
+  // entries are zero — pad with zeros to expectedSizes.size() before
+  // comparing so the test's dense data model still works against the
+  // sparse-on-wire trailer.
   void verifyHeader(
       const std::string& buffer,
       SerializationVersion expectedVersion,
@@ -71,7 +96,7 @@ class WriteHeaderTest : public ::testing::Test {
     auto actualVersion = static_cast<SerializationVersion>(*pos++);
     EXPECT_EQ(actualVersion, expectedVersion);
 
-    // Read row count. kCompactRaw uses varint, kLegacy uses u32.
+    // Read row count. kLegacyCompact uses varint, kLegacy uses u32.
     const bool isCompact = isCompactFormat(expectedVersion);
     uint32_t actualRowCount;
     if (isCompact) {
@@ -81,9 +106,12 @@ class WriteHeaderTest : public ::testing::Test {
     }
     EXPECT_EQ(actualRowCount, expectedRowCount);
 
-    // For kCompactRaw, verify stream sizes from trailer.
+    // For kLegacyCompact, verify stream sizes from trailer.
     if (isCompactFormat(expectedVersion)) {
-      auto actualSizes = serde::detail::readTrailerStreamSizes(end);
+      auto actualSizes = readTrailerStreamMetadataDenseForTest(end);
+      if (actualSizes.size() < expectedSizes.size()) {
+        actualSizes.resize(expectedSizes.size(), 0);
+      }
       EXPECT_EQ(actualSizes, expectedSizes);
     }
   }
@@ -100,43 +128,43 @@ TEST_F(WriteHeaderTest, legacyFormat) {
 TEST_F(WriteHeaderTest, compactRawFormatTrivial) {
   std::vector<uint32_t> sizes = {10, 20, 30};
   auto buffer = buildCompactRawHeaderTrailer(200, sizes, EncodingType::Trivial);
-  verifyHeader(buffer, SerializationVersion::kCompactRaw, 200, sizes);
+  verifyHeader(buffer, SerializationVersion::kSerialization, 200, sizes);
 }
 
 TEST_F(WriteHeaderTest, compactRawFormatVarint) {
   std::vector<uint32_t> sizes = {10, 20, 30};
   auto buffer = buildCompactRawHeaderTrailer(200, sizes, EncodingType::Varint);
-  verifyHeader(buffer, SerializationVersion::kCompactRaw, 200, sizes);
+  verifyHeader(buffer, SerializationVersion::kSerialization, 200, sizes);
 }
 
 TEST_F(WriteHeaderTest, compactRawFormatDelta) {
   std::vector<uint32_t> sizes = {10, 20, 30};
   auto buffer = buildCompactRawHeaderTrailer(200, sizes, EncodingType::Delta);
-  verifyHeader(buffer, SerializationVersion::kCompactRaw, 200, sizes);
+  verifyHeader(buffer, SerializationVersion::kSerialization, 200, sizes);
 }
 
 TEST_F(WriteHeaderTest, compactRawFormatDeltaSimilarSizes) {
   // Stream sizes that are very similar benefit most from delta encoding.
   std::vector<uint32_t> sizes = {1'000, 1'002, 998, 1'001, 999, 1'003};
   auto buffer = buildCompactRawHeaderTrailer(500, sizes, EncodingType::Delta);
-  verifyHeader(buffer, SerializationVersion::kCompactRaw, 500, sizes);
+  verifyHeader(buffer, SerializationVersion::kSerialization, 500, sizes);
 }
 
 TEST_F(WriteHeaderTest, compactRawFormatDeltaWithZeros) {
   std::vector<uint32_t> sizes = {100, 0, 0, 50, 0, 200};
   auto buffer = buildCompactRawHeaderTrailer(300, sizes, EncodingType::Delta);
-  verifyHeader(buffer, SerializationVersion::kCompactRaw, 300, sizes);
+  verifyHeader(buffer, SerializationVersion::kSerialization, 300, sizes);
 }
 
 TEST_F(WriteHeaderTest, compactRawFormatDeltaSingleElement) {
   std::vector<uint32_t> sizes = {42};
   auto buffer = buildCompactRawHeaderTrailer(100, sizes, EncodingType::Delta);
-  verifyHeader(buffer, SerializationVersion::kCompactRaw, 100, sizes);
+  verifyHeader(buffer, SerializationVersion::kSerialization, 100, sizes);
 }
 
 TEST_F(WriteHeaderTest, compactRawFormatEmptySizes) {
   auto buffer = buildCompactRawHeaderTrailer(10, {});
-  verifyHeader(buffer, SerializationVersion::kCompactRaw, 10, {});
+  verifyHeader(buffer, SerializationVersion::kSerialization, 10, {});
 }
 
 TEST_F(WriteHeaderTest, compactRawFormatManySizes) {
@@ -145,7 +173,7 @@ TEST_F(WriteHeaderTest, compactRawFormatManySizes) {
     sizes[i * 2] = i + 1;
   }
   auto buffer = buildCompactRawHeaderTrailer(1000, sizes);
-  verifyHeader(buffer, SerializationVersion::kCompactRaw, 1000, sizes);
+  verifyHeader(buffer, SerializationVersion::kSerialization, 1000, sizes);
 }
 
 TEST_F(WriteHeaderTest, zeroRowCount) {
@@ -156,9 +184,9 @@ TEST_F(WriteHeaderTest, zeroRowCount) {
     verifyHeader(buffer, SerializationVersion::kLegacy, 0, {});
   }
   {
-    SCOPED_TRACE("kCompactRaw");
+    SCOPED_TRACE("kLegacyCompact");
     auto buffer = buildCompactRawHeaderTrailer(0, {});
-    verifyHeader(buffer, SerializationVersion::kCompactRaw, 0, {});
+    verifyHeader(buffer, SerializationVersion::kSerialization, 0, {});
   }
 }
 
@@ -177,12 +205,12 @@ TEST_F(WriteHeaderTest, maxRowCount) {
         {});
   }
   {
-    SCOPED_TRACE("kCompactRaw");
+    SCOPED_TRACE("kLegacyCompact");
     auto buffer =
         buildCompactRawHeaderTrailer(std::numeric_limits<uint32_t>::max(), {});
     verifyHeader(
         buffer,
-        SerializationVersion::kCompactRaw,
+        SerializationVersion::kSerialization,
         std::numeric_limits<uint32_t>::max(),
         {});
   }
@@ -243,10 +271,10 @@ TEST_F(WriteHeaderTest, estimateHeaderSizeCompactRaw) {
     SCOPED_TRACE(testData.debugString());
     std::string buffer;
     serde::writeSerializationHeader(
-        buffer, SerializationVersion::kCompactRaw, testData.rowCount);
+        buffer, SerializationVersion::kSerialization, testData.rowCount);
     EXPECT_EQ(
         serde::estimateSerializationHeaderSize(
-            SerializationVersion::kCompactRaw, testData.rowCount),
+            SerializationVersion::kSerialization, testData.rowCount),
         buffer.size());
   }
 }
@@ -277,10 +305,13 @@ TEST_F(WriteHeaderTest, estimateTrailerSize) {
   for (const auto& testData : testSettings) {
     SCOPED_TRACE(testData.debugString());
     std::string buffer;
-    serde::detail::writeTrailer(testData.sizes, EncodingType::Trivial, buffer);
+    serde::detail::writeTrailer(
+        testData.sizes, EncodingType::Trivial, EncodingType::Trivial, buffer);
     EXPECT_GE(
         serde::detail::estimateTrailerSize(
-            testData.sizes.size(), EncodingType::Trivial),
+            testData.sizes.size(),
+            EncodingType::Trivial,
+            EncodingType::Trivial),
         buffer.size())
         << "Estimate must be >= actual trailer size";
   }
@@ -496,21 +527,22 @@ TEST_F(ParseStreamsTest, legacyFormatMultipleStreams) {
   EXPECT_EQ(streams[2], "third");
 }
 
-// kCompactRaw format tests use writeHeader/parseStreams roundtrip since
+// kLegacyCompact format tests use writeHeader/parseStreams roundtrip since
 // the size encoding is now opaque (nimble-encoded).
 
 TEST_F(ParseStreamsTest, denseFormatEmpty) {
   // Write header + trailer with empty sizes array, then parse.
   std::string buffer;
   serde::writeSerializationHeader(
-      buffer, SerializationVersion::kCompactRaw, 10);
-  serde::detail::writeTrailer({}, EncodingType::Trivial, buffer);
+      buffer, SerializationVersion::kSerialization, 10);
+  serde::detail::writeTrailer(
+      {}, EncodingType::Trivial, EncodingType::Trivial, buffer);
 
   auto streams = serde::detail::parseStreams(
       // Skip version byte and row count varint.
       buffer.data() + 1 + varint::varintSize(10),
       buffer.data() + buffer.size(),
-      SerializationVersion::kCompactRaw,
+      SerializationVersion::kSerialization,
       pool_.get());
   EXPECT_TRUE(streams.empty());
 }
@@ -525,11 +557,12 @@ TEST_F(ParseStreamsTest, denseFormatSequential) {
 
   std::string buffer;
   serde::writeSerializationHeader(
-      buffer, SerializationVersion::kCompactRaw, 100);
+      buffer, SerializationVersion::kSerialization, 100);
   for (const auto& d : data) {
     buffer.append(d);
   }
-  serde::detail::writeTrailer(sizes, EncodingType::Trivial, buffer);
+  serde::detail::writeTrailer(
+      sizes, EncodingType::Trivial, EncodingType::Trivial, buffer);
 
   // Skip version byte + varint row count.
   const char* pos = buffer.data() + 1;
@@ -538,7 +571,7 @@ TEST_F(ParseStreamsTest, denseFormatSequential) {
   auto streams = serde::detail::parseStreams(
       pos,
       buffer.data() + buffer.size(),
-      SerializationVersion::kCompactRaw,
+      SerializationVersion::kSerialization,
       pool_.get());
 
   ASSERT_EQ(streams.size(), 3);
@@ -554,11 +587,12 @@ TEST_F(ParseStreamsTest, denseFormatWithGaps) {
 
   std::string buffer;
   serde::writeSerializationHeader(
-      buffer, SerializationVersion::kCompactRaw, 100);
+      buffer, SerializationVersion::kSerialization, 100);
   buffer.append("zero");
   buffer.append("two");
   buffer.append("five");
-  serde::detail::writeTrailer(sizes, EncodingType::Trivial, buffer);
+  serde::detail::writeTrailer(
+      sizes, EncodingType::Trivial, EncodingType::Trivial, buffer);
 
   const char* pos = buffer.data() + 1;
   varint::readVarint32(&pos);
@@ -566,7 +600,7 @@ TEST_F(ParseStreamsTest, denseFormatWithGaps) {
   auto streams = serde::detail::parseStreams(
       pos,
       buffer.data() + buffer.size(),
-      SerializationVersion::kCompactRaw,
+      SerializationVersion::kSerialization,
       pool_.get());
 
   ASSERT_EQ(streams.size(), 6);
@@ -585,9 +619,10 @@ TEST_F(ParseStreamsTest, denseFormatOnlyLastStream) {
 
   std::string buffer;
   serde::writeSerializationHeader(
-      buffer, SerializationVersion::kCompactRaw, 100);
+      buffer, SerializationVersion::kSerialization, 100);
   buffer.append("hello");
-  serde::detail::writeTrailer(sizes, EncodingType::Trivial, buffer);
+  serde::detail::writeTrailer(
+      sizes, EncodingType::Trivial, EncodingType::Trivial, buffer);
 
   const char* pos = buffer.data() + 1;
   varint::readVarint32(&pos);
@@ -595,7 +630,7 @@ TEST_F(ParseStreamsTest, denseFormatOnlyLastStream) {
   auto streams = serde::detail::parseStreams(
       pos,
       buffer.data() + buffer.size(),
-      SerializationVersion::kCompactRaw,
+      SerializationVersion::kSerialization,
       pool_.get());
 
   ASSERT_EQ(streams.size(), 5);
@@ -606,7 +641,7 @@ TEST_F(ParseStreamsTest, denseFormatOnlyLastStream) {
   EXPECT_EQ(streams[4], "hello");
 }
 
-// Tests for readTrailerStreamSizes roundtrip (kCompactRaw).
+// Tests for readTrailerStreamMetadata roundtrip (kLegacyCompact).
 
 class EncodeDecodeTest : public ::testing::Test {
  protected:
@@ -618,17 +653,41 @@ class EncodeDecodeTest : public ::testing::Test {
     pool_ = memory::memoryManager()->addLeafPool("encode_decode_test");
   }
 
-  // Helper to build a kCompactRaw trailer (encoded sizes + trailer size u32).
+  // Helper to build a kLegacyCompact trailer (two-array sparse) using the same
+  // encoding on both axes.
   std::string buildCompactTrailer(const std::vector<uint32_t>& values) {
+    return buildCompactTrailer(
+        values, EncodingType::Trivial, EncodingType::Trivial);
+  }
+
+  std::string buildCompactTrailer(
+      const std::vector<uint32_t>& values,
+      EncodingType indicesEnc,
+      EncodingType sizesEnc) {
     std::string buffer;
-    serde::detail::writeTrailer(values, EncodingType::Trivial, buffer);
+    serde::detail::writeTrailer(values, indicesEnc, sizesEnc, buffer);
     return buffer;
+  }
+
+  // Roundtrip-compare the dense view, padding the readback with trailing
+  // zeros to match the expected dense length (the sparse-on-wire trailer
+  // does not preserve trailing zeros structurally — only via the schema's
+  // streamCount which lives outside the trailer).
+  void expectDenseRoundtripEq(
+      const std::vector<uint32_t>& expected,
+      const std::string& buffer) {
+    auto decoded =
+        readTrailerStreamMetadataDenseForTest(buffer.data() + buffer.size());
+    if (decoded.size() < expected.size()) {
+      decoded.resize(expected.size(), 0);
+    }
+    EXPECT_EQ(decoded, expected);
   }
 
   std::shared_ptr<memory::MemoryPool> pool_;
 };
 
-TEST_F(EncodeDecodeTest, readTrailerStreamSizesRoundtrip) {
+TEST_F(EncodeDecodeTest, readTrailerStreamMetadataRoundtrip) {
   struct TestParam {
     std::vector<uint32_t> values;
     std::string debugString() const {
@@ -644,237 +703,143 @@ TEST_F(EncodeDecodeTest, readTrailerStreamSizesRoundtrip) {
   };
   for (const auto& testData : testSettings) {
     SCOPED_TRACE(testData.debugString());
-
     auto buffer = buildCompactTrailer(testData.values);
-    auto decoded =
-        serde::detail::readTrailerStreamSizes(buffer.data() + buffer.size());
-    EXPECT_EQ(decoded, testData.values);
+    expectDenseRoundtripEq(testData.values, buffer);
   }
 }
 
-TEST_F(EncodeDecodeTest, readTrailerStreamSizesLargeValues) {
+// Verifies that every (indicesEncoding, sizesEncoding) combination from the
+// supported encoding set round-trips correctly across representative shapes:
+// empty, dense, sparse (mostly-zero), and all-nonzero.
+TEST_F(EncodeDecodeTest, readTrailerStreamMetadataAxisEncodingCombinations) {
+  const std::vector<EncodingType> encodings = {
+      EncodingType::Trivial,
+      EncodingType::Varint,
+      EncodingType::Delta,
+      EncodingType::FixedBitWidth,
+  };
+  std::vector<std::pair<std::string, std::vector<uint32_t>>> namedCases = {
+      {"empty", {}},
+      {"single-nonzero", {42}},
+      {"all-zero", {0, 0, 0, 0}},
+      {"mostly-zero-scattered", {0, 0, 11, 0, 0, 22, 0, 0, 33, 0}},
+      {"all-nonzero-small", {1, 2, 3, 4, 5}},
+      {"all-nonzero-similar", {1000, 1002, 998, 1001, 999, 1003}},
+      {"uint32-max-scattered",
+       {0, std::numeric_limits<uint32_t>::max(), 0, 12345}},
+  };
+  {
+    std::vector<uint32_t> v1000(1000, 0);
+    v1000[50] = 11;
+    v1000[123] = 22;
+    v1000[456] = 33;
+    v1000[789] = 44;
+    v1000[999] = 55;
+    namedCases.emplace_back("sparse-1000-slots", std::move(v1000));
+  }
+
+  for (const auto indicesEnc : encodings) {
+    for (const auto sizesEnc : encodings) {
+      for (const auto& [label, values] : namedCases) {
+        SCOPED_TRACE(
+            fmt::format(
+                "indicesEnc={} sizesEnc={} case={}",
+                toString(indicesEnc),
+                toString(sizesEnc),
+                label));
+        auto buffer = buildCompactTrailer(values, indicesEnc, sizesEnc);
+        expectDenseRoundtripEq(values, buffer);
+        const auto estimate = serde::detail::estimateTrailerSize(
+            values.size(), indicesEnc, sizesEnc);
+        EXPECT_LE(buffer.size(), estimate)
+            << "Estimate must be >= actual trailer size";
+      }
+    }
+  }
+}
+
+// Randomized roundtrip over all (indicesEnc, sizesEnc) combinations.
+// Length drawn uniformly from [0, kMaxStreamCount]; per-entry value drawn
+// uniformly across uint32_t with a random nonzero density per iteration.
+// Seed is fixed so the test is fully deterministic.
+TEST_F(EncodeDecodeTest, readTrailerStreamMetadataRandomRoundtrip) {
+  constexpr uint32_t kSeed = 0xC0FFEE;
+  std::mt19937 rng(kSeed);
+  constexpr uint32_t kMaxStreamCount = 1000;
+  constexpr int kIterationsPerCombo = 5;
+  std::uniform_int_distribution<uint32_t> lengthDist(0, kMaxStreamCount);
+  std::uniform_int_distribution<uint32_t> valueDist(
+      0, std::numeric_limits<uint32_t>::max());
+  std::uniform_int_distribution<int> densityDist(0, 100);
+  const std::vector<EncodingType> encodings = {
+      EncodingType::Trivial,
+      EncodingType::Varint,
+      EncodingType::Delta,
+      EncodingType::FixedBitWidth,
+  };
+  for (const auto indicesEnc : encodings) {
+    for (const auto sizesEnc : encodings) {
+      for (int iter = 0; iter < kIterationsPerCombo; ++iter) {
+        const uint32_t streamCount = lengthDist(rng);
+        const int nonzeroPercent = densityDist(rng);
+        SCOPED_TRACE(
+            fmt::format(
+                "indicesEnc={} sizesEnc={} iter={} streamCount={} nonzero%={}",
+                toString(indicesEnc),
+                toString(sizesEnc),
+                iter,
+                streamCount,
+                nonzeroPercent));
+        std::vector<uint32_t> sizes;
+        sizes.reserve(streamCount);
+        std::uniform_int_distribution<int> coinDist(0, 99);
+        for (uint32_t i = 0; i < streamCount; ++i) {
+          sizes.push_back(coinDist(rng) < nonzeroPercent ? valueDist(rng) : 0);
+        }
+        auto buffer = buildCompactTrailer(sizes, indicesEnc, sizesEnc);
+        expectDenseRoundtripEq(sizes, buffer);
+      }
+    }
+  }
+}
+
+TEST_F(EncodeDecodeTest, readTrailerStreamMetadataLargeValues) {
   std::vector<uint32_t> values;
+  values.reserve(1000);
   for (uint32_t i = 0; i < 1000; ++i) {
     values.emplace_back(i * 3);
   }
 
   auto buffer = buildCompactTrailer(values);
-  auto decoded =
-      serde::detail::readTrailerStreamSizes(buffer.data() + buffer.size());
-  EXPECT_EQ(decoded, values);
+  expectDenseRoundtripEq(values, buffer);
 }
 
-// MainlyConstant trailer roundtrip — encoding assumes 0 is the dominant value
-// and writes a sparse list of (index, value) pairs for non-zero slots.
-TEST_F(EncodeDecodeTest, readTrailerStreamSizesMainlyConstant) {
-  struct TestParam {
-    std::vector<uint32_t> values;
-    std::string label;
-  };
-  std::vector<TestParam> cases = {
-      {{}, "empty"},
-      {{0}, "single-zero"},
-      {{42}, "single-nonzero"},
-      {{0, 0, 0, 0, 0}, "all-zero"},
-      // Sparse cases (encoding's sweet spot).
-      {{0, 0, 0, 5, 0, 0, 0, 0, 0, 0}, "mostly-zero-one-nonzero"},
-      {{0, 0, 11, 0, 0, 22, 0, 0, 33, 0}, "mostly-zero-scattered"},
-      // nonConstantCount == count (all non-zero): degenerate path — still
-      // roundtrips even though MainlyConstant is the wrong choice for this
-      // input.
-      {{1, 2, 3, 4, 5}, "all-nonzero-degenerate"},
-      // UINT32_MAX as a stream size — exercises 5-byte varint and
-      // 32-bit valBitWidth.
-      {{0, 0, std::numeric_limits<uint32_t>::max(), 0}, "uint32-max-value"},
-      // Mixed near-max values exercise full valBitWidth=32.
-      {{0,
-        std::numeric_limits<uint32_t>::max(),
-        std::numeric_limits<uint32_t>::max() - 1,
-        0},
-       "max-and-near-max"},
-      // Trailer typical of full-projected hybrid blob: 1000 slots, 5 non-zero.
-      {[] {
-         std::vector<uint32_t> v(1000, 0);
-         v[50] = 11;
-         v[123] = 22;
-         v[456] = 33;
-         v[789] = 44;
-         v[999] = 55;
-         return v;
-       }(),
-       "sparse-1000-slots"},
-      // Smallest count where idxBitWidth > 0 (count=2 needs 1 bit).
-      {{0, 7}, "count2-nonzero-at-end-idxBitWidth1"},
-      {{7, 0}, "count2-nonzero-at-start-idxBitWidth1"},
-      // count=3 with non-zero at last index (idx=2 needs 2 bits).
-      {{0, 0, 9}, "count3-nonzero-at-end-idxBitWidth2"},
-      // idxBitWidth byte boundaries: 256 needs 8 bits, 257 needs 9 bits.
-      {[] {
-         std::vector<uint32_t> v(256, 0);
-         v[255] = 42;
-         return v;
-       }(),
-       "count256-nonzero-at-end-idxBitWidth8"},
-      {[] {
-         std::vector<uint32_t> v(257, 0);
-         v[256] = 42;
-         return v;
-       }(),
-       "count257-nonzero-at-end-idxBitWidth9"},
-      // streamCount=1 with the only non-zero value at UINT32_MAX exercises the
-      // idxBitWidth=0 fast path together with a 32-bit valBitWidth.
-      {{std::numeric_limits<uint32_t>::max()}, "single-uint32-max"},
-      // streamCount=2 with both slots non-zero (nonConstantCount == count):
-      // exercises the idxBitWidth=1 path with both indices populated.
-      {{5, 7}, "count2-both-nonzero"},
-      // Alternating zero/non-zero pattern exercises K=count/2 with indices
-      // densely covering half the slot space.
-      {{1, 0, 2, 0, 3, 0, 4, 0}, "alternating-zero-nonzero"},
-      // idxBitWidth=16 boundary: count=65537 needs 17 bits for indices.
-      {[] {
-         std::vector<uint32_t> v(65537, 0);
-         v[65536] = 1;
-         return v;
-       }(),
-       "count65537-nonzero-at-end-idxBitWidth17"},
-      // valBitWidth byte boundary: max value = 255 fits in 8 bits, 256 needs 9.
-      {{0, 0, 255, 0}, "valBitWidth8-boundary"},
-      {{0, 0, 256, 0}, "valBitWidth9-boundary"},
-  };
-  for (const auto& tc : cases) {
-    SCOPED_TRACE(tc.label);
-    std::string buffer;
-    serde::detail::writeTrailer(
-        tc.values, EncodingType::MainlyConstant, buffer);
-    auto decoded =
-        serde::detail::readTrailerStreamSizes(buffer.data() + buffer.size());
-    EXPECT_EQ(decoded, tc.values);
-  }
-}
-
-// Verify the MainlyConstant trailer wire format omits the `constant` field
-// (always 0) and additionally omits the idxBitWidth/valBitWidth bytes (plus
-// any packed arrays) when nonZeroCount == 0. For all-zero input the trailer
-// is exactly:
-//   encType(1) + streamCountVarint + nonZeroCountVarint(=1 for empty)
-//   + trailer_size(4)
-TEST_F(EncodeDecodeTest, mainlyConstantWireFormatAllZeroIsMinimal) {
-  // All-zero: nonZeroCount=0, no idxBitWidth/valBitWidth bytes, no packed
-  // bytes. streamCount=4 → varintSize=1. nonZeroCount=0 → varintSize=1.
-  // Expected: 1 + 1 + 1 + 4 = 7 bytes.
-  std::vector<uint32_t> sizes = {0, 0, 0, 0};
+// Decoder must reject a trailer whose indices and sizes axes report
+// different counts — the two-array layout requires identical lengths.
+TEST_F(EncodeDecodeTest, readTrailerStreamMetadataAxisCountMismatch) {
+  // Build a buffer by writing two independent axes with differing counts.
+  // Indices axis: 3 values via Trivial encoding; sizes axis: 2 values via
+  // Trivial encoding. Then append the trailer-size suffix manually.
   std::string buffer;
-  serde::detail::writeTrailer(sizes, EncodingType::MainlyConstant, buffer);
-  EXPECT_EQ(buffer.size(), 7u);
+  const auto trailerStart = buffer.size();
+  std::vector<uint32_t> indices{0u, 1u, 2u};
+  std::vector<uint32_t> sizes{10u, 20u};
+  // Indices axis.
+  buffer.push_back(static_cast<char>(EncodingType::Trivial));
+  serde::detail::writeTrivialSection(indices, buffer);
+  // Sizes axis with mismatching count.
+  buffer.push_back(static_cast<char>(EncodingType::Trivial));
+  serde::detail::writeTrivialSection(sizes, buffer);
+  const uint32_t trailerSize =
+      static_cast<uint32_t>(buffer.size() - trailerStart);
+  const auto sizeOffset = buffer.size();
+  buffer.resize(sizeOffset + sizeof(uint32_t));
+  char* sizePos = buffer.data() + sizeOffset;
+  encoding::writeUint32(trailerSize, sizePos);
 
-  // Roundtrip must produce the exact input.
-  auto decoded =
-      serde::detail::readTrailerStreamSizes(buffer.data() + buffer.size());
-  EXPECT_EQ(decoded, sizes);
-}
-
-// Estimate must be an upper bound (>= actual) for representative inputs.
-TEST_F(EncodeDecodeTest, mainlyConstantEstimateIsUpperBound) {
-  std::vector<std::vector<uint32_t>> cases = {
-      {},
-      {0},
-      {42},
-      {0, 0, 0, 0, 0},
-      {0, 5, 0, 0, 9, 0, 0, 0, 0, 3},
-      {1, 2, 3, 4, 5},
-      [] {
-        std::vector<uint32_t> v(1000, 0);
-        v[100] = 50;
-        v[500] = 80;
-        v[999] = 30;
-        return v;
-      }(),
-      [] {
-        std::vector<uint32_t> v(257, 0);
-        v[256] = std::numeric_limits<uint32_t>::max();
-        return v;
-      }(),
-  };
-  for (const auto& tc : cases) {
-    SCOPED_TRACE(fmt::format("size={}", tc.size()));
-    std::string buffer;
-    serde::detail::writeTrailer(tc, EncodingType::MainlyConstant, buffer);
-    const auto estimate = serde::detail::estimateTrailerSize(
-        tc.size(), EncodingType::MainlyConstant);
-    EXPECT_LE(buffer.size(), estimate);
-  }
-}
-
-// Verify MainlyConstant produces a much smaller trailer than FixedBitWidth and
-// Varint when the input is dominated by a single value.
-TEST_F(EncodeDecodeTest, mainlyConstantSparseSize) {
-  // 1000 slots, mostly zeros, with 5 small non-zero values.
-  std::vector<uint32_t> sizes(1000, 0);
-  sizes[100] = 50;
-  sizes[200] = 80;
-  sizes[300] = 30;
-  sizes[400] = 12;
-  sizes[500] = 7;
-
-  std::string trivialBuf, fbwBuf, varintBuf, mcBuf;
-  serde::detail::writeTrailer(sizes, EncodingType::Trivial, trivialBuf);
-  serde::detail::writeTrailer(sizes, EncodingType::FixedBitWidth, fbwBuf);
-  serde::detail::writeTrailer(sizes, EncodingType::Varint, varintBuf);
-  serde::detail::writeTrailer(sizes, EncodingType::MainlyConstant, mcBuf);
-
-  // MainlyConstant should beat all others on this sparse input.
-  EXPECT_LT(mcBuf.size(), trivialBuf.size());
-  EXPECT_LT(mcBuf.size(), fbwBuf.size());
-  EXPECT_LT(mcBuf.size(), varintBuf.size());
-
-  // All four should roundtrip to the same values.
-  for (const auto* buf : {&trivialBuf, &fbwBuf, &varintBuf, &mcBuf}) {
-    auto decoded =
-        serde::detail::readTrailerStreamSizes(buf->data() + buf->size());
-    EXPECT_EQ(decoded, sizes);
-  }
-}
-
-// Randomized roundtrip: encode then decode a fuzzed stream-sizes vector.
-// Length is drawn uniformly from [0, kMaxStreamCount], values are drawn
-// uniformly across uint32_t. Seed is fixed so the test is fully
-// deterministic and reproducible.
-TEST_F(EncodeDecodeTest, mainlyConstantRandomRoundtrip) {
-  constexpr uint32_t kSeed = 0xC0FFEE;
-  std::mt19937 rng(kSeed);
-
-  constexpr uint32_t kMaxStreamCount = 5'000;
-  constexpr int kIterations = 200;
-  std::uniform_int_distribution<uint32_t> lengthDist(0, kMaxStreamCount);
-  std::uniform_int_distribution<uint32_t> valueDist(
-      0, std::numeric_limits<uint32_t>::max());
-  // Per iteration, draw a fresh nonzero density so we cover both
-  // sparse (MainlyConstant's sweet spot) and dense inputs.
-  std::uniform_int_distribution<int> densityDist(0, 100);
-
-  for (int iter = 0; iter < kIterations; ++iter) {
-    const uint32_t streamCount = lengthDist(rng);
-    const int nonzeroPercent = densityDist(rng);
-    SCOPED_TRACE(
-        fmt::format(
-            "iter={} streamCount={} nonzeroPercent={}",
-            iter,
-            streamCount,
-            nonzeroPercent));
-
-    std::vector<uint32_t> sizes;
-    sizes.reserve(streamCount);
-    std::uniform_int_distribution<int> coinDist(0, 99);
-    for (uint32_t i = 0; i < streamCount; ++i) {
-      sizes.push_back(coinDist(rng) < nonzeroPercent ? valueDist(rng) : 0);
-    }
-
-    std::string buffer;
-    serde::detail::writeTrailer(sizes, EncodingType::MainlyConstant, buffer);
-    const auto decoded =
-        serde::detail::readTrailerStreamSizes(buffer.data() + buffer.size());
-    EXPECT_EQ(decoded, sizes);
-  }
+  EXPECT_THROW(
+      serde::detail::readTrailerStreamMetadata(buffer.data() + buffer.size()),
+      facebook::nimble::NimbleInternalError);
 }
 
 TEST_F(EncodeDecodeTest, streamSizesEncodingType) {
@@ -883,24 +848,23 @@ TEST_F(EncodeDecodeTest, streamSizesEncodingType) {
   for (auto encodingType :
        {EncodingType::Trivial,
         EncodingType::FixedBitWidth,
-        EncodingType::Varint,
-        EncodingType::MainlyConstant}) {
+        EncodingType::Varint}) {
     SCOPED_TRACE(toString(encodingType));
 
     std::string buffer;
     serde::writeSerializationHeader(
-        buffer, SerializationVersion::kCompactRaw, 100);
+        buffer, SerializationVersion::kSerialization, 100);
     buffer.append("s0");
     buffer.append("s1");
     buffer.append("s2");
-    serde::detail::writeTrailer(sizes, encodingType, buffer);
+    serde::detail::writeTrailer(sizes, encodingType, encodingType, buffer);
 
     const char* pos = buffer.data() + 1;
     varint::readVarint32(&pos);
     auto streams = serde::detail::parseStreams(
         pos,
         buffer.data() + buffer.size(),
-        SerializationVersion::kCompactRaw,
+        SerializationVersion::kSerialization,
         pool_.get());
 
     ASSERT_EQ(streams.size(), 3);
@@ -915,18 +879,19 @@ TEST_F(EncodeDecodeTest, streamSizesEncodingTypeDefault) {
 
   std::string buffer;
   serde::writeSerializationHeader(
-      buffer, SerializationVersion::kCompactRaw, 100);
+      buffer, SerializationVersion::kSerialization, 100);
   buffer.append("a");
   buffer.append("b");
   buffer.append("c");
-  serde::detail::writeTrailer(sizes, EncodingType::Trivial, buffer);
+  serde::detail::writeTrailer(
+      sizes, EncodingType::Trivial, EncodingType::Trivial, buffer);
 
   const char* pos = buffer.data() + 1;
   varint::readVarint32(&pos);
   auto streams = serde::detail::parseStreams(
       pos,
       buffer.data() + buffer.size(),
-      SerializationVersion::kCompactRaw,
+      SerializationVersion::kSerialization,
       pool_.get());
 
   ASSERT_EQ(streams.size(), 3);
@@ -944,18 +909,18 @@ TEST_F(EncodeDecodeTest, streamSizesEncodingTypeCompactRaw) {
 
     std::string buffer;
     serde::writeSerializationHeader(
-        buffer, SerializationVersion::kCompactRaw, 100);
+        buffer, SerializationVersion::kSerialization, 100);
     buffer.append(std::string(10, 'a'));
     buffer.append(std::string(20, 'b'));
     buffer.append(std::string(30, 'c'));
-    serde::detail::writeTrailer(sizes, encodingType, buffer);
+    serde::detail::writeTrailer(sizes, encodingType, encodingType, buffer);
 
     const char* pos = buffer.data() + 1;
     varint::readVarint32(&pos);
     auto streams = serde::detail::parseStreams(
         pos,
         buffer.data() + buffer.size(),
-        SerializationVersion::kCompactRaw,
+        SerializationVersion::kSerialization,
         pool_.get());
 
     ASSERT_EQ(streams.size(), 3);
@@ -991,7 +956,7 @@ std::vector<ProjectedStream> projectStreams(
   streams.reserve(selectedStreamIndices.size());
 
   if (isCompactFormat(version)) {
-    auto streamSizes = serde::detail::readTrailerStreamSizes(end);
+    auto streamSizes = readTrailerStreamMetadataDenseForTest(end);
     const char* dataStart = pos;
 
     uint32_t dataOffset = 0;
@@ -1039,7 +1004,7 @@ std::vector<ProjectedStream> projectStreams(
 
 class ProjectStreamsTest : public ParseStreamsTest {
  protected:
-  // Helper to build a kCompactRaw buffer using writeHeader + raw data.
+  // Helper to build a kLegacyCompact buffer using writeHeader + raw data.
   // Takes (streamIndex, data) pairs and builds a dense sizes array.
   // Returns buffer starting after version byte + row count (streams position).
   std::string buildDenseBuffer(
@@ -1056,7 +1021,7 @@ class ProjectStreamsTest : public ParseStreamsTest {
 
     std::string buffer;
     serde::writeSerializationHeader(
-        buffer, SerializationVersion::kCompactRaw, 100);
+        buffer, SerializationVersion::kSerialization, 100);
 
     // Append raw stream data in index order (only non-zero sizes).
     // Sort by index to ensure correct order.
@@ -1067,7 +1032,8 @@ class ProjectStreamsTest : public ParseStreamsTest {
     }
 
     // Write trailer with encoded sizes.
-    serde::detail::writeTrailer(sizes, EncodingType::Trivial, buffer);
+    serde::detail::writeTrailer(
+        sizes, EncodingType::Trivial, EncodingType::Trivial, buffer);
 
     // Skip version byte + varint row count to get to streams position.
     const char* pos = buffer.data() + 1;
@@ -1180,7 +1146,7 @@ TEST_F(ProjectStreamsTest, denseSelectAll) {
   auto streams = projectStreams(
       buffer.data(),
       buffer.data() + buffer.size(),
-      SerializationVersion::kCompactRaw,
+      SerializationVersion::kSerialization,
       selected,
       pool_.get());
 
@@ -1201,7 +1167,7 @@ TEST_F(ProjectStreamsTest, denseSelectSubset) {
   auto streams = projectStreams(
       buffer.data(),
       buffer.data() + buffer.size(),
-      SerializationVersion::kCompactRaw,
+      SerializationVersion::kSerialization,
       selected,
       pool_.get());
 
@@ -1220,7 +1186,7 @@ TEST_F(ProjectStreamsTest, denseWithGaps) {
   auto streams = projectStreams(
       buffer.data(),
       buffer.data() + buffer.size(),
-      SerializationVersion::kCompactRaw,
+      SerializationVersion::kSerialization,
       selected,
       pool_.get());
 
@@ -1239,7 +1205,7 @@ TEST_F(ProjectStreamsTest, denseSelectedNotInInput) {
   auto streams = projectStreams(
       buffer.data(),
       buffer.data() + buffer.size(),
-      SerializationVersion::kCompactRaw,
+      SerializationVersion::kSerialization,
       selected,
       pool_.get());
 
@@ -1258,7 +1224,7 @@ TEST_F(ProjectStreamsTest, denseEmpty) {
   auto streams = projectStreams(
       buffer.data(),
       buffer.data() + buffer.size(),
-      SerializationVersion::kCompactRaw,
+      SerializationVersion::kSerialization,
       selected,
       pool_.get());
   EXPECT_TRUE(streams.empty());
@@ -1271,7 +1237,7 @@ TEST_F(ProjectStreamsTest, denseSelectFirstAndLast) {
   auto streams = projectStreams(
       buffer.data(),
       buffer.data() + buffer.size(),
-      SerializationVersion::kCompactRaw,
+      SerializationVersion::kSerialization,
       selected,
       pool_.get());
 
@@ -1290,10 +1256,11 @@ TEST_F(EncodeDecodeTest, rawTrailerRoundtrip) {
   }
 
   std::string buffer;
-  serde::detail::writeTrailer(sizes, EncodingType::Trivial, buffer);
+  serde::detail::writeTrailer(
+      sizes, EncodingType::Trivial, EncodingType::Trivial, buffer);
 
   const auto* end = buffer.data() + buffer.size();
-  auto decoded = serde::detail::readTrailerStreamSizes(end);
+  auto decoded = readTrailerStreamMetadataDenseForTest(end);
   EXPECT_EQ(decoded, sizes);
 }
 
@@ -1304,7 +1271,7 @@ TEST_F(ProjectStreamsTest, denseSkipsEmptyStreams) {
   auto streams = projectStreams(
       buffer.data(),
       buffer.data() + buffer.size(),
-      SerializationVersion::kCompactRaw,
+      SerializationVersion::kSerialization,
       selected,
       pool_.get());
 
@@ -1538,7 +1505,8 @@ class TabletChunkStripTest : public ::testing::Test {
         reinterpret_cast<const char*>(headerIOBuf.data()),
         headerIOBuf.length());
     buffer.append(streamData);
-    serde::detail::writeTrailer(sizes, EncodingType::Trivial, buffer);
+    serde::detail::writeTrailer(
+        sizes, EncodingType::Trivial, EncodingType::Trivial, buffer);
 
     // Parse via StreamDataReader.
     DeserializerOptions options{.hasHeader = true};
@@ -1749,7 +1717,8 @@ class ZstdDCtxReuseTest : public TabletChunkStripTest {
         reinterpret_cast<const char*>(headerIOBuf.data()),
         headerIOBuf.length());
     buffer.append(streamData);
-    serde::detail::writeTrailer(sizes, EncodingType::Trivial, buffer);
+    serde::detail::writeTrailer(
+        sizes, EncodingType::Trivial, EncodingType::Trivial, buffer);
 
     DeserializerOptions options{.hasHeader = true};
     StreamDataReader reader(pool_.get(), options);

--- a/dwio/nimble/tools/SerializerDumpLib.cpp
+++ b/dwio/nimble/tools/SerializerDumpLib.cpp
@@ -68,38 +68,35 @@ SerializationDump::SerializationStats SerializationDump::serializationStats(
   info.version =
       static_cast<SerializationVersion>(static_cast<uint8_t>(*pos++));
 
-  // Read row count (varint for kCompactRaw).
+  // Read row count (varint for kLegacyCompact).
   info.rowCount = varint::readVarint32(&pos);
 
-  // Parse stream sizes from trailer. Dispatch on the version byte: legacy
-  // kCompactRaw / kTablet blobs go through the frozen legacy reader; the
-  // else branch is scaffolding for the next change that will introduce a
-  // sibling reader for a new wire format.
-  std::vector<uint32_t> streamSizes;
-  if (usesLegacyTrailer(info.version)) {
-    streamSizes = serde::legacy::readLegacyTrailerStreamSizesDense(end);
-  } else {
-    NIMBLE_UNREACHABLE("unexpected non-legacy trailer version");
-  }
+  // Walk the sparse (indices, sizes) trailer directly. Emit "empty" entries
+  // for gaps between non-zero slots so the offset-indexed view is preserved.
+  // Legacy kLegacyCompact blobs are decoded via the frozen legacy reader.
+  auto [indices, sizes] = usesLegacyTrailer(info.version)
+      ? serde::legacy::readLegacyTrailerStreamMetadata(end)
+      // NOLINTNEXTLINE(facebook-hte-DetailCall)
+      : serde::detail::readTrailerStreamMetadata(end);
+  const uint32_t numStreams = indices.empty() ? 0 : indices.back() + 1;
+  info.streams.reserve(numStreams);
 
-  // Walk streams and extract encoding info.
-  info.streams.reserve(streamSizes.size());
-
-  for (size_t i = 0; i < streamSizes.size(); ++i) {
+  size_t k = 0;
+  for (uint32_t i = 0; i < numStreams; ++i) {
     StreamStats si{};
-    si.streamIndex = static_cast<uint32_t>(i);
+    si.streamIndex = i;
 
     auto label = streamLabels_.streamLabel(static_cast<offset_size>(i));
     if (!label.empty()) {
       si.schemaLabel = std::string(label);
     }
 
-    const auto streamSize = streamSizes[i];
-    if (streamSize == 0) {
+    if (k >= indices.size() || indices[k] != i) {
       si.empty = true;
       info.streams.push_back(std::move(si));
       continue;
     }
+    const uint32_t streamSize = sizes[k++];
 
     si.encodingType = static_cast<EncodingType>(static_cast<uint8_t>(pos[0]));
     si.dataType = static_cast<DataType>(static_cast<uint8_t>(pos[1]));

--- a/dwio/nimble/tools/tests/SerializerDumpLibTest.cpp
+++ b/dwio/nimble/tools/tests/SerializerDumpLibTest.cpp
@@ -46,7 +46,7 @@ TEST_F(SerializerDumpLibTest, BasicStats) {
   auto type = velox::ROW({"a", "b"}, {velox::INTEGER(), velox::BIGINT()});
 
   SerializerOptions options{
-      .version = SerializationVersion::kCompactRaw,
+      .version = SerializationVersion::kSerialization,
   };
   Serializer serializer{options, type, leafPool_.get()};
 
@@ -99,7 +99,7 @@ TEST_F(SerializerDumpLibTest, MultipleSerializations) {
   auto type = velox::ROW({"x"}, {velox::INTEGER()});
 
   SerializerOptions options{
-      .version = SerializationVersion::kCompactRaw,
+      .version = SerializationVersion::kSerialization,
   };
   Serializer serializer{options, type, leafPool_.get()};
 
@@ -142,7 +142,7 @@ TEST_F(SerializerDumpLibTest, Reset) {
   auto type = velox::ROW({"v"}, {velox::INTEGER()});
 
   SerializerOptions options{
-      .version = SerializationVersion::kCompactRaw,
+      .version = SerializationVersion::kSerialization,
   };
   Serializer serializer{options, type, leafPool_.get()};
 
@@ -170,14 +170,15 @@ TEST_F(SerializerDumpLibTest, Reset) {
 }
 
 // Verifies that SerializationDump handles varying stream counts across
-// serializations. With flat maps in kCompactRaw format, different rows can have
-// different keys, producing different numbers of streams per serialization.
+// serializations. With flat maps in kLegacyCompact format, different rows can
+// have different keys, producing different numbers of streams per
+// serialization.
 TEST_F(SerializerDumpLibTest, varyingStreamCountsWithFlatMap) {
   auto type =
       velox::ROW({{"features", velox::MAP(velox::INTEGER(), velox::BIGINT())}});
 
   const SerializerOptions options{
-      .version = SerializationVersion::kCompactRaw,
+      .version = SerializationVersion::kSerialization,
       .flatMapColumns = {{"features", {}}},
   };
   Serializer serializer{options, type, leafPool_.get()};

--- a/dwio/nimble/velox/index/NimbleIndexProjector.cpp
+++ b/dwio/nimble/velox/index/NimbleIndexProjector.cpp
@@ -416,7 +416,11 @@ folly::IOBuf NimbleIndexProjector::packStripe(size_t stripeOffset) {
   }
 
   std::string trailerBuf;
-  serde::detail::writeTrailer(streamSizes, EncodingType::Trivial, trailerBuf);
+  serde::detail::writeTrailer(
+      streamSizes,
+      EncodingType::FixedBitWidth,
+      EncodingType::FixedBitWidth,
+      trailerBuf);
 
   NIMBLE_CHECK_NOT_NULL(chain);
   auto trailer = folly::IOBuf::copyBuffer(trailerBuf);

--- a/dwio/nimble/velox/index/tests/NimbleIndexProjectorTest.cpp
+++ b/dwio/nimble/velox/index/tests/NimbleIndexProjectorTest.cpp
@@ -826,10 +826,10 @@ TEST_P(NimbleIndexProjectorTest, deserializerMultiBatchMixedRanges) {
 
 TEST_P(NimbleIndexProjectorTest, deserializerMultiBatchMixedVersions) {
   // Mix a kTablet chunk slice (projector output, narrow row range) with
-  // a kCompactRaw chunk (Serializer output, no row range) in one deserialize
+  // a kLegacyCompact chunk (Serializer output, no row range) in one deserialize
   // call. Verifies the no-range branch of the per-batch loop: when
   // batchRanges[i] is nullopt, numRowsInBatch falls back to batchRows
-  // (the full kCompactRaw batch).
+  // (the full kLegacyCompact batch).
   auto rowType = ROW({"key", "value"}, {BIGINT(), INTEGER()});
 
   const int numRows = 100;
@@ -857,25 +857,25 @@ TEST_P(NimbleIndexProjectorTest, deserializerMultiBatchMixedVersions) {
   ASSERT_EQ(result.responses[0].slices.size(), 1u);
   auto tabletOwned = result.responses[0].slices[0].cloneCoalescedAsValue();
 
-  // kCompactRaw batch: serialize a 5-row Row<INTEGER> vector matching the
+  // kLegacyCompact batch: serialize a 5-row Row<INTEGER> vector matching the
   // projected schema. The Serializer is constructed against the same velox
   // type the Deserializer will use, so the streams encode in lockstep.
   auto projectedVeloxType =
       convertToVeloxType(*projector->projectedNimbleType());
-  std::vector<int32_t> kCompactRawValues = {1000, 2000, 3000, 4000, 5000};
-  auto kCompactRawRow = vectorMaker_->rowVector(
-      {"value"}, {vectorMaker_->flatVector<int32_t>(kCompactRawValues)});
+  std::vector<int32_t> kLegacyCompactValues = {1000, 2000, 3000, 4000, 5000};
+  auto kLegacyCompactRow = vectorMaker_->rowVector(
+      {"value"}, {vectorMaker_->flatVector<int32_t>(kLegacyCompactValues)});
   SerializerOptions serOptions{
-      .version = SerializationVersion::kCompactRaw,
+      .version = SerializationVersion::kSerialization,
   };
   Serializer ser{
       serOptions,
       projectedVeloxType,
       leafPool_.get(),
   };
-  auto kCompactRawBytes = ser.serialize(
-      kCompactRawRow,
-      OrderedRanges::of(0, static_cast<uint32_t>(kCompactRawValues.size())));
+  auto kLegacyCompactBytes = ser.serialize(
+      kLegacyCompactRow,
+      OrderedRanges::of(0, static_cast<uint32_t>(kLegacyCompactValues.size())));
 
   DeserializerOptions deserOptions;
   deserOptions.hasHeader = true;
@@ -886,15 +886,16 @@ TEST_P(NimbleIndexProjectorTest, deserializerMultiBatchMixedVersions) {
       std::string_view(
           reinterpret_cast<const char*>(tabletOwned.data()),
           tabletOwned.length()),
-      kCompactRawBytes,
+      kLegacyCompactBytes,
   };
   VectorPtr output;
   deserializer.deserialize(batches, output);
 
   // Over-fetch: kTablet batch decodes its full 100 stripe rows;
-  // kCompactRaw batch contributes 5 rows. Concatenation = 105 rows. The
+  // kLegacyCompact batch contributes 5 rows. Concatenation = 105 rows. The
   // in-range subset of the kTablet batch (positions [10, 40) within the
-  // first 100) carries values[10..39]; the kCompactRaw batch's 5 rows follow.
+  // first 100) carries values[10..39]; the kLegacyCompact batch's 5 rows
+  // follow.
   ASSERT_EQ(output->size(), 105u);
   auto* rowVec = output->as<velox::RowVector>();
   auto* valueVec = rowVec->childAt(0)->as<velox::FlatVector<int32_t>>();
@@ -903,8 +904,8 @@ TEST_P(NimbleIndexProjectorTest, deserializerMultiBatchMixedVersions) {
         << "kTablet i=" << i;
   }
   for (uint32_t i = 0; i < 5; ++i) {
-    EXPECT_EQ(valueVec->valueAt(100 + i), kCompactRawValues[i])
-        << "kCompactRaw i=" << i;
+    EXPECT_EQ(valueVec->valueAt(100 + i), kLegacyCompactValues[i])
+        << "kLegacyCompact i=" << i;
   }
 }
 


### PR DESCRIPTION
Summary:

Replaces the kCompactRaw / kTablet single-array stream-sizes trailer with a two-array sparse layout where the indices and sizes axes are independently encoded.

New wire format:
  [indicesEncType:1B][indicesPayload]
  [sizesEncType:1B][sizesPayload]
  [trailerSize:u32]

Each axis-payload is self-delimiting (Varint/Delta/FixedBitWidth lead with a varint count; Trivial leads with a varint count). The trailer encodes only the non-zero entries of the conceptual dense streamSizes array — the streamCount is known to readers from the schema and to writers at emit time.

This generalizes MainlyConstant's sparse `(indices, values)` representation into the outer trailer layout, with each axis free to pick its own encoding from {Trivial, Varint, Delta, FixedBitWidth}. MainlyConstant becomes redundant for trailers and is removed from the trailer code path (it remains a valid EncodingType for stream-data encoding). Nothing kCompactRaw-encoded is in production yet, so the wire format is updated in place (no new SerializationVersion).

Notable changes:

- `Options.h`: split `SerializerOptions::streamSizesEncodingType` into `streamSizesIndicesEncodingType` + `streamSizesValuesEncodingType` (both default `FixedBitWidth`). Same split on `Projector::Options`. `getTrailerEncodingType()` no longer accepts `MainlyConstant`.

- `SerializerImpl.{h,cpp}`: factored per-encoding logic into reusable `axis::writeTrivial/Varint/Delta/FixedBitWidth` helpers and `decodeAxisTrivial/...` symmetric decoders. New top-level `writeTrailer(streamSizes, indicesEnc, sizesEnc, buffer)` walks streamSizes once to collect non-zero `(indices, values)` and emits each axis with its chosen encoding. New `readTrailerStreamSizes(end, indices, sizes)` caller-fills overload returns parallel arrays; a value-returning + IOBuf overload return `pair<vec, vec>`; `readTrailerStreamSizesDense()` scatters into a dense vector for cold-path consumers. `estimateTrailerSize(numStreams, indicesEnc, sizesEnc)` sums two upper-bound axis estimates. The dense decoder asserts `indices.size() == sizes.size()` and the per-axis payload consumed exactly the trailer bytes.

- `DeserializerImpl.h`: `StreamDataReader::iterateStreams()` on the kCompactRaw / kTablet path is always-sparse — fills `streamIndicesBuf_` / `streamSizesBuf_` (renamed member buffers) and walks the parallel arrays directly. The dense iteration branch and the `usesSparseSizes` dispatch are gone.

- `Projector.cpp` + `SerializerDumpLib.cpp`: consume `readTrailerStreamSizesDense(...)` (cold path; the dense view is materialized only at the consumer).

- rexdb writer callers (`SstBenchmarkReader.cpp`, `SSTConverterLib.cpp`, `UserSequenceReadVerification.cpp`, `NimbleEncodingEval.cpp`) and the DISCO util (`SstRewriteUtil.cpp`) updated to set both new option fields. DISCO previously set `streamSizesEncodingType = MainlyConstant`; now sets both axes to FixedBitWidth (same per-blob decode characteristics as MainlyConstant gave, plus better compression on the indices axis from the two-axis structure).

Reviewed By: xiaoxmeng, srsuryadev

Differential Revision: D108024182


