### PR TITLE
fix: Fix Nimble OSS CI format and build failures (#852)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -56,6 +56,12 @@ set(
   "Velox vector test utilities (VectorMaker)."
 )
 set(
+  VELOX_ENABLE_PARQUET
+  OFF
+  CACHE BOOL
+  "Disable Velox Parquet support for Nimble minimal builds."
+)
+set(
   VELOX_DEPENDENCY_SOURCE
   AUTO
   CACHE STRING

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/dwio/nimble/encodings/SubIntSplitConfig.h
+++ b/dwio/nimble/encodings/SubIntSplitConfig.h
@@ -27,8 +27,7 @@
 
 namespace facebook::nimble::detail::subintsplit {
 
-inline constexpr std::string_view kSplitModeConfigKey =
-    "subintsplit.mode";
+inline constexpr std::string_view kSplitModeConfigKey = "subintsplit.mode";
 inline constexpr std::string_view kSplitBoundariesConfigKey =
     "subintsplit.boundaries";
 inline constexpr std::string_view kSplitModeRecompute = "recompute";
@@ -70,16 +69,15 @@ inline std::optional<std::vector<SegmentPlan>> parseSplitBoundaries(
     const std::string_view startText = value.substr(cursor, dashPos - cursor);
     const std::string_view endText = value.substr(
         dashPos + 1,
-        semiPos == std::string_view::npos
-            ? value.size() - (dashPos + 1)
-            : semiPos - (dashPos + 1));
+        semiPos == std::string_view::npos ? value.size() - (dashPos + 1)
+                                          : semiPos - (dashPos + 1));
 
     int bitStart = 0;
     int bitEnd = 0;
-    const auto startResult =
-        std::from_chars(startText.data(), startText.data() + startText.size(), bitStart);
-    const auto endResult =
-        std::from_chars(endText.data(), endText.data() + endText.size(), bitEnd);
+    const auto startResult = std::from_chars(
+        startText.data(), startText.data() + startText.size(), bitStart);
+    const auto endResult = std::from_chars(
+        endText.data(), endText.data() + endText.size(), bitEnd);
     if (startResult.ec != std::errc{} ||
         startResult.ptr != startText.data() + startText.size() ||
         endResult.ec != std::errc{} ||
@@ -87,7 +85,8 @@ inline std::optional<std::vector<SegmentPlan>> parseSplitBoundaries(
       return std::nullopt;
     }
 
-    if (bitStart != expectedStart || bitStart < 0 || bitEnd < bitStart || bitEnd >= kBits) {
+    if (bitStart != expectedStart || bitStart < 0 || bitEnd < bitStart ||
+        bitEnd >= kBits) {
       return std::nullopt;
     }
 
@@ -110,7 +109,8 @@ inline std::unordered_map<std::string, std::string> makePreserveSplitConfig(
     std::span<const SegmentPlan> segments) {
   return {
       {std::string(kSplitModeConfigKey), std::string(kSplitModePreserve)},
-      {std::string(kSplitBoundariesConfigKey), serializeSplitBoundaries(segments)},
+      {std::string(kSplitBoundariesConfigKey),
+       serializeSplitBoundaries(segments)},
   };
 }
 

--- a/dwio/nimble/encodings/SubIntSplitCostModels.h
+++ b/dwio/nimble/encodings/SubIntSplitCostModels.h
@@ -83,11 +83,10 @@ inline double fixedBitWidthCostBits(
       static_cast<double>(storageWidthBits(bitWidth)) / 8.0;
   const double headerBits = (7.0 + baselineBytes + 1.0) * 8.0;
 
-  const uint8_t rangeWidth = m.range == 0
-      ? uint8_t{0}
-      : static_cast<uint8_t>(std::bit_width(m.range));
-  const uint8_t packedBits = std::min<uint8_t>(
-      static_cast<uint8_t>(bitWidth), rangeWidth);
+  const uint8_t rangeWidth =
+      m.range == 0 ? uint8_t{0} : static_cast<uint8_t>(std::bit_width(m.range));
+  const uint8_t packedBits =
+      std::min<uint8_t>(static_cast<uint8_t>(bitWidth), rangeWidth);
   // Round up to byte boundary (matches nimble's current FixedBitWidth impl).
   const uint8_t roundedBits = (packedBits + 7u) & ~7u;
 
@@ -133,8 +132,7 @@ inline double dictionaryCostBits(
       ? 1u
       : std::min(32u, static_cast<uint32_t>(std::bit_width(uniques - 1)));
   // Bit-packed indices rounded up to byte boundary
-  const double roundedIndexBits =
-      static_cast<double>((indexWidth + 7u) & ~7u);
+  const double roundedIndexBits = static_cast<double>((indexWidth + 7u) & ~7u);
   const double indexBits = roundedIndexBits * static_cast<double>(numValues);
   // prefix(6) + alphabetSize(4) + nested header overhead (~15 bytes)
   const double headerBits = (6.0 + 4.0 + 15.0) * 8.0;
@@ -149,16 +147,13 @@ inline double dictionaryCostBits(
 
 // RLE: run values + bit-packed run lengths.
 // Required: RunStats, MinMax
-inline double rleCostBits(
-    const SegmentMetrics& m,
-    size_t numValues,
-    int bitWidth) noexcept {
+inline double
+rleCostBits(const SegmentMetrics& m, size_t numValues, int bitWidth) noexcept {
   if (numValues == 0 || m.avgRunLength <= 0.0) {
     return 0.0;
   }
   // avgRunLength is scale-invariant, so extrapolate run count to full stream.
-  const double estimatedRuns =
-      static_cast<double>(numValues) / m.avgRunLength;
+  const double estimatedRuns = static_cast<double>(numValues) / m.avgRunLength;
   // prefix(6) + runLengthsSize(4) + nested encoding overhead (~16 bytes)
   const double headerBits = (6.0 + 4.0 + 16.0) * 8.0;
   const double runValuesBits =
@@ -202,8 +197,7 @@ inline double varintCostBits(
   const double headerBits =
       (6.0 + static_cast<double>(storageWidthBits(bitWidth)) / 8.0) * 8.0;
   return headerBits +
-      static_cast<double>(varintBytes) * 8.0 *
-      static_cast<double>(numValues);
+      static_cast<double>(varintBytes) * 8.0 * static_cast<double>(numValues);
 }
 
 // Evaluate all cost models and return the minimum cost in bits.

--- a/dwio/nimble/encodings/SubIntSplitEncoding.h
+++ b/dwio/nimble/encodings/SubIntSplitEncoding.h
@@ -27,15 +27,15 @@
 #include "dwio/nimble/common/Exceptions.h"
 #include "dwio/nimble/common/Types.h"
 #include "dwio/nimble/common/Vector.h"
+#include "dwio/nimble/encodings/SubIntSplitConfig.h"
+#include "dwio/nimble/encodings/SubIntSplitSampler.h"
+#include "dwio/nimble/encodings/SubIntSplitSelector.h"
 #include "dwio/nimble/encodings/common/Encoding.h"
 #include "dwio/nimble/encodings/common/EncodingFactory.h"
 #include "dwio/nimble/encodings/common/EncodingPrimitives.h"
 #include "dwio/nimble/encodings/common/EncodingType.h"
 #include "dwio/nimble/encodings/selection/EncodingIdentifier.h"
 #include "dwio/nimble/encodings/selection/EncodingSelection.h"
-#include "dwio/nimble/encodings/SubIntSplitConfig.h"
-#include "dwio/nimble/encodings/SubIntSplitSampler.h"
-#include "dwio/nimble/encodings/SubIntSplitSelector.h"
 #include "velox/common/memory/Memory.h"
 #ifdef __AVX2__
 #include <immintrin.h>
@@ -118,9 +118,12 @@ class SubIntSplitEncoding
 
   // Return the storage byte width for a section of the given bit width.
   static constexpr uint8_t sectionStorageBytes(int bitWidth) noexcept {
-    if (bitWidth <= 8) return 1;
-    if (bitWidth <= 16) return 2;
-    if (bitWidth <= 32) return 4;
+    if (bitWidth <= 8)
+      return 1;
+    if (bitWidth <= 16)
+      return 2;
+    if (bitWidth <= 32)
+      return 4;
     return 8;
   }
 
@@ -152,7 +155,8 @@ class SubIntSplitEncoding
 //
 
 namespace detail {
-inline constexpr uint32_t kSubIntSplitSectionHeaderSize = 6; // bitStart+bitEnd+size
+inline constexpr uint32_t kSubIntSplitSectionHeaderSize =
+    6; // bitStart+bitEnd+size
 
 inline uint32_t subIntSplitSpecificHeaderSize(uint8_t splitCount) noexcept {
   return 2u + static_cast<uint32_t>(splitCount) * kSubIntSplitSectionHeaderSize;
@@ -195,9 +199,7 @@ SubIntSplitEncoding<T>::SubIntSplitEncoding(
     sec.mask = (width >= 64) ? ~uint64_t{0} : ((uint64_t{1} << width) - 1);
     sec.storageBytes = sectionStorageBytes(width);
     sec.encoding = factory.create(
-        *this->pool_,
-        {pos, meta[s].encodedSize},
-        stringBufferFactory);
+        *this->pool_, {pos, meta[s].encodedSize}, stringBufferFactory);
     pos += meta[s].encodedSize;
   }
 }
@@ -242,24 +244,29 @@ void SubIntSplitEncoding<T>::accumulateSection(
       // Widening into 64-bit output
       // ----------------------------------------------------------------
       const __m128i vshift = _mm_cvtsi64_si128(static_cast<int64_t>(shift));
-      const __m256i vmask  = _mm256_set1_epi64x(static_cast<int64_t>(mask));
+      const __m256i vmask = _mm256_set1_epi64x(static_cast<int64_t>(mask));
 
       if constexpr (sizeof(SectionT) == 1) {
         // uint8 → uint64: _mm256_cvtepu8_epi64 processes 4 elements.
         uint32_t i = 0;
         for (; i + 4 <= count; i += 4) {
-          _mm_prefetch(reinterpret_cast<const char*>(src + i + 32), _MM_HINT_T1);
-          _mm_prefetch(reinterpret_cast<const char*>(dst + i + 32), _MM_HINT_T1);
+          _mm_prefetch(
+              reinterpret_cast<const char*>(src + i + 32), _MM_HINT_T1);
+          _mm_prefetch(
+              reinterpret_cast<const char*>(dst + i + 32), _MM_HINT_T1);
           int32_t tmp;
           std::memcpy(&tmp, src + i, 4);
           __m256i vs = _mm256_cvtepu8_epi64(_mm_cvtsi32_si128(tmp));
           vs = _mm256_and_si256(vs, vmask);
-          if (shift) vs = _mm256_sll_epi64(vs, vshift);
+          if (shift)
+            vs = _mm256_sll_epi64(vs, vshift);
           if constexpr (IsFirst) {
             _mm256_storeu_si256(reinterpret_cast<__m256i*>(dst + i), vs);
           } else {
-            __m256i vd = _mm256_loadu_si256(reinterpret_cast<const __m256i*>(dst + i));
-            _mm256_storeu_si256(reinterpret_cast<__m256i*>(dst + i), _mm256_or_si256(vd, vs));
+            __m256i vd =
+                _mm256_loadu_si256(reinterpret_cast<const __m256i*>(dst + i));
+            _mm256_storeu_si256(
+                reinterpret_cast<__m256i*>(dst + i), _mm256_or_si256(vd, vs));
           }
         }
         for (; i < count; ++i) {
@@ -274,17 +281,22 @@ void SubIntSplitEncoding<T>::accumulateSection(
         // uint16 → uint64: _mm256_cvtepu16_epi64 processes 4 elements.
         uint32_t i = 0;
         for (; i + 4 <= count; i += 4) {
-          _mm_prefetch(reinterpret_cast<const char*>(src + i + 32), _MM_HINT_T1);
-          _mm_prefetch(reinterpret_cast<const char*>(dst + i + 32), _MM_HINT_T1);
+          _mm_prefetch(
+              reinterpret_cast<const char*>(src + i + 32), _MM_HINT_T1);
+          _mm_prefetch(
+              reinterpret_cast<const char*>(dst + i + 32), _MM_HINT_T1);
           __m256i vs = _mm256_cvtepu16_epi64(
               _mm_loadl_epi64(reinterpret_cast<const __m128i*>(src + i)));
           vs = _mm256_and_si256(vs, vmask);
-          if (shift) vs = _mm256_sll_epi64(vs, vshift);
+          if (shift)
+            vs = _mm256_sll_epi64(vs, vshift);
           if constexpr (IsFirst) {
             _mm256_storeu_si256(reinterpret_cast<__m256i*>(dst + i), vs);
           } else {
-            __m256i vd = _mm256_loadu_si256(reinterpret_cast<const __m256i*>(dst + i));
-            _mm256_storeu_si256(reinterpret_cast<__m256i*>(dst + i), _mm256_or_si256(vd, vs));
+            __m256i vd =
+                _mm256_loadu_si256(reinterpret_cast<const __m256i*>(dst + i));
+            _mm256_storeu_si256(
+                reinterpret_cast<__m256i*>(dst + i), _mm256_or_si256(vd, vs));
           }
         }
         for (; i < count; ++i) {
@@ -299,17 +311,22 @@ void SubIntSplitEncoding<T>::accumulateSection(
         // uint32 → uint64: _mm256_cvtepu32_epi64 processes 4 elements.
         uint32_t i = 0;
         for (; i + 4 <= count; i += 4) {
-          _mm_prefetch(reinterpret_cast<const char*>(src + i + 16), _MM_HINT_T1);
-          _mm_prefetch(reinterpret_cast<const char*>(dst + i + 32), _MM_HINT_T1);
+          _mm_prefetch(
+              reinterpret_cast<const char*>(src + i + 16), _MM_HINT_T1);
+          _mm_prefetch(
+              reinterpret_cast<const char*>(dst + i + 32), _MM_HINT_T1);
           __m256i vs = _mm256_cvtepu32_epi64(
               _mm_loadu_si128(reinterpret_cast<const __m128i*>(src + i)));
           vs = _mm256_and_si256(vs, vmask);
-          if (shift) vs = _mm256_sll_epi64(vs, vshift);
+          if (shift)
+            vs = _mm256_sll_epi64(vs, vshift);
           if constexpr (IsFirst) {
             _mm256_storeu_si256(reinterpret_cast<__m256i*>(dst + i), vs);
           } else {
-            __m256i vd = _mm256_loadu_si256(reinterpret_cast<const __m256i*>(dst + i));
-            _mm256_storeu_si256(reinterpret_cast<__m256i*>(dst + i), _mm256_or_si256(vd, vs));
+            __m256i vd =
+                _mm256_loadu_si256(reinterpret_cast<const __m256i*>(dst + i));
+            _mm256_storeu_si256(
+                reinterpret_cast<__m256i*>(dst + i), _mm256_or_si256(vd, vs));
           }
         }
         for (; i < count; ++i) {
@@ -326,24 +343,29 @@ void SubIntSplitEncoding<T>::accumulateSection(
       // Widening into 32-bit output
       // ----------------------------------------------------------------
       const __m128i vshift = _mm_cvtsi32_si128(static_cast<int32_t>(shift));
-      const __m256i vmask  = _mm256_set1_epi32(static_cast<int32_t>(mask));
+      const __m256i vmask = _mm256_set1_epi32(static_cast<int32_t>(mask));
 
       if constexpr (sizeof(SectionT) == 1) {
         // uint8 → uint32: _mm256_cvtepu8_epi32 processes 8 elements.
         uint32_t i = 0;
         for (; i + 8 <= count; i += 8) {
-          _mm_prefetch(reinterpret_cast<const char*>(src + i + 64), _MM_HINT_T1);
-          _mm_prefetch(reinterpret_cast<const char*>(dst + i + 32), _MM_HINT_T1);
+          _mm_prefetch(
+              reinterpret_cast<const char*>(src + i + 64), _MM_HINT_T1);
+          _mm_prefetch(
+              reinterpret_cast<const char*>(dst + i + 32), _MM_HINT_T1);
           int64_t tmp;
           std::memcpy(&tmp, src + i, 8);
           __m256i vs = _mm256_cvtepu8_epi32(_mm_cvtsi64_si128(tmp));
           vs = _mm256_and_si256(vs, vmask);
-          if (shift) vs = _mm256_sll_epi32(vs, vshift);
+          if (shift)
+            vs = _mm256_sll_epi32(vs, vshift);
           if constexpr (IsFirst) {
             _mm256_storeu_si256(reinterpret_cast<__m256i*>(dst + i), vs);
           } else {
-            __m256i vd = _mm256_loadu_si256(reinterpret_cast<const __m256i*>(dst + i));
-            _mm256_storeu_si256(reinterpret_cast<__m256i*>(dst + i), _mm256_or_si256(vd, vs));
+            __m256i vd =
+                _mm256_loadu_si256(reinterpret_cast<const __m256i*>(dst + i));
+            _mm256_storeu_si256(
+                reinterpret_cast<__m256i*>(dst + i), _mm256_or_si256(vd, vs));
           }
         }
         for (; i < count; ++i) {
@@ -358,17 +380,22 @@ void SubIntSplitEncoding<T>::accumulateSection(
         // uint16 → uint32: _mm256_cvtepu16_epi32 processes 8 elements.
         uint32_t i = 0;
         for (; i + 8 <= count; i += 8) {
-          _mm_prefetch(reinterpret_cast<const char*>(src + i + 32), _MM_HINT_T1);
-          _mm_prefetch(reinterpret_cast<const char*>(dst + i + 32), _MM_HINT_T1);
+          _mm_prefetch(
+              reinterpret_cast<const char*>(src + i + 32), _MM_HINT_T1);
+          _mm_prefetch(
+              reinterpret_cast<const char*>(dst + i + 32), _MM_HINT_T1);
           __m256i vs = _mm256_cvtepu16_epi32(
               _mm_loadu_si128(reinterpret_cast<const __m128i*>(src + i)));
           vs = _mm256_and_si256(vs, vmask);
-          if (shift) vs = _mm256_sll_epi32(vs, vshift);
+          if (shift)
+            vs = _mm256_sll_epi32(vs, vshift);
           if constexpr (IsFirst) {
             _mm256_storeu_si256(reinterpret_cast<__m256i*>(dst + i), vs);
           } else {
-            __m256i vd = _mm256_loadu_si256(reinterpret_cast<const __m256i*>(dst + i));
-            _mm256_storeu_si256(reinterpret_cast<__m256i*>(dst + i), _mm256_or_si256(vd, vs));
+            __m256i vd =
+                _mm256_loadu_si256(reinterpret_cast<const __m256i*>(dst + i));
+            _mm256_storeu_si256(
+                reinterpret_cast<__m256i*>(dst + i), _mm256_or_si256(vd, vs));
           }
         }
         for (; i < count; ++i) {
@@ -384,7 +411,8 @@ void SubIntSplitEncoding<T>::accumulateSection(
 #endif // __AVX2__
 
   // Scalar path: same-width sections (SectionT == physicalType), or builds
-  // without AVX2, or narrow cases not covered by the AVX2 specialisations above.
+  // without AVX2, or narrow cases not covered by the AVX2 specialisations
+  // above.
   // __restrict__ on the parameters allows the compiler to auto-vectorise this
   // loop for same-width cases (e.g. uint32_t → uint32_t, uint64_t → uint64_t).
   if constexpr (IsFirst) {
@@ -431,36 +459,44 @@ void SubIntSplitEncoding<T>::materialize(uint32_t rowCount, void* buffer) {
           auto* scratch = reinterpret_cast<uint8_t*>(scratchBuf_.data());
           sec.encoding->materialize(chunkCount, scratch);
           if (isFirst)
-            accumulateSection<uint8_t, true>(scratch, chunkOutput, chunkCount, mask, shift);
+            accumulateSection<uint8_t, true>(
+                scratch, chunkOutput, chunkCount, mask, shift);
           else
-            accumulateSection<uint8_t, false>(scratch, chunkOutput, chunkCount, mask, shift);
+            accumulateSection<uint8_t, false>(
+                scratch, chunkOutput, chunkCount, mask, shift);
           break;
         }
         case 2: {
           auto* scratch = reinterpret_cast<uint16_t*>(scratchBuf_.data());
           sec.encoding->materialize(chunkCount, scratch);
           if (isFirst)
-            accumulateSection<uint16_t, true>(scratch, chunkOutput, chunkCount, mask, shift);
+            accumulateSection<uint16_t, true>(
+                scratch, chunkOutput, chunkCount, mask, shift);
           else
-            accumulateSection<uint16_t, false>(scratch, chunkOutput, chunkCount, mask, shift);
+            accumulateSection<uint16_t, false>(
+                scratch, chunkOutput, chunkCount, mask, shift);
           break;
         }
         case 4: {
           auto* scratch = reinterpret_cast<uint32_t*>(scratchBuf_.data());
           sec.encoding->materialize(chunkCount, scratch);
           if (isFirst)
-            accumulateSection<uint32_t, true>(scratch, chunkOutput, chunkCount, mask, shift);
+            accumulateSection<uint32_t, true>(
+                scratch, chunkOutput, chunkCount, mask, shift);
           else
-            accumulateSection<uint32_t, false>(scratch, chunkOutput, chunkCount, mask, shift);
+            accumulateSection<uint32_t, false>(
+                scratch, chunkOutput, chunkCount, mask, shift);
           break;
         }
         case 8: {
           auto* scratch = reinterpret_cast<uint64_t*>(scratchBuf_.data());
           sec.encoding->materialize(chunkCount, scratch);
           if (isFirst)
-            accumulateSection<uint64_t, true>(scratch, chunkOutput, chunkCount, mask, shift);
+            accumulateSection<uint64_t, true>(
+                scratch, chunkOutput, chunkCount, mask, shift);
           else
-            accumulateSection<uint64_t, false>(scratch, chunkOutput, chunkCount, mask, shift);
+            accumulateSection<uint64_t, false>(
+                scratch, chunkOutput, chunkCount, mask, shift);
           break;
         }
         default:
@@ -595,7 +631,8 @@ std::string_view SubIntSplitEncoding<T>::encode(
         }
         encoded = selection.template encodeNested<uint8_t>(
             static_cast<NestedEncodingIdentifier>(s),
-            std::span<const uint8_t>(sectionValues.data(), sectionValues.size()),
+            std::span<const uint8_t>(
+                sectionValues.data(), sectionValues.size()),
             tempBuffer,
             options);
         break;
@@ -697,13 +734,13 @@ std::string_view SubIntSplitEncoding<T>::encode(
 template <typename T>
 std::string SubIntSplitEncoding<T>::debugString(int offset) const {
   std::string indent(offset, ' ');
-  std::string result = indent + "SubIntSplitEncoding sections=" +
-      std::to_string(sections_.size()) + "\n";
+  std::string result = indent +
+      "SubIntSplitEncoding sections=" + std::to_string(sections_.size()) + "\n";
   for (size_t s = 0; s < sections_.size(); ++s) {
     const auto& sec = sections_[s];
     result += indent + "  [" + std::to_string(sec.bitStart) + ".." +
-        std::to_string(sec.bitEnd) + "] storageBytes=" +
-        std::to_string(sec.storageBytes) + "\n";
+        std::to_string(sec.bitEnd) +
+        "] storageBytes=" + std::to_string(sec.storageBytes) + "\n";
     result += sec.encoding->debugString(offset + 4);
     result += "\n";
   }

--- a/dwio/nimble/encodings/SubIntSplitMetrics.h
+++ b/dwio/nimble/encodings/SubIntSplitMetrics.h
@@ -67,7 +67,8 @@ struct SegmentMetrics {
 // and uses a running prev-value comparison for run counting.
 class MetricCollector {
  public:
-  static constexpr size_t kUniqueCountCap = 1 << 14; // 16K cap (lighter than full HLL)
+  static constexpr size_t kUniqueCountCap = 1
+      << 14; // 16K cap (lighter than full HLL)
 
   SegmentMetrics compute(
       const std::vector<uint64_t>& values,

--- a/dwio/nimble/encodings/SubIntSplitSelector.h
+++ b/dwio/nimble/encodings/SubIntSplitSelector.h
@@ -140,7 +140,8 @@ inline SelectorResult selectSplits(
     for (int r = l; r < sz; ++r) {
       extractor.extend(r);
       const std::vector<uint64_t>& segValues = extractor.values();
-      const SegmentMetrics metrics = collector.compute(segValues, requiredFlags);
+      const SegmentMetrics metrics =
+          collector.compute(segValues, requiredFlags);
       const int bitWidth = r - l + 1;
 
       EncodingType bestEnc = EncodingType::Trivial;
@@ -148,8 +149,8 @@ inline SelectorResult selectSplits(
           bestCostBits(metrics, numSamples, bitWidth, bestEnc);
 
       // Scale to full stream
-      const double fullCost = perSampleCost *
-          static_cast<double>(fullCount) / static_cast<double>(numSamples);
+      const double fullCost = perSampleCost * static_cast<double>(fullCount) /
+          static_cast<double>(numSamples);
 
       bestCost[l * sz + r] = {fullCost, bestEnc};
     }

--- a/dwio/nimble/encodings/benchmarks/FixedBitWidthBenchmark.cpp
+++ b/dwio/nimble/encodings/benchmarks/FixedBitWidthBenchmark.cpp
@@ -99,21 +99,21 @@ void observeWrittenBuffer(
 template <typename T>
 std::string encodeFixedBitWidth(
     Buffer& buffer,
-  const Vector<T>& data,
-  const Encoding::Options& options = {}) {
+    const Vector<T>& data,
+    const Encoding::Options& options = {}) {
   using physicalType = typename TypeTraits<T>::physicalType;
 
   auto physicalValues = std::span<const physicalType>(
-    reinterpret_cast<const physicalType*>(data.data()), data.size());
+      reinterpret_cast<const physicalType*>(data.data()), data.size());
   EncodingSelectionResult selectionResult{
-    .encodingType = EncodingType::FixedBitWidth};
+      .encodingType = EncodingType::FixedBitWidth};
   auto selection = EncodingSelection<physicalType>{
-    std::move(selectionResult),
-    Statistics<physicalType>::create(physicalValues),
-    nullptr};
+      std::move(selectionResult),
+      Statistics<physicalType>::create(physicalValues),
+      nullptr};
 
   auto encoded = FixedBitWidthEncoding<T>::encode(
-    selection, physicalValues, buffer, options);
+      selection, physicalValues, buffer, options);
   return std::string{encoded.data(), encoded.size()};
 }
 

--- a/dwio/nimble/encodings/tests/ConstantEncodingTest.cpp
+++ b/dwio/nimble/encodings/tests/ConstantEncodingTest.cpp
@@ -56,10 +56,11 @@ class ConstantEncodingTest : public ::testing::Test {
     if constexpr (std::is_same_v<T, double>) {
       const double dNaN0 = std::numeric_limits<double>::quiet_NaN();
       const double dNaN1 = std::numeric_limits<double>::signaling_NaN();
-      const double dNaN2 = nimble::EncodingPhysicalType<double>::
-          asEncodingLogicalType((nimble::EncodingPhysicalType<double>::
-                                     asEncodingPhysicalType(dNaN0) |
-                                 0x3));
+      const double dNaN2 =
+          nimble::EncodingPhysicalType<double>::asEncodingLogicalType(
+              (nimble::EncodingPhysicalType<double>::asEncodingPhysicalType(
+                   dNaN0) |
+               0x3));
       return {
           toVector({0.0}),
           toVector({0.0, 0.00}),
@@ -71,10 +72,11 @@ class ConstantEncodingTest : public ::testing::Test {
     } else if constexpr (std::is_same_v<T, float>) {
       const float fNaN0 = std::numeric_limits<float>::quiet_NaN();
       const float fNaN1 = std::numeric_limits<float>::signaling_NaN();
-      const float fNaN2 = nimble::EncodingPhysicalType<float>::
-        asEncodingLogicalType((nimble::EncodingPhysicalType<float>::
-                     asEncodingPhysicalType(fNaN0) |
-                   0x3));
+      const float fNaN2 =
+          nimble::EncodingPhysicalType<float>::asEncodingLogicalType(
+              (nimble::EncodingPhysicalType<float>::asEncodingPhysicalType(
+                   fNaN0) |
+               0x3));
       return {
           toVector({0.0f}),
           toVector({0.0f, 0.00f}),
@@ -101,10 +103,11 @@ class ConstantEncodingTest : public ::testing::Test {
           toVector({dNaN0, dNaN0, dNaN1})};
     } else if constexpr (std::is_same_v<T, float>) {
       const float fNaN0 = std::numeric_limits<float>::quiet_NaN();
-      const float fNaN2 = nimble::EncodingPhysicalType<float>::
-          asEncodingLogicalType((nimble::EncodingPhysicalType<float>::
-                                     asEncodingPhysicalType(fNaN0) |
-                                 0x3));
+      const float fNaN2 =
+          nimble::EncodingPhysicalType<float>::asEncodingLogicalType(
+              (nimble::EncodingPhysicalType<float>::asEncodingPhysicalType(
+                   fNaN0) |
+               0x3));
       return {
           toVector({-0.0f, -0.00f, -0.0000001f}),
           toVector({-2.1f, -2.1f, -2.1f, -2.1f, -2.2f}),

--- a/dwio/nimble/encodings/tests/EncodingLayoutTest.cpp
+++ b/dwio/nimble/encodings/tests/EncodingLayoutTest.cpp
@@ -20,8 +20,8 @@
 #ifdef NIMBLE_ENABLE_EXPERIMENTAL_ENCODINGS
 #include "dwio/nimble/encodings/SubIntSplitConfig.h"
 #endif
-#include "dwio/nimble/encodings/selection/EncodingSelectionPolicy.h"
 #include "dwio/nimble/encodings/common/EncodingFactory.h"
+#include "dwio/nimble/encodings/selection/EncodingSelectionPolicy.h"
 #include "dwio/nimble/tools/EncodingUtilities.h"
 #include "velox/common/memory/Memory.h"
 
@@ -448,25 +448,26 @@ TEST(EncodingLayoutTests, SubIntSplitCapture) {
   }
 
   auto encoding = nimble::EncodingFactory::encode<int64_t>(
-      std::make_unique<ForceSubIntSplitPolicy<int64_t>>(),
-      data,
-      buffer);
+      std::make_unique<ForceSubIntSplitPolicy<int64_t>>(), data, buffer);
 
   // Capture must succeed and not throw.
   auto captured = nimble::EncodingLayoutCapture::capture(encoding);
   ASSERT_EQ(captured.encodingType(), nimble::EncodingType::SubIntSplit);
   ASSERT_GT(captured.childrenCount(), 0u);
-    EXPECT_EQ(
-      captured.config().get(std::string(nimble::detail::subintsplit::kSplitModeConfigKey)),
+  EXPECT_EQ(
+      captured.config().get(
+          std::string(nimble::detail::subintsplit::kSplitModeConfigKey)),
       nimble::detail::subintsplit::kSplitModePreserve);
-    ASSERT_TRUE(captured.config().get(
-      std::string(nimble::detail::subintsplit::kSplitBoundariesConfigKey)).has_value());
+  ASSERT_TRUE(
+      captured.config()
+          .get(
+              std::string(
+                  nimble::detail::subintsplit::kSplitBoundariesConfigKey))
+          .has_value());
 
   // The encoded stream must round-trip through the encoding factory.
   auto decoded = nimble::EncodingFactory().create(
-      *defaultPool,
-      encoding,
-      [](uint32_t) { return nullptr; });
+      *defaultPool, encoding, [](uint32_t) { return nullptr; });
   nimble::Vector<int64_t> decodedValues{defaultPool.get()};
   decodedValues.resize(data.size());
   decoded->materialize(data.size(), decodedValues.data());
@@ -516,8 +517,7 @@ TEST(EncodingLayoutTests, SubIntSplitCapture) {
   EXPECT_EQ(*deserializedBoundaries, *capturedBoundaries);
 
   // Each child must be non-nullopt (all sections were encoded).
-  for (nimble::NestedEncodingIdentifier id = 0;
-       id < captured.childrenCount();
+  for (nimble::NestedEncodingIdentifier id = 0; id < captured.childrenCount();
        ++id) {
     EXPECT_TRUE(captured.child(id).has_value());
   }
@@ -526,7 +526,7 @@ TEST(EncodingLayoutTests, SubIntSplitCapture) {
 TEST(EncodingLayoutTests, SubIntSplitPreserveBoundariesReplay) {
   nimble::EncodingSelectionPolicyFactory encodingSelectionPolicyFactory =
       [encodingFactory = nimble::ManualEncodingSelectionPolicyFactory{}](
-        nimble::DataType dataType)
+          nimble::DataType dataType)
       -> std::unique_ptr<nimble::EncodingSelectionPolicyBase> {
     return encodingFactory.createPolicy(dataType);
   };
@@ -553,9 +553,7 @@ TEST(EncodingLayoutTests, SubIntSplitPreserveBoundariesReplay) {
 
   auto encoding = nimble::EncodingFactory::encode<int64_t>(
       std::make_unique<nimble::ReplayedEncodingSelectionPolicy<int64_t>>(
-          preserveLayout,
-          std::nullopt,
-          encodingSelectionPolicyFactory),
+          preserveLayout, std::nullopt, encodingSelectionPolicyFactory),
       data,
       buffer);
 

--- a/dwio/nimble/encodings/tests/MainlyConstantEncodingTest.cpp
+++ b/dwio/nimble/encodings/tests/MainlyConstantEncodingTest.cpp
@@ -46,20 +46,21 @@ class MainlyConstantEncodingTest : public ::testing::Test {
 
   template <typename T>
   std::vector<nimble::Vector<T>> prepareValues() {
-    auto toVector = [this]<typename ValueType>(
-                         std::initializer_list<ValueType> values) {
-      nimble::Vector<ValueType> vector{pool_.get()};
-      vector.insert(vector.end(), values.begin(), values.end());
-      return vector;
-    };
+    auto toVector =
+        [this]<typename ValueType>(std::initializer_list<ValueType> values) {
+          nimble::Vector<ValueType> vector{pool_.get()};
+          vector.insert(vector.end(), values.begin(), values.end());
+          return vector;
+        };
 
     if constexpr (std::is_same_v<T, double>) {
       const double dNaN0 = std::numeric_limits<double>::quiet_NaN();
       const double dNaN1 = std::numeric_limits<double>::signaling_NaN();
-      const double dNaN2 = nimble::EncodingPhysicalType<double>::
-          asEncodingLogicalType((nimble::EncodingPhysicalType<double>::
-                                     asEncodingPhysicalType(dNaN0) |
-                                 0x3));
+      const double dNaN2 =
+          nimble::EncodingPhysicalType<double>::asEncodingLogicalType(
+              (nimble::EncodingPhysicalType<double>::asEncodingPhysicalType(
+                   dNaN0) |
+               0x3));
       return {
           toVector({0.0}),
           toVector({0.0, 0.00, 0.12}),
@@ -68,10 +69,11 @@ class MainlyConstantEncodingTest : public ::testing::Test {
     } else if constexpr (std::is_same_v<T, float>) {
       const float fNaN0 = std::numeric_limits<float>::quiet_NaN();
       const float fNaN1 = std::numeric_limits<float>::signaling_NaN();
-      const float fNaN2 = nimble::EncodingPhysicalType<float>::
-          asEncodingLogicalType((nimble::EncodingPhysicalType<float>::
-                                     asEncodingPhysicalType(fNaN0) |
-                                 0x3));
+      const float fNaN2 =
+          nimble::EncodingPhysicalType<float>::asEncodingLogicalType(
+              (nimble::EncodingPhysicalType<float>::asEncodingPhysicalType(
+                   fNaN0) |
+               0x3));
       return {
           toVector({0.0f}),
           toVector({0.0f, 0.00f, 0.12f}),

--- a/dwio/nimble/encodings/tests/RLEEncodingTest.cpp
+++ b/dwio/nimble/encodings/tests/RLEEncodingTest.cpp
@@ -56,81 +56,89 @@ class RleEncodingTest : public ::testing::Test {
     if constexpr (std::is_same_v<T, double>) {
       const double dNaN0 = std::numeric_limits<double>::quiet_NaN();
       const double dNaN1 = std::numeric_limits<double>::signaling_NaN();
-      const double dNaN2 = nimble::EncodingPhysicalType<double>::
-        asEncodingLogicalType((nimble::EncodingPhysicalType<double>::
-                     asEncodingPhysicalType(dNaN0) |
-                   0x3));
-      const double dNaN3 = nimble::EncodingPhysicalType<double>::
-        asEncodingLogicalType((nimble::EncodingPhysicalType<double>::
-                     asEncodingPhysicalType(dNaN0) |
-                   0x5));
+      const double dNaN2 =
+          nimble::EncodingPhysicalType<double>::asEncodingLogicalType(
+              (nimble::EncodingPhysicalType<double>::asEncodingPhysicalType(
+                   dNaN0) |
+               0x3));
+      const double dNaN3 =
+          nimble::EncodingPhysicalType<double>::asEncodingLogicalType(
+              (nimble::EncodingPhysicalType<double>::asEncodingPhysicalType(
+                   dNaN0) |
+               0x5));
       return {
-        toVector({0.0, -0.0}),
-        toVector({-0.0, -0.0, -0.0, -0.0, -0.0, -0.0, -0.0, -0.0, -0.0, -0.0}),
-        toVector({-0.0, -0.0, -0.0, +0.0, -0.0, +0.0, -0.0, -0.0, -0.0, -0.0}),
-        toVector({-2.1, -0.0, -0.0, 3.54, 9.87, -0.0, -0.0, -0.0, -0.0, 10.6}),
-        toVector({0.00, 1.11, 2.22, 3.33, 4.44, 5.55, 6.66, 7.77, 8.88, 9.99}),
-        toVector(
-          {dNaN0, dNaN0, dNaN0, dNaN1, dNaN1, dNaN2, dNaN3, dNaN3, dNaN0})};
+          toVector({0.0, -0.0}),
+          toVector(
+              {-0.0, -0.0, -0.0, -0.0, -0.0, -0.0, -0.0, -0.0, -0.0, -0.0}),
+          toVector(
+              {-0.0, -0.0, -0.0, +0.0, -0.0, +0.0, -0.0, -0.0, -0.0, -0.0}),
+          toVector(
+              {-2.1, -0.0, -0.0, 3.54, 9.87, -0.0, -0.0, -0.0, -0.0, 10.6}),
+          toVector(
+              {0.00, 1.11, 2.22, 3.33, 4.44, 5.55, 6.66, 7.77, 8.88, 9.99}),
+          toVector(
+              {dNaN0, dNaN0, dNaN0, dNaN1, dNaN1, dNaN2, dNaN3, dNaN3, dNaN0})};
     } else if constexpr (std::is_same_v<T, float>) {
       const float fNaN0 = std::numeric_limits<float>::quiet_NaN();
       const float fNaN1 = std::numeric_limits<float>::signaling_NaN();
-      const float fNaN2 = nimble::EncodingPhysicalType<float>::
-        asEncodingLogicalType((nimble::EncodingPhysicalType<float>::
-                     asEncodingPhysicalType(fNaN0) |
-                   0x3));
-      const float fNaN3 = nimble::EncodingPhysicalType<float>::
-        asEncodingLogicalType((nimble::EncodingPhysicalType<float>::
-                     asEncodingPhysicalType(fNaN0) |
-                   0x5));
+      const float fNaN2 =
+          nimble::EncodingPhysicalType<float>::asEncodingLogicalType(
+              (nimble::EncodingPhysicalType<float>::asEncodingPhysicalType(
+                   fNaN0) |
+               0x3));
+      const float fNaN3 =
+          nimble::EncodingPhysicalType<float>::asEncodingLogicalType(
+              (nimble::EncodingPhysicalType<float>::asEncodingPhysicalType(
+                   fNaN0) |
+               0x5));
       return {
-        toVector({0.0f, -0.0f}),
-        toVector(
-          {-0.0f,
-           -0.0f,
-           -0.0f,
-           -0.0f,
-           -0.0f,
-           -0.0f,
-           -0.0f,
-           -0.0f,
-           -0.0f,
-           -0.0f}),
-        toVector(
-          {-0.0f,
-           -0.0f,
-           -0.0f,
-           +0.0f,
-           -0.0f,
-           +0.0f,
-           -0.0f,
-           -0.0f,
-           -0.0f,
-           -0.0f}),
-        toVector(
-          {-2.1f,
-           -0.0f,
-           -0.0f,
-           3.54f,
-           9.87f,
-           -0.0f,
-           -0.0f,
-           -0.0f,
-           -0.0f,
-           10.6f}),
-        toVector(
-          {0.00f,
-           1.11f,
-           2.22f,
-           3.33f,
-           4.44f,
-           5.55f,
-           6.66f,
-           7.77f,
-           8.88f,
-           9.99f}),
-        toVector(
-          {fNaN0, fNaN0, fNaN0, fNaN1, fNaN1, fNaN2, fNaN3, fNaN3, fNaN0})};
+          toVector({0.0f, -0.0f}),
+          toVector(
+              {-0.0f,
+               -0.0f,
+               -0.0f,
+               -0.0f,
+               -0.0f,
+               -0.0f,
+               -0.0f,
+               -0.0f,
+               -0.0f,
+               -0.0f}),
+          toVector(
+              {-0.0f,
+               -0.0f,
+               -0.0f,
+               +0.0f,
+               -0.0f,
+               +0.0f,
+               -0.0f,
+               -0.0f,
+               -0.0f,
+               -0.0f}),
+          toVector(
+              {-2.1f,
+               -0.0f,
+               -0.0f,
+               3.54f,
+               9.87f,
+               -0.0f,
+               -0.0f,
+               -0.0f,
+               -0.0f,
+               10.6f}),
+          toVector(
+              {0.00f,
+               1.11f,
+               2.22f,
+               3.33f,
+               4.44f,
+               5.55f,
+               6.66f,
+               7.77f,
+               8.88f,
+               9.99f}),
+          toVector(
+              {fNaN0, fNaN0, fNaN0, fNaN1, fNaN1, fNaN2, fNaN3, fNaN3, fNaN0})};
     } else if constexpr (std::is_same_v<T, int32_t>) {
       return {toVector({2, 3, 3}), toVector({1, 2, 2, 3, 3, 3, 4, 4, 4, 4})};
     } else {

--- a/dwio/nimble/encodings/tests/SubIntSplitEncodingTest.cpp
+++ b/dwio/nimble/encodings/tests/SubIntSplitEncodingTest.cpp
@@ -72,8 +72,7 @@ std::vector<nimble::detail::subintsplit::SegmentPlan> makePreserveSegments() {
 }
 
 template <typename T>
-std::vector<nimble::detail::subintsplit::SegmentPlan>
-makeFullWidthSegments() {
+std::vector<nimble::detail::subintsplit::SegmentPlan> makeFullWidthSegments() {
   return {{0, static_cast<int>(sizeof(PhysicalType<T>) * 8 - 1)}};
 }
 
@@ -83,8 +82,10 @@ std::string_view encodeWithNonRecursiveSubIntSplit(
     nimble::Buffer& buffer);
 
 nimble::EncodingSelectionPolicyFactory makeLeafPolicyFactory() {
-  return [](nimble::DataType type) -> std::unique_ptr<nimble::EncodingSelectionPolicyBase> {
-    auto readFactors = nimble::ManualEncodingSelectionPolicyFactory::defaultReadFactors();
+  return [](nimble::DataType type)
+             -> std::unique_ptr<nimble::EncodingSelectionPolicyBase> {
+    auto readFactors =
+        nimble::ManualEncodingSelectionPolicyFactory::defaultReadFactors();
     readFactors.erase(
         std::remove_if(
             readFactors.begin(),
@@ -100,7 +101,8 @@ nimble::EncodingSelectionPolicyFactory makeLeafPolicyFactory() {
 }
 
 template <typename T>
-class NonRecursiveSubIntSplitPolicy final : public nimble::EncodingSelectionPolicy<T> {
+class NonRecursiveSubIntSplitPolicy final
+    : public nimble::EncodingSelectionPolicy<T> {
   using physicalType = typename nimble::TypeTraits<T>::physicalType;
 
  public:
@@ -121,7 +123,8 @@ class NonRecursiveSubIntSplitPolicy final : public nimble::EncodingSelectionPoli
       nimble::EncodingType /* encodingType */,
       nimble::NestedEncodingIdentifier /* identifier */,
       nimble::DataType type) override {
-    auto readFactors = nimble::ManualEncodingSelectionPolicyFactory::defaultReadFactors();
+    auto readFactors =
+        nimble::ManualEncodingSelectionPolicyFactory::defaultReadFactors();
     readFactors.erase(
         std::remove_if(
             readFactors.begin(),
@@ -272,13 +275,8 @@ class SubIntSplitEncodingTest : public ::testing::Test {
   std::unique_ptr<nimble::Buffer> buffer_;
 };
 
-using SubIntSplitEncodingTypes = ::testing::Types<
-    int32_t,
-    uint32_t,
-    int64_t,
-    uint64_t,
-    float,
-    double>;
+using SubIntSplitEncodingTypes =
+    ::testing::Types<int32_t, uint32_t, int64_t, uint64_t, float, double>;
 
 TYPED_TEST_CASE(SubIntSplitEncodingTest, SubIntSplitEncodingTypes);
 
@@ -286,7 +284,8 @@ TYPED_TEST(SubIntSplitEncodingTest, RecomputeRoundTripAndReplay) {
   using T = TypeParam;
   const auto values = makeStructuredValues<T>();
 
-  const auto encoded = encodeWithNonRecursiveSubIntSplit<T>(values, *this->buffer_);
+  const auto encoded =
+      encodeWithNonRecursiveSubIntSplit<T>(values, *this->buffer_);
   const auto captured = nimble::EncodingLayoutCapture::capture(encoded);
 
   ASSERT_EQ(captured.encodingType(), nimble::EncodingType::SubIntSplit);
@@ -304,7 +303,8 @@ TYPED_TEST(SubIntSplitEncodingTest, RecomputeRoundTripAndReplay) {
   const auto decoded = decodeAll<T>(encoded, *this->pool_);
   expectBitwiseEqual(values, decoded);
 
-  const auto replayed = encodeWithReplayLayout<T>(captured, values, *this->buffer_);
+  const auto replayed =
+      encodeWithReplayLayout<T>(captured, values, *this->buffer_);
   const auto replayCaptured = nimble::EncodingLayoutCapture::capture(replayed);
   expectSameLayout(captured, replayCaptured);
 
@@ -320,7 +320,8 @@ TYPED_TEST(SubIntSplitEncodingTest, RecomputeRoundTripAndReplay) {
 
   encoding->reset();
   std::vector<T> fullRoundTrip(values.size());
-  encoding->materialize(static_cast<uint32_t>(values.size()), fullRoundTrip.data());
+  encoding->materialize(
+      static_cast<uint32_t>(values.size()), fullRoundTrip.data());
   expectBitwiseEqual(values, fullRoundTrip);
 }
 
@@ -330,7 +331,8 @@ TYPED_TEST(SubIntSplitEncodingTest, PreserveRoundTripExplicitBoundaries) {
   const auto segments = makePreserveSegments<T>();
   const auto layout = makePreserveLayout<T>(segments);
 
-  const auto encoded = encodeWithReplayLayout<T>(layout, values, *this->buffer_);
+  const auto encoded =
+      encodeWithReplayLayout<T>(layout, values, *this->buffer_);
   const auto captured = nimble::EncodingLayoutCapture::capture(encoded);
 
   ASSERT_EQ(captured.encodingType(), nimble::EncodingType::SubIntSplit);
@@ -354,9 +356,7 @@ TYPED_TEST(SubIntSplitEncodingTest, PreserveRoundTripExplicitBoundaries) {
 
 TEST(SubIntSplitEncodingTests, PreserveModeRequiresBoundaries) {
   const std::vector<int64_t> values{
-      0x1234567890000000LL,
-      0x1234567890000001LL,
-      0x1234567890000002LL};
+      0x1234567890000000LL, 0x1234567890000001LL, 0x1234567890000002LL};
 
   nimble::EncodingLayout layout{
       nimble::EncodingType::SubIntSplit,

--- a/dwio/nimble/fuzzer/encoding/EncodingFuzzer.h
+++ b/dwio/nimble/fuzzer/encoding/EncodingFuzzer.h
@@ -135,7 +135,7 @@ Vector<T> makeBitStructuredData(
   Vector<T> data(&pool);
   data.reserve(rowCount);
   if constexpr (
-  std::is_arithmetic_v<T> && !std::is_same_v<T, bool> && sizeof(T) >= 4) {
+      std::is_arithmetic_v<T> && !std::is_same_v<T, bool> && sizeof(T) >= 4) {
     using UintType = std::conditional_t<sizeof(T) == 4, uint32_t, uint64_t>;
     UintType prefix{};
     if constexpr (sizeof(T) == 4) {
@@ -144,8 +144,8 @@ Vector<T> makeBitStructuredData(
       prefix = static_cast<UintType>(0x1234567800000000ULL);
     }
     for (uint32_t i = 0; i < rowCount; ++i) {
-      auto bits = static_cast<UintType>(
-          prefix + (folly::Random::rand32(rng) & 0xFFFF));
+      auto bits =
+          static_cast<UintType>(prefix + (folly::Random::rand32(rng) & 0xFFFF));
       data.push_back(std::bit_cast<T>(bits));
     }
   }

--- a/dwio/nimble/fuzzer/encoding/EncodingFuzzerTest.cpp
+++ b/dwio/nimble/fuzzer/encoding/EncodingFuzzerTest.cpp
@@ -354,4 +354,4 @@ TYPED_TEST(SubIntSplitFuzzerTest, Correctness) {
       FLAGS_fuzzer_compression);
   fuzzer.run();
 }
-#endif  // NIMBLE_ENABLE_EXPERIMENTAL_ENCODINGS
+#endif // NIMBLE_ENABLE_EXPERIMENTAL_ENCODINGS

--- a/dwio/nimble/tools/NimbleDumpLib.cpp
+++ b/dwio/nimble/tools/NimbleDumpLib.cpp
@@ -127,7 +127,8 @@ uint64_t getRawDataSize(
       pos += otherValuesSize;
       auto constantValueSize = encoding::readUint32(pos);
       result += (rowCount - otherValuesCount) * constantValueSize;
-      result += getRawDataSize(memoryPool, {otherValuesOffset, otherValuesSize});
+      result +=
+          getRawDataSize(memoryPool, {otherValuesOffset, otherValuesSize});
       break;
     }
 

--- a/dwio/nimble/velox/selective/tests/E2EFilterTest.cpp
+++ b/dwio/nimble/velox/selective/tests/E2EFilterTest.cpp
@@ -1149,11 +1149,12 @@ TEST_P(E2EFilterTest, floatBiasedSubIntSplit) {
       /*withRecursiveNulls=*/true,
       biasedEncodingFactors(EncodingType::SubIntSplit));
 }
-#endif  // NIMBLE_ENABLE_EXPERIMENTAL_ENCODINGS
+#endif // NIMBLE_ENABLE_EXPERIMENTAL_ENCODINGS
 
 #ifdef NIMBLE_ENABLE_EXPERIMENTAL_ENCODINGS
 // Forces SubIntSplit via EncodingLayoutTree and verifies the on-disk encoding
-// matches. Schema uses only 32/64-bit types (SubIntSplit requires sizeof(T)>=4).
+// matches. Schema uses only 32/64-bit types (SubIntSplit requires
+// sizeof(T)>=4).
 TEST_P(E2EFilterTest, integerForcedSubIntSplit) {
   forcedEncodingType_ = EncodingType::SubIntSplit;
   testWithTypes(

--- a/dwio/nimble/velox/selective/tests/SelectiveNimbleReaderTest.cpp
+++ b/dwio/nimble/velox/selective/tests/SelectiveNimbleReaderTest.cpp
@@ -81,8 +81,8 @@ struct NullableMapData {
     }
   }
 
-  operator std::optional<std::vector<std::pair<int64_t, std::optional<int64_t>>>>()
-      const {
+  operator std::optional<
+      std::vector<std::pair<int64_t, std::optional<int64_t>>>>() const {
     return value;
   }
 };
@@ -653,7 +653,8 @@ class SelectiveNimbleReaderTest
       bool stringDecoderZeroCopy,
       bool filterAfterRead = false) {
     std::vector<
-        std::optional<std::vector<std::pair<int64_t, std::optional<int64_t>>>>> converted;
+        std::optional<std::vector<std::pair<int64_t, std::optional<int64_t>>>>>
+        converted;
     converted.reserve(data.size());
     for (const auto& item : data) {
       converted.push_back(item);

--- a/dwio/nimble/velox/selective/tests/VariableLengthColumnReaderTest.cpp
+++ b/dwio/nimble/velox/selective/tests/VariableLengthColumnReaderTest.cpp
@@ -320,14 +320,14 @@ TEST_F(VariableLengthColumnReaderTest, mapMixedNullsAndEmpty) {
       std::optional<std::vector<std::pair<int64_t, std::optional<int64_t>>>>>
       data = {
           std::nullopt,
-      makeNullableMap<int64_t>({}),
-      makeNullableMap<int64_t>({{1, 10}, {2, 20}}),
+          makeNullableMap<int64_t>({}),
+          makeNullableMap<int64_t>({{1, 10}, {2, 20}}),
           std::nullopt,
-      makeNullableMap<int64_t>({}),
-      makeNullableMap<int64_t>({{3, 30}}),
+          makeNullableMap<int64_t>({}),
+          makeNullableMap<int64_t>({{3, 30}}),
           std::nullopt,
-      makeNullableMap<int64_t>({{4, 40}, {5, 50}, {6, 60}}),
-      makeNullableMap<int64_t>({}),
+          makeNullableMap<int64_t>({{4, 40}, {5, 50}, {6, 60}}),
+          makeNullableMap<int64_t>({}),
       };
   auto input = makeRowVector({makeNullableMapVector<int64_t, int64_t>(data)});
   auto scanSpec = std::make_shared<common::ScanSpec>("root");

--- a/dwio/nimble/velox/tests/VeloxWriterTest.cpp
+++ b/dwio/nimble/velox/tests/VeloxWriterTest.cpp
@@ -4998,8 +4998,7 @@ TEST_F(VeloxWriterTest, encodingLayoutDeltaMultiStripe) {
       batches[0]->type(),
       std::move(writeFile),
       *rootPool_,
-      {.encodingLayoutTree = std::move(layoutTree),
-       .flushPolicyFactory = []() {
+      {.encodingLayoutTree = std::move(layoutTree), .flushPolicyFactory = []() {
          return std::make_unique<nimble::StripeRawSizeFlushPolicy>(1024);
        }});
 
@@ -5282,8 +5281,7 @@ TEST_F(VeloxWriterTest, encodingLayoutDeltaMultiStripeLegacyRead) {
       batches[0]->type(),
       std::move(writeFile),
       *rootPool_,
-      {.encodingLayoutTree = std::move(layoutTree),
-       .flushPolicyFactory = []() {
+      {.encodingLayoutTree = std::move(layoutTree), .flushPolicyFactory = []() {
          return std::make_unique<nimble::StripeRawSizeFlushPolicy>(1024);
        }});
 


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebookincubator/velox/pull/17794


per title

Added
```
set(
  VELOX_ENABLE_PARQUET
  OFF
  CACHE BOOL
  "Disable Velox Parquet support for Nimble minimal builds."
)
```
fizz dependency should be excluded
```
if(VELOX_ENABLE_REMOTE_FUNCTIONS OR VELOX_ENABLE_PARQUET)
  find_package(fizz CONFIG REQUIRED)
  find_package(wangle CONFIG REQUIRED)
  find_package(FBThrift CONFIG REQUIRED)
endif()
```

Reviewed By: xiaoxmeng

Differential Revision: D108181676


