### PR TITLE
feat: Add index factory support for custom index extensions (#981)

### DIFF
--- a/dwio/nimble/docs/architecture/nimble_metadata_cache.html
+++ b/dwio/nimble/docs/architecture/nimble_metadata_cache.html
@@ -632,7 +632,7 @@ ensureInput() copies across boundary.
 │   Metadata       "columnar.metadata"        — key-value pairs           │
 │   Stats          "columnar.vectorized_stats"— per-column stats          │
 │   ChunkIndex     "columnar.chunk.index"     — root → per-group blobs   │
-│   ClusterIndex   "columnar.cluster.index"   — root → per-group blobs   │
+│   FileIndexes    "columnar.indexes"         — named index manifest     │
 │   StrideIndex    "columnar.stride.index"    — root → per-group blobs   │
 ├──────────────────────────────────────────────────────────────────────────┤
 │ <strong>FOOTER</strong> (FlatBuffers, possibly Zstd compressed)                         │
@@ -684,14 +684,14 @@ ensureInput() copies across boundary.
                    │                              optional_sections:
                    │                                "columnar.schema"        → {0xB000, ...}
                    │                                "columnar.chunk.index"   → {0xC000, ...}
-                   │                                "columnar.cluster.index" → {0xD000, ...}
+                   │                                "columnar.indexes"       → {0xD000, ...}
                    │
                    ├─ 0x8000: StripeGroup 0 blob
                    ├─ 0x9000: StripeGroup 1 blob
                    ├─ 0xA000: Stripes blob
                    ├─ 0xB000: Schema blob
                    ├─ 0xC000: ChunkIndex root blob
-                   └─ 0xD000: ClusterIndex root blob
+                   └─ 0xD000: File index manifest blob
 
 One field (row_count) gives the answer directly.
 Everything else says "go read that blob if you need it."</div>
@@ -763,7 +763,7 @@ Together with StripeGroup, you can read any column.</div>
   <tr><td><code>columnar.stats</code></td><td>Legacy (replaced by vectorized_stats)</td></tr>
   <tr><td><code>columnar.vectorized_stats</code></td><td>Active</td></tr>
   <tr><td><code>columnar.chunk.index</code></td><td>Active</td></tr>
-  <tr><td><code>columnar.cluster.index</code></td><td>Active</td></tr>
+  <tr><td><code>columnar.indexes</code></td><td>Active file index manifest</td></tr>
   <tr><td><code>columnar.stride.index</code></td><td>New</td></tr>
   <tr><td><code>columnar.dense.index</code></td><td>Defined, not implemented</td></tr>
 </table>

--- a/dwio/nimble/index/CMakeLists.txt
+++ b/dwio/nimble/index/CMakeLists.txt
@@ -17,11 +17,14 @@ add_library(
   ChunkIndex.cpp
   ChunkIndexGroup.cpp
   ClusterIndex.cpp
+  ClusterIndexFactory.cpp
   ClusterIndexWriter.cpp
   DenseIndexRegistry.cpp
   HashIndex.cpp
   HashIndexWriter.cpp
+  IndexConfig.cpp
   IndexFilter.cpp
+  IndexKeyEncoder.cpp
   KeyChunkDecoder.cpp
   KeyEncoding.cpp
   SortedIndex.cpp
@@ -39,6 +42,7 @@ target_link_libraries(
   nimble_cluster_index_fb
   nimble_chunk_index_fb
   nimble_hash_index_fb
+  nimble_index_fb
   nimble_bloom_filter_fb
   nimble_sorted_index_fb
   velox_core

--- a/dwio/nimble/index/ClusterIndexFactory.cpp
+++ b/dwio/nimble/index/ClusterIndexFactory.cpp
@@ -1,0 +1,103 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "dwio/nimble/index/ClusterIndexFactory.h"
+
+#include <mutex>
+#include <optional>
+
+#include "dwio/nimble/common/Exceptions.h"
+#include "dwio/nimble/index/ClusterIndex.h"
+#include "dwio/nimble/index/ClusterIndexWriter.h"
+#include "folly/container/F14Map.h"
+
+namespace facebook::nimble::index {
+
+namespace {
+
+using FactoryMap =
+    folly::F14FastMap<std::string, std::shared_ptr<const ClusterIndexFactory>>;
+
+FactoryMap& factories() {
+  static auto* map = new FactoryMap();
+  return *map;
+}
+
+std::mutex& factoriesMutex() {
+  static auto* mutex = new std::mutex();
+  return *mutex;
+}
+
+class NimbleClusterIndexFactory final : public ClusterIndexFactory {
+ public:
+  std::string_view name() const override {
+    return kClusterIndexName;
+  }
+
+  std::unique_ptr<IndexWriter> createWriter(
+      const ClusterIndexConfig& config,
+      const velox::TypePtr& inputType,
+      velox::memory::MemoryPool* pool) const override {
+    return ClusterIndexWriter::create(
+        std::optional<ClusterIndexConfig>{config}, inputType, pool);
+  }
+
+  std::unique_ptr<IndexKeyEncoder> createKeyEncoder(
+      const std::vector<std::string>& columns,
+      const velox::RowTypePtr& inputType,
+      const std::vector<SortOrder>& sortOrders,
+      velox::memory::MemoryPool* pool) const override {
+    return createNimbleIndexKeyEncoder(columns, inputType, sortOrders, pool);
+  }
+
+  std::unique_ptr<ClusterIndex> createReader(
+      Section rootSection,
+      velox::memory::MemoryPool* pool,
+      const IndexLookup::Options& options) const override {
+    return ClusterIndex::create(std::move(rootSection), pool, options);
+  }
+};
+
+void ensureBuiltInFactoriesRegistered() {
+  static const bool registered = [] {
+    registerClusterIndexFactory(
+        std::make_shared<const NimbleClusterIndexFactory>());
+    return true;
+  }();
+  (void)registered;
+}
+
+} // namespace
+
+void registerClusterIndexFactory(
+    std::shared_ptr<const ClusterIndexFactory> factory) {
+  NIMBLE_CHECK_NOT_NULL(factory);
+  const auto name = std::string{factory->name()};
+  NIMBLE_CHECK(!name.empty(), "Cluster index factory name cannot be empty");
+  std::lock_guard lock(factoriesMutex());
+  auto [_, inserted] = factories().emplace(name, std::move(factory));
+  NIMBLE_CHECK(inserted, "Cluster index factory already registered: {}", name);
+}
+
+const ClusterIndexFactory& clusterIndexFactory(std::string_view name) {
+  ensureBuiltInFactoriesRegistered();
+  std::lock_guard lock(factoriesMutex());
+  auto it = factories().find(name);
+  NIMBLE_CHECK(
+      it != factories().end(), "Unknown cluster index factory: {}", name);
+  return *it->second;
+}
+
+} // namespace facebook::nimble::index

--- a/dwio/nimble/index/ClusterIndexFactory.h
+++ b/dwio/nimble/index/ClusterIndexFactory.h
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <memory>
+#include <string_view>
+
+#include "dwio/nimble/index/IndexConfig.h"
+#include "dwio/nimble/index/IndexKeyEncoder.h"
+#include "dwio/nimble/index/IndexLookup.h"
+#include "dwio/nimble/index/IndexWriter.h"
+#include "dwio/nimble/tablet/MetadataBuffer.h"
+#include "velox/common/memory/Memory.h"
+#include "velox/type/Type.h"
+
+namespace facebook::nimble::index {
+
+class ClusterIndex;
+
+class ClusterIndexFactory {
+ public:
+  virtual ~ClusterIndexFactory() = default;
+
+  virtual std::string_view name() const = 0;
+
+  virtual std::unique_ptr<IndexWriter> createWriter(
+      const ClusterIndexConfig& config,
+      const velox::TypePtr& inputType,
+      velox::memory::MemoryPool* pool) const = 0;
+
+  virtual std::unique_ptr<IndexKeyEncoder> createKeyEncoder(
+      const std::vector<std::string>& columns,
+      const velox::RowTypePtr& inputType,
+      const std::vector<SortOrder>& sortOrders,
+      velox::memory::MemoryPool* pool) const = 0;
+
+  virtual std::unique_ptr<ClusterIndex> createReader(
+      Section rootSection,
+      velox::memory::MemoryPool* pool,
+      const IndexLookup::Options& options) const = 0;
+};
+
+void registerClusterIndexFactory(
+    std::shared_ptr<const ClusterIndexFactory> factory);
+
+const ClusterIndexFactory& clusterIndexFactory(std::string_view name);
+
+} // namespace facebook::nimble::index

--- a/dwio/nimble/index/ClusterIndexWriter.cpp
+++ b/dwio/nimble/index/ClusterIndexWriter.cpp
@@ -15,6 +15,7 @@
  */
 #include "dwio/nimble/index/ClusterIndexWriter.h"
 
+#include "dwio/nimble/index/ClusterIndexFactory.h"
 #include "dwio/nimble/index/IndexConstants.h"
 #include "dwio/nimble/tablet/ClusterIndexGenerated.h"
 #include "dwio/nimble/tablet/Constants.h"
@@ -47,41 +48,6 @@ const InputBufferGrowthPolicy& keyStreamGrowthPolicy() {
   static const auto policy =
       DefaultInputBufferGrowthPolicy::withDefaultRanges();
   return *policy;
-}
-
-// Converts nimble SortOrders to velox::core::SortOrders.
-// If sortOrders is empty, returns default ascending sort orders.
-std::vector<velox::core::SortOrder> toVeloxSortOrders(
-    const std::vector<SortOrder>& sortOrders,
-    size_t columnCount) {
-  if (sortOrders.empty()) {
-    return std::vector<velox::core::SortOrder>(
-        columnCount, velox::core::SortOrder{true, false});
-  }
-  std::vector<velox::core::SortOrder> result;
-  result.reserve(sortOrders.size());
-  for (const auto& sortOrder : sortOrders) {
-    result.push_back(sortOrder.toVeloxSortOrder());
-  }
-  return result;
-}
-
-std::unique_ptr<velox::serializer::KeyEncoder> createClusterKeyEncoder(
-    const ClusterIndexConfig& config,
-    const velox::RowTypePtr& inputType,
-    velox::memory::MemoryPool* pool) {
-  NIMBLE_CHECK(
-      config.sortOrders.empty() ||
-          config.sortOrders.size() == config.columns.size(),
-      "sortOrders size ({}) must be empty or match columns size ({})",
-      config.sortOrders.size(),
-      config.columns.size());
-
-  return velox::serializer::KeyEncoder::create(
-      config.columns,
-      inputType,
-      toVeloxSortOrders(config.sortOrders, config.columns.size()),
-      pool);
 }
 
 std::string_view asView(const flatbuffers::FlatBufferBuilder& builder) {
@@ -127,7 +93,9 @@ ClusterIndexWriter::ClusterIndexWriter(
                                           config.columns.size(),
                                           SortOrder{.ascending = true})
                                     : config.sortOrders},
-      keyEncoder_{createClusterKeyEncoder(config, inputType, pool)},
+      keyEncoder_{
+          clusterIndexFactory(config.indexName)
+              .createKeyEncoder(config.columns, inputType, sortOrders_, pool)},
       encodingLayout_{config.encodingLayout},
       enforceKeyOrder_{config.enforceKeyOrder},
       keyColumnIndices_{getKeyColumnIndices({config.columns}, inputType)},
@@ -168,9 +136,14 @@ void ClusterIndexWriter::write(const velox::VectorPtr& input) {
   const auto newKeyStart = keyStream_->mutableData().size();
   keyStream_->ensureMutableDataCapacity(newKeyStart + input->size());
 
-  keyEncoder_->encode(input, keyStream_->mutableData(), [this](size_t size) {
+  encodedKeys_.clear();
+  encodedKeys_.reserve(input->size());
+  keyEncoder_->encode(input, encodedKeys_, [this](size_t size) {
     return keyBuffer_->reserve(size);
   });
+  for (const auto key : encodedKeys_) {
+    keyStream_->mutableData().emplace_back(key);
+  }
 
   validateKeyOrder(newKeyStart);
 
@@ -299,10 +272,9 @@ void ClusterIndexWriter::encodeKeyChunk(
   }
 }
 
-void ClusterIndexWriter::close(
+std::optional<IndexDescriptor> ClusterIndexWriter::close(
     const WriteDataFn& /*writeDataFn*/,
-    const CreateMetadataSectionFn& createMetadataFn,
-    const WriteOptionalSectionFn& writeMetadataFn) {
+    const CreateMetadataSectionFn& createMetadataFn) {
   setClosed();
 
   SCOPE_EXIT {
@@ -313,7 +285,7 @@ void ClusterIndexWriter::close(
   };
 
   if (indexRoot_ == nullptr) {
-    return;
+    return std::nullopt;
   }
 
   NIMBLE_CHECK(
@@ -369,7 +341,10 @@ void ClusterIndexWriter::close(
           partitionKeysVector,
           partitionRowCountsVector));
 
-  writeMetadataFn(std::string(kClusterIndexSection), asView(builder));
+  return IndexDescriptor{
+      .family = IndexFamily::Cluster,
+      .name = std::string{kClusterIndexName},
+      .root = createMetadataFn(asView(builder))};
 }
 
 void ClusterIndexWriter::ensureIndexRoot() {

--- a/dwio/nimble/index/ClusterIndexWriter.h
+++ b/dwio/nimble/index/ClusterIndexWriter.h
@@ -27,7 +27,6 @@
 #include "dwio/nimble/tablet/MetadataBuffer.h"
 #include "dwio/nimble/velox/StreamData.h"
 #include "velox/common/memory/Memory.h"
-#include "velox/serializers/KeyEncoder.h"
 #include "velox/vector/ComplexVector.h"
 
 namespace facebook::nimble::index {
@@ -86,10 +85,9 @@ class ClusterIndexWriter : public IndexWriter {
       const WriteDataFn& writeDataFn,
       const CreateMetadataSectionFn& createMetadataFn) override;
 
-  void close(
+  std::optional<IndexDescriptor> close(
       const WriteDataFn& writeDataFn,
-      const CreateMetadataSectionFn& createMetadataFn,
-      const WriteOptionalSectionFn& writeMetadataFn) override;
+      const CreateMetadataSectionFn& createMetadataFn) override;
 
  private:
   ClusterIndexWriter(
@@ -172,7 +170,7 @@ class ClusterIndexWriter : public IndexWriter {
   velox::memory::MemoryPool* const pool_;
   const std::vector<std::string> columns_;
   const std::vector<SortOrder> sortOrders_;
-  const std::unique_ptr<velox::serializer::KeyEncoder> keyEncoder_;
+  const std::unique_ptr<IndexKeyEncoder> keyEncoder_;
   const EncodingLayout encodingLayout_;
   const bool enforceKeyOrder_;
   const std::vector<velox::column_index_t> keyColumnIndices_;
@@ -189,6 +187,8 @@ class ClusterIndexWriter : public IndexWriter {
   // in keyStream_ point into this buffer. Reset after encodeKeyChunks()
   // processes the keys into encoded chunks.
   std::unique_ptr<Buffer> keyBuffer_;
+  // Reused batch output before appending views to keyStream_.
+  std::vector<std::string_view> encodedKeys_;
 
   // Partition-level state accumulator.
   std::unique_ptr<IndexPartition> indexPartition_;

--- a/dwio/nimble/index/DenseIndexRegistry.h
+++ b/dwio/nimble/index/DenseIndexRegistry.h
@@ -31,8 +31,8 @@ class SortedIndex;
 
 /// Unified registry for dense indices (hash and sorted) on a Nimble file.
 ///
-/// Loads from both "columnar.hash.index" and "columnar.sorted.index" optional
-/// sections. Validates no duplicate column sets across index types.
+/// Loads dense index payloads referenced by the common index manifest and
+/// validates no duplicate column sets across index types.
 class DenseIndexRegistry {
  public:
   /// Creates a registry from optional hash and sorted index sections.

--- a/dwio/nimble/index/HashIndexWriter.cpp
+++ b/dwio/nimble/index/HashIndexWriter.cpp
@@ -283,6 +283,11 @@ HashIndexWriter::HashIndexWriter(
   for (const auto& config : configs) {
     NIMBLE_CHECK(
         !config.columns.empty(), "Hash index must have at least one column");
+    NIMBLE_CHECK_EQ(
+        config.indexName,
+        kDenseHashIndexName,
+        "Unsupported hash index implementation: {}",
+        config.indexName);
     // Check for duplicate index columns.
     for (size_t i = 0; i < accumulators_.size(); ++i) {
       NIMBLE_CHECK(
@@ -295,7 +300,12 @@ HashIndexWriter::HashIndexWriter(
     accumulators_.emplace_back(
         IndexAccumulator{
             .config = config,
-            .encoder = createKeyEncoder(config.columns, inputType, pool),
+            .encoder = createNimbleIndexKeyEncoder(
+                config.columns,
+                inputType,
+                std::vector<SortOrder>(
+                    config.columns.size(), SortOrder{.ascending = true}),
+                pool),
         });
   }
 }
@@ -336,14 +346,13 @@ void HashIndexWriter::write(const velox::VectorPtr& input) {
   numRows_ += input->size();
 }
 
-void HashIndexWriter::close(
+std::optional<IndexDescriptor> HashIndexWriter::close(
     const WriteDataFn& /*writeDataFn*/,
-    const CreateMetadataSectionFn& createMetadataFn,
-    const WriteOptionalSectionFn& writeMetadataFn) {
+    const CreateMetadataSectionFn& createMetadataFn) {
   setClosed();
 
   if (numRows_ == 0) {
-    return;
+    return std::nullopt;
   }
 
   // Write each hash index as a separate section.
@@ -360,12 +369,15 @@ void HashIndexWriter::close(
 
   flatbuffers::FlatBufferBuilder directoryBuilder;
   buildIndexDirectoryFlatBuffer(directoryBuilder, indexSections);
-  writeMetadataFn(
-      std::string(kHashIndexSection), asStringView(directoryBuilder));
 
   for (auto& accumulator : accumulators_) {
     accumulator.clear();
   }
+
+  return IndexDescriptor{
+      .family = IndexFamily::Dense,
+      .name = std::string{kDenseHashIndexName},
+      .root = createMetadataFn(asStringView(directoryBuilder))};
 }
 
 } // namespace facebook::nimble::index

--- a/dwio/nimble/index/HashIndexWriter.h
+++ b/dwio/nimble/index/HashIndexWriter.h
@@ -16,16 +16,17 @@
 #pragma once
 
 #include <memory>
+#include <optional>
 #include <string>
 #include <vector>
 
 #include "dwio/nimble/common/Buffer.h"
 #include "dwio/nimble/index/IndexConfig.h"
+#include "dwio/nimble/index/IndexKeyEncoder.h"
 #include "dwio/nimble/index/IndexWriter.h"
 #include "dwio/nimble/tablet/MetadataBuffer.h"
 #include "flatbuffers/flatbuffers.h"
 #include "velox/common/memory/Memory.h"
-#include "velox/serializers/KeyEncoder.h"
 #include "velox/vector/ComplexVector.h"
 
 namespace facebook::nimble::serialization {
@@ -96,10 +97,9 @@ class HashIndexWriter : public IndexWriter {
   /// Encodes keys from the input batch and records row mappings.
   void write(const velox::VectorPtr& input) override;
 
-  void close(
+  std::optional<IndexDescriptor> close(
       const WriteDataFn& writeDataFn,
-      const CreateMetadataSectionFn& createMetadataFn,
-      const WriteOptionalSectionFn& writeMetadataFn) override;
+      const CreateMetadataSectionFn& createMetadataFn) override;
 
  private:
   HashIndexWriter(
@@ -118,7 +118,7 @@ class HashIndexWriter : public IndexWriter {
   // Per-index accumulator that collects keys and builds the hash table.
   struct IndexAccumulator {
     HashIndexConfig config;
-    std::unique_ptr<velox::serializer::KeyEncoder> encoder;
+    std::unique_ptr<IndexKeyEncoder> encoder;
     // Accumulated index entries with encoded keys pointing into
     // encodingBuffer_.
     std::vector<IndexEntry> entries;

--- a/dwio/nimble/index/IndexConfig.cpp
+++ b/dwio/nimble/index/IndexConfig.cpp
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "dwio/nimble/index/IndexSerialization.h"
+
+#include "dwio/nimble/common/Exceptions.h"
+
+namespace facebook::nimble::index {
+
+IndexFamily toIndexFamily(serialization::IndexFamily family) {
+  switch (family) {
+    case serialization::IndexFamily_Cluster:
+      return IndexFamily::Cluster;
+    case serialization::IndexFamily_Dense:
+      return IndexFamily::Dense;
+  }
+  NIMBLE_UNREACHABLE(
+      "Unsupported serialized index family: {}", static_cast<int>(family));
+}
+
+serialization::IndexFamily toIndexFamily(IndexFamily family) {
+  switch (family) {
+    case IndexFamily::Cluster:
+      return serialization::IndexFamily_Cluster;
+    case IndexFamily::Dense:
+      return serialization::IndexFamily_Dense;
+  }
+  NIMBLE_UNREACHABLE("Unsupported index family: {}", static_cast<int>(family));
+}
+
+} // namespace facebook::nimble::index

--- a/dwio/nimble/index/IndexConfig.h
+++ b/dwio/nimble/index/IndexConfig.h
@@ -15,15 +15,39 @@
  */
 #pragma once
 
+#include <cstdint>
+#include <memory>
 #include <optional>
 #include <string>
+#include <string_view>
 #include <vector>
 
 #include "dwio/nimble/common/Types.h"
 #include "dwio/nimble/encodings/common/EncodingLayout.h"
 #include "dwio/nimble/index/SortOrder.h"
+#include "dwio/nimble/tablet/MetadataBuffer.h"
 
-namespace facebook::nimble {
+namespace facebook::velox::config {
+class ConfigBase;
+}
+
+namespace facebook::nimble::index {
+
+enum class IndexFamily : uint8_t {
+  Cluster,
+  Dense,
+};
+
+struct IndexDescriptor {
+  IndexFamily family;
+  std::string name;
+  MetadataSection root;
+};
+
+inline constexpr std::string_view kClusterIndexName{"nimble.cluster.v1"};
+inline constexpr std::string_view kDenseHashIndexName{"nimble.dense.hash.v1"};
+inline constexpr std::string_view kDenseSortedIndexName{
+    "nimble.dense.sorted.v1"};
 
 /// Configuration for index generation.
 /// The index allows efficient filtering and pruning of data based on
@@ -31,6 +55,8 @@ namespace facebook::nimble {
 // EXPERIMENTAL: Cluster index is not production-ready. Do not enable for
 // production tables without consulting the Nimble team (oncall: dwios).
 struct ClusterIndexConfig {
+  /// Named cluster index implementation.
+  std::string indexName{std::string(kClusterIndexName)};
   /// Columns to be indexed for data pruning.
   /// These columns will be encoded using KeyWriter to generate index keys
   /// that enable efficient data skipping during reads.
@@ -65,6 +91,8 @@ struct ClusterIndexConfig {
   /// granularity — chunks have start/end keys for binary search. Smaller values
   /// give finer-grained lookups at the cost of more metadata.
   uint64_t maxRowsPerKeyChunk{10'000};
+  /// Configuration options for a custom cluster index implementation.
+  std::shared_ptr<const velox::config::ConfigBase> customOptions;
 };
 
 /// Configuration for bloom filter.
@@ -83,6 +111,8 @@ struct BloomFilterConfig {
 // EXPERIMENTAL: Hash index is not production-ready. Do not enable for
 // production tables without consulting the Nimble team (oncall: dwios).
 struct HashIndexConfig {
+  /// Named dense index implementation.
+  std::string indexName{std::string(kDenseHashIndexName)};
   /// Columns forming the composite key for point lookups.
   std::vector<std::string> columns;
 
@@ -109,6 +139,8 @@ struct HashIndexConfig {
 // EXPERIMENTAL: Sorted index is not production-ready. Do not enable for
 // production tables without consulting the Nimble team (oncall: dwios).
 struct SortedIndexConfig {
+  /// Named dense index implementation.
+  std::string indexName{std::string(kDenseSortedIndexName)};
   /// Columns forming the composite key.
   std::vector<std::string> columns;
   /// The encoding layout for the key stream.
@@ -123,4 +155,4 @@ struct SortedIndexConfig {
   uint64_t maxRowsPerKeyChunk{0};
 };
 
-} // namespace facebook::nimble
+} // namespace facebook::nimble::index

--- a/dwio/nimble/index/IndexKeyEncoder.cpp
+++ b/dwio/nimble/index/IndexKeyEncoder.cpp
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "dwio/nimble/index/IndexKeyEncoder.h"
+
+#include "dwio/nimble/common/Exceptions.h"
+
+namespace facebook::nimble::index {
+namespace {
+
+class NimbleIndexKeyEncoder final : public IndexKeyEncoder {
+ public:
+  explicit NimbleIndexKeyEncoder(
+      std::unique_ptr<velox::serializer::KeyEncoder> encoder)
+      : encoder_{std::move(encoder)} {}
+
+  void encode(
+      const velox::VectorPtr& input,
+      std::vector<std::string_view>& encodedKeys,
+      const BufferAllocator& bufferAllocator) override {
+    encoder_->encode(input, encodedKeys, bufferAllocator);
+  }
+
+  std::vector<velox::serializer::EncodedKeyBounds> encodeIndexBounds(
+      const velox::serializer::IndexBounds& indexBounds) override {
+    return encoder_->encodeIndexBounds(indexBounds);
+  }
+
+ private:
+  std::unique_ptr<velox::serializer::KeyEncoder> encoder_;
+};
+
+} // namespace
+
+std::unique_ptr<IndexKeyEncoder> createNimbleIndexKeyEncoder(
+    const std::vector<std::string>& columns,
+    const velox::RowTypePtr& inputType,
+    const std::vector<SortOrder>& sortOrders,
+    velox::memory::MemoryPool* pool) {
+  NIMBLE_CHECK_EQ(
+      sortOrders.size(),
+      columns.size(),
+      "sortOrders and columns must have the same size");
+  std::vector<velox::core::SortOrder> veloxSortOrders;
+  veloxSortOrders.reserve(sortOrders.size());
+  for (const auto& sortOrder : sortOrders) {
+    veloxSortOrders.emplace_back(sortOrder.toVeloxSortOrder());
+  }
+  return std::make_unique<NimbleIndexKeyEncoder>(
+      velox::serializer::KeyEncoder::create(
+          columns, inputType, std::move(veloxSortOrders), pool));
+}
+
+} // namespace facebook::nimble::index

--- a/dwio/nimble/index/IndexKeyEncoder.h
+++ b/dwio/nimble/index/IndexKeyEncoder.h
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <functional>
+#include <memory>
+#include <string_view>
+#include <vector>
+
+#include "dwio/nimble/index/SortOrder.h"
+#include "velox/serializers/KeyEncoder.h"
+
+namespace facebook::nimble::index {
+
+/// Encodes index keys for writing and lookup using a consistent byte format.
+class IndexKeyEncoder {
+ public:
+  /// Allocates stable storage for one encoded batch.
+  using BufferAllocator = std::function<void*(size_t)>;
+
+  virtual ~IndexKeyEncoder() = default;
+
+  /// Encodes one key per input row into memory provided by bufferAllocator.
+  virtual void encode(
+      const velox::VectorPtr& input,
+      std::vector<std::string_view>& encodedKeys,
+      const BufferAllocator& bufferAllocator) = 0;
+
+  /// Encodes lookup bounds using the same format as write-path keys.
+  virtual std::vector<velox::serializer::EncodedKeyBounds> encodeIndexBounds(
+      const velox::serializer::IndexBounds& indexBounds) = 0;
+};
+
+/// Creates the built-in Velox-backed index key encoder.
+std::unique_ptr<IndexKeyEncoder> createNimbleIndexKeyEncoder(
+    const std::vector<std::string>& columns,
+    const velox::RowTypePtr& inputType,
+    const std::vector<SortOrder>& sortOrders,
+    velox::memory::MemoryPool* pool);
+
+} // namespace facebook::nimble::index

--- a/dwio/nimble/index/IndexSerialization.h
+++ b/dwio/nimble/index/IndexSerialization.h
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include "dwio/nimble/index/IndexConfig.h"
+#include "dwio/nimble/tablet/IndexGenerated.h"
+
+namespace facebook::nimble::index {
+
+/// Converts a serialized index family to its runtime representation.
+IndexFamily toIndexFamily(serialization::IndexFamily family);
+
+/// Converts a runtime index family to its serialized representation.
+serialization::IndexFamily toIndexFamily(IndexFamily family);
+
+} // namespace facebook::nimble::index

--- a/dwio/nimble/index/IndexWriter.cpp
+++ b/dwio/nimble/index/IndexWriter.cpp
@@ -48,17 +48,6 @@ void IndexWriter::validateNoNullKeys(
 }
 
 // static
-std::unique_ptr<velox::serializer::KeyEncoder> IndexWriter::createKeyEncoder(
-    const std::vector<std::string>& columns,
-    const velox::RowTypePtr& inputType,
-    velox::memory::MemoryPool* pool) {
-  std::vector<velox::core::SortOrder> sortOrders(
-      columns.size(), velox::core::SortOrder{true, false});
-  return velox::serializer::KeyEncoder::create(
-      columns, inputType, std::move(sortOrders), pool);
-}
-
-// static
 std::vector<velox::column_index_t> IndexWriter::getKeyColumnIndices(
     const std::vector<std::vector<std::string>>& columnSets,
     const velox::RowTypePtr& inputType) {

--- a/dwio/nimble/index/IndexWriter.h
+++ b/dwio/nimble/index/IndexWriter.h
@@ -16,12 +16,14 @@
 #pragma once
 
 #include <memory>
+#include <optional>
 #include <string>
 #include <vector>
 
 #include "dwio/nimble/common/Exceptions.h"
+#include "dwio/nimble/index/IndexConfig.h"
+#include "dwio/nimble/index/IndexKeyEncoder.h"
 #include "dwio/nimble/tablet/MetadataBuffer.h"
-#include "velox/serializers/KeyEncoder.h"
 #include "velox/vector/ComplexVector.h"
 
 namespace facebook::nimble::index {
@@ -45,12 +47,11 @@ class IndexWriter {
       const WriteDataFn& writeDataFn,
       const CreateMetadataSectionFn& createMetadataFn) {}
 
-  /// Finalizes the index, writes it as an optional section, and releases
-  /// resources.
-  virtual void close(
+  /// Finalizes the index, writes implementation-specific metadata sections,
+  /// and returns a descriptor for the common index manifest.
+  virtual std::optional<IndexDescriptor> close(
       const WriteDataFn& writeDataFn,
-      const CreateMetadataSectionFn& createMetadataFn,
-      const WriteOptionalSectionFn& writeMetadataFn) = 0;
+      const CreateMetadataSectionFn& createMetadataFn) = 0;
 
  protected:
   void checkNotClosed() const {
@@ -66,12 +67,6 @@ class IndexWriter {
   static void validateNoNullKeys(
       const velox::VectorPtr& input,
       const std::vector<velox::column_index_t>& keyColumnIndices);
-
-  // Creates a KeyEncoder with ascending sort order for the given columns.
-  static std::unique_ptr<velox::serializer::KeyEncoder> createKeyEncoder(
-      const std::vector<std::string>& columns,
-      const velox::RowTypePtr& inputType,
-      velox::memory::MemoryPool* pool);
 
   // Returns deduplicated key column indices across multiple column sets.
   static std::vector<velox::column_index_t> getKeyColumnIndices(

--- a/dwio/nimble/index/SortedIndexWriter.cpp
+++ b/dwio/nimble/index/SortedIndexWriter.cpp
@@ -142,6 +142,11 @@ SortedIndexWriter::SortedIndexWriter(
   for (const auto& config : configs) {
     NIMBLE_CHECK(
         !config.columns.empty(), "Sorted index must have at least one column");
+    NIMBLE_CHECK_EQ(
+        config.indexName,
+        kDenseSortedIndexName,
+        "Unsupported sorted index implementation: {}",
+        config.indexName);
     for (size_t i = 0; i < accumulators_.size(); ++i) {
       NIMBLE_CHECK(
           accumulators_[i].config.columns != config.columns,
@@ -151,7 +156,12 @@ SortedIndexWriter::SortedIndexWriter(
     accumulators_.emplace_back(
         IndexAccumulator{
             .config = config,
-            .encoder = createKeyEncoder(config.columns, inputType, pool),
+            .encoder = createNimbleIndexKeyEncoder(
+                config.columns,
+                inputType,
+                std::vector<SortOrder>(
+                    config.columns.size(), SortOrder{.ascending = true}),
+                pool),
         });
   }
 }
@@ -324,14 +334,13 @@ void SortedIndexWriter::buildDirectoryFlatBuffer(
       serialization::CreateSortedIndexDirectory(builder, indicesVec));
 }
 
-void SortedIndexWriter::close(
+std::optional<IndexDescriptor> SortedIndexWriter::close(
     const WriteDataFn& writeDataFn,
-    const CreateMetadataSectionFn& createMetadataFn,
-    const WriteOptionalSectionFn& writeMetadataFn) {
+    const CreateMetadataSectionFn& createMetadataFn) {
   setClosed();
 
   if (numRows_ == 0) {
-    return;
+    return std::nullopt;
   }
 
   std::vector<MetadataSection> indexSections;
@@ -344,8 +353,10 @@ void SortedIndexWriter::close(
 
   flatbuffers::FlatBufferBuilder directoryBuilder;
   buildDirectoryFlatBuffer(directoryBuilder, indexSections);
-  writeMetadataFn(
-      std::string(kSortedIndexSection), asStringView(directoryBuilder));
+  return IndexDescriptor{
+      .family = IndexFamily::Dense,
+      .name = std::string{kDenseSortedIndexName},
+      .root = createMetadataFn(asStringView(directoryBuilder))};
 }
 
 } // namespace facebook::nimble::index

--- a/dwio/nimble/index/SortedIndexWriter.h
+++ b/dwio/nimble/index/SortedIndexWriter.h
@@ -16,17 +16,18 @@
 #pragma once
 
 #include <memory>
+#include <optional>
 #include <string>
 #include <vector>
 
 #include "dwio/nimble/common/Buffer.h"
 #include "dwio/nimble/index/IndexConfig.h"
+#include "dwio/nimble/index/IndexKeyEncoder.h"
 #include "dwio/nimble/index/IndexWriter.h"
 #include "dwio/nimble/tablet/MetadataBuffer.h"
 #include "flatbuffers/flatbuffers.h"
 #include "velox/buffer/Buffer.h"
 #include "velox/common/memory/Memory.h"
-#include "velox/serializers/KeyEncoder.h"
 #include "velox/vector/ComplexVector.h"
 
 namespace facebook::nimble::serialization {
@@ -66,10 +67,9 @@ class SortedIndexWriter : public IndexWriter {
 
   void write(const velox::VectorPtr& input) override;
 
-  void close(
+  std::optional<IndexDescriptor> close(
       const WriteDataFn& writeDataFn,
-      const CreateMetadataSectionFn& createMetadataFn,
-      const WriteOptionalSectionFn& writeMetadataFn) override;
+      const CreateMetadataSectionFn& createMetadataFn) override;
 
  private:
   SortedIndexWriter(
@@ -84,7 +84,7 @@ class SortedIndexWriter : public IndexWriter {
 
   struct IndexAccumulator {
     SortedIndexConfig config;
-    std::unique_ptr<velox::serializer::KeyEncoder> encoder;
+    std::unique_ptr<IndexKeyEncoder> encoder;
     std::vector<IndexEntry> entries;
     // Backs encoded key string_views in entries. Each accumulator owns its
     // buffer so it can be freed independently after composite entries are

--- a/dwio/nimble/index/tests/ClusterIndexTestUtils.cpp
+++ b/dwio/nimble/index/tests/ClusterIndexTestUtils.cpp
@@ -18,10 +18,12 @@
 
 #include "dwio/nimble/encodings/common/EncodingFactory.h"
 #include "dwio/nimble/encodings/selection/EncodingSelectionPolicy.h"
+#include "dwio/nimble/index/IndexConfig.h"
 #include "dwio/nimble/index/IndexConstants.h"
 #include "dwio/nimble/tablet/ChunkIndexGenerated.h"
 #include "dwio/nimble/tablet/ClusterIndexGenerated.h"
 #include "dwio/nimble/tablet/Constants.h"
+#include "dwio/nimble/tablet/IndexGenerated.h"
 #include "dwio/nimble/tablet/MetadataBuffer.h"
 #include "dwio/nimble/velox/ChunkedStreamWriter.h"
 #include "dwio/nimble/velox/VeloxWriter.h"
@@ -360,13 +362,14 @@ TabletWriter::CloseCallback
 TestClusterIndexMetadataWriter::createCloseCallback() {
   return [this](
              const WriteDataFn& /*writeDataFn*/,
-             const CreateMetadataSectionFn& /*createMetadataFn*/,
+             const CreateMetadataSectionFn& createMetadataFn,
              const WriteOptionalSectionFn& writeMetadataFn) {
-    writeRoot(writeMetadataFn);
+    writeRoot(createMetadataFn, writeMetadataFn);
   };
 }
 
 void TestClusterIndexMetadataWriter::writeRoot(
+    const CreateMetadataSectionFn& createMetadataSection,
     const WriteOptionalSectionFn& writeOptionalSection) {
   if (indexPartitions_.empty()) {
     return;
@@ -432,7 +435,25 @@ void TestClusterIndexMetadataWriter::writeRoot(
   std::string_view view{
       reinterpret_cast<const char*>(builder.GetBufferPointer()),
       builder.GetSize()};
-  writeOptionalSection(std::string(kClusterIndexSection), view);
+  const auto payloadSection = createMetadataSection(view);
+
+  flatbuffers::FlatBufferBuilder rootBuilder(kInitialFooterSize);
+  auto name = rootBuilder.CreateString(kClusterIndexName);
+  auto payload = serialization::CreateMetadataSection(
+      rootBuilder,
+      payloadSection.offset(),
+      payloadSection.size(),
+      static_cast<serialization::CompressionType>(
+          payloadSection.compressionType()),
+      payloadSection.uncompressedSize().value_or(payloadSection.size()));
+  auto descriptor = serialization::CreateIndexDescriptor(
+      rootBuilder, serialization::IndexFamily_Cluster, name, payload);
+  auto indexes = rootBuilder.CreateVector(&descriptor, 1);
+  rootBuilder.Finish(serialization::CreateIndexRoot(rootBuilder, indexes));
+  std::string_view rootView{
+      reinterpret_cast<const char*>(rootBuilder.GetBufferPointer()),
+      rootBuilder.GetSize()};
+  writeOptionalSection(std::string(kIndexSection), rootView);
 }
 
 } // namespace facebook::nimble::index::test

--- a/dwio/nimble/index/tests/ClusterIndexTestUtils.h
+++ b/dwio/nimble/index/tests/ClusterIndexTestUtils.h
@@ -315,7 +315,9 @@ class TestClusterIndexMetadataWriter {
     uint32_t keyStreamFileSize{0};
   };
 
-  void writeRoot(const WriteOptionalSectionFn& writeOptionalSection);
+  void writeRoot(
+      const CreateMetadataSectionFn& createMetadataSection,
+      const WriteOptionalSectionFn& writeOptionalSection);
 
   void flushKeyStream(const WriteDataFn& writeData);
 

--- a/dwio/nimble/index/tests/ClusterIndexWriterTest.cpp
+++ b/dwio/nimble/index/tests/ClusterIndexWriterTest.cpp
@@ -240,7 +240,7 @@ TEST_F(ClusterIndexWriterTest, multiColumnWithDifferentSortOrders) {
             EncodingLayout{EncodingType::Prefix, {}, CompressionType::Zstd}};
     NIMBLE_ASSERT_THROW(
         ClusterIndexWriter::create(config, type, pool_.get()),
-        "sortOrders size (2) must be empty or match columns size (3)");
+        "sortOrders and columns must have the same size");
   }
 
   {
@@ -255,7 +255,7 @@ TEST_F(ClusterIndexWriterTest, multiColumnWithDifferentSortOrders) {
             EncodingLayout{EncodingType::Prefix, {}, CompressionType::Zstd}};
     NIMBLE_ASSERT_THROW(
         ClusterIndexWriter::create(config, type, pool_.get()),
-        "sortOrders size (3) must be empty or match columns size (2)");
+        "sortOrders and columns must have the same size");
   }
 
   // Data test: write data with multiple columns and different sort orders,
@@ -922,11 +922,9 @@ TEST_P(ClusterIndexWriterDataTest, close) {
   CreateMetadataSectionFn createMetadataFn = [&](std::string_view) {
     return MetadataSection{nextSectionId++, 0, CompressionType::Uncompressed};
   };
-  WriteOptionalSectionFn noopWriteFn = [](const std::string&,
-                                          std::string_view) {};
   WriteDataFn noopWriteDataFn = [](const std::vector<std::string_view>&)
       -> std::pair<uint64_t, uint32_t> { return {0, 0}; };
-  writer->close(noopWriteDataFn, createMetadataFn, noopWriteFn);
+  EXPECT_FALSE(writer->close(noopWriteDataFn, createMetadataFn).has_value());
 }
 
 TEST_P(ClusterIndexWriterDataTest, writeAfterClose) {
@@ -939,16 +937,14 @@ TEST_P(ClusterIndexWriterDataTest, writeAfterClose) {
   CreateMetadataSectionFn createMetadataFn = [&](std::string_view) {
     return MetadataSection{nextSectionId++, 0, CompressionType::Uncompressed};
   };
-  WriteOptionalSectionFn noopWriteFn = [](const std::string&,
-                                          std::string_view) {};
   WriteDataFn noopWriteDataFn = [](const std::vector<std::string_view>&)
       -> std::pair<uint64_t, uint32_t> { return {0, 0}; };
-  writer->close(noopWriteDataFn, createMetadataFn, noopWriteFn);
+  EXPECT_FALSE(writer->close(noopWriteDataFn, createMetadataFn).has_value());
 
   NIMBLE_ASSERT_THROW(
       writer->write(makeInput({4, 5, 6})), "IndexWriter has been closed");
   NIMBLE_ASSERT_THROW(
-      writer->close(noopWriteDataFn, createMetadataFn, noopWriteFn),
+      writer->close(noopWriteDataFn, createMetadataFn),
       "close() already called");
 }
 
@@ -1103,19 +1099,15 @@ TEST_P(ClusterIndexWriterChunkTest, maxRowsPerKeyChunk) {
   };
   writer->flush(writeDataFn, createMetadataFn);
 
-  // Close the writer and capture the root index data.
-  std::string rootIndexData;
+  // Close the writer and capture the root index payload.
   WriteDataFn noopWriteDataFn2 = [](const std::vector<std::string_view>&)
       -> std::pair<uint64_t, uint32_t> { return {0, 0}; };
-  writer->close(
-      noopWriteDataFn2,
-      createMetadataFn,
-      [&rootIndexData](const std::string&, std::string_view content) {
-        rootIndexData = std::string(content);
-      });
+  auto descriptor = writer->close(noopWriteDataFn2, createMetadataFn);
+  ASSERT_TRUE(descriptor.has_value());
+  const auto& rootIndexData = partitionMetadata.back();
 
   ASSERT_FALSE(rootIndexData.empty());
-  ASSERT_EQ(partitionMetadata.size(), 1);
+  ASSERT_EQ(partitionMetadata.size(), 2);
 
   // Load ClusterIndex from serialized data and verify layout.
   Section rootSection{MetadataBuffer(

--- a/dwio/nimble/index/tests/HashIndexWriterTest.cpp
+++ b/dwio/nimble/index/tests/HashIndexWriterTest.cpp
@@ -77,36 +77,44 @@ class HashIndexWriterTestBase : public velox::test::VectorTestBase {
   // in memory and returns MetadataSection with sequential offsets.
   struct MockSectionStore {
     std::vector<std::string> sections;
+    std::vector<MetadataSection> metadataSections;
     uint64_t nextOffset{0};
 
     CreateMetadataSectionFn createFn() {
       return [this](std::string_view content) -> MetadataSection {
         const auto offset = nextOffset;
         const auto size = content.size();
-        sections.emplace_back(content);
         nextOffset += size;
-        return MetadataSection{
+        auto section = MetadataSection{
             offset, static_cast<uint32_t>(size), CompressionType::Uncompressed};
+        sections.emplace_back(content);
+        metadataSections.emplace_back(section);
+        return section;
       };
     }
+
+    const std::string& sectionContent(const MetadataSection& section) const {
+      for (size_t i = 0; i < metadataSections.size(); ++i) {
+        if (metadataSections[i].offset() == section.offset()) {
+          return sections[i];
+        }
+      }
+      NIMBLE_UNREACHABLE("Missing metadata section");
+    }
   };
-
-  // Captures the directory written by close().
-  static WriteOptionalSectionFn writeFn(std::string& output) {
-    return [&output](const std::string& /*name*/, std::string_view content) {
-      output = std::string(content);
-    };
-  }
-
-  // No-op write function for tests that don't inspect the output.
-  static WriteOptionalSectionFn noopWriteFn() {
-    return [](const std::string&, std::string_view) {};
-  }
 
   // No-op data write function for tests.
   static WriteDataFn noopWriteDataFn() {
     return [](const std::vector<std::string_view>&)
                -> std::pair<uint64_t, uint32_t> { return {0, 0}; };
+  }
+
+  static std::string closeAndReadDirectory(
+      HashIndexWriter& writer,
+      MockSectionStore& store) {
+    auto descriptor = writer.close(noopWriteDataFn(), store.createFn());
+    NIMBLE_CHECK(descriptor.has_value(), "Expected hash index descriptor");
+    return store.sectionContent(descriptor->root);
   }
 
   // Validates the HashIndexDirectory has the expected indices with the
@@ -132,6 +140,27 @@ class HashIndexWriterTestBase : public velox::test::VectorTestBase {
         EXPECT_EQ(columns->Get(i)->string_view(), expectedColumns[idx][i]);
       }
     }
+  }
+
+  static const std::string& indexSectionContent(
+      const std::string& directory,
+      size_t index,
+      const MockSectionStore& store) {
+    const auto* root = flatbuffers::GetRoot<serialization::HashIndexDirectory>(
+        directory.data());
+    NIMBLE_CHECK_NOT_NULL(root);
+    const auto* indices = root->indices();
+    NIMBLE_CHECK_NOT_NULL(indices);
+    NIMBLE_CHECK_LT(index, indices->size());
+    const auto* indexDescriptor = indices->Get(index);
+    NIMBLE_CHECK_NOT_NULL(indexDescriptor);
+    const auto* section = indexDescriptor->section();
+    NIMBLE_CHECK_NOT_NULL(section);
+    return store.sectionContent(
+        MetadataSection{
+            section->offset(),
+            section->size(),
+            static_cast<CompressionType>(section->compression_type())});
   }
 
   // Validates the HashIndex FlatBuffer has the expected row/key counts
@@ -316,12 +345,7 @@ TEST_P(HashIndexWriterParamTest, writeEmptyVector) {
   EXPECT_EQ(helper.numEntries(0), 0);
 
   MockSectionStore store;
-  bool writeCalled = false;
-  writer->close(
-      noopWriteDataFn(),
-      store.createFn(),
-      [&](const std::string&, std::string_view) { writeCalled = true; });
-  EXPECT_FALSE(writeCalled);
+  EXPECT_FALSE(writer->close(noopWriteDataFn(), store.createFn()).has_value());
   EXPECT_TRUE(store.sections.empty());
 }
 
@@ -336,12 +360,14 @@ TEST_P(HashIndexWriterParamTest, writeSingleBatch) {
   EXPECT_EQ(helper.numEntries(0), 5);
 
   MockSectionStore store;
-  std::string directory;
-  writer->close(noopWriteDataFn(), store.createFn(), writeFn(directory));
+  auto directory = closeAndReadDirectory(*writer, store);
 
   const auto& columns = GetParam().columns;
   validateDirectory(directory, {columns});
-  validateIndex(store.sections.back(), 5, /*expectedNumPartitions=*/1);
+  validateIndex(
+      indexSectionContent(directory, /*index=*/0, store),
+      5,
+      /*expectedNumPartitions=*/1);
 }
 
 TEST_P(HashIndexWriterParamTest, writeMultipleBatches) {
@@ -357,12 +383,14 @@ TEST_P(HashIndexWriterParamTest, writeMultipleBatches) {
   EXPECT_EQ(helper.numEntries(0), 9);
 
   MockSectionStore store;
-  std::string directory;
-  writer->close(noopWriteDataFn(), store.createFn(), writeFn(directory));
+  auto directory = closeAndReadDirectory(*writer, store);
 
   const auto& columns = GetParam().columns;
   validateDirectory(directory, {columns});
-  validateIndex(store.sections.back(), 9, /*expectedNumPartitions=*/1);
+  validateIndex(
+      indexSectionContent(directory, /*index=*/0, store),
+      9,
+      /*expectedNumPartitions=*/1);
 }
 
 TEST_P(HashIndexWriterParamTest, writeWithEmptyBatchesMixed) {
@@ -380,12 +408,14 @@ TEST_P(HashIndexWriterParamTest, writeWithEmptyBatchesMixed) {
   EXPECT_EQ(helper.numEntries(0), 3);
 
   MockSectionStore store;
-  std::string directory;
-  writer->close(noopWriteDataFn(), store.createFn(), writeFn(directory));
+  auto directory = closeAndReadDirectory(*writer, store);
 
   const auto& columns = GetParam().columns;
   validateDirectory(directory, {columns});
-  validateIndex(store.sections.back(), 3, /*expectedNumPartitions=*/1);
+  validateIndex(
+      indexSectionContent(directory, /*index=*/0, store),
+      3,
+      /*expectedNumPartitions=*/1);
 }
 
 TEST_F(HashIndexWriterTest, rejectNullKeys) {
@@ -463,7 +493,7 @@ TEST_P(HashIndexWriterParamTest, writeAfterCloseThrows) {
   writer->write(makeInput({1}));
 
   MockSectionStore store;
-  writer->close(noopWriteDataFn(), store.createFn(), noopWriteFn());
+  EXPECT_TRUE(writer->close(noopWriteDataFn(), store.createFn()).has_value());
 
   NIMBLE_ASSERT_THROW(
       writer->write(makeInput({2})), "IndexWriter has been closed");
@@ -474,10 +504,10 @@ TEST_P(HashIndexWriterParamTest, doubleCloseThrows) {
   writer->write(makeInput({1}));
 
   MockSectionStore store;
-  writer->close(noopWriteDataFn(), store.createFn(), noopWriteFn());
+  EXPECT_TRUE(writer->close(noopWriteDataFn(), store.createFn()).has_value());
 
   NIMBLE_ASSERT_THROW(
-      writer->close(noopWriteDataFn(), store.createFn(), noopWriteFn()),
+      writer->close(noopWriteDataFn(), store.createFn()),
       "close() already called");
 }
 
@@ -499,8 +529,7 @@ TEST_F(HashIndexWriterTest, multipleIndices) {
   writer->write(makeInput({1, 2, 3}));
 
   MockSectionStore store;
-  std::string directory;
-  writer->close(noopWriteDataFn(), store.createFn(), writeFn(directory));
+  auto directory = closeAndReadDirectory(*writer, store);
 
   validateDirectory(directory, {{"col1"}, {"col0"}});
   // store has: partition for index 0, index 0, partition for index 1, index 1.
@@ -536,11 +565,10 @@ TEST_F(HashIndexWriterTest, withBloomFilter) {
     writer->write(makeInput({1, 2, 3, 4, 5}));
 
     MockSectionStore store;
-    std::string directory;
-    writer->close(noopWriteDataFn(), store.createFn(), writeFn(directory));
+    auto directory = closeAndReadDirectory(*writer, store);
 
     const auto* hashIndex = flatbuffers::GetRoot<serialization::HashIndex>(
-        store.sections.back().data());
+        indexSectionContent(directory, /*index=*/0, store).data());
     ASSERT_NE(hashIndex, nullptr);
     if (tc.expectBloomFilter) {
       EXPECT_NE(hashIndex->bloom_filter(), nullptr);
@@ -566,18 +594,16 @@ TEST_F(HashIndexWriterTest, withPartitioning) {
   writer->write(makeInput(values));
 
   MockSectionStore store;
-  std::string directory;
-  writer->close(noopWriteDataFn(), store.createFn(), writeFn(directory));
+  auto directory = closeAndReadDirectory(*writer, store);
 
   validateDirectory(directory, {{"col1"}});
-  // The last section is the HashIndex; preceding sections are partitions.
   // With 100 keys and 32-byte partition limit, expect multiple partitions.
   const auto* hashIndex = flatbuffers::GetRoot<serialization::HashIndex>(
-      store.sections.back().data());
+      indexSectionContent(directory, /*index=*/0, store).data());
   ASSERT_NE(hashIndex, nullptr);
   ASSERT_NE(hashIndex->partition_sections(), nullptr);
   EXPECT_GT(hashIndex->partition_sections()->size(), 1u);
-  validateIndex(store.sections.back(), 100);
+  validateIndex(indexSectionContent(directory, /*index=*/0, store), 100);
 }
 
 TEST_F(HashIndexWriterTest, loadFactorVariations) {
@@ -605,11 +631,13 @@ TEST_F(HashIndexWriterTest, loadFactorVariations) {
     writer->write(makeInput(values));
 
     MockSectionStore store;
-    std::string directory;
-    writer->close(noopWriteDataFn(), store.createFn(), writeFn(directory));
+    auto directory = closeAndReadDirectory(*writer, store);
 
     validateDirectory(directory, {{"col1"}});
-    validateIndex(store.sections.back(), 50, /*expectedNumPartitions=*/1);
+    validateIndex(
+        indexSectionContent(directory, /*index=*/0, store),
+        50,
+        /*expectedNumPartitions=*/1);
   }
 }
 
@@ -623,11 +651,13 @@ TEST_P(HashIndexWriterParamTest, duplicateKeysAllowed) {
   EXPECT_EQ(helper.numEntries(0), 5);
 
   MockSectionStore store;
-  std::string directory;
-  writer->close(noopWriteDataFn(), store.createFn(), writeFn(directory));
+  auto directory = closeAndReadDirectory(*writer, store);
 
   validateDirectory(directory, {GetParam().columns});
-  validateIndex(store.sections.back(), 5, /*expectedNumPartitions=*/1);
+  validateIndex(
+      indexSectionContent(directory, /*index=*/0, store),
+      5,
+      /*expectedNumPartitions=*/1);
 }
 
 } // namespace

--- a/dwio/nimble/index/tests/IndexConfigTest.cpp
+++ b/dwio/nimble/index/tests/IndexConfigTest.cpp
@@ -17,6 +17,8 @@
 #include <gtest/gtest.h>
 
 #include "dwio/nimble/index/IndexConfig.h"
+#include "dwio/nimble/index/IndexSerialization.h"
+#include "dwio/nimble/tablet/IndexGenerated.h"
 
 namespace facebook::nimble::index::test {
 
@@ -54,6 +56,16 @@ TEST(IndexConfigTest, customEncodingLayout) {
       EncodingLayout{EncodingType::Trivial, {}, CompressionType::Zstd};
   EXPECT_EQ(config.encodingLayout.encodingType(), EncodingType::Trivial);
   EXPECT_EQ(config.encodingLayout.compressionType(), CompressionType::Zstd);
+}
+
+TEST(IndexConfigTest, indexFamilySerializationRoundTrip) {
+  for (const auto [family, serializedFamily] :
+       {std::pair{IndexFamily::Cluster, serialization::IndexFamily_Cluster},
+        std::pair{IndexFamily::Dense, serialization::IndexFamily_Dense}}) {
+    SCOPED_TRACE(static_cast<int>(family));
+    EXPECT_EQ(toIndexFamily(family), serializedFamily);
+    EXPECT_EQ(toIndexFamily(serializedFamily), family);
+  }
 }
 
 } // namespace facebook::nimble::index::test

--- a/dwio/nimble/index/tests/IndexFactoryTest.cpp
+++ b/dwio/nimble/index/tests/IndexFactoryTest.cpp
@@ -1,0 +1,232 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <gtest/gtest.h>
+
+#include "dwio/nimble/common/Buffer.h"
+#include "dwio/nimble/common/Exceptions.h"
+#include "dwio/nimble/common/tests/GTestUtils.h"
+#include "dwio/nimble/index/ClusterIndexFactory.h"
+#include "dwio/nimble/index/IndexKeyEncoder.h"
+#include "dwio/nimble/tablet/TabletReader.h"
+#include "dwio/nimble/velox/VeloxWriter.h"
+#include "velox/common/file/FileSystems.h"
+#include "velox/common/io/IoStatistics.h"
+#include "velox/common/io/Options.h"
+#include "velox/common/memory/Memory.h"
+#include "velox/common/testutil/TempDirectoryPath.h"
+#include "velox/vector/FlatVector.h"
+
+namespace facebook::nimble::index::test {
+namespace {
+
+constexpr std::string_view kCustomClusterIndexName{"test.cluster.v1"};
+
+class RenamedIndexWriter final : public IndexWriter {
+ public:
+  RenamedIndexWriter(std::unique_ptr<IndexWriter> delegate, std::string name)
+      : delegate_{std::move(delegate)}, name_{std::move(name)} {}
+
+  void write(const velox::VectorPtr& input) override {
+    delegate_->write(input);
+  }
+
+  void flush(
+      const WriteDataFn& writeDataFn,
+      const CreateMetadataSectionFn& createMetadataSectionFn) override {
+    delegate_->flush(writeDataFn, createMetadataSectionFn);
+  }
+
+  std::optional<IndexDescriptor> close(
+      const WriteDataFn& writeDataFn,
+      const CreateMetadataSectionFn& createMetadataSectionFn) override {
+    auto descriptor = delegate_->close(writeDataFn, createMetadataSectionFn);
+    if (descriptor.has_value()) {
+      descriptor->name = name_;
+    }
+    return descriptor;
+  }
+
+ private:
+  std::unique_ptr<IndexWriter> delegate_;
+  const std::string name_;
+};
+
+class TestClusterIndexFactory final : public ClusterIndexFactory {
+ public:
+  std::string_view name() const override {
+    return kCustomClusterIndexName;
+  }
+
+  std::unique_ptr<IndexWriter> createWriter(
+      const ClusterIndexConfig& config,
+      const velox::TypePtr& inputType,
+      velox::memory::MemoryPool* pool) const override {
+    auto builtInConfig = config;
+    builtInConfig.indexName = kClusterIndexName;
+    return std::make_unique<RenamedIndexWriter>(
+        clusterIndexFactory(kClusterIndexName)
+            .createWriter(builtInConfig, inputType, pool),
+        std::string{name()});
+  }
+
+  std::unique_ptr<IndexKeyEncoder> createKeyEncoder(
+      const std::vector<std::string>& columns,
+      const velox::RowTypePtr& inputType,
+      const std::vector<SortOrder>& sortOrders,
+      velox::memory::MemoryPool* pool) const override {
+    return clusterIndexFactory(kClusterIndexName)
+        .createKeyEncoder(columns, inputType, sortOrders, pool);
+  }
+
+  std::unique_ptr<ClusterIndex> createReader(
+      Section rootSection,
+      velox::memory::MemoryPool* pool,
+      const IndexLookup::Options& options) const override {
+    return clusterIndexFactory(kClusterIndexName)
+        .createReader(std::move(rootSection), pool, options);
+  }
+};
+
+class IndexFactoryTest : public testing::Test {
+ protected:
+  static void SetUpTestSuite() {
+    velox::filesystems::registerLocalFileSystem();
+    velox::memory::MemoryManager::testingSetInstance({});
+    registerClusterIndexFactory(
+        std::make_shared<const TestClusterIndexFactory>());
+  }
+
+  void SetUp() override {
+    rootPool_ = velox::memory::memoryManager()->addRootPool("IndexFactoryTest");
+    leafPool_ = rootPool_->addLeafChild("leaf");
+    tempDirectory_ = velox::common::testutil::TempDirectoryPath::create();
+  }
+
+  static velox::RowTypePtr rowType() {
+    return velox::ROW({{"id", velox::INTEGER()}});
+  }
+
+  velox::RowVectorPtr makeBatch() {
+    constexpr int32_t kNumRows{20};
+    auto ids =
+        velox::BaseVector::create(velox::INTEGER(), kNumRows, leafPool_.get());
+    auto* flatIds = ids->asFlatVector<int32_t>();
+    for (int32_t i = 0; i < kNumRows; ++i) {
+      flatIds->set(i, i);
+    }
+    return std::make_shared<velox::RowVector>(
+        leafPool_.get(),
+        rowType(),
+        nullptr,
+        kNumRows,
+        std::vector<velox::VectorPtr>{ids});
+  }
+
+  std::string writeFile() {
+    const auto path = tempDirectory_->getPath() + "/custom_indexes";
+    auto fileSystem = velox::filesystems::getFileSystem(path, {});
+    auto file = fileSystem->openFileForWrite(
+        path,
+        {.shouldCreateParentDirectories = true,
+         .shouldThrowOnFileAlreadyExists = false});
+    VeloxWriterOptions options;
+    options.clusterIndexConfig = ClusterIndexConfig{
+        .indexName = std::string{kCustomClusterIndexName},
+        .columns = {"id"},
+        .enforceKeyOrder = true,
+    };
+    VeloxWriter writer(rowType(), std::move(file), *rootPool_, options);
+    writer.write(makeBatch());
+    writer.close();
+    return path;
+  }
+
+  std::shared_ptr<TabletReader> openFile(
+      const std::string& path,
+      std::string clusterIndexName) {
+    auto fileSystem = velox::filesystems::getFileSystem(path, {});
+    TabletReader::Options options;
+    options.loadClusterIndex = true;
+    options.clusterIndexName = std::move(clusterIndexName);
+    options.ioOptions.emplace(leafPool_.get())
+        .setMetadataIoStats(std::make_shared<velox::io::IoStatistics>())
+        .setIndexIoStats(std::make_shared<velox::io::IoStatistics>());
+    return TabletReader::create(
+        fileSystem->openFileForRead(path), leafPool_.get(), options);
+  }
+
+  std::string encodeKey(int32_t value) {
+    auto keyVector =
+        velox::BaseVector::create(velox::INTEGER(), 1, leafPool_.get());
+    keyVector->asFlatVector<int32_t>()->set(0, value);
+    auto input = std::make_shared<velox::RowVector>(
+        leafPool_.get(),
+        rowType(),
+        nullptr,
+        1,
+        std::vector<velox::VectorPtr>{keyVector});
+    auto encoder = clusterIndexFactory(kCustomClusterIndexName)
+                       .createKeyEncoder(
+                           {"id"},
+                           rowType(),
+                           {SortOrder{.ascending = true}},
+                           leafPool_.get());
+    Buffer buffer{*leafPool_};
+    std::vector<std::string_view> keys;
+    encoder->encode(
+        input, keys, [&buffer](size_t size) { return buffer.reserve(size); });
+    return std::string{keys.front()};
+  }
+
+  std::shared_ptr<velox::memory::MemoryPool> rootPool_;
+  std::shared_ptr<velox::memory::MemoryPool> leafPool_;
+  std::shared_ptr<velox::common::testutil::TempDirectoryPath> tempDirectory_;
+};
+
+TEST_F(IndexFactoryTest, customClusterFactoryEndToEnd) {
+  const auto path = writeFile();
+  auto tablet = openFile(path, std::string{kCustomClusterIndexName});
+  ASSERT_NE(tablet->clusterIndex(), nullptr);
+  const auto key = encodeKey(7);
+  auto clusterResult = tablet->clusterIndex()->lookup(
+      IndexLookup::LookupRequest::pointLookup({key}));
+  ASSERT_EQ(clusterResult.size(), 1);
+  EXPECT_FALSE(clusterResult[0].empty());
+
+  auto wrongClusterName = openFile(path, std::string{kClusterIndexName});
+  EXPECT_EQ(wrongClusterName->clusterIndex(), nullptr);
+}
+
+TEST_F(IndexFactoryTest, builtInClusterFactoryIsRegistered) {
+  EXPECT_EQ(clusterIndexFactory(kClusterIndexName).name(), kClusterIndexName);
+}
+
+TEST_F(IndexFactoryTest, rejectDuplicateClusterFactoryRegistration) {
+  NIMBLE_ASSERT_THROW(
+      registerClusterIndexFactory(
+          std::make_shared<const TestClusterIndexFactory>()),
+      "Cluster index factory already registered: test.cluster.v1");
+}
+
+TEST_F(IndexFactoryTest, rejectUnknownClusterFactory) {
+  NIMBLE_ASSERT_THROW(
+      clusterIndexFactory("test.missing.cluster.v1"),
+      "Unknown cluster index factory: test.missing.cluster.v1");
+}
+
+} // namespace
+} // namespace facebook::nimble::index::test

--- a/dwio/nimble/index/tests/IndexKeyEncoderTest.cpp
+++ b/dwio/nimble/index/tests/IndexKeyEncoderTest.cpp
@@ -1,0 +1,88 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <gtest/gtest.h>
+
+#include "dwio/nimble/common/Buffer.h"
+#include "dwio/nimble/common/Exceptions.h"
+#include "dwio/nimble/common/tests/GTestUtils.h"
+#include "dwio/nimble/index/IndexKeyEncoder.h"
+#include "velox/common/memory/Memory.h"
+#include "velox/vector/FlatVector.h"
+
+namespace facebook::nimble::index::test {
+namespace {
+
+class IndexKeyEncoderTest : public testing::Test {
+ protected:
+  static void SetUpTestSuite() {
+    velox::memory::MemoryManager::testingSetInstance({});
+  }
+
+  void SetUp() override {
+    rootPool_ =
+        velox::memory::memoryManager()->addRootPool("IndexKeyEncoderTest");
+    leafPool_ = rootPool_->addLeafChild("leaf");
+  }
+
+  velox::RowTypePtr rowType() const {
+    return velox::ROW({{"id", velox::INTEGER()}});
+  }
+
+  velox::RowVectorPtr makeBatch() const {
+    constexpr int32_t kNumRows{20};
+    auto ids =
+        velox::BaseVector::create(velox::INTEGER(), kNumRows, leafPool_.get());
+    auto* flatIds = ids->asFlatVector<int32_t>();
+    for (int32_t i = 0; i < kNumRows; ++i) {
+      flatIds->set(i, i);
+    }
+    return std::make_shared<velox::RowVector>(
+        leafPool_.get(),
+        rowType(),
+        nullptr,
+        kNumRows,
+        std::vector<velox::VectorPtr>{ids});
+  }
+
+  std::shared_ptr<velox::memory::MemoryPool> rootPool_;
+  std::shared_ptr<velox::memory::MemoryPool> leafPool_;
+};
+
+TEST_F(IndexKeyEncoderTest, encodeBatchInSortOrder) {
+  auto encoder = createNimbleIndexKeyEncoder(
+      {"id"}, rowType(), {SortOrder{.ascending = true}}, leafPool_.get());
+  Buffer buffer{*leafPool_};
+  std::vector<std::string_view> keys;
+  encoder->encode(makeBatch(), keys, [&buffer](size_t size) {
+    return buffer.reserve(size);
+  });
+
+  ASSERT_EQ(keys.size(), 20);
+  for (size_t i = 1; i < keys.size(); ++i) {
+    SCOPED_TRACE(i);
+    EXPECT_LT(keys[i - 1], keys[i]);
+  }
+}
+
+TEST_F(IndexKeyEncoderTest, rejectMismatchedSortOrders) {
+  NIMBLE_ASSERT_THROW(
+      createNimbleIndexKeyEncoder({"id"}, rowType(), {}, leafPool_.get()),
+      "sortOrders and columns must have the same size");
+}
+
+} // namespace
+} // namespace facebook::nimble::index::test

--- a/dwio/nimble/tablet/CMakeLists.txt
+++ b/dwio/nimble/tablet/CMakeLists.txt
@@ -49,6 +49,22 @@ target_include_directories(
 add_dependencies(nimble_cluster_index_fb nimble_cluster_index_schema_fb)
 
 build_flatbuffers(
+  "${CMAKE_CURRENT_SOURCE_DIR}/Index.fbs"
+  ""
+  nimble_index_schema_fb
+  ""
+  "${CMAKE_CURRENT_BINARY_DIR}"
+  ""
+  ""
+)
+add_library(nimble_index_fb INTERFACE)
+target_include_directories(
+  nimble_index_fb
+  INTERFACE ${PROJECT_BINARY_DIR} ${FLATBUFFERS_INCLUDE_DIR}
+)
+add_dependencies(nimble_index_fb nimble_index_schema_fb)
+
+build_flatbuffers(
   "${CMAKE_CURRENT_SOURCE_DIR}/ChunkIndex.fbs"
   ""
   nimble_chunk_index_schema_fb

--- a/dwio/nimble/tablet/ClusterIndex.fbs
+++ b/dwio/nimble/tablet/ClusterIndex.fbs
@@ -37,8 +37,8 @@ table ClusterIndexPartition {
   chunk_keys:[string];
 }
 
-/// Root index table for the entire file.
-/// Stored in the optional sections of the footer.
+/// Root index table for the built-in Nimble cluster index implementation.
+/// Referenced by IndexDescriptor name "nimble.cluster.v1".
 table ClusterIndex {
   /// Names of columns used for indexing.
   index_columns:[string];

--- a/dwio/nimble/tablet/Constants.h
+++ b/dwio/nimble/tablet/Constants.h
@@ -34,9 +34,8 @@ constexpr std::string_view kMetadataSection = "columnar.metadata";
 constexpr std::string_view kStatsSection = "columnar.stats";
 constexpr std::string_view kVectorizedStatsSection =
     "columnar.vectorized_stats";
-constexpr std::string_view kClusterIndexSection = "columnar.cluster.index";
+constexpr std::string_view kIndexSection = "columnar.indexes";
+// TODO: Rename this section to "columnar.chunk.stats".
 constexpr std::string_view kChunkIndexSection = "columnar.chunk.index";
-constexpr std::string_view kHashIndexSection = "columnar.hash.index";
-constexpr std::string_view kSortedIndexSection = "columnar.sorted.index";
 
 } // namespace facebook::nimble

--- a/dwio/nimble/tablet/FileLayout.h
+++ b/dwio/nimble/tablet/FileLayout.h
@@ -64,9 +64,8 @@ namespace facebook::nimble {
 /// +===================================================================+
 /// |  Stripes Metadata (row_counts, offsets, sizes, group_indices)     |
 /// +-------------------------------------------------------------------+
-/// |  Optional: "columnar.cluster.index" (root ClusterIndex flatbuffer |
-/// |            with stripe_keys, index_columns, sort_orders,          |
-/// |            stripe_indexes)                                        |
+/// |  Optional: "columnar.indexes" (root index manifest with named     |
+/// |            cluster and dense index payloads)                      |
 /// +-------------------------------------------------------------------+
 /// |  Optional: "columnar.chunk.index" (root ChunkIndex flatbuffer     |
 /// |            with stripe_indexes)                                   |
@@ -94,8 +93,10 @@ namespace facebook::nimble {
 /// co-location enables efficient single IO to load both stripe and
 /// index metadata.
 ///
-/// Cluster Index ("columnar.cluster.index"):
-///   Root ClusterIndex flatbuffer (see ClusterIndex.fbs) containing:
+/// Index Manifest ("columnar.indexes"):
+///   Root IndexRoot flatbuffer (see Index.fbs) containing named index payloads.
+///
+/// Cluster index payload (see ClusterIndex.fbs) contains:
 ///   - stripe_keys: key boundaries per stripe (size = stripe_count + 1)
 ///   - index_columns: names of indexed columns
 ///   - sort_orders: sort order per column ("ASC NULLS FIRST", etc.)

--- a/dwio/nimble/tablet/HashIndex.fbs
+++ b/dwio/nimble/tablet/HashIndex.fbs
@@ -88,10 +88,9 @@ table HashIndexSection {
   section:MetadataSection;
 }
 
-/// Root table for the hash index optional section.
+/// Root table for the hash index payload referenced by the index manifest.
 /// Supports multiple independent hash indices per file,
 /// each on a different set of composite key columns.
-/// Stored in optional section "columnar.hash.index".
 table HashIndexDirectory {
   /// One descriptor per hash index defined on the file.
   indices:[HashIndexSection];

--- a/dwio/nimble/tablet/Index.fbs
+++ b/dwio/nimble/tablet/Index.fbs
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+include "Footer.fbs";
+
+namespace facebook.nimble.serialization;
+
+/// Index access pattern used to select the corresponding reader path.
+enum IndexFamily : byte {
+  /// Primary index over data ordered by the indexed columns.
+  Cluster = 0,
+  /// Secondary index over data independent of its physical ordering.
+  Dense = 1,
+}
+
+/// Describes a named file-level index and its implementation-specific root.
+table IndexDescriptor {
+  /// Access pattern used to dispatch to the typed reader path.
+  family:IndexFamily;
+  /// Registered implementation name within the family.
+  name:string (required);
+  /// Section containing the implementation-specific root metadata.
+  root:MetadataSection (required);
+}
+
+/// Root table for all file-level indexes.
+/// Stored in optional section "columnar.indexes".
+table IndexRoot {
+  indexes:[IndexDescriptor] (required);
+}
+
+root_type IndexRoot;

--- a/dwio/nimble/tablet/SortedIndex.fbs
+++ b/dwio/nimble/tablet/SortedIndex.fbs
@@ -51,8 +51,7 @@ table SortedIndexSection {
   section:MetadataSection;
 }
 
-/// Root table for the sorted index optional section.
-/// Stored in optional section "columnar.sorted.index".
+/// Root table for the sorted index payload referenced by the index manifest.
 table SortedIndexDirectory {
   /// One descriptor per sorted index defined on the file.
   indices:[SortedIndexSection];

--- a/dwio/nimble/tablet/TabletReader.cpp
+++ b/dwio/nimble/tablet/TabletReader.cpp
@@ -17,9 +17,12 @@
 #include "dwio/nimble/common/Checksum.h"
 #include "dwio/nimble/common/Exceptions.h"
 #include "dwio/nimble/common/Types.h"
+#include "dwio/nimble/index/ClusterIndexFactory.h"
+#include "dwio/nimble/index/IndexSerialization.h"
 #include "dwio/nimble/tablet/ChunkIndexGenerated.h"
 #include "dwio/nimble/tablet/Constants.h"
 #include "dwio/nimble/tablet/FooterGenerated.h"
+#include "dwio/nimble/tablet/IndexGenerated.h"
 #include "velox/dwio/common/SeekableInputStream.h"
 
 #include "folly/io/Cursor.h"
@@ -76,9 +79,6 @@ TabletReader::Options TabletReader::configureOptions(
   tabletOptions.preloadOptionalSections = {
       std::string(kSchemaSection), std::string(kVectorizedStatsSection)};
   tabletOptions.loadClusterIndex = options.loadClusterIndex();
-  if (tabletOptions.loadClusterIndex) {
-    tabletOptions.preloadOptionalSections.emplace_back(kClusterIndexSection);
-  }
   tabletOptions.preloadIndex = options.preloadIndex();
   tabletOptions.loadChunkIndex = options.loadChunkIndex();
   if (tabletOptions.loadChunkIndex) {
@@ -227,6 +227,7 @@ TabletReader::TabletReader(
     : pool_{&pool},
       file_{std::move(readFile)},
       loadClusterIndex_{options.loadClusterIndex},
+      clusterIndexName_{options.clusterIndexName},
       loadChunkIndex_{options.loadChunkIndex},
       loadDenseIndexes_{options.loadDenseIndexes},
       ioOptions_{[&]() {
@@ -321,6 +322,7 @@ void TabletReader::init(const Options& options) {
   loadSections(sections);
 
   initStripes(footerView, footerOffset);
+  initIndexes();
   initClusterIndex();
   initChunkIndex(footerView, footerOffset);
   initDenseIndexes();
@@ -445,6 +447,7 @@ bool TabletReader::initFromCache(const Options& options) {
   loadSections(sections);
 
   initStripes();
+  initIndexes();
   initClusterIndex();
   initChunkIndex();
   initDenseIndexes();
@@ -500,11 +503,10 @@ void TabletReader::cacheMetadata(
     cacheSection(toMetadataSection(stripeGroups->Get(0)));
   }
 
-  if (clusterIndex_ != nullptr) {
-    auto clusterIndexIt =
-        optionalSections_.find(std::string{kClusterIndexSection});
-    NIMBLE_CHECK(clusterIndexIt != optionalSections_.end());
-    cacheSection(clusterIndexIt->second);
+  if (clusterIndex_ != nullptr || denseIndexRegistry_ != nullptr) {
+    auto indexIt = optionalSections_.find(std::string{kIndexSection});
+    NIMBLE_CHECK(indexIt != optionalSections_.end());
+    cacheSection(indexIt->second);
   }
 
   if (chunkIndex_ != nullptr) {
@@ -542,8 +544,8 @@ void TabletReader::loadStripes(
       requiredOffset = std::min(requiredOffset, it->second.offset());
     }
   };
-  if (options.loadClusterIndex) {
-    updateOffset(kClusterIndexSection);
+  if (options.loadClusterIndex || options.loadDenseIndexes) {
+    updateOffset(kIndexSection);
   }
   if (options.loadChunkIndex) {
     updateOffset(kChunkIndexSection);
@@ -718,10 +720,18 @@ void TabletReader::initOptionalSections() {
 
 std::vector<std::string> TabletReader::preloadSectionNames(
     const Options& options) const {
-  auto names = options.preloadOptionalSections;
-  if (options.loadDenseIndexes) {
-    names.emplace_back(kHashIndexSection);
-    names.emplace_back(kSortedIndexSection);
+  std::vector<std::string> names;
+  names.reserve(options.preloadOptionalSections.size() + 1);
+  auto addName = [&names](std::string name) {
+    if (std::find(names.begin(), names.end(), name) == names.end()) {
+      names.emplace_back(std::move(name));
+    }
+  };
+  for (const auto& name : options.preloadOptionalSections) {
+    addName(name);
+  }
+  if (options.loadClusterIndex || options.loadDenseIndexes) {
+    addName(std::string{kIndexSection});
   }
   return names;
 }
@@ -1089,8 +1099,59 @@ bool TabletReader::hasChunkIndexSection() const {
   return hasOptionalSection(std::string{kChunkIndexSection});
 }
 
-bool TabletReader::hasClusterIndexSection() const {
-  return hasOptionalSection(std::string{kClusterIndexSection});
+bool TabletReader::hasIndexSection() const {
+  return hasOptionalSection(std::string{kIndexSection});
+}
+
+const index::IndexDescriptor* TabletReader::findIndexDescriptor(
+    index::IndexFamily family,
+    std::string_view indexName) const {
+  NIMBLE_CHECK(!indexName.empty(), "Index name cannot be empty");
+  const index::IndexDescriptor* result = nullptr;
+  for (const auto& descriptor : indexDescriptors_) {
+    if (descriptor.family != family || descriptor.name != indexName) {
+      continue;
+    }
+    NIMBLE_CHECK(
+        result == nullptr,
+        "Nimble file contains multiple indexes for family {} and name '{}'",
+        static_cast<int>(family),
+        indexName);
+    result = &descriptor;
+  }
+  return result;
+}
+
+void TabletReader::initIndexes() {
+  if (!loadClusterIndex_ && !loadDenseIndexes_) {
+    return;
+  }
+  NIMBLE_CHECK(indexDescriptors_.empty(), "Indexes already initialized");
+
+  auto indexSection =
+      loadOptionalSection(std::string{kIndexSection}, /*keepCache=*/true);
+  if (!indexSection.has_value()) {
+    return;
+  }
+
+  const auto* root = flatbuffers::GetRoot<serialization::IndexRoot>(
+      indexSection->content().data());
+  NIMBLE_CHECK_NOT_NULL(root);
+  const auto* indexes = root->indexes();
+  NIMBLE_CHECK_NOT_NULL(indexes);
+
+  for (const auto* descriptor : *indexes) {
+    NIMBLE_CHECK_NOT_NULL(descriptor);
+    const auto* name = descriptor->name();
+    NIMBLE_CHECK_NOT_NULL(name, "Index descriptor name is missing");
+    const auto* indexRoot = descriptor->root();
+    NIMBLE_CHECK_NOT_NULL(indexRoot, "Index descriptor root is missing");
+    indexDescriptors_.emplace_back(
+        index::IndexDescriptor{
+            .family = index::toIndexFamily(descriptor->family()),
+            .name = name->str(),
+            .root = toMetadataSection(indexRoot)});
+  }
 }
 
 void TabletReader::initClusterIndex() {
@@ -1099,16 +1160,21 @@ void TabletReader::initClusterIndex() {
   }
   NIMBLE_CHECK_NULL(clusterIndex_, "Index already initialized.");
 
-  if (!hasClusterIndexSection()) {
+  if (!hasIndexSection()) {
     return;
   }
 
-  auto indexSection = loadOptionalSection(
-      std::string{kClusterIndexSection}, /*keepCache=*/false);
-  NIMBLE_CHECK(indexSection.has_value(), "Failed to load index section.");
+  const auto* clusterIndex =
+      findIndexDescriptor(index::IndexFamily::Cluster, clusterIndexName_);
+  if (clusterIndex == nullptr) {
+    return;
+  }
 
-  clusterIndex_ = ClusterIndex::create(
-      std::move(indexSection.value()), pool_, indexOptions_);
+  clusterIndex_ = index::clusterIndexFactory(clusterIndex->name)
+                      .createReader(
+                          Section{std::move(*readMetadata(clusterIndex->root))},
+                          pool_,
+                          indexOptions_);
 }
 
 const index::IndexLookup* TabletReader::denseIndex(
@@ -1123,10 +1189,17 @@ void TabletReader::initDenseIndexes() {
   if (!loadDenseIndexes_) {
     return;
   }
-  denseIndexRegistry_ = DenseIndexRegistry::create(
-      loadOptionalSection(std::string{kHashIndexSection}, /*keepCache=*/false),
-      loadOptionalSection(
-          std::string{kSortedIndexSection}, /*keepCache=*/false),
+  const auto* hashIndex = findIndexDescriptor(
+      index::IndexFamily::Dense, index::kDenseHashIndexName);
+  const auto* sortedIndex = findIndexDescriptor(
+      index::IndexFamily::Dense, index::kDenseSortedIndexName);
+  denseIndexRegistry_ = index::DenseIndexRegistry::create(
+      hashIndex == nullptr ? std::nullopt
+                           : std::optional<Section>{Section{
+                                 std::move(*readMetadata(hashIndex->root))}},
+      sortedIndex == nullptr ? std::nullopt
+                             : std::optional<Section>{Section{std::move(
+                                   *readMetadata(sortedIndex->root))}},
       indexOptions_,
       pool_);
 }

--- a/dwio/nimble/tablet/TabletReader.h
+++ b/dwio/nimble/tablet/TabletReader.h
@@ -26,6 +26,7 @@
 #include "dwio/nimble/index/ChunkIndexGroup.h"
 #include "dwio/nimble/index/ClusterIndex.h"
 #include "dwio/nimble/index/DenseIndexRegistry.h"
+#include "dwio/nimble/index/IndexConfig.h"
 #include "dwio/nimble/index/IndexLookup.h"
 #include "dwio/nimble/tablet/Constants.h"
 #include "dwio/nimble/tablet/FileLayout.h"
@@ -138,7 +139,6 @@ class StripeIdentifier {
 };
 
 using index::ClusterIndex;
-using index::DenseIndexRegistry;
 
 /// Provides read access to a tablet written by a TabletWriter.
 /// Example usage to read all streams from stripe 0 in a file:
@@ -161,6 +161,9 @@ class TabletReader {
 
     /// Whether to load the cluster index during initialization. Default false.
     bool loadClusterIndex{false};
+
+    /// Cluster index implementation to load.
+    std::string clusterIndexName{index::kClusterIndexName};
 
     /// Whether to eagerly preload all per-partition metadata and decode all
     /// per-partition key streams during ClusterIndex construction. Only
@@ -267,8 +270,8 @@ class TabletReader {
   // Returns true if the file has a chunk index optional section.
   bool hasChunkIndexSection() const;
 
-  // Returns true if the file has a cluster index optional section.
-  bool hasClusterIndexSection() const;
+  // Returns true if the file has an index optional section.
+  bool hasIndexSection() const;
 
   // Returns true if the cluster index is loaded.
   inline bool hasClusterIndex() const {
@@ -477,8 +480,15 @@ class TabletReader {
 
   std::shared_ptr<StripeGroup> loadStripeGroup(uint32_t stripeGroupIndex) const;
 
-  // Index.
-  //
+  // Parses the shared index section and caches its runtime descriptors.
+  void initIndexes();
+
+  // Finds the unique descriptor matching the family and name.
+  // Returns nullptr when no descriptor matches.
+  const index::IndexDescriptor* findIndexDescriptor(
+      index::IndexFamily family,
+      std::string_view indexName) const;
+
   void initClusterIndex();
 
   // Holds the result of a coalesced metadata load for a stripe group.
@@ -528,6 +538,7 @@ class TabletReader {
   MemoryPool* const pool_;
   const std::shared_ptr<velox::ReadFile> file_;
   const bool loadClusterIndex_;
+  const std::string clusterIndexName_;
   const bool loadChunkIndex_;
   const bool loadDenseIndexes_;
   // IO options copied from Options.ioOptions (required, with non-null
@@ -559,10 +570,10 @@ class TabletReader {
   std::vector<uint64_t> stripeRows_;
 
   // Index related fields.
+  std::vector<index::IndexDescriptor> indexDescriptors_;
   std::unique_ptr<ClusterIndex> clusterIndex_;
 
-  // Unified dense index registry for hash and sorted indices.
-  std::unique_ptr<DenseIndexRegistry> denseIndexRegistry_;
+  std::unique_ptr<index::DenseIndexRegistry> denseIndexRegistry_;
 
   // Chunk index root, loaded from "chunk_index" optional section.
   std::unique_ptr<ChunkIndex> chunkIndex_;

--- a/dwio/nimble/tablet/tests/ClusterIndexWriterTest.cpp
+++ b/dwio/nimble/tablet/tests/ClusterIndexWriterTest.cpp
@@ -88,7 +88,7 @@ class ClusterIndexWriterTest : public ::testing::Test {
   // Returns a callback that stores root index data in TestFileIndex.
   static auto writeRootIndexCallback(TestFileIndex& fileIndex) {
     return [&fileIndex](const std::string& name, std::string_view content) {
-      EXPECT_EQ(name, nimble::kClusterIndexSection);
+      EXPECT_EQ(name, nimble::kIndexSection);
       fileIndex.rootIndexData = std::string(content);
     };
   }

--- a/dwio/nimble/tablet/tests/TabletTest.cpp
+++ b/dwio/nimble/tablet/tests/TabletTest.cpp
@@ -1026,8 +1026,7 @@ TEST_P(TabletTest, hasOptionalSection) {
   EXPECT_FALSE(tablet->hasOptionalSection("section4"));
   EXPECT_FALSE(tablet->hasOptionalSection("nonexistent"));
   EXPECT_FALSE(tablet->hasOptionalSection(""));
-  EXPECT_FALSE(
-      tablet->hasOptionalSection(std::string(nimble::kClusterIndexSection)));
+  EXPECT_FALSE(tablet->hasOptionalSection(std::string(nimble::kIndexSection)));
 }
 
 TEST_P(TabletTest, hasOptionalSectionEmpty) {
@@ -1762,8 +1761,7 @@ TEST_P(TabletWithIndexTest, singleGroup) {
   EXPECT_EQ(tablet->stripeRowCount(2), 150);
 
   // Verify index section exists
-  EXPECT_TRUE(
-      tablet->hasOptionalSection(std::string(nimble::kClusterIndexSection)));
+  EXPECT_TRUE(tablet->hasOptionalSection(std::string(nimble::kIndexSection)));
 
   // Verify the index is available
   const nimble::ClusterIndex* index = tablet->clusterIndex();
@@ -2157,8 +2155,7 @@ TEST_P(TabletWithIndexTest, multipleGroups) {
   EXPECT_EQ(tablet->stripeRowCount(2), 120);
 
   // Verify index section exists
-  EXPECT_TRUE(
-      tablet->hasOptionalSection(std::string(nimble::kClusterIndexSection)));
+  EXPECT_TRUE(tablet->hasOptionalSection(std::string(nimble::kIndexSection)));
 
   // Verify the index is available
   const nimble::ClusterIndex* index = tablet->clusterIndex();
@@ -2592,8 +2589,7 @@ TEST_P(TabletWithIndexTest, singleGroupWithEmptyStream) {
   EXPECT_EQ(tablet->stripeRowCount(3), 100);
 
   // Verify index section exists
-  EXPECT_TRUE(
-      tablet->hasOptionalSection(std::string(nimble::kClusterIndexSection)));
+  EXPECT_TRUE(tablet->hasOptionalSection(std::string(nimble::kIndexSection)));
 
   // Verify the index is available
   const nimble::ClusterIndex* index = tablet->clusterIndex();
@@ -3018,8 +3014,7 @@ TEST_P(TabletWithIndexTest, multipleGroupsWithEmptyStream) {
   EXPECT_EQ(tablet->stripeRowCount(3), 100);
 
   // Verify index section exists
-  EXPECT_TRUE(
-      tablet->hasOptionalSection(std::string(nimble::kClusterIndexSection)));
+  EXPECT_TRUE(tablet->hasOptionalSection(std::string(nimble::kIndexSection)));
 
   // Verify the index is available
   const nimble::ClusterIndex* index = tablet->clusterIndex();
@@ -3424,8 +3419,7 @@ TEST_P(TabletWithIndexTest, streamDeduplication) {
   EXPECT_EQ(tablet->stripeRowCount(0), 100);
 
   // Verify index section exists
-  EXPECT_TRUE(
-      tablet->hasOptionalSection(std::string(nimble::kClusterIndexSection)));
+  EXPECT_TRUE(tablet->hasOptionalSection(std::string(nimble::kIndexSection)));
 
   // Verify the index is available
   const nimble::ClusterIndex* index = tablet->clusterIndex();
@@ -3593,8 +3587,8 @@ TEST_P(TabletWithIndexTest, keyOrderEnforcement) {
                 file, false);
         auto tablet = createTabletReader(readFile);
         EXPECT_EQ(tablet->stripeCount(), 2);
-        EXPECT_TRUE(tablet->hasOptionalSection(
-            std::string(nimble::kClusterIndexSection)));
+        EXPECT_TRUE(
+            tablet->hasOptionalSection(std::string(nimble::kIndexSection)));
       }
     }
   }
@@ -3629,8 +3623,7 @@ TEST_P(TabletWithIndexTest, noIndex) {
       std::make_shared<nimble::testing::InMemoryTrackableReadFile>(file, false);
   auto tablet = createTabletReader(readFile);
   EXPECT_EQ(tablet->stripeCount(), 1);
-  EXPECT_FALSE(
-      tablet->hasOptionalSection(std::string(nimble::kClusterIndexSection)));
+  EXPECT_FALSE(tablet->hasOptionalSection(std::string(nimble::kIndexSection)));
   EXPECT_FALSE(
       tablet->hasOptionalSection(std::string(nimble::kChunkIndexSection)));
 }
@@ -3829,9 +3822,9 @@ TEST_P(TabletWithIndexTest, loadDenseIndexes) {
   auto writeFile = std::make_unique<velox::InMemoryWriteFile>(&file);
   nimble::VeloxWriterOptions writerOptions;
   writerOptions.hashIndexConfigs.push_back(
-      nimble::HashIndexConfig{.columns = {"id"}});
+      nimble::index::HashIndexConfig{.columns = {"id"}});
   writerOptions.sortedIndexConfigs.push_back(
-      nimble::SortedIndexConfig{.columns = {"value"}});
+      nimble::index::SortedIndexConfig{.columns = {"value"}});
   nimble::VeloxWriter writer(
       type, std::move(writeFile), *pool_, std::move(writerOptions));
   writer.write(batch);
@@ -3877,7 +3870,7 @@ TEST_P(TabletWithIndexTest, loadDenseIndexesMissingIoStats) {
   auto writeFile = std::make_unique<velox::InMemoryWriteFile>(&file);
   nimble::VeloxWriterOptions writerOptions;
   writerOptions.hashIndexConfigs.push_back(
-      nimble::HashIndexConfig{.columns = {"id"}});
+      nimble::index::HashIndexConfig{.columns = {"id"}});
   nimble::VeloxWriter writer(
       type, std::move(writeFile), *pool_, std::move(writerOptions));
   writer.write(batch);
@@ -4008,7 +4001,7 @@ TEST_F(TabletWithIndexTest, configCombinations) {
         tablet->hasOptionalSection(std::string(nimble::kChunkIndexSection)),
         config.expectChunkIndex);
     EXPECT_EQ(
-        tablet->hasOptionalSection(std::string(nimble::kClusterIndexSection)),
+        tablet->hasOptionalSection(std::string(nimble::kIndexSection)),
         config.expectClusterIndex);
 
     // Verify chunk index functionality
@@ -4099,8 +4092,7 @@ TEST_P(TabletWithIndexTest, emptyFileWithIndexConfig) {
   EXPECT_EQ(tablet->stripeCount(), 0);
 
   // Empty file: no data was written, so no cluster index section is produced.
-  EXPECT_FALSE(
-      tablet->hasOptionalSection(std::string(nimble::kClusterIndexSection)));
+  EXPECT_FALSE(tablet->hasOptionalSection(std::string(nimble::kIndexSection)));
   EXPECT_FALSE(tablet->hasClusterIndex());
 }
 
@@ -4220,7 +4212,7 @@ TEST_P(TabletWithIndexTest, fileLayoutOrdering) {
 
   // Optional sections (cluster index, chunk index) come after index partitions.
   const auto clusterIndexIt =
-      layout.optionalSections.find(std::string(nimble::kClusterIndexSection));
+      layout.optionalSections.find(std::string(nimble::kIndexSection));
   ASSERT_NE(clusterIndexIt, layout.optionalSections.end());
   EXPECT_GT(clusterIndexIt->second.offset(), layout.indexPartitions[0].offset())
       << "Cluster index should come after index partition metadata";
@@ -4304,7 +4296,7 @@ TEST_P(TabletWithIndexTest, cacheWarmPath) {
   // Preload index sections so the cache warm path can serve them from cache.
   nimble::TabletReader::Options options;
   options.preloadOptionalSections = {
-      std::string(nimble::kClusterIndexSection),
+      std::string(nimble::kIndexSection),
       std::string(nimble::kChunkIndexSection)};
 
   // Cold path: first reader populates the cache.
@@ -4636,8 +4628,8 @@ TEST_P(TabletTest, configureOptionsIndexFlags) {
     EXPECT_TRUE(opts.loadChunkIndex);
     EXPECT_TRUE(
         containsSection(opts.preloadOptionalSections, nimble::kSchemaSection));
-    EXPECT_FALSE(containsSection(
-        opts.preloadOptionalSections, nimble::kClusterIndexSection));
+    EXPECT_FALSE(
+        containsSection(opts.preloadOptionalSections, nimble::kIndexSection));
     EXPECT_TRUE(containsSection(
         opts.preloadOptionalSections, nimble::kChunkIndexSection));
   }
@@ -4651,8 +4643,8 @@ TEST_P(TabletTest, configureOptionsIndexFlags) {
     EXPECT_FALSE(opts.loadChunkIndex);
     EXPECT_TRUE(
         containsSection(opts.preloadOptionalSections, nimble::kSchemaSection));
-    EXPECT_FALSE(containsSection(
-        opts.preloadOptionalSections, nimble::kClusterIndexSection));
+    EXPECT_FALSE(
+        containsSection(opts.preloadOptionalSections, nimble::kIndexSection));
     EXPECT_FALSE(containsSection(
         opts.preloadOptionalSections, nimble::kChunkIndexSection));
   }
@@ -4664,8 +4656,8 @@ TEST_P(TabletTest, configureOptionsIndexFlags) {
     auto opts = nimble::TabletReader::configureOptions(readerOptions);
     EXPECT_TRUE(opts.loadClusterIndex);
     EXPECT_FALSE(opts.loadChunkIndex);
-    EXPECT_TRUE(containsSection(
-        opts.preloadOptionalSections, nimble::kClusterIndexSection));
+    EXPECT_FALSE(
+        containsSection(opts.preloadOptionalSections, nimble::kIndexSection));
     EXPECT_FALSE(containsSection(
         opts.preloadOptionalSections, nimble::kChunkIndexSection));
   }
@@ -4677,8 +4669,8 @@ TEST_P(TabletTest, configureOptionsIndexFlags) {
     auto opts = nimble::TabletReader::configureOptions(readerOptions);
     EXPECT_FALSE(opts.loadClusterIndex);
     EXPECT_TRUE(opts.loadChunkIndex);
-    EXPECT_FALSE(containsSection(
-        opts.preloadOptionalSections, nimble::kClusterIndexSection));
+    EXPECT_FALSE(
+        containsSection(opts.preloadOptionalSections, nimble::kIndexSection));
     EXPECT_TRUE(containsSection(
         opts.preloadOptionalSections, nimble::kChunkIndexSection));
   }
@@ -6650,7 +6642,7 @@ TEST_P(TabletWithIndexTest, cacheWarmPathCompressedChunkIndex) {
 
   nimble::TabletReader::Options options;
   options.preloadOptionalSections = {
-      std::string(nimble::kClusterIndexSection),
+      std::string(nimble::kIndexSection),
       std::string(nimble::kChunkIndexSection)};
 
   // Cold path.

--- a/dwio/nimble/velox/VeloxWriter.cpp
+++ b/dwio/nimble/velox/VeloxWriter.cpp
@@ -16,12 +16,17 @@
 #include "dwio/nimble/velox/VeloxWriter.h"
 
 #include <memory>
+#include <optional>
 #include <unordered_map>
+#include <vector>
 
 #include "dwio/nimble/common/Exceptions.h"
 #include "dwio/nimble/common/Types.h"
 #include "dwio/nimble/encodings/selection/EncodingSelectionPolicy.h"
+#include "dwio/nimble/index/ClusterIndexFactory.h"
+#include "dwio/nimble/index/IndexSerialization.h"
 #include "dwio/nimble/tablet/Constants.h"
+#include "dwio/nimble/tablet/IndexGenerated.h"
 #include "dwio/nimble/velox/BufferGrowthPolicy.h"
 #include "dwio/nimble/velox/ChunkedStreamWriter.h"
 #include "dwio/nimble/velox/EncodingLayoutTree.h"
@@ -223,6 +228,51 @@ class WriterContext : public FieldWriterContext {
 } // namespace detail
 
 namespace {
+
+std::unique_ptr<index::IndexWriter> createClusterIndexWriter(
+    const std::optional<index::ClusterIndexConfig>& config,
+    const velox::TypePtr& type,
+    velox::memory::MemoryPool* pool) {
+  if (!config.has_value()) {
+    return nullptr;
+  }
+  return index::clusterIndexFactory(config->indexName)
+      .createWriter(config.value(), type, pool);
+}
+
+std::string_view asView(const flatbuffers::FlatBufferBuilder& builder) {
+  return {
+      reinterpret_cast<const char*>(builder.GetBufferPointer()),
+      builder.GetSize()};
+}
+
+void writeIndexSection(
+    const std::vector<index::IndexDescriptor>& descriptors,
+    const WriteOptionalSectionFn& writeMetadataFn) {
+  if (descriptors.empty()) {
+    return;
+  }
+
+  flatbuffers::FlatBufferBuilder builder(kInitialFooterSize);
+  auto indexes =
+      builder.CreateVector<flatbuffers::Offset<serialization::IndexDescriptor>>(
+          descriptors.size(), [&builder, &descriptors](size_t i) {
+            const auto& descriptor = descriptors[i];
+            auto name = builder.CreateString(descriptor.name);
+            auto root = serialization::CreateMetadataSection(
+                builder,
+                descriptor.root.offset(),
+                descriptor.root.size(),
+                static_cast<serialization::CompressionType>(
+                    descriptor.root.compressionType()),
+                descriptor.root.uncompressedSize().value_or(
+                    descriptor.root.size()));
+            return serialization::CreateIndexDescriptor(
+                builder, index::toIndexFamily(descriptor.family), name, root);
+          });
+  builder.Finish(serialization::CreateIndexRoot(builder, indexes));
+  writeMetadataFn(std::string(kIndexSection), asView(builder));
+}
 
 velox::RuntimeMetric toRuntimeMetric(const std::vector<uint64_t>& values) {
   velox::RuntimeMetric metric;
@@ -789,7 +839,7 @@ VeloxWriter::VeloxWriter(
           *writerMemoryPool_,
           std::move(options))},
       file_{std::move(file)},
-      clusterIndexWriter_{index::ClusterIndexWriter::create(
+      clusterIndexWriter_{createClusterIndexWriter(
           context_->options().clusterIndexConfig,
           type,
           &(*context_->bufferMemoryPool()))},
@@ -1050,15 +1100,26 @@ void VeloxWriter::writeIndexes(
     const WriteDataFn& writeDataFn,
     const CreateMetadataSectionFn& createMetadataFn,
     const WriteOptionalSectionFn& writeMetadataFn) {
+  std::vector<index::IndexDescriptor> descriptors;
   if (hasHashIndex()) {
-    hashIndexWriter_->close(writeDataFn, createMetadataFn, writeMetadataFn);
+    if (auto descriptor =
+            hashIndexWriter_->close(writeDataFn, createMetadataFn)) {
+      descriptors.emplace_back(std::move(descriptor.value()));
+    }
   }
   if (hasSortedIndex()) {
-    sortedIndexWriter_->close(writeDataFn, createMetadataFn, writeMetadataFn);
+    if (auto descriptor =
+            sortedIndexWriter_->close(writeDataFn, createMetadataFn)) {
+      descriptors.emplace_back(std::move(descriptor.value()));
+    }
   }
   if (hasClusterIndex()) {
-    clusterIndexWriter_->close(writeDataFn, createMetadataFn, writeMetadataFn);
+    if (auto descriptor =
+            clusterIndexWriter_->close(writeDataFn, createMetadataFn)) {
+      descriptors.emplace_back(std::move(descriptor.value()));
+    }
   }
+  writeIndexSection(descriptors, writeMetadataFn);
 }
 
 bool VeloxWriter::shouldFlush(FlushPolicy* policy) const {

--- a/dwio/nimble/velox/VeloxWriter.h
+++ b/dwio/nimble/velox/VeloxWriter.h
@@ -212,9 +212,9 @@ class VeloxWriter {
   MemoryPoolHolder encodingMemoryPool_;
   const std::unique_ptr<detail::WriterContext> context_;
   std::unique_ptr<velox::WriteFile> file_;
-  const std::unique_ptr<index::ClusterIndexWriter> clusterIndexWriter_;
-  const std::unique_ptr<index::HashIndexWriter> hashIndexWriter_;
-  const std::unique_ptr<index::SortedIndexWriter> sortedIndexWriter_;
+  const std::unique_ptr<index::IndexWriter> clusterIndexWriter_;
+  const std::unique_ptr<index::IndexWriter> hashIndexWriter_;
+  const std::unique_ptr<index::IndexWriter> sortedIndexWriter_;
   const std::unique_ptr<TabletWriter> tabletWriter_;
 
   std::unique_ptr<FieldWriter> rootWriter_;

--- a/dwio/nimble/velox/VeloxWriterOptions.h
+++ b/dwio/nimble/velox/VeloxWriterOptions.h
@@ -80,21 +80,21 @@ struct VeloxWriterOptions {
   /// writing. The index stores the per-chunk min and max key for each stripe.
   // EXPERIMENTAL: Cluster index is not production-ready. Do not enable for
   // production tables without consulting the Nimble team (oncall: dwios).
-  std::optional<ClusterIndexConfig> clusterIndexConfig;
+  std::optional<index::ClusterIndexConfig> clusterIndexConfig;
 
   /// Hash index configurations. Each config builds an independent hash-based
   /// point lookup index on the specified columns. Unlike cluster index, hash
   /// index does not require sorted data.
   // EXPERIMENTAL: Hash index is not production-ready. Do not enable for
   // production tables without consulting the Nimble team (oncall: dwios).
-  std::vector<HashIndexConfig> hashIndexConfigs;
+  std::vector<index::HashIndexConfig> hashIndexConfigs;
 
   /// Sorted index configurations. Each config builds an independent sorted
   /// key stream index supporting both point lookups and range scans on
   /// unsorted data.
   // EXPERIMENTAL: Sorted index is not production-ready. Do not enable for
   // production tables without consulting the Nimble team (oncall: dwios).
-  std::vector<SortedIndexConfig> sortedIndexConfigs;
+  std::vector<index::SortedIndexConfig> sortedIndexConfigs;
 
   // Columns that should be encoded as flat maps. Maps column name to a set
   /// of predefined key strings. When the set is empty, the column is

--- a/dwio/nimble/velox/index/tests/NimbleIndexProjectorTest.cpp
+++ b/dwio/nimble/velox/index/tests/NimbleIndexProjectorTest.cpp
@@ -48,6 +48,7 @@ namespace facebook::nimble::test {
 
 using namespace velox;
 using namespace velox::dwio::common;
+using index::ClusterIndexConfig;
 using Subfield = velox::common::Subfield;
 
 namespace {

--- a/dwio/nimble/velox/selective/tests/E2EFilterTest.cpp
+++ b/dwio/nimble/velox/selective/tests/E2EFilterTest.cpp
@@ -40,6 +40,7 @@ namespace facebook::nimble {
 namespace {
 
 using namespace facebook::velox;
+using index::ClusterIndexConfig;
 
 using E2EFilterTestParams =
     std::tuple<bool, bool, bool, bool, bool, bool, bool>;

--- a/dwio/nimble/velox/selective/tests/E2EIndexTest.cpp
+++ b/dwio/nimble/velox/selective/tests/E2EIndexTest.cpp
@@ -44,6 +44,7 @@ namespace facebook::nimble::test {
 using namespace velox;
 using namespace velox::common;
 using namespace velox::dwio::common;
+using index::ClusterIndexConfig;
 
 namespace {
 

--- a/dwio/nimble/velox/tests/VeloxWriterTest.cpp
+++ b/dwio/nimble/velox/tests/VeloxWriterTest.cpp
@@ -432,7 +432,7 @@ TEST_F(VeloxWriterTest, emptyFileWithIndexEnabled) {
       {"value_col", velox::VARCHAR()},
   });
 
-  nimble::ClusterIndexConfig clusterIndexConfig{
+  nimble::index::ClusterIndexConfig clusterIndexConfig{
       .columns = {"key_col"},
       .sortOrders = {nimble::SortOrder{.ascending = true}},
       .enforceKeyOrder = true,
@@ -872,7 +872,7 @@ TEST_F(VeloxWriterTest, featureReorderingStreamCollocation) {
               {flatmapOrdinal, reorderedKeys}};
 
       if (enableIndex) {
-        nimble::ClusterIndexConfig clusterIndexConfig;
+        nimble::index::ClusterIndexConfig clusterIndexConfig;
         clusterIndexConfig.columns = {"key"};
         clusterIndexConfig.sortOrders = {nimble::SortOrder{.ascending = true}};
         clusterIndexConfig.enforceKeyOrder = true;
@@ -3730,10 +3730,10 @@ class VeloxWriterIndexTest
     return batches;
   }
 
-  nimble::ClusterIndexConfig createIndexConfig(
+  nimble::index::ClusterIndexConfig createIndexConfig(
       const std::vector<std::string>& columns,
       bool enforceKeyOrder = true) {
-    nimble::ClusterIndexConfig config{
+    nimble::index::ClusterIndexConfig config{
         .columns = columns,
         .enforceKeyOrder = enforceKeyOrder,
     };
@@ -3770,7 +3770,7 @@ class VeloxWriterIndexTest
   }
 
   nimble::VeloxWriterOptions createWriterOptions(
-      const nimble::ClusterIndexConfig& clusterIndexConfig,
+      const nimble::index::ClusterIndexConfig& clusterIndexConfig,
       const std::function<std::unique_ptr<nimble::FlushPolicy>()>&
           flushPolicyFactory = nullptr) {
     nimble::VeloxWriterOptions options{
@@ -4142,7 +4142,7 @@ TEST_P(VeloxWriterIndexTest, singleGroup) {
   // group.
   auto type = defaultType();
 
-  nimble::ClusterIndexConfig clusterIndexConfig =
+  nimble::index::ClusterIndexConfig clusterIndexConfig =
       createIndexConfig({"key_col"});
 
   std::string file;
@@ -4187,8 +4187,7 @@ TEST_P(VeloxWriterIndexTest, singleGroup) {
   }
 
   // Verify index section exists
-  EXPECT_TRUE(
-      tablet->hasOptionalSection(std::string(nimble::kClusterIndexSection)));
+  EXPECT_TRUE(tablet->hasOptionalSection(std::string(nimble::kIndexSection)));
 
   // Verify index is available
   const auto* index = tablet->clusterIndex();
@@ -4246,7 +4245,7 @@ TEST_P(VeloxWriterIndexTest, multipleGroups) {
   // stripes.
   auto type = defaultType();
 
-  nimble::ClusterIndexConfig clusterIndexConfig =
+  nimble::index::ClusterIndexConfig clusterIndexConfig =
       createIndexConfig({"key_col"});
 
   std::string file;
@@ -4292,8 +4291,7 @@ TEST_P(VeloxWriterIndexTest, multipleGroups) {
   }
 
   // Verify index section exists
-  EXPECT_TRUE(
-      tablet->hasOptionalSection(std::string(nimble::kClusterIndexSection)));
+  EXPECT_TRUE(tablet->hasOptionalSection(std::string(nimble::kIndexSection)));
 
   // Verify index is available
   const auto* index = tablet->clusterIndex();
@@ -4354,7 +4352,7 @@ TEST_P(VeloxWriterIndexTest, multipleIndexColumns) {
       {"data_col", velox::VARCHAR()},
   });
 
-  nimble::ClusterIndexConfig clusterIndexConfig =
+  nimble::index::ClusterIndexConfig clusterIndexConfig =
       createIndexConfig({"key1", "key2"});
 
   std::string file;
@@ -4477,7 +4475,7 @@ TEST_F(VeloxWriterTest, indexEnforceKeyOrder) {
               testCase == TestCase::kOutOfOrder ? "OutOfOrder"
                                                 : "DuplicateKeys"));
 
-      nimble::ClusterIndexConfig clusterIndexConfig{
+      nimble::index::ClusterIndexConfig clusterIndexConfig{
           .columns = {"key_col"},
           .enforceKeyOrder = enforceKeyOrder,
           .noDuplicateKey = enforceKeyOrder,
@@ -4535,7 +4533,7 @@ TEST_F(VeloxWriterTest, indexEnforceKeyOrder) {
         velox::InMemoryReadFile readFile(file);
         nimble::VeloxReader reader(&readFile, *leafPool_);
         EXPECT_TRUE(reader.tabletReader().hasOptionalSection(
-            std::string(nimble::kClusterIndexSection)));
+            std::string(nimble::kIndexSection)));
       }
     }
   }
@@ -4546,7 +4544,7 @@ TEST_P(VeloxWriterIndexTest, duplicateKeys) {
   // This is a valid scenario where multiple rows have the same key value.
   auto type = defaultType();
 
-  nimble::ClusterIndexConfig clusterIndexConfig =
+  nimble::index::ClusterIndexConfig clusterIndexConfig =
       createIndexConfig({"key_col"});
 
   std::string file;
@@ -4687,7 +4685,7 @@ TEST_P(VeloxWriterIndexTest, chunking) {
   // Test index with chunking enabled
   auto type = defaultType();
 
-  nimble::ClusterIndexConfig clusterIndexConfig =
+  nimble::index::ClusterIndexConfig clusterIndexConfig =
       createIndexConfig({"key_col"});
 
   std::string file;
@@ -4753,7 +4751,7 @@ TEST_P(VeloxWriterIndexTest, streamDeduplication) {
       {"string_col2", velox::VARCHAR()},
   });
 
-  nimble::ClusterIndexConfig clusterIndexConfig =
+  nimble::index::ClusterIndexConfig clusterIndexConfig =
       createIndexConfig({"key_col"});
 
   std::string file;
@@ -4871,7 +4869,7 @@ TEST_P(VeloxWriterIndexTest, streamStatsNoDuplicates) {
       {"string_col2", velox::VARCHAR()},
   });
 
-  nimble::ClusterIndexConfig clusterIndexConfig =
+  nimble::index::ClusterIndexConfig clusterIndexConfig =
       createIndexConfig({"key_col"});
 
   std::string file;
@@ -4964,7 +4962,7 @@ TEST_F(VeloxWriterTest, customPrefixRestartInterval) {
             std::to_string(customRestartInterval.value())}}};
     }
 
-    nimble::ClusterIndexConfig clusterIndexConfig{
+    nimble::index::ClusterIndexConfig clusterIndexConfig{
         .columns = {"key_col"},
         .enforceKeyOrder = true,
         .encodingLayout =


### PR DESCRIPTION
Summary:

Introduce a common `columnar.indexes` optional section that stores named index descriptors for cluster and dense index payloads. Add `nimble.cluster.v1`, `nimble.dense.hash.v1`, and `nimble.dense.sorted.v1` names, wire cluster index creation through a factory registry, and make tablet readers dispatch index payloads from the common manifest. Keep the existing cluster payload schema and dense registry internals while moving the file-level section layout to the shared index manifest.

Reviewed By: HuamengJiang, tanjialiang

Differential Revision: D110005947
