### PR TITLE
feat: Per-SchemaNode attributes + field-id for Iceberg V3 (OSS nimble)

### DIFF
--- a/dwio/nimble/velox/FieldWriter.cpp
+++ b/dwio/nimble/velox/FieldWriter.cpp
@@ -2748,7 +2748,7 @@ size_t DecodingContextPool::size() const {
 std::unique_ptr<FieldWriter> FieldWriter::create(
     FieldWriterContext& context,
     const std::shared_ptr<const velox::dwio::common::TypeWithId>& type,
-    std::function<void(const TypeBuilder&)> typeAddedHandler) {
+    std::function<void(TypeBuilder&, uint32_t)> typeAddedHandler) {
   context.setTypeAddedHandler(std::move(typeAddedHandler));
   return create(context, type);
 }
@@ -2845,7 +2845,7 @@ std::unique_ptr<FieldWriter> FieldWriter::create(
     default:
       NIMBLE_UNSUPPORTED("Unsupported kind: {}.", type->type()->kind());
   }
-  context.handleAddedType(*field->typeBuilder());
+  context.handleAddedType(*field->typeBuilder(), type->id());
   return field;
 }
 

--- a/dwio/nimble/velox/FieldWriter.h
+++ b/dwio/nimble/velox/FieldWriter.h
@@ -323,12 +323,12 @@ class FieldWriterContext {
     flatmapFieldAddedEventHandler_ = std::move(handler);
   }
 
-  inline void handleAddedType(const TypeBuilder& typeBuilder) const {
-    typeAddedHandler_(typeBuilder);
+  inline void handleAddedType(TypeBuilder& typeBuilder, uint32_t nodeId) const {
+    typeAddedHandler_(typeBuilder, nodeId);
   }
 
   inline void setTypeAddedHandler(
-      std::function<void(const TypeBuilder&)>&& handler) {
+      std::function<void(TypeBuilder&, uint32_t)>&& handler) {
     typeAddedHandler_ = std::move(handler);
   }
 
@@ -499,8 +499,8 @@ class FieldWriterContext {
   std::function<void(const TypeBuilder&, std::string_view, const TypeBuilder&)>
       flatmapFieldAddedEventHandler_;
 
-  std::function<void(const TypeBuilder&)> typeAddedHandler_{
-      [](const TypeBuilder&) {}};
+  std::function<void(TypeBuilder&, uint32_t)> typeAddedHandler_{
+      [](TypeBuilder&, uint32_t) {}};
 
  private:
   void finalizeStatsCollector(
@@ -662,7 +662,7 @@ class FieldWriter {
   static std::unique_ptr<FieldWriter> create(
       FieldWriterContext& context,
       const std::shared_ptr<const velox::dwio::common::TypeWithId>& type,
-      std::function<void(const TypeBuilder&)> typeAddedHandler);
+      std::function<void(TypeBuilder&, uint32_t)> typeAddedHandler);
 
  protected:
   // Computes the number of parallel write tasks based on max parallelism and

--- a/dwio/nimble/velox/SchemaBuilder.cpp
+++ b/dwio/nimble/velox/SchemaBuilder.cpp
@@ -482,6 +482,11 @@ void SchemaBuilder::addNode(
     std::vector<SchemaNode>& nodes,
     const TypeBuilder& type,
     std::optional<std::string> name) const {
+  // Attributes are owned by the main TypeBuilder and are emitted onto the
+  // first (primary) SchemaNode for that TypeBuilder. Synthetic child stream
+  // descriptor nodes (e.g. nanos for TimestampMicroNano, offsets for
+  // ArrayWithOffsets, lengths for SlidingWindowMap, in-map nodes for
+  // FlatMap) do not carry attributes.
   switch (type.kind()) {
     case Kind::Scalar: {
       const auto& scalar = type.asScalar();
@@ -489,7 +494,9 @@ void SchemaBuilder::addNode(
           type.kind(),
           scalar.scalarDescriptor().offset(),
           scalar.scalarDescriptor().scalarKind(),
-          std::move(name));
+          std::move(name),
+          /*childrenCount*/ 0,
+          type.attributes());
       break;
     }
 
@@ -499,7 +506,9 @@ void SchemaBuilder::addNode(
           type.kind(),
           timestampMicroNano.microsDescriptor().offset(),
           ScalarKind::Int64,
-          std::move(name));
+          std::move(name),
+          /*childrenCount*/ 0,
+          type.attributes());
       nodes.emplace_back(
           Kind::Scalar,
           timestampMicroNano.nanosDescriptor().offset(),
@@ -513,7 +522,9 @@ void SchemaBuilder::addNode(
           type.kind(),
           array.lengthsDescriptor().offset(),
           ScalarKind::UInt32,
-          std::move(name));
+          std::move(name),
+          /*childrenCount*/ 0,
+          type.attributes());
       addNode(nodes, array.elements());
       break;
     }
@@ -523,7 +534,9 @@ void SchemaBuilder::addNode(
           type.kind(),
           array.lengthsDescriptor().offset(),
           ScalarKind::UInt32,
-          std::move(name));
+          std::move(name),
+          /*childrenCount*/ 0,
+          type.attributes());
       nodes.emplace_back(
           Kind::Scalar,
           array.offsetsDescriptor().offset(),
@@ -539,7 +552,8 @@ void SchemaBuilder::addNode(
           row.nullsDescriptor().offset(),
           ScalarKind::Bool,
           std::move(name),
-          row.childrenCount());
+          row.childrenCount(),
+          type.attributes());
       for (auto i = 0; i < row.childrenCount(); ++i) {
         addNode(nodes, row.childAt(i), row.nameAt(i));
       }
@@ -551,7 +565,9 @@ void SchemaBuilder::addNode(
           type.kind(),
           map.lengthsDescriptor().offset(),
           ScalarKind::UInt32,
-          std::move(name));
+          std::move(name),
+          /*childrenCount*/ 0,
+          type.attributes());
       addNode(nodes, map.keys());
       addNode(nodes, map.values());
       break;
@@ -562,7 +578,9 @@ void SchemaBuilder::addNode(
           type.kind(),
           map.offsetsDescriptor().offset(),
           ScalarKind::UInt32,
-          std::move(name));
+          std::move(name),
+          /*childrenCount*/ 0,
+          type.attributes());
       nodes.emplace_back(
           Kind::Scalar,
           map.lengthsDescriptor().offset(),
@@ -581,7 +599,8 @@ void SchemaBuilder::addNode(
           map.nullsDescriptor().offset(),
           map.keyScalarKind(),
           std::move(name),
-          childrenSize);
+          childrenSize,
+          type.attributes());
       NIMBLE_CHECK_EQ(
           map.inMapDescriptors_.size(),
           childrenSize,

--- a/dwio/nimble/velox/SchemaBuilder.h
+++ b/dwio/nimble/velox/SchemaBuilder.h
@@ -118,6 +118,20 @@ class TypeBuilder {
 
   Kind kind() const;
 
+  // Sets the per-type string-keyed attribute bag. Insertion order is
+  // preserved end-to-end through schema serialization. Overwrites any
+  // previously set attributes. Intended for writer-side callers that annotate
+  // nodes with format-specific metadata.
+  void setAttributes(
+      std::vector<std::pair<std::string, std::string>> attributes) {
+    attributes_ = std::move(attributes);
+  }
+
+  // Returns the per-type string-keyed attribute bag. Empty by default.
+  const std::vector<std::pair<std::string, std::string>>& attributes() const {
+    return attributes_;
+  }
+
   ScalarTypeBuilder& asScalar();
   TimestampMicroNanoTypeBuilder& asTimestampMicroNano();
   ArrayTypeBuilder& asArray();
@@ -144,6 +158,7 @@ class TypeBuilder {
  private:
   Kind kind_;
   mutable std::unique_ptr<TypeBuilderContext> context_;
+  std::vector<std::pair<std::string, std::string>> attributes_;
 
   friend class SchemaBuilder;
 };

--- a/dwio/nimble/velox/SchemaReader.cpp
+++ b/dwio/nimble/velox/SchemaReader.cpp
@@ -47,7 +47,10 @@ struct NamedType {
 
 } // namespace
 
-Type::Type(Kind kind) : kind_{kind} {}
+Type::Type(
+    Kind kind,
+    std::vector<std::pair<std::string, std::string>> attributes)
+    : kind_{kind}, attributes_{std::move(attributes)} {}
 
 Kind Type::kind() const {
   return kind_;
@@ -145,8 +148,11 @@ const SlidingWindowMapType& Type::asSlidingWindowMap() const {
   return dynamic_cast<const SlidingWindowMapType&>(*this);
 }
 
-ScalarType::ScalarType(StreamDescriptor scalarDescriptor)
-    : Type(Kind::Scalar), scalarDescriptor_{std::move(scalarDescriptor)} {}
+ScalarType::ScalarType(
+    StreamDescriptor scalarDescriptor,
+    std::vector<std::pair<std::string, std::string>> attributes)
+    : Type(Kind::Scalar, std::move(attributes)),
+      scalarDescriptor_{std::move(scalarDescriptor)} {}
 
 const StreamDescriptor& ScalarType::scalarDescriptor() const {
   return scalarDescriptor_;
@@ -154,8 +160,9 @@ const StreamDescriptor& ScalarType::scalarDescriptor() const {
 
 TimestampMicroNanoType::TimestampMicroNanoType(
     StreamDescriptor microsDescriptor,
-    StreamDescriptor nanosDescriptor)
-    : Type(Kind::TimestampMicroNano),
+    StreamDescriptor nanosDescriptor,
+    std::vector<std::pair<std::string, std::string>> attributes)
+    : Type(Kind::TimestampMicroNano, std::move(attributes)),
       microsDescriptor_{std::move(microsDescriptor)},
       nanosDescriptor_{std::move(nanosDescriptor)} {}
 
@@ -169,8 +176,9 @@ const StreamDescriptor& TimestampMicroNanoType::nanosDescriptor() const {
 
 ArrayType::ArrayType(
     StreamDescriptor lengthsDescriptor,
-    std::shared_ptr<const Type> elements)
-    : Type(Kind::Array),
+    std::shared_ptr<const Type> elements,
+    std::vector<std::pair<std::string, std::string>> attributes)
+    : Type(Kind::Array, std::move(attributes)),
       lengthsDescriptor_{std::move(lengthsDescriptor)},
       elements_{std::move(elements)} {}
 
@@ -185,8 +193,9 @@ const std::shared_ptr<const Type>& ArrayType::elements() const {
 MapType::MapType(
     StreamDescriptor lengthsDescriptor,
     std::shared_ptr<const Type> keys,
-    std::shared_ptr<const Type> values)
-    : Type(Kind::Map),
+    std::shared_ptr<const Type> values,
+    std::vector<std::pair<std::string, std::string>> attributes)
+    : Type(Kind::Map, std::move(attributes)),
       lengthsDescriptor_{std::move(lengthsDescriptor)},
       keys_{std::move(keys)},
       values_{std::move(values)} {}
@@ -207,8 +216,9 @@ SlidingWindowMapType::SlidingWindowMapType(
     StreamDescriptor offsetsDescriptor,
     StreamDescriptor lengthsDescriptor,
     std::shared_ptr<const Type> keys,
-    std::shared_ptr<const Type> values)
-    : Type(Kind::SlidingWindowMap),
+    std::shared_ptr<const Type> values,
+    std::vector<std::pair<std::string, std::string>> attributes)
+    : Type(Kind::SlidingWindowMap, std::move(attributes)),
       offsetsDescriptor_{std::move(offsetsDescriptor)},
       lengthsDescriptor_{std::move(lengthsDescriptor)},
 
@@ -234,8 +244,9 @@ const std::shared_ptr<const Type>& SlidingWindowMapType::values() const {
 RowType::RowType(
     StreamDescriptor nullsDescriptor,
     std::vector<std::string> names,
-    std::vector<std::shared_ptr<const Type>> children)
-    : Type(Kind::Row),
+    std::vector<std::shared_ptr<const Type>> children,
+    std::vector<std::pair<std::string, std::string>> attributes)
+    : Type(Kind::Row, std::move(attributes)),
       nullsDescriptor_{std::move(nullsDescriptor)},
       names_{std::move(names)},
       children_{std::move(children)} {
@@ -278,8 +289,9 @@ FlatMapType::FlatMapType(
     ScalarKind keyScalarKind,
     std::vector<std::string> names,
     std::vector<std::unique_ptr<StreamDescriptor>> inMapDescriptors,
-    std::vector<std::shared_ptr<const Type>> children)
-    : Type(Kind::FlatMap),
+    std::vector<std::shared_ptr<const Type>> children,
+    std::vector<std::pair<std::string, std::string>> attributes)
+    : Type(Kind::FlatMap, std::move(attributes)),
       nullsDescriptor_{nullsDescriptor},
       keyScalarKind_{keyScalarKind},
       names_{std::move(names)},
@@ -332,8 +344,9 @@ std::optional<size_t> FlatMapType::findChild(std::string_view name) const {
 ArrayWithOffsetsType::ArrayWithOffsetsType(
     StreamDescriptor offsetsDescriptor,
     StreamDescriptor lengthsDescriptor,
-    std::shared_ptr<const Type> elements)
-    : Type(Kind::ArrayWithOffsets),
+    std::shared_ptr<const Type> elements,
+    std::vector<std::pair<std::string, std::string>> attributes)
+    : Type(Kind::ArrayWithOffsets, std::move(attributes)),
       offsetsDescriptor_{std::move(offsetsDescriptor)},
       lengthsDescriptor_{std::move(lengthsDescriptor)},
       elements_{std::move(elements)} {}
@@ -355,11 +368,18 @@ NamedType getType(offset_size& index, const std::vector<SchemaNode>& nodes) {
   const auto& node = nodes[index++];
   auto offset = node.offset();
   auto kind = node.kind();
+  // Attributes are sourced from the primary SchemaNode of each TypeBuilder
+  // (the first node emitted in addNode). Synthetic intermediate nodes such
+  // as the nanos descriptor of TimestampMicroNano, the offsets descriptor
+  // of ArrayWithOffsets, the lengths descriptor of SlidingWindowMap, and
+  // the in-map descriptors of FlatMap do not carry attributes.
+  auto attributes = node.attributes();
   switch (kind) {
     case Kind::Scalar: {
       return {
           .type = std::make_shared<ScalarType>(
-              StreamDescriptor{offset, node.scalarKind()}),
+              StreamDescriptor{offset, node.scalarKind()},
+              std::move(attributes)),
           .name = node.name()};
     }
     case Kind::TimestampMicroNano: {
@@ -371,7 +391,8 @@ NamedType getType(offset_size& index, const std::vector<SchemaNode>& nodes) {
       return {
           .type = std::make_shared<TimestampMicroNanoType>(
               StreamDescriptor{offset, ScalarKind::Int64},
-              StreamDescriptor{nanosNode.offset(), nanosNode.scalarKind()}),
+              StreamDescriptor{nanosNode.offset(), nanosNode.scalarKind()},
+              std::move(attributes)),
           .name = node.name()};
     }
     case Kind::Array: {
@@ -379,7 +400,8 @@ NamedType getType(offset_size& index, const std::vector<SchemaNode>& nodes) {
       return {
           .type = std::make_shared<ArrayType>(
               StreamDescriptor{offset, ScalarKind::UInt32},
-              std::move(elements)),
+              std::move(elements),
+              std::move(attributes)),
           .name = node.name()};
     }
     case Kind::Map: {
@@ -389,7 +411,8 @@ NamedType getType(offset_size& index, const std::vector<SchemaNode>& nodes) {
           .type = std::make_shared<MapType>(
               StreamDescriptor{offset, ScalarKind::UInt32},
               std::move(keys),
-              std::move(values)),
+              std::move(values),
+              std::move(attributes)),
           .name = node.name()};
     }
     case Kind::SlidingWindowMap: {
@@ -405,7 +428,8 @@ NamedType getType(offset_size& index, const std::vector<SchemaNode>& nodes) {
               StreamDescriptor{offset, ScalarKind::UInt32},
               StreamDescriptor{lengthsNode.offset(), lengthsNode.scalarKind()},
               std::move(keys),
-              std::move(values)),
+              std::move(values),
+              std::move(attributes)),
           .name = node.name()};
     }
     case Kind::Row: {
@@ -422,7 +446,8 @@ NamedType getType(offset_size& index, const std::vector<SchemaNode>& nodes) {
           .type = std::make_shared<RowType>(
               StreamDescriptor{offset, ScalarKind::Bool},
               std::move(names),
-              std::move(children)),
+              std::move(children),
+              std::move(attributes)),
           .name = node.name()};
     }
     case Kind::FlatMap: {
@@ -454,7 +479,8 @@ NamedType getType(offset_size& index, const std::vector<SchemaNode>& nodes) {
               node.scalarKind(),
               std::move(names),
               std::move(inMapDescriptors),
-              std::move(children)),
+              std::move(children),
+              std::move(attributes)),
           .name = node.name()};
     }
     case Kind::ArrayWithOffsets: {
@@ -468,7 +494,8 @@ NamedType getType(offset_size& index, const std::vector<SchemaNode>& nodes) {
           .type = std::make_shared<ArrayWithOffsetsType>(
               StreamDescriptor{offsetsNode.offset(), offsetsNode.scalarKind()},
               StreamDescriptor{offset, ScalarKind::UInt32},
-              std::move(elements)),
+              std::move(elements),
+              std::move(attributes)),
           .name = node.name()};
     }
 

--- a/dwio/nimble/velox/SchemaReader.h
+++ b/dwio/nimble/velox/SchemaReader.h
@@ -69,8 +69,18 @@ class Type {
   const FlatMapType& asFlatMap() const;
   const SlidingWindowMapType& asSlidingWindowMap() const;
 
+  /// Returns the per-type string-keyed attribute bag. Insertion order
+  /// matches the writer-side `TypeBuilder::attributes()` it was sourced
+  /// from. Empty when the underlying SchemaNode had no attributes (covers
+  /// both legacy files and present-but-empty lists).
+  const std::vector<std::pair<std::string, std::string>>& attributes() const {
+    return attributes_;
+  }
+
  protected:
-  explicit Type(Kind kind);
+  explicit Type(
+      Kind kind,
+      std::vector<std::pair<std::string, std::string>> attributes = {});
 
   virtual ~Type() = default;
 
@@ -79,11 +89,14 @@ class Type {
   Type(Type&&) = delete;
 
   Kind kind_;
+  std::vector<std::pair<std::string, std::string>> attributes_;
 };
 
 class ScalarType : public Type {
  public:
-  explicit ScalarType(StreamDescriptor scalarDescriptor);
+  explicit ScalarType(
+      StreamDescriptor scalarDescriptor,
+      std::vector<std::pair<std::string, std::string>> attributes = {});
 
   const StreamDescriptor& scalarDescriptor() const;
 
@@ -95,7 +108,8 @@ class TimestampMicroNanoType : public Type {
  public:
   explicit TimestampMicroNanoType(
       StreamDescriptor microsDescriptor,
-      StreamDescriptor nanosDescriptor);
+      StreamDescriptor nanosDescriptor,
+      std::vector<std::pair<std::string, std::string>> attributes = {});
 
   const StreamDescriptor& microsDescriptor() const;
   const StreamDescriptor& nanosDescriptor() const;
@@ -109,7 +123,8 @@ class ArrayType : public Type {
  public:
   ArrayType(
       StreamDescriptor lengthsDescriptor,
-      std::shared_ptr<const Type> elements);
+      std::shared_ptr<const Type> elements,
+      std::vector<std::pair<std::string, std::string>> attributes = {});
 
   const StreamDescriptor& lengthsDescriptor() const;
   const std::shared_ptr<const Type>& elements() const;
@@ -124,7 +139,8 @@ class MapType : public Type {
   MapType(
       StreamDescriptor lengthsDescriptor,
       std::shared_ptr<const Type> keys,
-      std::shared_ptr<const Type> values);
+      std::shared_ptr<const Type> values,
+      std::vector<std::pair<std::string, std::string>> attributes = {});
 
   const StreamDescriptor& lengthsDescriptor() const;
   const std::shared_ptr<const Type>& keys() const;
@@ -142,7 +158,8 @@ class SlidingWindowMapType : public virtual Type {
       StreamDescriptor offsetsDescriptor,
       StreamDescriptor lengthsDescriptor,
       std::shared_ptr<const Type> keys,
-      std::shared_ptr<const Type> values);
+      std::shared_ptr<const Type> values,
+      std::vector<std::pair<std::string, std::string>> attributes = {});
 
   const StreamDescriptor& offsetsDescriptor() const;
   const StreamDescriptor& lengthsDescriptor() const;
@@ -161,7 +178,8 @@ class RowType : public Type {
   RowType(
       StreamDescriptor nullsDescriptor,
       std::vector<std::string> names,
-      std::vector<std::shared_ptr<const Type>> children);
+      std::vector<std::shared_ptr<const Type>> children,
+      std::vector<std::pair<std::string, std::string>> attributes = {});
 
   const StreamDescriptor& nullsDescriptor() const;
   size_t childrenCount() const;
@@ -193,7 +211,8 @@ class FlatMapType : public Type {
       ScalarKind keyScalarKind,
       std::vector<std::string> names,
       std::vector<std::unique_ptr<StreamDescriptor>> inMapDescriptors,
-      std::vector<std::shared_ptr<const Type>> children);
+      std::vector<std::shared_ptr<const Type>> children,
+      std::vector<std::pair<std::string, std::string>> attributes = {});
 
   const StreamDescriptor& nullsDescriptor() const;
   const StreamDescriptor& inMapDescriptorAt(size_t index) const;
@@ -219,7 +238,8 @@ class ArrayWithOffsetsType : public Type {
   ArrayWithOffsetsType(
       StreamDescriptor offsetsDescriptor,
       StreamDescriptor lengthsDescriptor,
-      std::shared_ptr<const Type> elements);
+      std::shared_ptr<const Type> elements,
+      std::vector<std::pair<std::string, std::string>> attributes = {});
 
   const StreamDescriptor& offsetsDescriptor() const;
   const StreamDescriptor& lengthsDescriptor() const;

--- a/dwio/nimble/velox/SchemaSerialization.cpp
+++ b/dwio/nimble/velox/SchemaSerialization.cpp
@@ -194,6 +194,26 @@ std::string_view SchemaSerializer::serialize(
       builder_.CreateVector<flatbuffers::Offset<serialization::SchemaNode>>(
           nodes.size(), [this, &nodes](size_t i) {
             const auto& node = nodes[i];
+            // Build the attribute vector for this node. Empty attributes
+            // skip the vtable slot so wire output stays byte-identical to
+            // pre-attributes serialization for callers that never set
+            // attributes.
+            flatbuffers::Offset<flatbuffers::Vector<
+                flatbuffers::Offset<serialization::StringPair>>>
+                attributes = 0;
+            if (!node.attributes().empty()) {
+              std::vector<flatbuffers::Offset<serialization::StringPair>>
+                  attrOffsets;
+              attrOffsets.reserve(node.attributes().size());
+              for (const auto& [key, value] : node.attributes()) {
+                attrOffsets.push_back(
+                    serialization::CreateStringPair(
+                        builder_,
+                        builder_.CreateString(key),
+                        builder_.CreateString(value)));
+              }
+              attributes = builder_.CreateVector(attrOffsets);
+            }
             return serialization::CreateSchemaNode(
                 builder_,
                 nodeToSerializationKind(&node),
@@ -201,7 +221,8 @@ std::string_view SchemaSerializer::serialize(
                 node.name().has_value()
                     ? builder_.CreateString(node.name().value())
                     : 0,
-                node.offset());
+                node.offset(),
+                attributes);
           });
 
   builder_.Finish(serialization::CreateSchema(builder_, schema));
@@ -220,13 +241,26 @@ std::shared_ptr<const Type> SchemaDeserializer::deserialize(
   for (auto i = 0; i < nodeCount; ++i) {
     auto* node = schema->nodes()->Get(i);
     auto kind = serializationNodeToKind(node);
+    // Older NIMBLE files predate the `attributes` flatbuffer field and
+    // surface as nullptr here. Treat that case the same as a present-but-
+    // empty list so the deserialized SchemaNode always exposes a vector.
+    std::vector<std::pair<std::string, std::string>> attributes;
+    if (node->attributes() != nullptr) {
+      attributes.reserve(node->attributes()->size());
+      for (const auto* pair : *node->attributes()) {
+        attributes.emplace_back(
+            pair->key() ? pair->key()->str() : std::string{},
+            pair->value() ? pair->value()->str() : std::string{});
+      }
+    }
     nodes.emplace_back(
         kind.first,
         node->offset(),
         kind.second,
         node->name() ? std::optional<std::string>(node->name()->str())
                      : std::nullopt,
-        node->children());
+        node->children(),
+        std::move(attributes));
   }
 
   return SchemaReader::getSchema(nodes);

--- a/dwio/nimble/velox/SchemaTypes.h
+++ b/dwio/nimble/velox/SchemaTypes.h
@@ -19,6 +19,9 @@
 #include <cstdint>
 #include <optional>
 #include <ostream>
+#include <string>
+#include <utility>
+#include <vector>
 
 namespace facebook::nimble {
 
@@ -110,12 +113,14 @@ class SchemaNode {
       offset_size offset,
       ScalarKind scalarKind,
       std::optional<std::string> name = std::nullopt,
-      size_t childrenCount = 0)
+      size_t childrenCount = 0,
+      std::vector<std::pair<std::string, std::string>> attributes = {})
       : kind_{kind},
         offset_{offset},
         name_{std::move(name)},
         scalarKind_{scalarKind},
-        childrenCount_{childrenCount} {}
+        childrenCount_{childrenCount},
+        attributes_{std::move(attributes)} {}
 
   Kind kind() const {
     return kind_;
@@ -137,12 +142,20 @@ class SchemaNode {
     return scalarKind_;
   }
 
+  // Returns the per-node string-keyed attribute bag. Preserves insertion
+  // order so that attributes can round-trip through the flatbuffer
+  // serialization without reordering. Empty by default.
+  const std::vector<std::pair<std::string, std::string>>& attributes() const {
+    return attributes_;
+  }
+
  private:
   Kind kind_;
   offset_size offset_;
   std::optional<std::string> name_;
   ScalarKind scalarKind_;
   size_t childrenCount_;
+  std::vector<std::pair<std::string, std::string>> attributes_;
 };
 
 } // namespace facebook::nimble

--- a/dwio/nimble/velox/VeloxWriter.cpp
+++ b/dwio/nimble/velox/VeloxWriter.cpp
@@ -16,6 +16,7 @@
 #include "dwio/nimble/velox/VeloxWriter.h"
 
 #include <memory>
+#include <unordered_map>
 
 #include "dwio/nimble/common/Exceptions.h"
 #include "dwio/nimble/common/Types.h"
@@ -450,6 +451,49 @@ WriterStreamContext& getStreamContext(
 // restrictive) external configuration and perform internal conversion to node
 // ids. Once the new language is ready, we'll switch to using it instead and
 // this translation logic will be removed.
+
+// Resolves a dotted-path key (e.g. "user.name") against a TypeWithId tree by
+// walking RowType children. Returns nullptr if any segment fails to match a
+// row child. The empty path resolves to `root`. Paths that traverse a
+// non-Row parent return nullptr; callers currently emit flat top-level /
+// nested-struct keys only. Returning nullptr is the intentional "unresolved
+// path" result; folly is avoided per the velox coding guideline, so the
+// nullable-return check is suppressed instead of using FOLLY_NULLABLE.
+//
+// NOLINTNEXTLINE(facebook-hte-NullableReturn)
+const velox::dwio::common::TypeWithId* resolveDottedPath(
+    const velox::dwio::common::TypeWithId& root,
+    std::string_view path) {
+  if (path.empty()) {
+    return &root;
+  }
+  const velox::dwio::common::TypeWithId* current = &root;
+  size_t start = 0;
+  while (start <= path.size()) {
+    auto dot = path.find('.', start);
+    auto end = (dot == std::string_view::npos) ? path.size() : dot;
+    auto segment = path.substr(start, end - start);
+    if (current->type()->kind() != velox::TypeKind::ROW) {
+      return nullptr;
+    }
+    std::shared_ptr<const velox::dwio::common::TypeWithId> child;
+    try {
+      child = current->childByName(std::string(segment));
+    } catch (const velox::VeloxUserError&) {
+      return nullptr;
+    }
+    if (child == nullptr) {
+      return nullptr;
+    }
+    current = child.get();
+    if (dot == std::string_view::npos) {
+      break;
+    }
+    start = dot + 1;
+  }
+  return current;
+}
+
 std::unique_ptr<FieldWriter> createRootFieldWriter(
     const std::shared_ptr<const velox::dwio::common::TypeWithId>& type,
     detail::WriterContext& context) {
@@ -491,21 +535,40 @@ std::unique_ptr<FieldWriter> createRootFieldWriter(
     context.initStatsCollectors(type);
   }
 
-  return FieldWriter::create(context, type, [&](const TypeBuilder& type) {
-    switch (type.kind()) {
-      case Kind::Row: {
-        getStreamContext(type.asRow().nullsDescriptor()).setIsNullStream(true);
-        break;
+  // Translate dotted-path column-name keys to TypeWithId::id keys so the
+  // typeAddedHandler can look them up in O(1) as each TypeBuilder is
+  // constructed. Paths that fail to resolve are silently dropped (see
+  // VeloxWriterOptions::attributesByColumn doc).
+  std::unordered_map<uint32_t, std::vector<std::pair<std::string, std::string>>>
+      attributesByNodeId;
+  if (!context.options().attributesByColumn.empty()) {
+    attributesByNodeId.reserve(context.options().attributesByColumn.size());
+    for (const auto& [path, attributes] :
+         context.options().attributesByColumn) {
+      const auto* resolved = resolveDottedPath(*type, path);
+      if (resolved != nullptr) {
+        attributesByNodeId.emplace(resolved->id(), attributes);
       }
-      case Kind::FlatMap: {
-        getStreamContext(type.asFlatMap().nullsDescriptor())
-            .setIsNullStream(true);
-        break;
-      }
-      default:
-        break;
     }
-  });
+  }
+
+  return FieldWriter::create(
+      context,
+      type,
+      [&, nodeAttributes = std::move(attributesByNodeId)](
+          TypeBuilder& type, uint32_t nodeId) {
+        if (type.kind() == Kind::Row) {
+          getStreamContext(type.asRow().nullsDescriptor())
+              .setIsNullStream(true);
+        } else if (type.kind() == Kind::FlatMap) {
+          getStreamContext(type.asFlatMap().nullsDescriptor())
+              .setIsNullStream(true);
+        }
+        auto it = nodeAttributes.find(nodeId);
+        if (it != nodeAttributes.end()) {
+          type.setAttributes(it->second);
+        }
+      });
 }
 
 void initializeEncodingLayouts(

--- a/dwio/nimble/velox/VeloxWriterOptions.h
+++ b/dwio/nimble/velox/VeloxWriterOptions.h
@@ -101,7 +101,31 @@ struct VeloxWriterOptions {
   /// the set will cause an error during writing.
   folly::F14FastMap<std::string, std::set<std::string>> flatMapColumns;
 
-  /// When true, the writer skips encoding flat map in-map boolean streams that
+  /// Per-column string-keyed attributes to stamp onto the NIMBLE schema.
+  // Keyed by a dotted path of `RowType` child names that resolves to a node
+  // in the input `RowType`. The empty key (`""`) targets the root.
+  // Examples:
+  //   "id"              -> top-level column `id`
+  //   "user.name"       -> field `name` inside top-level struct column
+  //                        `user`
+  // Each value is the attribute bag forwarded verbatim to
+  // `TypeBuilder::setAttributes(...)` on the matching node and preserves
+  // insertion order end-to-end through schema serialization.
+  //
+  // Paths that do not resolve to a node in the input `RowType` are silently
+  // ignored so that callers can submit a superset of attributes and let
+  // schema evolution drop entries that no longer apply. Paths walking
+  // through non-`RowType` parents are not supported in this diff; callers
+  // currently emit flat top-level / nested-struct keys only, and richer
+  // addressing can be added in a follow-up if needed.
+  //
+  // Empty map (default) is a no-op: every existing NIMBLE writer produces
+  // byte-identical files.
+  folly::
+      F14FastMap<std::string, std::vector<std::pair<std::string, std::string>>>
+          attributesByColumn;
+
+  // When true, the writer skips encoding flat map in-map boolean streams that
   /// are all-true (every row has the key) or all-false (no row has the key).
   /// The reader infers the in-map state from value stream presence: all-true
   /// keys have value streams, all-false keys do not.

--- a/dwio/nimble/velox/stats/ColumnStatistics.cpp
+++ b/dwio/nimble/velox/stats/ColumnStatistics.cpp
@@ -290,6 +290,7 @@ void StatisticsCollector::merge(const StatisticsCollector& other) {
       return std::make_unique<StringStatisticsCollector>();
     case velox::TypeKind::BOOLEAN:
     case velox::TypeKind::TIMESTAMP:
+    case velox::TypeKind::HUGEINT:
     case velox::TypeKind::ROW:
     case velox::TypeKind::ARRAY:
     case velox::TypeKind::MAP:

--- a/dwio/nimble/velox/tests/SchemaSerializationTest.cpp
+++ b/dwio/nimble/velox/tests/SchemaSerializationTest.cpp
@@ -16,6 +16,7 @@
 #include "dwio/nimble/velox/SchemaSerialization.h"
 #include <gtest/gtest.h>
 #include "dwio/nimble/velox/SchemaBuilder.h"
+#include "dwio/nimble/velox/SchemaGenerated.h"
 #include "dwio/nimble/velox/SchemaReader.h"
 #include "dwio/nimble/velox/tests/SchemaUtils.h"
 
@@ -231,4 +232,240 @@ TEST(SchemaSerializationTest, NestedComplex) {
   EXPECT_EQ(
       ScalarKind::Int64,
       map.values()->asScalar().scalarDescriptor().scalarKind());
+}
+
+// ---------------------------------------------------------------------------
+// Per-SchemaNode attributes round-trip.
+//
+// The flatbuffer wire format for `SchemaNode.attributes` is already validated
+// in NimbleSchemaAttributesTest. These tests cover the C++ plumbing:
+// TypeBuilder::setAttributes(...) -> SchemaBuilder::addNode ->
+// SchemaSerializer -> flatbuffer -> SchemaDeserializer ->
+// SchemaReader::getSchema -> Type::attributes().
+// ---------------------------------------------------------------------------
+
+TEST(SchemaSerializationTest, AttributesRoundTripOnLeaf) {
+  // Set string-keyed attributes on the leaf TypeBuilder before it is
+  // attached to the row. The keys must survive serialize -> deserialize and
+  // surface on the deserialized Type with insertion order preserved.
+  const std::vector<std::pair<std::string, std::string>> kAttrs = {
+      {"key.a", "12"},
+      {"key.b", "true"},
+      {"key.c", "LONG"},
+  };
+
+  SchemaBuilder schemaBuilder;
+  auto leaf = schemaBuilder.createScalarTypeBuilder(ScalarKind::Int64);
+  leaf->setAttributes(kAttrs);
+  auto row = schemaBuilder.createRowTypeBuilder(1);
+  row->addChild("field", leaf);
+
+  auto root = roundTrip(schemaBuilder);
+  ASSERT_EQ(Kind::Row, root->kind());
+  // Row itself was not annotated.
+  EXPECT_TRUE(root->attributes().empty());
+
+  const auto& child = root->asRow().childAt(0);
+  EXPECT_EQ(Kind::Scalar, child->kind());
+  EXPECT_EQ(kAttrs, child->attributes());
+}
+
+TEST(SchemaSerializationTest, AttributesRoundTripOnParentAndChild) {
+  // Both a nested struct (RowType) and one of its leaves carry distinct
+  // attribute bags. Verify each set lands on the corresponding deserialized
+  // Type independently and does not bleed between nodes.
+  const std::vector<std::pair<std::string, std::string>> kParentAttrs = {
+      {"key.a", "1"},
+      {"key.b", "Variant"},
+  };
+  const std::vector<std::pair<std::string, std::string>> kChildAttrs = {
+      {"key.a", "2"},
+      {"key.b", "UUID"},
+      {"key.c", "16"},
+  };
+
+  SchemaBuilder schemaBuilder;
+  auto leaf = schemaBuilder.createScalarTypeBuilder(ScalarKind::Binary);
+  leaf->setAttributes(kChildAttrs);
+  auto innerRow = schemaBuilder.createRowTypeBuilder(1);
+  innerRow->addChild("uuid", leaf);
+  innerRow->setAttributes(kParentAttrs);
+  auto outerRow = schemaBuilder.createRowTypeBuilder(1);
+  outerRow->addChild("variant", innerRow);
+
+  auto root = roundTrip(schemaBuilder);
+  ASSERT_EQ(Kind::Row, root->kind());
+  EXPECT_TRUE(root->attributes().empty());
+
+  const auto& inner = root->asRow().childAt(0);
+  ASSERT_EQ(Kind::Row, inner->kind());
+  EXPECT_EQ(kParentAttrs, inner->attributes());
+
+  const auto& innerLeaf = inner->asRow().childAt(0);
+  EXPECT_EQ(Kind::Scalar, innerLeaf->kind());
+  EXPECT_EQ(kChildAttrs, innerLeaf->attributes());
+}
+
+TEST(SchemaSerializationTest, AttributesEmptyByDefault) {
+  // A builder without setAttributes(...) must produce a deserialized Type
+  // tree where every node exposes an empty (not throwing, not null) vector.
+  // This is the no-op upgrade path for every NIMBLE writer that does not
+  // know about attributes.
+  SchemaBuilder schemaBuilder;
+  NIMBLE_SCHEMA(
+      schemaBuilder,
+      NIMBLE_ROW({{"a", NIMBLE_INTEGER()}, {"b", NIMBLE_STRING()}}));
+
+  auto root = roundTrip(schemaBuilder);
+  ASSERT_EQ(Kind::Row, root->kind());
+  EXPECT_TRUE(root->attributes().empty());
+  const auto& row = root->asRow();
+  ASSERT_EQ(2, row.childrenCount());
+  EXPECT_TRUE(row.childAt(0)->attributes().empty());
+  EXPECT_TRUE(row.childAt(1)->attributes().empty());
+}
+
+// ---------------------------------------------------------------------------
+// Backward-compatibility regressions.
+//
+// These tests pin invariants that protect every NIMBLE file produced before
+// the `attributes` plumbing landed. They are written to FAIL if a future
+// refactor either:
+//   (a) stops accepting legacy flatbuffer buffers that omit the
+//       `attributes` vtable slot, or
+//   (b) starts emitting an `attributes` vtable slot for nodes whose
+//       TypeBuilder never called setAttributes, which would silently change
+//       on-disk bytes for callers that haven't opted in to attributes.
+// ---------------------------------------------------------------------------
+
+TEST(SchemaSerializationTest, LegacyWireBufferDeserializesWithEmptyAttributes) {
+  // Construct a flatbuffer Schema with NO `attributes` vtable slot on any
+  // node -- byte-for-byte the wire format used by every NIMBLE writer
+  // before this stack landed. SchemaDeserializer must accept it, produce
+  // a correct Type tree, and surface empty attributes on every node.
+  //
+  // Schema shape: ROW{"a": Int32, "b": String}
+  // DFS node layout (matches SchemaBuilder::addNode emit order):
+  //   nodes[0] = ROW(name="root_field", offset=0, children=2)
+  //   nodes[1] = Int32(name="a",        offset=1)
+  //   nodes[2] = String(name="b",       offset=2)
+  namespace fbs = facebook::nimble::serialization;
+  flatbuffers::FlatBufferBuilder builder;
+
+  auto makeNode = [&](fbs::Kind kind,
+                      uint32_t offset,
+                      uint32_t children,
+                      const std::string& name) {
+    auto nameOffset = builder.CreateString(name);
+    fbs::SchemaNodeBuilder nodeBuilder(builder);
+    nodeBuilder.add_kind(kind);
+    nodeBuilder.add_children(children);
+    nodeBuilder.add_name(nameOffset);
+    nodeBuilder.add_offset(offset);
+    // Deliberately NOT calling add_attributes(...) so the legacy vtable
+    // shape is preserved.
+    return nodeBuilder.Finish();
+  };
+
+  std::vector<flatbuffers::Offset<fbs::SchemaNode>> nodeOffsets;
+  // The Row is always wrapped at the top by the writer; the root passed to
+  // the deserializer is the row itself, which has no enclosing name from
+  // SchemaBuilder's perspective. Mirror that here with an empty name on the
+  // root.
+  {
+    fbs::SchemaNodeBuilder nodeBuilder(builder);
+    nodeBuilder.add_kind(fbs::Kind_Row);
+    nodeBuilder.add_children(2);
+    nodeBuilder.add_offset(0);
+    nodeOffsets.push_back(nodeBuilder.Finish());
+  }
+  nodeOffsets.push_back(makeNode(fbs::Kind_Int32, 1, 0, "a"));
+  nodeOffsets.push_back(makeNode(fbs::Kind_String, 2, 0, "b"));
+
+  auto nodesVector = builder.CreateVector(nodeOffsets);
+  builder.Finish(fbs::CreateSchema(builder, nodesVector));
+
+  // Sanity-check that the legacy buffer truly omits the attributes slot
+  // on every node -- if a future refactor changes that, the rest of this
+  // test becomes meaningless and we want to know.
+  const auto* schema = fbs::GetSchema(builder.GetBufferPointer());
+  ASSERT_NE(schema, nullptr);
+  ASSERT_NE(schema->nodes(), nullptr);
+  ASSERT_EQ(schema->nodes()->size(), 3u);
+  for (const auto* node : *schema->nodes()) {
+    EXPECT_EQ(node->attributes(), nullptr)
+        << "Legacy fixture must not encode attributes vtable slot.";
+  }
+
+  auto serialized = std::string_view(
+      reinterpret_cast<const char*>(builder.GetBufferPointer()),
+      builder.GetSize());
+  auto root = SchemaDeserializer::deserialize(serialized);
+
+  ASSERT_EQ(Kind::Row, root->kind());
+  // The empty attribute bag must surface on every Type, not crash, and not
+  // signal "I have attributes" to callers that branch on size.
+  EXPECT_TRUE(root->attributes().empty());
+
+  const auto& row = root->asRow();
+  ASSERT_EQ(2, row.childrenCount());
+  EXPECT_EQ("a", row.nameAt(0));
+  EXPECT_EQ(Kind::Scalar, row.childAt(0)->kind());
+  EXPECT_EQ(
+      ScalarKind::Int32,
+      row.childAt(0)->asScalar().scalarDescriptor().scalarKind());
+  EXPECT_TRUE(row.childAt(0)->attributes().empty());
+
+  EXPECT_EQ("b", row.nameAt(1));
+  EXPECT_EQ(Kind::Scalar, row.childAt(1)->kind());
+  EXPECT_EQ(
+      ScalarKind::String,
+      row.childAt(1)->asScalar().scalarDescriptor().scalarKind());
+  EXPECT_TRUE(row.childAt(1)->attributes().empty());
+}
+
+TEST(SchemaSerializationTest, NoAttributesWireShapeMatchesLegacy) {
+  // When no TypeBuilder calls setAttributes(...), the new serializer must
+  // NOT emit the `attributes` vtable slot on any node. This is the
+  // byte-shape invariant for every NIMBLE writer that has not opted in to
+  // attributes: their on-disk files stay structurally identical to
+  // pre-attributes output, so any reader (Velox, external ORC-spec readers
+  // that treat NIMBLE files as ORC) sees the same vtable layout it always
+  // did.
+  namespace fbs = facebook::nimble::serialization;
+  SchemaBuilder schemaBuilder;
+  // Cover one of each non-trivial container kind to guard against a future
+  // change that accidentally stamps an empty attributes vector through one
+  // codepath but not another.
+  NIMBLE_SCHEMA(
+      schemaBuilder,
+      NIMBLE_ROW(
+          {{"i", NIMBLE_INTEGER()},
+           {"arr", NIMBLE_ARRAY(NIMBLE_BIGINT())},
+           {"m", NIMBLE_MAP(NIMBLE_STRING(), NIMBLE_INTEGER())},
+           {"ts", NIMBLE_TIMESTAMPMICRONANO()}}));
+
+  SchemaSerializer serializer;
+  auto serialized = serializer.serialize(schemaBuilder);
+
+  const auto* schema = fbs::GetSchema(serialized.data());
+  ASSERT_NE(schema, nullptr);
+  ASSERT_NE(schema->nodes(), nullptr);
+  ASSERT_GT(schema->nodes()->size(), 0u);
+  for (const auto* node : *schema->nodes()) {
+    EXPECT_EQ(node->attributes(), nullptr)
+        << "Serializer must not emit attributes vtable slot when no "
+           "TypeBuilder set attributes -- this would silently change "
+           "on-disk bytes for legacy callers.";
+  }
+
+  // Sanity: deserialize still works and produces empty attributes on every
+  // Type. Belt-and-suspenders next to LegacyWireBufferDeserializes... .
+  auto root = SchemaDeserializer::deserialize(serialized);
+  ASSERT_EQ(Kind::Row, root->kind());
+  EXPECT_TRUE(root->attributes().empty());
+  const auto& row = root->asRow();
+  for (size_t i = 0; i < row.childrenCount(); ++i) {
+    EXPECT_TRUE(row.childAt(i)->attributes().empty()) << "child " << i;
+  }
 }

--- a/dwio/nimble/velox/tests/SchemaTest.cpp
+++ b/dwio/nimble/velox/tests/SchemaTest.cpp
@@ -616,6 +616,58 @@ TEST(SchemaTests, typeBuilderCheckedContext) {
   EXPECT_EQ(wrongCtx, nullptr);
 }
 
+TEST(SchemaTests, typeBuilderAttributesEmptyByDefault) {
+  // A freshly created TypeBuilder exposes an empty attribute bag before any
+  // setAttributes call. The accessor lives on the base TypeBuilder, so verify
+  // it on both a leaf (scalar) and a container (row) builder.
+  nimble::SchemaBuilder builder;
+  auto scalar = builder.createScalarTypeBuilder(nimble::ScalarKind::Int32);
+  auto row = builder.createRowTypeBuilder(0);
+
+  EXPECT_TRUE(scalar->attributes().empty());
+  EXPECT_TRUE(row->attributes().empty());
+}
+
+TEST(SchemaTests, typeBuilderSetAttributesPreservesOrder) {
+  // setAttributes stores the bag verbatim and attributes() returns it with
+  // insertion order preserved (no sorting/dedup). Exercised directly on the
+  // builder, independent of schema serialization.
+  const std::vector<std::pair<std::string, std::string>> kAttrs = {
+      {"key.a", "12"},
+      {"key.b", "true"},
+      {"key.c", "LONG"},
+  };
+
+  nimble::SchemaBuilder builder;
+  auto scalar = builder.createScalarTypeBuilder(nimble::ScalarKind::Int64);
+  scalar->setAttributes(kAttrs);
+  EXPECT_EQ(scalar->attributes(), kAttrs);
+
+  // Same API on the base class, so it must behave identically on a row.
+  auto row = builder.createRowTypeBuilder(0);
+  row->setAttributes(kAttrs);
+  EXPECT_EQ(row->attributes(), kAttrs);
+}
+
+TEST(SchemaTests, typeBuilderSetAttributesOverwrites) {
+  // The second setAttributes call fully replaces the first (documented
+  // overwrite semantics) -- it does not merge or append.
+  const std::vector<std::pair<std::string, std::string>> kFirst = {
+      {"key.a", "1"},
+      {"key.b", "true"},
+  };
+  const std::vector<std::pair<std::string, std::string>> kSecond = {
+      {"key.a", "2"},
+  };
+
+  nimble::SchemaBuilder builder;
+  auto scalar = builder.createScalarTypeBuilder(nimble::ScalarKind::Int32);
+  scalar->setAttributes(kFirst);
+  scalar->setAttributes(kSecond);
+
+  EXPECT_EQ(scalar->attributes(), kSecond);
+}
+
 TEST(SchemaTests, rowTypeFindChild) {
   nimble::SchemaBuilder builder;
 

--- a/dwio/nimble/velox/tests/VeloxReaderTest.cpp
+++ b/dwio/nimble/velox/tests/VeloxReaderTest.cpp
@@ -7488,6 +7488,142 @@ TEST_P(VeloxReaderTest, openZLCompressionRoundTrip) {
       writerOptions);
 }
 
+// ---------------------------------------------------------------------------
+// End-to-end attributes propagation through the writer/reader pipeline.
+//
+// Validates VeloxWriterOptions::attributesByColumn round-trips through the
+// writer pipeline, the schema flatbuffer, and back through VeloxReader to
+// the deserialized Type tree exposed by reader.schema(). Top-level and
+// nested-struct dotted-path keys are covered; unresolved paths must be
+// silently dropped per the documented contract.
+// ---------------------------------------------------------------------------
+TEST_P(VeloxReaderTest, attributesByColumnRoundTrip) {
+  facebook::velox::test::VectorMaker vectorMaker(leafPool_.get());
+
+  // ROW{id BIGINT, user ROW{name VARCHAR, age INTEGER}}
+  auto userType =
+      velox::ROW({"name", "age"}, {velox::VARCHAR(), velox::INTEGER()});
+  auto type = velox::ROW({"id", "user"}, {velox::BIGINT(), userType});
+
+  facebook::nimble::VeloxWriterOptions writerOptions;
+  // Top-level leaf and a nested-struct leaf via dotted path. The bogus path
+  // "user.does_not_exist" must be silently dropped.
+  writerOptions.attributesByColumn["id"] = {
+      {"key.a", "1"},
+      {"key.b", "true"},
+      {"key.c", "LONG"},
+  };
+  writerOptions.attributesByColumn["user"] = {
+      {"key.a", "2"},
+      {"key.b", "false"},
+  };
+  writerOptions.attributesByColumn["user.name"] = {
+      {"key.a", "3"},
+      {"key.b", "true"},
+  };
+  writerOptions.attributesByColumn["user.does_not_exist"] = {
+      {"key.a", "999"},
+  };
+
+  std::string file;
+  auto writeFile = std::make_unique<velox::InMemoryWriteFile>(&file);
+  nimble::VeloxWriter writer(
+      type, std::move(writeFile), *rootPool_, std::move(writerOptions));
+  auto users = vectorMaker.rowVector(
+      {"name", "age"},
+      {vectorMaker.flatVector<velox::StringView>({"alice", "bob"}),
+       vectorMaker.flatVector<int32_t>({30, 25})});
+  auto vector = vectorMaker.rowVector(
+      {"id", "user"}, {vectorMaker.flatVector<int64_t>({100, 200}), users});
+  writer.write(vector);
+  writer.close();
+
+  // Read back and inspect the deserialized Type tree's attributes().
+  velox::InMemoryReadFile readFile(file);
+  auto selector = std::make_shared<velox::dwio::common::ColumnSelector>(type);
+  nimble::VeloxReader reader(
+      &readFile, *leafPool_, std::move(selector), createReadParams());
+  const auto& root = reader.schema();
+  ASSERT_EQ(nimble::Kind::Row, root->kind());
+  EXPECT_TRUE(root->attributes().empty());
+
+  const auto& rowSchema = root->asRow();
+  ASSERT_EQ(2, rowSchema.childrenCount());
+  EXPECT_EQ("id", rowSchema.nameAt(0));
+  EXPECT_EQ("user", rowSchema.nameAt(1));
+
+  // Top-level leaf attributes.
+  const auto& idType = rowSchema.childAt(0);
+  EXPECT_EQ(nimble::Kind::Scalar, idType->kind());
+  const std::vector<std::pair<std::string, std::string>> kIdAttrs = {
+      {"key.a", "1"},
+      {"key.b", "true"},
+      {"key.c", "LONG"},
+  };
+  EXPECT_EQ(kIdAttrs, idType->attributes());
+
+  // Nested-struct attributes on the parent row.
+  const auto& userTypeSchema = rowSchema.childAt(1);
+  ASSERT_EQ(nimble::Kind::Row, userTypeSchema->kind());
+  const std::vector<std::pair<std::string, std::string>> kUserAttrs = {
+      {"key.a", "2"},
+      {"key.b", "false"},
+  };
+  EXPECT_EQ(kUserAttrs, userTypeSchema->attributes());
+
+  // Nested-struct attributes on a leaf reached by dotted path.
+  const auto& userRowSchema = userTypeSchema->asRow();
+  ASSERT_EQ(2, userRowSchema.childrenCount());
+  EXPECT_EQ("name", userRowSchema.nameAt(0));
+  const auto& nameType = userRowSchema.childAt(0);
+  EXPECT_EQ(nimble::Kind::Scalar, nameType->kind());
+  const std::vector<std::pair<std::string, std::string>> kNameAttrs = {
+      {"key.a", "3"},
+      {"key.b", "true"},
+  };
+  EXPECT_EQ(kNameAttrs, nameType->attributes());
+
+  // `age` was never annotated -- must surface as empty (the unresolved
+  // "user.does_not_exist" path must have been dropped without bleeding
+  // into a sibling).
+  const auto& ageType = userRowSchema.childAt(1);
+  EXPECT_TRUE(ageType->attributes().empty());
+}
+
+// Backward-compat: a writer that does NOT set attributesByColumn must
+// produce a NIMBLE file whose deserialized Type tree exposes empty
+// attributes on every node. Pins the no-op upgrade path for every
+// existing NIMBLE writer.
+TEST_P(VeloxReaderTest, attributesByColumnEmptyByDefault) {
+  facebook::velox::test::VectorMaker vectorMaker(leafPool_.get());
+
+  auto type = velox::ROW({"a", "b"}, {velox::BIGINT(), velox::VARCHAR()});
+
+  std::string file;
+  auto writeFile = std::make_unique<velox::InMemoryWriteFile>(&file);
+  facebook::nimble::VeloxWriterOptions writerOptions; // defaults
+  nimble::VeloxWriter writer(
+      type, std::move(writeFile), *rootPool_, std::move(writerOptions));
+  auto vector = vectorMaker.rowVector(
+      {"a", "b"},
+      {vectorMaker.flatVector<int64_t>({1, 2}),
+       vectorMaker.flatVector<velox::StringView>({"x", "y"})});
+  writer.write(vector);
+  writer.close();
+
+  velox::InMemoryReadFile readFile(file);
+  auto selector = std::make_shared<velox::dwio::common::ColumnSelector>(type);
+  nimble::VeloxReader reader(
+      &readFile, *leafPool_, std::move(selector), createReadParams());
+  const auto& root = reader.schema();
+  ASSERT_EQ(nimble::Kind::Row, root->kind());
+  EXPECT_TRUE(root->attributes().empty());
+  const auto& rowSchema = root->asRow();
+  ASSERT_EQ(2, rowSchema.childrenCount());
+  EXPECT_TRUE(rowSchema.childAt(0)->attributes().empty());
+  EXPECT_TRUE(rowSchema.childAt(1)->attributes().empty());
+}
+
 INSTANTIATE_TEST_SUITE_P(
     VeloxReaderTestSuite,
     VeloxReaderTest,


### PR DESCRIPTION
Summary:
OSS NIMBLE (dwio/nimble/velox) support for Iceberg V3 field-ids / type-attributes:
per-SchemaNode attributes end-to-end and HUGEINT stats support. No FB-internal or
Velox-connector code (those are split into the follow-up diffs).

- SchemaBuilder/SchemaReader/SchemaSerialization/SchemaTypes: per-SchemaNode
  attributes carrying Iceberg V3 field-id / type-attributes.
- FieldWriter, VeloxWriter(+Options): plumb the attributes through the writer.
- stats/ColumnStatistics: HUGEINT support in StatisticsCollector::create.
- tests: SchemaTest, SchemaSerializationTest, VeloxReaderTest.

Bottom of the velox/nimble portion of the consolidated Iceberg-V3 stack (split out of
the former combined velox diff D108699499).

Reviewed By: srsuryadev

Differential Revision: D108700351


