### PR TITLE
test(velox): Unbound flat-map keys in flatMapParallelEncode

### DIFF
--- a/dwio/nimble/velox/tests/VeloxWriterTest.cpp
+++ b/dwio/nimble/velox/tests/VeloxWriterTest.cpp
@@ -6750,11 +6750,17 @@ TEST_P(ParallelEncodeWriterTest, flatMapParallelEncode) {
       leafPool_.get(),
       seed);
 
+  // The fuzzer emits random INTEGER keys, so the number of distinct flat-map
+  // keys varies per seed and can exceed the default limit. This test compares
+  // parallel vs sequential encoding, so lift the limit (0 = unlimited) to keep
+  // the run independent of the seed's key cardinality.
   auto writerOptions = parallelWriterOptions();
   writerOptions.flatMapColumns = {{"flatmap", {}}};
+  writerOptions.maxFlatMapKeys = 0;
 
   nimble::VeloxWriterOptions seqOptions;
   seqOptions.flatMapColumns = {{"flatmap", {}}};
+  seqOptions.maxFlatMapKeys = 0;
 
   std::string seqFile;
   std::string parFile;


### PR DESCRIPTION
Summary:
`ParallelEncodeWriterTest.flatMapParallelEncode` fuzzes random INTEGER flat-map keys, so the number of distinct keys varies per random seed and can exceed the default `maxFlatMapKeys` limit (30000). When it does, the writer correctly throws `Too many flatmap keys`, which made the test flaky. The failure fires in the sequential writer that runs first on the same data, so it is unrelated to parallel encoding — the parallelism parameter is incidental.

The test compares parallel vs sequential flat-map encoding for value equality, so the exact key cardinality is irrelevant to what it verifies. Set `maxFlatMapKeys = 0` (unlimited) on both writers so the run no longer depends on the seed's key count, while still exercising many value streams across the parallel encode tasks.

Differential Revision: D111937966


