### PR TITLE
misc(encoding): Allowlist new encodings

### DIFF
--- a/dwio/nimble/encodings/selection/EncodingSelectionPolicy.h
+++ b/dwio/nimble/encodings/selection/EncodingSelectionPolicy.h
@@ -411,12 +411,10 @@ class ManualEncodingSelectionPolicyFactory {
         EncodingType::Dictionary,
         EncodingType::RLE,
         EncodingType::Varint,
-        // SubIntSplit integration commented out (disabled):
-        /*
-#ifdef NIMBLE_ENABLE_EXPERIMENTAL_ENCODINGS
+        EncodingType::PFOR,
+        EncodingType::SimdForBitpack,
         EncodingType::SubIntSplit,
-#endif
-        */
+        EncodingType::BlockBitPacking,
     };
   }
 


### PR DESCRIPTION
Summary: Add new encoding to the set returned by the ManualEncodingSelectionPolicyFactory::possibleEncodings. This allows experimentation with the new encodings (SST), and at the same time the new encodings are not configured to be used in prod unless explicitly specified in read factors.

Differential Revision: D108354875


