### PR TITLE
fix(selective): Prepare result nulls on abandon-dictionary fallback (#912)

### DIFF
--- a/dwio/nimble/encodings/NullableEncoding.h
+++ b/dwio/nimble/encodings/NullableEncoding.h
@@ -318,7 +318,7 @@ void NullableEncoding<T>::materializeNullsForVisitor(
     auto* nulls = params.makeReaderNulls();
     nulls_->materializeBoolsAsBits(rowCount, nulls, params.numScanned);
   }
-  params.initReturnReaderNulls();
+  params.setReturnNullsMode();
 }
 
 template <typename T>

--- a/dwio/nimble/encodings/common/Encoding.h
+++ b/dwio/nimble/encodings/common/Encoding.h
@@ -86,9 +86,11 @@ struct ReadWithVisitorParams {
   // across potential multiple chunks.
   std::function<uint64_t*()> makeReaderNulls;
 
-  // Initialize `SelectiveColumnReader::returnReaderNulls_' field.  Need to be
-  // called after decoding nulls in `NullableEncoding'.
-  std::function<void()> initReturnReaderNulls;
+  // Resolves which buffer `SelectiveColumnReader::resultNulls()' returns for
+  // this read by setting the `returnReaderNulls_' flag (and `anyNulls_').
+  // Resolves the flag only; allocates no buffer.  Must be called after decoding
+  // nulls in `NullableEncoding'.
+  std::function<void()> setReturnNullsMode;
 
   // Create the result nulls if not already exists.  Similar to
   // `makeReaderNulls', we create one single buffer for all the results nulls
@@ -449,7 +451,8 @@ T castFromPhysicalType(const PhysicalType& value) {
 // not pre-populate nullsInReadRange_ in prepareRead() for scalar columns (their
 // nulls are materialized lazily during decode), so prepareRead() did not size
 // resultNulls_; the dense filtered path must allocate it before the first
-// addNull(). No-op without a filter (no processNull path) or without nulls.
+// addNull(). No-op without a filter (no processNull path); the call itself
+// no-ops when the read range has no nulls (prepareNulls short-circuits).
 //
 // TODO: This is intentionally eager -- it allocates resultNulls_ whenever a
 // filtered read sees a null bitmap, even for value filters where no null row
@@ -458,13 +461,9 @@ T castFromPhysicalType(const PhysicalType& value) {
 // kHasFilter branch entirely and handles null emission post-hoc, at which point
 // this helper and its call sites should be deleted.
 template <typename V>
-void prepareResultNullsForDenseFilter(
-    const ReadWithVisitorParams& params,
-    const uint64_t* rawNulls) {
+void prepareResultNullsForDenseFilter(const ReadWithVisitorParams& params) {
   if constexpr (V::kHasFilter) {
-    if (rawNulls != nullptr) {
-      params.prepareResultNulls();
-    }
+    params.prepareResultNulls();
   }
 }
 
@@ -490,7 +489,7 @@ void readDenseMaterializedIndices(
     uint32_t numNonNulls) {
   // On the filtered path, allocate the result-nulls buffer up front so the
   // per-row processNull() -> addNull() below has somewhere to write.
-  prepareResultNullsForDenseFilter<V>(params, rawNulls);
+  prepareResultNullsForDenseFilter<V>(params);
   const auto readOffset = params.numScanned;
   // When the visitor has a filter, materialize indices into a temp buffer
   // and dispatch through the visitor's process()/processNull() per row.
@@ -592,6 +591,9 @@ void readSparseMaterializedIndices(
   // When the visitor has a filter, dispatch through process()/processNull()
   // per row so the visitor evaluates the filter and handles outputRows.
   if constexpr (V::kHasFilter) {
+    // Allocate the result-nulls buffer up front (self-no-ops when the range has
+    // no nulls) so the per-row processNull() -> addNull() below has a buffer.
+    prepareResultNulls();
     uint32_t indexOffset = 0;
     bool atEnd = false;
     if (rawNulls != nullptr) {
@@ -609,11 +611,6 @@ void readSparseMaterializedIndices(
           ++indexOffset;
         } else {
           if (readCurrentRow) {
-            // Ensure the result-nulls buffer exists before processNull() ->
-            // addNull() writes rawResultNulls_. On the filtered path
-            // returnReaderNulls_ is false, so only prepareResultNulls()
-            // allocates it. Idempotent.
-            prepareResultNulls();
             visitor.processNull(atEnd);
           }
         }
@@ -639,10 +636,18 @@ void readSparseMaterializedIndices(
       reinterpret_cast<int32_t*>(visitor.reader().rawValues());
   const auto valueOutputOffset = visitor.reader().numValues();
 
+  // Allocate and clear resultNulls_ before the loop rather than on the first
+  // emitted null: the loop only writes null positions, so a read whose
+  // surviving rows are all non-null would leave a reused buffer untouched and
+  // leak stale null bits into the output. Called unconditionally: the callback
+  // passes the read-range null state to prepareNulls, which self-short-circuits
+  // (no allocate/clear) when there are no nulls.
+  prepareResultNulls();
+
   const auto startRowIndex = visitor.rowIndex();
   uint32_t indexOffset = 0;
   auto readRowIndex = startRowIndex;
-  bool nullsEmitted = false;
+  bool anyNull = false;
   for (uint32_t row = 0; row < numReadRows && readRowIndex < visitor.numRows();
        ++row) {
     const bool readCurrentRow =
@@ -651,13 +656,9 @@ void readSparseMaterializedIndices(
         !velox::bits::isBitSet(rawNulls, readOffset + row);
     if (isNull) {
       if (readCurrentRow) {
-        if (!nullsEmitted) {
-          nullsEmitted = true;
-          prepareResultNulls();
-          visitor.reader().setHasNulls();
-        }
+        anyNull = true;
         // In the sparse case, returnReaderNulls_ is false
-        // (initReturnReaderNulls only sets it for dense rows). resultNulls()
+        // (setReturnNullsMode only sets it for dense rows). resultNulls()
         // then returns resultNulls_ instead of nullsInReadRange_. We must
         // explicitly write null bits to resultNulls_ so
         // DictionaryVector::validate() knows to skip these positions. Also
@@ -675,6 +676,9 @@ void readSparseMaterializedIndices(
       ++readRowIndex;
     }
     ++indexOffset;
+  }
+  if (anyNull) {
+    visitor.reader().setHasNulls();
   }
   visitor.addNumValues(visitor.numRows() - visitor.rowIndex());
   visitor.setRowIndex(visitor.numRows());

--- a/dwio/nimble/encodings/legacy/NullableEncoding.h
+++ b/dwio/nimble/encodings/legacy/NullableEncoding.h
@@ -279,7 +279,7 @@ void NullableEncoding<T>::readWithVisitor(
     auto* nulls = params.makeReaderNulls();
     nulls_->materializeBoolsAsBits(rowCount, nulls, params.numScanned);
   }
-  params.initReturnReaderNulls();
+  params.setReturnNullsMode();
   legacy::callReadWithVisitor(*nonNullValues_, visitor, params);
 }
 

--- a/dwio/nimble/encodings/tests/ReadWithVisitorTest.cpp
+++ b/dwio/nimble/encodings/tests/ReadWithVisitorTest.cpp
@@ -1068,8 +1068,8 @@ ReadWithVisitorParams makeReadWithVisitorParams(
   params.prepareResultNulls = [&visitor, &rows] {
     visitor.reader().prepareNulls(rows, true, 8);
   };
-  params.initReturnReaderNulls = [&visitor, &rows] {
-    visitor.reader().initReturnReaderNulls(rows);
+  params.setReturnNullsMode = [&visitor, &rows] {
+    visitor.reader().setReturnNullsMode(rows);
   };
   const auto numRows = visitor.numRows();
   params.makeReaderNulls = [memPool, numRows, &visitor] {

--- a/dwio/nimble/tools/encoding_bench/EncodingBench.cpp
+++ b/dwio/nimble/tools/encoding_bench/EncodingBench.cpp
@@ -368,8 +368,8 @@ nimble::ReadWithVisitorParams makeReadWithVisitorParams(
   params.prepareResultNulls = [&visitor, &rows] {
     visitor.reader().prepareNulls(rows, true, 8);
   };
-  params.initReturnReaderNulls = [&visitor, &rows] {
-    visitor.reader().initReturnReaderNulls(rows);
+  params.setReturnNullsMode = [&visitor, &rows] {
+    visitor.reader().setReturnNullsMode(rows);
   };
   const auto numRows = visitor.numRows();
   params.makeReaderNulls = [memPool, numRows, &visitor] {

--- a/dwio/nimble/velox/selective/ChunkedDecoder.h
+++ b/dwio/nimble/velox/selective/ChunkedDecoder.h
@@ -115,42 +115,45 @@ class ChunkedDecoder {
     NIMBLE_CHECK(
         readOffset == 0 || stringDecoderZeroCopy_,
         "readOffset is only valid for dict→flat encoding fallback reads");
+    // The visitor always carries the complete output row set. When a read is
+    // resumed mid-range (readOffset > 0 — e.g. the dict→flat abandon-dictionary
+    // fallback), the caller advances the visitor's rowIndex past the
+    // already-read prefix instead of slicing the row set, so null prep still
+    // sees the full range for buffer sizing and the return-nulls mode.
     const velox::RowSet rows(visitor.rows(), visitor.numRows());
     NIMBLE_DCHECK(std::is_sorted(rows.begin(), rows.end()));
     const auto numRows = visitor.numRows();
     ReadWithVisitorParams params{};
     params.numScanned = readOffset;
-    bool resultNullsPrepared{false};
-    if (readOffset > 0) {
-      // Flat encoding fallback (resuming mid-batch after an abandoned
-      // dictionary read). The dictionary phase already prepared the result
-      // null buffer and the return-nulls mode for the full output; this read
-      // only appends. Re-preparing here would clear/re-base the shared null
-      // buffer (wiping the dict portion's nulls) and re-evaluate the mode on
-      // the non-dense continuation row set. So both are no-ops — prepare once.
-      params.prepareResultNulls = [] {};
-      params.setReturnNullsMode = [] {};
-    } else {
-      // Allocate one extra byte (8 bits) for nulls to handle multi-chunk
-      // reading, where each chunk we need to align the result nulls to byte
-      // boundary then shift.
-      params.prepareResultNulls = [&resultNullsPrepared, &visitor, &rows] {
-        if (FOLLY_UNLIKELY(!resultNullsPrepared)) {
-          // Pass the real read-range null state so prepareNulls short-circuits
-          // (no allocate/clear) when the range carries no nulls. Only mark the
-          // buffer prepared when prepareNulls actually allocated it: on a
-          // null-free call it no-ops, so a later chunk that does carry nulls
-          // must still trigger a real prepare.
-          const bool hasNulls =
-              visitor.reader().rawNullsInReadRange() != nullptr;
-          visitor.reader().prepareNulls(rows, hasNulls, /*extraRows=*/8);
-          resultNullsPrepared = hasNulls;
-        }
-      };
-      params.setReturnNullsMode = [&visitor, &rows] {
-        visitor.reader().setReturnNullsMode(rows);
-      };
-    }
+    // readOffset > 0 means a single read range is being decoded in segments
+    // across multiple readWithVisitor calls (e.g. the dict→flat
+    // abandon-dictionary fallback resuming at the abandoned chunk boundary), so
+    // the lazy null-prep hooks below must prepare resultNulls_ for the WHOLE
+    // read range, not just this segment. An earlier segment already prepared it
+    // for the full output IFF that segment emitted nulls (reader hasNulls()):
+    // seed the guard to skip re-preparing in that case — appending to, rather
+    // than clobbering, the earlier segment's nulls — and leave it unset when
+    // the earlier segment produced no nulls, so a nullable chunk in this
+    // segment prepares the buffer.
+    bool resultNullsPrepared{readOffset > 0 && visitor.reader().hasNulls()};
+    // Allocate one extra byte (8 bits) for nulls to handle multi-chunk
+    // reading, where each chunk we need to align the result nulls to byte
+    // boundary then shift.
+    params.prepareResultNulls = [&resultNullsPrepared, &visitor, &rows] {
+      if (FOLLY_UNLIKELY(!resultNullsPrepared)) {
+        // Pass the real read-range null state so prepareNulls short-circuits
+        // (no allocate/clear) when the range carries no nulls. Only mark the
+        // buffer prepared when prepareNulls actually allocated it: on a
+        // null-free call it no-ops, so a later chunk that does carry nulls must
+        // still trigger a real prepare.
+        const bool hasNulls = visitor.reader().rawNullsInReadRange() != nullptr;
+        visitor.reader().prepareNulls(rows, hasNulls, /*extraRows=*/8);
+        resultNullsPrepared = hasNulls;
+      }
+    };
+    params.setReturnNullsMode = [&visitor, &rows] {
+      visitor.reader().setReturnNullsMode(rows);
+    };
     bool readerNullsMade{false};
     if (auto& nulls = visitor.reader().nullsInReadRange()) {
       // For flat map child columns, NimbleData::readNulls() may alias inMap_

--- a/dwio/nimble/velox/selective/ChunkedDecoder.h
+++ b/dwio/nimble/velox/selective/ChunkedDecoder.h
@@ -129,20 +129,26 @@ class ChunkedDecoder {
       // buffer (wiping the dict portion's nulls) and re-evaluate the mode on
       // the non-dense continuation row set. So both are no-ops — prepare once.
       params.prepareResultNulls = [] {};
-      params.initReturnReaderNulls = [] {};
+      params.setReturnNullsMode = [] {};
     } else {
       // Allocate one extra byte (8 bits) for nulls to handle multi-chunk
       // reading, where each chunk we need to align the result nulls to byte
       // boundary then shift.
       params.prepareResultNulls = [&resultNullsPrepared, &visitor, &rows] {
         if (FOLLY_UNLIKELY(!resultNullsPrepared)) {
-          visitor.reader().prepareNulls(
-              rows, /*hasNulls=*/true, /*extraRows=*/8);
-          resultNullsPrepared = true;
+          // Pass the real read-range null state so prepareNulls short-circuits
+          // (no allocate/clear) when the range carries no nulls. Only mark the
+          // buffer prepared when prepareNulls actually allocated it: on a
+          // null-free call it no-ops, so a later chunk that does carry nulls
+          // must still trigger a real prepare.
+          const bool hasNulls =
+              visitor.reader().rawNullsInReadRange() != nullptr;
+          visitor.reader().prepareNulls(rows, hasNulls, /*extraRows=*/8);
+          resultNullsPrepared = hasNulls;
         }
       };
-      params.initReturnReaderNulls = [&visitor, &rows] {
-        visitor.reader().initReturnReaderNulls(rows);
+      params.setReturnNullsMode = [&visitor, &rows] {
+        visitor.reader().setReturnNullsMode(rows);
       };
     }
     bool readerNullsMade{false};
@@ -336,12 +342,18 @@ class ChunkedDecoder {
     // boundary then shift.
     params.prepareResultNulls = [&resultNullsPrepared, &visitor, &rows] {
       if (FOLLY_UNLIKELY(!resultNullsPrepared)) {
-        visitor.reader().prepareNulls(rows, /*hasNulls=*/true, /*extraRows=*/8);
-        resultNullsPrepared = true;
+        // Pass the real read-range null state so prepareNulls short-circuits
+        // (no allocate/clear) when the range carries no nulls. Only mark the
+        // buffer prepared when prepareNulls actually allocated it: on a
+        // null-free call it no-ops, so a later chunk that does carry nulls must
+        // still trigger a real prepare.
+        const bool hasNulls = visitor.reader().rawNullsInReadRange() != nullptr;
+        visitor.reader().prepareNulls(rows, hasNulls, /*extraRows=*/8);
+        resultNullsPrepared = hasNulls;
       }
     };
-    params.initReturnReaderNulls = [&visitor, &rows] {
-      visitor.reader().initReturnReaderNulls(rows);
+    params.setReturnNullsMode = [&visitor, &rows] {
+      visitor.reader().setReturnNullsMode(rows);
     };
     bool readerNullsMade{false};
     if (auto& nulls = visitor.reader().nullsInReadRange()) {

--- a/dwio/nimble/velox/selective/StringColumnReader.cpp
+++ b/dwio/nimble/velox/selective/StringColumnReader.cpp
@@ -264,34 +264,32 @@ void StringColumnReader::read(
       : 0;
   NIMBLE_CHECK_LE(numReadRows, endReadRow);
 
-  // Build the row set for the flat read.
-  // - Fresh read (numReadRows == 0): use the original rows directly.
-  // - Continuation after an abandoned dict read: numReadRows is the chunk
-  //   boundary where the decoder is parked. The remaining rows are the
-  //   suffix of the (sorted) original rows at positions >= the boundary — a
-  //   contiguous subrange we reference in place (no copy). The flat read
-  //   resumes the decode at numReadRows and skips to the first such row.
-  velox::RowSet readRowSet;
+  // Always read against the complete original rows so the visitor — and hence
+  // null prep — sees the full output range. On a continuation after an
+  // abandoned dict read, numReadRows is the chunk boundary where the decoder is
+  // parked; advance the visitor to the first row at/after it so the flat read
+  // resumes there (the dict portion was already produced) instead of re-reading
+  // the prefix.
+  velox::vector_size_t startRowIndex = 0;
   if (numReadRows == 0) {
     prepareRead<std::string_view>(offset, rows, incomingNulls);
-    readRowSet = rows;
   } else {
-    const auto* remainingRowStart =
-        std::lower_bound(rows.data(), rows.data() + rows.size(), numReadRows);
-    readRowSet = velox::RowSet(
-        remainingRowStart,
-        static_cast<size_t>(rows.data() + rows.size() - remainingRowStart));
+    startRowIndex = static_cast<velox::vector_size_t>(
+        std::lower_bound(rows.data(), rows.data() + rows.size(), numReadRows) -
+        rows.data());
   }
 
   dwio::common::StringColumnReadWithVisitorHelper<
       /*kEncodingHasNulls=*/false,
-      /*kDictionary=*/false>(*this, readRowSet)([&](auto visitor) {
+      /*kDictionary=*/false>(*this, rows)([&](auto visitor) {
     if (numReadRows == 0) {
       decoder_.readWithVisitor(visitor);
     } else {
-      // Append string buffers from the flat read to the existing ones
-      // (which include the dict portion's string buffer from
+      // Resume the flat read at the abandoned chunk boundary: skip the rows the
+      // dict portion already produced, then append the new string buffers to
+      // the existing ones (which include the dict portion's buffer from
       // abandonDictionaryEncoding).
+      visitor.setRowIndex(startRowIndex);
       decoder_.readWithVisitor(
           visitor,
           /*readOffset=*/numReadRows,

--- a/dwio/nimble/velox/selective/tests/E2EFilterTest.cpp
+++ b/dwio/nimble/velox/selective/tests/E2EFilterTest.cpp
@@ -75,6 +75,37 @@ struct E2EFilterTestParam {
   }
 };
 
+// Applies the multi-chunk writer config used by the shared write path so that
+// standalone tests (which build their own writer) also produce multiple chunks
+// per stream within a stripe, exercising the cross-chunk reader resume paths.
+// Note: chunks are emitted at write() boundaries, so a single write() still
+// yields one chunk — callers that write a single batch must split it.
+void applyMultiChunkOptions(VeloxWriterOptions& options) {
+  options.enableChunking = true;
+  options.minStreamChunkRawSize = 0;
+  options.flushPolicyFactory = [] {
+    return std::make_unique<LambdaFlushPolicy>(
+        /*flushLambda=*/[](const StripeProgress&) { return false; },
+        /*chunkLambda=*/[](const StripeProgress&) { return true; });
+  };
+}
+
+// Writes `batch` as `numChunks` row-slices so the multi-chunk options above
+// emit a separate chunk per slice (a single write() would yield one chunk).
+void writeInChunks(
+    VeloxWriter& writer,
+    const RowVectorPtr& batch,
+    int numChunks = 3) {
+  const vector_size_t total = batch->size();
+  const vector_size_t per =
+      std::max<vector_size_t>(1, (total + numChunks - 1) / numChunks);
+  for (vector_size_t offset = 0; offset < total; offset += per) {
+    writer.write(
+        std::dynamic_pointer_cast<RowVector>(
+            batch->slice(offset, std::min(per, total - offset))));
+  }
+}
+
 class E2EFilterTest
     : public dwio::common::E2EFilterTestBase,
       public ::testing::WithParamInterface<E2EFilterTestParams> {
@@ -550,9 +581,10 @@ class E2EFilterTest
       auto writeFile = std::make_unique<InMemoryWriteFile>(&sinkData_);
       VeloxWriterOptions writerOptions;
       writerOptions.encodingLayoutTree.emplace(std::move(layoutTree));
+      applyMultiChunkOptions(writerOptions);
       VeloxWriter writer(
           type, std::move(writeFile), *rootPool_, std::move(writerOptions));
-      writer.write(batch);
+      writeInChunks(writer, batch);
       writer.close();
     }
 
@@ -2021,11 +2053,11 @@ class PrefixEncodingE2ETest : public E2EFilterTest {
         Kind::Row, {}, "", std::move(children)};
 
     auto writeFile = std::make_unique<InMemoryWriteFile>(&sinkData_);
+    VeloxWriterOptions options;
+    options.encodingLayoutTree.emplace(std::move(encodingLayoutTree));
+    applyMultiChunkOptions(options);
     VeloxWriter writer(
-        rowType_,
-        std::move(writeFile),
-        *rootPool_,
-        {.encodingLayoutTree = std::move(encodingLayoutTree)});
+        rowType_, std::move(writeFile), *rootPool_, std::move(options));
     for (auto& batch : batches) {
       writer.write(batch);
     }
@@ -2315,8 +2347,9 @@ TEST_P(E2EFilterTest, nestedMainlyConstantWithDictionary) {
   auto writeFile = std::make_unique<InMemoryWriteFile>(&sinkData_);
   VeloxWriterOptions writerOptions;
   writerOptions.encodingLayoutTree.emplace(std::move(encodingLayoutTree));
+  applyMultiChunkOptions(writerOptions);
   VeloxWriter writer(type, std::move(writeFile), *rootPool_, writerOptions);
-  writer.write(batch);
+  writeInChunks(writer, batch);
   writer.close();
 
   // Read back and verify the data is correct.
@@ -2519,9 +2552,10 @@ TEST_P(E2EFilterTest, fuzzMainlyConstantDictionaryVector) {
     VeloxWriterOptions writerOptions;
     writerOptions.encodingLayoutTree.emplace(
         buildForcedMainlyConstantDictionaryEncodingLayoutTree());
+    applyMultiChunkOptions(writerOptions);
     VeloxWriter writer(
         type, std::move(writeFile), *rootPool_, std::move(writerOptions));
-    writer.write(batch);
+    writeInChunks(writer, batch);
     writer.close();
   }
 
@@ -2634,9 +2668,10 @@ TEST_P(E2EFilterTest, fuzzRleDictionaryVector) {
     VeloxWriterOptions writerOptions;
     writerOptions.encodingLayoutTree.emplace(
         buildForcedRleDictionaryEncodingLayoutTree());
+    applyMultiChunkOptions(writerOptions);
     VeloxWriter writer(
         type, std::move(writeFile), *rootPool_, std::move(writerOptions));
-    writer.write(batch);
+    writeInChunks(writer, batch);
     writer.close();
   }
 
@@ -2712,9 +2747,11 @@ TEST_P(E2EFilterTest, constantStringDictionaryVector) {
   sinkData_.clear();
   {
     auto writeFile = std::make_unique<InMemoryWriteFile>(&sinkData_);
+    VeloxWriterOptions options;
+    applyMultiChunkOptions(options);
     VeloxWriter writer(
-        type, std::move(writeFile), *rootPool_, VeloxWriterOptions{});
-    writer.write(batch);
+        type, std::move(writeFile), *rootPool_, std::move(options));
+    writeInChunks(writer, batch);
     writer.close();
   }
 
@@ -2780,9 +2817,11 @@ TEST_P(E2EFilterTest, constantStringWithNullsDictionaryVector) {
   sinkData_.clear();
   {
     auto writeFile = std::make_unique<InMemoryWriteFile>(&sinkData_);
+    VeloxWriterOptions options;
+    applyMultiChunkOptions(options);
     VeloxWriter writer(
-        type, std::move(writeFile), *rootPool_, VeloxWriterOptions{});
-    writer.write(batch);
+        type, std::move(writeFile), *rootPool_, std::move(options));
+    writeInChunks(writer, batch);
     writer.close();
   }
 
@@ -2996,10 +3035,11 @@ class NimbleExtractionTest : public E2EFilterTest {
     // Write.
     rowType_ = asRowType(data->type());
     VeloxWriterOptions options;
+    applyMultiChunkOptions(options);
     auto writeFile = std::make_unique<InMemoryWriteFile>(&sinkData_);
     VeloxWriter writer(
         rowType_, std::move(writeFile), *rootPool_, std::move(options));
-    writer.write(data);
+    writeInChunks(writer, data);
     writer.close();
 
     // Read.

--- a/dwio/nimble/velox/selective/tests/StringColumnReaderTest.cpp
+++ b/dwio/nimble/velox/selective/tests/StringColumnReaderTest.cpp
@@ -119,13 +119,28 @@ class StringColumnReaderTest : public ::testing::Test,
       const RowVector& input,
       dwio::common::RowReader& rowReader,
       int batchSize,
-      const std::function<bool(int)>& filter) {
+      const std::function<bool(int)>& filter,
+      std::optional<VectorEncoding::Simple> expectedChildEncoding =
+          std::nullopt,
+      int childIndex = 0) {
     auto result = BaseVector::create(asRowType(input.type()), 0, pool());
     int numScanned = 0;
     int i = 0;
     while (numScanned < input.size()) {
       numScanned += rowReader.next(batchSize, result);
       result->validate();
+      // When set, assert the column under test was materialized with the
+      // expected encoding (e.g. DICTIONARY for the dict-index path, FLAT for
+      // the flat path), so a silent encoding fallback cannot mask the read
+      // path.
+      if (expectedChildEncoding.has_value() && result->size() > 0) {
+        EXPECT_EQ(
+            BaseVector::loadedVectorShared(
+                result->asUnchecked<RowVector>()->childAt(childIndex))
+                ->encoding(),
+            *expectedChildEncoding)
+            << "Unexpected encoding for child " << childIndex;
+      }
       for (int j = 0; j < result->size(); ++j) {
         for (;;) {
           ASSERT_LT(i, input.size());
@@ -2866,6 +2881,176 @@ TEST_P(StringColumnReaderTest, fuzzMultiChunkReadCorrectness) {
     auto readers = makeReaders(expected, file, scanSpec, stringDecoderZeroCopy);
     validate(*expected, *readers.rowReader, batchSize);
   }
+}
+
+// Regression for the prepareResultNulls guard bug. A sibling filter on c0
+// forces ONE sparse readWithVisitor over c1 that spans both chunks: chunk 1's
+// c1 values are non-null and chunk 2's are nullable. The null-free chunk-1
+// portion calls prepareResultNulls with hasNulls=false (prepareNulls no-ops and
+// allocates nothing); if the shared resultNullsPrepared guard is flipped
+// regardless, the nullable chunk-2 portion skips the real prepare and writes
+// nulls into an unallocated resultNulls_ -> crash. Exercises the
+// dictionary-index read path (readDictionaryIndices).
+TEST_P(StringColumnReaderTest, multiChunkLateNullPreparationDictPath) {
+  const bool stringDecoderZeroCopy = GetParam();
+  if (!stringDecoderZeroCopy) {
+    GTEST_SKIP() << "Dictionary path requires stringDecoderZeroCopy";
+  }
+
+  constexpr int kRowsPerChunk = 200;
+  // c1 low-cardinality -> Dictionary. chunk 1 non-null, chunk 2 nullable.
+  auto chunk1 = makeRowVector({
+      makeFlatVector<int64_t>(kRowsPerChunk, [](auto i) { return i; }),
+      makeFlatVector<std::string>(
+          kRowsPerChunk,
+          [](auto i) {
+            return std::vector<std::string>{"aa", "bb", "cc"}[i % 3];
+          }),
+  });
+  auto chunk2 = makeRowVector({
+      makeFlatVector<int64_t>(
+          kRowsPerChunk, [](auto i) { return kRowsPerChunk + i; }),
+      makeFlatVector<std::string>(
+          kRowsPerChunk,
+          [](auto i) { return std::vector<std::string>{"xx", "yy"}[i % 2]; },
+          nullEvery(7)),
+  });
+
+  // Force c1 to a bare Dictionary via the encoding layout tree, driving the
+  // dictionary-index read path. The writer wraps it in Nullable automatically
+  // for the nullable chunk.
+  EncodingLayout c1DictLayout{
+      EncodingType::Dictionary,
+      {},
+      CompressionType::Uncompressed,
+      {std::nullopt, std::nullopt}};
+  VeloxWriterOptions writerOptions;
+  writerOptions.enableChunking = true;
+  writerOptions.minStreamChunkRawSize = 0;
+  writerOptions.encodingLayoutTree.emplace(
+      Kind::Row,
+      std::
+          unordered_map<EncodingLayoutTree::StreamIdentifier, EncodingLayout>{},
+      "",
+      std::vector<EncodingLayoutTree>{
+          EncodingLayoutTree{Kind::Scalar, {}, "c0"},
+          EncodingLayoutTree{
+              Kind::Scalar, {{0, std::move(c1DictLayout)}}, "c1"}});
+  writerOptions.flushPolicyFactory = [] {
+    return std::make_unique<LambdaFlushPolicy>(
+        /*flushLambda=*/[](const StripeProgress&) { return false; },
+        /*chunkLambda=*/[](const StripeProgress&) { return true; });
+  };
+  auto file = test::createNimbleFile(
+      *rootPool(), {chunk1, chunk2}, writerOptions, /*flushAfterWrite=*/false);
+
+  // Filter c0 to [100, 300]: a row set spanning the chunk boundary at 200, so
+  // c1 (no filter) is read sparsely across both chunks in a single
+  // readWithVisitor.
+  auto readType = ROW({"c0", "c1"}, {BIGINT(), VARCHAR()});
+  auto scanSpec = std::make_shared<common::ScanSpec>("root");
+  scanSpec->addAllChildFields(*readType);
+  scanSpec->childByName("c0")->setFilter(
+      std::make_unique<common::BigintRange>(100, 300, /*nullAllowed=*/false));
+
+  auto input = makeRowVector({
+      makeFlatVector<int64_t>(2 * kRowsPerChunk, [](auto i) { return i; }),
+      makeFlatVector<std::string>(
+          2 * kRowsPerChunk,
+          [](auto i) {
+            return i < kRowsPerChunk
+                ? std::vector<std::string>{"aa", "bb", "cc"}[i % 3]
+                : std::vector<std::string>{"xx", "yy"}[(i - kRowsPerChunk) % 2];
+          },
+          [](auto i) {
+            return i >= kRowsPerChunk && ((i - kRowsPerChunk) % 7 == 0);
+          }),
+  });
+
+  auto readers = makeReaders(input, file, scanSpec, stringDecoderZeroCopy);
+  validateWithFilter(
+      *input,
+      *readers.rowReader,
+      2 * kRowsPerChunk,
+      [](int i) { return i >= 100 && i <= 300; },
+      VectorEncoding::Simple::DICTIONARY,
+      /*childIndex=*/1);
+}
+
+// Same regression for the non-dictionary (flat) read path (readWithVisitor):
+// unique values force Trivial, so c1 goes through readWithVisitorFast rather
+// than the dictionary-index path.
+TEST_P(StringColumnReaderTest, multiChunkLateNullPreparationFlatPath) {
+  const bool stringDecoderZeroCopy = GetParam();
+  if (!stringDecoderZeroCopy) {
+    GTEST_SKIP() << "Repro requires the dict-vector flags";
+  }
+
+  constexpr int kRowsPerChunk = 200;
+  // c1 unique -> Trivial (flat). chunk 1 non-null, chunk 2 nullable.
+  auto chunk1 = makeRowVector({
+      makeFlatVector<int64_t>(kRowsPerChunk, [](auto i) { return i; }),
+      makeFlatVector<std::string>(
+          kRowsPerChunk, [](auto i) { return "u_" + std::to_string(i); }),
+  });
+  auto chunk2 = makeRowVector({
+      makeFlatVector<int64_t>(
+          kRowsPerChunk, [](auto i) { return kRowsPerChunk + i; }),
+      makeFlatVector<std::string>(
+          kRowsPerChunk,
+          [](auto i) { return "u_" + std::to_string(kRowsPerChunk + i); },
+          nullEvery(7)),
+  });
+
+  // Force c1 to Trivial via the encoding layout tree, driving the flat
+  // readWithVisitorFast path. The writer wraps it in Nullable automatically for
+  // the nullable chunk.
+  EncodingLayout c1TrivialLayout{
+      EncodingType::Trivial, {}, CompressionType::Uncompressed, {std::nullopt}};
+  VeloxWriterOptions writerOptions;
+  writerOptions.enableChunking = true;
+  writerOptions.minStreamChunkRawSize = 0;
+  writerOptions.encodingLayoutTree.emplace(
+      Kind::Row,
+      std::
+          unordered_map<EncodingLayoutTree::StreamIdentifier, EncodingLayout>{},
+      "",
+      std::vector<EncodingLayoutTree>{
+          EncodingLayoutTree{Kind::Scalar, {}, "c0"},
+          EncodingLayoutTree{
+              Kind::Scalar, {{0, std::move(c1TrivialLayout)}}, "c1"}});
+  writerOptions.flushPolicyFactory = [] {
+    return std::make_unique<LambdaFlushPolicy>(
+        /*flushLambda=*/[](const StripeProgress&) { return false; },
+        /*chunkLambda=*/[](const StripeProgress&) { return true; });
+  };
+  auto file = test::createNimbleFile(
+      *rootPool(), {chunk1, chunk2}, writerOptions, /*flushAfterWrite=*/false);
+
+  auto readType = ROW({"c0", "c1"}, {BIGINT(), VARCHAR()});
+  auto scanSpec = std::make_shared<common::ScanSpec>("root");
+  scanSpec->addAllChildFields(*readType);
+  scanSpec->childByName("c0")->setFilter(
+      std::make_unique<common::BigintRange>(100, 300, /*nullAllowed=*/false));
+
+  auto input = makeRowVector({
+      makeFlatVector<int64_t>(2 * kRowsPerChunk, [](auto i) { return i; }),
+      makeFlatVector<std::string>(
+          2 * kRowsPerChunk,
+          [](auto i) { return "u_" + std::to_string(i); },
+          [](auto i) {
+            return i >= kRowsPerChunk && ((i - kRowsPerChunk) % 7 == 0);
+          }),
+  });
+
+  auto readers = makeReaders(input, file, scanSpec, stringDecoderZeroCopy);
+  validateWithFilter(
+      *input,
+      *readers.rowReader,
+      2 * kRowsPerChunk,
+      [](int i) { return i >= 100 && i <= 300; },
+      VectorEncoding::Simple::FLAT,
+      /*childIndex=*/1);
 }
 
 INSTANTIATE_TEST_CASE_P(

--- a/dwio/nimble/velox/selective/tests/StringColumnReaderTest.cpp
+++ b/dwio/nimble/velox/selective/tests/StringColumnReaderTest.cpp
@@ -2694,6 +2694,90 @@ TEST_P(StringColumnReaderTest, sparseRowsAcrossChunkAbandonNullsBothPortions) {
   });
 }
 
+// Like sparseRowsAcrossChunkAbandonNullsBothPortions, but the dict portion
+// (chunk1) is ALL non-null while only the flat-fallback portion (chunk2) has
+// nulls. An all-non-null dict chunk never allocates/prepares the result null
+// buffer during the dict phase (rawNullsInReadRange stays null), so the
+// readOffset>0 flat continuation is the first to discover nulls and must
+// prepare the buffer over the complete output itself rather than assuming the
+// dict phase already did. Regression for the resume branch no-op'ing
+// prepareResultNulls/setReturnNullsMode and emitting nulls into an unprepared
+// resultNulls_.
+TEST_P(
+    StringColumnReaderTest,
+    sparseRowsAcrossChunkAbandonNullsOnlyInFlatPortion) {
+  const bool stringDecoderZeroCopy = GetParam();
+  if (!stringDecoderZeroCopy) {
+    GTEST_SKIP() << "Dictionary path requires stringDecoderZeroCopy";
+  }
+
+  // chunk1: low cardinality, NO nulls → Dictionary (dict path, no null buffer).
+  auto chunk1 = makeRowVector({
+      makeFlatVector<int64_t>(300, [](auto i) { return i; }),
+      makeFlatVector<std::string>(
+          300,
+          [](auto i) { return std::vector<std::string>{"aaa", "bbb"}[i % 2]; }),
+  });
+  // chunk2: all-unique long strings (non-dict → forces abandon) WITH nulls →
+  // Nullable→Trivial. The flat fallback emits these nulls into a result null
+  // buffer the all-non-null dict phase never prepared.
+  auto chunk2 = makeRowVector({
+      makeFlatVector<int64_t>(300, [](auto i) { return 300 + i; }),
+      makeFlatVector<std::string>(
+          300,
+          [](auto i) {
+            return fmt::format("unique_chunk2_row_{}_pad_to_avoid_inline", i);
+          },
+          nullEvery(5)),
+  });
+
+  VeloxWriterOptions writerOptions;
+  writerOptions.enableChunking = true;
+  writerOptions.minStreamChunkRawSize = 0;
+  writerOptions.flushPolicyFactory = [] {
+    return std::make_unique<LambdaFlushPolicy>(
+        /*flushLambda=*/[](const StripeProgress&) { return false; },
+        /*chunkLambda=*/[](const StripeProgress&) { return true; });
+  };
+  auto file = test::createNimbleFile(
+      *rootPool(), {chunk1, chunk2}, writerOptions, /*flushAfterWrite=*/false);
+
+  // Sibling filter on c0 selects a non-dense set spanning both chunks:
+  // [50,199] in chunk1 (dict, no nulls) and [400,549] in chunk2 (non-dict,
+  // with nulls).
+  auto readType = ROW({"c0", "c1"}, {BIGINT(), VARCHAR()});
+  auto scanSpec = std::make_shared<common::ScanSpec>("root");
+  scanSpec->addAllChildFields(*readType);
+  std::vector<std::unique_ptr<common::BigintRange>> ranges;
+  ranges.push_back(
+      std::make_unique<common::BigintRange>(50, 199, /*nullAllowed=*/false));
+  ranges.push_back(
+      std::make_unique<common::BigintRange>(400, 549, /*nullAllowed=*/false));
+  scanSpec->childByName("c0")->setFilter(
+      std::make_unique<common::BigintMultiRange>(
+          std::move(ranges), /*nullAllowed=*/false));
+
+  // Full 600-row content. Nulls only in chunk2 (chunk2-local (i-300) % 5 == 0).
+  auto expected = makeRowVector({
+      makeFlatVector<int64_t>(600, [](auto i) { return i; }),
+      makeFlatVector<std::string>(
+          600,
+          [](auto i) {
+            if (i < 300) {
+              return std::vector<std::string>{"aaa", "bbb"}[i % 2];
+            }
+            return fmt::format(
+                "unique_chunk2_row_{}_pad_to_avoid_inline", i - 300);
+          },
+          [](auto i) { return i >= 300 && (i - 300) % 5 == 0; }),
+  });
+
+  auto readers = makeReaders(expected, file, scanSpec, stringDecoderZeroCopy);
+  validateWithFilter(*expected, *readers.rowReader, 600, [](int i) {
+    return (i >= 50 && i <= 199) || (i >= 400 && i <= 549);
+  });
+}
+
 // Fuzz test: randomizes the number of chunks, rows per chunk, batch size,
 // and null probability. Exercises multi-chunk dict reads with merged
 // alphabets across chunk boundaries.


### PR DESCRIPTION
Summary:

When a preserve-dictionary string read crosses into a non-dictionary chunk, the dictionary read is abandoned and the remaining rows fall back to a flat-encoding read (`ChunkedDecoder::readWithVisitor` with `readOffset > 0`). That continuation must still prepare the reader's result-null buffer over the COMPLETE output row set, not just the suffix it decodes.

Two problems are fixed:
- The continuation no-op'd null prep, assuming the dict phase already prepared `resultNulls_`. When the abandoned dict prefix was all non-null, nothing allocated the buffer, and a nullable flat chunk in the continuation then wrote nulls into an unprepared `resultNulls_` (`addNull` on a null `rawResultNulls_`) -- corruption / abort. Now `readWithVisitor` seeds `resultNullsPrepared` from `reader.hasNulls()`: it re-prepares the buffer when the dict phase did not, and skips re-prep (avoiding clobbering the dict portion's nulls) when it did.
- The continuation visitor only carried the suffix, so null prep saw the wrong row set. `StringColumnReader::read` now runs the flat continuation against the COMPLETE row set and advances the visitor's `rowIndex` past the already-read dict prefix (instead of slicing to a suffix), so buffer sizing and the return-nulls mode see the full output range.

Reviewed By: xiaoxmeng

Differential Revision: D109734664


