### PR TITLE
refactor(nimble): Rename inMapPresentOffsets{,List}_ → streamPresent{Bitmap,DirtyList}_

### DIFF
--- a/dwio/nimble/serializer/Deserializer.cpp
+++ b/dwio/nimble/serializer/Deserializer.cpp
@@ -707,9 +707,9 @@ Deserializer::Deserializer(
   for (auto& [offset, decoder] : deserializerMap_) {
     deserializers_[offset] = decoder.get();
   }
-  // Size inMapPresentOffsets_ to match for flatmap present tracking.
+  // Size streamPresentBitmap_ to match for flatmap present tracking.
   if (!inMapChildTypes_.empty()) {
-    inMapPresentOffsets_.resize(maxOffset + 1, false);
+    streamPresentBitmap_.resize(maxOffset + 1, false);
   }
 }
 
@@ -800,11 +800,11 @@ void Deserializer::deserialize(
     const auto numRows = reader.initialize(sv);
     const auto version = reader.version();
     // Reset present tracking from previous batch.
-    if (hasInMapChildren && !inMapPresentOffsetsList_.empty()) {
-      for (auto off : inMapPresentOffsetsList_) {
-        inMapPresentOffsets_[off] = false;
+    if (hasInMapChildren && !streamPresentDirtyList_.empty()) {
+      for (auto off : streamPresentDirtyList_) {
+        streamPresentBitmap_[off] = false;
       }
-      inMapPresentOffsetsList_.clear();
+      streamPresentDirtyList_.clear();
     }
     // iterateStreams() is a templated callback walker; the lambda body
     // inlines into the loop, eliminating std::function dispatch on the
@@ -812,8 +812,8 @@ void Deserializer::deserialize(
     reader.iterateStreams([&](uint32_t offset, std::string_view streamData) {
       if (offset <= maxStreamOffset) {
         if (hasInMapChildren) {
-          inMapPresentOffsets_[offset] = true;
-          inMapPresentOffsetsList_.emplace_back(offset);
+          streamPresentBitmap_[offset] = true;
+          streamPresentDirtyList_.emplace_back(offset);
         }
         // Null is possible: deserializers_ is sized to maxOffset+1 but only
         // populated for offsets in deserializerMap_. Some serialized stream
@@ -832,11 +832,11 @@ void Deserializer::deserialize(
     // hot path is a flat bitmap scan; no recursive schema walk and no
     // callback dispatch.
     for (const auto& [inMapOffset, valueOffsets] : inMapValueStreamOffsets_) {
-      if (inMapPresentOffsets_[inMapOffset]) {
+      if (streamPresentBitmap_[inMapOffset]) {
         continue;
       }
       for (const auto offset : valueOffsets) {
-        if (offset <= maxStreamOffset && inMapPresentOffsets_[offset]) {
+        if (offset <= maxStreamOffset && streamPresentBitmap_[offset]) {
           DeserializerImpl::toDecoderImpl(deserializers_[inMapOffset])
               ->addPresentInMapSegment(rowOffset, numRows);
           break;

--- a/dwio/nimble/serializer/Deserializer.h
+++ b/dwio/nimble/serializer/Deserializer.h
@@ -80,13 +80,15 @@ class Deserializer {
   folly::F14FastMap<uint32_t, std::vector<offset_size>>
       inMapValueStreamOffsets_;
 
-  // Flat boolean vector indexed by stream offset for tracking which streams
-  // are present in the current batch. Replaces F14FastSet for O(1) access.
-  // Only used when inMapChildTypes_ is non-empty.
-  mutable std::vector<bool> inMapPresentOffsets_;
-  // Offsets that were set in inMapPresentOffsets_ this batch (for efficient
-  // reset).
-  mutable std::vector<uint32_t> inMapPresentOffsetsList_;
+  // Flat boolean vector indexed by stream offset, tracking which streams are
+  // present in the current batch. Consumed by the in-map inference pass to
+  // detect dropped inMap streams whose values are still present. Holds ALL
+  // present offsets (value streams, lengths streams, nulls, inMap), not just
+  // inMap ones. Only allocated when inMapChildTypes_ is non-empty.
+  mutable std::vector<bool> streamPresentBitmap_;
+  // Dirty list of offsets flipped to `true` in `streamPresentBitmap_` this
+  // batch, so reset between batches is O(touched) instead of O(maxOffset).
+  mutable std::vector<uint32_t> streamPresentDirtyList_;
 };
 
 } // namespace facebook::nimble


### PR DESCRIPTION
Summary:
Pure rename. The two `inMapPresentOffsets*` members on `Deserializer` track
ALL stream offsets present in the current batch — value streams, lengths
streams, nulls streams, AND inMap streams. The `inMap` prefix described
the consumer (the in-map inference pass that probes the bitmap) rather
than the contents, which is misleading: readers expect a name starting
with `inMap` to hold inMap-related state, but these hold every present
stream offset, indexed by raw stream offset.

Renames:
  - `inMapPresentOffsets_`     → `streamPresentBitmap_`
  - `inMapPresentOffsetsList_` → `streamPresentDirtyList_`

Both type and behavior are unchanged: a `vector<bool>` indexed by stream
offset plus an O(touched)-reset dirty list.

Names that ARE genuinely inMap-keyed are kept as-is:
  - `inMapChildTypes_`     — `inMapStreamOffset → child Type*`, keyed by inMap.
  - `inMapValueAnchors_`   — `inMapStreamOffset → vector<anchor offsets>`,
                              also keyed by inMap.
  - `presentInMapSegments_` (inside `DeserializerImpl`) — the synthesized
                              "key was implicitly present in this row range"
                              segment list, genuinely about inMap.

Touched only Deserializer.{h,cpp} (15 occurrences across 13 references in
.cpp and 2 in .h). Member comments tightened to match the new names.

Differential Revision: D107615247


