### PR TITLE
perf: Deduplicate aliased streams in index projector kTablet output

### DIFF
--- a/dwio/nimble/serializer/DeserializerImpl.h
+++ b/dwio/nimble/serializer/DeserializerImpl.h
@@ -216,23 +216,46 @@ class StreamDataReader {
   /// over hundreds of keys).
   template <typename Callback>
   void iterateStreams(Callback&& callback) {
-    if (nonLegacyFormat(version_)) {
-      // kLegacyCompact/kTablet/kSerialization/kProjection: stream sizes are
-      // packed into a sparse trailer at the end of the blob. Production blobs
-      // at kLegacyCompact are decoded via the legacy reader (frozen snapshot of
-      // the pre-two-array wire format); all newer versions go through the new
-      // two-array sparse trailer reader. Reusable member buffers keep this
-      // path alloc-free across blobs.
-      if (usesLegacyTrailer(version_)) {
-        legacy::readLegacyTrailerStreamMetadata(
-            end_, streamIndices_, streamSizes_);
-      } else {
-        detail::readTrailerStreamMetadata(end_, streamIndices_, streamSizes_);
-      }
-      const bool isTablet = isTabletVersion(version_);
-      const size_t numStreams = streamIndices_.size();
+    if (isTabletVersion(version_)) {
+      // kTablet: the trailer stores stream ids, per-stream size indices, and
+      // unique sizes. Per-slot sizes and body offsets are reconstructed from
+      // (sizeIndex, uniqueSizes); duplicate slots resolve to a single body
+      // extent, so streams are addressed by the reconstructed offset rather
+      // than walked sequentially.
+      detail::readTrailerStreamMetadata(
+          end_,
+          streamIds_,
+          streamOffsets_,
+          streamSizes_,
+          uniqueStreamSizesScratch_);
+      const char* const bodyBase = pos_;
+      const size_t numStreams = streamIds_.size();
       for (size_t entryIdx = 0; entryIdx < numStreams; ++entryIdx) {
-        const uint32_t streamOffset = streamIndices_[entryIdx];
+        const uint32_t streamId = streamIds_[entryIdx];
+        const uint32_t streamSize = streamSizes_[entryIdx];
+        std::string_view streamData(
+            bodyBase + streamOffsets_[entryIdx], streamSize);
+        // kTablet stream data includes tablet chunk headers:
+        // [chunkSize:u32][compressionType:1B][encoded_data...]. Strip headers
+        // and decompress if needed before handing off.
+        callback(streamId, stripChunkHeaders(streamData));
+      }
+      pos_ = end_; // Skip past trailer.
+    } else if (nonLegacyFormat(version_)) {
+      // kLegacyCompact/kSerialization/kProjection: sizes-only sparse trailer.
+      // Each stream's body offset is the prefix sum of preceding sizes, so
+      // streams are walked sequentially. Production blobs at kLegacyCompact are
+      // decoded via the legacy reader (frozen snapshot of the pre-two-array
+      // wire format); newer versions use the two-array sparse trailer reader.
+      // Reusable member buffers keep this path alloc-free across blobs.
+      if (usesLegacyTrailer(version_)) {
+        legacy::readLegacyTrailerStreamMetadata(end_, streamIds_, streamSizes_);
+      } else {
+        detail::readTrailerStreamMetadata(end_, streamIds_, streamSizes_);
+      }
+      const size_t numStreams = streamIds_.size();
+      for (size_t entryIdx = 0; entryIdx < numStreams; ++entryIdx) {
+        const uint32_t streamId = streamIds_[entryIdx];
         const uint32_t streamSize = streamSizes_[entryIdx];
         // Writer invariant: the sparse trailer only encodes non-zero stream
         // slots (SerializerImpl.h writeTrailer skips streamSizes[i]==0).
@@ -241,14 +264,7 @@ class StreamDataReader {
             streamSize, 0, "Sparse trailer must not encode zero-sized stream");
         std::string_view streamData(pos_, streamSize);
         pos_ += streamSize;
-        if (isTablet) {
-          // kTablet: stream data includes tablet chunk headers:
-          // [chunkSize:u32][compressionType:1B][encoded_data...]
-          // Strip headers and decompress if needed before handing off.
-          callback(streamOffset, stripChunkHeaders(streamData));
-        } else {
-          callback(streamOffset, streamData);
-        }
+        callback(streamId, streamData);
       }
       pos_ = end_; // Skip past trailer.
     } else {
@@ -326,14 +342,21 @@ class StreamDataReader {
   const char* end_{nullptr};
   // Reusable buffer for chunk header stripping (compressed/multi-chunk case).
   Vector<char> chunkStrippingBuffer_;
-  // Reusable parallel buffers for the per-blob sparse trailer. Refilled by
-  // iterateStreams() on the kLegacyCompact/kTablet path: streamIndices_
-  // holds the offsets of non-zero stream slots (sorted ascending);
-  // streamSizes_ holds the corresponding byte sizes. Sized to the same
-  // length, cleared+filled in place each blob to keep the hot path
-  // alloc-free across invocations.
-  std::vector<uint32_t> streamIndices_;
+  // Reusable parallel buffers for the per-blob trailer. Refilled by
+  // iterateStreams(): streamIds_ holds the ids of non-zero stream slots (sorted
+  // ascending) and streamSizes_ their byte sizes. For kTablet,
+  // streamOffsets_ additionally holds each slot's body offset; with the
+  // kTablet dedup trailer those offsets and sizes are reconstructed from the
+  // per-slot size indices and the unique-size table (duplicate slots resolve
+  // to a shared offset). The sizes-only formats leave streamOffsets_ empty and
+  // derive offsets by prefix-summing sizes. uniqueStreamSizesScratch_ is reused
+  // across blobs for the unique stream table: decoded as sizes, then
+  // transformed in place into unique-offset prefix sums to keep the hot path
+  // alloc-free.
+  std::vector<uint32_t> streamIds_;
+  std::vector<uint32_t> streamOffsets_;
   std::vector<uint32_t> streamSizes_;
+  std::vector<uint32_t> uniqueStreamSizesScratch_;
 };
 
 } // namespace facebook::nimble::serde

--- a/dwio/nimble/serializer/SerializerImpl.cpp
+++ b/dwio/nimble/serializer/SerializerImpl.cpp
@@ -250,20 +250,20 @@ size_t estimateSectionSize(EncodingType encodingType, size_t count) {
   }
 }
 
-// Decodes a two-array sparse trailer into parallel `streamIndices` and
+// Decodes a two-array sparse trailer into parallel `streamIds` and
 // `streamSizes` arrays. Validates that the per-section decoders consume
-// exactly the trailer payload and that
-// `streamIndices.size() == streamSizes.size()`.
+// exactly the trailer payload and that `streamIds.size() ==
+// streamSizes.size()`.
 void decodeTrailerStreamMetadata(
     const char* trailerStart,
     uint32_t trailerSize,
-    std::vector<uint32_t>& streamIndices,
+    std::vector<uint32_t>& streamIds,
     std::vector<uint32_t>& streamSizes) {
   const auto* trailerEnd = trailerStart + trailerSize;
   const char* payload = trailerStart;
   const auto indicesEncodingType =
       static_cast<EncodingType>(static_cast<uint8_t>(*payload++));
-  decodeSection(indicesEncodingType, payload, trailerEnd, streamIndices);
+  decodeSection(indicesEncodingType, payload, trailerEnd, streamIds);
   const auto sizesEncodingType =
       static_cast<EncodingType>(static_cast<uint8_t>(*payload++));
   decodeSection(sizesEncodingType, payload, trailerEnd, streamSizes);
@@ -274,11 +274,77 @@ void decodeTrailerStreamMetadata(
       payload - trailerStart,
       trailerSize);
   NIMBLE_CHECK_EQ(
-      streamIndices.size(),
+      streamIds.size(),
       streamSizes.size(),
-      "Trailer indices/sizes section count mismatch: indices={} sizes={}",
-      streamIndices.size(),
-      streamSizes.size());
+      "Trailer indices/sizes section count mismatch");
+}
+
+// Decodes the kTablet dedup trailer layout (streamIds, sizeIndices,
+// uniqueSizes) and reconstructs the parallel `streamIds`, `streamOffsets`,
+// and `streamSizes` arrays. The sizeIndices section stores, for each present
+// stream slot, the unique body stream it aliases. `streamOffsets` is reused as
+// scratch for those unique-stream indices before being overwritten with
+// reconstructed body offsets; `uniqueStreamSizes` receives the decoded
+// unique-size table and is then transformed in place into exclusive prefix-sum
+// offsets.
+void decodeTrailerStreamMetadata(
+    const char* trailerStart,
+    uint32_t trailerSize,
+    std::vector<uint32_t>& streamIds,
+    std::vector<uint32_t>& streamOffsets,
+    std::vector<uint32_t>& streamSizes,
+    std::vector<uint32_t>& uniqueStreamSizes) {
+  const auto* trailerEnd = trailerStart + trailerSize;
+  const char* payload = trailerStart;
+  const auto streamIdsEncodingType =
+      static_cast<EncodingType>(static_cast<uint8_t>(*payload++));
+  decodeSection(streamIdsEncodingType, payload, trailerEnd, streamIds);
+  const auto sizeIndicesEncodingType =
+      static_cast<EncodingType>(static_cast<uint8_t>(*payload++));
+  // streamOffsets temporarily holds the per-slot unique stream index; it is
+  // overwritten with the reconstructed body offset below.
+  decodeSection(sizeIndicesEncodingType, payload, trailerEnd, streamOffsets);
+  const auto uniqueSizesEncodingType =
+      static_cast<EncodingType>(static_cast<uint8_t>(*payload++));
+  decodeSection(
+      uniqueSizesEncodingType, payload, trailerEnd, uniqueStreamSizes);
+  NIMBLE_CHECK_EQ(
+      payload,
+      trailerEnd,
+      "Trailer size mismatch: read {} bytes, expected {}",
+      payload - trailerStart,
+      trailerSize);
+  NIMBLE_CHECK_EQ(
+      streamIds.size(),
+      streamOffsets.size(),
+      "Trailer streamIds/sizeIndices section count mismatch");
+
+  const auto numStreams = streamIds.size();
+  const auto numUniqueStreams = uniqueStreamSizes.size();
+  streamSizes.resize(numStreams);
+  // Expand per-slot sizes from the unique-size table.
+  for (size_t i = 0; i < numStreams; ++i) {
+    const auto uniqueStreamIndex = streamOffsets[i];
+    NIMBLE_CHECK_LT(
+        uniqueStreamIndex,
+        numUniqueStreams,
+        "Unique stream index out of range");
+    streamSizes[i] = uniqueStreamSizes[uniqueStreamIndex];
+  }
+  // Transform uniqueStreamSizes in place into exclusive prefix-sum body
+  // offsets.
+  uint32_t nextBodyOffset{0};
+  for (size_t i = 0; i < numUniqueStreams; ++i) {
+    const auto sizeValue = uniqueStreamSizes[i];
+    uniqueStreamSizes[i] = nextBodyOffset;
+    nextBodyOffset += sizeValue;
+  }
+  // Expand per-slot body offsets from the unique-offset table.
+  // streamOffsets[i] currently holds the unique stream index; read it, then
+  // overwrite with the resolved offset.
+  for (size_t i = 0; i < numStreams; ++i) {
+    streamOffsets[i] = uniqueStreamSizes[streamOffsets[i]];
+  }
 }
 
 } // namespace
@@ -344,26 +410,45 @@ encode(const SerializerOptions& options, std::string_view input, char* output) {
 
 void readTrailerStreamMetadata(
     const char* end,
-    std::vector<uint32_t>& streamIndices,
+    std::vector<uint32_t>& streamIds,
     std::vector<uint32_t>& streamSizes) {
   const uint32_t trailerSize = readTrailerSize(end);
   NIMBLE_CHECK_LE(
       trailerSize,
       kMaxTrailerBytes,
-      "Trailer size sanity cap exceeded (likely buffer corruption): {} > {}",
-      trailerSize,
-      kMaxTrailerBytes);
+      "Trailer size sanity cap exceeded (likely buffer corruption)");
   const char* trailerStart = end - sizeof(uint32_t) - trailerSize;
   decodeTrailerStreamMetadata(
-      trailerStart, trailerSize, streamIndices, streamSizes);
+      trailerStart, trailerSize, streamIds, streamSizes);
 }
 
 std::pair<std::vector<uint32_t>, std::vector<uint32_t>>
 readTrailerStreamMetadata(const char* end) {
-  std::vector<uint32_t> streamIndices;
+  std::vector<uint32_t> streamIds;
   std::vector<uint32_t> streamSizes;
-  readTrailerStreamMetadata(end, streamIndices, streamSizes);
-  return {std::move(streamIndices), std::move(streamSizes)};
+  readTrailerStreamMetadata(end, streamIds, streamSizes);
+  return {std::move(streamIds), std::move(streamSizes)};
+}
+
+void readTrailerStreamMetadata(
+    const char* end,
+    std::vector<uint32_t>& streamIds,
+    std::vector<uint32_t>& streamOffsets,
+    std::vector<uint32_t>& streamSizes,
+    std::vector<uint32_t>& uniqueStreamSizesScratch) {
+  const uint32_t trailerSize = readTrailerSize(end);
+  NIMBLE_CHECK_LE(
+      trailerSize,
+      kMaxTrailerBytes,
+      "Trailer size sanity cap exceeded (likely buffer corruption)");
+  const char* trailerStart = end - sizeof(uint32_t) - trailerSize;
+  decodeTrailerStreamMetadata(
+      trailerStart,
+      trailerSize,
+      streamIds,
+      streamOffsets,
+      streamSizes,
+      uniqueStreamSizesScratch);
 }
 
 std::pair<std::vector<uint32_t>, std::vector<uint32_t>>
@@ -387,27 +472,23 @@ readTrailerStreamMetadata(const folly::IOBuf& input) {
   NIMBLE_CHECK_LE(
       trailerSize,
       kMaxTrailerBytes,
-      "Trailer size sanity cap exceeded (likely buffer corruption): {} > {}",
-      trailerSize,
-      kMaxTrailerBytes);
+      "Trailer size sanity cap exceeded (likely buffer corruption)");
   // Bound trailerSize against the actual IOBuf chain length so a corrupted
   // value cannot drive a huge std::string allocation.
   NIMBLE_CHECK_LE(
       static_cast<uint64_t>(trailerSize) + sizeof(uint32_t),
       totalLength,
-      "Trailer size exceeds IOBuf chain length: trailerSize={}, chain={}",
-      trailerSize,
-      totalLength);
+      "Trailer size exceeds IOBuf chain length");
 
   folly::io::Cursor sizesCursor(&input);
   sizesCursor.skip(totalLength - sizeof(uint32_t) - trailerSize);
   std::string trailerBuf(trailerSize, '\0');
   sizesCursor.pull(trailerBuf.data(), trailerSize);
-  std::vector<uint32_t> streamIndices;
+  std::vector<uint32_t> streamIds;
   std::vector<uint32_t> streamSizes;
   decodeTrailerStreamMetadata(
-      trailerBuf.data(), trailerSize, streamIndices, streamSizes);
-  return {std::move(streamIndices), std::move(streamSizes)};
+      trailerBuf.data(), trailerSize, streamIds, streamSizes);
+  return {std::move(streamIds), std::move(streamSizes)};
 }
 
 size_t estimateTrailerSize(
@@ -423,6 +504,24 @@ size_t estimateTrailerSize(
       estimateSectionSize(sizesEncodingType, numStreams) + sizeof(uint32_t);
 }
 
+size_t estimateTrailerSize(
+    size_t numPresentStreams,
+    size_t numUniqueStreams,
+    EncodingType streamIdsEncodingType,
+    EncodingType sizeIndicesEncodingType,
+    EncodingType uniqueSizesEncodingType) {
+  // [streamIdsEncType:1B][streamIdsPayload]
+  // [sizeIndicesEncType:1B][sizeIndicesPayload]
+  // [uniqueSizesEncType:1B][uniqueSizesPayload][trailer_size:u32]
+  return sizeof(uint8_t) +
+      estimateSectionSize(streamIdsEncodingType, numPresentStreams) +
+      sizeof(uint8_t) +
+      estimateSectionSize(sizeIndicesEncodingType, numPresentStreams) +
+      sizeof(uint8_t) +
+      estimateSectionSize(uniqueSizesEncodingType, numUniqueStreams) +
+      sizeof(uint32_t);
+}
+
 std::vector<std::string_view> parseStreams(
     const char* pos,
     const char* end,
@@ -433,26 +532,25 @@ std::vector<std::string_view> parseStreams(
   std::vector<std::string_view> streams;
 
   if (isCompactFormat(version)) {
-    // Walk the sparse (streamIndices, streamSizes) trailer and place each
+    // Walk the sparse (streamIds, streamSizes) trailer and place each
     // stream at its offset slot. Gaps remain empty string_views. Legacy
     // kLegacyCompact blobs are decoded via the frozen legacy reader.
-    auto [streamIndices, streamSizes] = usesLegacyTrailer(version)
+    auto [streamIds, streamSizes] = usesLegacyTrailer(version)
         ? legacy::readLegacyTrailerStreamMetadata(end)
         : readTrailerStreamMetadata(end);
-    if (!streamIndices.empty()) {
-      streams.resize(streamIndices.back() + 1);
-      for (size_t k = 0; k < streamIndices.size(); ++k) {
+    if (!streamIds.empty()) {
+      streams.resize(streamIds.back() + 1);
+      for (size_t i = 0; i < streamIds.size(); ++i) {
         // NOLINTNEXTLINE(facebook-hte-LocalUncheckedArrayBounds)
-        streams[streamIndices[k]] = std::string_view(pos, streamSizes[k]);
-        pos += streamSizes[k];
+        streams[streamIds[i]] = std::string_view(pos, streamSizes[i]);
+        pos += streamSizes[i];
       }
     }
   } else {
     NIMBLE_CHECK_EQ(
         version,
         SerializationVersion::kLegacy,
-        "unexpected version {}",
-        version);
+        "Unexpected serialization version");
     // kLegacy format: inline [size:u32][data]...
     while (pos < end) {
       streams.emplace_back(readStream<false>(pos));

--- a/dwio/nimble/serializer/SerializerImpl.h
+++ b/dwio/nimble/serializer/SerializerImpl.h
@@ -21,6 +21,7 @@
 #include <cstring>
 #include <optional>
 #include <string>
+#include <tuple>
 #include <unordered_map>
 #include <vector>
 
@@ -121,6 +122,17 @@ size_t estimateTrailerSize(
     size_t numStreams,
     EncodingType indicesEncodingType,
     EncodingType sizesEncodingType);
+
+/// Returns an upper-bound estimate for the kTablet dedup trailer layout:
+/// present stream IDs, per-present-stream size indices, and unique stream
+/// sizes. `numPresentStreams` is the number of present streams;
+/// `numUniqueStreams` is the number of streams with unique content.
+size_t estimateTrailerSize(
+    size_t numPresentStreams,
+    size_t numUniqueStreams,
+    EncodingType streamIdsEncodingType,
+    EncodingType sizeIndicesEncodingType,
+    EncodingType uniqueSizesEncodingType);
 
 /// Overload that accepts SerializationVersion for API compatibility.
 inline size_t estimateTrailerSize(
@@ -280,6 +292,51 @@ void writeTrailer(
   encoding::writeUint32(trailerSize, sizePos);
 }
 
+/// Writes the kTablet dedup trailer layout used when projected streams may be
+/// duplicated. The caller supplies the three trailer sections directly:
+/// `streamIds` (present slot ids),
+/// `streamSizeIndices` (per present slot, an index into `uniqueStreamSizes`),
+/// and `uniqueStreamSizes` (the distinct stream sizes in body order). Neither
+/// offsets nor duplicated sizes are stored: offsets are implied by
+/// prefix-summing `uniqueStreamSizes`, and duplicate slots reuse a unique-size
+/// entry through `streamSizeIndices`. The caller chooses the encoding for each
+/// section. Wire:
+/// [streamIdsEncType:1B][streamIdsPayload]
+///       [sizeIndicesEncType:1B][sizeIndicesPayload]
+///       [uniqueSizesEncType:1B][uniqueSizesPayload][trailer_size:u32]
+template <typename T>
+void writeTrailer(
+    const std::vector<uint32_t>& streamIds,
+    const std::vector<uint32_t>& streamSizeIndices,
+    const std::vector<uint32_t>& uniqueStreamSizes,
+    EncodingType streamIdsEncodingType,
+    EncodingType sizeIndicesEncodingType,
+    EncodingType uniqueSizesEncodingType,
+    T& buffer) {
+  NIMBLE_CHECK_EQ(
+      streamSizeIndices.size(),
+      streamIds.size(),
+      "Stream ids and size indices must have the same length");
+
+  const auto trailerStartOffset = buffer.size();
+  auto* streamIdsTypePos = extend(buffer, sizeof(uint8_t));
+  *streamIdsTypePos = static_cast<char>(streamIdsEncodingType);
+  writeSection(streamIdsEncodingType, streamIds, buffer);
+
+  auto* sizeIndicesTypePos = extend(buffer, sizeof(uint8_t));
+  *sizeIndicesTypePos = static_cast<char>(sizeIndicesEncodingType);
+  writeSection(sizeIndicesEncodingType, streamSizeIndices, buffer);
+
+  auto* uniqueSizesTypePos = extend(buffer, sizeof(uint8_t));
+  *uniqueSizesTypePos = static_cast<char>(uniqueSizesEncodingType);
+  writeSection(uniqueSizesEncodingType, uniqueStreamSizes, buffer);
+
+  const uint32_t trailerSize =
+      static_cast<uint32_t>(buffer.size() - trailerStartOffset);
+  auto* sizePos = extend(buffer, sizeof(uint32_t));
+  encoding::writeUint32(trailerSize, sizePos);
+}
+
 /// Writes a single stream to the buffer.
 /// Writes [size][data...] where size is varint (useVarint=true) or u32
 /// (useVarint=false).
@@ -341,18 +398,18 @@ void skipStream(const char*& pos) {
 }
 
 /// Reads the two-array sparse stream-sizes trailer from the end of a
-/// contiguous buffer. Fills `streamIndices` (offsets of non-zero stream
-/// slots, sorted ascending) and `streamSizes` (their byte sizes), parallel
-/// arrays of identical length. Both vectors are reusable buffers owned by
+/// contiguous buffer. Fills `streamIds` (non-zero stream slot ids, sorted
+/// ascending) and `streamSizes` (their byte sizes), parallel arrays of
+/// identical length. Both vectors are reusable buffers owned by
 /// the caller (e.g. members on `StreamDataReader`) to keep the per-blob hot
 /// path alloc-free across invocations.
 void readTrailerStreamMetadata(
     const char* end,
-    std::vector<uint32_t>& streamIndices,
+    std::vector<uint32_t>& streamIds,
     std::vector<uint32_t>& streamSizes);
 
 /// Value-returning convenience overload for cold-path consumers
-/// (tests, dump tools). Returns parallel (streamIndices, streamSizes) arrays.
+/// (tests, dump tools). Returns parallel (streamIds, streamSizes) arrays.
 std::pair<std::vector<uint32_t>, std::vector<uint32_t>>
 readTrailerStreamMetadata(const char* end);
 
@@ -362,6 +419,20 @@ readTrailerStreamMetadata(const char* end);
 /// cursor + pull() when the trailer spans a chain boundary.
 std::pair<std::vector<uint32_t>, std::vector<uint32_t>>
 readTrailerStreamMetadata(const folly::IOBuf& input);
+
+/// Reads the kTablet dedup trailer written by the three-section `writeTrailer`
+/// overload and reconstructs the same parallel `streamIds`,
+/// `streamOffsets`, and `streamSizes` arrays used by the kTablet decode path.
+/// `uniqueStreamSizesScratch` is a caller-owned reusable buffer: it receives
+/// the decoded unique-size table and is then transformed in place into the
+/// unique-offset (prefix-sum) table. Keeping it caller-owned keeps the per-blob
+/// hot path alloc-free.
+void readTrailerStreamMetadata(
+    const char* end,
+    std::vector<uint32_t>& streamIds,
+    std::vector<uint32_t>& streamOffsets,
+    std::vector<uint32_t>& streamSizes,
+    std::vector<uint32_t>& uniqueStreamSizesScratch);
 
 /// Parses all streams from a serialized buffer.
 /// Returns a vector of stream data indexed by their original offset.

--- a/dwio/nimble/serializer/SerializerImpl.h
+++ b/dwio/nimble/serializer/SerializerImpl.h
@@ -35,6 +35,7 @@
 #include "dwio/nimble/serializer/SerializationHeader.h"
 #include "dwio/nimble/velox/RowRange.h"
 #include "dwio/nimble/velox/StreamData.h"
+#include "folly/Likely.h"
 #include "folly/io/Cursor.h"
 #include "folly/io/IOBuf.h"
 #include "velox/common/Casts.h"
@@ -256,7 +257,9 @@ void writeTrailer(
   streamIds.reserve(streamCount);
   streamSizes.reserve(streamCount);
   for (uint32_t i = 0; i < streamCount; ++i) {
-    if (denseStreamSizes[i] != 0) {
+    // Sparse trailer: in the dominant flat-map RPC workload most stream slots
+    // are empty in any given batch, so the non-zero branch is the rare case.
+    if (FOLLY_UNLIKELY(denseStreamSizes[i] != 0)) {
       streamIds.emplace_back(i);
       streamSizes.emplace_back(denseStreamSizes[i]);
     }

--- a/dwio/nimble/serializer/tests/SerializationTest.cpp
+++ b/dwio/nimble/serializer/tests/SerializationTest.cpp
@@ -21,6 +21,7 @@
 #include "dwio/nimble/common/tests/GTestUtils.h"
 #include "dwio/nimble/serializer/Deserializer.h"
 #include "dwio/nimble/serializer/DeserializerImpl.h"
+#include "dwio/nimble/serializer/SerializationHeader.h"
 #include "dwio/nimble/serializer/Serializer.h"
 #include "dwio/nimble/serializer/SerializerImpl.h"
 #include "dwio/nimble/tablet/Constants.h"
@@ -103,6 +104,11 @@ class SerializationTest : public ::testing::TestWithParam<TestParams> {
     std::vector<std::string> serialized;
     // Nimble schema for deserialization.
     std::shared_ptr<const Type> schema;
+    // Populated only for kTablet test assemblies.
+    std::vector<size_t> numTabletStreams;
+    std::vector<size_t> numUniqueTabletStreams;
+    std::vector<uint64_t> tabletBodyBytes;
+    std::vector<uint64_t> tabletUniqueBodyBytes;
   };
 
   // Serializes input vectors using the current test parameter's version.
@@ -121,6 +127,14 @@ class SerializationTest : public ::testing::TestWithParam<TestParams> {
       const velox::TypePtr& type,
       const std::vector<velox::VectorPtr>& inputs,
       bool enableChunking);
+
+  SerializeResult serializeTablet(
+      const velox::TypePtr& type,
+      const std::vector<velox::VectorPtr>& inputs,
+      bool enableChunking,
+      EncodingType streamIdsEncodingType,
+      EncodingType sizeIndicesEncodingType,
+      EncodingType uniqueSizesEncodingType);
 
   std::shared_ptr<velox::memory::MemoryPool> rootPool_;
   std::shared_ptr<velox::memory::MemoryPool> pool_;
@@ -371,6 +385,90 @@ TEST_P(SerializationTest, fuzzSimple) {
 
 namespace {
 
+// References one logical stream body while assembling a kTablet test blob.
+struct TabletStream {
+  uint32_t id{0};
+  std::string_view data;
+};
+
+// Reports whether kTablet assembly found exact-duplicate stream bodies.
+struct TabletTrailerWriteResult {
+  size_t numStreams{0};
+  size_t numUniqueStreams{0};
+  uint64_t numBodyBytes{0};
+  uint64_t numUniqueBodyBytes{0};
+
+  bool hasSharedStreamBodies() const {
+    return numUniqueStreams < numStreams;
+  }
+};
+
+std::vector<TabletStream> collectTabletStreams(
+    const std::vector<uint32_t>& streamOffsets,
+    const std::vector<std::unique_ptr<StreamLoader>>& streamLoaders) {
+  std::vector<TabletStream> streams;
+  streams.reserve(streamLoaders.size());
+  for (size_t i = 0; i < streamLoaders.size(); ++i) {
+    if (streamLoaders[i] == nullptr) {
+      continue;
+    }
+    streams.push_back({streamOffsets[i], streamLoaders[i]->getStream()});
+  }
+  return streams;
+}
+
+TabletTrailerWriteResult writeTabletStreamsAndTrailer(
+    const std::vector<TabletStream>& streams,
+    EncodingType streamIdsEncodingType,
+    EncodingType sizeIndicesEncodingType,
+    EncodingType uniqueSizesEncodingType,
+    std::string& buffer) {
+  TabletTrailerWriteResult result;
+  std::vector<uint32_t> streamIds;
+  std::vector<uint32_t> streamSizeIndices;
+  std::vector<uint32_t> uniqueStreamSizes;
+  std::vector<std::string_view> uniqueStreams;
+  streamIds.reserve(streams.size());
+  streamSizeIndices.reserve(streams.size());
+  uniqueStreams.reserve(streams.size());
+  uniqueStreamSizes.reserve(streams.size());
+
+  for (const auto& stream : streams) {
+    if (stream.data.empty()) {
+      continue;
+    }
+    streamIds.emplace_back(stream.id);
+    result.numBodyBytes += stream.data.size();
+
+    size_t uniqueStreamIndex{0};
+    for (; uniqueStreamIndex < uniqueStreams.size(); ++uniqueStreamIndex) {
+      if (uniqueStreams[uniqueStreamIndex] == stream.data) {
+        break;
+      }
+    }
+
+    if (uniqueStreamIndex == uniqueStreams.size()) {
+      uniqueStreams.emplace_back(stream.data);
+      uniqueStreamSizes.emplace_back(static_cast<uint32_t>(stream.data.size()));
+      result.numUniqueBodyBytes += stream.data.size();
+      buffer.append(stream.data.data(), stream.data.size());
+    }
+    streamSizeIndices.emplace_back(static_cast<uint32_t>(uniqueStreamIndex));
+  }
+
+  result.numStreams = streamIds.size();
+  result.numUniqueStreams = uniqueStreams.size();
+  serde::detail::writeTrailer(
+      streamIds,
+      streamSizeIndices,
+      uniqueStreamSizes,
+      streamIdsEncodingType,
+      sizeIndicesEncodingType,
+      uniqueSizesEncodingType,
+      buffer);
+  return result;
+}
+
 void collectStreamOffsets(
     const nimble::Type& type,
     std::set<uint32_t>& offsets) {
@@ -502,6 +600,22 @@ SerializationTest::SerializeResult SerializationTest::serializeTablet(
     const velox::TypePtr& type,
     const std::vector<velox::VectorPtr>& inputs,
     bool enableChunking) {
+  return serializeTablet(
+      type,
+      inputs,
+      enableChunking,
+      EncodingType::Trivial,
+      EncodingType::Trivial,
+      EncodingType::Trivial);
+}
+
+SerializationTest::SerializeResult SerializationTest::serializeTablet(
+    const velox::TypePtr& type,
+    const std::vector<velox::VectorPtr>& inputs,
+    bool enableChunking,
+    EncodingType streamIdsEncodingType,
+    EncodingType sizeIndicesEncodingType,
+    EncodingType uniqueSizesEncodingType) {
   // Write all inputs to a single Nimble file.
   std::string fileData;
   {
@@ -550,30 +664,20 @@ SerializationTest::SerializeResult SerializationTest::serializeTablet(
         reinterpret_cast<const char*>(headerIOBuf.data()),
         headerIOBuf.length());
 
-    const auto maxOffset = streamOffsets.back();
-    std::string streamData;
-    std::vector<uint32_t> streamSizes(maxOffset + 1, 0);
-    for (size_t i = 0; i < streamLoaders.size(); ++i) {
-      if (streamLoaders[i] == nullptr) {
-        continue;
-      }
-      auto stream = streamLoaders[i]->getStream();
-      streamData.append(stream.data(), stream.size());
-      streamSizes[streamOffsets[i]] = static_cast<uint32_t>(stream.size());
-    }
-
-    std::string trailerBuf;
-    serde::detail::writeTrailer(
-        streamSizes,
-        nimble::EncodingType::Trivial,
-        nimble::EncodingType::Trivial,
-        trailerBuf);
-
+    auto streams = collectTabletStreams(streamOffsets, streamLoaders);
     std::string assembled;
-    assembled.reserve(headerBuf.size() + streamData.size() + trailerBuf.size());
+    assembled.reserve(headerBuf.size());
     assembled.append(headerBuf);
-    assembled.append(streamData);
-    assembled.append(trailerBuf);
+    auto writeResult = writeTabletStreamsAndTrailer(
+        streams,
+        streamIdsEncodingType,
+        sizeIndicesEncodingType,
+        uniqueSizesEncodingType,
+        assembled);
+    result.numTabletStreams.push_back(writeResult.numStreams);
+    result.numUniqueTabletStreams.push_back(writeResult.numUniqueStreams);
+    result.tabletBodyBytes.push_back(writeResult.numBodyBytes);
+    result.tabletUniqueBodyBytes.push_back(writeResult.numUniqueBodyBytes);
     result.serialized.push_back(std::move(assembled));
   }
   return result;
@@ -3230,6 +3334,76 @@ TEST_F(SerializationTest, tabletDeserialization) {
   }
 }
 
+TEST_F(SerializationTest, tabletTrailerDeserialization) {
+  auto rowType =
+      velox::ROW({{"dup_a", velox::INTEGER()}, {"dup_b", velox::INTEGER()}});
+  const std::vector<EncodingType> encodings = {
+      EncodingType::Trivial,
+      EncodingType::Varint,
+      EncodingType::Delta,
+      EncodingType::FixedBitWidth,
+  };
+
+  constexpr int numRows = 128;
+  auto dupA = velox::BaseVector::create(
+      velox::INTEGER(),
+      static_cast<velox::vector_size_t>(numRows),
+      pool_.get());
+  auto dupB = velox::BaseVector::create(
+      velox::INTEGER(),
+      static_cast<velox::vector_size_t>(numRows),
+      pool_.get());
+  for (velox::vector_size_t i = 0; i < numRows; ++i) {
+    const auto value = static_cast<int32_t>(i * 7);
+    dupA->asFlatVector<int32_t>()->set(i, value);
+    dupB->asFlatVector<int32_t>()->set(i, value);
+  }
+  auto input = std::make_shared<velox::RowVector>(
+      pool_.get(),
+      rowType,
+      nullptr,
+      static_cast<velox::vector_size_t>(numRows),
+      std::vector<velox::VectorPtr>{dupA, dupB});
+
+  for (const auto streamIdsEncodingType : encodings) {
+    for (const auto sizeIndicesEncodingType : encodings) {
+      for (const auto uniqueSizesEncodingType : encodings) {
+        SCOPED_TRACE(
+            fmt::format(
+                "streamIdsEncodingType={} sizeIndicesEncodingType={} uniqueSizesEncodingType={}",
+                toString(streamIdsEncodingType),
+                toString(sizeIndicesEncodingType),
+                toString(uniqueSizesEncodingType)));
+        auto tablet = serializeTablet(
+            rowType,
+            {input},
+            /*enableChunking=*/true,
+            streamIdsEncodingType,
+            sizeIndicesEncodingType,
+            uniqueSizesEncodingType);
+        ASSERT_EQ(tablet.serialized.size(), 1);
+        ASSERT_EQ(tablet.numTabletStreams.size(), 1);
+        ASSERT_GT(tablet.numTabletStreams[0], tablet.numUniqueTabletStreams[0]);
+        ASSERT_LT(tablet.tabletUniqueBodyBytes[0], tablet.tabletBodyBytes[0]);
+
+        nimble::Deserializer deserializer{
+            tablet.schema, pool_.get(), DeserializerOptions{.hasHeader = true}};
+        velox::VectorPtr output;
+        deserializer.deserialize(
+            std::string_view(tablet.serialized[0]), output);
+
+        ASSERT_NE(output, nullptr);
+        ASSERT_EQ(output->size(), numRows);
+        for (velox::vector_size_t i = 0; i < numRows; ++i) {
+          ASSERT_TRUE(input->equalValueAt(output.get(), i, i))
+              << "Mismatch at row " << i << "\nExpected: " << input->toString(i)
+              << "\nActual: " << output->toString(i);
+        }
+      }
+    }
+  }
+}
+
 // Verifies ZSTD decompression round-trips correctly with the thread-local
 // ZSTD_DCtx reuse (always-on). Exercises the StreamDataReader and StreamData
 // decompress paths with kTablet chunked format.
@@ -3394,30 +3568,16 @@ TEST_F(SerializationTest, zstdThreadLocalDCtxHighParallelism) {
         reinterpret_cast<const char*>(headerIOBuf.data()),
         headerIOBuf.length());
 
-    const auto maxOffset = streamOffsets.back();
-    std::string streamData;
-    std::vector<uint32_t> streamSizes(maxOffset + 1, 0);
-    for (size_t i = 0; i < streamLoaders.size(); ++i) {
-      if (streamLoaders[i] == nullptr) {
-        continue;
-      }
-      auto stream = streamLoaders[i]->getStream();
-      streamData.append(stream.data(), stream.size());
-      streamSizes[streamOffsets[i]] = static_cast<uint32_t>(stream.size());
-    }
-
-    std::string trailerBuf;
-    serde::detail::writeTrailer(
-        streamSizes,
-        nimble::EncodingType::Trivial,
-        nimble::EncodingType::Trivial,
-        trailerBuf);
-
+    auto streams = collectTabletStreams(streamOffsets, streamLoaders);
     std::string assembled;
-    assembled.reserve(headerBuf.size() + streamData.size() + trailerBuf.size());
+    assembled.reserve(headerBuf.size());
     assembled.append(headerBuf);
-    assembled.append(streamData);
-    assembled.append(trailerBuf);
+    writeTabletStreamsAndTrailer(
+        streams,
+        EncodingType::Trivial,
+        EncodingType::Trivial,
+        EncodingType::Trivial,
+        assembled);
     assembledBuffers.push_back(std::move(assembled));
   }
 
@@ -3520,31 +3680,16 @@ TEST_F(SerializationTest, zstdThreadLocalDCtxConcurrentDeserializers) {
           reinterpret_cast<const char*>(headerIOBuf.data()),
           headerIOBuf.length());
 
-      const auto maxOffset = streamOffsets.back();
-      std::string streamData;
-      std::vector<uint32_t> streamSizes(maxOffset + 1, 0);
-      for (size_t i = 0; i < streamLoaders.size(); ++i) {
-        if (streamLoaders[i] == nullptr) {
-          continue;
-        }
-        auto stream = streamLoaders[i]->getStream();
-        streamData.append(stream.data(), stream.size());
-        streamSizes[streamOffsets[i]] = static_cast<uint32_t>(stream.size());
-      }
-
-      std::string trailerBuf;
-      serde::detail::writeTrailer(
-          streamSizes,
-          nimble::EncodingType::Trivial,
-          nimble::EncodingType::Trivial,
-          trailerBuf);
-
+      auto streams = collectTabletStreams(streamOffsets, streamLoaders);
       std::string assembled;
-      assembled.reserve(
-          headerBuf.size() + streamData.size() + trailerBuf.size());
+      assembled.reserve(headerBuf.size());
       assembled.append(headerBuf);
-      assembled.append(streamData);
-      assembled.append(trailerBuf);
+      writeTabletStreamsAndTrailer(
+          streams,
+          EncodingType::Trivial,
+          EncodingType::Trivial,
+          EncodingType::Trivial,
+          assembled);
       allAssembled[t].push_back(std::move(assembled));
     }
   }
@@ -3695,30 +3840,16 @@ TEST_F(SerializationTest, zstdThreadLocalDCtxFlatMapWithParallelDecode) {
         reinterpret_cast<const char*>(headerIOBuf.data()),
         headerIOBuf.length());
 
-    const auto maxOffset = streamOffsets.back();
-    std::string streamData;
-    std::vector<uint32_t> streamSizes(maxOffset + 1, 0);
-    for (size_t i = 0; i < streamLoaders.size(); ++i) {
-      if (streamLoaders[i] == nullptr) {
-        continue;
-      }
-      auto stream = streamLoaders[i]->getStream();
-      streamData.append(stream.data(), stream.size());
-      streamSizes[streamOffsets[i]] = static_cast<uint32_t>(stream.size());
-    }
-
-    std::string trailerBuf;
-    serde::detail::writeTrailer(
-        streamSizes,
-        nimble::EncodingType::Trivial,
-        nimble::EncodingType::Trivial,
-        trailerBuf);
-
+    auto streams = collectTabletStreams(streamOffsets, streamLoaders);
     std::string assembled;
-    assembled.reserve(headerBuf.size() + streamData.size() + trailerBuf.size());
+    assembled.reserve(headerBuf.size());
     assembled.append(headerBuf);
-    assembled.append(streamData);
-    assembled.append(trailerBuf);
+    writeTabletStreamsAndTrailer(
+        streams,
+        EncodingType::Trivial,
+        EncodingType::Trivial,
+        EncodingType::Trivial,
+        assembled);
     assembledBuffers.push_back(std::move(assembled));
   }
 
@@ -3819,30 +3950,16 @@ TEST_F(SerializationTest, zstdThreadLocalDCtxRepeatedBatches) {
         reinterpret_cast<const char*>(headerIOBuf.data()),
         headerIOBuf.length());
 
-    const auto maxOffset = streamOffsets.back();
-    std::string streamData;
-    std::vector<uint32_t> streamSizes(maxOffset + 1, 0);
-    for (size_t i = 0; i < streamLoaders.size(); ++i) {
-      if (streamLoaders[i] == nullptr) {
-        continue;
-      }
-      auto stream = streamLoaders[i]->getStream();
-      streamData.append(stream.data(), stream.size());
-      streamSizes[streamOffsets[i]] = static_cast<uint32_t>(stream.size());
-    }
-
-    std::string trailerBuf;
-    serde::detail::writeTrailer(
-        streamSizes,
-        nimble::EncodingType::Trivial,
-        nimble::EncodingType::Trivial,
-        trailerBuf);
-
+    auto streams = collectTabletStreams(streamOffsets, streamLoaders);
     std::string assembled;
-    assembled.reserve(headerBuf.size() + streamData.size() + trailerBuf.size());
+    assembled.reserve(headerBuf.size());
     assembled.append(headerBuf);
-    assembled.append(streamData);
-    assembled.append(trailerBuf);
+    writeTabletStreamsAndTrailer(
+        streams,
+        EncodingType::Trivial,
+        EncodingType::Trivial,
+        EncodingType::Trivial,
+        assembled);
     assembledBuffers.push_back(std::move(assembled));
   }
 

--- a/dwio/nimble/serializer/tests/SerializerImplTest.cpp
+++ b/dwio/nimble/serializer/tests/SerializerImplTest.cpp
@@ -16,6 +16,7 @@
 
 #include <limits>
 #include <random>
+#include <string_view>
 
 #include <gtest/gtest.h>
 #include <lz4.h>
@@ -37,19 +38,109 @@ using namespace facebook::velox;
 
 namespace {
 
-// Test-only helper: scatter the sparse (indices, sizes) trailer into a dense
-// vector sized to max(indices) + 1, matching the legacy dense round-trip view
-// the tests below were written against.
+// Test-only helper: scatter the sparse (stream ids, sizes) trailer into a dense
+// vector sized to max(stream ids) + 1, matching the legacy dense round-trip
+// view the tests below were written against.
 std::vector<uint32_t> readTrailerStreamMetadataDenseForTest(const char* end) {
-  auto [indices, sizes] = serde::detail::readTrailerStreamMetadata(end);
-  if (indices.empty()) {
+  auto [streamIds, sizes] = serde::detail::readTrailerStreamMetadata(end);
+  if (streamIds.empty()) {
     return {};
   }
-  std::vector<uint32_t> dense(indices.back() + 1, 0);
-  for (size_t k = 0; k < indices.size(); ++k) {
-    dense[indices[k]] = sizes[k];
+  std::vector<uint32_t> dense(streamIds.back() + 1, 0);
+  for (size_t i = 0; i < streamIds.size(); ++i) {
+    dense[streamIds[i]] = sizes[i];
   }
   return dense;
+}
+
+// Writes the kTablet trailer for a sequentially-laid-out body: every present
+// slot is its own unique stream, so its stream size index is the running unique
+// index and uniqueStreamSizes equals the present sizes in order. Test
+// scaffolding that assembles kTablet chunks must emit the same trailer layout.
+void writeTabletTrailer(
+    const std::vector<uint32_t>& sizes,
+    std::string& buffer) {
+  std::vector<uint32_t> streamIds;
+  std::vector<uint32_t> streamSizeIndices;
+  std::vector<uint32_t> uniqueStreamSizes;
+  for (size_t i = 0; i < sizes.size(); ++i) {
+    const auto streamSize = sizes[i];
+    if (streamSize == 0) {
+      continue;
+    }
+    streamIds.emplace_back(static_cast<uint32_t>(i));
+    streamSizeIndices.emplace_back(
+        static_cast<uint32_t>(uniqueStreamSizes.size()));
+    uniqueStreamSizes.emplace_back(streamSize);
+  }
+  serde::detail::writeTrailer(
+      streamIds,
+      streamSizeIndices,
+      uniqueStreamSizes,
+      EncodingType::Trivial,
+      EncodingType::Trivial,
+      EncodingType::Trivial,
+      buffer);
+}
+
+void skipTrailerSectionPayloadForTest(
+    EncodingType encodingType,
+    const char*& payload) {
+  switch (encodingType) {
+    case EncodingType::Trivial: {
+      const auto count = varint::readVarint32(&payload);
+      payload += count * sizeof(uint32_t);
+      return;
+    }
+    case EncodingType::Varint: {
+      const auto count = varint::readVarint32(&payload);
+      for (uint32_t i = 0; i < count; ++i) {
+        varint::readVarint32(&payload);
+      }
+      return;
+    }
+    case EncodingType::Delta: {
+      const auto count = varint::readVarint32(&payload);
+      for (uint32_t i = 0; i < count; ++i) {
+        varint::readVarint32(&payload);
+      }
+      return;
+    }
+    case EncodingType::FixedBitWidth: {
+      const auto bitWidth = static_cast<uint8_t>(*payload++);
+      const auto count = varint::readVarint32(&payload);
+      if (bitWidth > 0 && count > 0) {
+        payload += FixedBitArray::bufferSize(count, bitWidth);
+      }
+      return;
+    }
+    default:
+      FAIL() << "Unsupported trailer encoding type: " << encodingType;
+  }
+}
+
+void expectTabletTrailerEncodingTypes(
+    const std::string& buffer,
+    EncodingType streamIdsEncodingType,
+    EncodingType sizeIndicesEncodingType,
+    EncodingType uniqueSizesEncodingType) {
+  const char* const end = buffer.data() + buffer.size();
+  const auto trailerSize = serde::detail::readTrailerSize(end);
+  const char* payload = end - sizeof(uint32_t) - trailerSize;
+  const char* const trailerEnd = end - sizeof(uint32_t);
+
+  const auto verifySection = [&](EncodingType expectedEncodingType) {
+    ASSERT_LT(payload, trailerEnd);
+    const auto actualEncodingType =
+        static_cast<EncodingType>(static_cast<uint8_t>(*payload++));
+    EXPECT_EQ(actualEncodingType, expectedEncodingType);
+    skipTrailerSectionPayloadForTest(actualEncodingType, payload);
+  };
+
+  verifySection(streamIdsEncodingType);
+  verifySection(sizeIndicesEncodingType);
+  verifySection(uniqueSizesEncodingType);
+  EXPECT_EQ(payload, trailerEnd);
 }
 
 } // namespace
@@ -705,6 +796,154 @@ TEST_F(EncodeDecodeTest, readTrailerStreamMetadataRoundtrip) {
     SCOPED_TRACE(testData.debugString());
     auto buffer = buildCompactTrailer(testData.values);
     expectDenseRoundtripEq(testData.values, buffer);
+  }
+}
+
+// Round-trips the kTablet trailer layout (streamIds, sizeIndices, uniqueSizes).
+// Duplicate slots carry the stream size index of the stream they alias, so the
+// reader rebuilds the same (streamIds, offsets, sizes) triple without storing
+// offsets or duplicated sizes.
+TEST_F(EncodeDecodeTest, tabletTrailerRoundtrip) {
+  // Slot 2 aliases slot 0 (size index 0) and slot 4 aliases slot 1
+  // (size index 1). Unique streams in body order are slots 0, 1, 5.
+  const std::vector<uint32_t> streamIds = {0, 1, 2, 4, 5};
+  const std::vector<uint32_t> streamSizeIndices = {0, 1, 0, 1, 2};
+  const std::vector<uint32_t> uniqueStreamSizes = {100, 50, 80};
+  constexpr auto kStreamIdsEncoding = EncodingType::Varint;
+  constexpr auto kSizeIndicesEncoding = EncodingType::Trivial;
+  constexpr auto kUniqueSizesEncoding = EncodingType::FixedBitWidth;
+
+  std::string buffer;
+  serde::detail::writeTrailer(
+      streamIds,
+      streamSizeIndices,
+      uniqueStreamSizes,
+      kStreamIdsEncoding,
+      kSizeIndicesEncoding,
+      kUniqueSizesEncoding,
+      buffer);
+  expectTabletTrailerEncodingTypes(
+      buffer, kStreamIdsEncoding, kSizeIndicesEncoding, kUniqueSizesEncoding);
+  EXPECT_LE(
+      buffer.size(),
+      serde::detail::estimateTrailerSize(
+          streamIds.size(),
+          uniqueStreamSizes.size(),
+          kStreamIdsEncoding,
+          kSizeIndicesEncoding,
+          kUniqueSizesEncoding));
+
+  std::vector<uint32_t> decodedStreamIds;
+  std::vector<uint32_t> offsets;
+  std::vector<uint32_t> sizes;
+  std::vector<uint32_t> uniqueStreamSizesScratch;
+  serde::detail::readTrailerStreamMetadata(
+      buffer.data() + buffer.size(),
+      decodedStreamIds,
+      offsets,
+      sizes,
+      uniqueStreamSizesScratch);
+
+  const std::vector<uint32_t> expectedStreamIds = {0, 1, 2, 4, 5};
+  const std::vector<uint32_t> expectedOffsets = {0, 100, 0, 100, 150};
+  const std::vector<uint32_t> expectedSizes = {100, 50, 100, 50, 80};
+  EXPECT_EQ(decodedStreamIds, expectedStreamIds);
+  EXPECT_EQ(offsets, expectedOffsets);
+  EXPECT_EQ(sizes, expectedSizes);
+}
+
+// Verifies that every kTablet trailer section encoding combination round-trips
+// to the same decoded (streamIds, offsets, sizes) metadata.
+TEST_F(EncodeDecodeTest, tabletTrailerEncodingCombinations) {
+  const std::vector<EncodingType> encodings = {
+      EncodingType::Trivial,
+      EncodingType::Varint,
+      EncodingType::Delta,
+      EncodingType::FixedBitWidth,
+  };
+  struct TestCase {
+    std::string_view label;
+    std::vector<uint32_t> streamIds;
+    std::vector<uint32_t> streamSizeIndices;
+    std::vector<uint32_t> uniqueStreamSizes;
+    std::vector<uint32_t> expectedOffsets;
+    std::vector<uint32_t> expectedSizes;
+  };
+  const std::vector<TestCase> testCases = {
+      {
+          "empty",
+          {},
+          {},
+          {},
+          {},
+          {},
+      },
+      {
+          "no-duplicates",
+          {0, 3, 7},
+          {0, 1, 2},
+          {10, 20, 30},
+          {0, 10, 30},
+          {10, 20, 30},
+      },
+      {
+          "duplicates",
+          {0, 1, 2, 4, 5},
+          {0, 1, 0, 1, 2},
+          {100, 50, 80},
+          {0, 100, 0, 100, 150},
+          {100, 50, 100, 50, 80},
+      },
+  };
+
+  for (const auto streamIdsEnc : encodings) {
+    for (const auto sizeIndicesEnc : encodings) {
+      for (const auto uniqueSizesEnc : encodings) {
+        for (const auto& testCase : testCases) {
+          SCOPED_TRACE(
+              fmt::format(
+                  "streamIdsEnc={} sizeIndicesEnc={} uniqueSizesEnc={} case={}",
+                  toString(streamIdsEnc),
+                  toString(sizeIndicesEnc),
+                  toString(uniqueSizesEnc),
+                  testCase.label));
+          std::string buffer;
+          serde::detail::writeTrailer(
+              testCase.streamIds,
+              testCase.streamSizeIndices,
+              testCase.uniqueStreamSizes,
+              streamIdsEnc,
+              sizeIndicesEnc,
+              uniqueSizesEnc,
+              buffer);
+          expectTabletTrailerEncodingTypes(
+              buffer, streamIdsEnc, sizeIndicesEnc, uniqueSizesEnc);
+
+          const auto estimate = serde::detail::estimateTrailerSize(
+              testCase.streamIds.size(),
+              testCase.uniqueStreamSizes.size(),
+              streamIdsEnc,
+              sizeIndicesEnc,
+              uniqueSizesEnc);
+          EXPECT_LE(buffer.size(), estimate);
+
+          std::vector<uint32_t> decodedStreamIds;
+          std::vector<uint32_t> offsets;
+          std::vector<uint32_t> sizes;
+          std::vector<uint32_t> uniqueStreamSizesScratch;
+          serde::detail::readTrailerStreamMetadata(
+              buffer.data() + buffer.size(),
+              decodedStreamIds,
+              offsets,
+              sizes,
+              uniqueStreamSizesScratch);
+
+          EXPECT_EQ(decodedStreamIds, testCase.streamIds);
+          EXPECT_EQ(offsets, testCase.expectedOffsets);
+          EXPECT_EQ(sizes, testCase.expectedSizes);
+        }
+      }
+    }
   }
 }
 
@@ -1505,8 +1744,7 @@ class TabletChunkStripTest : public ::testing::Test {
         reinterpret_cast<const char*>(headerIOBuf.data()),
         headerIOBuf.length());
     buffer.append(streamData);
-    serde::detail::writeTrailer(
-        sizes, EncodingType::Trivial, EncodingType::Trivial, buffer);
+    writeTabletTrailer(sizes, buffer);
 
     // Parse via StreamDataReader.
     DeserializerOptions options{.hasHeader = true};
@@ -1717,8 +1955,7 @@ class ZstdDCtxReuseTest : public TabletChunkStripTest {
         reinterpret_cast<const char*>(headerIOBuf.data()),
         headerIOBuf.length());
     buffer.append(streamData);
-    serde::detail::writeTrailer(
-        sizes, EncodingType::Trivial, EncodingType::Trivial, buffer);
+    writeTabletTrailer(sizes, buffer);
 
     DeserializerOptions options{.hasHeader = true};
     StreamDataReader reader(pool_.get(), options);

--- a/dwio/nimble/tablet/DataInput.cpp
+++ b/dwio/nimble/tablet/DataInput.cpp
@@ -213,11 +213,25 @@ void DirectDataInput::populateBufferRefs(
     const std::vector<IoGroup>& ioGroups,
     const char* buffer) {
   for (const auto& group : ioGroups) {
+    // group.regions is sorted by offset and then enqueueIndex. Duplicate read
+    // regions are therefore contiguous, with the earliest enqueued request
+    // first. The BufferRef for the first request in each run is canonical:
+    // it points canonicalIndex to itself, and later duplicates point
+    // canonicalIndex to it while sharing the same buffer slice. Since enqueue
+    // order matches consumer order, the canonical ref is processed before any
+    // duplicate that reuses it.
+    const EnqueuedRegion* shared = nullptr;
     for (const auto& region : group.regions) {
-      auto& ref = bufferRefs_[region.bufferIndex];
-      ref.data = buffer + group.bufferOffset +
+      auto& bufferRef = bufferRefs_[region.enqueueIndex];
+      bufferRef.data = buffer + group.bufferOffset +
           (region.region.offset - group.readOffset);
-      ref.length = region.region.length;
+      bufferRef.length = region.region.length;
+      if (shared != nullptr && region.sameRegionAs(*shared)) {
+        bufferRef.canonicalIndex = shared->enqueueIndex;
+      } else {
+        bufferRef.canonicalIndex = region.enqueueIndex;
+        shared = &region;
+      }
     }
   }
 }
@@ -280,7 +294,13 @@ DataInput::Handle DirectDataInput::load() {
         regions_.begin() + start,
         regions_.begin() + end,
         [](const EnqueuedRegion& a, const EnqueuedRegion& b) {
-          return a.region.offset < b.region.offset;
+          if (a.region.offset != b.region.offset) {
+            return a.region.offset < b.region.offset;
+          }
+          // Tiebreak equal extents by enqueue index so the first member of each
+          // duplicate run is its stored copy (smallest enqueue index = earliest
+          // processed by the consumer).
+          return a.enqueueIndex < b.enqueueIndex;
         });
 
     if (i > 0) {

--- a/dwio/nimble/tablet/DataInput.h
+++ b/dwio/nimble/tablet/DataInput.h
@@ -48,6 +48,12 @@ class DataInput {
   struct BufferRef {
     const char* data{nullptr};
     uint64_t length{0};
+    /// Index of the canonical BufferRef for this loaded region.
+    /// Unique regions refer to themselves (`canonicalIndex == i`). Exact
+    /// duplicate regions refer to the first enqueued copy and share that copy's
+    /// `data` pointer, allowing callers to reuse `bufferRef(canonicalIndex)`
+    /// instead of emitting the duplicate again. Only valid after load().
+    uint32_t canonicalIndex{0};
   };
 
   /// Opaque handle keeping all loaded allocations alive.
@@ -73,7 +79,10 @@ class DataInput {
   /// done with all BufferRefs (e.g., capture in IOBuf destructors).
   virtual Handle load() = 0;
 
-  /// Get the loaded buffer for a previously enqueued request.
+  /// Get the loaded buffer for a previously enqueued request. The returned
+  /// BufferRef::canonicalIndex identifies the stored copy when the region is an
+  /// exact duplicate of an earlier enqueued request (see BufferRef). Only valid
+  /// after load().
   virtual const BufferRef& bufferRef(uint32_t index) const = 0;
 
   /// Release all state (loaded buffers, enqueued requests).
@@ -120,7 +129,12 @@ class DirectDataInput : public DataInput {
 
  private:
   struct EnqueuedRegion {
-    uint32_t bufferIndex;
+    bool sameRegionAs(const EnqueuedRegion& other) const {
+      return region.offset == other.region.offset &&
+          region.length == other.region.length;
+    }
+
+    uint32_t enqueueIndex;
     Region region;
   };
 

--- a/dwio/nimble/tablet/tests/DataInputTest.cpp
+++ b/dwio/nimble/tablet/tests/DataInputTest.cpp
@@ -484,6 +484,13 @@ DEBUG_ONLY_TEST_F(DataInputTest, coalescesDuplicateRegions) {
   EXPECT_EQ(refData(input.bufferRef(adjacent0)), data.substr(150, 50));
   EXPECT_EQ(refData(input.bufferRef(adjacent1)), data.substr(200, 25));
   EXPECT_EQ(input.bufferRef(duplicate0).data, input.bufferRef(duplicate1).data);
+  // BufferRef::canonicalIndex exposes the dedup: both duplicates resolve to
+  // the stored copy (the first-enqueued index of the duplicate set), while
+  // unique regions resolve to themselves.
+  EXPECT_EQ(input.bufferRef(adjacent0).canonicalIndex, adjacent0);
+  EXPECT_EQ(input.bufferRef(adjacent1).canonicalIndex, adjacent1);
+  EXPECT_EQ(input.bufferRef(duplicate0).canonicalIndex, duplicate0);
+  EXPECT_EQ(input.bufferRef(duplicate1).canonicalIndex, duplicate0);
   EXPECT_EQ(ioStats_->read().count(), 1);
   EXPECT_EQ(ioStats_->read().sum(), 125);
   EXPECT_EQ(ioStats_->rawBytesRead(), 125);

--- a/dwio/nimble/velox/index/NimbleIndexProjector.cpp
+++ b/dwio/nimble/velox/index/NimbleIndexProjector.cpp
@@ -60,6 +60,67 @@ std::string NimbleIndexProjector::Stats::toString() const {
 
 namespace {
 
+// Adapter that lets serializer helpers append directly into an already
+// allocated IOBuf. resize() only advances the IOBuf length within existing
+// tailroom; it never reallocates.
+class IOBufAppender {
+ public:
+  explicit IOBufAppender(folly::IOBuf& buffer) : buffer_{buffer} {}
+
+  size_t size() const {
+    return buffer_.length();
+  }
+
+  void resize(size_t size) {
+    const auto currentSize = buffer_.length();
+    NIMBLE_CHECK_GE(
+        size, currentSize, "IOBufAppender only supports appending data");
+    const auto appendSize = size - currentSize;
+    NIMBLE_CHECK_LE(
+        appendSize,
+        buffer_.tailroom(),
+        "Estimated trailer tailroom is too small: {} > {}",
+        appendSize,
+        buffer_.tailroom());
+    buffer_.append(appendSize);
+  }
+
+  char* data() {
+    return reinterpret_cast<char*>(buffer_.writableData());
+  }
+
+ private:
+  folly::IOBuf& buffer_;
+};
+
+constexpr auto kTabletTrailerEncoding = EncodingType::FixedBitWidth;
+
+size_t estimateTabletTrailerSize(
+    size_t numPresentStreams,
+    size_t numUniqueStreams) {
+  return serde::detail::estimateTrailerSize(
+      numPresentStreams,
+      numUniqueStreams,
+      kTabletTrailerEncoding,
+      kTabletTrailerEncoding,
+      kTabletTrailerEncoding);
+}
+
+void writeTabletTrailer(
+    const std::vector<uint32_t>& streamIds,
+    const std::vector<uint32_t>& streamSizeIndices,
+    const std::vector<uint32_t>& uniqueStreamSizes,
+    IOBufAppender& buffer) {
+  serde::detail::writeTrailer(
+      streamIds,
+      streamSizeIndices,
+      uniqueStreamSizes,
+      kTabletTrailerEncoding,
+      kTabletTrailerEncoding,
+      kTabletTrailerEncoding,
+      buffer);
+}
+
 std::unique_ptr<DataInput> createDataInput(
     const velox::FileHandle& fileHandle,
     const velox::dwio::common::ReaderOptions& options) {
@@ -223,6 +284,7 @@ void NimbleIndexProjector::clearRequest() {
   ctx_.dataInputIndices.clear();
   ctx_.dataHandle.reset();
   ctx_.stripeBodies.clear();
+  ctx_.packScratch.clear();
   dataInput_->clear();
 }
 
@@ -328,14 +390,15 @@ void NimbleIndexProjector::loadStripes() {
   for (size_t stripeOffset = 0; stripeOffset < stripePlans.size();
        ++stripeOffset) {
     dataInput_->startGroup();
-    const auto base = stripeOffset * numProjectedStreams;
+    const auto dataInputBase = stripeOffset * numProjectedStreams;
     const auto& streams = stripePlans[stripeOffset].projectedStreams;
     for (size_t streamIndex = 0; streamIndex < streams.size(); ++streamIndex) {
       const auto& stream = streams[streamIndex];
       if (!stream.has_value()) {
         continue;
       }
-      ctx_.dataInputIndices[base + streamIndex] = dataInput_->enqueue(*stream);
+      ctx_.dataInputIndices[dataInputBase + streamIndex] =
+          dataInput_->enqueue(*stream);
     }
   }
   ctx_.dataHandle = dataInput_->load();
@@ -346,6 +409,7 @@ NimbleIndexProjector::Result NimbleIndexProjector::processStripes() {
   Result result;
   result.responses.resize(ctx_.numRequests);
   ctx_.stripeBodies.resize(ctx_.plan.stripePlans.size());
+
   for (size_t i = 0; i < ctx_.plan.stripePlans.size(); ++i) {
     ++stats_.numReadStripes;
     ctx_.stripeBodies[i] = packStripe(i);
@@ -384,49 +448,129 @@ folly::IOBuf NimbleIndexProjector::packStripe(size_t stripeOffset) {
   const auto& stripePlan = ctx_.plan.stripePlans[stripeOffset];
   const auto numRows = stripeRowCount(stripePlan.stripeIndex);
   const auto numProjectedStreams = projectedStreamOffsets_.size();
-  const auto base = stripeOffset * numProjectedStreams;
 
-  // Build stream sizes from the precomputed projected regions.
-  std::vector<uint32_t> streamSizes(numProjectedStreams, 0);
-  for (size_t i = 0; i < numProjectedStreams; ++i) {
-    if (stripePlan.projectedStreams[i].has_value()) {
-      streamSizes[i] =
-          static_cast<uint32_t>(stripePlan.projectedStreams[i]->length);
-    }
-  }
+  // Deduplicate streams that the source tablet already aliased: multiple
+  // projected slots can resolve to the same physical extent. DataInput detects
+  // those exact duplicates during load(); packStripe consumes that result via
+  // BufferRef::canonicalIndex (below) rather than re-detecting, so each
+  // physical stream is written into the body only once and duplicate slots
+  // reuse the stored copy's stream size index in the kTablet dedup trailer.
+  auto& packScratch = ctx_.packScratch;
+  SCOPE_EXIT {
+    packScratch.clear();
+  };
+  packScratch.reserve(numProjectedStreams);
 
-  // First stream IOBuf holds the DataInput::Handle via takeOwnership,
-  // keeping the loaded data alive. Subsequent streams use wrapBuffer
-  // (no ownership) since the chain is always cloned/destroyed as a unit.
+  // Each unique stream is wrapped zero-copy into the output chain. Streams that
+  // are physically contiguous in the DataInput read buffer are merged into a
+  // single IOBuf node — fewer nodes means cheaper appendToChain here and
+  // cheaper cloneAsValue per request in buildResult. The first node holds the
+  // DataInput::Handle (takeOwnership) to keep the loaded data alive; the rest
+  // wrapBuffer it, since the chain is always cloned/destroyed as a unit.
   std::unique_ptr<folly::IOBuf> chain;
-  for (size_t i = 0; i < numProjectedStreams; ++i) {
-    if (!ctx_.dataInputIndices[base + i].has_value()) {
-      continue;
+  const char* runData = nullptr;
+  uint64_t runLength = 0;
+  const auto flushRun = [&]() {
+    if (runData == nullptr) {
+      return;
     }
-    const auto& ref = dataInput_->bufferRef(*ctx_.dataInputIndices[base + i]);
     if (chain == nullptr) {
       chain = folly::IOBuf::takeOwnership(
-          const_cast<char*>(ref.data),
-          ref.length,
+          const_cast<char*>(runData),
+          runLength,
           freeDataHandle,
           new DataInput::Handle(ctx_.dataHandle));
     } else {
-      chain->appendToChain(folly::IOBuf::wrapBuffer(ref.data, ref.length));
+      chain->appendToChain(folly::IOBuf::wrapBuffer(runData, runLength));
+    }
+    runData = nullptr;
+    runLength = 0;
+  };
+
+  uint32_t bodyOffset{0};
+  uint32_t streamEnqueueBase{0};
+  const auto dataInputBase = stripeOffset * numProjectedStreams;
+  for (size_t i = 0; i < numProjectedStreams; ++i) {
+    if (!stripePlan.projectedStreams[i].has_value()) {
+      continue;
+    }
+    const auto& streamRegion = *stripePlan.projectedStreams[i];
+    NIMBLE_CHECK_GT(
+        streamRegion.length, 0, "Projected stream must not be empty");
+    const auto streamSize = static_cast<uint32_t>(streamRegion.length);
+    packScratch.streamIds.emplace_back(static_cast<uint32_t>(i));
+
+    NIMBLE_CHECK(
+        ctx_.dataInputIndices[dataInputBase + i].has_value(),
+        "Present projected stream must have an enqueued data input index");
+    const auto enqueueIndex = *ctx_.dataInputIndices[dataInputBase + i];
+    if (packScratch.streamSizeIndices.empty()) {
+      streamEnqueueBase = enqueueIndex;
+    }
+    const auto& bufferRef = dataInput_->bufferRef(enqueueIndex);
+    NIMBLE_CHECK_EQ(
+        bufferRef.length,
+        streamRegion.length,
+        "Loaded stream length must match projected stream length");
+    // DataInput already detected exact-duplicate extents during load(). A
+    // duplicate stream's canonicalIndex differs from its own; only the stored
+    // copy appends its bytes, while duplicates reuse the stored copy's stream
+    // size index. Duplicates are confined to a single stripe group, and enqueue
+    // order matches this loop's present-stream order, so the stored copy's
+    // local index has already been written to streamSizeIndices.
+    if (bufferRef.canonicalIndex != enqueueIndex) {
+      NIMBLE_CHECK_GE(
+          bufferRef.canonicalIndex,
+          streamEnqueueBase,
+          "Duplicate stream must refer to the current stripe");
+      const auto canonicalIndexOffset =
+          bufferRef.canonicalIndex - streamEnqueueBase;
+      NIMBLE_CHECK_LT(
+          canonicalIndexOffset,
+          packScratch.streamSizeIndices.size(),
+          "Duplicate stream must refer to an earlier stream in the stripe");
+      packScratch.streamSizeIndices.emplace_back(
+          packScratch.streamSizeIndices[canonicalIndexOffset]);
+      continue;
+    }
+    packScratch.streamSizeIndices.emplace_back(
+        static_cast<uint32_t>(packScratch.uniqueStreamSizes.size()));
+    packScratch.uniqueStreamSizes.emplace_back(streamSize);
+    bodyOffset += streamSize;
+
+    if (runData != nullptr && bufferRef.data == runData + runLength) {
+      // Contiguous in the read buffer: extend the current run rather than
+      // adding another IOBuf node.
+      runLength += bufferRef.length;
+    } else {
+      flushRun();
+      runData = bufferRef.data;
+      runLength = bufferRef.length;
     }
   }
+  flushRun();
 
-  std::string trailerBuf;
-  serde::detail::writeTrailer(
-      streamSizes,
-      EncodingType::FixedBitWidth,
-      EncodingType::FixedBitWidth,
+  const auto estimatedTrailerSize = estimateTabletTrailerSize(
+      packScratch.streamIds.size(), packScratch.uniqueStreamSizes.size());
+  // The trailer is a small standalone node with an estimated upper-bound
+  // capacity. createCombined() keeps the IOBuf object and byte storage in one
+  // allocation, avoiding the extra backing-buffer allocation that create()
+  // would use.
+  auto trailer = folly::IOBuf::createCombined(estimatedTrailerSize);
+  IOBufAppender trailerBuf{*trailer};
+  writeTabletTrailer(
+      packScratch.streamIds,
+      packScratch.streamSizeIndices,
+      packScratch.uniqueStreamSizes,
       trailerBuf);
 
   NIMBLE_CHECK_NOT_NULL(chain);
-  auto trailer = folly::IOBuf::copyBuffer(trailerBuf);
+  const auto trailerSize = trailer->length();
   chain->appendToChain(std::move(trailer));
 
-  const size_t bodySize = stripePlan.projectedBytes + trailerBuf.size();
+  // projectedBytes counts logical projected stream bytes, including duplicate
+  // slots. bodyOffset is the physical body size after deduplication.
+  const size_t bodySize = bodyOffset + trailerSize;
   stats_.numReadRows += numRows;
   stats_.numOutputBytes += bodySize;
   return std::move(*chain);

--- a/dwio/nimble/velox/index/NimbleIndexProjector.h
+++ b/dwio/nimble/velox/index/NimbleIndexProjector.h
@@ -244,7 +244,8 @@ class NimbleIndexProjector {
     uint32_t numRows{0};
     // Number of projected streams present in this stripe.
     uint32_t numStreams{0};
-    // Total bytes across all projected streams in this stripe.
+    // Total logical bytes across all projected streams in this stripe.
+    // Duplicate regions are counted once per projected stream.
     uint64_t projectedBytes{0};
     // Stream regions for projected columns. Indexed by projected stream
     // offset; nullopt for streams absent in this stripe.
@@ -342,6 +343,32 @@ class NimbleIndexProjector {
     // Serialized stripe bodies, one per StripePlan. Populated by
     // processStripes(), consumed during buildResult().
     std::vector<folly::IOBuf> stripeBodies;
+
+    // Reusable per-stripe inputs for the kTablet trailer. packStripe()
+    // rebuilds these vectors for each stripe and clears them on exit to avoid
+    // repeated allocations across stripes.
+    struct PackScratch {
+      void clear() {
+        streamIds.clear();
+        streamSizeIndices.clear();
+        uniqueStreamSizes.clear();
+      }
+
+      void reserve(uint32_t numProjectedStreams) {
+        streamIds.reserve(numProjectedStreams);
+        streamSizeIndices.reserve(numProjectedStreams);
+        uniqueStreamSizes.reserve(numProjectedStreams);
+      }
+
+      // Present projected stream slots, in projected-stream order.
+      std::vector<uint32_t> streamIds;
+      // For each streamIds entry, the body-order index of the unique stream
+      // bytes used by that slot.
+      std::vector<uint32_t> streamSizeIndices;
+      // Sizes for unique stream byte ranges, in body order.
+      std::vector<uint32_t> uniqueStreamSizes;
+    };
+    PackScratch packScratch;
   };
   ProjectionContext ctx_;
 

--- a/dwio/nimble/velox/index/tests/NimbleIndexProjectorTest.cpp
+++ b/dwio/nimble/velox/index/tests/NimbleIndexProjectorTest.cpp
@@ -39,6 +39,7 @@
 #include "velox/common/testutil/TempFilePath.h"
 #include "velox/serializers/KeyEncoder.h"
 #include "velox/vector/tests/utils/VectorMaker.h"
+#include "velox/vector/tests/utils/VectorTestBase.h"
 
 namespace facebook::nimble::test {
 
@@ -217,6 +218,61 @@ class NimbleIndexProjectorTest : public ::testing::TestWithParam<TestParam> {
     ensureTabletReaderCache();
     return NimbleIndexProjector::create(
         *tabletReaderCache_, fileHandle, projectedSubfields, readerOptions);
+  }
+
+  VectorPtr deserializeProjectedBatches(
+      const NimbleIndexProjector& projector,
+      const std::vector<std::string_view>& batches) {
+    DeserializerOptions deserOptions;
+    deserOptions.hasHeader = true;
+    Deserializer deserializer(
+        projector.projectedNimbleType(), leafPool_.get(), deserOptions);
+    VectorPtr output;
+    deserializer.deserialize(batches, output);
+    return output;
+  }
+
+  VectorPtr deserializeProjectedSlice(
+      const NimbleIndexProjector& projector,
+      const folly::IOBuf& slice) {
+    auto coalesced = coalesceChunkSlice(slice);
+    std::vector<std::string_view> batches{std::string_view(
+        reinterpret_cast<const char*>(coalesced.data()), coalesced.length())};
+    return deserializeProjectedBatches(projector, batches);
+  }
+
+  VectorPtr makeOutputRange(
+      const VectorPtr& output,
+      uint32_t outputOffset,
+      vector_size_t numRows) {
+    if (outputOffset == 0 && output->size() == numRows) {
+      return output;
+    }
+
+    auto indices = allocateIndices(numRows, leafPool_.get());
+    auto* rawIndices = indices->asMutable<vector_size_t>();
+    for (vector_size_t i = 0; i < numRows; ++i) {
+      rawIndices[i] = static_cast<vector_size_t>(outputOffset) + i;
+    }
+    return BaseVector::wrapInDictionary(nullptr, indices, numRows, output);
+  }
+
+  // Compares decoded output rows with a compact expected vector. The
+  // deserializer returns full stripes, so range tests dictionary-wrap the
+  // selected rows before using Velox's vector equality assertion.
+  void expectVectorRows(
+      const VectorPtr& output,
+      uint32_t expectedRows,
+      const VectorPtr& expected,
+      uint32_t outputOffset = 0) {
+    ASSERT_NE(output, nullptr);
+    ASSERT_NE(expected, nullptr);
+    ASSERT_EQ(output->size(), expectedRows);
+    ASSERT_LE(
+        static_cast<uint64_t>(outputOffset) + expected->size(),
+        static_cast<uint64_t>(output->size()));
+    velox::test::assertEqualVectors(
+        expected, makeOutputRange(output, outputOffset, expected->size()));
   }
 
   // Creates encoded key bounds for a point lookup on a single int64 key.
@@ -600,9 +656,33 @@ TEST_P(NimbleIndexProjectorTest, deduplicatedProjectedStreamsReadOnce) {
   ASSERT_EQ(result.responses[0].slices.size(), 1);
   EXPECT_EQ(projector->stats().numReadStripes, 1);
   EXPECT_EQ(dataIoStats_->read().count(), 1);
-  EXPECT_LE(dataIoStats_->rawBytesRead() * 2, projector->stats().numOutputBytes)
-      << "The physical payload should be one deduplicated stream while the "
-         "projected output still contains both logical streams";
+  // dup_a and dup_b carry identical data, so the source tablet aliases their
+  // streams to one extent. The packed output is now deduplicated too: the body
+  // holds a single physical copy that both logical streams reference via the
+  // kTablet dedup trailer, so the output stays well under the ~2x size it would
+  // be if each logical stream carried its own copy.
+  EXPECT_LT(projector->stats().numOutputBytes, dataIoStats_->rawBytesRead() * 2)
+      << "Deduplicated output must hold a single physical copy of the aliased "
+         "stream, not two";
+
+  // The duplicate streams are reported through IoStatistics (surfaced via the
+  // rexdb benchmark): DirectDataInput coalesces the aliased dup_a/dup_b regions
+  // into one read, so the projector's data IO stats record the duplicate.
+  EXPECT_GT(dataIoStats_->duplicateReadRegions(), 0u)
+      << "dup_a and dup_b should be detected as duplicate read regions";
+  EXPECT_GT(dataIoStats_->duplicateReadBytes(), 0u);
+
+  // Both aliased logical streams must still decode correctly from the single
+  // shared body copy: the kTablet dedup trailer resolves both slots to the same
+  // body extent.
+  auto expected = vectorMaker_->rowVector(
+      {"dup_a", "dup_b"},
+      {vectorMaker_->flatVector<int32_t>(values),
+       vectorMaker_->flatVector<int32_t>(values)});
+  expectVectorRows(
+      deserializeProjectedSlice(*projector, result.responses[0].slices[0]),
+      static_cast<uint32_t>(numRows),
+      expected);
 }
 
 // Round-trips a single-batch deserialize over a key range. The Deserializer
@@ -636,26 +716,17 @@ TEST_P(NimbleIndexProjectorTest, deduplicatedProjectedStreamsReadOnce) {
     request.keyBounds = {bounds};                                              \
     auto result = projector->project(request, {});                             \
     ASSERT_EQ(result.responses[0].slices.size(), 1);                           \
-    auto coalesced = result.responses[0].slices[0].cloneCoalescedAsValue();    \
-    auto bytes = std::string_view(                                             \
-        reinterpret_cast<const char*>(coalesced.data()), coalesced.length());  \
-    DeserializerOptions deserOptions;                                          \
-    deserOptions.hasHeader = true;                                             \
-    Deserializer deserializer(                                                 \
-        projector->projectedNimbleType(), leafPool_.get(), deserOptions);      \
-    std::vector<std::string_view> singleBatch{bytes};                          \
-    VectorPtr output;                                                          \
-    deserializer.deserialize(singleBatch, output);                             \
-    ASSERT_EQ(output->size(), static_cast<uint32_t>(numRows));                 \
-    auto* rowVec = output->as<velox::RowVector>();                             \
-    auto* valueVec = rowVec->childAt(0)->as<velox::FlatVector<int32_t>>();     \
-    /* Verify the in-range subset has expected values. */                      \
-    for (uint32_t i = static_cast<uint32_t>(lowerKey_);                        \
-         i < static_cast<uint32_t>(upperKey_);                                 \
-         ++i) {                                                                \
-      EXPECT_EQ(valueVec->valueAt(i), static_cast<int32_t>(i * 10))            \
-          << "i=" << i;                                                        \
-    }                                                                          \
+    const auto expectedOffset = static_cast<size_t>(lowerKey_);                \
+    const auto expectedEnd = static_cast<size_t>(upperKey_);                   \
+    std::vector<int32_t> expectedValues(                                       \
+        values.begin() + expectedOffset, values.begin() + expectedEnd);        \
+    auto expected = vectorMaker_->rowVector(                                   \
+        {"value"}, {vectorMaker_->flatVector<int32_t>(expectedValues)});       \
+    expectVectorRows(                                                          \
+        deserializeProjectedSlice(*projector, result.responses[0].slices[0]),  \
+        static_cast<uint32_t>(numRows),                                        \
+        expected,                                                              \
+        static_cast<uint32_t>(expectedOffset));                                \
   } while (0)
 
 TEST_P(NimbleIndexProjectorTest, deserializerRangeAtStart) {
@@ -1009,6 +1080,7 @@ TEST_P(NimbleIndexProjectorTest, localReadModeStats) {
   constexpr int rowsPerBatch = 128;
   constexpr int numRows = numBatches * rowsPerBatch;
   std::vector<RowVectorPtr> inputBatches;
+  std::vector<int32_t> expectedValues(numRows);
   inputBatches.reserve(numBatches);
   for (int batch = 0; batch < numBatches; ++batch) {
     std::vector<int64_t> keys(rowsPerBatch);
@@ -1017,6 +1089,7 @@ TEST_P(NimbleIndexProjectorTest, localReadModeStats) {
       const auto key = batch * rowsPerBatch + row;
       keys[row] = key;
       values[row] = key * 10;
+      expectedValues[key] = values[row];
     }
     inputBatches.emplace_back(vectorMaker_->rowVector(
         {"key", "value"},
@@ -1100,19 +1173,12 @@ TEST_P(NimbleIndexProjectorTest, localReadModeStats) {
           ownedSlices.back().length());
     }
 
-    DeserializerOptions deserOptions;
-    deserOptions.hasHeader = true;
-    Deserializer deserializer(
-        projector->projectedNimbleType(), leafPool_.get(), deserOptions);
-    VectorPtr output;
-    deserializer.deserialize(serializedBatches, output);
-    ASSERT_EQ(output->size(), static_cast<uint32_t>(numRows));
-    auto* rowVec = output->as<RowVector>();
-    auto* valueVec = rowVec->childAt(0)->as<FlatVector<int32_t>>();
-    for (uint32_t row = 0; row < numRows; ++row) {
-      EXPECT_EQ(valueVec->valueAt(row), static_cast<int32_t>(row * 10))
-          << "row=" << row;
-    }
+    auto expected = vectorMaker_->rowVector(
+        {"value"}, {vectorMaker_->flatVector<int32_t>(expectedValues)});
+    expectVectorRows(
+        deserializeProjectedBatches(*projector, serializedBatches),
+        static_cast<uint32_t>(numRows),
+        expected);
 
     EXPECT_EQ(projector->stats().numReadStripes, numBatches);
     EXPECT_EQ(projector->stats().numReadRows, numRows);


### PR DESCRIPTION
Summary:
CONTEXT: When the index projector packs projected streams into a kTablet output chunk, multiple projected slots can point at the same source tablet extent. The source writer already aliases identical stream contents, but the projector previously copied each projected slot into the output body independently, inflating pack CPU and output bytes.

WHAT: Deduplicate aliased streams in `NimbleIndexProjector::packStripe()`. `DataInput` canonicalizes exact duplicate read regions during `load()` and exposes each loaded `BufferRef`'s `canonicalIndex`; the projector writes each physical stream body once, records each logical stream slot's unique-stream index, and emits the kTablet trailer with `streamIds`, `streamSizeIndices`, and `uniqueStreamSizes`. The deserializer reconstructs per-slot sizes and body offsets from that trailer, so duplicate logical slots decode from the same body extent. The trailer writer remains configurable for tests, while the projector owns the fixed `FixedBitWidth` encoding policy through local `estimateTabletTrailerSize()` / `writeTabletTrailer()` helpers.

DETAILS: Trailer construction now writes directly into an `IOBuf` via `IOBufAppender`, avoiding a temporary `std::string` copy; the trailer node uses `folly::IOBuf::createCombined()` because the trailer is a small standalone buffer with an estimated upper-bound capacity. Naming/comments were updated from generic index/dictionary wording to `streamIds`, `sizeIndices`, `uniqueStreamSizes`, `canonicalIndex`, and `uniqueStreamSizesScratch_`. Projector tests now compare decoded output against expected Velox vectors rather than hand-checking individual `int32` columns. Serializer tests now refer to the three-section format as the kTablet trailer, and `SerializationTest.tabletTrailerDeserialization` assembles kTablet blobs through the same trailer utility, verifies duplicate stream bodies collapse to fewer unique body ranges, loops over all supported trailer section encoding combinations, and deserializes each blob back to the original vector.

Reviewed By: tanjialiang

Differential Revision: D108532184


