### PR TITLE
fix(serializer): Make zero-count StreamData decode a no-op

### DIFF
--- a/dwio/nimble/serializer/DeserializerImpl.cpp
+++ b/dwio/nimble/serializer/DeserializerImpl.cpp
@@ -217,6 +217,15 @@ StreamData::DecodeResult StreamData::decode(
     uint32_t width,
     const std::function<void*()>& getOutputNulls,
     const velox::bits::Bitmap* scatterOutputBitmap) {
+  // Decoding zero rows is a no-op. Empty streams are omitted from the
+  // serialized payload (see StreamDataWriter::writeData) and so are never
+  // reset() with an encoding; a zero-count decode of such a stream must not
+  // require one. Mirrors the count == 0 guards in decodeLegacy() and
+  // materialize().
+  if (count == 0) {
+    return {};
+  }
+
   // Nimble encoding path: use materialize() to decode.
   NIMBLE_CHECK_NOT_NULL(
       encoding_,

--- a/dwio/nimble/serializer/tests/SerializerImplTest.cpp
+++ b/dwio/nimble/serializer/tests/SerializerImplTest.cpp
@@ -2083,6 +2083,31 @@ TEST_F(ZstdDCtxReuseTest, streamDataLegacyDecodeFails) {
       "Legacy StreamData must be decoded through copyTo() or decodeStrings()");
 }
 
+TEST_F(ZstdDCtxReuseTest, streamDataZeroCountDecodeIsNoOp) {
+  const std::vector<int32_t> expected = {10, 20, 30, 40};
+  std::string_view payload(
+      reinterpret_cast<const char*>(expected.data()),
+      expected.size() * sizeof(int32_t));
+  auto compressed = buildLegacyCompressedData(payload);
+
+  std::vector<BufferPtr> stringBuffers;
+  serde::StreamData sd(
+      ScalarKind::Int32,
+      compressed,
+      stringBuffers,
+      pool_.get(),
+      serde::StreamData::Options{
+          .version = SerializationVersion::kLegacy,
+          .decompressionBuffer = &decompressionBuffer_});
+
+  // A zero-count decode must be a no-op even for a stream with no encoding
+  // (legacy/empty stream), rather than throwing.
+  const auto result =
+      sd.decode(/*output=*/nullptr, /*offset=*/0, /*count=*/0, sizeof(int32_t));
+  EXPECT_EQ(result.numOutputRows, 0);
+  EXPECT_EQ(result.nonNullOutputRows, 0);
+}
+
 TEST_F(ZstdDCtxReuseTest, streamDataDCtxReusedAcrossReset) {
   const std::vector<int32_t> values1 = {1, 2, 3};
   std::string_view payload1(


### PR DESCRIPTION
Summary:
When a stream contains no values it is omitted from the serialized payload (`StreamDataWriter::writeData` skips empty streams), so on decode it is never `reset()` with an encoding. `StreamData::decode` checked for a non-null encoding before inspecting the requested row count, so decoding zero rows from such an omitted stream threw `Legacy StreamData must be decoded through copyTo() or decodeStrings()` instead of doing nothing. This surfaced intermittently when round-tripping values with empty containers, depending on whether the affected stream had been populated by an earlier value (which left a stale encoding that masked the issue).

Make a zero-count decode a no-op before requiring an encoding, matching the existing `count == 0` guards in `decodeLegacy()` and `materialize()`. This is behavior-preserving for callers that consume the `DecodeResult`, since none of them request zero rows; it only turns a spurious throw into a no-op.

Added a unit test asserting a zero-count decode of a stream with no encoding is a no-op, and a round-trip test covering values whose containers are all empty.

Differential Revision: D111816156


