### PR TITLE
build(nimble): Gersemi-format OSS CMakeLists for encoding-view benchmark/fuzzer

### DIFF
--- a/dwio/nimble/encodings/benchmarks/CMakeLists.txt
+++ b/dwio/nimble/encodings/benchmarks/CMakeLists.txt
@@ -61,10 +61,7 @@ target_link_libraries(
   fmt::fmt
 )
 
-add_executable(
-  nimble_simd_for_bitpack_benchmark
-  SimdForBitpackBenchmark.cpp
-)
+add_executable(nimble_simd_for_bitpack_benchmark SimdForBitpackBenchmark.cpp)
 
 target_link_libraries(
   nimble_simd_for_bitpack_benchmark

--- a/dwio/nimble/fuzzer/encoding/CMakeLists.txt
+++ b/dwio/nimble/fuzzer/encoding/CMakeLists.txt
@@ -20,12 +20,13 @@ if(NOT TARGET gflags::gflags)
 endif()
 
 if(NOT TARGET gflags::gflags)
-  foreach(_nimble_gflags_target
-          gflags
-          gflags_static
-          gflags_nothreads_static
-          gflags_shared
-          gflags_nothreads_shared
+  foreach(
+    _nimble_gflags_target
+    gflags
+    gflags_static
+    gflags_nothreads_static
+    gflags_shared
+    gflags_nothreads_shared
   )
     if(TARGET ${_nimble_gflags_target})
       add_library(nimble_gflags INTERFACE)
@@ -64,10 +65,7 @@ add_test(
   --nofuzzer_compression
 )
 
-add_executable(
-  nimble_encoding_view_fuzzer_tests
-  EncodingViewFuzzerTest.cpp
-)
+add_executable(nimble_encoding_view_fuzzer_tests EncodingViewFuzzerTest.cpp)
 
 target_link_libraries(
   nimble_encoding_view_fuzzer_tests


### PR DESCRIPTION
Summary: The OSS pre-commit gersemi (CMake formatter) rewrites two CMakeLists to its canonical style: collapse the single-source multi-line `add_executable(...)` calls onto one line and reindent the gflags-target `foreach(...)` loop. Formatting-only — no build, target, or dependency changes. Clears the OSS CMake-format pre-commit signal for `nimble_simd_for_bitpack_benchmark` and `nimble_encoding_view_fuzzer_tests`.

Differential Revision: D111558165


