### PR TITLE
perf: Optimize numeric statistics collection

### DIFF
--- a/dwio/nimble/velox/stats/ColumnStatistics.cpp
+++ b/dwio/nimble/velox/stats/ColumnStatistics.cpp
@@ -15,9 +15,126 @@
  */
 #include "dwio/nimble/velox/stats/ColumnStatistics.h"
 
+#include <algorithm>
+#include <cmath>
+#include <optional>
+#include <utility>
+
 #include "dwio/nimble/common/Exceptions.h"
+#include "velox/common/base/SimdUtil.h"
 
 namespace facebook::nimble {
+
+namespace {
+
+template <typename T>
+struct MinMax {
+  T min;
+  T max;
+};
+
+template <typename T>
+MinMax<int64_t> findIntegralMinMax(std::span<T> values) {
+  static_assert(std::is_integral_v<T>);
+  using Batch = xsimd::batch<T>;
+
+  auto* rawValues = values.data();
+  size_t index{0};
+  T minValue{values.front()};
+  T maxValue{values.front()};
+
+  if (values.size() >= Batch::size) {
+    auto minBatch = Batch::load_unaligned(rawValues);
+    auto maxBatch = minBatch;
+    index = Batch::size;
+    for (; index + Batch::size <= values.size(); index += Batch::size) {
+      const auto batch = Batch::load_unaligned(rawValues + index);
+      minBatch = xsimd::min(minBatch, batch);
+      maxBatch = xsimd::max(maxBatch, batch);
+    }
+    minValue = xsimd::reduce_min(minBatch);
+    maxValue = xsimd::reduce_max(maxBatch);
+  }
+
+  for (; index < values.size(); ++index) {
+    minValue = std::min(minValue, values[index]);
+    maxValue = std::max(maxValue, values[index]);
+  }
+
+  return {
+      .min = static_cast<int64_t>(minValue),
+      .max = static_cast<int64_t>(maxValue),
+  };
+}
+
+template <typename T>
+std::optional<MinMax<double>> findFloatingPointMinMax(std::span<T> values) {
+  static_assert(std::is_floating_point_v<T>);
+  using Batch = xsimd::batch<T>;
+
+  auto* rawValues = values.data();
+  size_t index{0};
+  T minValue{values.front()};
+  T maxValue{values.front()};
+
+  if (std::isnan(minValue)) {
+    return std::nullopt;
+  }
+
+  if (values.size() >= Batch::size) {
+    auto minBatch = Batch::load_unaligned(rawValues);
+    if (xsimd::any(minBatch != minBatch)) {
+      return std::nullopt;
+    }
+    auto maxBatch = minBatch;
+    index = Batch::size;
+    for (; index + Batch::size <= values.size(); index += Batch::size) {
+      const auto batch = Batch::load_unaligned(rawValues + index);
+      if (xsimd::any(batch != batch)) {
+        return std::nullopt;
+      }
+      minBatch = xsimd::min(minBatch, batch);
+      maxBatch = xsimd::max(maxBatch, batch);
+    }
+    minValue = xsimd::reduce_min(minBatch);
+    maxValue = xsimd::reduce_max(maxBatch);
+  }
+
+  for (; index < values.size(); ++index) {
+    const auto value = values[index];
+    if (std::isnan(value)) {
+      return std::nullopt;
+    }
+    minValue = std::min(minValue, value);
+    maxValue = std::max(maxValue, value);
+  }
+
+  return MinMax<double>{
+      .min = static_cast<double>(minValue),
+      .max = static_cast<double>(maxValue),
+  };
+}
+
+template <typename T>
+void addFloatingPointValuesScalar(
+    std::optional<double>& min,
+    std::optional<double>& max,
+    std::span<T> values) {
+  if (UNLIKELY(!min.has_value())) {
+    min = static_cast<double>(values.front());
+  }
+  if (UNLIKELY(!max.has_value())) {
+    max = static_cast<double>(values.front());
+  }
+
+  for (const auto& value : values) {
+    auto current = static_cast<double>(value);
+    min = min > current ? std::make_optional(current) : min;
+    max = max < current ? std::make_optional(current) : max;
+  }
+}
+
+} // namespace
 
 ColumnStatistics::ColumnStatistics(
     uint64_t valueCount,
@@ -314,20 +431,17 @@ void IntegralStatisticsCollector::addValues(std::span<T> values) {
   static_assert(std::is_integral_v<T>);
   addLogicalSize(values.size() * sizeof(T));
 
-  if (!values.empty()) {
-    auto* stats = integralStats();
-    if (UNLIKELY(!stats->min_.has_value())) {
-      stats->min_ = static_cast<int64_t>(values.front());
-    }
-    if (UNLIKELY(!stats->max_.has_value())) {
-      stats->max_ = static_cast<int64_t>(values.front());
-    }
+  if (values.empty()) {
+    return;
+  }
 
-    for (const auto& value : values) {
-      auto v = static_cast<int64_t>(value);
-      stats->min_ = stats->min_ > v ? std::make_optional(v) : stats->min_;
-      stats->max_ = stats->max_ < v ? std::make_optional(v) : stats->max_;
-    }
+  auto* stats = integralStats();
+  const auto minMax = findIntegralMinMax(values);
+  if (!stats->min_.has_value() || minMax.min < *stats->min_) {
+    stats->min_ = minMax.min;
+  }
+  if (!stats->max_.has_value() || minMax.max > *stats->max_) {
+    stats->max_ = minMax.max;
   }
 }
 
@@ -379,20 +493,21 @@ void FloatingPointStatisticsCollector::addValues(std::span<T> values) {
   static_assert(std::is_floating_point_v<T>);
   addLogicalSize(values.size() * sizeof(T));
 
-  if (!values.empty()) {
-    auto* stats = floatingPointStats();
-    if (UNLIKELY(!stats->min_.has_value())) {
-      stats->min_ = static_cast<double>(values.front());
-    }
-    if (UNLIKELY(!stats->max_.has_value())) {
-      stats->max_ = static_cast<double>(values.front());
-    }
+  if (values.empty()) {
+    return;
+  }
 
-    for (const auto& value : values) {
-      auto v = static_cast<double>(value);
-      stats->min_ = stats->min_ > v ? std::make_optional(v) : stats->min_;
-      stats->max_ = stats->max_ < v ? std::make_optional(v) : stats->max_;
-    }
+  auto* stats = floatingPointStats();
+  const auto minMax = findFloatingPointMinMax(values);
+  if (!minMax.has_value()) {
+    addFloatingPointValuesScalar(stats->min_, stats->max_, values);
+    return;
+  }
+  if (!stats->min_.has_value() || minMax->min < *stats->min_) {
+    stats->min_ = minMax->min;
+  }
+  if (!stats->max_.has_value() || minMax->max > *stats->max_) {
+    stats->max_ = minMax->max;
   }
 }
 

--- a/dwio/nimble/velox/stats/benchmarks/ColumnStatisticsBenchmark.cpp
+++ b/dwio/nimble/velox/stats/benchmarks/ColumnStatisticsBenchmark.cpp
@@ -1,0 +1,244 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <algorithm>
+#include <cstdint>
+#include <limits>
+#include <optional>
+#include <span>
+#include <vector>
+
+#include <folly/Benchmark.h>
+#include <folly/Portability.h>
+#include <folly/init/Init.h>
+
+#include "dwio/nimble/velox/stats/ColumnStatistics.h"
+
+using namespace facebook::nimble;
+
+namespace {
+
+struct LegacyIntegralStatistics {
+  uint64_t logicalSize{0};
+  std::optional<int64_t> min;
+  std::optional<int64_t> max;
+};
+
+struct LegacyFloatingPointStatistics {
+  uint64_t logicalSize{0};
+  std::optional<double> min;
+  std::optional<double> max;
+};
+
+template <typename T>
+std::vector<T> makeIntegralValues(size_t numValues) {
+  std::vector<T> values;
+  values.reserve(numValues);
+
+  const auto lower =
+      std::max<int64_t>(std::numeric_limits<T>::min(), -1'000'000);
+  const auto upper =
+      std::min<int64_t>(std::numeric_limits<T>::max(), 1'000'000);
+  const auto range = static_cast<uint64_t>(upper - lower) + 1;
+  for (size_t i = 0; i < numValues; ++i) {
+    const auto mixed = i * 1'103'515'245 + 12'345;
+    values.push_back(static_cast<T>(lower + (mixed % range)));
+  }
+
+  if (!values.empty()) {
+    values[numValues / 3] = std::numeric_limits<T>::min();
+    values[(2 * numValues) / 3] = std::numeric_limits<T>::max();
+  }
+  return values;
+}
+
+template <typename T, size_t NumValues>
+std::vector<T>& integralValues() {
+  static auto* values = new std::vector<T>(makeIntegralValues<T>(NumValues));
+  return *values;
+}
+
+template <typename T>
+std::vector<T> makeFloatingPointValues(size_t numValues) {
+  std::vector<T> values;
+  values.reserve(numValues);
+
+  for (size_t i = 0; i < numValues; ++i) {
+    const auto mixed = i * 1'103'515'245 + 12'345;
+    values.push_back(
+        static_cast<T>(static_cast<int64_t>(mixed % 2'000'001) - 1'000'000) /
+        static_cast<T>(10.0));
+  }
+
+  if (!values.empty()) {
+    values[numValues / 3] = std::numeric_limits<T>::lowest();
+    values[(2 * numValues) / 3] = std::numeric_limits<T>::max();
+  }
+  return values;
+}
+
+template <typename T, size_t NumValues>
+std::vector<T>& floatingPointValues() {
+  static auto* values =
+      new std::vector<T>(makeFloatingPointValues<T>(NumValues));
+  return *values;
+}
+
+template <typename T>
+FOLLY_NOINLINE void legacyAddIntegralValues(
+    LegacyIntegralStatistics& stats,
+    std::span<T> values) {
+  stats.logicalSize += values.size() * sizeof(T);
+
+  if (values.empty()) {
+    return;
+  }
+
+  if (!stats.min.has_value()) {
+    stats.min = static_cast<int64_t>(values.front());
+  }
+  if (!stats.max.has_value()) {
+    stats.max = static_cast<int64_t>(values.front());
+  }
+
+  for (const auto& value : values) {
+    auto current = static_cast<int64_t>(value);
+    stats.min = stats.min > current ? std::make_optional(current) : stats.min;
+    stats.max = stats.max < current ? std::make_optional(current) : stats.max;
+  }
+}
+
+template <typename T>
+FOLLY_NOINLINE void legacyAddFloatingPointValues(
+    LegacyFloatingPointStatistics& stats,
+    std::span<T> values) {
+  stats.logicalSize += values.size() * sizeof(T);
+
+  if (values.empty()) {
+    return;
+  }
+
+  if (!stats.min.has_value()) {
+    stats.min = static_cast<double>(values.front());
+  }
+  if (!stats.max.has_value()) {
+    stats.max = static_cast<double>(values.front());
+  }
+
+  for (const auto& value : values) {
+    auto current = static_cast<double>(value);
+    stats.min = stats.min > current ? std::make_optional(current) : stats.min;
+    stats.max = stats.max < current ? std::make_optional(current) : stats.max;
+  }
+}
+
+template <typename T, size_t NumValues>
+void legacyIntegralOptionalBenchmark(unsigned int iters) {
+  auto& input = integralValues<T, NumValues>();
+  LegacyIntegralStatistics stats;
+
+  while (iters--) {
+    legacyAddIntegralValues(stats, std::span<T>(input));
+  }
+
+  folly::doNotOptimizeAway(stats.logicalSize);
+  folly::doNotOptimizeAway(stats.min);
+  folly::doNotOptimizeAway(stats.max);
+}
+
+template <typename T, size_t NumValues>
+void currentIntegralCollectorBenchmark(unsigned int iters) {
+  auto& input = integralValues<T, NumValues>();
+  IntegralStatisticsCollector collector;
+
+  while (iters--) {
+    collector.addValues(std::span<T>(input));
+  }
+
+  auto* stats = collector.getStatsView()->as<IntegralStatistics>();
+  folly::doNotOptimizeAway(stats->getLogicalSize());
+  folly::doNotOptimizeAway(stats->getMin());
+  folly::doNotOptimizeAway(stats->getMax());
+}
+
+template <typename T, size_t NumValues>
+void legacyFloatingPointOptionalBenchmark(unsigned int iters) {
+  auto& input = floatingPointValues<T, NumValues>();
+  LegacyFloatingPointStatistics stats;
+
+  while (iters--) {
+    legacyAddFloatingPointValues(stats, std::span<T>(input));
+  }
+
+  folly::doNotOptimizeAway(stats.logicalSize);
+  folly::doNotOptimizeAway(stats.min);
+  folly::doNotOptimizeAway(stats.max);
+}
+
+template <typename T, size_t NumValues>
+void currentFloatingPointCollectorBenchmark(unsigned int iters) {
+  auto& input = floatingPointValues<T, NumValues>();
+  FloatingPointStatisticsCollector collector;
+
+  while (iters--) {
+    collector.addValues(std::span<T>(input));
+  }
+
+  auto* stats = collector.getStatsView()->as<FloatingPointStatistics>();
+  folly::doNotOptimizeAway(stats->getLogicalSize());
+  folly::doNotOptimizeAway(stats->getMin());
+  folly::doNotOptimizeAway(stats->getMax());
+}
+
+} // namespace
+
+#define INTEGRAL_STATS_BENCHMARKS(type, name, numValues)             \
+  BENCHMARK(legacyOptional_##name##_##numValues, iters) {            \
+    legacyIntegralOptionalBenchmark<type, numValues>(iters);         \
+  }                                                                  \
+  BENCHMARK_RELATIVE(currentCollector_##name##_##numValues, iters) { \
+    currentIntegralCollectorBenchmark<type, numValues>(iters);       \
+  }                                                                  \
+  BENCHMARK_DRAW_LINE()
+
+#define FLOATING_POINT_STATS_BENCHMARKS(type, name, numValues)         \
+  BENCHMARK(legacyFloatingPointOptional_##name##_##numValues, iters) { \
+    legacyFloatingPointOptionalBenchmark<type, numValues>(iters);      \
+  }                                                                    \
+  BENCHMARK_RELATIVE(                                                  \
+      currentFloatingPointCollector_##name##_##numValues, iters) {     \
+    currentFloatingPointCollectorBenchmark<type, numValues>(iters);    \
+  }                                                                    \
+  BENCHMARK_DRAW_LINE()
+
+INTEGRAL_STATS_BENCHMARKS(int8_t, int8, 128);
+INTEGRAL_STATS_BENCHMARKS(int8_t, int8, 8192);
+INTEGRAL_STATS_BENCHMARKS(int16_t, int16, 128);
+INTEGRAL_STATS_BENCHMARKS(int16_t, int16, 8192);
+INTEGRAL_STATS_BENCHMARKS(int32_t, int32, 128);
+INTEGRAL_STATS_BENCHMARKS(int32_t, int32, 8192);
+INTEGRAL_STATS_BENCHMARKS(int64_t, int64, 128);
+INTEGRAL_STATS_BENCHMARKS(int64_t, int64, 8192);
+FLOATING_POINT_STATS_BENCHMARKS(float, float, 128);
+FLOATING_POINT_STATS_BENCHMARKS(float, float, 8192);
+FLOATING_POINT_STATS_BENCHMARKS(double, double, 128);
+FLOATING_POINT_STATS_BENCHMARKS(double, double, 8192);
+
+int main(int argc, char** argv) {
+  folly::Init init(&argc, &argv);
+  folly::runBenchmarks();
+  return 0;
+}

--- a/dwio/nimble/velox/stats/tests/ColumnStatisticsTests.cpp
+++ b/dwio/nimble/velox/stats/tests/ColumnStatisticsTests.cpp
@@ -13,12 +13,84 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+#include <cmath>
+
 #include <gtest/gtest.h>
 
 #include "dwio/nimble/velox/stats/ColumnStatistics.h"
 
 using namespace facebook;
 using namespace facebook::nimble;
+
+namespace {
+
+template <typename T>
+void testIntegralMinMaxAcrossBatches() {
+  IntegralStatisticsCollector collector;
+
+  std::vector<T> firstValues = {
+      static_cast<T>(5),
+      static_cast<T>(-3),
+      static_cast<T>(12),
+      static_cast<T>(7),
+  };
+  collector.addValues(std::span<T>(firstValues));
+
+  auto* stats = collector.getStatsView()->as<IntegralStatistics>();
+  ASSERT_NE(stats, nullptr);
+  EXPECT_EQ(stats->getMin(), -3);
+  EXPECT_EQ(stats->getMax(), 12);
+
+  std::vector<T> secondValues = {
+      std::numeric_limits<T>::max(),
+      static_cast<T>(0),
+      std::numeric_limits<T>::min(),
+  };
+  collector.addValues(std::span<T>(secondValues));
+
+  EXPECT_EQ(
+      stats->getMin(), static_cast<int64_t>(std::numeric_limits<T>::min()));
+  EXPECT_EQ(
+      stats->getMax(), static_cast<int64_t>(std::numeric_limits<T>::max()));
+}
+
+template <typename T>
+void testFloatingPointMinMaxAcrossBatches() {
+  FloatingPointStatisticsCollector collector;
+
+  std::vector<T> firstValues = {
+      static_cast<T>(5.5),
+      static_cast<T>(-3.25),
+      static_cast<T>(12.75),
+      static_cast<T>(7.0),
+  };
+  collector.addValues(std::span<T>(firstValues));
+
+  auto* stats = collector.getStatsView()->as<FloatingPointStatistics>();
+  ASSERT_NE(stats, nullptr);
+  ASSERT_TRUE(stats->getMin().has_value());
+  EXPECT_DOUBLE_EQ(stats->getMin().value(), -3.25);
+  ASSERT_TRUE(stats->getMax().has_value());
+  EXPECT_DOUBLE_EQ(stats->getMax().value(), 12.75);
+
+  std::vector<T> secondValues = {
+      std::numeric_limits<T>::max(),
+      static_cast<T>(0),
+      std::numeric_limits<T>::lowest(),
+  };
+  collector.addValues(std::span<T>(secondValues));
+
+  ASSERT_TRUE(stats->getMin().has_value());
+  EXPECT_DOUBLE_EQ(
+      stats->getMin().value(),
+      static_cast<double>(std::numeric_limits<T>::lowest()));
+  ASSERT_TRUE(stats->getMax().has_value());
+  EXPECT_DOUBLE_EQ(
+      stats->getMax().value(),
+      static_cast<double>(std::numeric_limits<T>::max()));
+}
+
+} // namespace
 
 class ColumnStatisticsTests : public ::testing::Test {};
 
@@ -526,6 +598,36 @@ TEST_F(StatisticsCollectorTests, IntegralMinMaxAfterAddCounts) {
   EXPECT_EQ(stats->getMax().value(), 12);
 }
 
+TEST_F(StatisticsCollectorTests, integralMinMaxAcrossBatches) {
+  {
+    SCOPED_TRACE("int8_t");
+    testIntegralMinMaxAcrossBatches<int8_t>();
+  }
+  {
+    SCOPED_TRACE("int16_t");
+    testIntegralMinMaxAcrossBatches<int16_t>();
+  }
+  {
+    SCOPED_TRACE("int32_t");
+    testIntegralMinMaxAcrossBatches<int32_t>();
+  }
+  {
+    SCOPED_TRACE("int64_t");
+    testIntegralMinMaxAcrossBatches<int64_t>();
+  }
+}
+
+TEST_F(StatisticsCollectorTests, floatingPointMinMaxAcrossBatches) {
+  {
+    SCOPED_TRACE("float");
+    testFloatingPointMinMaxAcrossBatches<float>();
+  }
+  {
+    SCOPED_TRACE("double");
+    testFloatingPointMinMaxAcrossBatches<double>();
+  }
+}
+
 TEST_F(StatisticsCollectorTests, FloatingPointStatisticsCollectorCtor) {
   FloatingPointStatisticsCollector collector;
   auto* stats = collector.getStatsView()->as<FloatingPointStatistics>();
@@ -586,6 +688,48 @@ TEST_F(StatisticsCollectorTests, FloatingPointMinMaxAfterAddCounts) {
   EXPECT_DOUBLE_EQ(stats->getMin().value(), -2.7);
   ASSERT_TRUE(stats->getMax().has_value());
   EXPECT_DOUBLE_EQ(stats->getMax().value(), 99.9);
+}
+
+TEST_F(StatisticsCollectorTests, FloatingPointNanBehavior) {
+  const auto nan = std::numeric_limits<double>::quiet_NaN();
+  {
+    FloatingPointStatisticsCollector collector;
+    std::vector<double> values = {1.0, nan, -2.0, 3.0};
+    collector.addValues(std::span<double>(values));
+
+    auto* stats = collector.getStatsView()->as<FloatingPointStatistics>();
+    ASSERT_NE(stats, nullptr);
+    ASSERT_TRUE(stats->getMin().has_value());
+    EXPECT_DOUBLE_EQ(stats->getMin().value(), -2.0);
+    ASSERT_TRUE(stats->getMax().has_value());
+    EXPECT_DOUBLE_EQ(stats->getMax().value(), 3.0);
+  }
+  {
+    FloatingPointStatisticsCollector collector;
+    std::vector<double> values = {nan, -2.0, 3.0};
+    collector.addValues(std::span<double>(values));
+
+    auto* stats = collector.getStatsView()->as<FloatingPointStatistics>();
+    ASSERT_NE(stats, nullptr);
+    ASSERT_TRUE(stats->getMin().has_value());
+    EXPECT_TRUE(std::isnan(stats->getMin().value()));
+    ASSERT_TRUE(stats->getMax().has_value());
+    EXPECT_TRUE(std::isnan(stats->getMax().value()));
+  }
+  {
+    FloatingPointStatisticsCollector collector;
+    std::vector<double> firstValues = {0.0, 10.0};
+    collector.addValues(std::span<double>(firstValues));
+    std::vector<double> secondValues = {nan, -5.0, 15.0};
+    collector.addValues(std::span<double>(secondValues));
+
+    auto* stats = collector.getStatsView()->as<FloatingPointStatistics>();
+    ASSERT_NE(stats, nullptr);
+    ASSERT_TRUE(stats->getMin().has_value());
+    EXPECT_DOUBLE_EQ(stats->getMin().value(), -5.0);
+    ASSERT_TRUE(stats->getMax().has_value());
+    EXPECT_DOUBLE_EQ(stats->getMax().value(), 15.0);
+  }
 }
 
 // StringStatisticsCollector Tests


### PR DESCRIPTION
Summary: Use Velox xsimd utilities to reduce integral and floating-point min/max values per batch, then update column statistics once per addValues call instead of mutating optional min/max for every value. Floating-point stats keep the legacy NaN behavior by falling back to the scalar loop whenever the input batch contains NaN. Add focused unit coverage and a microbenchmark comparing the legacy optional-update loop with the current collectors.

Differential Revision: D111589634


