### PR TITLE
Reuse OpenZL Compressor and contexts across compression calls

### DIFF
--- a/dwio/nimble/common/Constants.h
+++ b/dwio/nimble/common/Constants.h
@@ -25,6 +25,7 @@ namespace facebook::nimble {
 constexpr uint32_t kMetaInternalMinCompressionSize{40};
 constexpr uint32_t kZstdMinCompressionSize{25};
 constexpr uint32_t kLz4MinCompressionSize{12};
+constexpr uint32_t kOpenZLMinCompressionSize{40};
 
 /// Default options for the ChunkFlushPolicy.
 /// Threshold to trigger chunking to relieve memory pressure

--- a/dwio/nimble/common/Types.cpp
+++ b/dwio/nimble/common/Types.cpp
@@ -114,6 +114,8 @@ std::string toString(CompressionType compressionType) {
       return "MetaInternal";
     case CompressionType::Lz4:
       return "Lz4";
+    case CompressionType::OpenZL:
+      return "OpenZL";
     default:
       return fmt::format(
           "Unknown compression type: {}",

--- a/dwio/nimble/common/Types.h
+++ b/dwio/nimble/common/Types.h
@@ -159,6 +159,7 @@ enum class CompressionType : uint8_t {
   Zstd = 1,
   MetaInternal = 2,
   Lz4 = 3,
+  OpenZL = 4,
 };
 
 std::string toString(CompressionType compressionType);

--- a/dwio/nimble/compression/CMakeLists.txt
+++ b/dwio/nimble/compression/CMakeLists.txt
@@ -15,7 +15,15 @@ add_library(
   nimble_compression
   Compression.cpp
   Lz4Compressor.cpp
+  OpenZLCompressor.cpp
   ZstdCompressor.cpp
 )
 
-target_link_libraries(nimble_compression nimble_common Folly::folly lz4)
+target_link_libraries(
+  nimble_compression
+  nimble_common
+  Folly::folly
+  lz4
+  openzl
+  openzl_cpp
+)

--- a/dwio/nimble/compression/Compression.cpp
+++ b/dwio/nimble/compression/Compression.cpp
@@ -16,6 +16,7 @@
 #include "dwio/nimble/compression/Compression.h"
 #include "dwio/nimble/common/Exceptions.h"
 #include "dwio/nimble/compression/Lz4Compressor.h"
+#include "dwio/nimble/compression/OpenZLCompressor.h"
 #include "dwio/nimble/compression/ZstdCompressor.h"
 #include "dwio/nimble/encodings/common/EncodingPrimitives.h"
 
@@ -29,11 +30,13 @@ namespace {
 
 struct CompressorRegistry {
   CompressorRegistry() {
-    compressors.reserve(3);
+    compressors.reserve(4);
     compressors.emplace(
         CompressionType::Zstd, std::make_unique<ZstdCompressor>());
     compressors.emplace(
         CompressionType::Lz4, std::make_unique<Lz4Compressor>());
+    compressors.emplace(
+        CompressionType::OpenZL, std::make_unique<OpenZLCompressor>());
 #ifndef DISABLE_META_INTERNAL_COMPRESSOR
     compressors.emplace(
         CompressionType::MetaInternal,

--- a/dwio/nimble/compression/CompressionPolicy.h
+++ b/dwio/nimble/compression/CompressionPolicy.h
@@ -90,10 +90,17 @@ struct MetaInternalCompressionParameters {
   MetaInternalCompressionKey compressionKey;
 };
 
+struct OpenZLCompressionParameters {
+  int compressionLevel = 6;
+  int decompressionLevel = 3;
+  int formatVersion = 25; // current prod max, as of 2026-06-10
+};
+
 struct CompressionParameters {
   ZstdCompressionParameters zstd{};
   Lz4CompressionParameters lz4{};
   MetaInternalCompressionParameters metaInternal{};
+  OpenZLCompressionParameters openzl{};
 };
 
 struct CompressionInformation {

--- a/dwio/nimble/compression/OpenZLCompressor.cpp
+++ b/dwio/nimble/compression/OpenZLCompressor.cpp
@@ -232,14 +232,10 @@ class SelectRangePack : public openzl::Selector {
   openzl::GraphID noRangePack_;
 };
 
-// Registers the chunk segmenter on the raw compressor and wraps @p innerGraph
-// with it, threading the element byte width through as a local parameter. This
-// is the only place the C API is used directly, since segmenters have no C++
-// wrapper.
-openzl::GraphID wrapWithDefaultSegmenter(
-    ZL_Compressor* cgraph,
-    openzl::GraphID innerGraph,
-    size_t elementByteWidth) {
+// Registers the base multi-chunk segmenter, without the per-width element-width
+// parameter. The same base is reused for every element width. This is the only
+// place the C API is used directly, since segmenters have no C++ wrapper.
+openzl::GraphID registerDefaultSegmenterBase(ZL_Compressor* cgraph) {
   ZL_Type inputType = ZL_Type_serial;
   ZL_SegmenterDesc desc = {
       .name = "!nimble.default_segmenter",
@@ -251,9 +247,17 @@ openzl::GraphID wrapWithDefaultSegmenter(
       .numCustomGraphs = 0,
       .localParams = {},
   };
-  ZL_GraphID const segmenterBase =
-      ZL_Compressor_registerSegmenter(cgraph, &desc);
+  return ZL_Compressor_registerSegmenter(cgraph, &desc);
+}
 
+// Wraps @p innerGraph with the pre-registered @p segmenterBase, threading the
+// element byte width through as a local parameter so the segmenter can align
+// chunks to element boundaries.
+openzl::GraphID wrapWithSegmenter(
+    ZL_Compressor* cgraph,
+    openzl::GraphID segmenterBase,
+    openzl::GraphID innerGraph,
+    size_t elementByteWidth) {
   ZL_IntParam intParams[] = {{
       .paramId = kNimbleElementByteWidthParamId,
       .paramValue = static_cast<int>(elementByteWidth),
@@ -270,78 +274,142 @@ openzl::GraphID wrapWithDefaultSegmenter(
   return ZL_Compressor_registerParameterizedGraph(cgraph, &segGraphDesc);
 }
 
-// Builds the default numeric graph:
-//   serial -> interpret-as-LE(width) -> range-pack? -> tokenize?+delta -> lz
-// Wrapped by the multi-chunk segmenter.
-// This decision-making is a default "should-be-good-enough" pipeline that can
-// be modified or replaced to fit to your specific use case.
-openzl::GraphID makeNumericGraph(
-    openzl::Compressor& compressor,
-    bool isFloat,
-    size_t elementBitWidth,
-    int formatVersion) {
-  const size_t elementByteWidth = elementBitWidth / 8;
+// Width-independent selectors/nodes and the base segmenter. These are
+// registered once and reused by every per-DataType graph.
+struct SharedGraphs {
+  openzl::GraphID lz;
+  openzl::GraphID tokenize;
+  openzl::GraphID segmenterBase;
+};
 
+// Registers the width-independent portion of the numeric pipeline once:
+//   lz       = select(field-lz | zstd)
+//   deltaLz  = delta -> lz
+//   tokenize = tokenize -> (deltaLz | lz)
+SharedGraphs registerSharedGraphs(openzl::Compressor& compressor) {
   const openzl::GraphID fieldLz = openzl::graphs::FieldLz{}(compressor);
   const openzl::GraphID lz = openzl::Selector::registerSelector(
       compressor, std::make_shared<SelectLz>(fieldLz));
-
   const openzl::GraphID deltaLz = openzl::nodes::DeltaInt{}(compressor, lz);
   const openzl::GraphID tokenize =
       openzl::nodes::TokenizeNumeric{/* sort */ true}(compressor, deltaLz, lz);
-
-  const openzl::GraphID tokenizeOrNot = openzl::Selector::registerSelector(
-      compressor, std::make_shared<SelectTokenize>(tokenize, lz, isFloat));
-
-  const openzl::GraphID range =
-      openzl::nodes::RangePack{}(compressor, tokenizeOrNot);
-  const openzl::GraphID rangeOrNot = openzl::Selector::registerSelector(
-      compressor, std::make_shared<SelectRangePack>(range, tokenizeOrNot));
-
-  openzl::nodes::ConvertSerialToNumLE toNumeric{
-      static_cast<int>(elementByteWidth)};
-  const openzl::GraphID innerGraph = toNumeric(compressor, rangeOrNot);
-  return wrapWithDefaultSegmenter(
-      compressor.get(), innerGraph, elementByteWidth);
+  return {
+      .lz = lz,
+      .tokenize = tokenize,
+      .segmenterBase = registerDefaultSegmenterBase(compressor.get()),
+  };
 }
 
-// Maps the nimble DataType to the appropriate numeric graph. Types without
-// a dedicated numeric pipeline fall back to a plain zstd graph (still a valid
-// OpenZL frame).
-openzl::GraphID createGraph(
+// Registers the int- or float-specific tail of the numeric graph, reusing the
+// shared graphs. The tail differs only by the tokenize cardinality heuristic
+// (int vs float), so it is registered once per variant rather than per width:
+//   tokenizeOrNot = select(tokenize | lz)
+//   rangeOrNot    = select(range-pack -> tokenizeOrNot | tokenizeOrNot)
+openzl::GraphID registerNumericTail(
     openzl::Compressor& compressor,
-    DataType dataType,
-    int formatVersion) {
-  switch (dataType) {
-    case DataType::Int8:
-    case DataType::Uint8:
-      return makeNumericGraph(
-          compressor, /* isFloat */ false, 8, formatVersion);
-    case DataType::Int16:
-    case DataType::Uint16:
-      return makeNumericGraph(
-          compressor, /* isFloat */ false, 16, formatVersion);
-    case DataType::Int32:
-    case DataType::Uint32:
-      return makeNumericGraph(
-          compressor, /* isFloat */ false, 32, formatVersion);
-    case DataType::Int64:
-    case DataType::Uint64:
-      return makeNumericGraph(
-          compressor, /* isFloat */ false, 64, formatVersion);
-    case DataType::Float:
-      return makeNumericGraph(
-          compressor, /* isFloat */ true, 32, formatVersion);
-    case DataType::Double:
-    case DataType::Bool:
-    case DataType::String:
-    case DataType::Undefined:
-    default:
-      return ZL_GRAPH_ZSTD;
-  }
+    const SharedGraphs& shared,
+    bool isFloat) {
+  const openzl::GraphID tokenizeOrNot = openzl::Selector::registerSelector(
+      compressor,
+      std::make_shared<SelectTokenize>(shared.tokenize, shared.lz, isFloat));
+  const openzl::GraphID range =
+      openzl::nodes::RangePack{}(compressor, tokenizeOrNot);
+  return openzl::Selector::registerSelector(
+      compressor, std::make_shared<SelectRangePack>(range, tokenizeOrNot));
+}
+
+// Builds the per-width entry graph: interpret serial bytes as little-endian
+// numerics of the given width, route them through the shared @p tail, and wrap
+// the whole thing in the multi-chunk segmenter.
+//   serial -> interpret-as-LE(width) -> tail -> ... -> lz
+openzl::GraphID buildNumericGraph(
+    openzl::Compressor& compressor,
+    const SharedGraphs& shared,
+    openzl::GraphID tail,
+    size_t elementBitWidth) {
+  const size_t elementByteWidth = elementBitWidth / 8;
+  openzl::nodes::ConvertSerialToNumLE toNumeric{
+      static_cast<int>(elementByteWidth)};
+  const openzl::GraphID innerGraph = toNumeric(compressor, tail);
+  return wrapWithSegmenter(
+      compressor.get(), shared.segmenterBase, innerGraph, elementByteWidth);
+}
+
+// Reuses one OpenZL decompression context per thread, mirroring
+// ZstdCompressor::getThreadLocalDCtx, to avoid per-call context allocation.
+openzl::DCtx& getThreadLocalDCtx() {
+  static thread_local openzl::DCtx dctx;
+  return dctx;
 }
 
 } // namespace
+
+// Builds and owns the OpenZL Compressor and its per-DataType graphs. The
+// width-independent selectors/nodes and the base segmenter are registered once
+// and shared; only the per-width entry (serial->numeric conversion + segmenter)
+// is registered per DataType. The Compressor is validated and shared read-only
+// so each compress() call only needs a CCtx that refs it.
+struct OpenZLCompressor::GraphCache {
+  openzl::Compressor compressor;
+  openzl::GraphID int8Graph;
+  openzl::GraphID int16Graph;
+  openzl::GraphID int32Graph;
+  openzl::GraphID int64Graph;
+  openzl::GraphID floatGraph;
+
+  GraphCache() {
+    const SharedGraphs shared = registerSharedGraphs(compressor);
+    const openzl::GraphID intTail =
+        registerNumericTail(compressor, shared, /* isFloat */ false);
+    const openzl::GraphID floatTail =
+        registerNumericTail(compressor, shared, /* isFloat */ true);
+
+    int8Graph = buildNumericGraph(compressor, shared, intTail, 8);
+    int16Graph = buildNumericGraph(compressor, shared, intTail, 16);
+    int32Graph = buildNumericGraph(compressor, shared, intTail, 32);
+    int64Graph = buildNumericGraph(compressor, shared, intTail, 64);
+    floatGraph = buildNumericGraph(compressor, shared, floatTail, 32);
+    // A starting graph must be set before the Compressor can be reffed by a
+    // CCtx; this also validates the Compressor once, single-threaded. Each
+    // compress() call overrides the starting graph per DataType.
+    compressor.selectStartingGraph(ZL_GRAPH_ZSTD);
+  }
+
+  // Maps the nimble DataType to its numeric graph. Types without a dedicated
+  // numeric pipeline fall back to a plain zstd graph (still a valid OpenZL
+  // frame).
+  // The numeric decision-making is a default "should-be-good-enough" pipeline
+  // that can be modified or replaced to fit to your specific use case.
+  openzl::GraphID graphFor(DataType dataType) const {
+    switch (dataType) {
+      case DataType::Int8:
+      case DataType::Uint8:
+        return int8Graph;
+      case DataType::Int16:
+      case DataType::Uint16:
+        return int16Graph;
+      case DataType::Int32:
+      case DataType::Uint32:
+        return int32Graph;
+      case DataType::Int64:
+      case DataType::Uint64:
+        return int64Graph;
+      case DataType::Float:
+        return floatGraph;
+      case DataType::Double:
+      case DataType::Bool:
+      case DataType::String:
+      case DataType::Undefined:
+      default:
+        return ZL_GRAPH_ZSTD;
+    }
+  }
+};
+
+OpenZLCompressor::OpenZLCompressor()
+    : graphCache_{std::make_unique<GraphCache>()} {}
+
+OpenZLCompressor::~OpenZLCompressor() = default;
 
 CompressionResult OpenZLCompressor::compress(
     velox::memory::MemoryPool& pool,
@@ -351,17 +419,17 @@ CompressionResult OpenZLCompressor::compress(
     const CompressionPolicy& compressionPolicy) {
   const auto parameters = compressionPolicy.compression().parameters.openzl;
 
-  openzl::Compressor compressor;
-  compressor.selectStartingGraph(
-      createGraph(compressor, dataType, parameters.formatVersion));
-
   openzl::CCtx cctx;
   cctx.setParameter(
       openzl::CParam::CompressionLevel, parameters.compressionLevel);
   cctx.setParameter(
       openzl::CParam::DecompressionLevel, parameters.decompressionLevel);
   cctx.setParameter(openzl::CParam::FormatVersion, parameters.formatVersion);
-  cctx.refCompressor(compressor);
+  // Ref the prebuilt, shared Compressor and pick the per-DataType starting
+  // graph. This refs the Compressor read-only; all per-call state lives in the
+  // CCtx, so the shared Compressor is safe to use from multiple threads.
+  cctx.selectStartingGraph(
+      graphCache_->compressor, graphCache_->graphFor(dataType));
 
   Vector<char> buffer{&pool, openzl::compressBound(data.size())};
   const size_t compressedSize =
@@ -388,7 +456,7 @@ velox::BufferPtr OpenZLCompressor::uncompress(
     const DataType /* dataType */,
     std::string_view data,
     velox::BufferPool* bufferPool) {
-  openzl::DCtx dctx;
+  openzl::DCtx& dctx = getThreadLocalDCtx();
   const size_t uncompressedSize =
       dctx.unwrap(ZL_getDecompressedSize(data.data(), data.size()));
   auto buffer = allocateBuffer(pool, bufferPool, uncompressedSize);

--- a/dwio/nimble/compression/OpenZLCompressor.cpp
+++ b/dwio/nimble/compression/OpenZLCompressor.cpp
@@ -1,0 +1,418 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "dwio/nimble/compression/OpenZLCompressor.h"
+
+#include <algorithm>
+#include <memory>
+#include <optional>
+
+#include "dwio/nimble/common/Exceptions.h"
+
+#include "openzl/cpp/CCtx.hpp"
+#include "openzl/cpp/CParam.hpp"
+#include "openzl/cpp/Codecs.hpp"
+#include "openzl/cpp/Compressor.hpp"
+#include "openzl/cpp/DCtx.hpp"
+#include "openzl/cpp/Input.hpp"
+#include "openzl/cpp/Selector.hpp"
+#include "openzl/cpp/Type.hpp"
+
+#include "openzl/zl_compressor.h"
+#include "openzl/zl_data.h"
+#include "openzl/zl_decompress.h"
+#include "openzl/zl_errors.h"
+#include "openzl/zl_localParams.h"
+#include "openzl/zl_segmenter.h"
+#include "openzl/zl_version.h"
+
+#include "openzl/common/assertion.h"
+#include "openzl/shared/bits.h"
+#include "openzl/shared/estimate.h"
+#include "openzl/shared/numeric_operations.h"
+
+namespace facebook::nimble {
+namespace {
+
+// Local parameter ID for element byte width, consumed by the chunk segmenter.
+constexpr int kNimbleElementByteWidthParamId = 1;
+// Target chunk size: ~16MB.
+constexpr size_t kDefaultChunkByteSizeTarget = 16 << 20;
+
+// Multi-chunk segmenter. It splits the serial input into
+// ~16MB chunks (aligned to element width) and routes each through the inner
+// numeric graph. There is no C++ wrapper for segmenters, so this is registered
+// via the C API.
+ZL_Report defaultSegmenter(ZL_Segmenter* sctx) {
+  ZL_RESULT_DECLARE_SCOPE_REPORT(sctx);
+
+  size_t const numInputs = ZL_Segmenter_numInputs(sctx);
+  ZL_ERR_IF_NE(numInputs, 1, node_invalid_input);
+
+  const ZL_Input* const input = ZL_Segmenter_getInput(sctx, 0);
+  ZL_ASSERT_NN(input);
+  size_t const totalBytes = ZL_Input_contentSize(input);
+
+  if (totalBytes == 0) {
+    ZL_ERR_IF_ERR(ZL_Segmenter_processChunk(
+        sctx, &totalBytes, 1, ZL_GRAPH_STORE, nullptr));
+    return ZL_returnSuccess();
+  }
+
+  ZL_GraphIDList const customGraphs = ZL_Segmenter_getCustomGraphs(sctx);
+  ZL_ASSERT_EQ(customGraphs.nbGraphIDs, 1);
+  ZL_GraphID const innerGraph = customGraphs.graphids[0];
+
+  ZL_IntParam const eltWidthParam =
+      ZL_Segmenter_getLocalIntParam(sctx, kNimbleElementByteWidthParamId);
+  ZL_ERR_IF_EQ(
+      eltWidthParam.paramId, ZL_LP_INVALID_PARAMID, node_invalid_input);
+  size_t const eltWidth = (size_t)eltWidthParam.paramValue;
+
+  size_t const chunkTarget =
+      (kDefaultChunkByteSizeTarget / eltWidth) * eltWidth;
+
+  size_t remaining = totalBytes;
+  while (remaining > 0) {
+    size_t chunkSize = (remaining > chunkTarget) ? chunkTarget : remaining;
+    ZL_ERR_IF_ERR(
+        ZL_Segmenter_processChunk(sctx, &chunkSize, 1, innerGraph, nullptr));
+    remaining -= chunkSize;
+  }
+  return ZL_returnSuccess();
+}
+
+// Decides if a tokenize transform can and should be used on @p input. It
+// calculates an upper bound on the size of tokenization itself (size of
+// alphabet + size of indices) and compares it to the original size times a
+// threshold multiplier. The multiplier differs for floats and ints.
+bool shouldTokenize(
+    const openzl::Input& input,
+    int compressionLevel,
+    bool isFloat) {
+  auto const eltWidth = input.eltWidth();
+  auto const nbElts = input.numElts();
+  auto const src = input.ptr();
+  auto const srcSize = eltWidth * nbElts;
+
+  if (compressionLevel == 1 && eltWidth == 8) {
+    // Disable tokenization for level 1 and 64-bit integers because it is
+    // quite slow.
+    return false;
+  }
+
+  static constexpr size_t maxAlphabetSizeInBytes =
+      64 * 1024; // see T246457068 for details
+  const auto maxAlphabetSizeInElts = maxAlphabetSizeInBytes / eltWidth;
+
+  uint64_t const maxEltValue =
+      (eltWidth >= 8) ? UINT64_MAX : (1ull << (8 * eltWidth)) - 1;
+  uint64_t const maxCardValue =
+      std::min(std::min(maxEltValue, (uint64_t)nbElts), maxAlphabetSizeInElts);
+  auto const cardinality =
+      ZL_estimateCardinality_fixed(src, nbElts, eltWidth, maxCardValue);
+  if (cardinality.estimateUpperBound >= maxAlphabetSizeInElts) {
+    return false;
+  }
+  size_t const multiplier = (isFloat || compressionLevel == 1) ? 7 : 9;
+  auto const tokenizeEstimatedAlphabetSize =
+      cardinality.estimateUpperBound * eltWidth;
+  auto const tokenizeEstimatedIndicesSize =
+      nbElts * (size_t)ZL_nextPow2(cardinality.estimateUpperBound) / 8;
+  auto const tokenizeEstimatedUpperBounds =
+      tokenizeEstimatedAlphabetSize + tokenizeEstimatedIndicesSize;
+  return tokenizeEstimatedUpperBounds < srcSize * multiplier / 10;
+}
+
+// Selects field-lz vs zstd as the backend LZ stage. Single-byte elements go to
+// zstd; wider elements use the struct-aware field-lz graph.
+class SelectLz : public openzl::Selector {
+ public:
+  explicit SelectLz(openzl::GraphID fieldLz) : fieldLz_{fieldLz} {}
+
+  openzl::SelectorDescription selectorDescription() const override {
+    return {
+        .name = std::string{"nimble.select_lz"},
+        .inputTypeMask = openzl::TypeMask::Numeric,
+        .customGraphs = {fieldLz_},
+    };
+  }
+
+  openzl::GraphID select(
+      openzl::SelectorState& /* state */,
+      const openzl::Input& input) const override {
+    if (input.eltWidth() == 1) {
+      return ZL_GRAPH_ZSTD;
+    }
+    return fieldLz_;
+  }
+
+ private:
+  openzl::GraphID fieldLz_;
+};
+
+// Selects whether to apply the tokenize stage based on a cardinality estimate.
+class SelectTokenize : public openzl::Selector {
+ public:
+  SelectTokenize(
+      openzl::GraphID tokenize,
+      openzl::GraphID noTokenize,
+      bool isFloat)
+      : tokenize_{tokenize}, noTokenize_{noTokenize}, isFloat_{isFloat} {}
+
+  openzl::SelectorDescription selectorDescription() const override {
+    return {
+        .name = isFloat_ ? "nimble.select_tokenize_f32"
+                         : "nimble.select_tokenize_int",
+        .inputTypeMask = openzl::TypeMask::Numeric,
+        .customGraphs = {tokenize_, noTokenize_},
+    };
+  }
+
+  openzl::GraphID select(
+      openzl::SelectorState& state,
+      const openzl::Input& input) const override {
+    const int compressionLevel =
+        state.getCParam(openzl::CParam::CompressionLevel);
+    return shouldTokenize(input, compressionLevel, isFloat_) ? tokenize_
+                                                             : noTokenize_;
+  }
+
+ private:
+  openzl::GraphID tokenize_;
+  openzl::GraphID noTokenize_;
+  bool isFloat_;
+};
+
+// Selects whether to range-pack (subtract min and pack into the smallest
+// integer width) based on the actual value range of the input.
+class SelectRangePack : public openzl::Selector {
+ public:
+  SelectRangePack(openzl::GraphID rangePack, openzl::GraphID noRangePack)
+      : rangePack_{rangePack}, noRangePack_{noRangePack} {}
+
+  openzl::SelectorDescription selectorDescription() const override {
+    return {
+        .name = std::string{"nimble.select_range_pack"},
+        .inputTypeMask = openzl::TypeMask::Numeric,
+        .customGraphs = {rangePack_, noRangePack_},
+    };
+  }
+
+  openzl::GraphID select(
+      openzl::SelectorState& /* state */,
+      const openzl::Input& input) const override {
+    const auto eltWidth = input.eltWidth();
+    const auto nbElts = input.numElts();
+    const auto src = input.ptr();
+    const ZL_ElementRange range =
+        ZL_computeUnsignedRange(src, nbElts, eltWidth);
+    const auto rangeSize = range.max - range.min;
+    if (NUMOP_numericWidthForValue(rangeSize) < eltWidth) {
+      return rangePack_;
+    }
+    return noRangePack_;
+  }
+
+ private:
+  openzl::GraphID rangePack_;
+  openzl::GraphID noRangePack_;
+};
+
+// Registers the chunk segmenter on the raw compressor and wraps @p innerGraph
+// with it, threading the element byte width through as a local parameter. This
+// is the only place the C API is used directly, since segmenters have no C++
+// wrapper.
+openzl::GraphID wrapWithDefaultSegmenter(
+    ZL_Compressor* cgraph,
+    openzl::GraphID innerGraph,
+    size_t elementByteWidth) {
+  ZL_Type inputType = ZL_Type_serial;
+  ZL_SegmenterDesc desc = {
+      .name = "!nimble.default_segmenter",
+      .segmenterFn = defaultSegmenter,
+      .inputTypeMasks = &inputType,
+      .numInputs = 1,
+      .lastInputIsVariable = false,
+      .customGraphs = nullptr,
+      .numCustomGraphs = 0,
+      .localParams = {},
+  };
+  ZL_GraphID const segmenterBase =
+      ZL_Compressor_registerSegmenter(cgraph, &desc);
+
+  ZL_IntParam intParams[] = {{
+      .paramId = kNimbleElementByteWidthParamId,
+      .paramValue = static_cast<int>(elementByteWidth),
+  }};
+  ZL_LocalParams segParams = {
+      .intParams = {.intParams = intParams, .nbIntParams = 1},
+  };
+  ZL_ParameterizedGraphDesc const segGraphDesc = {
+      .graph = segmenterBase,
+      .customGraphs = &innerGraph,
+      .nbCustomGraphs = 1,
+      .localParams = &segParams,
+  };
+  return ZL_Compressor_registerParameterizedGraph(cgraph, &segGraphDesc);
+}
+
+// Builds the default numeric graph:
+//   serial -> interpret-as-LE(width) -> range-pack? -> tokenize?+delta -> lz
+// Wrapped by the multi-chunk segmenter.
+// This decision-making is a default "should-be-good-enough" pipeline that can
+// be modified or replaced to fit to your specific use case.
+openzl::GraphID makeNumericGraph(
+    openzl::Compressor& compressor,
+    bool isFloat,
+    size_t elementBitWidth,
+    int formatVersion) {
+  const size_t elementByteWidth = elementBitWidth / 8;
+
+  const openzl::GraphID fieldLz = openzl::graphs::FieldLz{}(compressor);
+  const openzl::GraphID lz = openzl::Selector::registerSelector(
+      compressor, std::make_shared<SelectLz>(fieldLz));
+
+  const openzl::GraphID deltaLz = openzl::nodes::DeltaInt{}(compressor, lz);
+  const openzl::GraphID tokenize =
+      openzl::nodes::TokenizeNumeric{/* sort */ true}(compressor, deltaLz, lz);
+
+  const openzl::GraphID tokenizeOrNot = openzl::Selector::registerSelector(
+      compressor, std::make_shared<SelectTokenize>(tokenize, lz, isFloat));
+
+  const openzl::GraphID range =
+      openzl::nodes::RangePack{}(compressor, tokenizeOrNot);
+  const openzl::GraphID rangeOrNot = openzl::Selector::registerSelector(
+      compressor, std::make_shared<SelectRangePack>(range, tokenizeOrNot));
+
+  openzl::nodes::ConvertSerialToNumLE toNumeric{
+      static_cast<int>(elementByteWidth)};
+  const openzl::GraphID innerGraph = toNumeric(compressor, rangeOrNot);
+  return wrapWithDefaultSegmenter(
+      compressor.get(), innerGraph, elementByteWidth);
+}
+
+// Maps the nimble DataType to the appropriate numeric graph. Types without
+// a dedicated numeric pipeline fall back to a plain zstd graph (still a valid
+// OpenZL frame).
+openzl::GraphID createGraph(
+    openzl::Compressor& compressor,
+    DataType dataType,
+    int formatVersion) {
+  switch (dataType) {
+    case DataType::Int8:
+    case DataType::Uint8:
+      return makeNumericGraph(
+          compressor, /* isFloat */ false, 8, formatVersion);
+    case DataType::Int16:
+    case DataType::Uint16:
+      return makeNumericGraph(
+          compressor, /* isFloat */ false, 16, formatVersion);
+    case DataType::Int32:
+    case DataType::Uint32:
+      return makeNumericGraph(
+          compressor, /* isFloat */ false, 32, formatVersion);
+    case DataType::Int64:
+    case DataType::Uint64:
+      return makeNumericGraph(
+          compressor, /* isFloat */ false, 64, formatVersion);
+    case DataType::Float:
+      return makeNumericGraph(
+          compressor, /* isFloat */ true, 32, formatVersion);
+    case DataType::Double:
+    case DataType::Bool:
+    case DataType::String:
+    case DataType::Undefined:
+    default:
+      return ZL_GRAPH_ZSTD;
+  }
+}
+
+} // namespace
+
+CompressionResult OpenZLCompressor::compress(
+    velox::memory::MemoryPool& pool,
+    std::string_view data,
+    DataType dataType,
+    int /* bitWidth */,
+    const CompressionPolicy& compressionPolicy) {
+  const auto parameters = compressionPolicy.compression().parameters.openzl;
+
+  openzl::Compressor compressor;
+  compressor.selectStartingGraph(
+      createGraph(compressor, dataType, parameters.formatVersion));
+
+  openzl::CCtx cctx;
+  cctx.setParameter(
+      openzl::CParam::CompressionLevel, parameters.compressionLevel);
+  cctx.setParameter(
+      openzl::CParam::DecompressionLevel, parameters.decompressionLevel);
+  cctx.setParameter(openzl::CParam::FormatVersion, parameters.formatVersion);
+  cctx.refCompressor(compressor);
+
+  Vector<char> buffer{&pool, openzl::compressBound(data.size())};
+  const size_t compressedSize =
+      cctx.compressSerial({buffer.data(), buffer.size()}, data);
+
+  if (!compressionPolicy.shouldAccept(
+          CompressionType::OpenZL, data.size(), compressedSize)) {
+    return {
+        .compressionType = CompressionType::Uncompressed,
+        .buffer = std::nullopt,
+    };
+  }
+
+  buffer.resize(compressedSize);
+  return {
+      .compressionType = CompressionType::OpenZL,
+      .buffer = std::move(buffer),
+  };
+}
+
+velox::BufferPtr OpenZLCompressor::uncompress(
+    velox::memory::MemoryPool& pool,
+    const CompressionType /* compressionType */,
+    const DataType /* dataType */,
+    std::string_view data,
+    velox::BufferPool* bufferPool) {
+  openzl::DCtx dctx;
+  const size_t uncompressedSize =
+      dctx.unwrap(ZL_getDecompressedSize(data.data(), data.size()));
+  auto buffer = allocateBuffer(pool, bufferPool, uncompressedSize);
+  const size_t written =
+      dctx.decompressSerial({buffer->asMutable<char>(), buffer->size()}, data);
+  NIMBLE_CHECK(
+      written == uncompressedSize,
+      "Decompressed size mismatch: expected {}, got {}",
+      uncompressedSize,
+      written);
+  return buffer;
+}
+
+std::optional<size_t> OpenZLCompressor::uncompressedSize(
+    std::string_view data) const {
+  const ZL_Report report = ZL_getDecompressedSize(data.data(), data.size());
+  if (ZL_isError(report)) {
+    return std::nullopt;
+  }
+  return ZL_validResult(report);
+}
+
+CompressionType OpenZLCompressor::compressionType() {
+  return CompressionType::OpenZL;
+}
+
+} // namespace facebook::nimble

--- a/dwio/nimble/compression/OpenZLCompressor.h
+++ b/dwio/nimble/compression/OpenZLCompressor.h
@@ -16,13 +16,23 @@
 
 #pragma once
 
+#include <memory>
+
 #include "dwio/nimble/compression/Compression.h"
 
 namespace facebook::nimble {
 
-/// ICompressor backed by custom graphs implemented using OpenZL
+/// ICompressor backed by custom graphs implemented using OpenZL.
+///
+/// The OpenZL numeric graphs are built once per instance and shared (read-only)
+/// across all compress() calls, so per-call setup is limited to a CCtx that
+/// refs the prebuilt graphs. Instances are expected to be long-lived (a single
+/// instance is registered in the compressor registry).
 class OpenZLCompressor : public ICompressor {
  public:
+  OpenZLCompressor();
+  ~OpenZLCompressor() override;
+
   CompressionResult compress(
       velox::memory::MemoryPool& pool,
       std::string_view data,
@@ -40,6 +50,12 @@ class OpenZLCompressor : public ICompressor {
   std::optional<size_t> uncompressedSize(std::string_view data) const override;
 
   CompressionType compressionType() override;
+
+ private:
+  // Holds the prebuilt OpenZL Compressor and its per-DataType graphs. Defined
+  // in the .cpp to keep OpenZL headers out of this header.
+  struct GraphCache;
+  std::unique_ptr<GraphCache> graphCache_;
 };
 
 } // namespace facebook::nimble

--- a/dwio/nimble/compression/OpenZLCompressor.h
+++ b/dwio/nimble/compression/OpenZLCompressor.h
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "dwio/nimble/compression/Compression.h"
+
+namespace facebook::nimble {
+
+/// ICompressor backed by custom graphs implemented using OpenZL
+class OpenZLCompressor : public ICompressor {
+ public:
+  CompressionResult compress(
+      velox::memory::MemoryPool& pool,
+      std::string_view data,
+      DataType dataType,
+      int bitWidth,
+      const CompressionPolicy& compressionPolicy) override;
+
+  velox::BufferPtr uncompress(
+      velox::memory::MemoryPool& pool,
+      CompressionType compressionType,
+      DataType dataType,
+      std::string_view data,
+      velox::BufferPool* bufferPool = nullptr) override;
+
+  std::optional<size_t> uncompressedSize(std::string_view data) const override;
+
+  CompressionType compressionType() override;
+};
+
+} // namespace facebook::nimble

--- a/dwio/nimble/encodings/selection/EncodingSelectionPolicy.h
+++ b/dwio/nimble/encodings/selection/EncodingSelectionPolicy.h
@@ -116,6 +116,12 @@ struct CompressionOptions {
   uint32_t internalDecompressionLevel = 2;
   bool useVariableBitWidthCompressor = false;
   MetaInternalCompressionKey metaInternalCompressionKey;
+  // OpenZL settings
+  uint64_t openzlMinCompressionSize = kOpenZLMinCompressionSize;
+  // 6/3 is a close analogue to the performance of zstd level 3
+  int32_t openzlCompressionLevel = 6;
+  int32_t openzlDecompressionLevel = 3;
+  int32_t openzlFormatVersion = 25;
   // Per-encoding overrides for compressionAcceptRatio.
   // BlockBitPacking default 0.7: data is already well-packed via per-block
   // baselines, so compression must save at least 30% to justify CPU cost.
@@ -242,6 +248,19 @@ class ManualEncodingSelectionPolicy : public EncodingSelectionPolicy<T> {
               .minCompressionSize = compressionOptions_.lz4MinCompressionSize};
           information.parameters.lz4.accelerationLevel =
               compressionOptions_.lz4AccelerationLevel;
+          return information;
+        }
+        if (compressionOptions_.compressionType == CompressionType::OpenZL) {
+          CompressionInformation information{
+              .compressionType = CompressionType::OpenZL,
+              .minCompressionSize =
+                  compressionOptions_.openzlMinCompressionSize};
+          information.parameters.openzl.compressionLevel =
+              compressionOptions_.openzlCompressionLevel;
+          information.parameters.openzl.decompressionLevel =
+              compressionOptions_.openzlDecompressionLevel;
+          information.parameters.openzl.formatVersion =
+              compressionOptions_.openzlFormatVersion;
           return information;
         }
         CompressionInformation information{

--- a/dwio/nimble/encodings/tests/CMakeLists.txt
+++ b/dwio/nimble/encodings/tests/CMakeLists.txt
@@ -31,6 +31,7 @@ add_executable(
   FrequencyPartitionEncodingTest.cpp
   MainlyConstantEncodingTest.cpp
   NullableEncodingTest.cpp
+  OpenZLCompressorTest.cpp
   PFOREncodingTest.cpp
   PrefixEncodingTest.cpp
   RLEEncodingTest.cpp

--- a/dwio/nimble/encodings/tests/OpenZLCompressorTest.cpp
+++ b/dwio/nimble/encodings/tests/OpenZLCompressorTest.cpp
@@ -1,0 +1,228 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "dwio/nimble/compression/OpenZLCompressor.h"
+#include <gtest/gtest.h>
+#include <cstring>
+#include <random>
+#include <vector>
+#include "velox/buffer/BufferPool.h"
+#include "velox/common/memory/Memory.h"
+
+using namespace facebook::nimble;
+
+namespace {
+
+class TestOpenZLCompressionPolicy : public CompressionPolicy {
+ public:
+  explicit TestOpenZLCompressionPolicy(uint64_t minCompressionSize = 0) {
+    compressionInfo_ = {
+        .compressionType = CompressionType::OpenZL,
+        .minCompressionSize = minCompressionSize};
+  }
+
+  CompressionInformation compression() const override {
+    return compressionInfo_;
+  }
+
+  bool shouldAccept(
+      CompressionType /* compressionType */,
+      uint64_t uncompressedSize,
+      uint64_t compressedSize) const override {
+    return compressedSize < uncompressedSize;
+  }
+
+ private:
+  CompressionInformation compressionInfo_;
+};
+
+// Builds a serial byte buffer from a numeric vector for feeding into the
+// compressor.
+template <typename T>
+std::string_view asBytes(const std::vector<T>& values) {
+  return std::string_view(
+      reinterpret_cast<const char*>(values.data()), values.size() * sizeof(T));
+}
+
+// Round-trips compressible numeric data through OpenZL and asserts the bytes
+// come back identical.
+template <typename T>
+void roundTripNumeric(DataType dataType, const std::vector<T>& values) {
+  auto pool = facebook::velox::memory::deprecatedAddDefaultLeafMemoryPool();
+  OpenZLCompressor compressor;
+  TestOpenZLCompressionPolicy policy;
+
+  auto input = asBytes(values);
+  auto result = compressor.compress(*pool, input, dataType, 0, policy);
+  ASSERT_EQ(CompressionType::OpenZL, result.compressionType);
+  ASSERT_TRUE(result.buffer.has_value());
+
+  std::string_view compressed(result.buffer->data(), result.buffer->size());
+  auto decompressed = compressor.uncompress(
+      *pool, CompressionType::OpenZL, dataType, compressed);
+  ASSERT_EQ(input.size(), decompressed->size());
+  EXPECT_EQ(
+      0, std::memcmp(input.data(), decompressed->as<char>(), input.size()));
+}
+
+} // namespace
+
+TEST(OpenZLCompressorTest, CompressionType) {
+  OpenZLCompressor compressor;
+  EXPECT_EQ(CompressionType::OpenZL, compressor.compressionType());
+}
+
+TEST(OpenZLCompressorTest, RoundTripInt8) {
+  std::vector<int8_t> values(4096);
+  for (size_t i = 0; i < values.size(); ++i) {
+    values[i] = static_cast<int8_t>(i % 10);
+  }
+  roundTripNumeric(DataType::Int8, values);
+}
+
+TEST(OpenZLCompressorTest, RoundTripInt32) {
+  // A narrow, locally-correlated range that exercises range-pack and delta.
+  std::vector<int32_t> values(4096);
+  for (size_t i = 0; i < values.size(); ++i) {
+    values[i] = static_cast<int32_t>(1000 + (i % 50));
+  }
+  roundTripNumeric(DataType::Int32, values);
+}
+
+TEST(OpenZLCompressorTest, RoundTripInt64) {
+  std::vector<int64_t> values(4096);
+  for (size_t i = 0; i < values.size(); ++i) {
+    values[i] = static_cast<int64_t>(i / 4);
+  }
+  roundTripNumeric(DataType::Int64, values);
+}
+
+TEST(OpenZLCompressorTest, RoundTripFloat) {
+  std::vector<float> values(4096);
+  for (size_t i = 0; i < values.size(); ++i) {
+    values[i] = static_cast<float>(i % 16);
+  }
+  roundTripNumeric(DataType::Float, values);
+}
+
+TEST(OpenZLCompressorTest, RoundTripSerialInput) {
+  // Feed raw serial bytes tagged as Int8 (single-byte path -> zstd backend).
+  auto pool = facebook::velox::memory::deprecatedAddDefaultLeafMemoryPool();
+  OpenZLCompressor compressor;
+  TestOpenZLCompressionPolicy policy;
+
+  std::vector<char> original(2048);
+  for (size_t i = 0; i < original.size(); ++i) {
+    original[i] = static_cast<char>(i % 7);
+  }
+  std::string_view input(original.data(), original.size());
+
+  auto result = compressor.compress(*pool, input, DataType::Int8, 0, policy);
+  ASSERT_EQ(CompressionType::OpenZL, result.compressionType);
+  ASSERT_TRUE(result.buffer.has_value());
+
+  std::string_view compressed(result.buffer->data(), result.buffer->size());
+  auto decompressed = compressor.uncompress(
+      *pool, CompressionType::OpenZL, DataType::Int8, compressed);
+  ASSERT_EQ(original.size(), decompressed->size());
+  EXPECT_EQ(
+      0,
+      std::memcmp(original.data(), decompressed->as<char>(), original.size()));
+}
+
+TEST(OpenZLCompressorTest, UncompressedSize) {
+  auto pool = facebook::velox::memory::deprecatedAddDefaultLeafMemoryPool();
+  OpenZLCompressor compressor;
+  TestOpenZLCompressionPolicy policy;
+
+  std::vector<int32_t> values(2048, 42);
+  auto input = asBytes(values);
+
+  auto result = compressor.compress(*pool, input, DataType::Int32, 0, policy);
+  ASSERT_EQ(CompressionType::OpenZL, result.compressionType);
+  ASSERT_TRUE(result.buffer.has_value());
+
+  std::string_view compressed(result.buffer->data(), result.buffer->size());
+  auto size = compressor.uncompressedSize(compressed);
+  ASSERT_TRUE(size.has_value());
+  EXPECT_EQ(input.size(), size.value());
+}
+
+TEST(OpenZLCompressorTest, IncompressibleData) {
+  auto pool = facebook::velox::memory::deprecatedAddDefaultLeafMemoryPool();
+  OpenZLCompressor compressor;
+  TestOpenZLCompressionPolicy policy;
+
+  std::mt19937 rng(42);
+  std::uniform_int_distribution<int> dist(0, 255);
+  std::vector<char> randomData(256);
+  for (auto& byte : randomData) {
+    byte = static_cast<char>(dist(rng));
+  }
+  std::string_view input(randomData.data(), randomData.size());
+
+  auto result = compressor.compress(*pool, input, DataType::Int8, 0, policy);
+  // Random data should not compress; the policy rejects it -> Uncompressed.
+  EXPECT_EQ(CompressionType::Uncompressed, result.compressionType);
+  EXPECT_FALSE(result.buffer.has_value());
+}
+
+TEST(OpenZLCompressorTest, MinCompressionSizeSkipsSmallData) {
+  auto pool = facebook::velox::memory::deprecatedAddDefaultLeafMemoryPool();
+
+  std::vector<char> data(50, 'a');
+  std::string_view input(data.data(), data.size());
+
+  // minCompressionSize larger than the data -> CompressionEncoder skips it.
+  TestOpenZLCompressionPolicy policy(data.size() + 1);
+  CompressionEncoder<int8_t> encoder{*pool, policy, DataType::Int8, input};
+  EXPECT_EQ(CompressionType::Uncompressed, encoder.compressionType());
+}
+
+TEST(OpenZLCompressorTest, UncompressWithBufferPool) {
+  auto pool = facebook::velox::memory::deprecatedAddDefaultLeafMemoryPool();
+  OpenZLCompressor compressor;
+  TestOpenZLCompressionPolicy policy;
+  facebook::velox::BufferPool bufferPool{
+      facebook::velox::BufferPool::kDefaultCapacity};
+
+  std::vector<int32_t> values(2048);
+  for (size_t i = 0; i < values.size(); ++i) {
+    values[i] = static_cast<int32_t>(i % 20);
+  }
+  auto input = asBytes(values);
+
+  auto result = compressor.compress(*pool, input, DataType::Int32, 0, policy);
+  ASSERT_TRUE(result.buffer.has_value());
+  std::string_view compressed(result.buffer->data(), result.buffer->size());
+
+  // First decompress allocates fresh from the pool path.
+  auto decompressed = compressor.uncompress(
+      *pool, CompressionType::OpenZL, DataType::Int32, compressed, &bufferPool);
+  ASSERT_EQ(input.size(), decompressed->size());
+  EXPECT_EQ(
+      0, std::memcmp(input.data(), decompressed->as<char>(), input.size()));
+
+  // Return to the pool, then decompress again -> should reuse.
+  bufferPool.release(std::move(decompressed));
+  EXPECT_EQ(bufferPool.size(), 1);
+
+  auto decompressed2 = compressor.uncompress(
+      *pool, CompressionType::OpenZL, DataType::Int32, compressed, &bufferPool);
+  EXPECT_EQ(bufferPool.size(), 0);
+  ASSERT_EQ(input.size(), decompressed2->size());
+  EXPECT_EQ(
+      0, std::memcmp(input.data(), decompressed2->as<char>(), input.size()));
+}

--- a/dwio/nimble/tablet/Footer.fbs
+++ b/dwio/nimble/tablet/Footer.fbs
@@ -20,6 +20,7 @@ enum CompressionType:uint8 {
   Zstd = 1,
   MetaInternal = 2,
   Lz4 = 3,
+  OpenZL = 4,
 }
 
 table Stripes {

--- a/dwio/nimble/velox/tests/VeloxReaderTest.cpp
+++ b/dwio/nimble/velox/tests/VeloxReaderTest.cpp
@@ -7349,6 +7349,85 @@ TEST_P(VeloxReaderTest, flatMapStringKeyOwnership) {
   ASSERT_EQ(output->size(), kBatches);
 }
 
+TEST_P(VeloxReaderTest, openZLCompressionRoundTrip) {
+  // E2E: write numeric columns (covering every width OpenZL has a numeric graph
+  // for) plus double/string columns that exercise the zstd-fallback path, with
+  // the OpenZL codec forced. Verify the data round-trips across all reader
+  // parameter combinations (cache/pin/skip).
+  auto type = velox::ROW({
+      {"i8", velox::TINYINT()},
+      {"i16", velox::SMALLINT()},
+      {"i32", velox::INTEGER()},
+      {"i64", velox::BIGINT()},
+      {"f32", velox::REAL()},
+      {"f64", velox::DOUBLE()},
+      {"str", velox::VARCHAR()},
+  });
+
+  velox::test::VectorMaker vectorMaker{leafPool_.get()};
+  constexpr velox::vector_size_t kRowCount = 1000;
+
+  auto generator = [&](const velox::RowTypePtr& rowType) -> velox::VectorPtr {
+    return vectorMaker.rowVector(
+        rowType->names(),
+        {
+            vectorMaker.flatVector<int8_t>(
+                kRowCount,
+                [](auto row) { return static_cast<int8_t>(row % 7); }),
+            vectorMaker.flatVector<int16_t>(
+                kRowCount,
+                [](auto row) { return static_cast<int16_t>(row % 100); }),
+            vectorMaker.flatVector<int32_t>(
+                kRowCount,
+                [](auto row) { return static_cast<int32_t>(1000 + row % 50); }),
+            vectorMaker.flatVector<int64_t>(
+                kRowCount,
+                [](auto row) { return static_cast<int64_t>(row / 4); }),
+            vectorMaker.flatVector<float>(
+                kRowCount,
+                [](auto row) { return static_cast<float>(row % 16); }),
+            vectorMaker.flatVector<double>(
+                kRowCount,
+                [](auto row) { return static_cast<double>(row % 32); }),
+            vectorMaker.flatVector<std::string>(
+                kRowCount,
+                [](auto row) { return "value_" + std::to_string(row % 20); }),
+        });
+  };
+
+  nimble::VeloxWriterOptions writerOptions;
+  // The default write path drives compression off the encoding selection policy
+  // (not VeloxWriterOptions::compressionOptions), so force OpenZL via the
+  // factory so the codec is actually exercised end-to-end.
+  writerOptions.encodingSelectionPolicyFactory =
+      [factory =
+           nimble::ManualEncodingSelectionPolicyFactory{
+               nimble::ManualEncodingSelectionPolicyFactory::
+                   defaultReadFactors(),
+               nimble::CompressionOptions{
+                   .compressionAcceptRatio = 100,
+                   .compressionType = nimble::CompressionType::OpenZL,
+                   .openzlMinCompressionSize = 0,
+               }}](nimble::DataType dataType)
+      -> std::unique_ptr<nimble::EncodingSelectionPolicyBase> {
+    return factory.createPolicy(dataType);
+  };
+
+  uint32_t seed = FLAGS_reader_tests_seed > 0 ? FLAGS_reader_tests_seed
+                                              : folly::Random::rand32();
+  LOG(INFO) << "seed: " << seed;
+  std::mt19937 rng{seed};
+
+  writeAndVerify(
+      rng,
+      *leafPool_,
+      type,
+      generator,
+      vectorEquals,
+      /* batchCount */ 3,
+      writerOptions);
+}
+
 INSTANTIATE_TEST_SUITE_P(
     VeloxReaderTestSuite,
     VeloxReaderTest,

--- a/dwio/nimble/velox/tests/VeloxWriterTest.cpp
+++ b/dwio/nimble/velox/tests/VeloxWriterTest.cpp
@@ -1072,6 +1072,120 @@ TEST_F(VeloxWriterTest, encodingLayout) {
   }
 }
 
+TEST_F(VeloxWriterTest, openZLCompressionNumericRoundTrip) {
+  // E2E: force the OpenZL codec, write compressible numeric columns, and assert
+  // (a) at least one numeric stream is actually OpenZL-compressed and (b) the
+  // data round-trips byte-for-byte through the reader.
+  velox::test::VectorMaker vectorMaker{leafPool_.get()};
+  constexpr velox::vector_size_t kRowCount = 1000;
+  auto vector = vectorMaker.rowVector(
+      {"i32", "i64", "f32"},
+      {
+          vectorMaker.flatVector<int32_t>(
+              kRowCount,
+              [](auto row) { return static_cast<int32_t>(1000 + row % 50); }),
+          vectorMaker.flatVector<int64_t>(
+              kRowCount,
+              [](auto row) { return static_cast<int64_t>(row / 4); }),
+          vectorMaker.flatVector<float>(
+              kRowCount, [](auto row) { return static_cast<float>(row % 16); }),
+      });
+
+  std::string file;
+  auto writeFile = std::make_unique<velox::InMemoryWriteFile>(&file);
+  nimble::VeloxWriterOptions writerOptions;
+  // The default write path drives compression off the encoding selection policy
+  // (not VeloxWriterOptions::compressionOptions), so force OpenZL via the
+  // factory. Accept ratio 100 + min size 0 ensure the codec is actually applied
+  // even to tiny streams.
+  writerOptions.encodingSelectionPolicyFactory =
+      [factory =
+           nimble::ManualEncodingSelectionPolicyFactory{
+               nimble::ManualEncodingSelectionPolicyFactory::
+                   defaultReadFactors(),
+               nimble::CompressionOptions{
+                   .compressionAcceptRatio = 100,
+                   .compressionType = nimble::CompressionType::OpenZL,
+                   .openzlMinCompressionSize = 0,
+               }}](nimble::DataType dataType)
+      -> std::unique_ptr<nimble::EncodingSelectionPolicyBase> {
+    return factory.createPolicy(dataType);
+  };
+  nimble::VeloxWriter writer(
+      vector->type(),
+      std::move(writeFile),
+      *rootPool_,
+      std::move(writerOptions));
+  writer.write(vector);
+  writer.close();
+
+  auto readFile = std::make_shared<velox::InMemoryReadFile>(file);
+  auto tablet = nimble::TabletReader::create(
+      readFile, leafPool_.get(), makeTestTabletOptions(leafPool_.get()));
+  auto section =
+      tablet->loadOptionalSection(std::string(nimble::kSchemaSection));
+  ASSERT_TRUE(section.has_value());
+  auto schema =
+      nimble::SchemaDeserializer::deserialize(section->content().data());
+
+  // Recursively checks whether any node in the encoding tree was compressed
+  // with the given codec, so the assertion does not depend on which encoding
+  // the writer happened to pick.
+  std::function<bool(const nimble::EncodingLayout&, nimble::CompressionType)>
+      usesCompression = [&](const nimble::EncodingLayout& layout,
+                            nimble::CompressionType compressionType) {
+        if (layout.compressionType() == compressionType) {
+          return true;
+        }
+        for (uint8_t i = 0; i < layout.childrenCount(); ++i) {
+          const auto& child = layout.child(i);
+          if (child.has_value() &&
+              usesCompression(child.value(), compressionType)) {
+            return true;
+          }
+        }
+        return false;
+      };
+
+  bool anyOpenZL = false;
+  for (auto stripe = 0; stripe < tablet->stripeCount(); ++stripe) {
+    auto stripeIdentifier = tablet->stripeIdentifier(stripe);
+    for (auto column = 0; column < schema->asRow().childrenCount(); ++column) {
+      auto offset = schema->asRow()
+                        .childAt(column)
+                        ->asScalar()
+                        .scalarDescriptor()
+                        .offset();
+      auto streams =
+          tablet->load(stripeIdentifier, std::vector<uint32_t>{offset});
+      if (streams.empty() || streams[0] == nullptr) {
+        continue;
+      }
+      nimble::InMemoryChunkedStream chunkedStream{
+          *leafPool_, std::move(streams[0])};
+      while (chunkedStream.hasNext()) {
+        auto capture =
+            nimble::EncodingLayoutCapture::capture(chunkedStream.nextChunk());
+        if (usesCompression(capture, nimble::CompressionType::OpenZL)) {
+          anyOpenZL = true;
+        }
+      }
+    }
+  }
+  EXPECT_TRUE(anyOpenZL)
+      << "Expected at least one numeric stream to be OpenZL-compressed";
+
+  nimble::VeloxReader reader(readFile.get(), *leafPool_);
+  velox::VectorPtr result;
+  ASSERT_TRUE(reader.next(kRowCount, result));
+  ASSERT_EQ(kRowCount, result->size());
+  for (velox::vector_size_t i = 0; i < kRowCount; ++i) {
+    EXPECT_TRUE(vector->equalValueAt(result.get(), i, i))
+        << "Content mismatch at row " << i;
+  }
+  ASSERT_FALSE(reader.next(1, result));
+}
+
 TEST_F(VeloxWriterTest, encodingLayoutSchemaMismatch) {
   nimble::EncodingLayoutTree expected{
       nimble::Kind::Row,


### PR DESCRIPTION
Summary:
Addresses review feedback on D108189356 about per-call OpenZL setup overhead.

Previously OpenZLCompressor rebuilt the entire numeric graph (registering every
selector and segmenter) on every compress() call, and created a fresh DCtx on
every uncompress() call. In high-throughput paths (Nimble compresses many
columns per write) this per-call setup is significant overhead.

- Build the OpenZL Compressor once per instance and ref it from a per-call CCtx
  in compress(), selecting the per-DataType starting graph. The Compressor is
  validated once (single-threaded) and then shared read-only across threads,
  which is OpenZL's intended reuse pattern.
- Register the width-independent selectors/nodes (FieldLz, SelectLz, DeltaInt,
  TokenizeNumeric) and the base segmenter once, the int/float tail once per
  variant, and only the genuinely per-width pieces (serial->numeric conversion
  + parameterized segmenter) per DataType.
- Reuse a thread-local openzl::DCtx in uncompress(), mirroring
  ZstdCompressor::getThreadLocalDCtx.

Reviewed By: srsuryadev

Differential Revision: D108670715


