### PR TITLE
feat: Add stripe stats pruning

### DIFF
--- a/dwio/nimble/tablet/Constants.h
+++ b/dwio/nimble/tablet/Constants.h
@@ -34,6 +34,7 @@ constexpr std::string_view kMetadataSection = "columnar.metadata";
 constexpr std::string_view kStatsSection = "columnar.stats";
 constexpr std::string_view kVectorizedStatsSection =
     "columnar.vectorized_stats";
+constexpr std::string_view kStripeStatsSection = "columnar.stripe_stats";
 constexpr std::string_view kClusterIndexSection = "columnar.cluster.index";
 constexpr std::string_view kChunkIndexSection = "columnar.chunk.index";
 constexpr std::string_view kHashIndexSection = "columnar.hash.index";

--- a/dwio/nimble/tablet/TabletReader.cpp
+++ b/dwio/nimble/tablet/TabletReader.cpp
@@ -74,7 +74,9 @@ TabletReader::Options TabletReader::configureOptions(
   Options tabletOptions;
   tabletOptions.maxFooterIoBytes = options.footerSpeculativeIoSize();
   tabletOptions.preloadOptionalSections = {
-      std::string(kSchemaSection), std::string(kVectorizedStatsSection)};
+      std::string(kSchemaSection),
+      std::string(kVectorizedStatsSection),
+      std::string(kStripeStatsSection)};
   tabletOptions.loadClusterIndex = options.loadClusterIndex();
   if (tabletOptions.loadClusterIndex) {
     tabletOptions.preloadOptionalSections.emplace_back(kClusterIndexSection);

--- a/dwio/nimble/velox/FieldWriter.h
+++ b/dwio/nimble/velox/FieldWriter.h
@@ -16,6 +16,7 @@
 
 #pragma once
 
+#include <cmath>
 #include <set>
 
 #include <folly/Executor.h>
@@ -299,20 +300,17 @@ class FieldWriterContext {
   }
 
   inline std::vector<ColumnStatistics*> columnStats() {
-    if (!statsFinalized_) {
-      return {};
-    }
-    // TODO: add a build method for this pattern.
     std::vector<ColumnStatistics*> statsViews;
-    statsViews.reserve(statsCollectors_.size());
-    for (auto& collector : statsCollectors_) {
-      // FIXME: don't need this branching.
-      statsViews.push_back(
-          collector->shared()
-              ? collector->as<SharedStatisticsCollector>()->getBaseStatistics()
-              : collector->getStatsView());
+    statsViews.reserve(fileStats_.size());
+    for (auto& stat : fileStats_) {
+      statsViews.push_back(stat.get());
     }
     return statsViews;
+  }
+
+  inline const std::vector<std::vector<std::unique_ptr<ColumnStatistics>>>&
+  stripeStats() const {
+    return stripeStats_;
   }
 
   void handleFlatmapFieldAddEvent(
@@ -479,10 +477,40 @@ class FieldWriterContext {
   // 1. roll up logical and physical sizes
   // 2. wrap all ancestors of deduplicated types
   // 3. backfill both known and newly wrapped deduplicated stats
-  void finalizeStatsCollectors() {
+  void finalizeStripeStatsCollectors() {
     NIMBLE_CHECK(!statsFinalized_);
     finalizeStatsCollector(schemaWithId_);
     statsFinalized_ = true;
+    snapshotStripeStats();
+    resetStatsCollectors();
+  }
+
+  void finalizeFileStatsFromStripes() {
+    fileStats_.clear();
+    if (stripeStats_.empty()) {
+      if (!statsFinalized_) {
+        finalizeStatsCollector(schemaWithId_);
+        statsFinalized_ = true;
+      }
+      fileStats_.reserve(statsCollectors_.size());
+      for (auto& collector : statsCollectors_) {
+        auto* stats = collector->shared()
+            ? collector->as<SharedStatisticsCollector>()->getBaseStatistics()
+            : collector->getStatsView();
+        fileStats_.push_back(stats->clone());
+      }
+      return;
+    }
+    fileStats_.reserve(stripeStats_.front().size());
+    for (const auto& stat : stripeStats_.front()) {
+      fileStats_.push_back(stat->clone());
+    }
+    for (size_t stripe = 1; stripe < stripeStats_.size(); ++stripe) {
+      NIMBLE_CHECK_EQ(stripeStats_[stripe].size(), fileStats_.size());
+      for (size_t column = 0; column < fileStats_.size(); ++column) {
+        mergeColumnStats(*fileStats_[column], *stripeStats_[stripe][column]);
+      }
+    }
   }
 
  protected:
@@ -513,6 +541,157 @@ class FieldWriterContext {
       [](TypeBuilder&, uint32_t) {}};
 
  private:
+  // Merges min/max from source into target for a scalar statistics subclass
+  // (Integral/FloatingPoint/String). Keeps the widest range across stripes.
+  template <typename StatsT>
+  static void mergeMinMax(
+      ColumnStatistics& target,
+      const ColumnStatistics& source) {
+    auto* targetStats = target.as<StatsT>();
+    const auto* sourceStats = source.as<StatsT>();
+    if (sourceStats->getMin().has_value() &&
+        (!targetStats->getMin().has_value() ||
+         *sourceStats->getMin() < *targetStats->getMin())) {
+      targetStats->min_ = sourceStats->getMin();
+    }
+    if (sourceStats->getMax().has_value() &&
+        (!targetStats->getMax().has_value() ||
+         *sourceStats->getMax() > *targetStats->getMax())) {
+      targetStats->max_ = sourceStats->getMax();
+    }
+  }
+
+  static bool shouldUseSourceFloatingPointMin(
+      const FloatingPointStatistics& target,
+      const FloatingPointStatistics& source) {
+    if (!source.getMin().has_value()) {
+      return false;
+    }
+    if (!target.getMin().has_value()) {
+      return true;
+    }
+    if (std::isnan(*target.getMin())) {
+      return false;
+    }
+    if (std::isnan(*source.getMin())) {
+      return true;
+    }
+    return *source.getMin() < *target.getMin();
+  }
+
+  static bool shouldUseSourceFloatingPointMax(
+      const FloatingPointStatistics& target,
+      const FloatingPointStatistics& source) {
+    if (!source.getMax().has_value()) {
+      return false;
+    }
+    if (!target.getMax().has_value()) {
+      return true;
+    }
+    if (std::isnan(*target.getMax())) {
+      return false;
+    }
+    if (std::isnan(*source.getMax())) {
+      return true;
+    }
+    return *source.getMax() > *target.getMax();
+  }
+
+  static void mergeFloatingPointMinMax(
+      ColumnStatistics& target,
+      const ColumnStatistics& source) {
+    auto* targetStats = target.as<FloatingPointStatistics>();
+    const auto* sourceStats = source.as<FloatingPointStatistics>();
+    if (shouldUseSourceFloatingPointMin(*targetStats, *sourceStats)) {
+      targetStats->min_ = sourceStats->getMin();
+    }
+    if (shouldUseSourceFloatingPointMax(*targetStats, *sourceStats)) {
+      targetStats->max_ = sourceStats->getMax();
+    }
+  }
+
+  static void mergeColumnStats(
+      ColumnStatistics& target,
+      const ColumnStatistics& source) {
+    NIMBLE_CHECK(
+        target.getType() == source.getType(),
+        "Merging stats with mismatched types: {} vs {}.",
+        static_cast<uint8_t>(target.getType()),
+        static_cast<uint8_t>(source.getType()));
+    // Deduplicated stats delegate their base metrics (value/null count, sizes)
+    // to the wrapped base statistics, so merge into that base rather than
+    // target's own (unused) member fields, and accumulate the dedup-specific
+    // counters separately.
+    if (target.getType() == StatType::DEDUPLICATED) {
+      auto* targetStats = target.as<DeduplicatedColumnStatistics>();
+      const auto* sourceStats = source.as<DeduplicatedColumnStatistics>();
+      targetStats->dedupedCount_ += sourceStats->getDedupedCount();
+      targetStats->dedupedLogicalSize_ += sourceStats->getDedupedLogicalSize();
+      auto* targetBase = targetStats->getBaseStatistics();
+      const auto* sourceBase = sourceStats->getBaseStatistics();
+      NIMBLE_CHECK(
+          (targetBase == nullptr) == (sourceBase == nullptr),
+          "Mismatched deduplicated stats structure during merge.");
+      if (targetBase != nullptr && sourceBase != nullptr) {
+        mergeColumnStats(*targetBase, *sourceBase);
+      }
+      return;
+    }
+
+    target.valueCount_ += source.getValueCount();
+    target.nullCount_ += source.getNullCount();
+    target.logicalSize_ += source.getLogicalSize();
+    target.physicalSize_ += source.getPhysicalSize();
+    switch (target.getType()) {
+      case StatType::INTEGRAL:
+        mergeMinMax<IntegralStatistics>(target, source);
+        break;
+      case StatType::FLOATING_POINT:
+        mergeFloatingPointMinMax(target, source);
+        break;
+      case StatType::STRING:
+        mergeMinMax<StringStatistics>(target, source);
+        break;
+      case StatType::DEFAULT:
+        break;
+      case StatType::DEDUPLICATED:
+        NIMBLE_UNREACHABLE("Deduplicated stats are handled above.");
+    }
+  }
+
+  void snapshotStripeStats() {
+    auto& stripe = stripeStats_.emplace_back();
+    stripe.reserve(statsCollectors_.size());
+    for (auto& collector : statsCollectors_) {
+      auto* stats = collector->shared()
+          ? collector->as<SharedStatisticsCollector>()->getBaseStatistics()
+          : collector->getStatsView();
+      stripe.push_back(stats->clone());
+    }
+  }
+
+  void resetStatsCollectors() {
+    // finalizeStatsCollector() wraps ancestors of deduplicated nodes into a
+    // DeduplicatedStatisticsCollector in place. That wrapping must be undone
+    // between stripes; otherwise the next stripe's finalization would take the
+    // "already deduplicated" branch and skip rolling child logical/physical
+    // sizes up into the ancestor, corrupting the file-level stats
+    // reconstruction. Genuine deduplicated nodes (configured at init via
+    // dictionary array / deduplicated map ids) must remain wrapped.
+    for (uint32_t id = 0; id < statsCollectors_.size(); ++id) {
+      auto& collector = statsCollectors_[id];
+      if (collector->getType() == StatType::DEDUPLICATED &&
+          !hasDictionaryArrayNodeId(id) && !hasDeduplicatedMapNodeId(id)) {
+        collector = collector->asChecked<DeduplicatedStatisticsCollector>()
+                        ->releaseBaseCollector();
+      }
+    }
+    for (auto& collector : statsCollectors_) {
+      collector->reset();
+    }
+    statsFinalized_ = false;
+  }
+
   void finalizeStatsCollector(
       const std::shared_ptr<const velox::dwio::common::TypeWithId>& type) {
     auto statsCollector = statsCollectors_[type->id()].get();
@@ -627,6 +806,8 @@ class FieldWriterContext {
   std::vector<std::pair<uint32_t, std::unique_ptr<StreamData>>> streams_;
   std::shared_ptr<const velox::dwio::common::TypeWithId> schemaWithId_;
   std::vector<std::unique_ptr<StatisticsCollector>> statsCollectors_;
+  std::vector<std::vector<std::unique_ptr<ColumnStatistics>>> stripeStats_;
+  std::vector<std::unique_ptr<ColumnStatistics>> fileStats_;
   bool statsFinalized_{false};
 };
 

--- a/dwio/nimble/velox/VeloxWriter.cpp
+++ b/dwio/nimble/velox/VeloxWriter.cpp
@@ -954,6 +954,7 @@ void VeloxWriter::writeMetadata() {
 }
 
 void VeloxWriter::writeColumnStats() {
+  context_->finalizeFileStatsFromStripes();
   // When enableStatsConsistencyCheck is true, verify that fileRawSize
   // (accumulated via RawSizeUtils) matches the root column statistics.
   if (context_->options().enableStatsConsistencyCheck) {
@@ -969,6 +970,12 @@ void VeloxWriter::writeColumnStats() {
     Buffer buffer{*encodingMemoryPool_};
     tabletWriter_->writeOptionalSection(
         std::string(kVectorizedStatsSection), fileStats.serialize(buffer));
+    VectorizedStripeStats stripeStats{
+        context_->stripeStats(), encodingMemoryPool_.get()};
+    Buffer stripeStatsBuffer{*encodingMemoryPool_};
+    tabletWriter_->writeOptionalSection(
+        std::string(kStripeStatsSection),
+        stripeStats.serialize(stripeStatsBuffer));
   } else {
     flatbuffers::FlatBufferBuilder builder;
     builder.Finish(
@@ -1086,9 +1093,6 @@ void VeloxWriter::close() {
     try {
       writeStripe();
       rootWriter_->close();
-      if (context_->options().enableStatsCollection) {
-        context_->finalizeStatsCollectors();
-      }
 
       writeMetadata();
       if (context_->options().enableStatsCollection) {
@@ -1552,6 +1556,9 @@ bool VeloxWriter::writeStripe() {
     writeChunks(streamIndices, /*ensureFullChunks=*/false, /*lastChunk=*/true);
   } else {
     writeStreams();
+  }
+  if (context_->options().enableStatsCollection) {
+    context_->finalizeStripeStatsCollectors();
   }
 
   uint64_t stripeSize{0};

--- a/dwio/nimble/velox/selective/ReaderBase.cpp
+++ b/dwio/nimble/velox/selective/ReaderBase.cpp
@@ -153,7 +153,22 @@ ReaderBase::ReaderBase(
           return {};
         }
         return fileStats->toColumnStatistics(fileSchema_, nimbleSchema_);
-      }()} {}
+      }()},
+      stripeColumnStats_{
+          [&]() -> std::vector<std::vector<std::unique_ptr<ColumnStatistics>>> {
+            auto statsSection =
+                tablet_->loadOptionalSection(std::string(kStripeStatsSection));
+            if (!statsSection.has_value()) {
+              return {};
+            }
+            auto stripeStats = VectorizedStripeStats::deserialize(
+                statsSection->content(), *pool_);
+            if (!stripeStats) {
+              return {};
+            }
+            return stripeStats->takeStripeColumnStatistics(
+                fileSchema_, nimbleSchema_);
+          }()} {}
 
 void LazyInput::load() {
   if (!loaded_) {

--- a/dwio/nimble/velox/selective/ReaderBase.h
+++ b/dwio/nimble/velox/selective/ReaderBase.h
@@ -118,6 +118,11 @@ class ReaderBase {
     return fileColumnStats_;
   }
 
+  const std::vector<std::vector<std::unique_ptr<ColumnStatistics>>>&
+  stripeColumnStats() const {
+    return stripeColumnStats_;
+  }
+
  private:
   ReaderBase(
       std::unique_ptr<velox::dwio::common::BufferedInput> input,
@@ -138,6 +143,8 @@ class ReaderBase {
   // File-level column statistics deserialized from the vectorized stats
   // optional section at construction.
   const std::vector<std::unique_ptr<ColumnStatistics>> fileColumnStats_;
+  const std::vector<std::vector<std::unique_ptr<ColumnStatistics>>>
+      stripeColumnStats_;
   mutable std::shared_ptr<const velox::dwio::common::TypeWithId>
       fileSchemaWithId_;
 };

--- a/dwio/nimble/velox/selective/SelectiveNimbleReader.cpp
+++ b/dwio/nimble/velox/selective/SelectiveNimbleReader.cpp
@@ -204,6 +204,8 @@ class SelectiveNimbleRowReader : public dwio::common::RowReader {
   // if stats are available.
   void computeStatsBasedRowSize() const;
 
+  bool shouldSkipStripe(uint32_t stripe) const;
+
   // Computes which top-level columns should use lazy I/O based on the scan
   // spec and remaining filter columns. Returns a const set used for the
   // lifetime of this reader.
@@ -272,7 +274,14 @@ int64_t SelectiveNimbleRowReader::nextRowNumber() {
           readerBase_->randomSkip()->nextSkip() >= numStripeRows) {
         readerBase_->randomSkip()->consume(numStripeRows);
         ++skippedStripes_;
-        goto advanceToNextStripe;
+        advanceToNextStripe();
+        continue;
+      }
+      if (shouldSkipStripe(currentStripe_)) {
+        maybeUpdateRandomSkip(numStripeRows);
+        ++skippedStripes_;
+        advanceToNextStripe();
+        continue;
       }
       loadCurrentStripe();
     }
@@ -284,7 +293,6 @@ int64_t SelectiveNimbleRowReader::nextRowNumber() {
       nextRowNumber_ = stripeRowOffsets_[currentStripe_] + rowInCurrentStripe_;
       return *nextRowNumber_;
     }
-  advanceToNextStripe:
     advanceToNextStripe();
   }
   // Update random skip tracker for trailing rows that were skipped due to upper
@@ -368,6 +376,60 @@ void SelectiveNimbleRowReader::computeStatsBasedRowSize() const {
   if (totalRows > 0) {
     statsBasedRowSize_ = std::max<size_t>(1, totalLogicalSize / totalRows);
   }
+}
+
+bool SelectiveNimbleRowReader::shouldSkipStripe(uint32_t stripe) const {
+  const auto& stripeStats = readerBase_->stripeColumnStats();
+  if (stripe >= stripeStats.size() || stripeStats[stripe].empty()) {
+    return false;
+  }
+  const auto& rootType = *readerBase_->fileSchemaWithId();
+  const auto& rowType = rootType.type()->asRow();
+  for (auto* childSpec : options_.scanSpec()->stableChildren()) {
+    if (!childSpec->hasFilter() || childSpec->filter() == nullptr ||
+        childSpec->isConstant() || !childSpec->readFromFile()) {
+      continue;
+    }
+    const auto columnIndex =
+        rowType.getChildIdxIfExists(childSpec->fieldName());
+    if (!columnIndex.has_value()) {
+      continue;
+    }
+    const auto& childType = rootType.childAt(columnIndex.value());
+    if (childType == nullptr) {
+      continue;
+    }
+    // Only top-level integral columns are pruned here. Use an explicit
+    // comparison rather than a switch over TypeKind to avoid -Wswitch-enum
+    // requiring every enumerator to be listed.
+    const auto kind = childType->type()->kind();
+    if (kind != TypeKind::TINYINT && kind != TypeKind::SMALLINT &&
+        kind != TypeKind::INTEGER && kind != TypeKind::BIGINT) {
+      continue;
+    }
+    // Per-stripe stats are laid out by schema type id: the writer snapshots
+    // statsCollectors_ (indexed by TypeWithId::id()) in order, so
+    // stripeStats[stripe][id] matches childType->id() just like the file-level
+    // column stats. The bound check below guards against a stats section that
+    // covers fewer columns than the current schema.
+    const auto columnId = childType->id();
+    if (columnId >= stripeStats[stripe].size() ||
+        !stripeStats[stripe][columnId]) {
+      continue;
+    }
+    const auto* integralStats =
+        stripeStats[stripe][columnId]->as<IntegralStatistics>();
+    if (integralStats == nullptr || !integralStats->getMin().has_value() ||
+        !integralStats->getMax().has_value()) {
+      continue;
+    }
+    const auto hasNull = integralStats->getNullCount() > 0;
+    if (!childSpec->filter()->testInt64Range(
+            *integralStats->getMin(), *integralStats->getMax(), hasNull)) {
+      return true;
+    }
+  }
+  return false;
 }
 
 std::optional<size_t> SelectiveNimbleRowReader::estimatedRowSize() const {

--- a/dwio/nimble/velox/selective/tests/SelectiveNimbleReaderTest.cpp
+++ b/dwio/nimble/velox/selective/tests/SelectiveNimbleReaderTest.cpp
@@ -129,14 +129,14 @@ class SelectiveNimbleReaderTest
   }
 
  protected:
-  static void SetUpTestCase() {
+  static void SetUpTestSuite() {
     if (!memory::MemoryManager::testInstance()) {
       memory::initializeMemoryManager(velox::memory::MemoryManager::Options{});
     }
     registerSelectiveNimbleReaderFactory();
   }
 
-  static void TearDownTestCase() {
+  static void TearDownTestSuite() {
     unregisterSelectiveNimbleReaderFactory();
   }
 
@@ -3397,6 +3397,94 @@ TEST_P(SelectiveNimbleReaderTest, deltaSawtoothSmallBatches) {
   validate(*input, *readers.rowReader, 7, [](auto) { return true; });
 }
 
+TEST_P(SelectiveNimbleReaderTest, stripeStatsPruneIntegralFilter) {
+  auto firstStripe = makeRowVector({
+      makeFlatVector<int64_t>(100, folly::identity),
+  });
+  auto secondStripe = makeRowVector({
+      makeFlatVector<int64_t>(100, [](auto row) { return 1000 + row; }),
+  });
+  auto input = makeRowVector({
+      makeFlatVector<int64_t>(
+          200, [](auto row) { return row < 100 ? row : 900 + row; }),
+  });
+
+  VeloxWriterOptions writerOptions;
+  writerOptions.enableVectorizedStats = true;
+  writerOptions.flushPolicyFactory = [] {
+    return std::make_unique<LambdaFlushPolicy>(
+        /*flushLambda=*/[](const StripeProgress&) { return true; });
+  };
+  auto fileContent = test::createNimbleFile(
+      *rootPool(), {firstStripe, secondStripe}, writerOptions, false);
+
+  auto scanSpec = std::make_shared<common::ScanSpec>("root");
+  scanSpec->addAllChildFields(*input->type());
+  scanSpec->childByName("c0")->setFilter(
+      std::make_unique<common::BigintRange>(10, 20, false));
+  auto readers =
+      makeReaders(input, fileContent, scanSpec, this->stringDecoderZeroCopy());
+
+  validate(*input, *readers.rowReader, 7, [](auto row) {
+    return row >= 10 && row <= 20;
+  });
+
+  dwio::common::RuntimeStatistics stats;
+  readers.rowReader->updateRuntimeStats(stats);
+  EXPECT_GT(stats.skippedStrides, 0);
+}
+
+// File-level stats for a deduplicated column are reconstructed by merging the
+// per-stripe snapshots. Writing identical data as two stripes exercises that
+// merge (including the per-stripe ancestor unwrapping), while writing it as a
+// single stripe needs no merge and serves as the oracle: the resulting
+// file-level column statistics must match.
+TEST_P(SelectiveNimbleReaderTest, stripeStatsMergeDeduplicatedArray) {
+  const std::vector<std::vector<int64_t>> firstRows{{1, 2}, {3, 4}, {1, 2}};
+  const std::vector<std::vector<int64_t>> secondRows{
+      {5, 6}, {5, 6}, {7, 8}, {9}};
+  std::vector<std::vector<int64_t>> allRows = firstRows;
+  allRows.insert(allRows.end(), secondRows.begin(), secondRows.end());
+
+  auto batch1 = makeRowVector({makeArrayVector<int64_t>(firstRows)});
+  auto batch2 = makeRowVector({makeArrayVector<int64_t>(secondRows)});
+  auto combined = makeRowVector({makeArrayVector<int64_t>(allRows)});
+
+  VeloxWriterOptions writerOptions;
+  writerOptions.enableVectorizedStats = true;
+  writerOptions.dictionaryArrayColumns = {"c0"};
+
+  auto multiStripeFile = test::createNimbleFile(
+      *rootPool(), {batch1, batch2}, writerOptions, /*flushAfterWrite=*/true);
+  auto singleStripeFile = test::createNimbleFile(
+      *rootPool(), combined, writerOptions, /*flushAfterWrite=*/false);
+
+  auto scanSpec = std::make_shared<common::ScanSpec>("root");
+  scanSpec->addAllChildFields(*combined->type());
+  auto multiReaders = makeReaders(
+      combined, multiStripeFile, scanSpec, this->stringDecoderZeroCopy());
+  auto singleReaders = makeReaders(
+      combined, singleStripeFile, scanSpec, this->stringDecoderZeroCopy());
+
+  // Column 1 is the deduplicated array; column 2 is its integral element.
+  for (uint32_t column : {1u, 2u}) {
+    auto multiStats = multiReaders.reader->columnStatistics(column);
+    auto singleStats = singleReaders.reader->columnStatistics(column);
+    ASSERT_NE(multiStats, nullptr);
+    ASSERT_NE(singleStats, nullptr);
+    ASSERT_TRUE(singleStats->getNumberOfValues().has_value());
+    ASSERT_TRUE(multiStats->getNumberOfValues().has_value());
+    EXPECT_EQ(
+        multiStats->getNumberOfValues().value(),
+        singleStats->getNumberOfValues().value())
+        << "column " << column;
+  }
+
+  // Independent oracle: the array column has one entry per row, no nulls.
+  auto arrayStats = multiReaders.reader->columnStatistics(1);
+  EXPECT_EQ(arrayStats->getNumberOfValues().value(), allRows.size());
+}
+
 // Verifies columnStatistics returns IntegerColumnStatistics for BIGINT columns
 // with correct value count and null status.
 TEST_P(SelectiveNimbleReaderTest, columnStatisticsInteger) {
@@ -3947,14 +4035,14 @@ INSTANTIATE_TEST_CASE_P(
 class SmallFilePreloadTest : public ::testing::Test,
                              public velox::test::VectorTestBase {
  protected:
-  static void SetUpTestCase() {
+  static void SetUpTestSuite() {
     if (!memory::MemoryManager::testInstance()) {
       memory::initializeMemoryManager(velox::memory::MemoryManager::Options{});
     }
     registerSelectiveNimbleReaderFactory();
   }
 
-  static void TearDownTestCase() {
+  static void TearDownTestSuite() {
     unregisterSelectiveNimbleReaderFactory();
   }
 };

--- a/dwio/nimble/velox/stats/ColumnStatistics.cpp
+++ b/dwio/nimble/velox/stats/ColumnStatistics.cpp
@@ -76,6 +76,11 @@ StatType ColumnStatistics::getType() const {
   return StatType::DEFAULT;
 }
 
+std::unique_ptr<ColumnStatistics> ColumnStatistics::clone() const {
+  return std::make_unique<ColumnStatistics>(
+      getValueCount(), getNullCount(), getLogicalSize(), getPhysicalSize());
+}
+
 std::unique_ptr<velox::dwio::common::ColumnStatistics>
 ColumnStatistics::toCommonStatistics() const {
   const auto valueCount = std::make_optional<uint64_t>(getValueCount());
@@ -154,6 +159,16 @@ StatType StringStatistics::getType() const {
   return StatType::STRING;
 }
 
+std::unique_ptr<ColumnStatistics> StringStatistics::clone() const {
+  return std::make_unique<StringStatistics>(
+      getValueCount(),
+      getNullCount(),
+      getLogicalSize(),
+      getPhysicalSize(),
+      getMin(),
+      getMax());
+}
+
 IntegralStatistics::IntegralStatistics(
     uint64_t valueCount,
     uint64_t nullCount,
@@ -175,6 +190,16 @@ std::optional<int64_t> IntegralStatistics::getMax() const {
 
 StatType IntegralStatistics::getType() const {
   return StatType::INTEGRAL;
+}
+
+std::unique_ptr<ColumnStatistics> IntegralStatistics::clone() const {
+  return std::make_unique<IntegralStatistics>(
+      getValueCount(),
+      getNullCount(),
+      getLogicalSize(),
+      getPhysicalSize(),
+      getMin(),
+      getMax());
 }
 
 FloatingPointStatistics::FloatingPointStatistics(
@@ -200,11 +225,30 @@ StatType FloatingPointStatistics::getType() const {
   return StatType::FLOATING_POINT;
 }
 
+std::unique_ptr<ColumnStatistics> FloatingPointStatistics::clone() const {
+  return std::make_unique<FloatingPointStatistics>(
+      getValueCount(),
+      getNullCount(),
+      getLogicalSize(),
+      getPhysicalSize(),
+      getMin(),
+      getMax());
+}
+
 DeduplicatedColumnStatistics::DeduplicatedColumnStatistics(
     ColumnStatistics* baseStatistics,
     uint64_t dedupedCount,
     uint64_t dedupedLogicalSize)
     : baseStatistics_{baseStatistics},
+      dedupedCount_{dedupedCount},
+      dedupedLogicalSize_{dedupedLogicalSize} {}
+
+DeduplicatedColumnStatistics::DeduplicatedColumnStatistics(
+    std::unique_ptr<ColumnStatistics> baseStatistics,
+    uint64_t dedupedCount,
+    uint64_t dedupedLogicalSize)
+    : ownedBaseStatistics_{std::move(baseStatistics)},
+      baseStatistics_{ownedBaseStatistics_.get()},
       dedupedCount_{dedupedCount},
       dedupedLogicalSize_{dedupedLogicalSize} {}
 
@@ -234,6 +278,14 @@ uint64_t DeduplicatedColumnStatistics::getDedupedLogicalSize() const {
 
 StatType DeduplicatedColumnStatistics::getType() const {
   return StatType::DEDUPLICATED;
+}
+
+std::unique_ptr<ColumnStatistics> DeduplicatedColumnStatistics::clone() const {
+  return std::make_unique<DeduplicatedColumnStatistics>(
+      baseStatistics_ == nullptr ? std::make_unique<ColumnStatistics>()
+                                 : baseStatistics_->clone(),
+      getDedupedCount(),
+      getDedupedLogicalSize());
 }
 
 ColumnStatistics* DeduplicatedColumnStatistics::getBaseStatistics() {
@@ -301,6 +353,10 @@ void StatisticsCollector::merge(const StatisticsCollector& other) {
   stats_->physicalSize_ += otherStats->getPhysicalSize();
 }
 
+void StatisticsCollector::reset() {
+  stats_ = std::make_unique<ColumnStatistics>();
+}
+
 /* static */ std::unique_ptr<StatisticsCollector> StatisticsCollector::create(
     const std::shared_ptr<const velox::dwio::common::TypeWithId>& type) {
   switch (type->type()->kind()) {
@@ -355,6 +411,10 @@ void IntegralStatisticsCollector::addValues(std::span<T> values) {
   if (!stats->max_.has_value() || max > *stats->max_) {
     stats->max_ = max;
   }
+}
+
+void IntegralStatisticsCollector::reset() {
+  stats_ = std::make_unique<IntegralStatistics>();
 }
 
 void IntegralStatisticsCollector::merge(const StatisticsCollector& other) {
@@ -425,6 +485,10 @@ void FloatingPointStatisticsCollector::addValues(std::span<T> values) {
   }
 }
 
+void FloatingPointStatisticsCollector::reset() {
+  stats_ = std::make_unique<FloatingPointStatistics>();
+}
+
 void FloatingPointStatisticsCollector::merge(const StatisticsCollector& other) {
   auto* otherStats = other.getStatsView();
   NIMBLE_CHECK(
@@ -485,6 +549,10 @@ void StringStatisticsCollector::addValues(std::span<std::string_view> values) {
   }
 }
 
+void StringStatisticsCollector::reset() {
+  stats_ = std::make_unique<StringStatistics>();
+}
+
 void StringStatisticsCollector::merge(const StatisticsCollector& other) {
   auto* otherStats = other.getStatsView();
   NIMBLE_CHECK(
@@ -528,21 +596,34 @@ DeduplicatedStatisticsCollector::wrap(
 }
 
 ColumnStatistics* DeduplicatedStatisticsCollector::getStatsView() {
-  // Return this as DeduplicatedColumnStatistics to resolve diamond ambiguity
+  NIMBLE_DCHECK_NOT_NULL(baseCollector_);
+  // Return this as DeduplicatedColumnStatistics to resolve diamond ambiguity.
   return stats_.get();
 }
 
 const ColumnStatistics* DeduplicatedStatisticsCollector::getStatsView() const {
+  NIMBLE_DCHECK_NOT_NULL(baseCollector_);
   return stats_.get();
 }
 
 StatisticsCollector* DeduplicatedStatisticsCollector::getBaseCollector() const {
+  NIMBLE_DCHECK_NOT_NULL(baseCollector_);
   return baseCollector_.get();
+}
+
+std::unique_ptr<StatisticsCollector>
+DeduplicatedStatisticsCollector::releaseBaseCollector() {
+  auto released = std::move(baseCollector_);
+  dedupedStats_ = nullptr;
+  stats_.reset();
+  return released;
 }
 
 void DeduplicatedStatisticsCollector::recordDeduplicatedStats(
     uint64_t count,
     uint64_t deduplicatedSize) {
+  NIMBLE_DCHECK_NOT_NULL(baseCollector_);
+  NIMBLE_DCHECK_NOT_NULL(dedupedStats_);
   dedupedStats_->dedupedCount_ += count;
   dedupedStats_->dedupedLogicalSize_ += deduplicatedSize;
 }
@@ -550,14 +631,17 @@ void DeduplicatedStatisticsCollector::recordDeduplicatedStats(
 void DeduplicatedStatisticsCollector::addCounts(
     uint64_t totalCount,
     uint64_t nullCount) {
+  NIMBLE_DCHECK_NOT_NULL(baseCollector_);
   baseCollector_->addCounts(totalCount, nullCount);
 }
 
 void DeduplicatedStatisticsCollector::addLogicalSize(uint64_t logicalSize) {
+  NIMBLE_DCHECK_NOT_NULL(baseCollector_);
   baseCollector_->addLogicalSize(logicalSize);
 }
 
 void DeduplicatedStatisticsCollector::addPhysicalSize(uint64_t physicalSize) {
+  NIMBLE_DCHECK_NOT_NULL(baseCollector_);
   baseCollector_->addPhysicalSize(physicalSize);
 }
 
@@ -573,6 +657,13 @@ void DeduplicatedStatisticsCollector::merge(const StatisticsCollector& other) {
   const auto& otherDedup =
       dynamic_cast<const DeduplicatedStatisticsCollector&>(other);
   baseCollector_->merge(*otherDedup.baseCollector_);
+}
+
+void DeduplicatedStatisticsCollector::reset() {
+  baseCollector_->reset();
+  stats_ = std::make_unique<DeduplicatedColumnStatistics>(
+      baseCollector_->getStatsView(), 0, 0);
+  dedupedStats_ = stats_->as<DeduplicatedColumnStatistics>();
 }
 
 SharedStatisticsCollector::SharedStatisticsCollector(
@@ -653,6 +744,11 @@ void SharedStatisticsCollector::updateBaseCollector(
 void SharedStatisticsCollector::merge(const StatisticsCollector& other) {
   std::lock_guard<std::mutex> l{mutex_};
   baseCollector_->merge(other);
+}
+
+void SharedStatisticsCollector::reset() {
+  std::lock_guard<std::mutex> l{mutex_};
+  baseCollector_->reset();
 }
 
 } // namespace facebook::nimble

--- a/dwio/nimble/velox/stats/ColumnStatistics.h
+++ b/dwio/nimble/velox/stats/ColumnStatistics.h
@@ -73,6 +73,8 @@ class ColumnStatistics {
 
   virtual StatType getType() const;
 
+  virtual std::unique_ptr<ColumnStatistics> clone() const;
+
   /// Converts this nimble ColumnStatistics to dwio::common::ColumnStatistics
   /// for use in file-level filter pushdown.
   std::unique_ptr<velox::dwio::common::ColumnStatistics> toCommonStatistics()
@@ -92,6 +94,7 @@ class ColumnStatistics {
 
  protected:
   friend class StatisticsCollector;
+  friend class FieldWriterContext;
 
   uint64_t valueCount_{0};
   uint64_t nullCount_{0};
@@ -115,8 +118,11 @@ class StringStatistics : public ColumnStatistics {
 
   StatType getType() const override;
 
+  std::unique_ptr<ColumnStatistics> clone() const override;
+
  protected:
   friend class StringStatisticsCollector;
+  friend class FieldWriterContext;
 
   std::optional<std::string> min_;
   std::optional<std::string> max_;
@@ -138,8 +144,11 @@ class IntegralStatistics : public ColumnStatistics {
 
   StatType getType() const override;
 
+  std::unique_ptr<ColumnStatistics> clone() const override;
+
  protected:
   friend class IntegralStatisticsCollector;
+  friend class FieldWriterContext;
 
   std::optional<int64_t> min_;
   std::optional<int64_t> max_;
@@ -161,8 +170,11 @@ class FloatingPointStatistics : public ColumnStatistics {
 
   StatType getType() const override;
 
+  std::unique_ptr<ColumnStatistics> clone() const override;
+
  protected:
   friend class FloatingPointStatisticsCollector;
+  friend class FieldWriterContext;
 
   std::optional<double> min_;
   std::optional<double> max_;
@@ -181,6 +193,10 @@ class DeduplicatedColumnStatistics : public virtual ColumnStatistics {
       ColumnStatistics* baseStatistics,
       uint64_t dedupedCount,
       uint64_t dedupedLogicalSize);
+  DeduplicatedColumnStatistics(
+      std::unique_ptr<ColumnStatistics> baseStatistics,
+      uint64_t dedupedCount,
+      uint64_t dedupedLogicalSize);
 
   // Getters delegate to baseStatistics_ for base metrics
   uint64_t getValueCount() const override;
@@ -193,13 +209,19 @@ class DeduplicatedColumnStatistics : public virtual ColumnStatistics {
 
   StatType getType() const override;
 
+  std::unique_ptr<ColumnStatistics> clone() const override;
+
   // Access the wrapped base statistics (e.g., to get min/max for
   // IntegralStatistics)
   ColumnStatistics* getBaseStatistics();
   const ColumnStatistics* getBaseStatistics() const;
 
+ private:
+  std::unique_ptr<ColumnStatistics> ownedBaseStatistics_;
+
  protected:
   friend class DeduplicatedStatisticsCollector;
+  friend class FieldWriterContext;
 
   ColumnStatistics* baseStatistics_;
   uint64_t dedupedCount_{0};
@@ -264,6 +286,7 @@ class StatisticsCollector {
   virtual void addPhysicalSize(uint64_t physicalSize);
 
   virtual void merge(const StatisticsCollector& other);
+  virtual void reset();
 
  protected:
   std::unique_ptr<ColumnStatistics> stats_;
@@ -277,6 +300,7 @@ class IntegralStatisticsCollector : public StatisticsCollector {
   void addValues(std::span<T> values);
 
   void merge(const StatisticsCollector& other) override;
+  void reset() override;
 
  private:
   // Helper to access stats_ as IntegralStatistics
@@ -291,6 +315,7 @@ class FloatingPointStatisticsCollector : public StatisticsCollector {
   void addValues(std::span<T> values);
 
   void merge(const StatisticsCollector& other) override;
+  void reset() override;
 
  private:
   // Helper to access stats_ as FloatingPointStatistics
@@ -303,6 +328,7 @@ class StringStatisticsCollector : public StatisticsCollector {
 
   void addValues(std::span<std::string_view> values);
   void merge(const StatisticsCollector& other) override;
+  void reset() override;
 
  private:
   // Helper to access stats_ as StringStatistics
@@ -327,9 +353,15 @@ class DeduplicatedStatisticsCollector : public StatisticsCollector {
   void addPhysicalSize(uint64_t physicalSize) override;
 
   StatisticsCollector* getBaseCollector() const;
+  // Releases ownership of the wrapped base collector. Used to undo an ancestor
+  // deduplicated wrapping that was applied during finalization so per-stripe
+  // finalization can start from an identical collector structure. After this
+  // call the deduplicated wrapper must be discarded.
+  std::unique_ptr<StatisticsCollector> releaseBaseCollector();
   void recordDeduplicatedStats(uint64_t count, uint64_t deduplicatedSize);
 
   void merge(const StatisticsCollector& other) override;
+  void reset() override;
 
  private:
   std::unique_ptr<StatisticsCollector> baseCollector_;
@@ -369,6 +401,7 @@ class SharedStatisticsCollector : public StatisticsCollector {
       std::function<void(StatisticsCollector*)> updateFunc);
 
   void merge(const StatisticsCollector& other) override;
+  void reset() override;
 
  private:
   mutable std::mutex mutex_;

--- a/dwio/nimble/velox/stats/VectorizedStatistics.cpp
+++ b/dwio/nimble/velox/stats/VectorizedStatistics.cpp
@@ -24,7 +24,8 @@ namespace facebook::nimble {
 
 namespace {
 constexpr static uint16_t kVectorizedStatsVersion = 0;
-}
+constexpr static uint16_t kVectorizedStripeStatsVersion = 0;
+} // namespace
 
 template <typename T>
 void TypedVectorizedStatistic<T>::append(std::optional<T> value) {
@@ -838,6 +839,128 @@ VectorizedFileStats::toColumnStatistics(
   auto schemaInfo = getSchemaInfo(schema, nimbleType);
   traverseSchema(schema, schemaInfo, statStreams_, statTypeCounts, columnStats);
   return columnStats;
+}
+
+VectorizedStripeStats::VectorizedStripeStats(
+    const std::vector<std::vector<std::unique_ptr<ColumnStatistics>>>&
+        stripeStats,
+    velox::memory::MemoryPool* pool)
+    : numStripes_{static_cast<uint32_t>(stripeStats.size())},
+      numColumns_{
+          numStripes_ == 0
+              ? 0
+              : static_cast<uint32_t>(stripeStats.front().size())} {
+  stripeFileStats_.reserve(numStripes_);
+  for (const auto& stripe : stripeStats) {
+    NIMBLE_CHECK_EQ(stripe.size(), numColumns_);
+    std::vector<ColumnStatistics*> columnStats;
+    columnStats.reserve(stripe.size());
+    for (const auto& stat : stripe) {
+      columnStats.push_back(stat.get());
+    }
+    stripeFileStats_.push_back(
+        std::make_unique<VectorizedFileStats>(columnStats, pool));
+  }
+}
+
+VectorizedStripeStats::VectorizedStripeStats(
+    uint32_t numStripes,
+    uint32_t numColumns,
+    std::vector<std::unique_ptr<VectorizedFileStats>> stripeFileStats)
+    : numStripes_{numStripes},
+      numColumns_{numColumns},
+      stripeFileStats_{std::move(stripeFileStats)} {}
+
+std::string_view VectorizedStripeStats::serialize(nimble::Buffer& buffer) {
+  Buffer statsBuffer{buffer.getMemoryPool()};
+  std::vector<std::string_view> stripePayloads;
+  stripePayloads.reserve(stripeFileStats_.size());
+  uint64_t totalLength = sizeof(uint16_t) + (2 * sizeof(uint32_t)) +
+      (stripeFileStats_.size() * sizeof(uint64_t));
+  for (auto& stripeFileStats : stripeFileStats_) {
+    auto payload = stripeFileStats->serialize(statsBuffer);
+    stripePayloads.push_back(payload);
+    totalLength += payload.size();
+  }
+
+  auto writeBuffer = buffer.reserve(totalLength);
+  auto pos = writeBuffer;
+  encoding::write<uint16_t>(kVectorizedStripeStatsVersion, pos);
+  encoding::write<uint32_t>(numStripes_, pos);
+  encoding::write<uint32_t>(numColumns_, pos);
+  for (const auto payload : stripePayloads) {
+    encoding::writeUint64(payload.size(), pos);
+  }
+  for (const auto payload : stripePayloads) {
+    std::memcpy(pos, payload.data(), payload.size());
+    pos += payload.size();
+  }
+  NIMBLE_CHECK_EQ(pos - writeBuffer, totalLength);
+  return {writeBuffer, totalLength};
+}
+
+std::unique_ptr<VectorizedStripeStats> VectorizedStripeStats::deserialize(
+    std::string_view payload,
+    velox::memory::MemoryPool& pool) {
+  const auto* pos = payload.data();
+  const auto* const end = pos + payload.size();
+
+  constexpr size_t kHeaderSize = sizeof(uint16_t) + (2 * sizeof(uint32_t));
+  NIMBLE_CHECK(
+      payload.size() >= kHeaderSize,
+      "Stripe stats payload too small for header");
+  const auto version = encoding::read<uint16_t>(pos);
+  NIMBLE_CHECK_EQ(version, kVectorizedStripeStatsVersion);
+  const auto numStripes = encoding::read<uint32_t>(pos);
+  const auto numColumns = encoding::read<uint32_t>(pos);
+
+  const size_t lengthsSize = static_cast<size_t>(numStripes) * sizeof(uint64_t);
+  NIMBLE_CHECK(
+      static_cast<size_t>(end - pos) >= lengthsSize,
+      "Stripe stats payload too small for stripe lengths");
+  std::vector<uint64_t> stripePayloadLengths;
+  stripePayloadLengths.reserve(numStripes);
+  for (uint32_t stripe = 0; stripe < numStripes; ++stripe) {
+    stripePayloadLengths.push_back(encoding::readUint64(pos));
+  }
+  std::vector<std::unique_ptr<VectorizedFileStats>> stripeFileStats;
+  stripeFileStats.reserve(numStripes);
+  for (const auto payloadLength : stripePayloadLengths) {
+    NIMBLE_CHECK(
+        static_cast<size_t>(end - pos) >= payloadLength,
+        "Stripe stats payload too small for stripe content");
+    stripeFileStats.push_back(
+        VectorizedFileStats::deserialize(
+            {pos, static_cast<size_t>(payloadLength)}, pool));
+    pos += payloadLength;
+  }
+  return std::unique_ptr<VectorizedStripeStats>(new VectorizedStripeStats(
+      numStripes, numColumns, std::move(stripeFileStats)));
+}
+
+const std::vector<std::vector<std::unique_ptr<ColumnStatistics>>>&
+VectorizedStripeStats::toStripeColumnStatistics(
+    const velox::TypePtr& schema,
+    const std::shared_ptr<const nimble::Type>& nimbleType) {
+  if (!stripeStats_.empty()) {
+    return stripeStats_;
+  }
+  NIMBLE_CHECK_EQ(stripeFileStats_.size(), numStripes_);
+  stripeStats_.reserve(numStripes_);
+  for (auto& stripeFileStats : stripeFileStats_) {
+    auto columnStats = stripeFileStats->toColumnStatistics(schema, nimbleType);
+    NIMBLE_CHECK_EQ(columnStats.size(), numColumns_);
+    stripeStats_.push_back(std::move(columnStats));
+  }
+  return stripeStats_;
+}
+
+std::vector<std::vector<std::unique_ptr<ColumnStatistics>>>
+VectorizedStripeStats::takeStripeColumnStatistics(
+    const velox::TypePtr& schema,
+    const std::shared_ptr<const nimble::Type>& nimbleType) {
+  toStripeColumnStatistics(schema, nimbleType);
+  return std::move(stripeStats_);
 }
 
 } // namespace facebook::nimble

--- a/dwio/nimble/velox/stats/VectorizedStatistics.h
+++ b/dwio/nimble/velox/stats/VectorizedStatistics.h
@@ -135,6 +135,8 @@ class VectorizedFileStats {
       const std::shared_ptr<const nimble::Type>& nimbleType);
 
  private:
+  friend class VectorizedStripeStats;
+
   VectorizedFileStats(
       const std::vector<StatStreamType>& streamTypes,
       const std::vector<uint64_t>& streamLengths,
@@ -161,6 +163,50 @@ class VectorizedFileStats {
           DataType dataType) -> std::unique_ptr<EncodingSelectionPolicyBase> {
     return encodingFactory.createPolicy(dataType);
   };
+};
+
+// Not thread-safe. toStripeColumnStatistics() lazily populates stripeStats_ as
+// a memoization cache on first call, so a single VectorizedStripeStats instance
+// must not be shared across threads. Readers construct one transiently and copy
+// the result out on a single thread (see ReaderBase).
+class VectorizedStripeStats {
+ public:
+  VectorizedStripeStats(
+      const std::vector<std::vector<std::unique_ptr<ColumnStatistics>>>&
+          stripeStats,
+      velox::memory::MemoryPool* pool);
+
+  std::string_view serialize(nimble::Buffer& buffer);
+
+  static std::unique_ptr<VectorizedStripeStats> deserialize(
+      std::string_view payload,
+      velox::memory::MemoryPool& pool);
+
+  // Lazily materializes and caches the per-stripe column statistics. Mutates
+  // stripeStats_ on first call; see the thread-safety note above.
+  const std::vector<std::vector<std::unique_ptr<ColumnStatistics>>>&
+  toStripeColumnStatistics(
+      const velox::TypePtr& schema,
+      const std::shared_ptr<const nimble::Type>& nimbleType);
+
+  // Materializes if needed, then transfers ownership of the cached stats to the
+  // caller. Use this for single-use extraction when the VectorizedStripeStats
+  // instance will be discarded afterward.
+  std::vector<std::vector<std::unique_ptr<ColumnStatistics>>>
+  takeStripeColumnStatistics(
+      const velox::TypePtr& schema,
+      const std::shared_ptr<const nimble::Type>& nimbleType);
+
+ private:
+  VectorizedStripeStats(
+      uint32_t numStripes,
+      uint32_t numColumns,
+      std::vector<std::unique_ptr<VectorizedFileStats>> stripeFileStats);
+
+  uint32_t numStripes_{0};
+  uint32_t numColumns_{0};
+  std::vector<std::unique_ptr<VectorizedFileStats>> stripeFileStats_;
+  std::vector<std::vector<std::unique_ptr<ColumnStatistics>>> stripeStats_;
 };
 
 } // namespace facebook::nimble

--- a/dwio/nimble/velox/stats/tests/ColumnStatisticsTests.cpp
+++ b/dwio/nimble/velox/stats/tests/ColumnStatisticsTests.cpp
@@ -277,6 +277,34 @@ TEST_F(ColumnStatisticsTests, StringStatisticsDefaultConstructor) {
   }
 }
 
+TEST_F(ColumnStatisticsTests, ClonePreservesScalarStatistics) {
+  IntegralStatistics integralStat(100, 10, 1000, 500, -50, 150);
+  auto integralClone = integralStat.clone();
+  auto* clonedIntegralStat = integralClone->as<IntegralStatistics>();
+  ASSERT_NE(clonedIntegralStat, nullptr);
+  EXPECT_EQ(clonedIntegralStat->getValueCount(), 100);
+  EXPECT_EQ(clonedIntegralStat->getNullCount(), 10);
+  EXPECT_EQ(clonedIntegralStat->getLogicalSize(), 1000);
+  EXPECT_EQ(clonedIntegralStat->getPhysicalSize(), 500);
+  EXPECT_EQ(clonedIntegralStat->getMin(), -50);
+  EXPECT_EQ(clonedIntegralStat->getMax(), 150);
+
+  FloatingPointStatistics floatingPointStat(20, 2, 200, 80, -1.5, 9.5);
+  auto floatingPointClone = floatingPointStat.clone();
+  auto* clonedFloatingPointStat =
+      floatingPointClone->as<FloatingPointStatistics>();
+  ASSERT_NE(clonedFloatingPointStat, nullptr);
+  EXPECT_EQ(clonedFloatingPointStat->getMin(), -1.5);
+  EXPECT_EQ(clonedFloatingPointStat->getMax(), 9.5);
+
+  StringStatistics stringStat(3, 0, 12, 8, "apple", "pear");
+  auto stringClone = stringStat.clone();
+  auto* clonedStringStat = stringClone->as<StringStatistics>();
+  ASSERT_NE(clonedStringStat, nullptr);
+  EXPECT_EQ(clonedStringStat->getMin(), "apple");
+  EXPECT_EQ(clonedStringStat->getMax(), "pear");
+}
+
 TEST_F(ColumnStatisticsTests, DeduplicatedColumnStatistics) {
   {
     DeduplicatedColumnStatistics stat;
@@ -537,6 +565,27 @@ TEST_F(StatisticsCollectorTests, MergeDefaultStatisticsCollectors) {
   EXPECT_EQ(collector1.getNullCount(), 30);
   EXPECT_EQ(collector1.getLogicalSize(), 3000);
   EXPECT_EQ(collector1.getPhysicalSize(), 1500);
+}
+
+TEST_F(StatisticsCollectorTests, ResetClearsScalarStatistics) {
+  IntegralStatisticsCollector collector;
+  collector.addCounts(4, 1);
+  std::vector<int64_t> values = {3, 7, -1};
+  collector.addValues(std::span<int64_t>(values));
+  ASSERT_NE(
+      collector.getStatsView()->as<IntegralStatistics>()->getMin(),
+      std::nullopt);
+
+  collector.reset();
+
+  auto* stats = collector.getStatsView()->as<IntegralStatistics>();
+  ASSERT_NE(stats, nullptr);
+  EXPECT_EQ(stats->getValueCount(), 0);
+  EXPECT_EQ(stats->getNullCount(), 0);
+  EXPECT_EQ(stats->getLogicalSize(), 0);
+  EXPECT_EQ(stats->getPhysicalSize(), 0);
+  EXPECT_EQ(stats->getMin(), std::nullopt);
+  EXPECT_EQ(stats->getMax(), std::nullopt);
 }
 
 TEST_F(StatisticsCollectorTests, IntegralStatisticsCollectorCtor) {

--- a/dwio/nimble/velox/stats/tests/VectorizedFileStatsTests.cpp
+++ b/dwio/nimble/velox/stats/tests/VectorizedFileStatsTests.cpp
@@ -508,6 +508,44 @@ TEST_F(VectorizedFileStatsTests, SchemaBasedRoundTripFlatRow) {
   expectStringStatisticsEqual(stringStat, *actualStringStat);
 }
 
+TEST_F(VectorizedFileStatsTests, StripeStatsRoundTripFlatRow) {
+  auto schema = velox::ROW({{"id", velox::BIGINT()}});
+  auto nimbleType = convertToNimbleType(*schema);
+
+  std::vector<std::vector<std::unique_ptr<ColumnStatistics>>> stripeStats;
+  auto& firstStripe = stripeStats.emplace_back();
+  firstStripe.push_back(std::make_unique<ColumnStatistics>(4, 0, 32, 16));
+  firstStripe.push_back(
+      std::make_unique<IntegralStatistics>(4, 0, 32, 16, 0, 3));
+  auto& secondStripe = stripeStats.emplace_back();
+  secondStripe.push_back(std::make_unique<ColumnStatistics>(4, 0, 32, 16));
+  secondStripe.push_back(
+      std::make_unique<IntegralStatistics>(4, 0, 32, 16, 100, 103));
+
+  VectorizedStripeStats vectorizedStripeStats(stripeStats, leafPool_.get());
+  nimble::Buffer buffer(*leafPool_);
+  const auto serialized = vectorizedStripeStats.serialize(buffer);
+  ASSERT_FALSE(serialized.empty());
+
+  auto deserialized =
+      VectorizedStripeStats::deserialize(serialized, *leafPool_);
+  const auto& roundTrippedStats =
+      deserialized->toStripeColumnStatistics(schema, nimbleType);
+  ASSERT_EQ(roundTrippedStats.size(), 2);
+  ASSERT_EQ(roundTrippedStats[0].size(), 2);
+  ASSERT_EQ(roundTrippedStats[1].size(), 2);
+
+  auto* firstStripeIdStats = roundTrippedStats[0][1]->as<IntegralStatistics>();
+  ASSERT_NE(firstStripeIdStats, nullptr);
+  EXPECT_EQ(firstStripeIdStats->getMin(), 0);
+  EXPECT_EQ(firstStripeIdStats->getMax(), 3);
+
+  auto* secondStripeIdStats = roundTrippedStats[1][1]->as<IntegralStatistics>();
+  ASSERT_NE(secondStripeIdStats, nullptr);
+  EXPECT_EQ(secondStripeIdStats->getMin(), 100);
+  EXPECT_EQ(secondStripeIdStats->getMax(), 103);
+}
+
 TEST_F(VectorizedFileStatsTests, SchemaBasedRoundTripNestedRow) {
   // Create a nested row schema
   auto schema = velox::ROW(


### PR DESCRIPTION
Summary:
Add a stripe-level vectorized stats optional section for Nimble files and use it in the selective reader to conservatively skip stripes for integral filters when min/max proves no rows can match.

The writer snapshots per-stripe column stats and reconstructs file-level stats by merging those snapshots, preserving a fallback path for files that do not emit stripe snapshots. The reader preloads and deserializes the new optional stats section while treating absent stats as a normal full-scan fallback.

Deduplicated columns are now handled correctly across stripes. mergeColumnStats merges into the wrapped base statistics (which back the delegating getters) and accumulates the dedup counters, instead of writing to unused fields. The per-stripe ancestor deduplication wrapping applied during finalization is undone between stripes (releasing the base collector) so every stripe finalizes from an identical collector structure; without this, stripe 1+ skipped the child logical-size rollup and the reconstructed file-level stats were wrong (tripping the raw-size consistency check). Genuine deduplicated nodes configured at init stay wrapped.

Differential Revision: D112143149


