### PR TITLE
feat(nimble): Add column-pruning Deserializer overload (#975)

### DIFF
--- a/dwio/nimble/serializer/Deserializer.cpp
+++ b/dwio/nimble/serializer/Deserializer.cpp
@@ -21,6 +21,7 @@
 #include "dwio/nimble/velox/SchemaUtils.h"
 #include "folly/Likely.h"
 #include "velox/buffer/Buffer.h"
+#include "velox/dwio/common/ColumnSelector.h"
 #include "velox/dwio/common/TypeWithId.h"
 
 #include <algorithm>
@@ -650,6 +651,46 @@ const StreamDescriptor& getMainDescriptor(const Type& type) {
   }
 }
 
+void checkColumnProjectionSubfield(
+    const RowType& row,
+    const Deserializer::Subfield& subfield) {
+  const auto& path = subfield.path();
+  NIMBLE_USER_CHECK(
+      subfield.valid(),
+      "Column projection deserialize requires a named subfield path: {}",
+      subfield);
+  auto childIndex = row.findChild(subfield.baseName());
+  NIMBLE_USER_CHECK(
+      childIndex.has_value(),
+      "Column projection subfield does not exist in schema: {}",
+      subfield);
+  const auto* nestedType = row.childAt(childIndex.value()).get();
+  for (size_t i = 1; i < path.size(); ++i) {
+    NIMBLE_USER_CHECK(
+        !nestedType->isFlatMap(),
+        "Column projection deserialize does not support FlatMap feature projection: {}",
+        subfield);
+    NIMBLE_USER_CHECK(
+        path[i]->is(velox::common::SubfieldKind::kNestedField),
+        "Column projection deserialize only supports named fields. Path: {}, element: {}",
+        subfield,
+        path[i]->toString());
+    NIMBLE_USER_CHECK(
+        nestedType->isRow(),
+        "Column projection deserialize only supports nested Row fields. Path: {}, type: {}",
+        subfield,
+        nestedType->kind());
+    const auto& nestedName =
+        path[i]->asChecked<velox::common::Subfield::NestedField>()->name();
+    childIndex = nestedType->asRow().findChild(nestedName);
+    NIMBLE_USER_CHECK(
+        childIndex.has_value(),
+        "Column projection subfield does not exist in schema: {}",
+        subfield);
+    nestedType = nestedType->asRow().childAt(childIndex.value()).get();
+  }
+}
+
 } // namespace
 
 FieldReaderParams Deserializer::createFieldReaderParams() const {
@@ -707,15 +748,54 @@ Deserializer::Deserializer(
     std::shared_ptr<const Type> schema,
     velox::memory::MemoryPool* pool,
     DeserializerOptions options)
-    : schema_{std::move(schema)}, pool_{pool}, options_{std::move(options)} {
+    : Deserializer{
+          std::move(schema),
+          /*selectedSubfields=*/{},
+          pool,
+          std::move(options)} {}
+
+Deserializer::Deserializer(
+    std::shared_ptr<const Type> schema,
+    const std::vector<Deserializer::Subfield>& selectedSubfields,
+    velox::memory::MemoryPool* pool,
+    DeserializerOptions options)
+    : schema_{std::move(schema)},
+      pool_{pool},
+      options_{std::move(options)},
+      columnProjectionEnabled_{!selectedSubfields.empty()} {
+  auto veloxType = convertToVeloxType(*schema_);
+  if (selectedSubfields.empty()) {
+    initialize(velox::dwio::common::TypeWithId::create(veloxType), [](auto) {
+      return true;
+    });
+    return;
+  }
+
+  auto rowType = velox::checkedPointerCast<const velox::RowType>(veloxType);
+  std::vector<std::string> projectedColumnPaths;
+  projectedColumnPaths.reserve(selectedSubfields.size());
+  for (const auto& subfield : selectedSubfields) {
+    checkColumnProjectionSubfield(schema_->asRow(), subfield);
+    projectedColumnPaths.emplace_back(subfield.toString());
+  }
+
+  auto selector = std::make_shared<velox::dwio::common::ColumnSelector>(
+      rowType, projectedColumnPaths);
+  auto schemaWithId = selector->getSchemaWithId();
+  initialize(schemaWithId, [selector](auto nodeId) {
+    return selector->shouldReadNode(nodeId);
+  });
+}
+
+void Deserializer::initialize(
+    const std::shared_ptr<const velox::dwio::common::TypeWithId>& schemaWithId,
+    const std::function<bool(uint32_t)>& isSelected) {
   const auto params = createFieldReaderParams();
   parser_ = std::make_unique<serde::StreamDataParser>(pool_, options_);
 
-  std::shared_ptr<const velox::dwio::common::TypeWithId> schemaWithId =
-      velox::dwio::common::TypeWithId::create(convertToVeloxType(*schema_));
   std::vector<uint32_t> offsets;
   rootFactory_ = FieldReaderFactory::create(
-      params, schema_, schemaWithId, offsets, [](auto) { return true; }, pool_);
+      params, schema_, schemaWithId, offsets, isSelected, pool_);
   SchemaReader::traverseSchema(schema_, [this](auto depth, auto& type, auto&) {
     createDeserializersForType(type, depth);
   });
@@ -730,6 +810,14 @@ Deserializer::Deserializer(
   deserializers_.resize(maxOffset + 1, nullptr);
   for (auto& [offset, decoder] : deserializerMap_) {
     deserializers_[offset] = decoder.get();
+  }
+
+  if (columnProjectionEnabled_) {
+    selectedStreamOffsetFlags_.resize(maxOffset + 1, false);
+    for (const auto offset : offsets) {
+      NIMBLE_CHECK_LE(offset, maxOffset, "Unexpected selected stream offset");
+      selectedStreamOffsetFlags_[offset] = true;
+    }
   }
   // Pre-size stream presence-tracking state once. Both vectors are bounded
   // by maxOffset because every value-stream anchor offset is a Type main
@@ -839,6 +927,10 @@ void Deserializer::appendStreamSegments(
   }
   parser_->iterateStreams([&](uint32_t offset, std::string_view streamData) {
     if (FOLLY_UNLIKELY(offset > maxStreamOffset)) {
+      return;
+    }
+    if (FOLLY_UNLIKELY(
+            columnProjectionEnabled_ && !selectedStreamOffsetFlags_[offset])) {
       return;
     }
     if (hasInMapChildren) {

--- a/dwio/nimble/serializer/Deserializer.h
+++ b/dwio/nimble/serializer/Deserializer.h
@@ -16,13 +16,20 @@
 #pragma once
 
 #include <cstdint>
+#include <functional>
 #include <limits>
+#include <vector>
 
 #include "dwio/nimble/serializer/Options.h"
 #include "dwio/nimble/velox/FieldReader.h"
 #include "folly/Range.h"
 #include "folly/container/F14Map.h"
+#include "velox/type/Subfield.h"
 #include "velox/vector/BaseVector.h"
+
+namespace facebook::velox::dwio::common {
+class TypeWithId;
+} // namespace facebook::velox::dwio::common
 
 namespace facebook::nimble {
 
@@ -39,6 +46,7 @@ class StreamDataParser;
 class Deserializer {
  public:
   using Options = DeserializerOptions;
+  using Subfield = velox::common::Subfield;
 
   Deserializer(
       std::shared_ptr<const Type> schema,
@@ -46,6 +54,17 @@ class Deserializer {
 
   Deserializer(
       std::shared_ptr<const Type> schema,
+      velox::memory::MemoryPool* pool,
+      DeserializerOptions options);
+
+  /// Builds a deserializer that reads selected subfields from a Row schema.
+  /// Empty selectedSubfields reads all fields.
+  /// Output keeps the original Row type, but fields not reached by
+  /// selectedSubfields are left unset. This does not support FlatMap feature
+  /// projection, schema compaction, or stream offset remapping.
+  Deserializer(
+      std::shared_ptr<const Type> schema,
+      const std::vector<Subfield>& selectedSubfields,
       velox::memory::MemoryPool* pool,
       DeserializerOptions options);
 
@@ -63,6 +82,13 @@ class Deserializer {
       velox::VectorPtr& output) const;
 
  private:
+  // Invoked by constructors to build parser, reader factory, reader, and stream
+  // decoders. `isSelected` is keyed by schemaWithId node id.
+  void initialize(
+      const std::shared_ptr<const velox::dwio::common::TypeWithId>&
+          schemaWithId,
+      const std::function<bool(uint32_t)>& isSelected);
+
   // Creates deserializers for a type and its FlatMap inMap streams.
   void createDeserializersForType(const Type& type, uint32_t depth);
 
@@ -107,6 +133,10 @@ class Deserializer {
   velox::memory::MemoryPool* const pool_;
   const DeserializerOptions options_;
 
+  // If column projection is enabled, only selected fields in the schema will be
+  // deserialized.
+  const bool columnProjectionEnabled_;
+
   // --- Non-const members (assigned in constructor body) ---
   std::unique_ptr<FieldReaderFactory> rootFactory_;
   std::unique_ptr<FieldReader> reader_;
@@ -120,8 +150,12 @@ class Deserializer {
   // Non-owning pointers; ownership stays in deserializerMap_.
   mutable std::vector<Decoder*> deserializers_;
 
-  // Maps FlatMap in-map stream offsets to their child value types. Used to
-  // reconstruct in-map streams omitted by older serializers.
+  // Stream offsets selected by the reader tree. Empty when column projection is
+  // disabled.
+  std::vector<bool> selectedStreamOffsetFlags_;
+
+  // --- FlatMap omitted in-map stream reconstruction ---
+  // Maps FlatMap in-map stream offsets to their child value types.
   folly::F14FastMap<uint32_t, const Type*> inMapChildTypes_;
 
   static constexpr uint32_t kInvalidInMapOffset =

--- a/dwio/nimble/serializer/tests/ProjectorTest.cpp
+++ b/dwio/nimble/serializer/tests/ProjectorTest.cpp
@@ -649,6 +649,297 @@ INSTANTIATE_TEST_SUITE_P(
 // Non-parameterized tests for special cases.
 class ProjectorTest : public ProjectorTestBase {};
 
+TEST_F(ProjectorTest, columnProjectionDeserializerKeepsOriginalShape) {
+  auto type = ROW({
+      {"a", INTEGER()},
+      {"b", BIGINT()},
+      {"c", VARCHAR()},
+  });
+
+  auto vec = makeSimpleRowVector(
+      {"a", "b", "c"},
+      {
+          makeIntVector<int32_t>({1, 2, 3}),
+          makeIntVector<int64_t>({100, 200, 300}),
+          makeStringVector({"x", "y", "z"}),
+      });
+
+  auto serialized =
+      serialize(vec, type, {.version = SerializationVersion::kSerialization});
+  auto inputSchema =
+      getNimbleSchema(type, {.version = SerializationVersion::kSerialization});
+
+  Deserializer deserializer{
+      inputSchema, makeSubfields({"b"}), pool_.get(), {.hasHeader = true}};
+  VectorPtr output;
+  deserializer.deserialize(serialized, output);
+
+  ASSERT_EQ(output->size(), 3);
+  auto* row = output->as<RowVector>();
+  ASSERT_NE(row, nullptr);
+  ASSERT_EQ(row->children().size(), 3);
+
+  EXPECT_EQ(row->childAt(0), nullptr);
+
+  auto* b = row->childAt(1)->as<FlatVector<int64_t>>();
+  ASSERT_NE(b, nullptr);
+  EXPECT_EQ(b->valueAt(0), 100);
+  EXPECT_EQ(b->valueAt(1), 200);
+  EXPECT_EQ(b->valueAt(2), 300);
+
+  EXPECT_EQ(row->childAt(2), nullptr);
+}
+
+TEST_F(ProjectorTest, columnProjectionDeserializerCanBeReused) {
+  auto type = ROW({
+      {"a", INTEGER()},
+      {"b", BIGINT()},
+  });
+
+  auto inputSchema =
+      getNimbleSchema(type, {.version = SerializationVersion::kSerialization});
+  Deserializer deserializer{
+      inputSchema, makeSubfields({"b"}), pool_.get(), {.hasHeader = true}};
+
+  auto makeInput = [&](const std::vector<int32_t>& aValues,
+                       const std::vector<int64_t>& bValues) {
+    return serialize(
+        makeSimpleRowVector(
+            {"a", "b"},
+            {
+                makeIntVector<int32_t>(aValues),
+                makeIntVector<int64_t>(bValues),
+            }),
+        type,
+        {.version = SerializationVersion::kSerialization});
+  };
+
+  VectorPtr firstOutput;
+  deserializer.deserialize(makeInput({1, 2}, {100, 200}), firstOutput);
+  auto* firstRow = firstOutput->as<RowVector>();
+  ASSERT_NE(firstRow, nullptr);
+  EXPECT_EQ(firstRow->childAt(0), nullptr);
+  auto* firstB = firstRow->childAt(1)->as<FlatVector<int64_t>>();
+  ASSERT_NE(firstB, nullptr);
+  EXPECT_EQ(firstB->valueAt(0), 100);
+  EXPECT_EQ(firstB->valueAt(1), 200);
+
+  VectorPtr secondOutput;
+  deserializer.deserialize(makeInput({3, 4, 5}, {300, 400, 500}), secondOutput);
+  auto* secondRow = secondOutput->as<RowVector>();
+  ASSERT_NE(secondRow, nullptr);
+  EXPECT_EQ(secondRow->childAt(0), nullptr);
+  auto* secondB = secondRow->childAt(1)->as<FlatVector<int64_t>>();
+  ASSERT_NE(secondB, nullptr);
+  EXPECT_EQ(secondB->valueAt(0), 300);
+  EXPECT_EQ(secondB->valueAt(1), 400);
+  EXPECT_EQ(secondB->valueAt(2), 500);
+}
+
+TEST_F(ProjectorTest, columnProjectionDeserializerProjectsNestedFields) {
+  auto type = ROW({
+      {"outer",
+       ROW({
+           {"inner1", INTEGER()},
+           {"inner2", VARCHAR()},
+       })},
+      {"other", BIGINT()},
+  });
+
+  auto outer = makeSimpleRowVector(
+      {"inner1", "inner2"},
+      {
+          makeIntVector<int32_t>({10, 20}),
+          makeStringVector({"a", "b"}),
+      });
+  auto vec = makeSimpleRowVector(
+      {"outer", "other"},
+      {
+          outer,
+          makeIntVector<int64_t>({100, 200}),
+      });
+
+  auto serialized =
+      serialize(vec, type, {.version = SerializationVersion::kSerialization});
+  auto inputSchema =
+      getNimbleSchema(type, {.version = SerializationVersion::kSerialization});
+
+  Deserializer deserializer{
+      inputSchema,
+      makeSubfields({"outer.inner1"}),
+      pool_.get(),
+      {.hasHeader = true}};
+  VectorPtr output;
+  deserializer.deserialize(serialized, output);
+
+  ASSERT_EQ(output->size(), 2);
+  auto* row = output->as<RowVector>();
+  ASSERT_NE(row, nullptr);
+  ASSERT_EQ(row->children().size(), 2);
+
+  auto* outerRow = row->childAt(0)->as<RowVector>();
+  ASSERT_NE(outerRow, nullptr);
+  ASSERT_EQ(outerRow->children().size(), 2);
+
+  auto* inner1 = outerRow->childAt(0)->as<FlatVector<int32_t>>();
+  ASSERT_NE(inner1, nullptr);
+  EXPECT_EQ(inner1->valueAt(0), 10);
+  EXPECT_EQ(inner1->valueAt(1), 20);
+
+  EXPECT_EQ(outerRow->childAt(1), nullptr);
+
+  EXPECT_EQ(row->childAt(1), nullptr);
+}
+
+TEST_F(
+    ProjectorTest,
+    columnProjectionDeserializerEmptySelectionReadsAllFields) {
+  auto type = ROW({
+      {"a", INTEGER()},
+      {"b", BIGINT()},
+  });
+
+  auto vec = makeSimpleRowVector(
+      {"a", "b"},
+      {
+          makeIntVector<int32_t>({1, 2, 3}),
+          makeIntVector<int64_t>({100, 200, 300}),
+      });
+
+  auto serialized =
+      serialize(vec, type, {.version = SerializationVersion::kSerialization});
+  auto inputSchema =
+      getNimbleSchema(type, {.version = SerializationVersion::kSerialization});
+
+  Deserializer deserializer{inputSchema, {}, pool_.get(), {.hasHeader = true}};
+  VectorPtr output;
+  deserializer.deserialize(serialized, output);
+
+  ASSERT_EQ(output->size(), 3);
+  auto* row = output->as<RowVector>();
+  ASSERT_NE(row, nullptr);
+  ASSERT_EQ(row->children().size(), 2);
+
+  auto* a = row->childAt(0)->as<FlatVector<int32_t>>();
+  ASSERT_NE(a, nullptr);
+  EXPECT_EQ(a->valueAt(0), 1);
+  EXPECT_EQ(a->valueAt(1), 2);
+  EXPECT_EQ(a->valueAt(2), 3);
+
+  auto* b = row->childAt(1)->as<FlatVector<int64_t>>();
+  ASSERT_NE(b, nullptr);
+  EXPECT_EQ(b->valueAt(0), 100);
+  EXPECT_EQ(b->valueAt(1), 200);
+  EXPECT_EQ(b->valueAt(2), 300);
+}
+
+TEST_F(ProjectorTest, columnProjectionDeserializerReadsTopLevelFlatMap) {
+  auto type = ROW({
+      {"id", BIGINT()},
+      {"features", MAP(INTEGER(), DOUBLE())},
+  });
+
+  const vector_size_t numRows = 1;
+  auto ids = makeIntVector<int64_t>({100});
+  auto mapOffsets = allocateOffsets(numRows, pool_.get());
+  auto mapSizes = allocateSizes(numRows, pool_.get());
+  mapOffsets->asMutable<vector_size_t>()[0] = 0;
+  mapSizes->asMutable<vector_size_t>()[0] = 1;
+
+  auto mapVector = std::make_shared<MapVector>(
+      pool_.get(),
+      MAP(INTEGER(), DOUBLE()),
+      nullptr,
+      numRows,
+      mapOffsets,
+      mapSizes,
+      makeIntVector<int32_t>({1}),
+      BaseVector::create<FlatVector<double>>(DOUBLE(), 1, pool_.get()));
+  mapVector->mapValues()->as<FlatVector<double>>()->set(0, 1.5);
+
+  auto vec = std::make_shared<RowVector>(
+      pool_.get(),
+      type,
+      nullptr,
+      numRows,
+      std::vector<VectorPtr>{ids, mapVector});
+
+  auto [serialized, inputSchema] = serializeWithSchema(
+      vec,
+      type,
+      {
+          .version = SerializationVersion::kSerialization,
+          .flatMapColumns = {{"features", {}}},
+      });
+
+  Deserializer deserializer{
+      inputSchema,
+      makeSubfields({"features"}),
+      pool_.get(),
+      {.hasHeader = true}};
+  VectorPtr output;
+  deserializer.deserialize(serialized, output);
+
+  ASSERT_EQ(output->size(), numRows);
+  auto* row = output->as<RowVector>();
+  ASSERT_NE(row, nullptr);
+  ASSERT_EQ(row->children().size(), 2);
+  EXPECT_EQ(row->childAt(0), nullptr);
+
+  auto* features = row->childAt(1)->as<MapVector>();
+  ASSERT_NE(features, nullptr);
+  ASSERT_EQ(features->sizeAt(0), 1);
+  const auto offset = features->offsetAt(0);
+  auto* keys = features->mapKeys()->as<FlatVector<int32_t>>();
+  auto* values = features->mapValues()->as<FlatVector<double>>();
+  ASSERT_NE(keys, nullptr);
+  ASSERT_NE(values, nullptr);
+  EXPECT_EQ(keys->valueAt(offset), 1);
+  EXPECT_DOUBLE_EQ(values->valueAt(offset), 1.5);
+}
+
+TEST_F(ProjectorTest, columnProjectionDeserializerRejectsFlatMapFeature) {
+  auto type = ROW({
+      {"features", MAP(INTEGER(), DOUBLE())},
+  });
+
+  const vector_size_t numRows = 1;
+  auto mapOffsets = allocateOffsets(numRows, pool_.get());
+  auto mapSizes = allocateSizes(numRows, pool_.get());
+  mapOffsets->asMutable<vector_size_t>()[0] = 0;
+  mapSizes->asMutable<vector_size_t>()[0] = 1;
+
+  auto mapVector = std::make_shared<MapVector>(
+      pool_.get(),
+      MAP(INTEGER(), DOUBLE()),
+      nullptr,
+      numRows,
+      mapOffsets,
+      mapSizes,
+      makeIntVector<int32_t>({1}),
+      BaseVector::create<FlatVector<double>>(DOUBLE(), 1, pool_.get()));
+  mapVector->mapValues()->as<FlatVector<double>>()->set(0, 1.5);
+
+  auto vec = std::make_shared<RowVector>(
+      pool_.get(), type, nullptr, numRows, std::vector<VectorPtr>{mapVector});
+
+  auto [_, inputSchema] = serializeWithSchema(
+      vec,
+      type,
+      {
+          .version = SerializationVersion::kSerialization,
+          .flatMapColumns = {{"features", {}}},
+      });
+
+  NIMBLE_ASSERT_USER_THROW(
+      Deserializer(
+          inputSchema,
+          makeSubfields({"features[\"1\"]"}),
+          pool_.get(),
+          {.hasHeader = true}),
+      "Column projection deserialize does not support FlatMap feature projection");
+}
+
 // Test that incompatible format combinations are rejected at projection time.
 TEST_F(ProjectorTest, incompatibleFormatsRejected) {
   auto type = ROW({

--- a/dwio/nimble/velox/FieldReader.cpp
+++ b/dwio/nimble/velox/FieldReader.cpp
@@ -2381,7 +2381,6 @@ class RowFieldReader final : public FieldReader {
     }
 
     for (auto& reader : childrenReaders_) {
-      // Non selected fields are set to null.
       if (reader == nullptr) {
         continue;
       }


### PR DESCRIPTION
Summary:


Adds a column-pruning Deserializer constructor that accepts selected Velox Subfields and builds a reader tree for only those Row fields.

So that deserializer can directly uses as 
```
weightDeserializer = std::make_unique<nimble::Deserializer>(
        nimbleInputSchema_,
        buildWeightProjectSubfields(),
        newState->leafPool.get(),
        weightSelectorOptions,
        weightDeserializerOptions);
  }
...
nimble.weightDeserializer->deserialize(rawValues, nimble.weightVector);
```

Differential Revision: D112019764


