### PR TITLE
misc: Advance Velox hash

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ Nimble integrates Velox as a Git submodule, referencing a specific commit of the
 Velox repository. The Velox badge at the top of this README shows the current
 commit and how far behind it is from Velox main.
 
-[See what changed since the current Velox commit.](https://github.com/facebookincubator/velox/compare/a018cad73fb6c2c150d1111b501de56a00bdad47...main)
+[See what changed since the current Velox commit.](https://github.com/facebookincubator/velox/compare/e06dd2b5ee7816b99bccbdbd382fe68b3d8f4a48...main)
 <!-- pre-commit check-velox-readme validates the SHA above matches the submodule -->
 
 Advance Velox when your changes depend on code in Velox that


### PR DESCRIPTION
Summary: Advance the Nimble OSS Velox submodule pin to e06dd2b5ee7816b99bccbdbd382fe68b3d8f4a48 to pick up facebookincubator/velox#17954. Updates `velox.submodule.txt` and the README compare link in lockstep (the OSS `check-velox-readme` pre-commit hook requires the two SHAs to match). fbcode builds against the in-repo `velox/`, so this only affects the OSS CMake build; validation runs in OSS GitHub CI after landing.

Differential Revision: D110002607
