### PR TITLE
fix: Update NullColumnReaderTest to enable runtime filter

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "velox"]
 	path = velox
-	url = https://github.com/facebookincubator/velox.git
+	url = https://github.com/rui-mo/velox-dev.git
 [submodule "openzl"]
 	path = openzl
 	url = https://github.com/facebook/openzl.git

--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ Nimble integrates Velox as a Git submodule, referencing a specific commit of the
 Velox repository. The Velox badge at the top of this README shows the current
 commit and how far behind it is from Velox main.
 
-[See what changed since the current Velox commit.](https://github.com/facebookincubator/velox/compare/14779a1a9de69c6bd222396ab2f4bfe14e85fd48...main)
+[See what changed since the current Velox commit.](https://github.com/facebookincubator/velox/compare/4f27142e871f3993ec6eb9bb64d3caadb53216e6...main)
 <!-- pre-commit check-velox-readme validates the SHA above matches the submodule -->
 
 Advance Velox when your changes depend on code in Velox that

--- a/dwio/nimble/velox/selective/tests/NullColumnReaderTest.cpp
+++ b/dwio/nimble/velox/selective/tests/NullColumnReaderTest.cpp
@@ -176,12 +176,15 @@ TEST_F(NullColumnReaderTest, filterIsNullOnMissing) {
   auto result = BaseVector::create(readType, 0, pool());
   ASSERT_EQ(readers.rowReader->next(kSize, result), kSize);
   ASSERT_EQ(result->size(), kSize);
+  // Reader returns all rows; the missing column is all nulls.
+  auto* row = result->asUnchecked<RowVector>();
+  for (int i = 0; i < kSize; ++i) {
+    ASSERT_TRUE(row->childAt(1)->isNullAt(i));
+  }
 }
 
-// IsNotNull filter on a missing column.
-// Note: top-level missing field filter rejection is handled by
-// SplitReader::filterOnStats, not by the file reader. The reader materializes
-// all rows with the missing column as null constants regardless of filters.
+// With runtime filtering enabled for missing constants, all rows are
+// filtered out because the column materializes as all-null.
 TEST_F(NullColumnReaderTest, filterIsNotNullOnMissing) {
   constexpr int kSize = 50;
   auto input = makeRowVector({
@@ -194,16 +197,13 @@ TEST_F(NullColumnReaderTest, filterIsNotNullOnMissing) {
   auto readers = makeReaders(input, readType, scanSpec);
   auto result = BaseVector::create(readType, 0, pool());
   ASSERT_EQ(readers.rowReader->next(kSize, result), kSize);
-  // Reader returns all rows; the missing column is all nulls.
-  auto* row = result->asUnchecked<RowVector>();
-  for (int i = 0; i < kSize; ++i) {
-    ASSERT_TRUE(row->childAt(1)->isNullAt(i));
-  }
+  // Reader returns empty result; the missing column is all nulls.
+  ASSERT_EQ(result->size(), 0);
 }
 
 // BigintRange filter on a missing column.
-// Same as above: top-level missing field filter evaluation is handled by
-// SplitReader, not by the file reader.
+// Missing column materializes as null, which does not pass this filter
+// (nullAllowed=false), so all rows are filtered out.
 TEST_F(NullColumnReaderTest, filterValueOnMissing) {
   constexpr int kSize = 50;
   auto input = makeRowVector({
@@ -217,11 +217,8 @@ TEST_F(NullColumnReaderTest, filterValueOnMissing) {
   auto readers = makeReaders(input, readType, scanSpec);
   auto result = BaseVector::create(readType, 0, pool());
   ASSERT_EQ(readers.rowReader->next(kSize, result), kSize);
-  // Reader returns all rows; the missing column is all nulls.
-  auto* row = result->asUnchecked<RowVector>();
-  for (int i = 0; i < kSize; ++i) {
-    ASSERT_TRUE(row->childAt(1)->isNullAt(i));
-  }
+  // Reader returns empty result; the missing column is all nulls.
+  ASSERT_EQ(result->size(), 0);
 }
 
 // BigintRange(nullAllowed=true) on a missing column — all rows pass.
@@ -239,6 +236,11 @@ TEST_F(NullColumnReaderTest, filterValueAllowNullOnMissing) {
   auto result = BaseVector::create(readType, 0, pool());
   ASSERT_EQ(readers.rowReader->next(kSize, result), kSize);
   ASSERT_EQ(result->size(), kSize);
+  // Reader returns all rows; the missing column is all nulls.
+  auto* row = result->asUnchecked<RowVector>();
+  for (int i = 0; i < kSize; ++i) {
+    ASSERT_TRUE(row->childAt(1)->isNullAt(i));
+  }
 }
 
 // Read with small batch sizes to exercise skip on NullColumnReader.


### PR DESCRIPTION
Trying to address the incompatibility caused by https://github.com/facebookincubator/velox/pull/17554.