### PR TITLE
feat(selective): SIMD filterCache evaluation for dictionary index reading with filters

### DIFF
--- a/dwio/nimble/encodings/common/Encoding.h
+++ b/dwio/nimble/encodings/common/Encoding.h
@@ -446,27 +446,6 @@ T castFromPhysicalType(const PhysicalType& value) {
   }
 }
 
-// Ensures the reader's result-nulls buffer exists before a filtered dense index
-// read emits a null via processNull() -> addNull(). Unlike DWRF, Nimble does
-// not pre-populate nullsInReadRange_ in prepareRead() for scalar columns (their
-// nulls are materialized lazily during decode), so prepareRead() did not size
-// resultNulls_; the dense filtered path must allocate it before the first
-// addNull(). No-op without a filter (no processNull path); the call itself
-// no-ops when the read range has no nulls (prepareNulls short-circuits).
-//
-// TODO: This is intentionally eager -- it allocates resultNulls_ whenever a
-// filtered read sees a null bitmap, even for value filters where no null row
-// ever passes (so the buffer goes unused). The SIMD follow-up
-// (StringColumnReader::filterDictionaryIndices) removes the in-visitor
-// kHasFilter branch entirely and handles null emission post-hoc, at which point
-// this helper and its call sites should be deleted.
-template <typename V>
-void prepareResultNullsForDenseFilter(const ReadWithVisitorParams& params) {
-  if constexpr (V::kHasFilter) {
-    params.prepareResultNulls();
-  }
-}
-
 // Materializes dictionary indices into the reader's rawValues_ and scatters
 // for null gaps. Used by DictionaryEncoding and MainlyConstantEncoding
 // readIndicesWithVisitor as the dense no-filter fast path.
@@ -487,48 +466,7 @@ void readDenseMaterializedIndices(
     const uint64_t* rawNulls,
     uint32_t numReadRows,
     uint32_t numNonNulls) {
-  // On the filtered path, allocate the result-nulls buffer up front so the
-  // per-row processNull() -> addNull() below has somewhere to write.
-  prepareResultNullsForDenseFilter<V>(params);
   const auto readOffset = params.numScanned;
-  // When the visitor has a filter, materialize indices into a temp buffer
-  // and dispatch through the visitor's process()/processNull() per row.
-  // This lets the visitor evaluate the filter (e.g., filterCache lookup)
-  // and handle nulls correctly. The bulk path below skips process() and
-  // writes directly to rawValues_, which is only safe without a filter.
-  if constexpr (V::kHasFilter) {
-    // TODO: Avoid this per-call scratch allocation. This in-visitor filter
-    // path is superseded by the bulk SIMD post-hoc filter
-    // (StringColumnReader::filterDictionaryIndices), which removes the whole
-    // kHasFilter branch here in a follow-up. Until that lands, keep the simple
-    // allocation rather than thrashing this function's signature to thread a
-    // reusable buffer through every caller.
-    std::vector<uint32_t> tempIndices(numNonNulls);
-    encoding.materializeIndices(numNonNulls, tempIndices.data());
-    uint32_t nonNullIdx = 0;
-    bool atEnd = false;
-    if (rawNulls != nullptr) {
-      NIMBLE_CHECK_NOT_NULL(
-          visitor.reader().rawResultNulls(),
-          "prepareResultNullsForDenseFilter() must have allocated the "
-          "result-nulls buffer before a filtered dense read with nulls reaches "
-          "processNull() -> addNull().");
-      for (uint32_t row = 0; row < numReadRows && !atEnd; ++row) {
-        if (velox::bits::isBitSet(rawNulls, readOffset + row)) {
-          visitor.process(
-              static_cast<int32_t>(tempIndices[nonNullIdx++]), atEnd);
-        } else {
-          visitor.processNull(atEnd);
-        }
-      }
-    } else {
-      for (uint32_t row = 0; row < numReadRows && !atEnd; ++row) {
-        visitor.process(static_cast<int32_t>(tempIndices[nonNullIdx++]), atEnd);
-      }
-    }
-    return;
-  }
-
   auto* rawOutputValues =
       reinterpret_cast<int32_t*>(visitor.reader().rawValues());
   const auto valueOutputOffset = visitor.reader().numValues();
@@ -587,50 +525,6 @@ void readSparseMaterializedIndices(
     uint32_t numNonNulls,
     uint32_t* indicesBuffer) {
   encoding.materializeIndices(numNonNulls, indicesBuffer);
-
-  // When the visitor has a filter, dispatch through process()/processNull()
-  // per row so the visitor evaluates the filter and handles outputRows.
-  if constexpr (V::kHasFilter) {
-    // Allocate the result-nulls buffer up front (self-no-ops when the range has
-    // no nulls) so the per-row processNull() -> addNull() below has a buffer.
-    prepareResultNulls();
-    uint32_t indexOffset = 0;
-    bool atEnd = false;
-    if (rawNulls != nullptr) {
-      for (uint32_t row = 0; row < numReadRows && !atEnd &&
-           visitor.rowIndex() < visitor.numRows();
-           ++row) {
-        const bool readCurrentRow = row ==
-            static_cast<uint32_t>(visitor.rowAt(visitor.rowIndex()) -
-                                  readOffset);
-        if (velox::bits::isBitSet(rawNulls, readOffset + row)) {
-          if (readCurrentRow) {
-            visitor.process(
-                static_cast<int32_t>(indicesBuffer[indexOffset]), atEnd);
-          }
-          ++indexOffset;
-        } else {
-          if (readCurrentRow) {
-            visitor.processNull(atEnd);
-          }
-        }
-      }
-    } else {
-      for (uint32_t row = 0; row < numReadRows && !atEnd &&
-           visitor.rowIndex() < visitor.numRows();
-           ++row) {
-        const bool readCurrentRow = row ==
-            static_cast<uint32_t>(visitor.rowAt(visitor.rowIndex()) -
-                                  readOffset);
-        if (readCurrentRow) {
-          visitor.process(
-              static_cast<int32_t>(indicesBuffer[indexOffset]), atEnd);
-        }
-        ++indexOffset;
-      }
-    }
-    return;
-  }
 
   auto* rawOutputValues =
       reinterpret_cast<int32_t*>(visitor.reader().rawValues());

--- a/dwio/nimble/velox/selective/StringColumnReader.cpp
+++ b/dwio/nimble/velox/selective/StringColumnReader.cpp
@@ -16,6 +16,7 @@
 
 #include "dwio/nimble/velox/selective/StringColumnReader.h"
 
+#include <folly/ScopeGuard.h>
 #include <algorithm>
 #include "dwio/nimble/encodings/legacy/EncodingUtils.h"
 #include "dwio/nimble/velox/selective/NimbleData.h"
@@ -48,32 +49,238 @@ void StringColumnReader::ensureDictionaryState() {
       decoder_.currentEncoding());
 }
 
-void StringColumnReader::updateDictionaryScanState(
-    const std::vector<std::string_view>& chunkAlphabet) {
+void StringColumnReader::ensureFilterCache() {
   using FilterResult = velox::dwio::common::FilterResult;
-  const auto alphabetSize = static_cast<int32_t>(chunkAlphabet.size());
-
-  auto values =
-      velox::AlignedBuffer::allocate<velox::StringView>(alphabetSize, pool_);
-  auto* rawValues = values->asMutable<velox::StringView>();
-  for (int32_t i = 0; i < alphabetSize; ++i) {
-    rawValues[i] =
-        velox::StringView(chunkAlphabet[i].data(), chunkAlphabet[i].size());
+  const auto alphabetSize = dictionaryState_.alphabet.size();
+  const auto oldSize = dictionaryState_.filterCache.size();
+  // The filter cache size and the merged-alphabet (dictionary) size increase
+  // monotonically: the alphabet only grows by appending within a read and the
+  // cache extends to match; on a chunk boundary both are cleared and rebuilt
+  // together (the cache is never reused across a different chunk), and the
+  // reader is rebuilt per stripe. So oldSize never exceeds alphabetSize — it is
+  // either equal (same alphabet reused) or smaller (alphabet grew).
+  NIMBLE_CHECK_LE(oldSize, alphabetSize);
+  if (oldSize >= alphabetSize) {
+    return;
   }
-  scanState_.dictionary.values = std::move(values);
-  scanState_.dictionary.numValues = alphabetSize;
+  dictionaryState_.filterCache.resize(alphabetSize);
+  velox::simd::memset(
+      dictionaryState_.filterCache.data() + oldSize,
+      static_cast<uint8_t>(FilterResult::kUnknown),
+      static_cast<int32_t>(alphabetSize - oldSize));
+}
 
-  // The filter dictionary is per-chunk: a given local index maps to a
-  // different value in each chunk, so the cache must be rebuilt (reset to
-  // kUnknown), not extended, at every chunk boundary.
-  if (velox::dwio::common::DictionaryValues::hasFilter(scanSpec_->filter())) {
-    scanState_.filterCache.resize(alphabetSize);
-    velox::simd::memset(
-        scanState_.filterCache.data(),
-        static_cast<uint8_t>(FilterResult::kUnknown),
-        alphabetSize);
+namespace {
+
+// Compacts the non-null (index, row) pairs out of a materialized run. Writes
+// the dictionary index and file row of each non-null position into
+// outIndices/outRows (caller-sized to at least numValues) and returns the
+// non-null count. A null 'nulls' bitmap means no nulls, so every entry is
+// copied. Pure: touches no reader member state.
+int32_t extractNonNullEntries(
+    const int32_t* indices,
+    const velox::RowSet& rows,
+    const uint64_t* nulls,
+    velox::vector_size_t numValues,
+    int32_t* outIndices,
+    int32_t* outRows) {
+  int32_t count = 0;
+  for (velox::vector_size_t i = 0; i < numValues; ++i) {
+    if (nulls != nullptr && velox::bits::isBitNull(nulls, i)) {
+      continue;
+    }
+    outIndices[count] = indices[i];
+    outRows[count] = rows[i];
+    ++count;
   }
-  scanState_.updateRawState();
+  return count;
+}
+
+// Filters a run of materialized dictionary indices through the merged alphabet
+// and the per-index filterCache. Writes the passing indices to outputIndices
+// and their rows to outputRows (both caller-sized, compacted to the survivors),
+// records each newly resolved verdict into filterCache (kSuccess/kFailure), and
+// returns the number of passing rows.
+int32_t filterByCache(
+    const int32_t* inputIndices,
+    const int32_t* inputRows,
+    int32_t numInput,
+    const std::vector<std::string_view>& alphabet,
+    const velox::common::Filter& filter,
+    uint8_t* filterCache,
+    int32_t* outputIndices,
+    int32_t* outputRows) {
+  // Delegate to the shared SIMD dictionary-filter kernel. Nimble's merged
+  // alphabet is single-tier, so the per-index test resolves the dictionary
+  // entry directly and applies the byte filter. The Nimble path always emits
+  // both indices and rows, hence kFilterOnly=false.
+  return velox::dwio::common::filterDictionaryRunSimd</*kFilterOnly=*/false>(
+      inputIndices,
+      numInput,
+      inputRows,
+      filterCache,
+      outputRows,
+      outputIndices,
+      /*numValues=*/0,
+      [&](int32_t dictIndex) {
+        const auto& sv = alphabet[dictIndex];
+        return filter.testBytes(sv.data(), static_cast<int32_t>(sv.size()));
+      });
+}
+
+} // namespace
+
+void StringColumnReader::ensureWritableResultNulls(velox::vector_size_t size) {
+  if (!returnReaderNulls_) {
+    // Non-dense reads already hold an output-indexed resultNulls_ allocated by
+    // prepareRead/prepareNulls; nothing to do.
+    return;
+  }
+  // Dense reads with nulls park the null flags in nullsInReadRange_ and return
+  // them directly (returnReaderNulls_). The dict-filter path pre-compacts
+  // values, so it must instead write compacted output nulls into resultNulls_.
+  // Mirror compactScalarValues' allocation and switch the fast path off.
+  if (!(resultNulls_ && resultNulls_->unique() &&
+        resultNulls_->capacity() >=
+            velox::bits::nbytes(size) + velox::simd::kPadding)) {
+    resultNulls_ = velox::AlignedBuffer::allocate<bool>(
+        size + velox::simd::kPadding * 8, pool_);
+    rawResultNulls_ = resultNulls_->asMutable<uint64_t>();
+  }
+  returnReaderNulls_ = false;
+}
+
+void StringColumnReader::filterDictionaryIndices(
+    const RowSet& rows,
+    const velox::common::Filter* filter) {
+  NIMBLE_CHECK_NOT_NULL(filter);
+  ensureFilterCache();
+
+  const auto readCount = numValues_;
+  constexpr int32_t kSimdPadding = xsimd::batch<int32_t>::size;
+  std::vector<int32_t> nonNullIndices(readCount + kSimdPadding, 0);
+  std::vector<int32_t> nonNullRows(readCount + kSimdPadding, 0);
+  // The dict indices in rawValues_ are output-indexed, so the null check must
+  // use the output-indexed bitmap. resultNulls() is the single source of truth
+  // for it (nullsInReadRange_ for dense reads, resultNulls_ for non-dense). Use
+  // it instead of rawNullsInReadRange(), which is file-indexed and wrong for
+  // non-dense reads (nested-under-nullable, cross-stripe, sibling-filter).
+  const auto& resultNullsBuffer = resultNulls();
+  const auto* nulls =
+      resultNullsBuffer ? resultNullsBuffer->as<uint64_t>() : nullptr;
+
+  const auto numNonNull = extractNonNullEntries(
+      reinterpret_cast<const int32_t*>(rawValues_),
+      rows,
+      nulls,
+      readCount,
+      nonNullIndices.data(),
+      nonNullRows.data());
+
+  if (nulls == nullptr) {
+    // No nulls in range: filter the dictionary indices in place. There is no
+    // null bitmap to realign.
+    auto* outputRows = mutableOutputRows(numNonNull);
+    numValues_ = filterByCache(
+        nonNullIndices.data(),
+        nonNullRows.data(),
+        numNonNull,
+        dictionaryState_.alphabet,
+        *filter,
+        dictionaryState_.filterCache.data(),
+        reinterpret_cast<int32_t*>(rawValues_),
+        outputRows);
+    outputRows_.resize(numValues_);
+    return;
+  }
+
+  // Nulls are present. The dict-filter path pre-compacts rawValues_/outputRows_
+  // to the passing rows, which makes the framework's compactScalarValues a
+  // no-op (rows.size() == numValues_) and skips its null move. So realign the
+  // result null bitmap to the compacted output layout here; otherwise
+  // getValues() would hand DictionaryVector a read-range-indexed bitmap against
+  // compacted indices and misplace nulls.
+  if (!filter->testNull()) {
+    // The filter rejects nulls, so every null row is dropped and the
+    // SIMD-filtered non-null passing rows are the entire output. Filter in
+    // place, then mark the compacted output all-non-null.
+    auto* outputRows = mutableOutputRows(numNonNull);
+    numValues_ = filterByCache(
+        nonNullIndices.data(),
+        nonNullRows.data(),
+        numNonNull,
+        dictionaryState_.alphabet,
+        *filter,
+        dictionaryState_.filterCache.data(),
+        reinterpret_cast<int32_t*>(rawValues_),
+        outputRows);
+    outputRows_.resize(numValues_);
+    ensureWritableResultNulls(readCount);
+    velox::bits::fillBits(
+        rawResultNulls_, 0, numValues_, velox::bits::kNotNull);
+    return;
+  }
+
+  // The filter accepts nulls (e.g. IS NULL): retain every null row and merge
+  // it, in ascending row order, with the SIMD-filtered non-null passing rows.
+  // The non-null rows are filtered into temporaries because the merge writes
+  // the interleaved result back into rawValues_/outputRows_ in row order.
+  std::vector<int32_t> passIndices(numNonNull + kSimdPadding, 0);
+  std::vector<int32_t> passRows(numNonNull + kSimdPadding, 0);
+  const auto numPass = filterByCache(
+      nonNullIndices.data(),
+      nonNullRows.data(),
+      numNonNull,
+      dictionaryState_.alphabet,
+      *filter,
+      dictionaryState_.filterCache.data(),
+      passIndices.data(),
+      passRows.data());
+
+  ensureWritableResultNulls(readCount);
+  auto* indices = reinterpret_cast<int32_t*>(rawValues_);
+  auto* outputRows = mutableOutputRows(readCount);
+  numValues_ = processNullAndPassingRows(
+      nulls,
+      rows,
+      readCount,
+      passIndices.data(),
+      passRows.data(),
+      numPass,
+      indices,
+      outputRows);
+  outputRows_.resize(numValues_);
+}
+
+velox::vector_size_t StringColumnReader::processNullAndPassingRows(
+    const uint64_t* nulls,
+    const velox::RowSet& rows,
+    velox::vector_size_t readCount,
+    const int32_t* passIndices,
+    const int32_t* passRows,
+    int32_t numPass,
+    int32_t* indices,
+    int32_t* outputRows) {
+  velox::vector_size_t count = 0;
+  int32_t passCursor = 0;
+  for (velox::vector_size_t i = 0; i < readCount; ++i) {
+    if (velox::bits::isBitNull(nulls, i)) {
+      // Null row: passes because the filter accepts nulls. The index is
+      // unused for a null position; write 0 as a safe placeholder.
+      velox::bits::setNull(rawResultNulls_, count, /*isNull=*/true);
+      indices[count] = 0;
+      outputRows[count] = rows[i];
+      ++count;
+    } else if (passCursor < numPass && passRows[passCursor] == rows[i]) {
+      // Non-null row that passed the byte filter.
+      velox::bits::setNull(rawResultNulls_, count, /*isNull=*/false);
+      indices[count] = passIndices[passCursor];
+      outputRows[count] = rows[i];
+      ++count;
+      ++passCursor;
+    }
+  }
+  return count;
 }
 
 void StringColumnReader::updateDictionaryIndices(
@@ -116,9 +323,6 @@ bool StringColumnReader::tryExtendDictionaryAtChunkBoundary(
       chunkAlphabet.begin(),
       chunkAlphabet.end());
   dictionaryState_.alphabetVector.reset();
-  if (scanSpec_->hasFilter()) {
-    updateDictionaryScanState(chunkAlphabet);
-  }
   crossChunkRead_ = true;
   return true;
 }
@@ -171,9 +375,6 @@ bool StringColumnReader::readWithDictionary(
 
   prepareRead<int32_t>(offset, rows, incomingNulls);
   ensureDictionaryState();
-  if (scanSpec_->hasFilter()) {
-    updateDictionaryScanState(dictionaryState_.alphabet);
-  }
   velox::common::testutil::TestValue::adjust(
       "facebook::nimble::StringColumnReader::readWithDictionary",
       &dictionaryState_.alphabet);
@@ -193,17 +394,25 @@ bool StringColumnReader::readWithDictionary(
   //     readDictionaryIndices stops and the reactive flat fallback below
   //     takes over.
   //
-  // When a filter is active, the visitor's process()/processNull() in
-  // readDenseMaterializedIndices handle filter evaluation and outputRows
-  // via the if constexpr (kHasFilter) path in the encoding layer.
-  // kEncodingHasNulls must be false: unlike DWRF, Nimble does not pre-populate
-  // nullsInReadRange_ before the read. Nulls are materialized lazily by
-  // NullableEncoding during the decode (inside readDictionaryIndices). Passing
-  // true would route IsNull/IsNotNull through
-  // SelectiveColumnReader::filterNulls, which reads the still-empty
-  // nullsInReadRange_ and silently drops every matching row. With false,
-  // IsNull/IsNotNull go through the visitor/decode path (processNull) like
-  // every other filter, matching the flat read() below.
+  // Save and suppress the filter during index reading so the bulk
+  // materializeIndices path runs (not approach C's per-row process path).
+  // The SIMD filterDictionaryIndices applies the filter post-hoc.
+  std::unique_ptr<velox::common::Filter> savedFilter;
+  if (scanSpec_->hasFilter()) {
+    savedFilter = scanSpec_->filter()->clone();
+    scanSpec_->setFilter(nullptr);
+  }
+  // If the read below throws, reinstall the suppressed filter so scanSpec_ is
+  // not left permanently filterless, which would silently drop the pushed-down
+  // filter on subsequent reads.
+  auto filterGuard = folly::makeGuard([&] {
+    if (savedFilter != nullptr) {
+      scanSpec_->setFilter(std::move(savedFilter));
+    }
+  });
+
+  // kEncodingHasNulls must be false: Nimble materializes nulls lazily during
+  // decode and does not pre-populate nullsInReadRange_.
   dwio::common::StringColumnReadWithVisitorHelper<
       /*kEncodingHasNulls=*/false,
       /*kDictionary=*/false>(*this, rows)([&](auto visitor) {
@@ -229,8 +438,51 @@ bool StringColumnReader::readWithDictionary(
     // Offset the final chunk's indices into the merged alphabet.
     updateDictionaryIndices(alphabetOffset, valueOffset);
   });
+  // Reinstate the filter before the post-hoc SIMD filtering below needs it; the
+  // guard then no-ops since savedFilter has been moved out.
+  filterGuard.dismiss();
+  if (savedFilter != nullptr) {
+    scanSpec_->setFilter(std::move(savedFilter));
+  }
 
   if (!abandonDictionary) {
+    // Reconcile the reader's null state after the bulk dictionary read, for
+    // DENSE reads only. A dense read records its nulls in nullsInReadRange_
+    // (fresh per read, output==file), but the bulk index path (unlike the
+    // per-row processNull path) does not set anyNulls_/returnReaderNulls_;
+    // without this, resultNulls() reports no nulls and
+    // filterDictionaryIndices/getValues read the uninitialized index slots at
+    // null positions. Set returnReaderNulls_ directly rather than via
+    // resolveReturnNullBuffer(), which forces it false for filtered reads.
+    //
+    // Non-dense reads are intentionally NOT reconciled here: they set anyNulls_
+    // via their own per-row processNull path, and their resultNulls_ must not
+    // be inspected — it is populated lazily (only when a null is hit), so a
+    // no-null non-dense read leaves it stale from a prior read and would
+    // falsely report nulls, marking non-null rows null.
+    //
+    // Contract this couples to (keep in sync with SelectiveColumnReader): a
+    // dense read is exactly rows == [0, rows.size()), the same test the
+    // framework's useBulkPath()/resolveReturnNullBuffer() apply; and for a
+    // dense bulk read with nulls, resultNulls() must return nullsInReadRange_
+    // (returnReaderNulls_ == true). resolveReturnNullBuffer() would establish
+    // that, but it forces the flag false whenever a filter is present, so we
+    // set it directly here. Revisit if the framework changes how
+    // returnReaderNulls_ is derived for dense reads.
+    const bool isDense = !rows.empty() && rows.back() == rows.size() - 1;
+    if (!anyNulls_ && numValues_ > 0 && isDense &&
+        nullsInReadRange() != nullptr &&
+        !velox::bits::isAllSet(
+            nullsInReadRange()->as<uint64_t>(),
+            0,
+            numValues_,
+            velox::bits::kNotNull)) {
+      anyNulls_ = true;
+      returnReaderNulls_ = true;
+    }
+    if (scanSpec_->hasFilter()) {
+      filterDictionaryIndices(rows, scanSpec_->filter());
+    }
     readOffset_ += endReadRow;
     return true;
   }

--- a/dwio/nimble/velox/selective/StringColumnReader.h
+++ b/dwio/nimble/velox/selective/StringColumnReader.h
@@ -59,10 +59,12 @@ class StringColumnReader : public velox::dwio::common::SelectiveColumnReader {
   struct DictionaryState {
     std::vector<std::string_view> alphabet;
     velox::VectorPtr alphabetVector;
+    velox::raw_vector<uint8_t> filterCache;
 
     void clear() {
       alphabet.clear();
       alphabetVector.reset();
+      filterCache.clear();
     }
   };
 
@@ -105,13 +107,52 @@ class StringColumnReader : public velox::dwio::common::SelectiveColumnReader {
       int32_t& alphabetOffset,
       velox::vector_size_t& valueOffset);
 
-  // Populates scanState_.dictionary and scanState_.filterCache from the given
-  // chunk's local alphabet so the visitor's process() can evaluate filters on
-  // that chunk's raw (local) dictionary indices. Called once per chunk during a
-  // filtered dictionary read; the filterCache is reset on each call because a
-  // local index maps to a different value in each chunk.
-  void updateDictionaryScanState(
-      const std::vector<std::string_view>& chunkAlphabet);
+  // Grows dictionaryState_.filterCache to one byte per merged-alphabet entry,
+  // initializing newly added bytes to FilterResult::kUnknown. Extend-only: it
+  // never shrinks, relying on DictionaryState::clear() to drop the cache
+  // together with the alphabet so no stale verdict outlives its entry.
+  void ensureFilterCache();
+
+  // Switches off the dense returnReaderNulls_ fast path and ensures
+  // resultNulls_ is a writable, output-indexed buffer of at least `size` bits.
+  // The dict-filter path pre-compacts values, so compactScalarValues' null move
+  // is skipped; this provides a buffer to write the compacted output nulls
+  // into.
+  void ensureWritableResultNulls(velox::vector_size_t size);
+
+  // Applies the pushed-down filter to the just-materialized dictionary indices,
+  // post-hoc on the merged alphabet (the bulk index read suppressed the
+  // filter). Compacts in place to the passing rows and rewrites the reader's
+  // output state:
+  //   - rawValues_: overwritten with the passing dictionary indices, compacted.
+  //   - outputRows_: set to the passing file rows, resized to the pass count.
+  //   - numValues_: set to the number of passing rows.
+  // When nulls are present it also realigns the result-null bitmap to the
+  // compacted output layout via ensureWritableResultNulls() (which allocates
+  // resultNulls_ and clears returnReaderNulls_), because pre-compaction makes
+  // the framework's compactScalarValues null move a no-op. Reads the
+  // output-indexed null bitmap from resultNulls() and consults
+  // dictionaryState_.alphabet and filterCache (lazily filled via
+  // ensureFilterCache()).
+  void filterDictionaryIndices(
+      const velox::RowSet& rows,
+      const velox::common::Filter* filter);
+
+  // Merges, in ascending row order, the null rows (which pass because the
+  // filter accepts nulls) with the byte-filter-passing non-null rows held in
+  // passIndices/passRows. Writes the merged dictionary indices into 'indices',
+  // the merged file rows into 'outputRows', and the per-output null bits into
+  // rawResultNulls_ (null positions marked null, index 0 as a placeholder).
+  // Returns the merged output count (the new numValues_).
+  velox::vector_size_t processNullAndPassingRows(
+      const uint64_t* nulls,
+      const velox::RowSet& rows,
+      velox::vector_size_t readCount,
+      const int32_t* passIndices,
+      const int32_t* passRows,
+      int32_t numPass,
+      int32_t* indices,
+      int32_t* outputRows);
 
   // Converts the dict indices in rawValues_ to flat StringView values by
   // resolving each index against the merged alphabet. The StringViews point

--- a/dwio/nimble/velox/selective/tests/StringColumnReaderTest.cpp
+++ b/dwio/nimble/velox/selective/tests/StringColumnReaderTest.cpp
@@ -1147,6 +1147,164 @@ TEST_P(StringColumnReaderTest, flatMapStringDictionaryPath) {
   ASSERT_EQ(0, rowReader->next(1, result));
 }
 
+// Flatmap string column read through a BARE DictionaryEncoding with EXTERNAL
+// (inMap) nulls. This is the genuine regression guard for
+// ChunkedDecoder::readDictionaryIndicesImpl<kHasNulls=true> handling nulls that
+// originate from the flatmap inMap bitmap rather than from the encoding itself.
+//
+// Why a dedicated test is needed: flatMapStringDictionaryPath above uses data
+// whose value stream is encoded as MainlyConstant<Dictionary>. MC's own
+// readIndicesWithVisitor maps rows to values internally, so that test passes
+// with OR without the kHasNulls fix and never exercises the external-null
+// batching in readDictionaryIndicesImpl. Here MainlyConstant is removed from
+// the writer's read factors so the value stream is encoded as a bare
+// DictionaryEncoding (dictionaryEnabled() == true, no inner null handling). The
+// decode then flows read() -> readWithDictionary() ->
+// decoder_.readDictionaryIndices() -> readDictionaryIndicesImpl<true>, which
+// must use computeNextRowIndex<kHasNulls> to skip the inMap-null rows when
+// batching indices. If kHasNulls were ignored, the decoder would over-read the
+// index stream and land values at the wrong (null) row positions.
+//
+// Key 1 is present in every row (dense, no inMap nulls). Key 2 is absent when
+// i % 3 == 0, so its child column receives external inMap nulls at exactly
+// those rows. The alphabets are small with no dominant value, so Dictionary is
+// the natural choice for the sub-encoding once MainlyConstant is excluded.
+TEST_P(
+    StringColumnReaderTest,
+    flatMapStringDictionaryPathExternalNullsBareDict) {
+  const bool stringDecoderZeroCopy = GetParam();
+  if (!stringDecoderZeroCopy) {
+    GTEST_SKIP() << "Dictionary path requires stringDecoderZeroCopy";
+  }
+
+  // Write map<int8_t, varchar> as a flatmap. Key 1 is present in all rows;
+  // key 2 is present only when i % 3 != 0, creating inMap nulls for key 2.
+  constexpr int kRows = 120;
+  std::vector<int8_t> allKeys;
+  std::vector<std::string> allVals;
+  std::vector<vector_size_t> mapOffsets;
+  std::vector<vector_size_t> mapSizes;
+  // Cycle through small alphabets with no single dominant value so the value
+  // streams are encoded as a bare Dictionary (not Trivial or MainlyConstant).
+  const std::vector<std::string> key1Alphabet = {
+      "alpha", "bravo", "charlie", "delta"};
+  const std::vector<std::string> key2Alphabet = {"echo", "foxtrot", "golf"};
+  for (int i = 0; i < kRows; ++i) {
+    mapOffsets.push_back(static_cast<vector_size_t>(allKeys.size()));
+    allKeys.push_back(1);
+    allVals.push_back(key1Alphabet[i % key1Alphabet.size()]);
+    if (i % 3 != 0) {
+      allKeys.push_back(2);
+      allVals.push_back(key2Alphabet[i % key2Alphabet.size()]);
+    }
+    mapSizes.push_back(
+        static_cast<vector_size_t>(allKeys.size() - mapOffsets.back()));
+  }
+  auto keysFv = makeFlatVector<int8_t>(allKeys);
+  auto valsFv = makeFlatVector<std::string>(allVals);
+  auto offBuf = allocateOffsets(kRows, pool());
+  auto sizBuf = allocateSizes(kRows, pool());
+  auto* rawOff = offBuf->asMutable<vector_size_t>();
+  auto* rawSiz = sizBuf->asMutable<vector_size_t>();
+  for (int i = 0; i < kRows; ++i) {
+    rawOff[i] = mapOffsets[i];
+    rawSiz[i] = mapSizes[i];
+  }
+  auto input = makeRowVector({std::make_shared<MapVector>(
+      pool(),
+      MAP(TINYINT(), VARCHAR()),
+      nullptr,
+      kRows,
+      offBuf,
+      sizBuf,
+      keysFv,
+      valsFv)});
+
+  // Exclude MainlyConstant so the flatmap value streams pick a bare Dictionary
+  // encoding, forcing the read through readDictionaryIndicesImpl rather than
+  // MC's internal row->value mapping.
+  auto readFactors = ManualEncodingSelectionPolicyFactory::defaultReadFactors();
+  std::erase_if(readFactors, [](const auto& pair) {
+    return pair.first == EncodingType::MainlyConstant;
+  });
+  VeloxWriterOptions writerOptions;
+  writerOptions.flatMapColumns = {{"c0", {}}};
+  writerOptions.encodingSelectionPolicyFactory =
+      [readFactors](DataType dataType) {
+        return ManualEncodingSelectionPolicyFactory(readFactors)
+            .createPolicy(dataType);
+      };
+  auto file = test::createNimbleFile(*rootPool(), input, writerOptions);
+
+  // Read back as struct with flatmap-as-struct projection.
+  auto outType = ROW({"c0"}, {ROW({"1", "2"}, {VARCHAR(), VARCHAR()})});
+  auto scanSpec = std::make_shared<common::ScanSpec>("root");
+  scanSpec->addAllChildFields(*outType);
+  scanSpec->childByName("c0")->setFlatMapAsStruct(true);
+
+  auto readFile = std::make_shared<InMemoryReadFile>(file);
+  auto factory =
+      dwio::common::getReaderFactory(dwio::common::FileFormat::NIMBLE);
+  dwio::common::ReaderOptions options(pool());
+  options.setDataIoStats(dataIoStats_);
+  options.setMetadataIoStats(metadataIoStats_);
+  options.setScanSpec(scanSpec);
+  auto reader = factory->createReader(
+      std::make_unique<dwio::common::BufferedInput>(readFile, *pool()),
+      options);
+  dwio::common::RowReaderOptions rowOptions;
+  rowOptions.setScanSpec(scanSpec);
+  rowOptions.setRequestedType(asRowType(input->type()));
+  rowOptions.setStringDecoderZeroCopy(true);
+  rowOptions.setNimblePreserveDictionaryEncoding(true);
+  auto rowReader = reader->createRowReader(rowOptions);
+
+  // Build expected output: key 1 always present, key 2 null when i % 3 == 0.
+  auto expected = makeRowVector({makeRowVector(
+      {"1", "2"},
+      {
+          makeFlatVector<std::string>(
+              kRows,
+              [&](auto i) { return key1Alphabet[i % key1Alphabet.size()]; }),
+          makeFlatVector<std::string>(
+              kRows,
+              [&](auto i) { return key2Alphabet[i % key2Alphabet.size()]; },
+              [](auto i) { return i % 3 == 0; }),
+      })});
+
+  using E = VectorEncoding::Simple;
+  auto result = BaseVector::create(outType, 0, pool());
+  int numScanned = 0;
+  int offset = 0;
+  while (numScanned < kRows) {
+    // Batch size 23 forces several batches so the external-null batching runs
+    // repeatedly within the chunk.
+    numScanned += rowReader->next(23, result);
+    result->validate();
+    if (result->size() == 0) {
+      continue;
+    }
+    // Assert the key-2 child (the one with external inMap nulls) decoded into a
+    // DictionaryVector, proving the bare-dictionary index path was taken.
+    // Load through any lazy/wrapping layers before reaching the nested struct.
+    auto c0 = BaseVector::loadedVectorShared(
+        result->asUnchecked<RowVector>()->childAt(0));
+    auto key2Child = BaseVector::loadedVectorShared(
+        c0->asUnchecked<RowVector>()->childAt(1));
+    EXPECT_EQ(key2Child->encoding(), E::DICTIONARY)
+        << "key 2 child should be a bare DictionaryVector at output offset "
+        << offset;
+    for (int j = 0; j < result->size(); ++j) {
+      ASSERT_TRUE(result->equalValueAt(expected.get(), j, offset + j))
+          << "Mismatch at row " << (offset + j) << ": expected "
+          << expected->toString(offset + j) << " got " << result->toString(j);
+    }
+    offset += result->size();
+  }
+  ASSERT_EQ(numScanned, kRows);
+  ASSERT_EQ(0, rowReader->next(1, result));
+}
+
 // Multi-chunk flatmap string dictionary path. Tests kHasNulls=true dict
 // index reading across chunk boundaries with inMap nulls. Key 2 is absent
 // in some rows (inMap=0), and the batch spans two chunks.
@@ -1627,6 +1785,153 @@ TEST_P(StringColumnReaderTest, dictionaryIsNullFilterProjected) {
   // IsNull passes exactly the null rows (every 3rd).
   validateWithFilter(
       *input, *readers.rowReader, 23, [](auto i) { return i % 3 == 0; });
+}
+
+// Regression for the stale-resultNulls_ bug in filterDictionaryIndices ("3c").
+// A no-null read at a SPARSE (non-contiguous) row set must not inspect a
+// resultNulls_ left dirty by an earlier null-containing batch. resultNulls_ for
+// non-dense reads is populated lazily (only when a null is actually hit) and is
+// not reset per read, so an earlier null batch can leave it stale. If
+// filterDictionaryIndices reads it unconditionally, extractNonNullEntries
+// wrongly drops rows and the wrong null-handling path runs.
+//
+// Setup: a dict-encoded string column c1 with a filter on it, plus a sibling
+// integer column c0 whose filter narrows the row set to a sparse set within
+// each batch. The first batch covers rows [0,99] where c1 has nulls (dirtying
+// resultNulls_); the second batch covers rows [100,199] where c1 has no nulls.
+// The second batch is the no-null sparse read whose filterDictionaryIndices
+// must not be misled by the stale buffer.
+TEST_P(StringColumnReaderTest, dictionaryFilterSparseNoNullsAfterNullBatch) {
+  const bool stringDecoderZeroCopy = GetParam();
+  if (!stringDecoderZeroCopy) {
+    GTEST_SKIP() << "Dictionary path requires stringDecoderZeroCopy";
+  }
+
+  constexpr int kRows = 200;
+  // c1: small alphabet so Dictionary applies. Nulls only in the first half
+  // (rows [0,99], every 7th); the second half (rows [100,199]) is all non-null.
+  auto c0 = makeFlatVector<int64_t>(kRows, [](auto i) { return i; });
+  auto c1 = makeFlatVector<std::string>(
+      kRows,
+      [](auto i) { return "v_" + std::to_string(i % 4); },
+      [](auto i) { return i < 100 && i % 7 == 0; });
+  auto input = makeRowVector({c0, c1});
+
+  // Force plain Dictionary encoding for c1; the writer wraps it in Nullable for
+  // the first-half null rows (Nullable -> Dictionary).
+  EncodingLayout dictLayout{
+      EncodingType::Dictionary,
+      {},
+      CompressionType::Uncompressed,
+      {std::nullopt, std::nullopt}};
+  VeloxWriterOptions writerOptions;
+  writerOptions.encodingLayoutTree.emplace(
+      Kind::Row,
+      std::
+          unordered_map<EncodingLayoutTree::StreamIdentifier, EncodingLayout>{},
+      "",
+      std::vector<EncodingLayoutTree>{
+          EncodingLayoutTree{Kind::Scalar, {}, "c0"},
+          EncodingLayoutTree{
+              Kind::Scalar, {{0, std::move(dictLayout)}}, "c1"}});
+  auto file = test::createNimbleFile(*rootPool(), input, writerOptions);
+
+  // Sibling filter on c0 keeps only even rows -> a sparse (non-contiguous) row
+  // set reaches c1 in every batch. Filter on c1 accepts a subset of the
+  // alphabet so filterDictionaryIndices runs on the sparse rows.
+  auto scanSpec = std::make_shared<common::ScanSpec>("root");
+  scanSpec->addAllChildFields(*input->type());
+  scanSpec->childByName("c0")->setFilter(
+      std::make_unique<common::BigintValuesUsingBitmask>(
+          0,
+          kRows,
+          [] {
+            std::vector<int64_t> evens;
+            for (int i = 0; i < kRows; i += 2) {
+              evens.push_back(i);
+            }
+            return evens;
+          }(),
+          /*nullAllowed=*/false));
+  scanSpec->childByName("c1")->setFilter(
+      std::make_unique<common::BytesValues>(
+          std::vector<std::string>{"v_1", "v_3"}, false));
+
+  auto readers = makeReaders(input, file, scanSpec, stringDecoderZeroCopy);
+  // Batch size 100 splits into batch 1 = rows [0,99] (c1 has nulls) and
+  // batch 2 = rows [100,199] (c1 no nulls, sparse). A row survives only when
+  // c0 is even, c1 is non-null, and c1 in {"v_1","v_3"}.
+  validateWithFilter(*input, *readers.rowReader, 100, [](int i) {
+    if (i % 2 != 0) {
+      return false;
+    }
+    if (i < 100 && i % 7 == 0) {
+      return false;
+    }
+    auto v = i % 4;
+    return v == 1 || v == 3;
+  });
+}
+
+// IS NULL filter on a nullable dict-encoded string column read at a SPARSE row
+// set. dictionaryIsNullFilterProjected covers the DENSE case; this exercises
+// filterDictionaryIndices' null-accepting row-ordered merge (path 3) under a
+// non-contiguous row set produced by a sibling column's filter. The surviving
+// (null) rows and their row mapping must be correct.
+TEST_P(StringColumnReaderTest, dictionaryIsNullFilterSparseRows) {
+  const bool stringDecoderZeroCopy = GetParam();
+  if (!stringDecoderZeroCopy) {
+    GTEST_SKIP() << "Dictionary path requires stringDecoderZeroCopy";
+  }
+
+  constexpr int kRows = 200;
+  auto c0 = makeFlatVector<int64_t>(kRows, [](auto i) { return i; });
+  // c1: small alphabet (Dictionary applies); null every 3rd row.
+  auto c1 = makeFlatVector<std::string>(
+      kRows, [](auto i) { return "v_" + std::to_string(i % 5); }, nullEvery(3));
+  auto input = makeRowVector({c0, c1});
+
+  // Force plain Dictionary encoding for c1 (Nullable -> Dictionary).
+  EncodingLayout dictLayout{
+      EncodingType::Dictionary,
+      {},
+      CompressionType::Uncompressed,
+      {std::nullopt, std::nullopt}};
+  VeloxWriterOptions writerOptions;
+  writerOptions.encodingLayoutTree.emplace(
+      Kind::Row,
+      std::
+          unordered_map<EncodingLayoutTree::StreamIdentifier, EncodingLayout>{},
+      "",
+      std::vector<EncodingLayoutTree>{
+          EncodingLayoutTree{Kind::Scalar, {}, "c0"},
+          EncodingLayoutTree{
+              Kind::Scalar, {{0, std::move(dictLayout)}}, "c1"}});
+  auto file = test::createNimbleFile(*rootPool(), input, writerOptions);
+
+  // Sibling filter on c0 keeps only even rows -> a sparse row set reaches c1.
+  // IS NULL on c1 then passes exactly the null rows within that sparse set.
+  auto scanSpec = std::make_shared<common::ScanSpec>("root");
+  scanSpec->addAllChildFields(*input->type());
+  scanSpec->childByName("c0")->setFilter(
+      std::make_unique<common::BigintValuesUsingBitmask>(
+          0,
+          kRows,
+          [] {
+            std::vector<int64_t> evens;
+            for (int i = 0; i < kRows; i += 2) {
+              evens.push_back(i);
+            }
+            return evens;
+          }(),
+          /*nullAllowed=*/false));
+  scanSpec->childByName("c1")->setFilter(std::make_unique<common::IsNull>());
+
+  auto readers = makeReaders(input, file, scanSpec, stringDecoderZeroCopy);
+  // A row survives only when c0 is even and c1 is null (every 3rd row).
+  validateWithFilter(*input, *readers.rowReader, 100, [](int i) {
+    return i % 2 == 0 && i % 3 == 0;
+  });
 }
 
 // Mainly-constant string column with chunking where read batches align with


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebookincubator/velox/pull/17954

Dictionary-encoded string columns in the selective Nimble reader emit a `DictionaryVector` backed by a single alphabet merged across all chunks of a read range. A filter pushed down on such a column cannot be evaluated inside the encoding's per-row decode: the merged alphabet (and therefore the per-alphabet-index `filterCache`) is not known until every chunk has been read, and the inner encoding's `bulkScan` would apply a string filter directly to raw `int32` dictionary indices. The filter is therefore suppressed during the bulk `materializeIndices` read and applied post-hoc on the merged alphabet.

This diff replaces the previous in-encoding (`populateScanState` / framework `StringDictionaryColumnVisitor`) filter evaluation with that post-hoc path, makes it SIMD-accelerated, and removes the now-dead in-encoding code:

- Shared SIMD kernel. Add a free function `filterDictionaryRunSimd<kFilterOnly>(...)` in `velox/dwio/common/ColumnVisitors.h` that gathers each index's cached verdict from `filterCache`, resolves cache misses through the filter (recording the result back), and SIMD-compacts the passing rows (and, unless `kFilterOnly`, the passing indices). Nimble's `filterByCache` calls it directly. DWRF's `StringDictionaryColumnVisitor::processRun` is left unchanged; it still holds an equivalent inline loop, marked with a TODO to adopt the shared kernel in a follow-up diff (kept separate to isolate the DWRF change from this Nimble feature).
- Post-hoc filter in `StringColumnReader`. `readWithDictionary` saves and clears the scan-spec filter so the bulk index read runs, then `filterDictionaryIndices` applies the filter on the merged alphabet via `filterByCache`, compacting `rawValues_`/`outputRows_` to the passing rows. `ensureFilterCache` lazily sizes the per-alphabet-index cache, which grows and clears together with the alphabet.
- Output-layout null realignment. Pre-compacting `rawValues_`/`outputRows_` makes the framework's `compactScalarValues` a no-op (`rows.size() == numValues_`), which skips its null move, so `filterDictionaryIndices` realigns the result nulls itself in three cases: (1) no nulls — filter in place; (2) value filter rejects nulls — filter in place and mark the compacted output all-non-null; (3) IS NULL accepts nulls — merge null rows with the passing non-null rows in row order. `ensureWritableResultNulls` mirrors the framework's `shouldMoveNulls` by switching off the dense `returnReaderNulls_` fast path and allocating an output-indexed null bitmap.
- Delete dead code. With `StringColumnReader` the sole owner of dictionary filtering, the per-encoding `kHasFilter` branches and the `prepareResultNullsForDenseFilter` helper in `encodings/common/Encoding.h` (and their call sites in the `Constant`, `Dictionary`, `MainlyConstant`, and `RLE` encodings) are unreachable and removed, along with `StringColumnReader::populateScanState`.

Performance. On a simulated filter workload (`parallel_reader` over a dictionary-encoded string column, `l_returnflag='R'`, opt mode, `batch_size=1024`, concurrency 16, `read_count=500`, P50), the SIMD `filterCache` path reads at ~52 ms, versus ~70 ms for the parent diff's scalar per-row filter (−26%) and 130 ms for a no-dictionary flat read (−60%). The gain comes from evaluating the byte filter once per distinct dictionary value (`filterCache` memoization) and SIMD-gathering/compacting survivors, instead of testing the filter per row. (Parent/flat figures are from the 2026-06-05 A/B; the SIMD figure was reconfirmed on the current stack on 2026-06-13: P50 wall 52/52/54 ms across 3 runs.)

No behavior change for non-dictionary columns or for dictionary columns read without a pushed-down filter.

Reviewed By: Yuhta

Differential Revision: D102273283


