### PR TITLE
feat(nimble): Nest BlockBitPacking per-block metadata sub-streams (#860)

### DIFF
--- a/dwio/nimble/encodings/BlockBitPackingEncoding.h
+++ b/dwio/nimble/encodings/BlockBitPackingEncoding.h
@@ -25,9 +25,12 @@
 #include "dwio/nimble/common/FixedBitArray.h"
 #include "dwio/nimble/common/Vector.h"
 #include "dwio/nimble/compression/Compression.h"
+#include "dwio/nimble/encodings/TrivialEncoding.h"
 #include "dwio/nimble/encodings/common/Encoding.h"
+#include "dwio/nimble/encodings/common/EncodingFactory.h"
 #include "dwio/nimble/encodings/common/EncodingPrimitives.h"
 #include "dwio/nimble/encodings/common/EncodingType.h"
+#include "dwio/nimble/encodings/selection/EncodingIdentifier.h"
 #include "dwio/nimble/encodings/selection/EncodingSelection.h"
 #include "velox/common/base/BitUtil.h"
 #include "velox/dwio/common/DecoderUtil.h"
@@ -81,27 +84,31 @@ class BlockBitPackingEncoding final
       const Encoding::Options& options = {});
 
   /// Estimates the uncompressed encoded size using the same per-block packing
-  /// decisions as encode().
+  /// decisions as encode(). The per-block metadata is routed through nested
+  /// encoding selection (data-dependent size), so it is estimated as Trivial
+  /// sub-encodings; the estimate is approximate, not exact.
   static uint64_t estimateSize(
       std::span<const physicalType> values,
       uint16_t blockSize = kBlockBitPackingBlockSize);
 
-  /// Returns the metadata overhead in bytes for the encoding header.
-  /// Shared by encode() and EncodingSizeEstimation to keep the two in sync.
-  static uint32_t encodingOverhead(uint32_t numBlocks) {
-    return 1 /* compressionType */ + 2 /* blockSize */ + 2 /* numBlocks */ +
-        numBlocks *
-        (sizeof(physicalType) + 1) /* per-block baseline + bitWidth */
-        + numBlocks * sizeof(uint32_t) /* per-block data offsets */;
-  }
-
   std::string debugString(int offset) const final;
 
  private:
-  // Per-block metadata stored in the header: baseline (minimum) value,
-  // bit width for the packed representation, and whether this block
-  // falls back to storing raw uncompressed values.
+  // Fixed metadata header written before the three nested sub-streams:
+  // compressionType + blockSize + numBlocks + three 4-byte sub-stream size
+  // prefixes. Shared by encode() and estimateSize() so the two stay in sync.
+  static constexpr uint32_t kMetadataHeaderSize =
+      sizeof(uint8_t) /*compressionType=*/ + sizeof(uint16_t) /*blockSize=*/ +
+      sizeof(uint16_t) /*numBlocks=*/ +
+      3 * sizeof(uint32_t) /*subStreamSizePrefixes=*/;
+
+  // Per-block metadata, materialized from the nested baselines / bit-widths /
+  // data-offsets sub-streams: baseline (minimum) value, bit width for the
+  // packed representation, and whether this block falls back to storing raw
+  // uncompressed values.
   struct BlockMeta {
+    // Raw block bit width indicates that the block stores raw values.
+    static constexpr uint8_t kRawBlockBitWidth = 255;
     // Minimum value in the block; packed values are stored as
     // (value - baseline).
     physicalType baseline;
@@ -153,7 +160,7 @@ class BlockBitPackingEncoding final
   uint16_t blockSize_;
   uint16_t numBlocks_;
   Vector<BlockMeta> blocksMetadata_;
-  Vector<uint32_t> blockDataOffsets_;
+  Vector<uint32_t> blockOffsets_;
   const char* packedData_;
   uint32_t row_ = 0;
   velox::BufferPtr uncompressedData_;
@@ -176,8 +183,17 @@ uint64_t BlockBitPackingEncoding<T>::estimateSize(
     const auto end = std::min<uint32_t>(start + blockSize, rowCount);
     packedSize += makeBlockInfo(values, start, end - start).packedSize;
   }
-  return EncodingPrefix::kFixedPrefixSize + encodingOverhead(numBlocks) +
-      packedSize;
+  // Per-block metadata (baselines, bit widths, data offsets) is stored as
+  // nested encodings; dumping real files shows selection picks Trivial for all
+  // three, so estimate them as Trivial sub-encodings -- mirroring how
+  // Dictionary estimates its alphabet child. This is an approximation (the
+  // actual nested encoding is data-dependent); the estimate-vs-actual test
+  // allows a 2x band.
+  const uint64_t metadataSize = kMetadataHeaderSize +
+      TrivialEncoding<physicalType>::estimateSize(numBlocks) +
+      TrivialEncoding<uint8_t>::estimateSize(numBlocks) +
+      TrivialEncoding<uint32_t>::estimateSize(numBlocks);
+  return EncodingPrefix::kFixedPrefixSize + metadataSize + packedSize;
 }
 
 template <typename T>
@@ -221,11 +237,11 @@ template <typename T>
 BlockBitPackingEncoding<T>::BlockBitPackingEncoding(
     velox::memory::MemoryPool& pool,
     std::string_view data,
-    const std::function<void*(uint32_t)>& /* stringBufferFactory */,
+    const std::function<void*(uint32_t)>& stringBufferFactory,
     const Encoding::Options& options)
     : TypedEncoding<T, physicalType>{pool, data, options},
       blocksMetadata_{&pool},
-      blockDataOffsets_{&pool},
+      blockOffsets_{&pool},
       packedData_{nullptr},
       buffer_(this->template getVectorBuffer<physicalType>()) {
   auto pos = data.data() + this->dataOffset();
@@ -237,17 +253,36 @@ BlockBitPackingEncoding<T>::BlockBitPackingEncoding(
   NIMBLE_CHECK_EQ(numBlocks_, (this->rowCount() + blockSize_ - 1) / blockSize_);
 
   blocksMetadata_.resize(numBlocks_);
-  for (uint16_t i = 0; i < numBlocks_; ++i) {
-    blocksMetadata_[i].baseline = encoding::read<const physicalType>(pos);
-    const auto bitWidth = static_cast<uint8_t>(encoding::readChar(pos));
-    blocksMetadata_[i].skipEncoding = (bitWidth == 255);
-    blocksMetadata_[i].bitWidth =
-        blocksMetadata_[i].skipEncoding ? 0 : bitWidth;
-  }
+  blockOffsets_.resize(numBlocks_);
 
-  blockDataOffsets_.resize(numBlocks_);
+  // BlockBitPacking stores the per-block metadata (baselines, bit widths, data
+  // offsets) as self-describing nested encodings, letting Nimble's recursive
+  // encoding selection pick the best encoding for each metadata stream. The
+  // packed block data stays raw.
+  Vector<physicalType> baselines{&pool};
+  baselines.resize(numBlocks_);
+  Vector<uint8_t> bitWidths{&pool};
+  bitWidths.resize(numBlocks_);
+
+  // Each metadata stream: read its 4-byte size, decode the nested sub-encoding
+  // into the target, then advance past it.
+  auto readMetadataStream = [&](auto& subStream) {
+    const uint32_t size = encoding::readUint32(pos);
+    EncodingFactory(options)
+        .create(pool, {pos, size}, stringBufferFactory)
+        ->materialize(numBlocks_, subStream.data());
+    pos += size;
+  };
+  readMetadataStream(baselines); // per-block baselines
+  readMetadataStream(bitWidths); // per-block bit widths
+  readMetadataStream(blockOffsets_); // per-block data offsets
+
   for (uint16_t i = 0; i < numBlocks_; ++i) {
-    blockDataOffsets_[i] = encoding::read<const uint32_t>(pos);
+    blocksMetadata_[i].baseline = baselines[i];
+    blocksMetadata_[i].skipEncoding =
+        (bitWidths[i] == BlockMeta::kRawBlockBitWidth);
+    blocksMetadata_[i].bitWidth =
+        blocksMetadata_[i].skipEncoding ? 0 : bitWidths[i];
   }
 
   if (compressionType != CompressionType::Uncompressed) {
@@ -288,7 +323,7 @@ BlockBitPackingEncoding<T>::readSingleValue(uint32_t row) const {
   const auto& blockMetadata = blocksMetadata_[blockIndex];
   if (blockMetadata.skipEncoding) {
     const auto* rawValues = reinterpret_cast<const physicalType*>(
-        packedData_ + blockDataOffsets_[blockIndex]);
+        packedData_ + blockOffsets_[blockIndex]);
     return rawValues[blockOffset];
   }
   if (blockMetadata.bitWidth == 0) {
@@ -296,7 +331,7 @@ BlockBitPackingEncoding<T>::readSingleValue(uint32_t row) const {
   }
   const auto numRows = blockRowCount(blockIndex);
   FixedBitArray fba{
-      {packedData_ + blockDataOffsets_[blockIndex],
+      {packedData_ + blockOffsets_[blockIndex],
        FixedBitArray::bufferSize(numRows, blockMetadata.bitWidth)},
       blockMetadata.bitWidth};
   return static_cast<physicalType>(fba.get(blockOffset)) +
@@ -310,7 +345,7 @@ void BlockBitPackingEncoding<T>::materializeBlockRange(
     uint32_t blockValueCount,
     physicalType* output) const {
   const auto& blockMetadata = blocksMetadata_[blockIndex];
-  const auto* blockData = packedData_ + blockDataOffsets_[blockIndex];
+  const auto* blockData = packedData_ + blockOffsets_[blockIndex];
 
   if (blockMetadata.skipEncoding) {
     const auto* rawValues = reinterpret_cast<const physicalType*>(blockData);
@@ -558,8 +593,8 @@ void BlockBitPackingEncoding<T>::bulkScan(
       }
 
       physicalType tmp[kMaxBlockSize];
-      const auto numRows = blockRowCount(blockIndex);
-      materializeBlockRange(blockIndex, 0, numRows, tmp);
+      const auto blockRows = blockRowCount(blockIndex);
+      materializeBlockRange(blockIndex, 0, blockRows, tmp);
       for (vector_size_t j = i; j < runEnd; ++j) {
         const auto blockOffset = static_cast<uint32_t>(selectedRows[j]) +
             static_cast<uint32_t>(offset) - blockStart;
@@ -635,12 +670,10 @@ std::string_view BlockBitPackingEncoding<T>::encode(
     totalPackedSize += blocks[blockIndex].packedSize;
   }
 
-  const uint32_t metaOverhead = encodingOverhead(numBlocks);
-
-  // Note: if totalPackedSize + metaOverhead >= rawSize, this encoding is not
-  // beneficial. The encoding selection policy should avoid selecting it in that
-  // case. We still encode correctly so the round-trip contract holds.
-
+  // Note: if the encoded size (packed data + nested metadata sub-streams +
+  // header) >= rawSize, this encoding is not beneficial. The encoding selection
+  // policy should avoid selecting it in that case. We still encode correctly so
+  // the round-trip contract holds.
   Vector<char> packedVector{&buffer.getMemoryPool()};
   auto dataCompressionPolicy = selection.compressionPolicy();
   CompressionEncoder<T> compressionEncoder{
@@ -711,8 +744,52 @@ std::string_view BlockBitPackingEncoding<T>::encode(
         return pos;
       }};
 
+  // BlockBitPacking routes the per-block metadata (baselines, bit widths, data
+  // offsets) through recursive encoding selection so Nimble can pick the best
+  // encoding for each (e.g. Constant/Delta for correlated baselines, Delta for
+  // the ascending offsets). The packed block data stays raw (still optionally
+  // Zstd-compressed via the compression encoder).
+  Vector<physicalType> baselines{&buffer.getMemoryPool()};
+  baselines.resize(numBlocks);
+  Vector<uint8_t> bitWidths{&buffer.getMemoryPool()};
+  bitWidths.resize(numBlocks);
+  Vector<uint32_t> blockOffsets{&buffer.getMemoryPool()};
+  blockOffsets.resize(numBlocks);
+  uint32_t runningOffset{0};
+  for (uint16_t blockIndex = 0; blockIndex < numBlocks; ++blockIndex) {
+    baselines[blockIndex] = blocks[blockIndex].baseline;
+    bitWidths[blockIndex] = blocks[blockIndex].skipEncoding
+        ? BlockMeta::kRawBlockBitWidth
+        : blocks[blockIndex].bitWidth;
+    blockOffsets[blockIndex] = runningOffset;
+    runningOffset += blocks[blockIndex].packedSize;
+  }
+
+  Buffer tempBuffer{buffer.getMemoryPool()};
+  const std::string_view baselinesEncoded =
+      selection.template encodeNested<physicalType>(
+          EncodingIdentifiers::BlockBitPacking::Baselines,
+          baselines,
+          tempBuffer,
+          options);
+  const std::string_view bitWidthsEncoded =
+      selection.template encodeNested<uint8_t>(
+          EncodingIdentifiers::BlockBitPacking::BitWidths,
+          bitWidths,
+          tempBuffer,
+          options);
+  const std::string_view offsetsEncoded =
+      selection.template encodeNested<uint32_t>(
+          EncodingIdentifiers::BlockBitPacking::Offsets,
+          blockOffsets,
+          tempBuffer,
+          options);
+
+  const uint32_t metaHeaderSize = kMetadataHeaderSize +
+      static_cast<uint32_t>(baselinesEncoded.size() + bitWidthsEncoded.size() +
+                            offsetsEncoded.size());
   const uint32_t encodingSize =
-      Encoding::serializePrefixSize(rowCount, useVarint) + metaOverhead +
+      Encoding::serializePrefixSize(rowCount, useVarint) + metaHeaderSize +
       compressionEncoder.getSize();
 
   char* reserved = buffer.reserve(encodingSize);
@@ -727,19 +804,9 @@ std::string_view BlockBitPackingEncoding<T>::encode(
       static_cast<char>(compressionEncoder.compressionType()), pos);
   encoding::write(blockSize, pos);
   encoding::write(static_cast<uint16_t>(numBlocks), pos);
-
-  uint32_t runningOffset = 0;
-  for (uint16_t blockIndex = 0; blockIndex < numBlocks; ++blockIndex) {
-    encoding::write(blocks[blockIndex].baseline, pos);
-    const uint8_t bwOnDisk =
-        blocks[blockIndex].skipEncoding ? 255 : blocks[blockIndex].bitWidth;
-    encoding::writeChar(static_cast<char>(bwOnDisk), pos);
-  }
-  for (uint16_t blockIndex = 0; blockIndex < numBlocks; ++blockIndex) {
-    encoding::write(runningOffset, pos);
-    runningOffset += blocks[blockIndex].packedSize;
-  }
-
+  encoding::writeString(baselinesEncoded, pos);
+  encoding::writeString(bitWidthsEncoded, pos);
+  encoding::writeString(offsetsEncoded, pos);
   compressionEncoder.write(pos);
 
   NIMBLE_DCHECK_EQ(encodingSize, pos - reserved, "Encoding size mismatch.");

--- a/dwio/nimble/encodings/common/EncodingLayout.cpp
+++ b/dwio/nimble/encodings/common/EncodingLayout.cpp
@@ -121,6 +121,19 @@ constexpr uint32_t kMinEncodingLayoutBufferSize = 5;
   NIMBLE_CHECK_EQ(pos, end, "Invalid encoding layout config length.");
   return EncodingLayout::Config{std::move(configs)};
 }
+
+// Captures one size-prefixed nested sub-stream into `children` (nullopt when
+// the sub-stream is empty)
+void captureSizedChild(
+    std::vector<std::optional<const EncodingLayout>>& children,
+    const char*& cursor) {
+  const uint32_t size = encoding::readUint32(cursor);
+  children.emplace_back(
+      size > 0 ? std::optional<const EncodingLayout>(
+                     EncodingLayoutCapture::capture({cursor, size}))
+               : std::nullopt);
+  cursor += size;
+}
 } // namespace
 
 std::optional<std::string> EncodingLayout::Config::get(
@@ -370,7 +383,6 @@ EncodingLayout EncodingLayoutCapture::capture(std::string_view encoding) {
     case EncodingType::Constant:
     case EncodingType::Prefix:
     case EncodingType::ALP:
-    case EncodingType::BlockBitPacking:
     case EncodingType::SimdForBitpack:
     // SubIntSplit integration is disabled; treat it as a non-nested encoding
     // (zero children) so its layout is captured without nested logic.
@@ -390,18 +402,23 @@ EncodingLayout EncodingLayoutCapture::capture(std::string_view encoding) {
       encoding::readChar(pos); // baseBitWidth
       encoding::readUint32(pos); // numExceptions
 
-      auto captureChild = [&](const char*& cursor) {
-        const uint32_t size = encoding::readUint32(cursor);
-        children.emplace_back(
-            size > 0 ? std::optional<const EncodingLayout>(
-                           EncodingLayoutCapture::capture({cursor, size}))
-                     : std::nullopt);
-        cursor += size;
-      };
-
       children.reserve(2);
-      captureChild(pos); // exception positions
-      captureChild(pos); // exception values
+      captureSizedChild(children, pos); // exception positions
+      captureSizedChild(children, pos); // exception values
+      break;
+    }
+    case EncodingType::BlockBitPacking: {
+      // BlockBitPacking nests three per-block metadata sub-streams: baselines,
+      // bit widths, and data offsets.
+      const char* pos = encoding.data() + kEncodingPrefixSize;
+      encoding::readChar(pos); // compressionType
+      encoding::read<uint16_t>(pos); // blockSize
+      encoding::read<uint16_t>(pos); // numBlocks
+
+      children.reserve(3);
+      captureSizedChild(children, pos); // baselines
+      captureSizedChild(children, pos); // bit widths
+      captureSizedChild(children, pos); // data offsets
       break;
     }
     case EncodingType::Trivial: {

--- a/dwio/nimble/encodings/selection/EncodingIdentifier.h
+++ b/dwio/nimble/encodings/selection/EncodingIdentifier.h
@@ -74,7 +74,8 @@ struct EncodingIdentifiers {
 
   struct FrequencyPartition {
     // Partition metadata
-    // Eventually we may want to allow for non-power-of-two bit partitions, but for now we can just define constants for the power-of-two cases.
+    // Eventually we may want to allow for non-power-of-two bit partitions, but
+    // for now we can just define constants for the power-of-two cases.
     static constexpr NestedEncodingIdentifier PartitionOffsets = 0;
     static constexpr NestedEncodingIdentifier PartitionSizes = 1;
     // Per-tier dictionaries (1-bit, 2-bit, 4-bit, 8-bit, etc.)
@@ -100,6 +101,15 @@ struct EncodingIdentifiers {
     // exception residual values.
     static constexpr NestedEncodingIdentifier ExceptionPositions = 0;
     static constexpr NestedEncodingIdentifier ExceptionValues = 1;
+  };
+
+  struct BlockBitPacking {
+    // Nested per-block metadata sub-streams for BlockBitPacking: the per-block
+    // baselines, the per-block bit widths, and the ascending per-block data
+    // offsets.
+    static constexpr NestedEncodingIdentifier Baselines = 0;
+    static constexpr NestedEncodingIdentifier BitWidths = 1;
+    static constexpr NestedEncodingIdentifier Offsets = 2;
   };
 };
 

--- a/dwio/nimble/encodings/selection/EncodingSelectionPolicy.h
+++ b/dwio/nimble/encodings/selection/EncodingSelectionPolicy.h
@@ -738,7 +738,7 @@ class ReplayedEncodingSelectionPolicy
 
  private:
   const std::optional<CompressionOptions> compressionOptions_;
-  const EncodingSelectionPolicyFactory& encodingSelectionPolicyFactory_;
+  const EncodingSelectionPolicyFactory encodingSelectionPolicyFactory_;
   EncodingLayout encodingLayout_;
 };
 

--- a/dwio/nimble/encodings/tests/BlockBitPackingEncodingTest.cpp
+++ b/dwio/nimble/encodings/tests/BlockBitPackingEncodingTest.cpp
@@ -342,7 +342,8 @@ TEST_F(BlockBitPackingEncodingTest, sparseBoolWithCbpIndices) {
       {nimble::EncodingLayout{
           nimble::EncodingType::BlockBitPacking,
           {},
-          nimble::CompressionType::Uncompressed}}};
+          nimble::CompressionType::Uncompressed,
+          {std::nullopt, std::nullopt, std::nullopt}}}};
   nimble::Buffer cbpBuffer(*pool_);
   auto cbpPolicy =
       std::make_unique<nimble::ReplayedEncodingSelectionPolicy<bool>>(
@@ -425,7 +426,8 @@ TEST_F(BlockBitPackingEncodingTest, sparseBoolWithCbpIndicesLargeIrregular) {
       {nimble::EncodingLayout{
           nimble::EncodingType::BlockBitPacking,
           {},
-          nimble::CompressionType::Uncompressed}}};
+          nimble::CompressionType::Uncompressed,
+          {std::nullopt, std::nullopt, std::nullopt}}}};
   nimble::Buffer cbpBuffer(*pool_);
   auto cbpPolicy =
       std::make_unique<nimble::ReplayedEncodingSelectionPolicy<bool>>(

--- a/dwio/nimble/encodings/tests/EncodingLayoutTest.cpp
+++ b/dwio/nimble/encodings/tests/EncodingLayoutTest.cpp
@@ -273,6 +273,37 @@ TEST(EncodingLayoutTests, Pfor) {
   EXPECT_TRUE(captured.child(1).has_value());
 }
 
+TEST(EncodingLayoutTests, BlockBitPacking) {
+  // BlockBitPacking nests three per-block metadata sub-streams (baselines, bit
+  // widths, data offsets). Capture records each present sub-stream recursively,
+  // like the compound encodings, so a captured layout reproduces the full tree.
+  nimble::EncodingLayout bbpLayout{
+      nimble::EncodingType::BlockBitPacking,
+      {},
+      nimble::CompressionType::Uncompressed,
+      {std::nullopt, std::nullopt, std::nullopt}};
+
+  // Serialization preserves the BlockBitPacking node and its three child slots.
+  testSerialization(bbpLayout);
+
+  // Locally narrow per-block ranges so blocks get distinct baselines / widths.
+  std::vector<uint32_t> data;
+  data.reserve(1000);
+  for (uint32_t i = 0; i < 1000; ++i) {
+    data.push_back((i / 200) * 1000 + (i % 37));
+  }
+
+  // The nullopt children drive selection to BlockBitPacking while letting each
+  // sub-stream re-select; capture must then record all three sub-streams'
+  // encodings (not nullopt), proving recursive capture of the nested layout.
+  auto captured = encodeAndCapture<uint32_t>(bbpLayout, data);
+  ASSERT_EQ(captured.encodingType(), nimble::EncodingType::BlockBitPacking);
+  ASSERT_EQ(captured.childrenCount(), 3);
+  EXPECT_TRUE(captured.child(0).has_value());
+  EXPECT_TRUE(captured.child(1).has_value());
+  EXPECT_TRUE(captured.child(2).has_value());
+}
+
 TEST(EncodingLayoutTests, SparseBool) {
   nimble::EncodingLayout expected{
       nimble::EncodingType::SparseBool,

--- a/dwio/nimble/encodings/tests/EncodingLayoutTestHelper.cpp
+++ b/dwio/nimble/encodings/tests/EncodingLayoutTestHelper.cpp
@@ -65,7 +65,10 @@ SparseBoolEnc::operator EncodingLayout() const {
 
 BlockBitPackingEnc::operator EncodingLayout() const {
   return EncodingLayout(
-      EncodingType::BlockBitPacking, {}, CompressionType::Uncompressed);
+      EncodingType::BlockBitPacking,
+      {},
+      CompressionType::Uncompressed,
+      {std::nullopt, std::nullopt, std::nullopt});
 }
 
 DeltaEnc::operator EncodingLayout() const {

--- a/dwio/nimble/encodings/tests/EncodingSizeEstimationTest.cpp
+++ b/dwio/nimble/encodings/tests/EncodingSizeEstimationTest.cpp
@@ -108,7 +108,16 @@ class EncodingSizeEstimationTest : public ::testing::Test {
         nimble::test::Encoder<nimble::BlockBitPackingEncoding<T>>::encode(
             buffer, nimble::Vector<T>(pool_.get(), data.begin(), data.end()));
 
-    EXPECT_EQ(estimated, encoded.size());
+    // estimateSize() estimates the per-block metadata as Trivial sub-encodings,
+    // while the actual encoding routes that metadata through nested encoding
+    // selection (whose size is data-dependent), so the estimate is an
+    // approximation rather than exact. Allow a 2x band, matching the other
+    // estimate checks.
+    EXPECT_GT(estimated, encoded.size() / 2)
+        << "estimate too low: " << estimated << " vs actual " << encoded.size();
+    EXPECT_LT(estimated, encoded.size() * 2)
+        << "estimate too high: " << estimated << " vs actual "
+        << encoded.size();
   }
 
   std::shared_ptr<velox::memory::MemoryPool> pool_;

--- a/dwio/nimble/serializer/tests/SerializationTest.cpp
+++ b/dwio/nimble/serializer/tests/SerializationTest.cpp
@@ -2193,6 +2193,85 @@ TEST_P(SerializationTest, pforColumnarRoundTrip) {
   }
 }
 
+// Columnar reader-level round-trip for BlockBitPackingEncoding. Forces
+// BlockBitPacking via EncodingLayoutTree on integer columns and verifies data
+// integrity through the full Serializer → Deserializer path, exercising the
+// nested per-block metadata sub-streams (baselines, bit widths, data offsets).
+TEST_P(SerializationTest, blockBitPackingColumnarRoundTrip) {
+  auto type = velox::ROW({
+      {"int_val", velox::INTEGER()},
+      {"long_val", velox::BIGINT()},
+  });
+
+  EncodingLayoutTree layoutTree{
+      Kind::Row,
+      {},
+      "",
+      {
+          {Kind::Scalar,
+           {{EncodingLayoutTree::StreamIdentifiers::Scalar::ScalarStream,
+             EncodingLayout{
+                 EncodingType::BlockBitPacking,
+                 {},
+                 CompressionType::Uncompressed,
+                 {std::nullopt, std::nullopt, std::nullopt}}}},
+           ""},
+          {Kind::Scalar,
+           {{EncodingLayoutTree::StreamIdentifiers::Scalar::ScalarStream,
+             EncodingLayout{
+                 EncodingType::BlockBitPacking,
+                 {},
+                 CompressionType::Uncompressed,
+                 {std::nullopt, std::nullopt, std::nullopt}}}},
+           ""},
+      }};
+
+  SerializerOptions options{
+      .version = version(),
+      .encodingLayoutTree = layoutTree,
+      .compressionOptions = compressionOptions(),
+  };
+
+  Serializer serializer{options, type, pool_.get()};
+
+  // Enough rows to span multiple blocks; per-block-varying ranges so blocks get
+  // distinct baselines and bit widths.
+  const velox::vector_size_t numRows = 3000;
+  auto intVals =
+      velox::BaseVector::create(velox::INTEGER(), numRows, pool_.get());
+  auto longVals =
+      velox::BaseVector::create(velox::BIGINT(), numRows, pool_.get());
+  for (velox::vector_size_t i = 0; i < numRows; ++i) {
+    intVals->asFlatVector<int32_t>()->set(i, (i / 256) * 1000 + (i % 37));
+    longVals->asFlatVector<int64_t>()->set(
+        i, (i / 256) * 1'000'000LL + (i % 37));
+  }
+
+  auto input = std::make_shared<velox::RowVector>(
+      pool_.get(),
+      type,
+      nullptr,
+      numRows,
+      std::vector<velox::VectorPtr>{intVals, longVals});
+
+  auto serialized =
+      serializer.serialize(input, OrderedRanges::of(0, input->size()));
+
+  Deserializer deserializer{
+      SchemaReader::getSchema(serializer.schemaBuilder().schemaNodes()),
+      pool_.get(),
+      deserializerOptions()};
+
+  velox::VectorPtr output;
+  deserializer.deserialize(serialized, output);
+
+  ASSERT_EQ(output->size(), input->size());
+  for (velox::vector_size_t i = 0; i < input->size(); ++i) {
+    ASSERT_TRUE(vectorEquals(output, input, i))
+        << "Content mismatch at index " << i;
+  }
+}
+
 // Columnar reader-level round-trip for SimdForBitpackEncoding. Forces
 // SimdForBitpack via EncodingLayoutTree on integer columns and verifies data
 // integrity through the full Serializer → Deserializer path.

--- a/dwio/nimble/tools/EncodingUtilities.cpp
+++ b/dwio/nimble/tools/EncodingUtilities.cpp
@@ -113,12 +113,39 @@ void traverseEncodings(
     case EncodingType::Constant:
     case EncodingType::Prefix:
     case EncodingType::ALP:
-    case EncodingType::BlockBitPacking:
     case EncodingType::SimdForBitpack:
     // SubIntSplit integration is disabled; treat it as having no nested
     // encoding to traverse.
     case EncodingType::SubIntSplit: {
       // don't have any nested encoding
+      break;
+    }
+    case EncodingType::BlockBitPacking: {
+      // Layout after the common prefix: compressionType [1 byte], blockSize
+      // [2 bytes], numBlocks [2 bytes], then three self-describing nested
+      // metadata sub-streams, each preceded by a 4-byte size: the per-block
+      // baselines, bit widths, and data offsets.
+      const char* pos = stream.data() + kEncodingPrefixSize;
+      encoding::readChar(pos); // compressionType
+      encoding::read<uint16_t>(pos); // blockSize
+      encoding::read<uint16_t>(pos); // numBlocks
+      const uint32_t baselinesSize = encoding::readUint32(pos);
+      if (baselinesSize > 0) {
+        traverseEncodings(
+            {pos, baselinesSize}, level + 1, 0, "Baselines", visitor);
+      }
+      pos += baselinesSize;
+      const uint32_t bitWidthsSize = encoding::readUint32(pos);
+      if (bitWidthsSize > 0) {
+        traverseEncodings(
+            {pos, bitWidthsSize}, level + 1, 1, "BitWidths", visitor);
+      }
+      pos += bitWidthsSize;
+      const uint32_t offsetsSize = encoding::readUint32(pos);
+      if (offsetsSize > 0) {
+        traverseEncodings(
+            {pos, offsetsSize}, level + 1, 2, "DataOffsets", visitor);
+      }
       break;
     }
     case EncodingType::PFOR: {

--- a/dwio/nimble/tools/tests/EncodingUtilitiesTest.cpp
+++ b/dwio/nimble/tools/tests/EncodingUtilitiesTest.cpp
@@ -93,7 +93,7 @@ class EncodingUtilitiesTest : public ::testing::Test {
       uint32_t numExceptions,
       const std::string& positions,
       const std::string& values) {
-    uint32_t totalSize = 6 + sizeof(uint32_t) /* baseline */ +
+    const size_t totalSize = 6 + sizeof(uint32_t) /* baseline */ +
         1 /* baseBitWidth */ + sizeof(uint32_t) /* numExceptions */ +
         sizeof(uint32_t) + positions.size() + sizeof(uint32_t) + values.size();
     std::string buf(totalSize, '\0');
@@ -108,6 +108,40 @@ class EncodingUtilitiesTest : public ::testing::Test {
     encoding::writeBytes(positions, pos);
     encoding::writeUint32(static_cast<uint32_t>(values.size()), pos);
     encoding::writeBytes(values, pos);
+    return buf;
+  }
+
+  // Build a BlockBitPacking-encoded stream wrapping the given per-block
+  // metadata sub-streams. The packed data region is omitted since
+  // traverseEncodings does not read it. Layout:
+  //   bytes 0-5: prefix (EncodingType::BlockBitPacking, DataType::Uint32,
+  //              rowCount)
+  //   byte 6: compressionType (Uncompressed)
+  //   bytes 7-8: blockSize (uint16)
+  //   bytes 9-10: numBlocks (uint16)
+  //   then the baselines / bitWidths / offsets sub-streams, each preceded by a
+  //   4-byte size.
+  std::string buildBlockBitPackingUint32Stream(
+      const std::string& baselines,
+      const std::string& bitWidths,
+      const std::string& offsets) {
+    const size_t totalSize = 6 + 1 /* compressionType */ + 2 /* blockSize */ +
+        2 /* numBlocks */ + sizeof(uint32_t) + baselines.size() +
+        sizeof(uint32_t) + bitWidths.size() + sizeof(uint32_t) + offsets.size();
+    std::string buf(totalSize, '\0');
+    char* pos = buf.data();
+    encoding::writeChar(static_cast<char>(EncodingType::BlockBitPacking), pos);
+    encoding::writeChar(static_cast<char>(DataType::Uint32), pos);
+    encoding::writeUint32(/* rowCount */ 100, pos);
+    encoding::writeChar(static_cast<char>(CompressionType::Uncompressed), pos);
+    encoding::write<uint16_t>(/* blockSize */ 64, pos);
+    encoding::write<uint16_t>(/* numBlocks */ 2, pos);
+    encoding::writeUint32(static_cast<uint32_t>(baselines.size()), pos);
+    encoding::writeBytes(baselines, pos);
+    encoding::writeUint32(static_cast<uint32_t>(bitWidths.size()), pos);
+    encoding::writeBytes(bitWidths, pos);
+    encoding::writeUint32(static_cast<uint32_t>(offsets.size()), pos);
+    encoding::writeBytes(offsets, pos);
     return buf;
   }
 
@@ -359,6 +393,55 @@ TEST_F(EncodingUtilitiesTest, GetEncodingLabelPfor) {
   EXPECT_NE(label.find("PFOR"), std::string::npos);
   EXPECT_NE(label.find("ExceptionPositions:Trivial"), std::string::npos);
   EXPECT_NE(label.find("ExceptionValues:Trivial"), std::string::npos);
+}
+
+// --- BlockBitPacking nested metadata sub-streams ---
+
+TEST_F(EncodingUtilitiesTest, TraverseEncodingsBlockBitPackingChildren) {
+  auto baselines = buildTrivialUint32Stream({0, 64});
+  auto bitWidths = buildTrivialUint32Stream({4, 5});
+  auto offsets = buildTrivialUint32Stream({0, 32});
+  auto stream = buildBlockBitPackingUint32Stream(baselines, bitWidths, offsets);
+
+  EncodingType rootType = EncodingType::Constant; // init to something else
+  std::vector<std::string> nestedNames;
+  traverseEncodings(
+      stream,
+      [&](EncodingType encodingType,
+          DataType /* dataType */,
+          uint32_t level,
+          uint32_t /* index */,
+          const std::string& nestedEncodingName,
+          const std::unordered_map<EncodingPropertyType, EncodingProperty>&
+          /* properties */) -> bool {
+        if (level == 0) {
+          rootType = encodingType;
+        } else {
+          nestedNames.push_back(nestedEncodingName);
+        }
+        return true;
+      });
+
+  EXPECT_EQ(rootType, EncodingType::BlockBitPacking);
+  const std::vector<std::string> expected{
+      "Baselines", "BitWidths", "DataOffsets"};
+  EXPECT_EQ(nestedNames, expected);
+}
+
+TEST_F(EncodingUtilitiesTest, GetEncodingLabelBlockBitPacking) {
+  // The rendered label surfaces the picked sub-encodings for the per-block
+  // metadata, e.g. BlockBitPacking<Uint32>[Baselines:Trivial<...>,
+  // BitWidths:Trivial<...>,DataOffsets:Trivial<...>].
+  auto baselines = buildTrivialUint32Stream({0, 64});
+  auto bitWidths = buildTrivialUint32Stream({4, 5});
+  auto offsets = buildTrivialUint32Stream({0, 32});
+  auto stream = buildBlockBitPackingUint32Stream(baselines, bitWidths, offsets);
+
+  auto label = getEncodingLabel(stream);
+  EXPECT_NE(label.find("BlockBitPacking"), std::string::npos);
+  EXPECT_NE(label.find("Baselines:Trivial"), std::string::npos);
+  EXPECT_NE(label.find("BitWidths:Trivial"), std::string::npos);
+  EXPECT_NE(label.find("DataOffsets:Trivial"), std::string::npos);
 }
 
 } // namespace facebook::nimble::tools::test


### PR DESCRIPTION
Summary:

Splits BlockBitPacking's per-block metadata into three separate, self-describing nested sub-streams — baselines, bit widths, and data offsets — each chosen  by Nimble's recursive encoding selection. 

Previously the metadata was written as raw inline arrays: (baseline, bitWidth) interleaved per block, followed by a raw offsets array

Reviewed By: xiaoxmeng

Differential Revision: D108194903


