### PR TITLE
fix(prism): Set delta reader FileHandle and cache identity to the delta file, not the base file (#937)

### DIFF
--- a/dwio/nimble/tablet/MetadataInput.cpp
+++ b/dwio/nimble/tablet/MetadataInput.cpp
@@ -510,6 +510,8 @@ std::vector<uint32_t> CachedMetadataInput::loadFromCache(
 
     if (uncompressedSize.has_value()) {
       auto pin = acquireCachePin(key, uncompressedSize.value());
+      velox::common::testutil::TestValue::adjust(
+          "facebook::nimble::CachedMetadataInput::loadFromCache", &pin);
       auto buffer = tryCacheHit(uncompressedSize.value(), pin);
       if (buffer != nullptr) {
         sections[index].buffer = std::move(buffer);


### PR DESCRIPTION
Summary:

D106845438 added `baseReaderOpts_.setFileHandle(...)` to enable Nimble metadata caching. Delta reader methods copy `baseReaderOpts_`, inheriting the base file's `FileHandle`. The delta `TabletReader` then uses the base file's `fileId` for `AsyncDataCache` metadata cache keys.

When a delta delete file and a delta update file share the same `fileId` and their stripe data sizes coincide, their stripe group metadata lands at the same byte offset but with different FlatBuffer sizes (different stream counts). The second reader's `loadFromCache()` finds the first's cached entry with a mismatched size, throwing `NimbleInternalError: Cached entry size mismatch with expected size`.

Fix: set each delta reader's `FileHandle` and `cache` on its `ReaderOptions` copy after generating the delta file's own `FileHandle`.

Differential Revision: D110549120


