### PR TITLE
refactor: Share SIMD min max helpers

### DIFF
--- a/dwio/nimble/velox/stats/ColumnStatistics.cpp
+++ b/dwio/nimble/velox/stats/ColumnStatistics.cpp
@@ -15,105 +15,15 @@
  */
 #include "dwio/nimble/velox/stats/ColumnStatistics.h"
 
-#include <algorithm>
-#include <cmath>
 #include <optional>
 #include <utility>
 
 #include "dwio/nimble/common/Exceptions.h"
-#include "velox/common/base/SimdUtil.h"
+#include "dwio/nimble/velox/stats/ColumnStatsUtils.h"
 
 namespace facebook::nimble {
 
 namespace {
-
-template <typename T>
-struct MinMax {
-  T min;
-  T max;
-};
-
-template <typename T>
-MinMax<int64_t> findIntegralMinMax(std::span<T> values) {
-  static_assert(std::is_integral_v<T>);
-  using Batch = xsimd::batch<T>;
-
-  auto* rawValues = values.data();
-  size_t index{0};
-  T minValue{values.front()};
-  T maxValue{values.front()};
-
-  if (values.size() >= Batch::size) {
-    auto minBatch = Batch::load_unaligned(rawValues);
-    auto maxBatch = minBatch;
-    index = Batch::size;
-    for (; index + Batch::size <= values.size(); index += Batch::size) {
-      const auto batch = Batch::load_unaligned(rawValues + index);
-      minBatch = xsimd::min(minBatch, batch);
-      maxBatch = xsimd::max(maxBatch, batch);
-    }
-    minValue = xsimd::reduce_min(minBatch);
-    maxValue = xsimd::reduce_max(maxBatch);
-  }
-
-  for (; index < values.size(); ++index) {
-    minValue = std::min(minValue, values[index]);
-    maxValue = std::max(maxValue, values[index]);
-  }
-
-  return {
-      .min = static_cast<int64_t>(minValue),
-      .max = static_cast<int64_t>(maxValue),
-  };
-}
-
-template <typename T>
-std::optional<MinMax<double>> findFloatingPointMinMax(std::span<T> values) {
-  static_assert(std::is_floating_point_v<T>);
-  using Batch = xsimd::batch<T>;
-
-  auto* rawValues = values.data();
-  size_t index{0};
-  T minValue{values.front()};
-  T maxValue{values.front()};
-
-  if (std::isnan(minValue)) {
-    return std::nullopt;
-  }
-
-  if (values.size() >= Batch::size) {
-    auto minBatch = Batch::load_unaligned(rawValues);
-    if (xsimd::any(minBatch != minBatch)) {
-      return std::nullopt;
-    }
-    auto maxBatch = minBatch;
-    index = Batch::size;
-    for (; index + Batch::size <= values.size(); index += Batch::size) {
-      const auto batch = Batch::load_unaligned(rawValues + index);
-      if (xsimd::any(batch != batch)) {
-        return std::nullopt;
-      }
-      minBatch = xsimd::min(minBatch, batch);
-      maxBatch = xsimd::max(maxBatch, batch);
-    }
-    minValue = xsimd::reduce_min(minBatch);
-    maxValue = xsimd::reduce_max(maxBatch);
-  }
-
-  for (; index < values.size(); ++index) {
-    const auto value = values[index];
-    if (std::isnan(value)) {
-      return std::nullopt;
-    }
-    minValue = std::min(minValue, value);
-    maxValue = std::max(maxValue, value);
-  }
-
-  return MinMax<double>{
-      .min = static_cast<double>(minValue),
-      .max = static_cast<double>(maxValue),
-  };
-}
 
 template <typename T>
 void addFloatingPointValuesScalar(
@@ -436,12 +346,14 @@ void IntegralStatisticsCollector::addValues(std::span<T> values) {
   }
 
   auto* stats = integralStats();
-  const auto minMax = findIntegralMinMax(values);
-  if (!stats->min_.has_value() || minMax.min < *stats->min_) {
-    stats->min_ = minMax.min;
+  const auto minMax = findMinMax(values);
+  const auto min = static_cast<int64_t>(minMax.min);
+  const auto max = static_cast<int64_t>(minMax.max);
+  if (!stats->min_.has_value() || min < *stats->min_) {
+    stats->min_ = min;
   }
-  if (!stats->max_.has_value() || minMax.max > *stats->max_) {
-    stats->max_ = minMax.max;
+  if (!stats->max_.has_value() || max > *stats->max_) {
+    stats->max_ = max;
   }
 }
 
@@ -498,16 +410,18 @@ void FloatingPointStatisticsCollector::addValues(std::span<T> values) {
   }
 
   auto* stats = floatingPointStats();
-  const auto minMax = findFloatingPointMinMax(values);
+  const auto minMax = findMinMax(values);
   if (!minMax.has_value()) {
     addFloatingPointValuesScalar(stats->min_, stats->max_, values);
     return;
   }
-  if (!stats->min_.has_value() || minMax->min < *stats->min_) {
-    stats->min_ = minMax->min;
+  const auto min = static_cast<double>(minMax->min);
+  const auto max = static_cast<double>(minMax->max);
+  if (!stats->min_.has_value() || min < *stats->min_) {
+    stats->min_ = min;
   }
-  if (!stats->max_.has_value() || minMax->max > *stats->max_) {
-    stats->max_ = minMax->max;
+  if (!stats->max_.has_value() || max > *stats->max_) {
+    stats->max_ = max;
   }
 }
 

--- a/dwio/nimble/velox/stats/ColumnStatsUtils.h
+++ b/dwio/nimble/velox/stats/ColumnStatsUtils.h
@@ -14,16 +14,123 @@
  * limitations under the License.
  */
 #pragma once
+#include <algorithm>
+#include <cmath>
+#include <cstddef>
 #include <optional>
+#include <span>
+#include <type_traits>
 #include <unordered_map>
 
 #include "dwio/nimble/velox/OrderedRanges.h"
 #include "dwio/nimble/velox/RawSizeContext.h"
 #include "dwio/nimble/velox/SchemaBuilder.h"
 #include "dwio/nimble/velox/SchemaTypes.h"
+#include "velox/common/base/SimdUtil.h"
 #include "velox/vector/BaseVector.h"
 
 namespace facebook::nimble {
+
+template <typename T>
+struct MinMax {
+  T min;
+  T max;
+};
+
+template <typename T>
+constexpr bool kIntegralMinMaxType = std::is_integral_v<std::remove_cv_t<T>> &&
+    !std::is_same_v<std::remove_cv_t<T>, bool>;
+
+template <typename T>
+constexpr bool kFloatingPointMinMaxType =
+    std::is_floating_point_v<std::remove_cv_t<T>>;
+
+template <typename T>
+std::enable_if_t<kIntegralMinMaxType<T>, MinMax<std::remove_cv_t<T>>>
+findMinMax(std::span<T> values) {
+  using Value = std::remove_cv_t<T>;
+  using Batch = xsimd::batch<Value>;
+
+  const auto* rawValues = values.data();
+  size_t index{0};
+  Value minValue{values.front()};
+  Value maxValue{values.front()};
+
+  if (values.size() >= Batch::size) {
+    auto minBatch = Batch::load_unaligned(rawValues);
+    auto maxBatch = minBatch;
+    index = Batch::size;
+    for (; index + Batch::size <= values.size(); index += Batch::size) {
+      const auto batch = Batch::load_unaligned(rawValues + index);
+      minBatch = xsimd::min(minBatch, batch);
+      maxBatch = xsimd::max(maxBatch, batch);
+    }
+    minValue = xsimd::reduce_min(minBatch);
+    maxValue = xsimd::reduce_max(maxBatch);
+  }
+
+  for (; index < values.size(); ++index) {
+    minValue = std::min(minValue, values[index]);
+    maxValue = std::max(maxValue, values[index]);
+  }
+
+  return {
+      .min = minValue,
+      .max = maxValue,
+  };
+}
+
+template <typename T>
+std::enable_if_t<
+    kFloatingPointMinMaxType<T>,
+    std::optional<MinMax<std::remove_cv_t<T>>>>
+findMinMax(std::span<T> values) {
+  using Value = std::remove_cv_t<T>;
+  using Batch = xsimd::batch<Value>;
+
+  const auto* rawValues = values.data();
+  size_t index{0};
+  Value minValue{values.front()};
+  Value maxValue{values.front()};
+
+  if (std::isnan(minValue)) {
+    return std::nullopt;
+  }
+
+  if (values.size() >= Batch::size) {
+    auto minBatch = Batch::load_unaligned(rawValues);
+    if (xsimd::any(minBatch != minBatch)) {
+      return std::nullopt;
+    }
+    auto maxBatch = minBatch;
+    index = Batch::size;
+    for (; index + Batch::size <= values.size(); index += Batch::size) {
+      const auto batch = Batch::load_unaligned(rawValues + index);
+      if (xsimd::any(batch != batch)) {
+        return std::nullopt;
+      }
+      minBatch = xsimd::min(minBatch, batch);
+      maxBatch = xsimd::max(maxBatch, batch);
+    }
+    minValue = xsimd::reduce_min(minBatch);
+    maxValue = xsimd::reduce_max(maxBatch);
+  }
+
+  for (; index < values.size(); ++index) {
+    const auto value = values[index];
+    if (std::isnan(value)) {
+      return std::nullopt;
+    }
+    minValue = std::min(minValue, value);
+    maxValue = std::max(maxValue, value);
+  }
+
+  return MinMax<Value>{
+      .min = minValue,
+      .max = maxValue,
+  };
+}
+
 struct ColumnStats {
   uint64_t logicalSize{0};
   std::optional<uint64_t> dedupedLogicalSize{std::nullopt};

--- a/dwio/nimble/velox/stats/tests/ColumnStatisticsTests.cpp
+++ b/dwio/nimble/velox/stats/tests/ColumnStatisticsTests.cpp
@@ -14,10 +14,16 @@
  * limitations under the License.
  */
 #include <cmath>
+#include <cstdint>
+#include <limits>
+#include <span>
+#include <type_traits>
+#include <vector>
 
 #include <gtest/gtest.h>
 
 #include "dwio/nimble/velox/stats/ColumnStatistics.h"
+#include "dwio/nimble/velox/stats/ColumnStatsUtils.h"
 
 using namespace facebook;
 using namespace facebook::nimble;
@@ -88,6 +94,29 @@ void testFloatingPointMinMaxAcrossBatches() {
   EXPECT_DOUBLE_EQ(
       stats->getMax().value(),
       static_cast<double>(std::numeric_limits<T>::max()));
+}
+
+template <typename T>
+void expectIntegralMinMax(T expectedMin, T expectedMax, std::vector<T> values) {
+  const auto minMax = findMinMax(std::span<const T>{values});
+  EXPECT_EQ(minMax.min, expectedMin);
+  EXPECT_EQ(minMax.max, expectedMax);
+}
+
+template <typename T>
+void expectFloatingPointMinMax(
+    T expectedMin,
+    T expectedMax,
+    std::vector<T> values) {
+  const auto minMax = findMinMax(std::span<const T>{values});
+  ASSERT_TRUE(minMax.has_value());
+  if constexpr (std::is_same_v<T, float>) {
+    EXPECT_FLOAT_EQ(minMax->min, expectedMin);
+    EXPECT_FLOAT_EQ(minMax->max, expectedMax);
+  } else {
+    EXPECT_DOUBLE_EQ(minMax->min, expectedMin);
+    EXPECT_DOUBLE_EQ(minMax->max, expectedMax);
+  }
 }
 
 } // namespace
@@ -218,6 +247,50 @@ TEST_F(ColumnStatisticsTests, FloatingPointStatistics) {
     EXPECT_EQ(stat.getMin(), minVal);
     EXPECT_EQ(stat.getMax(), maxVal);
   }
+}
+
+TEST_F(ColumnStatisticsTests, findMinMaxHandlesIntegralTypes) {
+  std::vector<int32_t> signedValues(257);
+  for (size_t i = 0; i < signedValues.size(); ++i) {
+    signedValues[i] = static_cast<int32_t>(i) - 128;
+  }
+  signedValues[13] = std::numeric_limits<int32_t>::min();
+  signedValues[199] = std::numeric_limits<int32_t>::max();
+  expectIntegralMinMax<int32_t>(
+      std::numeric_limits<int32_t>::min(),
+      std::numeric_limits<int32_t>::max(),
+      signedValues);
+
+  std::vector<uint64_t> unsignedValues(257);
+  for (size_t i = 0; i < unsignedValues.size(); ++i) {
+    unsignedValues[i] = 1000 + i;
+  }
+  unsignedValues[17] = 0;
+  unsignedValues[211] = std::numeric_limits<uint64_t>::max();
+  expectIntegralMinMax<uint64_t>(
+      0, std::numeric_limits<uint64_t>::max(), unsignedValues);
+}
+
+TEST_F(ColumnStatisticsTests, findMinMaxHandlesFloatingPointTypes) {
+  std::vector<float> floatValues(257, 1.25F);
+  floatValues[11] = -123.5F;
+  floatValues[211] = 456.75F;
+  expectFloatingPointMinMax<float>(-123.5F, 456.75F, floatValues);
+
+  std::vector<double> doubleValues(257, 2.5);
+  doubleValues[31] = -9876.5;
+  doubleValues[199] = 54321.25;
+  expectFloatingPointMinMax<double>(-9876.5, 54321.25, doubleValues);
+}
+
+TEST_F(ColumnStatisticsTests, findMinMaxReturnsEmptyForFloatingPointNaN) {
+  std::vector<float> floatValues(257, 1.25F);
+  floatValues[211] = std::numeric_limits<float>::quiet_NaN();
+  EXPECT_EQ(findMinMax(std::span<const float>{floatValues}), std::nullopt);
+
+  std::vector<double> doubleValues(257, 2.5);
+  doubleValues[31] = std::numeric_limits<double>::quiet_NaN();
+  EXPECT_EQ(findMinMax(std::span<const double>{doubleValues}), std::nullopt);
 }
 
 // StringStatistics Tests


### PR DESCRIPTION
Summary:
Share the SIMD min/max scans used by Velox column statistics in `dwio/nimble/velox/stats/ColumnStatsUtils.h`.

The helper now uses one overloaded `findMinMax()` template name: integral non-bool spans return `MinMax<T>`, and floating-point spans return `std::optional<MinMax<T>>` so NaN inputs can keep the existing scalar fallback behavior. `ColumnStatistics.cpp` uses the shared helper for both integral and floating-point collectors.

Reviewed By: duxiao1212

Differential Revision: D111642191


