### PR TITLE
feat: Add experimental ALP encoding support for floating-point data (#943)

### DIFF
--- a/dwio/nimble/encodings/ADDING_NEW_ENCODING.md
+++ b/dwio/nimble/encodings/ADDING_NEW_ENCODING.md
@@ -218,7 +218,7 @@ case EncodingType::MyEncoding:
 
 **File:** `dwio/nimble/encodings/selection/EncodingSizeEstimation.h`
 
-Add estimation logic to the appropriate method(s):
+Add estimation logic to the appropriate private helper(s):
 
 - `estimateNumericSize<T>()` — for numeric types
 - `estimateBoolSize()` — for bool

--- a/dwio/nimble/encodings/ALPEncoding.h
+++ b/dwio/nimble/encodings/ALPEncoding.h
@@ -15,19 +15,26 @@
  */
 #pragma once
 
+#include <algorithm>
+#include <array>
 #include <cmath>
 #include <cstring>
 #include <limits>
+#include <optional>
 #include <span>
+#include <vector>
 #include "dwio/nimble/common/Buffer.h"
 #include "dwio/nimble/common/Exceptions.h"
 #include "dwio/nimble/common/Vector.h"
+#include "dwio/nimble/encodings/FixedBitWidthEncoding.h"
+#include "dwio/nimble/encodings/TrivialEncoding.h"
 #include "dwio/nimble/encodings/common/Encoding.h"
 #include "dwio/nimble/encodings/common/EncodingFactory.h"
 #include "dwio/nimble/encodings/common/EncodingPrimitives.h"
 #include "dwio/nimble/encodings/common/EncodingType.h"
 #include "dwio/nimble/encodings/selection/EncodingIdentifier.h"
 #include "dwio/nimble/encodings/selection/EncodingSelection.h"
+#include "velox/common/encode/Coding.h"
 
 /// ALP (Adaptive Lossless floating-Point) encoding for float/double.
 ///
@@ -37,7 +44,7 @@
 ///   1 byte:  factor   (uint8)
 ///   4 bytes: exceptionCount (uint32)
 ///   4 bytes: encodedValuesSize (uint32, size of nested encoding)
-///   N bytes: nested encoding of int64 encoded values
+///   N bytes: nested encoding of ZigZag-coded signed encoded values
 ///   exceptionCount * 4 bytes: exception positions (uint32 each)
 ///   exceptionCount * sizeof(physicalType) bytes: exception values
 
@@ -45,114 +52,16 @@ namespace facebook::nimble {
 
 namespace detail::alp {
 
-/// Pre-computed powers of 10 for double precision.
-inline constexpr double kPow10Double[] = {
-    1e0,  1e1,  1e2,  1e3,  1e4,  1e5,  1e6,  1e7,  1e8,  1e9,  1e10, 1e11,
-    1e12, 1e13, 1e14, 1e15, 1e16, 1e17, 1e18, 1e19, 1e20, 1e21, 1e22, 1e23,
-};
-inline constexpr int kMaxExponent = 23;
-inline constexpr int kMaxFactor = 23;
-
-/// ALP prefix: exponent(1) + factor(1) + exceptionCount(4) +
-/// encodedValuesSize(4).
-inline constexpr int kAlpPrefixSize = 10;
-
-/// Sample up to this many values to find the best (exponent, factor) pair.
-inline constexpr uint32_t kSampleSize = 1024;
-
-/// Checks whether a double value round-trips losslessly through int64
-/// encoding with the given (exponent, factor) pair.
 template <typename FloatType>
-inline bool roundTrips(FloatType value, int exponent, int factor) {
-  double scaled = static_cast<double>(value) * kPow10Double[exponent];
-  if (scaled < static_cast<double>(std::numeric_limits<int64_t>::min()) ||
-      scaled > static_cast<double>(std::numeric_limits<int64_t>::max())) {
-    return false;
-  }
-  int64_t encoded = static_cast<int64_t>(std::llround(scaled));
-
-  double restored = static_cast<double>(encoded) / kPow10Double[exponent];
-  if (factor > 0) {
-    int64_t factored =
-        static_cast<int64_t>(std::llround(scaled / kPow10Double[factor]));
-    double fromFactored = static_cast<double>(factored) * kPow10Double[factor] /
-        kPow10Double[exponent];
-    restored = fromFactored;
-  }
-
-  return static_cast<FloatType>(restored) == value;
+inline FloatType toLogical(
+    typename TypeTraits<FloatType>::physicalType physicalValue) {
+  return EncodingPhysicalType<FloatType>::asEncodingLogicalType(physicalValue);
 }
 
-/// Finds the best (exponent, factor) pair that maximizes round-trip success
-/// rate on the given sample.
 template <typename FloatType>
-inline std::pair<uint8_t, uint8_t> findBestExponentFactor(
-    std::span<const FloatType> values) {
-  uint32_t sampleSize =
-      std::min(static_cast<uint32_t>(values.size()), kSampleSize);
-
-  uint8_t bestE = 0;
-  uint8_t bestF = 0;
-  uint32_t bestCount = 0;
-
-  for (int e = 0; e <= kMaxExponent; ++e) {
-    uint32_t countNoFactor = 0;
-    for (uint32_t i = 0; i < sampleSize; ++i) {
-      if (roundTrips(values[i], e, /*factor=*/0)) {
-        ++countNoFactor;
-      }
-    }
-    if (countNoFactor > bestCount) {
-      bestCount = countNoFactor;
-      bestE = static_cast<uint8_t>(e);
-      bestF = 0;
-    }
-    if (bestCount == sampleSize) {
-      break;
-    }
-
-    for (int f = 1; f <= std::min(e, kMaxFactor); ++f) {
-      uint32_t countWithFactor = 0;
-      for (uint32_t i = 0; i < sampleSize; ++i) {
-        if (roundTrips(values[i], e, f)) {
-          ++countWithFactor;
-        }
-      }
-      if (countWithFactor > bestCount) {
-        bestCount = countWithFactor;
-        bestE = static_cast<uint8_t>(e);
-        bestF = static_cast<uint8_t>(f);
-      }
-      if (bestCount == sampleSize) {
-        break;
-      }
-    }
-    if (bestCount == sampleSize) {
-      break;
-    }
-  }
-  return {bestE, bestF};
-}
-
-/// Encodes a single value with the given (exponent, factor) pair.
-inline int64_t encodeValue(double value, int exponent, int factor) {
-  double scaled = value * kPow10Double[exponent];
-  if (factor > 0) {
-    return static_cast<int64_t>(std::llround(scaled / kPow10Double[factor]));
-  }
-  return static_cast<int64_t>(std::llround(scaled));
-}
-
-/// Decodes a single encoded integer back to a floating-point value.
-template <typename FloatType>
-inline FloatType decodeValue(int64_t encoded, int exponent, int factor) {
-  if (factor > 0) {
-    return static_cast<FloatType>(
-        static_cast<double>(encoded) * kPow10Double[factor] /
-        kPow10Double[exponent]);
-  }
-  return static_cast<FloatType>(
-      static_cast<double>(encoded) / kPow10Double[exponent]);
+inline typename TypeTraits<FloatType>::physicalType toPhysical(
+    FloatType logicalValue) {
+  return EncodingPhysicalType<FloatType>::asEncodingPhysicalType(logicalValue);
 }
 
 } // namespace detail::alp
@@ -182,11 +91,11 @@ class ALPEncoding final
     const uint32_t encodedValuesSize = encoding::readUint32(pos);
 
     const EncodingFactory encodingFactory(options);
-    auto nullStringBufferFactory = [](uint32_t) -> void* { return nullptr; };
+    auto noStringBufferFactory = [](uint32_t) -> void* { return nullptr; };
     encodedValuesEncoding_ = encodingFactory.create(
         *this->pool_,
         std::string_view(pos, encodedValuesSize),
-        nullStringBufferFactory);
+        noStringBufferFactory);
     pos += encodedValuesSize;
 
     exceptionPositions_ = pos;
@@ -209,11 +118,12 @@ class ALPEncoding final
   void materialize(uint32_t rowCount, void* buffer) final {
     auto* output = static_cast<physicalType*>(buffer);
     for (uint32_t i = 0; i < rowCount; ++i) {
-      output[i] = detail::alp::decodeValue<physicalType>(
-          static_cast<int64_t>(encodedBuffer_[pos_ + i]), exponent_, factor_);
+      const auto encoded = velox::ZigZag::decode(encodedBuffer_[pos_ + i]);
+      output[i] = detail::alp::toPhysical<cppDataType>(
+          decodeValue(encoded, exponent_, factor_));
     }
 
-    patchExceptions(output, pos_, rowCount);
+    patchExceptions(pos_, rowCount, output);
     pos_ += rowCount;
   }
 
@@ -228,15 +138,10 @@ class ALPEncoding final
   void readWithVisitor(DecoderVisitor& visitor, ReadWithVisitorParams& params) {
     auto skipFn = [&](auto toSkip) { pos_ += toSkip; };
     auto decodeFn = [&] {
-      physicalType value = detail::alp::decodeValue<physicalType>(
-          static_cast<int64_t>(encodedBuffer_[pos_]), exponent_, factor_);
-      auto exPos = reinterpret_cast<const uint32_t*>(exceptionPositions_);
-      auto exVals = reinterpret_cast<const physicalType*>(exceptionValues_);
-      for (uint32_t e = 0; e < exceptionCount_; ++e) {
-        if (exPos[e] == pos_) {
-          value = exVals[e];
-          break;
-        }
+      physicalType value = detail::alp::toPhysical<cppDataType>(decodeValue(
+          velox::ZigZag::decode(encodedBuffer_[pos_]), exponent_, factor_));
+      if (const auto* exceptionValue = findException(pos_)) {
+        value = *exceptionValue;
       }
       ++pos_;
       return value;
@@ -248,8 +153,8 @@ class ALPEncoding final
     return fmt::format(
         "{}{}<{}> rowCount={} exponent={} factor={} exceptions={}",
         std::string(offset, ' '),
-        toString(this->encodingType()),
-        toString(this->dataType()),
+        this->encodingType(),
+        this->dataType(),
         this->rowCount(),
         exponent_,
         factor_,
@@ -267,30 +172,37 @@ class ALPEncoding final
     }
 
     const uint32_t rowCount = values.size();
+    auto* pool = &buffer.getMemoryPool();
 
-    auto [exponent, factor] =
-        detail::alp::findBestExponentFactor<physicalType>(values);
+    Vector<cppDataType> logicalValues(pool, rowCount);
+    for (uint32_t i = 0; i < rowCount; ++i) {
+      logicalValues[i] = detail::alp::toLogical<cppDataType>(values[i]);
+    }
 
-    Vector<uint64_t> encodedValues(&buffer.getMemoryPool(), rowCount);
-    Vector<uint32_t> exceptionPositions(&buffer.getMemoryPool());
-    Vector<physicalType> exceptionValues(&buffer.getMemoryPool());
+    const auto [exponent, factor] = findBestExponentFactor(
+        std::span<const cppDataType>{
+            logicalValues.data(), logicalValues.size()});
+
+    Vector<uint64_t> encodedValues(pool, rowCount);
+    Vector<uint32_t> exceptionPositions(pool);
+    Vector<physicalType> exceptionValues(pool);
 
     for (uint32_t i = 0; i < rowCount; ++i) {
-      int64_t encoded = detail::alp::encodeValue(
-          static_cast<double>(values[i]), exponent, factor);
-      encodedValues[i] = static_cast<uint64_t>(encoded);
-
-      physicalType restored =
-          detail::alp::decodeValue<physicalType>(encoded, exponent, factor);
-      if (restored != values[i]) {
+      if (!canRepresentExactly(logicalValues[i], values[i], exponent, factor)) {
+        encodedValues[i] = 0;
         exceptionPositions.push_back(i);
         exceptionValues.push_back(values[i]);
+        continue;
       }
+
+      const auto encoded =
+          encodeValue(static_cast<double>(logicalValues[i]), exponent, factor);
+      encodedValues[i] = velox::ZigZag::encode(encoded);
     }
 
     const uint32_t exceptionCount = exceptionPositions.size();
 
-    Buffer tempBuffer{buffer.getMemoryPool()};
+    Buffer tempBuffer{*pool};
     std::string_view serializedEncoded =
         selection.template encodeNested<uint64_t>(
             EncodingIdentifiers::ALP::EncodedValues,
@@ -301,9 +213,8 @@ class ALPEncoding final
     const uint32_t exceptionPositionsSize = exceptionCount * sizeof(uint32_t);
     const uint32_t exceptionValuesSize = exceptionCount * sizeof(physicalType);
     const uint32_t encodingSize =
-        Encoding::serializePrefixSize(rowCount, useVarint) +
-        detail::alp::kAlpPrefixSize + serializedEncoded.size() +
-        exceptionPositionsSize + exceptionValuesSize;
+        Encoding::serializePrefixSize(rowCount, useVarint) + kAlpPrefixSize +
+        serializedEncoded.size() + exceptionPositionsSize + exceptionValuesSize;
 
     char* reserved = buffer.reserve(encodingSize);
     char* pos = reserved;
@@ -323,11 +234,214 @@ class ALPEncoding final
       pos += exceptionValuesSize;
     }
 
-    NIMBLE_DCHECK_EQ(encodingSize, pos - reserved, "Encoding size mismatch.");
+    NIMBLE_CHECK_EQ(encodingSize, pos - reserved, "Encoding size mismatch.");
     return {reserved, encodingSize};
   }
 
+  static std::optional<uint64_t> estimateSize(
+      std::span<const physicalType> values,
+      const Encoding::Options& options = {}) {
+    if (values.empty()) {
+      return std::nullopt;
+    }
+
+    const uint64_t rowCount = values.size();
+    const uint32_t sampleSize =
+        std::min(static_cast<uint32_t>(rowCount), kSampleSize);
+
+    std::vector<cppDataType> logicalValues;
+    logicalValues.reserve(sampleSize);
+    std::vector<physicalType> sampledValues;
+    sampledValues.reserve(sampleSize);
+    for (uint32_t i = 0; i < sampleSize; ++i) {
+      const auto value = values[sampledValueIndex(i, rowCount, sampleSize)];
+      logicalValues.push_back(detail::alp::toLogical<cppDataType>(value));
+      sampledValues.push_back(value);
+    }
+
+    const auto [exponent, factor] = findBestExponentFactor(
+        std::span<const cppDataType>{
+            logicalValues.data(), logicalValues.size()});
+
+    std::vector<uint64_t> encodedValues;
+    encodedValues.reserve(sampleSize);
+    uint64_t sampleExceptionCount{0};
+    for (auto i = 0; i < sampleSize; ++i) {
+      if (!canRepresentExactly(
+              logicalValues[i], sampledValues[i], exponent, factor)) {
+        encodedValues.push_back(0);
+        ++sampleExceptionCount;
+        continue;
+      }
+
+      const auto encoded =
+          encodeValue(static_cast<double>(logicalValues[i]), exponent, factor);
+      encodedValues.push_back(velox::ZigZag::encode(encoded));
+    }
+
+    const auto encodedStats = Statistics<uint64_t>::create(
+        std::span<const uint64_t>{encodedValues.data(), encodedValues.size()});
+    // Match existing nested-stream estimators: use FixedBitWidth as a simple
+    // representative estimate instead of recursively modeling nested selection.
+    const uint64_t nestedEncodedValuesSize =
+        FixedBitWidthEncoding<uint64_t>::estimateSize(
+            rowCount, encodedStats, options);
+    const uint64_t exceptionCount =
+        (sampleExceptionCount * rowCount + sampleSize - 1) / sampleSize;
+    const uint64_t exceptionPositionsSize = exceptionCount * sizeof(uint32_t);
+    const uint64_t exceptionValuesSize = exceptionCount * sizeof(physicalType);
+    return Encoding::serializePrefixSize(
+               static_cast<uint32_t>(rowCount), options.useVarintRowCount) +
+        kAlpPrefixSize + nestedEncodedValuesSize + exceptionPositionsSize +
+        exceptionValuesSize;
+  }
+
  private:
+  // Pre-computed powers of 10 for double precision.
+  static constexpr std::array<double, 24> kPow10Double{
+      1e0,  1e1,  1e2,  1e3,  1e4,  1e5,  1e6,  1e7,  1e8,  1e9,  1e10, 1e11,
+      1e12, 1e13, 1e14, 1e15, 1e16, 1e17, 1e18, 1e19, 1e20, 1e21, 1e22, 1e23};
+  // Largest exponent and factor values backed by kPow10Double.
+  static constexpr int kMaxExponent{23};
+  static constexpr int kMaxFactor{23};
+  // ALP prefix: exponent(1) + factor(1) + exceptionCount(4) +
+  // encodedValuesSize(4).
+  static constexpr int kAlpPrefixSize{10};
+  // Sample up to this many values to find the best (exponent, factor) pair.
+  static constexpr uint32_t kSampleSize{1024};
+
+  // Maps a dense sample ordinal to an evenly spaced input row.
+  static uint64_t sampledValueIndex(
+      uint32_t sampleIndex,
+      uint64_t rowCount,
+      uint32_t sampleSize) {
+    return sampleIndex * rowCount / sampleSize;
+  }
+
+  // Checks whether the selected ALP transform can encode the value without an
+  // exception.
+  static bool canRepresentExactly(
+      cppDataType value,
+      physicalType physicalValue,
+      int exponent,
+      int factor) {
+    const double exponentMultiplier = kPow10Double[exponent];
+    const double factorMultiplier = kPow10Double[factor];
+    const double scaled = static_cast<double>(value) * exponentMultiplier;
+    if (!std::isfinite(scaled)) {
+      return false;
+    }
+    if (scaled < static_cast<double>(std::numeric_limits<int64_t>::min()) ||
+        scaled > static_cast<double>(std::numeric_limits<int64_t>::max())) {
+      return false;
+    }
+    const int64_t factored =
+        static_cast<int64_t>(std::llround(scaled / factorMultiplier));
+    const double restored =
+        static_cast<double>(factored) * factorMultiplier / exponentMultiplier;
+
+    return detail::alp::toPhysical<cppDataType>(
+               static_cast<cppDataType>(restored)) == physicalValue;
+  }
+
+  // Selects the sampled (exponent, factor) pair that preserves the most values.
+  static std::pair<uint8_t, uint8_t> findBestExponentFactor(
+      std::span<const cppDataType> values) {
+    const uint32_t sampleSize =
+        std::min(static_cast<uint32_t>(values.size()), kSampleSize);
+
+    uint8_t bestExponent = 0;
+    uint8_t bestFactor = 0;
+    uint32_t bestRepresentableCount = 0;
+
+    for (int e = 0; e <= kMaxExponent; ++e) {
+      uint32_t countNoFactor = 0;
+      for (uint32_t i = 0; i < sampleSize; ++i) {
+        if (canRepresentExactly(
+                values[i],
+                detail::alp::toPhysical<cppDataType>(values[i]),
+                e,
+                /*factor=*/0)) {
+          ++countNoFactor;
+        }
+      }
+      if (countNoFactor > bestRepresentableCount) {
+        bestRepresentableCount = countNoFactor;
+        bestExponent = static_cast<uint8_t>(e);
+        bestFactor = 0;
+      }
+      if (bestRepresentableCount == sampleSize) {
+        break;
+      }
+
+      for (int f = 1; f <= std::min(e, kMaxFactor); ++f) {
+        uint32_t countWithFactor = 0;
+        for (uint32_t i = 0; i < sampleSize; ++i) {
+          if (canRepresentExactly(
+                  values[i],
+                  detail::alp::toPhysical<cppDataType>(values[i]),
+                  e,
+                  f)) {
+            ++countWithFactor;
+          }
+        }
+        if (countWithFactor > bestRepresentableCount) {
+          bestRepresentableCount = countWithFactor;
+          bestExponent = static_cast<uint8_t>(e);
+          bestFactor = static_cast<uint8_t>(f);
+        }
+        if (bestRepresentableCount == sampleSize) {
+          break;
+        }
+      }
+      if (bestRepresentableCount == sampleSize) {
+        break;
+      }
+    }
+    return {bestExponent, bestFactor};
+  }
+
+  // Converts a floating-point value to the integer stored by ALP.
+  static int64_t encodeValue(double value, int exponent, int factor) {
+    const double scaled = value * kPow10Double[exponent];
+    return static_cast<int64_t>(std::llround(scaled / kPow10Double[factor]));
+  }
+
+  // Reconstructs a floating-point value from an ALP integer.
+  static cppDataType decodeValue(int64_t encoded, int exponent, int factor) {
+    return static_cast<cppDataType>(
+        static_cast<double>(encoded) * kPow10Double[factor] /
+        kPow10Double[exponent]);
+  }
+
+  void
+  patchExceptions(uint32_t startRow, uint32_t rowCount, physicalType* output) {
+    const auto* exPos = reinterpret_cast<const uint32_t*>(exceptionPositions_);
+    const auto* exVals =
+        reinterpret_cast<const physicalType*>(exceptionValues_);
+    const auto* exBegin = exPos;
+    const auto* exEnd = exPos + exceptionCount_;
+    const auto* first = std::lower_bound(exBegin, exEnd, startRow);
+    const auto* last = std::lower_bound(first, exEnd, startRow + rowCount);
+    for (auto* it = first; it != last; ++it) {
+      const uint32_t absPos = *it;
+      output[absPos - startRow] = exVals[it - exBegin];
+    }
+  }
+
+  const physicalType* findException(uint32_t row) const {
+    const auto* exPos = reinterpret_cast<const uint32_t*>(exceptionPositions_);
+    const auto* exVals =
+        reinterpret_cast<const physicalType*>(exceptionValues_);
+    const auto* exBegin = exPos;
+    const auto* exEnd = exPos + exceptionCount_;
+    const auto* it = std::lower_bound(exBegin, exEnd, row);
+    if (it == exEnd || *it != row) {
+      return nullptr;
+    }
+    return exVals + (it - exBegin);
+  }
+
   uint8_t exponent_;
   uint8_t factor_;
   uint32_t exceptionCount_;
@@ -336,18 +450,6 @@ class ALPEncoding final
   const char* exceptionValues_;
   std::vector<uint64_t> encodedBuffer_;
   uint32_t pos_;
-
-  void
-  patchExceptions(physicalType* output, uint32_t startRow, uint32_t rowCount) {
-    auto exPos = reinterpret_cast<const uint32_t*>(exceptionPositions_);
-    auto exVals = reinterpret_cast<const physicalType*>(exceptionValues_);
-    for (uint32_t e = 0; e < exceptionCount_; ++e) {
-      uint32_t absPos = exPos[e];
-      if (absPos >= startRow && absPos < startRow + rowCount) {
-        output[absPos - startRow] = exVals[e];
-      }
-    }
-  }
 };
 
 } // namespace facebook::nimble

--- a/dwio/nimble/encodings/DictionaryEncoding.h
+++ b/dwio/nimble/encodings/DictionaryEncoding.h
@@ -144,6 +144,12 @@ class DictionaryEncoding
   }
 
  private:
+  static std::string_view encodeAlphabet(
+      EncodingSelection<physicalType>& selection,
+      const Vector<physicalType>& alphabet,
+      Buffer& buffer,
+      const Encoding::Options& options);
+
   uint32_t* ensureIndicesBuffer(uint32_t numElements) {
     const auto bytes = numElements * sizeof(uint32_t);
     if (indicesBuffer_ == nullptr || indicesBuffer_->capacity() < bytes) {
@@ -329,6 +335,38 @@ void DictionaryEncoding<T>::readIndicesWithVisitor(
 }
 
 template <typename T>
+std::string_view DictionaryEncoding<T>::encodeAlphabet(
+    EncodingSelection<physicalType>& selection,
+    const Vector<physicalType>& alphabet,
+    Buffer& buffer,
+    const Encoding::Options& options) {
+  if constexpr (isFloatingPointType<T>()) {
+    Vector<T> logicalAlphabet{&buffer.getMemoryPool()};
+    logicalAlphabet.resize(alphabet.size());
+    for (uint32_t i = 0; i < alphabet.size(); ++i) {
+      logicalAlphabet[i] =
+          EncodingPhysicalType<T>::asEncodingLogicalType(alphabet[i]);
+    }
+
+    auto nestedPolicy = std::unique_ptr<EncodingSelectionPolicy<T>>(
+        static_cast<EncodingSelectionPolicy<T>*>(
+            selection
+                .template createNestedPolicy<T>(
+                    selection.encodingType(),
+                    EncodingIdentifiers::Dictionary::Alphabet)
+                .release()));
+    return EncodingFactory::encode<T>(
+        std::move(nestedPolicy),
+        std::span<const T>{logicalAlphabet.data(), logicalAlphabet.size()},
+        buffer,
+        options);
+  } else {
+    return selection.template encodeNested<physicalType>(
+        EncodingIdentifiers::Dictionary::Alphabet, {alphabet}, buffer, options);
+  }
+}
+
+template <typename T>
 std::string_view DictionaryEncoding<T>::encode(
     EncodingSelection<physicalType>& selection,
     std::span<const physicalType> values,
@@ -401,11 +439,7 @@ std::string_view DictionaryEncoding<T>::encode(
 
   Buffer tempBuffer{buffer.getMemoryPool()};
   std::string_view serializedAlphabet =
-      selection.template encodeNested<physicalType>(
-          EncodingIdentifiers::Dictionary::Alphabet,
-          {alphabet},
-          tempBuffer,
-          options);
+      encodeAlphabet(selection, alphabet, tempBuffer, options);
   std::string_view serializedIndices =
       selection.template encodeNested<uint32_t>(
           EncodingIdentifiers::Dictionary::Indices,

--- a/dwio/nimble/encodings/FsstEncoding.cpp
+++ b/dwio/nimble/encodings/FsstEncoding.cpp
@@ -64,7 +64,7 @@ class TrivialFallbackSelectionPolicy final
   EncodingSelectionResult select(
       std::span<const std::string_view> /* values */,
       const Statistics<std::string_view>& /* statistics */,
-      const Encoding::Options& /* options */ = {}) override {
+      const Encoding::Options& /* options */) override {
     return trivialSelectionResult();
   }
 
@@ -72,7 +72,7 @@ class TrivialFallbackSelectionPolicy final
       std::span<const std::string_view> /* values */,
       std::span<const bool> /* nulls */,
       const Statistics<std::string_view>& /* statistics */,
-      const Encoding::Options& /* options */ = {}) override {
+      const Encoding::Options& /* options */) override {
     NIMBLE_UNSUPPORTED("Nullable FSST fallback is not supported.");
   }
 
@@ -221,7 +221,7 @@ std::string_view FsstEncoding::encodeTrivialFallback(
   auto fallbackPolicy = std::make_unique<TrivialFallbackSelectionPolicy>(
       selection, compressionPolicy);
   EncodingSelection<std::string_view> fallbackSelection{
-      fallbackPolicy->select(values, selection.statistics()),
+      fallbackPolicy->select(values, selection.statistics(), options),
       Statistics<std::string_view>{selection.statistics()},
       std::move(fallbackPolicy)};
   return TrivialEncoding<std::string_view>::encode(

--- a/dwio/nimble/encodings/common/Encoding.h
+++ b/dwio/nimble/encodings/common/Encoding.h
@@ -139,6 +139,11 @@ class Encoding {
     /// false, FixedBitWidth and PFOR round to byte or bucket boundaries.
     bool fixedBitWidthUseExactBits{false};
 
+    /// EXPERIMENTATION: Allows ALP to participate in nested floating-point
+    /// encoding selection. False by default; do not enable for production
+    /// until ALP is production-ready.
+    bool allowNestedAlpSelection{false};
+
     /// Per-column decoding statistics for timing decompression.
     velox::dwio::common::DecodingStats* decodingStats = nullptr;
 

--- a/dwio/nimble/encodings/common/EncodingFactory.cpp
+++ b/dwio/nimble/encodings/common/EncodingFactory.cpp
@@ -20,11 +20,6 @@
 #include "dwio/nimble/encodings/DeltaEncoding.h"
 #include "dwio/nimble/encodings/DictionaryEncoding.h"
 #include "dwio/nimble/encodings/FixedBitWidthEncoding.h"
-// FOR and FrequencyPartition integration commented out (disabled):
-/*
-#include "dwio/nimble/encodings/ForEncoding.h"
-#include "dwio/nimble/encodings/FrequencyPartitionEncoding.h"
-*/
 #include "dwio/nimble/encodings/FsstEncoding.h"
 #include "dwio/nimble/encodings/MainlyConstantEncoding.h"
 #include "dwio/nimble/encodings/NullableEncoding.h"
@@ -33,12 +28,6 @@
 #include "dwio/nimble/encodings/RLEEncoding.h"
 #include "dwio/nimble/encodings/SimdForBitpackEncoding.h"
 #include "dwio/nimble/encodings/SparseBoolEncoding.h"
-// SubIntSplit integration commented out (disabled):
-/*
-#ifdef NIMBLE_ENABLE_EXPERIMENTAL_ENCODINGS
-#include "dwio/nimble/encodings/SubIntSplitEncoding.h"
-#endif
-*/
 #include "dwio/nimble/encodings/TrivialEncoding.h"
 #include "dwio/nimble/encodings/VarintEncoding.h"
 #include "dwio/nimble/encodings/selection/EncodingSelection.h"
@@ -299,9 +288,18 @@ std::unique_ptr<Encoding> EncodingFactory::create(
       RETURN_ENCODING_BY_NUMERIC_TYPE(DeltaEncoding, dataType);
     }
     case EncodingType::ALP: {
-      // TODO: Wire up ALPEncoding deserialization once the actual ALP algorithm
-      // is implemented. ALP only supports float and double.
-      NIMBLE_UNSUPPORTED("ALP encoding is not yet implemented.");
+      switch (dataType) {
+        case DataType::Float:
+          return std::make_unique<ALPEncoding<float>>(
+              pool, data, stringBufferFactory, options);
+        case DataType::Double:
+          return std::make_unique<ALPEncoding<double>>(
+              pool, data, stringBufferFactory, options);
+        default:
+          NIMBLE_INCOMPATIBLE_ENCODING(
+              "ALP encoding only supports float and double data types, got {}.",
+              dataType);
+      }
     }
     case EncodingType::BlockBitPacking: {
       RETURN_ENCODING_BY_NUMERIC_TYPE(BlockBitPackingEncoding, dataType);
@@ -312,25 +310,6 @@ std::unique_ptr<Encoding> EncodingFactory::create(
     case EncodingType::SimdForBitpack: {
       RETURN_ENCODING_BY_NUMERIC_TYPE(SimdForBitpackEncoding, dataType);
     }
-    // SubIntSplit integration commented out (disabled):
-    /*
-#ifdef NIMBLE_ENABLE_EXPERIMENTAL_ENCODINGS
-    case EncodingType::SubIntSplit: {
-      RETURN_ENCODING_BY_VARINT_TYPE(SubIntSplitEncoding, dataType);
-    }
-#endif
-    */
-    // FOR and FrequencyPartition integration commented out (disabled):
-    /*
-#ifdef NIMBLE_ENABLE_EXPERIMENTAL_ENCODINGS
-    case EncodingType::FOR: {
-      RETURN_ENCODING_BY_INTEGER_TYPE(ForEncoding, dataType);
-    }
-    case EncodingType::FrequencyPartition: {
-      RETURN_ENCODING_BY_NON_BOOL_TYPE(FrequencyPartitionEncoding, dataType);
-    }
-#endif
-    */
     default: {
       NIMBLE_UNREACHABLE(
           "Trying to deserialize invalid EncodingType:{} -- garbage input?",
@@ -419,10 +398,9 @@ std::string_view EncodingFactory::encode(
       if constexpr (isNumericType<physicalType>()) {
         return FixedBitWidthEncoding<T>::encode(
             selection, castedValues, buffer, options);
-      } else {
-        NIMBLE_INCOMPATIBLE_ENCODING(
-            "FixedBitWidth encoding should not be selected for non-numeric data types.");
       }
+      NIMBLE_INCOMPATIBLE_ENCODING(
+          "FixedBitWidth encoding should not be selected for non-numeric data types.");
     }
     case EncodingType::Varint: {
       // TODO: we can support floating point types, but currently Statistics
@@ -434,130 +412,86 @@ std::string_view EncodingFactory::encode(
           (sizeof(physicalType) == 4 || sizeof(T) == 8)) {
         return VarintEncoding<T>::encode(
             selection, castedValues, buffer, options);
-      } else {
-        NIMBLE_INCOMPATIBLE_ENCODING(
-            "Varint encoding can only be selected for large numeric data types.");
       }
+      NIMBLE_INCOMPATIBLE_ENCODING(
+          "Varint encoding can only be selected for large numeric data types.");
     }
     case EncodingType::MainlyConstant: {
-      if constexpr (std::is_same<T, bool>::value) {
-        NIMBLE_INCOMPATIBLE_ENCODING(
-            "MainlyConstant encoding should not be selected for bool data types.");
-      } else {
+      if constexpr (!std::is_same<T, bool>::value) {
         return MainlyConstantEncoding<T>::encode(
             selection, castedValues, buffer, options);
       }
+      NIMBLE_INCOMPATIBLE_ENCODING(
+          "MainlyConstant encoding should not be selected for bool data types.");
     }
-    // FOR and FrequencyPartition integration commented out (disabled):
-    /*
-#ifdef NIMBLE_ENABLE_EXPERIMENTAL_ENCODINGS
-    case EncodingType::FrequencyPartition: {
-      if constexpr (std::is_same<T, bool>::value) {
-        NIMBLE_INCOMPATIBLE_ENCODING(
-            "FrequencyPartition encoding should not be selected for bool data
-types."); } else { return FrequencyPartitionEncoding<T>::encode( selection,
-castedValues, buffer, options);
-      }
-    }
-    case EncodingType::FOR: {
-      if constexpr (
-          std::is_integral<physicalType>::value &&
-          !std::is_same<T, bool>::value) {
-        return ForEncoding<T>::encode(selection, castedValues, buffer, options);
-      } else {
-        NIMBLE_INCOMPATIBLE_ENCODING(
-            "For encoding can only be selected for integral data types (not
-bool).");
-      }
-    }
-#endif
-    */
     case EncodingType::SparseBool: {
-      if constexpr (!std::is_same<T, bool>::value) {
-        NIMBLE_INCOMPATIBLE_ENCODING(
-            "SparseBool encoding should not be selected for non-bool data types.");
-      } else {
+      if constexpr (std::is_same<T, bool>::value) {
         return SparseBoolEncoding::encode(
             selection, castedValues, buffer, options);
       }
+      NIMBLE_INCOMPATIBLE_ENCODING(
+          "SparseBool encoding should not be selected for non-bool data types.");
     }
     case EncodingType::Prefix: {
-      if constexpr (!std::is_same<T, std::string_view>::value) {
-        NIMBLE_INCOMPATIBLE_ENCODING(
-            "Prefix encoding should only be selected for string_view data types.");
-      } else {
+      if constexpr (std::is_same<T, std::string_view>::value) {
         return PrefixEncoding::encode(selection, castedValues, buffer, options);
       }
+      NIMBLE_INCOMPATIBLE_ENCODING(
+          "Prefix encoding should only be selected for string_view data types.");
     }
     case EncodingType::Fsst: {
-      if constexpr (!std::is_same<T, std::string_view>::value) {
-        NIMBLE_INCOMPATIBLE_ENCODING(
-            "Fsst encoding should only be selected for string_view data types.");
-      } else {
+      if constexpr (std::is_same<T, std::string_view>::value) {
         return FsstEncoding::encode(selection, castedValues, buffer, options);
       }
+      NIMBLE_INCOMPATIBLE_ENCODING(
+          "Fsst encoding should only be selected for string_view data types.");
     }
     case EncodingType::Delta: {
       if constexpr (isNumericType<physicalType>()) {
         return DeltaEncoding<T>::encode(
             selection, castedValues, buffer, options);
-      } else {
-        NIMBLE_INCOMPATIBLE_ENCODING(
-            "Delta encoding should not be selected for non-numeric data type: {}.",
-            toString(TypeTraits<T>::dataType));
       }
+      NIMBLE_INCOMPATIBLE_ENCODING(
+          "Delta encoding should not be selected for non-numeric data type: {}.",
+          TypeTraits<T>::dataType);
     }
     case EncodingType::ALP: {
-      NIMBLE_UNSUPPORTED("ALP encoding is not yet implemented.");
+      if constexpr (isFloatingPointType<T>()) {
+        return ALPEncoding<T>::encode(selection, castedValues, buffer, options);
+      }
+      NIMBLE_INCOMPATIBLE_ENCODING(
+          "ALP encoding should only be selected for float or double data types, got {}.",
+          TypeTraits<T>::dataType);
     }
     case EncodingType::BlockBitPacking: {
       if constexpr (isNumericType<physicalType>()) {
         return BlockBitPackingEncoding<T>::encode(
             selection, castedValues, buffer, options);
-      } else {
-        NIMBLE_INCOMPATIBLE_ENCODING(
-            "BlockBitPacking encoding should not be selected for non-numeric data types.");
       }
+      NIMBLE_INCOMPATIBLE_ENCODING(
+          "BlockBitPacking encoding should not be selected for non-numeric data types.");
     }
     case EncodingType::PFOR: {
       if constexpr (isIntegralType<physicalType>()) {
         return PFOREncoding<T>::encode(
             selection, castedValues, buffer, options);
-      } else {
-        NIMBLE_INCOMPATIBLE_ENCODING(
-            "PFOR encoding should not be selected for non-integral data type: {}.",
-            toString(TypeTraits<T>::dataType));
       }
+      NIMBLE_INCOMPATIBLE_ENCODING(
+          "PFOR encoding should not be selected for non-integral data type: {}.",
+          TypeTraits<T>::dataType);
     }
     case EncodingType::SimdForBitpack: {
       if constexpr (isIntegralType<physicalType>()) {
         return SimdForBitpackEncoding<T>::encode(
             selection, castedValues, buffer, options);
-      } else {
-        NIMBLE_INCOMPATIBLE_ENCODING(
-            "SimdForBitpack encoding only supports integral data types, got {}.",
-            TypeTraits<T>::dataType);
       }
+      NIMBLE_INCOMPATIBLE_ENCODING(
+          "SimdForBitpack encoding only supports integral data types, got {}.",
+          TypeTraits<T>::dataType);
     }
-    // SubIntSplit integration commented out (disabled):
-    /*
-#ifdef NIMBLE_ENABLE_EXPERIMENTAL_ENCODINGS
-    case EncodingType::SubIntSplit: {
-      if constexpr (
-          isNumericType<physicalType>() &&
-          (sizeof(physicalType) == 4 || sizeof(physicalType) == 8)) {
-        return SubIntSplitEncoding<T>::encode(
-            selection, castedValues, buffer, options);
-      } else {
-        NIMBLE_INCOMPATIBLE_ENCODING(
-            "SubIntSplit encoding only supports 32- and 64-bit numeric types.");
-      }
-    }
-#endif
-    */
     default: {
       NIMBLE_UNSUPPORTED(
-          "Encoding {} is not supported.", toString(selection.encodingType()));
+          "Encoding {} is not supported.", selection.encodingType());
     }
   }
 }
@@ -578,7 +512,7 @@ std::string_view EncodingFactory::encodeNullable(
     default: {
       NIMBLE_UNSUPPORTED(
           "Encoding {} is not supported for nullable data.",
-          toString(selection.encodingType()));
+          selection.encodingType());
     }
   }
 }

--- a/dwio/nimble/encodings/common/EncodingLayout.cpp
+++ b/dwio/nimble/encodings/common/EncodingLayout.cpp
@@ -14,14 +14,10 @@
  * limitations under the License.
  */
 #include "dwio/nimble/encodings/common/EncodingLayout.h"
-#include <algorithm>
 #include <cstdint>
-#include <limits>
 #include <memory>
 #include <vector>
 #include "dwio/nimble/common/Exceptions.h"
-// SubIntSplit integration commented out (disabled):
-// #include "dwio/nimble/encodings/SubIntSplitConfig.h"
 #include "dwio/nimble/encodings/FsstEncoding.h"
 #include "dwio/nimble/encodings/common/EncodingPrimitives.h"
 #include "dwio/nimble/encodings/common/EncodingUtils.h"
@@ -30,98 +26,6 @@ namespace facebook::nimble {
 
 namespace {
 constexpr uint32_t kMinEncodingLayoutBufferSize = 5;
-
-// SubIntSplit is currently the only encoding that populates an encoding config.
-// These helpers serialize/deserialize that config (extra-data). The call sites
-// are currently commented out, so the functions are marked [[maybe_unused]].
-[[maybe_unused]] uint32_t serializedConfigSize(
-    const EncodingLayout::Config& config) {
-  if (config.values().empty()) {
-    return 0;
-  }
-
-  uint32_t size = sizeof(uint16_t);
-  for (const auto& [key, value] : config.values()) {
-    size += sizeof(uint16_t) + static_cast<uint32_t>(key.size());
-    size += sizeof(uint16_t) + static_cast<uint32_t>(value.size());
-  }
-  NIMBLE_CHECK_LE(
-      size,
-      std::numeric_limits<uint16_t>::max(),
-      "EncodingLayout config too large.");
-  return size;
-}
-
-[[maybe_unused]] void serializeConfig(
-    const EncodingLayout::Config& config,
-    char*& pos) {
-  std::vector<std::pair<std::string_view, std::string_view>> entries;
-  entries.reserve(config.values().size());
-  for (const auto& [key, value] : config.values()) {
-    entries.emplace_back(key, value);
-  }
-  std::sort(
-      entries.begin(), entries.end(), [](const auto& left, const auto& right) {
-        return left.first < right.first;
-      });
-
-  encoding::write<uint16_t>(static_cast<uint16_t>(entries.size()), pos);
-  for (const auto& [key, value] : entries) {
-    encoding::write<uint16_t>(static_cast<uint16_t>(key.size()), pos);
-    encoding::writeBytes(key, pos);
-    encoding::write<uint16_t>(static_cast<uint16_t>(value.size()), pos);
-    encoding::writeBytes(value, pos);
-  }
-}
-
-[[maybe_unused]] EncodingLayout::Config deserializeConfig(
-    std::string_view extraData) {
-  if (extraData.empty()) {
-    return {};
-  }
-
-  const char* pos = extraData.data();
-  const char* const end = extraData.data() + extraData.size();
-  std::unordered_map<std::string, std::string> configs;
-
-  NIMBLE_CHECK_LE(
-      static_cast<size_t>(end - pos),
-      extraData.size(),
-      "Invalid encoding layout config.");
-  const uint16_t configCount = encoding::read<uint16_t>(pos);
-  configs.reserve(configCount);
-
-  for (uint16_t i = 0; i < configCount; ++i) {
-    NIMBLE_CHECK_LE(
-        sizeof(uint16_t),
-        static_cast<size_t>(end - pos),
-        "Invalid encoding layout config.");
-    const uint16_t keySize = encoding::read<uint16_t>(pos);
-    NIMBLE_CHECK_LE(
-        keySize,
-        static_cast<size_t>(end - pos),
-        "Invalid encoding layout config.");
-    std::string key(pos, keySize);
-    pos += keySize;
-
-    NIMBLE_CHECK_LE(
-        sizeof(uint16_t),
-        static_cast<size_t>(end - pos),
-        "Invalid encoding layout config.");
-    const uint16_t valueSize = encoding::read<uint16_t>(pos);
-    NIMBLE_CHECK_LE(
-        valueSize,
-        static_cast<size_t>(end - pos),
-        "Invalid encoding layout config.");
-    std::string value(pos, valueSize);
-    pos += valueSize;
-
-    configs.emplace(std::move(key), std::move(value));
-  }
-
-  NIMBLE_CHECK_EQ(pos, end, "Invalid encoding layout config length.");
-  return EncodingLayout::Config{std::move(configs)};
-}
 
 // Captures one size-prefixed nested sub-stream into `children` (nullopt when
 // the sub-stream is empty)
@@ -173,30 +77,9 @@ int32_t EncodingLayout::serialize(std::span<char> output) const {
   // We store at least kMinEncodingLayoutBufferSize bytes: encoding type,
   // compression type, children count and extra data size (2 bytes), plus one
   // byte per child.
-  // SubIntSplit-specific logic commented out to restore original behavior:
-  /*
-  const uint32_t extraDataSize = serializedConfigSize(encodingConfig_);
-  NIMBLE_CHECK(
-      output.size() >=
-          kMinEncodingLayoutBufferSize + extraDataSize + children_.size(),
-      "Captured encoding layout buffer too small.");
-
-  char* pos = output.data();
-  pos[0] = static_cast<char>(encodingType_);
-  pos[1] = static_cast<char>(compressionType_);
-  pos[2] = static_cast<char>(children_.size());
-  pos += 3;
-  encoding::write<uint16_t>(static_cast<uint16_t>(extraDataSize), pos);
-
-  int32_t size = static_cast<int32_t>(pos - output.data());
-  if (extraDataSize > 0) {
-    char* extraPos = output.data() + size;
-    serializeConfig(encodingConfig_, extraPos);
-    size += extraDataSize;
-  }
-  */
-  NIMBLE_CHECK(
-      output.size() >= kMinEncodingLayoutBufferSize + children_.size(),
+  NIMBLE_CHECK_GE(
+      output.size(),
+      kMinEncodingLayoutBufferSize + children_.size(),
       "Captured encoding layout buffer too small.");
 
   output[0] = static_cast<char>(encodingType_);
@@ -223,28 +106,15 @@ int32_t EncodingLayout::serialize(std::span<char> output) const {
 
 std::pair<EncodingLayout, uint32_t> EncodingLayout::create(
     std::string_view encoding) {
-  NIMBLE_CHECK(
-      encoding.size() >= kMinEncodingLayoutBufferSize,
+  NIMBLE_CHECK_GE(
+      encoding.size(),
+      kMinEncodingLayoutBufferSize,
       "Invalid captured encoding layout. Buffer too small.");
 
   auto pos = encoding.data();
   const auto encodingType = encoding::read<uint8_t, EncodingType>(pos);
   const auto compressionType = encoding::read<uint8_t, CompressionType>(pos);
   const auto childrenCount = encoding::read<uint8_t>(pos);
-  // SubIntSplit-specific logic commented out to restore original behavior:
-  /*
-  const auto extraDataSize = encoding::read<uint16_t>(pos);
-
-  NIMBLE_CHECK_GE(
-      encoding.size(),
-      kMinEncodingLayoutBufferSize + extraDataSize,
-      "Invalid captured encoding layout. Buffer too small.");
-
-  const auto encodingConfig = deserializeConfig(
-      {encoding.data() + kMinEncodingLayoutBufferSize, extraDataSize});
-
-  uint32_t offset = kMinEncodingLayoutBufferSize + extraDataSize;
-  */
   [[maybe_unused]] const auto extraDataSize = encoding::read<uint16_t>(pos);
 
   NIMBLE_DCHECK_EQ(extraDataSize, 0, "Extra data currently not supported.");
@@ -264,15 +134,6 @@ std::pair<EncodingLayout, uint32_t> EncodingLayout::create(
     }
   }
 
-  // SubIntSplit-specific logic commented out to restore original behavior:
-  /*
-  return {
-      {encodingType,
-       std::move(encodingConfig),
-       compressionType,
-       std::move(children)},
-      offset};
-  */
   return {{encodingType, {}, compressionType, std::move(children)}, offset};
 }
 
@@ -306,61 +167,6 @@ namespace {
 
 constexpr uint32_t kEncodingPrefixSize = 6;
 
-// SubIntSplit integration commented out (disabled):
-/*
-Captures the layout of a SubIntSplit encoding by reading its per-section bit
-ranges and recursively capturing each split's nested encoding. The recovered
-bit boundaries are preserved in the encoding config so the same split layout
-can be replayed.
-[[maybe_unused]] EncodingLayout captureSubIntSplit(
-    std::string_view encoding,
-    CompressionType compressionType) {
-  const char* pos = encoding.data() + kEncodingPrefixSize;
-  const uint8_t splitCount = encoding::read<uint8_t>(pos);
-  encoding::read<uint8_t>(pos); // reserved
-
-  struct SectionMeta {
-    uint8_t bitStart;
-    uint8_t bitEnd;
-    uint32_t encodedSize;
-  };
-
-  std::vector<SectionMeta> sectionMeta;
-  sectionMeta.reserve(splitCount);
-  for (uint8_t s = 0; s < splitCount; ++s) {
-    SectionMeta meta{};
-    meta.bitStart = encoding::read<uint8_t>(pos);
-    meta.bitEnd = encoding::read<uint8_t>(pos);
-    meta.encodedSize = encoding::readUint32(pos);
-    sectionMeta.push_back(meta);
-  }
-
-  std::vector<std::optional<const EncodingLayout>> children;
-  children.reserve(splitCount);
-  for (uint8_t s = 0; s < splitCount; ++s) {
-    children.emplace_back(
-        EncodingLayoutCapture::capture({pos, sectionMeta[s].encodedSize}));
-    pos += sectionMeta[s].encodedSize;
-  }
-
-  std::vector<detail::subintsplit::SegmentPlan> boundaryPlans;
-  boundaryPlans.reserve(splitCount);
-  for (uint8_t s = 0; s < splitCount; ++s) {
-    detail::subintsplit::SegmentPlan segment{};
-    segment.bitStart = static_cast<int>(sectionMeta[s].bitStart);
-    segment.bitEnd = static_cast<int>(sectionMeta[s].bitEnd);
-    boundaryPlans.push_back(segment);
-  }
-
-  return {
-      EncodingType::SubIntSplit,
-      EncodingLayout::Config{
-          detail::subintsplit::makePreserveSplitConfig(boundaryPlans)},
-      compressionType,
-      std::move(children)};
-}
-*/
-
 } // namespace
 
 EncodingLayout EncodingLayoutCapture::capture(std::string_view encoding) {
@@ -383,18 +189,24 @@ EncodingLayout EncodingLayoutCapture::capture(std::string_view encoding) {
     case EncodingType::Varint:
     case EncodingType::Constant:
     case EncodingType::Prefix:
-    case EncodingType::ALP:
     case EncodingType::SimdForBitpack:
-    // SubIntSplit integration is disabled; treat it as a non-nested encoding
-    // (zero children) so its layout is captured without nested logic.
     case EncodingType::SubIntSplit:
-    // FOR and FrequencyPartition integration is disabled; treat them as
-    // non-nested encodings (zero children). Their nested-capture logic is
-    // commented out below.
     case EncodingType::FOR:
     case EncodingType::FrequencyPartition:
       // Non nested encodings have zero children
       break;
+    case EncodingType::ALP: {
+      const char* pos = encoding.data() + kEncodingPrefixSize;
+      encoding::read<uint8_t>(pos); // exponent
+      encoding::read<uint8_t>(pos); // factor
+      encoding::readUint32(pos); // exceptionCount
+      const uint32_t encodedValuesBytes = encoding::readUint32(pos);
+
+      children.reserve(1);
+      children.emplace_back(
+          EncodingLayoutCapture::capture({pos, encodedValuesBytes}));
+      break;
+    }
     case EncodingType::PFOR: {
       const auto dataType =
           encoding::peek<uint8_t, DataType>(encoding.data() + 1);
@@ -519,41 +331,6 @@ EncodingLayout EncodingLayoutCapture::capture(std::string_view encoding) {
               {pos, encoding.size() - (pos - encoding.data())}));
       break;
     }
-      // SubIntSplit-specific logic commented out to restore original behavior:
-      /*
-      case EncodingType::SubIntSplit:
-        return captureSubIntSplit(encoding, compressionType);
-      */
-    // FOR and FrequencyPartition integration commented out (disabled):
-    /*
-    case EncodingType::FOR: {
-      compressionType = encoding::peek<uint8_t, CompressionType>(
-          encoding.data() + kEncodingPrefixSize);
-      const bool enableBitOffsets = encoding::peek<uint8_t, bool>(
-          encoding.data() + kEncodingPrefixSize + 9);
-
-      const char* pos = encoding.data() + kEncodingPrefixSize + 10;
-
-      const uint32_t bitWidthsBytes = encoding::readUint32(pos);
-      children.emplace_back(
-          EncodingLayoutCapture::capture({pos, bitWidthsBytes}));
-      pos += bitWidthsBytes;
-
-      const uint32_t referencesBytes = encoding::readUint32(pos);
-      children.emplace_back(
-          EncodingLayoutCapture::capture({pos, referencesBytes}));
-      pos += referencesBytes;
-
-      if (enableBitOffsets) {
-        const uint32_t bitOffsetsBytes = encoding::readUint32(pos);
-        children.emplace_back(
-            EncodingLayoutCapture::capture({pos, bitOffsetsBytes}));
-      }
-      break;
-    }
-    case EncodingType::FrequencyPartition:
-      break;
-    */
     case EncodingType::Nullable: {
       const char* pos = encoding.data() + kEncodingPrefixSize;
       const uint32_t dataBytes = encoding::readUint32(pos);

--- a/dwio/nimble/encodings/common/EncodingUtils.h
+++ b/dwio/nimble/encodings/common/EncodingUtils.h
@@ -21,11 +21,6 @@
 #include "dwio/nimble/encodings/DeltaEncoding.h"
 #include "dwio/nimble/encodings/DictionaryEncoding.h"
 #include "dwio/nimble/encodings/FixedBitWidthEncoding.h"
-// FOR and FrequencyPartition integration commented out (disabled):
-/*
-#include "dwio/nimble/encodings/ForEncoding.h"
-#include "dwio/nimble/encodings/FrequencyPartitionEncoding.h"
-*/
 #include "dwio/nimble/encodings/FsstEncoding.h"
 #include "dwio/nimble/encodings/MainlyConstantEncoding.h"
 #include "dwio/nimble/encodings/NullableEncoding.h"
@@ -34,12 +29,6 @@
 #include "dwio/nimble/encodings/RLEEncoding.h"
 #include "dwio/nimble/encodings/SimdForBitpackEncoding.h"
 #include "dwio/nimble/encodings/SparseBoolEncoding.h"
-// SubIntSplit integration commented out (disabled):
-/*
-#ifdef NIMBLE_ENABLE_EXPERIMENTAL_ENCODINGS
-#include "dwio/nimble/encodings/SubIntSplitEncoding.h"
-#endif
-*/
 #include "dwio/nimble/encodings/TrivialEncoding.h"
 #include "dwio/nimble/encodings/VarintEncoding.h"
 
@@ -120,9 +109,10 @@ auto encodingTypeDispatchNonString(Encoding& encoding, F&& f) {
     case EncodingType::SparseBool:
       if constexpr (std::is_same_v<T, bool>) {
         return f(static_cast<SparseBoolEncoding&>(encoding));
-      } else {
-        NIMBLE_UNREACHABLE("{}", encoding.dataType());
       }
+      NIMBLE_UNREACHABLE(
+          "SparseBool encoding only supports bool data types, got {}.",
+          encoding.dataType());
     case EncodingType::Varint:
       if constexpr (folly::IsOneOf<
                         T,
@@ -133,9 +123,10 @@ auto encodingTypeDispatchNonString(Encoding& encoding, F&& f) {
                         float,
                         double>::value) {
         return f(static_cast<VarintEncoding<T>&>(encoding));
-      } else {
-        NIMBLE_UNREACHABLE("{}", encoding.dataType());
       }
+      NIMBLE_UNREACHABLE(
+          "Varint encoding only supports 32- and 64-bit numeric data types, got {}.",
+          encoding.dataType());
     case EncodingType::Constant:
       return f(static_cast<ConstantEncoding<T>&>(encoding));
     case EncodingType::MainlyConstant:
@@ -143,49 +134,28 @@ auto encodingTypeDispatchNonString(Encoding& encoding, F&& f) {
     case EncodingType::Delta:
       return f(static_cast<DeltaEncoding<T>&>(encoding));
     case EncodingType::ALP:
-      NIMBLE_UNSUPPORTED("ALP encoding is not yet implemented.");
+      if constexpr (isFloatingPointType<T>()) {
+        return f(static_cast<ALPEncoding<T>&>(encoding));
+      }
+      NIMBLE_UNSUPPORTED(
+          "ALP encoding only supports float and double data types, got {}.",
+          encoding.dataType());
     case EncodingType::BlockBitPacking:
       return f(static_cast<BlockBitPackingEncoding<T>&>(encoding));
     case EncodingType::PFOR:
       if constexpr (isIntegralType<T>()) {
         return f(static_cast<PFOREncoding<T>&>(encoding));
-      } else {
-        NIMBLE_UNREACHABLE("{}", encoding.dataType());
       }
+      NIMBLE_UNREACHABLE(
+          "PFOR encoding only supports integral data types, got {}.",
+          encoding.dataType());
     case EncodingType::SimdForBitpack:
       if constexpr (isIntegralType<T>()) {
         return f(static_cast<SimdForBitpackEncoding<T>&>(encoding));
-      } else {
-        NIMBLE_UNREACHABLE("{}", encoding.dataType());
       }
-      // SubIntSplit integration commented out (disabled):
-      /*
-  #ifdef NIMBLE_ENABLE_EXPERIMENTAL_ENCODINGS
-      case EncodingType::SubIntSplit:
-        if constexpr (isNumericType<T>() && sizeof(T) >= 4) {
-          return f(static_cast<SubIntSplitEncoding<T>&>(encoding));
-        } else {
-          NIMBLE_UNREACHABLE(toString(encoding.dataType()));
-        }
-  #endif
-      */
-    // FOR and FrequencyPartition integration commented out (disabled):
-    /*
-#ifdef NIMBLE_ENABLE_EXPERIMENTAL_ENCODINGS
-    case EncodingType::FOR:
-      if constexpr (std::is_integral_v<T> && !std::is_same_v<T, bool>) {
-        return f(static_cast<ForEncoding<T>&>(encoding));
-      } else {
-        NIMBLE_UNREACHABLE(toString(encoding.dataType()));
-      }
-    case EncodingType::FrequencyPartition:
-      if constexpr (!std::is_same_v<T, bool>) {
-        return f(static_cast<FrequencyPartitionEncoding<T>&>(encoding));
-      } else {
-        NIMBLE_UNREACHABLE(toString(encoding.dataType()));
-      }
-#endif
-    */
+      NIMBLE_UNREACHABLE(
+          "SimdForBitpack encoding only supports integral data types, got {}.",
+          encoding.dataType());
     default:
       NIMBLE_UNSUPPORTED("{}", encoding.encodingType());
   }

--- a/dwio/nimble/encodings/legacy/EncodingFactory.cpp
+++ b/dwio/nimble/encodings/legacy/EncodingFactory.cpp
@@ -349,7 +349,8 @@ std::string_view EncodingFactory::encode(
   using physicalType = typename TypeTraits<T>::physicalType;
   auto physicalValues = toPhysicalSpan(values);
   auto statistics = Statistics<physicalType>::create(physicalValues);
-  auto selectionResult = selectorPolicy->select(physicalValues, statistics);
+  auto selectionResult =
+      selectorPolicy->select(physicalValues, statistics, Encoding::Options{});
   EncodingSelection<physicalType> selection{
       std::move(selectionResult),
       std::move(statistics),
@@ -367,8 +368,8 @@ std::string_view EncodingFactory::encodeNullable(
   using physicalType = typename TypeTraits<T>::physicalType;
   auto physicalValues = toPhysicalSpan(values);
   auto statistics = Statistics<physicalType>::create(physicalValues);
-  auto selectionResult =
-      selectorPolicy->selectNullable(physicalValues, nulls, statistics);
+  auto selectionResult = selectorPolicy->selectNullable(
+      physicalValues, nulls, statistics, Encoding::Options{});
   EncodingSelection<physicalType> selection{
       std::move(selectionResult),
       std::move(statistics),

--- a/dwio/nimble/encodings/selection/EncodingIdentifier.h
+++ b/dwio/nimble/encodings/selection/EncodingIdentifier.h
@@ -62,16 +62,6 @@ struct EncodingIdentifiers {
     static constexpr NestedEncodingIdentifier EncodedValues = 0;
   };
 
-  // SubIntSplit integration commented out (disabled):
-  /*
-  struct SubIntSplit {
-    // Section identifiers equal the section index (0..splitCount-1).
-    // Maximum 64 sections (one per bit of a 64-bit integer).
-    // The identifier is written directly as section_index, so no named
-    // constants are defined here; callers use the index directly.
-  };
-  */
-
   struct FrequencyPartition {
     // Partition metadata
     // Eventually we may want to allow for non-power-of-two bit partitions, but

--- a/dwio/nimble/encodings/selection/EncodingSelection.h
+++ b/dwio/nimble/encodings/selection/EncodingSelection.h
@@ -193,14 +193,14 @@ class EncodingSelectionPolicy : public EncodingSelectionPolicyBase {
   virtual EncodingSelectionResult select(
       std::span<const physicalType> values,
       const Statistics<physicalType>& statistics,
-      const Encoding::Options& options = {}) = 0;
+      const Encoding::Options& options) = 0;
 
   /// Same as the |select()| method above, but for nullable values.
   virtual EncodingSelectionResult selectNullable(
       std::span<const physicalType> values,
       std::span<const bool> nulls,
       const Statistics<physicalType>& statistics,
-      const Encoding::Options& options = {}) = 0;
+      const Encoding::Options& options) = 0;
 
   virtual ~EncodingSelectionPolicy() = default;
 };

--- a/dwio/nimble/encodings/selection/EncodingSelectionPolicy.cpp
+++ b/dwio/nimble/encodings/selection/EncodingSelectionPolicy.cpp
@@ -114,6 +114,7 @@ ManualEncodingSelectionPolicyFactory::possibleEncodings() {
       // EXPERIMENTAL: The following encodings are not production-ready. Do not
       // enable for production tables without consulting the Nimble team
       // (oncall: dwios).
+      EncodingType::ALP,
       EncodingType::PFOR,
       EncodingType::SimdForBitpack,
       EncodingType::SubIntSplit,

--- a/dwio/nimble/encodings/selection/EncodingSelectionPolicy.h
+++ b/dwio/nimble/encodings/selection/EncodingSelectionPolicy.h
@@ -114,15 +114,31 @@ class ManualEncodingSelectionPolicy : public EncodingSelectionPolicy<T> {
   EncodingSelectionResult select(
       std::span<const physicalType> values,
       const Statistics<physicalType>& statistics,
-      const Encoding::Options& options = {}) override {
+      const Encoding::Options& options) override {
     if (values.empty()) {
       return {
           .encodingType = EncodingType::Trivial,
       };
     }
 
+    auto candidateEncodingReadFactors = candidateEncodingReadFactors_;
+    // TODO: Remove this opt-in once ALP is production-ready for default
+    // selection.
+    if constexpr (isFloatingPointType<T>()) {
+      if (options.allowNestedAlpSelection &&
+          identifier_ == EncodingIdentifiers::Dictionary::Alphabet &&
+          std::none_of(
+              candidateEncodingReadFactors.begin(),
+              candidateEncodingReadFactors.end(),
+              [](const auto& entry) {
+                return entry.first == EncodingType::ALP;
+              })) {
+        candidateEncodingReadFactors.emplace_back(EncodingType::ALP, 1.0);
+      }
+    }
+
     // Fast path: when there are no candidate encodings, fall back to Trivial.
-    if (candidateEncodingReadFactors_.empty()) {
+    if (candidateEncodingReadFactors.empty()) {
       return {
           .encodingType = EncodingType::Trivial,
       };
@@ -132,11 +148,11 @@ class ManualEncodingSelectionPolicy : public EncodingSelectionPolicy<T> {
     EncodingType selectedEncoding = EncodingType::Trivial;
     // Iterate on all candidate encodings, and pick the encoding with the
     // minimal cost.
-    for (const auto& entry : candidateEncodingReadFactors_) {
+    for (const auto& entry : candidateEncodingReadFactors) {
       const auto encodingType = entry.first;
       const auto estimatedSize =
           detail::EncodingSizeEstimation<T>::estimateSize(
-              encodingType, values.size(), statistics, options);
+              encodingType, values, statistics, options);
       if (!estimatedSize.has_value()) {
         NIMBLE_SELECTION_LOG(encodingType << " encoding is incompatible.");
         continue;
@@ -192,7 +208,7 @@ class ManualEncodingSelectionPolicy : public EncodingSelectionPolicy<T> {
       std::span<const physicalType> /* values */,
       std::span<const bool> /* nulls */,
       const Statistics<physicalType>& /* statistics */,
-      const Encoding::Options& /* options */ = {}) override {
+      const Encoding::Options& /* options */) override {
     return {
         .encodingType = EncodingType::Nullable,
     };
@@ -219,7 +235,7 @@ class ManualEncodingSelectionPolicy : public EncodingSelectionPolicy<T> {
     // should we allow trivial string lengths to be encoded using trivial
     // encoding?)
     std::vector<std::pair<EncodingType, float>> nestedEncodingReadFactors;
-    nestedEncodingReadFactors.reserve(candidateEncodingReadFactors_.size() - 1);
+    nestedEncodingReadFactors.reserve(candidateEncodingReadFactors_.size());
     for (const auto& entry : candidateEncodingReadFactors_) {
       if (entry.first != parentEncodingType) {
         nestedEncodingReadFactors.emplace_back(entry);
@@ -251,8 +267,7 @@ class ManualEncodingSelectionPolicy : public EncodingSelectionPolicy<T> {
 
 class ManualEncodingSelectionPolicyFactory {
  public:
-  /// TODO: Add EncodingType::ALP with an appropriate read factor once the
-  /// actual ALP algorithm is implemented.
+  /// TODO: Add ALP once it is production-ready for default manual selection.
   static std::vector<std::pair<EncodingType, float>>
   defaultEncodingReadFactors();
 
@@ -272,8 +287,6 @@ class ManualEncodingSelectionPolicyFactory {
       DataType dataType) const;
 
  private:
-  // TODO: Add EncodingType::ALP here once the actual ALP algorithm is
-  // implemented and size estimation is wired up in EncodingSizeEstimation.h.
   static std::vector<EncodingType> possibleEncodings();
 
   const std::vector<std::pair<EncodingType, float>> encodingReadFactors_;
@@ -324,13 +337,13 @@ class LearnedEncodingSelectionPolicy : public EncodingSelectionPolicy<T> {
   EncodingSelectionResult select(
       std::span<const physicalType> values,
       const Statistics<physicalType>& statistics,
-      const Encoding::Options& options = {}) override;
+      const Encoding::Options& options) override;
 
   EncodingSelectionResult selectNullable(
       std::span<const physicalType> /* values */,
       std::span<const bool> /* nulls */,
       const Statistics<physicalType>& /* statistics */,
-      const Encoding::Options& /* options */ = {}) override {
+      const Encoding::Options& /* options */) override {
     return {
         .encodingType = EncodingType::Nullable,
     };
@@ -346,12 +359,13 @@ class LearnedEncodingSelectionPolicy : public EncodingSelectionPolicy<T> {
     // parent), it provides an additional safety net, making sure the encoding
     // selection will eventually converge, and also slightly speeds up nested
     // encoding selection.
+    //
     // TODO: validate the assumptions here compared to brute forcing, to see if
     // the same encoding is selected multiple times in the tree (for example,
     // should we allow trivial string lengths to be encoded using trivial
     // encoding?)
     std::vector<EncodingType> nestedEncodingChoices;
-    nestedEncodingChoices.reserve(encodingChoices_.size() - 1);
+    nestedEncodingChoices.reserve(encodingChoices_.size());
     for (const auto& encodingType_ : encodingChoices_) {
       if (encodingType_ != parentEncodingType) {
         nestedEncodingChoices.push_back(encodingType_);
@@ -365,8 +379,7 @@ class LearnedEncodingSelectionPolicy : public EncodingSelectionPolicy<T> {
   }
 
  private:
-  // TODO: Add EncodingType::ALP here once the actual ALP algorithm is
-  // implemented.
+  // TODO: Add ALP once it is production-ready for learned selection.
   static std::vector<EncodingType> possibleEncodingChoices() {
     return {
         EncodingType::Constant,
@@ -429,7 +442,7 @@ class ReplayedEncodingSelectionPolicy
   nimble::EncodingSelectionResult select(
       std::span<const physicalType> /* values */,
       const nimble::Statistics<physicalType>& /* statistics */,
-      const Encoding::Options& /* options */ = {}) override {
+      const Encoding::Options& /* options */) override {
     if (!compressionOptions_.has_value()) {
       return {
           .encodingType = encodingLayout_.encodingType(),
@@ -449,7 +462,7 @@ class ReplayedEncodingSelectionPolicy
       std::span<const physicalType> /* values */,
       std::span<const bool> /* nulls */,
       const Statistics<physicalType>& /* statistics */,
-      const Encoding::Options& /* options */ = {}) override {
+      const Encoding::Options& /* options */) override {
     // NullableEncoding asks createImpl() for nullable data and nulls children.
     // The replay policy is initialized with the data layout, so synthesize the
     // nullable parent shape here.

--- a/dwio/nimble/encodings/selection/EncodingSizeEstimation.h
+++ b/dwio/nimble/encodings/selection/EncodingSizeEstimation.h
@@ -16,12 +16,11 @@
 #pragma once
 
 #include <glog/logging.h>
-#include <algorithm>
 #include <optional>
 #include <span>
 #include "dwio/nimble/common/Exceptions.h"
-#include "dwio/nimble/common/FixedBitArray.h"
 #include "dwio/nimble/common/Types.h"
+#include "dwio/nimble/encodings/ALPEncoding.h"
 #include "dwio/nimble/encodings/BlockBitPackingEncoding.h"
 #include "dwio/nimble/encodings/ConstantEncoding.h"
 #include "dwio/nimble/encodings/DictionaryEncoding.h"
@@ -34,24 +33,58 @@
 #include "dwio/nimble/encodings/SparseBoolEncoding.h"
 #include "dwio/nimble/encodings/TrivialEncoding.h"
 #include "dwio/nimble/encodings/VarintEncoding.h"
-#include "velox/common/base/BitUtil.h"
 
 namespace facebook::nimble {
 
 namespace detail {
 
-// This class is meant to quickly estimate the size of encoded data using a
-// given encoding type. It does a lot of assumptions, and it is not meant to be
-// 100% accurate.
+/// Estimates encoded data size for encoding selection. Estimates are heuristic
+/// and are not expected to match the serialized size exactly.
 template <typename T>
 struct EncodingSizeEstimation {
   using physicalType = typename TypeTraits<T>::physicalType;
 
+  static std::optional<uint64_t> estimateSize(
+      const EncodingType encodingType,
+      const size_t entryCount,
+      const Statistics<physicalType>& statistics,
+      const Encoding::Options& options) {
+    if constexpr (isNumericType<physicalType>()) {
+      return estimateNumericSize(encodingType, entryCount, statistics, options);
+    } else if constexpr (isBoolType<physicalType>()) {
+      return estimateBoolSize(encodingType, entryCount, statistics, options);
+    } else if constexpr (isStringType<physicalType>()) {
+      return estimateStringSize(encodingType, entryCount, statistics, options);
+    }
+
+    NIMBLE_UNREACHABLE(
+        "Unable to estimate size for type {}.", folly::demangle(typeid(T)));
+  }
+
+  static std::optional<uint64_t> estimateSize(
+      const EncodingType encodingType,
+      std::span<const physicalType> values,
+      const Statistics<physicalType>& statistics,
+      const Encoding::Options& options) {
+    if constexpr (isNumericType<physicalType>()) {
+      return estimateNumericSize(encodingType, values, statistics, options);
+    } else if constexpr (isBoolType<physicalType>()) {
+      return estimateBoolSize(encodingType, values.size(), statistics, options);
+    } else if constexpr (isStringType<physicalType>()) {
+      return estimateStringSize(
+          encodingType, values.size(), statistics, options);
+    }
+
+    NIMBLE_UNREACHABLE(
+        "Unable to estimate size for type {}.", folly::demangle(typeid(T)));
+  }
+
+ private:
   static std::optional<uint64_t> estimateNumericSize(
       const EncodingType encodingType,
       const uint64_t entryCount,
       const Statistics<physicalType>& statistics,
-      const Encoding::Options& options = {}) {
+      const Encoding::Options& options) {
     switch (encodingType) {
       case EncodingType::Constant: {
         return ConstantEncoding<physicalType>::estimateSize(statistics);
@@ -111,39 +144,31 @@ struct EncodingSizeEstimation {
         return BlockBitPackingEncoding<physicalType>::estimateSize(
             statistics, options.blockBitPackingBlockSize);
       }
-      // SubIntSplit integration commented out (disabled):
-      /*
-#ifdef NIMBLE_ENABLE_EXPERIMENTAL_ENCODINGS
-      case EncodingType::SubIntSplit: {
-        if constexpr (
-            isNumericType<physicalType>() &&
-            (sizeof(physicalType) == 4 || sizeof(physicalType) == 8)) {
-          constexpr uint64_t kTypeWidthBits =
-              static_cast<uint64_t>(sizeof(physicalType)) * 8u;
-          const uint64_t rangeBits =
-              velox::bits::bitsRequired(statistics.max() - statistics.min());
-          if (rangeBits > (kTypeWidthBits * 3) / 4) {
-            return std::nullopt;
-          }
-          const auto fbwEst = estimateNumericSize(
-              EncodingType::FixedBitWidth, entryCount, statistics);
-          if (!fbwEst.has_value()) {
-            return std::nullopt;
-          }
-          constexpr uint64_t kOverheadBytes = 6u + 2u + 4u * 6u + 4u * 8u;
-          const uint64_t estimate =
-              static_cast<uint64_t>(
-                  static_cast<double>(fbwEst.value()) * 0.90) +
-              kOverheadBytes;
-          return estimate;
+      case EncodingType::ALP: {
+        return std::nullopt;
+      }
+      default: {
+        return std::nullopt;
+      }
+    }
+  }
+
+  static std::optional<uint64_t> estimateNumericSize(
+      const EncodingType encodingType,
+      std::span<const physicalType> values,
+      const Statistics<physicalType>& statistics,
+      const Encoding::Options& options) {
+    switch (encodingType) {
+      case EncodingType::ALP: {
+        if constexpr (isFloatingPointType<T>()) {
+          return ALPEncoding<T>::estimateSize(values, options);
         } else {
           return std::nullopt;
         }
       }
-#endif
-      */
       default: {
-        return std::nullopt;
+        return estimateNumericSize(
+            encodingType, values.size(), statistics, options);
       }
     }
   }
@@ -177,7 +202,7 @@ struct EncodingSizeEstimation {
       const EncodingType encodingType,
       const size_t entryCount,
       const Statistics<std::string_view>& statistics,
-      const Encoding::Options& options = {}) {
+      const Encoding::Options& options) {
     switch (encodingType) {
       case EncodingType::Constant: {
         return ConstantEncoding<std::string_view>::estimateSize(statistics);
@@ -205,23 +230,6 @@ struct EncodingSizeEstimation {
         return std::nullopt;
       }
     }
-  }
-
-  static std::optional<uint64_t> estimateSize(
-      const EncodingType encodingType,
-      const size_t entryCount,
-      const Statistics<physicalType>& statistics,
-      const Encoding::Options& options = {}) {
-    if constexpr (isNumericType<physicalType>()) {
-      return estimateNumericSize(encodingType, entryCount, statistics, options);
-    } else if constexpr (isBoolType<physicalType>()) {
-      return estimateBoolSize(encodingType, entryCount, statistics, options);
-    } else if constexpr (isStringType<physicalType>()) {
-      return estimateStringSize(encodingType, entryCount, statistics, options);
-    }
-
-    NIMBLE_UNREACHABLE(
-        "Unable to estimate size for type {}.", folly::demangle(typeid(T)));
   }
 };
 } // namespace detail

--- a/dwio/nimble/encodings/tests/ALPEncodingTest.cpp
+++ b/dwio/nimble/encodings/tests/ALPEncodingTest.cpp
@@ -18,10 +18,19 @@
 #include <gtest/gtest.h>
 #include "dwio/nimble/common/Buffer.h"
 #include "dwio/nimble/common/Types.h"
+#include "dwio/nimble/common/tests/GTestUtils.h"
 #include "dwio/nimble/common/tests/NimbleCompare.h"
+#include "dwio/nimble/encodings/common/EncodingFactory.h"
+#include "dwio/nimble/encodings/selection/EncodingSelectionPolicy.h"
 #include "dwio/nimble/encodings/tests/TestUtils.h"
+#include "dwio/nimble/tools/EncodingUtilities.h"
+#include "fmt/core.h"
 
 #include <limits>
+#include <random>
+#include <string_view>
+#include <tuple>
+#include <unordered_map>
 #include <vector>
 
 using namespace facebook;
@@ -57,6 +66,167 @@ using TestTypes = ::testing::Types<TC(float), TC(double)>;
 
 TYPED_TEST_CASE(ALPEncodingTest, TestTypes);
 
+nimble::EncodingLayout fixedBitWidthLayout() {
+  return nimble::EncodingLayout{
+      nimble::EncodingType::FixedBitWidth,
+      {},
+      nimble::CompressionType::Uncompressed};
+}
+
+nimble::EncodingLayout alpWithFixedBitWidthPayloadLayout() {
+  return nimble::EncodingLayout{
+      nimble::EncodingType::ALP,
+      {},
+      nimble::CompressionType::Uncompressed,
+      {fixedBitWidthLayout()}};
+}
+
+nimble::EncodingLayout dictionaryWithAlpAlphabetLayout() {
+  return nimble::EncodingLayout{
+      nimble::EncodingType::Dictionary,
+      {},
+      nimble::CompressionType::Uncompressed,
+      {alpWithFixedBitWidthPayloadLayout(), fixedBitWidthLayout()}};
+}
+
+nimble::EncodingSelectionPolicyCreator unusedNestedPolicyCreator() {
+  return [](nimble::DataType) {
+    return std::unique_ptr<nimble::EncodingSelectionPolicyBase>{};
+  };
+}
+
+template <typename D>
+nimble::Vector<D> makeRandomDecimalValues(
+    velox::memory::MemoryPool* pool,
+    uint32_t rowCount,
+    uint32_t uniqueCount,
+    uint32_t seed) {
+  std::mt19937 rng(seed);
+  std::uniform_int_distribution<int32_t> valueDistribution{-5000, 5000};
+  std::uniform_int_distribution<uint32_t> indexDistribution{0, uniqueCount - 1};
+
+  std::vector<D> dictionary;
+  dictionary.reserve(uniqueCount);
+  for (uint32_t i = 0; i < uniqueCount; ++i) {
+    dictionary.push_back(
+        static_cast<D>(valueDistribution(rng)) / static_cast<D>(100));
+  }
+
+  nimble::Vector<D> values{pool};
+  values.reserve(rowCount);
+  for (uint32_t i = 0; i < rowCount; ++i) {
+    values.push_back(dictionary[indexDistribution(rng)]);
+  }
+  return values;
+}
+
+void expectEncodingLayout(
+    std::string_view serialized,
+    const std::vector<
+        std::tuple<nimble::EncodingType, nimble::DataType, std::string>>&
+        expected) {
+  std::vector<std::tuple<nimble::EncodingType, nimble::DataType, std::string>>
+      actual;
+  nimble::tools::traverseEncodings(
+      serialized,
+      [&](auto encodingType,
+          auto dataType,
+          auto /* level */,
+          auto /* index */,
+          auto nestedEncodingName,
+          std::unordered_map<
+              nimble::tools::EncodingPropertyType,
+              nimble::tools::EncodingProperty> /* properties */) {
+        actual.emplace_back(encodingType, dataType, nestedEncodingName);
+        return true;
+      });
+
+  EXPECT_EQ(actual, expected);
+}
+
+std::unique_ptr<nimble::Encoding> createEncoding(
+    velox::memory::MemoryPool* pool,
+    std::string_view serialized,
+    const nimble::Encoding::Options& options,
+    std::vector<velox::BufferPtr>& stringBuffers) {
+  const auto stringBufferFactory = [&](uint32_t totalLength) {
+    auto& stringBuffer = stringBuffers.emplace_back(
+        velox::AlignedBuffer::allocate<char>(totalLength, pool));
+    return stringBuffer->template asMutable<void>();
+  };
+  return nimble::EncodingFactory(options).create(
+      *pool, serialized, stringBufferFactory);
+}
+
+template <typename D>
+std::string_view encodeWithLayout(
+    nimble::Buffer& buffer,
+    const nimble::Vector<D>& values,
+    nimble::EncodingLayout layout,
+    const nimble::Encoding::Options& options) {
+  auto policy = std::make_unique<nimble::ReplayedEncodingSelectionPolicy<D>>(
+      std::move(layout), std::nullopt, unusedNestedPolicyCreator());
+  return nimble::EncodingFactory::encode<D>(
+      std::move(policy),
+      std::span<const D>{values.data(), values.size()},
+      buffer,
+      options);
+}
+
+template <typename D>
+void expectInterleavedMaterializeAndSkip(
+    nimble::Encoding& encoding,
+    const nimble::Vector<D>& values,
+    velox::memory::MemoryPool* pool,
+    uint32_t seed) {
+  std::mt19937 rng(seed);
+  std::uniform_int_distribution<uint32_t> skipDistribution{0, 13};
+  std::uniform_int_distribution<uint32_t> readDistribution{1, 17};
+
+  nimble::Vector<D> output{pool};
+  uint32_t cursor{0};
+  while (cursor < values.size()) {
+    const auto remainingRows = static_cast<uint32_t>(values.size() - cursor);
+    const auto rowsToSkip = std::min(skipDistribution(rng), remainingRows);
+    encoding.skip(rowsToSkip);
+    cursor += rowsToSkip;
+
+    if (cursor == values.size()) {
+      break;
+    }
+
+    const auto rowsToRead = std::min(
+        readDistribution(rng), static_cast<uint32_t>(values.size() - cursor));
+    output.resize(rowsToRead);
+    encoding.materialize(rowsToRead, output.data());
+
+    for (uint32_t i = 0; i < rowsToRead; ++i) {
+      SCOPED_TRACE(fmt::format("cursor={} i={}", cursor, i));
+      EXPECT_TRUE(
+          nimble::NimbleCompare<D>::equals(output[i], values[cursor + i]));
+    }
+    cursor += rowsToRead;
+  }
+
+  std::uniform_int_distribution<uint32_t> targetDistribution{
+      0, static_cast<uint32_t>(values.size() - 1)};
+  for (uint32_t attempt = 0; attempt < 32; ++attempt) {
+    const auto target = targetDistribution(rng);
+    const auto rowsToRead = std::min(
+        readDistribution(rng), static_cast<uint32_t>(values.size() - target));
+    encoding.reset();
+    encoding.skip(target);
+    output.resize(rowsToRead);
+    encoding.materialize(rowsToRead, output.data());
+
+    for (uint32_t i = 0; i < rowsToRead; ++i) {
+      SCOPED_TRACE(fmt::format("target={} i={}", target, i));
+      EXPECT_TRUE(
+          nimble::NimbleCompare<D>::equals(output[i], values[target + i]));
+    }
+  }
+}
+
 TYPED_TEST(ALPEncodingTest, roundTrip) {
   using D = typename TypeParam::data_type;
   const nimble::Encoding::Options options{
@@ -87,6 +257,259 @@ TYPED_TEST(ALPEncodingTest, roundTrip) {
 
   for (uint32_t i = 0; i < values.size(); ++i) {
     EXPECT_TRUE(nimble::NimbleCompare<D>::equals(result[i], values[i]));
+  }
+}
+
+TYPED_TEST(ALPEncodingTest, roundTripSignedDecimals) {
+  using D = typename TypeParam::data_type;
+  const nimble::Encoding::Options options{
+      .useVarintRowCount = TypeParam::useVarint};
+
+  auto values =
+      this->template toVector<D>({-12.5, -1.25, -0.5, 0, 0.5, 1.25, 12.5});
+
+  std::vector<velox::BufferPtr> stringBuffers;
+  const auto stringBufferFactory = [&](uint32_t totalLength) {
+    auto& buf = stringBuffers.emplace_back(
+        velox::AlignedBuffer::allocate<char>(totalLength, this->pool_.get()));
+    return buf->template asMutable<void>();
+  };
+
+  auto encoding = nimble::test::Encoder<nimble::ALPEncoding<D>>::createEncoding(
+      *this->buffer_,
+      values,
+      stringBufferFactory,
+      nimble::CompressionType::Uncompressed,
+      options);
+
+  nimble::Vector<D> result(this->pool_.get(), values.size());
+  encoding->materialize(values.size(), result.data());
+
+  for (uint32_t i = 0; i < values.size(); ++i) {
+    SCOPED_TRACE(fmt::format("i={}", i));
+    EXPECT_TRUE(nimble::NimbleCompare<D>::equals(result[i], values[i]));
+  }
+}
+
+TYPED_TEST(ALPEncodingTest, manualSelectionUsesAlpEstimate) {
+  using D = typename TypeParam::data_type;
+  const nimble::Encoding::Options options{
+      .useVarintRowCount = false, .fixedBitWidthUseExactBits = true};
+
+  nimble::Vector<D> values{this->pool_.get()};
+  values.reserve(2048);
+  for (auto i = 0; i < 2048; ++i) {
+    values.push_back(static_cast<D>((i % 129) - 64) / static_cast<D>(10));
+  }
+
+  auto policy = std::make_unique<nimble::ManualEncodingSelectionPolicy<D>>(
+      std::vector<std::pair<nimble::EncodingType, float>>{
+          {nimble::EncodingType::ALP, 1.0},
+          {nimble::EncodingType::Trivial, 1.0},
+          {nimble::EncodingType::FixedBitWidth, 1.0},
+      },
+      std::nullopt,
+      std::nullopt);
+
+  const auto serialized = nimble::EncodingFactory::encode<D>(
+      std::move(policy),
+      std::span<const D>{values.data(), values.size()},
+      *this->buffer_,
+      options);
+
+  std::vector<std::tuple<nimble::EncodingType, nimble::DataType, std::string>>
+      actual;
+  nimble::tools::traverseEncodings(
+      serialized,
+      [&](auto encodingType,
+          auto dataType,
+          auto /* level */,
+          auto /* index */,
+          auto nestedEncodingName,
+          std::unordered_map<
+              nimble::tools::EncodingPropertyType,
+              nimble::tools::EncodingProperty> /* properties */) {
+        actual.emplace_back(encodingType, dataType, nestedEncodingName);
+        return true;
+      });
+
+  const std::vector<
+      std::tuple<nimble::EncodingType, nimble::DataType, std::string>>
+      expected{
+          {nimble::EncodingType::ALP, nimble::TypeTraits<D>::dataType, ""},
+          {nimble::EncodingType::FixedBitWidth,
+           nimble::DataType::Uint64,
+           "EncodedValues"},
+      };
+  EXPECT_EQ(actual, expected);
+
+  std::vector<velox::BufferPtr> stringBuffers;
+  const auto stringBufferFactory = [&](uint32_t totalLength) {
+    auto& buf = stringBuffers.emplace_back(
+        velox::AlignedBuffer::allocate<char>(totalLength, this->pool_.get()));
+    return buf->template asMutable<void>();
+  };
+  auto encoding = nimble::EncodingFactory(options).create(
+      *this->pool_, serialized, stringBufferFactory);
+
+  nimble::Vector<D> result(this->pool_.get(), values.size());
+  encoding->materialize(values.size(), result.data());
+
+  for (uint32_t i = 0; i < values.size(); ++i) {
+    SCOPED_TRACE(fmt::format("i={}", i));
+    EXPECT_TRUE(nimble::NimbleCompare<D>::equals(result[i], values[i]));
+  }
+}
+
+TYPED_TEST(ALPEncodingTest, dictionaryAlphabetUsesNestedAlpWhenEnabled) {
+  using D = typename TypeParam::data_type;
+  const nimble::Encoding::Options options{
+      .useVarintRowCount = false,
+      .fixedBitWidthUseExactBits = true,
+      .allowNestedAlpSelection = true};
+
+  nimble::Vector<D> values{this->pool_.get()};
+  for (auto i = 0; i < 256; ++i) {
+    values.push_back(static_cast<D>((i % 17) - 8) / static_cast<D>(4));
+  }
+
+  auto policy = std::make_unique<nimble::ManualEncodingSelectionPolicy<D>>(
+      std::vector<std::pair<nimble::EncodingType, float>>{
+          {nimble::EncodingType::Dictionary, 1.0},
+      },
+      std::nullopt,
+      std::nullopt);
+
+  const auto serialized = nimble::EncodingFactory::encode<D>(
+      std::move(policy),
+      std::span<const D>{values.data(), values.size()},
+      *this->buffer_,
+      options);
+
+  std::vector<std::tuple<nimble::EncodingType, nimble::DataType, std::string>>
+      actual;
+  nimble::tools::traverseEncodings(
+      serialized,
+      [&](auto encodingType,
+          auto dataType,
+          auto /* level */,
+          auto /* index */,
+          auto nestedEncodingName,
+          std::unordered_map<
+              nimble::tools::EncodingPropertyType,
+              nimble::tools::EncodingProperty> /* properties */) {
+        actual.emplace_back(encodingType, dataType, nestedEncodingName);
+        return true;
+      });
+
+  const std::vector<
+      std::tuple<nimble::EncodingType, nimble::DataType, std::string>>
+      expected{
+          {nimble::EncodingType::Dictionary,
+           nimble::TypeTraits<D>::dataType,
+           ""},
+          {nimble::EncodingType::ALP,
+           nimble::TypeTraits<D>::dataType,
+           "Alphabet"},
+          {nimble::EncodingType::Trivial,
+           nimble::DataType::Uint64,
+           "EncodedValues"},
+          {nimble::EncodingType::Trivial, nimble::DataType::Uint32, "Indices"},
+      };
+  EXPECT_EQ(actual, expected);
+
+  std::vector<velox::BufferPtr> stringBuffers;
+  const auto stringBufferFactory = [&](uint32_t totalLength) {
+    auto& buf = stringBuffers.emplace_back(
+        velox::AlignedBuffer::allocate<char>(totalLength, this->pool_.get()));
+    return buf->template asMutable<void>();
+  };
+  auto encoding = nimble::EncodingFactory(options).create(
+      *this->pool_, serialized, stringBufferFactory);
+
+  nimble::Vector<D> result(this->pool_.get(), values.size());
+  encoding->materialize(values.size(), result.data());
+
+  for (uint32_t i = 0; i < values.size(); ++i) {
+    SCOPED_TRACE(fmt::format("i={}", i));
+    EXPECT_TRUE(nimble::NimbleCompare<D>::equals(result[i], values[i]));
+  }
+}
+
+TYPED_TEST(ALPEncodingTest, randomizedFixedLayoutMaterializeAndSkip) {
+  using D = typename TypeParam::data_type;
+  const nimble::Encoding::Options options{
+      .useVarintRowCount = false, .fixedBitWidthUseExactBits = true};
+
+  struct Scenario {
+    std::string name;
+    nimble::EncodingLayout layout;
+    uint32_t rowCount;
+    uint32_t uniqueCount;
+    std::vector<std::tuple<nimble::EncodingType, nimble::DataType, std::string>>
+        expectedLayout;
+  };
+
+  const std::vector<Scenario> scenarios{
+      {
+          "alp",
+          alpWithFixedBitWidthPayloadLayout(),
+          4096,
+          257,
+          {
+              {nimble::EncodingType::ALP, nimble::TypeTraits<D>::dataType, ""},
+              {nimble::EncodingType::FixedBitWidth,
+               nimble::DataType::Uint64,
+               "EncodedValues"},
+          },
+      },
+      {
+          "dictionary",
+          dictionaryWithAlpAlphabetLayout(),
+          4096,
+          97,
+          {
+              {nimble::EncodingType::Dictionary,
+               nimble::TypeTraits<D>::dataType,
+               ""},
+              {nimble::EncodingType::ALP,
+               nimble::TypeTraits<D>::dataType,
+               "Alphabet"},
+              {nimble::EncodingType::FixedBitWidth,
+               nimble::DataType::Uint64,
+               "EncodedValues"},
+              {nimble::EncodingType::FixedBitWidth,
+               nimble::DataType::Uint32,
+               "Indices"},
+          },
+      },
+  };
+
+  for (uint32_t scenarioIndex = 0; scenarioIndex < scenarios.size();
+       ++scenarioIndex) {
+    const auto& scenario = scenarios[scenarioIndex];
+    SCOPED_TRACE(
+        fmt::format(
+            "scenario={} type={} useVarint={}",
+            scenario.name,
+            nimble::TypeTraits<D>::dataType,
+            options.useVarintRowCount));
+
+    nimble::Buffer buffer{*this->pool_};
+    auto values = makeRandomDecimalValues<D>(
+        this->pool_.get(),
+        scenario.rowCount,
+        scenario.uniqueCount,
+        0xC0FFEE + scenarioIndex);
+    const auto serialized =
+        encodeWithLayout<D>(buffer, values, scenario.layout, options);
+    expectEncodingLayout(serialized, scenario.expectedLayout);
+
+    std::vector<velox::BufferPtr> stringBuffers;
+    auto encoding =
+        createEncoding(this->pool_.get(), serialized, options, stringBuffers);
+    expectInterleavedMaterializeAndSkip(
+        *encoding, values, this->pool_.get(), 0xA11CE + scenarioIndex);
   }
 }
 
@@ -169,12 +592,12 @@ TYPED_TEST(ALPEncodingTest, emptyDataRejected) {
     return buf->template asMutable<void>();
   };
 
-  EXPECT_THROW(
+  NIMBLE_ASSERT_USER_THROW(
       nimble::test::Encoder<nimble::ALPEncoding<D>>::createEncoding(
           *this->buffer_,
           empty,
           stringBufferFactory,
           nimble::CompressionType::Uncompressed,
           options),
-      nimble::NimbleUserError);
+      "ALP encoding cannot encode empty data.");
 }

--- a/dwio/nimble/encodings/tests/EncodingSelectionTest.cpp
+++ b/dwio/nimble/encodings/tests/EncodingSelectionTest.cpp
@@ -130,9 +130,11 @@ void verifySizeEstimate(
       },
       std::nullopt);
 
+  const nimble::Encoding::Options options;
+
   // Check the serialized uncompressed size
-  auto serialized =
-      nimble::EncodingFactory::encode<T>(std::move(policy), values, buffer);
+  auto serialized = nimble::EncodingFactory::encode<T>(
+      std::move(policy), values, buffer, options);
   auto actualSize = serialized.size();
   EXPECT_EQ(actualSize, expectedActualSize);
 
@@ -140,7 +142,8 @@ void verifySizeEstimate(
   auto estimatedSize = nimble::detail::EncodingSizeEstimation<T>::estimateSize(
       encodingTypeForEstimation,
       values.size(),
-      nimble::Statistics<T>::create(values));
+      nimble::Statistics<T>::create(values),
+      options);
   EXPECT_EQ(estimatedSize, expectedEstimatedSize);
 }
 
@@ -250,7 +253,7 @@ TEST_P(FixedBitWidthSelectionTest, selectsExpectedEncodingForNarrowValues) {
 }
 
 INSTANTIATE_TEST_SUITE_P(
-    FixedBitWidthUseExactBits,
+    fixedBitWidthUseExactBits,
     FixedBitWidthSelectionTest,
     ::testing::Values(
         FixedBitWidthSelectionParam{
@@ -282,7 +285,7 @@ TYPED_TEST_CASE(EncodingSelectionNumericTests, NumericTypes);
 template <typename C>
 class EncodingSelectionNumericTests : public ::testing::Test {};
 
-TYPED_TEST(EncodingSelectionNumericTests, SelectConst) {
+TYPED_TEST(EncodingSelectionNumericTests, selectConst) {
   using T = TypeParam;
 
   for (const T value :
@@ -306,7 +309,7 @@ TYPED_TEST(EncodingSelectionNumericTests, SelectConst) {
   }
 }
 
-TYPED_TEST(EncodingSelectionNumericTests, SelectMainlyConst) {
+TYPED_TEST(EncodingSelectionNumericTests, selectMainlyConst) {
   using T = TypeParam;
 
   for (const T value : {
@@ -383,7 +386,7 @@ TYPED_TEST(EncodingSelectionNumericTests, SelectMainlyConst) {
   }
 }
 
-TYPED_TEST(EncodingSelectionNumericTests, SelectTrivial) {
+TYPED_TEST(EncodingSelectionNumericTests, selectTrivial) {
   using T = TypeParam;
 
   auto seed = folly::Random::rand32();
@@ -407,7 +410,7 @@ TYPED_TEST(EncodingSelectionNumericTests, SelectTrivial) {
       });
 }
 
-TYPED_TEST(EncodingSelectionNumericTests, SelectFixedBitWidth) {
+TYPED_TEST(EncodingSelectionNumericTests, selectFixedBitWidth) {
   using T = TypeParam;
 
   auto seed = folly::Random::rand32();
@@ -436,7 +439,7 @@ TYPED_TEST(EncodingSelectionNumericTests, SelectFixedBitWidth) {
   }
 }
 
-TYPED_TEST(EncodingSelectionNumericTests, SelectDictionary) {
+TYPED_TEST(EncodingSelectionNumericTests, selectDictionary) {
   using T = TypeParam;
 
   auto seed = folly::Random::rand32();
@@ -460,8 +463,10 @@ TYPED_TEST(EncodingSelectionNumericTests, SelectDictionary) {
            .level = 0,
            .nestedEncodingName = ""},
           {.encodingType = nimble::EncodingType::Trivial,
-           .dataType = nimble::TypeTraits<
-               typename nimble::EncodingPhysicalType<T>::type>::dataType,
+           .dataType = nimble::isFloatingPointType<T>()
+               ? nimble::TypeTraits<T>::dataType
+               : nimble::TypeTraits<
+                     typename nimble::EncodingPhysicalType<T>::type>::dataType,
            .level = 1,
            .nestedEncodingName = "Alphabet"},
           {.encodingType = nimble::EncodingType::FixedBitWidth,
@@ -471,7 +476,7 @@ TYPED_TEST(EncodingSelectionNumericTests, SelectDictionary) {
       });
 }
 
-TYPED_TEST(EncodingSelectionNumericTests, SelectRunLength) {
+TYPED_TEST(EncodingSelectionNumericTests, selectRunLength) {
   using T = TypeParam;
 
   auto seed = folly::Random::rand32();
@@ -550,7 +555,7 @@ TYPED_TEST(EncodingSelectionNumericTests, SelectRunLength) {
   }
 }
 
-TYPED_TEST(EncodingSelectionNumericTests, SelectVarint) {
+TYPED_TEST(EncodingSelectionNumericTests, selectVarint) {
   using T = TypeParam;
 
   if constexpr (sizeof(T) < 4) {
@@ -586,7 +591,7 @@ TYPED_TEST(EncodingSelectionNumericTests, SelectVarint) {
       });
 }
 
-TEST(EncodingSelectionBoolTests, SelectConst) {
+TEST(EncodingSelectionBoolTests, selectConst) {
   using T = bool;
 
   for (const T value : {true, false}) {
@@ -606,7 +611,7 @@ TEST(EncodingSelectionBoolTests, SelectConst) {
   }
 }
 
-TEST(EncodingSelectionBoolTests, SelectSparseBool) {
+TEST(EncodingSelectionBoolTests, selectSparseBool) {
   using T = bool;
 
   for (const T value : {false, true}) {
@@ -634,7 +639,7 @@ TEST(EncodingSelectionBoolTests, SelectSparseBool) {
   }
 }
 
-TEST(EncodingSelectionBoolTests, SelectTrivial) {
+TEST(EncodingSelectionBoolTests, selectTrivial) {
   using T = bool;
 
   auto seed = folly::Random::rand32();
@@ -693,7 +698,7 @@ TEST(EncodingSelectionBoolTests, SelectTrivial) {
   }
 }
 
-TEST(EncodingSelectionBoolTests, SelectRunLength) {
+TEST(EncodingSelectionBoolTests, selectRunLength) {
   using T = bool;
 
   auto seed = folly::Random::rand32();
@@ -747,7 +752,7 @@ TEST(EncodingSelectionBoolTests, SelectRunLength) {
       });
 }
 
-TEST(EncodingSelectionStringTests, SelectConst) {
+TEST(EncodingSelectionStringTests, selectConst) {
   using T = std::string_view;
 
   auto pool = facebook::velox::memory::deprecatedAddDefaultLeafMemoryPool();
@@ -786,7 +791,7 @@ TEST(EncodingSelectionStringTests, SelectConst) {
   }
 }
 
-TEST(EncodingSelectionStringTests, SelectMainlyConst) {
+TEST(EncodingSelectionStringTests, selectMainlyConst) {
   using T = std::string_view;
 
   auto pool = facebook::velox::memory::deprecatedAddDefaultLeafMemoryPool();
@@ -856,7 +861,7 @@ TEST(EncodingSelectionStringTests, SelectMainlyConst) {
   }
 }
 
-TEST(EncodingSelectionStringTests, SelectTrivial) {
+TEST(EncodingSelectionStringTests, selectTrivial) {
   using T = std::string_view;
 
   auto seed = folly::Random::rand32();
@@ -910,7 +915,7 @@ TEST(EncodingSelectionStringTests, SelectTrivial) {
       });
 }
 
-TEST(EncodingSelectionStringTests, SelectDictionary) {
+TEST(EncodingSelectionStringTests, selectDictionary) {
   using T = std::string_view;
 
   auto seed = folly::Random::rand32();
@@ -966,7 +971,7 @@ TEST(EncodingSelectionStringTests, SelectDictionary) {
       });
 }
 
-TEST(EncodingSelectionStringTests, SelectRunLength) {
+TEST(EncodingSelectionStringTests, selectRunLength) {
   using T = std::string_view;
 
   auto seed = folly::Random::rand32();
@@ -1039,7 +1044,7 @@ TEST(EncodingSelectionStringTests, SelectRunLength) {
       });
 }
 
-TEST(EncodingSelectionTests, TestNullable) {
+TEST(EncodingSelectionTests, testNullable) {
   using T = std::string_view;
   auto pool = facebook::velox::memory::deprecatedAddDefaultLeafMemoryPool();
   nimble::Buffer buffer{*pool};
@@ -1074,8 +1079,10 @@ TEST(ManualEncodingSelectionPolicyTest, noCompressFlag) {
               defaultEncodingReadFactors(),
           nimble::CompressionOptions{},
           std::nullopt);
-  auto result =
-      compressPolicy->select(data, nimble::Statistics<uint32_t>::create(data));
+  auto result = compressPolicy->select(
+      data,
+      nimble::Statistics<uint32_t>::create(data),
+      nimble::Encoding::Options{});
   auto compressionPolicy = result.compressionPolicyFactory();
   // Compression should be attempted (non-Uncompressed type).
   EXPECT_NE(
@@ -1090,8 +1097,10 @@ TEST(ManualEncodingSelectionPolicyTest, noCompressFlag) {
         dynamic_cast<nimble::EncodingSelectionPolicy<uint32_t>*>(
             defaultPolicy.get());
     ASSERT_NE(typedDefault, nullptr);
-    auto defaultResult =
-        typedDefault->select(data, nimble::Statistics<uint32_t>::create(data));
+    auto defaultResult = typedDefault->select(
+        data,
+        nimble::Statistics<uint32_t>::create(data),
+        nimble::Encoding::Options{});
     auto defaultCompressionPolicy = defaultResult.compressionPolicyFactory();
     EXPECT_NE(
         defaultCompressionPolicy->config().compressionType,
@@ -1106,7 +1115,9 @@ TEST(ManualEncodingSelectionPolicyTest, noCompressFlag) {
           /*compressionOptions=*/std::nullopt,
           std::nullopt);
   auto noCompressResult = noCompressPolicy->select(
-      data, nimble::Statistics<uint32_t>::create(data));
+      data,
+      nimble::Statistics<uint32_t>::create(data),
+      nimble::Encoding::Options{});
   auto noCompressionPolicy = noCompressResult.compressionPolicyFactory();
   // Compression should be Uncompressed (default NoCompressionPolicy).
   EXPECT_EQ(
@@ -1139,8 +1150,10 @@ TEST(ManualEncodingSelectionPolicyTest, noCompressFlagPropagesToNested) {
 
   // The nested policy should also disable compression.
   std::vector<uint32_t> data(100, 7);
-  auto nestedResult =
-      typedNested->select(data, nimble::Statistics<uint32_t>::create(data));
+  auto nestedResult = typedNested->select(
+      data,
+      nimble::Statistics<uint32_t>::create(data),
+      nimble::Encoding::Options{});
   auto nestedCompressionPolicy = nestedResult.compressionPolicyFactory();
   EXPECT_EQ(
       nestedCompressionPolicy->config().compressionType,
@@ -1164,8 +1177,10 @@ TEST(ManualEncodingSelectionPolicyTest, perEncodingCompressionAcceptRatio) {
   for (uint32_t i = 0; i < data.size(); ++i) {
     data[i] = i % 100;
   }
-  auto cbpResult =
-      cbpPolicy->select(data, nimble::Statistics<uint32_t>::create(data));
+  auto cbpResult = cbpPolicy->select(
+      data,
+      nimble::Statistics<uint32_t>::create(data),
+      nimble::Encoding::Options{});
   EXPECT_EQ(cbpResult.encodingType, nimble::EncodingType::BlockBitPacking);
   auto cbpCompressionPolicy = cbpResult.compressionPolicyFactory();
   // BlockBitPacking ratio is 0.7: reject compression that only saves 20%.
@@ -1182,8 +1197,10 @@ TEST(ManualEncodingSelectionPolicyTest, perEncodingCompressionAcceptRatio) {
               {nimble::EncodingType::Trivial, 1.0}},
           nimble::CompressionOptions{},
           std::nullopt);
-  auto trivialResult =
-      trivialPolicy->select(data, nimble::Statistics<uint32_t>::create(data));
+  auto trivialResult = trivialPolicy->select(
+      data,
+      nimble::Statistics<uint32_t>::create(data),
+      nimble::Encoding::Options{});
   EXPECT_EQ(trivialResult.encodingType, nimble::EncodingType::Trivial);
   auto trivialCompressionPolicy = trivialResult.compressionPolicyFactory();
   // Trivial uses default ratio 0.98: accept compression that saves 20%.
@@ -1207,8 +1224,10 @@ TEST(ManualEncodingSelectionPolicyTest, customCompressionAcceptRatioOverride) {
   for (uint32_t i = 0; i < data.size(); ++i) {
     data[i] = i;
   }
-  auto result =
-      fbwPolicy->select(data, nimble::Statistics<uint32_t>::create(data));
+  auto result = fbwPolicy->select(
+      data,
+      nimble::Statistics<uint32_t>::create(data),
+      nimble::Encoding::Options{});
   EXPECT_EQ(result.encodingType, nimble::EncodingType::FixedBitWidth);
   auto compressionPolicy = result.compressionPolicyFactory();
   // FixedBitWidth ratio is 0.0: reject all compression.
@@ -1222,8 +1241,10 @@ TEST(ManualEncodingSelectionPolicyTest, customCompressionAcceptRatioOverride) {
               {nimble::EncodingType::BlockBitPacking, 1.0}},
           options,
           std::nullopt);
-  auto cbpResult =
-      cbpPolicy->select(data, nimble::Statistics<uint32_t>::create(data));
+  auto cbpResult = cbpPolicy->select(
+      data,
+      nimble::Statistics<uint32_t>::create(data),
+      nimble::Encoding::Options{});
   auto cbpCompressionPolicy = cbpResult.compressionPolicyFactory();
   // BlockBitPacking has no override here, uses default 0.98: accept moderate
   // savings.
@@ -1245,7 +1266,10 @@ TEST(ManualEncodingSelectionPolicyFactoryTest, noCompressFactory) {
   ASSERT_NE(typed, nullptr);
 
   std::vector<uint32_t> data(100, 42);
-  auto result = typed->select(data, nimble::Statistics<uint32_t>::create(data));
+  auto result = typed->select(
+      data,
+      nimble::Statistics<uint32_t>::create(data),
+      nimble::Encoding::Options{});
   auto compressionPolicy = result.compressionPolicyFactory();
   EXPECT_EQ(
       compressionPolicy->config().compressionType,
@@ -1277,8 +1301,10 @@ TEST(
 
   // The nested policy should also disable compression.
   std::vector<uint32_t> data(100, 7);
-  auto nestedResult =
-      typedNested->select(data, nimble::Statistics<uint32_t>::create(data));
+  auto nestedResult = typedNested->select(
+      data,
+      nimble::Statistics<uint32_t>::create(data),
+      nimble::Encoding::Options{});
   auto nestedCompressionPolicy = nestedResult.compressionPolicyFactory();
   EXPECT_EQ(
       nestedCompressionPolicy->config().compressionType,
@@ -1552,8 +1578,10 @@ TEST(ManualEncodingSelectionPolicyTest, defaultCompressionType) {
               defaultEncodingReadFactors(),
           nimble::CompressionOptions{},
           std::nullopt);
-  auto result =
-      policy->select(data, nimble::Statistics<uint32_t>::create(data));
+  auto result = policy->select(
+      data,
+      nimble::Statistics<uint32_t>::create(data),
+      nimble::Encoding::Options{});
   auto compressionPolicy = result.compressionPolicyFactory();
   auto info = compressionPolicy->config();
 
@@ -1578,8 +1606,10 @@ TEST(ManualEncodingSelectionPolicyTest, explicitZstdCompressionType) {
               defaultEncodingReadFactors(),
           options,
           std::nullopt);
-  auto result =
-      policy->select(data, nimble::Statistics<uint32_t>::create(data));
+  auto result = policy->select(
+      data,
+      nimble::Statistics<uint32_t>::create(data),
+      nimble::Encoding::Options{});
   auto compressionPolicy = result.compressionPolicyFactory();
   auto info = compressionPolicy->config();
 
@@ -1604,8 +1634,10 @@ TEST(ManualEncodingSelectionPolicyTest, explicitMetaInternalCompressionType) {
               defaultEncodingReadFactors(),
           options,
           std::nullopt);
-  auto result =
-      policy->select(data, nimble::Statistics<uint32_t>::create(data));
+  auto result = policy->select(
+      data,
+      nimble::Statistics<uint32_t>::create(data),
+      nimble::Encoding::Options{});
   auto compressionPolicy = result.compressionPolicyFactory();
   auto info = compressionPolicy->config();
 
@@ -1665,8 +1697,10 @@ TEST(ManualEncodingSelectionPolicyTest, compressionAcceptRatioOverride) {
               defaultEncodingReadFactors(),
           options,
           std::nullopt);
-  auto result =
-      policy->select(data, nimble::Statistics<uint32_t>::create(data));
+  auto result = policy->select(
+      data,
+      nimble::Statistics<uint32_t>::create(data),
+      nimble::Encoding::Options{});
 
   // Data is all-constant, so Constant encoding is selected.
   EXPECT_EQ(result.encodingType, nimble::EncodingType::Constant);
@@ -1719,8 +1753,10 @@ TEST(
               defaultEncodingReadFactors(),
           options,
           std::nullopt);
-  auto result =
-      policy->select(data, nimble::Statistics<uint32_t>::create(data));
+  auto result = policy->select(
+      data,
+      nimble::Statistics<uint32_t>::create(data),
+      nimble::Encoding::Options{});
 
   // Data is all-constant, so Constant encoding is selected — not Trivial.
   EXPECT_EQ(result.encodingType, nimble::EncodingType::Constant);
@@ -1751,8 +1787,10 @@ TEST(
               defaultEncodingReadFactors(),
           options,
           std::nullopt);
-  auto result =
-      policy->select(data, nimble::Statistics<uint32_t>::create(data));
+  auto result = policy->select(
+      data,
+      nimble::Statistics<uint32_t>::create(data),
+      nimble::Encoding::Options{});
   EXPECT_EQ(result.encodingType, nimble::EncodingType::Constant);
 
   auto compressionPolicy = result.compressionPolicyFactory();

--- a/dwio/nimble/encodings/tests/EncodingSizeEstimationTest.cpp
+++ b/dwio/nimble/encodings/tests/EncodingSizeEstimationTest.cpp
@@ -20,6 +20,7 @@
 
 #include "dwio/nimble/common/Types.h"
 #include "dwio/nimble/common/Vector.h"
+#include "dwio/nimble/encodings/ALPEncoding.h"
 #include "dwio/nimble/encodings/BlockBitPackingEncoding.h"
 #include "dwio/nimble/encodings/ConstantEncoding.h"
 #include "dwio/nimble/encodings/DictionaryEncoding.h"
@@ -30,6 +31,7 @@
 #include "dwio/nimble/encodings/SparseBoolEncoding.h"
 #include "dwio/nimble/encodings/TrivialEncoding.h"
 #include "dwio/nimble/encodings/VarintEncoding.h"
+#include "dwio/nimble/encodings/common/EncodingType.h"
 
 #include "dwio/nimble/encodings/tests/TestUtils.h"
 #include "velox/common/base/BitUtil.h"
@@ -101,8 +103,8 @@ class EncodingSizeEstimationTest : public ::testing::Test {
       auto stats = Statistics<T>::create(data);
       const uint32_t numValues = static_cast<uint32_t>(data.size());
 
-      auto estimated = Est::estimateNumericSize(
-          EncodingType::SimdForBitpack, numValues, stats);
+      auto estimated = Est::estimateSize(
+          EncodingType::SimdForBitpack, numValues, stats, defaultOptions_);
       ASSERT_TRUE(estimated.has_value());
 
       nimble::Buffer buffer{*pool_};
@@ -153,7 +155,57 @@ class EncodingSizeEstimationTest : public ::testing::Test {
         << encoded.size();
   }
 
+  template <typename T>
+  void verifyAlpEstimateVsActualSize() {
+    using physicalType = typename TypeTraits<T>::physicalType;
+    using Est = detail::EncodingSizeEstimation<T>;
+    SCOPED_TRACE(toString(TypeTraits<T>::dataType));
+
+    std::vector<T> data;
+    data.reserve(512);
+    for (int32_t i = 0; i < 512; ++i) {
+      data.push_back(static_cast<T>((i % 33) - 16) / static_cast<T>(4));
+    }
+
+    const auto physicalValues =
+        EncodingPhysicalType<T>::asEncodingPhysicalTypeSpan(
+            std::span<const T>{data.data(), data.size()});
+    auto stats = Statistics<physicalType>::create(physicalValues);
+
+    EXPECT_FALSE(
+        Est::estimateSize(
+            EncodingType::ALP, data.size(), stats, defaultOptions_)
+            .has_value());
+
+    const auto estimated = Est::estimateSize(
+        EncodingType::ALP, physicalValues, stats, defaultOptions_);
+    ASSERT_TRUE(estimated.has_value());
+
+    auto policy = std::make_unique<ManualEncodingSelectionPolicy<T>>(
+        std::vector<std::pair<EncodingType, float>>{
+            {EncodingType::FixedBitWidth, 1.0},
+        },
+        std::nullopt,
+        std::nullopt);
+    EncodingSelection<physicalType> selection{
+        {.encodingType = EncodingType::ALP},
+        Statistics<physicalType>::create(physicalValues),
+        std::move(policy)};
+
+    Buffer buffer{*pool_};
+    const auto encoded = ALPEncoding<T>::encode(
+        selection, physicalValues, buffer, defaultOptions_);
+
+    EXPECT_GT(estimated.value(), encoded.size() / 2)
+        << "estimate too low: " << estimated.value() << " vs actual "
+        << encoded.size();
+    EXPECT_LT(estimated.value(), encoded.size() * 2)
+        << "estimate too high: " << estimated.value() << " vs actual "
+        << encoded.size();
+  }
+
   std::shared_ptr<velox::memory::MemoryPool> pool_;
+  const Encoding::Options defaultOptions_;
 };
 
 TEST_F(EncodingSizeEstimationTest, numericConstant) {
@@ -162,7 +214,8 @@ TEST_F(EncodingSizeEstimationTest, numericConstant) {
   std::vector<uint32_t> data(100, 42);
   auto stats = Statistics<uint32_t>::create(data);
 
-  auto size = Est::estimateNumericSize(EncodingType::Constant, 100, stats);
+  auto size =
+      Est::estimateSize(EncodingType::Constant, 100, stats, defaultOptions_);
   ASSERT_TRUE(size.has_value());
   EXPECT_GT(size.value(), 0);
   EXPECT_LT(size.value(), 100 * sizeof(uint32_t));
@@ -174,7 +227,8 @@ TEST_F(EncodingSizeEstimationTest, numericConstantNonConstantData) {
   std::vector<uint32_t> data = {1, 2, 3};
   auto stats = Statistics<uint32_t>::create(data);
 
-  auto size = Est::estimateNumericSize(EncodingType::Constant, 3, stats);
+  auto size =
+      Est::estimateSize(EncodingType::Constant, 3, stats, defaultOptions_);
   EXPECT_FALSE(size.has_value());
 }
 
@@ -184,7 +238,8 @@ TEST_F(EncodingSizeEstimationTest, numericTrivial) {
   std::vector<uint32_t> data = {1, 2, 3, 4, 5};
   auto stats = Statistics<uint32_t>::create(data);
 
-  auto size = Est::estimateNumericSize(EncodingType::Trivial, 5, stats);
+  auto size =
+      Est::estimateSize(EncodingType::Trivial, 5, stats, defaultOptions_);
   ASSERT_TRUE(size.has_value());
   EXPECT_GE(size.value(), 5 * sizeof(uint32_t));
 }
@@ -195,7 +250,8 @@ TEST_F(EncodingSizeEstimationTest, numericFixedBitWidth) {
   std::vector<uint32_t> data = {100, 101, 102, 103, 104};
   auto stats = Statistics<uint32_t>::create(data);
 
-  auto size = Est::estimateNumericSize(EncodingType::FixedBitWidth, 5, stats);
+  auto size =
+      Est::estimateSize(EncodingType::FixedBitWidth, 5, stats, defaultOptions_);
   ASSERT_TRUE(size.has_value());
   EXPECT_LT(size.value(), 5 * sizeof(uint32_t));
 }
@@ -208,7 +264,7 @@ TEST_F(EncodingSizeEstimationTest, fixedBitWidthEstimateUsesExactBits) {
   Encoding::Options options;
   options.fixedBitWidthUseExactBits = true;
 
-  const auto size = Est::estimateNumericSize(
+  const auto size = Est::estimateSize(
       EncodingType::FixedBitWidth, data.size(), stats, options);
 
   ASSERT_TRUE(size.has_value());
@@ -228,7 +284,8 @@ TEST_F(EncodingSizeEstimationTest, numericDictionary) {
   std::vector<uint32_t> data = {1, 2, 1, 2, 1, 2, 1, 2, 1, 2};
   auto stats = Statistics<uint32_t>::create(data);
 
-  auto size = Est::estimateNumericSize(EncodingType::Dictionary, 10, stats);
+  auto size =
+      Est::estimateSize(EncodingType::Dictionary, 10, stats, defaultOptions_);
   ASSERT_TRUE(size.has_value());
   EXPECT_GT(size.value(), 0);
 }
@@ -240,8 +297,8 @@ TEST_F(EncodingSizeEstimationTest, numericMainlyConstant) {
   data[50] = 99;
   auto stats = Statistics<uint32_t>::create(data);
 
-  auto size =
-      Est::estimateNumericSize(EncodingType::MainlyConstant, 100, stats);
+  auto size = Est::estimateSize(
+      EncodingType::MainlyConstant, 100, stats, defaultOptions_);
   ASSERT_TRUE(size.has_value());
   EXPECT_LT(size.value(), 100 * sizeof(uint32_t));
 }
@@ -258,7 +315,7 @@ TEST_F(EncodingSizeEstimationTest, numericRle) {
   }
   auto stats = Statistics<uint32_t>::create(data);
 
-  auto size = Est::estimateNumericSize(EncodingType::RLE, 100, stats);
+  auto size = Est::estimateSize(EncodingType::RLE, 100, stats, defaultOptions_);
   ASSERT_TRUE(size.has_value());
   EXPECT_LT(size.value(), 100 * sizeof(uint32_t));
 }
@@ -269,7 +326,8 @@ TEST_F(EncodingSizeEstimationTest, numericVarint32) {
   std::vector<uint32_t> data = {0, 1, 127, 128, 255, 256, 1000};
   auto stats = Statistics<uint32_t>::create(data);
 
-  auto size = Est::estimateNumericSize(EncodingType::Varint, 7, stats);
+  auto size =
+      Est::estimateSize(EncodingType::Varint, 7, stats, defaultOptions_);
   ASSERT_TRUE(size.has_value());
   EXPECT_GT(size.value(), 0);
 }
@@ -280,7 +338,8 @@ TEST_F(EncodingSizeEstimationTest, numericVarint64) {
   std::vector<uint64_t> data = {0, 1, 127, 128, 16384, 1000000};
   auto stats = Statistics<uint64_t>::create(data);
 
-  auto size = Est::estimateNumericSize(EncodingType::Varint, 6, stats);
+  auto size =
+      Est::estimateSize(EncodingType::Varint, 6, stats, defaultOptions_);
   ASSERT_TRUE(size.has_value());
   EXPECT_GT(size.value(), 0);
 }
@@ -291,7 +350,8 @@ TEST_F(EncodingSizeEstimationTest, numericUnsupportedEncoding) {
   std::vector<uint32_t> data = {1, 2, 3};
   auto stats = Statistics<uint32_t>::create(data);
 
-  auto size = Est::estimateNumericSize(EncodingType::SparseBool, 3, stats);
+  auto size =
+      Est::estimateSize(EncodingType::SparseBool, 3, stats, defaultOptions_);
   EXPECT_FALSE(size.has_value());
 }
 
@@ -301,11 +361,21 @@ TEST_F(EncodingSizeEstimationTest, numericEstimateSizeDispatches) {
   std::vector<uint32_t> data = {1, 2, 3, 4, 5};
   auto stats = Statistics<uint32_t>::create(data);
 
-  auto size = Est::estimateSize(EncodingType::Trivial, 5, stats);
+  auto size = Est::estimateSize(
+      EncodingType::Trivial, data.size(), stats, defaultOptions_);
   ASSERT_TRUE(size.has_value());
 
-  auto directSize = Est::estimateNumericSize(EncodingType::Trivial, 5, stats);
-  EXPECT_EQ(size.value(), directSize.value());
+  auto sizeFromValues = Est::estimateSize(
+      EncodingType::Trivial,
+      std::span<const uint32_t>{data},
+      stats,
+      defaultOptions_);
+  EXPECT_EQ(sizeFromValues, size);
+}
+
+TEST_F(EncodingSizeEstimationTest, alpEstimateRequiresValuesAndMatchesActual) {
+  verifyAlpEstimateVsActualSize<float>();
+  verifyAlpEstimateVsActualSize<double>();
 }
 
 TEST_F(EncodingSizeEstimationTest, fixedBitWidthEstimateUsesValueRange) {
@@ -566,9 +636,9 @@ TEST_F(EncodingSizeEstimationTest, trivialSmallerThanDictionaryForUnique) {
   auto stats = Statistics<uint32_t>::create(data);
 
   auto trivialSize =
-      Est::estimateNumericSize(EncodingType::Trivial, 100, stats);
+      Est::estimateSize(EncodingType::Trivial, 100, stats, defaultOptions_);
   auto dictSize =
-      Est::estimateNumericSize(EncodingType::Dictionary, 100, stats);
+      Est::estimateSize(EncodingType::Dictionary, 100, stats, defaultOptions_);
 
   ASSERT_TRUE(trivialSize.has_value());
   ASSERT_TRUE(dictSize.has_value());
@@ -585,9 +655,9 @@ TEST_F(EncodingSizeEstimationTest, dictionarySmallerForHighRepetition) {
   auto stats = Statistics<uint32_t>::create(data);
 
   auto trivialSize =
-      Est::estimateNumericSize(EncodingType::Trivial, 1000, stats);
+      Est::estimateSize(EncodingType::Trivial, 1000, stats, defaultOptions_);
   auto dictSize =
-      Est::estimateNumericSize(EncodingType::Dictionary, 1000, stats);
+      Est::estimateSize(EncodingType::Dictionary, 1000, stats, defaultOptions_);
 
   ASSERT_TRUE(trivialSize.has_value());
   ASSERT_TRUE(dictSize.has_value());
@@ -601,9 +671,9 @@ TEST_F(EncodingSizeEstimationTest, constantSmallestForConstantData) {
   auto stats = Statistics<uint32_t>::create(data);
 
   auto constantSize =
-      Est::estimateNumericSize(EncodingType::Constant, 1000, stats);
+      Est::estimateSize(EncodingType::Constant, 1000, stats, defaultOptions_);
   auto trivialSize =
-      Est::estimateNumericSize(EncodingType::Trivial, 1000, stats);
+      Est::estimateSize(EncodingType::Trivial, 1000, stats, defaultOptions_);
 
   ASSERT_TRUE(constantSize.has_value());
   ASSERT_TRUE(trivialSize.has_value());
@@ -622,9 +692,10 @@ TEST_F(EncodingSizeEstimationTest, rleSmallForLongRuns) {
   }
   auto stats = Statistics<uint32_t>::create(data);
 
-  auto rleSize = Est::estimateNumericSize(EncodingType::RLE, 1000, stats);
+  auto rleSize =
+      Est::estimateSize(EncodingType::RLE, 1000, stats, defaultOptions_);
   auto trivialSize =
-      Est::estimateNumericSize(EncodingType::Trivial, 1000, stats);
+      Est::estimateSize(EncodingType::Trivial, 1000, stats, defaultOptions_);
 
   ASSERT_TRUE(rleSize.has_value());
   ASSERT_TRUE(trivialSize.has_value());
@@ -640,10 +711,10 @@ TEST_F(EncodingSizeEstimationTest, fbwSmallForNarrowRange) {
   }
   auto stats = Statistics<uint32_t>::create(data);
 
-  auto fbwSize =
-      Est::estimateNumericSize(EncodingType::FixedBitWidth, 1000, stats);
+  auto fbwSize = Est::estimateSize(
+      EncodingType::FixedBitWidth, 1000, stats, defaultOptions_);
   auto trivialSize =
-      Est::estimateNumericSize(EncodingType::Trivial, 1000, stats);
+      Est::estimateSize(EncodingType::Trivial, 1000, stats, defaultOptions_);
 
   ASSERT_TRUE(fbwSize.has_value());
   ASSERT_TRUE(trivialSize.has_value());
@@ -660,17 +731,21 @@ TEST_F(EncodingSizeEstimationTest, uint64AllEncodings) {
   auto stats = Statistics<uint64_t>::create(data);
 
   ASSERT_TRUE(
-      Est::estimateNumericSize(EncodingType::Trivial, 100, stats).has_value());
-  ASSERT_TRUE(
-      Est::estimateNumericSize(EncodingType::FixedBitWidth, 100, stats)
+      Est::estimateSize(EncodingType::Trivial, 100, stats, defaultOptions_)
           .has_value());
   ASSERT_TRUE(
-      Est::estimateNumericSize(EncodingType::Dictionary, 100, stats)
+      Est::estimateSize(
+          EncodingType::FixedBitWidth, 100, stats, defaultOptions_)
           .has_value());
   ASSERT_TRUE(
-      Est::estimateNumericSize(EncodingType::RLE, 100, stats).has_value());
+      Est::estimateSize(EncodingType::Dictionary, 100, stats, defaultOptions_)
+          .has_value());
   ASSERT_TRUE(
-      Est::estimateNumericSize(EncodingType::Varint, 100, stats).has_value());
+      Est::estimateSize(EncodingType::RLE, 100, stats, defaultOptions_)
+          .has_value());
+  ASSERT_TRUE(
+      Est::estimateSize(EncodingType::Varint, 100, stats, defaultOptions_)
+          .has_value());
 }
 
 TEST_F(EncodingSizeEstimationTest, pforEstimateVsActualSize) {
@@ -688,7 +763,7 @@ TEST_F(EncodingSizeEstimationTest, pforEstimateVsActualSize) {
   const uint32_t numValues = static_cast<uint32_t>(data.size());
 
   auto estimated =
-      Est::estimateNumericSize(EncodingType::PFOR, numValues, stats);
+      Est::estimateSize(EncodingType::PFOR, numValues, stats, defaultOptions_);
   ASSERT_TRUE(estimated.has_value());
 
   // Actually encode and measure real size.
@@ -890,8 +965,8 @@ TEST_F(
   }
   auto stats = Statistics<uint32_t>::create(data);
 
-  auto estimate =
-      Est::estimateNumericSize(EncodingType::BlockBitPacking, 2048, stats);
+  auto estimate = Est::estimateSize(
+      EncodingType::BlockBitPacking, 2048, stats, defaultOptions_);
   ASSERT_TRUE(estimate.has_value());
   EXPECT_GT(estimate.value(), 0);
 
@@ -903,8 +978,8 @@ TEST_F(
   // Verify options.blockBitPackingBlockSize is threaded through.
   Encoding::Options options;
   options.blockBitPackingBlockSize = 512;
-  auto estimateSmallBlock = Est::estimateNumericSize(
-      EncodingType::BlockBitPacking, 2048, stats, options);
+  auto estimateSmallBlock =
+      Est::estimateSize(EncodingType::BlockBitPacking, 2048, stats, options);
   ASSERT_TRUE(estimateSmallBlock.has_value());
   EXPECT_NE(estimateSmallBlock.value(), estimate.value());
 }

--- a/dwio/nimble/encodings/tests/ReadWithVisitorTest.cpp
+++ b/dwio/nimble/encodings/tests/ReadWithVisitorTest.cpp
@@ -36,8 +36,10 @@
 #include "dwio/nimble/encodings/legacy/EncodingUtils.h"
 #include "dwio/nimble/encodings/selection/EncodingSelectionPolicy.h"
 #include "dwio/nimble/encodings/tests/EncodingLayoutTestHelper.h"
+#include "dwio/nimble/velox/ChunkedStream.h"
 #include "dwio/nimble/velox/selective/ByteColumnReader.h"
 #include "dwio/nimble/velox/selective/ColumnReader.h"
+#include "dwio/nimble/velox/selective/FloatingPointColumnReader.h"
 #include "dwio/nimble/velox/selective/IntegerColumnReader.h"
 #include "dwio/nimble/velox/selective/NimbleData.h"
 #include "dwio/nimble/velox/selective/ReaderBase.h"
@@ -51,10 +53,18 @@
 #include "velox/vector/fuzzer/VectorFuzzer.h"
 #include "velox/vector/tests/utils/VectorTestBase.h"
 
+#include <random>
+
 namespace facebook::nimble {
 namespace {
 
 using namespace facebook::velox;
+
+template <typename V>
+ReadWithVisitorParams makeReadWithVisitorParams(
+    V& visitor,
+    const RowSet& rows,
+    velox::memory::MemoryPool* memPool);
 
 // ---------------------------------------------------------------------------
 // Test-only accessor: exposes protected prepareRead and readOffset_ so that
@@ -78,6 +88,25 @@ class IntegerColumnReaderTestAccessor : public IntegerColumnReader {
 
   void advanceReadOffset(const RowSet& rows) {
     readOffset_ += rows.back() + 1;
+  }
+};
+
+// ---------------------------------------------------------------------------
+// Test-only accessor for FloatingPointColumnReader: exposes protected
+// prepareRead so tests can call readWithVisitor explicitly with a hand-built
+// ColumnVisitor.
+// No new data members — static_cast from the real FloatingPointColumnReader*
+// is layout-safe.
+// ---------------------------------------------------------------------------
+template <typename T>
+class FloatingPointColumnReaderTestAccessor
+    : public FloatingPointColumnReader<T, T> {
+ public:
+  using FloatingPointColumnReader<T, T>::FloatingPointColumnReader;
+
+  void
+  doPrepareRead(int64_t offset, const RowSet& rows, const uint64_t* nulls) {
+    this->template prepareRead<T>(offset, rows, nulls);
   }
 };
 
@@ -177,6 +206,60 @@ std::unique_ptr<SubIntSplitEncoding<T>> makeSubIntSplitEncoding(
       memPool, encoded, [](uint32_t) { return nullptr; });
 }
 
+EncodingLayout makeAlpEncodingLayout(EncodingType encodedValuesEncodingType) {
+  const auto encodedValuesLayout = [&] {
+    switch (encodedValuesEncodingType) {
+      case EncodingType::Trivial:
+        return EncodingLayout{
+            EncodingType::Trivial, {}, CompressionType::Uncompressed};
+      case EncodingType::Dictionary:
+        return EncodingLayout{
+            EncodingType::Dictionary,
+            {},
+            CompressionType::Uncompressed,
+            {std::nullopt, std::nullopt}};
+      default:
+        NIMBLE_UNREACHABLE(
+            "Unsupported ALP encoded values encoding type: {}",
+            encodedValuesEncodingType);
+    }
+  }();
+
+  return EncodingLayout{
+      EncodingType::ALP,
+      {},
+      CompressionType::Uncompressed,
+      {encodedValuesLayout}};
+}
+
+VeloxWriterOptions makeSingleColumnWriterOptions(
+    const EncodingLayout& encodingLayout) {
+  using StreamLayouts =
+      std::unordered_map<EncodingLayoutTree::StreamIdentifier, EncodingLayout>;
+
+  VeloxWriterOptions options;
+  std::vector<EncodingLayoutTree> children;
+  children.emplace_back(
+      Kind::Scalar,
+      StreamLayouts{
+          {EncodingLayoutTree::StreamIdentifiers::Scalar::ScalarStream,
+           encodingLayout}},
+      "c0");
+  options.encodingLayoutTree.emplace(
+      Kind::Row, StreamLayouts{}, "", std::move(children));
+  return options;
+}
+
+template <typename T>
+std::vector<T> makeAlpFloatingPointValues() {
+  constexpr int kRows = 120;
+  std::vector<T> data(kRows);
+  for (int i = 0; i < kRows; ++i) {
+    data[i] = static_cast<T>((i % 21) - 10) / static_cast<T>(4);
+  }
+  return data;
+}
+
 // ---------------------------------------------------------------------------
 // Test fixture
 // ---------------------------------------------------------------------------
@@ -205,9 +288,12 @@ class ReadWithVisitorTest : public ::testing::TestWithParam<bool>,
 
   // Write |input| to an in-memory nimble file and prepare the stripe for
   // reading.  Returns a heap-allocated context to avoid copy/move issues.
-  std::unique_ptr<FileContext> makeFileContext(const RowVectorPtr& input) {
+  std::unique_ptr<FileContext> makeFileContext(
+      const RowVectorPtr& input,
+      VeloxWriterOptions writerOptions = {}) {
     auto ctx = std::make_unique<FileContext>();
-    ctx->fileData = test::createNimbleFile(*rootPool_, input);
+    ctx->fileData =
+        test::createNimbleFile(*rootPool_, input, std::move(writerOptions));
 
     auto readFile = std::make_shared<InMemoryReadFile>(ctx->fileData);
     dwio::common::ReaderOptions readerOpts(pool());
@@ -226,20 +312,191 @@ class ReadWithVisitorTest : public ::testing::TestWithParam<bool>,
     return ctx;
   }
 
-  // Build a struct column reader (root) for the given schema + scanSpec.
-  // Uses the test parameter to select either the non-legacy or legacy
-  // encoding factory and dispatch trait.
+  std::optional<EncodingLayout> captureFirstColumnEncoding(FileContext& ctx) {
+    const auto& childNode =
+        ctx.readerBase->nimbleSchema()->asRow().childAt(0)->asScalar();
+    auto streams = ctx.readerBase->tablet().load(
+        ctx.readerBase->tablet().stripeIdentifier(0),
+        std::vector<uint32_t>{childNode.scalarDescriptor().offset()});
+
+    InMemoryChunkedStream chunkedStream{*pool(), std::move(streams[0])};
+    if (!chunkedStream.hasNext()) {
+      return std::nullopt;
+    }
+    return EncodingLayoutCapture::capture(chunkedStream.nextChunk());
+  }
+
+  template <typename T>
+  void testColumnReaderAlpFloatingPointRange(
+      EncodingType encodedValuesEncodingType) {
+    SCOPED_TRACE(fmt::format("dataType={}", toString(TypeTraits<T>::dataType)));
+    constexpr T kLower = static_cast<T>(-1.25);
+    constexpr T kUpper = static_cast<T>(1.25);
+
+    const auto data = makeAlpFloatingPointValues<T>();
+    auto input = makeRowVector(
+        {makeFlatVector<T>(data.size(), [&](auto row) { return data[row]; })});
+    auto rowType = asRowType(input->type());
+    auto ctx = makeFileContext(
+        input,
+        makeSingleColumnWriterOptions(
+            makeAlpEncodingLayout(encodedValuesEncodingType)));
+
+    auto captured = captureFirstColumnEncoding(*ctx);
+    ASSERT_TRUE(captured.has_value());
+    ASSERT_EQ(captured->encodingType(), EncodingType::ALP);
+    const auto& encodedValues =
+        captured->child(EncodingIdentifiers::ALP::EncodedValues);
+    ASSERT_TRUE(encodedValues.has_value());
+    EXPECT_EQ(encodedValues->encodingType(), encodedValuesEncodingType);
+    if (encodedValuesEncodingType == EncodingType::Dictionary) {
+      const auto& alphabet =
+          encodedValues->child(EncodingIdentifiers::Dictionary::Alphabet);
+      const auto& indices =
+          encodedValues->child(EncodingIdentifiers::Dictionary::Indices);
+      EXPECT_TRUE(alphabet.has_value());
+      EXPECT_TRUE(indices.has_value());
+    }
+
+    auto scanSpec = std::make_shared<common::ScanSpec>("root");
+    scanSpec->addAllChildFields(*rowType);
+    scanSpec->childByName("c0")->setFilter(
+        std::make_unique<common::FloatingPointRange<T>>(
+            kLower, false, false, kUpper, false, false, false));
+
+    auto root =
+        buildReader(*ctx, rowType, *scanSpec, /*stringDecoderZeroCopy=*/true);
+    auto* child = readColumn(root.get(), data.size());
+
+    std::vector<vector_size_t> expectedRows;
+    std::vector<T> expectedValues;
+    for (int i = 0; i < static_cast<int>(data.size()); ++i) {
+      if (data[i] >= kLower && data[i] <= kUpper) {
+        expectedRows.push_back(i);
+        expectedValues.push_back(data[i]);
+      }
+    }
+
+    EXPECT_EQ(child->numValues(), expectedValues.size());
+
+    const auto outputRows = child->outputRows();
+    ASSERT_EQ(outputRows.size(), expectedRows.size());
+    for (int i = 0; i < static_cast<int>(expectedRows.size()); ++i) {
+      SCOPED_TRACE(fmt::format("rowIndex={}", i));
+      EXPECT_EQ(outputRows[i], expectedRows[i]);
+    }
+
+    const auto actualValues = getValues<T>(child);
+    ASSERT_EQ(actualValues.size(), expectedValues.size());
+    for (int i = 0; i < static_cast<int>(expectedValues.size()); ++i) {
+      SCOPED_TRACE(fmt::format("valueIndex={}", i));
+      EXPECT_EQ(actualValues[i], expectedValues[i]);
+    }
+  }
+
+  template <typename T>
+  void testEncodingLevelAlpRandomizedSparse(
+      EncodingType encodedValuesEncodingType) {
+    SCOPED_TRACE(
+        fmt::format(
+            "dataType={} encodedValuesEncodingType={}",
+            toString(TypeTraits<T>::dataType),
+            toString(encodedValuesEncodingType)));
+
+    constexpr int kRows = 512;
+    constexpr T kLower = static_cast<T>(-25);
+    constexpr T kUpper = static_cast<T>(25);
+
+    std::mt19937 rng(0xA117);
+    std::uniform_int_distribution<int32_t> valueDistribution{-5'000, 5'000};
+    std::uniform_int_distribution<int32_t> rowDistribution{0, 3};
+
+    std::vector<T> data(kRows);
+    for (int i = 0; i < kRows; ++i) {
+      data[i] = static_cast<T>(valueDistribution(rng)) / static_cast<T>(100);
+    }
+
+    std::vector<vector_size_t> rowVec;
+    for (int i = 0; i < kRows; ++i) {
+      if (rowDistribution(rng) == 0) {
+        rowVec.push_back(i);
+      }
+    }
+    ASSERT_FALSE(rowVec.empty());
+
+    auto input = makeRowVector(
+        {makeFlatVector<T>(kRows, [&](auto i) { return data[i]; })});
+    auto rowType = asRowType(input->type());
+    auto ctx = makeFileContext(input);
+    auto scanSpec = std::make_shared<common::ScanSpec>("root");
+    scanSpec->addAllChildFields(*rowType);
+    scanSpec->childByName("c0")->setFilter(
+        std::make_unique<common::FloatingPointRange<T>>(
+            kLower, false, false, kUpper, false, false, false));
+    auto root = buildReader(*ctx, rowType, *scanSpec);
+
+    auto* structReader =
+        dynamic_cast<dwio::common::SelectiveStructColumnReaderBase*>(
+            root.get());
+    auto* reader = static_cast<FloatingPointColumnReaderTestAccessor<T>*>(
+        dynamic_cast<FloatingPointColumnReader<T, T>*>(
+            structReader->children()[0]));
+    ASSERT_NE(reader, nullptr);
+
+    RowSet rows(rowVec.data(), rowVec.size());
+    reader->doPrepareRead(0, rows, nullptr);
+
+    Buffer buffer(*pool());
+    auto encoding = createFromCustomLayout<T>(
+        makeAlpEncodingLayout(encodedValuesEncodingType),
+        data,
+        *pool(),
+        buffer);
+    ASSERT_EQ(encoding->encodingType(), EncodingType::ALP);
+
+    common::FloatingPointRange<T> filter(
+        kLower, false, false, kUpper, false, false, false);
+    dwio::common::ExtractToReader extractValues(reader);
+    constexpr bool kIsDense = false;
+    DecoderVisitor<
+        T,
+        common::FloatingPointRange<T>,
+        dwio::common::ExtractToReader,
+        kIsDense>
+        visitor(filter, reader, rows, extractValues);
+    auto params = makeReadWithVisitorParams(visitor, rows, pool());
+
+    dispatchCallReadWithVisitor(*encoding, visitor, params);
+
+    std::vector<T> expectedValues;
+    for (const auto row : rowVec) {
+      if (data[row] >= kLower && data[row] <= kUpper) {
+        expectedValues.push_back(data[row]);
+      }
+    }
+
+    EXPECT_EQ(reader->numValues(), expectedValues.size());
+    const auto actualValues = getValues<T>(reader);
+    ASSERT_EQ(actualValues.size(), expectedValues.size());
+    for (int i = 0; i < static_cast<int>(expectedValues.size()); ++i) {
+      SCOPED_TRACE(fmt::format("valueIndex={}", i));
+      EXPECT_EQ(actualValues[i], expectedValues[i]);
+    }
+  }
+
   std::unique_ptr<dwio::common::SelectiveColumnReader> buildReader(
       FileContext& ctx,
       const RowTypePtr& rowType,
-      common::ScanSpec& scanSpec) {
+      common::ScanSpec& scanSpec,
+      bool stringDecoderZeroCopy = false) {
     NimbleParams params(
         *pool(),
         ctx.stats,
         ctx.readerBase->nimbleSchema(),
         *ctx.streams,
         ctx.rowSizeTracker.get(),
-        ctx.encodingFactory);
+        ctx.encodingFactory,
+        stringDecoderZeroCopy);
 
     auto reader = buildColumnReader(
         rowType,
@@ -1047,6 +1304,38 @@ TEST_P(ReadWithVisitorTest, explicitReadWithVisitorIsNotNullNullable) {
   EXPECT_EQ(reader->numValues(), expectedNonNull);
 }
 
+TEST_P(ReadWithVisitorTest, columnReaderAlpFloatAndDouble) {
+  if (!useNonLegacy()) {
+    return;
+  }
+
+  for (const auto encodedValuesEncodingType :
+       {EncodingType::Trivial, EncodingType::Dictionary}) {
+    SCOPED_TRACE(
+        fmt::format(
+            "encodedValuesEncodingType={}",
+            toString(encodedValuesEncodingType)));
+    testColumnReaderAlpFloatingPointRange<float>(encodedValuesEncodingType);
+    testColumnReaderAlpFloatingPointRange<double>(encodedValuesEncodingType);
+  }
+}
+
+TEST_P(ReadWithVisitorTest, encodingLevelAlpRandomizedSparse) {
+  if (!useNonLegacy()) {
+    return;
+  }
+
+  for (const auto encodedValuesEncodingType :
+       {EncodingType::Trivial, EncodingType::Dictionary}) {
+    SCOPED_TRACE(
+        fmt::format(
+            "encodedValuesEncodingType={}",
+            toString(encodedValuesEncodingType)));
+    testEncodingLevelAlpRandomizedSparse<float>(encodedValuesEncodingType);
+    testEncodingLevelAlpRandomizedSparse<double>(encodedValuesEncodingType);
+  }
+}
+
 // ===========================================================================
 // ENCODING-LEVEL readWithVisitor TESTS
 //
@@ -1267,6 +1556,90 @@ TEST_P(ReadWithVisitorTest, encodingLevelFixedBitWidthBigintRangeSparse) {
   for (int i = 0; i < reader->numValues(); ++i) {
     EXPECT_GE(values[i], 5);
     EXPECT_LE(values[i], 10);
+  }
+}
+
+TEST_P(ReadWithVisitorTest, encodingLevelAlpFloatingPointRangeSparse) {
+  if (!useNonLegacy()) {
+    return;
+  }
+
+  constexpr int kRows = 120;
+  constexpr double kLower = -1.25;
+  constexpr double kUpper = 1.25;
+
+  std::vector<double> data(kRows);
+  for (int i = 0; i < kRows; ++i) {
+    data[i] = static_cast<double>((i % 21) - 10) / 4;
+  }
+
+  auto input = makeRowVector(
+      {makeFlatVector<double>(kRows, [&](auto i) { return data[i]; })});
+  auto rowType = asRowType(input->type());
+  auto ctx = makeFileContext(input);
+  auto scanSpec = std::make_shared<common::ScanSpec>("root");
+  scanSpec->addAllChildFields(*rowType);
+  scanSpec->childByName("c0")->setFilter(
+      std::make_unique<common::FloatingPointRange<double>>(
+          kLower, false, false, kUpper, false, false, false));
+  auto root = buildReader(*ctx, rowType, *scanSpec);
+
+  auto* structReader =
+      dynamic_cast<dwio::common::SelectiveStructColumnReaderBase*>(root.get());
+  auto* reader = static_cast<FloatingPointColumnReaderTestAccessor<double>*>(
+      dynamic_cast<FloatingPointColumnReader<double, double>*>(
+          structReader->children()[0]));
+  ASSERT_NE(reader, nullptr);
+
+  std::vector<vector_size_t> rowVec;
+  for (int i = 0; i < kRows; i += 3) {
+    rowVec.push_back(i);
+  }
+  RowSet rows(rowVec.data(), rowVec.size());
+
+  reader->doPrepareRead(0, rows, nullptr);
+
+  std::vector<std::optional<const EncodingLayout>> children;
+  children.emplace_back(TrivialEnc{});
+  const EncodingLayout alpLayout(
+      EncodingType::ALP,
+      {},
+      CompressionType::Uncompressed,
+      std::move(children));
+  Buffer buffer(*pool());
+  auto encoding =
+      createFromCustomLayout<double>(alpLayout, data, *pool(), buffer);
+  ASSERT_EQ(encoding->encodingType(), EncodingType::ALP);
+
+  common::FloatingPointRange<double> filter(
+      kLower, false, false, kUpper, false, false, false);
+  dwio::common::ExtractToReader extractValues(reader);
+  constexpr bool kIsDense = false;
+  DecoderVisitor<
+      double,
+      common::FloatingPointRange<double>,
+      dwio::common::ExtractToReader,
+      kIsDense>
+      visitor(filter, reader, rows, extractValues);
+  auto params = makeReadWithVisitorParams(visitor, rows, pool());
+
+  dispatchCallReadWithVisitor(*encoding, visitor, params);
+
+  int expected = 0;
+  for (const auto row : rowVec) {
+    if (data[row] >= kLower && data[row] <= kUpper) {
+      ++expected;
+    }
+  }
+  EXPECT_EQ(reader->numValues(), expected);
+
+  auto values = getValues<double>(reader);
+  int outputIndex = 0;
+  for (const auto row : rowVec) {
+    if (data[row] >= kLower && data[row] <= kUpper) {
+      EXPECT_DOUBLE_EQ(values[outputIndex], data[row]);
+      ++outputIndex;
+    }
   }
 }
 

--- a/dwio/nimble/fuzzer/encoding/EncodingFuzzer.h
+++ b/dwio/nimble/fuzzer/encoding/EncodingFuzzer.h
@@ -17,6 +17,7 @@
 
 #include <bit>
 #include <cmath>
+#include <iterator>
 #include <limits>
 #include <random>
 #include <string_view>
@@ -152,6 +153,75 @@ Vector<T> makeBitStructuredData(
   return data;
 }
 
+template <typename T, typename RNG>
+Vector<T> makeFloatingPointDecimalData(
+    velox::memory::MemoryPool& pool,
+    RNG& rng,
+    uint32_t rowCount,
+    [[maybe_unused]] Buffer* buffer) {
+  Vector<T> data(&pool);
+  data.reserve(rowCount);
+  if constexpr (std::is_floating_point_v<T>) {
+    constexpr double kDivisors[] = {1.0, 10.0, 100.0, 1000.0, 10000.0};
+    const auto divisor =
+        kDivisors[folly::Random::rand32(rng) % std::size(kDivisors)];
+    for (uint32_t i = 0; i < rowCount; ++i) {
+      const auto base =
+          static_cast<int32_t>((i * 37 + folly::Random::rand32(rng)) % 2001) -
+          1000;
+      data.push_back(static_cast<T>(static_cast<double>(base) / divisor));
+    }
+  }
+  return data;
+}
+
+template <typename T, typename RNG>
+Vector<T> makeFloatingPointSpecialData(
+    velox::memory::MemoryPool& pool,
+    [[maybe_unused]] RNG& rng,
+    uint32_t rowCount,
+    [[maybe_unused]] Buffer* buffer) {
+  Vector<T> data(&pool);
+  data.reserve(rowCount);
+  if constexpr (std::is_floating_point_v<T>) {
+    const T values[] = {
+        T{0},
+        -T{0},
+        std::numeric_limits<T>::infinity(),
+        -std::numeric_limits<T>::infinity(),
+        std::numeric_limits<T>::quiet_NaN(),
+        std::numeric_limits<T>::denorm_min(),
+        std::numeric_limits<T>::min(),
+        -std::numeric_limits<T>::min()};
+    for (uint32_t i = 0; i < rowCount; ++i) {
+      data.push_back(values[i % std::size(values)]);
+    }
+  }
+  return data;
+}
+
+template <typename T, typename RNG>
+Vector<T> makeFloatingPointMixedExceptionData(
+    velox::memory::MemoryPool& pool,
+    RNG& rng,
+    uint32_t rowCount,
+    [[maybe_unused]] Buffer* buffer) {
+  Vector<T> data(&pool);
+  data.reserve(rowCount);
+  if constexpr (std::is_floating_point_v<T>) {
+    for (uint32_t i = 0; i < rowCount; ++i) {
+      const auto scaled =
+          static_cast<T>(static_cast<int32_t>(i % 257) - 128) / T{100};
+      if ((i + folly::Random::rand32(rng)) % 5 == 0) {
+        data.push_back(std::nextafter(scaled, std::numeric_limits<T>::max()));
+      } else {
+        data.push_back(scaled);
+      }
+    }
+  }
+  return data;
+}
+
 // ============================================================================
 // Fuzzer operations
 // ============================================================================
@@ -258,6 +328,18 @@ class EncodingFuzzer {
     if constexpr (std::is_arithmetic_v<T> && !std::is_same_v<T, bool>) {
       datasets.push_back(
           makeBitStructuredData<T>(*pool_, rng, rowCount, buffer_.get()));
+    }
+
+    if constexpr (std::is_floating_point_v<T>) {
+      datasets.push_back(
+          makeFloatingPointDecimalData<T>(
+              *pool_, rng, rowCount, buffer_.get()));
+      datasets.push_back(
+          makeFloatingPointSpecialData<T>(
+              *pool_, rng, rowCount, buffer_.get()));
+      datasets.push_back(
+          makeFloatingPointMixedExceptionData<T>(
+              *pool_, rng, rowCount, buffer_.get()));
     }
 
     // Small data (1-3 rows) for edge cases.

--- a/dwio/nimble/serializer/tests/SerializerImplTest.cpp
+++ b/dwio/nimble/serializer/tests/SerializerImplTest.cpp
@@ -1608,7 +1608,8 @@ TEST_F(EncodeTypedCompressionTest, defaultFactoryNoCompression) {
   ASSERT_NE(typed, nullptr);
 
   std::vector<uint32_t> data(1000, 42);
-  auto result = typed->select(data, Statistics<uint32_t>::create(data));
+  auto result = typed->select(
+      data, Statistics<uint32_t>::create(data), Encoding::Options{});
   auto compressionPolicy = result.compressionPolicyFactory();
   EXPECT_EQ(
       compressionPolicy->config().compressionType,

--- a/dwio/nimble/tools/EncodingUtilities.cpp
+++ b/dwio/nimble/tools/EncodingUtilities.cpp
@@ -114,12 +114,21 @@ void traverseEncodings(
     case EncodingType::Varint:
     case EncodingType::Constant:
     case EncodingType::Prefix:
-    case EncodingType::ALP:
     case EncodingType::SimdForBitpack:
     // SubIntSplit integration is disabled; treat it as having no nested
     // encoding to traverse.
     case EncodingType::SubIntSplit: {
       // don't have any nested encoding
+      break;
+    }
+    case EncodingType::ALP: {
+      const char* pos = stream.data() + kEncodingPrefixSize;
+      encoding::read<uint8_t>(pos); // exponent
+      encoding::read<uint8_t>(pos); // factor
+      encoding::readUint32(pos); // exceptionCount
+      const uint32_t encodedValuesSize = encoding::readUint32(pos);
+      traverseEncodings(
+          {pos, encodedValuesSize}, level + 1, 0, "EncodedValues", visitor);
       break;
     }
     case EncodingType::BlockBitPacking: {
@@ -271,32 +280,6 @@ void traverseEncodings(
           visitor);
       break;
     }
-    // SubIntSplit integration commented out (disabled):
-    /*
-    case EncodingType::SubIntSplit: {
-      const char* pos = stream.data() + kEncodingPrefixSize;
-      const uint8_t splitCount = encoding::read<uint8_t>(pos);
-      encoding::read<uint8_t>(pos); // reserved
-
-      std::vector<uint32_t> sectionBytes(splitCount);
-      for (uint8_t s = 0; s < splitCount; ++s) {
-        encoding::read<uint8_t>(pos); // bitStart
-        encoding::read<uint8_t>(pos); // bitEnd
-        sectionBytes[s] = encoding::readUint32(pos);
-      }
-
-      for (uint8_t s = 0; s < splitCount; ++s) {
-        traverseEncodings(
-            {pos, sectionBytes[s]},
-            level + 1,
-            s,
-            folly::to<std::string>("Section", static_cast<int>(s)),
-            visitor);
-        pos += sectionBytes[s];
-      }
-      break;
-    }
-    */
     case EncodingType::Sentinel: {
       const char* pos = stream.data() + kEncodingPrefixSize + 8;
       traverseEncodings(

--- a/dwio/nimble/velox/VeloxWriterOptions.h
+++ b/dwio/nimble/velox/VeloxWriterOptions.h
@@ -47,6 +47,7 @@ struct VeloxWriterOptions {
     return {
         .blockBitPackingBlockSize = blockBitPackingBlockSize,
         .fixedBitWidthUseExactBits = fixedBitWidthUseExactBits,
+        .allowNestedAlpSelection = allowNestedAlpSelection,
         .fsstCompressionTargetRatio = fsstCompressionTargetRatio};
   }
 
@@ -195,6 +196,11 @@ struct VeloxWriterOptions {
   /// FSST is kept only when its final encoded size is at most this fraction of
   /// the original string bytes.
   double fsstCompressionTargetRatio{0.6};
+
+  /// EXPERIMENTATION: Allows ALP to participate in nested floating-point
+  /// encoding selection. False by default; do not enable for production until
+  /// ALP is production-ready.
+  bool allowNestedAlpSelection{false};
 
   /// In low-memory mode, the writer is trying to perform smaller (and more
   /// precise) buffer allocations. This means that overall, the writer will

--- a/dwio/nimble/velox/selective/tests/FloatingPointColumnReaderTest.cpp
+++ b/dwio/nimble/velox/selective/tests/FloatingPointColumnReaderTest.cpp
@@ -1,0 +1,273 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "dwio/nimble/velox/selective/SelectiveNimbleReader.h"
+
+#include "dwio/nimble/common/tests/NimbleFileWriter.h"
+#include "dwio/nimble/velox/EncodingLayoutTree.h"
+#include "velox/common/base/tests/GTestUtils.h"
+#include "velox/common/io/IoStatistics.h"
+#include "velox/dwio/common/TypeUtils.h"
+#include "velox/vector/tests/utils/VectorTestBase.h"
+
+#include <fmt/format.h>
+#include <gtest/gtest.h>
+#include <random>
+#include <unordered_map>
+
+namespace facebook::nimble {
+namespace {
+
+using namespace facebook::velox;
+
+class FloatingPointColumnReaderTest : public ::testing::Test,
+                                      public velox::test::VectorTestBase {
+ protected:
+  static void SetUpTestCase() {
+    memory::initializeMemoryManager(velox::memory::MemoryManager::Options{});
+    registerSelectiveNimbleReaderFactory();
+  }
+
+  static void TearDownTestCase() {
+    unregisterSelectiveNimbleReaderFactory();
+  }
+
+  memory::MemoryPool* rootPool() {
+    return rootPool_.get();
+  }
+
+  struct Readers {
+    std::unique_ptr<dwio::common::Reader> reader;
+    std::unique_ptr<dwio::common::RowReader> rowReader;
+  };
+
+  Readers makeReaders(
+      const RowVectorPtr& expected,
+      const std::string& file,
+      const std::shared_ptr<common::ScanSpec>& scanSpec) {
+    auto readFile = std::make_shared<InMemoryReadFile>(file);
+    auto factory =
+        dwio::common::getReaderFactory(dwio::common::FileFormat::NIMBLE);
+    dwio::common::ReaderOptions options(pool());
+    options.setDataIoStats(dataIoStats_);
+    options.setMetadataIoStats(metadataIoStats_);
+    options.setScanSpec(scanSpec);
+
+    Readers readers;
+    readers.reader = factory->createReader(
+        std::make_unique<dwio::common::BufferedInput>(readFile, *pool()),
+        options);
+
+    dwio::common::RowReaderOptions rowOptions;
+    rowOptions.setScanSpec(scanSpec);
+    rowOptions.setRequestedType(asRowType(expected->type()));
+    rowOptions.setStringDecoderZeroCopy(true);
+    readers.rowReader = readers.reader->createRowReader(rowOptions);
+    return readers;
+  }
+
+  void validate(
+      const RowVector& expected,
+      dwio::common::RowReader& rowReader,
+      int batchSize) {
+    auto result = BaseVector::create(asRowType(expected.type()), 0, pool());
+    int numScanned = 0;
+    int offset = 0;
+    while (numScanned < expected.size()) {
+      numScanned += rowReader.next(batchSize, result);
+      result->validate();
+      for (int i = 0; i < result->size(); ++i) {
+        ASSERT_TRUE(result->equalValueAt(&expected, i, offset + i))
+            << "Mismatch at row " << (offset + i) << ": expected "
+            << expected.toString(offset + i) << " got " << result->toString(i);
+      }
+      offset += result->size();
+    }
+    ASSERT_EQ(numScanned, expected.size());
+    ASSERT_EQ(0, rowReader.next(1, result));
+  }
+
+  void validateWithFilter(
+      const RowVector& input,
+      dwio::common::RowReader& rowReader,
+      int batchSize,
+      const std::function<bool(int)>& filter) {
+    auto result = BaseVector::create(asRowType(input.type()), 0, pool());
+    int numScanned = 0;
+    int inputRow = 0;
+    while (numScanned < input.size()) {
+      numScanned += rowReader.next(batchSize, result);
+      result->validate();
+      for (int i = 0; i < result->size(); ++i) {
+        for (;;) {
+          ASSERT_LT(inputRow, input.size());
+          if (filter(inputRow)) {
+            break;
+          }
+          ++inputRow;
+        }
+        ASSERT_TRUE(result->equalValueAt(&input, i, inputRow))
+            << "Mismatch at input row " << inputRow;
+        ++inputRow;
+      }
+    }
+    while (inputRow < input.size()) {
+      ASSERT_FALSE(filter(inputRow));
+      ++inputRow;
+    }
+    ASSERT_EQ(numScanned, input.size());
+    ASSERT_EQ(0, rowReader.next(1, result));
+  }
+
+  template <typename T>
+  RowVectorPtr makeAlpInput() {
+    return makeRowVector({
+        makeFlatVector<T>(
+            257,
+            [](auto i) {
+              return static_cast<T>((static_cast<int32_t>(i % 67) - 33)) /
+                  static_cast<T>(4);
+            }),
+    });
+  }
+
+  template <typename T>
+  RowVectorPtr makeInput(const std::vector<T>& data) {
+    return makeRowVector({
+        makeFlatVector<T>(data.size(), [&](auto i) { return data[i]; }),
+    });
+  }
+
+  template <typename T>
+  void testAlpRead(int batchSize) {
+    SCOPED_TRACE(fmt::format("type={}", TypeTraits<T>::dataType));
+
+    auto input = makeAlpInput<T>();
+    auto scanSpec = std::make_shared<common::ScanSpec>("root");
+    scanSpec->addAllChildFields(*input->type());
+    const auto file = test::createNimbleFile(
+        *rootPool(), input, makeSingleScalarColumnWriterOptions());
+
+    auto readers = makeReaders(input, file, scanSpec);
+    validate(*input, *readers.rowReader, batchSize);
+  }
+
+  template <typename T>
+  void testAlpReadWithFilter(int batchSize) {
+    SCOPED_TRACE(fmt::format("type={}", TypeTraits<T>::dataType));
+    constexpr T kLower = static_cast<T>(-2.5);
+    constexpr T kUpper = static_cast<T>(2.5);
+
+    auto input = makeAlpInput<T>();
+    auto scanSpec = std::make_shared<common::ScanSpec>("root");
+    scanSpec->addAllChildFields(*input->type());
+    scanSpec->childByName("c0")->setFilter(
+        std::make_unique<common::FloatingPointRange<T>>(
+            kLower, false, false, kUpper, false, false, false));
+    const auto file = test::createNimbleFile(
+        *rootPool(), input, makeSingleScalarColumnWriterOptions());
+
+    auto readers = makeReaders(input, file, scanSpec);
+    validateWithFilter(*input, *readers.rowReader, batchSize, [](auto row) {
+      const auto value = static_cast<T>((static_cast<int32_t>(row % 67) - 33)) /
+          static_cast<T>(4);
+      return value >= kLower && value <= kUpper;
+    });
+  }
+
+  template <typename T>
+  void testAlpReadWithRandomFilter(uint32_t seed, int batchSize) {
+    SCOPED_TRACE(fmt::format("type={} seed={}", TypeTraits<T>::dataType, seed));
+
+    std::mt19937 rng(seed);
+    std::uniform_int_distribution<int32_t> valueDistribution{-10'000, 10'000};
+    std::uniform_int_distribution<int32_t> boundDistribution{-50, 50};
+
+    std::vector<T> data(511);
+    for (auto& value : data) {
+      value = static_cast<T>(valueDistribution(rng)) / static_cast<T>(100);
+    }
+
+    auto lower = static_cast<T>(boundDistribution(rng));
+    auto upper = static_cast<T>(boundDistribution(rng));
+    if (lower > upper) {
+      std::swap(lower, upper);
+    }
+
+    auto input = makeInput(data);
+    auto scanSpec = std::make_shared<common::ScanSpec>("root");
+    scanSpec->addAllChildFields(*input->type());
+    scanSpec->childByName("c0")->setFilter(
+        std::make_unique<common::FloatingPointRange<T>>(
+            lower, false, false, upper, false, false, false));
+    const auto file = test::createNimbleFile(
+        *rootPool(), input, makeSingleScalarColumnWriterOptions());
+
+    auto readers = makeReaders(input, file, scanSpec);
+    validateWithFilter(*input, *readers.rowReader, batchSize, [&](auto row) {
+      return data[row] >= lower && data[row] <= upper;
+    });
+  }
+
+  const std::shared_ptr<io::IoStatistics> dataIoStats_{
+      std::make_shared<io::IoStatistics>()};
+  const std::shared_ptr<io::IoStatistics> metadataIoStats_{
+      std::make_shared<io::IoStatistics>()};
+
+ private:
+  static EncodingLayout makeAlpEncodingLayout() {
+    return EncodingLayout{
+        EncodingType::ALP,
+        {},
+        CompressionType::Uncompressed,
+        {EncodingLayout{
+            EncodingType::FixedBitWidth, {}, CompressionType::Uncompressed}}};
+  }
+
+  static VeloxWriterOptions makeSingleScalarColumnWriterOptions() {
+    using StreamLayouts = std::
+        unordered_map<EncodingLayoutTree::StreamIdentifier, EncodingLayout>;
+
+    VeloxWriterOptions writerOptions;
+    writerOptions.encodingLayoutTree.emplace(
+        Kind::Row,
+        StreamLayouts{},
+        "",
+        std::vector<EncodingLayoutTree>{EncodingLayoutTree{
+            Kind::Scalar,
+            StreamLayouts{
+                {EncodingLayoutTree::StreamIdentifiers::Scalar::ScalarStream,
+                 makeAlpEncodingLayout()}},
+            "c0"}});
+    return writerOptions;
+  }
+};
+
+TEST_F(FloatingPointColumnReaderTest, alpFloatAndDoubleRead) {
+  testAlpRead<float>(19);
+  testAlpRead<double>(23);
+  testAlpReadWithFilter<float>(17);
+  testAlpReadWithFilter<double>(29);
+
+  for (const auto seed : {0xA11CEu, 0xBEEFu, 0xC0FFEEu}) {
+    SCOPED_TRACE(fmt::format("seed={}", seed));
+    testAlpReadWithRandomFilter<float>(seed, 31);
+    testAlpReadWithRandomFilter<double>(seed + 1, 37);
+  }
+}
+
+} // namespace
+} // namespace facebook::nimble

--- a/dwio/nimble/velox/tests/VeloxWriterTest.cpp
+++ b/dwio/nimble/velox/tests/VeloxWriterTest.cpp
@@ -83,6 +83,86 @@ class VeloxWriterTest : public ::testing::Test {
   std::shared_ptr<velox::memory::MemoryPool> leafPool_;
 };
 
+nimble::EncodingSelectionPolicyCreator makeEncodingSelectionPolicyCreator(
+    nimble::EncodingType encodingType) {
+  nimble::ManualEncodingSelectionPolicyFactory factory{
+      {{encodingType, 1.0}}, std::nullopt};
+  return [factory = std::move(factory)](nimble::DataType dataType)
+             -> std::unique_ptr<nimble::EncodingSelectionPolicyBase> {
+    return factory.createPolicy(dataType);
+  };
+}
+
+nimble::EncodingLayout captureFirstColumnEncoding(
+    const std::string& file,
+    velox::memory::MemoryPool* pool) {
+  auto readFile = std::make_shared<velox::InMemoryReadFile>(file);
+  auto tablet =
+      nimble::TabletReader::create(readFile, pool, makeTestTabletOptions(pool));
+  auto section =
+      tablet->loadOptionalSection(std::string(nimble::kSchemaSection));
+  NIMBLE_CHECK(section.has_value(), "Schema not found.");
+  auto schema =
+      nimble::SchemaDeserializer::deserialize(section->content().data());
+  const auto& scalarNode = schema->asRow().childAt(0)->asScalar();
+
+  std::vector<uint32_t> streamIdentifiers{
+      scalarNode.scalarDescriptor().offset()};
+  auto streams = tablet->load(tablet->stripeIdentifier(0), streamIdentifiers);
+  nimble::InMemoryChunkedStream chunkedStream{*pool, std::move(streams[0])};
+  NIMBLE_CHECK(chunkedStream.hasNext(), "Expected at least one chunk.");
+  return nimble::EncodingLayoutCapture::capture(chunkedStream.nextChunk());
+}
+
+template <typename T>
+void testAlpE2EWriterSelection(
+    velox::memory::MemoryPool& rootPool,
+    velox::memory::MemoryPool* leafPool) {
+  SCOPED_TRACE(fmt::format("type={}", nimble::TypeTraits<T>::dataType));
+
+  velox::test::VectorMaker vectorMaker{leafPool};
+  auto vector = vectorMaker.rowVector(
+      {"c0"}, {vectorMaker.flatVector<T>(512, [](auto row) {
+        return static_cast<T>(static_cast<int32_t>(row % 101) - 50) /
+            static_cast<T>(4);
+      })});
+
+  {
+    std::string file;
+    auto writeFile = std::make_unique<velox::InMemoryWriteFile>(&file);
+    nimble::VeloxWriterOptions options;
+    options.encodingSelectionPolicyCreator =
+        makeEncodingSelectionPolicyCreator(nimble::EncodingType::ALP);
+    nimble::VeloxWriter writer(
+        vector->type(), std::move(writeFile), rootPool, std::move(options));
+    writer.write(vector);
+    writer.close();
+
+    const auto captured = captureFirstColumnEncoding(file, leafPool);
+    EXPECT_EQ(captured.encodingType(), nimble::EncodingType::ALP);
+  }
+
+  {
+    std::string file;
+    auto writeFile = std::make_unique<velox::InMemoryWriteFile>(&file);
+    nimble::VeloxWriterOptions options;
+    options.allowNestedAlpSelection = true;
+    options.encodingSelectionPolicyCreator =
+        makeEncodingSelectionPolicyCreator(nimble::EncodingType::Dictionary);
+    nimble::VeloxWriter writer(
+        vector->type(), std::move(writeFile), rootPool, std::move(options));
+    writer.write(vector);
+    writer.close();
+
+    const auto captured = captureFirstColumnEncoding(file, leafPool);
+    ASSERT_EQ(captured.encodingType(), nimble::EncodingType::Dictionary);
+    const auto& alphabet =
+        captured.child(nimble::EncodingIdentifiers::Dictionary::Alphabet);
+    ASSERT_TRUE(alphabet.has_value());
+    EXPECT_EQ(alphabet->encodingType(), nimble::EncodingType::ALP);
+  }
+}
+
 TEST_F(VeloxWriterTest, emptyFile) {
   auto type = velox::ROW({{"simple", velox::INTEGER()}});
 
@@ -113,19 +193,32 @@ TEST_F(VeloxWriterTest, buildEncodingOptionsPropagatesEncodingOptions) {
     const nimble::VeloxWriterOptions options;
     const auto encodingOptions = options.buildEncodingOptions();
     EXPECT_FALSE(encodingOptions.fixedBitWidthUseExactBits);
+    EXPECT_FALSE(encodingOptions.allowNestedAlpSelection);
   }
 
   for (const auto useExactBits : {false, true}) {
     SCOPED_TRACE(fmt::format("useExactBits={}", useExactBits));
-    nimble::VeloxWriterOptions options;
-    options.fsstCompressionTargetRatio = 0.42;
-    options.fixedBitWidthUseExactBits = useExactBits;
+    for (const auto allowNestedAlpSelection : {false, true}) {
+      SCOPED_TRACE(
+          fmt::format("allowNestedAlpSelection={}", allowNestedAlpSelection));
+      nimble::VeloxWriterOptions options;
+      options.fsstCompressionTargetRatio = 0.42;
+      options.fixedBitWidthUseExactBits = useExactBits;
+      options.allowNestedAlpSelection = allowNestedAlpSelection;
 
-    const auto encodingOptions = options.buildEncodingOptions();
+      const auto encodingOptions = options.buildEncodingOptions();
 
-    EXPECT_DOUBLE_EQ(encodingOptions.fsstCompressionTargetRatio, 0.42);
-    EXPECT_EQ(encodingOptions.fixedBitWidthUseExactBits, useExactBits);
+      EXPECT_DOUBLE_EQ(encodingOptions.fsstCompressionTargetRatio, 0.42);
+      EXPECT_EQ(encodingOptions.fixedBitWidthUseExactBits, useExactBits);
+      EXPECT_EQ(
+          encodingOptions.allowNestedAlpSelection, allowNestedAlpSelection);
+    }
   }
+}
+
+TEST_F(VeloxWriterTest, alpEncodingSelectionControlsWriterEncoding) {
+  testAlpE2EWriterSelection<float>(*rootPool_, leafPool_.get());
+  testAlpE2EWriterSelection<double>(*rootPool_, leafPool_.get());
 }
 
 TEST_F(VeloxWriterTest, fsstEncodingTargetControlsWriterEncoding) {


### PR DESCRIPTION
Summary:

Implements experimental ALP encode/decode for float and double values using scaled signed integers, ZigZag storage in nested uint64 encoded values, and raw exception streams for values that do not round-trip exactly.

Wires ALP through the non-legacy encoding factory, encoding views, layout capture/traversal, and encoding utilities so explicitly selected ALP streams can be written, read, inspected, and tested end to end. ALP remains out of default read factors while it is experimental.

Adds ALP size estimation from logical floating-point values and an experiment-only allowAlpInNestedEncodingSelection option. When enabled, floating-point Dictionary::Alphabet nested selection can consider ALP so dictionary alphabets can be compared against regular Nimble nested encodings.

Propagates the option through VeloxWriterOptions and adds codec, selection, size-estimation, visitor, selective column reader, randomized fixed-layout, and Velox writer E2E coverage for float and double ALP paths.

Reviewed By: srsuryadev

Differential Revision: D110828880


