### PR TITLE
fix(encoding): Reject empty Dictionary replay as incompatible

### DIFF
--- a/dwio/nimble/encodings/common/EncodingFactory.cpp
+++ b/dwio/nimble/encodings/common/EncodingFactory.cpp
@@ -390,9 +390,19 @@ std::string_view EncodingFactory::encode(
       return RLEEncoding<T>::encode(selection, castedValues, buffer, options);
     }
     case EncodingType::Dictionary: {
-      NIMBLE_DCHECK(
-          (!std::is_same<T, bool>::value && !castedValues.empty()),
-          "Invalid DictionaryEncoding selection.");
+      if constexpr (std::is_same<T, bool>::value) {
+        NIMBLE_INCOMPATIBLE_ENCODING(
+            "Dictionary encoding cannot be used for boolean data.");
+      }
+      if (castedValues.empty()) {
+        // A replayed Dictionary layout can land on an empty stream (e.g. a
+        // MainlyConstant whose OtherValues are all the common value). Reject it
+        // as an incompatible encoding -- like the other data-requiring
+        // encodings here -- so the writer retries without the captured layout
+        // instead of aborting on an empty dictionary.
+        NIMBLE_INCOMPATIBLE_ENCODING(
+            "Dictionary encoding cannot be used with 0 rows.");
+      }
       return DictionaryEncoding<T>::encode(
           selection, castedValues, buffer, options);
     }

--- a/dwio/nimble/encodings/tests/EncodingLayoutTest.cpp
+++ b/dwio/nimble/encodings/tests/EncodingLayoutTest.cpp
@@ -17,6 +17,7 @@
 #include <gtest/gtest.h>
 #include "dwio/nimble/common/Buffer.h"
 #include "dwio/nimble/common/Exceptions.h"
+#include "dwio/nimble/common/tests/GTestUtils.h"
 #ifdef NIMBLE_ENABLE_EXPERIMENTAL_ENCODINGS
 #include "dwio/nimble/encodings/SubIntSplitConfig.h"
 #endif
@@ -392,6 +393,75 @@ TEST(EncodingLayoutTests, Dictionary) {
 
   testSerialization(expected);
   testCapture<uint32_t>(expected, {1, 1, 1, 1, 5, 1});
+}
+
+TEST(EncodingLayoutTests, ReplayDictionaryRejectsEmpty) {
+  // A replayed Dictionary layout applied to an EMPTY value stream cannot build
+  // a dictionary. It must reject the stream with an incompatible-encoding error
+  // -- like the other data-requiring encodings in EncodingFactory -- so the
+  // writer retries the stream without the captured layout. Before the fix this
+  // was a NIMBLE_DCHECK that aborted the process (and was silently ignored in
+  // opt).
+  nimble::EncodingLayout dictionary{
+      nimble::EncodingType::Dictionary,
+      {},
+      nimble::CompressionType::Uncompressed,
+      {
+          nimble::EncodingLayout{
+              nimble::EncodingType::Trivial,
+              {},
+              nimble::CompressionType::Uncompressed},
+          nimble::EncodingLayout{
+              nimble::EncodingType::FixedBitWidth,
+              {},
+              nimble::CompressionType::Uncompressed},
+      }};
+
+  NIMBLE_ASSERT_THROW(
+      encodeAndCapture<uint32_t>(
+          std::move(dictionary), std::vector<uint32_t>{}),
+      "Dictionary encoding cannot be used with 0 rows.");
+}
+
+TEST(
+    EncodingLayoutTests,
+    ReplayMainlyConstantDictionaryRejectsEmptyOtherValues) {
+  // Replay a MainlyConstant whose OtherValues stream is a nested Dictionary.
+  // When every value equals the common value, OtherValues is empty, so the
+  // nested Dictionary replay has nothing to encode -- the data shape that made
+  // fuzzMainlyConstantDictionaryVector flake. The empty inner Dictionary must
+  // reject with an incompatible-encoding error (propagated out of the
+  // MainlyConstant encode) instead of aborting, so the writer can retry.
+  nimble::EncodingLayout mainlyConstant{
+      nimble::EncodingType::MainlyConstant,
+      {},
+      nimble::CompressionType::Uncompressed,
+      {
+          nimble::EncodingLayout{
+              nimble::EncodingType::Trivial,
+              {},
+              nimble::CompressionType::Uncompressed},
+          nimble::EncodingLayout{
+              nimble::EncodingType::Dictionary,
+              {},
+              nimble::CompressionType::Uncompressed,
+              {
+                  nimble::EncodingLayout{
+                      nimble::EncodingType::Trivial,
+                      {},
+                      nimble::CompressionType::Uncompressed},
+                  nimble::EncodingLayout{
+                      nimble::EncodingType::FixedBitWidth,
+                      {},
+                      nimble::CompressionType::Uncompressed},
+              }},
+      }};
+
+  // All values identical -> MainlyConstant OtherValues stream is empty.
+  std::vector<uint32_t> data(64, 7);
+  NIMBLE_ASSERT_THROW(
+      encodeAndCapture<uint32_t>(std::move(mainlyConstant), data),
+      "Dictionary encoding cannot be used with 0 rows.");
 }
 
 TEST(EncodingLayoutTests, Rle) {


### PR DESCRIPTION
Summary:
`ReplayedEncodingSelectionPolicy` replays a captured layout's encoding type unconditionally, ignoring the values being encoded. When a replayed `Dictionary` lands on an empty value stream -- e.g. a `MainlyConstant` whose `OtherValues` are all the common value -- `EncodingFactory::encode`'s `Dictionary` case guarded the empty case with `NIMBLE_DCHECK` ("Invalid DictionaryEncoding selection"), which aborts dev/test builds and is silently skipped in opt builds (which then proceed into `DictionaryEncoding::encode` on empty data).

Every other data-requiring encoding in `EncodingFactory` (`FixedBitWidth`, `MainlyConstant`, `PFOR`, `SimdForBitpack`, ...) rejects this situation with the catchable `NIMBLE_INCOMPATIBLE_ENCODING`, which `VeloxWriter::encodeStreamTyped` catches (`error_code::IncompatibleEncoding`) and recovers from by re-encoding the stream without the captured layout. `Dictionary` was the lone exception. This makes the `Dictionary` case reject empty (and boolean) input with `NIMBLE_INCOMPATIBLE_ENCODING` like its siblings, so the writer's existing retry recovers instead of aborting. The `Dictionary` case is written as sequential noreturn guards (`if constexpr` bool check, then empty check) followed by a fall-through `return DictionaryEncoding<T>::encode(...)`, rather than an `if/else if/else` chain.

Surfaced as a seed-dependent flake in `E2EFilterTest.fuzzMainlyConstantDictionaryVector` (e.g. seed 2631927570, where an all-common chunk produced an empty `OtherValues` stream).

Also folds in a build-signal fix unrelated to the encoding logic: `dwio/nimble/encodings/tests:bucket_benchmark` set x86-only SIMD `compiler_flags` (`-mavx`, `-mavx2`, `-mbmi`, ...) with no arch guard, so it failed the aarch64 build (clang rejects those flags for that target). This is a pre-existing break that surfaced as a land-blocking signal here only because the target determinator builds the `encodings/tests` package this diff touches. Gated the flags behind `select({"ovr_config//cpu:x86_64": [...], "DEFAULT": []})` so the portable source still builds on aarch64.

Differential Revision: D109690967


