### PR TITLE
feat(nimble): Add EXPERIMENTAL annotations to non-production-ready features

### DIFF
--- a/dwio/nimble/common/Types.h
+++ b/dwio/nimble/common/Types.h
@@ -109,17 +109,25 @@ enum class EncodingType {
   // Patched Frame-of-Reference. Subtracts a min baseline, bitpacks ~90% of
   // residuals at a narrow base bit width, and stores the remaining outliers
   // ("exceptions") as a parallel position+value array.
+  // EXPERIMENTAL: Not production-ready. Do not enable for production tables
+  // without consulting the Nimble team (oncall: dwios).
   PFOR = 13,
   // SIMD Frame-of-Reference bitpacking. Subtracts baseline (global min),
   // packs residuals in groups of 32 via Lemire FastPFor SIMD bitpacking.
+  // EXPERIMENTAL: Not production-ready. Do not enable for production tables
+  // without consulting the Nimble team (oncall: dwios).
   SimdForBitpack = 14,
   // Decomposes each value into bit-range sub-streams and encodes each
   // independently. Optimal splits are chosen via a sample-driven DP algorithm.
   // Only supported for 32- and 64-bit numeric types.
+  // EXPERIMENTAL: Not production-ready. Do not enable for production tables
+  // without consulting the Nimble team (oncall: dwios).
   SubIntSplit = 16,
   // Stores integer data in fixed-size chunks (default 1024 rows), each with
   // its own baseline and bit width. Adapts per-chunk variable bit widths for
   // better compression on data with locally narrow value ranges.
+  // EXPERIMENTAL: Not production-ready. Do not enable for production tables
+  // without consulting the Nimble team (oncall: dwios).
   BlockBitPacking = 15,
   // Partitions data by value frequency. Also, frequent values get shorter
   // bit-width
@@ -131,6 +139,8 @@ enum class EncodingType {
   // Stores string data compressed with FSST (Fast Static Symbol Table).
   // Trains a per-stripe symbol table and compresses each string independently,
   // enabling random access decompression without touching neighboring strings.
+  // EXPERIMENTAL: Not production-ready. Do not enable for production tables
+  // without consulting the Nimble team (oncall: dwios).
   Fsst = 19,
 };
 std::string toString(EncodingType encodingType);

--- a/dwio/nimble/encodings/selection/EncodingSelectionPolicy.cpp
+++ b/dwio/nimble/encodings/selection/EncodingSelectionPolicy.cpp
@@ -111,6 +111,9 @@ ManualEncodingSelectionPolicyFactory::possibleEncodings() {
       EncodingType::Dictionary,
       EncodingType::RLE,
       EncodingType::Varint,
+      // EXPERIMENTAL: The following encodings are not production-ready. Do not
+      // enable for production tables without consulting the Nimble team
+      // (oncall: dwios).
       EncodingType::PFOR,
       EncodingType::SimdForBitpack,
       EncodingType::SubIntSplit,

--- a/dwio/nimble/index/IndexConfig.h
+++ b/dwio/nimble/index/IndexConfig.h
@@ -28,6 +28,8 @@ namespace facebook::nimble {
 /// Configuration for index generation.
 /// The index allows efficient filtering and pruning of data based on
 /// the specified index columns.
+// EXPERIMENTAL: Cluster index is not production-ready. Do not enable for
+// production tables without consulting the Nimble team (oncall: dwios).
 struct ClusterIndexConfig {
   /// Columns to be indexed for data pruning.
   /// These columns will be encoded using KeyWriter to generate index keys
@@ -78,6 +80,8 @@ struct BloomFilterConfig {
 /// A hash index provides point lookups from composite key columns to row
 /// numbers without requiring data to be sorted. Multiple hash indices can
 /// coexist per file, each on a different set of columns.
+// EXPERIMENTAL: Hash index is not production-ready. Do not enable for
+// production tables without consulting the Nimble team (oncall: dwios).
 struct HashIndexConfig {
   /// Columns forming the composite key for point lookups.
   std::vector<std::string> columns;
@@ -102,6 +106,8 @@ struct HashIndexConfig {
 /// A sorted index stores a sorted key stream with embedded row IDs for
 /// point lookups and range scans on unsorted data. Unlike ClusterIndex
 /// (which requires sorted data), this is a secondary index.
+// EXPERIMENTAL: Sorted index is not production-ready. Do not enable for
+// production tables without consulting the Nimble team (oncall: dwios).
 struct SortedIndexConfig {
   /// Columns forming the composite key.
   std::vector<std::string> columns;

--- a/dwio/nimble/velox/NimbleConfig.cpp
+++ b/dwio/nimble/velox/NimbleConfig.cpp
@@ -259,6 +259,8 @@ std::map<uint64_t, float> parseGrowthConfigMap(const std::string& str) {
 /// Enable chunk index for chunk-level seeking and per-chunk statistics
 /// for filter pushdown. When enabled, a chunk index optional section is
 /// written alongside chunk position data in the file.
+// EXPERIMENTAL: Not production-ready. Do not enable for production tables
+// without consulting the Nimble team (oncall: dwios).
 /* static */ Config::Entry<bool> Config::ENABLE_CHUNK_INDEX(
     "nimble.chunk.index.enabled",
     false);
@@ -307,6 +309,8 @@ std::map<uint64_t, float> parseGrowthConfigMap(const std::string& str) {
         "nimble.chunking.writer.wide.schema.max.chunk.size",
         kChunkingWriterWideSchemaMaxChunkSize);
 
+// EXPERIMENTAL: Cluster index is not production-ready. Do not enable for
+// production tables without consulting the Nimble team (oncall: dwios).
 /* static */ Config::Entry<const std::vector<std::string>>
     Config::INDEX_COLUMNS(
         "nimble.index.columns",
@@ -345,6 +349,9 @@ std::map<uint64_t, float> parseGrowthConfigMap(const std::string& str) {
     "nimble.index.max_rows_per_key_chunk",
     10'000);
 
+// EXPERIMENTAL: BlockBitPacking encoding is not production-ready. Do not
+// enable for production tables without consulting the Nimble team
+// (oncall: dwios).
 /* static */ Config::Entry<uint16_t> Config::BLOCK_BIT_PACKING_BLOCK_SIZE(
     "nimble.blockbitpacking.block.size",
     kBlockBitPackingBlockSize);

--- a/dwio/nimble/velox/NimbleConfig.h
+++ b/dwio/nimble/velox/NimbleConfig.h
@@ -50,6 +50,8 @@ class Config : public velox::config::ConfigBase {
       INPUT_BUFFER_DEFAULT_GROWTH_CONFIGS;
   static Entry<const std::map<uint64_t, float>> STRING_BUFFER_GROWTH_CONFIGS;
   static Entry<bool> ENABLE_CHUNKING;
+  // EXPERIMENTAL: Not production-ready. Do not enable for production tables
+  // without consulting the Nimble team (oncall: dwios).
   static Entry<bool> ENABLE_CHUNK_INDEX;
   static Entry<uint64_t> CHUNKING_WRITER_MEMORY_HIGH_THRESHOLD;
   static Entry<uint64_t> CHUNKING_WRITER_MEMORY_LOW_THRESHOLD;
@@ -58,6 +60,9 @@ class Config : public velox::config::ConfigBase {
   static Entry<uint64_t> CHUNKING_WRITER_MIN_CHUNK_SIZE;
   static Entry<uint64_t> CHUNKING_WRITER_MAX_CHUNK_SIZE;
   static Entry<uint64_t> CHUNKING_WRITER_WIDE_SCHEMA_MAX_CHUNK_SIZE;
+
+  // EXPERIMENTAL: Cluster index is not production-ready. Do not enable for
+  // production tables without consulting the Nimble team (oncall: dwios).
 
   /// Index columns to build cluster index during writing.
   /// Column names are separated by commas.
@@ -85,6 +90,9 @@ class Config : public velox::config::ConfigBase {
   /// chunk per partition), which can hang on large tables. Default: 10000.
   static Entry<uint64_t> INDEX_MAX_ROWS_PER_KEY_CHUNK;
 
+  // EXPERIMENTAL: BlockBitPacking encoding is not production-ready. Do not
+  // enable for production tables without consulting the Nimble team
+  // (oncall: dwios).
   static Entry<uint16_t> BLOCK_BIT_PACKING_BLOCK_SIZE;
 
   /// Enable column statistics collection during writing.

--- a/dwio/nimble/velox/VeloxWriterOptions.h
+++ b/dwio/nimble/velox/VeloxWriterOptions.h
@@ -56,6 +56,8 @@ struct VeloxWriterOptions {
   // enabling O(1) chunk-level seeking within stripes. Independent of
   // the cluster index (clusterIndexConfig). When clusterIndexConfig is set,
   // chunk index is always enabled regardless of this flag.
+  // EXPERIMENTAL: Not production-ready. Do not enable for production tables
+  // without consulting the Nimble team (oncall: dwios).
   bool enableChunkIndex{false};
 
   // Skip writing chunk index for a stripe group if the average number
@@ -65,16 +67,22 @@ struct VeloxWriterOptions {
 
   /// If set, the cluster index on the specified columns will be built during
   /// writing. The index stores the per-chunk min and max key for each stripe.
+  // EXPERIMENTAL: Cluster index is not production-ready. Do not enable for
+  // production tables without consulting the Nimble team (oncall: dwios).
   std::optional<ClusterIndexConfig> clusterIndexConfig;
 
   /// Hash index configurations. Each config builds an independent hash-based
   /// point lookup index on the specified columns. Unlike cluster index, hash
   /// index does not require sorted data.
+  // EXPERIMENTAL: Hash index is not production-ready. Do not enable for
+  // production tables without consulting the Nimble team (oncall: dwios).
   std::vector<HashIndexConfig> hashIndexConfigs;
 
   /// Sorted index configurations. Each config builds an independent sorted
   /// key stream index supporting both point lookups and range scans on
   /// unsorted data.
+  // EXPERIMENTAL: Sorted index is not production-ready. Do not enable for
+  // production tables without consulting the Nimble team (oncall: dwios).
   std::vector<SortedIndexConfig> sortedIndexConfigs;
 
   // Columns that should be encoded as flat maps. Maps column name to a set
@@ -131,6 +139,9 @@ struct VeloxWriterOptions {
   CompressionOptions compressionOptions;
 
   // Block size for BlockBitPacking encoding.
+  // EXPERIMENTAL: BlockBitPacking encoding is not production-ready. Do not
+  // enable for production tables without consulting the Nimble team
+  // (oncall: dwios).
   uint16_t blockBitPackingBlockSize = kBlockBitPackingBlockSize;
 
   /// FSST is kept only when its final encoded size is at most this fraction of


### PR DESCRIPTION
Summary:
CONTEXT: Several Nimble features are not production-ready but are discoverable by users and AI tooling, leading to accidental enablement on production tables.

WHAT: Adds `EXPERIMENTAL: Not production-ready` annotations at every entry point where these features can be discovered or enabled.

**Non-default encodings** — annotated in the `EncodingType` enum (`Types.h`) and in the `possibleEncodings()` candidate list (`EncodingSelectionPolicy.cpp`):
- `PFOR` (Patched Frame-of-Reference)
- `SimdForBitpack` (SIMD Frame-of-Reference bitpacking)
- `SubIntSplit` (bit-range sub-stream decomposition)
- `BlockBitPacking` (per-chunk variable bit-width packing) — also annotated in `NimbleConfig.h/cpp` config entry and `VeloxWriterOptions.h` writer option
- `Fsst` (Fast Static Symbol Table string compression)

**Index features** — annotated in config definitions (`NimbleConfig.h/cpp`), writer options (`VeloxWriterOptions.h`), index config structs (`IndexConfig.h`), serde parameter wiring (`NimbleWriterOptionBuilder.cpp`), and Java Hive table properties (`HiveTableProperties.java`):
- Cluster index (`nimble.index.columns`, `indexed_by` DDL property)
- Chunk index (`nimble.chunk.index.enabled`, `chunk_index_enabled` DDL property)
- Hash index (`HashIndexConfig`)
- Sorted index (`SortedIndexConfig`)

All annotations direct users to consult the Nimble team (oncall: dwios) before enabling.

Reviewed By: xiaoxmeng

Differential Revision: D110344784


