### PR TITLE
fix(serializer): Avoid capturing structured binding in lambda (#892)

### DIFF
--- a/dwio/nimble/serializer/Deserializer.cpp
+++ b/dwio/nimble/serializer/Deserializer.cpp
@@ -730,8 +730,9 @@ Deserializer::Deserializer(
     // child was absent but a sibling was present.
     for (const auto& [inMapOffset, childType] : inMapChildTypes_) {
       visitValueStreamLeaves(
-          *childType, [this, inMapOffset](offset_size valueOffset) {
-            valueOffsetToInMap_[valueOffset] = inMapOffset;
+          *childType,
+          [this, _inMapOffset = inMapOffset](offset_size valueOffset) {
+            valueOffsetToInMap_[valueOffset] = _inMapOffset;
             return false;
           });
     }


### PR DESCRIPTION
Summary:

Copy the FlatMap in-map offset into a regular local variable

Differential Revision: D109318122


