### PR TITLE
fix(nimble): Exclude delta-updated columns from lazy column I/O

### DIFF
--- a/dwio/nimble/velox/selective/SelectiveNimbleReader.cpp
+++ b/dwio/nimble/velox/selective/SelectiveNimbleReader.cpp
@@ -415,8 +415,8 @@ void SelectiveNimbleRowReader::initReadRange() {
 
 // Computes the set of top-level columns eligible for lazy I/O. A column
 // qualifies if it has no pushdown filter, is not referenced by the remaining
-// filter, has no extraction transform, and is projected in the output.
-// Returns empty set when lazy I/O is disabled.
+// filter, has no extraction transform, has no delta update, and is projected
+// in the output. Returns empty set when lazy I/O is disabled.
 folly::F14FastSet<std::string> SelectiveNimbleRowReader::computeLazyIoColumns(
     const dwio::common::RowReaderOptions& options) {
   folly::F14FastSet<std::string> lazyIoColumns;
@@ -436,9 +436,12 @@ folly::F14FastSet<std::string> SelectiveNimbleRowReader::computeLazyIoColumns(
         "Column with no filter should be projected");
     // A column is eligible for lazy I/O if it has no pushdown filter, is not
     // referenced by the remaining filter (must be eager for filter eval), has
-    // no extraction transform, and is projected in the output.
+    // no extraction transform, has no delta update, and is projected in the
+    // output. Transform and delta-updated columns are excluded because their
+    // loaders read through the eager input and never call LazyInput::load().
     if (!childSpec->hasFilter() && remainingFilterColumns.count(name) == 0 &&
-        !childSpec->hasTransform() && childSpec->projectOut()) {
+        !childSpec->hasTransform() && !childSpec->deltaUpdate() &&
+        childSpec->projectOut()) {
       lazyIoColumns.insert(name);
     }
   }


### PR DESCRIPTION
Summary:
A Metalake delta-updated column wrongly qualified for lazy-column-io.
ScanSpec::setDeltaUpdate() disables the column filter, so it passed the
!hasFilter() check in computeLazyIoColumns() and its Nimble streams were routed
to the lazy input clone. But delta columns are materialized by the generic
DeltaUpdateColumnLoader, which reads through the eager input and never calls
LazyInput::load(), so the clone was never loaded and the first read failed with
"Fail to read region" under FilterProject.

Exclude delta-updated columns from lazy I/O, mirroring the existing
!hasTransform() exclusion (TransformColumnLoader has the same limitation).

Differential Revision: D110095905


