### PR TITLE
perf: Add single-range unique count fast path

### DIFF
--- a/dwio/nimble/common/StatsUtil.h
+++ b/dwio/nimble/common/StatsUtil.h
@@ -1,0 +1,129 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <algorithm>
+#include <cmath>
+#include <cstddef>
+#include <optional>
+#include <span>
+#include <type_traits>
+
+#include "velox/common/base/SimdUtil.h"
+
+namespace facebook::nimble {
+
+template <typename T>
+struct MinMax {
+  T min;
+  T max;
+};
+
+template <typename T>
+constexpr bool kIntegralMinMaxType = std::is_integral_v<std::remove_cv_t<T>> &&
+    !std::is_same_v<std::remove_cv_t<T>, bool>;
+
+template <typename T>
+constexpr bool kFloatingPointMinMaxType =
+    std::is_floating_point_v<std::remove_cv_t<T>>;
+
+template <typename T>
+std::enable_if_t<kIntegralMinMaxType<T>, MinMax<std::remove_cv_t<T>>>
+findMinMax(std::span<T> values) {
+  using Value = std::remove_cv_t<T>;
+  using Batch = xsimd::batch<Value>;
+
+  const auto* rawValues = values.data();
+  size_t index{0};
+  Value minValue{values.front()};
+  Value maxValue{values.front()};
+
+  if (values.size() >= Batch::size) {
+    auto minBatch = Batch::load_unaligned(rawValues);
+    auto maxBatch = minBatch;
+    index = Batch::size;
+    for (; index + Batch::size <= values.size(); index += Batch::size) {
+      const auto batch = Batch::load_unaligned(rawValues + index);
+      minBatch = xsimd::min(minBatch, batch);
+      maxBatch = xsimd::max(maxBatch, batch);
+    }
+    minValue = xsimd::reduce_min(minBatch);
+    maxValue = xsimd::reduce_max(maxBatch);
+  }
+
+  for (; index < values.size(); ++index) {
+    minValue = std::min(minValue, values[index]);
+    maxValue = std::max(maxValue, values[index]);
+  }
+
+  return {
+      .min = minValue,
+      .max = maxValue,
+  };
+}
+
+template <typename T>
+std::enable_if_t<
+    kFloatingPointMinMaxType<T>,
+    std::optional<MinMax<std::remove_cv_t<T>>>>
+findMinMax(std::span<T> values) {
+  using Value = std::remove_cv_t<T>;
+  using Batch = xsimd::batch<Value>;
+
+  const auto* rawValues = values.data();
+  size_t index{0};
+  Value minValue{values.front()};
+  Value maxValue{values.front()};
+
+  if (std::isnan(minValue)) {
+    return std::nullopt;
+  }
+
+  if (values.size() >= Batch::size) {
+    auto minBatch = Batch::load_unaligned(rawValues);
+    if (xsimd::any(minBatch != minBatch)) {
+      return std::nullopt;
+    }
+    auto maxBatch = minBatch;
+    index = Batch::size;
+    for (; index + Batch::size <= values.size(); index += Batch::size) {
+      const auto batch = Batch::load_unaligned(rawValues + index);
+      if (xsimd::any(batch != batch)) {
+        return std::nullopt;
+      }
+      minBatch = xsimd::min(minBatch, batch);
+      maxBatch = xsimd::max(maxBatch, batch);
+    }
+    minValue = xsimd::reduce_min(minBatch);
+    maxValue = xsimd::reduce_max(maxBatch);
+  }
+
+  for (; index < values.size(); ++index) {
+    const auto value = values[index];
+    if (std::isnan(value)) {
+      return std::nullopt;
+    }
+    minValue = std::min(minValue, value);
+    maxValue = std::max(maxValue, value);
+  }
+
+  return MinMax<Value>{
+      .min = minValue,
+      .max = maxValue,
+  };
+}
+
+} // namespace facebook::nimble

--- a/dwio/nimble/common/tests/StatsUtilTest.cpp
+++ b/dwio/nimble/common/tests/StatsUtilTest.cpp
@@ -1,0 +1,99 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include <cstddef>
+#include <cstdint>
+#include <limits>
+#include <optional>
+#include <span>
+#include <type_traits>
+#include <vector>
+
+#include <gtest/gtest.h>
+
+#include "dwio/nimble/common/StatsUtil.h"
+
+using namespace facebook::nimble;
+
+namespace {
+
+template <typename T>
+void expectIntegralMinMax(T expectedMin, T expectedMax, std::vector<T> values) {
+  const auto minMax = findMinMax(std::span<const T>{values});
+  EXPECT_EQ(minMax.min, expectedMin);
+  EXPECT_EQ(minMax.max, expectedMax);
+}
+
+template <typename T>
+void expectFloatingPointMinMax(
+    T expectedMin,
+    T expectedMax,
+    std::vector<T> values) {
+  const auto minMax = findMinMax(std::span<const T>{values});
+  ASSERT_TRUE(minMax.has_value());
+  if constexpr (std::is_same_v<T, float>) {
+    EXPECT_FLOAT_EQ(minMax->min, expectedMin);
+    EXPECT_FLOAT_EQ(minMax->max, expectedMax);
+  } else {
+    EXPECT_DOUBLE_EQ(minMax->min, expectedMin);
+    EXPECT_DOUBLE_EQ(minMax->max, expectedMax);
+  }
+}
+
+} // namespace
+
+TEST(StatsUtilTest, findMinMaxHandlesIntegralTypes) {
+  std::vector<int32_t> signedValues(257);
+  for (size_t i = 0; i < signedValues.size(); ++i) {
+    signedValues[i] = static_cast<int32_t>(i) - 128;
+  }
+  signedValues[13] = std::numeric_limits<int32_t>::min();
+  signedValues[199] = std::numeric_limits<int32_t>::max();
+  expectIntegralMinMax<int32_t>(
+      std::numeric_limits<int32_t>::min(),
+      std::numeric_limits<int32_t>::max(),
+      signedValues);
+
+  std::vector<uint64_t> unsignedValues(257);
+  for (size_t i = 0; i < unsignedValues.size(); ++i) {
+    unsignedValues[i] = 1000 + i;
+  }
+  unsignedValues[17] = 0;
+  unsignedValues[211] = std::numeric_limits<uint64_t>::max();
+  expectIntegralMinMax<uint64_t>(
+      0, std::numeric_limits<uint64_t>::max(), unsignedValues);
+}
+
+TEST(StatsUtilTest, findMinMaxHandlesFloatingPointTypes) {
+  std::vector<float> floatValues(257, 1.25F);
+  floatValues[11] = -123.5F;
+  floatValues[211] = 456.75F;
+  expectFloatingPointMinMax<float>(-123.5F, 456.75F, floatValues);
+
+  std::vector<double> doubleValues(257, 2.5);
+  doubleValues[31] = -9876.5;
+  doubleValues[199] = 54321.25;
+  expectFloatingPointMinMax<double>(-9876.5, 54321.25, doubleValues);
+}
+
+TEST(StatsUtilTest, findMinMaxReturnsEmptyForFloatingPointNaN) {
+  std::vector<float> floatValues(257, 1.25F);
+  floatValues[211] = std::numeric_limits<float>::quiet_NaN();
+  EXPECT_EQ(findMinMax(std::span<const float>{floatValues}), std::nullopt);
+
+  std::vector<double> doubleValues(257, 2.5);
+  doubleValues[31] = std::numeric_limits<double>::quiet_NaN();
+  EXPECT_EQ(findMinMax(std::span<const double>{doubleValues}), std::nullopt);
+}

--- a/dwio/nimble/encodings/benchmarks/StatisticsBenchmark.cpp
+++ b/dwio/nimble/encodings/benchmarks/StatisticsBenchmark.cpp
@@ -1,0 +1,103 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <cstdint>
+#include <limits>
+#include <span>
+#include <vector>
+
+#include "dwio/nimble/encodings/selection/Statistics.h"
+#include "folly/Benchmark.h"
+#include "folly/init/Init.h"
+
+using namespace facebook::nimble;
+
+namespace {
+
+constexpr uint32_t kValueCount{1 << 20};
+// Keep dense cases at the same limit used by Statistics.cpp.
+constexpr uint32_t kDenseRangeSize{4096};
+
+std::vector<int64_t> int64DenseRange{};
+std::vector<int64_t> int64DenseRangeAtMin{};
+std::vector<int64_t> int64SparseRange{};
+std::vector<int64_t> int64FullSpan{};
+std::vector<uint64_t> uint64DenseRangeAtMax{};
+
+template <typename T>
+void updateUniqueStats(uint32_t iters, const std::vector<T>& data) {
+  while (iters-- > 0) {
+    auto statistics =
+        Statistics<T>::create(std::span<const T>{data.data(), data.size()});
+    const auto& uniqueCounts = statistics.uniqueCounts().value();
+    folly::doNotOptimizeAway(uniqueCounts.size());
+    folly::doNotOptimizeAway(uniqueCounts.at(data[data.size() / 2]));
+  }
+}
+
+void prepareData() {
+  int64DenseRange.resize(kValueCount);
+  int64DenseRangeAtMin.resize(kValueCount);
+  int64SparseRange.resize(kValueCount);
+  int64FullSpan.resize(kValueCount);
+  uint64DenseRangeAtMax.resize(kValueCount);
+
+  constexpr int64_t int64Min{std::numeric_limits<int64_t>::lowest()};
+  constexpr int64_t int64Max{std::numeric_limits<int64_t>::max()};
+  constexpr uint64_t uint64HighBase{
+      std::numeric_limits<uint64_t>::max() - kDenseRangeSize + 1};
+
+  for (uint32_t i = 0; i < kValueCount; ++i) {
+    const uint32_t denseOffset{i % kDenseRangeSize};
+    int64DenseRange[i] = static_cast<int64_t>(denseOffset);
+    int64DenseRangeAtMin[i] = int64Min + static_cast<int64_t>(denseOffset);
+    int64SparseRange[i] = static_cast<int64_t>(denseOffset * 2);
+    uint64DenseRangeAtMax[i] = uint64HighBase + denseOffset;
+
+    const uint32_t fullSpanOffset{i % 3};
+    int64FullSpan[i] = fullSpanOffset == 0
+        ? int64Min
+        : (fullSpanOffset == 1 ? int64_t{0} : int64Max);
+  }
+}
+
+} // namespace
+
+BENCHMARK(UniqueStats_Int64DenseRange, iters) {
+  updateUniqueStats(iters, int64DenseRange);
+}
+
+BENCHMARK_RELATIVE(UniqueStats_Int64DenseRangeAtMin, iters) {
+  updateUniqueStats(iters, int64DenseRangeAtMin);
+}
+
+BENCHMARK_RELATIVE(UniqueStats_Uint64DenseRangeAtMax, iters) {
+  updateUniqueStats(iters, uint64DenseRangeAtMax);
+}
+
+BENCHMARK_RELATIVE(UniqueStats_Int64SparseRangeHash, iters) {
+  updateUniqueStats(iters, int64SparseRange);
+}
+
+BENCHMARK_RELATIVE(UniqueStats_Int64FullSpanHash, iters) {
+  updateUniqueStats(iters, int64FullSpan);
+}
+
+int main(int argc, char** argv) {
+  folly::Init init(&argc, &argv);
+  prepareData();
+  folly::runBenchmarks();
+}

--- a/dwio/nimble/encodings/benchmarks/StatisticsBenchmark.cpp
+++ b/dwio/nimble/encodings/benchmarks/StatisticsBenchmark.cpp
@@ -32,6 +32,7 @@ constexpr uint32_t kValueCount{1 << 20};
 constexpr uint32_t kDenseRangeSize{4096};
 
 std::vector<int64_t> int64DenseRange{};
+std::vector<int64_t> int64SingleValue{};
 std::vector<int64_t> int64DenseRangeAtMin{};
 std::vector<int64_t> int64SparseRange{};
 std::vector<int64_t> int64FullSpan{};
@@ -50,6 +51,7 @@ void updateUniqueStats(uint32_t iters, const std::vector<T>& data) {
 
 void prepareData() {
   int64DenseRange.resize(kValueCount);
+  int64SingleValue.resize(kValueCount);
   int64DenseRangeAtMin.resize(kValueCount);
   int64SparseRange.resize(kValueCount);
   int64FullSpan.resize(kValueCount);
@@ -63,6 +65,7 @@ void prepareData() {
   for (uint32_t i = 0; i < kValueCount; ++i) {
     const uint32_t denseOffset{i % kDenseRangeSize};
     int64DenseRange[i] = static_cast<int64_t>(denseOffset);
+    int64SingleValue[i] = 42;
     int64DenseRangeAtMin[i] = int64Min + static_cast<int64_t>(denseOffset);
     int64SparseRange[i] = static_cast<int64_t>(denseOffset * 2);
     uint64DenseRangeAtMax[i] = uint64HighBase + denseOffset;
@@ -78,6 +81,10 @@ void prepareData() {
 
 BENCHMARK(UniqueStats_Int64DenseRange, iters) {
   updateUniqueStats(iters, int64DenseRange);
+}
+
+BENCHMARK_RELATIVE(UniqueStats_Int64SingleValue, iters) {
+  updateUniqueStats(iters, int64SingleValue);
 }
 
 BENCHMARK_RELATIVE(UniqueStats_Int64DenseRangeAtMin, iters) {

--- a/dwio/nimble/encodings/selection/Statistics.cpp
+++ b/dwio/nimble/encodings/selection/Statistics.cpp
@@ -82,6 +82,13 @@ MapType<T, T> populateRangeUniqueCounts(
     std::span<const T> values,
     T minValue,
     uint32_t rangeSize) {
+  if (rangeSize == 1) {
+    MapType<T, T> uniqueCounts;
+    uniqueCounts.reserve(1);
+    uniqueCounts.emplace(minValue, static_cast<uint64_t>(values.size()));
+    return uniqueCounts;
+  }
+
   std::vector<uint64_t> counts(rangeSize);
   for (const auto value : values) {
     ++counts[denseRangeOffset(value, minValue)];

--- a/dwio/nimble/encodings/selection/Statistics.cpp
+++ b/dwio/nimble/encodings/selection/Statistics.cpp
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 #include "dwio/nimble/encodings/selection/Statistics.h"
+#include "dwio/nimble/common/StatsUtil.h"
 #include "dwio/nimble/common/Types.h"
 
 #include <algorithm>
@@ -27,8 +28,75 @@ namespace facebook::nimble {
 
 namespace {
 
+constexpr uint32_t kMaxDenseRangeSize{4096};
+
 template <typename T, typename InputType>
 using MapType = typename UniqueValueCounts<T, InputType>::MapType;
+
+template <typename T>
+uint64_t integralRangeDistance(T value, T rangeBase) {
+  return static_cast<uint64_t>(value) - static_cast<uint64_t>(rangeBase);
+}
+
+template <typename T>
+uint32_t denseRangeOffset(T value, T rangeBase) {
+  return static_cast<uint32_t>(integralRangeDistance(value, rangeBase));
+}
+
+template <typename T>
+T integralValueAtOffset(T rangeBase, uint32_t offset) {
+  if constexpr (std::is_signed_v<T>) {
+    return static_cast<T>(
+        static_cast<int64_t>(rangeBase) + static_cast<int64_t>(offset));
+  } else {
+    return static_cast<T>(static_cast<uint64_t>(rangeBase) + offset);
+  }
+}
+
+template <typename T>
+std::optional<uint32_t>
+denseRangeSize(T minValue, T maxValue, size_t valueCount) {
+  const auto rangeDistance = integralRangeDistance(maxValue, minValue);
+  const auto maxRangeSize = std::min<uint64_t>(kMaxDenseRangeSize, valueCount);
+  if (rangeDistance >= maxRangeSize) {
+    return std::nullopt;
+  }
+  return static_cast<uint32_t>(rangeDistance) + 1;
+}
+
+template <typename T, typename InputType>
+MapType<T, InputType> populateHashUniqueCounts(
+    std::span<const InputType> values) {
+  MapType<T, InputType> uniqueCounts;
+  // NOTE: There is no science behind the reservation size. Just trying to
+  // minimize internal allocations...
+  uniqueCounts.reserve(values.size() / 3);
+  for (auto i = 0; i < values.size(); ++i) {
+    ++uniqueCounts[values[i]];
+  }
+  return uniqueCounts;
+}
+
+template <typename T>
+MapType<T, T> populateRangeUniqueCounts(
+    std::span<const T> values,
+    T minValue,
+    uint32_t rangeSize) {
+  std::vector<uint64_t> counts(rangeSize);
+  for (const auto value : values) {
+    ++counts[denseRangeOffset(value, minValue)];
+  }
+
+  MapType<T, T> uniqueCounts;
+  uniqueCounts.reserve(std::min<size_t>(rangeSize, values.size()));
+  for (uint32_t offset = 0; offset < rangeSize; ++offset) {
+    if (counts[offset] > 0) {
+      uniqueCounts.emplace(
+          integralValueAtOffset(minValue, offset), counts[offset]);
+    }
+  }
+  return uniqueCounts;
+}
 
 uint64_t countTrueValues(std::span<const bool> values) {
   static_assert(sizeof(bool) == sizeof(uint8_t));
@@ -128,13 +196,20 @@ void Statistics<T, InputType>::populateUniques() const {
     if (trueCount > 0) {
       uniqueCounts.emplace(true, trueCount);
     }
-  } else {
-    // Note: There is no science behind the reservation size. Just trying to
-    // minimize internal allocations...
-    uniqueCounts.reserve(data_.size() / 3);
-    for (auto i = 0; i < data_.size(); ++i) {
-      ++uniqueCounts[data_[i]];
+  } else if constexpr (
+      nimble::isIntegralType<T>() && std::is_same_v<T, InputType>) {
+    const auto minMax = findMinMax(data_);
+    min_ = minMax.min;
+    max_ = minMax.max;
+    if (const auto rangeSize =
+            denseRangeSize(minMax.min, minMax.max, data_.size())) {
+      uniqueCounts =
+          populateRangeUniqueCounts<T>(data_, minMax.min, rangeSize.value());
+    } else {
+      uniqueCounts = populateHashUniqueCounts<T, InputType>(data_);
     }
+  } else {
+    uniqueCounts = populateHashUniqueCounts<T, InputType>(data_);
   }
   uniqueCounts_.emplace(std::make_optional(std::move(uniqueCounts)));
 }

--- a/dwio/nimble/encodings/tests/StatisticsTest.cpp
+++ b/dwio/nimble/encodings/tests/StatisticsTest.cpp
@@ -18,6 +18,7 @@
 #include <limits>
 #include <string_view>
 #include <type_traits>
+#include <utility>
 
 #include "dwio/nimble/common/Varint.h"
 #include "dwio/nimble/encodings/selection/Statistics.h"
@@ -189,6 +190,85 @@ TYPED_TEST(StatisticsBoolTests, Create) {
       expectedDistinctValuesCount, statistics.uniqueCounts().value().size());
   EXPECT_EQ(trueCount, statistics.uniqueCounts().value().at(true));
   EXPECT_EQ(falseCount, statistics.uniqueCounts().value().at(false));
+}
+
+TYPED_TEST(StatisticsIntegerTests, uniqueCountsDenseRange) {
+  using T = TypeParam;
+  using ValueType = typename T::valueType;
+
+  struct Test {
+    std::string_view name;
+    std::vector<ValueType> data;
+    std::vector<std::pair<ValueType, uint64_t>> expectedCounts;
+    ValueType expectedMin;
+    ValueType expectedMax;
+  };
+
+  std::vector<Test> tests;
+  if constexpr (std::is_signed_v<ValueType>) {
+    tests = {
+        {"crosses zero",
+         {static_cast<ValueType>(-2),
+          static_cast<ValueType>(-1),
+          static_cast<ValueType>(-2),
+          static_cast<ValueType>(0),
+          static_cast<ValueType>(1),
+          static_cast<ValueType>(1)},
+         {{static_cast<ValueType>(-2), 2},
+          {static_cast<ValueType>(-1), 1},
+          {static_cast<ValueType>(0), 1},
+          {static_cast<ValueType>(1), 2}},
+         static_cast<ValueType>(-2),
+         static_cast<ValueType>(1)},
+        {"near lowest",
+         {std::numeric_limits<ValueType>::lowest(),
+          static_cast<ValueType>(std::numeric_limits<ValueType>::lowest() + 1),
+          std::numeric_limits<ValueType>::lowest()},
+         {{std::numeric_limits<ValueType>::lowest(), 2},
+          {static_cast<ValueType>(std::numeric_limits<ValueType>::lowest() + 1),
+           1}},
+         std::numeric_limits<ValueType>::lowest(),
+         static_cast<ValueType>(std::numeric_limits<ValueType>::lowest() + 1)},
+    };
+  } else {
+    tests = {
+        {"near max",
+         {static_cast<ValueType>(std::numeric_limits<ValueType>::max() - 2),
+          static_cast<ValueType>(std::numeric_limits<ValueType>::max() - 1),
+          std::numeric_limits<ValueType>::max(),
+          static_cast<ValueType>(std::numeric_limits<ValueType>::max() - 2),
+          std::numeric_limits<ValueType>::max()},
+         {{static_cast<ValueType>(std::numeric_limits<ValueType>::max() - 2),
+           2},
+          {static_cast<ValueType>(std::numeric_limits<ValueType>::max() - 1),
+           1},
+          {std::numeric_limits<ValueType>::max(), 2}},
+         static_cast<ValueType>(std::numeric_limits<ValueType>::max() - 2),
+         std::numeric_limits<ValueType>::max()},
+        {"starts at zero",
+         {static_cast<ValueType>(0),
+          static_cast<ValueType>(1),
+          static_cast<ValueType>(0),
+          static_cast<ValueType>(2)},
+         {{static_cast<ValueType>(0), 2},
+          {static_cast<ValueType>(1), 1},
+          {static_cast<ValueType>(2), 1}},
+         static_cast<ValueType>(0),
+         static_cast<ValueType>(2)},
+    };
+  }
+
+  for (const auto& test : tests) {
+    SCOPED_TRACE(test.name);
+    const auto statistics = T::create({test.data});
+    const auto& uniqueCounts = statistics.uniqueCounts().value();
+    EXPECT_EQ(test.expectedCounts.size(), uniqueCounts.size());
+    for (const auto& [value, count] : test.expectedCounts) {
+      EXPECT_EQ(count, uniqueCounts.at(value));
+    }
+    EXPECT_EQ(test.expectedMin, statistics.min());
+    EXPECT_EQ(test.expectedMax, statistics.max());
+  }
 }
 
 template <typename T>

--- a/dwio/nimble/encodings/tests/StatisticsTest.cpp
+++ b/dwio/nimble/encodings/tests/StatisticsTest.cpp
@@ -207,6 +207,14 @@ TYPED_TEST(StatisticsIntegerTests, uniqueCountsDenseRange) {
   std::vector<Test> tests;
   if constexpr (std::is_signed_v<ValueType>) {
     tests = {
+        {"single value",
+         {std::numeric_limits<ValueType>::lowest(),
+          std::numeric_limits<ValueType>::lowest(),
+          std::numeric_limits<ValueType>::lowest(),
+          std::numeric_limits<ValueType>::lowest()},
+         {{std::numeric_limits<ValueType>::lowest(), 4}},
+         std::numeric_limits<ValueType>::lowest(),
+         std::numeric_limits<ValueType>::lowest()},
         {"crosses zero",
          {static_cast<ValueType>(-2),
           static_cast<ValueType>(-1),
@@ -232,6 +240,14 @@ TYPED_TEST(StatisticsIntegerTests, uniqueCountsDenseRange) {
     };
   } else {
     tests = {
+        {"single value",
+         {std::numeric_limits<ValueType>::max(),
+          std::numeric_limits<ValueType>::max(),
+          std::numeric_limits<ValueType>::max(),
+          std::numeric_limits<ValueType>::max()},
+         {{std::numeric_limits<ValueType>::max(), 4}},
+         std::numeric_limits<ValueType>::max(),
+         std::numeric_limits<ValueType>::max()},
         {"near max",
          {static_cast<ValueType>(std::numeric_limits<ValueType>::max() - 2),
           static_cast<ValueType>(std::numeric_limits<ValueType>::max() - 1),

--- a/dwio/nimble/velox/stats/ColumnStatsUtils.h
+++ b/dwio/nimble/velox/stats/ColumnStatsUtils.h
@@ -14,122 +14,18 @@
  * limitations under the License.
  */
 #pragma once
-#include <algorithm>
-#include <cmath>
 #include <cstddef>
 #include <optional>
-#include <span>
-#include <type_traits>
 #include <unordered_map>
 
+#include "dwio/nimble/common/StatsUtil.h"
 #include "dwio/nimble/velox/OrderedRanges.h"
 #include "dwio/nimble/velox/RawSizeContext.h"
 #include "dwio/nimble/velox/SchemaBuilder.h"
 #include "dwio/nimble/velox/SchemaTypes.h"
-#include "velox/common/base/SimdUtil.h"
 #include "velox/vector/BaseVector.h"
 
 namespace facebook::nimble {
-
-template <typename T>
-struct MinMax {
-  T min;
-  T max;
-};
-
-template <typename T>
-constexpr bool kIntegralMinMaxType = std::is_integral_v<std::remove_cv_t<T>> &&
-    !std::is_same_v<std::remove_cv_t<T>, bool>;
-
-template <typename T>
-constexpr bool kFloatingPointMinMaxType =
-    std::is_floating_point_v<std::remove_cv_t<T>>;
-
-template <typename T>
-std::enable_if_t<kIntegralMinMaxType<T>, MinMax<std::remove_cv_t<T>>>
-findMinMax(std::span<T> values) {
-  using Value = std::remove_cv_t<T>;
-  using Batch = xsimd::batch<Value>;
-
-  const auto* rawValues = values.data();
-  size_t index{0};
-  Value minValue{values.front()};
-  Value maxValue{values.front()};
-
-  if (values.size() >= Batch::size) {
-    auto minBatch = Batch::load_unaligned(rawValues);
-    auto maxBatch = minBatch;
-    index = Batch::size;
-    for (; index + Batch::size <= values.size(); index += Batch::size) {
-      const auto batch = Batch::load_unaligned(rawValues + index);
-      minBatch = xsimd::min(minBatch, batch);
-      maxBatch = xsimd::max(maxBatch, batch);
-    }
-    minValue = xsimd::reduce_min(minBatch);
-    maxValue = xsimd::reduce_max(maxBatch);
-  }
-
-  for (; index < values.size(); ++index) {
-    minValue = std::min(minValue, values[index]);
-    maxValue = std::max(maxValue, values[index]);
-  }
-
-  return {
-      .min = minValue,
-      .max = maxValue,
-  };
-}
-
-template <typename T>
-std::enable_if_t<
-    kFloatingPointMinMaxType<T>,
-    std::optional<MinMax<std::remove_cv_t<T>>>>
-findMinMax(std::span<T> values) {
-  using Value = std::remove_cv_t<T>;
-  using Batch = xsimd::batch<Value>;
-
-  const auto* rawValues = values.data();
-  size_t index{0};
-  Value minValue{values.front()};
-  Value maxValue{values.front()};
-
-  if (std::isnan(minValue)) {
-    return std::nullopt;
-  }
-
-  if (values.size() >= Batch::size) {
-    auto minBatch = Batch::load_unaligned(rawValues);
-    if (xsimd::any(minBatch != minBatch)) {
-      return std::nullopt;
-    }
-    auto maxBatch = minBatch;
-    index = Batch::size;
-    for (; index + Batch::size <= values.size(); index += Batch::size) {
-      const auto batch = Batch::load_unaligned(rawValues + index);
-      if (xsimd::any(batch != batch)) {
-        return std::nullopt;
-      }
-      minBatch = xsimd::min(minBatch, batch);
-      maxBatch = xsimd::max(maxBatch, batch);
-    }
-    minValue = xsimd::reduce_min(minBatch);
-    maxValue = xsimd::reduce_max(maxBatch);
-  }
-
-  for (; index < values.size(); ++index) {
-    const auto value = values[index];
-    if (std::isnan(value)) {
-      return std::nullopt;
-    }
-    minValue = std::min(minValue, value);
-    maxValue = std::max(maxValue, value);
-  }
-
-  return MinMax<Value>{
-      .min = minValue,
-      .max = maxValue,
-  };
-}
 
 struct ColumnStats {
   uint64_t logicalSize{0};

--- a/dwio/nimble/velox/stats/tests/ColumnStatisticsTests.cpp
+++ b/dwio/nimble/velox/stats/tests/ColumnStatisticsTests.cpp
@@ -17,13 +17,11 @@
 #include <cstdint>
 #include <limits>
 #include <span>
-#include <type_traits>
 #include <vector>
 
 #include <gtest/gtest.h>
 
 #include "dwio/nimble/velox/stats/ColumnStatistics.h"
-#include "dwio/nimble/velox/stats/ColumnStatsUtils.h"
 
 using namespace facebook;
 using namespace facebook::nimble;
@@ -94,29 +92,6 @@ void testFloatingPointMinMaxAcrossBatches() {
   EXPECT_DOUBLE_EQ(
       stats->getMax().value(),
       static_cast<double>(std::numeric_limits<T>::max()));
-}
-
-template <typename T>
-void expectIntegralMinMax(T expectedMin, T expectedMax, std::vector<T> values) {
-  const auto minMax = findMinMax(std::span<const T>{values});
-  EXPECT_EQ(minMax.min, expectedMin);
-  EXPECT_EQ(minMax.max, expectedMax);
-}
-
-template <typename T>
-void expectFloatingPointMinMax(
-    T expectedMin,
-    T expectedMax,
-    std::vector<T> values) {
-  const auto minMax = findMinMax(std::span<const T>{values});
-  ASSERT_TRUE(minMax.has_value());
-  if constexpr (std::is_same_v<T, float>) {
-    EXPECT_FLOAT_EQ(minMax->min, expectedMin);
-    EXPECT_FLOAT_EQ(minMax->max, expectedMax);
-  } else {
-    EXPECT_DOUBLE_EQ(minMax->min, expectedMin);
-    EXPECT_DOUBLE_EQ(minMax->max, expectedMax);
-  }
 }
 
 } // namespace
@@ -247,50 +222,6 @@ TEST_F(ColumnStatisticsTests, FloatingPointStatistics) {
     EXPECT_EQ(stat.getMin(), minVal);
     EXPECT_EQ(stat.getMax(), maxVal);
   }
-}
-
-TEST_F(ColumnStatisticsTests, findMinMaxHandlesIntegralTypes) {
-  std::vector<int32_t> signedValues(257);
-  for (size_t i = 0; i < signedValues.size(); ++i) {
-    signedValues[i] = static_cast<int32_t>(i) - 128;
-  }
-  signedValues[13] = std::numeric_limits<int32_t>::min();
-  signedValues[199] = std::numeric_limits<int32_t>::max();
-  expectIntegralMinMax<int32_t>(
-      std::numeric_limits<int32_t>::min(),
-      std::numeric_limits<int32_t>::max(),
-      signedValues);
-
-  std::vector<uint64_t> unsignedValues(257);
-  for (size_t i = 0; i < unsignedValues.size(); ++i) {
-    unsignedValues[i] = 1000 + i;
-  }
-  unsignedValues[17] = 0;
-  unsignedValues[211] = std::numeric_limits<uint64_t>::max();
-  expectIntegralMinMax<uint64_t>(
-      0, std::numeric_limits<uint64_t>::max(), unsignedValues);
-}
-
-TEST_F(ColumnStatisticsTests, findMinMaxHandlesFloatingPointTypes) {
-  std::vector<float> floatValues(257, 1.25F);
-  floatValues[11] = -123.5F;
-  floatValues[211] = 456.75F;
-  expectFloatingPointMinMax<float>(-123.5F, 456.75F, floatValues);
-
-  std::vector<double> doubleValues(257, 2.5);
-  doubleValues[31] = -9876.5;
-  doubleValues[199] = 54321.25;
-  expectFloatingPointMinMax<double>(-9876.5, 54321.25, doubleValues);
-}
-
-TEST_F(ColumnStatisticsTests, findMinMaxReturnsEmptyForFloatingPointNaN) {
-  std::vector<float> floatValues(257, 1.25F);
-  floatValues[211] = std::numeric_limits<float>::quiet_NaN();
-  EXPECT_EQ(findMinMax(std::span<const float>{floatValues}), std::nullopt);
-
-  std::vector<double> doubleValues(257, 2.5);
-  doubleValues[31] = std::numeric_limits<double>::quiet_NaN();
-  EXPECT_EQ(findMinMax(std::span<const double>{doubleValues}), std::nullopt);
 }
 
 // StringStatistics Tests


### PR DESCRIPTION
Summary:
When the dense integral unique-count path sees `rangeSize == 1`, all values are equal to `minValue`. Return the one-entry `UniqueValueCounts` map directly instead of allocating and filling the temporary dense count vector.

Also add a benchmark row for the all-values-identical case and extend the existing typed dense-range test to cover `min == max` for signed and unsigned integral types.

bypass-github-export-checks

Differential Revision: D112064120


