### PR TITLE
misc(nimble): Bump Velox submodule to latest main

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ Nimble integrates Velox as a Git submodule, referencing a specific commit of the
 Velox repository. The Velox badge at the top of this README shows the current
 commit and how far behind it is from Velox main.
 
-[See what changed since the current Velox commit.](https://github.com/facebookincubator/velox/compare/25f1fe4936676efb899893b916ff9a7f9650fb89...main)
+[See what changed since the current Velox commit.](https://github.com/facebookincubator/velox/compare/232ab605bad3cd471cd64d0b1a95630341e607cb...main)
 <!-- pre-commit check-velox-readme validates the SHA above matches the submodule -->
 
 Advance Velox when your changes depend on code in Velox that


### PR DESCRIPTION
Summary:

Routine bump to keep Nimble's pinned Velox submodule current with `main` so the OSS GitHub CI builds against the latest Velox.

Bumps `dwio/nimble/public_tld/velox.submodule.txt` from `25f1fe4936676efb899893b916ff9a7f9650fb89` to `232ab605bad3cd471cd64d0b1a95630341e607cb`. README.md compare-link updated in lockstep (the `pre-commit check-velox-readme` hook validates the SHA above matches the submodule).

Differential Revision: D108716529
