### PR TITLE
feat(nimble): Add decompression time tracking to Nimble selective reader (#861)

### DIFF
--- a/dwio/nimble/compression/Compression.cpp
+++ b/dwio/nimble/compression/Compression.cpp
@@ -19,6 +19,7 @@
 #include "dwio/nimble/compression/OpenZLCompressor.h"
 #include "dwio/nimble/compression/ZstdCompressor.h"
 #include "dwio/nimble/encodings/common/EncodingPrimitives.h"
+#include "velox/dwio/common/Statistics.h"
 
 #ifndef DISABLE_META_INTERNAL_COMPRESSOR
 #include "dwio/nimble/compression/fb/MetaInternalCompressor.h"
@@ -75,9 +76,13 @@ ICompressor& getCompressor(CompressionType compressionType) {
     CompressionType compressionType,
     DataType dataType,
     std::string_view data,
+    velox::io::IoCounter* decompressCounter,
     velox::BufferPool* bufferPool) {
-  return getCompressor(compressionType)
-      .uncompress(pool, compressionType, dataType, data, bufferPool);
+  auto& compressor = getCompressor(compressionType);
+  return velox::dwio::common::withDecompressStats(decompressCounter, [&] {
+    return compressor.uncompress(
+        pool, compressionType, dataType, data, bufferPool);
+  });
 }
 
 /* static */ std::optional<size_t> Compression::uncompressedSize(

--- a/dwio/nimble/compression/Compression.h
+++ b/dwio/nimble/compression/Compression.h
@@ -22,6 +22,7 @@
 #include "folly/io/IOBuf.h"
 #include "velox/buffer/Buffer.h"
 #include "velox/buffer/BufferPool.h"
+#include "velox/common/base/IoCounter.h"
 
 namespace facebook::nimble {
 
@@ -82,6 +83,7 @@ class Compression {
       CompressionType compressionType,
       DataType dataType,
       std::string_view data,
+      velox::io::IoCounter* decompressCounter,
       velox::BufferPool* bufferPool = nullptr);
 
   static std::optional<size_t> uncompressedSize(

--- a/dwio/nimble/encodings/BlockBitPackingEncoding.h
+++ b/dwio/nimble/encodings/BlockBitPackingEncoding.h
@@ -322,6 +322,7 @@ BlockBitPackingEncoding<T>::BlockBitPackingEncoding(
         compressionType,
         DataType::Undefined,
         {pos, static_cast<size_t>(data.end() - pos)},
+        options.decompressCounter(),
         options.bufferPool);
     packedData_ = uncompressedData_->as<char>();
   } else {

--- a/dwio/nimble/encodings/FixedBitWidthEncoding.h
+++ b/dwio/nimble/encodings/FixedBitWidthEncoding.h
@@ -159,6 +159,7 @@ FixedBitWidthEncoding<T>::FixedBitWidthEncoding(
         compressionType,
         DataType::Undefined,
         {pos, static_cast<size_t>(data.end() - pos)},
+        options.decompressCounter(),
         options.bufferPool);
     fixedBitArray_ = FixedBitArray{
         {uncompressedData_->as<char>(), uncompressedData_->size()}, bitWidth_};

--- a/dwio/nimble/encodings/ForEncoding.h
+++ b/dwio/nimble/encodings/ForEncoding.h
@@ -189,7 +189,11 @@ ForEncoding<T>::ForEncoding(
 
   if (compressionType != CompressionType::Uncompressed) {
     uncompressedData_ = Compression::uncompress(
-        *this->pool_, compressionType, DataType::Undefined, packedDataView);
+        *this->pool_,
+        compressionType,
+        DataType::Undefined,
+        packedDataView,
+        options.decompressCounter());
     packedData_ = uncompressedData_->as<char>();
   } else {
     packedData_ = packedDataView.data();

--- a/dwio/nimble/encodings/TrivialEncoding.cpp
+++ b/dwio/nimble/encodings/TrivialEncoding.cpp
@@ -40,6 +40,7 @@ TrivialEncoding<std::string_view>::TrivialEncoding(
         dataCompressionType,
         DataType::String,
         {blob_, static_cast<size_t>(data.end() - blob_)},
+        options.decompressCounter(),
         options.bufferPool);
     blob_ = dataUncompressed_->as<char>();
     uncompressedDataBytes_ = dataUncompressed_->size();
@@ -166,6 +167,7 @@ TrivialEncoding<bool>::TrivialEncoding(
         compressionType,
         DataType::Undefined,
         {bitmap_, static_cast<size_t>(data.end() - bitmap_)},
+        options.decompressCounter(),
         options.bufferPool);
     bitmap_ = uncompressed_->as<char>();
     NIMBLE_CHECK_EQ(

--- a/dwio/nimble/encodings/TrivialEncoding.h
+++ b/dwio/nimble/encodings/TrivialEncoding.h
@@ -245,6 +245,7 @@ TrivialEncoding<T>::TrivialEncoding(
         compressionType,
         TypeTraits<physicalType>::dataType,
         {data.data() + valuesOffset, data.size() - valuesOffset},
+        options.decompressCounter(),
         options.bufferPool);
     values_ = reinterpret_cast<const T*>(uncompressed_->as<char>());
     NIMBLE_CHECK_EQ(

--- a/dwio/nimble/encodings/common/Encoding.h
+++ b/dwio/nimble/encodings/common/Encoding.h
@@ -65,6 +65,10 @@
 ///  encodings
 ///     have slightly different semantics than other encodings.
 
+namespace facebook::velox::dwio::common {
+struct DecodingStats;
+} // namespace facebook::velox::dwio::common
+
 namespace facebook::nimble {
 
 template <typename T, typename Filter, typename ExtractValues, bool kIsDense>
@@ -128,6 +132,14 @@ class Encoding {
     /// are packed per block. Written to the stream header; the reader
     /// reads it back from the stream (self-describing).
     uint16_t blockBitPackingBlockSize = kBlockBitPackingBlockSize;
+
+    /// Per-column decoding statistics for timing decompression.
+    velox::dwio::common::DecodingStats* decodingStats = nullptr;
+
+    velox::io::IoCounter* decompressCounter() const {
+      return decodingStats != nullptr ? &decodingStats->decompressCPUTimeNanos
+                                      : nullptr;
+    }
   };
 
   static constexpr int kEncodingTypeOffset =

--- a/dwio/nimble/encodings/legacy/FixedBitWidthEncoding.h
+++ b/dwio/nimble/encodings/legacy/FixedBitWidthEncoding.h
@@ -99,7 +99,8 @@ FixedBitWidthEncoding<T>::FixedBitWidthEncoding(
         pool,
         compressionType,
         TypeTraits<physicalType>::dataType,
-        {pos, static_cast<size_t>(data.end() - pos)});
+        {pos, static_cast<size_t>(data.end() - pos)},
+        /*decompressCounter=*/nullptr);
     fixedBitArray_ = FixedBitArray{
         {uncompressedData_->as<char>(), uncompressedData_->size()}, bitWidth_};
   } else {

--- a/dwio/nimble/encodings/legacy/TrivialEncoding.cpp
+++ b/dwio/nimble/encodings/legacy/TrivialEncoding.cpp
@@ -38,7 +38,8 @@ TrivialEncoding<std::string_view>::TrivialEncoding(
         pool,
         dataCompressionType,
         DataType::String,
-        {blob_, static_cast<size_t>(data.end() - blob_)});
+        {blob_, static_cast<size_t>(data.end() - blob_)},
+        /*decompressCounter=*/nullptr);
     blob_ = dataUncompressed_->as<char>();
     uncompressedDataBytes_ = dataUncompressed_->size();
   } else {
@@ -148,7 +149,8 @@ TrivialEncoding<bool>::TrivialEncoding(
         pool,
         compressionType,
         DataType::Undefined,
-        {bitmap_, static_cast<size_t>(data.end() - bitmap_)});
+        {bitmap_, static_cast<size_t>(data.end() - bitmap_)},
+        /*decompressCounter=*/nullptr);
     bitmap_ = uncompressed_->as<char>();
     NIMBLE_CHECK_EQ(
         bitmap_ + FixedBitArray::bufferSize(rowCount(), 1),

--- a/dwio/nimble/encodings/legacy/TrivialEncoding.h
+++ b/dwio/nimble/encodings/legacy/TrivialEncoding.h
@@ -199,7 +199,8 @@ TrivialEncoding<T>::TrivialEncoding(
         pool,
         compressionType,
         TypeTraits<physicalType>::dataType,
-        {data.data() + kDataOffset, data.size() - kDataOffset});
+        {data.data() + kDataOffset, data.size() - kDataOffset},
+        /*decompressCounter=*/nullptr);
     values_ = reinterpret_cast<const T*>(uncompressed_->as<char>());
     NIMBLE_CHECK_EQ(
         reinterpret_cast<const char*>(values_ + this->rowCount()),

--- a/dwio/nimble/velox/selective/ChunkedDecoder.cpp
+++ b/dwio/nimble/velox/selective/ChunkedDecoder.cpp
@@ -57,8 +57,10 @@ bool ChunkedDecoder::loadNextChunk(
     return buffer->asMutable<void>();
   };
   auto data = std::string_view(chunkData, chunkSize);
+  // Copy, not reference.
   auto options = encodingFactory_->options();
   options.preserveDictionaryEncoding = preserveDictionaryEncoding;
+  options.decodingStats = decodingStats_;
   encoding_ =
       encodingFactory_->create(*pool_, data, stringBufferFactory, options);
   remainingValues_ = encoding_->rowCount();

--- a/dwio/nimble/velox/selective/ChunkedDecoder.h
+++ b/dwio/nimble/velox/selective/ChunkedDecoder.h
@@ -59,7 +59,8 @@ class ChunkedDecoder {
       bool decodeValuesWithNulls,
       const EncodingFactory* encodingFactory,
       velox::memory::MemoryPool* pool,
-      bool stringDecoderZeroCopy = false)
+      bool stringDecoderZeroCopy = false,
+      velox::dwio::common::DecodingStats* decodingStats = nullptr)
       : input_{std::move(input)},
         pool_{pool},
         decodeValuesWithNulls_{decodeValuesWithNulls},
@@ -68,7 +69,8 @@ class ChunkedDecoder {
         streamIndex_{std::move(streamIndex)},
         streamRowCount_{
             streamIndex_ ? std::optional<uint32_t>(streamIndex_->rowCount())
-                         : std::nullopt} {
+                         : std::nullopt},
+        decodingStats_{decodingStats} {
     NIMBLE_CHECK_NOT_NULL(input_);
     NIMBLE_CHECK_NOT_NULL(encodingFactory_);
   }
@@ -851,6 +853,9 @@ class ChunkedDecoder {
   // Tracks the current row position in the stream.
   uint32_t rowPosition_{0};
 
+  // Per-column decoding statistics. Owned by ColumnReaderStatistics; valid for
+  // the lifetime of this decoder.
+  velox::dwio::common::DecodingStats* const decodingStats_{nullptr};
   friend class ChunkedDecoderTestHelper;
 };
 

--- a/dwio/nimble/velox/selective/NimbleData.cpp
+++ b/dwio/nimble/velox/selective/NimbleData.cpp
@@ -31,13 +31,15 @@ NimbleData::NimbleData(
     const EncodingFactory& encodingFactory,
     bool stringDecoderZeroCopy,
     bool nimblePreserveDictionaryEncoding,
-    bool lazyColumnIo)
+    bool lazyColumnIo,
+    velox::dwio::common::DecodingStats* decodingStats)
     : nimbleType_(nimbleType),
       streams_(&streams),
       pool_(&memoryPool),
       inMapDecoder_(inMapDecoder),
       encodingFactory_(&encodingFactory),
-      lazyColumnIo_(lazyColumnIo) {
+      lazyColumnIo_(lazyColumnIo),
+      decodingStats_(decodingStats) {
   switch (nimbleType->kind()) {
     case Kind::Scalar:
       // Nulls in scalar types will be decoded along with values.
@@ -170,7 +172,8 @@ ChunkedDecoder NimbleData::makeScalarDecoder() {
       /*decodeValuesWithNulls=*/false,
       encodingFactory_,
       pool_,
-      stringDecoderZeroCopy_);
+      stringDecoderZeroCopy_,
+      decodingStats_);
 }
 
 ChunkedDecoder NimbleData::makeMicrosDecoder() {
@@ -183,7 +186,8 @@ ChunkedDecoder NimbleData::makeMicrosDecoder() {
       /*decodeValuesWithNulls=*/false,
       encodingFactory_,
       pool_,
-      stringDecoderZeroCopy_);
+      stringDecoderZeroCopy_,
+      decodingStats_);
 }
 
 ChunkedDecoder NimbleData::makeNanosDecoder() {
@@ -196,7 +200,8 @@ ChunkedDecoder NimbleData::makeNanosDecoder() {
       /*decodeValuesWithNulls=*/false,
       encodingFactory_,
       pool_,
-      stringDecoderZeroCopy_);
+      stringDecoderZeroCopy_,
+      decodingStats_);
 }
 
 std::unique_ptr<ChunkedDecoder> NimbleData::makeLengthDecoder() {
@@ -226,12 +231,18 @@ std::unique_ptr<ChunkedDecoder> NimbleData::makeDecoder(
       decodeValuesWithNulls,
       encodingFactory_,
       pool_,
-      stringDecoderZeroCopy_);
+      stringDecoderZeroCopy_,
+      decodingStats_);
 }
 
 std::unique_ptr<velox::dwio::common::FormatData> NimbleParams::toFormatData(
-    const std::shared_ptr<const velox::dwio::common::TypeWithId>& /*type*/,
+    const std::shared_ptr<const velox::dwio::common::TypeWithId>& type,
     const velox::common::ScanSpec& /*scanSpec*/) {
+  velox::dwio::common::DecodingStats* decodingStats = nullptr;
+  if (runtimeStatistics().decodingStatsSet.has_value()) {
+    decodingStats = runtimeStatistics().decodingStatsSet->getOrCreate(
+        type->id(), type->type()->kind());
+  }
   return std::make_unique<NimbleData>(
       nimbleType_,
       *streams_,
@@ -240,7 +251,8 @@ std::unique_ptr<velox::dwio::common::FormatData> NimbleParams::toFormatData(
       *encodingFactory_,
       stringDecoderZeroCopy_,
       nimblePreserveDictionaryEncoding_,
-      lazyColumnIo_);
+      lazyColumnIo_,
+      decodingStats);
 }
 
 } // namespace facebook::nimble

--- a/dwio/nimble/velox/selective/NimbleData.h
+++ b/dwio/nimble/velox/selective/NimbleData.h
@@ -22,6 +22,7 @@
 #include "dwio/nimble/velox/selective/ReaderBase.h"
 #include "dwio/nimble/velox/selective/RowSizeTracker.h"
 #include "velox/dwio/common/FormatData.h"
+#include "velox/dwio/common/Statistics.h"
 
 namespace facebook::nimble {
 
@@ -37,7 +38,8 @@ class NimbleData : public velox::dwio::common::FormatData {
       const EncodingFactory& encodingFactory,
       bool stringDecoderZeroCopy,
       bool nimblePreserveDictionaryEncoding = false,
-      bool lazyColumnIo = false);
+      bool lazyColumnIo = false,
+      velox::dwio::common::DecodingStats* decodingStats = nullptr);
 
   /// Read internal node nulls. For leaf nodes, we only copy `incomingNulls' if
   /// it exists.
@@ -118,6 +120,9 @@ class NimbleData : public velox::dwio::common::FormatData {
   const EncodingFactory* const encodingFactory_;
   bool nimblePreserveDictionaryEncoding_{false};
   bool lazyColumnIo_{false};
+  // Per-column decoding statistics. May be nullptr if column stats collection
+  // is disabled.
+  velox::dwio::common::DecodingStats* const decodingStats_{nullptr};
 };
 
 class NimbleParams : public velox::dwio::common::FormatParams {

--- a/dwio/nimble/velox/selective/tests/SelectiveNimbleReaderTest.cpp
+++ b/dwio/nimble/velox/selective/tests/SelectiveNimbleReaderTest.cpp
@@ -2612,59 +2612,76 @@ TEST_P(SelectiveNimbleReaderTest, mapAsStructAllNulls) {
   velox::test::assertEqualVectors(expected, batch);
 }
 
-// TODO: Re-enable after the decompression time tracking diff lands and
-// updates the member access from columnMetricsSet to decodingStatsSet.
-// TEST_P(SelectiveNimbleReaderTest, columnDecodeMetrics) {
-//   const bool stringDecoderZeroCopy = this->stringDecoderZeroCopy();
-//   const int numRows = 10'000;
-//   auto input = makeRowVector({
-//       makeFlatVector<int64_t>(numRows, [](auto i) { return i; }),
-//       makeFlatVector<std::string>(
-//           numRows, [](auto i) { return std::to_string(i); }),
-//   });
-//   auto scanSpec = std::make_shared<common::ScanSpec>("root");
-//   scanSpec->addAllChildFields(*asRowType(input->type()));
-//   auto file = test::createNimbleFile(*rootPool(), input);
-//   auto readFile = std::make_shared<InMemoryReadFile>(file);
-//   auto factory =
-//       dwio::common::getReaderFactory(dwio::common::FileFormat::NIMBLE);
-//   dwio::common::ReaderOptions options(pool());
-//   options.setDataIoStats(dataIoStats_);
-//   options.setMetadataIoStats(metadataIoStats_);
-//   options.setScanSpec(scanSpec);
-//   auto reader = factory->createReader(
-//       std::make_unique<dwio::common::BufferedInput>(readFile, *pool()),
-//       options);
-//   dwio::common::RowReaderOptions rowOptions;
-//   rowOptions.setScanSpec(scanSpec);
-//   rowOptions.setRequestedType(asRowType(input->type()));
-//   rowOptions.setStringDecoderZeroCopy(stringDecoderZeroCopy);
-//   rowOptions.setCollectColumnStats(true);
-//   rowOptions.setEagerFirstStripeLoad(true);
-//   auto rowReader = reader->createRowReader(rowOptions);
-//
-//   VectorPtr result = BaseVector::create(asRowType(input->type()), 0, pool());
-//   uint64_t totalRows = 0;
-//   while (auto n = rowReader->next(1'000, result)) {
-//     totalRows += n;
-//     auto* row = result->as<RowVector>();
-//     for (auto i = 0; i < row->childrenSize(); ++i) {
-//       row->childAt(i)->loadedVector();
-//     }
-//   }
-//   EXPECT_EQ(totalRows, numRows) << "should read all rows";
-//
-//   dwio::common::RuntimeStatistics stats;
-//   rowReader->updateRuntimeStats(stats);
-//   ASSERT_TRUE(stats.columnReaderStats.decodingStatsSet.has_value());
-//
-//   auto* col1 = stats.columnReaderStats.decodingStatsSet->getOrCreate(1);
-//   EXPECT_GT(col1->decodeCPUTimeNanos.count(), 0)
-//       << "column 1 decode count should be > 0";
-//   auto* col2 = stats.columnReaderStats.decodingStatsSet->getOrCreate(2);
-//   EXPECT_GT(col2->decodeCPUTimeNanos.count(), 0)
-//       << "column 2 decode count should be > 0";
-// }
+TEST_P(SelectiveNimbleReaderTest, columnDecodeMetrics) {
+  const int numRows = 100'000;
+  auto input = makeRowVector({
+      makeFlatVector<int64_t>(numRows, [](auto i) { return i * 7 + 13; }),
+      makeFlatVector<std::string>(
+          numRows, [](auto i) { return std::string(20, 'a' + (i % 26)); }),
+  });
+  auto scanSpec = std::make_shared<common::ScanSpec>("root");
+  scanSpec->addAllChildFields(*asRowType(input->type()));
+  nimble::CompressionOptions comprOpts;
+  comprOpts.compressionAcceptRatio = 100.0f;
+  comprOpts.compressionAcceptRatioOverrides = {};
+  nimble::ManualEncodingSelectionPolicyFactory encodingFactory(
+      {{{nimble::EncodingType::Trivial, 1.0}}}, comprOpts);
+  nimble::VeloxWriterOptions writerOptions;
+  writerOptions.encodingSelectionPolicyFactory = [&](nimble::DataType dt) {
+    return encodingFactory.createPolicy(dt);
+  };
+  auto file =
+      test::createNimbleFile(*rootPool(), input, std::move(writerOptions));
+  auto readFile = std::make_shared<InMemoryReadFile>(file);
+  auto factory =
+      dwio::common::getReaderFactory(dwio::common::FileFormat::NIMBLE);
+  dwio::common::ReaderOptions options(pool());
+  options.setDataIoStats(dataIoStats_);
+  options.setMetadataIoStats(metadataIoStats_);
+  options.setScanSpec(scanSpec);
+  auto reader = factory->createReader(
+      std::make_unique<dwio::common::BufferedInput>(readFile, *pool()),
+      options);
+  dwio::common::RowReaderOptions rowOptions;
+  rowOptions.setScanSpec(scanSpec);
+  rowOptions.setRequestedType(asRowType(input->type()));
+  // zeroCopy=true uses nimble::EncodingFactory (not legacy), which forwards
+  // Encoding::Options including decodingStats to encoding constructors.
+  rowOptions.setStringDecoderZeroCopy(true);
+  rowOptions.setCollectColumnStats(true);
+  rowOptions.setEagerFirstStripeLoad(true);
+  auto rowReader = reader->createRowReader(rowOptions);
+
+  VectorPtr result = BaseVector::create(asRowType(input->type()), 0, pool());
+  uint64_t totalRows = 0;
+  while (auto n = rowReader->next(1'000, result)) {
+    totalRows += n;
+    auto* row = result->as<RowVector>();
+    for (auto i = 0; i < row->childrenSize(); ++i) {
+      row->childAt(i)->loadedVector();
+    }
+  }
+  EXPECT_EQ(totalRows, numRows) << "should read all rows";
+
+  dwio::common::RuntimeStatistics stats;
+  rowReader->updateRuntimeStats(stats);
+  ASSERT_TRUE(stats.columnReaderStats.decodingStatsSet.has_value());
+
+  auto* col1 = stats.columnReaderStats.decodingStatsSet->getOrCreate(1);
+  EXPECT_GT(col1->decodeCPUTimeNanos.count(), 0)
+      << "column 1 decode count should be > 0";
+  EXPECT_GT(col1->decompressCPUTimeNanos.count(), 0)
+      << "column 1 decompress count should be > 0";
+  // Decompression is a subset of the full decode path. Both use CPU time
+  // (withDecompressStats / NanosecondCPUTimer), so the comparison is safe.
+  EXPECT_LE(col1->decompressCPUTimeNanos.sum(), col1->decodeCPUTimeNanos.sum())
+      << "decompress time should be <= decode time (it is a subset)";
+  auto* col2 = stats.columnReaderStats.decodingStatsSet->getOrCreate(2);
+  EXPECT_GT(col2->decodeCPUTimeNanos.count(), 0)
+      << "column 2 decode count should be > 0";
+  EXPECT_GT(col2->decompressCPUTimeNanos.count(), 0)
+      << "column 2 decompress count should be > 0";
+}
 
 // Tests for FixedBitWidthEncoding fast path.
 // The fast path is used for 4-byte integral types without filters or hooks.


### PR DESCRIPTION
Summary:

Thread `DecodingStats*` from `ColumnReaderStatistics` through `NimbleData` → `ChunkedDecoder` → encoding constructors, and pass the `decompressCPUTimeNanos` counter to `Compression::uncompress()` so decompression CPU time is tracked per column.

Reviewed By: xiaoxmeng

Differential Revision: D108361387
