### PR TITLE
fix(nimble): Link nimble_velox_schema_utils in OSS nimble_index_projector_test

### DIFF
--- a/dwio/nimble/velox/index/tests/CMakeLists.txt
+++ b/dwio/nimble/velox/index/tests/CMakeLists.txt
@@ -25,6 +25,7 @@ target_link_libraries(
   nimble_velox_common
   nimble_velox_writer
   nimble_velox_selective
+  nimble_velox_schema_utils
   velox_dwio_common
   velox_key_encoder
   velox_memory


### PR DESCRIPTION
Summary:
D112750424 added tests to `NimbleIndexProjectorTest.cpp` that use the schema
test-builder DSL (`test::schema`, `test::row`, `test::flatMap`,
`FlatMapChildAdder`) defined in `dwio/nimble/velox/tests/SchemaUtils.cpp` (the
`nimble_velox_schema_utils` library). It updated the fbcode `BUCK` deps but not
the OSS `CMakeLists.txt`, so the open-source `facebookincubator/nimble`
Linux/Ubuntu build fails at link time for `nimble_index_projector_test` with
`undefined reference` to `facebook::nimble::test::schema/row/flatMap`.

Add `nimble_velox_schema_utils` to that target's `target_link_libraries` in
`dwio/nimble/velox/index/tests/CMakeLists.txt`. OSS-CMake-only change; no Buck or
production impact.

Broke in: D112750424 ("[nimble] perf: Cache projections and pin decoded index chunks").

Differential Revision: D112781963


