### PR TITLE
perf: Preload small Nimble files to reduce WarmStorage round trips (#854)

### DIFF
--- a/dwio/nimble/velox/index/tests/NimbleIndexProjectorTest.cpp
+++ b/dwio/nimble/velox/index/tests/NimbleIndexProjectorTest.cpp
@@ -212,6 +212,7 @@ class NimbleIndexProjectorTest : public ::testing::TestWithParam<TestParam> {
     readerOptions.setCacheData(false);
     readerOptions.setCacheMetadata(GetParam().cacheMetadata);
     readerOptions.setPinMetadata(GetParam().pinMetadata);
+    readerOptions.setFilePreloadThreshold(0);
     readerOptions.setIOExecutor(ioExecutor_);
     ensureTabletReaderCache();
     return NimbleIndexProjector::create(
@@ -1791,6 +1792,7 @@ TEST_P(NimbleIndexProjectorTest, featureReorderingStorageReads) {
     readerOptions.setMaxCoalesceDistance(maxCoalesceDistance);
     readerOptions.setCacheData(false);
     readerOptions.setIOExecutor(ioExecutor_);
+    readerOptions.setFilePreloadThreshold(0);
 
     TabletReaderCache::testingReset();
     ensureTabletReaderCache();

--- a/dwio/nimble/velox/selective/ReaderBase.cpp
+++ b/dwio/nimble/velox/selective/ReaderBase.cpp
@@ -19,6 +19,9 @@
 #include "dwio/nimble/tablet/Constants.h"
 #include "dwio/nimble/velox/SchemaSerialization.h"
 #include "dwio/nimble/velox/SchemaUtils.h"
+#include "velox/buffer/Buffer.h"
+#include "velox/common/file/File.h"
+#include "velox/dwio/common/InputStream.h"
 #include "velox/dwio/common/Reader.h"
 
 namespace facebook::nimble {
@@ -45,11 +48,42 @@ TypePtr getFileSchema(
   return dwio::common::Reader::updateColumnNames(
       fileSchema, options.fileSchema());
 }
+
+// Reads a small file fully in one storage round trip and returns a
+// BufferedInput backed by an owning in-memory ReadFile, so footer and stripe
+// reads are served from memory. Returns the original input unchanged when the
+// file is empty, over the threshold, or an AsyncDataCache is present.
+std::unique_ptr<velox::dwio::common::BufferedInput> maybePreloadInput(
+    std::unique_ptr<velox::dwio::common::BufferedInput> input,
+    const velox::dwio::common::ReaderOptions& options) {
+  const auto readFile = input->getReadFile();
+  const auto fileSize = readFile->size();
+  if (fileSize == 0 || fileSize > options.filePreloadThreshold() ||
+      options.cache() != nullptr) {
+    return input;
+  }
+  auto buffer = velox::AlignedBuffer::allocateExact<char>(
+      fileSize, &options.memoryPool());
+  velox::dwio::common::ReadFileInputStream(
+      readFile,
+      velox::dwio::common::MetricsLog::voidLog(),
+      options.dataIoStats().get())
+      .read(
+          buffer->asMutable<char>(),
+          fileSize,
+          /*offset=*/0,
+          velox::dwio::common::LogType::FILE);
+  return std::make_unique<velox::dwio::common::BufferedInput>(
+      std::make_shared<velox::InMemoryReadFile>(std::move(buffer)),
+      options.memoryPool());
+}
 } // namespace
 
 std::shared_ptr<ReaderBase> ReaderBase::create(
     std::unique_ptr<velox::dwio::common::BufferedInput> input,
     const velox::dwio::common::ReaderOptions& options) {
+  input = maybePreloadInput(std::move(input), options);
+
   auto tabletOptions = TabletReader::configureOptions(options);
 
   auto tablet = TabletReader::create(
@@ -65,11 +99,11 @@ std::shared_ptr<ReaderBase> ReaderBase::create(
   return std::shared_ptr<ReaderBase>(new ReaderBase(
       std::move(input),
       std::move(tablet),
-      pool,
       randomSkip,
       scanSpec,
       nimbleSchema,
-      std::move(fileSchema)));
+      std::move(fileSchema),
+      pool));
 }
 
 std::shared_ptr<ReaderBase> ReaderBase::create(
@@ -85,21 +119,21 @@ std::shared_ptr<ReaderBase> ReaderBase::create(
   return std::shared_ptr<ReaderBase>(new ReaderBase(
       std::move(input),
       std::move(cachedTablet.tablet),
-      pool,
       randomSkip,
       scanSpec,
       std::move(cachedTablet.nimbleSchema),
-      std::move(fileSchema)));
+      std::move(fileSchema),
+      pool));
 }
 
 ReaderBase::ReaderBase(
     std::unique_ptr<velox::dwio::common::BufferedInput> input,
     std::shared_ptr<TabletReader> tablet,
-    velox::memory::MemoryPool* pool,
     const std::shared_ptr<velox::random::RandomSkipTracker>& randomSkip,
     const std::shared_ptr<velox::common::ScanSpec>& scanSpec,
     std::shared_ptr<const Type> nimbleSchema,
-    velox::RowTypePtr fileSchema)
+    velox::RowTypePtr fileSchema,
+    velox::memory::MemoryPool* pool)
     : input_{std::move(input)},
       tablet_{std::move(tablet)},
       pool_{pool},

--- a/dwio/nimble/velox/selective/ReaderBase.h
+++ b/dwio/nimble/velox/selective/ReaderBase.h
@@ -122,11 +122,11 @@ class ReaderBase {
   ReaderBase(
       std::unique_ptr<velox::dwio::common::BufferedInput> input,
       std::shared_ptr<TabletReader> tablet,
-      velox::memory::MemoryPool* pool,
       const std::shared_ptr<velox::random::RandomSkipTracker>& randomSkip,
       const std::shared_ptr<velox::common::ScanSpec>& scanSpec,
       std::shared_ptr<const Type> nimbleSchema,
-      velox::RowTypePtr fileSchema);
+      velox::RowTypePtr fileSchema,
+      velox::memory::MemoryPool* pool);
 
   const std::unique_ptr<velox::dwio::common::BufferedInput> input_;
   const std::shared_ptr<TabletReader> tablet_;

--- a/dwio/nimble/velox/selective/tests/ReaderBaseTest.cpp
+++ b/dwio/nimble/velox/selective/tests/ReaderBaseTest.cpp
@@ -24,6 +24,7 @@
 #include "dwio/nimble/velox/VeloxWriter.h"
 #include "folly/executors/CPUThreadPoolExecutor.h"
 #include "velox/common/file/File.h"
+#include "velox/common/file/tests/TestUtils.h"
 #include "velox/common/memory/Memory.h"
 #include "velox/dwio/common/BufferedInput.h"
 #include "velox/vector/tests/utils/VectorMaker.h"
@@ -329,4 +330,37 @@ TEST_F(StripeStreamsMultiStripeTest, locateStreams) {
           stripeInfo.offset + stripeInfo.size);
     }
   }
+}
+
+TEST_F(StripeStreamsMultiStripeTest, preloadCollapsesStripeReads) {
+  constexpr uint32_t kStripeCount = 3;
+
+  auto preadsReadingAllStripes = [&](uint64_t preloadThreshold) {
+    auto countingFile =
+        std::make_shared<velox::tests::utils::CountingReadFile>(fileData_);
+    auto opts = makeReaderOptions();
+    opts.setFilePreloadThreshold(preloadThreshold);
+    auto input = std::make_unique<velox::dwio::common::BufferedInput>(
+        countingFile, *pool_);
+    auto reader = ReaderBase::create(std::move(input), opts);
+    EXPECT_EQ(reader->tablet().stripeCount(), kStripeCount);
+
+    StripeStreams streams(reader);
+    const auto numStreams = reader->nimbleSchema()->asRow().childrenCount() + 1;
+    for (uint32_t stripe = 0; stripe < kStripeCount; ++stripe) {
+      streams.setStripe(stripe);
+      std::vector<std::unique_ptr<velox::dwio::common::SeekableInputStream>>
+          enqueued;
+      for (uint32_t streamId = 0; streamId < numStreams; ++streamId) {
+        if (streams.hasStream(streamId)) {
+          enqueued.push_back(streams.enqueue(streamId));
+        }
+      }
+      streams.load();
+    }
+    return countingFile->numReads();
+  };
+
+  EXPECT_EQ(preadsReadingAllStripes(fileData_.size() + 1), 1);
+  EXPECT_GE(preadsReadingAllStripes(0), kStripeCount);
 }

--- a/dwio/nimble/velox/selective/tests/SelectiveNimbleReaderTest.cpp
+++ b/dwio/nimble/velox/selective/tests/SelectiveNimbleReaderTest.cpp
@@ -35,6 +35,7 @@
 #include "velox/common/caching/FileHandle.h"
 #include "velox/common/caching/FileIds.h"
 #include "velox/common/caching/ScanTracker.h"
+#include "velox/common/file/tests/TestUtils.h"
 #include "velox/common/io/IoStatistics.h"
 #include "velox/common/memory/MallocAllocator.h"
 #include "velox/dwio/common/CachedBufferedInput.h"
@@ -129,7 +130,9 @@ class SelectiveNimbleReaderTest
 
  protected:
   static void SetUpTestCase() {
-    memory::initializeMemoryManager(velox::memory::MemoryManager::Options{});
+    if (!memory::MemoryManager::testInstance()) {
+      memory::initializeMemoryManager(velox::memory::MemoryManager::Options{});
+    }
     registerSelectiveNimbleReaderFactory();
   }
 
@@ -187,6 +190,7 @@ class SelectiveNimbleReaderTest
     options.setScanSpec(scanSpec);
     options.setPinMetadata(GetParam().pinMetadata);
     options.setCacheMetadata(GetParam().enableCache);
+    options.setFilePreloadThreshold(0);
     std::unique_ptr<dwio::common::BufferedInput> input;
     auto& ids = fileIds();
     const auto readerId = readerIdCounter_++;
@@ -3923,6 +3927,159 @@ INSTANTIATE_TEST_CASE_P(
     [](const ::testing::TestParamInfo<TestParam>& info) {
       return info.param.debugString();
     });
+
+class SmallFilePreloadTest : public ::testing::Test,
+                             public velox::test::VectorTestBase {
+ protected:
+  static void SetUpTestCase() {
+    if (!memory::MemoryManager::testInstance()) {
+      memory::initializeMemoryManager(velox::memory::MemoryManager::Options{});
+    }
+    registerSelectiveNimbleReaderFactory();
+  }
+
+  static void TearDownTestCase() {
+    unregisterSelectiveNimbleReaderFactory();
+  }
+};
+
+TEST_F(SmallFilePreloadTest, preloadReducesPreadCalls) {
+  auto input = makeRowVector({
+      makeFlatVector<int64_t>(500, folly::identity),
+      makeFlatVector<int64_t>(500, [](auto i) { return i * 10; }),
+  });
+  auto nimbleFile = test::createNimbleFile(*rootPool_, input);
+  ASSERT_LE(nimbleFile.size(), 8 << 20);
+
+  auto factory =
+      dwio::common::getReaderFactory(dwio::common::FileFormat::NIMBLE);
+
+  auto preadsWithThreshold = [&](uint64_t preloadThreshold) {
+    auto countingFile =
+        std::make_shared<velox::tests::utils::CountingReadFile>(nimbleFile);
+    auto bufferedInput =
+        std::make_unique<dwio::common::BufferedInput>(countingFile, *pool());
+    dwio::common::ReaderOptions options(pool());
+    auto ioStats = std::make_shared<io::IoStatistics>();
+    options.setDataIoStats(ioStats);
+    options.setMetadataIoStats(ioStats);
+    auto scanSpec = std::make_shared<common::ScanSpec>("root");
+    scanSpec->addAllChildFields(*input->type());
+    options.setScanSpec(scanSpec);
+    options.setFilePreloadThreshold(preloadThreshold);
+
+    auto reader = factory->createReader(std::move(bufferedInput), options);
+    dwio::common::RowReaderOptions rowOptions;
+    rowOptions.setScanSpec(scanSpec);
+    auto rowReader = reader->createRowReader(rowOptions);
+    VectorPtr result = BaseVector::create(asRowType(input->type()), 0, pool());
+    EXPECT_EQ(rowReader->next(1'000, result), 500);
+    velox::test::assertEqualVectors(input, result);
+    return countingFile->numReads();
+  };
+
+  EXPECT_EQ(preadsWithThreshold(nimbleFile.size() + 1), 1);
+  EXPECT_GT(preadsWithThreshold(0), 1);
+}
+
+TEST_F(SmallFilePreloadTest, preloadAttributesSingleReadToData) {
+  auto input = makeRowVector({
+      makeFlatVector<int64_t>(500, folly::identity),
+      makeFlatVector<int64_t>(500, [](auto i) { return i * 10; }),
+  });
+  auto nimbleFile = test::createNimbleFile(*rootPool_, input);
+  ASSERT_LE(nimbleFile.size(), 8 << 20);
+
+  auto factory =
+      dwio::common::getReaderFactory(dwio::common::FileFormat::NIMBLE);
+
+  auto dataStats = std::make_shared<io::IoStatistics>();
+  auto metadataStats = std::make_shared<io::IoStatistics>();
+
+  auto countingFile =
+      std::make_shared<velox::tests::utils::CountingReadFile>(nimbleFile);
+  auto bufferedInput =
+      std::make_unique<dwio::common::BufferedInput>(countingFile, *pool());
+  dwio::common::ReaderOptions options(pool());
+  options.setDataIoStats(dataStats);
+  options.setMetadataIoStats(metadataStats);
+  auto scanSpec = std::make_shared<common::ScanSpec>("root");
+  scanSpec->addAllChildFields(*input->type());
+  options.setScanSpec(scanSpec);
+  options.setFilePreloadThreshold(nimbleFile.size() + 1);
+
+  auto reader = factory->createReader(std::move(bufferedInput), options);
+  dwio::common::RowReaderOptions rowOptions;
+  rowOptions.setScanSpec(scanSpec);
+  auto rowReader = reader->createRowReader(rowOptions);
+  VectorPtr result = BaseVector::create(asRowType(input->type()), 0, pool());
+  ASSERT_EQ(rowReader->next(1'000, result), 500);
+  velox::test::assertEqualVectors(input, result);
+
+  EXPECT_EQ(countingFile->numReads(), 1);
+  EXPECT_EQ(dataStats->rawBytesRead(), nimbleFile.size());
+}
+
+// Preload must skip when a cache is present, else it bypasses the data cache.
+TEST_F(SmallFilePreloadTest, cachePresentSkipsPreload) {
+  auto input = makeRowVector({
+      makeFlatVector<int64_t>(500, folly::identity),
+      makeFlatVector<int64_t>(500, [](auto i) { return i * 10; }),
+  });
+  auto nimbleFile = test::createNimbleFile(*rootPool_, input);
+  ASSERT_LE(nimbleFile.size(), 8 << 20);
+
+  auto allocator = std::make_shared<memory::MallocAllocator>(
+      memory::MemoryAllocator::Options{
+          .capacity = 512 << 20, .reservationByteLimit = 0});
+  auto cache = cache::AsyncDataCache::create(allocator.get());
+  auto scanTracker =
+      std::make_shared<cache::ScanTracker>("preloadGate", nullptr, 256 << 10);
+  folly::CPUThreadPoolExecutor ioExecutor(1);
+  auto ioStats = std::make_shared<io::IoStatistics>();
+
+  auto countingFile =
+      std::make_shared<velox::tests::utils::CountingReadFile>(nimbleFile);
+
+  auto factory =
+      dwio::common::getReaderFactory(dwio::common::FileFormat::NIMBLE);
+  {
+    auto& ids = fileIds();
+    io::ReaderOptions ioReaderOpts(pool());
+    ioReaderOpts.setDataIoStats(ioStats);
+    auto cachedInput = std::make_unique<dwio::common::CachedBufferedInput>(
+        countingFile,
+        dwio::common::MetricsLog::voidLog(),
+        StringIdLease(ids, "preloadGateFile"),
+        cache.get(),
+        scanTracker,
+        StringIdLease(ids, "preloadGateGroup"),
+        ioStats,
+        nullptr,
+        &ioExecutor,
+        ioReaderOpts);
+
+    dwio::common::ReaderOptions options(pool());
+    options.setDataIoStats(ioStats);
+    options.setMetadataIoStats(ioStats);
+    auto scanSpec = std::make_shared<common::ScanSpec>("root");
+    scanSpec->addAllChildFields(*input->type());
+    options.setScanSpec(scanSpec);
+    options.setFilePreloadThreshold(nimbleFile.size() + 1);
+    options.setCache(cache.get());
+
+    auto reader = factory->createReader(std::move(cachedInput), options);
+    dwio::common::RowReaderOptions rowOptions;
+    rowOptions.setScanSpec(scanSpec);
+    auto rowReader = reader->createRowReader(rowOptions);
+    VectorPtr result = BaseVector::create(asRowType(input->type()), 0, pool());
+    ASSERT_EQ(rowReader->next(1'000, result), 500);
+    velox::test::assertEqualVectors(input, result);
+  }
+  cache->shutdown();
+
+  EXPECT_GT(countingFile->numReads(), 1);
+}
 
 } // namespace
 } // namespace facebook::nimble


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebookincubator/velox/pull/17821


For small Nimble files (≤ filePreloadThreshold, default 4MB for presto batch  - same as DWRF), read the
entire file into memory once via ReadFile::pread(), then back both
TabletReader and BufferedInput with an InMemoryReadFile wrapping that
buffer.

This gives 1 storage round trip total:
- TabletReader::init() reads footer/metadata from InMemoryReadFile (memory)
- StripeStreams::enqueue() + BufferedInput::load() reads stripe data from
  InMemoryReadFile (memory)

Without this change, a small file with N stripes requires 1 + N round trips
(1 speculative tail read for footer + 1 per stripe for stream data).

This mirrors the DWRF reader's small-file preload optimization in
dwrf::ReaderBase which calls input_->preload() for files below the
threshold.

Reviewed By: xiaoxmeng

Differential Revision: D105470326


