### PR TITLE
feat(encoding): Add readWithVisitor fast path for SubIntSplit encoding

### DIFF
--- a/dwio/nimble/encodings/SubIntSplitEncoding.h
+++ b/dwio/nimble/encodings/SubIntSplitEncoding.h
@@ -37,6 +37,7 @@
 #include "dwio/nimble/encodings/selection/EncodingIdentifier.h"
 #include "dwio/nimble/encodings/selection/EncodingSelection.h"
 #include "velox/common/memory/Memory.h"
+#include "velox/dwio/common/DecoderUtil.h"
 #ifdef __AVX2__
 #include <immintrin.h>
 #endif
@@ -93,6 +94,17 @@ class SubIntSplitEncoding
   template <typename DecoderVisitor>
   void readWithVisitor(DecoderVisitor& visitor, ReadWithVisitorParams& params);
 
+  // Bulk scan method for the readWithVisitor fast path. Decodes the contiguous
+  // span covering the selected rows once, then gathers/scatters the requested
+  // positions through the visitor. Invoked by detail::readWithVisitorFast.
+  template <bool kScatter, typename Visitor>
+  void bulkScan(
+      Visitor& visitor,
+      vector_size_t currentRow,
+      const vector_size_t* selectedRows,
+      vector_size_t numSelected,
+      const vector_size_t* scatterRows);
+
   static std::string_view encode(
       EncodingSelection<physicalType>& selection,
       std::span<const physicalType> values,
@@ -115,6 +127,15 @@ class SubIntSplitEncoding
   // Persistent scratch buffer reused across materialize() calls. Sized to
   // kMaterializeChunkSize * sizeof(physicalType) bytes on first use.
   Vector<uint8_t> scratchBuf_;
+
+  // Logical read cursor (rows consumed so far). Maintained across skip(),
+  // materialize(), and the readWithVisitor slow path so the fast path can map
+  // external row numbers onto the section cursors.
+  uint32_t row_{0};
+
+  // Scratch buffer for the readWithVisitor fast path. Holds the decoded span of
+  // physical values before they are gathered/widened into the reader output.
+  Vector<physicalType> decodeBuf_;
 
   // Return the storage byte width for a section of the given bit width.
   static constexpr uint8_t sectionStorageBytes(int bitWidth) noexcept {
@@ -171,7 +192,8 @@ SubIntSplitEncoding<T>::SubIntSplitEncoding(
     const Encoding::Options& options)
     : TypedEncoding<T, physicalType>{pool, data, options},
       sections_{},
-      scratchBuf_{&pool} {
+      scratchBuf_{&pool},
+      decodeBuf_{&pool} {
   const EncodingFactory factory{options};
   const auto* pos = data.data() + this->dataOffset();
 
@@ -209,6 +231,7 @@ void SubIntSplitEncoding<T>::reset() {
   for (auto& sec : sections_) {
     sec.encoding->reset();
   }
+  row_ = 0;
 }
 
 template <typename T>
@@ -216,6 +239,7 @@ void SubIntSplitEncoding<T>::skip(uint32_t rowCount) {
   for (auto& sec : sections_) {
     sec.encoding->skip(rowCount);
   }
+  row_ += rowCount;
 }
 
 // accumulateSection: widen narrow section values into the physicalType output.
@@ -504,13 +528,42 @@ void SubIntSplitEncoding<T>::materialize(uint32_t rowCount, void* buffer) {
       }
     }
   }
+
+  row_ += rowCount;
 }
 
 template <typename T>
-template <typename DecoderVisitor>
+template <typename V>
 void SubIntSplitEncoding<T>::readWithVisitor(
-    DecoderVisitor& visitor,
+    V& visitor,
     ReadWithVisitorParams& params) {
+  using OutputType = detail::ValueType<typename V::DataType>;
+  constexpr bool kIsSuitableWidth =
+      (isFourByteIntegralType<physicalType>() ||
+       isEightByteIntegralType<physicalType>());
+  constexpr bool kIsFluidCast = sizeof(OutputType) >= sizeof(physicalType) &&
+      std::is_integral_v<OutputType> && std::is_integral_v<physicalType>;
+
+  // Fast path: bulk-decode for integral 4/8-byte physical types extracted into
+  // the reader with a compatible (at-least-as-wide integral) output type.
+  // Float/double fall through here (kIsFluidCast is false for them) and use the
+  // slow path, which applies castFromPhysicalType. The runtime useFastPath
+  // check additionally requires a deterministic filter, AVX2, and the bulk path
+  // being enabled with null+filter/hook compatibility.
+  if constexpr (
+      kIsSuitableWidth &&
+      std::is_same_v<
+          typename V::Extract,
+          velox::dwio::common::ExtractToReader> &&
+      kIsFluidCast) {
+    auto* nulls = visitor.reader().rawNullsInReadRange();
+    if (velox::dwio::common::useFastPath(visitor, nulls)) {
+      detail::readWithVisitorFast(*this, visitor, params, nulls);
+      return;
+    }
+  }
+
+  // Slow path: reconstruct one value at a time from the section encodings.
   detail::readWithVisitorSlow(
       visitor,
       params,
@@ -552,8 +605,114 @@ void SubIntSplitEncoding<T>::readWithVisitor(
             }
           }
         }
+        // Keep row_ in sync so a subsequent fast-path chunk maps rows
+        // correctly.
+        ++row_;
         return value;
       });
+}
+
+template <typename T>
+template <bool kScatter, typename V>
+void SubIntSplitEncoding<T>::bulkScan(
+    V& visitor,
+    vector_size_t currentRow,
+    const vector_size_t* selectedRows,
+    vector_size_t numSelected,
+    const vector_size_t* scatterRows) {
+  using OutputType = detail::ValueType<typename V::DataType>;
+  static_assert(
+      isFourByteIntegralType<physicalType>() ||
+          isEightByteIntegralType<physicalType>(),
+      "bulkScan only supports 4-byte or 8-byte integral types");
+
+  if (numSelected == 0) {
+    return;
+  }
+
+  const auto numRows = visitor.numRows() - visitor.rowIndex();
+
+  // Map external row numbers onto the section cursors. Nulls can make the
+  // encoding (non-null) position lag the logical row number.
+  const auto offset =
+      static_cast<int32_t>(row_) - static_cast<int32_t>(currentRow);
+
+  // The selected rows all lie within one contiguous span of stored (non-null)
+  // values. Decode that whole span once, then gather the selected positions.
+  const vector_size_t spanStart = selectedRows[0] + offset;
+  const vector_size_t spanEnd = selectedRows[numSelected - 1] + offset;
+  const uint32_t spanLength = static_cast<uint32_t>(spanEnd - spanStart + 1);
+
+  // Advance the section cursors to the start of the span.
+  if (spanStart > static_cast<vector_size_t>(row_)) {
+    skip(static_cast<uint32_t>(spanStart - static_cast<vector_size_t>(row_)));
+  }
+
+  auto* values = detail::mutableValues<OutputType>(visitor, numRows);
+
+  // Same-size integral output shares the physical bit pattern, so we can decode
+  // straight into the reader buffer; otherwise stage in decodeBuf_ and widen.
+  constexpr bool kSameSize = sizeof(physicalType) == sizeof(OutputType);
+
+  if constexpr (V::dense) {
+    // Dense: the span is exactly the selected rows (spanLength == numSelected).
+    if constexpr (kSameSize) {
+      materialize(spanLength, values);
+    } else {
+      decodeBuf_.resize(spanLength);
+      materialize(spanLength, decodeBuf_.data());
+      for (vector_size_t i = 0; i < numSelected; ++i) {
+        values[i] = static_cast<OutputType>(decodeBuf_[i]);
+      }
+    }
+  } else {
+    // Sparse: decode the span, then gather the selected positions.
+    decodeBuf_.resize(spanLength);
+    materialize(spanLength, decodeBuf_.data());
+    for (vector_size_t i = 0; i < numSelected; ++i) {
+      values[i] = static_cast<OutputType>(
+          decodeBuf_[selectedRows[i] - selectedRows[0]]);
+    }
+  }
+
+  // No scatter, filter, or hook: values are already in the output buffer.
+  if constexpr (!kScatter && !V::kHasFilter && !V::kHasHook) {
+    visitor.addNumValues(numRows);
+    visitor.setRowIndex(visitor.numRows());
+    return;
+  }
+
+  // processFixedWidthRun handles scatter (null gaps), filter evaluation, and
+  // hook forwarding. For non-hook paths it operates in place on the reader's
+  // rawValues; for hooks, values stays as the staged buffer.
+  if constexpr (!V::kHasHook) {
+    values = reinterpret_cast<OutputType*>(visitor.reader().rawValues());
+  }
+
+  auto numValues = visitor.reader().numValues();
+  int32_t* filterHits = nullptr;
+  if constexpr (V::kHasFilter) {
+    filterHits = visitor.outputRows(numSelected) - numValues;
+  }
+
+  velox::dwio::common::
+      processFixedWidthRun<OutputType, V::kFilterOnly, kScatter, V::dense>(
+          velox::RowSet(selectedRows, numSelected),
+          0,
+          numSelected,
+          scatterRows,
+          values,
+          filterHits,
+          numValues,
+          visitor.filter(),
+          visitor.hook());
+
+  if constexpr (!V::kHasHook) {
+    // Filter: count passing rows; no filter: all rows produce values.
+    visitor.addNumValues(
+        V::kHasFilter ? numValues - visitor.reader().numValues() : numRows);
+  }
+  visitor.setRowIndex(visitor.numRows());
 }
 
 template <typename T>

--- a/dwio/nimble/encodings/tests/ReadWithVisitorTest.cpp
+++ b/dwio/nimble/encodings/tests/ReadWithVisitorTest.cpp
@@ -29,10 +29,12 @@
 
 #include "dwio/nimble/common/Buffer.h"
 #include "dwio/nimble/common/tests/NimbleFileWriter.h"
+#include "dwio/nimble/encodings/SubIntSplitEncoding.h"
 #include "dwio/nimble/encodings/common/EncodingFactory.h"
 #include "dwio/nimble/encodings/common/EncodingUtils.h"
 #include "dwio/nimble/encodings/legacy/EncodingFactory.h"
 #include "dwio/nimble/encodings/legacy/EncodingUtils.h"
+#include "dwio/nimble/encodings/selection/EncodingSelectionPolicy.h"
 #include "dwio/nimble/encodings/tests/EncodingLayoutTestHelper.h"
 #include "dwio/nimble/velox/selective/ByteColumnReader.h"
 #include "dwio/nimble/velox/selective/ColumnReader.h"
@@ -108,6 +110,70 @@ class StringColumnReaderTestAccessor : public StringColumnReader {
     readOffset_ += rows.back() + 1;
   }
 };
+
+// ---------------------------------------------------------------------------
+// SubIntSplit test support.
+//
+// SubIntSplit is not yet wired into the EncodingFactory dispatch, so we build
+// the encoding directly: encode via the static encode() with a policy that
+// never recurses back into SubIntSplit for the section sub-streams, then
+// construct the typed encoding (its constructor decodes the sections via the
+// regular factory) and call readWithVisitor on it directly.
+// ---------------------------------------------------------------------------
+template <typename T>
+class NonRecursiveSubIntSplitPolicy final : public EncodingSelectionPolicy<T> {
+  using physicalType = typename TypeTraits<T>::physicalType;
+
+ public:
+  EncodingSelectionResult select(
+      std::span<const physicalType> /* values */,
+      const Statistics<physicalType>& /* statistics */) override {
+    return {.encodingType = EncodingType::SubIntSplit};
+  }
+
+  EncodingSelectionResult selectNullable(
+      std::span<const physicalType> /* values */,
+      std::span<const bool> /* nulls */,
+      const Statistics<physicalType>& /* statistics */) override {
+    return {.encodingType = EncodingType::Nullable};
+  }
+
+  std::unique_ptr<EncodingSelectionPolicyBase> createImpl(
+      EncodingType /* encodingType */,
+      NestedEncodingIdentifier /* identifier */,
+      DataType type) override {
+    auto readFactors =
+        ManualEncodingSelectionPolicyFactory::defaultReadFactors();
+    readFactors.erase(
+        std::remove_if(
+            readFactors.begin(),
+            readFactors.end(),
+            [](const auto& factor) {
+              return factor.first == EncodingType::SubIntSplit;
+            }),
+        readFactors.end());
+    ManualEncodingSelectionPolicyFactory factory{
+        std::move(readFactors), std::nullopt};
+    return factory.createPolicy(type);
+  }
+};
+
+template <typename T>
+std::unique_ptr<SubIntSplitEncoding<T>> makeSubIntSplitEncoding(
+    const std::vector<T>& data,
+    Buffer& buffer,
+    velox::memory::MemoryPool& memPool) {
+  using PhysicalType = typename TypeTraits<T>::physicalType;
+  auto span = std::span<const PhysicalType>(
+      reinterpret_cast<const PhysicalType*>(data.data()), data.size());
+  EncodingSelection<PhysicalType> selection{
+      {.encodingType = EncodingType::SubIntSplit},
+      Statistics<PhysicalType>::create(span),
+      std::make_unique<NonRecursiveSubIntSplitPolicy<T>>()};
+  auto encoded = SubIntSplitEncoding<T>::encode(selection, span, buffer);
+  return std::make_unique<SubIntSplitEncoding<T>>(
+      memPool, encoded, [](uint32_t) { return nullptr; });
+}
 
 // ---------------------------------------------------------------------------
 // Test fixture
@@ -4364,6 +4430,189 @@ TEST_P(
   for (int i = 0; i < numSelected; ++i) {
     EXPECT_EQ(values[i], data[rowVec[i]])
         << "selected row " << rowVec[i] << " at index " << i;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// SubIntSplitEncoding<int64_t> + AlwaysTrue + dense
+// Exercises the no-filter dense fast path for the 8-byte physical type.
+// ---------------------------------------------------------------------------
+TEST_P(ReadWithVisitorTest, encodingLevelSubIntSplitAlwaysTrueDense) {
+  constexpr int kRows = 500;
+
+  // Values share a high prefix so the splitter produces multiple sections.
+  std::vector<int64_t> data(kRows);
+  for (int i = 0; i < kRows; ++i) {
+    data[i] = static_cast<int64_t>(0x1234560000000000LL + i);
+  }
+
+  auto input = makeRowVector({makeFlatVector<int64_t>(
+      kRows, [](auto i) { return 0x1234560000000000LL + i; })});
+  auto rowType = asRowType(input->type());
+  auto ctx = makeFileContext(input);
+  auto scanSpec = std::make_shared<common::ScanSpec>("root");
+  scanSpec->addAllChildFields(*rowType);
+  scanSpec->childByName("c0")->setFilter(
+      std::make_unique<common::AlwaysTrue>());
+  auto root = buildReader(*ctx, rowType, *scanSpec);
+
+  auto* structReader =
+      dynamic_cast<dwio::common::SelectiveStructColumnReaderBase*>(root.get());
+  auto* reader = static_cast<IntegerColumnReaderTestAccessor*>(
+      dynamic_cast<IntegerColumnReader*>(structReader->children()[0]));
+  ASSERT_NE(reader, nullptr);
+
+  std::vector<vector_size_t> rowVec(kRows);
+  std::iota(rowVec.begin(), rowVec.end(), 0);
+  RowSet rows(rowVec.data(), rowVec.size());
+
+  reader->doPrepareRead<int64_t>(0, rows, nullptr);
+
+  Buffer buffer(*pool());
+  auto encoding = makeSubIntSplitEncoding<int64_t>(data, buffer, *pool());
+
+  common::AlwaysTrue filter;
+  dwio::common::ExtractToReader extractValues(reader);
+  constexpr bool kIsDense = true;
+  DecoderVisitor<
+      int64_t,
+      common::AlwaysTrue,
+      dwio::common::ExtractToReader,
+      kIsDense>
+      visitor(filter, reader, rows, extractValues);
+  auto params = makeReadWithVisitorParams(visitor, rows, pool());
+
+  encoding->readWithVisitor(visitor, params);
+
+  EXPECT_EQ(reader->numValues(), kRows);
+  auto values = getValues<int64_t>(reader);
+  for (int i = 0; i < kRows; ++i) {
+    EXPECT_EQ(values[i], data[i]) << "row " << i;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// SubIntSplitEncoding<int64_t> + BigintRange + sparse
+// Exercises the sparse gather + filter fast path.
+// ---------------------------------------------------------------------------
+TEST_P(ReadWithVisitorTest, encodingLevelSubIntSplitBigintRangeSparse) {
+  constexpr int kRows = 500;
+
+  // Small-range data so a BigintRange filter selects a meaningful subset.
+  std::vector<int64_t> data(kRows);
+  for (int i = 0; i < kRows; ++i) {
+    data[i] = i % 16;
+  }
+
+  auto input = makeRowVector(
+      {makeFlatVector<int64_t>(kRows, [](auto i) { return i % 16; })});
+  auto rowType = asRowType(input->type());
+  auto ctx = makeFileContext(input);
+  auto scanSpec = std::make_shared<common::ScanSpec>("root");
+  scanSpec->addAllChildFields(*rowType);
+  scanSpec->childByName("c0")->setFilter(
+      std::make_unique<common::BigintRange>(5, 10, false));
+  auto root = buildReader(*ctx, rowType, *scanSpec);
+
+  auto* structReader =
+      dynamic_cast<dwio::common::SelectiveStructColumnReaderBase*>(root.get());
+  auto* reader = static_cast<IntegerColumnReaderTestAccessor*>(
+      dynamic_cast<IntegerColumnReader*>(structReader->children()[0]));
+  ASSERT_NE(reader, nullptr);
+
+  // Sparse RowSet: every other row.
+  std::vector<vector_size_t> rowVec;
+  for (int i = 0; i < kRows; i += 2) {
+    rowVec.push_back(i);
+  }
+  RowSet rows(rowVec.data(), rowVec.size());
+
+  reader->doPrepareRead<int64_t>(0, rows, nullptr);
+
+  Buffer buffer(*pool());
+  auto encoding = makeSubIntSplitEncoding<int64_t>(data, buffer, *pool());
+
+  common::BigintRange filter(5, 10, false);
+  dwio::common::ExtractToReader extractValues(reader);
+  constexpr bool kIsDense = false;
+  DecoderVisitor<
+      int64_t,
+      common::BigintRange,
+      dwio::common::ExtractToReader,
+      kIsDense>
+      visitor(filter, reader, rows, extractValues);
+  auto params = makeReadWithVisitorParams(visitor, rows, pool());
+
+  encoding->readWithVisitor(visitor, params);
+
+  int expected = 0;
+  for (int i = 0; i < kRows; i += 2) {
+    if (data[i] >= 5 && data[i] <= 10) {
+      ++expected;
+    }
+  }
+  EXPECT_EQ(reader->numValues(), expected);
+  auto values = getValues<int64_t>(reader);
+  for (int i = 0; i < reader->numValues(); ++i) {
+    EXPECT_GE(values[i], 5);
+    EXPECT_LE(values[i], 10);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// SubIntSplitEncoding<int32_t> + AlwaysTrue + dense
+// Exercises the dense fast path for the 4-byte physical type.
+// ---------------------------------------------------------------------------
+TEST_P(ReadWithVisitorTest, encodingLevelSubIntSplitInt32AlwaysTrueDense) {
+  constexpr int kRows = 500;
+
+  std::vector<int32_t> data(kRows);
+  for (int i = 0; i < kRows; ++i) {
+    data[i] = static_cast<int32_t>(0x12340000 + i);
+  }
+
+  auto input = makeRowVector(
+      {makeFlatVector<int32_t>(kRows, [](auto i) { return 0x12340000 + i; })});
+  auto rowType = asRowType(input->type());
+  auto ctx = makeFileContext(input);
+  auto scanSpec = std::make_shared<common::ScanSpec>("root");
+  scanSpec->addAllChildFields(*rowType);
+  scanSpec->childByName("c0")->setFilter(
+      std::make_unique<common::AlwaysTrue>());
+  auto root = buildReader(*ctx, rowType, *scanSpec);
+
+  auto* structReader =
+      dynamic_cast<dwio::common::SelectiveStructColumnReaderBase*>(root.get());
+  auto* reader = static_cast<IntegerColumnReaderTestAccessor*>(
+      dynamic_cast<IntegerColumnReader*>(structReader->children()[0]));
+  ASSERT_NE(reader, nullptr);
+
+  std::vector<vector_size_t> rowVec(kRows);
+  std::iota(rowVec.begin(), rowVec.end(), 0);
+  RowSet rows(rowVec.data(), rowVec.size());
+
+  reader->doPrepareRead<int32_t>(0, rows, nullptr);
+
+  Buffer buffer(*pool());
+  auto encoding = makeSubIntSplitEncoding<int32_t>(data, buffer, *pool());
+
+  common::AlwaysTrue filter;
+  dwio::common::ExtractToReader extractValues(reader);
+  constexpr bool kIsDense = true;
+  DecoderVisitor<
+      int32_t,
+      common::AlwaysTrue,
+      dwio::common::ExtractToReader,
+      kIsDense>
+      visitor(filter, reader, rows, extractValues);
+  auto params = makeReadWithVisitorParams(visitor, rows, pool());
+
+  encoding->readWithVisitor(visitor, params);
+
+  EXPECT_EQ(reader->numValues(), kRows);
+  auto values = getValues<int32_t>(reader);
+  for (int i = 0; i < kRows; ++i) {
+    EXPECT_EQ(values[i], data[i]) << "row " << i;
   }
 }
 


### PR DESCRIPTION
Summary: SubIntSplitEncoding only had a slow `readWithVisitor` path that reconstructed each value one section at a time (one `materialize(1, ...)` virtual call per section per row). This adds a bulk fast path.

Reviewed By: apurva-meta

Differential Revision: D108570504


