### PR TITLE
fix(tablet): Handle missing `uncompressed_size` in ChunkIndex and ClusterIndex readers

### DIFF
--- a/dwio/nimble/index/ChunkIndex.cpp
+++ b/dwio/nimble/index/ChunkIndex.cpp
@@ -35,11 +35,13 @@ std::unique_ptr<ChunkIndex> ChunkIndex::create(Section indexSection) {
   groupSections.reserve(indexes->size());
   for (uint32_t i = 0; i < indexes->size(); ++i) {
     const auto* ms = indexes->Get(i);
+    const auto rawUncompressedSize = ms->uncompressed_size();
     groupSections.emplace_back(
         ms->offset(),
         ms->size(),
         static_cast<CompressionType>(ms->compression_type()),
-        ms->uncompressed_size());
+        rawUncompressedSize > 0 ? std::optional<uint32_t>(rawUncompressedSize)
+                                : std::nullopt);
   }
 
   return std::unique_ptr<ChunkIndex>(

--- a/dwio/nimble/index/ClusterIndex.cpp
+++ b/dwio/nimble/index/ClusterIndex.cpp
@@ -442,11 +442,13 @@ MetadataSection ClusterIndex::partitionSection(uint32_t partitionId) const {
   const auto* indexPartitions = indexRoot_->index_partitions();
   NIMBLE_CHECK_NOT_NULL(indexPartitions);
   const auto* metadata = indexPartitions->Get(partitionId);
+  const auto rawUncompressedSize = metadata->uncompressed_size();
   return MetadataSection{
       metadata->offset(),
       metadata->size(),
       static_cast<CompressionType>(metadata->compression_type()),
-      metadata->uncompressed_size()};
+      rawUncompressedSize > 0 ? std::optional<uint32_t>(rawUncompressedSize)
+                              : std::nullopt};
 }
 
 ClusterIndex::IndexPartition::IndexPartition(

--- a/dwio/nimble/tablet/tests/ChunkIndexWriterTest.cpp
+++ b/dwio/nimble/tablet/tests/ChunkIndexWriterTest.cpp
@@ -625,19 +625,27 @@ TEST_F(ChunkIndexWriterTest, uncompressedSizeRoundtrip) {
   }
 }
 
-// Verifies that index metadata without uncompressed_size is rejected.
-// Index is not in production yet, so all files must have the field set.
-TEST_F(ChunkIndexWriterTest, missingUncompressedSizeRejected) {
+// Verifies that index metadata without uncompressed_size (written before
+// D108464890) is handled gracefully: the reader returns nullopt instead of
+// throwing, restoring backward compatibility with old files.
+TEST_F(ChunkIndexWriterTest, missingUncompressedSizeBackwardCompat) {
   flatbuffers::FlatBufferBuilder builder(256);
 
+  // Simulate a pre-D108464890 FlatBuffer: no uncompressed_size field set.
   auto section0 = serialization::CreateMetadataSection(
       builder,
       /*offset=*/100,
       /*size=*/200,
       serialization::CompressionType_Zstd);
 
+  auto section1 = serialization::CreateMetadataSection(
+      builder,
+      /*offset=*/300,
+      /*size=*/150,
+      serialization::CompressionType_Uncompressed);
+
   std::vector<flatbuffers::Offset<serialization::MetadataSection>> sections = {
-      section0};
+      section0, section1};
   auto stripeIndexes = builder.CreateVector(sections);
   builder.Finish(serialization::CreateChunkIndex(builder, stripeIndexes));
 
@@ -651,8 +659,20 @@ TEST_F(ChunkIndexWriterTest, missingUncompressedSizeRejected) {
       MetadataBuffer::decompress(
           std::move(rootBuffer), CompressionType::Uncompressed, pool_.get()))};
 
-  NIMBLE_ASSERT_THROW(
-      index::ChunkIndex::create(std::move(rootSection)), "Uncompressed size");
+  auto chunkIndex = index::ChunkIndex::create(std::move(rootSection));
+  ASSERT_NE(chunkIndex, nullptr);
+  ASSERT_EQ(chunkIndex->numGroups(), 2);
+
+  const auto& zstdSection = chunkIndex->groupMetadata(0);
+  EXPECT_EQ(zstdSection.compressionType(), CompressionType::Zstd);
+  EXPECT_FALSE(zstdSection.uncompressedSize().has_value());
+  EXPECT_EQ(zstdSection.size(), 200);
+
+  const auto& uncompressedSection = chunkIndex->groupMetadata(1);
+  EXPECT_EQ(
+      uncompressedSection.compressionType(), CompressionType::Uncompressed);
+  EXPECT_FALSE(uncompressedSection.uncompressedSize().has_value());
+  EXPECT_EQ(uncompressedSection.size(), 150);
 }
 
 // Verifies that uncompressed sections get uncompressedSize == size in the


### PR DESCRIPTION
Summary:
CONTEXT: D108464890 added `uncompressed_size` serialization to ChunkIndex and ClusterIndex FlatBuffers, but the reader blindly passes `ms->uncompressed_size()` to `MetadataSection`. FlatBuffers returns 0 for `uint32` fields that were never serialized, so files written before D108464890 produce `uncompressed_size = 0`. The `MetadataSection` constructor then fails the invariant check: `(0 vs. 25908) Uncompressed size must equal size for uncompressed data`.

WHAT: Treat `uncompressed_size == 0` as "field not present" by converting to `std::nullopt`. A real metadata section always has size > 0, so 0 is an unambiguous sentinel for missing data. This restores backward compatibility with pre-D108464890 files.

Reviewed By: xiaoxmeng

Differential Revision: D109379740


