### PR TITLE
feat: Read compressed cluster-index key chunks (#993)

### DIFF
--- a/dwio/nimble/index/CMakeLists.txt
+++ b/dwio/nimble/index/CMakeLists.txt
@@ -37,6 +37,7 @@ add_library(
 target_link_libraries(
   nimble_index
   nimble_common
+  nimble_compression
   nimble_encodings
   nimble_tablet_common
   nimble_cluster_index_fb

--- a/dwio/nimble/index/KeyChunkDecoder.cpp
+++ b/dwio/nimble/index/KeyChunkDecoder.cpp
@@ -17,6 +17,7 @@
 
 #include "dwio/nimble/common/ChunkHeader.h"
 #include "dwio/nimble/common/Exceptions.h"
+#include "dwio/nimble/compression/Compression.h"
 
 namespace facebook::nimble::index {
 
@@ -30,10 +31,12 @@ std::shared_ptr<DecodedKeyChunk> decodeKeyChunk(
   NIMBLE_CHECK_GE(bufLen, kChunkHeaderSize);
   const auto* header = static_cast<const char*>(buf);
   const auto chunkHeader = readChunkHeader(header);
-  NIMBLE_CHECK_EQ(
-      chunkHeader.compressionType,
-      CompressionType::Uncompressed,
-      "Compressed key chunks are not supported");
+  NIMBLE_CHECK(
+      chunkHeader.compressionType == CompressionType::Uncompressed ||
+          chunkHeader.compressionType == CompressionType::Zstd ||
+          chunkHeader.compressionType == CompressionType::Lz4,
+      "Unsupported key chunk compression type: {}",
+      chunkHeader.compressionType);
 
   const auto dataLen = chunkHeader.length;
   auto result = std::make_shared<DecodedKeyChunk>();
@@ -69,11 +72,32 @@ std::shared_ptr<DecodedKeyChunk> decodeKeyChunk(
     result->stringBuffers.push_back(dataBuffer);
   }
 
+  // chunkData/dataLen is the raw chunk payload. For a compressed chunk it must
+  // be decompressed into an owned buffer before decoding keys, so the returned
+  // (and cached) DecodedKeyChunk holds uncompressed key bytes. Uses the same
+  // Compression::uncompress path as the general chunked-stream reader.
+  std::string_view encodedData{chunkData, dataLen};
+  if (chunkHeader.compressionType != CompressionType::Uncompressed) {
+    auto uncompressed = Compression::uncompress(
+        pool,
+        chunkHeader.compressionType,
+        DataType::String,
+        encodedData,
+        /*decompressCounter=*/nullptr);
+    // Drop the returned chunk's references to the compressed payload (input
+    // stream or staging copy) so the cached DecodedKeyChunk holds only the
+    // uncompressed key bytes. The caller's dataBuffer scratch may still hold
+    // the staging copy, but callers use only the returned chunk and discard it.
+    result->dataStream.reset();
+    result->stringBuffers.clear();
+    encodedData =
+        std::string_view(uncompressed->as<char>(), uncompressed->size());
+    result->stringBuffers.push_back(std::move(uncompressed));
+  }
+
   auto* raw = result.get();
   result->encoding = KeyEncoding::create(
-      pool,
-      std::string_view(chunkData, dataLen),
-      [raw, &pool](uint32_t totalLength) {
+      pool, encodedData, [raw, &pool](uint32_t totalLength) {
         auto& buffer = raw->stringBuffers.emplace_back(
             velox::AlignedBuffer::allocate<char>(totalLength, &pool));
         return buffer->asMutable<void>();

--- a/dwio/nimble/index/tests/CMakeLists.txt
+++ b/dwio/nimble/index/tests/CMakeLists.txt
@@ -44,6 +44,7 @@ add_executable(
   IndexFilterTest.cpp
   IndexLookupTest.cpp
   ClusterIndexTest.cpp
+  KeyChunkDecoderTest.cpp
   ClusterIndexTestBase.cpp
 )
 

--- a/dwio/nimble/index/tests/KeyChunkDecoderTest.cpp
+++ b/dwio/nimble/index/tests/KeyChunkDecoderTest.cpp
@@ -14,9 +14,12 @@
  * limitations under the License.
  */
 
+#include <fmt/format.h>
 #include <gtest/gtest.h>
 
 #include "dwio/nimble/common/Buffer.h"
+#include "dwio/nimble/common/ChunkHeader.h"
+#include "dwio/nimble/common/tests/GTestUtils.h"
 #include "dwio/nimble/encodings/common/EncodingFactory.h"
 #include "dwio/nimble/encodings/selection/EncodingSelectionPolicy.h"
 #include "dwio/nimble/index/KeyChunkDecoder.h"
@@ -40,7 +43,9 @@ class KeyChunkDecoderTest : public ::testing::TestWithParam<EncodingType> {
     leafPool_ = pool_->addLeafChild("leaf");
   }
 
-  std::string encodeChunk(const std::vector<std::string_view>& keys) {
+  std::string encodeChunk(
+      const std::vector<std::string_view>& keys,
+      CompressionType compressionType = CompressionType::Uncompressed) {
     Buffer encodingBuffer{*leafPool_};
     auto policy =
         std::make_unique<ManualEncodingSelectionPolicy<std::string_view>>(
@@ -50,7 +55,8 @@ class KeyChunkDecoderTest : public ::testing::TestWithParam<EncodingType> {
     auto encoded = EncodingFactory::encode<std::string_view>(
         std::move(policy), keys, encodingBuffer);
 
-    ChunkedStreamWriter writer{encodingBuffer};
+    ChunkedStreamWriter writer{
+        encodingBuffer, CompressionParams{.type = compressionType}};
     auto segments = writer.encode(encoded);
     std::string result;
     for (const auto& segment : segments) {
@@ -59,10 +65,17 @@ class KeyChunkDecoderTest : public ::testing::TestWithParam<EncodingType> {
     return result;
   }
 
+  // blockSize caps how many bytes each SeekableArrayInputStream::Next() returns
+  // (0 means the whole buffer in one call). decodeKeyChunk branches on whether
+  // the first Next() window already holds the whole chunk, so a small blockSize
+  // splits the data across windows and forces its multi-buffer copy path.
   std::unique_ptr<SeekableArrayInputStream> makeStream(
-      const std::string& data) {
+      const std::string& data,
+      uint64_t blockSize = 0) {
     return std::make_unique<SeekableArrayInputStream>(
-        reinterpret_cast<const unsigned char*>(data.data()), data.size());
+        reinterpret_cast<const unsigned char*>(data.data()),
+        data.size(),
+        blockSize);
   }
 
   std::shared_ptr<velox::memory::MemoryPool> pool_;
@@ -152,6 +165,69 @@ TEST_P(KeyChunkDecoderTest, materializeAfterMoveAssign) {
   EXPECT_EQ(materialized[0], "gamma");
   EXPECT_EQ(materialized[1], "delta");
   EXPECT_EQ(materialized[2], "epsilon");
+}
+
+TEST_P(KeyChunkDecoderTest, roundTripsCompressedKeyChunk) {
+  // Many sorted keys sharing a long prefix so the encoded blob is compressible
+  // and ChunkedStreamWriter actually emits a Zstd chunk header (it falls back
+  // to Uncompressed when compression would not shrink the payload).
+  const std::string prefix(64, 'a');
+  std::vector<std::string> storage;
+  std::vector<std::string_view> keys;
+  storage.reserve(2000);
+  keys.reserve(2000);
+  for (int i = 0; i < 2000; ++i) {
+    storage.push_back(fmt::format("{}{:05d}", prefix, i));
+    keys.emplace_back(storage.back());
+  }
+
+  for (const auto compressionType :
+       {CompressionType::Zstd, CompressionType::Lz4}) {
+    SCOPED_TRACE(toString(compressionType));
+    const auto chunkData = encodeChunk(keys, compressionType);
+
+    // Sanity-check the setup: the chunk header's compression-type byte (the
+    // last byte of the 5-byte header) must actually say the requested type,
+    // otherwise the test is not exercising the decompression path.
+    ASSERT_GE(chunkData.size(), kChunkHeaderSize);
+    ASSERT_EQ(
+        static_cast<uint8_t>(chunkData[kChunkHeaderSize - 1]),
+        static_cast<uint8_t>(compressionType));
+
+    // Exercise both compressed-payload release paths. blockSize 0 delivers the
+    // whole chunk in the first Next() (zero-copy branch: releases dataStream);
+    // blockSize 64 delivers it in 64-byte windows, so the first window is
+    // smaller than the payload and decode stitches across windows (multi-buffer
+    // branch: releases the staging copy from stringBuffers).
+    for (const uint64_t blockSize : {uint64_t{0}, uint64_t{64}}) {
+      SCOPED_TRACE(fmt::format("blockSize={}", blockSize));
+      auto result = decodeKeyChunk(
+          makeStream(chunkData, blockSize), *leafPool_, dataBuffer_);
+      ASSERT_NE(result, nullptr);
+      ASSERT_NE(result->encoding, nullptr);
+      ASSERT_EQ(
+          result->encoding->rowCount(), static_cast<uint32_t>(keys.size()));
+
+      auto materialized =
+          result->encoding->materialize(0, static_cast<uint32_t>(keys.size()));
+      for (size_t i = 0; i < keys.size(); ++i) {
+        EXPECT_EQ(materialized[i], keys[i]);
+      }
+    }
+  }
+}
+
+TEST_P(KeyChunkDecoderTest, rejectsUnsupportedChunkCompression) {
+  std::vector<std::string_view> keys = {"apple", "banana", "cherry"};
+  auto chunkData = encodeChunk(keys); // uncompressed chunk
+  ASSERT_GE(chunkData.size(), kChunkHeaderSize);
+  // Rewrite the header's compression-type byte to an unsupported type.
+  chunkData[kChunkHeaderSize - 1] =
+      static_cast<char>(CompressionType::MetaInternal);
+
+  NIMBLE_ASSERT_THROW(
+      decodeKeyChunk(makeStream(chunkData), *leafPool_, dataBuffer_),
+      "Unsupported key chunk compression type");
 }
 
 INSTANTIATE_TEST_SUITE_P(


### PR DESCRIPTION
Summary:

`KeyChunkDecoder` rejected any compressed cluster-index key chunk. Teach it to decompress: accept `Uncompressed`/`Zstd`/`Lz4` (matching `ChunkedStreamWriter` and `InMemoryChunkedStream`) and, for a compressed chunk, run `Compression::uncompress` before building the `KeyEncoding` so the decoded/cached chunk holds uncompressed bytes; other types throw. After decompression the compressed payload — the input stream in the zero-copy branch, or the staging copy in the multi-buffer branch — is released, so the cached chunk retains only the uncompressed bytes rather than both representations.

Read side only: no writer emits compressed key chunks yet, so this is a no-op for existing files. It must land before the writer since the index has no format-version gate; the writer config wireup is a follow-up.

CMake: link `nimble_compression` into `nimble_index` and add `KeyChunkDecoderTest.cpp` to `nimble_index_tests`.

Reviewed By: xiaoxmeng

Differential Revision: D112867456


