### PR TITLE
perf(nimble): Reserve serialized value buffers efficiently (#942)

### DIFF
--- a/dwio/nimble/serializer/SerializationHeader.h
+++ b/dwio/nimble/serializer/SerializationHeader.h
@@ -16,13 +16,16 @@
 
 #pragma once
 
+#include <algorithm>
 #include <cstddef>
 #include <cstdint>
+#include <limits>
 #include <optional>
 #include <string>
 
 #include "dwio/nimble/common/Exceptions.h"
 #include "dwio/nimble/common/Varint.h"
+#include "dwio/nimble/common/Vector.h"
 #include "dwio/nimble/encodings/common/EncodingPrimitives.h"
 #include "dwio/nimble/serializer/Options.h"
 #include "dwio/nimble/velox/RowRange.h"
@@ -55,8 +58,38 @@ struct SerializationHeader {
 namespace detail {
 
 template <typename T>
+void reserveForAppend(T& /* buffer */, uint64_t /* requiredSize */) {}
+
+/// Reserves geometrically for Vector<char> append paths (starting at 4 KB and
+/// doubling) so repeated appends stay amortized O(1); the exact final payload
+/// size is unknown without buffering or a dry run. No-op for other buffer
+/// types.
+inline void reserveForAppend(Vector<char>& buffer, uint64_t requiredSize) {
+  constexpr uint64_t kInitialAppendCapacity = 4096;
+  constexpr uint64_t kMaxDoublingCapacity =
+      std::numeric_limits<uint64_t>::max() / 2;
+
+  if (requiredSize <= buffer.capacity()) {
+    return;
+  }
+
+  uint64_t newCapacity = buffer.capacity() == 0
+      ? std::max(kInitialAppendCapacity, requiredSize)
+      : buffer.capacity();
+  while (newCapacity < requiredSize) {
+    if (newCapacity > kMaxDoublingCapacity) {
+      newCapacity = requiredSize;
+      break;
+    }
+    newCapacity *= 2;
+  }
+  buffer.reserve(newCapacity);
+}
+
+template <typename T>
 char* extend(T& buffer, uint32_t size) {
   const auto oldSize = buffer.size();
+  reserveForAppend(buffer, oldSize + size);
   buffer.resize(oldSize + size);
   return buffer.data() + oldSize;
 }

--- a/dwio/nimble/serializer/tests/SerializationHeaderTest.cpp
+++ b/dwio/nimble/serializer/tests/SerializationHeaderTest.cpp
@@ -291,6 +291,47 @@ TabletChunkHeader roundTripTabletChunkHeader(const TabletChunkHeader& in) {
 
 // ---- SerializationHeader tests ----
 
+TEST(SerializationHeaderTest, reserveForAppendIsNoOpForOtherBuffers) {
+  std::vector<char> buffer;
+  const auto originalCapacity = buffer.capacity();
+
+  facebook::nimble::serde::detail::reserveForAppend(buffer, 1);
+
+  EXPECT_EQ(buffer.capacity(), originalCapacity);
+}
+
+TEST(SerializationHeaderTest, reserveForAppendGrowsVectorGeometrically) {
+  auto pool = facebook::velox::memory::deprecatedAddDefaultLeafMemoryPool();
+  Vector<char> buffer{pool.get()};
+  Vector<char> expectedBuffer{pool.get()};
+
+  expectedBuffer.reserve(4096);
+
+  facebook::nimble::serde::detail::reserveForAppend(buffer, 1);
+  const auto initialCapacity = buffer.capacity();
+  EXPECT_EQ(initialCapacity, expectedBuffer.capacity());
+
+  facebook::nimble::serde::detail::reserveForAppend(buffer, initialCapacity);
+  EXPECT_EQ(buffer.capacity(), initialCapacity);
+
+  expectedBuffer.reserve(initialCapacity * 2);
+  facebook::nimble::serde::detail::reserveForAppend(
+      buffer, initialCapacity + 1);
+  EXPECT_EQ(buffer.capacity(), expectedBuffer.capacity());
+}
+
+TEST(SerializationHeaderTest, reserveForAppendUsesLargeInitialSize) {
+  auto pool = facebook::velox::memory::deprecatedAddDefaultLeafMemoryPool();
+  Vector<char> buffer{pool.get()};
+  Vector<char> expectedBuffer{pool.get()};
+  constexpr uint64_t kRequiredSize = 5000;
+
+  expectedBuffer.reserve(kRequiredSize);
+  facebook::nimble::serde::detail::reserveForAppend(buffer, kRequiredSize);
+
+  EXPECT_EQ(buffer.capacity(), expectedBuffer.capacity());
+}
+
 class SerializationHeaderRoundTripTest
     : public ::testing::TestWithParam<SerializationHeaderRoundTripParam> {};
 


### PR DESCRIPTION
Summary:

Use the existing exact serialization-header size estimate to reserve known header bytes before writing, avoiding the previous 4 KB minimum allocation for tiny headers. Keep geometric growth for Vector<char> append paths where the full serialized stream payload is not known without buffering or a dry run. Add SerializationHeaderTest coverage for the Vector<char> header reservation path.

Reviewed By: xiaoxmeng

Differential Revision: D110654254


