### PR TITLE
feat(nimble): Nest PFOR exception sub-streams (positions, values) (#857)

### DIFF
--- a/dwio/nimble/encodings/PFOREncoding.h
+++ b/dwio/nimble/encodings/PFOREncoding.h
@@ -17,17 +17,18 @@
 
 #include <algorithm>
 #include <cstring>
-#include <limits>
 #include <span>
 
 #include "dwio/nimble/common/Buffer.h"
 #include "dwio/nimble/common/Exceptions.h"
 #include "dwio/nimble/common/FixedBitArray.h"
 #include "dwio/nimble/common/Types.h"
-#include "dwio/nimble/common/Varint.h"
 #include "dwio/nimble/common/Vector.h"
+#include "dwio/nimble/encodings/TrivialEncoding.h"
 #include "dwio/nimble/encodings/common/Encoding.h"
+#include "dwio/nimble/encodings/common/EncodingFactory.h"
 #include "dwio/nimble/encodings/common/EncodingPrimitives.h"
+#include "dwio/nimble/encodings/selection/EncodingIdentifier.h"
 #include "dwio/nimble/encodings/selection/EncodingSelection.h"
 #include "velox/common/base/BitUtil.h"
 
@@ -35,7 +36,9 @@
 // Each value is decomposed as `value = baseline + residual`, where the
 // residuals are bitpacked at a base bit width chosen so that ~90% of the
 // residuals fit. Values whose residual overflows the base width are recorded
-// as (position, value) "exceptions" stored separately as varints.
+// as (position, value) "exceptions" stored separately as two self-describing
+// nested sub-encodings (one for the positions, one for the values), each
+// chosen by Nimble's recursive encoding selection.
 //
 // Decode uses a branchless two-pass strategy (ported from AusIntListPfor):
 //   Pass 1: Unpack all base residuals in a tight branchless loop.
@@ -54,9 +57,14 @@ namespace facebook::nimble {
 ///   1 byte                    : baseBitWidth (bits per bitpacked residual;
 ///                               range [0, 64])
 ///   4 bytes                   : numExceptions (uint32_t, fixed width)
-///   numExceptions varints     : exception positions, strictly ascending
-///   numExceptions varints     : exception values (full residual, i.e.
-///                               value - baseline)
+///   4 bytes + N bytes         : exception positions sub-stream -- a 4-byte
+///                               size prefix followed by a nested encoding of
+///                               the strictly ascending positions (size 0 and
+///                               no encoding when there are no exceptions)
+///   4 bytes + N bytes         : exception values sub-stream -- a 4-byte size
+///                               prefix followed by a nested encoding of the
+///                               full residuals, i.e. value - baseline (size 0
+///                               and no encoding when there are no exceptions)
 ///   FixedBitArray::bufferSize(rowCount, baseBitWidth) bytes:
 ///                               bitpacked base residuals (omitted when
 ///                               baseBitWidth == 0)
@@ -102,15 +110,19 @@ class PFOREncoding final
     const uint64_t baseValuesSize = baseBitWidth == 0
         ? 0
         : FixedBitArray::bufferSize(rowCount, baseBitWidth);
-    const uint64_t valueVarintBytes =
-        varint::maxVarintSizeForBitWidth(maxBitWidth);
-    const uint64_t positionVarintBytes =
-        varint::maxVarintSizeForBitWidth(std::numeric_limits<uint32_t>::digits);
-    const uint64_t exceptionsSize =
-        numExceptions * (positionVarintBytes + valueVarintBytes);
+    // The exception side-channels are stored as nested encodings. Dumping real
+    // files shows selection picks Trivial for both (the streams are small, so
+    // Trivial's raw layout beats bit-packing), so we estimate them as Trivial
+    // sub-encodings -- mirroring how Dictionary estimates its alphabet child.
+    // This is an approximation (the actual nested encoding is data-dependent);
+    // the estimate-vs-actual test allows a 2x band.
+    const uint64_t positionsSize =
+        TrivialEncoding<uint32_t>::estimateSize(numExceptions);
+    const uint64_t valuesSize =
+        TrivialEncoding<physicalType>::estimateSize(numExceptions);
     const uint64_t outerEncodingSize =
         EncodingPrefix::kFixedPrefixSize + kPrefixSize;
-    return outerEncodingSize + baseValuesSize + exceptionsSize;
+    return outerEncodingSize + baseValuesSize + positionsSize + valuesSize;
   }
 
  private:
@@ -191,7 +203,7 @@ template <typename T>
 PFOREncoding<T>::PFOREncoding(
     velox::memory::MemoryPool& pool,
     std::string_view data,
-    const std::function<void*(uint32_t)>& /* stringBufferFactory */,
+    const std::function<void*(uint32_t)>& stringBufferFactory,
     const Encoding::Options& options)
     : TypedEncoding<T, physicalType>{pool, data, options},
       exceptionPositions_{this->pool_},
@@ -213,10 +225,26 @@ PFOREncoding<T>::PFOREncoding(
         this->rowCount_,
         "Pfor exception count exceeds row count.");
 
-    // Eagerly decode exception positions (varint-encoded, ascending order).
-    exceptionPositions_.resize(numExceptions_);
+    auto readExceptionStream = [&](auto& subStream) {
+      subStream.resize(numExceptions_);
+      const uint32_t size = encoding::readUint32(pos);
+      if (numExceptions_ > 0) {
+        auto subEncoding = EncodingFactory(options).create(
+            pool, {pos, size}, stringBufferFactory);
+        subEncoding->materialize(numExceptions_, subStream.data());
+      }
+      pos += size;
+    };
+    readExceptionStream(exceptionPositions_); // exception positions
+    readExceptionStream(exceptionValues_); // exception values
+
+    NIMBLE_CHECK_EQ(
+        exceptionPositions_.size(),
+        exceptionValues_.size(),
+        "Pfor exception positions and values must have the same size.");
+
+    // Validate the materialized positions (strictly ascending, in range).
     for (uint32_t i = 0; i < numExceptions_; ++i) {
-      exceptionPositions_[i] = varint::readVarint32(&pos);
       NIMBLE_CHECK_LT(
           exceptionPositions_[i],
           this->rowCount_,
@@ -226,19 +254,6 @@ PFOREncoding<T>::PFOREncoding(
             exceptionPositions_[i],
             exceptionPositions_[i - 1],
             "Pfor exception positions must be strictly ascending.");
-      }
-    }
-
-    // Eagerly decode exception values (varint-encoded full residuals).
-    exceptionValues_.resize(numExceptions_);
-    for (uint32_t i = 0; i < numExceptions_; ++i) {
-      if constexpr (
-          isFourByteIntegralType<physicalType>() || sizeof(physicalType) < 4) {
-        exceptionValues_[i] =
-            static_cast<physicalType>(varint::readVarint32(&pos));
-      } else {
-        exceptionValues_[i] =
-            static_cast<physicalType>(varint::readVarint64(&pos));
       }
     }
 
@@ -415,23 +430,36 @@ std::string_view PFOREncoding<T>::encode(
     const uint32_t numExceptions =
         static_cast<uint32_t>(exceptionPositions.size());
 
-    // Compute varint sizes for the exception side-channel.
-    uint64_t exceptionPositionBytes{0};
-    uint64_t exceptionValueBytes{0};
-    for (uint32_t i = 0; i < numExceptions; ++i) {
-      exceptionPositionBytes += varint::varintSize(exceptionPositions[i]);
-      exceptionValueBytes += varint::varintSize(exceptionValues[i]);
-    }
     const uint64_t bitpackedSize = baseBitWidth == 0
         ? 0
         : FixedBitArray::bufferSize(rowCount, baseBitWidth);
-    const uint32_t encodingSize =
-        Encoding::serializePrefixSize(rowCount, useVarint) +
-        PFOREncoding<T>::kPrefixSize +
-        static_cast<uint32_t>(
-            exceptionPositionBytes + exceptionValueBytes + bitpackedSize);
 
-    // Serialize into the output buffer.
+    // PFOR encodes the exception side-channels through recursive encoding
+    // selection so Nimble can pick the best sub-encoding.
+    // The bulk base residuals always stay raw to preserve the fast decode path.
+    Buffer tempBuffer{buffer.getMemoryPool()};
+    std::string_view exceptionPositionsEncoded{};
+    std::string_view exceptionValuesEncoded{};
+    if (numExceptions > 0) {
+      exceptionPositionsEncoded = selection.template encodeNested<uint32_t>(
+          EncodingIdentifiers::Pfor::ExceptionPositions,
+          std::span<const uint32_t>(exceptionPositions.data(), numExceptions),
+          tempBuffer,
+          options);
+      exceptionValuesEncoded = selection.template encodeNested<physicalType>(
+          EncodingIdentifiers::Pfor::ExceptionValues,
+          std::span<const physicalType>(exceptionValues.data(), numExceptions),
+          tempBuffer,
+          options);
+    }
+    // Two size-prefixed nested streams (positions, values) carry the exception
+    // side-channel.
+    const uint32_t encodingSize = Encoding::serializePrefixSize(
+                                      rowCount, useVarint) +
+        PFOREncoding<T>::kPrefixSize +
+        static_cast<uint32_t>(2 * sizeof(uint32_t) +
+                              exceptionPositionsEncoded.size() +
+                              exceptionValuesEncoded.size() + bitpackedSize);
     char* reserved = buffer.reserve(encodingSize);
     char* pos = reserved;
     Encoding::serializePrefix(
@@ -439,21 +467,11 @@ std::string_view PFOREncoding<T>::encode(
     encoding::write(baseline, pos);
     encoding::writeChar(static_cast<char>(baseBitWidth), pos);
     encoding::writeUint32(numExceptions, pos);
-
-    // Write exception positions (ascending varint sequence).
-    for (uint32_t i = 0; i < numExceptions; ++i) {
-      varint::writeVarint(exceptionPositions[i], &pos);
-    }
-    // Write exception values (full residual varints).
-    for (uint32_t i = 0; i < numExceptions; ++i) {
-      varint::writeVarint(exceptionValues[i], &pos);
-    }
-
-    // Bitpack the masked residuals.
+    encoding::writeString(exceptionPositionsEncoded, pos);
+    encoding::writeString(exceptionValuesEncoded, pos);
     if (baseBitWidth > 0) {
-      char* bitpackedStart = pos;
-      std::memset(bitpackedStart, 0, bitpackedSize);
-      FixedBitArray fba(bitpackedStart, baseBitWidth);
+      std::memset(pos, 0, bitpackedSize);
+      FixedBitArray fba(pos, baseBitWidth);
       fba.bulkSetWithBaseline(
           /*start=*/0,
           /*length=*/rowCount,
@@ -461,7 +479,6 @@ std::string_view PFOREncoding<T>::encode(
           /*baseline=*/physicalType{0});
       pos += bitpackedSize;
     }
-
     NIMBLE_CHECK_EQ(
         pos - reserved, encodingSize, "Pfor encoding size mismatch.");
     return {reserved, encodingSize};

--- a/dwio/nimble/encodings/common/EncodingLayout.cpp
+++ b/dwio/nimble/encodings/common/EncodingLayout.cpp
@@ -23,6 +23,7 @@
 // SubIntSplit integration commented out (disabled):
 // #include "dwio/nimble/encodings/SubIntSplitConfig.h"
 #include "dwio/nimble/encodings/common/EncodingPrimitives.h"
+#include "dwio/nimble/encodings/common/EncodingUtils.h"
 
 namespace facebook::nimble {
 
@@ -370,7 +371,6 @@ EncodingLayout EncodingLayoutCapture::capture(std::string_view encoding) {
     case EncodingType::Prefix:
     case EncodingType::ALP:
     case EncodingType::BlockBitPacking:
-    case EncodingType::PFOR:
     case EncodingType::SimdForBitpack:
     // SubIntSplit integration is disabled; treat it as a non-nested encoding
     // (zero children) so its layout is captured without nested logic.
@@ -382,6 +382,28 @@ EncodingLayout EncodingLayoutCapture::capture(std::string_view encoding) {
     case EncodingType::FrequencyPartition:
       // Non nested encodings have zero children
       break;
+    case EncodingType::PFOR: {
+      const auto dataType =
+          encoding::peek<uint8_t, DataType>(encoding.data() + 1);
+      const char* pos = encoding.data() + kEncodingPrefixSize;
+      pos += detail::dataTypeSize(dataType); // baseline
+      encoding::readChar(pos); // baseBitWidth
+      encoding::readUint32(pos); // numExceptions
+
+      auto captureChild = [&](const char*& cursor) {
+        const uint32_t size = encoding::readUint32(cursor);
+        children.emplace_back(
+            size > 0 ? std::optional<const EncodingLayout>(
+                           EncodingLayoutCapture::capture({cursor, size}))
+                     : std::nullopt);
+        cursor += size;
+      };
+
+      children.reserve(2);
+      captureChild(pos); // exception positions
+      captureChild(pos); // exception values
+      break;
+    }
     case EncodingType::Trivial: {
       const auto dataType =
           encoding::peek<uint8_t, DataType>(encoding.data() + 1);

--- a/dwio/nimble/encodings/selection/EncodingIdentifier.h
+++ b/dwio/nimble/encodings/selection/EncodingIdentifier.h
@@ -71,7 +71,7 @@ struct EncodingIdentifiers {
     // constants are defined here; callers use the index directly.
   };
   */
-  
+
   struct FrequencyPartition {
     // Partition metadata
     // Eventually we may want to allow for non-power-of-two bit partitions, but for now we can just define constants for the power-of-two cases.
@@ -93,6 +93,13 @@ struct EncodingIdentifiers {
     static constexpr NestedEncodingIdentifier Keys32Bit = 13;
     // Unencoded partition (raw values that don't fit in any tier)
     static constexpr NestedEncodingIdentifier UnencodedValues = 14;
+  };
+
+  struct Pfor {
+    // Nested sub-streams for PFOR: the ascending exception positions and the
+    // exception residual values.
+    static constexpr NestedEncodingIdentifier ExceptionPositions = 0;
+    static constexpr NestedEncodingIdentifier ExceptionValues = 1;
   };
 };
 

--- a/dwio/nimble/encodings/tests/EncodingLayoutTest.cpp
+++ b/dwio/nimble/encodings/tests/EncodingLayoutTest.cpp
@@ -26,6 +26,7 @@
 #include "velox/common/memory/Memory.h"
 
 #include <unordered_map>
+#include <utility>
 
 using namespace facebook;
 
@@ -80,7 +81,9 @@ void testSerialization(nimble::EncodingLayout expected) {
 }
 
 template <typename T, typename TCollection = std::vector<T>>
-void testCapture(nimble::EncodingLayout expected, TCollection data) {
+nimble::EncodingLayout encodeAndCapture(
+    nimble::EncodingLayout encodingLayout,
+    TCollection data) {
   nimble::EncodingSelectionPolicyFactory encodingSelectionPolicyFactory =
       [encodingFactory = nimble::ManualEncodingSelectionPolicyFactory{}](
           nimble::DataType dataType)
@@ -92,15 +95,20 @@ void testCapture(nimble::EncodingLayout expected, TCollection data) {
   nimble::Buffer buffer{*defaultPool};
   auto encoding = nimble::EncodingFactory::encode<T>(
       std::make_unique<nimble::ReplayedEncodingSelectionPolicy<T>>(
-          expected,
+          std::move(encodingLayout),
           nimble::CompressionOptions{
               .compressionAcceptRatio = 100, .internalMinCompressionSize = 0},
           encodingSelectionPolicyFactory),
       data,
       buffer);
 
-  auto actual = nimble::EncodingLayoutCapture::capture(encoding);
-  verifyEncodingLayout(expected, actual);
+  return nimble::EncodingLayoutCapture::capture(encoding);
+}
+
+template <typename T, typename TCollection = std::vector<T>>
+void testCapture(nimble::EncodingLayout expected, TCollection data) {
+  verifyEncodingLayout(
+      expected, encodeAndCapture<T>(expected, std::move(data)));
 }
 
 #ifdef NIMBLE_ENABLE_EXPERIMENTAL_ENCODINGS
@@ -232,6 +240,37 @@ TEST(EncodingLayoutTests, Constant) {
 
   testSerialization(expected);
   testCapture<uint32_t>(expected, {1, 1, 1});
+}
+
+TEST(EncodingLayoutTests, Pfor) {
+  // PFOR nests two exception sub-streams (positions, residual values). Capture
+  // records each present sub-stream recursively, like the compound encodings,
+  // so a captured layout reproduces the full PFOR tree.
+  nimble::EncodingLayout pforLayout{
+      nimble::EncodingType::PFOR,
+      {},
+      nimble::CompressionType::Uncompressed,
+      {std::nullopt, std::nullopt}};
+
+  // Serialization preserves the PFOR node and its two child slots.
+  testSerialization(pforLayout);
+
+  // Sparse outliers so the encoding emits exceptions and both nested
+  // sub-streams are present.
+  std::vector<uint32_t> data;
+  data.reserve(500);
+  for (uint32_t i = 0; i < 500; ++i) {
+    data.push_back(i % 10 == 7 ? 100000 + i : 50 + (i % 50));
+  }
+
+  // The nullopt children drive selection to PFOR while letting each sub-stream
+  // re-select; capture must then record both sub-streams' encodings (not
+  // nullopt), proving recursive capture of the nested layout.
+  auto captured = encodeAndCapture<uint32_t>(pforLayout, data);
+  ASSERT_EQ(captured.encodingType(), nimble::EncodingType::PFOR);
+  ASSERT_EQ(captured.childrenCount(), 2);
+  EXPECT_TRUE(captured.child(0).has_value());
+  EXPECT_TRUE(captured.child(1).has_value());
 }
 
 TEST(EncodingLayoutTests, SparseBool) {

--- a/dwio/nimble/encodings/tests/PFOREncodingTest.cpp
+++ b/dwio/nimble/encodings/tests/PFOREncodingTest.cpp
@@ -49,7 +49,10 @@ class PFOREncodingTest : public ::testing::Test {
 
   std::unique_ptr<EncodingSelectionPolicy<T>> createSelectionPolicy() {
     EncodingLayout layout{
-        EncodingType::PFOR, {}, CompressionType::Uncompressed};
+        EncodingType::PFOR,
+        {},
+        CompressionType::Uncompressed,
+        {std::nullopt, std::nullopt}};
     return std::make_unique<ReplayedEncodingSelectionPolicy<T>>(
         std::move(layout),
         CompressionOptions{},
@@ -280,7 +283,10 @@ class PFOREncodingFuzzerTest : public ::testing::Test {
 
       Buffer buffer{*pool_};
       EncodingLayout layout{
-          EncodingType::PFOR, {}, CompressionType::Uncompressed};
+          EncodingType::PFOR,
+          {},
+          CompressionType::Uncompressed,
+          {std::nullopt, std::nullopt}};
       auto policy = std::make_unique<ReplayedEncodingSelectionPolicy<T>>(
           std::move(layout), CompressionOptions{}, factory);
       auto encoded = EncodingFactory::encode<T>(
@@ -350,7 +356,11 @@ TEST_F(PFOREncodingFuzzerTest, fuzzerUint64) {
 
 TEST_F(PFOREncodingFuzzerTest, encodeRejectsEmpty) {
   Buffer buffer{*pool_};
-  EncodingLayout layout{EncodingType::PFOR, {}, CompressionType::Uncompressed};
+  EncodingLayout layout{
+      EncodingType::PFOR,
+      {},
+      CompressionType::Uncompressed,
+      {std::nullopt, std::nullopt}};
   ManualEncodingSelectionPolicyFactory manualFactory;
   EncodingSelectionPolicyFactory factory = [&manualFactory](DataType dataType) {
     return manualFactory.createPolicy(dataType);

--- a/dwio/nimble/serializer/tests/SerializationTest.cpp
+++ b/dwio/nimble/serializer/tests/SerializationTest.cpp
@@ -2132,12 +2132,18 @@ TEST_P(SerializationTest, pforColumnarRoundTrip) {
           {Kind::Scalar,
            {{EncodingLayoutTree::StreamIdentifiers::Scalar::ScalarStream,
              EncodingLayout{
-                 EncodingType::PFOR, {}, CompressionType::Uncompressed}}},
+                 EncodingType::PFOR,
+                 {},
+                 CompressionType::Uncompressed,
+                 {std::nullopt, std::nullopt}}}},
            ""},
           {Kind::Scalar,
            {{EncodingLayoutTree::StreamIdentifiers::Scalar::ScalarStream,
              EncodingLayout{
-                 EncodingType::PFOR, {}, CompressionType::Uncompressed}}},
+                 EncodingType::PFOR,
+                 {},
+                 CompressionType::Uncompressed,
+                 {std::nullopt, std::nullopt}}}},
            ""},
       }};
 

--- a/dwio/nimble/tools/EncodingUtilities.cpp
+++ b/dwio/nimble/tools/EncodingUtilities.cpp
@@ -15,6 +15,7 @@
  */
 #include "dwio/nimble/tools/EncodingUtilities.h"
 #include "dwio/nimble/common/Exceptions.h"
+#include "dwio/nimble/encodings/common/EncodingUtils.h"
 
 namespace facebook::nimble::tools {
 namespace {
@@ -113,12 +114,33 @@ void traverseEncodings(
     case EncodingType::Prefix:
     case EncodingType::ALP:
     case EncodingType::BlockBitPacking:
-    case EncodingType::PFOR:
     case EncodingType::SimdForBitpack:
     // SubIntSplit integration is disabled; treat it as having no nested
     // encoding to traverse.
     case EncodingType::SubIntSplit: {
       // don't have any nested encoding
+      break;
+    }
+    case EncodingType::PFOR: {
+      // Layout after the common prefix: baseline [dataTypeSize bytes],
+      // baseBitWidth [1 byte], numExceptions [4 bytes], then two
+      // self-describing nested sub-streams, each preceded by a 4-byte size:
+      // the exception positions and the exception residual values.
+      const char* pos = stream.data() + kEncodingPrefixSize;
+      pos += detail::dataTypeSize(dataType); // baseline
+      encoding::readChar(pos); // baseBitWidth
+      encoding::readUint32(pos); // numExceptions
+      const uint32_t positionsSize = encoding::readUint32(pos);
+      if (positionsSize > 0) {
+        traverseEncodings(
+            {pos, positionsSize}, level + 1, 0, "ExceptionPositions", visitor);
+      }
+      pos += positionsSize;
+      const uint32_t valuesSize = encoding::readUint32(pos);
+      if (valuesSize > 0) {
+        traverseEncodings(
+            {pos, valuesSize}, level + 1, 1, "ExceptionValues", visitor);
+      }
       break;
     }
     case EncodingType::Trivial: {

--- a/dwio/nimble/tools/tests/EncodingUtilitiesTest.cpp
+++ b/dwio/nimble/tools/tests/EncodingUtilitiesTest.cpp
@@ -79,6 +79,38 @@ class EncodingUtilitiesTest : public ::testing::Test {
     return buf;
   }
 
+  // Build a PFOR-encoded stream wrapping the given exception positions / values
+  // sub-streams. baseBitWidth is 0 so there is no trailing bitpacked residual
+  // region (traverseEncodings does not read it).
+  // Layout:
+  //   bytes 0-5: prefix (EncodingType::PFOR, DataType::Uint32, rowCount)
+  //   bytes 6-9: baseline (uint32)
+  //   byte 10: baseBitWidth (0)
+  //   bytes 11-14: numExceptions (uint32)
+  //   then the positions sub-stream and the values sub-stream, each preceded by
+  //   a 4-byte size.
+  std::string buildPforUint32Stream(
+      uint32_t numExceptions,
+      const std::string& positions,
+      const std::string& values) {
+    uint32_t totalSize = 6 + sizeof(uint32_t) /* baseline */ +
+        1 /* baseBitWidth */ + sizeof(uint32_t) /* numExceptions */ +
+        sizeof(uint32_t) + positions.size() + sizeof(uint32_t) + values.size();
+    std::string buf(totalSize, '\0');
+    char* pos = buf.data();
+    encoding::writeChar(static_cast<char>(EncodingType::PFOR), pos);
+    encoding::writeChar(static_cast<char>(DataType::Uint32), pos);
+    encoding::writeUint32(/* rowCount */ 100, pos);
+    encoding::writeUint32(/* baseline */ 0, pos);
+    encoding::writeChar(/* baseBitWidth */ 0, pos);
+    encoding::writeUint32(numExceptions, pos);
+    encoding::writeUint32(static_cast<uint32_t>(positions.size()), pos);
+    encoding::writeBytes(positions, pos);
+    encoding::writeUint32(static_cast<uint32_t>(values.size()), pos);
+    encoding::writeBytes(values, pos);
+    return buf;
+  }
+
   std::shared_ptr<velox::memory::MemoryPool> pool_;
 };
 
@@ -256,6 +288,77 @@ TEST_F(EncodingUtilitiesTest, GetEncodingLabelWithRealConstantEncoding) {
   auto label = getEncodingLabel(encoded);
   EXPECT_NE(label.find("Constant"), std::string::npos);
   EXPECT_NE(label.find("Uint32"), std::string::npos);
+}
+
+// --- PFOR nested exception sub-streams ---
+
+TEST_F(EncodingUtilitiesTest, TraverseEncodingsPforChildren) {
+  auto positions = buildTrivialUint32Stream({0, 5});
+  auto values = buildTrivialUint32Stream({100, 200});
+  auto stream = buildPforUint32Stream(/* numExceptions */ 2, positions, values);
+
+  EncodingType rootType = EncodingType::Constant; // init to something else
+  std::vector<std::pair<std::string, uint32_t>> nestedVisits; // name, level
+  traverseEncodings(
+      stream,
+      [&](EncodingType encodingType,
+          DataType /* dataType */,
+          uint32_t level,
+          uint32_t /* index */,
+          const std::string& nestedEncodingName,
+          const std::unordered_map<EncodingPropertyType, EncodingProperty>&
+          /* properties */) -> bool {
+        if (level == 0) {
+          rootType = encodingType;
+        } else {
+          nestedVisits.emplace_back(nestedEncodingName, level);
+        }
+        return true;
+      });
+
+  EXPECT_EQ(rootType, EncodingType::PFOR);
+  const std::vector<std::pair<std::string, uint32_t>> expected{
+      {"ExceptionPositions", 1u}, {"ExceptionValues", 1u}};
+  EXPECT_EQ(nestedVisits, expected);
+}
+
+TEST_F(EncodingUtilitiesTest, TraverseEncodingsPforNoExceptions) {
+  // With zero exceptions both sub-streams are empty and must be skipped rather
+  // than traversed (which would read past the end of the stream).
+  auto stream = buildPforUint32Stream(
+      /* numExceptions */ 0, /* positions */ "", /* values */ "");
+
+  int nestedVisitCount = 0;
+  traverseEncodings(
+      stream,
+      [&](EncodingType /* encodingType */,
+          DataType /* dataType */,
+          uint32_t level,
+          uint32_t /* index */,
+          const std::string& /* nestedEncodingName */,
+          const std::unordered_map<EncodingPropertyType, EncodingProperty>&
+          /* properties */) -> bool {
+        if (level > 0) {
+          ++nestedVisitCount;
+        }
+        return true;
+      });
+
+  EXPECT_EQ(nestedVisitCount, 0);
+}
+
+TEST_F(EncodingUtilitiesTest, GetEncodingLabelPfor) {
+  // The rendered label surfaces the picked sub-encodings for the exception
+  // side-channels, e.g. PFOR<Uint32>[ExceptionPositions:Trivial<...>,
+  // ExceptionValues:Trivial<...>].
+  auto positions = buildTrivialUint32Stream({0, 5});
+  auto values = buildTrivialUint32Stream({100, 200});
+  auto stream = buildPforUint32Stream(/* numExceptions */ 2, positions, values);
+
+  auto label = getEncodingLabel(stream);
+  EXPECT_NE(label.find("PFOR"), std::string::npos);
+  EXPECT_NE(label.find("ExceptionPositions:Trivial"), std::string::npos);
+  EXPECT_NE(label.find("ExceptionValues:Trivial"), std::string::npos);
 }
 
 } // namespace facebook::nimble::tools::test


### PR DESCRIPTION
Summary:

Changes `PFOR` to store its exception position/value side-channels as self-describing nested encodings

Reviewed By: xiaoxmeng

Differential Revision: D108198781


