### PR TITLE
feat(selective): Compact dictionary across chunks with deduplication

### DIFF
--- a/dwio/nimble/velox/selective/NimbleData.cpp
+++ b/dwio/nimble/velox/selective/NimbleData.cpp
@@ -31,6 +31,7 @@ NimbleData::NimbleData(
     const EncodingFactory& encodingFactory,
     bool stringDecoderZeroCopy,
     bool nimblePreserveDictionaryEncoding,
+    bool nimbleCompactDictionaryAcrossChunks,
     bool lazyColumnIo,
     velox::dwio::common::DecodingStats* decodingStats)
     : nimbleType_(nimbleType),
@@ -90,6 +91,7 @@ NimbleData::NimbleData(
   }
   stringDecoderZeroCopy_ = stringDecoderZeroCopy;
   nimblePreserveDictionaryEncoding_ = nimblePreserveDictionaryEncoding;
+  nimbleCompactDictionaryAcrossChunks_ = nimbleCompactDictionaryAcrossChunks;
 }
 
 void NimbleData::readNulls(
@@ -251,6 +253,7 @@ std::unique_ptr<velox::dwio::common::FormatData> NimbleParams::toFormatData(
       *encodingFactory_,
       stringDecoderZeroCopy_,
       nimblePreserveDictionaryEncoding_,
+      nimbleCompactDictionaryAcrossChunks_,
       lazyColumnIo_,
       decodingStats);
 }

--- a/dwio/nimble/velox/selective/NimbleData.h
+++ b/dwio/nimble/velox/selective/NimbleData.h
@@ -38,6 +38,7 @@ class NimbleData : public velox::dwio::common::FormatData {
       const EncodingFactory& encodingFactory,
       bool stringDecoderZeroCopy,
       bool nimblePreserveDictionaryEncoding = false,
+      bool nimbleCompactDictionaryAcrossChunks = false,
       bool lazyColumnIo = false,
       velox::dwio::common::DecodingStats* decodingStats = nullptr);
 
@@ -106,6 +107,10 @@ class NimbleData : public velox::dwio::common::FormatData {
     return nimblePreserveDictionaryEncoding_;
   }
 
+  bool nimbleCompactDictionaryAcrossChunks() const {
+    return nimbleCompactDictionaryAcrossChunks_;
+  }
+
  private:
   std::unique_ptr<ChunkedDecoder> makeDecoder(
       const StreamDescriptor& descriptor,
@@ -119,6 +124,7 @@ class NimbleData : public velox::dwio::common::FormatData {
   velox::BufferPtr inMap_;
   const EncodingFactory* const encodingFactory_;
   bool nimblePreserveDictionaryEncoding_{false};
+  bool nimbleCompactDictionaryAcrossChunks_{false};
   bool lazyColumnIo_{false};
   // Per-column decoding statistics. May be nullptr if column stats collection
   // is disabled.
@@ -137,6 +143,7 @@ class NimbleParams : public velox::dwio::common::FormatParams {
       bool stringDecoderZeroCopy = false,
       bool preserveFlatMapsInMemory = false,
       bool nimblePreserveDictionaryEncoding = false,
+      bool nimbleCompactDictionaryAcrossChunks = false,
       const folly::F14FastSet<std::string>* lazyIoColumns = nullptr,
       bool lazyColumnIo = false)
       : FormatParams(pool, stats),
@@ -148,7 +155,9 @@ class NimbleParams : public velox::dwio::common::FormatParams {
         encodingFactory_(&encodingFactory),
         lazyColumnIo_(lazyColumnIo),
         stringDecoderZeroCopy_{stringDecoderZeroCopy},
-        nimblePreserveDictionaryEncoding_{nimblePreserveDictionaryEncoding} {}
+        nimblePreserveDictionaryEncoding_{nimblePreserveDictionaryEncoding},
+        nimbleCompactDictionaryAcrossChunks_{
+            nimbleCompactDictionaryAcrossChunks} {}
 
   std::unique_ptr<velox::dwio::common::FormatData> toFormatData(
       const std::shared_ptr<const velox::dwio::common::TypeWithId>& /*type*/,
@@ -165,6 +174,7 @@ class NimbleParams : public velox::dwio::common::FormatParams {
         stringDecoderZeroCopy_,
         preserveFlatMapsInMemory_,
         nimblePreserveDictionaryEncoding_,
+        nimbleCompactDictionaryAcrossChunks_,
         /*lazyIoColumns=*/nullptr,
         lazyColumnIo_);
   }
@@ -234,6 +244,7 @@ class NimbleParams : public velox::dwio::common::FormatParams {
   ChunkedDecoder* inMapDecoder_{nullptr};
   bool stringDecoderZeroCopy_{false};
   bool nimblePreserveDictionaryEncoding_{false};
+  bool nimbleCompactDictionaryAcrossChunks_{false};
 };
 
 } // namespace facebook::nimble

--- a/dwio/nimble/velox/selective/SelectiveNimbleReader.cpp
+++ b/dwio/nimble/velox/selective/SelectiveNimbleReader.cpp
@@ -462,6 +462,7 @@ void SelectiveNimbleRowReader::loadCurrentStripe() {
       options_.stringDecoderZeroCopy(),
       options_.preserveFlatMapsInMemory(),
       options_.nimblePreserveDictionaryEncoding(),
+      options_.nimbleCompactDictionaryAcrossChunks(),
       lazyIoColumns_.empty() ? nullptr : &lazyIoColumns_);
 
   columnReader_ = buildColumnReader(

--- a/dwio/nimble/velox/selective/StringColumnReader.cpp
+++ b/dwio/nimble/velox/selective/StringColumnReader.cpp
@@ -290,27 +290,73 @@ velox::vector_size_t StringColumnReader::processNullAndPassingRows(
   return count;
 }
 
+void StringColumnReader::ensureAlphabetIndex() {
+  auto& alphabetIndex = dictionaryState_.alphabetIndex;
+  const auto& alphabet = dictionaryState_.alphabet;
+  // After the first boundary, tryExtendDictionaryAtChunkBoundary keeps the map
+  // in lockstep with the alphabet, so this becomes a no-op. The only entries
+  // missing here are the first chunk's, indexed at their identity positions.
+  if (alphabetIndex.size() == alphabet.size()) {
+    return;
+  }
+  alphabetIndex.reserve(alphabet.size());
+  for (auto i = static_cast<int32_t>(alphabetIndex.size());
+       i < static_cast<int32_t>(alphabet.size());
+       ++i) {
+    alphabetIndex.emplace(alphabet[i], i);
+  }
+}
+
 void StringColumnReader::updateDictionaryIndices(
-    vector_size_t alphabetSize,
+    int32_t alphabetOffset,
     vector_size_t valueOffset) {
-  if (alphabetSize > 0) {
-    auto* values = reinterpret_cast<int32_t*>(rawValues_);
-    for (auto i = valueOffset; i < numValues_; ++i) {
-      values[i] += alphabetSize;
+  if (alphabetOffset == 0) {
+    return;
+  }
+  auto* values = reinterpret_cast<int32_t*>(rawValues_);
+  for (auto i = valueOffset; i < numValues_; ++i) {
+    values[i] += alphabetOffset;
+  }
+}
+
+void StringColumnReader::updateCompactedDictionaryIndices(
+    const std::vector<int32_t>& remap,
+    vector_size_t valueOffset) {
+  if (remap.empty()) {
+    // Identity remap: the first chunk's local indices already reference the
+    // merged alphabet's leading entries [0, firstChunkAlphabetSize).
+    return;
+  }
+  const auto remapSize = static_cast<int32_t>(remap.size());
+  auto* values = reinterpret_cast<int32_t*>(rawValues_);
+  for (auto i = valueOffset; i < numValues_; ++i) {
+    const auto localIndex = values[i];
+    // Null positions hold uninitialized indices that are never read
+    // downstream; guard the lookup so out-of-range garbage cannot fault.
+    // Valid non-null local indices are always in [0, remapSize).
+    if (localIndex >= 0 && localIndex < remapSize) {
+      values[i] = remap[localIndex];
     }
   }
 }
 
 bool StringColumnReader::tryExtendDictionaryAtChunkBoundary(
     int32_t& alphabetOffset,
+    std::vector<int32_t>& pendingRemap,
     vector_size_t& valueOffset) {
-  // Offset the indices written by the previous chunk so they reference the
+  const bool compactDictionary = compactDictionaryAcrossChunks();
+
+  // Remap the indices written by the previous chunk so they reference the
   // merged alphabet instead of the per-chunk alphabet. numValues_ is
   // incremented by the visitor (via process() / processNull()) as
   // readDictionaryIndices reads each row. At this point, numValues_ reflects
   // all rows read so far across chunks, and [valueOffset, numValues_) are
-  // the indices from the just-completed chunk that need offsetting.
-  updateDictionaryIndices(alphabetOffset, valueOffset);
+  // the indices from the just-completed chunk that need remapping.
+  if (compactDictionary) {
+    updateCompactedDictionaryIndices(pendingRemap, valueOffset);
+  } else {
+    updateDictionaryIndices(alphabetOffset, valueOffset);
+  }
   valueOffset = numValues_;
 
   // Check if the new chunk's encoding supports dictionary index reading.
@@ -319,16 +365,35 @@ bool StringColumnReader::tryExtendDictionaryAtChunkBoundary(
     return false;
   }
 
-  // Extend the merged alphabet with the new chunk's dictionary entries.
-  // alphabetOffset tracks the cumulative size so that the next chunk's
-  // indices can be offset correctly.
-  alphabetOffset = static_cast<int32_t>(dictionaryState_.alphabet.size());
   auto chunkAlphabet = buildEncodingDictionaryAlphabet<std::string_view>(
       decoder_.currentEncoding());
-  dictionaryState_.alphabet.insert(
-      dictionaryState_.alphabet.end(),
-      chunkAlphabet.begin(),
-      chunkAlphabet.end());
+
+  if (compactDictionary) {
+    // Deduplicate the new chunk's alphabet against the merged alphabet.
+    // An entry already present reuses its existing position; a new entry
+    // is appended. The remap table translates per-chunk local indices into
+    // the merged alphabet's index space.
+    ensureAlphabetIndex();
+    pendingRemap.resize(chunkAlphabet.size());
+    for (int32_t i = 0; i < static_cast<int32_t>(chunkAlphabet.size()); ++i) {
+      const auto mergedPosition =
+          static_cast<int32_t>(dictionaryState_.alphabet.size());
+      auto [it, inserted] = dictionaryState_.alphabetIndex.emplace(
+          chunkAlphabet[i], mergedPosition);
+      if (inserted) {
+        dictionaryState_.alphabet.push_back(chunkAlphabet[i]);
+      }
+      pendingRemap[i] = it->second;
+    }
+  } else {
+    // Simple append: the new chunk's indices are uniformly offset by the
+    // current merged alphabet size. No dedup map overhead.
+    alphabetOffset = static_cast<int32_t>(dictionaryState_.alphabet.size());
+    dictionaryState_.alphabet.insert(
+        dictionaryState_.alphabet.end(),
+        chunkAlphabet.begin(),
+        chunkAlphabet.end());
+  }
   dictionaryState_.alphabetVector.reset();
   crossChunkRead_ = true;
   return true;
@@ -443,7 +508,10 @@ bool StringColumnReader::readWithDictionary(
       /*kDictionary=*/false>(*this, rows)([&](auto visitor) {
     auto dictVisitor = visitor.toStringDictionaryColumnVisitor();
 
+    // The compaction-off path carries a running offset; the compaction-on path
+    // carries a per-chunk dedup table. Only one is used, per the mode.
     int32_t alphabetOffset = 0;
+    std::vector<int32_t> pendingRemap;
     velox::vector_size_t valueOffset = numValues_;
 
     // At each chunk boundary, try to extend the merged alphabet with the
@@ -451,7 +519,8 @@ bool StringColumnReader::readWithDictionary(
     // dict-compatible (alphabet extended, continue reading). Returns false
     // if the new chunk is not dict-compatible (stop, fall back to flat).
     auto onChunkBoundary = [&]() -> bool {
-      return tryExtendDictionaryAtChunkBoundary(alphabetOffset, valueOffset);
+      return tryExtendDictionaryAtChunkBoundary(
+          alphabetOffset, pendingRemap, valueOffset);
     };
 
     // readDictionaryIndices returns false when the onChunkBoundary callback
@@ -460,8 +529,12 @@ bool StringColumnReader::readWithDictionary(
     abandonDictionary =
         !decoder_.readDictionaryIndices(dictVisitor, onChunkBoundary);
 
-    // Offset the final chunk's indices into the merged alphabet.
-    updateDictionaryIndices(alphabetOffset, valueOffset);
+    // Remap the final chunk's indices into the merged alphabet.
+    if (compactDictionaryAcrossChunks()) {
+      updateCompactedDictionaryIndices(pendingRemap, valueOffset);
+    } else {
+      updateDictionaryIndices(alphabetOffset, valueOffset);
+    }
   });
   // Reinstate the filter before the post-hoc SIMD filtering below needs it; the
   // guard then no-ops since savedFilter has been moved out.

--- a/dwio/nimble/velox/selective/StringColumnReader.h
+++ b/dwio/nimble/velox/selective/StringColumnReader.h
@@ -18,6 +18,7 @@
 
 #include <vector>
 #include "dwio/nimble/velox/selective/ChunkedDecoder.h"
+#include "folly/container/F14Map.h"
 #include "velox/dwio/common/SelectiveColumnReader.h"
 
 namespace facebook::nimble {
@@ -64,11 +65,15 @@ class StringColumnReader : public velox::dwio::common::SelectiveColumnReader {
   // boundary (via the skip callback) to invalidate stale state.
   struct DictionaryState {
     std::vector<std::string_view> alphabet;
+    // Maps alphabet entries to their index in alphabet for deduplication
+    // when compacting dictionaries across chunks.
+    folly::F14FastMap<std::string_view, int32_t> alphabetIndex;
     velox::VectorPtr alphabetVector;
     velox::raw_vector<uint8_t> filterCache;
 
     void clear() {
       alphabet.clear();
+      alphabetIndex.clear();
       alphabetVector.reset();
       filterCache.clear();
     }
@@ -86,31 +91,63 @@ class StringColumnReader : public velox::dwio::common::SelectiveColumnReader {
     dictionaryState_.clear();
   }
 
+  // Whether cross-chunk dictionary alphabets should be deduplicated
+  // (compacted), per the nimbleCompactDictionaryAcrossChunks read option.
+  bool compactDictionaryAcrossChunks() const {
+    return static_cast<const NimbleData&>(formatData())
+        .nimbleCompactDictionaryAcrossChunks();
+  }
+
+  // Back-fills alphabetIndex from the merged alphabet for any entries not yet
+  // indexed (the first chunk's alphabet, built by ensureDictionaryState).
+  // Called lazily on the first chunk boundary so single-chunk reads never
+  // build the dedup map. Idempotent: a no-op once the map is in sync.
+  void ensureAlphabetIndex();
+
+  // Shifts the dictionary indices in rawValues_ at [valueOffset, numValues_) by
+  // alphabetOffset, the compaction-off remap: each chunk is appended
+  // contiguously, so a local index maps to alphabetOffset + localIndex. A
+  // vectorizable scalar add applied to every position (null slots included,
+  // harmless since their indices are never read downstream). alphabetOffset ==
+  // 0 is the identity, i.e. the first chunk.
+  void updateDictionaryIndices(
+      int32_t alphabetOffset,
+      velox::vector_size_t valueOffset);
+
+  // Translates the dictionary indices in rawValues_ at [valueOffset,
+  // numValues_) through remap, the compaction-on remap: deduplication makes the
+  // mapping non-uniform, so each local index is looked up in the table. An
+  // empty remap is the identity (the first chunk, whose local indices already
+  // reference the merged alphabet's leading entries). Null positions hold
+  // uninitialized indices; the lookup is guarded against out-of-range garbage.
+  void updateCompactedDictionaryIndices(
+      const std::vector<int32_t>& remap,
+      velox::vector_size_t valueOffset);
+
   // Attempts to extend the merged dictionary alphabet when a chunk boundary
-  // is crossed during multi-chunk dictionary index reading. Offsets the
-  // indices written since valueOffset by alphabetOffset (to reference the
-  // merged alphabet), then checks whether the new chunk is
-  // dictionary-convertible.
+  // is crossed during multi-chunk dictionary index reading. First remaps the
+  // indices written since valueOffset (to reference the merged alphabet), then
+  // checks whether the new chunk is dictionary-convertible.
   //
   // Returns true if the new chunk's alphabet was appended and reading
   // should continue. Returns false if the new chunk is not
   // dictionary-convertible, signaling the caller to fall back to flat
   // decoding for the remaining rows.
   //
-  // @param alphabetOffset Running offset into the merged alphabet. Updated
-  //   to the new alphabet size when a chunk is appended. Tracked to produce
-  //   the correct indices in the merged alphabets.
+  // Carries the previous chunk's remap in whichever of the two forms the
+  // compaction mode uses (see updateDictionaryIndices /
+  // updateCompactedDictionaryIndices), and rebuilds it for the newly appended
+  // chunk.
+  //
+  // @param alphabetOffset Running merged-alphabet offset for the compaction-off
+  //   path. Updated to the pre-append merged size for the new chunk.
+  // @param pendingRemap Local->merged table for the compaction-on path. Rebuilt
+  //   (deduplicated) for the new chunk.
   // @param valueOffset Index into rawValues_ marking where the current
-  //   chunk's indices start. Updated to numValues_ after offsetting.
-  // Offsets dictionary indices in rawValues_ by alphabetSize, starting
-  // from position 'valueOffset' up to numValues_. Used to remap per-chunk
-  // indices into the merged alphabet's index space.
-  void updateDictionaryIndices(
-      velox::vector_size_t alphabetSize,
-      velox::vector_size_t valueOffset);
-
+  //   chunk's indices start. Updated to numValues_ after remapping.
   bool tryExtendDictionaryAtChunkBoundary(
       int32_t& alphabetOffset,
+      std::vector<int32_t>& pendingRemap,
       velox::vector_size_t& valueOffset);
 
   // Grows dictionaryState_.filterCache to one byte per merged-alphabet entry,

--- a/dwio/nimble/velox/selective/tests/E2EFilterTest.cpp
+++ b/dwio/nimble/velox/selective/tests/E2EFilterTest.cpp
@@ -3509,6 +3509,154 @@ TEST_P(E2EFilterTest, multiChunkDictionaryWithDifferentAlphabets) {
   EXPECT_EQ(totalRows, kNumBatches * kRowsPerBatch);
 }
 
+// Verifies cross-chunk dictionary deduplication (compaction). Each chunk's
+// alphabet is the same kSharedValues shared values PLUS one batch-unique value.
+// The unique value forces the writer to emit a distinct dictionary per chunk
+// (so the read path actually merges alphabets across chunks); the shared values
+// give the merge something to deduplicate. When N chunks are merged in a single
+// next(), the compacted alphabet must hold kSharedValues + N entries (the
+// shared values appear once, plus one unique per chunk). Without dedup it would
+// hold (kSharedValues + 1) * N entries, bloating the DictionaryVector's backing
+// FlatVector and memory.
+TEST_P(E2EFilterTest, multiChunkDictionaryWithOverlappingAlphabets) {
+  auto type = ROW({"string_val", "long_val"}, {VARCHAR(), BIGINT()});
+  rowType_ = asRowType(type);
+
+  const size_t kRowsPerBatch = 200;
+  const int kNumBatches = 8;
+  const int kSharedValues = 5;
+  // Row index within each batch that carries the batch-unique value.
+  const size_t kUniqueRow = 5;
+  std::vector<RowVectorPtr> batches;
+
+  // Reconstructs the value written at a given global row, so reads can be
+  // verified and the alphabet shape reasoned about.
+  auto valueAtGlobalRow = [&](int64_t globalRow) {
+    const auto rowInBatch = globalRow % kRowsPerBatch;
+    const auto batchIdx = globalRow / kRowsPerBatch;
+    return rowInBatch == kUniqueRow
+        ? fmt::format("BATCH{}_UNIQUE", batchIdx)
+        : fmt::format("SHARED_VAL_{}", rowInBatch % kSharedValues);
+  };
+
+  for (int batchIdx = 0; batchIdx < kNumBatches; ++batchIdx) {
+    std::vector<std::string> stringStorage(kRowsPerBatch);
+    std::vector<int64_t> longVals(kRowsPerBatch);
+
+    // Each batch's distinct values are {SHARED_VAL_0..4, BATCH<idx>_UNIQUE}:
+    // five shared entries plus one per-batch unique entry. The unique entry
+    // makes every chunk's dictionary differ, forcing separate chunks.
+    for (size_t i = 0; i < kRowsPerBatch; ++i) {
+      const auto globalRow = batchIdx * kRowsPerBatch + i;
+      stringStorage[i] = valueAtGlobalRow(globalRow);
+      longVals[i] = globalRow;
+    }
+
+    auto stringVector =
+        velox::test::VectorMaker(leafPool_.get())
+            .flatVector<velox::StringView>(kRowsPerBatch, [&](auto row) {
+              return velox::StringView(stringStorage[row]);
+            });
+    auto longVector = velox::test::VectorMaker(leafPool_.get())
+                          .flatVector<int64_t>(kRowsPerBatch, [&](auto row) {
+                            return longVals[row];
+                          });
+
+    batches.push_back(
+        std::make_shared<RowVector>(
+            leafPool_.get(),
+            type,
+            nullptr,
+            kRowsPerBatch,
+            std::vector<VectorPtr>{stringVector, longVector}));
+  }
+
+  // Single stripe (flushLambda=false), one chunk per batch (chunkLambda=true),
+  // all dictionary-encoded — forcing cross-chunk alphabet merging on read.
+  {
+    auto writeFile = std::make_unique<InMemoryWriteFile>(&sinkData_);
+    VeloxWriterOptions writerOptions;
+    writerOptions.enableChunking = true;
+    // Without this, the writer coalesces the small per-batch chunks into a
+    // single stream chunk (one shared dictionary), and the cross-chunk merge
+    // path is never exercised. Setting it to 0 keeps each batch a distinct
+    // chunk with its own dictionary.
+    writerOptions.minStreamChunkRawSize = 0;
+    writerOptions.flushPolicyFactory = [] {
+      return std::make_unique<LambdaFlushPolicy>(
+          /*flushLambda=*/[](const StripeProgress&) { return false; },
+          /*chunkLambda=*/[](const StripeProgress&) { return true; });
+    };
+    writerOptions.encodingLayoutTree.emplace(
+        buildForcedDictionaryEncodingLayoutTree());
+    VeloxWriter writer(
+        type, std::move(writeFile), *rootPool_, std::move(writerOptions));
+    for (auto& batch : batches) {
+      writer.write(batch);
+    }
+    writer.close();
+  }
+
+  auto input = std::make_unique<velox::dwio::common::BufferedInput>(
+      std::make_shared<velox::InMemoryReadFile>(sinkData_),
+      *leafPool_,
+      velox::dwio::common::MetricsLog::voidLog());
+
+  velox::dwio::common::ReaderOptions readerOpts{leafPool_.get()};
+  readerOpts.setMetadataIoStats(metadataIoStats_);
+  auto reader = makeReader(readerOpts, std::move(input));
+  auto scanSpec = std::make_shared<velox::common::ScanSpec>("root");
+  scanSpec->addAllChildFields(*type);
+  velox::dwio::common::RowReaderOptions rowReaderOptions;
+  rowReaderOptions.setScanSpec(scanSpec);
+  rowReaderOptions.setStringDecoderZeroCopy(param().stringDecoderZeroCopy);
+  rowReaderOptions.setNimblePreserveDictionaryEncoding(
+      param().stringDecoderZeroCopy);
+  auto rowReader = reader->createRowReader(rowReaderOptions);
+
+  // Batch size (1000) > chunk size (200): each next() merges multiple chunks.
+  VectorPtr result = velox::BaseVector::create(type, 0, leafPool_.get());
+  size_t totalRows = 0;
+  while (rowReader->next(1000, result)) {
+    auto* rowResult = result->as<RowVector>();
+    ASSERT_NE(rowResult, nullptr);
+    totalRows += rowResult->size();
+
+    auto stringChild = rowResult->childAt(0)->loadedVector();
+    if (param().stringDecoderZeroCopy) {
+      ASSERT_EQ(stringChild->encoding(), VectorEncoding::Simple::DICTIONARY)
+          << "Expected DICTIONARY encoding for string column, got "
+          << stringChild->encoding();
+      // Without compaction (nimbleCompactDictionaryAcrossChunks=false), each
+      // chunk's full alphabet is appended: (kSharedValues + 1) * chunksMerged.
+      // With compaction, shared entries are deduplicated: kSharedValues +
+      // chunksMerged. TODO: enable the compacted assertion once the session
+      // property is plumbed through RowReaderOptions.
+      ASSERT_EQ(rowResult->size() % kRowsPerBatch, 0)
+          << "Expected a whole number of chunks per next()";
+      const auto chunksMerged = rowResult->size() / kRowsPerBatch;
+      ASSERT_NE(stringChild->valueVector(), nullptr);
+      EXPECT_EQ(
+          stringChild->valueVector()->size(),
+          (kSharedValues + 1) * chunksMerged)
+          << "Alphabet should contain all per-chunk entries without compaction";
+    }
+
+    velox::DecodedVector decodedString(*stringChild);
+    velox::DecodedVector decodedLong(*rowResult->childAt(1));
+
+    for (velox::vector_size_t i = 0; i < rowResult->size(); ++i) {
+      const auto globalRow = decodedLong.valueAt<int64_t>(i);
+      ASSERT_EQ(
+          decodedString.valueAt<velox::StringView>(i).str(),
+          valueAtGlobalRow(globalRow))
+          << "Mismatch at globalRow=" << globalRow;
+    }
+  }
+
+  EXPECT_EQ(totalRows, kNumBatches * kRowsPerBatch);
+}
+
 // Regression test for two bugs in the dictionary reactive fallback path:
 //   Bug 1: expandDictionaryToFlat was called after mergedAlphabet_.clear(),
 //          causing out-of-bounds access when expanding dictionary indices.

--- a/dwio/nimble/velox/selective/tests/StringColumnReaderTest.cpp
+++ b/dwio/nimble/velox/selective/tests/StringColumnReaderTest.cpp
@@ -71,7 +71,8 @@ class StringColumnReaderTest : public ::testing::Test,
       const RowVectorPtr& expected,
       const std::string& file,
       const std::shared_ptr<common::ScanSpec>& scanSpec,
-      bool stringDecoderZeroCopy) {
+      bool stringDecoderZeroCopy,
+      bool compactDictionaryAcrossChunks = false) {
     auto readFile = std::make_shared<InMemoryReadFile>(file);
     auto factory =
         dwio::common::getReaderFactory(dwio::common::FileFormat::NIMBLE);
@@ -89,6 +90,8 @@ class StringColumnReaderTest : public ::testing::Test,
     rowOptions.setRequestedType(type);
     rowOptions.setStringDecoderZeroCopy(stringDecoderZeroCopy);
     rowOptions.setNimblePreserveDictionaryEncoding(stringDecoderZeroCopy);
+    rowOptions.setNimbleCompactDictionaryAcrossChunks(
+        compactDictionaryAcrossChunks);
     readers.rowReader = readers.reader->createRowReader(rowOptions);
     return readers;
   }
@@ -3339,6 +3342,94 @@ DEBUG_ONLY_TEST_P(StringColumnReaderTest, dictionaryPathAlphabetSize) {
       asRowType(input->type()),
       pool());
   EXPECT_EQ(dictPathEntries, 1);
+}
+
+// Cross-chunk dictionary deduplication (compaction). Two chunks share the same
+// kSharedValues values plus one chunk-unique value each. The unique value
+// forces a distinct per-chunk dictionary, so a batch spanning both chunks
+// merges the alphabets. With compaction enabled via the
+// nimbleCompactDictionaryAcrossChunks read option, the shared entries are
+// deduplicated: the merged alphabet holds kSharedValues + chunksMerged entries
+// (shared once, plus one unique per merged chunk) instead of
+// (kSharedValues + 1) * chunksMerged.
+TEST_P(StringColumnReaderTest, compactDictionaryAcrossChunks) {
+  const bool stringDecoderZeroCopy = GetParam();
+  if (!stringDecoderZeroCopy) {
+    GTEST_SKIP() << "Dictionary path requires stringDecoderZeroCopy";
+  }
+
+  constexpr int kChunkRows = 300;
+  constexpr int kSharedValues = 5;
+  // Value at row r of the given chunk: cycle through the kSharedValues shared
+  // values, with every (kSharedValues+1)-th row carrying the chunk-unique
+  // value. Each chunk's distinct set is {SHARED_0..4, UNIQUE_<chunk>}.
+  auto valueAt = [](int chunk, int rowInChunk) {
+    const int k = rowInChunk % (kSharedValues + 1);
+    return k < kSharedValues ? fmt::format("SHARED_{}", k)
+                             : fmt::format("UNIQUE_{}", chunk);
+  };
+  auto makeChunk = [&](int chunk) {
+    return makeRowVector({makeFlatVector<std::string>(
+        kChunkRows, [&](auto r) { return valueAt(chunk, r); })});
+  };
+
+  VeloxWriterOptions writerOptions;
+  writerOptions.enableChunking = true;
+  writerOptions.minStreamChunkRawSize = 0;
+  writerOptions.flushPolicyFactory = [] {
+    return std::make_unique<LambdaFlushPolicy>(
+        /*flushLambda=*/[](const StripeProgress&) { return false; },
+        /*chunkLambda=*/[](const StripeProgress&) { return true; });
+  };
+  auto file = test::createNimbleFile(
+      *rootPool(),
+      {makeChunk(0), makeChunk(1)},
+      writerOptions,
+      /*flushAfterWrite=*/false);
+
+  auto expected =
+      makeRowVector({makeFlatVector<std::string>(2 * kChunkRows, [&](auto i) {
+        return valueAt(i / kChunkRows, i % kChunkRows);
+      })});
+
+  auto scanSpec = std::make_shared<common::ScanSpec>("root");
+  scanSpec->addAllChildFields(*expected->type());
+  auto readers = makeReaders(
+      expected,
+      file,
+      scanSpec,
+      stringDecoderZeroCopy,
+      /*compactDictionaryAcrossChunks=*/true);
+
+  // Batch size (2*kChunkRows) > chunk size: one next() merges both chunks.
+  auto result = BaseVector::create(asRowType(expected->type()), 0, pool());
+  int numScanned = 0;
+  int maxChunksMerged = 0;
+  while (numScanned < expected->size()) {
+    const auto n = readers.rowReader->next(2 * kChunkRows, result);
+    if (n == 0) {
+      break;
+    }
+    auto* row = result->asUnchecked<RowVector>();
+    auto stringChild = BaseVector::loadedVectorShared(row->childAt(0));
+    ASSERT_EQ(stringChild->encoding(), VectorEncoding::Simple::DICTIONARY);
+    ASSERT_EQ(result->size() % kChunkRows, 0);
+    const int chunksMerged = result->size() / kChunkRows;
+    if (chunksMerged > maxChunksMerged) {
+      maxChunksMerged = chunksMerged;
+    }
+    EXPECT_EQ(stringChild->valueVector()->size(), kSharedValues + chunksMerged)
+        << "Merged alphabet was not deduplicated across chunks";
+    for (int j = 0; j < result->size(); ++j) {
+      ASSERT_TRUE(stringChild->equalValueAt(
+          expected->childAt(0).get(), j, numScanned + j))
+          << "Mismatch at row " << (numScanned + j);
+    }
+    numScanned += result->size();
+  }
+  ASSERT_EQ(numScanned, expected->size());
+  ASSERT_GE(maxChunksMerged, 2)
+      << "Read never spanned a chunk boundary; dedup path not exercised";
 }
 
 // Reactive fallback: chunk 1 is dictionary-encoded, chunk 2 is trivial.


### PR DESCRIPTION
Summary:
When multiple chunks are merged in a single `next()` call, each chunk's dictionary alphabet was blindly appended to the merged alphabet, duplicating values shared across chunks and bloating the output `DictionaryVector`'s backing `FlatVector`.

This diff deduplicates the merge: each chunk's local alphabet entries are looked up in an `alphabetIndex` (`folly::F14FastMap`); an entry already present reuses its merged position, a new entry is appended, and the chunk's local indices are remapped into the merged index space. The dedup is gated on the `nimbleCompactDictionaryAcrossChunks` read option (plumbed by the parent D110593187, default off), since the dedup map adds CPU that not all workloads benefit from.

To keep the default path fast, the two modes use separate methods: compaction-off keeps the vectorizable uniform-offset update (`updateDictionaryIndices`), while compaction-on uses the dedup remap table (`updateCompactedDictionaryIndices`).

Differential Revision: D101228445


