### PR TITLE
feat(nimble): Override currentStripe() on SelectiveNimbleRowReader (#976)

### DIFF
--- a/dwio/nimble/velox/selective/SelectiveNimbleReader.cpp
+++ b/dwio/nimble/velox/selective/SelectiveNimbleReader.cpp
@@ -160,6 +160,8 @@ class SelectiveNimbleRowReader : public dwio::common::RowReader {
 
   bool allPrefetchIssued() const final;
 
+  uint32_t currentStripe() const override;
+
  private:
   // Initializes the stripe range to read based on row offset bounds
   // specified in options. Sets startStripe_ and endStripe_.
@@ -300,6 +302,10 @@ void SelectiveNimbleRowReader::advanceToNextStripe() {
   ++currentStripe_;
   rowInCurrentStripe_ = 0;
   endRowInCurrentStripe_.reset();
+}
+
+uint32_t SelectiveNimbleRowReader::currentStripe() const {
+  return static_cast<uint32_t>(currentStripe_);
 }
 
 int64_t SelectiveNimbleRowReader::nextReadSize(uint64_t size) {

--- a/dwio/nimble/velox/selective/tests/SelectiveNimbleReaderTest.cpp
+++ b/dwio/nimble/velox/selective/tests/SelectiveNimbleReaderTest.cpp
@@ -719,6 +719,17 @@ TEST_P(SelectiveNimbleReaderTest, basic) {
   });
 }
 
+TEST_P(SelectiveNimbleReaderTest, currentStripe) {
+  const bool stringDecoderZeroCopy = this->stringDecoderZeroCopy();
+  auto input = makeRowVector({
+      makeFlatVector<int64_t>(200, folly::identity),
+  });
+  auto scanSpec = std::make_shared<common::ScanSpec>("root");
+  scanSpec->addAllChildFields(*input->type());
+  auto readers = makeReaders(input, scanSpec, stringDecoderZeroCopy);
+  EXPECT_EQ(readers.rowReader->currentStripe(), 0u);
+}
+
 TEST_P(SelectiveNimbleReaderTest, denseWithNulls) {
   const bool stringDecoderZeroCopy = this->stringDecoderZeroCopy();
   auto input = makeRowVector({


### PR DESCRIPTION
Summary:

Overrides `currentStripe()` on `SelectiveNimbleRowReader` to expose the currently loaded stripe index.

Reviewed By: xiaoxmeng

Differential Revision: D112177582


