### PR TITLE
perf(nimble): Preserve dictionary mode across a between-batch skip

### DIFF
--- a/dwio/nimble/velox/selective/ChunkedDecoder.cpp
+++ b/dwio/nimble/velox/selective/ChunkedDecoder.cpp
@@ -275,7 +275,7 @@ void ChunkedDecoder::skipWithoutIndex(
     const ChunkBoundaryCallback& onChunkBoundary) {
   while (numValues > 0) {
     if (FOLLY_UNLIKELY(remainingValues_ == 0)) {
-      loadNextChunk(/*preserveDictionaryEncoding=*/false, onChunkBoundary);
+      loadNextChunk(preserveDictionaryEncoding_, onChunkBoundary);
     }
     if (numValues < remainingValues_) {
       encoding_->skip(numValues);
@@ -302,7 +302,7 @@ void ChunkedDecoder::seekToChunk(
   remainingValues_ = 0;
 
   // Load the chunk at this position
-  loadNextChunk(/*preserveDictionaryEncoding=*/false, onChunkBoundary);
+  loadNextChunk(preserveDictionaryEncoding_, onChunkBoundary);
 }
 
 std::optional<size_t> ChunkedDecoder::estimateRowCount() const {

--- a/dwio/nimble/velox/selective/ChunkedDecoder.h
+++ b/dwio/nimble/velox/selective/ChunkedDecoder.h
@@ -309,6 +309,17 @@ class ChunkedDecoder {
   /// Caller must call ensureLoaded() first.
   bool dictionaryConvertible() const;
 
+  /// Controls whether the skip paths (skipWithoutIndex, seekToChunk) load the
+  /// chunk they advance into (the chunk after the skip) with dictionary
+  /// encoding preserved. The string dictionary reader sets this so a
+  /// between-batch skip that lands in a preserve-gated encoding (e.g.
+  /// RLE<Dictionary>) loads that chunk in dictionary mode instead of flattening
+  /// it. All other readers leave it at the default (false), so their skips are
+  /// unaffected.
+  void setPreserveDictionaryEncoding(bool preserve) {
+    preserveDictionaryEncoding_ = preserve;
+  }
+
   int64_t remainingValues() const {
     return remainingValues_;
   }
@@ -845,6 +856,11 @@ class ChunkedDecoder {
   const bool decodeValuesWithNulls_;
   const EncodingFactory* const encodingFactory_;
   const bool stringDecoderZeroCopy_{false};
+  // When true, the skip paths (skipWithoutIndex, seekToChunk) load the chunk
+  // they advance into (the chunk after the skip) with dictionary encoding
+  // preserved. Set by the string dictionary reader; all other decoders keep the
+  // default so their skips load chunks in flat mode.
+  bool preserveDictionaryEncoding_{false};
   // Optional stream index for accelerating skip operations
   const std::shared_ptr<index::StreamIndex> streamIndex_;
   // Total row count in the stream, set from stream index if available.

--- a/dwio/nimble/velox/selective/StringColumnReader.cpp
+++ b/dwio/nimble/velox/selective/StringColumnReader.cpp
@@ -30,6 +30,13 @@ namespace facebook::nimble {
 
 using namespace facebook::velox;
 
+bool StringColumnReader::dictionaryPreservable() {
+  return scanSpec_->valueHook() == nullptr &&
+      formatData().stringDecoderZeroCopy() &&
+      static_cast<const NimbleData&>(formatData())
+          .nimblePreserveDictionaryEncoding();
+}
+
 uint64_t StringColumnReader::skip(uint64_t numValues) {
   numValues = SelectiveColumnReader::skip(numValues);
   // Clear cached dictionary state when skip crosses a chunk boundary,
@@ -331,20 +338,14 @@ bool StringColumnReader::readWithDictionary(
     int64_t offset,
     const RowSet& rows,
     const uint64_t* incomingNulls) {
-  // Dictionary path requires: no value hook, non-legacy encoding path
-  // (zero-copy), session property enabled, and dictionary-convertible
-  // encoding. Filters are supported via post-materialization filtering
-  // on the bulk-read dictionary indices.
-  // TODO: Value hooks (aggregation pushdown) could be supported by
-  // resolving alphabet[index] and calling hook->addValue() post-read,
-  // similar to filterDictionaryIndices. Neither Nimble nor DWRF
-  // currently support filter+hook combined for dict string columns.
-  if (scanSpec_->valueHook() || !formatData().stringDecoderZeroCopy() ||
-      !static_cast<const NimbleData&>(formatData())
-           .nimblePreserveDictionaryEncoding()) {
-    clearDictionaryState();
-    return false;
-  }
+  // Contract: read() only enters the dictionary path when the dictionary
+  // encoding is preservable — no value hook, the zero-copy (non-legacy)
+  // encoding path, and preserve-dictionary enabled. Check it here so a caller
+  // that forgets the gate fails loudly instead of silently mis-reading a
+  // legacy/hook column through the (zero-copy) dictionary machinery.
+  NIMBLE_CHECK(
+      dictionaryPreservable(),
+      "readWithDictionary entered when the dictionary is not preservable");
 
   // When the previous batch's readDictionaryIndices consumed the last row of
   // a chunk (remainingValues_ == 0), ensureLoaded loads the next chunk. The
@@ -355,10 +356,6 @@ bool StringColumnReader::readWithDictionary(
         clearDictionaryState();
         return true;
       });
-  if (!decoder_.dictionaryConvertible()) {
-    clearDictionaryState();
-    return false;
-  }
 
   // A cross-chunk merged alphabet is per-read: getValues() clears it (and snaps
   // its backing into the output DictionaryVector) once the read is consumed.
@@ -374,11 +371,26 @@ bool StringColumnReader::readWithDictionary(
   }
 
   prepareRead<int32_t>(offset, rows, incomingNulls);
+  const auto endReadRow = rows.back() + 1;
+  // prepareRead runs seekTo -> skip, which can advance the decoder across a
+  // chunk boundary and load the landed chunk with preserveDictionaryEncoding
+  // false (skipWithoutIndex/seekToChunk hardcode it), so a Dictionary-encoded
+  // landed chunk is created non-dict and reports not convertible. Check
+  // convertibility once here, on the chunk that will actually be read — this
+  // single post-prepareRead check covers both the no-skip and cross-chunk-skip
+  // cases. When it is not convertible, no dictionary indices were materialized;
+  // re-type the value buffer to StringView (abandonDictionaryEncoding handles
+  // numValues_ == 0) so read()'s flat continuation fills it. Crucially, read()
+  // must NOT run a second prepareRead in this case — that would advance the
+  // null/in-map decoders a second time and corrupt flatmap reads.
+  if (!decoder_.dictionaryConvertible()) {
+    abandonDictionaryEncoding(endReadRow);
+    return false;
+  }
   ensureDictionaryState();
   velox::common::testutil::TestValue::adjust(
       "facebook::nimble::StringColumnReader::readWithDictionary",
       &dictionaryState_.alphabet);
-  const auto endReadRow = rows.back() + 1;
   // Set to true when the dictionary read is abandoned at a non-dict chunk;
   // false when the whole range is read in dictionary mode. On abandon,
   // readDictionaryIndices has already advanced readOffset_ to the decoder's
@@ -504,21 +516,35 @@ void StringColumnReader::read(
     int64_t offset,
     const RowSet& rows,
     const uint64_t* incomingNulls) {
-  if (readWithDictionary(offset, rows, incomingNulls)) {
-    return;
+  // numReadRows is how many rows the dictionary portion produced before
+  // abandoning: 0 when the dictionary is not preservable or the landed chunk
+  // was non-convertible, or the chunk boundary when the dict path was abandoned
+  // mid-read. It selects a fresh flat read vs a flat continuation below.
+  velox::vector_size_t numReadRows = 0;
+  // The dictionary encoding is preservable only without a value hook, on the
+  // zero-copy (non-legacy) encoding path, and with preserve-dictionary enabled.
+  // Deciding here (rather than inside readWithDictionary) lets
+  // readWithDictionary own the single prepareRead: when it abandons it re-types
+  // the value buffer via abandonDictionaryEncoding, so read() never issues a
+  // second prepareRead — which would advance the null/in-map decoders twice and
+  // corrupt flatmap reads.
+  if (dictionaryPreservable()) {
+    if (readWithDictionary(offset, rows, incomingNulls)) {
+      return;
+    }
+    numReadRows = readOffset_ > offset
+        ? static_cast<velox::vector_size_t>(readOffset_ - offset)
+        : 0;
+  } else {
+    // Dictionary not preservable: full flat read. Clearing the dictionary state
+    // converts the reader back to flat read mode, dropping anything a
+    // dictionary-mode read (readWithDictionary) may have prepared, so this read
+    // materializes plain StringViews.
+    clearDictionaryState();
+    prepareRead<std::string_view>(offset, rows, incomingNulls);
   }
 
   const auto endReadRow = rows.back() + 1;
-  // readWithDictionary returns false for two reasons:
-  // 1. Preconditions not met (e.g., zeroCopy disabled) — readOffset_
-  //    unchanged, numReadRows == 0. Full flat read via prepareRead below.
-  // 2. Dict abandoned mid-read — readOffset_ advanced to the chunk boundary,
-  //    numReadRows > 0. Flat encoding fallback for the remaining rows only.
-  // Both the return value (false) and numReadRows > 0 are needed to
-  // distinguish abandoned dict (case 2) from dict path not taken (case 1).
-  const auto numReadRows = readOffset_ > offset
-      ? static_cast<velox::vector_size_t>(readOffset_ - offset)
-      : 0;
   NIMBLE_CHECK_LE(numReadRows, endReadRow);
 
   // Always read against the complete original rows so the visitor — and hence
@@ -528,9 +554,7 @@ void StringColumnReader::read(
   // resumes there (the dict portion was already produced) instead of re-reading
   // the prefix.
   velox::vector_size_t startRowIndex = 0;
-  if (numReadRows == 0) {
-    prepareRead<std::string_view>(offset, rows, incomingNulls);
-  } else {
+  if (numReadRows > 0) {
     startRowIndex = static_cast<velox::vector_size_t>(
         std::lower_bound(rows.data(), rows.data() + rows.size(), numReadRows) -
         rows.data());
@@ -585,7 +609,12 @@ void StringColumnReader::ensureAlphabetVector() {
 }
 
 void StringColumnReader::abandonDictionaryEncoding(vector_size_t endReadRow) {
-  NIMBLE_CHECK(!dictionaryState_.alphabet.empty());
+  // numValues_ == 0 means the dictionary path was abandoned before
+  // materializing any indices (the landed chunk was not convertible at the
+  // read's start), so there is no alphabet and nothing to resolve — the loop
+  // below is a no-op and this only re-types the value buffer to StringView for
+  // the flat continuation.
+  NIMBLE_CHECK(numValues_ == 0 || !dictionaryState_.alphabet.empty());
 
   // Resolve dictionary indices to flat StringViews. The underlying string
   // data lives in the encoding's string buffers, which the reader already

--- a/dwio/nimble/velox/selective/StringColumnReader.cpp
+++ b/dwio/nimble/velox/selective/StringColumnReader.cpp
@@ -347,15 +347,13 @@ bool StringColumnReader::readWithDictionary(
       dictionaryPreservable(),
       "readWithDictionary entered when the dictionary is not preservable");
 
-  // When the previous batch's readDictionaryIndices consumed the last row of
-  // a chunk (remainingValues_ == 0), ensureLoaded loads the next chunk. The
-  // callback clears stale dictionary state so ensureDictionaryState rebuilds
-  // from the new encoding.
-  decoder_.ensureLoaded(
-      /*preserveDictionaryEncoding=*/true, [this] {
-        clearDictionaryState();
-        return true;
-      });
+  // Entering the dictionary read path: load any chunk this read advances into
+  // (via prepareRead's skip below) with dictionary encoding preserved, so a
+  // between-batch skip that lands in a preserve-gated encoding (e.g.
+  // RLE<Dictionary>) stays dictionary-convertible instead of being flattened.
+  // abandonDictionaryEncoding sets it back to false when the dictionary path is
+  // given up.
+  decoder_.setPreserveDictionaryEncoding(true);
 
   // A cross-chunk merged alphabet is per-read: getValues() clears it (and snaps
   // its backing into the output DictionaryVector) once the read is consumed.
@@ -371,18 +369,33 @@ bool StringColumnReader::readWithDictionary(
   }
 
   prepareRead<int32_t>(offset, rows, incomingNulls);
+
+  // Load the chunk that will actually be read, AFTER prepareRead's seekTo ->
+  // skip. The skip advances the value decoder and can leave a stale chunk
+  // current: the previous batch's exhausted chunk (no skip needed), or, when
+  // the skip lands exactly on a chunk boundary, the last chunk it skipped
+  // through. Loading here rather than before prepareRead ensures the
+  // convertibility check below inspects the chunk that will be read, not a
+  // stale one. It loads with dictionary encoding preserved — the same mode the
+  // skip's own chunk loads use (the flag set above) — which is what lets this
+  // move after the skip. The callback clears stale dictionary state so
+  // ensureDictionaryState rebuilds from the new chunk.
+  decoder_.ensureLoaded(
+      /*preserveDictionaryEncoding=*/true, [this] {
+        clearDictionaryState();
+        return true;
+      });
+
   const auto endReadRow = rows.back() + 1;
-  // prepareRead runs seekTo -> skip, which can advance the decoder across a
-  // chunk boundary and load the landed chunk with preserveDictionaryEncoding
-  // false (skipWithoutIndex/seekToChunk hardcode it), so a Dictionary-encoded
-  // landed chunk is created non-dict and reports not convertible. Check
-  // convertibility once here, on the chunk that will actually be read — this
-  // single post-prepareRead check covers both the no-skip and cross-chunk-skip
-  // cases. When it is not convertible, no dictionary indices were materialized;
-  // re-type the value buffer to StringView (abandonDictionaryEncoding handles
-  // numValues_ == 0) so read()'s flat continuation fills it. Crucially, read()
-  // must NOT run a second prepareRead in this case — that would advance the
-  // null/in-map decoders a second time and corrupt flatmap reads.
+  // Check convertibility once, on that chunk. A between-batch skip may load it
+  // in dictionary mode (preserve flag above), so a dict-convertible chunk stays
+  // convertible here; only a genuinely non-dictionary encoding (e.g. Trivial)
+  // fails it. When it is not convertible, no dictionary indices were
+  // materialized; re-type the value buffer to StringView
+  // (abandonDictionaryEncoding handles numValues_ == 0) so read()'s flat
+  // continuation fills it. Crucially, read() must NOT run a second prepareRead
+  // in this case — that would advance the null/in-map decoders a second time
+  // and corrupt flatmap reads.
   if (!decoder_.dictionaryConvertible()) {
     abandonDictionaryEncoding(endReadRow);
     return false;
@@ -610,7 +623,7 @@ void StringColumnReader::ensureAlphabetVector() {
 
 void StringColumnReader::abandonDictionaryEncoding(vector_size_t endReadRow) {
   // numValues_ == 0 means the dictionary path was abandoned before
-  // materializing any indices (the landed chunk was not convertible at the
+  // materializing any indices (the chunk read was not convertible at the
   // read's start), so there is no alphabet and nothing to resolve — the loop
   // below is a no-op and this only re-types the value buffer to StringView for
   // the flat continuation.
@@ -653,6 +666,9 @@ void StringColumnReader::abandonDictionaryEncoding(vector_size_t endReadRow) {
   valueSize_ = sizeof(StringView);
   clearDictionaryState();
   crossChunkRead_ = false;
+  // The dictionary path is given up: subsequent chunk loads (including any
+  // skip) revert to flat mode until the next readWithDictionary re-enters it.
+  decoder_.setPreserveDictionaryEncoding(false);
 }
 
 void StringColumnReader::getValues(const RowSet& rows, VectorPtr* result) {

--- a/dwio/nimble/velox/selective/StringColumnReader.h
+++ b/dwio/nimble/velox/selective/StringColumnReader.h
@@ -52,6 +52,12 @@ class StringColumnReader : public velox::dwio::common::SelectiveColumnReader {
     return false;
   }
 
+  // Whether the dictionary encoding is preservable for this read: only without
+  // a value hook, on the zero-copy (non-legacy) encoding path, and with
+  // preserve-dictionary enabled. Gates read()'s dispatch into
+  // readWithDictionary.
+  bool dictionaryPreservable();
+
   // Merged alphabet accumulated across chunks for multi-chunk dictionary
   // reads. Each chunk's alphabet is appended, and indices are offset to
   // reference this merged alphabet. Cleared when skip crosses a chunk

--- a/dwio/nimble/velox/selective/tests/StringColumnReaderTest.cpp
+++ b/dwio/nimble/velox/selective/tests/StringColumnReaderTest.cpp
@@ -16,11 +16,20 @@
 
 #include "dwio/nimble/velox/selective/SelectiveNimbleReader.h"
 
+#include "dwio/nimble/common/Exceptions.h"
 #include "dwio/nimble/common/tests/NimbleFileWriter.h"
+#include "dwio/nimble/encodings/common/EncodingLayout.h"
+#include "dwio/nimble/encodings/selection/EncodingIdentifier.h"
+#include "dwio/nimble/tablet/Constants.h"
+#include "dwio/nimble/tablet/TabletReader.h"
+#include "dwio/nimble/tablet/tests/TabletTestUtils.h"
+#include "dwio/nimble/velox/ChunkedStream.h"
 #include "dwio/nimble/velox/EncodingLayoutTree.h"
 #include "dwio/nimble/velox/FlushPolicy.h"
+#include "dwio/nimble/velox/SchemaSerialization.h"
 #include "dwio/nimble/velox/VeloxWriter.h"
 #include "velox/common/base/tests/GTestUtils.h"
+#include "velox/common/file/File.h"
 #include "velox/common/io/IoStatistics.h"
 #include "velox/common/testutil/RandomSeed.h"
 #include "velox/common/testutil/TestValue.h"
@@ -173,6 +182,57 @@ class StringColumnReaderTest : public ::testing::Test,
 // Returns the encoding of a vector, loading through lazy wrappers if present.
 VectorEncoding::Simple getEncoding(const VectorPtr& vector) {
   return BaseVector::loadedVectorShared(vector)->encoding();
+}
+
+// The on-disk encoding of one chunk of a scalar stream.
+struct ChunkEncoding {
+  // Top-level encoding of the chunk. Any Nullable/Sentinel wrapper is already
+  // stripped by EncodingLayoutCapture, so this is the data encoding directly.
+  EncodingType encodingType;
+  // Run-values sub-encoding, populated only for RLE chunks.
+  std::optional<EncodingType> runValuesType;
+};
+
+// Reads the on-disk encoding of every chunk of the scalar stream for the column
+// at 'columnIndex' from an in-memory Nimble file. Used to assert that crafted
+// data produced the intended per-chunk encodings (e.g. RLE<Dictionary> vs
+// Trivial), since natural encoding selection is data-driven, not guaranteed.
+std::vector<ChunkEncoding> getStreamChunkEncodings(
+    const std::string& file,
+    uint32_t columnIndex,
+    velox::memory::MemoryPool* pool) {
+  auto readFile = std::make_shared<velox::InMemoryReadFile>(file);
+  auto tablet =
+      TabletReader::create(readFile, pool, test::makeTestTabletOptions(pool));
+
+  auto section = tablet->loadOptionalSection(std::string(kSchemaSection));
+  NIMBLE_CHECK(section.has_value(), "Schema not found.");
+  auto schema = SchemaDeserializer::deserialize(section->content().data());
+  const auto& scalarNode = schema->asRow().childAt(columnIndex)->asScalar();
+  const std::vector<uint32_t> identifiers{
+      scalarNode.scalarDescriptor().offset()};
+
+  std::vector<ChunkEncoding> result;
+  for (uint32_t stripe = 0; stripe < tablet->stripeCount(); ++stripe) {
+    auto streams = tablet->load(tablet->stripeIdentifier(stripe), identifiers);
+    if (streams.empty() || streams[0] == nullptr) {
+      continue;
+    }
+    InMemoryChunkedStream chunkedStream{*pool, std::move(streams[0])};
+    while (chunkedStream.hasNext()) {
+      auto capture = EncodingLayoutCapture::capture(chunkedStream.nextChunk());
+      ChunkEncoding chunk{capture.encodingType(), std::nullopt};
+      if (capture.encodingType() == EncodingType::RLE) {
+        const auto& runValues =
+            capture.child(EncodingIdentifiers::RunLength::RunValues);
+        if (runValues.has_value()) {
+          chunk.runValuesType = runValues->encodingType();
+        }
+      }
+      result.push_back(chunk);
+    }
+  }
+  return result;
 }
 
 EncodingLayout makeFsstEncodingLayout() {
@@ -1347,25 +1407,27 @@ EncodingLayoutTree makeSecondChildRleDictionaryLayoutTree() {
           EncodingLayoutTree{Kind::Scalar, {{0, std::move(rleLayout)}}, "c1"}}};
 }
 
-// Reverse of the mid-read dict abandon: a between-batch skip (inside
-// prepareRead's seekTo) lands the decoder inside an RLE<Dictionary> chunk that
-// is loaded with preserveDictionaryEncoding=false, so that chunk is in FLAT
-// mode (dictValues_ null, dictionaryEnabled()==false). readWithDictionary now
-// runs its single dictionaryConvertible() check AFTER prepareRead, on the
-// landed chunk, so the flat second chunk is detected as non-convertible and
-// abandons to the flat read path instead of driving the dict-mode path
-// (ensureDictionaryState -> buildEncodingDictionaryAlphabet /
-// readDictionaryIndices -> materializeIndices) on a flat encoding. Before the
-// check was moved after prepareRead, this crashed with
-// "buildEncodingDictionaryAlphabet requires a dictionary-enabled encoding".
+// A between-batch skip (inside prepareRead's seekTo) advances the decoder into
+// a second RLE<Dictionary> chunk that is dictionary-convertible. Because the
+// value decoder carries the dictionary-preserve flag, the skip loads that chunk
+// in dictionary mode (dictValues_ set, dictionaryEnabled()==true), so
+// readWithDictionary's post-prepareRead dictionaryConvertible() check passes
+// and the chunk is read in dictionary mode across the skip.
+//
+// Before the skip paths honored the preserve flag, skipWithoutIndex/seekToChunk
+// hardcoded loadNextChunk(preserveDictionaryEncoding=false), so a benign
+// dict-convertible chunk was materialized in FLAT mode (dictValues_ null,
+// dictionaryEnabled()==false) and read flat (VectorEncoding FLAT) for the
+// remainder of the chunk — losing the dictionary/zero-copy path even though
+// nothing about the chunk required abandoning it.
 //
 // Mirrors skipAcrossChunkBoundaryDictRecovery scenario 1 (kChunkRows=400,
-// accept [0,349] u [600,799], batchSize=250), but forces the string column to
-// RLE<Dictionary> via a forced encoding layout so the preserve=false load
-// flattens it. A plain Dictionary chunk (as in that test) would stay
-// dict-convertible even when loaded preserve=false, which is why that scenario
-// does not surface this path.
-TEST_P(StringColumnReaderTest, skipAcrossChunkBoundaryRleDictionaryAbandon) {
+// accept [0,349] u [600,799], batchSize=250), but forces BOTH chunks of the
+// string column to RLE<Dictionary> via a forced encoding layout so the second
+// chunk is dict-capable and must stay in dictionary mode across the skip. (A
+// preserve-gated RLE<Dictionary> is the shape that flips modes with the load
+// flag; a plain Dictionary chunk is dict-convertible regardless.)
+TEST_P(StringColumnReaderTest, skipAcrossChunkBoundaryRleDictionaryPreserved) {
   const bool stringDecoderZeroCopy = GetParam();
   if (!stringDecoderZeroCopy) {
     GTEST_SKIP() << "Dictionary path requires stringDecoderZeroCopy";
@@ -1419,24 +1481,281 @@ TEST_P(StringColumnReaderTest, skipAcrossChunkBoundaryRleDictionaryAbandon) {
       std::make_unique<common::BigintMultiRange>(
           std::move(ranges), /*nullAllowed=*/false));
 
-  // Combined 800-row input for validateWithFilter.
-  auto input = makeRowVector({
-      makeFlatVector<int64_t>(2 * kChunkRows, [](auto i) { return i; }),
-      makeFlatVector<std::string>(
-          2 * kChunkRows,
-          [&](auto i) {
-            return i < kChunkRows
-                ? chunk1Values[(i / kRunLength) % 3]
-                : chunk2Values[((i - kChunkRows) / kRunLength) % 3];
-          }),
+  // Qualifying rows only, in output order: chunk-1 rows [0, 349] then chunk-2
+  // rows [600, 799] (chunk-local [200, 399]).
+  auto expectedStrings = makeFlatVector<std::string>(550, [&](auto i) {
+    if (i < 350) {
+      return chunk1Values[(i / kRunLength) % 3];
+    }
+    const int fileRow = 600 + (i - 350);
+    return chunk2Values[((fileRow - kChunkRows) / kRunLength) % 3];
   });
 
-  auto readers = makeReaders(input, file, scanSpec, stringDecoderZeroCopy);
-  validateWithFilter(
-      *input,
+  auto readers = makeReaders(chunk1, file, scanSpec, stringDecoderZeroCopy);
+  using E = VectorEncoding::Simple;
+  // Batches: [0,249] dict, [250,349] dict (chunk 1), [600,749] dict,
+  // [750,799] dict (chunk 2 — read in dictionary mode across the skip).
+  validateWithEncodingChecks(
+      *expectedStrings,
       *readers.rowReader,
       /*batchSize=*/250,
-      /*filter=*/[](int i) { return i <= 349 || i >= 600; });
+      /*totalRows=*/2 * kChunkRows,
+      {E::DICTIONARY, E::DICTIONARY, E::DICTIONARY, E::DICTIONARY},
+      readType,
+      pool(),
+      /*childIndex=*/1);
+}
+
+// Exercises dictionary preservation (the skip-time preserve flag) together with
+// the abandon path across a four-chunk string column whose on-disk chunk
+// encodings are RLE<Dictionary>, RLE<Dictionary>, Trivial, RLE<Dictionary>.
+//
+// A forced encoding layout cannot produce this mix: a layout is bound per
+// stream and applied to every chunk, and RLE<Dictionary> never falls back for
+// all-unique data (RLE/Dictionary accept any input), so a forced
+// RLE<Dictionary> would make the "Trivial" chunk dictionary-convertible too.
+// The mix is therefore produced by natural cost-based selection with crafted
+// per-chunk data -- many short runs of a few distinct strings pick RLE with a
+// Dictionary run-value sub-encoding, while all-unique data picks Trivial -- and
+// the on-disk encodings are asserted below (natural selection is data-driven,
+// not guaranteed).
+//
+// The Trivial chunk is not dictionary-convertible, so the dictionary path
+// abandons on it; the RLE<Dictionary> chunks are preserve-gated, so a skip that
+// lands in one must load it in dictionary mode rather than flatten it. Four
+// read patterns are exercised, each with a fresh reader:
+//   1) Full range in one batch: abandons at the third chunk -> whole batch
+//   FLAT. 2) First read stops mid the second chunk (dictionary); a later read
+//   skips
+//      across the Trivial third chunk into the fourth chunk, which stays
+//      DICTIONARY (preserved across the skip).
+//   3) Skip the first chunk entirely and read from the second chunk to the end:
+//      the second chunk is loaded by the skip in dictionary mode, then the read
+//      abandons at the Trivial third chunk -> FLAT. Differs from pattern 1 in
+//      that the first dictionary chunk is reached via a skip.
+//   4) Read through the Trivial third chunk (abandoning, which turns the
+//      preserve flag off), then skip into the fourth chunk, which is still
+//      DICTIONARY because readWithDictionary turns the flag back on before the
+//      skip.
+TEST_P(
+    StringColumnReaderTest,
+    abandonAndPreserveAcrossRleDictionaryAndTrivialChunks) {
+  const bool stringDecoderZeroCopy = GetParam();
+  if (!stringDecoderZeroCopy) {
+    GTEST_SKIP() << "Dictionary path requires stringDecoderZeroCopy";
+  }
+
+  constexpr int kChunkRows = 400;
+  constexpr int kRunLength = 10;
+  constexpr int kNumChunks = 4;
+  constexpr int kTotalRows = kChunkRows * kNumChunks;
+  const std::string kChunk0[3] = {"alpha", "bravo", "charlie"};
+  const std::string kChunk1[3] = {"delta", "echo", "foxtrot"};
+  const std::string kChunk3[3] = {"golf", "hotel", "india"};
+
+  // Value for global row g. Chunks 0/1/3 cycle three distinct strings in
+  // kRunLength-row runs (many runs, few distinct -> RLE<Dictionary>); chunk 2
+  // is all-unique (-> Trivial).
+  auto valueAt = [&](int g) -> std::string {
+    const int chunk = g / kChunkRows;
+    const int run = (g % kChunkRows / kRunLength) % 3;
+    switch (chunk) {
+      case 0:
+        return kChunk0[run];
+      case 1:
+        return kChunk1[run];
+      case 2:
+        return fmt::format("uniq_{}", g);
+      default:
+        return kChunk3[run];
+    }
+  };
+
+  RowVectorPtr schemaSample;
+  std::vector<VectorPtr> chunkVectors;
+  for (int chunk = 0; chunk < kNumChunks; ++chunk) {
+    const int base = chunk * kChunkRows;
+    auto rowVector = makeRowVector({
+        makeFlatVector<int64_t>(kChunkRows, [&](auto i) { return base + i; }),
+        makeFlatVector<std::string>(
+            kChunkRows, [&](auto i) { return valueAt(base + i); }),
+    });
+    if (chunk == 0) {
+      schemaSample = rowVector;
+    }
+    chunkVectors.push_back(rowVector);
+  }
+
+  VeloxWriterOptions writerOptions;
+  writerOptions.enableChunking = true;
+  writerOptions.minStreamChunkRawSize = 0;
+  writerOptions.flushPolicyFactory = [] {
+    return std::make_unique<LambdaFlushPolicy>(
+        /*flushLambda=*/[](const StripeProgress&) { return false; },
+        /*chunkLambda=*/[](const StripeProgress&) { return true; });
+  };
+  auto file = test::createNimbleFile(
+      *rootPool(), chunkVectors, writerOptions, /*flushAfterWrite=*/false);
+
+  // Assert the crafted data produced the intended on-disk encodings, since
+  // natural selection is data-driven: chunks 0/1/3 = RLE<Dictionary>, chunk 2 =
+  // Trivial. This guards the preserve-gating patterns below from silently
+  // degrading (e.g. a chunk coming out plain Dictionary, which is always
+  // convertible). c1 is column index 1.
+  const auto chunkEncodings =
+      getStreamChunkEncodings(file, /*columnIndex=*/1, pool());
+  ASSERT_EQ(chunkEncodings.size(), static_cast<size_t>(kNumChunks));
+  for (int c : {0, 1, 3}) {
+    EXPECT_EQ(chunkEncodings[c].encodingType, EncodingType::RLE)
+        << "chunk " << c;
+    ASSERT_TRUE(chunkEncodings[c].runValuesType.has_value()) << "chunk " << c;
+    EXPECT_EQ(*chunkEncodings[c].runValuesType, EncodingType::Dictionary)
+        << "chunk " << c;
+  }
+  EXPECT_EQ(chunkEncodings[2].encodingType, EncodingType::Trivial);
+
+  auto readType = ROW({"c0", "c1"}, {BIGINT(), VARCHAR()});
+  using E = VectorEncoding::Simple;
+
+  // Expected qualifying string values (in output order) for a row predicate.
+  auto expectedFor = [&](const std::function<bool(int)>& accept) {
+    std::vector<std::string> values;
+    for (int g = 0; g < kTotalRows; ++g) {
+      if (accept(g)) {
+        values.push_back(valueAt(g));
+      }
+    }
+    return makeFlatVector<std::string>(
+        values.size(), [&](auto i) { return values[i]; });
+  };
+
+  // Builds a ScanSpec whose c0 filter accepts the given inclusive row ranges,
+  // forcing the string column to skip over the rejected rows.
+  auto makeC0RangeFilter =
+      [&](std::vector<std::pair<int64_t, int64_t>> accepted) {
+        auto scanSpec = std::make_shared<common::ScanSpec>("root");
+        scanSpec->addAllChildFields(*readType);
+        std::vector<std::unique_ptr<common::BigintRange>> ranges;
+        for (const auto& [lo, hi] : accepted) {
+          ranges.push_back(
+              std::make_unique<common::BigintRange>(
+                  lo, hi, /*nullAllowed=*/false));
+        }
+        if (ranges.size() == 1) {
+          scanSpec->childByName("c0")->setFilter(std::move(ranges[0]));
+        } else {
+          scanSpec->childByName("c0")->setFilter(
+              std::make_unique<common::BigintMultiRange>(
+                  std::move(ranges), /*nullAllowed=*/false));
+        }
+        return scanSpec;
+      };
+
+  // Control: contiguous per-chunk read. The Trivial chunk abandons to FLAT; the
+  // RLE<Dictionary> chunks read as DICTIONARY (no skip involved).
+  {
+    auto scanSpec = std::make_shared<common::ScanSpec>("root");
+    scanSpec->addAllChildFields(*readType);
+    auto readers =
+        makeReaders(schemaSample, file, scanSpec, stringDecoderZeroCopy);
+    validateWithEncodingChecks(
+        *expectedFor([](int) { return true; }),
+        *readers.rowReader,
+        /*batchSize=*/kChunkRows,
+        /*totalRows=*/kTotalRows,
+        {E::DICTIONARY, E::DICTIONARY, E::FLAT, E::DICTIONARY},
+        readType,
+        pool(),
+        /*childIndex=*/1);
+  }
+
+  // Pattern 1: full range in a single batch -> abandons mid-read at the Trivial
+  // chunk -> the whole batch is FLAT.
+  {
+    auto scanSpec = std::make_shared<common::ScanSpec>("root");
+    scanSpec->addAllChildFields(*readType);
+    auto readers =
+        makeReaders(schemaSample, file, scanSpec, stringDecoderZeroCopy);
+    validateWithEncodingChecks(
+        *expectedFor([](int) { return true; }),
+        *readers.rowReader,
+        /*batchSize=*/kTotalRows,
+        /*totalRows=*/kTotalRows,
+        {E::FLAT},
+        readType,
+        pool(),
+        /*childIndex=*/1);
+  }
+
+  // Pattern 2: first read stops mid the second chunk (rows [0,599],
+  // dictionary), then a skip crosses the Trivial third chunk and lands in the
+  // fourth chunk (rows [1200,1599]), which is read in DICTIONARY mode
+  // (preserved across the skip).
+  {
+    auto accept = [](int g) { return g <= 599 || g >= 1200; };
+    auto scanSpec = makeC0RangeFilter({{0, 599}, {1200, kTotalRows - 1}});
+    auto readers =
+        makeReaders(schemaSample, file, scanSpec, stringDecoderZeroCopy);
+    validateWithEncodingChecks(
+        *expectedFor(accept),
+        *readers.rowReader,
+        /*batchSize=*/600,
+        /*totalRows=*/kTotalRows,
+        {E::DICTIONARY, E::DICTIONARY},
+        readType,
+        pool(),
+        /*childIndex=*/1);
+  }
+
+  // Pattern 3: skip the first chunk entirely and read the second chunk to the
+  // end in one batch. The second chunk is loaded by the skip (dictionary mode),
+  // then the read abandons at the Trivial third chunk -> whole batch FLAT.
+  {
+    auto accept = [](int g) { return g >= 400; };
+    auto scanSpec = makeC0RangeFilter({{400, kTotalRows - 1}});
+    auto readers =
+        makeReaders(schemaSample, file, scanSpec, stringDecoderZeroCopy);
+    validateWithEncodingChecks(
+        *expectedFor(accept),
+        *readers.rowReader,
+        /*batchSize=*/kTotalRows,
+        /*totalRows=*/kTotalRows,
+        {E::FLAT},
+        readType,
+        pool(),
+        /*childIndex=*/1);
+  }
+
+  // Pattern 4: first read runs through the Trivial third chunk (rows [0,899])
+  // and abandons there (FLAT), turning the preserve flag off; the next read
+  // skips into the fourth chunk (rows [1200,1599]), which must still be read as
+  // DICTIONARY because readWithDictionary turns the flag back on before the
+  // skip.
+  //
+  // TODO(T280373333): the fourth chunk should be DICTIONARY, but currently
+  // reads FLAT. read1 ends mid the Trivial third chunk (row 900), so this
+  // batch's leading rejected rows [900,1199] make the framework call
+  // read(offset=900, rows=[300..699]): offset lands in the Trivial chunk while
+  // the first row actually read is in the fourth chunk. The convertibility gate
+  // inspects the chunk at offset (Trivial) instead of at offset + rows[0] (the
+  // fourth chunk), so it spuriously abandons. This is a pre-existing gap,
+  // independent of the preserve flag. Expect FLAT here until that gap is fixed,
+  // then flip the second batch to DICTIONARY.
+  {
+    auto accept = [](int g) { return g <= 899 || g >= 1200; };
+    auto scanSpec = makeC0RangeFilter({{0, 899}, {1200, kTotalRows - 1}});
+    auto readers =
+        makeReaders(schemaSample, file, scanSpec, stringDecoderZeroCopy);
+    validateWithEncodingChecks(
+        *expectedFor(accept),
+        *readers.rowReader,
+        /*batchSize=*/900,
+        /*totalRows=*/kTotalRows,
+        {E::FLAT, E::FLAT},
+        readType,
+        pool(),
+        /*childIndex=*/1);
+  }
 }
 
 // Flatmap string column read via dictionary path.

--- a/dwio/nimble/velox/selective/tests/StringColumnReaderTest.cpp
+++ b/dwio/nimble/velox/selective/tests/StringColumnReaderTest.cpp
@@ -1012,6 +1012,433 @@ TEST_P(StringColumnReaderTest, skipAcrossChunkBoundaryDictRecovery) {
   }
 }
 
+// Regression for T278234148: a between-batch skip in prepareRead crosses a
+// chunk boundary and lands on a chunk whose encoding is NOT dictionary-enabled.
+//
+// readWithDictionary checks dictionaryConvertible() on the chunk that is
+// current at entry (chunk1, Dictionary → passes), but then prepareRead<int32_t>
+// runs seekTo → skip, which loads the landed chunk with
+// preserveDictionaryEncoding=false. When that chunk is a non-dict encoding
+// (here Trivial, forced by high-cardinality unique strings), the stale guard no
+// longer matches the current encoding, and ensureDictionaryState() calls
+// buildEncodingDictionaryAlphabet() on it → NIMBLE_CHECK(dictionaryEnabled())
+// fires. This mirrors the production crash on
+// ad_delivery.ads_ai_eval_judge_results.original_request_id (all-varchar table,
+// per-chunk encoding varies between Dictionary and Trivial). The fix re-checks
+// dictionaryConvertible() after prepareRead and falls back to the flat path
+// (FLAT output encoding).
+TEST_P(StringColumnReaderTest, abandonDictionaryAfterSkip) {
+  const bool stringDecoderZeroCopy = GetParam();
+  if (!stringDecoderZeroCopy) {
+    GTEST_SKIP() << "Dictionary path requires stringDecoderZeroCopy";
+  }
+
+  constexpr int kChunkRows = 400;
+  // Chunk 1: low-cardinality strings → Dictionary (dictionary-enabled).
+  auto chunk1 = makeRowVector({
+      makeFlatVector<int64_t>(kChunkRows, [](auto i) { return i; }),
+      makeFlatVector<std::string>(
+          kChunkRows,
+          [](auto i) {
+            return std::vector<std::string>{"aaa", "bbb", "ccc"}[i % 3];
+          }),
+  });
+  // Chunk 2: all-unique strings → Trivial (NOT dictionary-enabled).
+  auto chunk2 = makeRowVector({
+      makeFlatVector<int64_t>(
+          kChunkRows, [](auto i) { return kChunkRows + i; }),
+      makeFlatVector<std::string>(
+          kChunkRows,
+          [](auto i) { return fmt::format("unique_string_value_{}", i); }),
+  });
+
+  VeloxWriterOptions writerOptions;
+  writerOptions.enableChunking = true;
+  writerOptions.minStreamChunkRawSize = 0;
+  writerOptions.flushPolicyFactory = [] {
+    return std::make_unique<LambdaFlushPolicy>(
+        /*flushLambda=*/[](const StripeProgress&) { return false; },
+        /*chunkLambda=*/[](const StripeProgress&) { return true; });
+  };
+  auto file = test::createNimbleFile(
+      *rootPool(), {chunk1, chunk2}, writerOptions, /*flushAfterWrite=*/false);
+
+  // Filter on c0: accept [0,349] then [600,799]. Rejecting [350,599] forces a
+  // between-batch skip (350 → 600) that crosses the chunk boundary at 400 and
+  // lands inside chunk 2 (Trivial), while the decoder is still parked mid
+  // chunk 1 at entry (so the dictionaryConvertible() guard sees chunk 1).
+  auto readType = ROW({"c0", "c1"}, {BIGINT(), VARCHAR()});
+  auto scanSpec = std::make_shared<common::ScanSpec>("root");
+  scanSpec->addAllChildFields(*readType);
+  std::vector<std::unique_ptr<common::BigintRange>> ranges;
+  ranges.push_back(
+      std::make_unique<common::BigintRange>(0, 349, /*nullAllowed=*/false));
+  ranges.push_back(
+      std::make_unique<common::BigintRange>(
+          600, 2 * kChunkRows - 1, /*nullAllowed=*/false));
+  scanSpec->childByName("c0")->setFilter(
+      std::make_unique<common::BigintMultiRange>(
+          std::move(ranges), /*nullAllowed=*/false));
+
+  // Accepted output: chunk 1 rows 0-349 (350), then chunk 2 rows 600-799 which
+  // are chunk-local indices 200-399 (200) → 550 rows total.
+  auto expectedStrings = makeFlatVector<std::string>(550, [](auto i) {
+    if (i < 350) {
+      return std::vector<std::string>{"aaa", "bbb", "ccc"}[i % 3];
+    }
+    const int chunk2Index = (i - 350) + 200;
+    return fmt::format("unique_string_value_{}", chunk2Index);
+  });
+
+  auto readers = makeReaders(chunk1, file, scanSpec, stringDecoderZeroCopy);
+
+  using E = VectorEncoding::Simple;
+  // Batches: [0,249] dict, [250,349] dict (chunk 1), [600,749] flat,
+  // [750,799] flat (chunk 2 via the abandon-to-flat fallback).
+  validateWithEncodingChecks(
+      *expectedStrings,
+      *readers.rowReader,
+      /*batchSize=*/250,
+      /*totalRows=*/2 * kChunkRows,
+      {E::DICTIONARY, E::DICTIONARY, E::FLAT, E::FLAT},
+      readType,
+      pool(),
+      /*childIndex=*/1);
+}
+
+// Same as abandonDictionaryAfterSkip but with a NULLABLE string column. The
+// between-batch skip that lands in the non-dict chunk drives the abandon path
+// (readWithDictionary runs prepareRead<int32_t>, the landed chunk is not
+// convertible, so it abandons and read() re-runs
+// prepareRead<std::string_view>). Because NimbleData::readNulls advances the
+// nulls decoder (nextBools), that double prepareRead reads the null stream
+// twice and misplaces the nulls.
+TEST_P(StringColumnReaderTest, abandonDictionaryAfterSkipWithNulls) {
+  const bool stringDecoderZeroCopy = GetParam();
+  if (!stringDecoderZeroCopy) {
+    GTEST_SKIP() << "Dictionary path requires stringDecoderZeroCopy";
+  }
+
+  constexpr int kChunkRows = 400;
+  auto chunk1String = [](auto i) -> std::optional<std::string> {
+    if (i % 7 == 0) {
+      return std::nullopt;
+    }
+    return std::vector<std::string>{"aaa", "bbb", "ccc"}[i % 3];
+  };
+  auto chunk2String = [](auto i) -> std::optional<std::string> {
+    if (i % 7 == 0) {
+      return std::nullopt;
+    }
+    return fmt::format("unique_string_value_{}", i);
+  };
+
+  std::vector<std::optional<std::string>> chunk1Data(kChunkRows);
+  std::vector<std::optional<std::string>> chunk2Data(kChunkRows);
+  for (int i = 0; i < kChunkRows; ++i) {
+    chunk1Data[i] = chunk1String(i);
+    chunk2Data[i] = chunk2String(i);
+  }
+  // Chunk 1: low-cardinality → nullable Dictionary. Chunk 2: unique → Trivial.
+  auto chunk1 = makeRowVector({
+      makeFlatVector<int64_t>(kChunkRows, [](auto i) { return i; }),
+      makeNullableFlatVector<std::string>(chunk1Data),
+  });
+  auto chunk2 = makeRowVector({
+      makeFlatVector<int64_t>(
+          kChunkRows, [](auto i) { return kChunkRows + i; }),
+      makeNullableFlatVector<std::string>(chunk2Data),
+  });
+
+  VeloxWriterOptions writerOptions;
+  writerOptions.enableChunking = true;
+  writerOptions.minStreamChunkRawSize = 0;
+  writerOptions.flushPolicyFactory = [] {
+    return std::make_unique<LambdaFlushPolicy>(
+        /*flushLambda=*/[](const StripeProgress&) { return false; },
+        /*chunkLambda=*/[](const StripeProgress&) { return true; });
+  };
+  auto file = test::createNimbleFile(
+      *rootPool(), {chunk1, chunk2}, writerOptions, /*flushAfterWrite=*/false);
+
+  auto readType = ROW({"c0", "c1"}, {BIGINT(), VARCHAR()});
+  auto scanSpec = std::make_shared<common::ScanSpec>("root");
+  scanSpec->addAllChildFields(*readType);
+  std::vector<std::unique_ptr<common::BigintRange>> ranges;
+  ranges.push_back(
+      std::make_unique<common::BigintRange>(0, 349, /*nullAllowed=*/false));
+  ranges.push_back(
+      std::make_unique<common::BigintRange>(
+          600, 2 * kChunkRows - 1, /*nullAllowed=*/false));
+  scanSpec->childByName("c0")->setFilter(
+      std::make_unique<common::BigintMultiRange>(
+          std::move(ranges), /*nullAllowed=*/false));
+
+  // Accepted output: chunk-1 rows 0-349, then chunk-2 rows 600-799 (chunk-local
+  // indices 200-399) → 550 rows total, carrying their nulls.
+  std::vector<std::optional<std::string>> expectedData(550);
+  for (int i = 0; i < 550; ++i) {
+    expectedData[i] = i < 350 ? chunk1String(i) : chunk2String((i - 350) + 200);
+  }
+  auto expectedStrings = makeNullableFlatVector<std::string>(expectedData);
+
+  auto readers = makeReaders(chunk1, file, scanSpec, stringDecoderZeroCopy);
+  using E = VectorEncoding::Simple;
+  validateWithEncodingChecks(
+      *expectedStrings,
+      *readers.rowReader,
+      /*batchSize=*/250,
+      /*totalRows=*/2 * kChunkRows,
+      {E::DICTIONARY, E::DICTIONARY, E::FLAT, E::FLAT},
+      readType,
+      pool(),
+      /*childIndex=*/1);
+}
+
+// Non-convertible ENTRY chunk with NO cross-chunk skip: a single Trivial
+// (all-unique) nullable string column read contiguously. readWithDictionary
+// abandons at entry. Isolates whether the no-skip abandon (prepareRead then
+// abandon, no between-batch skip) corrupts nulls.
+TEST_P(StringColumnReaderTest, abandonDictionaryNoSkipWithNulls) {
+  const bool stringDecoderZeroCopy = GetParam();
+  if (!stringDecoderZeroCopy) {
+    GTEST_SKIP() << "Dictionary path requires stringDecoderZeroCopy";
+  }
+
+  constexpr int kRows = 400;
+  std::vector<std::optional<std::string>> data(kRows);
+  for (int i = 0; i < kRows; ++i) {
+    data[i] = (i % 7 == 0)
+        ? std::nullopt
+        : std::optional<std::string>(fmt::format("unique_value_{}", i));
+  }
+  auto chunk = makeRowVector({
+      makeFlatVector<int64_t>(kRows, [](auto i) { return i; }),
+      makeNullableFlatVector<std::string>(data),
+  });
+
+  VeloxWriterOptions writerOptions;
+  writerOptions.enableChunking = true;
+  writerOptions.minStreamChunkRawSize = 0;
+  auto file = test::createNimbleFile(*rootPool(), chunk, writerOptions);
+
+  auto readType = ROW({"c0", "c1"}, {BIGINT(), VARCHAR()});
+  auto scanSpec = std::make_shared<common::ScanSpec>("root");
+  scanSpec->addAllChildFields(*readType);
+
+  auto expected = makeNullableFlatVector<std::string>(data);
+  auto readers = makeReaders(chunk, file, scanSpec, stringDecoderZeroCopy);
+  using E = VectorEncoding::Simple;
+  validateWithEncodingChecks(
+      *expected,
+      *readers.rowReader,
+      /*batchSize=*/kRows,
+      /*totalRows=*/kRows,
+      {E::FLAT},
+      readType,
+      pool(),
+      /*childIndex=*/1);
+}
+
+// Latent check #2 bug for a FLATMAP feature: the feature's value stream is
+// Dictionary in chunk 1 and Trivial in chunk 2, and a sibling-column filter
+// forces a between-batch skip that crosses the chunk boundary, driving the
+// feature's child StringColumnReader to abandon the dictionary after
+// prepareRead. read() then re-runs prepareRead (numReadRows == 0), so
+// NimbleData::readNulls advances the feature's in-map decoder twice and the
+// output map gets phantom/missing entries. Plain-null columns survive this, so
+// only the flatmap in-map path exposes it.
+TEST_P(StringColumnReaderTest, abandonDictionaryAfterSkipFlatMap) {
+  const bool stringDecoderZeroCopy = GetParam();
+  if (!stringDecoderZeroCopy) {
+    GTEST_SKIP() << "Dictionary path requires stringDecoderZeroCopy";
+  }
+
+  constexpr int kChunkRows = 400;
+  // Feature key 1 is present on ~2/3 of rows (absent when g % 3 == 0), so the
+  // in-map bitmap is non-trivial. Its values are low-cardinality in chunk 1
+  // (→ Dictionary) and unique in chunk 2 (→ Trivial), all inline (< 12 bytes)
+  // so makeMapVector copies them and no source lifetime is needed.
+  auto present = [](int g) { return g % 3 != 0; };
+  auto valueStr = [](int g) {
+    return g < kChunkRows ? fmt::format("v{}", g % 5) : fmt::format("u{}", g);
+  };
+  std::vector<std::string> keep;
+  keep.reserve(4 * kChunkRows);
+  auto makeChunk = [&](int base, int n) {
+    std::vector<std::vector<std::pair<int32_t, std::optional<StringView>>>>
+        maps(n);
+    for (int r = 0; r < n; ++r) {
+      const int g = base + r;
+      if (present(g)) {
+        keep.push_back(valueStr(g));
+        maps[r] = {{1, StringView(keep.back())}};
+      }
+    }
+    return makeRowVector(
+        {"c0", "c1"},
+        {makeFlatVector<int64_t>(n, [base](auto r) { return base + r; }),
+         makeMapVector<int32_t, StringView>(maps)});
+  };
+  auto chunk1 = makeChunk(0, kChunkRows);
+  auto chunk2 = makeChunk(kChunkRows, kChunkRows);
+  auto combined = makeChunk(0, 2 * kChunkRows);
+
+  VeloxWriterOptions writerOptions;
+  writerOptions.enableChunking = true;
+  writerOptions.minStreamChunkRawSize = 0;
+  writerOptions.flatMapColumns = {{"c1", {}}};
+  writerOptions.flushPolicyFactory = [] {
+    return std::make_unique<LambdaFlushPolicy>(
+        /*flushLambda=*/[](const StripeProgress&) { return false; },
+        /*chunkLambda=*/[](const StripeProgress&) { return true; });
+  };
+  auto file = test::createNimbleFile(
+      *rootPool(), {chunk1, chunk2}, writerOptions, /*flushAfterWrite=*/false);
+
+  // Filter on sibling c0: accept [0,349] then [600,799]. Rejecting [350,599]
+  // forces a between-batch skip (350 → 600) crossing the chunk boundary at 400.
+  auto scanSpec = std::make_shared<common::ScanSpec>("root");
+  scanSpec->addAllChildFields(*combined->type());
+  std::vector<std::unique_ptr<common::BigintRange>> ranges;
+  ranges.push_back(
+      std::make_unique<common::BigintRange>(0, 349, /*nullAllowed=*/false));
+  ranges.push_back(
+      std::make_unique<common::BigintRange>(
+          600, 2 * kChunkRows - 1, /*nullAllowed=*/false));
+  scanSpec->childByName("c0")->setFilter(
+      std::make_unique<common::BigintMultiRange>(
+          std::move(ranges), /*nullAllowed=*/false));
+
+  auto readers = makeReaders(combined, file, scanSpec, stringDecoderZeroCopy);
+  validateWithFilter(
+      *combined, *readers.rowReader, /*batchSize=*/250, [](int i) {
+        return i <= 349 || i >= 600;
+      });
+}
+
+// Forces the string column "c1" (child index 1) to encode as RLE wrapping
+// Dictionary, while the bigint sibling "c0" (child index 0) keeps its default
+// encoding. Row-schema children are matched to the layout tree by position, so
+// both children must be present in schema order.
+EncodingLayoutTree makeSecondChildRleDictionaryLayoutTree() {
+  EncodingLayout dictLayout{
+      EncodingType::Dictionary,
+      {},
+      CompressionType::Uncompressed,
+      {std::nullopt, std::nullopt}};
+  EncodingLayout rleLayout{
+      EncodingType::RLE,
+      {},
+      CompressionType::Uncompressed,
+      {std::nullopt, std::move(dictLayout)}};
+  return EncodingLayoutTree{
+      Kind::Row,
+      std::
+          unordered_map<EncodingLayoutTree::StreamIdentifier, EncodingLayout>{},
+      "",
+      std::vector<EncodingLayoutTree>{
+          EncodingLayoutTree{
+              Kind::Scalar,
+              std::unordered_map<
+                  EncodingLayoutTree::StreamIdentifier,
+                  EncodingLayout>{},
+              "c0"},
+          EncodingLayoutTree{Kind::Scalar, {{0, std::move(rleLayout)}}, "c1"}}};
+}
+
+// Reverse of the mid-read dict abandon: a between-batch skip (inside
+// prepareRead's seekTo) lands the decoder inside an RLE<Dictionary> chunk that
+// is loaded with preserveDictionaryEncoding=false, so that chunk is in FLAT
+// mode (dictValues_ null, dictionaryEnabled()==false). readWithDictionary now
+// runs its single dictionaryConvertible() check AFTER prepareRead, on the
+// landed chunk, so the flat second chunk is detected as non-convertible and
+// abandons to the flat read path instead of driving the dict-mode path
+// (ensureDictionaryState -> buildEncodingDictionaryAlphabet /
+// readDictionaryIndices -> materializeIndices) on a flat encoding. Before the
+// check was moved after prepareRead, this crashed with
+// "buildEncodingDictionaryAlphabet requires a dictionary-enabled encoding".
+//
+// Mirrors skipAcrossChunkBoundaryDictRecovery scenario 1 (kChunkRows=400,
+// accept [0,349] u [600,799], batchSize=250), but forces the string column to
+// RLE<Dictionary> via a forced encoding layout so the preserve=false load
+// flattens it. A plain Dictionary chunk (as in that test) would stay
+// dict-convertible even when loaded preserve=false, which is why that scenario
+// does not surface this path.
+TEST_P(StringColumnReaderTest, skipAcrossChunkBoundaryRleDictionaryAbandon) {
+  const bool stringDecoderZeroCopy = GetParam();
+  if (!stringDecoderZeroCopy) {
+    GTEST_SKIP() << "Dictionary path requires stringDecoderZeroCopy";
+  }
+
+  constexpr int kChunkRows = 400;
+  constexpr int kRunLength = 100;
+  const std::string chunk1Values[] = {"alpha", "bravo", "charlie"};
+  const std::string chunk2Values[] = {"delta", "echo", "foxtrot"};
+  // Long runs (100 rows each) so the forced RLE<Dictionary> layout produces
+  // real RLE runs of dictionary indices.
+  auto chunk1 = makeRowVector({
+      makeFlatVector<int64_t>(kChunkRows, [](auto i) { return i; }),
+      makeFlatVector<std::string>(
+          kChunkRows,
+          [&](auto i) { return chunk1Values[(i / kRunLength) % 3]; }),
+  });
+  auto chunk2 = makeRowVector({
+      makeFlatVector<int64_t>(
+          kChunkRows, [](auto i) { return kChunkRows + i; }),
+      makeFlatVector<std::string>(
+          kChunkRows,
+          [&](auto i) { return chunk2Values[(i / kRunLength) % 3]; }),
+  });
+
+  VeloxWriterOptions writerOptions;
+  writerOptions.encodingLayoutTree.emplace(
+      makeSecondChildRleDictionaryLayoutTree());
+  writerOptions.enableChunking = true;
+  writerOptions.minStreamChunkRawSize = 0;
+  writerOptions.flushPolicyFactory = [] {
+    return std::make_unique<LambdaFlushPolicy>(
+        /*flushLambda=*/[](const StripeProgress&) { return false; },
+        /*chunkLambda=*/[](const StripeProgress&) { return true; });
+  };
+  auto file = test::createNimbleFile(
+      *rootPool(), {chunk1, chunk2}, writerOptions, /*flushAfterWrite=*/false);
+
+  // Filter on c0: accept [0, 349] u [600, 799]. c1 has no filter, so it takes
+  // the dictionary index path.
+  auto readType = ROW({"c0", "c1"}, {BIGINT(), VARCHAR()});
+  auto scanSpec = std::make_shared<common::ScanSpec>("root");
+  scanSpec->addAllChildFields(*readType);
+  std::vector<std::unique_ptr<common::BigintRange>> ranges;
+  ranges.push_back(
+      std::make_unique<common::BigintRange>(0, 349, /*nullAllowed=*/false));
+  ranges.push_back(
+      std::make_unique<common::BigintRange>(
+          600, 2 * kChunkRows - 1, /*nullAllowed=*/false));
+  scanSpec->childByName("c0")->setFilter(
+      std::make_unique<common::BigintMultiRange>(
+          std::move(ranges), /*nullAllowed=*/false));
+
+  // Combined 800-row input for validateWithFilter.
+  auto input = makeRowVector({
+      makeFlatVector<int64_t>(2 * kChunkRows, [](auto i) { return i; }),
+      makeFlatVector<std::string>(
+          2 * kChunkRows,
+          [&](auto i) {
+            return i < kChunkRows
+                ? chunk1Values[(i / kRunLength) % 3]
+                : chunk2Values[((i - kChunkRows) / kRunLength) % 3];
+          }),
+  });
+
+  auto readers = makeReaders(input, file, scanSpec, stringDecoderZeroCopy);
+  validateWithFilter(
+      *input,
+      *readers.rowReader,
+      /*batchSize=*/250,
+      /*filter=*/[](int i) { return i <= 349 || i >= 600; });
+}
+
 // Flatmap string column read via dictionary path.
 // When a string column is inside a flatmap, rows where the key is absent have
 // inMap=0 (null). The encoding only has data for in-map rows. The dictionary


### PR DESCRIPTION
Summary:
When the selective string reader takes the dictionary path, it reads each chunk in dictionary-index mode as long as the chunk's encoding is dictionary-convertible. Preserve-gated encodings — an `RLE` wrapping a `Dictionary` — only report `dictionaryEnabled() == true` when they are loaded with `preserveDictionaryEncoding=true`; loaded the default way they materialize in flat mode.

Every chunk loader on the dictionary read path already passes `preserveDictionaryEncoding=true` (`ensureLoaded` at the top of `readWithDictionary`, and the multi-chunk `readDictionaryIndices` loop) — except the skip paths. `ChunkedDecoder::skipWithoutIndex` and `ChunkedDecoder::seekToChunk` hardcoded `loadNextChunk(/*preserveDictionaryEncoding=*/false)`. `prepareRead`'s `seekTo -> skip` runs through those paths, so a between-batch skip that lands in a preserve-gated `RLE<Dictionary>` chunk materializes it flat. Because `ensureLoaded` early-returns once a chunk is loaded with remaining values, that flattened chunk is never re-loaded in dictionary mode — so a perfectly dictionary-convertible chunk is read flat (losing the dictionary/zero-copy path) for the remainder of the chunk, purely because an earlier batch's skip happened to land in it. It recovers only at the next chunk boundary.

This is not a correctness bug (the values are right either way, and D111832535 already made the resulting abandon-to-flat safe). It is a performance regression: an unlucky skip can flatten a benign, low-cardinality string chunk.

Fix: make dictionary preservation a property of the decoder rather than a per-call argument on the generic skip. `ChunkedDecoder` gains a `preserveDictionaryEncoding_` member (default false) and a `setPreserveDictionaryEncoding` setter; the two skip paths load the chunk they advance into with that member instead of a hardcoded false. `StringColumnReader` drives the flag by read-mode transition: it sets it to true when it enters the dictionary read path (`readWithDictionary`, before `prepareRead`'s skip runs) and back to false in `abandonDictionaryEncoding` when the dictionary path is given up. So a skip taken while reading in dictionary mode loads the chunk it advances into in dictionary mode, keeping a dict-convertible chunk convertible; a reader that never enters (or has left) the dictionary path skips in flat mode. All other scalar readers leave the flag at its default, so their skips are unchanged, and the generic `skip()` signature stays untouched (no per-call preserve argument threaded through the shared skip API).

Stacked on D111832535: that diff moved the convertibility check after the skip so the chunk the read advances into is inspected (and, when genuinely non-dictionary, safely abandoned without a double `prepareRead`); this diff makes the common case — a chunk that IS dictionary-convertible — stay in dictionary mode instead of being needlessly flattened.

This diff also moves `readWithDictionary`'s `ensureLoaded` to after `prepareRead`. A between-batch skip can land exactly on a chunk boundary (`remainingValues_ == 0`) with the previous, exhausted chunk still current; loading the landing chunk after the skip (rather than only before `prepareRead`) makes the convertibility check inspect the chunk that will actually be read. This is safe precisely because dictionary preservation is now decoder state: the post-skip load and the skip's own chunk loads use the same preserve mode, so a skip landing on a preserve-gated chunk boundary reads it in dictionary mode instead of flattening it.

Test: adds `abandonAndPreserveAcrossRleDictionaryAndTrivialChunks`, a four-chunk string column (`RLE<Dictionary>`, `RLE<Dictionary>`, `Trivial`, `RLE<Dictionary>`) produced by natural encoding selection and asserted on-disk (via a new `getStreamChunkEncodings` helper, since natural selection is data-driven). It exercises full-range abandon, stop-mid-chunk-then-skip preservation, skip-first-chunk-then-abandon, and abandon-then-skip preservation. One pre-existing, perf-only gap it surfaces — the convertibility gate inspects the chunk at `offset` rather than at the first required row (`offset + rows[0]`) when a batch's leading rows are filtered — is documented in the test and tracked in T280373333 (to be fixed in a follow-up).

Reviewed By: xiaoxmeng

Differential Revision: D112533979


