### PR TITLE
perf(dwio/nimble): Keep DataInput pool alive for IOBufs

### DIFF
--- a/dwio/nimble/tablet/DataInput.cpp
+++ b/dwio/nimble/tablet/DataInput.cpp
@@ -232,7 +232,10 @@ std::pair<char*, DataInput::Handle> DirectDataInput::allocateBuffer(
       reinterpret_cast<uintptr_t>(buffer) % alignment_ == 0,
       "allocateAligned returned unaligned buffer");
   auto handle = Handle(
-      buffer, [pool = pool_, bytes, allocAlignment = allocAlignment_](void* p) {
+      buffer,
+      [pool = pool_->shared_from_this(),
+       bytes,
+       allocAlignment = allocAlignment_](void* p) {
         pool->freeAligned(p, static_cast<int64_t>(bytes), allocAlignment);
       });
   return {buffer, std::move(handle)};

--- a/dwio/nimble/tablet/tests/DataInputTest.cpp
+++ b/dwio/nimble/tablet/tests/DataInputTest.cpp
@@ -239,6 +239,35 @@ TEST_P(DataInputParamTest, clearAndReuse) {
   }
 }
 
+TEST_F(DataInputTest, loadedBufferHandleKeepsPoolOwnerAlive) {
+  std::string data(1'000, '\0');
+  for (int i = 0; i < 1'000; ++i) {
+    data[i] = static_cast<char>(i % 256);
+  }
+
+  auto rootPool =
+      velox::memory::memoryManager()->addRootPool("DataInputOwnerTest");
+  DataInput::Handle handle;
+  {
+    auto ownedPool = rootPool->addLeafChild("owned");
+    auto file = createFile(data);
+    auto options = makeOptions();
+    options.pool = ownedPool.get();
+
+    DirectDataInput input(file.get(), options);
+    input.reserve(1);
+    input.startGroup();
+    const auto index = input.enqueue({500, 100});
+    handle = input.load();
+    EXPECT_EQ(refData(input.bufferRef(index)), data.substr(500, 100));
+
+    ownedPool.reset();
+  }
+
+  handle.reset();
+  rootPool.reset();
+}
+
 TEST_P(DataInputParamTest, fuzz) {
   const size_t fileSize = 102'400;
   std::string data(fileSize, '\0');


### PR DESCRIPTION
Summary: `DirectDataInput::load()` returns a handle captured by zero-copy `IOBuf`s. Capture `pool_->shared_from_this()` in that handle deleter so cloned `IOBuf`s can outlive `DirectDataInput` or the RocksDB iterator while still freeing the aligned read buffer before the pool is destroyed.

Differential Revision: D108319412


