### PR TITLE
perf: Reuse encoding scratch buffers during writes (#950)

### DIFF
--- a/dwio/nimble/common/Buffer.cpp
+++ b/dwio/nimble/common/Buffer.cpp
@@ -15,6 +15,7 @@
  */
 
 #include "dwio/nimble/common/Buffer.h"
+#include "dwio/nimble/common/Exceptions.h"
 
 namespace facebook::nimble {
 
@@ -53,12 +54,56 @@ bool Buffer::tryAdvanceToNextChunk(uint64_t bytes) {
 
 void Buffer::addChunk(uint64_t bytes) {
   const uint64_t chunkSize = std::max(bytes, kMinChunkSize);
-  auto bufferPtr = velox::AlignedBuffer::allocate<char>(chunkSize, memoryPool_);
+  auto bufferPtr = velox::AlignedBuffer::allocateExact<char>(chunkSize, pool_);
   pos_ = bufferPtr->asMutable<char>();
   chunkEnd_ = pos_ + chunkSize;
   reserveEnd_ = pos_ + bytes;
-  chunks_.push_back(std::move(bufferPtr));
+  chunks_.emplace_back(std::move(bufferPtr));
   chunkIndex_ = chunks_.size() - 1;
+}
+
+EncodingBufferPool::EncodingBufferPool(
+    MemoryPool* pool,
+    uint32_t maxCachedBuffers)
+    : pool_{pool}, maxCachedBuffers_{maxCachedBuffers} {
+  NIMBLE_CHECK_NOT_NULL(pool_, "Memory pool cannot be null");
+}
+
+std::unique_ptr<Buffer> EncodingBufferPool::acquire() {
+  if (!buffers_.empty()) {
+    auto buffer = std::move(buffers_.back());
+    buffers_.pop_back();
+    // Keep acquire() as the handoff point that guarantees a clean scratch
+    // buffer, even though release() also resets before caching.
+    buffer->reset();
+    return buffer;
+  }
+
+  return std::make_unique<Buffer>(*pool_);
+}
+
+void EncodingBufferPool::release(std::unique_ptr<Buffer> buffer) {
+  NIMBLE_CHECK_NOT_NULL(buffer, "Buffer cannot be null");
+
+  buffer->reset();
+  if (buffers_.size() < maxCachedBuffers_) {
+    buffers_.emplace_back(std::move(buffer));
+  }
+}
+
+ScopedEncodingBuffer::ScopedEncodingBuffer(
+    MemoryPool* memoryPool,
+    EncodingBufferPool* bufferPool)
+    : bufferPool_{bufferPool} {
+  NIMBLE_CHECK_NOT_NULL(memoryPool, "Memory pool cannot be null");
+  buffer_ = bufferPool_ != nullptr ? bufferPool_->acquire()
+                                   : std::make_unique<Buffer>(*memoryPool);
+}
+
+ScopedEncodingBuffer::~ScopedEncodingBuffer() {
+  if (bufferPool_ != nullptr) {
+    bufferPool_->release(std::move(buffer_));
+  }
 }
 
 } // namespace facebook::nimble

--- a/dwio/nimble/common/Buffer.h
+++ b/dwio/nimble/common/Buffer.h
@@ -20,6 +20,7 @@
 
 #include <cstring>
 #include <memory>
+#include <mutex>
 #include <string_view>
 #include <vector>
 
@@ -35,15 +36,14 @@
 namespace facebook::nimble {
 
 /// Internally manages memory in chunks. Releases memory only upon destruction.
-/// Buffer is NOT threadsafe: external locking is required.
+///
+/// NOTE: This class is not thread-safe. External locking is required.
 class Buffer {
   using MemoryPool = facebook::velox::memory::MemoryPool;
 
  public:
-  explicit Buffer(
-      MemoryPool& memoryPool,
-      uint64_t initialChunkSize = kMinChunkSize)
-      : memoryPool_(&memoryPool) {
+  explicit Buffer(MemoryPool& pool, uint64_t initialChunkSize = kMinChunkSize)
+      : pool_{&pool} {
     addChunk(initialChunkSize);
     reserveEnd_ = pos_;
   }
@@ -62,7 +62,7 @@ class Buffer {
   }
 
   MemoryPool& getMemoryPool() {
-    return *memoryPool_;
+    return *pool_;
   }
 
   std::string_view takeOwnership(velox::BufferPtr&& bufferPtr) {
@@ -97,7 +97,7 @@ class Buffer {
   void addChunk(uint64_t bytes);
 
   // --- Const members ---
-  MemoryPool* const memoryPool_;
+  MemoryPool* const pool_;
 
   // --- Mutable members (protected by mutex_) ---
 
@@ -111,6 +111,50 @@ class Buffer {
   char* reserveEnd_;
   uint32_t chunkIndex_{0};
   std::vector<velox::BufferPtr> chunks_;
+};
+
+/// Reuses Nimble encoding scratch buffers across nested encode calls.
+/// Not thread-safe: each writer thread or encode task should use its own pool.
+class EncodingBufferPool {
+ private:
+  using MemoryPool = facebook::velox::memory::MemoryPool;
+
+ public:
+  static constexpr uint32_t kDefaultMaxCachedBuffers = 8;
+
+  explicit EncodingBufferPool(
+      MemoryPool* pool,
+      uint32_t maxCachedBuffers = kDefaultMaxCachedBuffers);
+
+  std::unique_ptr<Buffer> acquire();
+
+  void release(std::unique_ptr<Buffer> buffer);
+
+ private:
+  MemoryPool* const pool_;
+  const uint32_t maxCachedBuffers_;
+
+  std::vector<std::unique_ptr<Buffer>> buffers_;
+};
+
+class ScopedEncodingBuffer {
+  using MemoryPool = facebook::velox::memory::MemoryPool;
+
+ public:
+  ScopedEncodingBuffer(MemoryPool* memoryPool, EncodingBufferPool* bufferPool);
+
+  ~ScopedEncodingBuffer();
+
+  ScopedEncodingBuffer(const ScopedEncodingBuffer&) = delete;
+  ScopedEncodingBuffer& operator=(const ScopedEncodingBuffer&) = delete;
+
+  Buffer& get() {
+    return *buffer_;
+  }
+
+ private:
+  EncodingBufferPool* const bufferPool_;
+  std::unique_ptr<Buffer> buffer_;
 };
 
 } // namespace facebook::nimble

--- a/dwio/nimble/common/tests/BufferTest.cpp
+++ b/dwio/nimble/common/tests/BufferTest.cpp
@@ -17,8 +17,12 @@
 #include <gtest/gtest.h>
 
 #include <cstring>
+#include <optional>
+#include <vector>
 
 #include "dwio/nimble/common/Buffer.h"
+#include "dwio/nimble/common/NimbleException.h"
+#include "dwio/nimble/common/tests/GTestUtils.h"
 #include "velox/common/memory/Memory.h"
 
 namespace facebook::nimble::test {
@@ -32,7 +36,7 @@ class BufferTest : public ::testing::Test {
   std::shared_ptr<velox::memory::MemoryPool> pool_;
 };
 
-TEST_F(BufferTest, ReserveSmall) {
+TEST_F(BufferTest, reserveSmall) {
   Buffer buffer(*pool_);
   char* ptr = buffer.reserve(10);
   ASSERT_NE(ptr, nullptr);
@@ -42,7 +46,7 @@ TEST_F(BufferTest, ReserveSmall) {
   EXPECT_EQ(ptr[9], 'A');
 }
 
-TEST_F(BufferTest, ReserveMultipleWithinChunk) {
+TEST_F(BufferTest, reserveMultipleWithinChunk) {
   Buffer buffer(*pool_);
   char* ptr1 = buffer.reserve(100);
   char* ptr2 = buffer.reserve(200);
@@ -56,7 +60,7 @@ TEST_F(BufferTest, ReserveMultipleWithinChunk) {
   EXPECT_EQ(ptr2[0], 'B');
 }
 
-TEST_F(BufferTest, ReserveOversized) {
+TEST_F(BufferTest, reserveOversized) {
   // Request more than kMinChunkSize (1 MB) to trigger a new chunk allocation
   Buffer buffer(*pool_);
   constexpr uint64_t bigSize = 2 * 1024 * 1024; // 2 MB
@@ -68,7 +72,7 @@ TEST_F(BufferTest, ReserveOversized) {
   EXPECT_EQ(ptr[0], 'X');
   EXPECT_EQ(ptr[bigSize - 1], 'Y');
 }
-TEST_F(BufferTest, WriteStringBasic) {
+TEST_F(BufferTest, writeStringBasic) {
   // Single write
   {
     Buffer buffer(*pool_);
@@ -101,7 +105,7 @@ TEST_F(BufferTest, WriteStringBasic) {
     EXPECT_EQ(result.size(), 0);
   }
 }
-TEST_F(BufferTest, TakeOwnership) {
+TEST_F(BufferTest, takeOwnership) {
   Buffer buffer(*pool_);
 
   auto simple_view = [&]() {
@@ -115,7 +119,7 @@ TEST_F(BufferTest, TakeOwnership) {
       std::string_view(simple_view.data(), 25), "simple extended test data");
 }
 
-TEST_F(BufferTest, GetMemoryPool) {
+TEST_F(BufferTest, getMemoryPool) {
   Buffer buffer(*pool_);
   auto& poolRef = buffer.getMemoryPool();
   // Just verify we get a valid reference back
@@ -206,6 +210,101 @@ TEST_F(BufferTest, resetMultipleTimes) {
   }
   // Only the initial chunk should exist — no growth.
   EXPECT_EQ(buffer.testingChunkCount(), 1);
+}
+
+TEST_F(BufferTest, encodingBufferPool) {
+  struct TestCase {
+    const char* name;
+    uint32_t maxCachedBuffers;
+    uint32_t numReleaseBuffers;
+    std::optional<uint32_t> expectedReusedBufferIndex;
+  };
+
+  for (const auto testCase : {
+           TestCase{"no cached buffers", 0, 1, std::nullopt},
+           TestCase{"single cached buffer", 1, 1, 0},
+           TestCase{"cache limit drops extra released buffer", 1, 2, 0},
+           TestCase{"multi-buffer cache reuses last cached buffer", 2, 2, 1},
+       }) {
+    SCOPED_TRACE(testCase.name);
+
+    EncodingBufferPool bufferPool{
+        pool_.get(), /*maxCachedBuffers=*/testCase.maxCachedBuffers};
+
+    std::vector<std::unique_ptr<Buffer>> buffers;
+    buffers.reserve(testCase.numReleaseBuffers);
+    std::vector<Buffer*> bufferAddresses;
+    bufferAddresses.reserve(testCase.numReleaseBuffers);
+
+    constexpr uint64_t bigSize = 2 * 1024 * 1024;
+    for (uint32_t i = 0; i < testCase.numReleaseBuffers; ++i) {
+      buffers.push_back(bufferPool.acquire());
+      bufferAddresses.push_back(buffers.back().get());
+
+      buffers.back()->reserve(bigSize);
+      EXPECT_EQ(buffers.back()->testingChunkCount(), 2);
+      EXPECT_EQ(buffers.back()->testingCurrentChunkIndex(), 1);
+    }
+
+    for (auto& buffer : buffers) {
+      bufferPool.release(std::move(buffer));
+    }
+
+    auto reusedBuffer = bufferPool.acquire();
+    if (testCase.expectedReusedBufferIndex.has_value()) {
+      EXPECT_EQ(
+          reusedBuffer.get(),
+          bufferAddresses[*testCase.expectedReusedBufferIndex]);
+      EXPECT_EQ(reusedBuffer->testingChunkCount(), 2);
+    } else {
+      EXPECT_EQ(reusedBuffer->testingChunkCount(), 1);
+    }
+    EXPECT_EQ(reusedBuffer->testingCurrentChunkIndex(), 0);
+
+    reusedBuffer->reserve(128);
+    EXPECT_EQ(reusedBuffer->testingCurrentChunkIndex(), 0);
+  }
+}
+
+TEST_F(BufferTest, encodingBufferPoolRejectsNullBufferRelease) {
+  EncodingBufferPool bufferPool{pool_.get()};
+
+  NIMBLE_ASSERT_THROW(bufferPool.release(nullptr), "Buffer cannot be null");
+}
+
+TEST_F(BufferTest, scopedEncodingBuffer) {
+  {
+    SCOPED_TRACE("returns buffer to pool");
+    EncodingBufferPool bufferPool{pool_.get(), /*maxCachedBuffers=*/1};
+    Buffer* scopedBufferAddress;
+
+    {
+      ScopedEncodingBuffer scopedBuffer{pool_.get(), &bufferPool};
+      scopedBufferAddress = &scopedBuffer.get();
+      scopedBuffer.get().reserve(128);
+    }
+
+    auto reusedBuffer = bufferPool.acquire();
+    EXPECT_EQ(reusedBuffer.get(), scopedBufferAddress);
+  }
+
+  {
+    SCOPED_TRACE("rejects null memory pool");
+    EncodingBufferPool bufferPool{pool_.get()};
+
+    NIMBLE_ASSERT_THROW(
+        ScopedEncodingBuffer(nullptr, &bufferPool),
+        "Memory pool cannot be null");
+  }
+
+  {
+    SCOPED_TRACE("uses memory pool without buffer pool");
+    ScopedEncodingBuffer scopedBuffer{pool_.get(), nullptr};
+
+    auto* ptr = scopedBuffer.get().reserve(128);
+    ASSERT_NE(ptr, nullptr);
+    EXPECT_EQ(&scopedBuffer.get().getMemoryPool(), pool_.get());
+  }
 }
 
 } // namespace facebook::nimble::test

--- a/dwio/nimble/encodings/ALPEncoding.h
+++ b/dwio/nimble/encodings/ALPEncoding.h
@@ -202,12 +202,13 @@ class ALPEncoding final
 
     const uint32_t exceptionCount = exceptionPositions.size();
 
-    Buffer tempBuffer{*pool};
+    ScopedEncodingBuffer scopedBuffer{
+        &buffer.getMemoryPool(), options.encodingBufferPool};
     std::string_view serializedEncoded =
         selection.template encodeNested<uint64_t>(
             EncodingIdentifiers::ALP::EncodedValues,
             {encodedValues},
-            tempBuffer,
+            scopedBuffer.get(),
             options);
 
     const uint32_t exceptionPositionsSize = exceptionCount * sizeof(uint32_t);

--- a/dwio/nimble/encodings/BlockBitPackingEncoding.h
+++ b/dwio/nimble/encodings/BlockBitPackingEncoding.h
@@ -828,24 +828,25 @@ std::string_view BlockBitPackingEncoding<T>::encode(
     runningOffset += blocks[blockIndex].packedSize;
   }
 
-  Buffer tempBuffer{buffer.getMemoryPool()};
+  ScopedEncodingBuffer tempBuffer{
+      &buffer.getMemoryPool(), options.encodingBufferPool};
   const std::string_view baselinesEncoded =
       selection.template encodeNested<physicalType>(
           EncodingIdentifiers::BlockBitPacking::Baselines,
           baselines,
-          tempBuffer,
+          tempBuffer.get(),
           options);
   const std::string_view bitWidthsEncoded =
       selection.template encodeNested<uint8_t>(
           EncodingIdentifiers::BlockBitPacking::BitWidths,
           bitWidths,
-          tempBuffer,
+          tempBuffer.get(),
           options);
   const std::string_view offsetsEncoded =
       selection.template encodeNested<uint32_t>(
           EncodingIdentifiers::BlockBitPacking::Offsets,
           blockOffsets,
-          tempBuffer,
+          tempBuffer.get(),
           options);
 
   const uint32_t metaHeaderSize = kMetadataHeaderSize +

--- a/dwio/nimble/encodings/DeltaEncoding.h
+++ b/dwio/nimble/encodings/DeltaEncoding.h
@@ -318,22 +318,26 @@ std::string_view DeltaEncoding<T>::encode(
 
   internal::computeDeltas(values, &deltas, &restatements, &isRestatements);
 
-  Buffer tempBuffer{buffer.getMemoryPool()};
+  ScopedEncodingBuffer tempBuffer{
+      &buffer.getMemoryPool(), options.encodingBufferPool};
 
   const std::string_view serializedDeltas =
       selection.template encodeNested<physicalType>(
-          EncodingIdentifiers::Delta::Deltas, deltas, tempBuffer, options);
+          EncodingIdentifiers::Delta::Deltas,
+          deltas,
+          tempBuffer.get(),
+          options);
   const std::string_view serializedRestatements =
       selection.template encodeNested<physicalType>(
           EncodingIdentifiers::Delta::Restatements,
           restatements,
-          tempBuffer,
+          tempBuffer.get(),
           options);
   const std::string_view serializedIsRestatements =
       selection.template encodeNested<bool>(
           EncodingIdentifiers::Delta::IsRestatements,
           isRestatements,
-          tempBuffer,
+          tempBuffer.get(),
           options);
 
   const uint32_t encodingSize =

--- a/dwio/nimble/encodings/DictionaryEncoding.h
+++ b/dwio/nimble/encodings/DictionaryEncoding.h
@@ -437,14 +437,15 @@ std::string_view DictionaryEncoding<T>::encode(
   NIMBLE_CHECK_EQ(indices.size(), valueCount, "Indices size mismatch.");
   NIMBLE_CHECK_EQ(alphabet.size(), alphabetCount, "Alphabet size mismatch.");
 
-  Buffer tempBuffer{buffer.getMemoryPool()};
+  ScopedEncodingBuffer scopedBuffer{
+      &buffer.getMemoryPool(), options.encodingBufferPool};
   std::string_view serializedAlphabet =
-      encodeAlphabet(selection, alphabet, tempBuffer, options);
+      encodeAlphabet(selection, alphabet, scopedBuffer.get(), options);
   std::string_view serializedIndices =
       selection.template encodeNested<uint32_t>(
           EncodingIdentifiers::Dictionary::Indices,
           {indices},
-          tempBuffer,
+          scopedBuffer.get(),
           options);
 
   const uint32_t encodingSize =

--- a/dwio/nimble/encodings/ForEncoding.h
+++ b/dwio/nimble/encodings/ForEncoding.h
@@ -453,14 +453,15 @@ std::string_view ForEncoding<T>::encode(
 
   const uint32_t numFrames = (rowCount + frameSize - 1) / frameSize;
 
-  Vector<uint8_t> bitWidths(&buffer.getMemoryPool(), numFrames);
-  Vector<physicalType> references(&buffer.getMemoryPool(), numFrames);
-  Vector<uint64_t> bitOffsets(&buffer.getMemoryPool());
+  auto* pool = &buffer.getMemoryPool();
+  Vector<uint8_t> bitWidths(pool, numFrames);
+  Vector<physicalType> references(pool, numFrames);
+  Vector<uint64_t> bitOffsets(pool);
   if (enableBitOffsets) {
     bitOffsets.resize(numFrames);
   }
 
-  Vector<char> packedData(&buffer.getMemoryPool());
+  Vector<char> packedData(pool);
   uint64_t bitBuffer = 0;
   size_t bitBufferLen = 0;
 
@@ -558,27 +559,28 @@ std::string_view ForEncoding<T>::encode(
     packedData.push_back(static_cast<char>(bitBuffer & 0xFF));
   }
 
-  Buffer tempBuffer{buffer.getMemoryPool()};
+  ScopedEncodingBuffer scopedBuffer{pool, options.encodingBufferPool};
 
   std::string_view serializedBitWidths =
       selection.template encodeNested<uint8_t>(
           0, // identifier - TODO: define proper identifiers
           {bitWidths},
-          tempBuffer);
+          scopedBuffer.get(),
+          options);
 
   std::string_view serializedReferences =
       selection.template encodeNested<physicalType>(
-          1, {references}, tempBuffer);
+          1, {references}, scopedBuffer.get(), options);
 
   std::string_view serializedBitOffsets;
   if (enableBitOffsets) {
-    serializedBitOffsets =
-        selection.template encodeNested<uint64_t>(2, {bitOffsets}, tempBuffer);
+    serializedBitOffsets = selection.template encodeNested<uint64_t>(
+        2, {bitOffsets}, scopedBuffer.get(), options);
   }
 
   auto dataCompressionPolicy = selection.compressionPolicy();
   CompressionEncoder<char> compressionEncoder{
-      buffer.getMemoryPool(),
+      *pool,
       *dataCompressionPolicy,
       DataType::Undefined,
       0, // bitWidth not applicable

--- a/dwio/nimble/encodings/FrequencyPartitionEncoding.h
+++ b/dwio/nimble/encodings/FrequencyPartitionEncoding.h
@@ -960,6 +960,7 @@ std::string_view FrequencyPartitionEncoding<T>::encode(
         : keyBits(0), capacity(0), dictionary(&pool) {}
   };
 
+  auto* pool = &buffer.getMemoryPool();
   std::vector<TierAssignment> tierAssignments;
   tierAssignments.reserve(6);
 
@@ -971,7 +972,7 @@ std::string_view FrequencyPartitionEncoding<T>::encode(
       break;
     }
 
-    TierAssignment tier{buffer.getMemoryPool()};
+    TierAssignment tier{*pool};
     tier.keyBits = keyBits;
     tier.capacity = getCapacity(keyBits);
 
@@ -1015,8 +1016,8 @@ std::string_view FrequencyPartitionEncoding<T>::encode(
   }
 
   // Partition offsets and sizes
-  Vector<uint32_t> partitionOffsets(&buffer.getMemoryPool());
-  Vector<uint32_t> partitionSizes(&buffer.getMemoryPool());
+  Vector<uint32_t> partitionOffsets(pool);
+  Vector<uint32_t> partitionSizes(pool);
   partitionOffsets.reserve(tierRows.size());
   partitionSizes.reserve(tierRows.size());
 
@@ -1027,17 +1028,18 @@ std::string_view FrequencyPartitionEncoding<T>::encode(
     offset += static_cast<uint32_t>(rows.size());
   }
 
-  // Encode partition metadata and tier data into tempBuffer
-  Buffer tempBuffer{buffer.getMemoryPool()};
+  ScopedEncodingBuffer scopedBuffer{pool, options.encodingBufferPool};
   std::string_view serializedOffsets =
       selection.template encodeNested<uint32_t>(
           EncodingIdentifiers::FrequencyPartition::PartitionOffsets,
           {partitionOffsets},
-          tempBuffer);
+          scopedBuffer.get(),
+          options);
   std::string_view serializedSizes = selection.template encodeNested<uint32_t>(
       EncodingIdentifiers::FrequencyPartition::PartitionSizes,
       {partitionSizes},
-      tempBuffer);
+      scopedBuffer.get(),
+      options);
 
   std::vector<std::string_view> serializedDicts(tierAssignments.size());
   std::vector<std::string_view> serializedKeys(tierAssignments.size());
@@ -1053,9 +1055,10 @@ std::string_view FrequencyPartitionEncoding<T>::encode(
     serializedDicts[tierIdx] = selection.template encodeNested<physicalType>(
         EncodingIdentifiers::FrequencyPartition::Dict1Bit + tierIdx,
         {tier.dictionary},
-        tempBuffer);
+        scopedBuffer.get(),
+        options);
 
-    Vector<uint32_t> keys(&buffer.getMemoryPool());
+    Vector<uint32_t> keys(pool);
     keys.reserve(rows.size());
     for (uint32_t row : rows) {
       keys.push_back(tier.valueToKey.at(values[row]));
@@ -1064,12 +1067,13 @@ std::string_view FrequencyPartitionEncoding<T>::encode(
     serializedKeys[tierIdx] = selection.template encodeNested<uint32_t>(
         EncodingIdentifiers::FrequencyPartition::Keys1Bit + tierIdx,
         {keys},
-        tempBuffer);
+        scopedBuffer.get(),
+        options);
   }
 
   std::string_view serializedUnencoded;
   if (!tierRows.back().empty()) {
-    Vector<physicalType> unencodedValues(&buffer.getMemoryPool());
+    Vector<physicalType> unencodedValues(pool);
     unencodedValues.reserve(tierRows.back().size());
     for (uint32_t row : tierRows.back()) {
       unencodedValues.push_back(values[row]);
@@ -1077,7 +1081,8 @@ std::string_view FrequencyPartitionEncoding<T>::encode(
     serializedUnencoded = selection.template encodeNested<physicalType>(
         EncodingIdentifiers::FrequencyPartition::UnencodedValues,
         {unencodedValues},
-        tempBuffer);
+        scopedBuffer.get(),
+        options);
   }
 
   // Build index payload (only for non-NoIndex modes)

--- a/dwio/nimble/encodings/MainlyConstantEncoding.cpp
+++ b/dwio/nimble/encodings/MainlyConstantEncoding.cpp
@@ -53,35 +53,29 @@ std::string_view MainlyConstantEncoding<std::string_view>::encode(
   }
 
   const auto& uniqueCounts = selection.statistics().uniqueCounts().value();
-  const auto commonElement = internal::mainlyConstantCommonValue(uniqueCounts);
+  const auto commonElement =
+      MainlyConstantEncodingBase<std::string_view>::mainlyConstantCommonValue(
+          uniqueCounts);
 
   const uint32_t entryCount = values.size();
-  const uint32_t uncommonCount = entryCount - commonElement->second;
 
-  Vector<bool> isCommon{&buffer.getMemoryPool(), values.size(), true};
-  Vector<physicalType> otherValues(&buffer.getMemoryPool());
-  otherValues.reserve(uncommonCount);
-
+  auto* pool = &buffer.getMemoryPool();
   physicalType commonValue = commonElement->first;
-  for (auto i = 0; i < values.size(); ++i) {
-    physicalType currentValue = values[i];
-    if (currentValue != commonValue) {
-      isCommon[i] = false;
-      otherValues.push_back(std::move(currentValue));
-    }
-  }
+  auto childStreams =
+      MainlyConstantEncodingBase<std::string_view>::prepareChildStreams(
+          pool, values, commonValue, commonElement->second);
 
-  Buffer tempBuffer{buffer.getMemoryPool()};
+  ScopedEncodingBuffer scopedBuffer{pool, options.encodingBufferPool};
   std::string_view serializedIsCommon = selection.template encodeNested<bool>(
       EncodingIdentifiers::MainlyConstant::IsCommon,
-      isCommon,
-      tempBuffer,
+      childStreams.isCommon,
+      scopedBuffer.get(),
       options);
   std::string_view serializedOtherValues =
       selection.template encodeNested<physicalType>(
           EncodingIdentifiers::MainlyConstant::OtherValues,
-          otherValues,
-          tempBuffer,
+          childStreams.otherValues,
+          scopedBuffer.get(),
           options);
 
   uint32_t encodingSize = Encoding::serializePrefixSize(entryCount, useVarint) +

--- a/dwio/nimble/encodings/MainlyConstantEncoding.h
+++ b/dwio/nimble/encodings/MainlyConstantEncoding.h
@@ -62,25 +62,6 @@
 
 namespace facebook::nimble {
 
-namespace internal {
-
-template <typename UniqueCounts>
-auto mainlyConstantCommonValue(const UniqueCounts& uniqueCounts) {
-  // Select the highest-frequency value. Break count ties by the smaller value
-  // so absl::flat_hash_map iteration order cannot affect estimates or output.
-  return std::max_element(
-      uniqueCounts.cbegin(),
-      uniqueCounts.cend(),
-      [](const auto& left, const auto& right) {
-        if (left.second != right.second) {
-          return left.second < right.second;
-        }
-        return left.first > right.first;
-      });
-}
-
-} // namespace internal
-
 // Data layout is:
 // EncodingPrefix::kFixedPrefixSize bytes: standard Encoding prefix
 // 4 bytes: num isCommon encoding bytes (X)
@@ -123,8 +104,7 @@ class MainlyConstantEncodingBase
 
     // Find most common item count.
     const auto& uniqueCounts = statistics.uniqueCounts().value();
-    const auto maxUniqueCount =
-        internal::mainlyConstantCommonValue(uniqueCounts);
+    const auto maxUniqueCount = mainlyConstantCommonValue(uniqueCounts);
     // Deduce uncommon values count
     const uint64_t uncommonCount = rowCount - maxUniqueCount->second;
     // Uncommon values (sparse bool) bitmap will have index per value,
@@ -567,6 +547,63 @@ class MainlyConstantEncodingBase
   }
 
  protected:
+  template <typename UniqueCounts>
+  static auto mainlyConstantCommonValue(const UniqueCounts& uniqueCounts) {
+    // Select the highest-frequency value. Break count ties by the smaller value
+    // so absl::flat_hash_map iteration order cannot affect estimates or output.
+    return std::max_element(
+        uniqueCounts.cbegin(),
+        uniqueCounts.cend(),
+        [](const auto& left, const auto& right) {
+          if (left.second != right.second) {
+            return left.second < right.second;
+          }
+          return left.first > right.first;
+        });
+  }
+
+  // Encode-time child streams: isCommon spans all input rows, while
+  // otherValues contains only rows that differ from the common value.
+  struct ChildStreams {
+    ChildStreams(velox::memory::MemoryPool* pool, uint32_t rowCount)
+        : isCommon{pool, rowCount}, otherValues{pool} {}
+
+    Vector<bool> isCommon;
+    Vector<physicalType> otherValues;
+  };
+
+  static ChildStreams prepareChildStreams(
+      velox::memory::MemoryPool* pool,
+      std::span<const physicalType> values,
+      const physicalType& commonValue,
+      uint32_t commonCount) {
+    const auto entryCount = static_cast<uint32_t>(values.size());
+    const uint32_t uncommonCount = entryCount - commonCount;
+    if (uncommonCount == 0) {
+      ChildStreams streams{pool, entryCount};
+      streams.isCommon.fill(true);
+      return streams;
+    }
+
+    ChildStreams streams{pool, entryCount};
+    streams.otherValues.reserve(uncommonCount);
+
+    for (uint32_t i = 0; i < entryCount; ++i) {
+      const physicalType currentValue = values[i];
+      const bool isCommon = currentValue == commonValue;
+      streams.isCommon[i] = isCommon;
+      if (FOLLY_UNLIKELY(!isCommon)) {
+        streams.otherValues.push_back(currentValue);
+      }
+    }
+
+    NIMBLE_CHECK_EQ(
+        streams.otherValues.size(),
+        uncommonCount,
+        "Unexpected uncommon value count.");
+    return streams;
+  }
+
   // Counts unset bits across all words. Caller must mask tail bits
   // before calling (set garbage tail bits to 1 in the last word).
   FOLLY_ALWAYS_INLINE static uint32_t countNonCommon(
@@ -685,35 +722,27 @@ std::string_view MainlyConstantEncoding<T>::encode(
   }
 
   const auto& uniqueCounts = selection.statistics().uniqueCounts().value();
-  const auto commonElement = internal::mainlyConstantCommonValue(uniqueCounts);
+  const auto commonElement =
+      MainlyConstantEncodingBase<T>::mainlyConstantCommonValue(uniqueCounts);
 
   const uint32_t entryCount = values.size();
-  const uint32_t uncommonCount = entryCount - commonElement->second;
 
-  Vector<bool> isCommon{&buffer.getMemoryPool(), values.size(), true};
-  Vector<physicalType> otherValues(&buffer.getMemoryPool());
-  otherValues.reserve(uncommonCount);
-
+  auto* pool = &buffer.getMemoryPool();
   physicalType commonValue = commonElement->first;
-  for (auto i = 0; i < values.size(); ++i) {
-    physicalType currentValue = values[i];
-    if (currentValue != commonValue) {
-      isCommon[i] = false;
-      otherValues.push_back(std::move(currentValue));
-    }
-  }
+  auto childStreams = MainlyConstantEncodingBase<T>::prepareChildStreams(
+      pool, values, commonValue, commonElement->second);
 
-  Buffer tempBuffer{buffer.getMemoryPool()};
+  ScopedEncodingBuffer scopedBuffer{pool, options.encodingBufferPool};
   std::string_view serializedIsCommon = selection.template encodeNested<bool>(
       EncodingIdentifiers::MainlyConstant::IsCommon,
-      isCommon,
-      tempBuffer,
+      childStreams.isCommon,
+      scopedBuffer.get(),
       options);
   std::string_view serializedOtherValues =
       selection.template encodeNested<physicalType>(
           EncodingIdentifiers::MainlyConstant::OtherValues,
-          otherValues,
-          tempBuffer,
+          childStreams.otherValues,
+          scopedBuffer.get(),
           options);
 
   uint32_t encodingSize = Encoding::serializePrefixSize(entryCount, useVarint) +

--- a/dwio/nimble/encodings/NullableEncoding.h
+++ b/dwio/nimble/encodings/NullableEncoding.h
@@ -358,12 +358,16 @@ std::string_view NullableEncoding<T>::encodeNullable(
   const bool useVarint = options.useVarintRowCount;
   const uint32_t rowCount = nulls.size();
 
-  Buffer tempBuffer{buffer.getMemoryPool()};
+  auto* pool = &buffer.getMemoryPool();
+  ScopedEncodingBuffer scopedBuffer{pool, options.encodingBufferPool};
   std::string_view serializedValues =
       selection.template encodeNested<physicalType>(
-          EncodingIdentifiers::Nullable::Data, values, tempBuffer, options);
+          EncodingIdentifiers::Nullable::Data,
+          values,
+          scopedBuffer.get(),
+          options);
   std::string_view serializedNulls = selection.template encodeNested<bool>(
-      EncodingIdentifiers::Nullable::Nulls, nulls, tempBuffer, options);
+      EncodingIdentifiers::Nullable::Nulls, nulls, scopedBuffer.get(), options);
 
   const uint32_t encodingSize =
       Encoding::serializePrefixSize(rowCount, useVarint) + 4 +

--- a/dwio/nimble/encodings/PFOREncoding.h
+++ b/dwio/nimble/encodings/PFOREncoding.h
@@ -413,13 +413,14 @@ std::string_view PFOREncoding<T>::encode(
         ? physicalType{0}
         : static_cast<physicalType>(velox::bits::lowMask(selectedBaseBitWidth));
 
-    Vector<uint32_t> exceptionPositions{&buffer.getMemoryPool()};
-    Vector<physicalType> exceptionValues{&buffer.getMemoryPool()};
+    auto* pool = &buffer.getMemoryPool();
+    Vector<uint32_t> exceptionPositions{pool};
+    Vector<physicalType> exceptionValues{pool};
     // Reserve for expected exceptions based on the 90% coverage threshold.
     exceptionPositions.reserve(expectedExceptions);
     exceptionValues.reserve(expectedExceptions);
 
-    Vector<physicalType> maskedResiduals{&buffer.getMemoryPool()};
+    Vector<physicalType> maskedResiduals{pool};
     maskedResiduals.resize(rowCount);
     physicalType maxBaseResidual{0};
     for (auto i = 0; i < rowCount; ++i) {
@@ -453,19 +454,19 @@ std::string_view PFOREncoding<T>::encode(
     // PFOR encodes the exception side-channels through recursive encoding
     // selection so Nimble can pick the best sub-encoding.
     // The bulk base residuals always stay raw to preserve the fast decode path.
-    Buffer tempBuffer{buffer.getMemoryPool()};
+    ScopedEncodingBuffer scopedBuffer{pool, options.encodingBufferPool};
     std::string_view exceptionPositionsEncoded{};
     std::string_view exceptionValuesEncoded{};
     if (numExceptions > 0) {
       exceptionPositionsEncoded = selection.template encodeNested<uint32_t>(
           EncodingIdentifiers::Pfor::ExceptionPositions,
           std::span<const uint32_t>(exceptionPositions.data(), numExceptions),
-          tempBuffer,
+          scopedBuffer.get(),
           options);
       exceptionValuesEncoded = selection.template encodeNested<physicalType>(
           EncodingIdentifiers::Pfor::ExceptionValues,
           std::span<const physicalType>(exceptionValues.data(), numExceptions),
-          tempBuffer,
+          scopedBuffer.get(),
           options);
     }
     // Two size-prefixed nested streams (positions, values) carry the exception

--- a/dwio/nimble/encodings/RLEEncoding.h
+++ b/dwio/nimble/encodings/RLEEncoding.h
@@ -165,20 +165,21 @@ class RLEEncodingBase
       const Encoding::Options& options = {}) {
     const bool useVarint = options.useVarintRowCount;
     const uint32_t valueCount = values.size();
-    Vector<uint32_t> runLengths(&buffer.getMemoryPool());
-    Vector<physicalType> runValues(&buffer.getMemoryPool());
+    auto* pool = &buffer.getMemoryPool();
+    Vector<uint32_t> runLengths(pool);
+    Vector<physicalType> runValues(pool);
     rle::computeRuns(values, &runLengths, &runValues);
 
-    Buffer tempBuffer{buffer.getMemoryPool()};
+    ScopedEncodingBuffer scopedBuffer{pool, options.encodingBufferPool};
     std::string_view serializedRunLengths =
         selection.template encodeNested<uint32_t>(
             EncodingIdentifiers::RunLength::RunLengths,
             runLengths,
-            tempBuffer,
+            scopedBuffer.get(),
             options);
 
-    std::string_view serializedRunValues =
-        getSerializedRunValues(selection, runValues, tempBuffer, options);
+    std::string_view serializedRunValues = getSerializedRunValues(
+        selection, runValues, scopedBuffer.get(), options);
 
     const uint32_t encodingSize =
         Encoding::serializePrefixSize(valueCount, useVarint) + 4 +

--- a/dwio/nimble/encodings/SparseBoolEncoding.cpp
+++ b/dwio/nimble/encodings/SparseBoolEncoding.cpp
@@ -151,7 +151,8 @@ std::string_view SparseBoolEncoding::encode(
     indexCount = setCount;
   }
 
-  Vector<uint32_t> indices{&buffer.getMemoryPool()};
+  auto* pool = &buffer.getMemoryPool();
+  Vector<uint32_t> indices{pool};
   indices.reserve(indexCount + 1);
   if (sparseValue) {
     for (auto i = 0; i < values.size(); ++i) {
@@ -171,12 +172,12 @@ std::string_view SparseBoolEncoding::encode(
   // in order to stop looping as this value is greater than any possible index.
   indices.push_back(valueCount);
 
-  Buffer tempBuffer{buffer.getMemoryPool()};
+  ScopedEncodingBuffer scopedBuffer{pool, options.encodingBufferPool};
   std::string_view serializedIndices =
       selection.template encodeNested<uint32_t>(
           EncodingIdentifiers::SparseBool::Indices,
           indices,
-          tempBuffer,
+          scopedBuffer.get(),
           options);
 
   const uint32_t encodingSize =

--- a/dwio/nimble/encodings/SubIntSplitEncoding.h
+++ b/dwio/nimble/encodings/SubIntSplitEncoding.h
@@ -763,10 +763,13 @@ std::string_view SubIntSplitEncoding<T>::encode(
       !segments.empty(), "SubIntSplitEncoding: selector returned no segments");
   const uint8_t splitCount = static_cast<uint8_t>(segments.size());
 
-  // --- Step 2: Encode each section into a temporary buffer ---
+  // Encode each section into a temporary buffer.
   // Each section is encoded as the narrowest unsigned integer type that fits
   // its bit width, so narrow sections don't pay an 8-byte-per-value penalty.
-  Buffer tempBuffer{buffer.getMemoryPool()};
+  auto* pool = &buffer.getMemoryPool();
+  ScopedEncodingBuffer scopedBuffer{pool, options.encodingBufferPool};
+  Buffer& sectionBuffer = scopedBuffer.get();
+  auto* sectionPool = &sectionBuffer.getMemoryPool();
   std::vector<std::string_view> sectionData;
   sectionData.reserve(splitCount);
 
@@ -782,7 +785,7 @@ std::string_view SubIntSplitEncoding<T>::encode(
     std::string_view encoded;
     switch (sb) {
       case 1: {
-        Vector<uint8_t> sectionValues{&tempBuffer.getMemoryPool(), valueCount};
+        Vector<uint8_t> sectionValues{sectionPool, valueCount};
         for (uint32_t i = 0; i < valueCount; ++i) {
           uint64_t v = 0;
           __builtin_memcpy(&v, &values[i], sizeof(physicalType));
@@ -792,12 +795,12 @@ std::string_view SubIntSplitEncoding<T>::encode(
             static_cast<NestedEncodingIdentifier>(s),
             std::span<const uint8_t>(
                 sectionValues.data(), sectionValues.size()),
-            tempBuffer,
+            sectionBuffer,
             options);
         break;
       }
       case 2: {
-        Vector<uint16_t> sectionValues{&tempBuffer.getMemoryPool(), valueCount};
+        Vector<uint16_t> sectionValues{sectionPool, valueCount};
         for (uint32_t i = 0; i < valueCount; ++i) {
           uint64_t v = 0;
           __builtin_memcpy(&v, &values[i], sizeof(physicalType));
@@ -807,12 +810,12 @@ std::string_view SubIntSplitEncoding<T>::encode(
             static_cast<NestedEncodingIdentifier>(s),
             std::span<const uint16_t>(
                 sectionValues.data(), sectionValues.size()),
-            tempBuffer,
+            sectionBuffer,
             options);
         break;
       }
       case 4: {
-        Vector<uint32_t> sectionValues{&tempBuffer.getMemoryPool(), valueCount};
+        Vector<uint32_t> sectionValues{sectionPool, valueCount};
         for (uint32_t i = 0; i < valueCount; ++i) {
           uint64_t v = 0;
           __builtin_memcpy(&v, &values[i], sizeof(physicalType));
@@ -822,12 +825,12 @@ std::string_view SubIntSplitEncoding<T>::encode(
             static_cast<NestedEncodingIdentifier>(s),
             std::span<const uint32_t>(
                 sectionValues.data(), sectionValues.size()),
-            tempBuffer,
+            sectionBuffer,
             options);
         break;
       }
       case 8: {
-        Vector<uint64_t> sectionValues{&tempBuffer.getMemoryPool(), valueCount};
+        Vector<uint64_t> sectionValues{sectionPool, valueCount};
         for (uint32_t i = 0; i < valueCount; ++i) {
           uint64_t v = 0;
           __builtin_memcpy(&v, &values[i], sizeof(physicalType));
@@ -837,7 +840,7 @@ std::string_view SubIntSplitEncoding<T>::encode(
             static_cast<NestedEncodingIdentifier>(s),
             std::span<const uint64_t>(
                 sectionValues.data(), sectionValues.size()),
-            tempBuffer,
+            sectionBuffer,
             options);
         break;
       }
@@ -848,7 +851,7 @@ std::string_view SubIntSplitEncoding<T>::encode(
     sectionData.push_back(encoded);
   }
 
-  // --- Step 3: Write final encoding to main buffer ---
+  // Write final encoding to main buffer.
   const uint32_t prefixSize =
       Encoding::serializePrefixSize(valueCount, useVarint);
   const uint32_t specificHeader =

--- a/dwio/nimble/encodings/TrivialEncoding.cpp
+++ b/dwio/nimble/encodings/TrivialEncoding.cpp
@@ -103,21 +103,22 @@ std::string_view TrivialEncoding<std::string_view>::encode(
     lengths.push_back(value.size());
   }
 
-  Buffer tempBuffer{buffer.getMemoryPool()};
+  auto* pool = &buffer.getMemoryPool();
+  ScopedEncodingBuffer scopedBuffer{pool, options.encodingBufferPool};
   std::string_view serializedLengths =
       selection.template encodeNested<uint32_t>(
           EncodingIdentifiers::Trivial::Lengths,
           {lengths},
-          tempBuffer,
+          scopedBuffer.get(),
           options);
 
   auto dataCompressionPolicy = selection.compressionPolicy();
   auto uncompressedSize = selection.statistics().totalStringsLength();
 
-  Vector<char> vector{&buffer.getMemoryPool()};
+  Vector<char> vector{pool};
 
   CompressionEncoder<std::string_view> compressionEncoder{
-      buffer.getMemoryPool(),
+      *pool,
       *dataCompressionPolicy,
       DataType::String,
       /*bitWidth=*/0,
@@ -253,11 +254,12 @@ std::string_view TrivialEncoding<bool>::encode(
   const uint32_t valueCount = values.size();
   const uint32_t bitmapBytes = FixedBitArray::bufferSize(valueCount, 1);
 
-  Vector<char> vector{&buffer.getMemoryPool()};
+  auto* pool = &buffer.getMemoryPool();
+  Vector<char> vector{pool};
 
   auto dataCompressionPolicy = selection.compressionPolicy();
   CompressionEncoder<std::string_view> compressionEncoder{
-      buffer.getMemoryPool(),
+      *pool,
       *dataCompressionPolicy,
       DataType::Undefined,
       /*bitWidth=*/1,

--- a/dwio/nimble/encodings/common/Encoding.h
+++ b/dwio/nimble/encodings/common/Encoding.h
@@ -71,6 +71,8 @@ struct DecodingStats;
 
 namespace facebook::nimble {
 
+class EncodingBufferPool;
+
 template <typename T, typename Filter, typename ExtractValues, bool kIsDense>
 using DecoderVisitor =
     velox::dwio::common::ColumnVisitor<T, Filter, ExtractValues, kIsDense>;
@@ -118,6 +120,10 @@ class Encoding {
     /// on destruction and grab pre-allocated buffers on construction, avoiding
     /// MemoryPool alloc/free overhead.
     velox::BufferPool* bufferPool = nullptr;
+
+    /// Optional pool for Nimble Buffer scratch arenas used while encoding
+    /// nested child streams.
+    EncodingBufferPool* encodingBufferPool = nullptr;
 
     /// When true, encodings that support dictionary mode (e.g., RLE) will
     /// use the dictionary index path when the inner encoding is

--- a/dwio/nimble/encodings/selection/Statistics.cpp
+++ b/dwio/nimble/encodings/selection/Statistics.cpp
@@ -88,19 +88,7 @@ void Statistics<T, InputType>::populateMinMax() const {
     min_ = *min;
     max_ = *max;
   } else if constexpr (nimble::isStringType<InputType>()) {
-    std::string_view minString = data_[0];
-    std::string_view maxString = data_[0];
-    for (int i = 0; i < data_.size(); ++i) {
-      const auto& value = data_[i];
-      if (value.size() > maxString.size()) {
-        maxString = value;
-      }
-      if (value.size() < minString.size()) {
-        minString = value;
-      }
-    }
-    min_ = minString;
-    max_ = maxString;
+    populateStringLength();
   }
 }
 
@@ -180,11 +168,22 @@ void Statistics<T, InputType>::populateBucketCounts() const {
 
 template <typename T, typename InputType>
 void Statistics<T, InputType>::populateStringLength() const {
-  uint64_t total = 0;
+  uint64_t totalBytes = 0;
+  std::string_view minString = data_[0];
+  std::string_view maxString = data_[0];
   for (int i = 0; i < data_.size(); ++i) {
-    total += data_[i].size();
+    const auto& value = data_[i];
+    totalBytes += value.size();
+    if (value.size() > maxString.size()) {
+      maxString = value;
+    }
+    if (value.size() < minString.size()) {
+      minString = value;
+    }
   }
-  totalStringsLength_ = total;
+  totalStringsLength_ = totalBytes;
+  min_ = minString;
+  max_ = maxString;
 }
 
 template <typename T, typename InputType>

--- a/dwio/nimble/serializer/Options.h
+++ b/dwio/nimble/serializer/Options.h
@@ -22,6 +22,7 @@
 #include <optional>
 #include <ostream>
 
+#include "dwio/nimble/common/Buffer.h"
 #include "dwio/nimble/common/Types.h"
 #include "dwio/nimble/encodings/selection/EncodingSelectionPolicy.h"
 #include "dwio/nimble/velox/EncodingLayoutTree.h"
@@ -241,6 +242,11 @@ struct SerializerOptions {
   /// format-level settings (varint row count) and per-encoding config
   /// (e.g., BlockBitPacking block size).
   Encoding::Options encodingOptions{.useVarintRowCount = true};
+
+  /// Maximum number of scratch buffers retained by the serializer-owned
+  /// nested encoding buffer pool. 0 disables nested encoding buffer caching.
+  /// Disabled by default; callers can set a non-zero value to opt in.
+  uint32_t maxCachedNestedEncodingBuffers{0};
 
   /// Encoding type for the sizes array of the sparse stream-sizes trailer.
   /// Sizes are the byte sizes of non-zero streams, parallel to the indices

--- a/dwio/nimble/serializer/Serializer.cpp
+++ b/dwio/nimble/serializer/Serializer.cpp
@@ -64,7 +64,16 @@ Serializer::Serializer(
     velox::memory::MemoryPool* pool)
     : options_{normalizeWriterVersion(std::move(options))},
       context_{*pool},
+      nestedEncodingBufferPool_{
+          options_.enableEncoding() &&
+                  options_.maxCachedNestedEncodingBuffers > 0
+              ? std::make_unique<EncodingBufferPool>(
+                    context_.bufferMemoryPool().get(),
+                    options_.maxCachedNestedEncodingBuffers)
+              : nullptr},
       buffer_{context_.bufferMemoryPool().get()} {
+  options_.encodingOptions.encodingBufferPool = nestedEncodingBufferPool_.get();
+
   const auto version = options_.serializationVersion();
   NIMBLE_CHECK(
       version == SerializationVersion::kLegacy ||

--- a/dwio/nimble/serializer/Serializer.h
+++ b/dwio/nimble/serializer/Serializer.h
@@ -81,8 +81,10 @@ class Serializer {
       const velox::VectorPtr& vector,
       const OrderedRanges& ranges) const;
 
-  const SerializerOptions options_;
+  SerializerOptions options_;
   mutable FieldWriterContext context_;
+  // Reused across serialize() calls for nested child streams.
+  std::unique_ptr<EncodingBufferPool> nestedEncodingBufferPool_;
   // Kept alive because FlatMap field writers hold references to child nodes.
   std::shared_ptr<const velox::dwio::common::TypeWithId> typeWithId_;
   std::unique_ptr<FieldWriter> writer_;

--- a/dwio/nimble/serializer/SerializerImpl.h
+++ b/dwio/nimble/serializer/SerializerImpl.h
@@ -119,7 +119,8 @@ std::string_view encodeNullableTyped(
     std::string_view data,
     std::span<const bool> nonNulls,
     nimble::Buffer& encodingBuffer,
-    const EncodingLayout* encodingLayout) {
+    const EncodingLayout* encodingLayout,
+    const Encoding::Options& encodingOptions) {
   const auto count = data.size() / sizeof(T);
   std::span<const T> values{reinterpret_cast<const T*>(data.data()), count};
 
@@ -131,7 +132,7 @@ std::string_view encodeNullableTyped(
       values,
       nonNulls,
       encodingBuffer,
-      Encoding::Options{.useVarintRowCount = true});
+      encodingOptions);
 }
 
 inline std::string_view boolsAsStringView(std::span<const bool> values) {
@@ -488,14 +489,15 @@ std::string_view encodeTyped(
     std::string_view data,
     velox::memory::MemoryPool& pool,
     nimble::Buffer& encodingBuffer,
-    const EncodingLayout* encodingLayout) {
+    const EncodingLayout* encodingLayout,
+    const Encoding::Options& encodingOptions) {
   const auto count = data.size() / sizeof(T);
   std::span<const T> values{reinterpret_cast<const T*>(data.data()), count};
   return encodeTyped<T>(
       values,
       encodingBuffer,
       options.encodingSelectionPolicyCreator,
-      options.encodingOptions,
+      encodingOptions,
       encodingLayout,
       options.compressionOptions);
 }
@@ -508,46 +510,47 @@ std::string_view encodeScalar(
     std::string_view data,
     velox::memory::MemoryPool& pool,
     nimble::Buffer& encodingBuffer,
-    const EncodingLayout* encodingLayout) {
+    const EncodingLayout* encodingLayout,
+    const Encoding::Options& encodingOptions) {
   switch (scalarKind) {
     case ScalarKind::Bool:
       return encodeTyped<bool, Buffer>(
-          options, data, pool, encodingBuffer, encodingLayout);
+          options, data, pool, encodingBuffer, encodingLayout, encodingOptions);
     case ScalarKind::Int8:
       return encodeTyped<int8_t, Buffer>(
-          options, data, pool, encodingBuffer, encodingLayout);
+          options, data, pool, encodingBuffer, encodingLayout, encodingOptions);
     case ScalarKind::UInt8:
       return encodeTyped<uint8_t, Buffer>(
-          options, data, pool, encodingBuffer, encodingLayout);
+          options, data, pool, encodingBuffer, encodingLayout, encodingOptions);
     case ScalarKind::Int16:
       return encodeTyped<int16_t, Buffer>(
-          options, data, pool, encodingBuffer, encodingLayout);
+          options, data, pool, encodingBuffer, encodingLayout, encodingOptions);
     case ScalarKind::UInt16:
       return encodeTyped<uint16_t, Buffer>(
-          options, data, pool, encodingBuffer, encodingLayout);
+          options, data, pool, encodingBuffer, encodingLayout, encodingOptions);
     case ScalarKind::Int32:
       return encodeTyped<int32_t, Buffer>(
-          options, data, pool, encodingBuffer, encodingLayout);
+          options, data, pool, encodingBuffer, encodingLayout, encodingOptions);
     case ScalarKind::UInt32:
       return encodeTyped<uint32_t, Buffer>(
-          options, data, pool, encodingBuffer, encodingLayout);
+          options, data, pool, encodingBuffer, encodingLayout, encodingOptions);
     case ScalarKind::Int64:
       return encodeTyped<int64_t, Buffer>(
-          options, data, pool, encodingBuffer, encodingLayout);
+          options, data, pool, encodingBuffer, encodingLayout, encodingOptions);
     case ScalarKind::UInt64:
       return encodeTyped<uint64_t, Buffer>(
-          options, data, pool, encodingBuffer, encodingLayout);
+          options, data, pool, encodingBuffer, encodingLayout, encodingOptions);
     case ScalarKind::Float:
       return encodeTyped<float, Buffer>(
-          options, data, pool, encodingBuffer, encodingLayout);
+          options, data, pool, encodingBuffer, encodingLayout, encodingOptions);
     case ScalarKind::Double:
       return encodeTyped<double, Buffer>(
-          options, data, pool, encodingBuffer, encodingLayout);
+          options, data, pool, encodingBuffer, encodingLayout, encodingOptions);
     case ScalarKind::String:
       [[fallthrough]];
     case ScalarKind::Binary:
       return encodeTyped<std::string_view, Buffer>(
-          options, data, pool, encodingBuffer, encodingLayout);
+          options, data, pool, encodingBuffer, encodingLayout, encodingOptions);
     default:
       NIMBLE_UNSUPPORTED(
           "Unsupported scalar kind for nimble encoding: {}", scalarKind);
@@ -561,46 +564,107 @@ std::string_view encodeNullableScalar(
     std::string_view data,
     std::span<const bool> nonNulls,
     nimble::Buffer& encodingBuffer,
-    const EncodingLayout* encodingLayout) {
+    const EncodingLayout* encodingLayout,
+    const Encoding::Options& encodingOptions) {
   switch (scalarKind) {
     case ScalarKind::Bool:
       return encodeNullableTyped<bool>(
-          options, data, nonNulls, encodingBuffer, encodingLayout);
+          options,
+          data,
+          nonNulls,
+          encodingBuffer,
+          encodingLayout,
+          encodingOptions);
     case ScalarKind::Int8:
       return encodeNullableTyped<int8_t>(
-          options, data, nonNulls, encodingBuffer, encodingLayout);
+          options,
+          data,
+          nonNulls,
+          encodingBuffer,
+          encodingLayout,
+          encodingOptions);
     case ScalarKind::UInt8:
       return encodeNullableTyped<uint8_t>(
-          options, data, nonNulls, encodingBuffer, encodingLayout);
+          options,
+          data,
+          nonNulls,
+          encodingBuffer,
+          encodingLayout,
+          encodingOptions);
     case ScalarKind::Int16:
       return encodeNullableTyped<int16_t>(
-          options, data, nonNulls, encodingBuffer, encodingLayout);
+          options,
+          data,
+          nonNulls,
+          encodingBuffer,
+          encodingLayout,
+          encodingOptions);
     case ScalarKind::UInt16:
       return encodeNullableTyped<uint16_t>(
-          options, data, nonNulls, encodingBuffer, encodingLayout);
+          options,
+          data,
+          nonNulls,
+          encodingBuffer,
+          encodingLayout,
+          encodingOptions);
     case ScalarKind::Int32:
       return encodeNullableTyped<int32_t>(
-          options, data, nonNulls, encodingBuffer, encodingLayout);
+          options,
+          data,
+          nonNulls,
+          encodingBuffer,
+          encodingLayout,
+          encodingOptions);
     case ScalarKind::UInt32:
       return encodeNullableTyped<uint32_t>(
-          options, data, nonNulls, encodingBuffer, encodingLayout);
+          options,
+          data,
+          nonNulls,
+          encodingBuffer,
+          encodingLayout,
+          encodingOptions);
     case ScalarKind::Int64:
       return encodeNullableTyped<int64_t>(
-          options, data, nonNulls, encodingBuffer, encodingLayout);
+          options,
+          data,
+          nonNulls,
+          encodingBuffer,
+          encodingLayout,
+          encodingOptions);
     case ScalarKind::UInt64:
       return encodeNullableTyped<uint64_t>(
-          options, data, nonNulls, encodingBuffer, encodingLayout);
+          options,
+          data,
+          nonNulls,
+          encodingBuffer,
+          encodingLayout,
+          encodingOptions);
     case ScalarKind::Float:
       return encodeNullableTyped<float>(
-          options, data, nonNulls, encodingBuffer, encodingLayout);
+          options,
+          data,
+          nonNulls,
+          encodingBuffer,
+          encodingLayout,
+          encodingOptions);
     case ScalarKind::Double:
       return encodeNullableTyped<double>(
-          options, data, nonNulls, encodingBuffer, encodingLayout);
+          options,
+          data,
+          nonNulls,
+          encodingBuffer,
+          encodingLayout,
+          encodingOptions);
     case ScalarKind::String:
       [[fallthrough]];
     case ScalarKind::Binary:
       return encodeNullableTyped<std::string_view>(
-          options, data, nonNulls, encodingBuffer, encodingLayout);
+          options,
+          data,
+          nonNulls,
+          encodingBuffer,
+          encodingLayout,
+          encodingOptions);
     case ScalarKind::Undefined:
       NIMBLE_UNSUPPORTED(
           "Unsupported scalar kind for nullable nimble encoding: {}",
@@ -648,17 +712,19 @@ class StreamDataWriter {
 
   // --- Const members ---
   const SerializerOptions& options_;
-  // Memory pool for encoding buffer allocation.
+  // Memory pool for encoding scratch buffers.
   velox::memory::MemoryPool* const pool_;
-  // Buffer for nimble encoding output.
-  const std::unique_ptr<nimble::Buffer> encodingBuffer_;
+  // Scratch buffer holding one encoded stream before it is copied to output.
+  const std::unique_ptr<nimble::Buffer> streamEncodingBuffer_;
   // Optional map from stream offset to encoding layout for replaying captured
   // encodings. Only set when options_.encodingLayoutTree is specified.
   const std::unordered_map<uint32_t, const EncodingLayout*>* const
       streamEncodingLayouts_;
 
   // --- Mutable members ---
-  T& buffer_;
+  // Final serialized output. Encoded stream bytes and stream metadata are
+  // appended here after each stream encode completes.
+  T& outputBuffer_;
   // Track last stream offset for kLegacy format zero-filling.
   uint32_t lastStream_{0xffffffff};
   // Dense stream sizes. streamSizes_[i] = byte size of stream i (0 for
@@ -680,11 +746,11 @@ StreamDataWriter<T>::StreamDataWriter(
         streamEncodingLayouts)
     : options_{options},
       pool_{pool},
-      encodingBuffer_{
+      streamEncodingBuffer_{
           options.enableEncoding() ? std::make_unique<nimble::Buffer>(*pool)
                                    : nullptr},
       streamEncodingLayouts_{streamEncodingLayouts},
-      buffer_{buffer} {
+      outputBuffer_{buffer} {
   NIMBLE_CHECK(
       streamEncodingLayouts_ == nullptr || options_.enableEncoding(),
       "streamEncodingLayouts can only be set when encoding is enabled");
@@ -698,15 +764,17 @@ StreamDataWriter<T>::StreamDataWriter(
   writesHeaderFlags_ = usesHeaderFlags(version);
   if (writesHeaderFlags_) {
     headerFlagsOffset_ =
-        writeSerializationHeader(buffer_, version.value(), rowCount);
+        writeSerializationHeader(outputBuffer_, version.value(), rowCount);
     NIMBLE_CHECK_LT(
-        headerFlagsOffset_, buffer_.size(), "Invalid null barrier flag offset");
+        headerFlagsOffset_,
+        outputBuffer_.size(),
+        "Invalid null barrier flag offset");
     NIMBLE_CHECK_EQ(
-        static_cast<uint8_t>(buffer_.data()[headerFlagsOffset_]),
+        static_cast<uint8_t>(outputBuffer_.data()[headerFlagsOffset_]),
         0,
         "Null barrier flag should be initialized to zero");
   } else {
-    writeLegacySerializationHeader(buffer_, version, rowCount);
+    writeLegacySerializationHeader(outputBuffer_, version, rowCount);
   }
 }
 
@@ -734,7 +802,7 @@ void StreamDataWriter<T>::writeData(const nimble::StreamData& streamData) {
         "Use kSerialization for nullable support.");
 
     NIMBLE_CHECK_LE(lastStream_ + 1, streamOffset, "unexpected stream offset");
-    detail::writeMissingStreams(buffer_, lastStream_, streamOffset);
+    detail::writeMissingStreams(outputBuffer_, lastStream_, streamOffset);
     lastStream_ = streamOffset;
     encodeStream(scalarKind, streamOffset, data);
     return;
@@ -768,18 +836,18 @@ void StreamDataWriter<T>::encodeStream(
     if (scalarKind == ScalarKind::String || scalarKind == ScalarKind::Binary) {
       // Legacy string encoding: [total_size:u32][len_0:u32][data_0]...
       const auto size = detail::getStringsTotalSize(data);
-      auto* pos = detail::extend(buffer_, size + sizeof(uint32_t));
+      auto* pos = detail::extend(outputBuffer_, size + sizeof(uint32_t));
       detail::encodeStrings(data, size, pos);
     } else {
       // Legacy scalar encoding:
       //   Zstd: [size:u32][compType:i8][data...]
       //   LZ4:  [size:u32][compType:i8][origSize:u32][data...]
-      const auto bufferStart = buffer_.size();
+      const auto bufferStart = outputBuffer_.size();
       const uint32_t maxSize = data.size() + 2 * sizeof(uint32_t) + 1;
-      auto* pos = detail::extend(buffer_, maxSize);
+      auto* pos = detail::extend(outputBuffer_, maxSize);
       const auto encodedSize = detail::encode(options_, data, pos);
       if (encodedSize < maxSize) {
-        buffer_.resize(bufferStart + encodedSize);
+        outputBuffer_.resize(bufferStart + encodedSize);
       }
     }
     return;
@@ -793,14 +861,25 @@ void StreamDataWriter<T>::encodeStream(
     }
   }
 
-  // Use nimble encoding framework for optimal compression.
   std::string_view encoded;
   if (!facebook::nimble::StreamData::hasNullValues(nonNulls)) {
     encoded = detail::encodeScalar<T>(
-        options_, scalarKind, data, *pool_, *encodingBuffer_, encodingLayout);
+        options_,
+        scalarKind,
+        data,
+        *pool_,
+        *streamEncodingBuffer_,
+        encodingLayout,
+        options_.encodingOptions);
   } else {
     encoded = detail::encodeNullableScalar<T>(
-        options_, scalarKind, data, nonNulls, *encodingBuffer_, encodingLayout);
+        options_,
+        scalarKind,
+        data,
+        nonNulls,
+        *streamEncodingBuffer_,
+        encodingLayout,
+        options_.encodingOptions);
   }
 
   // Track size for trailer.
@@ -808,28 +887,32 @@ void StreamDataWriter<T>::encodeStream(
     streamSizes_.resize(streamOffset + 1, 0);
   }
   streamSizes_[streamOffset] = static_cast<uint32_t>(encoded.size());
-  auto* pos = detail::extend(buffer_, static_cast<uint32_t>(encoded.size()));
+  auto* pos =
+      detail::extend(outputBuffer_, static_cast<uint32_t>(encoded.size()));
   std::memcpy(pos, encoded.data(), encoded.size());
+  streamEncodingBuffer_->reset();
 }
 
 template <typename T>
 void StreamDataWriter<T>::close(uint32_t nodeCount) {
   if (!options_.enableEncoding()) {
-    detail::writeMissingStreams(buffer_, lastStream_, nodeCount);
+    detail::writeMissingStreams(outputBuffer_, lastStream_, nodeCount);
     return;
   }
 
   if (writesHeaderFlags_) {
     NIMBLE_CHECK_LT(
-        headerFlagsOffset_, buffer_.size(), "Invalid null barrier flag offset");
-    buffer_.data()[headerFlagsOffset_] =
+        headerFlagsOffset_,
+        outputBuffer_.size(),
+        "Invalid null barrier flag offset");
+    outputBuffer_.data()[headerFlagsOffset_] =
         static_cast<char>(detail::makeFlagsByte(requiresNullBarrier_));
   }
   detail::writeTrailer(
       streamSizes_,
       options_.streamIndicesEncodingType,
       options_.streamSizesEncodingType,
-      buffer_);
+      outputBuffer_);
 }
 
 } // namespace facebook::nimble::serde

--- a/dwio/nimble/serializer/tests/SerializationTest.cpp
+++ b/dwio/nimble/serializer/tests/SerializationTest.cpp
@@ -2361,6 +2361,82 @@ TEST_F(SerializationTest, rowNullStreamOmissionRoundTrips) {
   serializeAndVerify(/*allNull=*/true, /*expectNestedNullStream=*/true);
 }
 
+TEST_F(SerializationTest, nestedEncodingBufferCacheSizeConfigured) {
+  constexpr velox::vector_size_t kRows = 16;
+  auto type = velox::ROW({{"value", velox::BIGINT()}});
+
+  auto makeInput = [&](int64_t base) -> velox::VectorPtr {
+    auto values =
+        velox::BaseVector::create(velox::BIGINT(), kRows, pool_.get());
+    auto* flatValues = values->asFlatVector<int64_t>();
+    for (velox::vector_size_t i = 0; i < kRows; ++i) {
+      flatValues->set(i, base + i);
+      if (i % 5 == 0) {
+        values->setNull(i, true);
+      }
+    }
+    return std::make_shared<velox::RowVector>(
+        pool_.get(),
+        type,
+        nullptr,
+        kRows,
+        std::vector<velox::VectorPtr>{values});
+  };
+
+  struct TestCase {
+    const char* name;
+    bool setMaxCachedNestedEncodingBuffers;
+    uint32_t maxCachedNestedEncodingBuffers;
+  };
+
+  for (const auto& testCase : std::vector<TestCase>{
+           {
+               .name = "default",
+               .setMaxCachedNestedEncodingBuffers = false,
+               .maxCachedNestedEncodingBuffers = 0,
+           },
+           {
+               .name = "cache disabled",
+               .setMaxCachedNestedEncodingBuffers = true,
+               .maxCachedNestedEncodingBuffers = 0,
+           },
+           {
+               .name = "cache enabled",
+               .setMaxCachedNestedEncodingBuffers = true,
+               .maxCachedNestedEncodingBuffers = 1,
+           },
+       }) {
+    SCOPED_TRACE(testCase.name);
+
+    SerializerOptions options{
+        .version = SerializationVersion::kSerialization,
+    };
+    if (testCase.setMaxCachedNestedEncodingBuffers) {
+      options.maxCachedNestedEncodingBuffers =
+          testCase.maxCachedNestedEncodingBuffers;
+    }
+    Serializer serializer{options, type, pool_.get()};
+    Deserializer deserializer{
+        SchemaReader::getSchema(serializer.schemaBuilder().schemaNodes()),
+        pool_.get(),
+        DeserializerOptions{.hasHeader = true}};
+
+    for (const auto base : {0, 100}) {
+      auto input = makeInput(base);
+      const std::string serialized{
+          serializer.serialize(input, OrderedRanges::of(0, input->size()))};
+
+      velox::VectorPtr output;
+      deserializer.deserialize(serialized, output);
+
+      ASSERT_EQ(output->size(), input->size());
+      for (velox::vector_size_t i = 0; i < kRows; ++i) {
+        EXPECT_TRUE(vectorEquals(input, output, i));
+      }
+    }
+  }
+}
+
 TEST_F(SerializationTest, encodedSerializerRoundTripsTopLevelRowNulls) {
   constexpr velox::vector_size_t kRows = 6;
   auto type = velox::ROW({
@@ -2541,6 +2617,7 @@ TEST_F(SerializationTest, deserializerReadsPhysicalRootNullStream) {
 
   auto makeSerialized = [&](const std::array<bool, kRows>& rootNonNulls,
                             std::string_view valueData) -> std::string {
+    const Encoding::Options encodingOptions{.useVarintRowCount = true};
     Buffer rootBuffer{*pool_};
     const std::string_view rootData{
         reinterpret_cast<const char*>(rootNonNulls.data()),
@@ -2551,7 +2628,8 @@ TEST_F(SerializationTest, deserializerReadsPhysicalRootNullStream) {
         rootData,
         *pool_,
         rootBuffer,
-        /*encodingLayout=*/nullptr)};
+        /*encodingLayout=*/nullptr,
+        encodingOptions)};
 
     Buffer valueBuffer{*pool_};
     std::string valueEncoded{serde::detail::encodeScalar<std::string>(
@@ -2560,7 +2638,8 @@ TEST_F(SerializationTest, deserializerReadsPhysicalRootNullStream) {
         valueData,
         *pool_,
         valueBuffer,
-        /*encodingLayout=*/nullptr)};
+        /*encodingLayout=*/nullptr,
+        encodingOptions)};
 
     std::vector<std::pair<uint32_t, std::string>> streams;
     streams.emplace_back(rootNullOffset, std::move(rootEncoded));

--- a/dwio/nimble/velox/VeloxWriter.cpp
+++ b/dwio/nimble/velox/VeloxWriter.cpp
@@ -36,6 +36,7 @@
 #include "dwio/nimble/velox/StatsGenerated.h"
 #include "dwio/nimble/velox/StreamChunker.h"
 #include "dwio/nimble/velox/stats/VectorizedStatistics.h"
+#include "velox/common/testutil/TestValue.h"
 #include "velox/common/time/CpuWallTimer.h"
 #include "velox/common/time/Timer.h"
 #include "velox/type/Type.h"
@@ -324,6 +325,7 @@ std::string_view encode(
     std::optional<EncodingLayout> encodingLayout,
     detail::WriterContext& context,
     Buffer& buffer,
+    EncodingBufferPool* encodingBufferPool,
     const StreamData& streamData) {
   NIMBLE_DCHECK_EQ(
       streamData.data().size() % sizeof(T),
@@ -349,7 +351,10 @@ std::string_view encode(
                 .release()));
   }
 
-  const auto encodingOptions = context.options().buildEncodingOptions();
+  auto encodingOptions = context.options().buildEncodingOptions();
+  encodingOptions.encodingBufferPool = encodingBufferPool;
+  velox::common::testutil::TestValue::adjust(
+      "facebook::nimble::VeloxWriter::encode", &encodingOptions);
 
   if (streamData.hasNulls()) {
     std::span<const bool> notNulls = streamData.nonNulls();
@@ -365,6 +370,7 @@ template <typename T>
 std::string_view encodeStreamTyped(
     detail::WriterContext& context,
     Buffer& buffer,
+    EncodingBufferPool* encodingBufferPool,
     const StreamData& streamData) {
   const auto* streamContext =
       streamData.descriptor().context<WriterStreamContext>();
@@ -375,7 +381,12 @@ std::string_view encodeStreamTyped(
   }
 
   try {
-    return encode<T>(std::move(encodingLayout), context, buffer, streamData);
+    return encode<T>(
+        std::move(encodingLayout),
+        context,
+        buffer,
+        encodingBufferPool,
+        streamData);
   } catch (const NimbleUserError& e) {
     if (e.errorCode() != error_code::IncompatibleEncoding ||
         !encodingLayout.has_value()) {
@@ -383,37 +394,49 @@ std::string_view encodeStreamTyped(
     }
 
     // Incompatible captured encoding. Try again without a captured encoding.
-    return encode<T>(std::nullopt, context, buffer, streamData);
+    return encode<T>(
+        std::nullopt, context, buffer, encodingBufferPool, streamData);
   }
 }
 
 std::string_view encodeStreamData(
     detail::WriterContext& context,
     Buffer& buffer,
+    EncodingBufferPool* encodingBufferPool,
     const StreamData& streamData) {
   auto scalarKind = streamData.descriptor().scalarKind();
   switch (scalarKind) {
     case ScalarKind::Bool:
-      return encodeStreamTyped<bool>(context, buffer, streamData);
+      return encodeStreamTyped<bool>(
+          context, buffer, encodingBufferPool, streamData);
     case ScalarKind::Int8:
-      return encodeStreamTyped<int8_t>(context, buffer, streamData);
+      return encodeStreamTyped<int8_t>(
+          context, buffer, encodingBufferPool, streamData);
     case ScalarKind::Int16:
-      return encodeStreamTyped<int16_t>(context, buffer, streamData);
+      return encodeStreamTyped<int16_t>(
+          context, buffer, encodingBufferPool, streamData);
     case ScalarKind::UInt16:
-      return encodeStreamTyped<uint16_t>(context, buffer, streamData);
+      return encodeStreamTyped<uint16_t>(
+          context, buffer, encodingBufferPool, streamData);
     case ScalarKind::Int32:
-      return encodeStreamTyped<int32_t>(context, buffer, streamData);
+      return encodeStreamTyped<int32_t>(
+          context, buffer, encodingBufferPool, streamData);
     case ScalarKind::UInt32:
-      return encodeStreamTyped<uint32_t>(context, buffer, streamData);
+      return encodeStreamTyped<uint32_t>(
+          context, buffer, encodingBufferPool, streamData);
     case ScalarKind::Int64:
-      return encodeStreamTyped<int64_t>(context, buffer, streamData);
+      return encodeStreamTyped<int64_t>(
+          context, buffer, encodingBufferPool, streamData);
     case ScalarKind::Float:
-      return encodeStreamTyped<float>(context, buffer, streamData);
+      return encodeStreamTyped<float>(
+          context, buffer, encodingBufferPool, streamData);
     case ScalarKind::Double:
-      return encodeStreamTyped<double>(context, buffer, streamData);
+      return encodeStreamTyped<double>(
+          context, buffer, encodingBufferPool, streamData);
     case ScalarKind::String:
     case ScalarKind::Binary:
-      return encodeStreamTyped<std::string_view>(context, buffer, streamData);
+      return encodeStreamTyped<std::string_view>(
+          context, buffer, encodingBufferPool, streamData);
     default:
       NIMBLE_UNREACHABLE("Unsupported scalar kind {}", toString(scalarKind));
   }
@@ -1130,8 +1153,59 @@ void VeloxWriter::ensureEncodingBuffer() {
   }
 }
 
+std::unique_ptr<EncodingBufferPool> VeloxWriter::makeEncodingBufferPool()
+    const {
+  const auto maxCachedBuffers =
+      context_->options().maxCachedNestedEncodingBuffers;
+  if (maxCachedBuffers == 0) {
+    return nullptr;
+  }
+  return std::make_unique<EncodingBufferPool>(
+      encodingMemoryPool_.get(), maxCachedBuffers);
+}
+
+uint32_t VeloxWriter::encodingConcurrency(uint32_t taskCount) const {
+  if (taskCount == 0) {
+    return 0;
+  }
+  const auto& options = context_->options();
+  if (!options.encodingExecutor || options.maxEncodeParallelism == 0) {
+    return 1;
+  }
+  return std::min(taskCount, options.maxEncodeParallelism);
+}
+
+void VeloxWriter::ensureEncodingBufferPools(uint32_t poolCount) {
+  if (context_->options().maxCachedNestedEncodingBuffers == 0) {
+    NIMBLE_CHECK(
+        encodingBufferPools_.empty(),
+        "Encoding buffer pools should not be created when caching is disabled.");
+    return;
+  }
+  while (encodingBufferPools_.size() < poolCount) {
+    encodingBufferPools_.emplace_back(makeEncodingBufferPool());
+  }
+}
+
+EncodingBufferPool* VeloxWriter::encodingBufferPool(uint32_t index) {
+  if (context_->options().maxCachedNestedEncodingBuffers == 0) {
+    return nullptr;
+  }
+  ensureEncodingBufferPools(index + 1);
+  NIMBLE_CHECK_LT(index, encodingBufferPools_.size());
+  return encodingBufferPools_[index].get();
+}
+
 void VeloxWriter::clearEncodingBuffer() {
-  encodingBuffer_.reset();
+  if (encodingBuffer_ == nullptr) {
+    return;
+  }
+  if (context_->options().lowMemoryMode) {
+    encodingBuffer_.reset();
+    encodingBufferPools_.clear();
+    return;
+  }
+  encodingBuffer_->reset();
 }
 
 void VeloxWriter::ensureWriteStreams() {
@@ -1154,33 +1228,47 @@ void VeloxWriter::writeStreams() {
 
     ensureWriteStreams();
 
-    if (context_->options().encodingExecutor) {
-      velox::dwio::common::ExecutorBarrier barrier{
-          context_->options().encodingExecutor};
-      for (auto& [nodeId, streamData] : context_->streams()) {
-        barrier.add([&,
-                     statsCollector = context_->getStatsCollector(nodeId),
-                     _streamData = streamData.get()]() {
-          uint64_t startCpuNs = velox::process::threadCpuNanos();
-          uint64_t streamSize{0};
-          processStream(*_streamData, streamSize, chunkSize);
-          if (statsCollector) {
-            statsCollector->addPhysicalSize(streamSize);
-          }
-          encodingCpuNanos.fetch_add(
-              velox::process::threadCpuNanos() - startCpuNs,
-              std::memory_order_relaxed);
-        });
-      }
+    const auto& streams = context_->streams();
+    const auto streamCount = static_cast<uint32_t>(streams.size());
+    const auto concurrency = encodingConcurrency(streamCount);
+    ensureEncodingBufferPools(concurrency);
 
-      barrier.waitAll();
+    if (concurrency > 1) {
+      const auto& encodingExecutor = context_->options().encodingExecutor;
+      NIMBLE_CHECK(
+          encodingExecutor,
+          "Encoding executor is required for parallel encoding.");
+      for (uint32_t start = 0; start < streamCount; start += concurrency) {
+        velox::dwio::common::ExecutorBarrier barrier{encodingExecutor};
+        const auto batchSize = std::min(concurrency, streamCount - start);
+        for (uint32_t index = 0; index < batchSize; ++index) {
+          auto& [nodeId, streamData] = streams[start + index];
+          auto* encodingBufferPool = this->encodingBufferPool(index);
+          barrier.add([&,
+                       statsCollector = context_->getStatsCollector(nodeId),
+                       _streamData = streamData.get(),
+                       encodingBufferPool]() {
+            uint64_t startCpuNs = velox::process::threadCpuNanos();
+            uint64_t streamSize{0};
+            processStream(
+                *_streamData, encodingBufferPool, streamSize, chunkSize);
+            if (statsCollector) {
+              statsCollector->addPhysicalSize(streamSize);
+            }
+            encodingCpuNanos.fetch_add(
+                velox::process::threadCpuNanos() - startCpuNs,
+                std::memory_order_relaxed);
+          });
+        }
+        barrier.waitAll();
+      }
     } else {
-      const auto& streams = context_->streams();
+      auto* encodingBufferPool = this->encodingBufferPool();
       for (auto& [nodeId, streamData] : streams) {
         auto statsCollector = context_->getStatsCollector(nodeId);
         uint64_t startCpuNs = velox::process::threadCpuNanos();
         uint64_t streamSize{0};
-        processStream(*streamData, streamSize, chunkSize);
+        processStream(*streamData, encodingBufferPool, streamSize, chunkSize);
         if (statsCollector) {
           statsCollector->addPhysicalSize(streamSize);
         }
@@ -1203,6 +1291,7 @@ void VeloxWriter::writeStreams() {
 
 void VeloxWriter::encodeStream(
     StreamData& streamData,
+    EncodingBufferPool* encodingBufferPool,
     uint64_t& streamSize,
     std::atomic_uint64_t& chunkSize) {
   const auto offset = streamData.descriptor().offset();
@@ -1213,7 +1302,7 @@ void VeloxWriter::encodeStream(
   // used in non-chunked mode.
   NIMBLE_CHECK(encodedStream.chunks.empty());
   auto& chunk = encodedStream.chunks.emplace_back();
-  const auto chunkBytes = encodeChunk(streamData, chunk);
+  const auto chunkBytes = encodeChunk(streamData, chunk, encodingBufferPool);
   streamSize += chunkBytes;
   chunkSize += chunkBytes;
   streamData.reset();
@@ -1221,6 +1310,7 @@ void VeloxWriter::encodeStream(
 
 void VeloxWriter::processStream(
     StreamData& streamData,
+    EncodingBufferPool* encodingBufferPool,
     uint64_t& streamSize,
     std::atomic_uint64_t& chunkSize) {
   const auto offset = streamData.descriptor().offset();
@@ -1231,7 +1321,7 @@ void VeloxWriter::processStream(
     // boolean data.
     if (streamData.hasNullValues()) {
       NullsAsDataStreamData nullsStreamData{streamData};
-      encodeStream(nullsStreamData, streamSize, chunkSize);
+      encodeStream(nullsStreamData, encodingBufferPool, streamSize, chunkSize);
     }
   } else if (
       (context != nullptr) && context->isInMapStream() &&
@@ -1245,12 +1335,12 @@ void VeloxWriter::processStream(
     // skipConstantFlatMapInMapStreams to remain false.
     streamData.materialize();
     if (!isConstantBoolStream(streamData.data())) {
-      encodeStream(streamData, streamSize, chunkSize);
+      encodeStream(streamData, encodingBufferPool, streamSize, chunkSize);
     }
   } else {
     streamData.materialize();
     if (!streamData.data().empty()) {
-      encodeStream(streamData, streamSize, chunkSize);
+      encodeStream(streamData, encodingBufferPool, streamSize, chunkSize);
     }
   }
 }
@@ -1261,6 +1351,7 @@ bool VeloxWriter::encodeStreamChunk(
     uint64_t maxChunkSize,
     bool ensureFullChunks,
     Stream& encodedStream,
+    EncodingBufferPool* encodingBufferPool,
     uint64_t& streamBytes,
     std::atomic_uint64_t& chunkBytes,
     std::atomic_uint64_t& logicalBytes) {
@@ -1277,7 +1368,8 @@ bool VeloxWriter::encodeStreamChunk(
   uint64_t encodedChunkBytes{0};
   while (auto chunkView = chunker->next()) {
     auto& streamChunk = streamChunks.emplace_back();
-    encodedChunkBytes += encodeChunk(*chunkView, streamChunk);
+    encodedChunkBytes +=
+        encodeChunk(*chunkView, streamChunk, encodingBufferPool);
     writtenChunk = true;
   }
   streamBytes += encodedChunkBytes;
@@ -1288,9 +1380,12 @@ bool VeloxWriter::encodeStreamChunk(
   return writtenChunk;
 }
 
-uint32_t VeloxWriter::encodeChunk(const StreamData& chunkView, Chunk& chunk) {
-  std::string_view encoded =
-      encodeStreamData(*context_, *encodingBuffer_, chunkView);
+uint32_t VeloxWriter::encodeChunk(
+    const StreamData& chunkView,
+    Chunk& chunk,
+    EncodingBufferPool* encodingBufferPool) {
+  std::string_view encoded = encodeStreamData(
+      *context_, *encodingBuffer_, encodingBufferPool, chunkView);
   NIMBLE_DCHECK(!encoded.empty());
   if (encoded.empty()) {
     return 0;
@@ -1327,40 +1422,55 @@ bool VeloxWriter::writeChunks(
     ensureWriteStreams();
 
     const auto& streams = context_->streams();
-    if (context_->options().encodingExecutor) {
-      velox::dwio::common::ExecutorBarrier barrier{
-          context_->options().encodingExecutor};
-      for (auto streamIndex : streamIndices) {
-        auto& [nodeId, streamData] = streams[streamIndex];
-        const auto offset = streamData->descriptor().offset();
-        auto& encodeStream = encodedStreams_[offset];
-        barrier.add([&,
-                     streamData = streamData.get(),
-                     statsCollector = context_->getStatsCollector(nodeId)] {
-          uint64_t startCpuNs = velox::process::threadCpuNanos();
-          uint64_t streamSize = 0;
-          if (encodeStreamChunk(
-                  *streamData,
-                  minChunkSize,
-                  maxChunkSize,
-                  ensureFullChunks,
-                  encodeStream,
-                  streamSize,
-                  chunkBytes,
-                  logicalBytes)) {
-            writtenChunk = true;
-          }
-          if (statsCollector) {
-            statsCollector->addPhysicalSize(streamSize);
-          }
-          encodingCpuNanos.fetch_add(
-              velox::process::threadCpuNanos() - startCpuNs,
-              std::memory_order_relaxed);
-        });
-      }
+    const auto streamCount = static_cast<uint32_t>(streamIndices.size());
+    const auto concurrency = encodingConcurrency(streamCount);
+    ensureEncodingBufferPools(concurrency);
 
-      barrier.waitAll();
+    if (concurrency > 1) {
+      const auto& encodingExecutor = context_->options().encodingExecutor;
+      NIMBLE_CHECK(
+          encodingExecutor,
+          "Encoding executor is required for parallel encoding.");
+      for (uint32_t start = 0; start < streamCount; start += concurrency) {
+        velox::dwio::common::ExecutorBarrier barrier{encodingExecutor};
+        const auto batchSize = std::min(concurrency, streamCount - start);
+        for (uint32_t index = 0; index < batchSize; ++index) {
+          const auto streamIndex = streamIndices[start + index];
+          auto& [nodeId, streamData] = streams[streamIndex];
+          const auto offset = streamData->descriptor().offset();
+          auto* encodedStream = &encodedStreams_[offset];
+          auto* encodingBufferPool = this->encodingBufferPool(index);
+          barrier.add([&,
+                       streamData = streamData.get(),
+                       encodedStream,
+                       encodingBufferPool,
+                       statsCollector = context_->getStatsCollector(nodeId)] {
+            uint64_t startCpuNs = velox::process::threadCpuNanos();
+            uint64_t streamSize = 0;
+            if (encodeStreamChunk(
+                    *streamData,
+                    minChunkSize,
+                    maxChunkSize,
+                    ensureFullChunks,
+                    *encodedStream,
+                    encodingBufferPool,
+                    streamSize,
+                    chunkBytes,
+                    logicalBytes)) {
+              writtenChunk = true;
+            }
+            if (statsCollector) {
+              statsCollector->addPhysicalSize(streamSize);
+            }
+            encodingCpuNanos.fetch_add(
+                velox::process::threadCpuNanos() - startCpuNs,
+                std::memory_order_relaxed);
+          });
+        }
+        barrier.waitAll();
+      }
     } else {
+      auto* encodingBufferPool = this->encodingBufferPool();
       for (auto streamIndex : streamIndices) {
         auto& [nodeId, streamData] = streams[streamIndex];
         const auto offset = streamData->descriptor().offset();
@@ -1373,6 +1483,7 @@ bool VeloxWriter::writeChunks(
                 maxChunkSize,
                 ensureFullChunks,
                 encodedStreams_[offset],
+                encodingBufferPool,
                 streamSize,
                 chunkBytes,
                 logicalBytes)) {

--- a/dwio/nimble/velox/VeloxWriter.h
+++ b/dwio/nimble/velox/VeloxWriter.h
@@ -136,21 +136,27 @@ class VeloxWriter {
       uint64_t maxChunkSize,
       bool ensureFullChunks,
       Stream& stream,
+      EncodingBufferPool* encodingBufferPool,
       uint64_t& streamBytes,
       std::atomic_uint64_t& chunkBytes,
       std::atomic_uint64_t& logicalBytes);
 
   // Encodes a single chunk view and writes it to the encoded chunk.
   // Returns the number of bytes written to the encoded chunk.
-  uint32_t encodeChunk(const StreamData& chunkView, Chunk& chunk);
+  uint32_t encodeChunk(
+      const StreamData& chunkView,
+      Chunk& chunk,
+      EncodingBufferPool* encodingBufferPool);
 
   void encodeStream(
       StreamData& streamData,
+      EncodingBufferPool* encodingBufferPool,
       uint64_t& streamSize,
       std::atomic_uint64_t& chunkSize);
 
   void processStream(
       StreamData& streamData,
+      EncodingBufferPool* encodingBufferPool,
       uint64_t& streamSize,
       std::atomic_uint64_t& chunkSize);
 
@@ -186,8 +192,17 @@ class VeloxWriter {
       const CreateMetadataSectionFn& createMetadataFn,
       const WriteOptionalSectionFn& writeMetadataFn);
 
+  // Top-level stream encoding buffer reused after encoded bytes are copied out.
   void ensureEncodingBuffer();
   void clearEncodingBuffer();
+
+  // Nested encoding scratch pools. Pool 0 is used by sequential writes;
+  // parallel writes use one pool per concurrent encode task because the pool is
+  // not thread-safe.
+  std::unique_ptr<EncodingBufferPool> makeEncodingBufferPool() const;
+  uint32_t encodingConcurrency(uint32_t taskCount) const;
+  void ensureEncodingBufferPools(uint32_t poolCount);
+  EncodingBufferPool* encodingBufferPool(uint32_t index = 0);
 
   void ensureWriteStreams();
   void resetFieldWriter();
@@ -204,6 +219,7 @@ class VeloxWriter {
 
   std::unique_ptr<FieldWriter> rootWriter_;
   std::unique_ptr<Buffer> encodingBuffer_;
+  std::vector<std::unique_ptr<EncodingBufferPool>> encodingBufferPools_;
   std::vector<Stream> encodedStreams_;
   std::exception_ptr lastException_;
 };

--- a/dwio/nimble/velox/VeloxWriterOptions.h
+++ b/dwio/nimble/velox/VeloxWriterOptions.h
@@ -15,6 +15,7 @@
  */
 #pragma once
 
+#include "dwio/nimble/common/Buffer.h"
 #include "dwio/nimble/common/MetricsLogger.h"
 #include "dwio/nimble/common/Types.h"
 #include "dwio/nimble/encodings/selection/EncodingSelectionPolicy.h"
@@ -201,6 +202,11 @@ struct VeloxWriterOptions {
   /// encoding selection. False by default; do not enable for production until
   /// ALP is production-ready.
   bool allowNestedAlpSelection{false};
+
+  /// Maximum number of scratch buffers retained by each nested encoding buffer
+  /// pool. 0 disables nested encoding buffer caching. Disabled by default;
+  /// callers can set a non-zero value to opt in.
+  uint32_t maxCachedNestedEncodingBuffers{0};
 
   /// In low-memory mode, the writer is trying to perform smaller (and more
   /// precise) buffer allocations. This means that overall, the writer will

--- a/dwio/nimble/velox/tests/VeloxWriterTest.cpp
+++ b/dwio/nimble/velox/tests/VeloxWriterTest.cpp
@@ -221,6 +221,109 @@ TEST_F(VeloxWriterTest, alpEncodingSelectionControlsWriterEncoding) {
   testAlpE2EWriterSelection<double>(*rootPool_, leafPool_.get());
 }
 
+DEBUG_ONLY_TEST_F(VeloxWriterTest, encodingBufferPoolPassedToEncodeOptions) {
+  velox::common::testutil::TestValue::enable();
+
+  velox::test::VectorMaker vectorMaker{leafPool_.get()};
+  auto vector = vectorMaker.rowVector(
+      {"a", "b", "c", "d"},
+      {vectorMaker.flatVector<int64_t>(
+           128,
+           [](auto row) { return static_cast<int64_t>(row % 8); },
+           [](auto row) { return row % 7 == 0; }),
+       vectorMaker.flatVector<int64_t>(
+           128, [](auto row) { return static_cast<int64_t>(row); }),
+       vectorMaker.flatVector<int32_t>(
+           128, [](auto row) { return static_cast<int32_t>(row % 11); }),
+       vectorMaker.flatVector<double>(
+           128, [](auto row) { return static_cast<double>(row) * 0.5; })});
+
+  struct TestCase {
+    const char* name;
+    bool setMaxCachedNestedEncodingBuffers;
+    uint32_t maxCachedNestedEncodingBuffers;
+    uint32_t maxEncodeParallelism;
+    bool expectEncodingBufferPool;
+    size_t expectedPoolCount;
+  };
+
+  for (const auto& testCase : std::vector<TestCase>{
+           {
+               .name = "default",
+               .setMaxCachedNestedEncodingBuffers = false,
+               .maxCachedNestedEncodingBuffers = 0,
+               .maxEncodeParallelism = 0,
+               .expectEncodingBufferPool = false,
+               .expectedPoolCount = 0,
+           },
+           {
+               .name = "cache disabled",
+               .setMaxCachedNestedEncodingBuffers = true,
+               .maxCachedNestedEncodingBuffers = 0,
+               .maxEncodeParallelism = 0,
+               .expectEncodingBufferPool = false,
+               .expectedPoolCount = 0,
+           },
+           {
+               .name = "cache enabled",
+               .setMaxCachedNestedEncodingBuffers = true,
+               .maxCachedNestedEncodingBuffers = 1,
+               .maxEncodeParallelism = 0,
+               .expectEncodingBufferPool = true,
+               .expectedPoolCount = 1,
+           },
+           {
+               .name = "parallel cache enabled",
+               .setMaxCachedNestedEncodingBuffers = true,
+               .maxCachedNestedEncodingBuffers = 1,
+               .maxEncodeParallelism = 2,
+               .expectEncodingBufferPool = true,
+               .expectedPoolCount = 2,
+           },
+       }) {
+    SCOPED_TRACE(testCase.name);
+
+    uint32_t encodeCount{0};
+    uint32_t pooledEncodeCount{0};
+    std::set<const void*> observedPools;
+    SCOPED_TESTVALUE_SET(
+        "facebook::nimble::VeloxWriter::encode",
+        std::function<void(nimble::Encoding::Options*)>(
+            [&](nimble::Encoding::Options* encodingOptions) {
+              ++encodeCount;
+              if (encodingOptions->encodingBufferPool != nullptr) {
+                ++pooledEncodeCount;
+                observedPools.insert(encodingOptions->encodingBufferPool);
+              }
+            }));
+
+    std::shared_ptr<folly::CPUThreadPoolExecutor> executor;
+    nimble::VeloxWriterOptions options;
+    if (testCase.setMaxCachedNestedEncodingBuffers) {
+      options.maxCachedNestedEncodingBuffers =
+          testCase.maxCachedNestedEncodingBuffers;
+    }
+    if (testCase.maxEncodeParallelism > 0) {
+      executor = std::make_shared<folly::CPUThreadPoolExecutor>(
+          testCase.maxEncodeParallelism);
+      options.encodingExecutor = folly::getKeepAliveToken(*executor);
+      options.maxEncodeParallelism = testCase.maxEncodeParallelism;
+    }
+
+    std::string file;
+    auto writeFile = std::make_unique<velox::InMemoryWriteFile>(&file);
+    nimble::VeloxWriter writer(
+        vector->type(), std::move(writeFile), *rootPool_, std::move(options));
+    writer.write(vector);
+    writer.close();
+
+    EXPECT_GT(encodeCount, 0);
+    EXPECT_EQ(
+        pooledEncodeCount, testCase.expectEncodingBufferPool ? encodeCount : 0);
+    EXPECT_EQ(observedPools.size(), testCase.expectedPoolCount);
+  }
+}
+
 TEST_F(VeloxWriterTest, fsstEncodingTargetControlsWriterEncoding) {
   velox::test::VectorMaker vectorMaker{leafPool_.get()};
   auto vector = vectorMaker.rowVector(


### PR DESCRIPTION
Summary:

Add a small Nimble encoding scratch-buffer pool for write-time encoding and thread it through `Encoding::Options`, `VeloxWriter`, and serializer encode paths. Nested encodings now borrow a scoped `nimble::Buffer` instead of allocating a fresh local arena for each child stream, and normal-mode writers reset/reuse the top-level encoding arena after encoded bytes have been copied out.

`EncodingBufferPool` is a simple non-thread-safe retained-buffer stack. `VeloxWriter` owns a lazy pool for sequential Nimble file-write encode paths, releases it with the top-level encoding arena in low-memory mode, and keeps parallel encode tasks on separate local pools so nested scratch-buffer acquire/release does not require a pool-level mutex.

Keep the existing decode-side Velox scratch-buffer option name as `bufferPool`; the new write-side Nimble scratch arena is exposed separately as `encodingBufferPool`.

This also keeps the earlier small encode-path cleanups in this stack: `MainlyConstantEncoding` builds child streams without the previous full-bitmap initialization pattern for all-common data, and string input byte accounting uses existing `Statistics` string length data instead of rescanning strings.

Reviewed By: jiahaol-work, duxiao1212

Differential Revision: D111195999


