### PR TITLE
fix: Gate GooglePolyline and format Nimble tests

### DIFF
--- a/dwio/nimble/common/Types.h
+++ b/dwio/nimble/common/Types.h
@@ -121,7 +121,8 @@ enum class EncodingType {
   // its own baseline and bit width. Adapts per-chunk variable bit widths for
   // better compression on data with locally narrow value ranges.
   BlockBitPacking = 15,
-  // Partitions data by value frequency. Also, frequent values get shorter bit-width
+  // Partitions data by value frequency. Also, frequent values get shorter
+  // bit-width
   // codes. Rows are reordered to group values with same code length.
   FrequencyPartition = 17,
   // Frame of Reference: stores offsets from per-frame minimum values.

--- a/dwio/nimble/encodings/ForEncoding.h
+++ b/dwio/nimble/encodings/ForEncoding.h
@@ -20,14 +20,14 @@
 #include <vector>
 
 #include "dwio/nimble/common/Buffer.h"
-#include "dwio/nimble/encodings/common/EncodingPrimitives.h"
-#include "dwio/nimble/encodings/common/EncodingType.h"
 #include "dwio/nimble/common/Exceptions.h"
 #include "dwio/nimble/common/FixedBitArray.h"
 #include "dwio/nimble/common/Vector.h"
 #include "dwio/nimble/compression/Compression.h"
 #include "dwio/nimble/encodings/common/Encoding.h"
 #include "dwio/nimble/encodings/common/EncodingFactory.h"
+#include "dwio/nimble/encodings/common/EncodingPrimitives.h"
+#include "dwio/nimble/encodings/common/EncodingType.h"
 #include "dwio/nimble/encodings/selection/EncodingSelection.h"
 
 // Frame of Reference encoding. Divides data into fixed-size frames, storing
@@ -63,8 +63,8 @@ class ForEncoding final
   ForEncoding(
       velox::memory::MemoryPool& memoryPool,
       std::string_view data,
-    std::function<void*(uint32_t)> stringBufferFactory = nullptr,
-    const Encoding::Options& options = {});
+      std::function<void*(uint32_t)> stringBufferFactory = nullptr,
+      const Encoding::Options& options = {});
 
   ~ForEncoding() override {
     this->releaseBuffer(uncompressedData_);
@@ -80,8 +80,8 @@ class ForEncoding final
   static std::string_view encode(
       EncodingSelection<physicalType>& selection,
       std::span<const physicalType> values,
-    Buffer& buffer,
-    const Encoding::Options& options = {});
+      Buffer& buffer,
+      const Encoding::Options& options = {});
 
   std::string debugString(int offset) const final;
 
@@ -110,10 +110,8 @@ class ForEncoding final
     return row % frameSize_;
   }
 
-  void decodeRange(
-      uint32_t startRow,
-      uint32_t rowCount,
-      physicalType* output) const;
+  void decodeRange(uint32_t startRow, uint32_t rowCount, physicalType* output)
+      const;
 
   physicalType decodeValue(uint32_t row) const;
 };
@@ -125,9 +123,9 @@ template <typename T>
 ForEncoding<T>::ForEncoding(
     velox::memory::MemoryPool& memoryPool,
     std::string_view data,
-  std::function<void*(uint32_t)> stringBufferFactory,
-  const Encoding::Options& options)
-  : TypedEncoding<T, physicalType>{memoryPool, data, options},
+    std::function<void*(uint32_t)> stringBufferFactory,
+    const Encoding::Options& options)
+    : TypedEncoding<T, physicalType>{memoryPool, data, options},
       frames_{&memoryPool},
       currentRow_(0),
       buffer_{&memoryPool} {
@@ -137,10 +135,11 @@ ForEncoding<T>::ForEncoding(
 
   const char* pos = data.data() + kCompressionOffset;
   const EncodingFactory encodingFactory(options);
-  const auto nullStringBufferFactory =
-    [](uint32_t /*size*/) -> void* { return nullptr; };
+  const auto nullStringBufferFactory = [](uint32_t /*size*/) -> void* {
+    return nullptr;
+  };
   const auto& decodeStringBufferFactory =
-    stringBufferFactory ? stringBufferFactory : nullStringBufferFactory;
+      stringBufferFactory ? stringBufferFactory : nullStringBufferFactory;
 
   CompressionType compressionType =
       static_cast<CompressionType>(encoding::readChar(pos));
@@ -152,7 +151,9 @@ ForEncoding<T>::ForEncoding(
   // Read BitWidths array
   const uint32_t bitWidthsSize = encoding::readUint32(pos);
   auto bitWidthsEncoding = encodingFactory.create(
-      *this->pool_, std::string_view(pos, bitWidthsSize), decodeStringBufferFactory);
+      *this->pool_,
+      std::string_view(pos, bitWidthsSize),
+      decodeStringBufferFactory);
   pos += bitWidthsSize;
 
   Vector<uint8_t> bitWidths(&memoryPool, numFrames_);
@@ -161,7 +162,9 @@ ForEncoding<T>::ForEncoding(
   // Read References array
   const uint32_t referencesSize = encoding::readUint32(pos);
   auto referencesEncoding = encodingFactory.create(
-      *this->pool_, std::string_view(pos, referencesSize), decodeStringBufferFactory);
+      *this->pool_,
+      std::string_view(pos, referencesSize),
+      decodeStringBufferFactory);
   pos += referencesSize;
 
   Vector<physicalType> references(&memoryPool, numFrames_);
@@ -172,7 +175,9 @@ ForEncoding<T>::ForEncoding(
   if (enableBitOffsets_) {
     const uint32_t bitOffsetsSize = encoding::readUint32(pos);
     auto bitOffsetsEncoding = encodingFactory.create(
-        *this->pool_, std::string_view(pos, bitOffsetsSize), decodeStringBufferFactory);
+        *this->pool_,
+        std::string_view(pos, bitOffsetsSize),
+        decodeStringBufferFactory);
     pos += bitOffsetsSize;
 
     bitOffsets.resize(numFrames_);
@@ -198,8 +203,7 @@ ForEncoding<T>::ForEncoding(
     FrameInfo frame;
     frame.reference = references[i];
     frame.bitWidth = bitWidths[i];
-    frame.bitOffset =
-        enableBitOffsets_ ? bitOffsets[i] : cumulativeBitOffset;
+    frame.bitOffset = enableBitOffsets_ ? bitOffsets[i] : cumulativeBitOffset;
 
     uint32_t startRow = i * frameSize_;
     uint32_t endRow = std::min(startRow + frameSize_, this->rowCount_);
@@ -232,18 +236,16 @@ void ForEncoding<T>::decodeRange(
     uint32_t rowCount,
     physicalType* output) const {
   NIMBLE_DCHECK(
-      startRow + rowCount <= this->rowCount_,
-      "Decoding past end of encoding");
+      startRow + rowCount <= this->rowCount_, "Decoding past end of encoding");
 
-  // Streaming bit-cursor decoder: reads rowsToDecode values of frame.bitWidth bits
-  // from byteCursor at bitOffsetInByte, writing results via decodeException.
-  auto decodeBitStream = [](
-      const uint8_t* byteCursor,
-      uint8_t bitOffsetInByte,
-      uint8_t bitWidth,
-      uint32_t rowsToDecode,
-      auto&& decodeException) {
-
+  // Streaming bit-cursor decoder: reads rowsToDecode values of frame.bitWidth
+  // bits from byteCursor at bitOffsetInByte, writing results via
+  // decodeException.
+  auto decodeBitStream = [](const uint8_t* byteCursor,
+                            uint8_t bitOffsetInByte,
+                            uint8_t bitWidth,
+                            uint32_t rowsToDecode,
+                            auto&& decodeException) {
     uint64_t bitBuffer = 0;
     uint32_t bitsInBuffer = 0;
 
@@ -258,7 +260,8 @@ void ForEncoding<T>::decodeRange(
 
     for (uint32_t i = 0; i < rowsToDecode; ++i) {
       while (bitsInBuffer < bitWidth) {
-        bitBuffer |= static_cast<uint64_t>(static_cast<uint8_t>(*byteCursor)) << bitsInBuffer;
+        bitBuffer |= static_cast<uint64_t>(static_cast<uint8_t>(*byteCursor))
+            << bitsInBuffer;
         ++byteCursor;
         bitsInBuffer += 8;
       }
@@ -277,13 +280,15 @@ void ForEncoding<T>::decodeRange(
     const auto& frame = frames_[frameIndex];
     const uint32_t positionInFrame = getPositionInFrame(currentRow);
     const uint32_t rowsAvailableInFrame = frame.size - positionInFrame;
-    const uint32_t rowsToDecode = std::min(remainingRowCount, rowsAvailableInFrame);
+    const uint32_t rowsToDecode =
+        std::min(remainingRowCount, rowsAvailableInFrame);
 
     // Per-frame reference application — captures frame by ref
     auto decodeException = [&](uint32_t i, uint64_t residual) {
       if constexpr (std::is_signed_v<physicalType>) {
         output[outputOffset + i] = static_cast<physicalType>(
-            static_cast<int64_t>(residual) + static_cast<int64_t>(frame.reference));
+            static_cast<int64_t>(residual) +
+            static_cast<int64_t>(frame.reference));
       } else {
         output[outputOffset + i] =
             static_cast<physicalType>(residual + frame.reference);
@@ -292,17 +297,21 @@ void ForEncoding<T>::decodeRange(
 
     if (frame.bitWidth == 0) {
       // All values in frame are identical to reference
-      std::fill(output + outputOffset, output + outputOffset + rowsToDecode, frame.reference);
+      std::fill(
+          output + outputOffset,
+          output + outputOffset + rowsToDecode,
+          frame.reference);
 
     } else {
-      const uint64_t bitPosition =
-          frame.bitOffset + static_cast<uint64_t>(positionInFrame) * frame.bitWidth;
+      const uint64_t bitPosition = frame.bitOffset +
+          static_cast<uint64_t>(positionInFrame) * frame.bitWidth;
       const uint8_t bitOffsetInByte = static_cast<uint8_t>(bitPosition & 7U);
       const uint8_t* byteCursor =
           reinterpret_cast<const uint8_t*>(packedData_) + (bitPosition / 8);
 
       if (bitOffsetInByte == 0) {
-        // Byte-aligned: use typed loads for power-of-two widths, bit-stream otherwise
+        // Byte-aligned: use typed loads for power-of-two widths, bit-stream
+        // otherwise
         switch (frame.bitWidth) {
           case 8:
             for (uint32_t i = 0; i < rowsToDecode; ++i) {
@@ -312,32 +321,41 @@ void ForEncoding<T>::decodeRange(
           case 16:
             for (uint32_t i = 0; i < rowsToDecode; ++i) {
               uint16_t v;
-              std::memcpy(&v, byteCursor + i * sizeof(uint16_t), sizeof(uint16_t));
+              std::memcpy(
+                  &v, byteCursor + i * sizeof(uint16_t), sizeof(uint16_t));
               decodeException(i, v);
             }
             break;
           case 32:
             for (uint32_t i = 0; i < rowsToDecode; ++i) {
               uint32_t v;
-              std::memcpy(&v, byteCursor + i * sizeof(uint32_t), sizeof(uint32_t));
+              std::memcpy(
+                  &v, byteCursor + i * sizeof(uint32_t), sizeof(uint32_t));
               decodeException(i, v);
             }
             break;
           case 64:
             for (uint32_t i = 0; i < rowsToDecode; ++i) {
               uint64_t v;
-              std::memcpy(&v, byteCursor + i * sizeof(uint64_t), sizeof(uint64_t));
+              std::memcpy(
+                  &v, byteCursor + i * sizeof(uint64_t), sizeof(uint64_t));
               decodeException(i, v);
             }
             break;
           default:
             // Non-power-of-two width, byte-aligned start: bitOffsetInByte == 0
-            decodeBitStream(byteCursor, 0, frame.bitWidth, rowsToDecode, decodeException);
+            decodeBitStream(
+                byteCursor, 0, frame.bitWidth, rowsToDecode, decodeException);
             break;
         }
       } else {
         // Unaligned: always use the bit-streaming path
-        decodeBitStream(byteCursor, bitOffsetInByte, frame.bitWidth, rowsToDecode, decodeException);
+        decodeBitStream(
+            byteCursor,
+            bitOffsetInByte,
+            frame.bitWidth,
+            rowsToDecode,
+            decodeException);
       }
     }
 
@@ -398,8 +416,8 @@ std::string ForEncoding<T>::debugString(int offset) const {
     bitWidthCounts[frame.bitWidth]++;
   }
 
-  log += fmt::format(
-      "\n{}bitWidth distribution: ", std::string(offset + 2, ' '));
+  log +=
+      fmt::format("\n{}bitWidth distribution: ", std::string(offset + 2, ' '));
   for (const auto& [width, count] : bitWidthCounts) {
     log += fmt::format("{}b:{} ", width, count);
   }
@@ -425,8 +443,9 @@ std::string_view ForEncoding<T>::encode(
   }
 
   // Configuration (TODO: make configurable via policy)
-  const bool enableBitOffsets = true;  // Default: enable for O(1) random access
-  const uint32_t frameSize = 128;      // Default frame size (TODO: adaptive selection)
+  const bool enableBitOffsets = true; // Default: enable for O(1) random access
+  const uint32_t frameSize =
+      128; // Default frame size (TODO: adaptive selection)
 
   const uint32_t numFrames = (rowCount + frameSize - 1) / frameSize;
 
@@ -443,17 +462,18 @@ std::string_view ForEncoding<T>::encode(
 
   auto writeBits = [&](uint64_t value, uint8_t numBits) {
     size_t bitsToWrite = numBits;
-    
+
     while (bitsToWrite > 0) {
       size_t spaceInBuffer = 64 - bitBufferLen;
       size_t bitsThisRound = std::min(bitsToWrite, spaceInBuffer);
-      
-      uint64_t mask = (bitsThisRound == 64) ? ~0ULL : ((1ULL << bitsThisRound) - 1);
+
+      uint64_t mask =
+          (bitsThisRound == 64) ? ~0ULL : ((1ULL << bitsThisRound) - 1);
       uint64_t chunk = value & mask;
-      
+
       bitBuffer |= (chunk << bitBufferLen);
       bitBufferLen += bitsThisRound;
-      
+
       // Shifting by the full width (64) is undefined behavior, so guard it the
       // same way as the mask computation above.
       value = (bitsThisRound == 64) ? 0 : (value >> bitsThisRound);
@@ -470,12 +490,14 @@ std::string_view ForEncoding<T>::encode(
   constexpr std::array<uint8_t, 7> BIT_WIDTHS = {1, 2, 4, 8, 16, 32, 64};
 
   auto findMinBitWidth = [&](uint64_t maxValue) -> uint8_t {
-    if (maxValue == 0) return 1;
+    if (maxValue == 0)
+      return 1;
 
     size_t bitsNeeded = 64 - __builtin_clzll(maxValue);
 
     for (uint8_t width : BIT_WIDTHS) {
-      if (width >= bitsNeeded) return width;
+      if (width >= bitsNeeded)
+        return width;
     }
 
     return 64;
@@ -532,22 +554,20 @@ std::string_view ForEncoding<T>::encode(
 
   Buffer tempBuffer{buffer.getMemoryPool()};
 
-  std::string_view serializedBitWidths = selection.template encodeNested<uint8_t>(
-      0,  // identifier - TODO: define proper identifiers
-      {bitWidths},
-      tempBuffer);
+  std::string_view serializedBitWidths =
+      selection.template encodeNested<uint8_t>(
+          0, // identifier - TODO: define proper identifiers
+          {bitWidths},
+          tempBuffer);
 
-  std::string_view serializedReferences = selection.template encodeNested<physicalType>(
-      1,
-      {references},
-      tempBuffer);
+  std::string_view serializedReferences =
+      selection.template encodeNested<physicalType>(
+          1, {references}, tempBuffer);
 
   std::string_view serializedBitOffsets;
   if (enableBitOffsets) {
-    serializedBitOffsets = selection.template encodeNested<uint64_t>(
-        2,
-        {bitOffsets},
-        tempBuffer);
+    serializedBitOffsets =
+        selection.template encodeNested<uint64_t>(2, {bitOffsets}, tempBuffer);
   }
 
   auto dataCompressionPolicy = selection.compressionPolicy();
@@ -555,7 +575,7 @@ std::string_view ForEncoding<T>::encode(
       buffer.getMemoryPool(),
       *dataCompressionPolicy,
       DataType::Undefined,
-      0,  // bitWidth not applicable
+      0, // bitWidth not applicable
       static_cast<uint32_t>(packedData.size()),
       [&]() { return std::span<char>{packedData}; },
       [&](char*& pos) {
@@ -564,26 +584,21 @@ std::string_view ForEncoding<T>::encode(
         return pos;
       }};
 
-  uint32_t encodingSize =
-    Encoding::serializePrefixSize(rowCount, useVarint) +
-    // FOR-specific fixed fields only; the standard prefix is accounted for
-    // separately above via serializePrefixSize (kPrefixSize already includes
-    // Encoding::kPrefixSize, so subtract it to avoid double-counting).
-    (ForEncoding<T>::kPrefixSize - Encoding::kPrefixSize) +
-      4 + serializedBitWidths.size() +       // BitWidths
-      4 + serializedReferences.size() +      // References
-      (enableBitOffsets ? 4 + serializedBitOffsets.size() : 0) +
-      4 + compressionEncoder.getSize();
+  uint32_t encodingSize = Encoding::serializePrefixSize(rowCount, useVarint) +
+      // FOR-specific fixed fields only; the standard prefix is accounted for
+      // separately above via serializePrefixSize (kPrefixSize already includes
+      // Encoding::kPrefixSize, so subtract it to avoid double-counting).
+      (ForEncoding<T>::kPrefixSize - Encoding::kPrefixSize) + 4 +
+      serializedBitWidths.size() + // BitWidths
+      4 + serializedReferences.size() + // References
+      (enableBitOffsets ? 4 + serializedBitOffsets.size() : 0) + 4 +
+      compressionEncoder.getSize();
 
   char* reserved = buffer.reserve(encodingSize);
   char* pos = reserved;
 
   Encoding::serializePrefix(
-    EncodingType::FOR,
-    TypeTraits<T>::dataType,
-    rowCount,
-    useVarint,
-    pos);
+      EncodingType::FOR, TypeTraits<T>::dataType, rowCount, useVarint, pos);
 
   encoding::writeChar(
       static_cast<char>(compressionEncoder.compressionType()), pos);

--- a/dwio/nimble/encodings/FrequencyPartitionEncoding.h
+++ b/dwio/nimble/encodings/FrequencyPartitionEncoding.h
@@ -23,12 +23,12 @@
 #include <vector>
 
 #include "dwio/nimble/common/Buffer.h"
-#include "dwio/nimble/encodings/common/EncodingPrimitives.h"
-#include "dwio/nimble/encodings/common/EncodingType.h"
 #include "dwio/nimble/common/Types.h"
 #include "dwio/nimble/common/Vector.h"
 #include "dwio/nimble/encodings/common/Encoding.h"
 #include "dwio/nimble/encodings/common/EncodingFactory.h"
+#include "dwio/nimble/encodings/common/EncodingPrimitives.h"
+#include "dwio/nimble/encodings/common/EncodingType.h"
 #include "dwio/nimble/encodings/selection/EncodingIdentifier.h"
 #include "dwio/nimble/encodings/selection/EncodingSelection.h"
 #include "folly/container/F14Map.h"
@@ -86,10 +86,10 @@ namespace facebook::nimble {
 
 /// Selects the positional index representation stored in the wire format.
 enum class FreqPartIndexType : uint8_t {
-  NoIndex        = 0, ///< no index; tier-order output (backward-compatible)
+  NoIndex = 0, ///< no index; tier-order output (backward-compatible)
   PerTierBitmaps = 1, ///< one N-bit bitmap per tier + Rank9 superblock
-  TierTagArray   = 2, ///< packed tag array + sampled rank index
-  EliasFano      = 3, ///< per-tier Elias-Fano positions (decoded at load time)
+  TierTagArray = 2, ///< packed tag array + sampled rank index
+  EliasFano = 3, ///< per-tier Elias-Fano positions (decoded at load time)
 };
 
 template <typename T>
@@ -134,14 +134,14 @@ class FrequencyPartitionEncoding
     // For NoIndex: rank = sequential position in tier's encoded range.
     // For indexed modes: rank = count of tier elements before original pos u.
     Vector<uint32_t> indices;
-    uint32_t startRow;  // NoIndex only: offset in encoded stream
-    uint32_t size;      // NoIndex only: count in encoded stream
+    uint32_t startRow; // NoIndex only: offset in encoded stream
+    uint32_t size; // NoIndex only: count in encoded stream
 
     // Index fields — populated based on indexType_:
-    uint32_t tierCount{0};             // element count (indexed modes)
-    Vector<uint64_t> bitmap;           // PerTierBitmaps: N-bit bitmap
-    Vector<uint32_t> rankSuperblock;   // PerTierBitmaps: Rank9 cumulative counts
-    Vector<uint32_t> efPositions;      // EliasFano: decoded original positions
+    uint32_t tierCount{0}; // element count (indexed modes)
+    Vector<uint64_t> bitmap; // PerTierBitmaps: N-bit bitmap
+    Vector<uint32_t> rankSuperblock; // PerTierBitmaps: Rank9 cumulative counts
+    Vector<uint32_t> efPositions; // EliasFano: decoded original positions
 
     TierInfo(velox::memory::MemoryPool* pool)
         : keyBits(0),
@@ -157,13 +157,13 @@ class FrequencyPartitionEncoding
 
   // Get capacity for a given key bit width
   static constexpr uint32_t getCapacity(uint32_t keyBits) {
-    return (keyBits == 1)  ? 2
-        : (keyBits == 2)   ? 4
-        : (keyBits == 4)   ? 16
-        : (keyBits == 8)   ? 256
-        : (keyBits == 16)  ? (65536 - 256)
-        : (keyBits == 32)  ? (4294967296ULL - 65536)
-                           : 0;
+    return (keyBits == 1) ? 2
+        : (keyBits == 2)  ? 4
+        : (keyBits == 4)  ? 16
+        : (keyBits == 8)  ? 256
+        : (keyBits == 16) ? (65536 - 256)
+        : (keyBits == 32) ? (4294967296ULL - 65536)
+                          : 0;
   }
 
   static constexpr uint32_t getMaxKeyBits() {
@@ -187,14 +187,17 @@ class FrequencyPartitionEncoding
   // ---------------------------------------------------------------------------
 
   static constexpr uint8_t ceilLog2WithMinOne(uint32_t x) {
-    if (x <= 1u) return 1u;
+    if (x <= 1u)
+      return 1u;
     return static_cast<uint8_t>(std::bit_width(x - 1u));
   }
 
   static uint8_t chooseEliasFanoLowBits(uint64_t universe, uint64_t n) {
-    if (n == 0 || universe <= n) return 0;
+    if (n == 0 || universe <= n)
+      return 0;
     const uint64_t ratio = universe / n;
-    if (ratio <= 1) return 0;
+    if (ratio <= 1)
+      return 0;
     return static_cast<uint8_t>(
         std::min<uint64_t>(31, std::bit_width(ratio) - 1));
   }
@@ -226,7 +229,8 @@ class FrequencyPartitionEncoding
   // Extract `keyBits`-wide value at zero-based rank `r` from a LSB-first
   // packed byte array. Safe bounded read (no padding required).
   static uint32_t unpackBits(const uint8_t* base, uint32_t r, uint8_t keyBits) {
-    if (keyBits == 0) return 0;
+    if (keyBits == 0)
+      return 0;
     const size_t bitPos = static_cast<size_t>(r) * keyBits;
     const size_t byteIdx = bitPos >> 3;
     const uint32_t bitOff = static_cast<uint32_t>(bitPos & 7);
@@ -245,7 +249,8 @@ class FrequencyPartitionEncoding
       const uint32_t* keys,
       uint32_t count,
       uint8_t keyBits) {
-    if (keyBits == 0 || count == 0) return;
+    if (keyBits == 0 || count == 0)
+      return;
     const size_t byteCount = (static_cast<size_t>(count) * keyBits + 7) / 8;
     const size_t base = out.size();
     out.resize(base + byteCount, '\0');
@@ -257,8 +262,8 @@ class FrequencyPartitionEncoding
       while (bitsLeft > 0) {
         const size_t byteIdx = bitPos / 8;
         const size_t bitOff = bitPos % 8;
-        const uint8_t chunk =
-            static_cast<uint8_t>(bitsLeft > (8 - bitOff) ? (8 - bitOff) : bitsLeft);
+        const uint8_t chunk = static_cast<uint8_t>(
+            bitsLeft > (8 - bitOff) ? (8 - bitOff) : bitsLeft);
         reinterpret_cast<uint8_t&>(out[base + byteIdx]) |=
             static_cast<uint8_t>((remaining & ((1u << chunk) - 1u)) << bitOff);
         remaining >>= chunk;
@@ -270,10 +275,8 @@ class FrequencyPartitionEncoding
 
   // Extract tag at position `pos` from a LSB-first packed tag array.
   // tagBits must be ≤ 8.
-  static uint8_t unpackTagAt(
-      const uint8_t* base,
-      uint32_t pos,
-      uint8_t tagBits) {
+  static uint8_t
+  unpackTagAt(const uint8_t* base, uint32_t pos, uint8_t tagBits) {
     const size_t bitPos = static_cast<size_t>(pos) * tagBits;
     const size_t byteIdx = bitPos / 8;
     const size_t bitOff = bitPos % 8;
@@ -309,8 +312,8 @@ class FrequencyPartitionEncoding
     const uint32_t word = pos / 64;
     uint32_t rank = fallbackWordPrefix_[word];
     const uint64_t uncov = ~coveredBitmap_[word];
-    rank += static_cast<uint32_t>(__builtin_popcountll(
-        uncov & ((uint64_t{1} << (pos % 64)) - 1)));
+    rank += static_cast<uint32_t>(
+        __builtin_popcountll(uncov & ((uint64_t{1} << (pos % 64)) - 1)));
     return rank;
   }
 
@@ -325,7 +328,8 @@ class FrequencyPartitionEncoding
     for (uint32_t j = scanStart; j < pos; ++j) {
       const uint8_t t = unpackTagAt(tagBase, j, tagBits_);
       const uint32_t b = (t < numActiveTiers) ? t : numActiveTiers;
-      if (b == tierIdx) ++rank;
+      if (b == tierIdx)
+        ++rank;
     }
     return rank;
   }
@@ -359,16 +363,16 @@ class FrequencyPartitionEncoding
   uint32_t currentOriginalPos_;
 
   // PerTierBitmaps / EliasFano: covered bitmap and fallback prefix table
-  Vector<uint64_t> coveredBitmap_;     // bit i set ↔ position i in some tier
-  Vector<uint32_t> fallbackWordPrefix_; // [w] = fallback count in positions [0, w*64)
+  Vector<uint64_t> coveredBitmap_; // bit i set ↔ position i in some tier
+  Vector<uint32_t>
+      fallbackWordPrefix_; // [w] = fallback count in positions [0, w*64)
 
   // TierTagArray fields
   uint8_t tagBits_;
   Vector<uint8_t> tagArray_;
-  // tierRankSamples_[t][si] = count of tag==t in positions [0, si*kRankSampleStride)
-  // Index tiers_.size() is used for the fallback bucket.
+  // tierRankSamples_[t][si] = count of tag==t in positions [0,
+  // si*kRankSampleStride) Index tiers_.size() is used for the fallback bucket.
   std::vector<std::vector<uint32_t>> tierRankSamples_;
-
 };
 
 //
@@ -462,7 +466,9 @@ FrequencyPartitionEncoding<T>::FrequencyPartitionEncoding(
       if (unencodedSize > 0) {
         const uint32_t valuesSize = encoding::readUint32(pos);
         auto valuesEncoding = encodingFactory.create(
-            *this->pool_, std::string_view(pos, valuesSize), stringBufferFactory);
+            *this->pool_,
+            std::string_view(pos, valuesSize),
+            stringBufferFactory);
         pos += valuesSize;
 
         unencodedValues_.resize(unencodedSize);
@@ -493,7 +499,8 @@ FrequencyPartitionEncoding<T>::FrequencyPartitionEncoding(
         case FreqPartIndexType::PerTierBitmaps: {
           coveredBitmap_.resize(numWords, 0);
           for (auto& tier : tiers_) {
-            if (tier.size == 0) continue;
+            if (tier.size == 0)
+              continue;
             const uint32_t bitmapByteCount = encoding::readUint32(pos);
             NIMBLE_CHECK(
                 bitmapByteCount == numWords * 8,
@@ -543,7 +550,8 @@ FrequencyPartitionEncoding<T>::FrequencyPartitionEncoding(
           const uint32_t numBuckets = static_cast<uint32_t>(numActiveTiers) + 1;
           const uint32_t numSamples =
               (totalRowCount_ + kRankSampleStride - 1) / kRankSampleStride + 1;
-          tierRankSamples_.assign(numBuckets, std::vector<uint32_t>(numSamples, 0));
+          tierRankSamples_.assign(
+              numBuckets, std::vector<uint32_t>(numSamples, 0));
 
           std::vector<uint32_t> counts(numBuckets, 0);
           for (uint32_t i = 0; i < totalRowCount_; ++i) {
@@ -576,7 +584,8 @@ FrequencyPartitionEncoding<T>::FrequencyPartitionEncoding(
           }
 
           for (auto& tier : tiers_) {
-            if (tier.size == 0) continue;
+            if (tier.size == 0)
+              continue;
             const uint8_t lowBits = encoding::read<uint8_t>(pos);
             pos += 3; // padding
             const uint32_t lowByteCount = encoding::readUint32(pos);
@@ -588,8 +597,12 @@ FrequencyPartitionEncoding<T>::FrequencyPartitionEncoding(
             pos += static_cast<size_t>(highWordCount) * 8;
 
             decodeEliasFanoPositions(
-                lowBase, lowBits, highBase, highWordCount,
-                tier.tierCount, tier.efPositions);
+                lowBase,
+                lowBits,
+                highBase,
+                highWordCount,
+                tier.tierCount,
+                tier.efPositions);
 
             if (hasFallback) {
               for (uint32_t p : tier.efPositions)
@@ -635,8 +648,10 @@ void FrequencyPartitionEncoding<T>::reset() {
 template <typename T>
 uint32_t FrequencyPartitionEncoding<T>::getTierForRow(uint32_t rowIndex) const {
   for (uint32_t i = 0; i < tiers_.size(); ++i) {
-    if (rowIndex < tiers_[i].startRow) break;  // tiers are contiguous and ordered
-    if (rowIndex < tiers_[i].startRow + tiers_[i].size) return i;
+    if (rowIndex < tiers_[i].startRow)
+      break; // tiers are contiguous and ordered
+    if (rowIndex < tiers_[i].startRow + tiers_[i].size)
+      return i;
   }
   return tiers_.size();
 }
@@ -676,7 +691,8 @@ template <FreqPartIndexType I>
 T FrequencyPartitionEncoding<T>::decodeAtOriginalIndexImpl(uint32_t u) const {
   if constexpr (I == FreqPartIndexType::PerTierBitmaps) {
     for (const auto& tier : tiers_) {
-      if (tier.bitmap.empty()) continue;
+      if (tier.bitmap.empty())
+        continue;
       if (tier.bitmap[u / 64] & (uint64_t{1} << (u % 64))) {
         const uint32_t rank = popcountPrefixFast(tier, u);
         return tier.dictionary[tier.indices[rank]];
@@ -696,9 +712,10 @@ T FrequencyPartitionEncoding<T>::decodeAtOriginalIndexImpl(uint32_t u) const {
 
   } else if constexpr (I == FreqPartIndexType::EliasFano) {
     for (const auto& tier : tiers_) {
-      if (tier.efPositions.empty()) continue;
-      auto it = std::lower_bound(
-          tier.efPositions.begin(), tier.efPositions.end(), u);
+      if (tier.efPositions.empty())
+        continue;
+      auto it =
+          std::lower_bound(tier.efPositions.begin(), tier.efPositions.end(), u);
       if (it != tier.efPositions.end() && *it == u) {
         const uint32_t rank =
             static_cast<uint32_t>(it - tier.efPositions.begin());
@@ -897,10 +914,9 @@ std::string_view FrequencyPartitionEncoding<T>::encode(
   for (const auto& [value, freq] : frequencyMap) {
     freqVec.emplace_back(value, freq);
   }
-  std::sort(
-      freqVec.begin(),
-      freqVec.end(),
-      [](const auto& a, const auto& b) { return a.second > b.second; });
+  std::sort(freqVec.begin(), freqVec.end(), [](const auto& a, const auto& b) {
+    return a.second > b.second;
+  });
 
   const uint32_t uniqueCount = static_cast<uint32_t>(freqVec.size());
   constexpr uint32_t maxKeyBits = getMaxKeyBits();
@@ -994,11 +1010,10 @@ std::string_view FrequencyPartitionEncoding<T>::encode(
           EncodingIdentifiers::FrequencyPartition::PartitionOffsets,
           {partitionOffsets},
           tempBuffer);
-  std::string_view serializedSizes =
-      selection.template encodeNested<uint32_t>(
-          EncodingIdentifiers::FrequencyPartition::PartitionSizes,
-          {partitionSizes},
-          tempBuffer);
+  std::string_view serializedSizes = selection.template encodeNested<uint32_t>(
+      EncodingIdentifiers::FrequencyPartition::PartitionSizes,
+      {partitionSizes},
+      tempBuffer);
 
   std::vector<std::string_view> serializedDicts(tierAssignments.size());
   std::vector<std::string_view> serializedKeys(tierAssignments.size());
@@ -1049,7 +1064,8 @@ std::string_view FrequencyPartitionEncoding<T>::encode(
   if (indexType == FreqPartIndexType::PerTierBitmaps) {
     // Build per-tier bitmaps from tierRows (already in ascending row order).
     for (uint32_t t = 0; t < numTiers; ++t) {
-      if (tierRows[t].empty()) continue;
+      if (tierRows[t].empty())
+        continue;
       std::vector<uint64_t> bitmap(numWords, 0);
       for (uint32_t row : tierRows[t]) {
         bitmap[row / 64] |= uint64_t{1} << (row % 64);
@@ -1063,9 +1079,11 @@ std::string_view FrequencyPartitionEncoding<T>::encode(
     }
 
   } else if (indexType == FreqPartIndexType::TierTagArray) {
-    // Build tag array: tag[pos] = tier index (0..numTiers-1) or numTiers (fallback).
+    // Build tag array: tag[pos] = tier index (0..numTiers-1) or numTiers
+    // (fallback).
     const uint8_t tagBits = ceilLog2WithMinOne(numTiers + 1);
-    const size_t tagArrayByteCount = (static_cast<size_t>(valueCount) * tagBits + 7) / 8;
+    const size_t tagArrayByteCount =
+        (static_cast<size_t>(valueCount) * tagBits + 7) / 8;
 
     // Reverse map: row → tag
     std::vector<uint8_t> rowToTag(valueCount, static_cast<uint8_t>(numTiers));
@@ -1106,22 +1124,24 @@ std::string_view FrequencyPartitionEncoding<T>::encode(
   } else if (indexType == FreqPartIndexType::EliasFano) {
     // Build per-tier Elias-Fano position encodings.
     for (uint32_t t = 0; t < numTiers; ++t) {
-      if (tierRows[t].empty()) continue;
+      if (tierRows[t].empty())
+        continue;
       const std::vector<uint32_t>& positions = tierRows[t]; // ascending order
       const uint32_t tierCount = static_cast<uint32_t>(positions.size());
 
       const uint8_t lowBits = chooseEliasFanoLowBits(valueCount, tierCount);
-      const uint32_t lowMask =
-          (lowBits == 0) ? 0u
-          : (lowBits == 32) ? 0xFFFFFFFFu
-          : ((1u << lowBits) - 1u);
+      const uint32_t lowMask = (lowBits == 0) ? 0u
+          : (lowBits == 32)                   ? 0xFFFFFFFFu
+                                              : ((1u << lowBits) - 1u);
 
       // Build low array
       std::vector<uint32_t> lows;
       lows.reserve(tierCount);
-      for (uint32_t pos : positions) lows.push_back(pos & lowMask);
+      for (uint32_t pos : positions)
+        lows.push_back(pos & lowMask);
 
-      const size_t lowByteCount = (static_cast<size_t>(tierCount) * lowBits + 7) / 8;
+      const size_t lowByteCount =
+          (static_cast<size_t>(tierCount) * lowBits + 7) / 8;
 
       // Build high bitmap
       const size_t highBitsLen =
@@ -1162,14 +1182,16 @@ std::string_view FrequencyPartitionEncoding<T>::encode(
   // Compute total encoding size
   uint32_t encodingSize = Encoding::serializePrefixSize(valueCount, useVarint) +
       4 + // num partitions
-      4 + static_cast<uint32_t>(serializedOffsets.size()) +
-      4 + static_cast<uint32_t>(serializedSizes.size());
+      4 + static_cast<uint32_t>(serializedOffsets.size()) + 4 +
+      static_cast<uint32_t>(serializedSizes.size());
 
   for (const auto& dict : serializedDicts) {
-    if (!dict.empty()) encodingSize += 4 + static_cast<uint32_t>(dict.size());
+    if (!dict.empty())
+      encodingSize += 4 + static_cast<uint32_t>(dict.size());
   }
   for (const auto& keys : serializedKeys) {
-    if (!keys.empty()) encodingSize += 4 + static_cast<uint32_t>(keys.size());
+    if (!keys.empty())
+      encodingSize += 4 + static_cast<uint32_t>(keys.size());
   }
   if (!serializedUnencoded.empty()) {
     encodingSize += 4 + static_cast<uint32_t>(serializedUnencoded.size());
@@ -1200,14 +1222,17 @@ std::string_view FrequencyPartitionEncoding<T>::encode(
 
   for (size_t i = 0; i < serializedDicts.size(); ++i) {
     if (!serializedDicts[i].empty()) {
-      encoding::writeUint32(static_cast<uint32_t>(serializedDicts[i].size()), wpos);
+      encoding::writeUint32(
+          static_cast<uint32_t>(serializedDicts[i].size()), wpos);
       encoding::writeBytes(serializedDicts[i], wpos);
-      encoding::writeUint32(static_cast<uint32_t>(serializedKeys[i].size()), wpos);
+      encoding::writeUint32(
+          static_cast<uint32_t>(serializedKeys[i].size()), wpos);
       encoding::writeBytes(serializedKeys[i], wpos);
     }
   }
   if (!serializedUnencoded.empty()) {
-    encoding::writeUint32(static_cast<uint32_t>(serializedUnencoded.size()), wpos);
+    encoding::writeUint32(
+        static_cast<uint32_t>(serializedUnencoded.size()), wpos);
     encoding::writeBytes(serializedUnencoded, wpos);
   }
 
@@ -1230,10 +1255,10 @@ std::string_view FrequencyPartitionEncoding<T>::encode(
 template <typename T>
 std::string FrequencyPartitionEncoding<T>::debugString(int offset) const {
   const char* idxName = indexType_ == FreqPartIndexType::NoIndex ? "NoIndex"
-      : indexType_ == FreqPartIndexType::PerTierBitmaps           ? "PerTierBitmaps"
-      : indexType_ == FreqPartIndexType::TierTagArray             ? "TierTagArray"
-      : indexType_ == FreqPartIndexType::EliasFano                ? "EliasFano"
-                                                                  : "Unknown";
+      : indexType_ == FreqPartIndexType::PerTierBitmaps ? "PerTierBitmaps"
+      : indexType_ == FreqPartIndexType::TierTagArray   ? "TierTagArray"
+      : indexType_ == FreqPartIndexType::EliasFano      ? "EliasFano"
+                                                        : "Unknown";
   std::string log = Encoding::debugString(offset);
   log += fmt::format(
       "\n{}tiers={}, unencoded_rows={}, index={}",

--- a/dwio/nimble/encodings/selection/EncodingIdentifier.h
+++ b/dwio/nimble/encodings/selection/EncodingIdentifier.h
@@ -74,7 +74,8 @@ struct EncodingIdentifiers {
 
   struct FrequencyPartition {
     // Partition metadata
-    // Eventually we may want to allow for non-power-of-two bit partitions, but for now we can just define constants for the power-of-two cases.
+    // Eventually we may want to allow for non-power-of-two bit partitions, but
+    // for now we can just define constants for the power-of-two cases.
     static constexpr NestedEncodingIdentifier PartitionOffsets = 0;
     static constexpr NestedEncodingIdentifier PartitionSizes = 1;
     // Per-tier dictionaries (1-bit, 2-bit, 4-bit, 8-bit, etc.)

--- a/dwio/nimble/encodings/tests/ConstantEncodingTest.cpp
+++ b/dwio/nimble/encodings/tests/ConstantEncodingTest.cpp
@@ -65,7 +65,8 @@ struct ValuesPreparer<double, TestClass> {
         test->toVector({test->dNaN1, test->dNaN1, test->dNaN1}),
         test->toVector({test->dNaN2, test->dNaN2, test->dNaN2})};
   }
-  static std::vector<nimble::Vector<double>> prepareFailureValues(TestClass* test) {
+  static std::vector<nimble::Vector<double>> prepareFailureValues(
+      TestClass* test) {
     return {
         test->toVector({-0.0, -0.00, -0.0000001}),
         test->toVector({-2.1, -2.1, -2.1, -2.1, -2.2}),
@@ -85,7 +86,8 @@ struct ValuesPreparer<float, TestClass> {
         test->toVector({test->fNaN1, test->fNaN1, test->fNaN1}),
         test->toVector({test->fNaN2, test->fNaN2, test->fNaN2})};
   }
-  static std::vector<nimble::Vector<float>> prepareFailureValues(TestClass* test) {
+  static std::vector<nimble::Vector<float>> prepareFailureValues(
+      TestClass* test) {
     return {
         test->toVector({-0.0f, -0.00f, -0.0000001f}),
         test->toVector({-2.1f, -2.1f, -2.1f, -2.1f, -2.2f}),
@@ -98,7 +100,8 @@ struct ValuesPreparer<int32_t, TestClass> {
   static std::vector<nimble::Vector<int32_t>> prepareValues(TestClass* test) {
     return {test->toVector({1}), test->toVector({3, 3, 3})};
   }
-  static std::vector<nimble::Vector<int32_t>> prepareFailureValues(TestClass* test) {
+  static std::vector<nimble::Vector<int32_t>> prepareFailureValues(
+      TestClass* test) {
     return {test->toVector({3, 2, 3})};
   }
 };

--- a/dwio/nimble/encodings/tests/EncodingLayoutTest.cpp
+++ b/dwio/nimble/encodings/tests/EncodingLayoutTest.cpp
@@ -42,15 +42,16 @@ void verifyEncodingLayout(
   }
 
   ASSERT_EQ(expected->encodingType(), actual->encodingType());
-  
+
   // When MetaInternal is not available, it gets redirected to Zstd.
   // For tests, we need to account for this mapping.
   auto expectedCompression = expected->compressionType();
   auto actualCompression = actual->compressionType();
-  
+
 #ifdef DISABLE_META_INTERNAL_COMPRESSOR
-  // If expected is MetaInternal but we don't have it, accept Zstd or Uncompressed
-  // (Uncompressed can happen if the data is too small to benefit from compression)
+  // If expected is MetaInternal but we don't have it, accept Zstd or
+  // Uncompressed (Uncompressed can happen if the data is too small to benefit
+  // from compression)
   if (expectedCompression == nimble::CompressionType::MetaInternal) {
     ASSERT_TRUE(
         actualCompression == nimble::CompressionType::Zstd ||
@@ -63,7 +64,7 @@ void verifyEncodingLayout(
 #else
   ASSERT_EQ(expectedCompression, actualCompression);
 #endif
-  
+
   ASSERT_EQ(expected->childrenCount(), actual->childrenCount());
 
   for (auto i = 0; i < expected->childrenCount(); ++i) {
@@ -147,7 +148,9 @@ class ForceSubIntSplitPolicy final : public nimble::EncodingSelectionPolicy<T> {
 TEST(EncodingLayoutTests, Trivial) {
   {
     nimble::EncodingLayout expected{
-        nimble::EncodingType::Trivial, {}, nimble::CompressionType::Uncompressed};
+        nimble::EncodingType::Trivial,
+        {},
+        nimble::CompressionType::Uncompressed};
 
     testSerialization(expected);
     testCapture<uint32_t>(expected, {1, 2, 3});
@@ -155,7 +158,9 @@ TEST(EncodingLayoutTests, Trivial) {
 
   {
     nimble::EncodingLayout expected{
-        nimble::EncodingType::Trivial, {}, nimble::CompressionType::MetaInternal};
+        nimble::EncodingType::Trivial,
+        {},
+        nimble::CompressionType::MetaInternal};
 
     testSerialization(expected);
     testCapture<uint32_t>(expected, {1, 2, 3});
@@ -399,11 +404,11 @@ TEST(EncodingLayoutTests, Nullable) {
       nimble::CompressionType::Uncompressed,
       {nimble::EncodingLayout{
            nimble::EncodingType::FixedBitWidth,
-            {},
+           {},
            nimble::CompressionType::Uncompressed},
        nimble::EncodingLayout{
            nimble::EncodingType::SparseBool,
-            {},
+           {},
            nimble::CompressionType::Uncompressed,
            {
                nimble::EncodingLayout{

--- a/dwio/nimble/encodings/tests/EncodingLegacyTest.cpp
+++ b/dwio/nimble/encodings/tests/EncodingLegacyTest.cpp
@@ -195,31 +195,41 @@ template <typename C, typename Encoding>
 struct EncodingTypeTraitsHelper {};
 
 template <typename C>
-struct EncodingTypeTraitsHelper<C, nimble::legacy::ConstantEncoding<typename C::cppDataType>> {
+struct EncodingTypeTraitsHelper<
+    C,
+    nimble::legacy::ConstantEncoding<typename C::cppDataType>> {
   static inline nimble::EncodingType encodingType =
       nimble::EncodingType::Constant;
 };
 
 template <typename C>
-struct EncodingTypeTraitsHelper<C, nimble::legacy::DictionaryEncoding<typename C::cppDataType>> {
+struct EncodingTypeTraitsHelper<
+    C,
+    nimble::legacy::DictionaryEncoding<typename C::cppDataType>> {
   static inline nimble::EncodingType encodingType =
       nimble::EncodingType::Dictionary;
 };
 
 template <typename C>
-struct EncodingTypeTraitsHelper<C, nimble::legacy::FixedBitWidthEncoding<typename C::cppDataType>> {
+struct EncodingTypeTraitsHelper<
+    C,
+    nimble::legacy::FixedBitWidthEncoding<typename C::cppDataType>> {
   static inline nimble::EncodingType encodingType =
       nimble::EncodingType::FixedBitWidth;
 };
 
 template <typename C>
-struct EncodingTypeTraitsHelper<C, nimble::legacy::MainlyConstantEncoding<typename C::cppDataType>> {
+struct EncodingTypeTraitsHelper<
+    C,
+    nimble::legacy::MainlyConstantEncoding<typename C::cppDataType>> {
   static inline nimble::EncodingType encodingType =
       nimble::EncodingType::MainlyConstant;
 };
 
 template <typename C>
-struct EncodingTypeTraitsHelper<C, nimble::legacy::RLEEncoding<typename C::cppDataType>> {
+struct EncodingTypeTraitsHelper<
+    C,
+    nimble::legacy::RLEEncoding<typename C::cppDataType>> {
   static inline nimble::EncodingType encodingType = nimble::EncodingType::RLE;
 };
 
@@ -230,13 +240,17 @@ struct EncodingTypeTraitsHelper<C, nimble::legacy::SparseBoolEncoding> {
 };
 
 template <typename C>
-struct EncodingTypeTraitsHelper<C, nimble::legacy::TrivialEncoding<typename C::cppDataType>> {
+struct EncodingTypeTraitsHelper<
+    C,
+    nimble::legacy::TrivialEncoding<typename C::cppDataType>> {
   static inline nimble::EncodingType encodingType =
       nimble::EncodingType::Trivial;
 };
 
 template <typename C>
-struct EncodingTypeTraitsHelper<C, nimble::legacy::VarintEncoding<typename C::cppDataType>> {
+struct EncodingTypeTraitsHelper<
+    C,
+    nimble::legacy::VarintEncoding<typename C::cppDataType>> {
   static inline nimble::EncodingType encodingType =
       nimble::EncodingType::Varint;
 };

--- a/dwio/nimble/encodings/tests/EncodingTest.cpp
+++ b/dwio/nimble/encodings/tests/EncodingTest.cpp
@@ -413,22 +413,26 @@ struct EncodingTypeGetter<nimble::ConstantEncoding<T>> {
 
 template <typename T>
 struct EncodingTypeGetter<nimble::DictionaryEncoding<T>> {
-  static constexpr nimble::EncodingType value = nimble::EncodingType::Dictionary;
+  static constexpr nimble::EncodingType value =
+      nimble::EncodingType::Dictionary;
 };
 
 template <typename T>
 struct EncodingTypeGetter<nimble::FixedBitWidthEncoding<T>> {
-  static constexpr nimble::EncodingType value = nimble::EncodingType::FixedBitWidth;
+  static constexpr nimble::EncodingType value =
+      nimble::EncodingType::FixedBitWidth;
 };
 
 template <typename T>
 struct EncodingTypeGetter<nimble::FrequencyPartitionEncoding<T>> {
-  static constexpr nimble::EncodingType value = nimble::EncodingType::FrequencyPartition;
+  static constexpr nimble::EncodingType value =
+      nimble::EncodingType::FrequencyPartition;
 };
 
 template <typename T>
 struct EncodingTypeGetter<nimble::MainlyConstantEncoding<T>> {
-  static constexpr nimble::EncodingType value = nimble::EncodingType::MainlyConstant;
+  static constexpr nimble::EncodingType value =
+      nimble::EncodingType::MainlyConstant;
 };
 
 template <typename T>
@@ -438,7 +442,8 @@ struct EncodingTypeGetter<nimble::RLEEncoding<T>> {
 
 template <>
 struct EncodingTypeGetter<nimble::SparseBoolEncoding> {
-  static constexpr nimble::EncodingType value = nimble::EncodingType::SparseBool;
+  static constexpr nimble::EncodingType value =
+      nimble::EncodingType::SparseBool;
 };
 
 template <typename T>

--- a/dwio/nimble/encodings/tests/ForEncodingTest.cpp
+++ b/dwio/nimble/encodings/tests/ForEncodingTest.cpp
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+#include "dwio/nimble/encodings/ForEncoding.h"
 #include <glog/logging.h>
 #include <gtest/gtest.h>
 #include <algorithm>
@@ -21,7 +22,6 @@
 #include "dwio/nimble/common/Buffer.h"
 #include "dwio/nimble/common/Vector.h"
 #include "dwio/nimble/encodings/tests/TestUtils.h"
-#include "dwio/nimble/encodings/ForEncoding.h"
 #include "folly/Random.h"
 #include "velox/common/memory/Memory.h"
 
@@ -100,24 +100,25 @@ TEST_F(ForEncodingTest, ConstantValue) {
   encoding->materialize(500, result.data());
 
   for (size_t i = 0; i < data.size(); ++i) {
-    ASSERT_EQ(result[i], constantValue) << "Expected " << constantValue << " at index " << i;
+    ASSERT_EQ(result[i], constantValue)
+        << "Expected " << constantValue << " at index " << i;
   }
 }
 
 // Test with values requiring different bit widths
 TEST_F(ForEncodingTest, MixedBitWidths) {
   nimble::Vector<int32_t> data(pool_.get());
-  
+
   // Frame 1: small range (1-bit)
   for (int i = 0; i < 128; ++i) {
     data.push_back(100 + (i % 2));
   }
-  
+
   // Frame 2: medium range (4-bit)
   for (int i = 0; i < 128; ++i) {
     data.push_back(200 + (i % 16));
   }
-  
+
   // Frame 3: larger range (8-bit)
   for (int i = 0; i < 128; ++i) {
     data.push_back(300 + (i % 256));
@@ -170,16 +171,16 @@ TEST_F(ForEncodingTest, SelectiveRead) {
   // Read first 100
   nimble::Vector<int32_t> result1(pool_.get(), 100);
   encoding->materialize(100, result1.data());
-  
+
   for (size_t i = 0; i < 100; ++i) {
     ASSERT_EQ(result1[i], data[i]) << "Mismatch at index " << i;
   }
-  
+
   // Skip 200, then read next 100
   encoding->skip(200);
   nimble::Vector<int32_t> result2(pool_.get(), 100);
   encoding->materialize(100, result2.data());
-  
+
   for (size_t i = 0; i < 100; ++i) {
     ASSERT_EQ(result2[i], data[300 + i]) << "Mismatch at index " << (300 + i);
   }
@@ -249,9 +250,9 @@ TEST_F(ForEncodingTest, UnsignedTypes) {
 TEST_F(ForEncodingTest, LargeValues) {
   nimble::Vector<int64_t> data(pool_.get());
   data.push_back(0);
-  data.push_back(1LL << 30);  // ~1 billion
-  data.push_back(1LL << 31);  // ~2 billion
-  data.push_back(1LL << 32);  // ~4 billion
+  data.push_back(1LL << 30); // ~1 billion
+  data.push_back(1LL << 31); // ~2 billion
+  data.push_back(1LL << 32); // ~4 billion
   data.push_back((1LL << 33) - 1);
 
   auto encoding = createEncoding(data);
@@ -273,16 +274,16 @@ TEST_F(ForEncodingTest, Skip) {
   }
 
   auto encoding = createEncoding(data);
-  
+
   // Skip first 100 elements
   encoding->skip(100);
-  
+
   // Read next 50
   nimble::Vector<int32_t> result(pool_.get(), 50);
   encoding->materialize(50, result.data());
 
   for (size_t i = 0; i < 50; ++i) {
-    ASSERT_EQ(result[i], data[100 + i]) 
+    ASSERT_EQ(result[i], data[100 + i])
         << "Mismatch at index " << (100 + i) << " after skip";
   }
 }
@@ -295,20 +296,20 @@ TEST_F(ForEncodingTest, Reset) {
   }
 
   auto encoding = createEncoding(data);
-  
+
   // Read first 50
   nimble::Vector<int32_t> result1(pool_.get(), 50);
   encoding->materialize(50, result1.data());
 
   // Reset
   encoding->reset();
-  
+
   // Read first 50 again
   nimble::Vector<int32_t> result2(pool_.get(), 50);
   encoding->materialize(50, result2.data());
 
   for (size_t i = 0; i < 50; ++i) {
-    ASSERT_EQ(result1[i], result2[i]) 
+    ASSERT_EQ(result1[i], result2[i])
         << "Reset failed - mismatch at index " << i;
   }
 }
@@ -317,16 +318,16 @@ TEST_F(ForEncodingTest, Reset) {
 TEST_F(ForEncodingTest, WithCompression) {
   nimble::Vector<int32_t> data(pool_.get());
   for (int i = 0; i < 1000; ++i) {
-    data.push_back(i % 100);  // Repeating pattern
+    data.push_back(i % 100); // Repeating pattern
   }
 
-  auto encoding = nimble::test::Encoder<nimble::ForEncoding<int32_t>>::
-      createEncoding(
+  auto encoding =
+      nimble::test::Encoder<nimble::ForEncoding<int32_t>>::createEncoding(
           *buffer_,
           data,
           [](uint32_t) -> void* { return nullptr; },
           nimble::CompressionType::Zstd);
-  
+
   ASSERT_EQ(encoding->rowCount(), 1000);
 
   nimble::Vector<int32_t> result(pool_.get(), 1000);
@@ -359,7 +360,7 @@ TEST_F(ForEncodingTest, SmallData) {
 TEST_F(ForEncodingTest, ExactFrameBoundary) {
   nimble::Vector<int32_t> data(pool_.get());
   // Default frame size is 128
-  for (int i = 0; i < 256; ++i) {  // Exactly 2 frames
+  for (int i = 0; i < 256; ++i) { // Exactly 2 frames
     data.push_back(i);
   }
 
@@ -424,7 +425,7 @@ TEST_F(ForEncodingTest, Uint64Type) {
 TEST_F(ForEncodingTest, SelectiveReadsWithPattern) {
   nimble::Vector<int32_t> data(pool_.get());
   for (int i = 0; i < 1000; ++i) {
-    data.push_back(i * 7);  // Some pattern
+    data.push_back(i * 7); // Some pattern
   }
 
   auto encoding = createEncoding(data);
@@ -442,7 +443,7 @@ TEST_F(ForEncodingTest, SelectiveReadsWithPattern) {
   for (int i = 0; i < 100; ++i) {
     // Read one value
     encoding->materialize(1, &results[resultIdx++]);
-    
+
     // Skip next 9 (unless last iteration)
     if (i < 99) {
       encoding->skip(9);
@@ -450,7 +451,7 @@ TEST_F(ForEncodingTest, SelectiveReadsWithPattern) {
   }
 
   for (size_t i = 0; i < expected.size(); ++i) {
-    ASSERT_EQ(results[i], expected[i]) 
+    ASSERT_EQ(results[i], expected[i])
         << "Mismatch at selective index " << i << " (row " << (i * 10) << ")";
   }
 }
@@ -494,7 +495,7 @@ TEST_F(ForEncodingTest, RandomAccessWithResets) {
 TEST_F(ForEncodingTest, SparseSelectiveReads) {
   nimble::Vector<uint32_t> data(pool_.get());
   for (uint32_t i = 0; i < 1000; ++i) {
-    data.push_back(i * i);  // Quadratic values
+    data.push_back(i * i); // Quadratic values
   }
 
   auto encoding = createEncoding(data);
@@ -507,25 +508,24 @@ TEST_F(ForEncodingTest, SparseSelectiveReads) {
   }
 
   nimble::Vector<uint32_t> results(pool_.get(), indices.size());
-  
+
   // Read index 0
   encoding->materialize(1, &results[0]);
-  
+
   // Skip to 100, read it
   encoding->skip(99);
   encoding->materialize(1, &results[1]);
-  
+
   // Skip to 500, read it
   encoding->skip(399);
   encoding->materialize(1, &results[2]);
-  
+
   // Skip to 999, read it
   encoding->skip(498);
   encoding->materialize(1, &results[3]);
 
   for (size_t i = 0; i < indices.size(); ++i) {
-    ASSERT_EQ(results[i], expected[i]) 
-        << "Mismatch for index " << indices[i];
+    ASSERT_EQ(results[i], expected[i]) << "Mismatch for index " << indices[i];
   }
 }
 
@@ -542,24 +542,24 @@ TEST_F(ForEncodingTest, SelectiveAcrossFrameBoundaries) {
   // Read values at frame boundaries
   // Frame 0: 0-127, Frame 1: 128-255, Frame 2: 256-383
   std::vector<uint32_t> testIndices = {
-      0,    // Start of frame 0
-      63,   // Middle of frame 0
-      127,  // End of frame 0
-      128,  // Start of frame 1
-      191,  // Middle of frame 1  
-      255,  // End of frame 1
-      256,  // Start of frame 2
-      319,  // Middle of frame 2
-      383   // End of frame 2
+      0, // Start of frame 0
+      63, // Middle of frame 0
+      127, // End of frame 0
+      128, // Start of frame 1
+      191, // Middle of frame 1
+      255, // End of frame 1
+      256, // Start of frame 2
+      319, // Middle of frame 2
+      383 // End of frame 2
   };
 
   encoding->reset();
   nimble::Vector<int32_t> results(pool_.get(), testIndices.size());
-  
+
   uint32_t currentPos = 0;
   for (size_t i = 0; i < testIndices.size(); ++i) {
     uint32_t targetIdx = testIndices[i];
-    
+
     if (targetIdx > currentPos) {
       encoding->skip(targetIdx - currentPos);
       currentPos = targetIdx;
@@ -569,13 +569,13 @@ TEST_F(ForEncodingTest, SelectiveAcrossFrameBoundaries) {
       encoding->skip(targetIdx);
       currentPos = targetIdx;
     }
-    
+
     encoding->materialize(1, &results[i]);
     currentPos++;
   }
 
   for (size_t i = 0; i < testIndices.size(); ++i) {
-    ASSERT_EQ(results[i], static_cast<int32_t>(testIndices[i])) 
+    ASSERT_EQ(results[i], static_cast<int32_t>(testIndices[i]))
         << "Mismatch at frame boundary index " << testIndices[i];
   }
 }
@@ -583,41 +583,40 @@ TEST_F(ForEncodingTest, SelectiveAcrossFrameBoundaries) {
 // Test selective read with varying bit widths across frames
 TEST_F(ForEncodingTest, SelectiveWithVaryingBitWidths) {
   nimble::Vector<int64_t> data(pool_.get());
-  
+
   // Frame 0: small range (1-bit width)
   for (int i = 0; i < 128; ++i) {
     data.push_back(1000 + (i % 2));
   }
-  
+
   // Frame 1: medium range (8-bit width)
   for (int i = 0; i < 128; ++i) {
     data.push_back(2000 + (i % 200));
   }
-  
+
   // Frame 2: large range (32-bit width)
   for (int i = 0; i < 128; ++i) {
     data.push_back(1000000000LL + i);
   }
 
   auto encoding = createEncoding(data);
-  
+
   // Selectively read from each frame
   std::vector<std::pair<uint32_t, int64_t>> tests = {
-      {50, 1000 + (50 % 2)},              // From frame 0
-      {150, 2000 + (22 % 200)},            // From frame 1 (150 - 128 = 22)
-      {300, 1000000000LL + (300 - 256)}    // From frame 2 (300 - 256 = 44)
+      {50, 1000 + (50 % 2)}, // From frame 0
+      {150, 2000 + (22 % 200)}, // From frame 1 (150 - 128 = 22)
+      {300, 1000000000LL + (300 - 256)} // From frame 2 (300 - 256 = 44)
   };
 
   encoding->reset();
   for (const auto& [index, expectedValue] : tests) {
     encoding->reset();
     encoding->skip(index);
-    
+
     nimble::Vector<int64_t> result(pool_.get(), 1);
     encoding->materialize(1, result.data());
-    
-    ASSERT_EQ(result[0], expectedValue) 
-        << "Mismatch at index " << index;
+
+    ASSERT_EQ(result[0], expectedValue) << "Mismatch at index " << index;
   }
 }
 
@@ -632,16 +631,15 @@ TEST_F(ForEncodingTest, BatchSelectiveReads) {
 
   // Read batches: [0-9], [100-109], [500-509], [900-909]
   std::vector<std::pair<uint32_t, uint32_t>> ranges = {
-      {0, 10}, {100, 10}, {500, 10}, {900, 10}
-  };
+      {0, 10}, {100, 10}, {500, 10}, {900, 10}};
 
   for (const auto& [start, count] : ranges) {
     encoding->reset();
     encoding->skip(start);
-    
+
     nimble::Vector<int32_t> result(pool_.get(), count);
     encoding->materialize(count, result.data());
-    
+
     for (uint32_t i = 0; i < count; ++i) {
       uint32_t expectedIdx = start + i;
       ASSERT_EQ(result[i], static_cast<int32_t>(expectedIdx * 3))

--- a/dwio/nimble/encodings/tests/FrequencyPartitionEncodingTest.cpp
+++ b/dwio/nimble/encodings/tests/FrequencyPartitionEncodingTest.cpp
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+#include "dwio/nimble/encodings/FrequencyPartitionEncoding.h"
 #include <glog/logging.h>
 #include <gtest/gtest.h>
 #include <algorithm>
@@ -21,7 +22,6 @@
 #include "dwio/nimble/common/Buffer.h"
 #include "dwio/nimble/common/Vector.h"
 #include "dwio/nimble/encodings/tests/TestUtils.h"
-#include "dwio/nimble/encodings/FrequencyPartitionEncoding.h"
 #include "folly/Random.h"
 #include "velox/common/memory/Memory.h"
 
@@ -37,9 +37,9 @@ class FrequencyPartitionEncodingTest : public ::testing::Test {
   template <typename T>
   std::unique_ptr<nimble::Encoding> createEncoding(
       const nimble::Vector<T>& data) {
-    return nimble::test::Encoder<
-               nimble::FrequencyPartitionEncoding<T>>::createEncoding(
-        *buffer_, data, nullptr, nimble::CompressionType::Uncompressed);
+    return nimble::test::Encoder<nimble::FrequencyPartitionEncoding<T>>::
+        createEncoding(
+            *buffer_, data, nullptr, nimble::CompressionType::Uncompressed);
   }
 
   template <typename T>
@@ -48,9 +48,13 @@ class FrequencyPartitionEncodingTest : public ::testing::Test {
       nimble::FreqPartIndexType indexType) {
     nimble::Encoding::Options opts{};
     opts.frequencyPartitionIndex = static_cast<uint8_t>(indexType);
-    return nimble::test::Encoder<
-               nimble::FrequencyPartitionEncoding<T>>::createEncoding(
-        *buffer_, data, nullptr, nimble::CompressionType::Uncompressed, opts);
+    return nimble::test::Encoder<nimble::FrequencyPartitionEncoding<T>>::
+        createEncoding(
+            *buffer_,
+            data,
+            nullptr,
+            nimble::CompressionType::Uncompressed,
+            opts);
   }
 
   std::shared_ptr<velox::memory::MemoryPool> pool_;
@@ -84,7 +88,8 @@ TEST_F(FrequencyPartitionEncodingTest, BasicEncodeDecode) {
 
   ASSERT_EQ(sortedData.size(), sortedResult.size());
   for (size_t i = 0; i < sortedData.size(); ++i) {
-    ASSERT_EQ(sortedResult[i], sortedData[i]) << "Mismatch at sorted index " << i;
+    ASSERT_EQ(sortedResult[i], sortedData[i])
+        << "Mismatch at sorted index " << i;
   }
 }
 
@@ -98,7 +103,7 @@ TEST_F(FrequencyPartitionEncodingTest, ZipfianDistribution) {
   const int numUniqueValues = 100;
 
   nimble::Vector<int64_t> data(pool_.get());
-  
+
   // Create Zipfian distribution: first values appear much more frequently
   std::vector<int> frequencies(numUniqueValues);
   for (int i = 0; i < numUniqueValues; ++i) {
@@ -133,7 +138,8 @@ TEST_F(FrequencyPartitionEncodingTest, ZipfianDistribution) {
 
   ASSERT_EQ(sortedData.size(), sortedResult.size());
   for (size_t i = 0; i < sortedData.size(); ++i) {
-    ASSERT_EQ(sortedResult[i], sortedData[i]) << "Mismatch at sorted index " << i;
+    ASSERT_EQ(sortedResult[i], sortedData[i])
+        << "Mismatch at sorted index " << i;
   }
 }
 
@@ -146,7 +152,7 @@ TEST_F(FrequencyPartitionEncodingTest, UniformDistribution) {
 
   const int numValues = 5000;
   nimble::Vector<uint32_t> data(pool_.get());
-  
+
   for (int i = 0; i < numValues; ++i) {
     data.push_back(dist(rng));
   }
@@ -165,7 +171,8 @@ TEST_F(FrequencyPartitionEncodingTest, UniformDistribution) {
 
   ASSERT_EQ(sortedData.size(), sortedResult.size());
   for (size_t i = 0; i < sortedData.size(); ++i) {
-    ASSERT_EQ(sortedResult[i], sortedData[i]) << "Mismatch at sorted index " << i;
+    ASSERT_EQ(sortedResult[i], sortedData[i])
+        << "Mismatch at sorted index " << i;
   }
 }
 
@@ -173,7 +180,7 @@ TEST_F(FrequencyPartitionEncodingTest, UniformDistribution) {
 TEST_F(FrequencyPartitionEncodingTest, AllIdenticalValues) {
   const int numValues = 1000;
   nimble::Vector<int32_t> data(pool_.get());
-  
+
   for (int i = 0; i < numValues; ++i) {
     data.push_back(42);
   }
@@ -215,41 +222,43 @@ TEST_F(FrequencyPartitionEncodingTest, IncrementalMaterialization) {
 
   // Read all data at once
   encoding->materialize(100, result.data());
-  
+
   // Verify all values are present (compare sorted)
   std::vector<uint64_t> sortedData(data.begin(), data.end());
   std::vector<uint64_t> sortedResult(result.begin(), result.end());
   std::sort(sortedData.begin(), sortedData.end());
   std::sort(sortedResult.begin(), sortedResult.end());
-  
+
   ASSERT_EQ(sortedData.size(), sortedResult.size());
   for (size_t i = 0; i < sortedData.size(); ++i) {
-    ASSERT_EQ(sortedResult[i], sortedData[i]) << "Mismatch at sorted index " << i;
+    ASSERT_EQ(sortedResult[i], sortedData[i])
+        << "Mismatch at sorted index " << i;
   }
 
   // Test reset functionality
   encoding->reset();
   encoding->materialize(100, result.data());
-  
+
   // Verify reset works - should get same reordered data again
   std::vector<uint64_t> sortedResult2(result.begin(), result.end());
   std::sort(sortedResult2.begin(), sortedResult2.end());
   for (size_t i = 0; i < sortedData.size(); ++i) {
-    ASSERT_EQ(sortedResult2[i], sortedData[i]) << "Reset mismatch at sorted index " << i;
+    ASSERT_EQ(sortedResult2[i], sortedData[i])
+        << "Reset mismatch at sorted index " << i;
   }
 }
 
 // Test with large values (to test different tier sizes)
 TEST_F(FrequencyPartitionEncodingTest, LargeValues) {
   nimble::Vector<uint64_t> data(pool_.get());
-  
+
   // Add values that require different bit widths
-  data.push_back(1ULL);                    // 1 bit
-  data.push_back(255ULL);                  // 8 bits
-  data.push_back(65535ULL);                // 16 bits
-  data.push_back(4294967295ULL);           // 32 bits
+  data.push_back(1ULL); // 1 bit
+  data.push_back(255ULL); // 8 bits
+  data.push_back(65535ULL); // 16 bits
+  data.push_back(4294967295ULL); // 32 bits
   data.push_back(18446744073709551615ULL); // 64 bits
-  data.push_back(1ULL);                    // Repeat small value
+  data.push_back(1ULL); // Repeat small value
 
   auto encoding = createEncoding(data);
   ASSERT_EQ(encoding->rowCount(), 6);
@@ -265,7 +274,8 @@ TEST_F(FrequencyPartitionEncodingTest, LargeValues) {
 
   ASSERT_EQ(sortedData.size(), sortedResult.size());
   for (size_t i = 0; i < sortedData.size(); ++i) {
-    ASSERT_EQ(sortedResult[i], sortedData[i]) << "Large value mismatch at sorted index " << i;
+    ASSERT_EQ(sortedResult[i], sortedData[i])
+        << "Large value mismatch at sorted index " << i;
   }
 }
 
@@ -293,7 +303,8 @@ TEST_F(FrequencyPartitionEncodingTest, FloatValues) {
 
   ASSERT_EQ(sortedData.size(), sortedResult.size());
   for (size_t i = 0; i < sortedData.size(); ++i) {
-    ASSERT_EQ(sortedResult[i], sortedData[i]) << "Float mismatch at sorted index " << i;
+    ASSERT_EQ(sortedResult[i], sortedData[i])
+        << "Float mismatch at sorted index " << i;
   }
 }
 
@@ -320,7 +331,8 @@ TEST_F(FrequencyPartitionEncodingTest, DoubleValues) {
 
   ASSERT_EQ(sortedData.size(), sortedResult.size());
   for (size_t i = 0; i < sortedData.size(); ++i) {
-    ASSERT_EQ(sortedResult[i], sortedData[i]) << "Double mismatch at sorted index " << i;
+    ASSERT_EQ(sortedResult[i], sortedData[i])
+        << "Double mismatch at sorted index " << i;
   }
 }
 
@@ -332,10 +344,10 @@ TEST_F(FrequencyPartitionEncodingTest, EncodingLayout) {
   }
 
   auto encoding = createEncoding(data);
-  
+
   // Verify the encoding type is correct
   ASSERT_EQ(encoding->encodingType(), nimble::EncodingType::FrequencyPartition);
-  
+
   // The encoding should have nested encodings for:
   // - Tier assignments
   // - Tier dictionaries
@@ -346,7 +358,7 @@ TEST_F(FrequencyPartitionEncodingTest, EncodingLayout) {
 // Test with edge case: maximum tier count
 TEST_F(FrequencyPartitionEncodingTest, MaximumTiers) {
   nimble::Vector<uint8_t> data(pool_.get());
-  
+
   // Create data with many unique values to potentially trigger maximum tiers
   for (int i = 0; i < 256; ++i) {
     data.push_back(static_cast<uint8_t>(i));
@@ -366,7 +378,8 @@ TEST_F(FrequencyPartitionEncodingTest, MaximumTiers) {
 
   ASSERT_EQ(sortedData.size(), sortedResult.size());
   for (size_t i = 0; i < sortedData.size(); ++i) {
-    ASSERT_EQ(sortedResult[i], sortedData[i]) << "Max tiers mismatch at sorted index " << i;
+    ASSERT_EQ(sortedResult[i], sortedData[i])
+        << "Max tiers mismatch at sorted index " << i;
   }
 }
 
@@ -397,7 +410,8 @@ TEST_F(FrequencyPartitionEncodingTest, SparseData) {
 
   ASSERT_EQ(sortedData.size(), sortedResult.size());
   for (size_t i = 0; i < sortedData.size(); ++i) {
-    ASSERT_EQ(sortedResult[i], sortedData[i]) << "Sparse data mismatch at sorted index " << i;
+    ASSERT_EQ(sortedResult[i], sortedData[i])
+        << "Sparse data mismatch at sorted index " << i;
   }
 }
 
@@ -416,8 +430,8 @@ static void testIndexedRoundTrip(
     nimble::FreqPartIndexType indexType) {
   nimble::Encoding::Options opts{};
   opts.frequencyPartitionIndex = static_cast<uint8_t>(indexType);
-  auto encoding =
-      nimble::test::Encoder<nimble::FrequencyPartitionEncoding<T>>::createEncoding(
+  auto encoding = nimble::test::Encoder<nimble::FrequencyPartitionEncoding<T>>::
+      createEncoding(
           buffer, data, nullptr, nimble::CompressionType::Uncompressed, opts);
 
   const uint32_t N = static_cast<uint32_t>(data.size());
@@ -427,8 +441,7 @@ static void testIndexedRoundTrip(
   nimble::Vector<T> result(pool, N);
   encoding->materialize(N, result.data());
   for (uint32_t i = 0; i < N; ++i) {
-    ASSERT_EQ(result[i], data[i])
-        << "Full materialize mismatch at index " << i;
+    ASSERT_EQ(result[i], data[i]) << "Full materialize mismatch at index " << i;
   }
 
   // 2. Reset and partial reads.
@@ -440,9 +453,11 @@ static void testIndexedRoundTrip(
     encoding->materialize(half, first.data());
     encoding->materialize(N - half, second.data());
     for (uint32_t i = 0; i < half; ++i)
-      ASSERT_EQ(first[i], data[i]) << "Partial read (first half) mismatch at " << i;
+      ASSERT_EQ(first[i], data[i])
+          << "Partial read (first half) mismatch at " << i;
     for (uint32_t i = 0; i < N - half; ++i)
-      ASSERT_EQ(second[i], data[half + i]) << "Partial read (second half) mismatch at " << i;
+      ASSERT_EQ(second[i], data[half + i])
+          << "Partial read (second half) mismatch at " << i;
   }
 
   // 3. Skip + materialize.
@@ -499,9 +514,11 @@ TEST_F(FrequencyPartitionEncodingTest, IndexedEliasFano_int32) {
 }
 
 TEST_F(FrequencyPartitionEncodingTest, IndexedNoIndex_preservesTierOrder) {
-  // NoIndex stays backward-compatible (sorted-multiset equality, not exact order).
+  // NoIndex stays backward-compatible (sorted-multiset equality, not exact
+  // order).
   nimble::Vector<int32_t> data(pool_.get());
-  for (int i = 0; i < 200; ++i) data.push_back(i % 5);
+  for (int i = 0; i < 200; ++i)
+    data.push_back(i % 5);
 
   auto encoding = createEncoding(data); // default = NoIndex
   ASSERT_EQ(encoding->rowCount(), 200u);
@@ -537,7 +554,8 @@ TEST_F(FrequencyPartitionEncodingTest, IndexedEliasFano_uint64) {
 TEST_F(FrequencyPartitionEncodingTest, IndexedAllIdentical_PerTierBitmaps) {
   // Edge case: all same value → one tier, no fallback.
   nimble::Vector<int32_t> data(pool_.get());
-  for (int i = 0; i < 100; ++i) data.push_back(7);
+  for (int i = 0; i < 100; ++i)
+    data.push_back(7);
   testIndexedRoundTrip(
       pool_.get(), *buffer_, data, nimble::FreqPartIndexType::PerTierBitmaps);
 }
@@ -545,7 +563,8 @@ TEST_F(FrequencyPartitionEncodingTest, IndexedAllIdentical_PerTierBitmaps) {
 TEST_F(FrequencyPartitionEncodingTest, IndexedAllUnique_EliasFano) {
   // Edge case: all unique values → no tiers, all fallback.
   nimble::Vector<int32_t> data(pool_.get());
-  for (int i = 0; i < 50; ++i) data.push_back(i * 1000);
+  for (int i = 0; i < 50; ++i)
+    data.push_back(i * 1000);
   testIndexedRoundTrip(
       pool_.get(), *buffer_, data, nimble::FreqPartIndexType::EliasFano);
 }
@@ -578,14 +597,16 @@ TEST_F(FrequencyPartitionEncodingTest, IndexedLargeSkewed_AllThreeModes) {
             opts);
   };
 
-  enc(nimble::FreqPartIndexType::PerTierBitmaps)->materialize(N, resultBitmaps.data());
-  enc(nimble::FreqPartIndexType::TierTagArray)->materialize(N, resultTags.data());
+  enc(nimble::FreqPartIndexType::PerTierBitmaps)
+      ->materialize(N, resultBitmaps.data());
+  enc(nimble::FreqPartIndexType::TierTagArray)
+      ->materialize(N, resultTags.data());
   enc(nimble::FreqPartIndexType::EliasFano)->materialize(N, resultEF.data());
 
   for (uint32_t i = 0; i < N; ++i) {
     ASSERT_EQ(resultBitmaps[i], data[i]) << "Bitmaps mismatch at " << i;
-    ASSERT_EQ(resultTags[i], data[i])    << "TagArray mismatch at "  << i;
-    ASSERT_EQ(resultEF[i], data[i])      << "EliasFano mismatch at " << i;
+    ASSERT_EQ(resultTags[i], data[i]) << "TagArray mismatch at " << i;
+    ASSERT_EQ(resultEF[i], data[i]) << "EliasFano mismatch at " << i;
   }
 }
 
@@ -597,14 +618,17 @@ TEST_F(FrequencyPartitionEncodingTest, IndexedLargeSkewed_AllThreeModes) {
 //   Fallback: none; row 15 is past the end → returns tiers_.size() == 2
 TEST_F(FrequencyPartitionEncodingTest, GetTierForRow) {
   nimble::Vector<int32_t> data(pool_.get());
-  for (int i = 0; i < 8; ++i) data.push_back(1);
-  for (int i = 0; i < 4; ++i) data.push_back(2);
-  for (int i = 0; i < 2; ++i) data.push_back(3);
+  for (int i = 0; i < 8; ++i)
+    data.push_back(1);
+  for (int i = 0; i < 4; ++i)
+    data.push_back(2);
+  for (int i = 0; i < 2; ++i)
+    data.push_back(3);
   data.push_back(4);
 
   auto encoding = createEncoding(data);
-  auto* fpe = static_cast<nimble::FrequencyPartitionEncoding<int32_t>*>(
-      encoding.get());
+  auto* fpe =
+      static_cast<nimble::FrequencyPartitionEncoding<int32_t>*>(encoding.get());
 
   // Tier 0: encoded rows 0–11
   EXPECT_EQ(fpe->getTierForRow(0), 0u);

--- a/dwio/nimble/encodings/tests/MainlyConstantEncodingTest.cpp
+++ b/dwio/nimble/encodings/tests/MainlyConstantEncodingTest.cpp
@@ -56,7 +56,8 @@ struct MainlyConstantValuesPreparer<double, TestClass> {
         test->toVector({0.0}),
         test->toVector({0.0, 0.00, 0.12}),
         test->toVector({-2.1, -2.1, -2.3, -2.1, -2.1}),
-        test->toVector({test->dNaN0, test->dNaN0, test->dNaN1, test->dNaN2, test->dNaN0})};
+        test->toVector(
+            {test->dNaN0, test->dNaN0, test->dNaN1, test->dNaN2, test->dNaN0})};
   }
 };
 
@@ -67,7 +68,8 @@ struct MainlyConstantValuesPreparer<float, TestClass> {
         test->toVector({0.0f}),
         test->toVector({0.0f, 0.00f, 0.12f}),
         test->toVector({-2.1f, -2.1f, -2.3f, -2.1f, -2.1f}),
-        test->toVector({test->fNaN0, test->fNaN0, test->fNaN1, test->fNaN2, test->fNaN2})};
+        test->toVector(
+            {test->fNaN0, test->fNaN0, test->fNaN1, test->fNaN2, test->fNaN2})};
   }
 };
 

--- a/dwio/nimble/encodings/tests/RLEEncodingTest.cpp
+++ b/dwio/nimble/encodings/tests/RLEEncodingTest.cpp
@@ -54,12 +54,24 @@ struct RleValuesPreparer<double, TestClass> {
   static std::vector<nimble::Vector<double>> prepareValues(TestClass* test) {
     return {
         test->toVector({0.0, -0.0}),
-        test->toVector({-0.0, -0.0, -0.0, -0.0, -0.0, -0.0, -0.0, -0.0, -0.0, -0.0}),
-        test->toVector({-0.0, -0.0, -0.0, +0.0, -0.0, +0.0, -0.0, -0.0, -0.0, -0.0}),
-        test->toVector({-2.1, -0.0, -0.0, 3.54, 9.87, -0.0, -0.0, -0.0, -0.0, 10.6}),
-        test->toVector({0.00, 1.11, 2.22, 3.33, 4.44, 5.55, 6.66, 7.77, 8.88, 9.99}),
         test->toVector(
-            {test->dNaN0, test->dNaN0, test->dNaN0, test->dNaN1, test->dNaN1, test->dNaN2, test->dNaN3, test->dNaN3, test->dNaN0})};
+            {-0.0, -0.0, -0.0, -0.0, -0.0, -0.0, -0.0, -0.0, -0.0, -0.0}),
+        test->toVector(
+            {-0.0, -0.0, -0.0, +0.0, -0.0, +0.0, -0.0, -0.0, -0.0, -0.0}),
+        test->toVector(
+            {-2.1, -0.0, -0.0, 3.54, 9.87, -0.0, -0.0, -0.0, -0.0, 10.6}),
+        test->toVector(
+            {0.00, 1.11, 2.22, 3.33, 4.44, 5.55, 6.66, 7.77, 8.88, 9.99}),
+        test->toVector(
+            {test->dNaN0,
+             test->dNaN0,
+             test->dNaN0,
+             test->dNaN1,
+             test->dNaN1,
+             test->dNaN2,
+             test->dNaN3,
+             test->dNaN3,
+             test->dNaN0})};
   }
 };
 
@@ -113,14 +125,24 @@ struct RleValuesPreparer<float, TestClass> {
              8.88f,
              9.99f}),
         test->toVector(
-            {test->fNaN0, test->fNaN0, test->fNaN0, test->fNaN1, test->fNaN1, test->fNaN2, test->fNaN3, test->fNaN3, test->fNaN0})};
+            {test->fNaN0,
+             test->fNaN0,
+             test->fNaN0,
+             test->fNaN1,
+             test->fNaN1,
+             test->fNaN2,
+             test->fNaN3,
+             test->fNaN3,
+             test->fNaN0})};
   }
 };
 
 template <typename TestClass>
 struct RleValuesPreparer<int32_t, TestClass> {
   static std::vector<nimble::Vector<int32_t>> prepareValues(TestClass* test) {
-    return {test->toVector({2, 3, 3}), test->toVector({1, 2, 2, 3, 3, 3, 4, 4, 4, 4})};
+    return {
+        test->toVector({2, 3, 3}),
+        test->toVector({1, 2, 2, 3, 3, 3, 4, 4, 4, 4})};
   }
 };
 

--- a/dwio/nimble/encodings/tests/TestGenerator.cpp
+++ b/dwio/nimble/encodings/tests/TestGenerator.cpp
@@ -179,8 +179,7 @@ void writeFile(
   }
 
   for (auto compressionType :
-       {nimble::CompressionType::Uncompressed,
-        nimble::CompressionType::Zstd}) {
+       {nimble::CompressionType::Uncompressed, nimble::CompressionType::Zstd}) {
     std::string_view encoded;
     if constexpr (
         nimble::test::Encoder<E>::encodingType() ==


### PR DESCRIPTION
Summary: Move GooglePolylineFunctions.cpp behind VELOX_ENABLE_GEO in CMake so OSS builds without GEOS do not compile it, declare the direct geo dependencies explicitly, and apply clang-format fixes required by the Nimble GitHub pre-commit job.

Differential Revision: D108570476


