### PR TITLE
fix(index): Make NimbleIndexProjector result IOBuf chains fully managed

### DIFF
--- a/dwio/nimble/velox/index/NimbleIndexProjector.cpp
+++ b/dwio/nimble/velox/index/NimbleIndexProjector.cpp
@@ -464,9 +464,11 @@ folly::IOBuf NimbleIndexProjector::packStripe(size_t stripeOffset) {
   // Each unique stream is wrapped zero-copy into the output chain. Streams that
   // are physically contiguous in the DataInput read buffer are merged into a
   // single IOBuf node — fewer nodes means cheaper appendToChain here and
-  // cheaper cloneAsValue per request in buildResult. The first node holds the
-  // DataInput::Handle (takeOwnership) to keep the loaded data alive; the rest
-  // wrapBuffer it, since the chain is always cloned/destroyed as a unit.
+  // cheaper cloneAsValue per request in buildResult. Every node takes ownership
+  // of its own refcounted DataInput::Handle on the read buffer, so the whole
+  // chain is managed (folly::IOBuf::isManaged()) and self-contained: each node
+  // keeps the loaded data alive independently, so no node dangles if it is
+  // separated from its siblings.
   std::unique_ptr<folly::IOBuf> chain;
   const char* runData = nullptr;
   uint64_t runLength = 0;
@@ -474,14 +476,19 @@ folly::IOBuf NimbleIndexProjector::packStripe(size_t stripeOffset) {
     if (runData == nullptr) {
       return;
     }
+    // TODO: each run allocates a fresh DataInput::Handle (a heap shared_ptr
+    // copy pinning the read buffer). If this allocation shows up in CPU
+    // profiling, use a slab cache or reuse a single Handle/buffer across the
+    // chain's nodes.
+    auto node = folly::IOBuf::takeOwnership(
+        const_cast<char*>(runData),
+        runLength,
+        freeDataHandle,
+        new DataInput::Handle(ctx_.dataHandle));
     if (chain == nullptr) {
-      chain = folly::IOBuf::takeOwnership(
-          const_cast<char*>(runData),
-          runLength,
-          freeDataHandle,
-          new DataInput::Handle(ctx_.dataHandle));
+      chain = std::move(node);
     } else {
-      chain->appendToChain(folly::IOBuf::wrapBuffer(runData, runLength));
+      chain->appendToChain(std::move(node));
     }
     runData = nullptr;
     runLength = 0;

--- a/dwio/nimble/velox/index/tests/NimbleIndexProjectorTest.cpp
+++ b/dwio/nimble/velox/index/tests/NimbleIndexProjectorTest.cpp
@@ -456,6 +456,63 @@ TEST_P(NimbleIndexProjectorTest, basicColumnProjection) {
   EXPECT_EQ(colAResult->valueAt(rowRange.startRow), 500);
 }
 
+// Every IOBuf node in a result slice chain should be managed (own/refcount its
+// own buffer) so the chain is self-contained. This currently fails when the
+// projected streams are non-contiguous in the read buffer, because packStripe
+// wraps the additional run(s) with folly::IOBuf::wrapBuffer (unmanaged). It
+// asserts the invariant we are moving toward.
+TEST_P(NimbleIndexProjectorTest, resultSlicesAreManaged) {
+  // 4 columns; project a NON-adjacent subset (col_a, col_c) so the skipped
+  // col_b stream sits between them in the read buffer, forcing a second run.
+  auto rowType =
+      ROW({"key", "col_a", "col_b", "col_c"},
+          {BIGINT(), INTEGER(), INTEGER(), INTEGER()});
+
+  const int numRows = 200;
+  std::vector<int64_t> keys(numRows);
+  std::vector<int32_t> colA(numRows);
+  std::vector<int32_t> colB(numRows);
+  std::vector<int32_t> colC(numRows);
+  for (int i = 0; i < numRows; ++i) {
+    keys[i] = i * 10;
+    colA[i] = i * 100;
+    colB[i] = i * 1000;
+    colC[i] = i * 7;
+  }
+  auto batch = vectorMaker_->rowVector(
+      {"key", "col_a", "col_b", "col_c"},
+      {vectorMaker_->flatVector<int64_t>(keys),
+       vectorMaker_->flatVector<int32_t>(colA),
+       vectorMaker_->flatVector<int32_t>(colB),
+       vectorMaker_->flatVector<int32_t>(colC)});
+
+  writeData({batch}, {"key"}, /*flatMapColumns=*/{}, /*stripeSize=*/1 << 10);
+
+  // Skip col_b: its stream lands between col_a's and col_c's in the read
+  // buffer, so packStripe cannot extend a single contiguous run.
+  std::vector<Subfield> subfields;
+  subfields.emplace_back("col_a");
+  subfields.emplace_back("col_c");
+  auto projector = createProjector(subfields);
+
+  // Range scan over all keys hits every stripe.
+  auto rangeBounds = makeRangeLookup(rowType, {"key"}, 0, numRows * 10);
+  NimbleIndexProjector::Request request;
+  request.keyBounds = {rangeBounds};
+  auto result = projector->project(request, {});
+
+  ASSERT_EQ(result.responses.size(), 1);
+  const auto& response = result.responses[0];
+  ASSERT_FALSE(response.slices.empty());
+
+  for (size_t s = 0; s < response.slices.size(); ++s) {
+    const auto& slice = response.slices[s];
+    EXPECT_TRUE(slice.isManaged())
+        << "slice " << s << "/" << response.slices.size()
+        << " has an unmanaged (wrapBuffer) IOBuf node";
+  }
+}
+
 TEST_P(NimbleIndexProjectorTest, emptyResult) {
   auto rowType = ROW({"key", "value"}, {BIGINT(), INTEGER()});
 


### PR DESCRIPTION
Summary:

`NimbleIndexProjector::packStripe` wrapped the first contiguous run of projected stream bytes with `folly::IOBuf::takeOwnership` (managed — it holds a refcounted `DataInput::Handle` on the read buffer) but every additional contiguous run with `folly::IOBuf::wrapBuffer` (unmanaged — `sharedInfo_ == nullptr`, owns nothing). So a result slice chain for a multi-run stripe body was only partially managed: `folly::IOBuf::isManaged()` returned false, and the unmanaged nodes relied on the single managed node — plus the chain always being cloned/destroyed as a unit — to keep their bytes alive. Any code that cloned or held a node independently of its managed sibling would dangle into freed pool memory.

This makes every node in the chain take ownership of its own refcounted `DataInput::Handle`, so the whole chain is managed and self-contained: each node keeps the read buffer alive independently. The output is byte-identical (same zero-copy slices, same node boundaries); only per-node ownership changes — each additional run now also carries a `SharedInfo` and a `Handle` refcount.

As defense-in-depth, add a `checkResultChunkManaged()` helper (anonymous namespace in `rocks/nimble/NimbleTable.cpp`) called at the consumer (`NimbleTableIterator::executeScan`, where the projector's `response.slices` are drained into the iterator). It walks the entire result IOBuf chain node-by-node and, on the rare unmanaged node, fails via `if (FOLLY_UNLIKELY(!node->isManagedOne())) VELOX_FAIL(...)` — the explicit `FOLLY_UNLIKELY` keeps the managed common path on the hot branch and the failure message pinpoints the offending node index, so any future regression that reintroduces an unmanaged node fails loudly instead of dangling into freed pool memory.

Reviewed By: azhavnerchik-meta, stephpontikes

Differential Revision: D109769056


