### PR TITLE
fix(tablet): Serialize uncompressed_size in ChunkIndex and ClusterIndex FlatBuffers (#867)

### DIFF
--- a/dwio/nimble/index/ChunkIndex.cpp
+++ b/dwio/nimble/index/ChunkIndex.cpp
@@ -38,7 +38,8 @@ std::unique_ptr<ChunkIndex> ChunkIndex::create(Section indexSection) {
     groupSections.emplace_back(
         ms->offset(),
         ms->size(),
-        static_cast<CompressionType>(ms->compression_type()));
+        static_cast<CompressionType>(ms->compression_type()),
+        ms->uncompressed_size());
   }
 
   return std::unique_ptr<ChunkIndex>(

--- a/dwio/nimble/index/ClusterIndex.cpp
+++ b/dwio/nimble/index/ClusterIndex.cpp
@@ -445,7 +445,8 @@ MetadataSection ClusterIndex::partitionSection(uint32_t partitionId) const {
   return MetadataSection{
       metadata->offset(),
       metadata->size(),
-      static_cast<CompressionType>(metadata->compression_type())};
+      static_cast<CompressionType>(metadata->compression_type()),
+      metadata->uncompressed_size()};
 }
 
 ClusterIndex::IndexPartition::IndexPartition(

--- a/dwio/nimble/index/ClusterIndexWriter.cpp
+++ b/dwio/nimble/index/ClusterIndexWriter.cpp
@@ -346,7 +346,9 @@ void ClusterIndexWriter::close(
                 indexRoot_->indexPartitions[i].offset(),
                 indexRoot_->indexPartitions[i].size(),
                 static_cast<serialization::CompressionType>(
-                    indexRoot_->indexPartitions[i].compressionType()));
+                    indexRoot_->indexPartitions[i].compressionType()),
+                indexRoot_->indexPartitions[i].uncompressedSize().value_or(
+                    indexRoot_->indexPartitions[i].size()));
           });
 
   auto partitionKeysVector =

--- a/dwio/nimble/index/tests/ClusterIndexTestBase.cpp
+++ b/dwio/nimble/index/tests/ClusterIndexTestBase.cpp
@@ -148,7 +148,11 @@ ClusterIndexTestBase::IndexBuffers ClusterIndexTestBase::createTestClusterIndex(
         reinterpret_cast<const char*>(groupBuilder.GetBufferPointer()), size);
 
     auto metadataSection = serialization::CreateMetadataSection(
-        builder, offset, size, serialization::CompressionType_Uncompressed);
+        builder,
+        offset,
+        size,
+        serialization::CompressionType_Uncompressed,
+        size);
     clusterIndexGroupMetadataOffsets.push_back(metadataSection);
 
     const uint32_t numStreams = streamChunkCounts.size() / groupStripeCount;
@@ -319,7 +323,11 @@ ClusterIndexTestBase::createChunkOnlyTestClusterIndex(
         reinterpret_cast<const char*>(groupBuilder.GetBufferPointer()), size);
 
     auto metadataSection = serialization::CreateMetadataSection(
-        builder, offset, size, serialization::CompressionType_Uncompressed);
+        builder,
+        offset,
+        size,
+        serialization::CompressionType_Uncompressed,
+        size);
     clusterIndexGroupMetadataOffsets.push_back(metadataSection);
   }
 

--- a/dwio/nimble/index/tests/ClusterIndexTestUtils.cpp
+++ b/dwio/nimble/index/tests/ClusterIndexTestUtils.cpp
@@ -395,7 +395,9 @@ void TestClusterIndexMetadataWriter::writeRoot(
                 indexPartitions_[i].offset(),
                 indexPartitions_[i].size(),
                 static_cast<serialization::CompressionType>(
-                    indexPartitions_[i].compressionType()));
+                    indexPartitions_[i].compressionType()),
+                indexPartitions_[i].uncompressedSize().value_or(
+                    indexPartitions_[i].size()));
           });
 
   // Build partition keys: [firstKey, lastKeyPartition0, lastKeyPartition1, ...]

--- a/dwio/nimble/index/tests/ClusterIndexWriterTest.cpp
+++ b/dwio/nimble/index/tests/ClusterIndexWriterTest.cpp
@@ -1095,7 +1095,11 @@ TEST_P(ClusterIndexWriterChunkTest, maxRowsPerKeyChunk) {
   auto createMetadataFn =
       [&partitionMetadata](std::string_view metadata) -> MetadataSection {
     partitionMetadata.emplace_back(metadata);
-    return MetadataSection(0, metadata.size(), CompressionType::Uncompressed);
+    return MetadataSection(
+        0,
+        metadata.size(),
+        CompressionType::Uncompressed,
+        static_cast<uint32_t>(metadata.size()));
   };
   writer->flush(writeDataFn, createMetadataFn);
 

--- a/dwio/nimble/tablet/ChunkIndexWriter.cpp
+++ b/dwio/nimble/tablet/ChunkIndexWriter.cpp
@@ -181,7 +181,9 @@ void ChunkIndexWriter::writeRoot(
                 chunkIndexSections_[i].offset(),
                 chunkIndexSections_[i].size(),
                 static_cast<serialization::CompressionType>(
-                    chunkIndexSections_[i].compressionType()));
+                    chunkIndexSections_[i].compressionType()),
+                chunkIndexSections_[i].uncompressedSize().value_or(
+                    chunkIndexSections_[i].size()));
           });
 
   builder.Finish(serialization::CreateChunkIndex(builder, stripeIndexesVector));

--- a/dwio/nimble/tablet/tests/ChunkIndexWriterTest.cpp
+++ b/dwio/nimble/tablet/tests/ChunkIndexWriterTest.cpp
@@ -23,6 +23,7 @@
 #include "dwio/nimble/index/ChunkIndexGroup.h"
 #include "dwio/nimble/index/tests/ClusterIndexTestUtils.h"
 
+#include "dwio/nimble/index/ChunkIndex.h"
 #include "dwio/nimble/tablet/ChunkIndexGenerated.h"
 #include "dwio/nimble/tablet/Constants.h"
 #include "dwio/nimble/tablet/TabletWriter.h"
@@ -552,6 +553,154 @@ TEST_F(ChunkIndexWriterTest, minAvgChunksPerStream) {
       }
     }
   }
+}
+
+TEST_F(ChunkIndexWriterTest, uncompressedSizeRoundtrip) {
+  ChunkIndexWriter writer(*pool_, /*minAvgChunksPerStream=*/0);
+  Buffer buffer{*pool_};
+  TestChunkFileIndex fileIndex;
+
+  uint64_t nextOffset = 1000;
+  auto compressedCallback =
+      [&fileIndex, &nextOffset](std::string_view metadata) -> MetadataSection {
+    fileIndex.groupMetadataSections.emplace_back(metadata);
+    const auto uncompressedSize = static_cast<uint32_t>(metadata.size());
+    const auto compressedSize = uncompressedSize / 2;
+    auto offset = nextOffset;
+    nextOffset += compressedSize;
+    return MetadataSection(
+        offset, compressedSize, CompressionType::Zstd, uncompressedSize);
+  };
+
+  writer.newStripe(2);
+  writer.addStream(0, createChunks(buffer, {{50, 10}, {50, 12}}));
+  writer.addStream(1, createChunks(buffer, {{60, 20}, {40, 12}}));
+  writer.writeGroup(2, 1, compressedCallback);
+
+  writer.newStripe(2);
+  writer.addStream(0, createChunks(buffer, {{80, 20}, {20, 5}}));
+  writer.addStream(1, createChunks(buffer, {{50, 15}, {50, 18}}));
+  writer.writeGroup(2, 1, compressedCallback);
+
+  writer.writeRoot(writeRootCallback(fileIndex));
+
+  ASSERT_EQ(fileIndex.groupMetadataSections.size(), 2);
+  ASSERT_FALSE(fileIndex.rootIndexData.empty());
+
+  auto* root = flatbuffers::GetRoot<serialization::ChunkIndex>(
+      fileIndex.rootIndexData.data());
+  ASSERT_NE(root, nullptr);
+  ASSERT_NE(root->stripe_indexes(), nullptr);
+  ASSERT_EQ(root->stripe_indexes()->size(), 2);
+
+  for (uint32_t i = 0; i < 2; ++i) {
+    auto* entry = root->stripe_indexes()->Get(i);
+    EXPECT_EQ(entry->compression_type(), serialization::CompressionType_Zstd)
+        << "Group " << i;
+    EXPECT_GT(entry->uncompressed_size(), 0) << "Group " << i;
+    EXPECT_GT(entry->uncompressed_size(), entry->size()) << "Group " << i;
+  }
+
+  auto rootBuffer = velox::AlignedBuffer::allocate<char>(
+      fileIndex.rootIndexData.size(), pool_.get());
+  std::memcpy(
+      rootBuffer->asMutable<char>(),
+      fileIndex.rootIndexData.data(),
+      fileIndex.rootIndexData.size());
+  Section rootSection{MetadataBuffer(
+      MetadataBuffer::decompress(
+          std::move(rootBuffer), CompressionType::Uncompressed, pool_.get()))};
+
+  auto chunkIndex = index::ChunkIndex::create(std::move(rootSection));
+  ASSERT_NE(chunkIndex, nullptr);
+  ASSERT_EQ(chunkIndex->numGroups(), 2);
+
+  for (uint32_t i = 0; i < 2; ++i) {
+    const auto& section = chunkIndex->groupMetadata(i);
+    EXPECT_EQ(section.compressionType(), CompressionType::Zstd)
+        << "Group " << i;
+    EXPECT_TRUE(section.uncompressedSize().has_value()) << "Group " << i;
+    EXPECT_GT(section.uncompressedSize().value(), section.size())
+        << "Group " << i;
+  }
+}
+
+// Verifies that index metadata without uncompressed_size is rejected.
+// Index is not in production yet, so all files must have the field set.
+TEST_F(ChunkIndexWriterTest, missingUncompressedSizeRejected) {
+  flatbuffers::FlatBufferBuilder builder(256);
+
+  auto section0 = serialization::CreateMetadataSection(
+      builder,
+      /*offset=*/100,
+      /*size=*/200,
+      serialization::CompressionType_Zstd);
+
+  std::vector<flatbuffers::Offset<serialization::MetadataSection>> sections = {
+      section0};
+  auto stripeIndexes = builder.CreateVector(sections);
+  builder.Finish(serialization::CreateChunkIndex(builder, stripeIndexes));
+
+  auto rootBuffer =
+      velox::AlignedBuffer::allocate<char>(builder.GetSize(), pool_.get());
+  std::memcpy(
+      rootBuffer->asMutable<char>(),
+      builder.GetBufferPointer(),
+      builder.GetSize());
+  Section rootSection{MetadataBuffer(
+      MetadataBuffer::decompress(
+          std::move(rootBuffer), CompressionType::Uncompressed, pool_.get()))};
+
+  NIMBLE_ASSERT_THROW(
+      index::ChunkIndex::create(std::move(rootSection)), "Uncompressed size");
+}
+
+// Verifies that uncompressed sections get uncompressedSize == size in the
+// FlatBuffer, and the reader correctly recovers it.
+TEST_F(ChunkIndexWriterTest, uncompressedSizeForUncompressedSections) {
+  ChunkIndexWriter writer(*pool_, /*minAvgChunksPerStream=*/0);
+  Buffer buffer{*pool_};
+  TestChunkFileIndex fileIndex;
+
+  writer.newStripe(2);
+  writer.addStream(0, createChunks(buffer, {{50, 10}, {50, 12}}));
+  writer.addStream(1, createChunks(buffer, {{60, 20}, {40, 12}}));
+  writer.writeGroup(2, 1, createMetadataSectionCallback(fileIndex));
+
+  writer.writeRoot(writeRootCallback(fileIndex));
+
+  ASSERT_EQ(fileIndex.groupMetadataSections.size(), 1);
+  ASSERT_FALSE(fileIndex.rootIndexData.empty());
+
+  auto* root = flatbuffers::GetRoot<serialization::ChunkIndex>(
+      fileIndex.rootIndexData.data());
+  ASSERT_NE(root, nullptr);
+  ASSERT_NE(root->stripe_indexes(), nullptr);
+  ASSERT_EQ(root->stripe_indexes()->size(), 1);
+
+  auto* entry = root->stripe_indexes()->Get(0);
+  EXPECT_EQ(
+      entry->compression_type(), serialization::CompressionType_Uncompressed);
+  EXPECT_EQ(entry->uncompressed_size(), entry->size());
+
+  auto rootBuffer = velox::AlignedBuffer::allocate<char>(
+      fileIndex.rootIndexData.size(), pool_.get());
+  std::memcpy(
+      rootBuffer->asMutable<char>(),
+      fileIndex.rootIndexData.data(),
+      fileIndex.rootIndexData.size());
+  Section rootSection{MetadataBuffer(
+      MetadataBuffer::decompress(
+          std::move(rootBuffer), CompressionType::Uncompressed, pool_.get()))};
+
+  auto chunkIndex = index::ChunkIndex::create(std::move(rootSection));
+  ASSERT_NE(chunkIndex, nullptr);
+  ASSERT_EQ(chunkIndex->numGroups(), 1);
+
+  const auto& section = chunkIndex->groupMetadata(0);
+  EXPECT_EQ(section.compressionType(), CompressionType::Uncompressed);
+  EXPECT_TRUE(section.uncompressedSize().has_value());
+  EXPECT_EQ(section.uncompressedSize().value(), section.size());
 }
 
 } // namespace facebook::nimble::test

--- a/dwio/nimble/tablet/tests/TabletTest.cpp
+++ b/dwio/nimble/tablet/tests/TabletTest.cpp
@@ -6242,6 +6242,87 @@ TEST_P(TabletTest, cacheMetadataSmallFooterIoBytes) {
   }
 }
 
+// Verifies cache warm path with multiple stripe groups where stripe group
+// metadata is large enough to be Zstd-compressed. The warm reader must find
+// decompressed entries in cache for each stripe group without file IO.
+TEST_P(TabletTest, cacheMetadataCompressedMultipleStripeGroups) {
+  if (GetParam() != BufferedInputMode::kCachedBufferedInput) {
+    GTEST_SKIP() << "Only applies to CachedBufferedInput";
+  }
+
+  std::string file;
+  velox::InMemoryWriteFile writeFile(&file);
+  nimble::Buffer buffer(*pool_);
+
+  // Use a low flush threshold so each stripe gets its own stripe group.
+  auto tabletWriter = nimble::TabletWriter::create(
+      &writeFile,
+      *pool_,
+      {.metadataFlushThreshold = 1, .streamDeduplicationEnabled = false});
+
+  // 500 streams per stripe triggers Zstd compression on stripe group
+  // metadata.
+  constexpr int kNumStripes = 3;
+  constexpr int kNumStreams = 500;
+  for (int i = 0; i < kNumStripes; ++i) {
+    std::vector<nimble::Stream> streams;
+    for (int s = 0; s < kNumStreams; ++s) {
+      const auto size = 50;
+      auto* pos = buffer.reserve(size);
+      std::memset(pos, (i * kNumStreams + s) & 0xFF, size);
+      streams.push_back(
+          {.offset = static_cast<uint32_t>(s),
+           .chunks = {
+               {.rowCount = 100, .content = {std::string_view(pos, size)}}}});
+    }
+    tabletWriter->writeStripe(100, std::move(streams));
+  }
+  tabletWriter->close();
+  writeFile.close();
+
+  auto readFile = std::make_shared<velox::InMemoryReadFile>(file);
+
+  allocator_ = std::make_shared<velox::memory::MallocAllocator>(
+      velox::memory::MemoryAllocator::Options{
+          .capacity = 1UL << 30, .reservationByteLimit = 0});
+  cache_ = velox::cache::AsyncDataCache::create(allocator_.get());
+
+  // Cold path.
+  {
+    auto coldReader = createTabletReader(readFile);
+    EXPECT_EQ(coldReader->stripeCount(), kNumStripes);
+    for (uint32_t i = 0; i < kNumStripes; ++i) {
+      auto stripeId = coldReader->stripeIdentifier(i);
+      EXPECT_NE(stripeId.stripeGroup(), nullptr);
+    }
+  }
+
+  auto coldCacheStats = cache_->refreshStats();
+  EXPECT_GT(coldCacheStats.numEntries, 0);
+
+  dataIoStats_ = std::make_shared<velox::io::IoStatistics>();
+  metadataIoStats_ = std::make_shared<velox::io::IoStatistics>();
+  indexIoStats_ = std::make_shared<velox::io::IoStatistics>();
+  readerOptions_.reset();
+
+  // Warm path: all stripe groups should be served from cache.
+  {
+    auto warmReader = createTabletReader(readFile);
+    EXPECT_EQ(warmReader->stripeCount(), kNumStripes);
+    EXPECT_EQ(warmReader->tabletRowCount(), kNumStripes * 100);
+    EXPECT_GT(metadataIoStats_->ramHit().count(), 0);
+    EXPECT_EQ(metadataIoStats_->rawBytesRead(), 0);
+
+    for (uint32_t i = 0; i < kNumStripes; ++i) {
+      auto stripeId = warmReader->stripeIdentifier(i);
+      EXPECT_NE(stripeId.stripeGroup(), nullptr);
+    }
+  }
+
+  auto warmCacheStats = cache_->refreshStats();
+  EXPECT_EQ(warmCacheStats.numEvict, 0);
+}
+
 INSTANTIATE_TEST_SUITE_P(
     BufferedInputModes,
     TabletTest,
@@ -6489,6 +6570,110 @@ TEST_P(TabletTest, footerReadTrackedInMetadataIoStats) {
     EXPECT_EQ(ioStats->read().count(), 1);
     EXPECT_EQ(ioStats->read().sum(), file.size());
   }
+}
+
+// Verifies that cache warm path works for chunk index group metadata that is
+// Zstd-compressed. This exercises the uncompressed_size fix in ChunkIndex
+// FlatBuffer serialization — without it, resolveUncompressedSize() returns
+// nullopt for chunk index groups, causing orphaned cache entries and
+// unnecessary file IO on warm reads.
+TEST_P(TabletWithIndexTest, cacheWarmPathCompressedChunkIndex) {
+  if (GetParam() != BufferedInputMode::kCachedBufferedInput) {
+    GTEST_SKIP() << "Only applies to CachedBufferedInput";
+  }
+
+  std::string file;
+  velox::InMemoryWriteFile writeFile(&file);
+  nimble::Buffer buffer(*pool_);
+
+  nimble::index::test::TestClusterIndexMetadataWriter indexHelper(
+      *pool_,
+      {"col1"},
+      {SortOrder{.ascending = true}},
+      /*enforceKeyOrder=*/true);
+
+  // 500 streams per stripe -> chunk index group metadata exceeds 64KB,
+  // triggering Zstd compression.
+  constexpr int kNumStripes = 5;
+  constexpr int kNumStreams = 500;
+  auto tabletWriter = nimble::TabletWriter::create(
+      &writeFile,
+      *pool_,
+      {.metadataFlushThreshold = 1024 * 1024 * 1024,
+       .streamDeduplicationEnabled = false,
+       .enableChunkIndex = true,
+       .stripeGroupFlushCallback = indexHelper.createStripeGroupFlushCallback(),
+       .closeCallback = indexHelper.createCloseCallback()});
+
+  std::vector<std::string> keys = {"aaa", "bbb", "ccc", "ddd", "eee"};
+  for (int i = 0; i < kNumStripes; ++i) {
+    std::vector<nimble::Stream> streams;
+    for (int s = 0; s < kNumStreams; ++s) {
+      const auto size = 50;
+      auto* pos = buffer.reserve(size);
+      std::memset(pos, (i * kNumStreams + s) & 0xFF, size);
+      streams.push_back(
+          {.offset = static_cast<uint32_t>(s),
+           .chunks = {
+               {.rowCount = 100, .content = {std::string_view(pos, size)}}}});
+    }
+    indexHelper.addStripe({{.rowCount = 100, .key = keys[i]}});
+    tabletWriter->writeStripe(100, std::move(streams));
+  }
+  tabletWriter->close();
+  writeFile.close();
+
+  auto readFile = std::make_shared<velox::InMemoryReadFile>(file);
+
+  allocator_ = std::make_shared<velox::memory::MallocAllocator>(
+      velox::memory::MemoryAllocator::Options{
+          .capacity = 1UL << 30, .reservationByteLimit = 0});
+  cache_ = velox::cache::AsyncDataCache::create(allocator_.get());
+
+  nimble::TabletReader::Options options;
+  options.preloadOptionalSections = {
+      std::string(nimble::kClusterIndexSection),
+      std::string(nimble::kChunkIndexSection)};
+
+  // Cold path.
+  {
+    auto coldReader = createTabletReader(readFile, options);
+    EXPECT_EQ(coldReader->stripeCount(), kNumStripes);
+    EXPECT_TRUE(coldReader->hasClusterIndex());
+    for (uint32_t i = 0; i < kNumStripes; ++i) {
+      auto stripeId = coldReader->stripeIdentifier(i);
+      EXPECT_NE(stripeId.stripeGroup(), nullptr);
+      EXPECT_NE(stripeId.chunkIndex(), nullptr);
+    }
+  }
+
+  auto coldCacheStats = cache_->refreshStats();
+  EXPECT_GT(coldCacheStats.numEntries, 0);
+
+  dataIoStats_ = std::make_shared<velox::io::IoStatistics>();
+  metadataIoStats_ = std::make_shared<velox::io::IoStatistics>();
+  indexIoStats_ = std::make_shared<velox::io::IoStatistics>();
+  readerOptions_.reset();
+
+  // Warm path: all metadata (including compressed chunk index group)
+  // should be served from cache with zero file IO and zero evictions.
+  {
+    auto warmReader = createTabletReader(readFile, options);
+    EXPECT_EQ(warmReader->stripeCount(), kNumStripes);
+    EXPECT_EQ(warmReader->tabletRowCount(), kNumStripes * 100);
+    EXPECT_GT(metadataIoStats_->ramHit().count(), 0);
+    EXPECT_EQ(metadataIoStats_->rawBytesRead(), 0);
+    EXPECT_TRUE(warmReader->hasClusterIndex());
+
+    for (uint32_t i = 0; i < kNumStripes; ++i) {
+      auto stripeId = warmReader->stripeIdentifier(i);
+      EXPECT_NE(stripeId.stripeGroup(), nullptr);
+      EXPECT_NE(stripeId.chunkIndex(), nullptr);
+    }
+  }
+
+  auto warmCacheStats = cache_->refreshStats();
+  EXPECT_EQ(warmCacheStats.numEvict, 0);
 }
 
 } // namespace


### PR DESCRIPTION
Summary:

CONTEXT: When `uncompressed_size` was added to the `MetadataSection` FlatBuffer table (a2b6d6bea1ce), `TabletWriter` was updated to serialize it for stripes, stripe groups, and optional sections. However, `ChunkIndexWriter::writeRoot()` and `ClusterIndexWriter::close()` were not updated, nor were their matching readers. This causes `resolveUncompressedSize()` to return `nullopt` for index metadata sections, preventing cache pin pre-allocation at the correct decompressed size.

WHAT:
- Writer: serialize `uncompressed_size` in `ChunkIndexWriter::writeRoot()` and `ClusterIndexWriter::close()`.
- Reader: read `uncompressed_size` in `ChunkIndex::create()` and `ClusterIndex::partitionSection()`.
- Test: added `uncompressedSizeRoundtrip` verifying FlatBuffer round-trip of `uncompressed_size` through ChunkIndex.

Reviewed By: xiaoxmeng

Differential Revision: D108464890


