### PR TITLE
feat(fuzzer): Add random chunking mode in fuzzer (#919)

### DIFF
--- a/dwio/nimble/velox/FlushPolicy.cpp
+++ b/dwio/nimble/velox/FlushPolicy.cpp
@@ -15,6 +15,8 @@
  */
 #include "dwio/nimble/velox/FlushPolicy.h"
 
+#include "dwio/nimble/common/Exceptions.h"
+
 namespace facebook::nimble {
 // Relieve memory pressure with chunking.
 bool ChunkFlushPolicy::shouldChunk(const StripeProgress& stripeProgress) {
@@ -45,6 +47,56 @@ bool ChunkFlushPolicy::shouldFlush(const StripeProgress& stripeProgress) {
   double expectedEncodedStripeSize = stripeProgress.stripeEncodedSize +
       stripeProgress.stripeRawSize / std::max(compressionFactor, 1.0);
   return (expectedEncodedStripeSize >= config_.targetStripeSizeBytes);
+}
+
+TestFlushPolicy::TestFlushPolicy(State* state, Options options)
+    : options_{std::move(options)}, state_{state} {
+  NIMBLE_CHECK_NOT_NULL(state_, "TestFlushPolicy state must not be null.");
+  NIMBLE_CHECK_GT(
+      options_.maxStripePhysicalSize, 0, "maxStripePhysicalSize must be > 0.");
+  NIMBLE_CHECK_GE(
+      options_.estimatedCompressionFactor,
+      1.0,
+      "estimatedCompressionFactor must be >= 1.0.");
+  NIMBLE_CHECK_GE(
+      options_.flushChunkProbability,
+      0.0,
+      "flushChunkProbability must be in [0, 1].");
+  NIMBLE_CHECK_LE(
+      options_.flushChunkProbability,
+      1.0,
+      "flushChunkProbability must be in [0, 1].");
+  NIMBLE_CHECK_GE(
+      options_.flushStripeProbability,
+      0.0,
+      "flushStripeProbability must be in [0, 1].");
+  NIMBLE_CHECK_LE(
+      options_.flushStripeProbability,
+      1.0,
+      "flushStripeProbability must be in [0, 1].");
+}
+
+bool TestFlushPolicy::shouldChunk(const StripeProgress& /* stripeProgress */) {
+  return std::uniform_real_distribution<double>(0.0, 1.0)(state_->rng) <
+      options_.flushChunkProbability;
+}
+
+bool TestFlushPolicy::shouldFlush(const StripeProgress& stripeProgress) {
+  double compressionFactor = options_.estimatedCompressionFactor;
+  // Use the observed compression ratio once some data has been encoded.
+  if (stripeProgress.stripeEncodedSize > 0) {
+    compressionFactor =
+        static_cast<double>(stripeProgress.stripeEncodedLogicalSize) /
+        stripeProgress.stripeEncodedSize;
+  }
+  const double expectedEncodedStripeSize = stripeProgress.stripeEncodedSize +
+      stripeProgress.stripeRawSize / std::max(compressionFactor, 1.0);
+  // The rng draw is always evaluated first (left of the ||), so the rng
+  // advances on every call regardless of the size guard -- the determinism
+  // tests rely on that fixed consumption order.
+  return std::uniform_real_distribution<double>(0.0, 1.0)(state_->rng) <
+      options_.flushStripeProbability ||
+      expectedEncodedStripeSize >= options_.maxStripePhysicalSize;
 }
 
 } // namespace facebook::nimble

--- a/dwio/nimble/velox/FlushPolicy.h
+++ b/dwio/nimble/velox/FlushPolicy.h
@@ -17,6 +17,8 @@
 
 #include <cstdint>
 #include <functional>
+#include <optional>
+#include <random>
 
 namespace facebook::nimble {
 
@@ -107,6 +109,80 @@ class ChunkFlushPolicy : public FlushPolicy {
  private:
   const ChunkFlushPolicyConfig config_;
   bool lastChunkDecision_;
+};
+
+/// Test-only policy driving chunk and stripe boundaries for the fuzzer, seeded
+/// so a failing run can be reproduced from the logged seed. It chunks and
+/// flushes probabilistically, with an encoded-size flush guard. Per-type tuning
+/// (the nimble.flush_policy_config "type") is assembled by
+/// FlushPolicyFactoryFactory, not here. Instances are created only by
+/// TestFlushPolicyFactory, which owns the shared rng State (see State below) so
+/// decisions vary across the per-write() policy instances the writer creates.
+class TestFlushPolicy final : public FlushPolicy {
+ public:
+  /// Default chunk/stripe flush probabilities. Prod-representative values
+  /// ported from the (removed) Vader validation-service policy.
+  static constexpr double kDefaultFlushChunkProbability = 1.0 / 3;
+  static constexpr double kDefaultFlushStripeProbability = 1.0 / 20;
+
+  /// Tuning for TestFlushPolicy; unset fields keep the defaults below.
+  struct Options {
+    /// Seed for the policy's rng. Log it to reproduce a failing run.
+    uint64_t seed{0};
+    /// Probability in [0, 1] of cutting a chunk on each write.
+    double flushChunkProbability{kDefaultFlushChunkProbability};
+    /// Probability in [0, 1] of flushing the stripe on each write, independent
+    /// of the size guard below.
+    double flushStripeProbability{kDefaultFlushStripeProbability};
+    /// Encoded-size flush guard: flush once the predicted encoded stripe size
+    /// reaches this many bytes.
+    uint64_t maxStripePhysicalSize{128 * 1024L * 1024L};
+    /// Raw->encoded ratio used to predict the encoded stripe size before any
+    /// data has been encoded (once a stripe has encoded bytes the observed
+    /// ratio is used instead). 3.7 is the prod-representative value the Vader
+    /// validation service used.
+    double estimatedCompressionFactor{3.7};
+  };
+
+  /// Flushes the stripe with probability options.flushStripeProbability, or
+  /// when the predicted encoded stripe size would exceed
+  /// options.maxStripePhysicalSize.
+  bool shouldFlush(const StripeProgress& stripeProgress) override;
+
+  /// Cuts a chunk with probability options.flushChunkProbability, independent
+  /// of accumulated size.
+  bool shouldChunk(const StripeProgress& stripeProgress) override;
+
+ private:
+  // TestFlushPolicyFactory owns the shared State and constructs policies that
+  // borrow it, so it needs access to the private State and constructor.
+  friend class TestFlushPolicyFactory;
+
+  /// Shared rng state, owned by TestFlushPolicyFactory and outliving the
+  /// per-write() policy instances the writer recreates. VeloxWriter rebuilds
+  /// the flush policy from its factory on every write() (see
+  /// VeloxWriter::evaluateFlushPolicy), so an rng owned by the policy itself
+  /// would reseed identically each call and make the same decision every
+  /// write(). Holding it here instead lets decisions vary across writes while
+  /// staying reproducible from the seed.
+  struct State {
+    explicit State(uint64_t seed) : rng{seed} {}
+
+    // TODO: rng is not thread-safe; TestFlushPolicy must be driven from a
+    // single writer thread.
+    std::mt19937_64 rng;
+  };
+
+  /// 'state' is the shared rng container (see State), owned by the factory and
+  /// outliving this policy; it must be non-null. Every tuning value is
+  /// sanity-checked here; an already range-validated Options from
+  /// FlushPolicyFactoryFactory always passes.
+  TestFlushPolicy(State* state, Options options);
+
+  const Options options_;
+  // Borrowed, non-owning: the factory (owner) outlives this policy, which the
+  // writer recreates on every write().
+  State* const state_;
 };
 
 } // namespace facebook::nimble

--- a/dwio/nimble/velox/FlushPolicyFactory.cpp
+++ b/dwio/nimble/velox/FlushPolicyFactory.cpp
@@ -1,0 +1,183 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "dwio/nimble/velox/FlushPolicyFactory.h"
+
+#include <cstdint>
+#include <memory>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include <folly/Conv.h>
+#include <folly/String.h>
+
+#include "dwio/nimble/common/Exceptions.h"
+#include "velox/common/base/Exceptions.h"
+#include "velox/common/config/Config.h"
+
+namespace facebook::nimble {
+namespace {
+
+// Trims leading/trailing whitespace, returning a view into the input.
+std::string_view trimToken(std::string_view token) {
+  const auto trimmed = folly::trimWhitespace(folly::StringPiece(token));
+  return std::string_view(trimmed.data(), trimmed.size());
+}
+
+// Parses a numeric value, surfacing a NimbleUserError (not a
+// folly::ConversionError) on bad input.
+template <typename T>
+T parseValue(std::string_view key, std::string_view value) {
+  const auto parsed = folly::tryTo<T>(folly::StringPiece(value));
+  NIMBLE_USER_CHECK(
+      parsed.hasValue(),
+      "Invalid value '{}' for flush policy config key '{}'.",
+      value,
+      key);
+  return parsed.value();
+}
+
+using ConfigEntries =
+    std::vector<std::pair<std::string_view, std::string_view>>;
+
+// Parses the "test_random" tuning from the config's key:value pairs (the "type"
+// key already removed) into TestFlushPolicy::Options. Ranges are validated as
+// user errors here so a bad config throws NimbleUserError rather than the
+// TestFlushPolicy constructor's NimbleInternalError. This is the shared parser
+// the other types build on.
+TestFlushPolicy::Options parseTestRandomConfig(const ConfigEntries& entries) {
+  TestFlushPolicy::Options options;
+  for (const auto& [key, value] : entries) {
+    if (key == "seed") {
+      options.seed = parseValue<uint64_t>(key, value);
+    } else if (key == "flush_chunk_probability") {
+      options.flushChunkProbability = parseValue<double>(key, value);
+    } else if (key == "flush_stripe_probability") {
+      options.flushStripeProbability = parseValue<double>(key, value);
+    } else if (key == "max_stripe_physical_size") {
+      // velox::config::toCapacity parses a binary byte size with an embedded,
+      // case-insensitive KB/MB/GB suffix (e.g. "128MB").
+      try {
+        options.maxStripePhysicalSize = velox::config::toCapacity(
+            std::string(value), velox::config::CapacityUnit::BYTE);
+      } catch (const velox::VeloxUserError&) {
+        NIMBLE_USER_FAIL(
+            "Invalid byte size '{}' for flush policy config key '{}'.",
+            value,
+            key);
+      }
+    } else if (key == "estimated_compression_factor") {
+      options.estimatedCompressionFactor = parseValue<double>(key, value);
+    } else {
+      NIMBLE_USER_FAIL("Unknown nimble.flush_policy_config key '{}'.", key);
+    }
+  }
+  NIMBLE_USER_CHECK_GT(
+      options.maxStripePhysicalSize,
+      0,
+      "flush policy max_stripe_physical_size must be > 0.");
+  NIMBLE_USER_CHECK_GE(
+      options.estimatedCompressionFactor,
+      1.0,
+      "flush policy estimated_compression_factor must be >= 1.0.");
+  NIMBLE_USER_CHECK_GE(
+      options.flushChunkProbability,
+      0.0,
+      "flush policy flush_chunk_probability must be in [0, 1].");
+  NIMBLE_USER_CHECK_LE(
+      options.flushChunkProbability,
+      1.0,
+      "flush policy flush_chunk_probability must be in [0, 1].");
+  NIMBLE_USER_CHECK_GE(
+      options.flushStripeProbability,
+      0.0,
+      "flush policy flush_stripe_probability must be in [0, 1].");
+  NIMBLE_USER_CHECK_LE(
+      options.flushStripeProbability,
+      1.0,
+      "flush policy flush_stripe_probability must be in [0, 1].");
+  return options;
+}
+
+// Parses the "test_per_batch" tuning: the test_random tuning with
+// flush_chunk_probability pinned to 1.0 (cuts a chunk every batch; any value in
+// the spec is ignored).
+TestFlushPolicy::Options parseTestPerBatchConfig(const ConfigEntries& entries) {
+  auto options = parseTestRandomConfig(entries);
+  options.flushChunkProbability = 1.0;
+  return options;
+}
+
+} // namespace
+
+// Out of line because it reaches TestFlushPolicy's private State and ctor via
+// friendship: owns the shared rng State and hands each produced policy a raw,
+// non-owning pointer to it, so the policies the writer recreates per write()
+// keep advancing one rng.
+TestFlushPolicyFactory::TestFlushPolicyFactory(TestFlushPolicy::Options options)
+    : state_{std::make_shared<TestFlushPolicy::State>(options.seed)},
+      options_{std::move(options)} {}
+
+std::unique_ptr<FlushPolicy> TestFlushPolicyFactory::operator()() const {
+  // Constructed via new (not make_unique): TestFlushPolicy's constructor is
+  // private and make_unique is not the friend -- this factory is.
+  return std::unique_ptr<TestFlushPolicy>(
+      new TestFlushPolicy(state_.get(), options_));
+}
+
+std::optional<FlushPolicyFactory> FlushPolicyFactoryFactory::create(
+    std::string_view configStr) {
+  if (configStr.empty()) {
+    return std::nullopt;
+  }
+  // Tokenize into key:value pairs and peel off "type", which selects the
+  // parser.
+  std::string_view type;
+  ConfigEntries entries;
+  std::vector<std::string_view> rawEntries;
+  folly::split(',', configStr, rawEntries);
+  for (const auto rawEntry : rawEntries) {
+    const auto colonPos = rawEntry.find(':');
+    NIMBLE_USER_CHECK(
+        colonPos != std::string_view::npos,
+        "Malformed nimble.flush_policy_config entry '{}'; want key:value.",
+        rawEntry);
+    const auto key = trimToken(rawEntry.substr(0, colonPos));
+    const auto value = trimToken(rawEntry.substr(colonPos + 1));
+    if (key == "type") {
+      type = value;
+    } else {
+      entries.emplace_back(key, value);
+    }
+  }
+  // An absent type keeps the production size-based policy.
+  if (type.empty()) {
+    return std::nullopt;
+  }
+  if (type == "test_random") {
+    return FlushPolicyFactory{
+        TestFlushPolicyFactory{parseTestRandomConfig(entries)}};
+  }
+  if (type == "test_per_batch") {
+    return FlushPolicyFactory{
+        TestFlushPolicyFactory{parseTestPerBatchConfig(entries)}};
+  }
+  NIMBLE_USER_FAIL(
+      "Invalid nimble.flush_policy_config type '{}'. Valid: 'test_per_batch', 'test_random'.",
+      type);
+}
+
+} // namespace facebook::nimble

--- a/dwio/nimble/velox/FlushPolicyFactory.h
+++ b/dwio/nimble/velox/FlushPolicyFactory.h
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <functional>
+#include <memory>
+#include <optional>
+#include <string_view>
+
+#include "dwio/nimble/velox/FlushPolicy.h"
+
+namespace facebook::nimble {
+
+using FlushPolicyFactory = std::function<std::unique_ptr<FlushPolicy>()>;
+
+/// Factory functor for the test flush policy: owns the shared rng state
+/// (TestFlushPolicy::State) and hands each produced policy a raw, non-owning
+/// pointer to it, so the policies the writer recreates per write() keep
+/// advancing one rng. The state is held via shared_ptr because a std::function
+/// target must be copyable; policies only borrow it, so the refcount stays 1. A
+/// friend of TestFlushPolicy, giving it access to the private State and ctor.
+class TestFlushPolicyFactory {
+ public:
+  explicit TestFlushPolicyFactory(TestFlushPolicy::Options options);
+
+  std::unique_ptr<FlushPolicy> operator()() const;
+
+ private:
+  const std::shared_ptr<TestFlushPolicy::State> state_;
+  const TestFlushPolicy::Options options_;
+};
+
+/// Builds a flush-policy factory from a nimble.flush_policy_config string of
+/// the form "type:<t>,key:value,...". The leading "type" selects which policy
+/// to build and each type parses only the keys it accepts, so the handling is
+/// fully independent per type. Returns std::nullopt for an absent type,
+/// signalling the caller to keep the size-based policy.
+///
+/// A malformed entry, unknown key, unparseable/out-of-range value, or unknown
+/// type is reported as a NimbleUserError.
+class FlushPolicyFactoryFactory {
+ public:
+  static std::optional<FlushPolicyFactory> create(std::string_view configStr);
+};
+
+} // namespace facebook::nimble

--- a/dwio/nimble/velox/NimbleConfig.cpp
+++ b/dwio/nimble/velox/NimbleConfig.cpp
@@ -309,6 +309,10 @@ std::map<uint64_t, float> parseGrowthConfigMap(const std::string& str) {
         "nimble.chunking.writer.wide.schema.max.chunk.size",
         kChunkingWriterWideSchemaMaxChunkSize);
 
+/* static */ Config::Entry<std::string> Config::FLUSH_POLICY_CONFIG(
+    "nimble.flush_policy_config",
+    "");
+
 // EXPERIMENTAL: Cluster index is not production-ready. Do not enable for
 // production tables without consulting the Nimble team (oncall: dwios).
 /* static */ Config::Entry<const std::vector<std::string>>

--- a/dwio/nimble/velox/NimbleConfig.h
+++ b/dwio/nimble/velox/NimbleConfig.h
@@ -61,6 +61,20 @@ class Config : public velox::config::ConfigBase {
   static Entry<uint64_t> CHUNKING_WRITER_MAX_CHUNK_SIZE;
   static Entry<uint64_t> CHUNKING_WRITER_WIDE_SCHEMA_MAX_CHUNK_SIZE;
 
+  /// Selects and tunes the writer flush policy via a comma-separated
+  /// "key:value" spec whose "type" key chooses the policy. An absent key keeps
+  /// the standard size-based behavior. Test-only types: "type:test_per_batch"
+  /// cuts a chunk every batch; "type:test_random" randomizes chunk/stripe
+  /// boundaries. The remaining keys tune the test types: seed,
+  /// flush_chunk_probability, flush_stripe_probability,
+  /// max_stripe_physical_size (bytes; accepts a KB/MB/GB suffix),
+  /// estimated_compression_factor; unset keys keep the TestFlushPolicy::Options
+  /// defaults. This only selects the flush policy; enable and size chunking
+  /// separately via the CHUNKING_WRITER_* configs. Not for production use. E.g.
+  /// "type:test_random,flush_chunk_probability:0.1,seed:42".
+  // @lint-ignore CLANGTIDY facebook-hte-NonPodStaticDeclaration
+  static Entry<std::string> FLUSH_POLICY_CONFIG;
+
   // EXPERIMENTAL: Cluster index is not production-ready. Do not enable for
   // production tables without consulting the Nimble team (oncall: dwios).
 

--- a/dwio/nimble/velox/tests/FlushPolicyTest.cpp
+++ b/dwio/nimble/velox/tests/FlushPolicyTest.cpp
@@ -16,7 +16,14 @@
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
+#include <array>
+#include <memory>
+#include <string>
+#include <string_view>
+
+#include "dwio/nimble/common/Exceptions.h"
 #include "dwio/nimble/velox/FlushPolicy.h"
+#include "dwio/nimble/velox/FlushPolicyFactory.h"
 
 namespace facebook::nimble {
 
@@ -227,6 +234,376 @@ TEST(FlushPolicyTest, LambdaFlushPolicyDefaultLambdas) {
   EXPECT_FALSE(policy.shouldFlush(progress));
   ;
   EXPECT_FALSE(policy.shouldChunk(progress));
+}
+
+class TestFlushPolicyTest : public ::testing::Test {};
+
+// Same seed reproduces the decision sequence (so a failing run replays from its
+// logged seed); distinct seeds diverge (the seed actually drives the rng).
+TEST_F(TestFlushPolicyTest, seedBasics) {
+  // A non-trivial progress so shouldFlush exercises its full computation.
+  const StripeProgress progress{
+      .stripeRawSize = 1000,
+      .stripeEncodedSize = 500,
+      .stripeEncodedLogicalSize = 800};
+
+  // Same seed -> identical decisions.
+  TestFlushPolicyFactory factoryA{TestFlushPolicy::Options{.seed = 42}};
+  TestFlushPolicyFactory factoryB{TestFlushPolicy::Options{.seed = 42}};
+  auto policyA = factoryA();
+  auto policyB = factoryB();
+  for (int i = 0; i < 1000; ++i) {
+    EXPECT_EQ(policyA->shouldChunk(progress), policyB->shouldChunk(progress));
+    EXPECT_EQ(policyA->shouldFlush(progress), policyB->shouldFlush(progress));
+  }
+
+  // Distinct seeds -> at least one differing decision.
+  TestFlushPolicyFactory factoryC{TestFlushPolicy::Options{.seed = 1}};
+  TestFlushPolicyFactory factoryD{TestFlushPolicy::Options{.seed = 2}};
+  auto policyC = factoryC();
+  auto policyD = factoryD();
+  bool anyDifferent = false;
+  for (int i = 0; i < 1000; ++i) {
+    if (policyC->shouldChunk(progress) != policyD->shouldChunk(progress)) {
+      anyDifferent = true;
+    }
+  }
+  EXPECT_TRUE(anyDifferent);
+}
+
+// A policy recreated per call from a factory keeps drawing from the factory's
+// single shared State, so its decision stream matches one persistent policy
+// from an equivalent same-seed factory. This is what makes the fuzzer's
+// boundaries vary across the writer's per-write() policy recreation.
+TEST_F(TestFlushPolicyTest, sharedStateContinuesSequence) {
+  const StripeProgress progress{
+      .stripeRawSize = 0,
+      .stripeEncodedSize = 0,
+      .stripeEncodedLogicalSize = 0};
+
+  constexpr int kDecisions = 8;
+  TestFlushPolicyFactory persistentFactory{
+      TestFlushPolicy::Options{.seed = 99}};
+  auto persistent = persistentFactory();
+  std::array<bool, kDecisions> persistentDecisions{};
+  for (int i = 0; i < kDecisions; ++i) {
+    persistentDecisions[i] = persistent->shouldChunk(progress);
+  }
+
+  // Same seed, but a fresh policy recreated per call (mimics the writer's
+  // per-write() recreation) -- must reproduce the persistent stream.
+  TestFlushPolicyFactory recreatingFactory{
+      TestFlushPolicy::Options{.seed = 99}};
+  std::array<bool, kDecisions> recreatedDecisions{};
+  for (int i = 0; i < kDecisions; ++i) {
+    recreatedDecisions[i] = recreatingFactory()->shouldChunk(progress);
+  }
+  EXPECT_EQ(persistentDecisions, recreatedDecisions);
+}
+
+// The size guard must force a flush regardless of the random draw or seed when
+// the predicted encoded stripe size already exceeds maxStripePhysicalSize.
+TEST_F(TestFlushPolicyTest, flushSizeGuard) {
+  // stripeEncodedSize alone is >= the default 128MB max, so
+  // expectedEncodedStripeSize is too, independent of the compression heuristic.
+  const StripeProgress oversized{
+      .stripeRawSize = 0,
+      .stripeEncodedSize = 128 * 1024L * 1024L,
+      .stripeEncodedLogicalSize = 0};
+
+  for (uint64_t seed = 0; seed < 50; ++seed) {
+    TestFlushPolicyFactory factory{TestFlushPolicy::Options{.seed = seed}};
+    auto policy = factory();
+    for (int i = 0; i < 100; ++i) {
+      EXPECT_TRUE(policy->shouldFlush(oversized));
+    }
+  }
+}
+
+// The default flushChunkProbability is 1/3; over many calls the observed rate
+// should land near it.
+TEST_F(TestFlushPolicyTest, defaultChunkRate) {
+  TestFlushPolicyFactory factory{TestFlushPolicy::Options{.seed = 7}};
+  auto policy = factory();
+
+  const StripeProgress progress{
+      .stripeRawSize = 0,
+      .stripeEncodedSize = 0,
+      .stripeEncodedLogicalSize = 0};
+
+  constexpr int kCalls = 100000;
+  int chunkCount = 0;
+  for (int i = 0; i < kCalls; ++i) {
+    if (policy->shouldChunk(progress)) {
+      ++chunkCount;
+    }
+  }
+
+  const double rate = static_cast<double>(chunkCount) / kCalls;
+  // Band around the default 1/3 probability.
+  EXPECT_GE(rate, 0.30);
+  EXPECT_LE(rate, 0.36);
+}
+
+// The default flushStripeProbability is 1/20 when the size guard never trips;
+// with a tiny progress the predicted size stays far below the physical max, so
+// only the random draw can flush.
+TEST_F(TestFlushPolicyTest, defaultFlushRate) {
+  TestFlushPolicyFactory factory{TestFlushPolicy::Options{.seed = 7}};
+  auto policy = factory();
+
+  // All sizes tiny, so expectedEncodedStripeSize is far below 128MB.
+  const StripeProgress progress{
+      .stripeRawSize = 1,
+      .stripeEncodedSize = 1,
+      .stripeEncodedLogicalSize = 1};
+
+  constexpr int kCalls = 100000;
+  int flushCount = 0;
+  for (int i = 0; i < kCalls; ++i) {
+    if (policy->shouldFlush(progress)) {
+      ++flushCount;
+    }
+  }
+
+  const double rate = static_cast<double>(flushCount) / kCalls;
+  // Band around the default 1/20 probability.
+  EXPECT_GE(rate, 0.03);
+  EXPECT_LE(rate, 0.07);
+}
+
+// A custom flushChunkProbability is honored: the observed chunk rate tracks it.
+TEST_F(TestFlushPolicyTest, customChunkProbability) {
+  TestFlushPolicyFactory factory{
+      TestFlushPolicy::Options{.seed = 11, .flushChunkProbability = 0.8}};
+  auto policy = factory();
+
+  const StripeProgress progress{
+      .stripeRawSize = 0,
+      .stripeEncodedSize = 0,
+      .stripeEncodedLogicalSize = 0};
+
+  constexpr int kCalls = 100000;
+  int chunkCount = 0;
+  for (int i = 0; i < kCalls; ++i) {
+    if (policy->shouldChunk(progress)) {
+      ++chunkCount;
+    }
+  }
+
+  const double rate = static_cast<double>(chunkCount) / kCalls;
+  // Band around the configured 0.8 probability.
+  EXPECT_GE(rate, 0.78);
+  EXPECT_LE(rate, 0.82);
+}
+
+// flushChunkProbability 1.0 chunks on every write (the test_per_batch behavior
+// the factory pins), while a configurable stripe probability still drives
+// flushes.
+TEST_F(TestFlushPolicyTest, alwaysChunksWhenProbabilityOne) {
+  TestFlushPolicyFactory factory{TestFlushPolicy::Options{
+      .seed = 5, .flushChunkProbability = 1.0, .flushStripeProbability = 0.5}};
+  auto policy = factory();
+  const StripeProgress progress{
+      .stripeRawSize = 1,
+      .stripeEncodedSize = 1,
+      .stripeEncodedLogicalSize = 1};
+  int flushCount = 0;
+  for (int i = 0; i < 1000; ++i) {
+    EXPECT_TRUE(policy->shouldChunk(progress));
+    if (policy->shouldFlush(progress)) {
+      ++flushCount;
+    }
+  }
+  // The configurable stripe probability is honored (not forced off).
+  EXPECT_GT(flushCount, 0);
+}
+
+// The constructor sanity-checks every tuning value as an internal error (a
+// config coming through FlushPolicyFactoryFactory is already user-validated).
+// The factory constructs the policy, so a bad Options surfaces when invoked.
+TEST_F(TestFlushPolicyTest, ctorInvalidArgs) {
+  // maxStripePhysicalSize must be > 0.
+  EXPECT_THROW(
+      TestFlushPolicyFactory{
+          TestFlushPolicy::Options{.maxStripePhysicalSize = 0}}(),
+      NimbleInternalError);
+  // estimatedCompressionFactor must be >= 1.0.
+  EXPECT_THROW(
+      TestFlushPolicyFactory{
+          TestFlushPolicy::Options{.estimatedCompressionFactor = 0.5}}(),
+      NimbleInternalError);
+  // flushChunkProbability must be within [0, 1].
+  EXPECT_THROW(
+      TestFlushPolicyFactory{
+          TestFlushPolicy::Options{.flushChunkProbability = -0.1}}(),
+      NimbleInternalError);
+  EXPECT_THROW(
+      TestFlushPolicyFactory{
+          TestFlushPolicy::Options{.flushChunkProbability = 1.5}}(),
+      NimbleInternalError);
+  // flushStripeProbability must be within [0, 1].
+  EXPECT_THROW(
+      TestFlushPolicyFactory{
+          TestFlushPolicy::Options{.flushStripeProbability = -0.1}}(),
+      NimbleInternalError);
+  EXPECT_THROW(
+      TestFlushPolicyFactory{
+          TestFlushPolicy::Options{.flushStripeProbability = 1.5}}(),
+      NimbleInternalError);
+  // The defaults and explicit valid values construct cleanly.
+  EXPECT_NO_THROW(TestFlushPolicyFactory{TestFlushPolicy::Options{}}());
+  EXPECT_NO_THROW((TestFlushPolicyFactory{TestFlushPolicy::Options{
+      .flushChunkProbability = 0.0,
+      .flushStripeProbability = 1.0,
+      .maxStripePhysicalSize = 1024,
+      .estimatedCompressionFactor = 1.0}}()));
+}
+
+// A custom maxStripePhysicalSize is honored: a small max makes the size guard
+// trip (forcing a flush) regardless of the random draw.
+TEST_F(TestFlushPolicyTest, customFlushSizeGuard) {
+  TestFlushPolicyFactory factory{
+      TestFlushPolicy::Options{.seed = 3, .maxStripePhysicalSize = 1024}};
+  auto policy = factory();
+
+  // Encoded size alone already exceeds the 1024-byte max.
+  const StripeProgress overMax{
+      .stripeRawSize = 0,
+      .stripeEncodedSize = 2048,
+      .stripeEncodedLogicalSize = 0};
+
+  for (int i = 0; i < 100; ++i) {
+    EXPECT_TRUE(policy->shouldFlush(overMax));
+  }
+}
+
+class FlushPolicyFactoryFactoryTest : public ::testing::Test {
+ protected:
+  // Returns the factory for a config string, asserting one was produced. The
+  // factory owns any shared rng state, so callers must keep it alive for as
+  // long as any policy it produces -- hence we hand back the factory, not a
+  // policy (a returned policy would dangle once the factory dropped).
+  FlushPolicyFactory buildFactory(std::string_view configStr) {
+    auto factory = FlushPolicyFactoryFactory::create(configStr);
+    EXPECT_TRUE(factory.has_value());
+    return factory.value_or(FlushPolicyFactory{});
+  }
+};
+
+// An absent type (empty string, or tuning with no "type" key) keeps the
+// production policy.
+TEST_F(FlushPolicyFactoryFactoryTest, absentTypeReturnsNullopt) {
+  EXPECT_FALSE(FlushPolicyFactoryFactory::create("").has_value());
+  // A spec with tuning but no type keeps the production policy.
+  EXPECT_FALSE(FlushPolicyFactoryFactory::create("seed:5").has_value());
+}
+
+// An unknown type -- including the former "default" -- is a user error.
+TEST_F(FlushPolicyFactoryFactoryTest, unknownTypeThrows) {
+  EXPECT_THROW(
+      FlushPolicyFactoryFactory::create("type:bogus"), NimbleUserError);
+  EXPECT_THROW(
+      FlushPolicyFactoryFactory::create("type:default"), NimbleUserError);
+}
+
+// "test_random" builds a TestFlushPolicy and honors the parsed tuning: chunk
+// probability 1.0 always chunks, and the 1KB max trips the size guard while a
+// small stripe stays under it.
+TEST_F(FlushPolicyFactoryFactoryTest, testRandomBuildsPolicyAndParsesParams) {
+  auto factory = buildFactory(
+      "type:test_random,flush_chunk_probability:1.0,flush_stripe_probability:0.0,"
+      "max_stripe_physical_size:1KB,seed:5");
+  ASSERT_NE(factory, nullptr);
+  auto policy = factory();
+  ASSERT_NE(policy, nullptr);
+  EXPECT_NE(dynamic_cast<TestFlushPolicy*>(policy.get()), nullptr);
+
+  const StripeProgress small{
+      .stripeRawSize = 0,
+      .stripeEncodedSize = 0,
+      .stripeEncodedLogicalSize = 0};
+  EXPECT_TRUE(policy->shouldChunk(small));
+  EXPECT_TRUE(policy->shouldChunk(small));
+
+  const StripeProgress overMax{
+      .stripeRawSize = 0,
+      .stripeEncodedSize = 2048,
+      .stripeEncodedLogicalSize = 0};
+  EXPECT_TRUE(policy->shouldFlush(overMax));
+  EXPECT_FALSE(policy->shouldFlush(small));
+}
+
+// "test_per_batch" pins flush_chunk_probability to 1.0 (always chunks),
+// overriding any value in the spec.
+TEST_F(FlushPolicyFactoryFactoryTest, testPerBatchPinsChunkProbability) {
+  const StripeProgress small{
+      .stripeRawSize = 1,
+      .stripeEncodedSize = 1,
+      .stripeEncodedLogicalSize = 1};
+
+  auto factory = buildFactory("type:test_per_batch,seed:5");
+  ASSERT_NE(factory, nullptr);
+  auto policy = factory();
+  ASSERT_NE(policy, nullptr);
+  for (int i = 0; i < 100; ++i) {
+    EXPECT_TRUE(policy->shouldChunk(small));
+  }
+
+  // A flush_chunk_probability in the spec is overridden to 1.0, not honored.
+  auto overriddenFactory =
+      buildFactory("type:test_per_batch,flush_chunk_probability:0.5");
+  ASSERT_NE(overriddenFactory, nullptr);
+  auto overridden = overriddenFactory();
+  ASSERT_NE(overridden, nullptr);
+  for (int i = 0; i < 100; ++i) {
+    EXPECT_TRUE(overridden->shouldChunk(small));
+  }
+}
+
+// A malformed entry, unknown key, unparseable value, or out-of-range value is a
+// NimbleUserError (not a folly::ConversionError or the ctor's internal error).
+TEST_F(FlushPolicyFactoryFactoryTest, invalidConfigThrows) {
+  const auto create = [](const std::string& spec) {
+    return FlushPolicyFactoryFactory::create("type:test_random," + spec);
+  };
+  EXPECT_THROW(create("no_colon_here"), NimbleUserError);
+  EXPECT_THROW(create("unknown_key:1"), NimbleUserError);
+  EXPECT_THROW(create("seed:abc"), NimbleUserError);
+  EXPECT_THROW(create("max_stripe_physical_size:notasize"), NimbleUserError);
+  EXPECT_THROW(create("flush_chunk_probability:2.0"), NimbleUserError);
+  EXPECT_THROW(create("max_stripe_physical_size:0B"), NimbleUserError);
+}
+
+// The factory hands every policy the same shared state, so recreating the
+// policy on each call (as VeloxWriter does via flushPolicyFactory() per
+// write()) keeps advancing one rng rather than restarting it. A
+// recreate-per-call decision stream must therefore match a single persistent
+// policy from an equivalent factory -- i.e. the factory neutralizes the
+// writer's per-write() recreation.
+TEST_F(FlushPolicyFactoryFactoryTest, recreatedPoliciesShareRng) {
+  const StripeProgress progress{
+      .stripeRawSize = 0,
+      .stripeEncodedSize = 0,
+      .stripeEncodedLogicalSize = 0};
+
+  constexpr int kDecisions = 8;
+  auto referenceFactory = buildFactory("type:test_random,seed:7");
+  ASSERT_NE(referenceFactory, nullptr);
+  auto reference = referenceFactory();
+  std::array<bool, kDecisions> referenceDecisions{};
+  for (int i = 0; i < kDecisions; ++i) {
+    referenceDecisions[i] = reference->shouldChunk(progress);
+  }
+
+  // A separate factory with the same seed, but a fresh policy per call.
+  auto recreatingFactory = buildFactory("type:test_random,seed:7");
+  ASSERT_NE(recreatingFactory, nullptr);
+  std::array<bool, kDecisions> recreatedDecisions{};
+  for (int i = 0; i < kDecisions; ++i) {
+    recreatedDecisions[i] = recreatingFactory()->shouldChunk(progress);
+  }
+  EXPECT_EQ(referenceDecisions, recreatedDecisions);
 }
 
 } // namespace facebook::nimble


### PR DESCRIPTION
Summary:

X-link: https://github.com/facebookincubator/velox/pull/17970

The `TableEvolutionFuzzer` writes single-chunk Nimble files, so Nimble's chunked write/read paths go unexercised. This wires randomized chunk/stripe flush behavior into the fuzzer, porting the idea from the (removed) Vader validation-service flush policy (D89336482).

What it adds:
- `nimble::TestFlushPolicy` (`dwio/nimble/velox/FlushPolicy.{h,cpp}`) — a seeded, test-only flush policy. `shouldChunk` cuts a chunk with probability `flushChunkProbability` (default 1/3); `shouldFlush` flushes with probability `flushStripeProbability` (default 1/20) plus an encoded-stripe-size guard (`maxStripePhysicalSize` default 128MB, using `estimatedCompressionFactor` default 3.7 before any data is encoded). Tunables live in a nested `TestFlushPolicy::Options`, range-checked in the constructor. The RNG lives in a shared `TestFlushState` that the policy borrows via a raw, non-owning pointer: `VeloxWriter` rebuilds the flush policy from its factory on every `write()`, so an RNG owned by the policy would reseed identically each call; holding it in state that outlives the per-`write()` policy instances lets decisions vary across writes while staying reproducible from the seed. The `TestFlushState` is owned by the factory closure (a `std::shared_ptr`, since a `std::function` target must be copyable) and each policy takes a raw pointer.
- `nimble::FlushPolicyFactoryFactory` (`dwio/nimble/velox/FlushPolicyFactory.{h,cpp}`) — builds a flush-policy factory from a `nimble.flush_policy_config` string of the form `type:<t>,key:value,...`. The leading `type` selects the policy and dispatches to a per-type parser (`parseRandomConfig` / `parsePerBatchConfig`), each returning a `TestFlushPolicy::Options`; `makeRandom` wraps it in a factory whose produced policies share one `TestFlushState`. `random` uses the parsed tuning as-is; `per_batch` pins `flushChunkProbability` to 1.0 (cuts a chunk every batch, ignoring any value in the spec). `type:default` (or an absent key) returns `std::nullopt`, so the caller keeps the size-based policy. Byte sizes go through `velox::config::toCapacity` (case-insensitive `KB`/`MB`/`GB`); a malformed entry, unknown key, unparseable/out-of-range value, or unknown type fails fast as `NimbleUserError`.
- A single `nimble::Config` key `FLUSH_POLICY_CONFIG` (`nimble.flush_policy_config`). `NimbleWriterOptionBuilder::withSerdeParams` consults `FlushPolicyFactoryFactory::create` first (it takes precedence over the size-based paths); when it returns a factory, chunking is forced on and `minStreamChunkRawSize` is set to 0 so even small inputs chunk. A throttled tripwire logs when a test policy is installed.
- A generic, format-agnostic `Config::extraWriteSerdeParams` hook on the OSS-core `velox/exec/tests/TableEvolutionFuzzer` (no Nimble coupling in OSS). The Meta `fb_velox` driver sets it to choose default / `per_batch` / `random` ~1/3 each per written file, seeded from `FLAGS_seed` for reproducibility.

The `per_batch` and `random` types are test-only; production writes are unaffected (the `nimble.flush_policy_config` key is never set in production).

Differential Revision: D109997547


