### PR TITLE
fix: Revert D108126830 presto-facebook-hive compilation failure (#889)

### DIFF
--- a/dwio/nimble/velox/NimbleConfig.h
+++ b/dwio/nimble/velox/NimbleConfig.h
@@ -91,23 +91,6 @@ class Config : public velox::config::ConfigBase {
   static constexpr const char* kNimbleWriteTargetRawStripeSize =
       "nimble_write_target_raw_stripe_size";
 
-  static constexpr const char* kNimbleChunkingEnabled =
-      "nimble_chunking_enabled";
-  static constexpr const char* kNimbleChunkingMemoryHighThreshold =
-      "nimble_chunking_memory_high_threshold";
-  static constexpr const char* kNimbleChunkingMemoryLowThreshold =
-      "nimble_chunking_memory_low_threshold";
-  static constexpr const char* kNimbleChunkingTargetStripeStorageSize =
-      "nimble_chunking_target_stripe_storage_size";
-  static constexpr const char* kNimbleChunkingEstimatedCompressionFactor =
-      "nimble_chunking_estimated_compression_factor";
-  static constexpr const char* kNimbleChunkingMinChunkSize =
-      "nimble_chunking_min_chunk_size";
-  static constexpr const char* kNimbleChunkingMaxChunkSize =
-      "nimble_chunking_max_chunk_size";
-  static constexpr const char* kNimbleChunkingWideSchemaMaxChunkSize =
-      "nimble_chunking_wide_schema_max_chunk_size";
-
   static std::shared_ptr<Config> fromMap(
       const std::map<std::string, std::string>& map) {
     auto config = std::make_shared<Config>();


### PR DESCRIPTION
Summary:

Revert "feat(presto): Add session properties for Nimble chunking configuration" (D108126830, 4b0ec7d5a4b4).

This diff broke the presto-facebook-hive Maven build in Sandcastle with 7 compilation errors in HiveSessionProperties.java:
  error: cannot find symbol
    symbol:   method longProperty(String,String,<null>,boolean)
    location: class HiveSessionProperties
  (same for doubleProperty)

Root cause: HiveSessionProperties.java added calls to longProperty() and doubleProperty() without adding the corresponding static imports:
  import static com.facebook.presto.spi.session.PropertyMetadata.longProperty;
  import static com.facebook.presto.spi.session.PropertyMetadata.doubleProperty;

HiveTableProperties.java in the same diff correctly uses qualified PropertyMetadata.longProperty(), which is why that file compiles.

Reverting to unblock the build. Original author has been notified in D108126830.

bypass-github-export-checks

Reviewed By: shrinidhijoshi

Differential Revision: D109155785


