### PR TITLE
feat(nimble): Cap flat-map key cardinality to prevent unbounded writer memory growth (#893)

### DIFF
--- a/dwio/nimble/velox/FieldWriter.cpp
+++ b/dwio/nimble/velox/FieldWriter.cpp
@@ -2059,6 +2059,19 @@ class FlatMapFieldWriter : public FieldWriter {
           nodeId_);
       std::scoped_lock<std::mutex> lock{context_.flatMapSchemaMutex()};
 
+      // Bound the number of distinct flat-map keys to prevent unbounded native
+      // memory growth. High-cardinality keys (e.g. BIGINT ids) are unsuitable
+      // for flat-map encoding; use a regular map or raise
+      // orc.map.flat.max.keys. A limit of 0 means unlimited. Checked under
+      // flatMapSchemaMutex_ so the size check and the allValueFields_ insertion
+      // below are atomic.
+      const auto maxFlatMapKeys = context_.maxFlatMapKeys();
+      NIMBLE_USER_CHECK(
+          maxFlatMapKeys == 0 || allValueFields_.size() < maxFlatMapKeys,
+          "Too many flatmap keys for node {}: limit is {}",
+          nodeId_,
+          maxFlatMapKeys);
+
       auto valueFieldWriter = FieldWriter::create(context_, valueType_);
       const auto& inMapDescriptor = typeBuilder_->asFlatMap().addChild(
           stringKey, valueFieldWriter->typeBuilder());
@@ -2071,7 +2084,6 @@ class FlatMapFieldWriter : public FieldWriter {
       flatFieldIt =
           allValueFields_.emplace(ownedKey, std::move(flatMapValueField)).first;
     }
-    // TODO: assert on not having too many keys?
     // Use the key stored in allValueFields_ (which points to owned memory)
     // rather than the input key (which may point to transient vector buffers).
     it = currentValueFields_

--- a/dwio/nimble/velox/FieldWriter.h
+++ b/dwio/nimble/velox/FieldWriter.h
@@ -23,6 +23,7 @@
 
 #include "dwio/nimble/common/Buffer.h"
 #include "dwio/nimble/velox/BufferGrowthPolicy.h"
+#include "dwio/nimble/velox/NimbleConfig.h"
 #include "dwio/nimble/velox/OrderedRanges.h"
 #include "dwio/nimble/velox/SchemaBuilder.h"
 #include "dwio/nimble/velox/StreamData.h"
@@ -240,6 +241,14 @@ class FieldWriterContext {
 
   inline void setIgnoreTopLevelNulls(bool value) {
     ignoreTopLevelNulls_ = value;
+  }
+
+  inline uint32_t maxFlatMapKeys() const {
+    return maxFlatMapKeys_;
+  }
+
+  inline void setMaxFlatMapKeys(uint32_t value) {
+    maxFlatMapKeys_ = value;
   }
 
   void setParallelEncoding(
@@ -486,6 +495,7 @@ class FieldWriterContext {
   folly::F14FastSet<uint32_t> deduplicatedMapNodeIds_;
   bool ignoreTopLevelNulls_{false};
   bool disableSharedStringBuffers_{false};
+  uint32_t maxFlatMapKeys_{kDefaultMaxFlatMapKeys};
 
   folly::Executor* encodeExecutor_{nullptr};
   uint32_t maxEncodeParallelism_{0};

--- a/dwio/nimble/velox/NimbleConfig.cpp
+++ b/dwio/nimble/velox/NimbleConfig.cpp
@@ -89,6 +89,11 @@ std::map<uint64_t, float> parseGrowthConfigMap(const std::string& str) {
       return parseVector<uint32_t>(val);
     });
 
+// Maximum number of distinct flat-map keys allowed per file; 0 means unlimited.
+/* static */ Config::Entry<uint32_t> Config::MAP_FLAT_MAX_KEYS(
+    "orc.map.flat.max.keys",
+    kDefaultMaxFlatMapKeys);
+
 /* static */ Config::Entry<const std::vector<uint32_t>>
     Config::DEDUPLICATED_COLS(
         "alpha.map.deduplicated.cols",

--- a/dwio/nimble/velox/NimbleConfig.h
+++ b/dwio/nimble/velox/NimbleConfig.h
@@ -21,6 +21,11 @@
 
 namespace facebook::nimble {
 
+// Default cap on the number of distinct flat-map keys per file; 0 means
+// unlimited. Shared default for Config::MAP_FLAT_MAX_KEYS,
+// VeloxWriterOptions::maxFlatMapKeys, and FieldWriterContext::maxFlatMapKeys_.
+inline constexpr uint32_t kDefaultMaxFlatMapKeys = 30000;
+
 class Config : public velox::config::ConfigBase {
  public:
   template <typename T>
@@ -28,6 +33,8 @@ class Config : public velox::config::ConfigBase {
 
   static Entry<bool> FLATTEN_MAP;
   static Entry<const std::vector<uint32_t>> MAP_FLAT_COLS;
+  // @lint-ignore CLANGTIDY facebook-hte-NonPodStaticDeclaration
+  static Entry<uint32_t> MAP_FLAT_MAX_KEYS;
   static Entry<const std::vector<uint32_t>> BATCH_REUSE_COLS;
   static Entry<const std::vector<uint32_t>> DEDUPLICATED_COLS;
   static Entry<uint64_t> RAW_STRIPE_SIZE;

--- a/dwio/nimble/velox/VeloxWriter.cpp
+++ b/dwio/nimble/velox/VeloxWriter.cpp
@@ -65,6 +65,7 @@ class WriterContext : public FieldWriterContext {
         : this->options_.stringBufferGrowthPolicyFactory();
     ignoreTopLevelNulls_ = options_.ignoreTopLevelNulls;
     disableSharedStringBuffers_ = options_.disableSharedStringBuffers;
+    maxFlatMapKeys_ = options_.maxFlatMapKeys;
     if (this->options_.encodingExecutor &&
         this->options_.maxEncodeParallelism > 0) {
       setParallelEncoding(

--- a/dwio/nimble/velox/VeloxWriterOptions.h
+++ b/dwio/nimble/velox/VeloxWriterOptions.h
@@ -22,6 +22,7 @@
 #include "dwio/nimble/velox/BufferGrowthPolicy.h"
 #include "dwio/nimble/velox/EncodingLayoutTree.h"
 #include "dwio/nimble/velox/FlushPolicy.h"
+#include "dwio/nimble/velox/NimbleConfig.h"
 #include "folly/container/F14Map.h"
 #include "folly/container/F14Set.h"
 
@@ -100,6 +101,11 @@ struct VeloxWriterOptions {
   /// identical schemas regardless of data arrival order. Unknown keys not in
   /// the set will cause an error during writing.
   folly::F14FastMap<std::string, std::set<std::string>> flatMapColumns;
+
+  // Maximum number of distinct flat-map keys allowed per file; 0 means
+  // unlimited. Writing fails when exceeded, bounding the per-key native memory
+  // the flat-map writer holds.
+  uint32_t maxFlatMapKeys{kDefaultMaxFlatMapKeys};
 
   /// Per-column string-keyed attributes to stamp onto the NIMBLE schema.
   // Keyed by a dotted path of `RowType` child names that resolves to a node

--- a/dwio/nimble/velox/tests/VeloxWriterTest.cpp
+++ b/dwio/nimble/velox/tests/VeloxWriterTest.cpp
@@ -514,6 +514,124 @@ TEST_F(
   writer.close();
 }
 
+// A single write whose map has more distinct keys than maxFlatMapKeys fails.
+TEST_F(VeloxWriterTest, FlatMapKeyLimitExceededInSingleWriteThrows) {
+  velox::test::VectorMaker vectorMaker{leafPool_.get()};
+  // One row with 10 distinct BIGINT keys against a limit of 4.
+  auto vector = vectorMaker.rowVector(
+      {"flatmap"},
+      {vectorMaker.mapVector<int64_t, int64_t>(
+          /* size */
+          1,
+          /* sizeAt */ [](auto) { return 10; },
+          /* keyAt */ [](auto, auto mapIndex) -> int64_t { return mapIndex; },
+          /* valueAt */ [](auto, auto mapIndex) -> int64_t { return mapIndex; },
+          /* isNullAt */ [](auto) { return false; })});
+
+  std::string file;
+  auto writeFile = std::make_unique<velox::InMemoryWriteFile>(&file);
+  nimble::VeloxWriter writer(
+      vector->type(),
+      std::move(writeFile),
+      *rootPool_,
+      {.flatMapColumns = {{"flatmap", {}}}, .maxFlatMapKeys = 4});
+
+  NIMBLE_ASSERT_USER_THROW(
+      writer.write(vector), "Too many flatmap keys for node");
+}
+
+// A map whose distinct key count is at/under maxFlatMapKeys writes fine.
+TEST_F(VeloxWriterTest, FlatMapKeyLimitWithinLimitSucceeds) {
+  velox::test::VectorMaker vectorMaker{leafPool_.get()};
+  // 5 distinct keys, well under the limit of 100.
+  auto vector = vectorMaker.rowVector(
+      {"flatmap"},
+      {vectorMaker.mapVector<int64_t, int64_t>(
+          /* size */
+          10,
+          /* sizeAt */ [](auto) { return 5; },
+          /* keyAt */ [](auto, auto mapIndex) -> int64_t { return mapIndex; },
+          /* valueAt */
+          [](auto row, auto mapIndex) -> int64_t {
+            return row * 10 + mapIndex;
+          },
+          /* isNullAt */ [](auto) { return false; })});
+
+  std::string file;
+  auto writeFile = std::make_unique<velox::InMemoryWriteFile>(&file);
+  nimble::VeloxWriter writer(
+      vector->type(),
+      std::move(writeFile),
+      *rootPool_,
+      {.flatMapColumns = {{"flatmap", {}}}, .maxFlatMapKeys = 100});
+
+  EXPECT_NO_THROW(writer.write(vector));
+  EXPECT_NO_THROW(writer.close());
+}
+
+// The limit is file-wide: distinct keys accumulate across write() calls even
+// when no single write exceeds it.
+TEST_F(VeloxWriterTest, FlatMapKeyLimitAccumulatesAcrossWrites) {
+  velox::test::VectorMaker vectorMaker{leafPool_.get()};
+  // Each batch has 8 distinct keys (< limit 10), but the two batches use
+  // disjoint key ranges, so the file-wide count (16) exceeds the limit.
+  auto makeBatch = [&](int64_t keyOffset) {
+    return vectorMaker.rowVector(
+        {"flatmap"},
+        {vectorMaker.mapVector<int64_t, int64_t>(
+            /* size */
+            1,
+            /* sizeAt */ [](auto) { return 8; },
+            /* keyAt */
+            [keyOffset](auto, auto mapIndex) -> int64_t {
+              return keyOffset + mapIndex;
+            },
+            /* valueAt */
+            [](auto, auto mapIndex) -> int64_t { return mapIndex; },
+            /* isNullAt */ [](auto) { return false; })});
+  };
+
+  std::string file;
+  auto writeFile = std::make_unique<velox::InMemoryWriteFile>(&file);
+  nimble::VeloxWriter writer(
+      makeBatch(0)->type(),
+      std::move(writeFile),
+      *rootPool_,
+      {.flatMapColumns = {{"flatmap", {}}}, .maxFlatMapKeys = 10});
+
+  // First batch: 8 distinct keys, under the limit.
+  EXPECT_NO_THROW(writer.write(makeBatch(0)));
+  // Second batch: 8 new keys push the file-wide total to 16, over the limit.
+  NIMBLE_ASSERT_USER_THROW(
+      writer.write(makeBatch(100)), "Too many flatmap keys for node");
+}
+
+// A maxFlatMapKeys of 0 disables the cap (unlimited keys).
+TEST_F(VeloxWriterTest, FlatMapKeyLimitZeroMeansUnlimited) {
+  velox::test::VectorMaker vectorMaker{leafPool_.get()};
+  // 50 distinct keys, which would exceed any small positive limit.
+  auto vector = vectorMaker.rowVector(
+      {"flatmap"},
+      {vectorMaker.mapVector<int64_t, int64_t>(
+          /* size */
+          1,
+          /* sizeAt */ [](auto) { return 50; },
+          /* keyAt */ [](auto, auto mapIndex) -> int64_t { return mapIndex; },
+          /* valueAt */ [](auto, auto mapIndex) -> int64_t { return mapIndex; },
+          /* isNullAt */ [](auto) { return false; })});
+
+  std::string file;
+  auto writeFile = std::make_unique<velox::InMemoryWriteFile>(&file);
+  nimble::VeloxWriter writer(
+      vector->type(),
+      std::move(writeFile),
+      *rootPool_,
+      {.flatMapColumns = {{"flatmap", {}}}, .maxFlatMapKeys = 0});
+
+  EXPECT_NO_THROW(writer.write(vector));
+  EXPECT_NO_THROW(writer.close());
+}
+
 TEST_F(VeloxWriterTest, featureReorderingStreamCollocation) {
   velox::test::VectorMaker vectorMaker{leafPool_.get()};
 


### PR DESCRIPTION
Summary:

The Nimble FlatMapFieldWriter places no limit on the number of distinct
flat-map keys. For a MAP column written with orc.flatten.map=true and
high-cardinality keys (e.g. BIGINT ids), each distinct key allocates per-key
native streams that are retained for the whole file in allValueFields_. With
millions of keys a single writer can grow to tens of GB of native memory and
be OOM-killed mid-write, before any flush policy can intervene.

This adds a configurable per-file cap on the number of distinct flat-map keys,
exposed via the orc.map.flat.max.keys serde param (default 30000, matching the
DWRF writer). When the cap is exceeded the writer fails fast with a clear
NimbleUserError instead of growing without bound. A value of 0 disables the cap
(unlimited).

The check is performed on allValueFields_ (the file-wide owner of the per-key
value writers) under flatMapSchemaMutex_, so the check and the key insertion
are atomic and the cap also bounds keys that accumulate across multiple write()
calls / stripes. Unlike the DWRF writer, whose cap is per-stripe (per-key state
is released every stripe), Nimble's flat-map schema is file-global and cannot
release per-key state mid-file, so the cap is per-file; ~30000 keys corresponds
to roughly 1 GB of writer memory.

Config plumbing follows the existing flat-map path:
orc.map.flat.max.keys -> nimble::Config::MAP_FLAT_MAX_KEYS ->
VeloxWriterOptions::maxFlatMapKeys -> FieldWriterContext -> FlatMapFieldWriter.

Reviewed By: HuamengJiang

Differential Revision: D109083077


