### PR TITLE
refactor(encoding): Add EncodingFactory::create overload with Options parameter (#905)

### DIFF
--- a/dwio/nimble/encodings/common/EncodingFactory.cpp
+++ b/dwio/nimble/encodings/common/EncodingFactory.cpp
@@ -60,7 +60,14 @@ std::unique_ptr<Encoding> EncodingFactory::create(
     velox::memory::MemoryPool& pool,
     std::string_view data,
     std::function<void*(uint32_t)> stringBufferFactory) const {
-  const auto& options = options_;
+  return create(pool, data, std::move(stringBufferFactory), options_);
+}
+
+std::unique_ptr<Encoding> EncodingFactory::create(
+    velox::memory::MemoryPool& pool,
+    std::string_view data,
+    std::function<void*(uint32_t)> stringBufferFactory,
+    const Encoding::Options& options) const {
   // Maybe we should have a magic number of encodings too? Hrm.
   const EncodingType encodingType = static_cast<EncodingType>(data[0]);
   const DataType dataType = static_cast<DataType>(data[1]);

--- a/dwio/nimble/encodings/common/EncodingFactory.h
+++ b/dwio/nimble/encodings/common/EncodingFactory.h
@@ -42,6 +42,13 @@ class EncodingFactory {
       std::string_view data,
       std::function<void*(uint32_t)> stringBufferFactory) const;
 
+  /// Same as above but uses the provided options instead of stored options_.
+  virtual std::unique_ptr<Encoding> create(
+      velox::memory::MemoryPool& pool,
+      std::string_view data,
+      std::function<void*(uint32_t)> stringBufferFactory,
+      const Encoding::Options& options) const;
+
   const Encoding::Options& options() const {
     return options_;
   }

--- a/dwio/nimble/encodings/legacy/EncodingFactory.cpp
+++ b/dwio/nimble/encodings/legacy/EncodingFactory.cpp
@@ -333,6 +333,14 @@ std::unique_ptr<Encoding> EncodingFactory::create(
   }
 }
 
+std::unique_ptr<Encoding> EncodingFactory::create(
+    velox::memory::MemoryPool& memoryPool,
+    std::string_view data,
+    std::function<void*(uint32_t)> stringBufferFactory,
+    const Encoding::Options& /*options*/) const {
+  return create(memoryPool, data, std::move(stringBufferFactory));
+}
+
 template <typename T>
 std::string_view EncodingFactory::encode(
     std::unique_ptr<EncodingSelectionPolicy<T>>&& selectorPolicy,

--- a/dwio/nimble/encodings/legacy/EncodingFactory.h
+++ b/dwio/nimble/encodings/legacy/EncodingFactory.h
@@ -34,6 +34,12 @@ class EncodingFactory : public ::facebook::nimble::EncodingFactory {
       std::string_view data,
       std::function<void*(uint32_t)> stringBufferFactory) const override;
 
+  std::unique_ptr<Encoding> create(
+      velox::memory::MemoryPool& memoryPool,
+      std::string_view data,
+      std::function<void*(uint32_t)> stringBufferFactory,
+      const Encoding::Options& options) const override;
+
   template <typename T>
   static std::string_view encode(
       std::unique_ptr<EncodingSelectionPolicy<T>>&& selectorPolicy,

--- a/dwio/nimble/velox/selective/ChunkedDecoder.cpp
+++ b/dwio/nimble/velox/selective/ChunkedDecoder.cpp
@@ -57,14 +57,10 @@ bool ChunkedDecoder::loadNextChunk(
     return buffer->asMutable<void>();
   };
   auto data = std::string_view(chunkData, chunkSize);
-  if (preserveDictionaryEncoding) {
-    auto options = encodingFactory_->options();
-    options.preserveDictionaryEncoding = true;
-    encoding_ =
-        EncodingFactory(options).create(*pool_, data, stringBufferFactory);
-  } else {
-    encoding_ = encodingFactory_->create(*pool_, data, stringBufferFactory);
-  }
+  auto options = encodingFactory_->options();
+  options.preserveDictionaryEncoding = preserveDictionaryEncoding;
+  encoding_ =
+      encodingFactory_->create(*pool_, data, stringBufferFactory, options);
   remainingValues_ = encoding_->rowCount();
   NIMBLE_CHECK_GT(remainingValues_, 0);
   VLOG(1) << encoding_->debugString();


### PR DESCRIPTION
Summary:

CONTEXT: `EncodingFactory::create()` always uses the factory internal `options_`. Callers that need custom options (e.g. `preserveDictionaryEncoding`, `decodingStats`) must construct a new `EncodingFactory(options)`, which slices the factory — if the instance is a `legacy::EncodingFactory`, the subclass `create()` override is lost, producing incorrect encodings.

WHAT:
- Add virtual `EncodingFactory::create(pool, data, stringBufferFactory, options)` overload that uses caller-provided options instead of internal `options_`
- Refactor existing 3-arg `create()` to delegate to the new 4-arg overload
- Override in `legacy::EncodingFactory` to delegate to legacy 3-arg `create()` (legacy encodings do not use options)

Differential Revision: D109653414


