### PR TITLE
fix:  Stop perpetually skipping VeloxReaderTest.fsstStringBatchReader (#932)

### DIFF
--- a/dwio/nimble/velox/tests/VeloxReaderTest.cpp
+++ b/dwio/nimble/velox/tests/VeloxReaderTest.cpp
@@ -1721,11 +1721,26 @@ TEST_P(VeloxReaderTest, lifetime) {
   }
 }
 
-TEST_P(VeloxReaderTest, fsstStringBatchReader) {
-  if (!optimizeStringBufferHandling()) {
-    GTEST_SKIP() << "FSST is only available in the current encoding factory.";
+// FSST is only produced by the optimizeStringBufferHandling encoding factory,
+// so the test below can only run for that subset of params. Instantiating it on
+// the full VeloxReaderTest param set left the
+// optimizeStringBufferHandling=false instances perpetually skipped, which the
+// test-health monitor flags. Restrict this fixture to the
+// optimizeStringBufferHandling=true params so every instance actually runs.
+class VeloxReaderFsstTest : public VeloxReaderTest {
+ public:
+  static std::vector<TestParam> getFsstTestParams() {
+    std::vector<TestParam> params;
+    for (const auto& param : VeloxReaderTest::getTestParams()) {
+      if (param.optimizeStringBufferHandling) {
+        params.push_back(param);
+      }
+    }
+    return params;
   }
+};
 
+TEST_P(VeloxReaderFsstTest, fsstStringBatchReader) {
   constexpr int kRows = 2'000;
   velox::test::VectorMaker vectorMaker{leafPool_.get()};
   auto vector = vectorMaker.rowVector(
@@ -7492,6 +7507,14 @@ INSTANTIATE_TEST_SUITE_P(
     VeloxReaderTestSuite,
     VeloxReaderTest,
     ::testing::ValuesIn(VeloxReaderTest::getTestParams()),
+    [](const ::testing::TestParamInfo<TestParam>& info) {
+      return info.param.debugString();
+    });
+
+INSTANTIATE_TEST_SUITE_P(
+    VeloxReaderFsstTestSuite,
+    VeloxReaderFsstTest,
+    ::testing::ValuesIn(VeloxReaderFsstTest::getFsstTestParams()),
     [](const ::testing::TestParamInfo<TestParam>& info) {
       return info.param.debugString();
     });


### PR DESCRIPTION
Summary:

Context:
The test-health monitor filed multiple SKIPPING issues (T278108817) for
VeloxReaderTest.fsstStringBatchReader. The test GTEST_SKIP()s whenever
optimizeStringBufferHandling is false (FSST is only produced by that encoding
factory), and getTestParams() generates many optimize=false param instances, so
those instances always skip and get flagged as unhealthy.

This diff:
Moves the test onto a new VeloxReaderFsstTest fixture that instantiates only the
optimizeStringBufferHandling=true subset of params, so every instance actually
runs instead of perpetually skipping. Drops the now-unnecessary skip guard.

Reviewed By: HuamengJiang

Differential Revision: D110523003


