### PR TITLE
feat: Separate needResumeKey responsibility to a separate option

### DIFF
--- a/dwio/nimble/velox/index/NimbleIndexProjector.cpp
+++ b/dwio/nimble/velox/index/NimbleIndexProjector.cpp
@@ -218,19 +218,54 @@ NimbleIndexProjector::Result NimbleIndexProjector::project(
 void NimbleIndexProjector::pruneStripeRanges(
     std::vector<StripeRange>& stripeRanges,
     const std::vector<uint64_t>& rowsPerRequest) {
-  if (ctx_.options->maxRowsPerRequest > 0) {
-    std::erase_if(stripeRanges, [&](const auto& range) {
-      return rowsPerRequest[range.requestIndex] >=
-          ctx_.options->maxRowsPerRequest;
+  const auto maxRowsPerRequest = ctx_.options->maxRowsPerRequest;
+  if (maxRowsPerRequest == 0) {
+    return;
+  }
+  std::erase_if(stripeRanges, [&](const auto& range) {
+    return rowsPerRequest[range.requestIndex] >= maxRowsPerRequest;
+  });
+}
+
+void NimbleIndexProjector::setResumeKey(
+    uint32_t requestIndex,
+    uint32_t stripeOffset,
+    uint32_t readEndRow,
+    bool partialRead) {
+  if (ctx_.resumeKeys[requestIndex].has_value()) {
+    return;
+  }
+  // More rows remain iff we clipped mid-stripe, or the request continues into
+  // the next stripe. A request occupies one contiguous stripe span, so
+  // "continues" can only mean the immediately-next stripe -- no scan needed.
+  bool hasMore = partialRead;
+  const uint32_t nextStripe = stripeOffset + 1;
+  if (!hasMore && nextStripe < ctx_.stripeRanges.numStripes) {
+    const auto ranges = ctx_.stripeRanges.getRanges(nextStripe);
+    hasMore = std::any_of(ranges.begin(), ranges.end(), [&](const auto& range) {
+      return range.requestIndex == requestIndex;
     });
+  }
+  // The first un-returned row is stripeStartRow + readEndRow in both cases:
+  // the clip point for a mid-stripe cut, or this stripe's end (== the next
+  // stripe's start) for a boundary cap.
+  if (hasMore) {
+    const uint32_t stripeIndex = ctx_.stripeRanges.startStripe + stripeOffset;
+    const auto stripeStartRow =
+        static_cast<uint32_t>(tablet_->stripeStartRow(stripeIndex));
+    ctx_.resumeKeys[requestIndex] =
+        clusterIndex_->keyAtRow(stripeStartRow + readEndRow);
   }
 }
 
 void NimbleIndexProjector::prepareStripes() {
   uint64_t totalRows{0};
   uint64_t totalBytes{0};
+  const auto maxRowsPerRequest = ctx_.options->maxRowsPerRequest;
+  const auto needResumeKey = ctx_.options->needResumeKey;
   std::vector<uint64_t> rowsPerRequest(ctx_.numRequests, 0);
   ctx_.hasStripeRanges.assign(ctx_.numRequests, false);
+  ctx_.resumeKeys.assign(ctx_.numRequests, std::nullopt);
 
   for (uint32_t offset = 0; offset < ctx_.stripeRanges.numStripes; ++offset) {
     auto spanRanges = ctx_.stripeRanges.getRanges(offset);
@@ -240,22 +275,37 @@ void NimbleIndexProjector::prepareStripes() {
       continue;
     }
 
+    const uint32_t stripeIndex = ctx_.stripeRanges.startStripe + offset;
+
     uint64_t stripeRows{0};
     for (auto& stripeRange : stripeRanges) {
+      const auto requestIndex = stripeRange.requestIndex;
       const auto numRows =
           static_cast<uint64_t>(stripeRange.rowRange.numRows());
-      if (ctx_.options->maxRowsPerRequest > 0) {
-        const auto remaining = ctx_.options->maxRowsPerRequest -
-            rowsPerRequest[stripeRange.requestIndex];
-        const auto rowsToRead = std::min(numRows, remaining);
-        rowsPerRequest[stripeRange.requestIndex] += rowsToRead;
-        stripeRows += rowsToRead;
-        if (rowsToRead < numRows) {
-          stripeRange.rowRange.endRow =
-              stripeRange.rowRange.startRow + static_cast<uint32_t>(rowsToRead);
-        }
-      } else {
+      if (maxRowsPerRequest == 0) {
+        rowsPerRequest[requestIndex] += numRows;
         stripeRows += numRows;
+        continue;
+      }
+
+      const auto remaining = maxRowsPerRequest - rowsPerRequest[requestIndex];
+      const auto rowsToRead = std::min(numRows, remaining);
+      rowsPerRequest[requestIndex] += rowsToRead;
+      stripeRows += rowsToRead;
+
+      // The hard cap cut this request mid-stripe: clip its range to the rows we
+      // keep. Clipping is independent of resume keys and always applies.
+      const bool partialRead = rowsToRead < numRows;
+      if (partialRead) {
+        stripeRange.rowRange.endRow =
+            stripeRange.rowRange.startRow + static_cast<uint32_t>(rowsToRead);
+      }
+
+      // Once the request reaches its cap (via a mid-stripe clip or by landing
+      // exactly on this stripe's end), record where it resumes.
+      if (needResumeKey && rowsPerRequest[requestIndex] >= maxRowsPerRequest) {
+        setResumeKey(
+            requestIndex, offset, stripeRange.rowRange.endRow, partialRead);
       }
     }
 
@@ -263,7 +313,6 @@ void NimbleIndexProjector::prepareStripes() {
       ctx_.hasStripeRanges[range.requestIndex] = true;
     }
 
-    const uint32_t stripeIndex = ctx_.stripeRanges.startStripe + offset;
     StripePlan stripePlan;
     stripePlan.stripeIndex = stripeIndex;
     stripePlan.stripeRanges = std::move(stripeRanges);
@@ -299,6 +348,7 @@ void NimbleIndexProjector::clearRequest() {
   ctx_.plan.stripePlans.clear();
   ctx_.plan.truncated = false;
   ctx_.hasStripeRanges.clear();
+  ctx_.resumeKeys.clear();
   ctx_.dataInputIndices.clear();
   ctx_.dataHandle.reset();
   ctx_.stripeBodies.clear();
@@ -606,6 +656,14 @@ folly::IOBuf NimbleIndexProjector::packStripe(size_t stripeOffset) {
 }
 
 void NimbleIndexProjector::setResumeKeys(Result& result) {
+  if (!ctx_.options->needResumeKey) {
+    return;
+  }
+  for (size_t i = 0; i < result.responses.size(); ++i) {
+    if (ctx_.resumeKeys[i].has_value()) {
+      result.responses[i].resumeKey = ctx_.resumeKeys[i];
+    }
+  }
   if (!ctx_.plan.truncated) {
     return;
   }
@@ -634,8 +692,8 @@ void NimbleIndexProjector::setResumeKeys(Result& result) {
 
   for (const auto& request : stripeRanges) {
     auto& response = result.responses[request.requestIndex];
-    NIMBLE_CHECK(!response.resumeKey.has_value());
-    if (std::any_of(
+    if (!response.resumeKey.has_value() &&
+        std::any_of(
             nextRanges.begin(), nextRanges.end(), [&](const auto& range) {
               return range.requestIndex == request.requestIndex;
             })) {

--- a/dwio/nimble/velox/index/NimbleIndexProjector.h
+++ b/dwio/nimble/velox/index/NimbleIndexProjector.h
@@ -67,8 +67,8 @@ using Subfield = velox::common::Subfield;
 ///     const auto& response = result.responses[i];
 ///     for (const auto& slice : response.slices) {
 ///       // `slice` is a self-describing kTablet IOBuf chain with
-///       // the request's row range and (on the last slice of a truncated
-///       // response) the resume key embedded in the header.
+///       // the request's row range and (on the last slice of a
+///       // cut-short response) the resume key embedded in the header.
 ///     }
 ///   }
 /// NOTE: NimbleIndexProjector is not thread-safe. Each thread must use its
@@ -94,6 +94,13 @@ class NimbleIndexProjector {
   ~NimbleIndexProjector() = default;
 
   /// Options for controlling projection behavior.
+  ///
+  /// The three limits below (maxRows, maxBytes, maxRowsPerRequest) only bound
+  /// how much data a single project() call returns; on their own they never
+  /// decide whether a resume key is produced. Resume keys are governed solely
+  /// by needResumeKey: when it is set, any request whose results were cut short
+  /// by one of these limits carries a resume key; when it is unset, no resume
+  /// keys are produced regardless of which limits fire.
   struct Options {
     /// Soft limit on total rows across all requests. 0 means no limit.
     /// When the running total exceeds this limit mid-stripe, the entire
@@ -106,9 +113,14 @@ class NimbleIndexProjector {
     /// that exceeds the budget.
     uint64_t maxBytes{0};
     /// Hard per-request row limit. 0 means no limit. Each request's row
-    /// range is clipped so that it never exceeds this many rows total.
-    /// No resume key is set — the request is considered fulfilled.
+    /// range is clipped so that it never returns more than this many rows.
     uint64_t maxRowsPerRequest{0};
+    /// When set, every request whose results were cut short by a limit
+    /// (maxRows, maxBytes, or maxRowsPerRequest) is given a resume key so the
+    /// caller can continue from where the request stopped (use the resume key
+    /// as the new lowerKey with the original upperKey). When unset, no resume
+    /// keys are produced even if a limit truncated the results.
+    bool needResumeKey{false};
   };
 
   /// Request for a batch of index lookups.
@@ -130,9 +142,11 @@ class NimbleIndexProjector {
     /// the last slice to extract it.
     std::vector<folly::IOBuf> slices;
 
-    /// If the result was truncated by maxRows or maxBytes, the encoded resume
-    /// key for continuation. The caller constructs new key bounds using this
-    /// as lowerKey with their original upperKey. nullopt if complete or miss.
+    /// When Options::needResumeKey is set and this request's results were cut
+    /// short by a limit (maxRows, maxBytes, or maxRowsPerRequest), the encoded
+    /// resume key for continuation. The caller constructs new key bounds using
+    /// this as lowerKey with their original upperKey. nullopt if complete, a
+    /// miss, or needResumeKey was not set.
     ///
     /// Also embedded in the last slice's per-slice header (when slices
     /// is non-empty) so consumers that hold an IOBuf can recover the key
@@ -284,6 +298,21 @@ class NimbleIndexProjector {
       std::vector<StripeRange>& stripeRanges,
       const std::vector<uint64_t>& rowsPerRequest);
 
+  // Records the resume key for a request that reached its maxRowsPerRequest cap
+  // in the stripe at `stripeOffset` (index relative to
+  // stripeRanges.startStripe, not an absolute stripe index). `readEndRow` is
+  // the request's stripe-relative end row after clipping. When `partialRead` is
+  // true the cap fell inside the stripe, so the key is the row-precise key at
+  // `readEndRow`; otherwise the cap landed on the stripe boundary and the key
+  // resumes from the next stripe still holding this request. The stripe's
+  // absolute start row is derived from `stripeOffset`. Idempotent (no-op once a
+  // key is recorded); callers gate on Options::needResumeKey.
+  void setResumeKey(
+      uint32_t requestIndex,
+      uint32_t stripeOffset,
+      uint32_t readEndRow,
+      bool partialRead);
+
   // Applies row and byte limits to the looked-up stripe ranges, computes stream
   // metadata for selected stripes, and populates ctx_.plan.
   void prepareStripes();
@@ -300,8 +329,10 @@ class NimbleIndexProjector {
   // loaded data directly into an IOBuf chain without copying.
   folly::IOBuf packStripe(size_t stripeOffset);
 
-  // If ctx_.plan.truncated, sets resume keys on requests that have data in the
-  // next unprocessed stripe.
+  // When Options::needResumeKey is set, attaches resume keys to requests whose
+  // results were cut short: per-request keys from maxRowsPerRequest caps, plus
+  // (on global maxRows/maxBytes truncation) keys for requests that still have
+  // data in an unprocessed stripe. No-op when needResumeKey is unset.
   void setResumeKeys(Result& result);
 
   // Iterates ctx_.plan.stripePlans and ctx_.stripeBodies to build per-request
@@ -343,6 +374,9 @@ class NimbleIndexProjector {
     // Per-request flag: true if the request has ranges in any StripePlan.
     // Set by prepareStripes(), used by setResumeKeys().
     std::vector<bool> hasStripeRanges;
+    // Per-request resume keys set when a request reaches maxRowsPerRequest and
+    // Options::needResumeKey is enabled.
+    std::vector<std::optional<std::string>> resumeKeys;
     // Flat array of enqueue indices, logically
     // [stripeOffset * numProjectedStreams + streamIndex]. nullopt for absent
     // streams. Populated by loadStripes().

--- a/dwio/nimble/velox/index/tests/NimbleIndexProjectorTest.cpp
+++ b/dwio/nimble/velox/index/tests/NimbleIndexProjectorTest.cpp
@@ -3157,6 +3157,7 @@ TEST_P(NimbleIndexProjectorTest, resumeKeyOnTruncation) {
   request.keyBounds = {bounds};
   NimbleIndexProjector::Options options;
   options.maxRows = 50;
+  options.needResumeKey = true;
   auto result = projector->project(request, options);
 
   ASSERT_EQ(result.responses.size(), 1);
@@ -3247,6 +3248,7 @@ TEST_P(NimbleIndexProjectorTest, softLimitAtStripeBoundary) {
     request.keyBounds = {bounds};
     NimbleIndexProjector::Options options;
     options.maxRows = 99;
+    options.needResumeKey = true;
     auto result = projector->project(request, options);
 
     ASSERT_EQ(result.responses.size(), 1);
@@ -3266,6 +3268,7 @@ TEST_P(NimbleIndexProjectorTest, softLimitAtStripeBoundary) {
     request.keyBounds = {bounds};
     NimbleIndexProjector::Options options;
     options.maxRows = 100;
+    options.needResumeKey = true;
     auto result = projector->project(request, options);
 
     ASSERT_EQ(result.responses.size(), 1);
@@ -3286,6 +3289,7 @@ TEST_P(NimbleIndexProjectorTest, softLimitAtStripeBoundary) {
     request.keyBounds = {bounds};
     NimbleIndexProjector::Options options;
     options.maxRows = 101;
+    options.needResumeKey = true;
     auto result = projector->project(request, options);
 
     ASSERT_EQ(result.responses.size(), 1);
@@ -3323,6 +3327,7 @@ TEST_P(NimbleIndexProjectorTest, resumeKeyPagination) {
     request.keyBounds = {currentBounds};
     NimbleIndexProjector::Options options;
     options.maxRows = maxRows;
+    options.needResumeKey = true;
     auto result = projector->project(request, options);
 
     ASSERT_EQ(result.responses.size(), 1);
@@ -3370,6 +3375,7 @@ TEST_P(NimbleIndexProjectorTest, maxRowsTotalAcrossRequests) {
   request.keyBounds = {bounds0, bounds1};
   NimbleIndexProjector::Options options;
   options.maxRows = 50;
+  options.needResumeKey = true;
   auto result = projector->project(request, options);
 
   ASSERT_EQ(result.responses.size(), 2);
@@ -3413,6 +3419,7 @@ TEST_P(NimbleIndexProjectorTest, noResumeKeyWhenRequestFullySatisfied) {
   request.keyBounds = {bounds0, bounds1};
   NimbleIndexProjector::Options options;
   options.maxRows = 100;
+  options.needResumeKey = true;
   auto result = projector->project(request, options);
 
   ASSERT_EQ(result.responses.size(), 2);
@@ -3497,6 +3504,7 @@ TEST_P(NimbleIndexProjectorTest, maxRowsSingleRowStripes) {
   request.keyBounds = {bounds};
   NimbleIndexProjector::Options options;
   options.maxRows = 3;
+  options.needResumeKey = true;
   auto result = projector->project(request, options);
 
   ASSERT_EQ(result.responses.size(), 1);
@@ -3621,6 +3629,7 @@ TEST_P(NimbleIndexProjectorTest, maxBytesTruncation) {
     request.keyBounds = {bounds};
     NimbleIndexProjector::Options options;
     options.maxBytes = bytesPerStripe * 2;
+    options.needResumeKey = true;
 
     auto result = projector->project(request, options);
     ASSERT_EQ(result.responses.size(), 1);
@@ -3702,6 +3711,7 @@ TEST_P(NimbleIndexProjectorTest, maxBytesPagination) {
       request.keyBounds = {currentBounds};
       NimbleIndexProjector::Options options;
       options.maxBytes = maxBytes;
+      options.needResumeKey = true;
 
       auto result = projector->project(request, options);
       EXPECT_EQ(result.responses.size(), 1);
@@ -3757,6 +3767,7 @@ TEST_P(NimbleIndexProjectorTest, maxBytesAndMaxRowsInteraction) {
     NimbleIndexProjector::Options options;
     options.maxRows = 50;
     options.maxBytes = bytesPerStripe * 3;
+    options.needResumeKey = true;
 
     auto result = projector->project(request, options);
     ASSERT_EQ(result.responses.size(), 1);
@@ -3775,6 +3786,7 @@ TEST_P(NimbleIndexProjectorTest, maxBytesAndMaxRowsInteraction) {
     NimbleIndexProjector::Options options;
     options.maxRows = 500;
     options.maxBytes = bytesPerStripe;
+    options.needResumeKey = true;
 
     auto result = projector->project(request, options);
     ASSERT_EQ(result.responses.size(), 1);
@@ -3809,7 +3821,8 @@ TEST_P(NimbleIndexProjectorTest, maxRowsPerRequestAndGlobalMaxRows) {
   }
 
   // Global limit is tighter: 50 rows global vs 300 rows/request.
-  // Global limit triggers resume key (stripe-boundary soft limit = 100 rows).
+  // Global limit triggers a resume key (needResumeKey set; stripe-boundary
+  // soft limit = 100 rows).
   {
     auto projector = createProjector(subfields);
     auto bounds = makeRangeLookup(rowType, {"key"}, 0, 500);
@@ -3818,6 +3831,7 @@ TEST_P(NimbleIndexProjectorTest, maxRowsPerRequestAndGlobalMaxRows) {
     NimbleIndexProjector::Options options;
     options.maxRowsPerRequest = 300;
     options.maxRows = 50;
+    options.needResumeKey = true;
 
     auto result = projector->project(request, options);
     ASSERT_EQ(result.responses.size(), 1);
@@ -3842,6 +3856,234 @@ TEST_P(NimbleIndexProjectorTest, maxRowsPerRequestAndGlobalMaxRows) {
     EXPECT_FALSE(result.responses[0].resumeKey.has_value());
     EXPECT_EQ(projector->stats().numProjectedRows, 50);
   }
+}
+
+TEST_P(NimbleIndexProjectorTest, maxRowsPerRequestStripeAlignedSetsResumeKeys) {
+  auto rowType = ROW({"key", "value"}, {BIGINT(), INTEGER()});
+  writeResumeKeyTestData();
+
+  std::vector<Subfield> subfields;
+  subfields.emplace_back("value");
+  auto projector = createProjector(subfields);
+
+  auto bounds0 = makeRangeLookup(rowType, {"key"}, 0, 500);
+  auto bounds1 = makeRangeLookup(rowType, {"key"}, 200, 800);
+
+  // maxRowsPerRequest=100 lands exactly on the stripe boundary; needResumeKey
+  // makes each request resume from the next stripe that still contains it.
+  NimbleIndexProjector::Request request;
+  request.keyBounds = {bounds0, bounds1};
+  NimbleIndexProjector::Options options;
+  options.maxRowsPerRequest = 100;
+  options.needResumeKey = true;
+  auto result = projector->project(request, options);
+
+  ASSERT_EQ(result.responses.size(), 2);
+  EXPECT_EQ(projector->stats().numReadStripes, 2);
+  EXPECT_EQ(projector->stats().numProjectedRows, 200);
+
+  for (const auto& response : result.responses) {
+    ASSERT_EQ(response.slices.size(), 1);
+    EXPECT_EQ(readEmbeddedRowRange(response.slices[0]).numRows(), 100);
+    ASSERT_TRUE(response.resumeKey.has_value());
+    EXPECT_EQ(readEmbeddedResumeKey(response.slices[0]), response.resumeKey);
+  }
+}
+
+TEST_P(NimbleIndexProjectorTest, needResumeKeyGatesResumeKey) {
+  auto rowType = ROW({"key", "value"}, {BIGINT(), INTEGER()});
+  // 10 stripes x 100 rows.
+  writeResumeKeyTestData();
+
+  std::vector<Subfield> subfields;
+  subfields.emplace_back("value");
+  auto bounds = makeRangeLookup(rowType, {"key"}, 0, 500);
+
+  // maxRows truncates after the first stripe, but needResumeKey is unset, so
+  // neither the response nor the last slice carries a resume key.
+  {
+    auto projector = createProjector(subfields);
+    NimbleIndexProjector::Request request;
+    request.keyBounds = {bounds};
+    NimbleIndexProjector::Options options;
+    options.maxRows = 50;
+    auto result = projector->project(request, options);
+    ASSERT_EQ(result.responses.size(), 1);
+    const auto& response = result.responses[0];
+    ASSERT_FALSE(response.slices.empty());
+    EXPECT_FALSE(response.resumeKey.has_value());
+    EXPECT_FALSE(readEmbeddedResumeKey(response.slices.back()).has_value());
+  }
+
+  // Same truncation with needResumeKey set -> resume key present.
+  {
+    auto projector = createProjector(subfields);
+    NimbleIndexProjector::Request request;
+    request.keyBounds = {bounds};
+    NimbleIndexProjector::Options options;
+    options.maxRows = 50;
+    options.needResumeKey = true;
+    auto result = projector->project(request, options);
+    ASSERT_EQ(result.responses.size(), 1);
+    EXPECT_TRUE(result.responses[0].resumeKey.has_value());
+  }
+
+  // maxRowsPerRequest cuts the request mid-stripe; without needResumeKey the
+  // request is returned capped with no resume key.
+  {
+    auto projector = createProjector(subfields);
+    NimbleIndexProjector::Request request;
+    request.keyBounds = {bounds};
+    NimbleIndexProjector::Options options;
+    options.maxRowsPerRequest = 150;
+    auto result = projector->project(request, options);
+    ASSERT_EQ(result.responses.size(), 1);
+    EXPECT_FALSE(result.responses[0].resumeKey.has_value());
+    EXPECT_EQ(projector->stats().numProjectedRows, 150);
+  }
+
+  // Same per-request cap with needResumeKey set -> resume key present.
+  {
+    auto projector = createProjector(subfields);
+    NimbleIndexProjector::Request request;
+    request.keyBounds = {bounds};
+    NimbleIndexProjector::Options options;
+    options.maxRowsPerRequest = 150;
+    options.needResumeKey = true;
+    auto result = projector->project(request, options);
+    ASSERT_EQ(result.responses.size(), 1);
+    EXPECT_TRUE(result.responses[0].resumeKey.has_value());
+    EXPECT_EQ(projector->stats().numProjectedRows, 150);
+  }
+}
+
+TEST_P(NimbleIndexProjectorTest, limitsTruncateButEmitNoResumeKeyWhenDisabled) {
+  auto rowType = ROW({"key", "value"}, {BIGINT(), INTEGER()});
+  // 10 stripes x 100 rows = 1000 rows, keys 0..999.
+  writeResumeKeyTestData();
+
+  std::vector<Subfield> subfields;
+  subfields.emplace_back("value");
+
+  // maxRows still truncates at the stripe boundary (100 of the 500 matching
+  // rows, one stripe), but with needResumeKey unset no resume key is produced.
+  {
+    auto projector = createProjector(subfields);
+    auto bounds = makeRangeLookup(rowType, {"key"}, 0, 500);
+    NimbleIndexProjector::Request request;
+    request.keyBounds = {bounds};
+    NimbleIndexProjector::Options options;
+    options.maxRows = 50;
+    options.needResumeKey = false;
+    auto result = projector->project(request, options);
+
+    ASSERT_EQ(result.responses.size(), 1);
+    const auto& response = result.responses[0];
+    uint64_t totalRows = 0;
+    for (const auto& slice : response.slices) {
+      totalRows += readEmbeddedRowRange(slice).numRows();
+    }
+    EXPECT_EQ(totalRows, 100);
+    EXPECT_EQ(projector->stats().numReadStripes, 1);
+    ASSERT_FALSE(response.slices.empty());
+    EXPECT_FALSE(response.resumeKey.has_value());
+    EXPECT_FALSE(readEmbeddedResumeKey(response.slices.back()).has_value());
+  }
+
+  // maxRowsPerRequest still hard-clips the request to 150 rows, but with
+  // needResumeKey unset no resume key is produced.
+  {
+    auto projector = createProjector(subfields);
+    auto bounds = makeRangeLookup(rowType, {"key"}, 0, 500);
+    NimbleIndexProjector::Request request;
+    request.keyBounds = {bounds};
+    NimbleIndexProjector::Options options;
+    options.maxRowsPerRequest = 150;
+    options.needResumeKey = false;
+    auto result = projector->project(request, options);
+
+    ASSERT_EQ(result.responses.size(), 1);
+    const auto& response = result.responses[0];
+    EXPECT_EQ(projector->stats().numProjectedRows, 150);
+    ASSERT_FALSE(response.slices.empty());
+    EXPECT_FALSE(response.resumeKey.has_value());
+    EXPECT_FALSE(readEmbeddedResumeKey(response.slices.back()).has_value());
+  }
+
+  // maxBytes still truncates the stripes read, but with needResumeKey unset no
+  // resume key is produced.
+  {
+    uint64_t bytesPerStripe = 0;
+    {
+      auto probe = createProjector(subfields);
+      auto bounds = makeRangeLookup(rowType, {"key"}, 0, 100);
+      NimbleIndexProjector::Request request;
+      request.keyBounds = {bounds};
+      auto result = probe->project(request, {});
+      bytesPerStripe = probe->stats().numOutputBytes;
+      ASSERT_GT(bytesPerStripe, 0);
+    }
+
+    auto projector = createProjector(subfields);
+    auto bounds = makeRangeLookup(rowType, {"key"}, 0, 500);
+    NimbleIndexProjector::Request request;
+    request.keyBounds = {bounds};
+    NimbleIndexProjector::Options options;
+    options.maxBytes = bytesPerStripe * 2;
+    options.needResumeKey = false;
+    auto result = projector->project(request, options);
+
+    ASSERT_EQ(result.responses.size(), 1);
+    const auto& response = result.responses[0];
+    // Soft byte limit truncates before all 5 stripes are read.
+    EXPECT_LT(projector->stats().numReadStripes, 5);
+    ASSERT_FALSE(response.slices.empty());
+    EXPECT_FALSE(response.resumeKey.has_value());
+    EXPECT_FALSE(readEmbeddedResumeKey(response.slices.back()).has_value());
+  }
+}
+
+TEST_P(NimbleIndexProjectorTest, maxRowsPerRequestResumeKeyPagination) {
+  auto rowType = ROW({"key", "value"}, {BIGINT(), INTEGER()});
+  // 10 stripes x 100 rows = 1000 rows, keys 0..999.
+  writeResumeKeyTestData();
+
+  std::vector<Subfield> subfields;
+  subfields.emplace_back("value");
+
+  // maxRowsPerRequest=150 cuts mid-stripe. With needResumeKey, the row-precise
+  // resume key lets the caller paginate the full range with no gaps or overlap:
+  // every page returns exactly 150 rows until the final tail page.
+  auto currentBounds = makeRangeLookup(rowType, {"key"}, 0, 1000);
+  uint64_t totalRows = 0;
+  int pages = 0;
+  while (pages < 100) {
+    ++pages;
+    auto projector = createProjector(subfields);
+    NimbleIndexProjector::Request request;
+    request.keyBounds = {currentBounds};
+    NimbleIndexProjector::Options options;
+    options.maxRowsPerRequest = 150;
+    options.needResumeKey = true;
+    auto result = projector->project(request, options);
+    ASSERT_EQ(result.responses.size(), 1);
+    const auto& response = result.responses[0];
+
+    uint64_t pageRows = 0;
+    for (const auto& slice : response.slices) {
+      pageRows += readEmbeddedRowRange(slice).numRows();
+    }
+    totalRows += pageRows;
+    if (!response.resumeKey.has_value()) {
+      break;
+    }
+    EXPECT_EQ(pageRows, 150) << "page " << pages;
+    currentBounds = velox::serializer::EncodedKeyBounds{
+        .lowerKey = response.resumeKey.value(),
+        .upperKey = currentBounds.upperKey};
+  }
+  EXPECT_LT(pages, 100);
+  EXPECT_EQ(totalRows, 1000);
 }
 
 TEST_P(
@@ -3931,6 +4173,7 @@ TEST_P(NimbleIndexProjectorTest, maxRowsLargeScale) {
       request.keyBounds = {currentBounds};
       NimbleIndexProjector::Options options;
       options.maxRows = maxRows;
+      options.needResumeKey = true;
       auto result = projector->project(request, options);
       EXPECT_EQ(result.responses.size(), 1);
       totalReadRows += projector->stats().numProjectedRows;
@@ -3973,6 +4216,7 @@ TEST_P(NimbleIndexProjectorTest, maxRowsMultiRequestMixedSatisfaction) {
   request.keyBounds = {bounds0, bounds1, bounds2, bounds3};
   NimbleIndexProjector::Options options;
   options.maxRows = 100;
+  options.needResumeKey = true;
   auto result = projector->project(request, options);
 
   ASSERT_EQ(result.responses.size(), 4);
@@ -4041,6 +4285,7 @@ TEST_P(NimbleIndexProjectorTest, maxBytesAndMaxRowsPerRequestInteraction) {
     NimbleIndexProjector::Options options;
     options.maxRowsPerRequest = 300;
     options.maxBytes = bytesPerStripe;
+    options.needResumeKey = true;
 
     auto result = projector->project(request, options);
     ASSERT_EQ(result.responses.size(), 1);
@@ -4081,6 +4326,7 @@ TEST_P(NimbleIndexProjectorTest, maxBytesLargeScale) {
     request.keyBounds = {currentBounds};
     NimbleIndexProjector::Options options;
     options.maxBytes = bytesPerStripe * 3;
+    options.needResumeKey = true;
     auto result = projector->project(request, options);
     EXPECT_EQ(result.responses.size(), 1);
     totalReadRows += projector->stats().numProjectedRows;


### PR DESCRIPTION
Summary:

Keep the vector-read coalescing changes while preserving the two Nimble row-limit semantics used by ZippyDB. `nimble.max_rows` remains the total row budget for a batched projector call, and `nimble.max_rows_per_scan_range` carries the per-scan-range soft row cap. `NimbleIndexProjector` accepts per-request soft row limits so Rocks/Nimble can batch ranges under one total cap without collapsing distinct range caps. ZippyDB now forwards `scanMaxRowsServerLimit` as `nimble.max_rows` and per-query `Scan.scanMaxRows` as `nimble.max_rows_per_scan_range` instead of taking their minimum.

Reviewed By: xiaoxmeng

Differential Revision: D109256693


