### PR TITLE
misc(nimble): Bump Velox submodule version (#883)

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ Nimble integrates Velox as a Git submodule, referencing a specific commit of the
 Velox repository. The Velox badge at the top of this README shows the current
 commit and how far behind it is from Velox main.
 
-[See what changed since the current Velox commit.](https://github.com/facebookincubator/velox/compare/232ab605bad3cd471cd64d0b1a95630341e607cb...main)
+[See what changed since the current Velox commit.](https://github.com/facebookincubator/velox/compare/e48e3cd6cbb2e26138e32a72ca2b1ff8808eeaf4...main)
 <!-- pre-commit check-velox-readme validates the SHA above matches the submodule -->
 
 Advance Velox when your changes depend on code in Velox that


### PR DESCRIPTION
Summary:

Bump Nimble's Velox submodule to e48e3cd6cbb2e26138e32a72ca2b1ff8808eeaf4 and update the Velox compare link in README.md to match (enforced by the check-velox-readme pre-commit hook) to fix the build issue.

Differential Revision: D108823663
