### PR TITLE
feat(presto): Add session properties for Nimble chunking configuration

### DIFF
--- a/dwio/nimble/velox/NimbleConfig.h
+++ b/dwio/nimble/velox/NimbleConfig.h
@@ -91,6 +91,23 @@ class Config : public velox::config::ConfigBase {
   static constexpr const char* kNimbleWriteTargetRawStripeSize =
       "nimble_write_target_raw_stripe_size";
 
+  static constexpr const char* kNimbleChunkingEnabled =
+      "nimble_chunking_enabled";
+  static constexpr const char* kNimbleChunkingMemoryHighThreshold =
+      "nimble_chunking_memory_high_threshold";
+  static constexpr const char* kNimbleChunkingMemoryLowThreshold =
+      "nimble_chunking_memory_low_threshold";
+  static constexpr const char* kNimbleChunkingTargetStripeStorageSize =
+      "nimble_chunking_target_stripe_storage_size";
+  static constexpr const char* kNimbleChunkingEstimatedCompressionFactor =
+      "nimble_chunking_estimated_compression_factor";
+  static constexpr const char* kNimbleChunkingMinChunkSize =
+      "nimble_chunking_min_chunk_size";
+  static constexpr const char* kNimbleChunkingMaxChunkSize =
+      "nimble_chunking_max_chunk_size";
+  static constexpr const char* kNimbleChunkingWideSchemaMaxChunkSize =
+      "nimble_chunking_wide_schema_max_chunk_size";
+
   static std::shared_ptr<Config> fromMap(
       const std::map<std::string, std::string>& map) {
     auto config = std::make_shared<Config>();


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebookexternal/presto-facebook/pull/3654

Add session properties to control Nimble chunking behavior without requiring DDL table property changes or direct metastore manipulation.

Session properties added (all optional, null defaults — C++ writer falls back to built-in defaults when not set):
- `nimble_chunking_enabled`
- `nimble_chunking_memory_high_threshold`
- `nimble_chunking_memory_low_threshold`
- `nimble_chunking_target_stripe_storage_size`
- `nimble_chunking_estimated_compression_factor`
- `nimble_chunking_min_chunk_size`
- `nimble_chunking_max_chunk_size`
- `nimble_chunking_wide_schema_max_chunk_size`

Session properties take precedence over table-level serde parameters: a session property overrides the table's serde config for the same key. This applies to the chunking properties above and to the existing `nimble_write_file_buffer_size_bytes` session config, which now also overrides its table-level serde param for consistency.

Wiring:
- Java coordinator: `HiveSessionProperties.java` registers the properties
- C++ worker: `NimbleConfig.h` defines session key constants, `NimbleWriter.cpp::processConfigs()` reads them and overwrites the corresponding `serdeParameters` entries (session takes precedence over table-level)

Reviewed By: xiaoxmeng

Differential Revision: D108126830


