### PR TITLE
feat: Add FSST (Fast Static Symbol Table) encoding for string columns (#924)

### DIFF
--- a/dwio/nimble/common/Types.cpp
+++ b/dwio/nimble/common/Types.cpp
@@ -55,6 +55,8 @@ std::string toString(EncodingType encodingType) {
       return "Prefix";
     case EncodingType::ALP:
       return "ALP";
+    case EncodingType::Fsst:
+      return "Fsst";
     case EncodingType::PFOR:
       return "PFOR";
     case EncodingType::SimdForBitpack:

--- a/dwio/nimble/common/Types.h
+++ b/dwio/nimble/common/Types.h
@@ -128,6 +128,10 @@ enum class EncodingType {
   // Frame of Reference: stores offsets from per-frame minimum values.
   // Supports O(1) random access. Preserves row order.
   FOR = 18,
+  // Stores string data compressed with FSST (Fast Static Symbol Table).
+  // Trains a per-stripe symbol table and compresses each string independently,
+  // enabling random access decompression without touching neighboring strings.
+  Fsst = 19,
 };
 std::string toString(EncodingType encodingType);
 std::ostream& operator<<(std::ostream& out, EncodingType encodingType);

--- a/dwio/nimble/compression/CMakeLists.txt
+++ b/dwio/nimble/compression/CMakeLists.txt
@@ -14,6 +14,7 @@
 add_library(
   nimble_compression
   Compression.cpp
+  CompressionPolicy.cpp
   Lz4Compressor.cpp
   OpenZLCompressor.cpp
   ZstdCompressor.cpp

--- a/dwio/nimble/compression/COMPRESSION.md
+++ b/dwio/nimble/compression/COMPRESSION.md
@@ -15,7 +15,7 @@ Compression is applied at **leaf encoding nodes** in the encoding tree (e.g. `Tr
 ```
 VeloxWriterOptions::compressionOptions
   → ManualEncodingSelectionPolicy (encoding selection)
-    → AlwaysCompressPolicy (created per-stream at leaf level)
+    → ConfiguredCompressionPolicy (created per-stream at leaf level)
       → Compression::compress() (static dispatch)
         → CompressorRegistry → ICompressor::compress()
 ```
@@ -246,7 +246,7 @@ struct CompressionParameters {
 
 ### Step 5: Add configuration fields
 
-**`dwio/nimble/encodings/selection/EncodingSelectionPolicy.h`** — add fields to `CompressionOptions`:
+**`dwio/nimble/compression/CompressionPolicy.h`** — add fields to `CompressionOptions`:
 
 ```cpp
 struct CompressionOptions {
@@ -256,13 +256,13 @@ struct CompressionOptions {
 };
 ```
 
-**`dwio/nimble/encodings/selection/EncodingSelectionPolicy.h`** — update `AlwaysCompressPolicy::compression()` inside `ManualEncodingSelectionPolicy::select()` to handle the new codec:
+**`dwio/nimble/compression/CompressionPolicy.cpp`** — update `ConfiguredCompressionPolicy::config()` to handle the new codec:
 
 ```cpp
-CompressionInformation compression() const override {
+CompressionConfig config() const override {
   // ... existing Zstd and Lz4 branches ...
   if (compressionOptions_.compressionType == CompressionType::MyCodec) {
-    CompressionInformation information{
+    CompressionConfig information{
         .compressionType = CompressionType::MyCodec,
         .minCompressionSize = compressionOptions_.myCodecMinCompressionSize};
     information.parameters.myCodec.myOption =
@@ -322,8 +322,8 @@ Add compression round-trip tests in `dwio/nimble/encodings/tests/` or `dwio/nimb
 - [ ] Add min compression size constant to `Constants.h`
 - [ ] Register in `CompressorRegistry` in `Compression.cpp`
 - [ ] Add parameter struct to `CompressionPolicy.h`
-- [ ] Add fields to `CompressionOptions` in `EncodingSelectionPolicy.h`
-- [ ] Handle new codec in `AlwaysCompressPolicy::compression()`
+- [ ] Add fields to `CompressionOptions` in `CompressionPolicy.h`
+- [ ] Handle new codec in `ConfiguredCompressionPolicy::config()`
 - [ ] Add source/header to `compression/BUCK`
 - [ ] (Optional) Add serde parameters in `NimbleConfig.{h,cpp}` and `NimbleWriterOptionBuilder.cpp`
 - [ ] Add unit tests
@@ -336,12 +336,13 @@ Add compression round-trip tests in `dwio/nimble/encodings/tests/` or `dwio/nimb
 | `common/Constants.h` | Min compression size constants |
 | `compression/Compression.h` | `ICompressor` interface, `CompressionEncoder`, `Compression` static API |
 | `compression/Compression.cpp` | `CompressorRegistry`, dispatch logic |
-| `compression/CompressionPolicy.h` | `CompressionPolicy` interface, parameter structs |
+| `compression/CompressionPolicy.h` | `CompressionPolicy` interface, parameter structs, compression options |
+| `compression/CompressionPolicy.cpp` | `ConfiguredCompressionPolicy` implementation |
 | `compression/ZstdCompressor.{h,cpp}` | Zstd codec (good reference implementation) |
 | `compression/Lz4Compressor.{h,cpp}` | LZ4 codec |
 | `compression/fb/MetaInternalCompressor.{h,cpp}` | Zstrong/Managed Compression (internal only) |
 | `compression/BUCK` | Build target for all compression code |
-| `encodings/selection/EncodingSelectionPolicy.h` | `CompressionOptions`, `AlwaysCompressPolicy` |
+| `encodings/selection/EncodingSelectionPolicy.h` | Encoding selection policy |
 | `velox/VeloxWriterOptions.h` | `VeloxWriterOptions::compressionOptions` |
 | `tablet/Footer.fbs` | FlatBuffers schema (stores `CompressionType` per metadata section) |
 | `dwio/api/NimbleConfig.{h,cpp}` | Serde parameter definitions |

--- a/dwio/nimble/compression/Compression.cpp
+++ b/dwio/nimble/compression/Compression.cpp
@@ -65,7 +65,7 @@ ICompressor& getCompressor(CompressionType compressionType) {
     DataType dataType,
     int bitWidth,
     const CompressionPolicy& compressionPolicy) {
-  auto compression = compressionPolicy.compression();
+  auto compression = compressionPolicy.config();
 
   return getCompressor(compression.compressionType)
       .compress(pool, data, dataType, bitWidth, compressionPolicy);

--- a/dwio/nimble/compression/Compression.h
+++ b/dwio/nimble/compression/Compression.h
@@ -112,8 +112,8 @@ class CompressionEncoder {
       : dataSize_{uncompressedBuffer.size()},
         compressionType_{CompressionType::Uncompressed} {
     if (dataSize_ == 0 ||
-        dataSize_ < compressionPolicy.compression().minCompressionSize ||
-        compressionPolicy.compression().compressionType ==
+        dataSize_ < compressionPolicy.config().minCompressionSize ||
+        compressionPolicy.config().compressionType ==
             CompressionType::Uncompressed) {
       // No compression, just use the original buffer.
       data_ = uncompressedBuffer;
@@ -153,8 +153,8 @@ class CompressionEncoder {
         dataSize_{uncompressedSize},
         compressionType_{CompressionType::Uncompressed} {
     if (uncompressedSize == 0 ||
-        uncompressedSize < compressionPolicy.compression().minCompressionSize ||
-        compressionPolicy.compression().compressionType ==
+        uncompressedSize < compressionPolicy.config().minCompressionSize ||
+        compressionPolicy.config().compressionType ==
             CompressionType::Uncompressed) {
       // No compression. Do not encode the data yet. It will be encoded later
       // (in write()) directly into the output buffer.

--- a/dwio/nimble/compression/CompressionPolicy.cpp
+++ b/dwio/nimble/compression/CompressionPolicy.cpp
@@ -1,0 +1,158 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "dwio/nimble/compression/CompressionPolicy.h"
+
+namespace facebook::nimble {
+
+ConfiguredCompressionPolicy::ConfiguredCompressionPolicy(
+    CompressionOptions compressionOptions,
+    EncodingType encodingType)
+    : compressionOptions_{std::move(compressionOptions)},
+      effectiveAcceptRatio_{getAcceptRatio(encodingType)} {}
+
+CompressionConfig ConfiguredCompressionPolicy::config() const {
+  if (compressionOptions_.compressionType == CompressionType::Zstd) {
+    CompressionConfig config{
+        .compressionType = CompressionType::Zstd,
+        .minCompressionSize = compressionOptions_.zstdMinCompressionSize};
+    config.parameters.zstd.compressionLevel =
+        compressionOptions_.zstdCompressionLevel;
+    return config;
+  }
+
+  if (compressionOptions_.compressionType == CompressionType::Lz4) {
+    CompressionConfig config{
+        .compressionType = CompressionType::Lz4,
+        .minCompressionSize = compressionOptions_.lz4MinCompressionSize};
+    config.parameters.lz4.accelerationLevel =
+        compressionOptions_.lz4AccelerationLevel;
+    return config;
+  }
+
+  if (compressionOptions_.compressionType == CompressionType::OpenZL) {
+    CompressionConfig config{
+        .compressionType = CompressionType::OpenZL,
+        .minCompressionSize = compressionOptions_.openzlMinCompressionSize};
+    config.parameters.openzl.compressionLevel =
+        compressionOptions_.openzlCompressionLevel;
+    config.parameters.openzl.decompressionLevel =
+        compressionOptions_.openzlDecompressionLevel;
+    config.parameters.openzl.formatVersion =
+        compressionOptions_.openzlFormatVersion;
+    return config;
+  }
+
+  CompressionConfig config{
+      .compressionType = CompressionType::MetaInternal,
+      .minCompressionSize = compressionOptions_.internalMinCompressionSize};
+  config.parameters.metaInternal.compressionLevel =
+      compressionOptions_.internalCompressionLevel;
+  config.parameters.metaInternal.decompressionLevel =
+      compressionOptions_.internalDecompressionLevel;
+  config.parameters.metaInternal.useVariableBitWidthCompressor =
+      compressionOptions_.useVariableBitWidthCompressor;
+  config.parameters.metaInternal.compressionKey =
+      compressionOptions_.metaInternalCompressionKey;
+  return config;
+}
+
+bool ConfiguredCompressionPolicy::shouldAccept(
+    CompressionType /* compressionType */,
+    uint64_t uncompressedSize,
+    uint64_t compressedSize) const {
+  if (uncompressedSize * effectiveAcceptRatio_ < compressedSize) {
+    return false;
+  }
+
+  return true;
+}
+
+float ConfiguredCompressionPolicy::getAcceptRatio(
+    EncodingType encodingType) const {
+  for (const auto& [enc, ratio] :
+       compressionOptions_.compressionAcceptRatioOverrides) {
+    if (enc == encodingType) {
+      return ratio;
+    }
+  }
+  return compressionOptions_.compressionAcceptRatio;
+}
+
+ReplayedCompressionPolicy::ReplayedCompressionPolicy(
+    CompressionType compressionType,
+    CompressionOptions compressionOptions)
+    : compressionType_{compressionType},
+      compressionOptions_{std::move(compressionOptions)} {}
+
+CompressionConfig ReplayedCompressionPolicy::config() const {
+  if (compressionType_ == CompressionType::Uncompressed) {
+    return {.compressionType = CompressionType::Uncompressed};
+  }
+
+  if (compressionType_ == CompressionType::Zstd) {
+    CompressionConfig config{
+        .compressionType = CompressionType::Zstd,
+        .minCompressionSize = compressionOptions_.zstdMinCompressionSize};
+    config.parameters.zstd.compressionLevel =
+        compressionOptions_.zstdCompressionLevel;
+    return config;
+  }
+
+  if (compressionType_ == CompressionType::Lz4) {
+    CompressionConfig config{
+        .compressionType = CompressionType::Lz4,
+        .minCompressionSize = compressionOptions_.lz4MinCompressionSize};
+    config.parameters.lz4.accelerationLevel =
+        compressionOptions_.lz4AccelerationLevel;
+    return config;
+  }
+
+  if (compressionType_ == CompressionType::OpenZL) {
+    CompressionConfig config{
+        .compressionType = CompressionType::OpenZL,
+        .minCompressionSize = compressionOptions_.openzlMinCompressionSize};
+    config.parameters.openzl.compressionLevel =
+        compressionOptions_.openzlCompressionLevel;
+    config.parameters.openzl.decompressionLevel =
+        compressionOptions_.openzlDecompressionLevel;
+    config.parameters.openzl.formatVersion =
+        compressionOptions_.openzlFormatVersion;
+    return config;
+  }
+
+  CompressionConfig config{
+      .compressionType = CompressionType::MetaInternal,
+      .minCompressionSize = compressionOptions_.internalMinCompressionSize};
+  config.parameters.metaInternal.compressionLevel =
+      compressionOptions_.internalCompressionLevel;
+  config.parameters.metaInternal.decompressionLevel =
+      compressionOptions_.internalDecompressionLevel;
+  config.parameters.metaInternal.useVariableBitWidthCompressor =
+      compressionOptions_.useVariableBitWidthCompressor;
+  config.parameters.metaInternal.compressionKey =
+      compressionOptions_.metaInternalCompressionKey;
+  return config;
+}
+
+bool ReplayedCompressionPolicy::shouldAccept(
+    CompressionType /* compressionType */,
+    uint64_t uncompressedSize,
+    uint64_t compressedSize) const {
+  return compressedSize <=
+      uncompressedSize * compressionOptions_.compressionAcceptRatio;
+}
+
+} // namespace facebook::nimble

--- a/dwio/nimble/compression/CompressionPolicy.h
+++ b/dwio/nimble/compression/CompressionPolicy.h
@@ -17,7 +17,10 @@
 
 #include <cstdint>
 #include <string>
+#include <utility>
+#include <vector>
 
+#include "dwio/nimble/common/Constants.h"
 #include "dwio/nimble/common/Types.h"
 #include "folly/json/json.h"
 
@@ -103,15 +106,46 @@ struct CompressionParameters {
   OpenZLCompressionParameters openzl{};
 };
 
-struct CompressionInformation {
+struct CompressionConfig {
   CompressionType compressionType{};
   CompressionParameters parameters{};
   uint64_t minCompressionSize = 0;
 };
 
+struct CompressionOptions {
+  /// Rejects compression when compressedSize exceeds uncompressedSize
+  /// multiplied by this ratio. Currently only Zstrong/MetaInternal enforces
+  /// this through CompressionPolicy::shouldAccept().
+  /// TODO: Apply this consistently for Zstd and other compression types.
+  float compressionAcceptRatio = 0.98f;
+#ifndef DISABLE_META_INTERNAL_COMPRESSOR
+  CompressionType compressionType = CompressionType::MetaInternal;
+#else
+  CompressionType compressionType = CompressionType::Zstd;
+#endif
+  uint64_t zstdMinCompressionSize = kZstdMinCompressionSize;
+  uint32_t zstdCompressionLevel = 3;
+  uint64_t lz4MinCompressionSize = kLz4MinCompressionSize;
+  uint32_t lz4AccelerationLevel = 1;
+  uint64_t internalMinCompressionSize = kMetaInternalMinCompressionSize;
+  uint32_t internalCompressionLevel = 4;
+  uint32_t internalDecompressionLevel = 2;
+  bool useVariableBitWidthCompressor = false;
+  MetaInternalCompressionKey metaInternalCompressionKey;
+  uint64_t openzlMinCompressionSize = kOpenZLMinCompressionSize;
+  int32_t openzlCompressionLevel = 6;
+  int32_t openzlDecompressionLevel = 3;
+  int32_t openzlFormatVersion = 25;
+  /// Per-encoding overrides for compressionAcceptRatio.
+  /// BlockBitPacking default 0.7: data is already well-packed via per-block
+  /// baselines, so compression must save at least 30% to justify CPU cost.
+  std::vector<std::pair<EncodingType, float>> compressionAcceptRatioOverrides =
+      {{EncodingType::BlockBitPacking, 0.7f}};
+};
+
 class CompressionPolicy {
  public:
-  virtual CompressionInformation compression() const = 0;
+  virtual CompressionConfig config() const = 0;
   virtual bool shouldAccept(
       CompressionType /* compressionType */,
       uint64_t /* uncompressedSize */,
@@ -124,7 +158,7 @@ class CompressionPolicy {
 /// provided) is to not compress.
 class NoCompressionPolicy : public CompressionPolicy {
  public:
-  CompressionInformation compression() const override {
+  CompressionConfig config() const override {
     return {.compressionType = CompressionType::Uncompressed};
   }
 
@@ -134,6 +168,50 @@ class NoCompressionPolicy : public CompressionPolicy {
       uint64_t /* compressedSize */) const override {
     return false;
   }
+};
+
+/// Compression policy backed by CompressionOptions.
+/// Requests the configured compression type and uses
+/// CompressionOptions::compressionAcceptRatio to decide whether to keep the
+/// compressed result.
+class ConfiguredCompressionPolicy : public CompressionPolicy {
+ public:
+  ConfiguredCompressionPolicy(
+      CompressionOptions compressionOptions,
+      EncodingType encodingType);
+
+  CompressionConfig config() const override;
+
+  virtual bool shouldAccept(
+      CompressionType compressionType,
+      uint64_t uncompressedSize,
+      uint64_t compressedSize) const override;
+
+ private:
+  float getAcceptRatio(EncodingType encodingType) const;
+
+  const CompressionOptions compressionOptions_;
+  const float effectiveAcceptRatio_;
+};
+
+/// Compression policy for replaying an encoding layout's captured compression
+/// type while using current CompressionOptions parameters.
+class ReplayedCompressionPolicy : public CompressionPolicy {
+ public:
+  ReplayedCompressionPolicy(
+      CompressionType compressionType,
+      CompressionOptions compressionOptions);
+
+  CompressionConfig config() const override;
+
+  virtual bool shouldAccept(
+      CompressionType compressionType,
+      uint64_t uncompressedSize,
+      uint64_t compressedSize) const override;
+
+ private:
+  const CompressionType compressionType_;
+  const CompressionOptions compressionOptions_;
 };
 
 } // namespace facebook::nimble

--- a/dwio/nimble/compression/Lz4Compressor.cpp
+++ b/dwio/nimble/compression/Lz4Compressor.cpp
@@ -27,7 +27,7 @@ CompressionResult Lz4Compressor::compress(
     DataType /* dataType */,
     int /* bitWidth */,
     const CompressionPolicy& compressionPolicy) {
-  auto parameters = compressionPolicy.compression().parameters.lz4;
+  auto parameters = compressionPolicy.config().parameters.lz4;
   Vector<char> buffer{&memoryPool, data.size() + sizeof(uint32_t)};
   auto pos = buffer.data();
   encoding::writeUint32(data.size(), pos);

--- a/dwio/nimble/compression/OpenZLCompressor.cpp
+++ b/dwio/nimble/compression/OpenZLCompressor.cpp
@@ -349,7 +349,7 @@ CompressionResult OpenZLCompressor::compress(
     DataType dataType,
     int /* bitWidth */,
     const CompressionPolicy& compressionPolicy) {
-  const auto parameters = compressionPolicy.compression().parameters.openzl;
+  const auto parameters = compressionPolicy.config().parameters.openzl;
 
   openzl::Compressor compressor;
   compressor.selectStartingGraph(

--- a/dwio/nimble/compression/ZstdCompressor.cpp
+++ b/dwio/nimble/compression/ZstdCompressor.cpp
@@ -29,7 +29,7 @@ CompressionResult ZstdCompressor::compress(
     DataType dataType,
     int /* bitWidth */,
     const CompressionPolicy& compressionPolicy) {
-  auto parameters = compressionPolicy.compression().parameters.zstd;
+  auto parameters = compressionPolicy.config().parameters.zstd;
   Vector<char> buffer{&pool, data.size() + sizeof(uint32_t)};
   auto pos = buffer.data();
   encoding::writeUint32(data.size(), pos);

--- a/dwio/nimble/docs/architecture/encoding_cost_model.html
+++ b/dwio/nimble/docs/architecture/encoding_cost_model.html
@@ -289,9 +289,9 @@ code {
       <div class="step-label">Encoding selection</div>
       <h3>EncodingSelectionPolicy::select(values, statistics)</h3>
       <div class="formula" style="text-align:left">
-        hasPerBlockEncoding = any_of(readFactors_, == BlockBitPacking);<br>
+        hasPerBlockEncoding = any_of(encodingReadFactors_, == BlockBitPacking);<br>
         <br>
-        for (const auto&amp; [encodingType, readFactor] : readFactors_) {<br>
+        for (const auto&amp; [encodingType, readFactor] : encodingReadFactors_) {<br>
         &nbsp;&nbsp;estimatedSize = EncodingSizeEstimation::estimateSize(encodingType, count, statistics, hasPerBlockEncoding);<br>
         &nbsp;&nbsp;<span class="comment">// dispatches by type:</span><br>
         &nbsp;&nbsp;<span class="comment">//   numeric → estimateNumericSize()</span><br>

--- a/dwio/nimble/docs/architecture/encoding_options_flow.html
+++ b/dwio/nimble/docs/architecture/encoding_options_flow.html
@@ -268,7 +268,7 @@ code { font-family:'JetBrains Mono',monospace; font-size:0.6rem; background:colo
   <div style="text-align:left;margin-top:0.5rem;border:1.5px solid color-mix(in srgb, var(--hl) 30%, var(--border));border-radius:6px;padding:0.35rem 0.5rem;background:color-mix(in srgb, var(--hl) 5%, var(--surface))">
     <div class="d" style="color:var(--hl);font-weight:700;font-size:0.6rem;margin-bottom:0.15rem">Encoding</div>
     <div class="d" style="text-align:left;line-height:1.7">
-      <span style="color:#1d4ed8;font-weight:600">encodingSelectionPolicyFactory</span> &larr; opaque lambda<br>
+      <span style="color:#1d4ed8;font-weight:600">encodingSelectionPolicyCreator</span> &larr; opaque lambda<br>
       &nbsp;&nbsp;&#9500; <span style="color:#1d4ed8">readFactors</span> <span style="color:var(--muted)">(which encodings to try + weights)</span><br>
       &nbsp;&nbsp;&#9492; <span style="color:#1d4ed8">compressionOptions</span> <span style="color:var(--muted)">(codec, levels, accept ratio)</span><br>
       <span style="color:#2563eb;font-weight:600">blockBitPackingBlockSize</span> + <span style="color:#2563eb">buildEncodingOptions()</span> <span style="color:var(--muted)">&rarr; Encoding::Options</span><br>
@@ -378,7 +378,7 @@ code { font-family:'JetBrains Mono',monospace; font-size:0.6rem; background:colo
 <div class="ar"><div class="a"></div></div>
 <div class="node" style="border-color:color-mix(in srgb, var(--hl) 30%, var(--border));background:color-mix(in srgb, var(--hl) 5%, var(--surface))">
   <h3>select(values, stats, <span style="color:#2563eb">options</span>)</h3>
-  <div class="d">readFactors_ from policy + <span style="color:#2563eb;font-weight:600">blockSize</span> from <span style="color:#2563eb">options</span> <span style="color:var(--warm);font-weight:600">(new)</span> &rarr; EncodingCandidates &rarr; estimation</div>
+  <div class="d">encodingReadFactors_ from policy + <span style="color:#2563eb;font-weight:600">blockSize</span> from <span style="color:#2563eb">options</span> <span style="color:var(--warm);font-weight:600">(new)</span> &rarr; EncodingCandidates &rarr; estimation</div>
   <div class="d">picks best encoding &rarr; returns EncodingSelectionResult{BBP, comprFactory}</div>
 </div>
 

--- a/dwio/nimble/encodings/ADDING_NEW_ENCODING.md
+++ b/dwio/nimble/encodings/ADDING_NEW_ENCODING.md
@@ -235,14 +235,14 @@ case EncodingType::MyEncoding: {
 
 ### Step 7: Enable in Encoding Selection Policy
 
-**File:** `dwio/nimble/encodings/selection/EncodingSelectionPolicy.h`
+**File:** `dwio/nimble/encodings/selection/EncodingSelectionPolicy.cpp`
 
 Add the encoding to `ManualEncodingSelectionPolicyFactory`:
 
-1. **`defaultReadFactors()`** — add the encoding with a read cost factor (1.0 = baseline, lower = preferred):
+1. **`defaultEncodingReadFactors()`** — add the encoding with a read cost factor (1.0 = baseline, lower = preferred) if it should be selected by default:
 
 ```cpp
-static std::vector<std::pair<EncodingType, float>> defaultReadFactors() {
+static std::vector<std::pair<EncodingType, float>> defaultEncodingReadFactors() {
   return {
       // ... existing ...
       {EncodingType::MyEncoding, 1.0},
@@ -250,7 +250,7 @@ static std::vector<std::pair<EncodingType, float>> defaultReadFactors() {
 }
 ```
 
-2. **`possibleEncodings()`** — add the encoding type:
+2. **`possibleEncodings()`** — add the encoding type if it should be accepted in `parseEncodingReadFactors()` runtime config:
 
 ```cpp
 static std::vector<EncodingType> possibleEncodings() {
@@ -351,14 +351,14 @@ Once an encoding is registered in the factory (Steps 4-5), it can always **decod
 
 ### Encoding Selection Candidates (Default Behavior)
 
-The `ManualEncodingSelectionPolicyFactory` in `encodings/selection/EncodingSelectionPolicy.h` controls which encodings are candidates during write. Two lists define the defaults:
+The `ManualEncodingSelectionPolicyFactory` in `encodings/selection/EncodingSelectionPolicy.cpp` controls which encodings are candidates during write. Two lists control the candidate surface:
 
-- **`defaultReadFactors()`** — encoding + cost weight pairs. Only encodings in this list are considered. A lower read factor makes an encoding more favorable.
-- **`possibleEncodings()`** — parallel list used for string-based config parsing.
+- **`defaultEncodingReadFactors()`** — encoding + cost weight pairs. Only encodings in this list are considered. A lower read factor makes an encoding more favorable.
+- **`possibleEncodings()`** — private list used for string-based config parsing.
 
-**To disable an encoding globally:** Remove it from both `defaultReadFactors()` and `possibleEncodings()`. The encoding still works for decoding existing data — only new writes stop using it.
+**To disable an encoding globally:** Remove it from `defaultEncodingReadFactors()`. The encoding still works for decoding existing data — only new writes stop using it by default.
 
-**To enable a previously disabled encoding:** Add it back to both lists. For example, `Delta` and `Prefix` are registered in the factory but intentionally absent from the default candidates — they are special-purpose encodings triggered explicitly.
+**To make an encoding configurable but not default:** Keep it in `possibleEncodings()` and leave it out of `defaultEncodingReadFactors()`. For example, `Delta`, `Prefix`, and experimental encodings can be triggered explicitly without being selected by default.
 
 ### Custom Read Factors at Write Time
 
@@ -369,7 +369,7 @@ The `ManualEncodingSelectionPolicyFactory` constructor accepts custom read facto
 ManualEncodingSelectionPolicyFactory factory{
     {{EncodingType::Trivial, 1.0}, {EncodingType::RLE, 0.5}}};
 
-writerOptions.encodingSelectionPolicyFactory =
+writerOptions.encodingSelectionPolicyCreator =
     [factory](DataType dataType) {
       return factory.createPolicy(dataType);
     };
@@ -379,10 +379,10 @@ Encodings not in the provided list are excluded from selection. This is the prim
 
 ### String-Based Configuration (Parseable Read Factors)
 
-`ManualEncodingSelectionPolicyFactory::parseReadFactors()` parses a semicolon-delimited string of `EncodingType=factor` pairs:
+`ManualEncodingSelectionPolicyFactory::parseEncodingReadFactors()` parses a semicolon-delimited string of `EncodingType=factor` pairs:
 
 ```cpp
-auto factors = ManualEncodingSelectionPolicyFactory::parseReadFactors(
+auto factors = ManualEncodingSelectionPolicyFactory::parseEncodingReadFactors(
     "Trivial=0.7;RLE=1.0;Dictionary=1.0");
 ManualEncodingSelectionPolicyFactory factory{factors};
 ```
@@ -411,10 +411,10 @@ When an `EncodingLayoutTree` is set, the writer uses the specified encodings dir
 
 ### Custom Encoding Selection Policy
 
-For full control, implement a custom `EncodingSelectionPolicy<T>` and wire it through `VeloxWriterOptions::encodingSelectionPolicyFactory`:
+For full control, implement a custom `EncodingSelectionPolicy<T>` and wire it through `VeloxWriterOptions::encodingSelectionPolicyCreator`:
 
 ```cpp
-writerOptions.encodingSelectionPolicyFactory =
+writerOptions.encodingSelectionPolicyCreator =
     [](DataType dataType) -> std::unique_ptr<EncodingSelectionPolicyBase> {
   // Return a custom policy that implements select() and selectNullable()
   UNIQUE_PTR_FACTORY(dataType, MyCustomPolicy);
@@ -427,11 +427,11 @@ The custom policy's `select()` method receives data statistics and returns an `E
 
 | Layer | Scope | How |
 |-------|-------|-----|
-| Library defaults | All writers | Edit `defaultReadFactors()` / `possibleEncodings()` in `EncodingSelectionPolicy.h` |
+| Library defaults | All writers | Edit `defaultEncodingReadFactors()` in `EncodingSelectionPolicy.cpp` |
 | Per-writer read factors | Single writer | Pass custom read factors to `ManualEncodingSelectionPolicyFactory` constructor |
-| Runtime config string | Single writer | Use `parseReadFactors("Trivial=0.7;RLE=1.0")` from flags/config |
+| Runtime config string | Single writer | Use `parseEncodingReadFactors("Trivial=0.7;RLE=1.0")` from flags/config |
 | Encoding layout tree | Per-stream | Set `writerOptions.encodingLayoutTree` to force specific encodings |
-| Custom policy | Single writer | Implement `EncodingSelectionPolicy<T>` and set `encodingSelectionPolicyFactory` |
+| Custom policy | Single writer | Implement `EncodingSelectionPolicy<T>` and set `encodingSelectionPolicyCreator` |
 
 **Important:** Disabling an encoding at the selection layer only affects **writes**. The read path (`EncodingFactory::create()`) always supports all registered encodings, ensuring backward compatibility with existing files.
 

--- a/dwio/nimble/encodings/CMakeLists.txt
+++ b/dwio/nimble/encodings/CMakeLists.txt
@@ -18,6 +18,7 @@ add_subdirectory(legacy)
 add_library(
   nimble_encodings
   ConstantEncoding.cpp
+  FsstEncoding.cpp
   MainlyConstantEncoding.cpp
   PrefixEncoding.cpp
   RLEEncoding.cpp
@@ -26,8 +27,16 @@ add_library(
   common/Encoding.cpp
   common/EncodingFactory.cpp
   common/EncodingLayout.cpp
+  selection/EncodingSelectionPolicy.cpp
   selection/Statistics.cpp
 )
+
+set(FSST_SOURCE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/../../../third-party/fsst")
+if(NOT TARGET fsst AND EXISTS "${FSST_SOURCE_DIR}/CMakeLists.txt")
+  add_subdirectory("${FSST_SOURCE_DIR}" "${CMAKE_CURRENT_BINARY_DIR}/fsst")
+endif()
+
+target_include_directories(nimble_encodings PUBLIC "${FSST_SOURCE_DIR}")
 
 target_link_libraries(
   nimble_encodings
@@ -35,6 +44,7 @@ target_link_libraries(
   nimble_common
   velox_common_base
   velox_fastpforlib
+  fsst
   Folly::folly
   absl::flat_hash_map
   protobuf::libprotobuf

--- a/dwio/nimble/encodings/FsstEncoding.cpp
+++ b/dwio/nimble/encodings/FsstEncoding.cpp
@@ -1,0 +1,435 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "dwio/nimble/encodings/FsstEncoding.h"
+
+#include <cmath>
+#include <memory>
+#include <numeric>
+
+#include "dwio/nimble/encodings/FixedBitWidthEncoding.h"
+#include "dwio/nimble/encodings/TrivialEncoding.h"
+#include "dwio/nimble/encodings/common/EncodingFactory.h"
+#include "dwio/nimble/encodings/common/EncodingPrimitives.h"
+#include "folly/ScopeGuard.h"
+
+namespace facebook::nimble {
+
+namespace {
+
+// Forwards compression decisions to the shared parent policy.
+class DelegatingCompressionPolicy final : public CompressionPolicy {
+ public:
+  explicit DelegatingCompressionPolicy(
+      std::shared_ptr<CompressionPolicy> policy)
+      : policy_{std::move(policy)} {}
+
+  CompressionConfig config() const override {
+    return policy_->config();
+  }
+
+  bool shouldAccept(
+      CompressionType compressionType,
+      uint64_t uncompressedSize,
+      uint64_t compressedSize) const override {
+    return policy_->shouldAccept(
+        compressionType, uncompressedSize, compressedSize);
+  }
+
+ private:
+  std::shared_ptr<CompressionPolicy> policy_;
+};
+
+class TrivialFallbackSelectionPolicy final
+    : public EncodingSelectionPolicy<std::string_view> {
+ public:
+  TrivialFallbackSelectionPolicy(
+      EncodingSelection<std::string_view>& parentSelection,
+      std::shared_ptr<CompressionPolicy> compressionPolicy)
+      : parentSelection_{parentSelection},
+        compressionPolicy_{std::move(compressionPolicy)} {}
+
+  EncodingSelectionResult select(
+      std::span<const std::string_view> /* values */,
+      const Statistics<std::string_view>& /* statistics */,
+      const Encoding::Options& /* options */ = {}) override {
+    return trivialSelectionResult();
+  }
+
+  EncodingSelectionResult selectNullable(
+      std::span<const std::string_view> /* values */,
+      std::span<const bool> /* nulls */,
+      const Statistics<std::string_view>& /* statistics */,
+      const Encoding::Options& /* options */ = {}) override {
+    NIMBLE_UNSUPPORTED("Nullable FSST fallback is not supported.");
+  }
+
+ private:
+  EncodingSelectionResult trivialSelectionResult() const {
+    return {
+        .encodingType = EncodingType::Trivial,
+        .compressionPolicyFactory = [compressionPolicy = compressionPolicy_]() {
+          return std::make_unique<DelegatingCompressionPolicy>(
+              compressionPolicy);
+        }};
+  }
+
+  std::unique_ptr<EncodingSelectionPolicyBase> createImpl(
+      EncodingType parentEncodingType,
+      NestedEncodingIdentifier nestedEncodingIdentifier,
+      DataType nestedDataType) override {
+    NIMBLE_CHECK_EQ(
+        parentEncodingType,
+        EncodingType::Trivial,
+        "FSST fallback only supports Trivial nested encodings.");
+    NIMBLE_CHECK_EQ(
+        nestedDataType,
+        DataType::Uint32,
+        "Trivial string fallback only supports uint32 length encodings.");
+    return parentSelection_.template createNestedPolicy<uint32_t>(
+        EncodingType::Trivial, nestedEncodingIdentifier);
+  }
+
+  EncodingSelection<std::string_view>& parentSelection_;
+  std::shared_ptr<CompressionPolicy> compressionPolicy_;
+};
+
+size_t sumLengths(std::span<const size_t> lengths) {
+  return std::accumulate(lengths.begin(), lengths.end(), size_t{0});
+}
+
+} // namespace
+
+FsstEncoding::CompressedValues::CompressedValues(
+    velox::memory::MemoryPool* pool)
+    : compressedBuffer{pool}, compressedLengths{pool}, compressedPtrs{pool} {}
+
+FsstEncoding::Header FsstEncoding::parseHeader(const char* pos) {
+  Header header{};
+  header.symbolTableSize = encoding::readUint32(pos);
+  header.symbolTable = pos;
+  pos += header.symbolTableSize;
+  header.lengthsSize = encoding::readUint32(pos);
+  header.lengths = pos;
+  header.blob = pos + header.lengthsSize;
+  return header;
+}
+
+FsstEncoding::CompressedValues FsstEncoding::compressValues(
+    std::span<const physicalType> values,
+    velox::memory::MemoryPool* pool) {
+  NIMBLE_CHECK_NOT_NULL(pool, "Memory pool cannot be null.");
+  const auto valueCount = static_cast<uint32_t>(values.size());
+  CompressedValues result{pool};
+
+  Vector<size_t> inputLengths{pool, valueCount};
+  Vector<const unsigned char*> inputPtrs{pool, valueCount};
+  for (uint32_t i = 0; i < valueCount; ++i) {
+    inputLengths[i] = values[i].size();
+    inputPtrs[i] = reinterpret_cast<const unsigned char*>(values[i].data());
+  }
+  result.totalInputSize =
+      sumLengths({inputLengths.data(), inputLengths.size()});
+
+  auto* encoder = nimble_fsst_create(
+      valueCount,
+      inputLengths.data(),
+      inputPtrs.data(),
+      /*zeroTerminated=*/0);
+  NIMBLE_CHECK_NOT_NULL(encoder, "FSST encoder creation failed.");
+  SCOPE_EXIT {
+    nimble_fsst_destroy(encoder);
+  };
+
+  // fsst_export only takes a raw pointer, so the caller must provide the
+  // library-defined maximum header capacity.
+  result.symbolTableBuffer =
+      velox::AlignedBuffer::allocate<unsigned char>(FSST_MAXHEADER, pool);
+  result.symbolTableData = result.symbolTableBuffer->asMutable<unsigned char>();
+  result.symbolTableSize = nimble_fsst_export(encoder, result.symbolTableData);
+  NIMBLE_CHECK_LE(
+      result.symbolTableSize,
+      static_cast<size_t>(FSST_MAXHEADER),
+      "FSST exported symbol table exceeded FSST_MAXHEADER.");
+
+  // FSST's documented conservative compression output bound.
+  const size_t outputBufSize = 7 + 2 * result.totalInputSize;
+  result.compressedBuffer.resize(outputBufSize);
+  result.compressedLengths.resize(valueCount);
+  result.compressedPtrs.resize(valueCount);
+
+  const auto numCompressed = nimble_fsst_compress(
+      encoder,
+      valueCount,
+      inputLengths.data(),
+      inputPtrs.data(),
+      outputBufSize,
+      result.compressedBuffer.data(),
+      result.compressedLengths.data(),
+      result.compressedPtrs.data());
+  NIMBLE_CHECK_EQ(
+      static_cast<uint32_t>(numCompressed),
+      valueCount,
+      "FSST compression did not compress all strings.");
+
+  result.totalCompressedSize = sumLengths(
+      {result.compressedLengths.data(), result.compressedLengths.size()});
+  return result;
+}
+
+bool FsstEncoding::meetsCompressionTarget(
+    uint64_t uncompressedSize,
+    uint64_t encodedSize,
+    double compressionTargetRatio) {
+  return encodedSize <= uncompressedSize * compressionTargetRatio;
+}
+
+std::string_view FsstEncoding::encodeCompressedLengths(
+    EncodingSelection<physicalType>& selection,
+    std::span<const size_t> compressedLengths,
+    Buffer& buffer,
+    const Encoding::Options& options) {
+  Vector<uint32_t> lengths{&buffer.getMemoryPool(), compressedLengths.size()};
+  for (size_t i = 0; i < compressedLengths.size(); ++i) {
+    lengths[i] = static_cast<uint32_t>(compressedLengths[i]);
+  }
+
+  return selection.template encodeNested<uint32_t>(
+      EncodingIdentifiers::Fsst::Lengths, {lengths}, buffer, options);
+}
+
+std::string_view FsstEncoding::encodeTrivialFallback(
+    EncodingSelection<physicalType>& selection,
+    std::span<const physicalType> values,
+    Buffer& buffer,
+    const Encoding::Options& options) {
+  auto compressionPolicy = std::shared_ptr<CompressionPolicy>(
+      selection.compressionPolicy().release());
+
+  auto fallbackPolicy = std::make_unique<TrivialFallbackSelectionPolicy>(
+      selection, compressionPolicy);
+  EncodingSelection<std::string_view> fallbackSelection{
+      fallbackPolicy->select(values, selection.statistics()),
+      Statistics<std::string_view>{selection.statistics()},
+      std::move(fallbackPolicy)};
+  return TrivialEncoding<std::string_view>::encode(
+      fallbackSelection, values, buffer, options);
+}
+
+FsstEncoding::FsstEncoding(
+    velox::memory::MemoryPool& pool,
+    std::string_view data,
+    std::function<void*(uint32_t)> stringBufferFactory,
+    const Encoding::Options& options)
+    : TypedEncoding<std::string_view, std::string_view>{pool, data, options},
+      stringBufferFactory_{std::move(stringBufferFactory)},
+      lengthBuffer_{&pool},
+      decompressBuffer_{&pool} {
+  const auto header = parseHeader(data.data() + this->dataOffset());
+  NIMBLE_CHECK_GT(
+      header.symbolTableSize, 0, "FSST symbol table size must be positive.");
+  const auto bytesConsumed = nimble_fsst_import(
+      &decoder_,
+      const_cast<unsigned char*>(
+          reinterpret_cast<const unsigned char*>(header.symbolTable)));
+  NIMBLE_CHECK_EQ(
+      static_cast<uint32_t>(bytesConsumed),
+      header.symbolTableSize,
+      "FSST symbol table import size mismatch.");
+
+  lengths_ = EncodingFactory(options).create(
+      pool, {header.lengths, header.lengthsSize}, stringBufferFactory_);
+  blob_ = header.blob;
+  pos_ = blob_;
+}
+
+std::string_view FsstEncoding::lengthsEncoding(
+    std::string_view encoding,
+    const Encoding::Options& options) {
+  NIMBLE_CHECK_GE(
+      encoding.size(),
+      EncodingPrefix::kRowCountOffset,
+      "FSST encoding too small.");
+  NIMBLE_CHECK_EQ(
+      static_cast<EncodingType>(encoding[EncodingPrefix::kEncodingTypeOffset]),
+      EncodingType::Fsst,
+      "Expected FSST encoding.");
+
+  const auto prefixSize = readPrefixSize(encoding, options.useVarintRowCount);
+  NIMBLE_CHECK_GE(encoding.size(), prefixSize, "FSST encoding too small.");
+  const auto header = parseHeader(encoding.data() + prefixSize);
+  return {header.lengths, header.lengthsSize};
+}
+
+void FsstEncoding::captureNestedEncoding(
+    std::string_view encoding,
+    std::vector<std::optional<const EncodingLayout>>& children,
+    const Encoding::Options& options) {
+  children.reserve(1);
+  children.emplace_back(
+      EncodingLayoutCapture::capture(lengthsEncoding(encoding, options)));
+}
+
+void FsstEncoding::reset() {
+  row_ = 0;
+  pos_ = blob_;
+  lengths_->reset();
+}
+
+void FsstEncoding::skip(uint32_t rowCount) {
+  lengthBuffer_.resize(rowCount);
+  lengths_->materialize(rowCount, lengthBuffer_.data());
+  row_ += rowCount;
+  pos_ +=
+      std::accumulate(lengthBuffer_.begin(), lengthBuffer_.end(), uint64_t{0});
+}
+
+void FsstEncoding::materialize(uint32_t rowCount, void* buffer) {
+  lengthBuffer_.resize(rowCount);
+  lengths_->materialize(rowCount, lengthBuffer_.data());
+
+  auto* output = static_cast<std::string_view*>(buffer);
+  for (uint32_t i = 0; i < rowCount; ++i) {
+    const auto compressedLen = lengthBuffer_[i];
+    output[i] = decompressToStringBuffer(pos_, compressedLen);
+    pos_ += compressedLen;
+  }
+  row_ += rowCount;
+}
+
+std::string_view FsstEncoding::decompressToStringBuffer(
+    const char* compressedData,
+    uint32_t compressedLength) {
+  if (compressedLength == 0) {
+    return {};
+  }
+
+  const size_t maxDecompressedSize =
+      static_cast<size_t>(compressedLength) * kMaxSymbolLength;
+  decompressBuffer_.resize(maxDecompressedSize);
+
+  const auto decompressedSize = nimble_fsst_decompress(
+      &decoder_,
+      compressedLength,
+      reinterpret_cast<const unsigned char*>(compressedData),
+      maxDecompressedSize,
+      reinterpret_cast<unsigned char*>(decompressBuffer_.data()));
+
+  NIMBLE_CHECK_GT(
+      decompressedSize,
+      0,
+      "FSST decompression failed for non-empty compressed string.");
+
+  if (pageCapacityBytes_ - pageUsedBytes_ < decompressedSize) {
+    allocatePage(std::max(kStringPageSize, decompressedSize));
+  }
+
+  std::memcpy(
+      currentPage_ + pageUsedBytes_,
+      decompressBuffer_.data(),
+      decompressedSize);
+  std::string_view result(currentPage_ + pageUsedBytes_, decompressedSize);
+  pageUsedBytes_ += decompressedSize;
+  return result;
+}
+
+void FsstEncoding::allocatePage(size_t minSize) {
+  currentPage_ = static_cast<char*>(stringBufferFactory_(minSize));
+  pageCapacityBytes_ = minSize;
+  pageUsedBytes_ = 0;
+}
+
+std::string_view FsstEncoding::encode(
+    EncodingSelection<physicalType>& selection,
+    std::span<const physicalType> values,
+    Buffer& buffer,
+    const Encoding::Options& options) {
+  {
+    auto compressedValues = compressValues(values, &buffer.getMemoryPool());
+
+    Buffer lengthsBuffer{buffer.getMemoryPool()};
+    const std::string_view serializedLengths = encodeCompressedLengths(
+        selection,
+        {compressedValues.compressedLengths.data(),
+         compressedValues.compressedLengths.size()},
+        lengthsBuffer,
+        options);
+
+    const bool useVarint = options.useVarintRowCount;
+    const auto valueCount = static_cast<uint32_t>(values.size());
+    const uint32_t encodingSize =
+        Encoding::serializePrefixSize(valueCount, useVarint) +
+        4 /* symbolTableSize */ + compressedValues.symbolTableSize +
+        4 /* lengthsSize */ + serializedLengths.size() +
+        compressedValues.totalCompressedSize;
+
+    if (meetsCompressionTarget(
+            compressedValues.totalInputSize,
+            encodingSize,
+            options.fsstCompressionTargetRatio)) {
+      Buffer fsstBuffer{buffer.getMemoryPool()};
+      char* reserved = fsstBuffer.reserve(encodingSize);
+      char* pos = reserved;
+      Encoding::serializePrefix(
+          EncodingType::Fsst, DataType::String, valueCount, useVarint, pos);
+      encoding::writeUint32(compressedValues.symbolTableSize, pos);
+      std::memcpy(
+          pos,
+          compressedValues.symbolTableData,
+          compressedValues.symbolTableSize);
+      pos += compressedValues.symbolTableSize;
+      encoding::writeUint32(serializedLengths.size(), pos);
+      encoding::writeBytes(serializedLengths, pos);
+      for (uint32_t i = 0; i < valueCount; ++i) {
+        std::memcpy(
+            pos,
+            compressedValues.compressedPtrs[i],
+            compressedValues.compressedLengths[i]);
+        pos += compressedValues.compressedLengths[i];
+      }
+
+      NIMBLE_CHECK_EQ(pos - reserved, encodingSize, "Encoding size mismatch.");
+      std::string_view fsstEncoded{reserved, encodingSize};
+      return buffer.writeString(fsstEncoded);
+    }
+  }
+
+  Buffer trivialBuffer{buffer.getMemoryPool()};
+  return buffer.writeString(
+      encodeTrivialFallback(selection, values, trivialBuffer, options));
+}
+
+uint64_t FsstEncoding::estimateSize(
+    uint64_t rowCount,
+    const Statistics<std::string_view>& statistics,
+    bool fixedByteWidth,
+    double compressionTargetRatio) {
+  const uint64_t estimatedBlobSize = static_cast<uint64_t>(
+      statistics.totalStringsLength() * compressionTargetRatio);
+  const uint64_t estimatedMaxCompressedLength = static_cast<uint64_t>(
+      std::ceil(statistics.max().size() * compressionTargetRatio));
+  const uint64_t estimatedLengthsSize =
+      FixedBitWidthEncoding<uint32_t>::estimateSize(
+          rowCount, 0, estimatedMaxCompressedLength, fixedByteWidth);
+  return kSymbolTableOverhead + estimatedBlobSize + estimatedLengthsSize +
+      EncodingPrefix::kFixedPrefixSize;
+}
+
+std::string FsstEncoding::debugString(int offset) const {
+  return fmt::format(
+      "{}FsstEncoding: {} rows", std::string(offset, ' '), rowCount());
+}
+
+} // namespace facebook::nimble

--- a/dwio/nimble/encodings/FsstEncoding.h
+++ b/dwio/nimble/encodings/FsstEncoding.h
@@ -1,0 +1,264 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <optional>
+#include <span>
+
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wimplicit-fallthrough"
+#pragma push_macro("fsst_create")
+#pragma push_macro("fsst_duplicate")
+#pragma push_macro("fsst_export")
+#pragma push_macro("fsst_destroy")
+#pragma push_macro("fsst_import")
+#pragma push_macro("fsst_decoder")
+#pragma push_macro("fsst_compress")
+#pragma push_macro("fsst_decompress")
+#define fsst_create nimble_fsst_create
+#define fsst_duplicate nimble_fsst_duplicate
+#define fsst_export nimble_fsst_export
+#define fsst_destroy nimble_fsst_destroy
+#define fsst_import nimble_fsst_import
+#define fsst_decoder nimble_fsst_decoder
+#define fsst_compress nimble_fsst_compress
+#define fsst_decompress nimble_fsst_decompress
+#include <fsst.h>
+#pragma pop_macro("fsst_decompress")
+#pragma pop_macro("fsst_compress")
+#pragma pop_macro("fsst_decoder")
+#pragma pop_macro("fsst_import")
+#pragma pop_macro("fsst_destroy")
+#pragma pop_macro("fsst_export")
+#pragma pop_macro("fsst_duplicate")
+#pragma pop_macro("fsst_create")
+#pragma clang diagnostic pop
+
+#include "dwio/nimble/common/Buffer.h"
+#include "dwio/nimble/common/Types.h"
+#include "dwio/nimble/common/Vector.h"
+#include "dwio/nimble/encodings/common/Encoding.h"
+#include "dwio/nimble/encodings/common/EncodingFactory.h"
+#include "dwio/nimble/encodings/common/EncodingLayout.h"
+#include "dwio/nimble/encodings/common/EncodingType.h"
+#include "dwio/nimble/encodings/selection/EncodingIdentifier.h"
+#include "dwio/nimble/encodings/selection/EncodingSelection.h"
+#include "velox/common/memory/Memory.h"
+
+namespace facebook::nimble {
+
+/// Encoding for string data using FSST (Fast Static Symbol Table) compression.
+///
+/// FSST compresses strings by mapping frequent byte sequences (1-8 bytes) to
+/// single-byte codes via a trained symbol table. Each string is compressed
+/// independently, enabling random-access decompression without touching
+/// neighboring strings.
+///
+/// Binary layout:
+/// - Encoding::kPrefixSize bytes: standard Encoding prefix
+/// - 4 bytes: serialized FSST symbol table size
+/// - N bytes: serialized FSST symbol table (~2KB typical)
+/// - 4 bytes: lengths encoding size
+/// - M bytes: nested encoding of compressed string lengths
+/// - K bytes: compressed string blob (concatenated FSST-compressed strings)
+///
+/// Only supports std::string_view data type.
+class FsstEncoding final
+    : public TypedEncoding<std::string_view, std::string_view> {
+ public:
+  using cppDataType = std::string_view;
+  using physicalType = std::string_view;
+
+  FsstEncoding(
+      velox::memory::MemoryPool& pool,
+      std::string_view data,
+      std::function<void*(uint32_t)> stringBufferFactory,
+      const Encoding::Options& options = {});
+
+  void reset() final;
+  void skip(uint32_t rowCount) final;
+  void materialize(uint32_t rowCount, void* buffer) final;
+
+  template <typename DecoderVisitor>
+  void readWithVisitor(DecoderVisitor& visitor, ReadWithVisitorParams& params);
+
+  static std::string_view encode(
+      EncodingSelection<physicalType>& selection,
+      std::span<const physicalType> values,
+      Buffer& buffer,
+      const Encoding::Options& options = {});
+
+  /// Returns the estimated encoded size used by encoding selection.
+  static uint64_t estimateSize(
+      uint64_t rowCount,
+      const Statistics<std::string_view>& statistics,
+      bool fixedByteWidth,
+      double compressionTargetRatio);
+
+  /// Returns the nested compressed-lengths encoding from serialized FSST data.
+  static std::string_view lengthsEncoding(
+      std::string_view encoding,
+      const Encoding::Options& options = {});
+
+  /// Captures FSST's nested compressed-lengths encoding layout.
+  static void captureNestedEncoding(
+      std::string_view encoding,
+      std::vector<std::optional<const EncodingLayout>>& children,
+      const Encoding::Options& options = {});
+
+  std::string debugString(int offset) const final;
+
+ private:
+  // Approximate serialized symbol table size in bytes (~2KB typical).
+  static constexpr uint32_t kSymbolTableOverhead = 2048;
+
+  // Maximum bytes a compressed FSST code can expand to.
+  static constexpr size_t kMaxSymbolLength = 8;
+
+  static constexpr size_t kStringPageSize = 256 * 1024;
+
+  struct Header {
+    // Serialized FSST symbol table byte length.
+    uint32_t symbolTableSize;
+
+    // Start of the serialized FSST symbol table.
+    const char* symbolTable;
+
+    // Nested encoding byte length for per-row compressed string sizes.
+    uint32_t lengthsSize;
+
+    // Start of the nested compressed-lengths encoding.
+    const char* lengths;
+
+    // Start of the concatenated FSST-compressed string data.
+    const char* blob;
+  };
+
+  struct CompressedValues {
+    explicit CompressedValues(velox::memory::MemoryPool* pool);
+
+    // Serialized FSST symbol table buffer. Kept alive until final
+    // serialization.
+    velox::BufferPtr symbolTableBuffer;
+    unsigned char* symbolTableData{nullptr};
+    size_t symbolTableSize{0};
+
+    // Concatenated FSST output storage. compressedPtrs point into this buffer.
+    Vector<unsigned char> compressedBuffer;
+    Vector<size_t> compressedLengths;
+    Vector<unsigned char*> compressedPtrs;
+
+    size_t totalInputSize{0};
+    size_t totalCompressedSize{0};
+  };
+
+  // Parses the serialized FSST header after the encoding prefix.
+  static Header parseHeader(const char* pos);
+
+  // Trains FSST and compresses each input string independently.
+  static CompressedValues compressValues(
+      std::span<const physicalType> values,
+      velox::memory::MemoryPool* pool);
+
+  // Checks whether the final FSST encoding meets the compression target.
+  static bool meetsCompressionTarget(
+      uint64_t uncompressedSize,
+      uint64_t encodedSize,
+      double compressionTargetRatio);
+
+  // Encodes the per-row FSST-compressed lengths as the nested lengths stream.
+  static std::string_view encodeCompressedLengths(
+      EncodingSelection<physicalType>& selection,
+      std::span<const size_t> compressedLengths,
+      Buffer& buffer,
+      const Encoding::Options& options);
+
+  // Encodes the original values with TrivialEncoding after FSST misses its
+  // compression target.
+  static std::string_view encodeTrivialFallback(
+      EncodingSelection<physicalType>& selection,
+      std::span<const physicalType> values,
+      Buffer& buffer,
+      const Encoding::Options& options);
+
+  // Decompresses a single compressed string and copies the result into the
+  // string buffer page. Returns a stable string_view.
+  std::string_view decompressToStringBuffer(
+      const char* compressedData,
+      uint32_t compressedLength);
+
+  // Allocates a new string page of at least minSize bytes via
+  // stringBufferFactory_.
+  void allocatePage(size_t minSize);
+
+  const std::function<void*(uint32_t)> stringBufferFactory_;
+
+  // FSST decoder (symbol table for decompression).
+  fsst_decoder_t decoder_{};
+
+  // Nested encoding for compressed string lengths.
+  std::unique_ptr<Encoding> lengths_;
+
+  // Pointer into the compressed string blob.
+  const char* blob_;
+  const char* pos_;
+
+  // Current row index.
+  uint32_t row_{0};
+
+  // Scratch buffer for materializing lengths.
+  Vector<uint32_t> lengthBuffer_;
+
+  // Current string page for stable storage of decompressed values.
+  char* currentPage_{nullptr};
+  size_t pageCapacityBytes_{0};
+  size_t pageUsedBytes_{0};
+
+  // Scratch buffer for decompression output.
+  Vector<char> decompressBuffer_;
+};
+
+template <typename V>
+void FsstEncoding::readWithVisitor(V& visitor, ReadWithVisitorParams& params) {
+  // Pre-materialize all compressed lengths needed for this read.
+  const auto endRow = visitor.rowAt(visitor.numRows() - 1);
+  auto numSelected = endRow + 1 - params.numScanned;
+  if (auto& nulls = visitor.reader().nullsInReadRange()) {
+    numSelected -= velox::bits::countNulls(
+        nulls->template as<uint64_t>(), params.numScanned, endRow + 1);
+  }
+  lengthBuffer_.resize(numSelected);
+  lengths_->materialize(numSelected, lengthBuffer_.data());
+  auto* lengths = lengthBuffer_.data();
+
+  detail::readWithVisitorSlow(
+      visitor,
+      params,
+      [&](auto toSkip) {
+        row_ += toSkip;
+        pos_ += std::accumulate(lengths, lengths + toSkip, 0ull);
+        lengths += toSkip;
+      },
+      [&] {
+        const auto compressedLen = *lengths++;
+        auto result = decompressToStringBuffer(pos_, compressedLen);
+        ++row_;
+        pos_ += compressedLen;
+        return result;
+      });
+}
+
+} // namespace facebook::nimble

--- a/dwio/nimble/encodings/benchmarks/BenchmarkUtils.h
+++ b/dwio/nimble/encodings/benchmarks/BenchmarkUtils.h
@@ -181,7 +181,8 @@ inline Vector<bool> makeDenseBool(uint32_t n = kNumElements) {
 inline std::unique_ptr<EncodingSelectionPolicyBase> makeDefaultPolicy(
     DataType dataType) {
   static ManualEncodingSelectionPolicyFactory factory{
-      ManualEncodingSelectionPolicyFactory::defaultReadFactors(), std::nullopt};
+      ManualEncodingSelectionPolicyFactory::defaultEncodingReadFactors(),
+      std::nullopt};
   return factory.createPolicy(dataType);
 }
 

--- a/dwio/nimble/encodings/common/Encoding.h
+++ b/dwio/nimble/encodings/common/Encoding.h
@@ -142,6 +142,10 @@ class Encoding {
       return decodingStats != nullptr ? &decodingStats->decompressCPUTimeNanos
                                       : nullptr;
     }
+
+    /// FSST is kept only when its final encoded size is at most this fraction
+    /// of the original string bytes.
+    double fsstCompressionTargetRatio = 0.6;
   };
 
   static constexpr int kEncodingTypeOffset =

--- a/dwio/nimble/encodings/common/EncodingFactory.cpp
+++ b/dwio/nimble/encodings/common/EncodingFactory.cpp
@@ -25,6 +25,7 @@
 #include "dwio/nimble/encodings/ForEncoding.h"
 #include "dwio/nimble/encodings/FrequencyPartitionEncoding.h"
 */
+#include "dwio/nimble/encodings/FsstEncoding.h"
 #include "dwio/nimble/encodings/MainlyConstantEncoding.h"
 #include "dwio/nimble/encodings/NullableEncoding.h"
 #include "dwio/nimble/encodings/PFOREncoding.h"
@@ -286,6 +287,14 @@ std::unique_ptr<Encoding> EncodingFactory::create(
       return std::make_unique<PrefixEncoding>(
           pool, data, stringBufferFactory, options);
     }
+    case EncodingType::Fsst: {
+      NIMBLE_CHECK_EQ(
+          dataType,
+          DataType::String,
+          "Trying to deserialize a FsstEncoding with a non-string data type.");
+      return std::make_unique<FsstEncoding>(
+          pool, data, stringBufferFactory, options);
+    }
     case EncodingType::Delta: {
       RETURN_ENCODING_BY_NUMERIC_TYPE(DeltaEncoding, dataType);
     }
@@ -478,6 +487,14 @@ bool).");
             "Prefix encoding should only be selected for string_view data types.");
       } else {
         return PrefixEncoding::encode(selection, castedValues, buffer, options);
+      }
+    }
+    case EncodingType::Fsst: {
+      if constexpr (!std::is_same<T, std::string_view>::value) {
+        NIMBLE_INCOMPATIBLE_ENCODING(
+            "Fsst encoding should only be selected for string_view data types.");
+      } else {
+        return FsstEncoding::encode(selection, castedValues, buffer, options);
       }
     }
     case EncodingType::Delta: {

--- a/dwio/nimble/encodings/common/EncodingLayout.cpp
+++ b/dwio/nimble/encodings/common/EncodingLayout.cpp
@@ -22,6 +22,7 @@
 #include "dwio/nimble/common/Exceptions.h"
 // SubIntSplit integration commented out (disabled):
 // #include "dwio/nimble/encodings/SubIntSplitConfig.h"
+#include "dwio/nimble/encodings/FsstEncoding.h"
 #include "dwio/nimble/encodings/common/EncodingPrimitives.h"
 #include "dwio/nimble/encodings/common/EncodingUtils.h"
 
@@ -432,6 +433,10 @@ EncodingLayout EncodingLayoutCapture::capture(std::string_view encoding) {
         children.emplace_back(
             EncodingLayoutCapture::capture({pos, lengthsBytes}));
       }
+      break;
+    }
+    case EncodingType::Fsst: {
+      FsstEncoding::captureNestedEncoding(encoding, children);
       break;
     }
     case EncodingType::SparseBool: {

--- a/dwio/nimble/encodings/common/EncodingUtils.h
+++ b/dwio/nimble/encodings/common/EncodingUtils.h
@@ -26,6 +26,7 @@
 #include "dwio/nimble/encodings/ForEncoding.h"
 #include "dwio/nimble/encodings/FrequencyPartitionEncoding.h"
 */
+#include "dwio/nimble/encodings/FsstEncoding.h"
 #include "dwio/nimble/encodings/MainlyConstantEncoding.h"
 #include "dwio/nimble/encodings/NullableEncoding.h"
 #include "dwio/nimble/encodings/PFOREncoding.h"
@@ -94,6 +95,8 @@ auto encodingTypeDispatchString(Encoding& encoding, F f) {
           static_cast<MainlyConstantEncoding<std::string_view>&>(encoding));
     case EncodingType::Prefix:
       return f(static_cast<PrefixEncoding&>(encoding));
+    case EncodingType::Fsst:
+      return f(static_cast<FsstEncoding&>(encoding));
     default:
       NIMBLE_UNSUPPORTED("{}", encoding.encodingType());
   }

--- a/dwio/nimble/encodings/legacy/EncodingSelectionPolicy.h
+++ b/dwio/nimble/encodings/legacy/EncodingSelectionPolicy.h
@@ -15,7 +15,6 @@
  */
 #pragma once
 
-#include <glog/logging.h>
 #include <algorithm>
 #include <optional>
 #include <utility>
@@ -28,29 +27,8 @@
 
 namespace facebook::nimble::legacy {
 
-using EncodingSelectionPolicyFactory =
+using EncodingSelectionPolicyCreator =
     std::function<std::unique_ptr<EncodingSelectionPolicyBase>(DataType)>;
-
-// The following enables encoding selection debug messages. By default, these
-// logs are turned off (with zero overhead). In tests (or in debug sessions), we
-// enable these logs.
-#define RED "\033[31m"
-#define GREEN "\033[32m"
-#define YELLOW "\033[33m"
-#define BLUE "\033[34m"
-#define PURPLE "\033[35m"
-#define CYAN "\033[36m"
-#define RESET_COLOR "\033[0m"
-
-#ifndef NIMBLE_ENCODING_SELECTION_DEBUG_MAX_ITEMS
-#define NIMBLE_ENCODING_SELECTION_DEBUG_MAX_ITEMS 50
-#endif
-
-#ifdef NIMBLE_ENCODING_SELECTION_DEBUG
-#define NIMBLE_SELECTION_LOG(stream) LOG(INFO) << stream << RESET_COLOR
-#else
-#define NIMBLE_SELECTION_LOG(stream)
-#endif
 
 #define COMMA ,
 #define UNIQUE_PTR_FACTORY_EXTRA(data_type, class, extra_types, ...)        \
@@ -101,6 +79,10 @@ using EncodingSelectionPolicyFactory =
   UNIQUE_PTR_FACTORY_EXTRA(data_type, class, , __VA_ARGS__)
 
 struct CompressionOptions {
+  /// Rejects compression when compressedSize exceeds uncompressedSize
+  /// multiplied by this ratio. Currently only Zstrong/MetaInternal enforces
+  /// this through CompressionPolicy::shouldAccept().
+  /// TODO: Apply this consistently for Zstd and other compression types.
   float compressionAcceptRatio = 0.98f;
   uint64_t zstdMinCompressionSize = kZstdMinCompressionSize;
   uint32_t zstdCompressionLevel = 3;
@@ -117,46 +99,16 @@ struct CompressionOptions {
 // appropriate encoding based on the provided statistics.
 template <typename T, bool FixedByteWidth = true>
 class ManualEncodingSelectionPolicy : public EncodingSelectionPolicy<T> {
+ public:
   using physicalType = typename TypeTraits<T>::physicalType;
 
- public:
   ManualEncodingSelectionPolicy(
-      std::vector<std::pair<EncodingType, float>> readFactors,
+      std::vector<std::pair<EncodingType, float>> encodingReadFactors,
       std::optional<CompressionOptions> compressionOptions,
       std::optional<NestedEncodingIdentifier> identifier)
-      : readFactors_{std::move(readFactors)},
+      : candidateEncodingReadFactors_{std::move(encodingReadFactors)},
         compressionOptions_{std::move(compressionOptions)},
         identifier_{identifier} {}
-
-  std::unique_ptr<EncodingSelectionPolicyBase> createImpl(
-      EncodingType encodingType,
-      NestedEncodingIdentifier identifier,
-      DataType type) override {
-    // In each sub-level of the encoding selection, we exclude the encodings
-    // selected in parent levels. Although this is not required (as hopefully,
-    // the model will not pick a nested encoding of the same type as the
-    // parent), it provides an additional safty net, making sure the encoding
-    // selection will eventually converge, and also slightly speeds up nested
-    // encoding selection.
-    // TODO: validate the assumptions here compared to brute forcing, to see if
-    // the same encoding is selected multiple times in the tree (for example,
-    // should we allow trivial string lengths to be encoded using trivial
-    // encoding?)
-    std::vector<std::pair<EncodingType, float>> filteredReadFactors;
-    filteredReadFactors.reserve(readFactors_.size() - 1);
-    for (const auto& pair : readFactors_) {
-      if (pair.first != encodingType) {
-        filteredReadFactors.push_back(pair);
-      }
-    }
-    UNIQUE_PTR_FACTORY_EXTRA(
-        type,
-        ManualEncodingSelectionPolicy,
-        COMMA FixedByteWidth,
-        std::move(filteredReadFactors),
-        compressionOptions_,
-        identifier);
-  }
 
   EncodingSelectionResult select(
       std::span<const physicalType> values,
@@ -172,24 +124,19 @@ class ManualEncodingSelectionPolicy : public EncodingSelectionPolicy<T> {
     EncodingType selectedEncoding = EncodingType::Trivial;
     // Iterate on all candidate encodings, and pick the encoding with the
     // minimal cost.
-    for (const auto& pair : readFactors_) {
-      auto encodingType = pair.first;
+    for (const auto& entry : candidateEncodingReadFactors_) {
+      auto encodingType = entry.first;
       auto size =
           nimble::legacy::detail::EncodingSizeEstimation<T, FixedByteWidth>::
               estimateSize(encodingType, values.size(), statistics);
       if (!size.has_value()) {
-        NIMBLE_SELECTION_LOG(
-            PURPLE << encodingType << " encoding is incompatible.");
         continue;
       }
 
       // We use read factor weights to raise/lower the favorability of each
       // encoding.
-      auto readFactor = pair.second;
-      auto cost = size.value() * readFactor;
-      NIMBLE_SELECTION_LOG(
-          YELLOW << "Encoding: " << encodingType << ", Size: " << size.value()
-                 << ", Factor: " << readFactor << ", Cost: " << cost);
+      const auto readFactor = entry.second;
+      const auto cost = size.value() * readFactor;
       if (cost < minCost) {
         minCost = cost;
         selectedEncoding = encodingType;
@@ -208,9 +155,9 @@ class ManualEncodingSelectionPolicy : public EncodingSelectionPolicy<T> {
           : compressionOptions_{std::move(compressionOptions)},
             effectiveAcceptRatio_{getAcceptRatio(encodingType)} {}
 
-      CompressionInformation compression() const override {
+      CompressionConfig config() const override {
 #ifndef DISABLE_META_INTERNAL_COMPRESSOR
-        CompressionInformation information{
+        CompressionConfig information{
             .compressionType = CompressionType::MetaInternal,
             .minCompressionSize =
                 compressionOptions_.internalMinCompressionSize};
@@ -224,7 +171,7 @@ class ManualEncodingSelectionPolicy : public EncodingSelectionPolicy<T> {
             compressionOptions_.metaInternalCompressionKey;
         return information;
 #else
-        CompressionInformation information{
+        CompressionConfig information{
             .compressionType = CompressionType::Zstd,
             .minCompressionSize = compressionOptions_.zstdMinCompressionSize};
         information.parameters.zstd.compressionLevel =
@@ -234,22 +181,13 @@ class ManualEncodingSelectionPolicy : public EncodingSelectionPolicy<T> {
       }
 
       virtual bool shouldAccept(
-          CompressionType compressionType,
+          CompressionType /* compressionType */,
           uint64_t uncompressedSize,
           uint64_t compressedSize) const override {
         if (uncompressedSize * effectiveAcceptRatio_ < compressedSize) {
-          NIMBLE_SELECTION_LOG(
-              BLUE << compressionType
-                   << " compression rejected. Original size: "
-                   << uncompressedSize
-                   << ", Compressed size: " << compressedSize);
           return false;
         }
 
-        NIMBLE_SELECTION_LOG(
-            CYAN << compressionType
-                 << " compression accepted. Original size: " << uncompressedSize
-                 << ", Compressed size: " << compressedSize);
         return true;
       }
 
@@ -268,24 +206,6 @@ class ManualEncodingSelectionPolicy : public EncodingSelectionPolicy<T> {
       const float effectiveAcceptRatio_;
     };
 
-    NIMBLE_SELECTION_LOG(
-        "Selected Encoding"
-        << (identifier_.has_value()
-                ? folly::to<std::string>(
-                      " [NestedEncodingIdentifier: ", identifier_.value(), "]")
-                : "")
-        << ": " << GREEN << selectedEncoding << RESET_COLOR
-        << ", Sampled Data: "
-        << folly::join(
-               ",",
-               std::span<const physicalType>{
-                   values.data(),
-                   std::min(
-                       size_t(NIMBLE_ENCODING_SELECTION_DEBUG_MAX_ITEMS),
-                       values.size())})
-        << (values.size() > size_t(NIMBLE_ENCODING_SELECTION_DEBUG_MAX_ITEMS)
-                ? "..."
-                : ""));
     if (!compressionOptions_.has_value()) {
       return {.encodingType = selectedEncoding};
     }
@@ -309,53 +229,66 @@ class ManualEncodingSelectionPolicy : public EncodingSelectionPolicy<T> {
     };
   }
 
-  const std::vector<std::pair<EncodingType, float>>& readFactors() const {
-    return readFactors_;
+  const std::vector<std::pair<EncodingType, float>>&
+  candidateEncodingReadFactors() const {
+    return candidateEncodingReadFactors_;
+  }
+
+ protected:
+  std::unique_ptr<EncodingSelectionPolicyBase> createImpl(
+      EncodingType parentEncodingType,
+      NestedEncodingIdentifier nestedEncodingIdentifier,
+      DataType nestedDataType) override {
+    // In each sub-level of the encoding selection, we exclude the encodings
+    // selected in parent levels. Although this is not required (as hopefully,
+    // the model will not pick a nested encoding of the same type as the
+    // parent), it provides an additional safty net, making sure the encoding
+    // selection will eventually converge, and also slightly speeds up nested
+    // encoding selection.
+    // TODO: validate the assumptions here compared to brute forcing, to see if
+    // the same encoding is selected multiple times in the tree (for example,
+    // should we allow trivial string lengths to be encoded using trivial
+    // encoding?)
+    std::vector<std::pair<EncodingType, float>> nestedEncodingReadFactors;
+    nestedEncodingReadFactors.reserve(candidateEncodingReadFactors_.size() - 1);
+    for (const auto& entry : candidateEncodingReadFactors_) {
+      if (entry.first != parentEncodingType) {
+        nestedEncodingReadFactors.emplace_back(entry);
+      }
+    }
+    UNIQUE_PTR_FACTORY_EXTRA(
+        nestedDataType,
+        ManualEncodingSelectionPolicy,
+        COMMA FixedByteWidth,
+        std::move(nestedEncodingReadFactors),
+        compressionOptions_,
+        nestedEncodingIdentifier);
   }
 
  private:
-  // These read factors are used to raise or lower the chances of an encoding to
-  // be picked. Right now, these represent mostly the cpu cost to decode the
-  // values. Trivial is being boosed as we factor in the added benefit of
-  // applying compression.
+  // Candidate encodings and their read-cost factors. Encoding selection uses
+  // estimatedSize * readFactor as the cost, so a lower factor makes an
+  // encoding more likely to be picked. Right now, these represent mostly the
+  // CPU cost to decode values. Trivial is boosted with a lower factor because
+  // it also benefits from applying compression.
   // See ManualEncodingSelectionPolicyFactory::defaultReadFactors for the
   // default.
-  const std::vector<std::pair<EncodingType, float>> readFactors_;
+  const std::vector<std::pair<EncodingType, float>>
+      candidateEncodingReadFactors_;
   // When nullopt, compression is disabled for this policy and all nested
   // policies created from it.
   const std::optional<CompressionOptions> compressionOptions_;
   const std::optional<NestedEncodingIdentifier> identifier_;
 };
 
-// This model is trained offline and parameters are updated here.
-// The parameters are relatively robust and do not need to be updated
-// unless we add / remove an encoding type.
-template <typename T>
-struct EncodingPredictionModel {
-  using physicalType = typename TypeTraits<T>::physicalType;
-  explicit EncodingPredictionModel()
-      : maxRepeatParam(1.52), minRepeatParam(1.13), uniqueParam(2.589) {}
-  float maxRepeatParam;
-  float minRepeatParam;
-  float uniqueParam;
-  float predict(const Statistics<physicalType>& statistics) {
-    // TODO: Utilize more features within statistics for prediction.
-    auto maxRepeat = statistics.maxRepeat();
-    auto minRepeat = statistics.minRepeat();
-    auto unique = statistics.uniqueCounts().value().size();
-    return maxRepeatParam * maxRepeat + minRepeatParam * minRepeat +
-        uniqueParam * unique;
-  }
-};
-
 class ManualEncodingSelectionPolicyFactory {
  public:
   ManualEncodingSelectionPolicyFactory(
-      std::vector<std::pair<EncodingType, float>> readFactors =
+      std::vector<std::pair<EncodingType, float>> encodingReadFactors =
           defaultReadFactors(),
       std::optional<CompressionOptions> compressionOptions =
           CompressionOptions{})
-      : readFactors_{std::move(readFactors)},
+      : encodingReadFactors_{std::move(encodingReadFactors)},
         compressionOptions_{std::move(compressionOptions)} {}
 
   std::unique_ptr<EncodingSelectionPolicyBase> createPolicy(
@@ -363,7 +296,7 @@ class ManualEncodingSelectionPolicyFactory {
     UNIQUE_PTR_FACTORY(
         dataType,
         ManualEncodingSelectionPolicy,
-        readFactors_,
+        encodingReadFactors_,
         compressionOptions_,
         std::nullopt);
   }
@@ -394,21 +327,22 @@ class ManualEncodingSelectionPolicyFactory {
     };
   }
 
-  static std::vector<std::pair<nimble::EncodingType, float>> parseReadFactors(
-      const std::string& val) {
-    std::vector<std::pair<nimble::EncodingType, float>> readFactors;
+  /// Parses semicolon-delimited runtime read-factor config.
+  static std::vector<std::pair<nimble::EncodingType, float>>
+  parseEncodingReadFactors(const std::string& readFactorsConfig) {
+    std::vector<std::pair<nimble::EncodingType, float>> encodingReadFactors;
     std::vector<std::string> parts;
-    folly::split(';', folly::trimWhitespace(val), parts);
-    readFactors.reserve(parts.size());
+    folly::split(';', folly::trimWhitespace(readFactorsConfig), parts);
+    encodingReadFactors.reserve(parts.size());
 
     std::vector<nimble::EncodingType> possibleEncodings =
         ManualEncodingSelectionPolicyFactory::possibleEncodings();
-    std::vector<std::string> possibleEncodingStrings;
-    possibleEncodingStrings.reserve(possibleEncodings.size());
+    std::vector<std::string> possibleEncodingStrs;
+    possibleEncodingStrs.reserve(possibleEncodings.size());
     std::transform(
         possibleEncodings.cbegin(),
         possibleEncodings.cend(),
-        std::back_inserter(possibleEncodingStrings),
+        std::back_inserter(possibleEncodingStrs),
         [](const auto& encoding) { return toString(encoding); });
     for (const auto& part : parts) {
       std::vector<std::string> kv;
@@ -417,23 +351,23 @@ class ManualEncodingSelectionPolicyFactory {
           kv.size(),
           2,
           "Invalid read factor format. "
-          "Expected format is <EncodingType>=<facor>;<EncodingType>=<facor>. "
+          "Expected format is <EncodingType>=<factor>;<EncodingType>=<factor>. "
           "Unable to parse '{}'.",
           part);
-      auto value = folly::tryTo<float>(kv[1]);
+      const auto value = folly::tryTo<float>(kv[1]);
       NIMBLE_CHECK(
           value.hasValue(),
           "Unable to parse read factor value '{}' in '{}'. Expected valid float value.",
           kv[1],
           part);
       bool found = false;
-      auto key = folly::trimWhitespace(kv[0]);
+      const auto key = folly::trimWhitespace(kv[0]);
       for (auto i = 0; i < possibleEncodings.size(); ++i) {
         auto encoding = possibleEncodings[i];
         // @lint-ignore CLANGTIDY facebook-hte-LocalUncheckedArrayBounds
-        if (key == possibleEncodingStrings[i]) {
+        if (key == possibleEncodingStrs[i]) {
           found = true;
-          readFactors.emplace_back(encoding, value.value());
+          encodingReadFactors.emplace_back(encoding, value.value());
           break;
         }
       }
@@ -441,13 +375,13 @@ class ManualEncodingSelectionPolicyFactory {
           found,
           "Unknown or unexpected read factor encoding '{}'. Allowed values: {}",
           key,
-          folly::join(",", possibleEncodingStrings));
+          folly::join(",", possibleEncodingStrs));
     }
-    return readFactors;
+    return encodingReadFactors;
   }
 
  private:
-  const std::vector<std::pair<EncodingType, float>> readFactors_;
+  const std::vector<std::pair<EncodingType, float>> encodingReadFactors_;
   const std::optional<CompressionOptions> compressionOptions_;
 };
 
@@ -457,10 +391,31 @@ class LearnedEncodingSelectionPolicy : public EncodingSelectionPolicy<T> {
   using physicalType = typename TypeTraits<T>::physicalType;
 
  public:
+  // This model is trained offline and parameters are updated here. The
+  // parameters are relatively robust and do not need to be updated unless we
+  // add or remove an encoding type.
+  struct EncodingPredictionModel {
+    explicit EncodingPredictionModel()
+        : maxRepeatParam(1.52), minRepeatParam(1.13), uniqueParam(2.589) {}
+
+    float maxRepeatParam;
+    float minRepeatParam;
+    float uniqueParam;
+
+    float predict(const Statistics<physicalType>& statistics) {
+      // TODO: Utilize more features within statistics for prediction.
+      const auto maxRepeat = statistics.maxRepeat();
+      const auto minRepeat = statistics.minRepeat();
+      const auto unique = statistics.uniqueCounts().value().size();
+      return maxRepeatParam * maxRepeat + minRepeatParam * minRepeat +
+          uniqueParam * unique;
+    }
+  };
+
   LearnedEncodingSelectionPolicy(
       std::vector<EncodingType> encodingChoices,
       std::optional<NestedEncodingIdentifier> identifier,
-      EncodingPredictionModel<T> encodingModel = EncodingPredictionModel<T>())
+      EncodingPredictionModel encodingModel = EncodingPredictionModel())
       : encodingChoices_{std::move(encodingChoices)},
         identifier_{identifier},
         mlModel_{encodingModel} {}
@@ -469,31 +424,12 @@ class LearnedEncodingSelectionPolicy : public EncodingSelectionPolicy<T> {
       : LearnedEncodingSelectionPolicy{
             possibleEncodingChoices(),
             std::nullopt,
-            EncodingPredictionModel<T>()} {}
+            EncodingPredictionModel()} {}
 
   EncodingSelectionResult select(
       std::span<const physicalType> values,
       const Statistics<physicalType>& statistics,
-      const Encoding::Options& /* options */ = {}) override {
-    if (values.empty()) {
-      return {
-          .encodingType = EncodingType::Trivial,
-      };
-    }
-
-    float prediction = mlModel_.predict(statistics);
-    if (prediction > 0.1) {
-      return {
-          .encodingType = EncodingType::Trivial,
-      };
-    }
-    // TODO: Implement a multi-class Encoding model so that we can predict not
-    // only a trivial encoding but also other encodings.
-
-    return {
-        .encodingType = EncodingType::Trivial,
-    };
-  }
+      const Encoding::Options& options = {}) override;
 
   EncodingSelectionResult selectNullable(
       std::span<const physicalType> /* values */,
@@ -506,9 +442,9 @@ class LearnedEncodingSelectionPolicy : public EncodingSelectionPolicy<T> {
   }
 
   std::unique_ptr<EncodingSelectionPolicyBase> createImpl(
-      EncodingType encodingType,
-      NestedEncodingIdentifier identifier,
-      DataType type) override {
+      EncodingType parentEncodingType,
+      NestedEncodingIdentifier nestedEncodingIdentifier,
+      DataType nestedDataType) override {
     // In each sub-level of the encoding selection, we exclude the encodings
     // selected in parent levels. Although this is not required (as hopefully,
     // the model will not pick a nested encoding of the same type as the
@@ -519,18 +455,18 @@ class LearnedEncodingSelectionPolicy : public EncodingSelectionPolicy<T> {
     // the same encoding is selected multiple times in the tree (for example,
     // should we allow trivial string lengths to be encoded using trivial
     // encoding?)
-    std::vector<EncodingType> filteredReadFactors;
-    filteredReadFactors.reserve(encodingChoices_.size() - 1);
+    std::vector<EncodingType> nestedEncodingChoices;
+    nestedEncodingChoices.reserve(encodingChoices_.size() - 1);
     for (const auto& encodingType_ : encodingChoices_) {
-      if (encodingType_ != encodingType) {
-        filteredReadFactors.push_back(encodingType_);
+      if (encodingType_ != parentEncodingType) {
+        nestedEncodingChoices.push_back(encodingType_);
       }
     }
     UNIQUE_PTR_FACTORY(
-        type,
+        nestedDataType,
         LearnedEncodingSelectionPolicy,
-        std::move(filteredReadFactors),
-        identifier);
+        std::move(nestedEncodingChoices),
+        nestedEncodingIdentifier);
   }
 
  private:
@@ -549,90 +485,53 @@ class LearnedEncodingSelectionPolicy : public EncodingSelectionPolicy<T> {
 
   std::vector<EncodingType> encodingChoices_;
   std::optional<NestedEncodingIdentifier> identifier_;
-  EncodingPredictionModel<T> mlModel_;
+  EncodingPredictionModel mlModel_;
 };
 
-class ReplayedCompressionPolicy : public CompressionPolicy {
- public:
-  explicit ReplayedCompressionPolicy(
-      nimble::CompressionType compressionType,
-      CompressionOptions compressionOptions)
-      : compressionType_{compressionType},
-        compressionOptions_{std::move(compressionOptions)} {}
-
-  CompressionInformation compression() const override {
-    if (compressionType_ == nimble::CompressionType::Uncompressed) {
-      return {.compressionType = nimble::CompressionType::Uncompressed};
-    }
-
-    if (compressionType_ == nimble::CompressionType::Zstd) {
-      CompressionInformation information{
-          .compressionType = nimble::CompressionType::Zstd,
-          .minCompressionSize = compressionOptions_.zstdMinCompressionSize};
-      information.parameters.zstd.compressionLevel =
-          compressionOptions_.zstdCompressionLevel;
-      return information;
-    }
-
-    CompressionInformation information{
-        .compressionType = nimble::CompressionType::MetaInternal,
-        .minCompressionSize = compressionOptions_.internalMinCompressionSize};
-    information.parameters.metaInternal.compressionLevel =
-        compressionOptions_.internalCompressionLevel;
-    information.parameters.metaInternal.decompressionLevel =
-        compressionOptions_.internalDecompressionLevel;
-    information.parameters.metaInternal.useVariableBitWidthCompressor =
-        compressionOptions_.useVariableBitWidthCompressor;
-    information.parameters.metaInternal.compressionKey =
-        compressionOptions_.metaInternalCompressionKey;
-    return information;
+template <typename T>
+EncodingSelectionResult LearnedEncodingSelectionPolicy<T>::select(
+    std::span<const typename LearnedEncodingSelectionPolicy<T>::physicalType>
+        values,
+    const Statistics<typename LearnedEncodingSelectionPolicy<T>::physicalType>&
+        statistics,
+    const Encoding::Options& /* options */) {
+  if (values.empty()) {
+    return {
+        .encodingType = EncodingType::Trivial,
+    };
   }
 
-  virtual bool shouldAccept(
-      nimble::CompressionType /* compressionType */,
-      uint64_t uncompressedSize,
-      uint64_t compressedSize) const override {
-    if (uncompressedSize * compressionOptions_.compressionAcceptRatio <
-        compressedSize) {
-      NIMBLE_SELECTION_LOG(
-          BLUE << compressionType_ << " compression rejected. Original size: "
-               << uncompressedSize << ", Compressed size: " << compressedSize);
-      return false;
-    }
-
-    NIMBLE_SELECTION_LOG(
-        CYAN << compressionType_ << " compression accepted. Original size: "
-             << uncompressedSize << ", Compressed size: " << compressedSize);
-    return true;
+  const auto prediction = mlModel_.predict(statistics);
+  if (prediction > 0.1) {
+    return {
+        .encodingType = EncodingType::Trivial,
+    };
   }
+  // TODO: Implement a multi-class Encoding model so that we can predict not
+  // only a trivial encoding but also other encodings.
 
- private:
-  const nimble::CompressionType compressionType_;
-  const CompressionOptions compressionOptions_;
-};
+  return {
+      .encodingType = EncodingType::Trivial,
+  };
+}
 
-template <typename TInner>
-class ReplayedEncodingSelectionPolicy;
-
-template <typename TInner>
-class ReplayedEncodingSelectionPolicy : public EncodingSelectionPolicy<TInner> {
-  using physicalType = typename nimble::TypeTraits<TInner>::physicalType;
-
+template <typename T>
+class ReplayedEncodingSelectionPolicy : public EncodingSelectionPolicy<T> {
  public:
+  using physicalType = typename nimble::TypeTraits<T>::physicalType;
+
   ReplayedEncodingSelectionPolicy(
       EncodingLayout encodingLayout,
       std::optional<CompressionOptions> compressionOptions,
-      const EncodingSelectionPolicyFactory& encodingSelectionPolicyFactory)
+      const EncodingSelectionPolicyCreator& encodingSelectionPolicyCreator)
       : compressionOptions_{std::move(compressionOptions)},
-        encodingSelectionPolicyFactory_{encodingSelectionPolicyFactory},
+        encodingSelectionPolicyCreator_{encodingSelectionPolicyCreator},
         encodingLayout_{std::move(encodingLayout)} {}
 
   EncodingSelectionResult select(
       std::span<const physicalType> /* values */,
       const nimble::Statistics<physicalType>& /* statistics */,
       const Encoding::Options& /* options */ = {}) override {
-    NIMBLE_SELECTION_LOG(
-        CYAN << "Replaying encoding " << encodingLayout_.encodingType());
     if (!compressionOptions_.has_value()) {
       return {
           .encodingType = encodingLayout_.encodingType(),
@@ -651,9 +550,9 @@ class ReplayedEncodingSelectionPolicy : public EncodingSelectionPolicy<TInner> {
       std::span<const bool> /* nulls */,
       const Statistics<physicalType>& /* statistics */,
       const Encoding::Options& /* options */ = {}) override {
-    NIMBLE_SELECTION_LOG(
-        CYAN << "Replaying nullable encoding "
-             << encodingLayout_.encodingType());
+    // NullableEncoding asks createImpl() for nullable data and nulls children.
+    // The replay policy is initialized with the data layout, so synthesize the
+    // nullable parent shape here.
     encodingLayout_ = EncodingLayout{
         EncodingType::Nullable,
         {},
@@ -667,31 +566,32 @@ class ReplayedEncodingSelectionPolicy : public EncodingSelectionPolicy<TInner> {
     };
   }
 
+ protected:
   std::unique_ptr<EncodingSelectionPolicyBase> createImpl(
-      nimble::EncodingType /* encodingType */,
-      nimble::NestedEncodingIdentifier identifier,
-      nimble::DataType type) override {
+      nimble::EncodingType /* parentEncodingType */,
+      nimble::NestedEncodingIdentifier nestedEncodingIdentifier,
+      nimble::DataType nestedDataType) override {
     NIMBLE_CHECK_LT(
-        identifier,
+        nestedEncodingIdentifier,
         encodingLayout_.childrenCount(),
         "Sub-encoding identifier out of range.");
-    auto child = encodingLayout_.child(identifier);
+    auto child = encodingLayout_.child(nestedEncodingIdentifier);
 
     if (child.has_value()) {
       UNIQUE_PTR_FACTORY(
-          type,
+          nestedDataType,
           ReplayedEncodingSelectionPolicy,
           child.value(),
           compressionOptions_,
-          encodingSelectionPolicyFactory_);
+          encodingSelectionPolicyCreator_);
     } else {
-      return encodingSelectionPolicyFactory_(type);
+      return encodingSelectionPolicyCreator_(nestedDataType);
     }
   }
 
  private:
   const std::optional<CompressionOptions> compressionOptions_;
-  const EncodingSelectionPolicyFactory& encodingSelectionPolicyFactory_;
+  const EncodingSelectionPolicyCreator& encodingSelectionPolicyCreator_;
   EncodingLayout encodingLayout_;
 };
 

--- a/dwio/nimble/encodings/selection/ENCODING_SELECTION_FLOW.md
+++ b/dwio/nimble/encodings/selection/ENCODING_SELECTION_FLOW.md
@@ -13,7 +13,7 @@ Nimble uses a **top-down greedy approach** to build an encoding tree:
 ## 📝 Key Components
 
 ### 1. **EncodingSelectionPolicy** (Policy Interface)
-- **Base class**: `EncodingSelectionPolicy<T>` 
+- **Base class**: `EncodingSelectionPolicy<T>`
 - **Purpose**: Pluggable policy for selecting the best encoding for given data
 - **Key methods**:
   - `select(values, statistics)` → Returns `EncodingSelectionResult`
@@ -88,7 +88,7 @@ auto encoded = EncodingFactory::encode<uint32_t>(
    ```cpp
    return EncodingFactory::encode<T>(std::move(selection), physicalValues, buffer);
    ```
-   
+
    This dispatches to the selected encoding's `encode()` method:
    ```cpp
    switch (selection.encodingType()) {
@@ -122,32 +122,32 @@ auto encoded = EncodingFactory::encode<uint32_t>(
            {alphabet},
            tempBuffer);
    ```
-   
+
    **What happens inside `encodeNested`** (`EncodingSelection::encodeNested`, line 264-283):
-   
+
    a. **Create Child Policy** (line 270-273)
       ```cpp
       auto nestedPolicy = selectionPolicy_->template create<physicalType>(
           EncodingType::Dictionary,
           EncodingIdentifiers::Dictionary::Alphabet);
       ```
-      
+
       This calls `ManualEncodingSelectionPolicy::createImpl` (line 130-158):
       - Filters out parent encoding from candidate list (prevents infinite recursion)
       - Creates new policy instance with same configuration
-   
+
    b. **Create Statistics for Nested Data** (line 274)
       ```cpp
       auto statistics = Statistics<physicalType>::create(alphabet);
       ```
-   
+
    c. **Select Encoding for Alphabet** (line 275)
       ```cpp
       auto selectionResult = nestedPolicy->select(alphabet, statistics);
       ```
       - Policy might select `TrivialEncoding` for small alphabets
       - Or `FixedBitWidthEncoding` for numeric alphabets
-   
+
    d. **Recursively Encode** (line 276-282)
       ```cpp
       return EncodingFactory::encode<physicalType>(
@@ -192,9 +192,9 @@ After encoding is complete, compression is applied:
    auto policy = selectionResult_.compressionPolicyFactory();
    ```
 
-2. **Compression Information** (from `AlwaysCompressPolicy::compression()`)
+2. **Compression Information** (from `ConfiguredCompressionPolicy::config()`)
    ```cpp
-   CompressionInformation info{
+   CompressionConfig info{
        .compressionType = CompressionType::MetaInternal,
        .compressionLevel = 4,
        // ... other parameters
@@ -322,7 +322,7 @@ ReplayedEncodingSelectionPolicy<T> : EncodingSelectionPolicy<T>
 
 The **EncodingSelectionPolicy** system enables Nimble to:
 1. **Automatically select optimal encodings** based on data characteristics
-2. **Build nested encoding trees** recursively and efficiently  
+2. **Build nested encoding trees** recursively and efficiently
 3. **Apply compression intelligently** at each level
 4. **Support pluggable policies** (manual, learned, replayed)
 5. **Make type-safe selections** across different data types

--- a/dwio/nimble/encodings/selection/EncodingIdentifier.h
+++ b/dwio/nimble/encodings/selection/EncodingIdentifier.h
@@ -111,6 +111,10 @@ struct EncodingIdentifiers {
     static constexpr NestedEncodingIdentifier BitWidths = 1;
     static constexpr NestedEncodingIdentifier Offsets = 2;
   };
+
+  struct Fsst {
+    static constexpr NestedEncodingIdentifier Lengths = 0;
+  };
 };
 
 } // namespace facebook::nimble

--- a/dwio/nimble/encodings/selection/EncodingSelection.h
+++ b/dwio/nimble/encodings/selection/EncodingSelection.h
@@ -106,6 +106,11 @@ class EncodingSelection {
     return policy;
   }
 
+  template <typename NestedT>
+  std::unique_ptr<EncodingSelectionPolicyBase> createNestedPolicy(
+      EncodingType parentEncodingType,
+      NestedEncodingIdentifier nestedEncodingIdentifier);
+
   /// Returns a config value for the given key, or std::nullopt if not found.
   /// The caller is responsible for type casting the returned string value.
   std::optional<std::string> getConfig(const std::string& key) const {
@@ -118,7 +123,7 @@ class EncodingSelection {
   /// are selected).
   template <typename NestedT>
   std::string_view encodeNested(
-      NestedEncodingIdentifier identifier,
+      NestedEncodingIdentifier nestedEncodingIdentifier,
       std::span<const NestedT> values,
       Buffer& buffer,
       const Encoding::Options& options = {});
@@ -142,9 +147,12 @@ class EncodingSelectionPolicyBase {
  public:
   template <typename NestedT>
   std::unique_ptr<EncodingSelectionPolicyBase> create(
-      EncodingType encodingType,
-      NestedEncodingIdentifier identifier) {
-    return createImpl(encodingType, identifier, TypeTraits<NestedT>::dataType);
+      EncodingType parentEncodingType,
+      NestedEncodingIdentifier nestedEncodingIdentifier) {
+    return createImpl(
+        parentEncodingType,
+        nestedEncodingIdentifier,
+        TypeTraits<NestedT>::dataType);
   }
 
   virtual ~EncodingSelectionPolicyBase() = default;
@@ -155,13 +163,23 @@ class EncodingSelectionPolicyBase {
   /// This method allows transferring state between parent and nested encoding
   /// selection policy instances.
   /// A child encoding selection policy instance will be created for every
-  /// nested stream of the parent encoding. The identifier passed in allows to
-  /// differentiate between the nested streams.
+  /// nested stream of the parent encoding. The nested encoding identifier
+  /// differentiates between the nested streams.
   virtual std::unique_ptr<EncodingSelectionPolicyBase> createImpl(
-      EncodingType encodingType,
-      NestedEncodingIdentifier identifier,
-      DataType type) = 0;
+      EncodingType parentEncodingType,
+      NestedEncodingIdentifier nestedEncodingIdentifier,
+      DataType nestedDataType) = 0;
 };
+
+template <typename T>
+template <typename NestedT>
+std::unique_ptr<EncodingSelectionPolicyBase>
+EncodingSelection<T>::createNestedPolicy(
+    EncodingType parentEncodingType,
+    NestedEncodingIdentifier nestedEncodingIdentifier) {
+  return selectionPolicy_->create<NestedT>(
+      parentEncodingType, nestedEncodingIdentifier);
+}
 
 /// This is the main base class for defining an encoding selection policy.
 template <typename T>
@@ -197,7 +215,7 @@ std::unique_ptr<T> unique_ptr_cast(std::unique_ptr<S> src) {
 template <typename T>
 template <typename NestedT>
 std::string_view EncodingSelection<T>::encodeNested(
-    NestedEncodingIdentifier identifier,
+    NestedEncodingIdentifier nestedEncodingIdentifier,
     std::span<const NestedT> values,
     Buffer& buffer,
     const Encoding::Options& options) {
@@ -205,7 +223,9 @@ std::string_view EncodingSelection<T>::encodeNested(
   // strongly templated type.
   auto nestedPolicy = std::unique_ptr<EncodingSelectionPolicy<NestedT>>(
       static_cast<EncodingSelectionPolicy<NestedT>*>(
-          selectionPolicy_->template create<NestedT>(encodingType(), identifier)
+          selectionPolicy_
+              ->template create<NestedT>(
+                  encodingType(), nestedEncodingIdentifier)
               .release()));
   auto statistics = Statistics<NestedT>::create(values);
   auto selectionResult = nestedPolicy->select(values, statistics, options);

--- a/dwio/nimble/encodings/selection/EncodingSelectionPolicy.cpp
+++ b/dwio/nimble/encodings/selection/EncodingSelectionPolicy.cpp
@@ -1,0 +1,122 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "dwio/nimble/encodings/selection/EncodingSelectionPolicy.h"
+
+namespace facebook::nimble {
+
+/* static */ std::vector<std::pair<EncodingType, float>>
+ManualEncodingSelectionPolicyFactory::defaultEncodingReadFactors() {
+  return {
+      {EncodingType::Constant, 1.0},
+      {EncodingType::Trivial, 0.7},
+      {EncodingType::FixedBitWidth, 0.9},
+      {EncodingType::MainlyConstant, 1.0},
+      {EncodingType::SparseBool, 1.0},
+      {EncodingType::Dictionary, 1.0},
+      {EncodingType::RLE, 1.0},
+      {EncodingType::Varint, 1.0},
+  };
+}
+
+/* static */ std::vector<std::pair<nimble::EncodingType, float>>
+ManualEncodingSelectionPolicyFactory::parseEncodingReadFactors(
+    const std::string& readFactorsConfig) {
+  std::vector<std::pair<nimble::EncodingType, float>> encodingReadFactors;
+  std::vector<std::string> parts;
+  folly::split(';', folly::trimWhitespace(readFactorsConfig), parts);
+  encodingReadFactors.reserve(parts.size());
+
+  const auto possibleEncodings =
+      ManualEncodingSelectionPolicyFactory::possibleEncodings();
+  std::vector<std::string> possibleEncodingStrs;
+  possibleEncodingStrs.reserve(possibleEncodings.size());
+  std::transform(
+      possibleEncodings.cbegin(),
+      possibleEncodings.cend(),
+      std::back_inserter(possibleEncodingStrs),
+      [](const auto& encoding) { return toString(encoding); });
+  for (const auto& part : parts) {
+    std::vector<std::string> kv;
+    folly::split('=', part, kv);
+    NIMBLE_CHECK_EQ(
+        kv.size(),
+        2,
+        "Invalid read factor format. "
+        "Expected format is <EncodingType>=<factor>;<EncodingType>=<factor>. "
+        "Unable to parse '{}'.",
+        part);
+    const auto value = folly::tryTo<float>(kv[1]);
+    NIMBLE_CHECK(
+        value.hasValue(),
+        "Unable to parse read factor value '{}' in '{}'. Expected valid float value.",
+        kv[1],
+        part);
+    bool found = false;
+    const auto key = folly::trimWhitespace(kv[0]);
+    for (auto i = 0; i < possibleEncodings.size(); ++i) {
+      auto encoding = possibleEncodings[i];
+      // @lint-ignore CLANGTIDY facebook-hte-LocalUncheckedArrayBounds
+      if (key == possibleEncodingStrs[i]) {
+        found = true;
+        encodingReadFactors.emplace_back(encoding, value.value());
+        break;
+      }
+    }
+    NIMBLE_CHECK(
+        found,
+        "Unknown or unexpected read factor encoding '{}'. Allowed values: {}",
+        key,
+        folly::join(",", possibleEncodingStrs));
+  }
+  return encodingReadFactors;
+}
+
+ManualEncodingSelectionPolicyFactory::ManualEncodingSelectionPolicyFactory(
+    std::vector<std::pair<EncodingType, float>> encodingReadFactors,
+    std::optional<CompressionOptions> compressionOptions)
+    : encodingReadFactors_{std::move(encodingReadFactors)},
+      compressionOptions_{std::move(compressionOptions)} {}
+
+std::unique_ptr<EncodingSelectionPolicyBase>
+ManualEncodingSelectionPolicyFactory::createPolicy(DataType dataType) const {
+  UNIQUE_PTR_FACTORY(
+      dataType,
+      ManualEncodingSelectionPolicy,
+      encodingReadFactors_,
+      compressionOptions_,
+      std::nullopt);
+}
+
+/* static */ std::vector<EncodingType>
+ManualEncodingSelectionPolicyFactory::possibleEncodings() {
+  return {
+      EncodingType::Constant,
+      EncodingType::Trivial,
+      EncodingType::FixedBitWidth,
+      EncodingType::MainlyConstant,
+      EncodingType::SparseBool,
+      EncodingType::Dictionary,
+      EncodingType::RLE,
+      EncodingType::Varint,
+      EncodingType::PFOR,
+      EncodingType::SimdForBitpack,
+      EncodingType::SubIntSplit,
+      EncodingType::BlockBitPacking,
+      EncodingType::Fsst,
+  };
+}
+
+} // namespace facebook::nimble

--- a/dwio/nimble/encodings/selection/EncodingSelectionPolicy.h
+++ b/dwio/nimble/encodings/selection/EncodingSelectionPolicy.h
@@ -18,36 +18,31 @@
 #include <glog/logging.h>
 #include <algorithm>
 #include <optional>
+#include <string>
 #include <utility>
+#include <vector>
 #include "dwio/nimble/common/Constants.h"
 #include "dwio/nimble/encodings/common/EncodingLayout.h"
 #include "dwio/nimble/encodings/common/EncodingType.h"
 #include "dwio/nimble/encodings/selection/EncodingIdentifier.h"
 #include "dwio/nimble/encodings/selection/EncodingSelection.h"
 #include "dwio/nimble/encodings/selection/EncodingSizeEstimation.h"
+#include "velox/common/base/SuccinctPrinter.h"
 
 namespace facebook::nimble {
 
-using EncodingSelectionPolicyFactory =
+using EncodingSelectionPolicyCreator =
     std::function<std::unique_ptr<EncodingSelectionPolicyBase>(DataType)>;
 
 // The following enables encoding selection debug messages. By default, these
 // logs are turned off (with zero overhead). In tests (or in debug sessions), we
 // enable these logs.
-#define RED "\033[31m"
-#define GREEN "\033[32m"
-#define YELLOW "\033[33m"
-#define BLUE "\033[34m"
-#define PURPLE "\033[35m"
-#define CYAN "\033[36m"
-#define RESET_COLOR "\033[0m"
-
 #ifndef NIMBLE_ENCODING_SELECTION_DEBUG_MAX_ITEMS
 #define NIMBLE_ENCODING_SELECTION_DEBUG_MAX_ITEMS 50
 #endif
 
 #ifdef NIMBLE_ENCODING_SELECTION_DEBUG
-#define NIMBLE_SELECTION_LOG(stream) LOG(INFO) << stream << RESET_COLOR
+#define NIMBLE_SELECTION_LOG(stream) LOG(INFO) << stream
 #else
 #define NIMBLE_SELECTION_LOG(stream)
 #endif
@@ -100,80 +95,21 @@ using EncodingSelectionPolicyFactory =
 #define UNIQUE_PTR_FACTORY(data_type, class, ...) \
   UNIQUE_PTR_FACTORY_EXTRA(data_type, class, , __VA_ARGS__)
 
-struct CompressionOptions {
-  float compressionAcceptRatio = 0.98f;
-#ifndef DISABLE_META_INTERNAL_COMPRESSOR
-  CompressionType compressionType = CompressionType::MetaInternal;
-#else
-  CompressionType compressionType = CompressionType::Zstd;
-#endif
-  uint64_t zstdMinCompressionSize = kZstdMinCompressionSize;
-  uint32_t zstdCompressionLevel = 3;
-  uint64_t lz4MinCompressionSize = kLz4MinCompressionSize;
-  uint32_t lz4AccelerationLevel = 1;
-  uint64_t internalMinCompressionSize = kMetaInternalMinCompressionSize;
-  uint32_t internalCompressionLevel = 4;
-  uint32_t internalDecompressionLevel = 2;
-  bool useVariableBitWidthCompressor = false;
-  MetaInternalCompressionKey metaInternalCompressionKey;
-  // OpenZL settings
-  uint64_t openzlMinCompressionSize = kOpenZLMinCompressionSize;
-  // 6/3 is a close analogue to the performance of zstd level 3
-  int32_t openzlCompressionLevel = 6;
-  int32_t openzlDecompressionLevel = 3;
-  int32_t openzlFormatVersion = 25;
-  // Per-encoding overrides for compressionAcceptRatio.
-  // BlockBitPacking default 0.7: data is already well-packed via per-block
-  // baselines, so compression must save at least 30% to justify CPU cost.
-  std::vector<std::pair<EncodingType, float>> compressionAcceptRatioOverrides =
-      {{EncodingType::BlockBitPacking, 0.7f}};
-};
-
-// This is the manual encoding selection implementation.
-// The manual selection is using a manually crafted model to choose the most
-// appropriate encoding based on the provided statistics.
+/// Manual encoding selection implementation.
+/// Uses a manually crafted model to choose the most appropriate encoding based
+/// on the provided statistics.
 template <typename T, bool FixedByteWidth = true>
 class ManualEncodingSelectionPolicy : public EncodingSelectionPolicy<T> {
+ public:
   using physicalType = typename TypeTraits<T>::physicalType;
 
- public:
   ManualEncodingSelectionPolicy(
-      std::vector<std::pair<EncodingType, float>> readFactors,
+      std::vector<std::pair<EncodingType, float>> encodingReadFactors,
       std::optional<CompressionOptions> compressionOptions,
       std::optional<NestedEncodingIdentifier> identifier)
-      : readFactors_{std::move(readFactors)},
+      : candidateEncodingReadFactors_{std::move(encodingReadFactors)},
         compressionOptions_{std::move(compressionOptions)},
         identifier_{identifier} {}
-
-  std::unique_ptr<EncodingSelectionPolicyBase> createImpl(
-      EncodingType encodingType,
-      NestedEncodingIdentifier identifier,
-      DataType type) override {
-    // In each sub-level of the encoding selection, we exclude the encodings
-    // selected in parent levels. Although this is not required (as hopefully,
-    // the model will not pick a nested encoding of the same type as the
-    // parent), it provides an additional safety net, making sure the encoding
-    // selection will eventually converge, and also slightly speeds up nested
-    // encoding selection.
-    // TODO: validate the assumptions here compared to brute forcing, to see if
-    // the same encoding is selected multiple times in the tree (for example,
-    // should we allow trivial string lengths to be encoded using trivial
-    // encoding?)
-    std::vector<std::pair<EncodingType, float>> filteredReadFactors;
-    filteredReadFactors.reserve(readFactors_.size() - 1);
-    for (const auto& pair : readFactors_) {
-      if (pair.first != encodingType) {
-        filteredReadFactors.push_back(pair);
-      }
-    }
-    UNIQUE_PTR_FACTORY_EXTRA(
-        type,
-        ManualEncodingSelectionPolicy,
-        COMMA FixedByteWidth,
-        std::move(filteredReadFactors),
-        compressionOptions_,
-        identifier);
-  }
 
   EncodingSelectionResult select(
       std::span<const physicalType> values,
@@ -186,7 +122,7 @@ class ManualEncodingSelectionPolicy : public EncodingSelectionPolicy<T> {
     }
 
     // Fast path: when there are no candidate encodings, fall back to Trivial.
-    if (readFactors_.empty()) {
+    if (candidateEncodingReadFactors_.empty()) {
       return {
           .encodingType = EncodingType::Trivial,
       };
@@ -196,122 +132,29 @@ class ManualEncodingSelectionPolicy : public EncodingSelectionPolicy<T> {
     EncodingType selectedEncoding = EncodingType::Trivial;
     // Iterate on all candidate encodings, and pick the encoding with the
     // minimal cost.
-    for (const auto& pair : readFactors_) {
-      const auto encodingType = pair.first;
+    for (const auto& entry : candidateEncodingReadFactors_) {
+      const auto encodingType = entry.first;
       const auto estimatedSize =
           detail::EncodingSizeEstimation<T, FixedByteWidth>::estimateSize(
               encodingType, values.size(), statistics, options);
       if (!estimatedSize.has_value()) {
-        NIMBLE_SELECTION_LOG(
-            PURPLE << encodingType << " encoding is incompatible.");
+        NIMBLE_SELECTION_LOG(encodingType << " encoding is incompatible.");
         continue;
       }
 
       // We use read factor weights to raise/lower the favorability of each
       // encoding.
-      auto readFactor = pair.second;
-      auto cost = estimatedSize.value() * readFactor;
+      const auto readFactor = entry.second;
+      const auto cost = estimatedSize.value() * readFactor;
       NIMBLE_SELECTION_LOG(
-          YELLOW << "Encoding: " << encodingType
-                 << ", Size: " << estimatedSize.value()
-                 << ", Factor: " << readFactor << ", Cost: " << cost);
+          "Encoding: " << encodingType << ", Size: "
+                       << velox::succinctBytes(estimatedSize.value())
+                       << ", Factor: " << readFactor << ", Cost: " << cost);
       if (cost < minCost) {
         minCost = cost;
         selectedEncoding = encodingType;
       }
     }
-
-    // Currently, we always attempt to compress leaf data streams. The logic
-    // behind this is that encoding selection optimizes the in-memory layout of
-    // data, while compression provides extra saving for persistent storage (and
-    // bandwidth).
-    class AlwaysCompressPolicy : public CompressionPolicy {
-     public:
-      AlwaysCompressPolicy(
-          CompressionOptions compressionOptions,
-          EncodingType encodingType)
-          : compressionOptions_{std::move(compressionOptions)},
-            effectiveAcceptRatio_{getAcceptRatio(encodingType)} {}
-
-      CompressionInformation compression() const override {
-        if (compressionOptions_.compressionType == CompressionType::Zstd) {
-          CompressionInformation information{
-              .compressionType = CompressionType::Zstd,
-              .minCompressionSize = compressionOptions_.zstdMinCompressionSize};
-          information.parameters.zstd.compressionLevel =
-              compressionOptions_.zstdCompressionLevel;
-          return information;
-        }
-        if (compressionOptions_.compressionType == CompressionType::Lz4) {
-          CompressionInformation information{
-              .compressionType = CompressionType::Lz4,
-              .minCompressionSize = compressionOptions_.lz4MinCompressionSize};
-          information.parameters.lz4.accelerationLevel =
-              compressionOptions_.lz4AccelerationLevel;
-          return information;
-        }
-        if (compressionOptions_.compressionType == CompressionType::OpenZL) {
-          CompressionInformation information{
-              .compressionType = CompressionType::OpenZL,
-              .minCompressionSize =
-                  compressionOptions_.openzlMinCompressionSize};
-          information.parameters.openzl.compressionLevel =
-              compressionOptions_.openzlCompressionLevel;
-          information.parameters.openzl.decompressionLevel =
-              compressionOptions_.openzlDecompressionLevel;
-          information.parameters.openzl.formatVersion =
-              compressionOptions_.openzlFormatVersion;
-          return information;
-        }
-        CompressionInformation information{
-            .compressionType = CompressionType::MetaInternal,
-            .minCompressionSize =
-                compressionOptions_.internalMinCompressionSize};
-        information.parameters.metaInternal.compressionLevel =
-            compressionOptions_.internalCompressionLevel;
-        information.parameters.metaInternal.decompressionLevel =
-            compressionOptions_.internalDecompressionLevel;
-        information.parameters.metaInternal.useVariableBitWidthCompressor =
-            compressionOptions_.useVariableBitWidthCompressor;
-        information.parameters.metaInternal.compressionKey =
-            compressionOptions_.metaInternalCompressionKey;
-        return information;
-      }
-
-      virtual bool shouldAccept(
-          CompressionType compressionType,
-          uint64_t uncompressedSize,
-          uint64_t compressedSize) const override {
-        if (uncompressedSize * effectiveAcceptRatio_ < compressedSize) {
-          NIMBLE_SELECTION_LOG(
-              BLUE << compressionType
-                   << " compression rejected. Original size: "
-                   << uncompressedSize
-                   << ", Compressed size: " << compressedSize);
-          return false;
-        }
-
-        NIMBLE_SELECTION_LOG(
-            CYAN << compressionType
-                 << " compression accepted. Original size: " << uncompressedSize
-                 << ", Compressed size: " << compressedSize);
-        return true;
-      }
-
-     private:
-      float getAcceptRatio(EncodingType encodingType) const {
-        for (const auto& [enc, ratio] :
-             compressionOptions_.compressionAcceptRatioOverrides) {
-          if (enc == encodingType) {
-            return ratio;
-          }
-        }
-        return compressionOptions_.compressionAcceptRatio;
-      }
-
-      const CompressionOptions compressionOptions_;
-      const float effectiveAcceptRatio_;
-    };
 
     NIMBLE_SELECTION_LOG(
         "Selected Encoding"
@@ -319,8 +162,7 @@ class ManualEncodingSelectionPolicy : public EncodingSelectionPolicy<T> {
                 ? folly::to<std::string>(
                       " [NestedEncodingIdentifier: ", identifier_.value(), "]")
                 : "")
-        << ": " << GREEN << selectedEncoding << RESET_COLOR
-        << ", Sampled Data: "
+        << ": " << selectedEncoding << ", Sampled Data: "
         << folly::join(
                ",",
                std::span<const physicalType>{
@@ -334,12 +176,14 @@ class ManualEncodingSelectionPolicy : public EncodingSelectionPolicy<T> {
     if (!compressionOptions_.has_value()) {
       return {.encodingType = selectedEncoding};
     }
+    // Encoding selection optimizes the in-memory layout. Compression is still
+    // attempted for leaf data streams to reduce persistent storage size.
     return {
         .encodingType = selectedEncoding,
         .compressionPolicyFactory = [compressionOptions =
                                          compressionOptions_.value(),
                                      selectedEncoding]() {
-          return std::make_unique<AlwaysCompressPolicy>(
+          return std::make_unique<ConfiguredCompressionPolicy>(
               compressionOptions, selectedEncoding);
         }};
   }
@@ -354,172 +198,120 @@ class ManualEncodingSelectionPolicy : public EncodingSelectionPolicy<T> {
     };
   }
 
-  const std::vector<std::pair<EncodingType, float>>& readFactors() const {
-    return readFactors_;
+  const std::vector<std::pair<EncodingType, float>>&
+  candidateEncodingReadFactors() const {
+    return candidateEncodingReadFactors_;
+  }
+
+ protected:
+  std::unique_ptr<EncodingSelectionPolicyBase> createImpl(
+      EncodingType parentEncodingType,
+      NestedEncodingIdentifier nestedEncodingIdentifier,
+      DataType nestedDataType) override {
+    // In each sub-level of the encoding selection, we exclude the encodings
+    // selected in parent levels. Although this is not required (as hopefully,
+    // the model will not pick a nested encoding of the same type as the
+    // parent), it provides an additional safety net, making sure the encoding
+    // selection will eventually converge, and also slightly speeds up nested
+    // encoding selection.
+    // TODO: validate the assumptions here compared to brute forcing, to see if
+    // the same encoding is selected multiple times in the tree (for example,
+    // should we allow trivial string lengths to be encoded using trivial
+    // encoding?)
+    std::vector<std::pair<EncodingType, float>> nestedEncodingReadFactors;
+    nestedEncodingReadFactors.reserve(candidateEncodingReadFactors_.size() - 1);
+    for (const auto& entry : candidateEncodingReadFactors_) {
+      if (entry.first != parentEncodingType) {
+        nestedEncodingReadFactors.emplace_back(entry);
+      }
+    }
+    UNIQUE_PTR_FACTORY_EXTRA(
+        nestedDataType,
+        ManualEncodingSelectionPolicy,
+        COMMA FixedByteWidth,
+        std::move(nestedEncodingReadFactors),
+        compressionOptions_,
+        nestedEncodingIdentifier);
   }
 
  private:
-  // These read factors are used to raise or lower the chances of an encoding to
-  // be picked. Right now, these represent mostly the cpu cost to decode the
-  // values. Trivial is being boosed as we factor in the added benefit of
-  // applying compression.
-  // See ManualEncodingSelectionPolicyFactory::defaultReadFactors for the
-  // default.
-  const std::vector<std::pair<EncodingType, float>> readFactors_;
+  // Candidate encodings and their read-cost factors. Encoding selection uses
+  // estimatedSize * readFactor as the cost, so a lower factor makes an
+  // encoding more likely to be picked. Right now, these represent mostly the
+  // CPU cost to decode values. Trivial is boosted with a lower factor because
+  // it also benefits from applying compression.
+  // See ManualEncodingSelectionPolicyFactory::defaultEncodingReadFactors for
+  // the default.
+  const std::vector<std::pair<EncodingType, float>>
+      candidateEncodingReadFactors_;
   // When nullopt, compression is disabled for this policy and all nested
   // policies created from it.
   const std::optional<CompressionOptions> compressionOptions_;
   const std::optional<NestedEncodingIdentifier> identifier_;
 };
 
-// This model is trained offline and parameters are updated here.
-// The parameters are relatively robust and do not need to be updated
-// unless we add / remove an encoding type.
-template <typename T>
-struct EncodingPredictionModel {
-  using physicalType = typename TypeTraits<T>::physicalType;
-  explicit EncodingPredictionModel()
-      : maxRepeatParam(1.52), minRepeatParam(1.13), uniqueParam(2.589) {}
-  float maxRepeatParam;
-  float minRepeatParam;
-  float uniqueParam;
-  float predict(const Statistics<physicalType>& statistics) {
-    // TODO: Utilize more features within statistics for prediction.
-    auto maxRepeat = statistics.maxRepeat();
-    auto minRepeat = statistics.minRepeat();
-    auto unique = statistics.uniqueCounts().value().size();
-    return maxRepeatParam * maxRepeat + minRepeatParam * minRepeat +
-        uniqueParam * unique;
-  }
-};
-
 class ManualEncodingSelectionPolicyFactory {
  public:
+  /// TODO: Add EncodingType::ALP with an appropriate read factor once the
+  /// actual ALP algorithm is implemented.
+  static std::vector<std::pair<EncodingType, float>>
+  defaultEncodingReadFactors();
+
+  /// Parses semicolon-delimited runtime read-factor config.
+  /// Allows explicit opt-in to parseable encodings that are not part of
+  /// defaultEncodingReadFactors().
+  static std::vector<std::pair<nimble::EncodingType, float>>
+  parseEncodingReadFactors(const std::string& readFactorsConfig);
+
   ManualEncodingSelectionPolicyFactory(
-      std::vector<std::pair<EncodingType, float>> readFactors =
-          defaultReadFactors(),
+      std::vector<std::pair<EncodingType, float>> encodingReadFactors =
+          defaultEncodingReadFactors(),
       std::optional<CompressionOptions> compressionOptions =
-          CompressionOptions{})
-      : readFactors_{std::move(readFactors)},
-        compressionOptions_{std::move(compressionOptions)} {}
+          CompressionOptions{});
 
   std::unique_ptr<EncodingSelectionPolicyBase> createPolicy(
-      DataType dataType) const {
-    UNIQUE_PTR_FACTORY(
-        dataType,
-        ManualEncodingSelectionPolicy,
-        readFactors_,
-        compressionOptions_,
-        std::nullopt);
-  }
-
-  // TODO: Add EncodingType::ALP here once the actual ALP algorithm is
-  // implemented and size estimation is wired up in EncodingSizeEstimation.h.
-  static std::vector<EncodingType> possibleEncodings() {
-    return {
-        EncodingType::Constant,
-        EncodingType::Trivial,
-        EncodingType::FixedBitWidth,
-        EncodingType::MainlyConstant,
-        EncodingType::SparseBool,
-        EncodingType::Dictionary,
-        EncodingType::RLE,
-        EncodingType::Varint,
-        EncodingType::PFOR,
-        EncodingType::SimdForBitpack,
-        EncodingType::SubIntSplit,
-        EncodingType::BlockBitPacking,
-    };
-  }
-
-  // TODO: Add EncodingType::ALP with an appropriate read factor once the
-  // actual ALP algorithm is implemented.
-  static std::vector<std::pair<EncodingType, float>> defaultReadFactors() {
-    return {
-        {EncodingType::Constant, 1.0},
-        {EncodingType::Trivial, 0.7},
-        {EncodingType::FixedBitWidth, 0.9},
-        {EncodingType::MainlyConstant, 1.0},
-        {EncodingType::SparseBool, 1.0},
-        {EncodingType::Dictionary, 1.0},
-        {EncodingType::RLE, 1.0},
-        {EncodingType::Varint, 1.0},
-        // SubIntSplit integration commented out (disabled):
-        /*
-#ifdef NIMBLE_ENABLE_EXPERIMENTAL_ENCODINGS
-        {EncodingType::SubIntSplit, 0.85},
-#endif
-        */
-    };
-  }
-
-  static std::vector<std::pair<nimble::EncodingType, float>> parseReadFactors(
-      const std::string& val) {
-    std::vector<std::pair<nimble::EncodingType, float>> readFactors;
-    std::vector<std::string> parts;
-    folly::split(';', folly::trimWhitespace(val), parts);
-    readFactors.reserve(parts.size());
-
-    std::vector<nimble::EncodingType> possibleEncodings =
-        nimble::ManualEncodingSelectionPolicyFactory::possibleEncodings();
-    std::vector<std::string> possibleEncodingStrings;
-    possibleEncodingStrings.reserve(possibleEncodings.size());
-    std::transform(
-        possibleEncodings.cbegin(),
-        possibleEncodings.cend(),
-        std::back_inserter(possibleEncodingStrings),
-        [](const auto& encoding) { return toString(encoding); });
-    for (const auto& part : parts) {
-      std::vector<std::string> kv;
-      folly::split('=', part, kv);
-      NIMBLE_CHECK_EQ(
-          kv.size(),
-          2,
-          "Invalid read factor format. "
-          "Expected format is <EncodingType>=<facor>;<EncodingType>=<facor>. "
-          "Unable to parse '{}'.",
-          part);
-      auto value = folly::tryTo<float>(kv[1]);
-      NIMBLE_CHECK(
-          value.hasValue(),
-          "Unable to parse read factor value '{}' in '{}'. Expected valid float value.",
-          kv[1],
-          part);
-      bool found = false;
-      auto key = folly::trimWhitespace(kv[0]);
-      for (auto i = 0; i < possibleEncodings.size(); ++i) {
-        auto encoding = possibleEncodings[i];
-        // @lint-ignore CLANGTIDY facebook-hte-LocalUncheckedArrayBounds
-        if (key == possibleEncodingStrings[i]) {
-          found = true;
-          readFactors.emplace_back(encoding, value.value());
-          break;
-        }
-      }
-      NIMBLE_CHECK(
-          found,
-          "Unknown or unexpected read factor encoding '{}'. Allowed values: {}",
-          key,
-          folly::join(",", possibleEncodingStrings));
-    }
-    return readFactors;
-  }
+      DataType dataType) const;
 
  private:
-  const std::vector<std::pair<EncodingType, float>> readFactors_;
+  // TODO: Add EncodingType::ALP here once the actual ALP algorithm is
+  // implemented and size estimation is wired up in EncodingSizeEstimation.h.
+  static std::vector<EncodingType> possibleEncodings();
+
+  const std::vector<std::pair<EncodingType, float>> encodingReadFactors_;
   const std::optional<CompressionOptions> compressionOptions_;
 };
 
-// This is a learned encoding selection implementation.
+/// Learned encoding selection implementation.
 template <typename T>
 class LearnedEncodingSelectionPolicy : public EncodingSelectionPolicy<T> {
   using physicalType = typename TypeTraits<T>::physicalType;
 
  public:
+  /// Model trained offline for learned encoding selection.
+  /// Parameters are relatively robust and do not need updates unless encodings
+  /// are added or removed.
+  struct EncodingPredictionModel {
+    explicit EncodingPredictionModel()
+        : maxRepeatParam(1.52), minRepeatParam(1.13), uniqueParam(2.589) {}
+
+    float maxRepeatParam;
+    float minRepeatParam;
+    float uniqueParam;
+
+    float predict(const Statistics<physicalType>& statistics) {
+      // TODO: Utilize more features within statistics for prediction.
+      const auto maxRepeat = statistics.maxRepeat();
+      const auto minRepeat = statistics.minRepeat();
+      const auto unique = statistics.uniqueCounts().value().size();
+      return maxRepeatParam * maxRepeat + minRepeatParam * minRepeat +
+          uniqueParam * unique;
+    }
+  };
+
   LearnedEncodingSelectionPolicy(
       std::vector<EncodingType> encodingChoices,
       std::optional<NestedEncodingIdentifier> identifier,
-      EncodingPredictionModel<T> encodingModel = EncodingPredictionModel<T>())
+      EncodingPredictionModel encodingModel = EncodingPredictionModel())
       : encodingChoices_{std::move(encodingChoices)},
         identifier_{identifier},
         mlModel_{encodingModel} {}
@@ -528,31 +320,12 @@ class LearnedEncodingSelectionPolicy : public EncodingSelectionPolicy<T> {
       : LearnedEncodingSelectionPolicy{
             possibleEncodingChoices(),
             std::nullopt,
-            EncodingPredictionModel<T>()} {}
+            EncodingPredictionModel()} {}
 
   EncodingSelectionResult select(
       std::span<const physicalType> values,
       const Statistics<physicalType>& statistics,
-      const Encoding::Options& /* options */ = {}) override {
-    if (values.empty()) {
-      return {
-          .encodingType = EncodingType::Trivial,
-      };
-    }
-
-    float prediction = mlModel_.predict(statistics);
-    if (prediction > 0.1) {
-      return {
-          .encodingType = EncodingType::Trivial,
-      };
-    }
-    // TODO: Implement a multi-class Encoding model so that we can predict not
-    // only a trivial encoding but also other encodings.
-
-    return {
-        .encodingType = EncodingType::Trivial,
-    };
-  }
+      const Encoding::Options& options = {}) override;
 
   EncodingSelectionResult selectNullable(
       std::span<const physicalType> /* values */,
@@ -565,9 +338,9 @@ class LearnedEncodingSelectionPolicy : public EncodingSelectionPolicy<T> {
   }
 
   std::unique_ptr<EncodingSelectionPolicyBase> createImpl(
-      EncodingType encodingType,
-      NestedEncodingIdentifier identifier,
-      DataType type) override {
+      EncodingType parentEncodingType,
+      NestedEncodingIdentifier nestedEncodingIdentifier,
+      DataType nestedDataType) override {
     // In each sub-level of the encoding selection, we exclude the encodings
     // selected in parent levels. Although this is not required (as hopefully,
     // the model will not pick a nested encoding of the same type as the
@@ -578,18 +351,18 @@ class LearnedEncodingSelectionPolicy : public EncodingSelectionPolicy<T> {
     // the same encoding is selected multiple times in the tree (for example,
     // should we allow trivial string lengths to be encoded using trivial
     // encoding?)
-    std::vector<EncodingType> filteredReadFactors;
-    filteredReadFactors.reserve(encodingChoices_.size() - 1);
+    std::vector<EncodingType> nestedEncodingChoices;
+    nestedEncodingChoices.reserve(encodingChoices_.size() - 1);
     for (const auto& encodingType_ : encodingChoices_) {
-      if (encodingType_ != encodingType) {
-        filteredReadFactors.push_back(encodingType_);
+      if (encodingType_ != parentEncodingType) {
+        nestedEncodingChoices.push_back(encodingType_);
       }
     }
     UNIQUE_PTR_FACTORY(
-        type,
+        nestedDataType,
         LearnedEncodingSelectionPolicy,
-        std::move(filteredReadFactors),
-        identifier);
+        std::move(nestedEncodingChoices),
+        nestedEncodingIdentifier);
   }
 
  private:
@@ -610,91 +383,54 @@ class LearnedEncodingSelectionPolicy : public EncodingSelectionPolicy<T> {
 
   std::vector<EncodingType> encodingChoices_;
   std::optional<NestedEncodingIdentifier> identifier_;
-  EncodingPredictionModel<T> mlModel_;
+  EncodingPredictionModel mlModel_;
 };
 
-class ReplayedCompressionPolicy : public nimble::CompressionPolicy {
- public:
-  explicit ReplayedCompressionPolicy(
-      nimble::CompressionType compressionType,
-      CompressionOptions compressionOptions)
-      : compressionType_{compressionType},
-        compressionOptions_{std::move(compressionOptions)} {}
-
-  nimble::CompressionInformation compression() const override {
-    if (compressionType_ == nimble::CompressionType::Uncompressed) {
-      return {.compressionType = nimble::CompressionType::Uncompressed};
-    }
-
-    if (compressionType_ == nimble::CompressionType::Zstd) {
-      nimble::CompressionInformation information{
-          .compressionType = nimble::CompressionType::Zstd,
-          .minCompressionSize = compressionOptions_.zstdMinCompressionSize};
-      information.parameters.zstd.compressionLevel =
-          compressionOptions_.zstdCompressionLevel;
-      return information;
-    }
-
-    nimble::CompressionInformation information{
-        .compressionType = nimble::CompressionType::MetaInternal,
-        .minCompressionSize = compressionOptions_.internalMinCompressionSize};
-    information.parameters.metaInternal.compressionLevel =
-        compressionOptions_.internalCompressionLevel;
-    information.parameters.metaInternal.decompressionLevel =
-        compressionOptions_.internalDecompressionLevel;
-    information.parameters.metaInternal.useVariableBitWidthCompressor =
-        compressionOptions_.useVariableBitWidthCompressor;
-    information.parameters.metaInternal.compressionKey =
-        compressionOptions_.metaInternalCompressionKey;
-    return information;
+template <typename T>
+EncodingSelectionResult LearnedEncodingSelectionPolicy<T>::select(
+    std::span<const typename LearnedEncodingSelectionPolicy<T>::physicalType>
+        values,
+    const Statistics<typename LearnedEncodingSelectionPolicy<T>::physicalType>&
+        statistics,
+    const Encoding::Options& /* options */) {
+  if (values.empty()) {
+    return {
+        .encodingType = EncodingType::Trivial,
+    };
   }
 
-  virtual bool shouldAccept(
-      nimble::CompressionType /* compressionType */,
-      uint64_t uncompressedSize,
-      uint64_t compressedSize) const override {
-    if (uncompressedSize * compressionOptions_.compressionAcceptRatio <
-        compressedSize) {
-      NIMBLE_SELECTION_LOG(
-          BLUE << compressionType_ << " compression rejected. Original size: "
-               << uncompressedSize << ", Compressed size: " << compressedSize);
-      return false;
-    }
-
-    NIMBLE_SELECTION_LOG(
-        CYAN << compressionType_ << " compression accepted. Original size: "
-             << uncompressedSize << ", Compressed size: " << compressedSize);
-    return true;
+  const auto prediction = mlModel_.predict(statistics);
+  if (prediction > 0.1) {
+    return {
+        .encodingType = EncodingType::Trivial,
+    };
   }
+  // TODO: Implement a multi-class Encoding model so that we can predict not
+  // only a trivial encoding but also other encodings.
 
- private:
-  const nimble::CompressionType compressionType_;
-  const CompressionOptions compressionOptions_;
-};
+  return {
+      .encodingType = EncodingType::Trivial,
+  };
+}
 
-template <typename TInner>
-class ReplayedEncodingSelectionPolicy;
-
-template <typename TInner>
+template <typename T>
 class ReplayedEncodingSelectionPolicy
-    : public nimble::EncodingSelectionPolicy<TInner> {
-  using physicalType = typename nimble::TypeTraits<TInner>::physicalType;
-
+    : public nimble::EncodingSelectionPolicy<T> {
  public:
+  using physicalType = typename nimble::TypeTraits<T>::physicalType;
+
   ReplayedEncodingSelectionPolicy(
       EncodingLayout encodingLayout,
       std::optional<CompressionOptions> compressionOptions,
-      const EncodingSelectionPolicyFactory& encodingSelectionPolicyFactory)
+      const EncodingSelectionPolicyCreator& encodingSelectionPolicyCreator)
       : compressionOptions_{std::move(compressionOptions)},
-        encodingSelectionPolicyFactory_{encodingSelectionPolicyFactory},
+        encodingSelectionPolicyCreator_{encodingSelectionPolicyCreator},
         encodingLayout_{std::move(encodingLayout)} {}
 
   nimble::EncodingSelectionResult select(
       std::span<const physicalType> /* values */,
       const nimble::Statistics<physicalType>& /* statistics */,
       const Encoding::Options& /* options */ = {}) override {
-    NIMBLE_SELECTION_LOG(
-        CYAN << "Replaying encoding " << encodingLayout_.encodingType());
     if (!compressionOptions_.has_value()) {
       return {
           .encodingType = encodingLayout_.encodingType(),
@@ -715,47 +451,48 @@ class ReplayedEncodingSelectionPolicy
       std::span<const bool> /* nulls */,
       const Statistics<physicalType>& /* statistics */,
       const Encoding::Options& /* options */ = {}) override {
-    NIMBLE_SELECTION_LOG(
-        CYAN << "Replaying nullable encoding "
-             << encodingLayout_.encodingType());
+    // NullableEncoding asks createImpl() for nullable data and nulls children.
+    // The replay policy is initialized with the data layout, so synthesize the
+    // nullable parent shape here.
     encodingLayout_ = EncodingLayout{
         EncodingType::Nullable,
         {},
         CompressionType::Uncompressed,
         {
-            /* Data */ std::move(encodingLayout_),
-            /* Nulls */ std::nullopt,
+            /*Data=*/std::move(encodingLayout_),
+            /*Nulls=*/std::nullopt,
         }};
     return {
         .encodingType = EncodingType::Nullable,
     };
   }
 
+ protected:
   std::unique_ptr<nimble::EncodingSelectionPolicyBase> createImpl(
-      nimble::EncodingType /* encodingType */,
-      nimble::NestedEncodingIdentifier identifier,
-      nimble::DataType type) override {
+      nimble::EncodingType /* parentEncodingType */,
+      nimble::NestedEncodingIdentifier nestedEncodingIdentifier,
+      nimble::DataType nestedDataType) override {
     NIMBLE_CHECK_LT(
-        identifier,
+        nestedEncodingIdentifier,
         encodingLayout_.childrenCount(),
         "Sub-encoding identifier out of range.");
-    auto child = encodingLayout_.child(identifier);
+    auto child = encodingLayout_.child(nestedEncodingIdentifier);
 
     if (child.has_value()) {
       UNIQUE_PTR_FACTORY(
-          type,
+          nestedDataType,
           ReplayedEncodingSelectionPolicy,
           child.value(),
           compressionOptions_,
-          encodingSelectionPolicyFactory_);
+          encodingSelectionPolicyCreator_);
     } else {
-      return encodingSelectionPolicyFactory_(type);
+      return encodingSelectionPolicyCreator_(nestedDataType);
     }
   }
 
  private:
   const std::optional<CompressionOptions> compressionOptions_;
-  const EncodingSelectionPolicyFactory encodingSelectionPolicyFactory_;
+  const EncodingSelectionPolicyCreator encodingSelectionPolicyCreator_;
   EncodingLayout encodingLayout_;
 };
 

--- a/dwio/nimble/encodings/selection/EncodingSizeEstimation.h
+++ b/dwio/nimble/encodings/selection/EncodingSizeEstimation.h
@@ -17,7 +17,6 @@
 
 #include <glog/logging.h>
 #include <algorithm>
-#include <cmath>
 #include <optional>
 #include <span>
 #include "dwio/nimble/common/Exceptions.h"
@@ -27,6 +26,7 @@
 #include "dwio/nimble/encodings/ConstantEncoding.h"
 #include "dwio/nimble/encodings/DictionaryEncoding.h"
 #include "dwio/nimble/encodings/FixedBitWidthEncoding.h"
+#include "dwio/nimble/encodings/FsstEncoding.h"
 #include "dwio/nimble/encodings/MainlyConstantEncoding.h"
 #include "dwio/nimble/encodings/PFOREncoding.h"
 #include "dwio/nimble/encodings/RLEEncoding.h"
@@ -178,7 +178,8 @@ struct EncodingSizeEstimation {
   static std::optional<uint64_t> estimateStringSize(
       const EncodingType encodingType,
       const size_t entryCount,
-      const Statistics<std::string_view>& statistics) {
+      const Statistics<std::string_view>& statistics,
+      const Encoding::Options& options = {}) {
     switch (encodingType) {
       case EncodingType::Constant: {
         return ConstantEncoding<std::string_view>::estimateSize(statistics);
@@ -199,6 +200,13 @@ struct EncodingSizeEstimation {
         return RLEEncoding<std::string_view>::estimateSize(
             entryCount, statistics, FixedByteWidth);
       }
+      case EncodingType::Fsst: {
+        return FsstEncoding::estimateSize(
+            entryCount,
+            statistics,
+            FixedByteWidth,
+            options.fsstCompressionTargetRatio);
+      }
       default: {
         return std::nullopt;
       }
@@ -215,7 +223,7 @@ struct EncodingSizeEstimation {
     } else if constexpr (isBoolType<physicalType>()) {
       return estimateBoolSize(encodingType, entryCount, statistics);
     } else if constexpr (isStringType<physicalType>()) {
-      return estimateStringSize(encodingType, entryCount, statistics);
+      return estimateStringSize(encodingType, entryCount, statistics, options);
     }
 
     NIMBLE_UNREACHABLE(

--- a/dwio/nimble/encodings/tests/CMakeLists.txt
+++ b/dwio/nimble/encodings/tests/CMakeLists.txt
@@ -26,6 +26,7 @@ add_executable(
   CompressionTest.cpp
   EncodingTest.cpp
   EncodingLegacyTest.cpp
+  FsstEncodingTest.cpp
   Lz4CompressorTest.cpp
   ForEncodingTest.cpp
   FrequencyPartitionEncodingTest.cpp

--- a/dwio/nimble/encodings/tests/CompressionTest.cpp
+++ b/dwio/nimble/encodings/tests/CompressionTest.cpp
@@ -50,7 +50,7 @@ class TestCompressionPolicy : public nimble::CompressionPolicy {
     compressionInfo_.parameters.metaInternal.decompressionLevel = 2;
   }
 
-  nimble::CompressionInformation compression() const override {
+  nimble::CompressionConfig config() const override {
     return compressionInfo_;
   }
 
@@ -62,7 +62,7 @@ class TestCompressionPolicy : public nimble::CompressionPolicy {
   }
 
  private:
-  nimble::CompressionInformation compressionInfo_;
+  nimble::CompressionConfig compressionInfo_;
 };
 
 template <typename T>
@@ -150,6 +150,55 @@ TEST(CompressionTests, VerifyDefaultMinCompressionSize) {
       nimble::kZstdMinCompressionSize);
   EXPECT_EQ(
       compressionOptions.lz4MinCompressionSize, nimble::kLz4MinCompressionSize);
+}
+
+TEST(CompressionTests, NoCompressionPolicy) {
+  nimble::NoCompressionPolicy policy;
+
+  EXPECT_EQ(
+      policy.config().compressionType, nimble::CompressionType::Uncompressed);
+  EXPECT_FALSE(policy.shouldAccept(
+      nimble::CompressionType::Zstd,
+      /*uncompressedSize=*/100,
+      /*compressedSize=*/1));
+}
+
+TEST(CompressionTests, ConfiguredCompressionPolicyUsesCompressionOptions) {
+  nimble::CompressionOptions options{
+      .compressionType = nimble::CompressionType::Zstd,
+      .zstdMinCompressionSize = 123,
+      .zstdCompressionLevel = 7,
+  };
+
+  nimble::ConfiguredCompressionPolicy policy{
+      options, nimble::EncodingType::FixedBitWidth};
+  const auto compression = policy.config();
+
+  EXPECT_EQ(compression.compressionType, nimble::CompressionType::Zstd);
+  EXPECT_EQ(compression.minCompressionSize, 123);
+  EXPECT_EQ(compression.parameters.zstd.compressionLevel, 7);
+}
+
+TEST(CompressionTests, ConfiguredCompressionPolicyAcceptRatioOverride) {
+  nimble::ConfiguredCompressionPolicy blockBitPackingPolicy{
+      nimble::CompressionOptions{}, nimble::EncodingType::BlockBitPacking};
+
+  EXPECT_FALSE(blockBitPackingPolicy.shouldAccept(
+      nimble::CompressionType::MetaInternal,
+      /*uncompressedSize=*/100,
+      /*compressedSize=*/80));
+  EXPECT_TRUE(blockBitPackingPolicy.shouldAccept(
+      nimble::CompressionType::MetaInternal,
+      /*uncompressedSize=*/100,
+      /*compressedSize=*/60));
+
+  nimble::ConfiguredCompressionPolicy trivialPolicy{
+      nimble::CompressionOptions{}, nimble::EncodingType::Trivial};
+
+  EXPECT_TRUE(trivialPolicy.shouldAccept(
+      nimble::CompressionType::MetaInternal,
+      /*uncompressedSize=*/100,
+      /*compressedSize=*/80));
 }
 
 TEST(CompressionTests, MinCompresssionSizeIsApplied) {

--- a/dwio/nimble/encodings/tests/DeltaEncodingLegacyTest.cpp
+++ b/dwio/nimble/encodings/tests/DeltaEncodingLegacyTest.cpp
@@ -34,7 +34,7 @@ namespace {
 
 class TestCompressPolicy : public CompressionPolicy {
  public:
-  CompressionInformation compression() const override {
+  CompressionConfig config() const override {
     return {.compressionType = CompressionType::Uncompressed};
   }
 

--- a/dwio/nimble/encodings/tests/EncodingLayoutTest.cpp
+++ b/dwio/nimble/encodings/tests/EncodingLayoutTest.cpp
@@ -86,7 +86,7 @@ template <typename T, typename TCollection = std::vector<T>>
 nimble::EncodingLayout encodeAndCapture(
     nimble::EncodingLayout encodingLayout,
     TCollection data) {
-  nimble::EncodingSelectionPolicyFactory encodingSelectionPolicyFactory =
+  nimble::EncodingSelectionPolicyCreator encodingSelectionPolicyCreator =
       [encodingFactory = nimble::ManualEncodingSelectionPolicyFactory{}](
           nimble::DataType dataType)
       -> std::unique_ptr<nimble::EncodingSelectionPolicyBase> {
@@ -100,7 +100,7 @@ nimble::EncodingLayout encodeAndCapture(
           std::move(encodingLayout),
           nimble::CompressionOptions{
               .compressionAcceptRatio = 100, .internalMinCompressionSize = 0},
-          encodingSelectionPolicyFactory),
+          encodingSelectionPolicyCreator),
       data,
       buffer);
 
@@ -139,7 +139,8 @@ class ForceSubIntSplitPolicy final : public nimble::EncodingSelectionPolicy<T> {
       nimble::NestedEncodingIdentifier /* identifier */,
       nimble::DataType type) override {
     nimble::ManualEncodingSelectionPolicyFactory factory{
-        nimble::ManualEncodingSelectionPolicyFactory::defaultReadFactors(),
+        nimble::ManualEncodingSelectionPolicyFactory::
+            defaultEncodingReadFactors(),
         std::nullopt};
     return factory.createPolicy(type);
   }
@@ -522,7 +523,7 @@ TEST(EncodingLayoutTests, Nullable) {
 
   testSerialization(expected);
 
-  nimble::EncodingSelectionPolicyFactory encodingSelectionPolicyFactory =
+  nimble::EncodingSelectionPolicyCreator encodingSelectionPolicyCreator =
       [encodingFactory = nimble::ManualEncodingSelectionPolicyFactory{}](
           nimble::DataType dataType)
       -> std::unique_ptr<nimble::EncodingSelectionPolicyBase> {
@@ -535,7 +536,7 @@ TEST(EncodingLayoutTests, Nullable) {
       std::make_unique<nimble::ReplayedEncodingSelectionPolicy<uint32_t>>(
           expected.child(nimble::EncodingIdentifiers::Nullable::Data).value(),
           nimble::CompressionOptions{},
-          encodingSelectionPolicyFactory),
+          encodingSelectionPolicyCreator),
       std::vector<uint32_t>{1, 1, 1, 1, 5, 1},
       std::array<bool, 6>{false, false, true, false, false, false},
       buffer);
@@ -616,7 +617,7 @@ TEST(EncodingLayoutTests, SubIntSplitSerialization) {
 // Verify that EncodingLayoutCapture correctly reads the SubIntSplit binary
 // format and that the captured tree round-trips through serialize/deserialize.
 TEST(EncodingLayoutTests, SubIntSplitCapture) {
-  nimble::EncodingSelectionPolicyFactory encodingSelectionPolicyFactory =
+  nimble::EncodingSelectionPolicyCreator encodingSelectionPolicyCreator =
       [encodingFactory = nimble::ManualEncodingSelectionPolicyFactory{}](
           nimble::DataType dataType)
       -> std::unique_ptr<nimble::EncodingSelectionPolicyBase> {
@@ -714,7 +715,7 @@ TEST(EncodingLayoutTests, SubIntSplitCapture) {
 }
 
 TEST(EncodingLayoutTests, SubIntSplitPreserveBoundariesReplay) {
-  nimble::EncodingSelectionPolicyFactory encodingSelectionPolicyFactory =
+  nimble::EncodingSelectionPolicyCreator encodingSelectionPolicyCreator =
       [encodingFactory = nimble::ManualEncodingSelectionPolicyFactory{}](
           nimble::DataType dataType)
       -> std::unique_ptr<nimble::EncodingSelectionPolicyBase> {
@@ -743,7 +744,7 @@ TEST(EncodingLayoutTests, SubIntSplitPreserveBoundariesReplay) {
 
   auto encoding = nimble::EncodingFactory::encode<int64_t>(
       std::make_unique<nimble::ReplayedEncodingSelectionPolicy<int64_t>>(
-          preserveLayout, std::nullopt, encodingSelectionPolicyFactory),
+          preserveLayout, std::nullopt, encodingSelectionPolicyCreator),
       data,
       buffer);
 

--- a/dwio/nimble/encodings/tests/EncodingLegacyTest.cpp
+++ b/dwio/nimble/encodings/tests/EncodingLegacyTest.cpp
@@ -58,12 +58,12 @@ class TestCompressPolicy : public nimble::CompressionPolicy {
       : compress_{compress},
         useVariableBitWidthCompressor_{useVariableBitWidthCompressor} {}
 
-  nimble::CompressionInformation compression() const override {
+  nimble::CompressionConfig config() const override {
     if (!compress_) {
       return {.compressionType = nimble::CompressionType::Uncompressed};
     }
 
-    nimble::CompressionInformation information{
+    nimble::CompressionConfig information{
         .compressionType = nimble::CompressionType::MetaInternal};
     information.parameters.metaInternal.compressionLevel = 9;
     information.parameters.metaInternal.decompressionLevel = 2;

--- a/dwio/nimble/encodings/tests/EncodingSelectionTest.cpp
+++ b/dwio/nimble/encodings/tests/EncodingSelectionTest.cpp
@@ -1012,7 +1012,8 @@ TEST(ManualEncodingSelectionPolicyTest, noCompressFlag) {
   // Encode with compression enabled (explicit CompressionOptions).
   auto compressPolicy =
       std::make_unique<nimble::ManualEncodingSelectionPolicy<uint32_t>>(
-          nimble::ManualEncodingSelectionPolicyFactory::defaultReadFactors(),
+          nimble::ManualEncodingSelectionPolicyFactory::
+              defaultEncodingReadFactors(),
           nimble::CompressionOptions{},
           std::nullopt);
   auto result =
@@ -1020,7 +1021,7 @@ TEST(ManualEncodingSelectionPolicyTest, noCompressFlag) {
   auto compressionPolicy = result.compressionPolicyFactory();
   // Compression should be attempted (non-Uncompressed type).
   EXPECT_NE(
-      compressionPolicy->compression().compressionType,
+      compressionPolicy->config().compressionType,
       nimble::CompressionType::Uncompressed);
 
   // Default factory parameters — compression should also be enabled.
@@ -1035,14 +1036,15 @@ TEST(ManualEncodingSelectionPolicyTest, noCompressFlag) {
         typedDefault->select(data, nimble::Statistics<uint32_t>::create(data));
     auto defaultCompressionPolicy = defaultResult.compressionPolicyFactory();
     EXPECT_NE(
-        defaultCompressionPolicy->compression().compressionType,
+        defaultCompressionPolicy->config().compressionType,
         nimble::CompressionType::Uncompressed);
   }
 
   // Encode with compression disabled (nullopt).
   auto noCompressPolicy =
       std::make_unique<nimble::ManualEncodingSelectionPolicy<uint32_t>>(
-          nimble::ManualEncodingSelectionPolicyFactory::defaultReadFactors(),
+          nimble::ManualEncodingSelectionPolicyFactory::
+              defaultEncodingReadFactors(),
           /*compressionOptions=*/std::nullopt,
           std::nullopt);
   auto noCompressResult = noCompressPolicy->select(
@@ -1050,7 +1052,7 @@ TEST(ManualEncodingSelectionPolicyTest, noCompressFlag) {
   auto noCompressionPolicy = noCompressResult.compressionPolicyFactory();
   // Compression should be Uncompressed (default NoCompressionPolicy).
   EXPECT_EQ(
-      noCompressionPolicy->compression().compressionType,
+      noCompressionPolicy->config().compressionType,
       nimble::CompressionType::Uncompressed);
 
   // Both should select the same encoding type.
@@ -1064,7 +1066,8 @@ TEST(ManualEncodingSelectionPolicyTest, noCompressFlagPropagesToNested) {
   // compression disabled.
   auto policy =
       std::make_unique<nimble::ManualEncodingSelectionPolicy<uint32_t>>(
-          nimble::ManualEncodingSelectionPolicyFactory::defaultReadFactors(),
+          nimble::ManualEncodingSelectionPolicyFactory::
+              defaultEncodingReadFactors(),
           /*compressionOptions=*/std::nullopt,
           std::nullopt);
 
@@ -1082,7 +1085,7 @@ TEST(ManualEncodingSelectionPolicyTest, noCompressFlagPropagesToNested) {
       typedNested->select(data, nimble::Statistics<uint32_t>::create(data));
   auto nestedCompressionPolicy = nestedResult.compressionPolicyFactory();
   EXPECT_EQ(
-      nestedCompressionPolicy->compression().compressionType,
+      nestedCompressionPolicy->config().compressionType,
       nimble::CompressionType::Uncompressed);
 }
 
@@ -1174,7 +1177,8 @@ TEST(ManualEncodingSelectionPolicyFactoryTest, noCompressFactory) {
   // Factory with nullopt compressionOptions should create policies that skip
   // compression.
   nimble::ManualEncodingSelectionPolicyFactory factory{
-      nimble::ManualEncodingSelectionPolicyFactory::defaultReadFactors(),
+      nimble::ManualEncodingSelectionPolicyFactory::
+          defaultEncodingReadFactors(),
       /*compressionOptions=*/std::nullopt};
 
   auto policy = factory.createPolicy(nimble::DataType::Uint32);
@@ -1186,7 +1190,7 @@ TEST(ManualEncodingSelectionPolicyFactoryTest, noCompressFactory) {
   auto result = typed->select(data, nimble::Statistics<uint32_t>::create(data));
   auto compressionPolicy = result.compressionPolicyFactory();
   EXPECT_EQ(
-      compressionPolicy->compression().compressionType,
+      compressionPolicy->config().compressionType,
       nimble::CompressionType::Uncompressed);
 }
 
@@ -1196,7 +1200,8 @@ TEST(
   // Factory with nullopt compressionOptions should create policies whose
   // nested children also have compression disabled.
   nimble::ManualEncodingSelectionPolicyFactory factory{
-      nimble::ManualEncodingSelectionPolicyFactory::defaultReadFactors(),
+      nimble::ManualEncodingSelectionPolicyFactory::
+          defaultEncodingReadFactors(),
       /*compressionOptions=*/std::nullopt};
 
   auto policy = factory.createPolicy(nimble::DataType::Uint32);
@@ -1218,7 +1223,7 @@ TEST(
       typedNested->select(data, nimble::Statistics<uint32_t>::create(data));
   auto nestedCompressionPolicy = nestedResult.compressionPolicyFactory();
   EXPECT_EQ(
-      nestedCompressionPolicy->compression().compressionType,
+      nestedCompressionPolicy->config().compressionType,
       nimble::CompressionType::Uncompressed);
 }
 
@@ -1229,9 +1234,10 @@ TEST(ReplayedEncodingSelectionPolicyTest, encodingRoundTrip) {
   nimble::Buffer buffer(*pool);
 
   nimble::ManualEncodingSelectionPolicyFactory factory{
-      nimble::ManualEncodingSelectionPolicyFactory::defaultReadFactors(),
+      nimble::ManualEncodingSelectionPolicyFactory::
+          defaultEncodingReadFactors(),
       /*compressionOptions=*/std::nullopt};
-  nimble::EncodingSelectionPolicyFactory policyFactory =
+  nimble::EncodingSelectionPolicyCreator policyCreator =
       [&factory](nimble::DataType dataType) {
         return factory.createPolicy(dataType);
       };
@@ -1241,7 +1247,7 @@ TEST(ReplayedEncodingSelectionPolicyTest, encodingRoundTrip) {
     std::optional<nimble::CompressionOptions> compressionOptions;
     std::vector<uint32_t> data;
     // Children layouts for compound encodings (e.g., RLE needs RunLengths
-    // and RunValues slots). nullopt children fall back to policyFactory.
+    // and RunValues slots). nullopt children fall back to policyCreator.
     std::vector<std::optional<const nimble::EncodingLayout>> children;
     std::string debugString() const {
       return fmt::format(
@@ -1273,7 +1279,7 @@ TEST(ReplayedEncodingSelectionPolicyTest, encodingRoundTrip) {
         testData.children};
     auto policy =
         std::make_unique<nimble::ReplayedEncodingSelectionPolicy<uint32_t>>(
-            std::move(layout), testData.compressionOptions, policyFactory);
+            std::move(layout), testData.compressionOptions, policyCreator);
 
     auto encoded = nimble::EncodingFactory::encode<uint32_t>(
         std::move(policy), std::span<const uint32_t>(testData.data), buffer);
@@ -1329,7 +1335,8 @@ TEST(ManualEncodingSelectionPolicyTest, nestedEncodingCompressionType) {
     buffer.reset();
 
     nimble::ManualEncodingSelectionPolicyFactory factory{
-        nimble::ManualEncodingSelectionPolicyFactory::defaultReadFactors(),
+        nimble::ManualEncodingSelectionPolicyFactory::
+            defaultEncodingReadFactors(),
         testData.compressionOptions};
     auto basePolicy = factory.createPolicy(nimble::DataType::Uint32);
     auto* rawTyped = dynamic_cast<nimble::EncodingSelectionPolicy<uint32_t>*>(
@@ -1389,7 +1396,8 @@ TEST(ReplayedEncodingSelectionPolicyTest, nestedEncodingCompressionType) {
   nimble::Buffer buffer(*pool);
 
   nimble::ManualEncodingSelectionPolicyFactory fallbackFactory{
-      nimble::ManualEncodingSelectionPolicyFactory::defaultReadFactors(),
+      nimble::ManualEncodingSelectionPolicyFactory::
+          defaultEncodingReadFactors(),
       /*compressionOptions=*/std::nullopt};
   auto policyFactory = [&fallbackFactory](nimble::DataType dataType) {
     return fallbackFactory.createPolicy(dataType);
@@ -1482,13 +1490,14 @@ TEST(ManualEncodingSelectionPolicyTest, defaultCompressionType) {
 
   auto policy =
       std::make_unique<nimble::ManualEncodingSelectionPolicy<uint32_t>>(
-          nimble::ManualEncodingSelectionPolicyFactory::defaultReadFactors(),
+          nimble::ManualEncodingSelectionPolicyFactory::
+              defaultEncodingReadFactors(),
           nimble::CompressionOptions{},
           std::nullopt);
   auto result =
       policy->select(data, nimble::Statistics<uint32_t>::create(data));
   auto compressionPolicy = result.compressionPolicyFactory();
-  auto info = compressionPolicy->compression();
+  auto info = compressionPolicy->config();
 
 #ifndef DISABLE_META_INTERNAL_COMPRESSOR
   EXPECT_EQ(info.compressionType, nimble::CompressionType::MetaInternal);
@@ -1507,13 +1516,14 @@ TEST(ManualEncodingSelectionPolicyTest, explicitZstdCompressionType) {
   };
   auto policy =
       std::make_unique<nimble::ManualEncodingSelectionPolicy<uint32_t>>(
-          nimble::ManualEncodingSelectionPolicyFactory::defaultReadFactors(),
+          nimble::ManualEncodingSelectionPolicyFactory::
+              defaultEncodingReadFactors(),
           options,
           std::nullopt);
   auto result =
       policy->select(data, nimble::Statistics<uint32_t>::create(data));
   auto compressionPolicy = result.compressionPolicyFactory();
-  auto info = compressionPolicy->compression();
+  auto info = compressionPolicy->config();
 
   EXPECT_EQ(info.compressionType, nimble::CompressionType::Zstd);
   EXPECT_EQ(
@@ -1532,13 +1542,14 @@ TEST(ManualEncodingSelectionPolicyTest, explicitMetaInternalCompressionType) {
   };
   auto policy =
       std::make_unique<nimble::ManualEncodingSelectionPolicy<uint32_t>>(
-          nimble::ManualEncodingSelectionPolicyFactory::defaultReadFactors(),
+          nimble::ManualEncodingSelectionPolicyFactory::
+              defaultEncodingReadFactors(),
           options,
           std::nullopt);
   auto result =
       policy->select(data, nimble::Statistics<uint32_t>::create(data));
   auto compressionPolicy = result.compressionPolicyFactory();
-  auto info = compressionPolicy->compression();
+  auto info = compressionPolicy->config();
 
   EXPECT_EQ(info.compressionType, nimble::CompressionType::MetaInternal);
   EXPECT_EQ(
@@ -1562,7 +1573,8 @@ TEST(ManualEncodingSelectionPolicyTest, compressionTypeRoundTrip) {
   };
   auto policy =
       std::make_unique<nimble::ManualEncodingSelectionPolicy<uint32_t>>(
-          nimble::ManualEncodingSelectionPolicyFactory::defaultReadFactors(),
+          nimble::ManualEncodingSelectionPolicyFactory::
+              defaultEncodingReadFactors(),
           options,
           std::nullopt);
 
@@ -1591,7 +1603,8 @@ TEST(ManualEncodingSelectionPolicyTest, compressionAcceptRatioOverride) {
   };
   auto policy =
       std::make_unique<nimble::ManualEncodingSelectionPolicy<uint32_t>>(
-          nimble::ManualEncodingSelectionPolicyFactory::defaultReadFactors(),
+          nimble::ManualEncodingSelectionPolicyFactory::
+              defaultEncodingReadFactors(),
           options,
           std::nullopt);
   auto result =
@@ -1604,12 +1617,31 @@ TEST(ManualEncodingSelectionPolicyTest, compressionAcceptRatioOverride) {
   // Constant encoding has override ratio=0.0, so compression is attempted but
   // shouldAccept() will always reject (0 < compressedSize).
   EXPECT_NE(
-      compressionPolicy->compression().compressionType,
+      compressionPolicy->config().compressionType,
       nimble::CompressionType::Uncompressed);
   EXPECT_FALSE(compressionPolicy->shouldAccept(
       nimble::CompressionType::Zstd,
       /*uncompressedSize=*/100,
       /*compressedSize=*/1));
+}
+
+TEST(ManualEncodingSelectionPolicyFactoryTest, fsstRequiresExplicitOptIn) {
+  const auto defaultEncodingReadFactors = nimble::
+      ManualEncodingSelectionPolicyFactory::defaultEncodingReadFactors();
+  EXPECT_EQ(
+      std::find_if(
+          defaultEncodingReadFactors.begin(),
+          defaultEncodingReadFactors.end(),
+          [](const auto& entry) {
+            return entry.first == nimble::EncodingType::Fsst;
+          }),
+      defaultEncodingReadFactors.end());
+
+  EXPECT_EQ(
+      nimble::ManualEncodingSelectionPolicyFactory::parseEncodingReadFactors(
+          "Fsst=1.0"),
+      (std::vector<std::pair<nimble::EncodingType, float>>{
+          {nimble::EncodingType::Fsst, 1.0}}));
 }
 
 TEST(
@@ -1625,7 +1657,8 @@ TEST(
   };
   auto policy =
       std::make_unique<nimble::ManualEncodingSelectionPolicy<uint32_t>>(
-          nimble::ManualEncodingSelectionPolicyFactory::defaultReadFactors(),
+          nimble::ManualEncodingSelectionPolicyFactory::
+              defaultEncodingReadFactors(),
           options,
           std::nullopt);
   auto result =
@@ -1638,7 +1671,7 @@ TEST(
   // No override for Constant, so the global ratio applies — compression
   // should be attempted.
   EXPECT_NE(
-      compressionPolicy->compression().compressionType,
+      compressionPolicy->config().compressionType,
       nimble::CompressionType::Uncompressed);
 }
 
@@ -1656,7 +1689,8 @@ TEST(
   };
   auto policy =
       std::make_unique<nimble::ManualEncodingSelectionPolicy<uint32_t>>(
-          nimble::ManualEncodingSelectionPolicyFactory::defaultReadFactors(),
+          nimble::ManualEncodingSelectionPolicyFactory::
+              defaultEncodingReadFactors(),
           options,
           std::nullopt);
   auto result =

--- a/dwio/nimble/encodings/tests/EncodingTest.cpp
+++ b/dwio/nimble/encodings/tests/EncodingTest.cpp
@@ -65,12 +65,12 @@ class TestCompressPolicy : public nimble::CompressionPolicy {
       : compress_{compress},
         useVariableBitWidthCompressor_{useVariableBitWidthCompressor} {}
 
-  nimble::CompressionInformation compression() const override {
+  nimble::CompressionConfig config() const override {
     if (!compress_) {
       return {.compressionType = nimble::CompressionType::Uncompressed};
     }
 
-    nimble::CompressionInformation information{
+    nimble::CompressionConfig information{
         .compressionType = nimble::CompressionType::MetaInternal};
     information.parameters.metaInternal.compressionLevel = 9;
     information.parameters.metaInternal.decompressionLevel = 2;

--- a/dwio/nimble/encodings/tests/EncodingTestsLegacy.cpp
+++ b/dwio/nimble/encodings/tests/EncodingTestsLegacy.cpp
@@ -58,12 +58,12 @@ class TestCompressPolicy : public nimble::CompressionPolicy {
       : compress_{compress},
         useVariableBitWidthCompressor_{useVariableBitWidthCompressor} {}
 
-  nimble::CompressionInformation compression() const override {
+  nimble::CompressionConfig config() const override {
     if (!compress_) {
       return {.compressionType = nimble::CompressionType::Uncompressed};
     }
 
-    nimble::CompressionInformation information{
+    nimble::CompressionConfig information{
         .compressionType = nimble::CompressionType::Zstd};
     information.parameters.zstd.compressionLevel = 9;
     return information;

--- a/dwio/nimble/encodings/tests/FsstEncodingTest.cpp
+++ b/dwio/nimble/encodings/tests/FsstEncodingTest.cpp
@@ -1,0 +1,566 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "dwio/nimble/encodings/FsstEncoding.h"
+
+#include <fmt/core.h>
+#include <gtest/gtest.h>
+#include <limits>
+
+#include "dwio/nimble/common/Buffer.h"
+#include "dwio/nimble/encodings/FixedBitWidthEncoding.h"
+#include "dwio/nimble/encodings/common/EncodingFactory.h"
+#include "dwio/nimble/encodings/common/EncodingPrefix.h"
+#include "dwio/nimble/encodings/selection/EncodingSelection.h"
+#include "dwio/nimble/encodings/selection/EncodingSelectionPolicy.h"
+#include "velox/buffer/Buffer.h"
+#include "velox/common/memory/Memory.h"
+
+namespace facebook::nimble::test {
+namespace {
+
+class FsstEncodingTest : public ::testing::Test {
+ protected:
+  static void SetUpTestCase() {
+    velox::memory::MemoryManager::initialize({});
+  }
+
+  void SetUp() override {
+    pool_ = velox::memory::memoryManager()->addLeafPool();
+  }
+
+  std::unique_ptr<EncodingSelectionPolicy<std::string_view>>
+  createSelectionPolicy(
+      CompressionOptions compressionOptions = {},
+      CompressionType compressionType = CompressionType::Uncompressed) {
+    // FSST has one nested child encoding for compressed string lengths.
+    std::vector<std::optional<const EncodingLayout>> children;
+    children.emplace_back(
+        EncodingLayout{
+            EncodingType::Trivial, {}, CompressionType::Uncompressed});
+    EncodingLayout layout{
+        EncodingType::Fsst, {}, compressionType, std::move(children)};
+    return std::make_unique<ReplayedEncodingSelectionPolicy<std::string_view>>(
+        std::move(layout),
+        std::move(compressionOptions),
+        encodingSelectionPolicyCreator_);
+  }
+
+  std::unique_ptr<EncodingSelectionPolicy<std::string_view>>
+  createTrivialSelectionPolicy(CompressionOptions compressionOptions) {
+    const auto compressionType = compressionOptions.compressionType;
+    std::vector<std::optional<const EncodingLayout>> children;
+    children.emplace_back(
+        EncodingLayout{
+            EncodingType::Trivial, {}, CompressionType::Uncompressed});
+    EncodingLayout layout{
+        EncodingType::Trivial, {}, compressionType, std::move(children)};
+    return std::make_unique<ReplayedEncodingSelectionPolicy<std::string_view>>(
+        std::move(layout),
+        std::move(compressionOptions),
+        encodingSelectionPolicyCreator_);
+  }
+
+  std::function<void*(uint32_t)> createStringBufferFactory() {
+    return [this](uint32_t totalLength) {
+      auto& buffer = stringBuffers_.emplace_back(
+          velox::AlignedBuffer::allocate<char>(totalLength, pool_.get()));
+      return buffer->asMutable<void>();
+    };
+  }
+
+  std::string_view encodeFsst(
+      const std::vector<std::string_view>& values,
+      Buffer& buffer) {
+    return EncodingFactory::encode<std::string_view>(
+        createSelectionPolicy(),
+        values,
+        buffer,
+        {.fsstCompressionTargetRatio = std::numeric_limits<double>::max()});
+  }
+
+  void roundTrip(
+      const std::vector<std::string_view>& values,
+      const std::string& testName = "",
+      EncodingType expectedEncodingType = EncodingType::Fsst) {
+    SCOPED_TRACE(testName);
+
+    Buffer buffer{*pool_};
+    auto encoded = encodeFsst(values, buffer);
+    stringBuffers_.clear();
+
+    auto encoding = EncodingFactory({}).create(
+        *pool_, encoded, createStringBufferFactory());
+
+    ASSERT_EQ(encoding->dataType(), DataType::String);
+    ASSERT_EQ(encoding->encodingType(), expectedEncodingType);
+    ASSERT_EQ(encoding->rowCount(), values.size());
+
+    std::vector<std::string_view> decoded(values.size());
+    encoding->materialize(values.size(), decoded.data());
+
+    ASSERT_EQ(decoded.size(), values.size());
+    for (size_t i = 0; i < values.size(); ++i) {
+      EXPECT_EQ(decoded[i], values[i]) << "mismatch at row " << i;
+    }
+  }
+
+  std::shared_ptr<velox::memory::MemoryPool> pool_;
+  std::vector<velox::BufferPtr> stringBuffers_;
+  ManualEncodingSelectionPolicyFactory manualPolicyFactory_;
+  EncodingSelectionPolicyCreator encodingSelectionPolicyCreator_ =
+      [this](DataType dataType) {
+        return manualPolicyFactory_.createPolicy(dataType);
+      };
+};
+
+class TestReader {
+ public:
+  velox::BufferPtr& nullsInReadRange() {
+    return nullsInReadRange_;
+  }
+
+  const uint64_t* rawNullsInReadRange() const {
+    return nullsInReadRange_ ? nullsInReadRange_->as<uint64_t>() : nullptr;
+  }
+
+  bool returnReaderNulls() const {
+    return false;
+  }
+
+ private:
+  velox::BufferPtr nullsInReadRange_;
+};
+
+class StringReadWithVisitor {
+ public:
+  using DataType = std::string_view;
+  using Extract = std::nullptr_t;
+
+  explicit StringReadWithVisitor(std::vector<vector_size_t> rows)
+      : rows_{std::move(rows)} {}
+
+  TestReader& reader() {
+    return reader_;
+  }
+
+  vector_size_t numRows() const {
+    return rows_.size();
+  }
+
+  vector_size_t rowAt(vector_size_t index) const {
+    return rows_[index];
+  }
+
+  vector_size_t currentRow() const {
+    return rowAt(rowIndex_);
+  }
+
+  void process(std::string_view value, bool& atEnd) {
+    values_.push_back(value);
+    addRowIndex(1);
+    atEnd = this->atEnd();
+  }
+
+  void processNull(bool& atEnd) {
+    addRowIndex(1);
+    atEnd = this->atEnd();
+  }
+
+  bool allowNulls() const {
+    return false;
+  }
+
+  void addRowIndex(vector_size_t count) {
+    rowIndex_ += count;
+  }
+
+  void addNumValues(vector_size_t /* count */) {}
+
+  bool atEnd() const {
+    return rowIndex_ >= rows_.size();
+  }
+
+  const std::vector<std::string_view>& values() const {
+    return values_;
+  }
+
+ private:
+  TestReader reader_;
+  std::vector<vector_size_t> rows_;
+  vector_size_t rowIndex_{0};
+  std::vector<std::string_view> values_;
+};
+
+TEST_F(FsstEncodingTest, roundTripStrings) {
+  struct TestCase {
+    std::string name;
+    std::vector<std::string_view> values;
+    EncodingType expectedEncodingType{EncodingType::Fsst};
+  };
+
+  std::vector<std::string> highCardinalityStorage;
+  highCardinalityStorage.reserve(1'000);
+  for (int i = 0; i < 1'000; ++i) {
+    highCardinalityStorage.emplace_back(
+        fmt::format("url/path/segment/{}/page?id={}", i, i));
+  }
+  std::vector<std::string_view> highCardinalityValues;
+  highCardinalityValues.reserve(highCardinalityStorage.size());
+  for (const auto& value : highCardinalityStorage) {
+    highCardinalityValues.emplace_back(value);
+  }
+
+  std::string stringWithNullBytes1("ab\x00\x01\x02", 5);
+  std::string stringWithNullBytes2("\x00\xff\x00", 3);
+  std::string normalString("normal");
+  std::string longString1(10'000, 'a');
+  std::string longString2(10'000, 'b');
+
+  std::vector<TestCase> testCases{
+      {"basic strings", {"hello", "world", "hello world", "foo", "bar", "baz"}},
+      {"all empty strings", {"", "", "", ""}, EncodingType::Trivial},
+      {"mixed empty and non-empty", {"", "abc", "", "def", ""}},
+      {"single string", {"single"}},
+      {"high cardinality URLs", std::move(highCardinalityValues)},
+      {"strings with null bytes",
+       {std::string_view{stringWithNullBytes1},
+        std::string_view{stringWithNullBytes2},
+        std::string_view{normalString}}},
+      {"long strings",
+       {std::string_view{longString1}, std::string_view{longString2}}},
+  };
+
+  for (const auto& testCase : testCases) {
+    roundTrip(testCase.values, testCase.name, testCase.expectedEncodingType);
+  }
+}
+
+TEST_F(FsstEncodingTest, estimateSizeUsesTargetRatioAndLengthEncodingWidth) {
+  const std::vector<std::string_view> values{
+      "alpha",
+      "common/prefix/string/value/one",
+      "common/prefix/string/value/two",
+      "common/prefix/string/value/three",
+  };
+  const auto statistics = Statistics<std::string_view>::create(values);
+
+  auto estimatedVariablePart = [&](double compressionTargetRatio,
+                                   bool fixedByteWidth) {
+    const uint64_t estimatedBlobSize = static_cast<uint64_t>(
+        statistics.totalStringsLength() * compressionTargetRatio);
+    const uint64_t estimatedMaxCompressedLength = static_cast<uint64_t>(
+        std::ceil(statistics.max().size() * compressionTargetRatio));
+    return estimatedBlobSize +
+        FixedBitWidthEncoding<uint32_t>::estimateSize(
+               values.size(), 0, estimatedMaxCompressedLength, fixedByteWidth);
+  };
+
+  const auto fixedWidthSizeAt50 = FsstEncoding::estimateSize(
+      values.size(), statistics, /*fixedByteWidth=*/true, 0.5);
+  const auto fixedWidthSizeAt60 = FsstEncoding::estimateSize(
+      values.size(), statistics, /*fixedByteWidth=*/true, 0.6);
+  const auto bitPackedSizeAt60 = FsstEncoding::estimateSize(
+      values.size(), statistics, /*fixedByteWidth=*/false, 0.6);
+
+  EXPECT_EQ(
+      fixedWidthSizeAt60 - fixedWidthSizeAt50,
+      estimatedVariablePart(0.6, true) - estimatedVariablePart(0.5, true));
+  EXPECT_EQ(
+      fixedWidthSizeAt60 - bitPackedSizeAt60,
+      estimatedVariablePart(0.6, true) - estimatedVariablePart(0.6, false));
+}
+
+TEST_F(FsstEncodingTest, fsstCompressionTargetRatioFallsBackToTrivial) {
+  std::vector<std::string> storage;
+  storage.reserve(1'000);
+  for (int i = 0; i < 1'000; ++i) {
+    storage.emplace_back(
+        fmt::format(
+            "common/prefix/with/repeated/symbols/{:04}/common/suffix", i));
+  }
+
+  std::vector<std::string_view> values;
+  values.reserve(storage.size());
+  size_t totalRawSize{0};
+  for (const auto& value : storage) {
+    values.emplace_back(value);
+    totalRawSize += value.size();
+  }
+
+  Buffer fsstOnlyBuffer{*pool_};
+  const auto fsstOnlyEncoded = EncodingFactory::encode<std::string_view>(
+      createSelectionPolicy(),
+      values,
+      fsstOnlyBuffer,
+      {.fsstCompressionTargetRatio = std::numeric_limits<double>::max()});
+
+  Buffer trivialOnlyBuffer{*pool_};
+  CompressionOptions noCompressionOptions;
+  noCompressionOptions.compressionType = CompressionType::Uncompressed;
+  const auto trivialOnlyEncoded = EncodingFactory::encode<std::string_view>(
+      createTrivialSelectionPolicy(noCompressionOptions),
+      values,
+      trivialOnlyBuffer);
+
+  const auto permissiveTargetRatio =
+      static_cast<double>(fsstOnlyEncoded.size()) / totalRawSize;
+
+  Buffer permissiveTargetBuffer{*pool_};
+  auto permissiveTargetEncoded = EncodingFactory::encode<std::string_view>(
+      createSelectionPolicy(),
+      values,
+      permissiveTargetBuffer,
+      {.fsstCompressionTargetRatio = permissiveTargetRatio});
+  stringBuffers_.clear();
+
+  auto permissiveTargetEncoding = EncodingFactory({}).create(
+      *pool_, permissiveTargetEncoded, createStringBufferFactory());
+  EXPECT_EQ(permissiveTargetEncoding->encodingType(), EncodingType::Fsst);
+
+  Buffer strictTargetBuffer{*pool_};
+  auto strictTargetEncoded = EncodingFactory::encode<std::string_view>(
+      createSelectionPolicy(),
+      values,
+      strictTargetBuffer,
+      {.fsstCompressionTargetRatio = 0});
+  stringBuffers_.clear();
+
+  auto strictTargetEncoding = EncodingFactory({}).create(
+      *pool_, strictTargetEncoded, createStringBufferFactory());
+
+  EXPECT_EQ(strictTargetEncoded, trivialOnlyEncoded);
+  EXPECT_EQ(strictTargetEncoding->encodingType(), EncodingType::Trivial);
+  std::vector<std::string_view> decoded(values.size());
+  strictTargetEncoding->materialize(values.size(), decoded.data());
+  EXPECT_EQ(decoded, values);
+}
+
+TEST_F(FsstEncodingTest, skipAndMaterialize) {
+  std::vector<std::string_view> values = {
+      "alpha", "bravo", "charlie", "delta", "echo"};
+
+  Buffer buffer{*pool_};
+  auto encoded = encodeFsst(values, buffer);
+  stringBuffers_.clear();
+
+  auto encoding =
+      EncodingFactory({}).create(*pool_, encoded, createStringBufferFactory());
+
+  encoding->skip(2);
+
+  std::vector<std::string_view> decoded(2);
+  encoding->materialize(2, decoded.data());
+
+  EXPECT_EQ(decoded[0], "charlie");
+  EXPECT_EQ(decoded[1], "delta");
+}
+
+TEST_F(FsstEncodingTest, readWithVisitorReadsSelectedRows) {
+  std::vector<std::string_view> values = {
+      "zero/value",
+      "one/value",
+      "two/value",
+      "three/value",
+      "four/value",
+      "five/value",
+  };
+
+  Buffer buffer{*pool_};
+  const auto encoded = encodeFsst(values, buffer);
+
+  struct TestCase {
+    std::string name;
+    std::vector<vector_size_t> rows;
+    std::vector<std::string_view> expected;
+  };
+
+  for (const auto& testCase : std::vector<TestCase>{
+           {
+               .name = "dense rows",
+               .rows = {0, 1, 2, 3, 4, 5},
+               .expected = values,
+           },
+           {
+               .name = "sparse rows",
+               .rows = {0, 2, 5},
+               .expected = {values[0], values[2], values[5]},
+           },
+       }) {
+    SCOPED_TRACE(testCase.name);
+
+    stringBuffers_.clear();
+    FsstEncoding encoding{*pool_, encoded, createStringBufferFactory()};
+    StringReadWithVisitor visitor{testCase.rows};
+    ReadWithVisitorParams params;
+    params.numScanned = 0;
+
+    encoding.readWithVisitor(visitor, params);
+
+    EXPECT_EQ(visitor.values(), testCase.expected);
+  }
+}
+
+TEST_F(FsstEncodingTest, resetAndRematerialize) {
+  std::vector<std::string_view> values = {"first", "second", "third"};
+
+  Buffer buffer{*pool_};
+  auto encoded = encodeFsst(values, buffer);
+  stringBuffers_.clear();
+
+  auto encoding =
+      EncodingFactory({}).create(*pool_, encoded, createStringBufferFactory());
+
+  std::vector<std::string_view> decoded1(3);
+  encoding->materialize(3, decoded1.data());
+
+  encoding->reset();
+
+  std::vector<std::string_view> decoded2(3);
+  encoding->materialize(3, decoded2.data());
+
+  for (size_t i = 0; i < values.size(); ++i) {
+    EXPECT_EQ(decoded1[i], values[i]);
+    EXPECT_EQ(decoded2[i], values[i]);
+  }
+}
+
+TEST_F(FsstEncodingTest, materializeOneAtATime) {
+  std::vector<std::string_view> values = {"alpha", "bravo", "charlie"};
+
+  Buffer buffer{*pool_};
+  auto encoded = encodeFsst(values, buffer);
+  stringBuffers_.clear();
+
+  auto encoding =
+      EncodingFactory({}).create(*pool_, encoded, createStringBufferFactory());
+
+  for (size_t i = 0; i < values.size(); ++i) {
+    std::string_view decoded;
+    encoding->materialize(1, &decoded);
+    EXPECT_EQ(decoded, values[i]) << "mismatch at row " << i;
+  }
+}
+
+TEST_F(FsstEncodingTest, compressionRatio) {
+  std::vector<std::string> storage;
+  std::vector<std::string_view> values;
+  storage.reserve(1'000);
+  for (int i = 0; i < 1'000; ++i) {
+    storage.emplace_back(
+        fmt::format("https://www.example.com/api/v2/users/{}/profile", i));
+  }
+  values.reserve(storage.size());
+  for (const auto& s : storage) {
+    values.emplace_back(s);
+  }
+
+  Buffer fsstBuffer{*pool_};
+  auto fsstEncoded = encodeFsst(values, fsstBuffer);
+
+  size_t totalRawSize = 0;
+  for (const auto& v : values) {
+    totalRawSize += v.size();
+  }
+
+  EXPECT_LT(fsstEncoded.size(), totalRawSize)
+      << "FSST should compress the data";
+}
+
+TEST_F(FsstEncodingTest, debugString) {
+  std::vector<std::string> storage;
+  std::vector<std::string_view> values;
+  storage.reserve(2'000);
+  for (int i = 0; i < 2'000; ++i) {
+    storage.emplace_back(fmt::format("debug/string/value/{}", i % 16));
+  }
+  values.reserve(storage.size());
+  for (const auto& value : storage) {
+    values.emplace_back(value);
+  }
+
+  Buffer buffer{*pool_};
+  auto encoded = encodeFsst(values, buffer);
+  stringBuffers_.clear();
+
+  auto encoding =
+      EncodingFactory({}).create(*pool_, encoded, createStringBufferFactory());
+
+  EXPECT_EQ(encoding->debugString(0), "FsstEncoding: 2000 rows");
+}
+
+TEST_F(FsstEncodingTest, lengthsEncodingReturnsNestedLengthsEncoding) {
+  std::vector<std::string> storage;
+  std::vector<std::string_view> values;
+  storage.reserve(2'000);
+  for (int i = 0; i < 2'000; ++i) {
+    storage.emplace_back(
+        fmt::format("common/prefix/for/fsst/lengths/{}", i % 16));
+  }
+  values.reserve(storage.size());
+  for (const auto& value : storage) {
+    values.emplace_back(value);
+  }
+
+  Buffer buffer{*pool_};
+  auto encoded = encodeFsst(values, buffer);
+  ASSERT_EQ(
+      static_cast<EncodingType>(encoded[EncodingPrefix::kEncodingTypeOffset]),
+      EncodingType::Fsst);
+
+  const auto lengths = FsstEncoding::lengthsEncoding(encoded);
+  auto lengthsEncoding =
+      EncodingFactory({}).create(*pool_, lengths, createStringBufferFactory());
+
+  EXPECT_EQ(lengthsEncoding->dataType(), DataType::Uint32);
+  EXPECT_EQ(lengthsEncoding->encodingType(), EncodingType::Trivial);
+  ASSERT_EQ(lengthsEncoding->rowCount(), values.size());
+
+  std::vector<uint32_t> decodedLengths(values.size());
+  lengthsEncoding->materialize(values.size(), decodedLengths.data());
+  for (const auto decodedLength : decodedLengths) {
+    EXPECT_GT(decodedLength, 0);
+  }
+}
+
+TEST_F(FsstEncodingTest, captureNestedEncodingReturnsLengthsChildLayout) {
+  std::vector<std::string> storage;
+  std::vector<std::string_view> values;
+  storage.reserve(2'000);
+  for (int i = 0; i < 2'000; ++i) {
+    storage.emplace_back(
+        fmt::format("common/prefix/for/fsst/lengths/{}", i % 16));
+  }
+  values.reserve(storage.size());
+  for (const auto& value : storage) {
+    values.emplace_back(value);
+  }
+
+  Buffer buffer{*pool_};
+  auto encoded = encodeFsst(values, buffer);
+  ASSERT_EQ(
+      static_cast<EncodingType>(encoded[EncodingPrefix::kEncodingTypeOffset]),
+      EncodingType::Fsst);
+
+  std::vector<std::optional<const EncodingLayout>> children;
+  FsstEncoding::captureNestedEncoding(encoded, children);
+  ASSERT_EQ(children.size(), 1);
+  ASSERT_TRUE(children[0].has_value());
+  EXPECT_EQ(children[0]->encodingType(), EncodingType::Trivial);
+  EXPECT_EQ(children[0]->compressionType(), CompressionType::Uncompressed);
+}
+
+} // namespace
+} // namespace facebook::nimble::test

--- a/dwio/nimble/encodings/tests/Lz4CompressorTest.cpp
+++ b/dwio/nimble/encodings/tests/Lz4CompressorTest.cpp
@@ -32,7 +32,7 @@ class TestLz4CompressionPolicy : public CompressionPolicy {
     compressionInfo_.parameters.lz4.accelerationLevel = 1;
   }
 
-  CompressionInformation compression() const override {
+  CompressionConfig config() const override {
     return compressionInfo_;
   }
 
@@ -44,7 +44,7 @@ class TestLz4CompressionPolicy : public CompressionPolicy {
   }
 
  private:
-  CompressionInformation compressionInfo_;
+  CompressionConfig compressionInfo_;
 };
 
 } // namespace

--- a/dwio/nimble/encodings/tests/PFOREncodingTest.cpp
+++ b/dwio/nimble/encodings/tests/PFOREncodingTest.cpp
@@ -56,7 +56,7 @@ class PFOREncodingTest : public ::testing::Test {
     return std::make_unique<ReplayedEncodingSelectionPolicy<T>>(
         std::move(layout),
         CompressionOptions{},
-        encodingSelectionPolicyFactory_);
+        encodingSelectionPolicyCreator_);
   }
 
   std::unique_ptr<Encoding> encodeAndCreate(const std::vector<T>& values) {
@@ -86,7 +86,7 @@ class PFOREncodingTest : public ::testing::Test {
   std::shared_ptr<velox::memory::MemoryPool> pool_;
   std::vector<char> encodedStorage_;
   ManualEncodingSelectionPolicyFactory manualPolicyFactory_;
-  EncodingSelectionPolicyFactory encodingSelectionPolicyFactory_ =
+  EncodingSelectionPolicyCreator encodingSelectionPolicyCreator_ =
       [this](DataType dataType) {
         return manualPolicyFactory_.createPolicy(dataType);
       };
@@ -257,7 +257,7 @@ class PFOREncodingFuzzerTest : public ::testing::Test {
     std::mt19937 rng(seed);
 
     ManualEncodingSelectionPolicyFactory manualFactory;
-    EncodingSelectionPolicyFactory factory =
+    EncodingSelectionPolicyCreator creator =
         [&manualFactory](DataType dataType) {
           return manualFactory.createPolicy(dataType);
         };
@@ -288,7 +288,7 @@ class PFOREncodingFuzzerTest : public ::testing::Test {
           CompressionType::Uncompressed,
           {std::nullopt, std::nullopt}};
       auto policy = std::make_unique<ReplayedEncodingSelectionPolicy<T>>(
-          std::move(layout), CompressionOptions{}, factory);
+          std::move(layout), CompressionOptions{}, creator);
       auto encoded = EncodingFactory::encode<T>(
           std::move(policy),
           std::span<const T>{values.data(), values.size()},
@@ -362,11 +362,11 @@ TEST_F(PFOREncodingFuzzerTest, encodeRejectsEmpty) {
       CompressionType::Uncompressed,
       {std::nullopt, std::nullopt}};
   ManualEncodingSelectionPolicyFactory manualFactory;
-  EncodingSelectionPolicyFactory factory = [&manualFactory](DataType dataType) {
+  EncodingSelectionPolicyCreator creator = [&manualFactory](DataType dataType) {
     return manualFactory.createPolicy(dataType);
   };
   auto policy = std::make_unique<ReplayedEncodingSelectionPolicy<uint32_t>>(
-      std::move(layout), CompressionOptions{}, factory);
+      std::move(layout), CompressionOptions{}, creator);
   std::vector<uint32_t> empty;
   NIMBLE_ASSERT_THROW(
       EncodingFactory::encode<uint32_t>(

--- a/dwio/nimble/encodings/tests/PrefixEncodingTest.cpp
+++ b/dwio/nimble/encodings/tests/PrefixEncodingTest.cpp
@@ -50,7 +50,7 @@ class PrefixEncodingTest : public ::testing::Test {
     return std::make_unique<ReplayedEncodingSelectionPolicy<std::string_view>>(
         std::move(layout),
         CompressionOptions{},
-        encodingSelectionPolicyFactory_);
+        encodingSelectionPolicyCreator_);
   }
 
   // Helper function to create a string buffer factory for decoding
@@ -65,7 +65,7 @@ class PrefixEncodingTest : public ::testing::Test {
   std::shared_ptr<velox::memory::MemoryPool> pool_;
   std::vector<velox::BufferPtr> stringBuffers_;
   ManualEncodingSelectionPolicyFactory manualPolicyFactory_;
-  EncodingSelectionPolicyFactory encodingSelectionPolicyFactory_ =
+  EncodingSelectionPolicyCreator encodingSelectionPolicyCreator_ =
       [this](DataType dataType) {
         return manualPolicyFactory_.createPolicy(dataType);
       };
@@ -466,7 +466,7 @@ TEST_F(PrefixEncodingTest, customRestartInterval) {
         std::make_unique<ReplayedEncodingSelectionPolicy<std::string_view>>(
             std::move(layout),
             CompressionOptions{},
-            encodingSelectionPolicyFactory_);
+            encodingSelectionPolicyCreator_);
 
     auto encoded = EncodingFactory::encode<std::string_view>(
         std::move(policy), values, buffer);
@@ -507,7 +507,7 @@ TEST_F(PrefixEncodingTest, invalidRestartIntervalThrows) {
         std::make_unique<ReplayedEncodingSelectionPolicy<std::string_view>>(
             std::move(layout),
             CompressionOptions{},
-            encodingSelectionPolicyFactory_);
+            encodingSelectionPolicyCreator_);
 
     NIMBLE_ASSERT_THROW(
         EncodingFactory::encode<std::string_view>(

--- a/dwio/nimble/encodings/tests/ReadWithVisitorTest.cpp
+++ b/dwio/nimble/encodings/tests/ReadWithVisitorTest.cpp
@@ -145,7 +145,7 @@ class NonRecursiveSubIntSplitPolicy final : public EncodingSelectionPolicy<T> {
       NestedEncodingIdentifier /* identifier */,
       DataType type) override {
     auto readFactors =
-        ManualEncodingSelectionPolicyFactory::defaultReadFactors();
+        ManualEncodingSelectionPolicyFactory::defaultEncodingReadFactors();
     readFactors.erase(
         std::remove_if(
             readFactors.begin(),

--- a/dwio/nimble/encodings/tests/SimdForBitpackEncodingTest.cpp
+++ b/dwio/nimble/encodings/tests/SimdForBitpackEncodingTest.cpp
@@ -48,7 +48,7 @@ class SimdForBitpackEncodingTest : public ::testing::Test {
     return std::make_unique<ReplayedEncodingSelectionPolicy<T>>(
         std::move(layout),
         CompressionOptions{},
-        encodingSelectionPolicyFactory_);
+        encodingSelectionPolicyCreator_);
   }
 
   std::unique_ptr<Encoding> encodeAndCreate(const std::vector<T>& values) {
@@ -78,7 +78,7 @@ class SimdForBitpackEncodingTest : public ::testing::Test {
   std::shared_ptr<velox::memory::MemoryPool> pool_;
   std::vector<char> encodedStorage_;
   ManualEncodingSelectionPolicyFactory manualPolicyFactory_;
-  EncodingSelectionPolicyFactory encodingSelectionPolicyFactory_ =
+  EncodingSelectionPolicyCreator encodingSelectionPolicyCreator_ =
       [this](DataType dataType) {
         return manualPolicyFactory_.createPolicy(dataType);
       };
@@ -227,7 +227,7 @@ class SimdForBitpackFuzzerTest : public ::testing::Test {
     std::mt19937 rng(seed);
 
     ManualEncodingSelectionPolicyFactory manualFactory;
-    EncodingSelectionPolicyFactory factory =
+    EncodingSelectionPolicyCreator creator =
         [&manualFactory](DataType dataType) {
           return manualFactory.createPolicy(dataType);
         };
@@ -251,7 +251,7 @@ class SimdForBitpackFuzzerTest : public ::testing::Test {
       EncodingLayout layout{
           EncodingType::SimdForBitpack, {}, CompressionType::Uncompressed};
       auto policy = std::make_unique<ReplayedEncodingSelectionPolicy<T>>(
-          std::move(layout), CompressionOptions{}, factory);
+          std::move(layout), CompressionOptions{}, creator);
       auto encoded = EncodingFactory::encode<T>(
           std::move(policy),
           std::span<const T>{values.data(), values.size()},
@@ -328,11 +328,11 @@ TEST_F(SimdForBitpackFuzzerTest, encodeRejectsEmpty) {
   EncodingLayout layout{
       EncodingType::SimdForBitpack, {}, CompressionType::Uncompressed};
   ManualEncodingSelectionPolicyFactory manualFactory;
-  EncodingSelectionPolicyFactory factory = [&manualFactory](DataType dataType) {
+  EncodingSelectionPolicyCreator creator = [&manualFactory](DataType dataType) {
     return manualFactory.createPolicy(dataType);
   };
   auto policy = std::make_unique<ReplayedEncodingSelectionPolicy<uint32_t>>(
-      std::move(layout), CompressionOptions{}, factory);
+      std::move(layout), CompressionOptions{}, creator);
   std::vector<uint32_t> empty;
   NIMBLE_ASSERT_THROW(
       EncodingFactory::encode<uint32_t>(

--- a/dwio/nimble/encodings/tests/SubIntSplitEncodingTest.cpp
+++ b/dwio/nimble/encodings/tests/SubIntSplitEncodingTest.cpp
@@ -81,11 +81,11 @@ std::string_view encodeWithNonRecursiveSubIntSplit(
     const std::vector<T>& values,
     nimble::Buffer& buffer);
 
-nimble::EncodingSelectionPolicyFactory makeLeafPolicyFactory() {
+nimble::EncodingSelectionPolicyCreator makeLeafPolicyCreator() {
   return [](nimble::DataType type)
              -> std::unique_ptr<nimble::EncodingSelectionPolicyBase> {
-    auto readFactors =
-        nimble::ManualEncodingSelectionPolicyFactory::defaultReadFactors();
+    auto readFactors = nimble::ManualEncodingSelectionPolicyFactory::
+        defaultEncodingReadFactors();
     readFactors.erase(
         std::remove_if(
             readFactors.begin(),
@@ -125,8 +125,8 @@ class NonRecursiveSubIntSplitPolicy final
       nimble::EncodingType /* encodingType */,
       nimble::NestedEncodingIdentifier /* identifier */,
       nimble::DataType type) override {
-    auto readFactors =
-        nimble::ManualEncodingSelectionPolicyFactory::defaultReadFactors();
+    auto readFactors = nimble::ManualEncodingSelectionPolicyFactory::
+        defaultEncodingReadFactors();
     readFactors.erase(
         std::remove_if(
             readFactors.begin(),
@@ -154,10 +154,10 @@ std::string_view encodeWithReplayLayout(
     const nimble::EncodingLayout& layout,
     const std::vector<T>& values,
     nimble::Buffer& buffer) {
-  auto leafFactory = makeLeafPolicyFactory();
+  auto leafCreator = makeLeafPolicyCreator();
   return nimble::EncodingFactory::encode<T>(
       std::make_unique<nimble::ReplayedEncodingSelectionPolicy<T>>(
-          layout, std::nullopt, leafFactory),
+          layout, std::nullopt, leafCreator),
       values,
       buffer);
 }
@@ -371,11 +371,11 @@ TEST(SubIntSplitEncodingTests, PreserveModeRequiresBoundaries) {
   auto pool = velox::memory::deprecatedAddDefaultLeafMemoryPool();
   nimble::Buffer buffer{*pool};
 
-  auto leafFactory = makeLeafPolicyFactory();
+  auto leafCreator = makeLeafPolicyCreator();
   EXPECT_THROW(
       (nimble::EncodingFactory::encode<int64_t>(
           std::make_unique<nimble::ReplayedEncodingSelectionPolicy<int64_t>>(
-              layout, std::nullopt, leafFactory),
+              layout, std::nullopt, leafCreator),
           values,
           buffer)),
       nimble::NimbleInternalError);

--- a/dwio/nimble/encodings/tests/TestUtils.h
+++ b/dwio/nimble/encodings/tests/TestUtils.h
@@ -157,19 +157,19 @@ class Encoder {
     explicit TestCompressPolicy(CompressionType compressionType)
         : compressionType_{compressionType} {}
 
-    nimble::CompressionInformation compression() const override {
+    nimble::CompressionConfig config() const override {
       if (compressionType_ == CompressionType::Uncompressed) {
         return {.compressionType = CompressionType::Uncompressed};
       }
 
       if (compressionType_ == CompressionType::Zstd) {
-        nimble::CompressionInformation information{
+        nimble::CompressionConfig information{
             .compressionType = nimble::CompressionType::Zstd};
         information.parameters.zstd.compressionLevel = 3;
         return information;
       }
 
-      nimble::CompressionInformation information{
+      nimble::CompressionConfig information{
           .compressionType = nimble::CompressionType::MetaInternal};
       information.parameters.metaInternal.compressionLevel = 9;
       information.parameters.metaInternal.decompressionLevel = 2;

--- a/dwio/nimble/encodings/tests/ZstdCompressorTest.cpp
+++ b/dwio/nimble/encodings/tests/ZstdCompressorTest.cpp
@@ -33,7 +33,7 @@ class TestCompressionPolicy : public CompressionPolicy {
     compressionInfo_.parameters.zstd.compressionLevel = 3;
   }
 
-  CompressionInformation compression() const override {
+  CompressionConfig config() const override {
     return compressionInfo_;
   }
 
@@ -45,7 +45,7 @@ class TestCompressionPolicy : public CompressionPolicy {
   }
 
  private:
-  CompressionInformation compressionInfo_;
+  CompressionConfig compressionInfo_;
 };
 
 } // namespace

--- a/dwio/nimble/serializer/Options.cpp
+++ b/dwio/nimble/serializer/Options.cpp
@@ -52,14 +52,14 @@ EncodingType getTrailerEncodingType(EncodingType encodingType) {
   }
 }
 
-EncodingSelectionPolicyFactory defaultEncodingSelectionPolicyFactory() {
+EncodingSelectionPolicyCreator defaultEncodingSelectionPolicyCreator() {
   // Initialize the default factory once. It is const and createPolicy() does
   // not mutate it, so a single instance can be safely shared across all default
   // SerializerOptions instead of rebuilding the read-factor vector on every
   // construction. The returned lambda is captureless and refers to the shared
   // factory directly.
   static const ManualEncodingSelectionPolicyFactory factory(
-      ManualEncodingSelectionPolicyFactory::defaultReadFactors(),
+      ManualEncodingSelectionPolicyFactory::defaultEncodingReadFactors(),
       /*compressionOptions=*/std::nullopt);
   return [](DataType dataType) -> std::unique_ptr<EncodingSelectionPolicyBase> {
     return factory.createPolicy(dataType);

--- a/dwio/nimble/serializer/Options.h
+++ b/dwio/nimble/serializer/Options.h
@@ -186,10 +186,10 @@ inline std::ostream& operator<<(
   return os << toString(version);
 }
 
-/// Returns the default encoding selection policy factory. The underlying
+/// Returns the default encoding selection policy creator. The underlying
 /// ManualEncodingSelectionPolicyFactory (and its default read-factor vector) is
-/// initialized once and shared across all returned factories.
-EncodingSelectionPolicyFactory defaultEncodingSelectionPolicyFactory();
+/// initialized once and shared across all returned creators.
+EncodingSelectionPolicyCreator defaultEncodingSelectionPolicyCreator();
 
 struct SerializerOptions {
   /// Legacy (kLegacy) compression settings. These only apply when version is
@@ -224,14 +224,14 @@ struct SerializerOptions {
   /// When encodingLayoutTree is specified, used as fallback for streams or
   /// nested encodings not captured in the layout tree. When encodingLayoutTree
   /// is not specified, used directly for all streams.
-  EncodingSelectionPolicyFactory encodingSelectionPolicyFactory =
-      defaultEncodingSelectionPolicyFactory();
+  EncodingSelectionPolicyCreator encodingSelectionPolicyCreator =
+      defaultEncodingSelectionPolicyCreator();
 
   /// Optional captured encoding layout tree.
   /// When specified, encodings are replayed from this tree instead of using
-  /// encodingSelectionPolicyFactory. This speeds up writes by skipping runtime
+  /// encodingSelectionPolicyCreator. This speeds up writes by skipping runtime
   /// encoding selection and can provide better encodings based on historical
-  /// data. Falls back to encodingSelectionPolicyFactory for streams not in the
+  /// data. Falls back to encodingSelectionPolicyCreator for streams not in the
   /// tree.
   std::optional<EncodingLayoutTree> encodingLayoutTree{};
 

--- a/dwio/nimble/serializer/SerializerImpl.h
+++ b/dwio/nimble/serializer/SerializerImpl.h
@@ -50,7 +50,7 @@ namespace detail {
 FOLLY_ALWAYS_INLINE std::unique_ptr<EncodingSelectionPolicyBase>
 createDefaultEncodingPolicy(DataType dataType) {
   static const ManualEncodingSelectionPolicyFactory factory{
-      ManualEncodingSelectionPolicyFactory::defaultReadFactors(),
+      ManualEncodingSelectionPolicyFactory::defaultEncodingReadFactors(),
       /*compressionOptions=*/std::nullopt};
   return factory.createPolicy(dataType);
 }
@@ -88,7 +88,7 @@ template <typename T>
 std::string_view encodeTyped(
     std::span<const T> values,
     nimble::Buffer& encodingBuffer,
-    const EncodingSelectionPolicyFactory& policyFactory,
+    const EncodingSelectionPolicyCreator& policyFactory,
     const Encoding::Options& encodingOptions = {.useVarintRowCount = true},
     const EncodingLayout* encodingLayout = nullptr,
     std::optional<CompressionOptions> compressionOptions = std::nullopt) {
@@ -460,7 +460,7 @@ std::string_view encodeTyped(
   return encodeTyped<T>(
       values,
       encodingBuffer,
-      options.encodingSelectionPolicyFactory,
+      options.encodingSelectionPolicyCreator,
       options.encodingOptions,
       encodingLayout,
       options.compressionOptions);

--- a/dwio/nimble/serializer/tests/OptionsTest.cpp
+++ b/dwio/nimble/serializer/tests/OptionsTest.cpp
@@ -69,7 +69,7 @@ TEST(OptionsTest, serializerOptionsDefaults) {
   EXPECT_FALSE(options.compressionOptions.has_value());
 
   // Verify default encoding selection policy factory creates a valid policy.
-  auto policy = options.encodingSelectionPolicyFactory(DataType::Int32);
+  auto policy = options.encodingSelectionPolicyCreator(DataType::Int32);
   EXPECT_NE(policy, nullptr);
 }
 

--- a/dwio/nimble/serializer/tests/SerializerImplTest.cpp
+++ b/dwio/nimble/serializer/tests/SerializerImplTest.cpp
@@ -1559,7 +1559,7 @@ TEST_F(EncodeTypedCompressionTest, withEncodingLayout) {
   facebook::nimble::Buffer buffer(*pool_);
 
   ManualEncodingSelectionPolicyFactory factory{
-      ManualEncodingSelectionPolicyFactory::defaultReadFactors(),
+      ManualEncodingSelectionPolicyFactory::defaultEncodingReadFactors(),
       /*compressionOptions=*/std::nullopt};
   auto policyFactory = [&factory](DataType dataType) {
     return factory.createPolicy(dataType);
@@ -1620,7 +1620,7 @@ TEST_F(EncodeTypedCompressionTest, withoutEncodingLayout) {
 
   // Factory with compression disabled.
   ManualEncodingSelectionPolicyFactory noCompressFactory{
-      ManualEncodingSelectionPolicyFactory::defaultReadFactors(),
+      ManualEncodingSelectionPolicyFactory::defaultEncodingReadFactors(),
       /*compressionOptions=*/std::nullopt};
   auto noCompressPolicyFactory = [&noCompressFactory](DataType dataType) {
     return noCompressFactory.createPolicy(dataType);
@@ -1653,12 +1653,12 @@ TEST_F(EncodeTypedCompressionTest, withoutEncodingLayout) {
   EXPECT_EQ(decoded, data);
 }
 
-// Verify that the default SerializerOptions.encodingSelectionPolicyFactory
+// Verify that the default SerializerOptions.encodingSelectionPolicyCreator
 // creates policies with compression disabled.
 TEST_F(EncodeTypedCompressionTest, defaultFactoryNoCompression) {
   SerializerOptions options{};
 
-  auto policy = options.encodingSelectionPolicyFactory(DataType::Uint32);
+  auto policy = options.encodingSelectionPolicyCreator(DataType::Uint32);
   auto* typed = dynamic_cast<EncodingSelectionPolicy<uint32_t>*>(policy.get());
   ASSERT_NE(typed, nullptr);
 
@@ -1666,7 +1666,7 @@ TEST_F(EncodeTypedCompressionTest, defaultFactoryNoCompression) {
   auto result = typed->select(data, Statistics<uint32_t>::create(data));
   auto compressionPolicy = result.compressionPolicyFactory();
   EXPECT_EQ(
-      compressionPolicy->compression().compressionType,
+      compressionPolicy->config().compressionType,
       CompressionType::Uncompressed);
 }
 

--- a/dwio/nimble/tools/EncodingSelectionLogger.cpp
+++ b/dwio/nimble/tools/EncodingSelectionLogger.cpp
@@ -52,9 +52,9 @@ void logEncodingSelection(const std::vector<std::string>& source) {
           facebook::nimble::ManualEncodingSelectionPolicyFactory{
               FLAGS_read_factors.empty()
                   ? nimble::ManualEncodingSelectionPolicyFactory::
-                        defaultReadFactors()
+                        defaultEncodingReadFactors()
                   : nimble::ManualEncodingSelectionPolicyFactory::
-                        parseReadFactors(FLAGS_read_factors),
+                        parseEncodingReadFactors(FLAGS_read_factors),
               nimble::CompressionOptions{
                   .compressionAcceptRatio =
                       folly::to<float>(FLAGS_compression_acceptance_ratio)}}
@@ -65,8 +65,7 @@ void logEncodingSelection(const std::vector<std::string>& source) {
   auto serialized =
       nimble::EncodingFactory::encode<T>(std::move(policy), values, buffer);
 
-  LOG(INFO) << "Encoding: " << GREEN
-            << nimble::tools::getEncodingLabel(serialized) << RESET_COLOR;
+  LOG(INFO) << "Encoding: " << nimble::tools::getEncodingLabel(serialized);
 }
 
 int main(int argc, char* argv[]) {

--- a/dwio/nimble/tools/EncodingUtilities.cpp
+++ b/dwio/nimble/tools/EncodingUtilities.cpp
@@ -15,6 +15,7 @@
  */
 #include "dwio/nimble/tools/EncodingUtilities.h"
 #include "dwio/nimble/common/Exceptions.h"
+#include "dwio/nimble/encodings/FsstEncoding.h"
 #include "dwio/nimble/encodings/common/EncodingUtils.h"
 
 namespace facebook::nimble::tools {
@@ -52,6 +53,7 @@ void extractCompressionType(
     case EncodingType::MainlyConstant:
     case EncodingType::Prefix:
     case EncodingType::ALP:
+    case EncodingType::Fsst:
     case EncodingType::PFOR:
     case EncodingType::SimdForBitpack:
     // SubIntSplit integration is disabled; it carries no separate compression
@@ -90,8 +92,8 @@ void traverseEncodings(
         std::unordered_map<
             EncodingPropertyType,
             EncodingProperty> /* properties */)> visitor) {
-  NIMBLE_CHECK(
-      stream.size() >= kEncodingPrefixSize, "Unexpected end of stream.");
+  NIMBLE_CHECK_GE(
+      stream.size(), kEncodingPrefixSize, "Unexpected end of stream.");
 
   const EncodingType encodingType = static_cast<EncodingType>(stream[0]);
   auto dataType = static_cast<DataType>(stream[1]);
@@ -177,6 +179,15 @@ void traverseEncodings(
         traverseEncodings(
             {pos, lengthsBytes}, level + 1, 0, "Lengths", visitor);
       }
+      break;
+    }
+    case EncodingType::Fsst: {
+      traverseEncodings(
+          FsstEncoding::lengthsEncoding(stream),
+          level + 1,
+          0,
+          "Lengths",
+          visitor);
       break;
     }
     case EncodingType::SparseBool: {

--- a/dwio/nimble/tools/encoding_bench/EncodingBench.cpp
+++ b/dwio/nimble/tools/encoding_bench/EncodingBench.cpp
@@ -130,7 +130,8 @@ std::string_view encodeWithLayout(
     const std::optional<nimble::CompressionOptions>& compressionOpts,
     nimble::Buffer& buffer) {
   nimble::ManualEncodingSelectionPolicyFactory fallbackFactory{
-      nimble::ManualEncodingSelectionPolicyFactory::defaultReadFactors(),
+      nimble::ManualEncodingSelectionPolicyFactory::
+          defaultEncodingReadFactors(),
       compressionOpts};
 
   auto policy =
@@ -152,7 +153,8 @@ std::string_view encodeAutoSelect(
     nimble::Buffer& buffer) {
   auto policy =
       std::make_unique<nimble::ManualEncodingSelectionPolicy<int64_t>>(
-          nimble::ManualEncodingSelectionPolicyFactory::defaultReadFactors(),
+          nimble::ManualEncodingSelectionPolicyFactory::
+              defaultEncodingReadFactors(),
           compressionOpts,
           std::nullopt);
 

--- a/dwio/nimble/velox/NimbleConfig.cpp
+++ b/dwio/nimble/velox/NimbleConfig.cpp
@@ -133,13 +133,13 @@ std::map<uint64_t, float> parseGrowthConfigMap(const std::string& str) {
 /* static */ Config::Entry<const std::vector<std::pair<EncodingType, float>>>
     Config::MANUAL_ENCODING_SELECTION_READ_FACTORS(
         "alpha.encodingselection.read.factors",
-        ManualEncodingSelectionPolicyFactory::parseReadFactors(
+        ManualEncodingSelectionPolicyFactory::parseEncodingReadFactors(
             FLAGS_nimble_selection_read_factors),
-        [](const std::vector<std::pair<EncodingType, float>>& val) {
+        [](const std::vector<std::pair<EncodingType, float>>& readFactors) {
           std::vector<std::string> encodingFactorStrings;
           std::transform(
-              val.cbegin(),
-              val.cend(),
+              readFactors.cbegin(),
+              readFactors.cend(),
               std::back_inserter(encodingFactorStrings),
               [](const auto& readFactor) {
                 return fmt::format(
@@ -147,8 +147,9 @@ std::map<uint64_t, float> parseGrowthConfigMap(const std::string& str) {
               });
           return folly::join(";", encodingFactorStrings);
         },
-        [](const std::string& /* key */, const std::string& val) {
-          return ManualEncodingSelectionPolicyFactory::parseReadFactors(val);
+        [](const std::string& /* key */, const std::string& readFactorsConfig) {
+          return ManualEncodingSelectionPolicyFactory::parseEncodingReadFactors(
+              readFactorsConfig);
         });
 
 /* static */ Config::Entry<float>
@@ -160,22 +161,23 @@ std::map<uint64_t, float> parseGrowthConfigMap(const std::string& str) {
     Config::COMPRESSION_ACCEPT_RATIO_OVERRIDES(
         "alpha.encodingselection.compression.accept.ratio.overrides",
         {},
-        [](const std::vector<std::pair<EncodingType, float>>& val) {
+        [](const std::vector<std::pair<EncodingType, float>>& readFactors) {
           std::vector<std::string> parts;
           std::transform(
-              val.cbegin(),
-              val.cend(),
+              readFactors.cbegin(),
+              readFactors.cend(),
               std::back_inserter(parts),
               [](const auto& p) {
                 return fmt::format("{}={}", toString(p.first), p.second);
               });
           return folly::join(";", parts);
         },
-        [](const std::string& /* key */, const std::string& val) {
-          if (val.empty()) {
+        [](const std::string& /* key */, const std::string& readFactorsConfig) {
+          if (readFactorsConfig.empty()) {
             return std::vector<std::pair<EncodingType, float>>{};
           }
-          return ManualEncodingSelectionPolicyFactory::parseReadFactors(val);
+          return ManualEncodingSelectionPolicyFactory::parseEncodingReadFactors(
+              readFactorsConfig);
         });
 
 // Attempt to compress the data only if the data size is equal or greater than

--- a/dwio/nimble/velox/VeloxWriter.cpp
+++ b/dwio/nimble/velox/VeloxWriter.cpp
@@ -337,13 +337,13 @@ std::string_view encode(
     policy = std::make_unique<ReplayedEncodingSelectionPolicy<T>>(
         std::move(encodingLayout.value()),
         context.options().compressionOptions,
-        context.options().encodingSelectionPolicyFactory);
+        context.options().encodingSelectionPolicyCreator);
 
   } else {
     policy = std::unique_ptr<EncodingSelectionPolicy<T>>(
         static_cast<EncodingSelectionPolicy<T>*>(
             context.options()
-                .encodingSelectionPolicyFactory(TypeTraits<T>::dataType)
+                .encodingSelectionPolicyCreator(TypeTraits<T>::dataType)
                 .release()));
   }
 

--- a/dwio/nimble/velox/VeloxWriterOptions.h
+++ b/dwio/nimble/velox/VeloxWriterOptions.h
@@ -35,7 +35,7 @@ namespace facebook::nimble {
 
 namespace detail {
 std::unordered_map<std::string, std::string> defaultMetadata();
-}
+} // namespace detail
 
 // NOTE: the object could be large when encodingOverrides are
 // supplied. It's strongly advised to move instead of copying
@@ -133,9 +133,15 @@ struct VeloxWriterOptions {
   // Block size for BlockBitPacking encoding.
   uint16_t blockBitPackingBlockSize = kBlockBitPackingBlockSize;
 
+  /// FSST is kept only when its final encoded size is at most this fraction of
+  /// the original string bytes.
+  double fsstCompressionTargetRatio{0.6};
+
   /// Builds Encoding::Options from VeloxWriterOptions fields.
   Encoding::Options buildEncodingOptions() const {
-    return {.blockBitPackingBlockSize = blockBitPackingBlockSize};
+    return {
+        .blockBitPackingBlockSize = blockBitPackingBlockSize,
+        .fsstCompressionTargetRatio = fsstCompressionTargetRatio};
   }
 
   // In low-memory mode, the writer is trying to perform smaller (and more
@@ -175,7 +181,7 @@ struct VeloxWriterOptions {
   // Encoding selection policy is the way to balance the tradeoffs of
   // different performance factors (at both read and write times). Heuristics
   // based, ML based or specialized policies can be specified.
-  EncodingSelectionPolicyFactory encodingSelectionPolicyFactory =
+  EncodingSelectionPolicyCreator encodingSelectionPolicyCreator =
       [encodingFactory = ManualEncodingSelectionPolicyFactory{}](
           DataType dataType) -> std::unique_ptr<EncodingSelectionPolicyBase> {
     return encodingFactory.createPolicy(dataType);

--- a/dwio/nimble/velox/selective/tests/ChunkedDecoderTest.cpp
+++ b/dwio/nimble/velox/selective/tests/ChunkedDecoderTest.cpp
@@ -1492,15 +1492,15 @@ class ChunkedDecoderDictTest : public ChunkedDecoderTest {
     std::string streamData;
 
     for (const auto& chunk : chunks) {
-      // The factory must outlive the policy because
+      // The creator must outlive the policy because
       // ReplayedEncodingSelectionPolicy stores it by reference.
-      EncodingSelectionPolicyFactory factory =
+      EncodingSelectionPolicyCreator creator =
           [](DataType type) -> std::unique_ptr<EncodingSelectionPolicyBase> {
         UNIQUE_PTR_FACTORY(type, TrivialNestedPolicy);
       };
       auto policy =
           std::make_unique<ReplayedEncodingSelectionPolicy<std::string_view>>(
-              layout, CompressionOptions{}, factory);
+              layout, CompressionOptions{}, creator);
       auto encoded = EncodingFactory::encode<std::string_view>(
           std::move(policy),
           std::span<const std::string_view>(chunk.data(), chunk.size()),
@@ -1535,15 +1535,15 @@ class ChunkedDecoderDictTest : public ChunkedDecoderTest {
 
       // Pass just the data layout; ReplayedEncodingSelectionPolicy::
       // selectNullable() will automatically wrap it in a Nullable layout.
-      // The factory must outlive the policy because
+      // The creator must outlive the policy because
       // ReplayedEncodingSelectionPolicy stores it by reference.
-      EncodingSelectionPolicyFactory factory =
+      EncodingSelectionPolicyCreator creator =
           [](DataType type) -> std::unique_ptr<EncodingSelectionPolicyBase> {
         UNIQUE_PTR_FACTORY(type, TrivialNestedPolicy);
       };
       auto policy =
           std::make_unique<ReplayedEncodingSelectionPolicy<std::string_view>>(
-              dataLayout, CompressionOptions{}, factory);
+              dataLayout, CompressionOptions{}, creator);
 
       auto encoded = EncodingFactory::encodeNullable<std::string_view>(
           std::move(policy),

--- a/dwio/nimble/velox/selective/tests/E2EFilterTest.cpp
+++ b/dwio/nimble/velox/selective/tests/E2EFilterTest.cpp
@@ -356,7 +356,7 @@ class E2EFilterTest
       // Use custom encoding factors if set.
       // Capture by value to avoid dangling reference.
       auto factors = encodingFactors_.value();
-      options.encodingSelectionPolicyFactory = [factors](DataType dataType) {
+      options.encodingSelectionPolicyCreator = [factors](DataType dataType) {
         ManualEncodingSelectionPolicyFactory factory(factors);
         return factory.createPolicy(dataType);
       };
@@ -393,6 +393,10 @@ class E2EFilterTest
       // Need to set encodingLayoutTree at construction time.
       options.encodingLayoutTree.emplace(
           buildForcedDictionaryEncodingLayoutTree());
+    }
+    if (useForcedFsstEncoding_) {
+      options.fsstCompressionTargetRatio = 10.0;
+      options.encodingLayoutTree.emplace(buildForcedFsstEncodingLayoutTree());
     }
     VeloxWriter writer(
         writeSchema_, std::move(writeFile), *rootPool_, std::move(options));
@@ -444,6 +448,8 @@ class E2EFilterTest
   // where dictionary is not at the top level (e.g., Nullable -> Dictionary).
   bool useForcedDictionaryEncoding_{false};
 
+  bool useForcedFsstEncoding_{false};
+
   // Builds an encoding layout tree that forces dictionary encoding for string
   // columns. When data has nulls, the writer will wrap this with nullable
   // encoding, creating a Nullable -> Dictionary nesting.
@@ -477,6 +483,36 @@ class E2EFilterTest
                           // Indices (id=1): let writer decide
                           std::nullopt,
                       }}}},
+                std::string(childName)});
+      } else {
+        children.push_back(
+            EncodingLayoutTree{Kind::Scalar, {}, std::string(childName)});
+      }
+    }
+    return EncodingLayoutTree{Kind::Row, {}, "", std::move(children)};
+  }
+
+  EncodingLayoutTree buildForcedFsstEncodingLayoutTree() {
+    std::vector<EncodingLayoutTree> children;
+    for (column_index_t i = 0;
+         i < static_cast<column_index_t>(rowType_->size());
+         ++i) {
+      const auto& childType = rowType_->childAt(i);
+      const auto& childName = rowType_->nameOf(i);
+
+      if (childType->isVarchar() || childType->isVarbinary()) {
+        children.push_back(
+            EncodingLayoutTree{
+                Kind::Scalar,
+                {{EncodingLayoutTree::StreamIdentifiers::Scalar::ScalarStream,
+                  EncodingLayout{
+                      EncodingType::Fsst,
+                      {},
+                      CompressionType::Uncompressed,
+                      {EncodingLayout{
+                          EncodingType::Trivial,
+                          {},
+                          CompressionType::Uncompressed}}}}},
                 std::string(childName)});
       } else {
         children.push_back(
@@ -739,6 +775,51 @@ class E2EFilterTest
           EXPECT_EQ(expectedEncodingType, capture.encodingType())
               << "Column " << col << " stripe " << i;
         }
+      }
+    }
+  }
+
+  void verifyColumnEncodingOnDisk(
+      const std::string& columnName,
+      EncodingType expectedEncodingType) {
+    auto readFile = std::make_shared<InMemoryReadFile>(sinkData_);
+    auto& pool = *leafPool_;
+    auto tablet = TabletReader::create(
+        readFile, &pool, test::makeTestTabletOptions(&pool));
+    auto section = tablet->loadOptionalSection(std::string(kSchemaSection));
+    ASSERT_TRUE(section.has_value());
+    auto schema = SchemaDeserializer::deserialize(section->content().data());
+
+    std::optional<column_index_t> column;
+    for (column_index_t col = 0;
+         col < static_cast<column_index_t>(rowType_->size());
+         ++col) {
+      if (rowType_->nameOf(col) == columnName) {
+        column = col;
+        break;
+      }
+    }
+    ASSERT_TRUE(column.has_value()) << columnName;
+
+    auto& childNode = schema->asRow().childAt(*column)->asScalar();
+    for (auto i = 0; i < tablet->stripeCount(); ++i) {
+      auto stripeIdentifier = tablet->stripeIdentifier(i);
+      std::vector<uint32_t> identifiers{childNode.scalarDescriptor().offset()};
+      auto streams = tablet->load(stripeIdentifier, identifiers);
+
+      InMemoryChunkedStream chunkedStream{pool, std::move(streams[0])};
+      if (!chunkedStream.hasNext()) {
+        continue;
+      }
+      auto capture = EncodingLayoutCapture::capture(chunkedStream.nextChunk());
+      if (capture.encodingType() == EncodingType::Nullable) {
+        ASSERT_TRUE(capture.child(1).has_value())
+            << "Column " << columnName << " stripe " << i;
+        EXPECT_EQ(expectedEncodingType, capture.child(1)->encodingType())
+            << "Column " << columnName << " stripe " << i;
+      } else {
+        EXPECT_EQ(expectedEncodingType, capture.encodingType())
+            << "Column " << columnName << " stripe " << i;
       }
     }
   }
@@ -1310,6 +1391,28 @@ TEST_P(E2EFilterTest, stringDictionary) {
       true,
       {"string_val", "string_val_2"},
       20);
+}
+
+TEST_P(E2EFilterTest, fsstStringFilterPushdown) {
+  if (!param().stringDecoderZeroCopy) {
+    GTEST_SKIP() << "FSST string decoding requires zero-copy string decoder.";
+  }
+
+  useForcedFsstEncoding_ = true;
+  testWithTypes(
+      "string_val:string,"
+      "string_val_2:string,"
+      "long_val:bigint",
+      [&]() {
+        makeStringDistribution("string_val", 50, true, true);
+        makeStringDistribution("string_val_2", 80, true, false);
+      },
+      /*wrapInStruct=*/false,
+      {"string_val"},
+      /*numCombinations=*/5,
+      /*withRecursiveNulls=*/false);
+  verifyColumnEncodingOnDisk("string_val", EncodingType::Fsst);
+  useForcedFsstEncoding_ = false;
 }
 
 TEST_P(E2EFilterTest, listAndMapNoRecursiveNulls) {

--- a/dwio/nimble/velox/selective/tests/IntEncodingBenchmark.cpp
+++ b/dwio/nimble/velox/selective/tests/IntEncodingBenchmark.cpp
@@ -91,7 +91,7 @@ VeloxWriterOptions makeWriterOptions(
     EncodingType encoding,
     std::optional<CompressionOptions> comprOpts) {
   VeloxWriterOptions writerOptions;
-  writerOptions.encodingSelectionPolicyFactory =
+  writerOptions.encodingSelectionPolicyCreator =
       [encodingFactory =
            ManualEncodingSelectionPolicyFactory{{{encoding, 1.0}}, comprOpts}](
           DataType dataType) -> std::unique_ptr<EncodingSelectionPolicyBase> {

--- a/dwio/nimble/velox/selective/tests/SelectiveNimbleReaderTest.cpp
+++ b/dwio/nimble/velox/selective/tests/SelectiveNimbleReaderTest.cpp
@@ -827,7 +827,7 @@ TEST_P(SelectiveNimbleReaderTest, multiChunkNulls) {
   };
   ManualEncodingSelectionPolicyFactory encodingFactory(readFactors);
   VeloxWriterOptions options;
-  options.encodingSelectionPolicyFactory = [&](DataType dataType) {
+  options.encodingSelectionPolicyCreator = [&](DataType dataType) {
     return encodingFactory.createPolicy(dataType);
   };
   options.enableChunking = true;
@@ -876,7 +876,7 @@ TEST_P(SelectiveNimbleReaderTest, multiChunkInt16RowSetOverBoundary) {
   std::vector<std::pair<EncodingType, float>> readFactors;
   ManualEncodingSelectionPolicyFactory encodingFactory(readFactors);
   VeloxWriterOptions options;
-  options.encodingSelectionPolicyFactory = [&](DataType dataType) {
+  options.encodingSelectionPolicyCreator = [&](DataType dataType) {
     return encodingFactory.createPolicy(dataType);
   };
   options.enableChunking = true;
@@ -1062,7 +1062,7 @@ TEST_P(SelectiveNimbleReaderTest, smallDictionaryValue) {
   };
   ManualEncodingSelectionPolicyFactory encodingFactory(readFactors);
   VeloxWriterOptions options;
-  options.encodingSelectionPolicyFactory = [&](DataType dataType) {
+  options.encodingSelectionPolicyCreator = [&](DataType dataType) {
     return encodingFactory.createPolicy(dataType);
   };
   auto readers = makeReaders(
@@ -2627,7 +2627,7 @@ TEST_P(SelectiveNimbleReaderTest, columnDecodeMetrics) {
   nimble::ManualEncodingSelectionPolicyFactory encodingFactory(
       {{{nimble::EncodingType::Trivial, 1.0}}}, comprOpts);
   nimble::VeloxWriterOptions writerOptions;
-  writerOptions.encodingSelectionPolicyFactory = [&](nimble::DataType dt) {
+  writerOptions.encodingSelectionPolicyCreator = [&](nimble::DataType dt) {
     return encodingFactory.createPolicy(dt);
   };
   auto file =

--- a/dwio/nimble/velox/selective/tests/StringColumnReaderTest.cpp
+++ b/dwio/nimble/velox/selective/tests/StringColumnReaderTest.cpp
@@ -123,6 +123,8 @@ class StringColumnReaderTest : public ::testing::Test,
       std::optional<VectorEncoding::Simple> expectedChildEncoding =
           std::nullopt,
       int childIndex = 0) {
+    // The RowReader already has the actual ScanSpec filter. This predicate
+    // identifies the input rows expected to pass that filter.
     auto result = BaseVector::create(asRowType(input.type()), 0, pool());
     int numScanned = 0;
     int i = 0;
@@ -171,6 +173,15 @@ class StringColumnReaderTest : public ::testing::Test,
 // Returns the encoding of a vector, loading through lazy wrappers if present.
 VectorEncoding::Simple getEncoding(const VectorPtr& vector) {
   return BaseVector::loadedVectorShared(vector)->encoding();
+}
+
+EncodingLayout makeFsstEncodingLayout() {
+  return EncodingLayout{
+      EncodingType::Fsst,
+      {},
+      CompressionType::Uncompressed,
+      {EncodingLayout{
+          EncodingType::Trivial, {}, CompressionType::Uncompressed}}};
 }
 
 // Validates correctness and checks the expected encoding per batch.
@@ -398,6 +409,67 @@ TEST_P(StringColumnReaderTest, stringFilterWithSiblingColumn) {
           << expectedRow << ")";
       ++expectedRow;
     }
+  }
+}
+
+TEST_P(StringColumnReaderTest, fsstWithSiblingFilter) {
+  const bool stringDecoderZeroCopy = GetParam();
+  if (!stringDecoderZeroCopy) {
+    GTEST_SKIP() << "FSST is only available in the current encoding factory.";
+  }
+
+  constexpr int kRows = 2'000;
+  auto filterCol = makeFlatVector<int64_t>(kRows, [](auto i) { return i; });
+  auto dataCol = makeFlatVector<std::string>(kRows, [](auto i) {
+    return fmt::format("common/prefix/for/fsst/selective/{}", i % 32);
+  });
+  auto input = makeRowVector({filterCol, dataCol});
+
+  VeloxWriterOptions writerOptions;
+  writerOptions.fsstCompressionTargetRatio = 10.0;
+  writerOptions.encodingLayoutTree.emplace(
+      Kind::Row,
+      std::
+          unordered_map<EncodingLayoutTree::StreamIdentifier, EncodingLayout>{},
+      "",
+      std::vector<EncodingLayoutTree>{
+          EncodingLayoutTree{Kind::Scalar, {}, "c0"},
+          EncodingLayoutTree{
+              Kind::Scalar,
+              {{EncodingLayoutTree::StreamIdentifiers::Scalar::ScalarStream,
+                makeFsstEncodingLayout()}},
+              "c1"}});
+  auto file = test::createNimbleFile(*rootPool(), input, writerOptions);
+
+  {
+    SCOPED_TRACE("sibling filter");
+    auto scanSpec = std::make_shared<common::ScanSpec>("root");
+    scanSpec->addAllChildFields(*input->type());
+    scanSpec->childByName("c0")->setFilter(
+        std::make_unique<common::BigintRange>(
+            250, 1'249, /*nullAllowed=*/false));
+    auto readers = makeReaders(input, file, scanSpec, stringDecoderZeroCopy);
+
+    validateWithFilter(*input, *readers.rowReader, 137, [](auto i) {
+      return i >= 250 && i <= 1'249;
+    });
+  }
+
+  {
+    SCOPED_TRACE("FSST string filter");
+    auto scanSpec = std::make_shared<common::ScanSpec>("root");
+    scanSpec->addAllChildFields(*input->type());
+    scanSpec->childByName("c1")->setFilter(
+        std::make_unique<common::BytesValues>(
+            std::vector<std::string>{
+                "common/prefix/for/fsst/selective/3",
+                "common/prefix/for/fsst/selective/17"},
+            false));
+    auto readers = makeReaders(input, file, scanSpec, stringDecoderZeroCopy);
+
+    validateWithFilter(*input, *readers.rowReader, 137, [](auto i) {
+      return i % 32 == 3 || i % 32 == 17;
+    });
   }
 }
 
@@ -1012,13 +1084,14 @@ TEST_P(StringColumnReaderTest, readAcrossStripeBoundary) {
         return std::vector<std::string>{"delta", "echo"}[i % 2];
       })});
 
-  auto readFactors = ManualEncodingSelectionPolicyFactory::defaultReadFactors();
+  auto readFactors =
+      ManualEncodingSelectionPolicyFactory::defaultEncodingReadFactors();
   std::erase_if(readFactors, [](const auto& pair) {
     return pair.first == EncodingType::MainlyConstant;
   });
   VeloxWriterOptions writerOptions;
   writerOptions.enableChunking = true;
-  writerOptions.encodingSelectionPolicyFactory =
+  writerOptions.encodingSelectionPolicyCreator =
       [readFactors](DataType dataType) {
         return ManualEncodingSelectionPolicyFactory(readFactors)
             .createPolicy(dataType);
@@ -1223,13 +1296,14 @@ TEST_P(
   // Exclude MainlyConstant so the flatmap value streams pick a bare Dictionary
   // encoding, forcing the read through readDictionaryIndicesImpl rather than
   // MC's internal row->value mapping.
-  auto readFactors = ManualEncodingSelectionPolicyFactory::defaultReadFactors();
+  auto readFactors =
+      ManualEncodingSelectionPolicyFactory::defaultEncodingReadFactors();
   std::erase_if(readFactors, [](const auto& pair) {
     return pair.first == EncodingType::MainlyConstant;
   });
   VeloxWriterOptions writerOptions;
   writerOptions.flatMapColumns = {{"c0", {}}};
-  writerOptions.encodingSelectionPolicyFactory =
+  writerOptions.encodingSelectionPolicyCreator =
       [readFactors](DataType dataType) {
         return ManualEncodingSelectionPolicyFactory(readFactors)
             .createPolicy(dataType);

--- a/dwio/nimble/velox/stats/VectorizedStatistics.cpp
+++ b/dwio/nimble/velox/stats/VectorizedStatistics.cpp
@@ -75,11 +75,11 @@ std::optional<T> TypedVectorizedStatistic<T>::valueAt(size_t idx) const {
 
 template <typename T>
 std::string_view TypedVectorizedStatistic<T>::serialize(
-    const EncodingSelectionPolicyFactory& encodingSelectionPolicyFactory,
+    const EncodingSelectionPolicyCreator& encodingSelectionPolicyCreator,
     nimble::Buffer& buffer) {
   auto policy = std::unique_ptr<EncodingSelectionPolicy<T>>(
       static_cast<EncodingSelectionPolicy<T>*>(
-          encodingSelectionPolicyFactory(TypeTraits<T>::dataType).release()));
+          encodingSelectionPolicyCreator(TypeTraits<T>::dataType).release()));
   return EncodingFactory::encodeNullable<T>(
       std::move(policy), values_, isValid_, buffer);
 }
@@ -401,7 +401,7 @@ std::string_view VectorizedFileStats::serialize(nimble::Buffer& buffer) {
   std::vector<std::string_view> encodedStatStreams{};
   for (auto& statStream : statStreams_) {
     auto encoded =
-        statStream.second->serialize(encodingSelectionPolicyFactory_, buffer);
+        statStream.second->serialize(encodingSelectionPolicyCreator_, buffer);
     encodedStatStreams.push_back(encoded);
     totalLength += encoded.size();
   }

--- a/dwio/nimble/velox/stats/VectorizedStatistics.h
+++ b/dwio/nimble/velox/stats/VectorizedStatistics.h
@@ -69,7 +69,7 @@ class VectorizedStatistic {
   }
 
   virtual std::string_view serialize(
-      const EncodingSelectionPolicyFactory& encodingSelectionPolicyFactory,
+      const EncodingSelectionPolicyCreator& encodingSelectionPolicyCreator,
       nimble::Buffer& buffer) = 0;
 
   virtual void deserializeFrom(
@@ -101,7 +101,7 @@ class TypedVectorizedStatistic : public VectorizedStatistic {
   std::optional<T> valueAt(size_t idx) const;
 
   std::string_view serialize(
-      const EncodingSelectionPolicyFactory& encodingSelectionPolicyFactory,
+      const EncodingSelectionPolicyCreator& encodingSelectionPolicyCreator,
       nimble::Buffer& buffer) override;
 
   void deserializeFrom(
@@ -156,7 +156,7 @@ class VectorizedFileStats {
 
   std::set<StatType> statTypes_;
   std::map<StatStreamType, std::unique_ptr<VectorizedStatistic>> statStreams_;
-  EncodingSelectionPolicyFactory encodingSelectionPolicyFactory_ =
+  EncodingSelectionPolicyCreator encodingSelectionPolicyCreator_ =
       [encodingFactory = ManualEncodingSelectionPolicyFactory{}](
           DataType dataType) -> std::unique_ptr<EncodingSelectionPolicyBase> {
     return encodingFactory.createPolicy(dataType);

--- a/dwio/nimble/velox/tests/VeloxReaderTest.cpp
+++ b/dwio/nimble/velox/tests/VeloxReaderTest.cpp
@@ -1375,6 +1375,17 @@ class VeloxReaderTest : public ::testing::TestWithParam<TestParam> {
   uint64_t nextFileId_{0};
 };
 
+nimble::EncodingLayout makeFsstEncodingLayout() {
+  return nimble::EncodingLayout{
+      nimble::EncodingType::Fsst,
+      {},
+      nimble::CompressionType::Uncompressed,
+      {nimble::EncodingLayout{
+          nimble::EncodingType::Trivial,
+          {},
+          nimble::CompressionType::Uncompressed}}};
+}
+
 TEST_P(VeloxReaderTest, dontReadUnselectedColumnsFromFile) {
   auto type = velox::ROW({
       {"tinyint_val", velox::TINYINT()},
@@ -1708,6 +1719,55 @@ TEST_P(VeloxReaderTest, lifetime) {
         << "\nReference: " << vector->toString(i)
         << "\nResult: " << result->toString(i);
   }
+}
+
+TEST_P(VeloxReaderTest, fsstStringBatchReader) {
+  if (!optimizeStringBufferHandling()) {
+    GTEST_SKIP() << "FSST is only available in the current encoding factory.";
+  }
+
+  constexpr int kRows = 2'000;
+  velox::test::VectorMaker vectorMaker{leafPool_.get()};
+  auto vector = vectorMaker.rowVector(
+      {vectorMaker.flatVector<int64_t>(kRows, [](auto i) { return i; }),
+       vectorMaker.flatVector<std::string>(kRows, [](auto i) {
+         return fmt::format("common/prefix/for/fsst/batch/{}", i % 32);
+       })});
+
+  nimble::VeloxWriterOptions writerOptions;
+  writerOptions.fsstCompressionTargetRatio = 10.0;
+  writerOptions.encodingLayoutTree.emplace(
+      nimble::Kind::Row,
+      std::unordered_map<
+          nimble::EncodingLayoutTree::StreamIdentifier,
+          nimble::EncodingLayout>{},
+      "",
+      std::vector<nimble::EncodingLayoutTree>{
+          nimble::EncodingLayoutTree{nimble::Kind::Scalar, {}, "c0"},
+          nimble::EncodingLayoutTree{
+              nimble::Kind::Scalar,
+              {{nimble::EncodingLayoutTree::StreamIdentifiers::Scalar::
+                    ScalarStream,
+                makeFsstEncodingLayout()}},
+              "c1"}});
+  auto file = nimble::test::createNimbleFile(*rootPool_, vector, writerOptions);
+
+  auto readFile = std::make_shared<velox::InMemoryReadFile>(file);
+  auto selector = std::make_shared<velox::dwio::common::ColumnSelector>(
+      std::dynamic_pointer_cast<const velox::RowType>(vector->type()));
+  auto reader = createVeloxReader(readFile, *leafPool_, std::move(selector));
+
+  velox::VectorPtr result;
+  int32_t offset = 0;
+  while (offset < kRows) {
+    ASSERT_TRUE(reader->next(137, result));
+    for (int32_t i = 0; i < result->size(); ++i) {
+      ASSERT_TRUE(vector->equalValueAt(result.get(), offset + i, i))
+          << "Mismatch at row " << (offset + i);
+    }
+    offset += result->size();
+  }
+  ASSERT_FALSE(reader->next(1, result));
 }
 
 TEST_P(VeloxReaderTest, allValuesNulls) {
@@ -6330,7 +6390,7 @@ TEST_P(VeloxReaderTest, estimatedRowSizeComplex) {
 
       // TODO: Remove the customized policy after estimation is supported for
       // all encoding types.
-      writerOptions.encodingSelectionPolicyFactory =
+      writerOptions.encodingSelectionPolicyCreator =
           [encodingFactory = nimble::ManualEncodingSelectionPolicyFactory{{
                {nimble::EncodingType::Constant, 1.0},
                {nimble::EncodingType::Trivial, 0.7},
@@ -6479,7 +6539,7 @@ TEST_P(VeloxReaderTest, estimatedRowSizeMix) {
       writerOptions.enableChunking = false;
       // TODO: Remove the customized policy after estimation is supported
       // for all encoding types.
-      writerOptions.encodingSelectionPolicyFactory =
+      writerOptions.encodingSelectionPolicyCreator =
           [encodingFactory = nimble::ManualEncodingSelectionPolicyFactory{{
                {nimble::EncodingType::Constant, 1.0},
                {nimble::EncodingType::Trivial, 0.7},
@@ -6598,7 +6658,7 @@ TEST_P(VeloxReaderTest, readNonExistingFlatMapFeature) {
 
     // TODO: Remove the customized policy after estimation is supported for
     // all encoding types.
-    writerOptions.encodingSelectionPolicyFactory =
+    writerOptions.encodingSelectionPolicyCreator =
         [encodingFactory = nimble::ManualEncodingSelectionPolicyFactory{{
              {nimble::EncodingType::Constant, 1.0},
              {nimble::EncodingType::Trivial, 0.7},
@@ -7399,11 +7459,11 @@ TEST_P(VeloxReaderTest, openZLCompressionRoundTrip) {
   // The default write path drives compression off the encoding selection policy
   // (not VeloxWriterOptions::compressionOptions), so force OpenZL via the
   // factory so the codec is actually exercised end-to-end.
-  writerOptions.encodingSelectionPolicyFactory =
+  writerOptions.encodingSelectionPolicyCreator =
       [factory =
            nimble::ManualEncodingSelectionPolicyFactory{
                nimble::ManualEncodingSelectionPolicyFactory::
-                   defaultReadFactors(),
+                   defaultEncodingReadFactors(),
                nimble::CompressionOptions{
                    .compressionAcceptRatio = 100,
                    .compressionType = nimble::CompressionType::OpenZL,

--- a/dwio/nimble/velox/tests/VeloxWriterTest.cpp
+++ b/dwio/nimble/velox/tests/VeloxWriterTest.cpp
@@ -108,6 +108,116 @@ TEST_F(VeloxWriterTest, emptyFile) {
   ASSERT_FALSE(reader.next(1, result));
 }
 
+TEST_F(VeloxWriterTest, buildEncodingOptionsPropagatesFsstCompressionTarget) {
+  nimble::VeloxWriterOptions options;
+  options.fsstCompressionTargetRatio = 0.42;
+
+  const auto encodingOptions = options.buildEncodingOptions();
+
+  EXPECT_DOUBLE_EQ(encodingOptions.fsstCompressionTargetRatio, 0.42);
+}
+
+TEST_F(VeloxWriterTest, fsstEncodingTargetControlsWriterEncoding) {
+  velox::test::VectorMaker vectorMaker{leafPool_.get()};
+  auto vector = vectorMaker.rowVector(
+      {vectorMaker.flatVector<std::string>({std::string(2'000, 'x')})});
+
+  struct TestCase {
+    std::string name;
+    double targetRatio;
+    nimble::CompressionType fsstCompressionType;
+    nimble::CompressionOptions compressionOptions;
+    nimble::EncodingType expectedEncodingType;
+    nimble::CompressionType expectedCompressionType;
+  };
+
+  nimble::CompressionOptions zstdCompressionOptions;
+  zstdCompressionOptions.compressionType = nimble::CompressionType::Zstd;
+  zstdCompressionOptions.zstdMinCompressionSize = 0;
+
+  for (const auto& testCase : std::vector<TestCase>{
+           {
+               .name = "permissive_target_uses_fsst",
+               .targetRatio = 10.0,
+               .fsstCompressionType = nimble::CompressionType::Uncompressed,
+               .expectedEncodingType = nimble::EncodingType::Fsst,
+               .expectedCompressionType = nimble::CompressionType::Uncompressed,
+           },
+           {
+               .name = "strict_target_falls_back_to_compressed_trivial",
+               .targetRatio = 0.0,
+               .fsstCompressionType = nimble::CompressionType::Zstd,
+               .compressionOptions = zstdCompressionOptions,
+               .expectedEncodingType = nimble::EncodingType::Trivial,
+               .expectedCompressionType = nimble::CompressionType::Zstd,
+           },
+       }) {
+    SCOPED_TRACE(testCase.name);
+
+    nimble::EncodingLayout fsstLayout{
+        nimble::EncodingType::Fsst,
+        {},
+        testCase.fsstCompressionType,
+        {nimble::EncodingLayout{
+            nimble::EncodingType::Trivial,
+            {},
+            nimble::CompressionType::Uncompressed}}};
+
+    std::string file;
+    auto writeFile = std::make_unique<velox::InMemoryWriteFile>(&file);
+    nimble::VeloxWriter writer(
+        vector->type(),
+        std::move(writeFile),
+        *rootPool_,
+        {
+            .encodingLayoutTree =
+                nimble::EncodingLayoutTree{
+                    nimble::Kind::Row,
+                    {},
+                    "",
+                    {nimble::EncodingLayoutTree{
+                        nimble::Kind::Scalar,
+                        {{nimble::EncodingLayoutTree::StreamIdentifiers::
+                              Scalar::ScalarStream,
+                          std::move(fsstLayout)}},
+                        "c0"}}},
+            .compressionOptions = testCase.compressionOptions,
+            .fsstCompressionTargetRatio = testCase.targetRatio,
+        });
+    writer.write(vector);
+    writer.close();
+
+    auto readFile = std::make_shared<velox::InMemoryReadFile>(file);
+    auto tablet = nimble::TabletReader::create(
+        readFile, leafPool_.get(), makeTestTabletOptions(leafPool_.get()));
+    auto section =
+        tablet->loadOptionalSection(std::string(nimble::kSchemaSection));
+    NIMBLE_CHECK(section.has_value(), "Schema not found.");
+    auto schema =
+        nimble::SchemaDeserializer::deserialize(section->content().data());
+    const auto& scalarNode = schema->asRow().childAt(0)->asScalar();
+
+    ASSERT_EQ(tablet->stripeCount(), 1);
+    std::vector<uint32_t> streamIdentifiers{
+        scalarNode.scalarDescriptor().offset()};
+    auto streams = tablet->load(tablet->stripeIdentifier(0), streamIdentifiers);
+    nimble::InMemoryChunkedStream chunkedStream{
+        *leafPool_, std::move(streams[0])};
+    ASSERT_TRUE(chunkedStream.hasNext());
+    const auto capture =
+        nimble::EncodingLayoutCapture::capture(chunkedStream.nextChunk());
+
+    EXPECT_EQ(capture.encodingType(), testCase.expectedEncodingType);
+    EXPECT_EQ(capture.compressionType(), testCase.expectedCompressionType);
+    if (testCase.expectedEncodingType == nimble::EncodingType::Fsst) {
+      EXPECT_EQ(
+          capture.child(nimble::EncodingIdentifiers::Fsst::Lengths)
+              ->encodingType(),
+          nimble::EncodingType::Trivial);
+    }
+  }
+}
+
 TEST_F(VeloxWriterTest, emptyFileWithIndexEnabled) {
   auto type = velox::ROW({
       {"key_col", velox::INTEGER()},
@@ -1098,11 +1208,11 @@ TEST_F(VeloxWriterTest, openZLCompressionNumericRoundTrip) {
   // (not VeloxWriterOptions::compressionOptions), so force OpenZL via the
   // factory. Accept ratio 100 + min size 0 ensure the codec is actually applied
   // even to tiny streams.
-  writerOptions.encodingSelectionPolicyFactory =
+  writerOptions.encodingSelectionPolicyCreator =
       [factory =
            nimble::ManualEncodingSelectionPolicyFactory{
                nimble::ManualEncodingSelectionPolicyFactory::
-                   defaultReadFactors(),
+                   defaultEncodingReadFactors(),
                nimble::CompressionOptions{
                    .compressionAcceptRatio = 100,
                    .compressionType = nimble::CompressionType::OpenZL,


### PR DESCRIPTION
Summary:

Add `FsstEncoding` to Nimble for string column compression using FSST (Fast Static Symbol Table). FSST trains a per-stripe symbol table that maps frequent 1-8 byte sequences to single-byte codes. Each string is compressed independently, which keeps random-access decompression local to the requested string.

This encoding targets high-cardinality string data such as URLs, user agents, and log messages where dictionary encoding is often ineffective. FSST typically gives useful compression while preserving fast point reads and selective scans.

Wire format: encoding prefix + serialized FSST symbol table + nested compressed-lengths encoding + concatenated FSST-compressed string blob. The nested lengths stream is captured by `FsstEncoding::captureNestedEncoding`, and the final FSST payload is kept only when it meets the configurable `Encoding::Options::fsstCompressionTargetRatio` target; otherwise the writer can fall back to compressed Trivial string encoding when that is smaller.

Refactor/cleanup included in this diff: move reusable compression-selection policies into `dwio/nimble/compression`, rename compression metadata from `CompressionInformation` to `CompressionConfig`, rename encoding-selection factory plumbing to `EncodingSelectionPolicyCreator`, move non-template encoding-selection helpers into `.cpp` files, remove stale selection logs, and localize FSST nested-layout capture/size estimation inside `FsstEncoding` where possible.

This also wires FSST through encoding factories, size estimation, encoding layout capture, Velox writer options, selective/batch reader coverage, and tests.

Reviewed By: HuamengJiang, duxiao1212

Differential Revision: D105064770
