### PR TITLE
fix(selective): Fix deduplicated reader missed readNullsOnly() support

### DIFF
--- a/dwio/nimble/velox/selective/VariableLengthColumnReader.cpp
+++ b/dwio/nimble/velox/selective/VariableLengthColumnReader.cpp
@@ -830,7 +830,12 @@ void DeduplicatedReadHelper::makeNestedRowSet(
   lastRunLoaded_ = false;
   if (alphabetSize > 0) {
     lastRunLength_ = lengthAt(alphabetSize - 1);
-    if (runStartRows_[alphabetSize - 1] > rows.back()) {
+    // The last run is not selected when the batch was fully filtered (empty
+    // rows) or the run starts past the last selected row. The rows.empty() term
+    // also guards rows.back(), which is out-of-bounds on an empty RowSet.
+    const bool lastRunNotSelected =
+        rows.empty() || runStartRows_[alphabetSize - 1] > rows.back();
+    if (lastRunNotSelected) {
       // Leave the last run unread in child, in case we need it for the next
       // read. This is as if we skipped the last section manually. Alternatively
       // would be to always read the last run and populate the cache (but have
@@ -999,6 +1004,15 @@ void DeduplicatedArrayColumnReader::readLengths(
 void DeduplicatedArrayColumnReader::makeNestedRowSet(
     const velox::RowSet& rows,
     int32_t maxRow) {
+  if (readsNullsOnly()) {
+    // Nulls-only read (IS NULL): skip building the deduplicated states,
+    // matching the map reader. This avoids advancing the deduplicated decoders
+    // through the desynced skipNulls() seek path. Skipping is safe because the
+    // selected rows are all null, so the normal getValues() path returns
+    // correct all-null output.
+    nestedRows_ = {};
+    return;
+  }
   deduplicatedReadHelper_.makeNestedRowSet(
       rows,
       nullsInReadRange_ ? nullsInReadRange_->as<uint64_t>() : nullptr,
@@ -1155,6 +1169,15 @@ void DeduplicatedMapColumnReader::readLengths(
 void DeduplicatedMapColumnReader::makeNestedRowSet(
     const velox::RowSet& rows,
     int32_t maxRow) {
+  if (readsNullsOnly()) {
+    // Nulls-only read (IS NULL): skip building the deduplicated states. Their
+    // construction (prepareDeduplicatedStates) decodes the per-row lengths,
+    // which desync from the offsets after a skipNulls() seek and trip the
+    // shared-prefix check. Skipping is safe because the selected rows are all
+    // null, so the normal getValues() path returns correct all-null output.
+    nestedRows_ = {};
+    return;
+  }
   deduplicatedReadHelper_.makeNestedRowSet(
       rows,
       nullsInReadRange_ ? nullsInReadRange_->as<uint64_t>() : nullptr,

--- a/dwio/nimble/velox/selective/tests/E2EFilterTest.cpp
+++ b/dwio/nimble/velox/selective/tests/E2EFilterTest.cpp
@@ -1758,6 +1758,48 @@ TEST_P(E2EFilterTest, deduplicatedMap) {
       folly::Random::rand64(gen));
 }
 
+// Regression for the deduplicated-map seekTo desync. Reproducing it requires
+// the run-length-dictionary path: wrapping the batch so consecutive rows are
+// true duplicates produces long same-offset dedup runs. Under an IS NULL /
+// IS NOT NULL filter on map_val (-> readsNullsOnly), seekTo() uses skipNulls(),
+// which advances the nulls stream but freezes the deduplicated lengths decoder;
+// read over a long same-offset run, the stale length mismatches the real one,
+// tripping "None empty shared prefix is not allowed" in
+// prepareDeduplicatedStates. (Plain testWithTypes generates runs too short to
+// expose this -- hence the run-length-dictionary wrapping here.)
+TEST_P(E2EFilterTest, deduplicatedMapRunLengthDictSeekToDesync) {
+  if (common::testutil::useRandomSeed()) {
+    return;
+  }
+  seed_ = 2237282808;
+
+  deduplicatedMapColumns_ = {"map_val"};
+  // The base data comes from a persistent RNG that advances per makeDataset()
+  // call, so the testWithTypes() calls below must run first to reach the same
+  // data state that the run-length-dictionary path then desyncs on. Keep this
+  // sequence identical to the deduplicatedMap fuzz test.
+  testWithTypes(
+      "long_val:bigint,"
+      "int_val:int,"
+      "map_val:map<int, int>",
+      [&]() {},
+      true,
+      {"long_val", "int_val", "map_val"},
+      20,
+      /*withRecursiveNulls=*/true);
+  std::mt19937 gen{seed_};
+  testRunLengthDictionaryWithTypes(
+      "long_val:bigint,"
+      "int_val:int,"
+      "map_val:map<int, int>",
+      [&]() {},
+      true,
+      {"long_val", "int_val", "map_val"},
+      20,
+      /*withRecursiveNulls=*/true,
+      /*dictionaryGenSeed=*/folly::Random::rand64(gen));
+}
+
 // Pruning is only generated in struct_val.map_val in the normal case if filter
 // is present on top level map_val, but struct_val.map_val is not deduplicated,
 // so pruning is untested in normal case.

--- a/dwio/nimble/velox/selective/tests/VariableLengthColumnReaderTest.cpp
+++ b/dwio/nimble/velox/selective/tests/VariableLengthColumnReaderTest.cpp
@@ -468,5 +468,180 @@ TEST_F(VariableLengthColumnReaderTest, listAllNullsWithFilter) {
       *input, *readers.rowReader, 10, [](auto) { return false; });
 }
 
+// Nulls-only read (IS NULL) of a deduplicated map. Regression for the seekTo
+// desync (companion to the seed-pinned fuzz test
+// E2EFilterTest.deduplicatedMapRunLengthDictSeekToDesync). The data shape below
+// is a frozen, minimized reproduction; it does not depend on any random seed.
+//
+// The desync it guards against:
+//   * c1 (map) is deduplicated: offsets are deduplicated into same-offset runs
+//     of identical maps, while lengths are stored per row. Map sizes vary
+//     across runs (1..4 entries) so the per-row lengths stream is non-constant.
+//   * c0 is a sibling filter column. It is filtered first, so it trims the tail
+//     rows of a batch; the map reader then ends a batch behind the batch end
+//     and is seeked forward at the start of the next batch.
+//   * The IS NULL filter on c1 makes the map reads nulls-only, so that forward
+//     seek routes through skipNulls(). Pre-fix, skipNulls advanced the offsets
+//     stream but froze the separate per-row lengths decoder; a later
+//     same-offset run then read stale, mismatched lengths, tripping "None empty
+//     shared prefix is not allowed" in prepareDeduplicatedStates.
+//   * The multi-chunk layout (minStreamChunkRawSize=0 + frequent chunk flushes)
+//     is required to expose the cross-chunk decoder desync.
+TEST_F(VariableLengthColumnReaderTest, deduplicatedMapReadNullsOnly) {
+  // Same-offset dedup runs of varying size, interleaved with nulls. Each
+  // comment marks one run of identical maps (all rows in a run share a dedup
+  // offset); the varying sizes make the per-row lengths stream non-constant.
+  const std::vector<NullableMap<int64_t>> maps = {
+      // {0:0} x4
+      makeNullableMap<int64_t>({{0, 0}}),
+      makeNullableMap<int64_t>({{0, 0}}),
+      makeNullableMap<int64_t>({{0, 0}}),
+      makeNullableMap<int64_t>({{0, 0}}),
+      std::nullopt,
+      // {0:0, 1:1} x2
+      makeNullableMap<int64_t>({{0, 0}, {1, 1}}),
+      makeNullableMap<int64_t>({{0, 0}, {1, 1}}),
+      // {0:0, 1:1, 2:2, 3:3} x2
+      makeNullableMap<int64_t>({{0, 0}, {1, 1}, {2, 2}, {3, 3}}),
+      makeNullableMap<int64_t>({{0, 0}, {1, 1}, {2, 2}, {3, 3}}),
+      // {0:0} x3
+      makeNullableMap<int64_t>({{0, 0}}),
+      makeNullableMap<int64_t>({{0, 0}}),
+      makeNullableMap<int64_t>({{0, 0}}),
+      // {0:0, 1:1} x2
+      makeNullableMap<int64_t>({{0, 0}, {1, 1}}),
+      makeNullableMap<int64_t>({{0, 0}, {1, 1}}),
+      // {0:0} x2
+      makeNullableMap<int64_t>({{0, 0}}),
+      makeNullableMap<int64_t>({{0, 0}}),
+      // {0:0, 1:1, 2:2, 3:3} x1
+      makeNullableMap<int64_t>({{0, 0}, {1, 1}, {2, 2}, {3, 3}}),
+      // {0:0, 1:1, 2:2} x1
+      makeNullableMap<int64_t>({{0, 0}, {1, 1}, {2, 2}}),
+      std::nullopt,
+      // {0:0, 1:1, 2:2} x5
+      makeNullableMap<int64_t>({{0, 0}, {1, 1}, {2, 2}}),
+      makeNullableMap<int64_t>({{0, 0}, {1, 1}, {2, 2}}),
+      makeNullableMap<int64_t>({{0, 0}, {1, 1}, {2, 2}}),
+      makeNullableMap<int64_t>({{0, 0}, {1, 1}, {2, 2}}),
+      makeNullableMap<int64_t>({{0, 0}, {1, 1}, {2, 2}}),
+      // {0:0, 1:1} x1
+      makeNullableMap<int64_t>({{0, 0}, {1, 1}}),
+      // {0:0, 1:1, 2:2, 3:3} x1
+      makeNullableMap<int64_t>({{0, 0}, {1, 1}, {2, 2}, {3, 3}}),
+      std::nullopt,
+      // {0:0, 1:1, 2:2, 3:3} x3
+      makeNullableMap<int64_t>({{0, 0}, {1, 1}, {2, 2}, {3, 3}}),
+      makeNullableMap<int64_t>({{0, 0}, {1, 1}, {2, 2}, {3, 3}}),
+      makeNullableMap<int64_t>({{0, 0}, {1, 1}, {2, 2}, {3, 3}}),
+      std::nullopt,
+      // {0:0, 1:1, 2:2} x1
+      makeNullableMap<int64_t>({{0, 0}, {1, 1}, {2, 2}}),
+  };
+  const std::vector<int64_t> siblingValues = {4, 3, 9, 9, 0, 6, 6, 4, 4, 3, 3,
+                                              0, 3, 9, 5, 1, 7, 9, 3, 2, 3, 8,
+                                              9, 2, 0, 9, 7, 7, 7, 3, 6, 5};
+  ASSERT_EQ(maps.size(), siblingValues.size());
+  const int numRows = maps.size();
+
+  // Write as two batches within a stripe, forcing frequent chunk boundaries so
+  // the offsets and lengths streams are chunked (multi-chunk is required).
+  const int numBatches = 2;
+  std::vector<VectorPtr> batches;
+  for (int b = 0; b < numBatches; ++b) {
+    int start = b * numRows / numBatches;
+    int end = (b + 1) * numRows / numBatches;
+    std::vector<NullableMap<int64_t>> batchMaps(
+        maps.begin() + start, maps.begin() + end);
+    std::vector<int64_t> batchSiblings(
+        siblingValues.begin() + start, siblingValues.begin() + end);
+    batches.push_back(makeRowVector(
+        {"c0", "c1"},
+        {makeFlatVector<int64_t>(batchSiblings),
+         makeNullableMapVector<int64_t, int64_t>(batchMaps)}));
+  }
+
+  VeloxWriterOptions writerOptions;
+  writerOptions.enableChunking = true;
+  writerOptions.minStreamChunkRawSize = 0;
+  writerOptions.deduplicatedMapColumns = {"c1"};
+  int flushCounter = 0;
+  writerOptions.flushPolicyFactory = [&flushCounter]() {
+    return std::make_unique<LambdaFlushPolicy>(
+        [&flushCounter](const StripeProgress&) {
+          return flushCounter++ % 3 == 2;
+        },
+        [&flushCounter](const StripeProgress&) {
+          return flushCounter++ % 3 == 2;
+        });
+  };
+  auto file = test::createNimbleFile(
+      *rootPool(),
+      batches,
+      std::move(writerOptions),
+      /*flushAfterWrite=*/false);
+
+  auto fullInput = makeRowVector(
+      {"c0", "c1"},
+      {makeFlatVector<int64_t>(siblingValues),
+       makeNullableMapVector<int64_t, int64_t>(maps)});
+  auto fullType = asRowType(fullInput->type());
+
+  // The desync surfaces only once the per-row lengths buffer has been populated
+  // by earlier reads (a fresh buffer reads as zeros, which the "shared prefix
+  // of length 0" carve-out tolerates). This mirrors the fuzz test, which
+  // reaches the faulty state through a sequence of reads. Exercising several c0
+  // filter selectivities and batch sizes reproduces it: pre-fix, one of these
+  // reads trips "None empty shared prefix is not allowed"; post-fix, all return
+  // the rows whose sibling is in range and whose map is null.
+  const std::vector<std::pair<int64_t, int64_t>> siblingRanges = {
+      {0, 6}, {0, 3}, {2, 8}, {0, 7}, {1, 5}};
+  for (const auto& range : siblingRanges) {
+    for (int batchSize : {8, 16, 32}) {
+      auto scanSpec = std::make_shared<common::ScanSpec>("root");
+      scanSpec->addAllChildFields(*fullType);
+      // c0 is filtered first and trims batch tails; c1 IS NULL makes the map
+      // reader nulls-only so its forward seeks use skipNulls().
+      scanSpec->childByName("c1")->setFilter(
+          std::make_unique<common::IsNull>());
+      scanSpec->childByName("c0")->setFilter(
+          std::make_unique<common::BigintRange>(
+              range.first, range.second, false));
+      auto readers = makeReaders(fullInput, file, scanSpec);
+      validateWithFilter(*fullInput, *readers.rowReader, batchSize, [&](int i) {
+        return siblingValues[i] >= range.first &&
+            siblingValues[i] <= range.second && !maps[i].has_value();
+      });
+    }
+  }
+}
+
+// Regression for the rows.empty() guard in DeduplicatedReadHelper::
+// makeNestedRowSet. An all-non-null deduplicated map read under an IS NULL
+// filter leaves every read batch fully filtered (activeRows empty) while the
+// deduplicated alphabet is non-empty (alphabetSize > 0). The nulls-only read
+// path short-circuits this today, but if that early-return is ever removed the
+// reader reaches makeNestedRowSet with empty rows, where the rows.empty() guard
+// prevents an out-of-bounds rows.back() on the empty RowSet. (Verified: with
+// the early-return disabled and the guard removed, this reads rows.back() on an
+// empty RowSet.)
+TEST_F(VariableLengthColumnReaderTest, deduplicatedMapAllNonNullWithIsNull) {
+  auto c0 = makeMapVector<int64_t, int64_t>(
+      12,
+      [](auto i) { return 1 + (i % 3); },
+      [](auto j) { return j % 4; },
+      [](auto j) { return j % 4; });
+  auto input = makeRowVector({c0});
+  VeloxWriterOptions options;
+  options.deduplicatedMapColumns = {"c0"};
+  auto file = test::createNimbleFile(*rootPool(), input, std::move(options));
+  auto scanSpec = std::make_shared<common::ScanSpec>("root");
+  scanSpec->addAllChildFields(*input->type());
+  scanSpec->childByName("c0")->setFilter(std::make_unique<common::IsNull>());
+  auto readers = makeReaders(input, file, scanSpec);
+  // IS NULL matches nothing (all rows non-null): output is empty, no crash.
+  validateWithFilter(*input, *readers.rowReader, 4, [](auto) { return false; });
+}
+
 } // namespace
 } // namespace facebook::nimble


### PR DESCRIPTION
Summary:
The deduplicated map/array column readers (`DeduplicatedMapColumnReader`, `DeduplicatedArrayColumnReader`) inherit the base `readsNullsOnly()`, which returns true for `IS NULL` / `IS NOT NULL` filters. Under such a filter, `seekTo()` routes a forward skip through `skipNulls()`, which only advances the nulls/offsets decoder. But these readers keep the per-row lengths (and the deduplicated run state) in separate streams that `skipNulls()` never advances. After a forward seek — for example when a sibling filter trims a batch tail so the map reader ends a batch behind the batch end and is seeked forward at the start of the next batch, across a chunk boundary — the frozen lengths decoder is desynchronized from the (correctly advanced) offsets. A later same-offset deduplicated run then reads stale, mismatched per-row lengths and trips `INVALID_STATE: currentLength == 0 (... vs. 0) None empty shared prefix is not allowed` in `prepareDeduplicatedStates`.

Fix: under `readsNullsOnly()`, skip building the deduplicated states in `makeNestedRowSet()` on both readers, so the desync-prone per-row length decode in `prepareDeduplicatedStates` never runs. This is safe because the selected rows are all null (`IS NULL`), so the normal `getValues()` path still returns correct all-null output. Only the map reader trips the shared-prefix check (it stores per-row lengths); the array reader (deduplicated run lengths, no per-row check) is guarded symmetrically to keep the two paths consistent.

Also guards `rows.back()` in `DeduplicatedReadHelper::makeNestedRowSet` with a `rows.empty()` check (extracted into a named `lastRunNotSelected` condition), since the post-filter active row set can be empty when a filter rejects all rows in a batch (e.g. `IS NULL` on an all-non-null batch) and `rows.back()` on an empty `RowSet` is out of bounds.

This diff only prevents the crash while keeping results correct; on a nulls-only read it still falls through to the normal `getValues()` path, which materializes and then null-masks a dictionary vector. Taking the efficient nulls-only path (emitting null vectors directly and skipping child materialization) is a follow-up.

Reviewed By: xiaoxmeng

Differential Revision: D108277220


