### PR TITLE
fix: Make MainlyConstant common value selection deterministic (#941)

### DIFF
--- a/dwio/nimble/encodings/MainlyConstantEncoding.cpp
+++ b/dwio/nimble/encodings/MainlyConstantEncoding.cpp
@@ -52,10 +52,8 @@ std::string_view MainlyConstantEncoding<std::string_view>::encode(
     NIMBLE_INCOMPATIBLE_ENCODING("MainlyConstantEncoding cannot be empty.");
   }
 
-  const auto commonElement = std::max_element(
-      selection.statistics().uniqueCounts()->cbegin(),
-      selection.statistics().uniqueCounts()->cend(),
-      [](const auto& a, const auto& b) { return a.second < b.second; });
+  const auto& uniqueCounts = selection.statistics().uniqueCounts().value();
+  const auto commonElement = internal::mainlyConstantCommonValue(uniqueCounts);
 
   const uint32_t entryCount = values.size();
   const uint32_t uncommonCount = entryCount - commonElement->second;

--- a/dwio/nimble/encodings/MainlyConstantEncoding.h
+++ b/dwio/nimble/encodings/MainlyConstantEncoding.h
@@ -61,6 +61,25 @@
 
 namespace facebook::nimble {
 
+namespace internal {
+
+template <typename UniqueCounts>
+auto mainlyConstantCommonValue(const UniqueCounts& uniqueCounts) {
+  // Select the highest-frequency value. Break count ties by the smaller value
+  // so absl::flat_hash_map iteration order cannot affect estimates or output.
+  return std::max_element(
+      uniqueCounts.cbegin(),
+      uniqueCounts.cend(),
+      [](const auto& left, const auto& right) {
+        if (left.second != right.second) {
+          return left.second < right.second;
+        }
+        return left.first > right.first;
+      });
+}
+
+} // namespace internal
+
 // Data layout is:
 // EncodingPrefix::kFixedPrefixSize bytes: standard Encoding prefix
 // 4 bytes: num isCommon encoding bytes (X)
@@ -100,14 +119,10 @@ class MainlyConstantEncodingBase
     // uncommon value there will be an index. These indices will most likely
     // be stored bit-packed, with bit width of max(rowCount).
 
-    // Find most common item count
+    // Find most common item count.
     const auto& uniqueCounts = statistics.uniqueCounts().value();
-    const auto maxUniqueCount = std::max_element(
-        uniqueCounts.cbegin(),
-        uniqueCounts.cend(),
-        [](const auto& left, const auto& right) {
-          return left.second < right.second;
-        });
+    const auto maxUniqueCount =
+        internal::mainlyConstantCommonValue(uniqueCounts);
     // Deduce uncommon values count
     const uint64_t uncommonCount = rowCount - maxUniqueCount->second;
     // Uncommon values (sparse bool) bitmap will have index per value,
@@ -612,8 +627,6 @@ MainlyConstantEncoding<T>::MainlyConstantEncoding(
   NIMBLE_CHECK(pos == data.end(), "Unexpected mainly constant encoding end");
 }
 
-namespace internal {} // namespace internal
-
 template <typename T>
 std::string_view MainlyConstantEncoding<T>::encode(
     EncodingSelection<physicalType>& selection,
@@ -625,10 +638,8 @@ std::string_view MainlyConstantEncoding<T>::encode(
     NIMBLE_INCOMPATIBLE_ENCODING("MainlyConstantEncoding cannot be empty.");
   }
 
-  const auto commonElement = std::max_element(
-      selection.statistics().uniqueCounts().value().cbegin(),
-      selection.statistics().uniqueCounts().value().cend(),
-      [](const auto& a, const auto& b) { return a.second < b.second; });
+  const auto& uniqueCounts = selection.statistics().uniqueCounts().value();
+  const auto commonElement = internal::mainlyConstantCommonValue(uniqueCounts);
 
   const uint32_t entryCount = values.size();
   const uint32_t uncommonCount = entryCount - commonElement->second;

--- a/dwio/nimble/encodings/legacy/MainlyConstantEncoding.h
+++ b/dwio/nimble/encodings/legacy/MainlyConstantEncoding.h
@@ -350,10 +350,18 @@ std::string_view MainlyConstantEncoding<T>::encode(
     NIMBLE_INCOMPATIBLE_ENCODING("MainlyConstantEncoding cannot be empty.");
   }
 
+  // Tie-break on the value so the common value is deterministic;
+  // absl::flat_hash_map iteration order is randomized per run, which would
+  // otherwise make the encoded output vary for identical input.
   const auto commonElement = std::max_element(
       selection.statistics().uniqueCounts().value().cbegin(),
       selection.statistics().uniqueCounts().value().cend(),
-      [](const auto& a, const auto& b) { return a.second < b.second; });
+      [](const auto& a, const auto& b) {
+        if (a.second != b.second) {
+          return a.second < b.second;
+        }
+        return a.first < b.first;
+      });
 
   const uint32_t entryCount = values.size();
   const uint32_t uncommonCount = entryCount - commonElement->second;

--- a/dwio/nimble/encodings/tests/MainlyConstantEncodingTest.cpp
+++ b/dwio/nimble/encodings/tests/MainlyConstantEncodingTest.cpp
@@ -23,6 +23,7 @@
 #include "dwio/nimble/encodings/tests/TestUtils.h"
 
 #include <limits>
+#include <string>
 #include <type_traits>
 #include <vector>
 
@@ -174,6 +175,64 @@ TYPED_TEST(MainlyConstantEncodingTest, SerializeThenDeserialize) {
     EXPECT_EQ(encoding->rowCount(), rowCount);
     for (uint32_t i = 0; i < rowCount; ++i) {
       EXPECT_TRUE(nimble::NimbleCompare<D>::equals(result[i], values[i]));
+    }
+  }
+}
+
+TYPED_TEST(MainlyConstantEncodingTest, deterministicSerializationOnTie) {
+  using D = typename TypeParam::data_type;
+  const nimble::Encoding::Options options{
+      .useVarintRowCount = TypeParam::useVarint};
+
+  // 7 and 5 are tied for most-frequent (3 occurrences each). The common value
+  // is chosen via std::max_element over an absl::flat_hash_map whose iteration
+  // order is seeded per table, so each encode() below sees a differently-seeded
+  // map. The tie must be broken by value (deterministically) so that identical
+  // input always produces identical serialized bytes.
+  nimble::Vector<D> values{this->pool_.get()};
+  for (const auto value : {7, 7, 7, 5, 5, 5, 1}) {
+    values.push_back(static_cast<D>(value));
+  }
+  const uint32_t rowCount = values.size();
+
+  std::vector<velox::BufferPtr> stringBuffers;
+  const auto stringBufferFactory = [&](uint32_t totalLength) {
+    return stringBuffers
+        .emplace_back(
+            velox::AlignedBuffer::allocate<char>(
+                totalLength, this->pool_.get()))
+        ->template asMutable<void>();
+  };
+
+  // The tie-data must still round-trip to the original values.
+  auto encoding =
+      nimble::test::Encoder<nimble::MainlyConstantEncoding<D>>::createEncoding(
+          *this->buffer_,
+          values,
+          stringBufferFactory,
+          nimble::CompressionType::Uncompressed,
+          options);
+  nimble::Vector<D> result(this->pool_.get(), rowCount);
+  encoding->materialize(rowCount, result.data());
+  for (uint32_t i = 0; i < rowCount; ++i) {
+    EXPECT_TRUE(nimble::NimbleCompare<D>::equals(result[i], values[i]));
+  }
+
+  // Re-encoding the same input must yield byte-identical output regardless of
+  // per-run hash-map iteration order.
+  std::string expected;
+  constexpr int kIterations = 32;
+  for (int i = 0; i < kIterations; ++i) {
+    nimble::Buffer buffer{*this->pool_};
+    const std::string encoded{
+        nimble::test::Encoder<nimble::MainlyConstantEncoding<D>>::encode(
+            buffer, values, nimble::CompressionType::Uncompressed, options)};
+    if (i == 0) {
+      expected = encoded;
+    } else {
+      EXPECT_EQ(encoded, expected)
+          << "MainlyConstant serialization is not deterministic (iteration "
+          << i << ")";
     }
   }
 }


### PR DESCRIPTION
Summary:

CONTEXT: `MainlyConstantEncoding` selects the common value with `std::max_element` over `Statistics::uniqueCounts()`, an `absl::flat_hash_map`. abseil randomizes each table's iteration order per run (the seed comes from a thread-local variable address, randomized by ASLR), so when two values are tied for most-frequent the chosen common value — and therefore the emitted `commonValue`/`isCommon`/`otherValues` bytes and the nested encoding selected for `otherValues` — varied run to run for identical input. This made writer output non-deterministic and polluted decode-cost A/B comparisons.

WHAT: Break count ties by the value itself (`count`, then `value`) in the `std::max_element` comparator so the common value no longer depends on hash-map iteration order. Applied to `estimateSize` and `encode` in `MainlyConstantEncoding.h`, the `std::string_view` `encode` specialization in `MainlyConstantEncoding.cpp`, and the legacy `encode` in `legacy/MainlyConstantEncoding.h`. Adds `MainlyConstantEncodingTest.deterministicSerializationOnTie`, which encodes tie-data 32 times (each building a freshly seeded `flat_hash_map`) and asserts byte-identical output.

Reviewed By: duxiao1212

Differential Revision: D110378257


