### PR TITLE
feat: Add EncodingView support for MainlyConstant, FOR, and SparseBool (#979)

### DIFF
--- a/dwio/nimble/encodings/benchmarks/EncodingViewBenchmark.cpp
+++ b/dwio/nimble/encodings/benchmarks/EncodingViewBenchmark.cpp
@@ -33,9 +33,12 @@
 #include "dwio/nimble/encodings/ConstantEncoding.h"
 #include "dwio/nimble/encodings/DictionaryEncoding.h"
 #include "dwio/nimble/encodings/FixedBitWidthEncoding.h"
+#include "dwio/nimble/encodings/ForEncoding.h"
+#include "dwio/nimble/encodings/MainlyConstantEncoding.h"
 #include "dwio/nimble/encodings/PFOREncoding.h"
 #include "dwio/nimble/encodings/RLEEncoding.h"
 #include "dwio/nimble/encodings/SimdForBitpackEncoding.h"
+#include "dwio/nimble/encodings/SparseBoolEncoding.h"
 #include "dwio/nimble/encodings/TrivialEncoding.h"
 #include "dwio/nimble/encodings/benchmarks/BenchmarkUtils.h"
 #include "dwio/nimble/encodings/common/EncodingFactory.h"
@@ -355,6 +358,15 @@ Vector<uint32_t> pforData() {
   return data;
 }
 
+Vector<uint32_t> mainlyConstantData() {
+  Vector<uint32_t> data{benchmarkPool().get()};
+  data.resize(kRows, 7);
+  for (uint32_t i = 0; i < kRows; i += 17) {
+    data[i] = i;
+  }
+  return data;
+}
+
 Vector<bool> boolData() {
   Vector<bool> data{benchmarkPool().get()};
   data.resize(kRows);
@@ -442,6 +454,20 @@ MATERIALIZE_BENCHMARK(
     bool,
     encodeWithSelection<TrivialEncoding<bool>>(
         EncodingType::Trivial,
+        boolData()),
+    randomPositions(kRows))
+VIEW_BENCHMARK(
+    View_SparseBool_Random130,
+    bool,
+    encodeWithSelection<SparseBoolEncoding>(
+        EncodingType::SparseBool,
+        boolData()),
+    randomPositions(kRows))
+MATERIALIZE_BENCHMARK(
+    Materialize_SparseBool_Random130,
+    bool,
+    encodeWithSelection<SparseBoolEncoding>(
+        EncodingType::SparseBool,
         boolData()),
     randomPositions(kRows))
 
@@ -552,6 +578,20 @@ MATERIALIZE_BENCHMARK(
     encodeWithSelection<FixedBitWidthEncoding<uint32_t>>(
         EncodingType::FixedBitWidth,
         makeNarrow<uint32_t>(10, kRows)),
+    randomPositions(kRows))
+VIEW_BENCHMARK(
+    View_MainlyConstantUint32_Random130,
+    uint32_t,
+    encodeWithSelection<MainlyConstantEncoding<uint32_t>>(
+        EncodingType::MainlyConstant,
+        mainlyConstantData()),
+    randomPositions(kRows))
+MATERIALIZE_BENCHMARK(
+    Materialize_MainlyConstantUint32_Random130,
+    uint32_t,
+    encodeWithSelection<MainlyConstantEncoding<uint32_t>>(
+        EncodingType::MainlyConstant,
+        mainlyConstantData()),
     randomPositions(kRows))
 VIEW_BENCHMARK(
     View_DictionaryUint32_Random130,
@@ -685,6 +725,24 @@ MATERIALIZE_BENCHMARK(
         EncodingType::ALP,
         alpData<double>()),
     randomPositions(kRows))
+VIEW_BENCHMARK(
+    View_FORUint32_Random130,
+    uint32_t,
+    encodeWithSelection<ForEncoding<uint32_t>>(EncodingType::FOR, pforData()),
+    randomPositions(kRows))
+BENCHMARK(Materialize_FORUint32_Random130, iters) {
+  std::string encoded;
+  std::vector<uint32_t> positions;
+  std::unique_ptr<ForEncoding<uint32_t>> encoding;
+  BENCHMARK_SUSPEND {
+    encoded = encodeWithSelection<ForEncoding<uint32_t>>(
+        EncodingType::FOR, pforData());
+    positions = randomPositions(kRows);
+    encoding = std::make_unique<ForEncoding<uint32_t>>(
+        *benchmarkPool(), encoded, nullptr, Encoding::Options{});
+  }
+  readPositionsWithMaterialization<uint32_t>(*encoding, positions, iters);
+}
 VIEW_BENCHMARK(
     View_PFORUint32_Random130,
     uint32_t,

--- a/dwio/nimble/encodings/tests/CMakeLists.txt
+++ b/dwio/nimble/encodings/tests/CMakeLists.txt
@@ -33,10 +33,12 @@ add_executable(
   EncodingLegacyTest.cpp
   FixedBitWidthEncodingViewTest.cpp
   FsstEncodingTest.cpp
+  FOREncodingViewTest.cpp
   Lz4CompressorTest.cpp
   ForEncodingTest.cpp
   FrequencyPartitionEncodingTest.cpp
   MainlyConstantEncodingTest.cpp
+  MainlyConstantEncodingViewTest.cpp
   NullableEncodingTest.cpp
   OpenZLCompressorTest.cpp
   PFOREncodingViewTest.cpp
@@ -46,6 +48,7 @@ add_executable(
   RLEEncodingTest.cpp
   SentinelEncodingTest.cpp
   SimdForBitpackEncodingViewTest.cpp
+  SparseBoolEncodingViewTest.cpp
   StatisticsTest.cpp
   TrivialEncodingViewTest.cpp
   TrivialEncodingTest.cpp

--- a/dwio/nimble/encodings/tests/EncodingViewFactoryTest.cpp
+++ b/dwio/nimble/encodings/tests/EncodingViewFactoryTest.cpp
@@ -61,13 +61,10 @@ TEST_F(EncodingViewTest, rejectsUnsupportedEncodingTypes) {
       unsupportedEncodings{
           {nimble::EncodingType::Sentinel, nimble::DataType::Int32},
           {nimble::EncodingType::Nullable, nimble::DataType::Int32},
-          {nimble::EncodingType::SparseBool, nimble::DataType::Bool},
           {nimble::EncodingType::Delta, nimble::DataType::Int32},
-          {nimble::EncodingType::MainlyConstant, nimble::DataType::Int32},
           {nimble::EncodingType::Prefix, nimble::DataType::String},
           {nimble::EncodingType::SubIntSplit, nimble::DataType::Uint32},
           {nimble::EncodingType::FrequencyPartition, nimble::DataType::Uint32},
-          {nimble::EncodingType::FOR, nimble::DataType::Uint32},
           {nimble::EncodingType::Fsst, nimble::DataType::String},
       };
 

--- a/dwio/nimble/encodings/tests/FOREncodingViewTest.cpp
+++ b/dwio/nimble/encodings/tests/FOREncodingViewTest.cpp
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "dwio/nimble/encodings/tests/EncodingViewTestUtils.h"
+
+#include <gtest/gtest.h>
+
+#include "dwio/nimble/encodings/ForEncoding.h"
+
+using namespace facebook;
+
+using EncodingViewTest = nimble::test::EncodingViewTest;
+using FOREncodingViewTest = nimble::test::EncodingViewTest;
+
+TEST_F(EncodingViewTest, readsForEncoding) {
+  expectReads<nimble::ForEncoding<int32_t>>(
+      makeVector({100, 101, 102, 103, 5000, 104, 105, 106, -7, -6, -5}),
+      {8, 0, 4, 10, 5, 2});
+  expectReads<nimble::ForEncoding<uint32_t>>(
+      makeVector<uint32_t>({7, 8, 9, 10, 4096, 4097, 4098, 4099}),
+      {7, 0, 4, 6, 2});
+}
+
+TEST_F(FOREncodingViewTest, concurrent) {
+  expectConcurrentReads<nimble::ForEncoding<uint32_t>>(
+      randomPforData(/*seed=*/31), randomizedPositions(/*seed=*/32));
+}

--- a/dwio/nimble/encodings/tests/MainlyConstantEncodingViewTest.cpp
+++ b/dwio/nimble/encodings/tests/MainlyConstantEncodingViewTest.cpp
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "dwio/nimble/encodings/tests/EncodingViewTestUtils.h"
+
+#include <gtest/gtest.h>
+
+#include "dwio/nimble/encodings/MainlyConstantEncoding.h"
+
+using namespace facebook;
+
+using EncodingViewTest = nimble::test::EncodingViewTest;
+using MainlyConstantEncodingViewTest = nimble::test::EncodingViewTest;
+
+TEST_F(EncodingViewTest, readsMainlyConstantEncoding) {
+  expectReads<nimble::MainlyConstantEncoding<int32_t>>(
+      makeVector({7, 7, 11, 7, 7, 19, 7, 23, 7}), {8, 0, 2, 5, 7, 3});
+  expectReads<nimble::MainlyConstantEncoding<float>>(
+      makeVector<float>({1.25F, 1.25F, 2.5F, 1.25F, -3.75F, 1.25F}),
+      {5, 0, 2, 4, 1});
+  expectReads<nimble::MainlyConstantEncoding<double>>(
+      makeVector<double>({1.25, 1.25, 2.5, 1.25, -3.75, 1.25}),
+      {5, 0, 2, 4, 1});
+  expectReads<nimble::MainlyConstantEncoding<std::string_view>>(
+      makeVector<std::string_view>(
+          {"alpha", "alpha", "beta", "alpha", "gamma", "alpha"}),
+      {5, 0, 2, 4, 1});
+}
+
+TEST_F(MainlyConstantEncodingViewTest, concurrent) {
+  const auto positions = randomizedPositions(/*seed=*/29);
+
+  auto values = constantInt32(5);
+  for (uint32_t i = 0; i < values.size(); i += 17) {
+    values[i] = static_cast<int32_t>(i);
+  }
+  expectConcurrentReads<nimble::MainlyConstantEncoding<int32_t>>(
+      values, positions);
+}

--- a/dwio/nimble/encodings/tests/SparseBoolEncodingViewTest.cpp
+++ b/dwio/nimble/encodings/tests/SparseBoolEncodingViewTest.cpp
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "dwio/nimble/encodings/tests/EncodingViewTestUtils.h"
+
+#include <gtest/gtest.h>
+
+#include "dwio/nimble/encodings/SparseBoolEncoding.h"
+
+using namespace facebook;
+
+using EncodingViewTest = nimble::test::EncodingViewTest;
+using SparseBoolEncodingViewTest = nimble::test::EncodingViewTest;
+
+TEST_F(EncodingViewTest, readsSparseBoolEncoding) {
+  expectReads<nimble::SparseBoolEncoding>(
+      makeVector<bool>({false, false, true, false, true, false, false, true}),
+      {7, 0, 2, 4, 1});
+  expectReads<nimble::SparseBoolEncoding>(
+      makeVector<bool>({true, true, false, true, false, true, true, false}),
+      {7, 0, 2, 4, 1});
+}
+
+TEST_F(SparseBoolEncodingViewTest, concurrent) {
+  expectConcurrentReads<nimble::SparseBoolEncoding>(
+      randomBool(/*seed=*/33), randomizedPositions(/*seed=*/34));
+}

--- a/dwio/nimble/encodings/views/EncodingViewFactory.cpp
+++ b/dwio/nimble/encodings/views/EncodingViewFactory.cpp
@@ -19,10 +19,13 @@
 #include "dwio/nimble/encodings/views/BlockBitPackingEncodingView.h"
 #include "dwio/nimble/encodings/views/ConstantEncodingView.h"
 #include "dwio/nimble/encodings/views/DictionaryEncodingView.h"
+#include "dwio/nimble/encodings/views/FOREncodingView.h"
 #include "dwio/nimble/encodings/views/FixedBitWidthEncodingView.h"
+#include "dwio/nimble/encodings/views/MainlyConstantEncodingView.h"
 #include "dwio/nimble/encodings/views/PFOREncodingView.h"
 #include "dwio/nimble/encodings/views/RLEEncodingView.h"
 #include "dwio/nimble/encodings/views/SimdForBitpackEncodingView.h"
+#include "dwio/nimble/encodings/views/SparseBoolEncodingView.h"
 #include "dwio/nimble/encodings/views/TrivialEncodingView.h"
 
 namespace facebook::nimble {
@@ -41,6 +44,14 @@ std::unique_ptr<TypedEncodingView<T>> createTypedEncodingView(
       return std::make_unique<ConstantEncodingView<T>>(data, pool, options);
     case EncodingType::Trivial:
       return std::make_unique<TrivialEncodingView<T>>(data, pool, options);
+    case EncodingType::MainlyConstant:
+      // MainlyConstant supports all leaf types except bool.
+      if constexpr (!std::is_same_v<T, bool>) {
+        return std::make_unique<MainlyConstantEncodingView<T>>(
+            data, pool, options);
+      }
+      NIMBLE_INCOMPATIBLE_ENCODING(
+          "MainlyConstant encoding cannot be used for boolean data.");
     case EncodingType::ALP:
       if constexpr (isFloatingPointType<T>()) {
         return std::make_unique<ALPEncodingView<T>>(data, pool, options);
@@ -61,8 +72,21 @@ std::unique_ptr<TypedEncodingView<T>> createTypedEncodingView(
       }
       NIMBLE_INCOMPATIBLE_ENCODING(
           "Dictionary encoding cannot be used for boolean data.");
+    case EncodingType::SparseBool:
+      if constexpr (std::is_same_v<T, bool>) {
+        return std::make_unique<SparseBoolEncodingView>(data, pool, options);
+      }
+      NIMBLE_INCOMPATIBLE_ENCODING(
+          "SparseBool encoding only supports boolean data.");
     case EncodingType::RLE:
       return std::make_unique<RLEEncodingView<T>>(data, pool, options);
+    case EncodingType::FOR:
+      if constexpr (isIntegralType<physicalType>()) {
+        return std::make_unique<FOREncodingView<T>>(data, pool, options);
+      }
+      NIMBLE_INCOMPATIBLE_ENCODING(
+          "FOR encoding should not be selected for non-integral data type: {}.",
+          TypeTraits<T>::dataType);
     case EncodingType::PFOR:
       if constexpr (isIntegralType<physicalType>()) {
         return std::make_unique<PFOREncodingView<T>>(data, pool, options);

--- a/dwio/nimble/encodings/views/FOREncodingView.h
+++ b/dwio/nimble/encodings/views/FOREncodingView.h
@@ -1,0 +1,205 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <algorithm>
+#include <cstring>
+#include <type_traits>
+
+#include "dwio/nimble/encodings/common/EncodingPrimitives.h"
+#include "dwio/nimble/encodings/views/EncodingViewFactory.h"
+#include "velox/common/base/BitUtil.h"
+
+namespace facebook::nimble {
+
+template <typename T>
+class FOREncodingView final : public TypedEncodingView<T> {
+ public:
+  using physicalType = typename TypedEncodingView<T>::physicalType;
+
+  FOREncodingView(
+      std::string_view data,
+      velox::memory::MemoryPool* pool,
+      const Encoding::Options& options)
+      : TypedEncodingView<T>{data, pool, options},
+        bitWidths_{this->template getVectorBuffer<uint8_t>()},
+        references_{this->template getVectorBuffer<physicalType>()},
+        bitOffsets_{this->template getVectorBuffer<uint64_t>()} {
+    static_assert(
+        std::is_integral_v<physicalType>,
+        "FOREncodingView only supports integral types");
+
+    NIMBLE_CHECK_EQ(this->encodingType_, EncodingType::FOR);
+    const char* pos = data.data() + this->dataOffset_;
+    const auto compressionType =
+        static_cast<CompressionType>(encoding::readChar(pos));
+    NIMBLE_CHECK_EQ(
+        compressionType,
+        CompressionType::Uncompressed,
+        "EncodingView does not support compressed FOR streams.");
+    frameSize_ = encoding::readUint32(pos);
+    numFrames_ = encoding::readUint32(pos);
+    enableBitOffsets_ = static_cast<bool>(encoding::readChar(pos));
+    NIMBLE_CHECK_GT(frameSize_, 0);
+    NIMBLE_CHECK_EQ(
+        numFrames_, (this->rowCount_ + frameSize_ - 1) / frameSize_);
+
+    const auto bitWidthsSize = encoding::readUint32(pos);
+    auto bitWidths = detail::createTypedEncodingView<uint8_t>(
+        {pos, bitWidthsSize}, pool, options);
+    NIMBLE_CHECK_NOT_NULL(bitWidths);
+    NIMBLE_CHECK_EQ(bitWidths->rowCount(), numFrames_);
+    bitWidths_.resize(numFrames_);
+    for (uint32_t frame = 0; frame < numFrames_; ++frame) {
+      bitWidths_[frame] = bitWidths->readAt(frame);
+    }
+    pos += bitWidthsSize;
+
+    const auto referencesSize = encoding::readUint32(pos);
+    auto references = detail::createTypedEncodingView<physicalType>(
+        {pos, referencesSize}, pool, options);
+    NIMBLE_CHECK_NOT_NULL(references);
+    NIMBLE_CHECK_EQ(references->rowCount(), numFrames_);
+    references_.resize(numFrames_);
+    for (uint32_t frame = 0; frame < numFrames_; ++frame) {
+      references_[frame] = references->readAt(frame);
+    }
+    pos += referencesSize;
+
+    bitOffsets_.resize(numFrames_);
+    if (enableBitOffsets_) {
+      const auto bitOffsetsSize = encoding::readUint32(pos);
+      auto bitOffsets = detail::createTypedEncodingView<uint64_t>(
+          {pos, bitOffsetsSize}, pool, options);
+      NIMBLE_CHECK_NOT_NULL(bitOffsets);
+      NIMBLE_CHECK_EQ(bitOffsets->rowCount(), numFrames_);
+      for (uint32_t frame = 0; frame < numFrames_; ++frame) {
+        bitOffsets_[frame] = bitOffsets->readAt(frame);
+      }
+      pos += bitOffsetsSize;
+    } else {
+      uint64_t cumulativeBitOffset{0};
+      for (uint32_t frame = 0; frame < numFrames_; ++frame) {
+        bitOffsets_[frame] = cumulativeBitOffset;
+        cumulativeBitOffset += frameRowCount(frame) * bitWidths_[frame];
+      }
+    }
+
+    const auto packedDataSize = encoding::readUint32(pos);
+    packedData_ = pos;
+    pos += packedDataSize;
+    NIMBLE_CHECK_EQ(pos, data.end(), "Unexpected FOR view end.");
+  }
+
+  ~FOREncodingView() override {
+    this->releaseVectorBuffer(bitOffsets_);
+    this->releaseVectorBuffer(references_);
+    this->releaseVectorBuffer(bitWidths_);
+  }
+
+ private:
+  uint32_t frameRowCount(uint32_t frame) const {
+    const auto startRow = frame * frameSize_;
+    return std::min(frameSize_, this->rowCount_ - startRow);
+  }
+
+  uint64_t bitOffset(uint32_t frame) const {
+    return bitOffsets_[frame];
+  }
+
+  uint64_t byteAlignedResidualAt(uint64_t byteOffset, uint8_t bitWidth) const {
+    switch (bitWidth) {
+      case 8:
+        return static_cast<uint8_t>(packedData_[byteOffset]);
+      case 16: {
+        uint16_t value;
+        std::memcpy(&value, packedData_ + byteOffset, sizeof(value));
+        return value;
+      }
+      case 32: {
+        uint32_t value;
+        std::memcpy(&value, packedData_ + byteOffset, sizeof(value));
+        return value;
+      }
+      case 64: {
+        uint64_t value;
+        std::memcpy(&value, packedData_ + byteOffset, sizeof(value));
+        return value;
+      }
+      default:
+        return 0;
+    }
+  }
+
+  uint64_t residualAt(uint64_t rowBitOffset, uint8_t bitWidth) const {
+    if (bitWidth == 0) {
+      return 0;
+    }
+
+    const auto byteOffset = rowBitOffset / 8;
+    const auto bitOffsetInByte = rowBitOffset & 7;
+    if (bitOffsetInByte == 0 &&
+        (bitWidth == 8 || bitWidth == 16 || bitWidth == 32 || bitWidth == 64)) {
+      return byteAlignedResidualAt(byteOffset, bitWidth);
+    }
+
+    const auto bytesToRead = velox::bits::nbytes(bitOffsetInByte + bitWidth);
+    uint64_t word{0};
+    std::memcpy(
+        &word, packedData_ + byteOffset, std::min<uint64_t>(8, bytesToRead));
+    if (bytesToRead > 8) {
+      word = (word >> bitOffsetInByte) |
+          (static_cast<uint64_t>(
+               static_cast<uint8_t>(packedData_[byteOffset + 8]))
+           << (64 - bitOffsetInByte));
+      return word;
+    }
+    word >>= bitOffsetInByte;
+    const auto mask = bitWidth == 64 ? ~0ULL : ((uint64_t{1} << bitWidth) - 1);
+    return word & mask;
+  }
+
+  physicalType addResidual(physicalType reference, uint64_t residual) const {
+    if constexpr (std::is_signed_v<physicalType>) {
+      return static_cast<physicalType>(
+          static_cast<int64_t>(reference) + static_cast<int64_t>(residual));
+    } else {
+      return static_cast<physicalType>(reference + residual);
+    }
+  }
+
+  T readTypedAt(uint32_t index) const final {
+    NIMBLE_CHECK_LT(index, this->rowCount_);
+    const auto frame = index / frameSize_;
+    const auto positionInFrame = index % frameSize_;
+    const auto bitWidth = bitWidths_[frame];
+    NIMBLE_CHECK_LE(bitWidth, sizeof(physicalType) * 8);
+    const auto residual =
+        residualAt(bitOffset(frame) + positionInFrame * bitWidth, bitWidth);
+    const auto reference = references_[frame];
+    return detail::castFromPhysicalType<T>(addResidual(reference, residual));
+  }
+
+  uint32_t frameSize_{0};
+  uint32_t numFrames_{0};
+  bool enableBitOffsets_{false};
+  Vector<uint8_t> bitWidths_;
+  Vector<physicalType> references_;
+  Vector<uint64_t> bitOffsets_;
+  const char* packedData_{nullptr};
+};
+
+} // namespace facebook::nimble

--- a/dwio/nimble/encodings/views/MainlyConstantEncodingView.h
+++ b/dwio/nimble/encodings/views/MainlyConstantEncodingView.h
@@ -1,0 +1,92 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include "dwio/nimble/common/Vector.h"
+#include "dwio/nimble/encodings/common/EncodingFactory.h"
+#include "dwio/nimble/encodings/common/EncodingPrimitives.h"
+#include "dwio/nimble/encodings/views/EncodingViewFactory.h"
+
+namespace facebook::nimble {
+
+template <typename T>
+class MainlyConstantEncodingView final : public TypedEncodingView<T> {
+ public:
+  using physicalType = typename TypedEncodingView<T>::physicalType;
+
+  MainlyConstantEncodingView(
+      std::string_view data,
+      velox::memory::MemoryPool* pool,
+      const Encoding::Options& options)
+      : TypedEncodingView<T>{data, pool, options},
+        isCommon_{this->template getVectorBuffer<bool>()},
+        otherValueIndices_{this->template getVectorBuffer<uint32_t>()} {
+    NIMBLE_CHECK_EQ(this->encodingType_, EncodingType::MainlyConstant);
+    const char* pos = data.data() + this->dataOffset_;
+    const auto isCommonSize = encoding::readUint32(pos);
+    auto noStringBufferFactory = [](uint32_t) -> void* { return nullptr; };
+    auto isCommon = EncodingFactory{}.create(
+        *this->pool_, {pos, isCommonSize}, noStringBufferFactory, options);
+    NIMBLE_CHECK_NOT_NULL(isCommon);
+    isCommon_.resize(this->rowCount_);
+    isCommon->materialize(this->rowCount_, isCommon_.data());
+    pos += isCommonSize;
+
+    const auto otherValuesSize = encoding::readUint32(pos);
+    otherValues_ = detail::createTypedEncodingView<T>(
+        {pos, otherValuesSize}, this->pool_, options);
+    NIMBLE_CHECK_NOT_NULL(otherValues_);
+    pos += otherValuesSize;
+
+    commonValue_ = encoding::read<physicalType>(pos);
+    NIMBLE_CHECK_EQ(pos, data.end(), "Unexpected MainlyConstant view end.");
+
+    uint32_t otherValueCount = 0;
+    otherValueIndices_.resize(this->rowCount_);
+    for (uint32_t i = 0; i < this->rowCount_; ++i) {
+      otherValueIndices_[i] = otherValueCount;
+      if (!isCommon_[i]) {
+        ++otherValueCount;
+      }
+    }
+    NIMBLE_CHECK_EQ(otherValueCount, otherValues_->rowCount());
+  }
+
+  ~MainlyConstantEncodingView() override {
+    this->releaseVectorBuffer(otherValueIndices_);
+    this->releaseVectorBuffer(isCommon_);
+  }
+
+ private:
+  uint32_t otherValueIndex(uint32_t index) const {
+    return otherValueIndices_[index];
+  }
+
+  T readTypedAt(uint32_t index) const final {
+    NIMBLE_CHECK_LT(index, this->rowCount_);
+    if (isCommon_[index]) {
+      return detail::castFromPhysicalType<T>(commonValue_);
+    }
+    return otherValues_->readAt(otherValueIndex(index));
+  }
+
+  Vector<bool> isCommon_;
+  Vector<uint32_t> otherValueIndices_;
+  std::unique_ptr<TypedEncodingView<T>> otherValues_;
+  physicalType commonValue_;
+};
+
+} // namespace facebook::nimble

--- a/dwio/nimble/encodings/views/SparseBoolEncodingView.h
+++ b/dwio/nimble/encodings/views/SparseBoolEncodingView.h
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include "dwio/nimble/encodings/common/EncodingPrimitives.h"
+#include "dwio/nimble/encodings/views/EncodingViewFactory.h"
+
+namespace facebook::nimble {
+
+class SparseBoolEncodingView final : public TypedEncodingView<bool> {
+ public:
+  SparseBoolEncodingView(
+      std::string_view data,
+      velox::memory::MemoryPool* pool,
+      const Encoding::Options& options)
+      : TypedEncodingView<bool>{data, pool, options} {
+    NIMBLE_CHECK_EQ(this->encodingType_, EncodingType::SparseBool);
+    const char* pos = data.data() + this->dataOffset_;
+    sparseValue_ = static_cast<bool>(encoding::readChar(pos));
+    indices_ = detail::createTypedEncodingView<uint32_t>(
+        {pos, static_cast<size_t>(data.end() - pos)}, pool, options);
+    NIMBLE_CHECK_NOT_NULL(indices_);
+    NIMBLE_CHECK_GT(indices_->rowCount(), 0);
+    NIMBLE_CHECK_EQ(
+        indices_->readAt(indices_->rowCount() - 1), this->rowCount_);
+  }
+
+ private:
+  bool containsSparseIndex(uint32_t index) const {
+    uint32_t begin{0};
+    uint32_t end{indices_->rowCount()};
+    while (begin < end) {
+      const auto mid = begin + (end - begin) / 2;
+      if (indices_->readAt(mid) < index) {
+        begin = mid + 1;
+      } else {
+        end = mid;
+      }
+    }
+    return begin < indices_->rowCount() && indices_->readAt(begin) == index;
+  }
+
+  bool readTypedAt(uint32_t index) const final {
+    NIMBLE_CHECK_LT(index, this->rowCount_);
+    return containsSparseIndex(index) ? sparseValue_ : !sparseValue_;
+  }
+
+  bool sparseValue_{false};
+  std::unique_ptr<TypedEncodingView<uint32_t>> indices_;
+};
+
+} // namespace facebook::nimble


### PR DESCRIPTION
Summary:

Adds random-access EncodingView implementations and coverage for additional Nimble encodings used by dense feature normalization diagnostics.

Changes:
- Add `MainlyConstantEncodingView` with materialized per-row `otherValueIndices_` for faster random reads.
- Add `FOREncodingView` with compact materialized per-frame metadata (`bitWidths_`, `references_`, `bitOffsets_`) and byte-aligned residual fast paths.
- Add `SparseBoolEncodingView` for bool sparse-position streams.
- Wire the new views into `EncodingViewFactory` and remove FOR/SparseBool from the unsupported factory test matrix.
- Add focused tests and EncodingView benchmarks for MainlyConstant, FOR, and SparseBool.
- Include `for` and `sparse_bool` in dense feature normalization benchmark candidate parsing/defaults.

Reviewed By: HuamengJiang, duxiao1212

Differential Revision: D112596234


