### PR TITLE
fix(nimble): Move dictionary read-mode adjustment after prepareRead skip in StringColumnReader

### DIFF
--- a/dwio/nimble/velox/selective/StringColumnReader.cpp
+++ b/dwio/nimble/velox/selective/StringColumnReader.cpp
@@ -30,6 +30,13 @@ namespace facebook::nimble {
 
 using namespace facebook::velox;
 
+bool StringColumnReader::dictionaryPreservable() {
+  return scanSpec_->valueHook() == nullptr &&
+      formatData().stringDecoderZeroCopy() &&
+      static_cast<const NimbleData&>(formatData())
+          .nimblePreserveDictionaryEncoding();
+}
+
 uint64_t StringColumnReader::skip(uint64_t numValues) {
   numValues = SelectiveColumnReader::skip(numValues);
   // Clear cached dictionary state when skip crosses a chunk boundary,
@@ -331,20 +338,14 @@ bool StringColumnReader::readWithDictionary(
     int64_t offset,
     const RowSet& rows,
     const uint64_t* incomingNulls) {
-  // Dictionary path requires: no value hook, non-legacy encoding path
-  // (zero-copy), session property enabled, and dictionary-convertible
-  // encoding. Filters are supported via post-materialization filtering
-  // on the bulk-read dictionary indices.
-  // TODO: Value hooks (aggregation pushdown) could be supported by
-  // resolving alphabet[index] and calling hook->addValue() post-read,
-  // similar to filterDictionaryIndices. Neither Nimble nor DWRF
-  // currently support filter+hook combined for dict string columns.
-  if (scanSpec_->valueHook() || !formatData().stringDecoderZeroCopy() ||
-      !static_cast<const NimbleData&>(formatData())
-           .nimblePreserveDictionaryEncoding()) {
-    clearDictionaryState();
-    return false;
-  }
+  // Contract: read() only enters the dictionary path when the dictionary
+  // encoding is preservable — no value hook, the zero-copy (non-legacy)
+  // encoding path, and preserve-dictionary enabled. Check it here so a caller
+  // that forgets the gate fails loudly instead of silently mis-reading a
+  // legacy/hook column through the (zero-copy) dictionary machinery.
+  NIMBLE_CHECK(
+      dictionaryPreservable(),
+      "readWithDictionary entered when the dictionary is not preservable");
 
   // When the previous batch's readDictionaryIndices consumed the last row of
   // a chunk (remainingValues_ == 0), ensureLoaded loads the next chunk. The
@@ -355,10 +356,6 @@ bool StringColumnReader::readWithDictionary(
         clearDictionaryState();
         return true;
       });
-  if (!decoder_.dictionaryConvertible()) {
-    clearDictionaryState();
-    return false;
-  }
 
   // A cross-chunk merged alphabet is per-read: getValues() clears it (and snaps
   // its backing into the output DictionaryVector) once the read is consumed.
@@ -374,11 +371,26 @@ bool StringColumnReader::readWithDictionary(
   }
 
   prepareRead<int32_t>(offset, rows, incomingNulls);
+  const auto endReadRow = rows.back() + 1;
+  // prepareRead runs seekTo -> skip, which can advance the decoder across a
+  // chunk boundary and load the landed chunk with preserveDictionaryEncoding
+  // false (skipWithoutIndex/seekToChunk hardcode it), so a Dictionary-encoded
+  // landed chunk is created non-dict and reports not convertible. Check
+  // convertibility once here, on the chunk that will actually be read — this
+  // single post-prepareRead check covers both the no-skip and cross-chunk-skip
+  // cases. When it is not convertible, no dictionary indices were materialized;
+  // re-type the value buffer to StringView (abandonDictionaryEncoding handles
+  // numValues_ == 0) so read()'s flat continuation fills it. Crucially, read()
+  // must NOT run a second prepareRead in this case — that would advance the
+  // null/in-map decoders a second time and corrupt flatmap reads.
+  if (!decoder_.dictionaryConvertible()) {
+    abandonDictionaryEncoding(endReadRow);
+    return false;
+  }
   ensureDictionaryState();
   velox::common::testutil::TestValue::adjust(
       "facebook::nimble::StringColumnReader::readWithDictionary",
       &dictionaryState_.alphabet);
-  const auto endReadRow = rows.back() + 1;
   // Set to true when the dictionary read is abandoned at a non-dict chunk;
   // false when the whole range is read in dictionary mode. On abandon,
   // readDictionaryIndices has already advanced readOffset_ to the decoder's
@@ -504,21 +516,35 @@ void StringColumnReader::read(
     int64_t offset,
     const RowSet& rows,
     const uint64_t* incomingNulls) {
-  if (readWithDictionary(offset, rows, incomingNulls)) {
-    return;
+  // numReadRows is how many rows the dictionary portion produced before
+  // abandoning: 0 when the dictionary is not preservable or the landed chunk
+  // was non-convertible, or the chunk boundary when the dict path was abandoned
+  // mid-read. It selects a fresh flat read vs a flat continuation below.
+  velox::vector_size_t numReadRows = 0;
+  // The dictionary encoding is preservable only without a value hook, on the
+  // zero-copy (non-legacy) encoding path, and with preserve-dictionary enabled.
+  // Deciding here (rather than inside readWithDictionary) lets
+  // readWithDictionary own the single prepareRead: when it abandons it re-types
+  // the value buffer via abandonDictionaryEncoding, so read() never issues a
+  // second prepareRead — which would advance the null/in-map decoders twice and
+  // corrupt flatmap reads.
+  if (dictionaryPreservable()) {
+    if (readWithDictionary(offset, rows, incomingNulls)) {
+      return;
+    }
+    numReadRows = readOffset_ > offset
+        ? static_cast<velox::vector_size_t>(readOffset_ - offset)
+        : 0;
+  } else {
+    // Dictionary not preservable: full flat read. Clearing the dictionary state
+    // converts the reader back to flat read mode, dropping anything a
+    // dictionary-mode read (readWithDictionary) may have prepared, so this read
+    // materializes plain StringViews.
+    clearDictionaryState();
+    prepareRead<std::string_view>(offset, rows, incomingNulls);
   }
 
   const auto endReadRow = rows.back() + 1;
-  // readWithDictionary returns false for two reasons:
-  // 1. Preconditions not met (e.g., zeroCopy disabled) — readOffset_
-  //    unchanged, numReadRows == 0. Full flat read via prepareRead below.
-  // 2. Dict abandoned mid-read — readOffset_ advanced to the chunk boundary,
-  //    numReadRows > 0. Flat encoding fallback for the remaining rows only.
-  // Both the return value (false) and numReadRows > 0 are needed to
-  // distinguish abandoned dict (case 2) from dict path not taken (case 1).
-  const auto numReadRows = readOffset_ > offset
-      ? static_cast<velox::vector_size_t>(readOffset_ - offset)
-      : 0;
   NIMBLE_CHECK_LE(numReadRows, endReadRow);
 
   // Always read against the complete original rows so the visitor — and hence
@@ -528,9 +554,7 @@ void StringColumnReader::read(
   // resumes there (the dict portion was already produced) instead of re-reading
   // the prefix.
   velox::vector_size_t startRowIndex = 0;
-  if (numReadRows == 0) {
-    prepareRead<std::string_view>(offset, rows, incomingNulls);
-  } else {
+  if (numReadRows > 0) {
     startRowIndex = static_cast<velox::vector_size_t>(
         std::lower_bound(rows.data(), rows.data() + rows.size(), numReadRows) -
         rows.data());
@@ -585,7 +609,12 @@ void StringColumnReader::ensureAlphabetVector() {
 }
 
 void StringColumnReader::abandonDictionaryEncoding(vector_size_t endReadRow) {
-  NIMBLE_CHECK(!dictionaryState_.alphabet.empty());
+  // numValues_ == 0 means the dictionary path was abandoned before
+  // materializing any indices (the landed chunk was not convertible at the
+  // read's start), so there is no alphabet and nothing to resolve — the loop
+  // below is a no-op and this only re-types the value buffer to StringView for
+  // the flat continuation.
+  NIMBLE_CHECK(numValues_ == 0 || !dictionaryState_.alphabet.empty());
 
   // Resolve dictionary indices to flat StringViews. The underlying string
   // data lives in the encoding's string buffers, which the reader already

--- a/dwio/nimble/velox/selective/StringColumnReader.h
+++ b/dwio/nimble/velox/selective/StringColumnReader.h
@@ -52,6 +52,12 @@ class StringColumnReader : public velox::dwio::common::SelectiveColumnReader {
     return false;
   }
 
+  // Whether the dictionary encoding is preservable for this read: only without
+  // a value hook, on the zero-copy (non-legacy) encoding path, and with
+  // preserve-dictionary enabled. Gates read()'s dispatch into
+  // readWithDictionary.
+  bool dictionaryPreservable();
+
   // Merged alphabet accumulated across chunks for multi-chunk dictionary
   // reads. Each chunk's alphabet is appended, and indices are offset to
   // reference this merged alphabet. Cleared when skip crosses a chunk

--- a/dwio/nimble/velox/selective/tests/StringColumnReaderTest.cpp
+++ b/dwio/nimble/velox/selective/tests/StringColumnReaderTest.cpp
@@ -1012,6 +1012,433 @@ TEST_P(StringColumnReaderTest, skipAcrossChunkBoundaryDictRecovery) {
   }
 }
 
+// Regression for T278234148: a between-batch skip in prepareRead crosses a
+// chunk boundary and lands on a chunk whose encoding is NOT dictionary-enabled.
+//
+// readWithDictionary checks dictionaryConvertible() on the chunk that is
+// current at entry (chunk1, Dictionary → passes), but then prepareRead<int32_t>
+// runs seekTo → skip, which loads the landed chunk with
+// preserveDictionaryEncoding=false. When that chunk is a non-dict encoding
+// (here Trivial, forced by high-cardinality unique strings), the stale guard no
+// longer matches the current encoding, and ensureDictionaryState() calls
+// buildEncodingDictionaryAlphabet() on it → NIMBLE_CHECK(dictionaryEnabled())
+// fires. This mirrors the production crash on
+// ad_delivery.ads_ai_eval_judge_results.original_request_id (all-varchar table,
+// per-chunk encoding varies between Dictionary and Trivial). The fix re-checks
+// dictionaryConvertible() after prepareRead and falls back to the flat path
+// (FLAT output encoding).
+TEST_P(StringColumnReaderTest, abandonDictionaryAfterSkip) {
+  const bool stringDecoderZeroCopy = GetParam();
+  if (!stringDecoderZeroCopy) {
+    GTEST_SKIP() << "Dictionary path requires stringDecoderZeroCopy";
+  }
+
+  constexpr int kChunkRows = 400;
+  // Chunk 1: low-cardinality strings → Dictionary (dictionary-enabled).
+  auto chunk1 = makeRowVector({
+      makeFlatVector<int64_t>(kChunkRows, [](auto i) { return i; }),
+      makeFlatVector<std::string>(
+          kChunkRows,
+          [](auto i) {
+            return std::vector<std::string>{"aaa", "bbb", "ccc"}[i % 3];
+          }),
+  });
+  // Chunk 2: all-unique strings → Trivial (NOT dictionary-enabled).
+  auto chunk2 = makeRowVector({
+      makeFlatVector<int64_t>(
+          kChunkRows, [](auto i) { return kChunkRows + i; }),
+      makeFlatVector<std::string>(
+          kChunkRows,
+          [](auto i) { return fmt::format("unique_string_value_{}", i); }),
+  });
+
+  VeloxWriterOptions writerOptions;
+  writerOptions.enableChunking = true;
+  writerOptions.minStreamChunkRawSize = 0;
+  writerOptions.flushPolicyFactory = [] {
+    return std::make_unique<LambdaFlushPolicy>(
+        /*flushLambda=*/[](const StripeProgress&) { return false; },
+        /*chunkLambda=*/[](const StripeProgress&) { return true; });
+  };
+  auto file = test::createNimbleFile(
+      *rootPool(), {chunk1, chunk2}, writerOptions, /*flushAfterWrite=*/false);
+
+  // Filter on c0: accept [0,349] then [600,799]. Rejecting [350,599] forces a
+  // between-batch skip (350 → 600) that crosses the chunk boundary at 400 and
+  // lands inside chunk 2 (Trivial), while the decoder is still parked mid
+  // chunk 1 at entry (so the dictionaryConvertible() guard sees chunk 1).
+  auto readType = ROW({"c0", "c1"}, {BIGINT(), VARCHAR()});
+  auto scanSpec = std::make_shared<common::ScanSpec>("root");
+  scanSpec->addAllChildFields(*readType);
+  std::vector<std::unique_ptr<common::BigintRange>> ranges;
+  ranges.push_back(
+      std::make_unique<common::BigintRange>(0, 349, /*nullAllowed=*/false));
+  ranges.push_back(
+      std::make_unique<common::BigintRange>(
+          600, 2 * kChunkRows - 1, /*nullAllowed=*/false));
+  scanSpec->childByName("c0")->setFilter(
+      std::make_unique<common::BigintMultiRange>(
+          std::move(ranges), /*nullAllowed=*/false));
+
+  // Accepted output: chunk 1 rows 0-349 (350), then chunk 2 rows 600-799 which
+  // are chunk-local indices 200-399 (200) → 550 rows total.
+  auto expectedStrings = makeFlatVector<std::string>(550, [](auto i) {
+    if (i < 350) {
+      return std::vector<std::string>{"aaa", "bbb", "ccc"}[i % 3];
+    }
+    const int chunk2Index = (i - 350) + 200;
+    return fmt::format("unique_string_value_{}", chunk2Index);
+  });
+
+  auto readers = makeReaders(chunk1, file, scanSpec, stringDecoderZeroCopy);
+
+  using E = VectorEncoding::Simple;
+  // Batches: [0,249] dict, [250,349] dict (chunk 1), [600,749] flat,
+  // [750,799] flat (chunk 2 via the abandon-to-flat fallback).
+  validateWithEncodingChecks(
+      *expectedStrings,
+      *readers.rowReader,
+      /*batchSize=*/250,
+      /*totalRows=*/2 * kChunkRows,
+      {E::DICTIONARY, E::DICTIONARY, E::FLAT, E::FLAT},
+      readType,
+      pool(),
+      /*childIndex=*/1);
+}
+
+// Same as abandonDictionaryAfterSkip but with a NULLABLE string column. The
+// between-batch skip that lands in the non-dict chunk drives the abandon path
+// (readWithDictionary runs prepareRead<int32_t>, the landed chunk is not
+// convertible, so it abandons and read() re-runs
+// prepareRead<std::string_view>). Because NimbleData::readNulls advances the
+// nulls decoder (nextBools), that double prepareRead reads the null stream
+// twice and misplaces the nulls.
+TEST_P(StringColumnReaderTest, abandonDictionaryAfterSkipWithNulls) {
+  const bool stringDecoderZeroCopy = GetParam();
+  if (!stringDecoderZeroCopy) {
+    GTEST_SKIP() << "Dictionary path requires stringDecoderZeroCopy";
+  }
+
+  constexpr int kChunkRows = 400;
+  auto chunk1String = [](auto i) -> std::optional<std::string> {
+    if (i % 7 == 0) {
+      return std::nullopt;
+    }
+    return std::vector<std::string>{"aaa", "bbb", "ccc"}[i % 3];
+  };
+  auto chunk2String = [](auto i) -> std::optional<std::string> {
+    if (i % 7 == 0) {
+      return std::nullopt;
+    }
+    return fmt::format("unique_string_value_{}", i);
+  };
+
+  std::vector<std::optional<std::string>> chunk1Data(kChunkRows);
+  std::vector<std::optional<std::string>> chunk2Data(kChunkRows);
+  for (int i = 0; i < kChunkRows; ++i) {
+    chunk1Data[i] = chunk1String(i);
+    chunk2Data[i] = chunk2String(i);
+  }
+  // Chunk 1: low-cardinality → nullable Dictionary. Chunk 2: unique → Trivial.
+  auto chunk1 = makeRowVector({
+      makeFlatVector<int64_t>(kChunkRows, [](auto i) { return i; }),
+      makeNullableFlatVector<std::string>(chunk1Data),
+  });
+  auto chunk2 = makeRowVector({
+      makeFlatVector<int64_t>(
+          kChunkRows, [](auto i) { return kChunkRows + i; }),
+      makeNullableFlatVector<std::string>(chunk2Data),
+  });
+
+  VeloxWriterOptions writerOptions;
+  writerOptions.enableChunking = true;
+  writerOptions.minStreamChunkRawSize = 0;
+  writerOptions.flushPolicyFactory = [] {
+    return std::make_unique<LambdaFlushPolicy>(
+        /*flushLambda=*/[](const StripeProgress&) { return false; },
+        /*chunkLambda=*/[](const StripeProgress&) { return true; });
+  };
+  auto file = test::createNimbleFile(
+      *rootPool(), {chunk1, chunk2}, writerOptions, /*flushAfterWrite=*/false);
+
+  auto readType = ROW({"c0", "c1"}, {BIGINT(), VARCHAR()});
+  auto scanSpec = std::make_shared<common::ScanSpec>("root");
+  scanSpec->addAllChildFields(*readType);
+  std::vector<std::unique_ptr<common::BigintRange>> ranges;
+  ranges.push_back(
+      std::make_unique<common::BigintRange>(0, 349, /*nullAllowed=*/false));
+  ranges.push_back(
+      std::make_unique<common::BigintRange>(
+          600, 2 * kChunkRows - 1, /*nullAllowed=*/false));
+  scanSpec->childByName("c0")->setFilter(
+      std::make_unique<common::BigintMultiRange>(
+          std::move(ranges), /*nullAllowed=*/false));
+
+  // Accepted output: chunk-1 rows 0-349, then chunk-2 rows 600-799 (chunk-local
+  // indices 200-399) → 550 rows total, carrying their nulls.
+  std::vector<std::optional<std::string>> expectedData(550);
+  for (int i = 0; i < 550; ++i) {
+    expectedData[i] = i < 350 ? chunk1String(i) : chunk2String((i - 350) + 200);
+  }
+  auto expectedStrings = makeNullableFlatVector<std::string>(expectedData);
+
+  auto readers = makeReaders(chunk1, file, scanSpec, stringDecoderZeroCopy);
+  using E = VectorEncoding::Simple;
+  validateWithEncodingChecks(
+      *expectedStrings,
+      *readers.rowReader,
+      /*batchSize=*/250,
+      /*totalRows=*/2 * kChunkRows,
+      {E::DICTIONARY, E::DICTIONARY, E::FLAT, E::FLAT},
+      readType,
+      pool(),
+      /*childIndex=*/1);
+}
+
+// Non-convertible ENTRY chunk with NO cross-chunk skip: a single Trivial
+// (all-unique) nullable string column read contiguously. readWithDictionary
+// abandons at entry. Isolates whether the no-skip abandon (prepareRead then
+// abandon, no between-batch skip) corrupts nulls.
+TEST_P(StringColumnReaderTest, abandonDictionaryNoSkipWithNulls) {
+  const bool stringDecoderZeroCopy = GetParam();
+  if (!stringDecoderZeroCopy) {
+    GTEST_SKIP() << "Dictionary path requires stringDecoderZeroCopy";
+  }
+
+  constexpr int kRows = 400;
+  std::vector<std::optional<std::string>> data(kRows);
+  for (int i = 0; i < kRows; ++i) {
+    data[i] = (i % 7 == 0)
+        ? std::nullopt
+        : std::optional<std::string>(fmt::format("unique_value_{}", i));
+  }
+  auto chunk = makeRowVector({
+      makeFlatVector<int64_t>(kRows, [](auto i) { return i; }),
+      makeNullableFlatVector<std::string>(data),
+  });
+
+  VeloxWriterOptions writerOptions;
+  writerOptions.enableChunking = true;
+  writerOptions.minStreamChunkRawSize = 0;
+  auto file = test::createNimbleFile(*rootPool(), chunk, writerOptions);
+
+  auto readType = ROW({"c0", "c1"}, {BIGINT(), VARCHAR()});
+  auto scanSpec = std::make_shared<common::ScanSpec>("root");
+  scanSpec->addAllChildFields(*readType);
+
+  auto expected = makeNullableFlatVector<std::string>(data);
+  auto readers = makeReaders(chunk, file, scanSpec, stringDecoderZeroCopy);
+  using E = VectorEncoding::Simple;
+  validateWithEncodingChecks(
+      *expected,
+      *readers.rowReader,
+      /*batchSize=*/kRows,
+      /*totalRows=*/kRows,
+      {E::FLAT},
+      readType,
+      pool(),
+      /*childIndex=*/1);
+}
+
+// Latent check #2 bug for a FLATMAP feature: the feature's value stream is
+// Dictionary in chunk 1 and Trivial in chunk 2, and a sibling-column filter
+// forces a between-batch skip that crosses the chunk boundary, driving the
+// feature's child StringColumnReader to abandon the dictionary after
+// prepareRead. read() then re-runs prepareRead (numReadRows == 0), so
+// NimbleData::readNulls advances the feature's in-map decoder twice and the
+// output map gets phantom/missing entries. Plain-null columns survive this, so
+// only the flatmap in-map path exposes it.
+TEST_P(StringColumnReaderTest, abandonDictionaryAfterSkipFlatMap) {
+  const bool stringDecoderZeroCopy = GetParam();
+  if (!stringDecoderZeroCopy) {
+    GTEST_SKIP() << "Dictionary path requires stringDecoderZeroCopy";
+  }
+
+  constexpr int kChunkRows = 400;
+  // Feature key 1 is present on ~2/3 of rows (absent when g % 3 == 0), so the
+  // in-map bitmap is non-trivial. Its values are low-cardinality in chunk 1
+  // (→ Dictionary) and unique in chunk 2 (→ Trivial), all inline (< 12 bytes)
+  // so makeMapVector copies them and no source lifetime is needed.
+  auto present = [](int g) { return g % 3 != 0; };
+  auto valueStr = [](int g) {
+    return g < kChunkRows ? fmt::format("v{}", g % 5) : fmt::format("u{}", g);
+  };
+  std::vector<std::string> keep;
+  keep.reserve(4 * kChunkRows);
+  auto makeChunk = [&](int base, int n) {
+    std::vector<std::vector<std::pair<int32_t, std::optional<StringView>>>>
+        maps(n);
+    for (int r = 0; r < n; ++r) {
+      const int g = base + r;
+      if (present(g)) {
+        keep.push_back(valueStr(g));
+        maps[r] = {{1, StringView(keep.back())}};
+      }
+    }
+    return makeRowVector(
+        {"c0", "c1"},
+        {makeFlatVector<int64_t>(n, [base](auto r) { return base + r; }),
+         makeMapVector<int32_t, StringView>(maps)});
+  };
+  auto chunk1 = makeChunk(0, kChunkRows);
+  auto chunk2 = makeChunk(kChunkRows, kChunkRows);
+  auto combined = makeChunk(0, 2 * kChunkRows);
+
+  VeloxWriterOptions writerOptions;
+  writerOptions.enableChunking = true;
+  writerOptions.minStreamChunkRawSize = 0;
+  writerOptions.flatMapColumns = {{"c1", {}}};
+  writerOptions.flushPolicyFactory = [] {
+    return std::make_unique<LambdaFlushPolicy>(
+        /*flushLambda=*/[](const StripeProgress&) { return false; },
+        /*chunkLambda=*/[](const StripeProgress&) { return true; });
+  };
+  auto file = test::createNimbleFile(
+      *rootPool(), {chunk1, chunk2}, writerOptions, /*flushAfterWrite=*/false);
+
+  // Filter on sibling c0: accept [0,349] then [600,799]. Rejecting [350,599]
+  // forces a between-batch skip (350 → 600) crossing the chunk boundary at 400.
+  auto scanSpec = std::make_shared<common::ScanSpec>("root");
+  scanSpec->addAllChildFields(*combined->type());
+  std::vector<std::unique_ptr<common::BigintRange>> ranges;
+  ranges.push_back(
+      std::make_unique<common::BigintRange>(0, 349, /*nullAllowed=*/false));
+  ranges.push_back(
+      std::make_unique<common::BigintRange>(
+          600, 2 * kChunkRows - 1, /*nullAllowed=*/false));
+  scanSpec->childByName("c0")->setFilter(
+      std::make_unique<common::BigintMultiRange>(
+          std::move(ranges), /*nullAllowed=*/false));
+
+  auto readers = makeReaders(combined, file, scanSpec, stringDecoderZeroCopy);
+  validateWithFilter(
+      *combined, *readers.rowReader, /*batchSize=*/250, [](int i) {
+        return i <= 349 || i >= 600;
+      });
+}
+
+// Forces the string column "c1" (child index 1) to encode as RLE wrapping
+// Dictionary, while the bigint sibling "c0" (child index 0) keeps its default
+// encoding. Row-schema children are matched to the layout tree by position, so
+// both children must be present in schema order.
+EncodingLayoutTree makeSecondChildRleDictionaryLayoutTree() {
+  EncodingLayout dictLayout{
+      EncodingType::Dictionary,
+      {},
+      CompressionType::Uncompressed,
+      {std::nullopt, std::nullopt}};
+  EncodingLayout rleLayout{
+      EncodingType::RLE,
+      {},
+      CompressionType::Uncompressed,
+      {std::nullopt, std::move(dictLayout)}};
+  return EncodingLayoutTree{
+      Kind::Row,
+      std::
+          unordered_map<EncodingLayoutTree::StreamIdentifier, EncodingLayout>{},
+      "",
+      std::vector<EncodingLayoutTree>{
+          EncodingLayoutTree{
+              Kind::Scalar,
+              std::unordered_map<
+                  EncodingLayoutTree::StreamIdentifier,
+                  EncodingLayout>{},
+              "c0"},
+          EncodingLayoutTree{Kind::Scalar, {{0, std::move(rleLayout)}}, "c1"}}};
+}
+
+// Reverse of the mid-read dict abandon: a between-batch skip (inside
+// prepareRead's seekTo) lands the decoder inside an RLE<Dictionary> chunk that
+// is loaded with preserveDictionaryEncoding=false, so that chunk is in FLAT
+// mode (dictValues_ null, dictionaryEnabled()==false). readWithDictionary now
+// runs its single dictionaryConvertible() check AFTER prepareRead, on the
+// landed chunk, so the flat second chunk is detected as non-convertible and
+// abandons to the flat read path instead of driving the dict-mode path
+// (ensureDictionaryState -> buildEncodingDictionaryAlphabet /
+// readDictionaryIndices -> materializeIndices) on a flat encoding. Before the
+// check was moved after prepareRead, this crashed with
+// "buildEncodingDictionaryAlphabet requires a dictionary-enabled encoding".
+//
+// Mirrors skipAcrossChunkBoundaryDictRecovery scenario 1 (kChunkRows=400,
+// accept [0,349] u [600,799], batchSize=250), but forces the string column to
+// RLE<Dictionary> via a forced encoding layout so the preserve=false load
+// flattens it. A plain Dictionary chunk (as in that test) would stay
+// dict-convertible even when loaded preserve=false, which is why that scenario
+// does not surface this path.
+TEST_P(StringColumnReaderTest, skipAcrossChunkBoundaryRleDictionaryAbandon) {
+  const bool stringDecoderZeroCopy = GetParam();
+  if (!stringDecoderZeroCopy) {
+    GTEST_SKIP() << "Dictionary path requires stringDecoderZeroCopy";
+  }
+
+  constexpr int kChunkRows = 400;
+  constexpr int kRunLength = 100;
+  const std::string chunk1Values[] = {"alpha", "bravo", "charlie"};
+  const std::string chunk2Values[] = {"delta", "echo", "foxtrot"};
+  // Long runs (100 rows each) so the forced RLE<Dictionary> layout produces
+  // real RLE runs of dictionary indices.
+  auto chunk1 = makeRowVector({
+      makeFlatVector<int64_t>(kChunkRows, [](auto i) { return i; }),
+      makeFlatVector<std::string>(
+          kChunkRows,
+          [&](auto i) { return chunk1Values[(i / kRunLength) % 3]; }),
+  });
+  auto chunk2 = makeRowVector({
+      makeFlatVector<int64_t>(
+          kChunkRows, [](auto i) { return kChunkRows + i; }),
+      makeFlatVector<std::string>(
+          kChunkRows,
+          [&](auto i) { return chunk2Values[(i / kRunLength) % 3]; }),
+  });
+
+  VeloxWriterOptions writerOptions;
+  writerOptions.encodingLayoutTree.emplace(
+      makeSecondChildRleDictionaryLayoutTree());
+  writerOptions.enableChunking = true;
+  writerOptions.minStreamChunkRawSize = 0;
+  writerOptions.flushPolicyFactory = [] {
+    return std::make_unique<LambdaFlushPolicy>(
+        /*flushLambda=*/[](const StripeProgress&) { return false; },
+        /*chunkLambda=*/[](const StripeProgress&) { return true; });
+  };
+  auto file = test::createNimbleFile(
+      *rootPool(), {chunk1, chunk2}, writerOptions, /*flushAfterWrite=*/false);
+
+  // Filter on c0: accept [0, 349] u [600, 799]. c1 has no filter, so it takes
+  // the dictionary index path.
+  auto readType = ROW({"c0", "c1"}, {BIGINT(), VARCHAR()});
+  auto scanSpec = std::make_shared<common::ScanSpec>("root");
+  scanSpec->addAllChildFields(*readType);
+  std::vector<std::unique_ptr<common::BigintRange>> ranges;
+  ranges.push_back(
+      std::make_unique<common::BigintRange>(0, 349, /*nullAllowed=*/false));
+  ranges.push_back(
+      std::make_unique<common::BigintRange>(
+          600, 2 * kChunkRows - 1, /*nullAllowed=*/false));
+  scanSpec->childByName("c0")->setFilter(
+      std::make_unique<common::BigintMultiRange>(
+          std::move(ranges), /*nullAllowed=*/false));
+
+  // Combined 800-row input for validateWithFilter.
+  auto input = makeRowVector({
+      makeFlatVector<int64_t>(2 * kChunkRows, [](auto i) { return i; }),
+      makeFlatVector<std::string>(
+          2 * kChunkRows,
+          [&](auto i) {
+            return i < kChunkRows
+                ? chunk1Values[(i / kRunLength) % 3]
+                : chunk2Values[((i - kChunkRows) / kRunLength) % 3];
+          }),
+  });
+
+  auto readers = makeReaders(input, file, scanSpec, stringDecoderZeroCopy);
+  validateWithFilter(
+      *input,
+      *readers.rowReader,
+      /*batchSize=*/250,
+      /*filter=*/[](int i) { return i <= 349 || i >= 600; });
+}
+
 // Flatmap string column read via dictionary path.
 // When a string column is inside a flatmap, rows where the key is absent have
 // inMap=0 (null). The encoding only has data for in-map rows. The dictionary


### PR DESCRIPTION
Summary:
`StringColumnReader::readWithDictionary` checks `decoder_.dictionaryConvertible()` to decide whether to read the column as dictionary indices or fall back to flat. But `prepareRead<int32_t>` runs seekTo -> skip, and both skip paths (`ChunkedDecoder::skipWithoutIndex`, `ChunkedDecoder::seekToChunk`) load the landed chunk with `preserveDictionaryEncoding=false`. When a between-batch skip crosses a chunk boundary into a chunk that is not dictionary-convertible, a convertibility check evaluated before the skip no longer matches the chunk that will actually be read.

The earlier form of this fix re-checked `dictionaryConvertible()` after `prepareRead` but returned false with `readOffset_ == offset`, so `read()` then ran a SECOND `prepareRead` (its `numReadRows == 0` branch). Each `prepareRead` calls `NimbleData::readNulls`, which advances the null/in-map decoders via `nextBools`. The double read over-advances the in-map decoder of a flat-map feature, corrupting the output (phantom/missing map entries) and, in the worst case, crashing with "Failed to read chunk header" when the in-map decoder runs past its data. Plain-null columns happen to survive the double read; flat-map (in-map) columns do not.

This diff moves the read-mode adjustment to after the skip and makes it happen exactly once, so there is a single `prepareRead` (and a single `readNulls`) per batch on every path:

- `read()` decides `dictApplicable` (no value hook, zero-copy encoding path, preserve-dictionary enabled) up front. When applicable it calls `readWithDictionary`; otherwise it does its own flat `prepareRead<std::string_view>`. That decision is also the single signal for "the dictionary path already prepared the read", so `read()` never issues a second `prepareRead`.
- `readWithDictionary` always does the single `prepareRead<int32_t>`, then performs ONE `dictionaryConvertible()` check on the chunk that will actually be read (the pre-skip and post-skip checks collapse into this one). When the landed chunk is not convertible, it calls `abandonDictionaryEncoding` to re-type the value buffer from `int32_t` to `StringView` for the flat continuation; `abandonDictionaryEncoding` now handles the zero-row case (no dictionary indices materialized, no alphabet).
- A `NIMBLE_CHECK` at the top of `readWithDictionary` documents and enforces the `dictApplicable` contract, so a caller that skips the gate fails loudly rather than silently mis-reading a legacy/hook column through the zero-copy dictionary machinery.

Net effect: the null/in-map decoders are advanced exactly once, fixing both the flat-map in-map corruption/crash and the original stale-guard assert, while collapsing the previous two convertibility checks into one.

Also fixes the skip-into-flattened-dictionary crash. Moving the convertibility check after `prepareRead` closes a symmetric hole on the read side: when a between-batch skip lands the decoder inside a chunk whose on-disk encoding is preserve-gated — an `RLE` wrapping a `Dictionary` — the skip paths load that chunk with `preserveDictionaryEncoding=false`, so `RLEEncoding` materializes it in FLAT mode (`dictValues_` null, `dictionaryEnabled()` returns false). With the old pre-skip check, that flat landed chunk was still driven through the dict-mode path (`ensureDictionaryState` -> `buildEncodingDictionaryAlphabet` / `readDictionaryIndices` -> `materializeIndices`) and aborted with "buildEncodingDictionaryAlphabet requires a dictionary-enabled encoding". The single post-`prepareRead` check now inspects the landed chunk, detects the flattened dictionary as non-convertible, and abandons to the flat read path. Same root cause as the in-map bug above — the check must run on the chunk that will actually be read, not the pre-skip chunk — with a different symptom.

Reproduces on `ad_delivery.ads_ai_eval_judge_results.original_request_id` (an all-varchar table whose per-chunk encoding alternates between `Dictionary` and `Trivial`) under `SELECT count(DISTINCT original_request_id) FROM ads_ai_eval_judge_results`, and on flat-map string features with the same per-chunk encoding shape.

Reviewed By: xiaoxmeng

Differential Revision: D111832535


