### PR TITLE
fix(nimble): Legacy FixedBitWidth trailer count check rejects bitWidth being 0

### DIFF
--- a/dwio/nimble/serializer/legacy/TrailerReader.cpp
+++ b/dwio/nimble/serializer/legacy/TrailerReader.cpp
@@ -95,8 +95,9 @@ void decodeDeltaTrailer(
 }
 
 // Frozen snapshot of master's `decodeFixedBitWidthTrailer`.
-// Bound: each value occupies at least 1 bit, so `count <= payloadSize * 8`
-// is a generous sanity ceiling against trailer corruption.
+// Bound: total packed bits `count * bitWidth` must fit in `payloadSize * 8`.
+// When `bitWidth == 0` (all stream sizes are 0) the packed array is empty,
+// so any `count` is valid and the check trivially passes (0 <= anything).
 void decodeFixedBitWidthTrailer(
     const char*& payload,
     uint32_t payloadSize,
@@ -106,9 +107,9 @@ void decodeFixedBitWidthTrailer(
       bitWidth, 32, "Legacy FixedBitWidth trailer bitWidth exceeds 32 bits");
   const uint32_t count = varint::readVarint32(&payload);
   NIMBLE_CHECK_LE(
-      static_cast<uint64_t>(count),
+      static_cast<uint64_t>(count) * bitWidth,
       static_cast<uint64_t>(payloadSize) * 8u,
-      "Legacy FixedBitWidth trailer count exceeds payload bit-capacity");
+      "Legacy FixedBitWidth trailer count*bitWidth exceeds payload bit-capacity");
   sizes.assign(count, 0);
   if (bitWidth > 0 && count > 0) {
     const uint32_t packedBytes =

--- a/dwio/nimble/serializer/legacy/tests/TrailerReaderTest.cpp
+++ b/dwio/nimble/serializer/legacy/tests/TrailerReaderTest.cpp
@@ -331,5 +331,32 @@ TEST(LegacyTrailerReaderTest, readLegacyTrailerStreamMetadataFixedBitWidth) {
   EXPECT_EQ(streamSizes, (std::vector<uint32_t>{1, 63, 7, 33, 5}));
 }
 
+TEST(
+    LegacyTrailerReaderTest,
+    readLegacyTrailerStreamMetadataFixedBitWidthAllZeros) {
+  // Regression: when every stream size is 0, master writes FixedBitWidth
+  // with bitWidth=0 and no packed bytes (just the bitWidth byte and the
+  // varint count). The decoder's sanity bound on count must respect
+  // bitWidth — `count <= payloadSize * 8` is wrong because it assumes
+  // each value takes >= 1 bit. The correct bound is
+  // `count * bitWidth <= payloadSize * 8`, which trivially passes when
+  // bitWidth == 0.
+  const uint32_t count = 210;
+  std::string buffer;
+  buffer.push_back(static_cast<char>(EncodingType::FixedBitWidth));
+  buffer.push_back(static_cast<char>(0)); // bitWidth = 0
+  appendVarint32(buffer, count);
+  // No packed bytes when bitWidth == 0.
+  const uint32_t trailerSize = static_cast<uint32_t>(buffer.size());
+  buffer.append(reinterpret_cast<const char*>(&trailerSize), sizeof(uint32_t));
+
+  const auto* end = buffer.data() + buffer.size();
+  auto [streamIndices, streamSizes] = readLegacyTrailerStreamMetadata(end);
+
+  // All sizes are 0, so the scatter-to-sparse step filters everything out.
+  EXPECT_TRUE(streamIndices.empty());
+  EXPECT_TRUE(streamSizes.empty());
+}
+
 } // namespace
 } // namespace facebook::nimble::serde::legacy


### PR DESCRIPTION
Summary:
The `decodeFixedBitWidthTrailer` sanity check added in D108208928 assumes every value occupies at least 1 bit:

```
NIMBLE_CHECK_LE(count, payloadSize * 8, ...);
```

This is incorrect. `FixedBitWidth` allows `bitWidth == 0` — the degenerate case where every stream size is 0 — and the packed payload is then 0 bytes (only the 1-byte `bitWidth` and the varint `count` are written). For such a blob (e.g. `count=210` streams all size-0 → `payloadSize=3`), the check fails: `210 > 3*8 = 24`, throwing `Legacy FixedBitWidth trailer count exceeds payload bit-capacity`. This regresses the read of legitimate old-format blobs produced by pre-D108208928 Nimble writers.

Multiply by `bitWidth`. The check now bounds total packed bits (`count * bitWidth`) against payload bits (`payloadSize * 8`), which is the actual wire invariant. When `bitWidth == 0` the check becomes `0 <= anything`, trivially passing.

Reported by an internal user running the hybrid-nimble verifier with the client on master (has D108208928) and the zippy server on old nimble (writes the bitWidth=0 shape).

Differential Revision: D108448054


