### PR TITLE
refactor(encoding): Rename preserveDictionaryEncoding to preserveStringDictionaryEncoding (#980)

### DIFF
--- a/dwio/nimble/encodings/RLEEncoding.h
+++ b/dwio/nimble/encodings/RLEEncoding.h
@@ -528,8 +528,8 @@ RLEEncoding<T>::RLEEncoding(
           internal::RLEEncodingBase<T, RLEEncoding<T>>::getValuesStart())};
   auto valuesEncoding =
       EncodingFactory(options).create(pool, valuesView, stringBufferFactory);
-  if (options.preserveDictionaryEncoding && isStringType<physicalType>() &&
-      valuesEncoding->dictionaryEnabled()) {
+  if (options.preserveStringDictionaryEncoding &&
+      isStringType<physicalType>() && valuesEncoding->dictionaryEnabled()) {
     dictValues_ =
         std::make_unique<detail::BufferedDictEncoding<physicalType, 128>>(
             std::move(valuesEncoding));

--- a/dwio/nimble/encodings/RLEEncoding.h
+++ b/dwio/nimble/encodings/RLEEncoding.h
@@ -528,7 +528,7 @@ RLEEncoding<T>::RLEEncoding(
           internal::RLEEncodingBase<T, RLEEncoding<T>>::getValuesStart())};
   auto valuesEncoding =
       EncodingFactory(options).create(pool, valuesView, stringBufferFactory);
-  if (options.preserveDictionaryEncoding &&
+  if (options.preserveDictionaryEncoding && isStringType<physicalType>() &&
       valuesEncoding->dictionaryEnabled()) {
     dictValues_ =
         std::make_unique<detail::BufferedDictEncoding<physicalType, 128>>(

--- a/dwio/nimble/encodings/common/Encoding.h
+++ b/dwio/nimble/encodings/common/Encoding.h
@@ -129,7 +129,7 @@ class Encoding {
     /// use the dictionary index path when the inner encoding is
     /// dictionary-enabled. False by default — only the selective
     /// reader enables this for dictionary vector output.
-    bool preserveDictionaryEncoding = false;
+    bool preserveStringDictionaryEncoding = false;
 
     /// FrequencyPartitionEncoding index type (cast to FreqPartIndexType).
     /// 0 = NoIndex (default, backward-compatible), 1 = PerTierBitmaps,

--- a/dwio/nimble/velox/selective/ChunkedDecoder.cpp
+++ b/dwio/nimble/velox/selective/ChunkedDecoder.cpp
@@ -31,7 +31,7 @@ using namespace facebook::velox;
 using velox::common::testutil::TestValue;
 
 bool ChunkedDecoder::loadNextChunk(
-    bool preserveDictionaryEncoding,
+    bool preserveStringDictionaryEncoding,
     const ChunkBoundaryCallback& onChunkLoaded) {
   auto ret = ensureInput(kChunkHeaderSize);
   NIMBLE_CHECK(ret, "Failed to read chunk header");
@@ -77,7 +77,7 @@ bool ChunkedDecoder::loadNextChunk(
   auto data = std::string_view(chunkData, chunkSize);
   // Copy, not reference.
   auto options = encodingFactory_->options();
-  options.preserveDictionaryEncoding = preserveDictionaryEncoding;
+  options.preserveStringDictionaryEncoding = preserveStringDictionaryEncoding;
   options.decodingStats = decodingStats_;
   encoding_ =
       encodingFactory_->create(*pool_, data, stringBufferFactory, options);
@@ -275,7 +275,8 @@ void ChunkedDecoder::skipWithoutIndex(
     const ChunkBoundaryCallback& onChunkBoundary) {
   while (numValues > 0) {
     if (FOLLY_UNLIKELY(remainingValues_ == 0)) {
-      loadNextChunk(/*preserveDictionaryEncoding=*/false, onChunkBoundary);
+      loadNextChunk(/*preserveStringDictionaryEncoding=*/false,
+                    onChunkBoundary);
     }
     if (numValues < remainingValues_) {
       encoding_->skip(numValues);
@@ -302,7 +303,7 @@ void ChunkedDecoder::seekToChunk(
   remainingValues_ = 0;
 
   // Load the chunk at this position
-  loadNextChunk(/*preserveDictionaryEncoding=*/false, onChunkBoundary);
+  loadNextChunk(/*preserveStringDictionaryEncoding=*/false, onChunkBoundary);
 }
 
 std::optional<size_t> ChunkedDecoder::estimateRowCount() const {

--- a/dwio/nimble/velox/selective/ChunkedDecoder.h
+++ b/dwio/nimble/velox/selective/ChunkedDecoder.h
@@ -287,14 +287,14 @@ class ChunkedDecoder {
   // that the caller sees the encoding and remainingValues of the chunk that
   // will actually be read.
   void ensureLoaded(
-      bool preserveDictionaryEncoding = false,
+      bool preserveStringDictionaryEncoding = false,
       const ChunkBoundaryCallback& onChunkBoundary = kNoopAtChunkBoundary) {
     if (encoding_ != nullptr && remainingValues_ != 0) {
       return;
     }
 
     if (hasMoreChunks()) {
-      loadNextChunk(preserveDictionaryEncoding, onChunkBoundary);
+      loadNextChunk(preserveStringDictionaryEncoding, onChunkBoundary);
     }
   }
 
@@ -440,7 +440,7 @@ class ChunkedDecoder {
       // chunk mid-count, which would produce numNonNulls spanning two
       // chunks and incorrect index reads.
       if (FOLLY_UNLIKELY(remainingValues_ == 0)) {
-        loadNextChunk(/*preserveDictionaryEncoding=*/true);
+        loadNextChunk(/*preserveStringDictionaryEncoding=*/true);
         if (!onChunkBoundary()) {
           // The new chunk is not dictionary-compatible. readOffset_ has not
           // moved during this read, so it still holds the read's start offset;
@@ -787,7 +787,8 @@ class ChunkedDecoder {
 
   // Loads the next chunk from the input stream and creates a new encoding.
   //
-  // @param preserveDictionaryEncoding When true, creates the encoding with
+  // @param preserveStringDictionaryEncoding When true, creates the encoding
+  // with
   //   dictionary mode enabled so that RLE enters dict index mode. Only the
   //   string dictionary reader passes true; all other callers use the
   //   default (false).
@@ -795,7 +796,7 @@ class ChunkedDecoder {
   //   continue reading, false to stop (e.g., the new chunk is not
   //   dictionary-compatible). Defaults to kNoopAtChunkBoundary.
   bool loadNextChunk(
-      bool preserveDictionaryEncoding = false,
+      bool preserveStringDictionaryEncoding = false,
       const ChunkBoundaryCallback& onChunkLoaded = kNoopAtChunkBoundary);
 
   void prepareInputBuffer(int32_t size);

--- a/dwio/nimble/velox/selective/StringColumnReader.cpp
+++ b/dwio/nimble/velox/selective/StringColumnReader.cpp
@@ -351,7 +351,7 @@ bool StringColumnReader::readWithDictionary(
   // callback clears stale dictionary state so ensureDictionaryState rebuilds
   // from the new encoding.
   decoder_.ensureLoaded(
-      /*preserveDictionaryEncoding=*/true, [this] {
+      /*preserveStringDictionaryEncoding=*/true, [this] {
         clearDictionaryState();
         return true;
       });


### PR DESCRIPTION
Summary:

Rename the flag to make its scope explicit — it only applies to string dictionary preservation for `DictionaryVector<StringView>` output.

Differential Revision: D112646498


