### PR TITLE
refactor(selective): Pick dict-filter null source by read shape (#978)

### DIFF
--- a/dwio/nimble/velox/selective/StringColumnReader.cpp
+++ b/dwio/nimble/velox/selective/StringColumnReader.cpp
@@ -84,6 +84,11 @@ namespace {
 // outIndices/outRows (caller-sized to at least numValues) and returns the
 // non-null count. A null 'nulls' bitmap means no nulls, so every entry is
 // copied. Pure: touches no reader member state.
+//
+// 'indices'/'rows'/'nulls' are consumed only over [0, numValues). The caller
+// passes the full read-range 'rows', which on the abandon path is longer than
+// numValues (the materialized dictionary prefix); positions >= numValues belong
+// to the non-dict chunk and are never read here.
 int32_t extractNonNullEntries(
     const int32_t* indices,
     const velox::RowSet& rows,
@@ -137,24 +142,31 @@ int32_t filterByCache(
 
 } // namespace
 
-void StringColumnReader::ensureWritableResultNulls(velox::vector_size_t size) {
-  if (!returnReaderNulls_) {
-    // Non-dense reads already hold an output-indexed resultNulls_ allocated by
-    // prepareRead/prepareNulls; nothing to do.
-    return;
-  }
-  // Dense reads with nulls park the null flags in nullsInReadRange_ and return
-  // them directly (returnReaderNulls_). The dict-filter path pre-compacts
-  // values, so it must instead write compacted output nulls into resultNulls_.
-  // Mirror compactScalarValues' allocation and switch the fast path off.
-  if (!(resultNulls_ && resultNulls_->unique() &&
-        resultNulls_->capacity() >=
-            velox::bits::nbytes(size) + velox::simd::kPadding)) {
-    resultNulls_ = velox::AlignedBuffer::allocate<bool>(
-        size + velox::simd::kPadding * 8, pool_);
-    rawResultNulls_ = resultNulls_->asMutable<uint64_t>();
-  }
-  returnReaderNulls_ = false;
+// TODO(T280425209): Delete this method (and its two call sites in
+// filterDictionaryIndices) once these guards have baked in prod without firing
+// — the fixup they replaced is dead on the dict-filter path.
+void StringColumnReader::checkWritableResultNulls(velox::vector_size_t size) {
+  // Invariant guard, not fixup. Picking the null source by read shape (dense:
+  // nullsInReadRange_; sparse: resultNulls_) means the dict-filter path never
+  // needs to convert the dense reader-nulls fast path into a compacted buffer:
+  // the suppressed-filter bulk read leaves hasFilter() cached true, so
+  // setReturnNullsMode always resolves returnReaderNulls_ to false here, and
+  // prepareResultNulls has already allocated a unique, output-indexed
+  // resultNulls_ sized for the read range. These are NIMBLE_CHECKs (prod
+  // signals, not DCHECK): a fire means that invariant regressed and the
+  // buffer-fixup this method used to perform must be restored before compacted
+  // nulls get written into the wrong (fast-path) buffer.
+  NIMBLE_CHECK(
+      !returnReaderNulls_,
+      "dict-filter path must not run on the dense reader-nulls fast path");
+  NIMBLE_CHECK_NOT_NULL(resultNulls_);
+  NIMBLE_CHECK_NOT_NULL(rawResultNulls_);
+  NIMBLE_CHECK(
+      resultNulls_->unique(),
+      "resultNulls_ must be uniquely owned before writing compacted nulls");
+  NIMBLE_CHECK_GE(
+      resultNulls_->capacity(),
+      velox::bits::nbytes(size) + velox::simd::kPadding);
 }
 
 void StringColumnReader::filterDictionaryIndices(
@@ -163,18 +175,38 @@ void StringColumnReader::filterDictionaryIndices(
   NIMBLE_CHECK_NOT_NULL(filter);
   ensureFilterCache();
 
+  // readCount bounds every pass below to the dictionary indices actually
+  // materialized into rawValues_. On the abandon path this is a prefix of the
+  // read range: 'rows' extends past readCount into the non-dict chunk, but
+  // those rows carry no dictionary index here (they are filtered by the flat
+  // continuation in read()), so extractNonNullEntries/processNullAndPassingRows
+  // only ever touch rawValues_/rows/nulls over [0, readCount).
   const auto readCount = numValues_;
   constexpr int32_t kSimdPadding = xsimd::batch<int32_t>::size;
   std::vector<int32_t> nonNullIndices(readCount + kSimdPadding, 0);
   std::vector<int32_t> nonNullRows(readCount + kSimdPadding, 0);
-  // The dict indices in rawValues_ are output-indexed, so the null check must
-  // use the output-indexed bitmap. resultNulls() is the single source of truth
-  // for it (nullsInReadRange_ for dense reads, resultNulls_ for non-dense). Use
-  // it instead of rawNullsInReadRange(), which is file-indexed and wrong for
-  // non-dense reads (nested-under-nullable, cross-stripe, sibling-filter).
-  const auto& resultNullsBuffer = resultNulls();
-  const auto* nulls =
-      resultNullsBuffer ? resultNullsBuffer->as<uint64_t>() : nullptr;
+  // A dense read is exactly rows == [0, rows.size()) — the same shape
+  // StringColumnReadWithVisitorHelper used to instantiate the dense/sparse
+  // ColumnVisitor, so it matches where the bulk read stored the output nulls.
+  // On the abandon path only rows[0, numValues_) were materialized, but the
+  // null buffer was still chosen from the full range, so isDense is derived
+  // from the full rows here as well.
+  const bool isDense = !rows.empty() && rows.back() == rows.size() - 1;
+  // The dict indices in rawValues_ are output-indexed, so the null check needs
+  // an output-indexed bitmap. The deferred-filter bulk read leaves
+  // anyNulls_/returnReaderNulls_ unset for the filtered read, so pick the
+  // source by read shape rather than routing through resultNulls(): a dense
+  // read keeps its nulls in nullsInReadRange_ (output == read range, so it is
+  // output-aligned), while a sparse read has them in the resultNulls_ buffer
+  // that readSparseMaterializedIndices built and compacted inline
+  // (rawNullsInReadRange is file-indexed and wrong for the sparse case).
+  const uint64_t* nulls;
+  if (isDense) {
+    nulls = rawNullsInReadRange();
+  } else {
+    const auto& resultNullsBuffer = resultNulls();
+    nulls = resultNullsBuffer ? resultNullsBuffer->as<uint64_t>() : nullptr;
+  }
 
   const auto numNonNull = extractNonNullEntries(
       reinterpret_cast<const int32_t*>(rawValues_),
@@ -222,7 +254,7 @@ void StringColumnReader::filterDictionaryIndices(
         reinterpret_cast<int32_t*>(rawValues_),
         outputRows);
     outputRows_.resize(numValues_);
-    ensureWritableResultNulls(readCount);
+    checkWritableResultNulls(readCount);
     velox::bits::fillBits(
         rawResultNulls_, 0, numValues_, velox::bits::kNotNull);
     return;
@@ -244,7 +276,7 @@ void StringColumnReader::filterDictionaryIndices(
       passIndices.data(),
       passRows.data());
 
-  ensureWritableResultNulls(readCount);
+  checkWritableResultNulls(readCount);
   auto* indices = reinterpret_cast<int32_t*>(rawValues_);
   auto* outputRows = mutableOutputRows(readCount);
   numValues_ = processNullAndPassingRows(
@@ -273,8 +305,11 @@ velox::vector_size_t StringColumnReader::processNullAndPassingRows(
   for (velox::vector_size_t i = 0; i < readCount; ++i) {
     if (velox::bits::isBitNull(nulls, i)) {
       // Null row: passes because the filter accepts nulls. The index is
-      // unused for a null position; write 0 as a safe placeholder.
+      // unused for a null position; write 0 as a safe placeholder. Record that
+      // the output carries a null (the deferred-filter path removed the
+      // reconciliation block that used to set anyNulls_).
       velox::bits::setNull(rawResultNulls_, count, /*isNull=*/true);
+      anyNulls_ = true;
       indices[count] = 0;
       outputRows[count] = rows[i];
       ++count;
@@ -470,44 +505,15 @@ bool StringColumnReader::readWithDictionary(
     scanSpec_->setFilter(std::move(savedFilter));
   }
 
-  // Reconcile the reader's null state after the bulk dictionary read, for
-  // DENSE reads only. A dense read records its nulls in nullsInReadRange_
-  // (fresh per read, output==file), but the bulk index path (unlike the
-  // per-row processNull path) does not set anyNulls_/returnReaderNulls_;
-  // without this, resultNulls() reports no nulls and
-  // filterDictionaryIndices/getValues read the uninitialized index slots at
-  // null positions. Set returnReaderNulls_ directly rather than via
-  // resolveReturnNullBuffer(), which forces it false for filtered reads.
-  //
-  // Non-dense reads are intentionally NOT reconciled here: they set anyNulls_
-  // via their own per-row processNull path, and their resultNulls_ must not
-  // be inspected — it is populated lazily (only when a null is hit), so a
-  // no-null non-dense read leaves it stale from a prior read and would
-  // falsely report nulls, marking non-null rows null.
-  //
-  // Contract this couples to (keep in sync with SelectiveColumnReader): a
-  // dense read is exactly rows == [0, rows.size()), the same test the
-  // framework's useBulkPath()/resolveReturnNullBuffer() apply; and for a
-  // dense bulk read with nulls, resultNulls() must return nullsInReadRange_
-  // (returnReaderNulls_ == true). resolveReturnNullBuffer() would establish
-  // that, but it forces the flag false whenever a filter is present, so we
-  // set it directly here. Revisit if the framework changes how
-  // returnReaderNulls_ is derived for dense reads.
-  //
-  // Applied regardless of abandonDictionary: the dict portion's indices
-  // must be filtered before either getValues() (normal path) or
-  // abandonDictionaryEncoding() (abandon path).
-  const bool isDense = !rows.empty() && rows.back() == rows.size() - 1;
-  if (!anyNulls_ && numValues_ > 0 && isDense &&
-      nullsInReadRange() != nullptr &&
-      !velox::bits::isAllSet(
-          nullsInReadRange()->as<uint64_t>(),
-          0,
-          numValues_,
-          velox::bits::kNotNull)) {
-    anyNulls_ = true;
-    returnReaderNulls_ = true;
-  }
+  // Apply the filter to the just-materialized dict indices BEFORE the abandon
+  // check so the dict portion is filtered on both paths: the normal path
+  // (getValues) and the dict->flat fallback (abandonDictionaryEncoding).
+  // filterDictionaryIndices derives its output-indexed null source from the
+  // read shape (dense: nullsInReadRange_; sparse: resultNulls_). The no-filter
+  // projected path needs no reconciliation — prepareResultNulls (called during
+  // the bulk read) already established anyNulls_/returnReaderNulls_ via
+  // setReturnNullsMode, since hasFilter() is genuinely false there (not
+  // suppressed).
   if (scanSpec_->hasFilter()) {
     filterDictionaryIndices(rows, scanSpec_->filter());
   }
@@ -518,7 +524,8 @@ bool StringColumnReader::readWithDictionary(
   }
 
   // Partial dict read: a non-dict chunk was encountered mid-read. Convert
-  // the already-filtered dict indices to flat StringViews. readOffset_ already
+  // the already-filtered dict indices to flat StringViews
+  // (filterDictionaryIndices above ran for this path too). readOffset_ already
   // points at the chunk boundary (set by readDictionaryIndices), so read()
   // resumes the flat read there and slices the remaining rows past it.
   abandonDictionaryEncoding(endReadRow);

--- a/dwio/nimble/velox/selective/StringColumnReader.h
+++ b/dwio/nimble/velox/selective/StringColumnReader.h
@@ -119,12 +119,14 @@ class StringColumnReader : public velox::dwio::common::SelectiveColumnReader {
   // together with the alphabet so no stale verdict outlives its entry.
   void ensureFilterCache();
 
-  // Switches off the dense returnReaderNulls_ fast path and ensures
-  // resultNulls_ is a writable, output-indexed buffer of at least `size` bits.
-  // The dict-filter path pre-compacts values, so compactScalarValues' null move
-  // is skipped; this provides a buffer to write the compacted output nulls
-  // into.
-  void ensureWritableResultNulls(velox::vector_size_t size);
+  // Asserts the invariant that lets the dict-filter path write compacted output
+  // nulls straight into resultNulls_ with no fixup: the reader is not on the
+  // dense reader-nulls fast path (returnReaderNulls_ == false) and
+  // prepareResultNulls has already allocated a unique, output-indexed
+  // resultNulls_ of at least `size` bits. Prod-visible NIMBLE_CHECKs (not
+  // DCHECK) guard it while we confirm the fast-path branch is unreachable here;
+  // a fire means the invariant regressed and the buffer fixup must be restored.
+  void checkWritableResultNulls(velox::vector_size_t size);
 
   // Applies the pushed-down filter to the just-materialized dictionary indices,
   // post-hoc on the merged alphabet (the bulk index read suppressed the
@@ -134,12 +136,14 @@ class StringColumnReader : public velox::dwio::common::SelectiveColumnReader {
   //   - outputRows_: set to the passing file rows, resized to the pass count.
   //   - numValues_: set to the number of passing rows.
   // When nulls are present it also realigns the result-null bitmap to the
-  // compacted output layout via ensureWritableResultNulls() (which allocates
-  // resultNulls_ and clears returnReaderNulls_), because pre-compaction makes
-  // the framework's compactScalarValues null move a no-op. Reads the
-  // output-indexed null bitmap from resultNulls() and consults
-  // dictionaryState_.alphabet and filterCache (lazily filled via
-  // ensureFilterCache()).
+  // compacted output layout, writing into the already-output-indexed
+  // resultNulls_ (checkWritableResultNulls() asserts that buffer is writable),
+  // because pre-compaction makes the framework's compactScalarValues null move
+  // a no-op. Selects the
+  // output-indexed input null bitmap by read shape, derived from `rows` (dense
+  // read == [0, rows.size()): nullsInReadRange_; sparse: resultNulls_ built
+  // inline by the sparse index path), and consults dictionaryState_.alphabet
+  // and filterCache (lazily filled via ensureFilterCache()).
   void filterDictionaryIndices(
       const velox::RowSet& rows,
       const velox::common::Filter* filter);
@@ -149,7 +153,10 @@ class StringColumnReader : public velox::dwio::common::SelectiveColumnReader {
   // passIndices/passRows. Writes the merged dictionary indices into 'indices',
   // the merged file rows into 'outputRows', and the per-output null bits into
   // rawResultNulls_ (null positions marked null, index 0 as a placeholder).
-  // Returns the merged output count (the new numValues_).
+  // Returns the merged output count (the new numValues_). Scans 'rows'/'nulls'
+  // only over [0, readCount) (the materialized dictionary prefix); on the
+  // abandon path 'rows' extends past readCount but those positions are never
+  // read here.
   velox::vector_size_t processNullAndPassingRows(
       const uint64_t* nulls,
       const velox::RowSet& rows,

--- a/dwio/nimble/velox/selective/tests/E2EFilterTest.cpp
+++ b/dwio/nimble/velox/selective/tests/E2EFilterTest.cpp
@@ -4444,6 +4444,488 @@ TEST_P(E2EFilterTest, crossChunkEncodingChangeWithFilter) {
   EXPECT_EQ(totalRows, expectedRows);
 }
 
+// Companion to filterOnlyDictAbandonDropsFilter with nulls in the dictionary
+// (filter) chunk: exercises the null-realignment branch of
+// filterDictionaryIndices on the abandon path — a non-null-accepting filter
+// must drop the null rows while filtering the dict portion before it is
+// expanded to flat.
+TEST_P(E2EFilterTest, crossChunkAbandonWithNullsAndFilter) {
+  if (!param().stringDecoderZeroCopy) {
+    GTEST_SKIP() << "Dictionary path requires stringDecoderZeroCopy";
+  }
+
+  auto type = ROW({"filter_col", "select_col"}, {VARCHAR(), VARCHAR()});
+  rowType_ = asRowType(type);
+
+  velox::test::VectorMaker maker(leafPool_.get());
+
+  // Chunk 1: low cardinality with periodic nulls → nullable dictionary.
+  constexpr size_t kChunk1Rows = 500;
+  constexpr size_t kNullEvery = 7;
+  std::vector<std::string> filter1Storage(kChunk1Rows);
+  std::vector<std::optional<velox::StringView>> filter1(kChunk1Rows);
+  std::vector<std::string> select1(kChunk1Rows);
+  for (size_t i = 0; i < kChunk1Rows; ++i) {
+    select1[i] = fmt::format("VAL_{}", i % 5);
+    if (i % kNullEvery == 0) {
+      filter1[i] = std::nullopt;
+    } else {
+      filter1Storage[i] = fmt::format("EVENT_{}", i % 10);
+      filter1[i] = velox::StringView(filter1Storage[i]);
+    }
+  }
+  auto chunk1 = std::make_shared<RowVector>(
+      leafPool_.get(),
+      type,
+      nullptr,
+      kChunk1Rows,
+      std::vector<VectorPtr>{
+          maker.flatVectorNullable<velox::StringView>(filter1),
+          maker.flatVector<velox::StringView>(kChunk1Rows, [&](auto row) {
+            return velox::StringView(select1[row]);
+          })});
+
+  // Chunk 2: all unique → trivial encoding, forcing abandon.
+  constexpr size_t kChunk2Rows = 300;
+  std::vector<std::string> filter2(kChunk2Rows);
+  std::vector<std::string> select2(kChunk2Rows);
+  for (size_t i = 0; i < kChunk2Rows; ++i) {
+    filter2[i] =
+        fmt::format("UNIQUE_EVENT_{}_padding_to_avoid_inline_string", i);
+    select2[i] = fmt::format("UNIQUE_VAL_{}", i);
+  }
+  auto chunk2 = std::make_shared<RowVector>(
+      leafPool_.get(),
+      type,
+      nullptr,
+      kChunk2Rows,
+      std::vector<VectorPtr>{
+          maker.flatVector<velox::StringView>(
+              kChunk2Rows,
+              [&](auto row) { return velox::StringView(filter2[row]); }),
+          maker.flatVector<velox::StringView>(kChunk2Rows, [&](auto row) {
+            return velox::StringView(select2[row]);
+          })});
+
+  {
+    auto writeFile = std::make_unique<InMemoryWriteFile>(&sinkData_);
+    VeloxWriterOptions writerOptions;
+    writerOptions.enableChunking = true;
+    writerOptions.minStreamChunkRawSize = 0;
+    writerOptions.flushPolicyFactory = [] {
+      return std::make_unique<LambdaFlushPolicy>(
+          /*flushLambda=*/[](const StripeProgress&) { return false; },
+          /*chunkLambda=*/[](const StripeProgress&) { return true; });
+    };
+    VeloxWriter writer(
+        type, std::move(writeFile), *rootPool_, std::move(writerOptions));
+    writer.write(chunk1);
+    writer.write(chunk2);
+    writer.close();
+  }
+
+  // Non-null-accepting filter: null rows must be dropped, and only matching
+  // non-null dict rows from chunk 1 survive.
+  std::vector<std::string> accepted = {"EVENT_3", "EVENT_7"};
+  std::set<std::string> acceptedSet(accepted.begin(), accepted.end());
+  size_t expectedRows = 0;
+  for (size_t i = 0; i < kChunk1Rows; ++i) {
+    if (filter1[i] && acceptedSet.count(filter1[i]->str())) {
+      ++expectedRows;
+    }
+  }
+
+  auto input = std::make_unique<velox::dwio::common::BufferedInput>(
+      std::make_shared<velox::InMemoryReadFile>(sinkData_),
+      *leafPool_,
+      velox::dwio::common::MetricsLog::voidLog());
+  velox::dwio::common::ReaderOptions readerOpts{leafPool_.get()};
+  readerOpts.setMetadataIoStats(metadataIoStats_);
+  auto reader = makeReader(readerOpts, std::move(input));
+
+  auto outputType = ROW({"select_col"}, {VARCHAR()});
+  auto scanSpec = std::make_shared<velox::common::ScanSpec>("root");
+  scanSpec->addAllChildFields(*outputType);
+  scanSpec->getOrCreateChild(velox::common::Subfield("filter_col"))
+      ->setFilter(
+          std::make_unique<velox::common::BytesValues>(accepted, false));
+
+  velox::dwio::common::RowReaderOptions rowReaderOptions;
+  rowReaderOptions.setScanSpec(scanSpec);
+  rowReaderOptions.setStringDecoderZeroCopy(true);
+  rowReaderOptions.setNimblePreserveDictionaryEncoding(true);
+  auto rowReader = reader->createRowReader(rowReaderOptions);
+
+  VectorPtr result = velox::BaseVector::create(outputType, 0, leafPool_.get());
+  size_t totalRows = 0;
+  while (rowReader->next(800, result)) {
+    totalRows += result->as<RowVector>()->size();
+  }
+
+  EXPECT_EQ(totalRows, expectedRows)
+      << "Nullable dict abandon path dropped or miscounted filtered rows";
+}
+
+// Projected variant of filterOnlyDictAbandonDropsFilter: the dictionary/filter
+// column is also read out, so the abandon path must produce correctly filtered
+// values (not just the right count) once the dict portion is expanded to flat.
+TEST_P(E2EFilterTest, crossChunkAbandonProjectedDictFilter) {
+  if (!param().stringDecoderZeroCopy) {
+    GTEST_SKIP() << "Dictionary path requires stringDecoderZeroCopy";
+  }
+
+  auto type = ROW({"string_val", "long_val"}, {VARCHAR(), BIGINT()});
+  rowType_ = asRowType(type);
+
+  velox::test::VectorMaker maker(leafPool_.get());
+
+  // Chunk 1: 10 distinct values → dictionary-encoded.
+  constexpr size_t kChunk1Rows = 500;
+  std::vector<std::string> string1(kChunk1Rows);
+  for (size_t i = 0; i < kChunk1Rows; ++i) {
+    string1[i] = fmt::format("EVENT_{}", i % 10);
+  }
+  auto chunk1 = std::make_shared<RowVector>(
+      leafPool_.get(),
+      type,
+      nullptr,
+      kChunk1Rows,
+      std::vector<VectorPtr>{
+          maker.flatVector<velox::StringView>(
+              kChunk1Rows,
+              [&](auto row) { return velox::StringView(string1[row]); }),
+          maker.flatVector<int64_t>(kChunk1Rows, [&](auto row) {
+            return static_cast<int64_t>(row);
+          })});
+
+  // Chunk 2: all unique → trivial encoding, forcing abandon.
+  constexpr size_t kChunk2Rows = 300;
+  std::vector<std::string> string2(kChunk2Rows);
+  for (size_t i = 0; i < kChunk2Rows; ++i) {
+    string2[i] = fmt::format("UNIQUE_{}_padding_to_avoid_inline_string", i);
+  }
+  auto chunk2 = std::make_shared<RowVector>(
+      leafPool_.get(),
+      type,
+      nullptr,
+      kChunk2Rows,
+      std::vector<VectorPtr>{
+          maker.flatVector<velox::StringView>(
+              kChunk2Rows,
+              [&](auto row) { return velox::StringView(string2[row]); }),
+          maker.flatVector<int64_t>(kChunk2Rows, [&](auto row) {
+            return static_cast<int64_t>(kChunk1Rows + row);
+          })});
+
+  {
+    auto writeFile = std::make_unique<InMemoryWriteFile>(&sinkData_);
+    VeloxWriterOptions writerOptions;
+    writerOptions.enableChunking = true;
+    writerOptions.minStreamChunkRawSize = 0;
+    writerOptions.flushPolicyFactory = [] {
+      return std::make_unique<LambdaFlushPolicy>(
+          /*flushLambda=*/[](const StripeProgress&) { return false; },
+          /*chunkLambda=*/[](const StripeProgress&) { return true; });
+    };
+    VeloxWriter writer(
+        type, std::move(writeFile), *rootPool_, std::move(writerOptions));
+    writer.write(chunk1);
+    writer.write(chunk2);
+    writer.close();
+  }
+
+  std::vector<std::string> accepted = {"EVENT_3", "EVENT_7"};
+  std::set<std::string> acceptedSet(accepted.begin(), accepted.end());
+  size_t expectedRows = 0;
+  for (const auto& s : string1) {
+    if (acceptedSet.count(s)) {
+      ++expectedRows;
+    }
+  }
+
+  auto input = std::make_unique<velox::dwio::common::BufferedInput>(
+      std::make_shared<velox::InMemoryReadFile>(sinkData_),
+      *leafPool_,
+      velox::dwio::common::MetricsLog::voidLog());
+  velox::dwio::common::ReaderOptions readerOpts{leafPool_.get()};
+  readerOpts.setMetadataIoStats(metadataIoStats_);
+  auto reader = makeReader(readerOpts, std::move(input));
+
+  auto scanSpec = std::make_shared<velox::common::ScanSpec>("root");
+  scanSpec->addAllChildFields(*type);
+  scanSpec->childByName("string_val")
+      ->setFilter(
+          std::make_unique<velox::common::BytesValues>(accepted, false));
+
+  velox::dwio::common::RowReaderOptions rowReaderOptions;
+  rowReaderOptions.setScanSpec(scanSpec);
+  rowReaderOptions.setStringDecoderZeroCopy(true);
+  rowReaderOptions.setNimblePreserveDictionaryEncoding(true);
+  auto rowReader = reader->createRowReader(rowReaderOptions);
+
+  VectorPtr result = velox::BaseVector::create(type, 0, leafPool_.get());
+  size_t totalRows = 0;
+  while (rowReader->next(800, result)) {
+    auto* rowResult = result->as<RowVector>();
+    ASSERT_NE(rowResult, nullptr);
+    totalRows += rowResult->size();
+    velox::DecodedVector decodedString(*rowResult->childAt(0)->loadedVector());
+    for (size_t i = 0; i < rowResult->size(); ++i) {
+      auto str = decodedString.valueAt<velox::StringView>(i).str();
+      ASSERT_TRUE(acceptedSet.count(str))
+          << "Row leaked past filter on abandon path: " << str;
+    }
+  }
+
+  EXPECT_EQ(totalRows, expectedRows)
+      << "Projected dict abandon path dropped filter on dict portion";
+}
+
+// Projected + nullable variant: the dict/filter column has periodic nulls and
+// is also read out. The non-null-accepting filter must drop nulls, filter the
+// dict portion, and expand it to flat with the output null bitmap realigned.
+TEST_P(E2EFilterTest, crossChunkAbandonProjectedNullableDictFilter) {
+  if (!param().stringDecoderZeroCopy) {
+    GTEST_SKIP() << "Dictionary path requires stringDecoderZeroCopy";
+  }
+
+  auto type = ROW({"string_val", "long_val"}, {VARCHAR(), BIGINT()});
+  rowType_ = asRowType(type);
+
+  velox::test::VectorMaker maker(leafPool_.get());
+
+  // Chunk 1: 10 distinct values with periodic nulls → nullable dictionary.
+  constexpr size_t kChunk1Rows = 500;
+  constexpr size_t kNullEvery = 7;
+  std::vector<std::string> string1Storage(kChunk1Rows);
+  std::vector<std::optional<velox::StringView>> string1(kChunk1Rows);
+  for (size_t i = 0; i < kChunk1Rows; ++i) {
+    if (i % kNullEvery == 0) {
+      string1[i] = std::nullopt;
+    } else {
+      string1Storage[i] = fmt::format("EVENT_{}", i % 10);
+      string1[i] = velox::StringView(string1Storage[i]);
+    }
+  }
+  auto chunk1 = std::make_shared<RowVector>(
+      leafPool_.get(),
+      type,
+      nullptr,
+      kChunk1Rows,
+      std::vector<VectorPtr>{
+          maker.flatVectorNullable<velox::StringView>(string1),
+          maker.flatVector<int64_t>(kChunk1Rows, [&](auto row) {
+            return static_cast<int64_t>(row);
+          })});
+
+  // Chunk 2: all unique → trivial encoding, forcing abandon.
+  constexpr size_t kChunk2Rows = 300;
+  std::vector<std::string> string2(kChunk2Rows);
+  for (size_t i = 0; i < kChunk2Rows; ++i) {
+    string2[i] = fmt::format("UNIQUE_{}_padding_to_avoid_inline_string", i);
+  }
+  auto chunk2 = std::make_shared<RowVector>(
+      leafPool_.get(),
+      type,
+      nullptr,
+      kChunk2Rows,
+      std::vector<VectorPtr>{
+          maker.flatVector<velox::StringView>(
+              kChunk2Rows,
+              [&](auto row) { return velox::StringView(string2[row]); }),
+          maker.flatVector<int64_t>(kChunk2Rows, [&](auto row) {
+            return static_cast<int64_t>(kChunk1Rows + row);
+          })});
+
+  {
+    auto writeFile = std::make_unique<InMemoryWriteFile>(&sinkData_);
+    VeloxWriterOptions writerOptions;
+    writerOptions.enableChunking = true;
+    writerOptions.minStreamChunkRawSize = 0;
+    writerOptions.flushPolicyFactory = [] {
+      return std::make_unique<LambdaFlushPolicy>(
+          /*flushLambda=*/[](const StripeProgress&) { return false; },
+          /*chunkLambda=*/[](const StripeProgress&) { return true; });
+    };
+    VeloxWriter writer(
+        type, std::move(writeFile), *rootPool_, std::move(writerOptions));
+    writer.write(chunk1);
+    writer.write(chunk2);
+    writer.close();
+  }
+
+  std::vector<std::string> accepted = {"EVENT_3", "EVENT_7"};
+  std::set<std::string> acceptedSet(accepted.begin(), accepted.end());
+  size_t expectedRows = 0;
+  for (size_t i = 0; i < kChunk1Rows; ++i) {
+    if (string1[i] && acceptedSet.count(string1[i]->str())) {
+      ++expectedRows;
+    }
+  }
+
+  auto input = std::make_unique<velox::dwio::common::BufferedInput>(
+      std::make_shared<velox::InMemoryReadFile>(sinkData_),
+      *leafPool_,
+      velox::dwio::common::MetricsLog::voidLog());
+  velox::dwio::common::ReaderOptions readerOpts{leafPool_.get()};
+  readerOpts.setMetadataIoStats(metadataIoStats_);
+  auto reader = makeReader(readerOpts, std::move(input));
+
+  auto scanSpec = std::make_shared<velox::common::ScanSpec>("root");
+  scanSpec->addAllChildFields(*type);
+  scanSpec->childByName("string_val")
+      ->setFilter(
+          std::make_unique<velox::common::BytesValues>(accepted, false));
+
+  velox::dwio::common::RowReaderOptions rowReaderOptions;
+  rowReaderOptions.setScanSpec(scanSpec);
+  rowReaderOptions.setStringDecoderZeroCopy(true);
+  rowReaderOptions.setNimblePreserveDictionaryEncoding(true);
+  auto rowReader = reader->createRowReader(rowReaderOptions);
+
+  VectorPtr result = velox::BaseVector::create(type, 0, leafPool_.get());
+  size_t totalRows = 0;
+  while (rowReader->next(800, result)) {
+    auto* rowResult = result->as<RowVector>();
+    ASSERT_NE(rowResult, nullptr);
+    totalRows += rowResult->size();
+    velox::DecodedVector decodedString(*rowResult->childAt(0)->loadedVector());
+    for (size_t i = 0; i < rowResult->size(); ++i) {
+      ASSERT_FALSE(decodedString.isNullAt(i))
+          << "Non-null-accepting filter emitted a null row on abandon path";
+      auto str = decodedString.valueAt<velox::StringView>(i).str();
+      ASSERT_TRUE(acceptedSet.count(str))
+          << "Row leaked past filter on abandon path: " << str;
+    }
+  }
+
+  EXPECT_EQ(totalRows, expectedRows)
+      << "Projected nullable dict abandon path dropped or miscounted rows";
+}
+
+// Sparse variant: a more-selective prior filter on `k` makes the dictionary
+// column `str` read over a non-contiguous (sparse) row set. When that sparse
+// read spans a dict chunk into a non-dict chunk, filterDictionaryIndices runs
+// on the abandon path with isDense=false — exercising the sparse null source
+// and the sparse rows[0, numValues_) mapping without subranging `rows`.
+TEST_P(E2EFilterTest, crossChunkAbandonSparseDictFilter) {
+  if (!param().stringDecoderZeroCopy) {
+    GTEST_SKIP() << "Dictionary path requires stringDecoderZeroCopy";
+  }
+
+  auto type = ROW({"k", "str"}, {BIGINT(), VARCHAR()});
+  rowType_ = asRowType(type);
+
+  velox::test::VectorMaker maker(leafPool_.get());
+
+  // Chunk 1: `str` low cardinality → dictionary. `k = i % 11`, so the very
+  // selective `k == 0` filter (~9%, applied before the ~12.5% `str` filter)
+  // sparsifies `str`'s read over non-contiguous rows.
+  constexpr size_t kChunk1Rows = 500;
+  std::vector<std::string> str1(kChunk1Rows);
+  for (size_t i = 0; i < kChunk1Rows; ++i) {
+    str1[i] = fmt::format("EVENT_{}", i % 10);
+  }
+  auto chunk1 = std::make_shared<RowVector>(
+      leafPool_.get(),
+      type,
+      nullptr,
+      kChunk1Rows,
+      std::vector<VectorPtr>{
+          maker.flatVector<int64_t>(
+              kChunk1Rows,
+              [](auto row) { return static_cast<int64_t>(row % 11); }),
+          maker.flatVector<velox::StringView>(kChunk1Rows, [&](auto row) {
+            return velox::StringView(str1[row]);
+          })});
+
+  // Chunk 2: unique → trivial encoding, forcing abandon.
+  constexpr size_t kChunk2Rows = 300;
+  std::vector<std::string> str2(kChunk2Rows);
+  for (size_t i = 0; i < kChunk2Rows; ++i) {
+    str2[i] = fmt::format("UNIQUE_{}_padding_to_avoid_inline_string", i);
+  }
+  auto chunk2 = std::make_shared<RowVector>(
+      leafPool_.get(),
+      type,
+      nullptr,
+      kChunk2Rows,
+      std::vector<VectorPtr>{
+          maker.flatVector<int64_t>(
+              kChunk2Rows,
+              [](auto row) { return static_cast<int64_t>(row % 11); }),
+          maker.flatVector<velox::StringView>(kChunk2Rows, [&](auto row) {
+            return velox::StringView(str2[row]);
+          })});
+
+  {
+    auto writeFile = std::make_unique<InMemoryWriteFile>(&sinkData_);
+    VeloxWriterOptions writerOptions;
+    writerOptions.enableChunking = true;
+    writerOptions.minStreamChunkRawSize = 0;
+    writerOptions.flushPolicyFactory = [] {
+      return std::make_unique<LambdaFlushPolicy>(
+          /*flushLambda=*/[](const StripeProgress&) { return false; },
+          /*chunkLambda=*/[](const StripeProgress&) { return true; });
+    };
+    VeloxWriter writer(
+        type, std::move(writeFile), *rootPool_, std::move(writerOptions));
+    writer.write(chunk1);
+    writer.write(chunk2);
+    writer.close();
+  }
+
+  std::vector<std::string> accepted = {"EVENT_3", "EVENT_7"};
+  std::set<std::string> acceptedSet(accepted.begin(), accepted.end());
+  // Expected: chunk-1 rows with k == 0 (i % 11 == 0) whose str matches.
+  size_t expectedRows = 0;
+  for (size_t i = 0; i < kChunk1Rows; ++i) {
+    if (i % 11 == 0 && acceptedSet.count(str1[i])) {
+      ++expectedRows;
+    }
+  }
+  ASSERT_GT(expectedRows, 0u);
+
+  auto input = std::make_unique<velox::dwio::common::BufferedInput>(
+      std::make_shared<velox::InMemoryReadFile>(sinkData_),
+      *leafPool_,
+      velox::dwio::common::MetricsLog::voidLog());
+  velox::dwio::common::ReaderOptions readerOpts{leafPool_.get()};
+  readerOpts.setMetadataIoStats(metadataIoStats_);
+  auto reader = makeReader(readerOpts, std::move(input));
+
+  auto scanSpec = std::make_shared<velox::common::ScanSpec>("root");
+  scanSpec->addAllChildFields(*type);
+  scanSpec->childByName("k")->setFilter(
+      std::make_unique<velox::common::BigintRange>(
+          0, 0, /*nullAllowed=*/false));
+  scanSpec->childByName("str")->setFilter(
+      std::make_unique<velox::common::BytesValues>(accepted, false));
+
+  velox::dwio::common::RowReaderOptions rowReaderOptions;
+  rowReaderOptions.setScanSpec(scanSpec);
+  rowReaderOptions.setStringDecoderZeroCopy(true);
+  rowReaderOptions.setNimblePreserveDictionaryEncoding(true);
+  auto rowReader = reader->createRowReader(rowReaderOptions);
+
+  VectorPtr result = velox::BaseVector::create(type, 0, leafPool_.get());
+  size_t totalRows = 0;
+  while (rowReader->next(800, result)) {
+    auto* rowResult = result->as<RowVector>();
+    ASSERT_NE(rowResult, nullptr);
+    totalRows += rowResult->size();
+    velox::DecodedVector decodedStr(*rowResult->childAt(1)->loadedVector());
+    for (size_t i = 0; i < rowResult->size(); ++i) {
+      auto s = decodedStr.valueAt<velox::StringView>(i).str();
+      ASSERT_TRUE(acceptedSet.count(s))
+          << "Row leaked past filter on sparse abandon path: " << s;
+    }
+  }
+
+  EXPECT_EQ(totalRows, expectedRows)
+      << "Sparse dict abandon path dropped or miscounted filtered rows";
+}
+
 // Exercises the IsNull filter guard: when a null-accepting filter (e.g. IsNull)
 // is combined with NullableEncoding wrapping Dictionary, the reader must bypass
 // the dictionary path. NullableEncoding::materializeNullsForVisitor writes


### PR DESCRIPTION
Summary:

The Nimble selective dictionary read path defers the pushed-down filter: `readWithDictionary` suppresses the filter (`setFilter(nullptr)`), bulk-materializes dictionary indices, then re-applies the filter post-hoc in `filterDictionaryIndices`. Because the suppression leaves `hasFilter()` cached-true, `setReturnNullsMode` does not establish `anyNulls_`/`returnReaderNulls_` during the bulk read the way a normal filtered read would, so the post-hoc filter cannot trust the flag-routed `resultNulls()` for its input null bitmap.

D111865988 handles this with a dense-only reconciliation block in `readWithDictionary` that force-sets `anyNulls_`/`returnReaderNulls_` after the bulk read. This diff replaces that reconciliation with an explicit, read-shape-driven selection inside `filterDictionaryIndices`: a dense read (`rows == [0, rows.size())`) keeps its nulls in `nullsInReadRange_` (output == read range, so it is output-aligned) and reads from `rawNullsInReadRange()`; a sparse read reads the `resultNulls_` that the sparse materialization path builds and compacts inline. This `isDense` is exactly the flag `StringColumnReadWithVisitorHelper` uses to instantiate the dense/sparse `ColumnVisitor`, so it always matches where the nulls were actually written — including on the abandon path, where only a prefix of the range was materialized but the null buffer was chosen from the full range. `processNullAndPassingRows` now owns setting `anyNulls_` per emitted null, so the reconciliation block is deleted.

`prepareResultNulls` in the shared dense materialization helper (`Encoding.h`, from D111865988) is retained unchanged: it establishes the null state for the no-filter projected path, where `hasFilter()` is genuinely false (not suppressed). The change is otherwise confined to the string reader; `abandonDictionaryEncoding` keeps reading the output null bitmap through `resultNulls()`.

This diff also folds in D112060317: `filterDictionaryIndices` now runs before the abandon-dictionary check, so a read that spans a dictionary chunk followed by a non-dictionary chunk filters the dictionary portion on both the normal path (`getValues`) and the dict->flat fallback (`abandonDictionaryEncoding`). Previously the filter sat inside `if (!abandonDictionary)`, so the abandon path expanded the dictionary portion unfiltered, leaking rows that should have been dropped.

Stacked on D111865988.

Differential Revision: D112067522


