### PR TITLE
feat(nimble): Add reader-owned lazy I/O load hook (#925)

### DIFF
--- a/dwio/nimble/velox/selective/ColumnLoader.h
+++ b/dwio/nimble/velox/selective/ColumnLoader.h
@@ -29,12 +29,10 @@ class TrackedColumnLoader : public velox::dwio::common::ColumnLoader {
       velox::dwio::common::SelectiveStructColumnReaderBase* structReader,
       velox::dwio::common::SelectiveColumnReader* fieldReader,
       uint64_t version,
-      RowSizeTracker* rowSizeTracker = nullptr,
-      LazyInput* lazyInput = nullptr)
+      RowSizeTracker* rowSizeTracker = nullptr)
       : velox::dwio::common::ColumnLoader{structReader, fieldReader, version},
         typeWithId_{fieldReader->fileType()},
-        rowSizeTracker_{rowSizeTracker},
-        lazyInput_{lazyInput} {}
+        rowSizeTracker_{rowSizeTracker} {}
 
  private:
   void loadInternal(
@@ -42,13 +40,6 @@ class TrackedColumnLoader : public velox::dwio::common::ColumnLoader {
       velox::ValueHook* hook,
       velox::vector_size_t resultSize,
       velox::VectorPtr* result) override {
-    if (lazyInput_ != nullptr) {
-      VELOX_CHECK_EQ(
-          version_,
-          structReader_->numReads(),
-          "Loading LazyVector after the enclosing reader has moved");
-      lazyInput_->load();
-    }
     velox::dwio::common::ColumnLoader::loadInternal(
         rows, hook, resultSize, result);
     if (result && rowSizeTracker_) {
@@ -208,9 +199,6 @@ class TrackedColumnLoader : public velox::dwio::common::ColumnLoader {
 
   const velox::dwio::common::TypeWithId& typeWithId_;
   RowSizeTracker* const rowSizeTracker_;
-  // Non-null when this column uses lazy I/O. Triggers load() on first
-  // lazy access to fetch the column's streams from WarmStorage.
-  LazyInput* const lazyInput_{nullptr};
 };
 
 } // namespace facebook::nimble

--- a/dwio/nimble/velox/selective/NimbleData.cpp
+++ b/dwio/nimble/velox/selective/NimbleData.cpp
@@ -23,6 +23,12 @@ namespace facebook::nimble {
 
 using namespace facebook::velox;
 
+void NimbleData::loadLazyInputStreams() {
+  if (lazyColumnIo_) {
+    streams_->loadLazyInput();
+  }
+}
+
 NimbleData::NimbleData(
     const std::shared_ptr<const Type>& nimbleType,
     StripeStreams& streams,

--- a/dwio/nimble/velox/selective/NimbleData.h
+++ b/dwio/nimble/velox/selective/NimbleData.h
@@ -106,6 +106,12 @@ class NimbleData : public velox::dwio::common::FormatData {
     return nimblePreserveDictionaryEncoding_;
   }
 
+  /// Loads the deferred lazy clone of this column's streams. Called from the
+  /// shared column-loader read path, so it fires for every loader type and the
+  /// streams are always resident before decode. No-op unless this column was
+  /// given lazy I/O.
+  void loadLazyInputStreams() override;
+
  private:
   std::unique_ptr<ChunkedDecoder> makeDecoder(
       const StreamDescriptor& descriptor,
@@ -205,11 +211,6 @@ class NimbleParams : public velox::dwio::common::FormatParams {
   /// Returns true if the top-level column 'name' should use lazy I/O.
   bool lazyIoColumn(const std::string& name) const {
     return lazyIoColumns_ != nullptr && lazyIoColumns_->count(name) > 0;
-  }
-
-  /// Returns the lazy I/O columns set.
-  const folly::F14FastSet<std::string>* lazyIoColumnsSet() const {
-    return lazyIoColumns_;
   }
 
   RowSizeTracker* rowSizeTracker() const {

--- a/dwio/nimble/velox/selective/ReaderBase.h
+++ b/dwio/nimble/velox/selective/ReaderBase.h
@@ -210,6 +210,13 @@ class StripeStreams {
     readerBase_->input().load(velox::dwio::common::LogType::STREAM_BUNDLE);
   }
 
+  /// Loads the lazy input clone, if one exists. Idempotent.
+  void loadLazyInput() {
+    if (lazyInput_) {
+      lazyInput_->load();
+    }
+  }
+
   /// Create a lazy input clone for lazy column I/O. Ownership is held
   /// by StripeStreams; the clone is valid until the next setStripe() call.
   LazyInput* createLazyInput();

--- a/dwio/nimble/velox/selective/SelectiveNimbleReader.cpp
+++ b/dwio/nimble/velox/selective/SelectiveNimbleReader.cpp
@@ -429,8 +429,8 @@ void SelectiveNimbleRowReader::initReadRange() {
 
 // Computes the set of top-level columns eligible for lazy I/O. A column
 // qualifies if it has no pushdown filter, is not referenced by the remaining
-// filter, has no extraction transform, has no delta update, and is projected
-// in the output. Returns empty set when lazy I/O is disabled.
+// filter, and is projected in the output. Returns empty set when lazy I/O is
+// disabled.
 folly::F14FastSet<std::string> SelectiveNimbleRowReader::computeLazyIoColumns(
     const dwio::common::RowReaderOptions& options) {
   folly::F14FastSet<std::string> lazyIoColumns;
@@ -448,13 +448,10 @@ folly::F14FastSet<std::string> SelectiveNimbleRowReader::computeLazyIoColumns(
     NIMBLE_DCHECK(
         childSpec->hasFilter() || childSpec->projectOut(),
         "Column with no filter should be projected");
-    // A column is eligible for lazy I/O if it has no pushdown filter, is not
-    // referenced by the remaining filter (must be eager for filter eval), has
-    // no extraction transform, has no delta update, and is projected in the
-    // output. Transform and delta-updated columns are excluded because their
-    // loaders read through the eager input and never call LazyInput::load().
+    // Being lazy only defers a column's stream I/O; it does not change which
+    // loader decodes the column, so transform and delta columns are eligible
+    // too, not just plain projected ones.
     if (!childSpec->hasFilter() && remainingFilterColumns.count(name) == 0 &&
-        !childSpec->hasTransform() && !childSpec->deltaUpdate() &&
         childSpec->projectOut()) {
       lazyIoColumns.insert(name);
     }

--- a/dwio/nimble/velox/selective/StructColumnReader.cpp
+++ b/dwio/nimble/velox/selective/StructColumnReader.cpp
@@ -66,7 +66,6 @@ StructColumnReader::StructColumnReader(
   const auto& fileRowType = fileType_->type()->asRow();
   if (params.hasLazyIoColumns()) {
     lazyInput_ = params.streams().createLazyInput();
-    lazyIoColumns_ = params.lazyIoColumnsSet();
   }
   for (auto* childSpec : scanSpec.stableChildren()) {
     if (childSpec->isConstant() || isChildMissing(*childSpec)) {

--- a/dwio/nimble/velox/selective/StructColumnReader.h
+++ b/dwio/nimble/velox/selective/StructColumnReader.h
@@ -86,35 +86,15 @@ class StructColumnReader : public StructColumnReaderBase {
   bool estimateMaterializedSize(size_t& byteSize, size_t& rowCount) const final;
 
  private:
-  // Creates a column loader for lazy I/O columns. Lazy columns get a
-  // TrackedColumnLoader that triggers LazyInput::load() on first access;
-  // non-lazy columns fall through to the base class loader.
-  std::unique_ptr<velox::dwio::common::ColumnLoader> makeColumnLoader(
-      velox::vector_size_t index) override {
-    if (lazyInput_ != nullptr) {
-      for (const auto& childSpec : scanSpec_->children()) {
-        if (childSpec->subscript() == index &&
-            lazyIoColumns_->count(childSpec->fieldName()) > 0) {
-          return std::make_unique<nimble::TrackedColumnLoader>(
-              this, children_[index], numReads_, rowSizeTracker_, lazyInput_);
-        }
-      }
-    }
-    return StructColumnReaderBase::makeColumnLoader(index);
-  }
-
   void addChild(std::unique_ptr<SelectiveColumnReader> child) {
     children_.push_back(child.get());
     childrenOwned_.push_back(std::move(child));
   }
 
   std::vector<std::unique_ptr<SelectiveColumnReader>> childrenOwned_;
-  // Lazy input for all lazy I/O columns in this stripe. Null when
-  // no columns use lazy I/O. Owned by StripeStreams.
+  // Lazy input clone for this stripe's lazy I/O columns, or null if none are
+  // lazy. Owned by StripeStreams; used by estimateMaterializedSize().
   LazyInput* lazyInput_{nullptr};
-  // Set of top-level column names eligible for lazy I/O. Pointer to the
-  // const set owned by SelectiveNimbleRowReader.
-  const folly::F14FastSet<std::string>* lazyIoColumns_{nullptr};
 };
 
 } // namespace facebook::nimble

--- a/dwio/nimble/velox/selective/tests/FlatMapColumnReaderTest.cpp
+++ b/dwio/nimble/velox/selective/tests/FlatMapColumnReaderTest.cpp
@@ -1137,7 +1137,10 @@ TEST_P(FlatMapColumnReaderTest, lazyIONestedRowNoFilter) {
   velox::test::assertEqualVectors(expected, result);
 }
 
-TEST_P(FlatMapColumnReaderTest, lazyIOTransformColumnStaysEager) {
+// A projected column with a post-read extraction transform, read with lazy
+// column I/O enabled. The transform is still applied and the result must match
+// the eager read.
+TEST_P(FlatMapColumnReaderTest, lazyIOTransformColumn) {
   auto input = makeRowVector({
       makeFlatVector<int64_t>({10, 20, 30, 40, 50}),
       makeFlatVector<int64_t>({1, 2, 3, 4, 5}),
@@ -1190,6 +1193,63 @@ TEST_P(FlatMapColumnReaderTest, lazyIOTransformColumnStaysEager) {
   velox::test::assertEqualVectors(expected, result);
 }
 
+// A transform column read lazily across three stripes, applying the transform
+// at each stripe; the result must match the eager read.
+TEST_P(FlatMapColumnReaderTest, lazyIOTransformColumnMultiStripe) {
+  auto batch1 = makeRowVector({
+      makeFlatVector<int64_t>({1, 2, 3}),
+      makeFlatVector<int64_t>({100, 200, 300}),
+  });
+  auto batch2 = makeRowVector({
+      makeFlatVector<int64_t>({4, 5, 6}),
+      makeFlatVector<int64_t>({400, 500, 600}),
+  });
+  auto batch3 = makeRowVector({
+      makeFlatVector<int64_t>({7, 8, 9}),
+      makeFlatVector<int64_t>({700, 800, 900}),
+  });
+  VeloxWriterOptions writerOptions;
+  writerOptions.skipConstantFlatMapInMapStreams = GetParam();
+  auto file = test::createNimbleFile(
+      *rootPool(),
+      {batch1, batch2, batch3},
+      writerOptions,
+      /*flushAfterWrite=*/true);
+
+  auto scanSpec = std::make_shared<common::ScanSpec>("root");
+  scanSpec->addAllChildFields(*batch1->type());
+  // Pass-all filter keeps c0 eager; c1 has a post-read transform (x10) and is
+  // projected -> lazy-eligible.
+  scanSpec->childByName("c0")->setFilter(
+      std::make_unique<common::BigintRange>(0, 1000, false));
+  scanSpec->childByName("c1")->setTransform(
+      [](const VectorPtr& v, memory::MemoryPool* pool) -> VectorPtr {
+        auto* flat = v->asFlatVector<int64_t>();
+        auto result = BaseVector::create(BIGINT(), flat->size(), pool);
+        auto* out = result->asFlatVector<int64_t>();
+        for (auto i = 0; i < flat->size(); ++i) {
+          out->set(i, flat->valueAt(i) * 10);
+        }
+        return result;
+      },
+      BIGINT());
+
+  auto expected = makeRowVector({
+      makeFlatVector<int64_t>({1, 2, 3, 4, 5, 6, 7, 8, 9}),
+      makeFlatVector<int64_t>(
+          {1000, 2000, 3000, 4000, 5000, 6000, 7000, 8000, 9000}),
+  });
+  auto readers = makeReaders(
+      expected,
+      file,
+      scanSpec,
+      /*preserveFlatMapsInMemory=*/false,
+      /*lazyColumnIo=*/true);
+  // Batch size 2 (< 3 rows/stripe) crosses stripe boundaries while c1 is
+  // materialized via the lazy TransformColumnLoader + hook.
+  validate(*expected, *readers.rowReader, 2);
+}
+
 TEST_P(FlatMapColumnReaderTest, lazyIORegularMapColumn) {
   auto input = makeRowVector({
       makeFlatVector<int64_t>({10, 20, 30, 40}),
@@ -1225,6 +1285,74 @@ TEST_P(FlatMapColumnReaderTest, lazyIORegularMapColumn) {
       }),
   });
   velox::test::assertEqualVectors(expected, result);
+}
+
+// A lazy flat-map column read across three stripes, covering lazy loading at
+// each stripe boundary.
+TEST_P(FlatMapColumnReaderTest, lazyIOMultiStripe) {
+  auto batch1 = makeRowVector({
+      makeFlatVector<int64_t>({10, 20, 30}),
+      makeMapVector<int32_t, int64_t>({
+          {{1, 100}, {2, 200}},
+          {{1, 300}},
+          {{2, 400}, {3, 500}},
+      }),
+  });
+  auto batch2 = makeRowVector({
+      makeFlatVector<int64_t>({40, 50, 60}),
+      makeMapVector<int32_t, int64_t>({
+          {{1, 600}},
+          {{2, 700}, {3, 800}},
+          {{1, 900}},
+      }),
+  });
+  auto batch3 = makeRowVector({
+      makeFlatVector<int64_t>({70, 80, 90}),
+      makeMapVector<int32_t, int64_t>({
+          {{3, 1000}},
+          {{1, 1100}, {2, 1200}},
+          {},
+      }),
+  });
+  VeloxWriterOptions writerOptions;
+  writerOptions.flatMapColumns = {{"c1", {}}};
+  writerOptions.skipConstantFlatMapInMapStreams = GetParam();
+  auto file = test::createNimbleFile(
+      *rootPool(),
+      {batch1, batch2, batch3},
+      writerOptions,
+      /*flushAfterWrite=*/true);
+
+  auto expected = makeRowVector({
+      makeFlatVector<int64_t>({10, 20, 30, 40, 50, 60, 70, 80, 90}),
+      makeMapVector<int32_t, int64_t>({
+          {{1, 100}, {2, 200}},
+          {{1, 300}},
+          {{2, 400}, {3, 500}},
+          {{1, 600}},
+          {{2, 700}, {3, 800}},
+          {{1, 900}},
+          {{3, 1000}},
+          {{1, 1100}, {2, 1200}},
+          {},
+      }),
+  });
+
+  auto scanSpec = std::make_shared<common::ScanSpec>("root");
+  scanSpec->addAllChildFields(*expected->type());
+  // Pass-all filter keeps c0 eager (filter column) while the flatmap c1 stays
+  // lazy; all 9 rows survive so validate() compares the full cross-stripe read.
+  scanSpec->childByName("c0")->setFilter(
+      std::make_unique<common::BigintRange>(0, 1000, false));
+  auto readers = makeReaders(
+      expected,
+      file,
+      scanSpec,
+      /*preserveFlatMapsInMemory=*/false,
+      /*lazyColumnIo=*/true);
+  // Batch size 2 (< 3 rows/stripe) forces next() calls that cross stripe
+  // boundaries while c1 is materialized via the lazy hook.
+  validate(*expected, *readers.rowReader, 2);
 }
 
 INSTANTIATE_TEST_SUITE_P(


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebookincubator/velox/pull/17999


D110095905 fixed the "Fail to read region" crash on Nimble lazy column I/O by
excluding delta-updated columns from lazy I/O (a denylist). That stops the crash
but forces those columns to read eagerly, giving up the lazy-io benefit.

This replaces the denylist with a reader-owned load hook: a no-op
FormatData::loadLazyInputStreams() virtual, called from the shared ColumnLoader
read path and overridden by Nimble to load the deferred lazy clone. Because it
fires from the shared read path, every loader (plain, transform, delta) triggers
it, so deferred streams are loaded before decode and the "streams never loaded"
bug class is structurally impossible.

With the load decoupled from the loader, loader-type selection is left entirely
to the base makeColumnLoader(), independent of laziness: a lazy column gets the
same loader it would eagerly (TransformColumnLoader for extraction transforms,
DeltaUpdateColumnLoader for delta updates on a separate path, TrackedColumnLoader
otherwise). Deferring a column's streams therefore never changes how it decodes,
so delta-updated AND transform columns are lazy-eligible again;
computeLazyIoColumns() now excludes only filter, remaining-filter, and
non-projected columns.

Reviewed By: xiaoxmeng

Differential Revision: D110134101


