### PR TITLE
fix(selective): Guard chunk load in readDictionaryIndicesImpl for all-null tail batches

### DIFF
--- a/dwio/nimble/velox/selective/ChunkedDecoder.h
+++ b/dwio/nimble/velox/selective/ChunkedDecoder.h
@@ -445,34 +445,49 @@ class ChunkedDecoder {
     };
 
     while (visitor.rowIndex() < numRows) {
-      // Check for chunk exhaustion before computing the next row range.
-      // This is done unconditionally (for both kHasNulls and !kHasNulls)
-      // to avoid the testNulls path in computeNextRowIndex loading a new
-      // chunk mid-count, which would produce numNonNulls spanning two
-      // chunks and incorrect index reads.
+      // When the current chunk is exhausted, decide whether to load the
+      // next chunk based on the null bitmap. Fast path: if more chunks
+      // exist, load directly (common case). Slow path: no more chunks —
+      // scan the null bitmap to verify all remaining rows are null. If
+      // non-null rows remain with no chunks, loadNextChunk crashes —
+      // that's data corruption (encoding rowCount disagrees with the
+      // null bitmap).
       if (FOLLY_UNLIKELY(remainingValues_ == 0)) {
-        loadNextChunk(/*preserveDictionaryEncoding=*/true);
-        if (!onChunkBoundary()) {
-          // The new chunk is not dictionary-compatible. readOffset_ has not
-          // moved during this read, so it still holds the read's start offset;
-          // adding params.numScanned (the rows consumed up to this chunk
-          // boundary) advances it to the boundary, where the flat encoding
-          // fallback resumes the decode.
-          //
-          // TODO: Make the decoder the single owner of readOffset_ — also
-          // advance it on the full-read path here instead of readWithDictionary
-          // doing readOffset_ += endReadRow, so the update is not split across
-          // the reader and the decoder.
-          visitor.reader().setReadOffset(
-              visitor.reader().readOffset() + params.numScanned);
-          return false;
-        }
+        if (hasMoreChunks()) {
+          loadNextChunk(/*preserveDictionaryEncoding=*/true);
+          if (!onChunkBoundary()) {
+            // The new chunk is not dictionary-compatible. readOffset_ has not
+            // moved during this read, so it still holds the read's start
+            // offset; adding params.numScanned (the rows consumed up to this
+            // chunk boundary) advances it to the boundary, where the flat
+            // encoding fallback resumes the decode.
+            //
+            // TODO: Make the decoder the single owner of readOffset_ — also
+            // advance it on the full-read path here instead of
+            // readWithDictionary doing readOffset_ += endReadRow, so the
+            // update is not split across the reader and the decoder.
+            visitor.reader().setReadOffset(
+                visitor.reader().readOffset() + params.numScanned);
+            return false;
+          }
 
-        // onChunkBoundary() rebuilt the per-chunk filter dictionary in the
-        // reader's scan state. Re-snapshot it into the visitor so the next
-        // chunk's filter evaluation uses this chunk's dictionary, not the
-        // stale copy captured when the visitor was constructed.
-        visitor.refreshScanState();
+          // onChunkBoundary() rebuilt the per-chunk filter dictionary in the
+          // reader's scan state. Re-snapshot it into the visitor so the next
+          // chunk's filter evaluation uses this chunk's dictionary, not the
+          // stale copy captured when the visitor was constructed.
+          visitor.refreshScanState();
+        } else if constexpr (kHasNulls) {
+          const auto endRow = V::dense
+              ? params.numScanned + (numRows - visitor.rowIndex())
+              : visitor.rowAt(numRows - 1) + 1;
+          NIMBLE_CHECK_EQ(
+              velox::bits::countNonNulls(nulls, params.numScanned, endRow),
+              0,
+              "Encoding stream exhausted but non-null rows remain in bitmap");
+          // All remaining rows are null — no chunk load needed. Fall
+          // through to computeNextRowIndex which produces numNonNulls=0
+          // and processes the null rows normally.
+        }
       }
 
       velox::vector_size_t numNulls{0};

--- a/dwio/nimble/velox/selective/tests/E2EFilterTest.cpp
+++ b/dwio/nimble/velox/selective/tests/E2EFilterTest.cpp
@@ -4309,6 +4309,122 @@ TEST_P(E2EFilterTest, filterOnlyDictAbandonDropsFilter) {
       << "Dict abandon path dropped filter on dict portion";
 }
 
+// Regression: when all non-null values in a dictionary-encoded string field
+// inside a mostly-null struct are consumed in earlier batches, later batches
+// contain only null rows. readDictionaryIndicesImpl unconditionally calls
+// loadNextChunk when remainingValues_==0, even when no more chunks exist,
+// crashing with "Failed to read chunk header". The fix checks the null bitmap
+// to verify all remaining rows are null before skipping the chunk load.
+TEST_P(E2EFilterTest, dictionaryChunkExhaustedAllNullTail) {
+  if (!param().stringDecoderZeroCopy ||
+      !param().nimblePreserveDictionaryEncoding) {
+    GTEST_SKIP()
+        << "Dictionary path requires stringDecoderZeroCopy and nimblePreserveDict";
+  }
+
+  // 20,000 rows with only 20 struct-non-null. All non-null values are the
+  // same string → ConstantEncoding with rowCount=20. The non-null positions
+  // cluster in the first quarter so later batches are entirely null.
+  constexpr size_t kTotalRows = 20000;
+  constexpr size_t kNonNullCount = 20;
+
+  auto type =
+      ROW({"select_col", "info"}, {BIGINT(), ROW({{"val"}}, {VARCHAR()})});
+  rowType_ = asRowType(type);
+
+  velox::test::VectorMaker maker(leafPool_.get());
+
+  auto selectVector = maker.flatVector<int64_t>(
+      kTotalRows, [](auto row) { return static_cast<int64_t>(row); });
+
+  auto valVector = maker.flatVector<velox::StringView>(
+      kNonNullCount,
+      [](auto /*row*/) { return velox::StringView("constant-val"); });
+
+  auto innerType = ROW({{"val"}}, {VARCHAR()});
+  auto innerStruct = std::make_shared<RowVector>(
+      leafPool_.get(),
+      innerType,
+      nullptr,
+      kNonNullCount,
+      std::vector<VectorPtr>{valVector});
+
+  auto structNulls =
+      velox::AlignedBuffer::allocate<bool>(kTotalRows, leafPool_.get());
+  auto* rawStructNulls = structNulls->asMutable<uint64_t>();
+  velox::bits::fillBits(rawStructNulls, 0, kTotalRows, velox::bits::kNull);
+  for (size_t i = 0; i < kNonNullCount; ++i) {
+    velox::bits::setBit(rawStructNulls, i * 250, true);
+  }
+
+  auto indices = velox::AlignedBuffer::allocate<vector_size_t>(
+      kTotalRows, leafPool_.get());
+  auto* rawIndices = indices->asMutable<vector_size_t>();
+  vector_size_t innerIdx = 0;
+  for (size_t i = 0; i < kTotalRows; ++i) {
+    rawIndices[i] = velox::bits::isBitSet(rawStructNulls, i) ? innerIdx++ : 0;
+  }
+
+  auto infoVector = BaseVector::wrapInDictionary(
+      structNulls, indices, kTotalRows, innerStruct);
+
+  auto batch = std::make_shared<RowVector>(
+      leafPool_.get(),
+      type,
+      nullptr,
+      kTotalRows,
+      std::vector<VectorPtr>{selectVector, infoVector});
+
+  {
+    auto writeFile = std::make_unique<InMemoryWriteFile>(&sinkData_);
+    VeloxWriterOptions writerOptions;
+    VeloxWriter writer(
+        type, std::move(writeFile), *rootPool_, std::move(writerOptions));
+    writer.write(batch);
+    writer.close();
+  }
+
+  auto input = std::make_unique<velox::dwio::common::BufferedInput>(
+      std::make_shared<velox::InMemoryReadFile>(sinkData_),
+      *leafPool_,
+      velox::dwio::common::MetricsLog::voidLog());
+  velox::dwio::common::ReaderOptions readerOpts{leafPool_.get()};
+  readerOpts.setMetadataIoStats(metadataIoStats_);
+  auto reader = makeReader(readerOpts, std::move(input));
+
+  auto scanSpec = std::make_shared<velox::common::ScanSpec>("root");
+  scanSpec->addAllChildFields(*type);
+
+  velox::dwio::common::RowReaderOptions rowReaderOptions;
+  rowReaderOptions.setScanSpec(scanSpec);
+  rowReaderOptions.setStringDecoderZeroCopy(true);
+  rowReaderOptions.setNimblePreserveDictionaryEncoding(true);
+  auto rowReader = reader->createRowReader(rowReaderOptions);
+
+  VectorPtr result = velox::BaseVector::create(type, 0, leafPool_.get());
+  size_t totalRows = 0;
+  size_t totalNonNull = 0;
+  constexpr size_t kBatchSize = 1000;
+  while (rowReader->next(kBatchSize, result)) {
+    auto* rowVector = result->as<RowVector>();
+    totalRows += rowVector->size();
+    auto info = rowVector->childAt(1);
+    info->loadedVector();
+    for (vector_size_t i = 0; i < info->size(); ++i) {
+      if (!info->isNullAt(i)) {
+        ++totalNonNull;
+        auto innerRow = info->as<RowVector>();
+        auto val = innerRow->childAt(0)->as<SimpleVector<velox::StringView>>();
+        ASSERT_FALSE(val->isNullAt(i));
+        EXPECT_EQ(val->valueAt(i), velox::StringView("constant-val"));
+      }
+    }
+  }
+
+  EXPECT_EQ(totalRows, kTotalRows);
+  EXPECT_EQ(totalNonNull, kNonNullCount);
+}
+
 // Exercises the reactive fallback path (dictionary → flat mid-batch) with an
 // active filter on the string column. The test creates alternating dictionary
 // and trivial chunks. When the reader encounters a trivial chunk mid-read, it


### PR DESCRIPTION
Summary:
CONTEXT:
When a dictionary-encoded string field is inside a struct with a high null rate (e.g., 22 non-null out of 20,821 rows), all non-null values are consumed in earlier batches. Later batches contain only null rows, but `readDictionaryIndicesImpl` unconditionally calls `loadNextChunk()` when `remainingValues_ == 0`, crashing with "Failed to read chunk header" because no more chunks exist.

The bug was found via Presto verifier failure on `prism.instagram.ig_data_apps_events_v2` where `page_info.report_id` (a `ConstantEncoding` string inside a 99.9%-null struct) crashed with dictionary preservation session properties enabled.

WHAT:
  - Add `hasMoreChunks()` guard to the chunk exhaustion check in `readDictionaryIndicesImpl`
  - When chunks remain: load next chunk (normal path)
  - When no chunks remain: verify via `NIMBLE_CHECK_EQ` that all remaining rows in the null bitmap are null — crash on corruption if non-null rows remain with no encoding data
  - If verification passes: fall through to `computeNextRowIndex` which produces `numNonNulls=0` and processes the all-null tail normally

This matches the reader paradigm: we know exactly how many rows we expect from the metadata, and crash upon corruption when metadata and runtime states mismatch.

Differential Revision: D112035625


