### PR TITLE
feat(nimble): Add per-chunk min/max (#989)

### DIFF
--- a/dwio/nimble/docs/architecture/nimble_metadata_cache.html
+++ b/dwio/nimble/docs/architecture/nimble_metadata_cache.html
@@ -631,7 +631,7 @@ ensureInput() copies across boundary.
 │   Schema         "columnar.schema"          — type tree                 │
 │   Metadata       "columnar.metadata"        — key-value pairs           │
 │   Stats          "columnar.vectorized_stats"— per-column stats          │
-│   ChunkIndex     "columnar.chunk.index"     — root → per-group blobs   │
+│   ChunkStats     "columnar.chunk.stats"     — root → per-group blobs   │
 │   FileIndexes    "columnar.indexes"         — named index manifest     │
 │   StrideIndex    "columnar.stride.index"    — root → per-group blobs   │
 ├──────────────────────────────────────────────────────────────────────────┤
@@ -683,7 +683,7 @@ ensureInput() copies across boundary.
                    │                                                {0x9000, 248, Zstd}]
                    │                              optional_sections:
                    │                                "columnar.schema"        → {0xB000, ...}
-                   │                                "columnar.chunk.index"   → {0xC000, ...}
+                   │                                "columnar.chunk.stats"   → {0xC000, ...}
                    │                                "columnar.indexes"       → {0xD000, ...}
                    │
                    ├─ 0x8000: StripeGroup 0 blob
@@ -762,7 +762,7 @@ Together with StripeGroup, you can read any column.</div>
   <tr><td><code>columnar.metadata</code></td><td>Active</td></tr>
   <tr><td><code>columnar.stats</code></td><td>Legacy (replaced by vectorized_stats)</td></tr>
   <tr><td><code>columnar.vectorized_stats</code></td><td>Active</td></tr>
-  <tr><td><code>columnar.chunk.index</code></td><td>Active</td></tr>
+  <tr><td><code>columnar.chunk.stats</code></td><td>Active</td></tr>
   <tr><td><code>columnar.indexes</code></td><td>Active file index manifest</td></tr>
   <tr><td><code>columnar.stride.index</code></td><td>New</td></tr>
   <tr><td><code>columnar.dense.index</code></td><td>Defined, not implemented</td></tr>
@@ -830,7 +830,7 @@ StripeGroup    — flushed incrementally at metadata threshold.
       <div style="font-family:var(--mono);font-size:0.52rem;color:var(--text-muted);margin-top:0.15rem;line-height:1.4;background:var(--code-bg);padding:0.2rem 0.3rem;border-radius:3px">
         optionalSections_:<br>
         &nbsp;"columnar.schema" → {0xB000, 256, Zstd}<br>
-        &nbsp;"columnar.chunk.index" → {0xC000, 1024, Zstd}<br>
+        &nbsp;"columnar.chunk.stats" → {0xC000, 1024, Zstd}<br>
         &nbsp;...
       </div>
     </div>

--- a/dwio/nimble/index/CMakeLists.txt
+++ b/dwio/nimble/index/CMakeLists.txt
@@ -14,8 +14,8 @@
 add_library(
   nimble_index
   BloomFilter.cpp
-  ChunkIndex.cpp
-  ChunkIndexGroup.cpp
+  ChunkStats.cpp
+  ChunkStatsGroup.cpp
   ClusterIndex.cpp
   ClusterIndexFactory.cpp
   ClusterIndexWriter.cpp
@@ -40,7 +40,7 @@ target_link_libraries(
   nimble_encodings
   nimble_tablet_common
   nimble_cluster_index_fb
-  nimble_chunk_index_fb
+  nimble_chunk_stats_fb
   nimble_hash_index_fb
   nimble_index_fb
   nimble_bloom_filter_fb

--- a/dwio/nimble/index/ChunkStats.cpp
+++ b/dwio/nimble/index/ChunkStats.cpp
@@ -14,15 +14,15 @@
  * limitations under the License.
  */
 
-#include "dwio/nimble/index/ChunkIndex.h"
+#include "dwio/nimble/index/ChunkStats.h"
 
 #include "dwio/nimble/common/Exceptions.h"
-#include "dwio/nimble/tablet/ChunkIndexGenerated.h"
+#include "dwio/nimble/tablet/ChunkStatsGenerated.h"
 
 namespace facebook::nimble::index {
 
-std::unique_ptr<ChunkIndex> ChunkIndex::create(Section indexSection) {
-  const auto* root = flatbuffers::GetRoot<serialization::ChunkIndex>(
+std::unique_ptr<ChunkStats> ChunkStats::create(Section indexSection) {
+  const auto* root = flatbuffers::GetRoot<serialization::ChunkStats>(
       indexSection.content().data());
   NIMBLE_CHECK_NOT_NULL(root);
 
@@ -44,17 +44,17 @@ std::unique_ptr<ChunkIndex> ChunkIndex::create(Section indexSection) {
                                 : std::nullopt);
   }
 
-  return std::unique_ptr<ChunkIndex>(
-      new ChunkIndex(std::move(indexSection), std::move(groupSections)));
+  return std::unique_ptr<ChunkStats>(
+      new ChunkStats(std::move(indexSection), std::move(groupSections)));
 }
 
-ChunkIndex::ChunkIndex(
+ChunkStats::ChunkStats(
     Section indexSection,
     std::vector<MetadataSection> groupSections)
     : indexSection_{std::move(indexSection)},
       groupSections_{std::move(groupSections)} {}
 
-const MetadataSection& ChunkIndex::groupMetadata(uint32_t groupIndex) const {
+const MetadataSection& ChunkStats::groupMetadata(uint32_t groupIndex) const {
   NIMBLE_CHECK_LT(
       groupIndex, groupSections_.size(), "Chunk index group out of range");
   return groupSections_[groupIndex];

--- a/dwio/nimble/index/ChunkStats.h
+++ b/dwio/nimble/index/ChunkStats.h
@@ -22,24 +22,24 @@
 
 namespace facebook::nimble::index {
 
-/// ChunkIndex provides access to chunk-level position index metadata for Nimble
+/// ChunkStats provides access to chunk-level position index metadata for Nimble
 /// tablets.
 ///
 /// This is the root-level chunk index that contains per-stripe-group
 /// MetadataSection references. Each stripe group's chunk index data
-/// (ChunkIndexGroup) can be loaded on demand using the metadata sections
+/// (ChunkStatsGroup) can be loaded on demand using the metadata sections
 /// provided by this class.
 ///
 /// Mirrors the ClusterIndex pattern: owns the root flatbuffer section and
 /// exposes per-group metadata for on-demand loading.
-class ChunkIndex {
+class ChunkStats {
  public:
-  /// Creates a ChunkIndex from the root chunk index optional section.
+  /// Creates a ChunkStats from the root chunk index optional section.
   ///
   /// @param indexSection The section containing the serialized root chunk index
-  /// @return A unique pointer to a newly created ChunkIndex, or nullptr if the
+  /// @return A unique pointer to a newly created ChunkStats, or nullptr if the
   ///         section contains no stripe indexes
-  static std::unique_ptr<ChunkIndex> create(Section indexSection);
+  static std::unique_ptr<ChunkStats> create(Section indexSection);
 
   /// Returns the number of stripe groups indexed.
   uint32_t numGroups() const {
@@ -53,7 +53,7 @@ class ChunkIndex {
   const MetadataSection& groupMetadata(uint32_t groupIndex) const;
 
  private:
-  explicit ChunkIndex(
+  explicit ChunkStats(
       Section indexSection,
       std::vector<MetadataSection> groupSections);
 

--- a/dwio/nimble/index/ChunkStatsGroup.cpp
+++ b/dwio/nimble/index/ChunkStatsGroup.cpp
@@ -161,6 +161,30 @@ std::optional<uint32_t> StreamIndex::chunkNullCount(uint32_t chunkIndex) const {
   return nullCounts->Get(chunkIndex);
 }
 
+std::optional<std::pair<int64_t, int64_t>> StreamIndex::chunkMinMax(
+    uint32_t chunkIndex) const {
+  const auto* root = asFlatBuffersRoot<serialization::StripeChunkStats>(
+      chunkStats_->metadata_->content());
+
+  const auto* valid = root->stream_chunk_min_max_valid();
+  const auto* mins = root->stream_chunk_min_values();
+  const auto* maxs = root->stream_chunk_max_values();
+  if (valid == nullptr || mins == nullptr || maxs == nullptr) {
+    // Absent in pre-stats files.
+    return std::nullopt;
+  }
+  // Arrays present and appended in lockstep, so an out-of-range index is a
+  // bug/corruption, not a legacy file -- fail loudly (mirrors chunkNullCount).
+  NIMBLE_CHECK_LT(chunkIndex, valid->size());
+  NIMBLE_CHECK_LT(chunkIndex, mins->size());
+  NIMBLE_CHECK_LT(chunkIndex, maxs->size());
+  if (valid->Get(chunkIndex) == 0) {
+    return std::nullopt; // recorded but unknown (NaN / ineligible / empty)
+  }
+  return std::pair<int64_t, int64_t>{
+      mins->Get(chunkIndex), maxs->Get(chunkIndex)};
+}
+
 uint32_t StreamIndex::rowCount() const {
   if (endChunkOffset_ == startChunkOffset_) {
     return 0;

--- a/dwio/nimble/index/ChunkStatsGroup.cpp
+++ b/dwio/nimble/index/ChunkStatsGroup.cpp
@@ -144,6 +144,23 @@ ChunkLocation StreamIndex::lookupChunk(uint32_t rowId) const {
       chunkIndex, streamOffset, nextOffset - streamOffset, rowOffset};
 }
 
+std::optional<uint32_t> StreamIndex::chunkNullCount(uint32_t chunkIndex) const {
+  const auto* root = asFlatBuffersRoot<serialization::StripeChunkStats>(
+      chunkStats_->metadata_->content());
+
+  const auto* nullCounts = root->stream_chunk_null_counts();
+  if (nullCounts == nullptr) {
+    // Absent in files written before per-chunk null statistics were added; the
+    // null count is unknown.
+    return std::nullopt;
+  }
+  // The array is present, so chunkIndex (derived from ChunkLocation) must be in
+  // range. An out-of-range index is a programmer error or malformed metadata,
+  // not a legacy file, so fail loudly rather than masking it as "unknown".
+  NIMBLE_CHECK_LT(chunkIndex, nullCounts->size());
+  return nullCounts->Get(chunkIndex);
+}
+
 uint32_t StreamIndex::rowCount() const {
   if (endChunkOffset_ == startChunkOffset_) {
     return 0;

--- a/dwio/nimble/index/ChunkStatsGroup.cpp
+++ b/dwio/nimble/index/ChunkStatsGroup.cpp
@@ -13,9 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#include "dwio/nimble/index/ChunkIndexGroup.h"
+#include "dwio/nimble/index/ChunkStatsGroup.h"
 
-#include "dwio/nimble/tablet/ChunkIndexGenerated.h"
+#include "dwio/nimble/tablet/ChunkStatsGenerated.h"
 #include "dwio/nimble/tablet/MetadataBuffer.h"
 
 #include <algorithm>
@@ -31,26 +31,26 @@ const T* asFlatBuffersRoot(std::string_view content) {
 
 } // namespace
 
-std::shared_ptr<ChunkIndexGroup> ChunkIndexGroup::create(
+std::shared_ptr<ChunkStatsGroup> ChunkStatsGroup::create(
     uint32_t firstStripe,
     uint32_t stripeCount,
     std::unique_ptr<MetadataBuffer> metadata) {
-  return std::shared_ptr<ChunkIndexGroup>(
-      new ChunkIndexGroup(firstStripe, stripeCount, std::move(metadata)));
+  return std::shared_ptr<ChunkStatsGroup>(
+      new ChunkStatsGroup(firstStripe, stripeCount, std::move(metadata)));
 }
 
-ChunkIndexGroup::ChunkIndexGroup(
+ChunkStatsGroup::ChunkStatsGroup(
     uint32_t firstStripe,
     uint32_t stripeCount,
     std::unique_ptr<MetadataBuffer> metadata)
     : metadata_{std::move(metadata)},
       firstStripe_{firstStripe},
       stripeCount_{stripeCount},
-      streamCount_{asFlatBuffersRoot<serialization::StripeChunkIndex>(
+      streamCount_{asFlatBuffersRoot<serialization::StripeChunkStats>(
                        metadata_->content())
                        ->stream_count()} {}
 
-std::shared_ptr<StreamIndex> ChunkIndexGroup::createStreamIndex(
+std::shared_ptr<StreamIndex> ChunkStatsGroup::createStreamIndex(
     uint32_t stripe,
     uint32_t streamId,
     uint32_t streamSize) const {
@@ -60,7 +60,7 @@ std::shared_ptr<StreamIndex> ChunkIndexGroup::createStreamIndex(
 
   const uint32_t stripeOff = stripeOffset(stripe);
   const auto* root =
-      asFlatBuffersRoot<serialization::StripeChunkIndex>(metadata_->content());
+      asFlatBuffersRoot<serialization::StripeChunkStats>(metadata_->content());
 
   const auto* streamChunkCounts = root->stream_chunk_counts();
   NIMBLE_CHECK_NOT_NULL(streamChunkCounts);
@@ -87,7 +87,7 @@ std::shared_ptr<StreamIndex> ChunkIndexGroup::createStreamIndex(
 }
 
 std::shared_ptr<StreamIndex> StreamIndex::create(
-    std::shared_ptr<const ChunkIndexGroup> chunkIndex,
+    std::shared_ptr<const ChunkStatsGroup> chunkIndex,
     uint32_t streamId,
     uint32_t startChunkOffset,
     uint32_t endChunkOffset,
@@ -101,22 +101,22 @@ std::shared_ptr<StreamIndex> StreamIndex::create(
 }
 
 StreamIndex::StreamIndex(
-    std::shared_ptr<const ChunkIndexGroup> chunkIndex,
+    std::shared_ptr<const ChunkStatsGroup> chunkIndex,
     uint32_t streamId,
     uint32_t startChunkOffset,
     uint32_t endChunkOffset,
     uint32_t streamSize)
-    : chunkIndex_(std::move(chunkIndex)),
+    : chunkStats_(std::move(chunkIndex)),
       streamId_(streamId),
       startChunkOffset_(startChunkOffset),
       endChunkOffset_(endChunkOffset),
       streamSize_(streamSize) {
-  NIMBLE_CHECK_NOT_NULL(chunkIndex_);
+  NIMBLE_CHECK_NOT_NULL(chunkStats_);
 }
 
 ChunkLocation StreamIndex::lookupChunk(uint32_t rowId) const {
-  const auto* root = asFlatBuffersRoot<serialization::StripeChunkIndex>(
-      chunkIndex_->metadata_->content());
+  const auto* root = asFlatBuffersRoot<serialization::StripeChunkStats>(
+      chunkStats_->metadata_->content());
 
   const auto* chunkRows = root->stream_chunk_rows();
   NIMBLE_CHECK_NOT_NULL(chunkRows);
@@ -149,8 +149,8 @@ uint32_t StreamIndex::rowCount() const {
     return 0;
   }
 
-  const auto* root = asFlatBuffersRoot<serialization::StripeChunkIndex>(
-      chunkIndex_->metadata_->content());
+  const auto* root = asFlatBuffersRoot<serialization::StripeChunkStats>(
+      chunkStats_->metadata_->content());
 
   const auto* chunkRows = root->stream_chunk_rows();
   NIMBLE_CHECK_NOT_NULL(chunkRows);

--- a/dwio/nimble/index/ChunkStatsGroup.h
+++ b/dwio/nimble/index/ChunkStatsGroup.h
@@ -18,6 +18,7 @@
 #include <cstdint>
 #include <memory>
 #include <optional>
+#include <utility>
 
 #include "dwio/nimble/common/Exceptions.h"
 #include "dwio/nimble/index/IndexTypes.h"
@@ -106,6 +107,12 @@ class StreamIndex {
   /// position (ChunkLocation::chunkIndex), or std::nullopt when per-chunk null
   /// statistics are absent (files written before chunk statistics were added).
   std::optional<uint32_t> chunkNullCount(uint32_t chunkIndex) const;
+
+  /// Returns the chunk's [min, max] raw 64-bit payloads (int64 for integral,
+  /// bit_cast<int64_t> of the double for float/double), or std::nullopt when
+  /// absent (pre-stats files) or invalid for that chunk.
+  std::optional<std::pair<int64_t, int64_t>> chunkMinMax(
+      uint32_t chunkIndex) const;
 
   /// Returns the total number of rows in this stream.
   uint32_t rowCount() const;

--- a/dwio/nimble/index/ChunkStatsGroup.h
+++ b/dwio/nimble/index/ChunkStatsGroup.h
@@ -28,25 +28,25 @@ class MetadataBuffer;
 namespace facebook::nimble::index {
 
 namespace test {
-class ChunkIndexTestHelper;
+class ChunkStatsTestHelper;
 } // namespace test
 
 class StreamIndex;
 
-/// ChunkIndexGroup provides O(1) chunk-level seeking by row ID within stripes.
-/// It reads from the standalone ChunkIndex flatbuffer stored in the
-/// "chunk_index" optional section.
+/// ChunkStatsGroup provides O(1) chunk-level seeking by row ID within stripes.
+/// It reads from the standalone ChunkStats flatbuffer stored in the
+/// "columnar.chunk.stats" optional section.
 ///
-/// Each ChunkIndexGroup instance corresponds to one stripe group and contains
+/// Each ChunkStatsGroup instance corresponds to one stripe group and contains
 /// chunk-level position data for all streams across all stripes in that group.
-class ChunkIndexGroup : public std::enable_shared_from_this<ChunkIndexGroup> {
+class ChunkStatsGroup : public std::enable_shared_from_this<ChunkStatsGroup> {
  public:
-  /// Creates a ChunkIndexGroup from a decompressed ChunkIndex flatbuffer.
+  /// Creates a ChunkStatsGroup from a decompressed ChunkStats flatbuffer.
   ///
   /// @param firstStripe First stripe index in this stripe group.
   /// @param stripeCount Number of stripes in this stripe group.
-  /// @param metadata Decompressed ChunkIndex flatbuffer data.
-  static std::shared_ptr<ChunkIndexGroup> create(
+  /// @param metadata Decompressed ChunkStats flatbuffer data.
+  static std::shared_ptr<ChunkStatsGroup> create(
       uint32_t firstStripe,
       uint32_t stripeCount,
       std::unique_ptr<MetadataBuffer> metadata);
@@ -60,7 +60,7 @@ class ChunkIndexGroup : public std::enable_shared_from_this<ChunkIndexGroup> {
       uint32_t streamSize) const;
 
  private:
-  ChunkIndexGroup(
+  ChunkStatsGroup(
       uint32_t firstStripe,
       uint32_t stripeCount,
       std::unique_ptr<MetadataBuffer> metadata);
@@ -83,7 +83,7 @@ class ChunkIndexGroup : public std::enable_shared_from_this<ChunkIndexGroup> {
   const uint32_t streamCount_;
 
   friend class StreamIndex;
-  friend class test::ChunkIndexTestHelper;
+  friend class test::ChunkStatsTestHelper;
 };
 
 /// StreamIndex provides O(1) chunk-level seeking for a specific stream within
@@ -92,7 +92,7 @@ class ChunkIndexGroup : public std::enable_shared_from_this<ChunkIndexGroup> {
 class StreamIndex {
  public:
   static std::shared_ptr<StreamIndex> create(
-      std::shared_ptr<const ChunkIndexGroup> chunkIndex,
+      std::shared_ptr<const ChunkStatsGroup> chunkIndex,
       uint32_t streamId,
       uint32_t startChunkOffset,
       uint32_t endChunkOffset,
@@ -111,14 +111,14 @@ class StreamIndex {
 
  private:
   StreamIndex(
-      std::shared_ptr<const ChunkIndexGroup> chunkIndex,
+      std::shared_ptr<const ChunkStatsGroup> chunkIndex,
       uint32_t streamId,
       uint32_t startChunkOffset,
       uint32_t endChunkOffset,
       uint32_t streamSize);
 
   // Kept alive to ensure metadata_ stays valid.
-  const std::shared_ptr<const ChunkIndexGroup> chunkIndex_;
+  const std::shared_ptr<const ChunkStatsGroup> chunkStats_;
   const uint32_t streamId_;
   // Precomputed chunk range [startChunkOffset_, endChunkOffset_) into the
   // flattened chunk_rows/chunk_offsets arrays.

--- a/dwio/nimble/index/ChunkStatsGroup.h
+++ b/dwio/nimble/index/ChunkStatsGroup.h
@@ -17,6 +17,7 @@
 
 #include <cstdint>
 #include <memory>
+#include <optional>
 
 #include "dwio/nimble/common/Exceptions.h"
 #include "dwio/nimble/index/IndexTypes.h"
@@ -100,6 +101,11 @@ class StreamIndex {
 
   /// Lookup chunk by row ID within the stream's row range.
   ChunkLocation lookupChunk(uint32_t rowId) const;
+
+  /// Returns the per-chunk null-value count for the chunk at the given absolute
+  /// position (ChunkLocation::chunkIndex), or std::nullopt when per-chunk null
+  /// statistics are absent (files written before chunk statistics were added).
+  std::optional<uint32_t> chunkNullCount(uint32_t chunkIndex) const;
 
   /// Returns the total number of rows in this stream.
   uint32_t rowCount() const;

--- a/dwio/nimble/index/tests/ChunkStatsTest.cpp
+++ b/dwio/nimble/index/tests/ChunkStatsTest.cpp
@@ -18,14 +18,14 @@
 
 #include "dwio/nimble/common/tests/GTestUtils.h"
 #include "dwio/nimble/common/tests/TestUtils.h"
-#include "dwio/nimble/index/ChunkIndexGroup.h"
+#include "dwio/nimble/index/ChunkStatsGroup.h"
 #include "dwio/nimble/index/tests/ClusterIndexTestBase.h"
 
 namespace facebook::nimble::index::test {
 
-class ChunkIndexTest : public ClusterIndexTestBase {};
+class ChunkStatsTest : public ClusterIndexTestBase {};
 
-TEST_F(ChunkIndexTest, lookupChunkWithRowId) {
+TEST_F(ChunkStatsTest, lookupChunkWithRowId) {
   std::vector<std::string> indexColumns = {"col1"};
   std::string minKey = "aaa";
   // Setup: 2 stripes, each with 2 streams with different chunk configurations
@@ -167,7 +167,7 @@ TEST_F(ChunkIndexTest, lookupChunkWithRowId) {
   NIMBLE_ASSERT_THROW(s11->lookupChunk(650), "beyond the last chunk");
 }
 
-TEST_F(ChunkIndexTest, lookupChunkPopulatesChunkIndex) {
+TEST_F(ChunkStatsTest, lookupChunkPopulatesChunkIndex) {
   // Single stripe, two streams. chunkIndex is the absolute position in the
   // stripe's chunkRows FlatBuffers array — i.e., it is offset by the number
   // of chunks belonging to earlier streams in the stripe.
@@ -226,7 +226,7 @@ TEST_F(ChunkIndexTest, lookupChunkPopulatesChunkIndex) {
   }
 }
 
-TEST_F(ChunkIndexTest, createStreamIndex) {
+TEST_F(ChunkStatsTest, createStreamIndex) {
   std::vector<std::string> indexColumns = {"col1"};
   std::string minKey = "aaa";
   std::vector<Stripe> stripes = {
@@ -255,7 +255,7 @@ TEST_F(ChunkIndexTest, createStreamIndex) {
   EXPECT_NE(chunkIndex->createStreamIndex(0, 1, /*streamSize=*/1000), nullptr);
 }
 
-TEST_F(ChunkIndexTest, singleChunkStreamReturnsNullptr) {
+TEST_F(ChunkStatsTest, singleChunkStreamReturnsNullptr) {
   std::vector<std::string> indexColumns = {"col1"};
   std::string minKey = "aaa";
   // Mix of single-chunk and multi-chunk streams across stripes.
@@ -288,7 +288,7 @@ TEST_F(ChunkIndexTest, singleChunkStreamReturnsNullptr) {
   EXPECT_EQ(streamIndex->streamId(), 1);
 }
 
-TEST_F(ChunkIndexTest, streamIndexStreamId) {
+TEST_F(ChunkStatsTest, streamIndexStreamId) {
   std::vector<std::string> indexColumns = {"col1"};
   std::string minKey = "aaa";
   // Each stream needs >1 chunk so createStreamIndex returns non-null.
@@ -343,7 +343,7 @@ TEST_F(ChunkIndexTest, streamIndexStreamId) {
   }
 }
 
-TEST_F(ChunkIndexTest, streamIndexLookupChunk) {
+TEST_F(ChunkStatsTest, streamIndexLookupChunk) {
   std::vector<std::string> indexColumns = {"col1"};
   std::string minKey = "aaa";
   // Setup: 4 stripes across 2 groups, each stripe with 2 streams
@@ -529,7 +529,7 @@ TEST_F(ChunkIndexTest, streamIndexLookupChunk) {
       "beyond the last chunk");
 }
 
-TEST_F(ChunkIndexTest, stripeIndexAndStreamIdOutOfBound) {
+TEST_F(ChunkStatsTest, stripeIndexAndStreamIdOutOfBound) {
   std::vector<std::string> indexColumns = {"col1"};
   std::string minKey = "aaa";
   // Setup: 4 stripes across 2 groups, each stripe with 2 streams
@@ -617,7 +617,7 @@ TEST_F(ChunkIndexTest, stripeIndexAndStreamIdOutOfBound) {
   EXPECT_EQ(chunkIndex1->createStreamIndex(3, 5, /*streamSize=*/1000), nullptr);
 }
 
-TEST_F(ChunkIndexTest, streamIndexRowCount) {
+TEST_F(ChunkStatsTest, streamIndexRowCount) {
   std::vector<std::string> indexColumns = {"col1"};
   std::string minKey = "aaa";
   // Setup: 4 stripes across 2 groups, each stripe with 2 streams
@@ -726,7 +726,7 @@ TEST_F(ChunkIndexTest, streamIndexRowCount) {
   }
 }
 
-TEST_F(ChunkIndexTest, chunkOnlyLookupByRowId) {
+TEST_F(ChunkStatsTest, chunkOnlyLookupByRowId) {
   // Chunk-index-only: no value index, no key stream.
   std::vector<ChunkOnlyStripe> stripes = {
       {.streams =

--- a/dwio/nimble/index/tests/ClusterIndexTestBase.cpp
+++ b/dwio/nimble/index/tests/ClusterIndexTestBase.cpp
@@ -16,7 +16,7 @@
 #include "dwio/nimble/index/tests/ClusterIndexTestBase.h"
 
 #include "dwio/nimble/index/tests/ClusterIndexTestUtils.h"
-#include "dwio/nimble/tablet/ChunkIndexGenerated.h"
+#include "dwio/nimble/tablet/ChunkStatsGenerated.h"
 #include "dwio/nimble/tablet/ClusterIndexGenerated.h"
 #include "dwio/nimble/tablet/MetadataInput.h"
 #include "folly/json/json.h"
@@ -76,7 +76,7 @@ ClusterIndexTestBase::IndexBuffers ClusterIndexTestBase::createTestClusterIndex(
     std::vector<uint32_t> chunkOffsets;
     std::vector<flatbuffers::Offset<flatbuffers::String>> chunkKeys;
 
-    // Build standalone ChunkIndexGroup for this group
+    // Build standalone ChunkStatsGroup for this group
     flatbuffers::FlatBufferBuilder chunkBuilder;
     std::vector<uint32_t> streamChunkCounts;
     std::vector<uint32_t> streamChunkRows;
@@ -157,8 +157,8 @@ ClusterIndexTestBase::IndexBuffers ClusterIndexTestBase::createTestClusterIndex(
 
     const uint32_t numStreams = streamChunkCounts.size() / groupStripeCount;
 
-    // Build standalone StripeChunkIndex flatbuffer
-    auto stripeChunkIndex = serialization::CreateStripeChunkIndex(
+    // Build standalone StripeChunkStats flatbuffer
+    auto stripeChunkIndex = serialization::CreateStripeChunkStats(
         chunkBuilder,
         numStreams,
         chunkBuilder.CreateVector(streamChunkCounts),
@@ -269,7 +269,7 @@ ClusterIndexTestBase::createChunkOnlyTestClusterIndex(
 
   uint32_t stripeIdx = 0;
   for (const auto& groupStripeCount : stripeGroups) {
-    // Build standalone ChunkIndexGroup only (no StripeClusterIndex needed)
+    // Build standalone ChunkStatsGroup only (no StripeClusterIndex needed)
     flatbuffers::FlatBufferBuilder chunkBuilder;
 
     std::vector<uint32_t> streamChunkCounts;
@@ -299,7 +299,7 @@ ClusterIndexTestBase::createChunkOnlyTestClusterIndex(
 
     const uint32_t numStreams = streamChunkCounts.size() / groupStripeCount;
 
-    auto stripeChunkIndex = serialization::CreateStripeChunkIndex(
+    auto stripeChunkIndex = serialization::CreateStripeChunkStats(
         chunkBuilder,
         numStreams,
         chunkBuilder.CreateVector(streamChunkCounts),
@@ -378,7 +378,7 @@ std::unique_ptr<ClusterIndex> ClusterIndexTestBase::createClusterIndex(
       std::move(dataInput));
 }
 
-std::shared_ptr<ChunkIndexGroup> ClusterIndexTestBase::createChunkIndex(
+std::shared_ptr<ChunkStatsGroup> ClusterIndexTestBase::createChunkIndex(
     const IndexBuffers& indexBuffers,
     uint32_t stripeGroupIndex) {
   // Compute firstStripe and stripeCount from stripeGroupIndices.
@@ -393,7 +393,7 @@ std::shared_ptr<ChunkIndexGroup> ClusterIndexTestBase::createChunkIndex(
     }
   }
 
-  // Find the ChunkIndexGroup data for this group using recorded sizes.
+  // Find the ChunkStatsGroup data for this group using recorded sizes.
   NIMBLE_CHECK_LT(stripeGroupIndex, indexBuffers.chunkIndexGroupSizes.size());
   size_t offset = 0;
   for (uint32_t g = 0; g < stripeGroupIndex; ++g) {
@@ -410,7 +410,7 @@ std::shared_ptr<ChunkIndexGroup> ClusterIndexTestBase::createChunkIndex(
           CompressionType::Uncompressed,
           pool_.get()));
 
-  return ChunkIndexGroup::create(
+  return ChunkStatsGroup::create(
       firstStripe, stripeCount, std::move(chunkIndexBuffer));
 }
 

--- a/dwio/nimble/index/tests/ClusterIndexTestBase.h
+++ b/dwio/nimble/index/tests/ClusterIndexTestBase.h
@@ -20,7 +20,7 @@
 #include <vector>
 
 #include "dwio/nimble/common/Exceptions.h"
-#include "dwio/nimble/index/ChunkIndexGroup.h"
+#include "dwio/nimble/index/ChunkStatsGroup.h"
 #include "dwio/nimble/index/ClusterIndex.h"
 #include "dwio/nimble/tablet/MetadataBuffer.h"
 #include "velox/common/file/File.h"
@@ -59,9 +59,9 @@ class ClusterIndexTestBase : public ::testing::Test {
     /// Serialized ClusterIndexGroup flatbuffers (cluster index) appended
     /// sequentially.
     std::string indexPartitions;
-    /// Serialized ChunkIndex flatbuffers appended sequentially.
+    /// Serialized ChunkStats flatbuffers appended sequentially.
     std::string chunkIndexGroups;
-    /// Size of each ChunkIndex flatbuffer in chunkIndexGroups.
+    /// Size of each ChunkStats flatbuffer in chunkIndexGroups.
     std::vector<size_t> chunkIndexGroupSizes;
     /// Serialized root Index flatbuffer.
     std::string rootIndex;
@@ -103,8 +103,8 @@ class ClusterIndexTestBase : public ::testing::Test {
       const IndexBuffers& indexBuffers,
       velox::ReadFile* keyStreamFile = nullptr);
 
-  /// Creates a ChunkIndexGroup from the serialized IndexBuffers.
-  std::shared_ptr<ChunkIndexGroup> createChunkIndex(
+  /// Creates a ChunkStatsGroup from the serialized IndexBuffers.
+  std::shared_ptr<ChunkStatsGroup> createChunkIndex(
       const IndexBuffers& indexBuffers,
       uint32_t stripeGroupIndex);
 

--- a/dwio/nimble/index/tests/ClusterIndexTestUtils.cpp
+++ b/dwio/nimble/index/tests/ClusterIndexTestUtils.cpp
@@ -105,6 +105,9 @@ std::vector<Chunk> createChunks(
     chunks.push_back(
         {.rowCount = spec.rowCount,
          .nullCount = spec.nullCount,
+         .minValue = spec.minValue,
+         .maxValue = spec.maxValue,
+         .hasMinMax = spec.hasMinMax,
          .content = {{pos, spec.size}}});
   }
   return chunks;

--- a/dwio/nimble/index/tests/ClusterIndexTestUtils.cpp
+++ b/dwio/nimble/index/tests/ClusterIndexTestUtils.cpp
@@ -103,7 +103,9 @@ std::vector<Chunk> createChunks(
     auto pos = buffer.reserve(spec.size);
     std::memset(pos, 'X', spec.size);
     chunks.push_back(
-        {.rowCount = spec.rowCount, .content = {{pos, spec.size}}});
+        {.rowCount = spec.rowCount,
+         .nullCount = spec.nullCount,
+         .content = {{pos, spec.size}}});
   }
   return chunks;
 }
@@ -167,6 +169,7 @@ StreamStats ChunkStatsTestHelper::streamStats(uint32_t streamId) const {
   NIMBLE_CHECK_NOT_NULL(chunkRows);
   const auto* chunkOffsets = root->stream_chunk_offsets();
   NIMBLE_CHECK_NOT_NULL(chunkOffsets);
+  const auto* chunkNullCounts = root->stream_chunk_null_counts();
 
   const uint32_t stripeCount = chunkStats_->stripeCount_;
 
@@ -186,6 +189,9 @@ StreamStats ChunkStatsTestHelper::streamStats(uint32_t streamId) const {
       const uint32_t chunkIndex = startChunkIndex + i;
       stats.chunkRows.push_back(chunkRows->Get(chunkIndex));
       stats.chunkOffsets.push_back(chunkOffsets->Get(chunkIndex));
+      if (chunkNullCounts != nullptr) {
+        stats.chunkNullCounts.push_back(chunkNullCounts->Get(chunkIndex));
+      }
     }
   }
 

--- a/dwio/nimble/index/tests/ClusterIndexTestUtils.cpp
+++ b/dwio/nimble/index/tests/ClusterIndexTestUtils.cpp
@@ -20,7 +20,7 @@
 #include "dwio/nimble/encodings/selection/EncodingSelectionPolicy.h"
 #include "dwio/nimble/index/IndexConfig.h"
 #include "dwio/nimble/index/IndexConstants.h"
-#include "dwio/nimble/tablet/ChunkIndexGenerated.h"
+#include "dwio/nimble/tablet/ChunkStatsGenerated.h"
 #include "dwio/nimble/tablet/ClusterIndexGenerated.h"
 #include "dwio/nimble/tablet/Constants.h"
 #include "dwio/nimble/tablet/IndexGenerated.h"
@@ -147,18 +147,18 @@ PartitionStats ClusterIndexTestHelper::partitionStats(
   return stats;
 }
 
-StreamStats ChunkIndexTestHelper::streamStats(uint32_t streamId) const {
+StreamStats ChunkStatsTestHelper::streamStats(uint32_t streamId) const {
   StreamStats stats;
 
-  const auto* root = flatbuffers::GetRoot<serialization::StripeChunkIndex>(
-      chunkIndex_->metadata_->content().data());
+  const auto* root = flatbuffers::GetRoot<serialization::StripeChunkStats>(
+      chunkStats_->metadata_->content().data());
 
   const auto* streamChunkCounts = root->stream_chunk_counts();
   if (streamChunkCounts == nullptr) {
     return stats;
   }
 
-  const uint32_t streamCount = chunkIndex_->streamCount_;
+  const uint32_t streamCount = chunkStats_->streamCount_;
   if (streamId >= streamCount) {
     return stats;
   }
@@ -168,7 +168,7 @@ StreamStats ChunkIndexTestHelper::streamStats(uint32_t streamId) const {
   const auto* chunkOffsets = root->stream_chunk_offsets();
   NIMBLE_CHECK_NOT_NULL(chunkOffsets);
 
-  const uint32_t stripeCount = chunkIndex_->stripeCount_;
+  const uint32_t stripeCount = chunkStats_->stripeCount_;
 
   uint32_t accumulatedChunkCountForStream = 0;
   for (uint32_t stripeOffset = 0; stripeOffset < stripeCount; ++stripeOffset) {

--- a/dwio/nimble/index/tests/ClusterIndexTestUtils.h
+++ b/dwio/nimble/index/tests/ClusterIndexTestUtils.h
@@ -144,6 +144,9 @@ struct ChunkSpec {
   uint32_t rowCount{};
   uint32_t size{};
   uint32_t nullCount{0};
+  int64_t minValue{0};
+  int64_t maxValue{0};
+  bool hasMinMax{false};
 };
 
 /// Specification for a single stream (for test data creation).

--- a/dwio/nimble/index/tests/ClusterIndexTestUtils.h
+++ b/dwio/nimble/index/tests/ClusterIndexTestUtils.h
@@ -24,7 +24,7 @@
 #include <vector>
 
 #include "dwio/nimble/common/Exceptions.h"
-#include "dwio/nimble/index/ChunkIndexGroup.h"
+#include "dwio/nimble/index/ChunkStatsGroup.h"
 #include "dwio/nimble/index/ClusterIndex.h"
 #include "dwio/nimble/tablet/TabletReader.h"
 #include "dwio/nimble/tablet/TabletWriter.h"
@@ -242,29 +242,29 @@ class ClusterIndexTestHelper {
   const ClusterIndex* const clusterIndex_;
 };
 
-/// Test helper class for ChunkIndexGroup.
-class ChunkIndexTestHelper {
+/// Test helper class for ChunkStatsGroup.
+class ChunkStatsTestHelper {
  public:
-  explicit ChunkIndexTestHelper(const ChunkIndexGroup* chunkIndex)
-      : chunkIndex_(chunkIndex) {}
+  explicit ChunkStatsTestHelper(const ChunkStatsGroup* chunkIndex)
+      : chunkStats_(chunkIndex) {}
 
   uint32_t firstStripe() const {
-    return chunkIndex_->firstStripe_;
+    return chunkStats_->firstStripe_;
   }
 
   uint32_t stripeCount() const {
-    return chunkIndex_->stripeCount_;
+    return chunkStats_->stripeCount_;
   }
 
   uint32_t streamCount() const {
-    return chunkIndex_->streamCount_;
+    return chunkStats_->streamCount_;
   }
 
   /// Returns stream position index statistics for the specified stream.
   StreamStats streamStats(uint32_t streamId) const;
 
  private:
-  const ChunkIndexGroup* const chunkIndex_;
+  const ChunkStatsGroup* const chunkStats_;
 };
 
 /// Test-only cluster index metadata writer for tablet-level tests.
@@ -300,14 +300,14 @@ class TestClusterIndexMetadataWriter {
   TabletWriter::CloseCallback createCloseCallback();
 
  private:
-  struct ChunkIndex {
+  struct ChunkStats {
     std::vector<uint32_t> chunkRows;
     std::vector<uint32_t> chunkOffsets;
     std::vector<std::string_view> chunkKeys;
   };
 
   struct IndexPartition {
-    ChunkIndex chunks;
+    ChunkStats chunks;
     std::unique_ptr<Buffer> encodingBuffer;
     // File-level offset and size after flushKeyStream() writes the key data
     // blob.

--- a/dwio/nimble/index/tests/ClusterIndexTestUtils.h
+++ b/dwio/nimble/index/tests/ClusterIndexTestUtils.h
@@ -134,12 +134,16 @@ struct StreamStats {
   std::vector<uint32_t> chunkRows;
   /// Byte offset of each chunk within its stream.
   std::vector<uint32_t> chunkOffsets;
+  /// Per-chunk null-value count for this stream. Empty when per-chunk null
+  /// statistics are absent from the section.
+  std::vector<uint32_t> chunkNullCounts;
 };
 
 /// Specification for a single chunk in a stream (for test data creation).
 struct ChunkSpec {
-  uint32_t rowCount;
-  uint32_t size;
+  uint32_t rowCount{};
+  uint32_t size{};
+  uint32_t nullCount{0};
 };
 
 /// Specification for a single stream (for test data creation).

--- a/dwio/nimble/tablet/CMakeLists.txt
+++ b/dwio/nimble/tablet/CMakeLists.txt
@@ -65,20 +65,20 @@ target_include_directories(
 add_dependencies(nimble_index_fb nimble_index_schema_fb)
 
 build_flatbuffers(
-  "${CMAKE_CURRENT_SOURCE_DIR}/ChunkIndex.fbs"
+  "${CMAKE_CURRENT_SOURCE_DIR}/ChunkStats.fbs"
   ""
-  nimble_chunk_index_schema_fb
+  nimble_chunk_stats_schema_fb
   ""
   "${CMAKE_CURRENT_BINARY_DIR}"
   ""
   ""
 )
-add_library(nimble_chunk_index_fb INTERFACE)
+add_library(nimble_chunk_stats_fb INTERFACE)
 target_include_directories(
-  nimble_chunk_index_fb
+  nimble_chunk_stats_fb
   INTERFACE ${PROJECT_BINARY_DIR} ${FLATBUFFERS_INCLUDE_DIR}
 )
-add_dependencies(nimble_chunk_index_fb nimble_chunk_index_schema_fb)
+add_dependencies(nimble_chunk_stats_fb nimble_chunk_stats_schema_fb)
 
 build_flatbuffers(
   "${CMAKE_CURRENT_SOURCE_DIR}/BloomFilter.fbs"
@@ -162,7 +162,7 @@ target_link_libraries(
     nimble_index
     nimble_tablet_common
     nimble_cluster_index_fb
-    nimble_chunk_index_fb
+    nimble_chunk_stats_fb
     nimble_hash_index_fb
 )
 
@@ -183,12 +183,12 @@ target_link_libraries(
     Folly::folly
 )
 
-add_library(nimble_tablet_writer ChunkIndexWriter.cpp TabletWriter.cpp)
+add_library(nimble_tablet_writer ChunkStatsWriter.cpp TabletWriter.cpp)
 target_link_libraries(
   nimble_tablet_writer
   nimble_tablet_common
   nimble_cluster_index_fb
-  nimble_chunk_index_fb
+  nimble_chunk_stats_fb
 )
 
 add_subdirectory(tests)

--- a/dwio/nimble/tablet/Chunk.h
+++ b/dwio/nimble/tablet/Chunk.h
@@ -31,6 +31,11 @@ struct Chunk {
   /// are enabled (VeloxWriterOptions::enableChunkIndex); left at 0 otherwise.
   uint32_t nullCount{0};
 
+  /// Per-chunk min/max raw 64-bit payloads; valid only when hasMinMax.
+  int64_t minValue{0};
+  int64_t maxValue{0};
+  bool hasMinMax{false};
+
   /// The encoded and compressed data content of this chunk, stored as a vector
   /// of string views. Each string_view points to a buffer containing a portion
   /// of the chunk's data. Multiple buffers may be used for large chunks.

--- a/dwio/nimble/tablet/Chunk.h
+++ b/dwio/nimble/tablet/Chunk.h
@@ -27,6 +27,10 @@ namespace facebook::nimble {
 struct Chunk {
   uint32_t rowCount{0};
 
+  /// Number of null values in this chunk. Only populated when chunk statistics
+  /// are enabled (VeloxWriterOptions::enableChunkIndex); left at 0 otherwise.
+  uint32_t nullCount{0};
+
   /// The encoded and compressed data content of this chunk, stored as a vector
   /// of string views. Each string_view points to a buffer containing a portion
   /// of the chunk's data. Multiple buffers may be used for large chunks.

--- a/dwio/nimble/tablet/ChunkStats.fbs
+++ b/dwio/nimble/tablet/ChunkStats.fbs
@@ -43,6 +43,11 @@ table StripeChunkStats {
   /// Appended field: absent in files written before per-chunk null statistics
   /// were added, in which case readers treat the null count as unknown.
   stream_chunk_null_counts:[uint32];
+  /// Per-chunk min/max raw 64-bit payloads (int64 integral; bit_cast of double
+  /// for float). Valid where stream_chunk_min_max_valid==1; appended fields.
+  stream_chunk_min_values:[long];
+  stream_chunk_max_values:[long];
+  stream_chunk_min_max_valid:[ubyte];
 }
 
 /// Root table for the chunk stats optional section ("columnar.chunk.stats").

--- a/dwio/nimble/tablet/ChunkStats.fbs
+++ b/dwio/nimble/tablet/ChunkStats.fbs
@@ -23,8 +23,8 @@ namespace facebook.nimble.serialization;
 ///
 /// All streams are indexed. Streams with a single chunk have one entry
 /// each. The group-level minAvgChunksPerStream threshold controls whether
-/// the entire chunk index is written for a stripe group.
-table StripeChunkIndex {
+/// the entire chunk stats section is written for a stripe group.
+table StripeChunkStats {
   /// Total number of streams indexed in this stripe group.
   stream_count:uint32;
   /// Accumulated chunk counts per (stripe, stream) pair,
@@ -41,13 +41,13 @@ table StripeChunkIndex {
   stream_chunk_offsets:[uint32];
 }
 
-/// Root table for the chunk index optional section.
+/// Root table for the chunk stats optional section ("columnar.chunk.stats").
 /// Contains per-stripe-group MetadataSection references.
-table ChunkIndex {
-  /// MetadataSection for each stripe group's StripeChunkIndex.
-  /// Parallel to Footer.stripe_groups. size==0 means no chunk index
+table ChunkStats {
+  /// MetadataSection for each stripe group's StripeChunkStats.
+  /// Parallel to Footer.stripe_groups. size==0 means no chunk stats
   /// for that group (e.g., when average chunks per stream is below threshold).
   stripe_indexes:[MetadataSection];
 }
 
-root_type ChunkIndex;
+root_type ChunkStats;

--- a/dwio/nimble/tablet/ChunkStats.fbs
+++ b/dwio/nimble/tablet/ChunkStats.fbs
@@ -39,6 +39,10 @@ table StripeChunkStats {
   stream_chunk_rows:[uint32];
   /// Byte offset of each chunk within its stream.
   stream_chunk_offsets:[uint32];
+  /// Per-chunk null-value count, parallel to stream_chunk_rows/offsets.
+  /// Appended field: absent in files written before per-chunk null statistics
+  /// were added, in which case readers treat the null count as unknown.
+  stream_chunk_null_counts:[uint32];
 }
 
 /// Root table for the chunk stats optional section ("columnar.chunk.stats").

--- a/dwio/nimble/tablet/ChunkStatsWriter.cpp
+++ b/dwio/nimble/tablet/ChunkStatsWriter.cpp
@@ -66,6 +66,7 @@ void ChunkStatsWriter::addStream(
     accumulatedRows += chunk.rowCount;
     index.chunkRows.emplace_back(accumulatedRows);
     index.chunkOffsets.emplace_back(accumulatedOffset);
+    index.chunkNullCounts.emplace_back(chunk.nullCount);
     accumulatedOffset += chunk.contentSize();
     ++index.chunkCount;
   }
@@ -123,8 +124,10 @@ void ChunkStatsWriter::writeGroup(
 
   std::vector<uint32_t> flattenedChunkRows;
   std::vector<uint32_t> flattenedChunkOffsets;
+  std::vector<uint32_t> flattenedChunkNullCounts;
   flattenedChunkRows.reserve(accumulatedChunkCount);
   flattenedChunkOffsets.reserve(accumulatedChunkCount);
+  flattenedChunkNullCounts.reserve(accumulatedChunkCount);
 
   for (const auto& stripe : groupIndex_->stripes) {
     for (size_t streamId = 0; streamId < streamCount; ++streamId) {
@@ -138,6 +141,10 @@ void ChunkStatsWriter::writeGroup(
             flattenedChunkOffsets.end(),
             stream.chunkOffsets.begin(),
             stream.chunkOffsets.end());
+        flattenedChunkNullCounts.insert(
+            flattenedChunkNullCounts.end(),
+            stream.chunkNullCounts.begin(),
+            stream.chunkNullCounts.end());
       }
     }
   }
@@ -148,7 +155,8 @@ void ChunkStatsWriter::writeGroup(
       static_cast<uint32_t>(streamCount),
       builder.CreateVector(flattenedStreamChunkCounts),
       builder.CreateVector(flattenedChunkRows),
-      builder.CreateVector(flattenedChunkOffsets));
+      builder.CreateVector(flattenedChunkOffsets),
+      builder.CreateVector(flattenedChunkNullCounts));
   builder.Finish(chunkIndex);
 
   chunkIndexSections_.push_back(createMetadataSection(asView(builder)));

--- a/dwio/nimble/tablet/ChunkStatsWriter.cpp
+++ b/dwio/nimble/tablet/ChunkStatsWriter.cpp
@@ -14,12 +14,12 @@
  * limitations under the License.
  */
 
-#include "dwio/nimble/tablet/ChunkIndexWriter.h"
+#include "dwio/nimble/tablet/ChunkStatsWriter.h"
 
 #include <algorithm>
 
 #include "dwio/nimble/common/Exceptions.h"
-#include "dwio/nimble/tablet/ChunkIndexGenerated.h"
+#include "dwio/nimble/tablet/ChunkStatsGenerated.h"
 #include "dwio/nimble/tablet/Constants.h"
 #include "dwio/nimble/tablet/TabletWriter.h"
 #include "flatbuffers/flatbuffers.h"
@@ -37,13 +37,13 @@ std::string_view asView(const flatbuffers::FlatBufferBuilder& builder) {
 
 } // namespace
 
-ChunkIndexWriter::ChunkIndexWriter(
+ChunkStatsWriter::ChunkStatsWriter(
     velox::memory::MemoryPool& pool,
     float minAvgChunksPerStream)
     : pool_{&pool}, minAvgChunksPerStream_{minAvgChunksPerStream} {}
 
-void ChunkIndexWriter::newStripe(size_t streamCount) {
-  NIMBLE_CHECK(!finalized_, "ChunkIndexWriter has been finalized");
+void ChunkStatsWriter::newStripe(size_t streamCount) {
+  NIMBLE_CHECK(!finalized_, "ChunkStatsWriter has been finalized");
   if (groupIndex_ == nullptr) {
     groupIndex_ = std::make_unique<GroupIndex>();
   }
@@ -51,10 +51,10 @@ void ChunkIndexWriter::newStripe(size_t streamCount) {
   stripeIndex.streams.resize(streamCount);
 }
 
-void ChunkIndexWriter::addStream(
+void ChunkStatsWriter::addStream(
     uint32_t streamIndex,
     const std::vector<Chunk>& chunks) {
-  NIMBLE_CHECK(!finalized_, "ChunkIndexWriter has been finalized");
+  NIMBLE_CHECK(!finalized_, "ChunkStatsWriter has been finalized");
   NIMBLE_CHECK_NOT_NULL(groupIndex_);
   NIMBLE_CHECK(!groupIndex_->empty());
   NIMBLE_CHECK_LT(streamIndex, groupIndex_->stripes.back().streams.size());
@@ -71,11 +71,11 @@ void ChunkIndexWriter::addStream(
   }
 }
 
-void ChunkIndexWriter::writeGroup(
+void ChunkStatsWriter::writeGroup(
     size_t streamCount,
     size_t stripeCount,
     const CreateMetadataSectionFn& createMetadataSection) {
-  NIMBLE_CHECK(!finalized_, "ChunkIndexWriter has been finalized");
+  NIMBLE_CHECK(!finalized_, "ChunkStatsWriter has been finalized");
   NIMBLE_CHECK_NOT_NULL(groupIndex_);
   NIMBLE_CHECK_EQ(stripeCount, groupIndex_->stripes.size());
   NIMBLE_CHECK_GT(stripeCount, 0);
@@ -143,7 +143,7 @@ void ChunkIndexWriter::writeGroup(
   }
 
   flatbuffers::FlatBufferBuilder builder(kInitialFooterSize);
-  auto chunkIndex = serialization::CreateStripeChunkIndex(
+  auto chunkIndex = serialization::CreateStripeChunkStats(
       builder,
       static_cast<uint32_t>(streamCount),
       builder.CreateVector(flattenedStreamChunkCounts),
@@ -154,9 +154,9 @@ void ChunkIndexWriter::writeGroup(
   chunkIndexSections_.push_back(createMetadataSection(asView(builder)));
 }
 
-void ChunkIndexWriter::writeRoot(
+void ChunkStatsWriter::writeRoot(
     const WriteOptionalSectionFn& writeOptionalSection) {
-  NIMBLE_CHECK(!finalized_, "ChunkIndexWriter has been finalized");
+  NIMBLE_CHECK(!finalized_, "ChunkStatsWriter has been finalized");
   SCOPE_EXIT {
     finalized_ = true;
   };
@@ -186,8 +186,8 @@ void ChunkIndexWriter::writeRoot(
                     chunkIndexSections_[i].size()));
           });
 
-  builder.Finish(serialization::CreateChunkIndex(builder, stripeIndexesVector));
-  writeOptionalSection(std::string(kChunkIndexSection), asView(builder));
+  builder.Finish(serialization::CreateChunkStats(builder, stripeIndexesVector));
+  writeOptionalSection(std::string(kChunkStatsSection), asView(builder));
 }
 
 } // namespace facebook::nimble

--- a/dwio/nimble/tablet/ChunkStatsWriter.cpp
+++ b/dwio/nimble/tablet/ChunkStatsWriter.cpp
@@ -67,6 +67,9 @@ void ChunkStatsWriter::addStream(
     index.chunkRows.emplace_back(accumulatedRows);
     index.chunkOffsets.emplace_back(accumulatedOffset);
     index.chunkNullCounts.emplace_back(chunk.nullCount);
+    index.chunkMinValues.emplace_back(chunk.minValue);
+    index.chunkMaxValues.emplace_back(chunk.maxValue);
+    index.chunkMinMaxValid.emplace_back(chunk.hasMinMax ? 1 : 0);
     accumulatedOffset += chunk.contentSize();
     ++index.chunkCount;
   }
@@ -125,9 +128,15 @@ void ChunkStatsWriter::writeGroup(
   std::vector<uint32_t> flattenedChunkRows;
   std::vector<uint32_t> flattenedChunkOffsets;
   std::vector<uint32_t> flattenedChunkNullCounts;
+  std::vector<int64_t> flattenedChunkMinValues;
+  std::vector<int64_t> flattenedChunkMaxValues;
+  std::vector<uint8_t> flattenedChunkMinMaxValid;
   flattenedChunkRows.reserve(accumulatedChunkCount);
   flattenedChunkOffsets.reserve(accumulatedChunkCount);
   flattenedChunkNullCounts.reserve(accumulatedChunkCount);
+  flattenedChunkMinValues.reserve(accumulatedChunkCount);
+  flattenedChunkMaxValues.reserve(accumulatedChunkCount);
+  flattenedChunkMinMaxValid.reserve(accumulatedChunkCount);
 
   for (const auto& stripe : groupIndex_->stripes) {
     for (size_t streamId = 0; streamId < streamCount; ++streamId) {
@@ -145,9 +154,29 @@ void ChunkStatsWriter::writeGroup(
             flattenedChunkNullCounts.end(),
             stream.chunkNullCounts.begin(),
             stream.chunkNullCounts.end());
+        flattenedChunkMinValues.insert(
+            flattenedChunkMinValues.end(),
+            stream.chunkMinValues.begin(),
+            stream.chunkMinValues.end());
+        flattenedChunkMaxValues.insert(
+            flattenedChunkMaxValues.end(),
+            stream.chunkMaxValues.begin(),
+            stream.chunkMaxValues.end());
+        flattenedChunkMinMaxValid.insert(
+            flattenedChunkMinMaxValid.end(),
+            stream.chunkMinMaxValid.begin(),
+            stream.chunkMinMaxValid.end());
       }
     }
   }
+
+  // All per-chunk arrays must stay in lockstep -- the reader indexes them by
+  // the same chunk position.
+  NIMBLE_DCHECK_EQ(flattenedChunkOffsets.size(), flattenedChunkRows.size());
+  NIMBLE_DCHECK_EQ(flattenedChunkNullCounts.size(), flattenedChunkRows.size());
+  NIMBLE_DCHECK_EQ(flattenedChunkMinValues.size(), flattenedChunkRows.size());
+  NIMBLE_DCHECK_EQ(flattenedChunkMaxValues.size(), flattenedChunkRows.size());
+  NIMBLE_DCHECK_EQ(flattenedChunkMinMaxValid.size(), flattenedChunkRows.size());
 
   flatbuffers::FlatBufferBuilder builder(kInitialFooterSize);
   auto chunkIndex = serialization::CreateStripeChunkStats(
@@ -156,7 +185,10 @@ void ChunkStatsWriter::writeGroup(
       builder.CreateVector(flattenedStreamChunkCounts),
       builder.CreateVector(flattenedChunkRows),
       builder.CreateVector(flattenedChunkOffsets),
-      builder.CreateVector(flattenedChunkNullCounts));
+      builder.CreateVector(flattenedChunkNullCounts),
+      builder.CreateVector(flattenedChunkMinValues),
+      builder.CreateVector(flattenedChunkMaxValues),
+      builder.CreateVector(flattenedChunkMinMaxValid));
   builder.Finish(chunkIndex);
 
   chunkIndexSections_.push_back(createMetadataSection(asView(builder)));

--- a/dwio/nimble/tablet/ChunkStatsWriter.h
+++ b/dwio/nimble/tablet/ChunkStatsWriter.h
@@ -84,6 +84,9 @@ class ChunkStatsWriter {
     std::vector<uint32_t> chunkOffsets;
     // Per-chunk null-value count (statistic used for chunk skipping).
     std::vector<uint32_t> chunkNullCounts;
+    std::vector<int64_t> chunkMinValues;
+    std::vector<int64_t> chunkMaxValues;
+    std::vector<uint8_t> chunkMinMaxValid;
     // Number of chunks in this stripe for this stream.
     uint32_t chunkCount{0};
   };

--- a/dwio/nimble/tablet/ChunkStatsWriter.h
+++ b/dwio/nimble/tablet/ChunkStatsWriter.h
@@ -82,6 +82,8 @@ class ChunkStatsWriter {
     std::vector<uint32_t> chunkRows;
     // Byte offsets of each chunk within the stream.
     std::vector<uint32_t> chunkOffsets;
+    // Per-chunk null-value count (statistic used for chunk skipping).
+    std::vector<uint32_t> chunkNullCounts;
     // Number of chunks in this stripe for this stream.
     uint32_t chunkCount{0};
   };

--- a/dwio/nimble/tablet/ChunkStatsWriter.h
+++ b/dwio/nimble/tablet/ChunkStatsWriter.h
@@ -25,30 +25,30 @@ namespace facebook::nimble {
 
 struct Chunk;
 
-/// ChunkIndexWriter manages chunk-level position index data for streams.
+/// ChunkStatsWriter manages chunk-level position index data for streams.
 ///
 /// This index enables O(1) chunk-level seeking within stripes via
 /// ChunkedDecoder::skipWithIndex(). It can be used standalone (chunk-index-only
 /// mode) or combined with a cluster index (ClusterIndexWriter).
 ///
-/// Each stripe group produces a standalone ChunkIndex flatbuffer stored as a
-/// MetadataSection. The root ChunkIndexRoot table is written to the
-/// "chunk_index" optional section.
+/// Each stripe group produces a standalone ChunkStats flatbuffer stored as a
+/// MetadataSection. The root ChunkStats table is written to the
+/// "columnar.chunk.stats" optional section.
 ///
 /// NOTE: This class is not thread-safe. All methods must be called from a
 /// single thread.
-class ChunkIndexWriter {
+class ChunkStatsWriter {
  public:
   /// @param pool Memory pool for allocations.
   /// @param minAvgChunksPerStream Skip writing chunk index for a stripe group
   ///        if the average number of chunks per stream is below this threshold.
   ///        0 disables chunk index skipping.
-  explicit ChunkIndexWriter(
+  explicit ChunkStatsWriter(
       velox::memory::MemoryPool& pool,
       float minAvgChunksPerStream = 2);
 
-  ChunkIndexWriter(const ChunkIndexWriter&) = delete;
-  ChunkIndexWriter& operator=(const ChunkIndexWriter&) = delete;
+  ChunkStatsWriter(const ChunkStatsWriter&) = delete;
+  ChunkStatsWriter& operator=(const ChunkStatsWriter&) = delete;
 
   /// Initializes structures for writing a new stripe.
   void newStripe(size_t streamCount);
@@ -56,7 +56,7 @@ class ChunkIndexWriter {
   /// Adds chunk-level index data for a stream.
   void addStream(uint32_t streamIndex, const std::vector<Chunk>& chunks);
 
-  /// Writes a standalone ChunkIndex flatbuffer for the current stripe group
+  /// Writes a standalone ChunkStats flatbuffer for the current stripe group
   /// and stores the resulting MetadataSection.
   ///
   /// @param streamCount Total number of streams in the stripe group.
@@ -68,7 +68,7 @@ class ChunkIndexWriter {
       size_t stripeCount,
       const CreateMetadataSectionFn& createMetadataSection);
 
-  /// Writes the root ChunkIndexRoot table to the "chunk_index" optional
+  /// Writes the root ChunkStats table to the "columnar.chunk.stats" optional
   /// section.
   ///
   /// @param writeOptionalSection Callback to persist the root chunk index as a

--- a/dwio/nimble/tablet/Constants.h
+++ b/dwio/nimble/tablet/Constants.h
@@ -36,6 +36,6 @@ constexpr std::string_view kVectorizedStatsSection =
     "columnar.vectorized_stats";
 constexpr std::string_view kIndexSection = "columnar.indexes";
 // TODO: Rename this section to "columnar.chunk.stats".
-constexpr std::string_view kChunkIndexSection = "columnar.chunk.index";
+constexpr std::string_view kChunkStatsSection = "columnar.chunk.stats";
 
 } // namespace facebook::nimble

--- a/dwio/nimble/tablet/FileLayout.h
+++ b/dwio/nimble/tablet/FileLayout.h
@@ -67,7 +67,7 @@ namespace facebook::nimble {
 /// |  Optional: "columnar.indexes" (root index manifest with named     |
 /// |            cluster and dense index payloads)                      |
 /// +-------------------------------------------------------------------+
-/// |  Optional: "columnar.chunk.index" (root ChunkIndex flatbuffer     |
+/// |  Optional: "columnar.chunk.stats" (root ChunkStats flatbuffer     |
 /// |            with stripe_indexes)                                   |
 /// +-------------------------------------------------------------------+
 /// |  Optional: "schema", "stats", etc.                                |
@@ -113,11 +113,11 @@ namespace facebook::nimble {
 ///   | stripe_row_counts: row count per stripe                        |
 ///   +---------------------------------------------------------------+
 ///
-/// Chunk Index ("columnar.chunk.index"):
-///   Root ChunkIndex flatbuffer (see ChunkIndex.fbs) containing:
-///   - stripe_indexes: refs to per-group StripeChunkIndex metadata
+/// Chunk Stats ("columnar.chunk.stats"):
+///   Root ChunkStats flatbuffer (see ChunkStats.fbs) containing:
+///   - stripe_indexes: refs to per-group StripeChunkStats metadata
 ///
-///   StripeChunkIndex (per stripe group):
+///   StripeChunkStats (per stripe group):
 ///   +---------------------------------------------------------------+
 ///   | stream_count: total number of indexed streams                   |
 ///   | stream_chunk_counts: accumulated chunks per (stripe, stream)   |

--- a/dwio/nimble/tablet/TabletReader.cpp
+++ b/dwio/nimble/tablet/TabletReader.cpp
@@ -19,7 +19,7 @@
 #include "dwio/nimble/common/Types.h"
 #include "dwio/nimble/index/ClusterIndexFactory.h"
 #include "dwio/nimble/index/IndexSerialization.h"
-#include "dwio/nimble/tablet/ChunkIndexGenerated.h"
+#include "dwio/nimble/tablet/ChunkStatsGenerated.h"
 #include "dwio/nimble/tablet/Constants.h"
 #include "dwio/nimble/tablet/FooterGenerated.h"
 #include "dwio/nimble/tablet/IndexGenerated.h"
@@ -82,7 +82,7 @@ TabletReader::Options TabletReader::configureOptions(
   tabletOptions.preloadIndex = options.preloadIndex();
   tabletOptions.loadChunkIndex = options.loadChunkIndex();
   if (tabletOptions.loadChunkIndex) {
-    tabletOptions.preloadOptionalSections.emplace_back(kChunkIndexSection);
+    tabletOptions.preloadOptionalSections.emplace_back(kChunkStatsSection);
   }
   tabletOptions.pinMetadata = options.pinMetadata();
   tabletOptions.cacheMetadata = options.cacheMetadata();
@@ -276,7 +276,7 @@ TabletReader::TabletReader(
           options.pinMetadata},
       chunkIndexCache_{
           [this](uint32_t stripeGroupIndex) {
-            return loadChunkIndexGroup(stripeGroupIndex);
+            return loadChunkStatsGroup(stripeGroupIndex);
           },
           options.pinMetadata} {
   NIMBLE_CHECK_EQ(
@@ -509,12 +509,12 @@ void TabletReader::cacheMetadata(
     cacheSection(indexIt->second);
   }
 
-  if (chunkIndex_ != nullptr) {
-    auto chunkIndexIt = optionalSections_.find(std::string{kChunkIndexSection});
+  if (chunkStats_ != nullptr) {
+    auto chunkIndexIt = optionalSections_.find(std::string{kChunkStatsSection});
     NIMBLE_CHECK(chunkIndexIt != optionalSections_.end());
     cacheSection(chunkIndexIt->second);
 
-    const auto& firstSection = chunkIndex_->groupMetadata(0);
+    const auto& firstSection = chunkStats_->groupMetadata(0);
     if (firstSection.size() > 0) {
       cacheSection(firstSection);
     }
@@ -548,7 +548,7 @@ void TabletReader::loadStripes(
     updateOffset(kIndexSection);
   }
   if (options.loadChunkIndex) {
-    updateOffset(kChunkIndexSection);
+    updateOffset(kChunkStatsSection);
   }
   const uint64_t requiredSize = fileSize_ - requiredOffset;
   if (requiredSize > footerIoSize) {
@@ -862,7 +862,7 @@ TabletReader::StripeGroupMetadata TabletReader::loadStripeGroupMetadata(
   std::vector<MetadataSection> sections;
   sections.emplace_back(groupSection);
   if (hasChunkIndex) {
-    sections.emplace_back(chunkIndex_->groupMetadata(stripeGroupIndex));
+    sections.emplace_back(chunkStats_->groupMetadata(stripeGroupIndex));
   }
 
   auto results = metadataInput_->load(sections);
@@ -875,7 +875,7 @@ TabletReader::StripeGroupMetadata TabletReader::loadStripeGroupMetadata(
   if (hasChunkIndex) {
     auto chunkIndexMetadata =
         std::make_unique<MetadataBuffer>(std::move(*results[1]));
-    result.chunkIndex = ChunkIndexGroup::create(
+    result.chunkIndex = ChunkStatsGroup::create(
         result.stripeGroup->firstStripe(),
         result.stripeGroup->stripeCount(),
         std::move(chunkIndexMetadata));
@@ -938,7 +938,7 @@ StripeIdentifier TabletReader::stripeIdentifier(uint32_t stripeIndex) const {
       stripeGroupIndex,
       [&loaded](uint32_t) { return std::move(loaded.stripeGroup); });
 
-  std::shared_ptr<ChunkIndexGroup> cachedChunkIndex;
+  std::shared_ptr<ChunkStatsGroup> cachedChunkIndex;
   if (hasChunkIndex) {
     cachedChunkIndex = chunkIndexCache_.getOrCreate(
         stripeGroupIndex,
@@ -1096,7 +1096,7 @@ std::optional<Section> TabletReader::loadOptionalSection(
 }
 
 bool TabletReader::hasChunkIndexSection() const {
-  return hasOptionalSection(std::string{kChunkIndexSection});
+  return hasOptionalSection(std::string{kChunkStatsSection});
 }
 
 bool TabletReader::hasIndexSection() const {
@@ -1215,25 +1215,25 @@ void TabletReader::initChunkIndex(
   }
 
   auto section =
-      loadOptionalSection(std::string{kChunkIndexSection}, /*keepCache=*/false);
-  NIMBLE_CHECK(section.has_value(), "Failed to load chunk_index section.");
+      loadOptionalSection(std::string{kChunkStatsSection}, /*keepCache=*/false);
+  NIMBLE_CHECK(section.has_value(), "Failed to load chunk stats section.");
 
-  auto chunkIndex = ChunkIndex::create(std::move(section.value()));
+  auto chunkIndex = ChunkStats::create(std::move(section.value()));
   if (chunkIndex->numGroups() > 0) {
-    chunkIndex_ = std::move(chunkIndex);
+    chunkStats_ = std::move(chunkIndex);
   }
 
   // Eagerly pin the first chunk index group if covered by the speculative
   // buffer.
-  if (chunkIndex_ != nullptr && chunkIndex_->numGroups() == 1) {
-    const auto& groupMetadata = chunkIndex_->groupMetadata(0);
+  if (chunkStats_ != nullptr && chunkStats_->numGroups() == 1) {
+    const auto& groupMetadata = chunkStats_->groupMetadata(0);
     if (groupMetadata.size() > 0) {
       auto metadataBuffer =
           tryExtractFromBuffer(footerBuf, footerOffset, groupMetadata, pool_);
       if (metadataBuffer != nullptr) {
         chunkIndexCache_.pin(
             0,
-            ChunkIndexGroup::create(
+            ChunkStatsGroup::create(
                 firstStripe(0), stripeCount(0), std::move(metadataBuffer)));
       }
     }
@@ -1286,25 +1286,25 @@ uint32_t TabletReader::stripeCount(uint32_t stripeGroupIndex) const {
   return count;
 }
 
-std::shared_ptr<ChunkIndexGroup> TabletReader::chunkIndex(
+std::shared_ptr<ChunkStatsGroup> TabletReader::chunkIndex(
     uint32_t stripeGroupIndex) const {
   return chunkIndexCache_.getOrCreate(stripeGroupIndex);
 }
 
-std::shared_ptr<ChunkIndexGroup> TabletReader::loadChunkIndexGroup(
+std::shared_ptr<ChunkStatsGroup> TabletReader::loadChunkStatsGroup(
     uint32_t stripeGroupIndex) const {
-  NIMBLE_CHECK_NOT_NULL(chunkIndex_, "Chunk index not initialized.");
+  NIMBLE_CHECK_NOT_NULL(chunkStats_, "Chunk index not initialized.");
   NIMBLE_CHECK_LT(
       stripeGroupIndex,
-      chunkIndex_->numGroups(),
+      chunkStats_->numGroups(),
       "Chunk index group out of range");
 
-  const auto& section = chunkIndex_->groupMetadata(stripeGroupIndex);
+  const auto& section = chunkStats_->groupMetadata(stripeGroupIndex);
   if (section.size() == 0) {
     return nullptr;
   }
 
-  return ChunkIndexGroup::create(
+  return ChunkStatsGroup::create(
       this->firstStripe(stripeGroupIndex),
       this->stripeCount(stripeGroupIndex),
       readMetadata(section));

--- a/dwio/nimble/tablet/TabletReader.h
+++ b/dwio/nimble/tablet/TabletReader.h
@@ -22,8 +22,8 @@
 #include <vector>
 
 #include "dwio/nimble/common/Vector.h"
-#include "dwio/nimble/index/ChunkIndex.h"
-#include "dwio/nimble/index/ChunkIndexGroup.h"
+#include "dwio/nimble/index/ChunkStats.h"
+#include "dwio/nimble/index/ChunkStatsGroup.h"
 #include "dwio/nimble/index/ClusterIndex.h"
 #include "dwio/nimble/index/DenseIndexRegistry.h"
 #include "dwio/nimble/index/IndexConfig.h"
@@ -107,18 +107,18 @@ class StripeGroup {
   const uint32_t* streamSizes_;
 };
 
-using index::ChunkIndex;
-using index::ChunkIndexGroup;
+using index::ChunkStats;
+using index::ChunkStatsGroup;
 
 class StripeIdentifier {
  public:
   StripeIdentifier(
       uint32_t stripeId,
       std::shared_ptr<StripeGroup> stripeGroup,
-      std::shared_ptr<ChunkIndexGroup> chunkIndex = nullptr)
+      std::shared_ptr<ChunkStatsGroup> chunkIndex = nullptr)
       : stripeId_{stripeId},
         stripeGroup_{std::move(stripeGroup)},
-        chunkIndex_{std::move(chunkIndex)} {}
+        chunkStats_{std::move(chunkIndex)} {}
 
   uint32_t stripeId() const {
     return stripeId_;
@@ -128,14 +128,14 @@ class StripeIdentifier {
     return stripeGroup_;
   }
 
-  const std::shared_ptr<ChunkIndexGroup>& chunkIndex() const {
-    return chunkIndex_;
+  const std::shared_ptr<ChunkStatsGroup>& chunkIndex() const {
+    return chunkStats_;
   }
 
  private:
   uint32_t stripeId_;
   std::shared_ptr<StripeGroup> stripeGroup_;
-  std::shared_ptr<ChunkIndexGroup> chunkIndex_;
+  std::shared_ptr<ChunkStatsGroup> chunkStats_;
 };
 
 using index::ClusterIndex;
@@ -178,7 +178,7 @@ class TabletReader {
     /// Whether to load the dense indexes during initialization. Default false.
     bool loadDenseIndexes{false};
 
-    /// If true, pins parsed metadata objects (StripeGroup, ChunkIndexGroup)
+    /// If true, pins parsed metadata objects (StripeGroup, ChunkStatsGroup)
     /// in the metadata cache with strong references so they are never evicted.
     /// This avoids re-reading and re-parsing metadata on every stripe access
     /// when the weak-pointer cache entries would otherwise expire. Works
@@ -281,8 +281,8 @@ class TabletReader {
   // Returns true if the chunk index is loaded and has data for the given
   // stripe group.
   inline bool hasChunkIndex(uint32_t stripeGroupIndex) const {
-    return chunkIndex_ != nullptr &&
-        chunkIndex_->groupMetadata(stripeGroupIndex).size() > 0;
+    return chunkStats_ != nullptr &&
+        chunkStats_->groupMetadata(stripeGroupIndex).size() > 0;
   }
 
   // Returns the cluster index if available, nullptr otherwise.
@@ -494,7 +494,7 @@ class TabletReader {
   // Holds the result of a coalesced metadata load for a stripe group.
   struct StripeGroupMetadata {
     std::shared_ptr<StripeGroup> stripeGroup;
-    std::shared_ptr<ChunkIndexGroup> chunkIndex;
+    std::shared_ptr<ChunkStatsGroup> chunkIndex;
   };
 
   // Loads stripe group and chunk index together using coalesced IO via
@@ -522,11 +522,11 @@ class TabletReader {
       std::string_view footerBuf = {},
       uint64_t footerOffset = 0);
 
-  // Returns the cached ChunkIndexGroup for the given stripe group index.
-  std::shared_ptr<ChunkIndexGroup> chunkIndex(uint32_t stripeGroupIndex) const;
+  // Returns the cached ChunkStatsGroup for the given stripe group index.
+  std::shared_ptr<ChunkStatsGroup> chunkIndex(uint32_t stripeGroupIndex) const;
 
-  // Loads the ChunkIndexGroup for the given stripe group index from file.
-  std::shared_ptr<ChunkIndexGroup> loadChunkIndexGroup(
+  // Loads the ChunkStatsGroup for the given stripe group index from file.
+  std::shared_ptr<ChunkStatsGroup> loadChunkStatsGroup(
       uint32_t stripeGroupIndex) const;
 
   // Computes first stripe index for the given stripe group.
@@ -575,9 +575,9 @@ class TabletReader {
 
   std::unique_ptr<index::DenseIndexRegistry> denseIndexRegistry_;
 
-  // Chunk index root, loaded from "chunk_index" optional section.
-  std::unique_ptr<ChunkIndex> chunkIndex_;
-  mutable MetadataCache<uint32_t, ChunkIndexGroup> chunkIndexCache_;
+  // Chunk stats root, loaded from the "columnar.chunk.stats" optional section.
+  std::unique_ptr<ChunkStats> chunkStats_;
+  mutable MetadataCache<uint32_t, ChunkStatsGroup> chunkIndexCache_;
 
   std::unordered_map<std::string, MetadataSection> optionalSections_;
   mutable folly::Synchronized<

--- a/dwio/nimble/tablet/TabletWriter.cpp
+++ b/dwio/nimble/tablet/TabletWriter.cpp
@@ -39,7 +39,7 @@ TabletWriter::TabletWriter(
       options_(std::move(options)),
       checksum_{ChecksumFactory::create(options_.checksumType)},
       chunkIndexWriter_{
-          options_.enableChunkIndex ? std::make_unique<ChunkIndexWriter>(
+          options_.enableChunkIndex ? std::make_unique<ChunkStatsWriter>(
                                           pool,
                                           options_.chunkIndexMinAvgChunks)
                                     : nullptr} {}
@@ -298,7 +298,7 @@ void TabletWriter::writeStripe(uint32_t rowCount, std::vector<Stream> streams) {
   auto& stripeStreamOffsets = streamOffsets_.emplace_back(streamCount, 0);
   auto& stripeStreamSizes = streamSizes_.emplace_back(streamCount, 0);
 
-  finishStripeChunkIndex(streamCount);
+  finishStripeChunkStats(streamCount);
 
   if (options_.layoutPlanner != nullptr) {
     streams = options_.layoutPlanner->getLayout(std::move(streams));
@@ -580,7 +580,7 @@ void TabletWriter::tryWriteStripeGroup(bool force) {
   // these is handled by the |createFlattenedVector| function.
   writeStripeGroup(streamCount, stripeCount);
 
-  writeChunkIndexGroup(streamCount, stripeCount);
+  writeChunkStatsGroup(streamCount, stripeCount);
 
   invokeStripeGroupFlushCallback();
 
@@ -614,7 +614,7 @@ void TabletWriter::writeStreamWithChecksum(const Stream& stream) {
   }
 }
 
-void TabletWriter::finishStripeChunkIndex(size_t streamCount) {
+void TabletWriter::finishStripeChunkStats(size_t streamCount) {
   if (hasChunkIndex()) {
     chunkIndexWriter_->newStripe(streamCount);
   }
@@ -629,7 +629,7 @@ void TabletWriter::addStreamChunkIndex(
   chunkIndexWriter_->addStream(streamIndex, chunks);
 }
 
-void TabletWriter::writeChunkIndexGroup(
+void TabletWriter::writeChunkStatsGroup(
     size_t streamCount,
     size_t stripeCount) {
   if (hasChunkIndex()) {

--- a/dwio/nimble/tablet/TabletWriter.h
+++ b/dwio/nimble/tablet/TabletWriter.h
@@ -20,7 +20,7 @@
 #include "dwio/nimble/common/Checksum.h"
 #include "dwio/nimble/common/Vector.h"
 #include "dwio/nimble/tablet/Chunk.h"
-#include "dwio/nimble/tablet/ChunkIndexWriter.h"
+#include "dwio/nimble/tablet/ChunkStatsWriter.h"
 #include "dwio/nimble/tablet/FileLayout.h"
 #include "dwio/nimble/tablet/FooterGenerated.h"
 #include "dwio/nimble/tablet/MetadataBuffer.h"
@@ -180,7 +180,7 @@ class TabletWriter {
   void writeStreamWithChecksum(const Stream& stream);
 
   // Starts chunk index writing for a new stripe.
-  void finishStripeChunkIndex(size_t streamCount);
+  void finishStripeChunkStats(size_t streamCount);
 
   // Adds chunk-level index data for a stream.
   void addStreamChunkIndex(
@@ -188,7 +188,7 @@ class TabletWriter {
       const std::vector<Chunk>& chunks);
 
   // Writes the chunk index group for a completed stripe group.
-  void writeChunkIndexGroup(size_t streamCount, size_t stripeCount);
+  void writeChunkStatsGroup(size_t streamCount, size_t stripeCount);
 
   // Writes the chunk index root.
   void writeChunkIndexRoot();
@@ -198,7 +198,7 @@ class TabletWriter {
   const Options options_;
   const std::unique_ptr<Checksum> checksum_;
   // Chunk-level position index.
-  const std::unique_ptr<ChunkIndexWriter> chunkIndexWriter_;
+  const std::unique_ptr<ChunkStatsWriter> chunkIndexWriter_;
 
   // Number of rows in each stripe.
   std::vector<uint32_t> stripeRowCounts_;

--- a/dwio/nimble/tablet/tests/ChunkStatsWriterTest.cpp
+++ b/dwio/nimble/tablet/tests/ChunkStatsWriterTest.cpp
@@ -14,25 +14,25 @@
  * limitations under the License.
  */
 
-#include "dwio/nimble/tablet/ChunkIndexWriter.h"
+#include "dwio/nimble/tablet/ChunkStatsWriter.h"
 
 #include <gtest/gtest.h>
 
 #include "dwio/nimble/common/Buffer.h"
 #include "dwio/nimble/common/tests/GTestUtils.h"
-#include "dwio/nimble/index/ChunkIndexGroup.h"
+#include "dwio/nimble/index/ChunkStatsGroup.h"
 #include "dwio/nimble/index/tests/ClusterIndexTestUtils.h"
 
-#include "dwio/nimble/index/ChunkIndex.h"
-#include "dwio/nimble/tablet/ChunkIndexGenerated.h"
+#include "dwio/nimble/index/ChunkStats.h"
+#include "dwio/nimble/tablet/ChunkStatsGenerated.h"
 #include "dwio/nimble/tablet/Constants.h"
 #include "dwio/nimble/tablet/TabletWriter.h"
 #include "velox/common/memory/Memory.h"
 
 namespace facebook::nimble::test {
 
-using index::test::ChunkIndexTestHelper;
 using index::test::ChunkSpec;
+using index::test::ChunkStatsTestHelper;
 using index::test::createChunks;
 
 // Holds all the index data written during a test.
@@ -41,7 +41,7 @@ struct TestChunkFileIndex {
   std::string rootIndexData;
 };
 
-class ChunkIndexWriterTest : public ::testing::Test {
+class ChunkStatsWriterTest : public ::testing::Test {
  protected:
   static void SetUpTestCase() {
     velox::memory::MemoryManager::testingSetInstance({});
@@ -60,13 +60,13 @@ class ChunkIndexWriterTest : public ::testing::Test {
 
   static auto writeRootCallback(TestChunkFileIndex& fileIndex) {
     return [&fileIndex](const std::string& name, std::string_view content) {
-      EXPECT_EQ(name, nimble::kChunkIndexSection);
+      EXPECT_EQ(name, nimble::kChunkStatsSection);
       fileIndex.rootIndexData = std::string(content);
     };
   }
 
-  // Creates a ChunkIndexGroup reader from a serialized group metadata section.
-  std::shared_ptr<index::ChunkIndexGroup> loadChunkIndex(
+  // Creates a ChunkStatsGroup reader from a serialized group metadata section.
+  std::shared_ptr<index::ChunkStatsGroup> loadChunkIndex(
       const std::string& groupData,
       uint32_t firstStripe,
       uint32_t stripeCount) {
@@ -76,15 +76,15 @@ class ChunkIndexWriterTest : public ::testing::Test {
         inputBuffer->asMutable<char>(), groupData.data(), groupData.size());
     auto buffer = std::make_unique<MetadataBuffer>(MetadataBuffer::decompress(
         std::move(inputBuffer), CompressionType::Uncompressed, pool_.get()));
-    return index::ChunkIndexGroup::create(
+    return index::ChunkStatsGroup::create(
         firstStripe, stripeCount, std::move(buffer));
   }
 
   std::shared_ptr<velox::memory::MemoryPool> pool_;
 };
 
-TEST_F(ChunkIndexWriterTest, singleStripe) {
-  ChunkIndexWriter writer(*pool_);
+TEST_F(ChunkStatsWriterTest, singleStripe) {
+  ChunkStatsWriter writer(*pool_);
   Buffer buffer{*pool_};
   TestChunkFileIndex fileIndex;
 
@@ -104,16 +104,16 @@ TEST_F(ChunkIndexWriterTest, singleStripe) {
   ASSERT_EQ(fileIndex.groupMetadataSections.size(), 1);
   ASSERT_FALSE(fileIndex.rootIndexData.empty());
 
-  auto* rootChunkIndexes = flatbuffers::GetRoot<serialization::ChunkIndex>(
+  auto* rootChunkIndexes = flatbuffers::GetRoot<serialization::ChunkStats>(
       fileIndex.rootIndexData.data());
   ASSERT_NE(rootChunkIndexes, nullptr);
   ASSERT_NE(rootChunkIndexes->stripe_indexes(), nullptr);
   EXPECT_EQ(rootChunkIndexes->stripe_indexes()->size(), 1);
 
-  // Load as ChunkIndexGroup reader.
+  // Load as ChunkStatsGroup reader.
   auto chunkIndex = loadChunkIndex(fileIndex.groupMetadataSections[0], 0, 1);
 
-  ChunkIndexTestHelper helper(chunkIndex.get());
+  ChunkStatsTestHelper helper(chunkIndex.get());
   EXPECT_EQ(helper.firstStripe(), 0);
   EXPECT_EQ(helper.stripeCount(), 1);
   EXPECT_EQ(helper.streamCount(), 2);
@@ -165,8 +165,8 @@ TEST_F(ChunkIndexWriterTest, singleStripe) {
   EXPECT_EQ(r11.rowOffset, 60);
 }
 
-TEST_F(ChunkIndexWriterTest, multipleStripesInSingleGroup) {
-  ChunkIndexWriter writer(*pool_);
+TEST_F(ChunkStatsWriterTest, multipleStripesInSingleGroup) {
+  ChunkStatsWriter writer(*pool_);
   Buffer buffer{*pool_};
   TestChunkFileIndex fileIndex;
 
@@ -190,7 +190,7 @@ TEST_F(ChunkIndexWriterTest, multipleStripesInSingleGroup) {
   // Load and verify.
   auto chunkIndex = loadChunkIndex(fileIndex.groupMetadataSections[0], 0, 2);
 
-  ChunkIndexTestHelper helper(chunkIndex.get());
+  ChunkStatsTestHelper helper(chunkIndex.get());
   EXPECT_EQ(helper.stripeCount(), 2);
   EXPECT_EQ(helper.streamCount(), 2);
 
@@ -214,8 +214,8 @@ TEST_F(ChunkIndexWriterTest, multipleStripesInSingleGroup) {
   EXPECT_EQ(stream1Stats.chunkOffsets, (std::vector<uint32_t>{0, 0, 18}));
 }
 
-TEST_F(ChunkIndexWriterTest, multipleStripeGroups) {
-  ChunkIndexWriter writer(*pool_, 0);
+TEST_F(ChunkStatsWriterTest, multipleStripeGroups) {
+  ChunkStatsWriter writer(*pool_, 0);
   Buffer buffer{*pool_};
   TestChunkFileIndex fileIndex;
 
@@ -242,7 +242,7 @@ TEST_F(ChunkIndexWriterTest, multipleStripeGroups) {
   // All 3 groups are written (threshold=0, no skipping).
   ASSERT_EQ(fileIndex.groupMetadataSections.size(), 3);
 
-  auto* rootChunkIndexes = flatbuffers::GetRoot<serialization::ChunkIndex>(
+  auto* rootChunkIndexes = flatbuffers::GetRoot<serialization::ChunkStats>(
       fileIndex.rootIndexData.data());
   ASSERT_NE(rootChunkIndexes, nullptr);
   ASSERT_NE(rootChunkIndexes->stripe_indexes(), nullptr);
@@ -251,7 +251,7 @@ TEST_F(ChunkIndexWriterTest, multipleStripeGroups) {
   // Verify group 0 (stripe 0).
   {
     auto ci = loadChunkIndex(fileIndex.groupMetadataSections[0], 0, 1);
-    ChunkIndexTestHelper helper(ci.get());
+    ChunkStatsTestHelper helper(ci.get());
     EXPECT_EQ(helper.stripeCount(), 1);
     EXPECT_EQ(helper.streamCount(), 1);
     auto stats = helper.streamStats(0);
@@ -263,7 +263,7 @@ TEST_F(ChunkIndexWriterTest, multipleStripeGroups) {
   // Verify group 1 (stripe 1).
   {
     auto ci = loadChunkIndex(fileIndex.groupMetadataSections[1], 1, 1);
-    ChunkIndexTestHelper helper(ci.get());
+    ChunkStatsTestHelper helper(ci.get());
     EXPECT_EQ(helper.stripeCount(), 1);
     EXPECT_EQ(helper.streamCount(), 1);
     auto stats = helper.streamStats(0);
@@ -275,7 +275,7 @@ TEST_F(ChunkIndexWriterTest, multipleStripeGroups) {
   // Verify group 2 (stripe 2): 1 chunk, createStreamIndex returns nullptr.
   {
     auto ci = loadChunkIndex(fileIndex.groupMetadataSections[2], 2, 1);
-    ChunkIndexTestHelper helper(ci.get());
+    ChunkStatsTestHelper helper(ci.get());
     EXPECT_EQ(helper.stripeCount(), 1);
     EXPECT_EQ(helper.streamCount(), 1);
     auto stats = helper.streamStats(0);
@@ -287,8 +287,8 @@ TEST_F(ChunkIndexWriterTest, multipleStripeGroups) {
   }
 }
 
-TEST_F(ChunkIndexWriterTest, emptyStream) {
-  ChunkIndexWriter writer(*pool_, 0);
+TEST_F(ChunkStatsWriterTest, emptyStream) {
+  ChunkStatsWriter writer(*pool_, 0);
   Buffer buffer{*pool_};
   TestChunkFileIndex fileIndex;
 
@@ -303,7 +303,7 @@ TEST_F(ChunkIndexWriterTest, emptyStream) {
 
   auto chunkIndex = loadChunkIndex(fileIndex.groupMetadataSections[0], 0, 1);
 
-  ChunkIndexTestHelper helper(chunkIndex.get());
+  ChunkStatsTestHelper helper(chunkIndex.get());
   // All 3 streams are indexed (dense layout).
   EXPECT_EQ(helper.streamCount(), 3);
 
@@ -331,8 +331,8 @@ TEST_F(ChunkIndexWriterTest, emptyStream) {
   EXPECT_EQ(chunkIndex->createStreamIndex(0, 3, 0), nullptr);
 }
 
-TEST_F(ChunkIndexWriterTest, emptyFileNoStripeGroups) {
-  ChunkIndexWriter writer(*pool_);
+TEST_F(ChunkStatsWriterTest, emptyFileNoStripeGroups) {
+  ChunkStatsWriter writer(*pool_);
   TestChunkFileIndex fileIndex;
 
   // No stripes written — writeGroup() is never called.
@@ -342,8 +342,8 @@ TEST_F(ChunkIndexWriterTest, emptyFileNoStripeGroups) {
   EXPECT_TRUE(fileIndex.rootIndexData.empty());
 }
 
-TEST_F(ChunkIndexWriterTest, finalization) {
-  ChunkIndexWriter writer(*pool_);
+TEST_F(ChunkStatsWriterTest, finalization) {
+  ChunkStatsWriter writer(*pool_);
   Buffer buffer{*pool_};
   TestChunkFileIndex fileIndex;
 
@@ -354,20 +354,20 @@ TEST_F(ChunkIndexWriterTest, finalization) {
 
   // After finalization, all mutation methods should throw.
   NIMBLE_ASSERT_THROW(
-      writer.newStripe(1), "ChunkIndexWriter has been finalized");
+      writer.newStripe(1), "ChunkStatsWriter has been finalized");
   NIMBLE_ASSERT_THROW(
       writer.addStream(0, createChunks(buffer, {{10, 5}})),
-      "ChunkIndexWriter has been finalized");
+      "ChunkStatsWriter has been finalized");
   NIMBLE_ASSERT_THROW(
       writer.writeGroup(1, 1, createMetadataSectionCallback(fileIndex)),
-      "ChunkIndexWriter has been finalized");
+      "ChunkStatsWriter has been finalized");
   NIMBLE_ASSERT_THROW(
       writer.writeRoot(writeRootCallback(fileIndex)),
-      "ChunkIndexWriter has been finalized");
+      "ChunkStatsWriter has been finalized");
 }
 
-TEST_F(ChunkIndexWriterTest, addStreamIndexValidation) {
-  ChunkIndexWriter writer(*pool_);
+TEST_F(ChunkStatsWriterTest, addStreamIndexValidation) {
+  ChunkStatsWriter writer(*pool_);
   Buffer buffer{*pool_};
 
   // addStream before newStripe should fail.
@@ -378,8 +378,8 @@ TEST_F(ChunkIndexWriterTest, addStreamIndexValidation) {
   NIMBLE_ASSERT_THROW(writer.addStream(2, createChunks(buffer, {{10, 5}})), "");
 }
 
-TEST_F(ChunkIndexWriterTest, multipleStripesInMultipleGroups) {
-  ChunkIndexWriter writer(*pool_);
+TEST_F(ChunkStatsWriterTest, multipleStripesInMultipleGroups) {
+  ChunkStatsWriter writer(*pool_);
   Buffer buffer{*pool_};
   TestChunkFileIndex fileIndex;
 
@@ -411,7 +411,7 @@ TEST_F(ChunkIndexWriterTest, multipleStripesInMultipleGroups) {
 
   ASSERT_EQ(fileIndex.groupMetadataSections.size(), 2);
 
-  auto* rootChunkIndexes = flatbuffers::GetRoot<serialization::ChunkIndex>(
+  auto* rootChunkIndexes = flatbuffers::GetRoot<serialization::ChunkStats>(
       fileIndex.rootIndexData.data());
   ASSERT_NE(rootChunkIndexes, nullptr);
   ASSERT_NE(rootChunkIndexes->stripe_indexes(), nullptr);
@@ -420,7 +420,7 @@ TEST_F(ChunkIndexWriterTest, multipleStripesInMultipleGroups) {
   // Verify group 0 (2 stripes, firstStripe=0).
   {
     auto ci = loadChunkIndex(fileIndex.groupMetadataSections[0], 0, 2);
-    ChunkIndexTestHelper helper(ci.get());
+    ChunkStatsTestHelper helper(ci.get());
     EXPECT_EQ(helper.stripeCount(), 2);
 
     auto s0 = helper.streamStats(0);
@@ -437,7 +437,7 @@ TEST_F(ChunkIndexWriterTest, multipleStripesInMultipleGroups) {
   // Verify group 1 (1 stripe, firstStripe=2).
   {
     auto ci = loadChunkIndex(fileIndex.groupMetadataSections[1], 2, 1);
-    ChunkIndexTestHelper helper(ci.get());
+    ChunkStatsTestHelper helper(ci.get());
     EXPECT_EQ(helper.stripeCount(), 1);
     EXPECT_EQ(helper.streamCount(), 2);
 
@@ -455,7 +455,7 @@ TEST_F(ChunkIndexWriterTest, multipleStripesInMultipleGroups) {
   }
 }
 
-TEST_F(ChunkIndexWriterTest, minAvgChunksPerStream) {
+TEST_F(ChunkStatsWriterTest, minAvgChunksPerStream) {
   // Test that minAvgChunksPerStream controls group-level skipping.
   // Setup: 3 groups with different average chunks per stream.
   //   Group 0: 1 stripe, 2 streams. Stream 0: 3 chunks, Stream 1: 1 chunk.
@@ -501,7 +501,7 @@ TEST_F(ChunkIndexWriterTest, minAvgChunksPerStream) {
   for (const auto& testData : testSettings) {
     SCOPED_TRACE(testData.debugString());
 
-    ChunkIndexWriter writer(*pool_, testData.threshold);
+    ChunkStatsWriter writer(*pool_, testData.threshold);
     Buffer buffer{*pool_};
     TestChunkFileIndex fileIndex;
 
@@ -536,7 +536,7 @@ TEST_F(ChunkIndexWriterTest, minAvgChunksPerStream) {
 
     ASSERT_FALSE(fileIndex.rootIndexData.empty());
 
-    auto* rootChunkIndexes = flatbuffers::GetRoot<serialization::ChunkIndex>(
+    auto* rootChunkIndexes = flatbuffers::GetRoot<serialization::ChunkStats>(
         fileIndex.rootIndexData.data());
     ASSERT_NE(rootChunkIndexes, nullptr);
     ASSERT_NE(rootChunkIndexes->stripe_indexes(), nullptr);
@@ -555,8 +555,8 @@ TEST_F(ChunkIndexWriterTest, minAvgChunksPerStream) {
   }
 }
 
-TEST_F(ChunkIndexWriterTest, uncompressedSizeRoundtrip) {
-  ChunkIndexWriter writer(*pool_, /*minAvgChunksPerStream=*/0);
+TEST_F(ChunkStatsWriterTest, uncompressedSizeRoundtrip) {
+  ChunkStatsWriter writer(*pool_, /*minAvgChunksPerStream=*/0);
   Buffer buffer{*pool_};
   TestChunkFileIndex fileIndex;
 
@@ -587,7 +587,7 @@ TEST_F(ChunkIndexWriterTest, uncompressedSizeRoundtrip) {
   ASSERT_EQ(fileIndex.groupMetadataSections.size(), 2);
   ASSERT_FALSE(fileIndex.rootIndexData.empty());
 
-  auto* root = flatbuffers::GetRoot<serialization::ChunkIndex>(
+  auto* root = flatbuffers::GetRoot<serialization::ChunkStats>(
       fileIndex.rootIndexData.data());
   ASSERT_NE(root, nullptr);
   ASSERT_NE(root->stripe_indexes(), nullptr);
@@ -611,7 +611,7 @@ TEST_F(ChunkIndexWriterTest, uncompressedSizeRoundtrip) {
       MetadataBuffer::decompress(
           std::move(rootBuffer), CompressionType::Uncompressed, pool_.get()))};
 
-  auto chunkIndex = index::ChunkIndex::create(std::move(rootSection));
+  auto chunkIndex = index::ChunkStats::create(std::move(rootSection));
   ASSERT_NE(chunkIndex, nullptr);
   ASSERT_EQ(chunkIndex->numGroups(), 2);
 
@@ -628,7 +628,7 @@ TEST_F(ChunkIndexWriterTest, uncompressedSizeRoundtrip) {
 // Verifies that index metadata without uncompressed_size (written before
 // D108464890) is handled gracefully: the reader returns nullopt instead of
 // throwing, restoring backward compatibility with old files.
-TEST_F(ChunkIndexWriterTest, missingUncompressedSizeBackwardCompat) {
+TEST_F(ChunkStatsWriterTest, missingUncompressedSizeBackwardCompat) {
   flatbuffers::FlatBufferBuilder builder(256);
 
   // Simulate a pre-D108464890 FlatBuffer: no uncompressed_size field set.
@@ -647,7 +647,7 @@ TEST_F(ChunkIndexWriterTest, missingUncompressedSizeBackwardCompat) {
   std::vector<flatbuffers::Offset<serialization::MetadataSection>> sections = {
       section0, section1};
   auto stripeIndexes = builder.CreateVector(sections);
-  builder.Finish(serialization::CreateChunkIndex(builder, stripeIndexes));
+  builder.Finish(serialization::CreateChunkStats(builder, stripeIndexes));
 
   auto rootBuffer =
       velox::AlignedBuffer::allocate<char>(builder.GetSize(), pool_.get());
@@ -659,7 +659,7 @@ TEST_F(ChunkIndexWriterTest, missingUncompressedSizeBackwardCompat) {
       MetadataBuffer::decompress(
           std::move(rootBuffer), CompressionType::Uncompressed, pool_.get()))};
 
-  auto chunkIndex = index::ChunkIndex::create(std::move(rootSection));
+  auto chunkIndex = index::ChunkStats::create(std::move(rootSection));
   ASSERT_NE(chunkIndex, nullptr);
   ASSERT_EQ(chunkIndex->numGroups(), 2);
 
@@ -677,8 +677,8 @@ TEST_F(ChunkIndexWriterTest, missingUncompressedSizeBackwardCompat) {
 
 // Verifies that uncompressed sections get uncompressedSize == size in the
 // FlatBuffer, and the reader correctly recovers it.
-TEST_F(ChunkIndexWriterTest, uncompressedSizeForUncompressedSections) {
-  ChunkIndexWriter writer(*pool_, /*minAvgChunksPerStream=*/0);
+TEST_F(ChunkStatsWriterTest, uncompressedSizeForUncompressedSections) {
+  ChunkStatsWriter writer(*pool_, /*minAvgChunksPerStream=*/0);
   Buffer buffer{*pool_};
   TestChunkFileIndex fileIndex;
 
@@ -692,7 +692,7 @@ TEST_F(ChunkIndexWriterTest, uncompressedSizeForUncompressedSections) {
   ASSERT_EQ(fileIndex.groupMetadataSections.size(), 1);
   ASSERT_FALSE(fileIndex.rootIndexData.empty());
 
-  auto* root = flatbuffers::GetRoot<serialization::ChunkIndex>(
+  auto* root = flatbuffers::GetRoot<serialization::ChunkStats>(
       fileIndex.rootIndexData.data());
   ASSERT_NE(root, nullptr);
   ASSERT_NE(root->stripe_indexes(), nullptr);
@@ -713,7 +713,7 @@ TEST_F(ChunkIndexWriterTest, uncompressedSizeForUncompressedSections) {
       MetadataBuffer::decompress(
           std::move(rootBuffer), CompressionType::Uncompressed, pool_.get()))};
 
-  auto chunkIndex = index::ChunkIndex::create(std::move(rootSection));
+  auto chunkIndex = index::ChunkStats::create(std::move(rootSection));
   ASSERT_NE(chunkIndex, nullptr);
   ASSERT_EQ(chunkIndex->numGroups(), 1);
 

--- a/dwio/nimble/tablet/tests/ChunkStatsWriterTest.cpp
+++ b/dwio/nimble/tablet/tests/ChunkStatsWriterTest.cpp
@@ -165,6 +165,45 @@ TEST_F(ChunkStatsWriterTest, singleStripe) {
   EXPECT_EQ(r11.rowOffset, 60);
 }
 
+TEST_F(ChunkStatsWriterTest, perChunkNullCounts) {
+  ChunkStatsWriter writer(*pool_);
+  Buffer buffer{*pool_};
+  TestChunkFileIndex fileIndex;
+
+  // 1 stripe, 2 streams. ChunkSpec = {rowCount, size, nullCount}.
+  // Stream 0: 3 chunks with null counts 3, 0, 5.
+  // Stream 1: 2 chunks with null counts 0, 40 (a fully-null chunk).
+  writer.newStripe(2);
+  auto chunks0 = createChunks(buffer, {{30, 10, 3}, {45, 15, 0}, {25, 8, 5}});
+  auto chunks1 = createChunks(buffer, {{60, 20, 0}, {40, 12, 40}});
+  writer.addStream(0, chunks0);
+  writer.addStream(1, chunks1);
+
+  writer.writeGroup(2, 1, createMetadataSectionCallback(fileIndex));
+  writer.writeRoot(writeRootCallback(fileIndex));
+
+  auto chunkIndex = loadChunkIndex(fileIndex.groupMetadataSections[0], 0, 1);
+
+  // Null counts round-trip through the flatbuffer in flattened order.
+  ChunkStatsTestHelper helper(chunkIndex.get());
+  EXPECT_EQ(
+      helper.streamStats(0).chunkNullCounts, (std::vector<uint32_t>{3, 0, 5}));
+  EXPECT_EQ(
+      helper.streamStats(1).chunkNullCounts, (std::vector<uint32_t>{0, 40}));
+
+  // Public reader accessor: lookupChunk() yields the absolute chunk index,
+  // which chunkNullCount() maps to the per-chunk null statistic.
+  auto stream0 = chunkIndex->createStreamIndex(0, 0, 33);
+  ASSERT_NE(stream0, nullptr);
+  EXPECT_EQ(stream0->chunkNullCount(stream0->lookupChunk(0).chunkIndex), 3);
+  EXPECT_EQ(stream0->chunkNullCount(stream0->lookupChunk(30).chunkIndex), 0);
+  EXPECT_EQ(stream0->chunkNullCount(stream0->lookupChunk(75).chunkIndex), 5);
+
+  auto stream1 = chunkIndex->createStreamIndex(0, 1, 32);
+  ASSERT_NE(stream1, nullptr);
+  EXPECT_EQ(stream1->chunkNullCount(stream1->lookupChunk(60).chunkIndex), 40);
+}
+
 TEST_F(ChunkStatsWriterTest, multipleStripesInSingleGroup) {
   ChunkStatsWriter writer(*pool_);
   Buffer buffer{*pool_};

--- a/dwio/nimble/tablet/tests/ChunkStatsWriterTest.cpp
+++ b/dwio/nimble/tablet/tests/ChunkStatsWriterTest.cpp
@@ -204,6 +204,54 @@ TEST_F(ChunkStatsWriterTest, perChunkNullCounts) {
   EXPECT_EQ(stream1->chunkNullCount(stream1->lookupChunk(60).chunkIndex), 40);
 }
 
+TEST_F(ChunkStatsWriterTest, perChunkMinMax) {
+  ChunkStatsWriter writer(*pool_);
+  Buffer buffer{*pool_};
+  TestChunkFileIndex fileIndex;
+
+  // 1 stripe, 2 streams. ChunkSpec = {rowCount, size, nullCount, min, max,
+  // hasMinMax}. Stream 0's middle chunk has no valid min/max (e.g. all-null or
+  // NaN at encode time) and must read back as nullopt.
+  writer.newStripe(2);
+  auto chunks0 = createChunks(
+      buffer,
+      {{30, 10, 0, -5, 100, true},
+       {45, 15, 0, 0, 0, false},
+       {25, 8, 0, 7, 7, true}});
+  auto chunks1 = createChunks(
+      buffer, {{60, 20, 0, 1000, 2000, true}, {40, 12, 0, -1, -1, true}});
+  writer.addStream(0, chunks0);
+  writer.addStream(1, chunks1);
+
+  writer.writeGroup(2, 1, createMetadataSectionCallback(fileIndex));
+  writer.writeRoot(writeRootCallback(fileIndex));
+
+  auto chunkIndex = loadChunkIndex(fileIndex.groupMetadataSections[0], 0, 1);
+
+  using MinMax = std::optional<std::pair<int64_t, int64_t>>;
+
+  auto stream0 = chunkIndex->createStreamIndex(0, 0, 33);
+  ASSERT_NE(stream0, nullptr);
+  EXPECT_EQ(
+      stream0->chunkMinMax(stream0->lookupChunk(0).chunkIndex),
+      MinMax(std::pair<int64_t, int64_t>{-5, 100}));
+  // Middle chunk had hasMinMax=false -> unknown.
+  EXPECT_EQ(
+      stream0->chunkMinMax(stream0->lookupChunk(30).chunkIndex), MinMax{});
+  EXPECT_EQ(
+      stream0->chunkMinMax(stream0->lookupChunk(75).chunkIndex),
+      MinMax(std::pair<int64_t, int64_t>{7, 7}));
+
+  auto stream1 = chunkIndex->createStreamIndex(0, 1, 32);
+  ASSERT_NE(stream1, nullptr);
+  EXPECT_EQ(
+      stream1->chunkMinMax(stream1->lookupChunk(0).chunkIndex),
+      MinMax(std::pair<int64_t, int64_t>{1000, 2000}));
+  EXPECT_EQ(
+      stream1->chunkMinMax(stream1->lookupChunk(60).chunkIndex),
+      MinMax(std::pair<int64_t, int64_t>{-1, -1}));
+}
+
 TEST_F(ChunkStatsWriterTest, multipleStripesInSingleGroup) {
   ChunkStatsWriter writer(*pool_);
   Buffer buffer{*pool_};

--- a/dwio/nimble/tablet/tests/ClusterIndexWriterTest.cpp
+++ b/dwio/nimble/tablet/tests/ClusterIndexWriterTest.cpp
@@ -21,11 +21,11 @@
 #include "dwio/nimble/common/Buffer.h"
 
 #include "dwio/nimble/common/tests/GTestUtils.h"
-#include "dwio/nimble/index/ChunkIndexGroup.h"
+#include "dwio/nimble/index/ChunkStatsGroup.h"
 #include "dwio/nimble/index/ClusterIndex.h"
 #include "dwio/nimble/index/ClusterIndexGroup.h"
 #include "dwio/nimble/index/tests/ClusterIndexTestUtils.h"
-#include "dwio/nimble/tablet/ChunkIndexWriter.h"
+#include "dwio/nimble/tablet/ChunkStatsWriter.h"
 
 #include "dwio/nimble/tablet/ClusterIndexGenerated.h"
 #include "dwio/nimble/tablet/Constants.h"
@@ -35,8 +35,8 @@
 
 namespace facebook::nimble::test {
 
-using index::test::ChunkIndexTestHelper;
 using index::test::ChunkSpec;
+using index::test::ChunkStatsTestHelper;
 using index::test::createChunks;
 using index::test::createKeyStream;
 using index::test::KeyChunkSpec;
@@ -67,7 +67,7 @@ class ClusterIndexWriterTest : public ::testing::Test {
 
   void SetUp() override {
     pool_ = velox::memory::memoryManager()->addLeafPool();
-    chunkIndexWriter_ = std::make_unique<ChunkIndexWriter>(*pool_, 0);
+    chunkIndexWriter_ = std::make_unique<ChunkStatsWriter>(*pool_, 0);
   }
 
   // Returns a callback that appends key stream data to TestFileIndex.
@@ -104,13 +104,13 @@ class ClusterIndexWriterTest : public ::testing::Test {
   // Returns a callback that stores chunk root index data.
   static auto writeChunkRootIndexCallback(TestFileIndex& fileIndex) {
     return [&fileIndex](const std::string& name, std::string_view content) {
-      EXPECT_EQ(name, nimble::kChunkIndexSection);
+      EXPECT_EQ(name, nimble::kChunkStatsSection);
       fileIndex.chunkRootIndexData = std::string(content);
     };
   }
 
   std::shared_ptr<velox::memory::MemoryPool> pool_;
-  std::unique_ptr<ChunkIndexWriter> chunkIndexWriter_;
+  std::unique_ptr<ChunkStatsWriter> chunkIndexWriter_;
 };
 
 TEST_F(ClusterIndexWriterTest, basic) {
@@ -667,14 +667,14 @@ TEST_F(ClusterIndexWriterTest, writeAndReadWithSingleGroup) {
 
   // Verify chunk index for stream position data
   {
-    auto chunkIndex = index::ChunkIndexGroup::create(
+    auto chunkIndex = index::ChunkStatsGroup::create(
         0,
         3,
         std::make_unique<MetadataBuffer>(
             *pool_,
             fileIndex.chunkIndexGroupSections[0],
             CompressionType::Uncompressed));
-    ChunkIndexTestHelper chunkHelper(chunkIndex.get());
+    ChunkStatsTestHelper chunkHelper(chunkIndex.get());
     EXPECT_EQ(chunkHelper.streamCount(), 2);
 
     // Verify stream 0 position index stats
@@ -905,14 +905,14 @@ TEST_F(ClusterIndexWriterTest, writeAndReadWithMultipleGroups) {
     EXPECT_EQ(keyStats.chunkKeys, (std::vector<std::string>{"bbb", "ccc"}));
 
     // Verify chunk index for stream position data
-    auto chunkIndex = index::ChunkIndexGroup::create(
+    auto chunkIndex = index::ChunkStatsGroup::create(
         0,
         1,
         std::make_unique<MetadataBuffer>(
             *pool_,
             fileIndex.chunkIndexGroupSections[0],
             CompressionType::Uncompressed));
-    ChunkIndexTestHelper chunkHelper(chunkIndex.get());
+    ChunkStatsTestHelper chunkHelper(chunkIndex.get());
     EXPECT_EQ(chunkHelper.streamCount(), 2);
 
     // Verify stream 0 stats: 2 chunks (rows: 50, 50)
@@ -948,14 +948,14 @@ TEST_F(ClusterIndexWriterTest, writeAndReadWithMultipleGroups) {
         keyStats.chunkKeys, (std::vector<std::string>{"ddd", "eee", "fff"}));
 
     // Verify chunk index for stream position data
-    auto chunkIndex = index::ChunkIndexGroup::create(
+    auto chunkIndex = index::ChunkStatsGroup::create(
         1,
         1,
         std::make_unique<MetadataBuffer>(
             *pool_,
             fileIndex.chunkIndexGroupSections[1],
             CompressionType::Uncompressed));
-    ChunkIndexTestHelper chunkHelper(chunkIndex.get());
+    ChunkStatsTestHelper chunkHelper(chunkIndex.get());
     EXPECT_EQ(chunkHelper.streamCount(), 2);
 
     // Verify stream 0 stats: 3 chunks (rows: 40, 60, 50)
@@ -990,14 +990,14 @@ TEST_F(ClusterIndexWriterTest, writeAndReadWithMultipleGroups) {
     EXPECT_EQ(keyStats.chunkKeys, (std::vector<std::string>{"ggg", "hhh"}));
 
     // Verify chunk index for stream position data
-    auto chunkIndex = index::ChunkIndexGroup::create(
+    auto chunkIndex = index::ChunkStatsGroup::create(
         2,
         1,
         std::make_unique<MetadataBuffer>(
             *pool_,
             fileIndex.chunkIndexGroupSections[2],
             CompressionType::Uncompressed));
-    ChunkIndexTestHelper chunkHelper(chunkIndex.get());
+    ChunkStatsTestHelper chunkHelper(chunkIndex.get());
     EXPECT_EQ(chunkHelper.streamCount(), 2);
 
     // Verify stream 0 stats: 2 chunks (rows: 70, 50)
@@ -1228,14 +1228,14 @@ TEST_F(ClusterIndexWriterTest, writeAndReadWithMultipleGroupsAndEmptyStream) {
     EXPECT_EQ(keyStats.chunkKeys, (std::vector<std::string>{"bbb", "ccc"}));
 
     // Verify chunk index for stream position data
-    auto chunkIndex = index::ChunkIndexGroup::create(
+    auto chunkIndex = index::ChunkStatsGroup::create(
         0,
         1,
         std::make_unique<MetadataBuffer>(
             *pool_,
             fileIndex.chunkIndexGroupSections[0],
             CompressionType::Uncompressed));
-    ChunkIndexTestHelper chunkHelper(chunkIndex.get());
+    ChunkStatsTestHelper chunkHelper(chunkIndex.get());
     // All 4 streams indexed (minAvgChunksPerStream = 0).
     EXPECT_EQ(chunkHelper.streamCount(), 4);
 
@@ -1286,14 +1286,14 @@ TEST_F(ClusterIndexWriterTest, writeAndReadWithMultipleGroupsAndEmptyStream) {
         keyStats.chunkKeys, (std::vector<std::string>{"ddd", "eee", "fff"}));
 
     // Verify chunk index for stream position data
-    auto chunkIndex = index::ChunkIndexGroup::create(
+    auto chunkIndex = index::ChunkStatsGroup::create(
         1,
         1,
         std::make_unique<MetadataBuffer>(
             *pool_,
             fileIndex.chunkIndexGroupSections[1],
             CompressionType::Uncompressed));
-    ChunkIndexTestHelper chunkHelper(chunkIndex.get());
+    ChunkStatsTestHelper chunkHelper(chunkIndex.get());
     // All 4 streams indexed (minAvgChunksPerStream = 0).
     EXPECT_EQ(chunkHelper.streamCount(), 4);
 
@@ -1343,14 +1343,14 @@ TEST_F(ClusterIndexWriterTest, writeAndReadWithMultipleGroupsAndEmptyStream) {
     EXPECT_EQ(keyStats.chunkKeys, (std::vector<std::string>{"ggg", "hhh"}));
 
     // Verify chunk index for stream position data
-    auto chunkIndex = index::ChunkIndexGroup::create(
+    auto chunkIndex = index::ChunkStatsGroup::create(
         2,
         1,
         std::make_unique<MetadataBuffer>(
             *pool_,
             fileIndex.chunkIndexGroupSections[2],
             CompressionType::Uncompressed));
-    ChunkIndexTestHelper chunkHelper(chunkIndex.get());
+    ChunkStatsTestHelper chunkHelper(chunkIndex.get());
     // All 4 streams indexed (minAvgChunksPerStream = 0).
     EXPECT_EQ(chunkHelper.streamCount(), 4);
 
@@ -1400,14 +1400,14 @@ TEST_F(ClusterIndexWriterTest, writeAndReadWithMultipleGroupsAndEmptyStream) {
     EXPECT_EQ(keyStats.chunkKeys, (std::vector<std::string>{"iii", "jjj"}));
 
     // Verify chunk index for stream position data
-    auto chunkIndex = index::ChunkIndexGroup::create(
+    auto chunkIndex = index::ChunkStatsGroup::create(
         3,
         1,
         std::make_unique<MetadataBuffer>(
             *pool_,
             fileIndex.chunkIndexGroupSections[3],
             CompressionType::Uncompressed));
-    ChunkIndexTestHelper chunkHelper(chunkIndex.get());
+    ChunkStatsTestHelper chunkHelper(chunkIndex.get());
     // All 4 streams indexed (minAvgChunksPerStream = 0).
     EXPECT_EQ(chunkHelper.streamCount(), 4);
 
@@ -1488,7 +1488,7 @@ TEST_F(ClusterIndexWriterTest, writeRootIndexForEmptyFile) {
 }
 
 TEST_F(ClusterIndexWriterTest, chunkIndexOnlyWriteAndRead) {
-  // Test standalone ChunkIndexWriter without ClusterIndexWriter.
+  // Test standalone ChunkStatsWriter without ClusterIndexWriter.
   // This simulates the chunk-index-only mode where enableChunkIndex=true
   // but indexConfig is not set.
   TestFileIndex fileIndex;
@@ -1512,8 +1512,8 @@ TEST_F(ClusterIndexWriterTest, chunkIndexOnlyWriteAndRead) {
   ASSERT_EQ(fileIndex.chunkIndexGroupSections.size(), 1);
   ASSERT_FALSE(fileIndex.chunkRootIndexData.empty());
 
-  // Verify ChunkIndexGroup can be loaded and used for chunk seeking.
-  auto chunkIndex = index::ChunkIndexGroup::create(
+  // Verify ChunkStatsGroup can be loaded and used for chunk seeking.
+  auto chunkIndex = index::ChunkStatsGroup::create(
       0,
       1,
       std::make_unique<MetadataBuffer>(

--- a/dwio/nimble/tablet/tests/TabletTest.cpp
+++ b/dwio/nimble/tablet/tests/TabletTest.cpp
@@ -30,7 +30,7 @@
 #include "dwio/nimble/common/Types.h"
 #include "dwio/nimble/common/tests/GTestUtils.h"
 #include "dwio/nimble/common/tests/TestUtils.h"
-#include "dwio/nimble/index/ChunkIndexGroup.h"
+#include "dwio/nimble/index/ChunkStatsGroup.h"
 #include "dwio/nimble/index/IndexConfig.h"
 #include "dwio/nimble/index/IndexLookup.h"
 #include "dwio/nimble/index/tests/ClusterIndexTestUtils.h"
@@ -1467,8 +1467,8 @@ class TabletWithIndexTest : public TabletTest {
     const uint32_t streamSize = streamSizes[streamId];
 
     // Calculate stripe offset within the chunk index group.
-    // Use the ChunkIndexTestHelper to get the first stripe of the group.
-    nimble::index::test::ChunkIndexTestHelper chunkHelper(
+    // Use the ChunkStatsTestHelper to get the first stripe of the group.
+    nimble::index::test::ChunkStatsTestHelper chunkHelper(
         stripeIdentifier.chunkIndex().get());
     const uint32_t stripeOffsetInGroup = stripeIdx - chunkHelper.firstStripe();
 
@@ -1772,7 +1772,7 @@ TEST_P(TabletWithIndexTest, singleGroup) {
   // Verify the first group, index group, and chunk index group is pinned
   // and is the only one (covered by footer IO).
   EXPECT_TRUE(tabletHelper.hasOnlyFirstStripeGroupCached());
-  EXPECT_TRUE(tabletHelper.hasOnlyFirstChunkIndexGroupCached());
+  EXPECT_TRUE(tabletHelper.hasOnlyFirstChunkStatsGroupCached());
 
   // Verify index columns
   EXPECT_EQ(index->indexColumns().size(), 2);
@@ -1867,7 +1867,7 @@ TEST_P(TabletWithIndexTest, singleGroup) {
     nimble::index::test::ClusterIndexTestHelper clusterIndexTestHelper(
         tablet->clusterIndex());
 
-    nimble::index::test::ChunkIndexTestHelper chunkHelper(
+    nimble::index::test::ChunkStatsTestHelper chunkHelper(
         stripeIdWithIndex.chunkIndex().get());
     // We have 2 streams per stripe
     EXPECT_EQ(chunkHelper.streamCount(), 2);
@@ -1945,7 +1945,7 @@ TEST_P(TabletWithIndexTest, singleGroup) {
   {
     for (uint32_t stripeIdx = 0; stripeIdx < 3; ++stripeIdx) {
       auto stripeId = tablet->stripeIdentifier(stripeIdx);
-      nimble::index::test::ChunkIndexTestHelper chunkHelper(
+      nimble::index::test::ChunkStatsTestHelper chunkHelper(
           stripeId.chunkIndex().get());
       for (uint32_t streamId = 0; streamId < 2; ++streamId) {
         auto streamStats = chunkHelper.streamStats(streamId);
@@ -2166,7 +2166,7 @@ TEST_P(TabletWithIndexTest, multipleGroups) {
 
   // Verify no metadata is pinned from preload (more than one group).
   EXPECT_EQ(tabletHelper.cachedStripeGroupCount(), 0);
-  EXPECT_EQ(tabletHelper.cachedChunkIndexGroupCount(), 0);
+  EXPECT_EQ(tabletHelper.cachedChunkStatsGroupCount(), 0);
 
   // Verify index columns
   EXPECT_EQ(index->indexColumns().size(), 2);
@@ -2228,7 +2228,7 @@ TEST_P(TabletWithIndexTest, multipleGroups) {
   {
     auto stripeId = tablet->stripeIdentifier(0);
 
-    nimble::index::test::ChunkIndexTestHelper chunkHelper(
+    nimble::index::test::ChunkStatsTestHelper chunkHelper(
         stripeId.chunkIndex().get());
     EXPECT_EQ(chunkHelper.streamCount(), 2);
 
@@ -2252,7 +2252,7 @@ TEST_P(TabletWithIndexTest, multipleGroups) {
   {
     auto stripeId = tablet->stripeIdentifier(1);
 
-    nimble::index::test::ChunkIndexTestHelper chunkHelper(
+    nimble::index::test::ChunkStatsTestHelper chunkHelper(
         stripeId.chunkIndex().get());
     EXPECT_EQ(chunkHelper.streamCount(), 2);
 
@@ -2279,7 +2279,7 @@ TEST_P(TabletWithIndexTest, multipleGroups) {
   {
     auto stripeId = tablet->stripeIdentifier(2);
 
-    nimble::index::test::ChunkIndexTestHelper chunkHelper(
+    nimble::index::test::ChunkStatsTestHelper chunkHelper(
         stripeId.chunkIndex().get());
     EXPECT_EQ(chunkHelper.streamCount(), 2);
 
@@ -2307,7 +2307,7 @@ TEST_P(TabletWithIndexTest, multipleGroups) {
   {
     for (uint32_t stripeIdx = 0; stripeIdx < 3; ++stripeIdx) {
       auto stripeId = tablet->stripeIdentifier(stripeIdx);
-      nimble::index::test::ChunkIndexTestHelper chunkHelper(
+      nimble::index::test::ChunkStatsTestHelper chunkHelper(
           stripeId.chunkIndex().get());
       for (uint32_t streamId = 0; streamId < 2; ++streamId) {
         auto streamStats = chunkHelper.streamStats(streamId);
@@ -2604,7 +2604,7 @@ TEST_P(TabletWithIndexTest, singleGroupWithEmptyStream) {
 
   auto stripeId = tablet->stripeIdentifier(0);
 
-  nimble::index::test::ChunkIndexTestHelper chunkHelper(
+  nimble::index::test::ChunkStatsTestHelper chunkHelper(
       stripeId.chunkIndex().get());
   EXPECT_EQ(chunkHelper.streamCount(), 4);
 
@@ -3059,7 +3059,7 @@ TEST_P(TabletWithIndexTest, multipleGroupsWithEmptyStream) {
   {
     auto stripeId = tablet->stripeIdentifier(0);
 
-    nimble::index::test::ChunkIndexTestHelper chunkHelper(
+    nimble::index::test::ChunkStatsTestHelper chunkHelper(
         stripeId.chunkIndex().get());
     // All 4 streams indexed (chunkIndexMinAvgChunks = 0).
     EXPECT_EQ(chunkHelper.streamCount(), 4);
@@ -3098,7 +3098,7 @@ TEST_P(TabletWithIndexTest, multipleGroupsWithEmptyStream) {
   {
     auto stripeId = tablet->stripeIdentifier(1);
 
-    nimble::index::test::ChunkIndexTestHelper chunkHelper(
+    nimble::index::test::ChunkStatsTestHelper chunkHelper(
         stripeId.chunkIndex().get());
     // All 4 streams indexed (chunkIndexMinAvgChunks = 0).
     EXPECT_EQ(chunkHelper.streamCount(), 4);
@@ -3137,7 +3137,7 @@ TEST_P(TabletWithIndexTest, multipleGroupsWithEmptyStream) {
   {
     auto stripeId = tablet->stripeIdentifier(2);
 
-    nimble::index::test::ChunkIndexTestHelper chunkHelper(
+    nimble::index::test::ChunkStatsTestHelper chunkHelper(
         stripeId.chunkIndex().get());
     // All 4 streams indexed (chunkIndexMinAvgChunks = 0).
     EXPECT_EQ(chunkHelper.streamCount(), 4);
@@ -3176,7 +3176,7 @@ TEST_P(TabletWithIndexTest, multipleGroupsWithEmptyStream) {
   {
     auto stripeId = tablet->stripeIdentifier(3);
 
-    nimble::index::test::ChunkIndexTestHelper chunkHelper(
+    nimble::index::test::ChunkStatsTestHelper chunkHelper(
         stripeId.chunkIndex().get());
     // All 4 streams indexed (chunkIndexMinAvgChunks = 0).
     EXPECT_EQ(chunkHelper.streamCount(), 4);
@@ -3447,7 +3447,7 @@ TEST_P(TabletWithIndexTest, streamDeduplication) {
 
   auto stripeId = tablet->stripeIdentifier(0);
 
-  nimble::index::test::ChunkIndexTestHelper chunkHelper(
+  nimble::index::test::ChunkStatsTestHelper chunkHelper(
       stripeId.chunkIndex().get());
   EXPECT_EQ(chunkHelper.streamCount(), 4);
 
@@ -3625,7 +3625,7 @@ TEST_P(TabletWithIndexTest, noIndex) {
   EXPECT_EQ(tablet->stripeCount(), 1);
   EXPECT_FALSE(tablet->hasOptionalSection(std::string(nimble::kIndexSection)));
   EXPECT_FALSE(
-      tablet->hasOptionalSection(std::string(nimble::kChunkIndexSection)));
+      tablet->hasOptionalSection(std::string(nimble::kChunkStatsSection)));
 }
 
 TEST_P(TabletWithIndexTest, loadClusterIndex) {
@@ -3998,7 +3998,7 @@ TEST_F(TabletWithIndexTest, configCombinations) {
 
     // Verify optional sections
     EXPECT_EQ(
-        tablet->hasOptionalSection(std::string(nimble::kChunkIndexSection)),
+        tablet->hasOptionalSection(std::string(nimble::kChunkStatsSection)),
         config.expectChunkIndex);
     EXPECT_EQ(
         tablet->hasOptionalSection(std::string(nimble::kIndexSection)),
@@ -4009,7 +4009,7 @@ TEST_F(TabletWithIndexTest, configCombinations) {
       auto stripeId = tablet->stripeIdentifier(0);
       ASSERT_NE(stripeId.chunkIndex(), nullptr);
 
-      nimble::index::test::ChunkIndexTestHelper chunkHelper(
+      nimble::index::test::ChunkStatsTestHelper chunkHelper(
           stripeId.chunkIndex().get());
       EXPECT_EQ(chunkHelper.streamCount(), 2);
 
@@ -4218,7 +4218,7 @@ TEST_P(TabletWithIndexTest, fileLayoutOrdering) {
       << "Cluster index should come after index partition metadata";
 
   const auto chunkIndexIt =
-      layout.optionalSections.find(std::string(nimble::kChunkIndexSection));
+      layout.optionalSections.find(std::string(nimble::kChunkStatsSection));
   ASSERT_NE(chunkIndexIt, layout.optionalSections.end());
   EXPECT_GT(chunkIndexIt->second.offset(), layout.indexPartitions[0].offset())
       << "Chunk index should come after index partition metadata";
@@ -4297,7 +4297,7 @@ TEST_P(TabletWithIndexTest, cacheWarmPath) {
   nimble::TabletReader::Options options;
   options.preloadOptionalSections = {
       std::string(nimble::kIndexSection),
-      std::string(nimble::kChunkIndexSection)};
+      std::string(nimble::kChunkStatsSection)};
 
   // Cold path: first reader populates the cache.
   {
@@ -4631,7 +4631,7 @@ TEST_P(TabletTest, configureOptionsIndexFlags) {
     EXPECT_FALSE(
         containsSection(opts.preloadOptionalSections, nimble::kIndexSection));
     EXPECT_TRUE(containsSection(
-        opts.preloadOptionalSections, nimble::kChunkIndexSection));
+        opts.preloadOptionalSections, nimble::kChunkStatsSection));
   }
 
   {
@@ -4646,7 +4646,7 @@ TEST_P(TabletTest, configureOptionsIndexFlags) {
     EXPECT_FALSE(
         containsSection(opts.preloadOptionalSections, nimble::kIndexSection));
     EXPECT_FALSE(containsSection(
-        opts.preloadOptionalSections, nimble::kChunkIndexSection));
+        opts.preloadOptionalSections, nimble::kChunkStatsSection));
   }
 
   {
@@ -4659,7 +4659,7 @@ TEST_P(TabletTest, configureOptionsIndexFlags) {
     EXPECT_FALSE(
         containsSection(opts.preloadOptionalSections, nimble::kIndexSection));
     EXPECT_FALSE(containsSection(
-        opts.preloadOptionalSections, nimble::kChunkIndexSection));
+        opts.preloadOptionalSections, nimble::kChunkStatsSection));
   }
 
   {
@@ -4672,7 +4672,7 @@ TEST_P(TabletTest, configureOptionsIndexFlags) {
     EXPECT_FALSE(
         containsSection(opts.preloadOptionalSections, nimble::kIndexSection));
     EXPECT_TRUE(containsSection(
-        opts.preloadOptionalSections, nimble::kChunkIndexSection));
+        opts.preloadOptionalSections, nimble::kChunkStatsSection));
   }
 }
 
@@ -6583,7 +6583,7 @@ TEST_P(TabletTest, footerReadTrackedInMetadataIoStats) {
 }
 
 // Verifies that cache warm path works for chunk index group metadata that is
-// Zstd-compressed. This exercises the uncompressed_size fix in ChunkIndex
+// Zstd-compressed. This exercises the uncompressed_size fix in ChunkStats
 // FlatBuffer serialization — without it, resolveUncompressedSize() returns
 // nullopt for chunk index groups, causing orphaned cache entries and
 // unnecessary file IO on warm reads.
@@ -6643,7 +6643,7 @@ TEST_P(TabletWithIndexTest, cacheWarmPathCompressedChunkIndex) {
   nimble::TabletReader::Options options;
   options.preloadOptionalSections = {
       std::string(nimble::kIndexSection),
-      std::string(nimble::kChunkIndexSection)};
+      std::string(nimble::kChunkStatsSection)};
 
   // Cold path.
   {

--- a/dwio/nimble/tablet/tests/TabletTestUtils.h
+++ b/dwio/nimble/tablet/tests/TabletTestUtils.h
@@ -72,7 +72,7 @@ class TabletReaderTestHelper {
   }
 
   /// Returns the number of cached chunk index groups.
-  size_t cachedChunkIndexGroupCount() const {
+  size_t cachedChunkStatsGroupCount() const {
     return tabletReader_->chunkIndexCache_.testingCacheCount();
   }
 
@@ -82,7 +82,7 @@ class TabletReaderTestHelper {
   }
 
   /// Returns true if the chunk index group at the given index is cached.
-  bool hasChunkIndexGroupCached(uint32_t groupIndex) const {
+  bool hasChunkStatsGroupCached(uint32_t groupIndex) const {
     return tabletReader_->chunkIndexCache_.hasCacheEntry(groupIndex);
   }
 
@@ -90,8 +90,8 @@ class TabletReaderTestHelper {
   /// one. This is useful for verifying that when the chunk index is covered by
   /// footer IO, the first chunk index group is pre-populated in the cache
   /// without additional reads.
-  bool hasOnlyFirstChunkIndexGroupCached() const {
-    return cachedChunkIndexGroupCount() == 1 && hasChunkIndexGroupCached(0);
+  bool hasOnlyFirstChunkStatsGroupCached() const {
+    return cachedChunkStatsGroupCount() == 1 && hasChunkStatsGroupCached(0);
   }
 
   /// Returns the stripe offsets array.

--- a/dwio/nimble/velox/NimbleConfig.cpp
+++ b/dwio/nimble/velox/NimbleConfig.cpp
@@ -261,13 +261,15 @@ std::map<uint64_t, float> parseGrowthConfigMap(const std::string& str) {
     "nimble.chunking.enabled",
     true);
 
-/// Enable chunk index for chunk-level seeking and per-chunk statistics
-/// for filter pushdown. When enabled, a chunk index optional section is
-/// written alongside chunk position data in the file.
+/// Enable the chunk stats optional section: per-chunk positional index (for
+/// chunk-level seeking) plus null/min/max value stats (for filter pushdown).
+/// Enabling it writes both -- value stats are stored parallel to the chunk
+/// position data and are meaningless without it. Written to the on-disk
+/// "columnar.chunk.stats" section.
 // EXPERIMENTAL: Not production-ready. Do not enable for production tables
 // without consulting the Nimble team (oncall: dwios).
-/* static */ Config::Entry<bool> Config::ENABLE_CHUNK_INDEX(
-    "nimble.chunk.index.enabled",
+/* static */ Config::Entry<bool> Config::ENABLE_CHUNK_STATS(
+    "nimble.chunk.stats.enabled",
     false);
 
 /// Threshold to trigger chunking to relieve memory pressure.

--- a/dwio/nimble/velox/NimbleConfig.h
+++ b/dwio/nimble/velox/NimbleConfig.h
@@ -59,7 +59,7 @@ class Config : public velox::config::ConfigBase {
   static Entry<bool> ENABLE_CHUNKING;
   // EXPERIMENTAL: Not production-ready. Do not enable for production tables
   // without consulting the Nimble team (oncall: dwios).
-  static Entry<bool> ENABLE_CHUNK_INDEX;
+  static Entry<bool> ENABLE_CHUNK_STATS;
   static Entry<uint64_t> CHUNKING_WRITER_MEMORY_HIGH_THRESHOLD;
   static Entry<uint64_t> CHUNKING_WRITER_MEMORY_LOW_THRESHOLD;
   static Entry<uint64_t> CHUNKING_WRITER_TARGET_STRIPE_STORAGE_SIZE;

--- a/dwio/nimble/velox/VeloxWriter.cpp
+++ b/dwio/nimble/velox/VeloxWriter.cpp
@@ -41,6 +41,7 @@
 #include "dwio/nimble/velox/SchemaTypes.h"
 #include "dwio/nimble/velox/StatsGenerated.h"
 #include "dwio/nimble/velox/StreamChunker.h"
+#include "dwio/nimble/velox/stats/ColumnStatistics.h"
 #include "dwio/nimble/velox/stats/VectorizedStatistics.h"
 #include "velox/common/testutil/TestValue.h"
 #include "velox/common/time/CpuWallTimer.h"
@@ -1454,13 +1455,20 @@ uint32_t VeloxWriter::encodeChunk(
   }
   uint32_t chunkBytes{0};
   chunk.rowCount = chunkView.rowCount();
-  // Collect the per-chunk null-count statistic only when chunk statistics are
-  // enabled, so writers with chunk stats off pay no extra cost. Streams with no
-  // nulls keep the default 0 without scanning.
-  if (context_->options().enableChunkIndex && chunkView.hasNulls()) {
-    const auto nonNulls = chunkView.nonNulls();
-    chunk.nullCount = static_cast<uint32_t>(
-        std::count(nonNulls.begin(), nonNulls.end(), false));
+  // Per-chunk statistics, only when enabled (no cost when chunk stats are off).
+  if (context_->options().enableChunkIndex) {
+    if (chunkView.hasNulls()) {
+      const auto nonNulls = chunkView.nonNulls();
+      chunk.nullCount = static_cast<uint32_t>(
+          std::count(nonNulls.begin(), nonNulls.end(), false));
+    }
+    // Over the chunk's packed non-null values; self-filters by scalar kind.
+    if (const auto minMax = computeChunkMinMax(
+            chunkView.descriptor().scalarKind(), chunkView.data())) {
+      chunk.minValue = minMax->first;
+      chunk.maxValue = minMax->second;
+      chunk.hasMinMax = true;
+    }
   }
   ChunkedStreamWriter chunkWriter{
       *encodingBuffer_, context_->options().chunkCompression};

--- a/dwio/nimble/velox/VeloxWriter.cpp
+++ b/dwio/nimble/velox/VeloxWriter.cpp
@@ -15,6 +15,7 @@
  */
 #include "dwio/nimble/velox/VeloxWriter.h"
 
+#include <algorithm>
 #include <memory>
 #include <optional>
 #include <unordered_map>
@@ -1453,6 +1454,14 @@ uint32_t VeloxWriter::encodeChunk(
   }
   uint32_t chunkBytes{0};
   chunk.rowCount = chunkView.rowCount();
+  // Collect the per-chunk null-count statistic only when chunk statistics are
+  // enabled, so writers with chunk stats off pay no extra cost. Streams with no
+  // nulls keep the default 0 without scanning.
+  if (context_->options().enableChunkIndex && chunkView.hasNulls()) {
+    const auto nonNulls = chunkView.nonNulls();
+    chunk.nullCount = static_cast<uint32_t>(
+        std::count(nonNulls.begin(), nonNulls.end(), false));
+  }
   ChunkedStreamWriter chunkWriter{
       *encodingBuffer_, context_->options().chunkCompression};
   for (auto& buffer : chunkWriter.encode(encoded)) {

--- a/dwio/nimble/velox/selective/ChunkedDecoder.h
+++ b/dwio/nimble/velox/selective/ChunkedDecoder.h
@@ -24,7 +24,7 @@
 #include "dwio/nimble/encodings/NullableEncoding.h"
 #include "dwio/nimble/encodings/common/EncodingUtils.h"
 #include "dwio/nimble/encodings/legacy/EncodingTrait.h"
-#include "dwio/nimble/index/ChunkIndexGroup.h"
+#include "dwio/nimble/index/ChunkStatsGroup.h"
 #include "dwio/nimble/velox/selective/NimbleData.h"
 #include "velox/dwio/common/SeekableInputStream.h"
 #include "velox/dwio/common/SelectiveColumnReader.h"

--- a/dwio/nimble/velox/selective/ReaderBase.h
+++ b/dwio/nimble/velox/selective/ReaderBase.h
@@ -20,7 +20,7 @@
 #include <span>
 #include <vector>
 
-#include "dwio/nimble/index/ChunkIndexGroup.h"
+#include "dwio/nimble/index/ChunkStatsGroup.h"
 #include "dwio/nimble/index/ClusterIndex.h"
 #include "dwio/nimble/tablet/Constants.h"
 #include "dwio/nimble/tablet/TabletReader.h"
@@ -182,7 +182,7 @@ class StripeStreams {
   void setStripe(int stripe) {
     stripe_ = stripe;
     lazyInput_.reset();
-    // Keep previous stripe's shared_ptrs (StripeGroup, ChunkIndexGroup)
+    // Keep previous stripe's shared_ptrs (StripeGroup, ChunkStatsGroup)
     // alive while loading the new stripe. This prevents the weak-pointer
     // cache entries from expiring when consecutive stripes share the same
     // group index, avoiding redundant metadata re-reads and re-parses.

--- a/dwio/nimble/velox/selective/tests/ChunkedDecoderTest.cpp
+++ b/dwio/nimble/velox/selective/tests/ChunkedDecoderTest.cpp
@@ -645,7 +645,7 @@ class ChunkedDecoderDataTest : public index::test::ClusterIndexTestBase,
 
  private:
   IndexBuffers testIndexBuffers_;
-  std::shared_ptr<index::ChunkIndexGroup> testChunkIndex_;
+  std::shared_ptr<index::ChunkStatsGroup> testChunkIndex_;
   EncodingFactory encodingFactory_;
 };
 

--- a/dwio/nimble/velox/stats/ColumnStatistics.cpp
+++ b/dwio/nimble/velox/stats/ColumnStatistics.cpp
@@ -18,6 +18,8 @@
 #include <optional>
 #include <utility>
 
+#include <folly/lang/Bits.h>
+
 #include "dwio/nimble/common/Exceptions.h"
 #include "dwio/nimble/velox/stats/ColumnStatsUtils.h"
 
@@ -44,7 +46,76 @@ void addFloatingPointValuesScalar(
   }
 }
 
+// Packed scalar bytes as a span; findMinMax uses unaligned loads (no alignment
+// required).
+template <typename T>
+std::span<const T> chunkValues(std::string_view data) {
+  NIMBLE_DCHECK(
+      data.size() % sizeof(T) == 0,
+      "Chunk value stream size is not a multiple of the value width");
+  return {reinterpret_cast<const T*>(data.data()), data.size() / sizeof(T)};
+}
+
+template <typename T>
+std::optional<std::pair<int64_t, int64_t>> integralChunkMinMax(
+    std::string_view data) {
+  const auto values = chunkValues<T>(data);
+  if (values.empty()) {
+    return std::nullopt;
+  }
+  const auto minMax = findMinMax(values);
+  return std::pair<int64_t, int64_t>{minMax.min, minMax.max};
+}
+
+template <typename T>
+std::optional<std::pair<int64_t, int64_t>> floatingChunkMinMax(
+    std::string_view data) {
+  const auto values = chunkValues<T>(data);
+  if (values.empty()) {
+    return std::nullopt;
+  }
+  const auto minMax = findMinMax(values);
+  if (!minMax.has_value()) {
+    return std::nullopt;
+  }
+  // Store float and double bounds identically as the bit_cast of a double, so
+  // the reader can testDoubleRange regardless of the column's scalar kind.
+  return std::pair<int64_t, int64_t>{
+      folly::bit_cast<int64_t>(static_cast<double>(minMax->min)),
+      folly::bit_cast<int64_t>(static_cast<double>(minMax->max))};
+}
+
 } // namespace
+
+std::optional<std::pair<int64_t, int64_t>> computeChunkMinMax(
+    ScalarKind scalarKind,
+    std::string_view data) {
+  switch (scalarKind) {
+    case ScalarKind::Int8:
+      return integralChunkMinMax<int8_t>(data);
+    case ScalarKind::Int16:
+      return integralChunkMinMax<int16_t>(data);
+    case ScalarKind::Int32:
+      return integralChunkMinMax<int32_t>(data);
+    case ScalarKind::Int64:
+      return integralChunkMinMax<int64_t>(data);
+    case ScalarKind::Float:
+      return floatingChunkMinMax<float>(data);
+    case ScalarKind::Double:
+      return floatingChunkMinMax<double>(data);
+    // Not eligible for min/max chunk stats.
+    case ScalarKind::UInt8:
+    case ScalarKind::UInt16:
+    case ScalarKind::UInt32:
+    case ScalarKind::UInt64:
+    case ScalarKind::Bool:
+    case ScalarKind::String:
+    case ScalarKind::Binary:
+    case ScalarKind::Undefined:
+      return std::nullopt;
+  }
+  return std::nullopt;
+}
 
 ColumnStatistics::ColumnStatistics(
     uint64_t valueCount,

--- a/dwio/nimble/velox/stats/ColumnStatistics.h
+++ b/dwio/nimble/velox/stats/ColumnStatistics.h
@@ -22,6 +22,8 @@
 #include <set>
 #include <span>
 #include <string>
+#include <string_view>
+#include <utility>
 
 #include "dwio/nimble/common/Buffer.h"
 #include "dwio/nimble/common/Vector.h"
@@ -40,6 +42,14 @@ enum class StatType : uint8_t {
   STRING,
   DEDUPLICATED,
 };
+
+/// Computes [min, max] over the chunk's packed non-null scalar values (reusing
+/// the file-level vectorized routines) as raw 64-bit payloads: int64 for
+/// integral, bit_cast<int64_t> of the double for float/double. nullopt when
+/// empty, an ineligible kind, or NaN.
+std::optional<std::pair<int64_t, int64_t>> computeChunkMinMax(
+    ScalarKind scalarKind,
+    std::string_view data);
 
 // Forward declarations for friend classes
 class StatisticsCollector;

--- a/dwio/nimble/velox/stats/tests/ColumnStatisticsTests.cpp
+++ b/dwio/nimble/velox/stats/tests/ColumnStatisticsTests.cpp
@@ -19,6 +19,7 @@
 #include <span>
 #include <vector>
 
+#include <folly/lang/Bits.h>
 #include <gtest/gtest.h>
 
 #include "dwio/nimble/velox/stats/ColumnStatistics.h"
@@ -885,4 +886,45 @@ TEST_F(StatisticsCollectorTests, DeduplicatedStatisticsCollectorMerge) {
       dedupCollector1.getBaseCollector()->getValueCount(),
       270); // (100-10) + (200-20)
   EXPECT_EQ(dedupCollector1.getBaseCollector()->getNullCount(), 30);
+}
+
+namespace {
+template <typename T>
+std::string_view bytesOf(const std::vector<T>& values) {
+  return std::string_view(
+      reinterpret_cast<const char*>(values.data()), values.size() * sizeof(T));
+}
+} // namespace
+
+TEST(ComputeChunkMinMaxTest, integralAndFloating) {
+  // Signed integral: min/max are widened to int64.
+  const std::vector<int32_t> ints = {5, -3, 12, 7};
+  EXPECT_EQ(
+      computeChunkMinMax(ScalarKind::Int32, bytesOf(ints)),
+      (std::optional<std::pair<int64_t, int64_t>>({-3, 12})));
+
+  // Floating point: payloads are the bit_cast<int64_t> of the doubles.
+  const std::vector<double> dbls = {2.5, -1.0, 9.25};
+  const auto minMax = computeChunkMinMax(ScalarKind::Double, bytesOf(dbls));
+  ASSERT_TRUE(minMax.has_value());
+  EXPECT_EQ(folly::bit_cast<double>(minMax->first), -1.0);
+  EXPECT_EQ(folly::bit_cast<double>(minMax->second), 9.25);
+}
+
+TEST(ComputeChunkMinMaxTest, unknownCases) {
+  // Empty input -> unknown.
+  EXPECT_FALSE(computeChunkMinMax(ScalarKind::Int64, {}).has_value());
+
+  // NaN anywhere in floating data -> unknown.
+  const std::vector<double> withNan = {1.0, std::nan(""), 3.0};
+  EXPECT_FALSE(
+      computeChunkMinMax(ScalarKind::Double, bytesOf(withNan)).has_value());
+
+  // Non-eligible kinds (unsigned / bool / string) -> unknown.
+  const std::vector<uint32_t> unsignedValues = {1, 2, 3};
+  EXPECT_FALSE(computeChunkMinMax(ScalarKind::UInt32, bytesOf(unsignedValues))
+                   .has_value());
+  const std::vector<int32_t> boolBytes = {1};
+  EXPECT_FALSE(
+      computeChunkMinMax(ScalarKind::Bool, bytesOf(boolBytes)).has_value());
 }

--- a/dwio/nimble/velox/tests/VeloxWriterTest.cpp
+++ b/dwio/nimble/velox/tests/VeloxWriterTest.cpp
@@ -3831,7 +3831,7 @@ class VeloxWriterIndexTest
         continue;
       }
 
-      nimble::index::test::ChunkIndexTestHelper chunkHelper(
+      nimble::index::test::ChunkStatsTestHelper chunkHelper(
           stripeId.chunkIndex().get());
 
       const uint32_t stripeOffsetInGroup =


### PR DESCRIPTION
Summary:

Adds per-chunk min/max for scalar value streams. With the per-chunk null count,
this is the value information a reader needs to skip chunks on range filters.

- Reuses the vectorized min/max routines that already back Nimble's file-level
  column statistics, rather than writing a second implementation. Chunk and
  file stats now share one code path, including NaN handling.
- v1 covers signed integers (8/16/32/64) and float/double, selected by the
  stream's scalar kind. Unsigned, bool, string, and binary are follow-ups.
- Stored as raw 64-bit payloads (sign-extended int for integral, bit_cast for
  float) plus a validity byte, appended to the chunk-stats flatbuffer. NaN or
  ineligible kinds are recorded invalid, so the reader never prunes on them.
- Computed only when chunk stats are enabled; ineligible streams short-circuit
  without scanning.

Differential Revision: D111913792
