### PR TITLE
perf: Cache projections and pin decoded index chunks (#984)

### DIFF
--- a/dwio/nimble/index/tests/ClusterIndexTest.cpp
+++ b/dwio/nimble/index/tests/ClusterIndexTest.cpp
@@ -1581,6 +1581,11 @@ TEST_F(ClusterIndexTest, pinIndexEnabledRetainsChunks) {
   const auto bytesAfterChunk0 = indexIoStats_->rawBytesRead();
   EXPECT_GT(bytesAfterChunk0, 0);
 
+  reader->clusterIndex()->lookup(makeRangeScanRequest("bbb"));
+  EXPECT_EQ(helper.decodedChunkCount(0), 1);
+  EXPECT_EQ(indexIoStats_->rawBytesRead(), bytesAfterChunk0)
+      << "Repeated lookup of a pinned chunk must not trigger index IO";
+
   reader->clusterIndex()->lookup(makeRangeScanRequest("fff"));
   EXPECT_EQ(helper.decodedChunkCount(0), 2);
 

--- a/dwio/nimble/serializer/Projector.cpp
+++ b/dwio/nimble/serializer/Projector.cpp
@@ -321,23 +321,19 @@ Projector::Projector(
     NIMBLE_CHECK(subfield.valid(), "Invalid subfield: {}", subfield.toString());
   }
 
-  projectedSchema_ = buildProjectedNimbleType(
-      inputSchema_.get(),
-      projectSubfields,
-      inputStreamIndices_,
-      rowOrFlatMapNullStreams_);
+  projection_ = buildProjectedNimbleType(inputSchema_.get(), projectSubfields);
   NIMBLE_CHECK_EQ(
-      inputStreamIndices_.size(),
-      rowOrFlatMapNullStreams_.size(),
+      projection_.streamOffsets.size(),
+      projection_.rowOrFlatMapNullStreams.size(),
       "Projected stream indices and Row/FlatMap null stream mask must align");
 
-  inputStreamsSorted_ =
-      std::is_sorted(inputStreamIndices_.begin(), inputStreamIndices_.end());
+  inputStreamsSorted_ = std::is_sorted(
+      projection_.streamOffsets.begin(), projection_.streamOffsets.end());
 
   if (!inputStreamsSorted_) {
-    sortedStreamMappings_.reserve(inputStreamIndices_.size());
-    for (size_t i = 0; i < inputStreamIndices_.size(); ++i) {
-      sortedStreamMappings_.push_back({inputStreamIndices_[i], i});
+    sortedStreamMappings_.reserve(projection_.streamOffsets.size());
+    for (size_t i = 0; i < projection_.streamOffsets.size(); ++i) {
+      sortedStreamMappings_.push_back({projection_.streamOffsets[i], i});
     }
     std::sort(
         sortedStreamMappings_.begin(),
@@ -770,9 +766,9 @@ folly::IOBuf Projector::projectContiguous(
         dataOffset,
         streamIndices,
         streamSizes,
-        inputStreamIndices_,
+        projection_.streamOffsets,
         inputRequiresNullBarrier,
-        rowOrFlatMapNullStreams_,
+        projection_.rowOrFlatMapNullStreams,
         outputRequiresNullBarrier,
         output);
   } else {
@@ -781,9 +777,9 @@ folly::IOBuf Projector::projectContiguous(
         dataOffset,
         streamIndices,
         streamSizes,
-        inputStreamIndices_,
+        projection_.streamOffsets,
         inputRequiresNullBarrier,
-        rowOrFlatMapNullStreams_,
+        projection_.rowOrFlatMapNullStreams,
         outputRequiresNullBarrier,
         output);
   }
@@ -823,9 +819,9 @@ folly::IOBuf Projector::projectChained(
         cursor,
         streamIndices,
         streamSizes,
-        inputStreamIndices_,
+        projection_.streamOffsets,
         inputRequiresNullBarrier,
-        rowOrFlatMapNullStreams_,
+        projection_.rowOrFlatMapNullStreams,
         outputRequiresNullBarrier,
         output);
   } else {
@@ -835,7 +831,7 @@ folly::IOBuf Projector::projectChained(
         streamSizes,
         sortedStreamMappings_,
         inputRequiresNullBarrier,
-        rowOrFlatMapNullStreams_,
+        projection_.rowOrFlatMapNullStreams,
         outputRequiresNullBarrier,
         output);
   }

--- a/dwio/nimble/serializer/Projector.h
+++ b/dwio/nimble/serializer/Projector.h
@@ -132,13 +132,13 @@ class Projector {
   /// Returns the projected schema.
   /// The schema has compact stream indices starting from 0.
   std::shared_ptr<const Type> projectedSchema() const {
-    return projectedSchema_;
+    return projection_.nimbleType;
   }
 
   /// Returns the input stream indices that will be copied.
   /// Only for testing.
   const std::vector<uint32_t>& testingInputStreamIndices() const {
-    return inputStreamIndices_;
+    return projection_.streamOffsets;
   }
 
   /// Returns whether input stream indices are sorted (fast path eligible).
@@ -237,13 +237,9 @@ class Projector {
 
   std::shared_ptr<const Type> inputSchema_;
   // Built during construction.
-  std::shared_ptr<const Type> projectedSchema_;
-  std::vector<uint32_t> inputStreamIndices_;
-  // Parallel to inputStreamIndices_ and output stream indices. A true entry
-  // means the projected stream is a Row or FlatMap null stream.
-  std::vector<bool> rowOrFlatMapNullStreams_;
+  NimbleTypeProjection projection_;
 
-  // True when inputStreamIndices_ is already sorted (no FlatMap key
+  // True when projection_.streamOffsets is already sorted (no FlatMap key
   // reordering). Enables fast-path projection that avoids sorting and
   // reordering overhead.
   bool inputStreamsSorted_{false};

--- a/dwio/nimble/tablet/tests/TabletTestUtils.h
+++ b/dwio/nimble/tablet/tests/TabletTestUtils.h
@@ -76,6 +76,11 @@ class TabletReaderTestHelper {
     return tabletReader_->chunkIndexCache_.testingCacheCount();
   }
 
+  /// Returns statistics for cluster-index reads.
+  std::shared_ptr<velox::io::IoStatistics> indexIoStats() const {
+    return tabletReader_->ioOptions_.indexIoStats();
+  }
+
   /// Returns true if the chunk index group at the given index is cached.
   bool hasChunkIndexGroupCached(uint32_t groupIndex) const {
     return tabletReader_->chunkIndexCache_.hasCacheEntry(groupIndex);

--- a/dwio/nimble/velox/SchemaUtils.cpp
+++ b/dwio/nimble/velox/SchemaUtils.cpp
@@ -1010,19 +1010,15 @@ ColumnEncodings getColumnEncodings(const RowType& nimbleType) {
 
 } // namespace
 
-std::shared_ptr<const Type> buildProjectedNimbleType(
+NimbleTypeProjection buildProjectedNimbleType(
     const Type* type,
-    const std::vector<velox::common::Subfield>& projectedSubfields,
-    std::vector<uint32_t>& projectedStreamOffsets,
-    std::vector<bool>& rowOrFlatMapNullStreams) {
+    const std::vector<velox::common::Subfield>& projectedSubfields) {
   NIMBLE_CHECK(
       !projectedSubfields.empty(), "projectedSubfields must not be empty");
-  NIMBLE_CHECK(
-      projectedStreamOffsets.empty(), "projectedStreamOffsets must be empty");
-  NIMBLE_CHECK(
-      rowOrFlatMapNullStreams.empty(), "rowOrFlatMapNullStreams must be empty");
   NIMBLE_CHECK_NOT_NULL(type, "type must not be null");
   NIMBLE_CHECK(type->isRow(), "Root type must be a Row, got: {}", type->kind());
+
+  NimbleTypeProjection projection;
 
   // Resolve subfields against the source schema once. Real selections (Row
   // children + present FlatMap keys) land in `selectedChildren` keyed by
@@ -1054,7 +1050,7 @@ std::shared_ptr<const Type> buildProjectedNimbleType(
   // source-offset walker below to align positionally.
   auto veloxSource = convertToVeloxType(*type);
   const auto encodings = getColumnEncodings(rootRow);
-  auto projectedSchema = buildProjectedNimbleType(
+  projection.nimbleType = buildProjectedNimbleType(
       veloxSource->asRow(), projectedSubfields, encodings);
 
   // Walk the source nimble in the same DFS pre-order + FlatMap-alphabetical
@@ -1062,8 +1058,8 @@ std::shared_ptr<const Type> buildProjectedNimbleType(
   // and Row/FlatMap null stream bit per projected stream position (UINT32_MAX
   // for missing keys).
   appendProjectedStream(
-      projectedStreamOffsets,
-      rowOrFlatMapNullStreams,
+      projection.streamOffsets,
+      projection.rowOrFlatMapNullStreams,
       rootRow.nullsDescriptor().offset(),
       /*isRowOrFlatMapNullStream=*/true);
   for (size_t columnIdx : selectedColumnIndices) {
@@ -1073,21 +1069,22 @@ std::shared_ptr<const Type> buildProjectedNimbleType(
           child->asFlatMap(),
           selectedChildren,
           missingChildren,
-          projectedStreamOffsets,
-          rowOrFlatMapNullStreams);
+          projection.streamOffsets,
+          projection.rowOrFlatMapNullStreams);
     } else {
       projectStreamOffsets(
           child,
           selectedChildren,
           missingChildren,
-          projectedStreamOffsets,
-          rowOrFlatMapNullStreams);
+          projection.streamOffsets,
+          projection.rowOrFlatMapNullStreams);
     }
   }
   NIMBLE_DCHECK_EQ(
-      projectedStreamOffsets.size(), rowOrFlatMapNullStreams.size());
+      projection.streamOffsets.size(),
+      projection.rowOrFlatMapNullStreams.size());
 
-  return projectedSchema;
+  return projection;
 }
 
 } // namespace facebook::nimble

--- a/dwio/nimble/velox/SchemaUtils.h
+++ b/dwio/nimble/velox/SchemaUtils.h
@@ -52,40 +52,16 @@ std::shared_ptr<const Type> buildProjectedNimbleType(
     const std::vector<velox::common::Subfield>& projectedSubfields,
     const ColumnEncodings& columnEncodings = {});
 
-/// Builds a projected nimble schema from a source nimble schema and emits
-/// the source stream-offset mapping plus a Row/FlatMap null stream mask in one
-/// pass. Used by
-/// `nimble::serde::Projector` and `nimble::NimbleIndexProjector` to derive
-/// everything the byte-copy pipeline needs from `(type, projectedSubfields)`.
-///
-/// Internally: converts the source nimble schema to velox (FlatMaps collapse
-/// to `MAP<K,V>`), derives encoding hints from the source's top-level Kinds,
-/// builds the projected schema via the velox-source `buildProjectedNimbleType`
-/// overload, and walks the source nimble in the matching DFS pre-order +
-/// FlatMap-children-alphabetical traversal to emit one source stream offset
-/// and Row/FlatMap null stream bit per projected stream position.
-///
-/// Missing FlatMap keys are allowed: each subscript whose key does not exist
-/// in the source FlatMap produces a synthetic child in the returned schema
-/// (the value subtree is cloned from `flatMap.childAt(0)`'s type as a
-/// structural template) and emits `UINT32_MAX` placeholder entries in
-/// `projectedStreamOffsets` (>= any real source offset). The projector's
-/// stream-copy guard turns those into 0-byte placeholder slots in the
-/// projected blob, which the deserializer's gap-fill renders as null
-/// columns. An all-missing-keys projection is permitted and yields a
-/// FlatMap whose every child is a placeholder.
-///
-/// @param type                    The source nimble schema; root must be Row.
-/// @param projectedSubfields      Subfields to project; must not be empty.
-/// @param projectedStreamOffsets  Output: appended in projected-stream-
-///                                position order. Must be empty on entry.
-/// @param rowOrFlatMapNullStreams Output: parallel to projectedStreamOffsets;
-///                                true when the projected stream is a Row or
-///                                FlatMap null stream. Must be empty on entry.
-std::shared_ptr<const Type> buildProjectedNimbleType(
+/// Contains a projected Nimble schema and its mapping to source streams.
+struct NimbleTypeProjection {
+  std::shared_ptr<const Type> nimbleType;
+  std::vector<uint32_t> streamOffsets;
+  std::vector<bool> rowOrFlatMapNullStreams;
+};
+
+/// Builds a projected Nimble schema and its source-stream mapping.
+NimbleTypeProjection buildProjectedNimbleType(
     const Type* type,
-    const std::vector<velox::common::Subfield>& projectedSubfields,
-    std::vector<uint32_t>& projectedStreamOffsets,
-    std::vector<bool>& rowOrFlatMapNullStreams);
+    const std::vector<velox::common::Subfield>& projectedSubfields);
 
 } // namespace facebook::nimble

--- a/dwio/nimble/velox/index/NimbleIndexProjector.cpp
+++ b/dwio/nimble/velox/index/NimbleIndexProjector.cpp
@@ -150,22 +150,37 @@ std::unique_ptr<NimbleIndexProjector> NimbleIndexProjector::create(
       "NimbleIndexProjector does not support data caching");
   auto cached = tabletReaderCache.get(
       fileHandle.file, TabletReader::configureOptions(options));
+  auto projection = std::make_shared<NimbleTypeProjection>(
+      buildProjectedNimbleType(cached.nimbleSchema.get(), projectedSubfields));
+  return create(
+      std::move(cached.tablet), fileHandle, std::move(projection), options);
+}
+
+std::unique_ptr<NimbleIndexProjector> NimbleIndexProjector::create(
+    std::shared_ptr<TabletReader> tablet,
+    const velox::FileHandle& fileHandle,
+    std::shared_ptr<const NimbleTypeProjection> projection,
+    const velox::dwio::common::ReaderOptions& options) {
+  validateReaderOptions(options);
+  NIMBLE_CHECK(
+      !options.cacheData(),
+      "NimbleIndexProjector does not support data caching");
+  NIMBLE_CHECK_NOT_NULL(tablet);
+  NIMBLE_CHECK_NOT_NULL(projection);
   return std::unique_ptr<NimbleIndexProjector>(new NimbleIndexProjector(
-      std::move(cached.tablet),
-      std::move(cached.nimbleSchema),
+      std::move(tablet),
       fileHandle.file,
       createDataInput(fileHandle, options),
-      projectedSubfields,
+      std::move(projection),
       &options.memoryPool(),
       options.dataIoStats()));
 }
 
 NimbleIndexProjector::NimbleIndexProjector(
     std::shared_ptr<TabletReader> tablet,
-    std::shared_ptr<const Type> nimbleSchema,
     std::shared_ptr<velox::ReadFile> file,
     std::unique_ptr<DataInput> dataInput,
-    const std::vector<Subfield>& projectedSubfields,
+    std::shared_ptr<const NimbleTypeProjection> projection,
     velox::memory::MemoryPool* pool,
     std::shared_ptr<velox::io::IoStatistics> ioStats)
     : file_{std::move(file)},
@@ -174,19 +189,15 @@ NimbleIndexProjector::NimbleIndexProjector(
       pool_{pool},
       dataInput_{std::move(dataInput)},
       clusterIndex_{tablet_->clusterIndex()},
-      numStripes_{tablet_->stripeCount()} {
+      numStripes_{tablet_->stripeCount()},
+      projection_{std::move(projection)} {
   NIMBLE_CHECK_NOT_NULL(
       clusterIndex_, "NimbleIndexProjector requires a tablet with an index");
   NIMBLE_CHECK_GT(numStripes_, 0, "NimbleIndexProjector requires stripes");
 
-  projectedNimbleType_ = buildProjectedNimbleType(
-      nimbleSchema.get(),
-      projectedSubfields,
-      projectedStreamOffsets_,
-      rowOrFlatMapNullStreams_);
   NIMBLE_CHECK_EQ(
-      projectedStreamOffsets_.size(),
-      rowOrFlatMapNullStreams_.size(),
+      projection_->streamOffsets.size(),
+      projection_->rowOrFlatMapNullStreams.size(),
       "Projected stream offsets and Row/FlatMap null stream mask must align");
 }
 
@@ -392,7 +403,7 @@ void NimbleIndexProjector::loadStripes() {
   }
   dataInput_->reserve(totalStreams);
 
-  const auto numProjectedStreams = projectedStreamOffsets_.size();
+  const auto numProjectedStreams = projection_->streamOffsets.size();
   ctx_.dataInputIndices.resize(stripePlans.size() * numProjectedStreams);
   for (size_t stripeOffset = 0; stripeOffset < stripePlans.size();
        ++stripeOffset) {
@@ -438,9 +449,9 @@ void NimbleIndexProjector::locateStripeStreams(StripePlan& stripePlan) {
   const auto& streamOffsets = tablet_->streamOffsets(stripeId);
   const auto& streamSizes = tablet_->streamSizes(stripeId);
 
-  stripePlan.projectedStreams.resize(projectedStreamOffsets_.size());
-  for (size_t i = 0; i < projectedStreamOffsets_.size(); ++i) {
-    const auto streamId = projectedStreamOffsets_[i];
+  stripePlan.projectedStreams.resize(projection_->streamOffsets.size());
+  for (size_t i = 0; i < projection_->streamOffsets.size(); ++i) {
+    const auto streamId = projection_->streamOffsets[i];
     if (streamId >= streamCount || streamSizes[streamId] == 0) {
       continue;
     }
@@ -448,7 +459,7 @@ void NimbleIndexProjector::locateStripeStreams(StripePlan& stripePlan) {
         stripeOffset + streamOffsets[streamId], streamSizes[streamId]};
     ++stripePlan.numStreams;
     stripePlan.projectedBytes += streamSizes[streamId];
-    if (rowOrFlatMapNullStreams_[i]) {
+    if (projection_->rowOrFlatMapNullStreams[i]) {
       // A present Row/FlatMap null stream means the slice may carry nulls.
       stripePlan.requiresNullBarrier = true;
     }
@@ -458,7 +469,7 @@ void NimbleIndexProjector::locateStripeStreams(StripePlan& stripePlan) {
 folly::IOBuf NimbleIndexProjector::packStripe(size_t stripeOffset) {
   const auto& stripePlan = ctx_.plan.stripePlans[stripeOffset];
   const auto numRows = stripeRowCount(stripePlan.stripeIndex);
-  const auto numProjectedStreams = projectedStreamOffsets_.size();
+  const auto numProjectedStreams = projection_->streamOffsets.size();
 
   // Deduplicate streams that the source tablet already aliased: multiple
   // projected slots can resolve to the same physical extent. DataInput detects

--- a/dwio/nimble/velox/index/NimbleIndexProjector.h
+++ b/dwio/nimble/velox/index/NimbleIndexProjector.h
@@ -83,6 +83,14 @@ class NimbleIndexProjector {
       const std::vector<Subfield>& projectedSubfields,
       const velox::dwio::common::ReaderOptions& options);
 
+  /// Creates a projector with projection metadata built by the caller.
+  /// The projection must have been built from the schema of `tablet`.
+  static std::unique_ptr<NimbleIndexProjector> create(
+      std::shared_ptr<TabletReader> tablet,
+      const velox::FileHandle& fileHandle,
+      std::shared_ptr<const NimbleTypeProjection> projection,
+      const velox::dwio::common::ReaderOptions& options);
+
   ~NimbleIndexProjector() = default;
 
   /// Options for controlling projection behavior.
@@ -147,7 +155,7 @@ class NimbleIndexProjector {
   /// (ArrayWithOffsets, SlidingWindowMap, FlatMap) from the file schema.
   /// Clients need this to build a Deserializer for the output data.
   const std::shared_ptr<const Type>& projectedNimbleType() const {
-    return projectedNimbleType_;
+    return projection_->nimbleType;
   }
 
   /// Statistics captured during project().
@@ -182,10 +190,9 @@ class NimbleIndexProjector {
  private:
   NimbleIndexProjector(
       std::shared_ptr<TabletReader> tablet,
-      std::shared_ptr<const Type> nimbleSchema,
       std::shared_ptr<velox::ReadFile> file,
       std::unique_ptr<DataInput> dataInput,
-      const std::vector<Subfield>& projectedSubfields,
+      std::shared_ptr<const NimbleTypeProjection> projection,
       velox::memory::MemoryPool* pool,
       std::shared_ptr<velox::io::IoStatistics> ioStats);
 
@@ -262,7 +269,7 @@ class NimbleIndexProjector {
 
   // Output of prepareStripes(): the set of stripes to process and whether
   // global limits (maxRows/maxBytes) caused early termination.
-  struct ProjectionPlan {
+  struct ScanPlan {
     std::vector<StripePlan> stripePlans;
     bool truncated{false};
   };
@@ -319,14 +326,7 @@ class NimbleIndexProjector {
   const ClusterIndex* const clusterIndex_;
   const uint32_t numStripes_{0};
 
-  // Projected nimble schema built from file nimble schema. Preserves
-  // encoding-specific types (ArrayWithOffsets, SlidingWindowMap, FlatMap).
-  std::shared_ptr<const Type> projectedNimbleType_;
-  std::vector<uint32_t> projectedStreamOffsets_;
-  // Parallel to projectedStreamOffsets_: true at the projected stream indices
-  // that are Row/FlatMap null streams. Present streams with this bit require
-  // the null-barrier path.
-  std::vector<bool> rowOrFlatMapNullStreams_;
+  const std::shared_ptr<const NimbleTypeProjection> projection_;
 
   // Per-project() call state. Set by initRequest(), populated through the
   // pipeline (lookupStripes → prepareStripes → loadStripes → processStripes),
@@ -339,7 +339,7 @@ class NimbleIndexProjector {
     // lookupStripes(), read-only during stripe processing.
     StripeRanges stripeRanges;
     // Populated by prepareStripes().
-    ProjectionPlan plan;
+    ScanPlan plan;
     // Per-request flag: true if the request has ranges in any StripePlan.
     // Set by prepareStripes(), used by setResumeKeys().
     std::vector<bool> hasStripeRanges;

--- a/dwio/nimble/velox/index/tests/NimbleIndexProjectorTest.cpp
+++ b/dwio/nimble/velox/index/tests/NimbleIndexProjectorTest.cpp
@@ -28,9 +28,12 @@
 #include "dwio/nimble/tablet/TabletReader.h"
 #include "dwio/nimble/tablet/TabletReaderCache.h"
 #include "dwio/nimble/tablet/tests/TabletTestUtils.h"
+#include "dwio/nimble/velox/SchemaBuilder.h"
+#include "dwio/nimble/velox/SchemaReader.h"
 #include "dwio/nimble/velox/SchemaUtils.h"
 #include "dwio/nimble/velox/VeloxReader.h"
 #include "dwio/nimble/velox/VeloxWriter.h"
+#include "dwio/nimble/velox/tests/SchemaUtils.h"
 
 #include "folly/Random.h"
 #include "velox/common/caching/FileIds.h"
@@ -94,6 +97,82 @@ struct TestParam {
         "cacheMetadata={}, pinMetadata={}", cacheMetadata, pinMetadata);
   }
 };
+
+TEST(NimbleTypeProjectionTest, buildsScalarProjection) {
+  SchemaBuilder schemaBuilder;
+  NIMBLE_SCHEMA(
+      schemaBuilder,
+      NIMBLE_ROW({
+          {"id", NIMBLE_BIGINT()},
+          {"value", NIMBLE_INTEGER()},
+      }));
+  auto nimbleSchema = SchemaReader::getSchema(schemaBuilder.schemaNodes());
+
+  std::vector<Subfield> projectedSubfields;
+  projectedSubfields.emplace_back("value");
+  auto projection =
+      buildProjectedNimbleType(nimbleSchema.get(), projectedSubfields);
+
+  ASSERT_NE(projection.nimbleType, nullptr);
+  ASSERT_EQ(projection.nimbleType->kind(), Kind::Row);
+  const auto& projectedRow = projection.nimbleType->asRow();
+  ASSERT_EQ(projectedRow.childrenCount(), 1);
+  EXPECT_EQ(projectedRow.nameAt(0), "value");
+  EXPECT_EQ(projectedRow.childAt(0)->kind(), Kind::Scalar);
+  EXPECT_EQ(projection.streamOffsets, std::vector<uint32_t>({2, 1}));
+  EXPECT_EQ(
+      projection.rowOrFlatMapNullStreams, std::vector<bool>({true, false}));
+}
+
+TEST(NimbleTypeProjectionTest, buildsFlatMapProjectionWithMissingKey) {
+  SchemaBuilder schemaBuilder;
+  test::FlatMapChildAdder featuresAdder;
+  NIMBLE_SCHEMA(
+      schemaBuilder,
+      NIMBLE_ROW({
+          {"features", NIMBLE_FLATMAP(String, NIMBLE_INTEGER(), featuresAdder)},
+      }));
+  featuresAdder.addChild("a");
+  featuresAdder.addChild("c");
+  auto nimbleSchema = SchemaReader::getSchema(schemaBuilder.schemaNodes());
+
+  std::vector<Subfield> projectedSubfields;
+  projectedSubfields.emplace_back("features[\"a\"]");
+  projectedSubfields.emplace_back("features[\"missing\"]");
+  auto projection =
+      buildProjectedNimbleType(nimbleSchema.get(), projectedSubfields);
+
+  ASSERT_NE(projection.nimbleType, nullptr);
+  ASSERT_EQ(projection.nimbleType->kind(), Kind::Row);
+  const auto& projectedRow = projection.nimbleType->asRow();
+  ASSERT_EQ(projectedRow.childrenCount(), 1);
+  ASSERT_EQ(projectedRow.childAt(0)->kind(), Kind::FlatMap);
+  const auto& projectedFlatMap = projectedRow.childAt(0)->asFlatMap();
+  ASSERT_EQ(projectedFlatMap.childrenCount(), 2);
+  EXPECT_EQ(projectedFlatMap.nameAt(0), "a");
+  EXPECT_EQ(projectedFlatMap.nameAt(1), "missing");
+  EXPECT_EQ(
+      projection.streamOffsets,
+      std::vector<uint32_t>({1, 0, 2, 3, UINT32_MAX, UINT32_MAX}));
+  EXPECT_EQ(
+      projection.rowOrFlatMapNullStreams,
+      std::vector<bool>({true, true, false, false, false, false}));
+}
+
+TEST(NimbleTypeProjectionTest, rejectsEmptyProjection) {
+  SchemaBuilder schemaBuilder;
+  NIMBLE_SCHEMA(
+      schemaBuilder,
+      NIMBLE_ROW({
+          {"value", NIMBLE_INTEGER()},
+      }));
+  auto nimbleSchema = SchemaReader::getSchema(schemaBuilder.schemaNodes());
+
+  const std::vector<Subfield> projectedSubfields;
+  NIMBLE_ASSERT_THROW(
+      buildProjectedNimbleType(nimbleSchema.get(), projectedSubfields),
+      "projectedSubfields must not be empty");
+}
 
 class NimbleIndexProjectorTest : public ::testing::TestWithParam<TestParam> {
  protected:

--- a/dwio/nimble/velox/tests/SchemaUtilsTest.cpp
+++ b/dwio/nimble/velox/tests/SchemaUtilsTest.cpp
@@ -748,17 +748,12 @@ TEST(SchemaUtilsTest, projectionDeepWithStreamOffsets) {
 
   // Drive the projection through the same nimble-source API the projectors
   // use: derive projected schema metadata in one pass.
-  std::vector<uint32_t> projectedStreamOffsets;
-  std::vector<bool> rowOrFlatMapNullStreams;
-  auto projectedNimbleType = buildProjectedNimbleType(
-      convertedNimbleType.get(),
-      subfields,
-      projectedStreamOffsets,
-      rowOrFlatMapNullStreams);
+  auto projection =
+      buildProjectedNimbleType(convertedNimbleType.get(), subfields);
 
   // Verify projected schema structure.
-  ASSERT_EQ(projectedNimbleType->kind(), Kind::Row);
-  const auto& root = projectedNimbleType->asRow();
+  ASSERT_EQ(projection.nimbleType->kind(), Kind::Row);
+  const auto& root = projection.nimbleType->asRow();
   ASSERT_EQ(root.childrenCount(), 1);
   EXPECT_EQ(root.nameAt(0), "map_col");
 
@@ -784,9 +779,9 @@ TEST(SchemaUtilsTest, projectionDeepWithStreamOffsets) {
   //   key2.inner_a = 6, key2.inner_b = 7, key2.Row.nulls = 8, key2.inMap = 9.
   // The walker visits: outer-Row.nulls (1), map_col-FlatMap.nulls (0),
   // key1.Row.nulls (4), key1.inner_b (3), key1.inMap (5).
-  EXPECT_EQ(projectedStreamOffsets, std::vector<uint32_t>({1, 0, 4, 3, 5}));
+  EXPECT_EQ(projection.streamOffsets, std::vector<uint32_t>({1, 0, 4, 3, 5}));
   EXPECT_EQ(
-      rowOrFlatMapNullStreams,
+      projection.rowOrFlatMapNullStreams,
       std::vector<bool>({true, true, true, false, false}));
 }
 
@@ -849,19 +844,8 @@ TEST(SchemaUtilsTest, projectionMarksRowOrFlatMapNullStreams) {
         features.inMapDescriptorAt(featureAIdx).offset()};
   }();
 
-  struct ProjectedMetadata {
-    std::shared_ptr<const Type> schema;
-    std::vector<uint32_t> streamOffsets;
-    std::vector<bool> rowOrFlatMapNullStreams;
-  };
   auto project = [&](const std::vector<Subfield>& subfields) {
-    ProjectedMetadata metadata;
-    metadata.schema = buildProjectedNimbleType(
-        sourceNimbleType.get(),
-        subfields,
-        metadata.streamOffsets,
-        metadata.rowOrFlatMapNullStreams);
-    return metadata;
+    return buildProjectedNimbleType(sourceNimbleType.get(), subfields);
   };
 
   enum class ProjectedShape {
@@ -918,8 +902,8 @@ TEST(SchemaUtilsTest, projectionMarksRowOrFlatMapNullStreams) {
 
     auto metadata = project(subfields);
 
-    ASSERT_EQ(metadata.schema->kind(), Kind::Row);
-    const auto& projectedRoot = metadata.schema->asRow();
+    ASSERT_EQ(metadata.nimbleType->kind(), Kind::Row);
+    const auto& projectedRoot = metadata.nimbleType->asRow();
     ASSERT_EQ(projectedRoot.childrenCount(), 1);
     switch (testCase.shape) {
       case ProjectedShape::Scalar:
@@ -985,14 +969,8 @@ TEST(SchemaUtilsTest, nestedFlatMapProjectionFails) {
   std::vector<Subfield> subfields;
   subfields.emplace_back("nested");
 
-  std::vector<uint32_t> projectedStreamOffsets;
-  std::vector<bool> rowOrFlatMapNullStreams;
   NIMBLE_ASSERT_THROW(
-      buildProjectedNimbleType(
-          sourceNimbleType.get(),
-          subfields,
-          projectedStreamOffsets,
-          rowOrFlatMapNullStreams),
+      buildProjectedNimbleType(sourceNimbleType.get(), subfields),
       "FlatMap projection is supported only for top-level columns");
 }
 
@@ -1023,19 +1001,13 @@ TEST(SchemaUtilsTest, projectionEncodingHints_SlidingWindowMap) {
   subfields.emplace_back("id");
   subfields.emplace_back("dedup_map");
 
-  std::vector<uint32_t> projectedStreamOffsets;
-  std::vector<bool> rowOrFlatMapNullStreams;
-  auto projectedNimbleType = buildProjectedNimbleType(
-      sourceNimbleType.get(),
-      subfields,
-      projectedStreamOffsets,
-      rowOrFlatMapNullStreams);
+  auto projection = buildProjectedNimbleType(sourceNimbleType.get(), subfields);
 
   // Verify the SlidingWindowMap encoding is preserved (this is the path
   // through getColumnEncodings → deduplicatedMapColumns → velox-source
   // builder's SlidingWindowMap branch).
-  ASSERT_EQ(projectedNimbleType->kind(), Kind::Row);
-  const auto& root = projectedNimbleType->asRow();
+  ASSERT_EQ(projection.nimbleType->kind(), Kind::Row);
+  const auto& root = projection.nimbleType->asRow();
   ASSERT_EQ(root.childrenCount(), 2);
   EXPECT_EQ(root.nameAt(0), "id");
   EXPECT_EQ(root.childAt(0)->kind(), Kind::Scalar);
@@ -1044,9 +1016,10 @@ TEST(SchemaUtilsTest, projectionEncodingHints_SlidingWindowMap) {
 
   // Walker visits: outer-Row.nulls (5), id Scalar (0), dedup_map offsets (3),
   // lengths (4), keys (1), values (2).
-  EXPECT_EQ(projectedStreamOffsets, std::vector<uint32_t>({5, 0, 3, 4, 1, 2}));
   EXPECT_EQ(
-      rowOrFlatMapNullStreams,
+      projection.streamOffsets, std::vector<uint32_t>({5, 0, 3, 4, 1, 2}));
+  EXPECT_EQ(
+      projection.rowOrFlatMapNullStreams,
       std::vector<bool>({true, false, false, false, false, false}));
 }
 
@@ -1089,17 +1062,11 @@ TEST(SchemaUtilsTest, projectionEncodingHints_Mixed) {
   subfields.emplace_back("features[\"a\"]");
   subfields.emplace_back("features[\"missing\"]");
 
-  std::vector<uint32_t> projectedStreamOffsets;
-  std::vector<bool> rowOrFlatMapNullStreams;
-  auto projectedNimbleType = buildProjectedNimbleType(
-      sourceNimbleType.get(),
-      subfields,
-      projectedStreamOffsets,
-      rowOrFlatMapNullStreams);
+  auto projection = buildProjectedNimbleType(sourceNimbleType.get(), subfields);
 
   // All three encoding-specific Kinds survive the projection.
-  ASSERT_EQ(projectedNimbleType->kind(), Kind::Row);
-  const auto& root = projectedNimbleType->asRow();
+  ASSERT_EQ(projection.nimbleType->kind(), Kind::Row);
+  const auto& root = projection.nimbleType->asRow();
   ASSERT_EQ(root.childrenCount(), 4);
   EXPECT_EQ(root.childAt(0)->kind(), Kind::Scalar);
   EXPECT_EQ(root.childAt(1)->kind(), Kind::ArrayWithOffsets);
@@ -1120,11 +1087,11 @@ TEST(SchemaUtilsTest, projectionEncodingHints_Mixed) {
   //     "a" value (10), "a" inMap (11),
   //     "missing" value (UINT32_MAX), "missing" inMap (UINT32_MAX).
   EXPECT_EQ(
-      projectedStreamOffsets,
+      projection.streamOffsets,
       std::vector<uint32_t>(
           {9, 0, 2, 3, 1, 6, 7, 4, 5, 8, 10, 11, UINT32_MAX, UINT32_MAX}));
   EXPECT_EQ(
-      rowOrFlatMapNullStreams,
+      projection.rowOrFlatMapNullStreams,
       std::vector<bool>(
           {true,
            false,


### PR DESCRIPTION
Summary:

Change the existing Nimble-source `buildProjectedNimbleType` API to return one `NimbleTypeProjection`, and retain that aggregate directly in serializer/projector state. Cache shared immutable projections on `NimbleTableReader` by projection key. Enable lazy decoded cluster-index key chunk pinning for ZippyDB Nimble readers to reduce repeated decode CPU and index I/O.

Reviewed By: HuamengJiang, tanjialiang

Differential Revision: D112750424
