### PR TITLE
perf: Recycle decode metadata buffers (#929)

### DIFF
--- a/dwio/nimble/encodings/BlockBitPackingEncoding.h
+++ b/dwio/nimble/encodings/BlockBitPackingEncoding.h
@@ -60,6 +60,8 @@ class BlockBitPackingEncoding final
   ~BlockBitPackingEncoding() override {
     this->releaseBuffer(uncompressedData_);
     this->releaseVectorBuffer(buffer_);
+    this->releaseVectorBuffer(blockOffsets_);
+    this->releaseVectorBuffer(blocksMetadata_);
   }
 
   void reset() final;
@@ -271,10 +273,10 @@ BlockBitPackingEncoding<T>::BlockBitPackingEncoding(
     const std::function<void*(uint32_t)>& stringBufferFactory,
     const Encoding::Options& options)
     : TypedEncoding<T, physicalType>{pool, data, options},
-      blocksMetadata_{&pool},
-      blockOffsets_{&pool},
+      blocksMetadata_{this->template getVectorBuffer<BlockMeta>()},
+      blockOffsets_{this->template getVectorBuffer<uint32_t>()},
       packedData_{nullptr},
-      buffer_(this->template getVectorBuffer<physicalType>()) {
+      buffer_{&pool} {
   auto pos = data.data() + this->dataOffset();
   auto compressionType = static_cast<CompressionType>(encoding::readChar(pos));
   blockSize_ = encoding::read<const uint16_t>(pos);
@@ -290,9 +292,9 @@ BlockBitPackingEncoding<T>::BlockBitPackingEncoding(
   // offsets) as self-describing nested encodings, letting Nimble's recursive
   // encoding selection pick the best encoding for each metadata stream. The
   // packed block data stays raw.
-  Vector<physicalType> baselines{&pool};
+  auto baselines = this->template getVectorBuffer<physicalType>();
   baselines.resize(numBlocks_);
-  Vector<uint8_t> bitWidths{&pool};
+  auto bitWidths = this->template getVectorBuffer<uint8_t>();
   bitWidths.resize(numBlocks_);
 
   // Each metadata stream: read its 4-byte size, decode the nested sub-encoding
@@ -315,6 +317,8 @@ BlockBitPackingEncoding<T>::BlockBitPackingEncoding(
     blocksMetadata_[i].bitWidth =
         blocksMetadata_[i].skipEncoding ? 0 : bitWidths[i];
   }
+  this->releaseVectorBuffer(bitWidths);
+  this->releaseVectorBuffer(baselines);
 
   if (compressionType != CompressionType::Uncompressed) {
     uncompressedData_ = Compression::uncompress(
@@ -590,6 +594,9 @@ void BlockBitPackingEncoding<T>::bulkScan(
         currentAbsRow += toDecode;
       }
     } else if constexpr (kIsUpcast) {
+      if (buffer_.capacity() == 0) {
+        buffer_ = this->template getVectorBuffer<physicalType>();
+      }
       buffer_.resize(numSelected);
       auto* rawBuf = buffer_.data();
       uint32_t decodedRows = 0;

--- a/dwio/nimble/encodings/PFOREncoding.h
+++ b/dwio/nimble/encodings/PFOREncoding.h
@@ -81,6 +81,11 @@ class PFOREncoding final
       const std::function<void*(uint32_t)>& stringBufferFactory,
       const Encoding::Options& options = {});
 
+  ~PFOREncoding() override {
+    this->releaseVectorBuffer(exceptionValues_);
+    this->releaseVectorBuffer(exceptionPositions_);
+  }
+
   void reset() final;
   void skip(uint32_t rowCount) final;
   void materialize(uint32_t rowCount, void* buffer) final;
@@ -206,8 +211,8 @@ PFOREncoding<T>::PFOREncoding(
     const std::function<void*(uint32_t)>& stringBufferFactory,
     const Encoding::Options& options)
     : TypedEncoding<T, physicalType>{pool, data, options},
-      exceptionPositions_{this->pool_},
-      exceptionValues_{this->pool_} {
+      exceptionPositions_{this->template getVectorBuffer<uint32_t>()},
+      exceptionValues_{this->template getVectorBuffer<physicalType>()} {
   if constexpr (!isIntegralType<physicalType>()) {
     NIMBLE_INCOMPATIBLE_ENCODING(
         "Pfor encoding only supports integral data types.");

--- a/dwio/nimble/encodings/tests/BlockBitPackingEncodingTest.cpp
+++ b/dwio/nimble/encodings/tests/BlockBitPackingEncodingTest.cpp
@@ -22,6 +22,7 @@
 #include "dwio/nimble/encodings/SparseBoolEncoding.h"
 #include "dwio/nimble/encodings/tests/EncodingLayoutTestHelper.h"
 #include "dwio/nimble/encodings/tests/TestUtils.h"
+#include "velox/buffer/BufferPool.h"
 #include "velox/common/base/BitUtil.h"
 #include "velox/dwio/common/Lemire/BitPacking/bitpackinghelpers.h"
 
@@ -199,6 +200,44 @@ TEST_F(BlockBitPackingEncodingTest, resetAndReread) {
   std::vector<uint32_t> output2(count);
   encoding->materialize(count, output2.data());
   ASSERT_EQ(values, output2);
+}
+
+TEST_F(BlockBitPackingEncodingTest, bufferPoolReusesMetadataBuffers) {
+  using Enc = nimble::BlockBitPackingEncoding<uint32_t>;
+  constexpr uint32_t blockSize = Enc::kMaxBlockSize;
+  std::vector<uint32_t> input(blockSize * 8);
+  for (uint32_t i = 0; i < input.size(); ++i) {
+    input[i] = (i / blockSize) * 1'000 + (i % 127);
+  }
+
+  auto values = toVector(input);
+  const auto encoded = nimble::test::Encoder<Enc>::encode(*buffer_, values);
+  const std::vector<char> encodedStorage{encoded.begin(), encoded.end()};
+
+  auto decodePool =
+      facebook::velox::memory::deprecatedAddDefaultLeafMemoryPool();
+  facebook::velox::BufferPool bufferPool{
+      facebook::velox::BufferPool::kDefaultCapacity};
+  const nimble::Encoding::Options options{.bufferPool = &bufferPool};
+  std::function<void*(uint32_t)> stringBufferFactory;
+
+  auto decodeAndVerify = [&]() {
+    Enc encoding{
+        *decodePool,
+        {encodedStorage.data(), encodedStorage.size()},
+        stringBufferFactory,
+        options};
+    std::vector<uint32_t> output(input.size());
+    encoding.materialize(static_cast<uint32_t>(input.size()), output.data());
+    EXPECT_EQ(input, output);
+  };
+
+  decodeAndVerify();
+  const auto numAllocsAfterFirstDecode = decodePool->stats().numAllocs;
+  EXPECT_GT(bufferPool.size(), 0);
+
+  decodeAndVerify();
+  EXPECT_EQ(decodePool->stats().numAllocs, numAllocsAfterFirstDecode);
 }
 
 TEST_F(BlockBitPackingEncodingTest, sizeVsFixedBitWidth) {

--- a/dwio/nimble/encodings/tests/PFOREncodingTest.cpp
+++ b/dwio/nimble/encodings/tests/PFOREncodingTest.cpp
@@ -17,6 +17,7 @@
 
 #include <fmt/core.h>
 #include <gtest/gtest.h>
+#include <limits>
 #include <random>
 
 #include "dwio/nimble/common/Buffer.h"
@@ -25,6 +26,8 @@
 #include "dwio/nimble/encodings/common/EncodingLayout.h"
 #include "dwio/nimble/encodings/selection/EncodingSelection.h"
 #include "dwio/nimble/encodings/selection/EncodingSelectionPolicy.h"
+#include "dwio/nimble/encodings/tests/TestUtils.h"
+#include "velox/buffer/BufferPool.h"
 #include "velox/common/memory/Memory.h"
 
 using namespace ::facebook;
@@ -136,6 +139,49 @@ TYPED_TEST(PFOREncodingTest, sparseOutliers) {
     }
     this->roundTripAndExpect(values);
   }
+}
+
+TEST(PFOREncodingBufferPoolTest, reusesExceptionBuffers) {
+  using Value = uint64_t;
+  using EncodingType = PFOREncoding<Value>;
+
+  auto encodePool = velox::memory::deprecatedAddDefaultLeafMemoryPool();
+  Buffer encodeBuffer{*encodePool};
+  std::vector<Value> input;
+  input.reserve(1'000);
+  for (uint32_t i = 0; i < 1'000; ++i) {
+    input.push_back(
+        i % 10 == 0 ? std::numeric_limits<Value>::max() - i
+                    : static_cast<Value>(i % 64));
+  }
+
+  Vector<Value> values{encodePool.get()};
+  values.insert(values.end(), input.data(), input.data() + input.size());
+  const auto encoded = Encoder<EncodingType>::encode(encodeBuffer, values);
+  const std::vector<char> encodedStorage{encoded.begin(), encoded.end()};
+
+  auto decodePool = velox::memory::deprecatedAddDefaultLeafMemoryPool();
+  velox::BufferPool bufferPool{velox::BufferPool::kDefaultCapacity};
+  const Encoding::Options options{.bufferPool = &bufferPool};
+  std::function<void*(uint32_t)> stringBufferFactory;
+
+  auto decodeAndVerify = [&]() {
+    EncodingType encoding{
+        *decodePool,
+        {encodedStorage.data(), encodedStorage.size()},
+        stringBufferFactory,
+        options};
+    std::vector<Value> output(input.size());
+    encoding.materialize(static_cast<uint32_t>(input.size()), output.data());
+    EXPECT_EQ(input, output);
+  };
+
+  decodeAndVerify();
+  const auto numAllocsAfterFirstDecode = decodePool->stats().numAllocs;
+  EXPECT_GT(bufferPool.size(), 0);
+
+  decodeAndVerify();
+  EXPECT_EQ(decodePool->stats().numAllocs, numAllocsAfterFirstDecode);
 }
 
 TYPED_TEST(PFOREncodingTest, residualsAtBitWidthBoundary) {


### PR DESCRIPTION
Summary:

PFOR and BlockBitPacking decode allocate metadata vectors while constructing each segment. Recycle those vectors through the existing `Encoding` buffer pool so batched decode can reuse them across segments instead of returning them to the MemoryPool each time.

BlockBitPacking now acquires its materialization scratch buffer lazily so normal `materialize()` decode does not consume a pooled metadata buffer that the next decode can reuse.

Reviewed By: duxiao1212, kewang1024

Differential Revision: D110345427


