### PR TITLE
misc: Bump Velox version in Nimble (#891)

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ Nimble integrates Velox as a Git submodule, referencing a specific commit of the
 Velox repository. The Velox badge at the top of this README shows the current
 commit and how far behind it is from Velox main.
 
-[See what changed since the current Velox commit.](https://github.com/facebookincubator/velox/compare/232ab605bad3cd471cd64d0b1a95630341e607cb...main)
+[See what changed since the current Velox commit.](https://github.com/facebookincubator/velox/compare/7096ab48de8734b39c3d3eb7ba8ed9ae3b5b1027...main)
 <!-- pre-commit check-velox-readme validates the SHA above matches the submodule -->
 
 Advance Velox when your changes depend on code in Velox that


### PR DESCRIPTION
Summary:

Update Nimble public TLD Velox submodule pointer to `7096ab48de8734b39c3d3eb7ba8ed9ae3b5b1027` and keep the README compare link in sync.

Reviewed By: xiaoxmeng

Differential Revision: D109177616
