### PR TITLE
perf(nimble): Drive Deserializer in-map inference off inMapPresentOffsetsList_ instead of all FlatMap children (#872)

### DIFF
--- a/dwio/nimble/serializer/Deserializer.cpp
+++ b/dwio/nimble/serializer/Deserializer.cpp
@@ -707,9 +707,34 @@ Deserializer::Deserializer(
   for (auto& [offset, decoder] : deserializerMap_) {
     deserializers_[offset] = decoder.get();
   }
-  // Size inMapPresentOffsets_ to match for flatmap present tracking.
+  // Pre-size FlatMap present-tracking state once. Both vectors are bounded
+  // by maxOffset because every value-stream anchor offset is a Type main
+  // descriptor offset already in deserializerMap_. Sizing here (rather than
+  // grow-on-demand inside createDeserializersForType) avoids repeated
+  // reallocations and lets the per-batch hot path skip a bounds check.
   if (!inMapChildTypes_.empty()) {
     inMapPresentOffsets_.resize(maxOffset + 1, false);
+    valueOffsetToInMap_.resize(maxOffset + 1, kInvalidInMapOffset);
+    // Populate the reverse-lookup table: for each top-level FlatMap child,
+    // record its inMap stream offset at every one of its value-stream
+    // anchors. The per-batch in-map inference reads this to map a present
+    // value anchor back to its owning child without re-walking the schema.
+    //
+    // visitValueStreamLeaves visits ALL value-stream offsets in the child
+    // subtree (Row recurses all children; FlatMap recurses all children).
+    // Relies on RowFieldWriter writing every field over the same
+    // OrderedRanges, so sibling Row children populate in lockstep — if any
+    // sibling's value stream is present in a batch, all are. If a future
+    // writer ever made Row children conditionally absent, the in-map
+    // inference below would over-attribute presence to keys whose first
+    // child was absent but a sibling was present.
+    for (const auto& [inMapOffset, childType] : inMapChildTypes_) {
+      visitValueStreamLeaves(
+          *childType, [this, inMapOffset](offset_size valueOffset) {
+            valueOffsetToInMap_[valueOffset] = inMapOffset;
+            return false;
+          });
+    }
   }
 }
 
@@ -737,24 +762,6 @@ void Deserializer::createDeserializersForType(
           options_.bufferPoolCapacity,
           pool_);
       inMapChildTypes_[inMapOffset] = flatMap.childAt(i).get();
-      // Precompute the value-stream offsets that the per-batch in-map
-      // detection in deserialize() will probe. Built once here so the hot
-      // path is a flat bitmap scan instead of a recursive schema walk.
-      //
-      // Visits ALL value-stream offsets in the child subtree (Row recurses
-      // all children; FlatMap recurses all children). Relies on
-      // RowFieldWriter writing every field over the same OrderedRanges, so
-      // sibling Row children populate in lockstep — if any sibling's value
-      // stream is present in a batch, all are. If a future writer ever made
-      // Row children conditionally absent, the in-map inference below would
-      // over-attribute presence to keys whose first child was absent but a
-      // sibling was present.
-      auto& valueOffsets = inMapValueStreamOffsets_[inMapOffset];
-      visitValueStreamLeaves(
-          *flatMap.childAt(i), [&valueOffsets](offset_size offset) {
-            valueOffsets.push_back(offset);
-            return false;
-          });
     }
   }
 }
@@ -827,21 +834,31 @@ void Deserializer::deserialize(
       }
     });
 
-    // Detect present in-map streams using the precomputed value-stream
-    // offsets table (built once in createDeserializersForType). Per-batch
-    // hot path is a flat bitmap scan; no recursive schema walk and no
-    // callback dispatch.
-    for (const auto& [inMapOffset, valueOffsets] : inMapValueStreamOffsets_) {
-      if (inMapPresentOffsets_[inMapOffset]) {
+    // Detect present in-map streams by driving the scan off the small set
+    // of streams actually present in this blob (inMapPresentOffsetsList_,
+    // typically dozens of entries), rather than the schema's full FlatMap
+    // child cardinality (hundreds). For each present stream offset, the
+    // reverse-lookup table maps it back to its owning FlatMap child's
+    // inMap stream offset; if that child's inMap stream itself was NOT
+    // present, the child's values are implicitly all-present in this blob
+    // and we emit an in-map segment.
+    //
+    // Caveat: if a single child has multiple value-stream anchors (e.g.,
+    // Row<A,B> as a value type) and more than one fires in the same blob,
+    // addPresentInMapSegment will be called once per present anchor — the
+    // resulting segment list may contain duplicate {startRow, endRow}
+    // entries. Downstream fillMissingFlatMapRows overlays 1s onto the
+    // default-0 inMap bitmap and is idempotent over duplicates, so output
+    // correctness is preserved. EBF (Array<Scalar> values, one anchor per
+    // child) never hits this case.
+    for (const auto offset : inMapPresentOffsetsList_) {
+      const auto inMapOffset = valueOffsetToInMap_[offset];
+      if (inMapOffset == kInvalidInMapOffset ||
+          inMapPresentOffsets_[inMapOffset]) {
         continue;
       }
-      for (const auto offset : valueOffsets) {
-        if (offset <= maxStreamOffset && inMapPresentOffsets_[offset]) {
-          DeserializerImpl::toDecoderImpl(deserializers_[inMapOffset])
-              ->addPresentInMapSegment(rowOffset, numRows);
-          break;
-        }
-      }
+      DeserializerImpl::toDecoderImpl(deserializers_[inMapOffset])
+          ->addPresentInMapSegment(rowOffset, numRows);
     }
 
     rowOffset += numRows;

--- a/dwio/nimble/serializer/Deserializer.h
+++ b/dwio/nimble/serializer/Deserializer.h
@@ -15,6 +15,8 @@
  */
 #pragma once
 
+#include <limits>
+
 #include "dwio/nimble/serializer/Options.h"
 #include "dwio/nimble/velox/FieldReader.h"
 #include "folly/container/F14Map.h"
@@ -72,13 +74,25 @@ class Deserializer {
   // the serializer). Only populated for top-level FlatMap types (depth 1).
   folly::F14FastMap<uint32_t, const Type*> inMapChildTypes_;
 
-  // Precomputed value-stream offsets per top-level FlatMap child, keyed by
-  // the child's inMap stream offset. Populated alongside inMapChildTypes_
-  // via visitValueStreamLeaves(). Used by the per-batch in-map detection in
-  // deserialize() to check whether any of a child's value streams were
-  // present, without re-walking the schema on the hot path.
-  folly::F14FastMap<uint32_t, std::vector<offset_size>>
-      inMapValueStreamOffsets_;
+  // Sentinel for `valueOffsetToInMap_` entries that are NOT a FlatMap-child
+  // value-stream anchor.
+  static constexpr uint32_t kInvalidInMapOffset =
+      std::numeric_limits<uint32_t>::max();
+
+  // Reverse-lookup table used by the per-batch in-map detection in
+  // deserialize(). `valueOffsetToInMap_[off]` is the inMap stream offset of
+  // the FlatMap child whose value-stream lives at `off`, or
+  // `kInvalidInMapOffset` for any offset that isn't a FlatMap-child
+  // value-stream anchor. Populated at construction via
+  // visitValueStreamLeaves() and indexed directly by stream offset. Sized
+  // once to `maxStreamOffset + 1` so the hot path needs no bounds check.
+  //
+  // The hot path iterates `inMapPresentOffsetsList_` (the small set of
+  // present streams in the current blob, typically dozens) and consults
+  // this table to map each present value anchor back to its owning child's
+  // inMap stream — replacing the prior 357-entry forward scan with one
+  // proportional to the number of present streams in the blob.
+  std::vector<uint32_t> valueOffsetToInMap_;
 
   // Flat boolean vector indexed by stream offset for tracking which streams
   // are present in the current batch. Replaces F14FastSet for O(1) access.


### PR DESCRIPTION
Summary:

Replaces the per-batch in-map inference's forward "walk all FlatMap
children × probe value anchors" scan with a reverse scan driven by the
set of stream offsets actually present in the current blob
(`streamPresentDirtyList_`, typically dozens of entries vs the
schema's hundreds of children).

# Why

Pre-diff:
```cpp
for (uint32_t inMapOffset = 0; inMapOffset < inMapValuesOffsets_.size();
     ++inMapOffset) {
  if (inMapValuesOffsets_[inMapOffset].empty()) continue;
  if (streamPresentBitmap_[inMapOffset]) continue;
  for (const auto offset : inMapValuesOffsets_[inMapOffset]) {
    if (offset <= maxStreamOffset && streamPresentBitmap_[offset]) {
      ...->addPresentInMapSegment(rowOffset, batchRows);
      break;
    }
  }
}
```

For EBF flatmap workloads, the outer loop trip count was `maxStreamOffset+1`
(hundreds of slots, of which roughly half are FlatMap children); the
inner loop probed each child's value anchors looking for a present one.
The work scaled as `(numChildren × avg anchors per child) × blobs`.

But every blob only has ~tens of streams actually present
(`streamPresentDirtyList_.size()`), and every present value-stream
anchor uniquely identifies the FlatMap child whose in-map status needs
inference. Iterating present streams directly and mapping each back to
its child's inMap offset turns the inference cost from
`O(numChildren × blobs)` into `O(presentStreams × blobs)`.

# How

Replaced the forward `inMapValuesOffsets_` table (`vector<vector<offset>>`
indexed by inMap offset, holding each child's value-stream anchors)
with a single reverse-lookup `valueOffsetToInMap_` (`vector<uint32_t>`
indexed by stream offset, holding the inMap offset of the child whose
value-stream lives at that offset, or `kInvalidInMapOffset` otherwise).
Populated at construction via the same `visitValueStreamLeaves` walk
that previously populated the forward table.

Pass-2 in-map inference becomes:
```cpp
for (const auto offset : streamPresentDirtyList_) {
  if (offset >= valueOffsetToInMap_.size()) continue;
  const auto inMapOffset = valueOffsetToInMap_[offset];
  if (inMapOffset == kInvalidInMapOffset) continue;
  if (streamPresentBitmap_[inMapOffset]) continue;
  ...->addPresentInMapSegment(rowOffset, batchRows);
}
```

# Trade-off — duplicate addPresentInMapSegment calls in the multi-anchor case

If a single FlatMap child has multiple value-stream anchors (e.g.,
`Row<A, B>` nested as a value type), and more than one of those anchors
fires in the same blob, the new loop calls `addPresentInMapSegment`
once per present anchor instead of once per child (the old loop's
`break` ensured a single call). `addPresentInMapSegment` does not
dedupe identical `{startRow, endRow}` entries, so duplicates land in
`presentInMapSegments_`.

Downstream `fillMissingFlatMapRows` overlays 1s onto the default-0
inMap bitmap and is idempotent over duplicates — output correctness is
preserved. The segment list grows by a constant factor; the per-segment
overlay cost is unchanged. EBF (Array<Scalar> values, one anchor per
child) never hits this case.

# Test Plan

`buck2 test fbcode//dwio/nimble/serializer/tests:tests
            fbcode//dwio/nimble/velox/tests:tests`
— 1581 passed, 0 failed.

# Perf measurements

Same-session A/B, 5 runs each at batch=2500, scan-all-no-seek,
sequential decode, no block cache, MainlyConstant SST:

| Variant                       | Decode CPU mean | µs/row | Stddev |
|-------------------------------|-----------------|--------|--------|
| Baseline (D107615247)         | 11.406 s        | 13.87  | 0.109  |
| Inverted scan (this diff)     | 9.452 s         | 11.49  | 0.102  |
| Δ                             | **−1.954 s**    | **−2.38** | — |

**−17.1% on decode CPU, p << 0.001 (Welch's t = 29.3)**.

The win is ~3× larger than the back-of-envelope estimate
(~700-800 ms saved from inMapInference alone). The extra savings come
from cache locality: replacing `vector<vector<offset>>` (scattered
heap allocations per entry) with a single flat `vector<uint32_t>`
shrinks the in-map inference working set substantially, which spills
into improved L1/L2 utilization for the surrounding
`rootReader_->next()` decode pass as well.

# Cumulative end-to-end stack progress vs original master Nimble at batch=2500

Original master Nimble: ~20 µs/row
After this diff: ~11.5 µs/row → **−42%** decode CPU vs master.

Legacy ThriftMap+CompactRaw at batch=2500: ~12.1 µs/row. Hybrid Nimble
now BEATS legacy by ~5% on this workload.

Reviewed By: xiaoxmeng

Differential Revision: D107620632


