### PR TITLE
feat(nimble): Add per-block statistics for encoding size estimation (#885)

### DIFF
--- a/dwio/nimble/docs/architecture/encoding_cost_model.html
+++ b/dwio/nimble/docs/architecture/encoding_cost_model.html
@@ -1,0 +1,416 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<base target="_blank">
+<title>Nimble Encoding Cost Model</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;600;700&family=DM+Sans:wght@400;500&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
+<style>
+:root {
+  --bg: #f5f7fa;
+  --bg-alt: #eef1f6;
+  --surface: #ffffff;
+  --text-primary: #0f1a2e;
+  --text-secondary: #4a5568;
+  --text-muted: #8896ab;
+  --border: #dde3ed;
+  --border-strong: #c1c9d6;
+  --surface-hover: #f1f5f9;
+
+  --col0: #2563eb;
+  --col1: #9ca3af;
+  --col2: #7c3aed;
+  --col3: #059669;
+
+  --layer-query: #6366f1;
+  --layer-encoding: #059669;
+
+  --accent: #f59e0b;
+  --accent-glow: rgba(245,158,11,0.12);
+  --kill: #ef4444;
+  --pass: #22c55e;
+}
+body.dark-mode {
+  --bg: #0c1220;
+  --bg-alt: #111827;
+  --surface: #1a2332;
+  --text-primary: #e8ecf4;
+  --text-secondary: #94a3b8;
+  --text-muted: #64748b;
+  --border: #2a3548;
+  --border-strong: #3b4a60;
+  --surface-hover: #1e293b;
+  --accent-glow: rgba(245,158,11,0.06);
+}
+
+* { margin:0; padding:0; box-sizing:border-box; }
+body {
+  font-family: 'DM Sans', sans-serif;
+  background: var(--bg);
+  color: var(--text-primary);
+  line-height: 1.55;
+}
+body::before {
+  content:'';
+  position:fixed; inset:0;
+  background:
+    radial-gradient(ellipse at 15% 0%, rgba(99,102,241,0.06) 0%, transparent 55%),
+    radial-gradient(ellipse at 85% 100%, rgba(245,158,11,0.04) 0%, transparent 55%);
+  pointer-events:none; z-index:0;
+}
+.container { position:relative; z-index:1; max-width:1100px; margin:0 auto; padding:3rem 2rem 2rem; }
+
+h1 { font-family:'Space Grotesk',sans-serif; font-size:1.85rem; font-weight:700; text-align:center; letter-spacing:-0.02em; margin-bottom:0.15rem; }
+.subtitle { text-align:center; color:var(--text-secondary); font-size:0.9rem; margin-bottom:2rem; }
+
+/* Sections */
+.section { margin-bottom:2rem; }
+.section-head {
+  font-family:'Space Grotesk',sans-serif; font-size:0.65rem; font-weight:600;
+  letter-spacing:0.1em; text-transform:uppercase; color:var(--text-muted);
+  margin-bottom:0.6rem; display:flex; align-items:center; gap:0.5rem;
+}
+.section-head::after { content:''; flex:1; height:1px; background:var(--border); }
+.section-num {
+  display:inline-flex; align-items:center; justify-content:center;
+  width:18px; height:18px; border-radius:50%;
+  font-size:0.6rem; font-weight:700; color:#fff;
+}
+
+/* Step cards */
+.step {
+  border:1.5px solid var(--border); border-radius:12px;
+  padding:1rem 1.25rem; background:var(--surface);
+  margin-bottom:0.6rem;
+}
+.step h3 {
+  font-family:'Space Grotesk',sans-serif; font-size:0.95rem; font-weight:600;
+  margin-bottom:0.3rem;
+}
+.step-label {
+  font-family:'Space Grotesk',sans-serif; font-size:0.6rem; font-weight:600;
+  letter-spacing:0.08em; text-transform:uppercase; color:var(--accent);
+  margin-bottom:0.2rem;
+}
+
+code {
+  font-family:'JetBrains Mono',monospace; font-size:0.72rem;
+  background:var(--bg-alt); padding:0.08rem 0.3rem; border-radius:3px;
+}
+
+/* Formula blocks */
+.formula {
+  font-family:'JetBrains Mono',monospace; font-size:0.75rem;
+  background:var(--bg-alt); border:1px solid var(--border);
+  padding:0.6rem 0.8rem; border-radius:6px;
+  margin:0.5rem 0; line-height:1.8; overflow-x:auto;
+}
+.formula .var { color:var(--col0); }
+.formula .fn { color:var(--col3); }
+.formula .op { color:var(--accent); font-weight:500; }
+.formula .comment { color:var(--text-muted); font-style:italic; }
+.formula .highlight { color:var(--kill); font-weight:700; }
+
+/* Encoding cards */
+.encodings {
+  display:grid; grid-template-columns:repeat(auto-fit, minmax(280px, 1fr));
+  gap:0.8rem; margin:0.8rem 0;
+}
+.enc-card {
+  border:1.5px solid var(--border); border-radius:10px;
+  padding:0.9rem 1rem; background:var(--surface);
+  border-left:3px solid var(--border-strong);
+}
+.enc-card.highlight { border-left-color:var(--accent); }
+.enc-card.new { border-left-color:var(--kill); }
+.enc-name {
+  font-family:'Space Grotesk',sans-serif;
+  font-weight:700; font-size:0.9rem; margin-bottom:0.4rem;
+}
+.enc-name .tag {
+  font-family:'DM Sans',sans-serif;
+  font-size:0.6rem; padding:0.1rem 0.4rem; border-radius:3px;
+  margin-left:0.4rem; vertical-align:middle; font-weight:600;
+}
+.tag-new { background:var(--kill); color:#fff; }
+.tag-modified { background:var(--accent); color:#fff; }
+.tag-unchanged { background:var(--bg-alt); color:var(--text-muted); border:1px solid var(--border); }
+
+/* Comparison */
+.comparison {
+  display:grid; grid-template-columns:1fr 1fr; gap:0.8rem; margin:0.8rem 0;
+}
+.comparison > div {
+  border:1.5px solid var(--border); border-radius:10px;
+  padding:0.9rem 1rem; background:var(--surface);
+}
+.comparison .label {
+  font-family:'Space Grotesk',sans-serif;
+  font-size:0.65rem; font-weight:600; color:var(--text-muted);
+  text-transform:uppercase; letter-spacing:0.05em; margin-bottom:0.4rem;
+}
+.example {
+  background:var(--bg-alt); border-radius:6px;
+  padding:0.7rem 0.9rem; margin:0.4rem 0; font-size:0.78rem;
+  color:var(--text-secondary); line-height:1.7;
+}
+.example .title {
+  font-family:'Space Grotesk',sans-serif;
+  color:var(--text-primary); font-weight:600; font-size:0.8rem;
+  margin-bottom:0.25rem;
+}
+
+/* Table */
+.stats-table {
+  width:100%; border-collapse:collapse; margin:0.5rem 0; font-size:0.8rem;
+}
+.stats-table th {
+  text-align:left; color:var(--text-muted); font-weight:600;
+  padding:0.4rem 0.6rem; border-bottom:1.5px solid var(--border);
+  font-family:'Space Grotesk',sans-serif; font-size:0.7rem;
+  letter-spacing:0.03em; text-transform:uppercase;
+}
+.stats-table td {
+  padding:0.4rem 0.6rem; border-bottom:1px solid var(--border);
+  color:var(--text-secondary);
+}
+.stats-table .num { text-align:right; font-family:'JetBrains Mono',monospace; }
+
+/* Primitive stack */
+.stack { max-width:520px; margin:0.8rem 0; display:flex; flex-direction:column; align-items:center; gap:0; }
+.stack-box {
+  border:1.5px solid var(--border); border-radius:8px;
+  padding:0.35rem 0.7rem; background:var(--surface);
+  font-family:'JetBrains Mono',monospace; font-size:0.72rem;
+  text-align:center; white-space:nowrap;
+}
+.stack-arrow { color:var(--text-muted); font-size:0.6rem; padding:0.15rem 0; }
+.stack-row { display:flex; gap:0.6rem; justify-content:center; }
+
+/* Pipe arrow */
+.pipe-arrow { display:flex; justify-content:center; padding:0.15rem 0; }
+.pipe-arrow .arr {
+  width:2px; height:16px; background:var(--accent); position:relative;
+}
+.pipe-arrow .arr::after {
+  content:''; position:absolute; bottom:-1px; left:50%;
+  transform:translateX(-50%);
+  border-left:4px solid transparent; border-right:4px solid transparent;
+  border-top:5px solid var(--accent);
+}
+
+/* Legend */
+.legend {
+  display:flex; flex-wrap:wrap; gap:1rem; justify-content:center;
+  margin-bottom:1.5rem; font-size:0.75rem; color:var(--text-secondary);
+}
+.legend-item { display:flex; align-items:center; gap:0.3rem; }
+.legend-dot { width:10px; height:10px; border-radius:3px; }
+
+/* Callout */
+.callout {
+  display:flex; align-items:flex-start; gap:0.5rem;
+  padding:0.6rem 0.8rem; border-radius:8px;
+  background:var(--accent-glow);
+  border:1px solid color-mix(in srgb, var(--accent) 25%, transparent);
+  font-size:0.78rem; color:var(--text-secondary); margin-top:0.6rem;
+}
+
+/* Animate */
+.ani { opacity:0; animation: fadeUp 0.5s ease forwards; }
+@keyframes fadeUp { from { opacity:0; transform:translateY(10px); } to { opacity:1; transform:none; } }
+.d1{animation-delay:.05s}.d2{animation-delay:.1s}.d3{animation-delay:.15s}
+.d4{animation-delay:.2s}.d5{animation-delay:.25s}.d6{animation-delay:.3s}
+.d7{animation-delay:.35s}.d8{animation-delay:.4s}
+
+/* Dark mode toggle */
+.theme-toggle {
+  position:fixed; top:1rem; right:1rem; z-index:100;
+  width:36px; height:36px; border-radius:8px;
+  border:1px solid var(--border); background:var(--surface);
+  color:var(--text-secondary); cursor:pointer;
+  display:flex; align-items:center; justify-content:center;
+  box-shadow:0 2px 8px rgba(0,0,0,.08); transition:background .15s;
+}
+.theme-toggle:hover { background:var(--surface-hover); }
+
+/* Responsive */
+@media (max-width:700px) {
+  .container { padding:2rem 1rem; }
+  .comparison { grid-template-columns:1fr; }
+  .encodings { grid-template-columns:1fr; }
+}
+@media (prefers-reduced-motion:reduce) {
+  .ani { opacity:1 !important; animation:none !important; }
+}
+</style>
+</head>
+<body>
+
+<button class="theme-toggle" onclick="document.body.classList.toggle('dark-mode')" aria-label="Toggle theme">&#9684;</button>
+
+<div class="container">
+
+<h1 class="ani d1">Nimble Encoding Cost Model</h1>
+<p class="subtitle ani d2">How encoding selection estimates sizes with per-block statistics</p>
+
+<div class="legend ani d2">
+  <div class="legend-item"><div class="legend-dot" style="background:var(--kill)"></div> New</div>
+  <div class="legend-item"><div class="legend-dot" style="background:var(--accent)"></div> Modified</div>
+  <div class="legend-item"><div class="legend-dot" style="background:var(--border-strong)"></div> Unchanged</div>
+</div>
+
+<!-- ============ CALL STACK GRAPH ============ -->
+<div class="section ani d3">
+  <div class="section-head"><span class="section-num" style="background:var(--col2)">0</span> Full Call Stack</div>
+
+  <div style="display:flex;flex-direction:column;align-items:center;gap:0">
+
+    <!-- Caller -->
+    <div class="step" style="width:100%;text-align:center;border-color:var(--text-muted)">
+      <div class="step-label">Caller</div>
+      <h3>EncodingFactory::encode()</h3>
+      <div style="font-size:0.72rem;color:var(--text-muted)">
+        Called by FieldWriter when flushing a stream.
+      </div>
+      <div class="formula" style="text-align:left">
+        auto statistics = Statistics&lt;physicalType&gt;::create(values);<br>
+        <span class="comment">// O(1)</span> <span style="color:var(--accent);font-weight:600">&larr; data_</span><br>
+        <br>
+        auto result = selectorPolicy-&gt;select(values, statistics);
+      </div>
+    </div>
+    <div class="pipe-arrow"><div class="arr"></div></div>
+
+    <!-- Root -->
+    <div class="step" style="width:100%;text-align:center;border-color:var(--border-strong)">
+      <div class="step-label">Encoding selection</div>
+      <h3>EncodingSelectionPolicy::select(values, statistics)</h3>
+      <div class="formula" style="text-align:left">
+        hasPerBlockEncoding = any_of(readFactors_, == BlockBitPacking);<br>
+        <br>
+        for (const auto&amp; [encodingType, readFactor] : readFactors_) {<br>
+        &nbsp;&nbsp;estimatedSize = EncodingSizeEstimation::estimateSize(encodingType, count, statistics, hasPerBlockEncoding);<br>
+        &nbsp;&nbsp;<span class="comment">// dispatches by type:</span><br>
+        &nbsp;&nbsp;<span class="comment">//   numeric → estimateNumericSize()</span><br>
+        &nbsp;&nbsp;<span class="comment">//   bool    → estimateBoolSize()</span><br>
+        &nbsp;&nbsp;<span class="comment">//   string  → estimateStringSize()</span><br>
+        &nbsp;&nbsp;cost = estimatedSize * readFactor;<br>
+        &nbsp;&nbsp;if (cost &lt; minCost) {<br>
+        &nbsp;&nbsp;&nbsp;&nbsp;selectedEncoding = encodingType;<br>
+        &nbsp;&nbsp;}<br>
+        }
+      </div>
+    </div>
+    <div class="pipe-arrow"><div class="arr"></div></div>
+
+    <!-- EncodingSizeEstimation dispatcher -->
+    <div class="step" style="width:100%;text-align:center">
+      <h3>EncodingSizeEstimation::estimateNumericSize()</h3>
+      <div style="font-size:0.75rem;color:var(--text-muted);margin-top:0.2rem">switch (encodingType) &rarr; dispatches to each encoding's estimateSize()</div>
+    </div>
+    <div class="pipe-arrow"><div class="arr"></div></div>
+
+    <!-- Trivial + Constant -->
+    <div style="display:grid;grid-template-columns:1fr 1fr;gap:0.6rem;width:100%;margin-bottom:0.6rem">
+      <div class="enc-card" style="width:100%">
+        <div class="enc-name">Trivial <span class="tag tag-unchanged">UNCHANGED</span></div>
+        <div style="font-size:0.62rem;color:var(--text-muted);margin-bottom:0.2rem">no stats needed</div>
+        <div class="formula" style="font-size:0.65rem;margin:0.2rem 0 0">
+          return prefix + count &times; sizeof(T)
+        </div>
+      </div>
+      <div class="enc-card" style="width:100%">
+        <div class="enc-name">Constant <span class="tag tag-unchanged">UNCHANGED</span></div>
+        <div style="font-size:0.62rem;color:var(--text-muted);margin-bottom:0.2rem">no stats needed</div>
+        <div class="formula" style="font-size:0.65rem;margin:0.2rem 0 0">
+          return prefix + sizeof(T)
+        </div>
+      </div>
+    </div>
+
+    <!-- FixedBitWidth + BlockBitPacking side by side -->
+    <div style="display:grid;grid-template-columns:1fr 1fr;gap:0.6rem;width:100%;margin-bottom:0.6rem">
+      <div class="enc-card" style="width:100%">
+        <div class="enc-name">FixedBitWidth <span class="tag tag-unchanged">UNCHANGED</span></div>
+        <div class="formula" style="font-size:0.62rem;margin:0.2rem 0 0">
+          estimateSize(rowCount, statistics, fixedByteWidth) {<br>
+          &nbsp;&nbsp;return estimateSize(rowCount, statistics.min(), statistics.max(), fixedByteWidth);<br>
+          }<br>
+          <br>
+          estimateSize(rowCount, minValue, maxValue, fixedByteWidth) {<br>
+          &nbsp;&nbsp;payloadSize = bitPackedBytes(minValue, maxValue, rowCount, fixedByteWidth);<br>
+          &nbsp;&nbsp;return prefix + kPrefixSize + payloadSize;<br>
+          }
+        </div>
+        <div style="margin-top:0.5rem;font-size:0.62rem;color:var(--text-secondary);line-height:1.6;border-top:1px solid var(--border);padding-top:0.4rem">
+          <div style="display:flex;align-items:center;gap:0.3rem;margin-bottom:0.2rem">
+            <span style="font-family:'JetBrains Mono',monospace">statistics.min()</span>
+          </div>
+          <div style="padding-left:0.8rem;font-family:'JetBrains Mono',monospace;font-size:0.6rem;line-height:1.8">
+            if (!min_.has_value()) {<br>
+            &nbsp;&nbsp;populateMinMax(); <span style="color:var(--accent);font-weight:600">&larr; scans data_ once</span><br>
+            &nbsp;&nbsp;<span class="comment">// sets both min_ AND max_ in one pass</span><br>
+            &nbsp;&nbsp;<span class="comment">// via std::minmax_element(data_)</span><br>
+            }<br>
+            return min_.value(); <span style="color:var(--pass)">&larr; cached after first call</span>
+          </div>
+        </div>
+      </div>
+      <div class="enc-card new" style="width:100%">
+        <div class="enc-name">BlockBitPacking <span class="tag tag-new">NEW</span></div>
+        <div class="formula" style="font-size:0.62rem;margin:0.2rem 0 0">
+          estimateSize(const Statistics&amp; statistics) {<br>
+          &nbsp;&nbsp;const auto&amp; blocks = statistics.minMaxBlocks();<br>
+          <br>
+          &nbsp;&nbsp;for (const auto&amp; b : blocks) {<br>
+          &nbsp;&nbsp;&nbsp;&nbsp;range = b.max - b.min;<br>
+          &nbsp;&nbsp;&nbsp;&nbsp;bw = bitsRequired(range);<br>
+          &nbsp;&nbsp;&nbsp;&nbsp;packedSize = bufferSize(b.count, bw);<br>
+          &nbsp;&nbsp;&nbsp;&nbsp;rawSize = b.count * sizeof(T);<br>
+          &nbsp;&nbsp;&nbsp;&nbsp;if (packedSize &lt; rawSize) {<br>
+          &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;dataSize += packedSize;<br>
+          &nbsp;&nbsp;&nbsp;&nbsp;} else {<br>
+          &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;dataSize += rawSize; <span class="comment">// skip encoding</span><br>
+          &nbsp;&nbsp;&nbsp;&nbsp;}<br>
+          &nbsp;&nbsp;}<br>
+          <br>
+          &nbsp;&nbsp;<span class="comment">// per-block metadata stored as nested encodings:</span><br>
+          &nbsp;&nbsp;<span class="comment">//   baselines → Trivial&lt;T&gt;</span><br>
+          &nbsp;&nbsp;<span class="comment">//   bitWidths → Trivial&lt;uint8_t&gt;</span><br>
+          &nbsp;&nbsp;<span class="comment">//   dataOffsets → Trivial&lt;uint32_t&gt;</span><br>
+          &nbsp;&nbsp;metadataSize = kMetadataHeaderSize<br>
+          &nbsp;&nbsp;&nbsp;&nbsp;+ Trivial&lt;T&gt;::estimateSize(numBlocks)<br>
+          &nbsp;&nbsp;&nbsp;&nbsp;+ Trivial&lt;u8&gt;::estimateSize(numBlocks)<br>
+          &nbsp;&nbsp;&nbsp;&nbsp;+ Trivial&lt;u32&gt;::estimateSize(numBlocks);<br>
+          <br>
+          &nbsp;&nbsp;return prefix + metadataSize + dataSize;<br>
+          }
+        </div>
+        <div style="margin-top:0.5rem;font-size:0.62rem;color:var(--text-secondary);line-height:1.6;border-top:1px solid var(--border);padding-top:0.4rem">
+          <div style="display:flex;align-items:center;gap:0.3rem;margin-bottom:0.2rem">
+            <span style="font-family:'JetBrains Mono',monospace">statistics.minMaxBlocks()</span>
+          </div>
+          <div style="padding-left:0.8rem;font-family:'JetBrains Mono',monospace;font-size:0.6rem;line-height:1.8">
+            if (!minMaxBlocks_.has_value()) {<br>
+            &nbsp;&nbsp;populateMinMaxBlocks(); <span style="color:var(--accent);font-weight:600">&larr; scans data_ once</span><br>
+            &nbsp;&nbsp;<span class="comment">// BlockStatsAccumulator: for each value,</span><br>
+            &nbsp;&nbsp;<span class="comment">// track min/max, flush every 1024 rows</span><br>
+            &nbsp;&nbsp;<span class="comment">// &rarr; vector&lt;{count, min, max}&gt;</span><br>
+            }<br>
+            return minMaxBlocks_.value(); <span style="color:var(--pass)">&larr; cached after first call</span>
+          </div>
+        </div>
+      </div>
+    </div>
+
+
+  </div>
+</div>
+
+
+</div>
+</body>
+</html>

--- a/dwio/nimble/docs/architecture/encoding_options_flow.html
+++ b/dwio/nimble/docs/architecture/encoding_options_flow.html
@@ -1,0 +1,407 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Nimble Writer Configuration Flow</title>
+<link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;600;700&family=DM+Sans:wght@400;500&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
+<style>
+:root {
+  --bg: #fafbfc; --surface: #ffffff; --text: #1a1a2e; --muted: #6b7280; --sub: #4b5563;
+  --border: #d1d5db;
+  --hl: #2563eb; --warm: #b45309; --step: #059669;
+  --writer: #2563eb; --context: #7c3aed; --tablet: #0891b2;
+  --flush: #d97706; --encoding: #059669; --index: #dc2626;
+  --accent: #f59e0b; --kill: #ef4444; --pass: #22c55e;
+}
+body.dark {
+  --bg: #111118; --surface: #1a1a24; --text: #e5e7eb; --muted: #9ca3af; --sub: #d1d5db;
+  --border: #374151; --hl: #60a5fa; --warm: #fbbf24; --step: #34d399;
+}
+* { margin:0; padding:0; box-sizing:border-box; }
+body { font-family:'DM Sans',sans-serif; background:var(--bg); color:var(--text); padding:2rem; }
+.wrap { max-width:780px; margin:0 auto; }
+h1 { font-family:'Space Grotesk',sans-serif; font-size:1.4rem; text-align:center; margin-bottom:0.15rem; }
+.sub { text-align:center; color:var(--muted); font-size:0.78rem; margin-bottom:1.8rem; }
+code { font-family:'JetBrains Mono',monospace; font-size:0.6rem; background:color-mix(in srgb, var(--border) 30%, var(--surface)); padding:0.05rem 0.25rem; border-radius:3px; }
+.node { border:2px solid var(--border); border-radius:10px; padding:0.5rem 0.8rem; background:var(--surface); text-align:center; }
+.node h3 { font-family:'Space Grotesk',sans-serif; font-size:0.75rem; font-weight:600; }
+.node .d { font-family:'JetBrains Mono',monospace; font-size:0.55rem; color:var(--muted); margin-top:0.15rem; }
+.node .d b { color:var(--hl); }
+.ar { display:flex; justify-content:center; padding:0.12rem 0; }
+.ar .a { width:2px; height:18px; background:var(--border); position:relative; }
+.ar .a::after { content:''; position:absolute; bottom:-1px; left:50%; transform:translateX(-50%); border-left:4px solid transparent; border-right:4px solid transparent; border-top:5px solid var(--border); }
+.ar-accent .a { background:var(--accent); }
+.ar-accent .a::after { border-top-color:var(--accent); }
+.callout { display:flex; align-items:flex-start; gap:0.4rem; padding:0.4rem 0.6rem; border-radius:7px; font-size:0.65rem; color:var(--sub); margin-top:0.4rem; }
+.sec { margin-bottom:1.5rem; }
+.sec-head { font-family:'Space Grotesk',sans-serif; font-size:0.58rem; font-weight:600; letter-spacing:0.1em; text-transform:uppercase; color:var(--muted); margin-bottom:0.4rem; display:flex; align-items:center; gap:0.4rem; }
+.sec-head::after { content:''; flex:1; height:1px; background:var(--border); }
+.sn { display:inline-flex; align-items:center; justify-content:center; width:16px; height:16px; border-radius:50%; font-size:0.55rem; font-weight:700; color:#fff; }
+.part { margin-bottom:0.3rem; font-family:'Space Grotesk',sans-serif; font-size:0.85rem; font-weight:700; text-align:center; color:var(--text); margin-top:1.5rem; }
+.part-sub { text-align:center; color:var(--muted); font-size:0.65rem; margin-bottom:1rem; }
+.fp { font-family:'JetBrains Mono',monospace; font-size:0.48rem; color:var(--muted); margin-top:0.35rem; }
+.footer { text-align:center; font-size:0.6rem; color:var(--muted); margin-top:1.2rem; padding-top:0.5rem; border-top:1px solid var(--border); }
+.priority-bar { display:flex; height:24px; border-radius:6px; overflow:hidden; border:1.5px solid var(--border); margin:0.3rem 0; }
+.priority-seg { display:flex; align-items:center; justify-content:center; font-family:'JetBrains Mono',monospace; font-size:0.48rem; font-weight:500; color:#fff; }
+</style>
+</head>
+<body>
+<button onclick="document.body.classList.toggle('dark')" style="position:fixed;top:1rem;right:1rem;border:1px solid var(--border);background:var(--surface);border-radius:6px;padding:0.25rem 0.4rem;cursor:pointer;color:var(--text);font-size:0.8rem">&#9684;</button>
+<div class="wrap">
+
+<h1>Nimble Writer Configuration Flow</h1>
+
+<!-- ═══════════════════════════════════════════════════════════ -->
+<!-- PART 1: Encoding::Options Overview -->
+<!-- ═══════════════════════════════════════════════════════════ -->
+
+<div class="part" style="margin-top:0">Part 1: Encoding::Options Background</div>
+<div class="part-sub">What the struct is, where it's constructed, and which encodings consume which field</div>
+
+<!-- 1a: Fields & Consumption -->
+<div class="sec">
+<div class="sec-head"><span class="sn" style="background:var(--step)">1a</span> Encoding::Options &mdash; Fields &amp; Consumption</div>
+
+<div style="border:1.5px solid var(--border);border-radius:10px;background:var(--surface);padding:0.4rem 0.5rem;overflow-x:auto;">
+<div class="d" style="margin-bottom:0.3rem;text-align:center">dwio/nimble/encodings/common/Encoding.h</div>
+<table style="width:100%;border-collapse:collapse;font-size:0.55rem;">
+  <thead>
+    <tr>
+      <th style="font-family:'Space Grotesk',sans-serif;font-size:0.48rem;font-weight:600;letter-spacing:0.05em;text-transform:uppercase;color:var(--muted);padding:0.25rem 0.4rem;text-align:left;border-bottom:2px solid var(--border)">Encoding</th>
+      <th style="font-family:'Space Grotesk',sans-serif;font-size:0.48rem;font-weight:600;color:var(--muted);padding:0.25rem 0.3rem;text-align:center;border-bottom:2px solid var(--border)"><span style="display:inline-block;width:7px;height:7px;border-radius:50%;background:var(--step);vertical-align:middle"></span> useVarintRowCount<br><span style="font-weight:400;font-size:0.4rem;color:var(--muted)">bool = false</span></th>
+      <th style="font-family:'Space Grotesk',sans-serif;font-size:0.48rem;font-weight:600;color:var(--muted);padding:0.25rem 0.3rem;text-align:center;border-bottom:2px solid var(--border)"><span style="display:inline-block;width:7px;height:7px;border-radius:50%;background:var(--hl);vertical-align:middle"></span> bufferPool<br><span style="font-weight:400;font-size:0.4rem;color:var(--muted)">Pool* = nullptr</span></th>
+      <th style="font-family:'Space Grotesk',sans-serif;font-size:0.48rem;font-weight:600;color:var(--muted);padding:0.25rem 0.3rem;text-align:center;border-bottom:2px solid var(--border)"><span style="display:inline-block;width:7px;height:7px;border-radius:50%;background:#7c3aed;vertical-align:middle"></span> preserveDict<br><span style="font-weight:400;font-size:0.4rem;color:var(--muted)">bool = false</span></th>
+      <th style="font-family:'Space Grotesk',sans-serif;font-size:0.48rem;font-weight:600;color:var(--muted);padding:0.25rem 0.3rem;text-align:center;border-bottom:2px solid var(--border)"><span style="display:inline-block;width:7px;height:7px;border-radius:50%;background:#e11d48;vertical-align:middle"></span> freqPartIdx<br><span style="font-weight:400;font-size:0.4rem;color:var(--muted)">uint8_t = 0</span></th>
+      <th style="font-family:'Space Grotesk',sans-serif;font-size:0.48rem;font-weight:600;color:var(--muted);padding:0.25rem 0.3rem;text-align:center;border-bottom:2px solid var(--border)"><span style="display:inline-block;width:7px;height:7px;border-radius:50%;background:var(--warm);vertical-align:middle"></span> bbpBlockSize<br><span style="font-weight:400;font-size:0.4rem;color:var(--muted)">uint16_t = 1024</span></th>
+    </tr>
+  </thead>
+  <tbody style="font-family:'JetBrains Mono',monospace;font-size:0.5rem;color:var(--sub)">
+    <tr><td style="padding:0.2rem 0.4rem;border-bottom:1px solid var(--border);font-weight:600">Trivial</td><td style="text-align:center;border-bottom:1px solid var(--border)">&#9679;</td><td style="text-align:center;border-bottom:1px solid var(--border)">&#9679;</td><td style="text-align:center;border-bottom:1px solid var(--border);color:var(--border)">&#9675;</td><td style="text-align:center;border-bottom:1px solid var(--border);color:var(--border)">&#9675;</td><td style="text-align:center;border-bottom:1px solid var(--border);color:var(--border)">&#9675;</td></tr>
+    <tr><td style="padding:0.2rem 0.4rem;border-bottom:1px solid var(--border);font-weight:600">RLE</td><td style="text-align:center;border-bottom:1px solid var(--border)">&#9679;</td><td style="text-align:center;border-bottom:1px solid var(--border)">&#9679;</td><td style="text-align:center;border-bottom:1px solid var(--border);color:#7c3aed">&#9679;</td><td style="text-align:center;border-bottom:1px solid var(--border);color:var(--border)">&#9675;</td><td style="text-align:center;border-bottom:1px solid var(--border);color:var(--border)">&#9675;</td></tr>
+    <tr><td style="padding:0.2rem 0.4rem;border-bottom:1px solid var(--border);font-weight:600">Dictionary</td><td style="text-align:center;border-bottom:1px solid var(--border)">&#9679;</td><td style="text-align:center;border-bottom:1px solid var(--border)">&#9679;</td><td style="text-align:center;border-bottom:1px solid var(--border);color:var(--border)">&#9675;</td><td style="text-align:center;border-bottom:1px solid var(--border);color:var(--border)">&#9675;</td><td style="text-align:center;border-bottom:1px solid var(--border);color:var(--border)">&#9675;</td></tr>
+    <tr><td style="padding:0.2rem 0.4rem;border-bottom:1px solid var(--border);font-weight:600">FixedBitWidth</td><td style="text-align:center;border-bottom:1px solid var(--border)">&#9679;</td><td style="text-align:center;border-bottom:1px solid var(--border)">&#9679;</td><td style="text-align:center;border-bottom:1px solid var(--border);color:var(--border)">&#9675;</td><td style="text-align:center;border-bottom:1px solid var(--border);color:var(--border)">&#9675;</td><td style="text-align:center;border-bottom:1px solid var(--border);color:var(--border)">&#9675;</td></tr>
+    <tr><td style="padding:0.2rem 0.4rem;border-bottom:1px solid var(--border);font-weight:600">BlockBitPacking</td><td style="text-align:center;border-bottom:1px solid var(--border)">&#9679;</td><td style="text-align:center;border-bottom:1px solid var(--border)">&#9679;</td><td style="text-align:center;border-bottom:1px solid var(--border);color:var(--border)">&#9675;</td><td style="text-align:center;border-bottom:1px solid var(--border);color:var(--border)">&#9675;</td><td style="text-align:center;border-bottom:1px solid var(--border);color:var(--warm)">&#9679;</td></tr>
+    <tr><td style="padding:0.2rem 0.4rem;border-bottom:1px solid var(--border);font-weight:600">FreqPartition</td><td style="text-align:center;border-bottom:1px solid var(--border)">&#9679;</td><td style="text-align:center;border-bottom:1px solid var(--border)">&#9679;</td><td style="text-align:center;border-bottom:1px solid var(--border);color:var(--border)">&#9675;</td><td style="text-align:center;border-bottom:1px solid var(--border);color:#e11d48">&#9679;</td><td style="text-align:center;border-bottom:1px solid var(--border);color:var(--border)">&#9675;</td></tr>
+    <tr><td style="padding:0.2rem 0.4rem;font-weight:600">Delta, Varint, SparseBool,<br>MainlyConst, Constant,<br>Sentinel, Prefix, Nullable, ALP</td><td style="text-align:center">&#9679;</td><td style="text-align:center">&#9679;</td><td style="text-align:center;color:var(--border)">&#9675;</td><td style="text-align:center;color:var(--border)">&#9675;</td><td style="text-align:center;color:var(--border)">&#9675;</td></tr>
+  </tbody>
+</table>
+</div>
+<div class="callout" style="background:color-mix(in srgb, var(--step) 5%, var(--surface));border:1px solid color-mix(in srgb, var(--step) 15%, transparent)">
+  <span>&#9654;</span>
+  <div><code>useVarintRowCount</code> and <code>bufferPool</code> are read by all encodings via the base <code>Encoding</code> class (stream prefix row count format + scratch buffer reuse). The other three fields are encoding-specific.</div>
+</div>
+</div>
+
+<!-- 1b: Construction Sites -->
+<div class="sec">
+<div class="sec-head"><span class="sn" style="background:var(--accent)">1b</span> Construction Sites (3 Paths)</div>
+
+<div style="display:flex;gap:0.5rem;">
+
+  <!-- Write Path -->
+  <div style="flex:1;border:2px solid var(--step);border-radius:10px;padding:0.45rem 0.5rem;background:color-mix(in srgb, var(--step) 4%, var(--surface));">
+    <div style="font-family:'Space Grotesk',sans-serif;font-size:0.65rem;font-weight:700;color:var(--step);margin-bottom:0.1rem">Write Path</div>
+    <div class="d" style="margin-bottom:0.2rem">VeloxWriter &rarr; file writing</div>
+    <div class="node" style="border-color:var(--step);margin-bottom:0.1rem;padding:0.25rem 0.4rem">
+      <h3 style="font-size:0.58rem;color:var(--step)">VeloxWriterOptions</h3>
+      <div class="d">.blockBitPackingBlockSize = N <span style="color:var(--muted)">(from serde params)</span></div>
+    </div>
+    <div class="ar"><div class="a" style="background:var(--step)"></div></div>
+    <div class="node" style="border-color:var(--step);background:color-mix(in srgb, var(--step) 8%, var(--surface));padding:0.25rem 0.4rem">
+      <h3 style="font-size:0.58rem;color:var(--step)">VeloxWriter::encode&lt;T&gt;()</h3>
+      <div class="d">calls context.options().<span style="color:var(--step);font-weight:600">buildEncodingOptions()</span><br>reads .blockBitPackingBlockSize &rarr; Options{<span style="color:var(--step)">bbpBlockSize=N</span>}</div>
+    </div>
+    <div class="ar"><div class="a" style="background:var(--step)"></div></div>
+    <div class="node" style="border-color:var(--step);padding:0.25rem 0.4rem">
+      <h3 style="font-size:0.58rem">EncodingFactory::encode(options)</h3>
+      <div class="d">options &rarr; select() + EncodingSelection</div>
+    </div>
+  </div>
+
+  <!-- Serializer Path -->
+  <div style="flex:1;border:2px solid var(--hl);border-radius:10px;padding:0.45rem 0.5rem;background:color-mix(in srgb, var(--hl) 4%, var(--surface));">
+    <div style="font-family:'Space Grotesk',sans-serif;font-size:0.65rem;font-weight:700;color:var(--hl);margin-bottom:0.1rem">Serializer / Deserializer</div>
+    <div class="d" style="margin-bottom:0.2rem">Network/RPC vector transfer</div>
+    <div class="node" style="border-color:var(--hl);margin-bottom:0.1rem;padding:0.25rem 0.4rem">
+      <h3 style="font-size:0.58rem;color:var(--hl)">SerializerOptions</h3>
+      <div class="d">encodingOptions{<span style="color:var(--hl)">useVarint</span>=true, <span style="color:var(--hl)">bbpBlockSize</span>}</div>
+    </div>
+    <div class="ar"><div class="a" style="background:var(--hl)"></div></div>
+    <div class="node" style="border-color:var(--hl);background:color-mix(in srgb, var(--hl) 8%, var(--surface));padding:0.25rem 0.4rem">
+      <h3 style="font-size:0.58rem;color:var(--hl)">DeserializerImpl</h3>
+      <div class="d">Options{<span style="color:var(--hl)">useVarintRowCount</span>, <span style="color:var(--hl)">bufferPool</span>}</div>
+    </div>
+    <div class="ar"><div class="a" style="background:var(--hl)"></div></div>
+    <div class="node" style="border-color:var(--hl);padding:0.25rem 0.4rem">
+      <h3 style="font-size:0.58rem">EncodingFactory(opts).create()</h3>
+      <div class="d">options stored, passed to constructors</div>
+    </div>
+  </div>
+
+  <!-- Selective Reader Path -->
+  <div style="flex:1;border:2px solid #7c3aed;border-radius:10px;padding:0.45rem 0.5rem;background:color-mix(in srgb, #7c3aed 4%, var(--surface));">
+    <div style="font-family:'Space Grotesk',sans-serif;font-size:0.65rem;font-weight:700;color:#7c3aed;margin-bottom:0.1rem">Selective Reader</div>
+    <div class="d" style="margin-bottom:0.2rem">ChunkedDecoder path</div>
+    <div class="node" style="border-color:#7c3aed;margin-bottom:0.1rem;padding:0.25rem 0.4rem">
+      <h3 style="font-size:0.58rem;color:#7c3aed">SelectiveNimbleReader</h3>
+      <div class="d">EncodingFactory() with default Options{}</div>
+    </div>
+    <div class="ar"><div class="a" style="background:#7c3aed"></div></div>
+    <div class="node" style="border-color:#7c3aed;background:color-mix(in srgb, #7c3aed 8%, var(--surface));padding:0.25rem 0.4rem">
+      <h3 style="font-size:0.58rem;color:#7c3aed">ChunkedDecoder</h3>
+      <div class="d">copies opts, sets <span style="color:#7c3aed">preserveDictEncoding</span>=true</div>
+    </div>
+    <div class="ar"><div class="a" style="background:#7c3aed"></div></div>
+    <div class="node" style="border-color:#7c3aed;padding:0.25rem 0.4rem">
+      <h3 style="font-size:0.58rem">EncodingFactory(opts).create()</h3>
+      <div class="d">RLE sees preserveDict &rarr; dict output</div>
+    </div>
+  </div>
+</div>
+</div>
+
+
+<!-- ═══════════════════════════════════════════════════════════ -->
+<!-- PART 2: Write Path (Detail) -->
+<!-- ═══════════════════════════════════════════════════════════ -->
+
+<div class="part">Part 2: Write Path Overview</div>
+<div class="part-sub">How serde params collect into VeloxWriterOptions, fan out to components, and how <code>Encoding::Options</code> fits in</div>
+
+<!-- 2a: Entry Points -->
+<div class="sec">
+<div class="sec-head"><span class="sn" style="background:var(--writer)">2a</span> Entry Points</div>
+
+<div style="display:flex;gap:0.6rem;">
+
+  <!-- Path A -->
+  <div style="flex:1;border:2px solid var(--writer);border-radius:10px;padding:0.5rem 0.6rem;background:color-mix(in srgb, var(--writer) 4%, var(--surface));">
+    <div style="font-family:'Space Grotesk',sans-serif;font-size:0.68rem;font-weight:700;color:var(--writer);margin-bottom:0.15rem">Path A: DWIO FileWriter API</div>
+    <div class="d" style="color:var(--muted);margin-bottom:0.3rem">TableService / Ingestion pipelines</div>
+
+    <div class="node" style="border-color:var(--writer);margin-bottom:0.15rem">
+      <h3 style="color:var(--writer);font-size:0.65rem">Hive Metastore</h3>
+      <div class="d">HiveTableMetadata.sd().serdeInfo().parameters()</div>
+    </div>
+    <div class="ar ar-accent"><div class="a"></div></div>
+    <div class="node" style="border-color:var(--writer);margin-bottom:0.15rem">
+      <h3 style="font-size:0.65rem">FileWriterFactory::create()</h3>
+      <div class="d">format = NIMBLE &rarr; copy serdeParams</div>
+    </div>
+    <div class="ar ar-accent"><div class="a"></div></div>
+    <div class="node" style="border-color:var(--accent);border-width:2.5px">
+      <h3 style="color:var(--accent);font-size:0.65rem">NimbleWriterOptionBuilder</h3>
+      <div class="d">.withSerdeParams(schema, serdeParams).build()</div>
+    </div>
+    <div class="ar ar-accent"><div class="a"></div></div>
+    <div class="node" style="border-style:dashed">
+      <h3 style="font-size:0.65rem">optionOverrides.nimbleOverrides(options)</h3>
+      <div class="d">optional lambda-based overrides from caller</div>
+    </div>
+    <div class="fp">dwio/api/FileWriter.cpp:484-544</div>
+  </div>
+
+  <!-- Path B -->
+  <div style="flex:1;border:2px solid var(--context);border-radius:10px;padding:0.5rem 0.6rem;background:color-mix(in srgb, var(--context) 4%, var(--surface));">
+    <div style="font-family:'Space Grotesk',sans-serif;font-size:0.68rem;font-weight:700;color:var(--context);margin-bottom:0.15rem">Path B: Velox HiveDataSink</div>
+    <div class="d" style="color:var(--muted);margin-bottom:0.3rem">Presto / Spark write queries</div>
+
+    <div class="node" style="border-color:var(--context);margin-bottom:0.15rem">
+      <h3 style="color:var(--context);font-size:0.65rem">HiveInsertTableHandle</h3>
+      <div class="d">serdeParameters_ (from coordinator)</div>
+    </div>
+    <div class="ar ar-accent"><div class="a"></div></div>
+    <div class="node" style="border-color:var(--context);margin-bottom:0.15rem">
+      <h3 style="font-size:0.65rem">createWriterOptions()</h3>
+      <div class="d">options&rarr;serdeParameters = table serde params</div>
+    </div>
+    <div class="ar ar-accent"><div class="a"></div></div>
+    <div class="node" style="border-color:var(--flush);margin-bottom:0.15rem">
+      <h3 style="color:var(--flush);font-size:0.65rem">processConfigs(connectorConfig, session)</h3>
+      <div class="d">merges session &amp; connector overrides via emplace()</div>
+    </div>
+    <div class="ar ar-accent"><div class="a"></div></div>
+    <div class="node" style="border-color:var(--accent);border-width:2.5px">
+      <h3 style="color:var(--accent);font-size:0.65rem">NimbleWriterOptionBuilder</h3>
+      <div class="d">.withSerdeParams(schema, serdeParams).build()</div>
+    </div>
+    <div class="fp">velox/connectors/hive/HiveDataSink.cpp</div>
+  </div>
+</div>
+
+<div style="margin-top:0.5rem;">
+  <div style="font-family:'Space Grotesk',sans-serif;font-size:0.55rem;font-weight:600;color:var(--muted);margin-bottom:0.15rem;letter-spacing:0.05em">OVERRIDE PRIORITY (highest &rarr; lowest)</div>
+  <div class="priority-bar">
+    <div class="priority-seg" style="flex:3;background:var(--writer)">Table Serde Param</div>
+    <div class="priority-seg" style="flex:2;background:var(--context)">Session Property</div>
+    <div class="priority-seg" style="flex:2;background:var(--flush)">Connector Config</div>
+    <div class="priority-seg" style="flex:1.5;background:var(--muted)">Default</div>
+  </div>
+  <div class="d">Enforced by std::map::emplace() &mdash; only inserts if key does not already exist</div>
+</div>
+
+<div class="callout" style="background:color-mix(in srgb, var(--accent) 5%, var(--surface));border:1px solid color-mix(in srgb, var(--accent) 15%, transparent)">
+  <span>&#9654;</span>
+  <div>Both paths converge at <code>NimbleWriterOptionBuilder::withSerdeParams()</code>. This is the single chokepoint where the flat <code>map&lt;string,string&gt;</code> of serde params is parsed into typed <code>VeloxWriterOptions</code> fields.</div>
+</div>
+</div>
+
+<!-- 2b: VeloxWriterOptions Config Map -->
+<div class="sec">
+<div class="sec-head"><span class="sn" style="background:var(--sub)">2b</span> VeloxWriterOptions Config Map</div>
+
+<div class="node" style="padding:0.6rem 0.8rem">
+  <h3 style="text-align:left;font-size:0.75rem">VeloxWriterOptions</h3>
+
+  <div style="text-align:left;margin-top:0.5rem;border:1.5px solid color-mix(in srgb, var(--hl) 30%, var(--border));border-radius:6px;padding:0.35rem 0.5rem;background:color-mix(in srgb, var(--hl) 5%, var(--surface))">
+    <div class="d" style="color:var(--hl);font-weight:700;font-size:0.6rem;margin-bottom:0.15rem">Encoding</div>
+    <div class="d" style="text-align:left;line-height:1.7">
+      <span style="color:#1d4ed8;font-weight:600">encodingSelectionPolicyFactory</span> &larr; opaque lambda<br>
+      &nbsp;&nbsp;&#9500; <span style="color:#1d4ed8">readFactors</span> <span style="color:var(--muted)">(which encodings to try + weights)</span><br>
+      &nbsp;&nbsp;&#9492; <span style="color:#1d4ed8">compressionOptions</span> <span style="color:var(--muted)">(codec, levels, accept ratio)</span><br>
+      <span style="color:#2563eb;font-weight:600">blockBitPackingBlockSize</span> + <span style="color:#2563eb">buildEncodingOptions()</span> <span style="color:var(--muted)">&rarr; Encoding::Options</span><br>
+      <span style="color:#60a5fa">compressionOptions</span> &larr; direct field <span style="color:var(--muted)">(duplicate for replay path)</span><br>
+      <span style="color:#60a5fa">encodingLayoutTree</span> &larr; captured layout for replay
+    </div>
+  </div>
+
+  <div style="text-align:left;margin-top:0.3rem;border:1.5px solid color-mix(in srgb, var(--warm) 30%, var(--border));border-radius:6px;padding:0.35rem 0.5rem;background:color-mix(in srgb, var(--warm) 5%, var(--surface))">
+    <div class="d" style="color:var(--warm);font-weight:700;font-size:0.6rem;margin-bottom:0.15rem">Flush / Chunking</div>
+    <div class="d" style="text-align:left;line-height:1.7">
+      flushPolicyFactory &larr; opaque lambda <span style="color:var(--muted)">(stripe size, memory thresholds)</span><br>
+      enableChunking, min/max/wideSchemaMaxStreamChunkRawSize
+    </div>
+  </div>
+
+  <div style="text-align:left;margin-top:0.3rem;border:1.5px solid color-mix(in srgb, var(--step) 30%, var(--border));border-radius:6px;padding:0.35rem 0.5rem;background:color-mix(in srgb, var(--step) 5%, var(--surface))">
+    <div class="d" style="color:var(--step);font-weight:700;font-size:0.6rem;margin-bottom:0.15rem">Schema</div>
+    <div class="d" style="text-align:left;line-height:1.7">
+      flatMapColumns, dictionaryArrayColumns, deduplicatedMapColumns
+    </div>
+  </div>
+
+  <div style="display:flex;gap:0.3rem;margin-top:0.3rem">
+    <div style="flex:1;border:1.5px solid color-mix(in srgb, #7c3aed 30%, var(--border));border-radius:6px;padding:0.3rem 0.4rem;background:color-mix(in srgb, #7c3aed 5%, var(--surface))">
+      <div class="d" style="color:#7c3aed;font-weight:700;font-size:0.55rem">Index</div>
+      <div class="d" style="text-align:left">clusterIndexConfig</div>
+    </div>
+    <div style="flex:1;border:1.5px solid color-mix(in srgb, #0891b2 30%, var(--border));border-radius:6px;padding:0.3rem 0.4rem;background:color-mix(in srgb, #0891b2 5%, var(--surface))">
+      <div class="d" style="color:#0891b2;font-weight:700;font-size:0.55rem">Memory / Parallelism</div>
+      <div class="d" style="text-align:left">encodingExecutor, reclaimerFactory, spillConfig</div>
+    </div>
+    <div style="flex:1;border:1.5px solid color-mix(in srgb, #6b7280 30%, var(--border));border-radius:6px;padding:0.3rem 0.4rem;background:color-mix(in srgb, #6b7280 5%, var(--surface))">
+      <div class="d" style="color:#6b7280;font-weight:700;font-size:0.55rem">Stats / Misc</div>
+      <div class="d" style="text-align:left">enableStatsCollection, enableStreamDedup, metadata</div>
+    </div>
+  </div>
+</div>
+</div>
+
+<!-- 2c: Options Fan-Out -->
+<div class="sec">
+<div class="sec-head"><span class="sn" style="background:var(--flush)">2c</span> Options Fan-Out</div>
+
+<div style="display:flex;flex-direction:column;align-items:center;gap:0;margin-bottom:0.3rem;">
+  <div class="node" style="border-color:var(--accent);border-width:2.5px;padding:0.35rem 1.2rem;">
+    <h3 style="color:var(--accent);font-size:0.75rem">VeloxWriterOptions</h3>
+  </div>
+  <div class="ar ar-accent"><div class="a"></div></div>
+  <div class="node" style="border-color:var(--writer);width:100%;">
+    <h3 style="color:var(--writer)">VeloxWriter constructor</h3>
+    <div class="d">distributes options to context, creates TabletWriter, invokes factories</div>
+  </div>
+  <div class="ar ar-accent"><div class="a"></div></div>
+</div>
+
+<div style="display:grid;grid-template-columns:repeat(3, 1fr);gap:0.3rem;">
+  <div style="border:1.5px solid var(--writer);border-radius:8px;padding:0.35rem 0.4rem;background:color-mix(in srgb, var(--writer) 5%, var(--surface));text-align:center;">
+    <div style="font-family:'Space Grotesk',sans-serif;font-size:0.58rem;font-weight:600;color:var(--writer)">VeloxWriter</div>
+    <div class="d" style="text-align:left;line-height:1.5;margin-top:0.1rem;">enableChunking, chunk sizes<br>stats collection<br>schema columns<br>encoding layout<br>metadata</div>
+  </div>
+  <div style="border:1.5px solid var(--context);border-radius:8px;padding:0.35rem 0.4rem;background:color-mix(in srgb, var(--context) 5%, var(--surface));text-align:center;">
+    <div style="font-family:'Space Grotesk',sans-serif;font-size:0.58rem;font-weight:600;color:var(--context)">FieldWriterContext</div>
+    <div class="d" style="text-align:left;line-height:1.5;margin-top:0.1rem;">buffer growth<br>string buffers<br>parallel encoding<br>flat map nodes<br>dict array nodes</div>
+  </div>
+  <div style="border:1.5px solid var(--tablet);border-radius:8px;padding:0.35rem 0.4rem;background:color-mix(in srgb, var(--tablet) 5%, var(--surface));text-align:center;">
+    <div style="font-family:'Space Grotesk',sans-serif;font-size:0.58rem;font-weight:600;color:var(--tablet)">TabletWriter</div>
+    <div class="d" style="text-align:left;line-height:1.5;margin-top:0.1rem;">stream dedup<br>chunk index<br>metadata compression<br>feature reorder</div>
+  </div>
+  <div style="border:1.5px solid var(--flush);border-radius:8px;padding:0.35rem 0.4rem;background:color-mix(in srgb, var(--flush) 5%, var(--surface));text-align:center;">
+    <div style="font-family:'Space Grotesk',sans-serif;font-size:0.58rem;font-weight:600;color:var(--flush)">FlushPolicy</div>
+    <div class="d" style="text-align:left;line-height:1.5;margin-top:0.1rem;">stripe raw size<br>memory thresholds<br>target storage sz<br>compression factor</div>
+  </div>
+  <div style="border:2.5px solid var(--encoding);border-radius:8px;padding:0.35rem 0.4rem;background:color-mix(in srgb, var(--encoding) 10%, var(--surface));text-align:center;position:relative;">
+    <div style="position:absolute;top:-0.4rem;right:0.3rem;font-family:'Space Grotesk',sans-serif;font-size:0.4rem;font-weight:700;color:#fff;background:var(--encoding);padding:0.05rem 0.25rem;border-radius:3px">Encoding::Options</div>
+    <div style="font-family:'Space Grotesk',sans-serif;font-size:0.58rem;font-weight:600;color:var(--encoding)">EncodingSelection</div>
+    <div class="d" style="text-align:left;line-height:1.5;margin-top:0.1rem;">read factors <span style="color:var(--muted)">(policy)</span><br>compr accept ratio <span style="color:var(--muted)">(policy)</span><br><span style="color:var(--encoding);font-weight:600">blockBitPackingBlockSize</span> <span style="color:var(--muted)">(options)</span></div>
+  </div>
+  <div style="border:1.5px solid var(--index);border-radius:8px;padding:0.35rem 0.4rem;background:color-mix(in srgb, var(--index) 5%, var(--surface));text-align:center;">
+    <div style="font-family:'Space Grotesk',sans-serif;font-size:0.58rem;font-weight:600;color:var(--index)">ClusterIndexWriter</div>
+    <div class="d" style="text-align:left;line-height:1.5;margin-top:0.1rem;">index columns<br>sort orders<br>key constraints<br>encoding layout</div>
+  </div>
+</div>
+
+<div class="fp">dwio/nimble/velox/VeloxWriter.cpp &middot; VeloxWriterOptions.h &middot; FieldWriter.h &middot; TabletWriter.h</div>
+</div>
+
+<!-- 2d: Encoding Flow -->
+<div class="sec">
+<div class="sec-head"><span class="sn" style="background:var(--step)">2d</span> Encoding Flow (estimation &rarr; selection &rarr; encode)</div>
+
+<div class="node" style="border-color:color-mix(in srgb, var(--hl) 30%, var(--border));background:color-mix(in srgb, var(--hl) 5%, var(--surface))">
+  <h3>VeloxWriter::encode&lt;T&gt;()</h3>
+  <div class="d">calls <span style="color:#2563eb;font-weight:600">buildEncodingOptions()</span> <span style="color:var(--warm);font-weight:600">(new)</span> + creates policy from factory</div>
+</div>
+<div class="ar"><div class="a"></div></div>
+<div class="node" style="border-color:color-mix(in srgb, var(--hl) 30%, var(--border));background:color-mix(in srgb, var(--hl) 5%, var(--surface))">
+  <h3>EncodingFactory::encode(policy, data, buffer, <span style="color:#2563eb">options</span>)</h3>
+  <div class="d">passes <span style="color:#2563eb;font-weight:600">options</span> <span style="color:var(--warm);font-weight:600">(new)</span> to select() and EncodingSelection</div>
+</div>
+
+<div style="margin:0.4rem 0 0.15rem;display:flex;align-items:center;gap:0.4rem">
+  <span style="font-family:'Space Grotesk',sans-serif;font-size:0.6rem;font-weight:700;color:var(--step);background:color-mix(in srgb, var(--step) 10%, var(--surface));padding:0.15rem 0.4rem;border-radius:4px">Step 1</span>
+  <span style="font-family:'Space Grotesk',sans-serif;font-size:0.55rem;color:var(--sub)">Estimation &mdash; pick encoding</span>
+</div>
+
+<div class="ar"><div class="a"></div></div>
+<div class="node" style="border-color:color-mix(in srgb, var(--hl) 30%, var(--border));background:color-mix(in srgb, var(--hl) 5%, var(--surface))">
+  <h3>select(values, stats, <span style="color:#2563eb">options</span>)</h3>
+  <div class="d">readFactors_ from policy + <span style="color:#2563eb;font-weight:600">blockSize</span> from <span style="color:#2563eb">options</span> <span style="color:var(--warm);font-weight:600">(new)</span> &rarr; EncodingCandidates &rarr; estimation</div>
+  <div class="d">picks best encoding &rarr; returns EncodingSelectionResult{BBP, comprFactory}</div>
+</div>
+
+<div style="margin:0.4rem 0 0.15rem;display:flex;align-items:center;gap:0.4rem">
+  <span style="font-family:'Space Grotesk',sans-serif;font-size:0.6rem;font-weight:700;color:var(--step);background:color-mix(in srgb, var(--step) 10%, var(--surface));padding:0.15rem 0.4rem;border-radius:4px">Step 2</span>
+  <span style="font-family:'Space Grotesk',sans-serif;font-size:0.55rem;color:var(--sub)">Build selection &mdash; bundle result + options</span>
+</div>
+
+<div class="ar"><div class="a"></div></div>
+<div class="node" style="border-color:color-mix(in srgb, var(--hl) 30%, var(--border));background:color-mix(in srgb, var(--hl) 5%, var(--surface))">
+  <h3>EncodingSelection&lt;T&gt;</h3>
+  <div class="d">wraps result + stats + policy + <span style="color:#2563eb">options</span> <span style="color:var(--warm);font-weight:600">(new)</span></div>
+</div>
+
+<div style="margin:0.4rem 0 0.15rem;display:flex;align-items:center;gap:0.4rem">
+  <span style="font-family:'Space Grotesk',sans-serif;font-size:0.6rem;font-weight:700;color:var(--step);background:color-mix(in srgb, var(--step) 10%, var(--surface));padding:0.15rem 0.4rem;border-radius:4px">Step 3</span>
+  <span style="font-family:'Space Grotesk',sans-serif;font-size:0.55rem;color:var(--sub)">Encode &mdash; write data</span>
+</div>
+
+<div class="ar"><div class="a"></div></div>
+<div class="node" style="border-color:color-mix(in srgb, var(--hl) 30%, var(--border));background:color-mix(in srgb, var(--hl) 5%, var(--surface))">
+  <h3>BBP::encode(selection, values, buffer, <span style="color:#2563eb">options</span>)</h3>
+  <div class="d"><span style="color:#2563eb">options</span>.blockBitPackingBlockSize = <b>512</b> &#10003;</div>
+</div>
+
+<div style="text-align:center;margin-top:0.6rem">
+  <div style="display:inline-flex;gap:0.5rem;align-items:center;border:1.5px solid var(--border);border-radius:8px;padding:0.35rem 0.8rem">
+    <span style="font-family:'Space Grotesk',sans-serif;font-size:0.68rem;font-weight:600;color:var(--sub)">Estimation 512 = Encoding 512 &nbsp;&#10003;</span>
+  </div>
+</div>
+</div>
+
+
+<div class="footer">Ke Wang &middot; 2026-06-21</div>
+</div>
+</body>
+</html>

--- a/dwio/nimble/encodings/BlockBitPackingEncoding.h
+++ b/dwio/nimble/encodings/BlockBitPackingEncoding.h
@@ -91,6 +91,37 @@ class BlockBitPackingEncoding final
       std::span<const physicalType> values,
       uint16_t blockSize = kBlockBitPackingBlockSize);
 
+  static uint64_t estimateSize(
+      const Statistics<physicalType>& statistics,
+      uint16_t blockSize = kBlockBitPackingBlockSize) {
+    const auto& blocks = statistics.minMaxBlocks(blockSize);
+    const auto numBlocks = static_cast<uint32_t>(blocks.size());
+
+    uint64_t packedSize = 0;
+    for (const auto& block : blocks) {
+      const auto rawSize = block.count * sizeof(physicalType);
+      const auto range = block.max - block.min;
+      const auto bw = range == 0 ? 0 : velox::bits::bitsRequired(range);
+      if (bw >= sizeof(physicalType) * 8) {
+        packedSize += rawSize;
+        continue;
+      }
+      const auto blockPackedSize =
+          static_cast<uint64_t>(FixedBitArray::bufferSize(block.count, bw));
+      if (blockPackedSize < rawSize) {
+        packedSize += blockPackedSize;
+      } else {
+        packedSize += rawSize;
+      }
+    }
+
+    const uint64_t metadataSize = kMetadataHeaderSize +
+        TrivialEncoding<physicalType>::estimateSize(numBlocks) +
+        TrivialEncoding<uint8_t>::estimateSize(numBlocks) +
+        TrivialEncoding<uint32_t>::estimateSize(numBlocks);
+    return EncodingPrefix::kFixedPrefixSize + metadataSize + packedSize;
+  }
+
   std::string debugString(int offset) const final;
 
  private:

--- a/dwio/nimble/encodings/BlockBitPackingEncoding.h
+++ b/dwio/nimble/encodings/BlockBitPackingEncoding.h
@@ -651,7 +651,7 @@ std::string_view BlockBitPackingEncoding<T>::encode(
   static_assert(
       std::is_unsigned_v<physicalType>, "Physical type must be unsigned.");
 
-  const uint16_t blockSize = selection.blockBitPackingBlockSize();
+  const uint16_t blockSize = options.blockBitPackingBlockSize;
   const auto rowCount = static_cast<uint32_t>(values.size());
   const uint32_t numBlocks = velox::bits::divRoundUp(rowCount, blockSize);
   NIMBLE_CHECK_LE(

--- a/dwio/nimble/encodings/common/Encoding.h
+++ b/dwio/nimble/encodings/common/Encoding.h
@@ -15,6 +15,7 @@
  */
 #pragma once
 
+#include "dwio/nimble/common/Constants.h"
 #include "dwio/nimble/common/Exceptions.h"
 #include "dwio/nimble/common/Types.h"
 #include "dwio/nimble/common/Vector.h"
@@ -97,30 +98,36 @@ struct ReadWithVisitorParams {
 
 class Encoding {
  public:
-  /// Options for encoding/decoding, extracted from persisted storage version
-  /// (file footer or serializer version).
+  /// Options that control encoding behavior during encode and decode.
+  /// Includes format-level settings (e.g., varint row count from file version)
+  /// and per-encoding configuration (e.g., block size from serde params).
   struct Options {
     /// When true, rowCount in the encoding prefix is varint-encoded instead of
     /// fixed 4-byte uint32. Determined from file format version or serializer
     /// version.
-    bool useVarintRowCount;
+    bool useVarintRowCount = false;
 
     /// Optional buffer pool for reusing scratch buffers across encoding
     /// lifetimes. When set, encodings return their scratch buffers to the pool
     /// on destruction and grab pre-allocated buffers on construction, avoiding
     /// MemoryPool alloc/free overhead.
-    /// Value-initialized to nullptr when omitted from aggregate initialization.
-    velox::BufferPool* bufferPool;
+    velox::BufferPool* bufferPool = nullptr;
 
     /// When true, encodings that support dictionary mode (e.g., RLE) will
     /// use the dictionary index path when the inner encoding is
     /// dictionary-enabled. False by default — only the selective
     /// reader enables this for dictionary vector output.
-    bool preserveDictionaryEncoding;
+    bool preserveDictionaryEncoding = false;
+
     /// FrequencyPartitionEncoding index type (cast to FreqPartIndexType).
     /// 0 = NoIndex (default, backward-compatible), 1 = PerTierBitmaps,
     /// 2 = TierTagArray, 3 = EliasFano.
-    uint8_t frequencyPartitionIndex;
+    uint8_t frequencyPartitionIndex = 0;
+
+    /// Block size for BlockBitPacking encoding. Determines how many rows
+    /// are packed per block. Written to the stream header; the reader
+    /// reads it back from the stream (self-describing).
+    uint16_t blockBitPackingBlockSize = kBlockBitPackingBlockSize;
   };
 
   static constexpr int kEncodingTypeOffset =
@@ -132,7 +139,7 @@ class Encoding {
   Encoding(
       velox::memory::MemoryPool& pool,
       std::string_view data,
-      const Options& options = {});
+      const Options& options);
   virtual ~Encoding() = default;
 
   EncodingType encodingType() const {

--- a/dwio/nimble/encodings/common/EncodingFactory.cpp
+++ b/dwio/nimble/encodings/common/EncodingFactory.cpp
@@ -332,7 +332,8 @@ std::string_view EncodingFactory::encode(
   using physicalType = typename TypeTraits<T>::physicalType;
   auto physicalValues = toPhysicalSpan(values);
   auto statistics = Statistics<physicalType>::create(physicalValues);
-  auto selectionResult = selectorPolicy->select(physicalValues, statistics);
+  auto selectionResult =
+      selectorPolicy->select(physicalValues, statistics, options);
   EncodingSelection<physicalType> selection{
       std::move(selectionResult),
       std::move(statistics),
@@ -351,8 +352,8 @@ std::string_view EncodingFactory::encodeNullable(
   using physicalType = typename TypeTraits<T>::physicalType;
   auto physicalValues = toPhysicalSpan(values);
   auto statistics = Statistics<physicalType>::create(physicalValues);
-  auto selectionResult =
-      selectorPolicy->selectNullable(physicalValues, nulls, statistics);
+  auto selectionResult = selectorPolicy->selectNullable(
+      physicalValues, nulls, statistics, options);
   EncodingSelection<physicalType> selection{
       std::move(selectionResult),
       std::move(statistics),

--- a/dwio/nimble/encodings/legacy/EncodingSelectionPolicy.h
+++ b/dwio/nimble/encodings/legacy/EncodingSelectionPolicy.h
@@ -160,7 +160,8 @@ class ManualEncodingSelectionPolicy : public EncodingSelectionPolicy<T> {
 
   EncodingSelectionResult select(
       std::span<const physicalType> values,
-      const Statistics<physicalType>& statistics) override {
+      const Statistics<physicalType>& statistics,
+      const Encoding::Options& /* options */ = {}) override {
     if (values.empty()) {
       return {
           .encodingType = EncodingType::Trivial,
@@ -301,7 +302,8 @@ class ManualEncodingSelectionPolicy : public EncodingSelectionPolicy<T> {
   EncodingSelectionResult selectNullable(
       std::span<const physicalType> /* values */,
       std::span<const bool> /* nulls */,
-      const Statistics<physicalType>& /* statistics */) override {
+      const Statistics<physicalType>& /* statistics */,
+      const Encoding::Options& /* options */ = {}) override {
     return {
         .encodingType = EncodingType::Nullable,
     };
@@ -471,7 +473,8 @@ class LearnedEncodingSelectionPolicy : public EncodingSelectionPolicy<T> {
 
   EncodingSelectionResult select(
       std::span<const physicalType> values,
-      const Statistics<physicalType>& statistics) override {
+      const Statistics<physicalType>& statistics,
+      const Encoding::Options& /* options */ = {}) override {
     if (values.empty()) {
       return {
           .encodingType = EncodingType::Trivial,
@@ -495,7 +498,8 @@ class LearnedEncodingSelectionPolicy : public EncodingSelectionPolicy<T> {
   EncodingSelectionResult selectNullable(
       std::span<const physicalType> /* values */,
       std::span<const bool> /* nulls */,
-      const Statistics<physicalType>& /* statistics */) override {
+      const Statistics<physicalType>& /* statistics */,
+      const Encoding::Options& /* options */ = {}) override {
     return {
         .encodingType = EncodingType::Nullable,
     };
@@ -625,7 +629,8 @@ class ReplayedEncodingSelectionPolicy : public EncodingSelectionPolicy<TInner> {
 
   EncodingSelectionResult select(
       std::span<const physicalType> /* values */,
-      const nimble::Statistics<physicalType>& /* statistics */) override {
+      const nimble::Statistics<physicalType>& /* statistics */,
+      const Encoding::Options& /* options */ = {}) override {
     NIMBLE_SELECTION_LOG(
         CYAN << "Replaying encoding " << encodingLayout_.encodingType());
     if (!compressionOptions_.has_value()) {
@@ -644,7 +649,8 @@ class ReplayedEncodingSelectionPolicy : public EncodingSelectionPolicy<TInner> {
   EncodingSelectionResult selectNullable(
       std::span<const physicalType> /* values */,
       std::span<const bool> /* nulls */,
-      const Statistics<physicalType>& /* statistics */) override {
+      const Statistics<physicalType>& /* statistics */,
+      const Encoding::Options& /* options */ = {}) override {
     NIMBLE_SELECTION_LOG(
         CYAN << "Replaying nullable encoding "
              << encodingLayout_.encodingType());

--- a/dwio/nimble/encodings/selection/EncodingSelection.h
+++ b/dwio/nimble/encodings/selection/EncodingSelection.h
@@ -77,7 +77,6 @@ struct EncodingSelectionResult {
   EncodingLayout::Config encodingConfig;
   std::function<std::unique_ptr<CompressionPolicy>()> compressionPolicyFactory =
       []() { return std::make_unique<NoCompressionPolicy>(); };
-  uint16_t blockBitPackingBlockSize = kBlockBitPackingBlockSize;
 };
 
 /// The EncodingSelection class is passed in to the encode() method of each
@@ -105,10 +104,6 @@ class EncodingSelection {
   std::unique_ptr<CompressionPolicy> compressionPolicy() const noexcept {
     auto policy = selectionResult_.compressionPolicyFactory();
     return policy;
-  }
-
-  uint16_t blockBitPackingBlockSize() const noexcept {
-    return selectionResult_.blockBitPackingBlockSize;
   }
 
   /// Returns a config value for the given key, or std::nullopt if not found.
@@ -179,13 +174,15 @@ class EncodingSelectionPolicy : public EncodingSelectionPolicyBase {
   /// return the selected encoding (and the matching compression policy).
   virtual EncodingSelectionResult select(
       std::span<const physicalType> values,
-      const Statistics<physicalType>& statistics) = 0;
+      const Statistics<physicalType>& statistics,
+      const Encoding::Options& options = {}) = 0;
 
   /// Same as the |select()| method above, but for nullable values.
   virtual EncodingSelectionResult selectNullable(
       std::span<const physicalType> values,
       std::span<const bool> nulls,
-      const Statistics<physicalType>& statistics) = 0;
+      const Statistics<physicalType>& statistics,
+      const Encoding::Options& options = {}) = 0;
 
   virtual ~EncodingSelectionPolicy() = default;
 };
@@ -211,7 +208,7 @@ std::string_view EncodingSelection<T>::encodeNested(
           selectionPolicy_->template create<NestedT>(encodingType(), identifier)
               .release()));
   auto statistics = Statistics<NestedT>::create(values);
-  auto selectionResult = nestedPolicy->select(values, statistics);
+  auto selectionResult = nestedPolicy->select(values, statistics, options);
 
   return EncodingFactory::encode<NestedT>(
       EncodingSelection<NestedT>{

--- a/dwio/nimble/encodings/selection/EncodingSelectionPolicy.h
+++ b/dwio/nimble/encodings/selection/EncodingSelectionPolicy.h
@@ -117,7 +117,10 @@ struct CompressionOptions {
   bool useVariableBitWidthCompressor = false;
   MetaInternalCompressionKey metaInternalCompressionKey;
   // Per-encoding overrides for compressionAcceptRatio.
-  std::vector<std::pair<EncodingType, float>> compressionAcceptRatioOverrides;
+  // BlockBitPacking default 0.7: data is already well-packed via per-block
+  // baselines, so compression must save at least 30% to justify CPU cost.
+  std::vector<std::pair<EncodingType, float>> compressionAcceptRatioOverrides =
+      {{EncodingType::BlockBitPacking, 0.7f}};
 };
 
 // This is the manual encoding selection implementation.
@@ -169,7 +172,7 @@ class ManualEncodingSelectionPolicy : public EncodingSelectionPolicy<T> {
   EncodingSelectionResult select(
       std::span<const physicalType> values,
       const Statistics<physicalType>& statistics,
-      const Encoding::Options& /* options */ = {}) override {
+      const Encoding::Options& options = {}) override {
     if (values.empty()) {
       return {
           .encodingType = EncodingType::Trivial,
@@ -191,7 +194,7 @@ class ManualEncodingSelectionPolicy : public EncodingSelectionPolicy<T> {
       const auto encodingType = pair.first;
       const auto estimatedSize =
           detail::EncodingSizeEstimation<T, FixedByteWidth>::estimateSize(
-              encodingType, values.size(), statistics);
+              encodingType, values.size(), statistics, options);
       if (!estimatedSize.has_value()) {
         NIMBLE_SELECTION_LOG(
             PURPLE << encodingType << " encoding is incompatible.");

--- a/dwio/nimble/encodings/selection/EncodingSelectionPolicy.h
+++ b/dwio/nimble/encodings/selection/EncodingSelectionPolicy.h
@@ -131,12 +131,10 @@ class ManualEncodingSelectionPolicy : public EncodingSelectionPolicy<T> {
   ManualEncodingSelectionPolicy(
       std::vector<std::pair<EncodingType, float>> readFactors,
       std::optional<CompressionOptions> compressionOptions,
-      std::optional<NestedEncodingIdentifier> identifier,
-      uint16_t blockBitPackingBlockSize = kBlockBitPackingBlockSize)
+      std::optional<NestedEncodingIdentifier> identifier)
       : readFactors_{std::move(readFactors)},
         compressionOptions_{std::move(compressionOptions)},
-        identifier_{identifier},
-        blockBitPackingBlockSize_{blockBitPackingBlockSize} {}
+        identifier_{identifier} {}
 
   std::unique_ptr<EncodingSelectionPolicyBase> createImpl(
       EncodingType encodingType,
@@ -165,13 +163,13 @@ class ManualEncodingSelectionPolicy : public EncodingSelectionPolicy<T> {
         COMMA FixedByteWidth,
         std::move(filteredReadFactors),
         compressionOptions_,
-        identifier,
-        blockBitPackingBlockSize_);
+        identifier);
   }
 
   EncodingSelectionResult select(
       std::span<const physicalType> values,
-      const Statistics<physicalType>& statistics) override {
+      const Statistics<physicalType>& statistics,
+      const Encoding::Options& /* options */ = {}) override {
     if (values.empty()) {
       return {
           .encodingType = EncodingType::Trivial,
@@ -312,25 +310,23 @@ class ManualEncodingSelectionPolicy : public EncodingSelectionPolicy<T> {
                 ? "..."
                 : ""));
     if (!compressionOptions_.has_value()) {
-      return {
-          .encodingType = selectedEncoding,
-          .blockBitPackingBlockSize = blockBitPackingBlockSize_};
+      return {.encodingType = selectedEncoding};
     }
     return {
         .encodingType = selectedEncoding,
-        .compressionPolicyFactory =
-            [compressionOptions = compressionOptions_.value(),
-             selectedEncoding]() {
-              return std::make_unique<AlwaysCompressPolicy>(
-                  compressionOptions, selectedEncoding);
-            },
-        .blockBitPackingBlockSize = blockBitPackingBlockSize_};
+        .compressionPolicyFactory = [compressionOptions =
+                                         compressionOptions_.value(),
+                                     selectedEncoding]() {
+          return std::make_unique<AlwaysCompressPolicy>(
+              compressionOptions, selectedEncoding);
+        }};
   }
 
   EncodingSelectionResult selectNullable(
       std::span<const physicalType> /* values */,
       std::span<const bool> /* nulls */,
-      const Statistics<physicalType>& /* statistics */) override {
+      const Statistics<physicalType>& /* statistics */,
+      const Encoding::Options& /* options */ = {}) override {
     return {
         .encodingType = EncodingType::Nullable,
     };
@@ -352,7 +348,6 @@ class ManualEncodingSelectionPolicy : public EncodingSelectionPolicy<T> {
   // policies created from it.
   const std::optional<CompressionOptions> compressionOptions_;
   const std::optional<NestedEncodingIdentifier> identifier_;
-  const uint16_t blockBitPackingBlockSize_;
 };
 
 // This model is trained offline and parameters are updated here.
@@ -382,11 +377,9 @@ class ManualEncodingSelectionPolicyFactory {
       std::vector<std::pair<EncodingType, float>> readFactors =
           defaultReadFactors(),
       std::optional<CompressionOptions> compressionOptions =
-          CompressionOptions{},
-      uint16_t blockBitPackingBlockSize = kBlockBitPackingBlockSize)
+          CompressionOptions{})
       : readFactors_{std::move(readFactors)},
-        compressionOptions_{std::move(compressionOptions)},
-        blockBitPackingBlockSize_{blockBitPackingBlockSize} {}
+        compressionOptions_{std::move(compressionOptions)} {}
 
   std::unique_ptr<EncodingSelectionPolicyBase> createPolicy(
       DataType dataType) const {
@@ -395,8 +388,7 @@ class ManualEncodingSelectionPolicyFactory {
         ManualEncodingSelectionPolicy,
         readFactors_,
         compressionOptions_,
-        std::nullopt,
-        blockBitPackingBlockSize_);
+        std::nullopt);
   }
 
   // TODO: Add EncodingType::ALP here once the actual ALP algorithm is
@@ -494,7 +486,6 @@ class ManualEncodingSelectionPolicyFactory {
  private:
   const std::vector<std::pair<EncodingType, float>> readFactors_;
   const std::optional<CompressionOptions> compressionOptions_;
-  const uint16_t blockBitPackingBlockSize_;
 };
 
 // This is a learned encoding selection implementation.
@@ -519,7 +510,8 @@ class LearnedEncodingSelectionPolicy : public EncodingSelectionPolicy<T> {
 
   EncodingSelectionResult select(
       std::span<const physicalType> values,
-      const Statistics<physicalType>& statistics) override {
+      const Statistics<physicalType>& statistics,
+      const Encoding::Options& /* options */ = {}) override {
     if (values.empty()) {
       return {
           .encodingType = EncodingType::Trivial,
@@ -543,7 +535,8 @@ class LearnedEncodingSelectionPolicy : public EncodingSelectionPolicy<T> {
   EncodingSelectionResult selectNullable(
       std::span<const physicalType> /* values */,
       std::span<const bool> /* nulls */,
-      const Statistics<physicalType>& /* statistics */) override {
+      const Statistics<physicalType>& /* statistics */,
+      const Encoding::Options& /* options */ = {}) override {
     return {
         .encodingType = EncodingType::Nullable,
     };
@@ -676,7 +669,8 @@ class ReplayedEncodingSelectionPolicy
 
   nimble::EncodingSelectionResult select(
       std::span<const physicalType> /* values */,
-      const nimble::Statistics<physicalType>& /* statistics */) override {
+      const nimble::Statistics<physicalType>& /* statistics */,
+      const Encoding::Options& /* options */ = {}) override {
     NIMBLE_SELECTION_LOG(
         CYAN << "Replaying encoding " << encodingLayout_.encodingType());
     if (!compressionOptions_.has_value()) {
@@ -697,7 +691,8 @@ class ReplayedEncodingSelectionPolicy
   EncodingSelectionResult selectNullable(
       std::span<const physicalType> /* values */,
       std::span<const bool> /* nulls */,
-      const Statistics<physicalType>& /* statistics */) override {
+      const Statistics<physicalType>& /* statistics */,
+      const Encoding::Options& /* options */ = {}) override {
     NIMBLE_SELECTION_LOG(
         CYAN << "Replaying nullable encoding "
              << encodingLayout_.encodingType());

--- a/dwio/nimble/encodings/selection/EncodingSizeEstimation.h
+++ b/dwio/nimble/encodings/selection/EncodingSizeEstimation.h
@@ -19,8 +19,11 @@
 #include <algorithm>
 #include <cmath>
 #include <optional>
+#include <span>
 #include "dwio/nimble/common/Exceptions.h"
+#include "dwio/nimble/common/FixedBitArray.h"
 #include "dwio/nimble/common/Types.h"
+#include "dwio/nimble/encodings/BlockBitPackingEncoding.h"
 #include "dwio/nimble/encodings/ConstantEncoding.h"
 #include "dwio/nimble/encodings/DictionaryEncoding.h"
 #include "dwio/nimble/encodings/FixedBitWidthEncoding.h"
@@ -31,8 +34,10 @@
 #include "dwio/nimble/encodings/SparseBoolEncoding.h"
 #include "dwio/nimble/encodings/TrivialEncoding.h"
 #include "dwio/nimble/encodings/VarintEncoding.h"
+#include "velox/common/base/BitUtil.h"
 
 namespace facebook::nimble {
+
 namespace detail {
 
 // This class is meant to quickly estimate the size of encoded data using a
@@ -47,12 +52,16 @@ struct EncodingSizeEstimation {
   static std::optional<uint64_t> estimateNumericSize(
       const EncodingType encodingType,
       const uint64_t entryCount,
-      const Statistics<physicalType>& statistics) {
+      const Statistics<physicalType>& statistics,
+      const Encoding::Options& options = {}) {
     switch (encodingType) {
       case EncodingType::Constant: {
         return ConstantEncoding<physicalType>::estimateSize(statistics);
       }
       case EncodingType::MainlyConstant: {
+        // TODO: Wire per-block tightening when BlockBitPacking is a
+        // candidate. MainlyConstantEncoding::estimateSize already supports
+        // usePerBlockStats + blockSize params.
         return MainlyConstantEncoding<physicalType>::estimateSize(
             entryCount, statistics, FixedByteWidth);
       }
@@ -64,6 +73,9 @@ struct EncodingSizeEstimation {
             entryCount, statistics, FixedByteWidth);
       }
       case EncodingType::Dictionary: {
+        // TODO: Wire per-block tightening when BlockBitPacking is a
+        // candidate. DictionaryEncoding::estimateSize already supports
+        // usePerBlockStats + blockSize params.
         return DictionaryEncoding<physicalType>::estimateSize(
             entryCount, statistics, FixedByteWidth);
       }
@@ -96,6 +108,10 @@ struct EncodingSizeEstimation {
         } else {
           return std::nullopt;
         }
+      }
+      case EncodingType::BlockBitPacking: {
+        return BlockBitPackingEncoding<physicalType>::estimateSize(
+            statistics, options.blockBitPackingBlockSize);
       }
       // SubIntSplit integration commented out (disabled):
       /*
@@ -192,9 +208,10 @@ struct EncodingSizeEstimation {
   static std::optional<uint64_t> estimateSize(
       const EncodingType encodingType,
       const size_t entryCount,
-      const Statistics<physicalType>& statistics) {
+      const Statistics<physicalType>& statistics,
+      const Encoding::Options& options = {}) {
     if constexpr (isNumericType<physicalType>()) {
-      return estimateNumericSize(encodingType, entryCount, statistics);
+      return estimateNumericSize(encodingType, entryCount, statistics, options);
     } else if constexpr (isBoolType<physicalType>()) {
       return estimateBoolSize(encodingType, entryCount, statistics);
     } else if constexpr (isStringType<physicalType>()) {

--- a/dwio/nimble/encodings/selection/Statistics.cpp
+++ b/dwio/nimble/encodings/selection/Statistics.cpp
@@ -131,6 +131,16 @@ void Statistics<T, InputType>::populateUniques() const {
 }
 
 template <typename T, typename InputType>
+void Statistics<T, InputType>::populateMinMaxBlocks(uint16_t blockSize) const {
+  static_assert(std::is_unsigned_v<T>);
+  BlockStatsAccumulator acc(blockSize);
+  for (const auto& v : data_) {
+    acc.add(static_cast<uint64_t>(static_cast<T>(v)));
+  }
+  minMaxBlocks_ = acc.finish();
+}
+
+template <typename T, typename InputType>
 void Statistics<T, InputType>::populateBucketCounts() const {
   using UnsignedT = typename std::make_unsigned<T>::type;
   // Bucket counts are calculated in two phases. In phase one, we iterate on all
@@ -272,6 +282,13 @@ template void Statistics<float>::populateMinMax() const;
 template void Statistics<double>::populateMinMax() const;
 template void Statistics<std::string_view>::populateMinMax() const;
 template void Statistics<std::string_view, std::string>::populateMinMax() const;
+
+// populateMinMaxBlocks is used through the estimation path where T is always
+// the unsigned physicalType.
+template void Statistics<uint8_t>::populateMinMaxBlocks(uint16_t) const;
+template void Statistics<uint16_t>::populateMinMaxBlocks(uint16_t) const;
+template void Statistics<uint32_t>::populateMinMaxBlocks(uint16_t) const;
+template void Statistics<uint64_t>::populateMinMaxBlocks(uint16_t) const;
 
 // populateBucketCounts works on integral types only
 template void Statistics<int8_t>::populateBucketCounts() const;

--- a/dwio/nimble/encodings/selection/Statistics.h
+++ b/dwio/nimble/encodings/selection/Statistics.h
@@ -20,6 +20,7 @@
 #include <span>
 #include <type_traits>
 #include <vector>
+#include "dwio/nimble/common/Constants.h"
 #include "dwio/nimble/common/Types.h"
 
 #include "absl/container/flat_hash_map.h" // @manual=fbsource//third-party/abseil-cpp:container__flat_hash_map
@@ -195,14 +196,70 @@ class Statistics {
     return uniqueCounts_.value();
   }
 
+  struct BlockStats {
+    uint64_t count;
+    uint64_t min;
+    uint64_t max;
+  };
+
+  const std::vector<BlockStats>& minMaxBlocks(
+      uint16_t blockSize = kBlockBitPackingBlockSize) const noexcept {
+    static_assert(nimble::isNumericType<T>());
+    if (!minMaxBlocks_.has_value() || minMaxBlockSize_ != blockSize) {
+      populateMinMaxBlocks(blockSize);
+      minMaxBlockSize_ = blockSize;
+    }
+    return minMaxBlocks_.value();
+  }
+
  private:
   Statistics() = default;
   std::span<const InputType> data_;
+
+  class BlockStatsAccumulator {
+   public:
+    explicit BlockStatsAccumulator(uint16_t blockSize)
+        : blockSize_{blockSize} {}
+
+    void add(uint64_t val) {
+      if (val < blockMin_) {
+        blockMin_ = val;
+      }
+      if (val > blockMax_) {
+        blockMax_ = val;
+      }
+      if (++blockCount_ == blockSize_) {
+        flush();
+      }
+    }
+
+    std::vector<BlockStats> finish() {
+      flush();
+      return std::move(result_);
+    }
+
+   private:
+    void flush() {
+      if (blockCount_ > 0) {
+        result_.push_back({blockCount_, blockMin_, blockMax_});
+      }
+      blockCount_ = 0;
+      blockMin_ = std::numeric_limits<uint64_t>::max();
+      blockMax_ = 0;
+    }
+
+    const uint16_t blockSize_;
+    uint64_t blockCount_ = 0;
+    uint64_t blockMin_ = std::numeric_limits<uint64_t>::max();
+    uint64_t blockMax_ = 0;
+    std::vector<BlockStats> result_;
+  };
 
   void populateRepeats() const;
   void populateUniques() const;
   void populateMinMax() const;
   void populateBucketCounts() const;
+  void populateMinMaxBlocks(uint16_t blockSize) const;
   void populateStringLength() const;
 
   mutable std::optional<uint64_t> consecutiveRepeatCount_;
@@ -213,6 +270,8 @@ class Statistics {
   mutable std::optional<T> min_;
   mutable std::optional<T> max_;
   mutable std::optional<std::vector<uint64_t>> bucketCounts_;
+  mutable std::optional<std::vector<BlockStats>> minMaxBlocks_;
+  mutable uint16_t minMaxBlockSize_{0};
   mutable std::optional<std::optional<UniqueValueCounts<T, InputType>>>
       uniqueCounts_;
 };

--- a/dwio/nimble/encodings/tests/BufferedEncodingTest.cpp
+++ b/dwio/nimble/encodings/tests/BufferedEncodingTest.cpp
@@ -36,14 +36,16 @@ class NoOpEncodingSelectionPolicy : public nimble::EncodingSelectionPolicy<T> {
  public:
   nimble::EncodingSelectionResult select(
       std::span<const physicalType>,
-      const nimble::Statistics<physicalType>&) override {
+      const nimble::Statistics<physicalType>&,
+      const nimble::Encoding::Options& /* options */) override {
     return {.encodingType = nimble::EncodingType::Trivial};
   }
 
   nimble::EncodingSelectionResult selectNullable(
       std::span<const physicalType>,
       std::span<const bool>,
-      const nimble::Statistics<physicalType>&) override {
+      const nimble::Statistics<physicalType>&,
+      const nimble::Encoding::Options& /* options */) override {
     return {.encodingType = nimble::EncodingType::Nullable};
   }
 

--- a/dwio/nimble/encodings/tests/DeltaEncodingLegacyTest.cpp
+++ b/dwio/nimble/encodings/tests/DeltaEncodingLegacyTest.cpp
@@ -53,7 +53,8 @@ class TestTrivialSelectionPolicy : public EncodingSelectionPolicy<T> {
  public:
   EncodingSelectionResult select(
       std::span<const physicalType> /* values */,
-      const Statistics<physicalType>& /* statistics */) override {
+      const Statistics<physicalType>& /* statistics */,
+      const Encoding::Options& /* options */) override {
     return {
         .encodingType = EncodingType::Trivial,
         .compressionPolicyFactory = []() {
@@ -64,7 +65,8 @@ class TestTrivialSelectionPolicy : public EncodingSelectionPolicy<T> {
   EncodingSelectionResult selectNullable(
       std::span<const physicalType> /* values */,
       std::span<const bool> /* nulls */,
-      const Statistics<physicalType>& /* statistics */) override {
+      const Statistics<physicalType>& /* statistics */,
+      const Encoding::Options& /* options */) override {
     return {.encodingType = EncodingType::Nullable};
   }
 

--- a/dwio/nimble/encodings/tests/EncodingLayoutTest.cpp
+++ b/dwio/nimble/encodings/tests/EncodingLayoutTest.cpp
@@ -120,14 +120,16 @@ class ForceSubIntSplitPolicy final : public nimble::EncodingSelectionPolicy<T> {
  public:
   nimble::EncodingSelectionResult select(
       std::span<const physicalType> /* values */,
-      const nimble::Statistics<physicalType>& /* statistics */) override {
+      const nimble::Statistics<physicalType>& /* statistics */,
+      const nimble::Encoding::Options& /* options */) override {
     return {.encodingType = nimble::EncodingType::SubIntSplit};
   }
 
   nimble::EncodingSelectionResult selectNullable(
       std::span<const physicalType> /* values */,
       std::span<const bool> /* nulls */,
-      const nimble::Statistics<physicalType>& /* statistics */) override {
+      const nimble::Statistics<physicalType>& /* statistics */,
+      const nimble::Encoding::Options& /* options */) override {
     return {.encodingType = nimble::EncodingType::Nullable};
   }
 

--- a/dwio/nimble/encodings/tests/EncodingLayoutTestHelper.h
+++ b/dwio/nimble/encodings/tests/EncodingLayoutTestHelper.h
@@ -104,13 +104,15 @@ class TrivialNestedPolicy : public EncodingSelectionPolicy<T> {
  public:
   EncodingSelectionResult select(
       std::span<const physicalType>,
-      const Statistics<physicalType>&) override {
+      const Statistics<physicalType>&,
+      const Encoding::Options& /* options */) override {
     return {.encodingType = EncodingType::Trivial};
   }
   EncodingSelectionResult selectNullable(
       std::span<const physicalType>,
       std::span<const bool>,
-      const Statistics<physicalType>&) override {
+      const Statistics<physicalType>&,
+      const Encoding::Options& /* options */) override {
     return {.encodingType = EncodingType::Nullable};
   }
   std::unique_ptr<EncodingSelectionPolicyBase>

--- a/dwio/nimble/encodings/tests/EncodingLegacyTest.cpp
+++ b/dwio/nimble/encodings/tests/EncodingLegacyTest.cpp
@@ -100,7 +100,8 @@ class TestTrivialEncodingSelectionPolicy
 
   nimble::EncodingSelectionResult select(
       std::span<const physicalType> /* values */,
-      const nimble::Statistics<physicalType>& /* statistics */) override {
+      const nimble::Statistics<physicalType>& /* statistics */,
+      const nimble::Encoding::Options& /* options */) override {
     return {
         .encodingType = nimble::EncodingType::Trivial,
         .compressionPolicyFactory = [this]() {
@@ -112,7 +113,8 @@ class TestTrivialEncodingSelectionPolicy
   nimble::EncodingSelectionResult selectNullable(
       std::span<const physicalType> /* values */,
       std::span<const bool> /* nulls */,
-      const nimble::Statistics<physicalType>& /* statistics */) override {
+      const nimble::Statistics<physicalType>& /* statistics */,
+      const nimble::Encoding::Options& /* options */) override {
     return {
         .encodingType = nimble::EncodingType::Nullable,
     };

--- a/dwio/nimble/encodings/tests/EncodingSelectionTest.cpp
+++ b/dwio/nimble/encodings/tests/EncodingSelectionTest.cpp
@@ -1086,6 +1086,90 @@ TEST(ManualEncodingSelectionPolicyTest, noCompressFlagPropagesToNested) {
       nimble::CompressionType::Uncompressed);
 }
 
+TEST(ManualEncodingSelectionPolicyTest, perEncodingCompressionAcceptRatio) {
+  // Default CompressionOptions has BlockBitPacking=0.7 in overrides.
+  // The accept ratio is enforced by shouldAccept(), not by changing the
+  // compression type — compression is always attempted, but rejected if
+  // the compressed size exceeds the ratio threshold.
+
+  // Force BlockBitPacking selection via read factors.
+  auto cbpPolicy =
+      std::make_unique<nimble::ManualEncodingSelectionPolicy<uint32_t>>(
+          std::vector<std::pair<nimble::EncodingType, float>>{
+              {nimble::EncodingType::BlockBitPacking, 1.0}},
+          nimble::CompressionOptions{},
+          std::nullopt);
+  std::vector<uint32_t> data(2048);
+  for (uint32_t i = 0; i < data.size(); ++i) {
+    data[i] = i % 100;
+  }
+  auto cbpResult =
+      cbpPolicy->select(data, nimble::Statistics<uint32_t>::create(data));
+  EXPECT_EQ(cbpResult.encodingType, nimble::EncodingType::BlockBitPacking);
+  auto cbpCompressionPolicy = cbpResult.compressionPolicyFactory();
+  // BlockBitPacking ratio is 0.7: reject compression that only saves 20%.
+  EXPECT_FALSE(cbpCompressionPolicy->shouldAccept(
+      nimble::CompressionType::MetaInternal, 100, 80));
+  // Accept compression that saves 40%.
+  EXPECT_TRUE(cbpCompressionPolicy->shouldAccept(
+      nimble::CompressionType::MetaInternal, 100, 60));
+
+  // Force Trivial selection — default ratio is 0.98, more permissive.
+  auto trivialPolicy =
+      std::make_unique<nimble::ManualEncodingSelectionPolicy<uint32_t>>(
+          std::vector<std::pair<nimble::EncodingType, float>>{
+              {nimble::EncodingType::Trivial, 1.0}},
+          nimble::CompressionOptions{},
+          std::nullopt);
+  auto trivialResult =
+      trivialPolicy->select(data, nimble::Statistics<uint32_t>::create(data));
+  EXPECT_EQ(trivialResult.encodingType, nimble::EncodingType::Trivial);
+  auto trivialCompressionPolicy = trivialResult.compressionPolicyFactory();
+  // Trivial uses default ratio 0.98: accept compression that saves 20%.
+  EXPECT_TRUE(trivialCompressionPolicy->shouldAccept(
+      nimble::CompressionType::MetaInternal, 100, 80));
+}
+
+TEST(ManualEncodingSelectionPolicyTest, customCompressionAcceptRatioOverride) {
+  // Override: FixedBitWidth=0.0 (reject all compression).
+  nimble::CompressionOptions options;
+  options.compressionAcceptRatioOverrides = {
+      {nimble::EncodingType::FixedBitWidth, 0.0f}};
+
+  auto fbwPolicy =
+      std::make_unique<nimble::ManualEncodingSelectionPolicy<uint32_t>>(
+          std::vector<std::pair<nimble::EncodingType, float>>{
+              {nimble::EncodingType::FixedBitWidth, 1.0}},
+          options,
+          std::nullopt);
+  std::vector<uint32_t> data(1000);
+  for (uint32_t i = 0; i < data.size(); ++i) {
+    data[i] = i;
+  }
+  auto result =
+      fbwPolicy->select(data, nimble::Statistics<uint32_t>::create(data));
+  EXPECT_EQ(result.encodingType, nimble::EncodingType::FixedBitWidth);
+  auto compressionPolicy = result.compressionPolicyFactory();
+  // FixedBitWidth ratio is 0.0: reject all compression.
+  EXPECT_FALSE(compressionPolicy->shouldAccept(
+      nimble::CompressionType::MetaInternal, 100, 1));
+
+  // BlockBitPacking NOT in this override list — uses default ratio (0.98).
+  auto cbpPolicy =
+      std::make_unique<nimble::ManualEncodingSelectionPolicy<uint32_t>>(
+          std::vector<std::pair<nimble::EncodingType, float>>{
+              {nimble::EncodingType::BlockBitPacking, 1.0}},
+          options,
+          std::nullopt);
+  auto cbpResult =
+      cbpPolicy->select(data, nimble::Statistics<uint32_t>::create(data));
+  auto cbpCompressionPolicy = cbpResult.compressionPolicyFactory();
+  // BlockBitPacking has no override here, uses default 0.98: accept moderate
+  // savings.
+  EXPECT_TRUE(cbpCompressionPolicy->shouldAccept(
+      nimble::CompressionType::MetaInternal, 100, 80));
+}
+
 TEST(ManualEncodingSelectionPolicyFactoryTest, noCompressFactory) {
   // Factory with nullopt compressionOptions should create policies that skip
   // compression.

--- a/dwio/nimble/encodings/tests/EncodingSizeEstimationTest.cpp
+++ b/dwio/nimble/encodings/tests/EncodingSizeEstimationTest.cpp
@@ -527,3 +527,194 @@ TEST_F(EncodingSizeEstimationTest, blockBitPackingEstimateVsActualSize) {
   verifyBlockBitPackingEstimateVsActualSize<uint32_t>();
   verifyBlockBitPackingEstimateVsActualSize<uint64_t>();
 }
+
+TEST_F(
+    EncodingSizeEstimationTest,
+    blockBitPackingStatisticsOverloadMatchesSpanOverload) {
+  std::vector<uint32_t> data;
+  data.reserve(2050);
+  for (uint32_t i = 0; i < 1024; ++i) {
+    data.push_back(1000 + i % 4);
+  }
+  for (uint32_t i = 0; i < 1024; ++i) {
+    data.push_back(1'000'000 + i % 8);
+  }
+  data.push_back(std::numeric_limits<uint32_t>::min());
+  data.push_back(std::numeric_limits<uint32_t>::max());
+
+  const auto spanEstimate = BlockBitPackingEncoding<uint32_t>::estimateSize(
+      std::span<const uint32_t>{data.data(), data.size()});
+  auto stats = Statistics<uint32_t>::create(data);
+  const auto statsEstimate =
+      BlockBitPackingEncoding<uint32_t>::estimateSize(stats);
+
+  EXPECT_EQ(spanEstimate, statsEstimate);
+}
+
+TEST_F(
+    EncodingSizeEstimationTest,
+    blockBitPackingSkipEncodingForFullRangeBlock) {
+  std::vector<uint32_t> data;
+  data.reserve(2048);
+  // Block 0: narrow range (should pack)
+  for (uint32_t i = 0; i < 1024; ++i) {
+    data.push_back(i % 4);
+  }
+  // Block 1: full 32-bit range (should skip encoding)
+  for (uint32_t i = 0; i < 1024; ++i) {
+    data.push_back(i == 0 ? 0 : std::numeric_limits<uint32_t>::max());
+  }
+
+  auto stats = Statistics<uint32_t>::create(data);
+  const auto estimate = BlockBitPackingEncoding<uint32_t>::estimateSize(stats);
+
+  // Block 1 should fall back to raw: 1024 * 4 = 4096 bytes.
+  // Block 0 packs at 2 bits: much smaller.
+  // Total should be less than 2 * 1024 * 4 (if both were raw).
+  const auto bothRaw = 2 * 1024 * sizeof(uint32_t);
+  EXPECT_LT(estimate, bothRaw + 200);
+  EXPECT_GT(estimate, 4096);
+}
+
+// TODO: Add perBlockTighteningReducesMainlyConstantEstimate and
+// perBlockTighteningReducesDictionaryEstimate tests when per-block
+// tightening is wired up for MainlyConstant and Dictionary encodings.
+
+TEST_F(EncodingSizeEstimationTest, customBlockSizeAffectsEstimate) {
+  // With block size 512, we get 4 blocks instead of 2 (for 2048 values).
+  // Each smaller block has a tighter range → different estimate.
+  std::vector<uint32_t> data;
+  data.reserve(2048);
+  for (uint32_t i = 0; i < 2048; ++i) {
+    data.push_back(i);
+  }
+
+  auto stats = Statistics<uint32_t>::create(data);
+
+  const auto defaultBlockEstimate =
+      BlockBitPackingEncoding<uint32_t>::estimateSize(stats);
+  const auto smallBlockEstimate =
+      BlockBitPackingEncoding<uint32_t>::estimateSize(stats, /*blockSize=*/512);
+
+  // Smaller blocks → tighter per-block ranges → smaller packed data.
+  // But more blocks → more metadata overhead.
+  // The estimates should differ.
+  EXPECT_NE(defaultBlockEstimate, smallBlockEstimate);
+
+  // With sequential data [0..2047], smaller blocks have tighter ranges.
+  // Block size 512: 4 blocks, each spanning 512 values (9 bits).
+  // Block size 1024: 2 blocks, each spanning 1024 values (10 bits).
+  // Smaller blocks should pack tighter despite more metadata.
+  EXPECT_LT(smallBlockEstimate, defaultBlockEstimate);
+
+  // Calling with the original block size again should return the same result
+  // (verifies cache invalidation round-trips correctly).
+  const auto defaultBlockEstimateAgain =
+      BlockBitPackingEncoding<uint32_t>::estimateSize(stats);
+  EXPECT_EQ(defaultBlockEstimate, defaultBlockEstimateAgain);
+}
+
+TEST_F(
+    EncodingSizeEstimationTest,
+    blockBitPackingStatisticsOverloadMultipleTypes) {
+  // Verify Statistics-based and span-based estimateSize match for all unsigned
+  // physical types, not just uint32_t.
+  auto verifyMatch = [](auto typeTag) {
+    using T = decltype(typeTag);
+    std::vector<T> data;
+    data.reserve(2048);
+    for (uint32_t i = 0; i < 2048; ++i) {
+      data.push_back(static_cast<T>(i % 200));
+    }
+
+    const auto spanEstimate = BlockBitPackingEncoding<T>::estimateSize(
+        std::span<const T>{data.data(), data.size()});
+    auto stats = Statistics<T>::create(data);
+    const auto statsEstimate = BlockBitPackingEncoding<T>::estimateSize(stats);
+
+    EXPECT_EQ(spanEstimate, statsEstimate)
+        << "Mismatch for type size " << sizeof(T);
+  };
+
+  verifyMatch(uint8_t{});
+  verifyMatch(uint16_t{});
+  verifyMatch(uint32_t{});
+  verifyMatch(uint64_t{});
+}
+
+TEST_F(EncodingSizeEstimationTest, blockBitPackingConstantData) {
+  // All values identical: every block has range=0, bw=0, packedSize=0.
+  // Estimate should be dominated by metadata.
+  std::vector<uint32_t> data(2048, 42);
+
+  auto stats = Statistics<uint32_t>::create(data);
+  const auto estimate = BlockBitPackingEncoding<uint32_t>::estimateSize(stats);
+
+  const auto rawSize = 2048 * sizeof(uint32_t);
+  EXPECT_LT(estimate, rawSize / 2);
+  EXPECT_GT(estimate, 0);
+}
+
+TEST_F(EncodingSizeEstimationTest, blockBitPackingPartialLastBlock) {
+  // 1500 values: 1 full block (1024) + 1 partial block (476).
+  // Verifies BlockStatsAccumulator correctly flushes the remainder.
+  std::vector<uint32_t> data;
+  data.reserve(1500);
+  for (uint32_t i = 0; i < 1500; ++i) {
+    data.push_back(i % 16);
+  }
+
+  auto stats = Statistics<uint32_t>::create(data);
+  const auto statsEstimate =
+      BlockBitPackingEncoding<uint32_t>::estimateSize(stats);
+  const auto spanEstimate = BlockBitPackingEncoding<uint32_t>::estimateSize(
+      std::span<const uint32_t>{data.data(), data.size()});
+
+  EXPECT_EQ(spanEstimate, statsEstimate);
+  EXPECT_GT(statsEstimate, 0);
+}
+
+TEST_F(EncodingSizeEstimationTest, blockBitPackingSingleValue) {
+  // Edge case: 1 value.
+  std::vector<uint32_t> data = {12345};
+
+  auto stats = Statistics<uint32_t>::create(data);
+  const auto statsEstimate =
+      BlockBitPackingEncoding<uint32_t>::estimateSize(stats);
+  const auto spanEstimate = BlockBitPackingEncoding<uint32_t>::estimateSize(
+      std::span<const uint32_t>{data.data(), data.size()});
+
+  EXPECT_EQ(spanEstimate, statsEstimate);
+}
+
+TEST_F(
+    EncodingSizeEstimationTest,
+    blockBitPackingEstimateViaEncodingSizeEstimation) {
+  // Verify BlockBitPacking is wired up in EncodingSizeEstimation dispatcher.
+  using Est = detail::EncodingSizeEstimation<uint32_t, true>;
+
+  std::vector<uint32_t> data;
+  data.reserve(2048);
+  for (uint32_t i = 0; i < 2048; ++i) {
+    data.push_back(i % 100);
+  }
+  auto stats = Statistics<uint32_t>::create(data);
+
+  auto estimate =
+      Est::estimateNumericSize(EncodingType::BlockBitPacking, 2048, stats);
+  ASSERT_TRUE(estimate.has_value());
+  EXPECT_GT(estimate.value(), 0);
+
+  // Verify it matches the direct call with default block size.
+  const auto directEstimate =
+      BlockBitPackingEncoding<uint32_t>::estimateSize(stats);
+  EXPECT_EQ(estimate.value(), directEstimate);
+
+  // Verify options.blockBitPackingBlockSize is threaded through.
+  Encoding::Options options;
+  options.blockBitPackingBlockSize = 512;
+  auto estimateSmallBlock = Est::estimateNumericSize(
+      EncodingType::BlockBitPacking, 2048, stats, options);
+  ASSERT_TRUE(estimateSmallBlock.has_value());
+  EXPECT_NE(estimateSmallBlock.value(), estimate.value());
+}

--- a/dwio/nimble/encodings/tests/EncodingTest.cpp
+++ b/dwio/nimble/encodings/tests/EncodingTest.cpp
@@ -154,7 +154,8 @@ class TestTrivialEncodingSelectionPolicy
 
   nimble::EncodingSelectionResult select(
       std::span<const physicalType> /* values */,
-      const nimble::Statistics<physicalType>& /* statistics */) override {
+      const nimble::Statistics<physicalType>& /* statistics */,
+      const nimble::Encoding::Options& /* options */) override {
     return {
         .encodingType = nimble::EncodingType::Trivial,
         .compressionPolicyFactory = [this]() {
@@ -166,7 +167,8 @@ class TestTrivialEncodingSelectionPolicy
   nimble::EncodingSelectionResult selectNullable(
       std::span<const physicalType> /* values */,
       std::span<const bool> /* nulls */,
-      const nimble::Statistics<physicalType>& /* statistics */) override {
+      const nimble::Statistics<physicalType>& /* statistics */,
+      const nimble::Encoding::Options& /* options */) override {
     return {
         .encodingType = nimble::EncodingType::Nullable,
     };

--- a/dwio/nimble/encodings/tests/EncodingTestsLegacy.cpp
+++ b/dwio/nimble/encodings/tests/EncodingTestsLegacy.cpp
@@ -97,7 +97,8 @@ class TestTrivialEncodingSelectionPolicy
 
   nimble::EncodingSelectionResult select(
       std::span<const physicalType> /* values */,
-      const nimble::Statistics<physicalType>& /* statistics */) override {
+      const nimble::Statistics<physicalType>& /* statistics */,
+      const nimble::Encoding::Options& /* options */) override {
     return {
         .encodingType = nimble::EncodingType::Trivial,
         .compressionPolicyFactory = [this]() {
@@ -109,7 +110,8 @@ class TestTrivialEncodingSelectionPolicy
   nimble::EncodingSelectionResult selectNullable(
       std::span<const physicalType> /* values */,
       std::span<const bool> /* nulls */,
-      const nimble::Statistics<physicalType>& /* statistics */) override {
+      const nimble::Statistics<physicalType>& /* statistics */,
+      const nimble::Encoding::Options& /* options */) override {
     return {
         .encodingType = nimble::EncodingType::Nullable,
     };

--- a/dwio/nimble/encodings/tests/ReadWithVisitorTest.cpp
+++ b/dwio/nimble/encodings/tests/ReadWithVisitorTest.cpp
@@ -127,14 +127,16 @@ class NonRecursiveSubIntSplitPolicy final : public EncodingSelectionPolicy<T> {
  public:
   EncodingSelectionResult select(
       std::span<const physicalType> /* values */,
-      const Statistics<physicalType>& /* statistics */) override {
+      const Statistics<physicalType>& /* statistics */,
+      const Encoding::Options& /* options */) override {
     return {.encodingType = EncodingType::SubIntSplit};
   }
 
   EncodingSelectionResult selectNullable(
       std::span<const physicalType> /* values */,
       std::span<const bool> /* nulls */,
-      const Statistics<physicalType>& /* statistics */) override {
+      const Statistics<physicalType>& /* statistics */,
+      const Encoding::Options& /* options */) override {
     return {.encodingType = EncodingType::Nullable};
   }
 

--- a/dwio/nimble/encodings/tests/SubIntSplitEncodingTest.cpp
+++ b/dwio/nimble/encodings/tests/SubIntSplitEncodingTest.cpp
@@ -108,14 +108,16 @@ class NonRecursiveSubIntSplitPolicy final
  public:
   nimble::EncodingSelectionResult select(
       std::span<const physicalType> /* values */,
-      const nimble::Statistics<physicalType>& /* statistics */) override {
+      const nimble::Statistics<physicalType>& /* statistics */,
+      const nimble::Encoding::Options& /* options */) override {
     return {.encodingType = nimble::EncodingType::SubIntSplit};
   }
 
   nimble::EncodingSelectionResult selectNullable(
       std::span<const physicalType> /* values */,
       std::span<const bool> /* nulls */,
-      const nimble::Statistics<physicalType>& /* statistics */) override {
+      const nimble::Statistics<physicalType>& /* statistics */,
+      const nimble::Encoding::Options& /* options */) override {
     return {.encodingType = nimble::EncodingType::Nullable};
   }
 

--- a/dwio/nimble/encodings/tests/TestUtils.h
+++ b/dwio/nimble/encodings/tests/TestUtils.h
@@ -198,7 +198,8 @@ class Encoder {
 
     nimble::EncodingSelectionResult select(
         std::span<const physicalType> /* values */,
-        const nimble::Statistics<physicalType>& /* statistics */) override {
+        const nimble::Statistics<physicalType>& /* statistics */,
+        const nimble::Encoding::Options& /* options */) override {
       return {
           .encodingType = nimble::EncodingType::Trivial,
           .compressionPolicyFactory = [this]() {
@@ -209,7 +210,8 @@ class Encoder {
     EncodingSelectionResult selectNullable(
         std::span<const physicalType> /* values */,
         std::span<const bool> /* nulls */,
-        const Statistics<physicalType>& /* statistics */) override {
+        const Statistics<physicalType>& /* statistics */,
+        const Encoding::Options& /* options */) override {
       return {
           .encodingType = EncodingType::Nullable,
       };

--- a/dwio/nimble/serializer/Options.h
+++ b/dwio/nimble/serializer/Options.h
@@ -247,6 +247,11 @@ struct SerializerOptions {
   /// FixedBitWidth.
   EncodingType streamIndicesEncodingType{EncodingType::FixedBitWidth};
 
+  /// Per-encoding options passed to EncodingFactory::encode(). Controls
+  /// format-level settings (varint row count) and per-encoding config
+  /// (e.g., BlockBitPacking block size).
+  Encoding::Options encodingOptions{.useVarintRowCount = true};
+
   /// Encoding type for the sizes array of the sparse stream-sizes trailer.
   /// Sizes are the byte sizes of non-zero streams, parallel to the indices
   /// array. Supported types: Trivial, Varint, Delta, FixedBitWidth.

--- a/dwio/nimble/serializer/SerializerImpl.h
+++ b/dwio/nimble/serializer/SerializerImpl.h
@@ -89,6 +89,7 @@ std::string_view encodeTyped(
     std::span<const T> values,
     nimble::Buffer& encodingBuffer,
     const EncodingSelectionPolicyFactory& policyFactory,
+    const Encoding::Options& encodingOptions = {.useVarintRowCount = true},
     const EncodingLayout* encodingLayout = nullptr,
     std::optional<CompressionOptions> compressionOptions = std::nullopt) {
   std::unique_ptr<EncodingSelectionPolicy<T>> typedPolicy;
@@ -102,10 +103,7 @@ std::string_view encodeTyped(
         policyFactory(TypeTraits<T>::dataType));
   }
   return EncodingFactory::encode<T>(
-      std::move(typedPolicy),
-      values,
-      encodingBuffer,
-      Encoding::Options{.useVarintRowCount = true});
+      std::move(typedPolicy), values, encodingBuffer, encodingOptions);
 }
 
 /// Reads the trailer size (u32) from the last 4 bytes of the buffer.
@@ -463,6 +461,7 @@ std::string_view encodeTyped(
       values,
       encodingBuffer,
       options.encodingSelectionPolicyFactory,
+      options.encodingOptions,
       encodingLayout,
       options.compressionOptions);
 }

--- a/dwio/nimble/serializer/tests/SerializerImplTest.cpp
+++ b/dwio/nimble/serializer/tests/SerializerImplTest.cpp
@@ -1587,6 +1587,7 @@ TEST_F(EncodeTypedCompressionTest, withEncodingLayout) {
         std::span<const uint32_t>(data),
         buffer,
         policyFactory,
+        Encoding::Options{.useVarintRowCount = true},
         &layout,
         testData.compressionOptions);
 
@@ -1634,6 +1635,7 @@ TEST_F(EncodeTypedCompressionTest, withoutEncodingLayout) {
       std::span<const uint32_t>(data),
       buffer,
       noCompressPolicyFactory,
+      Encoding::Options{.useVarintRowCount = true},
       /*encodingLayout=*/nullptr,
       /*compressionOptions=*/CompressionOptions{});
 

--- a/dwio/nimble/velox/VeloxWriter.cpp
+++ b/dwio/nimble/velox/VeloxWriter.cpp
@@ -347,12 +347,15 @@ std::string_view encode(
                 .release()));
   }
 
+  const auto encodingOptions = context.options().buildEncodingOptions();
+
   if (streamData.hasNulls()) {
     std::span<const bool> notNulls = streamData.nonNulls();
     return EncodingFactory::encodeNullable(
-        std::move(policy), data, notNulls, buffer);
+        std::move(policy), data, notNulls, buffer, encodingOptions);
   } else {
-    return EncodingFactory::encode(std::move(policy), data, buffer);
+    return EncodingFactory::encode(
+        std::move(policy), data, buffer, encodingOptions);
   }
 }
 

--- a/dwio/nimble/velox/VeloxWriterOptions.h
+++ b/dwio/nimble/velox/VeloxWriterOptions.h
@@ -131,7 +131,12 @@ struct VeloxWriterOptions {
   CompressionOptions compressionOptions;
 
   // Block size for BlockBitPacking encoding.
-  uint16_t blockBitPackingBlockSize{kBlockBitPackingBlockSize};
+  uint16_t blockBitPackingBlockSize = kBlockBitPackingBlockSize;
+
+  /// Builds Encoding::Options from VeloxWriterOptions fields.
+  Encoding::Options buildEncodingOptions() const {
+    return {.blockBitPackingBlockSize = blockBitPackingBlockSize};
+  }
 
   // In low-memory mode, the writer is trying to perform smaller (and more
   // precise) buffer allocations. This means that overall, the writer will


### PR DESCRIPTION
Summary:

CONTEXT: BlockBitPacking encodes data in 1024-row blocks with per-block min subtraction, but encoding selection estimated competing encodings (MainlyConstant, Dictionary) using global min/max, making them appear cheaper than they are.

WHAT: Adds per-block statistics to `Statistics` class and wires them into encoding size estimation:

**Statistics (lazy, cached on first access):**
- `minMaxBlocks(blockSize)`: per-block min/max for BlockBitPacking estimation
- `dictIndexMinMaxBlocks(blockSize)`: per-block max dictionary index for Dictionary estimation
- `uncommonMinMaxBlocks(blockSize)`: per-block uncommon value min/max for MainlyConstant estimation
- `BlockStatsAccumulator`: shared accumulator that flushes every `blockSize` rows
- Block size is configurable (defaults to `kBlockBitPackingBlockSize` = 1024)

**Encoding size estimation:**
- `BlockBitPackingEncoding::estimateSize(Statistics&, blockSize)`: new overload using cached per-block stats, with per-block skip-encoding detection and nested Trivial metadata estimation
- `MainlyConstantEncoding::estimateSize(..., usePerBlockStats, blockSize)`: when enabled, tightens inner bit-packed estimate using `min(globalSize, perBlockSize)` for cascading inner encodings
- `DictionaryEncoding::estimateSize(..., usePerBlockStats, blockSize)`: same pattern for index stream
- `EncodingSizeEstimation` threads `blockSize` from `ManualEncodingSelectionPolicy` through to all estimators

**Shared primitives:**
- `FixedBitArray::packedDataSize(min, max, count)`: computes packed data size from value range

**Other:**
- Default `compressionAcceptRatio` override of 0.7 for BlockBitPacking (requires 30% savings to justify compression CPU cost)

Reviewed By: xiaoxmeng

Differential Revision: D108585458


