### PR TITLE
perf: Store fixed and PFOR payloads with exact bit widths (#939)

### DIFF
--- a/dwio/nimble/docs/architecture/encoding_cost_model.html
+++ b/dwio/nimble/docs/architecture/encoding_cost_model.html
@@ -336,12 +336,14 @@ code {
       <div class="enc-card" style="width:100%">
         <div class="enc-name">FixedBitWidth <span class="tag tag-unchanged">UNCHANGED</span></div>
         <div class="formula" style="font-size:0.62rem;margin:0.2rem 0 0">
-          estimateSize(rowCount, statistics, fixedByteWidth) {<br>
-          &nbsp;&nbsp;return estimateSize(rowCount, statistics.min(), statistics.max(), fixedByteWidth);<br>
+          estimateSize(rowCount, statistics, options) {<br>
+          &nbsp;&nbsp;return estimateSize(rowCount, statistics.min(), statistics.max(), options);<br>
           }<br>
           <br>
-          estimateSize(rowCount, minValue, maxValue, fixedByteWidth) {<br>
-          &nbsp;&nbsp;payloadSize = bitPackedBytes(minValue, maxValue, rowCount, fixedByteWidth);<br>
+          estimateSize(rowCount, minValue, maxValue, options) {<br>
+          &nbsp;&nbsp;bitWidth = bitsRequired(maxValue - minValue);<br>
+          &nbsp;&nbsp;if (!options.fixedBitWidthUseExactBits) bitWidth = roundUpToByte(bitWidth);<br>
+          &nbsp;&nbsp;payloadSize = nbytes(bitWidth * rowCount);<br>
           &nbsp;&nbsp;return prefix + kPrefixSize + payloadSize;<br>
           }
         </div>

--- a/dwio/nimble/encodings/DictionaryEncoding.h
+++ b/dwio/nimble/encodings/DictionaryEncoding.h
@@ -89,7 +89,7 @@ class DictionaryEncoding
   static uint64_t estimateSize(
       uint64_t rowCount,
       const Statistics<physicalType>& statistics,
-      bool fixedByteWidth) {
+      const Encoding::Options& options = {}) {
     // Assumptions:
     // Alphabet stored trivially.
     // Indices are stored bit-packed, with bit width needed to store max
@@ -101,7 +101,7 @@ class DictionaryEncoding
             rowCount,
             /*minValue=*/0,
             uniqueCount == 0 ? 0 : uniqueCount - 1,
-            fixedByteWidth);
+            options);
 
     uint64_t alphabetEncodingSize{};
     if constexpr (isStringType<physicalType>()) {
@@ -111,7 +111,7 @@ class DictionaryEncoding
           uniqueCounts.uniqueStringBytes(),
           statistics.min().size(),
           statistics.max().size(),
-          fixedByteWidth);
+          options);
     } else {
       alphabetEncodingSize =
           TrivialEncoding<physicalType>::estimateSize(uniqueCount);

--- a/dwio/nimble/encodings/FixedBitWidthEncoding.h
+++ b/dwio/nimble/encodings/FixedBitWidthEncoding.h
@@ -93,20 +93,19 @@ class FixedBitWidthEncoding final
   static uint64_t estimateSize(
       uint64_t rowCount,
       const Statistics<physicalType>& statistics,
-      bool fixedByteWidth) {
-    return estimateSize(
-        rowCount, statistics.min(), statistics.max(), fixedByteWidth);
+      const Encoding::Options& options) {
+    return estimateSize(rowCount, statistics.min(), statistics.max(), options);
   }
 
   static uint64_t estimateSize(
       uint64_t rowCount,
       uint64_t minValue,
       uint64_t maxValue,
-      bool fixedByteWidth) {
+      const Encoding::Options& options) {
     const uint64_t outerEncodingSize =
         EncodingPrefix::kFixedPrefixSize + kPrefixSize;
-    const uint64_t payloadSize =
-        bitPackedBytes(minValue, maxValue, rowCount, fixedByteWidth);
+    const uint64_t payloadSize = bitPackedBytes(
+        minValue, maxValue, rowCount, options.fixedBitWidthUseExactBits);
     return outerEncodingSize + payloadSize;
   }
 
@@ -119,12 +118,10 @@ class FixedBitWidthEncoding final
       uint64_t minValue,
       uint64_t maxValue,
       uint64_t count,
-      bool fixedByteWidth) {
-    const auto bitWidth = velox::bits::bitsRequired(maxValue - minValue);
-    if (fixedByteWidth) {
-      // Match FixedByteWidth encoding mode, which rounds bit width to the next
-      // byte boundary to mitigate compression issues on non-rounded bit widths.
-      return velox::bits::nbytes(((bitWidth + 7) & ~7) * count);
+      bool useExactBitWidth) {
+    auto bitWidth = velox::bits::bitsRequired(maxValue - minValue);
+    if (!useExactBitWidth) {
+      bitWidth = velox::bits::roundUp(bitWidth, 8);
     }
     return velox::bits::nbytes(bitWidth * count);
   }
@@ -355,22 +352,11 @@ std::string_view FixedBitWidthEncoding<T>::encode(
           physicalType>,
       "Physical type must be unsigned.");
   const uint32_t rowCount = values.size();
-  // NOTE: If we end up with bitsRequired not being a multiple of 8, it degrades
-  // compression efficiency a lot. To (temporarily) mitigate this, we revert to
-  // using "FixedByteWidth", meaning that we round the required bitness to the
-  // closest byte. This is a temporary solution. Going forward we should
-  // evaluate other options. For example:
-  // 1. Asymetric bit width, where we don't encode the data during write
-  // (instead we use Trivial + Compression), but we encode it when we read (for
-  // better in-memory representation).
-  // 2. Apply compression only if bit width is a multiple of 8
-  // 3. Try both bit width and byte width and pick one.
-  // 4. etc...
-  const int bitsRequired =
-      (velox::bits::bitsRequired(
-           selection.statistics().max() - selection.statistics().min()) +
-       7) &
-      ~7;
+  const int exactBitsRequired = velox::bits::bitsRequired(
+      selection.statistics().max() - selection.statistics().min());
+  const int bitsRequired = options.fixedBitWidthUseExactBits
+      ? exactBitsRequired
+      : velox::bits::roundUp(exactBitsRequired, 8);
 
   const uint32_t fixedBitArraySize =
       FixedBitArray::bufferSize(values.size(), bitsRequired);

--- a/dwio/nimble/encodings/FsstEncoding.cpp
+++ b/dwio/nimble/encodings/FsstEncoding.cpp
@@ -414,15 +414,14 @@ std::string_view FsstEncoding::encode(
 uint64_t FsstEncoding::estimateSize(
     uint64_t rowCount,
     const Statistics<std::string_view>& statistics,
-    bool fixedByteWidth,
-    double compressionTargetRatio) {
+    const Encoding::Options& options) {
   const uint64_t estimatedBlobSize = static_cast<uint64_t>(
-      statistics.totalStringsLength() * compressionTargetRatio);
+      statistics.totalStringsLength() * options.fsstCompressionTargetRatio);
   const uint64_t estimatedMaxCompressedLength = static_cast<uint64_t>(
-      std::ceil(statistics.max().size() * compressionTargetRatio));
+      std::ceil(statistics.max().size() * options.fsstCompressionTargetRatio));
   const uint64_t estimatedLengthsSize =
       FixedBitWidthEncoding<uint32_t>::estimateSize(
-          rowCount, 0, estimatedMaxCompressedLength, fixedByteWidth);
+          rowCount, 0, estimatedMaxCompressedLength, options);
   return kSymbolTableOverhead + estimatedBlobSize + estimatedLengthsSize +
       EncodingPrefix::kFixedPrefixSize;
 }

--- a/dwio/nimble/encodings/FsstEncoding.h
+++ b/dwio/nimble/encodings/FsstEncoding.h
@@ -105,8 +105,7 @@ class FsstEncoding final
   static uint64_t estimateSize(
       uint64_t rowCount,
       const Statistics<std::string_view>& statistics,
-      bool fixedByteWidth,
-      double compressionTargetRatio);
+      const Encoding::Options& options);
 
   /// Returns the nested compressed-lengths encoding from serialized FSST data.
   static std::string_view lengthsEncoding(

--- a/dwio/nimble/encodings/MainlyConstantEncoding.h
+++ b/dwio/nimble/encodings/MainlyConstantEncoding.h
@@ -88,7 +88,7 @@ class MainlyConstantEncodingBase
   static uint64_t estimateSize(
       uint64_t rowCount,
       const Statistics<physicalType>& statistics,
-      bool fixedByteWidth) {
+      const Encoding::Options& options = {}) {
     // Assumptions:
     // We store one entry for the common value.
     // Number of uncommon values is total item count minus the max unique
@@ -112,8 +112,8 @@ class MainlyConstantEncodingBase
     const uint64_t uncommonCount = rowCount - maxUniqueCount->second;
     // Uncommon values (sparse bool) bitmap will have index per value,
     // stored bit packed.
-    const uint64_t isCommonEncodingSize = SparseBoolEncoding::estimateSize(
-        rowCount, uncommonCount, fixedByteWidth);
+    const uint64_t isCommonEncodingSize =
+        SparseBoolEncoding::estimateSize(rowCount, uncommonCount, options);
 
     if constexpr (isStringType<physicalType>()) {
       const uint64_t commonValueSize = maxUniqueCount->first.size();
@@ -144,7 +144,7 @@ class MainlyConstantEncodingBase
               uniqueCounts.uniqueStringBytes() - commonValueSize,
               uncommonMinLength,
               uncommonMaxLength,
-              fixedByteWidth);
+              options);
       const uint64_t outerEncodingSize = EncodingPrefix::kFixedPrefixSize +
           2 * sizeof(uint32_t) + commonValueSize + sizeof(uint32_t);
       return outerEncodingSize + otherValuesSize + isCommonEncodingSize;
@@ -153,10 +153,7 @@ class MainlyConstantEncodingBase
       // Other values are encoded as a FixedBitWidth child.
       const uint64_t otherValuesSize =
           FixedBitWidthEncoding<physicalType>::estimateSize(
-              uncommonCount,
-              statistics.min(),
-              statistics.max(),
-              fixedByteWidth);
+              uncommonCount, statistics.min(), statistics.max(), options);
       const uint64_t outerEncodingSize = EncodingPrefix::kFixedPrefixSize +
           2 * sizeof(uint32_t) + commonValueSize;
       return outerEncodingSize + otherValuesSize + isCommonEncodingSize;

--- a/dwio/nimble/encodings/PFOREncoding.h
+++ b/dwio/nimble/encodings/PFOREncoding.h
@@ -136,9 +136,9 @@ class PFOREncoding final
   // Shared by encode() and EncodingSizeEstimation to keep the two in sync.
   //
   // Note: buckets have 7-bit granularity, so the selected baseBitWidth may
-  // overestimate by up to 6 bits. This is deliberate — the encode() path
-  // uses the exact bitsRequired() on each residual, so the actual wire
-  // format is tight. The overestimate only affects size estimation.
+  // overestimate by up to 6 bits. The encode() path may tighten the serialized
+  // base width after the actual residual pass when exact bit-width mode is
+  // enabled.
   template <typename BucketArray>
   static std::pair<uint8_t, uint64_t> selectBaseBitWidth(
       const BucketArray& bucketCounts,
@@ -403,15 +403,15 @@ std::string_view PFOREncoding<T>::encode(
     const uint8_t maxBitWidth =
         static_cast<uint8_t>(velox::bits::bitsRequired(fullRange));
 
-    const auto [baseBitWidth, expectedExceptions] = selectBaseBitWidth(
+    const auto [selectedBaseBitWidth, expectedExceptions] = selectBaseBitWidth(
         selection.statistics().bucketCounts(), rowCount, maxBitWidth);
 
     // Single pass: compute residuals, identify exceptions that overflow
     // baseBitWidth, and zero-mask exception slots in the residual array.
     constexpr uint32_t kBitsPerPhysicalType = sizeof(physicalType) * 8;
-    const physicalType baseMask = baseBitWidth == 0
+    const physicalType baseMask = selectedBaseBitWidth == 0
         ? physicalType{0}
-        : static_cast<physicalType>(velox::bits::lowMask(baseBitWidth));
+        : static_cast<physicalType>(velox::bits::lowMask(selectedBaseBitWidth));
 
     Vector<uint32_t> exceptionPositions{&buffer.getMemoryPool()};
     Vector<physicalType> exceptionValues{&buffer.getMemoryPool()};
@@ -421,19 +421,30 @@ std::string_view PFOREncoding<T>::encode(
 
     Vector<physicalType> maskedResiduals{&buffer.getMemoryPool()};
     maskedResiduals.resize(rowCount);
+    physicalType maxBaseResidual{0};
     for (auto i = 0; i < rowCount; ++i) {
       const physicalType residual =
           static_cast<physicalType>(values[i] - baseline);
-      if (baseBitWidth < kBitsPerPhysicalType && residual > baseMask) {
+      if (selectedBaseBitWidth < kBitsPerPhysicalType && residual > baseMask) {
         exceptionPositions.emplace_back(i);
         exceptionValues.emplace_back(residual);
         maskedResiduals[i] = physicalType{0};
       } else {
         maskedResiduals[i] = residual;
+        maxBaseResidual = std::max(maxBaseResidual, residual);
       }
     }
     const uint32_t numExceptions =
         static_cast<uint32_t>(exceptionPositions.size());
+    const uint8_t exactBaseBitWidth =
+        static_cast<uint8_t>(velox::bits::bitsRequired(maxBaseResidual));
+    NIMBLE_CHECK_LE(
+        exactBaseBitWidth,
+        selectedBaseBitWidth,
+        "Pfor exact bit width should not exceed selected bit width.");
+    const uint8_t baseBitWidth = options.fixedBitWidthUseExactBits
+        ? exactBaseBitWidth
+        : selectedBaseBitWidth;
 
     const uint64_t bitpackedSize = baseBitWidth == 0
         ? 0

--- a/dwio/nimble/encodings/RLEEncoding.h
+++ b/dwio/nimble/encodings/RLEEncoding.h
@@ -380,7 +380,7 @@ class RLEEncoding final : public internal::RLEEncodingBase<T, RLEEncoding<T>> {
   static uint64_t estimateSize(
       uint64_t /*rowCount*/,
       const Statistics<physicalType>& statistics,
-      bool fixedByteWidth) {
+      const Encoding::Options& options = {}) {
     // Estimate the two nested streams produced by RLE:
     //
     //   run lengths: one length per consecutive run, estimated as
@@ -392,10 +392,7 @@ class RLEEncoding final : public internal::RLEEncodingBase<T, RLEEncoding<T>> {
     // Run lengths are encoded as a FixedBitWidth child.
     const uint64_t runLengthsEncodingSize =
         FixedBitWidthEncoding<uint32_t>::estimateSize(
-            runCount,
-            statistics.minRepeat(),
-            statistics.maxRepeat(),
-            fixedByteWidth);
+            runCount, statistics.minRepeat(), statistics.maxRepeat(), options);
 
     uint64_t runValuesEncodingSize{0};
     if constexpr (isStringType<physicalType>()) {
@@ -404,11 +401,11 @@ class RLEEncoding final : public internal::RLEEncodingBase<T, RLEEncoding<T>> {
       // run.
       runValuesEncodingSize =
           DictionaryEncoding<std::string_view>::estimateSize(
-              runCount, statistics, fixedByteWidth);
+              runCount, statistics, options);
     } else {
       // Run values are encoded as a FixedBitWidth child.
       runValuesEncodingSize = FixedBitWidthEncoding<physicalType>::estimateSize(
-          runCount, statistics, fixedByteWidth);
+          runCount, statistics, options);
     }
     const uint64_t outerEncodingSize =
         EncodingPrefix::kFixedPrefixSize + sizeof(uint32_t);
@@ -488,7 +485,7 @@ class RLEEncoding<bool> final
   static uint64_t estimateSize(
       uint64_t /*rowCount*/,
       const Statistics<bool>& statistics,
-      bool fixedByteWidth) {
+      const Encoding::Options& options = {}) {
     // Assumptions:
     // Run lengths are stored using bit-packing (with bit width
     // needed to store max repetition count).
@@ -497,10 +494,7 @@ class RLEEncoding<bool> final
     // Run lengths are encoded as a FixedBitWidth child.
     const uint64_t runLengthsEncodingSize =
         FixedBitWidthEncoding<uint32_t>::estimateSize(
-            runCount,
-            statistics.minRepeat(),
-            statistics.maxRepeat(),
-            fixedByteWidth);
+            runCount, statistics.minRepeat(), statistics.maxRepeat(), options);
     const uint64_t outerEncodingSize =
         EncodingPrefix::kFixedPrefixSize + sizeof(uint32_t);
     return outerEncodingSize + initialValueSize + runLengthsEncodingSize;

--- a/dwio/nimble/encodings/SparseBoolEncoding.h
+++ b/dwio/nimble/encodings/SparseBoolEncoding.h
@@ -74,7 +74,7 @@ class SparseBoolEncoding final : public TypedEncoding<bool, bool> {
   static uint64_t estimateSize(
       uint64_t rowCount,
       const Statistics<bool>& statistics,
-      bool fixedByteWidth) {
+      const Encoding::Options& options = {}) {
     // Assumptions:
     // Uncommon indices are stored bit-packed (with bit width capable of
     // representing max entry count).
@@ -82,13 +82,13 @@ class SparseBoolEncoding final : public TypedEncoding<bool, bool> {
     const auto exceptionCount = std::min(
         statistics.uniqueCounts().value().at(true),
         statistics.uniqueCounts().value().at(false));
-    return estimateSize(rowCount, exceptionCount, fixedByteWidth);
+    return estimateSize(rowCount, exceptionCount, options);
   }
 
   static uint64_t estimateSize(
       uint64_t rowCount,
       uint64_t exceptionCount,
-      bool fixedByteWidth) {
+      const Encoding::Options& options = {}) {
     // Sparse indices are encoded as a FixedBitWidth child.
     // A rowCount sentinel is appended after the real sparse positions so the
     // decoder can stop without storing an explicit index count.
@@ -97,7 +97,7 @@ class SparseBoolEncoding final : public TypedEncoding<bool, bool> {
             exceptionCount + 1,
             /*minValue=*/0,
             /*maxValue=*/rowCount,
-            fixedByteWidth);
+            options);
 
     return EncodingPrefix::kFixedPrefixSize + kPrefixSize + indicesEncodingSize;
   }

--- a/dwio/nimble/encodings/TrivialEncoding.h
+++ b/dwio/nimble/encodings/TrivialEncoding.h
@@ -135,13 +135,13 @@ class TrivialEncoding<std::string_view> final
   static uint64_t estimateSize(
       uint64_t rowCount,
       const Statistics<std::string_view>& statistics,
-      bool fixedByteWidth) {
+      const Encoding::Options& options = {}) {
     return estimateSize(
         rowCount,
         statistics.totalStringsLength(),
         statistics.min().size(),
         statistics.max().size(),
-        fixedByteWidth);
+        options);
   }
 
   static uint64_t estimateSize(
@@ -149,11 +149,11 @@ class TrivialEncoding<std::string_view> final
       uint64_t totalStringsLength,
       uint64_t minLength,
       uint64_t maxLength,
-      bool fixedByteWidth) {
+      const Encoding::Options& options = {}) {
     // String lengths are encoded as a FixedBitWidth child.
     const uint64_t lengthsEncodingSize =
         FixedBitWidthEncoding<uint32_t>::estimateSize(
-            rowCount, minLength, maxLength, fixedByteWidth);
+            rowCount, minLength, maxLength, options);
     return EncodingPrefix::kFixedPrefixSize + kPrefixSize + totalStringsLength +
         lengthsEncodingSize;
   }

--- a/dwio/nimble/encodings/benchmarks/CMakeLists.txt
+++ b/dwio/nimble/encodings/benchmarks/CMakeLists.txt
@@ -22,6 +22,19 @@ target_link_libraries(
   velox_memory
 )
 
+add_executable(
+  nimble_exact_bit_width_storage_benchmark
+  ExactBitWidthStorageBenchmark.cpp
+)
+
+target_link_libraries(
+  nimble_exact_bit_width_storage_benchmark
+  nimble_encodings_tests_utils
+  nimble_encodings
+  nimble_common
+  velox_memory
+)
+
 add_executable(nimble_fsst_benchmark FsstBenchmark.cpp)
 
 target_link_libraries(

--- a/dwio/nimble/encodings/benchmarks/ExactBitWidthStorageBenchmark.cpp
+++ b/dwio/nimble/encodings/benchmarks/ExactBitWidthStorageBenchmark.cpp
@@ -1,0 +1,252 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <array>
+#include <cstdint>
+#include <iomanip>
+#include <iostream>
+#include <span>
+#include <string_view>
+
+#include "dwio/nimble/common/Vector.h"
+#include "dwio/nimble/encodings/DictionaryEncoding.h"
+#include "dwio/nimble/encodings/FixedBitWidthEncoding.h"
+#include "dwio/nimble/encodings/MainlyConstantEncoding.h"
+#include "dwio/nimble/encodings/PFOREncoding.h"
+#include "dwio/nimble/encodings/RLEEncoding.h"
+#include "dwio/nimble/encodings/benchmarks/BenchmarkUtils.h"
+#include "dwio/nimble/encodings/common/Encoding.h"
+#include "dwio/nimble/encodings/common/EncodingType.h"
+#include "dwio/nimble/encodings/selection/Statistics.h"
+#include "velox/common/memory/Memory.h"
+
+namespace facebook::nimble {
+namespace {
+
+constexpr uint32_t kRows = 130;
+constexpr uint32_t kBaseline = 1000;
+constexpr std::array<uint8_t, 18>
+    kValueBits{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 13, 14, 15, 17, 20, 21, 27};
+constexpr std::array<uint8_t, 8> kIndexBits{0, 1, 2, 3, 4, 5, 6, 7};
+
+uint32_t maxResidual(uint8_t bitWidth) {
+  if (bitWidth == 0) {
+    return 0;
+  }
+  return bitWidth == 32 ? ~uint32_t{0} : ((uint32_t{1} << bitWidth) - 1);
+}
+
+uint64_t savedPercent(uint64_t nonExactBytes, uint64_t exactBytes) {
+  if (nonExactBytes == 0 || nonExactBytes <= exactBytes) {
+    return 0;
+  }
+  return ((nonExactBytes - exactBytes) * 100 + nonExactBytes / 2) /
+      nonExactBytes;
+}
+
+Encoding::Options exactBitWidthOptions() {
+  Encoding::Options options;
+  options.fixedBitWidthUseExactBits = true;
+  return options;
+}
+
+Encoding::Options nonExactBitWidthOptions() {
+  Encoding::Options options;
+  options.fixedBitWidthUseExactBits = false;
+  return options;
+}
+
+void printHeader(std::string_view title) {
+  std::cout << "\n" << title << "\n";
+  std::cout << std::left << std::setw(24) << "encoding" << std::right
+            << std::setw(10) << "bits" << std::setw(12) << "non-exact B"
+            << std::setw(12) << "exact B" << std::setw(12) << "saved"
+            << std::setw(10) << "saved %" << "\n";
+}
+
+void printRow(
+    std::string_view encoding,
+    uint32_t bits,
+    uint64_t nonExactBytes,
+    uint64_t exactBytes) {
+  const int64_t saved =
+      static_cast<int64_t>(nonExactBytes) - static_cast<int64_t>(exactBytes);
+  std::cout << std::left << std::setw(24) << encoding << std::right
+            << std::setw(10) << bits << std::setw(12) << nonExactBytes
+            << std::setw(12) << exactBytes << std::setw(12) << saved
+            << std::setw(10) << savedPercent(nonExactBytes, exactBytes) << "\n";
+}
+
+template <typename T>
+Statistics<T> statsFor(const Vector<T>& values) {
+  return Statistics<T>::create(
+      std::span<const T>{values.data(), values.size()});
+}
+
+Vector<uint32_t> makeRangeData(uint8_t bitWidth) {
+  Vector<uint32_t> values{benchmarks::benchmarkPool().get()};
+  values.resize(kRows);
+  const auto residualMax = maxResidual(bitWidth);
+  for (uint32_t i = 0; i < kRows; ++i) {
+    values[i] = kBaseline +
+        (residualMax == 0 ? 0 : i % static_cast<uint32_t>(residualMax + 1));
+  }
+  values[0] = kBaseline;
+  values[kRows - 1] = kBaseline + residualMax;
+  return values;
+}
+
+Vector<uint32_t> makeDictionaryData(uint8_t indexBits) {
+  Vector<uint32_t> values{benchmarks::benchmarkPool().get()};
+  values.resize(kRows);
+  const uint32_t cardinality = indexBits == 0 ? 1 : uint32_t{1} << indexBits;
+  for (uint32_t i = 0; i < kRows; ++i) {
+    values[i] = kBaseline + (i % cardinality);
+  }
+  return values;
+}
+
+Vector<uint32_t> makeRunData(uint8_t valueBits) {
+  Vector<uint32_t> values{benchmarks::benchmarkPool().get()};
+  values.resize(kRows);
+  const auto residualMax = maxResidual(valueBits);
+  uint32_t row = 0;
+  uint32_t value = 0;
+  while (row < kRows) {
+    const uint32_t runLength = std::min<uint32_t>(2 + (value % 5), kRows - row);
+    for (uint32_t i = 0; i < runLength; ++i) {
+      values[row + i] = kBaseline +
+          (residualMax == 0 ? 0
+                            : value % static_cast<uint32_t>(residualMax + 1));
+    }
+    row += runLength;
+    ++value;
+  }
+  values[kRows - 1] = kBaseline + residualMax;
+  return values;
+}
+
+Vector<uint32_t> makeMainlyConstantData(uint8_t valueBits) {
+  Vector<uint32_t> values{benchmarks::benchmarkPool().get()};
+  values.resize(kRows);
+  const auto residualMax = maxResidual(valueBits);
+  for (uint32_t i = 0; i < kRows; ++i) {
+    values[i] = kBaseline;
+  }
+  for (uint32_t i = 19; i + 1 < kRows; i += 20) {
+    values[i] = kBaseline +
+        (residualMax == 0 ? 0 : i % static_cast<uint32_t>(residualMax + 1));
+  }
+  values[kRows - 1] = kBaseline + residualMax;
+  return values;
+}
+
+Vector<uint32_t> makePforData(uint8_t baseBits) {
+  Vector<uint32_t> values{benchmarks::benchmarkPool().get()};
+  values.resize(kRows);
+  const uint32_t coveredRows = (kRows * 9) / 10;
+  const auto baseMax = maxResidual(baseBits);
+  for (uint32_t i = 0; i < coveredRows; ++i) {
+    values[i] = kBaseline + (baseMax == 0 ? 0 : i % baseMax);
+  }
+  if (coveredRows > 0) {
+    values[coveredRows - 1] = kBaseline + baseMax;
+  }
+  const uint8_t nonExactBucketBits =
+      static_cast<uint8_t>(std::min<uint32_t>(((baseBits + 6) / 7) * 7, 32));
+  const uint32_t outlier = nonExactBucketBits == 32
+      ? ~uint32_t{0}
+      : uint32_t{1} << nonExactBucketBits;
+  for (uint32_t i = coveredRows; i < kRows; ++i) {
+    values[i] = kBaseline + outlier + (i - coveredRows);
+  }
+  return values;
+}
+
+template <typename EncodingT>
+void printEstimateRow(
+    std::string_view label,
+    uint8_t bits,
+    Vector<uint32_t> data) {
+  const auto statistics = statsFor(data);
+  const auto nonExactBytes = EncodingT::estimateSize(
+      data.size(), statistics, nonExactBitWidthOptions());
+  const auto exactBytes =
+      EncodingT::estimateSize(data.size(), statistics, exactBitWidthOptions());
+  printRow(label, bits, nonExactBytes, exactBytes);
+}
+
+void printFixedBitWidthActual() {
+  printHeader("FixedBitWidth actual serialized size");
+  for (const auto bitWidth : kValueBits) {
+    auto data = makeRangeData(bitWidth);
+    const auto nonExactEncoded =
+        benchmarks::encodeData<FixedBitWidthEncoding<uint32_t>>(
+            EncodingType::FixedBitWidth, data, nonExactBitWidthOptions());
+    const auto exactEncoded =
+        benchmarks::encodeData<FixedBitWidthEncoding<uint32_t>>(
+            EncodingType::FixedBitWidth, data, exactBitWidthOptions());
+    printRow(
+        "FixedBitWidth", bitWidth, nonExactEncoded.size(), exactEncoded.size());
+  }
+}
+
+void printEstimatorSweeps() {
+  printHeader("Estimator size: value bit-width children");
+  for (const auto bitWidth : kValueBits) {
+    printEstimateRow<FixedBitWidthEncoding<uint32_t>>(
+        "FixedBitWidth", bitWidth, makeRangeData(bitWidth));
+    printEstimateRow<RLEEncoding<uint32_t>>(
+        "RLE", bitWidth, makeRunData(bitWidth));
+    printEstimateRow<MainlyConstantEncoding<uint32_t>>(
+        "MainlyConstant", bitWidth, makeMainlyConstantData(bitWidth));
+  }
+
+  printHeader("Estimator size: dictionary index bit width");
+  for (const auto indexBits : kIndexBits) {
+    printEstimateRow<DictionaryEncoding<uint32_t>>(
+        "Dictionary", indexBits, makeDictionaryData(indexBits));
+  }
+}
+
+void printPforSweep() {
+  printHeader("PFOR actual size with non-exact bucket-width payload");
+  for (const auto baseBits : kValueBits) {
+    if (baseBits == 0) {
+      continue;
+    }
+    auto data = makePforData(baseBits);
+    const auto nonExactEncoded = benchmarks::encodeData<PFOREncoding<uint32_t>>(
+        EncodingType::PFOR, data, nonExactBitWidthOptions());
+    const auto exactEncoded = benchmarks::encodeData<PFOREncoding<uint32_t>>(
+        EncodingType::PFOR, data, exactBitWidthOptions());
+    printRow("PFOR", baseBits, nonExactEncoded.size(), exactEncoded.size());
+  }
+}
+
+} // namespace
+} // namespace facebook::nimble
+
+int main() {
+  facebook::velox::memory::MemoryManager::initialize({});
+
+  std::cout << "Exact bit-width storage benchmark; rows="
+            << facebook::nimble::kRows << "\n";
+  facebook::nimble::printFixedBitWidthActual();
+  facebook::nimble::printEstimatorSweeps();
+  facebook::nimble::printPforSweep();
+  return 0;
+}

--- a/dwio/nimble/encodings/benchmarks/FixedBitWidthBenchmark.cpp
+++ b/dwio/nimble/encodings/benchmarks/FixedBitWidthBenchmark.cpp
@@ -117,6 +117,24 @@ std::string encodeFixedBitWidth(
   return std::string{encoded.data(), encoded.size()};
 }
 
+Encoding::Options exactBitWidthOptions() {
+  Encoding::Options options;
+  options.fixedBitWidthUseExactBits = true;
+  return options;
+}
+
+Encoding::Options byteRoundedBitWidthOptions() {
+  Encoding::Options options;
+  options.fixedBitWidthUseExactBits = false;
+  return options;
+}
+
+std::string encodeByteRoundedUint32(
+    Buffer& buffer,
+    const Vector<uint32_t>& data) {
+  return encodeFixedBitWidth(buffer, data, byteRoundedBitWidthOptions());
+}
+
 } // namespace
 
 // ============================================================================
@@ -269,6 +287,48 @@ PFOR_PACK64_BENCHMARKS(40)
 PFOR_PACK64_BENCHMARKS(48)
 PFOR_PACK64_BENCHMARKS(56)
 PFOR_PACK64_BENCHMARKS(64)
+
+BENCHMARK_DRAW_LINE();
+
+// ============================================================================
+// FixedBitWidthEncoding materialize() — exact bit width vs byte-rounded
+// payloads. This isolates the storage-size change: exact streams read fewer
+// bytes, while byte-rounded streams may use byte-aligned bit widths.
+// ============================================================================
+
+#define FBW_MATERIALIZE_EXACT_VS_BYTE_ROUNDED(exactBitWidth, roundedBitWidth) \
+  BENCHMARK(FBW_Materialize_uint32_exact_##exactBitWidth##bit, iters) {       \
+    std::string encoded;                                                      \
+    std::vector<uint32_t> output(kNumElements);                               \
+    BENCHMARK_SUSPEND {                                                       \
+      Buffer buffer{*pool};                                                   \
+      auto data = makeData<uint32_t>(exactBitWidth);                          \
+      encoded = encodeFixedBitWidth(buffer, data, exactBitWidthOptions());    \
+    }                                                                         \
+    while (iters--) {                                                         \
+      auto encoding = EncodingFactory{}.create(                               \
+          *pool, encoded, [](uint32_t) -> void* { return nullptr; });         \
+      encoding->materialize(kNumElements, output.data());                     \
+    }                                                                         \
+  }                                                                           \
+  BENCHMARK_RELATIVE(                                                         \
+      FBW_Materialize_uint32_byteRounded_##roundedBitWidth##bit, iters) {     \
+    std::string encoded;                                                      \
+    std::vector<uint32_t> output(kNumElements);                               \
+    BENCHMARK_SUSPEND {                                                       \
+      Buffer buffer{*pool};                                                   \
+      auto data = makeData<uint32_t>(exactBitWidth);                          \
+      encoded = encodeByteRoundedUint32(buffer, data);                        \
+    }                                                                         \
+    while (iters--) {                                                         \
+      auto encoding = EncodingFactory{}.create(                               \
+          *pool, encoded, [](uint32_t) -> void* { return nullptr; });         \
+      encoding->materialize(kNumElements, output.data());                     \
+    }                                                                         \
+  }
+
+FBW_MATERIALIZE_EXACT_VS_BYTE_ROUNDED(6, 8)
+FBW_MATERIALIZE_EXACT_VS_BYTE_ROUNDED(9, 16)
 
 BENCHMARK_DRAW_LINE();
 

--- a/dwio/nimble/encodings/common/Encoding.h
+++ b/dwio/nimble/encodings/common/Encoding.h
@@ -135,6 +135,10 @@ class Encoding {
     /// reads it back from the stream (self-describing).
     uint16_t blockBitPackingBlockSize = kBlockBitPackingBlockSize;
 
+    /// When true, FOR-family payloads use the exact required bit width. When
+    /// false, FixedBitWidth and PFOR round to byte or bucket boundaries.
+    bool fixedBitWidthUseExactBits{false};
+
     /// Per-column decoding statistics for timing decompression.
     velox::dwio::common::DecodingStats* decodingStats = nullptr;
 

--- a/dwio/nimble/encodings/selection/EncodingSelectionPolicy.h
+++ b/dwio/nimble/encodings/selection/EncodingSelectionPolicy.h
@@ -98,7 +98,7 @@ using EncodingSelectionPolicyCreator =
 /// Manual encoding selection implementation.
 /// Uses a manually crafted model to choose the most appropriate encoding based
 /// on the provided statistics.
-template <typename T, bool FixedByteWidth = true>
+template <typename T>
 class ManualEncodingSelectionPolicy : public EncodingSelectionPolicy<T> {
  public:
   using physicalType = typename TypeTraits<T>::physicalType;
@@ -135,7 +135,7 @@ class ManualEncodingSelectionPolicy : public EncodingSelectionPolicy<T> {
     for (const auto& entry : candidateEncodingReadFactors_) {
       const auto encodingType = entry.first;
       const auto estimatedSize =
-          detail::EncodingSizeEstimation<T, FixedByteWidth>::estimateSize(
+          detail::EncodingSizeEstimation<T>::estimateSize(
               encodingType, values.size(), statistics, options);
       if (!estimatedSize.has_value()) {
         NIMBLE_SELECTION_LOG(encodingType << " encoding is incompatible.");
@@ -225,10 +225,9 @@ class ManualEncodingSelectionPolicy : public EncodingSelectionPolicy<T> {
         nestedEncodingReadFactors.emplace_back(entry);
       }
     }
-    UNIQUE_PTR_FACTORY_EXTRA(
+    UNIQUE_PTR_FACTORY(
         nestedDataType,
         ManualEncodingSelectionPolicy,
-        COMMA FixedByteWidth,
         std::move(nestedEncodingReadFactors),
         compressionOptions_,
         nestedEncodingIdentifier);

--- a/dwio/nimble/encodings/selection/EncodingSizeEstimation.h
+++ b/dwio/nimble/encodings/selection/EncodingSizeEstimation.h
@@ -43,12 +43,10 @@ namespace detail {
 // This class is meant to quickly estimate the size of encoded data using a
 // given encoding type. It does a lot of assumptions, and it is not meant to be
 // 100% accurate.
-template <typename T, bool FixedByteWidth>
+template <typename T>
 struct EncodingSizeEstimation {
   using physicalType = typename TypeTraits<T>::physicalType;
 
-  // TODO: Add EncodingType::ALP size estimation case once the actual ALP
-  // algorithm is implemented.
   static std::optional<uint64_t> estimateNumericSize(
       const EncodingType encodingType,
       const uint64_t entryCount,
@@ -63,25 +61,25 @@ struct EncodingSizeEstimation {
         // candidate. MainlyConstantEncoding::estimateSize already supports
         // usePerBlockStats + blockSize params.
         return MainlyConstantEncoding<physicalType>::estimateSize(
-            entryCount, statistics, FixedByteWidth);
+            entryCount, statistics, options);
       }
       case EncodingType::Trivial: {
         return TrivialEncoding<physicalType>::estimateSize(entryCount);
       }
       case EncodingType::FixedBitWidth: {
         return FixedBitWidthEncoding<physicalType>::estimateSize(
-            entryCount, statistics, FixedByteWidth);
+            entryCount, statistics, options);
       }
       case EncodingType::Dictionary: {
         // TODO: Wire per-block tightening when BlockBitPacking is a
         // candidate. DictionaryEncoding::estimateSize already supports
         // usePerBlockStats + blockSize params.
         return DictionaryEncoding<physicalType>::estimateSize(
-            entryCount, statistics, FixedByteWidth);
+            entryCount, statistics, options);
       }
       case EncodingType::RLE: {
         return RLEEncoding<physicalType>::estimateSize(
-            entryCount, statistics, FixedByteWidth);
+            entryCount, statistics, options);
       }
       case EncodingType::Varint: {
         // Note: the condition below actually support floating point numbers as
@@ -153,21 +151,21 @@ struct EncodingSizeEstimation {
   static std::optional<uint64_t> estimateBoolSize(
       const EncodingType encodingType,
       const size_t entryCount,
-      const Statistics<physicalType>& statistics) {
+      const Statistics<physicalType>& statistics,
+      const Encoding::Options& options) {
     switch (encodingType) {
       case EncodingType::Constant: {
         return ConstantEncoding<bool>::estimateSize(statistics);
       }
       case EncodingType::SparseBool: {
         return SparseBoolEncoding::estimateSize(
-            entryCount, statistics, FixedByteWidth);
+            entryCount, statistics, options);
       }
       case EncodingType::Trivial: {
         return TrivialEncoding<bool>::estimateSize(entryCount);
       }
       case EncodingType::RLE: {
-        return RLEEncoding<bool>::estimateSize(
-            entryCount, statistics, FixedByteWidth);
+        return RLEEncoding<bool>::estimateSize(entryCount, statistics, options);
       }
       default: {
         return std::nullopt;
@@ -186,26 +184,22 @@ struct EncodingSizeEstimation {
       }
       case EncodingType::MainlyConstant: {
         return MainlyConstantEncoding<std::string_view>::estimateSize(
-            entryCount, statistics, FixedByteWidth);
+            entryCount, statistics, options);
       }
       case EncodingType::Trivial: {
         return TrivialEncoding<std::string_view>::estimateSize(
-            entryCount, statistics, FixedByteWidth);
+            entryCount, statistics, options);
       }
       case EncodingType::Dictionary: {
         return DictionaryEncoding<std::string_view>::estimateSize(
-            entryCount, statistics, FixedByteWidth);
+            entryCount, statistics, options);
       }
       case EncodingType::RLE: {
         return RLEEncoding<std::string_view>::estimateSize(
-            entryCount, statistics, FixedByteWidth);
+            entryCount, statistics, options);
       }
       case EncodingType::Fsst: {
-        return FsstEncoding::estimateSize(
-            entryCount,
-            statistics,
-            FixedByteWidth,
-            options.fsstCompressionTargetRatio);
+        return FsstEncoding::estimateSize(entryCount, statistics, options);
       }
       default: {
         return std::nullopt;
@@ -221,7 +215,7 @@ struct EncodingSizeEstimation {
     if constexpr (isNumericType<physicalType>()) {
       return estimateNumericSize(encodingType, entryCount, statistics, options);
     } else if constexpr (isBoolType<physicalType>()) {
-      return estimateBoolSize(encodingType, entryCount, statistics);
+      return estimateBoolSize(encodingType, entryCount, statistics, options);
     } else if constexpr (isStringType<physicalType>()) {
       return estimateStringSize(encodingType, entryCount, statistics, options);
     }

--- a/dwio/nimble/encodings/tests/EncodingSelectionTest.cpp
+++ b/dwio/nimble/encodings/tests/EncodingSelectionTest.cpp
@@ -28,11 +28,20 @@ using namespace facebook;
 namespace {
 constexpr uint32_t commonPrefixSize = 6;
 
-template <typename T, bool FixedByteWidth = false>
-std::unique_ptr<nimble::ManualEncodingSelectionPolicy<T, FixedByteWidth>>
+nimble::Encoding::Options bitWidthOptions(bool fixedBitWidthUseExactBits) {
+  nimble::Encoding::Options options;
+  options.fixedBitWidthUseExactBits = fixedBitWidthUseExactBits;
+  return options;
+}
+
+nimble::Encoding::Options exactBitWidthOptions() {
+  return bitWidthOptions(true);
+}
+
+template <typename T>
+std::unique_ptr<nimble::ManualEncodingSelectionPolicy<T>>
 getRootManualSelectionPolicy() {
-  return std::make_unique<
-      nimble::ManualEncodingSelectionPolicy<T, FixedByteWidth>>(
+  return std::make_unique<nimble::ManualEncodingSelectionPolicy<T>>(
       std::vector<std::pair<nimble::EncodingType, float>>{
           {nimble::EncodingType::Constant, 1.0},
           {nimble::EncodingType::Trivial, 0.7},
@@ -105,7 +114,7 @@ typename nimble::TypeTraits<T>::physicalType asPhysicalType(T value) {
       &value);
 }
 
-template <typename T, bool FixedByteWidth>
+template <typename T>
 void verifySizeEstimate(
     std::span<const T> values,
     nimble::Buffer& buffer,
@@ -114,8 +123,7 @@ void verifySizeEstimate(
     nimble::EncodingType encodingTypeForEstimation,
     const std::vector<std::pair<nimble::EncodingType, float>>& readFactors) {
   // Create a policy that uses no compression
-  auto policy = std::make_unique<
-      nimble::ManualEncodingSelectionPolicy<T, FixedByteWidth>>(
+  auto policy = std::make_unique<nimble::ManualEncodingSelectionPolicy<T>>(
       readFactors,
       nimble::CompressionOptions{
           .compressionAcceptRatio = 0.0,
@@ -129,11 +137,10 @@ void verifySizeEstimate(
   EXPECT_EQ(actualSize, expectedActualSize);
 
   // Check the estimated size
-  auto estimatedSize =
-      nimble::detail::EncodingSizeEstimation<T, FixedByteWidth>::estimateSize(
-          encodingTypeForEstimation,
-          values.size(),
-          nimble::Statistics<T>::create(values));
+  auto estimatedSize = nimble::detail::EncodingSizeEstimation<T>::estimateSize(
+      encodingTypeForEstimation,
+      values.size(),
+      nimble::Statistics<T>::create(values));
   EXPECT_EQ(estimatedSize, expectedEstimatedSize);
 }
 
@@ -142,9 +149,10 @@ void test(std::span<const T> values, std::vector<EncodingDetails> expected) {
   auto pool = facebook::velox::memory::deprecatedAddDefaultLeafMemoryPool();
   auto policy = getRootManualSelectionPolicy<T>();
   nimble::Buffer buffer{*pool};
+  const auto options = exactBitWidthOptions();
 
-  auto serialized =
-      nimble::EncodingFactory::encode<T>(std::move(policy), values, buffer);
+  auto serialized = nimble::EncodingFactory::encode<T>(
+      std::move(policy), values, buffer, options);
 
   // test getRawDataSize
   auto size =
@@ -196,8 +204,8 @@ void test(std::span<const T> values, std::vector<EncodingDetails> expected) {
         velox::AlignedBuffer::allocate<char>(totalLength, pool.get()));
     return stringBuffer->asMutable<void>();
   };
-  auto encoding =
-      nimble::EncodingFactory().create(*pool, serialized, stringBufferFactory);
+  auto encoding = nimble::EncodingFactory(options).create(
+      *pool, serialized, stringBufferFactory);
   nimble::Vector<T> result{pool.get()};
   result.resize(values.size());
   encoding->materialize(values.size(), result.data());
@@ -206,6 +214,56 @@ void test(std::span<const T> values, std::vector<EncodingDetails> expected) {
     ASSERT_EQ(asPhysicalType(values[i]), asPhysicalType(result[i])) << i;
   }
 }
+
+struct FixedBitWidthSelectionParam {
+  bool fixedBitWidthUseExactBits;
+  nimble::EncodingType expectedEncodingType;
+};
+
+class FixedBitWidthSelectionTest
+    : public ::testing::TestWithParam<FixedBitWidthSelectionParam> {};
+
+TEST_P(FixedBitWidthSelectionTest, selectsExpectedEncodingForNarrowValues) {
+  using T = uint8_t;
+
+  auto pool = facebook::velox::memory::deprecatedAddDefaultLeafMemoryPool();
+  auto policy = getRootManualSelectionPolicy<T>();
+  nimble::Buffer buffer{*pool};
+  std::vector<T> values;
+  values.reserve(10000);
+  for (uint32_t i = 0; i < 10000; ++i) {
+    values.push_back(i % 32);
+  }
+
+  const auto options = bitWidthOptions(GetParam().fixedBitWidthUseExactBits);
+  const auto serialized = nimble::EncodingFactory::encode<T>(
+      std::move(policy), values, buffer, options);
+
+  verifyEncodingTree(
+      serialized,
+      {
+          {.encodingType = GetParam().expectedEncodingType,
+           .dataType = nimble::TypeTraits<T>::dataType,
+           .level = 0,
+           .nestedEncodingName = ""},
+      });
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    FixedBitWidthUseExactBits,
+    FixedBitWidthSelectionTest,
+    ::testing::Values(
+        FixedBitWidthSelectionParam{
+            .fixedBitWidthUseExactBits = false,
+            .expectedEncodingType = nimble::EncodingType::Trivial,
+        },
+        FixedBitWidthSelectionParam{
+            .fixedBitWidthUseExactBits = true,
+            .expectedEncodingType = nimble::EncodingType::FixedBitWidth,
+        }),
+    [](const ::testing::TestParamInfo<FixedBitWidthSelectionParam>& info) {
+      return info.param.fixedBitWidthUseExactBits ? "Exact" : "ByteRounded";
+    });
 
 using NumericTypes = ::testing::Types<
     int8_t,
@@ -605,7 +663,7 @@ TEST(EncodingSelectionBoolTests, SelectTrivial) {
     }
 
     const uint32_t expectedEncodedDataSize = std::ceil(values.size() / 8.0);
-    verifySizeEstimate<T, false>(
+    verifySizeEstimate<T>(
         values,
         buffer,
         expectedEncodedDataSize + encodingOverhead,
@@ -664,8 +722,8 @@ TEST(EncodingSelectionBoolTests, SelectRunLength) {
   }
 
   auto policy = getRootManualSelectionPolicy<T>();
-  auto serialized =
-      nimble::EncodingFactory::encode<T>(std::move(policy), values, buffer);
+  auto serialized = nimble::EncodingFactory::encode<T>(
+      std::move(policy), values, buffer, exactBitWidthOptions());
 
   // test getRawDataSize
   auto size =
@@ -706,8 +764,8 @@ TEST(EncodingSelectionStringTests, SelectConst) {
       values[i] = value;
     }
 
-    auto serialized =
-        nimble::EncodingFactory::encode<T>(std::move(policy), values, buffer);
+    auto serialized = nimble::EncodingFactory::encode<T>(
+        std::move(policy), values, buffer, exactBitWidthOptions());
 
     // test getRawDataSize
     auto size =
@@ -760,8 +818,8 @@ TEST(EncodingSelectionStringTests, SelectMainlyConst) {
     }
 
     auto policy = getRootManualSelectionPolicy<T>();
-    auto serialized =
-        nimble::EncodingFactory::encode<T>(std::move(policy), values, buffer);
+    auto serialized = nimble::EncodingFactory::encode<T>(
+        std::move(policy), values, buffer, exactBitWidthOptions());
 
     // test getRawDataSize
     auto size =
@@ -828,8 +886,8 @@ TEST(EncodingSelectionStringTests, SelectTrivial) {
     expectedSize += cache[i].size();
   }
 
-  auto serialized =
-      nimble::EncodingFactory::encode<T>(std::move(policy), values, buffer);
+  auto serialized = nimble::EncodingFactory::encode<T>(
+      std::move(policy), values, buffer, exactBitWidthOptions());
 
   // test getRawDataSize
   auto size =
@@ -875,8 +933,8 @@ TEST(EncodingSelectionStringTests, SelectDictionary) {
     expectedSize += val.size();
   }
 
-  auto serialized =
-      nimble::EncodingFactory::encode<T>(std::move(policy), values, buffer);
+  auto serialized = nimble::EncodingFactory::encode<T>(
+      std::move(policy), values, buffer, exactBitWidthOptions());
 
   // test getRawDataSize
   auto size =
@@ -941,8 +999,8 @@ TEST(EncodingSelectionStringTests, SelectRunLength) {
   }
 
   auto policy = getRootManualSelectionPolicy<T>();
-  auto serialized =
-      nimble::EncodingFactory::encode<T>(std::move(policy), values, buffer);
+  auto serialized = nimble::EncodingFactory::encode<T>(
+      std::move(policy), values, buffer, exactBitWidthOptions());
 
   // test getRawDataSize
   auto size =

--- a/dwio/nimble/encodings/tests/EncodingSizeEstimationTest.cpp
+++ b/dwio/nimble/encodings/tests/EncodingSizeEstimationTest.cpp
@@ -16,6 +16,7 @@
 #include <gtest/gtest.h>
 #include <array>
 #include <limits>
+#include <string>
 
 #include "dwio/nimble/common/Types.h"
 #include "dwio/nimble/common/Vector.h"
@@ -23,6 +24,7 @@
 #include "dwio/nimble/encodings/ConstantEncoding.h"
 #include "dwio/nimble/encodings/DictionaryEncoding.h"
 #include "dwio/nimble/encodings/FixedBitWidthEncoding.h"
+#include "dwio/nimble/encodings/FsstEncoding.h"
 #include "dwio/nimble/encodings/MainlyConstantEncoding.h"
 #include "dwio/nimble/encodings/RLEEncoding.h"
 #include "dwio/nimble/encodings/SparseBoolEncoding.h"
@@ -30,10 +32,41 @@
 #include "dwio/nimble/encodings/VarintEncoding.h"
 
 #include "dwio/nimble/encodings/tests/TestUtils.h"
+#include "velox/common/base/BitUtil.h"
 #include "velox/common/memory/Memory.h"
 
 using namespace facebook;
 using namespace facebook::nimble;
+
+namespace {
+
+Encoding::Options exactBitWidthOptions() {
+  Encoding::Options options;
+  options.fixedBitWidthUseExactBits = true;
+  return options;
+}
+
+Encoding::Options byteRoundedBitWidthOptions() {
+  Encoding::Options options;
+  options.fixedBitWidthUseExactBits = false;
+  return options;
+}
+
+template <typename T>
+uint64_t fixedBitWidthEstimate(
+    uint64_t rowCount,
+    uint64_t minValue,
+    uint64_t maxValue,
+    bool roundBitWidthToByte) {
+  auto bitWidth = velox::bits::bitsRequired(maxValue - minValue);
+  if (roundBitWidthToByte) {
+    bitWidth = velox::bits::roundUp(bitWidth, 8);
+  }
+  return EncodingPrefix::kFixedPrefixSize + 2 + sizeof(T) +
+      velox::bits::nbytes(bitWidth * rowCount);
+}
+
+} // namespace
 
 class EncodingSizeEstimationTest : public ::testing::Test {
  protected:
@@ -43,7 +76,7 @@ class EncodingSizeEstimationTest : public ::testing::Test {
 
   template <typename T>
   void verifySimdForBitpackEstimateVsActualSize() {
-    using Est = detail::EncodingSizeEstimation<T, false>;
+    using Est = detail::EncodingSizeEstimation<T>;
 
     const T min = std::numeric_limits<T>::min();
     const T max = std::numeric_limits<T>::max();
@@ -124,7 +157,7 @@ class EncodingSizeEstimationTest : public ::testing::Test {
 };
 
 TEST_F(EncodingSizeEstimationTest, numericConstant) {
-  using Est = detail::EncodingSizeEstimation<uint32_t, true>;
+  using Est = detail::EncodingSizeEstimation<uint32_t>;
 
   std::vector<uint32_t> data(100, 42);
   auto stats = Statistics<uint32_t>::create(data);
@@ -136,7 +169,7 @@ TEST_F(EncodingSizeEstimationTest, numericConstant) {
 }
 
 TEST_F(EncodingSizeEstimationTest, numericConstantNonConstantData) {
-  using Est = detail::EncodingSizeEstimation<uint32_t, true>;
+  using Est = detail::EncodingSizeEstimation<uint32_t>;
 
   std::vector<uint32_t> data = {1, 2, 3};
   auto stats = Statistics<uint32_t>::create(data);
@@ -146,7 +179,7 @@ TEST_F(EncodingSizeEstimationTest, numericConstantNonConstantData) {
 }
 
 TEST_F(EncodingSizeEstimationTest, numericTrivial) {
-  using Est = detail::EncodingSizeEstimation<uint32_t, true>;
+  using Est = detail::EncodingSizeEstimation<uint32_t>;
 
   std::vector<uint32_t> data = {1, 2, 3, 4, 5};
   auto stats = Statistics<uint32_t>::create(data);
@@ -157,7 +190,7 @@ TEST_F(EncodingSizeEstimationTest, numericTrivial) {
 }
 
 TEST_F(EncodingSizeEstimationTest, numericFixedBitWidth) {
-  using Est = detail::EncodingSizeEstimation<uint32_t, true>;
+  using Est = detail::EncodingSizeEstimation<uint32_t>;
 
   std::vector<uint32_t> data = {100, 101, 102, 103, 104};
   auto stats = Statistics<uint32_t>::create(data);
@@ -167,8 +200,30 @@ TEST_F(EncodingSizeEstimationTest, numericFixedBitWidth) {
   EXPECT_LT(size.value(), 5 * sizeof(uint32_t));
 }
 
+TEST_F(EncodingSizeEstimationTest, fixedBitWidthEstimateUsesExactBits) {
+  using Est = detail::EncodingSizeEstimation<uint32_t>;
+
+  const std::vector<uint32_t> data = {100, 101, 102, 103, 104};
+  auto stats = Statistics<uint32_t>::create(data);
+  Encoding::Options options;
+  options.fixedBitWidthUseExactBits = true;
+
+  const auto size = Est::estimateNumericSize(
+      EncodingType::FixedBitWidth, data.size(), stats, options);
+
+  ASSERT_TRUE(size.has_value());
+  EXPECT_EQ(
+      size.value(),
+      fixedBitWidthEstimate<uint32_t>(
+          data.size(), stats.min(), stats.max(), false));
+  EXPECT_LT(
+      size.value(),
+      fixedBitWidthEstimate<uint32_t>(
+          data.size(), stats.min(), stats.max(), true));
+}
+
 TEST_F(EncodingSizeEstimationTest, numericDictionary) {
-  using Est = detail::EncodingSizeEstimation<uint32_t, true>;
+  using Est = detail::EncodingSizeEstimation<uint32_t>;
 
   std::vector<uint32_t> data = {1, 2, 1, 2, 1, 2, 1, 2, 1, 2};
   auto stats = Statistics<uint32_t>::create(data);
@@ -179,7 +234,7 @@ TEST_F(EncodingSizeEstimationTest, numericDictionary) {
 }
 
 TEST_F(EncodingSizeEstimationTest, numericMainlyConstant) {
-  using Est = detail::EncodingSizeEstimation<uint32_t, true>;
+  using Est = detail::EncodingSizeEstimation<uint32_t>;
 
   std::vector<uint32_t> data(100, 42);
   data[50] = 99;
@@ -192,7 +247,7 @@ TEST_F(EncodingSizeEstimationTest, numericMainlyConstant) {
 }
 
 TEST_F(EncodingSizeEstimationTest, numericRle) {
-  using Est = detail::EncodingSizeEstimation<uint32_t, true>;
+  using Est = detail::EncodingSizeEstimation<uint32_t>;
 
   std::vector<uint32_t> data;
   for (int i = 0; i < 50; ++i) {
@@ -209,7 +264,7 @@ TEST_F(EncodingSizeEstimationTest, numericRle) {
 }
 
 TEST_F(EncodingSizeEstimationTest, numericVarint32) {
-  using Est = detail::EncodingSizeEstimation<uint32_t, true>;
+  using Est = detail::EncodingSizeEstimation<uint32_t>;
 
   std::vector<uint32_t> data = {0, 1, 127, 128, 255, 256, 1000};
   auto stats = Statistics<uint32_t>::create(data);
@@ -220,7 +275,7 @@ TEST_F(EncodingSizeEstimationTest, numericVarint32) {
 }
 
 TEST_F(EncodingSizeEstimationTest, numericVarint64) {
-  using Est = detail::EncodingSizeEstimation<uint64_t, true>;
+  using Est = detail::EncodingSizeEstimation<uint64_t>;
 
   std::vector<uint64_t> data = {0, 1, 127, 128, 16384, 1000000};
   auto stats = Statistics<uint64_t>::create(data);
@@ -231,7 +286,7 @@ TEST_F(EncodingSizeEstimationTest, numericVarint64) {
 }
 
 TEST_F(EncodingSizeEstimationTest, numericUnsupportedEncoding) {
-  using Est = detail::EncodingSizeEstimation<uint32_t, true>;
+  using Est = detail::EncodingSizeEstimation<uint32_t>;
 
   std::vector<uint32_t> data = {1, 2, 3};
   auto stats = Statistics<uint32_t>::create(data);
@@ -241,7 +296,7 @@ TEST_F(EncodingSizeEstimationTest, numericUnsupportedEncoding) {
 }
 
 TEST_F(EncodingSizeEstimationTest, numericEstimateSizeDispatches) {
-  using Est = detail::EncodingSizeEstimation<uint32_t, true>;
+  using Est = detail::EncodingSizeEstimation<uint32_t>;
 
   std::vector<uint32_t> data = {1, 2, 3, 4, 5};
   auto stats = Statistics<uint32_t>::create(data);
@@ -254,29 +309,169 @@ TEST_F(EncodingSizeEstimationTest, numericEstimateSizeDispatches) {
 }
 
 TEST_F(EncodingSizeEstimationTest, fixedBitWidthEstimateUsesValueRange) {
+  Encoding::Options options;
+  options.fixedBitWidthUseExactBits = true;
   const auto sizeFromZero = FixedBitWidthEncoding<uint32_t>::estimateSize(
       /*rowCount=*/100,
       /*minValue=*/0,
       /*maxValue=*/4,
-      /*fixedByteWidth=*/true);
+      options);
   const auto sizeWithBaseline = FixedBitWidthEncoding<uint32_t>::estimateSize(
       /*rowCount=*/100,
       /*minValue=*/100,
       /*maxValue=*/104,
-      /*fixedByteWidth=*/true);
+      options);
   EXPECT_EQ(sizeFromZero, sizeWithBaseline);
 
-  const auto fixedByteWidthSize = FixedBitWidthEncoding<uint32_t>::estimateSize(
+  const auto exactBitWidthSize = FixedBitWidthEncoding<uint32_t>::estimateSize(
       /*rowCount=*/100,
       /*minValue=*/0,
       /*maxValue=*/5,
-      /*fixedByteWidth=*/true);
-  const auto bitWidthSize = FixedBitWidthEncoding<uint32_t>::estimateSize(
-      /*rowCount=*/100,
-      /*minValue=*/0,
-      /*maxValue=*/5,
-      /*fixedByteWidth=*/false);
-  EXPECT_GE(fixedByteWidthSize, bitWidthSize);
+      options);
+  EXPECT_EQ(
+      exactBitWidthSize,
+      fixedBitWidthEstimate<uint32_t>(
+          /*rowCount=*/100, /*minValue=*/0, /*maxValue=*/5, false));
+  EXPECT_LT(
+      exactBitWidthSize,
+      fixedBitWidthEstimate<uint32_t>(
+          /*rowCount=*/100, /*minValue=*/0, /*maxValue=*/5, true));
+}
+
+TEST_F(EncodingSizeEstimationTest, fixedBitWidthEstimateOptionCanRoundToByte) {
+  std::vector<uint32_t> data(100);
+  for (uint32_t i = 0; i < data.size(); ++i) {
+    data[i] = i % 8;
+  }
+  const auto stats = Statistics<uint32_t>::create(data);
+  Encoding::Options exactOptions;
+  exactOptions.fixedBitWidthUseExactBits = true;
+  Encoding::Options roundedOptions;
+  roundedOptions.fixedBitWidthUseExactBits = false;
+
+  const auto exactSize = FixedBitWidthEncoding<uint32_t>::estimateSize(
+      data.size(), stats, exactOptions);
+  const auto roundedSize = FixedBitWidthEncoding<uint32_t>::estimateSize(
+      data.size(), stats, roundedOptions);
+
+  EXPECT_EQ(
+      exactSize,
+      fixedBitWidthEstimate<uint32_t>(
+          data.size(), stats.min(), stats.max(), false));
+  EXPECT_EQ(
+      roundedSize,
+      fixedBitWidthEstimate<uint32_t>(
+          data.size(), stats.min(), stats.max(), true));
+  EXPECT_LT(exactSize, roundedSize);
+}
+
+TEST_F(
+    EncodingSizeEstimationTest,
+    fixedBitWidthEstimateOptionPropagatesToNestedChildren) {
+  const auto exactOptions = exactBitWidthOptions();
+  const auto roundedOptions = byteRoundedBitWidthOptions();
+
+  std::vector<uint32_t> dictionaryData(100);
+  for (uint32_t i = 0; i < dictionaryData.size(); ++i) {
+    dictionaryData[i] = i % 8;
+  }
+  const auto dictionaryStats = Statistics<uint32_t>::create(dictionaryData);
+
+  std::vector<uint32_t> rleData;
+  for (uint32_t run = 0; run < 100; ++run) {
+    rleData.insert(rleData.end(), run % 8 + 1, run % 2);
+  }
+  const auto rleStats = Statistics<uint32_t>::create(rleData);
+
+  std::vector<uint32_t> mainlyConstantData(80, 42);
+  for (uint32_t i = 0; i < 50; ++i) {
+    mainlyConstantData.push_back(i % 8);
+  }
+  const auto mainlyConstantStats =
+      Statistics<uint32_t>::create(mainlyConstantData);
+
+  std::array<bool, 100> sparseBoolData;
+  sparseBoolData.fill(true);
+  for (size_t i = 0; i < sparseBoolData.size(); i += 10) {
+    sparseBoolData[i] = false;
+  }
+  const auto sparseBoolStats = Statistics<bool>::create(sparseBoolData);
+
+  std::vector<std::string> strings;
+  std::vector<std::string_view> stringViews;
+  strings.reserve(100);
+  stringViews.reserve(100);
+  for (uint32_t i = 0; i < 100; ++i) {
+    strings.emplace_back(i % 8 + 1, static_cast<char>('a' + (i % 8)));
+    stringViews.push_back(strings.back());
+  }
+  const auto stringStats = Statistics<std::string_view>::create(stringViews);
+
+  struct TestCase {
+    std::string name;
+    uint64_t exactSize;
+    uint64_t roundedSize;
+  };
+
+  for (const auto& testCase : std::vector<TestCase>{
+           {
+               .name = "Dictionary indices",
+               .exactSize = DictionaryEncoding<uint32_t>::estimateSize(
+                   dictionaryData.size(), dictionaryStats, exactOptions),
+               .roundedSize = DictionaryEncoding<uint32_t>::estimateSize(
+                   dictionaryData.size(), dictionaryStats, roundedOptions),
+           },
+           {
+               .name = "RLE run lengths and values",
+               .exactSize = RLEEncoding<uint32_t>::estimateSize(
+                   rleData.size(), rleStats, exactOptions),
+               .roundedSize = RLEEncoding<uint32_t>::estimateSize(
+                   rleData.size(), rleStats, roundedOptions),
+           },
+           {
+               .name = "MainlyConstant uncommon values and sparse bitmap",
+               .exactSize = MainlyConstantEncoding<uint32_t>::estimateSize(
+                   mainlyConstantData.size(),
+                   mainlyConstantStats,
+                   exactOptions),
+               .roundedSize = MainlyConstantEncoding<uint32_t>::estimateSize(
+                   mainlyConstantData.size(),
+                   mainlyConstantStats,
+                   roundedOptions),
+           },
+           {
+               .name = "SparseBool indices",
+               .exactSize = SparseBoolEncoding::estimateSize(
+                   sparseBoolData.size(), sparseBoolStats, exactOptions),
+               .roundedSize = SparseBoolEncoding::estimateSize(
+                   sparseBoolData.size(), sparseBoolStats, roundedOptions),
+           },
+           {
+               .name = "Trivial string lengths",
+               .exactSize = TrivialEncoding<std::string_view>::estimateSize(
+                   stringViews.size(), stringStats, exactOptions),
+               .roundedSize = TrivialEncoding<std::string_view>::estimateSize(
+                   stringViews.size(), stringStats, roundedOptions),
+           },
+           {
+               .name = "Dictionary string indices and alphabet lengths",
+               .exactSize = DictionaryEncoding<std::string_view>::estimateSize(
+                   stringViews.size(), stringStats, exactOptions),
+               .roundedSize =
+                   DictionaryEncoding<std::string_view>::estimateSize(
+                       stringViews.size(), stringStats, roundedOptions),
+           },
+           {
+               .name = "FSST compressed lengths",
+               .exactSize = FsstEncoding::estimateSize(
+                   stringViews.size(), stringStats, exactOptions),
+               .roundedSize = FsstEncoding::estimateSize(
+                   stringViews.size(), stringStats, roundedOptions),
+           },
+       }) {
+    SCOPED_TRACE(testCase.name);
+    EXPECT_LT(testCase.exactSize, testCase.roundedSize);
+  }
 }
 
 TEST_F(EncodingSizeEstimationTest, encodingEstimateHelpersReturnSizes) {
@@ -293,15 +488,14 @@ TEST_F(EncodingSizeEstimationTest, encodingEstimateHelpersReturnSizes) {
       0u);
   EXPECT_GT(
       FixedBitWidthEncoding<uint32_t>::estimateSize(
-          numericData.size(), numericStats, true),
+          numericData.size(), numericStats, Encoding::Options{}),
       0u);
   EXPECT_GT(
       DictionaryEncoding<uint32_t>::estimateSize(
-          numericData.size(), numericStats, true),
+          numericData.size(), numericStats),
       0u);
   EXPECT_GT(
-      RLEEncoding<uint32_t>::estimateSize(
-          numericData.size(), numericStats, true),
+      RLEEncoding<uint32_t>::estimateSize(numericData.size(), numericStats),
       0u);
   EXPECT_GT(VarintEncoding<uint32_t>::estimateSize(numericStats), 0u);
   EXPECT_GT(
@@ -310,10 +504,9 @@ TEST_F(EncodingSizeEstimationTest, encodingEstimateHelpersReturnSizes) {
       0u);
   EXPECT_GT(
       MainlyConstantEncoding<uint32_t>::estimateSize(
-          numericData.size(), numericStats, true),
+          numericData.size(), numericStats),
       0u);
-  EXPECT_GT(
-      SparseBoolEncoding::estimateSize(boolData.size(), boolStats, true), 0u);
+  EXPECT_GT(SparseBoolEncoding::estimateSize(boolData.size(), boolStats), 0u);
 }
 
 TEST_F(
@@ -331,43 +524,40 @@ TEST_F(
   };
   auto stats = Statistics<std::string_view>::create(data);
 
-  const uint64_t expectedSize =
-      EncodingPrefix::kFixedPrefixSize + 2 * sizeof(uint32_t) + common.size() +
-      sizeof(uint32_t) +
+  const uint64_t expectedSize = EncodingPrefix::kFixedPrefixSize +
+      2 * sizeof(uint32_t) + common.size() + sizeof(uint32_t) +
       TrivialEncoding<std::string_view>::estimateSize(
-          /*rowCount=*/2,
-          /*totalStringsLength=*/5,
-          /*minLength=*/2,
-          /*maxLength=*/3,
-          /*fixedByteWidth=*/false) +
-      SparseBoolEncoding::estimateSize(
-          data.size(), /*exceptionCount=*/2, /*fixedByteWidth=*/false);
+                                    /*rowCount=*/2,
+                                    /*totalStringsLength=*/5,
+                                    /*minLength=*/2,
+                                    /*maxLength=*/3) +
+      SparseBoolEncoding::estimateSize(data.size(), /*exceptionCount=*/2);
 
   EXPECT_EQ(
       MainlyConstantEncoding<std::string_view>::estimateSize(
-          data.size(), stats, /*fixedByteWidth=*/false),
+          data.size(), stats),
       expectedSize);
 }
 
 TEST_F(EncodingSizeEstimationTest, sparseBoolEstimateIncludesSentinelIndex) {
+  Encoding::Options options;
+  options.fixedBitWidthUseExactBits = false;
   const uint64_t indicesSize = FixedBitWidthEncoding<uint32_t>::estimateSize(
       /*rowCount=*/3,
       /*minValue=*/0,
       /*maxValue=*/10,
-      /*fixedByteWidth=*/false);
+      options);
   const uint64_t expectedSize =
       EncodingPrefix::kFixedPrefixSize + sizeof(uint8_t) + indicesSize;
 
   EXPECT_EQ(
       SparseBoolEncoding::estimateSize(
-          /*rowCount=*/10,
-          /*exceptionCount=*/2,
-          /*fixedByteWidth=*/false),
+          /*rowCount=*/10, /*exceptionCount=*/2),
       expectedSize);
 }
 
 TEST_F(EncodingSizeEstimationTest, trivialSmallerThanDictionaryForUnique) {
-  using Est = detail::EncodingSizeEstimation<uint32_t, true>;
+  using Est = detail::EncodingSizeEstimation<uint32_t>;
 
   std::vector<uint32_t> data;
   for (uint32_t i = 0; i < 100; ++i) {
@@ -386,7 +576,7 @@ TEST_F(EncodingSizeEstimationTest, trivialSmallerThanDictionaryForUnique) {
 }
 
 TEST_F(EncodingSizeEstimationTest, dictionarySmallerForHighRepetition) {
-  using Est = detail::EncodingSizeEstimation<uint32_t, true>;
+  using Est = detail::EncodingSizeEstimation<uint32_t>;
 
   std::vector<uint32_t> data;
   for (int i = 0; i < 1000; ++i) {
@@ -405,7 +595,7 @@ TEST_F(EncodingSizeEstimationTest, dictionarySmallerForHighRepetition) {
 }
 
 TEST_F(EncodingSizeEstimationTest, constantSmallestForConstantData) {
-  using Est = detail::EncodingSizeEstimation<uint32_t, true>;
+  using Est = detail::EncodingSizeEstimation<uint32_t>;
 
   std::vector<uint32_t> data(1000, 42);
   auto stats = Statistics<uint32_t>::create(data);
@@ -421,7 +611,7 @@ TEST_F(EncodingSizeEstimationTest, constantSmallestForConstantData) {
 }
 
 TEST_F(EncodingSizeEstimationTest, rleSmallForLongRuns) {
-  using Est = detail::EncodingSizeEstimation<uint32_t, true>;
+  using Est = detail::EncodingSizeEstimation<uint32_t>;
 
   std::vector<uint32_t> data;
   for (int i = 0; i < 500; ++i) {
@@ -442,7 +632,7 @@ TEST_F(EncodingSizeEstimationTest, rleSmallForLongRuns) {
 }
 
 TEST_F(EncodingSizeEstimationTest, fbwSmallForNarrowRange) {
-  using Est = detail::EncodingSizeEstimation<uint32_t, true>;
+  using Est = detail::EncodingSizeEstimation<uint32_t>;
 
   std::vector<uint32_t> data;
   for (uint32_t i = 0; i < 1000; ++i) {
@@ -461,7 +651,7 @@ TEST_F(EncodingSizeEstimationTest, fbwSmallForNarrowRange) {
 }
 
 TEST_F(EncodingSizeEstimationTest, uint64AllEncodings) {
-  using Est = detail::EncodingSizeEstimation<uint64_t, true>;
+  using Est = detail::EncodingSizeEstimation<uint64_t>;
 
   std::vector<uint64_t> data;
   for (uint64_t i = 0; i < 100; ++i) {
@@ -484,7 +674,7 @@ TEST_F(EncodingSizeEstimationTest, uint64AllEncodings) {
 }
 
 TEST_F(EncodingSizeEstimationTest, pforEstimateVsActualSize) {
-  using Est = detail::EncodingSizeEstimation<uint32_t, false>;
+  using Est = detail::EncodingSizeEstimation<uint32_t>;
 
   // ~90% values in [0, 100], ~10% outliers near max — Pfor's sweet spot.
   std::vector<uint32_t> data;
@@ -691,7 +881,7 @@ TEST_F(
     EncodingSizeEstimationTest,
     blockBitPackingEstimateViaEncodingSizeEstimation) {
   // Verify BlockBitPacking is wired up in EncodingSizeEstimation dispatcher.
-  using Est = detail::EncodingSizeEstimation<uint32_t, true>;
+  using Est = detail::EncodingSizeEstimation<uint32_t>;
 
   std::vector<uint32_t> data;
   data.reserve(2048);

--- a/dwio/nimble/encodings/tests/FixedBitWidthEncodingTest.cpp
+++ b/dwio/nimble/encodings/tests/FixedBitWidthEncodingTest.cpp
@@ -15,15 +15,31 @@
  */
 #include <glog/logging.h>
 #include <gtest/gtest.h>
+#include <cstring>
+#include <string>
 #include "dwio/nimble/common/Buffer.h"
+#include "dwio/nimble/common/FixedBitArray.h"
 #include "dwio/nimble/common/Types.h"
 #include "dwio/nimble/common/Vector.h"
+#include "dwio/nimble/encodings/common/Encoding.h"
+#include "dwio/nimble/encodings/common/EncodingFactory.h"
+#include "dwio/nimble/encodings/common/EncodingPrefix.h"
+#include "dwio/nimble/encodings/common/EncodingPrimitives.h"
 #include "dwio/nimble/encodings/common/EncodingType.h"
 #include "dwio/nimble/encodings/tests/TestUtils.h"
 #include "folly/Random.h"
 #include "velox/common/memory/Memory.h"
 
 using namespace facebook;
+
+namespace {
+
+struct EncodingTestAccess : nimble::Encoding {
+  using nimble::Encoding::serializePrefix;
+  using nimble::Encoding::serializePrefixSize;
+};
+
+} // namespace
 
 template <bool UseVarint>
 struct FBWTestConfig {
@@ -54,6 +70,35 @@ class FixedBitWidthEncodingTest : public ::testing::Test {
             stringBufferFactory(),
             nimble::CompressionType::Uncompressed,
             options);
+  }
+
+  std::string encodeByteRounded(
+      const nimble::Vector<uint32_t>& values,
+      const nimble::Encoding::Options& options = {}) {
+    constexpr uint8_t kByteRoundedBits{8};
+    constexpr uint32_t kBaseline{0};
+    const auto payloadSize =
+        nimble::FixedBitArray::bufferSize(values.size(), kByteRoundedBits);
+    const auto encodingSize = EncodingTestAccess::serializePrefixSize(
+                                  values.size(), options.useVarintRowCount) +
+        sizeof(uint8_t) + sizeof(uint32_t) + sizeof(uint8_t) + payloadSize;
+    std::string serialized(encodingSize, '\0');
+    char* pos = serialized.data();
+    EncodingTestAccess::serializePrefix(
+        nimble::EncodingType::FixedBitWidth,
+        nimble::TypeTraits<uint32_t>::dataType,
+        values.size(),
+        options.useVarintRowCount,
+        pos);
+    nimble::encoding::writeChar(
+        static_cast<char>(nimble::CompressionType::Uncompressed), pos);
+    nimble::encoding::write(kBaseline, pos);
+    nimble::encoding::writeChar(kByteRoundedBits, pos);
+    std::memset(pos, 0, payloadSize);
+    nimble::FixedBitArray fixedBitArray(pos, kByteRoundedBits);
+    fixedBitArray.bulkSetWithBaseline(
+        /*start=*/0, values.size(), values.data(), kBaseline);
+    return serialized;
   }
 
   std::function<void*(uint32_t)> stringBufferFactory() {
@@ -89,6 +134,81 @@ TYPED_TEST(FixedBitWidthEncodingTest, serializeThenDeserialize) {
   for (uint32_t i = 0; i < 10; ++i) {
     EXPECT_EQ(result[i], values[i]) << "index " << i;
   }
+}
+
+TYPED_TEST(
+    FixedBitWidthEncodingTest,
+    usesByteRoundedBitsByDefaultAndExactBitsWhenEnabled) {
+  auto values = this->toVector(
+      {0,  1,  2,  3,  4,  5,  6,  7,  8,  9,  10, 11, 12, 13, 14, 15, 16, 17,
+       18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35,
+       36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52});
+  nimble::Encoding::Options defaultOptions;
+  defaultOptions.useVarintRowCount = TypeParam::useVarint;
+  nimble::Encoding::Options exactOptions;
+  exactOptions.useVarintRowCount = TypeParam::useVarint;
+  exactOptions.fixedBitWidthUseExactBits = true;
+
+  nimble::Buffer defaultBuffer{*this->pool_};
+  const auto defaultSerialized =
+      nimble::test::Encoder<nimble::FixedBitWidthEncoding<uint32_t>>::encode(
+          defaultBuffer,
+          values,
+          nimble::CompressionType::Uncompressed,
+          defaultOptions);
+
+  const auto defaultPrefixSize = nimble::EncodingPrefix::readPrefixSize(
+      defaultSerialized, TypeParam::useVarint);
+  EXPECT_EQ(
+      static_cast<uint8_t>(
+          defaultSerialized[defaultPrefixSize + sizeof(uint8_t) + 4]),
+      8);
+
+  nimble::Buffer exactBuffer{*this->pool_};
+  const auto exactSerialized =
+      nimble::test::Encoder<nimble::FixedBitWidthEncoding<uint32_t>>::encode(
+          exactBuffer,
+          values,
+          nimble::CompressionType::Uncompressed,
+          exactOptions);
+
+  const auto exactPrefixSize = nimble::EncodingPrefix::readPrefixSize(
+      exactSerialized, TypeParam::useVarint);
+  EXPECT_EQ(
+      static_cast<uint8_t>(
+          exactSerialized[exactPrefixSize + sizeof(uint8_t) + 4]),
+      6);
+
+  auto encoding = nimble::EncodingFactory().create(
+      *this->pool_,
+      defaultSerialized,
+      this->stringBufferFactory(),
+      defaultOptions);
+  std::vector<uint32_t> result(values.size());
+  encoding->materialize(values.size(), result.data());
+  EXPECT_EQ(result, std::vector<uint32_t>(values.begin(), values.end()));
+}
+
+TYPED_TEST(FixedBitWidthEncodingTest, decodesByteRoundedPayload) {
+  auto values = this->toVector(
+      {0,  1,  2,  3,  4,  5,  6,  7,  8,  9,  10, 11, 12, 13, 14, 15, 16, 17,
+       18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35,
+       36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52});
+  const nimble::Encoding::Options options{
+      .useVarintRowCount = TypeParam::useVarint};
+
+  const auto serialized = this->encodeByteRounded(values, options);
+
+  const auto prefixSize =
+      nimble::EncodingPrefix::readPrefixSize(serialized, TypeParam::useVarint);
+  EXPECT_EQ(
+      static_cast<uint8_t>(serialized[prefixSize + sizeof(uint8_t) + 4]), 8);
+
+  auto encoding = nimble::EncodingFactory().create(
+      *this->pool_, serialized, this->stringBufferFactory(), options);
+  std::vector<uint32_t> result(values.size());
+  encoding->materialize(values.size(), result.data());
+  EXPECT_EQ(result, std::vector<uint32_t>(values.begin(), values.end()));
 }
 
 TYPED_TEST(FixedBitWidthEncodingTest, singleValue) {

--- a/dwio/nimble/encodings/tests/FsstEncodingTest.cpp
+++ b/dwio/nimble/encodings/tests/FsstEncodingTest.cpp
@@ -256,31 +256,33 @@ TEST_F(FsstEncodingTest, estimateSizeUsesTargetRatioAndLengthEncodingWidth) {
       "common/prefix/string/value/three",
   };
   const auto statistics = Statistics<std::string_view>::create(values);
-
-  auto estimatedVariablePart = [&](double compressionTargetRatio,
-                                   bool fixedByteWidth) {
-    const uint64_t estimatedBlobSize = static_cast<uint64_t>(
-        statistics.totalStringsLength() * compressionTargetRatio);
-    const uint64_t estimatedMaxCompressedLength = static_cast<uint64_t>(
-        std::ceil(statistics.max().size() * compressionTargetRatio));
-    return estimatedBlobSize +
-        FixedBitWidthEncoding<uint32_t>::estimateSize(
-               values.size(), 0, estimatedMaxCompressedLength, fixedByteWidth);
+  auto makeOptions = [](double compressionTargetRatio) {
+    Encoding::Options options;
+    options.fsstCompressionTargetRatio = compressionTargetRatio;
+    return options;
   };
 
-  const auto fixedWidthSizeAt50 = FsstEncoding::estimateSize(
-      values.size(), statistics, /*fixedByteWidth=*/true, 0.5);
-  const auto fixedWidthSizeAt60 = FsstEncoding::estimateSize(
-      values.size(), statistics, /*fixedByteWidth=*/true, 0.6);
-  const auto bitPackedSizeAt60 = FsstEncoding::estimateSize(
-      values.size(), statistics, /*fixedByteWidth=*/false, 0.6);
+  auto estimatedVariablePart = [&](const Encoding::Options& options) {
+    const uint64_t estimatedBlobSize = static_cast<uint64_t>(
+        statistics.totalStringsLength() * options.fsstCompressionTargetRatio);
+    const uint64_t estimatedMaxCompressedLength =
+        static_cast<uint64_t>(std::ceil(
+            statistics.max().size() * options.fsstCompressionTargetRatio));
+    return estimatedBlobSize +
+        FixedBitWidthEncoding<uint32_t>::estimateSize(
+               values.size(), 0, estimatedMaxCompressedLength, options);
+  };
+
+  const auto optionsAt50 = makeOptions(0.5);
+  const auto optionsAt60 = makeOptions(0.6);
+  const auto fixedWidthSizeAt50 =
+      FsstEncoding::estimateSize(values.size(), statistics, optionsAt50);
+  const auto fixedWidthSizeAt60 =
+      FsstEncoding::estimateSize(values.size(), statistics, optionsAt60);
 
   EXPECT_EQ(
       fixedWidthSizeAt60 - fixedWidthSizeAt50,
-      estimatedVariablePart(0.6, true) - estimatedVariablePart(0.5, true));
-  EXPECT_EQ(
-      fixedWidthSizeAt60 - bitPackedSizeAt60,
-      estimatedVariablePart(0.6, true) - estimatedVariablePart(0.6, false));
+      estimatedVariablePart(optionsAt60) - estimatedVariablePart(optionsAt50));
 }
 
 TEST_F(FsstEncodingTest, fsstCompressionTargetRatioFallsBackToTrivial) {

--- a/dwio/nimble/encodings/tests/PFOREncodingTest.cpp
+++ b/dwio/nimble/encodings/tests/PFOREncodingTest.cpp
@@ -24,6 +24,8 @@
 #include "dwio/nimble/common/tests/GTestUtils.h"
 #include "dwio/nimble/encodings/common/EncodingFactory.h"
 #include "dwio/nimble/encodings/common/EncodingLayout.h"
+#include "dwio/nimble/encodings/common/EncodingPrefix.h"
+#include "dwio/nimble/encodings/common/EncodingPrimitives.h"
 #include "dwio/nimble/encodings/selection/EncodingSelection.h"
 #include "dwio/nimble/encodings/selection/EncodingSelectionPolicy.h"
 #include "dwio/nimble/encodings/tests/TestUtils.h"
@@ -33,6 +35,33 @@
 using namespace ::facebook;
 
 namespace facebook::nimble::test {
+
+struct PforWireInfo {
+  uint8_t baseBitWidth;
+  uint32_t numExceptions;
+  size_t basePayloadSize;
+};
+
+PforWireInfo readPforWireInfo(
+    std::string_view encoded,
+    bool useVarintRowCount) {
+  const auto prefixSize =
+      EncodingPrefix::readPrefixSize(encoded, useVarintRowCount);
+  const char* pos = encoded.data() + prefixSize;
+  pos += sizeof(uint32_t);
+  const auto baseBitWidth = static_cast<uint8_t>(encoding::readChar(pos));
+  const auto numExceptions = encoding::readUint32(pos);
+  const auto exceptionPositionsSize = encoding::readUint32(pos);
+  pos += exceptionPositionsSize;
+  const auto exceptionValuesSize = encoding::readUint32(pos);
+  pos += exceptionValuesSize;
+  return {
+      .baseBitWidth = baseBitWidth,
+      .numExceptions = numExceptions,
+      .basePayloadSize =
+          static_cast<size_t>(encoded.data() + encoded.size() - pos),
+  };
+}
 
 // The Pfor wire format is byte-identical for a signed cpp type and its
 // matching unsigned physical type, so the per-type tests run on the unsigned
@@ -183,6 +212,78 @@ TEST(PFOREncodingBufferPoolTest, reusesExceptionBuffers) {
   decodeAndVerify();
   EXPECT_EQ(decodePool->stats().numAllocs, numAllocsAfterFirstDecode);
 }
+
+struct PforBitWidthStorageParam {
+  bool fixedBitWidthUseExactBits;
+  uint8_t expectedBaseBitWidth;
+};
+
+class PforBitWidthStorageTest
+    : public ::testing::TestWithParam<PforBitWidthStorageParam> {};
+
+TEST_P(PforBitWidthStorageTest, storesExpectedBasePayloadWidth) {
+  constexpr uint32_t kRowCount{130};
+  constexpr uint32_t kNumExceptions{13};
+  auto pool = velox::memory::deprecatedAddDefaultLeafMemoryPool();
+  std::vector<uint32_t> values;
+  values.reserve(kRowCount);
+  for (uint32_t i = 0; i < kRowCount; ++i) {
+    values.push_back(i < kRowCount - kNumExceptions ? i % 64 : 512 + i);
+  }
+
+  ManualEncodingSelectionPolicyFactory manualFactory;
+  EncodingSelectionPolicyCreator creator = [&manualFactory](DataType dataType) {
+    return manualFactory.createPolicy(dataType);
+  };
+  EncodingLayout layout{
+      EncodingType::PFOR,
+      {},
+      CompressionType::Uncompressed,
+      {std::nullopt, std::nullopt}};
+  auto policy = std::make_unique<ReplayedEncodingSelectionPolicy<uint32_t>>(
+      std::move(layout), CompressionOptions{}, creator);
+
+  Encoding::Options options;
+  options.fixedBitWidthUseExactBits = GetParam().fixedBitWidthUseExactBits;
+  Buffer buffer{*pool};
+  const auto encoded = EncodingFactory::encode<uint32_t>(
+      std::move(policy),
+      std::span<const uint32_t>{values.data(), values.size()},
+      buffer,
+      options);
+  const std::string encodedStorage{encoded};
+
+  const auto wireInfo =
+      readPforWireInfo(encodedStorage, options.useVarintRowCount);
+  EXPECT_EQ(wireInfo.baseBitWidth, GetParam().expectedBaseBitWidth);
+  EXPECT_EQ(wireInfo.numExceptions, kNumExceptions);
+  EXPECT_EQ(
+      wireInfo.basePayloadSize,
+      FixedBitArray::bufferSize(
+          values.size(), GetParam().expectedBaseBitWidth));
+
+  auto encoding =
+      EncodingFactory(options).create(*pool, encodedStorage, nullptr);
+  std::vector<uint32_t> decoded(values.size());
+  encoding->materialize(static_cast<uint32_t>(decoded.size()), decoded.data());
+  EXPECT_EQ(decoded, values);
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    PforBitWidthStorageModes,
+    PforBitWidthStorageTest,
+    ::testing::Values(
+        PforBitWidthStorageParam{
+            .fixedBitWidthUseExactBits = false,
+            .expectedBaseBitWidth = 7,
+        },
+        PforBitWidthStorageParam{
+            .fixedBitWidthUseExactBits = true,
+            .expectedBaseBitWidth = 6,
+        }),
+    [](const ::testing::TestParamInfo<PforBitWidthStorageParam>& info) {
+      return info.param.fixedBitWidthUseExactBits ? "Exact" : "Rounded";
+    });
 
 TYPED_TEST(PFOREncodingTest, residualsAtBitWidthBoundary) {
   // Residuals exactly at the (1<<7)-1 = 127 boundary — verifies the

--- a/dwio/nimble/velox/VeloxWriterOptions.h
+++ b/dwio/nimble/velox/VeloxWriterOptions.h
@@ -45,6 +45,7 @@ struct VeloxWriterOptions {
   Encoding::Options buildEncodingOptions() const {
     return {
         .blockBitPackingBlockSize = blockBitPackingBlockSize,
+        .fixedBitWidthUseExactBits = fixedBitWidthUseExactBits,
         .fsstCompressionTargetRatio = fsstCompressionTargetRatio};
   }
 
@@ -156,6 +157,10 @@ struct VeloxWriterOptions {
   /// enable for production tables without consulting the Nimble team
   ///(oncall: dwios).
   uint16_t blockBitPackingBlockSize = kBlockBitPackingBlockSize;
+
+  /// When true, FOR-family payloads use the exact required bit width. When
+  /// false, FixedBitWidth and PFOR round to byte or bucket boundaries.
+  bool fixedBitWidthUseExactBits{false};
 
   /// FSST is kept only when its final encoded size is at most this fraction of
   /// the original string bytes.

--- a/dwio/nimble/velox/tests/VeloxWriterTest.cpp
+++ b/dwio/nimble/velox/tests/VeloxWriterTest.cpp
@@ -108,13 +108,24 @@ TEST_F(VeloxWriterTest, emptyFile) {
   ASSERT_FALSE(reader.next(1, result));
 }
 
-TEST_F(VeloxWriterTest, buildEncodingOptionsPropagatesFsstCompressionTarget) {
-  nimble::VeloxWriterOptions options;
-  options.fsstCompressionTargetRatio = 0.42;
+TEST_F(VeloxWriterTest, buildEncodingOptionsPropagatesEncodingOptions) {
+  {
+    const nimble::VeloxWriterOptions options;
+    const auto encodingOptions = options.buildEncodingOptions();
+    EXPECT_FALSE(encodingOptions.fixedBitWidthUseExactBits);
+  }
 
-  const auto encodingOptions = options.buildEncodingOptions();
+  for (const auto useExactBits : {false, true}) {
+    SCOPED_TRACE(fmt::format("useExactBits={}", useExactBits));
+    nimble::VeloxWriterOptions options;
+    options.fsstCompressionTargetRatio = 0.42;
+    options.fixedBitWidthUseExactBits = useExactBits;
 
-  EXPECT_DOUBLE_EQ(encodingOptions.fsstCompressionTargetRatio, 0.42);
+    const auto encodingOptions = options.buildEncodingOptions();
+
+    EXPECT_DOUBLE_EQ(encodingOptions.fsstCompressionTargetRatio, 0.42);
+    EXPECT_EQ(encodingOptions.fixedBitWidthUseExactBits, useExactBits);
+  }
 }
 
 TEST_F(VeloxWriterTest, fsstEncodingTargetControlsWriterEncoding) {


### PR DESCRIPTION
Summary:

Add `Encoding::Options::fixedBitWidthUseExactBits` and `VeloxWriterOptions::fixedBitWidthUseExactBits` for FOR-family payload sizing, defaulting to false so existing byte-/bucket-rounded behavior remains the default. When enabled, `FixedBitWidthEncoding` writes the exact required bit width, fixed-width child size estimation prices exact payloads, and `PFOREncoding` writes the exact base residual payload width after exception selection. The option is threaded through Dictionary/RLE/MainlyConstant/SparseBool/string-length/FSST estimates so selection matches writer behavior. Compatibility is preserved because these streams already store their bit width in the payload header and decoders read that self-describing field. Decode remains a tradeoff: exact 6-bit was faster than byte-rounded 8-bit in the added benchmark, while exact 9-bit was slower than byte-rounded 16-bit due to non-byte-aligned unpacking.

Differential Revision: D110723343


