### PR TITLE
fix: Make SimdForBitpack EncodingView reads thread-safe (#949)

### DIFF
--- a/dwio/nimble/encodings/tests/ALPEncodingViewTest.cpp
+++ b/dwio/nimble/encodings/tests/ALPEncodingViewTest.cpp
@@ -23,10 +23,20 @@
 using namespace facebook;
 
 using EncodingViewTest = nimble::test::EncodingViewTest;
+using ALPEncodingViewTest = nimble::test::EncodingViewTest;
 
 TEST_F(EncodingViewTest, readsAlpEncoding) {
   expectReads<nimble::ALPEncoding<float>>(
       makeVector<float>({-12.5F, -1.25F, 0.0F, 1.25F, 12.5F}), {4, 0, 2, 1, 3});
   expectReads<nimble::ALPEncoding<double>>(
       makeVector<double>({-12.5, -1.25, 0.0, 1.25, 12.5}), {4, 0, 2, 1, 3});
+}
+
+TEST_F(ALPEncodingViewTest, concurrent) {
+  const auto positions = randomizedPositions(/*seed=*/14);
+
+  expectConcurrentReads<nimble::ALPEncoding<float>>(
+      randomAlpData<float>(/*seed=*/15), positions);
+  expectConcurrentReads<nimble::ALPEncoding<double>>(
+      randomAlpData<double>(/*seed=*/16), positions);
 }

--- a/dwio/nimble/encodings/tests/BlockBitPackingEncodingViewTest.cpp
+++ b/dwio/nimble/encodings/tests/BlockBitPackingEncodingViewTest.cpp
@@ -24,6 +24,7 @@
 using namespace facebook;
 
 using EncodingViewTest = nimble::test::EncodingViewTest;
+using BlockBitPackingEncodingViewTest = nimble::test::EncodingViewTest;
 
 TEST_F(EncodingViewTest, readsBlockBitPackingEncoding) {
   nimble::Vector<int32_t> values{pool_.get()};
@@ -35,4 +36,14 @@ TEST_F(EncodingViewTest, readsBlockBitPackingEncoding) {
   options.blockBitPackingBlockSize = 8;
   expectReads<nimble::BlockBitPackingEncoding<int32_t>>(
       values, {17, 0, 8, 9, 19, 3}, options);
+}
+
+TEST_F(BlockBitPackingEncodingViewTest, concurrent) {
+  nimble::Encoding::Options options;
+  options.blockBitPackingBlockSize = 64;
+
+  expectConcurrentReads<nimble::BlockBitPackingEncoding<uint32_t>>(
+      randomNarrowUnsigned<uint32_t>(/*seed=*/23),
+      randomizedPositions(/*seed=*/24),
+      options);
 }

--- a/dwio/nimble/encodings/tests/ConstantEncodingViewTest.cpp
+++ b/dwio/nimble/encodings/tests/ConstantEncodingViewTest.cpp
@@ -23,8 +23,14 @@
 using namespace facebook;
 
 using EncodingViewTest = nimble::test::EncodingViewTest;
+using ConstantEncodingViewTest = nimble::test::EncodingViewTest;
 
 TEST_F(EncodingViewTest, readsConstantEncoding) {
   expectReads<nimble::ConstantEncoding<int32_t>>(
       makeVector({7, 7, 7, 7}), {3, 0, 2, 2, 1});
+}
+
+TEST_F(ConstantEncodingViewTest, concurrent) {
+  expectConcurrentReads<nimble::ConstantEncoding<int32_t>>(
+      constantInt32(/*value=*/42), randomizedPositions(/*seed=*/1));
 }

--- a/dwio/nimble/encodings/tests/DictionaryEncodingViewTest.cpp
+++ b/dwio/nimble/encodings/tests/DictionaryEncodingViewTest.cpp
@@ -16,6 +16,9 @@
 
 #include "dwio/nimble/encodings/tests/EncodingViewTestUtils.h"
 
+#include <string>
+#include <vector>
+
 #include <gtest/gtest.h>
 
 #include "dwio/nimble/encodings/DictionaryEncoding.h"
@@ -23,6 +26,7 @@
 using namespace facebook;
 
 using EncodingViewTest = nimble::test::EncodingViewTest;
+using DictionaryEncodingViewTest = nimble::test::EncodingViewTest;
 
 TEST_F(EncodingViewTest, readsDictionaryEncoding) {
   expectReads<nimble::DictionaryEncoding<int32_t>>(
@@ -39,4 +43,14 @@ TEST_F(EncodingViewTest, readsDictionaryEncodingForSupportedTypeFamilies) {
   expectReads<nimble::DictionaryEncoding<std::string_view>>(
       makeVector<std::string_view>({"alpha", "beta", "alpha", "gamma", "beta"}),
       {4, 0, 3, 2, 1});
+}
+
+TEST_F(DictionaryEncodingViewTest, concurrent) {
+  const auto positions = randomizedPositions(/*seed=*/8);
+  std::vector<std::string> backing;
+
+  expectConcurrentReads<nimble::DictionaryEncoding<uint32_t>>(
+      randomDictionaryUint32(/*seed=*/9), positions);
+  expectConcurrentReads<nimble::DictionaryEncoding<std::string_view>>(
+      randomStringViews(backing, /*seed=*/10), positions);
 }

--- a/dwio/nimble/encodings/tests/EncodingViewTestUtils.h
+++ b/dwio/nimble/encodings/tests/EncodingViewTestUtils.h
@@ -15,9 +15,14 @@
  */
 #pragma once
 
+#include <algorithm>
+#include <atomic>
 #include <cstdint>
 #include <initializer_list>
 #include <memory>
+#include <random>
+#include <string>
+#include <thread>
 #include <vector>
 
 #include <gtest/gtest.h>
@@ -34,6 +39,8 @@ namespace facebook::nimble::test {
 
 class EncodingViewTest : public ::testing::Test {
  protected:
+  static constexpr uint32_t kConcurrentRows = 1024;
+
   void SetUp() override {
     pool_ = facebook::velox::memory::deprecatedAddDefaultLeafMemoryPool();
     buffer_ = std::make_unique<nimble::Buffer>(*pool_);
@@ -67,6 +74,191 @@ class EncodingViewTest : public ::testing::Test {
         EXPECT_EQ(value, values[position]);
       }
     }
+  }
+
+  template <typename Encoding>
+  void expectConcurrentReads(
+      const nimble::Vector<typename Encoding::cppDataType>& values,
+      const std::vector<uint32_t>& positions,
+      nimble::Encoding::Options baseOptions = {}) {
+    using T = typename Encoding::cppDataType;
+    for (const auto useVarint : {false, true}) {
+      SCOPED_TRACE(fmt::format("useVarint={}", useVarint));
+      auto options = baseOptions;
+      options.useVarintRowCount = useVarint;
+      auto serialized = nimble::test::Encoder<Encoding>::encode(
+          *buffer_, values, nimble::CompressionType::Uncompressed, options);
+      auto view = nimble::createEncodingView(serialized, pool_.get(), options);
+      ASSERT_NE(view, nullptr);
+
+      constexpr auto kThreadCount = 8;
+      constexpr auto kIterationCount = 64;
+      std::atomic<bool> failed{false};
+      std::vector<std::thread> threads;
+      threads.reserve(kThreadCount);
+      for (auto threadIndex = 0; threadIndex < kThreadCount; ++threadIndex) {
+        threads.emplace_back([&, threadIndex] {
+          std::mt19937 rng{
+              positions[threadIndex % positions.size()] + threadIndex};
+          std::uniform_int_distribution<size_t> positionIndex{
+              0, positions.size() - 1};
+          for (auto iteration = 0; iteration < kIterationCount; ++iteration) {
+            for (size_t read = 0; read < positions.size() / kThreadCount;
+                 ++read) {
+              const auto position = positions[positionIndex(rng)];
+              T value;
+              view->readAt(position, &value);
+              if (value != values[position]) {
+                failed.store(true, std::memory_order_relaxed);
+                return;
+              }
+            }
+          }
+        });
+      }
+
+      for (auto& thread : threads) {
+        thread.join();
+      }
+      EXPECT_FALSE(failed.load(std::memory_order_relaxed));
+    }
+  }
+
+  std::vector<uint32_t> randomizedPositions(uint32_t seed) {
+    std::mt19937 rng{seed};
+    std::uniform_int_distribution<uint32_t> position{0, kConcurrentRows - 1};
+    std::vector<uint32_t> positions;
+    positions.reserve(4096);
+    for (uint32_t i = 0; i < 4096; ++i) {
+      positions.push_back(position(rng));
+    }
+    return positions;
+  }
+
+  nimble::Vector<int32_t> constantInt32(int32_t value) {
+    nimble::Vector<int32_t> values{pool_.get()};
+    values.resize(kConcurrentRows, value);
+    return values;
+  }
+
+  nimble::Vector<int32_t> randomInt32(uint32_t seed) {
+    std::mt19937 rng{seed};
+    std::uniform_int_distribution<int32_t> value{-1024, 1024};
+    nimble::Vector<int32_t> values{pool_.get()};
+    values.reserve(kConcurrentRows);
+    for (uint32_t i = 0; i < kConcurrentRows; ++i) {
+      values.push_back(value(rng));
+    }
+    return values;
+  }
+
+  template <typename T>
+  nimble::Vector<T> randomNarrowUnsigned(uint32_t seed) {
+    std::mt19937 rng{seed};
+    std::uniform_int_distribution<uint32_t> value{0, 63};
+    nimble::Vector<T> values{pool_.get()};
+    values.reserve(kConcurrentRows);
+    for (uint32_t i = 0; i < kConcurrentRows; ++i) {
+      values.push_back(static_cast<T>(value(rng)));
+    }
+    return values;
+  }
+
+  nimble::Vector<uint32_t> randomPforData(uint32_t seed) {
+    std::mt19937 rng{seed};
+    std::uniform_int_distribution<uint32_t> narrowValue{0, 31};
+    std::uniform_int_distribution<uint32_t> exceptionValue{10000, 12000};
+    nimble::Vector<uint32_t> values{pool_.get()};
+    values.reserve(kConcurrentRows);
+    for (uint32_t i = 0; i < kConcurrentRows; ++i) {
+      values.push_back(i % 23 == 0 ? exceptionValue(rng) : narrowValue(rng));
+    }
+    return values;
+  }
+
+  template <typename T>
+  nimble::Vector<T> randomAlpData(uint32_t seed) {
+    std::mt19937 rng{seed};
+    std::uniform_int_distribution<int32_t> value{-400, 400};
+    nimble::Vector<T> values{pool_.get()};
+    values.reserve(kConcurrentRows);
+    for (uint32_t i = 0; i < kConcurrentRows; ++i) {
+      values.push_back(static_cast<T>(value(rng)) / 4);
+    }
+    return values;
+  }
+
+  nimble::Vector<bool> randomBool(uint32_t seed) {
+    std::mt19937 rng{seed};
+    nimble::Vector<bool> values{pool_.get()};
+    values.reserve(kConcurrentRows);
+    for (uint32_t i = 0; i < kConcurrentRows; ++i) {
+      values.push_back((rng() % 5) == 0);
+    }
+    return values;
+  }
+
+  nimble::Vector<int32_t> randomRleInt32(uint32_t seed) {
+    std::mt19937 rng{seed};
+    std::uniform_int_distribution<int32_t> value{-32, 32};
+    std::uniform_int_distribution<uint32_t> runLength{1, 9};
+    nimble::Vector<int32_t> values{pool_.get()};
+    values.reserve(kConcurrentRows);
+    while (values.size() < kConcurrentRows) {
+      const auto runValue = value(rng);
+      const auto count = std::min<uint32_t>(
+          runLength(rng),
+          static_cast<uint32_t>(kConcurrentRows - values.size()));
+      for (uint32_t i = 0; i < count; ++i) {
+        values.push_back(runValue);
+      }
+    }
+    return values;
+  }
+
+  nimble::Vector<bool> randomRleBool(uint32_t seed) {
+    std::mt19937 rng{seed};
+    std::uniform_int_distribution<uint32_t> runLength{1, 9};
+    nimble::Vector<bool> values{pool_.get()};
+    values.reserve(kConcurrentRows);
+    bool value = (rng() % 2) == 0;
+    while (values.size() < kConcurrentRows) {
+      const auto count = std::min<uint32_t>(
+          runLength(rng),
+          static_cast<uint32_t>(kConcurrentRows - values.size()));
+      for (uint32_t i = 0; i < count; ++i) {
+        values.push_back(value);
+      }
+      value = !value;
+    }
+    return values;
+  }
+
+  nimble::Vector<uint32_t> randomDictionaryUint32(uint32_t seed) {
+    std::mt19937 rng{seed};
+    std::uniform_int_distribution<uint32_t> index{0, 15};
+    nimble::Vector<uint32_t> values{pool_.get()};
+    values.reserve(kConcurrentRows);
+    for (uint32_t i = 0; i < kConcurrentRows; ++i) {
+      values.push_back(1000 + index(rng) * 17);
+    }
+    return values;
+  }
+
+  nimble::Vector<std::string_view> randomStringViews(
+      std::vector<std::string>& backing,
+      uint32_t seed) {
+    std::mt19937 rng{seed};
+    std::uniform_int_distribution<uint32_t> suffix{0, 31};
+    backing.clear();
+    backing.reserve(kConcurrentRows);
+    nimble::Vector<std::string_view> values{pool_.get()};
+    values.reserve(kConcurrentRows);
+    for (uint32_t i = 0; i < kConcurrentRows; ++i) {
+      backing.push_back(fmt::format("value-{}", suffix(rng)));
+      values.push_back(backing.back());
+    }
+    return values;
   }
 
   std::shared_ptr<velox::memory::MemoryPool> pool_;

--- a/dwio/nimble/encodings/tests/FixedBitWidthEncodingViewTest.cpp
+++ b/dwio/nimble/encodings/tests/FixedBitWidthEncodingViewTest.cpp
@@ -23,8 +23,15 @@
 using namespace facebook;
 
 using EncodingViewTest = nimble::test::EncodingViewTest;
+using FixedBitWidthEncodingViewTest = nimble::test::EncodingViewTest;
 
 TEST_F(EncodingViewTest, readsFixedBitWidthEncoding) {
   expectReads<nimble::FixedBitWidthEncoding<int32_t>>(
       makeVector({10, 12, 15, 31, 33, 63}), {5, 0, 4, 2, 1});
+}
+
+TEST_F(FixedBitWidthEncodingViewTest, concurrent) {
+  expectConcurrentReads<nimble::FixedBitWidthEncoding<uint32_t>>(
+      randomNarrowUnsigned<uint32_t>(/*seed=*/6),
+      randomizedPositions(/*seed=*/7));
 }

--- a/dwio/nimble/encodings/tests/PFOREncodingViewTest.cpp
+++ b/dwio/nimble/encodings/tests/PFOREncodingViewTest.cpp
@@ -23,9 +23,15 @@
 using namespace facebook;
 
 using EncodingViewTest = nimble::test::EncodingViewTest;
+using PFOREncodingViewTest = nimble::test::EncodingViewTest;
 
 TEST_F(EncodingViewTest, readsPforEncoding) {
   expectReads<nimble::PFOREncoding<int32_t>>(
       makeVector({100, 101, 102, 103, 104, 105, 106, 107, 100000, 108, 109}),
       {8, 0, 10, 4, 8, 2});
+}
+
+TEST_F(PFOREncodingViewTest, concurrent) {
+  expectConcurrentReads<nimble::PFOREncoding<uint32_t>>(
+      randomPforData(/*seed=*/17), randomizedPositions(/*seed=*/18));
 }

--- a/dwio/nimble/encodings/tests/RLEEncodingViewTest.cpp
+++ b/dwio/nimble/encodings/tests/RLEEncodingViewTest.cpp
@@ -23,8 +23,18 @@
 using namespace facebook;
 
 using EncodingViewTest = nimble::test::EncodingViewTest;
+using RLEEncodingViewTest = nimble::test::EncodingViewTest;
 
 TEST_F(EncodingViewTest, readsRleEncoding) {
   expectReads<nimble::RLEEncoding<int32_t>>(
       makeVector({1, 1, 1, 2, 2, 3, 3, 3, 3, 4}), {9, 0, 4, 5, 8, 2});
+}
+
+TEST_F(RLEEncodingViewTest, concurrent) {
+  const auto positions = randomizedPositions(/*seed=*/11);
+
+  expectConcurrentReads<nimble::RLEEncoding<int32_t>>(
+      randomRleInt32(/*seed=*/12), positions);
+  expectConcurrentReads<nimble::RLEEncoding<bool>>(
+      randomRleBool(/*seed=*/13), positions);
 }

--- a/dwio/nimble/encodings/tests/SimdForBitpackEncodingViewTest.cpp
+++ b/dwio/nimble/encodings/tests/SimdForBitpackEncodingViewTest.cpp
@@ -23,6 +23,7 @@
 using namespace facebook;
 
 using EncodingViewTest = nimble::test::EncodingViewTest;
+using SimdForBitpackEncodingViewTest = nimble::test::EncodingViewTest;
 
 TEST_F(EncodingViewTest, readsSimdForBitpackEncoding) {
   nimble::Vector<int32_t> values{pool_.get()};
@@ -31,4 +32,15 @@ TEST_F(EncodingViewTest, readsSimdForBitpackEncoding) {
   }
   expectReads<nimble::SimdForBitpackEncoding<int32_t>>(
       values, {69, 0, 31, 32, 64, 7});
+}
+
+TEST_F(SimdForBitpackEncodingViewTest, concurrent) {
+  const auto positions = randomizedPositions(/*seed=*/19);
+
+  expectConcurrentReads<nimble::SimdForBitpackEncoding<uint32_t>>(
+      randomNarrowUnsigned<uint32_t>(/*seed=*/20), positions);
+  expectConcurrentReads<nimble::SimdForBitpackEncoding<uint16_t>>(
+      randomNarrowUnsigned<uint16_t>(/*seed=*/21), positions);
+  expectConcurrentReads<nimble::SimdForBitpackEncoding<uint8_t>>(
+      randomNarrowUnsigned<uint8_t>(/*seed=*/22), positions);
 }

--- a/dwio/nimble/encodings/tests/TrivialEncodingViewTest.cpp
+++ b/dwio/nimble/encodings/tests/TrivialEncodingViewTest.cpp
@@ -16,6 +16,9 @@
 
 #include "dwio/nimble/encodings/tests/EncodingViewTestUtils.h"
 
+#include <string>
+#include <vector>
+
 #include <gtest/gtest.h>
 
 #include "dwio/nimble/encodings/TrivialEncoding.h"
@@ -23,6 +26,7 @@
 using namespace facebook;
 
 using EncodingViewTest = nimble::test::EncodingViewTest;
+using TrivialEncodingViewTest = nimble::test::EncodingViewTest;
 
 TEST_F(EncodingViewTest, readsTrivialEncoding) {
   expectReads<nimble::TrivialEncoding<int32_t>>(
@@ -37,4 +41,16 @@ TEST_F(EncodingViewTest, readsTrivialEncodingForAllLayoutFamilies) {
   expectReads<nimble::TrivialEncoding<std::string_view>>(
       makeVector<std::string_view>({"alpha", "", "beta", "longer-value"}),
       {3, 0, 1, 2});
+}
+
+TEST_F(TrivialEncodingViewTest, concurrent) {
+  const auto positions = randomizedPositions(/*seed=*/2);
+  std::vector<std::string> backing;
+
+  expectConcurrentReads<nimble::TrivialEncoding<int32_t>>(
+      randomInt32(/*seed=*/3), positions);
+  expectConcurrentReads<nimble::TrivialEncoding<bool>>(
+      randomBool(/*seed=*/4), positions);
+  expectConcurrentReads<nimble::TrivialEncoding<std::string_view>>(
+      randomStringViews(backing, /*seed=*/5), positions);
 }

--- a/dwio/nimble/encodings/views/SimdForBitpackEncodingView.h
+++ b/dwio/nimble/encodings/views/SimdForBitpackEncodingView.h
@@ -49,12 +49,10 @@ class SimdForBitpackEncodingView final : public TypedEncodingView<T> {
     }
 
     const auto groupIndex = index / kGroupSize;
-    if (cachedGroupIndex_ != groupIndex) {
-      unpackGroup(groupIndex, cachedGroup_.data());
-      cachedGroupIndex_ = groupIndex;
-    }
-    return detail::castFromPhysicalType<T>(static_cast<physicalType>(
-        cachedGroup_[index % kGroupSize] + baseline_));
+    std::array<physicalType, kGroupSize> group{};
+    unpackGroup(groupIndex, group.data());
+    return detail::castFromPhysicalType<T>(
+        static_cast<physicalType>(group[index % kGroupSize] + baseline_));
   }
 
   static constexpr uint32_t kGroupSize = SimdForBitpackEncoding<T>::kGroupSize;
@@ -87,8 +85,6 @@ class SimdForBitpackEncodingView final : public TypedEncodingView<T> {
   physicalType baseline_{};
   uint8_t bitWidth_{0};
   const char* packedData_{nullptr};
-  mutable uint32_t cachedGroupIndex_{~0u};
-  mutable std::array<physicalType, kGroupSize> cachedGroup_{};
 };
 
 } // namespace facebook::nimble

--- a/dwio/nimble/fuzzer/encoding/CMakeLists.txt
+++ b/dwio/nimble/fuzzer/encoding/CMakeLists.txt
@@ -11,6 +11,31 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+if(NOT TARGET gflags::gflags)
+  find_package(gflags CONFIG QUIET)
+endif()
+
+if(NOT TARGET gflags::gflags)
+  find_package(gflags QUIET)
+endif()
+
+if(NOT TARGET gflags::gflags)
+  foreach(_nimble_gflags_target
+          gflags
+          gflags_static
+          gflags_nothreads_static
+          gflags_shared
+          gflags_nothreads_shared
+  )
+    if(TARGET ${_nimble_gflags_target})
+      add_library(nimble_gflags INTERFACE)
+      target_link_libraries(nimble_gflags INTERFACE ${_nimble_gflags_target})
+      add_library(gflags::gflags ALIAS nimble_gflags)
+      break()
+    endif()
+  endforeach()
+endif()
+
 add_executable(nimble_encoding_fuzzer_tests EncodingFuzzerTest.cpp)
 
 target_compile_definitions(


### PR DESCRIPTION
Summary:

Remove the shared mutable decode cache from `SimdForBitpackEncodingView` so concurrent `readAt` calls on the same view do not race. Decode each requested group into stack-local storage instead, and add randomized `concurrent` tests beside each supported `EncodingView` test file. The SIMD view benchmark did not show a material regression; the `uint32` case was roughly flat and the narrower `uint16`/`uint8` cases improved in the measured run.

Differential Revision: D111392053


