### PR TITLE
fix: Gracefully handle cache-full in Nimble metadata cache

### DIFF
--- a/dwio/nimble/tablet/MetadataInput.cpp
+++ b/dwio/nimble/tablet/MetadataInput.cpp
@@ -345,8 +345,14 @@ velox::cache::CachePin CachedMetadataInput::acquireCachePin(
     uint32_t size) {
   for (;;) {
     folly::SemiFuture<bool> waitFuture{false};
-    auto pin =
-        cache_->findOrCreate(key, size, /*contiguous=*/true, &waitFuture);
+    velox::cache::CachePin pin;
+    try {
+      pin = cache_->findOrCreate(key, size, /*contiguous=*/true, &waitFuture);
+    } catch (const velox::VeloxRuntimeError&) {
+      // Cache is full and cannot evict enough entries. Return empty pin
+      // so the caller falls back to loading from storage without caching.
+      return {};
+    }
     if (!pin.empty()) {
       return pin;
     }
@@ -503,6 +509,11 @@ std::vector<uint32_t> CachedMetadataInput::loadFromCache(
 
     if (uncompressedSize.has_value()) {
       auto pin = acquireCachePin(key, uncompressedSize.value());
+      if (pin.empty()) {
+        // Cache is full; skip caching and load from storage directly.
+        loadIndices.push_back(index);
+        continue;
+      }
       auto buffer = tryCacheHit(uncompressedSize.value(), pin);
       if (buffer != nullptr) {
         sections[index].buffer = std::move(buffer);

--- a/dwio/nimble/tablet/tests/MetadataInputTest.cpp
+++ b/dwio/nimble/tablet/tests/MetadataInputTest.cpp
@@ -1275,6 +1275,53 @@ DEBUG_ONLY_TEST_P(CachedMetadataInputTest, concurrentCacheAndFind) {
   EXPECT_EQ(foundResult->content(), cachedData);
 }
 
+// Verifies that when the cache is completely full and cannot allocate new
+// entries, CachedMetadataInput gracefully falls back to loading metadata
+// from storage instead of throwing.
+TEST_P(CachedMetadataInputTest, loadFallsBackWhenCacheFull) {
+  const std::string sectionData(4096, 'X');
+  std::vector<SectionSpec> specs = {
+      {sectionData, nimble::CompressionType::Uncompressed}};
+
+  std::vector<nimble::MetadataSection> sections;
+  std::vector<std::string> fileDataParts;
+  buildSections(specs, pool_.get(), sections, fileDataParts);
+  const auto fileContent = buildFileContent(sections, fileDataParts);
+  auto readFile = std::make_shared<velox::InMemoryReadFile>(fileContent);
+
+  // Exhaust the allocator so the next cache allocation fails.
+  // Leave 1MB free for the fallback read buffer allocation.
+  std::vector<velox::memory::Allocation> allocations;
+  const auto totalPages = velox::memory::AllocationTraits::numPages(kCacheSize);
+  const auto reservePages = velox::memory::AllocationTraits::numPages(1 << 20);
+  uint64_t allocatedPages = 0;
+  while (allocatedPages + reservePages < totalPages) {
+    const auto pagesToAllocate =
+        std::min<uint64_t>(256, totalPages - reservePages - allocatedPages);
+    if (pagesToAllocate == 0) {
+      break;
+    }
+    velox::memory::Allocation allocation;
+    if (!allocator_->allocateNonContiguous(pagesToAllocate, allocation)) {
+      break;
+    }
+    allocatedPages += allocation.numPages();
+    allocations.push_back(std::move(allocation));
+  }
+  ASSERT_GT(allocatedPages, 0);
+
+  auto input = createCachedInput(readFile.get());
+  auto results = input->load(sections);
+
+  ASSERT_EQ(results.size(), 1);
+  ASSERT_NE(results[0], nullptr);
+  EXPECT_EQ(results[0]->content(), sectionData);
+
+  for (auto& allocation : allocations) {
+    allocator_->freeNonContiguous(allocation);
+  }
+}
+
 INSTANTIATE_TEST_SUITE_P(
     CachedMetadataInputTests,
     CachedMetadataInputTest,


### PR DESCRIPTION
Summary:
CONTEXT: When `cache-metadata` is enabled and the `AsyncDataCache` is fully occupied, `CachedMetadataInput::acquireCachePin` calls `findOrCreate` which throws `VeloxRuntimeError` from `AsyncDataCacheEntry::initialize` because it cannot allocate contiguous memory. This kills the entire query with `GENERIC_INTERNAL_ERROR` instead of falling back to reading metadata from storage.

WHAT: Add graceful degradation when the metadata cache is full:
- Catch `VeloxRuntimeError` in `acquireCachePin` and return an empty `CachePin` instead of propagating the exception
- Check for empty pin in `loadFromCache` and skip caching for that section, falling back to loading from storage directly
- Fix misleading "Failed to allocate 0B" error message in `AsyncDataCache` where `release()` zeroed `size_` before the error format string read it
- Add unit test that exhausts the allocator and verifies `load()` succeeds via storage fallback

Differential Revision: D108961848


