### PR TITLE
feat(encoding): Add DominantValue in substream case to SubIntSplit encoding

### DIFF
--- a/dwio/nimble/encodings/SubIntSplitCostModels.h
+++ b/dwio/nimble/encodings/SubIntSplitCostModels.h
@@ -55,7 +55,8 @@ inline constexpr uint8_t storageWidthBits(int bw) noexcept {
 
 // Union of MetricFlags needed across all cost models below.
 inline MetricFlags allCostModelRequiredFlags() noexcept {
-  return MetricFlag::MinMax | MetricFlag::RunStats | MetricFlag::UniqueCount;
+  return MetricFlag::MinMax | MetricFlag::RunStats | MetricFlag::UniqueCount |
+      MetricFlag::DominantValue;
 }
 
 // Trivial: store each value at its native storage width.
@@ -110,6 +111,55 @@ inline double constantCostBits(
   const double headerBits =
       (6.0 + static_cast<double>(storageWidthBits(bitWidth)) / 8.0) * 8.0;
   return headerBits;
+}
+
+// MainlyConstant: store one dominant value, a SparseBool mask marking the
+// exception rows, and the exception values as a FixedBitWidth child. Effective
+// when one value dominates the segment (say >=50%).
+// Required: DominantValue, MinMax
+inline double mainlyConstantCostBits(
+    const SegmentMetrics& m,
+    size_t numValues,
+    int bitWidth) noexcept {
+  if (numValues == 0) {
+    return 0.0;
+  }
+  // Without a reliable dominant-value count (cardinality exceeded the cap)
+  // there is no dominant value and MainlyConstant cannot help.
+  if (m.dominantCountCapped || m.dominantCount == 0) {
+    return std::numeric_limits<double>::infinity();
+  }
+
+  const double storageBits = static_cast<double>(storageWidthBits(bitWidth));
+  const double storageBytes = storageBits / 8.0;
+  const size_t uncommonCount =
+      m.dominantCount >= numValues ? 0 : numValues - m.dominantCount;
+
+  // Outer: prefix(6) + two child-size fields(4 each) + the common value.
+  const double outerBits = (6.0 + 4.0 + 4.0) * 8.0 + storageBits;
+
+  // otherValues: FixedBitWidth over the uncommon values (observed range),
+  // packed bits rounded up to a byte boundary.
+  const uint8_t rangeWidth =
+      m.range == 0 ? uint8_t{0} : static_cast<uint8_t>(std::bit_width(m.range));
+  const uint8_t packedBits = static_cast<uint8_t>(
+      (std::min<uint8_t>(static_cast<uint8_t>(bitWidth), rangeWidth) + 7u) &
+      ~7u);
+
+  const double otherHeaderBits = (7.0 + storageBytes + 1.0) * 8.0;
+  const double otherValuesBits = otherHeaderBits +
+      static_cast<double>(packedBits) * static_cast<double>(uncommonCount);
+
+  const uint32_t indexWidth =
+      numValues <= 1 ? 1u : static_cast<uint32_t>(std::bit_width(numValues));
+  const double roundedIndexBits = static_cast<double>((indexWidth + 7u) & ~7u);
+  // SparseBool: prefix(6) + tag(1) + FixedBitWidth header(7 + uint32 baseline +
+  // 1)
+  const double sparseHeaderBits = (6.0 + 1.0 + 7.0 + 4.0 + 1.0) * 8.0;
+  const double isCommonBits = sparseHeaderBits +
+      roundedIndexBits * static_cast<double>(uncommonCount + 1);
+
+  return outerBits + otherValuesBits + isCommonBits;
 }
 
 // Dictionary: unique value table + bit-packed indices.
@@ -220,6 +270,9 @@ inline double bestCostBits(
       fixedBitWidthCostBits(m, numValues, bitWidth),
       EncodingType::FixedBitWidth);
   consider(constantCostBits(m, numValues, bitWidth), EncodingType::Constant);
+  consider(
+      mainlyConstantCostBits(m, numValues, bitWidth),
+      EncodingType::MainlyConstant);
   consider(rleCostBits(m, numValues, bitWidth), EncodingType::RLE);
   consider(varintCostBits(m, numValues, bitWidth), EncodingType::Varint);
   // Dictionary only when cardinality << numValues

--- a/dwio/nimble/encodings/SubIntSplitMetrics.h
+++ b/dwio/nimble/encodings/SubIntSplitMetrics.h
@@ -36,7 +36,8 @@ enum class MetricFlag : uint32_t {
   MinMax = 1u << 0, // min, max, range
   RunStats = 1u << 1, // runCount, avgRunLength
   UniqueCount = 1u << 2, // uniqueCount (raw, capped)
-  All = (1u << 3) - 1,
+  DominantValue = 1u << 3, // dominantCount (most-frequent value's frequency)
+  All = (1u << 4) - 1,
 };
 using MetricFlags = uint32_t;
 
@@ -58,6 +59,11 @@ struct SegmentMetrics {
   size_t uniqueCount{0};
   bool uniqueCountCapped{false};
 
+  // Frequency of the most common value. Used by the MainlyConstant cost model.
+  // Unreliable (and flagged capped) once cardinality exceeds the unique cap.
+  size_t dominantCount{0};
+  bool dominantCountCapped{false};
+
   size_t runCount{0};
   double avgRunLength{0.0};
 };
@@ -76,6 +82,9 @@ class MetricCollector {
     const bool doMin = hasFlag(flags, MetricFlag::MinMax);
     const bool doRun = hasFlag(flags, MetricFlag::RunStats);
     const bool doUniq = hasFlag(flags, MetricFlag::UniqueCount);
+    const bool doDominant = hasFlag(flags, MetricFlag::DominantValue);
+    // Unique count and dominant value share a single frequency map pass.
+    const bool doFreq = doUniq || doDominant;
 
     SegmentMetrics out;
     const size_t n = values.size();
@@ -92,11 +101,13 @@ class MetricCollector {
       out.runCount = 1;
     }
 
-    absl::flat_hash_map<uint64_t, uint8_t> uniqSet;
+    absl::flat_hash_map<uint64_t, uint32_t> freqMap;
     bool capped = false;
-    if (doUniq) {
-      uniqSet.reserve(std::min(n, kUniqueCountCap));
-      uniqSet.emplace(v0, 1);
+    uint32_t maxCount = 0;
+    if (doFreq) {
+      freqMap.reserve(std::min(n, kUniqueCountCap));
+      freqMap.emplace(v0, 1u);
+      maxCount = 1;
     }
 
     uint64_t prev = v0;
@@ -113,9 +124,13 @@ class MetricCollector {
       if (doRun && v != prev) {
         ++out.runCount;
       }
-      if (doUniq && !capped) {
-        uniqSet.emplace(v, 1);
-        if (uniqSet.size() > kUniqueCountCap) {
+      if (doFreq && !capped) {
+        auto [it, inserted] = freqMap.try_emplace(v, 0u);
+        const uint32_t count = ++it->second;
+        if (count > maxCount) {
+          maxCount = count;
+        }
+        if (inserted && freqMap.size() > kUniqueCountCap) {
           capped = true;
         }
       }
@@ -130,8 +145,12 @@ class MetricCollector {
           static_cast<double>(n) / static_cast<double>(out.runCount);
     }
     if (doUniq) {
-      out.uniqueCount = capped ? (kUniqueCountCap + 1) : uniqSet.size();
+      out.uniqueCount = capped ? (kUniqueCountCap + 1) : freqMap.size();
       out.uniqueCountCapped = capped;
+    }
+    if (doDominant) {
+      out.dominantCount = maxCount;
+      out.dominantCountCapped = capped;
     }
 
     return out;


### PR DESCRIPTION
Summary:
Adds a new DominantValue metric to SubIntSplitMetrics (frequency of the most-common value), computed in a shared single-pass frequency map alongside unique-count.

Adds a mainlyConstantCostBits cost model in SubIntSplitCostModels and registers MainlyConstant as a candidate encoding in the selector.

Reviewed By: apurva-meta

Differential Revision: D108506559


