### PR TITLE
feat(selective): Enable dictionary path for filtered string reads (#862)

### DIFF
--- a/dwio/nimble/encodings/ConstantEncoding.h
+++ b/dwio/nimble/encodings/ConstantEncoding.h
@@ -110,8 +110,7 @@ class ConstantEncodingBase
   template <typename V>
   void readIndicesWithVisitor(V& visitor, ReadWithVisitorParams& params) {
     NIMBLE_CHECK(
-        !V::kHasFilter && !V::kHasHook,
-        "readIndicesWithVisitor should only be invoked in dictionary fast path");
+        !V::kHasHook, "readIndicesWithVisitor does not support value hooks");
     const auto numReadRows =
         visitor.rowAt(visitor.numRows() - 1) - params.numScanned + 1;
     auto* rawNulls = visitor.reader().rawNullsInReadRange();
@@ -126,12 +125,7 @@ class ConstantEncodingBase
           visitor.rowAt(0) + visitor.numRows() - 1,
           "Dense visitor must have contiguous rows");
       detail::readDenseMaterializedIndices(
-          *this,
-          visitor,
-          rawNulls,
-          params.numScanned,
-          numReadRows,
-          numNonNulls);
+          *this, visitor, params, rawNulls, numReadRows, numNonNulls);
       return;
     }
 

--- a/dwio/nimble/encodings/DictionaryEncoding.h
+++ b/dwio/nimble/encodings/DictionaryEncoding.h
@@ -290,8 +290,7 @@ void DictionaryEncoding<T>::readIndicesWithVisitor(
     ReadWithVisitorParams& params) {
   NIMBLE_CHECK(this->dictionaryEnabled());
   NIMBLE_CHECK(
-      !V::kHasFilter && !V::kHasHook,
-      "readIndicesWithVisitor should only be invoked in dictionary fast path");
+      !V::kHasHook, "readIndicesWithVisitor does not support value hooks");
   const auto numReadRows =
       visitor.rowAt(visitor.numRows() - 1) - params.numScanned + 1;
   auto* rawNulls = visitor.reader().rawNullsInReadRange();
@@ -307,7 +306,7 @@ void DictionaryEncoding<T>::readIndicesWithVisitor(
         visitor.rowAt(0) + visitor.numRows() - 1,
         "Dense visitor must have contiguous rows");
     detail::readDenseMaterializedIndices(
-        *this, visitor, rawNulls, params.numScanned, numReadRows, numNonNulls);
+        *this, visitor, params, rawNulls, numReadRows, numNonNulls);
     return;
   }
 

--- a/dwio/nimble/encodings/MainlyConstantEncoding.h
+++ b/dwio/nimble/encodings/MainlyConstantEncoding.h
@@ -273,8 +273,8 @@ class MainlyConstantEncodingBase
         this->dictionaryEnabled(),
         "readIndicesWithVisitor requires dictionary-enabled inner encoding");
     NIMBLE_CHECK(
-        !IndicesVisitor::kHasFilter && !IndicesVisitor::kHasHook,
-        "readIndicesWithVisitor should only be invoked in dictionary fast path");
+        !IndicesVisitor::kHasHook,
+        "readIndicesWithVisitor does not support value hooks");
     const auto numReadRows =
         visitor.rowAt(visitor.numRows() - 1) - params.numScanned + 1;
 
@@ -291,12 +291,7 @@ class MainlyConstantEncodingBase
           visitor.rowAt(0) + visitor.numRows() - 1,
           "Dense visitor must have contiguous rows");
       detail::readDenseMaterializedIndices(
-          *this,
-          visitor,
-          rawNulls,
-          params.numScanned,
-          numReadRows,
-          numNonNulls);
+          *this, visitor, params, rawNulls, numReadRows, numNonNulls);
       return;
     }
 
@@ -502,6 +497,13 @@ class MainlyConstantEncodingBase
   /// Reads isCommon, delegates to inner encoding's materializeIndices for
   /// non-common rows, fills common positions with commonValueIndex.
   void materializeIndices(uint32_t rowCount, uint32_t* buffer) override {
+    // An all-null read range produces zero dense non-null rows. Return early:
+    // nwords(0) is 0, so the isCommon[numWords - 1] tail-bit write below would
+    // underflow to isCommon[-1] (out-of-bounds). rowCount == 0 is the only
+    // input that yields numWords == 0.
+    if (rowCount == 0) {
+      return;
+    }
     const auto numWords = velox::bits::nwords(rowCount);
     isCommonBuffer_.resize(numWords * sizeof(uint64_t));
     auto* isCommon = reinterpret_cast<uint64_t*>(isCommonBuffer_.data());

--- a/dwio/nimble/encodings/NullableEncoding.h
+++ b/dwio/nimble/encodings/NullableEncoding.h
@@ -339,8 +339,7 @@ void NullableEncoding<T>::readIndicesWithVisitor(
       this->dictionaryEnabled(),
       "readIndicesWithVisitor requires dictionary-enabled inner encoding");
   NIMBLE_CHECK(
-      !V::kHasFilter && !V::kHasHook,
-      "readIndicesWithVisitor should only be invoked in dictionary fast path");
+      !V::kHasHook, "readIndicesWithVisitor does not support value hooks");
   materializeNullsForVisitor(visitor, params);
   callReadIndicesWithVisitor(*nonNullValues_, visitor, params);
 }

--- a/dwio/nimble/encodings/RLEEncoding.h
+++ b/dwio/nimble/encodings/RLEEncoding.h
@@ -346,8 +346,8 @@ class RLEEncoding final : public internal::RLEEncodingBase<T, RLEEncoding<T>> {
         this->dictionaryEnabled(),
         "readIndicesWithVisitor requires dictionary-enabled inner encoding");
     NIMBLE_CHECK(
-        !IndicesVisitor::kHasFilter && !IndicesVisitor::kHasHook,
-        "readIndicesWithVisitor should only be invoked in dictionary fast path");
+        !IndicesVisitor::kHasHook,
+        "readIndicesWithVisitor does not support value hooks");
     const auto numReadRows =
         visitor.rowAt(visitor.numRows() - 1) - params.numScanned + 1;
     auto* rawNulls = visitor.reader().rawNullsInReadRange();
@@ -362,12 +362,7 @@ class RLEEncoding final : public internal::RLEEncodingBase<T, RLEEncoding<T>> {
           visitor.rowAt(0) + visitor.numRows() - 1,
           "Dense visitor must have contiguous rows");
       detail::readDenseMaterializedIndices(
-          *this,
-          visitor,
-          rawNulls,
-          params.numScanned,
-          numReadRows,
-          numNonNulls);
+          *this, visitor, params, rawNulls, numReadRows, numNonNulls);
       return;
     }
 

--- a/dwio/nimble/encodings/common/Encoding.h
+++ b/dwio/nimble/encodings/common/Encoding.h
@@ -425,6 +425,30 @@ T castFromPhysicalType(const PhysicalType& value) {
   }
 }
 
+// Ensures the reader's result-nulls buffer exists before a filtered dense index
+// read emits a null via processNull() -> addNull(). Unlike DWRF, Nimble does
+// not pre-populate nullsInReadRange_ in prepareRead() for scalar columns (their
+// nulls are materialized lazily during decode), so prepareRead() did not size
+// resultNulls_; the dense filtered path must allocate it before the first
+// addNull(). No-op without a filter (no processNull path) or without nulls.
+//
+// TODO: This is intentionally eager -- it allocates resultNulls_ whenever a
+// filtered read sees a null bitmap, even for value filters where no null row
+// ever passes (so the buffer goes unused). The SIMD follow-up
+// (StringColumnReader::filterDictionaryIndices) removes the in-visitor
+// kHasFilter branch entirely and handles null emission post-hoc, at which point
+// this helper and its call sites should be deleted.
+template <typename V>
+void prepareResultNullsForDenseFilter(
+    const ReadWithVisitorParams& params,
+    const uint64_t* rawNulls) {
+  if constexpr (V::kHasFilter) {
+    if (rawNulls != nullptr) {
+      params.prepareResultNulls();
+    }
+  }
+}
+
 // Materializes dictionary indices into the reader's rawValues_ and scatters
 // for null gaps. Used by DictionaryEncoding and MainlyConstantEncoding
 // readIndicesWithVisitor as the dense no-filter fast path.
@@ -432,18 +456,61 @@ T castFromPhysicalType(const PhysicalType& value) {
 //
 // @param encoding The encoding to call materializeIndices on.
 // @param visitor The visitor (used for outerNonNullRows scratch buffer).
+// @param params Read params; provides numScanned (the read offset) and, on the
+//        filtered path, the result-nulls buffer allocation.
 // @param rawNulls The null bitmap from nullsInReadRange (may be nullptr).
-// @param readOffset Bit offset into rawNulls for the current read range.
 // @param numReadRows Total rows in the read range (including nulls).
 // @param numNonNulls Count of non-null rows in the range.
 template <typename V>
 void readDenseMaterializedIndices(
     Encoding& encoding,
     V& visitor,
+    const ReadWithVisitorParams& params,
     const uint64_t* rawNulls,
-    vector_size_t readOffset,
     uint32_t numReadRows,
     uint32_t numNonNulls) {
+  // On the filtered path, allocate the result-nulls buffer up front so the
+  // per-row processNull() -> addNull() below has somewhere to write.
+  prepareResultNullsForDenseFilter<V>(params, rawNulls);
+  const auto readOffset = params.numScanned;
+  // When the visitor has a filter, materialize indices into a temp buffer
+  // and dispatch through the visitor's process()/processNull() per row.
+  // This lets the visitor evaluate the filter (e.g., filterCache lookup)
+  // and handle nulls correctly. The bulk path below skips process() and
+  // writes directly to rawValues_, which is only safe without a filter.
+  if constexpr (V::kHasFilter) {
+    // TODO: Avoid this per-call scratch allocation. This in-visitor filter
+    // path is superseded by the bulk SIMD post-hoc filter
+    // (StringColumnReader::filterDictionaryIndices), which removes the whole
+    // kHasFilter branch here in a follow-up. Until that lands, keep the simple
+    // allocation rather than thrashing this function's signature to thread a
+    // reusable buffer through every caller.
+    std::vector<uint32_t> tempIndices(numNonNulls);
+    encoding.materializeIndices(numNonNulls, tempIndices.data());
+    uint32_t nonNullIdx = 0;
+    bool atEnd = false;
+    if (rawNulls != nullptr) {
+      NIMBLE_CHECK_NOT_NULL(
+          visitor.reader().rawResultNulls(),
+          "prepareResultNullsForDenseFilter() must have allocated the "
+          "result-nulls buffer before a filtered dense read with nulls reaches "
+          "processNull() -> addNull().");
+      for (uint32_t row = 0; row < numReadRows && !atEnd; ++row) {
+        if (velox::bits::isBitSet(rawNulls, readOffset + row)) {
+          visitor.process(
+              static_cast<int32_t>(tempIndices[nonNullIdx++]), atEnd);
+        } else {
+          visitor.processNull(atEnd);
+        }
+      }
+    } else {
+      for (uint32_t row = 0; row < numReadRows && !atEnd; ++row) {
+        visitor.process(static_cast<int32_t>(tempIndices[nonNullIdx++]), atEnd);
+      }
+    }
+    return;
+  }
+
   auto* rawOutputValues =
       reinterpret_cast<int32_t*>(visitor.reader().rawValues());
   const auto valueOutputOffset = visitor.reader().numValues();
@@ -502,6 +569,53 @@ void readSparseMaterializedIndices(
     uint32_t numNonNulls,
     uint32_t* indicesBuffer) {
   encoding.materializeIndices(numNonNulls, indicesBuffer);
+
+  // When the visitor has a filter, dispatch through process()/processNull()
+  // per row so the visitor evaluates the filter and handles outputRows.
+  if constexpr (V::kHasFilter) {
+    uint32_t indexOffset = 0;
+    bool atEnd = false;
+    if (rawNulls != nullptr) {
+      for (uint32_t row = 0; row < numReadRows && !atEnd &&
+           visitor.rowIndex() < visitor.numRows();
+           ++row) {
+        const bool readCurrentRow = row ==
+            static_cast<uint32_t>(visitor.rowAt(visitor.rowIndex()) -
+                                  readOffset);
+        if (velox::bits::isBitSet(rawNulls, readOffset + row)) {
+          if (readCurrentRow) {
+            visitor.process(
+                static_cast<int32_t>(indicesBuffer[indexOffset]), atEnd);
+          }
+          ++indexOffset;
+        } else {
+          if (readCurrentRow) {
+            // Ensure the result-nulls buffer exists before processNull() ->
+            // addNull() writes rawResultNulls_. On the filtered path
+            // returnReaderNulls_ is false, so only prepareResultNulls()
+            // allocates it. Idempotent.
+            prepareResultNulls();
+            visitor.processNull(atEnd);
+          }
+        }
+      }
+    } else {
+      for (uint32_t row = 0; row < numReadRows && !atEnd &&
+           visitor.rowIndex() < visitor.numRows();
+           ++row) {
+        const bool readCurrentRow = row ==
+            static_cast<uint32_t>(visitor.rowAt(visitor.rowIndex()) -
+                                  readOffset);
+        if (readCurrentRow) {
+          visitor.process(
+              static_cast<int32_t>(indicesBuffer[indexOffset]), atEnd);
+        }
+        ++indexOffset;
+      }
+    }
+    return;
+  }
+
   auto* rawOutputValues =
       reinterpret_cast<int32_t*>(visitor.reader().rawValues());
   const auto valueOutputOffset = visitor.reader().numValues();
@@ -512,23 +626,23 @@ void readSparseMaterializedIndices(
   bool nullsEmitted = false;
   for (uint32_t row = 0; row < numReadRows && readRowIndex < visitor.numRows();
        ++row) {
-    const bool isReadRow =
+    const bool readCurrentRow =
         row == static_cast<uint32_t>(visitor.rowAt(readRowIndex) - readOffset);
     const bool isNull = rawNulls != nullptr &&
         !velox::bits::isBitSet(rawNulls, readOffset + row);
     if (isNull) {
-      if (isReadRow) {
+      if (readCurrentRow) {
+        if (!nullsEmitted) {
+          nullsEmitted = true;
+          prepareResultNulls();
+          visitor.reader().setHasNulls();
+        }
         // In the sparse case, returnReaderNulls_ is false
         // (initReturnReaderNulls only sets it for dense rows). resultNulls()
         // then returns resultNulls_ instead of nullsInReadRange_. We must
         // explicitly write null bits to resultNulls_ so
         // DictionaryVector::validate() knows to skip these positions. Also
         // write 0 as a safe placeholder index.
-        if (!nullsEmitted) {
-          nullsEmitted = true;
-          prepareResultNulls();
-          visitor.reader().setHasNulls();
-        }
         const auto outputPos = valueOutputOffset + readRowIndex - startRowIndex;
         rawOutputValues[outputPos] = 0;
         velox::bits::setNull(visitor.reader().rawResultNulls(), outputPos);
@@ -536,7 +650,7 @@ void readSparseMaterializedIndices(
       }
       continue;
     }
-    if (isReadRow) {
+    if (readCurrentRow) {
       rawOutputValues[valueOutputOffset + readRowIndex - startRowIndex] =
           static_cast<int32_t>(indicesBuffer[indexOffset]);
       ++readRowIndex;

--- a/dwio/nimble/encodings/tests/ReadWithVisitorTest.cpp
+++ b/dwio/nimble/encodings/tests/ReadWithVisitorTest.cpp
@@ -3735,11 +3735,12 @@ TEST_P(ReadWithVisitorTest, readDenseMaterializedIndicesNoNulls) {
   ASSERT_EQ(reader->numValues(), 0);
 
   // Call the helper with no nulls.
+  ReadWithVisitorParams params{.numScanned = 0};
   detail::readDenseMaterializedIndices(
       *encoding,
       visitor,
+      params,
       /*rawNulls=*/nullptr,
-      /*readOffset=*/0,
       /*numReadRows=*/kRows,
       /*numNonNulls=*/kRows);
 
@@ -3838,11 +3839,12 @@ TEST_P(ReadWithVisitorTest, readDenseMaterializedIndicesWithNulls) {
   ASSERT_EQ(reader->numValues(), 0);
 
   // Call the helper with nulls.
+  ReadWithVisitorParams params{.numScanned = 0};
   detail::readDenseMaterializedIndices(
       *encoding,
       visitor,
+      params,
       rawNulls,
-      /*readOffset=*/0,
       /*numReadRows=*/kRows,
       /*numNonNulls=*/numNonNull);
 

--- a/dwio/nimble/velox/selective/ChunkedDecoder.h
+++ b/dwio/nimble/velox/selective/ChunkedDecoder.h
@@ -439,6 +439,12 @@ class ChunkedDecoder {
               visitor.reader().readOffset() + params.numScanned);
           return false;
         }
+
+        // onChunkBoundary() rebuilt the per-chunk filter dictionary in the
+        // reader's scan state. Re-snapshot it into the visitor so the next
+        // chunk's filter evaluation uses this chunk's dictionary, not the
+        // stale copy captured when the visitor was constructed.
+        visitor.refreshScanState();
       }
 
       velox::vector_size_t numNulls{0};

--- a/dwio/nimble/velox/selective/StringColumnReader.cpp
+++ b/dwio/nimble/velox/selective/StringColumnReader.cpp
@@ -19,7 +19,9 @@
 #include <algorithm>
 #include "dwio/nimble/encodings/legacy/EncodingUtils.h"
 #include "dwio/nimble/velox/selective/NimbleData.h"
+#include "velox/common/base/SimdUtil.h"
 #include "velox/common/testutil/TestValue.h"
+#include "velox/dwio/common/ColumnVisitors.h"
 #include "velox/dwio/common/SelectiveColumnReaderInternal.h"
 #include "velox/vector/DictionaryVector.h"
 
@@ -44,6 +46,34 @@ void StringColumnReader::ensureDictionaryState() {
   }
   dictionaryState_.alphabet = buildEncodingDictionaryAlphabet<std::string_view>(
       decoder_.currentEncoding());
+}
+
+void StringColumnReader::updateDictionaryScanState(
+    const std::vector<std::string_view>& chunkAlphabet) {
+  using FilterResult = velox::dwio::common::FilterResult;
+  const auto alphabetSize = static_cast<int32_t>(chunkAlphabet.size());
+
+  auto values =
+      velox::AlignedBuffer::allocate<velox::StringView>(alphabetSize, pool_);
+  auto* rawValues = values->asMutable<velox::StringView>();
+  for (int32_t i = 0; i < alphabetSize; ++i) {
+    rawValues[i] =
+        velox::StringView(chunkAlphabet[i].data(), chunkAlphabet[i].size());
+  }
+  scanState_.dictionary.values = std::move(values);
+  scanState_.dictionary.numValues = alphabetSize;
+
+  // The filter dictionary is per-chunk: a given local index maps to a
+  // different value in each chunk, so the cache must be rebuilt (reset to
+  // kUnknown), not extended, at every chunk boundary.
+  if (velox::dwio::common::DictionaryValues::hasFilter(scanSpec_->filter())) {
+    scanState_.filterCache.resize(alphabetSize);
+    velox::simd::memset(
+        scanState_.filterCache.data(),
+        static_cast<uint8_t>(FilterResult::kUnknown),
+        alphabetSize);
+  }
+  scanState_.updateRawState();
 }
 
 void StringColumnReader::updateDictionaryIndices(
@@ -86,6 +116,9 @@ bool StringColumnReader::tryExtendDictionaryAtChunkBoundary(
       chunkAlphabet.begin(),
       chunkAlphabet.end());
   dictionaryState_.alphabetVector.reset();
+  if (scanSpec_->hasFilter()) {
+    updateDictionaryScanState(chunkAlphabet);
+  }
   crossChunkRead_ = true;
   return true;
 }
@@ -94,11 +127,15 @@ bool StringColumnReader::readWithDictionary(
     int64_t offset,
     const RowSet& rows,
     const uint64_t* incomingNulls) {
-  // Dictionary path requires: no filter pushdown, no value hook, non-legacy
-  // encoding path (zero-copy), session property enabled, and
-  // dictionary-convertible encoding.
-  if (scanSpec_->hasFilter() || scanSpec_->valueHook() ||
-      !formatData().stringDecoderZeroCopy() ||
+  // Dictionary path requires: no value hook, non-legacy encoding path
+  // (zero-copy), session property enabled, and dictionary-convertible
+  // encoding. Filters are supported via post-materialization filtering
+  // on the bulk-read dictionary indices.
+  // TODO: Value hooks (aggregation pushdown) could be supported by
+  // resolving alphabet[index] and calling hook->addValue() post-read,
+  // similar to filterDictionaryIndices. Neither Nimble nor DWRF
+  // currently support filter+hook combined for dict string columns.
+  if (scanSpec_->valueHook() || !formatData().stringDecoderZeroCopy() ||
       !static_cast<const NimbleData&>(formatData())
            .nimblePreserveDictionaryEncoding()) {
     clearDictionaryState();
@@ -119,8 +156,24 @@ bool StringColumnReader::readWithDictionary(
     return false;
   }
 
+  // A cross-chunk merged alphabet is per-read: getValues() clears it (and snaps
+  // its backing into the output DictionaryVector) once the read is consumed.
+  // But the parent struct reader skips this column's getValues() when it
+  // filters out all rows in a batch, leaving crossChunkRead_ set and a stale
+  // merged alphabet whose backing buffers the next read's setStringBuffers()
+  // will free. Clear it before reuse so ensureDictionaryState() rebuilds a
+  // fresh, valid alphabet. Single-chunk reads keep their cached alphabet
+  // (crossChunkRead_ stays false).
+  if (crossChunkRead_) {
+    clearDictionaryState();
+    crossChunkRead_ = false;
+  }
+
   prepareRead<int32_t>(offset, rows, incomingNulls);
   ensureDictionaryState();
+  if (scanSpec_->hasFilter()) {
+    updateDictionaryScanState(dictionaryState_.alphabet);
+  }
   velox::common::testutil::TestValue::adjust(
       "facebook::nimble::StringColumnReader::readWithDictionary",
       &dictionaryState_.alphabet);
@@ -139,8 +192,20 @@ bool StringColumnReader::readWithDictionary(
   //   - Returns false: the new chunk is not dict-compatible, so
   //     readDictionaryIndices stops and the reactive flat fallback below
   //     takes over.
+  //
+  // When a filter is active, the visitor's process()/processNull() in
+  // readDenseMaterializedIndices handle filter evaluation and outputRows
+  // via the if constexpr (kHasFilter) path in the encoding layer.
+  // kEncodingHasNulls must be false: unlike DWRF, Nimble does not pre-populate
+  // nullsInReadRange_ before the read. Nulls are materialized lazily by
+  // NullableEncoding during the decode (inside readDictionaryIndices). Passing
+  // true would route IsNull/IsNotNull through
+  // SelectiveColumnReader::filterNulls, which reads the still-empty
+  // nullsInReadRange_ and silently drops every matching row. With false,
+  // IsNull/IsNotNull go through the visitor/decode path (processNull) like
+  // every other filter, matching the flat read() below.
   dwio::common::StringColumnReadWithVisitorHelper<
-      /*kEncodingHasNulls=*/true,
+      /*kEncodingHasNulls=*/false,
       /*kDictionary=*/false>(*this, rows)([&](auto visitor) {
     auto dictVisitor = visitor.toStringDictionaryColumnVisitor();
 

--- a/dwio/nimble/velox/selective/StringColumnReader.h
+++ b/dwio/nimble/velox/selective/StringColumnReader.h
@@ -105,6 +105,14 @@ class StringColumnReader : public velox::dwio::common::SelectiveColumnReader {
       int32_t& alphabetOffset,
       velox::vector_size_t& valueOffset);
 
+  // Populates scanState_.dictionary and scanState_.filterCache from the given
+  // chunk's local alphabet so the visitor's process() can evaluate filters on
+  // that chunk's raw (local) dictionary indices. Called once per chunk during a
+  // filtered dictionary read; the filterCache is reset on each call because a
+  // local index maps to a different value in each chunk.
+  void updateDictionaryScanState(
+      const std::vector<std::string_view>& chunkAlphabet);
+
   // Converts the dict indices in rawValues_ to flat StringView values by
   // resolving each index against the merged alphabet. The StringViews point
   // into the encoding's string buffers already held by stringBuffers_. Null

--- a/dwio/nimble/velox/selective/tests/E2EFilterTest.cpp
+++ b/dwio/nimble/velox/selective/tests/E2EFilterTest.cpp
@@ -359,6 +359,7 @@ class E2EFilterTest
     // Branch on whether we need forced dictionary encoding, since
     // EncodingLayoutTree is not move-assignable due to const members.
     if (useForcedDictionaryEncoding_) {
+      // Need to set encodingLayoutTree at construction time.
       options.encodingLayoutTree.emplace(
           buildForcedDictionaryEncodingLayoutTree());
     }
@@ -2169,7 +2170,7 @@ TEST_P(E2EFilterTest, stringFilterOnBothColumnsCrossStripeNested) {
 // 2. Forcing the otherValues_ child to use Dictionary encoding via
 // EncodingLayoutTree
 //
-// This scenario is challenging because isDictionaryCompatible() must handle
+// This scenario is challenging because dictionaryEnabled() must handle
 // deeper nesting like MainlyConstant→Dictionary, not just direct Dictionary
 // or Nullable→Dictionary.
 TEST_P(E2EFilterTest, nestedMainlyConstantWithDictionary) {
@@ -2329,6 +2330,23 @@ TEST_P(E2EFilterTest, dictionaryVectorReturned) {
   std::vector<std::string> stringData(kRowCount);
   for (vector_size_t i = 0; i < kRowCount; ++i) {
     stringData[i] = alphabet[gen() % numDistinct];
+  }
+
+  rowType_ = ROW({"string_val", "long_val"}, {VARCHAR(), BIGINT()});
+  verifyDictionaryVectorReturned(
+      buildForcedDictionaryEncodingLayoutTree(), stringData);
+}
+
+// Regression test: the FlatVector backing the dictionary alphabet must hold
+// the decoder's string buffers so that non-inline StringViews point into
+// the vector's own buffers. FlatVector::validate() (debug mode) checks this
+// invariant. Non-inline strings (>12 bytes) are the only ones affected since
+// inline strings are stored directly in the StringView.
+TEST_P(E2EFilterTest, dictionaryVectorNonInlineAlphabet) {
+  const vector_size_t kRowCount = 1000;
+  std::vector<std::string> stringData(kRowCount);
+  for (vector_size_t i = 0; i < kRowCount; ++i) {
+    stringData[i] = fmt::format("LONG_DICTIONARY_VALUE_NUMBER_{}", i % 10);
   }
 
   rowType_ = ROW({"string_val", "long_val"}, {VARCHAR(), BIGINT()});
@@ -3133,5 +3151,612 @@ INSTANTIATE_TEST_SUITE_P(
     ::testing::Values(
         E2EFilterTestParams{false, false, false, false, false, false, false},
         E2EFilterTestParams{false, false, false, false, false, true, false}));
+
+// Exercises multi-chunk dictionary reads where each chunk has a distinct
+// alphabet. All batches are dictionary-encoded and placed in a single stripe
+// (each batch = one chunk). The reader requests 1000 rows per next() call,
+// forcing the dictionary read path to merge alphabets across 5 chunks.
+//
+// This test guards against two bugs found in the original implementation:
+// 1. Chunk-transition detection via pointer comparison was unreliable (the
+//    allocator reused the same address after destroying the old encoding).
+// 2. The onChunkLoad_ callback cleared the accumulated mergedAlphabet_
+//    during the read, destroying previously merged alphabet entries.
+TEST_P(E2EFilterTest, multiChunkDictionaryWithDifferentAlphabets) {
+  auto type = ROW({"string_val", "long_val"}, {VARCHAR(), BIGINT()});
+  rowType_ = asRowType(type);
+
+  const size_t kRowsPerBatch = 200;
+  const int kNumBatches = 8;
+  std::vector<RowVectorPtr> batches;
+
+  for (int batchIdx = 0; batchIdx < kNumBatches; ++batchIdx) {
+    std::vector<std::string> stringStorage(kRowsPerBatch);
+    std::vector<int64_t> longVals(kRowsPerBatch);
+
+    // Each batch has a unique alphabet prefix so multi-chunk merging is
+    // exercised (identical alphabets would trivially work).
+    for (size_t i = 0; i < kRowsPerBatch; ++i) {
+      stringStorage[i] = fmt::format("BATCH{}_VAL_{}", batchIdx, i % 5);
+      longVals[i] = batchIdx * kRowsPerBatch + i;
+    }
+
+    auto stringVector =
+        velox::test::VectorMaker(leafPool_.get())
+            .flatVector<velox::StringView>(kRowsPerBatch, [&](auto row) {
+              return velox::StringView(stringStorage[row]);
+            });
+    auto longVector = velox::test::VectorMaker(leafPool_.get())
+                          .flatVector<int64_t>(kRowsPerBatch, [&](auto row) {
+                            return longVals[row];
+                          });
+
+    batches.push_back(
+        std::make_shared<RowVector>(
+            leafPool_.get(),
+            type,
+            nullptr,
+            kRowsPerBatch,
+            std::vector<VectorPtr>{stringVector, longVector}));
+  }
+
+  // Write directly with flushLambda=false (no stripe flush → single stripe)
+  // and chunkLambda=true (each batch = one chunk). This creates multiple
+  // dictionary-encoded chunks within a single stripe.
+  {
+    auto writeFile = std::make_unique<InMemoryWriteFile>(&sinkData_);
+    VeloxWriterOptions writerOptions;
+    writerOptions.enableChunking = true;
+    writerOptions.minStreamChunkRawSize = 0;
+    writerOptions.flushPolicyFactory = [] {
+      return std::make_unique<LambdaFlushPolicy>(
+          /*flushLambda=*/[](const StripeProgress&) { return false; },
+          /*chunkLambda=*/[](const StripeProgress&) { return true; });
+    };
+    writerOptions.encodingLayoutTree.emplace(
+        buildForcedDictionaryEncodingLayoutTree());
+    VeloxWriter writer(
+        type, std::move(writeFile), *rootPool_, std::move(writerOptions));
+    for (auto& batch : batches) {
+      writer.write(batch);
+    }
+    writer.close();
+  }
+
+  auto input = std::make_unique<velox::dwio::common::BufferedInput>(
+      std::make_shared<velox::InMemoryReadFile>(sinkData_),
+      *leafPool_,
+      velox::dwio::common::MetricsLog::voidLog());
+
+  velox::dwio::common::ReaderOptions readerOpts{leafPool_.get()};
+  readerOpts.setMetadataIoStats(metadataIoStats_);
+  auto reader = makeReader(readerOpts, std::move(input));
+  auto scanSpec = std::make_shared<velox::common::ScanSpec>("root");
+  scanSpec->addAllChildFields(*type);
+  velox::dwio::common::RowReaderOptions rowReaderOptions;
+  rowReaderOptions.setScanSpec(scanSpec);
+  rowReaderOptions.setStringDecoderZeroCopy(param().stringDecoderZeroCopy);
+  rowReaderOptions.setNimblePreserveDictionaryEncoding(
+      param().stringDecoderZeroCopy);
+  auto rowReader = reader->createRowReader(rowReaderOptions);
+
+  // Read with batch size (1000) > chunk size (200), forcing cross-chunk reads.
+  VectorPtr result = velox::BaseVector::create(type, 0, leafPool_.get());
+  size_t totalRows = 0;
+  while (rowReader->next(1000, result)) {
+    auto* rowResult = result->as<RowVector>();
+    ASSERT_NE(rowResult, nullptr);
+    totalRows += rowResult->size();
+
+    auto stringChild = rowResult->childAt(0)->loadedVector();
+    if (param().stringDecoderZeroCopy) {
+      ASSERT_EQ(stringChild->encoding(), VectorEncoding::Simple::DICTIONARY)
+          << "Expected DICTIONARY encoding for string column, got "
+          << stringChild->encoding();
+    }
+
+    velox::DecodedVector decodedString(*stringChild);
+    velox::DecodedVector decodedLong(*rowResult->childAt(1));
+
+    for (size_t i = 0; i < rowResult->size(); ++i) {
+      auto globalRow = decodedLong.valueAt<int64_t>(i);
+      auto batchIdx = globalRow / kRowsPerBatch;
+      auto rowInBatch = globalRow % kRowsPerBatch;
+      auto expected = fmt::format("BATCH{}_VAL_{}", batchIdx, rowInBatch % 5);
+      ASSERT_EQ(decodedString.valueAt<velox::StringView>(i).str(), expected)
+          << "Mismatch at globalRow=" << globalRow;
+    }
+  }
+
+  EXPECT_EQ(totalRows, kNumBatches * kRowsPerBatch);
+}
+
+// Regression test for two bugs in the dictionary reactive fallback path:
+//   Bug 1: expandDictionaryToFlat was called after mergedAlphabet_.clear(),
+//          causing out-of-bounds access when expanding dictionary indices.
+//   Bug 2: The flat fallback's visitor added 0-based row numbers to
+//          outputRows_ without biasing by the number of rows consumed during
+//          the dictionary phase. This causes wrong cross-column row mapping.
+//
+// Both bugs require the reactive fallback: the string column starts with
+// dictionary-compatible chunks but encounters a non-dictionary chunk mid-read.
+// Bug 2 further requires hasFilter()=true so that useOutputRows()=true.
+//
+// The test verifies cross-column consistency: long_val encodes the original
+// row position, so we can reconstruct the expected string_val from it. If
+// Bug 2 causes wrong outputRows_, long_val maps to the wrong row, and the
+// reconstructed string_val won't match the actual string_val.
+TEST_P(E2EFilterTest, reactiveEncodingFallbackOutputRowsBias) {
+  auto type = ROW({"string_val", "long_val"}, {VARCHAR(), BIGINT()});
+  rowType_ = asRowType(type);
+
+  const size_t kRowsPerBatch = 200;
+  const int kNumBatches = 4;
+  std::vector<RowVectorPtr> batches;
+
+  for (int batchIdx = 0; batchIdx < kNumBatches; ++batchIdx) {
+    std::vector<std::string> stringStorage(kRowsPerBatch);
+    std::vector<int64_t> longVals(kRowsPerBatch);
+
+    for (size_t i = 0; i < kRowsPerBatch; ++i) {
+      longVals[i] = batchIdx * kRowsPerBatch + i;
+      if (batchIdx % 2 == 0) {
+        stringStorage[i] = fmt::format("DICT_VAL_{}", i % 5);
+      } else {
+        stringStorage[i] = fmt::format("UNIQUE_BATCH{}_ROW{}_PAD", batchIdx, i);
+      }
+    }
+
+    auto stringVector =
+        velox::test::VectorMaker(leafPool_.get())
+            .flatVector<velox::StringView>(kRowsPerBatch, [&](auto row) {
+              return velox::StringView(stringStorage[row]);
+            });
+    auto longVector = velox::test::VectorMaker(leafPool_.get())
+                          .flatVector<int64_t>(kRowsPerBatch, [&](auto row) {
+                            return longVals[row];
+                          });
+
+    batches.push_back(
+        std::make_shared<RowVector>(
+            leafPool_.get(),
+            type,
+            nullptr,
+            kRowsPerBatch,
+            std::vector<VectorPtr>{stringVector, longVector}));
+  }
+
+  {
+    auto writeFile = std::make_unique<InMemoryWriteFile>(&sinkData_);
+    VeloxWriterOptions writerOptions;
+    writerOptions.enableChunking = true;
+    writerOptions.flushPolicyFactory = [] {
+      return std::make_unique<LambdaFlushPolicy>(
+          /*flushLambda=*/[](const StripeProgress&) { return false; },
+          /*chunkLambda=*/[](const StripeProgress&) { return true; });
+    };
+    VeloxWriter writer(
+        type, std::move(writeFile), *rootPool_, std::move(writerOptions));
+    for (auto& batch : batches) {
+      writer.write(batch);
+    }
+    writer.close();
+  }
+
+  // Accept values from both dictionary and non-dictionary chunks so the
+  // reactive fallback produces output rows from both phases.
+  std::vector<std::string> accepted = {
+      "DICT_VAL_0", "UNIQUE_BATCH1_ROW0_PAD", "UNIQUE_BATCH3_ROW0_PAD"};
+  std::set<std::string> acceptedSet(accepted.begin(), accepted.end());
+
+  size_t expectedRows = 0;
+  for (int batchIdx = 0; batchIdx < kNumBatches; ++batchIdx) {
+    for (size_t i = 0; i < kRowsPerBatch; ++i) {
+      std::string val;
+      if (batchIdx % 2 == 0) {
+        val = fmt::format("DICT_VAL_{}", i % 5);
+      } else {
+        val = fmt::format("UNIQUE_BATCH{}_ROW{}_PAD", batchIdx, i);
+      }
+      if (acceptedSet.count(val)) {
+        ++expectedRows;
+      }
+    }
+  }
+
+  auto input = std::make_unique<velox::dwio::common::BufferedInput>(
+      std::make_shared<velox::InMemoryReadFile>(sinkData_),
+      *leafPool_,
+      velox::dwio::common::MetricsLog::voidLog());
+
+  velox::dwio::common::ReaderOptions readerOpts{leafPool_.get()};
+  readerOpts.setMetadataIoStats(metadataIoStats_);
+  auto reader = makeReader(readerOpts, std::move(input));
+  auto scanSpec = std::make_shared<velox::common::ScanSpec>("root");
+  scanSpec->addAllChildFields(*type);
+  scanSpec->childByName("string_val")
+      ->setFilter(
+          std::make_unique<velox::common::BytesValues>(accepted, false));
+  velox::dwio::common::RowReaderOptions rowReaderOptions;
+  rowReaderOptions.setScanSpec(scanSpec);
+  rowReaderOptions.setStringDecoderZeroCopy(param().stringDecoderZeroCopy);
+  auto rowReader = reader->createRowReader(rowReaderOptions);
+
+  VectorPtr result = velox::BaseVector::create(type, 0, leafPool_.get());
+  size_t totalRows = 0;
+  while (rowReader->next(1000, result)) {
+    auto* rowResult = result->as<RowVector>();
+    ASSERT_NE(rowResult, nullptr);
+    totalRows += rowResult->size();
+
+    velox::DecodedVector decodedString(*rowResult->childAt(0)->loadedVector());
+    velox::DecodedVector decodedLong(*rowResult->childAt(1)->loadedVector());
+
+    for (size_t i = 0; i < rowResult->size(); ++i) {
+      auto str = decodedString.valueAt<velox::StringView>(i).str();
+      auto longVal = decodedLong.valueAt<int64_t>(i);
+
+      ASSERT_TRUE(acceptedSet.count(str))
+          << "Value didn't pass filter: " << str;
+
+      // Verify cross-column consistency. long_val encodes the original row
+      // position, from which we can reconstruct the expected string_val.
+      auto batchIdx = longVal / kRowsPerBatch;
+      auto rowInBatch = longVal % kRowsPerBatch;
+      std::string expectedStr;
+      if (batchIdx % 2 == 0) {
+        expectedStr = fmt::format("DICT_VAL_{}", rowInBatch % 5);
+      } else {
+        expectedStr =
+            fmt::format("UNIQUE_BATCH{}_ROW{}_PAD", batchIdx, rowInBatch);
+      }
+      ASSERT_EQ(str, expectedStr)
+          << "Cross-column row mapping mismatch at result row " << i
+          << ", long_val=" << longVal << " (batch " << batchIdx << ", row "
+          << rowInBatch << ")";
+    }
+  }
+
+  EXPECT_EQ(totalRows, expectedRows);
+}
+
+// Exercises multi-chunk dictionary reads with different alphabets AND a filter
+// on the string column. This validates that:
+// 1. updateDictionaryScanState() correctly re-populates the filter cache as
+//    chunks
+//    are merged (new alphabet entries must be kUnknown, not stale).
+// 2. DictionaryColumnVisitor::refreshState() correctly re-syncs after
+//    chunk boundary alphabet growth.
+// 3. Index offsetting (alphabetOffset) interacts correctly with filter cache
+//    lookups — the visitor uses merged indices, not per-chunk indices.
+TEST_P(E2EFilterTest, multiChunkDictionaryWithFilter) {
+  auto type = ROW({"string_val", "long_val"}, {VARCHAR(), BIGINT()});
+  rowType_ = asRowType(type);
+
+  const size_t kRowsPerBatch = 200;
+  const int kNumBatches = 8;
+  std::vector<RowVectorPtr> batches;
+
+  for (int batchIdx = 0; batchIdx < kNumBatches; ++batchIdx) {
+    std::vector<std::string> stringStorage(kRowsPerBatch);
+    std::vector<int64_t> longVals(kRowsPerBatch);
+
+    for (size_t i = 0; i < kRowsPerBatch; ++i) {
+      stringStorage[i] = fmt::format("BATCH{}_VAL_{}", batchIdx, i % 5);
+      longVals[i] = batchIdx * kRowsPerBatch + i;
+    }
+
+    auto stringVector =
+        velox::test::VectorMaker(leafPool_.get())
+            .flatVector<velox::StringView>(kRowsPerBatch, [&](auto row) {
+              return velox::StringView(stringStorage[row]);
+            });
+    auto longVector = velox::test::VectorMaker(leafPool_.get())
+                          .flatVector<int64_t>(kRowsPerBatch, [&](auto row) {
+                            return longVals[row];
+                          });
+
+    batches.push_back(
+        std::make_shared<RowVector>(
+            leafPool_.get(),
+            type,
+            nullptr,
+            kRowsPerBatch,
+            std::vector<VectorPtr>{stringVector, longVector}));
+  }
+
+  // Single stripe, each batch = one chunk, forced dictionary encoding.
+  {
+    auto writeFile = std::make_unique<InMemoryWriteFile>(&sinkData_);
+    VeloxWriterOptions writerOptions;
+    writerOptions.enableChunking = true;
+    writerOptions.flushPolicyFactory = [] {
+      return std::make_unique<LambdaFlushPolicy>(
+          /*flushLambda=*/[](const StripeProgress&) { return false; },
+          /*chunkLambda=*/[](const StripeProgress&) { return true; });
+    };
+    writerOptions.encodingLayoutTree.emplace(
+        buildForcedDictionaryEncodingLayoutTree());
+    VeloxWriter writer(
+        type, std::move(writeFile), *rootPool_, std::move(writerOptions));
+    for (auto& batch : batches) {
+      writer.write(batch);
+    }
+    writer.close();
+  }
+
+  // Apply a BytesValues filter that matches entries from multiple chunks.
+  // BATCH0_VAL_2 is in chunk 0, BATCH3_VAL_1 is in chunk 3, BATCH7_VAL_4 is
+  // in chunk 7 — the filter cache must be correctly extended at each boundary.
+  std::vector<std::string> accepted = {
+      "BATCH0_VAL_2", "BATCH3_VAL_1", "BATCH7_VAL_4"};
+  std::set<std::string> acceptedSet(accepted.begin(), accepted.end());
+
+  auto input = std::make_unique<velox::dwio::common::BufferedInput>(
+      std::make_shared<velox::InMemoryReadFile>(sinkData_),
+      *leafPool_,
+      velox::dwio::common::MetricsLog::voidLog());
+
+  velox::dwio::common::ReaderOptions readerOpts{leafPool_.get()};
+  readerOpts.setMetadataIoStats(metadataIoStats_);
+  auto reader = makeReader(readerOpts, std::move(input));
+  auto scanSpec = std::make_shared<velox::common::ScanSpec>("root");
+  scanSpec->addAllChildFields(*type);
+  scanSpec->childByName("string_val")
+      ->setFilter(
+          std::make_unique<velox::common::BytesValues>(accepted, false));
+  velox::dwio::common::RowReaderOptions rowReaderOptions;
+  rowReaderOptions.setScanSpec(scanSpec);
+  rowReaderOptions.setStringDecoderZeroCopy(param().stringDecoderZeroCopy);
+  auto rowReader = reader->createRowReader(rowReaderOptions);
+
+  VectorPtr result = velox::BaseVector::create(type, 0, leafPool_.get());
+  size_t totalRows = 0;
+  while (rowReader->next(1000, result)) {
+    auto* rowResult = result->as<RowVector>();
+    ASSERT_NE(rowResult, nullptr);
+    totalRows += rowResult->size();
+
+    velox::DecodedVector decodedString(*rowResult->childAt(0)->loadedVector());
+    for (size_t i = 0; i < rowResult->size(); ++i) {
+      auto str = decodedString.valueAt<velox::StringView>(i).str();
+      ASSERT_TRUE(acceptedSet.count(str))
+          << "Unexpected value passed filter: " << str;
+    }
+  }
+
+  // Each accepted value appears in exactly one batch with kRowsPerBatch/5
+  // repetitions (200/5 = 40 rows each).
+  EXPECT_EQ(totalRows, accepted.size() * (kRowsPerBatch / 5));
+}
+
+// Exercises the reactive fallback path (dictionary → flat mid-batch) with an
+// active filter on the string column. The test creates alternating dictionary
+// and trivial chunks. When the reader encounters a trivial chunk mid-read, it
+// must:
+// 1. Correctly expand already-filtered dictionary indices to flat StringViews
+//    via expandDictionaryToFlat().
+// 2. Continue reading remaining rows as flat strings with the filter still
+//    applied.
+// 3. Produce correct filtered output combining both phases.
+TEST_P(E2EFilterTest, crossChunkEncodingChangeWithFilter) {
+  auto type = ROW({"string_val", "long_val"}, {VARCHAR(), BIGINT()});
+  rowType_ = asRowType(type);
+
+  const size_t kRowsPerBatch = 200;
+  const int kNumBatches = 8;
+  std::vector<RowVectorPtr> batches;
+
+  // Accumulate all expected string values for verification.
+  std::vector<std::string> allStringVals;
+
+  for (int batchIdx = 0; batchIdx < kNumBatches; ++batchIdx) {
+    std::vector<std::string> stringVals;
+    std::vector<int64_t> longVals;
+    stringVals.reserve(kRowsPerBatch);
+    longVals.reserve(kRowsPerBatch);
+
+    if (batchIdx % 2 == 0) {
+      // Even batches: repetitive → dictionary encoding.
+      for (size_t i = 0; i < kRowsPerBatch; ++i) {
+        stringVals.push_back(fmt::format("DICT_VAL_{}", i % 5));
+        longVals.push_back(batchIdx * kRowsPerBatch + i);
+      }
+    } else {
+      // Odd batches: unique → trivial encoding.
+      for (size_t i = 0; i < kRowsPerBatch; ++i) {
+        stringVals.push_back(
+            fmt::format("UNIQUE_VAL_BATCH{}_ROW{}_EXTRA_PADDING", batchIdx, i));
+        longVals.push_back(batchIdx * kRowsPerBatch + i);
+      }
+    }
+
+    allStringVals.insert(
+        allStringVals.end(), stringVals.begin(), stringVals.end());
+
+    auto stringVector =
+        velox::test::VectorMaker(leafPool_.get())
+            .flatVector<velox::StringView>(kRowsPerBatch, [&](auto row) {
+              return velox::StringView(stringVals[row]);
+            });
+    auto longVector = velox::test::VectorMaker(leafPool_.get())
+                          .flatVector<int64_t>(kRowsPerBatch, [&](auto row) {
+                            return longVals[row];
+                          });
+
+    batches.push_back(
+        std::make_shared<RowVector>(
+            leafPool_.get(),
+            type,
+            nullptr,
+            kRowsPerBatch,
+            std::vector<VectorPtr>{stringVector, longVector}));
+  }
+
+  // Write with per-batch chunking, single stripe.
+  {
+    auto writeFile = std::make_unique<InMemoryWriteFile>(&sinkData_);
+    VeloxWriterOptions writerOptions;
+    writerOptions.enableChunking = true;
+    writerOptions.flushPolicyFactory = [] {
+      return std::make_unique<LambdaFlushPolicy>(
+          /*flushLambda=*/[](const StripeProgress&) { return false; },
+          /*chunkLambda=*/[](const StripeProgress&) { return true; });
+    };
+    VeloxWriter writer(
+        type, std::move(writeFile), *rootPool_, std::move(writerOptions));
+    for (auto& batch : batches) {
+      writer.write(batch);
+    }
+    writer.close();
+  }
+
+  // Filter: accept "DICT_VAL_0" (from dictionary chunks) and anything
+  // starting with "UNIQUE_VAL_BATCH1" (from trivial chunk 1). Use BytesRange
+  // to catch the unique values: ["UNIQUE_VAL_BATCH1", "UNIQUE_VAL_BATCH1~").
+  // We test with BytesValues for the dictionary value and verify correctness
+  // across the encoding transition.
+  std::vector<std::string> accepted = {"DICT_VAL_0"};
+  // Also include one unique value to verify the flat path works with filter.
+  accepted.push_back("UNIQUE_VAL_BATCH1_ROW0_EXTRA_PADDING");
+  std::set<std::string> acceptedSet(accepted.begin(), accepted.end());
+
+  // Compute expected count.
+  size_t expectedRows = 0;
+  for (const auto& val : allStringVals) {
+    if (acceptedSet.count(val)) {
+      ++expectedRows;
+    }
+  }
+
+  auto input = std::make_unique<velox::dwio::common::BufferedInput>(
+      std::make_shared<velox::InMemoryReadFile>(sinkData_),
+      *leafPool_,
+      velox::dwio::common::MetricsLog::voidLog());
+
+  velox::dwio::common::ReaderOptions readerOpts{leafPool_.get()};
+  readerOpts.setMetadataIoStats(metadataIoStats_);
+  auto reader = makeReader(readerOpts, std::move(input));
+  auto scanSpec = std::make_shared<velox::common::ScanSpec>("root");
+  scanSpec->addAllChildFields(*type);
+  scanSpec->childByName("string_val")
+      ->setFilter(
+          std::make_unique<velox::common::BytesValues>(accepted, false));
+  velox::dwio::common::RowReaderOptions rowReaderOptions;
+  rowReaderOptions.setScanSpec(scanSpec);
+  rowReaderOptions.setStringDecoderZeroCopy(param().stringDecoderZeroCopy);
+  auto rowReader = reader->createRowReader(rowReaderOptions);
+
+  VectorPtr result = velox::BaseVector::create(type, 0, leafPool_.get());
+  size_t totalRows = 0;
+  while (rowReader->next(1000, result)) {
+    auto* rowResult = result->as<RowVector>();
+    ASSERT_NE(rowResult, nullptr);
+    totalRows += rowResult->size();
+
+    velox::DecodedVector decodedString(*rowResult->childAt(0)->loadedVector());
+    for (size_t i = 0; i < rowResult->size(); ++i) {
+      auto str = decodedString.valueAt<velox::StringView>(i).str();
+      ASSERT_TRUE(acceptedSet.count(str))
+          << "Unexpected value passed filter: " << str;
+    }
+  }
+
+  EXPECT_EQ(totalRows, expectedRows);
+}
+
+// Exercises the IsNull filter guard: when a null-accepting filter (e.g. IsNull)
+// is combined with NullableEncoding wrapping Dictionary, the reader must bypass
+// the dictionary path. NullableEncoding::materializeNullsForVisitor writes
+// encoding-level nulls to the bitmap but doesn't call processNull() for
+// individual null rows, so null-accepting filters would produce incorrect
+// results if the dictionary path were used.
+TEST_P(E2EFilterTest, isNullFilterWithNullableDictionary) {
+  auto type = ROW({"string_val", "long_val"}, {VARCHAR(), BIGINT()});
+  rowType_ = asRowType(type);
+
+  const size_t kRowCount = 1000;
+  std::vector<std::string> stringStorage;
+  std::vector<std::optional<velox::StringView>> stringVals;
+  std::vector<int64_t> longVals;
+  stringStorage.reserve(kRowCount);
+  stringVals.reserve(kRowCount);
+  longVals.reserve(kRowCount);
+
+  size_t expectedNullCount = 0;
+  for (size_t i = 0; i < kRowCount; ++i) {
+    longVals.push_back(i);
+    if (i % 7 == 0) {
+      // ~14% nulls.
+      stringVals.push_back(std::nullopt);
+      stringStorage.push_back("");
+      ++expectedNullCount;
+    } else {
+      stringStorage.push_back(fmt::format("VAL_{}", i % 10));
+      stringVals.push_back(velox::StringView(stringStorage.back()));
+    }
+  }
+
+  auto stringVector = velox::test::VectorMaker(leafPool_.get())
+                          .flatVectorNullable<velox::StringView>(stringVals);
+  auto longVector = velox::test::VectorMaker(leafPool_.get())
+                        .flatVector<int64_t>(
+                            kRowCount, [&](auto row) { return longVals[row]; });
+
+  auto batch = std::make_shared<RowVector>(
+      leafPool_.get(),
+      type,
+      nullptr,
+      kRowCount,
+      std::vector<VectorPtr>{stringVector, longVector});
+
+  // Write with forced dictionary encoding. With nulls, the writer will produce
+  // Nullable → Dictionary.
+  {
+    auto writeFile = std::make_unique<InMemoryWriteFile>(&sinkData_);
+    VeloxWriterOptions writerOptions;
+    writerOptions.enableChunking = true;
+    writerOptions.encodingLayoutTree.emplace(
+        buildForcedDictionaryEncodingLayoutTree());
+    VeloxWriter writer(
+        type, std::move(writeFile), *rootPool_, std::move(writerOptions));
+    writer.write(batch);
+    writer.close();
+  }
+
+  auto input = std::make_unique<velox::dwio::common::BufferedInput>(
+      std::make_shared<velox::InMemoryReadFile>(sinkData_),
+      *leafPool_,
+      velox::dwio::common::MetricsLog::voidLog());
+
+  velox::dwio::common::ReaderOptions readerOpts{leafPool_.get()};
+  readerOpts.setMetadataIoStats(metadataIoStats_);
+  auto reader = makeReader(readerOpts, std::move(input));
+  auto scanSpec = std::make_shared<velox::common::ScanSpec>("root");
+  scanSpec->addAllChildFields(*type);
+  scanSpec->childByName("string_val")
+      ->setFilter(std::make_unique<velox::common::IsNull>());
+  velox::dwio::common::RowReaderOptions rowReaderOptions;
+  rowReaderOptions.setScanSpec(scanSpec);
+  rowReaderOptions.setStringDecoderZeroCopy(param().stringDecoderZeroCopy);
+  auto rowReader = reader->createRowReader(rowReaderOptions);
+
+  VectorPtr result = velox::BaseVector::create(type, 0, leafPool_.get());
+  size_t totalRows = 0;
+  while (rowReader->next(kRowCount, result)) {
+    auto* rowResult = result->as<RowVector>();
+    ASSERT_NE(rowResult, nullptr);
+    totalRows += rowResult->size();
+
+    // Every returned row should have a null string value.
+    auto* stringChild = rowResult->childAt(0).get();
+    for (size_t i = 0; i < rowResult->size(); ++i) {
+      ASSERT_TRUE(stringChild->isNullAt(i))
+          << "Expected null at result row " << i;
+    }
+  }
+
+  EXPECT_EQ(totalRows, expectedNullCount);
+}
 
 } // namespace facebook::nimble

--- a/dwio/nimble/velox/selective/tests/StringColumnReaderTest.cpp
+++ b/dwio/nimble/velox/selective/tests/StringColumnReaderTest.cpp
@@ -344,6 +344,192 @@ TEST_P(StringColumnReaderTest, stringBytesRangeFilter) {
   });
 }
 
+// Filter on string column with a sibling integer column. Both columns are
+// projected. Verifies that the dict path correctly produces outputRows_ for
+// the struct reader and that the sibling column's values are correctly
+// filtered.
+TEST_P(StringColumnReaderTest, stringFilterWithSiblingColumn) {
+  const bool stringDecoderZeroCopy = GetParam();
+  const int numRows = 100;
+  auto filterCol = makeFlatVector<std::string>(
+      numRows, [](auto i) { return "val_" + std::to_string(i % 10); });
+  auto dataCol =
+      makeFlatVector<int64_t>(numRows, [](auto i) { return i * 100; });
+  auto input = makeRowVector({filterCol, dataCol});
+
+  auto scanSpec = std::make_shared<common::ScanSpec>("root");
+  scanSpec->addAllChildFields(*input->type());
+  scanSpec->childByName("c0")->setFilter(
+      std::make_unique<common::BytesValues>(
+          std::vector<std::string>{"val_3", "val_7"}, false));
+  auto readers = makeReaders(input, scanSpec, stringDecoderZeroCopy);
+
+  auto resultType = asRowType(input->type());
+  auto result = BaseVector::create(resultType, 0, pool());
+  int numScanned = 0;
+  int expectedRow = 0;
+  while (numScanned < numRows) {
+    numScanned += readers.rowReader->next(23, result);
+    auto* rowResult = result->as<RowVector>();
+    for (int j = 0; j < result->size(); ++j) {
+      while (expectedRow < numRows &&
+             !(expectedRow % 10 == 3 || expectedRow % 10 == 7)) {
+        ++expectedRow;
+      }
+      ASSERT_LT(expectedRow, numRows);
+      // c1 (data column) should match the corresponding input row.
+      ASSERT_TRUE(
+          rowResult->childAt(1)->equalValueAt(dataCol.get(), j, expectedRow))
+          << "c1 mismatch at filtered position " << j << " (input row "
+          << expectedRow << ")";
+      ++expectedRow;
+    }
+  }
+}
+
+// Filter that passes all rows — verifies no-op filtering doesn't corrupt.
+TEST_P(StringColumnReaderTest, stringFilterPassesAll) {
+  const bool stringDecoderZeroCopy = GetParam();
+  auto c0 = makeFlatVector<std::string>(
+      100, [](auto i) { return "val_" + std::to_string(i % 5); });
+  auto input = makeRowVector({c0});
+  auto scanSpec = std::make_shared<common::ScanSpec>("root");
+  scanSpec->addAllChildFields(*input->type());
+  scanSpec->childByName("c0")->setFilter(
+      std::make_unique<common::BytesValues>(
+          std::vector<std::string>{"val_0", "val_1", "val_2", "val_3", "val_4"},
+          false));
+  auto readers = makeReaders(input, scanSpec, stringDecoderZeroCopy);
+  validateWithFilter(*input, *readers.rowReader, 23, [](auto) { return true; });
+}
+
+// Filter that passes no rows — verifies empty output is handled correctly.
+TEST_P(StringColumnReaderTest, stringFilterPassesNone) {
+  const bool stringDecoderZeroCopy = GetParam();
+  auto c0 = makeFlatVector<std::string>(
+      100, [](auto i) { return "val_" + std::to_string(i % 5); });
+  auto input = makeRowVector({c0});
+  auto scanSpec = std::make_shared<common::ScanSpec>("root");
+  scanSpec->addAllChildFields(*input->type());
+  scanSpec->childByName("c0")->setFilter(
+      std::make_unique<common::BytesValues>(
+          std::vector<std::string>{"nonexistent"}, false));
+  auto readers = makeReaders(input, scanSpec, stringDecoderZeroCopy);
+  auto result = BaseVector::create(asRowType(input->type()), 0, pool());
+  int numScanned = 0;
+  while (numScanned < input->size()) {
+    numScanned += readers.rowReader->next(23, result);
+    ASSERT_EQ(result->size(), 0) << "Expected no rows to pass filter";
+  }
+}
+
+// Filter with nulls — nulls should not pass BytesValues filter.
+TEST_P(StringColumnReaderTest, stringFilterWithNulls) {
+  const bool stringDecoderZeroCopy = GetParam();
+  std::vector<std::optional<std::string>> data(100);
+  for (int i = 0; i < 100; ++i) {
+    if (i % 5 == 0) {
+      data[i] = std::nullopt;
+    } else {
+      data[i] = "val_" + std::to_string(i % 10);
+    }
+  }
+  auto c0 = makeNullableFlatVector<std::string>(data);
+  auto input = makeRowVector({c0});
+  auto scanSpec = std::make_shared<common::ScanSpec>("root");
+  scanSpec->addAllChildFields(*input->type());
+  scanSpec->childByName("c0")->setFilter(
+      std::make_unique<common::BytesValues>(
+          std::vector<std::string>{"val_3", "val_7"}, false));
+  auto readers = makeReaders(input, scanSpec, stringDecoderZeroCopy);
+  validateWithFilter(*input, *readers.rowReader, 23, [](auto i) {
+    if (i % 5 == 0) {
+      return false;
+    }
+    return i % 10 == 3 || i % 10 == 7;
+  });
+}
+
+// Fuzz test: filter on dict-encoded string column with random data shapes,
+// null rates, filter selectivities, and batch sizes.
+TEST_P(StringColumnReaderTest, fuzzFilterDictionary) {
+  const bool stringDecoderZeroCopy = GetParam();
+  if (!stringDecoderZeroCopy) {
+    GTEST_SKIP() << "Dictionary filter path requires stringDecoderZeroCopy";
+  }
+
+  for (int run = 0; run < 20; ++run) {
+    auto seed = folly::Random::rand32();
+    std::mt19937 rng(seed);
+    const int numRows = 100 + rng() % 900;
+    const int batchSize = 10 + rng() % numRows;
+    const int cardinality = 3 + rng() % 10;
+    const bool hasNulls = rng() % 3 == 0;
+    const int numAccepted = 1 + rng() % cardinality;
+
+    SCOPED_TRACE(
+        fmt::format(
+            "run={} seed={} numRows={} batchSize={} cardinality={} hasNulls={} numAccepted={}",
+            run,
+            seed,
+            numRows,
+            batchSize,
+            cardinality,
+            hasNulls,
+            numAccepted));
+
+    // Build accepted set.
+    std::vector<std::string> accepted;
+    for (int i = 0; i < numAccepted; ++i) {
+      accepted.push_back(fmt::format("val_{}", i));
+    }
+    std::set<std::string> acceptedSet(accepted.begin(), accepted.end());
+
+    // Build data.
+    std::vector<std::optional<std::string>> data(numRows);
+    for (int i = 0; i < numRows; ++i) {
+      if (hasNulls && rng() % 5 == 0) {
+        data[i] = std::nullopt;
+      } else {
+        data[i] = fmt::format("val_{}", rng() % cardinality);
+      }
+    }
+    auto c0 = makeNullableFlatVector<std::string>(data);
+    auto input = makeRowVector({c0});
+    auto scanSpec = std::make_shared<common::ScanSpec>("root");
+    scanSpec->addAllChildFields(*input->type());
+    scanSpec->childByName("c0")->setFilter(
+        std::make_unique<common::BytesValues>(accepted, false));
+    auto readers = makeReaders(input, scanSpec, stringDecoderZeroCopy);
+
+    // Validate: read all batches and compare against reference filter.
+    auto result = BaseVector::create(asRowType(input->type()), 0, pool());
+    int numScanned = 0;
+    int inputRow = 0;
+    while (numScanned < numRows) {
+      numScanned += readers.rowReader->next(batchSize, result);
+      for (int j = 0; j < result->size(); ++j) {
+        while (inputRow < numRows) {
+          if (c0->isNullAt(inputRow)) {
+            ++inputRow;
+            continue;
+          }
+          auto sv = c0->valueAt(inputRow).str();
+          if (acceptedSet.count(sv)) {
+            break;
+          }
+          ++inputRow;
+        }
+        ASSERT_LT(inputRow, numRows)
+            << "Ran out of input rows at result position " << j;
+        ASSERT_TRUE(result->equalValueAt(input.get(), j, inputRow))
+            << "Mismatch at input row " << inputRow;
+        ++inputRow;
+      }
+    }
+  }
+}
+
 // Small batch sizes to exercise skip positioning.
 TEST_P(StringColumnReaderTest, stringSkipAndRead) {
   const bool stringDecoderZeroCopy = GetParam();
@@ -1328,6 +1514,105 @@ TEST_P(StringColumnReaderTest, mainlyConstantDictionaryAcrossStripes) {
       pool());
 }
 
+// Regression for an out-of-bounds write in MainlyConstant::materializeIndices
+// when a read range has zero dense non-null rows (an all-null batch). nwords(0)
+// is 0, so the isCommon[numWords - 1] tail write underflowed to isCommon[-1].
+// The column is forced to MainlyConstant; the first half is non-null (mainly a
+// common value) and the second half is all null, so the second read batch has
+// no non-null rows and calls materializeIndices(0).
+TEST_P(StringColumnReaderTest, mainlyConstantAllNullReadRange) {
+  const bool stringDecoderZeroCopy = GetParam();
+  if (!stringDecoderZeroCopy) {
+    GTEST_SKIP() << "Dictionary path requires stringDecoderZeroCopy";
+  }
+
+  constexpr int kRows = 200;
+  constexpr int kBatchSize = 100;
+  const std::string commonValue(20, 'c');
+  const std::string otherValue(20, 'o');
+
+  // Rows [0, kBatchSize): non-null, mainly the common value (a few others) so
+  // MainlyConstant applies. Rows [kBatchSize, kRows): all null, making the
+  // second read batch a zero-non-null (all-null) range.
+  auto input = makeRowVector({makeFlatVector<std::string>(
+      kRows,
+      [&](auto i) { return i % 10 == 0 ? otherValue : commonValue; },
+      [&](auto i) { return i >= kBatchSize; })});
+
+  // Force MainlyConstant for the string column; the writer wraps it in Nullable
+  // for the null rows.
+  EncodingLayout dictLayout{
+      EncodingType::Dictionary,
+      {},
+      CompressionType::Uncompressed,
+      {std::nullopt, std::nullopt}};
+  EncodingLayout mainlyConstLayout{
+      EncodingType::MainlyConstant,
+      {},
+      CompressionType::Uncompressed,
+      {std::nullopt, std::move(dictLayout)}};
+  VeloxWriterOptions writerOptions;
+  writerOptions.encodingLayoutTree.emplace(
+      Kind::Row,
+      std::
+          unordered_map<EncodingLayoutTree::StreamIdentifier, EncodingLayout>{},
+      "",
+      std::vector<EncodingLayoutTree>{EncodingLayoutTree{
+          Kind::Scalar, {{0, std::move(mainlyConstLayout)}}, "c0"}});
+  auto file = test::createNimbleFile(*rootPool(), input, writerOptions);
+
+  auto scanSpec = std::make_shared<common::ScanSpec>("root");
+  scanSpec->addAllChildFields(*input->type());
+  auto readers = makeReaders(input, file, scanSpec, stringDecoderZeroCopy);
+  validate(*input, *readers.rowReader, kBatchSize);
+}
+
+// Repro for Bug #3: an IsNull filter on a dictionary-encoded string column that
+// is ALSO projected (keepValues=true). Null rows pass the IsNull filter and
+// must be emitted as null values. The dictionary filter+extract path must
+// produce one output row per null row, not drop them.
+TEST_P(StringColumnReaderTest, dictionaryIsNullFilterProjected) {
+  const bool stringDecoderZeroCopy = GetParam();
+  if (!stringDecoderZeroCopy) {
+    GTEST_SKIP() << "Dictionary path requires stringDecoderZeroCopy";
+  }
+
+  const int numRows = 100;
+  // Small alphabet so dictionary encoding applies; null every 3rd row.
+  auto input = makeRowVector({
+      makeFlatVector<std::string>(
+          numRows,
+          [](auto i) { return "v_" + std::to_string(i % 5); },
+          nullEvery(3)),
+  });
+
+  // Force plain Dictionary encoding for the string column; the writer wraps it
+  // in Nullable for the null rows (Nullable -> Dictionary).
+  EncodingLayout dictLayout{
+      EncodingType::Dictionary,
+      {},
+      CompressionType::Uncompressed,
+      {std::nullopt, std::nullopt}};
+  VeloxWriterOptions writerOptions;
+  writerOptions.encodingLayoutTree.emplace(
+      Kind::Row,
+      std::
+          unordered_map<EncodingLayoutTree::StreamIdentifier, EncodingLayout>{},
+      "",
+      std::vector<EncodingLayoutTree>{EncodingLayoutTree{
+          Kind::Scalar, {{0, std::move(dictLayout)}}, "c0"}});
+  auto file = test::createNimbleFile(*rootPool(), input, writerOptions);
+
+  auto scanSpec = std::make_shared<common::ScanSpec>("root");
+  scanSpec->addAllChildFields(*input->type());
+  scanSpec->childByName("c0")->setFilter(std::make_unique<common::IsNull>());
+
+  auto readers = makeReaders(input, file, scanSpec, stringDecoderZeroCopy);
+  // IsNull passes exactly the null rows (every 3rd).
+  validateWithFilter(
+      *input, *readers.rowReader, 23, [](auto i) { return i % 3 == 0; });
+}
+
 // Mainly-constant string column with chunking where read batches align with
 // chunk boundaries. This exercises the non-fallback dictionary fast path for
 // chunked layouts: each batch fits within a single chunk, so the dictionary
@@ -2279,8 +2564,13 @@ TEST_P(StringColumnReaderTest, fuzzMultiChunkDictionary) {
     GTEST_SKIP() << "Dictionary path requires stringDecoderZeroCopy";
   }
 
+  // Run 0 replays a previously-crashing seed as a fixed regression for the
+  // MainlyConstant::materializeIndices rowCount==0 out-of-bounds write (an
+  // all-null read range across a chunk boundary). The remaining runs are
+  // random; use --stress-runs to exercise more seeds.
+  constexpr uint32_t kRegressionSeed = 2770505665u;
   for (int run = 0; run < 20; ++run) {
-    auto seed = folly::Random::rand32();
+    auto seed = run == 0 ? kRegressionSeed : folly::Random::rand32();
     std::mt19937 rng(seed);
     const int numChunks = 2 + rng() % 6;
     const int rowsPerChunk = 100 + rng() % 900;


### PR DESCRIPTION
Summary:

X-link: https://github.com/facebookincubator/velox/pull/17810

Enable the dictionary vector path for string columns with filter pushdown. Previously, `readWithDictionary` rejected all queries with `scanSpec_->hasFilter()`, forcing filtered string reads through the flat `FlatVector<StringView>` path.

The filter is applied post-hoc after bulk index reading: `filterDictionaryIndices` iterates the materialized dictionary indices, evaluates the filter on `alphabet[index]` using a `filterCache` (avoiding redundant evaluations for repeated dictionary entries), and compacts passing indices into `rawValues_` while populating `outputRows_`.

This approach is necessary because Nimble's `readIndicesWithVisitor` uses bulk `materializeIndices` which bypasses the visitor's per-row `process()` — so the framework's `StringDictionaryColumnVisitor` filterCache logic is never reached. The post-materialization filter works with both the no-filter and filter paths without changing the index reading flow.

Changes:
- Remove `hasFilter()` gate from `readWithDictionary` (keep `valueHook()` gate — see TODO)
- Add `filterDictionaryIndices` with scalar filterCache evaluation loop
- Add `ensureFilterCache` for lazy filterCache initialization/extension
- Add `filterCache` to `DictionaryState` (cleared with alphabet on chunk boundary changes)
- Relax `!kHasFilter` assertions in `DictionaryEncoding::readIndicesWithVisitor` and `MainlyConstantEncoding::readIndicesWithVisitor` to `!kHasHook`
- Filter is saved/cloned and temporarily cleared from scanSpec during index reading so the visitor sees `AlwaysTrue`, then restored before `filterDictionaryIndices`

Benchmark (ke_benchmark l_returnflag, `BytesValues('R')`, selective reader, batch_size=1024, read_count=500, concurrency=16, column 8 only):

```
buck run @//mode/opt fbcode//dwio/nimble/tools/fb:parallel_reader -- \
  /home/huamengjiang/ke_benchmark_no_dict_vector_repro.nimble \
  --batch_size 1024 --reader_types selective --read_count 500 \
  --concurrency 16 --string_decoder_zero_copy \
  --filter_column l_returnflag --filter_values R --columns 8
```

| Config | P50 wall (ms) |
|--------|---------------|
| Flat (flag OFF) | 130 |
| Dict + scalar filter (flag ON) | 70 (-46%) |

Reviewed By: xiaoxmeng

Differential Revision: D100057063


