### PR TITLE
fix: Decode OpenZL (and all registered codecs) in Nimble chunk readers

### DIFF
--- a/dwio/nimble/velox/ChunkedStream.cpp
+++ b/dwio/nimble/velox/ChunkedStream.cpp
@@ -46,26 +46,18 @@ std::string_view InMemoryChunkedStream::nextChunk() {
       stream_.size() - (pos_ - stream_.data()),
       "Read beyond end of stream");
   std::string_view chunk;
-  switch (compressionType) {
-    case CompressionType::Uncompressed: {
-      chunk = {pos_, length};
-      break;
-    }
-    case CompressionType::Zstd:
-    case CompressionType::Lz4: {
-      uncompressed_ = Compression::uncompress(
-          memoryPool_,
-          compressionType,
-          DataType::String,
-          {pos_, length},
-          /*decompressCounter=*/nullptr);
-      chunk = {uncompressed_->as<char>(), uncompressed_->size()};
-      break;
-    }
-    default: {
-      NIMBLE_UNREACHABLE(
-          "Unexpected stream compression type: ", toString(compressionType));
-    }
+  if (compressionType == CompressionType::Uncompressed) {
+    chunk = {pos_, length};
+  } else {
+    // Any registered codec decodes through the registry; getCompressor()
+    // rejects types that are not registered.
+    uncompressed_ = Compression::uncompress(
+        memoryPool_,
+        compressionType,
+        DataType::String,
+        {pos_, length},
+        /*decompressCounter=*/nullptr);
+    chunk = {uncompressed_->as<char>(), uncompressed_->size()};
   }
   pos_ += length;
   return chunk;

--- a/dwio/nimble/velox/selective/ChunkedDecoder.cpp
+++ b/dwio/nimble/velox/selective/ChunkedDecoder.cpp
@@ -42,24 +42,20 @@ bool ChunkedDecoder::loadNextChunk(
   const char* chunkData;
   int64_t chunkSize;
   velox::BufferPtr uncompressedBuffer;
-  switch (compressionType) {
-    case CompressionType::Uncompressed:
-      chunkData = inputData_;
-      chunkSize = length;
-      break;
-    case CompressionType::Zstd:
-    case CompressionType::Lz4:
-      uncompressedBuffer = Compression::uncompress(
-          *pool_,
-          compressionType,
-          DataType::String,
-          std::string_view(inputData_, length),
-          /*decompressCounter=*/nullptr);
-      chunkData = uncompressedBuffer->as<char>();
-      chunkSize = uncompressedBuffer->size();
-      break;
-    default:
-      NIMBLE_UNSUPPORTED("Unsupported compression type: {}", compressionType);
+  if (compressionType == CompressionType::Uncompressed) {
+    chunkData = inputData_;
+    chunkSize = length;
+  } else {
+    // Any registered codec decodes through the registry; getCompressor()
+    // rejects types that are not registered.
+    uncompressedBuffer = Compression::uncompress(
+        *pool_,
+        compressionType,
+        DataType::String,
+        std::string_view(inputData_, length),
+        /*decompressCounter=*/nullptr);
+    chunkData = uncompressedBuffer->as<char>();
+    chunkSize = uncompressedBuffer->size();
   }
   inputData_ += length;
   inputSize_ -= length;

--- a/dwio/nimble/velox/selective/tests/ChunkedDecoderTest.cpp
+++ b/dwio/nimble/velox/selective/tests/ChunkedDecoderTest.cpp
@@ -19,6 +19,8 @@
 #include "dwio/nimble/common/Buffer.h"
 #include "dwio/nimble/common/ChunkHeader.h"
 #include "dwio/nimble/common/tests/GTestUtils.h"
+#include "dwio/nimble/compression/Compression.h"
+#include "dwio/nimble/compression/CompressionPolicy.h"
 #include "dwio/nimble/encodings/NullableEncoding.h"
 #include "dwio/nimble/encodings/TrivialEncoding.h"
 #include "dwio/nimble/encodings/common/EncodingFactory.h"
@@ -375,6 +377,62 @@ class ChunkedDecoderDataTest : public index::test::ClusterIndexTestBase,
       currentOffset = streamData.size();
     }
 
+    return {streamData, chunkInfos};
+  }
+
+  // Encodes chunks compressed with an arbitrary codec, bypassing
+  // ChunkedStreamWriter (whose allowlist only emits Zstd/Lz4). This mirrors
+  // files written with codecs the reader must still decode, such as OpenZL.
+  template <typename T>
+  std::pair<std::string, std::vector<ChunkInfo>> encodeForcedCompressionStream(
+      const std::vector<std::vector<T>>& chunks,
+      CompressionType compressionType) {
+    // Compression policy that requests the given codec and keeps the result
+    // unconditionally.
+    class ForcedCompressionPolicy : public CompressionPolicy {
+     public:
+      explicit ForcedCompressionPolicy(CompressionType type) : type_{type} {}
+
+      CompressionConfig config() const override {
+        return {.compressionType = type_};
+      }
+
+      bool shouldAccept(CompressionType, uint64_t, uint64_t) const override {
+        return true;
+      }
+
+     private:
+      const CompressionType type_;
+    };
+
+    Buffer buffer{*pool_};
+    std::string streamData;
+    std::vector<ChunkInfo> chunkInfos;
+    uint32_t currentOffset = 0;
+    for (const auto& chunk : chunks) {
+      auto encodedChunk = encodeValues<T>(chunk, buffer);
+      ForcedCompressionPolicy policy{compressionType};
+      auto result = Compression::compress(
+          *pool_, encodedChunk, DataType::String, /*bitWidth=*/0, policy);
+      NIMBLE_CHECK(
+          result.compressionType == compressionType &&
+              result.buffer.has_value(),
+          "Failed to compress test chunk with {}",
+          toString(compressionType));
+
+      const size_t headerPos = streamData.size();
+      streamData.resize(headerPos + kChunkHeaderSize);
+      char* pos = streamData.data() + headerPos;
+      writeChunkHeader(
+          static_cast<uint32_t>(result.buffer->size()), compressionType, pos);
+      streamData.append(result.buffer->data(), result.buffer->size());
+
+      chunkInfos.push_back({
+          .rowCount = static_cast<uint32_t>(chunk.size()),
+          .streamOffset = currentOffset,
+      });
+      currentOffset = streamData.size();
+    }
     return {streamData, chunkInfos};
   }
 
@@ -816,6 +874,40 @@ TEST_P(ChunkedDecoderDataTest, readsCompressedChunks) {
     expected.insert(expected.end(), chunks[1].size(), kSecondChunkValue);
     EXPECT_EQ(result, expected);
   }
+}
+
+// Regression test: chunks may be written with OpenZL compression, which the
+// selective reader previously rejected with "Unsupported compression type:
+// OpenZL". ChunkedStreamWriter's allowlist does not emit OpenZL, so the chunk
+// is synthesized directly to mirror the files produced by the writer that does.
+TEST_P(ChunkedDecoderDataTest, readsOpenZLCompressedChunks) {
+  constexpr uint32_t kFirstChunkValue = 42;
+  constexpr uint32_t kSecondChunkValue = 7;
+  const std::vector<std::vector<uint32_t>> chunks{
+      std::vector<uint32_t>(512, kFirstChunkValue),
+      std::vector<uint32_t>(384, kSecondChunkValue),
+  };
+
+  auto [streamData, chunkInfos] =
+      encodeForcedCompressionStream<uint32_t>(chunks, CompressionType::OpenZL);
+  verifyChunkCompressionTypes(
+      streamData, chunkInfos.size(), CompressionType::OpenZL);
+
+  ChunkedDecoder decoder(
+      std::make_unique<dwio::common::SeekableArrayInputStream>(
+          streamData.data(), streamData.size()),
+      createTestStreamIndex(chunkInfos),
+      false,
+      &encodingFactory(),
+      pool_.get());
+
+  std::vector<int32_t> result(chunks[0].size() + chunks[1].size());
+  decoder.nextIndices(result.data(), result.size(), nullptr);
+
+  std::vector<int32_t> expected;
+  expected.insert(expected.end(), chunks[0].size(), kFirstChunkValue);
+  expected.insert(expected.end(), chunks[1].size(), kSecondChunkValue);
+  EXPECT_EQ(result, expected);
 }
 
 TEST_P(ChunkedDecoderDataTest, skipMultipleChunks) {

--- a/dwio/nimble/velox/tests/ChunkedStreamTest.cpp
+++ b/dwio/nimble/velox/tests/ChunkedStreamTest.cpp
@@ -15,6 +15,10 @@
  */
 #include <gtest/gtest.h>
 
+#include "dwio/nimble/common/ChunkHeader.h"
+#include "dwio/nimble/common/Exceptions.h"
+#include "dwio/nimble/compression/Compression.h"
+#include "dwio/nimble/compression/CompressionPolicy.h"
 #include "dwio/nimble/velox/ChunkedStream.h"
 #include "dwio/nimble/velox/ChunkedStreamWriter.h"
 
@@ -80,6 +84,49 @@ createChunkedStream(
   }
 
   return {data, std::make_unique<TestStreamLoader>(result)};
+}
+
+// Builds a single-chunk stream compressed with an arbitrary codec, bypassing
+// ChunkedStreamWriter (whose allowlist only emits Zstd/Lz4). Mirrors production
+// files written with codecs the reader must still decode, e.g. OpenZL.
+std::unique_ptr<nimble::StreamLoader> createForcedCompressionChunk(
+    velox::memory::MemoryPool& pool,
+    std::string_view data,
+    nimble::CompressionType compressionType) {
+  // Compression policy that requests the given codec and keeps the result
+  // unconditionally.
+  class ForcedCompressionPolicy : public nimble::CompressionPolicy {
+   public:
+    explicit ForcedCompressionPolicy(nimble::CompressionType type)
+        : type_{type} {}
+
+    nimble::CompressionConfig config() const override {
+      return {.compressionType = type_};
+    }
+
+    bool shouldAccept(nimble::CompressionType, uint64_t, uint64_t)
+        const override {
+      return true;
+    }
+
+   private:
+    const nimble::CompressionType type_;
+  };
+
+  ForcedCompressionPolicy policy{compressionType};
+  auto result = nimble::Compression::compress(
+      pool, data, nimble::DataType::String, /*bitWidth=*/0, policy);
+  NIMBLE_CHECK(
+      result.compressionType == compressionType && result.buffer.has_value(),
+      "Failed to compress test chunk with the requested codec");
+
+  std::string stream;
+  stream.resize(nimble::kChunkHeaderSize);
+  char* pos = stream.data();
+  nimble::writeChunkHeader(
+      static_cast<uint32_t>(result.buffer->size()), compressionType, pos);
+  stream.append(result.buffer->data(), result.buffer->size());
+  return std::make_unique<TestStreamLoader>(std::move(stream));
 }
 
 } // namespace
@@ -246,6 +293,33 @@ TEST_P(ChunkedStreamCompressionTest, roundTripMultiChunk) {
       auto chunk = reader.nextChunk();
       EXPECT_EQ(data[j], chunk);
     }
+    EXPECT_FALSE(reader.hasNext());
+    reader.reset();
+  }
+}
+
+// Regression test: chunks may be written with OpenZL compression, which the
+// reader previously rejected with NIMBLE_UNREACHABLE ("Unexpected stream
+// compression type"). ChunkedStreamWriter does not emit OpenZL, so the chunk is
+// synthesized directly to mirror the files produced by the writer that does.
+TEST(ChunkedStreamTests, ReadsOpenZLCompressedChunk) {
+  uint32_t seed = folly::Random::rand32();
+  LOG(INFO) << "seed: " << seed;
+  std::mt19937 rng{seed};
+
+  auto memoryPool = velox::memory::deprecatedAddDefaultLeafMemoryPool();
+  const std::string data = randomString(rng, 100) + std::string(400, 'a');
+  auto result = createForcedCompressionChunk(
+      *memoryPool, data, nimble::CompressionType::OpenZL);
+  ASSERT_GT(result->getStream().size(), 0);
+
+  nimble::InMemoryChunkedStream reader{*memoryPool, std::move(result)};
+  // Run multiple times to verify that reset() is working.
+  for (auto i = 0; i < 3; ++i) {
+    ASSERT_TRUE(reader.hasNext());
+    EXPECT_EQ(nimble::CompressionType::OpenZL, reader.peekCompressionType());
+    auto chunk = reader.nextChunk();
+    EXPECT_EQ(data, chunk);
     EXPECT_FALSE(reader.hasNext());
     reader.reset();
   }


### PR DESCRIPTION
Summary:
Nimble's two chunk decoders -- the selective `ChunkedDecoder` and the non-selective `InMemoryChunkedStream` -- decompressed chunks with a hardcoded `switch` that only handled `Uncompressed`, `Zstd`, and `Lz4`, and threw (`NIMBLE_UNSUPPORTED` / `NIMBLE_UNREACHABLE`) on any other compression type. This diverged from every other decompression site in Nimble (the encoding readers, both current and legacy), which route any non-`Uncompressed` data through `Compression::uncompress` and let the codec registry decide what is supported. As a result, once a new codec (`OpenZL`) was registered and began appearing in written chunks, these two readers were the only places that could not decode it and failed with `Unsupported compression type: OpenZL`.

This replaces the hardcoded `switch` in both readers with the same registry-backed idiom used everywhere else: `Uncompressed` chunks are used directly, and everything else is routed through `Compression::uncompress`. The readers can now decode `OpenZL` (and any future registered codec) without further changes, and `getCompressor()` still raises a clear error for genuinely unregistered or corrupt compression-type bytes.

Both readers gain a regression test that synthesizes an `OpenZL`-compressed chunk directly (the chunk writer's own allowlist does not emit `OpenZL`) and verifies the reader round-trips it.

Differential Revision: D111755022


