### PR TITLE
perf(nimble): Use FBA per-element for BlockBitPacking sparse decode at low selectivity (#918)

### DIFF
--- a/dwio/nimble/encodings/BlockBitPackingEncoding.h
+++ b/dwio/nimble/encodings/BlockBitPackingEncoding.h
@@ -33,7 +33,6 @@
 #include "dwio/nimble/encodings/selection/EncodingIdentifier.h"
 #include "dwio/nimble/encodings/selection/EncodingSelection.h"
 #include "velox/common/base/BitUtil.h"
-#include "velox/dwio/common/BitPackDecoder.h"
 #include "velox/dwio/common/DecoderUtil.h"
 #include "velox/dwio/common/Lemire/BitPacking/bitpackinghelpers.h"
 
@@ -611,15 +610,22 @@ void BlockBitPackingEncoding<T>::bulkScan(
       }
     }
   } else {
-    // Sparse: decode full block into tmp, then pick selected values.
-    // Simpler than per-element decode — no branching on block type.
+    // Sparse: per-block strategy based on block type and selectivity:
+    //  - skipEncoding: direct array access, no decode
+    //  - bitWidth == 0: constant block, return baseline
+    //  - low selectivity (<5%): FBA per-element for selected rows only
+    //  - high selectivity: full block decode, pick rows
+    constexpr uint32_t kMaxFbaSelectivityPct = 5;
+
     vector_size_t i = 0;
     while (i < numSelected) {
       const auto absRow = static_cast<uint32_t>(selectedRows[i]) +
           static_cast<uint32_t>(offset);
       const auto blockIndex = absRow / blockSize_;
       const auto blockStart = static_cast<uint32_t>(blockIndex) * blockSize_;
+      const auto& meta = blocksMetadata_[blockIndex];
 
+      // Find all selected rows belonging to this block.
       vector_size_t runEnd = i + 1;
       while (runEnd < numSelected) {
         const auto nextAbsRow = static_cast<uint32_t>(selectedRows[runEnd]) +
@@ -630,13 +636,44 @@ void BlockBitPackingEncoding<T>::bulkScan(
         ++runEnd;
       }
 
-      physicalType tmp[kMaxBlockSize];
-      const auto blockRows = blockRowCount(blockIndex);
-      materializeBlockRange(blockIndex, 0, blockRows, tmp);
-      for (vector_size_t j = i; j < runEnd; ++j) {
-        const auto blockOffset = static_cast<uint32_t>(selectedRows[j]) +
-            static_cast<uint32_t>(offset) - blockStart;
-        values[j] = static_cast<OutputType>(tmp[blockOffset]);
+      const auto runLength = static_cast<uint32_t>(runEnd - i);
+      const auto numBlockRows = blockRowCount(blockIndex);
+
+      // Raw: direct index, no decode.
+      if (meta.skipEncoding) {
+        const auto* rawValues = reinterpret_cast<const physicalType*>(
+            packedData_ + blockOffsets_[blockIndex]);
+        for (vector_size_t j = i; j < runEnd; ++j) {
+          const auto blockOffset = static_cast<uint32_t>(selectedRows[j]) +
+              static_cast<uint32_t>(offset) - blockStart;
+          values[j] = static_cast<OutputType>(rawValues[blockOffset]);
+        }
+        // Constant: every value equals baseline.
+      } else if (meta.bitWidth == 0) {
+        for (vector_size_t j = i; j < runEnd; ++j) {
+          values[j] = static_cast<OutputType>(meta.baseline);
+        }
+      } else if (runLength * 100 < numBlockRows * kMaxFbaSelectivityPct) {
+        // Low selectivity: FBA per-element decode for selected rows only.
+        FixedBitArray fba{
+            {packedData_ + blockOffsets_[blockIndex],
+             FixedBitArray::bufferSize(numBlockRows, meta.bitWidth)},
+            meta.bitWidth};
+        for (vector_size_t j = i; j < runEnd; ++j) {
+          const auto blockOffset = static_cast<uint32_t>(selectedRows[j]) +
+              static_cast<uint32_t>(offset) - blockStart;
+          values[j] = static_cast<OutputType>(
+              static_cast<physicalType>(fba.get(blockOffset)) + meta.baseline);
+        }
+      } else {
+        // High selectivity: full block decode, pick rows.
+        physicalType tmp[kMaxBlockSize];
+        materializeBlockRange(blockIndex, 0, numBlockRows, tmp);
+        for (vector_size_t j = i; j < runEnd; ++j) {
+          const auto blockOffset = static_cast<uint32_t>(selectedRows[j]) +
+              static_cast<uint32_t>(offset) - blockStart;
+          values[j] = static_cast<OutputType>(tmp[blockOffset]);
+        }
       }
       i = runEnd;
     }

--- a/dwio/nimble/encodings/benchmarks/BlockBitPackingBenchmark.cpp
+++ b/dwio/nimble/encodings/benchmarks/BlockBitPackingBenchmark.cpp
@@ -14,27 +14,57 @@
  * limitations under the License.
  */
 
-// Benchmark: sparse decode — FBA per-element vs full block decode + pick.
-// Measures the crossover point where decoding the full block becomes
-// faster than per-element FixedBitArray::get().
+// Microbenchmark: isolates the raw decode step for BlockBitPacking.
+// No Nimble encoding, no Velox reader pipeline, no filters — directly
+// decodes packed bit arrays to measure pure decode cost.
+// 8192 blocks x 1024 rows = ~8M values per iteration.
 //
-// Run: buck2 run @//mode/opt
-// fbcode//dwio/nimble/encodings/benchmarks:block_bit_packing_benchmark
+// Strategies compared:
+//   A) FBA::get() per element (scalar, random access)
+//   B) Lemire fullUnpack entire block, then pick
+//   C) Lemire fastunpack per-group (32 values), pick within group
 //
-// Results (Release mode, bw=5, 1024-row block):
+// For E2E benchmarks through the full Velox selective reader pipeline,
+// see IntEncodingBenchmark.cpp.
 //
-//  Rows  Selectivity     FBA      FullBlock   PerGroup    Winner
-//     5       0.5%       10ns       124ns       24ns      FBA (11x)
-//    50         5%       85ns       137ns      142ns      FBA (1.6x)
-//   100        10%      153ns       159ns      195ns      ~ crossover
-//   200        20%      294ns       222ns      290ns      FullBlock (1.3x)
-//   500        49%      702ns       324ns      453ns      FullBlock (2.2x)
-//   800        78%     1.12us       425ns      616ns      FullBlock (2.6x)
-//  1024       100%     1.42us       502ns      743ns      FullBlock (2.8x)
+// Run: buck2 run @mode/opt
+//   fbcode//dwio/nimble/encodings/benchmarks:block_bit_packing_benchmark
 //
-// Conclusion: FBA wins below ~10% selectivity, full block wins above.
-// Per-group fastunpack never wins at any selectivity.
-// BBP uses a hybrid threshold of kMaxBlockSize/10 (~102 rows).
+// Results (opt mode, 8192 blocks x 1024 rows = ~8M values):
+//
+// FBA time as % of Lemire decode-all-then-pick (lower = faster):
+//
+// uint8:
+//   bw   1%sel   10%sel   25%sel
+//    1     4%      35%      71%
+//    4     6%      50%      94%
+//    8     6%      49%      94%
+//
+// uint16:
+//   bw   1%sel   10%sel   25%sel
+//    1     4%      18%      40%
+//    4     6%      21%      41%
+//    8    13%      41%      71%
+//   16    16%      51%      84%
+//
+// uint32:
+//   bw   1%sel   10%sel   20%sel
+//   16    22%      59%      68%
+//   20     5%      26%      55%
+//   25     8%      29%      39%
+//   28    10%      39%      48%
+//   32    21%      85%      80%
+//
+// uint64:
+//   bw   1%sel   10%sel   20%sel
+//   25     9%      38%      66%
+//   40     6%      33%      48%
+//   48     7%      49%      51%
+//   60     3%      75%      37%
+//
+// Decision: use FBA per-element for all types at <5% selectivity
+// (~50 rows per 1024-row block, 4.88%). Dense path always uses
+// Lemire (fastest for full-block decode).
 
 #include <algorithm>
 #include <numeric>
@@ -51,17 +81,36 @@ namespace {
 
 constexpr uint32_t kBlockSize = 1024;
 constexpr uint8_t kBitWidth = 5;
+constexpr uint32_t kNumBlocks = 8192;
+constexpr uint32_t kTotalValues = kBlockSize * kNumBlocks;
 
-std::vector<char> packedData;
-std::vector<uint32_t> output(kBlockSize);
+struct PackedBlocks {
+  std::vector<char> bits;
+  uint32_t bytesPerBlock;
+};
 
-// Selected row indices within the block.
-std::vector<uint32_t> sparseRows5;
-std::vector<uint32_t> sparseRows50;
-std::vector<uint32_t> sparseRows100;
-std::vector<uint32_t> sparseRows200;
-std::vector<uint32_t> sparseRows500;
-std::vector<uint32_t> sparseRows800;
+PackedBlocks packedBlocks;
+std::vector<uint32_t> output(kTotalValues);
+
+// Row sets for various selectivities (N rows out of 1024).
+std::vector<uint32_t> sparseRows5; // 0.5%
+std::vector<uint32_t> sparseRows10; // 1%
+std::vector<uint32_t> sparseRows50; // 5%
+std::vector<uint32_t> sparseRows100; // 10%
+std::vector<uint32_t> sparseRows200; // 20%
+std::vector<uint32_t> sparseRows205; // 20% (Section 3 — at kMaxFba boundary)
+std::vector<uint32_t> sparseRows256; // 25%
+std::vector<uint32_t> sparseRows307; // 30%
+std::vector<uint32_t> sparseRows410; // 40%
+std::vector<uint32_t> sparseRows500; // 49%
+std::vector<uint32_t> sparseRows512; // 50%
+std::vector<uint32_t> sparseRows614; // 60%
+std::vector<uint32_t> sparseRows717; // 70%
+std::vector<uint32_t> sparseRows800; // 78%
+std::vector<uint32_t> sparseRows819; // 80%
+std::vector<uint32_t> sparseRows922; // 90%
+std::vector<uint32_t> sparseRows973; // 95%
+std::vector<uint32_t> sparseRows1014; // 99%
 std::vector<uint32_t> denseRows1024;
 
 std::vector<uint32_t> makeSelectedRows(uint32_t count, uint32_t blockSize) {
@@ -75,169 +124,151 @@ std::vector<uint32_t> makeSelectedRows(uint32_t count, uint32_t blockSize) {
 }
 
 void setupData() {
-  auto bufSize = FixedBitArray::bufferSize(kBlockSize, kBitWidth);
-  packedData.resize(bufSize, 0);
-  FixedBitArray fba(packedData.data(), kBitWidth);
+  const auto blockBytes = FixedBitArray::bufferSize(kBlockSize, kBitWidth);
+  packedBlocks.bytesPerBlock = blockBytes;
+  packedBlocks.bits.resize(blockBytes * kNumBlocks, 0);
   std::mt19937 rng(123);
   uint32_t maxVal = (1u << kBitWidth) - 1;
-  for (uint32_t i = 0; i < kBlockSize; ++i) {
-    fba.set(i, rng() % (maxVal + 1));
+  for (uint32_t b = 0; b < kNumBlocks; ++b) {
+    FixedBitArray fba(packedBlocks.bits.data() + b * blockBytes, kBitWidth);
+    for (uint32_t i = 0; i < kBlockSize; ++i) {
+      fba.set(i, rng() % (maxVal + 1));
+    }
   }
 
   sparseRows5 = makeSelectedRows(5, kBlockSize);
+  sparseRows10 = makeSelectedRows(10, kBlockSize);
   sparseRows50 = makeSelectedRows(50, kBlockSize);
   sparseRows100 = makeSelectedRows(100, kBlockSize);
   sparseRows200 = makeSelectedRows(200, kBlockSize);
+  sparseRows205 = makeSelectedRows(205, kBlockSize);
+  sparseRows256 = makeSelectedRows(256, kBlockSize);
+  sparseRows307 = makeSelectedRows(307, kBlockSize);
+  sparseRows410 = makeSelectedRows(410, kBlockSize);
   sparseRows500 = makeSelectedRows(500, kBlockSize);
+  sparseRows512 = makeSelectedRows(512, kBlockSize);
+  sparseRows614 = makeSelectedRows(614, kBlockSize);
+  sparseRows717 = makeSelectedRows(717, kBlockSize);
   sparseRows800 = makeSelectedRows(800, kBlockSize);
+  sparseRows819 = makeSelectedRows(819, kBlockSize);
+  sparseRows922 = makeSelectedRows(922, kBlockSize);
+  sparseRows973 = makeSelectedRows(973, kBlockSize);
+  sparseRows1014 = makeSelectedRows(1014, kBlockSize);
   denseRows1024.resize(kBlockSize);
   std::iota(denseRows1024.begin(), denseRows1024.end(), 0);
 }
 
-// Option A: FBA::get() per selected row (current BBP sparse path)
-void decodeFBA(const std::vector<uint32_t>& rows) {
-  FixedBitArray fba{
-      {packedData.data(), FixedBitArray::bufferSize(kBlockSize, kBitWidth)},
-      kBitWidth};
-  for (uint32_t i = 0; i < rows.size(); ++i) {
-    output[i] = static_cast<uint32_t>(fba.get(rows[i]));
-  }
-  folly::doNotOptimizeAway(output[0]);
-}
-
-// Option B: fullUnpack entire block via Lemire, then pick rows (Impulse style)
-void decodeFullBlockThenPick(const std::vector<uint32_t>& rows) {
-  uint32_t decoded[kBlockSize];
-  const auto* input = reinterpret_cast<const uint32_t*>(packedData.data());
-  constexpr uint32_t kGroupSize = 32;
-  for (uint32_t r = 0; r < kBlockSize; r += kGroupSize) {
-    facebook::velox::fastpforlib::fastunpack(
-        input + r / kGroupSize * kBitWidth, decoded + r, kBitWidth);
-  }
-  for (uint32_t i = 0; i < rows.size(); ++i) {
-    output[i] = decoded[rows[i]];
-  }
-  folly::doNotOptimizeAway(output[0]);
-}
-
-// Option C: fastunpack only the groups that contain selected rows.
-// Decodes 32 values per group, picks only the needed ones.
-void decodePerGroup(const std::vector<uint32_t>& rows) {
-  constexpr uint32_t kGroupSize = 32;
-  const auto* input = reinterpret_cast<const uint32_t*>(packedData.data());
-  uint32_t tmp[kGroupSize];
-  uint32_t outIdx = 0;
-  uint32_t i = 0;
-  while (i < rows.size()) {
-    const auto groupIdx = rows[i] / kGroupSize;
-    facebook::velox::fastpforlib::fastunpack(
-        input + groupIdx * kBitWidth, tmp, kBitWidth);
-    while (i < rows.size() && rows[i] / kGroupSize == groupIdx) {
-      output[outIdx++] = tmp[rows[i] % kGroupSize];
-      ++i;
+// Option A: FBA::get() per selected row.
+void decodeFBA(const std::vector<uint32_t>& rows, uint32_t iters) {
+  while (iters--) {
+    const auto blockBytes = packedBlocks.bytesPerBlock;
+    auto* out = output.data();
+    for (uint32_t b = 0; b < kNumBlocks; ++b) {
+      FixedBitArray fba{
+          {packedBlocks.bits.data() + b * blockBytes,
+           static_cast<size_t>(blockBytes)},
+          kBitWidth};
+      for (uint32_t i = 0; i < rows.size(); ++i) {
+        out[i] = static_cast<uint32_t>(fba.get(rows[i]));
+      }
+      out += rows.size();
     }
   }
-  folly::doNotOptimizeAway(output[0]);
+}
+
+// Option B: fullUnpack entire block via Lemire, then pick rows.
+// When rows.size() == kBlockSize (dense), decodes directly into output.
+void decodeFullBlockThenPick(
+    const std::vector<uint32_t>& rows,
+    uint32_t iters) {
+  constexpr uint32_t kGroupSize = 32;
+  const bool isDense = rows.size() == kBlockSize;
+  while (iters--) {
+    const auto blockBytes = packedBlocks.bytesPerBlock;
+    auto* out = output.data();
+    for (uint32_t b = 0; b < kNumBlocks; ++b) {
+      const auto* input = reinterpret_cast<const uint32_t*>(
+          packedBlocks.bits.data() + b * blockBytes);
+      if (isDense) {
+        for (uint32_t r = 0; r < kBlockSize; r += kGroupSize) {
+          facebook::velox::fastpforlib::fastunpack(
+              input + r / kGroupSize * kBitWidth, out + r, kBitWidth);
+        }
+      } else {
+        uint32_t decoded[kBlockSize];
+        for (uint32_t r = 0; r < kBlockSize; r += kGroupSize) {
+          facebook::velox::fastpforlib::fastunpack(
+              input + r / kGroupSize * kBitWidth, decoded + r, kBitWidth);
+        }
+        for (uint32_t i = 0; i < rows.size(); ++i) {
+          out[i] = decoded[rows[i]];
+        }
+      }
+      out += rows.size();
+    }
+  }
+}
+
+// Option C: fastunpack per-group, pick within group.
+void decodePerGroup(const std::vector<uint32_t>& rows, uint32_t iters) {
+  constexpr uint32_t kGroupSize = 32;
+  while (iters--) {
+    const auto blockBytes = packedBlocks.bytesPerBlock;
+    auto* out = output.data();
+    for (uint32_t b = 0; b < kNumBlocks; ++b) {
+      const auto* input = reinterpret_cast<const uint32_t*>(
+          packedBlocks.bits.data() + b * blockBytes);
+      uint32_t tmp[kGroupSize];
+      uint32_t i = 0;
+      while (i < rows.size()) {
+        const auto groupIdx = rows[i] / kGroupSize;
+        facebook::velox::fastpforlib::fastunpack(
+            input + groupIdx * kBitWidth, tmp, kBitWidth);
+        while (i < rows.size() && rows[i] / kGroupSize == groupIdx) {
+          *out++ = tmp[rows[i] % kGroupSize];
+          ++i;
+        }
+      }
+    }
+  }
 }
 
 } // namespace
 
 // ============================================================================
-// 5 rows / 1024 (0.5% selectivity)
+// Section 1: uint32 sparse decode — FBA vs FullBlock vs PerGroup
+// (~8M values across 8192 blocks)
 // ============================================================================
-BENCHMARK(FBA_sparse_5) {
-  decodeFBA(sparseRows5);
+
+#define BENCHMARK_SPARSE_U32(n)                     \
+  BENCHMARK(FBA_sparse_##n, iters) {                \
+    decodeFBA(sparseRows##n, iters);                \
+  }                                                 \
+  BENCHMARK_RELATIVE(FullBlock_sparse_##n, iters) { \
+    decodeFullBlockThenPick(sparseRows##n, iters);  \
+  }                                                 \
+  BENCHMARK_RELATIVE(PerGroup_sparse_##n, iters) {  \
+    decodePerGroup(sparseRows##n, iters);           \
+  }                                                 \
+  BENCHMARK_DRAW_LINE();
+
+BENCHMARK_SPARSE_U32(5)
+BENCHMARK_SPARSE_U32(50)
+BENCHMARK_SPARSE_U32(100)
+BENCHMARK_SPARSE_U32(200)
+BENCHMARK_SPARSE_U32(500)
+BENCHMARK_SPARSE_U32(800)
+
+BENCHMARK(FBA_dense_1024, iters) {
+  decodeFBA(denseRows1024, iters);
 }
-BENCHMARK_RELATIVE(FullBlock_sparse_5) {
-  decodeFullBlockThenPick(sparseRows5);
+BENCHMARK_RELATIVE(FullBlock_dense_1024, iters) {
+  decodeFullBlockThenPick(denseRows1024, iters);
 }
-BENCHMARK_RELATIVE(PerGroup_sparse_5) {
-  decodePerGroup(sparseRows5);
+BENCHMARK_RELATIVE(PerGroup_dense_1024, iters) {
+  decodePerGroup(denseRows1024, iters);
 }
 BENCHMARK_DRAW_LINE();
-
-// ============================================================================
-// 50 rows / 1024 (5% selectivity)
-// ============================================================================
-BENCHMARK(FBA_sparse_50) {
-  decodeFBA(sparseRows50);
-}
-BENCHMARK_RELATIVE(FullBlock_sparse_50) {
-  decodeFullBlockThenPick(sparseRows50);
-}
-BENCHMARK_RELATIVE(PerGroup_sparse_50) {
-  decodePerGroup(sparseRows50);
-}
-BENCHMARK_DRAW_LINE();
-
-// ============================================================================
-// 100 rows / 1024 (10% selectivity)
-// ============================================================================
-BENCHMARK(FBA_sparse_100) {
-  decodeFBA(sparseRows100);
-}
-BENCHMARK_RELATIVE(FullBlock_sparse_100) {
-  decodeFullBlockThenPick(sparseRows100);
-}
-BENCHMARK_RELATIVE(PerGroup_sparse_100) {
-  decodePerGroup(sparseRows100);
-}
-BENCHMARK_DRAW_LINE();
-
-// ============================================================================
-// 200 rows / 1024 (20% selectivity)
-// ============================================================================
-BENCHMARK(FBA_sparse_200) {
-  decodeFBA(sparseRows200);
-}
-BENCHMARK_RELATIVE(FullBlock_sparse_200) {
-  decodeFullBlockThenPick(sparseRows200);
-}
-BENCHMARK_RELATIVE(PerGroup_sparse_200) {
-  decodePerGroup(sparseRows200);
-}
-BENCHMARK_DRAW_LINE();
-
-// ============================================================================
-// 500 rows / 1024 (49% selectivity)
-// ============================================================================
-BENCHMARK(FBA_sparse_500) {
-  decodeFBA(sparseRows500);
-}
-BENCHMARK_RELATIVE(FullBlock_sparse_500) {
-  decodeFullBlockThenPick(sparseRows500);
-}
-BENCHMARK_RELATIVE(PerGroup_sparse_500) {
-  decodePerGroup(sparseRows500);
-}
-BENCHMARK_DRAW_LINE();
-
-// ============================================================================
-// 800 rows / 1024 (78% selectivity)
-// ============================================================================
-BENCHMARK(FBA_sparse_800) {
-  decodeFBA(sparseRows800);
-}
-BENCHMARK_RELATIVE(FullBlock_sparse_800) {
-  decodeFullBlockThenPick(sparseRows800);
-}
-BENCHMARK_RELATIVE(PerGroup_sparse_800) {
-  decodePerGroup(sparseRows800);
-}
-BENCHMARK_DRAW_LINE();
-
-// ============================================================================
-// 1024 rows / 1024 (100% — dense)
-// ============================================================================
-BENCHMARK(FBA_dense_1024) {
-  decodeFBA(denseRows1024);
-}
-BENCHMARK_RELATIVE(FullBlock_dense_1024) {
-  decodeFullBlockThenPick(denseRows1024);
-}
-BENCHMARK_RELATIVE(PerGroup_dense_1024) {
-  decodePerGroup(denseRows1024);
-}
 
 // ============================================================================
 // Section 2: uint8 decode — fastunpack_quarter vs fastunpack32 + narrow
@@ -292,37 +323,45 @@ Uint8PackedData packUint8Data(uint8_t bitWidth) {
   return {std::move(bits), static_cast<uint32_t>(blockBytes)};
 }
 
-void decodeQuarter(const Uint8PackedData& data, uint8_t bitWidth) {
+void decodeQuarter(
+    const Uint8PackedData& data,
+    uint8_t bitWidth,
+    uint32_t iters) {
   constexpr uint32_t kGroupSize = 8;
-  auto* out = uint8OutputA.data();
-  for (uint32_t b = 0; b < kUint8NumBlocks; ++b) {
-    const auto* input = reinterpret_cast<const uint8_t*>(
-        data.bits.data() + b * data.bytesPerBlock);
-    for (uint32_t r = 0; r < kBlockSize; r += kGroupSize) {
-      facebook::velox::fastpforlib::internal::fastunpack_quarter(
-          input, out + b * kBlockSize + r, bitWidth);
-      input += bitWidth;
+  while (iters--) {
+    auto* out = uint8OutputA.data();
+    for (uint32_t b = 0; b < kUint8NumBlocks; ++b) {
+      const auto* input = reinterpret_cast<const uint8_t*>(
+          data.bits.data() + b * data.bytesPerBlock);
+      for (uint32_t r = 0; r < kBlockSize; r += kGroupSize) {
+        facebook::velox::fastpforlib::internal::fastunpack_quarter(
+            input, out + b * kBlockSize + r, bitWidth);
+        input += bitWidth;
+      }
     }
   }
-  folly::doNotOptimizeAway(uint8OutputA[0]);
 }
 
-void decode32Narrow(const Uint8PackedData& data, uint8_t bitWidth) {
+void decode32Narrow(
+    const Uint8PackedData& data,
+    uint8_t bitWidth,
+    uint32_t iters) {
   constexpr uint32_t kGroupSize = 32;
-  auto* out = uint8OutputB.data();
   uint32_t tmp[kGroupSize];
-  for (uint32_t b = 0; b < kUint8NumBlocks; ++b) {
-    const auto* input = reinterpret_cast<const uint32_t*>(
-        data.bits.data() + b * data.bytesPerBlock);
-    for (uint32_t r = 0; r < kBlockSize; r += kGroupSize) {
-      facebook::velox::fastpforlib::fastunpack(input, tmp, bitWidth);
-      for (uint32_t i = 0; i < kGroupSize; ++i) {
-        out[b * kBlockSize + r + i] = static_cast<uint8_t>(tmp[i]);
+  while (iters--) {
+    auto* out = uint8OutputB.data();
+    for (uint32_t b = 0; b < kUint8NumBlocks; ++b) {
+      const auto* input = reinterpret_cast<const uint32_t*>(
+          data.bits.data() + b * data.bytesPerBlock);
+      for (uint32_t r = 0; r < kBlockSize; r += kGroupSize) {
+        facebook::velox::fastpforlib::fastunpack(input, tmp, bitWidth);
+        for (uint32_t i = 0; i < kGroupSize; ++i) {
+          out[b * kBlockSize + r + i] = static_cast<uint8_t>(tmp[i]);
+        }
+        input += bitWidth;
       }
-      input += bitWidth;
     }
   }
-  folly::doNotOptimizeAway(uint8OutputB[0]);
 }
 
 void setupUint8Data() {
@@ -333,13 +372,13 @@ void setupUint8Data() {
 
 } // namespace
 
-#define BENCHMARK_UINT8_BW(bw)             \
-  BENCHMARK(quarter_bw##bw) {              \
-    decodeQuarter(uint8PackedBw[bw], bw);  \
-  }                                        \
-  BENCHMARK_RELATIVE(narrow32_bw##bw) {    \
-    decode32Narrow(uint8PackedBw[bw], bw); \
-  }                                        \
+#define BENCHMARK_UINT8_BW(bw)                    \
+  BENCHMARK(quarter_bw##bw, iters) {              \
+    decodeQuarter(uint8PackedBw[bw], bw, iters);  \
+  }                                               \
+  BENCHMARK_RELATIVE(narrow32_bw##bw, iters) {    \
+    decode32Narrow(uint8PackedBw[bw], bw, iters); \
+  }                                               \
   BENCHMARK_DRAW_LINE();
 
 BENCHMARK_UINT8_BW(1)
@@ -351,10 +390,398 @@ BENCHMARK_UINT8_BW(6)
 BENCHMARK_UINT8_BW(7)
 BENCHMARK_UINT8_BW(8)
 
+// ============================================================================
+// Section 3: Multi-type FBA vs Lemire — sparse and dense across types and
+// bit widths. Reuses PackedBlocks, kNumBlocks, kBlockSize from Section 1.
+// ============================================================================
+
+namespace {
+
+PackedBlocks packBlocks(uint8_t bw) {
+  const auto blockBytes = FixedBitArray::bufferSize(kBlockSize, bw);
+  PackedBlocks result;
+  result.bytesPerBlock = blockBytes;
+  result.bits.resize(blockBytes * kNumBlocks, 0);
+  std::mt19937 rng(42);
+  for (uint32_t b = 0; b < kNumBlocks; ++b) {
+    FixedBitArray fba(result.bits.data() + b * blockBytes, bw);
+    for (uint32_t i = 0; i < kBlockSize; ++i) {
+      if (bw >= 64) {
+        fba.set(i, rng());
+      } else {
+        fba.set(i, rng() % (1ULL << bw));
+      }
+    }
+  }
+  return result;
+}
+
+// Lemire decode — type-specialized. Dense decodes directly; sparse via temp.
+template <typename T>
+void lemireTyped(
+    const PackedBlocks& data,
+    uint8_t bw,
+    const std::vector<uint32_t>& rows,
+    uint32_t iters);
+
+template <>
+void lemireTyped<uint8_t>(
+    const PackedBlocks& data,
+    uint8_t bw,
+    const std::vector<uint32_t>& rows,
+    uint32_t iters) {
+  constexpr uint32_t kGroup = 8;
+  const bool isDense = rows.size() == kBlockSize;
+  std::vector<uint8_t> out(rows.size() * kNumBlocks);
+  while (iters--) {
+    auto* dst = out.data();
+    for (uint32_t b = 0; b < kNumBlocks; ++b) {
+      const auto* in = reinterpret_cast<const uint8_t*>(
+          data.bits.data() + b * data.bytesPerBlock);
+      if (isDense) {
+        for (uint32_t r = 0; r < kBlockSize; r += kGroup) {
+          facebook::velox::fastpforlib::internal::fastunpack_quarter(
+              in, dst + r, bw);
+          in += bw;
+        }
+      } else {
+        uint8_t tmp[kBlockSize];
+        for (uint32_t r = 0; r < kBlockSize; r += kGroup) {
+          facebook::velox::fastpforlib::internal::fastunpack_quarter(
+              in, tmp + r, bw);
+          in += bw;
+        }
+        for (uint32_t i = 0; i < rows.size(); ++i) {
+          dst[i] = tmp[rows[i]];
+        }
+      }
+      dst += rows.size();
+    }
+  }
+}
+
+template <>
+void lemireTyped<uint16_t>(
+    const PackedBlocks& data,
+    uint8_t bw,
+    const std::vector<uint32_t>& rows,
+    uint32_t iters) {
+  constexpr uint32_t kGroup = 16;
+  const bool isDense = rows.size() == kBlockSize;
+  std::vector<uint16_t> out(rows.size() * kNumBlocks);
+  while (iters--) {
+    auto* dst = out.data();
+    for (uint32_t b = 0; b < kNumBlocks; ++b) {
+      const auto* in = reinterpret_cast<const uint16_t*>(
+          data.bits.data() + b * data.bytesPerBlock);
+      if (isDense) {
+        for (uint32_t r = 0; r < kBlockSize; r += kGroup) {
+          facebook::velox::fastpforlib::internal::fastunpack_half(
+              in, dst + r, bw);
+          in += bw;
+        }
+      } else {
+        uint16_t tmp[kBlockSize];
+        for (uint32_t r = 0; r < kBlockSize; r += kGroup) {
+          facebook::velox::fastpforlib::internal::fastunpack_half(
+              in, tmp + r, bw);
+          in += bw;
+        }
+        for (uint32_t i = 0; i < rows.size(); ++i) {
+          dst[i] = tmp[rows[i]];
+        }
+      }
+      dst += rows.size();
+    }
+  }
+}
+
+template <>
+void lemireTyped<uint32_t>(
+    const PackedBlocks& data,
+    uint8_t bw,
+    const std::vector<uint32_t>& rows,
+    uint32_t iters) {
+  constexpr uint32_t kGroup = 32;
+  const bool isDense = rows.size() == kBlockSize;
+  std::vector<uint32_t> out(rows.size() * kNumBlocks);
+  while (iters--) {
+    auto* dst = out.data();
+    for (uint32_t b = 0; b < kNumBlocks; ++b) {
+      const auto* in = reinterpret_cast<const uint32_t*>(
+          data.bits.data() + b * data.bytesPerBlock);
+      if (isDense) {
+        for (uint32_t r = 0; r < kBlockSize; r += kGroup) {
+          facebook::velox::fastpforlib::fastunpack(in, dst + r, bw);
+          in += bw;
+        }
+      } else {
+        uint32_t tmp[kBlockSize];
+        for (uint32_t r = 0; r < kBlockSize; r += kGroup) {
+          facebook::velox::fastpforlib::fastunpack(in, tmp + r, bw);
+          in += bw;
+        }
+        for (uint32_t i = 0; i < rows.size(); ++i) {
+          dst[i] = tmp[rows[i]];
+        }
+      }
+      dst += rows.size();
+    }
+  }
+}
+
+template <>
+void lemireTyped<uint64_t>(
+    const PackedBlocks& data,
+    uint8_t bw,
+    const std::vector<uint32_t>& rows,
+    uint32_t iters) {
+  constexpr uint32_t kGroup = 32;
+  const bool isDense = rows.size() == kBlockSize;
+  std::vector<uint64_t> out(rows.size() * kNumBlocks);
+  while (iters--) {
+    auto* dst = out.data();
+    for (uint32_t b = 0; b < kNumBlocks; ++b) {
+      const auto* in = reinterpret_cast<const uint32_t*>(
+          data.bits.data() + b * data.bytesPerBlock);
+      if (isDense) {
+        for (uint32_t r = 0; r < kBlockSize; r += kGroup) {
+          facebook::velox::fastpforlib::fastunpack(in, dst + r, bw);
+          in += bw;
+        }
+      } else {
+        uint64_t tmp[kBlockSize];
+        for (uint32_t r = 0; r < kBlockSize; r += kGroup) {
+          facebook::velox::fastpforlib::fastunpack(in, tmp + r, bw);
+          in += bw;
+        }
+        for (uint32_t i = 0; i < rows.size(); ++i) {
+          dst[i] = tmp[rows[i]];
+        }
+      }
+      dst += rows.size();
+    }
+  }
+}
+
+// FBA per-element decode — type-generic.
+template <typename T>
+void fbaTyped(
+    const PackedBlocks& data,
+    uint8_t bw,
+    const std::vector<uint32_t>& rows,
+    uint32_t iters) {
+  std::vector<T> out(rows.size() * kNumBlocks);
+  while (iters--) {
+    auto* dst = out.data();
+    for (uint32_t b = 0; b < kNumBlocks; ++b) {
+      FixedBitArray fba{
+          {data.bits.data() + b * data.bytesPerBlock,
+           static_cast<size_t>(data.bytesPerBlock)},
+          bw};
+      for (uint32_t i = 0; i < rows.size(); ++i) {
+        dst[i] = static_cast<T>(fba.get(rows[i]));
+      }
+      dst += rows.size();
+    }
+  }
+}
+
+PackedBlocks bwData[65]; // index 1..64
+
+void setupMultiTypeData() {
+  for (uint8_t bw = 1; bw <= 64; ++bw) {
+    bwData[bw] = packBlocks(bw);
+  }
+}
+
+} // namespace
+
+// --- uint8: FBA vs Lemire ---
+
+#define BM_U8_SPARSE(bw, sel, rows)                             \
+  BENCHMARK(u8_bw##bw##_sel##sel##pct_fba, iters) {             \
+    fbaTyped<uint8_t>(bwData[bw], bw, rows, iters);             \
+  }                                                             \
+  BENCHMARK_RELATIVE(u8_bw##bw##_sel##sel##pct_lemire, iters) { \
+    lemireTyped<uint8_t>(bwData[bw], bw, rows, iters);          \
+  }                                                             \
+  BENCHMARK_DRAW_LINE();
+
+#define BM_U8(bw)                     \
+  BM_U8_SPARSE(bw, 1, sparseRows10)   \
+  BM_U8_SPARSE(bw, 10, sparseRows100) \
+  BM_U8_SPARSE(bw, 25, sparseRows256) \
+  BM_U8_SPARSE(bw, 50, sparseRows512) \
+  BM_U8_SPARSE(bw, 90, sparseRows922)
+
+BM_U8(1)
+BM_U8(4)
+BM_U8(8)
+
+// --- uint16: FBA vs Lemire at multiple selectivities ---
+
+#define BM_U16_SPARSE(bw, sel, rows)                             \
+  BENCHMARK(u16_bw##bw##_sel##sel##pct_fba, iters) {             \
+    fbaTyped<uint16_t>(bwData[bw], bw, rows, iters);             \
+  }                                                              \
+  BENCHMARK_RELATIVE(u16_bw##bw##_sel##sel##pct_lemire, iters) { \
+    lemireTyped<uint16_t>(bwData[bw], bw, rows, iters);          \
+  }                                                              \
+  BENCHMARK_DRAW_LINE();
+
+#define BM_U16_DENSE(bw)                                         \
+  BENCHMARK(u16_bw##bw##_dense_lemire, iters) {                  \
+    lemireTyped<uint16_t>(bwData[bw], bw, denseRows1024, iters); \
+  }                                                              \
+  BENCHMARK_DRAW_LINE();
+
+#define BM_U16_ALL(bw)                 \
+  BM_U16_SPARSE(bw, 1, sparseRows10)   \
+  BM_U16_SPARSE(bw, 10, sparseRows100) \
+  BM_U16_SPARSE(bw, 25, sparseRows256) \
+  BM_U16_SPARSE(bw, 50, sparseRows512) \
+  BM_U16_SPARSE(bw, 70, sparseRows717) \
+  BM_U16_SPARSE(bw, 90, sparseRows922) \
+  BM_U16_DENSE(bw)
+
+BM_U16_ALL(1)
+BM_U16_ALL(4)
+BM_U16_ALL(8)
+BM_U16_ALL(16)
+
+// --- uint32: FBA vs Lemire at multiple selectivities ---
+
+#define BM_U32_SPARSE(bw, sel, rows)                             \
+  BENCHMARK(u32_bw##bw##_sel##sel##pct_fba, iters) {             \
+    fbaTyped<uint32_t>(bwData[bw], bw, rows, iters);             \
+  }                                                              \
+  BENCHMARK_RELATIVE(u32_bw##bw##_sel##sel##pct_lemire, iters) { \
+    lemireTyped<uint32_t>(bwData[bw], bw, rows, iters);          \
+  }                                                              \
+  BENCHMARK_DRAW_LINE();
+
+#define BM_U32_DENSE(bw)                                         \
+  BENCHMARK(u32_bw##bw##_dense_lemire, iters) {                  \
+    lemireTyped<uint32_t>(bwData[bw], bw, denseRows1024, iters); \
+  }                                                              \
+  BENCHMARK_DRAW_LINE();
+
+#define BM_U32_ALL(bw)                  \
+  BM_U32_SPARSE(bw, 1, sparseRows10)    \
+  BM_U32_SPARSE(bw, 10, sparseRows100)  \
+  BM_U32_SPARSE(bw, 20, sparseRows205)  \
+  BM_U32_SPARSE(bw, 25, sparseRows256)  \
+  BM_U32_SPARSE(bw, 30, sparseRows307)  \
+  BM_U32_SPARSE(bw, 40, sparseRows410)  \
+  BM_U32_SPARSE(bw, 50, sparseRows512)  \
+  BM_U32_SPARSE(bw, 60, sparseRows614)  \
+  BM_U32_SPARSE(bw, 70, sparseRows717)  \
+  BM_U32_SPARSE(bw, 80, sparseRows819)  \
+  BM_U32_SPARSE(bw, 90, sparseRows922)  \
+  BM_U32_SPARSE(bw, 95, sparseRows973)  \
+  BM_U32_SPARSE(bw, 99, sparseRows1014) \
+  BM_U32_DENSE(bw)
+
+BM_U32_ALL(16)
+BM_U32_ALL(17)
+BM_U32_ALL(18)
+BM_U32_ALL(19)
+BM_U32_ALL(20)
+BM_U32_ALL(21)
+BM_U32_ALL(22)
+BM_U32_ALL(23)
+BM_U32_ALL(24)
+BM_U32_ALL(25)
+BM_U32_ALL(26)
+BM_U32_ALL(27)
+BM_U32_ALL(28)
+BM_U32_ALL(29)
+BM_U32_ALL(30)
+BM_U32_ALL(31)
+BM_U32_ALL(32)
+
+// --- uint64: FBA vs Lemire at multiple selectivities ---
+
+#define BM_U64_SPARSE(bw, sel, rows)                             \
+  BENCHMARK(u64_bw##bw##_sel##sel##pct_fba, iters) {             \
+    fbaTyped<uint64_t>(bwData[bw], bw, rows, iters);             \
+  }                                                              \
+  BENCHMARK_RELATIVE(u64_bw##bw##_sel##sel##pct_lemire, iters) { \
+    lemireTyped<uint64_t>(bwData[bw], bw, rows, iters);          \
+  }                                                              \
+  BENCHMARK_DRAW_LINE();
+
+#define BM_U64_ALL(bw)                 \
+  BM_U64_SPARSE(bw, 1, sparseRows10)   \
+  BM_U64_SPARSE(bw, 10, sparseRows100) \
+  BM_U64_SPARSE(bw, 20, sparseRows205) \
+  BM_U64_SPARSE(bw, 25, sparseRows256) \
+  BM_U64_SPARSE(bw, 30, sparseRows307) \
+  BM_U64_SPARSE(bw, 40, sparseRows410) \
+  BM_U64_SPARSE(bw, 50, sparseRows512) \
+  BM_U64_SPARSE(bw, 60, sparseRows614) \
+  BM_U64_SPARSE(bw, 70, sparseRows717) \
+  BM_U64_SPARSE(bw, 80, sparseRows819) \
+  BM_U64_SPARSE(bw, 90, sparseRows922) \
+  BM_U64_SPARSE(bw, 95, sparseRows973) \
+  BM_U64_SPARSE(bw, 99, sparseRows1014)
+
+BM_U64_ALL(16)
+BM_U64_ALL(17)
+BM_U64_ALL(18)
+BM_U64_ALL(19)
+BM_U64_ALL(20)
+BM_U64_ALL(21)
+BM_U64_ALL(22)
+BM_U64_ALL(23)
+BM_U64_ALL(24)
+BM_U64_ALL(25)
+BM_U64_ALL(26)
+BM_U64_ALL(27)
+BM_U64_ALL(28)
+BM_U64_ALL(29)
+BM_U64_ALL(30)
+BM_U64_ALL(31)
+BM_U64_ALL(32)
+BM_U64_ALL(33)
+BM_U64_ALL(34)
+BM_U64_ALL(35)
+BM_U64_ALL(36)
+BM_U64_ALL(37)
+BM_U64_ALL(38)
+BM_U64_ALL(39)
+BM_U64_ALL(40)
+BM_U64_ALL(41)
+BM_U64_ALL(42)
+BM_U64_ALL(43)
+BM_U64_ALL(44)
+BM_U64_ALL(45)
+BM_U64_ALL(46)
+BM_U64_ALL(47)
+BM_U64_ALL(48)
+BM_U64_ALL(49)
+BM_U64_ALL(50)
+BM_U64_ALL(51)
+BM_U64_ALL(52)
+BM_U64_ALL(53)
+BM_U64_ALL(54)
+BM_U64_ALL(55)
+BM_U64_ALL(56)
+BM_U64_ALL(57)
+BM_U64_ALL(58)
+BM_U64_ALL(59)
+BM_U64_ALL(60)
+BM_U64_ALL(61)
+BM_U64_ALL(62)
+BM_U64_ALL(63)
+BM_U64_ALL(64)
+
 int main(int argc, char** argv) {
   gflags::ParseCommandLineFlags(&argc, &argv, true);
   setupData();
   setupUint8Data();
+  setupMultiTypeData();
   folly::runBenchmarks();
   return 0;
 }

--- a/dwio/nimble/velox/selective/tests/IntEncodingBenchmark.cpp
+++ b/dwio/nimble/velox/selective/tests/IntEncodingBenchmark.cpp
@@ -14,16 +14,20 @@
  * limitations under the License.
  */
 
-/// End-to-end read benchmark comparing integer encoding strategies through the
-/// selective Nimble reader.
+/// E2E benchmark: measures total column decode CPU time through the full
+/// Velox selective reader pipeline. Writes a 10M-row Nimble file, reads it
+/// back with filters at various selectivities. Includes all reader overhead:
+/// encoding construction, row selection, lazy materialization, filter
+/// evaluation — not just the raw decode step.
+///
+/// For isolated decode-only microbenchmarks, see BlockBitPackingBenchmark.cpp.
 ///
 /// Two-column schema: ROW(c0: INTEGER, c1: INTEGER).
-///   - c0: filter column — random values in [0, 99]. A BigintRange filter on
+///   - c0: filter column — random values in [0, 499]. A BigintRange filter on
 ///     c0 determines which rows pass. c0 is always scanned densely.
 ///   - c1: data column — the column under test with varying encoding. When c0
 ///     has a filter, c1 is read SPARSELY (only rows passing c0's filter),
-///     exercising the sparse bulkScan path where BlockBitPacking decodes the
-///     full 1024-row block into a temp buffer then picks selected rows.
+///     exercising the sparse bulkScan path.
 ///
 /// Encodings under test (applied globally to both columns):
 ///   - Trivial + MetaInternal compression
@@ -34,11 +38,6 @@
 ///   - NarrowBlocks: per-block 4 bits, global ~20 bits (BBP sweet spot)
 ///   - Uniform: ~20 bits everywhere (all encodings comparable)
 ///
-/// Selectivity (controlled by filter on c0):
-///   - NoFilter: full scan, c1 read densely
-///   - Select20%: BigintRange(0, 19) on c0 → ~20% pass, c1 read sparsely
-///   - Select1%: BigintRange(0, 0) on c0 → ~1% pass, c1 read sparsely
-///
 /// Run:
 ///   buck2 run @//mode/opt \
 ///     fbcode//dwio/nimble/velox/selective/tests:int_encoding_benchmark
@@ -47,22 +46,22 @@
 ///
 /// NarrowBlocks (int32, per-block 4-bit, decode_ms(decompress_ms)):
 ///              Dense     50%      20%      10%       8%       1%     0.2%
-///  Trivial+MI  41(36)   38(35)   39(36)   39(36)   38(35)   38(35)   38(35)
+///  Trivial+MI  40(34)   38(35)   39(36)   39(36)   38(35)   38(35)   38(35)
 ///  FBW+MI      71(42)   69(41)   56(42)   49(42)   48(41)   48(42)   46(42)
-///  BBP          6(0)     4(0)    10(0)     7(0)     7(0)     6(0)     5(0)
+///  BBP          5(0)     4(0)     9(0)     5(0)     5(0)     4(0)     4(0)
 ///
 /// Uniform (int32, ~20-bit uniform, decode_ms(decompress_ms)):
 ///              Dense     50%      20%      10%       8%       1%     0.2%
-///  Trivial+MI  49(44)   46(44)   47(44)   46(44)   48(44)   48(44)   47(44)
+///  Trivial+MI  46(44)   46(44)   47(44)   46(44)   48(44)   48(44)   47(44)
 ///  FBW+MI      58(28)   56(29)   55(28)   37(29)   35(28)   34(29)   32(28)
-///  BBP          9(0)     7(0)    13(0)    10(0)    10(0)     8(0)     7(0)
+///  BBP          8(0)     6(0)    12(0)     8(0)     7(0)     5(0)     4(0)
 ///
 /// BBP multi-type (decode_ms(decompress_ms)):
-///              Dense     50%      20%      10%       1%
-///  int8         8(0)     6(0)     6(0)     6(0)     7(0)
-///  int16        7(0)     5(0)    11(0)     9(0)     7(0)
-///  int32        9(0)     7(0)    13(0)    10(0)     7(0)
-///  int64        9(0)     6(0)    12(0)    10(0)     8(0)
+///              Dense     50%      20%      10%       8%      *5%*      1%
+///  int8         8(0)     7(0)     7(0)     7(0)     9(0)     6(0)     4(0)
+///  int16        7(0)     5(0)    11(0)     9(0)     8(0)     6(0)     4(0)
+///  int32        8(0)     6(0)    12(0)    10(0)    10(0)     7(0)     5(0)
+///  int64        9(0)     7(0)    13(0)    10(0)    10(0)     8(0)     5(0)
 
 #include <random>
 
@@ -536,8 +535,12 @@ void runMultiTypeBenchmarks() {
       {"Dense     ", std::nullopt},
       {"Sparse50% ", {{0, 249}}},
       {"Sparse20% ", {{0, 99}}},
+      {"Sparse15% ", {{0, 74}}},
       {"Sparse10% ", {{0, 49}}},
+      {"Sparse8%  ", {{0, 39}}},
+      {"Sparse5%  ", {{0, 24}}},
       {"Sparse1%  ", {{0, 4}}},
+      {"Sparse0.4%", {{0, 1}}},
   };
 
   auto filterCol = s.generateFilterColumn();


### PR DESCRIPTION
Summary:

Changes:
- At <5% selectivity (~50/1024 rows per block), use FBA per-element decode for selected rows only, replacing full-block Lemire decode-then-pick. Applies to all integer types.
- Add skipEncoding and bitWidth==0 fast paths that skip decode entirely for raw and constant blocks.

E2E speedup (IntEncodingBenchmark, 10M rows BBP, c1 decode CPU ms):

  Type   Sel%   Before   After   Speedup
  int8   4.8%     9       7       1.3x
  int8     1%     7       4       1.8x
  int16    1%     7       4       1.8x
  int32    1%     8       5       1.6x
  int32  0.4%     8       4       2.0x
  int64    1%     8       5       1.6x
  int64  0.4%     8       4       2.0x

Reviewed By: HuamengJiang, xiaoxmeng

Differential Revision: D108585454


