### PR TITLE
perf: Skip bitmap expansion for SparseBool-backed MainlyConstant

### DIFF
--- a/dwio/nimble/encodings/MainlyConstantEncoding.h
+++ b/dwio/nimble/encodings/MainlyConstantEncoding.h
@@ -35,6 +35,7 @@
 #include "dwio/nimble/encodings/selection/EncodingIdentifier.h"
 #include "dwio/nimble/encodings/selection/EncodingSelection.h"
 #include "velox/buffer/BufferPool.h"
+#include "velox/common/Casts.h"
 #include "velox/common/base/SimdUtil.h"
 #include "velox/common/memory/Memory.h"
 
@@ -102,6 +103,7 @@ class MainlyConstantEncodingBase
       : TypedEncoding<T, physicalType>(pool, data, options),
         isCommonBuffer_(this->template getVectorBuffer<bool>()),
         otherValuesBuffer_(this->template getVectorBuffer<physicalType>()),
+        otherIndicesBuffer_(this->template getVectorBuffer<uint32_t>()),
         dictionaryAlphabet_(&pool) {}
 
   static uint64_t estimateSize(
@@ -178,6 +180,7 @@ class MainlyConstantEncodingBase
   ~MainlyConstantEncodingBase() override {
     this->releaseVectorBuffer(isCommonBuffer_);
     this->releaseVectorBuffer(otherValuesBuffer_);
+    this->releaseVectorBuffer(otherIndicesBuffer_);
   }
 
   void reset() final {
@@ -186,6 +189,15 @@ class MainlyConstantEncodingBase
   }
 
   void skip(uint32_t rowCount) override {
+    if (auto* sparseUncommon = sparseUncommonPositions()) {
+      const uint32_t nonCommonCount =
+          sparseUncommon->skipSparseIndices(rowCount);
+      if (nonCommonCount != 0) {
+        otherValues_->skip(nonCommonCount);
+      }
+      return;
+    }
+
     // Use bit-packed booleans for efficient SIMD counting.
     const auto numWords = velox::bits::nwords(rowCount);
     isCommonBuffer_.resize(numWords * sizeof(uint64_t));
@@ -207,6 +219,11 @@ class MainlyConstantEncodingBase
   }
 
   void materialize(uint32_t rowCount, void* buffer) override {
+    if (auto* sparseUncommon = sparseUncommonPositions()) {
+      materializeWithSparseUncommonIndices(rowCount, buffer, *sparseUncommon);
+      return;
+    }
+
     // Use bit-packed booleans for efficient SIMD counting.
     // isCommon_ encodes a bool stream so materializeBoolsAsBits is always
     // implemented.
@@ -562,6 +579,37 @@ class MainlyConstantEncodingBase
     return count;
   }
 
+  SparseBoolEncoding* sparseUncommonPositions() {
+    if (isCommon_->encodingType() != EncodingType::SparseBool) {
+      return nullptr;
+    }
+
+    auto* sparseBool =
+        velox::checkedPointerCast<SparseBoolEncoding>(isCommon_.get());
+    return sparseBool->sparseValue() ? nullptr : sparseBool;
+  }
+
+  void materializeWithSparseUncommonIndices(
+      uint32_t rowCount,
+      void* buffer,
+      SparseBoolEncoding& sparseUncommon) {
+    const uint32_t nonCommonCount =
+        sparseUncommon.materializeSparseIndices(rowCount, otherIndicesBuffer_);
+
+    physicalType* output = static_cast<physicalType*>(buffer);
+    velox::simd::simdFill(output, commonValue_, rowCount);
+
+    if (nonCommonCount == 0) {
+      return;
+    }
+
+    otherValuesBuffer_.reserve(nonCommonCount);
+    otherValues_->materialize(nonCommonCount, otherValuesBuffer_.data());
+    for (uint32_t i = 0; i < nonCommonCount; ++i) {
+      output[otherIndicesBuffer_[i]] = otherValuesBuffer_[i];
+    }
+  }
+
   std::unique_ptr<Encoding> isCommon_;
   std::unique_ptr<Encoding> otherValues_;
   physicalType commonValue_;
@@ -576,6 +624,7 @@ class MainlyConstantEncodingBase
 
   Vector<bool> isCommonBuffer_;
   Vector<physicalType> otherValuesBuffer_;
+  Vector<uint32_t> otherIndicesBuffer_;
   velox::BufferPtr indicesBuffer_;
   mutable Vector<physicalType> dictionaryAlphabet_;
 };

--- a/dwio/nimble/encodings/SparseBoolEncoding.cpp
+++ b/dwio/nimble/encodings/SparseBoolEncoding.cpp
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#include <numeric>
+#include <algorithm>
 
 #include "dwio/nimble/encodings/SparseBoolEncoding.h"
 
@@ -95,6 +95,40 @@ void SparseBoolEncoding::materializeBoolsAsBits(
     }
   }
   row_ = end;
+}
+
+uint32_t SparseBoolEncoding::materializeSparseIndices(
+    uint32_t rowCount,
+    Vector<uint32_t>& buffer) {
+  const uint32_t maxSparsePositions =
+      std::min(rowCount, indices_.rowCount() - 1);
+  buffer.reserve(maxSparsePositions);
+  const uint32_t begin = row_;
+  const uint32_t end = row_ + rowCount;
+  uint32_t count{0};
+  auto* positions = buffer.data();
+  while (nextIndex_ < end) {
+    NIMBLE_DCHECK_LT(
+        count,
+        maxSparsePositions,
+        "SparseBool sparse position count exceeds its upper bound.");
+    positions[count++] = nextIndex_ - begin;
+    nextIndex_ = indices_.nextValue();
+  }
+  buffer.update_size(count);
+  row_ = end;
+  return count;
+}
+
+uint32_t SparseBoolEncoding::skipSparseIndices(uint32_t rowCount) {
+  uint32_t count{0};
+  const uint32_t end = row_ + rowCount;
+  while (nextIndex_ < end) {
+    ++count;
+    nextIndex_ = indices_.nextValue();
+  }
+  row_ = end;
+  return count;
 }
 
 std::string_view SparseBoolEncoding::encode(

--- a/dwio/nimble/encodings/SparseBoolEncoding.h
+++ b/dwio/nimble/encodings/SparseBoolEncoding.h
@@ -62,6 +62,20 @@ class SparseBoolEncoding final : public TypedEncoding<bool, bool> {
   void materializeBoolsAsBits(uint32_t rowCount, uint64_t* buffer, int begin)
       final;
 
+  /// Returns the bool value represented by the sparse position stream.
+  bool sparseValue() const noexcept {
+    return sparseValue_;
+  }
+
+  /// Appends sparse positions in the next rowCount rows, relative to the
+  /// current row, and advances the row cursor.
+  uint32_t materializeSparseIndices(
+      uint32_t rowCount,
+      Vector<uint32_t>& buffer);
+
+  /// Advances rowCount rows and returns how many sparse positions were skipped.
+  uint32_t skipSparseIndices(uint32_t rowCount);
+
   template <typename DecoderVisitor>
   void readWithVisitor(DecoderVisitor& visitor, ReadWithVisitorParams& params);
 

--- a/dwio/nimble/encodings/common/BufferedEncoding.h
+++ b/dwio/nimble/encodings/common/BufferedEncoding.h
@@ -41,6 +41,11 @@ class BufferedEncoding {
     encoding_->reset();
   }
 
+  /// Returns the number of values in the wrapped encoding.
+  uint32_t rowCount() const {
+    return encoding_->rowCount();
+  }
+
  private:
   FOLLY_ALWAYS_INLINE void refill() {
     auto numRows = std::min<uint32_t>(

--- a/dwio/nimble/encodings/tests/BufferedEncodingTest.cpp
+++ b/dwio/nimble/encodings/tests/BufferedEncodingTest.cpp
@@ -116,6 +116,22 @@ TEST_F(BufferedEncodingTest, valueModeNotDictionaryEnabled) {
   }
 }
 
+TEST_F(BufferedEncodingTest, valueModeRowCount) {
+  std::vector<uint32_t> data = {11, 22, 33, 44, 55};
+  auto encoding = createTrivialEncoding(data);
+  const auto expectedRowCount = encoding->rowCount();
+
+  nimble::detail::BufferedEncoding<uint32_t, 2> buf(std::move(encoding));
+  EXPECT_EQ(buf.rowCount(), expectedRowCount);
+
+  EXPECT_EQ(buf.nextValue(), data[0]);
+  EXPECT_EQ(buf.rowCount(), expectedRowCount);
+
+  buf.reset();
+  EXPECT_EQ(buf.rowCount(), expectedRowCount);
+  EXPECT_EQ(buf.nextValue(), data[0]);
+}
+
 TEST_F(BufferedEncodingTest, dictionaryModeRead) {
   std::vector<uint32_t> data = {10, 20, 30, 10, 20, 30, 10, 20, 30, 10};
   auto encoding = createDictEncoding(data);

--- a/dwio/nimble/encodings/tests/MainlyConstantEncodingTest.cpp
+++ b/dwio/nimble/encodings/tests/MainlyConstantEncodingTest.cpp
@@ -19,9 +19,12 @@
 #include "dwio/nimble/common/Buffer.h"
 #include "dwio/nimble/common/Types.h"
 #include "dwio/nimble/common/tests/NimbleCompare.h"
+#include "dwio/nimble/encodings/common/EncodingPrefix.h"
+#include "dwio/nimble/encodings/common/EncodingPrimitives.h"
 #include "dwio/nimble/encodings/common/EncodingType.h"
 #include "dwio/nimble/encodings/tests/TestUtils.h"
 
+#include <initializer_list>
 #include <limits>
 #include <string>
 #include <type_traits>
@@ -234,5 +237,83 @@ TYPED_TEST(MainlyConstantEncodingTest, deterministicSerializationOnTie) {
           << "MainlyConstant serialization is not deterministic (iteration "
           << i << ")";
     }
+  }
+}
+
+TEST(MainlyConstantEncodingV1Test, materializeSparseBoolIsCommon) {
+  auto pool = facebook::velox::memory::deprecatedAddDefaultLeafMemoryPool();
+  const auto toBoolVector = [&](std::initializer_list<bool> values) {
+    nimble::Vector<bool> vector{pool.get()};
+    vector.insert(vector.end(), values.begin(), values.end());
+    return vector;
+  };
+  const auto toInt32Vector = [&](std::initializer_list<int32_t> values) {
+    nimble::Vector<int32_t> vector{pool.get()};
+    vector.insert(vector.end(), values.begin(), values.end());
+    return vector;
+  };
+
+  for (const bool useVarint : {false, true}) {
+    SCOPED_TRACE(testing::Message() << "useVarint=" << useVarint);
+    const nimble::Encoding::Options options{.useVarintRowCount = useVarint};
+    nimble::Buffer childBuffer{*pool};
+    nimble::Buffer mainlyConstantBuffer{*pool};
+    std::vector<velox::BufferPtr> stringBuffers;
+    const auto stringBufferFactory = [&](uint32_t totalLength) {
+      return stringBuffers
+          .emplace_back(
+              velox::AlignedBuffer::allocate<char>(totalLength, pool.get()))
+          ->template asMutable<void>();
+    };
+
+    const auto isCommon = toBoolVector(
+        {true, true, false, true, false, true, true, false, true, true});
+    const auto otherValues = toInt32Vector({20, 40, 70});
+    const auto serializedIsCommon =
+        nimble::test::Encoder<nimble::SparseBoolEncoding>::encode(
+            childBuffer,
+            isCommon,
+            nimble::CompressionType::Uncompressed,
+            options);
+    const auto serializedOtherValues =
+        nimble::test::Encoder<nimble::TrivialEncoding<int32_t>>::encode(
+            childBuffer,
+            otherValues,
+            nimble::CompressionType::Uncompressed,
+            options);
+
+    const uint32_t rowCount = isCommon.size();
+    const uint32_t encodingSize =
+        nimble::EncodingPrefix::serializedSize(rowCount, useVarint) + 8 +
+        serializedIsCommon.size() + serializedOtherValues.size() +
+        sizeof(uint32_t);
+    char* const reserved = mainlyConstantBuffer.reserve(encodingSize);
+    char* pos = reserved;
+    nimble::EncodingPrefix::serialize(
+        nimble::EncodingType::MainlyConstant,
+        nimble::DataType::Int32,
+        rowCount,
+        useVarint,
+        pos);
+    nimble::encoding::writeString(serializedIsCommon, pos);
+    nimble::encoding::writeString(serializedOtherValues, pos);
+    nimble::encoding::write<uint32_t>(7, pos);
+    ASSERT_EQ(pos - reserved, encodingSize);
+
+    nimble::MainlyConstantEncoding<int32_t> encoding{
+        *pool, {reserved, encodingSize}, stringBufferFactory, options};
+    nimble::Vector<int32_t> result{pool.get(), rowCount};
+    encoding.materialize(rowCount, result.data());
+    EXPECT_EQ(
+        std::vector<int32_t>(result.begin(), result.end()),
+        std::vector<int32_t>({7, 7, 20, 7, 40, 7, 7, 70, 7, 7}));
+
+    encoding.reset();
+    encoding.skip(3);
+    nimble::Vector<int32_t> partial{pool.get(), 4};
+    encoding.materialize(4, partial.data());
+    EXPECT_EQ(
+        std::vector<int32_t>(partial.begin(), partial.end()),
+        std::vector<int32_t>({7, 40, 7, 7}));
   }
 }

--- a/dwio/nimble/encodings/tests/SparseBoolEncodingTest.cpp
+++ b/dwio/nimble/encodings/tests/SparseBoolEncodingTest.cpp
@@ -24,6 +24,8 @@
 #include "folly/Random.h"
 #include "velox/common/memory/Memory.h"
 
+#include <vector>
+
 using namespace facebook;
 
 template <bool UseVarint>
@@ -137,6 +139,79 @@ TYPED_TEST(SparseBoolEncodingTest, sparseFalse) {
   for (uint32_t i = 0; i < 10; ++i) {
     EXPECT_EQ(result[i], values[i]) << "index " << i;
   }
+}
+
+TYPED_TEST(SparseBoolEncodingTest, materializeSparseIndicesForSparseFalse) {
+  const nimble::Encoding::Options options{
+      .useVarintRowCount = TypeParam::useVarint};
+  auto values = this->toVector(
+      {true, true, false, true, false, true, true, false, true, true});
+  auto encoding = this->createEncoding(values, options);
+  auto* sparseBool = dynamic_cast<nimble::SparseBoolEncoding*>(encoding.get());
+  ASSERT_NE(sparseBool, nullptr);
+  EXPECT_FALSE(sparseBool->sparseValue());
+
+  nimble::Vector<uint32_t> positions{this->pool_.get()};
+  EXPECT_EQ(sparseBool->materializeSparseIndices(5, positions), 2);
+  EXPECT_EQ(
+      std::vector<uint32_t>(positions.begin(), positions.end()),
+      std::vector<uint32_t>({2, 4}));
+
+  EXPECT_EQ(sparseBool->materializeSparseIndices(5, positions), 1);
+  EXPECT_EQ(
+      std::vector<uint32_t>(positions.begin(), positions.end()),
+      std::vector<uint32_t>({2}));
+
+  sparseBool->reset();
+  EXPECT_EQ(sparseBool->skipSparseIndices(5), 2);
+  EXPECT_EQ(sparseBool->materializeSparseIndices(5, positions), 1);
+  EXPECT_EQ(
+      std::vector<uint32_t>(positions.begin(), positions.end()),
+      std::vector<uint32_t>({2}));
+}
+
+TYPED_TEST(SparseBoolEncodingTest, materializeSparseIndicesForSparseTrue) {
+  const nimble::Encoding::Options options{
+      .useVarintRowCount = TypeParam::useVarint};
+  auto values = this->toVector(
+      {false, true, false, false, false, false, true, false, false, false});
+  auto encoding = this->createEncoding(values, options);
+  auto* sparseBool = dynamic_cast<nimble::SparseBoolEncoding*>(encoding.get());
+  ASSERT_NE(sparseBool, nullptr);
+  EXPECT_TRUE(sparseBool->sparseValue());
+
+  nimble::Vector<uint32_t> positions{this->pool_.get()};
+  EXPECT_EQ(sparseBool->materializeSparseIndices(10, positions), 2);
+  EXPECT_EQ(
+      std::vector<uint32_t>(positions.begin(), positions.end()),
+      std::vector<uint32_t>({1, 6}));
+
+  sparseBool->reset();
+  EXPECT_EQ(sparseBool->skipSparseIndices(5), 1);
+  EXPECT_EQ(sparseBool->materializeSparseIndices(5, positions), 1);
+  EXPECT_EQ(
+      std::vector<uint32_t>(positions.begin(), positions.end()),
+      std::vector<uint32_t>({1}));
+}
+
+TYPED_TEST(SparseBoolEncodingTest, sparseValueReportsPositionPolarity) {
+  const nimble::Encoding::Options options{
+      .useVarintRowCount = TypeParam::useVarint};
+  auto sparseFalseValues = this->toVector(
+      {true, true, false, true, true, true, true, true, true, true});
+  auto sparseFalseEncoding = this->createEncoding(sparseFalseValues, options);
+  auto* sparseFalse =
+      dynamic_cast<nimble::SparseBoolEncoding*>(sparseFalseEncoding.get());
+  ASSERT_NE(sparseFalse, nullptr);
+  EXPECT_FALSE(sparseFalse->sparseValue());
+
+  auto sparseTrueValues = this->toVector(
+      {false, false, true, false, false, false, false, false, false, false});
+  auto sparseTrueEncoding = this->createEncoding(sparseTrueValues, options);
+  auto* sparseTrue =
+      dynamic_cast<nimble::SparseBoolEncoding*>(sparseTrueEncoding.get());
+  ASSERT_NE(sparseTrue, nullptr);
+  EXPECT_TRUE(sparseTrue->sparseValue());
 }
 
 TYPED_TEST(SparseBoolEncodingTest, singleElement) {


### PR DESCRIPTION
Summary: Add a V1 read fast path for MainlyConstant streams whose isCommon child is SparseBool storing false positions. SparseBool now exposes sparse-position materialization/skip helpers, and MainlyConstant uses them to avoid expanding the bool mask, popcounting it, and scanning the dense bitmap before scattering uncommon values. This preserves the existing fallback for RLE, dense bool masks, and SparseBool streams that store true/common positions.

Differential Revision: D110930206


