### PR TITLE
refactor(nimble): Extract trailer reader into `legacy/` namespace + dispatch scaffolding (#858)

### DIFF
--- a/dwio/nimble/serializer/CMakeLists.txt
+++ b/dwio/nimble/serializer/CMakeLists.txt
@@ -23,6 +23,10 @@ target_link_libraries(
   Folly::folly
 )
 
+# Must come after nimble_serializer_options is declared since nimble_legacy
+# links against it.
+add_subdirectory(legacy)
+
 add_library(nimble_serialization_header SerializationHeader.cpp)
 target_link_libraries(
   nimble_serialization_header
@@ -39,6 +43,7 @@ target_link_libraries(
   nimble_serializer_options
   nimble_common
   nimble_encodings
+  nimble_legacy
   nimble_velox_stream_data
   velox_memory
 )
@@ -50,6 +55,7 @@ target_link_libraries(
   nimble_serializer_impl
   nimble_serializer_options
   nimble_encodings
+  nimble_legacy
   nimble_velox_schema
   nimble_common
   velox_memory
@@ -85,6 +91,7 @@ target_link_libraries(
   nimble_serialization_header
   nimble_serializer_options
   nimble_serializer_impl
+  nimble_legacy
   nimble_velox_schema_reader
   nimble_common
   velox_type

--- a/dwio/nimble/serializer/DeserializerImpl.h
+++ b/dwio/nimble/serializer/DeserializerImpl.h
@@ -25,6 +25,7 @@
 #include "dwio/nimble/serializer/Options.h"
 #include "dwio/nimble/serializer/SerializationHeader.h"
 #include "dwio/nimble/serializer/SerializerImpl.h"
+#include "dwio/nimble/serializer/legacy/TrailerReader.h"
 #include "dwio/nimble/velox/RowRange.h"
 #include "dwio/nimble/velox/SchemaTypes.h"
 #include "velox/buffer/Buffer.h"
@@ -216,56 +217,37 @@ class StreamDataReader {
   template <typename Callback>
   void iterateStreams(Callback&& callback) {
     if (nonLegacyFormat(version_)) {
-      // kCompactRaw/kTablet: stream sizes are packed into a trailer at the
-      // end of the blob. Fill into reusable member buffers — either the
-      // dense form (most encodings) or the sparse (indices, sizes) form
-      // for MainlyConstant.
-      const bool usesSparseSizes = detail::readTrailerStreamSizes(
-          end_,
-          streamSizesBuf_,
-          sparseStreamIndicesBuf_,
-          sparseStreamSizesBuf_);
-      const bool isTablet = isTabletVersion(version_);
-
-      if (usesSparseSizes) {
-        // Sparse iteration: visit only the non-empty stream slots that
-        // MainlyConstant naturally encodes. No dense scatter, no empty-skip
-        // branch per stream — every iteration emits a callback.
-        const size_t numNonEmptyStreams = sparseStreamIndicesBuf_.size();
-        for (size_t entryIdx = 0; entryIdx < numNonEmptyStreams; ++entryIdx) {
-          const uint32_t streamOffset = sparseStreamIndicesBuf_[entryIdx];
-          const uint32_t streamSize = sparseStreamSizesBuf_[entryIdx];
-          // Defensive: writer should never emit a non-zero-indexed entry
-          // with size 0, but guard so the dense empty-skip semantics still
-          // hold if it ever did.
-          if (streamSize == 0) {
-            continue;
-          }
-          std::string_view streamData(pos_, streamSize);
-          pos_ += streamSize;
-          if (isTablet) {
-            callback(streamOffset, stripChunkHeaders(streamData));
-          } else {
-            callback(streamOffset, streamData);
-          }
-        }
+      // kCompactRaw/kTablet (and any future non-legacy versions): the
+      // stream-size trailer at the end of the blob is dispatched on the
+      // version byte. Today every defined non-legacy version returns true
+      // from `usesLegacyTrailer`, so all blobs flow through the frozen
+      // legacy reader; the else branch is scaffolding for the next diff,
+      // which will introduce a new wire format and a sibling reader.
+      // Reusable member buffers keep the hot path alloc-free across blobs.
+      if (usesLegacyTrailer(version_)) {
+        legacy::readLegacyTrailerStreamMetadata(
+            end_, streamIndices_, streamSizes_);
       } else {
-        const uint32_t numStreams = streamSizesBuf_.size();
-        for (uint32_t streamOffset = 0; streamOffset < numStreams;
-             ++streamOffset) {
-          const uint32_t streamSize = streamSizesBuf_[streamOffset];
-          std::string_view streamData(pos_, streamSize);
-          pos_ += streamSize;
-          if (!streamData.empty()) {
-            if (isTablet) {
-              // kTablet: stream data includes tablet chunk headers:
-              // [chunkSize:u32][compressionType:1B][encoded_data...]
-              // Strip headers and decompress if needed before handing off.
-              callback(streamOffset, stripChunkHeaders(streamData));
-            } else {
-              callback(streamOffset, streamData);
-            }
-          }
+        NIMBLE_UNREACHABLE("unexpected non-legacy trailer version");
+      }
+      const bool isTablet = isTabletVersion(version_);
+      const size_t numStreams = streamIndices_.size();
+      for (size_t entryIdx = 0; entryIdx < numStreams; ++entryIdx) {
+        const uint32_t streamOffset = streamIndices_[entryIdx];
+        const uint32_t streamSize = streamSizes_[entryIdx];
+        // Writer invariant: the sparse trailer only encodes non-zero stream
+        // slots. Debug-only assert documents that invariant; release elides it.
+        NIMBLE_DCHECK_GT(
+            streamSize, 0, "Sparse trailer must not encode zero-sized stream");
+        std::string_view streamData(pos_, streamSize);
+        pos_ += streamSize;
+        if (isTablet) {
+          // kTablet: stream data includes tablet chunk headers:
+          // [chunkSize:u32][compressionType:1B][encoded_data...]
+          // Strip headers and decompress if needed before handing off.
+          callback(streamOffset, stripChunkHeaders(streamData));
+        } else {
+          callback(streamOffset, streamData);
         }
       }
       pos_ = end_; // Skip past trailer.
@@ -344,17 +326,14 @@ class StreamDataReader {
   const char* end_{nullptr};
   // Reusable buffer for chunk header stripping (compressed/multi-chunk case).
   Vector<char> chunkStrippingBuffer_;
-  // Reusable buffer for the per-blob trailer stream-size array. Repopulated
-  // by iterateStreams() on the kCompactRaw/kTablet path; cleared+filled in
-  // place to avoid the fresh malloc/free that the by-value
-  // readTrailerStreamSizes() overload would pay per blob.
-  //
-  // For MainlyConstant trailers, the sparse pair below is populated
-  // instead of `streamSizesBuf_`, letting iterateStreams visit only the
-  // non-empty stream slots directly off the wire encoding.
-  std::vector<uint32_t> streamSizesBuf_;
-  std::vector<uint32_t> sparseStreamIndicesBuf_;
-  std::vector<uint32_t> sparseStreamSizesBuf_;
+  // Reusable parallel buffers for the per-blob sparse trailer. Refilled by
+  // iterateStreams() on the kCompactRaw/kTablet path: streamIndices_ holds
+  // the offsets of non-zero stream slots (sorted ascending); streamSizes_
+  // holds the corresponding byte sizes. Sized to the same length, cleared
+  // and filled in place each blob to keep the hot path alloc-free across
+  // invocations.
+  std::vector<uint32_t> streamIndices_;
+  std::vector<uint32_t> streamSizes_;
 };
 
 } // namespace facebook::nimble::serde

--- a/dwio/nimble/serializer/Options.h
+++ b/dwio/nimble/serializer/Options.h
@@ -85,6 +85,30 @@ inline bool isRawFormat(SerializationVersion version) {
       version == SerializationVersion::kTablet;
 }
 
+/// Returns true if the version was written using the (now frozen) legacy
+/// trailer wire format decoded by `nimble::serde::legacy::`. All currently
+/// defined non-legacy versions (kCompactRaw, kTablet) share that format;
+/// future writer versions that emit a different trailer wire format will
+/// return false from this helper so dispatchers route them to a different
+/// reader.
+///
+/// kTablet is included here today because in master kTablet and kCompactRaw
+/// produce byte-identical trailer layouts (single encoding-type byte +
+/// payload + trailer-size u32) and the same reader code path handles both.
+/// Treating kTablet as legacy in this diff keeps the refactor purely
+/// behavior-preserving.
+///
+/// The next diff (the two-array sparse trailer change) migrates kTablet
+/// onto the new trailer wire format alongside the new kSerialization /
+/// kProjection versions, and this helper will be narrowed to return true
+/// only for kCompactRaw. kCompactRaw is the only version frozen forever
+/// here because it is the only one with existing production blobs that
+/// must remain readable.
+inline bool usesLegacyTrailer(SerializationVersion version) {
+  return version == SerializationVersion::kCompactRaw ||
+      version == SerializationVersion::kTablet;
+}
+
 /// Returns true if the optional version uses raw stream sizes.
 inline bool isRawFormat(std::optional<SerializationVersion> version) {
   return version.has_value() && isRawFormat(version.value());

--- a/dwio/nimble/serializer/Projector.cpp
+++ b/dwio/nimble/serializer/Projector.cpp
@@ -23,6 +23,7 @@
 #include "dwio/nimble/common/Varint.h"
 #include "dwio/nimble/encodings/common/EncodingPrimitives.h"
 #include "dwio/nimble/serializer/SerializerImpl.h"
+#include "dwio/nimble/serializer/legacy/TrailerReader.h"
 #include "dwio/nimble/velox/SchemaUtils.h"
 #include "folly/io/Cursor.h"
 #include "velox/type/Type.h"
@@ -601,7 +602,15 @@ folly::IOBuf Projector::projectContiguous(
   writeSerializationHeader(header, options_.projectVersion, rowCount);
   auto output = std::move(header).build();
 
-  const auto inputStreamSizes = detail::readTrailerStreamSizes(input);
+  // Dispatch on the version byte: legacy kCompactRaw / kTablet blobs go
+  // through the frozen legacy reader; the else branch is scaffolding for the
+  // next change that will introduce a sibling reader for a new wire format.
+  std::vector<uint32_t> inputStreamSizes;
+  if (usesLegacyTrailer(inputVersion)) {
+    inputStreamSizes = legacy::readLegacyTrailerStreamSizesDense(input);
+  } else {
+    NIMBLE_UNREACHABLE("unexpected non-legacy trailer version");
+  }
 
   // Extract selected streams as zero-copy sub-range clones.
   const auto dataOffset = static_cast<size_t>(pos - data);
@@ -628,7 +637,15 @@ folly::IOBuf Projector::projectChained(
   writeSerializationHeader(header, options_.projectVersion, rowCount);
   auto output = std::move(header).build();
 
-  const auto inputStreamSizes = detail::readTrailerStreamSizes(input);
+  // Dispatch on the version byte: legacy kCompactRaw / kTablet blobs go
+  // through the frozen legacy reader; the else branch is scaffolding for the
+  // next change that will introduce a sibling reader for a new wire format.
+  std::vector<uint32_t> inputStreamSizes;
+  if (usesLegacyTrailer(inputVersion)) {
+    inputStreamSizes = legacy::readLegacyTrailerStreamSizesDense(input);
+  } else {
+    NIMBLE_UNREACHABLE("unexpected non-legacy trailer version");
+  }
 
   // Extract selected streams as zero-copy clones via cursor.
   auto outputStreamSizes = inputStreamsSorted_

--- a/dwio/nimble/serializer/SerializerImpl.cpp
+++ b/dwio/nimble/serializer/SerializerImpl.cpp
@@ -20,6 +20,7 @@
 #include <limits>
 
 #include "dwio/nimble/serializer/SerializationHeader.h"
+#include "dwio/nimble/serializer/legacy/TrailerReader.h"
 
 #include <lz4.h>
 #include <lz4hc.h>
@@ -470,12 +471,25 @@ std::vector<std::string_view> parseStreams(
   std::vector<std::string_view> streams;
 
   if (isCompactFormat(version)) {
-    const auto streamSizes = readTrailerStreamSizes(end);
-    streams.resize(streamSizes.size());
-
-    for (uint32_t i = 0; i < streamSizes.size(); ++i) {
-      streams[i] = std::string_view(pos, streamSizes[i]);
-      pos += streamSizes[i];
+    // Dispatch on the version byte: legacy kCompactRaw blobs go through the
+    // frozen reader; the else branch is scaffolding for the next diff, which
+    // will introduce a new wire format and a sibling reader.
+    std::vector<uint32_t> streamIndices;
+    std::vector<uint32_t> streamSizes;
+    if (usesLegacyTrailer(version)) {
+      std::tie(streamIndices, streamSizes) =
+          legacy::readLegacyTrailerStreamMetadata(end);
+    } else {
+      NIMBLE_UNREACHABLE("unexpected non-legacy trailer version");
+    }
+    // Sparse-place: streams[streamIndices[k]] = stream bytes; gaps remain
+    // empty string_views, matching master's dense-output behavior.
+    if (!streamIndices.empty()) {
+      streams.resize(streamIndices.back() + 1);
+      for (size_t k = 0; k < streamIndices.size(); ++k) {
+        streams[streamIndices[k]] = std::string_view(pos, streamSizes[k]);
+        pos += streamSizes[k];
+      }
     }
   } else {
     NIMBLE_CHECK_EQ(

--- a/dwio/nimble/serializer/legacy/CMakeLists.txt
+++ b/dwio/nimble/serializer/legacy/CMakeLists.txt
@@ -1,0 +1,23 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+add_library(nimble_legacy TrailerReader.cpp)
+target_link_libraries(
+  nimble_legacy
+  nimble_serializer_options
+  nimble_common
+  nimble_encodings
+  Folly::folly
+)
+
+add_subdirectory(tests)

--- a/dwio/nimble/serializer/legacy/TrailerReader.cpp
+++ b/dwio/nimble/serializer/legacy/TrailerReader.cpp
@@ -1,0 +1,366 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "dwio/nimble/serializer/legacy/TrailerReader.h"
+
+#include <cstring>
+#include <string>
+
+#include <folly/io/Cursor.h>
+
+#include "dwio/nimble/common/Exceptions.h"
+#include "dwio/nimble/common/FixedBitArray.h"
+#include "dwio/nimble/common/Varint.h"
+#include "dwio/nimble/encodings/common/EncodingPrimitives.h"
+#include "dwio/nimble/serializer/Options.h"
+
+namespace facebook::nimble::serde::legacy {
+
+namespace {
+
+// Defensive sanity ceiling on the encoded trailer-size suffix. Production
+// stripe trailers are well under this (typical low-MB at worst). Anything
+// past this is treated as buffer corruption rather than a legitimate
+// allocation request.
+constexpr uint32_t kMaxLegacyTrailerBytes = 1u << 26; // 64 MiB.
+
+// Reads the trailing u32 trailer-size suffix from the last 4 bytes of the
+// buffer.
+inline uint32_t readTrailerSize(const char* end) {
+  const char* pos = end - sizeof(uint32_t);
+  return encoding::readUint32(pos);
+}
+
+void decodeTrivialTrailer(
+    const char*& payload,
+    uint32_t payloadSize,
+    std::vector<uint32_t>& sizes) {
+  const uint32_t count = payloadSize / sizeof(uint32_t);
+  sizes.resize(count);
+  if (count > 0) {
+    std::memcpy(sizes.data(), payload, count * sizeof(uint32_t));
+    payload += count * sizeof(uint32_t);
+  }
+}
+
+// Bound: each varint is at least one byte, so `count <= payloadSize` is a
+// sufficient sanity ceiling against trailer corruption.
+void decodeVarintTrailer(
+    const char*& payload,
+    uint32_t payloadSize,
+    std::vector<uint32_t>& sizes) {
+  const uint32_t count = varint::readVarint32(&payload);
+  NIMBLE_CHECK_LE(
+      count, payloadSize, "Legacy Varint trailer count exceeds payload size");
+  sizes.resize(count);
+  // NOLINTBEGIN(facebook-hte-ParameterUncheckedArrayBounds)
+  for (uint32_t i = 0; i < count; ++i) {
+    sizes[i] = varint::readVarint32(&payload);
+  }
+  // NOLINTEND(facebook-hte-ParameterUncheckedArrayBounds)
+}
+
+// Bound: each varint is at least one byte, so `count <= payloadSize` is a
+// sufficient sanity ceiling against trailer corruption.
+void decodeDeltaTrailer(
+    const char*& payload,
+    uint32_t payloadSize,
+    std::vector<uint32_t>& sizes) {
+  const uint32_t count = varint::readVarint32(&payload);
+  NIMBLE_CHECK_LE(
+      count, payloadSize, "Legacy Delta trailer count exceeds payload size");
+  sizes.resize(count);
+  if (count > 0) {
+    // NOLINTBEGIN(facebook-hte-ParameterUncheckedArrayBounds)
+    sizes[0] = varint::readVarint32(&payload);
+    for (uint32_t i = 1; i < count; ++i) {
+      const auto delta = varint::readVarint32(&payload);
+      sizes[i] = sizes[i - 1] + delta;
+    }
+    // NOLINTEND(facebook-hte-ParameterUncheckedArrayBounds)
+  }
+}
+
+// Frozen snapshot of master's `decodeFixedBitWidthTrailer`.
+// Bound: each value occupies at least 1 bit, so `count <= payloadSize * 8`
+// is a generous sanity ceiling against trailer corruption.
+void decodeFixedBitWidthTrailer(
+    const char*& payload,
+    uint32_t payloadSize,
+    std::vector<uint32_t>& sizes) {
+  const uint8_t bitWidth = static_cast<uint8_t>(*payload++);
+  NIMBLE_CHECK_LE(
+      bitWidth, 32, "Legacy FixedBitWidth trailer bitWidth exceeds 32 bits");
+  const uint32_t count = varint::readVarint32(&payload);
+  NIMBLE_CHECK_LE(
+      static_cast<uint64_t>(count),
+      static_cast<uint64_t>(payloadSize) * 8u,
+      "Legacy FixedBitWidth trailer count exceeds payload bit-capacity");
+  sizes.assign(count, 0);
+  if (bitWidth > 0 && count > 0) {
+    const uint32_t packedBytes =
+        static_cast<uint32_t>(FixedBitArray::bufferSize(count, bitWidth));
+    FixedBitArray arr{const_cast<char*>(payload), static_cast<int>(bitWidth)};
+    arr.bulkGet32(0, count, sizes.data());
+    payload += packedBytes;
+  }
+}
+
+// Sparse-native MainlyConstant decoder: fills parallel (indices, sizes)
+// arrays for only the non-zero stream slots.
+// Bound: `nonZeroCount` must be <= `streamCount` (existing master invariant)
+// AND <= `payloadSize` (sanity against trailer corruption that would force
+// huge allocations even with a consistent streamCount).
+void decodeMainlyConstantTrailerSparse(
+    const char*& payload,
+    uint32_t payloadSize,
+    std::vector<uint32_t>& indices,
+    std::vector<uint32_t>& sizes) {
+  const uint32_t streamCount = varint::readVarint32(&payload);
+  const uint32_t nonZeroCount = varint::readVarint32(&payload);
+  NIMBLE_CHECK_LE(
+      nonZeroCount,
+      streamCount,
+      "MainlyConstant nonZeroCount exceeds streamCount");
+  NIMBLE_CHECK_LE(
+      nonZeroCount,
+      payloadSize,
+      "MainlyConstant nonZeroCount exceeds payload size");
+  indices.resize(nonZeroCount);
+  sizes.resize(nonZeroCount);
+  if (nonZeroCount == 0) {
+    return;
+  }
+
+  const uint8_t idxBitWidth = static_cast<uint8_t>(*payload++);
+  NIMBLE_CHECK_LE(
+      idxBitWidth, 32, "MainlyConstant idxBitWidth exceeds 32 bits");
+  const uint32_t packedIndicesBytes = static_cast<uint32_t>(
+      FixedBitArray::bufferSize(nonZeroCount, idxBitWidth));
+  FixedBitArray idxArr{
+      const_cast<char*>(payload), static_cast<int>(idxBitWidth)};
+  idxArr.bulkGet32(0, nonZeroCount, indices.data());
+  payload += packedIndicesBytes;
+
+  // Validate decoded indices against streamCount. Catches trailer corruption.
+  for (uint32_t i = 0; i < nonZeroCount; ++i) {
+    NIMBLE_CHECK_LT(
+        indices[i], streamCount, "MainlyConstant trailer index out of range");
+  }
+
+  const uint8_t valBitWidth = static_cast<uint8_t>(*payload++);
+  NIMBLE_CHECK_LE(
+      valBitWidth, 32, "MainlyConstant valBitWidth exceeds 32 bits");
+  const uint32_t packedValuesBytes = static_cast<uint32_t>(
+      FixedBitArray::bufferSize(nonZeroCount, valBitWidth));
+  FixedBitArray valArr{
+      const_cast<char*>(payload), static_cast<int>(valBitWidth)};
+  valArr.bulkGet32(0, nonZeroCount, sizes.data());
+  payload += packedValuesBytes;
+}
+
+// Decodes the dense path (everything except MainlyConstant) into a dense
+// vector, then the public API scatters it into sparse (streamIndices,
+// streamSizes) pairs.
+void decodeDenseTrailer(
+    EncodingType encodingType,
+    const char*& payload,
+    uint32_t payloadSize,
+    const char* trailerEnd,
+    std::vector<uint32_t>& denseSizes) {
+  // NOLINTNEXTLINE(clang-diagnostic-switch-enum)
+  switch (encodingType) {
+    case EncodingType::Trivial:
+      decodeTrivialTrailer(payload, payloadSize, denseSizes);
+      break;
+    case EncodingType::Varint:
+      decodeVarintTrailer(payload, payloadSize, denseSizes);
+      break;
+    case EncodingType::Delta:
+      decodeDeltaTrailer(payload, payloadSize, denseSizes);
+      break;
+    case EncodingType::FixedBitWidth:
+      decodeFixedBitWidthTrailer(payload, payloadSize, denseSizes);
+      break;
+    default:
+      NIMBLE_FAIL(
+          "Unsupported EncodingType for legacy trailer dense path: {}",
+          encodingType);
+  }
+  NIMBLE_CHECK_EQ(
+      payload,
+      trailerEnd,
+      "Legacy trailer size mismatch (dense): read {} bytes, expected {}",
+      payload - (trailerEnd - payloadSize - sizeof(uint8_t)),
+      payloadSize + sizeof(uint8_t));
+}
+
+// Walks `denseSizes` once and emits `(i, denseSizes[i])` for every non-zero
+// entry into the output sparse pair. Used to normalize the dense decoder
+// output into the same shape MainlyConstant naturally produces.
+void scatterDenseToSparse(
+    const std::vector<uint32_t>& denseSizes,
+    std::vector<uint32_t>& streamIndices,
+    std::vector<uint32_t>& streamSizes) {
+  streamIndices.clear();
+  streamSizes.clear();
+  streamIndices.reserve(denseSizes.size());
+  streamSizes.reserve(denseSizes.size());
+  for (uint32_t i = 0; i < denseSizes.size(); ++i) {
+    if (denseSizes[i] != 0) {
+      streamIndices.emplace_back(i);
+      streamSizes.emplace_back(denseSizes[i]);
+    }
+  }
+}
+
+// Decodes the trailer bytes between [trailerStart, trailerStart+trailerSize)
+// into normalized sparse (streamIndices, streamSizes) pairs regardless of the
+// underlying encoding type.
+void decodeTrailerToSparse(
+    const char* trailerStart,
+    uint32_t trailerSize,
+    std::vector<uint32_t>& streamIndices,
+    std::vector<uint32_t>& streamSizes) {
+  NIMBLE_CHECK_GT(
+      trailerSize, 0, "Legacy trailer must contain at least an encoding byte");
+  const auto* trailerEnd = trailerStart + trailerSize;
+  const auto encodingType =
+      static_cast<EncodingType>(static_cast<uint8_t>(*trailerStart));
+  const char* payload = trailerStart + sizeof(uint8_t);
+  const uint32_t payloadSize = trailerSize - sizeof(uint8_t);
+
+  if (encodingType == EncodingType::MainlyConstant) {
+    decodeMainlyConstantTrailerSparse(
+        payload, payloadSize, streamIndices, streamSizes);
+    NIMBLE_CHECK_EQ(
+        payload,
+        trailerEnd,
+        "Legacy trailer size mismatch (MainlyConstant): read {} bytes, expected {}",
+        payload - trailerStart,
+        trailerSize);
+    return;
+  }
+
+  // Dense path: decode into a temp dense vector then scatter to sparse.
+  std::vector<uint32_t> denseSizes;
+  decodeDenseTrailer(
+      encodingType, payload, payloadSize, trailerEnd, denseSizes);
+  scatterDenseToSparse(denseSizes, streamIndices, streamSizes);
+}
+
+} // namespace
+
+void readLegacyTrailerStreamMetadata(
+    const char* end,
+    std::vector<uint32_t>& streamIndices,
+    std::vector<uint32_t>& streamSizes) {
+  const uint32_t trailerSize = readTrailerSize(end);
+  NIMBLE_CHECK_LE(
+      trailerSize,
+      kMaxLegacyTrailerBytes,
+      "Legacy trailer size sanity cap exceeded (likely buffer corruption): {} > {}",
+      trailerSize,
+      kMaxLegacyTrailerBytes);
+  const char* trailerStart = end - sizeof(uint32_t) - trailerSize;
+  decodeTrailerToSparse(trailerStart, trailerSize, streamIndices, streamSizes);
+}
+
+std::pair<std::vector<uint32_t>, std::vector<uint32_t>>
+readLegacyTrailerStreamMetadata(const char* end) {
+  std::vector<uint32_t> streamIndices;
+  std::vector<uint32_t> streamSizes;
+  readLegacyTrailerStreamMetadata(end, streamIndices, streamSizes);
+  return {std::move(streamIndices), std::move(streamSizes)};
+}
+
+std::pair<std::vector<uint32_t>, std::vector<uint32_t>>
+readLegacyTrailerStreamMetadata(const folly::IOBuf& input) {
+  // Fast path: trailer fits in the tail segment.
+  const auto* tail = input.prev();
+  if (tail->length() >= sizeof(uint32_t)) {
+    const auto* tailEnd =
+        reinterpret_cast<const char*>(tail->data()) + tail->length();
+    const uint32_t trailerSize = readTrailerSize(tailEnd);
+    if (tail->length() >= sizeof(uint32_t) + trailerSize) {
+      // Tail fast path: defer the kMaxLegacyTrailerBytes bound check to the
+      // raw-pointer overload below.
+      return readLegacyTrailerStreamMetadata(tailEnd);
+    }
+  }
+
+  // Fallback: trailer spans chain boundary — use cursor + pull().
+  const auto totalLength = input.computeChainDataLength();
+  folly::io::Cursor trailerCursor(&input);
+  trailerCursor.skip(totalLength - sizeof(uint32_t));
+  const uint32_t trailerSize = trailerCursor.read<uint32_t>();
+  NIMBLE_CHECK_LE(
+      trailerSize,
+      kMaxLegacyTrailerBytes,
+      "Legacy trailer size sanity cap exceeded (likely buffer corruption): {} > {}",
+      trailerSize,
+      kMaxLegacyTrailerBytes);
+  // Bound trailerSize against the actual IOBuf chain length so a corrupted
+  // value cannot drive a huge std::string allocation.
+  NIMBLE_CHECK_LE(
+      static_cast<uint64_t>(trailerSize) + sizeof(uint32_t),
+      totalLength,
+      "Legacy trailer size exceeds IOBuf chain length: trailerSize={}, chain={}",
+      trailerSize,
+      totalLength);
+
+  folly::io::Cursor sizesCursor(&input);
+  sizesCursor.skip(totalLength - sizeof(uint32_t) - trailerSize);
+  std::string trailerBuf(trailerSize, '\0');
+  sizesCursor.pull(trailerBuf.data(), trailerSize);
+  std::vector<uint32_t> streamIndices;
+  std::vector<uint32_t> streamSizes;
+  decodeTrailerToSparse(
+      trailerBuf.data(), trailerSize, streamIndices, streamSizes);
+  return {std::move(streamIndices), std::move(streamSizes)};
+}
+
+namespace {
+
+std::vector<uint32_t> scatterSparseToDense(
+    const std::vector<uint32_t>& indices,
+    const std::vector<uint32_t>& sizes) {
+  std::vector<uint32_t> dense;
+  if (!indices.empty()) {
+    dense.assign(indices.back() + 1, 0);
+    // NOLINTBEGIN(facebook-hte-LocalUncheckedArrayBounds)
+    for (size_t i = 0; i < indices.size(); ++i) {
+      dense[indices[i]] = sizes[i];
+    }
+    // NOLINTEND(facebook-hte-LocalUncheckedArrayBounds)
+  }
+  return dense;
+}
+
+} // namespace
+
+std::vector<uint32_t> readLegacyTrailerStreamSizesDense(const char* end) {
+  auto [indices, sizes] = readLegacyTrailerStreamMetadata(end);
+  return scatterSparseToDense(indices, sizes);
+}
+
+std::vector<uint32_t> readLegacyTrailerStreamSizesDense(
+    const folly::IOBuf& input) {
+  auto [indices, sizes] = readLegacyTrailerStreamMetadata(input);
+  return scatterSparseToDense(indices, sizes);
+}
+
+} // namespace facebook::nimble::serde::legacy

--- a/dwio/nimble/serializer/legacy/TrailerReader.h
+++ b/dwio/nimble/serializer/legacy/TrailerReader.h
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <cstdint>
+#include <utility>
+#include <vector>
+
+#include <folly/io/IOBuf.h>
+
+// Read-only legacy reader for the original kCompactRaw trailer wire format
+// (single encoding-type byte + dense payload, or MainlyConstant-special-case
+// sparse pair). Used by callers that need to decode existing production hybrid
+// Nimble blobs after the main serializer trailer wire format evolves.
+//
+// The public API normalizes master's dense-vs-sparse output divergence into a
+// uniform sparse (streamIndices, streamSizes) pair — the same shape the new
+// `detail::readTrailerStreamMetadata` returns — so dispatchers can pick
+// between the two implementations with a single-line version branch.
+
+namespace facebook::nimble::serde::legacy {
+
+/// Reads the legacy kCompactRaw trailer from the end of a contiguous buffer.
+/// Fills `streamIndices` (offsets of non-zero stream slots, sorted ascending)
+/// and `streamSizes` (their byte sizes), parallel arrays of identical length.
+/// Both vectors are reusable buffers owned by the caller (e.g. members on
+/// `StreamDataReader`) to keep the per-blob hot path alloc-free across
+/// invocations.
+void readLegacyTrailerStreamMetadata(
+    const char* end,
+    std::vector<uint32_t>& streamIndices,
+    std::vector<uint32_t>& streamSizes);
+
+/// Value-returning convenience overload for cold-path consumers (tests, dump
+/// tools). Returns parallel (streamIndices, streamSizes) arrays.
+std::pair<std::vector<uint32_t>, std::vector<uint32_t>>
+readLegacyTrailerStreamMetadata(const char* end);
+
+/// IOBuf overload: reads the trailer from a (possibly chained) IOBuf. Tries
+/// the fast path first (entire trailer in the tail segment), falls back to
+/// cursor + pull() when the trailer spans a chain boundary.
+std::pair<std::vector<uint32_t>, std::vector<uint32_t>>
+readLegacyTrailerStreamMetadata(const folly::IOBuf& input);
+
+/// Convenience overloads that scatter the sparse pair returned by
+/// `readLegacyTrailerStreamMetadata` into a dense vector indexed by stream
+/// offset. Empty stream slots remain 0; the returned vector's length is
+/// `lastNonEmptyOffset + 1` (or empty if no non-zero entries exist).
+/// For callers that need the dense layout (projector helpers, dump tools).
+std::vector<uint32_t> readLegacyTrailerStreamSizesDense(const char* end);
+
+std::vector<uint32_t> readLegacyTrailerStreamSizesDense(
+    const folly::IOBuf& input);
+
+} // namespace facebook::nimble::serde::legacy

--- a/dwio/nimble/serializer/legacy/tests/CMakeLists.txt
+++ b/dwio/nimble/serializer/legacy/tests/CMakeLists.txt
@@ -1,0 +1,24 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+add_executable(nimble_legacy_tests TrailerReaderTest.cpp)
+add_test(nimble_legacy_tests nimble_legacy_tests)
+
+target_link_libraries(
+  nimble_legacy_tests
+  nimble_legacy
+  nimble_serializer_options
+  gtest
+  gtest_main
+  Folly::folly
+)

--- a/dwio/nimble/serializer/legacy/tests/TrailerReaderTest.cpp
+++ b/dwio/nimble/serializer/legacy/tests/TrailerReaderTest.cpp
@@ -1,0 +1,335 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <algorithm>
+#include <bit>
+#include <cstring>
+#include <string>
+#include <vector>
+
+#include <gtest/gtest.h>
+
+#include "dwio/nimble/serializer/Options.h"
+#include "dwio/nimble/serializer/legacy/TrailerReader.h"
+
+namespace facebook::nimble::serde::legacy {
+namespace {
+
+// Builds a legacy Trivial-encoded kCompactRaw trailer for the given sizes:
+//   [encodingByte=Trivial][raw u32 array][trailerSize:u32]
+std::string buildLegacyTrivialTrailer(const std::vector<uint32_t>& sizes) {
+  std::string buffer;
+  buffer.push_back(static_cast<char>(EncodingType::Trivial));
+  buffer.append(
+      reinterpret_cast<const char*>(sizes.data()),
+      sizes.size() * sizeof(uint32_t));
+  const uint32_t trailerSize = static_cast<uint32_t>(buffer.size());
+  buffer.append(reinterpret_cast<const char*>(&trailerSize), sizeof(uint32_t));
+  return buffer;
+}
+
+// Writes a varint32 onto the back of |buf| (matches master's writeVarint).
+void appendVarint32(std::string& buf, uint32_t value) {
+  while (value >= 128) {
+    buf.push_back(static_cast<char>((value & 127) | 128));
+    value >>= 7;
+  }
+  buf.push_back(static_cast<char>(value));
+}
+
+// Bit-packs |values| at |bitWidth| in the same little-endian layout that
+// FixedBitArray::bulkGet32 expects (matches master's bulkSet32 byte order).
+// Buffer size matches FixedBitArray::bufferSize.
+std::string packFixedBitWidth(
+    const std::vector<uint32_t>& values,
+    int bitWidth) {
+  if (values.empty()) {
+    // bitWidth==0 OR empty input: emit only the slop bytes.
+    return std::string(7, '\0');
+  }
+  const uint64_t totalBits = values.size() * static_cast<uint64_t>(bitWidth);
+  const uint64_t bufSize = ((totalBits + 7) / 8) + /*slop=*/7;
+  std::string buf(bufSize, '\0');
+  if (bitWidth == 0) {
+    return buf;
+  }
+  uint64_t bitsOffset = 0;
+  for (const auto v : values) {
+    const uint64_t byteOffset = bitsOffset >> 3;
+    const uint64_t bitsRemainder = bitsOffset & 7;
+    uint64_t word;
+    std::memcpy(&word, buf.data() + byteOffset, sizeof(word));
+    word |= (static_cast<uint64_t>(v) << bitsRemainder);
+    std::memcpy(buf.data() + byteOffset, &word, sizeof(word));
+    bitsOffset += static_cast<uint64_t>(bitWidth);
+  }
+  return buf;
+}
+
+// Builds a legacy MainlyConstant-encoded kCompactRaw trailer for the given
+// (streamCount, indices, sizes) shape. Mirrors master's writer wire format:
+//   [encodingByte=MainlyConstant]
+//   [streamCount:varint][nonZeroCount:varint]
+//   (only when nonZeroCount > 0:)
+//     [idxBitWidth:1B][packed indices]
+//     [valBitWidth:1B][packed values]
+//   [trailerSize:u32]
+//
+// The early-return on `nonZeroCount == 0` is part of the master decoder's
+// invariant; the writer must not emit bit-width bytes in that case or the
+// post-decode `NIMBLE_CHECK_EQ(payload, trailerEnd)` will mismatch.
+std::string buildLegacyMainlyConstantTrailer(
+    uint32_t streamCount,
+    const std::vector<uint32_t>& indices,
+    const std::vector<uint32_t>& sizes) {
+  EXPECT_EQ(indices.size(), sizes.size());
+  std::string buffer;
+  buffer.push_back(static_cast<char>(EncodingType::MainlyConstant));
+  appendVarint32(buffer, streamCount);
+  appendVarint32(buffer, static_cast<uint32_t>(indices.size()));
+
+  if (!indices.empty()) {
+    const auto idxBitWidth = static_cast<uint8_t>(
+        std::bit_width(*std::max_element(indices.begin(), indices.end())));
+    buffer.push_back(static_cast<char>(idxBitWidth));
+    buffer.append(packFixedBitWidth(indices, idxBitWidth));
+
+    const auto valBitWidth = static_cast<uint8_t>(
+        std::bit_width(*std::max_element(sizes.begin(), sizes.end())));
+    buffer.push_back(static_cast<char>(valBitWidth));
+    buffer.append(packFixedBitWidth(sizes, valBitWidth));
+  }
+
+  const uint32_t trailerSize = static_cast<uint32_t>(buffer.size());
+  buffer.append(reinterpret_cast<const char*>(&trailerSize), sizeof(uint32_t));
+  return buffer;
+}
+
+TEST(LegacyTrailerReaderTest, readLegacyTrailerStreamMetadataTrivialSparse) {
+  // Dense input has zeros that should be filtered out by the
+  // normalize-to-sparse step inside the legacy reader.
+  const std::vector<uint32_t> denseSizes = {0, 17, 0, 0, 42, 99, 0};
+  const auto buffer = buildLegacyTrivialTrailer(denseSizes);
+
+  const auto* end = buffer.data() + buffer.size();
+  auto [streamIndices, streamSizes] = readLegacyTrailerStreamMetadata(end);
+
+  ASSERT_EQ(streamIndices.size(), streamSizes.size());
+  ASSERT_EQ(streamIndices.size(), 3u);
+  EXPECT_EQ(streamIndices[0], 1u);
+  EXPECT_EQ(streamIndices[1], 4u);
+  EXPECT_EQ(streamIndices[2], 5u);
+  EXPECT_EQ(streamSizes[0], 17u);
+  EXPECT_EQ(streamSizes[1], 42u);
+  EXPECT_EQ(streamSizes[2], 99u);
+}
+
+TEST(LegacyTrailerReaderTest, readLegacyTrailerStreamMetadataTrivialDense) {
+  // All-non-zero input: every slot appears in the normalized sparse pair.
+  const std::vector<uint32_t> denseSizes = {1, 2, 3, 4, 5};
+  const auto buffer = buildLegacyTrivialTrailer(denseSizes);
+
+  const auto* end = buffer.data() + buffer.size();
+  auto [streamIndices, streamSizes] = readLegacyTrailerStreamMetadata(end);
+
+  ASSERT_EQ(streamIndices.size(), 5u);
+  for (uint32_t i = 0; i < 5; ++i) {
+    EXPECT_EQ(streamIndices[i], i);
+    EXPECT_EQ(streamSizes[i], denseSizes[i]);
+  }
+}
+
+TEST(LegacyTrailerReaderTest, readLegacyTrailerStreamMetadataTrivialEmpty) {
+  // Empty input -> empty trailer + empty sparse output.
+  const std::vector<uint32_t> denseSizes;
+  const auto buffer = buildLegacyTrivialTrailer(denseSizes);
+
+  const auto* end = buffer.data() + buffer.size();
+  auto [streamIndices, streamSizes] = readLegacyTrailerStreamMetadata(end);
+
+  EXPECT_TRUE(streamIndices.empty());
+  EXPECT_TRUE(streamSizes.empty());
+}
+
+TEST(
+    LegacyTrailerReaderTest,
+    readLegacyTrailerStreamMetadataMainlyConstantSparse) {
+  // Typical MainlyConstant case: 8 stream slots, 3 of them non-zero.
+  const uint32_t streamCount = 8;
+  const std::vector<uint32_t> indices = {1, 4, 5};
+  const std::vector<uint32_t> sizes = {17, 42, 99};
+  const auto buffer =
+      buildLegacyMainlyConstantTrailer(streamCount, indices, sizes);
+
+  const auto* end = buffer.data() + buffer.size();
+  auto [streamIndices, streamSizes] = readLegacyTrailerStreamMetadata(end);
+
+  ASSERT_EQ(streamIndices.size(), 3u);
+  ASSERT_EQ(streamSizes.size(), 3u);
+  EXPECT_EQ(streamIndices, indices);
+  EXPECT_EQ(streamSizes, sizes);
+}
+
+TEST(
+    LegacyTrailerReaderTest,
+    readLegacyTrailerStreamMetadataMainlyConstantEmpty) {
+  // nonZeroCount==0 path: the reader must short-circuit before reading any
+  // bit-width bytes. streamCount stays at 0 here too — the most common shape
+  // for an all-empty stripe in production.
+  const auto buffer = buildLegacyMainlyConstantTrailer(
+      /*streamCount=*/0, /*indices=*/{}, /*sizes=*/{});
+
+  const auto* end = buffer.data() + buffer.size();
+  auto [streamIndices, streamSizes] = readLegacyTrailerStreamMetadata(end);
+
+  EXPECT_TRUE(streamIndices.empty());
+  EXPECT_TRUE(streamSizes.empty());
+}
+
+TEST(
+    LegacyTrailerReaderTest,
+    readLegacyTrailerStreamMetadataMainlyConstantDense) {
+  // Edge case: every slot non-zero. nonZeroCount == streamCount; the
+  // NIMBLE_CHECK_LE(nonZeroCount, streamCount) bound must accept equality.
+  const uint32_t streamCount = 4;
+  const std::vector<uint32_t> indices = {0, 1, 2, 3};
+  const std::vector<uint32_t> sizes = {7, 8, 9, 10};
+  const auto buffer =
+      buildLegacyMainlyConstantTrailer(streamCount, indices, sizes);
+
+  const auto* end = buffer.data() + buffer.size();
+  auto [streamIndices, streamSizes] = readLegacyTrailerStreamMetadata(end);
+
+  EXPECT_EQ(streamIndices, indices);
+  EXPECT_EQ(streamSizes, sizes);
+}
+
+TEST(
+    LegacyTrailerReaderTest,
+    readLegacyTrailerStreamMetadataMainlyConstantMaxBitWidth) {
+  // Stress the bit-packer at the FixedBitWidth ceiling: sizes hold a
+  // ~32-bit value so valBitWidth == 32 (the largest accepted by the
+  // decoder's NIMBLE_CHECK_LE valBitWidth, 32 bound).
+  const uint32_t streamCount = 1u << 30;
+  const std::vector<uint32_t> indices = {0, (1u << 29), (1u << 30) - 1};
+  const std::vector<uint32_t> sizes = {1u, 0xDEADBEEFu, 0xFFFFFFFFu / 2u};
+  const auto buffer =
+      buildLegacyMainlyConstantTrailer(streamCount, indices, sizes);
+
+  const auto* end = buffer.data() + buffer.size();
+  auto [streamIndices, streamSizes] = readLegacyTrailerStreamMetadata(end);
+
+  EXPECT_EQ(streamIndices, indices);
+  EXPECT_EQ(streamSizes, sizes);
+}
+
+// Builds a legacy Varint-encoded kCompactRaw trailer:
+//   [encodingByte=Varint][count:varint][v_0:varint]...[v_N:varint]
+//   [trailerSize:u32]
+std::string buildLegacyVarintTrailer(const std::vector<uint32_t>& denseSizes) {
+  std::string buffer;
+  buffer.push_back(static_cast<char>(EncodingType::Varint));
+  appendVarint32(buffer, static_cast<uint32_t>(denseSizes.size()));
+  for (const auto v : denseSizes) {
+    appendVarint32(buffer, v);
+  }
+  const uint32_t trailerSize = static_cast<uint32_t>(buffer.size());
+  buffer.append(reinterpret_cast<const char*>(&trailerSize), sizeof(uint32_t));
+  return buffer;
+}
+
+// Builds a legacy Delta-encoded kCompactRaw trailer:
+//   [encodingByte=Delta][count:varint][first:varint][delta_1:varint]...
+//   [trailerSize:u32]
+std::string buildLegacyDeltaTrailer(const std::vector<uint32_t>& denseSizes) {
+  std::string buffer;
+  buffer.push_back(static_cast<char>(EncodingType::Delta));
+  appendVarint32(buffer, static_cast<uint32_t>(denseSizes.size()));
+  if (!denseSizes.empty()) {
+    appendVarint32(buffer, denseSizes[0]);
+    for (size_t i = 1; i < denseSizes.size(); ++i) {
+      appendVarint32(buffer, denseSizes[i] - denseSizes[i - 1]);
+    }
+  }
+  const uint32_t trailerSize = static_cast<uint32_t>(buffer.size());
+  buffer.append(reinterpret_cast<const char*>(&trailerSize), sizeof(uint32_t));
+  return buffer;
+}
+
+// Builds a legacy FixedBitWidth-encoded kCompactRaw trailer:
+//   [encodingByte=FixedBitWidth][bitWidth:1B][count:varint][packed bytes]
+//   [trailerSize:u32]
+std::string buildLegacyFixedBitWidthTrailer(
+    const std::vector<uint32_t>& denseSizes) {
+  std::string buffer;
+  buffer.push_back(static_cast<char>(EncodingType::FixedBitWidth));
+  const uint8_t bitWidth = denseSizes.empty()
+      ? uint8_t{0}
+      : static_cast<uint8_t>(std::bit_width(
+            *std::max_element(denseSizes.begin(), denseSizes.end())));
+  buffer.push_back(static_cast<char>(bitWidth));
+  appendVarint32(buffer, static_cast<uint32_t>(denseSizes.size()));
+  if (!denseSizes.empty()) {
+    buffer.append(packFixedBitWidth(denseSizes, bitWidth));
+  }
+  const uint32_t trailerSize = static_cast<uint32_t>(buffer.size());
+  buffer.append(reinterpret_cast<const char*>(&trailerSize), sizeof(uint32_t));
+  return buffer;
+}
+
+TEST(LegacyTrailerReaderTest, readLegacyTrailerStreamMetadataVarint) {
+  // Mix small + large varint-encoded sizes; zeros must scatter to sparse.
+  const std::vector<uint32_t> denseSizes = {0, 5, 128, 0, 16384, 1u << 20, 0};
+  const auto buffer = buildLegacyVarintTrailer(denseSizes);
+
+  const auto* end = buffer.data() + buffer.size();
+  auto [streamIndices, streamSizes] = readLegacyTrailerStreamMetadata(end);
+
+  ASSERT_EQ(streamIndices.size(), 4u);
+  EXPECT_EQ(streamIndices, (std::vector<uint32_t>{1, 2, 4, 5}));
+  EXPECT_EQ(streamSizes, (std::vector<uint32_t>{5, 128, 16384, 1u << 20}));
+}
+
+TEST(LegacyTrailerReaderTest, readLegacyTrailerStreamMetadataDelta) {
+  // Monotonically increasing dense sizes — Delta's natural happy path. No
+  // zeros so every slot survives the scatter-to-sparse step.
+  const std::vector<uint32_t> denseSizes = {10, 12, 15, 20, 100, 250};
+  const auto buffer = buildLegacyDeltaTrailer(denseSizes);
+
+  const auto* end = buffer.data() + buffer.size();
+  auto [streamIndices, streamSizes] = readLegacyTrailerStreamMetadata(end);
+
+  ASSERT_EQ(streamSizes.size(), 6u);
+  EXPECT_EQ(streamSizes, denseSizes);
+  EXPECT_EQ(streamIndices, (std::vector<uint32_t>{0, 1, 2, 3, 4, 5}));
+}
+
+TEST(LegacyTrailerReaderTest, readLegacyTrailerStreamMetadataFixedBitWidth) {
+  // Sizes within a tight range: max=63 → bitWidth=6. Includes zeros that
+  // the scatter step must filter.
+  const std::vector<uint32_t> denseSizes = {1, 0, 63, 7, 0, 33, 0, 5};
+  const auto buffer = buildLegacyFixedBitWidthTrailer(denseSizes);
+
+  const auto* end = buffer.data() + buffer.size();
+  auto [streamIndices, streamSizes] = readLegacyTrailerStreamMetadata(end);
+
+  ASSERT_EQ(streamIndices.size(), 5u);
+  EXPECT_EQ(streamIndices, (std::vector<uint32_t>{0, 2, 3, 5, 7}));
+  EXPECT_EQ(streamSizes, (std::vector<uint32_t>{1, 63, 7, 33, 5}));
+}
+
+} // namespace
+} // namespace facebook::nimble::serde::legacy

--- a/dwio/nimble/tools/SerializerDumpLib.cpp
+++ b/dwio/nimble/tools/SerializerDumpLib.cpp
@@ -21,6 +21,7 @@
 #include "dwio/nimble/common/Exceptions.h"
 #include "dwio/nimble/common/Varint.h"
 #include "dwio/nimble/serializer/SerializerImpl.h"
+#include "dwio/nimble/serializer/legacy/TrailerReader.h"
 
 namespace facebook::nimble::tools {
 
@@ -70,8 +71,16 @@ SerializationDump::SerializationStats SerializationDump::serializationStats(
   // Read row count (varint for kCompactRaw).
   info.rowCount = varint::readVarint32(&pos);
 
-  // Parse stream sizes from trailer.
-  auto streamSizes = serde::detail::readTrailerStreamSizes(end);
+  // Parse stream sizes from trailer. Dispatch on the version byte: legacy
+  // kCompactRaw / kTablet blobs go through the frozen legacy reader; the
+  // else branch is scaffolding for the next change that will introduce a
+  // sibling reader for a new wire format.
+  std::vector<uint32_t> streamSizes;
+  if (usesLegacyTrailer(info.version)) {
+    streamSizes = serde::legacy::readLegacyTrailerStreamSizesDense(end);
+  } else {
+    NIMBLE_UNREACHABLE("unexpected non-legacy trailer version");
+  }
 
   // Walk streams and extract encoding info.
   info.streams.reserve(streamSizes.size());


### PR DESCRIPTION
Summary:

Pure refactor with no behavior change. Sets up infrastructure that the next diff (D108024182) will use when it introduces a new two-array sparse trailer wire format.

What this diff does:
1. Adds `fbcode/dwio/nimble/serializer/legacy/` — a frozen snapshot of the existing stream-sizes trailer reader. The snapshot duplicates every utility it touches (`Varint`, `EncodingPrimitives`, `FixedBitArray`) under `legacy/internal/` so that future evolutions of those helpers in `dwio/nimble/common/` cannot ripple into this code path.
2. Adds `usesLegacyTrailer(SerializationVersion)` in `Options.h` — returns true for every currently-defined non-legacy version (`kCompactRaw`, `kTablet`). The next diff will introduce versions that return false from this helper.
3. Refactors all four trailer-reading dispatch sites to a uniform shape:
   ```
   if (usesLegacyTrailer(version)) {
     legacy::readLegacyTrailerStreamSizes(...);
   } else {
     NIMBLE_UNREACHABLE("non-legacy trailer reader not implemented in this diff");
   }
   ```
   Sites: `StreamDataReader::iterateStreams`, `parseStreams`, `Projector::projectContiguous` / `projectChained`, `SerializerDumpLib::serializationStats`. The else branch is unreachable today (every defined version takes the true branch) and is scaffolding for the next diff to fill in.
4. Normalizes the legacy reader's output to a single sparse `(streamIndices, streamSizes)` pair regardless of whether the underlying wire encoding was MainlyConstant (already sparse) or dense (Trivial / Varint / Delta / FixedBitWidth — scattered to sparse inside the reader). Consumers iterate sparse-only, dropping the dense iteration path in `iterateStreams`.
5. Adds bounds checks in the legacy decoders (`count <= payloadSize` for the varint-counted encodings; `nonZeroCount <= payloadSize` for MainlyConstant; `bitWidth <= 32` validation; `trailerSize <= 64 MiB` sanity cap at the public reader entry points) to guard against corrupted blobs forcing huge allocations.
6. Adds 10 smoke tests for the legacy reader covering Trivial (dense / sparse / empty), MainlyConstant (sparse / empty / dense / max bit width), Varint, Delta, and FixedBitWidth wire shapes.

Why split this out:
The next diff (D108024182) introduces a new on-wire trailer format and new `SerializationVersion` enum values that select it. Landing the frozen reader + dispatch scaffolding separately keeps the format-change diff focused on the actual wire-format change.

Reviewed By: xiaoxmeng

Differential Revision: D108208928


