### PR TITLE
feat(nimble): Add per-chunk null count (#992)

### DIFF
--- a/dwio/nimble/index/ChunkStatsGroup.cpp
+++ b/dwio/nimble/index/ChunkStatsGroup.cpp
@@ -144,6 +144,23 @@ ChunkLocation StreamIndex::lookupChunk(uint32_t rowId) const {
       chunkIndex, streamOffset, nextOffset - streamOffset, rowOffset};
 }
 
+std::optional<uint32_t> StreamIndex::chunkNullCount(uint32_t chunkIndex) const {
+  const auto* root = asFlatBuffersRoot<serialization::StripeChunkStats>(
+      chunkStats_->metadata_->content());
+
+  const auto* nullCounts = root->stream_chunk_null_counts();
+  if (nullCounts == nullptr) {
+    // Absent in files written before per-chunk null statistics were added; the
+    // null count is unknown.
+    return std::nullopt;
+  }
+  // The array is present, so chunkIndex (derived from ChunkLocation) must be in
+  // range. An out-of-range index is a programmer error or malformed metadata,
+  // not a legacy file, so fail loudly rather than masking it as "unknown".
+  NIMBLE_CHECK_LT(chunkIndex, nullCounts->size());
+  return nullCounts->Get(chunkIndex);
+}
+
 uint32_t StreamIndex::rowCount() const {
   if (endChunkOffset_ == startChunkOffset_) {
     return 0;

--- a/dwio/nimble/index/ChunkStatsGroup.h
+++ b/dwio/nimble/index/ChunkStatsGroup.h
@@ -17,6 +17,7 @@
 
 #include <cstdint>
 #include <memory>
+#include <optional>
 
 #include "dwio/nimble/common/Exceptions.h"
 #include "dwio/nimble/index/IndexTypes.h"
@@ -100,6 +101,11 @@ class StreamIndex {
 
   /// Lookup chunk by row ID within the stream's row range.
   ChunkLocation lookupChunk(uint32_t rowId) const;
+
+  /// Returns the per-chunk null-value count for the chunk at the given absolute
+  /// position (ChunkLocation::chunkIndex), or std::nullopt when per-chunk null
+  /// statistics are absent (files written before chunk statistics were added).
+  std::optional<uint32_t> chunkNullCount(uint32_t chunkIndex) const;
 
   /// Returns the total number of rows in this stream.
   uint32_t rowCount() const;

--- a/dwio/nimble/index/tests/ChunkStatsTest.cpp
+++ b/dwio/nimble/index/tests/ChunkStatsTest.cpp
@@ -800,4 +800,26 @@ TEST_F(ChunkStatsTest, chunkOnlyLookupByRowId) {
       "beyond the last chunk");
 }
 
+TEST_F(ChunkStatsTest, chunkNullCountAbsentReturnsNullopt) {
+  // Files written before per-chunk null statistics existed store the chunk
+  // index without the appended null-count array (as do these fixtures, which
+  // set only counts/rows/offsets). chunkNullCount() must report the count as
+  // unknown (nullopt) rather than fabricating a value.
+  std::vector<ChunkOnlyStripe> stripes = {
+      {.streams = {
+           {.numChunks = 3,
+            .chunkRows = {100, 250, 400},
+            .chunkOffsets = {0, 50, 120}}}}};
+  std::vector<int> stripeGroups = {1};
+
+  auto indexBuffers = createChunkOnlyTestClusterIndex(stripes, stripeGroups);
+  auto chunkIndex = createChunkIndex(indexBuffers, 0);
+  ASSERT_NE(chunkIndex, nullptr);
+
+  auto streamIndex = chunkIndex->createStreamIndex(0, 0, /*streamSize=*/1000);
+  ASSERT_NE(streamIndex, nullptr);
+  const auto location = streamIndex->lookupChunk(0);
+  EXPECT_FALSE(streamIndex->chunkNullCount(location.chunkIndex).has_value());
+}
+
 } // namespace facebook::nimble::index::test

--- a/dwio/nimble/index/tests/ClusterIndexTestUtils.cpp
+++ b/dwio/nimble/index/tests/ClusterIndexTestUtils.cpp
@@ -104,7 +104,9 @@ std::vector<Chunk> createChunks(
     auto pos = buffer.reserve(spec.size);
     std::memset(pos, 'X', spec.size);
     chunks.push_back(
-        {.rowCount = spec.rowCount, .content = {{pos, spec.size}}});
+        {.rowCount = spec.rowCount,
+         .nullCount = spec.nullCount,
+         .content = {{pos, spec.size}}});
   }
   return chunks;
 }
@@ -168,6 +170,7 @@ StreamStats ChunkStatsTestHelper::streamStats(uint32_t streamId) const {
   NIMBLE_CHECK_NOT_NULL(chunkRows);
   const auto* chunkOffsets = root->stream_chunk_offsets();
   NIMBLE_CHECK_NOT_NULL(chunkOffsets);
+  const auto* chunkNullCounts = root->stream_chunk_null_counts();
 
   const uint32_t stripeCount = chunkStats_->stripeCount_;
 
@@ -187,6 +190,9 @@ StreamStats ChunkStatsTestHelper::streamStats(uint32_t streamId) const {
       const uint32_t chunkIndex = startChunkIndex + i;
       stats.chunkRows.push_back(chunkRows->Get(chunkIndex));
       stats.chunkOffsets.push_back(chunkOffsets->Get(chunkIndex));
+      if (chunkNullCounts != nullptr) {
+        stats.chunkNullCounts.push_back(chunkNullCounts->Get(chunkIndex));
+      }
     }
   }
 

--- a/dwio/nimble/index/tests/ClusterIndexTestUtils.h
+++ b/dwio/nimble/index/tests/ClusterIndexTestUtils.h
@@ -134,12 +134,16 @@ struct StreamStats {
   std::vector<uint32_t> chunkRows;
   /// Byte offset of each chunk within its stream.
   std::vector<uint32_t> chunkOffsets;
+  /// Per-chunk null-value count for this stream. Empty when per-chunk null
+  /// statistics are absent from the section.
+  std::vector<uint32_t> chunkNullCounts;
 };
 
 /// Specification for a single chunk in a stream (for test data creation).
 struct ChunkSpec {
-  uint32_t rowCount;
-  uint32_t size;
+  uint32_t rowCount{};
+  uint32_t size{};
+  uint32_t nullCount{0};
 };
 
 /// Specification for a single stream (for test data creation).

--- a/dwio/nimble/tablet/Chunk.h
+++ b/dwio/nimble/tablet/Chunk.h
@@ -27,6 +27,10 @@ namespace facebook::nimble {
 struct Chunk {
   uint32_t rowCount{0};
 
+  /// Number of null values in this chunk. Only populated when chunk statistics
+  /// are enabled (VeloxWriterOptions::enableChunkIndex); left at 0 otherwise.
+  uint32_t nullCount{0};
+
   /// The encoded and compressed data content of this chunk, stored as a vector
   /// of string views. Each string_view points to a buffer containing a portion
   /// of the chunk's data. Multiple buffers may be used for large chunks.

--- a/dwio/nimble/tablet/ChunkStats.fbs
+++ b/dwio/nimble/tablet/ChunkStats.fbs
@@ -39,6 +39,10 @@ table StripeChunkStats {
   stream_chunk_rows:[uint32];
   /// Byte offset of each chunk within its stream.
   stream_chunk_offsets:[uint32];
+  /// Per-chunk null-value count, parallel to stream_chunk_rows/offsets.
+  /// Appended field: absent in files written before per-chunk null statistics
+  /// were added, in which case readers treat the null count as unknown.
+  stream_chunk_null_counts:[uint32];
 }
 
 /// Root table for the chunk stats optional section ("columnar.chunk.stats").

--- a/dwio/nimble/tablet/ChunkStatsWriter.cpp
+++ b/dwio/nimble/tablet/ChunkStatsWriter.cpp
@@ -66,6 +66,7 @@ void ChunkStatsWriter::addStream(
     accumulatedRows += chunk.rowCount;
     index.chunkRows.emplace_back(accumulatedRows);
     index.chunkOffsets.emplace_back(accumulatedOffset);
+    index.chunkNullCounts.emplace_back(chunk.nullCount);
     accumulatedOffset += chunk.contentSize();
     ++index.chunkCount;
   }
@@ -123,8 +124,10 @@ void ChunkStatsWriter::writeGroup(
 
   std::vector<uint32_t> flattenedChunkRows;
   std::vector<uint32_t> flattenedChunkOffsets;
+  std::vector<uint32_t> flattenedChunkNullCounts;
   flattenedChunkRows.reserve(accumulatedChunkCount);
   flattenedChunkOffsets.reserve(accumulatedChunkCount);
+  flattenedChunkNullCounts.reserve(accumulatedChunkCount);
 
   for (const auto& stripe : groupIndex_->stripes) {
     for (size_t streamId = 0; streamId < streamCount; ++streamId) {
@@ -138,6 +141,10 @@ void ChunkStatsWriter::writeGroup(
             flattenedChunkOffsets.end(),
             stream.chunkOffsets.begin(),
             stream.chunkOffsets.end());
+        flattenedChunkNullCounts.insert(
+            flattenedChunkNullCounts.end(),
+            stream.chunkNullCounts.begin(),
+            stream.chunkNullCounts.end());
       }
     }
   }
@@ -148,7 +155,8 @@ void ChunkStatsWriter::writeGroup(
       static_cast<uint32_t>(streamCount),
       builder.CreateVector(flattenedStreamChunkCounts),
       builder.CreateVector(flattenedChunkRows),
-      builder.CreateVector(flattenedChunkOffsets));
+      builder.CreateVector(flattenedChunkOffsets),
+      builder.CreateVector(flattenedChunkNullCounts));
   builder.Finish(chunkIndex);
 
   chunkIndexSections_.push_back(createMetadataSection(asView(builder)));

--- a/dwio/nimble/tablet/ChunkStatsWriter.h
+++ b/dwio/nimble/tablet/ChunkStatsWriter.h
@@ -82,6 +82,8 @@ class ChunkStatsWriter {
     std::vector<uint32_t> chunkRows;
     // Byte offsets of each chunk within the stream.
     std::vector<uint32_t> chunkOffsets;
+    // Per-chunk null-value count (statistic used for chunk skipping).
+    std::vector<uint32_t> chunkNullCounts;
     // Number of chunks in this stripe for this stream.
     uint32_t chunkCount{0};
   };

--- a/dwio/nimble/tablet/tests/ChunkStatsWriterTest.cpp
+++ b/dwio/nimble/tablet/tests/ChunkStatsWriterTest.cpp
@@ -165,6 +165,45 @@ TEST_F(ChunkStatsWriterTest, singleStripe) {
   EXPECT_EQ(r11.rowOffset, 60);
 }
 
+TEST_F(ChunkStatsWriterTest, perChunkNullCounts) {
+  ChunkStatsWriter writer(*pool_);
+  Buffer buffer{*pool_};
+  TestChunkFileIndex fileIndex;
+
+  // 1 stripe, 2 streams. ChunkSpec = {rowCount, size, nullCount}.
+  // Stream 0: 3 chunks with null counts 3, 0, 5.
+  // Stream 1: 2 chunks with null counts 0, 40 (a fully-null chunk).
+  writer.newStripe(2);
+  auto chunks0 = createChunks(buffer, {{30, 10, 3}, {45, 15, 0}, {25, 8, 5}});
+  auto chunks1 = createChunks(buffer, {{60, 20, 0}, {40, 12, 40}});
+  writer.addStream(0, chunks0);
+  writer.addStream(1, chunks1);
+
+  writer.writeGroup(2, 1, createMetadataSectionCallback(fileIndex));
+  writer.writeRoot(writeRootCallback(fileIndex));
+
+  auto chunkIndex = loadChunkIndex(fileIndex.groupMetadataSections[0], 0, 1);
+
+  // Null counts round-trip through the flatbuffer in flattened order.
+  ChunkStatsTestHelper helper(chunkIndex.get());
+  EXPECT_EQ(
+      helper.streamStats(0).chunkNullCounts, (std::vector<uint32_t>{3, 0, 5}));
+  EXPECT_EQ(
+      helper.streamStats(1).chunkNullCounts, (std::vector<uint32_t>{0, 40}));
+
+  // Public reader accessor: lookupChunk() yields the absolute chunk index,
+  // which chunkNullCount() maps to the per-chunk null statistic.
+  auto stream0 = chunkIndex->createStreamIndex(0, 0, 33);
+  ASSERT_NE(stream0, nullptr);
+  EXPECT_EQ(stream0->chunkNullCount(stream0->lookupChunk(0).chunkIndex), 3);
+  EXPECT_EQ(stream0->chunkNullCount(stream0->lookupChunk(30).chunkIndex), 0);
+  EXPECT_EQ(stream0->chunkNullCount(stream0->lookupChunk(75).chunkIndex), 5);
+
+  auto stream1 = chunkIndex->createStreamIndex(0, 1, 32);
+  ASSERT_NE(stream1, nullptr);
+  EXPECT_EQ(stream1->chunkNullCount(stream1->lookupChunk(60).chunkIndex), 40);
+}
+
 TEST_F(ChunkStatsWriterTest, multipleStripesInSingleGroup) {
   ChunkStatsWriter writer(*pool_);
   Buffer buffer{*pool_};

--- a/dwio/nimble/velox/StreamChunker.h
+++ b/dwio/nimble/velox/StreamChunker.h
@@ -16,6 +16,8 @@
 
 #pragma once
 
+#include <algorithm>
+
 #include "dwio/nimble/velox/StreamData.h"
 
 namespace facebook::nimble {
@@ -288,14 +290,19 @@ class NullsStreamChunker final : public StreamChunker {
     // Null stream values are converted to boolean data for encoding.
     streamData_->materialize();
     auto& nonNulls = streamData_->mutableNonNulls();
+    const auto* chunkBegin = nonNulls.data() + nonNullsOffset_;
+    // Validity booleans are the payload (no bitmap): nulls are the false bits.
+    const auto nullCount = static_cast<uint32_t>(
+        std::count(chunkBegin, chunkBegin + nonNullsInChunk, false));
     std::string_view dataChunk = {
-        reinterpret_cast<const char*>(nonNulls.data() + nonNullsOffset_),
-        nonNullsInChunk};
+        reinterpret_cast<const char*>(chunkBegin), nonNullsInChunk};
     nonNullsOffset_ += nonNullsInChunk;
     return StreamDataView{
         streamData_->descriptor(),
         dataChunk,
-        static_cast<uint32_t>(nonNullsInChunk)};
+        static_cast<uint32_t>(nonNullsInChunk),
+        /*nonNulls=*/std::nullopt,
+        nullCount};
   }
 
  private:
@@ -404,7 +411,9 @@ class NullableContentStreamChunker final : public StreamChunker {
           streamData_->descriptor(),
           dataChunk,
           static_cast<uint32_t>(chunkSize.nullElementCount),
-          nonNullsChunk};
+          nonNullsChunk,
+          static_cast<uint32_t>(
+              chunkSize.nullElementCount - chunkSize.dataElementCount)};
     }
     NIMBLE_CHECK_EQ(chunkSize.dataElementCount, chunkSize.nullElementCount);
     return StreamDataView{
@@ -635,7 +644,9 @@ class NullableContentStringStreamChunker final : public StreamChunker {
           streamData_->descriptor(),
           dataChunk,
           static_cast<uint32_t>(chunkSize.nullElementCount),
-          nonNullsChunk};
+          nonNullsChunk,
+          static_cast<uint32_t>(
+              chunkSize.nullElementCount - chunkSize.dataElementCount)};
     }
     NIMBLE_DCHECK_EQ(chunkSize.dataElementCount, chunkSize.nullElementCount);
     return StreamDataView{

--- a/dwio/nimble/velox/StreamData.h
+++ b/dwio/nimble/velox/StreamData.h
@@ -60,6 +60,17 @@ class StreamData {
     return hasNulls() && hasNullValues(nonNulls());
   }
 
+  /// Number of null (false) entries in the validity bitmap; 0 when absent.
+  /// Chunk views override this to return the count precomputed by the chunker.
+  virtual uint64_t numNulls() const {
+    if (!hasNulls()) {
+      return 0;
+    }
+    const auto validity = nonNulls();
+    return static_cast<uint64_t>(
+        std::count(validity.begin(), validity.end(), false));
+  }
+
   virtual bool empty() const = 0;
 
   virtual uint64_t memoryUsed() const = 0;
@@ -116,17 +127,20 @@ class StreamDataView final : public StreamData {
       const StreamDescriptorBuilder& descriptor,
       std::string_view data,
       uint32_t rowCount,
-      std::optional<std::span<const bool>> nonNulls = std::nullopt)
+      std::optional<std::span<const bool>> nonNulls = std::nullopt,
+      uint32_t nullCount = 0)
       : StreamData(descriptor),
         data_{data},
         rowCount_{rowCount},
-        nonNulls_{nonNulls} {}
+        nonNulls_{nonNulls},
+        nullCount_{nullCount} {}
 
   StreamDataView(StreamDataView&& other) noexcept
       : StreamData(other.descriptor()),
         data_{other.data_},
         rowCount_{other.rowCount_},
-        nonNulls_{other.nonNulls_} {}
+        nonNulls_{other.nonNulls_},
+        nullCount_{other.nullCount_} {}
 
   StreamDataView(const StreamDataView&) = delete;
 
@@ -152,6 +166,10 @@ class StreamDataView final : public StreamData {
     return nonNulls_.has_value();
   }
 
+  uint64_t numNulls() const override {
+    return nullCount_;
+  }
+
   uint64_t memoryUsed() const override {
     NIMBLE_UNREACHABLE("StreamDataView is non-owning");
   }
@@ -168,6 +186,7 @@ class StreamDataView final : public StreamData {
   const std::string_view data_;
   const uint32_t rowCount_;
   const std::optional<std::span<const bool>> nonNulls_;
+  const uint32_t nullCount_;
 };
 
 /// Content only data stream.

--- a/dwio/nimble/velox/VeloxWriter.cpp
+++ b/dwio/nimble/velox/VeloxWriter.cpp
@@ -15,6 +15,7 @@
  */
 #include "dwio/nimble/velox/VeloxWriter.h"
 
+#include <algorithm>
 #include <memory>
 #include <optional>
 #include <unordered_map>
@@ -1463,6 +1464,10 @@ uint32_t VeloxWriter::encodeChunk(
   }
   uint32_t chunkBytes{0};
   chunk.rowCount = chunkView.rowCount();
+  // Per-chunk null count, precomputed by the chunker.
+  if (context_->options().enableChunkIndex) {
+    chunk.nullCount = static_cast<uint32_t>(chunkView.numNulls());
+  }
   ChunkedStreamWriter chunkWriter{
       *encodingBuffer_, context_->options().chunkCompression};
   for (auto& buffer : chunkWriter.encode(encoded)) {

--- a/dwio/nimble/velox/tests/StreamChunkerTest.cpp
+++ b/dwio/nimble/velox/tests/StreamChunkerTest.cpp
@@ -94,6 +94,19 @@ class StreamChunkerTestsBase : public ::testing::Test {
           chunkView->nonNulls(),
           ::testing::ElementsAreArray(expectedChunkNonNulls));
       EXPECT_EQ(chunkView->hasNulls(), expectedChunk.hasNulls);
+      // Null count is precomputed by the chunker: false entries in the bitmap,
+      // or -- for the null-only stream -- false entries in the validity
+      // payload.
+      uint64_t expectedNulls = std::count(
+          expectedChunkNonNulls.begin(), expectedChunkNonNulls.end(), false);
+      if constexpr (std::is_same_v<T, bool>) {
+        if (expectedChunkNonNulls.empty() &&
+            dynamic_cast<NullsStreamData*>(&stream) != nullptr) {
+          expectedNulls = std::count(
+              expectedChunkData.begin(), expectedChunkData.end(), false);
+        }
+      }
+      EXPECT_EQ(chunkView->numNulls(), expectedNulls);
       ++chunkIndex;
     }
     ASSERT_EQ(chunkIndex, expectedChunks.size());

--- a/dwio/nimble/velox/tests/StreamDataTest.cpp
+++ b/dwio/nimble/velox/tests/StreamDataTest.cpp
@@ -605,6 +605,161 @@ TEST_F(rowCountTest, isNullStreamClassification) {
   EXPECT_FALSE(view.isNullStream());
 }
 
+class numNullsTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    velox::memory::MemoryManager::testingSetInstance(
+        velox::memory::MemoryManager::Options{});
+    pool_ = velox::memory::memoryManager()->addLeafPool("test");
+    schemaBuilder_ = std::make_unique<SchemaBuilder>();
+  }
+
+  std::shared_ptr<velox::memory::MemoryPool> pool_;
+  std::unique_ptr<SchemaBuilder> schemaBuilder_;
+};
+
+TEST_F(numNullsTest, contentStreamDataHasNoNulls) {
+  ExactGrowthPolicy growthPolicy;
+  const auto scalarBuilder =
+      schemaBuilder_->createScalarTypeBuilder(ScalarKind::Int32);
+  const auto& descriptor = scalarBuilder->scalarDescriptor();
+  ContentStreamData<int32_t> streamData(*pool_, descriptor, growthPolicy);
+
+  // Content-only streams never carry a validity bitmap.
+  EXPECT_FALSE(streamData.hasNulls());
+  EXPECT_EQ(streamData.numNulls(), 0);
+
+  auto& data = streamData.mutableData();
+  data.push_back(1);
+  data.push_back(2);
+  EXPECT_EQ(streamData.numNulls(), 0);
+}
+
+TEST_F(numNullsTest, nullsStreamData) {
+  ExactGrowthPolicy growthPolicy;
+  const auto scalarBuilder =
+      schemaBuilder_->createScalarTypeBuilder(ScalarKind::Bool);
+  const auto& descriptor = scalarBuilder->scalarDescriptor();
+  NullsStreamData streamData(*pool_, descriptor, growthPolicy);
+
+  // No validity bitmap -> no nulls, no scan.
+  streamData.ensureAdditionalNullsCapacity(/*mayHaveNulls=*/false, 3);
+  EXPECT_FALSE(streamData.hasNulls());
+  EXPECT_EQ(streamData.numNulls(), 0);
+
+  // Validity bitmap [t, f, t, f] -> 2 nulls.
+  streamData.reset();
+  streamData.ensureAdditionalNullsCapacity(/*mayHaveNulls=*/true, 4);
+  auto& nonNulls = streamData.mutableNonNulls();
+  nonNulls.push_back(true);
+  nonNulls.push_back(false);
+  nonNulls.push_back(true);
+  nonNulls.push_back(false);
+  EXPECT_TRUE(streamData.hasNulls());
+  EXPECT_EQ(streamData.numNulls(), 2);
+}
+
+TEST_F(numNullsTest, nullableContentStreamData) {
+  ExactGrowthPolicy growthPolicy;
+  const auto scalarBuilder =
+      schemaBuilder_->createScalarTypeBuilder(ScalarKind::Int32);
+  const auto& descriptor = scalarBuilder->scalarDescriptor();
+  NullableContentStreamData<int32_t> streamData(
+      *pool_, descriptor, growthPolicy);
+
+  // No nulls -> 0.
+  streamData.ensureAdditionalNullsCapacity(/*mayHaveNulls=*/false, 3);
+  auto& data = streamData.mutableData();
+  data.push_back(10);
+  data.push_back(20);
+  data.push_back(30);
+  EXPECT_EQ(streamData.numNulls(), 0);
+
+  // 5 rows: 3 non-null values, 2 nulls.
+  streamData.reset();
+  streamData.ensureAdditionalNullsCapacity(/*mayHaveNulls=*/true, 5);
+  auto& nonNulls = streamData.mutableNonNulls();
+  auto& data2 = streamData.mutableData();
+  nonNulls.push_back(true);
+  data2.push_back(1);
+  nonNulls.push_back(false);
+  nonNulls.push_back(true);
+  data2.push_back(2);
+  nonNulls.push_back(false);
+  nonNulls.push_back(true);
+  data2.push_back(3);
+  EXPECT_EQ(streamData.numNulls(), 2);
+
+  // All 4 rows null.
+  streamData.reset();
+  streamData.ensureAdditionalNullsCapacity(/*mayHaveNulls=*/true, 4);
+  auto& nonNulls2 = streamData.mutableNonNulls();
+  for (int i = 0; i < 4; ++i) {
+    nonNulls2.push_back(false);
+  }
+  EXPECT_EQ(streamData.numNulls(), 4);
+}
+
+TEST_F(numNullsTest, streamDataView) {
+  const auto scalarBuilder =
+      schemaBuilder_->createScalarTypeBuilder(ScalarKind::Int32);
+  const auto& descriptor = scalarBuilder->scalarDescriptor();
+
+  std::vector<int32_t> testData = {1, 2, 3};
+  std::string_view dataView(
+      reinterpret_cast<const char*>(testData.data()),
+      testData.size() * sizeof(int32_t));
+
+  // View reports the null count precomputed by the chunker.
+  StreamDataView noNulls(descriptor, dataView, /*rowCount=*/3);
+  EXPECT_FALSE(noNulls.hasNulls());
+  EXPECT_EQ(noNulls.numNulls(), 0);
+
+  std::array<bool, 5> nonNulls = {true, false, true, false, true};
+  StreamDataView view(
+      descriptor, dataView, /*rowCount=*/5, nonNulls, /*nullCount=*/2);
+  EXPECT_TRUE(view.hasNulls());
+  EXPECT_EQ(view.numNulls(), 2);
+}
+
+TEST_F(numNullsTest, streamDataViewNullStream) {
+  const auto scalarBuilder =
+      schemaBuilder_->createScalarTypeBuilder(ScalarKind::Int32);
+  const auto& descriptor = scalarBuilder->scalarDescriptor();
+
+  // Null-only (struct/ROW) chunk view: validity is the payload, no bitmap, so
+  // hasNulls() is false yet numNulls() reflects the chunker-precomputed count.
+  const std::array<char, 5> validity = {1, 0, 1, 0, 0};
+  std::string_view dataView(validity.data(), validity.size());
+  StreamDataView view(
+      descriptor,
+      dataView,
+      /*rowCount=*/5,
+      /*nonNulls=*/std::nullopt,
+      /*nullCount=*/3);
+  EXPECT_FALSE(view.hasNulls());
+  EXPECT_EQ(view.numNulls(), 3);
+}
+
+TEST_F(numNullsTest, nullableContentStringStreamData) {
+  ExactGrowthPolicy growthPolicy;
+  const auto scalarBuilder =
+      schemaBuilder_->createScalarTypeBuilder(ScalarKind::String);
+  const auto& descriptor = scalarBuilder->scalarDescriptor();
+  NullableContentStringStreamData streamData(
+      *pool_, descriptor, growthPolicy, growthPolicy);
+
+  // 4 rows: "hello", null, "world", null -> 2 nulls.
+  streamData.ensureAdditionalNullsCapacity(/*mayHaveNulls=*/true, 4);
+  auto& nonNulls = streamData.mutableNonNulls();
+  nonNulls.push_back(true);
+  nonNulls.push_back(false);
+  nonNulls.push_back(true);
+  nonNulls.push_back(false);
+  EXPECT_TRUE(streamData.hasNulls());
+  EXPECT_EQ(streamData.numNulls(), 2);
+}
+
 class NullableContentStringStreamDataTest : public ::testing::Test {
  protected:
   void SetUp() override {

--- a/dwio/nimble/velox/tests/VeloxWriterTest.cpp
+++ b/dwio/nimble/velox/tests/VeloxWriterTest.cpp
@@ -32,6 +32,7 @@
 #include "dwio/nimble/encodings/common/EncodingLayout.h"
 #include "dwio/nimble/encodings/common/EncodingUtils.h"
 #include "dwio/nimble/encodings/tests/TestUtils.h"
+#include "dwio/nimble/index/ChunkStatsGroup.h"
 #include "dwio/nimble/index/KeyEncoding.h"
 #include "dwio/nimble/index/tests/ClusterIndexTestUtils.h"
 #include "dwio/nimble/tablet/Constants.h"
@@ -2366,6 +2367,107 @@ TEST_F(VeloxWriterTest, chunkedStreamsRowSomeNullsWithChunksMinSizeZero) {
           ASSERT_CHUNK_COUNT(1, chunked);
         }
       });
+}
+
+// Regression guard for per-chunk null counts on null-only (struct/ROW) streams.
+// A nullable ROW writes a dedicated null stream whose validity is promoted to
+// boolean bytes at chunk time -- there is no separate validity bitmap. The
+// per-chunk null count must count those bytes; before the fix numNulls()
+// returned 0 for such streams, silently mis-reporting struct/ROW nulls as "no
+// nulls" in columnar.chunk.stats (a false "no nulls" assertion that would
+// over-prune once struct pruning consumes it).
+TEST_F(VeloxWriterTest, chunkNullCountsForStructNullStream) {
+  velox::test::VectorMaker vectorMaker{leafPool_.get()};
+
+  // Batch 1: 5 rows, the entire struct is null.
+  auto nullsVector =
+      vectorMaker.rowVector({"c1"}, {vectorMaker.flatVector<int32_t>({})});
+  nullsVector->appendNulls(5);
+
+  // Batch 2: 3 rows, struct null at row 1 (child values otherwise present).
+  auto someNullsVector = vectorMaker.rowVector(
+      {"c1"}, {vectorMaker.flatVector<int32_t>({1, 2, 3})});
+  someNullsVector->setNull(1, /*isNull=*/true);
+
+  const auto& type = nullsVector->type();
+
+  std::string file;
+  auto writeFile = std::make_unique<velox::InMemoryWriteFile>(&file);
+  bool flushDecision = false;
+  nimble::VeloxWriter writer(
+      type,
+      std::move(writeFile),
+      *rootPool_,
+      {
+          .enableChunkIndex = true,
+          // Never skip the stripe group, so the section is always written.
+          .chunkIndexMinAvgChunks = 0,
+          .minStreamChunkRawSize = 0,
+          .flushPolicyFactory =
+              [&]() {
+                return std::make_unique<nimble::LambdaFlushPolicy>(
+                    /*flushLambda=*/[&](auto&) { return false; },
+                    /*chunkLambda=*/[&](auto&) { return flushDecision; });
+              },
+          .enableChunking = true,
+      });
+
+  // Force a chunk boundary between the two writes so the null stream is split
+  // into two chunks (5 nulls, then 1 null).
+  flushDecision = true;
+  writer.write(nullsVector);
+  writer.write(someNullsVector);
+  writer.close();
+
+  auto readFile = std::make_shared<velox::InMemoryReadFile>(file);
+  auto tablet = nimble::TabletReader::create(
+      readFile, leafPool_.get(), makeTestTabletOptions(leafPool_.get()));
+  ASSERT_EQ(1, tablet->stripeCount());
+
+  auto stripeIdentifier = tablet->stripeIdentifier(0);
+  auto chunkStats = stripeIdentifier.chunkIndex();
+  ASSERT_NE(chunkStats, nullptr)
+      << "columnar.chunk.stats section should be present";
+
+  // The root struct null stream is the only source of nulls: 5 (batch 1) + 1
+  // (batch 2) = 6. Sum per-chunk null counts across every indexed stream; the
+  // int child stream has no nulls of its own and is single-chunk (not indexed).
+  const uint32_t streamCount = tablet->streamCount(stripeIdentifier);
+  uint64_t totalChunkNullCount = 0;
+  bool sawIndexedStream = false;
+  bool sawNonZeroChunk = false;
+  for (uint32_t streamId = 0; streamId < streamCount; ++streamId) {
+    auto streamIndex = chunkStats->createStreamIndex(
+        0, streamId, tablet->streamSize(stripeIdentifier, streamId));
+    if (streamIndex == nullptr) {
+      continue; // single-chunk (<=1) streams are not indexed
+    }
+    const uint32_t rows = streamIndex->rowCount();
+    if (rows == 0) {
+      continue;
+    }
+    sawIndexedStream = true;
+    const uint32_t firstChunk = streamIndex->lookupChunk(0).chunkIndex;
+    const uint32_t lastChunk = streamIndex->lookupChunk(rows - 1).chunkIndex;
+    for (uint32_t ci = firstChunk; ci <= lastChunk; ++ci) {
+      auto nullCount = streamIndex->chunkNullCount(ci);
+      ASSERT_TRUE(nullCount.has_value())
+          << "chunk " << ci << " of stream " << streamId
+          << " should carry a null count";
+      totalChunkNullCount += *nullCount;
+      if (*nullCount > 0) {
+        sawNonZeroChunk = true;
+      }
+    }
+  }
+
+  EXPECT_TRUE(sawIndexedStream)
+      << "expected an indexed (multi-chunk) null stream";
+  // Before the fix, every per-chunk null count for the struct null stream was
+  // 0.
+  EXPECT_TRUE(sawNonZeroChunk)
+      << "per-chunk null counts for the struct null stream must be non-zero";
+  EXPECT_EQ(6, totalChunkNullCount);
 }
 
 TEST_F(VeloxWriterTest, chunkedStreamsRowNoNullsNoChunks) {


### PR DESCRIPTION
Summary:

The first real per-chunk statistic. Chunk stats are still purely positional;
this records how many nulls each chunk holds, so a later reader can skip chunks
on null-related predicates and we can eventually retire the read-time
byte-peeking row estimates in ChunkedDecoder.

- The writer counts nulls per chunk during encode, only when chunk stats are
  enabled. The fleet default is off, so no writer pays for this yet.
- Stored as a new field appended to the existing chunk-stats flatbuffer. Files
  written before this simply lack it, and the reader reports "unknown" rather
  than a wrong value.
- Reader accessor StreamIndex::chunkNullCount returns the count, or nullopt for
  pre-stats files.


Rationale: https://docs.google.com/document/d/1cTCXje3RkPdhwFGK-FTY5muy4Cky2qnfnP-e_VFkjQA/edit?tab=t.0#heading=h.rpljwjiiglku

Reviewed By: xiaoxmeng

Differential Revision: D111913795


