### PR TITLE
perf: Improve scalar encoding selection and compact ALP metadata (#986)

### DIFF
--- a/dwio/nimble/encodings/ALPEncoding.h
+++ b/dwio/nimble/encodings/ALPEncoding.h
@@ -25,6 +25,7 @@
 #include <vector>
 #include "dwio/nimble/common/Buffer.h"
 #include "dwio/nimble/common/Exceptions.h"
+#include "dwio/nimble/common/Varint.h"
 #include "dwio/nimble/common/Vector.h"
 #include "dwio/nimble/encodings/FixedBitWidthEncoding.h"
 #include "dwio/nimble/encodings/TrivialEncoding.h"
@@ -40,10 +41,14 @@
 ///
 ///
 /// Data layout after the standard Encoding prefix:
-///   1 byte:  exponent (uint8)
-///   1 byte:  factor   (uint8)
-///   4 bytes: exceptionCount (uint32)
-///   4 bytes: encodedValuesSize (uint32, size of nested encoding)
+///   3 bytes: ALP control word:
+///     bits 0..4: exponent
+///     bits 5..9: factor
+///     bits 10..15: reserved
+///     bit 16: has exceptions
+///     bits 17..23: reserved
+///   1-5 bytes: exceptionCount (varint, present only when has exceptions)
+///   1-5 bytes: encodedValuesSize (varint uint32, size of nested encoding)
 ///   N bytes: nested encoding of ZigZag-coded signed encoded values
 ///   exceptionCount * 4 bytes: exception positions (uint32 each)
 ///   exceptionCount * sizeof(physicalType) bytes: exception values
@@ -62,6 +67,39 @@ template <typename FloatType>
 inline typename TypeTraits<FloatType>::physicalType toPhysical(
     FloatType logicalValue) {
   return EncodingPhysicalType<FloatType>::asEncodingPhysicalType(logicalValue);
+}
+
+struct Header {
+  // Parameters used to transform floating-point values into integers.
+  uint8_t exponent{0};
+  uint8_t factor{0};
+
+  // Whether the optional exception count and exception streams are present.
+  bool hasExceptions{false};
+};
+
+inline Header readHeader(const char*& pos) {
+  const auto control = static_cast<uint32_t>(
+      static_cast<uint8_t>(pos[0]) | (static_cast<uint8_t>(pos[1]) << 8) |
+      (static_cast<uint8_t>(pos[2]) << 16));
+  pos += 3;
+  return Header{
+      .exponent = static_cast<uint8_t>(control & 0x1f),
+      .factor = static_cast<uint8_t>((control >> 5) & 0x1f),
+      .hasExceptions = (control & (1u << 16)) != 0};
+}
+
+inline void writeHeader(const Header& header, char*& pos) {
+  NIMBLE_DCHECK_LE(header.exponent, 31);
+  NIMBLE_DCHECK_LE(header.factor, 31);
+  uint32_t control = header.exponent | (header.factor << 5);
+  if (header.hasExceptions) {
+    control |= 1u << 16;
+  }
+  pos[0] = static_cast<char>(control & 0xff);
+  pos[1] = static_cast<char>((control >> 8) & 0xff);
+  pos[2] = static_cast<char>((control >> 16) & 0xff);
+  pos += 3;
 }
 
 } // namespace detail::alp
@@ -85,10 +123,11 @@ class ALPEncoding final
       : TypedEncoding<T, physicalType>(pool, data, options), pos_(0) {
     const char* pos = data.data() + this->dataOffset();
 
-    exponent_ = encoding::read<uint8_t>(pos);
-    factor_ = encoding::read<uint8_t>(pos);
-    exceptionCount_ = encoding::readUint32(pos);
-    const uint32_t encodedValuesSize = encoding::readUint32(pos);
+    const auto header = detail::alp::readHeader(pos);
+    exponent_ = header.exponent;
+    factor_ = header.factor;
+    exceptionCount_ = header.hasExceptions ? varint::readVarint32(&pos) : 0;
+    const uint32_t encodedValuesSize = varint::readVarint32(&pos);
 
     const EncodingFactory encodingFactory(options);
     auto noStringBufferFactory = [](uint32_t) -> void* { return nullptr; };
@@ -213,8 +252,11 @@ class ALPEncoding final
 
     const uint32_t exceptionPositionsSize = exceptionCount * sizeof(uint32_t);
     const uint32_t exceptionValuesSize = exceptionCount * sizeof(physicalType);
+    const uint32_t metadataSize = kHeaderSize +
+        (exceptionCount > 0 ? varint::varintSize(exceptionCount) : 0) +
+        varint::varintSize(serializedEncoded.size());
     const uint32_t encodingSize =
-        Encoding::serializePrefixSize(rowCount, useVarint) + kAlpPrefixSize +
+        Encoding::serializePrefixSize(rowCount, useVarint) + metadataSize +
         serializedEncoded.size() + exceptionPositionsSize + exceptionValuesSize;
 
     char* reserved = buffer.reserve(encodingSize);
@@ -222,10 +264,16 @@ class ALPEncoding final
     Encoding::serializePrefix(
         EncodingType::ALP, TypeTraits<T>::dataType, rowCount, useVarint, pos);
 
-    encoding::write<uint8_t>(exponent, pos);
-    encoding::write<uint8_t>(factor, pos);
-    encoding::writeUint32(exceptionCount, pos);
-    encoding::writeUint32(serializedEncoded.size(), pos);
+    detail::alp::writeHeader(
+        detail::alp::Header{
+            .exponent = exponent,
+            .factor = factor,
+            .hasExceptions = exceptionCount > 0},
+        pos);
+    if (exceptionCount > 0) {
+      varint::writeVarint(exceptionCount, &pos);
+    }
+    varint::writeVarint(serializedEncoded.size(), &pos);
     encoding::writeBytes(serializedEncoded, pos);
 
     if (exceptionCount > 0) {
@@ -247,17 +295,37 @@ class ALPEncoding final
     }
 
     const uint64_t rowCount = values.size();
-    const uint32_t sampleSize =
-        std::min(static_cast<uint32_t>(rowCount), kSampleSize);
+    const uint32_t sampleSize = estimateSampleSize(rowCount);
+
+    std::vector<physicalType> sampledValues;
+    sampledValues.reserve(sampleSize);
+    // Select evenly spaced input positions without accumulating rounding error.
+    for (uint32_t i = 0; i < sampleSize; ++i) {
+      const auto inputIndex = sampledValueIndex(i, rowCount, sampleSize);
+      sampledValues.push_back(values[inputIndex]);
+    }
+
+    return estimateSizeFromSample(rowCount, sampledValues, options);
+  }
+
+  static std::optional<uint64_t> estimateSizeFromSample(
+      uint64_t rowCount,
+      std::span<const physicalType> sampledValues,
+      const Encoding::Options& options = {}) {
+    NIMBLE_CHECK_GT(rowCount, 0, "ALP estimation requires non-empty input.");
+    NIMBLE_CHECK(
+        !sampledValues.empty(), "ALP estimation requires a non-empty sample.");
+    NIMBLE_CHECK_LE(
+        sampledValues.size(),
+        rowCount,
+        "ALP sample size cannot exceed the input row count.");
+
+    const uint64_t sampleSize = sampledValues.size();
 
     std::vector<cppDataType> logicalValues;
     logicalValues.reserve(sampleSize);
-    std::vector<physicalType> sampledValues;
-    sampledValues.reserve(sampleSize);
-    for (uint32_t i = 0; i < sampleSize; ++i) {
-      const auto value = values[sampledValueIndex(i, rowCount, sampleSize)];
+    for (const auto value : sampledValues) {
       logicalValues.push_back(detail::alp::toLogical<cppDataType>(value));
-      sampledValues.push_back(value);
     }
 
     const auto [exponent, factor] = findBestExponentFactor(
@@ -269,7 +337,10 @@ class ALPEncoding final
     uint64_t sampleExceptionCount{0};
     for (auto i = 0; i < sampleSize; ++i) {
       if (!canRepresentExactly(
-              logicalValues[i], sampledValues[i], exponent, factor)) {
+              logicalValues[i],
+              sampledValues[static_cast<size_t>(i)],
+              exponent,
+              factor)) {
         encodedValues.push_back(0);
         ++sampleExceptionCount;
         continue;
@@ -282,19 +353,35 @@ class ALPEncoding final
 
     const auto encodedStats = Statistics<uint64_t>::create(
         std::span<const uint64_t>{encodedValues.data(), encodedValues.size()});
-    // Match existing nested-stream estimators: use FixedBitWidth as a simple
-    // representative estimate instead of recursively modeling nested selection.
-    const uint64_t nestedEncodedValuesSize =
+    // Model the inexpensive scalar candidates without recursively estimating
+    // complex nested encodings.
+    const uint64_t nestedEncodedValuesSize = std::min(
         FixedBitWidthEncoding<uint64_t>::estimateSize(
-            rowCount, encodedStats, options);
+            rowCount, encodedStats, options),
+        TrivialEncoding<uint64_t>::estimateSize(rowCount));
     const uint64_t exceptionCount =
         (sampleExceptionCount * rowCount + sampleSize - 1) / sampleSize;
     const uint64_t exceptionPositionsSize = exceptionCount * sizeof(uint32_t);
     const uint64_t exceptionValuesSize = exceptionCount * sizeof(physicalType);
+    const uint64_t metadataSize = kHeaderSize +
+        (exceptionCount > 0 ? varint::varintSize(exceptionCount) : 0) +
+        varint::varintSize(nestedEncodedValuesSize);
     return Encoding::serializePrefixSize(
                static_cast<uint32_t>(rowCount), options.useVarintRowCount) +
-        kAlpPrefixSize + nestedEncodedValuesSize + exceptionPositionsSize +
+        metadataSize + nestedEncodedValuesSize + exceptionPositionsSize +
         exceptionValuesSize;
+  }
+
+  static uint32_t estimateSampleSize(uint64_t rowCount) {
+    return std::min(static_cast<uint32_t>(rowCount), kSampleSize);
+  }
+
+  /// Maps a dense sample ordinal to an evenly spaced input row.
+  static uint64_t sampledValueIndex(
+      uint32_t sampleIndex,
+      uint64_t rowCount,
+      uint32_t sampleSize) {
+    return sampleIndex * rowCount / sampleSize;
   }
 
   // Pre-computed powers of 10 for double precision.
@@ -306,19 +393,10 @@ class ALPEncoding final
   // Largest exponent and factor values backed by kPow10Double.
   static constexpr int kMaxExponent{23};
   static constexpr int kMaxFactor{23};
-  // ALP prefix: exponent(1) + factor(1) + exceptionCount(4) +
-  // encodedValuesSize(4).
-  static constexpr int kAlpPrefixSize{10};
+  // ALP-specific control word following the standard Encoding prefix.
+  static constexpr uint32_t kHeaderSize{3};
   // Sample up to this many values to find the best (exponent, factor) pair.
   static constexpr uint32_t kSampleSize{1024};
-
-  // Maps a dense sample ordinal to an evenly spaced input row.
-  static uint64_t sampledValueIndex(
-      uint32_t sampleIndex,
-      uint64_t rowCount,
-      uint32_t sampleSize) {
-    return sampleIndex * rowCount / sampleSize;
-  }
 
   // Checks whether the selected ALP transform can encode the value without an
   // exception.
@@ -418,11 +496,11 @@ class ALPEncoding final
 
   void
   patchExceptions(uint32_t startRow, uint32_t rowCount, physicalType* output) {
-    const auto* exPos = reinterpret_cast<const uint32_t*>(exceptionPositions_);
     const auto* exVals =
         reinterpret_cast<const physicalType*>(exceptionValues_);
-    const auto* exBegin = exPos;
-    const auto* exEnd = exPos + exceptionCount_;
+    const auto* exBegin =
+        reinterpret_cast<const uint32_t*>(exceptionPositions_);
+    const auto* exEnd = exBegin + exceptionCount_;
     const auto* first = std::lower_bound(exBegin, exEnd, startRow);
     const auto* last = std::lower_bound(first, exEnd, startRow + rowCount);
     for (auto* it = first; it != last; ++it) {
@@ -432,11 +510,11 @@ class ALPEncoding final
   }
 
   const physicalType* findException(uint32_t row) const {
-    const auto* exPos = reinterpret_cast<const uint32_t*>(exceptionPositions_);
     const auto* exVals =
         reinterpret_cast<const physicalType*>(exceptionValues_);
-    const auto* exBegin = exPos;
-    const auto* exEnd = exPos + exceptionCount_;
+    const auto* exBegin =
+        reinterpret_cast<const uint32_t*>(exceptionPositions_);
+    const auto* exEnd = exBegin + exceptionCount_;
     const auto* it = std::lower_bound(exBegin, exEnd, row);
     if (it == exEnd || *it != row) {
       return nullptr;

--- a/dwio/nimble/encodings/ConstantEncoding.h
+++ b/dwio/nimble/encodings/ConstantEncoding.h
@@ -15,6 +15,7 @@
  */
 #pragma once
 
+#include <algorithm>
 #include <optional>
 #include <span>
 #include "dwio/nimble/common/Buffer.h"
@@ -46,11 +47,14 @@ class ConstantEncodingBase
       : TypedEncoding<T, physicalType>(pool, data, options) {}
 
   static std::optional<uint64_t> estimateSize(
-      const Statistics<physicalType>& statistics) {
-    if (statistics.uniqueCounts().value().size() != 1) {
+      std::span<const physicalType> values,
+      const Statistics<physicalType>& statistics,
+      const Encoding::Options& options) {
+    if (!isConstant(values, statistics)) {
       return std::nullopt;
     }
-    const uint64_t outerEncodingSize = EncodingPrefix::kFixedPrefixSize;
+    const uint64_t outerEncodingSize =
+        Encoding::serializePrefixSize(values.size(), options.useVarintRowCount);
     if constexpr (isStringType<physicalType>()) {
       const uint64_t valueSize = statistics.max().size() + sizeof(uint32_t);
       return outerEncodingSize + valueSize;
@@ -165,7 +169,7 @@ class ConstantEncodingBase
       NIMBLE_INCOMPATIBLE_ENCODING("ConstantEncoding cannot be empty.");
     }
 
-    if (selection.statistics().uniqueCounts().value().size() != 1) {
+    if (!isConstant(values, selection.statistics())) {
       NIMBLE_INCOMPATIBLE_ENCODING("ConstantEncoding requires constant data.");
     }
 
@@ -184,12 +188,41 @@ class ConstantEncodingBase
         rowCount,
         useVarint,
         pos);
-    encoding::write<physicalType>(values[0], pos);
+    encoding::write<physicalType>(canonicalValue(values.front()), pos);
     NIMBLE_DCHECK_EQ(pos - reserved, encodingSize, "Encoding size mismatch.");
     return {reserved, encodingSize};
   }
 
  protected:
+  static bool isConstant(
+      std::span<const physicalType> values,
+      const Statistics<physicalType>& statistics) {
+    NIMBLE_CHECK(
+        !values.empty(), "ConstantEncoding requires non-empty values.");
+    if (values.size() == 1 || statistics.uniqueCounts().value().size() == 1) {
+      return true;
+    }
+    if constexpr (!isFloatingPointType<T>()) {
+      return false;
+    }
+    const auto logicalValue =
+        EncodingPhysicalType<T>::asEncodingLogicalType(values.front());
+    return std::all_of(values.begin(), values.end(), [&](physicalType value) {
+      return EncodingPhysicalType<T>::asEncodingLogicalType(value) ==
+          logicalValue;
+    });
+  }
+
+  static physicalType canonicalValue(physicalType value) {
+    if constexpr (!isFloatingPointType<T>()) {
+      return value;
+    }
+    // Floating-point constant selection uses logical equality; store the
+    // matching canonical physical value.
+    const auto logical = EncodingPhysicalType<T>::asEncodingLogicalType(value);
+    return EncodingPhysicalType<T>::asEncodingPhysicalType(logical);
+  }
+
   physicalType value_;
 };
 

--- a/dwio/nimble/encodings/DictionaryEncoding.h
+++ b/dwio/nimble/encodings/DictionaryEncoding.h
@@ -27,6 +27,7 @@
 #include "dwio/nimble/encodings/common/EncodingType.h"
 #include "dwio/nimble/encodings/selection/EncodingIdentifier.h"
 #include "dwio/nimble/encodings/selection/EncodingSelection.h"
+#include "dwio/nimble/encodings/selection/NestedAlpSizeEstimation.h"
 #include "folly/container/F14Map.h"
 #include "velox/common/memory/Memory.h"
 
@@ -90,10 +91,11 @@ class DictionaryEncoding
       uint64_t rowCount,
       const Statistics<physicalType>& statistics,
       const Encoding::Options& options = {}) {
-    // Assumptions:
-    // Alphabet estimated as min of Trival and bit-packed.
-    // Indices are stored bit-packed, with bit width needed to store max
-    // dictionary index.
+    // Estimate the two nested streams produced by Dictionary:
+    //
+    //   alphabet: unique values. Floating-point alphabets may use ALP when
+    //     nested ALP selection is enabled.
+    //   indices: one dictionary index per row, estimated as FixedBitWidth.
     const auto& uniqueCounts = statistics.uniqueCounts().value();
     const uint64_t uniqueCount = uniqueCounts.size();
     const uint64_t indicesEncodingSize =
@@ -117,6 +119,15 @@ class DictionaryEncoding
           TrivialEncoding<physicalType>::estimateSize(uniqueCount),
           FixedBitWidthEncoding<physicalType>::estimateSize(
               uniqueCount, statistics.min(), statistics.max(), options));
+      // TODO: Consider PFOR after its statistics can be derived from unique
+      // values without rebuilding Statistics for every dictionary estimate.
+      if constexpr (isFloatingPointType<T>()) {
+        if (const auto alpEncodingSize =
+                detail::uniqueValuesNestedAlpSize<T>(uniqueCounts, options)) {
+          alphabetEncodingSize =
+              std::min(alphabetEncodingSize, *alpEncodingSize);
+        }
+      }
     }
     const uint64_t outerEncodingSize =
         EncodingPrefix::kFixedPrefixSize + sizeof(uint32_t);

--- a/dwio/nimble/encodings/MainlyConstantEncoding.h
+++ b/dwio/nimble/encodings/MainlyConstantEncoding.h
@@ -17,6 +17,7 @@
 
 #include <algorithm>
 #include <span>
+#include <vector>
 
 #include <folly/CPortability.h>
 
@@ -24,6 +25,7 @@
 #include "dwio/nimble/common/Exceptions.h"
 #include "dwio/nimble/common/Types.h"
 #include "dwio/nimble/common/Vector.h"
+#include "dwio/nimble/encodings/ConstantEncoding.h"
 #include "dwio/nimble/encodings/DictionaryEncoding.h"
 #include "dwio/nimble/encodings/FixedBitWidthEncoding.h"
 #include "dwio/nimble/encodings/SparseBoolEncoding.h"
@@ -34,6 +36,7 @@
 #include "dwio/nimble/encodings/common/EncodingType.h"
 #include "dwio/nimble/encodings/selection/EncodingIdentifier.h"
 #include "dwio/nimble/encodings/selection/EncodingSelection.h"
+#include "dwio/nimble/encodings/selection/NestedAlpSizeEstimation.h"
 #include "velox/buffer/BufferPool.h"
 #include "velox/common/Casts.h"
 #include "velox/common/base/SimdUtil.h"
@@ -147,10 +150,11 @@ class MainlyConstantEncodingBase
       return outerEncodingSize + otherValuesSize + isCommonEncodingSize;
     } else {
       const uint64_t commonValueSize = sizeof(physicalType);
-      // Other values are encoded as a FixedBitWidth child.
-      const uint64_t otherValuesSize =
-          FixedBitWidthEncoding<physicalType>::estimateSize(
-              uncommonCount, statistics.min(), statistics.max(), options);
+      const uint64_t otherValuesSize = estimateOtherValuesSize(
+          uniqueCounts,
+          /*commonValue=*/maxUniqueCount->first,
+          uncommonCount,
+          options);
       const uint64_t outerEncodingSize = EncodingPrefix::kFixedPrefixSize +
           2 * sizeof(uint32_t) + commonValueSize;
       return outerEncodingSize + otherValuesSize + isCommonEncodingSize;
@@ -562,6 +566,59 @@ class MainlyConstantEncodingBase
         });
   }
 
+  template <typename UniqueCounts>
+  static uint64_t estimateOtherValuesSize(
+      const UniqueCounts& uniqueCounts,
+      const physicalType& commonValue,
+      uint64_t uncommonCount,
+      const Encoding::Options& options) {
+    std::vector<physicalType> otherValues;
+    otherValues.reserve(uncommonCount);
+    for (const auto& uniqueCount : uniqueCounts) {
+      if (uniqueCount.first == commonValue) {
+        continue;
+      }
+      otherValues.insert(
+          otherValues.end(), uniqueCount.second, uniqueCount.first);
+    }
+
+    if (otherValues.empty()) {
+      return TrivialEncoding<physicalType>::estimateSize(0);
+    }
+
+    // Removing the common value can change the child stream's range and value
+    // distribution, so estimate its candidates from the actual other values.
+    const auto otherStats = Statistics<physicalType>::create(
+        std::span<const physicalType>{otherValues.data(), otherValues.size()});
+
+    uint64_t estimatedSize = std::min({
+        FixedBitWidthEncoding<physicalType>::estimateSize(
+            otherValues.size(), otherStats.min(), otherStats.max(), options),
+        TrivialEncoding<physicalType>::estimateSize(otherValues.size()),
+        DictionaryEncoding<T>::estimateSize(
+            otherValues.size(), otherStats, options),
+    });
+
+    const auto constantSize = ConstantEncoding<T>::estimateSize(
+        std::span<const physicalType>{otherValues.data(), otherValues.size()},
+        otherStats,
+        options);
+    if (constantSize.has_value()) {
+      estimatedSize = std::min(estimatedSize, constantSize.value());
+    }
+
+    if constexpr (isFloatingPointType<T>()) {
+      if (const auto alpEncodingSize = detail::nestedAlpSize<T>(
+              std::span<const physicalType>{
+                  otherValues.data(), otherValues.size()},
+              options)) {
+        estimatedSize = std::min(estimatedSize, *alpEncodingSize);
+      }
+    }
+
+    return estimatedSize;
+  }
+
   // Encode-time child streams: isCommon spans all input rows, while
   // otherValues contains only rows that differ from the common value.
   struct ChildStreams {
@@ -602,6 +659,41 @@ class MainlyConstantEncodingBase
         uncommonCount,
         "Unexpected uncommon value count.");
     return streams;
+  }
+
+  static std::string_view encodeOtherValues(
+      EncodingSelection<physicalType>& selection,
+      std::span<const physicalType> otherValues,
+      Buffer& buffer,
+      const Encoding::Options& options = {}) {
+    if constexpr (!isFloatingPointType<T>()) {
+      return selection.template encodeNested<physicalType>(
+          EncodingIdentifiers::MainlyConstant::OtherValues,
+          otherValues,
+          buffer,
+          options);
+    } else {
+      Vector<T> logicalOtherValues{&buffer.getMemoryPool()};
+      logicalOtherValues.resize(otherValues.size());
+      for (uint32_t i = 0; i < otherValues.size(); ++i) {
+        logicalOtherValues[i] =
+            EncodingPhysicalType<T>::asEncodingLogicalType(otherValues[i]);
+      }
+
+      auto nestedPolicy = std::unique_ptr<EncodingSelectionPolicy<T>>(
+          static_cast<EncodingSelectionPolicy<T>*>(
+              selection
+                  .template createNestedPolicy<T>(
+                      selection.encodingType(),
+                      EncodingIdentifiers::MainlyConstant::OtherValues)
+                  .release()));
+      return EncodingFactory::encode<T>(
+          std::move(nestedPolicy),
+          std::span<const T>{
+              logicalOtherValues.data(), logicalOtherValues.size()},
+          buffer,
+          options);
+    }
   }
 
   // Counts unset bits across all words. Caller must mask tail bits
@@ -739,11 +831,8 @@ std::string_view MainlyConstantEncoding<T>::encode(
       scopedBuffer.get(),
       options);
   std::string_view serializedOtherValues =
-      selection.template encodeNested<physicalType>(
-          EncodingIdentifiers::MainlyConstant::OtherValues,
-          childStreams.otherValues,
-          scopedBuffer.get(),
-          options);
+      MainlyConstantEncodingBase<T>::encodeOtherValues(
+          selection, childStreams.otherValues, scopedBuffer.get(), options);
 
   uint32_t encodingSize = Encoding::serializePrefixSize(entryCount, useVarint) +
       8 + serializedIsCommon.size() + serializedOtherValues.size();

--- a/dwio/nimble/encodings/RLEEncoding.h
+++ b/dwio/nimble/encodings/RLEEncoding.h
@@ -15,7 +15,9 @@
  */
 #pragma once
 
+#include <algorithm>
 #include <span>
+#include <vector>
 
 #include "dwio/nimble/common/Buffer.h"
 #include "dwio/nimble/common/FixedBitArray.h"
@@ -30,6 +32,7 @@
 #include "dwio/nimble/encodings/common/EncodingType.h"
 #include "dwio/nimble/encodings/selection/EncodingIdentifier.h"
 #include "dwio/nimble/encodings/selection/EncodingSelection.h"
+#include "dwio/nimble/encodings/selection/NestedAlpSizeEstimation.h"
 #include "velox/common/base/SimdUtil.h"
 
 // Holds data in RLE format. Consecutive equal values are collapsed into runs:
@@ -50,11 +53,16 @@ namespace facebook::nimble {
 
 namespace rle {
 
-template <typename T>
+/// Builds run lengths and applies `transform` to each run's representative
+/// input value before storing it in `runValues`. This allows floating-point
+/// physical values to be converted back to their logical type for nested
+/// encoding.
+template <typename T, typename RunValue, typename Transform>
 void computeRuns(
     std::span<const T> data,
     Vector<uint32_t>* runLengths,
-    Vector<T>* runValues) {
+    Vector<RunValue>* runValues,
+    Transform transform) {
   static_assert(!std::is_floating_point_v<T>);
   if (data.empty()) {
     return;
@@ -66,13 +74,21 @@ void computeRuns(
       ++runLength;
     } else {
       runLengths->push_back(runLength);
-      runValues->push_back(last);
+      runValues->push_back(transform(last));
       last = data[i];
       runLength = 1;
     }
   }
   runLengths->push_back(runLength);
-  runValues->push_back(last);
+  runValues->push_back(transform(last));
+}
+
+template <typename T>
+void computeRuns(
+    std::span<const T> data,
+    Vector<uint32_t>* runLengths,
+    Vector<T>* runValues) {
+  computeRuns(data, runLengths, runValues, [](const T value) { return value; });
 }
 
 } // namespace rle
@@ -167,19 +183,33 @@ class RLEEncodingBase
     const uint32_t valueCount = values.size();
     auto* pool = &buffer.getMemoryPool();
     Vector<uint32_t> runLengths(pool);
-    Vector<physicalType> runValues(pool);
-    rle::computeRuns(values, &runLengths, &runValues);
-
     ScopedEncodingBuffer scopedBuffer{pool, options.encodingBufferPool};
-    std::string_view serializedRunLengths =
-        selection.template encodeNested<uint32_t>(
-            EncodingIdentifiers::RunLength::RunLengths,
-            runLengths,
-            scopedBuffer.get(),
-            options);
-
-    std::string_view serializedRunValues = getSerializedRunValues(
-        selection, runValues, scopedBuffer.get(), options);
+    std::string_view serializedRunLengths;
+    std::string_view serializedRunValues;
+    if constexpr (isFloatingPointType<T>()) {
+      Vector<T> logicalRunValues(pool);
+      rle::computeRuns(
+          values, &runLengths, &logicalRunValues, [](const physicalType value) {
+            return EncodingPhysicalType<T>::asEncodingLogicalType(value);
+          });
+      serializedRunLengths = selection.template encodeNested<uint32_t>(
+          EncodingIdentifiers::RunLength::RunLengths,
+          runLengths,
+          scopedBuffer.get(),
+          options);
+      serializedRunValues = RLEEncoding::getSerializedLogicalRunValues(
+          selection, logicalRunValues, scopedBuffer.get(), options);
+    } else {
+      Vector<physicalType> runValues(pool);
+      rle::computeRuns(values, &runLengths, &runValues);
+      serializedRunLengths = selection.template encodeNested<uint32_t>(
+          EncodingIdentifiers::RunLength::RunLengths,
+          runLengths,
+          scopedBuffer.get(),
+          options);
+      serializedRunValues = getSerializedPhysicalRunValues(
+          selection, runValues, scopedBuffer.get(), options);
+    }
 
     const uint32_t encodingSize =
         Encoding::serializePrefixSize(valueCount, useVarint) + 4 +
@@ -221,12 +251,12 @@ class RLEEncodingBase
     advanceRunValue();
   }
 
-  static std::string_view getSerializedRunValues(
+  static std::string_view getSerializedPhysicalRunValues(
       EncodingSelection<physicalType>& selection,
       const Vector<physicalType>& runValues,
       Buffer& buffer,
       const Encoding::Options& options = {}) {
-    return RLEEncoding::getSerializedRunValues(
+    return RLEEncoding::getSerializedPhysicalRunValues(
         selection, runValues, buffer, options);
   }
 
@@ -273,11 +303,32 @@ class RLEEncoding final : public internal::RLEEncodingBase<T, RLEEncoding<T>> {
 
   void resetValues();
 
-  static std::string_view getSerializedRunValues(
+  static std::string_view getSerializedLogicalRunValues(
+      EncodingSelection<physicalType>& selection,
+      const Vector<T>& logicalRunValues,
+      Buffer& buffer,
+      const Encoding::Options& options = {}) {
+    static_assert(isFloatingPointType<T>());
+    auto nestedPolicy = std::unique_ptr<EncodingSelectionPolicy<T>>(
+        static_cast<EncodingSelectionPolicy<T>*>(
+            selection
+                .template createNestedPolicy<T>(
+                    selection.encodingType(),
+                    EncodingIdentifiers::RunLength::RunValues)
+                .release()));
+    return EncodingFactory::encode<T>(
+        std::move(nestedPolicy),
+        std::span<const T>{logicalRunValues.data(), logicalRunValues.size()},
+        buffer,
+        options);
+  }
+
+  static std::string_view getSerializedPhysicalRunValues(
       EncodingSelection<physicalType>& selection,
       const Vector<physicalType>& runValues,
       Buffer& buffer,
       const Encoding::Options& options = {}) {
+    static_assert(!isFloatingPointType<T>());
     return selection.template encodeNested<physicalType>(
         EncodingIdentifiers::RunLength::RunValues, runValues, buffer, options);
   }
@@ -379,7 +430,7 @@ class RLEEncoding final : public internal::RLEEncodingBase<T, RLEEncoding<T>> {
   }
 
   static uint64_t estimateSize(
-      uint64_t /*rowCount*/,
+      uint64_t rowCount,
       const Statistics<physicalType>& statistics,
       const Encoding::Options& options = {}) {
     // Estimate the two nested streams produced by RLE:
@@ -395,25 +446,39 @@ class RLEEncoding final : public internal::RLEEncodingBase<T, RLEEncoding<T>> {
         FixedBitWidthEncoding<uint32_t>::estimateSize(
             runCount, statistics.minRepeat(), statistics.maxRepeat(), options);
 
-    uint64_t runValuesEncodingSize{0};
-    if constexpr (isStringType<physicalType>()) {
-      // String run values often repeat across non-adjacent runs, so estimate
-      // them as Dictionary: unique strings in the alphabet plus one index per
-      // run.
-      runValuesEncodingSize =
-          DictionaryEncoding<std::string_view>::estimateSize(
-              runCount, statistics, options);
-    } else {
-      // Run values are encoded as a FixedBitWidth child.
-      runValuesEncodingSize = FixedBitWidthEncoding<physicalType>::estimateSize(
-          runCount, statistics, options);
-    }
+    const uint64_t runValuesEncodingSize =
+        estimateRunValuesSize(runCount, statistics, options);
     const uint64_t outerEncodingSize =
         EncodingPrefix::kFixedPrefixSize + sizeof(uint32_t);
     return outerEncodingSize + runValuesEncodingSize + runLengthsEncodingSize;
   }
 
  private:
+  static uint64_t estimateRunValuesSize(
+      uint64_t runCount,
+      const Statistics<physicalType>& statistics,
+      const Encoding::Options& options) {
+    if constexpr (isStringType<physicalType>()) {
+      return DictionaryEncoding<std::string_view>::estimateSize(
+          runCount, statistics, options);
+    } else {
+      uint64_t bestSize = FixedBitWidthEncoding<physicalType>::estimateSize(
+          runCount, statistics, options);
+      if constexpr (isFloatingPointType<T>()) {
+        if (options.allowNestedAlpSelection) {
+          const auto& runValues = statistics.runValues();
+          if (const auto alpEncodingSize = detail::nestedAlpSize<T>(
+                  std::span<const physicalType>{
+                      runValues.data(), runValues.size()},
+                  options)) {
+            bestSize = std::min(bestSize, *alpEncodingSize);
+          }
+        }
+      }
+      return bestSize;
+    }
+  }
+
   using internal::RLEEncodingBase<T, RLEEncoding<T>>::advanceRunLength;
 
   void advanceRunValue();
@@ -470,7 +535,7 @@ class RLEEncoding<bool> final
 
   bool nextValue();
   void resetValues();
-  static std::string_view getSerializedRunValues(
+  static std::string_view getSerializedPhysicalRunValues(
       EncodingSelection<bool>& /* selection */,
       const Vector<bool>& runValues,
       Buffer& buffer,

--- a/dwio/nimble/encodings/common/EncodingLayout.cpp
+++ b/dwio/nimble/encodings/common/EncodingLayout.cpp
@@ -18,6 +18,8 @@
 #include <memory>
 #include <vector>
 #include "dwio/nimble/common/Exceptions.h"
+#include "dwio/nimble/common/Varint.h"
+#include "dwio/nimble/encodings/ALPEncoding.h"
 #include "dwio/nimble/encodings/FsstEncoding.h"
 #include "dwio/nimble/encodings/common/EncodingPrimitives.h"
 #include "dwio/nimble/encodings/common/EncodingUtils.h"
@@ -197,10 +199,11 @@ EncodingLayout EncodingLayoutCapture::capture(std::string_view encoding) {
       break;
     case EncodingType::ALP: {
       const char* pos = encoding.data() + kEncodingPrefixSize;
-      encoding::read<uint8_t>(pos); // exponent
-      encoding::read<uint8_t>(pos); // factor
-      encoding::readUint32(pos); // exceptionCount
-      const uint32_t encodedValuesBytes = encoding::readUint32(pos);
+      const auto header = detail::alp::readHeader(pos);
+      if (header.hasExceptions) {
+        varint::readVarint32(&pos); // exceptionCount
+      }
+      const uint32_t encodedValuesBytes = varint::readVarint32(&pos);
 
       children.reserve(1);
       children.emplace_back(

--- a/dwio/nimble/encodings/selection/EncodingSelectionPolicy.h
+++ b/dwio/nimble/encodings/selection/EncodingSelectionPolicy.h
@@ -126,7 +126,9 @@ class ManualEncodingSelectionPolicy : public EncodingSelectionPolicy<T> {
     // selection.
     if constexpr (isFloatingPointType<T>()) {
       if (options.allowNestedAlpSelection &&
-          identifier_ == EncodingIdentifiers::Dictionary::Alphabet &&
+          (identifier_ == EncodingIdentifiers::Dictionary::Alphabet ||
+           identifier_ == EncodingIdentifiers::MainlyConstant::OtherValues ||
+           identifier_ == EncodingIdentifiers::RunLength::RunValues) &&
           std::none_of(
               candidateEncodingReadFactors.begin(),
               candidateEncodingReadFactors.end(),

--- a/dwio/nimble/encodings/selection/EncodingSizeEstimation.h
+++ b/dwio/nimble/encodings/selection/EncodingSizeEstimation.h
@@ -69,10 +69,9 @@ struct EncodingSizeEstimation {
     if constexpr (isNumericType<physicalType>()) {
       return estimateNumericSize(encodingType, values, statistics, options);
     } else if constexpr (isBoolType<physicalType>()) {
-      return estimateBoolSize(encodingType, values.size(), statistics, options);
+      return estimateBoolSize(encodingType, values, statistics, options);
     } else if constexpr (isStringType<physicalType>()) {
-      return estimateStringSize(
-          encodingType, values.size(), statistics, options);
+      return estimateStringSize(encodingType, values, statistics, options);
     }
 
     NIMBLE_UNREACHABLE(
@@ -87,13 +86,13 @@ struct EncodingSizeEstimation {
       const Encoding::Options& options) {
     switch (encodingType) {
       case EncodingType::Constant: {
-        return ConstantEncoding<physicalType>::estimateSize(statistics);
+        return std::nullopt;
       }
       case EncodingType::MainlyConstant: {
         // TODO: Wire per-block tightening when BlockBitPacking is a
         // candidate. MainlyConstantEncoding::estimateSize already supports
         // usePerBlockStats + blockSize params.
-        return MainlyConstantEncoding<physicalType>::estimateSize(
+        return MainlyConstantEncoding<T>::estimateSize(
             entryCount, statistics, options);
       }
       case EncodingType::Trivial: {
@@ -107,12 +106,11 @@ struct EncodingSizeEstimation {
         // TODO: Wire per-block tightening when BlockBitPacking is a
         // candidate. DictionaryEncoding::estimateSize already supports
         // usePerBlockStats + blockSize params.
-        return DictionaryEncoding<physicalType>::estimateSize(
+        return DictionaryEncoding<T>::estimateSize(
             entryCount, statistics, options);
       }
       case EncodingType::RLE: {
-        return RLEEncoding<physicalType>::estimateSize(
-            entryCount, statistics, options);
+        return RLEEncoding<T>::estimateSize(entryCount, statistics, options);
       }
       case EncodingType::Varint: {
         // Note: the condition below actually support floating point numbers as
@@ -162,6 +160,9 @@ struct EncodingSizeEstimation {
       const Statistics<physicalType>& statistics,
       const Encoding::Options& options) {
     switch (encodingType) {
+      case EncodingType::Constant: {
+        return ConstantEncoding<T>::estimateSize(values, statistics, options);
+      }
       case EncodingType::ALP: {
         if constexpr (isFloatingPointType<T>()) {
           return ALPEncoding<T>::estimateSize(values, options);
@@ -183,7 +184,7 @@ struct EncodingSizeEstimation {
       const Encoding::Options& options) {
     switch (encodingType) {
       case EncodingType::Constant: {
-        return ConstantEncoding<bool>::estimateSize(statistics);
+        return std::nullopt;
       }
       case EncodingType::SparseBool: {
         return SparseBoolEncoding::estimateSize(
@@ -201,6 +202,23 @@ struct EncodingSizeEstimation {
     }
   }
 
+  static std::optional<uint64_t> estimateBoolSize(
+      const EncodingType encodingType,
+      std::span<const physicalType> values,
+      const Statistics<physicalType>& statistics,
+      const Encoding::Options& options) {
+    switch (encodingType) {
+      case EncodingType::Constant: {
+        return ConstantEncoding<bool>::estimateSize(
+            values, statistics, options);
+      }
+      default: {
+        return estimateBoolSize(
+            encodingType, values.size(), statistics, options);
+      }
+    }
+  }
+
   static std::optional<uint64_t> estimateStringSize(
       const EncodingType encodingType,
       const size_t entryCount,
@@ -208,7 +226,7 @@ struct EncodingSizeEstimation {
       const Encoding::Options& options) {
     switch (encodingType) {
       case EncodingType::Constant: {
-        return ConstantEncoding<std::string_view>::estimateSize(statistics);
+        return std::nullopt;
       }
       case EncodingType::MainlyConstant: {
         return MainlyConstantEncoding<std::string_view>::estimateSize(
@@ -231,6 +249,23 @@ struct EncodingSizeEstimation {
       }
       default: {
         return std::nullopt;
+      }
+    }
+  }
+
+  static std::optional<uint64_t> estimateStringSize(
+      const EncodingType encodingType,
+      std::span<const physicalType> values,
+      const Statistics<std::string_view>& statistics,
+      const Encoding::Options& options) {
+    switch (encodingType) {
+      case EncodingType::Constant: {
+        return ConstantEncoding<std::string_view>::estimateSize(
+            values, statistics, options);
+      }
+      default: {
+        return estimateStringSize(
+            encodingType, values.size(), statistics, options);
       }
     }
   }

--- a/dwio/nimble/encodings/selection/NestedAlpSizeEstimation.h
+++ b/dwio/nimble/encodings/selection/NestedAlpSizeEstimation.h
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <optional>
+#include <span>
+#include <vector>
+#include "dwio/nimble/common/Types.h"
+#include "dwio/nimble/encodings/ALPEncoding.h"
+#include "dwio/nimble/encodings/common/Encoding.h"
+
+namespace facebook::nimble::detail {
+
+/// Estimates the nested ALP size from all physical values when `T` is a
+/// floating-point type and nested ALP selection is enabled. Returns
+/// `std::nullopt` when nested ALP is not eligible.
+template <typename T>
+std::optional<uint64_t> nestedAlpSize(
+    std::span<const typename TypeTraits<T>::physicalType> values,
+    const Encoding::Options& options) {
+  static_assert(
+      isFloatingPointType<T>(),
+      "nestedAlpSize only supports floating-point logical types.");
+  if (!options.allowNestedAlpSelection) {
+    return std::nullopt;
+  }
+  return ALPEncoding<T>::estimateSize(values, options);
+}
+
+/// Estimates the nested ALP size by sampling the distinct physical values in
+/// `uniqueCounts`. Returns `std::nullopt` when nested ALP is not eligible or
+/// there are no values to sample.
+template <typename T, typename UniqueCounts>
+std::optional<uint64_t> uniqueValuesNestedAlpSize(
+    const UniqueCounts& uniqueCounts,
+    const Encoding::Options& options) {
+  static_assert(
+      isFloatingPointType<T>(),
+      "uniqueValuesNestedAlpSize only supports floating-point logical types.");
+  if (!options.allowNestedAlpSelection) {
+    return std::nullopt;
+  }
+  if (uniqueCounts.size() == 0) {
+    return std::nullopt;
+  }
+
+  using physicalType = typename TypeTraits<T>::physicalType;
+  const uint64_t uniqueCount = uniqueCounts.size();
+  const uint32_t sampleSize = ALPEncoding<T>::estimateSampleSize(uniqueCount);
+  std::vector<physicalType> sampledValues;
+  sampledValues.reserve(sampleSize);
+  for (const auto& [value, count] : uniqueCounts) {
+    (void)count;
+    sampledValues.push_back(value);
+    if (sampledValues.size() == sampleSize) {
+      break;
+    }
+  }
+  return ALPEncoding<T>::estimateSizeFromSample(
+      uniqueCount, sampledValues, options);
+}
+
+} // namespace facebook::nimble::detail

--- a/dwio/nimble/encodings/selection/Statistics.cpp
+++ b/dwio/nimble/encodings/selection/Statistics.cpp
@@ -128,7 +128,7 @@ uint64_t countTrueValues(std::span<const bool> values) {
 } // namespace
 
 template <typename T, typename InputType>
-void Statistics<T, InputType>::populateRepeats() const {
+void Statistics<T, InputType>::populateRepeats(bool collectRunValues) const {
   uint64_t consecutiveRepeatCount = 0;
   uint64_t minRepeat = std::numeric_limits<uint64_t>::max();
   uint64_t maxRepeat = 0;
@@ -140,6 +140,10 @@ void Statistics<T, InputType>::populateRepeats() const {
 
   T currentValue = data_[0];
   uint64_t currentRepeat = 0;
+  std::vector<T> runValues;
+  if (collectRunValues) {
+    runValues.push_back(currentValue);
+  }
 
   for (auto i = 0; i < data_.size(); ++i) {
     const auto& value = data_[i];
@@ -160,6 +164,9 @@ void Statistics<T, InputType>::populateRepeats() const {
 
       currentRepeat = 1;
       currentValue = value;
+      if (collectRunValues) {
+        runValues.push_back(currentValue);
+      }
       ++consecutiveRepeatCount;
     }
   }
@@ -177,6 +184,9 @@ void Statistics<T, InputType>::populateRepeats() const {
   maxRepeat_ = maxRepeat;
   consecutiveRepeatCount_ = consecutiveRepeatCount;
   totalStringsRepeatLength_ = totalRepeatLength;
+  if (collectRunValues) {
+    runValues_ = std::move(runValues);
+  }
 }
 
 template <typename T, typename InputType>
@@ -340,20 +350,20 @@ Statistics<std::string_view, std::string>::create(
     std::span<const std::string> data);
 
 // populateRepeats works on all types
-template void Statistics<int8_t>::populateRepeats() const;
-template void Statistics<uint8_t>::populateRepeats() const;
-template void Statistics<int16_t>::populateRepeats() const;
-template void Statistics<uint16_t>::populateRepeats() const;
-template void Statistics<int32_t>::populateRepeats() const;
-template void Statistics<uint32_t>::populateRepeats() const;
-template void Statistics<int64_t>::populateRepeats() const;
-template void Statistics<uint64_t>::populateRepeats() const;
-template void Statistics<float>::populateRepeats() const;
-template void Statistics<double>::populateRepeats() const;
-template void Statistics<bool>::populateRepeats() const;
-template void Statistics<std::string_view>::populateRepeats() const;
-template void Statistics<std::string_view, std::string>::populateRepeats()
-    const;
+template void Statistics<int8_t>::populateRepeats(bool) const;
+template void Statistics<uint8_t>::populateRepeats(bool) const;
+template void Statistics<int16_t>::populateRepeats(bool) const;
+template void Statistics<uint16_t>::populateRepeats(bool) const;
+template void Statistics<int32_t>::populateRepeats(bool) const;
+template void Statistics<uint32_t>::populateRepeats(bool) const;
+template void Statistics<int64_t>::populateRepeats(bool) const;
+template void Statistics<uint64_t>::populateRepeats(bool) const;
+template void Statistics<float>::populateRepeats(bool) const;
+template void Statistics<double>::populateRepeats(bool) const;
+template void Statistics<bool>::populateRepeats(bool) const;
+template void Statistics<std::string_view>::populateRepeats(bool) const;
+template void Statistics<std::string_view, std::string>::populateRepeats(
+    bool) const;
 
 // populateUniques works on all types
 template void Statistics<int8_t>::populateUniques() const;

--- a/dwio/nimble/encodings/selection/Statistics.h
+++ b/dwio/nimble/encodings/selection/Statistics.h
@@ -196,6 +196,32 @@ class Statistics {
     return uniqueCounts_.value();
   }
 
+  /// Returns one value per consecutive run in input order. The sequence is
+  /// computed lazily and cached independently from aggregate repeat metrics.
+  const std::vector<T>& runValues() const {
+    if (runValues_.has_value()) {
+      return runValues_.value();
+    }
+    if (!consecutiveRepeatCount_.has_value()) {
+      populateRepeats(/*collectRunValues=*/true);
+      return runValues_.value();
+    }
+
+    std::vector<T> values;
+    if (!data_.empty()) {
+      values.reserve(consecutiveRepeatCount());
+      T last = data_.front();
+      values.push_back(last);
+      for (size_t i = 1; i < data_.size(); ++i) {
+        if (data_[i] != last) {
+          last = data_[i];
+          values.push_back(last);
+        }
+      }
+    }
+    return runValues_.emplace(std::move(values));
+  }
+
   struct BlockStats {
     uint64_t count;
     uint64_t min;
@@ -255,7 +281,7 @@ class Statistics {
     std::vector<BlockStats> result_;
   };
 
-  void populateRepeats() const;
+  void populateRepeats(bool collectRunValues = false) const;
   void populateUniques() const;
   void populateMinMax() const;
   void populateBucketCounts() const;
@@ -274,6 +300,7 @@ class Statistics {
   mutable uint16_t minMaxBlockSize_{0};
   mutable std::optional<std::optional<UniqueValueCounts<T, InputType>>>
       uniqueCounts_;
+  mutable std::optional<std::vector<T>> runValues_;
 };
 
 } // namespace facebook::nimble

--- a/dwio/nimble/encodings/tests/ALPEncodingTest.cpp
+++ b/dwio/nimble/encodings/tests/ALPEncodingTest.cpp
@@ -95,6 +95,46 @@ nimble::EncodingSelectionPolicyCreator unusedNestedPolicyCreator() {
   };
 }
 
+TEST(ALPSizeEstimationTest, invalidSampleRejected) {
+  const std::vector<uint32_t> sample = {0, 1};
+
+  NIMBLE_ASSERT_THROW(
+      nimble::ALPEncoding<float>::estimateSizeFromSample(
+          /*rowCount=*/0, std::span<const uint32_t>{sample.data(), 1}),
+      "ALP estimation requires non-empty input.");
+  NIMBLE_ASSERT_THROW(
+      nimble::ALPEncoding<float>::estimateSizeFromSample(
+          /*rowCount=*/1, std::span<const uint32_t>{}),
+      "ALP estimation requires a non-empty sample.");
+  NIMBLE_ASSERT_THROW(
+      nimble::ALPEncoding<float>::estimateSizeFromSample(
+          /*rowCount=*/1, sample),
+      "ALP sample size cannot exceed the input row count.");
+}
+
+TEST(ALPEncodingHeaderTest, compactControlWordRoundTrip) {
+  std::array<char, 3> serialized{};
+  char* writePosition = serialized.data();
+  nimble::detail::alp::writeHeader(
+      nimble::detail::alp::Header{
+          .exponent = 23, .factor = 17, .hasExceptions = true},
+      writePosition);
+
+  const std::array<char, 3> expected = {
+      static_cast<char>(0x37),
+      static_cast<char>(0x02),
+      static_cast<char>(0x01)};
+  EXPECT_EQ(serialized, expected);
+  EXPECT_EQ(writePosition, serialized.data() + serialized.size());
+
+  const char* readPosition = serialized.data();
+  const auto header = nimble::detail::alp::readHeader(readPosition);
+  EXPECT_EQ(header.exponent, 23);
+  EXPECT_EQ(header.factor, 17);
+  EXPECT_TRUE(header.hasExceptions);
+  EXPECT_EQ(readPosition, serialized.data() + serialized.size());
+}
+
 template <typename D>
 nimble::Vector<D> makeRandomDecimalValues(
     velox::memory::MemoryPool* pool,
@@ -260,6 +300,50 @@ TYPED_TEST(ALPEncodingTest, roundTrip) {
   }
 }
 
+TYPED_TEST(ALPEncodingTest, headerMetadataUsesVarints) {
+  using D = typename TypeParam::data_type;
+  const nimble::Encoding::Options options{
+      .useVarintRowCount = TypeParam::useVarint,
+      .fixedBitWidthUseExactBits = true};
+
+  nimble::Vector<D> values{this->pool_.get(), 200};
+  values.fill(D{1.25});
+  values[150] = std::numeric_limits<D>::infinity();
+  const auto serialized = encodeWithLayout<D>(
+      *this->buffer_, values, alpWithFixedBitWidthPayloadLayout(), options);
+
+  const char* pos = serialized.data() +
+      nimble::EncodingPrefix::readPrefixSize(
+                        serialized, options.useVarintRowCount);
+  const auto header = nimble::detail::alp::readHeader(pos);
+  EXPECT_TRUE(header.hasExceptions);
+
+  const auto* exceptionCountStart = pos;
+  EXPECT_EQ(nimble::varint::readVarint32(&pos), 1);
+  EXPECT_EQ(pos - exceptionCountStart, 1);
+
+  const auto* encodedValuesSizeStart = pos;
+  const auto encodedValuesSize = nimble::varint::readVarint32(&pos);
+  EXPECT_EQ(
+      pos - encodedValuesSizeStart,
+      nimble::varint::varintSize(encodedValuesSize));
+  pos += encodedValuesSize;
+
+  const auto* exceptionPositionStart = pos;
+  EXPECT_EQ(nimble::encoding::readUint32(pos), 150);
+  EXPECT_EQ(pos - exceptionPositionStart, sizeof(uint32_t));
+
+  std::vector<velox::BufferPtr> stringBuffers;
+  auto encoding =
+      createEncoding(this->pool_.get(), serialized, options, stringBuffers);
+  nimble::Vector<D> result{this->pool_.get(), values.size()};
+  encoding->materialize(values.size(), result.data());
+  for (uint32_t i = 0; i < values.size(); ++i) {
+    SCOPED_TRACE(i);
+    EXPECT_TRUE(nimble::NimbleCompare<D>::equals(result[i], values[i]));
+  }
+}
+
 TYPED_TEST(ALPEncodingTest, roundTripSignedDecimals) {
   using D = typename TypeParam::data_type;
   const nimble::Encoding::Options options{
@@ -415,6 +499,160 @@ TYPED_TEST(ALPEncodingTest, dictionaryAlphabetUsesNestedAlpWhenEnabled) {
            nimble::DataType::Uint64,
            "EncodedValues"},
           {nimble::EncodingType::Trivial, nimble::DataType::Uint32, "Indices"},
+      };
+  EXPECT_EQ(actual, expected);
+
+  std::vector<velox::BufferPtr> stringBuffers;
+  const auto stringBufferFactory = [&](uint32_t totalLength) {
+    auto& buf = stringBuffers.emplace_back(
+        velox::AlignedBuffer::allocate<char>(totalLength, this->pool_.get()));
+    return buf->template asMutable<void>();
+  };
+  auto encoding = nimble::EncodingFactory(options).create(
+      *this->pool_, serialized, stringBufferFactory);
+
+  nimble::Vector<D> result(this->pool_.get(), values.size());
+  encoding->materialize(values.size(), result.data());
+
+  for (uint32_t i = 0; i < values.size(); ++i) {
+    SCOPED_TRACE(fmt::format("i={}", i));
+    EXPECT_TRUE(nimble::NimbleCompare<D>::equals(result[i], values[i]));
+  }
+}
+
+TYPED_TEST(ALPEncodingTest, rleRunValuesUseNestedAlpWhenEnabled) {
+  using D = typename TypeParam::data_type;
+  const nimble::Encoding::Options options{
+      .useVarintRowCount = false,
+      .fixedBitWidthUseExactBits = true,
+      .allowNestedAlpSelection = true};
+
+  nimble::Vector<D> values{this->pool_.get()};
+  for (auto i = 0; i < 128; ++i) {
+    const auto value = static_cast<D>((i % 17) - 8) / static_cast<D>(4);
+    values.push_back(value);
+    values.push_back(value);
+    values.push_back(value);
+  }
+
+  auto policy = std::make_unique<nimble::ManualEncodingSelectionPolicy<D>>(
+      std::vector<std::pair<nimble::EncodingType, float>>{
+          {nimble::EncodingType::RLE, 1.0},
+      },
+      std::nullopt,
+      std::nullopt);
+
+  const auto serialized = nimble::EncodingFactory::encode<D>(
+      std::move(policy),
+      std::span<const D>{values.data(), values.size()},
+      *this->buffer_,
+      options);
+
+  std::vector<std::tuple<nimble::EncodingType, nimble::DataType, std::string>>
+      actual;
+  nimble::tools::traverseEncodings(
+      serialized,
+      [&](auto encodingType,
+          auto dataType,
+          auto /* level */,
+          auto /* index */,
+          auto nestedEncodingName,
+          std::unordered_map<
+              nimble::tools::EncodingPropertyType,
+              nimble::tools::EncodingProperty> /* properties */) {
+        actual.emplace_back(encodingType, dataType, nestedEncodingName);
+        return true;
+      });
+
+  const std::vector<
+      std::tuple<nimble::EncodingType, nimble::DataType, std::string>>
+      expected{
+          {nimble::EncodingType::RLE, nimble::TypeTraits<D>::dataType, ""},
+          {nimble::EncodingType::Trivial, nimble::DataType::Uint32, "Lengths"},
+          {nimble::EncodingType::ALP,
+           nimble::TypeTraits<D>::dataType,
+           "Values"},
+          {nimble::EncodingType::Trivial,
+           nimble::DataType::Uint64,
+           "EncodedValues"},
+      };
+  EXPECT_EQ(actual, expected);
+
+  std::vector<velox::BufferPtr> stringBuffers;
+  const auto stringBufferFactory = [&](uint32_t totalLength) {
+    auto& buf = stringBuffers.emplace_back(
+        velox::AlignedBuffer::allocate<char>(totalLength, this->pool_.get()));
+    return buf->template asMutable<void>();
+  };
+  auto encoding = nimble::EncodingFactory(options).create(
+      *this->pool_, serialized, stringBufferFactory);
+
+  nimble::Vector<D> result(this->pool_.get(), values.size());
+  encoding->materialize(values.size(), result.data());
+
+  for (uint32_t i = 0; i < values.size(); ++i) {
+    SCOPED_TRACE(fmt::format("i={}", i));
+    EXPECT_TRUE(nimble::NimbleCompare<D>::equals(result[i], values[i]));
+  }
+}
+
+TYPED_TEST(ALPEncodingTest, mainlyConstantOtherValuesUseNestedAlpWhenEnabled) {
+  using D = typename TypeParam::data_type;
+  const nimble::Encoding::Options options{
+      .useVarintRowCount = false,
+      .fixedBitWidthUseExactBits = true,
+      .allowNestedAlpSelection = true};
+
+  nimble::Vector<D> values{this->pool_.get()};
+  for (auto i = 0; i < 256; ++i) {
+    values.push_back(D{0});
+    if (i % 8 == 0) {
+      values.back() = static_cast<D>((i % 17) - 8) / static_cast<D>(4);
+    }
+  }
+
+  auto policy = std::make_unique<nimble::ManualEncodingSelectionPolicy<D>>(
+      std::vector<std::pair<nimble::EncodingType, float>>{
+          {nimble::EncodingType::MainlyConstant, 1.0},
+      },
+      std::nullopt,
+      std::nullopt);
+
+  const auto serialized = nimble::EncodingFactory::encode<D>(
+      std::move(policy),
+      std::span<const D>{values.data(), values.size()},
+      *this->buffer_,
+      options);
+
+  std::vector<std::tuple<nimble::EncodingType, nimble::DataType, std::string>>
+      actual;
+  nimble::tools::traverseEncodings(
+      serialized,
+      [&](auto encodingType,
+          auto dataType,
+          auto /* level */,
+          auto /* index */,
+          auto nestedEncodingName,
+          std::unordered_map<
+              nimble::tools::EncodingPropertyType,
+              nimble::tools::EncodingProperty> /* properties */) {
+        actual.emplace_back(encodingType, dataType, nestedEncodingName);
+        return true;
+      });
+
+  const std::vector<
+      std::tuple<nimble::EncodingType, nimble::DataType, std::string>>
+      expected{
+          {nimble::EncodingType::MainlyConstant,
+           nimble::TypeTraits<D>::dataType,
+           ""},
+          {nimble::EncodingType::Trivial, nimble::DataType::Bool, "IsCommon"},
+          {nimble::EncodingType::ALP,
+           nimble::TypeTraits<D>::dataType,
+           "OtherValues"},
+          {nimble::EncodingType::Trivial,
+           nimble::DataType::Uint64,
+           "EncodedValues"},
       };
   EXPECT_EQ(actual, expected);
 

--- a/dwio/nimble/encodings/tests/ALPEncodingViewTest.cpp
+++ b/dwio/nimble/encodings/tests/ALPEncodingViewTest.cpp
@@ -17,6 +17,7 @@
 #include "dwio/nimble/encodings/tests/EncodingViewTestUtils.h"
 
 #include <gtest/gtest.h>
+#include <limits>
 
 #include "dwio/nimble/encodings/ALPEncoding.h"
 
@@ -30,6 +31,9 @@ TEST_F(EncodingViewTest, readsAlpEncoding) {
       makeVector<float>({-12.5F, -1.25F, 0.0F, 1.25F, 12.5F}), {4, 0, 2, 1, 3});
   expectReads<nimble::ALPEncoding<double>>(
       makeVector<double>({-12.5, -1.25, 0.0, 1.25, 12.5}), {4, 0, 2, 1, 3});
+  expectReads<nimble::ALPEncoding<float>>(
+      makeVector<float>({1.25F, std::numeric_limits<float>::infinity(), 2.5F}),
+      {1, 2, 0});
 }
 
 TEST_F(ALPEncodingViewTest, concurrent) {

--- a/dwio/nimble/encodings/tests/EncodingSelectionTest.cpp
+++ b/dwio/nimble/encodings/tests/EncodingSelectionTest.cpp
@@ -141,7 +141,7 @@ void verifySizeEstimate(
   // Check the estimated size
   auto estimatedSize = nimble::detail::EncodingSizeEstimation<T>::estimateSize(
       encodingTypeForEstimation,
-      values.size(),
+      values,
       nimble::Statistics<T>::create(values),
       options);
   EXPECT_EQ(estimatedSize, expectedEstimatedSize);
@@ -353,8 +353,10 @@ TYPED_TEST(EncodingSelectionNumericTests, selectMainlyConst) {
                .level = 2,
                .nestedEncodingName = "Indices"},
               {.encodingType = nimble::EncodingType::Trivial,
-               .dataType = nimble::TypeTraits<
-                   typename nimble::EncodingPhysicalType<T>::type>::dataType,
+               .dataType = nimble::isFloatingPointType<T>()
+                   ? nimble::TypeTraits<T>::dataType
+                   : nimble::TypeTraits<typename nimble::EncodingPhysicalType<
+                         T>::type>::dataType,
                .level = 1,
                .nestedEncodingName = "OtherValues"},
           });
@@ -520,13 +522,17 @@ TYPED_TEST(EncodingSelectionNumericTests, selectRunLength) {
              .level = 1,
              .nestedEncodingName = "Lengths"},
             {.encodingType = nimble::EncodingType::Dictionary,
-             .dataType = nimble::TypeTraits<
-                 typename nimble::EncodingPhysicalType<T>::type>::dataType,
+             .dataType = nimble::isFloatingPointType<T>()
+                 ? nimble::TypeTraits<T>::dataType
+                 : nimble::TypeTraits<typename nimble::EncodingPhysicalType<
+                       T>::type>::dataType,
              .level = 1,
              .nestedEncodingName = "Values"},
             {.encodingType = nimble::EncodingType::Trivial,
-             .dataType = nimble::TypeTraits<
-                 typename nimble::EncodingPhysicalType<T>::type>::dataType,
+             .dataType = nimble::isFloatingPointType<T>()
+                 ? nimble::TypeTraits<T>::dataType
+                 : nimble::TypeTraits<typename nimble::EncodingPhysicalType<
+                       T>::type>::dataType,
              .level = 2,
              .nestedEncodingName = "Alphabet"},
             {.encodingType = nimble::EncodingType::FixedBitWidth,

--- a/dwio/nimble/encodings/tests/EncodingSizeEstimationTest.cpp
+++ b/dwio/nimble/encodings/tests/EncodingSizeEstimationTest.cpp
@@ -217,7 +217,7 @@ TEST_F(EncodingSizeEstimationTest, numericConstant) {
   auto stats = Statistics<uint32_t>::create(data);
 
   auto size =
-      Est::estimateSize(EncodingType::Constant, 100, stats, defaultOptions_);
+      Est::estimateSize(EncodingType::Constant, data, stats, defaultOptions_);
   ASSERT_TRUE(size.has_value());
   EXPECT_GT(size.value(), 0);
   EXPECT_LT(size.value(), 100 * sizeof(uint32_t));
@@ -280,6 +280,165 @@ TEST_F(EncodingSizeEstimationTest, fixedBitWidthEstimateUsesExactBits) {
           data.size(), stats.min(), stats.max(), true));
 }
 
+TEST_F(EncodingSizeEstimationTest, floatingDictionaryEstimateUsesNestedAlp) {
+  auto verify = [&](auto typeTag) {
+    using T = decltype(typeTag);
+    using physicalType = typename TypeTraits<T>::physicalType;
+    using Est = detail::EncodingSizeEstimation<T>;
+    SCOPED_TRACE(toString(TypeTraits<T>::dataType));
+
+    std::vector<T> data;
+    data.reserve(4096);
+    for (int32_t i = 0; i < 4096; ++i) {
+      data.push_back(static_cast<T>((i % 1024) - 512) / static_cast<T>(100));
+    }
+    const auto physicalValues =
+        EncodingPhysicalType<T>::asEncodingPhysicalTypeSpan(
+            std::span<const T>{data.data(), data.size()});
+    const auto stats = Statistics<physicalType>::create(physicalValues);
+
+    auto nestedAlpOptions = defaultOptions_;
+    nestedAlpOptions.allowNestedAlpSelection = true;
+    const auto defaultEstimate = Est::estimateSize(
+        EncodingType::Dictionary,
+        physicalValues.size(),
+        stats,
+        defaultOptions_);
+    const auto nestedAlpEstimate = Est::estimateSize(
+        EncodingType::Dictionary,
+        physicalValues.size(),
+        stats,
+        nestedAlpOptions);
+
+    ASSERT_TRUE(defaultEstimate.has_value());
+    ASSERT_TRUE(nestedAlpEstimate.has_value());
+    EXPECT_LT(nestedAlpEstimate.value(), defaultEstimate.value());
+  };
+
+  verify(float{});
+  verify(double{});
+}
+
+TEST_F(EncodingSizeEstimationTest, floatingRleEstimateUsesNestedAlp) {
+  auto verify = [&](auto typeTag) {
+    using T = decltype(typeTag);
+    using physicalType = typename TypeTraits<T>::physicalType;
+    using Est = detail::EncodingSizeEstimation<T>;
+    SCOPED_TRACE(toString(TypeTraits<T>::dataType));
+
+    std::vector<T> data;
+    data.reserve(4096);
+    for (int32_t i = 0; i < 1024; ++i) {
+      const auto value = static_cast<T>((i % 257) - 128) / static_cast<T>(100);
+      data.push_back(value);
+      data.push_back(value);
+      data.push_back(value);
+      data.push_back(value);
+    }
+    const auto physicalValues =
+        EncodingPhysicalType<T>::asEncodingPhysicalTypeSpan(
+            std::span<const T>{data.data(), data.size()});
+    const auto stats = Statistics<physicalType>::create(physicalValues);
+
+    auto nestedAlpOptions = defaultOptions_;
+    nestedAlpOptions.allowNestedAlpSelection = true;
+    const auto defaultEstimate = Est::estimateSize(
+        EncodingType::RLE, physicalValues, stats, defaultOptions_);
+    const auto nestedAlpEstimate = Est::estimateSize(
+        EncodingType::RLE, physicalValues, stats, nestedAlpOptions);
+
+    ASSERT_TRUE(defaultEstimate.has_value());
+    ASSERT_TRUE(nestedAlpEstimate.has_value());
+    EXPECT_LT(nestedAlpEstimate.value(), defaultEstimate.value());
+  };
+
+  verify(float{});
+  verify(double{});
+}
+
+TEST_F(
+    EncodingSizeEstimationTest,
+    floatingMainlyConstantEstimateUsesNestedAlp) {
+  auto verify = [&](auto typeTag) {
+    using T = decltype(typeTag);
+    using physicalType = typename TypeTraits<T>::physicalType;
+    using Est = detail::EncodingSizeEstimation<T>;
+    SCOPED_TRACE(toString(TypeTraits<T>::dataType));
+
+    std::vector<T> data(1024, static_cast<T>(123.456));
+    data.reserve(4096);
+    for (int32_t i = 0; i < 3072; ++i) {
+      data.push_back(static_cast<T>((i % 1024) - 512) / static_cast<T>(100));
+    }
+
+    const auto physicalValues =
+        EncodingPhysicalType<T>::asEncodingPhysicalTypeSpan(
+            std::span<const T>{data.data(), data.size()});
+    const auto stats = Statistics<physicalType>::create(physicalValues);
+
+    auto nestedAlpOptions = defaultOptions_;
+    nestedAlpOptions.allowNestedAlpSelection = true;
+    const auto defaultEstimate = Est::estimateSize(
+        EncodingType::MainlyConstant,
+        physicalValues.size(),
+        stats,
+        defaultOptions_);
+    const auto nestedAlpEstimate = Est::estimateSize(
+        EncodingType::MainlyConstant,
+        physicalValues.size(),
+        stats,
+        nestedAlpOptions);
+
+    ASSERT_TRUE(defaultEstimate.has_value());
+    ASSERT_TRUE(nestedAlpEstimate.has_value());
+    EXPECT_LT(nestedAlpEstimate.value(), defaultEstimate.value());
+  };
+
+  verify(float{});
+  verify(double{});
+}
+
+TEST_F(EncodingSizeEstimationTest, nestedAlpSizeEligibility) {
+  const std::vector<float> logicalValues = {1.25F, 2.5F, 3.75F};
+  const auto physicalValues =
+      EncodingPhysicalType<float>::asEncodingPhysicalTypeSpan(logicalValues);
+
+  EXPECT_FALSE(
+      detail::nestedAlpSize<float>(physicalValues, defaultOptions_)
+          .has_value());
+
+  auto enabledOptions = defaultOptions_;
+  enabledOptions.allowNestedAlpSelection = true;
+  EXPECT_EQ(
+      detail::nestedAlpSize<float>(physicalValues, enabledOptions),
+      ALPEncoding<float>::estimateSize(physicalValues, enabledOptions));
+}
+
+TEST_F(EncodingSizeEstimationTest, uniqueValuesNestedAlpSizeEligibility) {
+  const std::vector<float> logicalValues = {1.25F, 1.25F, 2.5F, 3.75F};
+  const auto physicalValues =
+      EncodingPhysicalType<float>::asEncodingPhysicalTypeSpan(logicalValues);
+  const auto statistics = Statistics<uint32_t>::create(physicalValues);
+  const auto& uniqueCounts = statistics.uniqueCounts().value();
+
+  EXPECT_FALSE(
+      detail::uniqueValuesNestedAlpSize<float>(uniqueCounts, defaultOptions_)
+          .has_value());
+
+  auto enabledOptions = defaultOptions_;
+  enabledOptions.allowNestedAlpSelection = true;
+  EXPECT_TRUE(
+      detail::uniqueValuesNestedAlpSize<float>(uniqueCounts, enabledOptions)
+          .has_value());
+
+  const auto emptyStatistics =
+      Statistics<uint32_t>::create(std::span<const uint32_t>{});
+  EXPECT_FALSE(
+      detail::uniqueValuesNestedAlpSize<float>(
+          emptyStatistics.uniqueCounts().value(), enabledOptions)
+          .has_value());
+}
+
 TEST_F(EncodingSizeEstimationTest, numericDictionary) {
   using Est = detail::EncodingSizeEstimation<uint32_t>;
 
@@ -303,6 +462,61 @@ TEST_F(EncodingSizeEstimationTest, numericMainlyConstant) {
       EncodingType::MainlyConstant, 100, stats, defaultOptions_);
   ASSERT_TRUE(size.has_value());
   EXPECT_LT(size.value(), 100 * sizeof(uint32_t));
+}
+
+TEST_F(
+    EncodingSizeEstimationTest,
+    numericMainlyConstantEstimateUsesUncommonValueRange) {
+  using Est = detail::EncodingSizeEstimation<uint32_t>;
+
+  for (const bool commonIsMinimum : {false, true}) {
+    SCOPED_TRACE(commonIsMinimum);
+    const uint32_t commonValue = commonIsMinimum ? 0 : 1'000'000;
+    const uint32_t uncommonBase = commonIsMinimum ? 1'000'000 : 0;
+    std::vector<uint32_t> data(80, commonValue);
+    for (uint32_t i = 0; i < 40; ++i) {
+      data.push_back(uncommonBase + i % 8);
+    }
+    const auto stats = Statistics<uint32_t>::create(data);
+    auto options = exactBitWidthOptions();
+
+    const auto estimate = Est::estimateSize(
+        EncodingType::MainlyConstant, data.size(), stats, options);
+    ASSERT_TRUE(estimate.has_value());
+
+    const auto isCommonSize = SparseBoolEncoding::estimateSize(
+        data.size(), /*exceptionCount=*/40, options);
+    const auto oldFullRangeOtherValuesSize =
+        FixedBitWidthEncoding<uint32_t>::estimateSize(
+            /*rowCount=*/40, stats.min(), stats.max(), options);
+    const auto oldFullRangeEstimate = EncodingPrefix::kFixedPrefixSize +
+        2 * sizeof(uint32_t) + sizeof(uint32_t) + isCommonSize +
+        oldFullRangeOtherValuesSize;
+
+    EXPECT_LT(estimate.value(), oldFullRangeEstimate);
+  }
+}
+
+TEST_F(
+    EncodingSizeEstimationTest,
+    numericMainlyConstantEstimateUsesConstantForOtherValues) {
+  using Est = detail::EncodingSizeEstimation<uint32_t>;
+
+  std::vector<uint32_t> data(80, 1'000'000);
+  data.insert(data.end(), 40, 7);
+  const auto statistics = Statistics<uint32_t>::create(data);
+  const auto options = exactBitWidthOptions();
+
+  const auto estimate = Est::estimateSize(
+      EncodingType::MainlyConstant, data.size(), statistics, options);
+  ASSERT_TRUE(estimate.has_value());
+
+  const auto expectedSize = EncodingPrefix::kFixedPrefixSize +
+      2 * sizeof(uint32_t) + sizeof(uint32_t) +
+      SparseBoolEncoding::estimateSize(
+                                data.size(), /*exceptionCount=*/40, options) +
+      EncodingPrefix::kFixedPrefixSize + sizeof(uint32_t);
+  EXPECT_EQ(estimate.value(), expectedSize);
 }
 
 TEST_F(EncodingSizeEstimationTest, numericRle) {
@@ -553,9 +767,12 @@ TEST_F(EncodingSizeEstimationTest, encodingEstimateHelpersReturnSizes) {
   auto boolStats = Statistics<bool>::create(boolData);
 
   EXPECT_GT(TrivialEncoding<uint32_t>::estimateSize(numericData.size()), 0u);
+  const std::vector<uint32_t> constantData = {1, 1};
   EXPECT_GT(
       ConstantEncoding<uint32_t>::estimateSize(
-          Statistics<uint32_t>::create(std::vector<uint32_t>{1, 1}))
+          std::span<const uint32_t>{constantData.data(), constantData.size()},
+          Statistics<uint32_t>::create(constantData),
+          Encoding::Options{})
           .value(),
       0u);
   EXPECT_GT(
@@ -673,7 +890,7 @@ TEST_F(EncodingSizeEstimationTest, constantSmallestForConstantData) {
   auto stats = Statistics<uint32_t>::create(data);
 
   auto constantSize =
-      Est::estimateSize(EncodingType::Constant, 1000, stats, defaultOptions_);
+      Est::estimateSize(EncodingType::Constant, data, stats, defaultOptions_);
   auto trivialSize =
       Est::estimateSize(EncodingType::Trivial, 1000, stats, defaultOptions_);
 

--- a/dwio/nimble/encodings/tests/StatisticsTest.cpp
+++ b/dwio/nimble/encodings/tests/StatisticsTest.cpp
@@ -56,6 +56,30 @@ class StatisticsBoolTests : public ::testing::Test {};
 template <typename C>
 class StatisticsStringTests : public ::testing::Test {};
 
+TEST(StatisticsTest, runValues) {
+  const std::vector<int32_t> data = {1, 1, 2, 2, 1, 3, 3};
+  const std::vector<int32_t> expected = {1, 2, 1, 3};
+  for (const bool populateRepeatMetricsFirst : {false, true}) {
+    SCOPED_TRACE(populateRepeatMetricsFirst);
+    const auto statistics = nimble::Statistics<int32_t>::create(data);
+    if (populateRepeatMetricsFirst) {
+      EXPECT_EQ(statistics.consecutiveRepeatCount(), 4);
+      EXPECT_EQ(statistics.minRepeat(), 1);
+      EXPECT_EQ(statistics.maxRepeat(), 2);
+    }
+
+    const auto& runValues = statistics.runValues();
+    EXPECT_EQ(runValues, expected);
+    EXPECT_EQ(&statistics.runValues(), &runValues);
+    EXPECT_EQ(statistics.consecutiveRepeatCount(), 4);
+    EXPECT_EQ(statistics.minRepeat(), 1);
+    EXPECT_EQ(statistics.maxRepeat(), 2);
+  }
+
+  const std::vector<int32_t> empty;
+  EXPECT_TRUE(nimble::Statistics<int32_t>::create(empty).runValues().empty());
+}
+
 TYPED_TEST(StatisticsNumericTests, Create) {
   using T = TypeParam;
   using ValueType = typename T::valueType;

--- a/dwio/nimble/encodings/views/ALPEncodingView.h
+++ b/dwio/nimble/encodings/views/ALPEncodingView.h
@@ -40,10 +40,11 @@ class ALPEncodingView final : public TypedEncodingView<T> {
       : TypedEncodingView<T>{data, pool, options} {
     NIMBLE_CHECK_EQ(this->encodingType_, EncodingType::ALP);
     const char* pos = data.data() + this->dataOffset_;
-    exponent_ = encoding::read<uint8_t>(pos);
-    factor_ = encoding::read<uint8_t>(pos);
-    exceptionCount_ = encoding::readUint32(pos);
-    const auto encodedValuesSize = encoding::readUint32(pos);
+    const auto header = detail::alp::readHeader(pos);
+    exponent_ = header.exponent;
+    factor_ = header.factor;
+    exceptionCount_ = header.hasExceptions ? varint::readVarint32(&pos) : 0;
+    const auto encodedValuesSize = varint::readVarint32(&pos);
 
     encodedValues_ = detail::createTypedEncodingView<uint64_t>(
         {pos, encodedValuesSize}, this->pool_, options);
@@ -68,7 +69,7 @@ class ALPEncodingView final : public TypedEncodingView<T> {
 
   const physicalType* findException(uint32_t index) const {
     const auto* begin = exceptionPositions_;
-    const auto* end = exceptionPositions_ + exceptionCount_;
+    const auto* end = begin + exceptionCount_;
     const auto* it = std::lower_bound(begin, end, index);
     if (it == end || *it != index) {
       return nullptr;

--- a/dwio/nimble/tools/EncodingUtilities.cpp
+++ b/dwio/nimble/tools/EncodingUtilities.cpp
@@ -15,6 +15,7 @@
  */
 #include "dwio/nimble/tools/EncodingUtilities.h"
 #include "dwio/nimble/common/Exceptions.h"
+#include "dwio/nimble/common/Varint.h"
 #include "dwio/nimble/encodings/FsstEncoding.h"
 #include "dwio/nimble/encodings/common/EncodingUtils.h"
 
@@ -123,10 +124,11 @@ void traverseEncodings(
     }
     case EncodingType::ALP: {
       const char* pos = stream.data() + kEncodingPrefixSize;
-      encoding::read<uint8_t>(pos); // exponent
-      encoding::read<uint8_t>(pos); // factor
-      encoding::readUint32(pos); // exceptionCount
-      const uint32_t encodedValuesSize = encoding::readUint32(pos);
+      const auto header = detail::alp::readHeader(pos);
+      if (header.hasExceptions) {
+        varint::readVarint32(&pos); // exceptionCount
+      }
+      const uint32_t encodedValuesSize = varint::readVarint32(&pos);
       traverseEncodings(
           {pos, encodedValuesSize}, level + 1, 0, "EncodedValues", visitor);
       break;


### PR DESCRIPTION
Summary:

Improve scalar encoding estimates and nested floating-point encoding so selection models the bytes that child streams actually write.

Encoding selection:

- Make Constant estimation value-aware, including canonical physical storage when floating-point physical values are logically equal.
- Estimate MainlyConstant uncommon values from their own distribution and compare Constant, Trivial, FixedBitWidth, Dictionary, and eligible nested ALP candidates.
- Estimate Dictionary floating-point alphabets from sampled unique values without rebuilding expanded input.
- Add lazy cached run values to Statistics so RLE can estimate its actual run-value stream and avoid storing them unless requested.
- Serialize floating-point MainlyConstant and RLE child values through logical-type nested policies, and allow ALP for Dictionary alphabets, MainlyConstant uncommon values, and RLE run values when allowNestedAlpSelection is enabled.

ALP format and estimation:

- Improve ALP sampling and estimate validation, and account for the exact metadata layout.
- Replace separate exponent/factor metadata with an unconditional 3-byte control word containing exponent, factor, and exception presence. No writer option selects the layout.
- Omit exceptionCount when there are no exceptions and encode exceptionCount and nested encoded-values size as varints. Exception positions remain fixed-width uint32_t for efficient lookup.
- Update ALP decoding, EncodingView, and EncodingUtilities nested traversal for the compact layout.

This changes the ALP wire layout; readers and writers must use the updated format together. The change includes focused coverage for header bytes, round trips, views, traversal, estimation, nested selection, lazy run statistics, and uncommon-value estimation.

Differential Revision: D112619794


