### PR TITLE
feat: Support Row/FlatMap null barriers in serializer (#890)

### DIFF
--- a/dwio/nimble/encodings/NullableEncoding.h
+++ b/dwio/nimble/encodings/NullableEncoding.h
@@ -68,8 +68,8 @@ class NullableEncoding final
   uint32_t materializeNullable(
       uint32_t rowCount,
       void* buffer,
-      std::function<void*()> nulls,
-      const velox::bits::Bitmap* scatterBitmap = nullptr,
+      std::function<void*()> getOutputNulls,
+      const velox::bits::Bitmap* scatterOutputBitmap = nullptr,
       uint32_t offset = 0) final;
 
   template <typename DecoderVisitor>
@@ -221,8 +221,8 @@ template <typename T>
 uint32_t NullableEncoding<T>::materializeNullable(
     uint32_t rowCount,
     void* buffer,
-    std::function<void*()> nulls,
-    const velox::bits::Bitmap* scatterBitmap,
+    std::function<void*()> getOutputNulls,
+    const velox::bits::Bitmap* scatterOutputBitmap,
     uint32_t offset) {
   nullBuffer_.resize(rowCount);
   nulls_->materialize(rowCount, nullBuffer_.data());
@@ -235,9 +235,13 @@ uint32_t NullableEncoding<T>::materializeNullable(
   nonNullValues_->materialize(nonNullCount, buffer);
 
   const auto scatterSize =
-      scatterBitmap ? scatterBitmap->size() - offset : rowCount;
+      scatterOutputBitmap ? scatterOutputBitmap->size() - offset : rowCount;
+  NIMBLE_CHECK_GE(
+      scatterSize,
+      rowCount,
+      "Scattered output must have at least rowCount positions");
   if (nonNullCount != scatterSize) {
-    void* nullBitmap = nulls();
+    void* nullBitmap = getOutputNulls();
     velox::bits::BitmapBuilder nullBits{nullBitmap, offset + scatterSize};
     nullBits.clear(offset, offset + scatterSize);
 
@@ -250,9 +254,9 @@ uint32_t NullableEncoding<T>::materializeNullable(
     if (scatterSize != rowCount) {
       // In scattered reads, spread the items into the right positions in
       // |buffer| and |nullBitmap| based on the bits set to 1 in
-      // |scatterBitmap|.
+      // |scatterOutputBitmap|.
       while (output != lastNonNull) {
-        if (scatterBitmap->test(pos)) {
+        if (scatterOutputBitmap->test(pos)) {
           if (*nonNullIt--) {
             nullBits.set(pos);
             *output = *lastNonNull;

--- a/dwio/nimble/encodings/SentinelEncoding.h
+++ b/dwio/nimble/encodings/SentinelEncoding.h
@@ -61,8 +61,8 @@ class SentinelEncoding final
   uint32_t materializeNullable(
       uint32_t rowCount,
       void* buffer,
-      std::function<void*()> nulls,
-      const velox::bits::Bitmap* scatterBitmap = nullptr,
+      std::function<void*()> getOutputNulls,
+      const velox::bits::Bitmap* scatterOutputBitmap = nullptr,
       uint32_t offset = 0) final;
 
   // // Our signature here for estimate size and serialize are a little
@@ -155,8 +155,8 @@ template <typename T>
 uint32_t SentinelEncoding<T>::materializeNullable(
     uint32_t rowCount,
     void* buffer,
-    std::function<void*()> nulls,
-    const velox::bits::Bitmap* scatterBitmap,
+    std::function<void*()> getOutputNulls,
+    const velox::bits::Bitmap* scatterOutputBitmap,
     uint32_t offset) {
   if (offset > 0) {
     buffer = static_cast<physicalType*>(buffer) + offset;
@@ -165,8 +165,9 @@ uint32_t SentinelEncoding<T>::materializeNullable(
 
   // Member variables in tight loops are bad.
   const physicalType localSentinel = sentinelValue_;
-  auto scatterCount = scatterBitmap ? scatterBitmap->size() - offset : rowCount;
-  void* nullBitmap = nulls();
+  auto scatterCount =
+      scatterOutputBitmap ? scatterOutputBitmap->size() - offset : rowCount;
+  void* nullBitmap = getOutputNulls();
   velox::bits::BitmapBuilder nullBits{nullBitmap, offset + scatterCount};
   nullBits.clear(offset, offset + scatterCount);
 
@@ -176,7 +177,7 @@ uint32_t SentinelEncoding<T>::materializeNullable(
     physicalType* castBuffer = static_cast<physicalType*>(buffer);
 
     for (int64_t i = offset + scatterCount - 1; i >= offset; --i) {
-      if (scatterBitmap->test(i)) {
+      if (scatterOutputBitmap->test(i)) {
         --lastValue;
         if (*lastValue != localSentinel) {
           castBuffer[i] = *lastValue;

--- a/dwio/nimble/encodings/common/Encoding.h
+++ b/dwio/nimble/encodings/common/Encoding.h
@@ -209,26 +209,28 @@ class Encoding {
   /// ith row was null or not. 0 means null, 1 means not null. Null rows are
   /// left untouched instead of being filled with default values.
   ///
-  /// If |scatterBitmap| is provided, |rowCount| still indicates how many items
-  /// to be read from the encoding. However, instead of placing them
+  /// If |scatterOutputBitmap| is provided, |rowCount| still indicates how many
+  /// items to be read from the encoding. However, instead of placing them
   /// sequentially in the output |buffer|, the items are scattered. This means
   /// that item will be place into the slot where the corresponding positional
-  /// bit is set to 1 in |scatterBitmap|, (note that the value being read may be
-  /// null). For every positional scatter bit set to 0, it will fill a null in
-  /// the poisition in the output |buffer|. |rowCount| should match the number
-  /// of bits set to 1 in |scatterBitmap|. For scattered reads, |buffer| and
-  /// |nulls| should have enough space to accommodate |scatterBitmap.size()|
-  /// items. When |offset| is specified, use the |scatterBitmap| starting from
-  /// |offset| and scatter to |buffer| and |nulls| starting from |offset|.
+  /// bit is set to 1 in |scatterOutputBitmap|, (note that the value being read
+  /// may be null). For every positional scatter bit set to 0, it will fill a
+  /// null in the poisition in the output |buffer|. |rowCount| should match the
+  /// number of bits set to 1 in |scatterOutputBitmap|. For scattered reads,
+  /// |buffer| and
+  /// |getOutputNulls()| should have enough space to accommodate
+  /// |scatterOutputBitmap.size()| items. When |offset| is specified, use the
+  /// |scatterOutputBitmap| starting from |offset| and scatter to |buffer| and
+  /// |getOutputNulls()| starting from |offset|.
   ///
   /// Returns number of items that are not null. In the case when all values are
-  /// non null, |nulls| will not be filled with all 1s. It's expected that
-  /// caller explicitly checks for that condition.
+  /// non null, |getOutputNulls()| will not be filled with all 1s. It's
+  /// expected that caller explicitly checks for that condition.
   virtual uint32_t materializeNullable(
       uint32_t rowCount,
       void* buffer,
-      std::function<void*()> nulls,
-      const velox::bits::Bitmap* scatterBitmap = nullptr,
+      std::function<void*()> getOutputNulls,
+      const velox::bits::Bitmap* scatterOutputBitmap = nullptr,
       uint32_t offset = 0) = 0;
 
   /// Read bool values to output buffer as bits.
@@ -376,28 +378,30 @@ class TypedEncoding : public Encoding {
       const Options& options = {})
       : Encoding{pool, data, options} {}
 
-  // Similar to materialize(), but scatters values to output buffer according to
-  // scatterBitmap. When scatterBitmap is nullptr or all 1's, the output
-  // nullBitmap will not be set. It's expected that caller explicitly checks
-  // against the return value and handle such all 1's cases properly.
+  /// Similar to materialize(), but scatters values to output buffer according
+  /// to scatterOutputBitmap. When scatterOutputBitmap is nullptr or all 1's,
+  /// the output nullBitmap will not be set. It's expected that caller
+  /// explicitly checks against the return value and handle such all 1's cases
+  /// properly.
   uint32_t materializeNullable(
       uint32_t rowCount,
       void* buffer,
-      std::function<void*()> nulls,
-      const velox::bits::Bitmap* scatterBitmap,
+      std::function<void*()> getOutputNulls,
+      const velox::bits::Bitmap* scatterOutputBitmap,
       uint32_t offset) override {
     // 1. Read X items from the encoding.
     // 2. Spread the items read in #1 into positions in |buffer| where
-    // |scatterBitmap| has a matching positional bit set to 1.
+    // |scatterOutputBitmap| has a matching positional bit set to 1.
     if (offset > 0) {
       buffer = static_cast<physicalType*>(buffer) + offset;
     }
 
     materialize(rowCount, buffer);
 
-    // TODO: check rowCount matches the number of set bits in scatterBitmap.
+    // TODO: check rowCount matches the number of set bits in
+    // scatterOutputBitmap.
     auto scatterCount =
-        scatterBitmap ? scatterBitmap->size() - offset : rowCount;
+        scatterOutputBitmap ? scatterOutputBitmap->size() - offset : rowCount;
     if (scatterCount == rowCount) {
       // No need to scatter. Avoid setting nullBitmap since caller is expected
       // to explicitly handle such non-null cases.
@@ -406,10 +410,10 @@ class TypedEncoding : public Encoding {
 
     NIMBLE_CHECK_LT(rowCount, scatterCount, "Unexpected count");
 
-    void* nullBitmap = nulls();
+    void* nullBitmap = getOutputNulls();
 
     velox::bits::BitmapBuilder nullBits{nullBitmap, offset + scatterCount};
-    nullBits.copy(*scatterBitmap, offset, offset + scatterCount);
+    nullBits.copy(*scatterOutputBitmap, offset, offset + scatterCount);
 
     // Scatter backward
     uint32_t pos = offset + scatterCount - 1;
@@ -418,7 +422,7 @@ class TypedEncoding : public Encoding {
     const physicalType* source =
         static_cast<physicalType*>(buffer) + rowCount - 1;
     while (output != source) {
-      if (scatterBitmap->test(pos)) {
+      if (scatterOutputBitmap->test(pos)) {
         *output = *source;
         --source;
       }

--- a/dwio/nimble/encodings/legacy/NullableEncoding.h
+++ b/dwio/nimble/encodings/legacy/NullableEncoding.h
@@ -60,8 +60,8 @@ class NullableEncoding final
   uint32_t materializeNullable(
       uint32_t rowCount,
       void* buffer,
-      std::function<void*()> nulls,
-      const velox::bits::Bitmap* scatterBitmap = nullptr,
+      std::function<void*()> getOutputNulls,
+      const velox::bits::Bitmap* scatterOutputBitmap = nullptr,
       uint32_t offset = 0) final;
 
   template <typename DecoderVisitor>
@@ -182,8 +182,8 @@ template <typename T>
 uint32_t NullableEncoding<T>::materializeNullable(
     uint32_t rowCount,
     void* buffer,
-    std::function<void*()> nulls,
-    const velox::bits::Bitmap* scatterBitmap,
+    std::function<void*()> getOutputNulls,
+    const velox::bits::Bitmap* scatterOutputBitmap,
     uint32_t offset) {
   nullBuffer_.resize(rowCount);
   nulls_->materialize(rowCount, nullBuffer_.data());
@@ -196,9 +196,9 @@ uint32_t NullableEncoding<T>::materializeNullable(
   nonNullValues_->materialize(nonNullCount, buffer);
 
   const auto scatterSize =
-      scatterBitmap ? scatterBitmap->size() - offset : rowCount;
+      scatterOutputBitmap ? scatterOutputBitmap->size() - offset : rowCount;
   if (nonNullCount != scatterSize) {
-    void* nullBitmap = nulls();
+    void* nullBitmap = getOutputNulls();
     velox::bits::BitmapBuilder nullBits{nullBitmap, offset + scatterSize};
     nullBits.clear(offset, offset + scatterSize);
 
@@ -211,9 +211,9 @@ uint32_t NullableEncoding<T>::materializeNullable(
     if (scatterSize != rowCount) {
       // In scattered reads, spread the items into the right positions in
       // |buffer| and |nullBitmap| based on the bits set to 1 in
-      // |scatterBitmap|.
+      // |scatterOutputBitmap|.
       while (output != lastNonNull) {
-        if (scatterBitmap->test(pos)) {
+        if (scatterOutputBitmap->test(pos)) {
           if (*nonNullIt--) {
             nullBits.set(pos);
             *output = *lastNonNull;

--- a/dwio/nimble/encodings/legacy/SentinelEncoding.h
+++ b/dwio/nimble/encodings/legacy/SentinelEncoding.h
@@ -60,8 +60,8 @@ class SentinelEncoding final
   uint32_t materializeNullable(
       uint32_t rowCount,
       void* buffer,
-      std::function<void*()> nulls,
-      const velox::bits::Bitmap* scatterBitmap = nullptr,
+      std::function<void*()> getOutputNulls,
+      const velox::bits::Bitmap* scatterOutputBitmap = nullptr,
       uint32_t offset = 0) final;
 
   // // Our signature here for estimate size and serialize are a little
@@ -155,8 +155,8 @@ template <typename T>
 uint32_t SentinelEncoding<T>::materializeNullable(
     uint32_t rowCount,
     void* buffer,
-    std::function<void*()> nulls,
-    const velox::bits::Bitmap* scatterBitmap,
+    std::function<void*()> getOutputNulls,
+    const velox::bits::Bitmap* scatterOutputBitmap,
     uint32_t offset) {
   if (offset > 0) {
     buffer = static_cast<physicalType*>(buffer) + offset;
@@ -165,8 +165,9 @@ uint32_t SentinelEncoding<T>::materializeNullable(
 
   // Member variables in tight loops are bad.
   const physicalType localSentinel = sentinelValue_;
-  auto scatterCount = scatterBitmap ? scatterBitmap->size() - offset : rowCount;
-  void* nullBitmap = nulls();
+  auto scatterCount =
+      scatterOutputBitmap ? scatterOutputBitmap->size() - offset : rowCount;
+  void* nullBitmap = getOutputNulls();
   velox::bits::BitmapBuilder nullBits{nullBitmap, offset + scatterCount};
   nullBits.clear(offset, offset + scatterCount);
 
@@ -176,7 +177,7 @@ uint32_t SentinelEncoding<T>::materializeNullable(
     physicalType* castBuffer = static_cast<physicalType*>(buffer);
 
     for (int64_t i = offset + scatterCount - 1; i >= offset; --i) {
-      if (scatterBitmap->test(i)) {
+      if (scatterOutputBitmap->test(i)) {
         --lastValue;
         if (*lastValue != localSentinel) {
           castBuffer[i] = *lastValue;

--- a/dwio/nimble/encodings/tests/EncodingTest.cpp
+++ b/dwio/nimble/encodings/tests/EncodingTest.cpp
@@ -134,7 +134,7 @@ class TestEncoding : public nimble::Encoding {
       uint32_t /*rowCount*/,
       void* /*buffer*/,
       std::function<void*()> /*nulls*/,
-      const velox::bits::Bitmap* /*scatterBitmap*/,
+      const velox::bits::Bitmap* /*scatterOutputBitmap*/,
       uint32_t /*offset*/) override {
     return 0;
   }

--- a/dwio/nimble/serializer/Deserializer.cpp
+++ b/dwio/nimble/serializer/Deserializer.cpp
@@ -19,8 +19,13 @@
 #include "dwio/nimble/velox/Decoder.h"
 #include "dwio/nimble/velox/SchemaReader.h"
 #include "dwio/nimble/velox/SchemaUtils.h"
+#include "folly/Likely.h"
 #include "velox/buffer/Buffer.h"
 #include "velox/dwio/common/TypeWithId.h"
+
+#include <algorithm>
+#include <limits>
+#include <optional>
 
 namespace facebook::nimble {
 
@@ -81,77 +86,74 @@ inline ScalarKind getScalarKindForType(const Type& type) {
   NIMBLE_UNSUPPORTED("Unsupported type: {}", toString(type.kind()));
 }
 
-// Initializes the nulls buffer on the Velox vector for scattered reads.
-// When count=0, all rows are absent so all bits are cleared (all null).
-// When count < bitmap size, copies the scatter bitmap as the nulls buffer.
-inline void ensureNulls(
-    const std::function<void*()>& nulls,
-    const velox::bits::Bitmap* scatterBitmap,
-    uint32_t count) {
-  if (!nulls || scatterBitmap == nullptr) {
+// Empty scattered reads still need to mark every output row as absent.
+inline void markEmptyScatteredOutputNulls(
+    const std::function<void*()>& getOutputNulls,
+    const velox::bits::Bitmap* scatterOutputBitmap) {
+  if (scatterOutputBitmap == nullptr) {
     return;
   }
-  auto* nullsBuffer = static_cast<uint64_t*>(nulls());
-  if (count == 0) {
-    velox::bits::fillBits(nullsBuffer, 0, scatterBitmap->size(), false);
-  } else if (count < scatterBitmap->size()) {
-    velox::bits::copyBits(
-        static_cast<const uint64_t*>(scatterBitmap->bits()),
-        0,
-        nullsBuffer,
-        0,
-        scatterBitmap->size());
-  }
+  NIMBLE_CHECK_EQ(
+      velox::bits::countBits(
+          static_cast<const uint64_t*>(scatterOutputBitmap->bits()),
+          0,
+          scatterOutputBitmap->size()),
+      0,
+      "Empty scattered reads require an empty scatterOutputBitmap");
+  NIMBLE_CHECK_NOT_NULL(
+      getOutputNulls, "Scattered reads require output nulls callback");
+  velox::bits::fillBits(
+      static_cast<uint64_t*>(getOutputNulls()),
+      0,
+      scatterOutputBitmap->size(),
+      velox::bits::kNull);
 }
 
-// Decoder implementation for deserializing stream data from multiple batches.
-class DeserializerImpl : public Decoder {
+// Decoder for one logical stream assembled from per-batch segments.
+class SegmentedStreamDecoder : public Decoder {
  public:
-  // inMapStream: true for FlatMap inMap streams (fills with 'false' when
-  // missing), false for nulls streams (fills with 'true' when missing).
-  // FlatMap is only supported at depth 1 (top-level columns), so gap detection
-  // is enabled whenever the type is FlatMap.
-  DeserializerImpl(
+  SegmentedStreamDecoder(
       const Type* type,
-      bool inMapStream,
+      bool isInMapStream,
       size_t bufferPoolCapacity,
       velox::memory::MemoryPool* pool)
       : type_{type},
         pool_{pool},
-        inMapStream_{inMapStream},
+        isInMapStream_{isInMapStream},
         scalarKind_{getScalarKindForType(*type)},
         typeStorageWidth_{getTypeStorageWidth(*type)},
         bufferPool_{
             bufferPoolCapacity > 0
                 ? std::make_unique<velox::BufferPool>(bufferPoolCapacity)
-                : nullptr} {}
+                : nullptr} {
+    NIMBLE_CHECK(
+        !isInMapStream_ || typeStorageWidth_ == sizeof(bool),
+        "FlatMap in-map stream should be bool");
+  }
 
   uint32_t next(
       uint32_t count,
       void* output,
       std::vector<velox::BufferPtr>& stringBuffers,
-      std::function<void*()> nulls = nullptr,
-      const velox::bits::Bitmap* scatterBitmap = nullptr) override {
+      std::function<void*()> getOutputNulls = nullptr,
+      const velox::bits::Bitmap* scatterOutputBitmap = nullptr) override {
+    NIMBLE_CHECK(
+        scatterOutputBitmap == nullptr || !isInMapStream(),
+        "scatterOutputBitmap not used for FlatMap in-map streams");
+
     if (count == 0) {
-      ensureNulls(nulls, scatterBitmap, count);
+      markEmptyScatteredOutputNulls(getOutputNulls, scatterOutputBitmap);
       return 0;
     }
 
-    // Three read paths based on stream type:
-    // readFlatMap: For FlatMap nulls/inMap with gap detection
-    // scatteredRead: For scatterBitmap (StructFlatMapFieldReader values)
-    // contiguousRead: For nested types - simple contiguous read
-    if (type_->isFlatMap()) {
-      NIMBLE_CHECK_NULL(
-          scatterBitmap, "scatterBitmap not used for FlatMap streams");
-      return readFlatMap(count, output, typeStorageWidth_, stringBuffers);
-    }
-    if (scatterBitmap != nullptr) {
-      ensureNulls(nulls, scatterBitmap, count);
+    if (scatterOutputBitmap != nullptr) {
       return scatteredRead(
-          count, output, typeStorageWidth_, scatterBitmap, stringBuffers);
+          count, output, getOutputNulls, scatterOutputBitmap, stringBuffers);
     }
-    return contiguousRead(count, output, typeStorageWidth_, stringBuffers);
+    if (isInMapStream()) {
+      return inMapRead(count, output, stringBuffers);
+    }
+    return denseRead(count, output, getOutputNulls, stringBuffers);
   }
 
   void skip(uint32_t /* count */) override {
@@ -159,50 +161,46 @@ class DeserializerImpl : public Decoder {
   }
 
   void reset() override {
-    NIMBLE_UNREACHABLE("unexpected call");
+    clear();
+  }
+
+  void clear() {
+    streamSegments_.clear();
+    presentInMapSegments_.clear();
+    streamData_.reset();
+    streamSegmentIndex_ = 0;
+    presentSegmentIndex_ = 0;
   }
 
   const Encoding* encoding() const override {
     NIMBLE_UNREACHABLE("unexpected call");
   }
 
-  static inline DeserializerImpl* toDecoderImpl(Decoder* d) {
-    return static_cast<DeserializerImpl*>(d);
+  static inline SegmentedStreamDecoder* as(Decoder* d) {
+    return static_cast<SegmentedStreamDecoder*>(d);
   }
 
-  // Clear all state (called at the start of deserialization).
-  void clear() {
-    batchSegments_.clear();
-    streamData_.reset();
-    presentInMapSegments_.clear();
-    topLevelRows_ = 0;
-    currentFlatMapRow_ = 0;
-    currentSegment_ = 0;
-    currentInMapSegment_ = 0;
-  }
-
-  // Add data starting at the given row offset. Stores the raw data without
-  // creating encoding objects. Encodings are created lazily when the segment
-  // is first read, ensuring only one encoding tree exists at a time. This
-  // avoids the memory locality and allocation overhead of creating hundreds
-  // of encoding trees simultaneously in batch decode.
+  // Stores raw data without creating encoding objects. Encodings are created
+  // lazily when the segment is first read, ensuring only one encoding tree
+  // exists at a time. This avoids the memory locality and allocation overhead
+  // of creating hundreds of encoding trees simultaneously in batch decode.
+  // Appends a physical stream segment. Only FlatMap in-map streams use
+  // `startRow` to reconstruct gaps for batches that omitted the stream.
+  // Other streams concatenate by payload order.
   void addBatch(
-      uint32_t rowOffset,
+      uint32_t startRow,
       std::string_view data,
       SerializationVersion version) {
-    if (data.empty()) {
-      return;
-    }
-    batchSegments_.emplace_back(BatchSegment{rowOffset, data, version});
+    NIMBLE_CHECK(!data.empty(), "Physical stream segment must be non-empty");
+    streamSegments_.emplace_back(
+        StreamSegment{.startRow = startRow, .data = data, .version = version});
   }
 
-  // Record a segment where this key is present in every row (in-map stream
-  // skipped by the serializer). Used by fillMissingFlatMapRows to fill gaps
-  // with true (present) instead of false (absent).
-  void addPresentInMapSegment(uint32_t startRow, uint32_t rowCount) {
-    NIMBLE_CHECK(
-        type_->isFlatMap() && inMapStream_,
-        "addPresentInMapSegment requires FlatMap in-map stream");
+  // Records a batch range where this FlatMap key is present in every row.
+  void addPresentInMapBatch(uint32_t startRow, uint32_t rowCount) {
+    NIMBLE_CHECK(isInMapStream(), "Expected FlatMap in-map stream");
+    NIMBLE_CHECK_GT(
+        rowCount, 0, "All-present in-map segment must be non-empty");
     const uint32_t endRow = startRow + rowCount;
     // Merge with the previous segment if contiguous.
     if (!presentInMapSegments_.empty() &&
@@ -213,396 +211,422 @@ class DeserializerImpl : public Decoder {
     }
   }
 
-  void setTopLevelRows(uint32_t rows) {
-    topLevelRows_ = rows;
+  // Records an all-present FlatMap key range for a null-barrier batch, where
+  // the read request determines the effective end row.
+  void addPresentInMapBatch() {
+    NIMBLE_CHECK(isInMapStream(), "Expected FlatMap in-map stream");
+    NIMBLE_CHECK(
+        streamSegments_.empty(),
+        "All-present in-map segment must not be mixed with physical batches");
+    presentInMapSegments_.emplace_back(
+        InMapSegment{.startRow = 0, .endRow = kPresentInMapEndRow});
   }
 
  private:
-  // Lazily creates StreamData for the given segment index.
-  // Destroys the previous StreamData so the allocator reuses the same
-  // cache-hot memory (matching non-batch mode's sequential pattern).
-  // Ensures streamData_ is initialized for the current segment. Creates a new
-  // StreamData lazily on first access or after advanceSegment() resets it.
-  // String buffers from encoding are pushed directly into the caller's
-  // stringBuffers vector, so no explicit release is needed.
+  // Sentinel end row for all-present FlatMap in-map ranges whose actual row
+  // count comes from the current read request. Null-barrier batches use this
+  // because FlatMap child reads are scoped by the parent Row/FlatMap null
+  // stream, not the physical batch row count.
+  static constexpr uint32_t kPresentInMapEndRow =
+      std::numeric_limits<uint32_t>::max();
+
+  // Physical stream data for one batch.
+  struct StreamSegment {
+    // Top-level row where this batch starts. Only relevant for FlatMap in-map
+    // streams to detect gaps when decoding across multiple chunks.
+    uint32_t startRow;
+    std::string_view data;
+    SerializationVersion version;
+  };
+
+  // Row range where a FlatMap key is present in every requested row and the
+  // in-map stream was omitted from the physical payload.
+  struct InMapSegment {
+    uint32_t startRow;
+    uint32_t endRow;
+  };
+
+  // True for the FlatMap child-presence stream, not for the FlatMap
+  // value/null stream itself.
+  bool isInMapStream() const {
+    return isInMapStream_;
+  }
+
+  // Lazily creates StreamData for the current physical segment. String buffers
+  // from encoding are pushed directly into the caller's stringBuffers vector,
+  // so no explicit release is needed.
   serde::StreamData& ensureStreamData(
       std::vector<velox::BufferPtr>& stringBuffers) {
     if (streamData_.has_value()) {
       return *streamData_;
     }
 
-    NIMBLE_CHECK_LT(currentSegment_, batchSegments_.size());
-    const auto& segment = batchSegments_[currentSegment_];
-    const serde::StreamData::Options options{
-        .version = segment.version,
-        .bufferPool = bufferPool_.get(),
-        .decompressionBuffer = &decompressionBuffer_,
-    };
+    NIMBLE_CHECK_LT(streamSegmentIndex_, streamSegments_.size());
+    const auto& segment = streamSegments_[streamSegmentIndex_];
     streamData_.emplace(
-        scalarKind_, segment.data, stringBuffers, pool_, options);
+        scalarKind_,
+        segment.data,
+        stringBuffers,
+        pool_,
+        serde::StreamData::Options{
+            .version = segment.version,
+            .bufferPool = bufferPool_.get(),
+            .decompressionBuffer = &decompressionBuffer_});
     return *streamData_;
   }
 
-  // Advances to the next segment. Destroys current StreamData so the next
-  // ensureStreamData() creates a fresh one for the new segment.
+  // Advances to the next segment. ensureStreamData() will create StreamData for
+  // the new segment before decoding it.
   void advanceSegment() {
     streamData_.reset();
-    ++currentSegment_;
+    ++streamSegmentIndex_;
   }
 
-  uint32_t readFromBatchSegment(
+  uint32_t fillInMapGap(uint32_t rowOffset, uint32_t rowCount, void* output) {
+    NIMBLE_CHECK(isInMapStream(), "Expected FlatMap in-map stream");
+    // rowOffset and rowCount are in the same concatenated batch-run row domain
+    // as StreamSegment::startRow.
+    const auto requestEndRow = rowOffset + rowCount;
+    const auto gapEndRow = streamSegmentIndex_ < streamSegments_.size()
+        ? std::min(requestEndRow, streamSegments_[streamSegmentIndex_].startRow)
+        : requestEndRow;
+    NIMBLE_CHECK_GT(
+        gapEndRow,
+        rowOffset,
+        "FlatMap in-map gap fill requires a non-empty output range");
+    const auto numGapRows = gapEndRow - rowOffset;
+    auto* const outputBools =
+        static_cast<char*>(output) + rowOffset * typeStorageWidth_;
+    constexpr char kInMapAbsent = 0;
+    constexpr char kInMapPresent = 1;
+    std::memset(outputBools, kInMapAbsent, numGapRows * typeStorageWidth_);
+    while (presentSegmentIndex_ < presentInMapSegments_.size()) {
+      const auto& segment = presentInMapSegments_[presentSegmentIndex_];
+      if (segment.startRow >= gapEndRow) {
+        break;
+      }
+      NIMBLE_CHECK_GE(
+          segment.startRow,
+          rowOffset,
+          "Present in-map segment starts before absent row range");
+      const auto presentEndRow = std::min(segment.endRow, gapEndRow);
+      std::memset(
+          outputBools + (segment.startRow - rowOffset) * typeStorageWidth_,
+          kInMapPresent,
+          (presentEndRow - segment.startRow) * typeStorageWidth_);
+      if (segment.endRow > gapEndRow) {
+        // Synthetic all-present ranges can span past the current read request;
+        // physical present ranges are expected to end within this gap.
+        NIMBLE_CHECK_EQ(
+            segment.endRow,
+            kPresentInMapEndRow,
+            "Only all-present in-map segment can extend beyond gap range");
+        break;
+      }
+      ++presentSegmentIndex_;
+    }
+    return numGapRows;
+  }
+
+  serde::StreamData::DecodeResult readLegacyStreamSegment(
+      serde::StreamData& streamData,
+      void* output,
+      uint32_t offset,
+      uint32_t count) {
+    const auto width = typeStorageWidth_;
+    if (width > 0) {
+      return streamData.decodeLegacy(output, offset, count, width);
+    }
+
+    auto* dest = static_cast<std::string_view*>(output) + offset;
+    return streamData.decodeStrings(count, dest);
+  }
+
+  serde::StreamData::DecodeResult readSegment(
       void* output,
       uint32_t offset,
       uint32_t count,
-      uint32_t width,
+      const std::function<void*()>& getOutputNulls,
+      const velox::bits::Bitmap* scatterOutputBitmap,
       std::vector<velox::BufferPtr>& stringBuffers) {
+    NIMBLE_CHECK(
+        scatterOutputBitmap == nullptr || !isInMapStream(),
+        "scatterOutputBitmap not used for FlatMap in-map streams");
+
+    NIMBLE_CHECK_LT(streamSegmentIndex_, streamSegments_.size());
     auto& streamData = ensureStreamData(stringBuffers);
-
-    // Nimble encoding path: decode dispatches by type width.
-    // Returns actual count decoded (may be less than requested if encoding
-    // has fewer remaining rows).
-    if (streamData.hasEncoding()) {
-      return streamData.decode(output, offset, count, width);
+    if (!streamData.hasEncoding()) {
+      NIMBLE_CHECK_NULL(
+          scatterOutputBitmap,
+          "scatterOutputBitmap is only used for encoded streams");
+      return readLegacyStreamSegment(streamData, output, offset, count);
     }
 
-    // Legacy path.
-    if (width > 0) {
-      auto* dest = static_cast<char*>(output) + offset * width;
-      const auto copied = streamData.copyTo(dest, count * width);
-      return copied / width;
-    } else {
-      // String type.
-      auto* dest = static_cast<std::string_view*>(output) + offset;
-      return streamData.decodeStrings(count, dest);
-    }
+    const auto width = typeStorageWidth_;
+    return streamData.decode(
+        output, offset, count, width, getOutputNulls, scatterOutputBitmap);
   }
 
-  // Simple contiguous read for nested types. Reads `count` values from
-  // segments directly to output without gap detection or scattering.
-  uint32_t contiguousRead(
+  // Reads `count` non-in-map values into dense output row positions.
+  uint32_t denseRead(
       uint32_t count,
       void* output,
-      uint32_t width,
+      const std::function<void*()>& getOutputNulls,
       std::vector<velox::BufferPtr>& stringBuffers) {
-    NIMBLE_CHECK(!type_->isFlatMap(), "contiguousRead not used for FlatMap");
-
-    // Handle empty batchSegments_ for Row nulls streams. The serializer omits
-    // Row nulls when all values are non-null. Fill with true (all non-null).
-    if (batchSegments_.empty()) {
+    const auto width = typeStorageWidth_;
+    if (FOLLY_UNLIKELY(streamSegments_.empty())) {
       NIMBLE_CHECK(
-          type_->isRow(),
-          "batchSegments_ is empty for unexpected type={}",
-          toString(type_->kind()));
-      fillMissingRows(output, /*offset=*/0, count, width);
+          type_->isRow() || type_->isFlatMap(),
+          "streamSegments_ is empty for unexpected stream type={}",
+          type_->kind());
+      NIMBLE_CHECK_EQ(
+          width, sizeof(bool), "Row/FlatMap null stream should be bool");
+      // All-non-null Row/FlatMap null streams are omitted on the wire and
+      // reconstructed as all-true here (no null rows).
+      std::fill_n(static_cast<bool*>(output), count, true);
       return count;
     }
 
-    uint32_t valuesRead{0};
-    while (valuesRead < count && currentSegment_ < batchSegments_.size()) {
-      const uint32_t toRead = count - valuesRead;
-      const uint32_t read = readFromBatchSegment(
-          output, valuesRead, toRead, width, stringBuffers);
-      if (read == 0) {
-        advanceSegment();
-      } else {
-        valuesRead += read;
-        if (read < toRead) {
-          advanceSegment();
+    uint32_t rowsRead{0};
+    uint32_t nonNullCount{0};
+    bool nullsInitialized{false};
+    while (rowsRead < count) {
+      NIMBLE_CHECK_LT(
+          streamSegmentIndex_,
+          streamSegments_.size(),
+          "Non-in-map stream ended before requested rows were decoded");
+      const uint32_t rowsToRead = count - rowsRead;
+      const auto result = readSegment(
+          output,
+          rowsRead,
+          rowsToRead,
+          getOutputNulls,
+          /*scatterOutputBitmap=*/nullptr,
+          stringBuffers);
+      NIMBLE_CHECK_GT(
+          result.numOutputRows, 0, "Current segment returned no rows");
+      NIMBLE_CHECK_LE(
+          result.nonNullOutputRows,
+          result.numOutputRows,
+          "non-null row count exceeds row count");
+      const bool segmentAllNonNull =
+          result.nonNullOutputRows == result.numOutputRows;
+      const bool needsNullHandling = !segmentAllNonNull || nullsInitialized;
+      if (FOLLY_UNLIKELY(needsNullHandling)) {
+        NIMBLE_CHECK_NOT_NULL(
+            getOutputNulls, "nullable segment requires output nulls callback");
+        if (!segmentAllNonNull && !nullsInitialized) {
+          velox::bits::fillBits(
+              static_cast<uint64_t*>(getOutputNulls()),
+              0,
+              rowsRead,
+              velox::bits::kNotNull);
+          nullsInitialized = true;
+        } else if (segmentAllNonNull && nullsInitialized) {
+          // Nullable decoding does not touch the null bitmap for all-non-null
+          // segments, so keep the stitched output range explicitly non-null.
+          velox::bits::fillBits(
+              static_cast<uint64_t*>(getOutputNulls()),
+              rowsRead,
+              rowsRead + result.numOutputRows,
+              velox::bits::kNotNull);
         }
       }
+      rowsRead += result.numOutputRows;
+      nonNullCount += result.nonNullOutputRows;
+      if (FOLLY_LIKELY(result.segmentExhausted)) {
+        advanceSegment();
+      }
     }
-    NIMBLE_CHECK_EQ(valuesRead, count, "Incomplete read");
-    return count;
+
+    NIMBLE_CHECK_EQ(
+        rowsRead,
+        count,
+        "Incomplete read: typeKind={} inMap={} segments={} streamSegmentIndex={}",
+        toString(type_->kind()),
+        isInMapStream_,
+        streamSegments_.size(),
+        streamSegmentIndex_);
+    return nonNullCount;
   }
 
-  // Read for FlatMap nulls/inMap streams with gap detection.
-  // Detects gaps between segments (where certain keys are missing) and fills
-  // with placeholder data. Uses currentFlatMapRow_ to track position and
-  // compare with segment startRow.
-  uint32_t readFlatMap(
+  // FlatMap in-map streams still materialize dense bool output. Their physical
+  // stream can be omitted for all-absent/all-present batch ranges, so this path
+  // reconstructs those gaps while normal dense reads avoid the in-map branches.
+  uint32_t inMapRead(
       uint32_t count,
       void* output,
-      uint32_t width,
       std::vector<velox::BufferPtr>& stringBuffers) {
-    NIMBLE_CHECK(type_->isFlatMap(), "readFlatMap requires FlatMap type");
-    // Only used for FlatMap nulls/inMap streams which are boolean.
-    NIMBLE_CHECK_EQ(width, sizeof(bool), "readFlatMap expects bool width");
-
-    uint32_t rowsRead = 0;
+    uint32_t rowsRead{0};
+    uint32_t nonNullCount{0};
     while (rowsRead < count) {
-      // Gap detection: fill missing rows before current segment starts.
-      if (currentSegment_ < batchSegments_.size() &&
-          currentFlatMapRow_ < batchSegments_[currentSegment_].startRow) {
-        const uint32_t segmentStartRow =
-            batchSegments_[currentSegment_].startRow;
-        const uint32_t numMissingRows =
-            std::min(segmentStartRow - currentFlatMapRow_, count - rowsRead);
-        fillMissingFlatMapRows(output, rowsRead, numMissingRows, width);
-        rowsRead += numMissingRows;
-        currentFlatMapRow_ += numMissingRows;
+      if (streamSegmentIndex_ >= streamSegments_.size()) {
+        const auto rows = fillInMapGap(rowsRead, count - rowsRead, output);
+        rowsRead += rows;
+        nonNullCount += rows;
+        break;
+      }
+
+      const auto nextStreamStartRow =
+          streamSegments_[streamSegmentIndex_].startRow;
+      if (nextStreamStartRow > rowsRead) {
+        const auto rows = fillInMapGap(rowsRead, count - rowsRead, output);
+        NIMBLE_CHECK_EQ(
+            rows,
+            std::min(count, nextStreamStartRow) - rowsRead,
+            "FlatMap in-map gap fill returned unexpected row count");
+        rowsRead += rows;
+        nonNullCount += rows;
         continue;
       }
 
-      if (currentSegment_ >= batchSegments_.size()) {
-        // No more segments - fill remaining with placeholder.
-        if (currentFlatMapRow_ < topLevelRows_) {
-          const uint32_t numMissingRows =
-              std::min(topLevelRows_ - currentFlatMapRow_, count - rowsRead);
-          fillMissingFlatMapRows(output, rowsRead, numMissingRows, width);
-          rowsRead += numMissingRows;
-          currentFlatMapRow_ += numMissingRows;
-          continue;
-        }
-        NIMBLE_FAIL("Incomplete read: no more segments and beyond totalRows");
-      }
-
-      // Read from current segment.
       const uint32_t rowsToRead = count - rowsRead;
-      const uint32_t numRowsRead = readFromBatchSegment(
-          output, /*offset=*/rowsRead, rowsToRead, width, stringBuffers);
-      if (numRowsRead == 0) {
+      const auto result = readSegment(
+          output,
+          rowsRead,
+          rowsToRead,
+          /*getOutputNulls=*/nullptr,
+          /*scatterOutputBitmap=*/nullptr,
+          stringBuffers);
+      NIMBLE_CHECK_GT(
+          result.numOutputRows, 0, "Current in-map segment returned no rows");
+      NIMBLE_CHECK_EQ(
+          result.nonNullOutputRows,
+          result.numOutputRows,
+          "FlatMap in-map stream must not contain nulls");
+      rowsRead += result.numOutputRows;
+      nonNullCount += result.numOutputRows;
+      if (FOLLY_LIKELY(result.segmentExhausted)) {
         advanceSegment();
-      } else {
-        rowsRead += numRowsRead;
-        currentFlatMapRow_ += numRowsRead;
-        if (numRowsRead < rowsToRead) {
-          advanceSegment();
-        }
       }
     }
-    return count;
+
+    NIMBLE_CHECK_EQ(
+        rowsRead,
+        count,
+        "Incomplete in-map read: segments={} streamSegmentIndex={}",
+        streamSegments_.size(),
+        streamSegmentIndex_);
+    return nonNullCount;
   }
 
-  // Ensure scatterBuffer_ has at least the requested capacity.
-  // Only grows the buffer, never shrinks, to avoid repeated allocations.
-  char* ensureScatterBuffer(size_t bytes) {
-    if (scatterBuffer_ == nullptr || scatterBuffer_->capacity() < bytes) {
-      scatterBuffer_ = velox::AlignedBuffer::allocate<char>(bytes, pool_);
-    }
-    return scatterBuffer_->asMutable<char>();
-  }
-
-  // Read values contiguously then scatter to positions where scatterBitmap
-  // bits are set. Used for FlatMap value columns where some rows don't have
-  // certain keys (inMap=false).
+  // Decode directly to positions where scatterOutputBitmap bits are set. Used
+  // for FlatMap value columns where some rows don't have certain keys
+  // (inMap=false).
   uint32_t scatteredRead(
       uint32_t count,
       void* output,
-      uint32_t width,
-      const velox::bits::Bitmap* scatterBitmap,
+      const std::function<void*()>& getOutputNulls,
+      const velox::bits::Bitmap* scatterOutputBitmap,
       std::vector<velox::BufferPtr>& stringBuffers) {
-    const auto outputSize = scatterBitmap->size();
+    NIMBLE_CHECK(
+        !type_->isFlatMap(),
+        "scatterOutputBitmap not used for FlatMap null streams");
+
+    const auto outputSize = scatterOutputBitmap->size();
     // Fast path: if bitmap is dense (all bits set), read directly to output.
     // This avoids temp buffer allocation and scatter overhead.
     if (count == outputSize) {
-      return contiguousRead(count, output, width, stringBuffers);
+      return denseRead(count, output, getOutputNulls, stringBuffers);
     }
 
-    if (width > 0) {
-      // Fixed-width types: read to temp buffer, then scatter.
-      auto* buffer = ensureScatterBuffer((size_t)count * width);
-      uint32_t valuesRead = 0;
-      while (valuesRead < count && currentSegment_ < batchSegments_.size()) {
-        const auto toRead = count - valuesRead;
-        const auto read = readFromBatchSegment(
-            buffer, valuesRead, toRead, width, stringBuffers);
-        if (read == 0) {
-          advanceSegment();
-        } else {
-          valuesRead += read;
-          if (read < toRead) {
-            advanceSegment();
-          }
-        }
-      }
-      NIMBLE_CHECK_EQ(valuesRead, count, "Incomplete read");
+    uint32_t rowsRead = 0;
+    uint32_t nonNullCount = 0;
 
-      // Scatter to output positions where bitmap is set.
-      const char* src = buffer;
-      auto* dst = static_cast<char*>(output);
-      for (uint32_t pos = 0; pos < outputSize; ++pos) {
-        if (scatterBitmap->test(pos)) {
-          std::memcpy(dst + pos * width, src, width);
-          src += width;
-        }
-      }
-    } else {
-      // String types: read to temp buffer, then scatter.
-      auto* stringBuffer = reinterpret_cast<std::string_view*>(
-          ensureScatterBuffer(count * sizeof(std::string_view)));
-      uint32_t valuesRead = 0;
-      while (valuesRead < count && currentSegment_ < batchSegments_.size()) {
-        const auto toRead = count - valuesRead;
-        const auto read = readFromBatchSegment(
-            stringBuffer, valuesRead, toRead, width, stringBuffers);
-        if (read == 0) {
-          advanceSegment();
-        } else {
-          valuesRead += read;
-          if (read < toRead) {
-            advanceSegment();
-          }
-        }
-      }
-      NIMBLE_CHECK_EQ(valuesRead, count, "Incomplete read");
+    NIMBLE_CHECK_NOT_NULL(
+        getOutputNulls,
+        "Output nulls callback is required for scattered reads");
+    uint32_t offset = 0;
+    bool hasNulls = false;
 
-      // Scatter to output positions where bitmap is set.
-      const std::string_view* src = stringBuffer;
-      auto* dst = static_cast<std::string_view*>(output);
-      for (uint32_t pos = 0; pos < outputSize; ++pos) {
-        if (scatterBitmap->test(pos)) {
-          dst[pos] = *src++;
-        }
-      }
-    }
+    while (rowsRead < count && streamSegmentIndex_ < streamSegments_.size()) {
+      auto& streamData = ensureStreamData(stringBuffers);
+      NIMBLE_CHECK(
+          streamData.hasEncoding(),
+          "Scattered reads require encoded stream data");
+      const auto requestRows = count - rowsRead;
+      const auto rowsToRead = std::min(requestRows, streamData.remainingRows());
+      NIMBLE_CHECK_GT(rowsToRead, 0, "Current scattered segment has no rows");
 
-    return count;
-  }
-
-  // Fill missing rows for FlatMap streams (nulls or in-map).
-  // For nulls streams, delegates to fillMissingRows (fills with true).
-  // For in-map streams, a gap can span multiple segments — some with key
-  // present in every row (serializer skipped), some absent (key missing).
-  // Default fills with false, then overlays present segments.
-  void fillMissingFlatMapRows(
-      void* output,
-      uint32_t offset,
-      uint32_t count,
-      uint32_t width) {
-    NIMBLE_CHECK(
-        type_->isFlatMap(), "fillMissingFlatMapRows requires FlatMap type");
-
-    if (!inMapStream_ || presentInMapSegments_.empty()) {
-      fillMissingRows(output, offset, count, width);
-      return;
-    }
-
-    auto* bools = static_cast<bool*>(output) + offset;
-    const uint32_t startRow = currentFlatMapRow_;
-    const uint32_t endRow = startRow + count;
-
-    // Fast path: single present segment covers the entire gap.
-    if (currentInMapSegment_ < presentInMapSegments_.size()) {
-      const auto& segment = presentInMapSegments_[currentInMapSegment_];
-      if (segment.startRow <= startRow && segment.endRow >= endRow) {
-        std::memset(bools, 1, count);
-        return;
-      }
-    }
-
-    // General path: default fill with false, then overlay present segments.
-    // Segments are sorted by startRow, so advance currentInMapSegment_ past
-    // consumed segments to avoid re-scanning.
-    std::memset(bools, 0, count);
-    while (currentInMapSegment_ < presentInMapSegments_.size()) {
-      const auto& segment = presentInMapSegments_[currentInMapSegment_];
-      if (segment.startRow >= endRow) {
-        break;
-      }
-      if (segment.endRow > startRow) {
-        const uint32_t overlapStart = std::max(segment.startRow, startRow);
-        const uint32_t overlapEnd = std::min(segment.endRow, endRow);
-        std::memset(
-            bools + (overlapStart - startRow), 1, overlapEnd - overlapStart);
-      }
-      // Advance past segments fully consumed by this gap.
-      if (segment.endRow <= endRow) {
-        ++currentInMapSegment_;
-      } else {
-        break;
-      }
-    }
-  }
-
-  void fillMissingRows(
-      void* output,
-      uint32_t offset,
-      uint32_t count,
-      uint32_t width) {
-    if (type_->isRow() || type_->isFlatMap()) {
-      // For Row/FlatMap nulls stream, fill with true (all non-null).
-      // For FlatMap inMap streams, fill with false (key not present).
-      NIMBLE_CHECK_EQ(width, sizeof(bool), "Unexpected width for Row/FlatMap");
-      auto* bools = static_cast<bool*>(output) + offset;
-      std::memset(bools, inMapStream_ ? 0 : 1, count);
-    } else if (type_->isScalar()) {
-      // For Scalar types, fill with zeros.
-      if (width > 0) {
-        std::memset(
-            static_cast<char*>(output) + offset * width, 0, count * width);
-      }
-      // For strings (width == 0), leave as empty string_views.
-    } else {
-      // For other types (Array, Map, etc.), fill lengths with zeros.
+      const auto endOffset = velox::bits::findSetBit(
+          static_cast<const char*>(scatterOutputBitmap->bits()),
+          offset,
+          outputSize,
+          rowsToRead + 1);
+      velox::bits::Bitmap segmentScatterBitmap{
+          scatterOutputBitmap->bits(), endOffset};
+      const auto result = readSegment(
+          output,
+          offset,
+          rowsToRead,
+          getOutputNulls,
+          &segmentScatterBitmap,
+          stringBuffers);
       NIMBLE_CHECK_EQ(
-          width, sizeof(uint32_t), "Unexpected width for Array/Map");
-      std::memset(
-          static_cast<char*>(output) + offset * width, 0, count * width);
+          result.numOutputRows,
+          rowsToRead,
+          "Incomplete scattered segment read");
+
+      const auto segmentRows = endOffset - offset;
+      const bool segmentHasNulls = result.nonNullOutputRows != segmentRows;
+      if (segmentHasNulls && !hasNulls) {
+        velox::bits::BitmapBuilder nullBits{getOutputNulls(), offset};
+        nullBits.set(0, offset);
+      }
+      if (hasNulls && !segmentHasNulls) {
+        velox::bits::BitmapBuilder nullBits{getOutputNulls(), endOffset};
+        nullBits.set(offset, endOffset);
+      }
+      hasNulls |= segmentHasNulls;
+
+      rowsRead += result.numOutputRows;
+      nonNullCount += result.nonNullOutputRows;
+      offset = endOffset;
+      if (FOLLY_LIKELY(result.segmentExhausted)) {
+        advanceSegment();
+      }
     }
+
+    NIMBLE_CHECK_EQ(
+        rowsRead,
+        count,
+        "Incomplete scattered read: typeKind={} segments={} streamSegmentIndex={}",
+        toString(type_->kind()),
+        streamSegments_.size(),
+        streamSegmentIndex_);
+    return nonNullCount;
   }
-
-  // Batch segment storing raw data for lazy StreamData creation.
-  // Encoding objects are created on-demand when the segment is first read,
-  // ensuring only one encoding tree exists at a time for better cache locality.
-  struct BatchSegment {
-    uint32_t startRow; // Row offset where this segment starts.
-    std::string_view data; // Raw stream data (valid for lifetime of input).
-    SerializationVersion version;
-  };
-
-  // Row range [startRow, endRow) for segments where this key is present in
-  // every row. The serializer skips the in-map stream for these segments, and
-  // fillMissingFlatMapRows fills with true (present) instead of false (absent).
-  struct InMapSegment {
-    uint32_t startRow;
-    uint32_t endRow;
-  };
 
   // --- Const members (set at construction, never modified) ---
   const Type* const type_;
   velox::memory::MemoryPool* const pool_;
-  // True for inMap streams (fills with 'false' when missing), false for nulls
-  // streams (fills with 'true' when missing).
-  const bool inMapStream_;
+  // True when this decoder reads a FlatMap child in-map presence stream rather
+  // than the FlatMap value/null stream.
+  const bool isInMapStream_;
   // Cached from type at construction to avoid per-call dispatch.
   const ScalarKind scalarKind_;
   const uint32_t typeStorageWidth_;
   // Pool for encoding scratch buffers (e.g. MainlyConstant's isCommon and
-  // otherValues buffers). Persists across clear()/addBatch() cycles so buffers
+  // otherValues buffers). Persists across reset()/addBatch() cycles so buffers
   // are reused instead of being allocated/freed through MemoryPool each time.
   // Null when buffer pooling is disabled via DeserializerOptions.
   const std::unique_ptr<velox::BufferPool> bufferPool_;
   // Decompression buffer reused across StreamData lifetimes. Persists across
-  // clear()/addBatch() cycles so the buffer capacity is reused instead of
+  // reset()/addBatch() cycles so the buffer capacity is reused instead of
   // freed and re-allocated on each segment transition.
   velox::BufferPtr decompressionBuffer_;
 
-  // --- Batch decode state (reset in clear()) ---
-  // Total top-level rows across all batches. Used for FlatMap gap detection to
-  // fill missing rows at the end.
-  uint32_t topLevelRows_{0};
-  std::vector<BatchSegment> batchSegments_;
-  size_t currentSegment_{0}; // Current index into batchSegments_
+  // --- Stream decode state (cleared by reset()) ---
+  size_t streamSegmentIndex_{0};
+  std::vector<StreamSegment> streamSegments_;
 
-  // Lazily-created StreamData. Only one exists at a time — destroyed before
-  // creating the next so the allocator reuses cache-hot memory.
-  std::optional<serde::StreamData> streamData_;
-
-  // --- FlatMap state (reset in clear()) ---
-  // FlatMap is only supported at depth 1 (top-level columns). Gap detection is
-  // enabled whenever type_->isFlatMap(). These fields are unused for
-  // non-FlatMap types.
-
-  // Current read position for FlatMap gap detection.
-  uint32_t currentFlatMapRow_{0};
-  // Segments where this key is present in every row (in-map stream skipped).
-  // Used by fillMissingFlatMapRows to fill with true (present).
+  // --- FlatMap in-map state (cleared by reset()) ---
+  size_t presentSegmentIndex_{0};
   std::vector<InMapSegment> presentInMapSegments_;
-  size_t currentInMapSegment_{0}; // Current index into presentInMapSegments_
 
-  // Temp buffer for scattered reads (reused to avoid repeated allocations).
-  // Used for both fixed-width types (as char*) and strings (as string_view*).
-  velox::BufferPtr scatterBuffer_;
+  // Lazily-created StreamData wrapper reused across physical segments for this
+  // stream decoder.
+  std::optional<serde::StreamData> streamData_;
 };
 
 const StreamDescriptor& getMainDescriptor(const Type& type) {
@@ -685,6 +709,7 @@ Deserializer::Deserializer(
     DeserializerOptions options)
     : schema_{std::move(schema)}, pool_{pool}, options_{std::move(options)} {
   const auto params = createFieldReaderParams();
+  parser_ = std::make_unique<serde::StreamDataParser>(pool_, options_);
 
   std::shared_ptr<const velox::dwio::common::TypeWithId> schemaWithId =
       velox::dwio::common::TypeWithId::create(convertToVeloxType(*schema_));
@@ -695,8 +720,7 @@ Deserializer::Deserializer(
     createDeserializersForType(type, depth);
   });
 
-  rootReader_ = rootFactory_->createReader(deserializerMap_);
-  inputBuffer_.resize(1);
+  reader_ = rootFactory_->createReader(deserializerMap_);
 
   // Build flat vector for O(1) stream offset lookup during deserialize().
   uint32_t maxOffset = 0;
@@ -707,13 +731,13 @@ Deserializer::Deserializer(
   for (auto& [offset, decoder] : deserializerMap_) {
     deserializers_[offset] = decoder.get();
   }
-  // Pre-size FlatMap present-tracking state once. Both vectors are bounded
+  // Pre-size stream presence-tracking state once. Both vectors are bounded
   // by maxOffset because every value-stream anchor offset is a Type main
   // descriptor offset already in deserializerMap_. Sizing here (rather than
   // grow-on-demand inside createDeserializersForType) avoids repeated
   // reallocations and lets the per-batch hot path skip a bounds check.
   if (!inMapChildTypes_.empty()) {
-    inMapPresentOffsets_.resize(maxOffset + 1, false);
+    streamPresentFlags_.resize(maxOffset + 1, false);
     valueOffsetToInMap_.resize(maxOffset + 1, kInvalidInMapOffset);
     // Populate the reverse-lookup table: for each top-level FlatMap child,
     // record its inMap stream offset at every one of its value-stream
@@ -739,27 +763,28 @@ Deserializer::Deserializer(
   }
 }
 
+Deserializer::~Deserializer() = default;
+
 void Deserializer::createDeserializersForType(
     const Type& type,
     uint32_t depth) {
   deserializerMap_[getMainDescriptor(type).offset()] =
-      std::make_unique<DeserializerImpl>(
+      std::make_unique<SegmentedStreamDecoder>(
           &type,
-          /*inMapStream=*/false,
+          /*isInMapStream=*/false,
           options_.bufferPoolCapacity,
           pool_);
-  // FlatMap is only supported at depth 1 (top-level columns). FlatMap keys can
-  // vary across batches, causing gaps in nulls/inMap streams. Gap detection is
-  // enabled in DeserializerImpl whenever type->isFlatMap().
+  // FlatMap is only supported at depth 1 (top-level columns). Register each
+  // child in-map stream so it is decoded like other physical streams.
   if (type.isFlatMap()) {
     NIMBLE_CHECK_EQ(
         depth, 1, "FlatMap is only supported as a top-level column (depth 1)");
     auto& flatMap = type.asFlatMap();
     for (size_t i = 0; i < flatMap.childrenCount(); ++i) {
       const auto inMapOffset = flatMap.inMapDescriptorAt(i).offset();
-      deserializerMap_[inMapOffset] = std::make_unique<DeserializerImpl>(
+      deserializerMap_[inMapOffset] = std::make_unique<SegmentedStreamDecoder>(
           &type,
-          /*inMapStream=*/true,
+          /*isInMapStream=*/true,
           options_.bufferPoolCapacity,
           pool_);
       inMapChildTypes_[inMapOffset] = flatMap.childAt(i).get();
@@ -767,111 +792,120 @@ void Deserializer::createDeserializersForType(
   }
 }
 
-void Deserializer::deserialize(std::string_view data, velox::VectorPtr& vector)
+void Deserializer::deserialize(std::string_view data, velox::VectorPtr& output)
     const {
-  inputBuffer_[0] = data;
-  deserialize(inputBuffer_, vector);
+  deserialize(folly::Range<const std::string_view*>(&data, 1), output);
 }
 
 void Deserializer::deserialize(
     const std::vector<std::string_view>& data,
-    velox::VectorPtr& vector) const {
-  // Clear deserializer state from previous calls.
-  for (auto& [_, decoder] : deserializerMap_) {
-    DeserializerImpl::toDecoderImpl(decoder.get())->clear();
+    velox::VectorPtr& output) const {
+  deserialize(
+      folly::Range<const std::string_view*>(data.data(), data.size()), output);
+}
+
+void Deserializer::appendToOutput(
+    velox::VectorPtr&& decoded,
+    velox::VectorPtr& output) const {
+  if (FOLLY_LIKELY(output == nullptr)) {
+    output = std::move(decoded);
+    return;
   }
-  const bool hasInMapChildren = !inMapChildTypes_.empty();
+  output->append(decoded.get());
+}
+
+void Deserializer::decodeRun(DecodeRun& run, velox::VectorPtr& output) const {
+  if (FOLLY_UNLIKELY(run.batches == 0)) {
+    return;
+  }
+
+  velox::VectorPtr decoded;
+  reader_->next(run.rows, decoded, nullptr);
+  run = {};
+  appendToOutput(std::move(decoded), output);
+  reader_->reset();
+}
+
+void Deserializer::appendStreamSegments(
+    uint32_t rowCount,
+    uint32_t startRow,
+    bool requiresBarrier) const {
   const auto maxStreamOffset = deserializers_.size() - 1;
-
-  // Iterate batches and add stream data with row offsets. Streams missing
-  // from a batch will have gaps that are filled later during reading.
-  //
-  // We decode the full cumulative stream below — over-fetching rows outside
-  // any per-batch row range. For kTablet inputs from NimbleIndexProjector
-  // (the producer of row-range-bearing slices), this over-fetch is bounded
-  // by stripe boundaries and never crosses users: each chunk slice covers
-  // exactly one (request × stripe) intersection. For non-kTablet inputs
-  // (kLegacyCompact/kLegacy) there's no embedded row range, so
-  // "over-fetch" doesn't apply — the full batch is decoded as intended.
-  //
-  // Callers that want only the in-range rows of a kTablet slice can read
-  // the range via rocks::readResultRowRange and slice the output themselves.
-  //
-  // TODO: optimize by pushing the row range into the FieldReader::skip
-  // cascade so the decode pass produces only the in-range rows. Correct for
-  // nested-nullable types because the cascade goes through FieldReader
-  // (parent nulls/lengths are read and translated to child counts). Avoids
-  // the over-fetch CPU entirely.
-  uint32_t rowOffset{0};
-  serde::StreamDataReader reader{pool_, options_};
-  for (auto sv : data) {
-    const auto numRows = reader.initialize(sv);
-    const auto version = reader.version();
-    // Reset present tracking from previous batch.
-    if (hasInMapChildren && !inMapPresentOffsetsList_.empty()) {
-      for (auto off : inMapPresentOffsetsList_) {
-        inMapPresentOffsets_[off] = false;
-      }
-      inMapPresentOffsetsList_.clear();
+  const auto version = parser_->version();
+  const bool hasInMapChildren = !inMapChildTypes_.empty();
+  if (hasInMapChildren) {
+    std::fill(streamPresentFlags_.begin(), streamPresentFlags_.end(), false);
+    presentStreamOffsets_.clear();
+  }
+  parser_->iterateStreams([&](uint32_t offset, std::string_view streamData) {
+    if (FOLLY_UNLIKELY(offset > maxStreamOffset)) {
+      return;
     }
-    // iterateStreams() is a templated callback walker; the lambda body
-    // inlines into the loop, eliminating std::function dispatch on the
-    // per-batch flatmap deserialization hot path.
-    reader.iterateStreams([&](uint32_t offset, std::string_view streamData) {
-      if (offset <= maxStreamOffset) {
-        if (hasInMapChildren) {
-          inMapPresentOffsets_[offset] = true;
-          inMapPresentOffsetsList_.emplace_back(offset);
-        }
-        // Null is possible: deserializers_ is sized to maxOffset+1 but only
-        // populated for offsets in deserializerMap_. Some serialized stream
-        // offsets (e.g., TimestampMicroNano's nanosDescriptor) are not in
-        // the map, so their slot stays null; skip them here.
-        auto* decoder = deserializers_[offset];
-        if (decoder != nullptr) {
-          DeserializerImpl::toDecoderImpl(decoder)->addBatch(
-              rowOffset, streamData, version);
-        }
+    if (hasInMapChildren) {
+      if (!streamPresentFlags_[offset]) {
+        streamPresentFlags_[offset] = true;
+        presentStreamOffsets_.emplace_back(offset);
       }
-    });
-
-    // Detect present in-map streams by driving the scan off the small set
-    // of streams actually present in this blob (inMapPresentOffsetsList_,
-    // typically dozens of entries), rather than the schema's full FlatMap
-    // child cardinality (hundreds). For each present stream offset, the
-    // reverse-lookup table maps it back to its owning FlatMap child's
-    // inMap stream offset; if that child's inMap stream itself was NOT
-    // present, the child's values are implicitly all-present in this blob
-    // and we emit an in-map segment.
-    //
-    // Caveat: if a single child has multiple value-stream anchors (e.g.,
-    // Row<A,B> as a value type) and more than one fires in the same blob,
-    // addPresentInMapSegment will be called once per present anchor — the
-    // resulting segment list may contain duplicate {startRow, endRow}
-    // entries. Downstream fillMissingFlatMapRows overlays 1s onto the
-    // default-0 inMap bitmap and is idempotent over duplicates, so output
-    // correctness is preserved. EBF (Array<Scalar> values, one anchor per
-    // child) never hits this case.
-    for (const auto offset : inMapPresentOffsetsList_) {
-      const auto inMapOffset = valueOffsetToInMap_[offset];
-      if (inMapOffset == kInvalidInMapOffset ||
-          inMapPresentOffsets_[inMapOffset]) {
-        continue;
-      }
-      DeserializerImpl::toDecoderImpl(deserializers_[inMapOffset])
-          ->addPresentInMapSegment(rowOffset, numRows);
     }
+    auto* decoder = deserializers_[offset];
+    NIMBLE_CHECK_NOT_NULL(decoder, "Missing decoder for stream");
+    SegmentedStreamDecoder::as(decoder)->addBatch(
+        startRow, streamData, version);
+  });
 
-    rowOffset += numRows;
+  if (!hasInMapChildren) {
+    return;
+  }
+  const auto presentStreamCount = presentStreamOffsets_.size();
+  for (size_t i = 0; i < presentStreamCount; ++i) {
+    const auto inMapOffset = valueOffsetToInMap_[presentStreamOffsets_[i]];
+    if (inMapOffset == kInvalidInMapOffset ||
+        streamPresentFlags_[inMapOffset]) {
+      continue;
+    }
+    auto* decoder = deserializers_[inMapOffset];
+    NIMBLE_CHECK_NOT_NULL(decoder, "Missing FlatMap in-map decoder");
+    auto* segmentedDecoder = SegmentedStreamDecoder::as(decoder);
+    if (requiresBarrier) {
+      segmentedDecoder->addPresentInMapBatch();
+    } else {
+      segmentedDecoder->addPresentInMapBatch(startRow, rowCount);
+    }
+    streamPresentFlags_[inMapOffset] = true;
+  }
+}
+
+void Deserializer::appendBatch(
+    std::string_view batch,
+    DecodeRun& run,
+    velox::VectorPtr& output) const {
+  const auto rowCount = parser_->initialize(batch);
+  const auto requiresBarrier = parser_->requiresNullBarrier();
+  if (FOLLY_UNLIKELY(requiresBarrier)) {
+    decodeRun(run, output);
   }
 
-  // Set total top-level rows so deserializers can fill missing FlatMap data.
-  for (auto& [_, decoder] : deserializerMap_) {
-    DeserializerImpl::toDecoderImpl(decoder.get())->setTopLevelRows(rowOffset);
+  appendStreamSegments(rowCount, /*startRow=*/run.rows, requiresBarrier);
+  run.rows += rowCount;
+  ++run.batches;
+  if (FOLLY_UNLIKELY(requiresBarrier)) {
+    decodeRun(run, output);
+    parser_->reset();
   }
+}
 
-  // Single-pass decode of all batches concatenated.
-  rootReader_->next(rowOffset, vector, /*scatterBitmap=*/nullptr);
+void Deserializer::deserialize(
+    folly::Range<const std::string_view*> data,
+    velox::VectorPtr& output) const {
+  NIMBLE_CHECK(!data.empty(), "Expected at least one serialized batch");
+
+  output = nullptr;
+  DecodeRun run;
+  for (const auto batch : data) {
+    appendBatch(batch, run, output);
+  }
+  decodeRun(run, output);
+  parser_->reset();
 }
 
 } // namespace facebook::nimble

--- a/dwio/nimble/serializer/Deserializer.h
+++ b/dwio/nimble/serializer/Deserializer.h
@@ -15,14 +15,27 @@
  */
 #pragma once
 
+#include <cstdint>
 #include <limits>
 
 #include "dwio/nimble/serializer/Options.h"
 #include "dwio/nimble/velox/FieldReader.h"
+#include "folly/Range.h"
 #include "folly/container/F14Map.h"
 #include "velox/vector/BaseVector.h"
 
 namespace facebook::nimble {
+
+namespace serde {
+class StreamDataParser;
+} // namespace serde
+
+/// Deserializer converts serialized nimble streams into Velox vectors.
+///
+/// This class provides a lightweight deserialization interface for
+/// materializing one or more serialized batches into a vector matching the
+/// configured schema. It supports FlatMap reconstruction and omitted
+/// null/in-map streams according to Deserializer::Options.
 class Deserializer {
  public:
   using Options = DeserializerOptions;
@@ -36,11 +49,18 @@ class Deserializer {
       velox::memory::MemoryPool* pool,
       DeserializerOptions options);
 
-  void deserialize(std::string_view data, velox::VectorPtr& vector) const;
+  ~Deserializer();
+
+  Deserializer(Deserializer&&) = delete;
+  Deserializer& operator=(Deserializer&&) = delete;
+  Deserializer(const Deserializer&) = delete;
+  Deserializer& operator=(const Deserializer&) = delete;
+
+  void deserialize(std::string_view data, velox::VectorPtr& output) const;
 
   void deserialize(
       const std::vector<std::string_view>& data,
-      velox::VectorPtr& vector) const;
+      velox::VectorPtr& output) const;
 
  private:
   // Creates deserializers for a type and its FlatMap inMap streams.
@@ -50,6 +70,38 @@ class Deserializer {
   // executor, parallel decode threshold, and flatmap-as-struct settings.
   FieldReaderParams createFieldReaderParams() const;
 
+  void deserialize(
+      folly::Range<const std::string_view*> data,
+      velox::VectorPtr& output) const;
+
+  // Open run of non-barrier batches that can be decoded together.
+  struct DecodeRun {
+    uint32_t rows{0};
+    uint32_t batches{0};
+  };
+
+  // Adds one serialized batch to the current decode run, decoding before and
+  // after batches that require a null barrier.
+  void appendBatch(
+      std::string_view batch,
+      DecodeRun& run,
+      velox::VectorPtr& output) const;
+
+  // Registers this batch's physical stream segments and synthesizes omitted
+  // FlatMap in-map segments when older serializers leave them implicit.
+  void appendStreamSegments(
+      uint32_t rowCount,
+      uint32_t startRow,
+      bool requiresBarrier) const;
+
+  // Appends a decoded run to the accumulated output vector.
+  void appendToOutput(velox::VectorPtr&& decoded, velox::VectorPtr& output)
+      const;
+
+  // Decodes the pending non-barrier batch run and resets reader state for the
+  // next run.
+  void decodeRun(DecodeRun& run, velox::VectorPtr& output) const;
+
   // --- Const members (set at construction, never modified) ---
   const std::shared_ptr<const Type> schema_;
   velox::memory::MemoryPool* const pool_;
@@ -57,50 +109,34 @@ class Deserializer {
 
   // --- Non-const members (assigned in constructor body) ---
   std::unique_ptr<FieldReaderFactory> rootFactory_;
-  std::unique_ptr<FieldReader> rootReader_;
+  std::unique_ptr<FieldReader> reader_;
+  mutable std::unique_ptr<serde::StreamDataParser> parser_;
 
   // --- Mutable members (modified during deserialization) ---
   mutable folly::F14FastMap<uint32_t, std::unique_ptr<Decoder>>
       deserializerMap_;
-  mutable std::vector<std::string_view> inputBuffer_;
 
   // Flat vector indexed by stream offset for O(1) lookup in deserialize().
   // Non-owning pointers; ownership stays in deserializerMap_.
   mutable std::vector<Decoder*> deserializers_;
 
-  // Map from in-map stream offset to the child value type for detecting
-  // present in-map streams. When an in-map stream is missing from a batch but
-  // its value streams are present, the key is present in every row (skipped by
-  // the serializer). Only populated for top-level FlatMap types (depth 1).
+  // Maps FlatMap in-map stream offsets to their child value types. Used to
+  // reconstruct in-map streams omitted by older serializers.
   folly::F14FastMap<uint32_t, const Type*> inMapChildTypes_;
 
-  // Sentinel for `valueOffsetToInMap_` entries that are NOT a FlatMap-child
-  // value-stream anchor.
   static constexpr uint32_t kInvalidInMapOffset =
       std::numeric_limits<uint32_t>::max();
 
-  // Reverse-lookup table used by the per-batch in-map detection in
-  // deserialize(). `valueOffsetToInMap_[off]` is the inMap stream offset of
-  // the FlatMap child whose value-stream lives at `off`, or
-  // `kInvalidInMapOffset` for any offset that isn't a FlatMap-child
-  // value-stream anchor. Populated at construction via
-  // visitValueStreamLeaves() and indexed directly by stream offset. Sized
-  // once to `maxStreamOffset + 1` so the hot path needs no bounds check.
-  //
-  // The hot path iterates `inMapPresentOffsetsList_` (the small set of
-  // present streams in the current blob, typically dozens) and consults
-  // this table to map each present value anchor back to its owning child's
-  // inMap stream — replacing the prior 357-entry forward scan with one
-  // proportional to the number of present streams in the blob.
+  // Reverse lookup from a FlatMap child value-stream offset to its in-map
+  // stream offset. Entries that are not FlatMap child value streams use
+  // kInvalidInMapOffset.
   std::vector<uint32_t> valueOffsetToInMap_;
 
-  // Flat boolean vector indexed by stream offset for tracking which streams
-  // are present in the current batch. Replaces F14FastSet for O(1) access.
-  // Only used when inMapChildTypes_ is non-empty.
-  mutable std::vector<bool> inMapPresentOffsets_;
-  // Offsets that were set in inMapPresentOffsets_ this batch (for efficient
-  // reset).
-  mutable std::vector<uint32_t> inMapPresentOffsetsList_;
+  // Per-batch stream presence, indexed by stream offset.
+  mutable std::vector<bool> streamPresentFlags_;
+  // Stream offsets present in the current batch. Used to find omitted FlatMap
+  // in-map streams.
+  mutable std::vector<uint32_t> presentStreamOffsets_;
 };
 
 } // namespace facebook::nimble

--- a/dwio/nimble/serializer/DeserializerImpl.cpp
+++ b/dwio/nimble/serializer/DeserializerImpl.cpp
@@ -44,6 +44,19 @@ ZSTD_DCtx* getThreadLocalDCtx() {
 
 StreamData::StreamData(
     ScalarKind kind,
+    std::vector<velox::BufferPtr>& stringBuffers,
+    velox::memory::MemoryPool* pool,
+    velox::BufferPtr* decompressionBuffer)
+    : kind_{kind},
+      pool_{pool},
+      decompressionBuffer_{decompressionBuffer},
+      stringBuffers_{&stringBuffers} {
+  NIMBLE_CHECK_NOT_NULL(pool_, "Memory pool required for encoding");
+  NIMBLE_CHECK_NOT_NULL(decompressionBuffer_, "Decompression buffer required");
+}
+
+StreamData::StreamData(
+    ScalarKind kind,
     std::string_view data,
     std::vector<velox::BufferPtr>& stringBuffers,
     velox::memory::MemoryPool* pool,
@@ -60,6 +73,14 @@ StreamData::StreamData(
   init(data);
 }
 
+void StreamData::reset(std::string_view data, SerializationVersion version) {
+  readRows_ = 0;
+  encoding_.reset();
+  encodingEnabled_ = nonLegacyFormat(version);
+  useVarintRowCount_ = !isTabletVersion(version);
+  init(data);
+}
+
 // Copy legacy stream data to output buffer.
 // Data is already decompressed by init() -> decompress().
 uint32_t StreamData::copyTo(char* output, uint32_t bufferSize) {
@@ -70,7 +91,9 @@ uint32_t StreamData::copyTo(char* output, uint32_t bufferSize) {
   return length;
 }
 
-uint32_t StreamData::decodeStrings(uint32_t count, std::string_view* output) {
+StreamData::DecodeResult StreamData::decodeStrings(
+    uint32_t count,
+    std::string_view* output) {
   if (encodingEnabled_) {
     return decode(output, /*offset=*/0, count, /*width=*/0);
   }
@@ -78,16 +101,10 @@ uint32_t StreamData::decodeStrings(uint32_t count, std::string_view* output) {
   while (pos_ < end_ && index < count) {
     output[index++] = encoding::readString(pos_);
   }
-  return index;
-}
-
-void StreamData::reset(std::string_view data, SerializationVersion version) {
-  readRows_ = 0;
-  encoding_.reset();
-  encodingEnabled_ = nonLegacyFormat(version);
-  useVarintRowCount_ = !isTabletVersion(version);
-  // Re-initialize with new data.
-  init(data);
+  return {
+      .numOutputRows = index,
+      .nonNullOutputRows = index,
+      .segmentExhausted = pos_ == end_};
 }
 
 void StreamData::init(std::string_view data) {
@@ -174,6 +191,8 @@ void StreamData::decompress() {
 void StreamData::prepareForDecoding(std::string_view data) {
   NIMBLE_CHECK(encodingEnabled_);
   NIMBLE_CHECK_NULL(encoding_, "Encoding already set");
+  NIMBLE_CHECK_NOT_NULL(
+      stringBuffers_, "String buffer storage required for encoded stream data");
 
   // Use nimble EncodingFactory to decode the data.
   // The encoded data is self-describing with type information.
@@ -191,80 +210,174 @@ void StreamData::prepareForDecoding(std::string_view data) {
       });
 }
 
-uint32_t StreamData::decode(
+StreamData::DecodeResult StreamData::decode(
+    void* output,
+    uint32_t offset,
+    uint32_t count,
+    uint32_t width,
+    const std::function<void*()>& getOutputNulls,
+    const velox::bits::Bitmap* scatterOutputBitmap) {
+  // Nimble encoding path: use materialize() to decode.
+  NIMBLE_CHECK_NOT_NULL(
+      encoding_,
+      "Legacy StreamData must be decoded through copyTo() or decodeStrings()");
+  // Only decode as many values as remain in the encoding.
+  const uint32_t remainingRows = this->remainingRows();
+  const uint32_t readCount = std::min(count, remainingRows);
+  const bool segmentExhausted = readCount == remainingRows;
+  // materializeNullable() is also the scatter-output API. Use it when the
+  // encoding carries nulls, or when a parent in-map stream selected sparse
+  // output rows that must be filled with decoded values and absent-row nulls.
+  if (encoding_->isNullable() || scatterOutputBitmap != nullptr) {
+    const auto nonNulls = decodeNullable(
+        output, offset, readCount, width, getOutputNulls, scatterOutputBitmap);
+    return {
+        .numOutputRows = readCount,
+        .nonNullOutputRows = nonNulls,
+        .segmentExhausted = segmentExhausted};
+  }
+  decodeNonNull(output, offset, readCount, width);
+  return {
+      .numOutputRows = readCount,
+      .nonNullOutputRows = readCount,
+      .segmentExhausted = segmentExhausted};
+}
+
+uint32_t StreamData::decodeNullable(
+    void* output,
+    uint32_t offset,
+    uint32_t readCount,
+    uint32_t width,
+    const std::function<void*()>& getOutputNulls,
+    const velox::bits::Bitmap* scatterOutputBitmap) {
+  NIMBLE_CHECK_NOT_NULL(getOutputNulls, "Null buffer callback required");
+  switch (width) {
+    case 0: {
+      const auto nonNulls = encoding_->materializeNullable(
+          readCount, output, getOutputNulls, scatterOutputBitmap, offset);
+      readRows_ += readCount;
+      return nonNulls;
+    }
+    case 1: {
+      const auto nonNulls = encoding_->materializeNullable(
+          readCount,
+          reinterpret_cast<int8_t*>(output),
+          getOutputNulls,
+          scatterOutputBitmap,
+          offset);
+      readRows_ += readCount;
+      return nonNulls;
+    }
+    case 2: {
+      const auto nonNulls = encoding_->materializeNullable(
+          readCount,
+          reinterpret_cast<int16_t*>(output),
+          getOutputNulls,
+          scatterOutputBitmap,
+          offset);
+      readRows_ += readCount;
+      return nonNulls;
+    }
+    case 4: {
+      const auto nonNulls = encoding_->materializeNullable(
+          readCount,
+          reinterpret_cast<int32_t*>(output),
+          getOutputNulls,
+          scatterOutputBitmap,
+          offset);
+      readRows_ += readCount;
+      return nonNulls;
+    }
+    case 8: {
+      const auto nonNulls = encoding_->materializeNullable(
+          readCount,
+          reinterpret_cast<int64_t*>(output),
+          getOutputNulls,
+          scatterOutputBitmap,
+          offset);
+      readRows_ += readCount;
+      return nonNulls;
+    }
+    default:
+      NIMBLE_FAIL("Unexpected width {} for nimble decoding", width);
+  }
+}
+
+void StreamData::decodeNonNull(
+    void* output,
+    uint32_t offset,
+    uint32_t readCount,
+    uint32_t width) {
+  switch (width) {
+    case 0: {
+      // String type: output is std::string_view*
+      auto* dest = static_cast<std::string_view*>(output) + offset;
+      materialize(readCount, dest);
+      return;
+    }
+    case 1: {
+      auto* dest = static_cast<char*>(output) + offset * width;
+      materialize(readCount, reinterpret_cast<int8_t*>(dest));
+      return;
+    }
+    case 2: {
+      auto* dest = static_cast<char*>(output) + offset * width;
+      materialize(readCount, reinterpret_cast<int16_t*>(dest));
+      return;
+    }
+    case 4: {
+      auto* dest = static_cast<char*>(output) + offset * width;
+      materialize(readCount, reinterpret_cast<int32_t*>(dest));
+      return;
+    }
+    case 8: {
+      auto* dest = static_cast<char*>(output) + offset * width;
+      materialize(readCount, reinterpret_cast<int64_t*>(dest));
+      return;
+    }
+    default:
+      NIMBLE_FAIL("Unexpected width {} for nimble decoding", width);
+  }
+}
+
+StreamData::DecodeResult StreamData::decodeLegacy(
     void* output,
     uint32_t offset,
     uint32_t count,
     uint32_t width) {
-  if (encodingEnabled_) {
-    // Nimble encoding path: use materialize() to decode.
-    NIMBLE_CHECK_NOT_NULL(encoding_);
-    // Only decode as many values as remain in the encoding.
-    const uint32_t readCount = std::min(count, remainingRows());
-    switch (width) {
-      case 0: {
-        // String type: output is std::string_view*
-        auto* dest = static_cast<std::string_view*>(output) + offset;
-        materialize(readCount, dest);
-        break;
-      }
-      case 1: {
-        auto* dest = static_cast<char*>(output) + offset * width;
-        materialize(readCount, reinterpret_cast<int8_t*>(dest));
-        break;
-      }
-      case 2: {
-        auto* dest = static_cast<char*>(output) + offset * width;
-        materialize(readCount, reinterpret_cast<int16_t*>(dest));
-        break;
-      }
-      case 4: {
-        auto* dest = static_cast<char*>(output) + offset * width;
-        materialize(readCount, reinterpret_cast<int32_t*>(dest));
-        break;
-      }
-      case 8: {
-        auto* dest = static_cast<char*>(output) + offset * width;
-        materialize(readCount, reinterpret_cast<int64_t*>(dest));
-        break;
-      }
-      default:
-        NIMBLE_FAIL("Unexpected width {} for nimble decoding", width);
-    }
-    return readCount;
-  }
-
-  // Legacy compression path: read raw bytes from pos_.
+  NIMBLE_CHECK(!encodingEnabled_, "decodeLegacy called for encoded stream");
   NIMBLE_CHECK_NE(width, 0, "String type not supported for legacy path");
   if (count == 0) {
-    return 0;
+    return {.segmentExhausted = pos_ == end_};
   }
-  const size_t bytesToRead = count * width;
-  NIMBLE_CHECK_LE(
-      pos_ + bytesToRead, end_, "Not enough data for legacy decode");
   auto* dest = static_cast<char*>(output) + offset * width;
-  std::memcpy(dest, pos_, bytesToRead);
-  pos_ += bytesToRead;
-  return count;
+  const auto copied = copyTo(dest, count * width);
+  NIMBLE_CHECK_EQ(copied % width, 0, "Legacy stream ended mid-value");
+  const auto rows = copied / width;
+  return {
+      .numOutputRows = rows,
+      .nonNullOutputRows = rows,
+      .segmentExhausted = pos_ == end_};
 }
 
-StreamDataReader::StreamDataReader(
+StreamDataParser::StreamDataParser(
     velox::memory::MemoryPool* pool,
     const DeserializerOptions& options)
-    : options_{options}, pool_{pool}, chunkStrippingBuffer_{pool_} {
+    : options_{options}, pool_{pool} {
   NIMBLE_CHECK_NOT_NULL(pool_);
 }
 
-uint32_t StreamDataReader::initialize(std::string_view data) {
+uint32_t StreamDataParser::initialize(std::string_view data) {
   pos_ = data.data();
   end_ = data.end();
   auto header = readSerializationHeader(pos_, end_, options_.hasHeader);
   version_ = header.version;
+  requiresNullBarrier_ = header.requiresNullBarrier;
   rowRange_ = header.rowRange;
   return header.rowCount;
 }
 
-std::string_view StreamDataReader::stripChunkHeaders(
+std::string_view StreamDataParser::stripChunkHeaders(
     std::string_view streamData) {
   const auto* pos = streamData.data();
   const auto* end = pos + streamData.size();
@@ -273,17 +386,24 @@ std::string_view StreamDataReader::stripChunkHeaders(
       streamData.size(), kChunkHeaderSize, "Truncated chunk header in stream");
 
   if (auto result = tryFastChunkHeaderStrip(pos, end)) {
+    NIMBLE_CHECK(
+        !result->empty(), "Chunked stream must have a non-empty payload");
     return *result;
   }
   return slowChunkHeaderStrip(pos, end);
 }
 
-std::string_view StreamDataReader::slowChunkHeaderStrip(
+std::string_view StreamDataParser::slowChunkHeaderStrip(
     const char* pos,
     const char* end) {
   // TODO: Consider using IOBuf chain to avoid concatenation for multi-chunk
   // streams.
-  chunkStrippingBuffer_.clear();
+  const auto payloadSize = strippedStreamSize(pos, end);
+  NIMBLE_CHECK_GT(
+      payloadSize, 0, "Chunked stream must have a non-empty payload");
+  auto buffer = velox::AlignedBuffer::allocateExact<char>(payloadSize, pool_);
+  auto* output = buffer->asMutable<char>();
+  auto* const outputEnd = output + payloadSize;
   while (pos < end) {
     NIMBLE_CHECK_GE(
         static_cast<size_t>(end - pos),
@@ -294,13 +414,16 @@ std::string_view StreamDataReader::slowChunkHeaderStrip(
         chunkLength,
         static_cast<uint32_t>(end - pos),
         "Chunk data exceeds stream boundary");
-    appendChunkData(compressionType, pos, chunkLength);
+    appendChunkData(compressionType, pos, chunkLength, output);
     pos += chunkLength;
   }
-  return {chunkStrippingBuffer_.data(), chunkStrippingBuffer_.size()};
+  NIMBLE_CHECK_EQ(output, outputEnd, "Stripped chunk size mismatch");
+  const auto* data = buffer->as<char>();
+  strippedStreamBuffers_.emplace_back(std::move(buffer));
+  return {data, payloadSize};
 }
 
-std::optional<std::string_view> StreamDataReader::tryFastChunkHeaderStrip(
+std::optional<std::string_view> StreamDataParser::tryFastChunkHeaderStrip(
     const char* pos,
     const char* end) {
   const auto [chunkLength, compressionType] = readChunkHeader(pos);
@@ -317,50 +440,87 @@ std::optional<std::string_view> StreamDataReader::tryFastChunkHeaderStrip(
   return std::nullopt;
 }
 
-void StreamDataReader::appendChunkData(
+size_t StreamDataParser::strippedStreamSize(const char* pos, const char* end) {
+  size_t size = 0;
+  while (pos < end) {
+    NIMBLE_CHECK_GE(
+        static_cast<size_t>(end - pos),
+        kChunkHeaderSize,
+        "Truncated chunk header in stream");
+    const auto [chunkLength, compressionType] = readChunkHeader(pos);
+    NIMBLE_CHECK_LE(
+        chunkLength,
+        static_cast<uint32_t>(end - pos),
+        "Chunk data exceeds stream boundary");
+    size += decodedChunkSize(compressionType, pos, chunkLength);
+    pos += chunkLength;
+  }
+  return size;
+}
+
+size_t StreamDataParser::decodedChunkSize(
     CompressionType compression,
     const char* data,
     uint32_t length) {
   switch (compression) {
-    case CompressionType::Uncompressed: {
-      const auto offset = chunkStrippingBuffer_.size();
-      chunkStrippingBuffer_.resize(offset + length);
-      std::memcpy(chunkStrippingBuffer_.data() + offset, data, length);
-      break;
-    }
+    case CompressionType::Uncompressed:
+      return length;
     case CompressionType::Zstd: {
       const auto decompressedSize = ZSTD_getFrameContentSize(data, length);
       NIMBLE_CHECK(
           decompressedSize != ZSTD_CONTENTSIZE_ERROR &&
               decompressedSize != ZSTD_CONTENTSIZE_UNKNOWN,
           "Error determining decompressed size");
-      const auto offset = chunkStrippingBuffer_.size();
-      chunkStrippingBuffer_.resize(offset + decompressedSize);
+      return decompressedSize;
+    }
+    case CompressionType::Lz4: {
+      NIMBLE_CHECK_GE(
+          length, sizeof(uint32_t), "Truncated LZ4 chunk size header");
+      const auto* pos = data;
+      return encoding::readUint32(pos);
+    }
+    default:
+      NIMBLE_UNSUPPORTED("Unsupported chunk compression {}", compression);
+  }
+}
+
+void StreamDataParser::appendChunkData(
+    CompressionType compression,
+    const char* data,
+    uint32_t length,
+    char*& output) {
+  switch (compression) {
+    case CompressionType::Uncompressed: {
+      std::memcpy(output, data, length);
+      output += length;
+      break;
+    }
+    case CompressionType::Zstd: {
+      const auto decompressedSize = decodedChunkSize(compression, data, length);
       const auto ret = ZSTD_decompressDCtx(
-          getThreadLocalDCtx(),
-          chunkStrippingBuffer_.data() + offset,
-          decompressedSize,
-          data,
-          length);
+          getThreadLocalDCtx(), output, decompressedSize, data, length);
       NIMBLE_CHECK(!ZSTD_isError(ret), "Error decompressing chunk data");
+      NIMBLE_CHECK_EQ(
+          ret, decompressedSize, "ZSTD chunk decompressed size mismatch");
+      output += decompressedSize;
       break;
     }
     case CompressionType::Lz4: {
+      const auto decompressedSize = decodedChunkSize(compression, data, length);
       const auto* pos = data;
-      const auto decompressedSize = encoding::readUint32(pos);
+      encoding::readUint32(pos);
       const auto compressedSize =
           static_cast<size_t>(length - sizeof(uint32_t));
-      const auto offset = chunkStrippingBuffer_.size();
-      chunkStrippingBuffer_.resize(offset + decompressedSize);
       const auto ret = LZ4_decompress_safe(
           pos,
-          chunkStrippingBuffer_.data() + offset,
+          output,
           static_cast<int>(compressedSize),
           static_cast<int>(decompressedSize));
       NIMBLE_CHECK_EQ(
           ret,
           static_cast<int>(decompressedSize),
           "LZ4 chunk decompressed size mismatch");
+      output += decompressedSize;
       break;
     }
     default:

--- a/dwio/nimble/serializer/DeserializerImpl.h
+++ b/dwio/nimble/serializer/DeserializerImpl.h
@@ -16,6 +16,7 @@
 
 #pragma once
 
+#include <cstdint>
 #include <optional>
 
 #include <zstd.h>
@@ -48,27 +49,11 @@ class StreamData {
     velox::BufferPtr* decompressionBuffer{nullptr};
   };
 
-  /// Constructor for thrift decoder: creates an empty stream that will be
-  /// populated later via reset().
-  /// @param kind Scalar kind for the stream data.
-  /// @param pool Memory pool for encoding buffer allocation. Required when
-  ///             reset() will be called with encodingEnabled=true.
-  /// @param stringBuffers External vector where string buffers from encoding
-  ///        are stored. The caller must keep the vector alive while
-  ///        string_views from this StreamData are in use.
   StreamData(
       ScalarKind kind,
       std::vector<velox::BufferPtr>& stringBuffers,
       velox::memory::MemoryPool* pool,
-      velox::BufferPtr* decompressionBuffer)
-      : kind_{kind},
-        pool_{pool},
-        encodingEnabled_{false},
-        decompressionBuffer_{decompressionBuffer},
-        stringBuffers_{&stringBuffers} {
-    NIMBLE_CHECK_NOT_NULL(
-        decompressionBuffer_, "Decompression buffer required");
-  }
+      velox::BufferPtr* decompressionBuffer);
 
   /// @param kind Scalar kind for the stream data.
   /// @param data Stream data to initialize with.
@@ -84,16 +69,44 @@ class StreamData {
       velox::memory::MemoryPool* pool,
       const Options& options);
 
+  struct DecodeResult {
+    // Decoded output rows produced from the stream segment. For scattered
+    // decode, this is the number of selected output rows, not the wider output
+    // span including absent positions.
+    uint32_t numOutputRows{0};
+    // Non-null rows in the output range covered by this decode. For scattered
+    // decode, this is in the output row domain, not the encoded row domain.
+    uint32_t nonNullOutputRows{0};
+    // True when this decode consumed the current physical stream segment.
+    bool segmentExhausted{false};
+  };
+
   uint32_t copyTo(char* output, uint32_t bufferSize);
 
-  uint32_t decodeStrings(uint32_t count, std::string_view* output);
+  DecodeResult decodeStrings(uint32_t count, std::string_view* output);
+
+  // Decode legacy raw fixed-width data. Legacy string streams use
+  // decodeStrings().
+  DecodeResult
+  decodeLegacy(void* output, uint32_t offset, uint32_t count, uint32_t width);
 
   /// Decode nimble-encoded data to output. Dispatches to typed materialize
   /// based on width. Only valid when hasEncoding() is true.
-  /// Returns the number of values actually decoded (may be less than count
-  /// if encoding has fewer remaining rows).
-  uint32_t
-  decode(void* output, uint32_t offset, uint32_t count, uint32_t width);
+  /// Returns decoded output rows and non-null rows in the output range.
+  /// numOutputRows may be less than count if the encoding has fewer remaining
+  /// rows.
+  ///
+  /// For nullable encodings or scattered output, getOutputNulls must return the
+  /// mutable output null bitmap. If scatterOutputBitmap is provided, decoded
+  /// rows and null bits are written using that scattered output layout;
+  /// otherwise output is dense starting at offset.
+  DecodeResult decode(
+      void* output,
+      uint32_t offset,
+      uint32_t count,
+      uint32_t width,
+      const std::function<void*()>& getOutputNulls = nullptr,
+      const velox::bits::Bitmap* scatterOutputBitmap = nullptr);
 
   /// Simplified decode for thrift decoder: decodes 'count' values to output.
   /// Uses sizeof(T) as width and offset 0.
@@ -102,10 +115,6 @@ class StreamData {
     decode(output, /*offset=*/0, count, sizeof(T));
   }
 
-  /// Reset the stream with new data. Used by thrift decoder between rows.
-  /// @param data New stream data to initialize with.
-  /// @param version Serialization version determining encoding and row count
-  ///        format.
   void reset(std::string_view data, SerializationVersion version);
 
   ScalarKind kind() const {
@@ -114,6 +123,12 @@ class StreamData {
 
   bool hasEncoding() const {
     return encoding_ != nullptr;
+  }
+
+  /// Remaining encoded rows in the current stream segment.
+  uint32_t remainingRows() const {
+    NIMBLE_DCHECK_NOT_NULL(encoding_);
+    return encoding_->rowCount() - readRows_;
   }
 
  private:
@@ -129,11 +144,22 @@ class StreamData {
   // can materialize values on demand.
   void prepareForDecoding(std::string_view data);
 
-  // Returns the number of rows remaining in the encoding.
-  uint32_t remainingRows() const {
-    NIMBLE_CHECK_NOT_NULL(encoding_);
-    return encoding_->rowCount() - readRows_;
-  }
+  // Decode nullable encoded data, optionally using scatterOutputBitmap to map
+  // encoded rows into sparse output positions.
+  uint32_t decodeNullable(
+      void* output,
+      uint32_t offset,
+      uint32_t readCount,
+      uint32_t width,
+      const std::function<void*()>& getOutputNulls,
+      const velox::bits::Bitmap* scatterOutputBitmap);
+
+  // Decode non-null encoded data into dense output positions.
+  void decodeNonNull(
+      void* output,
+      uint32_t offset,
+      uint32_t readCount,
+      uint32_t width);
 
   // Materialize values from nimble encoding to typed output.
   template <typename T>
@@ -156,9 +182,8 @@ class StreamData {
   // Optional pool for encoding scratch buffers. Owned externally
   // (typically by DeserializerImpl) to persist across StreamData lifetimes.
   velox::BufferPool* const bufferPool_{nullptr};
-  // Externally-owned decompression buffer. Always non-null — checked in both
-  // constructors. Owned by DeserializerImpl or thrift Decoder to persist
-  // across StreamData lifetimes.
+  // Externally-owned decompression buffer. Always non-null; owned by
+  // DeserializerImpl or thrift Decoder to persist across StreamData lifetimes.
   velox::BufferPtr* const decompressionBuffer_{nullptr};
 
   const char* pos_{nullptr};
@@ -169,7 +194,7 @@ class StreamData {
   // External storage for string buffers from encoding. Owned by the caller
   // (DeserializerImpl or thrift Decoder). Each buffer is allocated separately
   // to avoid pointer invalidation when the vector grows.
-  std::vector<velox::BufferPtr>* const stringBuffers_;
+  std::vector<velox::BufferPtr>* stringBuffers_;
 };
 
 template <typename T>
@@ -182,9 +207,9 @@ void StreamData::materialize(uint32_t count, T* output) {
   readRows_ += count;
 }
 
-class StreamDataReader {
+class StreamDataParser {
  public:
-  StreamDataReader(
+  StreamDataParser(
       velox::memory::MemoryPool* pool,
       const DeserializerOptions& options);
 
@@ -242,7 +267,8 @@ class StreamDataReader {
       }
       pos_ = end_; // Skip past trailer.
     } else if (nonLegacyFormat(version_)) {
-      // kLegacyCompact/kSerialization/kProjection: sizes-only sparse trailer.
+      // kLegacyCompact/kLegacySerialization/kSerialization/kProjection:
+      // sizes-only sparse trailer.
       // Each stream's body offset is the prefix sum of preceding sizes, so
       // streams are walked sequentially. Production blobs at kLegacyCompact are
       // decoded via the legacy reader (frozen snapshot of the pre-two-array
@@ -281,7 +307,11 @@ class StreamDataReader {
       }
     }
 
-    NIMBLE_CHECK_EQ(pos_, end_, "Unexpected trailing data");
+    NIMBLE_CHECK(
+        pos_ == end_,
+        "Unexpected trailing data: pos={} end={}",
+        reinterpret_cast<uintptr_t>(pos_),
+        reinterpret_cast<uintptr_t>(end_));
   }
 
   /// Returns the auto-detected serialization version.
@@ -290,10 +320,25 @@ class StreamDataReader {
     return version_;
   }
 
+  /// Returns true when Row/FlatMap null streams contain real nulls, forcing
+  /// this batch to be deserialized via the per-batch barrier path. Always
+  /// false for versions without a flags byte. Only valid after initialize().
+  bool requiresNullBarrier() const {
+    return requiresNullBarrier_;
+  }
+
   /// Returns true if nimble encoding is enabled based on the auto-detected
   /// version. Only valid after initialize() has been called.
   bool encodingEnabled() const {
     return nonLegacyFormat(version_);
+  }
+
+  /// Releases owned kTablet stream payload buffers after a decode run consumes
+  /// the string_views returned by iterateStreams(). This does not reset the
+  /// current initialized blob cursor/header because callers may initialize the
+  /// next batch before flushing the previous run.
+  void reset() {
+    strippedStreamBuffers_.clear();
   }
 
   /// Returns the row range embedded in the per-slice header for kTablet
@@ -308,11 +353,13 @@ class StreamDataReader {
   // Strips tablet chunk headers from stream data for kTablet format.
   // Each chunk is: [chunkSize:u32][compressionType:1B][encoded_data...]
   // Returns a view into the original data for single uncompressed chunks
-  // (zero-copy), or a view into chunkStrippingBuffer_ for compressed/
-  // multi-chunk streams.
+  // (zero-copy), or a view into strippedStreamBuffers_ for compressed/
+  // multi-chunk streams. Retained buffers are not cleared by initialize()
+  // because callers may append streams from multiple initialized batches
+  // before decoding the stored views.
   std::string_view stripChunkHeaders(std::string_view streamData);
 
-  // Slow path: decompress/concatenate all chunks into chunkStrippingBuffer_.
+  // Slow path: decompress/concatenate all chunks into an owned buffer.
   std::string_view slowChunkHeaderStrip(const char* pos, const char* end);
 
   // Returns a zero-copy view if the stream is a single uncompressed chunk.
@@ -321,11 +368,23 @@ class StreamDataReader {
       const char* pos,
       const char* end);
 
-  // Appends chunk data to chunkStrippingBuffer_, decompressing if needed.
-  void appendChunkData(
+  // Returns the payload bytes needed after removing per-chunk headers and
+  // expanding compressed chunks.
+  size_t strippedStreamSize(const char* pos, const char* end);
+
+  // Returns the uncompressed byte size for a single chunk payload.
+  size_t decodedChunkSize(
       CompressionType compression,
       const char* data,
       uint32_t length);
+
+  // Copies or decompresses one chunk into output and advances output past the
+  // appended bytes.
+  void appendChunkData(
+      CompressionType compression,
+      const char* data,
+      uint32_t length,
+      char*& output);
 
   const DeserializerOptions& options_;
   velox::memory::MemoryPool* const pool_;
@@ -334,14 +393,19 @@ class StreamDataReader {
   // header, this is read from the first byte; otherwise defaults to kLegacy.
   // When options specify a version, the data version is validated against it.
   SerializationVersion version_{SerializationVersion::kLegacy};
+  // True when Row/FlatMap null streams contain real nulls (read from the header
+  // flags byte). Defaults false for versions without a flags byte.
+  bool requiresNullBarrier_{false};
   // Per-request row range embedded in the kTablet header (post-rowCount,
   // before stream data). nullopt for non-kTablet formats or when the
   // producer did not embed a row range.
   std::optional<RowRange> rowRange_;
   const char* pos_{nullptr};
   const char* end_{nullptr};
-  // Reusable buffer for chunk header stripping (compressed/multi-chunk case).
-  Vector<char> chunkStrippingBuffer_;
+  // Owns slow-stripped kTablet stream payloads returned as string_views.
+  // A deserializer can append several batches before materializing the run,
+  // so each slow-stripped stream gets a stable backing allocation.
+  std::vector<velox::BufferPtr> strippedStreamBuffers_;
   // Reusable parallel buffers for the per-blob trailer. Refilled by
   // iterateStreams(): streamIds_ holds the ids of non-zero stream slots (sorted
   // ascending) and streamSizes_ their byte sizes. For kTablet,

--- a/dwio/nimble/serializer/Options.cpp
+++ b/dwio/nimble/serializer/Options.cpp
@@ -26,12 +26,14 @@ std::string toString(SerializationVersion version) {
       return "kLegacy";
     case SerializationVersion::kLegacyCompact:
       return "kLegacyCompact";
-    case SerializationVersion::kTablet:
-      return "kTablet";
+    case SerializationVersion::kLegacySerialization:
+      return "kLegacySerialization";
     case SerializationVersion::kSerialization:
       return "kSerialization";
     case SerializationVersion::kProjection:
       return "kProjection";
+    case SerializationVersion::kTablet:
+      return "kTablet";
     default:
       NIMBLE_FAIL(
           "Unknown SerializationVersion: {}", static_cast<int>(version));
@@ -75,7 +77,7 @@ SerializationVersion SerializerOptions::serializationVersion() const {
 }
 
 bool SerializerOptions::enableEncoding() const {
-  return isCompactFormat(serializationVersion());
+  return nonLegacyFormat(serializationVersion());
 }
 
 } // namespace facebook::nimble

--- a/dwio/nimble/serializer/Options.h
+++ b/dwio/nimble/serializer/Options.h
@@ -47,104 +47,60 @@ namespace facebook::nimble {
 ///   Wire: [version:1B][rowCount:varint][stream_data_0]...[stream_data_N]
 ///         [encodingByte:1B][denseSizes:u32[]|sparsePair]
 ///         [trailer_size:u32]
-///   New writers must NOT emit kLegacyCompact — Serializer rejects it; use
-///   kSerialization (Serializer default) or kProjection (Projector default).
+///   Serializer upgrades new kLegacyCompact writes to kSerialization.
 ///
-/// - kTablet: Tablet stream passthrough format. Like kSerialization but:
-///   (1) Each stream's data includes tablet chunk headers:
-///       [chunkSize:u32][compressionType:1B][encoded_data...]
-///       which the Deserializer strips before decoding.
-///   (2) Encoding headers within streams use fixed u32 row counts
-///       (useVarintRowCount=false), matching the tablet's default format.
-///   Wire: same two-array sparse trailer layout as kSerialization.
+/// - kLegacySerialization: READ-ONLY old encoded Serializer format. Uses the
+///   two-array sparse trailer and [version:1B][rowCount:varint], without a
+///   header flags byte. Serializer upgrades new writes to kSerialization.
 ///
-/// - kSerialization / kProjection: New writer versions using the two-array
-///   sparse trailer. Wire body identical to kLegacyCompact; trailer is:
+/// - kSerialization / kProjection: Writer versions using the two-array sparse
+///   trailer. Wire body identical to kLegacySerialization; trailer is:
+///   [version:1B][rowCount:varint][flags:1B][stream_data...]
 ///   [indicesEncType:1B][indicesPayload]
 ///   [sizesEncType:1B][sizesPayload]
 ///   [trailer_size:u32]
 ///   trailer_size = 2 + len(indicesPayload) + len(sizesPayload).
 ///   Indices and sizes axes independently choose from EncodingTypes
 ///   {Trivial, Varint, Delta, FixedBitWidth}. See getTrailerEncodingType()
-///   for validation. kSerialization is the Serializer's default writer
-///   version; kProjection is the Projector's. Same wire format today; the
-///   distinct version bytes let the two writers evolve independently.
+///   for validation. kSerialization is the Serializer writer version and
+///   kProjection is the Projector writer version. Both carry a compact-header
+///   flags byte after the row count.
+///
+/// - kTablet: Tablet stream passthrough format. Like kSerialization but:
+///   (1) Chunk slice headers are:
+///       [version:1B][rowCount:varint][flags:1B][rowRange/resumeKey...]
+///   (2) Each stream's data includes tablet chunk headers:
+///       [chunkSize:u32][compressionType:1B][encoded_data...]
+///       which the Deserializer strips before decoding.
+///   (3) Encoding headers within streams use fixed u32 row counts
+///       (useVarintRowCount=false), matching the tablet's default format.
+///   Wire: same two-array sparse trailer layout as kSerialization.
 enum class SerializationVersion : uint8_t {
   kLegacy = 0,
   // READ-ONLY post the two-array trailer change: production blobs with this
-  // version byte are still decoded via `nimble::serde::legacy::`, but writers
-  // must not emit it. New Serializer writers emit kSerialization;
-  // new Projector writers emit kProjection.
+  // version byte are still decoded via `nimble::serde::legacy::`. New
+  // Serializer writes are upgraded to kSerialization; Projector writers emit
+  // kProjection.
   kLegacyCompact = 2,
-  // Deprecated alias for kLegacyCompact; kept so call sites that still spell
-  // the old name keep compiling while they migrate. Same numeric value as
-  // kLegacyCompact, so existing wire-format checks and read paths are
-  // unaffected. New code should use kLegacyCompact (read) or kSerialization /
-  // kProjection (write).
-  kCompactRaw = 2,
-  // Default writer version for the Serializer: two-array sparse trailer.
-  kSerialization = 3,
+  // Source-level migration spelling for the old non-nullable encoded
+  // serializer wire format. Serializer upgrades new writes to kSerialization.
+  kLegacySerialization = 3,
+  // Default writer version for the Serializer: null-capable two-array sparse
+  // trailer with a compact-header flags byte.
+  kSerialization = 4,
   // Default writer version for the Projector: two-array sparse trailer.
   // Same wire format as kSerialization today; the distinct version byte lets
   // the two writers' formats evolve independently in the future.
-  kProjection = 4,
-  // Renumbered from 3 to 5: no production kTablet blobs existed at value 3,
-  // so the lower-numbered slots are reclaimed for the more common new writer
-  // versions (kSerialization / kProjection).
-  kTablet = 5,
+  kProjection = 5,
+  kTablet = 6,
 };
 
 std::string toString(SerializationVersion version);
 
-/// Returns true if the version is any non-legacy format (kLegacyCompact or
-/// kTablet). All non-legacy formats have a version header, encoded streams,
-/// and a stream sizes trailer.
+/// Returns true if the version is any non-legacy format. All non-legacy
+/// formats have a version header, encoded streams, and a stream sizes trailer.
 inline bool nonLegacyFormat(SerializationVersion version) {
   return version != SerializationVersion::kLegacy;
-}
-
-/// Returns true if the version uses compact encoding (kLegacyCompact,
-/// kSerialization, or kProjection). Note: kTablet is NOT a compact format
-/// (has chunk headers in streams).
-inline bool isCompactFormat(SerializationVersion version) {
-  return version == SerializationVersion::kLegacyCompact ||
-      version == SerializationVersion::kSerialization ||
-      version == SerializationVersion::kProjection;
-}
-
-/// Returns true if the version uses raw stream sizes (kLegacyCompact, kTablet,
-/// kSerialization, or kProjection) instead of nimble-encoded stream sizes.
-inline bool isRawFormat(SerializationVersion version) {
-  return version == SerializationVersion::kLegacyCompact ||
-      version == SerializationVersion::kTablet ||
-      version == SerializationVersion::kSerialization ||
-      version == SerializationVersion::kProjection;
-}
-
-/// Returns true if the version was written using the legacy kLegacyCompact
-/// trailer format (decoded via `nimble::serde::legacy::`). All other
-/// non-legacy formats (kTablet, kSerialization, kProjection) use the new
-/// two-array sparse trailer.
-///
-/// kTablet is included here today because in master kTablet and kLegacyCompact
-/// produce byte-identical trailer layouts (single encoding-type byte +
-/// payload + trailer-size u32) and the same reader code path handles both.
-/// Treating kTablet as legacy in this diff keeps the refactor purely
-/// behavior-preserving.
-///
-/// The next diff (the two-array sparse trailer change) migrates kTablet
-/// onto the new trailer wire format alongside the new kSerialization /
-/// kProjection versions, and this helper will be narrowed to return true
-/// only for kLegacyCompact. kLegacyCompact is the only version frozen forever
-/// here because it is the only one with existing production blobs that
-/// must remain readable.
-inline bool usesLegacyTrailer(SerializationVersion version) {
-  return version == SerializationVersion::kLegacyCompact;
-}
-
-/// Returns true if the optional version uses raw stream sizes.
-inline bool isRawFormat(std::optional<SerializationVersion> version) {
-  return version.has_value() && isRawFormat(version.value());
 }
 
 /// Returns true if the version is the tablet passthrough format.
@@ -152,14 +108,49 @@ inline bool isTabletVersion(SerializationVersion version) {
   return version == SerializationVersion::kTablet;
 }
 
+/// Returns true if the version was written using the legacy kLegacyCompact
+/// trailer format (decoded via `nimble::serde::legacy::`). All other
+/// non-legacy formats (kLegacySerialization, kTablet, kSerialization,
+/// kProjection) use the new two-array sparse trailer.
+///
+/// kLegacyCompact is the only frozen version here because it is the only one
+/// with existing production blobs that must keep using the legacy trailer
+/// reader.
+inline bool usesLegacyTrailer(SerializationVersion version) {
+  return version == SerializationVersion::kLegacyCompact;
+}
+
+/// Returns true if the version is a null-capable format that carries a
+/// per-batch null-barrier flag and is therefore eligible for the dense-batch
+/// concat / null barrier read path.
+inline bool isNullableFormat(SerializationVersion version) {
+  return version == SerializationVersion::kSerialization ||
+      version == SerializationVersion::kProjection ||
+      version == SerializationVersion::kTablet;
+}
+
+/// Returns true if the optional version is a null-capable format.
+inline bool isNullableFormat(std::optional<SerializationVersion> version) {
+  return version.has_value() && isNullableFormat(version.value());
+}
+
+/// Returns true if the version's compact header carries a flags byte after the
+/// row count. kTablet carries its flag in the tablet chunk header instead;
+/// kLegacy, the frozen kLegacyCompact, and kLegacySerialization have no flags
+/// byte.
+inline bool usesHeaderFlags(SerializationVersion version) {
+  return version == SerializationVersion::kSerialization ||
+      version == SerializationVersion::kProjection;
+}
+
+/// Returns true if the optional version's compact header carries a flags byte.
+inline bool usesHeaderFlags(std::optional<SerializationVersion> version) {
+  return version.has_value() && usesHeaderFlags(version.value());
+}
+
 /// Returns true if the version is the tablet passthrough format.
 inline bool isTabletVersion(std::optional<SerializationVersion> version) {
   return version.has_value() && isTabletVersion(version.value());
-}
-
-/// Returns true if the optional version uses compact encoding.
-inline bool isCompactFormat(std::optional<SerializationVersion> version) {
-  return version.has_value() && isCompactFormat(version.value());
 }
 
 /// Returns true if the version uses varint for the header row count.
@@ -192,21 +183,20 @@ inline std::ostream& operator<<(
 EncodingSelectionPolicyCreator defaultEncodingSelectionPolicyCreator();
 
 struct SerializerOptions {
-  /// Legacy (kLegacy) compression settings. These only apply when version is
-  /// kLegacy or nullopt. For kLegacyCompact, compression is controlled by
-  /// 'compressionOptions' below.
+  /// Legacy compression settings. These only apply when version is kLegacy or
+  /// nullopt. Encoded formats handle compression through the encoding selection
+  /// policy.
   CompressionType compressionType{CompressionType::Uncompressed};
   uint32_t compressionThreshold{0};
   int32_t compressionLevel{0};
 
   /// Serialization format version.
-  /// - nullopt (default): Legacy format with no version header (kLegacy).
-  /// - kLegacy: Legacy compression format.
-  /// - kSerialization: Default Serializer writer; two-array sparse trailer.
-  /// - kLegacyCompact: READ-ONLY post the two-array trailer change. Existing
-  ///   production blobs at this version are decoded via
-  ///   `nimble::serde::legacy::` but the Serializer constructor REJECTS this
-  ///   value for new writes — use kSerialization instead.
+  /// - nullopt: Legacy format with no version header.
+  /// - kSerialization: Encoded Serializer format.
+  /// - kLegacy / kLegacyCompact / kLegacySerialization: Legacy spellings for
+  ///   migration. Existing kLegacyCompact production blobs are decoded via
+  ///   `nimble::serde::legacy::`; new Serializer writes are upgraded to
+  ///   kSerialization while callers migrate.
   /// - kProjection / kTablet are not valid Serializer writer versions
   ///   (Projector + tablet pipelines write them, respectively).
   std::optional<SerializationVersion> version{};
@@ -220,7 +210,7 @@ struct SerializerOptions {
   folly::F14FastMap<std::string, std::set<std::string>> flatMapColumns{};
 
   /// Factory for creating encoding selection policies.
-  /// Only used when version is kLegacyCompact.
+  /// Used by encoded serializer writes.
   /// When encodingLayoutTree is specified, used as fallback for streams or
   /// nested encodings not captured in the layout tree. When encodingLayoutTree
   /// is not specified, used directly for all streams.
@@ -263,7 +253,7 @@ struct SerializerOptions {
   /// Returns the effective serialization version.
   SerializationVersion serializationVersion() const;
 
-  /// Returns true if nimble encoding is enabled (version is kLegacyCompact).
+  /// Returns true if nimble encoding is enabled.
   bool enableEncoding() const;
 };
 

--- a/dwio/nimble/serializer/Projector.cpp
+++ b/dwio/nimble/serializer/Projector.cpp
@@ -88,6 +88,28 @@ uint32_t readVarint32(folly::io::Cursor& cursor) {
   }
 }
 
+inline void setNullBarrierRequiredFlag(
+    folly::IOBuf& header,
+    size_t flagsOffset,
+    bool outputRequiresNullBarrier) {
+  NIMBLE_CHECK_LT(flagsOffset, header.length(), "Invalid flags byte offset");
+  header.writableData()[flagsOffset] =
+      detail::makeFlagsByte(outputRequiresNullBarrier);
+}
+
+inline void updateRequiresNullBarrier(
+    bool inputRequiresNullBarrier,
+    uint32_t streamSize,
+    const std::vector<bool>& rowOrFlatMapNullStreams,
+    size_t outputStreamIdx,
+    bool& outputRequiresNullBarrier) {
+  if (!inputRequiresNullBarrier || streamSize == 0) {
+    return;
+  }
+  NIMBLE_DCHECK_LT(outputStreamIdx, rowOrFlatMapNullStreams.size());
+  outputRequiresNullBarrier |= rowOrFlatMapNullStreams[outputStreamIdx];
+}
+
 // Forward declaration for recursive calls from per-type helpers.
 std::shared_ptr<const Type> updateColumnNames(
     const std::shared_ptr<const Type>& inputType,
@@ -300,7 +322,14 @@ Projector::Projector(
   }
 
   projectedSchema_ = buildProjectedNimbleType(
-      inputSchema_.get(), projectSubfields, inputStreamIndices_);
+      inputSchema_.get(),
+      projectSubfields,
+      inputStreamIndices_,
+      rowOrFlatMapNullStreams_);
+  NIMBLE_CHECK_EQ(
+      inputStreamIndices_.size(),
+      rowOrFlatMapNullStreams_.size(),
+      "Projected stream indices and Row/FlatMap null stream mask must align");
 
   inputStreamsSorted_ =
       std::is_sorted(inputStreamIndices_.begin(), inputStreamIndices_.end());
@@ -321,15 +350,22 @@ Projector::Projector(
 
 namespace {
 
-// Validates the input version header is a supported compact format
-// (kLegacyCompact via legacy reader, or kSerialization/kProjection via new
-// reader). kTablet is rejected — chunk headers are not handled by the
-// Projector.
+bool isProjectorInputVersion(SerializationVersion version) {
+  return version == SerializationVersion::kLegacyCompact ||
+      version == SerializationVersion::kLegacySerialization ||
+      version == SerializationVersion::kSerialization ||
+      version == SerializationVersion::kProjection;
+}
+
+// Validates the input version header is a supported compact non-tablet format.
+// kLegacyCompact is read via the legacy reader; kLegacySerialization,
+// kSerialization, and kProjection use the two-array sparse trailer reader.
+// kTablet is rejected because the Projector does not strip chunk headers.
 SerializationVersion getAndValidateInputVersion(const folly::IOBuf& input) {
   const auto version = static_cast<SerializationVersion>(*input.data());
   NIMBLE_CHECK(
-      isCompactFormat(version),
-      "Input must be a compact format (kLegacyCompact/kSerialization/kProjection), got: {}",
+      isProjectorInputVersion(version),
+      "Input must be kLegacyCompact, kLegacySerialization, kSerialization, or kProjection; got: {}",
       version);
   return version;
 }
@@ -352,6 +388,9 @@ std::vector<uint32_t> Projector::projectStreamsContiguousUnsorted(
     const std::vector<uint32_t>& streamIndices,
     const std::vector<uint32_t>& streamSizes,
     const std::vector<uint32_t>& selectedStreamIndices,
+    bool inputRequiresNullBarrier,
+    const std::vector<bool>& rowOrFlatMapNullStreams,
+    bool& outputRequiresNullBarrier,
     std::unique_ptr<folly::IOBuf>& output) {
   std::vector<uint32_t> outputSizes(selectedStreamIndices.size(), 0);
 
@@ -384,10 +423,10 @@ std::vector<uint32_t> Projector::projectStreamsContiguousUnsorted(
   };
 
   // Walk selectedStreamIndices in output order; binary-search sparse
-  // streamIndices for each. Selected streams absent from the sparse trailer
-  // keep outputSizes at 0 and contribute zero bytes, so they can sit inside
-  // a run without breaking byte-contiguity for the next present selected
-  // stream.
+  // streamIndices for each. Selected streams absent from the sparse trailer or
+  // present with size 0 keep outputSizes at 0 and contribute zero bytes, so
+  // they can sit inside a run without breaking byte-contiguity for the next
+  // present selected stream.
   for (size_t i = 0; i < selectedStreamIndices.size(); ++i) {
     const auto inputStreamIdx = selectedStreamIndices[i];
     const auto it = std::lower_bound(
@@ -401,6 +440,12 @@ std::vector<uint32_t> Projector::projectStreamsContiguousUnsorted(
     const auto streamOffset = streamOffsets[sparsePosition];
     outputSizes[i] = streamSize;
     // NOLINTEND(facebook-hte-LocalUncheckedArrayBounds)
+    updateRequiresNullBarrier(
+        inputRequiresNullBarrier,
+        streamSize,
+        rowOrFlatMapNullStreams,
+        i,
+        outputRequiresNullBarrier);
     if (numRunBytes > 0 && streamOffset == runStart + numRunBytes) {
       numRunBytes += streamSize;
     } else {
@@ -424,6 +469,9 @@ std::vector<uint32_t> Projector::projectStreamsContiguousSorted(
     const std::vector<uint32_t>& streamIndices,
     const std::vector<uint32_t>& streamSizes,
     const std::vector<uint32_t>& selectedStreamIndices,
+    bool inputRequiresNullBarrier,
+    const std::vector<bool>& rowOrFlatMapNullStreams,
+    bool& outputRequiresNullBarrier,
     std::unique_ptr<folly::IOBuf>& output) {
   std::vector<uint32_t> outputSizes(selectedStreamIndices.size(), 0);
 
@@ -467,15 +515,22 @@ std::vector<uint32_t> Projector::projectStreamsContiguousSorted(
     }
     // Match.
     // NOLINTBEGIN(facebook-hte-LocalUncheckedArrayBounds)
-    outputSizes[selectedPosition] = streamSizes[sparsePosition];
+    const auto streamSize = streamSizes[sparsePosition];
+    outputSizes[selectedPosition] = streamSize;
+    updateRequiresNullBarrier(
+        inputRequiresNullBarrier,
+        streamSize,
+        rowOrFlatMapNullStreams,
+        selectedPosition,
+        outputRequiresNullBarrier);
     if (numRunBytes > 0 && currentOffset == runStart + numRunBytes) {
-      numRunBytes += streamSizes[sparsePosition];
+      numRunBytes += streamSize;
     } else {
       flushRun();
       runStart = currentOffset;
-      numRunBytes = streamSizes[sparsePosition];
+      numRunBytes = streamSize;
     }
-    currentOffset += streamSizes[sparsePosition];
+    currentOffset += streamSize;
     // NOLINTEND(facebook-hte-LocalUncheckedArrayBounds)
     ++sparsePosition;
     ++selectedPosition;
@@ -495,6 +550,9 @@ std::vector<uint32_t> Projector::projectStreamsChainedSorted(
     const std::vector<uint32_t>& streamIndices,
     const std::vector<uint32_t>& streamSizes,
     const std::vector<uint32_t>& selectedStreamIndices,
+    bool inputRequiresNullBarrier,
+    const std::vector<bool>& rowOrFlatMapNullStreams,
+    bool& outputRequiresNullBarrier,
     std::unique_ptr<folly::IOBuf>& output) {
   std::vector<uint32_t> outputSizes(selectedStreamIndices.size(), 0);
 
@@ -535,8 +593,15 @@ std::vector<uint32_t> Projector::projectStreamsChainedSorted(
     }
     // Match: accumulate into the current run.
     // NOLINTBEGIN(facebook-hte-LocalUncheckedArrayBounds)
-    outputSizes[selectedPosition] = streamSizes[sparsePosition];
-    numRunBytes += streamSizes[sparsePosition];
+    const auto streamSize = streamSizes[sparsePosition];
+    outputSizes[selectedPosition] = streamSize;
+    updateRequiresNullBarrier(
+        inputRequiresNullBarrier,
+        streamSize,
+        rowOrFlatMapNullStreams,
+        selectedPosition,
+        outputRequiresNullBarrier);
+    numRunBytes += streamSize;
     // NOLINTEND(facebook-hte-LocalUncheckedArrayBounds)
     ++sparsePosition;
     ++selectedPosition;
@@ -558,6 +623,9 @@ std::vector<uint32_t> Projector::projectStreamsChainedUnsorted(
     const std::vector<uint32_t>& streamIndices,
     const std::vector<uint32_t>& streamSizes,
     const std::vector<StreamMapping>& sortedStreamMappings,
+    bool inputRequiresNullBarrier,
+    const std::vector<bool>& rowOrFlatMapNullStreams,
+    bool& outputRequiresNullBarrier,
     std::unique_ptr<folly::IOBuf>& output) {
   std::vector<uint32_t> outputSizes(sortedStreamMappings.size(), 0);
 
@@ -607,9 +675,16 @@ std::vector<uint32_t> Projector::projectStreamsChainedUnsorted(
             runOutputStreamIdx + numRunStreams) {
       // NOLINTBEGIN(facebook-hte-LocalUncheckedArrayBounds)
       const auto streamSize = streamSizes[sparsePosition + numRunStreams];
-      outputSizes[runOutputStreamIdx + numRunStreams] = streamSize;
-      // NOLINTEND(facebook-hte-LocalUncheckedArrayBounds)
+      const auto outputStreamIdx = runOutputStreamIdx + numRunStreams;
+      outputSizes[outputStreamIdx] = streamSize;
+      updateRequiresNullBarrier(
+          inputRequiresNullBarrier,
+          streamSize,
+          rowOrFlatMapNullStreams,
+          outputStreamIdx,
+          outputRequiresNullBarrier);
       numRunBytes += streamSize;
+      // NOLINTEND(facebook-hte-LocalUncheckedArrayBounds)
       ++numRunStreams;
     }
 
@@ -669,11 +744,13 @@ folly::IOBuf Projector::projectContiguous(
   // Skip version byte (already validated and passed in).
   const auto* pos = data + sizeof(uint8_t);
   const uint32_t rowCount = varint::readVarint32(&pos);
+  const bool inputRequiresNullBarrier =
+      readRequiresNullBarrierFlag(pos, inputVersion);
 
-  // Build header: [version byte][varint rowCount].
   IOBufSection header(
       estimateSerializationHeaderSize(options_.projectVersion, rowCount));
-  writeSerializationHeader(header, options_.projectVersion, rowCount);
+  const auto flagsOffset =
+      writeSerializationHeader(header, options_.projectVersion, rowCount);
   auto output = std::move(header).build();
 
   // Dispatch on input version: legacy kLegacyCompact blobs are read via the
@@ -685,21 +762,32 @@ folly::IOBuf Projector::projectContiguous(
 
   // Extract selected streams as zero-copy sub-range clones.
   const auto dataOffset = static_cast<size_t>(pos - data);
-  auto outputStreamSizes = inputStreamsSorted_
-      ? projectStreamsContiguousSorted(
-            input,
-            dataOffset,
-            streamIndices,
-            streamSizes,
-            inputStreamIndices_,
-            output)
-      : projectStreamsContiguousUnsorted(
-            input,
-            dataOffset,
-            streamIndices,
-            streamSizes,
-            inputStreamIndices_,
-            output);
+  bool outputRequiresNullBarrier = false;
+  std::vector<uint32_t> outputStreamSizes;
+  if (inputStreamsSorted_) {
+    outputStreamSizes = projectStreamsContiguousSorted(
+        input,
+        dataOffset,
+        streamIndices,
+        streamSizes,
+        inputStreamIndices_,
+        inputRequiresNullBarrier,
+        rowOrFlatMapNullStreams_,
+        outputRequiresNullBarrier,
+        output);
+  } else {
+    outputStreamSizes = projectStreamsContiguousUnsorted(
+        input,
+        dataOffset,
+        streamIndices,
+        streamSizes,
+        inputStreamIndices_,
+        inputRequiresNullBarrier,
+        rowOrFlatMapNullStreams_,
+        outputRequiresNullBarrier,
+        output);
+  }
+  setNullBarrierRequiredFlag(*output, flagsOffset, outputRequiresNullBarrier);
 
   return buildProjectedOutput(outputStreamSizes, std::move(output));
 }
@@ -711,11 +799,13 @@ folly::IOBuf Projector::projectChained(
   // Skip version byte (already validated and passed in).
   cursor.skip(sizeof(uint8_t));
   const uint32_t rowCount = readVarint32(cursor);
+  const bool inputRequiresNullBarrier =
+      readRequiresNullBarrierFlag(cursor, inputVersion);
 
-  // Build header: [version byte][varint rowCount].
   IOBufSection header(
       estimateSerializationHeaderSize(options_.projectVersion, rowCount));
-  writeSerializationHeader(header, options_.projectVersion, rowCount);
+  const auto flagsOffset =
+      writeSerializationHeader(header, options_.projectVersion, rowCount);
   auto output = std::move(header).build();
 
   // Dispatch on input version: legacy kLegacyCompact blobs are read via the
@@ -726,11 +816,30 @@ folly::IOBuf Projector::projectChained(
       : detail::readTrailerStreamMetadata(input);
 
   // Extract selected streams as zero-copy clones via cursor.
-  auto outputStreamSizes = inputStreamsSorted_
-      ? projectStreamsChainedSorted(
-            cursor, streamIndices, streamSizes, inputStreamIndices_, output)
-      : projectStreamsChainedUnsorted(
-            cursor, streamIndices, streamSizes, sortedStreamMappings_, output);
+  bool outputRequiresNullBarrier = false;
+  std::vector<uint32_t> outputStreamSizes;
+  if (inputStreamsSorted_) {
+    outputStreamSizes = projectStreamsChainedSorted(
+        cursor,
+        streamIndices,
+        streamSizes,
+        inputStreamIndices_,
+        inputRequiresNullBarrier,
+        rowOrFlatMapNullStreams_,
+        outputRequiresNullBarrier,
+        output);
+  } else {
+    outputStreamSizes = projectStreamsChainedUnsorted(
+        cursor,
+        streamIndices,
+        streamSizes,
+        sortedStreamMappings_,
+        inputRequiresNullBarrier,
+        rowOrFlatMapNullStreams_,
+        outputRequiresNullBarrier,
+        output);
+  }
+  setNullBarrierRequiredFlag(*output, flagsOffset, outputRequiresNullBarrier);
 
   return buildProjectedOutput(outputStreamSizes, std::move(output));
 }

--- a/dwio/nimble/serializer/Projector.h
+++ b/dwio/nimble/serializer/Projector.h
@@ -164,6 +164,13 @@ class Projector {
       const folly::IOBuf& input,
       SerializationVersion inputVersion) const;
 
+  // The stream projection helpers return output stream sizes. Size-zero
+  // streams remain zero slots in the returned vector and are omitted by the
+  // trailer writer. outputRequiresNullBarrier is set only when a copied stream
+  // has bytes, inputRequiresNullBarrier is true, and its corresponding
+  // rowOrFlatMapNullStreams entry is true. rowOrFlatMapNullStreams is parallel
+  // to output stream indices.
+
   // Projects selected streams from a contiguous IOBuf in unsorted order.
   // Walks selectedStreamIndices in output order; for each, binary-searches the
   // sparse (streamIndices, streamSizes) trailer for the corresponding bytes.
@@ -175,6 +182,9 @@ class Projector {
       const std::vector<uint32_t>& streamIndices,
       const std::vector<uint32_t>& streamSizes,
       const std::vector<uint32_t>& selectedStreamIndices,
+      bool inputRequiresNullBarrier,
+      const std::vector<bool>& rowOrFlatMapNullStreams,
+      bool& outputRequiresNullBarrier,
       std::unique_ptr<folly::IOBuf>& output);
 
   // Projects selected streams from a contiguous IOBuf in sorted order.
@@ -186,6 +196,9 @@ class Projector {
       const std::vector<uint32_t>& streamIndices,
       const std::vector<uint32_t>& streamSizes,
       const std::vector<uint32_t>& selectedStreamIndices,
+      bool inputRequiresNullBarrier,
+      const std::vector<bool>& rowOrFlatMapNullStreams,
+      bool& outputRequiresNullBarrier,
       std::unique_ptr<folly::IOBuf>& output);
 
   // Projects selected streams from a chained IOBuf in sorted order.
@@ -196,6 +209,9 @@ class Projector {
       const std::vector<uint32_t>& streamIndices,
       const std::vector<uint32_t>& streamSizes,
       const std::vector<uint32_t>& selectedStreamIndices,
+      bool inputRequiresNullBarrier,
+      const std::vector<bool>& rowOrFlatMapNullStreams,
+      bool& outputRequiresNullBarrier,
       std::unique_ptr<folly::IOBuf>& output);
 
   // Projects selected streams from a chained IOBuf in unsorted order.
@@ -206,6 +222,9 @@ class Projector {
       const std::vector<uint32_t>& streamIndices,
       const std::vector<uint32_t>& streamSizes,
       const std::vector<StreamMapping>& sortedStreamMappings,
+      bool inputRequiresNullBarrier,
+      const std::vector<bool>& rowOrFlatMapNullStreams,
+      bool& outputRequiresNullBarrier,
       std::unique_ptr<folly::IOBuf>& output);
 
   // Appends the trailer to the output IOBuf chain and returns it.
@@ -220,6 +239,9 @@ class Projector {
   // Built during construction.
   std::shared_ptr<const Type> projectedSchema_;
   std::vector<uint32_t> inputStreamIndices_;
+  // Parallel to inputStreamIndices_ and output stream indices. A true entry
+  // means the projected stream is a Row or FlatMap null stream.
+  std::vector<bool> rowOrFlatMapNullStreams_;
 
   // True when inputStreamIndices_ is already sorted (no FlatMap key
   // reordering). Enables fast-path projection that avoids sorting and

--- a/dwio/nimble/serializer/SerializationHeader.cpp
+++ b/dwio/nimble/serializer/SerializationHeader.cpp
@@ -22,9 +22,28 @@ namespace facebook::nimble::serde {
 
 namespace {
 
+inline SerializationVersion validateVersion(uint8_t versionByte) {
+  const auto version = static_cast<SerializationVersion>(versionByte);
+  NIMBLE_CHECK(
+      version == SerializationVersion::kLegacy ||
+          version == SerializationVersion::kLegacyCompact ||
+          version == SerializationVersion::kLegacySerialization ||
+          version == SerializationVersion::kTablet ||
+          version == SerializationVersion::kSerialization ||
+          version == SerializationVersion::kProjection,
+      "Unsupported version {}",
+      versionByte);
+  return version;
+}
+
 TabletChunkHeader extractTabletChunkHeader(const char*& pos, const char* end) {
   TabletChunkHeader header;
+
   header.rowCount = varint::readVarint32(&pos);
+
+  NIMBLE_CHECK_GT(end, pos, "Truncated chunk header (flags)");
+  header.requiresNullBarrier =
+      detail::nullBarrierRequired(static_cast<uint8_t>(*pos++));
 
   const uint32_t startRow = varint::readVarint32(&pos);
   const uint32_t endRow = varint::readVarint32(&pos);
@@ -58,30 +77,28 @@ readSerializationHeader(const char*& pos, const char* end, bool hasHeader) {
   SerializationHeader header;
 
   if (hasHeader) {
-    header.version = static_cast<SerializationVersion>(*pos);
-    NIMBLE_CHECK(
-        header.version == SerializationVersion::kLegacy ||
-            header.version == SerializationVersion::kLegacyCompact ||
-            header.version == SerializationVersion::kTablet ||
-            header.version == SerializationVersion::kSerialization ||
-            header.version == SerializationVersion::kProjection,
-        "Unsupported version {}",
-        static_cast<uint8_t>(header.version));
-    ++pos;
+    NIMBLE_CHECK_GE(end - pos, 1, "Truncated header (version)");
+    header.version = validateVersion(static_cast<uint8_t>(*pos++));
   }
 
   if (isTabletVersion(header.version)) {
     auto tablet = extractTabletChunkHeader(pos, end);
     header.rowCount = tablet.rowCount;
+    header.requiresNullBarrier = tablet.requiresNullBarrier;
     // TODO: consider setting rowRange to nullopt when it covers the full
     // stripe (startRow==0 && endRow==rowCount) to let consumers skip the
     // range check.
     header.rowRange = tablet.rowRange;
-  } else if (usesVarintRowCount(header.version)) {
+    return header;
+  }
+
+  if (usesVarintRowCount(header.version)) {
     header.rowCount = varint::readVarint32(&pos);
   } else {
     header.rowCount = encoding::readUint32(pos);
   }
+
+  header.requiresNullBarrier = readRequiresNullBarrierFlag(pos, header.version);
 
   return header;
 }
@@ -99,7 +116,7 @@ folly::IOBuf createTabletChunkHeader(const TabletChunkHeader& header) {
       ? static_cast<uint32_t>(header.resumeKey->size() + 1)
       : 0;
   size_t headerBytes = /*version=*/sizeof(uint8_t) +
-      varint::varintSize(header.rowCount) +
+      varint::varintSize(header.rowCount) + /*flags=*/sizeof(uint8_t) +
       varint::varintSize(header.rowRange.startRow) +
       varint::varintSize(header.rowRange.endRow) +
       varint::varintSize(resumeKeyLength);
@@ -111,6 +128,7 @@ folly::IOBuf createTabletChunkHeader(const TabletChunkHeader& header) {
   auto* pos = reinterpret_cast<char*>(buf->writableData());
   *pos++ = static_cast<char>(SerializationVersion::kTablet);
   varint::writeVarint(/*val=*/header.rowCount, &pos);
+  *pos++ = static_cast<char>(detail::makeFlagsByte(header.requiresNullBarrier));
   varint::writeVarint(/*val=*/header.rowRange.startRow, &pos);
   varint::writeVarint(/*val=*/header.rowRange.endRow, &pos);
   varint::writeVarint(/*val=*/resumeKeyLength, &pos);

--- a/dwio/nimble/serializer/SerializationHeader.h
+++ b/dwio/nimble/serializer/SerializationHeader.h
@@ -16,6 +16,7 @@
 
 #pragma once
 
+#include <cstddef>
 #include <cstdint>
 #include <optional>
 #include <string>
@@ -25,6 +26,7 @@
 #include "dwio/nimble/encodings/common/EncodingPrimitives.h"
 #include "dwio/nimble/serializer/Options.h"
 #include "dwio/nimble/velox/RowRange.h"
+#include "folly/io/Cursor.h"
 #include "folly/io/IOBuf.h"
 
 namespace facebook::nimble::serde {
@@ -33,8 +35,19 @@ namespace facebook::nimble::serde {
 
 /// Parsed serialization header common to all versions.
 struct SerializationHeader {
+  /// Header flags byte layout. bit0 is set when the serialized batch contains
+  /// Row/FlatMap null streams with real nulls. Readers treat this as a null
+  /// barrier and decode the batch through the per-batch path instead of the
+  /// dense concat fast path. The remaining bits are reserved for future use.
+  static constexpr uint8_t kNullBarrierRequiredFlag{0x01};
+
   SerializationVersion version{SerializationVersion::kLegacy};
   uint32_t rowCount{0};
+  /// True when Row/FlatMap null streams contain real nulls, forcing readers to
+  /// treat this batch as a null barrier instead of using dense concat. Always
+  /// false for versions without a flags byte (kLegacy, kLegacyCompact,
+  /// kLegacySerialization).
+  bool requiresNullBarrier{false};
   /// Row range embedded in kTablet headers. nullopt for other versions.
   std::optional<RowRange> rowRange;
 };
@@ -48,7 +61,48 @@ char* extend(T& buffer, uint32_t size) {
   return buffer.data() + oldSize;
 }
 
+inline uint8_t makeFlagsByte(bool requiresNullBarrier) {
+  return requiresNullBarrier ? SerializationHeader::kNullBarrierRequiredFlag
+                             : 0;
+}
+
+inline bool nullBarrierRequired(uint8_t flagsByte) {
+  return (flagsByte & SerializationHeader::kNullBarrierRequiredFlag) != 0;
+}
+
 } // namespace detail
+
+inline bool readRequiresNullBarrierFlag(
+    const char*& pos,
+    std::optional<SerializationVersion> version) {
+  if (!usesHeaderFlags(version)) {
+    return false;
+  }
+  return detail::nullBarrierRequired(static_cast<uint8_t>(*pos++));
+}
+
+inline bool readRequiresNullBarrierFlag(
+    const char*& pos,
+    SerializationVersion version) {
+  return readRequiresNullBarrierFlag(
+      pos, std::optional<SerializationVersion>{version});
+}
+
+inline bool readRequiresNullBarrierFlag(
+    folly::io::Cursor& cursor,
+    std::optional<SerializationVersion> version) {
+  if (!usesHeaderFlags(version)) {
+    return false;
+  }
+  return detail::nullBarrierRequired(cursor.read<uint8_t>());
+}
+
+inline bool readRequiresNullBarrierFlag(
+    folly::io::Cursor& cursor,
+    SerializationVersion version) {
+  return readRequiresNullBarrierFlag(
+      cursor, std::optional<SerializationVersion>{version});
+}
 
 /// Reads the serialization header from `*pos`, detecting the version from the
 /// first byte when `hasHeader` is true (otherwise defaults to kLegacy).
@@ -57,15 +111,25 @@ char* extend(T& buffer, uint32_t size) {
 SerializationHeader
 readSerializationHeader(const char*& pos, const char* end, bool hasHeader);
 
-/// Writes a serialization header to buffer.
-/// For kLegacy: writes [optional_version:1B][rowCount:u32]
-/// For kLegacyCompact: writes [version:1B][rowCount:varint]
+/// Writes a legacy serialization header that has no flags byte.
+/// Writes [optional_version:1B][rowCount]. For kLegacy / nullopt, rowCount is
+/// u32. For legacy encoded formats without a flags byte, rowCount is varint.
+/// kSerialization / kProjection must use writeSerializationHeader() returning
+/// the flags byte offset.
 /// kTablet headers must use createTabletChunkHeader() instead.
+///
+/// This is only used for legacy versions (kLegacy without header, or kLegacy
+/// with header but no flags). Non-legacy versions with headers are normalized
+/// to kSerialization and use writeSerializationHeader() with flags.
 template <typename T>
-void writeSerializationHeader(
+void writeLegacySerializationHeader(
     T& buffer,
     std::optional<SerializationVersion> version,
     uint32_t rowCount) {
+  NIMBLE_CHECK(
+      !usesHeaderFlags(version),
+      "Serialization headers without flags cannot write versions with header flags. Got: {}",
+      version.has_value() ? toString(version.value()) : "nullopt");
   NIMBLE_CHECK(
       !isTabletVersion(version),
       "kTablet headers must use createTabletChunkHeader()");
@@ -84,19 +148,45 @@ void writeSerializationHeader(
   }
 }
 
-/// Returns the exact byte size of the serialization header.
-/// Not valid for kTablet — use createTabletChunkHeader() instead.
-inline size_t estimateSerializationHeaderSize(
-    std::optional<SerializationVersion> version,
+/// Writes a nullable-format serialization header to buffer.
+/// Returns the byte offset of the flags byte within `buffer`. The flags byte
+/// is initialized to zero and may be patched before the buffer is consumed.
+/// Writes [version:1B][rowCount:varint][flags:1B].
+/// Legacy formats are read-only; new serializer/projector writes use
+/// kSerialization or kProjection.
+/// kTablet headers must use createTabletChunkHeader() instead.
+template <typename T>
+size_t writeSerializationHeader(
+    T& buffer,
+    SerializationVersion version,
     uint32_t rowCount) {
   NIMBLE_CHECK(
-      !isTabletVersion(version),
-      "kTablet headers must use createTabletChunkHeader()");
-  const size_t versionBytes = version.has_value() ? sizeof(uint8_t) : 0;
-  const size_t rowCountBytes = usesVarintRowCount(version)
-      ? varint::varintSize(rowCount)
-      : sizeof(uint32_t);
-  return versionBytes + rowCountBytes;
+      usesHeaderFlags(version),
+      "Serialization header writes require kSerialization or kProjection. Got: {}",
+      version);
+
+  auto* versionPos = detail::extend(buffer, 1);
+  *versionPos = static_cast<char>(version);
+
+  auto* rowCountPos = detail::extend(buffer, varint::varintSize(rowCount));
+  varint::writeVarint(rowCount, &rowCountPos);
+  const size_t flagsOffset = buffer.size();
+  auto* flagsPos = detail::extend(buffer, 1);
+  *flagsPos =
+      static_cast<char>(detail::makeFlagsByte(/*requiresNullBarrier=*/false));
+  return flagsOffset;
+}
+
+/// Returns the exact byte size of a writable compact serialization header.
+/// Valid only for kSerialization and kProjection.
+inline size_t estimateSerializationHeaderSize(
+    SerializationVersion version,
+    uint32_t rowCount) {
+  NIMBLE_CHECK(
+      usesHeaderFlags(version),
+      "Serialization header writes require kSerialization or kProjection. Got: {}",
+      version);
+  return sizeof(uint8_t) + sizeof(uint8_t) + varint::varintSize(rowCount);
 }
 
 // ---- Tablet chunk header (kTablet only) ----
@@ -104,6 +194,9 @@ inline size_t estimateSerializationHeaderSize(
 /// Parsed fields of a kTablet chunk slice header.
 struct TabletChunkHeader {
   uint32_t rowCount{0};
+  /// True when this chunk slice carries a Row/FlatMap null stream with real
+  /// nulls; routes the slice to the per-batch barrier path on read.
+  bool requiresNullBarrier{false};
   RowRange rowRange;
   std::optional<std::string> resumeKey;
 };

--- a/dwio/nimble/serializer/Serializer.cpp
+++ b/dwio/nimble/serializer/Serializer.cpp
@@ -34,17 +34,22 @@ class FlatmapEncodingLayoutContext : public TypeBuilderContext {
       keyEncodings_;
 };
 
-// kLegacyCompact is read-only post the two-array trailer change. Callers that
-// still pass it (e.g., not-yet-migrated tests or downstream code we can't
-// update in this diff due to directory branching) are silently upgraded to
-// kSerialization so the round-trip still works on the new wire format. A
-// LOG(WARNING) flags the migration so the caller can switch.
-SerializerOptions upgradeReadOnlyVersion(SerializerOptions options) {
-  if (options.version.has_value() &&
-      options.version.value() == SerializationVersion::kLegacyCompact) {
+// Legacy writer spellings with a version header are read-only / migration-only.
+// Callers that still pass them are silently upgraded to kSerialization so
+// round-trips use the current wire format while call sites migrate. A missing
+// version is the production no-header legacy format and must remain stable.
+SerializerOptions normalizeWriterVersion(SerializerOptions options) {
+  if (!options.version.has_value()) {
+    return options;
+  }
+
+  const auto version = options.version.value();
+  if (version == SerializationVersion::kLegacy ||
+      version == SerializationVersion::kLegacyCompact ||
+      version == SerializationVersion::kLegacySerialization) {
     LOG_FIRST_N(WARNING, 10)
-        << "Serializer constructed with kLegacyCompact (read-only post the "
-           "two-array trailer change); silently upgrading to kSerialization. "
+        << "Serializer constructed with " << toString(version)
+        << " (legacy writer spelling); silently upgrading to kSerialization. "
            "Migrate the caller to pass kSerialization explicitly.";
     options.version = SerializationVersion::kSerialization;
   }
@@ -57,14 +62,15 @@ Serializer::Serializer(
     SerializerOptions options,
     const std::shared_ptr<const velox::Type>& type,
     velox::memory::MemoryPool* pool)
-    : options_{upgradeReadOnlyVersion(std::move(options))},
-      pool_{pool},
-      context_{*pool_},
+    : options_{normalizeWriterVersion(std::move(options))},
+      context_{*pool},
       buffer_{context_.bufferMemoryPool().get()} {
+  const auto version = options_.serializationVersion();
   NIMBLE_CHECK(
-      !isTabletVersion(options_.version),
-      "kTablet is not supported by the serializer. It is only used in projection.");
-  // streamSizesEncodingType is ignored for kLegacy (no trailer).
+      version == SerializationVersion::kLegacy ||
+          version == SerializationVersion::kSerialization,
+      "Serializer writes must use kLegacy or kSerialization. Got: {}",
+      version);
   const std::shared_ptr<const velox::dwio::common::TypeWithId> typeWithId =
       velox::dwio::common::TypeWithId::create(type);
 
@@ -79,22 +85,20 @@ Serializer::Serializer(
 
   typeWithId_ = typeWithId;
 
-  // Register handler for dynamically discovered FlatMap keys before creating
-  // the writer tree, so that predefined keys also trigger the handler.
+  // Register handler before creating the writer tree so both predefined and
+  // dynamically discovered FlatMap keys are tracked.
   if (!options_.flatMapColumns.empty()) {
     context_.setFlatmapFieldAddedEventHandler(
         [this](
             const TypeBuilder& flatmap,
             std::string_view fieldKey,
             const TypeBuilder& fieldType) {
-          // Track in-map stream offset for constant stream skipping.
           const auto& flatmapBuilder = flatmap.asFlatMap();
           inMapStreamOffsets_.insert(
               flatmapBuilder
                   .inMapDescriptorAt(flatmapBuilder.childrenCount() - 1)
                   .offset());
 
-          // Handle encoding layout if configured.
           if (options_.encodingLayoutTree.has_value()) {
             auto* ctx = flatmap.context<FlatmapEncodingLayoutContext>();
             if (ctx != nullptr) {
@@ -124,14 +128,32 @@ std::string_view Serializer::serialize(
   return {buffer_.data(), buffer_.size()};
 }
 
+void Serializer::validateSupportedInput(
+    const velox::VectorPtr& vector,
+    const OrderedRanges& ranges) const {
+  if (options_.flatMapColumns.empty() || !vector->mayHaveNulls()) {
+    return;
+  }
+
+  bool hasNullRow{false};
+  ranges.applyEach([&](auto offset) {
+    if (vector->isNullAt(offset)) {
+      hasNullRow = true;
+    }
+  });
+  NIMBLE_CHECK(
+      !hasNullRow,
+      "Top-level row nulls are not supported when serializing FlatMap columns.");
+}
+
 void Serializer::buildStreamEncodingLayouts() {
   if (!options_.encodingLayoutTree.has_value()) {
     return;
   }
 
   // NOTE: The event handler for dynamically discovered FlatMap keys is
-  // registered in the constructor, which combines both in-map offset tracking
-  // and encoding layout lookup in a single handler.
+  // registered in the constructor, so keyed encoding layouts can be applied
+  // as keys appear.
 
   // Traverse the encoding layout tree to build the stream encoding layouts map.
   const auto& rootType = context_.schemaBuilder().root();

--- a/dwio/nimble/serializer/Serializer.h
+++ b/dwio/nimble/serializer/Serializer.h
@@ -30,9 +30,6 @@ namespace facebook::nimble {
 /// This class provides a lightweight serialization interface for converting
 /// Velox vectors to nimble encoded byte streams. It supports flat map encoding
 /// for specified columns via Serializer::Options::flatMapColumns.
-///
-/// NOTE: This serializer does not support null value encoding at the top-level.
-/// All input vectors are expected to have no top-level nulls.
 class Serializer {
  public:
   using Options = SerializerOptions;
@@ -78,8 +75,13 @@ class Serializer {
         : nullptr;
   }
 
+  // Validates input shapes that the serializer can write but the dense
+  // deserializer cannot reconstruct.
+  void validateSupportedInput(
+      const velox::VectorPtr& vector,
+      const OrderedRanges& ranges) const;
+
   const SerializerOptions options_;
-  velox::memory::MemoryPool* const pool_;
   mutable FieldWriterContext context_;
   // Kept alive because FlatMap field writers hold references to child nodes.
   std::shared_ptr<const velox::dwio::common::TypeWithId> typeWithId_;
@@ -90,7 +92,7 @@ class Serializer {
   // Mutable because FlatMap keys can be added during const serialize().
   mutable std::unordered_map<uint32_t, const EncodingLayout*>
       streamEncodingLayouts_;
-  // In-map stream offsets for constant stream skipping.
+  // In-map stream offsets for skipping constant FlatMap key-presence streams.
   // Mutable because FlatMap keys can be added during const serialize().
   mutable folly::F14FastSet<uint32_t> inMapStreamOffsets_;
 };
@@ -100,19 +102,27 @@ void Serializer::serialize(
     const velox::VectorPtr& vector,
     const OrderedRanges& ranges,
     T& buffer) const {
+  validateSupportedInput(vector, ranges);
   writer_->write(vector, ranges);
 
   serde::StreamDataWriter<T> streamWriter{
       options_,
       buffer,
       static_cast<uint32_t>(ranges.size()),
-      pool_,
+      context_.bufferMemoryPool().get(),
       getStreamEncodingLayouts()};
   for (auto& [_, streamData] : context_.streams()) {
-    // Skip constant in-map boolean streams. When all-false (no row has this
-    // key) or all-true (every row has this key), omit the stream. The
-    // deserializer uses the precomputed value-stream anchor list (built via
-    // visitValueStreamLeaves) to distinguish the two cases.
+    if (streamData->isNullStream()) {
+      // Omit any null stream that carries no actual nulls, even when a
+      // validity bitmap was allocated (hasNulls() true but all-true). Such
+      // streams are reconstructed as all-true on read. This must match the
+      // null-barrier flag (computed from hasNullValues()): writing an all-true
+      // null stream would make it present in only some batches of a dense
+      // concat run, which the reader cannot stitch.
+      if (!streamData->hasNullValues()) {
+        continue;
+      }
+    }
     if (!inMapStreamOffsets_.empty()) {
       const auto streamOffset = streamData->descriptor().offset();
       if (inMapStreamOffsets_.contains(streamOffset)) {

--- a/dwio/nimble/serializer/SerializerImpl.cpp
+++ b/dwio/nimble/serializer/SerializerImpl.cpp
@@ -531,7 +531,7 @@ std::vector<std::string_view> parseStreams(
 
   std::vector<std::string_view> streams;
 
-  if (isCompactFormat(version)) {
+  if (nonLegacyFormat(version) && !isTabletVersion(version)) {
     // Walk the sparse (streamIds, streamSizes) trailer and place each
     // stream at its offset slot. Gaps remain empty string_views. Legacy
     // kLegacyCompact blobs are decoded via the frozen legacy reader.

--- a/dwio/nimble/serializer/SerializerImpl.h
+++ b/dwio/nimble/serializer/SerializerImpl.h
@@ -19,6 +19,7 @@
 #include <algorithm>
 #include <bit>
 #include <cstring>
+#include <memory>
 #include <optional>
 #include <string>
 #include <tuple>
@@ -85,6 +86,19 @@ void writeMissingStreams(T& buffer, uint32_t lastStream, uint32_t nextStream) {
 /// not captured in the layout tree. When encodingLayout is not provided, uses
 /// policyFactory directly and compressionOptions is ignored.
 template <typename T>
+std::unique_ptr<EncodingSelectionPolicy<T>> makeEncodingPolicy(
+    const EncodingSelectionPolicyCreator& policyFactory,
+    const EncodingLayout* encodingLayout,
+    const std::optional<CompressionOptions>& compressionOptions) {
+  if (encodingLayout != nullptr) {
+    return std::make_unique<ReplayedEncodingSelectionPolicy<T>>(
+        *encodingLayout, compressionOptions, policyFactory);
+  }
+  return velox::checkedPointerCast<EncodingSelectionPolicy<T>>(
+      policyFactory(TypeTraits<T>::dataType));
+}
+
+template <typename T>
 std::string_view encodeTyped(
     std::span<const T> values,
     nimble::Buffer& encodingBuffer,
@@ -92,18 +106,38 @@ std::string_view encodeTyped(
     const Encoding::Options& encodingOptions = {.useVarintRowCount = true},
     const EncodingLayout* encodingLayout = nullptr,
     std::optional<CompressionOptions> compressionOptions = std::nullopt) {
-  std::unique_ptr<EncodingSelectionPolicy<T>> typedPolicy;
-  if (encodingLayout != nullptr) {
-    // Replay the captured encoding layout. policyFactory is used as fallback
-    // for nested encodings not in the layout tree.
-    typedPolicy = std::make_unique<ReplayedEncodingSelectionPolicy<T>>(
-        *encodingLayout, compressionOptions, policyFactory);
-  } else {
-    typedPolicy = velox::checkedPointerCast<EncodingSelectionPolicy<T>>(
-        policyFactory(TypeTraits<T>::dataType));
-  }
   return EncodingFactory::encode<T>(
-      std::move(typedPolicy), values, encodingBuffer, encodingOptions);
+      makeEncodingPolicy<T>(policyFactory, encodingLayout, compressionOptions),
+      values,
+      encodingBuffer,
+      encodingOptions);
+}
+
+template <typename T>
+std::string_view encodeNullableTyped(
+    const SerializerOptions& options,
+    std::string_view data,
+    std::span<const bool> nonNulls,
+    nimble::Buffer& encodingBuffer,
+    const EncodingLayout* encodingLayout) {
+  const auto count = data.size() / sizeof(T);
+  std::span<const T> values{reinterpret_cast<const T*>(data.data()), count};
+
+  return EncodingFactory::encodeNullable<T>(
+      makeEncodingPolicy<T>(
+          options.encodingSelectionPolicyCreator,
+          encodingLayout,
+          options.compressionOptions),
+      values,
+      nonNulls,
+      encodingBuffer,
+      Encoding::Options{.useVarintRowCount = true});
+}
+
+inline std::string_view boolsAsStringView(std::span<const bool> values) {
+  return {
+      reinterpret_cast<const char*>(values.data()),
+      values.size() * sizeof(bool)};
 }
 
 /// Reads the trailer size (u32) from the last 4 bytes of the buffer.
@@ -396,7 +430,7 @@ void skipStream(const char*& pos) {
 /// contiguous buffer. Fills `streamIds` (non-zero stream slot ids, sorted
 /// ascending) and `streamSizes` (their byte sizes), parallel arrays of
 /// identical length. Both vectors are reusable buffers owned by
-/// the caller (e.g. members on `StreamDataReader`) to keep the per-blob hot
+/// the caller (e.g. members on `StreamDataParser`) to keep the per-blob hot
 /// path alloc-free across invocations.
 void readTrailerStreamMetadata(
     const char* end,
@@ -510,12 +544,70 @@ std::string_view encodeScalar(
       return encodeTyped<double, Buffer>(
           options, data, pool, encodingBuffer, encodingLayout);
     case ScalarKind::String:
+      [[fallthrough]];
     case ScalarKind::Binary:
       return encodeTyped<std::string_view, Buffer>(
           options, data, pool, encodingBuffer, encodingLayout);
     default:
       NIMBLE_UNSUPPORTED(
-          "Unsupported scalar kind for nimble encoding: {}",
+          "Unsupported scalar kind for nimble encoding: {}", scalarKind);
+  }
+}
+
+template <typename Buffer>
+std::string_view encodeNullableScalar(
+    const SerializerOptions& options,
+    ScalarKind scalarKind,
+    std::string_view data,
+    std::span<const bool> nonNulls,
+    nimble::Buffer& encodingBuffer,
+    const EncodingLayout* encodingLayout) {
+  switch (scalarKind) {
+    case ScalarKind::Bool:
+      return encodeNullableTyped<bool>(
+          options, data, nonNulls, encodingBuffer, encodingLayout);
+    case ScalarKind::Int8:
+      return encodeNullableTyped<int8_t>(
+          options, data, nonNulls, encodingBuffer, encodingLayout);
+    case ScalarKind::UInt8:
+      return encodeNullableTyped<uint8_t>(
+          options, data, nonNulls, encodingBuffer, encodingLayout);
+    case ScalarKind::Int16:
+      return encodeNullableTyped<int16_t>(
+          options, data, nonNulls, encodingBuffer, encodingLayout);
+    case ScalarKind::UInt16:
+      return encodeNullableTyped<uint16_t>(
+          options, data, nonNulls, encodingBuffer, encodingLayout);
+    case ScalarKind::Int32:
+      return encodeNullableTyped<int32_t>(
+          options, data, nonNulls, encodingBuffer, encodingLayout);
+    case ScalarKind::UInt32:
+      return encodeNullableTyped<uint32_t>(
+          options, data, nonNulls, encodingBuffer, encodingLayout);
+    case ScalarKind::Int64:
+      return encodeNullableTyped<int64_t>(
+          options, data, nonNulls, encodingBuffer, encodingLayout);
+    case ScalarKind::UInt64:
+      return encodeNullableTyped<uint64_t>(
+          options, data, nonNulls, encodingBuffer, encodingLayout);
+    case ScalarKind::Float:
+      return encodeNullableTyped<float>(
+          options, data, nonNulls, encodingBuffer, encodingLayout);
+    case ScalarKind::Double:
+      return encodeNullableTyped<double>(
+          options, data, nonNulls, encodingBuffer, encodingLayout);
+    case ScalarKind::String:
+      [[fallthrough]];
+    case ScalarKind::Binary:
+      return encodeNullableTyped<std::string_view>(
+          options, data, nonNulls, encodingBuffer, encodingLayout);
+    case ScalarKind::Undefined:
+      NIMBLE_UNSUPPORTED(
+          "Unsupported scalar kind for nullable nimble encoding: {}",
+          toString(scalarKind));
+    default:
+      NIMBLE_UNSUPPORTED(
+          "Unsupported scalar kind for nullable nimble encoding: {}",
           toString(scalarKind));
   }
 }
@@ -525,7 +617,8 @@ template <typename T>
 class StreamDataWriter {
  public:
   /// Constructor. For kLegacy, writes the header immediately. For
-  /// kLegacyCompact, writes the header prefix (version + rowCount).
+  /// kSerialization, writes the compact header prefix (version, row count,
+  /// flags).
   ///
   /// @param pool Memory pool for encoding buffer allocation.
   /// @param streamEncodingLayouts Optional encoding layouts for replaying
@@ -539,20 +632,19 @@ class StreamDataWriter {
       const std::unordered_map<uint32_t, const EncodingLayout*>*
           streamEncodingLayouts);
 
-  /// Write encoded data for a single stream.
-  /// For both formats, writes directly to buffer.
-  /// For kLegacyCompact, also tracks stream sizes for the trailer.
+  /// Write data for a single stream.
   void writeData(const nimble::StreamData& streamData);
 
-  /// Close the writer. For kLegacy, fills trailing zeros up to nodeCount.
-  /// For kLegacyCompact, writes the trailer (encoded sizes).
+  /// Close the writer. For kLegacy, fills trailing zeros up to nodeCount. For
+  /// kSerialization, writes the stream-sizes trailer.
   void close(uint32_t nodeCount = 0);
 
  private:
   void encodeStream(
       ScalarKind scalarKind,
+      uint32_t streamOffset,
       std::string_view data,
-      uint32_t streamOffset);
+      std::span<const bool> nonNulls = {});
 
   // --- Const members ---
   const SerializerOptions& options_;
@@ -572,6 +664,10 @@ class StreamDataWriter {
   // Dense stream sizes. streamSizes_[i] = byte size of stream i (0 for
   // missing/empty).
   std::vector<uint32_t> streamSizes_;
+  // Byte offset of the serialization header flags byte, patched in close().
+  size_t headerFlagsOffset_{0};
+  bool writesHeaderFlags_{false};
+  bool requiresNullBarrier_{false};
 };
 
 template <typename T>
@@ -593,102 +689,147 @@ StreamDataWriter<T>::StreamDataWriter(
       streamEncodingLayouts_ == nullptr || options_.enableEncoding(),
       "streamEncodingLayouts can only be set when encoding is enabled");
   NIMBLE_CHECK_NOT_NULL(pool, "Memory pool cannot be null");
+
   std::optional<SerializationVersion> version;
   if (options_.hasVersionHeader()) {
     version = options_.serializationVersion();
   }
-  writeSerializationHeader(buffer_, version, rowCount);
+
+  writesHeaderFlags_ = usesHeaderFlags(version);
+  if (writesHeaderFlags_) {
+    headerFlagsOffset_ =
+        writeSerializationHeader(buffer_, version.value(), rowCount);
+    NIMBLE_CHECK_LT(
+        headerFlagsOffset_, buffer_.size(), "Invalid null barrier flag offset");
+    NIMBLE_CHECK_EQ(
+        static_cast<uint8_t>(buffer_.data()[headerFlagsOffset_]),
+        0,
+        "Null barrier flag should be initialized to zero");
+  } else {
+    writeLegacySerializationHeader(buffer_, version, rowCount);
+  }
 }
 
 template <typename T>
 void StreamDataWriter<T>::writeData(const nimble::StreamData& streamData) {
+  const auto scalarKind = streamData.descriptor().scalarKind();
+  const auto streamOffset = streamData.descriptor().offset();
   const auto nonNulls = streamData.nonNulls();
   const auto data = streamData.data();
 
+  // Streams with no physical payload are omitted. All-true Row/FlatMap null
+  // streams normally remain unmaterialized and are reconstructed on read.
   if (data.empty() && nonNulls.empty()) {
     return;
   }
-  NIMBLE_CHECK(
-      nonNulls.empty() ||
-          std::all_of(
-              nonNulls.begin(),
-              nonNulls.end(),
-              [](bool notNull) { return notNull; }),
-      "nulls not supported");
 
-  const auto scalarKind = streamData.descriptor().scalarKind();
-  const auto streamOffset = streamData.descriptor().offset();
+  if (!options_.enableEncoding()) {
+    NIMBLE_CHECK(
+        nonNulls.empty() ||
+            std::all_of(
+                nonNulls.begin(),
+                nonNulls.end(),
+                [](bool notNull) { return notNull; }),
+        "Null values are not supported in legacy serialization formats. "
+        "Use kSerialization for nullable support.");
 
-  if (options_.enableEncoding()) {
-    encodeStream(scalarKind, data, streamOffset);
+    NIMBLE_CHECK_LE(lastStream_ + 1, streamOffset, "unexpected stream offset");
+    detail::writeMissingStreams(buffer_, lastStream_, streamOffset);
+    lastStream_ = streamOffset;
+    encodeStream(scalarKind, streamOffset, data);
     return;
   }
 
-  // kLegacy: fill zeros for missing streams before writing.
-  NIMBLE_CHECK_LE(lastStream_ + 1, streamOffset, "unexpected stream offset");
-  detail::writeMissingStreams(buffer_, lastStream_, streamOffset);
-  lastStream_ = streamOffset;
-  encodeStream(scalarKind, data, streamOffset);
+  if (streamData.isNullStream()) {
+    requiresNullBarrier_ |= streamData.hasNullValues();
+    NIMBLE_CHECK(
+        data.empty(), "null streams should not carry a separate data payload");
+    const auto streamPayload = detail::boolsAsStringView(nonNulls);
+    NIMBLE_CHECK(!streamPayload.empty(), "Expected null stream payload");
+    encodeStream(scalarKind, streamOffset, streamPayload);
+    return;
+  }
+
+  // Nullable content streams store only non-null payload values; an all-null
+  // chunk has an empty value payload but still needs its non-null bits encoded.
+  NIMBLE_CHECK(
+      !data.empty() || streamData.hasNullValues(),
+      "Expected content stream payload");
+  encodeStream(scalarKind, streamOffset, data, nonNulls);
 }
 
 template <typename T>
 void StreamDataWriter<T>::encodeStream(
     ScalarKind scalarKind,
+    uint32_t streamOffset,
     std::string_view data,
-    uint32_t streamOffset) {
-  if (options_.enableEncoding()) {
-    // Look up encoding layout for this stream if available.
-    const EncodingLayout* encodingLayout = nullptr;
-    if (streamEncodingLayouts_ != nullptr) {
-      auto it = streamEncodingLayouts_->find(streamOffset);
-      if (it != streamEncodingLayouts_->end()) {
-        encodingLayout = it->second;
+    std::span<const bool> nonNulls) {
+  if (!options_.enableEncoding()) {
+    if (scalarKind == ScalarKind::String || scalarKind == ScalarKind::Binary) {
+      // Legacy string encoding: [total_size:u32][len_0:u32][data_0]...
+      const auto size = detail::getStringsTotalSize(data);
+      auto* pos = detail::extend(buffer_, size + sizeof(uint32_t));
+      detail::encodeStrings(data, size, pos);
+    } else {
+      // Legacy scalar encoding:
+      //   Zstd: [size:u32][compType:i8][data...]
+      //   LZ4:  [size:u32][compType:i8][origSize:u32][data...]
+      const auto bufferStart = buffer_.size();
+      const uint32_t maxSize = data.size() + 2 * sizeof(uint32_t) + 1;
+      auto* pos = detail::extend(buffer_, maxSize);
+      const auto encodedSize = detail::encode(options_, data, pos);
+      if (encodedSize < maxSize) {
+        buffer_.resize(bufferStart + encodedSize);
       }
     }
+    return;
+  }
 
-    // Use nimble encoding framework for optimal compression.
-    auto encoded = detail::encodeScalar<T>(
-        options_, scalarKind, data, *pool_, *encodingBuffer_, encodingLayout);
-
-    // Track size for trailer.
-    if (streamOffset >= streamSizes_.size()) {
-      streamSizes_.resize(streamOffset + 1, 0);
-    }
-    streamSizes_[streamOffset] = static_cast<uint32_t>(encoded.size());
-    auto* pos = detail::extend(buffer_, encoded.size());
-    std::memcpy(pos, encoded.data(), encoded.size());
-  } else if (
-      scalarKind == ScalarKind::String || scalarKind == ScalarKind::Binary) {
-    // Legacy string encoding: [total_size:u32][len_0:u32][data_0]...
-    const auto size = detail::getStringsTotalSize(data);
-    auto* pos = detail::extend(buffer_, size + sizeof(uint32_t));
-    detail::encodeStrings(data, size, pos);
-  } else {
-    // Legacy scalar encoding:
-    //   Zstd: [size:u32][compType:i8][data...]
-    //   LZ4:  [size:u32][compType:i8][origSize:u32][data...]
-    const auto bufferStart = buffer_.size();
-    const uint32_t maxSize = data.size() + 2 * sizeof(uint32_t) + 1;
-    auto* pos = detail::extend(buffer_, maxSize);
-    const auto encodedSize = detail::encode(options_, data, pos);
-    if (encodedSize < maxSize) {
-      buffer_.resize(bufferStart + encodedSize);
+  const EncodingLayout* encodingLayout = nullptr;
+  if (streamEncodingLayouts_ != nullptr) {
+    auto it = streamEncodingLayouts_->find(streamOffset);
+    if (it != streamEncodingLayouts_->end()) {
+      encodingLayout = it->second;
     }
   }
+
+  // Use nimble encoding framework for optimal compression.
+  std::string_view encoded;
+  if (!facebook::nimble::StreamData::hasNullValues(nonNulls)) {
+    encoded = detail::encodeScalar<T>(
+        options_, scalarKind, data, *pool_, *encodingBuffer_, encodingLayout);
+  } else {
+    encoded = detail::encodeNullableScalar<T>(
+        options_, scalarKind, data, nonNulls, *encodingBuffer_, encodingLayout);
+  }
+
+  // Track size for trailer.
+  if (streamOffset >= streamSizes_.size()) {
+    streamSizes_.resize(streamOffset + 1, 0);
+  }
+  streamSizes_[streamOffset] = static_cast<uint32_t>(encoded.size());
+  auto* pos = detail::extend(buffer_, static_cast<uint32_t>(encoded.size()));
+  std::memcpy(pos, encoded.data(), encoded.size());
 }
 
 template <typename T>
 void StreamDataWriter<T>::close(uint32_t nodeCount) {
-  if (options_.enableEncoding()) {
-    detail::writeTrailer(
-        streamSizes_,
-        options_.streamIndicesEncodingType,
-        options_.streamSizesEncodingType,
-        buffer_);
-  } else {
-    // kLegacy: fill trailing zeros up to nodeCount.
+  if (!options_.enableEncoding()) {
     detail::writeMissingStreams(buffer_, lastStream_, nodeCount);
+    return;
   }
+
+  if (writesHeaderFlags_) {
+    NIMBLE_CHECK_LT(
+        headerFlagsOffset_, buffer_.size(), "Invalid null barrier flag offset");
+    buffer_.data()[headerFlagsOffset_] =
+        static_cast<char>(detail::makeFlagsByte(requiresNullBarrier_));
+  }
+  detail::writeTrailer(
+      streamSizes_,
+      options_.streamIndicesEncodingType,
+      options_.streamSizesEncodingType,
+      buffer_);
 }
 
 } // namespace facebook::nimble::serde

--- a/dwio/nimble/serializer/legacy/TrailerReader.h
+++ b/dwio/nimble/serializer/legacy/TrailerReader.h
@@ -38,7 +38,7 @@ namespace facebook::nimble::serde::legacy {
 /// Fills `streamIndices` (offsets of non-zero stream slots, sorted ascending)
 /// and `streamSizes` (their byte sizes), parallel arrays of identical length.
 /// Both vectors are reusable buffers owned by the caller (e.g. members on
-/// `StreamDataReader`) to keep the per-blob hot path alloc-free across
+/// `StreamDataParser`) to keep the per-blob hot path alloc-free across
 /// invocations.
 void readLegacyTrailerStreamMetadata(
     const char* end,

--- a/dwio/nimble/serializer/tests/OptionsTest.cpp
+++ b/dwio/nimble/serializer/tests/OptionsTest.cpp
@@ -25,14 +25,21 @@ TEST(OptionsTest, serializationVersionEnumValues) {
   // Verify enum underlying values match expected wire format versions.
   EXPECT_EQ(static_cast<uint8_t>(SerializationVersion::kLegacy), 0);
   EXPECT_EQ(static_cast<uint8_t>(SerializationVersion::kLegacyCompact), 2);
-  EXPECT_EQ(static_cast<uint8_t>(SerializationVersion::kSerialization), 3);
-  EXPECT_EQ(static_cast<uint8_t>(SerializationVersion::kProjection), 4);
-  EXPECT_EQ(static_cast<uint8_t>(SerializationVersion::kTablet), 5);
+  EXPECT_EQ(
+      static_cast<uint8_t>(SerializationVersion::kLegacySerialization), 3);
+  EXPECT_EQ(static_cast<uint8_t>(SerializationVersion::kSerialization), 4);
+  EXPECT_EQ(static_cast<uint8_t>(SerializationVersion::kProjection), 5);
+  EXPECT_EQ(static_cast<uint8_t>(SerializationVersion::kTablet), 6);
 }
 
 TEST(OptionsTest, toStringVersion) {
   EXPECT_EQ(toString(SerializationVersion::kLegacy), "kLegacy");
   EXPECT_EQ(toString(SerializationVersion::kLegacyCompact), "kLegacyCompact");
+  EXPECT_EQ(
+      toString(SerializationVersion::kLegacySerialization),
+      "kLegacySerialization");
+  EXPECT_EQ(toString(SerializationVersion::kSerialization), "kSerialization");
+  EXPECT_EQ(toString(SerializationVersion::kProjection), "kProjection");
   EXPECT_EQ(toString(SerializationVersion::kTablet), "kTablet");
 }
 
@@ -56,10 +63,10 @@ TEST(OptionsTest, serializerOptionsDefaults) {
   EXPECT_EQ(options.compressionType, CompressionType::Uncompressed);
   EXPECT_EQ(options.compressionThreshold, 0);
   EXPECT_EQ(options.compressionLevel, 0);
-  EXPECT_FALSE(options.version.has_value());
+  EXPECT_EQ(options.version, std::nullopt);
   EXPECT_TRUE(options.flatMapColumns.empty());
 
-  // Verify helper methods with defaults (nullopt = legacy format).
+  // Verify helper methods with defaults.
   EXPECT_FALSE(options.hasVersionHeader());
   EXPECT_EQ(options.serializationVersion(), SerializationVersion::kLegacy);
   EXPECT_FALSE(options.enableEncoding());
@@ -74,7 +81,8 @@ TEST(OptionsTest, serializerOptionsDefaults) {
 }
 
 TEST(OptionsTest, serializerOptionsWithLegacyVersion) {
-  // Explicit kLegacy still means version header is present.
+  // Raw options preserve explicit kLegacy; Serializer normalizes it before
+  // writing.
   SerializerOptions options{.version = SerializationVersion::kLegacy};
 
   EXPECT_TRUE(options.version.has_value());
@@ -123,29 +131,52 @@ TEST(OptionsTest, serializerOptionsWithCompactRawVersion) {
   EXPECT_TRUE(options.enableEncoding());
 }
 
+TEST(OptionsTest, serializerOptionsWithTabletVersion) {
+  SerializerOptions options{.version = SerializationVersion::kTablet};
+
+  EXPECT_TRUE(options.hasVersionHeader());
+  EXPECT_EQ(options.serializationVersion(), SerializationVersion::kTablet);
+  EXPECT_TRUE(options.enableEncoding());
+}
+
 TEST(OptionsTest, nonLegacyFormat) {
   EXPECT_FALSE(nonLegacyFormat(SerializationVersion::kLegacy));
   EXPECT_TRUE(nonLegacyFormat(SerializationVersion::kLegacyCompact));
+  EXPECT_TRUE(nonLegacyFormat(SerializationVersion::kLegacySerialization));
+  EXPECT_TRUE(nonLegacyFormat(SerializationVersion::kSerialization));
+  EXPECT_TRUE(nonLegacyFormat(SerializationVersion::kProjection));
   EXPECT_TRUE(nonLegacyFormat(SerializationVersion::kTablet));
 }
 
-TEST(OptionsTest, isCompactFormat) {
-  EXPECT_FALSE(isCompactFormat(SerializationVersion::kLegacy));
-  EXPECT_TRUE(isCompactFormat(SerializationVersion::kLegacyCompact));
-  EXPECT_FALSE(isCompactFormat(SerializationVersion::kTablet));
+TEST(OptionsTest, usesHeaderFlags) {
+  EXPECT_FALSE(usesHeaderFlags(SerializationVersion::kLegacy));
+  EXPECT_FALSE(usesHeaderFlags(SerializationVersion::kLegacyCompact));
+  EXPECT_FALSE(usesHeaderFlags(SerializationVersion::kLegacySerialization));
+  EXPECT_TRUE(usesHeaderFlags(SerializationVersion::kSerialization));
+  EXPECT_TRUE(usesHeaderFlags(SerializationVersion::kProjection));
+  EXPECT_FALSE(usesHeaderFlags(SerializationVersion::kTablet));
 }
 
-TEST(OptionsTest, isCompactFormatOptional) {
-  EXPECT_FALSE(isCompactFormat(std::nullopt));
-  EXPECT_FALSE(isCompactFormat(std::optional{SerializationVersion::kLegacy}));
+TEST(OptionsTest, usesHeaderFlagsOptional) {
+  EXPECT_FALSE(usesHeaderFlags(std::nullopt));
+  EXPECT_FALSE(usesHeaderFlags(std::optional{SerializationVersion::kLegacy}));
+  EXPECT_FALSE(
+      usesHeaderFlags(std::optional{SerializationVersion::kLegacyCompact}));
+  EXPECT_FALSE(usesHeaderFlags(
+      std::optional{SerializationVersion::kLegacySerialization}));
   EXPECT_TRUE(
-      isCompactFormat(std::optional{SerializationVersion::kLegacyCompact}));
-  EXPECT_FALSE(isCompactFormat(std::optional{SerializationVersion::kTablet}));
+      usesHeaderFlags(std::optional{SerializationVersion::kSerialization}));
+  EXPECT_TRUE(
+      usesHeaderFlags(std::optional{SerializationVersion::kProjection}));
+  EXPECT_FALSE(usesHeaderFlags(std::optional{SerializationVersion::kTablet}));
 }
 
 TEST(OptionsTest, isTabletVersion) {
   EXPECT_FALSE(isTabletVersion(SerializationVersion::kLegacy));
   EXPECT_FALSE(isTabletVersion(SerializationVersion::kLegacyCompact));
+  EXPECT_FALSE(isTabletVersion(SerializationVersion::kLegacySerialization));
+  EXPECT_FALSE(isTabletVersion(SerializationVersion::kSerialization));
+  EXPECT_FALSE(isTabletVersion(SerializationVersion::kProjection));
   EXPECT_TRUE(isTabletVersion(SerializationVersion::kTablet));
 }
 
@@ -154,12 +185,44 @@ TEST(OptionsTest, isTabletVersionOptional) {
   EXPECT_FALSE(isTabletVersion(std::optional{SerializationVersion::kLegacy}));
   EXPECT_FALSE(
       isTabletVersion(std::optional{SerializationVersion::kLegacyCompact}));
+  EXPECT_FALSE(isTabletVersion(
+      std::optional{SerializationVersion::kLegacySerialization}));
+  EXPECT_FALSE(
+      isTabletVersion(std::optional{SerializationVersion::kSerialization}));
+  EXPECT_FALSE(
+      isTabletVersion(std::optional{SerializationVersion::kProjection}));
   EXPECT_TRUE(isTabletVersion(std::optional{SerializationVersion::kTablet}));
+}
+
+TEST(OptionsTest, nonLegacyNonTabletSelectsSequentialStreamLayout) {
+  struct TestCase {
+    SerializationVersion version;
+    bool expected;
+  };
+
+  const TestCase testCases[] = {
+      {SerializationVersion::kLegacy, false},
+      {SerializationVersion::kLegacyCompact, true},
+      {SerializationVersion::kLegacySerialization, true},
+      {SerializationVersion::kSerialization, true},
+      {SerializationVersion::kProjection, true},
+      {SerializationVersion::kTablet, false},
+  };
+
+  for (const auto& testCase : testCases) {
+    SCOPED_TRACE(toString(testCase.version));
+    EXPECT_EQ(
+        nonLegacyFormat(testCase.version) && !isTabletVersion(testCase.version),
+        testCase.expected);
+  }
 }
 
 TEST(OptionsTest, usesVarintRowCount) {
   EXPECT_FALSE(usesVarintRowCount(SerializationVersion::kLegacy));
   EXPECT_TRUE(usesVarintRowCount(SerializationVersion::kLegacyCompact));
+  EXPECT_TRUE(usesVarintRowCount(SerializationVersion::kLegacySerialization));
+  EXPECT_TRUE(usesVarintRowCount(SerializationVersion::kSerialization));
+  EXPECT_TRUE(usesVarintRowCount(SerializationVersion::kProjection));
   EXPECT_TRUE(usesVarintRowCount(SerializationVersion::kTablet));
 }
 
@@ -169,6 +232,12 @@ TEST(OptionsTest, usesVarintRowCountOptional) {
       usesVarintRowCount(std::optional{SerializationVersion::kLegacy}));
   EXPECT_TRUE(
       usesVarintRowCount(std::optional{SerializationVersion::kLegacyCompact}));
+  EXPECT_TRUE(usesVarintRowCount(
+      std::optional{SerializationVersion::kLegacySerialization}));
+  EXPECT_TRUE(
+      usesVarintRowCount(std::optional{SerializationVersion::kSerialization}));
+  EXPECT_TRUE(
+      usesVarintRowCount(std::optional{SerializationVersion::kProjection}));
   EXPECT_TRUE(usesVarintRowCount(std::optional{SerializationVersion::kTablet}));
 }
 

--- a/dwio/nimble/serializer/tests/ProjectorTest.cpp
+++ b/dwio/nimble/serializer/tests/ProjectorTest.cpp
@@ -16,8 +16,11 @@
 
 #include <gtest/gtest.h>
 
+#include <cstdint>
 #include <optional>
+#include <string_view>
 #include <utility>
+#include <vector>
 
 #include "dwio/nimble/common/Exceptions.h"
 
@@ -50,6 +53,14 @@ std::string toString(const folly::IOBuf& buf) {
     result.append(reinterpret_cast<const char*>(range.data()), range.size());
   }
   return result;
+}
+
+bool outputRequiresNullBarrier(const folly::IOBuf& buf) {
+  const auto serialized = toString(buf);
+  const char* pos = serialized.data();
+  const auto header =
+      readSerializationHeader(pos, serialized.data() + serialized.size(), true);
+  return header.requiresNullBarrier;
 }
 
 // Test parameter: input serialization version and output (project) version.
@@ -706,7 +717,7 @@ TEST_F(ProjectorTest, incompatibleFormatsRejected) {
 
     NIMBLE_ASSERT_THROW(
         projector.project(std::string_view(tabletInput)),
-        "Input must be a compact format");
+        "Input must be kLegacyCompact, kLegacySerialization, kSerialization, or kProjection");
   }
 }
 
@@ -1645,6 +1656,79 @@ TEST_F(ProjectorTest, projectFlatMapNonExistentKey) {
   }
 }
 
+TEST_F(ProjectorTest, flatMapMissingKeyDeserializesAsNullField) {
+  auto type = ROW({
+      {"id", BIGINT()},
+      {"features", MAP(VARCHAR(), BIGINT())},
+  });
+
+  constexpr vector_size_t numRows = 4;
+  constexpr vector_size_t entriesPerRow = 2;
+  auto offsets = allocateOffsets(numRows, pool_.get());
+  auto sizes = allocateSizes(numRows, pool_.get());
+  auto* rawOffsets = offsets->asMutable<vector_size_t>();
+  auto* rawSizes = sizes->asMutable<vector_size_t>();
+  for (vector_size_t row = 0; row < numRows; ++row) {
+    rawOffsets[row] = row * entriesPerRow;
+    rawSizes[row] = entriesPerRow;
+  }
+
+  auto features = std::make_shared<MapVector>(
+      pool_.get(),
+      MAP(VARCHAR(), BIGINT()),
+      nullptr,
+      numRows,
+      offsets,
+      sizes,
+      makeStringVector({"a", "b", "a", "b", "a", "b", "a", "b"}),
+      makeIntVector<int64_t>({10, 11, 20, 21, 30, 31, 40, 41}));
+  auto input = std::make_shared<RowVector>(
+      pool_.get(),
+      type,
+      nullptr,
+      numRows,
+      std::vector<VectorPtr>{makeIntVector<int64_t>({1, 2, 3, 4}), features});
+
+  SerializerOptions serOpts{
+      .version = SerializationVersion::kSerialization,
+      .flatMapColumns = {{"features", {}}},
+  };
+  auto [serialized, inputSchema] = serializeWithSchema(input, type, serOpts);
+
+  Projector projector{
+      inputSchema,
+      makeSubfields({"features[\"a\"]", "features[\"x\"]"}),
+      pool_.get(),
+      {.projectVersion = SerializationVersion::kProjection}};
+  auto projected = projectInput(projector, serialized, /*useIOBuf=*/false);
+
+  DeserializerOptions deserOpts{
+      .hasHeader = true,
+      .outputType = ROW({"features"}, {ROW({"a", "x"}, {BIGINT(), BIGINT()})})};
+  auto output =
+      deserialize(toString(projected), projector.projectedSchema(), deserOpts);
+
+  ASSERT_EQ(output->size(), numRows);
+  auto* featuresStruct = output->as<RowVector>()->childAt(0)->as<RowVector>();
+  ASSERT_NE(featuresStruct, nullptr);
+  ASSERT_EQ(featuresStruct->childrenSize(), 2);
+  EXPECT_EQ(featuresStruct->type()->asRow().nameOf(0), "a");
+  EXPECT_EQ(featuresStruct->type()->asRow().nameOf(1), "x");
+
+  const auto* presentKey = featuresStruct->childAt(0)->asFlatVector<int64_t>();
+  const auto* missingKey = featuresStruct->childAt(1)->asFlatVector<int64_t>();
+  ASSERT_NE(presentKey, nullptr);
+  ASSERT_NE(missingKey, nullptr);
+
+  const std::vector<int64_t> expectedPresentValues{10, 20, 30, 40};
+  for (vector_size_t row = 0; row < numRows; ++row) {
+    SCOPED_TRACE(fmt::format("row={}", row));
+    EXPECT_FALSE(presentKey->isNullAt(row));
+    EXPECT_EQ(presentKey->valueAt(row), expectedPresentValues[row]);
+    EXPECT_TRUE(missingKey->isNullAt(row));
+  }
+}
+
 // All-missing-keys projection on a FlatMap whose value subtree is a Row.
 // Exercises the `emitPlaceholderOffsets` Row branch end-to-end (Row.nulls +
 // 2 inner scalars = 3 UINT32_MAX value slots + 1 inMap slot per missing key).
@@ -1986,6 +2070,1120 @@ TEST_F(ProjectorTest, streamIndicesCorrect) {
   ASSERT_EQ(indices.size(), 2);
   EXPECT_EQ(indices[0], 0); // Root row nulls
   EXPECT_EQ(indices[1], 2); // Column b
+}
+
+TEST_F(ProjectorTest, nullBarrierFlagFollowsProjectedNullStreams) {
+  constexpr vector_size_t kRows = 3;
+
+  struct SerializedInput {
+    std::string_view name;
+    std::string serialized;
+    std::shared_ptr<const nimble::Type> schema;
+    bool expectedInputRequiresNullBarrier;
+  };
+
+  auto makeNestedRowInput = [&](std::string_view name,
+                                bool profileHasNull,
+                                bool rootHasNull) {
+    auto type = ROW({
+        {"id", BIGINT()},
+        {"profile", ROW({{"score", INTEGER()}})},
+    });
+
+    auto ids = makeIntVector<int64_t>({1, 2, 3});
+    auto scores = makeIntVector<int32_t>({10, 20, 30});
+    auto profile = std::make_shared<RowVector>(
+        pool_.get(),
+        ROW({{"score", INTEGER()}}),
+        nullptr,
+        kRows,
+        std::vector<VectorPtr>{scores});
+    if (profileHasNull) {
+      profile->setNull(1, true);
+    }
+    auto input = std::make_shared<RowVector>(
+        pool_.get(),
+        type,
+        nullptr,
+        kRows,
+        std::vector<VectorPtr>{ids, profile});
+    if (rootHasNull) {
+      input->setNull(2, true);
+    }
+
+    SerializerOptions serOpts{.version = SerializationVersion::kSerialization};
+    auto serialized = serialize(input, type, serOpts);
+    auto inputSchema = getNimbleSchema(type, serOpts);
+    return SerializedInput{
+        .name = name,
+        .serialized = std::move(serialized),
+        .schema = std::move(inputSchema),
+        .expectedInputRequiresNullBarrier = profileHasNull || rootHasNull,
+    };
+  };
+
+  auto makeFlatMapRowInput = [&](std::string_view name, bool valueRowHasNull) {
+    auto valueType = ROW({{"score", INTEGER()}});
+    auto type = ROW({
+        {"id", BIGINT()},
+        {"features", MAP(VARCHAR(), valueType)},
+    });
+
+    auto ids = makeIntVector<int64_t>({1, 2, 3});
+    auto offsets = allocateOffsets(kRows, pool_.get());
+    auto sizes = allocateSizes(kRows, pool_.get());
+    auto* rawOffsets = offsets->asMutable<vector_size_t>();
+    auto* rawSizes = sizes->asMutable<vector_size_t>();
+    for (vector_size_t i = 0; i < kRows; ++i) {
+      rawOffsets[i] = i;
+      rawSizes[i] = 1;
+    }
+
+    auto keys = makeStringVector({"a", "a", "a"});
+    auto scores = makeIntVector<int32_t>({10, 20, 30});
+    auto values = std::make_shared<RowVector>(
+        pool_.get(), valueType, nullptr, kRows, std::vector<VectorPtr>{scores});
+    if (valueRowHasNull) {
+      values->setNull(1, true);
+    }
+    auto features = std::make_shared<MapVector>(
+        pool_.get(),
+        MAP(VARCHAR(), valueType),
+        nullptr,
+        kRows,
+        offsets,
+        sizes,
+        keys,
+        values);
+    auto input = std::make_shared<RowVector>(
+        pool_.get(),
+        type,
+        nullptr,
+        kRows,
+        std::vector<VectorPtr>{ids, features});
+
+    SerializerOptions serOpts{
+        .version = SerializationVersion::kSerialization,
+        .flatMapColumns = {{"features", {}}},
+    };
+    auto [serialized, inputSchema] = serializeWithSchema(input, type, serOpts);
+    return SerializedInput{
+        .name = name,
+        .serialized = std::move(serialized),
+        .schema = std::move(inputSchema),
+        .expectedInputRequiresNullBarrier = valueRowHasNull,
+    };
+  };
+
+  auto makeRegularDataNullInput = [&](std::string_view name) {
+    auto type = ROW({
+        {"id", BIGINT()},
+        {"nullable_score", INTEGER()},
+        {"items", ARRAY(INTEGER())},
+        {"attrs", MAP(VARCHAR(), INTEGER())},
+    });
+
+    auto ids = makeIntVector<int64_t>({1, 2, 3});
+    auto nullableScores = makeIntVector<int32_t>({10, 20, 30});
+    nullableScores->setNull(0, true);
+
+    auto arrayOffsets = allocateOffsets(kRows, pool_.get());
+    auto arraySizes = allocateSizes(kRows, pool_.get());
+    auto* rawArrayOffsets = arrayOffsets->asMutable<vector_size_t>();
+    auto* rawArraySizes = arraySizes->asMutable<vector_size_t>();
+    for (vector_size_t i = 0; i < kRows; ++i) {
+      rawArrayOffsets[i] = i * 2;
+      rawArraySizes[i] = 2;
+    }
+    auto items = std::make_shared<ArrayVector>(
+        pool_.get(),
+        ARRAY(INTEGER()),
+        nullptr,
+        kRows,
+        arrayOffsets,
+        arraySizes,
+        makeIntVector<int32_t>({1, 2, 3, 4, 5, 6}));
+    items->setNull(1, true);
+
+    auto mapOffsets = allocateOffsets(kRows, pool_.get());
+    auto mapSizes = allocateSizes(kRows, pool_.get());
+    auto* rawMapOffsets = mapOffsets->asMutable<vector_size_t>();
+    auto* rawMapSizes = mapSizes->asMutable<vector_size_t>();
+    for (vector_size_t i = 0; i < kRows; ++i) {
+      rawMapOffsets[i] = i;
+      rawMapSizes[i] = 1;
+    }
+    auto attrs = std::make_shared<MapVector>(
+        pool_.get(),
+        MAP(VARCHAR(), INTEGER()),
+        nullptr,
+        kRows,
+        mapOffsets,
+        mapSizes,
+        makeStringVector({"a", "b", "c"}),
+        makeIntVector<int32_t>({100, 200, 300}));
+    attrs->setNull(2, true);
+
+    auto input = std::make_shared<RowVector>(
+        pool_.get(),
+        type,
+        nullptr,
+        kRows,
+        std::vector<VectorPtr>{ids, nullableScores, items, attrs});
+
+    SerializerOptions serOpts{.version = SerializationVersion::kSerialization};
+    auto [serialized, inputSchema] = serializeWithSchema(input, type, serOpts);
+    return SerializedInput{
+        .name = name,
+        .serialized = std::move(serialized),
+        .schema = std::move(inputSchema),
+        .expectedInputRequiresNullBarrier = false,
+    };
+  };
+
+  auto inputRequiresNullBarrier = [](const SerializedInput& input) {
+    return outputRequiresNullBarrier(
+        folly::IOBuf::wrapBufferAsValue(
+            input.serialized.data(), input.serialized.size()));
+  };
+
+  const auto nestedRowNoNulls =
+      makeNestedRowInput("nestedRowNoNulls", false, false);
+  const auto nestedRowHasNulls =
+      makeNestedRowInput("nestedRowHasNulls", true, false);
+  const auto topLevelRowHasNulls =
+      makeNestedRowInput("topLevelRowHasNulls", false, true);
+  const auto flatMapRowNoNulls =
+      makeFlatMapRowInput("flatMapRowNoNulls", false);
+  const auto flatMapRowHasNulls =
+      makeFlatMapRowInput("flatMapRowHasNulls", true);
+  const auto regularDataNulls = makeRegularDataNullInput("regularDataNulls");
+
+  for (const auto* input :
+       {&nestedRowNoNulls,
+        &nestedRowHasNulls,
+        &topLevelRowHasNulls,
+        &flatMapRowNoNulls,
+        &flatMapRowHasNulls,
+        &regularDataNulls}) {
+    SCOPED_TRACE(input->name);
+    EXPECT_EQ(
+        inputRequiresNullBarrier(*input),
+        input->expectedInputRequiresNullBarrier);
+  }
+
+  auto rootNullResult = deserialize(
+      topLevelRowHasNulls.serialized,
+      topLevelRowHasNulls.schema,
+      {.hasHeader = true});
+  ASSERT_EQ(rootNullResult->size(), kRows);
+  EXPECT_TRUE(rootNullResult->isNullAt(2));
+
+  struct TestCase {
+    std::string_view name;
+    const SerializedInput* input;
+    std::vector<common::Subfield> subfields;
+    bool expectedRequiresNullBarrier;
+  };
+  std::vector<TestCase> testCases;
+  testCases.reserve(10);
+  testCases.push_back({
+      .name = "nestedRowNoNulls",
+      .input = &nestedRowNoNulls,
+      .subfields = makeSubfields({"profile.score"}),
+      .expectedRequiresNullBarrier = false,
+  });
+  testCases.push_back({
+      .name = "nestedRowHasNullsScalarOnly",
+      .input = &nestedRowHasNulls,
+      .subfields = makeSubfields({"id"}),
+      .expectedRequiresNullBarrier = false,
+  });
+  testCases.push_back({
+      .name = "nestedRowHasNulls",
+      .input = &nestedRowHasNulls,
+      .subfields = makeSubfields({"profile.score"}),
+      .expectedRequiresNullBarrier = true,
+  });
+  testCases.push_back({
+      .name = "topLevelRowHasNulls",
+      .input = &topLevelRowHasNulls,
+      .subfields = makeSubfields({"id"}),
+      .expectedRequiresNullBarrier = true,
+  });
+  testCases.push_back({
+      .name = "flatMapRowNoNulls",
+      .input = &flatMapRowNoNulls,
+      .subfields = makeSubfields({"features[\"a\"].score"}),
+      .expectedRequiresNullBarrier = false,
+  });
+  testCases.push_back({
+      .name = "flatMapRowHasNullsScalarOnly",
+      .input = &flatMapRowHasNulls,
+      .subfields = makeSubfields({"id"}),
+      .expectedRequiresNullBarrier = false,
+  });
+  testCases.push_back({
+      .name = "flatMapRowHasNulls",
+      .input = &flatMapRowHasNulls,
+      .subfields = makeSubfields({"features[\"a\"].score"}),
+      .expectedRequiresNullBarrier = true,
+  });
+  testCases.push_back({
+      .name = "regularScalarNulls",
+      .input = &regularDataNulls,
+      .subfields = makeSubfields({"nullable_score"}),
+      .expectedRequiresNullBarrier = false,
+  });
+  testCases.push_back({
+      .name = "regularArrayNulls",
+      .input = &regularDataNulls,
+      .subfields = makeSubfields({"items"}),
+      .expectedRequiresNullBarrier = false,
+  });
+  testCases.push_back({
+      .name = "regularMapNulls",
+      .input = &regularDataNulls,
+      .subfields = makeSubfields({"attrs"}),
+      .expectedRequiresNullBarrier = false,
+  });
+
+  for (const auto& testCase : testCases) {
+    for (bool useChained : {false, true}) {
+      SCOPED_TRACE(fmt::format("{} useChained={}", testCase.name, useChained));
+      Projector projector(
+          testCase.input->schema, testCase.subfields, pool_.get(), {});
+      folly::IOBuf projected;
+      if (useChained) {
+        const auto mid = testCase.input->serialized.size() / 2;
+        auto chainedBuf =
+            folly::IOBuf::copyBuffer(testCase.input->serialized.data(), mid);
+        chainedBuf->appendToChain(
+            folly::IOBuf::copyBuffer(
+                testCase.input->serialized.data() + mid,
+                testCase.input->serialized.size() - mid));
+        projected = projector.project(*chainedBuf);
+      } else {
+        projected =
+            projector.project(std::string_view(testCase.input->serialized));
+      }
+      EXPECT_EQ(
+          outputRequiresNullBarrier(projected),
+          testCase.expectedRequiresNullBarrier);
+      auto result = deserialize(
+          toString(projected),
+          projector.projectedSchema(),
+          {.hasHeader = true});
+      ASSERT_EQ(result->size(), kRows);
+    }
+  }
+}
+
+TEST_F(ProjectorTest, projectedRowNullMixedBatchPreserveNulls) {
+  constexpr vector_size_t kRowsPerBatch = 3;
+
+  auto type = ROW({
+      {"id", BIGINT()},
+      {"score", INTEGER()},
+  });
+  SerializerOptions serOpts{.version = SerializationVersion::kSerialization};
+  auto inputSchema = getNimbleSchema(type, serOpts);
+  Projector projector(
+      inputSchema,
+      makeSubfields({"id"}),
+      pool_.get(),
+      {.projectVersion = SerializationVersion::kProjection});
+
+  auto makeInput = [&](const std::vector<int64_t>& ids,
+                       const std::vector<int32_t>& scores,
+                       std::optional<vector_size_t> nullRow) {
+    auto input = std::make_shared<RowVector>(
+        pool_.get(),
+        type,
+        nullptr,
+        kRowsPerBatch,
+        std::vector<VectorPtr>{
+            makeIntVector<int64_t>(ids), makeIntVector<int32_t>(scores)});
+    if (nullRow.has_value()) {
+      input->setNull(*nullRow, true);
+    }
+    return input;
+  };
+
+  const auto noNullBatch = serialize(
+      makeInput({1, 2, 3}, {10, 20, 30}, std::nullopt), type, serOpts);
+  const auto nullBatch =
+      serialize(makeInput({4, 5, 6}, {40, 50, 60}, 1), type, serOpts);
+
+  auto projectedNoNull =
+      projectInput(projector, noNullBatch, /*useIOBuf=*/false);
+  auto projectedWithNull =
+      projectInput(projector, nullBatch, /*useIOBuf=*/false);
+  EXPECT_FALSE(outputRequiresNullBarrier(projectedNoNull));
+  EXPECT_TRUE(outputRequiresNullBarrier(projectedWithNull));
+
+  const auto projectedNoNullString = toString(projectedNoNull);
+  const auto projectedWithNullString = toString(projectedWithNull);
+  std::vector<std::string_view> batches{
+      projectedNoNullString, projectedWithNullString};
+  Deserializer deserializer{
+      projector.projectedSchema(), pool_.get(), {.hasHeader = true}};
+  VectorPtr output;
+  deserializer.deserialize(batches, output);
+
+  ASSERT_EQ(output->size(), 2 * kRowsPerBatch);
+  const std::vector<bool> expectedRowNulls{
+      false, false, false, false, true, false};
+  for (vector_size_t i = 0; i < output->size(); ++i) {
+    EXPECT_EQ(output->isNullAt(i), expectedRowNulls[i]) << "row " << i;
+  }
+
+  auto* ids = output->as<RowVector>()->childAt(0)->as<FlatVector<int64_t>>();
+  ASSERT_NE(ids, nullptr);
+  EXPECT_EQ(ids->valueAt(0), 1);
+  EXPECT_EQ(ids->valueAt(1), 2);
+  EXPECT_EQ(ids->valueAt(2), 3);
+  EXPECT_EQ(ids->valueAt(3), 4);
+  EXPECT_EQ(ids->valueAt(5), 6);
+}
+
+TEST_F(ProjectorTest, projectedNestedRowNullsMixedBatchPreserveNulls) {
+  constexpr vector_size_t kRowsPerBatch = 3;
+
+  auto type = ROW({
+      {"id", BIGINT()},
+      {"profile", ROW({{"score", INTEGER()}})},
+  });
+  SerializerOptions serOpts{.version = SerializationVersion::kSerialization};
+  auto inputSchema = getNimbleSchema(type, serOpts);
+  Projector projector(
+      inputSchema,
+      makeSubfields({"profile.score"}),
+      pool_.get(),
+      {.projectVersion = SerializationVersion::kProjection});
+
+  auto makeInput = [&](const std::vector<int64_t>& ids,
+                       const std::vector<int32_t>& scores,
+                       std::optional<vector_size_t> nullProfileRow) {
+    auto profile = std::make_shared<RowVector>(
+        pool_.get(),
+        ROW({{"score", INTEGER()}}),
+        nullptr,
+        kRowsPerBatch,
+        std::vector<VectorPtr>{makeIntVector<int32_t>(scores)});
+    if (nullProfileRow.has_value()) {
+      profile->setNull(*nullProfileRow, true);
+    }
+    return std::make_shared<RowVector>(
+        pool_.get(),
+        type,
+        nullptr,
+        kRowsPerBatch,
+        std::vector<VectorPtr>{makeIntVector<int64_t>(ids), profile});
+  };
+
+  const auto noNullBatch = serialize(
+      makeInput({1, 2, 3}, {10, 20, 30}, std::nullopt), type, serOpts);
+  const auto nullBatch =
+      serialize(makeInput({4, 5, 6}, {40, 50, 60}, 1), type, serOpts);
+
+  auto projectedNoNull =
+      projectInput(projector, noNullBatch, /*useIOBuf=*/false);
+  auto projectedWithNull =
+      projectInput(projector, nullBatch, /*useIOBuf=*/false);
+  EXPECT_FALSE(outputRequiresNullBarrier(projectedNoNull));
+  EXPECT_TRUE(outputRequiresNullBarrier(projectedWithNull));
+
+  const auto projectedNoNullString = toString(projectedNoNull);
+  const auto projectedWithNullString = toString(projectedWithNull);
+  std::vector<std::string_view> batches{
+      projectedNoNullString, projectedWithNullString};
+  Deserializer deserializer{
+      projector.projectedSchema(), pool_.get(), {.hasHeader = true}};
+  VectorPtr output;
+  deserializer.deserialize(batches, output);
+
+  ASSERT_EQ(output->size(), 2 * kRowsPerBatch);
+  auto* profile = output->as<RowVector>()->childAt(0)->as<RowVector>();
+  ASSERT_NE(profile, nullptr);
+  const std::vector<bool> expectedProfileNulls{
+      false, false, false, false, true, false};
+  for (vector_size_t i = 0; i < output->size(); ++i) {
+    EXPECT_EQ(profile->isNullAt(i), expectedProfileNulls[i]) << "row " << i;
+  }
+
+  auto* scores = profile->childAt(0)->as<FlatVector<int32_t>>();
+  ASSERT_NE(scores, nullptr);
+  EXPECT_EQ(scores->valueAt(0), 10);
+  EXPECT_EQ(scores->valueAt(1), 20);
+  EXPECT_EQ(scores->valueAt(2), 30);
+  EXPECT_EQ(scores->valueAt(3), 40);
+  EXPECT_EQ(scores->valueAt(5), 60);
+}
+
+TEST_F(ProjectorTest, projectedFlatMapNullsMixedBatchPreserveNulls) {
+  constexpr vector_size_t kRowsPerBatch = 3;
+
+  auto valueType = ROW({{"score", INTEGER()}});
+  auto type = ROW({
+      {"id", BIGINT()},
+      {"features", MAP(VARCHAR(), valueType)},
+  });
+  SerializerOptions serOpts{
+      .version = SerializationVersion::kSerialization,
+      .flatMapColumns = {{"features", {}}},
+  };
+
+  auto makeInput = [&](const std::vector<int64_t>& ids,
+                       const std::vector<int32_t>& scores,
+                       std::optional<vector_size_t> nullValueRow) {
+    auto offsets = allocateOffsets(kRowsPerBatch, pool_.get());
+    auto sizes = allocateSizes(kRowsPerBatch, pool_.get());
+    auto* rawOffsets = offsets->asMutable<vector_size_t>();
+    auto* rawSizes = sizes->asMutable<vector_size_t>();
+    for (vector_size_t i = 0; i < kRowsPerBatch; ++i) {
+      rawOffsets[i] = i;
+      rawSizes[i] = 1;
+    }
+
+    auto values = std::make_shared<RowVector>(
+        pool_.get(),
+        valueType,
+        nullptr,
+        kRowsPerBatch,
+        std::vector<VectorPtr>{makeIntVector<int32_t>(scores)});
+    if (nullValueRow.has_value()) {
+      values->setNull(*nullValueRow, true);
+    }
+    auto features = std::make_shared<MapVector>(
+        pool_.get(),
+        MAP(VARCHAR(), valueType),
+        nullptr,
+        kRowsPerBatch,
+        offsets,
+        sizes,
+        makeStringVector({"a", "a", "a"}),
+        values);
+    return std::make_shared<RowVector>(
+        pool_.get(),
+        type,
+        nullptr,
+        kRowsPerBatch,
+        std::vector<VectorPtr>{makeIntVector<int64_t>(ids), features});
+  };
+
+  const auto noNullInput = makeInput({1, 2, 3}, {10, 20, 30}, std::nullopt);
+  const auto nullInput = makeInput({4, 5, 6}, {40, 50, 60}, 1);
+  const auto [noNullBatch, inputSchema] =
+      serializeWithSchema(noNullInput, type, serOpts);
+  const auto [nullBatch, _] = serializeWithSchema(nullInput, type, serOpts);
+  Projector projector(
+      inputSchema,
+      makeSubfields({"features[\"a\"].score"}),
+      pool_.get(),
+      {.projectVersion = SerializationVersion::kProjection});
+
+  auto projectedNoNull =
+      projectInput(projector, noNullBatch, /*useIOBuf=*/false);
+  auto projectedWithNull =
+      projectInput(projector, nullBatch, /*useIOBuf=*/false);
+  EXPECT_FALSE(outputRequiresNullBarrier(projectedNoNull));
+  EXPECT_TRUE(outputRequiresNullBarrier(projectedWithNull));
+
+  const auto projectedNoNullString = toString(projectedNoNull);
+  const auto projectedWithNullString = toString(projectedWithNull);
+  std::vector<std::string_view> batches{
+      projectedNoNullString, projectedWithNullString};
+  Deserializer deserializer{
+      projector.projectedSchema(), pool_.get(), {.hasHeader = true}};
+  VectorPtr output;
+  deserializer.deserialize(batches, output);
+
+  ASSERT_EQ(output->size(), 2 * kRowsPerBatch);
+  auto* features = output->as<RowVector>()->childAt(0)->as<MapVector>();
+  ASSERT_NE(features, nullptr);
+  auto* values = features->mapValues()->as<RowVector>();
+  ASSERT_NE(values, nullptr);
+  const std::vector<bool> expectedValueNulls{
+      false, false, false, false, true, false};
+  for (vector_size_t i = 0; i < output->size(); ++i) {
+    ASSERT_EQ(features->sizeAt(i), 1) << "row " << i;
+    EXPECT_EQ(values->isNullAt(features->offsetAt(i)), expectedValueNulls[i])
+        << "row " << i;
+  }
+
+  auto* scores = values->childAt(0)->as<FlatVector<int32_t>>();
+  ASSERT_NE(scores, nullptr);
+  EXPECT_EQ(scores->valueAt(features->offsetAt(0)), 10);
+  EXPECT_EQ(scores->valueAt(features->offsetAt(1)), 20);
+  EXPECT_EQ(scores->valueAt(features->offsetAt(2)), 30);
+  EXPECT_EQ(scores->valueAt(features->offsetAt(3)), 40);
+  EXPECT_EQ(scores->valueAt(features->offsetAt(5)), 60);
+}
+
+TEST_F(ProjectorTest, projectedUnselectedNullColumnDoesNotRequireNullBarrier) {
+  constexpr vector_size_t kRowsPerBatch = 4;
+
+  auto type = ROW({
+      {"id", BIGINT()},
+      {"kept", ROW({{"score", INTEGER()}})},
+      {"skipped", ROW({{"score", INTEGER()}})},
+  });
+  SerializerOptions serOpts{.version = SerializationVersion::kSerialization};
+  auto inputSchema = getNimbleSchema(type, serOpts);
+  Projector projector(
+      inputSchema,
+      makeSubfields({"kept.score"}),
+      pool_.get(),
+      {.projectVersion = SerializationVersion::kProjection});
+
+  auto kept = std::make_shared<RowVector>(
+      pool_.get(),
+      ROW({{"score", INTEGER()}}),
+      nullptr,
+      kRowsPerBatch,
+      std::vector<VectorPtr>{makeIntVector<int32_t>({10, 20, 30, 40})});
+  auto skipped = std::make_shared<RowVector>(
+      pool_.get(),
+      ROW({{"score", INTEGER()}}),
+      nullptr,
+      kRowsPerBatch,
+      std::vector<VectorPtr>{makeIntVector<int32_t>({100, 200, 300, 400})});
+  skipped->setNull(1, true);
+  skipped->setNull(3, true);
+  auto input = std::make_shared<RowVector>(
+      pool_.get(),
+      type,
+      nullptr,
+      kRowsPerBatch,
+      std::vector<VectorPtr>{
+          makeIntVector<int64_t>({1, 2, 3, 4}), kept, skipped});
+
+  auto serialized = serialize(input, type, serOpts);
+  auto projected = projectInput(projector, serialized, /*useIOBuf=*/false);
+  EXPECT_FALSE(outputRequiresNullBarrier(projected));
+
+  const auto projectedString = toString(projected);
+  std::vector<std::string_view> batches{projectedString};
+  Deserializer deserializer{
+      projector.projectedSchema(), pool_.get(), {.hasHeader = true}};
+  VectorPtr output;
+  deserializer.deserialize(batches, output);
+
+  ASSERT_EQ(output->size(), kRowsPerBatch);
+  auto* outputKept = output->as<RowVector>()->childAt(0)->as<RowVector>();
+  ASSERT_NE(outputKept, nullptr);
+  for (vector_size_t i = 0; i < kRowsPerBatch; ++i) {
+    EXPECT_FALSE(outputKept->isNullAt(i)) << "row " << i;
+  }
+  auto* scores = outputKept->childAt(0)->as<FlatVector<int32_t>>();
+  ASSERT_NE(scores, nullptr);
+  EXPECT_EQ(scores->valueAt(0), 10);
+  EXPECT_EQ(scores->valueAt(1), 20);
+  EXPECT_EQ(scores->valueAt(2), 30);
+  EXPECT_EQ(scores->valueAt(3), 40);
+}
+
+TEST_F(ProjectorTest, projectedComplexNullFuzzerPreservesNulls) {
+  constexpr vector_size_t kRowsPerBatch = 8;
+  constexpr int kIterations = 8;
+  constexpr int kBatches = 4;
+  constexpr vector_size_t kEntriesPerMapRow = 2;
+
+  auto mapValueType = ROW({
+      {"weight", DOUBLE()},
+      {"active", BOOLEAN()},
+  });
+  auto type = ROW({
+      {"id", BIGINT()},
+      {"profile",
+       ROW({
+           {"score", INTEGER()},
+           {"details",
+            ROW({
+                {"rank", BIGINT()},
+                {"quality", DOUBLE()},
+            })},
+       })},
+      {"activity",
+       ROW({
+           {"clicks", INTEGER()},
+           {"label", VARCHAR()},
+           {"inner",
+            ROW({
+                {"flag", BOOLEAN()},
+                {"weight", DOUBLE()},
+            })},
+       })},
+      {"events",
+       ARRAY(ROW({
+           {"event_id", BIGINT()},
+           {"payload",
+            ROW({
+                {"score", DOUBLE()},
+                {"tag", VARCHAR()},
+            })},
+       }))},
+      {"attrs", MAP(VARCHAR(), mapValueType)},
+      {"flatAttrs", MAP(VARCHAR(), mapValueType)},
+  });
+
+  SerializerOptions serOpts{
+      .version = SerializationVersion::kSerialization,
+      .flatMapColumns = {{"flatAttrs", {}}},
+  };
+  const auto rowType = velox::checkedPointerCast<const velox::RowType>(type);
+
+  struct RowLeafPath {
+    std::string path;
+    std::vector<std::string_view> names;
+  };
+  struct FlatMapLeafPath {
+    std::string path;
+    std::string_view key;
+    std::string_view field;
+  };
+
+  const std::vector<RowLeafPath> rowLeafPaths = {
+      {"id", {"id"}},
+      {"profile.score", {"profile", "score"}},
+      {"profile.details.rank", {"profile", "details", "rank"}},
+      {"profile.details.quality", {"profile", "details", "quality"}},
+      {"activity.clicks", {"activity", "clicks"}},
+      {"activity.label", {"activity", "label"}},
+      {"activity.inner.flag", {"activity", "inner", "flag"}},
+      {"activity.inner.weight", {"activity", "inner", "weight"}},
+  };
+  const std::vector<FlatMapLeafPath> flatMapLeafPaths = {
+      {"flatAttrs[\"a\"].weight", "a", "weight"},
+      {"flatAttrs[\"a\"].active", "a", "active"},
+      {"flatAttrs[\"b\"].weight", "b", "weight"},
+      {"flatAttrs[\"b\"].active", "b", "active"},
+  };
+
+  auto makeFlatInputRow = [&](VectorFuzzer& fuzzer) {
+    std::vector<VectorPtr> children;
+    children.reserve(rowType->size());
+    for (size_t child = 0; child < rowType->size(); ++child) {
+      children.push_back(
+          fuzzer.fuzzFlat(rowType->childAt(child), kRowsPerBatch));
+    }
+    return std::make_shared<RowVector>(
+        pool_.get(), rowType, nullptr, kRowsPerBatch, std::move(children));
+  };
+
+  auto childIndex = [](const RowVector* row, std::string_view name) {
+    const auto& rowType = row->type()->asRow();
+    for (size_t i = 0; i < rowType.size(); ++i) {
+      if (rowType.nameOf(i) == name) {
+        return i;
+      }
+    }
+    NIMBLE_FAIL("Missing child {}", name);
+  };
+
+  auto leafVector = [&](const RowVector* root,
+                        const RowLeafPath& path) -> const BaseVector* {
+    const RowVector* row = root;
+    for (size_t i = 0; i + 1 < path.names.size(); ++i) {
+      row = row->childAt(childIndex(row, path.names[i]))->as<RowVector>();
+    }
+    return row->childAt(childIndex(row, path.names.back())).get();
+  };
+
+  auto pathIsNull = [&](const RowVector* root,
+                        const RowLeafPath& path,
+                        vector_size_t rowIndex) {
+    const RowVector* row = root;
+    if (row->isNullAt(rowIndex)) {
+      return true;
+    }
+    for (size_t i = 0; i + 1 < path.names.size(); ++i) {
+      row = row->childAt(childIndex(row, path.names[i]))->as<RowVector>();
+      if (row->isNullAt(rowIndex)) {
+        return true;
+      }
+    }
+    return row->childAt(childIndex(row, path.names.back()))->isNullAt(rowIndex);
+  };
+
+  auto expectLeafEqual = [&](const RowVector* expectedRoot,
+                             vector_size_t expectedRow,
+                             const RowVector* actualRoot,
+                             vector_size_t actualRow,
+                             const RowLeafPath& path) {
+    const auto expectedNull = pathIsNull(expectedRoot, path, expectedRow);
+    EXPECT_EQ(pathIsNull(actualRoot, path, actualRow), expectedNull)
+        << "path=" << path.path << " expectedRow=" << expectedRow
+        << " actualRow=" << actualRow;
+    if (expectedNull) {
+      return;
+    }
+
+    const auto* expected = leafVector(expectedRoot, path);
+    const auto* actual = leafVector(actualRoot, path);
+    switch (expected->type()->kind()) {
+      case TypeKind::BOOLEAN:
+        EXPECT_EQ(
+            expected->as<FlatVector<bool>>()->valueAt(expectedRow),
+            actual->as<FlatVector<bool>>()->valueAt(actualRow));
+        break;
+      case TypeKind::INTEGER:
+        EXPECT_EQ(
+            expected->as<FlatVector<int32_t>>()->valueAt(expectedRow),
+            actual->as<FlatVector<int32_t>>()->valueAt(actualRow));
+        break;
+      case TypeKind::BIGINT:
+        EXPECT_EQ(
+            expected->as<FlatVector<int64_t>>()->valueAt(expectedRow),
+            actual->as<FlatVector<int64_t>>()->valueAt(actualRow));
+        break;
+      case TypeKind::DOUBLE:
+        EXPECT_EQ(
+            expected->as<FlatVector<double>>()->valueAt(expectedRow),
+            actual->as<FlatVector<double>>()->valueAt(actualRow));
+        break;
+      case TypeKind::VARCHAR:
+        EXPECT_EQ(
+            expected->as<FlatVector<StringView>>()->valueAt(expectedRow),
+            actual->as<FlatVector<StringView>>()->valueAt(actualRow));
+        break;
+      default:
+        NIMBLE_FAIL(
+            "Unexpected projected type {}", expected->type()->toString());
+    }
+  };
+
+  auto makeStringRowMap = [&](bool hasNulls, double valueBase) {
+    const auto numEntries = kRowsPerBatch * kEntriesPerMapRow;
+    auto offsets = allocateOffsets(kRowsPerBatch, pool_.get());
+    auto sizes = allocateSizes(kRowsPerBatch, pool_.get());
+    auto* rawOffsets = offsets->asMutable<vector_size_t>();
+    auto* rawSizes = sizes->asMutable<vector_size_t>();
+    for (vector_size_t row = 0; row < kRowsPerBatch; ++row) {
+      rawOffsets[row] = row * kEntriesPerMapRow;
+      rawSizes[row] = kEntriesPerMapRow;
+    }
+
+    std::vector<std::string> keys;
+    keys.reserve(numEntries);
+    auto weights = BaseVector::create<FlatVector<double>>(
+        DOUBLE(), numEntries, pool_.get());
+    auto active = BaseVector::create<FlatVector<bool>>(
+        BOOLEAN(), numEntries, pool_.get());
+    for (vector_size_t row = 0; row < kRowsPerBatch; ++row) {
+      for (vector_size_t mapIndex = 0; mapIndex < kEntriesPerMapRow;
+           ++mapIndex) {
+        const auto entry = row * kEntriesPerMapRow + mapIndex;
+        keys.emplace_back(mapIndex == 0 ? "a" : "b");
+        weights->set(entry, valueBase + row * 10 + mapIndex);
+        active->set(entry, (row + mapIndex) % 2 == 0);
+      }
+    }
+
+    auto values = std::make_shared<RowVector>(
+        pool_.get(),
+        mapValueType,
+        nullptr,
+        numEntries,
+        std::vector<VectorPtr>{weights, active});
+    if (hasNulls) {
+      values->setNull(4 * kEntriesPerMapRow, true);
+    }
+    auto map = std::make_shared<MapVector>(
+        pool_.get(),
+        MAP(VARCHAR(), mapValueType),
+        nullptr,
+        kRowsPerBatch,
+        offsets,
+        sizes,
+        makeStringVector(keys),
+        values);
+    if (hasNulls) {
+      map->setNull(5, true);
+    }
+    return map;
+  };
+
+  auto findStringKeyEntry =
+      [&](const MapVector* map,
+          vector_size_t row,
+          std::string_view key) -> std::optional<vector_size_t> {
+    if (map->isNullAt(row)) {
+      return std::nullopt;
+    }
+    const auto* keys = map->mapKeys()->as<FlatVector<StringView>>();
+    const auto offset = map->offsetAt(row);
+    const auto size = map->sizeAt(row);
+    for (vector_size_t i = 0; i < size; ++i) {
+      const auto entry = offset + i;
+      if (keys->valueAt(entry).str() == key) {
+        return entry;
+      }
+    }
+    return std::nullopt;
+  };
+
+  auto flatMapFieldVector =
+      [&](const RowVector* root,
+          const FlatMapLeafPath& path,
+          vector_size_t row) -> std::pair<const BaseVector*, vector_size_t> {
+    const auto* map =
+        root->childAt(childIndex(root, "flatAttrs"))->as<MapVector>();
+    const auto entry = findStringKeyEntry(map, row, path.key);
+    NIMBLE_CHECK(entry.has_value(), "Expected FlatMap key in test data");
+    const auto* values = map->mapValues()->as<RowVector>();
+    return {
+        values->childAt(childIndex(values, path.field)).get(),
+        *entry,
+    };
+  };
+
+  auto flatMapFieldIsNull = [&](const RowVector* root,
+                                const FlatMapLeafPath& path,
+                                vector_size_t row) {
+    if (root->isNullAt(row)) {
+      return true;
+    }
+    const auto* map =
+        root->childAt(childIndex(root, "flatAttrs"))->as<MapVector>();
+    const auto entry = findStringKeyEntry(map, row, path.key);
+    if (!entry.has_value()) {
+      return true;
+    }
+    const auto* values = map->mapValues()->as<RowVector>();
+    if (values->isNullAt(*entry)) {
+      return true;
+    }
+    return values->childAt(childIndex(values, path.field))->isNullAt(*entry);
+  };
+
+  auto expectFlatMapLeafEqual = [&](const RowVector* expectedRoot,
+                                    vector_size_t expectedRow,
+                                    const RowVector* actualRoot,
+                                    vector_size_t actualRow,
+                                    const FlatMapLeafPath& path) {
+    const auto expectedNull =
+        flatMapFieldIsNull(expectedRoot, path, expectedRow);
+    EXPECT_EQ(flatMapFieldIsNull(actualRoot, path, actualRow), expectedNull)
+        << "path=" << path.path << " expectedRow=" << expectedRow
+        << " actualRow=" << actualRow;
+    if (expectedNull) {
+      return;
+    }
+
+    const auto [expected, expectedEntry] =
+        flatMapFieldVector(expectedRoot, path, expectedRow);
+    const auto [actual, actualEntry] =
+        flatMapFieldVector(actualRoot, path, actualRow);
+    switch (expected->type()->kind()) {
+      case TypeKind::BOOLEAN:
+        EXPECT_EQ(
+            expected->as<FlatVector<bool>>()->valueAt(expectedEntry),
+            actual->as<FlatVector<bool>>()->valueAt(actualEntry));
+        break;
+      case TypeKind::DOUBLE:
+        EXPECT_EQ(
+            expected->as<FlatVector<double>>()->valueAt(expectedEntry),
+            actual->as<FlatVector<double>>()->valueAt(actualEntry));
+        break;
+      default:
+        NIMBLE_FAIL(
+            "Unexpected FlatMap projected type {}",
+            expected->type()->toString());
+    }
+  };
+
+  auto expectRegularMapEqual = [&](const RowVector* expectedRoot,
+                                   vector_size_t expectedRow,
+                                   const RowVector* actualRoot,
+                                   vector_size_t actualRow) {
+    const auto* expectedMap =
+        expectedRoot->childAt(childIndex(expectedRoot, "attrs"))
+            ->as<MapVector>();
+    const auto* actualMap =
+        actualRoot->childAt(childIndex(actualRoot, "attrs"))->as<MapVector>();
+    const auto expectedNull = expectedRoot->isNullAt(expectedRow) ||
+        expectedMap->isNullAt(expectedRow);
+    const auto actualNull =
+        actualRoot->isNullAt(actualRow) || actualMap->isNullAt(actualRow);
+    EXPECT_EQ(actualNull, expectedNull)
+        << "expectedRow=" << expectedRow << " actualRow=" << actualRow;
+    if (expectedNull) {
+      return;
+    }
+    EXPECT_TRUE(actualMap->equalValueAt(expectedMap, actualRow, expectedRow))
+        << "expectedRow=" << expectedRow << " actualRow=" << actualRow;
+  };
+
+  const auto seed = folly::Random::rand32();
+  LOG(INFO) << "projectedComplexNullFuzzerPreservesNulls seed: " << seed;
+  folly::detail::DefaultGenerator rng{seed};
+
+  for (int iteration = 0; iteration < kIterations; ++iteration) {
+    SCOPED_TRACE(fmt::format("iteration {}", iteration));
+
+    std::vector<size_t> selectedRowIndices;
+    auto containsRowIndex = [&](size_t index) {
+      for (const auto selectedIndex : selectedRowIndices) {
+        if (selectedIndex == index) {
+          return true;
+        }
+      }
+      return false;
+    };
+    auto addRowIndex = [&](size_t index) {
+      if (!containsRowIndex(index)) {
+        selectedRowIndices.push_back(index);
+      }
+    };
+
+    for (size_t i = 0; i < rowLeafPaths.size(); ++i) {
+      if (folly::Random::oneIn(2, rng)) {
+        addRowIndex(i);
+      }
+    }
+    if (selectedRowIndices.empty()) {
+      addRowIndex(folly::Random::rand32(rng) % rowLeafPaths.size());
+    }
+    bool hasTwoLevelNestedProjection = false;
+    for (const auto index : selectedRowIndices) {
+      hasTwoLevelNestedProjection |= rowLeafPaths[index].names.size() > 2;
+    }
+    if (!hasTwoLevelNestedProjection) {
+      addRowIndex(2 + folly::Random::rand32(rng) % (rowLeafPaths.size() - 2));
+    }
+
+    std::vector<std::string_view> selectedFlatMapKeys;
+    auto addFlatMapKey = [&](std::string_view key) {
+      for (const auto selectedKey : selectedFlatMapKeys) {
+        if (selectedKey == key) {
+          return;
+        }
+      }
+      selectedFlatMapKeys.push_back(key);
+    };
+    addFlatMapKey("a");
+    if (folly::Random::oneIn(2, rng)) {
+      addFlatMapKey("b");
+    }
+
+    std::vector<common::Subfield> subfields;
+    std::vector<const RowLeafPath*> selectedRowPaths;
+    std::vector<const FlatMapLeafPath*> selectedFlatMapPaths;
+    subfields.emplace_back("attrs");
+    for (const auto index : selectedRowIndices) {
+      subfields.emplace_back(rowLeafPaths[index].path);
+      selectedRowPaths.push_back(&rowLeafPaths[index]);
+    }
+    for (const auto& path : flatMapLeafPaths) {
+      for (const auto selectedKey : selectedFlatMapKeys) {
+        if (path.key == selectedKey) {
+          subfields.emplace_back(path.path);
+          selectedFlatMapPaths.push_back(&path);
+          break;
+        }
+      }
+    }
+
+    std::vector<RowVectorPtr> inputs;
+    std::vector<std::string> serializedBatches;
+    std::vector<std::string> projectedStrings;
+    std::shared_ptr<const nimble::Type> inputSchema;
+    inputs.reserve(kBatches);
+    serializedBatches.reserve(kBatches);
+    projectedStrings.reserve(kBatches);
+
+    for (int batch = 0; batch < kBatches; ++batch) {
+      const auto hasNulls = batch % 2 == 1;
+      VectorFuzzer fuzzer(
+          {
+              .vectorSize = kRowsPerBatch,
+              .nullRatio = 0,
+              .stringLength = 12,
+              .stringVariableLength = true,
+              .containerLength = 3,
+              .containerVariableLength = true,
+              .useRandomNullPattern = true,
+              .normalizeMapKeys = true,
+          },
+          pool_.get(),
+          folly::Random::rand32(rng));
+      auto fuzzed = makeFlatInputRow(fuzzer);
+      std::vector<VectorPtr> children;
+      children.reserve(rowType->size());
+      for (size_t child = 0; child < rowType->size(); ++child) {
+        children.push_back(fuzzed->childAt(child));
+      }
+      children[childIndex(fuzzed.get(), "attrs")] =
+          makeStringRowMap(hasNulls, /*valueBase=*/1000);
+      children[childIndex(fuzzed.get(), "flatAttrs")] =
+          makeStringRowMap(hasNulls, /*valueBase=*/2000);
+      auto input = std::make_shared<RowVector>(
+          pool_.get(), type, nullptr, kRowsPerBatch, std::move(children));
+      if (hasNulls) {
+        auto* profile =
+            input->childAt(childIndex(input.get(), "profile"))->as<RowVector>();
+        auto* details =
+            profile->childAt(childIndex(profile, "details"))->as<RowVector>();
+        details->setNull(2, true);
+        auto* activity = input->childAt(childIndex(input.get(), "activity"))
+                             ->as<RowVector>();
+        auto* inner =
+            activity->childAt(childIndex(activity, "inner"))->as<RowVector>();
+        inner->setNull(3, true);
+      }
+
+      auto [serialized, schema] = serializeWithSchema(input, type, serOpts);
+      if (inputSchema == nullptr) {
+        inputSchema = schema;
+      }
+      inputs.push_back(input);
+      serializedBatches.push_back(std::move(serialized));
+    }
+
+    Projector projector(
+        inputSchema,
+        subfields,
+        pool_.get(),
+        {.projectVersion = SerializationVersion::kProjection});
+
+    for (int batch = 0; batch < kBatches; ++batch) {
+      const auto hasNulls = batch % 2 == 1;
+      auto projected =
+          projectInput(projector, serializedBatches[batch], /*useIOBuf=*/false);
+      EXPECT_EQ(outputRequiresNullBarrier(projected), hasNulls);
+      projectedStrings.push_back(toString(projected));
+    }
+
+    std::vector<std::string_view> batches;
+    batches.reserve(projectedStrings.size());
+    for (const auto& projectedString : projectedStrings) {
+      batches.push_back(projectedString);
+    }
+
+    Deserializer deserializer{
+        projector.projectedSchema(), pool_.get(), {.hasHeader = true}};
+    VectorPtr output;
+    deserializer.deserialize(batches, output);
+    ASSERT_EQ(output->size(), kRowsPerBatch * kBatches);
+
+    const auto* outputRow = output->as<RowVector>();
+    for (int batch = 0; batch < kBatches; ++batch) {
+      const auto* inputRow = inputs[batch].get();
+      for (vector_size_t row = 0; row < kRowsPerBatch; ++row) {
+        const auto outputRowIndex = batch * kRowsPerBatch + row;
+        expectRegularMapEqual(inputRow, row, outputRow, outputRowIndex);
+        for (const auto* path : selectedRowPaths) {
+          expectLeafEqual(inputRow, row, outputRow, outputRowIndex, *path);
+        }
+        for (const auto* path : selectedFlatMapPaths) {
+          expectFlatMapLeafEqual(
+              inputRow, row, outputRow, outputRowIndex, *path);
+        }
+      }
+    }
+  }
 }
 
 // Test auto name mapping via projectType for schema evolution (column renames).
@@ -2453,8 +3651,8 @@ TEST_F(ProjectorTest, projectMultipleFlatMapColumns) {
 }
 
 // Verifies that the projector correctly handles serialized FlatMap data with
-// constant in-map stream skipping (both all-false and all-true cases).
-TEST_F(ProjectorTestBase, flatMapInMapStreamSkipping) {
+// omitted constant in-map streams (both all-false and all-true cases).
+TEST_F(ProjectorTestBase, flatMapConstantInMapStreams) {
   auto type = ROW({
       {"id", BIGINT()},
       {"flat_map", MAP(VARCHAR(), DOUBLE())},
@@ -2515,8 +3713,8 @@ TEST_F(ProjectorTestBase, flatMapInMapStreamSkipping) {
       .flatMapColumns = {{"flat_map", {}}},
   };
 
-  // Serialize multiple batches with different key sets to trigger in-map
-  // stream skipping (all-false for absent keys, all-true for present keys).
+  // Serialize multiple batches with different key sets to exercise constant
+  // in-map streams (all-false for absent keys, all-true for present keys).
   Serializer serializer{serOpts, type, pool_.get()};
 
   // Batch 1: keys "a" and "b"
@@ -2524,7 +3722,7 @@ TEST_F(ProjectorTestBase, flatMapInMapStreamSkipping) {
   auto serialized1 = std::string(
       serializer.serialize(batch1, OrderedRanges::of(0, batch1->size())));
 
-  // Batch 2: only key "a" (key "b" all-false in-map -> skipped)
+  // Batch 2: only key "a" (key "b" all-false in-map).
   auto batch2 = generateBatch({"a"});
   auto serialized2 = std::string(
       serializer.serialize(batch2, OrderedRanges::of(0, batch2->size())));
@@ -2534,8 +3732,7 @@ TEST_F(ProjectorTestBase, flatMapInMapStreamSkipping) {
   auto serialized3 = std::string(
       serializer.serialize(batch3, OrderedRanges::of(0, batch3->size())));
 
-  // Batch 4: keys "a", "b" (key "c" all-false, "a" and "b" all-true -> all
-  // three in-map streams are constant, all skipped)
+  // Batch 4: keys "a", "b" (key "c" all-false, "a" and "b" all-true).
   auto batch4 = generateBatch({"a", "b"});
   auto serialized4 = std::string(
       serializer.serialize(batch4, OrderedRanges::of(0, batch4->size())));
@@ -2547,7 +3744,7 @@ TEST_F(ProjectorTestBase, flatMapInMapStreamSkipping) {
   auto collectStreamOffsets =
       [&](std::string_view data) -> folly::F14FastSet<uint32_t> {
     DeserializerOptions desOpts{.hasHeader = true};
-    serde::StreamDataReader reader{pool_.get(), desOpts};
+    serde::StreamDataParser reader{pool_.get(), desOpts};
     reader.initialize(data);
     folly::F14FastSet<uint32_t> offsets;
     reader.iterateStreams(
@@ -2564,35 +3761,39 @@ TEST_F(ProjectorTestBase, flatMapInMapStreamSkipping) {
   }
   ASSERT_EQ(inMapOffsets.size(), 3);
 
-  // Verify constant in-map streams are NOT stored in serialized data.
+  // Verify constant in-map streams are omitted once their keys are discovered.
   {
     auto offsets1 = collectStreamOffsets(serialized1);
     EXPECT_FALSE(offsets1.contains(inMapOffsets[0]))
-        << "batch1: in-map 'a' should be skipped";
+        << "batch1: in-map 'a' should be absent";
     EXPECT_FALSE(offsets1.contains(inMapOffsets[1]))
-        << "batch1: in-map 'b' should be skipped";
+        << "batch1: in-map 'b' should be absent";
+    EXPECT_FALSE(offsets1.contains(inMapOffsets[2]))
+        << "batch1: in-map 'c' should be absent before discovery";
 
     auto offsets2 = collectStreamOffsets(serialized2);
     EXPECT_FALSE(offsets2.contains(inMapOffsets[0]))
-        << "batch2: in-map 'a' should be skipped";
+        << "batch2: in-map 'a' should be absent";
     EXPECT_FALSE(offsets2.contains(inMapOffsets[1]))
-        << "batch2: in-map 'b' should be skipped";
+        << "batch2: in-map 'b' should be absent";
+    EXPECT_FALSE(offsets2.contains(inMapOffsets[2]))
+        << "batch2: in-map 'c' should be absent before discovery";
 
     auto offsets3 = collectStreamOffsets(serialized3);
     EXPECT_FALSE(offsets3.contains(inMapOffsets[0]))
-        << "batch3: in-map 'a' should be skipped";
+        << "batch3: in-map 'a' should be absent";
     EXPECT_FALSE(offsets3.contains(inMapOffsets[1]))
-        << "batch3: in-map 'b' should be skipped";
+        << "batch3: in-map 'b' should be absent";
     EXPECT_FALSE(offsets3.contains(inMapOffsets[2]))
-        << "batch3: in-map 'c' should be skipped";
+        << "batch3: in-map 'c' should be absent";
 
     auto offsets4 = collectStreamOffsets(serialized4);
     EXPECT_FALSE(offsets4.contains(inMapOffsets[0]))
-        << "batch4: in-map 'a' should be skipped";
+        << "batch4: in-map 'a' should be absent";
     EXPECT_FALSE(offsets4.contains(inMapOffsets[1]))
-        << "batch4: in-map 'b' should be skipped";
+        << "batch4: in-map 'b' should be absent";
     EXPECT_FALSE(offsets4.contains(inMapOffsets[2]))
-        << "batch4: in-map 'c' should be skipped";
+        << "batch4: in-map 'c' should be absent";
   }
 
   // Project all columns through the projector. FlatMap requires explicit key

--- a/dwio/nimble/serializer/tests/SerializationHeaderTest.cpp
+++ b/dwio/nimble/serializer/tests/SerializationHeaderTest.cpp
@@ -14,7 +14,11 @@
  * limitations under the License.
  */
 
+#include <cstdint>
 #include <limits>
+#include <optional>
+#include <string>
+#include <vector>
 
 #include <gtest/gtest.h>
 
@@ -24,97 +28,255 @@
 using namespace facebook::nimble;
 using namespace facebook::nimble::serde;
 
-// ---- SerializationHeader tests ----
+namespace {
 
-TEST(SerializationHeaderTest, writeReadRoundtripLegacy) {
-  std::string buffer;
-  writeSerializationHeader(buffer, SerializationVersion::kLegacy, 42);
-
-  const char* pos = buffer.data();
-  auto header = readSerializationHeader(pos, pos + buffer.size(), true);
-  EXPECT_EQ(header.version, SerializationVersion::kLegacy);
-  EXPECT_EQ(header.rowCount, 42);
-  EXPECT_FALSE(header.rowRange.has_value());
+std::string nullBarrierName(bool requiresNullBarrier) {
+  return requiresNullBarrier ? "requiresNullBarrier" : "noNullBarrier";
 }
 
-TEST(SerializationHeaderTest, writeReadRoundtripCompactRaw) {
-  std::string buffer;
-  writeSerializationHeader(buffer, SerializationVersion::kLegacyCompact, 1000);
-
-  const char* pos = buffer.data();
-  auto header = readSerializationHeader(pos, pos + buffer.size(), true);
-  EXPECT_EQ(header.version, SerializationVersion::kLegacyCompact);
-  EXPECT_EQ(header.rowCount, 1000);
-  EXPECT_FALSE(header.rowRange.has_value());
+void setNullBarrierRequiredFlag(
+    std::string& buffer,
+    size_t flagsOffset,
+    bool requiresNullBarrier) {
+  NIMBLE_CHECK_LT(flagsOffset, buffer.size(), "Invalid flags byte offset");
+  buffer[flagsOffset] = static_cast<char>(
+      requiresNullBarrier ? SerializationHeader::kNullBarrierRequiredFlag : 0);
 }
 
-TEST(SerializationHeaderTest, writeReadRoundtripNoHeader) {
-  std::string buffer;
-  writeSerializationHeader(buffer, std::nullopt, 100);
-
-  const char* pos = buffer.data();
-  auto header = readSerializationHeader(pos, pos + buffer.size(), false);
-  EXPECT_EQ(header.version, SerializationVersion::kLegacy);
-  EXPECT_EQ(header.rowCount, 100);
-  EXPECT_FALSE(header.rowRange.has_value());
+std::string describeVersion(std::optional<SerializationVersion> version) {
+  return version.has_value() ? toString(*version) : std::string{"nullopt"};
 }
 
-TEST(SerializationHeaderTest, readTabletHeader) {
-  auto iobuf =
-      createTabletChunkHeader({.rowCount = 500, .rowRange = RowRange{10, 200}});
-  const char* pos = reinterpret_cast<const char*>(iobuf.data());
-  const char* end = pos + iobuf.length();
+struct SerializationHeaderRoundTripParam {
+  std::string name;
+  std::optional<SerializationVersion> version;
+  SerializationVersion expectedVersion{SerializationVersion::kLegacy};
+  uint32_t rowCount{};
+  bool requiresNullBarrier{};
+  bool hasHeader{};
 
-  auto header = readSerializationHeader(pos, end, true);
-  EXPECT_EQ(header.version, SerializationVersion::kTablet);
-  EXPECT_EQ(header.rowCount, 500);
-  ASSERT_TRUE(header.rowRange.has_value());
-  EXPECT_EQ(header.rowRange->startRow, 10);
-  EXPECT_EQ(header.rowRange->endRow, 200);
-}
+  std::string toString() const {
+    return "version=" + describeVersion(version) +
+        " rowCount=" + std::to_string(rowCount) +
+        " requiresNullBarrier=" + nullBarrierName(requiresNullBarrier) +
+        " hasHeader=" + (hasHeader ? "true" : "false");
+  }
+};
 
-TEST(SerializationHeaderTest, readRejectsUnsupportedVersion) {
-  std::string buffer;
-  buffer.push_back(static_cast<char>(99));
-  const char* pos = buffer.data();
-  NIMBLE_ASSERT_THROW(
-      readSerializationHeader(pos, pos + buffer.size(), true),
-      "Unsupported version");
-}
+struct SerializationHeaderSizeParam {
+  std::string name;
+  SerializationVersion version{SerializationVersion::kLegacy};
+  uint32_t rowCount{};
+  bool requiresNullBarrier{};
 
-TEST(SerializationHeaderTest, writeRejectsTablet) {
-  std::string buffer;
-  NIMBLE_ASSERT_THROW(
-      writeSerializationHeader(buffer, SerializationVersion::kTablet, 100),
-      "kTablet headers must use createTabletChunkHeader()");
-}
+  std::string toString() const {
+    return "version=" + facebook::nimble::toString(version) +
+        " rowCount=" + std::to_string(rowCount) +
+        " requiresNullBarrier=" + nullBarrierName(requiresNullBarrier);
+  }
+};
 
-TEST(SerializationHeaderTest, estimateRejectsTablet) {
-  NIMBLE_ASSERT_THROW(
-      estimateSerializationHeaderSize(SerializationVersion::kTablet, 100),
-      "kTablet headers must use createTabletChunkHeader()");
-}
+struct ReadNullBarrierFlagParam {
+  std::string name;
+  std::optional<SerializationVersion> version;
+  uint8_t flagsByte{};
+  bool expectedRequiresNullBarrier{};
+  size_t expectedAdvance{};
 
-TEST(SerializationHeaderTest, estimateSizeMatchesActual) {
-  for (auto version :
-       {std::optional<SerializationVersion>{std::nullopt},
-        std::optional{SerializationVersion::kLegacy},
-        std::optional{SerializationVersion::kLegacyCompact}}) {
+  std::string toString() const {
+    return "version=" + describeVersion(version) +
+        " flagsByte=" + std::to_string(flagsByte) +
+        " expectedRequiresNullBarrier=" +
+        nullBarrierName(expectedRequiresNullBarrier) +
+        " expectedAdvance=" + std::to_string(expectedAdvance);
+  }
+};
+
+struct ReadNullBarrierFlagVersionParam {
+  std::string name;
+  SerializationVersion version;
+  uint8_t flagsByte{};
+  bool expectedRequiresNullBarrier{};
+  size_t expectedAdvance{};
+
+  std::string toString() const {
+    return "version=" + facebook::nimble::toString(version) +
+        " flagsByte=" + std::to_string(flagsByte) +
+        " expectedRequiresNullBarrier=" +
+        nullBarrierName(expectedRequiresNullBarrier) +
+        " expectedAdvance=" + std::to_string(expectedAdvance);
+  }
+};
+
+struct TabletChunkHeaderRoundTripParam {
+  std::string name;
+  uint32_t rowCount{};
+  RowRange rowRange;
+  std::optional<std::string> resumeKey;
+  bool requiresNullBarrier{};
+
+  std::string toString() const {
+    return "rowCount=" + std::to_string(rowCount) + " rowRange=[" +
+        std::to_string(rowRange.startRow) + "," +
+        std::to_string(rowRange.endRow) +
+        "] requiresNullBarrier=" + nullBarrierName(requiresNullBarrier) +
+        " resumeKey=" + (resumeKey.has_value() ? "present" : "absent");
+  }
+};
+
+struct InvalidTabletRowRangeParam {
+  std::string name;
+  uint32_t rowCount{};
+  RowRange rowRange;
+  bool requiresNullBarrier{};
+
+  std::string toString() const {
+    return "rowCount=" + std::to_string(rowCount) + " rowRange=[" +
+        std::to_string(rowRange.startRow) + "," +
+        std::to_string(rowRange.endRow) +
+        "] requiresNullBarrier=" + nullBarrierName(requiresNullBarrier);
+  }
+};
+
+std::vector<SerializationHeaderSizeParam> serializationHeaderSizeParams() {
+  struct VersionCase {
+    SerializationVersion version;
+    bool requiresNullBarrier{};
+  };
+
+  const VersionCase versionCases[]{
+      {
+          .version = SerializationVersion::kSerialization,
+          .requiresNullBarrier = false,
+      },
+      {
+          .version = SerializationVersion::kSerialization,
+          .requiresNullBarrier = true,
+      },
+      {
+          .version = SerializationVersion::kProjection,
+          .requiresNullBarrier = false,
+      },
+      {
+          .version = SerializationVersion::kProjection,
+          .requiresNullBarrier = true,
+      },
+  };
+
+  std::vector<SerializationHeaderSizeParam> params;
+  for (const auto& versionCase : versionCases) {
     for (uint32_t rowCount : {0u, 1u, 127u, 128u, 16383u, 1000000u}) {
-      std::string buffer;
-      writeSerializationHeader(buffer, version, rowCount);
-      EXPECT_EQ(
-          estimateSerializationHeaderSize(version, rowCount), buffer.size())
-          << "version="
-          << (version.has_value() ? toString(*version) : "nullopt")
-          << " rowCount=" << rowCount;
+      params.push_back({
+          .name = toString(versionCase.version) + "_" +
+              nullBarrierName(versionCase.requiresNullBarrier) + "_rows" +
+              std::to_string(rowCount),
+          .version = versionCase.version,
+          .rowCount = rowCount,
+          .requiresNullBarrier = versionCase.requiresNullBarrier,
+      });
     }
   }
+  return params;
 }
 
-// ---- TabletChunkHeader tests ----
+std::vector<TabletChunkHeaderRoundTripParam>
+tabletChunkHeaderRoundTripParams() {
+  struct BaseCase {
+    std::string name;
+    uint32_t rowCount{};
+    RowRange rowRange;
+    std::optional<std::string> resumeKey;
+  };
 
-namespace {
+  const BaseCase baseCases[]{
+      {
+          .name = "noResumeKey",
+          .rowCount = 100,
+          .rowRange = RowRange{0, 100},
+      },
+      {
+          .name = "narrowRowRange",
+          .rowCount = 100,
+          .rowRange = RowRange{10, 40},
+      },
+      {
+          .name = "withResumeKey",
+          .rowCount = 100,
+          .rowRange = RowRange{0, 100},
+          .resumeKey = std::string{"my-resume-key"},
+      },
+      {
+          .name = "narrowRangeAndResumeKey",
+          .rowCount = 4096,
+          .rowRange = RowRange{500, 1000},
+          .resumeKey = std::string{"\x00\x01\x02", 3},
+      },
+      {
+          .name = "emptyResumeKey",
+          .rowCount = 1,
+          .rowRange = RowRange{0, 1},
+          .resumeKey = std::string{},
+      },
+      {
+          .name = "maxUint32RowCount",
+          .rowCount = std::numeric_limits<uint32_t>::max(),
+          .rowRange = RowRange{0, std::numeric_limits<uint32_t>::max()},
+      },
+      {
+          .name = "exactBoundaryEndRowEqualsRowCount",
+          .rowCount = 100,
+          .rowRange = RowRange{99, 100},
+      },
+  };
+
+  std::vector<TabletChunkHeaderRoundTripParam> params;
+  for (const auto& baseCase : baseCases) {
+    for (const bool requiresNullBarrier : {false, true}) {
+      params.push_back({
+          .name = baseCase.name + "_" + nullBarrierName(requiresNullBarrier),
+          .rowCount = baseCase.rowCount,
+          .rowRange = baseCase.rowRange,
+          .resumeKey = baseCase.resumeKey,
+          .requiresNullBarrier = requiresNullBarrier,
+      });
+    }
+  }
+  return params;
+}
+
+std::vector<InvalidTabletRowRangeParam> invalidTabletRowRangeParams() {
+  struct BaseCase {
+    std::string name;
+    uint32_t rowCount{};
+    RowRange rowRange;
+  };
+
+  const BaseCase baseCases[]{
+      {
+          .name = "rowRangeExceedingRowCount",
+          .rowCount = 5,
+          .rowRange = RowRange{0, 100},
+      },
+      {
+          .name = "invertedRowRange",
+          .rowCount = 10,
+          .rowRange = RowRange{5, 3},
+      },
+  };
+
+  std::vector<InvalidTabletRowRangeParam> params;
+  for (const auto& baseCase : baseCases) {
+    for (const bool requiresNullBarrier : {false, true}) {
+      params.push_back({
+          .name = baseCase.name + "_" + nullBarrierName(requiresNullBarrier),
+          .rowCount = baseCase.rowCount,
+          .rowRange = baseCase.rowRange,
+          .requiresNullBarrier = requiresNullBarrier,
+      });
+    }
+  }
+  return params;
+}
 
 TabletChunkHeader roundTripTabletChunkHeader(const TabletChunkHeader& in) {
   auto buf = createTabletChunkHeader(in);
@@ -127,54 +289,539 @@ TabletChunkHeader roundTripTabletChunkHeader(const TabletChunkHeader& in) {
 
 } // namespace
 
-TEST(TabletChunkHeaderTest, noResumeKey) {
-  TabletChunkHeader in{.rowCount = 100, .rowRange = RowRange{0, 100}};
-  const auto out = roundTripTabletChunkHeader(in);
-  EXPECT_EQ(out.rowCount, 100u);
-  EXPECT_EQ(out.rowRange, RowRange(0, 100));
-  EXPECT_FALSE(out.resumeKey.has_value());
+// ---- SerializationHeader tests ----
+
+class SerializationHeaderRoundTripTest
+    : public ::testing::TestWithParam<SerializationHeaderRoundTripParam> {};
+
+TEST_P(SerializationHeaderRoundTripTest, writeReadRoundtrip) {
+  const auto& testCase = GetParam();
+  SCOPED_TRACE(testCase.toString());
+
+  std::string buffer;
+  if (testCase.version.has_value() && usesHeaderFlags(*testCase.version)) {
+    const auto flagsOffset =
+        writeSerializationHeader(buffer, *testCase.version, testCase.rowCount);
+    EXPECT_EQ(
+        flagsOffset, sizeof(uint8_t) + varint::varintSize(testCase.rowCount));
+    setNullBarrierRequiredFlag(
+        buffer, flagsOffset, testCase.requiresNullBarrier);
+  } else {
+    EXPECT_FALSE(testCase.requiresNullBarrier);
+    writeLegacySerializationHeader(buffer, testCase.version, testCase.rowCount);
+  }
+
+  const char* pos = buffer.data();
+  const auto header =
+      readSerializationHeader(pos, pos + buffer.size(), testCase.hasHeader);
+  EXPECT_EQ(header.version, testCase.expectedVersion);
+  EXPECT_EQ(header.rowCount, testCase.rowCount);
+  EXPECT_EQ(header.requiresNullBarrier, testCase.requiresNullBarrier);
+  EXPECT_FALSE(header.rowRange.has_value());
 }
 
-TEST(TabletChunkHeaderTest, narrowRowRange) {
-  TabletChunkHeader in{.rowCount = 100, .rowRange = RowRange{10, 40}};
-  const auto out = roundTripTabletChunkHeader(in);
-  EXPECT_EQ(out.rowCount, 100u);
-  EXPECT_EQ(out.rowRange.startRow, 10u);
-  EXPECT_EQ(out.rowRange.endRow, 40u);
-  EXPECT_FALSE(out.resumeKey.has_value());
+INSTANTIATE_TEST_SUITE_P(
+    SerializationHeaderTest,
+    SerializationHeaderRoundTripTest,
+    ::testing::Values(
+        SerializationHeaderRoundTripParam{
+            .name = "noHeader",
+            .version = std::nullopt,
+            .expectedVersion = SerializationVersion::kLegacy,
+            .rowCount = 100,
+            .requiresNullBarrier = false,
+            .hasHeader = false,
+        },
+        SerializationHeaderRoundTripParam{
+            .name = "legacy",
+            .version = std::optional{SerializationVersion::kLegacy},
+            .expectedVersion = SerializationVersion::kLegacy,
+            .rowCount = 42,
+            .requiresNullBarrier = false,
+            .hasHeader = true,
+        },
+        SerializationHeaderRoundTripParam{
+            .name = "legacyCompact",
+            .version = std::optional{SerializationVersion::kLegacyCompact},
+            .expectedVersion = SerializationVersion::kLegacyCompact,
+            .rowCount = 1000,
+            .requiresNullBarrier = false,
+            .hasHeader = true,
+        },
+        SerializationHeaderRoundTripParam{
+            .name = "legacySerialization",
+            .version =
+                std::optional{SerializationVersion::kLegacySerialization},
+            .expectedVersion = SerializationVersion::kLegacySerialization,
+            .rowCount = 1000,
+            .requiresNullBarrier = false,
+            .hasHeader = true,
+        },
+        SerializationHeaderRoundTripParam{
+            .name = "serializationNoNullBarrier",
+            .version = std::optional{SerializationVersion::kSerialization},
+            .expectedVersion = SerializationVersion::kSerialization,
+            .rowCount = 1000,
+            .requiresNullBarrier = false,
+            .hasHeader = true,
+        },
+        SerializationHeaderRoundTripParam{
+            .name = "serializationRequiresNullBarrier",
+            .version = std::optional{SerializationVersion::kSerialization},
+            .expectedVersion = SerializationVersion::kSerialization,
+            .rowCount = 1000,
+            .requiresNullBarrier = true,
+            .hasHeader = true,
+        },
+        SerializationHeaderRoundTripParam{
+            .name = "projectionNoNullBarrier",
+            .version = std::optional{SerializationVersion::kProjection},
+            .expectedVersion = SerializationVersion::kProjection,
+            .rowCount = 1000,
+            .requiresNullBarrier = false,
+            .hasHeader = true,
+        },
+        SerializationHeaderRoundTripParam{
+            .name = "projectionRequiresNullBarrier",
+            .version = std::optional{SerializationVersion::kProjection},
+            .expectedVersion = SerializationVersion::kProjection,
+            .rowCount = 1000,
+            .requiresNullBarrier = true,
+            .hasHeader = true,
+        }),
+    [](const ::testing::TestParamInfo<SerializationHeaderRoundTripParam>&
+           info) { return info.param.name; });
+
+TEST(SerializationHeaderTest, readRejectsUnsupportedVersion) {
+  std::string buffer;
+  buffer.push_back(static_cast<char>(99));
+  const char* pos = buffer.data();
+  NIMBLE_ASSERT_THROW(
+      readSerializationHeader(pos, pos + buffer.size(), true),
+      "Unsupported version");
 }
 
-TEST(TabletChunkHeaderTest, withResumeKey) {
-  TabletChunkHeader in{
-      .rowCount = 100,
-      .rowRange = RowRange{0, 100},
-      .resumeKey = std::string{"my-resume-key"}};
-  const auto out = roundTripTabletChunkHeader(in);
-  EXPECT_EQ(out.rowCount, 100u);
-  EXPECT_EQ(out.rowRange, RowRange(0, 100));
-  ASSERT_TRUE(out.resumeKey.has_value());
-  EXPECT_EQ(*out.resumeKey, "my-resume-key");
+TEST(SerializationHeaderTest, writeNullableHeaderRejectsNonNullableVersions) {
+  for (const auto version :
+       {SerializationVersion::kLegacy,
+        SerializationVersion::kLegacyCompact,
+        SerializationVersion::kTablet,
+        SerializationVersion::kLegacySerialization}) {
+    SCOPED_TRACE(toString(version));
+    std::string buffer;
+    NIMBLE_ASSERT_THROW(
+        writeSerializationHeader(buffer, version, 100),
+        "Serialization header writes require kSerialization or kProjection");
+  }
 }
 
-TEST(TabletChunkHeaderTest, narrowRangeAndResumeKey) {
-  TabletChunkHeader in{
-      .rowCount = 4096,
-      .rowRange = RowRange{500, 1000},
-      .resumeKey = std::string{"\x00\x01\x02", 3}};
-  const auto out = roundTripTabletChunkHeader(in);
-  EXPECT_EQ(out.rowCount, 4096u);
-  EXPECT_EQ(out.rowRange, RowRange(500, 1000));
-  ASSERT_TRUE(out.resumeKey.has_value());
-  EXPECT_EQ(*out.resumeKey, (std::string{"\x00\x01\x02", 3}));
+TEST(SerializationHeaderTest, writeLegacyHeaderRejectsFlaggedVersions) {
+  for (const auto version :
+       {SerializationVersion::kSerialization,
+        SerializationVersion::kProjection}) {
+    SCOPED_TRACE(toString(version));
+    std::string buffer;
+    NIMBLE_ASSERT_THROW(
+        writeLegacySerializationHeader(buffer, std::optional{version}, 100),
+        "Serialization headers without flags cannot write versions with header flags");
+  }
 }
 
-TEST(TabletChunkHeaderTest, emptyResumeKey) {
-  TabletChunkHeader in{
-      .rowCount = 1, .rowRange = RowRange{0, 1}, .resumeKey = std::string{}};
-  const auto out = roundTripTabletChunkHeader(in);
-  EXPECT_EQ(out.rowCount, 1u);
-  ASSERT_TRUE(out.resumeKey.has_value());
-  EXPECT_TRUE(out.resumeKey->empty());
+TEST(SerializationHeaderTest, writeLegacyHeaderRejectsTabletVersion) {
+  std::string buffer;
+  NIMBLE_ASSERT_THROW(
+      writeLegacySerializationHeader(
+          buffer, std::optional{SerializationVersion::kTablet}, 100),
+      "kTablet headers must use createTabletChunkHeader()");
+}
+
+TEST(
+    SerializationHeaderTest,
+    writeLegacySerializationHeaderEncodesLegacyFormats) {
+  enum class RowCountEncoding {
+    kFixed32,
+    kVarint32,
+  };
+
+  struct TestCase {
+    std::string name;
+    std::optional<SerializationVersion> version;
+    SerializationVersion expectedVersion{SerializationVersion::kLegacy};
+    uint32_t rowCount{};
+    bool hasHeader{};
+    RowCountEncoding rowCountEncoding{RowCountEncoding::kFixed32};
+  };
+
+  const TestCase testCases[]{
+      {
+          .name = "noHeader",
+          .version = std::nullopt,
+          .expectedVersion = SerializationVersion::kLegacy,
+          .rowCount = 0x12345678,
+          .hasHeader = false,
+          .rowCountEncoding = RowCountEncoding::kFixed32,
+      },
+      {
+          .name = "legacy",
+          .version = std::optional{SerializationVersion::kLegacy},
+          .expectedVersion = SerializationVersion::kLegacy,
+          .rowCount = 42,
+          .hasHeader = true,
+          .rowCountEncoding = RowCountEncoding::kFixed32,
+      },
+      {
+          .name = "legacyCompact",
+          .version = std::optional{SerializationVersion::kLegacyCompact},
+          .expectedVersion = SerializationVersion::kLegacyCompact,
+          .rowCount = 1000,
+          .hasHeader = true,
+          .rowCountEncoding = RowCountEncoding::kVarint32,
+      },
+      {
+          .name = "legacySerialization",
+          .version = std::optional{SerializationVersion::kLegacySerialization},
+          .expectedVersion = SerializationVersion::kLegacySerialization,
+          .rowCount = 128,
+          .hasHeader = true,
+          .rowCountEncoding = RowCountEncoding::kVarint32,
+      },
+  };
+
+  for (const auto& testCase : testCases) {
+    SCOPED_TRACE(testCase.name);
+
+    std::string buffer;
+    writeLegacySerializationHeader(buffer, testCase.version, testCase.rowCount);
+
+    const size_t versionSize = testCase.hasHeader ? sizeof(uint8_t) : 0;
+    if (testCase.hasHeader) {
+      ASSERT_TRUE(testCase.version.has_value());
+      ASSERT_GE(buffer.size(), versionSize);
+      EXPECT_EQ(
+          static_cast<uint8_t>(buffer[0]),
+          static_cast<uint8_t>(*testCase.version));
+    }
+
+    const char* rowCountStart = buffer.data() + versionSize;
+    switch (testCase.rowCountEncoding) {
+      case RowCountEncoding::kFixed32: {
+        ASSERT_EQ(buffer.size(), versionSize + sizeof(uint32_t));
+        const auto* data = reinterpret_cast<const uint8_t*>(rowCountStart);
+        EXPECT_EQ(data[0], static_cast<uint8_t>(testCase.rowCount));
+        EXPECT_EQ(data[1], static_cast<uint8_t>(testCase.rowCount >> 8));
+        EXPECT_EQ(data[2], static_cast<uint8_t>(testCase.rowCount >> 16));
+        EXPECT_EQ(data[3], static_cast<uint8_t>(testCase.rowCount >> 24));
+        break;
+      }
+      case RowCountEncoding::kVarint32: {
+        ASSERT_GE(buffer.size(), versionSize + 1);
+        const char* pos = rowCountStart;
+        EXPECT_EQ(varint::readVarint32(&pos), testCase.rowCount);
+        EXPECT_EQ(pos, buffer.data() + buffer.size());
+        break;
+      }
+    }
+
+    const char* pos = buffer.data();
+    const auto header = readSerializationHeader(
+        pos, pos + buffer.size(), /*hasHeader=*/testCase.hasHeader);
+    EXPECT_EQ(header.version, testCase.expectedVersion);
+    EXPECT_EQ(header.rowCount, testCase.rowCount);
+    EXPECT_FALSE(header.requiresNullBarrier);
+    EXPECT_EQ(pos, buffer.data() + buffer.size());
+  }
+}
+
+TEST(SerializationHeaderTest, estimateRejectsReadOnlyVersions) {
+  for (const auto version :
+       {SerializationVersion::kLegacy,
+        SerializationVersion::kLegacyCompact,
+        SerializationVersion::kTablet,
+        SerializationVersion::kLegacySerialization}) {
+    SCOPED_TRACE(toString(version));
+    NIMBLE_ASSERT_THROW(
+        estimateSerializationHeaderSize(version, 100),
+        "Serialization header writes require kSerialization or kProjection");
+  }
+}
+
+TEST(SerializationHeaderTest, setNullBarrierRequiredFlagRejectsInvalidOffset) {
+  std::string buffer;
+  const auto flagsOffset = writeSerializationHeader(
+      buffer, SerializationVersion::kSerialization, /*rowCount=*/100);
+  ASSERT_LT(flagsOffset, buffer.size());
+
+  NIMBLE_ASSERT_THROW(
+      setNullBarrierRequiredFlag(buffer, buffer.size(), true),
+      "Invalid flags byte offset");
+}
+
+TEST(SerializationHeaderTest, writesFlagsAfterRowCount) {
+  std::string buffer;
+  const auto flagsOffset = writeSerializationHeader(
+      buffer, SerializationVersion::kSerialization, /*rowCount=*/128);
+  setNullBarrierRequiredFlag(buffer, flagsOffset, /*requiresNullBarrier=*/true);
+
+  ASSERT_EQ(buffer.size(), size_t{4});
+  EXPECT_EQ(
+      static_cast<uint8_t>(buffer[0]),
+      static_cast<uint8_t>(SerializationVersion::kSerialization));
+  EXPECT_EQ(static_cast<uint8_t>(buffer[1]), 0x80);
+  EXPECT_EQ(static_cast<uint8_t>(buffer[2]), 0x01);
+  EXPECT_EQ(
+      static_cast<uint8_t>(buffer[3]),
+      SerializationHeader::kNullBarrierRequiredFlag);
+  EXPECT_EQ(flagsOffset, size_t{3});
+}
+
+class SerializationHeaderSizeTest
+    : public ::testing::TestWithParam<SerializationHeaderSizeParam> {};
+
+TEST_P(SerializationHeaderSizeTest, estimateSizeMatchesActual) {
+  const auto& testCase = GetParam();
+  SCOPED_TRACE(testCase.toString());
+
+  std::string buffer;
+  const auto flagsOffset =
+      writeSerializationHeader(buffer, testCase.version, testCase.rowCount);
+  setNullBarrierRequiredFlag(buffer, flagsOffset, testCase.requiresNullBarrier);
+  EXPECT_EQ(
+      estimateSerializationHeaderSize(testCase.version, testCase.rowCount),
+      buffer.size());
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    SerializationHeaderTest,
+    SerializationHeaderSizeTest,
+    ::testing::ValuesIn(serializationHeaderSizeParams()),
+    [](const ::testing::TestParamInfo<SerializationHeaderSizeParam>& info) {
+      return info.param.name;
+    });
+
+class ReadNullBarrierFlagTest
+    : public ::testing::TestWithParam<ReadNullBarrierFlagParam> {};
+
+TEST_P(ReadNullBarrierFlagTest, readPointer) {
+  const auto& testCase = GetParam();
+  SCOPED_TRACE(testCase.toString());
+  std::string flagged;
+  flagged.push_back(static_cast<char>(testCase.flagsByte));
+
+  const char* pos = flagged.data();
+  EXPECT_EQ(
+      readRequiresNullBarrierFlag(pos, testCase.version),
+      testCase.expectedRequiresNullBarrier);
+  EXPECT_EQ(pos, flagged.data() + testCase.expectedAdvance);
+}
+
+TEST_P(ReadNullBarrierFlagTest, readCursor) {
+  const auto& testCase = GetParam();
+  SCOPED_TRACE(testCase.toString());
+  constexpr uint8_t kSentinel{0x7f};
+  std::string flagged;
+  flagged.push_back(static_cast<char>(testCase.flagsByte));
+  flagged.push_back(static_cast<char>(kSentinel));
+
+  auto buf = folly::IOBuf::wrapBufferAsValue(flagged.data(), flagged.size());
+  folly::io::Cursor cursor(&buf);
+  EXPECT_EQ(
+      readRequiresNullBarrierFlag(cursor, testCase.version),
+      testCase.expectedRequiresNullBarrier);
+  EXPECT_EQ(
+      cursor.read<uint8_t>(),
+      testCase.expectedAdvance == 0 ? testCase.flagsByte : kSentinel);
+}
+
+TEST(SerializationHeaderTest, readRequiresNullBarrierFlagVersionOverloads) {
+  const ReadNullBarrierFlagVersionParam testCases[]{
+      {
+          .name = "serializationRequiresNullBarrier",
+          .version = SerializationVersion::kSerialization,
+          .flagsByte = SerializationHeader::kNullBarrierRequiredFlag,
+          .expectedRequiresNullBarrier = true,
+          .expectedAdvance = 1,
+      },
+      {
+          .name = "projectionNoNullBarrier",
+          .version = SerializationVersion::kProjection,
+          .flagsByte = 0,
+          .expectedRequiresNullBarrier = false,
+          .expectedAdvance = 1,
+      },
+      {
+          .name = "legacySerializationIgnoresFlagByte",
+          .version = SerializationVersion::kLegacySerialization,
+          .flagsByte = SerializationHeader::kNullBarrierRequiredFlag,
+          .expectedRequiresNullBarrier = false,
+          .expectedAdvance = 0,
+      },
+  };
+
+  for (const auto& testCase : testCases) {
+    SCOPED_TRACE(testCase.toString());
+    std::string flagged;
+    flagged.push_back(static_cast<char>(testCase.flagsByte));
+
+    const char* pos = flagged.data();
+    EXPECT_EQ(
+        readRequiresNullBarrierFlag(pos, testCase.version),
+        testCase.expectedRequiresNullBarrier);
+    EXPECT_EQ(pos, flagged.data() + testCase.expectedAdvance);
+
+    constexpr uint8_t kSentinel{0x7f};
+    flagged.push_back(static_cast<char>(kSentinel));
+    auto buf = folly::IOBuf::wrapBufferAsValue(flagged.data(), flagged.size());
+    folly::io::Cursor cursor(&buf);
+    EXPECT_EQ(
+        readRequiresNullBarrierFlag(cursor, testCase.version),
+        testCase.expectedRequiresNullBarrier);
+    EXPECT_EQ(
+        cursor.read<uint8_t>(),
+        testCase.expectedAdvance == 0 ? testCase.flagsByte : kSentinel);
+  }
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    SerializationHeaderTest,
+    ReadNullBarrierFlagTest,
+    ::testing::Values(
+        ReadNullBarrierFlagParam{
+            .name = "serializationNoNullBarrier",
+            .version = std::optional{SerializationVersion::kSerialization},
+            .flagsByte = 0,
+            .expectedRequiresNullBarrier = false,
+            .expectedAdvance = 1,
+        },
+        ReadNullBarrierFlagParam{
+            .name = "serializationRequiresNullBarrier",
+            .version = std::optional{SerializationVersion::kSerialization},
+            .flagsByte = SerializationHeader::kNullBarrierRequiredFlag,
+            .expectedRequiresNullBarrier = true,
+            .expectedAdvance = 1,
+        },
+        ReadNullBarrierFlagParam{
+            .name = "serializationReservedBitsIgnored",
+            .version = std::optional{SerializationVersion::kSerialization},
+            .flagsByte = 0x02,
+            .expectedRequiresNullBarrier = false,
+            .expectedAdvance = 1,
+        },
+        ReadNullBarrierFlagParam{
+            .name = "serializationReservedBitsWithNullBarrier",
+            .version = std::optional{SerializationVersion::kSerialization},
+            .flagsByte = 0x03,
+            .expectedRequiresNullBarrier = true,
+            .expectedAdvance = 1,
+        },
+        ReadNullBarrierFlagParam{
+            .name = "projectionNoNullBarrier",
+            .version = std::optional{SerializationVersion::kProjection},
+            .flagsByte = 0,
+            .expectedRequiresNullBarrier = false,
+            .expectedAdvance = 1,
+        },
+        ReadNullBarrierFlagParam{
+            .name = "projectionRequiresNullBarrier",
+            .version = std::optional{SerializationVersion::kProjection},
+            .flagsByte = SerializationHeader::kNullBarrierRequiredFlag,
+            .expectedRequiresNullBarrier = true,
+            .expectedAdvance = 1,
+        },
+        ReadNullBarrierFlagParam{
+            .name = "legacyIgnoresFlagByte",
+            .version = std::optional{SerializationVersion::kLegacy},
+            .flagsByte = SerializationHeader::kNullBarrierRequiredFlag,
+            .expectedRequiresNullBarrier = false,
+            .expectedAdvance = 0,
+        },
+        ReadNullBarrierFlagParam{
+            .name = "legacyCompactIgnoresFlagByte",
+            .version = std::optional{SerializationVersion::kLegacyCompact},
+            .flagsByte = SerializationHeader::kNullBarrierRequiredFlag,
+            .expectedRequiresNullBarrier = false,
+            .expectedAdvance = 0,
+        },
+        ReadNullBarrierFlagParam{
+            .name = "legacySerializationIgnoresFlagByte",
+            .version =
+                std::optional{SerializationVersion::kLegacySerialization},
+            .flagsByte = SerializationHeader::kNullBarrierRequiredFlag,
+            .expectedRequiresNullBarrier = false,
+            .expectedAdvance = 0,
+        },
+        ReadNullBarrierFlagParam{
+            .name = "noHeaderIgnoresFlagByte",
+            .version = std::nullopt,
+            .flagsByte = SerializationHeader::kNullBarrierRequiredFlag,
+            .expectedRequiresNullBarrier = false,
+            .expectedAdvance = 0,
+        }),
+    [](const ::testing::TestParamInfo<ReadNullBarrierFlagParam>& info) {
+      return info.param.name;
+    });
+
+// ---- TabletChunkHeader tests ----
+
+class TabletChunkHeaderRoundTripTest
+    : public ::testing::TestWithParam<TabletChunkHeaderRoundTripParam> {};
+
+TEST_P(TabletChunkHeaderRoundTripTest, readTabletChunkHeaderRoundtrip) {
+  const auto& testCase = GetParam();
+  SCOPED_TRACE(testCase.toString());
+
+  const auto out = roundTripTabletChunkHeader({
+      .rowCount = testCase.rowCount,
+      .requiresNullBarrier = testCase.requiresNullBarrier,
+      .rowRange = testCase.rowRange,
+      .resumeKey = testCase.resumeKey,
+  });
+  EXPECT_EQ(out.rowCount, testCase.rowCount);
+  EXPECT_EQ(out.requiresNullBarrier, testCase.requiresNullBarrier);
+  EXPECT_EQ(out.rowRange, testCase.rowRange);
+  EXPECT_EQ(out.resumeKey, testCase.resumeKey);
+}
+
+TEST_P(TabletChunkHeaderRoundTripTest, readSerializationHeaderRoundtrip) {
+  const auto& testCase = GetParam();
+  SCOPED_TRACE(testCase.toString());
+
+  auto buf = createTabletChunkHeader({
+      .rowCount = testCase.rowCount,
+      .requiresNullBarrier = testCase.requiresNullBarrier,
+      .rowRange = testCase.rowRange,
+      .resumeKey = testCase.resumeKey,
+  });
+  const char* pos = reinterpret_cast<const char*>(buf.data());
+  const char* end = pos + buf.length();
+  const auto header = readSerializationHeader(pos, end, true);
+
+  EXPECT_EQ(header.version, SerializationVersion::kTablet);
+  EXPECT_EQ(header.rowCount, testCase.rowCount);
+  EXPECT_EQ(header.requiresNullBarrier, testCase.requiresNullBarrier);
+  ASSERT_TRUE(header.rowRange.has_value());
+  EXPECT_EQ(*header.rowRange, testCase.rowRange);
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    TabletChunkHeaderTest,
+    TabletChunkHeaderRoundTripTest,
+    ::testing::ValuesIn(tabletChunkHeaderRoundTripParams()),
+    [](const ::testing::TestParamInfo<TabletChunkHeaderRoundTripParam>& info) {
+      return info.param.name;
+    });
+
+TEST(TabletChunkHeaderTest, writesFlagsAfterRowCount) {
+  const auto buf = createTabletChunkHeader({
+      .rowCount = 128,
+      .requiresNullBarrier = true,
+      .rowRange = RowRange{0, 128},
+  });
+  ASSERT_GE(buf.length(), size_t{4});
+  const auto* data = reinterpret_cast<const uint8_t*>(buf.data());
+  EXPECT_EQ(data[0], static_cast<uint8_t>(SerializationVersion::kTablet));
+  EXPECT_EQ(data[1], 0x80);
+  EXPECT_EQ(data[2], 0x01);
+  EXPECT_EQ(data[3], SerializationHeader::kNullBarrierRequiredFlag);
 }
 
 TEST(TabletChunkHeaderTest, rejectsUnknownVersion) {
@@ -192,44 +839,27 @@ TEST(TabletChunkHeaderTest, truncatedVersionByte) {
   EXPECT_THROW(readTabletChunkHeader(pos, pos), NimbleInternalError);
 }
 
-TEST(TabletChunkHeaderTest, roundTripsMaxUint32RowCount) {
-  TabletChunkHeader in{
-      .rowCount = std::numeric_limits<uint32_t>::max(),
-      .rowRange = RowRange{0, std::numeric_limits<uint32_t>::max()},
-  };
-  const auto out = roundTripTabletChunkHeader(in);
-  EXPECT_EQ(out.rowCount, std::numeric_limits<uint32_t>::max());
-  EXPECT_EQ(out.rowRange.startRow, 0u);
-  EXPECT_EQ(out.rowRange.endRow, std::numeric_limits<uint32_t>::max());
-}
+class InvalidTabletRowRangeTest
+    : public ::testing::TestWithParam<InvalidTabletRowRangeParam> {};
 
-TEST(TabletChunkHeaderTest, exactBoundaryEndRowEqualsRowCount) {
-  TabletChunkHeader in{.rowCount = 100, .rowRange = RowRange{99, 100}};
-  const auto out = roundTripTabletChunkHeader(in);
-  EXPECT_EQ(out.rowCount, 100u);
-  EXPECT_EQ(out.rowRange, RowRange(99, 100));
-}
+TEST_P(InvalidTabletRowRangeTest, rejectsInvalidRowRange) {
+  const auto& testCase = GetParam();
+  SCOPED_TRACE(testCase.toString());
 
-TEST(TabletChunkHeaderTest, rejectsRowRangeExceedingRowCount) {
-  std::string buf;
-  buf.push_back(static_cast<char>(SerializationVersion::kTablet));
-  buf.push_back(0x05); // rowCount = 5
-  buf.push_back(0x00); // startRow = 0
-  buf.push_back(0x64); // endRow = 100 (> rowCount)
-  buf.push_back(0x00); // resumeKeyLength = 0
-  const char* pos = buf.data();
+  auto buf = createTabletChunkHeader({
+      .rowCount = testCase.rowCount,
+      .requiresNullBarrier = testCase.requiresNullBarrier,
+      .rowRange = testCase.rowRange,
+  });
+  const char* pos = reinterpret_cast<const char*>(buf.data());
   EXPECT_THROW(
-      readTabletChunkHeader(pos, pos + buf.size()), NimbleInternalError);
+      readTabletChunkHeader(pos, pos + buf.length()), NimbleInternalError);
 }
 
-TEST(TabletChunkHeaderTest, rejectsInvertedRowRange) {
-  std::string buf;
-  buf.push_back(static_cast<char>(SerializationVersion::kTablet));
-  buf.push_back(0x0a); // rowCount = 10
-  buf.push_back(0x05); // startRow = 5
-  buf.push_back(0x03); // endRow = 3 (< startRow)
-  buf.push_back(0x00); // resumeKeyLength = 0
-  const char* pos = buf.data();
-  EXPECT_THROW(
-      readTabletChunkHeader(pos, pos + buf.size()), NimbleInternalError);
-}
+INSTANTIATE_TEST_SUITE_P(
+    TabletChunkHeaderTest,
+    InvalidTabletRowRangeTest,
+    ::testing::ValuesIn(invalidTabletRowRangeParams()),
+    [](const ::testing::TestParamInfo<InvalidTabletRowRangeParam>& info) {
+      return info.param.name;
+    });

--- a/dwio/nimble/serializer/tests/SerializationTest.cpp
+++ b/dwio/nimble/serializer/tests/SerializationTest.cpp
@@ -16,6 +16,11 @@
 #include <folly/Random.h>
 #include <folly/executors/CPUThreadPoolExecutor.h>
 #include <gtest/gtest.h>
+#include <algorithm>
+#include <array>
+#include <numeric>
+#include <optional>
+#include <string_view>
 #include <thread>
 
 #include "dwio/nimble/common/tests/GTestUtils.h"
@@ -24,7 +29,6 @@
 #include "dwio/nimble/serializer/SerializationHeader.h"
 #include "dwio/nimble/serializer/Serializer.h"
 #include "dwio/nimble/serializer/SerializerImpl.h"
-#include "dwio/nimble/tablet/Constants.h"
 #include "dwio/nimble/tablet/TabletReader.h"
 #include "dwio/nimble/tablet/tests/TabletTestUtils.h"
 #include "dwio/nimble/velox/EncodingLayoutTree.h"
@@ -46,7 +50,7 @@ using namespace facebook::nimble;
 using facebook::nimble::test::makeTestTabletOptions;
 
 // Test parameters for parameterized tests.
-// For kLegacyCompact mode, we test both with and without compression to
+// For kSerialization mode, we test both with and without compression to
 // exercise the compressionOptions path in ReplayedEncodingSelectionPolicy.
 struct TestParams {
   std::optional<SerializationVersion> version;
@@ -134,7 +138,8 @@ class SerializationTest : public ::testing::TestWithParam<TestParams> {
       bool enableChunking,
       EncodingType streamIdsEncodingType,
       EncodingType sizeIndicesEncodingType,
-      EncodingType uniqueSizesEncodingType);
+      EncodingType uniqueSizesEncodingType,
+      bool forceDuplicateFirstTwoStreams = false);
 
   std::shared_ptr<velox::memory::MemoryPool> rootPool_;
   std::shared_ptr<velox::memory::MemoryPool> pool_;
@@ -281,20 +286,19 @@ class SerializationTest : public ::testing::TestWithParam<TestParams> {
           const velox::VectorPtr&,
           const velox::VectorPtr&,
           velox::vector_size_t)> validator,
+      const folly::F14FastMap<std::string, std::set<std::string>>&
+          flatMapColumns,
       size_t count) {
     SerializerOptions options{
         .compressionType = CompressionType::Zstd,
         .compressionThreshold = 32,
         .compressionLevel = 3,
         .version = version(),
+        .flatMapColumns = flatMapColumns,
         .streamIndicesEncodingType = streamSizesEncodingType(),
         .streamSizesEncodingType = streamSizesEncodingType(),
     };
     Serializer serializer{options, type, pool};
-    Deserializer deserializer{
-        SchemaReader::getSchema(serializer.schemaBuilder().schemaNodes()),
-        pool,
-        deserializerOptions()};
 
     velox::VectorPtr output;
     velox::VectorPtr expected;
@@ -310,7 +314,10 @@ class SerializationTest : public ::testing::TestWithParam<TestParams> {
         expected->resize(oldSize + input->size());
         expected->copy(input.get(), oldSize, 0, input->size());
       }
-      if (i < count - 1 && folly::Random::oneIn(3, rng)) {
+      // FlatMap output type construction needs the final schema after key
+      // discovery across all serialized batches.
+      if (flatMapColumns.empty() && i < count - 1 &&
+          folly::Random::oneIn(3, rng)) {
         velox::BaseVector::ensureWritable(
             velox::SelectivityVector::empty(),
             expected->type(),
@@ -323,6 +330,10 @@ class SerializationTest : public ::testing::TestWithParam<TestParams> {
       for (auto& s : serialized) {
         serializedSVs.push_back(s);
       }
+      Deserializer deserializer{
+          SchemaReader::getSchema(serializer.schemaBuilder().schemaNodes()),
+          pool,
+          deserializerOptions()};
       deserializer.deserialize(serializedSVs, output);
 
       ASSERT_EQ(output->size(), expected->size());
@@ -379,7 +390,460 @@ TEST_P(SerializationTest, fuzzSimple) {
               std::dynamic_pointer_cast<const velox::RowType>(type));
         },
         vectorEquals,
+        {},
         batches);
+  }
+}
+
+TEST_P(SerializationTest, fuzzNullableStreams) {
+  if (!isNullableFormat(version())) {
+    GTEST_SKIP()
+        << "Non-null-capable formats do not support Row/FlatMap null streams";
+  }
+
+  const char* seedEnv = std::getenv("FUZZ_SEED");
+  auto seed = seedEnv != nullptr ? static_cast<uint32_t>(std::stoul(seedEnv))
+                                 : folly::Random::rand32();
+  LOG(INFO) << "fuzzNullableStreams seed: " << seed;
+
+  const std::vector<velox::TypePtr> supportedScalarTypes = {
+      velox::BOOLEAN(),
+      velox::TINYINT(),
+      velox::SMALLINT(),
+      velox::INTEGER(),
+      velox::BIGINT(),
+      velox::REAL(),
+      velox::DOUBLE(),
+      velox::VARCHAR(),
+      velox::VARBINARY(),
+  };
+
+  folly::detail::DefaultGenerator rng{seed};
+  {
+    constexpr velox::vector_size_t kRows = 30;
+    const auto regularMapType = velox::MAP(velox::INTEGER(), velox::DOUBLE());
+    const auto intFeaturesType = velox::MAP(velox::INTEGER(), velox::DOUBLE());
+    const auto stringFeaturesType =
+        velox::MAP(velox::VARCHAR(), velox::VARCHAR());
+    const auto nestedRowType = velox::ROW({
+        {"child",
+         velox::ROW({
+             {"grandchild",
+              velox::ROW({
+                  {"flag", velox::BOOLEAN()},
+                  {"score", velox::DOUBLE()},
+              })},
+             {"labels", velox::ARRAY(velox::VARCHAR())},
+         })},
+    });
+    auto type = velox::ROW({
+        {"id", velox::BIGINT()},
+        {"regular_map", regularMapType},
+        {"int_features", intFeaturesType},
+        {"string_features", stringFeaturesType},
+        {"nested_row", nestedRowType},
+    });
+    velox::VectorFuzzer hasNulls(
+        {
+            .vectorSize = kRows,
+            .nullRatio = 0.25,
+            .useRandomNullPattern = true,
+            .stringLength = 8,
+            .stringVariableLength = false,
+            .containerLength = 5,
+            .containerVariableLength = true,
+            .normalizeMapKeys = true,
+        },
+        pool_.get(),
+        folly::Random::rand32(rng));
+    auto makeIntFeatures = [&]() -> velox::VectorPtr {
+      constexpr std::array<int32_t, 2> kKeys = {1, 2};
+      constexpr velox::vector_size_t kKeysPerRow = kKeys.size();
+      auto keys = velox::BaseVector::create(
+          velox::INTEGER(), kRows * kKeysPerRow, pool_.get());
+      auto values = velox::BaseVector::create(
+          velox::DOUBLE(), kRows * kKeysPerRow, pool_.get());
+      for (velox::vector_size_t row = 0; row < kRows; ++row) {
+        for (velox::vector_size_t keyIndex = 0; keyIndex < kKeysPerRow;
+             ++keyIndex) {
+          const auto entry = row * kKeysPerRow + keyIndex;
+          keys->asFlatVector<int32_t>()->set(entry, kKeys[keyIndex]);
+          values->asFlatVector<double>()->set(entry, row * 10 + keyIndex);
+          if ((row + keyIndex) % 7 == 0) {
+            values->setNull(entry, true);
+          }
+        }
+      }
+
+      auto offsets = velox::allocateOffsets(kRows, pool_.get());
+      auto sizes = velox::allocateSizes(kRows, pool_.get());
+      auto* rawOffsets = offsets->asMutable<velox::vector_size_t>();
+      auto* rawSizes = sizes->asMutable<velox::vector_size_t>();
+      for (velox::vector_size_t row = 0; row < kRows; ++row) {
+        rawOffsets[row] = row * kKeysPerRow;
+        rawSizes[row] = kKeysPerRow;
+      }
+      auto map = std::make_shared<velox::MapVector>(
+          pool_.get(),
+          intFeaturesType,
+          nullptr,
+          kRows,
+          offsets,
+          sizes,
+          keys,
+          values);
+      map->setNull(2, true);
+      map->setNull(11, true);
+      return map;
+    };
+    auto makeStringFeatures = [&]() -> velox::VectorPtr {
+      constexpr std::array<const char*, 2> kKeys = {"a", "b"};
+      constexpr std::array<const char*, 2> kValues = {"red", "blue"};
+      constexpr velox::vector_size_t kKeysPerRow = kKeys.size();
+      auto keys = velox::BaseVector::create(
+          velox::VARCHAR(), kRows * kKeysPerRow, pool_.get());
+      auto values = velox::BaseVector::create(
+          velox::VARCHAR(), kRows * kKeysPerRow, pool_.get());
+      for (velox::vector_size_t row = 0; row < kRows; ++row) {
+        for (velox::vector_size_t keyIndex = 0; keyIndex < kKeysPerRow;
+             ++keyIndex) {
+          const auto entry = row * kKeysPerRow + keyIndex;
+          keys->asFlatVector<velox::StringView>()->set(
+              entry, velox::StringView(kKeys[keyIndex]));
+          values->asFlatVector<velox::StringView>()->set(
+              entry, velox::StringView(kValues[(row + keyIndex) % 2]));
+          if ((row + keyIndex) % 11 == 0) {
+            values->setNull(entry, true);
+          }
+        }
+      }
+
+      auto offsets = velox::allocateOffsets(kRows, pool_.get());
+      auto sizes = velox::allocateSizes(kRows, pool_.get());
+      auto* rawOffsets = offsets->asMutable<velox::vector_size_t>();
+      auto* rawSizes = sizes->asMutable<velox::vector_size_t>();
+      for (velox::vector_size_t row = 0; row < kRows; ++row) {
+        rawOffsets[row] = row * kKeysPerRow;
+        rawSizes[row] = kKeysPerRow;
+      }
+      auto map = std::make_shared<velox::MapVector>(
+          pool_.get(),
+          stringFeaturesType,
+          nullptr,
+          kRows,
+          offsets,
+          sizes,
+          keys,
+          values);
+      map->setNull(5, true);
+      map->setNull(17, true);
+      return map;
+    };
+    auto generateDeterministicInput = [&]() -> velox::VectorPtr {
+      auto ids = velox::BaseVector::create(velox::BIGINT(), kRows, pool_.get());
+      for (velox::vector_size_t row = 0; row < kRows; ++row) {
+        ids->asFlatVector<int64_t>()->set(row, row);
+      }
+      ids->setNull(3, true);
+
+      auto input = std::make_shared<velox::RowVector>(
+          pool_.get(),
+          type,
+          nullptr,
+          kRows,
+          std::vector<velox::VectorPtr>{
+              ids,
+              hasNulls.fuzz(regularMapType),
+              makeIntFeatures(),
+              makeStringFeatures(),
+              hasNulls.fuzz(nestedRowType),
+          });
+      return input;
+    };
+    SCOPED_TRACE("deterministic regular map, FlatMap, and nested row");
+
+    writeAndVerify(
+        rng,
+        pool_.get(),
+        type,
+        [&](const auto&) { return generateDeterministicInput(); },
+        vectorEquals,
+        {{"int_features", {}}, {"string_features", {}}},
+        /*count=*/10);
+  }
+
+  {
+    auto nestedType = velox::ROW({
+        {"score", velox::BIGINT()},
+        {"label", velox::VARCHAR()},
+    });
+    auto type = velox::ROW({
+        {"id", velox::INTEGER()},
+        {"nested", nestedType},
+        {"events", velox::ARRAY(nestedType)},
+    });
+
+    SerializerOptions options{
+        .compressionType = CompressionType::Zstd,
+        .compressionThreshold = 32,
+        .compressionLevel = 3,
+        .version = version(),
+        .streamIndicesEncodingType = streamSizesEncodingType(),
+        .streamSizesEncodingType = streamSizesEncodingType(),
+    };
+    Serializer serializer{options, type, pool_.get()};
+    Deserializer deserializer{
+        SchemaReader::getSchema(serializer.schemaBuilder().schemaNodes()),
+        pool_.get(),
+        deserializerOptions()};
+
+    constexpr int kMultiBatchIterations = 8;
+    constexpr int kBatches = 6;
+    for (int iteration = 0; iteration < kMultiBatchIterations; ++iteration) {
+      SCOPED_TRACE(fmt::format("multi-batch iteration {}", iteration));
+      std::vector<velox::VectorPtr> inputs;
+      std::vector<std::string> serialized;
+      inputs.reserve(kBatches);
+      serialized.reserve(kBatches);
+
+      for (int batch = 0; batch < kBatches; ++batch) {
+        velox::VectorFuzzer fuzzer(
+            {
+                .vectorSize = 5,
+                .nullRatio = batch % 2 == 0 ? 0.0 : 0.35,
+                .useRandomNullPattern = true,
+                .stringLength = 12,
+                .stringVariableLength = true,
+                .containerLength = 3,
+                .containerVariableLength = true,
+            },
+            pool_.get(),
+            folly::Random::rand32(rng));
+        auto input = fuzzer.fuzzInputRow(
+            std::dynamic_pointer_cast<const velox::RowType>(type));
+        serialized.emplace_back(
+            serializer.serialize(input, OrderedRanges::of(0, input->size())));
+        inputs.emplace_back(std::move(input));
+      }
+
+      std::vector<std::string_view> serializedViews;
+      serializedViews.reserve(serialized.size());
+      for (const auto& data : serialized) {
+        serializedViews.push_back(data);
+      }
+
+      auto expected = inputs.front();
+      for (size_t i = 1; i < inputs.size(); ++i) {
+        const auto oldSize = expected->size();
+        expected->resize(oldSize + inputs[i]->size());
+        expected->copy(inputs[i].get(), oldSize, 0, inputs[i]->size());
+      }
+
+      velox::VectorPtr output;
+      deserializer.deserialize(serializedViews, output);
+
+      ASSERT_EQ(output->size(), expected->size());
+      for (velox::vector_size_t row = 0; row < expected->size(); ++row) {
+        EXPECT_TRUE(vectorEquals(expected, output, row))
+            << "Content mismatch at row " << row
+            << "\nExpected: " << expected->toString(row)
+            << "\nActual: " << output->toString(row);
+      }
+    }
+  }
+
+  constexpr int kIterations = 8;
+  for (int i = 0; i < kIterations; ++i) {
+    velox::VectorFuzzer hasNulls(
+        {
+            .vectorSize = 12,
+            .nullRatio = 0.2,
+            .useRandomNullPattern = true,
+            .stringLength = 20,
+            .stringVariableLength = true,
+            .containerLength = 5,
+            .containerVariableLength = true,
+            .normalizeMapKeys = true,
+        },
+        pool_.get(),
+        folly::Random::rand32(rng));
+    auto type = hasNulls.randRowType(
+        supportedScalarTypes,
+        /*maxDepth=*/3);
+    SCOPED_TRACE(fmt::format("iteration {}, type {}", i, type->toString()));
+
+    writeAndVerify(
+        rng,
+        pool_.get(),
+        type,
+        [&](auto& type) {
+          return hasNulls.fuzzInputRow(
+              std::dynamic_pointer_cast<const velox::RowType>(type));
+        },
+        vectorEquals,
+        {},
+        /*count=*/4);
+  }
+}
+
+TEST_P(SerializationTest, flatMapRejectsTopLevelNullRows) {
+  if (!isNullableFormat(version())) {
+    GTEST_SKIP()
+        << "Non-null-capable formats do not support Row/FlatMap null streams";
+  }
+
+  constexpr velox::vector_size_t kRows = 4;
+  auto type = velox::ROW({
+      {"id", velox::BIGINT()},
+      {"features", velox::MAP(velox::INTEGER(), velox::DOUBLE())},
+  });
+
+  auto ids = velox::BaseVector::create(velox::BIGINT(), kRows, pool_.get());
+  for (velox::vector_size_t row = 0; row < kRows; ++row) {
+    ids->asFlatVector<int64_t>()->set(row, row);
+  }
+
+  auto offsets = velox::allocateOffsets(kRows, pool_.get());
+  auto sizes = velox::allocateSizes(kRows, pool_.get());
+  auto* rawOffsets = offsets->asMutable<velox::vector_size_t>();
+  auto* rawSizes = sizes->asMutable<velox::vector_size_t>();
+  for (velox::vector_size_t row = 0; row < kRows; ++row) {
+    rawOffsets[row] = row;
+    rawSizes[row] = 1;
+  }
+  auto keys = velox::BaseVector::create(velox::INTEGER(), kRows, pool_.get());
+  auto values = velox::BaseVector::create(velox::DOUBLE(), kRows, pool_.get());
+  for (velox::vector_size_t row = 0; row < kRows; ++row) {
+    keys->asFlatVector<int32_t>()->set(row, 10 + row);
+    values->asFlatVector<double>()->set(row, row * 1.5);
+  }
+  auto features = std::make_shared<velox::MapVector>(
+      pool_.get(),
+      type->childAt(1),
+      nullptr,
+      kRows,
+      offsets,
+      sizes,
+      keys,
+      values);
+
+  auto input = std::make_shared<velox::RowVector>(
+      pool_.get(),
+      type,
+      nullptr,
+      kRows,
+      std::vector<velox::VectorPtr>{ids, features});
+  input->setNull(2, true);
+
+  SerializerOptions options{
+      .compressionType = CompressionType::Zstd,
+      .compressionThreshold = 32,
+      .compressionLevel = 3,
+      .version = version(),
+      .flatMapColumns = {{"features", {}}},
+      .streamIndicesEncodingType = streamSizesEncodingType(),
+      .streamSizesEncodingType = streamSizesEncodingType(),
+  };
+  Serializer serializer{options, type, pool_.get()};
+
+  NIMBLE_ASSERT_THROW(
+      serializer.serialize(input, OrderedRanges::of(0, kRows)),
+      "Top-level row nulls are not supported when serializing FlatMap columns.");
+}
+
+TEST_P(SerializationTest, flatMapWithNestedNullsRoundTrips) {
+  if (!isNullableFormat(version())) {
+    GTEST_SKIP()
+        << "Non-null-capable formats do not support Row/FlatMap null streams";
+  }
+
+  constexpr velox::vector_size_t kRows = 4;
+  constexpr velox::vector_size_t kKeysPerRow = 2;
+  auto type = velox::ROW({
+      {"id", velox::BIGINT()},
+      {"features", velox::MAP(velox::INTEGER(), velox::DOUBLE())},
+      {"nested", velox::ROW({{"score", velox::DOUBLE()}})},
+  });
+
+  auto ids = velox::BaseVector::create(velox::BIGINT(), kRows, pool_.get());
+  for (velox::vector_size_t row = 0; row < kRows; ++row) {
+    ids->asFlatVector<int64_t>()->set(row, row);
+  }
+
+  auto offsets = velox::allocateOffsets(kRows, pool_.get());
+  auto sizes = velox::allocateSizes(kRows, pool_.get());
+  auto* rawOffsets = offsets->asMutable<velox::vector_size_t>();
+  auto* rawSizes = sizes->asMutable<velox::vector_size_t>();
+  for (velox::vector_size_t row = 0; row < kRows; ++row) {
+    rawOffsets[row] = row * kKeysPerRow;
+    rawSizes[row] = kKeysPerRow;
+  }
+
+  auto keys = velox::BaseVector::create(
+      velox::INTEGER(), kRows * kKeysPerRow, pool_.get());
+  auto values = velox::BaseVector::create(
+      velox::DOUBLE(), kRows * kKeysPerRow, pool_.get());
+  for (velox::vector_size_t entry = 0; entry < kRows * kKeysPerRow; ++entry) {
+    keys->asFlatVector<int32_t>()->set(entry, entry % kKeysPerRow);
+    values->asFlatVector<double>()->set(entry, entry * 1.25);
+  }
+  values->setNull(3, true);
+  auto features = std::make_shared<velox::MapVector>(
+      pool_.get(),
+      type->childAt(1),
+      nullptr,
+      kRows,
+      offsets,
+      sizes,
+      keys,
+      values);
+  features->setNull(1, true);
+
+  auto scores = velox::BaseVector::create(velox::DOUBLE(), kRows, pool_.get());
+  for (velox::vector_size_t row = 0; row < kRows; ++row) {
+    scores->asFlatVector<double>()->set(row, row * 2.0);
+  }
+  auto nested = std::make_shared<velox::RowVector>(
+      pool_.get(),
+      type->childAt(2),
+      nullptr,
+      kRows,
+      std::vector<velox::VectorPtr>{scores});
+  nested->setNull(2, true);
+
+  auto input = std::make_shared<velox::RowVector>(
+      pool_.get(),
+      type,
+      nullptr,
+      kRows,
+      std::vector<velox::VectorPtr>{ids, features, nested});
+
+  SerializerOptions options{
+      .compressionType = CompressionType::Zstd,
+      .compressionThreshold = 32,
+      .compressionLevel = 3,
+      .version = version(),
+      .flatMapColumns = {{"features", {}}},
+      .streamIndicesEncodingType = streamSizesEncodingType(),
+      .streamSizesEncodingType = streamSizesEncodingType(),
+  };
+  Serializer serializer{options, type, pool_.get()};
+  auto serialized = std::string(
+      serializer.serialize(input, OrderedRanges::of(0, input->size())));
+
+  Deserializer deserializer{
+      SchemaReader::getSchema(serializer.schemaBuilder().schemaNodes()),
+      pool_.get(),
+      deserializerOptions()};
+  velox::VectorPtr output;
+  deserializer.deserialize(serialized, output);
+
+  ASSERT_EQ(output->size(), input->size());
+  for (velox::vector_size_t row = 0; row < input->size(); ++row) {
+    ASSERT_TRUE(vectorEquals(output, input, row))
+        << "Content mismatch at row " << row
+        << "\nReference: " << input->toString(row)
+        << "\nResult: " << output->toString(row);
   }
 }
 
@@ -549,6 +1013,9 @@ std::string formatName(const ::testing::TestParamInfo<TestParams>& info) {
       case SerializationVersion::kProjection:
         name = "ProjectionFormat";
         break;
+      case SerializationVersion::kLegacySerialization:
+        name = "LegacySerializationFormat";
+        break;
     }
   }
   // Add compression suffix for encoding modes.
@@ -615,7 +1082,8 @@ SerializationTest::SerializeResult SerializationTest::serializeTablet(
     bool enableChunking,
     EncodingType streamIdsEncodingType,
     EncodingType sizeIndicesEncodingType,
-    EncodingType uniqueSizesEncodingType) {
+    EncodingType uniqueSizesEncodingType,
+    bool forceDuplicateFirstTwoStreams) {
   // Write all inputs to a single Nimble file.
   std::string fileData;
   {
@@ -665,6 +1133,24 @@ SerializationTest::SerializeResult SerializationTest::serializeTablet(
         headerIOBuf.length());
 
     auto streams = collectTabletStreams(streamOffsets, streamLoaders);
+    if (forceDuplicateFirstTwoStreams) {
+      std::optional<std::string_view> firstNonEmptyStream;
+      bool duplicated = false;
+      for (auto& stream : streams) {
+        if (stream.data.empty()) {
+          continue;
+        }
+        if (!firstNonEmptyStream.has_value()) {
+          firstNonEmptyStream = stream.data;
+          continue;
+        }
+        stream.data = *firstNonEmptyStream;
+        duplicated = true;
+        break;
+      }
+      EXPECT_TRUE(duplicated) << "Expected at least two non-empty streams";
+    }
+
     std::string assembled;
     assembled.reserve(headerBuf.size());
     assembled.append(headerBuf);
@@ -861,6 +1347,7 @@ TEST_P(SerializationTest, fuzzComplex) {
               std::dynamic_pointer_cast<const velox::RowType>(type));
         },
         vectorEquals,
+        {},
         batches);
   }
 }
@@ -894,6 +1381,7 @@ TEST_P(SerializationTest, rootNotRow) {
         type,
         [&](auto& type) { return noNulls.fuzz(type); },
         vectorEquals,
+        {},
         batches);
   }
 }
@@ -1608,29 +2096,49 @@ TEST_P(SerializationTest, nestedFlatMapWithVaryingInnerKeys) {
   }
 }
 
-TEST_P(SerializationTest, nullsNotSupported) {
-  // Test that the serializer throws when input has nulls.
-  // The serializer currently does not support null values.
-
+TEST_P(SerializationTest, nullableStreamsRoundTrip) {
   auto seed = folly::Random::rand32();
-  LOG(INFO) << "nullsNotSupported seed: " << seed;
+  LOG(INFO) << "nullableStreamsRoundTrip seed: " << seed;
 
-  // Test 1: Top-level row with null.
-  {
-    auto type =
-        velox::ROW({{"id", velox::BIGINT()}, {"value", velox::DOUBLE()}});
-    auto row = velox::BaseVector::create(type, 10, pool_.get());
-    row->setNull(5, true); // Set one row as null
+  const folly::F14FastMap<std::string, std::set<std::string>> noFlatMaps;
+  auto roundTrip =
+      [&](const velox::TypePtr& type,
+          const velox::VectorPtr& row,
+          const folly::F14FastMap<std::string, std::set<std::string>>&
+              flatMapColumns) {
+        SerializerOptions options{
+            .compressionType = CompressionType::Zstd,
+            .compressionThreshold = 32,
+            .compressionLevel = 3,
+            .version = version(),
+            .flatMapColumns = flatMapColumns,
+            .streamIndicesEncodingType = streamSizesEncodingType(),
+            .streamSizesEncodingType = streamSizesEncodingType(),
+        };
+        Serializer serializer{options, type, pool_.get()};
+        auto serialized =
+            serializer.serialize(row, OrderedRanges::of(0, row->size()));
 
-    SerializerOptions options{.version = version()};
-    Serializer serializer{options, type, pool_.get()};
+        Deserializer deserializer{
+            SchemaReader::getSchema(serializer.schemaBuilder().schemaNodes()),
+            pool_.get(),
+            deserializerOptions()};
 
-    NIMBLE_ASSERT_THROW(
-        serializer.serialize(row, OrderedRanges::of(0, row->size())),
-        "nulls not supported");
-  }
+        velox::VectorPtr output;
+        deserializer.deserialize(serialized, output);
+        ASSERT_EQ(output->size(), row->size());
+        for (velox::vector_size_t i = 0; i < row->size(); ++i) {
+          ASSERT_TRUE(vectorEquals(output, row, i))
+              << "Content mismatch at row " << i
+              << "\nExpected: " << row->toString(i)
+              << "\nActual: " << output->toString(i);
+        }
+      };
 
-  // Test 2: Nested column with null.
+  const bool encodingEnabled =
+      SerializerOptions{.version = version()}.enableEncoding();
+
+  // Nested scalar content nulls require the encoded serializer format.
   {
     auto type =
         velox::ROW({{"id", velox::BIGINT()}, {"value", velox::DOUBLE()}});
@@ -1649,21 +2157,26 @@ TEST_P(SerializationTest, nullsNotSupported) {
         10,
         std::vector<velox::VectorPtr>{ids, values});
 
-    SerializerOptions options{.version = version()};
-    Serializer serializer{options, type, pool_.get()};
-
-    NIMBLE_ASSERT_THROW(
-        serializer.serialize(row, OrderedRanges::of(0, row->size())),
-        "nulls not supported");
+    if (encodingEnabled) {
+      roundTrip(type, row, noFlatMaps);
+    } else {
+      SerializerOptions options{.version = version()};
+      Serializer serializer{options, type, pool_.get()};
+      NIMBLE_ASSERT_THROW(
+          serializer.serialize(row, OrderedRanges::of(0, row->size())),
+          "nullable content streams require an encoded serializer format");
+    }
   }
 
-  // Test 3: Map with null key/value.
-  {
-    auto type = velox::ROW({
-        {"id", velox::BIGINT()},
-        {"map_col", velox::MAP(velox::INTEGER(), velox::DOUBLE())},
-    });
+  if (!encodingEnabled) {
+    return;
+  }
 
+  // Map value nulls are encoded as nullable content streams.
+  {
+    auto type = velox::ROW(
+        {{"id", velox::BIGINT()},
+         {"map_col", velox::MAP(velox::INTEGER(), velox::DOUBLE())}});
     const velox::vector_size_t numRows = 5;
     const velox::vector_size_t entriesPerRow = 3;
     const velox::vector_size_t totalEntries = numRows * entriesPerRow;
@@ -1709,21 +2222,14 @@ TEST_P(SerializationTest, nullsNotSupported) {
         numRows,
         std::vector<velox::VectorPtr>{ids, mapVector});
 
-    SerializerOptions options{.version = version()};
-    Serializer serializer{options, type, pool_.get()};
-
-    NIMBLE_ASSERT_THROW(
-        serializer.serialize(row, OrderedRanges::of(0, row->size())),
-        "nulls not supported");
+    roundTrip(type, row, noFlatMaps);
   }
 
-  // Test 4: FlatMap with null value (only for kLegacyCompact format).
-  if (SerializerOptions{.version = version()}.enableEncoding()) {
-    auto type = velox::ROW({
-        {"id", velox::BIGINT()},
-        {"features", velox::MAP(velox::INTEGER(), velox::DOUBLE())},
-    });
-
+  // FlatMap value nulls exercise nullable decoding through scatterBitmap.
+  {
+    auto type = velox::ROW(
+        {{"id", velox::BIGINT()},
+         {"features", velox::MAP(velox::INTEGER(), velox::DOUBLE())}});
     const velox::vector_size_t numRows = 5;
     const velox::vector_size_t entriesPerRow = 2;
     const velox::vector_size_t totalEntries = numRows * entriesPerRow;
@@ -1741,7 +2247,7 @@ TEST_P(SerializationTest, nullsNotSupported) {
       mapKeys->asFlatVector<int32_t>()->set(i, i % entriesPerRow);
       mapValues->asFlatVector<double>()->set(i, i * 0.5);
     }
-    mapValues->setNull(3, true); // Set one FlatMap value as null
+    mapValues->setNull(3, true);
 
     auto mapVector = std::make_shared<velox::MapVector>(
         pool_.get(),
@@ -1769,15 +2275,671 @@ TEST_P(SerializationTest, nullsNotSupported) {
         numRows,
         std::vector<velox::VectorPtr>{ids, mapVector});
 
+    roundTrip(type, row, {{"features", {}}});
+  }
+}
+
+TEST_F(SerializationTest, rowNullStreamOmissionRoundTrips) {
+  constexpr velox::vector_size_t kRows = 8;
+  auto nestedType = velox::ROW({{"value", velox::INTEGER()}});
+  auto type = velox::ROW({{"nested", nestedType}});
+
+  auto makeRow = [&](bool allNull) -> velox::VectorPtr {
+    auto values =
+        velox::BaseVector::create(velox::INTEGER(), kRows, pool_.get());
+    for (velox::vector_size_t i = 0; i < kRows; ++i) {
+      values->asFlatVector<int32_t>()->set(i, i);
+    }
+
+    auto nested = std::make_shared<velox::RowVector>(
+        pool_.get(),
+        nestedType,
+        nullptr,
+        kRows,
+        std::vector<velox::VectorPtr>{values});
+    if (allNull) {
+      for (velox::vector_size_t i = 0; i < kRows; ++i) {
+        nested->setNull(i, true);
+      }
+    }
+
+    return std::make_shared<velox::RowVector>(
+        pool_.get(),
+        type,
+        nullptr,
+        kRows,
+        std::vector<velox::VectorPtr>{nested});
+  };
+
+  auto serializeAndVerify = [&](bool allNull, bool expectNestedNullStream) {
     SerializerOptions options{
-        .version = version(),
-        .flatMapColumns = {{"features", {}}},
+        .version = SerializationVersion::kSerialization,
+        .streamIndicesEncodingType = EncodingType::Trivial,
+        .streamSizesEncodingType = EncodingType::Trivial,
     };
     Serializer serializer{options, type, pool_.get()};
+    auto row = makeRow(allNull);
+    const std::string serialized{
+        serializer.serialize(row, OrderedRanges::of(0, row->size()))};
+    const auto schema =
+        SchemaReader::getSchema(serializer.schemaBuilder().schemaNodes());
+    const auto rootNullOffset = schema->asRow().nullsDescriptor().offset();
+    const auto nestedNullOffset =
+        schema->asRow().childAt(0)->asRow().nullsDescriptor().offset();
 
-    NIMBLE_ASSERT_THROW(
-        serializer.serialize(row, OrderedRanges::of(0, row->size())),
-        "nulls not supported");
+    DeserializerOptions deserializerOptions{.hasHeader = true};
+    serde::StreamDataParser reader{pool_.get(), deserializerOptions};
+    reader.initialize(serialized);
+
+    bool sawRootNullStream = false;
+    bool sawNestedNullStream = false;
+    reader.iterateStreams([&](uint32_t offset, std::string_view streamData) {
+      if (offset == rootNullOffset) {
+        sawRootNullStream = true;
+        EXPECT_FALSE(streamData.empty());
+        return;
+      }
+      if (offset == nestedNullOffset) {
+        sawNestedNullStream = true;
+        EXPECT_FALSE(streamData.empty());
+      }
+    });
+
+    EXPECT_FALSE(sawRootNullStream);
+    EXPECT_EQ(sawNestedNullStream, expectNestedNullStream);
+
+    Deserializer deserializer{schema, pool_.get(), deserializerOptions};
+    velox::VectorPtr output;
+    deserializer.deserialize(serialized, output);
+
+    ASSERT_EQ(output->size(), row->size());
+    for (velox::vector_size_t i = 0; i < kRows; ++i) {
+      EXPECT_TRUE(vectorEquals(row, output, i));
+    }
+  };
+  serializeAndVerify(/*allNull=*/false, /*expectNestedNullStream=*/false);
+  serializeAndVerify(/*allNull=*/true, /*expectNestedNullStream=*/true);
+}
+
+TEST_F(SerializationTest, encodedSerializerRoundTripsTopLevelRowNulls) {
+  constexpr velox::vector_size_t kRows = 6;
+  auto type = velox::ROW({
+      {"id", velox::INTEGER()},
+      {"score", velox::DOUBLE()},
+  });
+
+  auto makeInput = [&]() -> velox::VectorPtr {
+    auto ids = velox::BaseVector::create(velox::INTEGER(), kRows, pool_.get());
+    auto scores =
+        velox::BaseVector::create(velox::DOUBLE(), kRows, pool_.get());
+    for (velox::vector_size_t i = 0; i < kRows; ++i) {
+      ids->asFlatVector<int32_t>()->set(i, 100 + i);
+      scores->asFlatVector<double>()->set(i, i * 1.25);
+    }
+
+    auto input = std::make_shared<velox::RowVector>(
+        pool_.get(),
+        type,
+        nullptr,
+        kRows,
+        std::vector<velox::VectorPtr>{ids, scores});
+    input->setNull(1, true);
+    input->setNull(4, true);
+    return input;
+  };
+
+  SerializerOptions options{
+      .version = SerializationVersion::kSerialization,
+      .streamIndicesEncodingType = EncodingType::Trivial,
+      .streamSizesEncodingType = EncodingType::Trivial,
+  };
+  Serializer serializer{options, type, pool_.get()};
+  auto input = makeInput();
+  const auto serialized =
+      serializer.serialize(input, OrderedRanges::of(0, input->size()));
+
+  const auto schema =
+      SchemaReader::getSchema(serializer.schemaBuilder().schemaNodes());
+  const auto rootNullOffset = schema->asRow().nullsDescriptor().offset();
+  DeserializerOptions deserializerOptions{.hasHeader = true};
+  serde::StreamDataParser reader{pool_.get(), deserializerOptions};
+  reader.initialize(serialized);
+  bool sawRootNullStream = false;
+  reader.iterateStreams([&](uint32_t offset, std::string_view streamData) {
+    if (offset == rootNullOffset) {
+      sawRootNullStream = true;
+      EXPECT_FALSE(streamData.empty());
+    }
+  });
+  EXPECT_TRUE(sawRootNullStream);
+
+  Deserializer deserializer{schema, pool_.get(), deserializerOptions};
+  velox::VectorPtr output;
+  deserializer.deserialize(serialized, output);
+
+  ASSERT_EQ(output->size(), input->size());
+  for (velox::vector_size_t i = 0; i < kRows; ++i) {
+    EXPECT_TRUE(vectorEquals(input, output, i));
+  }
+}
+
+TEST_F(SerializationTest, regularDataNullsDoNotRequireNullBarrier) {
+  constexpr velox::vector_size_t kRows = 3;
+  auto type = velox::ROW({
+      {"scalar", velox::INTEGER()},
+      {"items", velox::ARRAY(velox::INTEGER())},
+      {"attrs", velox::MAP(velox::VARCHAR(), velox::INTEGER())},
+  });
+
+  auto scalar = velox::BaseVector::create(velox::INTEGER(), kRows, pool_.get());
+  for (velox::vector_size_t i = 0; i < kRows; ++i) {
+    scalar->asFlatVector<int32_t>()->set(i, 10 + i);
+  }
+  scalar->setNull(0, true);
+
+  auto arrayOffsets = velox::allocateOffsets(kRows, pool_.get());
+  auto arraySizes = velox::allocateSizes(kRows, pool_.get());
+  auto* rawArrayOffsets = arrayOffsets->asMutable<velox::vector_size_t>();
+  auto* rawArraySizes = arraySizes->asMutable<velox::vector_size_t>();
+  for (velox::vector_size_t i = 0; i < kRows; ++i) {
+    rawArrayOffsets[i] = i * 2;
+    rawArraySizes[i] = 2;
+  }
+  auto arrayElements =
+      velox::BaseVector::create(velox::INTEGER(), kRows * 2, pool_.get());
+  for (velox::vector_size_t i = 0; i < kRows * 2; ++i) {
+    arrayElements->asFlatVector<int32_t>()->set(i, 100 + i);
+  }
+  auto items = std::make_shared<velox::ArrayVector>(
+      pool_.get(),
+      velox::ARRAY(velox::INTEGER()),
+      nullptr,
+      kRows,
+      arrayOffsets,
+      arraySizes,
+      arrayElements);
+  items->setNull(1, true);
+
+  auto mapOffsets = velox::allocateOffsets(kRows, pool_.get());
+  auto mapSizes = velox::allocateSizes(kRows, pool_.get());
+  auto* rawMapOffsets = mapOffsets->asMutable<velox::vector_size_t>();
+  auto* rawMapSizes = mapSizes->asMutable<velox::vector_size_t>();
+  for (velox::vector_size_t i = 0; i < kRows; ++i) {
+    rawMapOffsets[i] = i;
+    rawMapSizes[i] = 1;
+  }
+  auto mapKeys =
+      velox::BaseVector::create(velox::VARCHAR(), kRows, pool_.get());
+  auto mapValues =
+      velox::BaseVector::create(velox::INTEGER(), kRows, pool_.get());
+  const std::array<const char*, kRows> mapKeyValues = {"a", "b", "c"};
+  for (velox::vector_size_t i = 0; i < kRows; ++i) {
+    mapKeys->asFlatVector<velox::StringView>()->set(
+        i, velox::StringView(mapKeyValues[i]));
+    mapValues->asFlatVector<int32_t>()->set(i, 200 + i);
+  }
+  auto attrs = std::make_shared<velox::MapVector>(
+      pool_.get(),
+      velox::MAP(velox::VARCHAR(), velox::INTEGER()),
+      nullptr,
+      kRows,
+      mapOffsets,
+      mapSizes,
+      mapKeys,
+      mapValues);
+  attrs->setNull(2, true);
+
+  auto input = std::make_shared<velox::RowVector>(
+      pool_.get(),
+      type,
+      nullptr,
+      kRows,
+      std::vector<velox::VectorPtr>{scalar, items, attrs});
+
+  SerializerOptions options{
+      .version = SerializationVersion::kSerialization,
+      .streamIndicesEncodingType = EncodingType::Trivial,
+      .streamSizesEncodingType = EncodingType::Trivial,
+  };
+  Serializer serializer{options, type, pool_.get()};
+  const std::string serialized{
+      serializer.serialize(input, OrderedRanges::of(0, input->size()))};
+
+  const char* pos = serialized.data();
+  const auto header = serde::readSerializationHeader(
+      pos, serialized.data() + serialized.size(), true);
+  EXPECT_FALSE(header.requiresNullBarrier);
+
+  const auto schema =
+      SchemaReader::getSchema(serializer.schemaBuilder().schemaNodes());
+  Deserializer deserializer{
+      schema, pool_.get(), DeserializerOptions{.hasHeader = true}};
+  velox::VectorPtr output;
+  deserializer.deserialize(serialized, output);
+
+  ASSERT_EQ(output->size(), input->size());
+  for (velox::vector_size_t i = 0; i < kRows; ++i) {
+    EXPECT_TRUE(vectorEquals(input, output, i));
+  }
+}
+
+TEST_F(SerializationTest, deserializerReadsPhysicalRootNullStream) {
+  constexpr size_t kRows = 3;
+  auto type = velox::ROW({{"value", velox::INTEGER()}});
+  auto schema = convertToNimbleType(*type);
+  const auto rootNullOffset = schema->asRow().nullsDescriptor().offset();
+  const auto valueOffset =
+      schema->asRow().childAt(0)->asScalar().scalarDescriptor().offset();
+
+  const std::array<int32_t, kRows> allValues = {11, 22, 33};
+  const std::array<int32_t, 2> nonNullValues = {11, 33};
+  const SerializerOptions options{
+      .version = SerializationVersion::kSerialization,
+      .streamIndicesEncodingType = EncodingType::Trivial,
+      .streamSizesEncodingType = EncodingType::Trivial,
+  };
+
+  auto makeSerialized = [&](const std::array<bool, kRows>& rootNonNulls,
+                            std::string_view valueData) -> std::string {
+    Buffer rootBuffer{*pool_};
+    const std::string_view rootData{
+        reinterpret_cast<const char*>(rootNonNulls.data()),
+        rootNonNulls.size() * sizeof(bool)};
+    std::string rootEncoded{serde::detail::encodeScalar<std::string>(
+        options,
+        ScalarKind::Bool,
+        rootData,
+        *pool_,
+        rootBuffer,
+        /*encodingLayout=*/nullptr)};
+
+    Buffer valueBuffer{*pool_};
+    std::string valueEncoded{serde::detail::encodeScalar<std::string>(
+        options,
+        ScalarKind::Int32,
+        valueData,
+        *pool_,
+        valueBuffer,
+        /*encodingLayout=*/nullptr)};
+
+    std::vector<std::pair<uint32_t, std::string>> streams;
+    streams.emplace_back(rootNullOffset, std::move(rootEncoded));
+    streams.emplace_back(valueOffset, std::move(valueEncoded));
+    std::sort(streams.begin(), streams.end());
+
+    std::string serialized;
+    const auto flagsOffset = serde::writeSerializationHeader(
+        serialized, SerializationVersion::kSerialization, kRows);
+    const bool requiresNullBarrier = !std::all_of(
+        rootNonNulls.begin(), rootNonNulls.end(), [](bool nonNull) {
+          return nonNull;
+        });
+    NIMBLE_CHECK_LT(
+        flagsOffset, serialized.size(), "Invalid flags byte offset");
+    serialized[flagsOffset] = static_cast<char>(
+        requiresNullBarrier
+            ? serde::SerializationHeader::kNullBarrierRequiredFlag
+            : 0);
+    std::vector<uint32_t> streamSizes(streams.back().first + 1, 0);
+    for (const auto& [offset, stream] : streams) {
+      streamSizes[offset] = static_cast<uint32_t>(stream.size());
+      serialized.append(stream);
+    }
+    serde::detail::writeTrailer(
+        streamSizes, EncodingType::Trivial, EncodingType::Trivial, serialized);
+    return serialized;
+  };
+
+  DeserializerOptions deserializerOptions{.hasHeader = true};
+  Deserializer deserializer{schema, pool_.get(), deserializerOptions};
+
+  velox::VectorPtr output;
+  const std::string_view allValueData{
+      reinterpret_cast<const char*>(allValues.data()),
+      allValues.size() * sizeof(int32_t)};
+  deserializer.deserialize(
+      makeSerialized({true, true, true}, allValueData), output);
+  ASSERT_NE(output, nullptr);
+  ASSERT_EQ(output->size(), kRows);
+  auto* row = output->as<velox::RowVector>();
+  ASSERT_NE(row, nullptr);
+  auto* valueVector = row->childAt(0)->as<velox::FlatVector<int32_t>>();
+  ASSERT_NE(valueVector, nullptr);
+  for (velox::vector_size_t i = 0; i < kRows; ++i) {
+    EXPECT_EQ(valueVector->valueAt(i), allValues[i]);
+  }
+
+  velox::VectorPtr nullableOutput;
+  const std::string_view nonNullValueData{
+      reinterpret_cast<const char*>(nonNullValues.data()),
+      nonNullValues.size() * sizeof(int32_t)};
+  deserializer.deserialize(
+      makeSerialized({true, false, true}, nonNullValueData), nullableOutput);
+  ASSERT_NE(nullableOutput, nullptr);
+  ASSERT_EQ(nullableOutput->size(), kRows);
+  EXPECT_FALSE(nullableOutput->isNullAt(0));
+  EXPECT_TRUE(nullableOutput->isNullAt(1));
+  EXPECT_FALSE(nullableOutput->isNullAt(2));
+  auto* nullableRow = nullableOutput->as<velox::RowVector>();
+  ASSERT_NE(nullableRow, nullptr);
+  auto* nullableValues =
+      nullableRow->childAt(0)->as<velox::FlatVector<int32_t>>();
+  ASSERT_NE(nullableValues, nullptr);
+  EXPECT_EQ(nullableValues->valueAt(0), nonNullValues[0]);
+  EXPECT_EQ(nullableValues->valueAt(2), nonNullValues[1]);
+}
+
+TEST_F(
+    SerializationTest,
+    encodedSerializerNullableContentNullBitmapAcrossBatches) {
+  constexpr velox::vector_size_t kRows = 4;
+  auto type = velox::ROW({{"value", velox::INTEGER()}});
+
+  SerializerOptions options{
+      .version = SerializationVersion::kSerialization,
+      .streamIndicesEncodingType = EncodingType::Trivial,
+      .streamSizesEncodingType = EncodingType::Trivial,
+  };
+  Serializer serializer{options, type, pool_.get()};
+  Deserializer deserializer{
+      SchemaReader::getSchema(serializer.schemaBuilder().schemaNodes()),
+      pool_.get(),
+      DeserializerOptions{.hasHeader = true}};
+
+  auto makeInput = [&](int32_t base,
+                       const std::vector<velox::vector_size_t>& nullRows)
+      -> velox::VectorPtr {
+    auto values =
+        velox::BaseVector::create(velox::INTEGER(), kRows, pool_.get());
+    for (velox::vector_size_t i = 0; i < kRows; ++i) {
+      values->asFlatVector<int32_t>()->set(i, base + i);
+    }
+    for (auto row : nullRows) {
+      values->setNull(row, true);
+    }
+
+    return std::make_shared<velox::RowVector>(
+        pool_.get(),
+        type,
+        nullptr,
+        kRows,
+        std::vector<velox::VectorPtr>{values});
+  };
+
+  std::vector<velox::VectorPtr> inputs = {
+      makeInput(100, {}),
+      makeInput(200, {1, 3}),
+      makeInput(300, {}),
+      makeInput(400, {0}),
+      makeInput(500, {}),
+      makeInput(600, {0, 1, 2, 3}),
+      makeInput(700, {}),
+  };
+
+  std::vector<std::string> serialized;
+  serialized.reserve(inputs.size());
+  for (const auto& input : inputs) {
+    serialized.emplace_back(
+        serializer.serialize(input, OrderedRanges::of(0, input->size())));
+  }
+  std::vector<std::string_view> serializedViews;
+  serializedViews.reserve(serialized.size());
+  for (const auto& data : serialized) {
+    serializedViews.push_back(data);
+  }
+
+  auto expected = inputs.front();
+  for (size_t i = 1; i < inputs.size(); ++i) {
+    const auto oldSize = expected->size();
+    expected->resize(oldSize + inputs[i]->size());
+    expected->copy(inputs[i].get(), oldSize, 0, inputs[i]->size());
+  }
+
+  velox::VectorPtr output;
+  deserializer.deserialize(serializedViews, output);
+
+  ASSERT_EQ(output->size(), expected->size());
+  for (velox::vector_size_t i = 0; i < expected->size(); ++i) {
+    EXPECT_TRUE(vectorEquals(expected, output, i))
+        << "Content mismatch at row " << i
+        << "\nExpected: " << expected->toString(i)
+        << "\nActual: " << output->toString(i);
+  }
+}
+
+TEST_F(SerializationTest, encodedSerializerNestedRowNullsAcrossBatches) {
+  constexpr velox::vector_size_t kRows = 5;
+  auto nestedType = velox::ROW({{"score", velox::BIGINT()}});
+  auto type = velox::ROW({
+      {"id", velox::INTEGER()},
+      {"nested", nestedType},
+  });
+
+  SerializerOptions options{
+      .version = SerializationVersion::kSerialization,
+      .streamIndicesEncodingType = EncodingType::Trivial,
+      .streamSizesEncodingType = EncodingType::Trivial,
+  };
+  Serializer serializer{options, type, pool_.get()};
+  Deserializer deserializer{
+      SchemaReader::getSchema(serializer.schemaBuilder().schemaNodes()),
+      pool_.get(),
+      DeserializerOptions{.hasHeader = true}};
+
+  auto makeInput = [&](int32_t idBase,
+                       const std::vector<velox::vector_size_t>& nestedNullRows)
+      -> velox::VectorPtr {
+    auto ids = velox::BaseVector::create(velox::INTEGER(), kRows, pool_.get());
+    auto scores =
+        velox::BaseVector::create(velox::BIGINT(), kRows, pool_.get());
+    for (velox::vector_size_t i = 0; i < kRows; ++i) {
+      ids->asFlatVector<int32_t>()->set(i, idBase + i);
+      scores->asFlatVector<int64_t>()->set(i, (idBase + i) * 10);
+    }
+
+    auto nested = std::make_shared<velox::RowVector>(
+        pool_.get(),
+        nestedType,
+        nullptr,
+        kRows,
+        std::vector<velox::VectorPtr>{scores});
+    for (auto row : nestedNullRows) {
+      nested->setNull(row, true);
+    }
+
+    return std::make_shared<velox::RowVector>(
+        pool_.get(),
+        type,
+        nullptr,
+        kRows,
+        std::vector<velox::VectorPtr>{ids, nested});
+  };
+
+  struct TestCase {
+    std::string name;
+    std::vector<velox::vector_size_t> firstBatchNullRows;
+    std::vector<velox::vector_size_t> secondBatchNullRows;
+  };
+
+  const std::vector<TestCase> testCases = {
+      {
+          .name = "gap before nested null stream",
+          .firstBatchNullRows = {},
+          .secondBatchNullRows = {1, 3},
+      },
+      {
+          .name = "gap after nested null stream",
+          .firstBatchNullRows = {0, 2},
+          .secondBatchNullRows = {},
+      },
+      {
+          .name = "nested null stream missing from all batches",
+          .firstBatchNullRows = {},
+          .secondBatchNullRows = {},
+      },
+  };
+
+  for (const auto& testCase : testCases) {
+    SCOPED_TRACE(testCase.name);
+    auto first = makeInput(100, testCase.firstBatchNullRows);
+    auto second = makeInput(200, testCase.secondBatchNullRows);
+    std::vector<std::string> serialized;
+    serialized.emplace_back(
+        serializer.serialize(first, OrderedRanges::of(0, first->size())));
+    serialized.emplace_back(
+        serializer.serialize(second, OrderedRanges::of(0, second->size())));
+    std::vector<std::string_view> serializedViews;
+    serializedViews.reserve(serialized.size());
+    for (const auto& data : serialized) {
+      serializedViews.push_back(data);
+    }
+
+    auto expected = first;
+    const auto firstRows = first->size();
+    expected->resize(firstRows + second->size());
+    expected->copy(second.get(), firstRows, 0, second->size());
+
+    velox::VectorPtr output;
+    deserializer.deserialize(serializedViews, output);
+
+    ASSERT_EQ(output->size(), expected->size());
+    for (velox::vector_size_t i = 0; i < expected->size(); ++i) {
+      EXPECT_TRUE(vectorEquals(expected, output, i))
+          << "Content mismatch at row " << i
+          << "\nExpected: " << expected->toString(i)
+          << "\nActual: " << output->toString(i);
+    }
+  }
+}
+
+TEST_F(
+    SerializationTest,
+    encodedSerializerNestedRowNullsUnderArrayAcrossBatches) {
+  constexpr velox::vector_size_t kRows = 2;
+  auto nestedType = velox::ROW({{"score", velox::BIGINT()}});
+  auto type = velox::ROW({
+      {"events", velox::ARRAY(nestedType)},
+  });
+
+  SerializerOptions options{
+      .version = SerializationVersion::kSerialization,
+      .streamIndicesEncodingType = EncodingType::Trivial,
+      .streamSizesEncodingType = EncodingType::Trivial,
+  };
+  Serializer serializer{options, type, pool_.get()};
+  Deserializer deserializer{
+      SchemaReader::getSchema(serializer.schemaBuilder().schemaNodes()),
+      pool_.get(),
+      DeserializerOptions{.hasHeader = true}};
+
+  auto makeInput = [&](int64_t scoreBase,
+                       const std::array<velox::vector_size_t, kRows>& sizes,
+                       const std::vector<velox::vector_size_t>& nullElements)
+      -> velox::VectorPtr {
+    const velox::vector_size_t totalElements =
+        std::accumulate(sizes.begin(), sizes.end(), velox::vector_size_t{0});
+    auto scores =
+        velox::BaseVector::create(velox::BIGINT(), totalElements, pool_.get());
+    for (velox::vector_size_t i = 0; i < totalElements; ++i) {
+      scores->asFlatVector<int64_t>()->set(i, scoreBase + i);
+    }
+
+    auto nested = std::make_shared<velox::RowVector>(
+        pool_.get(),
+        nestedType,
+        nullptr,
+        totalElements,
+        std::vector<velox::VectorPtr>{scores});
+    for (auto element : nullElements) {
+      nested->setNull(element, true);
+    }
+
+    auto offsets = velox::allocateOffsets(kRows, pool_.get());
+    auto arraySizes = velox::allocateSizes(kRows, pool_.get());
+    auto* rawOffsets = offsets->asMutable<velox::vector_size_t>();
+    auto* rawSizes = arraySizes->asMutable<velox::vector_size_t>();
+    velox::vector_size_t runningOffset = 0;
+    for (velox::vector_size_t i = 0; i < kRows; ++i) {
+      rawOffsets[i] = runningOffset;
+      rawSizes[i] = sizes[i];
+      runningOffset += sizes[i];
+    }
+
+    auto events = std::make_shared<velox::ArrayVector>(
+        pool_.get(),
+        velox::ARRAY(nestedType),
+        nullptr,
+        kRows,
+        offsets,
+        arraySizes,
+        nested);
+    return std::make_shared<velox::RowVector>(
+        pool_.get(),
+        type,
+        nullptr,
+        kRows,
+        std::vector<velox::VectorPtr>{events});
+  };
+
+  struct TestCase {
+    std::string name;
+    std::vector<velox::vector_size_t> firstBatchNullElements;
+    std::vector<velox::vector_size_t> secondBatchNullElements;
+  };
+
+  const std::array<velox::vector_size_t, kRows> firstBatchSizes = {1, 1};
+  const std::array<velox::vector_size_t, kRows> secondBatchSizes = {2, 1};
+  const std::vector<TestCase> testCases = {
+      {
+          .name = "gap before nested array row null stream",
+          .firstBatchNullElements = {},
+          .secondBatchNullElements = {1},
+      },
+      {
+          .name = "gap after nested array row null stream",
+          .firstBatchNullElements = {0},
+          .secondBatchNullElements = {},
+      },
+      {
+          .name = "nested array row null stream all true in all batches",
+          .firstBatchNullElements = {},
+          .secondBatchNullElements = {},
+      },
+  };
+
+  for (const auto& testCase : testCases) {
+    SCOPED_TRACE(testCase.name);
+    auto first =
+        makeInput(100, firstBatchSizes, testCase.firstBatchNullElements);
+    auto second =
+        makeInput(200, secondBatchSizes, testCase.secondBatchNullElements);
+
+    std::vector<std::string> serialized;
+    serialized.emplace_back(
+        serializer.serialize(first, OrderedRanges::of(0, first->size())));
+    serialized.emplace_back(
+        serializer.serialize(second, OrderedRanges::of(0, second->size())));
+    std::vector<std::string_view> serializedViews;
+    serializedViews.reserve(serialized.size());
+    for (const auto& data : serialized) {
+      serializedViews.push_back(data);
+    }
+
+    auto expected = first;
+    const auto firstRows = first->size();
+    expected->resize(firstRows + second->size());
+    expected->copy(second.get(), firstRows, 0, second->size());
+
+    velox::VectorPtr output;
+    deserializer.deserialize(serializedViews, output);
+
+    ASSERT_EQ(output->size(), expected->size());
+    for (velox::vector_size_t i = 0; i < expected->size(); ++i) {
+      EXPECT_TRUE(vectorEquals(expected, output, i))
+          << "Content mismatch at row " << i
+          << "\nExpected: " << expected->toString(i)
+          << "\nActual: " << output->toString(i);
+    }
   }
 }
 
@@ -1916,59 +3078,99 @@ TEST_P(SerializationTest, flatMapSparseKeysScatterBitmap) {
   }
 }
 
-TEST_P(SerializationTest, versionMismatch) {
-  // Test that deserializing with wrong version fails with a clear error.
-  auto type = velox::ROW({
-      {"int_val", velox::INTEGER()},
-      {"string_val", velox::VARCHAR()},
-  });
-
-  velox::VectorFuzzer fuzzer(
-      {
-          .vectorSize = 10,
-          .nullRatio = 0,
-          .stringLength = 10,
-      },
-      pool_.get());
-
-  auto input = fuzzer.fuzzInputRow(
-      std::dynamic_pointer_cast<const velox::RowType>(type));
-
-  // Serialize with dense format (no version header).
+TEST_P(SerializationTest, deserializeRejectsEmptyBatchList) {
+  auto type = velox::ROW({{"int_val", velox::INTEGER()}});
   SerializerOptions serializerOptions{};
   Serializer serializer{serializerOptions, type, pool_.get()};
-  auto serialized =
-      serializer.serialize(input, OrderedRanges::of(0, input->size()));
-
-  // Try to deserialize with kLegacyCompact (expects version header).
-  // The first byte is rowCount (not version), so it will be read as version
-  // and fail the version check.
   Deserializer deserializer{
       SchemaReader::getSchema(serializer.schemaBuilder().schemaNodes()),
-      pool_.get(),
-      DeserializerOptions{.hasHeader = true}};
+      pool_.get()};
 
   velox::VectorPtr output;
   NIMBLE_ASSERT_THROW(
-      deserializer.deserialize(serialized, output), "Unsupported version");
+      deserializer.deserialize(std::vector<std::string_view>{}, output),
+      "Expected at least one serialized batch");
 }
 
-TEST_P(SerializationTest, tabletVersionRejected) {
+TEST_P(SerializationTest, unsupportedWriterVersionsRejected) {
   auto type = velox::ROW({{"int_val", velox::INTEGER()}});
-  SerializerOptions options{.version = SerializationVersion::kTablet};
-  NIMBLE_ASSERT_THROW(
-      Serializer(options, type, pool_.get()),
-      "kTablet is not supported by the serializer");
+  struct TestCase {
+    SerializationVersion version;
+    std::string_view expectedMessage;
+  };
+
+  const std::vector<TestCase> testCases{
+      TestCase{
+          .version = SerializationVersion::kProjection,
+          .expectedMessage =
+              "Serializer writes must use kLegacy or kSerialization"},
+      TestCase{
+          .version = SerializationVersion::kTablet,
+          .expectedMessage =
+              "Serializer writes must use kLegacy or kSerialization"},
+  };
+  for (const auto& testCase : testCases) {
+    SCOPED_TRACE(fmt::format("version={}", toString(testCase.version)));
+    SerializerOptions options{.version = testCase.version};
+    NIMBLE_ASSERT_THROW(
+        Serializer(options, type, pool_.get()), testCase.expectedMessage);
+  }
 }
 
-TEST_P(SerializationTest, streamSizesEncodingIgnoredForLegacy) {
-  auto type = velox::ROW({{"int_val", velox::INTEGER()}});
-  // Legacy format does not use stream sizes trailer, so non-trivial
-  // encoding types are accepted (and ignored).
-  SerializerOptions options{
-      .streamIndicesEncodingType = EncodingType::Delta,
-      .streamSizesEncodingType = EncodingType::Delta};
-  EXPECT_NO_THROW(Serializer(options, type, pool_.get()));
+TEST_F(
+    SerializationTest,
+    serializerNormalizesLegacyWriterVersionsToSerialization) {
+  auto type = velox::ROW({{"x", velox::INTEGER()}});
+  auto col = velox::BaseVector::create(velox::INTEGER(), 1, pool_.get());
+  col->asFlatVector<int32_t>()->set(0, 42);
+  auto row = std::make_shared<velox::RowVector>(
+      pool_.get(), type, nullptr, 1, std::vector<velox::VectorPtr>{col});
+
+  const std::vector<SerializationVersion> versions{
+      SerializationVersion::kLegacy,
+      SerializationVersion::kLegacyCompact,
+      SerializationVersion::kLegacySerialization};
+  for (const auto version : versions) {
+    SCOPED_TRACE(toString(version));
+    SerializerOptions options{.version = version};
+    Serializer serializer{options, type, pool_.get()};
+    std::string blob;
+    serializer.serialize(row, OrderedRanges::of(0, 1), blob);
+    ASSERT_FALSE(blob.empty());
+    const char* pos = blob.data();
+    const auto header =
+        serde::readSerializationHeader(pos, blob.data() + blob.size(), true);
+    EXPECT_EQ(header.version, SerializationVersion::kSerialization);
+    EXPECT_EQ(header.rowCount, 1);
+  }
+}
+
+TEST_F(SerializationTest, serializerDefaultWritesNoHeaderLegacy) {
+  auto type = velox::ROW({{"x", velox::INTEGER()}});
+  auto col = velox::BaseVector::create(velox::INTEGER(), 1, pool_.get());
+  col->asFlatVector<int32_t>()->set(0, 42);
+  auto row = std::make_shared<velox::RowVector>(
+      pool_.get(), type, nullptr, 1, std::vector<velox::VectorPtr>{col});
+
+  Serializer serializer{SerializerOptions{}, type, pool_.get()};
+  std::string blob;
+  serializer.serialize(row, OrderedRanges::of(0, 1), blob);
+  ASSERT_FALSE(blob.empty());
+
+  const char* pos = blob.data();
+  const auto header =
+      serde::readSerializationHeader(pos, blob.data() + blob.size(), false);
+  EXPECT_EQ(header.version, SerializationVersion::kLegacy);
+  EXPECT_EQ(header.rowCount, 1);
+  EXPECT_EQ(pos - blob.data(), sizeof(uint32_t));
+
+  Deserializer deserializer{
+      SchemaReader::getSchema(serializer.schemaBuilder().schemaNodes()),
+      pool_.get()};
+  velox::VectorPtr output;
+  deserializer.deserialize(blob, output);
+  ASSERT_EQ(output->size(), row->size());
+  EXPECT_TRUE(vectorEquals(output, row, 0));
 }
 
 // Test encoding layout tree for non-FlatMap types.
@@ -2860,11 +4062,9 @@ TEST_P(SerializationTest, encodingLayoutTreeMapForFlatMap) {
       "Incompatible encoding layout node. Expecting flatmap node.");
 }
 
-TEST_P(SerializationTest, flatMapInMapStreamSkipping) {
-  // Test that serializer skips constant in-map boolean streams: both all-false
-  // (key absent from a batch) and all-true (key present in every row). The
-  // deserializer uses visitValueStreamLeaves() to enumerate per-key value-
-  // stream anchors and probes a presence bitmap to distinguish the two cases.
+TEST_P(SerializationTest, flatMapInMapStreamsForDiscoveredKeys) {
+  // Test that serializer skips constant in-map boolean streams for discovered
+  // FlatMap keys while preserving mixed in-map streams.
   auto type = velox::ROW({
       {"id", velox::BIGINT()},
       {"flat_map", velox::MAP(velox::VARCHAR(), velox::DOUBLE())},
@@ -2872,26 +4072,28 @@ TEST_P(SerializationTest, flatMapInMapStreamSkipping) {
 
   const velox::vector_size_t batchSize = 10;
 
-  // Helper to create a batch with specific keys present.
-  auto generateBatch =
-      [&](const std::vector<std::string>& keys) -> velox::VectorPtr {
-    const auto numKeys = static_cast<velox::vector_size_t>(keys.size());
-    const velox::vector_size_t totalEntries = batchSize * numKeys;
+  auto generateRowsBatch =
+      [&](const std::vector<std::vector<std::string>>& keysByRow)
+      -> velox::VectorPtr {
+    const auto numRows = static_cast<velox::vector_size_t>(keysByRow.size());
+    velox::vector_size_t totalEntries = 0;
+    for (const auto& keys : keysByRow) {
+      totalEntries += static_cast<velox::vector_size_t>(keys.size());
+    }
 
-    auto ids =
-        velox::BaseVector::create(velox::BIGINT(), batchSize, pool_.get());
+    auto ids = velox::BaseVector::create(velox::BIGINT(), numRows, pool_.get());
     auto mapKeys =
         velox::BaseVector::create(velox::VARCHAR(), totalEntries, pool_.get());
     auto mapValues =
         velox::BaseVector::create(velox::DOUBLE(), totalEntries, pool_.get());
 
-    for (velox::vector_size_t i = 0; i < batchSize; ++i) {
+    for (velox::vector_size_t i = 0; i < numRows; ++i) {
       ids->asFlatVector<int64_t>()->set(i, i);
     }
 
     velox::vector_size_t idx = 0;
-    for (velox::vector_size_t row = 0; row < batchSize; ++row) {
-      for (const auto& key : keys) {
+    for (velox::vector_size_t row = 0; row < numRows; ++row) {
+      for (const auto& key : keysByRow[row]) {
         mapKeys->asFlatVector<velox::StringView>()->set(
             idx, velox::StringView(key));
         mapValues->asFlatVector<double>()->set(idx, row * 10.0 + idx);
@@ -2903,27 +4105,34 @@ TEST_P(SerializationTest, flatMapInMapStreamSkipping) {
         pool_.get(),
         velox::MAP(velox::VARCHAR(), velox::DOUBLE()),
         nullptr,
-        batchSize,
-        velox::allocateOffsets(batchSize, pool_.get()),
-        velox::allocateSizes(batchSize, pool_.get()),
+        numRows,
+        velox::allocateOffsets(numRows, pool_.get()),
+        velox::allocateSizes(numRows, pool_.get()),
         mapKeys,
         mapValues);
 
     auto* rawOffsets =
-        mapVector->mutableOffsets(batchSize)->asMutable<velox::vector_size_t>();
+        mapVector->mutableOffsets(numRows)->asMutable<velox::vector_size_t>();
     auto* rawSizes =
-        mapVector->mutableSizes(batchSize)->asMutable<velox::vector_size_t>();
-    for (velox::vector_size_t i = 0; i < batchSize; ++i) {
-      rawOffsets[i] = i * numKeys;
-      rawSizes[i] = numKeys;
+        mapVector->mutableSizes(numRows)->asMutable<velox::vector_size_t>();
+    velox::vector_size_t offset = 0;
+    for (velox::vector_size_t i = 0; i < numRows; ++i) {
+      rawOffsets[i] = offset;
+      rawSizes[i] = static_cast<velox::vector_size_t>(keysByRow[i].size());
+      offset += rawSizes[i];
     }
 
     return std::make_shared<velox::RowVector>(
         pool_.get(),
         type,
         nullptr,
-        batchSize,
+        numRows,
         std::vector<velox::VectorPtr>{ids, mapVector});
+  };
+  auto generateBatch =
+      [&](const std::vector<std::string>& keys) -> velox::VectorPtr {
+    return generateRowsBatch(
+        std::vector<std::vector<std::string>>(batchSize, keys));
   };
 
   SerializerOptions options{
@@ -2935,12 +4144,12 @@ TEST_P(SerializationTest, flatMapInMapStreamSkipping) {
   };
   Serializer serializer{options, type, pool_.get()};
 
-  // Batch 1: keys "a" and "b" (both in-map streams are all-true -> skipped)
+  // Batch 1: keys "a" and "b" (both in-map streams are all-true).
   auto batch1 = generateBatch({"a", "b"});
   auto serialized1 = std::string(
       serializer.serialize(batch1, OrderedRanges::of(0, batch1->size())));
 
-  // Batch 2: only key "a" (key "b" absent -> all-false in-map, skipped)
+  // Batch 2: only key "a" (key "b" absent -> all-false in-map).
   auto batch2 = generateBatch({"a"});
   auto serialized2 = std::string(
       serializer.serialize(batch2, OrderedRanges::of(0, batch2->size())));
@@ -2951,16 +4160,27 @@ TEST_P(SerializationTest, flatMapInMapStreamSkipping) {
       serializer.serialize(batch3, OrderedRanges::of(0, batch3->size())));
 
   // Batch 4: keys "a" and "b" again (key "a" and "b" all-true in-map, key "c"
-  // all-false in-map -> all three in-map streams are constant, all skipped)
+  // all-false in-map).
   auto batch4 = generateBatch({"a", "b"});
   auto serialized4 = std::string(
       serializer.serialize(batch4, OrderedRanges::of(0, batch4->size())));
+
+  std::vector<std::vector<std::string>> mixedKeys(batchSize);
+  for (velox::vector_size_t i = 0; i < batchSize; ++i) {
+    mixedKeys[i].emplace_back("a");
+    if (i % 2 == 0) {
+      mixedKeys[i].emplace_back("b");
+    }
+  }
+  auto batch5 = generateRowsBatch(mixedKeys);
+  auto serialized5 = std::string(
+      serializer.serialize(batch5, OrderedRanges::of(0, batch5->size())));
 
   // Helper to collect stream offsets present in serialized data.
   auto collectStreamOffsets =
       [&](std::string_view data) -> folly::F14FastSet<uint32_t> {
     auto desOpts = deserializerOptions();
-    serde::StreamDataReader reader{pool_.get(), desOpts};
+    serde::StreamDataParser reader{pool_.get(), desOpts};
     reader.initialize(data);
     folly::F14FastSet<uint32_t> offsets;
     reader.iterateStreams(
@@ -2977,57 +4197,68 @@ TEST_P(SerializationTest, flatMapInMapStreamSkipping) {
   for (size_t i = 0; i < flatMap.childrenCount(); ++i) {
     inMapOffsets.push_back(flatMap.inMapDescriptorAt(i).offset());
   }
-  // After batch 3, schema has keys "a", "b", "c" → 3 in-map streams.
+  // After batch 3, schema has keys "a", "b", "c": 3 in-map streams.
   ASSERT_EQ(inMapOffsets.size(), 3);
 
-  // Verify constant in-map streams are NOT stored in serialized data.
+  // Verify constant in-map streams are omitted once their keys are discovered.
   {
-    // Batch 1: keys "a" and "b" all-true → in-map "a" and "b" skipped.
-    // Key "c" not yet discovered.
+    // Batch 1: keys "a" and "b" all-true. Key "c" is not discovered yet.
     auto offsets1 = collectStreamOffsets(serialized1);
     EXPECT_FALSE(offsets1.contains(inMapOffsets[0]))
-        << "in-map 'a' should be skipped (all-true)";
+        << "in-map 'a' should be absent (all-true)";
     EXPECT_FALSE(offsets1.contains(inMapOffsets[1]))
-        << "in-map 'b' should be skipped (all-true)";
+        << "in-map 'b' should be absent (all-true)";
+    EXPECT_FALSE(offsets1.contains(inMapOffsets[2]))
+        << "in-map 'c' should be absent before discovery";
 
-    // Batch 2: key "a" all-true, key "b" all-false → both skipped.
+    // Batch 2: key "a" all-true, key "b" all-false. Key "c" is not
+    // discovered yet.
     auto offsets2 = collectStreamOffsets(serialized2);
     EXPECT_FALSE(offsets2.contains(inMapOffsets[0]))
-        << "in-map 'a' should be skipped (all-true)";
+        << "in-map 'a' should be absent (all-true)";
     EXPECT_FALSE(offsets2.contains(inMapOffsets[1]))
-        << "in-map 'b' should be skipped (all-false)";
+        << "in-map 'b' should be absent (all-false)";
+    EXPECT_FALSE(offsets2.contains(inMapOffsets[2]))
+        << "in-map 'c' should be absent before discovery";
 
-    // Batch 3: keys "a", "b", "c" all present → all in-map all-true → skipped.
+    // Batch 3: keys "a", "b", "c" all present.
     auto offsets3 = collectStreamOffsets(serialized3);
     EXPECT_FALSE(offsets3.contains(inMapOffsets[0]))
-        << "in-map 'a' should be skipped (all-true)";
+        << "in-map 'a' should be absent (all-true)";
     EXPECT_FALSE(offsets3.contains(inMapOffsets[1]))
-        << "in-map 'b' should be skipped (all-true)";
+        << "in-map 'b' should be absent (all-true)";
     EXPECT_FALSE(offsets3.contains(inMapOffsets[2]))
-        << "in-map 'c' should be skipped (all-true)";
+        << "in-map 'c' should be absent (all-true)";
 
-    // Batch 4: keys "a" and "b" all-true, key "c" all-false → all skipped.
+    // Batch 4: keys "a" and "b" all-true, key "c" all-false.
     auto offsets4 = collectStreamOffsets(serialized4);
     EXPECT_FALSE(offsets4.contains(inMapOffsets[0]))
-        << "in-map 'a' should be skipped (all-true)";
+        << "in-map 'a' should be absent (all-true)";
     EXPECT_FALSE(offsets4.contains(inMapOffsets[1]))
-        << "in-map 'b' should be skipped (all-true)";
+        << "in-map 'b' should be absent (all-true)";
     EXPECT_FALSE(offsets4.contains(inMapOffsets[2]))
-        << "in-map 'c' should be skipped (all-false)";
+        << "in-map 'c' should be absent (all-false)";
+
+    // Batch 5: key "b" is mixed and must remain physically present. Key "a"
+    // is all-true and key "c" is all-false.
+    auto offsets5 = collectStreamOffsets(serialized5);
+    EXPECT_FALSE(offsets5.contains(inMapOffsets[0]))
+        << "in-map 'a' should be absent (all-true)";
+    EXPECT_TRUE(offsets5.contains(inMapOffsets[1]))
+        << "in-map 'b' should be written (mixed)";
+    EXPECT_FALSE(offsets5.contains(inMapOffsets[2]))
+        << "in-map 'c' should be absent (all-false)";
   }
 
-  // Deserialize and verify correctness. This exercises three cases where
-  // DeserializerImpl::contiguousRead encounters empty batchSegments_:
-  // 1. Row nulls stream omitted (all non-null) — the Row wrapper.
-  // 2. In-map boolean stream omitted (constant all-true or all-false).
-  // 3. Value stream absent (key not present in batch, e.g. key "c" in
-  //    batches 1/2/4, key "b" value in batch 2).
+  // Deserialize and verify correctness. Keys that were not discovered yet in
+  // earlier batches are decoded as absent in those batches.
   Deserializer deserializer{nimbleSchema, pool_.get(), deserializerOptions()};
 
   // Verify each batch individually.
-  std::vector<velox::VectorPtr> inputs = {batch1, batch2, batch3, batch4};
+  std::vector<velox::VectorPtr> inputs = {
+      batch1, batch2, batch3, batch4, batch5};
   std::vector<std::string> serializedData = {
-      serialized1, serialized2, serialized3, serialized4};
+      serialized1, serialized2, serialized3, serialized4, serialized5};
 
   velox::VectorPtr output;
   for (size_t i = 0; i < inputs.size(); ++i) {
@@ -3284,6 +4515,85 @@ TEST_P(SerializationTest, flatMapAsStructWithMissingKeys) {
   }
 }
 
+TEST_P(SerializationTest, flatMapAsStructWithPreviouslyDiscoveredMissingKey) {
+  auto type = velox::ROW({
+      {"features", velox::MAP(velox::INTEGER(), velox::DOUBLE())},
+  });
+
+  auto makeInput = [&](const std::vector<std::vector<int32_t>>& keysByRow)
+      -> velox::VectorPtr {
+    const auto numRows = static_cast<velox::vector_size_t>(keysByRow.size());
+    velox::vector_size_t totalEntries = 0;
+    for (const auto& keys : keysByRow) {
+      totalEntries += static_cast<velox::vector_size_t>(keys.size());
+    }
+
+    auto keysFlat =
+        velox::BaseVector::create(velox::INTEGER(), totalEntries, pool_.get());
+    auto valuesFlat =
+        velox::BaseVector::create(velox::DOUBLE(), totalEntries, pool_.get());
+
+    velox::vector_size_t offset = 0;
+    for (velox::vector_size_t row = 0; row < numRows; ++row) {
+      for (const auto key : keysByRow[row]) {
+        keysFlat->asFlatVector<int32_t>()->set(offset, key);
+        valuesFlat->asFlatVector<double>()->set(offset, row * 10.0 + key);
+        ++offset;
+      }
+    }
+
+    auto mapVector = std::make_shared<velox::MapVector>(
+        pool_.get(),
+        velox::MAP(velox::INTEGER(), velox::DOUBLE()),
+        nullptr,
+        numRows,
+        velox::allocateOffsets(numRows, pool_.get()),
+        velox::allocateSizes(numRows, pool_.get()),
+        keysFlat,
+        valuesFlat);
+
+    auto* rawOffsets =
+        mapVector->mutableOffsets(numRows)->asMutable<velox::vector_size_t>();
+    auto* rawSizes =
+        mapVector->mutableSizes(numRows)->asMutable<velox::vector_size_t>();
+    offset = 0;
+    for (velox::vector_size_t row = 0; row < numRows; ++row) {
+      rawOffsets[row] = offset;
+      rawSizes[row] = static_cast<velox::vector_size_t>(keysByRow[row].size());
+      offset += rawSizes[row];
+    }
+
+    return std::make_shared<velox::RowVector>(
+        pool_.get(),
+        type,
+        nullptr,
+        numRows,
+        std::vector<velox::VectorPtr>{mapVector});
+  };
+
+  const SerializerOptions serOptions{
+      .version = version(),
+      .flatMapColumns = {{"features", {}}},
+  };
+  Serializer serializer{serOptions, type, pool_.get()};
+
+  std::vector<velox::VectorPtr> inputs{
+      makeInput({{1, 2}, {1}, {2}, {}, {1, 2}}),
+      makeInput({{2}, {2, 3}, {3}, {}, {2}}),
+      makeInput({{1, 3}, {1}, {3}, {}, {1, 3}}),
+      makeInput({{1, 2, 3}, {2}, {1}, {}, {3}}),
+  };
+
+  std::vector<std::string> serializedData;
+  serializedData.reserve(inputs.size());
+  for (const auto& input : inputs) {
+    serializedData.emplace_back(
+        serializer.serialize(input, OrderedRanges::of(0, input->size())));
+  }
+
+  verifyFlatMapAsStruct(serializer, serializedData, inputs);
+}
+
 // Standalone test for kTablet deserialization.
 // kTablet is not produced by the Serializer — it's constructed by reading
 // raw tablet stream bytes from a Nimble file and assembling them with a header
@@ -3380,7 +4690,8 @@ TEST_F(SerializationTest, tabletTrailerDeserialization) {
             /*enableChunking=*/true,
             streamIdsEncodingType,
             sizeIndicesEncodingType,
-            uniqueSizesEncodingType);
+            uniqueSizesEncodingType,
+            /*forceDuplicateFirstTwoStreams=*/true);
         ASSERT_EQ(tablet.serialized.size(), 1);
         ASSERT_EQ(tablet.numTabletStreams.size(), 1);
         ASSERT_GT(tablet.numTabletStreams[0], tablet.numUniqueTabletStreams[0]);
@@ -3405,7 +4716,7 @@ TEST_F(SerializationTest, tabletTrailerDeserialization) {
 }
 
 // Verifies ZSTD decompression round-trips correctly with the thread-local
-// ZSTD_DCtx reuse (always-on). Exercises the StreamDataReader and StreamData
+// ZSTD_DCtx reuse (always-on). Exercises the StreamDataParser and StreamData
 // decompress paths with kTablet chunked format.
 TEST_F(SerializationTest, zstdThreadLocalDCtxRoundTrip) {
   auto rowType = velox::ROW(
@@ -4092,7 +5403,7 @@ TEST_P(SerializationTest, flatMapDeserializeWithFlatMapSchema) {
 // Exercises the scatteredRead path in Deserializer when flat-map keys are
 // sparse (absent in some rows). Deserializing with outputType (struct mode)
 // triggers scatter bitmaps for each key. Without the nulls initialization fix
-// in DeserializerImpl::next(), this crashes in loadOffsets() accessing
+// in SegmentedStreamDecoder::next(), this crashes in loadOffsets() accessing
 // rawNulls() on an unallocated buffer.
 TEST_P(SerializationTest, flatMapScatteredReadWithSparseKeys) {
   if (!version().has_value() || version() == SerializationVersion::kLegacy) {
@@ -5393,15 +6704,24 @@ std::string buildLegacyTrivialTrailer(const std::vector<uint32_t>& denseSizes) {
 }
 
 // Rewrites a kSerialization blob to bytes a master-format kLegacyCompact writer
-// would have produced. The body wire format (varint row counts + per-stream
-// payloads) is byte-identical across the two versions; only the trailer
-// layout and the version byte differ. This lets us synthesize a production
-// kLegacyCompact blob without resurrecting the master writer.
+// would have produced. The stream payloads are byte-identical across the two
+// versions; this strips the kSerialization flags byte and rewrites the trailer.
 std::string rewriteAsLegacyCompactRaw(std::string_view kSerializationBlob) {
   const char* end = kSerializationBlob.data() + kSerializationBlob.size();
+  const char* headerEnd = kSerializationBlob.data();
+  const auto header = serde::readSerializationHeader(headerEnd, end, true);
+  NIMBLE_CHECK_EQ(header.version, SerializationVersion::kSerialization);
+  const auto bodyStartOffset =
+      static_cast<size_t>(headerEnd - kSerializationBlob.data());
+  const auto flagsOffset = bodyStartOffset - 1;
+
   auto [sparseIndices, sparseSizes] =
       serde::detail::readTrailerStreamMetadata(end);
   const auto newTrailerSize = serde::detail::readTrailerSize(end);
+  const auto bodyEndOffset =
+      kSerializationBlob.size() - sizeof(uint32_t) - newTrailerSize;
+  NIMBLE_CHECK_GE(
+      bodyEndOffset, bodyStartOffset, "Truncated kSerialization body");
 
   std::vector<uint32_t> denseSizes;
   if (!sparseIndices.empty()) {
@@ -5411,10 +6731,33 @@ std::string rewriteAsLegacyCompactRaw(std::string_view kSerializationBlob) {
     }
   }
 
-  std::string rewritten(kSerializationBlob.substr(
-      0, kSerializationBlob.size() - sizeof(uint32_t) - newTrailerSize));
-  rewritten[0] = static_cast<char>(SerializationVersion::kLegacyCompact);
+  std::string rewritten;
+  rewritten.reserve(
+      bodyEndOffset - 1 + sizeof(uint8_t) +
+      denseSizes.size() * sizeof(uint32_t) + sizeof(uint32_t));
+  rewritten.push_back(static_cast<char>(SerializationVersion::kLegacyCompact));
+  rewritten.append(kSerializationBlob.substr(1, flagsOffset - 1));
+  rewritten.append(kSerializationBlob.substr(
+      bodyStartOffset, bodyEndOffset - bodyStartOffset));
   rewritten.append(buildLegacyTrivialTrailer(denseSizes));
+  return rewritten;
+}
+
+std::string rewriteAsLegacySerialization(std::string_view kSerializationBlob) {
+  const char* end = kSerializationBlob.data() + kSerializationBlob.size();
+  const char* headerEnd = kSerializationBlob.data();
+  const auto header = serde::readSerializationHeader(headerEnd, end, true);
+  NIMBLE_CHECK_EQ(header.version, SerializationVersion::kSerialization);
+  const auto bodyStartOffset =
+      static_cast<size_t>(headerEnd - kSerializationBlob.data());
+  const auto flagsOffset = bodyStartOffset - 1;
+
+  std::string rewritten;
+  rewritten.reserve(kSerializationBlob.size() - 1);
+  rewritten.push_back(
+      static_cast<char>(SerializationVersion::kLegacySerialization));
+  rewritten.append(kSerializationBlob.substr(1, flagsOffset - 1));
+  rewritten.append(kSerializationBlob.substr(bodyStartOffset));
   return rewritten;
 }
 
@@ -5478,23 +6821,67 @@ TEST_F(SerializationTest, compactRawProductionBlobRoundtrip) {
   }
 }
 
-// kLegacyCompact is read-only post the two-array trailer change. Existing
-// callers (especially directory-branched prod code we can't touch in this
-// diff) still pass kLegacyCompact for writes — the Serializer must silently
-// upgrade them to kSerialization rather than throw, so they keep working
-// while migrating.
-TEST_F(SerializationTest, serializerUpgradesKLegacyCompactToKSerialization) {
-  auto type = velox::ROW({{"x", velox::INTEGER()}});
-  SerializerOptions options{
-      .version = SerializationVersion::kLegacyCompact,
+TEST_F(SerializationTest, legacySerializationProductionBlobRoundtrip) {
+  auto type = velox::ROW({
+      {"bool_val", velox::BOOLEAN()},
+      {"int_val", velox::INTEGER()},
+      {"long_val", velox::BIGINT()},
+      {"double_val", velox::DOUBLE()},
+      {"string_val", velox::VARCHAR()},
+  });
+
+  velox::VectorFuzzer fuzzer(
+      {
+          .vectorSize = 64,
+          .nullRatio = 0,
+          .stringLength = 16,
+          .stringVariableLength = true,
+      },
+      pool_.get(),
+      /*seed=*/12345);
+  auto input = fuzzer.fuzzInputRow(type);
+
+  SerializerOptions writerOptions{
+      .version = SerializationVersion::kSerialization,
   };
-  // Construction must not throw, and the produced blob must carry the
-  // kSerialization version byte (the silent-upgrade target).
-  Serializer serializer{options, type, pool_.get()};
+  Serializer serializer{writerOptions, type, pool_.get()};
+  const auto kSerializationBlob =
+      serializer.serialize(input, OrderedRanges::of(0, input->size()));
+
+  const std::string kLegacySerializationBlob =
+      rewriteAsLegacySerialization(kSerializationBlob);
+
+  ASSERT_FALSE(kLegacySerializationBlob.empty());
+  ASSERT_EQ(
+      static_cast<uint8_t>(kLegacySerializationBlob[0]),
+      static_cast<uint8_t>(SerializationVersion::kLegacySerialization));
+
+  DeserializerOptions deserOptions{.hasHeader = true};
+  Deserializer deserializer{
+      SchemaReader::getSchema(serializer.schemaBuilder().schemaNodes()),
+      pool_.get(),
+      deserOptions};
+
+  velox::VectorPtr output;
+  deserializer.deserialize(kLegacySerializationBlob, output);
+
+  ASSERT_EQ(output->size(), input->size());
+  for (velox::vector_size_t i = 0; i < input->size(); ++i) {
+    EXPECT_TRUE(vectorEquals(input, output, i))
+        << "Row " << i << " mismatch:\n  expected: " << input->toString(i)
+        << "\n  actual:   " << output->toString(i);
+  }
+}
+
+TEST_F(SerializationTest, serializerHonorsRequestedEncodedVersion) {
+  auto type = velox::ROW({{"x", velox::INTEGER()}});
   auto col = velox::BaseVector::create(velox::INTEGER(), 1, pool_.get());
   col->asFlatVector<int32_t>()->set(0, 42);
   auto row = std::make_shared<velox::RowVector>(
       pool_.get(), type, nullptr, 1, std::vector<velox::VectorPtr>{col});
+
+  SerializerOptions options{.version = SerializationVersion::kSerialization};
+  Serializer serializer{options, type, pool_.get()};
   std::string blob;
   serializer.serialize(row, OrderedRanges::of(0, 1), blob);
   ASSERT_FALSE(blob.empty());
@@ -5507,11 +6894,9 @@ INSTANTIATE_TEST_SUITE_P(
     AllFormats,
     SerializationTest,
     ::testing::Values(
-        // Legacy format (no nimble encoding).
-        TestParams{.version = std::nullopt},
-        // kLegacyCompact format without compression.
+        // kSerialization format without compression.
         TestParams{.version = SerializationVersion::kSerialization},
-        // kLegacyCompact format with compression enabled (for
+        // kSerialization format with compression enabled (for
         // encodingLayoutTree tests).
         TestParams{
             .version = SerializationVersion::kSerialization,
@@ -5519,20 +6904,19 @@ INSTANTIATE_TEST_SUITE_P(
                 CompressionOptions{
                     .compressionAcceptRatio = 1.0f,
                     .zstdMinCompressionSize = 0}},
-        // kLegacyCompact format with Delta stream sizes encoding.
+        // kSerialization format with Delta stream sizes encoding.
         TestParams{
             .version = SerializationVersion::kSerialization,
             .streamSizesEncodingType = EncodingType::Delta},
-        // kLegacyCompact format with FixedBitWidth stream sizes encoding.
+        // kSerialization format with FixedBitWidth stream sizes encoding.
         TestParams{
             .version = SerializationVersion::kSerialization,
             .streamSizesEncodingType = EncodingType::FixedBitWidth},
-        // kLegacyCompact format with Varint stream sizes encoding.
+        // kSerialization format with Varint stream sizes encoding.
         TestParams{
             .version = SerializationVersion::kSerialization,
             .streamSizesEncodingType = EncodingType::Varint},
         // Buffer pool disabled variants.
-        TestParams{.version = std::nullopt, .bufferPoolCapacity = 0},
         TestParams{
             .version = SerializationVersion::kSerialization,
             .bufferPoolCapacity = 0},

--- a/dwio/nimble/serializer/tests/SerializerImplTest.cpp
+++ b/dwio/nimble/serializer/tests/SerializerImplTest.cpp
@@ -25,6 +25,7 @@
 #include "dwio/nimble/common/ChunkHeader.h"
 #include "dwio/nimble/common/Exceptions.h"
 #include "dwio/nimble/common/Varint.h"
+#include "dwio/nimble/common/tests/GTestUtils.h"
 #include "dwio/nimble/encodings/common/EncodingFactory.h"
 #include "dwio/nimble/encodings/common/EncodingLayout.h"
 #include "dwio/nimble/encodings/common/EncodingPrimitives.h"
@@ -187,18 +188,23 @@ class WriteHeaderTest : public ::testing::Test {
     auto actualVersion = static_cast<SerializationVersion>(*pos++);
     EXPECT_EQ(actualVersion, expectedVersion);
 
-    // Read row count. kLegacyCompact uses varint, kLegacy uses u32.
-    const bool isCompact = isCompactFormat(expectedVersion);
+    // Read row count. Non-legacy formats use varint; kLegacy uses u32.
     uint32_t actualRowCount;
-    if (isCompact) {
+    if (usesVarintRowCount(expectedVersion)) {
       actualRowCount = varint::readVarint32(&pos);
     } else {
       actualRowCount = encoding::readUint32(pos);
     }
     EXPECT_EQ(actualRowCount, expectedRowCount);
 
-    // For kLegacyCompact, verify stream sizes from trailer.
-    if (isCompactFormat(expectedVersion)) {
+    // Skip the flags byte for versions that carry one (no nulls expected here).
+    if (usesHeaderFlags(expectedVersion)) {
+      EXPECT_EQ(static_cast<uint8_t>(*pos++), 0)
+          << "unexpected null-barrier flag";
+    }
+
+    // Sequential stream layouts keep stream sizes in the trailer.
+    if (nonLegacyFormat(expectedVersion) && !isTabletVersion(expectedVersion)) {
       auto actualSizes = readTrailerStreamMetadataDenseForTest(end);
       if (actualSizes.size() < expectedSizes.size()) {
         actualSizes.resize(expectedSizes.size(), 0);
@@ -209,12 +215,6 @@ class WriteHeaderTest : public ::testing::Test {
 
   std::shared_ptr<memory::MemoryPool> pool_;
 };
-
-TEST_F(WriteHeaderTest, legacyFormat) {
-  std::string buffer;
-  serde::writeSerializationHeader(buffer, SerializationVersion::kLegacy, 100);
-  verifyHeader(buffer, SerializationVersion::kLegacy, 100, {});
-}
 
 TEST_F(WriteHeaderTest, compactRawFormatTrivial) {
   std::vector<uint32_t> sizes = {10, 20, 30};
@@ -268,79 +268,21 @@ TEST_F(WriteHeaderTest, compactRawFormatManySizes) {
 }
 
 TEST_F(WriteHeaderTest, zeroRowCount) {
-  {
-    SCOPED_TRACE("kLegacy");
-    std::string buffer;
-    serde::writeSerializationHeader(buffer, SerializationVersion::kLegacy, 0);
-    verifyHeader(buffer, SerializationVersion::kLegacy, 0, {});
-  }
-  {
-    SCOPED_TRACE("kLegacyCompact");
-    auto buffer = buildCompactRawHeaderTrailer(0, {});
-    verifyHeader(buffer, SerializationVersion::kSerialization, 0, {});
-  }
+  auto buffer = buildCompactRawHeaderTrailer(0, {});
+  verifyHeader(buffer, SerializationVersion::kSerialization, 0, {});
 }
 
 TEST_F(WriteHeaderTest, maxRowCount) {
-  {
-    SCOPED_TRACE("kLegacy");
-    std::string buffer;
-    serde::writeSerializationHeader(
-        buffer,
-        SerializationVersion::kLegacy,
-        std::numeric_limits<uint32_t>::max());
-    verifyHeader(
-        buffer,
-        SerializationVersion::kLegacy,
-        std::numeric_limits<uint32_t>::max(),
-        {});
-  }
-  {
-    SCOPED_TRACE("kLegacyCompact");
-    auto buffer =
-        buildCompactRawHeaderTrailer(std::numeric_limits<uint32_t>::max(), {});
-    verifyHeader(
-        buffer,
-        SerializationVersion::kSerialization,
-        std::numeric_limits<uint32_t>::max(),
-        {});
-  }
-}
-
-TEST_F(WriteHeaderTest, noVersionHeader) {
-  std::string buffer;
-  serde::writeSerializationHeader(buffer, std::nullopt, 100);
-
-  // No version byte - only row count.
-  EXPECT_EQ(buffer.size(), sizeof(uint32_t));
-
-  const char* pos = buffer.data();
-  uint32_t rowCount = encoding::readUint32(pos);
-  EXPECT_EQ(rowCount, 100);
+  auto buffer =
+      buildCompactRawHeaderTrailer(std::numeric_limits<uint32_t>::max(), {});
+  verifyHeader(
+      buffer,
+      SerializationVersion::kSerialization,
+      std::numeric_limits<uint32_t>::max(),
+      {});
 }
 
 // Tests for estimateHeaderSize
-
-TEST_F(WriteHeaderTest, estimateHeaderSizeLegacy) {
-  struct TestParam {
-    uint32_t rowCount;
-    std::string debugString() const {
-      return fmt::format("rowCount {}", rowCount);
-    }
-  };
-  std::vector<TestParam> testSettings = {
-      {0}, {1}, {1000}, {std::numeric_limits<uint32_t>::max()}};
-  for (const auto& testData : testSettings) {
-    SCOPED_TRACE(testData.debugString());
-    std::string buffer;
-    serde::writeSerializationHeader(
-        buffer, SerializationVersion::kLegacy, testData.rowCount);
-    EXPECT_EQ(
-        serde::estimateSerializationHeaderSize(
-            SerializationVersion::kLegacy, testData.rowCount),
-        buffer.size());
-  }
-}
 
 TEST_F(WriteHeaderTest, estimateHeaderSizeCompactRaw) {
   struct TestParam {
@@ -368,13 +310,6 @@ TEST_F(WriteHeaderTest, estimateHeaderSizeCompactRaw) {
             SerializationVersion::kSerialization, testData.rowCount),
         buffer.size());
   }
-}
-
-TEST_F(WriteHeaderTest, estimateHeaderSizeNoVersion) {
-  std::string buffer;
-  serde::writeSerializationHeader(buffer, std::nullopt, 100);
-  EXPECT_EQ(
-      serde::estimateSerializationHeaderSize(std::nullopt, 100), buffer.size());
 }
 
 // Tests for estimateTrailerSize
@@ -618,7 +553,7 @@ TEST_F(ParseStreamsTest, legacyFormatMultipleStreams) {
   EXPECT_EQ(streams[2], "third");
 }
 
-// kLegacyCompact format tests use writeHeader/parseStreams roundtrip since
+// kSerialization format tests use writeHeader/parseStreams roundtrip since
 // the size encoding is now opaque (nimble-encoded).
 
 TEST_F(ParseStreamsTest, denseFormatEmpty) {
@@ -629,9 +564,12 @@ TEST_F(ParseStreamsTest, denseFormatEmpty) {
   serde::detail::writeTrailer(
       {}, EncodingType::Trivial, EncodingType::Trivial, buffer);
 
+  // Skip the header to reach the streams.
+  const char* streamsPos = buffer.data();
+  serde::readSerializationHeader(
+      streamsPos, buffer.data() + buffer.size(), /*hasHeader=*/true);
   auto streams = serde::detail::parseStreams(
-      // Skip version byte and row count varint.
-      buffer.data() + 1 + varint::varintSize(10),
+      streamsPos,
       buffer.data() + buffer.size(),
       SerializationVersion::kSerialization,
       pool_.get());
@@ -655,9 +593,10 @@ TEST_F(ParseStreamsTest, denseFormatSequential) {
   serde::detail::writeTrailer(
       sizes, EncodingType::Trivial, EncodingType::Trivial, buffer);
 
-  // Skip version byte + varint row count.
-  const char* pos = buffer.data() + 1;
-  varint::readVarint32(&pos);
+  // Skip the header.
+  const char* pos = buffer.data();
+  serde::readSerializationHeader(
+      pos, buffer.data() + buffer.size(), /*hasHeader=*/true);
 
   auto streams = serde::detail::parseStreams(
       pos,
@@ -685,8 +624,9 @@ TEST_F(ParseStreamsTest, denseFormatWithGaps) {
   serde::detail::writeTrailer(
       sizes, EncodingType::Trivial, EncodingType::Trivial, buffer);
 
-  const char* pos = buffer.data() + 1;
-  varint::readVarint32(&pos);
+  const char* pos = buffer.data();
+  serde::readSerializationHeader(
+      pos, buffer.data() + buffer.size(), /*hasHeader=*/true);
 
   auto streams = serde::detail::parseStreams(
       pos,
@@ -715,8 +655,9 @@ TEST_F(ParseStreamsTest, denseFormatOnlyLastStream) {
   serde::detail::writeTrailer(
       sizes, EncodingType::Trivial, EncodingType::Trivial, buffer);
 
-  const char* pos = buffer.data() + 1;
-  varint::readVarint32(&pos);
+  const char* pos = buffer.data();
+  serde::readSerializationHeader(
+      pos, buffer.data() + buffer.size(), /*hasHeader=*/true);
 
   auto streams = serde::detail::parseStreams(
       pos,
@@ -1098,8 +1039,9 @@ TEST_F(EncodeDecodeTest, streamSizesEncodingType) {
     buffer.append("s2");
     serde::detail::writeTrailer(sizes, encodingType, encodingType, buffer);
 
-    const char* pos = buffer.data() + 1;
-    varint::readVarint32(&pos);
+    const char* pos = buffer.data();
+    serde::readSerializationHeader(
+        pos, buffer.data() + buffer.size(), /*hasHeader=*/true);
     auto streams = serde::detail::parseStreams(
         pos,
         buffer.data() + buffer.size(),
@@ -1125,8 +1067,9 @@ TEST_F(EncodeDecodeTest, streamSizesEncodingTypeDefault) {
   serde::detail::writeTrailer(
       sizes, EncodingType::Trivial, EncodingType::Trivial, buffer);
 
-  const char* pos = buffer.data() + 1;
-  varint::readVarint32(&pos);
+  const char* pos = buffer.data();
+  serde::readSerializationHeader(
+      pos, buffer.data() + buffer.size(), /*hasHeader=*/true);
   auto streams = serde::detail::parseStreams(
       pos,
       buffer.data() + buffer.size(),
@@ -1154,8 +1097,9 @@ TEST_F(EncodeDecodeTest, streamSizesEncodingTypeCompactRaw) {
     buffer.append(std::string(30, 'c'));
     serde::detail::writeTrailer(sizes, encodingType, encodingType, buffer);
 
-    const char* pos = buffer.data() + 1;
-    varint::readVarint32(&pos);
+    const char* pos = buffer.data();
+    serde::readSerializationHeader(
+        pos, buffer.data() + buffer.size(), /*hasHeader=*/true);
     auto streams = serde::detail::parseStreams(
         pos,
         buffer.data() + buffer.size(),
@@ -1194,7 +1138,7 @@ std::vector<ProjectedStream> projectStreams(
   std::vector<ProjectedStream> streams;
   streams.reserve(selectedStreamIndices.size());
 
-  if (isCompactFormat(version)) {
+  if (nonLegacyFormat(version) && !isTabletVersion(version)) {
     auto streamSizes = readTrailerStreamMetadataDenseForTest(end);
     const char* dataStart = pos;
 
@@ -1274,9 +1218,10 @@ class ProjectStreamsTest : public ParseStreamsTest {
     serde::detail::writeTrailer(
         sizes, EncodingType::Trivial, EncodingType::Trivial, buffer);
 
-    // Skip version byte + varint row count to get to streams position.
-    const char* pos = buffer.data() + 1;
-    varint::readVarint32(&pos);
+    // Skip the header (version + flags + varint row count) to reach streams.
+    const char* pos = buffer.data();
+    serde::readSerializationHeader(
+        pos, buffer.data() + buffer.size(), /*hasHeader=*/true);
     auto offset = pos - buffer.data();
     return buffer.substr(offset);
   }
@@ -1670,10 +1615,10 @@ TEST_F(EncodeTypedCompressionTest, defaultFactoryNoCompression) {
       CompressionType::Uncompressed);
 }
 
-// Tests for kTablet chunk header stripping in StreamDataReader.
+// Tests for kTablet chunk header stripping in StreamDataParser.
 // kTablet streams contain chunk headers:
 //   [chunkSize:u32][compressionType:1B][encoded_data...]
-// StreamDataReader must strip these headers and decompress as needed.
+// StreamDataParser must strip these headers and decompress as needed.
 
 class TabletChunkStripTest : public ::testing::Test {
  protected:
@@ -1724,7 +1669,7 @@ class TabletChunkStripTest : public ::testing::Test {
   // Assembles a kTablet buffer from streams and returns the data collected
   // by iterateStreams.
   // Each entry in 'streams' is the raw stream bytes (with chunk headers).
-  std::vector<std::pair<uint32_t, std::string>> deserializeTablet(
+  std::string buildTabletBuffer(
       uint32_t rowCount,
       const std::vector<std::pair<uint32_t, std::string>>& streams) {
     // Build dense sizes array.
@@ -1747,10 +1692,17 @@ class TabletChunkStripTest : public ::testing::Test {
         headerIOBuf.length());
     buffer.append(streamData);
     writeTabletTrailer(sizes, buffer);
+    return buffer;
+  }
 
-    // Parse via StreamDataReader.
+  std::vector<std::pair<uint32_t, std::string>> deserializeTablet(
+      uint32_t rowCount,
+      const std::vector<std::pair<uint32_t, std::string>>& streams) {
+    const auto buffer = buildTabletBuffer(rowCount, streams);
+
+    // Parse via StreamDataParser.
     DeserializerOptions options{.hasHeader = true};
-    StreamDataReader reader(pool_.get(), options);
+    StreamDataParser reader(pool_.get(), options);
     auto actualRows = reader.initialize(std::string_view(buffer));
     EXPECT_EQ(actualRows, rowCount);
 
@@ -1841,6 +1793,111 @@ TEST_F(TabletChunkStripTest, multipleStreams) {
   EXPECT_EQ(result[1].second, payload2);
 }
 
+TEST_F(TabletChunkStripTest, streamViewsRemainStable) {
+  struct StreamViewCase {
+    std::string name;
+    std::vector<std::pair<uint32_t, std::string>> firstStreams;
+    std::vector<std::pair<uint32_t, std::string>> secondStreams;
+    std::vector<std::pair<uint32_t, std::string>> expectedAfterFirstBatch;
+    std::vector<std::pair<uint32_t, std::string>> expectedAfterSecondBatch;
+  };
+
+  const auto payload = [](char value) { return std::string(4096, value); };
+  const auto materialize =
+      [](const std::vector<std::pair<uint32_t, std::string_view>>& views) {
+        std::vector<std::pair<uint32_t, std::string>> result;
+        result.reserve(views.size());
+        for (const auto& [offset, data] : views) {
+          result.emplace_back(offset, std::string{data});
+        }
+        return result;
+      };
+
+  const auto uncompressed0 = payload('a');
+  const auto uncompressed1 = payload('b');
+  const auto uncompressed2 = payload('c');
+  const auto compressed0 = payload('d');
+  const auto compressed1 = payload('e');
+  const auto compressed2 = payload('f');
+  const auto mixed0 = payload('g');
+  const auto mixed1 = payload('h');
+  const auto mixed2 = payload('i');
+  const auto mixed3 = payload('j');
+  const auto mixed4 = payload('k');
+  const auto mixed5 = payload('l');
+
+  const std::vector<StreamViewCase> testCases{
+      {
+          .name = "uncompressed",
+          .firstStreams =
+              {{0, buildUncompressedChunk(uncompressed0)},
+               {1, buildUncompressedChunk(uncompressed1)}},
+          .secondStreams = {{0, buildUncompressedChunk(uncompressed2)}},
+          .expectedAfterFirstBatch = {{0, uncompressed0}, {1, uncompressed1}},
+          .expectedAfterSecondBatch =
+              {{0, uncompressed0}, {1, uncompressed1}, {0, uncompressed2}},
+      },
+      {
+          .name = "compressed",
+          .firstStreams =
+              {{0, buildCompressedChunk(compressed0)},
+               {1, buildCompressedChunk(compressed1)}},
+          .secondStreams = {{0, buildCompressedChunk(compressed2)}},
+          .expectedAfterFirstBatch = {{0, compressed0}, {1, compressed1}},
+          .expectedAfterSecondBatch =
+              {{0, compressed0}, {1, compressed1}, {0, compressed2}},
+      },
+      {
+          .name = "mixed",
+          .firstStreams =
+              {{0,
+                concatChunks(
+                    {buildUncompressedChunk(mixed0),
+                     buildCompressedChunk(mixed1)})},
+               {1,
+                concatChunks(
+                    {buildCompressedChunk(mixed2),
+                     buildUncompressedChunk(mixed3)})}},
+          .secondStreams =
+              {{0,
+                concatChunks(
+                    {buildUncompressedChunk(mixed4),
+                     buildCompressedChunk(mixed5)})}},
+          .expectedAfterFirstBatch =
+              {{0, mixed0 + mixed1}, {1, mixed2 + mixed3}},
+          .expectedAfterSecondBatch =
+              {{0, mixed0 + mixed1},
+               {1, mixed2 + mixed3},
+               {0, mixed4 + mixed5}},
+      },
+  };
+
+  for (const auto& testCase : testCases) {
+    SCOPED_TRACE(testCase.name);
+
+    const auto firstBatch = buildTabletBuffer(10, testCase.firstStreams);
+    const auto secondBatch = buildTabletBuffer(20, testCase.secondStreams);
+
+    DeserializerOptions options{.hasHeader = true};
+    StreamDataParser reader(pool_.get(), options);
+
+    std::vector<std::pair<uint32_t, std::string_view>> views;
+    EXPECT_EQ(reader.initialize(firstBatch), 10);
+    reader.iterateStreams([&](uint32_t offset, std::string_view data) {
+      views.emplace_back(offset, data);
+    });
+    EXPECT_EQ(materialize(views), testCase.expectedAfterFirstBatch);
+
+    EXPECT_EQ(reader.initialize(secondBatch), 20);
+    reader.iterateStreams([&](uint32_t offset, std::string_view data) {
+      views.emplace_back(offset, data);
+    });
+    EXPECT_EQ(materialize(views), testCase.expectedAfterSecondBatch);
+
+    reader.reset();
+  }
+}
+
 TEST_F(TabletChunkStripTest, multipleStreamsMultipleChunks) {
   // Stream 0: two uncompressed chunks.
   std::string s0p1 = "stream0 part1";
@@ -1871,14 +1928,15 @@ TEST_F(TabletChunkStripTest, multipleStreamsMultipleChunks) {
 }
 
 TEST_F(TabletChunkStripTest, emptyPayloadChunk) {
-  // Single uncompressed chunk with empty payload.
-  // The chunk header is still present (5 bytes), so iterateStreams calls the
-  // callback with the stripped (empty) data.
-  auto stream = buildUncompressedChunk("");
-  auto result = deserializeTablet(10, {{0, stream}});
-  ASSERT_EQ(result.size(), 1);
-  EXPECT_EQ(result[0].first, 0);
-  EXPECT_TRUE(result[0].second.empty());
+  for (const auto& [name, stream] : {
+           std::pair{"uncompressed", buildUncompressedChunk("")},
+           std::pair{"compressed", buildCompressedChunk("")},
+       }) {
+    SCOPED_TRACE(name);
+    NIMBLE_ASSERT_THROW(
+        deserializeTablet(10, {{0, stream}}),
+        "Chunked stream must have a non-empty payload");
+  }
 }
 
 TEST_F(TabletChunkStripTest, largePayload) {
@@ -1916,7 +1974,7 @@ TEST_F(TabletChunkStripTest, largePayloadMultipleChunks) {
   EXPECT_EQ(result[0].second, payload);
 }
 
-// Tests for ZSTD_DCtx reuse in StreamData and StreamDataReader.
+// Tests for ZSTD_DCtx reuse in StreamData and StreamDataParser.
 // Inherits from TabletChunkStripTest for shared helpers
 // (buildCompressedChunk, pool_, etc.).
 
@@ -1936,7 +1994,7 @@ class ZstdDCtxReuseTest : public TabletChunkStripTest {
   }
 
   // Like TabletChunkStripTest::deserializeTablet, but passes
-  // the fixture's shared dctx to StreamDataReader.
+  // the fixture's shared dctx to StreamDataParser.
   std::vector<std::pair<uint32_t, std::string>> deserializeTabletWithDCtx(
       uint32_t rowCount,
       const std::vector<std::pair<uint32_t, std::string>>& streams) {
@@ -1960,7 +2018,7 @@ class ZstdDCtxReuseTest : public TabletChunkStripTest {
     writeTabletTrailer(sizes, buffer);
 
     DeserializerOptions options{.hasHeader = true};
-    StreamDataReader reader(pool_.get(), options);
+    StreamDataParser reader(pool_.get(), options);
     auto actualRows = reader.initialize(std::string_view(buffer));
     EXPECT_EQ(actualRows, rowCount);
 
@@ -1997,6 +2055,33 @@ TEST_F(ZstdDCtxReuseTest, streamDataLegacyZstdWithDCtx) {
   EXPECT_EQ(output, expected);
 }
 
+TEST_F(ZstdDCtxReuseTest, streamDataLegacyDecodeFails) {
+  const std::vector<int32_t> expected = {10, 20, 30, 40};
+  std::string_view payload(
+      reinterpret_cast<const char*>(expected.data()),
+      expected.size() * sizeof(int32_t));
+  auto compressed = buildLegacyCompressedData(payload);
+
+  std::vector<BufferPtr> stringBuffers;
+  serde::StreamData sd(
+      ScalarKind::Int32,
+      compressed,
+      stringBuffers,
+      pool_.get(),
+      serde::StreamData::Options{
+          .version = SerializationVersion::kLegacy,
+          .decompressionBuffer = &decompressionBuffer_});
+
+  std::vector<int32_t> output(expected.size());
+  NIMBLE_ASSERT_THROW(
+      sd.decode(
+          output.data(),
+          /*offset=*/0,
+          static_cast<uint32_t>(output.size()),
+          sizeof(int32_t)),
+      "Legacy StreamData must be decoded through copyTo() or decodeStrings()");
+}
+
 TEST_F(ZstdDCtxReuseTest, streamDataDCtxReusedAcrossReset) {
   const std::vector<int32_t> values1 = {1, 2, 3};
   std::string_view payload1(
@@ -2026,17 +2111,25 @@ TEST_F(ZstdDCtxReuseTest, streamDataDCtxReusedAcrossReset) {
       output1.size() * sizeof(int32_t));
   EXPECT_EQ(output1, values1);
 
-  // Reset with new data; dctx is bound at construction and persists.
-  sd.reset(compressed2, SerializationVersion::kLegacy);
+  // Recreate with new data; decompression buffer storage is external and
+  // persists across StreamData lifetimes.
+  serde::StreamData sd2(
+      ScalarKind::Int32,
+      compressed2,
+      stringBuffers,
+      pool_.get(),
+      serde::StreamData::Options{
+          .version = SerializationVersion::kLegacy,
+          .decompressionBuffer = &decompressionBuffer_});
 
   std::vector<int32_t> output2(values2.size());
-  sd.copyTo(
+  sd2.copyTo(
       reinterpret_cast<char*>(output2.data()),
       output2.size() * sizeof(int32_t));
   EXPECT_EQ(output2, values2);
 }
 
-TEST_F(ZstdDCtxReuseTest, streamDataReaderCompressedChunkWithDCtx) {
+TEST_F(ZstdDCtxReuseTest, streamDataParserCompressedChunkWithDCtx) {
   std::string payload = "compressed data that should be zstd encoded for test";
   auto chunk = buildCompressedChunk(payload);
   auto result = deserializeTabletWithDCtx(10, {{0, chunk}});
@@ -2046,7 +2139,7 @@ TEST_F(ZstdDCtxReuseTest, streamDataReaderCompressedChunkWithDCtx) {
   EXPECT_EQ(result[0].second, payload);
 }
 
-TEST_F(ZstdDCtxReuseTest, streamDataReaderDCtxReusedAcrossStreams) {
+TEST_F(ZstdDCtxReuseTest, streamDataParserDCtxReusedAcrossStreams) {
   std::string payload1 = "first compressed stream payload data";
   std::string payload2 = "second compressed stream payload data";
   auto chunk1 = buildCompressedChunk(payload1);
@@ -2162,16 +2255,23 @@ TEST_F(LZ4RoundtripTest, streamDataLZ4ReusedAcrossReset) {
       static_cast<uint32_t>(output1.size() * sizeof(int32_t)));
   EXPECT_EQ(output1, values1);
 
-  sd.reset(compressed2, SerializationVersion::kLegacy);
+  serde::StreamData sd2(
+      ScalarKind::Int32,
+      compressed2,
+      stringBuffers,
+      pool_.get(),
+      serde::StreamData::Options{
+          .version = SerializationVersion::kLegacy,
+          .decompressionBuffer = &decompressionBuffer_});
 
   std::vector<int32_t> output2(values2.size());
-  sd.copyTo(
+  sd2.copyTo(
       reinterpret_cast<char*>(output2.data()),
       static_cast<uint32_t>(output2.size() * sizeof(int32_t)));
   EXPECT_EQ(output2, values2);
 }
 
-TEST_F(LZ4RoundtripTest, streamDataReaderLZ4CompressedChunk) {
+TEST_F(LZ4RoundtripTest, streamDataParserLZ4CompressedChunk) {
   std::string payload = "compressed data that should be lz4 encoded for test";
   auto chunk = buildLZ4CompressedChunk(payload);
   auto result = deserializeTablet(10, {{0, chunk}});
@@ -2181,7 +2281,7 @@ TEST_F(LZ4RoundtripTest, streamDataReaderLZ4CompressedChunk) {
   EXPECT_EQ(result[0].second, payload);
 }
 
-TEST_F(LZ4RoundtripTest, streamDataReaderLZ4ReusedAcrossStreams) {
+TEST_F(LZ4RoundtripTest, streamDataParserLZ4ReusedAcrossStreams) {
   std::string payload1 = "first compressed stream payload data";
   std::string payload2 = "second compressed stream payload data";
   auto chunk1 = buildLZ4CompressedChunk(payload1);
@@ -2194,7 +2294,7 @@ TEST_F(LZ4RoundtripTest, streamDataReaderLZ4ReusedAcrossStreams) {
   EXPECT_EQ(result[1].second, payload2);
 }
 
-TEST_F(LZ4RoundtripTest, streamDataReaderLZ4MultipleChunks) {
+TEST_F(LZ4RoundtripTest, streamDataParserLZ4MultipleChunks) {
   std::string part1 = "first chunk of lz4 compressed data here";
   std::string part2 = "second chunk of lz4 compressed data here";
   auto stream = concatChunks(
@@ -2206,7 +2306,7 @@ TEST_F(LZ4RoundtripTest, streamDataReaderLZ4MultipleChunks) {
   EXPECT_EQ(result[0].second, part1 + part2);
 }
 
-TEST_F(LZ4RoundtripTest, streamDataReaderLZ4MixedWithUncompressed) {
+TEST_F(LZ4RoundtripTest, streamDataParserLZ4MixedWithUncompressed) {
   std::string part1 = "uncompressed chunk one";
   std::string part2 = "lz4 compressed chunk two with some data";
   std::string part3 = "another uncompressed chunk three";
@@ -2323,22 +2423,22 @@ TEST_F(LZ4RoundtripTest, encodeDecodeLZ4HighCompression) {
   EXPECT_EQ(output, expected);
 }
 
-// Exercises the StreamDataReader::initialize path (delegates to the shared
+// Exercises the StreamDataParser::initialize path (delegates to the shared
 // readTabletChunkFieldsAfterVersion helper) on forged kTablet input.
 // Uses the WriteHeaderTest fixture purely for its initialized MemoryPool.
-class StreamDataReaderTabletTest : public WriteHeaderTest {
+class StreamDataParserTabletTest : public WriteHeaderTest {
  protected:
   void expectInitializeThrows(const std::string& buf) {
     DeserializerOptions options;
     options.hasHeader = true;
-    StreamDataReader reader{pool_.get(), options};
+    StreamDataParser reader{pool_.get(), options};
     EXPECT_THROW(
         reader.initialize(std::string_view(buf.data(), buf.size())),
         NimbleInternalError);
   }
 };
 
-TEST_F(StreamDataReaderTabletTest, rejectsRowRangeExceedingRowCount) {
+TEST_F(StreamDataParserTabletTest, rejectsRowRangeExceedingRowCount) {
   std::string buf;
   buf.push_back(static_cast<char>(SerializationVersion::kTablet));
   buf.push_back(0x05); // rowCount = 5
@@ -2348,7 +2448,7 @@ TEST_F(StreamDataReaderTabletTest, rejectsRowRangeExceedingRowCount) {
   expectInitializeThrows(buf);
 }
 
-TEST_F(StreamDataReaderTabletTest, rejectsInvertedRowRange) {
+TEST_F(StreamDataParserTabletTest, rejectsInvertedRowRange) {
   std::string buf;
   buf.push_back(static_cast<char>(SerializationVersion::kTablet));
   buf.push_back(0x0a); // rowCount = 10
@@ -2358,7 +2458,7 @@ TEST_F(StreamDataReaderTabletTest, rejectsInvertedRowRange) {
   expectInitializeThrows(buf);
 }
 
-TEST_F(StreamDataReaderTabletTest, rejectsTruncatedResumeKey) {
+TEST_F(StreamDataParserTabletTest, rejectsTruncatedResumeKey) {
   // Valid version + rowCount + row range + resumeKeyLength=4 (declares a
   // 3-byte key), but only 1 byte of resume key follows.
   std::string buf;

--- a/dwio/nimble/serializer/tests/StreamPresentFlagsBenchmark.cpp
+++ b/dwio/nimble/serializer/tests/StreamPresentFlagsBenchmark.cpp
@@ -1,0 +1,201 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <algorithm>
+#include <cstdint>
+#include <vector>
+
+#include "common/init/light.h"
+#include "folly/Benchmark.h"
+
+namespace {
+
+struct ClearParams {
+  uint32_t numStreamFlags;
+  uint32_t presentPercent;
+};
+
+struct ClearState {
+  std::vector<bool> streamPresentFlags;
+  std::vector<uint32_t> presentOffsets;
+};
+
+ClearState makeClearState(ClearParams params) {
+  const auto numPresentStreams =
+      params.numStreamFlags * params.presentPercent / 100;
+  ClearState state{
+      .streamPresentFlags = std::vector<bool>(params.numStreamFlags, false),
+      .presentOffsets = {},
+  };
+  state.presentOffsets.reserve(numPresentStreams);
+  for (uint32_t i = 0; i < numPresentStreams; ++i) {
+    state.presentOffsets.emplace_back(
+        i * params.numStreamFlags / numPresentStreams);
+  }
+  return state;
+}
+
+void restorePresentFlags(ClearState& state) {
+  for (const auto offset : state.presentOffsets) {
+    state.streamPresentFlags[offset] = true;
+  }
+}
+
+void selectiveClear(uint32_t iterations, ClearParams params) {
+  auto state = makeClearState(params);
+  const auto presentOffsets = state.presentOffsets;
+  folly::BenchmarkSuspender suspender;
+  for (uint32_t i = 0; i < iterations; ++i) {
+    state.presentOffsets = presentOffsets;
+    restorePresentFlags(state);
+    suspender.dismiss();
+    for (const auto offset : state.presentOffsets) {
+      state.streamPresentFlags[offset] = false;
+    }
+    state.presentOffsets.clear();
+    folly::doNotOptimizeAway(state);
+    suspender.rehire();
+  }
+}
+
+void denseClear(uint32_t iterations, ClearParams params) {
+  auto state = makeClearState(params);
+  const auto presentOffsets = state.presentOffsets;
+  folly::BenchmarkSuspender suspender;
+  for (uint32_t i = 0; i < iterations; ++i) {
+    state.presentOffsets = presentOffsets;
+    restorePresentFlags(state);
+    suspender.dismiss();
+    std::fill(
+        state.streamPresentFlags.begin(),
+        state.streamPresentFlags.end(),
+        false);
+    state.presentOffsets.clear();
+    folly::doNotOptimizeAway(state);
+    suspender.rehire();
+  }
+}
+
+BENCHMARK_NAMED_PARAM(
+    selectiveClear,
+    Flags100_Present10Pct,
+    ClearParams{100, 10})
+BENCHMARK_RELATIVE_NAMED_PARAM(
+    denseClear,
+    Flags100_Present10Pct,
+    ClearParams{100, 10})
+BENCHMARK_NAMED_PARAM(
+    selectiveClear,
+    Flags100_Present20Pct,
+    ClearParams{100, 20})
+BENCHMARK_RELATIVE_NAMED_PARAM(
+    denseClear,
+    Flags100_Present20Pct,
+    ClearParams{100, 20})
+BENCHMARK_NAMED_PARAM(
+    selectiveClear,
+    Flags100_Present40Pct,
+    ClearParams{100, 40})
+BENCHMARK_RELATIVE_NAMED_PARAM(
+    denseClear,
+    Flags100_Present40Pct,
+    ClearParams{100, 40})
+BENCHMARK_NAMED_PARAM(
+    selectiveClear,
+    Flags100_Present80Pct,
+    ClearParams{100, 80})
+BENCHMARK_RELATIVE_NAMED_PARAM(
+    denseClear,
+    Flags100_Present80Pct,
+    ClearParams{100, 80})
+
+BENCHMARK_DRAW_LINE();
+
+BENCHMARK_NAMED_PARAM(
+    selectiveClear,
+    Flags1K_Present10Pct,
+    ClearParams{1'000, 10})
+BENCHMARK_RELATIVE_NAMED_PARAM(
+    denseClear,
+    Flags1K_Present10Pct,
+    ClearParams{1'000, 10})
+BENCHMARK_NAMED_PARAM(
+    selectiveClear,
+    Flags1K_Present20Pct,
+    ClearParams{1'000, 20})
+BENCHMARK_RELATIVE_NAMED_PARAM(
+    denseClear,
+    Flags1K_Present20Pct,
+    ClearParams{1'000, 20})
+BENCHMARK_NAMED_PARAM(
+    selectiveClear,
+    Flags1K_Present40Pct,
+    ClearParams{1'000, 40})
+BENCHMARK_RELATIVE_NAMED_PARAM(
+    denseClear,
+    Flags1K_Present40Pct,
+    ClearParams{1'000, 40})
+BENCHMARK_NAMED_PARAM(
+    selectiveClear,
+    Flags1K_Present80Pct,
+    ClearParams{1'000, 80})
+BENCHMARK_RELATIVE_NAMED_PARAM(
+    denseClear,
+    Flags1K_Present80Pct,
+    ClearParams{1'000, 80})
+
+BENCHMARK_DRAW_LINE();
+
+BENCHMARK_NAMED_PARAM(
+    selectiveClear,
+    Flags10K_Present10Pct,
+    ClearParams{10'000, 10})
+BENCHMARK_RELATIVE_NAMED_PARAM(
+    denseClear,
+    Flags10K_Present10Pct,
+    ClearParams{10'000, 10})
+BENCHMARK_NAMED_PARAM(
+    selectiveClear,
+    Flags10K_Present20Pct,
+    ClearParams{10'000, 20})
+BENCHMARK_RELATIVE_NAMED_PARAM(
+    denseClear,
+    Flags10K_Present20Pct,
+    ClearParams{10'000, 20})
+BENCHMARK_NAMED_PARAM(
+    selectiveClear,
+    Flags10K_Present40Pct,
+    ClearParams{10'000, 40})
+BENCHMARK_RELATIVE_NAMED_PARAM(
+    denseClear,
+    Flags10K_Present40Pct,
+    ClearParams{10'000, 40})
+BENCHMARK_NAMED_PARAM(
+    selectiveClear,
+    Flags10K_Present80Pct,
+    ClearParams{10'000, 80})
+BENCHMARK_RELATIVE_NAMED_PARAM(
+    denseClear,
+    Flags10K_Present80Pct,
+    ClearParams{10'000, 80})
+
+} // namespace
+
+int main(int argc, char** argv) {
+  facebook::init::InitFacebookLight init{&argc, &argv};
+  folly::runBenchmarks();
+  return 0;
+}

--- a/dwio/nimble/tools/SerializerDumpLib.cpp
+++ b/dwio/nimble/tools/SerializerDumpLib.cpp
@@ -20,6 +20,7 @@
 
 #include "dwio/nimble/common/Exceptions.h"
 #include "dwio/nimble/common/Varint.h"
+#include "dwio/nimble/serializer/SerializationHeader.h"
 #include "dwio/nimble/serializer/SerializerImpl.h"
 #include "dwio/nimble/serializer/legacy/TrailerReader.h"
 
@@ -64,12 +65,9 @@ SerializationDump::SerializationStats SerializationDump::serializationStats(
   const char* pos = serialized.data();
   const char* end = pos + serialized.size();
 
-  // Read version byte.
-  info.version =
-      static_cast<SerializationVersion>(static_cast<uint8_t>(*pos++));
-
-  // Read row count (varint for kLegacyCompact).
-  info.rowCount = varint::readVarint32(&pos);
+  const auto header = serde::readSerializationHeader(pos, end, true);
+  info.version = header.version;
+  info.rowCount = header.rowCount;
 
   // Walk the sparse (indices, sizes) trailer directly. Emit "empty" entries
   // for gaps between non-zero slots so the offset-indexed view is preserved.

--- a/dwio/nimble/velox/ChunkedStreamDecoder.cpp
+++ b/dwio/nimble/velox/ChunkedStreamDecoder.cpp
@@ -76,15 +76,15 @@ uint32_t ChunkedStreamDecoder::next(
     uint32_t count,
     void* output,
     std::vector<velox::BufferPtr>& stringBuffers,
-    std::function<void*()> nulls,
-    const velox::bits::Bitmap* scatterBitmap) {
+    std::function<void*()> getOutputNulls,
+    const velox::bits::Bitmap* scatterOutputBitmap) {
   NIMBLE_DCHECK(stringBuffers.empty());
 
   if (count == 0) {
-    if (nulls && scatterBitmap) {
-      auto nullsPtr = nulls();
+    if (getOutputNulls && scatterOutputBitmap) {
+      auto nullsPtr = getOutputNulls();
       // @lint-ignore CLANGTIDY facebook-hte-BadMemset
-      memset(nullsPtr, 0, velox::bits::nbytes(scatterBitmap->size()));
+      memset(nullsPtr, 0, velox::bits::nbytes(scatterOutputBitmap->size()));
     }
     return 0;
   }
@@ -97,7 +97,7 @@ uint32_t ChunkedStreamDecoder::next(
   void* nullsPtr = nullptr;
   std::function<void*()> initNulls = [&]() {
     if (!nullsPtr) {
-      nullsPtr = nulls();
+      nullsPtr = getOutputNulls();
     }
     return nullsPtr;
   };
@@ -109,18 +109,19 @@ uint32_t ChunkedStreamDecoder::next(
     uint32_t chunkNonNullCount = 0;
     uint32_t endOffset = 0;
 
-    if (!nulls || !scatterBitmap) {
-      NIMBLE_CHECK(!scatterBitmap, "unexpected scatter bitmap");
+    if (!getOutputNulls || !scatterOutputBitmap) {
+      NIMBLE_CHECK_NULL(
+          scatterOutputBitmap, "Unexpected scatter output bitmap");
       chunkNonNullCount = encoding_->materializeNullable(
           rowsToRead, output, initNulls, nullptr, offset);
       endOffset = offset + rowsToRead;
     } else {
       endOffset = velox::bits::findSetBit(
-          static_cast<const char*>(scatterBitmap->bits()),
+          static_cast<const char*>(scatterOutputBitmap->bits()),
           offset,
-          scatterBitmap->size(),
+          scatterOutputBitmap->size(),
           rowsToRead + 1);
-      velox::bits::Bitmap localBitmap{scatterBitmap->bits(), endOffset};
+      velox::bits::Bitmap localBitmap{scatterOutputBitmap->bits(), endOffset};
       chunkNonNullCount = encoding_->materializeNullable(
           rowsToRead, output, initNulls, &localBitmap, offset);
     }

--- a/dwio/nimble/velox/ChunkedStreamDecoder.h
+++ b/dwio/nimble/velox/ChunkedStreamDecoder.h
@@ -43,8 +43,8 @@ class ChunkedStreamDecoder : public Decoder {
       uint32_t count,
       void* output,
       std::vector<velox::BufferPtr>& stringBuffers,
-      std::function<void*()> nulls = nullptr,
-      const velox::bits::Bitmap* scatterBitmap = nullptr) override;
+      std::function<void*()> getOutputNulls = nullptr,
+      const velox::bits::Bitmap* scatterOutputBitmap = nullptr) override;
 
   void skip(uint32_t count) override;
 

--- a/dwio/nimble/velox/ChunkedStreamWriter.cpp
+++ b/dwio/nimble/velox/ChunkedStreamWriter.cpp
@@ -27,9 +27,8 @@ ChunkedStreamWriter::ChunkedStreamWriter(
   NIMBLE_CHECK(
       compressionParams_.type == CompressionType::Uncompressed ||
           compressionParams_.type == CompressionType::Zstd,
-      fmt::format(
-          "Unsupported chunked stream compression type: {}",
-          toString(compressionParams_.type)));
+      "Unsupported chunked stream compression type: {}",
+      compressionParams_.type);
 }
 
 std::vector<std::string_view> ChunkedStreamWriter::encode(

--- a/dwio/nimble/velox/Decoder.h
+++ b/dwio/nimble/velox/Decoder.h
@@ -28,15 +28,25 @@ class Decoder {
  public:
   virtual ~Decoder() = default;
 
-  // Decode next 'count' values into 'output'.
-  // For string types, stringBuffers will be populated with buffers holding
-  // the string data. For non-string types, stringBuffers will remain empty.
+  /// Decode next 'count' rows into 'output' and return the number of non-null
+  /// rows materialized.
+  ///
+  /// For string types, stringBuffers will be populated with buffers holding
+  /// the string data. For non-string types, stringBuffers will remain empty.
+  ///
+  /// If the stream is nullable, getOutputNulls must return the mutable null
+  /// bitmap for the output vector. The callback is lazy so callers only
+  /// allocate nulls when the encoded stream actually contains nulls.
+  ///
+  /// If scatterOutputBitmap is provided, decoded rows are written into the
+  /// selected output positions and the null bitmap follows the same scattered
+  /// layout. A null scatterOutputBitmap means dense output.
   virtual uint32_t next(
       uint32_t count,
       void* output,
       std::vector<velox::BufferPtr>& stringBuffers,
-      std::function<void*()> nulls = nullptr,
-      const velox::bits::Bitmap* scatterBitmap = nullptr) = 0;
+      std::function<void*()> getOutputNulls = nullptr,
+      const velox::bits::Bitmap* scatterOutputBitmap = nullptr) = 0;
 
   virtual void skip(uint32_t count) = 0;
 

--- a/dwio/nimble/velox/FieldReader.cpp
+++ b/dwio/nimble/velox/FieldReader.cpp
@@ -512,8 +512,14 @@ class ScalarFieldReader final
           "Unexpected values buffer size.");
       auto* target = vector->values()->template asMutable<char>();
       std::fill(target, target + velox::bits::nbytes(rowCount), 0);
-      for (uint32_t i = 0; i < rowCount; ++i) {
-        velox::bits::maybeSetBit(target, i, buf[i]);
+      if (nonNullCount == rowCount) {
+        velox::bits::packBitmap(std::span<const bool>{buf, rowCount}, target);
+      } else {
+        for (uint32_t i = 0; i < rowCount; ++i) {
+          if (!vector->isNullAt(i)) {
+            velox::bits::maybeSetBit(target, i, buf[i]);
+          }
+        }
       }
     } else {
       NIMBLE_DCHECK_EQ(

--- a/dwio/nimble/velox/SchemaUtils.cpp
+++ b/dwio/nimble/velox/SchemaUtils.cpp
@@ -523,7 +523,7 @@ std::shared_ptr<const Type> buildProjectedNimbleType(
 }
 
 //
-// deriveColumnEncodings, computeSourceStreamOffsets.
+// deriveColumnEncodings, computeProjectedStreamMetadata.
 //
 
 namespace {
@@ -542,6 +542,15 @@ using SelectedChildrenMap = folly::F14FastMap<const Type*, std::set<size_t>>;
 // `buildProjectedNimbleType`).
 using MissingChildrenMap =
     folly::F14FastMap<const Type*, std::set<std::string>>;
+
+inline void appendProjectedStream(
+    std::vector<uint32_t>& projectedStreamOffsets,
+    std::vector<bool>& rowOrFlatMapNullStreams,
+    uint32_t sourceStreamOffset,
+    bool isRowOrFlatMapNullStream) {
+  projectedStreamOffsets.emplace_back(sourceStreamOffset);
+  rowOrFlatMapNullStreams.emplace_back(isRowOrFlatMapNullStream);
+}
 
 // Resolves a single subfield path against a source nimble schema, populating
 // selectedChildren for present Row children + present FlatMap keys (by
@@ -611,59 +620,110 @@ void resolveSubfield(
 }
 
 // Walks a value-type (typically `flatMap.childAt(0)` from a source FlatMap
-// whose requested key is missing) and pushes UINT32_MAX into
-// `projectedStreamOffsets` for every stream descriptor the subtree contains.
+// whose requested key is missing) and emits placeholder metadata for every
+// stream descriptor the subtree contains.
 // The number of UINT32_MAX entries matches the slot count the velox-source
 // `buildProjectedNimbleType` would allocate for the corresponding synthetic
 // FlatMap value subtree.
 void emitPlaceholderStreamOffsets(
     const Type* valueType,
-    std::vector<uint32_t>& projectedStreamOffsets) {
+    std::vector<uint32_t>& projectedStreamOffsets,
+    std::vector<bool>& rowOrFlatMapNullStreams) {
   switch (valueType->kind()) {
     case Kind::Scalar:
-      projectedStreamOffsets.push_back(UINT32_MAX);
+      appendProjectedStream(
+          projectedStreamOffsets,
+          rowOrFlatMapNullStreams,
+          UINT32_MAX,
+          /*isRowOrFlatMapNullStream=*/false);
       return;
     case Kind::TimestampMicroNano:
-      projectedStreamOffsets.push_back(UINT32_MAX); // micros
-      projectedStreamOffsets.push_back(UINT32_MAX); // nanos
+      appendProjectedStream(
+          projectedStreamOffsets,
+          rowOrFlatMapNullStreams,
+          UINT32_MAX,
+          /*isRowOrFlatMapNullStream=*/false);
+      appendProjectedStream(
+          projectedStreamOffsets,
+          rowOrFlatMapNullStreams,
+          UINT32_MAX,
+          /*isRowOrFlatMapNullStream=*/false);
       return;
     case Kind::Row: {
       const auto& row = valueType->asRow();
-      projectedStreamOffsets.push_back(UINT32_MAX); // nulls
+      appendProjectedStream(
+          projectedStreamOffsets,
+          rowOrFlatMapNullStreams,
+          UINT32_MAX,
+          /*isRowOrFlatMapNullStream=*/true);
       for (size_t i = 0; i < row.childrenCount(); ++i) {
         emitPlaceholderStreamOffsets(
-            row.childAt(i).get(), projectedStreamOffsets);
+            row.childAt(i).get(),
+            projectedStreamOffsets,
+            rowOrFlatMapNullStreams);
       }
       return;
     }
     case Kind::Array: {
       const auto& array = valueType->asArray();
-      projectedStreamOffsets.push_back(UINT32_MAX); // lengths
+      appendProjectedStream(
+          projectedStreamOffsets,
+          rowOrFlatMapNullStreams,
+          UINT32_MAX,
+          /*isRowOrFlatMapNullStream=*/false);
       emitPlaceholderStreamOffsets(
-          array.elements().get(), projectedStreamOffsets);
+          array.elements().get(),
+          projectedStreamOffsets,
+          rowOrFlatMapNullStreams);
       return;
     }
     case Kind::ArrayWithOffsets: {
       const auto& array = valueType->asArrayWithOffsets();
-      projectedStreamOffsets.push_back(UINT32_MAX); // offsets
-      projectedStreamOffsets.push_back(UINT32_MAX); // lengths
+      appendProjectedStream(
+          projectedStreamOffsets,
+          rowOrFlatMapNullStreams,
+          UINT32_MAX,
+          /*isRowOrFlatMapNullStream=*/false);
+      appendProjectedStream(
+          projectedStreamOffsets,
+          rowOrFlatMapNullStreams,
+          UINT32_MAX,
+          /*isRowOrFlatMapNullStream=*/false);
       emitPlaceholderStreamOffsets(
-          array.elements().get(), projectedStreamOffsets);
+          array.elements().get(),
+          projectedStreamOffsets,
+          rowOrFlatMapNullStreams);
       return;
     }
     case Kind::Map: {
       const auto& map = valueType->asMap();
-      projectedStreamOffsets.push_back(UINT32_MAX); // lengths
-      emitPlaceholderStreamOffsets(map.keys().get(), projectedStreamOffsets);
-      emitPlaceholderStreamOffsets(map.values().get(), projectedStreamOffsets);
+      appendProjectedStream(
+          projectedStreamOffsets,
+          rowOrFlatMapNullStreams,
+          UINT32_MAX,
+          /*isRowOrFlatMapNullStream=*/false);
+      emitPlaceholderStreamOffsets(
+          map.keys().get(), projectedStreamOffsets, rowOrFlatMapNullStreams);
+      emitPlaceholderStreamOffsets(
+          map.values().get(), projectedStreamOffsets, rowOrFlatMapNullStreams);
       return;
     }
     case Kind::SlidingWindowMap: {
       const auto& map = valueType->asSlidingWindowMap();
-      projectedStreamOffsets.push_back(UINT32_MAX); // offsets
-      projectedStreamOffsets.push_back(UINT32_MAX); // lengths
-      emitPlaceholderStreamOffsets(map.keys().get(), projectedStreamOffsets);
-      emitPlaceholderStreamOffsets(map.values().get(), projectedStreamOffsets);
+      appendProjectedStream(
+          projectedStreamOffsets,
+          rowOrFlatMapNullStreams,
+          UINT32_MAX,
+          /*isRowOrFlatMapNullStream=*/false);
+      appendProjectedStream(
+          projectedStreamOffsets,
+          rowOrFlatMapNullStreams,
+          UINT32_MAX,
+          /*isRowOrFlatMapNullStream=*/false);
+      emitPlaceholderStreamOffsets(
+          map.keys().get(), projectedStreamOffsets, rowOrFlatMapNullStreams);
+      emitPlaceholderStreamOffsets(
+          map.values().get(), projectedStreamOffsets, rowOrFlatMapNullStreams);
       return;
     }
     case Kind::FlatMap:
@@ -682,7 +742,8 @@ void projectStreamOffsets(
     const Type* type,
     const SelectedChildrenMap& selectedChildren,
     const MissingChildrenMap& missingChildren,
-    std::vector<uint32_t>& projectedStreamOffsets);
+    std::vector<uint32_t>& projectedStreamOffsets,
+    std::vector<bool>& rowOrFlatMapNullStreams);
 
 // Emits the FlatMap branch of `projectStreamOffsets`. Merges present keys
 // (from `selectedChildren[flatMap]`, by source index) and missing keys (from
@@ -695,7 +756,8 @@ void projectFlatmapStreamOffsets(
     const FlatMapType& flatMap,
     const SelectedChildrenMap& selectedChildren,
     const MissingChildrenMap& missingChildren,
-    std::vector<uint32_t>& projectedStreamOffsets) {
+    std::vector<uint32_t>& projectedStreamOffsets,
+    std::vector<bool>& rowOrFlatMapNullStreams) {
   const auto* flatMapPtr = static_cast<const Type*>(&flatMap);
   const auto selectedIt = selectedChildren.find(flatMapPtr);
   const auto missingIt = missingChildren.find(flatMapPtr);
@@ -711,8 +773,8 @@ void projectFlatmapStreamOffsets(
 
   struct Entry {
     std::string keyName;
-    // nullopt → missing; the value subtree and inMap are emitted as
-    // UINT32_MAX placeholders.
+    // Missing keys use nullopt and emit UINT32_MAX placeholders for the value
+    // subtree and inMap stream.
     std::optional<size_t> valueIndex;
   };
   std::vector<Entry> entries;
@@ -733,7 +795,11 @@ void projectFlatmapStreamOffsets(
         return lhs.keyName < rhs.keyName;
       });
 
-  projectedStreamOffsets.push_back(flatMap.nullsDescriptor().offset());
+  appendProjectedStream(
+      projectedStreamOffsets,
+      rowOrFlatMapNullStreams,
+      flatMap.nullsDescriptor().offset(),
+      /*isRowOrFlatMapNullStream=*/true);
   const auto* valueType = flatMap.childAt(0).get();
   for (const auto& entry : entries) {
     if (entry.valueIndex.has_value()) {
@@ -741,43 +807,68 @@ void projectFlatmapStreamOffsets(
           flatMap.childAt(*entry.valueIndex).get(),
           selectedChildren,
           missingChildren,
-          projectedStreamOffsets);
-      projectedStreamOffsets.push_back(
-          flatMap.inMapDescriptorAt(*entry.valueIndex).offset());
+          projectedStreamOffsets,
+          rowOrFlatMapNullStreams);
+      appendProjectedStream(
+          projectedStreamOffsets,
+          rowOrFlatMapNullStreams,
+          flatMap.inMapDescriptorAt(*entry.valueIndex).offset(),
+          /*isRowOrFlatMapNullStream=*/false);
     } else {
-      emitPlaceholderStreamOffsets(valueType, projectedStreamOffsets);
-      projectedStreamOffsets.push_back(UINT32_MAX);
+      emitPlaceholderStreamOffsets(
+          valueType, projectedStreamOffsets, rowOrFlatMapNullStreams);
+      appendProjectedStream(
+          projectedStreamOffsets,
+          rowOrFlatMapNullStreams,
+          UINT32_MAX,
+          /*isRowOrFlatMapNullStream=*/false);
     }
   }
 }
 
 // Walks `type` (a node within the source nimble schema) in DFS pre-order
-// and appends one source stream offset per stream descriptor into
-// `projectedStreamOffsets`. At Row nodes appearing in `selectedChildren`,
-// only the selected child indices are descended into (in source order). At
-// FlatMap nodes, defers to `projectFlatmapStreamOffsets` which merges
-// present and missing keys alphabetically. The traversal order matches the
-// velox-source overload of `buildProjectedNimbleType` so the emitted offsets
-// line up positionally with the projected schema it returns.
+// and appends one source stream offset plus one Row/FlatMap null stream bit per
+// stream descriptor. At Row nodes appearing in `selectedChildren`, only the
+// selected child indices are descended into (in source order). Top-level
+// FlatMap columns are handled by the root walker before this helper is called,
+// so any FlatMap encountered here is nested and unsupported. The traversal
+// order matches the velox-source overload of `buildProjectedNimbleType` so the
+// emitted metadata lines up positionally with the projected schema it returns.
 void projectStreamOffsets(
     const Type* type,
     const SelectedChildrenMap& selectedChildren,
     const MissingChildrenMap& missingChildren,
-    std::vector<uint32_t>& projectedStreamOffsets) {
+    std::vector<uint32_t>& projectedStreamOffsets,
+    std::vector<bool>& rowOrFlatMapNullStreams) {
   switch (type->kind()) {
     case Kind::Scalar:
-      projectedStreamOffsets.push_back(
-          type->asScalar().scalarDescriptor().offset());
+      appendProjectedStream(
+          projectedStreamOffsets,
+          rowOrFlatMapNullStreams,
+          type->asScalar().scalarDescriptor().offset(),
+          /*isRowOrFlatMapNullStream=*/false);
       return;
     case Kind::TimestampMicroNano: {
       const auto& ts = type->asTimestampMicroNano();
-      projectedStreamOffsets.push_back(ts.microsDescriptor().offset());
-      projectedStreamOffsets.push_back(ts.nanosDescriptor().offset());
+      appendProjectedStream(
+          projectedStreamOffsets,
+          rowOrFlatMapNullStreams,
+          ts.microsDescriptor().offset(),
+          /*isRowOrFlatMapNullStream=*/false);
+      appendProjectedStream(
+          projectedStreamOffsets,
+          rowOrFlatMapNullStreams,
+          ts.nanosDescriptor().offset(),
+          /*isRowOrFlatMapNullStream=*/false);
       return;
     }
     case Kind::Row: {
       const auto& row = type->asRow();
-      projectedStreamOffsets.push_back(row.nullsDescriptor().offset());
+      appendProjectedStream(
+          projectedStreamOffsets,
+          rowOrFlatMapNullStreams,
+          row.nullsDescriptor().offset(),
+          /*isRowOrFlatMapNullStream=*/true);
       const auto it = selectedChildren.find(type);
       if (it != selectedChildren.end()) {
         // std::set<size_t> iterates ascending — matches source child order.
@@ -786,7 +877,8 @@ void projectStreamOffsets(
               row.childAt(idx).get(),
               selectedChildren,
               missingChildren,
-              projectedStreamOffsets);
+              projectedStreamOffsets,
+              rowOrFlatMapNullStreams);
         }
       } else {
         for (size_t i = 0; i < row.childrenCount(); ++i) {
@@ -794,70 +886,96 @@ void projectStreamOffsets(
               row.childAt(i).get(),
               selectedChildren,
               missingChildren,
-              projectedStreamOffsets);
+              projectedStreamOffsets,
+              rowOrFlatMapNullStreams);
         }
       }
       return;
     }
     case Kind::Array: {
       const auto& array = type->asArray();
-      projectedStreamOffsets.push_back(array.lengthsDescriptor().offset());
+      appendProjectedStream(
+          projectedStreamOffsets,
+          rowOrFlatMapNullStreams,
+          array.lengthsDescriptor().offset(),
+          /*isRowOrFlatMapNullStream=*/false);
       projectStreamOffsets(
           array.elements().get(),
           selectedChildren,
           missingChildren,
-          projectedStreamOffsets);
+          projectedStreamOffsets,
+          rowOrFlatMapNullStreams);
       return;
     }
     case Kind::ArrayWithOffsets: {
       const auto& array = type->asArrayWithOffsets();
-      projectedStreamOffsets.push_back(array.offsetsDescriptor().offset());
-      projectedStreamOffsets.push_back(array.lengthsDescriptor().offset());
+      appendProjectedStream(
+          projectedStreamOffsets,
+          rowOrFlatMapNullStreams,
+          array.offsetsDescriptor().offset(),
+          /*isRowOrFlatMapNullStream=*/false);
+      appendProjectedStream(
+          projectedStreamOffsets,
+          rowOrFlatMapNullStreams,
+          array.lengthsDescriptor().offset(),
+          /*isRowOrFlatMapNullStream=*/false);
       projectStreamOffsets(
           array.elements().get(),
           selectedChildren,
           missingChildren,
-          projectedStreamOffsets);
+          projectedStreamOffsets,
+          rowOrFlatMapNullStreams);
       return;
     }
     case Kind::Map: {
       const auto& map = type->asMap();
-      projectedStreamOffsets.push_back(map.lengthsDescriptor().offset());
+      appendProjectedStream(
+          projectedStreamOffsets,
+          rowOrFlatMapNullStreams,
+          map.lengthsDescriptor().offset(),
+          /*isRowOrFlatMapNullStream=*/false);
       projectStreamOffsets(
           map.keys().get(),
           selectedChildren,
           missingChildren,
-          projectedStreamOffsets);
+          projectedStreamOffsets,
+          rowOrFlatMapNullStreams);
       projectStreamOffsets(
           map.values().get(),
           selectedChildren,
           missingChildren,
-          projectedStreamOffsets);
+          projectedStreamOffsets,
+          rowOrFlatMapNullStreams);
       return;
     }
     case Kind::SlidingWindowMap: {
       const auto& map = type->asSlidingWindowMap();
-      projectedStreamOffsets.push_back(map.offsetsDescriptor().offset());
-      projectedStreamOffsets.push_back(map.lengthsDescriptor().offset());
+      appendProjectedStream(
+          projectedStreamOffsets,
+          rowOrFlatMapNullStreams,
+          map.offsetsDescriptor().offset(),
+          /*isRowOrFlatMapNullStream=*/false);
+      appendProjectedStream(
+          projectedStreamOffsets,
+          rowOrFlatMapNullStreams,
+          map.lengthsDescriptor().offset(),
+          /*isRowOrFlatMapNullStream=*/false);
       projectStreamOffsets(
           map.keys().get(),
           selectedChildren,
           missingChildren,
-          projectedStreamOffsets);
+          projectedStreamOffsets,
+          rowOrFlatMapNullStreams);
       projectStreamOffsets(
           map.values().get(),
           selectedChildren,
           missingChildren,
-          projectedStreamOffsets);
+          projectedStreamOffsets,
+          rowOrFlatMapNullStreams);
       return;
     }
     case Kind::FlatMap:
-      projectFlatmapStreamOffsets(
-          type->asFlatMap(),
-          selectedChildren,
-          missingChildren,
-          projectedStreamOffsets);
-      return;
+      NIMBLE_FAIL("FlatMap projection is supported only for top-level columns");
   }
   NIMBLE_UNREACHABLE("Unknown type kind: {}", type->kind());
 }
@@ -895,13 +1013,14 @@ ColumnEncodings getColumnEncodings(const RowType& nimbleType) {
 std::shared_ptr<const Type> buildProjectedNimbleType(
     const Type* type,
     const std::vector<velox::common::Subfield>& projectedSubfields,
-    std::vector<uint32_t>& projectedStreamOffsets) {
+    std::vector<uint32_t>& projectedStreamOffsets,
+    std::vector<bool>& rowOrFlatMapNullStreams) {
   NIMBLE_CHECK(
       !projectedSubfields.empty(), "projectedSubfields must not be empty");
   NIMBLE_CHECK(
-      projectedStreamOffsets.empty(),
-      "projectedStreamOffsets must be empty, got size: {}",
-      projectedStreamOffsets.size());
+      projectedStreamOffsets.empty(), "projectedStreamOffsets must be empty");
+  NIMBLE_CHECK(
+      rowOrFlatMapNullStreams.empty(), "rowOrFlatMapNullStreams must be empty");
   NIMBLE_CHECK_NOT_NULL(type, "type must not be null");
   NIMBLE_CHECK(type->isRow(), "Root type must be a Row, got: {}", type->kind());
 
@@ -939,16 +1058,34 @@ std::shared_ptr<const Type> buildProjectedNimbleType(
       veloxSource->asRow(), projectedSubfields, encodings);
 
   // Walk the source nimble in the same DFS pre-order + FlatMap-alphabetical
-  // traversal the velox-source builder uses, emitting one source stream
-  // offset per projected stream position (UINT32_MAX for missing keys).
-  projectedStreamOffsets.push_back(rootRow.nullsDescriptor().offset());
+  // traversal the velox-source builder uses, emitting one source stream offset
+  // and Row/FlatMap null stream bit per projected stream position (UINT32_MAX
+  // for missing keys).
+  appendProjectedStream(
+      projectedStreamOffsets,
+      rowOrFlatMapNullStreams,
+      rootRow.nullsDescriptor().offset(),
+      /*isRowOrFlatMapNullStream=*/true);
   for (size_t columnIdx : selectedColumnIndices) {
-    projectStreamOffsets(
-        rootRow.childAt(columnIdx).get(),
-        selectedChildren,
-        missingChildren,
-        projectedStreamOffsets);
+    const auto* child = rootRow.childAt(columnIdx).get();
+    if (child->kind() == Kind::FlatMap) {
+      projectFlatmapStreamOffsets(
+          child->asFlatMap(),
+          selectedChildren,
+          missingChildren,
+          projectedStreamOffsets,
+          rowOrFlatMapNullStreams);
+    } else {
+      projectStreamOffsets(
+          child,
+          selectedChildren,
+          missingChildren,
+          projectedStreamOffsets,
+          rowOrFlatMapNullStreams);
+    }
   }
+  NIMBLE_DCHECK_EQ(
+      projectedStreamOffsets.size(), rowOrFlatMapNullStreams.size());
 
   return projectedSchema;
 }

--- a/dwio/nimble/velox/SchemaUtils.h
+++ b/dwio/nimble/velox/SchemaUtils.h
@@ -53,7 +53,8 @@ std::shared_ptr<const Type> buildProjectedNimbleType(
     const ColumnEncodings& columnEncodings = {});
 
 /// Builds a projected nimble schema from a source nimble schema and emits
-/// the source stream-offset mapping in one pass. Used by
+/// the source stream-offset mapping plus a Row/FlatMap null stream mask in one
+/// pass. Used by
 /// `nimble::serde::Projector` and `nimble::NimbleIndexProjector` to derive
 /// everything the byte-copy pipeline needs from `(type, projectedSubfields)`.
 ///
@@ -62,7 +63,7 @@ std::shared_ptr<const Type> buildProjectedNimbleType(
 /// builds the projected schema via the velox-source `buildProjectedNimbleType`
 /// overload, and walks the source nimble in the matching DFS pre-order +
 /// FlatMap-children-alphabetical traversal to emit one source stream offset
-/// per projected stream position.
+/// and Row/FlatMap null stream bit per projected stream position.
 ///
 /// Missing FlatMap keys are allowed: each subscript whose key does not exist
 /// in the source FlatMap produces a synthetic child in the returned schema
@@ -78,9 +79,13 @@ std::shared_ptr<const Type> buildProjectedNimbleType(
 /// @param projectedSubfields      Subfields to project; must not be empty.
 /// @param projectedStreamOffsets  Output: appended in projected-stream-
 ///                                position order. Must be empty on entry.
+/// @param rowOrFlatMapNullStreams Output: parallel to projectedStreamOffsets;
+///                                true when the projected stream is a Row or
+///                                FlatMap null stream. Must be empty on entry.
 std::shared_ptr<const Type> buildProjectedNimbleType(
     const Type* type,
     const std::vector<velox::common::Subfield>& projectedSubfields,
-    std::vector<uint32_t>& projectedStreamOffsets);
+    std::vector<uint32_t>& projectedStreamOffsets,
+    std::vector<bool>& rowOrFlatMapNullStreams);
 
 } // namespace facebook::nimble

--- a/dwio/nimble/velox/StreamChunker.h
+++ b/dwio/nimble/velox/StreamChunker.h
@@ -36,8 +36,11 @@ inline bool shouldOmitNullStream(
     const NullsStreamData& streamData,
     uint64_t minChunkSize,
     bool isFirstChunk) {
-  // When all values are non-nulls, we omit the entire null stream.
-  if (streamData.hasNulls() && streamData.nonNulls().size() > minChunkSize) {
+  // All-non-null rows can be omitted only if the whole stream is omitted.
+  if (!streamData.hasNullValues()) {
+    return isFirstChunk;
+  }
+  if (streamData.nonNulls().size() > minChunkSize) {
     return false;
   }
   return isFirstChunk || streamData.empty();
@@ -48,10 +51,10 @@ inline bool shouldOmitNullStream(
  * Options for configuring StreamChunker behavior.
  */
 struct StreamChunkerOptions {
-  uint64_t minChunkSize;
-  uint64_t maxChunkSize;
-  bool ensureFullChunks;
-  bool isFirstChunk;
+  uint64_t minChunkSize{};
+  uint64_t maxChunkSize{};
+  bool ensureFullChunks{};
+  bool isFirstChunk{};
 };
 
 /**
@@ -268,11 +271,6 @@ class NullsStreamChunker final : public StreamChunker {
         maxChunkSize_,
         1,
         "MaxChunkSize must be at least the size of a single element.");
-
-    // No need to materialize nulls stream if it's omitted.
-    if (!omitStream_) {
-      streamData.materialize();
-    }
   }
 
   std::optional<StreamDataView> next() override {
@@ -280,8 +278,7 @@ class NullsStreamChunker final : public StreamChunker {
       return std::nullopt;
     }
 
-    auto& nonNulls = streamData_->mutableNonNulls();
-    const size_t remainingNonNulls = nonNulls.size() - nonNullsOffset_;
+    const size_t remainingNonNulls = streamData_->rowCount() - nonNullsOffset_;
     const size_t nonNullsInChunk = std::min(maxChunkSize_, remainingNonNulls);
     if (nonNullsInChunk == 0 || nonNullsInChunk < minChunkSize_ ||
         (ensureFullChunks_ && nonNullsInChunk < maxChunkSize_)) {
@@ -289,6 +286,8 @@ class NullsStreamChunker final : public StreamChunker {
     }
 
     // Null stream values are converted to boolean data for encoding.
+    streamData_->materialize();
+    auto& nonNulls = streamData_->mutableNonNulls();
     std::string_view dataChunk = {
         reinterpret_cast<const char*>(nonNulls.data() + nonNullsOffset_),
         nonNullsInChunk};

--- a/dwio/nimble/velox/StreamData.h
+++ b/dwio/nimble/velox/StreamData.h
@@ -16,6 +16,7 @@
 
 #pragma once
 
+#include <algorithm>
 #include <cstring>
 #include <span>
 #include <string_view>
@@ -44,12 +45,33 @@ class StreamData {
   virtual std::span<const bool> nonNulls() const = 0;
   virtual bool hasNulls() const = 0;
 
+  /// Returns true only when the nonNulls bitmap contains at least one null
+  /// value. This differs from hasNulls(), which only says that a validity
+  /// bitmap is present.
+  static bool hasNullValues(std::span<const bool> nonNulls) {
+    return std::any_of(nonNulls.begin(), nonNulls.end(), [](bool notNull) {
+      return !notNull;
+    });
+  }
+
+  /// Returns true only when this stream has a validity bitmap and that bitmap
+  /// contains at least one null value.
+  bool hasNullValues() const {
+    return hasNulls() && hasNullValues(nonNulls());
+  }
+
   virtual bool empty() const = 0;
 
   virtual uint64_t memoryUsed() const = 0;
 
   /// Returns the number of rows in the stream.
   virtual uint32_t rowCount() const = 0;
+
+  /// Returns true for null-only streams. These streams carry boolean
+  /// non-null bits and may omit storage when all rows are non-null.
+  virtual bool isNullStream() const {
+    return false;
+  }
 
   virtual void reset() = 0;
 
@@ -241,6 +263,10 @@ class NullsStreamData : public MutableStreamData {
     return nonNulls_.empty() && bufferedCount_ == 0;
   }
 
+  bool isNullStream() const override {
+    return true;
+  }
+
   inline uint64_t memoryUsed() const override {
     return nonNulls_.size();
   }
@@ -277,7 +303,9 @@ class NullsStreamData : public MutableStreamData {
 };
 
 /// Nullable content data stream.
-/// Used in all cases where data may contain nulls.
+/// Used for scalar content streams where data_ stores row-aligned payload
+/// values and NullsStreamData::nonNulls_ stores the corresponding validity
+/// bits. Payload values for null rows are not semantically meaningful.
 template <typename T>
 class NullableContentStreamData final : public NullsStreamData {
  public:
@@ -301,6 +329,10 @@ class NullableContentStreamData final : public NullsStreamData {
   inline uint64_t memoryUsed() const override {
     return (data_.size() * sizeof(T)) + extraMemory_ +
         NullsStreamData::memoryUsed();
+  }
+
+  bool isNullStream() const override {
+    return false;
   }
 
   inline Vector<T>& mutableData() {
@@ -367,6 +399,10 @@ class NullableContentStringStreamData final : public NullsStreamData {
 
   inline uint64_t bufferSize() const {
     return lengths_.size() * sizeof(std::string_view) + buffer_.size();
+  }
+
+  bool isNullStream() const override {
+    return false;
   }
 
   inline StringBuffer mutableData() {

--- a/dwio/nimble/velox/VeloxWriter.cpp
+++ b/dwio/nimble/velox/VeloxWriter.cpp
@@ -1165,9 +1165,7 @@ void VeloxWriter::processStream(
   if ((context != nullptr) && context->isNullStream()) {
     // For null streams we promote the null values to be written as
     // boolean data.
-    // We still apply the same null logic, where if all values are
-    // non-nulls, we omit the entire stream.
-    if (streamData.hasNulls()) {
+    if (streamData.hasNullValues()) {
       NullsAsDataStreamData nullsStreamData{streamData};
       encodeStream(nullsStreamData, streamSize, chunkSize);
     }
@@ -1179,10 +1177,8 @@ void VeloxWriter::processStream(
     // these by checking value stream presence: all-true keys have value
     // streams, all-false keys do not.
     //
-    // NOTE: old readers that don't understand missing in-map streams will
-    // misinterpret data. This must stay behind the
-    // skipConstantFlatMapInMapStreams option until the new reader is fully
-    // rolled out.
+    // NOTE: readers that don't infer missing in-map streams require
+    // skipConstantFlatMapInMapStreams to remain false.
     streamData.materialize();
     if (!isConstantBoolStream(streamData.data())) {
       encodeStream(streamData, streamSize, chunkSize);

--- a/dwio/nimble/velox/VeloxWriterOptions.h
+++ b/dwio/nimble/velox/VeloxWriterOptions.h
@@ -98,9 +98,8 @@ struct VeloxWriterOptions {
   // The reader infers the in-map state from value stream presence: all-true
   // keys have value streams, all-false keys do not.
   //
-  // NOTE: old readers that don't understand missing in-map streams will
-  // misinterpret data. Keep this false until the new reader is fully rolled
-  // out, then default to true and eventually remove the option.
+  // NOTE: readers that do not infer omitted in-map streams require this to
+  // remain false so constant in-map streams are physically present.
   bool skipConstantFlatMapInMapStreams{false};
 
   // Columns that should be encoded as dictionary arrays
@@ -255,7 +254,7 @@ struct VeloxWriterOptions {
   // writer. Default function is no-op since its used for tests only.
   std::function<void(void)> vectorDecoderVisitor{[]() {}};
 
-  // Whether writer should ignore the top level nulls in the input.
+  /// Whether writer should ignore the top level nulls in the input.
   bool ignoreTopLevelNulls{false};
 
   bool enableStreamDeduplication{true};

--- a/dwio/nimble/velox/index/NimbleIndexProjector.cpp
+++ b/dwio/nimble/velox/index/NimbleIndexProjector.cpp
@@ -180,7 +180,14 @@ NimbleIndexProjector::NimbleIndexProjector(
   NIMBLE_CHECK_GT(numStripes_, 0, "NimbleIndexProjector requires stripes");
 
   projectedNimbleType_ = buildProjectedNimbleType(
-      nimbleSchema.get(), projectedSubfields, projectedStreamOffsets_);
+      nimbleSchema.get(),
+      projectedSubfields,
+      projectedStreamOffsets_,
+      rowOrFlatMapNullStreams_);
+  NIMBLE_CHECK_EQ(
+      projectedStreamOffsets_.size(),
+      rowOrFlatMapNullStreams_.size(),
+      "Projected stream offsets and Row/FlatMap null stream mask must align");
 }
 
 NimbleIndexProjector::Result NimbleIndexProjector::project(
@@ -441,6 +448,10 @@ void NimbleIndexProjector::locateStripeStreams(StripePlan& stripePlan) {
         stripeOffset + streamOffsets[streamId], streamSizes[streamId]};
     ++stripePlan.numStreams;
     stripePlan.projectedBytes += streamSizes[streamId];
+    if (rowOrFlatMapNullStreams_[i]) {
+      // A present Row/FlatMap null stream means the slice may carry nulls.
+      stripePlan.requiresNullBarrier = true;
+    }
   }
 }
 
@@ -642,11 +653,13 @@ namespace {
 /// Builds a kTablet IOBuf chain: [header] -> [shared body+trailer].
 folly::IOBuf assembleStripeSlice(
     uint32_t numRows,
+    bool requiresNullBarrier,
     RowRange rowRange,
     folly::IOBuf body,
     std::optional<std::string> resumeKey = std::nullopt) {
   serde::TabletChunkHeader header{
       .rowCount = numRows,
+      .requiresNullBarrier = requiresNullBarrier,
       .rowRange = rowRange,
       .resumeKey = std::move(resumeKey),
   };
@@ -688,6 +701,7 @@ void NimbleIndexProjector::buildResult(Result& result) {
       auto& response = result.responses[range.requestIndex];
       response.slices.emplace_back(assembleStripeSlice(
           stripePlan.numRows,
+          stripePlan.requiresNullBarrier,
           range.rowRange,
           stripeBody.cloneAsValue(),
           isLastSlice ? response.resumeKey : std::nullopt));

--- a/dwio/nimble/velox/index/NimbleIndexProjector.h
+++ b/dwio/nimble/velox/index/NimbleIndexProjector.h
@@ -242,6 +242,11 @@ class NimbleIndexProjector {
     uint32_t stripeIndex{};
     // Total rows in this stripe.
     uint32_t numRows{0};
+    // True when any projected Row/FlatMap null stream is present in this
+    // stripe, i.e. the slice may carry nulls. Surfaced in the kTablet chunk
+    // header so the deserializer routes the slice to the per-batch barrier path
+    // instead of the dense-batch concat fast path.
+    bool requiresNullBarrier{false};
     // Number of projected streams present in this stripe.
     uint32_t numStreams{0};
     // Total logical bytes across all projected streams in this stripe.
@@ -318,6 +323,10 @@ class NimbleIndexProjector {
   // encoding-specific types (ArrayWithOffsets, SlidingWindowMap, FlatMap).
   std::shared_ptr<const Type> projectedNimbleType_;
   std::vector<uint32_t> projectedStreamOffsets_;
+  // Parallel to projectedStreamOffsets_: true at the projected stream indices
+  // that are Row/FlatMap null streams. Present streams with this bit require
+  // the null-barrier path.
+  std::vector<bool> rowOrFlatMapNullStreams_;
 
   // Per-project() call state. Set by initRequest(), populated through the
   // pipeline (lookupStripes → prepareStripes → loadStripes → processStripes),

--- a/dwio/nimble/velox/index/tests/CMakeLists.txt
+++ b/dwio/nimble/velox/index/tests/CMakeLists.txt
@@ -28,6 +28,7 @@ target_link_libraries(
   velox_dwio_common
   velox_key_encoder
   velox_memory
+  velox_vector_fuzzer
   velox_vector_test_lib
   gtest
   gtest_main

--- a/dwio/nimble/velox/index/tests/NimbleIndexProjectorTest.cpp
+++ b/dwio/nimble/velox/index/tests/NimbleIndexProjectorTest.cpp
@@ -18,6 +18,7 @@
 
 #include <gtest/gtest.h>
 
+#include "dwio/nimble/common/Exceptions.h"
 #include "dwio/nimble/common/tests/GTestUtils.h"
 #include "dwio/nimble/common/tests/TestUtils.h"
 #include "dwio/nimble/serializer/Deserializer.h"
@@ -31,6 +32,7 @@
 #include "dwio/nimble/velox/VeloxReader.h"
 #include "dwio/nimble/velox/VeloxWriter.h"
 
+#include "folly/Random.h"
 #include "velox/common/caching/FileIds.h"
 #include "velox/common/file/IoUringReader.h"
 #include "velox/common/file/LocalFile.h"
@@ -38,6 +40,7 @@
 #include "velox/common/memory/Memory.h"
 #include "velox/common/testutil/TempFilePath.h"
 #include "velox/serializers/KeyEncoder.h"
+#include "velox/vector/fuzzer/VectorFuzzer.h"
 #include "velox/vector/tests/utils/VectorMaker.h"
 #include "velox/vector/tests/utils/VectorTestBase.h"
 
@@ -56,16 +59,19 @@ namespace {
 // these tests cannot include `rocks/nimble/NimbleTable.h`. Both helpers call
 // the same underlying `serde::readTabletChunkHeader` as the production rocks::
 // helpers, so behavior is in lockstep.
-RowRange readEmbeddedRowRange(const folly::IOBuf& slice) {
+serde::TabletChunkHeader readEmbeddedTabletChunkHeader(
+    const folly::IOBuf& slice) {
   const char* pos = reinterpret_cast<const char*>(slice.data());
   const char* end = pos + slice.length();
-  return serde::readTabletChunkHeader(pos, end).rowRange;
+  return serde::readTabletChunkHeader(pos, end);
+}
+
+RowRange readEmbeddedRowRange(const folly::IOBuf& slice) {
+  return readEmbeddedTabletChunkHeader(slice).rowRange;
 }
 
 std::optional<std::string> readEmbeddedResumeKey(const folly::IOBuf& slice) {
-  const char* pos = reinterpret_cast<const char*>(slice.data());
-  const char* end = pos + slice.length();
-  return serde::readTabletChunkHeader(pos, end).resumeKey;
+  return readEmbeddedTabletChunkHeader(slice).resumeKey;
 }
 
 // Coalesces the chunk slice IOBuf chain into a single contiguous buffer for
@@ -147,6 +153,9 @@ class NimbleIndexProjectorTest : public ::testing::TestWithParam<TestParam> {
       writer.write(batch);
     }
     writer.close();
+    TabletReaderCache::testingReset();
+    tabletReaderCache_.reset();
+    keyEncoder_.reset();
   }
 
  public:
@@ -429,20 +438,19 @@ TEST_P(NimbleIndexProjectorTest, basicColumnProjection) {
   // Coalesce the chunk slice IOBuf chain into a contiguous buffer that the
   // Deserializer can read end-to-end.
   auto coalesced = coalesceChunkSlice(slice);
+  const std::string_view projectedData{
+      reinterpret_cast<const char*>(coalesced.data()), coalesced.length()};
 
+  DeserializerOptions deserOptions;
+  deserOptions.hasHeader = true;
   // Deserialize using nimble Deserializer with nimble schema.
   auto projectedVeloxType = ROW({"col_a", "col_b"}, {INTEGER(), VARCHAR()});
   auto projectedNimbleSchema = convertToNimbleType(*projectedVeloxType);
-  DeserializerOptions deserOptions;
-  deserOptions.hasHeader = true;
   Deserializer deserializer(
       projectedNimbleSchema, leafPool_.get(), deserOptions);
 
   VectorPtr deserialized;
-  deserializer.deserialize(
-      std::string_view(
-          reinterpret_cast<const char*>(coalesced.data()), coalesced.length()),
-      deserialized);
+  deserializer.deserialize(projectedData, deserialized);
   ASSERT_NE(deserialized, nullptr);
 
   auto* rowResult = deserialized->as<RowVector>();
@@ -722,12 +730,15 @@ TEST_P(NimbleIndexProjectorTest, deduplicatedProjectedStreamsReadOnce) {
       << "Deduplicated output must hold a single physical copy of the aliased "
          "stream, not two";
 
-  // The duplicate streams are reported through IoStatistics (surfaced via the
-  // rexdb benchmark): DirectDataInput coalesces the aliased dup_a/dup_b regions
-  // into one read, so the projector's data IO stats record the duplicate.
-  EXPECT_GT(dataIoStats_->duplicateReadRegions(), 0u)
-      << "dup_a and dup_b should be detected as duplicate read regions";
-  EXPECT_GT(dataIoStats_->duplicateReadBytes(), 0u);
+  // The duplicate streams are reported through IoStatistics when the data read
+  // reaches DirectDataInput. With pinned metadata enabled, the read may be
+  // served from pinned stream bodies, so duplicate read counters are not a
+  // stable signal.
+  if (!GetParam().pinMetadata) {
+    EXPECT_GT(dataIoStats_->duplicateReadRegions(), 0u)
+        << "dup_a and dup_b should be detected as duplicate read regions";
+    EXPECT_GT(dataIoStats_->duplicateReadBytes(), 0u);
+  }
 
   // Both aliased logical streams must still decode correctly from the single
   // shared body copy: the kTablet dedup trailer resolves both slots to the same
@@ -740,6 +751,761 @@ TEST_P(NimbleIndexProjectorTest, deduplicatedProjectedStreamsReadOnce) {
       deserializeProjectedSlice(*projector, result.responses[0].slices[0]),
       static_cast<uint32_t>(numRows),
       expected);
+}
+
+TEST_P(NimbleIndexProjectorTest, projectedNullableDataDeserializes) {
+  auto rowType = ROW({"key", "value"}, {BIGINT(), INTEGER()});
+
+  constexpr int numRows = 64;
+  auto batch = vectorMaker_->rowVector(
+      {"key", "value"},
+      {vectorMaker_->flatVector<int64_t>(
+           numRows, [](auto row) { return static_cast<int64_t>(row); }),
+       vectorMaker_->flatVector<int32_t>(
+           numRows,
+           [](auto row) { return static_cast<int32_t>(row * 10); },
+           [](auto row) { return row % 5 == 0; })});
+
+  writeData({batch}, {"key"});
+
+  std::vector<Subfield> subfields;
+  subfields.emplace_back("value");
+  auto projector = createProjector(subfields);
+
+  auto bounds = makeRangeLookup(rowType, {"key"}, 10, 30);
+  NimbleIndexProjector::Request request;
+  request.keyBounds = {bounds};
+  auto result = projector->project(request, {});
+
+  ASSERT_EQ(result.responses.size(), 1);
+  ASSERT_EQ(result.responses[0].slices.size(), 1);
+
+  auto expected = vectorMaker_->rowVector(
+      {"value"},
+      {vectorMaker_->flatVector<int32_t>(
+          20,
+          [](auto row) { return static_cast<int32_t>((row + 10) * 10); },
+          [](auto row) { return (row + 10) % 5 == 0; })});
+  expectVectorRows(
+      deserializeProjectedSlice(*projector, result.responses[0].slices[0]),
+      static_cast<uint32_t>(numRows),
+      expected,
+      /*outputOffset=*/10);
+}
+
+TEST_P(NimbleIndexProjectorTest, projectedTabletNullBarrierFlag) {
+  constexpr vector_size_t kRows = 6;
+  auto nestedValueType = ROW({{"score", INTEGER()}});
+  auto nestedRowType = ROW({
+      {"key", BIGINT()},
+      {"id", BIGINT()},
+      {"profile", nestedValueType},
+      {"nullable_score", INTEGER()},
+  });
+
+  auto makeNestedBatch = [&](bool hasRowNulls) {
+    auto ids = vectorMaker_->flatVector<int64_t>(
+        kRows, [](auto row) { return static_cast<int64_t>(row); });
+    auto profile = std::make_shared<RowVector>(
+        leafPool_.get(),
+        nestedValueType,
+        nullptr,
+        kRows,
+        std::vector<VectorPtr>{vectorMaker_->flatVector<int32_t>(
+            kRows, [](auto row) { return static_cast<int32_t>(row * 10); })});
+    if (hasRowNulls) {
+      profile->setNull(2, true);
+    }
+
+    auto nullableScore = vectorMaker_->flatVector<int32_t>(
+        kRows,
+        [](auto row) { return static_cast<int32_t>(1000 + row); },
+        [](auto row) { return row == 4; });
+
+    return vectorMaker_->rowVector(
+        {"key", "id", "profile", "nullable_score"},
+        {vectorMaker_->flatVector<int64_t>(
+             kRows, [](auto row) { return static_cast<int64_t>(row); }),
+         ids,
+         profile,
+         nullableScore});
+  };
+
+  auto flatMapRowType =
+      ROW({{"key", BIGINT()}, {"features", MAP(VARCHAR(), DOUBLE())}});
+  auto makeFlatMapBatch = [&](bool hasValueNulls, bool hasFlatMapNulls) {
+    auto offsets = allocateOffsets(kRows, leafPool_.get());
+    auto sizes = allocateSizes(kRows, leafPool_.get());
+    auto* rawOffsets = offsets->asMutable<vector_size_t>();
+    auto* rawSizes = sizes->asMutable<vector_size_t>();
+    for (vector_size_t row = 0; row < kRows; ++row) {
+      rawOffsets[row] = row;
+      rawSizes[row] = 1;
+    }
+    auto featureValues = vectorMaker_->flatVector<double>(
+        kRows, [](auto row) { return static_cast<double>(100 + row); });
+    if (hasValueNulls) {
+      featureValues->setNull(2, true);
+    }
+    auto features = std::make_shared<MapVector>(
+        leafPool_.get(),
+        MAP(VARCHAR(), DOUBLE()),
+        nullptr,
+        kRows,
+        offsets,
+        sizes,
+        vectorMaker_->flatVector<StringView>(
+            kRows, [](auto /*row*/) { return StringView("a"); }),
+        featureValues);
+    if (hasFlatMapNulls) {
+      features->setNull(3, true);
+    }
+
+    return vectorMaker_->rowVector(
+        {"key", "features"},
+        {vectorMaker_->flatVector<int64_t>(
+             kRows, [](auto row) { return static_cast<int64_t>(row); }),
+         features});
+  };
+
+  auto assertBarrier =
+      [&](const RowVectorPtr& batch,
+          const RowTypePtr& rowType,
+          std::string_view subfield,
+          const folly::F14FastMap<std::string, std::set<std::string>>&
+              flatMapColumns,
+          bool expectedRequiresNullBarrier) {
+        writeData(
+            {batch},
+            {"key"},
+            flatMapColumns,
+            /*stripeSize=*/1 << 20);
+        std::vector<Subfield> subfields;
+        subfields.emplace_back(std::string{subfield});
+        auto projector = createProjector(subfields);
+        auto bounds = makeRangeLookup(rowType, {"key"}, 0, kRows);
+        NimbleIndexProjector::Request request;
+        request.keyBounds = {bounds};
+        auto result = projector->project(request, {});
+
+        ASSERT_EQ(result.responses.size(), 1);
+        ASSERT_EQ(result.responses[0].slices.size(), 1);
+        EXPECT_EQ(
+            readEmbeddedTabletChunkHeader(result.responses[0].slices[0])
+                .requiresNullBarrier,
+            expectedRequiresNullBarrier);
+      };
+
+  const auto nestedNoNulls = makeNestedBatch(false);
+  const auto nestedHasNulls = makeNestedBatch(true);
+  assertBarrier(nestedNoNulls, nestedRowType, "profile.score", {}, false);
+  assertBarrier(nestedNoNulls, nestedRowType, "nullable_score", {}, false);
+  assertBarrier(nestedHasNulls, nestedRowType, "id", {}, false);
+  assertBarrier(nestedHasNulls, nestedRowType, "nullable_score", {}, false);
+  assertBarrier(nestedHasNulls, nestedRowType, "profile.score", {}, true);
+
+  const auto flatMapNoNulls = makeFlatMapBatch(false, false);
+  const auto flatMapValueNulls = makeFlatMapBatch(true, false);
+  const auto flatMapHasNulls = makeFlatMapBatch(false, true);
+  assertBarrier(
+      flatMapNoNulls,
+      flatMapRowType,
+      "features[\"a\"]",
+      {{"features", {}}},
+      false);
+  assertBarrier(
+      flatMapValueNulls,
+      flatMapRowType,
+      "features[\"a\"]",
+      {{"features", {}}},
+      false);
+  assertBarrier(
+      flatMapHasNulls,
+      flatMapRowType,
+      "features[\"a\"]",
+      {{"features", {}}},
+      true);
+}
+
+TEST_P(
+    NimbleIndexProjectorTest,
+    projectedTabletMixedNullBarrierChunksPreserveNulls) {
+  constexpr vector_size_t kRowsPerBatch = 5;
+  auto nestedType = ROW({{"score", INTEGER()}});
+  auto rowType = ROW({
+      {"key", BIGINT()},
+      {"nested", nestedType},
+  });
+
+  auto makeBatch = [&](int64_t keyBase,
+                       int32_t valueBase,
+                       std::optional<vector_size_t> nestedNullRow) {
+    auto nested = std::make_shared<RowVector>(
+        leafPool_.get(),
+        nestedType,
+        nullptr,
+        kRowsPerBatch,
+        std::vector<VectorPtr>{vectorMaker_->flatVector<int32_t>(
+            kRowsPerBatch, [valueBase](auto row) {
+              return static_cast<int32_t>(valueBase + row);
+            })});
+    if (nestedNullRow.has_value()) {
+      nested->setNull(*nestedNullRow, true);
+    }
+    return vectorMaker_->rowVector(
+        {"key", "nested"},
+        {vectorMaker_->flatVector<int64_t>(
+             kRowsPerBatch, [keyBase](auto row) { return keyBase + row; }),
+         nested});
+  };
+
+  auto first = makeBatch(0, 100, std::nullopt);
+  auto second = makeBatch(5, 200, 2);
+  auto third = makeBatch(10, 300, std::nullopt);
+  writeData({first, second, third}, {"key"}, {}, /*stripeSize=*/1);
+
+  std::vector<Subfield> subfields;
+  subfields.emplace_back("nested.score");
+  auto projector = createProjector(subfields);
+  auto bounds = makeRangeLookup(rowType, {"key"}, 0, 15);
+  NimbleIndexProjector::Request request;
+  request.keyBounds = {bounds};
+  auto result = projector->project(request, {});
+
+  ASSERT_EQ(result.responses.size(), 1);
+  ASSERT_EQ(result.responses[0].slices.size(), 3);
+  EXPECT_FALSE(readEmbeddedTabletChunkHeader(result.responses[0].slices[0])
+                   .requiresNullBarrier);
+  EXPECT_TRUE(readEmbeddedTabletChunkHeader(result.responses[0].slices[1])
+                  .requiresNullBarrier);
+  EXPECT_FALSE(readEmbeddedTabletChunkHeader(result.responses[0].slices[2])
+                   .requiresNullBarrier);
+
+  std::vector<folly::IOBuf> owned;
+  std::vector<std::string_view> batches;
+  owned.reserve(result.responses[0].slices.size());
+  batches.reserve(result.responses[0].slices.size());
+  for (const auto& slice : result.responses[0].slices) {
+    owned.push_back(coalesceChunkSlice(slice));
+    batches.emplace_back(
+        reinterpret_cast<const char*>(owned.back().data()),
+        owned.back().length());
+  }
+  auto output = deserializeProjectedBatches(*projector, batches);
+  ASSERT_NE(output, nullptr);
+  ASSERT_EQ(output->size(), 15);
+
+  auto* nested = output->as<RowVector>()->childAt(0)->as<RowVector>();
+  ASSERT_NE(nested, nullptr);
+  auto* scores = nested->childAt(0)->as<FlatVector<int32_t>>();
+  ASSERT_NE(scores, nullptr);
+  for (vector_size_t row = 0; row < 15; ++row) {
+    if (row == 7) {
+      EXPECT_TRUE(nested->isNullAt(row));
+      continue;
+    }
+    EXPECT_FALSE(nested->isNullAt(row));
+    const auto batchBase = row < 5 ? 100 : (row < 10 ? 200 : 300);
+    EXPECT_EQ(scores->valueAt(row), batchBase + row % kRowsPerBatch);
+  }
+}
+
+TEST_P(
+    NimbleIndexProjectorTest,
+    projectedTabletUnselectedNullColumnDoesNotRequireNullBarrier) {
+  constexpr vector_size_t kRows = 6;
+  auto skippedType = ROW({{"score", INTEGER()}});
+  auto rowType = ROW({
+      {"key", BIGINT()},
+      {"kept", INTEGER()},
+      {"skipped", skippedType},
+  });
+
+  auto skipped = std::make_shared<RowVector>(
+      leafPool_.get(),
+      skippedType,
+      nullptr,
+      kRows,
+      std::vector<VectorPtr>{vectorMaker_->flatVector<int32_t>(
+          kRows, [](auto row) { return static_cast<int32_t>(100 + row); })});
+  skipped->setNull(1, true);
+  skipped->setNull(4, true);
+  auto batch = vectorMaker_->rowVector(
+      {"key", "kept", "skipped"},
+      {vectorMaker_->flatVector<int64_t>(
+           kRows, [](auto row) { return static_cast<int64_t>(row); }),
+       vectorMaker_->flatVector<int32_t>(
+           kRows, [](auto row) { return static_cast<int32_t>(10 + row); }),
+       skipped});
+
+  writeData({batch}, {"key"}, {}, /*stripeSize=*/1 << 20);
+
+  std::vector<Subfield> subfields;
+  subfields.emplace_back("kept");
+  auto projector = createProjector(subfields);
+  auto bounds = makeRangeLookup(rowType, {"key"}, 0, kRows);
+  NimbleIndexProjector::Request request;
+  request.keyBounds = {bounds};
+  auto result = projector->project(request, {});
+
+  ASSERT_EQ(result.responses.size(), 1);
+  ASSERT_EQ(result.responses[0].slices.size(), 1);
+  EXPECT_FALSE(readEmbeddedTabletChunkHeader(result.responses[0].slices[0])
+                   .requiresNullBarrier);
+
+  auto output =
+      deserializeProjectedSlice(*projector, result.responses[0].slices[0]);
+  ASSERT_EQ(output->size(), kRows);
+  auto* kept = output->as<RowVector>()->childAt(0)->as<FlatVector<int32_t>>();
+  ASSERT_NE(kept, nullptr);
+  for (vector_size_t row = 0; row < kRows; ++row) {
+    EXPECT_FALSE(kept->isNullAt(row));
+    EXPECT_EQ(kept->valueAt(row), 10 + row);
+  }
+}
+
+TEST_P(NimbleIndexProjectorTest, projectedComplexNullFuzzer) {
+  constexpr vector_size_t kRowsPerBatch = 8;
+  constexpr int kNumBatches = 4;
+  constexpr vector_size_t kRows = kRowsPerBatch * kNumBatches;
+  constexpr int kIterations = 8;
+  constexpr vector_size_t kEntriesPerMapRow = 2;
+
+  auto rowType = ROW({
+      {"key", BIGINT()},
+      {"profile",
+       ROW({
+           {"score", INTEGER()},
+           {"details",
+            ROW({
+                {"rank", BIGINT()},
+                {"quality", DOUBLE()},
+            })},
+       })},
+      {"activity",
+       ROW({
+           {"clicks", INTEGER()},
+           {"label", VARCHAR()},
+           {"inner",
+            ROW({
+                {"flag", BOOLEAN()},
+                {"weight", DOUBLE()},
+            })},
+       })},
+      {"attrs", MAP(VARCHAR(), DOUBLE())},
+      {"flatAttrs", MAP(VARCHAR(), DOUBLE())},
+  });
+
+  struct RowLeafPath {
+    std::string path;
+    std::vector<std::string_view> names;
+  };
+  struct FlatMapLeafPath {
+    std::string path;
+    std::string_view key;
+  };
+
+  const std::vector<RowLeafPath> rowLeafPaths = {
+      {"profile.score", {"profile", "score"}},
+      {"profile.details.rank", {"profile", "details", "rank"}},
+      {"profile.details.quality", {"profile", "details", "quality"}},
+      {"activity.clicks", {"activity", "clicks"}},
+      {"activity.label", {"activity", "label"}},
+      {"activity.inner.flag", {"activity", "inner", "flag"}},
+      {"activity.inner.weight", {"activity", "inner", "weight"}},
+  };
+  const std::vector<FlatMapLeafPath> flatMapLeafPaths = {
+      {"flatAttrs[\"a\"]", "a"},
+      {"flatAttrs[\"b\"]", "b"},
+  };
+
+  auto makeFlatInputRow = [&](VectorFuzzer& fuzzer) {
+    std::vector<VectorPtr> children;
+    children.reserve(rowType->size());
+    for (size_t child = 0; child < rowType->size(); ++child) {
+      children.push_back(
+          fuzzer.fuzzFlat(rowType->childAt(child), kRowsPerBatch));
+    }
+    return std::make_shared<RowVector>(
+        leafPool_.get(), rowType, nullptr, kRowsPerBatch, std::move(children));
+  };
+
+  auto childIndex = [](const RowVector* row, std::string_view name) {
+    const auto& type = row->type()->asRow();
+    for (size_t i = 0; i < type.size(); ++i) {
+      if (type.nameOf(i) == name) {
+        return i;
+      }
+    }
+    NIMBLE_FAIL("Missing child {}", name);
+  };
+
+  auto leafVector = [&](const RowVector* root,
+                        const RowLeafPath& path) -> const BaseVector* {
+    const RowVector* row = root;
+    for (size_t i = 0; i + 1 < path.names.size(); ++i) {
+      row = row->childAt(childIndex(row, path.names[i]))->as<RowVector>();
+    }
+    return row->childAt(childIndex(row, path.names.back())).get();
+  };
+
+  auto pathIsNull = [&](const RowVector* root,
+                        const RowLeafPath& path,
+                        vector_size_t rowIndex) {
+    const RowVector* row = root;
+    if (row->isNullAt(rowIndex)) {
+      return true;
+    }
+    for (size_t i = 0; i + 1 < path.names.size(); ++i) {
+      row = row->childAt(childIndex(row, path.names[i]))->as<RowVector>();
+      if (row->isNullAt(rowIndex)) {
+        return true;
+      }
+    }
+    return row->childAt(childIndex(row, path.names.back()))->isNullAt(rowIndex);
+  };
+
+  auto expectLeafEqual = [&](const RowVector* expectedRoot,
+                             vector_size_t expectedRow,
+                             const RowVector* actualRoot,
+                             vector_size_t actualRow,
+                             const RowLeafPath& path) {
+    const auto expectedNull = pathIsNull(expectedRoot, path, expectedRow);
+    EXPECT_EQ(pathIsNull(actualRoot, path, actualRow), expectedNull)
+        << "path=" << path.path << " expectedRow=" << expectedRow
+        << " actualRow=" << actualRow;
+    if (expectedNull) {
+      return;
+    }
+
+    const auto* expected = leafVector(expectedRoot, path);
+    const auto* actual = leafVector(actualRoot, path);
+    switch (expected->type()->kind()) {
+      case TypeKind::BOOLEAN:
+        EXPECT_EQ(
+            expected->as<FlatVector<bool>>()->valueAt(expectedRow),
+            actual->as<FlatVector<bool>>()->valueAt(actualRow));
+        break;
+      case TypeKind::INTEGER:
+        EXPECT_EQ(
+            expected->as<FlatVector<int32_t>>()->valueAt(expectedRow),
+            actual->as<FlatVector<int32_t>>()->valueAt(actualRow));
+        break;
+      case TypeKind::BIGINT:
+        EXPECT_EQ(
+            expected->as<FlatVector<int64_t>>()->valueAt(expectedRow),
+            actual->as<FlatVector<int64_t>>()->valueAt(actualRow));
+        break;
+      case TypeKind::DOUBLE:
+        EXPECT_EQ(
+            expected->as<FlatVector<double>>()->valueAt(expectedRow),
+            actual->as<FlatVector<double>>()->valueAt(actualRow));
+        break;
+      case TypeKind::VARCHAR:
+        EXPECT_EQ(
+            expected->as<FlatVector<StringView>>()->valueAt(expectedRow),
+            actual->as<FlatVector<StringView>>()->valueAt(actualRow));
+        break;
+      default:
+        NIMBLE_FAIL(
+            "Unexpected projected type {}", expected->type()->toString());
+    }
+  };
+
+  auto makeStringDoubleMap = [&](bool hasContainerNulls, double valueBase) {
+    const auto numEntries = kRowsPerBatch * kEntriesPerMapRow;
+    auto offsets = allocateOffsets(kRowsPerBatch, leafPool_.get());
+    auto sizes = allocateSizes(kRowsPerBatch, leafPool_.get());
+    auto* rawOffsets = offsets->asMutable<vector_size_t>();
+    auto* rawSizes = sizes->asMutable<vector_size_t>();
+    for (vector_size_t row = 0; row < kRowsPerBatch; ++row) {
+      rawOffsets[row] = row * kEntriesPerMapRow;
+      rawSizes[row] = kEntriesPerMapRow;
+    }
+
+    auto keys = BaseVector::create<FlatVector<StringView>>(
+        VARCHAR(), numEntries, leafPool_.get());
+    auto values = BaseVector::create<FlatVector<double>>(
+        DOUBLE(), numEntries, leafPool_.get());
+    for (vector_size_t row = 0; row < kRowsPerBatch; ++row) {
+      for (vector_size_t mapIndex = 0; mapIndex < kEntriesPerMapRow;
+           ++mapIndex) {
+        const auto entry = row * kEntriesPerMapRow + mapIndex;
+        keys->set(entry, StringView(mapIndex == 0 ? "a" : "b"));
+        values->set(entry, valueBase + row * 10 + mapIndex);
+      }
+    }
+    values->setNull(4 * kEntriesPerMapRow, true);
+    auto map = std::make_shared<MapVector>(
+        leafPool_.get(),
+        MAP(VARCHAR(), DOUBLE()),
+        nullptr,
+        kRowsPerBatch,
+        offsets,
+        sizes,
+        keys,
+        values);
+    if (hasContainerNulls) {
+      map->setNull(5, true);
+    }
+    return map;
+  };
+
+  auto findStringKeyEntry =
+      [&](const MapVector* map,
+          vector_size_t row,
+          std::string_view key) -> std::optional<vector_size_t> {
+    if (map->isNullAt(row)) {
+      return std::nullopt;
+    }
+    const auto* keys = map->mapKeys()->as<FlatVector<StringView>>();
+    const auto offset = map->offsetAt(row);
+    const auto size = map->sizeAt(row);
+    for (vector_size_t i = 0; i < size; ++i) {
+      const auto entry = offset + i;
+      if (keys->valueAt(entry).str() == key) {
+        return entry;
+      }
+    }
+    return std::nullopt;
+  };
+
+  auto flatMapFieldVector =
+      [&](const RowVector* root,
+          const FlatMapLeafPath& path,
+          vector_size_t row) -> std::pair<const BaseVector*, vector_size_t> {
+    const auto* map =
+        root->childAt(childIndex(root, "flatAttrs"))->as<MapVector>();
+    const auto entry = findStringKeyEntry(map, row, path.key);
+    NIMBLE_CHECK(entry.has_value(), "Expected FlatMap key in test data");
+    return {map->mapValues().get(), *entry};
+  };
+
+  auto flatMapFieldIsNull = [&](const RowVector* root,
+                                const FlatMapLeafPath& path,
+                                vector_size_t row) {
+    if (root->isNullAt(row)) {
+      return true;
+    }
+    const auto* map =
+        root->childAt(childIndex(root, "flatAttrs"))->as<MapVector>();
+    const auto entry = findStringKeyEntry(map, row, path.key);
+    if (!entry.has_value()) {
+      return true;
+    }
+    return map->mapValues()->isNullAt(*entry);
+  };
+
+  auto expectFlatMapLeafEqual = [&](const RowVector* expectedRoot,
+                                    vector_size_t expectedRow,
+                                    const RowVector* actualRoot,
+                                    vector_size_t actualRow,
+                                    const FlatMapLeafPath& path) {
+    const auto expectedNull =
+        flatMapFieldIsNull(expectedRoot, path, expectedRow);
+    EXPECT_EQ(flatMapFieldIsNull(actualRoot, path, actualRow), expectedNull)
+        << "path=" << path.path << " expectedRow=" << expectedRow
+        << " actualRow=" << actualRow;
+    if (expectedNull) {
+      return;
+    }
+
+    const auto [expected, expectedEntry] =
+        flatMapFieldVector(expectedRoot, path, expectedRow);
+    const auto [actual, actualEntry] =
+        flatMapFieldVector(actualRoot, path, actualRow);
+    EXPECT_EQ(
+        expected->as<FlatVector<double>>()->valueAt(expectedEntry),
+        actual->as<FlatVector<double>>()->valueAt(actualEntry));
+  };
+
+  auto expectRegularMapEqual = [&](const RowVector* expectedRoot,
+                                   vector_size_t expectedRow,
+                                   const RowVector* actualRoot,
+                                   vector_size_t actualRow) {
+    const auto* expectedMap =
+        expectedRoot->childAt(childIndex(expectedRoot, "attrs"))
+            ->as<MapVector>();
+    const auto* actualMap =
+        actualRoot->childAt(childIndex(actualRoot, "attrs"))->as<MapVector>();
+    const auto expectedNull = expectedRoot->isNullAt(expectedRow) ||
+        expectedMap->isNullAt(expectedRow);
+    const auto actualNull =
+        actualRoot->isNullAt(actualRow) || actualMap->isNullAt(actualRow);
+    EXPECT_EQ(actualNull, expectedNull)
+        << "expectedRow=" << expectedRow << " actualRow=" << actualRow;
+    if (expectedNull) {
+      return;
+    }
+    EXPECT_TRUE(actualMap->equalValueAt(expectedMap, actualRow, expectedRow))
+        << "expectedRow=" << expectedRow << " actualRow=" << actualRow;
+  };
+
+  const auto seed = folly::Random::rand32();
+  LOG(INFO) << "projectedComplexNullFuzzer seed: " << seed;
+  folly::detail::DefaultGenerator rng{seed};
+
+  for (int iteration = 0; iteration < kIterations; ++iteration) {
+    SCOPED_TRACE(fmt::format("iteration {}", iteration));
+
+    std::vector<size_t> selectedRowIndices;
+    auto addRowIndex = [&](size_t index) {
+      for (const auto selected : selectedRowIndices) {
+        if (selected == index) {
+          return;
+        }
+      }
+      selectedRowIndices.push_back(index);
+    };
+    addRowIndex(0);
+    for (size_t i = 0; i < rowLeafPaths.size(); ++i) {
+      if (folly::Random::oneIn(2, rng)) {
+        addRowIndex(i);
+      }
+    }
+    if (selectedRowIndices.empty()) {
+      addRowIndex(folly::Random::rand32(rng) % rowLeafPaths.size());
+    }
+    bool hasTwoLevelNestedProjection = false;
+    for (const auto index : selectedRowIndices) {
+      hasTwoLevelNestedProjection |= rowLeafPaths[index].names.size() > 2;
+    }
+    if (!hasTwoLevelNestedProjection) {
+      addRowIndex(1 + folly::Random::rand32(rng) % 2);
+    }
+
+    std::vector<std::string_view> selectedFlatMapKeys = {"a"};
+    if (folly::Random::oneIn(2, rng)) {
+      selectedFlatMapKeys.emplace_back("b");
+    }
+
+    std::vector<Subfield> subfields;
+    std::vector<const RowLeafPath*> selectedRowPaths;
+    std::vector<const FlatMapLeafPath*> selectedFlatMapPaths;
+    subfields.emplace_back("attrs");
+    for (const auto index : selectedRowIndices) {
+      subfields.emplace_back(rowLeafPaths[index].path);
+      selectedRowPaths.push_back(&rowLeafPaths[index]);
+    }
+    for (const auto& path : flatMapLeafPaths) {
+      for (const auto selectedKey : selectedFlatMapKeys) {
+        if (path.key == selectedKey) {
+          subfields.emplace_back(path.path);
+          selectedFlatMapPaths.push_back(&path);
+          break;
+        }
+      }
+    }
+
+    std::vector<RowVectorPtr> inputs;
+    inputs.reserve(kNumBatches);
+    for (int batchIndex = 0; batchIndex < kNumBatches; ++batchIndex) {
+      const auto hasContainerNulls = batchIndex % 2 == 1;
+      VectorFuzzer fuzzer(
+          {
+              .vectorSize = kRowsPerBatch,
+              .nullRatio = 0,
+              .stringLength = 12,
+              .stringVariableLength = true,
+              .containerLength = 3,
+              .containerVariableLength = true,
+              .useRandomNullPattern = true,
+              .normalizeMapKeys = true,
+          },
+          leafPool_.get(),
+          folly::Random::rand32(rng));
+      auto fuzzed = makeFlatInputRow(fuzzer);
+      std::vector<VectorPtr> children;
+      children.reserve(rowType->size());
+      for (size_t child = 0; child < rowType->size(); ++child) {
+        children.push_back(fuzzed->childAt(child));
+      }
+      const auto keyBase = static_cast<int64_t>(batchIndex) * kRowsPerBatch;
+      children[childIndex(fuzzed.get(), "key")] =
+          vectorMaker_->flatVector<int64_t>(
+              kRowsPerBatch, [keyBase](auto row) { return keyBase + row; });
+      children[childIndex(fuzzed.get(), "attrs")] =
+          makeStringDoubleMap(hasContainerNulls, 1000 + batchIndex * 100);
+      children[childIndex(fuzzed.get(), "flatAttrs")] =
+          makeStringDoubleMap(hasContainerNulls, 2000 + batchIndex * 100);
+      auto input = std::make_shared<RowVector>(
+          leafPool_.get(),
+          rowType,
+          nullptr,
+          kRowsPerBatch,
+          std::move(children));
+      auto* profile =
+          input->childAt(childIndex(input.get(), "profile"))->as<RowVector>();
+      profile->childAt(childIndex(profile, "score"))->setNull(1, true);
+      if (hasContainerNulls) {
+        auto* details =
+            profile->childAt(childIndex(profile, "details"))->as<RowVector>();
+        details->setNull(2, true);
+        auto* activity = input->childAt(childIndex(input.get(), "activity"))
+                             ->as<RowVector>();
+        auto* inner =
+            activity->childAt(childIndex(activity, "inner"))->as<RowVector>();
+        inner->setNull(3, true);
+      }
+      inputs.push_back(std::move(input));
+    }
+
+    writeData(inputs, {"key"}, {{"flatAttrs", {}}}, /*stripeSize=*/1);
+
+    auto projector = createProjector(subfields);
+    auto bounds = makeRangeLookup(rowType, {"key"}, 0, kRows);
+    NimbleIndexProjector::Request request;
+    request.keyBounds = {bounds};
+    auto result = projector->project(request, {});
+
+    ASSERT_EQ(result.responses.size(), 1);
+    ASSERT_EQ(result.responses[0].slices.size(), kNumBatches);
+    for (int batchIndex = 0; batchIndex < kNumBatches; ++batchIndex) {
+      const auto& slice = result.responses[0].slices[batchIndex];
+      EXPECT_EQ(readEmbeddedRowRange(slice), RowRange(0, kRowsPerBatch));
+      EXPECT_EQ(
+          readEmbeddedTabletChunkHeader(slice).requiresNullBarrier,
+          batchIndex % 2 == 1);
+    }
+
+    std::vector<folly::IOBuf> owned;
+    std::vector<std::string_view> batches;
+    owned.reserve(result.responses[0].slices.size());
+    batches.reserve(result.responses[0].slices.size());
+    for (const auto& slice : result.responses[0].slices) {
+      owned.push_back(coalesceChunkSlice(slice));
+      batches.emplace_back(
+          reinterpret_cast<const char*>(owned.back().data()),
+          owned.back().length());
+    }
+
+    const auto output = deserializeProjectedBatches(*projector, batches);
+    ASSERT_NE(output, nullptr);
+    ASSERT_EQ(output->size(), kRows);
+    const auto* outputRow = output->as<RowVector>();
+    ASSERT_NE(outputRow, nullptr);
+
+    for (int batchIndex = 0; batchIndex < kNumBatches; ++batchIndex) {
+      const auto* input = inputs[batchIndex].get();
+      const auto outputOffset = batchIndex * kRowsPerBatch;
+      for (vector_size_t row = 0; row < kRowsPerBatch; ++row) {
+        const auto outputRowIndex = outputOffset + row;
+        SCOPED_TRACE(
+            fmt::format(
+                "batch {} row {} outputRow {}",
+                batchIndex,
+                row,
+                outputRowIndex));
+        expectRegularMapEqual(input, row, outputRow, outputRowIndex);
+        for (const auto* path : selectedRowPaths) {
+          expectLeafEqual(input, row, outputRow, outputRowIndex, *path);
+        }
+        for (const auto* path : selectedFlatMapPaths) {
+          expectFlatMapLeafEqual(input, row, outputRow, outputRowIndex, *path);
+        }
+      }
+    }
+  }
 }
 
 // Round-trips a single-batch deserialize over a key range. The Deserializer
@@ -1498,6 +2264,139 @@ TEST_P(NimbleIndexProjectorTest, flatMapProjectionWithNarrowRowRange) {
   }
 }
 
+TEST_P(NimbleIndexProjectorTest, flatMapProjectionWithInterleavedMissingKeys) {
+  auto rowType = ROW({"key", "features"}, {BIGINT(), MAP(VARCHAR(), BIGINT())});
+
+  auto keyOrdinal = [](std::string_view key) -> int64_t {
+    if (key == "a") {
+      return 1;
+    }
+    if (key == "b") {
+      return 2;
+    }
+    if (key == "c") {
+      return 3;
+    }
+    NIMBLE_FAIL("Unexpected key {}", key);
+  };
+
+  std::vector<std::vector<std::vector<std::string>>> keysByBatch{
+      {{"a", "b"}, {"a"}, {"b"}, {}, {"a", "b"}},
+      {{"b"}, {"b", "c"}, {"c"}, {}, {"b"}},
+      {{"a", "c"}, {"a"}, {"c"}, {}, {"a", "c"}},
+      {{"a", "b", "c"}, {"b"}, {"a"}, {}, {"c"}},
+  };
+
+  std::vector<RowVectorPtr> batches;
+  std::vector<std::map<std::string, int64_t>> expectedRows;
+  batches.reserve(keysByBatch.size());
+  for (size_t batchIndex = 0; batchIndex < keysByBatch.size(); ++batchIndex) {
+    const auto& keysByRow = keysByBatch[batchIndex];
+    const auto numRows = static_cast<vector_size_t>(keysByRow.size());
+    const auto keyBase = static_cast<int64_t>(batchIndex * keysByRow.size());
+
+    vector_size_t numEntries = 0;
+    for (const auto& rowKeys : keysByRow) {
+      numEntries += static_cast<vector_size_t>(rowKeys.size());
+    }
+
+    auto featureKeys = BaseVector::create<FlatVector<StringView>>(
+        VARCHAR(), numEntries, leafPool_.get());
+    auto featureValues = BaseVector::create<FlatVector<int64_t>>(
+        BIGINT(), numEntries, leafPool_.get());
+
+    auto offsets = allocateOffsets(numRows, leafPool_.get());
+    auto sizes = allocateSizes(numRows, leafPool_.get());
+    auto* rawOffsets = offsets->asMutable<vector_size_t>();
+    auto* rawSizes = sizes->asMutable<vector_size_t>();
+
+    vector_size_t entry = 0;
+    for (vector_size_t row = 0; row < numRows; ++row) {
+      rawOffsets[row] = entry;
+      rawSizes[row] = static_cast<vector_size_t>(keysByRow[row].size());
+      const auto globalRow = keyBase + row;
+      auto& expected = expectedRows.emplace_back();
+      for (const auto& key : keysByRow[row]) {
+        featureKeys->set(entry, StringView(key));
+        const auto value = globalRow * 100 + keyOrdinal(key);
+        featureValues->set(entry, value);
+        expected.emplace(key, value);
+        ++entry;
+      }
+    }
+
+    auto features = std::make_shared<MapVector>(
+        leafPool_.get(),
+        MAP(VARCHAR(), BIGINT()),
+        nullptr,
+        numRows,
+        offsets,
+        sizes,
+        featureKeys,
+        featureValues);
+    batches.emplace_back(vectorMaker_->rowVector(
+        {"key", "features"},
+        {vectorMaker_->flatVector<int64_t>(
+             numRows, [keyBase](auto row) { return keyBase + row; }),
+         features}));
+  }
+
+  writeData(batches, {"key"}, {{"features", {}}}, /*stripeSize=*/1);
+
+  std::vector<Subfield> subfields;
+  subfields.emplace_back("features[\"a\"]");
+  subfields.emplace_back("features[\"b\"]");
+  subfields.emplace_back("features[\"c\"]");
+  auto projector = createProjector(subfields);
+
+  auto bounds = makeRangeLookup(
+      rowType, {"key"}, 0, static_cast<int64_t>(expectedRows.size()));
+  NimbleIndexProjector::Request request;
+  request.keyBounds = {bounds};
+  auto result = projector->project(request, {});
+
+  ASSERT_EQ(result.responses.size(), 1);
+  ASSERT_EQ(result.responses[0].slices.size(), keysByBatch.size());
+
+  std::vector<folly::IOBuf> owned;
+  std::vector<std::string_view> serializedBatches;
+  owned.reserve(result.responses[0].slices.size());
+  serializedBatches.reserve(result.responses[0].slices.size());
+  for (const auto& slice : result.responses[0].slices) {
+    owned.push_back(coalesceChunkSlice(slice));
+    serializedBatches.emplace_back(
+        reinterpret_cast<const char*>(owned.back().data()),
+        owned.back().length());
+  }
+
+  auto output = deserializeProjectedBatches(*projector, serializedBatches);
+  ASSERT_NE(output, nullptr);
+  ASSERT_EQ(output->size(), expectedRows.size());
+
+  auto* rowResult = output->as<RowVector>();
+  ASSERT_NE(rowResult, nullptr);
+  auto* features = rowResult->childAt(0)->as<MapVector>();
+  ASSERT_NE(features, nullptr);
+  auto* featureKeys = features->mapKeys()->as<FlatVector<StringView>>();
+  auto* featureValues = features->mapValues()->as<FlatVector<int64_t>>();
+  ASSERT_NE(featureKeys, nullptr);
+  ASSERT_NE(featureValues, nullptr);
+
+  for (vector_size_t row = 0; row < output->size(); ++row) {
+    SCOPED_TRACE(fmt::format("row {}", row));
+    std::map<std::string, int64_t> actual;
+    const auto offset = features->offsetAt(row);
+    const auto size = features->sizeAt(row);
+    for (vector_size_t i = 0; i < size; ++i) {
+      const auto entry = offset + i;
+      actual.emplace(
+          std::string(featureKeys->valueAt(entry)),
+          featureValues->valueAt(entry));
+    }
+    EXPECT_EQ(actual, expectedRows[row]);
+  }
+}
+
 TEST_P(NimbleIndexProjectorTest, flatMapFullColumnProjection) {
   // Full FlatMap projection (no key subscripts) is not supported —
   // buildProjectedNimbleType requires explicit key selection for FlatMap.
@@ -1835,6 +2734,82 @@ TEST_P(NimbleIndexProjectorTest, flatMapMissingKeys) {
   }
 }
 
+TEST_P(NimbleIndexProjectorTest, flatMapMissingKeyDeserializesAsNullField) {
+  auto rowType = ROW({"key", "features"}, {BIGINT(), MAP(VARCHAR(), BIGINT())});
+
+  constexpr int numRows = 64;
+  const std::vector<std::string> mapKeys = {"a", "b", "c"};
+  const auto numMapKeys = static_cast<vector_size_t>(mapKeys.size());
+
+  std::vector<StringView> mapKeyViews;
+  mapKeyViews.reserve(mapKeys.size());
+  for (const auto& key : mapKeys) {
+    mapKeyViews.emplace_back(key);
+  }
+
+  auto batch = vectorMaker_->rowVector(
+      {"key", "features"},
+      {vectorMaker_->flatVector<int64_t>(
+           numRows, [](auto row) { return static_cast<int64_t>(row); }),
+       vectorMaker_->mapVector<StringView, int64_t>(
+           numRows,
+           /*sizeAt*/ [&](auto /*row*/) { return numMapKeys; },
+           /*keyAt*/
+           [&](auto /*row*/, auto mapIndex) { return mapKeyViews[mapIndex]; },
+           /*valueAt*/
+           [](auto row, auto mapIndex) {
+             return static_cast<int64_t>(row * 100 + mapIndex);
+           })});
+
+  writeData({batch}, {"key"}, {{"features", {}}});
+
+  std::vector<Subfield> subfields;
+  subfields.emplace_back("features[\"a\"]");
+  subfields.emplace_back("features[\"x\"]");
+  auto projector = createProjector(subfields);
+
+  auto bounds = makeRangeLookup(rowType, {"key"}, 10, 20);
+  NimbleIndexProjector::Request request;
+  request.keyBounds = {bounds};
+  auto result = projector->project(request, {});
+
+  ASSERT_EQ(result.responses.size(), 1);
+  ASSERT_EQ(result.responses[0].slices.size(), 1);
+
+  auto coalesced = coalesceChunkSlice(result.responses[0].slices[0]);
+  DeserializerOptions deserOptions{
+      .hasHeader = true,
+      .outputType = ROW({"features"}, {ROW({"a", "x"}, {BIGINT(), BIGINT()})})};
+  Deserializer deserializer(
+      projector->projectedNimbleType(), leafPool_.get(), deserOptions);
+
+  VectorPtr output;
+  deserializer.deserialize(
+      std::string_view(
+          reinterpret_cast<const char*>(coalesced.data()), coalesced.length()),
+      output);
+
+  ASSERT_NE(output, nullptr);
+  ASSERT_EQ(output->size(), numRows);
+  auto* features = output->as<RowVector>()->childAt(0)->as<RowVector>();
+  ASSERT_NE(features, nullptr);
+  ASSERT_EQ(features->childrenSize(), 2);
+  EXPECT_EQ(features->type()->asRow().nameOf(0), "a");
+  EXPECT_EQ(features->type()->asRow().nameOf(1), "x");
+
+  const auto* presentKey = features->childAt(0)->asFlatVector<int64_t>();
+  const auto* missingKey = features->childAt(1)->asFlatVector<int64_t>();
+  ASSERT_NE(presentKey, nullptr);
+  ASSERT_NE(missingKey, nullptr);
+
+  for (vector_size_t row = 10; row < 20; ++row) {
+    SCOPED_TRACE(fmt::format("row={}", row));
+    EXPECT_FALSE(presentKey->isNullAt(row));
+    EXPECT_EQ(presentKey->valueAt(row), row * 100);
+    EXPECT_TRUE(missingKey->isNullAt(row));
+  }
+}
+
 TEST_P(NimbleIndexProjectorTest, featureReorderingStorageReads) {
   // Schema: key (int64, sorted), features (MAP<INT, BIGINT> as FlatMap).
   // Write with 10 FlatMap keys (0-9), project 3 keys {7, 3, 1}.
@@ -2064,7 +3039,8 @@ TEST_P(NimbleIndexProjectorTest, readGapTracking) {
     EXPECT_GT(dataIoStats_->readGap().min(), 0);
   }
 
-  // Project all columns — no gaps between adjacent streams.
+  // Project all value columns. All-true root null streams are omitted, so the
+  // projected value streams are physically contiguous.
   {
     std::vector<Subfield> subfields;
     subfields.emplace_back("a");
@@ -2080,7 +3056,7 @@ TEST_P(NimbleIndexProjectorTest, readGapTracking) {
     projector->project(request, {});
 
     EXPECT_EQ(dataIoStats_->readGap().count(), 0)
-        << "Projecting all adjacent columns should produce no gaps";
+        << "Projecting all value columns should not produce gaps";
   }
 }
 

--- a/dwio/nimble/velox/tests/SchemaUtilsTest.cpp
+++ b/dwio/nimble/velox/tests/SchemaUtilsTest.cpp
@@ -747,10 +747,14 @@ TEST(SchemaUtilsTest, projectionDeepWithStreamOffsets) {
   subfields.emplace_back(std::move(path));
 
   // Drive the projection through the same nimble-source API the projectors
-  // use: derive (projected schema, source stream offsets) in one pass.
+  // use: derive projected schema metadata in one pass.
   std::vector<uint32_t> projectedStreamOffsets;
+  std::vector<bool> rowOrFlatMapNullStreams;
   auto projectedNimbleType = buildProjectedNimbleType(
-      convertedNimbleType.get(), subfields, projectedStreamOffsets);
+      convertedNimbleType.get(),
+      subfields,
+      projectedStreamOffsets,
+      rowOrFlatMapNullStreams);
 
   // Verify projected schema structure.
   ASSERT_EQ(projectedNimbleType->kind(), Kind::Row);
@@ -781,6 +785,215 @@ TEST(SchemaUtilsTest, projectionDeepWithStreamOffsets) {
   // The walker visits: outer-Row.nulls (1), map_col-FlatMap.nulls (0),
   // key1.Row.nulls (4), key1.inner_b (3), key1.inMap (5).
   EXPECT_EQ(projectedStreamOffsets, std::vector<uint32_t>({1, 0, 4, 3, 5}));
+  EXPECT_EQ(
+      rowOrFlatMapNullStreams,
+      std::vector<bool>({true, true, true, false, false}));
+}
+
+TEST(SchemaUtilsTest, projectionMarksRowOrFlatMapNullStreams) {
+  SchemaBuilder schemaBuilder;
+  test::FlatMapChildAdder featuresAdder;
+  NIMBLE_SCHEMA(
+      schemaBuilder,
+      NIMBLE_ROW({
+          {"id", NIMBLE_BIGINT()},
+          {"profile",
+           NIMBLE_ROW({
+               {"age", NIMBLE_INTEGER()},
+               {"name", NIMBLE_STRING()},
+           })},
+          {"features",
+           NIMBLE_FLATMAP(
+               String,
+               NIMBLE_ROW({
+                   {"score", NIMBLE_INTEGER()},
+                   {"label", NIMBLE_STRING()},
+               }),
+               featuresAdder)},
+      }));
+  featuresAdder.addChild("a");
+  featuresAdder.addChild("b");
+  auto sourceNimbleType = SchemaReader::getSchema(schemaBuilder.schemaNodes());
+
+  const auto rowChild = [](const RowType& row,
+                           const char* name) -> const Type& {
+    return *row.childAt(row.findChild(name).value());
+  };
+  const auto scalarOffset = [](const Type& type) {
+    return type.asScalar().scalarDescriptor().offset();
+  };
+  struct SourceStreamOffsets {
+    uint32_t rootNull;
+    uint32_t id;
+    uint32_t profileNull;
+    uint32_t profileAge;
+    uint32_t featuresNull;
+    uint32_t featureARowNull;
+    uint32_t featureAScore;
+    uint32_t featureAInMap;
+  };
+  const auto sourceOffsets = [&]() {
+    const auto& root = sourceNimbleType->asRow();
+    const auto& profile = rowChild(root, "profile").asRow();
+    const auto& features = rowChild(root, "features").asFlatMap();
+    const auto featureAIdx = features.findChild("a").value();
+    const auto& featureARow = features.childAt(featureAIdx)->asRow();
+    return SourceStreamOffsets{
+        root.nullsDescriptor().offset(),
+        scalarOffset(rowChild(root, "id")),
+        profile.nullsDescriptor().offset(),
+        scalarOffset(rowChild(profile, "age")),
+        features.nullsDescriptor().offset(),
+        featureARow.nullsDescriptor().offset(),
+        scalarOffset(rowChild(featureARow, "score")),
+        features.inMapDescriptorAt(featureAIdx).offset()};
+  }();
+
+  struct ProjectedMetadata {
+    std::shared_ptr<const Type> schema;
+    std::vector<uint32_t> streamOffsets;
+    std::vector<bool> rowOrFlatMapNullStreams;
+  };
+  auto project = [&](const std::vector<Subfield>& subfields) {
+    ProjectedMetadata metadata;
+    metadata.schema = buildProjectedNimbleType(
+        sourceNimbleType.get(),
+        subfields,
+        metadata.streamOffsets,
+        metadata.rowOrFlatMapNullStreams);
+    return metadata;
+  };
+
+  enum class ProjectedShape {
+    Scalar,
+    RowWithAge,
+    FlatMapWithScore,
+    FlatMapWithFullRow,
+  };
+  struct TestCase {
+    std::string name;
+    std::string subfield;
+    ProjectedShape shape;
+    std::vector<uint32_t> expectedStreamOffsets;
+    std::vector<bool> expectedRowOrFlatMapNullStreams;
+  };
+  const std::vector<TestCase> testCases{
+      {"scalar",
+       "id",
+       ProjectedShape::Scalar,
+       {sourceOffsets.rootNull, sourceOffsets.id},
+       {true, false}},
+      {"nested-row",
+       "profile.age",
+       ProjectedShape::RowWithAge,
+       {sourceOffsets.rootNull,
+        sourceOffsets.profileNull,
+        sourceOffsets.profileAge},
+       {true, true, false}},
+      {"flatmap-row-value",
+       "features[\"a\"].score",
+       ProjectedShape::FlatMapWithScore,
+       {sourceOffsets.rootNull,
+        sourceOffsets.featuresNull,
+        sourceOffsets.featureARowNull,
+        sourceOffsets.featureAScore,
+        sourceOffsets.featureAInMap},
+       {true, true, true, false, false}},
+      {"missing-flatmap-row-value",
+       "features[\"missing\"]",
+       ProjectedShape::FlatMapWithFullRow,
+       {sourceOffsets.rootNull,
+        sourceOffsets.featuresNull,
+        UINT32_MAX,
+        UINT32_MAX,
+        UINT32_MAX,
+        UINT32_MAX},
+       {true, true, true, false, false, false}},
+  };
+
+  for (const auto& testCase : testCases) {
+    SCOPED_TRACE(testCase.name);
+    std::vector<Subfield> subfields;
+    subfields.emplace_back(testCase.subfield);
+
+    auto metadata = project(subfields);
+
+    ASSERT_EQ(metadata.schema->kind(), Kind::Row);
+    const auto& projectedRoot = metadata.schema->asRow();
+    ASSERT_EQ(projectedRoot.childrenCount(), 1);
+    switch (testCase.shape) {
+      case ProjectedShape::Scalar:
+        EXPECT_EQ(projectedRoot.nameAt(0), "id");
+        EXPECT_EQ(projectedRoot.childAt(0)->kind(), Kind::Scalar);
+        break;
+      case ProjectedShape::RowWithAge: {
+        EXPECT_EQ(projectedRoot.nameAt(0), "profile");
+        ASSERT_EQ(projectedRoot.childAt(0)->kind(), Kind::Row);
+        const auto& projectedProfile = projectedRoot.childAt(0)->asRow();
+        ASSERT_EQ(projectedProfile.childrenCount(), 1);
+        EXPECT_EQ(projectedProfile.nameAt(0), "age");
+        break;
+      }
+      case ProjectedShape::FlatMapWithScore: {
+        EXPECT_EQ(projectedRoot.nameAt(0), "features");
+        ASSERT_EQ(projectedRoot.childAt(0)->kind(), Kind::FlatMap);
+        const auto& projectedFeatures = projectedRoot.childAt(0)->asFlatMap();
+        ASSERT_EQ(projectedFeatures.childrenCount(), 1);
+        EXPECT_EQ(projectedFeatures.nameAt(0), "a");
+        ASSERT_EQ(projectedFeatures.childAt(0)->kind(), Kind::Row);
+        const auto& projectedFeatureA = projectedFeatures.childAt(0)->asRow();
+        ASSERT_EQ(projectedFeatureA.childrenCount(), 1);
+        EXPECT_EQ(projectedFeatureA.nameAt(0), "score");
+        break;
+      }
+      case ProjectedShape::FlatMapWithFullRow: {
+        EXPECT_EQ(projectedRoot.nameAt(0), "features");
+        ASSERT_EQ(projectedRoot.childAt(0)->kind(), Kind::FlatMap);
+        const auto& projectedFeatures = projectedRoot.childAt(0)->asFlatMap();
+        ASSERT_EQ(projectedFeatures.childrenCount(), 1);
+        EXPECT_EQ(projectedFeatures.nameAt(0), "missing");
+        ASSERT_EQ(projectedFeatures.childAt(0)->kind(), Kind::Row);
+        const auto& projectedFeature = projectedFeatures.childAt(0)->asRow();
+        ASSERT_EQ(projectedFeature.childrenCount(), 2);
+        EXPECT_EQ(projectedFeature.nameAt(0), "score");
+        EXPECT_EQ(projectedFeature.nameAt(1), "label");
+        break;
+      }
+    }
+    EXPECT_EQ(metadata.streamOffsets, testCase.expectedStreamOffsets);
+    EXPECT_EQ(
+        metadata.rowOrFlatMapNullStreams,
+        testCase.expectedRowOrFlatMapNullStreams);
+  }
+}
+
+TEST(SchemaUtilsTest, nestedFlatMapProjectionFails) {
+  SchemaBuilder schemaBuilder;
+  test::FlatMapChildAdder featuresAdder;
+  NIMBLE_SCHEMA(
+      schemaBuilder,
+      NIMBLE_ROW({
+          {"nested",
+           NIMBLE_ROW({
+               {"features",
+                NIMBLE_FLATMAP(String, NIMBLE_INTEGER(), featuresAdder)},
+           })},
+      }));
+  featuresAdder.addChild("a");
+  auto sourceNimbleType = SchemaReader::getSchema(schemaBuilder.schemaNodes());
+
+  std::vector<Subfield> subfields;
+  subfields.emplace_back("nested");
+
+  std::vector<uint32_t> projectedStreamOffsets;
+  std::vector<bool> rowOrFlatMapNullStreams;
+  NIMBLE_ASSERT_THROW(
+      buildProjectedNimbleType(
+          sourceNimbleType.get(),
+          subfields,
+          projectedStreamOffsets,
+          rowOrFlatMapNullStreams),
+      "FlatMap projection is supported only for top-level columns");
 }
 
 TEST(SchemaUtilsTest, projectionEncodingHints_SlidingWindowMap) {
@@ -811,8 +1024,12 @@ TEST(SchemaUtilsTest, projectionEncodingHints_SlidingWindowMap) {
   subfields.emplace_back("dedup_map");
 
   std::vector<uint32_t> projectedStreamOffsets;
+  std::vector<bool> rowOrFlatMapNullStreams;
   auto projectedNimbleType = buildProjectedNimbleType(
-      sourceNimbleType.get(), subfields, projectedStreamOffsets);
+      sourceNimbleType.get(),
+      subfields,
+      projectedStreamOffsets,
+      rowOrFlatMapNullStreams);
 
   // Verify the SlidingWindowMap encoding is preserved (this is the path
   // through getColumnEncodings → deduplicatedMapColumns → velox-source
@@ -828,6 +1045,9 @@ TEST(SchemaUtilsTest, projectionEncodingHints_SlidingWindowMap) {
   // Walker visits: outer-Row.nulls (5), id Scalar (0), dedup_map offsets (3),
   // lengths (4), keys (1), values (2).
   EXPECT_EQ(projectedStreamOffsets, std::vector<uint32_t>({5, 0, 3, 4, 1, 2}));
+  EXPECT_EQ(
+      rowOrFlatMapNullStreams,
+      std::vector<bool>({true, false, false, false, false, false}));
 }
 
 TEST(SchemaUtilsTest, projectionEncodingHints_Mixed) {
@@ -870,8 +1090,12 @@ TEST(SchemaUtilsTest, projectionEncodingHints_Mixed) {
   subfields.emplace_back("features[\"missing\"]");
 
   std::vector<uint32_t> projectedStreamOffsets;
+  std::vector<bool> rowOrFlatMapNullStreams;
   auto projectedNimbleType = buildProjectedNimbleType(
-      sourceNimbleType.get(), subfields, projectedStreamOffsets);
+      sourceNimbleType.get(),
+      subfields,
+      projectedStreamOffsets,
+      rowOrFlatMapNullStreams);
 
   // All three encoding-specific Kinds survive the projection.
   ASSERT_EQ(projectedNimbleType->kind(), Kind::Row);
@@ -899,6 +1123,23 @@ TEST(SchemaUtilsTest, projectionEncodingHints_Mixed) {
       projectedStreamOffsets,
       std::vector<uint32_t>(
           {9, 0, 2, 3, 1, 6, 7, 4, 5, 8, 10, 11, UINT32_MAX, UINT32_MAX}));
+  EXPECT_EQ(
+      rowOrFlatMapNullStreams,
+      std::vector<bool>(
+          {true,
+           false,
+           false,
+           false,
+           false,
+           false,
+           false,
+           false,
+           false,
+           true,
+           false,
+           false,
+           false,
+           false}));
 }
 
 TEST(SchemaUtilsTest, projectionEmptySubfieldsFails) {

--- a/dwio/nimble/velox/tests/StreamChunkerTest.cpp
+++ b/dwio/nimble/velox/tests/StreamChunkerTest.cpp
@@ -224,24 +224,40 @@ TEST_F(StreamChunkerTestsBase, shouldOmitNullStream) {
             /*isFirstChunk=*/false));
   }
 
-  // No nulls.
+  // No validity bitmap.
   {
     NullsStreamData nullsStream(
         *leafPool_, *descriptor, *inputBufferGrowthPolicy_);
-    std::vector<bool> nonNullsTestData = {true, false};
     nullsStream.ensureAdditionalNullsCapacity(
-        /*mayHaveNulls=*/false, static_cast<uint32_t>(nonNullsTestData.size()));
+        /*mayHaveNulls=*/false, /*additionalSize=*/2);
 
-    // Omit stream when first chunk and empty.
     EXPECT_TRUE(
         detail::shouldOmitNullStream(
             nullsStream,
             /*minChunkSize=*/1,
             /*isFirstChunk=*/true));
+    EXPECT_FALSE(
+        detail::shouldOmitNullStream(
+            nullsStream,
+            /*minChunkSize=*/1,
+            /*isFirstChunk=*/false));
+  }
 
+  // Allocated validity bitmap, but all values are non-null.
+  {
+    NullsStreamData nullsStream(
+        *leafPool_, *descriptor, *inputBufferGrowthPolicy_);
+    std::vector<bool> nonNullsTestData = {true, true};
+    nullsStream.ensureAdditionalNullsCapacity(
+        /*mayHaveNulls=*/true, static_cast<uint32_t>(nonNullsTestData.size()));
     auto& nonNulls = nullsStream.mutableNonNulls();
     populateData(nonNulls, nonNullsTestData);
-    // No omit stream when not first chunk and not empty.
+
+    EXPECT_TRUE(
+        detail::shouldOmitNullStream(
+            nullsStream,
+            /*minChunkSize=*/1,
+            /*isFirstChunk=*/true));
     EXPECT_FALSE(
         detail::shouldOmitNullStream(
             nullsStream,

--- a/dwio/nimble/velox/tests/StreamDataTest.cpp
+++ b/dwio/nimble/velox/tests/StreamDataTest.cpp
@@ -16,6 +16,8 @@
 
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
+
+#include <array>
 #include <vector>
 
 #include "dwio/nimble/velox/BufferGrowthPolicy.h"
@@ -48,16 +50,102 @@ uint64_t getAlignedBufferCapacity(
 }
 
 template <typename T>
-class nullStreamDataTest : public ::testing::Test {};
+class nullStreamDataTest : public ::testing::Test {
+ protected:
+  static void SetUpTestSuite() {
+    velox::memory::MemoryManager::testingSetInstance(
+        velox::memory::MemoryManager::Options{});
+  }
+
+  void SetUp() override {
+    pool_ = velox::memory::memoryManager()->addLeafPool("test");
+  }
+
+  std::shared_ptr<velox::memory::MemoryPool> pool_;
+};
 using NullTestTypes =
     ::testing::Types<NullsStreamData, NullableContentStreamData<int32_t>>;
 TYPED_TEST_SUITE(nullStreamDataTest, NullTestTypes);
 
+TEST(StreamDataTest, hasNullValuesFromSpan) {
+  constexpr std::array<bool, 3> allNonNull = {true, true, true};
+  constexpr std::array<bool, 3> hasNull = {true, false, true};
+
+  struct TestCase {
+    std::span<const bool> nonNulls;
+    bool expected;
+  };
+  const std::array<TestCase, 3> testCases = {{
+      {std::span<const bool>{}, false},
+      {allNonNull, false},
+      {hasNull, true},
+  }};
+
+  for (const auto& testCase : testCases) {
+    EXPECT_EQ(StreamData::hasNullValues(testCase.nonNulls), testCase.expected);
+  }
+}
+
+TYPED_TEST(nullStreamDataTest, hasNullValues) {
+  using T = TypeParam;
+
+  SchemaBuilder schemaBuilder;
+  const auto scalarBuilder =
+      schemaBuilder.createScalarTypeBuilder(ScalarKind::Int32);
+  const auto& descriptor = scalarBuilder->scalarDescriptor();
+  auto growthPolicy = DefaultInputBufferGrowthPolicy::withDefaultRanges();
+
+  struct TestCase {
+    const char* name{};
+    bool mayHaveNulls{};
+    uint64_t additionalSize{};
+    std::vector<bool> nonNullValues;
+    bool expectedHasNulls{};
+    bool expectedHasNullValues{};
+  };
+  const std::vector<TestCase> testCases = {
+      {
+          "no validity bitmap",
+          false,
+          3,
+          {},
+          false,
+          false,
+      },
+      {
+          "all non-null validity bitmap",
+          true,
+          3,
+          {true, true, true},
+          true,
+          false,
+      },
+      {
+          "contains null value",
+          true,
+          3,
+          {true, false, true},
+          true,
+          true,
+      },
+  };
+
+  for (const auto& testCase : testCases) {
+    SCOPED_TRACE(testCase.name);
+    T streamData(*this->pool_, descriptor, *growthPolicy);
+    streamData.ensureAdditionalNullsCapacity(
+        testCase.mayHaveNulls, testCase.additionalSize);
+    for (const bool notNull : testCase.nonNullValues) {
+      streamData.mutableNonNulls().push_back(notNull);
+    }
+
+    EXPECT_EQ(streamData.hasNulls(), testCase.expectedHasNulls);
+    EXPECT_EQ(streamData.hasNullValues(), testCase.expectedHasNullValues);
+  }
+}
+
 TYPED_TEST(nullStreamDataTest, ensureAdditionalNullsCapacity) {
   using T = TypeParam;
-  velox::memory::MemoryManager::testingSetInstance(
-      velox::memory::MemoryManager::Options{});
-  auto memoryPool = velox::memory::memoryManager()->addLeafPool("test");
   auto helperPool = velox::memory::memoryManager()->addLeafPool("helper");
 
   SchemaBuilder schemaBuilder;
@@ -76,11 +164,11 @@ TYPED_TEST(nullStreamDataTest, ensureAdditionalNullsCapacity) {
             1030, getAlignedBufferCapacity<bool>(20, helperPool)))
         .WillOnce(Return(1030));
   }
-  T streamData(*memoryPool, descriptor, growthPolicy);
+  T streamData(*this->pool_, descriptor, growthPolicy);
 
   // First ensure some capacity with nulls
   streamData.ensureAdditionalNullsCapacity(true, 20);
-  EXPECT_EQ(memoryPool->stats().numAllocs, 1);
+  EXPECT_EQ(this->pool_->stats().numAllocs, 1);
 
   // Check initial state
   EXPECT_TRUE(streamData.hasNulls());
@@ -103,12 +191,12 @@ TYPED_TEST(nullStreamDataTest, ensureAdditionalNullsCapacity) {
   streamData.ensureAdditionalNullsCapacity(true, 10);
   EXPECT_EQ(nonNulls.capacity(), actualCapacity1);
   EXPECT_EQ(nonNulls.size(), 20);
-  EXPECT_EQ(memoryPool->stats().numAllocs, 1);
+  EXPECT_EQ(this->pool_->stats().numAllocs, 1);
 
   // Grow the capacity
   streamData.ensureAdditionalNullsCapacity(true, 1000);
   const auto actualCapacity2 = nonNulls.capacity();
-  EXPECT_EQ(memoryPool->stats().numAllocs, 2);
+  EXPECT_EQ(this->pool_->stats().numAllocs, 2);
 
   // Check the capacity increased and size stayed the same
   EXPECT_GT(actualCapacity2, actualCapacity1);
@@ -135,7 +223,7 @@ TYPED_TEST(nullStreamDataTest, ensureAdditionalNullsCapacity) {
     EXPECT_EQ(nonNulls[i], (i % 2 == 0))
         << "Null value at index " << i << " was corrupted";
   }
-  EXPECT_EQ(memoryPool->stats().numAllocs, 2);
+  EXPECT_EQ(this->pool_->stats().numAllocs, 2);
 }
 
 template <typename T>
@@ -227,11 +315,11 @@ class rowCountTest : public ::testing::Test {
   void SetUp() override {
     velox::memory::MemoryManager::testingSetInstance(
         velox::memory::MemoryManager::Options{});
-    memoryPool_ = velox::memory::memoryManager()->addLeafPool("test");
+    pool_ = velox::memory::memoryManager()->addLeafPool("test");
     schemaBuilder_ = std::make_unique<SchemaBuilder>();
   }
 
-  std::shared_ptr<velox::memory::MemoryPool> memoryPool_;
+  std::shared_ptr<velox::memory::MemoryPool> pool_;
   std::unique_ptr<SchemaBuilder> schemaBuilder_;
 };
 
@@ -240,7 +328,7 @@ TEST_F(rowCountTest, contentStreamDataRowCount) {
   const auto scalarBuilder =
       schemaBuilder_->createScalarTypeBuilder(ScalarKind::Int32);
   const auto& descriptor = scalarBuilder->scalarDescriptor();
-  ContentStreamData<int32_t> streamData(*memoryPool_, descriptor, growthPolicy);
+  ContentStreamData<int32_t> streamData(*pool_, descriptor, growthPolicy);
 
   // Initially empty.
   EXPECT_EQ(streamData.rowCount(), 0);
@@ -273,7 +361,7 @@ TEST_F(rowCountTest, contentStreamDataStringRowCount) {
       schemaBuilder_->createScalarTypeBuilder(ScalarKind::String);
   const auto& descriptor = scalarBuilder->scalarDescriptor();
   ContentStreamData<std::string_view> streamData(
-      *memoryPool_, descriptor, growthPolicy);
+      *pool_, descriptor, growthPolicy);
 
   EXPECT_EQ(streamData.rowCount(), 0);
 
@@ -294,7 +382,7 @@ TEST_F(rowCountTest, nullsStreamDataRowCount) {
   const auto scalarBuilder =
       schemaBuilder_->createScalarTypeBuilder(ScalarKind::Bool);
   const auto& descriptor = scalarBuilder->scalarDescriptor();
-  NullsStreamData streamData(*memoryPool_, descriptor, growthPolicy);
+  NullsStreamData streamData(*pool_, descriptor, growthPolicy);
 
   // Initially empty.
   EXPECT_EQ(streamData.rowCount(), 0);
@@ -321,7 +409,7 @@ TEST_F(rowCountTest, nullsStreamDataRowCountWithNulls) {
   const auto scalarBuilder =
       schemaBuilder_->createScalarTypeBuilder(ScalarKind::Bool);
   const auto& descriptor = scalarBuilder->scalarDescriptor();
-  NullsStreamData streamData(*memoryPool_, descriptor, growthPolicy);
+  NullsStreamData streamData(*pool_, descriptor, growthPolicy);
 
   // Add data with nulls.
   streamData.ensureAdditionalNullsCapacity(/*mayHaveNulls=*/true, 4);
@@ -354,7 +442,7 @@ TEST_F(rowCountTest, nullableContentStreamDataRowCount) {
       schemaBuilder_->createScalarTypeBuilder(ScalarKind::Int32);
   const auto& descriptor = scalarBuilder->scalarDescriptor();
   NullableContentStreamData<int32_t> streamData(
-      *memoryPool_, descriptor, growthPolicy);
+      *pool_, descriptor, growthPolicy);
 
   // Initially empty.
   EXPECT_EQ(streamData.rowCount(), 0);
@@ -392,7 +480,7 @@ TEST_F(rowCountTest, nullableContentStreamDataRowCountWithoutNulls) {
       schemaBuilder_->createScalarTypeBuilder(ScalarKind::Int32);
   const auto& descriptor = scalarBuilder->scalarDescriptor();
   NullableContentStreamData<int32_t> streamData(
-      *memoryPool_, descriptor, growthPolicy);
+      *pool_, descriptor, growthPolicy);
 
   // Add data without nulls.
   streamData.ensureAdditionalNullsCapacity(/*mayHaveNulls=*/false, 3);
@@ -414,7 +502,7 @@ TEST_F(rowCountTest, nullableContentStreamDataRowCountWithAllNulls) {
       schemaBuilder_->createScalarTypeBuilder(ScalarKind::Int32);
   const auto& descriptor = scalarBuilder->scalarDescriptor();
   NullableContentStreamData<int32_t> streamData(
-      *memoryPool_, descriptor, growthPolicy);
+      *pool_, descriptor, growthPolicy);
 
   // Add data with all nulls.
   streamData.ensureAdditionalNullsCapacity(/*mayHaveNulls=*/true, 5);
@@ -490,13 +578,39 @@ TEST_F(rowCountTest, streamDataViewRowCountWithNulls) {
   EXPECT_EQ(view.nonNulls().size(), 5);
 }
 
+TEST_F(rowCountTest, isNullStreamClassification) {
+  ExactGrowthPolicy growthPolicy;
+  const auto intBuilder =
+      schemaBuilder_->createScalarTypeBuilder(ScalarKind::Int32);
+  const auto boolBuilder =
+      schemaBuilder_->createScalarTypeBuilder(ScalarKind::Bool);
+  const auto stringBuilder =
+      schemaBuilder_->createScalarTypeBuilder(ScalarKind::String);
+
+  ContentStreamData<int32_t> contentData(
+      *pool_, intBuilder->scalarDescriptor(), growthPolicy);
+  NullsStreamData nullData(
+      *pool_, boolBuilder->scalarDescriptor(), growthPolicy);
+  NullableContentStreamData<int32_t> nullableContentData(
+      *pool_, intBuilder->scalarDescriptor(), growthPolicy);
+  NullableContentStringStreamData nullableStringData(
+      *pool_, stringBuilder->scalarDescriptor(), growthPolicy, growthPolicy);
+  StreamDataView view(
+      intBuilder->scalarDescriptor(), std::string_view{}, /*rowCount=*/0);
+
+  EXPECT_FALSE(contentData.isNullStream());
+  EXPECT_TRUE(nullData.isNullStream());
+  EXPECT_FALSE(nullableContentData.isNullStream());
+  EXPECT_FALSE(nullableStringData.isNullStream());
+  EXPECT_FALSE(view.isNullStream());
+}
+
 class NullableContentStringStreamDataTest : public ::testing::Test {
  protected:
   void SetUp() override {
     velox::memory::MemoryManager::testingSetInstance(
         velox::memory::MemoryManager::Options{});
-    memoryPool_ = velox::memory::memoryManager()->addLeafPool("test");
-    helperPool_ = velox::memory::memoryManager()->addLeafPool("helper");
+    pool_ = velox::memory::memoryManager()->addLeafPool("test");
     schemaBuilder_ = std::make_unique<SchemaBuilder>();
     scalarBuilder_ =
         schemaBuilder_->createScalarTypeBuilder(ScalarKind::String);
@@ -506,14 +620,10 @@ class NullableContentStringStreamDataTest : public ::testing::Test {
       const InputBufferGrowthPolicy& dataPolicy,
       const InputBufferGrowthPolicy& bufferPolicy) {
     return NullableContentStringStreamData(
-        *memoryPool_,
-        scalarBuilder_->scalarDescriptor(),
-        dataPolicy,
-        bufferPolicy);
+        *pool_, scalarBuilder_->scalarDescriptor(), dataPolicy, bufferPolicy);
   }
 
-  std::shared_ptr<velox::memory::MemoryPool> memoryPool_;
-  std::shared_ptr<velox::memory::MemoryPool> helperPool_;
+  std::shared_ptr<velox::memory::MemoryPool> pool_;
   std::unique_ptr<SchemaBuilder> schemaBuilder_;
   std::shared_ptr<ScalarTypeBuilder> scalarBuilder_;
 };
@@ -571,7 +681,7 @@ TEST_F(NullableContentStringStreamDataTest, ensureStringBufferCapacity) {
 
   auto streamData = createStreamData(dataPolicy, bufferPolicy);
   streamData.ensureStringBufferCapacity(10, 100);
-  EXPECT_EQ(memoryPool_->stats().numAllocs, 2);
+  EXPECT_EQ(pool_->stats().numAllocs, 2);
 
   auto [buffer, lengths] = streamData.mutableData();
   EXPECT_GE(lengths.capacity(), 10);
@@ -579,7 +689,7 @@ TEST_F(NullableContentStringStreamDataTest, ensureStringBufferCapacity) {
 
   // Zero strings is a no-op.
   streamData.ensureStringBufferCapacity(0, 100);
-  EXPECT_EQ(memoryPool_->stats().numAllocs, 2);
+  EXPECT_EQ(pool_->stats().numAllocs, 2);
 }
 TEST(StreamDataUtilTest, isConstantBoolStream) {
   // Empty → constant.

--- a/dwio/nimble/velox/tests/VeloxWriterTest.cpp
+++ b/dwio/nimble/velox/tests/VeloxWriterTest.cpp
@@ -1721,6 +1721,182 @@ void testChunks(
   validateChunkSize(reader, minStreamChunkRawSize, maxStreamChunkRawSize);
 }
 
+TEST_F(VeloxWriterTest, omitsAllNonNullRowNullStreams) {
+  velox::test::VectorMaker vectorMaker{leafPool_.get()};
+  auto makeVector = [&]() {
+    return vectorMaker.rowVector(
+        {"nested"},
+        {vectorMaker.rowVector(
+            {"c1"}, {vectorMaker.flatVector<int32_t>({1, 2, 3})})});
+  };
+  auto makeVectorWithAllocatedAllNonNullNulls = [&]() {
+    constexpr velox::vector_size_t kSize = 3;
+    auto nestedType = velox::ROW({"c1"}, {velox::INTEGER()});
+    auto nestedNulls = velox::AlignedBuffer::allocate<bool>(
+        kSize, leafPool_.get(), velox::bits::kNotNull);
+    auto nested = std::make_shared<velox::RowVector>(
+        leafPool_.get(),
+        nestedType,
+        nestedNulls,
+        kSize,
+        std::vector<velox::VectorPtr>{
+            vectorMaker.flatVector<int32_t>({1, 2, 3})});
+
+    auto rootNulls = velox::AlignedBuffer::allocate<bool>(
+        kSize, leafPool_.get(), velox::bits::kNotNull);
+    return std::make_shared<velox::RowVector>(
+        leafPool_.get(),
+        velox::ROW({"nested"}, {nestedType}),
+        rootNulls,
+        kSize,
+        std::vector<velox::VectorPtr>{nested});
+  };
+
+  auto allNonNullVector = makeVector();
+  auto allocatedAllNonNullVector = makeVectorWithAllocatedAllNonNullNulls();
+  auto topLevelNullVector = makeVector();
+  topLevelNullVector->setNull(1, true);
+
+  struct TestCase {
+    std::string_view name;
+    velox::RowVectorPtr input;
+    velox::RowVectorPtr expected;
+    bool ignoreTopLevelNulls;
+    bool enableChunking;
+    bool expectRootNullStreamOmitted;
+  };
+
+  const std::vector<TestCase> testCases{
+      {
+          .name = "allNonNull",
+          .input = allNonNullVector,
+          .expected = allNonNullVector,
+          .ignoreTopLevelNulls = false,
+          .enableChunking = false,
+          .expectRootNullStreamOmitted = true,
+      },
+      {
+          .name = "allNonNull",
+          .input = allNonNullVector,
+          .expected = allNonNullVector,
+          .ignoreTopLevelNulls = false,
+          .enableChunking = true,
+          .expectRootNullStreamOmitted = true,
+      },
+      {
+          .name = "allocatedAllNonNullNulls",
+          .input = allocatedAllNonNullVector,
+          .expected = allNonNullVector,
+          .ignoreTopLevelNulls = false,
+          .enableChunking = false,
+          .expectRootNullStreamOmitted = true,
+      },
+      {
+          .name = "allocatedAllNonNullNulls",
+          .input = allocatedAllNonNullVector,
+          .expected = allNonNullVector,
+          .ignoreTopLevelNulls = false,
+          .enableChunking = true,
+          .expectRootNullStreamOmitted = true,
+      },
+      {
+          .name = "preservedTopLevelNulls",
+          .input = topLevelNullVector,
+          .expected = topLevelNullVector,
+          .ignoreTopLevelNulls = false,
+          .enableChunking = false,
+          .expectRootNullStreamOmitted = false,
+      },
+      {
+          .name = "preservedTopLevelNulls",
+          .input = topLevelNullVector,
+          .expected = topLevelNullVector,
+          .ignoreTopLevelNulls = false,
+          .enableChunking = true,
+          .expectRootNullStreamOmitted = false,
+      },
+      {
+          .name = "ignoredTopLevelNulls",
+          .input = topLevelNullVector,
+          .expected = allNonNullVector,
+          .ignoreTopLevelNulls = true,
+          .enableChunking = false,
+          .expectRootNullStreamOmitted = true,
+      },
+      {
+          .name = "ignoredTopLevelNulls",
+          .input = topLevelNullVector,
+          .expected = allNonNullVector,
+          .ignoreTopLevelNulls = true,
+          .enableChunking = true,
+          .expectRootNullStreamOmitted = true,
+      },
+  };
+
+  for (const auto& testCase : testCases) {
+    SCOPED_TRACE(
+        fmt::format(
+            "case={}, enableChunking={}",
+            testCase.name,
+            testCase.enableChunking));
+
+    std::string file;
+    auto writeFile = std::make_unique<velox::InMemoryWriteFile>(&file);
+
+    nimble::VeloxWriterOptions options;
+    options.enableChunking = testCase.enableChunking;
+    options.ignoreTopLevelNulls = testCase.ignoreTopLevelNulls;
+
+    nimble::VeloxWriter writer(
+        testCase.input->type(),
+        std::move(writeFile),
+        *rootPool_,
+        std::move(options));
+    writer.write(testCase.input);
+    writer.close();
+
+    auto readFile = std::make_shared<velox::InMemoryReadFile>(file);
+    auto tablet = nimble::TabletReader::create(
+        readFile, leafPool_.get(), makeTestTabletOptions(leafPool_.get()));
+    ASSERT_EQ(1, tablet->stripeCount());
+
+    nimble::VeloxReader reader(readFile.get(), *leafPool_);
+    const auto& root = reader.schema()->asRow();
+    const auto& nested = root.childAt(0)->asRow();
+    const auto rootNullOffset = root.nullsDescriptor().offset();
+    const auto nestedNullOffset = nested.nullsDescriptor().offset();
+    const auto stripeIdentifier = tablet->stripeIdentifier(0);
+    const auto streamSizes = tablet->streamSizes(stripeIdentifier);
+    ASSERT_GT(streamSizes.size(), static_cast<size_t>(rootNullOffset));
+    ASSERT_GT(streamSizes.size(), static_cast<size_t>(nestedNullOffset));
+
+    std::array<uint32_t, 2> nullStreamOffsets{rootNullOffset, nestedNullOffset};
+    auto streamLoaders = tablet->load(stripeIdentifier, nullStreamOffsets);
+    ASSERT_EQ(2, streamLoaders.size());
+
+    // All-non-null Row null streams are omitted on the wire. The root null
+    // stream is omitted only when the root is logically all-non-null (no nulls,
+    // or top-level nulls ignored); otherwise it is written and round-trips the
+    // top-level nulls. The always-non-null nested row null stream is omitted.
+    if (testCase.expectRootNullStreamOmitted) {
+      EXPECT_EQ(0, streamSizes[rootNullOffset]);
+      EXPECT_EQ(nullptr, streamLoaders[0]);
+    } else {
+      EXPECT_GT(streamSizes[rootNullOffset], 0);
+      EXPECT_NE(nullptr, streamLoaders[0]);
+    }
+    EXPECT_EQ(0, streamSizes[nestedNullOffset]);
+    EXPECT_EQ(nullptr, streamLoaders[1]);
+
+    velox::VectorPtr result;
+    ASSERT_TRUE(reader.next(testCase.expected->size(), result));
+    ASSERT_EQ(result->size(), testCase.expected->size());
+    for (velox::vector_size_t i = 0; i < testCase.expected->size(); ++i) {
+      ASSERT_TRUE(result->equalValueAt(testCase.expected.get(), i, i));
+    }
+  }
+}
+
 TEST_F(VeloxWriterTest, chunkedStreamsRowAllNullsNoChunks) {
   velox::test::VectorMaker vectorMaker{leafPool_.get()};
 


### PR DESCRIPTION
Summary:

Adds null-capable `kSerialization` support for Row/FlatMap null streams by writing a per-batch null-barrier flag. Batches that carry real Row/FlatMap nulls are decoded one batch at a time so null streams act as barriers, while batches without the flag are concatenated and decoded as runs. The serializer omits all-true Row/FlatMap null streams and reconstructs them on read, rejects real Row/FlatMap nulls for read-only legacy formats, and keeps scalar, array, map inline nulls plus FlatMap in-map presence streams on the dense batch path. Projection now tracks Row/FlatMap null stream positions so projected output sets the barrier only when a selected physical stream needs it, including nested rows and FlatMap value rows. The deserializer initializes each batch reader once, keeps readers alive for tablet chunk-stripping buffers, and reuses the same segment append path for single-batch, run, and barrier decode.

Reviewed By: HuamengJiang

Differential Revision: D108535508
