### PR TITLE
feat(nimble): Add streamChunkCompression in ChunkedStreamWriter compression (#936)

### DIFF
--- a/dwio/nimble/common/Types.h
+++ b/dwio/nimble/common/Types.h
@@ -183,12 +183,16 @@ enum class ChecksumType : uint8_t { XXH3_64 = 0 };
 
 std::string toString(ChecksumType type);
 
-// A CompressionType and any type-specific configuration params.
+/// A CompressionType and any type-specific configuration params.
 struct CompressionParams {
   CompressionType type;
 
-  // For zstd.
+  /// For zstd.
   int zstdLevel = 1;
+
+  /// Keep the compressed result only when compressedSize <= rawSize *
+  /// acceptRatio; otherwise fall back to Uncompressed.
+  float acceptRatio = 0.8f;
 };
 
 // Parameters controlling the search for the optimal encoding on a data set.

--- a/dwio/nimble/velox/ChunkedStream.cpp
+++ b/dwio/nimble/velox/ChunkedStream.cpp
@@ -16,7 +16,7 @@
 #include "dwio/nimble/velox/ChunkedStream.h"
 #include "dwio/nimble/common/ChunkHeader.h"
 #include "dwio/nimble/common/Exceptions.h"
-#include "dwio/nimble/tablet/Compression.h"
+#include "dwio/nimble/compression/Compression.h"
 #include "folly/io/Cursor.h"
 
 namespace facebook::nimble {
@@ -51,8 +51,14 @@ std::string_view InMemoryChunkedStream::nextChunk() {
       chunk = {pos_, length};
       break;
     }
-    case CompressionType::Zstd: {
-      uncompressed_ = ZstdCompression::uncompress({pos_, length}, &memoryPool_);
+    case CompressionType::Zstd:
+    case CompressionType::Lz4: {
+      uncompressed_ = Compression::uncompress(
+          memoryPool_,
+          compressionType,
+          DataType::String,
+          {pos_, length},
+          /*decompressCounter=*/nullptr);
       chunk = {uncompressed_->as<char>(), uncompressed_->size()};
       break;
     }

--- a/dwio/nimble/velox/ChunkedStreamWriter.cpp
+++ b/dwio/nimble/velox/ChunkedStreamWriter.cpp
@@ -16,9 +16,43 @@
 #include "dwio/nimble/velox/ChunkedStreamWriter.h"
 #include "dwio/nimble/common/ChunkHeader.h"
 #include "dwio/nimble/common/Exceptions.h"
-#include "dwio/nimble/tablet/Compression.h"
+#include "dwio/nimble/compression/Compression.h"
+#include "dwio/nimble/compression/CompressionPolicy.h"
 
 namespace facebook::nimble {
+
+namespace {
+
+class ChunkCompressionPolicy : public CompressionPolicy {
+ public:
+  explicit ChunkCompressionPolicy(CompressionParams params) : params_{params} {
+    NIMBLE_CHECK(
+        params_.type == CompressionType::Zstd ||
+            params_.type == CompressionType::Lz4,
+        "Unsupported chunk compression type: {}",
+        params_.type);
+  }
+
+  CompressionConfig config() const override {
+    CompressionConfig config{.compressionType = params_.type};
+    if (params_.type == CompressionType::Zstd) {
+      config.parameters.zstd.compressionLevel = params_.zstdLevel;
+    }
+    return config;
+  }
+
+  bool shouldAccept(
+      CompressionType /* compressionType */,
+      uint64_t uncompressedSize,
+      uint64_t compressedSize) const override {
+    return compressedSize <= uncompressedSize * params_.acceptRatio;
+  }
+
+ private:
+  const CompressionParams params_;
+};
+
+} // namespace
 
 ChunkedStreamWriter::ChunkedStreamWriter(
     Buffer& buffer,
@@ -26,7 +60,8 @@ ChunkedStreamWriter::ChunkedStreamWriter(
     : buffer_{buffer}, compressionParams_{compressionParams} {
   NIMBLE_CHECK(
       compressionParams_.type == CompressionType::Uncompressed ||
-          compressionParams_.type == CompressionType::Zstd,
+          compressionParams_.type == CompressionType::Zstd ||
+          compressionParams_.type == CompressionType::Lz4,
       "Unsupported chunked stream compression type: {}",
       compressionParams_.type);
 }
@@ -36,18 +71,28 @@ std::vector<std::string_view> ChunkedStreamWriter::encode(
   auto* header = buffer_.reserve(kChunkHeaderSize);
   auto* pos = header;
 
-  if (compressionParams_.type == CompressionType::Zstd) {
-    auto compressed = ZstdCompression::compress(
-        chunk, &buffer_.getMemoryPool(), compressionParams_.zstdLevel);
-    if (compressed.has_value()) {
-      writeChunkHeader(compressed.value()->size(), CompressionType::Zstd, pos);
-      return {
-          {header, kChunkHeaderSize},
-          buffer_.takeOwnership(std::move(*compressed))};
+  if (compressionParams_.type != CompressionType::Uncompressed) {
+    ChunkCompressionPolicy policy{compressionParams_};
+    auto result = Compression::compress(
+        buffer_.getMemoryPool(),
+        chunk,
+        DataType::String,
+        /*bitWidth=*/0,
+        policy);
+    if (result.buffer.has_value() &&
+        result.compressionType == compressionParams_.type &&
+        policy.shouldAccept(
+            result.compressionType, chunk.size(), result.buffer->size())) {
+      auto view =
+          buffer_.writeString({result.buffer->data(), result.buffer->size()});
+      writeChunkHeader(
+          static_cast<uint32_t>(view.size()), result.compressionType, pos);
+      return {{header, kChunkHeaderSize}, view};
     }
   }
 
-  writeChunkHeader(chunk.size(), CompressionType::Uncompressed, pos);
+  writeChunkHeader(
+      static_cast<uint32_t>(chunk.size()), CompressionType::Uncompressed, pos);
   return {{header, kChunkHeaderSize}, chunk};
 }
 

--- a/dwio/nimble/velox/VeloxWriter.cpp
+++ b/dwio/nimble/velox/VeloxWriter.cpp
@@ -1233,7 +1233,8 @@ uint32_t VeloxWriter::encodeChunk(const StreamData& chunkView, Chunk& chunk) {
   }
   uint32_t chunkBytes{0};
   chunk.rowCount = chunkView.rowCount();
-  ChunkedStreamWriter chunkWriter{*encodingBuffer_};
+  ChunkedStreamWriter chunkWriter{
+      *encodingBuffer_, context_->options().chunkCompression};
   for (auto& buffer : chunkWriter.encode(encoded)) {
     chunkBytes += buffer.size();
     chunk.content.push_back(std::move(buffer));

--- a/dwio/nimble/velox/VeloxWriterOptions.h
+++ b/dwio/nimble/velox/VeloxWriterOptions.h
@@ -41,6 +41,13 @@ std::unordered_map<std::string, std::string> defaultMetadata();
 // supplied. It's strongly advised to move instead of copying
 // it.
 struct VeloxWriterOptions {
+  /// Builds Encoding::Options from VeloxWriterOptions fields.
+  Encoding::Options buildEncodingOptions() const {
+    return {
+        .blockBitPackingBlockSize = blockBitPackingBlockSize,
+        .fsstCompressionTargetRatio = fsstCompressionTargetRatio};
+  }
+
   // Property bag for storing user metadata in the file.
   std::unordered_map<std::string, std::string> metadata =
       detail::defaultMetadata();
@@ -93,94 +100,96 @@ struct VeloxWriterOptions {
   /// the set will cause an error during writing.
   folly::F14FastMap<std::string, std::set<std::string>> flatMapColumns;
 
-  // When true, the writer skips encoding flat map in-map boolean streams that
-  // are all-true (every row has the key) or all-false (no row has the key).
-  // The reader infers the in-map state from value stream presence: all-true
-  // keys have value streams, all-false keys do not.
-  //
-  // NOTE: readers that do not infer omitted in-map streams require this to
-  // remain false so constant in-map streams are physically present.
+  /// When true, the writer skips encoding flat map in-map boolean streams that
+  /// are all-true (every row has the key) or all-false (no row has the key).
+  /// The reader infers the in-map state from value stream presence: all-true
+  /// keys have value streams, all-false keys do not.
+  ///
+  /// NOTE: readers that do not infer omitted in-map streams require this to
+  /// remain false so constant in-map streams are physically present.
   bool skipConstantFlatMapInMapStreams{false};
 
-  // Columns that should be encoded as dictionary arrays
-  // NOTE: For each column, ALL the arrays inside this column will be encoded
-  // using dictionary arrays. In the future we'll have finer control on
-  // individual arrays within a column.
+  /// Columns that should be encoded as dictionary arrays
+  /// NOTE: For each column, ALL the arrays inside this column will be encoded
+  /// using dictionary arrays. In the future we'll have finer control on
+  /// individual arrays within a column.
   folly::F14FastSet<std::string> dictionaryArrayColumns;
 
-  // Columns that should be encoded as dictionary map
-  // NOTE: For each column, ALL the maps inside this column will be encoded
-  // using dictionary maps.
+  /// Columns that should be encoded as dictionary map
+  /// NOTE: For each column, ALL the maps inside this column will be encoded
+  /// using dictionary maps.
   folly::F14FastSet<std::string> deduplicatedMapColumns;
 
-  // The metric logger would come populated with access descriptor information,
-  // application generated query id or specific sampling configs.
+  /// The metric logger would come populated with access descriptor information,
+  /// application generated query id or specific sampling configs.
   std::shared_ptr<MetricsLogger> metricsLogger;
 
-  // Optional feature reordering config.
-  // The key for this config is a (top-level) flat map column ordinal and
-  // the value is an ordered collection of feature ids. When provided, the
-  // writer will make sure that flat map features are grouped together and
-  // ordered based on this config.
+  /// Optional feature reordering config.
+  /// The key for this config is a (top-level) flat map column ordinal and
+  /// the value is an ordered collection of feature ids. When provided, the
+  /// writer will make sure that flat map features are grouped together and
+  /// ordered based on this config.
   std::optional<std::vector<std::tuple<size_t, std::vector<int64_t>>>>
       featureReordering;
 
-  // Optional captured encoding layout tree.
-  // Encoding layout tree is overlayed on the writer tree and the captured
-  // encodings are attempted to be used first, before resolving to perform an
-  // encoding selection.
-  // Captured encodings can be used to speed up writes (as no encoding selection
-  // is needed at runtime) and cal also provide better selected encodings, based
-  // on history data.
+  /// Optional captured encoding layout tree.
+  /// Encoding layout tree is overlayed on the writer tree and the captured
+  /// encodings are attempted to be used first, before resolving to perform an
+  /// encoding selection.
+  /// Captured encodings can be used to speed up writes (as no encoding
+  /// selection is needed at runtime) and cal also provide better selected
+  /// encodings, based on history data.
   std::optional<EncodingLayoutTree> encodingLayoutTree;
 
-  // Compression settings to be used when encoding and compressing data streams
+  /// Compression settings to be used when encoding and compressing data streams
   CompressionOptions compressionOptions;
 
-  // Block size for BlockBitPacking encoding.
-  // EXPERIMENTAL: BlockBitPacking encoding is not production-ready. Do not
-  // enable for production tables without consulting the Nimble team
-  // (oncall: dwios).
+  /// Per-chunk compression of encoded data streams (layered on top of
+  /// compressionOptions).
+  /// EXPERIMENTAL / benchmark-only; only Uncompressed, Zstd and Lz4 are
+  /// supported.
+  /// NOTE: !!! Do NOT enable in production !!!
+  CompressionParams chunkCompression{.type = CompressionType::Uncompressed};
+
+  /// Block size for BlockBitPacking encoding.
+  /// EXPERIMENTAL: BlockBitPacking encoding is not production-ready. Do not
+  /// enable for production tables without consulting the Nimble team
+  ///(oncall: dwios).
   uint16_t blockBitPackingBlockSize = kBlockBitPackingBlockSize;
 
   /// FSST is kept only when its final encoded size is at most this fraction of
   /// the original string bytes.
   double fsstCompressionTargetRatio{0.6};
 
-  /// Builds Encoding::Options from VeloxWriterOptions fields.
-  Encoding::Options buildEncodingOptions() const {
-    return {
-        .blockBitPackingBlockSize = blockBitPackingBlockSize,
-        .fsstCompressionTargetRatio = fsstCompressionTargetRatio};
-  }
-
-  // In low-memory mode, the writer is trying to perform smaller (and more
-  // precise) buffer allocations. This means that overall, the writer will
-  // consume less memory, but will come with an additional cost, of more
-  // reallocations and extra data copy.
-  // TODO: This options should be removed and integrated into the
-  // inputGrowthPolicyFactory option (e.g. allow the caller to set an
-  // ExactGrowthPolicy, as defined here: dwio/nimble/velox/BufferGrowthPolicy.h)
+  /// In low-memory mode, the writer is trying to perform smaller (and more
+  /// precise) buffer allocations. This means that overall, the writer will
+  /// consume less memory, but will come with an additional cost, of more
+  /// reallocations and extra data copy.
+  /// TODO: This options should be removed and integrated into the
+  /// inputGrowthPolicyFactory option (e.g. allow the caller to set an
+  /// ExactGrowthPolicy, as defined here:
+  /// dwio/nimble/velox/BufferGrowthPolicy.h)
   bool lowMemoryMode{false};
 
-  // If present, metadata sections above this threshold size will be compressed.
+  /// If present, metadata sections above this threshold size will be
+  /// compressed.
   std::optional<uint32_t> metadataCompressionThreshold;
 
-  // When flushing data streams into chunks, streams with raw data size smaller
-  // than this threshold will not be flushed.
-  // Note: this threshold is ignored when it is time to flush a stripe.
+  /// When flushing data streams into chunks, streams with raw data size smaller
+  /// than this threshold will not be flushed.
+  /// Note: this threshold is ignored when it is time to flush a stripe.
   uint64_t minStreamChunkRawSize{512 << 10};
 
-  // When flushing data streams into chunks, streams with raw data size larger
-  // than this threshold will be broken down into multiple smaller chunks. Each
-  // chunk will be at most this size.
+  /// When flushing data streams into chunks, streams with raw data size larger
+  /// than this threshold will be broken down into multiple smaller chunks. Each
+  /// chunk will be at most this size.
   uint64_t maxStreamChunkRawSize{20 << 20};
 
-  // Used in place of maxStreamChunkRawSize for tables with large schemas.
+  /// Used in place of maxStreamChunkRawSize for tables with large schemas.
   uint64_t wideSchemaMaxStreamChunkRawSize{2 << 20};
 
-  // When the number of schema nodes exceeds this threshold we use
-  // wideSchemaMaxStreamChunkRawSize in place of maxStreamChunkRawSize.
+  /// When the number of schema nodes exceeds this threshold we use
+  /// wideSchemaMaxStreamChunkRawSize in place of maxStreamChunkRawSize.
   size_t largeSchemaThreshold{500};
 
   // Number of streams to try chunking between memory pressure evaluations.

--- a/dwio/nimble/velox/selective/CMakeLists.txt
+++ b/dwio/nimble/velox/selective/CMakeLists.txt
@@ -34,6 +34,7 @@ add_library(
 target_link_libraries(
   nimble_velox_selective
   nimble_tablet_reader_cache
+  nimble_compression
   nimble_velox_reader
   nimble_velox_writer
   nimble_velox_common

--- a/dwio/nimble/velox/selective/ChunkedDecoder.cpp
+++ b/dwio/nimble/velox/selective/ChunkedDecoder.cpp
@@ -18,6 +18,7 @@
 
 #include "dwio/nimble/common/ChunkHeader.h"
 #include "dwio/nimble/common/Types.h"
+#include "dwio/nimble/compression/Compression.h"
 #include "dwio/nimble/encodings/common/EncodingFactory.h"
 #include "dwio/nimble/encodings/common/EncodingPrefix.h"
 #include "velox/common/testutil/TestValue.h"
@@ -40,10 +41,22 @@ bool ChunkedDecoder::loadNextChunk(
   NIMBLE_CHECK(ret);
   const char* chunkData;
   int64_t chunkSize;
+  velox::BufferPtr uncompressedBuffer;
   switch (compressionType) {
     case CompressionType::Uncompressed:
       chunkData = inputData_;
       chunkSize = length;
+      break;
+    case CompressionType::Zstd:
+    case CompressionType::Lz4:
+      uncompressedBuffer = Compression::uncompress(
+          *pool_,
+          compressionType,
+          DataType::String,
+          std::string_view(inputData_, length),
+          /*decompressCounter=*/nullptr);
+      chunkData = uncompressedBuffer->as<char>();
+      chunkSize = uncompressedBuffer->size();
       break;
     default:
       NIMBLE_UNSUPPORTED("Unsupported compression type: {}", compressionType);
@@ -51,6 +64,11 @@ bool ChunkedDecoder::loadNextChunk(
   inputData_ += length;
   inputSize_ -= length;
   currentStringBuffers_.clear();
+  // Keep the decompressed buffer alive for the lifetime of the encoding, which
+  // may reference it without copying.
+  if (FOLLY_UNLIKELY(uncompressedBuffer != nullptr)) {
+    currentStringBuffers_.push_back(std::move(uncompressedBuffer));
+  }
   auto stringBufferFactory = [&](uint32_t totalLength) {
     auto& buffer = currentStringBuffers_.emplace_back(
         velox::AlignedBuffer::allocate<char>(totalLength, pool_));

--- a/dwio/nimble/velox/selective/tests/ChunkedDecoderTest.cpp
+++ b/dwio/nimble/velox/selective/tests/ChunkedDecoderTest.cpp
@@ -17,6 +17,7 @@
 #include "dwio/nimble/velox/selective/ChunkedDecoder.h"
 
 #include "dwio/nimble/common/Buffer.h"
+#include "dwio/nimble/common/ChunkHeader.h"
 #include "dwio/nimble/common/tests/GTestUtils.h"
 #include "dwio/nimble/encodings/NullableEncoding.h"
 #include "dwio/nimble/encodings/TrivialEncoding.h"
@@ -344,7 +345,8 @@ class ChunkedDecoderDataTest : public index::test::ClusterIndexTestBase,
 
   template <typename T>
   std::pair<std::string, std::vector<ChunkInfo>> encodeChunkedStream(
-      const std::vector<std::vector<T>>& chunks) {
+      const std::vector<std::vector<T>>& chunks,
+      CompressionType compressionType = CompressionType::Uncompressed) {
     Buffer buffer{*pool_};
     std::string streamData;
     std::vector<ChunkInfo> chunkInfos;
@@ -355,8 +357,11 @@ class ChunkedDecoderDataTest : public index::test::ClusterIndexTestBase,
       auto encodedChunk = encodeValues<T>(chunk, buffer);
 
       // Write chunk using ChunkedStreamWriter
-      ChunkedStreamWriter writer{
-          buffer, {.type = CompressionType::Uncompressed}};
+      CompressionParams compressionParams{.type = compressionType};
+      if (compressionType == CompressionType::Zstd) {
+        compressionParams.zstdLevel = 3;
+      }
+      ChunkedStreamWriter writer{buffer, compressionParams};
       auto segments = writer.encode(encodedChunk);
 
       for (const auto& segment : segments) {
@@ -371,6 +376,21 @@ class ChunkedDecoderDataTest : public index::test::ClusterIndexTestBase,
     }
 
     return {streamData, chunkInfos};
+  }
+
+  static void verifyChunkCompressionTypes(
+      std::string_view streamData,
+      size_t chunkCount,
+      CompressionType compressionType) {
+    const char* position = streamData.data();
+    const char* const end = streamData.data() + streamData.size();
+    for (size_t index = 0; index < chunkCount; ++index) {
+      const auto [length, actualCompressionType] = readChunkHeader(position);
+      EXPECT_EQ(actualCompressionType, compressionType);
+      position += length;
+      ASSERT_LE(position, end);
+    }
+    EXPECT_EQ(position, end);
   }
 
   template <typename T>
@@ -763,6 +783,38 @@ TEST_P(ChunkedDecoderDataTest, skipTwoChunks) {
             << "Value mismatch at position " << i;
       }
     }
+  }
+}
+
+TEST_P(ChunkedDecoderDataTest, readsCompressedChunks) {
+  constexpr uint32_t kFirstChunkValue = 42;
+  constexpr uint32_t kSecondChunkValue = 7;
+  const std::vector<std::vector<uint32_t>> chunks{
+      std::vector<uint32_t>(512, kFirstChunkValue),
+      std::vector<uint32_t>(384, kSecondChunkValue),
+  };
+
+  for (auto compressionType : {CompressionType::Zstd, CompressionType::Lz4}) {
+    SCOPED_TRACE(toString(compressionType));
+    auto [streamData, chunkInfos] =
+        encodeChunkedStream<uint32_t>(chunks, compressionType);
+    verifyChunkCompressionTypes(streamData, chunkInfos.size(), compressionType);
+
+    ChunkedDecoder decoder(
+        std::make_unique<dwio::common::SeekableArrayInputStream>(
+            streamData.data(), streamData.size()),
+        createTestStreamIndex(chunkInfos),
+        false,
+        &encodingFactory(),
+        pool_.get());
+
+    std::vector<int32_t> result(chunks[0].size() + chunks[1].size());
+    decoder.nextIndices(result.data(), result.size(), nullptr);
+
+    std::vector<int32_t> expected;
+    expected.insert(expected.end(), chunks[0].size(), kFirstChunkValue);
+    expected.insert(expected.end(), chunks[1].size(), kSecondChunkValue);
+    EXPECT_EQ(result, expected);
   }
 }
 

--- a/dwio/nimble/velox/tests/CMakeLists.txt
+++ b/dwio/nimble/velox/tests/CMakeLists.txt
@@ -24,7 +24,7 @@ target_link_libraries(
 add_executable(
   nimble_velox_tests
   BufferGrowthPolicyTest.cpp
-  ChunkedStreamWriterTest.cpp
+  ChunkedStreamTest.cpp
   DecodedVectorManagerTest.cpp
   EncodingLayoutTreeTest.cpp
   LayoutPlannerTest.cpp

--- a/dwio/nimble/velox/tests/ChunkedStreamTest.cpp
+++ b/dwio/nimble/velox/tests/ChunkedStreamTest.cpp
@@ -49,12 +49,17 @@ createChunkedStream(
     RNG rng,
     nimble::Buffer& buffer,
     size_t chunkCount,
-    bool compress = false) {
+    nimble::CompressionType compressionType =
+        nimble::CompressionType::Uncompressed) {
+  const bool compress =
+      compressionType != nimble::CompressionType::Uncompressed;
   std::vector<std::string> data;
   data.resize(chunkCount);
   for (auto i = 0; i < data.size(); ++i) {
     data[i] = randomString(rng, 100);
     if (compress) {
+      // Append a highly compressible run so the codec actually shrinks the
+      // chunk (otherwise it would fall back to storing it uncompressed).
       data[i] += std::string(200, 'a');
     }
   }
@@ -62,10 +67,8 @@ createChunkedStream(
   for (auto i = 0; i < data.size(); ++i) {
     std::vector<std::string_view> segments;
     {
-      nimble::CompressionParams compressionParams{
-          .type = nimble::CompressionType::Uncompressed};
-      if (compress) {
-        compressionParams.type = nimble::CompressionType::Zstd;
+      nimble::CompressionParams compressionParams{.type = compressionType};
+      if (compressionType == nimble::CompressionType::Zstd) {
         compressionParams.zstdLevel = 3;
       }
       nimble::ChunkedStreamWriter writer{buffer, std::move(compressionParams)};
@@ -141,8 +144,8 @@ TEST(ChunkedStreamTests, SingleChunkWithCompression) {
 
   auto memoryPool = velox::memory::deprecatedAddDefaultLeafMemoryPool();
   nimble::Buffer buffer{*memoryPool};
-  auto [data, result] =
-      createChunkedStream(rng, buffer, /* chunkCount */ 1, /* compress */ true);
+  auto [data, result] = createChunkedStream(
+      rng, buffer, /* chunkCount */ 1, nimble::CompressionType::Zstd);
   ASSERT_GT(result->getStream().size(), 0);
   EXPECT_EQ(data.size(), 1);
 
@@ -169,7 +172,7 @@ TEST(ChunkedStreamTests, MultiChunkWithCompression) {
       rng,
       buffer,
       /* chunkCount */ std::max(2U, folly::Random::rand32(20, rng)),
-      /* compress */ true);
+      nimble::CompressionType::Zstd);
   ASSERT_GT(result->getStream().size(), 0);
   EXPECT_GE(data.size(), 2);
 
@@ -186,3 +189,81 @@ TEST(ChunkedStreamTests, MultiChunkWithCompression) {
     reader.reset();
   }
 }
+
+// Exercises the full write -> read round trip for every supported chunk
+// compression codec, including lz4 which routes through the encoding-level
+// compression facade rather than the tablet zstd compressor.
+class ChunkedStreamCompressionTest
+    : public ::testing::TestWithParam<nimble::CompressionType> {};
+
+TEST_P(ChunkedStreamCompressionTest, roundTripSingleChunk) {
+  const auto compressionType = GetParam();
+  uint32_t seed = folly::Random::rand32();
+  LOG(INFO) << "seed: " << seed;
+  std::mt19937 rng{seed};
+
+  auto memoryPool = velox::memory::deprecatedAddDefaultLeafMemoryPool();
+  nimble::Buffer buffer{*memoryPool};
+  auto [data, result] =
+      createChunkedStream(rng, buffer, /*chunkCount=*/1, compressionType);
+  ASSERT_GT(result->getStream().size(), 0);
+  EXPECT_EQ(data.size(), 1);
+
+  nimble::InMemoryChunkedStream reader{*memoryPool, std::move(result)};
+  // Run multiple times to verify that reset() is working.
+  for (auto i = 0; i < 3; ++i) {
+    ASSERT_TRUE(reader.hasNext());
+    EXPECT_EQ(compressionType, reader.peekCompressionType());
+    auto chunk = reader.nextChunk();
+    EXPECT_EQ(data[0], chunk);
+    EXPECT_FALSE(reader.hasNext());
+    reader.reset();
+  }
+}
+
+TEST_P(ChunkedStreamCompressionTest, roundTripMultiChunk) {
+  const auto compressionType = GetParam();
+  uint32_t seed = folly::Random::rand32();
+  LOG(INFO) << "seed: " << seed;
+  std::mt19937 rng{seed};
+
+  auto memoryPool = velox::memory::deprecatedAddDefaultLeafMemoryPool();
+  nimble::Buffer buffer{*memoryPool};
+  auto [data, result] = createChunkedStream(
+      rng,
+      buffer,
+      /* chunkCount */ std::max(2U, folly::Random::rand32(20, rng)),
+      compressionType);
+  ASSERT_GT(result->getStream().size(), 0);
+  EXPECT_GE(data.size(), 2);
+
+  nimble::InMemoryChunkedStream reader{*memoryPool, std::move(result)};
+  // Run multiple times to verify that reset() is working.
+  for (auto i = 0; i < 3; ++i) {
+    for (auto j = 0; j < data.size(); ++j) {
+      ASSERT_TRUE(reader.hasNext());
+      EXPECT_EQ(compressionType, reader.peekCompressionType());
+      auto chunk = reader.nextChunk();
+      EXPECT_EQ(data[j], chunk);
+    }
+    EXPECT_FALSE(reader.hasNext());
+    reader.reset();
+  }
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    ChunkedStreamTests,
+    ChunkedStreamCompressionTest,
+    ::testing::Values(
+        nimble::CompressionType::Zstd,
+        nimble::CompressionType::Lz4),
+    [](const ::testing::TestParamInfo<nimble::CompressionType>& info) {
+      switch (info.param) {
+        case nimble::CompressionType::Zstd:
+          return "Zstd";
+        case nimble::CompressionType::Lz4:
+          return "Lz4";
+        default:
+          return "Unknown";
+      }
+    });

--- a/dwio/nimble/velox/tests/ChunkedStreamWriterTest.cpp
+++ b/dwio/nimble/velox/tests/ChunkedStreamWriterTest.cpp
@@ -119,9 +119,122 @@ TEST(ChunkedStreamWriterTest, zstdFallbackToUncompressed) {
   EXPECT_EQ(compressionType, nimble::CompressionType::Uncompressed);
 }
 
+TEST(ChunkedStreamWriterTest, lowAcceptRatioRejectsCompression) {
+  auto pool = velox::memory::deprecatedAddDefaultLeafMemoryPool();
+  nimble::Buffer buffer{*pool};
+  // A tiny accept ratio demands near-total savings, so even highly compressible
+  // data is rejected and stored uncompressed.
+  nimble::CompressionParams params{
+      .type = nimble::CompressionType::Zstd,
+      .zstdLevel = 3,
+      .acceptRatio = 0.01f};
+  nimble::ChunkedStreamWriter writer{buffer, params};
+
+  std::string data(1000, 'a');
+  auto segments = writer.encode(data);
+
+  ASSERT_EQ(segments.size(), 2);
+
+  const char* pos = segments[0].data();
+  nimble::encoding::read<uint32_t>(pos); // skip size
+  auto compressionType = nimble::encoding::read<nimble::CompressionType>(pos);
+
+  EXPECT_EQ(compressionType, nimble::CompressionType::Uncompressed);
+}
+
+TEST(ChunkedStreamWriterTest, highAcceptRatioKeepsCompression) {
+  auto pool = velox::memory::deprecatedAddDefaultLeafMemoryPool();
+  nimble::Buffer buffer{*pool};
+  // A permissive accept ratio keeps any size reduction.
+  nimble::CompressionParams params{
+      .type = nimble::CompressionType::Zstd,
+      .zstdLevel = 3,
+      .acceptRatio = 1.0f};
+  nimble::ChunkedStreamWriter writer{buffer, params};
+
+  std::string data(1000, 'a');
+  auto segments = writer.encode(data);
+
+  ASSERT_EQ(segments.size(), 2);
+
+  const char* pos = segments[0].data();
+  auto compressedSize = nimble::encoding::read<uint32_t>(pos);
+  auto compressionType = nimble::encoding::read<nimble::CompressionType>(pos);
+
+  EXPECT_EQ(compressionType, nimble::CompressionType::Zstd);
+  EXPECT_LT(compressedSize, data.size());
+}
+
+TEST(ChunkedStreamWriterTest, lz4CompressionWithCompressibleData) {
+  auto pool = velox::memory::deprecatedAddDefaultLeafMemoryPool();
+  nimble::Buffer buffer{*pool};
+  nimble::CompressionParams params{.type = nimble::CompressionType::Lz4};
+  nimble::ChunkedStreamWriter writer{buffer, params};
+
+  // Highly compressible data: long string of repeated characters.
+  std::string data(1000, 'a');
+  auto segments = writer.encode(data);
+
+  ASSERT_EQ(segments.size(), 2);
+
+  const char* pos = segments[0].data();
+  auto compressedSize = nimble::encoding::read<uint32_t>(pos);
+  auto compressionType = nimble::encoding::read<nimble::CompressionType>(pos);
+
+  EXPECT_EQ(compressionType, nimble::CompressionType::Lz4);
+  EXPECT_LT(compressedSize, data.size());
+}
+
+TEST(ChunkedStreamWriterTest, lz4FallbackToUncompressed) {
+  auto pool = velox::memory::deprecatedAddDefaultLeafMemoryPool();
+  nimble::Buffer buffer{*pool};
+  nimble::CompressionParams params{.type = nimble::CompressionType::Lz4};
+  nimble::ChunkedStreamWriter writer{buffer, params};
+
+  // Small random data that won't compress well.
+  std::string data;
+  data.resize(16);
+  for (int i = 0; i < 16; ++i) {
+    data[i] = static_cast<char>(i * 17 + 31);
+  }
+  auto segments = writer.encode(data);
+
+  ASSERT_EQ(segments.size(), 2);
+
+  const char* pos = segments[0].data();
+  nimble::encoding::read<uint32_t>(pos); // skip size
+  auto compressionType = nimble::encoding::read<nimble::CompressionType>(pos);
+
+  // With small incompressible data, lz4 should fall back to uncompressed.
+  EXPECT_EQ(compressionType, nimble::CompressionType::Uncompressed);
+}
+
+TEST(ChunkedStreamWriterTest, lowAcceptRatioRejectsCompressionLz4) {
+  auto pool = velox::memory::deprecatedAddDefaultLeafMemoryPool();
+  nimble::Buffer buffer{*pool};
+  // The accept ratio applies to lz4 too: a tiny ratio rejects even highly
+  // compressible data.
+  nimble::CompressionParams params{
+      .type = nimble::CompressionType::Lz4, .acceptRatio = 0.01f};
+  nimble::ChunkedStreamWriter writer{buffer, params};
+
+  std::string data(1000, 'a');
+  auto segments = writer.encode(data);
+
+  ASSERT_EQ(segments.size(), 2);
+
+  const char* pos = segments[0].data();
+  nimble::encoding::read<uint32_t>(pos); // skip size
+  auto compressionType = nimble::encoding::read<nimble::CompressionType>(pos);
+
+  EXPECT_EQ(compressionType, nimble::CompressionType::Uncompressed);
+}
+
 TEST(ChunkedStreamWriterTest, unsupportedCompressionTypeThrows) {
   auto pool = velox::memory::deprecatedAddDefaultLeafMemoryPool();
   nimble::Buffer buffer{*pool};
+  // Only Uncompressed, Zstd and Lz4 are supported; zstrong (MetaInternal) is
+  // intentionally excluded (dominated by Zstd) and must be rejected.
   nimble::CompressionParams params{
       .type = nimble::CompressionType::MetaInternal};
   NIMBLE_ASSERT_THROW(


### PR DESCRIPTION
Summary:

Adds optional per-chunk compression of Nimble data streams via `ChunkedStreamWriter`, layered on top of encoding-level selection so it further shrinks files even when the encodings are already good. Three codecs are supported: Zstd and Lz4 

Measured on the DataFM cluster index (full 44GB RIO, 496,234 rows, 24.87GB uncompressed-chunk baseline, encoding-level compression disabled to isolate the chunk layer): lz4 -10.9% file / +0.7% decode, zstd L9 -18.4% / +24% decode

Reviewed By: xiaoxmeng

Differential Revision: D110698233


