### PR TITLE
perf: Fix O(n^2) reallocation in PrefixEncoding::encode() (#926)

### DIFF
--- a/dwio/nimble/encodings/PrefixEncoding.cpp
+++ b/dwio/nimble/encodings/PrefixEncoding.cpp
@@ -195,6 +195,13 @@ std::string_view PrefixEncoding::encode(
   restartOffsets.reserve(numRestarts);
   Vector<char> encodedData{&buffer.getMemoryPool()};
 
+  // Reserve upfront to avoid O(n^2) reallocations in the insert() loop below.
+  uint64_t estimatedSize = 0;
+  for (const auto& v : values) {
+    estimatedSize += 2 * sizeof(uint32_t) + v.size();
+  }
+  encodedData.reserve(estimatedSize);
+
   std::string_view lastValue;
   char buf[sizeof(uint32_t)];
 

--- a/dwio/nimble/encodings/tests/PrefixEncodingTest.cpp
+++ b/dwio/nimble/encodings/tests/PrefixEncodingTest.cpp
@@ -843,4 +843,45 @@ TEST_F(PrefixEncodingTest, fuzzerEncode) {
   }
 }
 
+TEST_F(PrefixEncodingTest, encodeLargeInputRoundTrip) {
+  constexpr uint32_t kNumValues = 500'000;
+
+  std::vector<std::string> keyStrings;
+  keyStrings.reserve(kNumValues);
+  for (uint32_t i = 0; i < kNumValues; ++i) {
+    keyStrings.push_back(fmt::format("key_{:010d}_suffix_{:05d}", i / 100, i));
+  }
+  std::vector<std::string_view> values;
+  values.reserve(kNumValues);
+  for (const auto& s : keyStrings) {
+    values.push_back(s);
+  }
+
+  Buffer buffer{*pool_};
+
+  const auto startTime = std::chrono::steady_clock::now();
+  auto encoded = EncodingFactory::encode<std::string_view>(
+      createSelectionPolicy(), values, buffer);
+  const auto elapsed = std::chrono::duration_cast<std::chrono::seconds>(
+                           std::chrono::steady_clock::now() - startTime)
+                           .count();
+  EXPECT_FALSE(encoded.empty());
+  // Without the reserve() fix, encoding 500K values takes 600+ seconds due to
+  // O(n^2) reallocations. With the fix it completes in under a second. Use a
+  // generous 120s limit to avoid flakes under ASAN/TSAN/loaded machines.
+  EXPECT_LT(elapsed, 120) << "Encoding " << kNumValues << " values took "
+                          << elapsed << "s";
+
+  stringBuffers_.clear();
+  auto encoding =
+      EncodingFactory().create(*pool_, encoded, createStringBufferFactory());
+  EXPECT_EQ(encoding->rowCount(), kNumValues);
+
+  std::vector<std::string_view> decoded(kNumValues);
+  encoding->materialize(kNumValues, decoded.data());
+  for (uint32_t i = 0; i < kNumValues; ++i) {
+    EXPECT_EQ(decoded[i], values[i]) << "Mismatch at row " << i;
+  }
+}
+
 } // namespace facebook::nimble::test


### PR DESCRIPTION
Summary:

CONTEXT: The Nimble cluster index writer hangs for 40+ minutes when encoding millions of keys. Root cause is `PrefixEncoding::encode()` building output via repeated `Vector<char>::insert(end(), ...)` calls. Each `insert()` at `end()` triggers `resize()` which calls `AlignedBuffer::allocateExact()` with no exponential growth — every insert reallocates and copies the entire buffer. With 2.4M keys and 3 inserts per key, this is O(n^2) total memcpy work.

WHAT: Add a pre-pass to estimate total encoded size and `reserve()` the buffer upfront before the encoding loop. This converts the O(n^2) reallocation pattern to O(n).

Reviewed By: xiaoxmeng

Differential Revision: D110281584


