### PR TITLE
fix(nimble): Estimate Dictionary alphabet cost and PFOR exception streams as min of bit-packed and raw Trivial (#957)

### DIFF
--- a/dwio/nimble/encodings/DictionaryEncoding.h
+++ b/dwio/nimble/encodings/DictionaryEncoding.h
@@ -91,7 +91,7 @@ class DictionaryEncoding
       const Statistics<physicalType>& statistics,
       const Encoding::Options& options = {}) {
     // Assumptions:
-    // Alphabet stored trivially.
+    // Alphabet estimated as min of Trival and bit-packed.
     // Indices are stored bit-packed, with bit width needed to store max
     // dictionary index.
     const auto& uniqueCounts = statistics.uniqueCounts().value();
@@ -113,8 +113,10 @@ class DictionaryEncoding
           statistics.max().size(),
           options);
     } else {
-      alphabetEncodingSize =
-          TrivialEncoding<physicalType>::estimateSize(uniqueCount);
+      alphabetEncodingSize = std::min(
+          TrivialEncoding<physicalType>::estimateSize(uniqueCount),
+          FixedBitWidthEncoding<physicalType>::estimateSize(
+              uniqueCount, statistics.min(), statistics.max(), options));
     }
     const uint64_t outerEncodingSize =
         EncodingPrefix::kFixedPrefixSize + sizeof(uint32_t);

--- a/dwio/nimble/encodings/PFOREncoding.h
+++ b/dwio/nimble/encodings/PFOREncoding.h
@@ -24,6 +24,7 @@
 #include "dwio/nimble/common/FixedBitArray.h"
 #include "dwio/nimble/common/Types.h"
 #include "dwio/nimble/common/Vector.h"
+#include "dwio/nimble/encodings/FixedBitWidthEncoding.h"
 #include "dwio/nimble/encodings/TrivialEncoding.h"
 #include "dwio/nimble/encodings/common/Encoding.h"
 #include "dwio/nimble/encodings/common/EncodingFactory.h"
@@ -103,7 +104,8 @@ class PFOREncoding final
 
   static uint64_t estimateSize(
       uint64_t rowCount,
-      const Statistics<physicalType>& statistics) {
+      const Statistics<physicalType>& statistics,
+      const Encoding::Options& options = {}) {
     const auto fullRange =
         static_cast<physicalType>(statistics.max() - statistics.min());
     const uint8_t maxBitWidth =
@@ -115,16 +117,17 @@ class PFOREncoding final
     const uint64_t baseValuesSize = baseBitWidth == 0
         ? 0
         : FixedBitArray::bufferSize(rowCount, baseBitWidth);
-    // The exception side-channels are stored as nested encodings. Dumping real
-    // files shows selection picks Trivial for both (the streams are small, so
-    // Trivial's raw layout beats bit-packing), so we estimate them as Trivial
-    // sub-encodings -- mirroring how Dictionary estimates its alphabet child.
-    // This is an approximation (the actual nested encoding is data-dependent);
-    // the estimate-vs-actual test allows a 2x band.
-    const uint64_t positionsSize =
-        TrivialEncoding<uint32_t>::estimateSize(numExceptions);
-    const uint64_t valuesSize =
-        TrivialEncoding<physicalType>::estimateSize(numExceptions);
+    const uint64_t positionsSize = std::min(
+        TrivialEncoding<uint32_t>::estimateSize(numExceptions),
+        FixedBitWidthEncoding<uint32_t>::estimateSize(
+            numExceptions,
+            /*minValue=*/0,
+            /*maxValue=*/rowCount == 0 ? 0 : rowCount - 1,
+            options));
+    const uint64_t valuesSize = std::min(
+        TrivialEncoding<physicalType>::estimateSize(numExceptions),
+        FixedBitWidthEncoding<physicalType>::estimateSize(
+            numExceptions, statistics, options));
     const uint64_t outerEncodingSize =
         EncodingPrefix::kFixedPrefixSize + kPrefixSize;
     return outerEncodingSize + baseValuesSize + positionsSize + valuesSize;

--- a/dwio/nimble/encodings/selection/EncodingSizeEstimation.h
+++ b/dwio/nimble/encodings/selection/EncodingSizeEstimation.h
@@ -127,7 +127,7 @@ struct EncodingSizeEstimation {
       case EncodingType::PFOR: {
         if constexpr (isIntegralType<physicalType>()) {
           return PFOREncoding<physicalType>::estimateSize(
-              entryCount, statistics);
+              entryCount, statistics, options);
         } else {
           return std::nullopt;
         }

--- a/dwio/nimble/encodings/tests/EncodingSizeEstimationTest.cpp
+++ b/dwio/nimble/encodings/tests/EncodingSizeEstimationTest.cpp
@@ -633,7 +633,7 @@ TEST_F(EncodingSizeEstimationTest, trivialSmallerThanDictionaryForUnique) {
 
   std::vector<uint32_t> data;
   for (uint32_t i = 0; i < 100; ++i) {
-    data.push_back(i);
+    data.push_back(i * 43'000'000u);
   }
   auto stats = Statistics<uint32_t>::create(data);
 


### PR DESCRIPTION
Summary:

`DictionaryEncoding<T>::encode()` serializes the alphabet via recursive encoding selection (`encodeNested`), so the alphabet is stored with the best encoding for it -- usually bit-packed `FixedBitWidth`, not raw `Trivial`.  Same case for PFOR exception streams

Measured on a real MRS DataFM cluster index (exact-bit width on, all-1.0 read factors, 2000 input rows -> 11,839 KVs): 665,424,571 -> 658,483,444 bytes = -1.04%. Dictionary correctly wins more Int32/Int64 streams away from FixedBitWidth (FBW Int32 92MB->49MB, Dictionary Int32 72MB->119MB), all at smaller total size.

Differential Revision: D111057748


