### PR TITLE
feat(encoding): Add OpenZL compression codec to OSS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -177,6 +177,26 @@ include_directories(SYSTEM velox/velox/external/xxhash)
 include_directories(SYSTEM ${CMAKE_BINARY_DIR}/_deps/xsimd-src/include/)
 
 add_subdirectory(velox)
+
+# OpenZL is vendored as a git submodule and provides the OpenZL compression
+# codec used by dwio/nimble/compression (the `openzl` and `openzl_cpp` targets).
+# Only those core libraries are needed here, so disable OpenZL's CLI, examples,
+# tools, parsers, tests, benchmarks, Python bindings and install rules to keep
+# the Nimble build minimal and avoid pulling in unneeded dependencies. This must
+# come before any subdirectory that links against OpenZL so the targets and
+# their public include directories (e.g. openzl/cpp/include) are defined.
+set(OPENZL_BUILD_CLI OFF CACHE BOOL "Build the OpenZL cli subdirectory" FORCE)
+set(OPENZL_BUILD_EXAMPLES OFF CACHE BOOL "Build OpenZL examples" FORCE)
+set(OPENZL_BUILD_TOOLS OFF CACHE BOOL "Build OpenZL tools" FORCE)
+set(OPENZL_BUILD_CUSTOM_PARSERS OFF CACHE BOOL "Build OpenZL custom parsers"
+    FORCE
+)
+set(OPENZL_BUILD_TESTS OFF CACHE BOOL "Build OpenZL tests" FORCE)
+set(OPENZL_BUILD_BENCHMARKS OFF CACHE BOOL "Build OpenZL benchmarks" FORCE)
+set(OPENZL_BUILD_PYTHON_EXT OFF CACHE BOOL "Build OpenZL Python extension" FORCE)
+set(OPENZL_INSTALL OFF CACHE BOOL "Install OpenZL" FORCE)
+add_subdirectory(openzl)
+
 add_subdirectory(dwio/nimble/common)
 add_subdirectory(dwio/nimble/compression)
 add_subdirectory(dwio/nimble/tools)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -188,14 +188,38 @@ add_subdirectory(velox)
 set(OPENZL_BUILD_CLI OFF CACHE BOOL "Build the OpenZL cli subdirectory" FORCE)
 set(OPENZL_BUILD_EXAMPLES OFF CACHE BOOL "Build OpenZL examples" FORCE)
 set(OPENZL_BUILD_TOOLS OFF CACHE BOOL "Build OpenZL tools" FORCE)
-set(OPENZL_BUILD_CUSTOM_PARSERS OFF CACHE BOOL "Build OpenZL custom parsers"
-    FORCE
+set(
+  OPENZL_BUILD_CUSTOM_PARSERS
+  OFF
+  CACHE BOOL
+  "Build OpenZL custom parsers"
+  FORCE
 )
 set(OPENZL_BUILD_TESTS OFF CACHE BOOL "Build OpenZL tests" FORCE)
 set(OPENZL_BUILD_BENCHMARKS OFF CACHE BOOL "Build OpenZL benchmarks" FORCE)
-set(OPENZL_BUILD_PYTHON_EXT OFF CACHE BOOL "Build OpenZL Python extension" FORCE)
+set(OPENZL_BUILD_PYTHON_EXT
+  OFF
+  CACHE BOOL
+  "Build OpenZL Python extension"
+  FORCE
+)
 set(OPENZL_INSTALL OFF CACHE BOOL "Install OpenZL" FORCE)
 add_subdirectory(openzl)
+
+# OpenZL hard-codes CMAKE_CXX_STANDARD to 17 (see openzl/CMakeLists.txt), but
+# Nimble builds with C++20. OpenZL's C++ bindings select between std:: types and
+# internal polyfills (poly::span, poly::source_location, poly::string_view, ...)
+# at compile time via feature-test macros (openzl/cpp/include/openzl/cpp/detail/
+# Portability.hpp). If openzl_cpp is compiled as C++17 while Nimble consumes its
+# headers as C++20, the same poly:: aliases resolve to different underlying types
+# (e.g. std::span vs poly::impl::span, std::source_location vs the polyfill),
+# producing mismatched mangled symbols and undefined-reference link errors. Force
+# the OpenZL C++ binding library to the same standard as Nimble so the polyfill
+# selection is identical on both sides of the ABI.
+set_target_properties(
+  openzl_cpp
+  PROPERTIES CXX_STANDARD ${CMAKE_CXX_STANDARD} CXX_STANDARD_REQUIRED ON
+)
 
 add_subdirectory(dwio/nimble/common)
 add_subdirectory(dwio/nimble/compression)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -197,7 +197,8 @@ set(
 )
 set(OPENZL_BUILD_TESTS OFF CACHE BOOL "Build OpenZL tests" FORCE)
 set(OPENZL_BUILD_BENCHMARKS OFF CACHE BOOL "Build OpenZL benchmarks" FORCE)
-set(OPENZL_BUILD_PYTHON_EXT
+set(
+  OPENZL_BUILD_PYTHON_EXT
   OFF
   CACHE BOOL
   "Build OpenZL Python extension"

--- a/dwio/nimble/common/Constants.h
+++ b/dwio/nimble/common/Constants.h
@@ -25,6 +25,7 @@ namespace facebook::nimble {
 constexpr uint32_t kMetaInternalMinCompressionSize{40};
 constexpr uint32_t kZstdMinCompressionSize{25};
 constexpr uint32_t kLz4MinCompressionSize{12};
+constexpr uint32_t kOpenZLMinCompressionSize{40};
 
 /// Default options for the ChunkFlushPolicy.
 /// Threshold to trigger chunking to relieve memory pressure

--- a/dwio/nimble/common/Types.cpp
+++ b/dwio/nimble/common/Types.cpp
@@ -114,6 +114,8 @@ std::string toString(CompressionType compressionType) {
       return "MetaInternal";
     case CompressionType::Lz4:
       return "Lz4";
+    case CompressionType::OpenZL:
+      return "OpenZL";
     default:
       return fmt::format(
           "Unknown compression type: {}",

--- a/dwio/nimble/common/Types.h
+++ b/dwio/nimble/common/Types.h
@@ -159,6 +159,7 @@ enum class CompressionType : uint8_t {
   Zstd = 1,
   MetaInternal = 2,
   Lz4 = 3,
+  OpenZL = 4,
 };
 
 std::string toString(CompressionType compressionType);

--- a/dwio/nimble/compression/CMakeLists.txt
+++ b/dwio/nimble/compression/CMakeLists.txt
@@ -15,7 +15,15 @@ add_library(
   nimble_compression
   Compression.cpp
   Lz4Compressor.cpp
+  OpenZLCompressor.cpp
   ZstdCompressor.cpp
 )
 
-target_link_libraries(nimble_compression nimble_common Folly::folly lz4)
+target_link_libraries(
+  nimble_compression
+  nimble_common
+  Folly::folly
+  lz4
+  openzl
+  openzl_cpp
+)

--- a/dwio/nimble/compression/Compression.cpp
+++ b/dwio/nimble/compression/Compression.cpp
@@ -16,6 +16,7 @@
 #include "dwio/nimble/compression/Compression.h"
 #include "dwio/nimble/common/Exceptions.h"
 #include "dwio/nimble/compression/Lz4Compressor.h"
+#include "dwio/nimble/compression/OpenZLCompressor.h"
 #include "dwio/nimble/compression/ZstdCompressor.h"
 #include "dwio/nimble/encodings/common/EncodingPrimitives.h"
 
@@ -29,11 +30,13 @@ namespace {
 
 struct CompressorRegistry {
   CompressorRegistry() {
-    compressors.reserve(3);
+    compressors.reserve(4);
     compressors.emplace(
         CompressionType::Zstd, std::make_unique<ZstdCompressor>());
     compressors.emplace(
         CompressionType::Lz4, std::make_unique<Lz4Compressor>());
+    compressors.emplace(
+        CompressionType::OpenZL, std::make_unique<OpenZLCompressor>());
 #ifndef DISABLE_META_INTERNAL_COMPRESSOR
     compressors.emplace(
         CompressionType::MetaInternal,

--- a/dwio/nimble/compression/CompressionPolicy.h
+++ b/dwio/nimble/compression/CompressionPolicy.h
@@ -90,10 +90,17 @@ struct MetaInternalCompressionParameters {
   MetaInternalCompressionKey compressionKey;
 };
 
+struct OpenZLCompressionParameters {
+  int compressionLevel = 6;
+  int decompressionLevel = 3;
+  int formatVersion = 25; // current prod max, as of 2026-06-10
+};
+
 struct CompressionParameters {
   ZstdCompressionParameters zstd{};
   Lz4CompressionParameters lz4{};
   MetaInternalCompressionParameters metaInternal{};
+  OpenZLCompressionParameters openzl{};
 };
 
 struct CompressionInformation {

--- a/dwio/nimble/compression/OpenZLCompressor.cpp
+++ b/dwio/nimble/compression/OpenZLCompressor.cpp
@@ -1,0 +1,418 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "dwio/nimble/compression/OpenZLCompressor.h"
+
+#include <algorithm>
+#include <memory>
+#include <optional>
+
+#include "dwio/nimble/common/Exceptions.h"
+
+#include "openzl/cpp/CCtx.hpp"
+#include "openzl/cpp/CParam.hpp"
+#include "openzl/cpp/Codecs.hpp"
+#include "openzl/cpp/Compressor.hpp"
+#include "openzl/cpp/DCtx.hpp"
+#include "openzl/cpp/Input.hpp"
+#include "openzl/cpp/Selector.hpp"
+#include "openzl/cpp/Type.hpp"
+
+#include "openzl/zl_compressor.h"
+#include "openzl/zl_data.h"
+#include "openzl/zl_decompress.h"
+#include "openzl/zl_errors.h"
+#include "openzl/zl_localParams.h"
+#include "openzl/zl_segmenter.h"
+#include "openzl/zl_version.h"
+
+#include "openzl/common/assertion.h"
+#include "openzl/shared/bits.h"
+#include "openzl/shared/estimate.h"
+#include "openzl/shared/numeric_operations.h"
+
+namespace facebook::nimble {
+namespace {
+
+// Local parameter ID for element byte width, consumed by the chunk segmenter.
+constexpr int kNimbleElementByteWidthParamId = 1;
+// Target chunk size: ~16MB.
+constexpr size_t kDefaultChunkByteSizeTarget = 16 << 20;
+
+// Multi-chunk segmenter. It splits the serial input into
+// ~16MB chunks (aligned to element width) and routes each through the inner
+// numeric graph. There is no C++ wrapper for segmenters, so this is registered
+// via the C API.
+ZL_Report defaultSegmenter(ZL_Segmenter* sctx) {
+  ZL_RESULT_DECLARE_SCOPE_REPORT(sctx);
+
+  size_t const numInputs = ZL_Segmenter_numInputs(sctx);
+  ZL_ERR_IF_NE(numInputs, 1, node_invalid_input);
+
+  const ZL_Input* const input = ZL_Segmenter_getInput(sctx, 0);
+  ZL_ASSERT_NN(input);
+  size_t const totalBytes = ZL_Input_contentSize(input);
+
+  if (totalBytes == 0) {
+    ZL_ERR_IF_ERR(ZL_Segmenter_processChunk(
+        sctx, &totalBytes, 1, ZL_GRAPH_STORE, nullptr));
+    return ZL_returnSuccess();
+  }
+
+  ZL_GraphIDList const customGraphs = ZL_Segmenter_getCustomGraphs(sctx);
+  ZL_ASSERT_EQ(customGraphs.nbGraphIDs, 1);
+  ZL_GraphID const innerGraph = customGraphs.graphids[0];
+
+  ZL_IntParam const eltWidthParam =
+      ZL_Segmenter_getLocalIntParam(sctx, kNimbleElementByteWidthParamId);
+  ZL_ERR_IF_EQ(
+      eltWidthParam.paramId, ZL_LP_INVALID_PARAMID, node_invalid_input);
+  size_t const eltWidth = (size_t)eltWidthParam.paramValue;
+
+  size_t const chunkTarget =
+      (kDefaultChunkByteSizeTarget / eltWidth) * eltWidth;
+
+  size_t remaining = totalBytes;
+  while (remaining > 0) {
+    size_t chunkSize = (remaining > chunkTarget) ? chunkTarget : remaining;
+    ZL_ERR_IF_ERR(
+        ZL_Segmenter_processChunk(sctx, &chunkSize, 1, innerGraph, nullptr));
+    remaining -= chunkSize;
+  }
+  return ZL_returnSuccess();
+}
+
+// Decides if a tokenize transform can and should be used on @p input. It
+// calculates an upper bound on the size of tokenization itself (size of
+// alphabet + size of indices) and compares it to the original size times a
+// threshold multiplier. The multiplier differs for floats and ints.
+bool shouldTokenize(
+    const openzl::Input& input,
+    int compressionLevel,
+    bool isFloat) {
+  auto const eltWidth = input.eltWidth();
+  auto const nbElts = input.numElts();
+  auto const src = input.ptr();
+  auto const srcSize = eltWidth * nbElts;
+
+  if (compressionLevel == 1 && eltWidth == 8) {
+    // Disable tokenization for level 1 and 64-bit integers because it is
+    // quite slow.
+    return false;
+  }
+
+  static constexpr size_t maxAlphabetSizeInBytes =
+      64 * 1024; // see T246457068 for details
+  const auto maxAlphabetSizeInElts = maxAlphabetSizeInBytes / eltWidth;
+
+  uint64_t const maxEltValue =
+      (eltWidth >= 8) ? UINT64_MAX : (1ull << (8 * eltWidth)) - 1;
+  uint64_t const maxCardValue =
+      std::min(std::min(maxEltValue, (uint64_t)nbElts), maxAlphabetSizeInElts);
+  auto const cardinality =
+      ZL_estimateCardinality_fixed(src, nbElts, eltWidth, maxCardValue);
+  if (cardinality.estimateUpperBound >= maxAlphabetSizeInElts) {
+    return false;
+  }
+  size_t const multiplier = (isFloat || compressionLevel == 1) ? 7 : 9;
+  auto const tokenizeEstimatedAlphabetSize =
+      cardinality.estimateUpperBound * eltWidth;
+  auto const tokenizeEstimatedIndicesSize =
+      nbElts * (size_t)ZL_nextPow2(cardinality.estimateUpperBound) / 8;
+  auto const tokenizeEstimatedUpperBounds =
+      tokenizeEstimatedAlphabetSize + tokenizeEstimatedIndicesSize;
+  return tokenizeEstimatedUpperBounds < srcSize * multiplier / 10;
+}
+
+// Selects field-lz vs zstd as the backend LZ stage. Single-byte elements go to
+// zstd; wider elements use the struct-aware field-lz graph.
+class SelectLz : public openzl::Selector {
+ public:
+  explicit SelectLz(openzl::GraphID fieldLz) : fieldLz_{fieldLz} {}
+
+  openzl::SelectorDescription selectorDescription() const override {
+    return {
+        .name = std::string{"nimble.select_lz"},
+        .inputTypeMask = openzl::TypeMask::Numeric,
+        .customGraphs = {fieldLz_},
+    };
+  }
+
+  openzl::GraphID select(
+      openzl::SelectorState& /* state */,
+      const openzl::Input& input) const override {
+    if (input.eltWidth() == 1) {
+      return ZL_GRAPH_ZSTD;
+    }
+    return fieldLz_;
+  }
+
+ private:
+  openzl::GraphID fieldLz_;
+};
+
+// Selects whether to apply the tokenize stage based on a cardinality estimate.
+class SelectTokenize : public openzl::Selector {
+ public:
+  SelectTokenize(
+      openzl::GraphID tokenize,
+      openzl::GraphID noTokenize,
+      bool isFloat)
+      : tokenize_{tokenize}, noTokenize_{noTokenize}, isFloat_{isFloat} {}
+
+  openzl::SelectorDescription selectorDescription() const override {
+    return {
+        .name = isFloat_ ? "nimble.select_tokenize_f32"
+                         : "nimble.select_tokenize_int",
+        .inputTypeMask = openzl::TypeMask::Numeric,
+        .customGraphs = {tokenize_, noTokenize_},
+    };
+  }
+
+  openzl::GraphID select(
+      openzl::SelectorState& state,
+      const openzl::Input& input) const override {
+    const int compressionLevel =
+        state.getCParam(openzl::CParam::CompressionLevel);
+    return shouldTokenize(input, compressionLevel, isFloat_) ? tokenize_
+                                                             : noTokenize_;
+  }
+
+ private:
+  openzl::GraphID tokenize_;
+  openzl::GraphID noTokenize_;
+  bool isFloat_;
+};
+
+// Selects whether to range-pack (subtract min and pack into the smallest
+// integer width) based on the actual value range of the input.
+class SelectRangePack : public openzl::Selector {
+ public:
+  SelectRangePack(openzl::GraphID rangePack, openzl::GraphID noRangePack)
+      : rangePack_{rangePack}, noRangePack_{noRangePack} {}
+
+  openzl::SelectorDescription selectorDescription() const override {
+    return {
+        .name = std::string{"nimble.select_range_pack"},
+        .inputTypeMask = openzl::TypeMask::Numeric,
+        .customGraphs = {rangePack_, noRangePack_},
+    };
+  }
+
+  openzl::GraphID select(
+      openzl::SelectorState& /* state */,
+      const openzl::Input& input) const override {
+    const auto eltWidth = input.eltWidth();
+    const auto nbElts = input.numElts();
+    const auto src = input.ptr();
+    const ZL_ElementRange range =
+        ZL_computeUnsignedRange(src, nbElts, eltWidth);
+    const auto rangeSize = range.max - range.min;
+    if (NUMOP_numericWidthForValue(rangeSize) < eltWidth) {
+      return rangePack_;
+    }
+    return noRangePack_;
+  }
+
+ private:
+  openzl::GraphID rangePack_;
+  openzl::GraphID noRangePack_;
+};
+
+// Registers the chunk segmenter on the raw compressor and wraps @p innerGraph
+// with it, threading the element byte width through as a local parameter. This
+// is the only place the C API is used directly, since segmenters have no C++
+// wrapper.
+openzl::GraphID wrapWithDefaultSegmenter(
+    ZL_Compressor* cgraph,
+    openzl::GraphID innerGraph,
+    size_t elementByteWidth) {
+  ZL_Type inputType = ZL_Type_serial;
+  ZL_SegmenterDesc desc = {
+      .name = "!nimble.default_segmenter",
+      .segmenterFn = defaultSegmenter,
+      .inputTypeMasks = &inputType,
+      .numInputs = 1,
+      .lastInputIsVariable = false,
+      .customGraphs = nullptr,
+      .numCustomGraphs = 0,
+      .localParams = {},
+  };
+  ZL_GraphID const segmenterBase =
+      ZL_Compressor_registerSegmenter(cgraph, &desc);
+
+  ZL_IntParam intParams[] = {{
+      .paramId = kNimbleElementByteWidthParamId,
+      .paramValue = static_cast<int>(elementByteWidth),
+  }};
+  ZL_LocalParams segParams = {
+      .intParams = {.intParams = intParams, .nbIntParams = 1},
+  };
+  ZL_ParameterizedGraphDesc const segGraphDesc = {
+      .graph = segmenterBase,
+      .customGraphs = &innerGraph,
+      .nbCustomGraphs = 1,
+      .localParams = &segParams,
+  };
+  return ZL_Compressor_registerParameterizedGraph(cgraph, &segGraphDesc);
+}
+
+// Builds the default numeric graph:
+//   serial -> interpret-as-LE(width) -> range-pack? -> tokenize?+delta -> lz
+// Wrapped by the multi-chunk segmenter.
+// This decision-making is a default "should-be-good-enough" pipeline that can
+// be modified or replaced to fit to your specific use case.
+openzl::GraphID makeNumericGraph(
+    openzl::Compressor& compressor,
+    bool isFloat,
+    size_t elementBitWidth,
+    int formatVersion) {
+  const size_t elementByteWidth = elementBitWidth / 8;
+
+  const openzl::GraphID fieldLz = openzl::graphs::FieldLz{}(compressor);
+  const openzl::GraphID lz = openzl::Selector::registerSelector(
+      compressor, std::make_shared<SelectLz>(fieldLz));
+
+  const openzl::GraphID deltaLz = openzl::nodes::DeltaInt{}(compressor, lz);
+  const openzl::GraphID tokenize =
+      openzl::nodes::TokenizeNumeric{/* sort */ true}(compressor, deltaLz, lz);
+
+  const openzl::GraphID tokenizeOrNot = openzl::Selector::registerSelector(
+      compressor, std::make_shared<SelectTokenize>(tokenize, lz, isFloat));
+
+  const openzl::GraphID range =
+      openzl::nodes::RangePack{}(compressor, tokenizeOrNot);
+  const openzl::GraphID rangeOrNot = openzl::Selector::registerSelector(
+      compressor, std::make_shared<SelectRangePack>(range, tokenizeOrNot));
+
+  openzl::nodes::ConvertSerialToNumLE toNumeric{
+      static_cast<int>(elementByteWidth)};
+  const openzl::GraphID innerGraph = toNumeric(compressor, rangeOrNot);
+  return wrapWithDefaultSegmenter(
+      compressor.get(), innerGraph, elementByteWidth);
+}
+
+// Maps the nimble DataType to the appropriate numeric graph. Types without
+// a dedicated numeric pipeline fall back to a plain zstd graph (still a valid
+// OpenZL frame).
+openzl::GraphID createGraph(
+    openzl::Compressor& compressor,
+    DataType dataType,
+    int formatVersion) {
+  switch (dataType) {
+    case DataType::Int8:
+    case DataType::Uint8:
+      return makeNumericGraph(
+          compressor, /* isFloat */ false, 8, formatVersion);
+    case DataType::Int16:
+    case DataType::Uint16:
+      return makeNumericGraph(
+          compressor, /* isFloat */ false, 16, formatVersion);
+    case DataType::Int32:
+    case DataType::Uint32:
+      return makeNumericGraph(
+          compressor, /* isFloat */ false, 32, formatVersion);
+    case DataType::Int64:
+    case DataType::Uint64:
+      return makeNumericGraph(
+          compressor, /* isFloat */ false, 64, formatVersion);
+    case DataType::Float:
+      return makeNumericGraph(
+          compressor, /* isFloat */ true, 32, formatVersion);
+    case DataType::Double:
+    case DataType::Bool:
+    case DataType::String:
+    case DataType::Undefined:
+    default:
+      return ZL_GRAPH_ZSTD;
+  }
+}
+
+} // namespace
+
+CompressionResult OpenZLCompressor::compress(
+    velox::memory::MemoryPool& pool,
+    std::string_view data,
+    DataType dataType,
+    int /* bitWidth */,
+    const CompressionPolicy& compressionPolicy) {
+  const auto parameters = compressionPolicy.compression().parameters.openzl;
+
+  openzl::Compressor compressor;
+  compressor.selectStartingGraph(
+      createGraph(compressor, dataType, parameters.formatVersion));
+
+  openzl::CCtx cctx;
+  cctx.setParameter(
+      openzl::CParam::CompressionLevel, parameters.compressionLevel);
+  cctx.setParameter(
+      openzl::CParam::DecompressionLevel, parameters.decompressionLevel);
+  cctx.setParameter(openzl::CParam::FormatVersion, parameters.formatVersion);
+  cctx.refCompressor(compressor);
+
+  Vector<char> buffer{&pool, openzl::compressBound(data.size())};
+  const size_t compressedSize =
+      cctx.compressSerial({buffer.data(), buffer.size()}, data);
+
+  if (!compressionPolicy.shouldAccept(
+          CompressionType::OpenZL, data.size(), compressedSize)) {
+    return {
+        .compressionType = CompressionType::Uncompressed,
+        .buffer = std::nullopt,
+    };
+  }
+
+  buffer.resize(compressedSize);
+  return {
+      .compressionType = CompressionType::OpenZL,
+      .buffer = std::move(buffer),
+  };
+}
+
+velox::BufferPtr OpenZLCompressor::uncompress(
+    velox::memory::MemoryPool& pool,
+    const CompressionType /* compressionType */,
+    const DataType /* dataType */,
+    std::string_view data,
+    velox::BufferPool* bufferPool) {
+  openzl::DCtx dctx;
+  const size_t uncompressedSize =
+      dctx.unwrap(ZL_getDecompressedSize(data.data(), data.size()));
+  auto buffer = allocateBuffer(pool, bufferPool, uncompressedSize);
+  const size_t written =
+      dctx.decompressSerial({buffer->asMutable<char>(), buffer->size()}, data);
+  NIMBLE_CHECK(
+      written == uncompressedSize,
+      "Decompressed size mismatch: expected {}, got {}",
+      uncompressedSize,
+      written);
+  return buffer;
+}
+
+std::optional<size_t> OpenZLCompressor::uncompressedSize(
+    std::string_view data) const {
+  const ZL_Report report = ZL_getDecompressedSize(data.data(), data.size());
+  if (ZL_isError(report)) {
+    return std::nullopt;
+  }
+  return ZL_validResult(report);
+}
+
+CompressionType OpenZLCompressor::compressionType() {
+  return CompressionType::OpenZL;
+}
+
+} // namespace facebook::nimble

--- a/dwio/nimble/compression/OpenZLCompressor.h
+++ b/dwio/nimble/compression/OpenZLCompressor.h
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "dwio/nimble/compression/Compression.h"
+
+namespace facebook::nimble {
+
+/// ICompressor backed by custom graphs implemented using OpenZL
+class OpenZLCompressor : public ICompressor {
+ public:
+  CompressionResult compress(
+      velox::memory::MemoryPool& pool,
+      std::string_view data,
+      DataType dataType,
+      int bitWidth,
+      const CompressionPolicy& compressionPolicy) override;
+
+  velox::BufferPtr uncompress(
+      velox::memory::MemoryPool& pool,
+      CompressionType compressionType,
+      DataType dataType,
+      std::string_view data,
+      velox::BufferPool* bufferPool = nullptr) override;
+
+  std::optional<size_t> uncompressedSize(std::string_view data) const override;
+
+  CompressionType compressionType() override;
+};
+
+} // namespace facebook::nimble

--- a/dwio/nimble/encodings/selection/EncodingSelectionPolicy.h
+++ b/dwio/nimble/encodings/selection/EncodingSelectionPolicy.h
@@ -116,6 +116,12 @@ struct CompressionOptions {
   uint32_t internalDecompressionLevel = 2;
   bool useVariableBitWidthCompressor = false;
   MetaInternalCompressionKey metaInternalCompressionKey;
+  // OpenZL settings
+  uint64_t openzlMinCompressionSize = kOpenZLMinCompressionSize;
+  // 6/3 is a close analogue to the performance of zstd level 3
+  int32_t openzlCompressionLevel = 6;
+  int32_t openzlDecompressionLevel = 3;
+  int32_t openzlFormatVersion = 25;
   // Per-encoding overrides for compressionAcceptRatio.
   // BlockBitPacking default 0.7: data is already well-packed via per-block
   // baselines, so compression must save at least 30% to justify CPU cost.
@@ -242,6 +248,19 @@ class ManualEncodingSelectionPolicy : public EncodingSelectionPolicy<T> {
               .minCompressionSize = compressionOptions_.lz4MinCompressionSize};
           information.parameters.lz4.accelerationLevel =
               compressionOptions_.lz4AccelerationLevel;
+          return information;
+        }
+        if (compressionOptions_.compressionType == CompressionType::OpenZL) {
+          CompressionInformation information{
+              .compressionType = CompressionType::OpenZL,
+              .minCompressionSize =
+                  compressionOptions_.openzlMinCompressionSize};
+          information.parameters.openzl.compressionLevel =
+              compressionOptions_.openzlCompressionLevel;
+          information.parameters.openzl.decompressionLevel =
+              compressionOptions_.openzlDecompressionLevel;
+          information.parameters.openzl.formatVersion =
+              compressionOptions_.openzlFormatVersion;
           return information;
         }
         CompressionInformation information{

--- a/dwio/nimble/encodings/tests/CMakeLists.txt
+++ b/dwio/nimble/encodings/tests/CMakeLists.txt
@@ -31,6 +31,7 @@ add_executable(
   FrequencyPartitionEncodingTest.cpp
   MainlyConstantEncodingTest.cpp
   NullableEncodingTest.cpp
+  OpenZLCompressorTest.cpp
   PFOREncodingTest.cpp
   PrefixEncodingTest.cpp
   RLEEncodingTest.cpp

--- a/dwio/nimble/encodings/tests/OpenZLCompressorTest.cpp
+++ b/dwio/nimble/encodings/tests/OpenZLCompressorTest.cpp
@@ -1,0 +1,228 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "dwio/nimble/compression/OpenZLCompressor.h"
+#include <gtest/gtest.h>
+#include <cstring>
+#include <random>
+#include <vector>
+#include "velox/buffer/BufferPool.h"
+#include "velox/common/memory/Memory.h"
+
+using namespace facebook::nimble;
+
+namespace {
+
+class TestOpenZLCompressionPolicy : public CompressionPolicy {
+ public:
+  explicit TestOpenZLCompressionPolicy(uint64_t minCompressionSize = 0) {
+    compressionInfo_ = {
+        .compressionType = CompressionType::OpenZL,
+        .minCompressionSize = minCompressionSize};
+  }
+
+  CompressionInformation compression() const override {
+    return compressionInfo_;
+  }
+
+  bool shouldAccept(
+      CompressionType /* compressionType */,
+      uint64_t uncompressedSize,
+      uint64_t compressedSize) const override {
+    return compressedSize < uncompressedSize;
+  }
+
+ private:
+  CompressionInformation compressionInfo_;
+};
+
+// Builds a serial byte buffer from a numeric vector for feeding into the
+// compressor.
+template <typename T>
+std::string_view asBytes(const std::vector<T>& values) {
+  return std::string_view(
+      reinterpret_cast<const char*>(values.data()), values.size() * sizeof(T));
+}
+
+// Round-trips compressible numeric data through OpenZL and asserts the bytes
+// come back identical.
+template <typename T>
+void roundTripNumeric(DataType dataType, const std::vector<T>& values) {
+  auto pool = facebook::velox::memory::deprecatedAddDefaultLeafMemoryPool();
+  OpenZLCompressor compressor;
+  TestOpenZLCompressionPolicy policy;
+
+  auto input = asBytes(values);
+  auto result = compressor.compress(*pool, input, dataType, 0, policy);
+  ASSERT_EQ(CompressionType::OpenZL, result.compressionType);
+  ASSERT_TRUE(result.buffer.has_value());
+
+  std::string_view compressed(result.buffer->data(), result.buffer->size());
+  auto decompressed = compressor.uncompress(
+      *pool, CompressionType::OpenZL, dataType, compressed);
+  ASSERT_EQ(input.size(), decompressed->size());
+  EXPECT_EQ(
+      0, std::memcmp(input.data(), decompressed->as<char>(), input.size()));
+}
+
+} // namespace
+
+TEST(OpenZLCompressorTest, CompressionType) {
+  OpenZLCompressor compressor;
+  EXPECT_EQ(CompressionType::OpenZL, compressor.compressionType());
+}
+
+TEST(OpenZLCompressorTest, RoundTripInt8) {
+  std::vector<int8_t> values(4096);
+  for (size_t i = 0; i < values.size(); ++i) {
+    values[i] = static_cast<int8_t>(i % 10);
+  }
+  roundTripNumeric(DataType::Int8, values);
+}
+
+TEST(OpenZLCompressorTest, RoundTripInt32) {
+  // A narrow, locally-correlated range that exercises range-pack and delta.
+  std::vector<int32_t> values(4096);
+  for (size_t i = 0; i < values.size(); ++i) {
+    values[i] = static_cast<int32_t>(1000 + (i % 50));
+  }
+  roundTripNumeric(DataType::Int32, values);
+}
+
+TEST(OpenZLCompressorTest, RoundTripInt64) {
+  std::vector<int64_t> values(4096);
+  for (size_t i = 0; i < values.size(); ++i) {
+    values[i] = static_cast<int64_t>(i / 4);
+  }
+  roundTripNumeric(DataType::Int64, values);
+}
+
+TEST(OpenZLCompressorTest, RoundTripFloat) {
+  std::vector<float> values(4096);
+  for (size_t i = 0; i < values.size(); ++i) {
+    values[i] = static_cast<float>(i % 16);
+  }
+  roundTripNumeric(DataType::Float, values);
+}
+
+TEST(OpenZLCompressorTest, RoundTripSerialInput) {
+  // Feed raw serial bytes tagged as Int8 (single-byte path -> zstd backend).
+  auto pool = facebook::velox::memory::deprecatedAddDefaultLeafMemoryPool();
+  OpenZLCompressor compressor;
+  TestOpenZLCompressionPolicy policy;
+
+  std::vector<char> original(2048);
+  for (size_t i = 0; i < original.size(); ++i) {
+    original[i] = static_cast<char>(i % 7);
+  }
+  std::string_view input(original.data(), original.size());
+
+  auto result = compressor.compress(*pool, input, DataType::Int8, 0, policy);
+  ASSERT_EQ(CompressionType::OpenZL, result.compressionType);
+  ASSERT_TRUE(result.buffer.has_value());
+
+  std::string_view compressed(result.buffer->data(), result.buffer->size());
+  auto decompressed = compressor.uncompress(
+      *pool, CompressionType::OpenZL, DataType::Int8, compressed);
+  ASSERT_EQ(original.size(), decompressed->size());
+  EXPECT_EQ(
+      0,
+      std::memcmp(original.data(), decompressed->as<char>(), original.size()));
+}
+
+TEST(OpenZLCompressorTest, UncompressedSize) {
+  auto pool = facebook::velox::memory::deprecatedAddDefaultLeafMemoryPool();
+  OpenZLCompressor compressor;
+  TestOpenZLCompressionPolicy policy;
+
+  std::vector<int32_t> values(2048, 42);
+  auto input = asBytes(values);
+
+  auto result = compressor.compress(*pool, input, DataType::Int32, 0, policy);
+  ASSERT_EQ(CompressionType::OpenZL, result.compressionType);
+  ASSERT_TRUE(result.buffer.has_value());
+
+  std::string_view compressed(result.buffer->data(), result.buffer->size());
+  auto size = compressor.uncompressedSize(compressed);
+  ASSERT_TRUE(size.has_value());
+  EXPECT_EQ(input.size(), size.value());
+}
+
+TEST(OpenZLCompressorTest, IncompressibleData) {
+  auto pool = facebook::velox::memory::deprecatedAddDefaultLeafMemoryPool();
+  OpenZLCompressor compressor;
+  TestOpenZLCompressionPolicy policy;
+
+  std::mt19937 rng(42);
+  std::uniform_int_distribution<int> dist(0, 255);
+  std::vector<char> randomData(256);
+  for (auto& byte : randomData) {
+    byte = static_cast<char>(dist(rng));
+  }
+  std::string_view input(randomData.data(), randomData.size());
+
+  auto result = compressor.compress(*pool, input, DataType::Int8, 0, policy);
+  // Random data should not compress; the policy rejects it -> Uncompressed.
+  EXPECT_EQ(CompressionType::Uncompressed, result.compressionType);
+  EXPECT_FALSE(result.buffer.has_value());
+}
+
+TEST(OpenZLCompressorTest, MinCompressionSizeSkipsSmallData) {
+  auto pool = facebook::velox::memory::deprecatedAddDefaultLeafMemoryPool();
+
+  std::vector<char> data(50, 'a');
+  std::string_view input(data.data(), data.size());
+
+  // minCompressionSize larger than the data -> CompressionEncoder skips it.
+  TestOpenZLCompressionPolicy policy(data.size() + 1);
+  CompressionEncoder<int8_t> encoder{*pool, policy, DataType::Int8, input};
+  EXPECT_EQ(CompressionType::Uncompressed, encoder.compressionType());
+}
+
+TEST(OpenZLCompressorTest, UncompressWithBufferPool) {
+  auto pool = facebook::velox::memory::deprecatedAddDefaultLeafMemoryPool();
+  OpenZLCompressor compressor;
+  TestOpenZLCompressionPolicy policy;
+  facebook::velox::BufferPool bufferPool{
+      facebook::velox::BufferPool::kDefaultCapacity};
+
+  std::vector<int32_t> values(2048);
+  for (size_t i = 0; i < values.size(); ++i) {
+    values[i] = static_cast<int32_t>(i % 20);
+  }
+  auto input = asBytes(values);
+
+  auto result = compressor.compress(*pool, input, DataType::Int32, 0, policy);
+  ASSERT_TRUE(result.buffer.has_value());
+  std::string_view compressed(result.buffer->data(), result.buffer->size());
+
+  // First decompress allocates fresh from the pool path.
+  auto decompressed = compressor.uncompress(
+      *pool, CompressionType::OpenZL, DataType::Int32, compressed, &bufferPool);
+  ASSERT_EQ(input.size(), decompressed->size());
+  EXPECT_EQ(
+      0, std::memcmp(input.data(), decompressed->as<char>(), input.size()));
+
+  // Return to the pool, then decompress again -> should reuse.
+  bufferPool.release(std::move(decompressed));
+  EXPECT_EQ(bufferPool.size(), 1);
+
+  auto decompressed2 = compressor.uncompress(
+      *pool, CompressionType::OpenZL, DataType::Int32, compressed, &bufferPool);
+  EXPECT_EQ(bufferPool.size(), 0);
+  ASSERT_EQ(input.size(), decompressed2->size());
+  EXPECT_EQ(
+      0, std::memcmp(input.data(), decompressed2->as<char>(), input.size()));
+}

--- a/dwio/nimble/tablet/Footer.fbs
+++ b/dwio/nimble/tablet/Footer.fbs
@@ -20,6 +20,7 @@ enum CompressionType:uint8 {
   Zstd = 1,
   MetaInternal = 2,
   Lz4 = 3,
+  OpenZL = 4,
 }
 
 table Stripes {


### PR DESCRIPTION
Summary:
## Context
Nimble's only "advanced" data compressor is `MetaInternalCompressor`, which depends
on Meta-only Managed Compression and the internal xldb compressor lib. These are
stripped from the open-source build (`DISABLE_META_INTERNAL_COMPRESSOR`), leaving OSS
Nimble with no OpenZL-based numeric compressor.

## This diff
Adds a new `OpenZLCompressor` codec (`CompressionType::OpenZL = 4`) that lives in the
open-source `dwio/nimble/compression/` folder and depends only on the open-sourced
OpenZL library (`//openzl:openzl_core`) — no Meta-only code. It uses a numeric graph built with OpenZL's C++ selector/codec APIs (`openzl::Selector`,
`openzl::nodes::*`, RAII `Compressor`/`CCtx`/`DCtx`). The codec is registered
unconditionally, like Zstd/Lz4.

Wiring (following `compression/COMPRESSION.md`'s "Adding a New Codec" checklist):
- `common/Types.{h,cpp}`: add `OpenZL = 4` enum value + `toString`.
- `tablet/Footer.fbs`: add matching `OpenZL = 4` (footer enum is `static_cast` from the
  C++ enum, so values must match).
- `common/Constants.h`: add `kOpenZLMinCompressionSize`.
- `compression/Compression.cpp`: register `OpenZLCompressor` in `CompressorRegistry`.
- `compression/CompressionPolicy.h`: add `OpenZLCompressionParameters`.
- `encodings/selection/EncodingSelectionPolicy.h`: add OpenZL fields to
  `CompressionOptions` and a branch in `AlwaysCompressPolicy::compression()` so the
  writer can actually select the codec.
- `compression/BUCK` + `compression/CMakeLists.txt`: build wiring + OpenZL dep.

Note: OpenZL frames self-describe their decompressed size (`ZL_getDecompressedSize`), so
unlike Zstd/Lz4 this codec doesn't prepend a `uint32_t` size header.

Reviewed By: srsuryadev

Differential Revision: D108189356


