### PR TITLE
feat: Add experimental Huffman encoding

### DIFF
--- a/dwio/nimble/common/Types.cpp
+++ b/dwio/nimble/common/Types.cpp
@@ -57,6 +57,8 @@ std::string toString(EncodingType encodingType) {
       return "ALP";
     case EncodingType::Fsst:
       return "Fsst";
+    case EncodingType::Huffman:
+      return "Huffman";
     case EncodingType::PFOR:
       return "PFOR";
     case EncodingType::SimdForBitpack:

--- a/dwio/nimble/common/Types.h
+++ b/dwio/nimble/common/Types.h
@@ -142,6 +142,11 @@ enum class EncodingType {
   // EXPERIMENTAL: Not production-ready. Do not enable for production tables
   // without consulting the Nimble team (oncall: dwios).
   Fsst = 19,
+  // Canonical Huffman coding for integral values. Preserves row order and
+  // stores periodic bit offsets for bounded random access.
+  // EXPERIMENTAL: Not production-ready. Do not enable for production tables
+  // without consulting the Nimble team (oncall: dwios).
+  Huffman = 20,
 };
 std::string toString(EncodingType encodingType);
 std::ostream& operator<<(std::ostream& out, EncodingType encodingType);

--- a/dwio/nimble/encodings/CMakeLists.txt
+++ b/dwio/nimble/encodings/CMakeLists.txt
@@ -19,6 +19,7 @@ add_library(
   nimble_encodings
   ConstantEncoding.cpp
   FsstEncoding.cpp
+  HuffmanEncoding.h
   MainlyConstantEncoding.cpp
   PrefixEncoding.cpp
   RLEEncoding.cpp
@@ -30,6 +31,7 @@ add_library(
   selection/EncodingSelectionPolicy.cpp
   selection/Statistics.cpp
   views/EncodingViewFactory.cpp
+  views/HuffmanEncodingView.h
 )
 
 set(FSST_SOURCE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/../../../third-party/fsst")

--- a/dwio/nimble/encodings/HuffmanEncoding.h
+++ b/dwio/nimble/encodings/HuffmanEncoding.h
@@ -1,0 +1,450 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <algorithm>
+#include <array>
+#include <cstdint>
+#include <cstring>
+#include <limits>
+#include <optional>
+#include <queue>
+#include <span>
+#include <type_traits>
+#include <vector>
+
+#include "dwio/nimble/common/Buffer.h"
+#include "dwio/nimble/common/Exceptions.h"
+#include "dwio/nimble/common/Varint.h"
+#include "dwio/nimble/common/Vector.h"
+#include "dwio/nimble/encodings/common/Encoding.h"
+#include "dwio/nimble/encodings/common/EncodingPrimitives.h"
+#include "dwio/nimble/encodings/selection/EncodingSelection.h"
+#include "folly/container/F14Map.h"
+#include "velox/common/base/BitUtil.h"
+
+namespace facebook::nimble {
+
+/// Canonical Huffman encoding for integral values. The bitstream preserves row
+/// order and stores a bit offset every 256 rows for bounded random access.
+///
+/// Wire format:
+///   EncodingPrefix:
+///     1 byte: EncodingType::Huffman
+///     1 byte: DataType
+///     4 bytes or varint: row count
+///   varint: symbol count (N)
+///   1 byte: maximum code length / decode-table log
+///   N * sizeof(physicalType) bytes: symbol alphabet
+///   N bytes: canonical Huffman code lengths, indexed by alphabet position
+///   varint: checkpoint count (C), ceil(row count / 256)
+///   C varints: delta-encoded bit offsets into the encoded symbol stream
+///   varint: encoded symbol stream size, including decoder padding
+///   variable bytes: LSB-first encoded symbol stream
+///   4 zero bytes: decoder lookahead padding, included in the stream size
+///
+/// Codes are reconstructed canonically from the code lengths. Decoding a code
+/// produces an alphabet index; alphabet[index] is the original integral value.
+template <typename T>
+class HuffmanEncoding final
+    : public TypedEncoding<T, typename TypeTraits<T>::physicalType> {
+ public:
+  using cppDataType = T;
+  using physicalType = typename TypeTraits<T>::physicalType;
+
+  static constexpr uint32_t kCheckpointStride{256};
+  // OpenZL's standard Huffman codec supports 256 symbols with a maximum
+  // 12-bit table. Its Large Huffman codec supports 65,536 symbols with a
+  // maximum 20-bit table and length-limits deeper trees. Nimble keeps the
+  // 12-bit table but supports up to 4,096 integral symbols, falling back when
+  // a skewed distribution would require a deeper tree.
+  static constexpr uint32_t kMaxSymbols{4096};
+  static constexpr uint8_t kMaxCodeBits{12};
+
+  HuffmanEncoding(
+      velox::memory::MemoryPool& pool,
+      std::string_view data,
+      const std::function<void*(uint32_t)>& /*stringBufferFactory*/ = nullptr,
+      const Encoding::Options& options = {});
+
+  void reset() final {
+    currentRow_ = 0;
+  }
+
+  void skip(uint32_t rowCount) final {
+    NIMBLE_CHECK_LE(rowCount, this->rowCount_ - currentRow_);
+    currentRow_ += rowCount;
+  }
+
+  void materialize(uint32_t rowCount, void* buffer) final;
+
+  template <typename DecoderVisitor>
+  void readWithVisitor(DecoderVisitor& visitor, ReadWithVisitorParams& params) {
+    detail::readWithVisitorSlow(
+        visitor,
+        params,
+        [&](auto count) { skip(count); },
+        [&] { return decodeValue(currentRow_++); });
+  }
+
+  static std::string_view encode(
+      EncodingSelection<physicalType>& selection,
+      std::span<const physicalType> values,
+      Buffer& buffer,
+      const Encoding::Options& options = {});
+
+  static std::optional<uint64_t> estimateSize(
+      std::span<const physicalType> values,
+      const Statistics<physicalType>& statistics,
+      const Encoding::Options& options = {});
+
+ private:
+  // Temporary encoder tree. Child fields index nodes_; leaves have no children
+  // and internal nodes have no symbol.
+  struct TreeNode {
+    uint64_t frequency;
+    int32_t left;
+    int32_t right;
+    int32_t symbol;
+  };
+
+  // Maps tableLog_ lookahead bits to an alphabet index and the number of bits
+  // consumed for that symbol.
+  struct DecodeEntry {
+    uint16_t symbol;
+    uint8_t bits;
+  };
+
+  // Convert canonical MSB-first codes to Nimble's LSB-first bitstream order.
+  static uint16_t reverseBits(uint16_t value, uint8_t bits) {
+    uint16_t reversed = 0;
+    for (uint8_t i = 0; i < bits; ++i) {
+      reversed = static_cast<uint16_t>((reversed << 1) | (value & 1));
+      value >>= 1;
+    }
+    return reversed;
+  }
+
+  // Derive leaf depths for canonical code construction. Distributions that
+  // exceed the bounded decoder table are rejected as incompatible.
+  static void assignCodeLengths(
+      const Vector<TreeNode>& nodes,
+      int32_t node,
+      uint8_t depth,
+      Vector<uint8_t>& lengths) {
+    if (nodes[node].symbol >= 0) {
+      if (depth > kMaxCodeBits) {
+        NIMBLE_INCOMPATIBLE_ENCODING(
+            "Huffman tree exceeds the {}-bit limit", kMaxCodeBits);
+      }
+      lengths[nodes[node].symbol] = std::max<uint8_t>(1, depth);
+      return;
+    }
+    assignCodeLengths(nodes, nodes[node].left, depth + 1, lengths);
+    assignCodeLengths(nodes, nodes[node].right, depth + 1, lengths);
+  }
+
+  physicalType decodeValue(uint32_t row) const;
+
+  Vector<physicalType> alphabet_;
+  Vector<DecodeEntry> decodeTable_;
+  Vector<uint32_t> checkpoints_;
+  const uint8_t* bitstream_{nullptr};
+  uint32_t bitstreamBytes_{0};
+  uint8_t tableLog_{0};
+  uint32_t currentRow_{0};
+};
+
+template <typename T>
+HuffmanEncoding<T>::HuffmanEncoding(
+    velox::memory::MemoryPool& pool,
+    std::string_view data,
+    const std::function<void*(uint32_t)>&,
+    const Encoding::Options& options)
+    : TypedEncoding<T, physicalType>{pool, data, options},
+      alphabet_{&pool},
+      decodeTable_{&pool},
+      checkpoints_{&pool} {
+  static_assert(
+      std::is_integral_v<physicalType> && !std::is_same_v<physicalType, bool>);
+
+  const char* pos = data.data() + this->dataOffset();
+  const uint32_t symbolCount = varint::readVarint32(&pos);
+  tableLog_ = static_cast<uint8_t>(encoding::readChar(pos));
+  NIMBLE_CHECK_GE(symbolCount, 2);
+  NIMBLE_CHECK_LE(symbolCount, kMaxSymbols);
+  NIMBLE_CHECK_LE(tableLog_, kMaxCodeBits);
+
+  alphabet_.resize(symbolCount);
+  std::memcpy(alphabet_.data(), pos, symbolCount * sizeof(physicalType));
+  pos += symbolCount * sizeof(physicalType);
+
+  const auto* lengths = reinterpret_cast<const uint8_t*>(pos);
+  pos += symbolCount;
+  decodeTable_.resize(1u << tableLog_);
+  std::fill(decodeTable_.begin(), decodeTable_.end(), DecodeEntry{0, 0});
+
+  // Number of symbols assigned to each code length, indexed by bit length.
+  std::array<uint16_t, kMaxCodeBits + 1> counts{};
+  for (uint32_t i = 0; i < symbolCount; ++i) {
+    NIMBLE_CHECK_GT(lengths[i], 0);
+    NIMBLE_CHECK_LE(lengths[i], tableLog_);
+    ++counts[lengths[i]];
+  }
+  std::array<uint16_t, kMaxCodeBits + 1> nextCode{};
+  uint16_t code = 0;
+  for (uint8_t bits = 1; bits <= tableLog_; ++bits) {
+    code = static_cast<uint16_t>((code + counts[bits - 1]) << 1);
+    nextCode[bits] = code;
+  }
+  for (uint32_t symbol = 0; symbol < symbolCount; ++symbol) {
+    const uint8_t bits = lengths[symbol];
+    const uint16_t reversed = reverseBits(nextCode[bits]++, bits);
+    for (uint32_t slot = reversed; slot < decodeTable_.size();
+         slot += 1u << bits) {
+      decodeTable_[slot] = DecodeEntry{static_cast<uint16_t>(symbol), bits};
+    }
+  }
+
+  const uint32_t checkpointCount = varint::readVarint32(&pos);
+  NIMBLE_CHECK_EQ(
+      checkpointCount,
+      velox::bits::divRoundUp(this->rowCount_, kCheckpointStride));
+  checkpoints_.resize(checkpointCount);
+  uint32_t bitOffset = 0;
+  for (uint32_t i = 0; i < checkpointCount; ++i) {
+    bitOffset += varint::readVarint32(&pos);
+    checkpoints_[i] = bitOffset;
+  }
+  bitstreamBytes_ = varint::readVarint32(&pos);
+  bitstream_ = reinterpret_cast<const uint8_t*>(pos);
+}
+
+template <typename T>
+typename HuffmanEncoding<T>::physicalType HuffmanEncoding<T>::decodeValue(
+    uint32_t row) const {
+  const uint32_t checkpoint = row / kCheckpointStride;
+  uint32_t bitOffset = checkpoints_[checkpoint];
+  uint32_t current = checkpoint * kCheckpointStride;
+  while (current <= row) {
+    uint32_t bits = 0;
+    const uint32_t byteOffset = bitOffset >> 3;
+    const uint32_t available =
+        std::min<uint32_t>(4, bitstreamBytes_ - byteOffset);
+    std::memcpy(&bits, bitstream_ + byteOffset, available);
+    bits >>= bitOffset & 7;
+    const auto entry = decodeTable_[bits & ((1u << tableLog_) - 1)];
+    NIMBLE_CHECK_GT(entry.bits, 0);
+    bitOffset += entry.bits;
+    if (current++ == row) {
+      return alphabet_[entry.symbol];
+    }
+  }
+  NIMBLE_UNREACHABLE("Invalid Huffman row {}", row);
+}
+
+template <typename T>
+void HuffmanEncoding<T>::materialize(uint32_t rowCount, void* buffer) {
+  NIMBLE_DCHECK_LE(currentRow_ + rowCount, this->rowCount_);
+  auto* output = static_cast<physicalType*>(buffer);
+  for (uint32_t i = 0; i < rowCount; ++i) {
+    output[i] = decodeValue(currentRow_ + i);
+  }
+  currentRow_ += rowCount;
+}
+
+template <typename T>
+std::optional<uint64_t> HuffmanEncoding<T>::estimateSize(
+    std::span<const physicalType> values,
+    const Statistics<physicalType>& statistics,
+    const Encoding::Options& options) {
+  if (values.size() < 2) {
+    return std::nullopt;
+  }
+  const auto& uniqueCounts = statistics.uniqueCounts();
+  if (!uniqueCounts.has_value() || uniqueCounts->size() < 2 ||
+      uniqueCounts->size() > kMaxSymbols) {
+    return std::nullopt;
+  }
+
+  uint64_t encodedBits = 0;
+  const uint64_t rowsMinusOne = values.size() - 1;
+  for (const auto& [value, count] : uniqueCounts.value()) {
+    (void)value;
+    encodedBits += count * velox::bits::bitsRequired(rowsMinusOne / count);
+  }
+  const uint64_t checkpoints =
+      velox::bits::divRoundUp(values.size(), kCheckpointStride);
+  const uint64_t bitstreamBytes = (encodedBits + 7) / 8 + 4;
+  return EncodingPrefix::serializedSize(
+             values.size(), options.useVarintRowCount) +
+      varint::varintSize(uniqueCounts->size()) + 1 +
+      uniqueCounts->size() * sizeof(physicalType) + uniqueCounts->size() +
+      varint::varintSize(checkpoints) + checkpoints * 2 +
+      varint::varintSize(bitstreamBytes) + bitstreamBytes;
+}
+
+template <typename T>
+std::string_view HuffmanEncoding<T>::encode(
+    EncodingSelection<physicalType>&,
+    std::span<const physicalType> values,
+    Buffer& buffer,
+    const Encoding::Options& options) {
+  static_assert(
+      std::is_integral_v<physicalType> && !std::is_same_v<physicalType, bool>);
+  if (values.size() < 2) {
+    NIMBLE_INCOMPATIBLE_ENCODING("Huffman encoding requires at least two rows");
+  }
+
+  auto* pool = &buffer.getMemoryPool();
+  folly::F14FastMap<physicalType, uint32_t> symbolByValue;
+  Vector<physicalType> alphabet{pool};
+  Vector<uint32_t> frequencies{pool};
+  for (const auto value : values) {
+    auto [it, inserted] =
+        symbolByValue.emplace(value, static_cast<uint32_t>(alphabet.size()));
+    if (inserted) {
+      if (alphabet.size() >= kMaxSymbols) {
+        NIMBLE_INCOMPATIBLE_ENCODING(
+            "Huffman encoding supports at most {} symbols", kMaxSymbols);
+      }
+      alphabet.push_back(value);
+      frequencies.push_back(0);
+    }
+    ++frequencies[it->second];
+  }
+  if (alphabet.size() < 2) {
+    NIMBLE_INCOMPATIBLE_ENCODING(
+        "Huffman encoding requires at least two symbols");
+  }
+
+  struct QueueEntry {
+    uint64_t frequency;
+    int32_t node;
+    bool operator>(const QueueEntry& other) const {
+      // Node order makes equal-frequency trees deterministic.
+      return frequency != other.frequency ? frequency > other.frequency
+                                          : node > other.node;
+    }
+  };
+  Vector<TreeNode> nodes{pool};
+  std::priority_queue<
+      QueueEntry,
+      std::vector<QueueEntry>,
+      std::greater<QueueEntry>>
+      queue;
+  for (uint32_t symbol = 0; symbol < frequencies.size(); ++symbol) {
+    nodes.emplace_back(
+        frequencies[symbol], -1, -1, static_cast<int32_t>(symbol));
+    queue.emplace(frequencies[symbol], static_cast<int32_t>(symbol));
+  }
+  while (queue.size() > 1) {
+    const auto left = queue.top();
+    queue.pop();
+    const auto right = queue.top();
+    queue.pop();
+    const auto node = static_cast<int32_t>(nodes.size());
+    nodes.emplace_back(
+        left.frequency + right.frequency, left.node, right.node, -1);
+    queue.emplace(left.frequency + right.frequency, node);
+  }
+
+  Vector<uint8_t> lengths{pool, alphabet.size()};
+  assignCodeLengths(nodes, queue.top().node, /*depth=*/0, lengths);
+  const uint8_t tableLog = *std::max_element(lengths.begin(), lengths.end());
+
+  // Number of symbols assigned to each code length, indexed by bit length.
+  std::array<uint16_t, kMaxCodeBits + 1> counts{};
+  for (const auto length : lengths) {
+    ++counts[length];
+  }
+  std::array<uint16_t, kMaxCodeBits + 1> nextCode{};
+  uint16_t code = 0;
+  for (uint8_t bits = 1; bits <= tableLog; ++bits) {
+    code = static_cast<uint16_t>((code + counts[bits - 1]) << 1);
+    nextCode[bits] = code;
+  }
+  Vector<uint16_t> codes{pool, alphabet.size()};
+  for (size_t symbol = 0; symbol < alphabet.size(); ++symbol) {
+    codes[symbol] = reverseBits(nextCode[lengths[symbol]]++, lengths[symbol]);
+  }
+
+  Vector<uint32_t> checkpoints{pool};
+  Vector<uint8_t> bitstream{pool};
+  uint64_t bitBuffer = 0;
+  uint32_t bufferedBits = 0;
+  uint32_t totalBits = 0;
+  for (size_t row = 0; row < values.size(); ++row) {
+    if (row % kCheckpointStride == 0) {
+      checkpoints.push_back(totalBits);
+    }
+    const auto symbol = symbolByValue.at(values[row]);
+    bitBuffer |= static_cast<uint64_t>(codes[symbol]) << bufferedBits;
+    bufferedBits += lengths[symbol];
+    totalBits += lengths[symbol];
+    while (bufferedBits >= 8) {
+      bitstream.push_back(static_cast<uint8_t>(bitBuffer));
+      bitBuffer >>= 8;
+      bufferedBits -= 8;
+    }
+  }
+  if (bufferedBits != 0) {
+    bitstream.push_back(static_cast<uint8_t>(bitBuffer));
+  }
+  bitstream.resize(bitstream.size() + 4, 0);
+
+  uint32_t checkpointBytes = 0;
+  uint32_t previousCheckpoint = 0;
+  for (const auto checkpoint : checkpoints) {
+    checkpointBytes += varint::varintSize(checkpoint - previousCheckpoint);
+    previousCheckpoint = checkpoint;
+  }
+  const uint64_t encodedSize =
+      Encoding::serializePrefixSize(values.size(), options.useVarintRowCount) +
+      varint::varintSize(alphabet.size()) + 1 +
+      alphabet.size() * sizeof(physicalType) + lengths.size() +
+      varint::varintSize(checkpoints.size()) + checkpointBytes +
+      varint::varintSize(bitstream.size()) + bitstream.size();
+  NIMBLE_CHECK_LE(encodedSize, std::numeric_limits<uint32_t>::max());
+  const auto size = static_cast<uint32_t>(encodedSize);
+  char* start = buffer.reserve(size);
+  char* pos = start;
+  Encoding::serializePrefix(
+      EncodingType::Huffman,
+      TypeTraits<T>::dataType,
+      values.size(),
+      options.useVarintRowCount,
+      pos);
+  varint::writeVarint(alphabet.size(), &pos);
+  encoding::writeChar(tableLog, pos);
+  std::memcpy(pos, alphabet.data(), alphabet.size() * sizeof(physicalType));
+  pos += alphabet.size() * sizeof(physicalType);
+  std::memcpy(pos, lengths.data(), lengths.size());
+  pos += lengths.size();
+  varint::writeVarint(checkpoints.size(), &pos);
+  previousCheckpoint = 0;
+  for (const auto checkpoint : checkpoints) {
+    varint::writeVarint(checkpoint - previousCheckpoint, &pos);
+    previousCheckpoint = checkpoint;
+  }
+  varint::writeVarint(bitstream.size(), &pos);
+  std::memcpy(pos, bitstream.data(), bitstream.size());
+  pos += bitstream.size();
+  NIMBLE_DCHECK_EQ(pos - start, size);
+  return {start, size};
+}
+
+} // namespace facebook::nimble

--- a/dwio/nimble/encodings/benchmarks/CMakeLists.txt
+++ b/dwio/nimble/encodings/benchmarks/CMakeLists.txt
@@ -47,6 +47,17 @@ target_link_libraries(
   fsst
 )
 
+add_executable(nimble_huffman_benchmark HuffmanBenchmark.cpp)
+
+target_link_libraries(
+  nimble_huffman_benchmark
+  nimble_encodings
+  nimble_common
+  Folly::follybenchmark
+  Folly::folly
+  velox_memory
+)
+
 add_executable(nimble_encoding_view_benchmark EncodingViewBenchmark.cpp)
 
 target_link_libraries(

--- a/dwio/nimble/encodings/benchmarks/EncodingViewBenchmark.cpp
+++ b/dwio/nimble/encodings/benchmarks/EncodingViewBenchmark.cpp
@@ -34,6 +34,7 @@
 #include "dwio/nimble/encodings/DictionaryEncoding.h"
 #include "dwio/nimble/encodings/FixedBitWidthEncoding.h"
 #include "dwio/nimble/encodings/ForEncoding.h"
+#include "dwio/nimble/encodings/HuffmanEncoding.h"
 #include "dwio/nimble/encodings/MainlyConstantEncoding.h"
 #include "dwio/nimble/encodings/PFOREncoding.h"
 #include "dwio/nimble/encodings/RLEEncoding.h"
@@ -355,6 +356,22 @@ Vector<uint32_t> pforData() {
       data[i] += 10000;
     }
   }
+  return data;
+}
+
+Vector<uint32_t> huffmanSkewedData() {
+  Vector<uint32_t> data{benchmarkPool().get()};
+  data.resize(kRows);
+  for (uint32_t row = 0; row < kRows; ++row) {
+    data[row] = row % 10 == 0 ? 1 + row % 15 : 0;
+  }
+  return data;
+}
+
+Vector<uint32_t> huffmanUniformData() {
+  Vector<uint32_t> data{benchmarkPool().get()};
+  data.resize(kRows);
+  std::iota(data.begin(), data.end(), 0);
   return data;
 }
 
@@ -752,6 +769,34 @@ MATERIALIZE_BENCHMARK(
     Materialize_PFORUint32_Random130,
     uint32_t,
     encodeWithSelection<PFOREncoding<uint32_t>>(EncodingType::PFOR, pforData()),
+    randomPositions(kRows))
+VIEW_BENCHMARK(
+    View_HuffmanUint32_SkewedRandom130,
+    uint32_t,
+    encodeWithSelection<HuffmanEncoding<uint32_t>>(
+        EncodingType::Huffman,
+        huffmanSkewedData()),
+    randomPositions(kRows))
+MATERIALIZE_BENCHMARK(
+    Materialize_HuffmanUint32_SkewedRandom130,
+    uint32_t,
+    encodeWithSelection<HuffmanEncoding<uint32_t>>(
+        EncodingType::Huffman,
+        huffmanSkewedData()),
+    randomPositions(kRows))
+VIEW_BENCHMARK(
+    View_HuffmanUint32_UniformRandom130,
+    uint32_t,
+    encodeWithSelection<HuffmanEncoding<uint32_t>>(
+        EncodingType::Huffman,
+        huffmanUniformData()),
+    randomPositions(kRows))
+MATERIALIZE_BENCHMARK(
+    Materialize_HuffmanUint32_UniformRandom130,
+    uint32_t,
+    encodeWithSelection<HuffmanEncoding<uint32_t>>(
+        EncodingType::Huffman,
+        huffmanUniformData()),
     randomPositions(kRows))
 VIEW_BENCHMARK(
     View_SimdForBitpackUint32_Random130,

--- a/dwio/nimble/encodings/benchmarks/HuffmanBenchmark.cpp
+++ b/dwio/nimble/encodings/benchmarks/HuffmanBenchmark.cpp
@@ -1,0 +1,80 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "dwio/nimble/encodings/HuffmanEncoding.h"
+#include "dwio/nimble/encodings/benchmarks/BenchmarkUtils.h"
+#include "folly/Benchmark.h"
+
+using namespace facebook::nimble;
+using namespace facebook::nimble::benchmarks;
+
+namespace {
+
+Vector<uint32_t> makeSkewedLowCardinality() {
+  Vector<uint32_t> data{benchmarkPool().get()};
+  data.resize(kNumElements);
+  for (uint32_t i = 0; i < data.size(); ++i) {
+    if (i % 100 < 90) {
+      data[i] = 0;
+    } else if (i % 100 < 96) {
+      data[i] = 1;
+    } else {
+      data[i] = 2 + i % 14;
+    }
+  }
+  return data;
+}
+
+Vector<uint32_t> makeUniformMaxCardinality() {
+  Vector<uint32_t> data{benchmarkPool().get()};
+  data.resize(kNumElements);
+  for (uint32_t i = 0; i < data.size(); ++i) {
+    data[i] = i % HuffmanEncoding<uint32_t>::kMaxSymbols;
+  }
+  return data;
+}
+
+#define HUFFMAN_BENCH(Pattern, DataExpr)                                      \
+  BENCHMARK(Huffman_Encode_##Pattern, iters) {                                \
+    Vector<uint32_t> data{benchmarkPool().get()};                             \
+    BENCHMARK_SUSPEND {                                                       \
+      data = DataExpr;                                                        \
+    }                                                                         \
+    encodeBenchmark<HuffmanEncoding<uint32_t>>(                               \
+        EncodingType::Huffman, data, iters);                                  \
+  }                                                                           \
+  BENCHMARK(Huffman_Decode_##Pattern, iters) {                                \
+    std::string encoded;                                                      \
+    BENCHMARK_SUSPEND {                                                       \
+      auto data = DataExpr;                                                   \
+      encoded =                                                               \
+          encodeData<HuffmanEncoding<uint32_t>>(EncodingType::Huffman, data); \
+    }                                                                         \
+    decodeBenchmark<uint32_t>(encoded, kNumElements, iters);                  \
+  }                                                                           \
+  BENCHMARK_DRAW_LINE()
+
+HUFFMAN_BENCH(SkewedLowCardinality, makeSkewedLowCardinality());
+HUFFMAN_BENCH(UniformMaxCardinality, makeUniformMaxCardinality());
+
+#undef HUFFMAN_BENCH
+
+} // namespace
+
+int main() {
+  facebook::velox::memory::MemoryManager::initialize({});
+  folly::runBenchmarks();
+}

--- a/dwio/nimble/encodings/common/EncodingFactory.cpp
+++ b/dwio/nimble/encodings/common/EncodingFactory.cpp
@@ -21,6 +21,7 @@
 #include "dwio/nimble/encodings/DictionaryEncoding.h"
 #include "dwio/nimble/encodings/FixedBitWidthEncoding.h"
 #include "dwio/nimble/encodings/FsstEncoding.h"
+#include "dwio/nimble/encodings/HuffmanEncoding.h"
 #include "dwio/nimble/encodings/MainlyConstantEncoding.h"
 #include "dwio/nimble/encodings/NullableEncoding.h"
 #include "dwio/nimble/encodings/PFOREncoding.h"
@@ -211,28 +212,40 @@ std::unique_ptr<Encoding> EncodingFactory::create(
           toString(dataType));                              \
   }
 
-#define RETURN_ENCODING_BY_INTEGER_TYPE(Encoding, dataType)    \
-  switch (dataType) {                                          \
-    case DataType::Int8:                                       \
-      return std::make_unique<Encoding<int8_t>>(pool, data);   \
-    case DataType::Uint8:                                      \
-      return std::make_unique<Encoding<uint8_t>>(pool, data);  \
-    case DataType::Int16:                                      \
-      return std::make_unique<Encoding<int16_t>>(pool, data);  \
-    case DataType::Uint16:                                     \
-      return std::make_unique<Encoding<uint16_t>>(pool, data); \
-    case DataType::Int32:                                      \
-      return std::make_unique<Encoding<int32_t>>(pool, data);  \
-    case DataType::Uint32:                                     \
-      return std::make_unique<Encoding<uint32_t>>(pool, data); \
-    case DataType::Int64:                                      \
-      return std::make_unique<Encoding<int64_t>>(pool, data);  \
-    case DataType::Uint64:                                     \
-      return std::make_unique<Encoding<uint64_t>>(pool, data); \
-    default:                                                   \
-      NIMBLE_UNREACHABLE(                                      \
-          "ForEncoding only supports integer types, got {}.",  \
-          toString(dataType));                                 \
+#define RETURN_ENCODING_BY_INTEGER_TYPE(Encoding, dataType)                  \
+  switch (dataType) {                                                        \
+    case DataType::Int8:                                                     \
+      return std::make_unique<Encoding<int8_t>>(                             \
+          pool, data, stringBufferFactory, options);                         \
+    case DataType::Uint8:                                                    \
+      return std::make_unique<Encoding<uint8_t>>(                            \
+          pool, data, stringBufferFactory, options);                         \
+    case DataType::Int16:                                                    \
+      return std::make_unique<Encoding<int16_t>>(                            \
+          pool, data, stringBufferFactory, options);                         \
+    case DataType::Uint16:                                                   \
+      return std::make_unique<Encoding<uint16_t>>(                           \
+          pool, data, stringBufferFactory, options);                         \
+    case DataType::Int32:                                                    \
+      return std::make_unique<Encoding<int32_t>>(                            \
+          pool, data, stringBufferFactory, options);                         \
+    case DataType::Uint32:                                                   \
+      return std::make_unique<Encoding<uint32_t>>(                           \
+          pool, data, stringBufferFactory, options);                         \
+    case DataType::Int64:                                                    \
+      return std::make_unique<Encoding<int64_t>>(                            \
+          pool, data, stringBufferFactory, options);                         \
+    case DataType::Uint64:                                                   \
+      return std::make_unique<Encoding<uint64_t>>(                           \
+          pool, data, stringBufferFactory, options);                         \
+    case DataType::Undefined:                                                \
+    case DataType::Float:                                                    \
+    case DataType::Double:                                                   \
+    case DataType::Bool:                                                     \
+    case DataType::String:                                                   \
+    default:                                                                 \
+      NIMBLE_UNREACHABLE(                                                    \
+          "HuffmanEncoding only supports integer types, got {}.", dataType); \
   }
 
   switch (encodingType) {
@@ -309,6 +322,9 @@ std::unique_ptr<Encoding> EncodingFactory::create(
     }
     case EncodingType::SimdForBitpack: {
       RETURN_ENCODING_BY_NUMERIC_TYPE(SimdForBitpackEncoding, dataType);
+    }
+    case EncodingType::Huffman: {
+      RETURN_ENCODING_BY_INTEGER_TYPE(HuffmanEncoding, dataType);
     }
     default: {
       NIMBLE_UNREACHABLE(
@@ -487,6 +503,15 @@ std::string_view EncodingFactory::encode(
       }
       NIMBLE_INCOMPATIBLE_ENCODING(
           "SimdForBitpack encoding only supports integral data types, got {}.",
+          TypeTraits<T>::dataType);
+    }
+    case EncodingType::Huffman: {
+      if constexpr (isIntegralType<physicalType>()) {
+        return HuffmanEncoding<T>::encode(
+            selection, castedValues, buffer, options);
+      }
+      NIMBLE_INCOMPATIBLE_ENCODING(
+          "Huffman encoding only supports integral data types, got {}.",
           TypeTraits<T>::dataType);
     }
     default: {

--- a/dwio/nimble/encodings/common/EncodingLayout.cpp
+++ b/dwio/nimble/encodings/common/EncodingLayout.cpp
@@ -195,6 +195,7 @@ EncodingLayout EncodingLayoutCapture::capture(std::string_view encoding) {
     case EncodingType::SubIntSplit:
     case EncodingType::FOR:
     case EncodingType::FrequencyPartition:
+    case EncodingType::Huffman:
       // Non nested encodings have zero children
       break;
     case EncodingType::ALP: {

--- a/dwio/nimble/encodings/common/EncodingUtils.h
+++ b/dwio/nimble/encodings/common/EncodingUtils.h
@@ -22,6 +22,7 @@
 #include "dwio/nimble/encodings/DictionaryEncoding.h"
 #include "dwio/nimble/encodings/FixedBitWidthEncoding.h"
 #include "dwio/nimble/encodings/FsstEncoding.h"
+#include "dwio/nimble/encodings/HuffmanEncoding.h"
 #include "dwio/nimble/encodings/MainlyConstantEncoding.h"
 #include "dwio/nimble/encodings/NullableEncoding.h"
 #include "dwio/nimble/encodings/PFOREncoding.h"
@@ -155,6 +156,13 @@ auto encodingTypeDispatchNonString(Encoding& encoding, F&& f) {
       }
       NIMBLE_UNREACHABLE(
           "SimdForBitpack encoding only supports integral data types, got {}.",
+          encoding.dataType());
+    case EncodingType::Huffman:
+      if constexpr (isIntegralType<T>()) {
+        return f(static_cast<HuffmanEncoding<T>&>(encoding));
+      }
+      NIMBLE_UNREACHABLE(
+          "Huffman encoding only supports integral data types, got {}.",
           encoding.dataType());
     default:
       NIMBLE_UNSUPPORTED("{}", encoding.encodingType());

--- a/dwio/nimble/encodings/legacy/EncodingFactory.cpp
+++ b/dwio/nimble/encodings/legacy/EncodingFactory.cpp
@@ -15,6 +15,7 @@
  */
 #include "dwio/nimble/encodings/legacy/EncodingFactory.h"
 #include "dwio/nimble/encodings/BlockBitPackingEncoding.h"
+#include "dwio/nimble/encodings/HuffmanEncoding.h"
 #include "dwio/nimble/encodings/PFOREncoding.h"
 #include "dwio/nimble/encodings/SimdForBitpackEncoding.h"
 // SubIntSplit integration commented out (disabled):
@@ -22,11 +23,6 @@
 #ifdef NIMBLE_ENABLE_EXPERIMENTAL_ENCODINGS
 #include "dwio/nimble/encodings/SubIntSplitEncoding.h"
 #endif
-*/
-// FOR and FrequencyPartition integration commented out (disabled):
-/*
-#include "dwio/nimble/encodings/ForEncoding.h"
-#include "dwio/nimble/encodings/FrequencyPartitionEncoding.h"
 */
 #include "dwio/nimble/encodings/legacy/ConstantEncoding.h"
 #include "dwio/nimble/encodings/legacy/DeltaEncoding.h"
@@ -218,36 +214,40 @@ std::unique_ptr<Encoding> EncodingFactory::create(
           toString(dataType));                              \
   }
 
-#define RETURN_ENCODING_BY_INTEGRAL_TYPE(Encoding, dataType)    \
-  switch (dataType) {                                           \
-    case DataType::Int8:                                        \
-      return std::make_unique<Encoding<int8_t>>(                \
-          memoryPool, data, stringBufferFactory);               \
-    case DataType::Uint8:                                       \
-      return std::make_unique<Encoding<uint8_t>>(               \
-          memoryPool, data, stringBufferFactory);               \
-    case DataType::Int16:                                       \
-      return std::make_unique<Encoding<int16_t>>(               \
-          memoryPool, data, stringBufferFactory);               \
-    case DataType::Uint16:                                      \
-      return std::make_unique<Encoding<uint16_t>>(              \
-          memoryPool, data, stringBufferFactory);               \
-    case DataType::Int32:                                       \
-      return std::make_unique<Encoding<int32_t>>(               \
-          memoryPool, data, stringBufferFactory);               \
-    case DataType::Uint32:                                      \
-      return std::make_unique<Encoding<uint32_t>>(              \
-          memoryPool, data, stringBufferFactory);               \
-    case DataType::Int64:                                       \
-      return std::make_unique<Encoding<int64_t>>(               \
-          memoryPool, data, stringBufferFactory);               \
-    case DataType::Uint64:                                      \
-      return std::make_unique<Encoding<uint64_t>>(              \
-          memoryPool, data, stringBufferFactory);               \
-    default:                                                    \
-      NIMBLE_UNREACHABLE(                                       \
-          "FOR encoding only supports integral types, got {}.", \
-          toString(dataType));                                  \
+#define RETURN_ENCODING_BY_INTEGRAL_TYPE(Encoding, dataType)                  \
+  switch (dataType) {                                                         \
+    case DataType::Int8:                                                      \
+      return std::make_unique<Encoding<int8_t>>(                              \
+          memoryPool, data, stringBufferFactory);                             \
+    case DataType::Uint8:                                                     \
+      return std::make_unique<Encoding<uint8_t>>(                             \
+          memoryPool, data, stringBufferFactory);                             \
+    case DataType::Int16:                                                     \
+      return std::make_unique<Encoding<int16_t>>(                             \
+          memoryPool, data, stringBufferFactory);                             \
+    case DataType::Uint16:                                                    \
+      return std::make_unique<Encoding<uint16_t>>(                            \
+          memoryPool, data, stringBufferFactory);                             \
+    case DataType::Int32:                                                     \
+      return std::make_unique<Encoding<int32_t>>(                             \
+          memoryPool, data, stringBufferFactory);                             \
+    case DataType::Uint32:                                                    \
+      return std::make_unique<Encoding<uint32_t>>(                            \
+          memoryPool, data, stringBufferFactory);                             \
+    case DataType::Int64:                                                     \
+      return std::make_unique<Encoding<int64_t>>(                             \
+          memoryPool, data, stringBufferFactory);                             \
+    case DataType::Uint64:                                                    \
+      return std::make_unique<Encoding<uint64_t>>(                            \
+          memoryPool, data, stringBufferFactory);                             \
+    case DataType::Undefined:                                                 \
+    case DataType::Float:                                                     \
+    case DataType::Double:                                                    \
+    case DataType::Bool:                                                      \
+    case DataType::String:                                                    \
+    default:                                                                  \
+      NIMBLE_UNREACHABLE(                                                     \
+          "HuffmanEncoding only supports integral types, got {}.", dataType); \
   }
 
   switch (encodingType) {
@@ -313,19 +313,10 @@ std::unique_ptr<Encoding> EncodingFactory::create(
       RETURN_ENCODING_BY_NUMERIC_TYPE(
           ::facebook::nimble::SimdForBitpackEncoding, dataType);
     }
-    // FOR and FrequencyPartition integration commented out (disabled):
-    /*
-#ifdef NIMBLE_ENABLE_EXPERIMENTAL_ENCODINGS
-    case EncodingType::FOR: {
+    case EncodingType::Huffman: {
       RETURN_ENCODING_BY_INTEGRAL_TYPE(
-          ::facebook::nimble::ForEncoding, dataType);
+          ::facebook::nimble::HuffmanEncoding, dataType);
     }
-    case EncodingType::FrequencyPartition: {
-      RETURN_ENCODING_BY_NON_BOOL_TYPE(
-          ::facebook::nimble::FrequencyPartitionEncoding, dataType);
-    }
-#endif
-    */
     default: {
       NIMBLE_UNREACHABLE(
           "Trying to deserialize invalid EncodingType -- garbage input?");

--- a/dwio/nimble/encodings/legacy/EncodingUtils.h
+++ b/dwio/nimble/encodings/legacy/EncodingUtils.h
@@ -15,6 +15,7 @@
  */
 #pragma once
 
+#include "dwio/nimble/encodings/HuffmanEncoding.h"
 #include "dwio/nimble/encodings/PFOREncoding.h"
 #include "dwio/nimble/encodings/SimdForBitpackEncoding.h"
 // SubIntSplit integration commented out (disabled):
@@ -133,6 +134,13 @@ auto encodingTypeDispatchNonString(Encoding& encoding, F&& f) {
       } else {
         NIMBLE_UNREACHABLE("{}", encoding.dataType());
       }
+    case EncodingType::Huffman:
+      if constexpr (isIntegralType<T>()) {
+        return f(
+            static_cast<::facebook::nimble::HuffmanEncoding<T>&>(encoding));
+      } else {
+        NIMBLE_UNREACHABLE("{}", encoding.dataType());
+      }
     // SubIntSplit integration commented out (disabled):
     /*
 #ifdef NIMBLE_ENABLE_EXPERIMENTAL_ENCODINGS
@@ -142,24 +150,6 @@ auto encodingTypeDispatchNonString(Encoding& encoding, F&& f) {
             static_cast<::facebook::nimble::SubIntSplitEncoding<T>&>(encoding));
       } else {
         NIMBLE_UNREACHABLE("{}", encoding.dataType());
-      }
-#endif
-    */
-    // FOR and FrequencyPartition integration commented out (disabled):
-    /*
-#ifdef NIMBLE_ENABLE_EXPERIMENTAL_ENCODINGS
-    case EncodingType::FOR:
-      if constexpr (std::is_integral_v<T> && !std::is_same_v<T, bool>) {
-        return f(static_cast<::facebook::nimble::ForEncoding<T>&>(encoding));
-      } else {
-        NIMBLE_UNREACHABLE(toString(encoding.dataType()));
-      }
-    case EncodingType::FrequencyPartition:
-      if constexpr (!std::is_same_v<T, bool>) {
-        return f(static_cast<
-                 ::facebook::nimble::FrequencyPartitionEncoding<T>&>(encoding));
-      } else {
-        NIMBLE_UNREACHABLE(toString(encoding.dataType()));
       }
 #endif
     */

--- a/dwio/nimble/encodings/selection/EncodingSelectionPolicy.cpp
+++ b/dwio/nimble/encodings/selection/EncodingSelectionPolicy.cpp
@@ -120,6 +120,7 @@ ManualEncodingSelectionPolicyFactory::possibleEncodings() {
       EncodingType::SubIntSplit,
       EncodingType::BlockBitPacking,
       EncodingType::Fsst,
+      EncodingType::Huffman,
   };
 }
 

--- a/dwio/nimble/encodings/selection/EncodingSizeEstimation.h
+++ b/dwio/nimble/encodings/selection/EncodingSizeEstimation.h
@@ -26,6 +26,7 @@
 #include "dwio/nimble/encodings/DictionaryEncoding.h"
 #include "dwio/nimble/encodings/FixedBitWidthEncoding.h"
 #include "dwio/nimble/encodings/FsstEncoding.h"
+#include "dwio/nimble/encodings/HuffmanEncoding.h"
 #include "dwio/nimble/encodings/MainlyConstantEncoding.h"
 #include "dwio/nimble/encodings/PFOREncoding.h"
 #include "dwio/nimble/encodings/RLEEncoding.h"
@@ -162,6 +163,13 @@ struct EncodingSizeEstimation {
     switch (encodingType) {
       case EncodingType::Constant: {
         return ConstantEncoding<T>::estimateSize(values, statistics, options);
+      }
+      case EncodingType::Huffman: {
+        if constexpr (isIntegralType<physicalType>()) {
+          return HuffmanEncoding<T>::estimateSize(values, statistics, options);
+        } else {
+          return std::nullopt;
+        }
       }
       case EncodingType::ALP: {
         if constexpr (isFloatingPointType<T>()) {

--- a/dwio/nimble/encodings/tests/CMakeLists.txt
+++ b/dwio/nimble/encodings/tests/CMakeLists.txt
@@ -33,6 +33,8 @@ add_executable(
   EncodingLegacyTest.cpp
   FixedBitWidthEncodingViewTest.cpp
   FsstEncodingTest.cpp
+  HuffmanEncodingTest.cpp
+  HuffmanEncodingViewTest.cpp
   FOREncodingViewTest.cpp
   Lz4CompressorTest.cpp
   ForEncodingTest.cpp

--- a/dwio/nimble/encodings/tests/HuffmanEncodingTest.cpp
+++ b/dwio/nimble/encodings/tests/HuffmanEncodingTest.cpp
@@ -1,0 +1,330 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "dwio/nimble/encodings/HuffmanEncoding.h"
+
+#include <fmt/core.h>
+#include <gtest/gtest.h>
+
+#include <array>
+#include <limits>
+#include <numeric>
+
+#include "dwio/nimble/common/Buffer.h"
+#include "dwio/nimble/common/Vector.h"
+#include "dwio/nimble/common/tests/GTestUtils.h"
+#include "dwio/nimble/encodings/common/EncodingFactory.h"
+#include "dwio/nimble/encodings/legacy/EncodingFactory.h"
+#include "dwio/nimble/encodings/tests/TestUtils.h"
+#include "velox/buffer/Buffer.h"
+#include "velox/common/memory/Memory.h"
+
+namespace facebook::nimble::test {
+namespace {
+
+class HuffmanEncodingTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    pool_ = velox::memory::deprecatedAddDefaultLeafMemoryPool();
+    buffer_ = std::make_unique<Buffer>(*pool_);
+  }
+
+  template <typename T>
+  std::unique_ptr<Encoding> encode(const Vector<T>& values) {
+    return Encoder<HuffmanEncoding<T>>::createEncoding(
+        *buffer_, values, nullptr);
+  }
+
+  template <typename T>
+  std::string_view encodeData(const Vector<T>& values) {
+    return Encoder<HuffmanEncoding<T>>::encode(*buffer_, values);
+  }
+
+  template <typename T>
+  void verifyFactoryRoundTrip() {
+    Vector<T> values{pool_.get()};
+    constexpr std::array<T, 5> alphabet{
+        std::numeric_limits<T>::lowest(),
+        T{0},
+        T{1},
+        std::numeric_limits<T>::max(),
+        static_cast<T>(std::numeric_limits<T>::max() / 2)};
+    for (uint32_t row = 0; row < 1025; ++row) {
+      values.push_back(alphabet[row % alphabet.size()]);
+    }
+
+    const auto encoded = encodeData(values);
+    for (const auto useLegacy : {false, true}) {
+      SCOPED_TRACE(fmt::format("legacy={}", useLegacy));
+      std::unique_ptr<Encoding> encoding = useLegacy
+          ? legacy::EncodingFactory({}).create(*pool_, encoded, nullptr)
+          : EncodingFactory({}).create(*pool_, encoded, nullptr);
+      EXPECT_EQ(encoding->encodingType(), EncodingType::Huffman);
+      EXPECT_EQ(encoding->dataType(), TypeTraits<T>::dataType);
+      EXPECT_EQ(encoding->rowCount(), values.size());
+
+      Vector<T> result{pool_.get(), values.size()};
+      encoding->materialize(
+          static_cast<uint32_t>(values.size()), result.data());
+      EXPECT_TRUE(std::equal(result.begin(), result.end(), values.begin()));
+    }
+  }
+
+  std::shared_ptr<velox::memory::MemoryPool> pool_;
+  std::unique_ptr<Buffer> buffer_;
+};
+
+class TestReader {
+ public:
+  velox::BufferPtr& nullsInReadRange() {
+    return nullsInReadRange_;
+  }
+
+  const uint64_t* rawNullsInReadRange() const {
+    return nullsInReadRange_ ? nullsInReadRange_->as<uint64_t>() : nullptr;
+  }
+
+  bool returnReaderNulls() const {
+    return false;
+  }
+
+ private:
+  velox::BufferPtr nullsInReadRange_;
+};
+
+template <typename T>
+class IntegralReadWithVisitor {
+ public:
+  using DataType = T;
+  using Extract = std::nullptr_t;
+
+  explicit IntegralReadWithVisitor(std::vector<vector_size_t> rows)
+      : rows_{std::move(rows)} {}
+
+  TestReader& reader() {
+    return reader_;
+  }
+
+  vector_size_t numRows() const {
+    return rows_.size();
+  }
+
+  vector_size_t rowAt(vector_size_t index) const {
+    return rows_[index];
+  }
+
+  vector_size_t currentRow() const {
+    return rowAt(rowIndex_);
+  }
+
+  void process(T value, bool& atEnd) {
+    values_.push_back(value);
+    addRowIndex(1);
+    atEnd = this->atEnd();
+  }
+
+  void processNull(bool& atEnd) {
+    addRowIndex(1);
+    atEnd = this->atEnd();
+  }
+
+  bool allowNulls() const {
+    return false;
+  }
+
+  void addRowIndex(vector_size_t count) {
+    rowIndex_ += count;
+  }
+
+  void addNumValues(vector_size_t /*count*/) {}
+
+  bool atEnd() const {
+    return rowIndex_ >= rows_.size();
+  }
+
+  const std::vector<T>& values() const {
+    return values_;
+  }
+
+ private:
+  TestReader reader_;
+  std::vector<vector_size_t> rows_;
+  vector_size_t rowIndex_{0};
+  std::vector<T> values_;
+};
+
+TEST_F(HuffmanEncodingTest, factoryRoundTripAllIntegralTypes) {
+  verifyFactoryRoundTrip<int8_t>();
+  verifyFactoryRoundTrip<uint8_t>();
+  verifyFactoryRoundTrip<int16_t>();
+  verifyFactoryRoundTrip<uint16_t>();
+  verifyFactoryRoundTrip<int32_t>();
+  verifyFactoryRoundTrip<uint32_t>();
+  verifyFactoryRoundTrip<int64_t>();
+  verifyFactoryRoundTrip<uint64_t>();
+}
+
+TEST_F(HuffmanEncodingTest, signedRoundTrip) {
+  Vector<int32_t> values{pool_.get()};
+  for (uint32_t i = 0; i < 700; ++i) {
+    values.push_back(i % 10 == 0 ? -7 : static_cast<int32_t>(i % 4));
+  }
+
+  auto encoding = encode(values);
+  Vector<int32_t> result{pool_.get(), values.size()};
+  encoding->materialize(static_cast<uint32_t>(values.size()), result.data());
+
+  EXPECT_TRUE(std::equal(result.begin(), result.end(), values.begin()));
+}
+
+TEST_F(HuffmanEncodingTest, skipAndPartialReadsCrossCheckpoints) {
+  Vector<uint64_t> values{pool_.get()};
+  for (uint32_t i = 0; i < 900; ++i) {
+    values.push_back(i % 17);
+  }
+
+  auto encoding = encode(values);
+  encoding->skip(250);
+  Vector<uint64_t> first{pool_.get(), 40};
+  encoding->materialize(static_cast<uint32_t>(first.size()), first.data());
+  EXPECT_TRUE(std::equal(first.begin(), first.end(), values.begin() + 250));
+
+  encoding->reset();
+  encoding->skip(510);
+  Vector<uint64_t> second{pool_.get(), 300};
+  encoding->materialize(static_cast<uint32_t>(second.size()), second.data());
+  EXPECT_TRUE(std::equal(second.begin(), second.end(), values.begin() + 510));
+}
+
+TEST_F(HuffmanEncodingTest, skipRejectsPastEnd) {
+  Vector<uint32_t> values{pool_.get()};
+  values.push_back(1);
+  values.push_back(2);
+
+  auto encoding = encode(values);
+  encoding->skip(2);
+  NIMBLE_ASSERT_THROW(encoding->skip(1), "(1 vs. 0)");
+}
+
+TEST_F(HuffmanEncodingTest, resetAndMaterializeOneAtATime) {
+  Vector<int32_t> values{pool_.get()};
+  for (uint32_t i = 0; i < 513; ++i) {
+    values.push_back(static_cast<int32_t>(i % 7) - 3);
+  }
+
+  auto encoding = encode(values);
+  for (uint32_t i = 0; i < values.size(); ++i) {
+    int32_t result{0};
+    encoding->materialize(1, &result);
+    EXPECT_EQ(result, values[i]) << "row=" << i;
+  }
+
+  encoding->reset();
+  Vector<int32_t> result{pool_.get(), values.size()};
+  encoding->materialize(static_cast<uint32_t>(values.size()), result.data());
+  EXPECT_TRUE(std::equal(result.begin(), result.end(), values.begin()));
+}
+
+TEST_F(HuffmanEncodingTest, readWithVisitorDenseAndSparseAcrossCheckpoints) {
+  Vector<int64_t> values{pool_.get()};
+  for (uint32_t i = 0; i < 1025; ++i) {
+    values.push_back(i % 13 == 0 ? -9 : static_cast<int64_t>(i % 5));
+  }
+  const auto encoded = encodeData(values);
+
+  struct TestCase {
+    std::string name;
+    std::vector<vector_size_t> rows;
+  };
+  for (const auto& testCase : std::vector<TestCase>{
+           {"dense around checkpoints", {254, 255, 256, 257, 510, 511, 512}},
+           {"sparse across checkpoints", {0, 17, 255, 513, 768, 1024}},
+       }) {
+    SCOPED_TRACE(testCase.name);
+    HuffmanEncoding<int64_t> encoding{*pool_, encoded};
+    IntegralReadWithVisitor<int64_t> visitor{testCase.rows};
+    ReadWithVisitorParams params;
+    params.numScanned = 0;
+
+    encoding.readWithVisitor(visitor, params);
+
+    ASSERT_EQ(visitor.values().size(), testCase.rows.size());
+    for (size_t i = 0; i < testCase.rows.size(); ++i) {
+      EXPECT_EQ(visitor.values()[i], values[testCase.rows[i]]);
+    }
+  }
+}
+
+TEST_F(HuffmanEncodingTest, estimateRejectsFewerThanTwoRows) {
+  const std::vector<uint32_t> empty;
+  const auto emptyStatistics = Statistics<uint32_t>::create(empty);
+  EXPECT_EQ(
+      HuffmanEncoding<uint32_t>::estimateSize(empty, emptyStatistics),
+      std::nullopt);
+
+  const std::vector<uint32_t> single{7};
+  const auto singleStatistics = Statistics<uint32_t>::create(single);
+  EXPECT_EQ(
+      HuffmanEncoding<uint32_t>::estimateSize(single, singleStatistics),
+      std::nullopt);
+}
+
+TEST_F(HuffmanEncodingTest, estimateRejectsUnsupportedCardinality) {
+  const std::vector<uint32_t> singleValue(100, 7);
+  EXPECT_EQ(
+      HuffmanEncoding<uint32_t>::estimateSize(
+          singleValue, Statistics<uint32_t>::create(singleValue)),
+      std::nullopt);
+
+  std::vector<uint32_t> tooManySymbols(
+      HuffmanEncoding<uint32_t>::kMaxSymbols + 1);
+  std::iota(tooManySymbols.begin(), tooManySymbols.end(), 0);
+  EXPECT_EQ(
+      HuffmanEncoding<uint32_t>::estimateSize(
+          tooManySymbols, Statistics<uint32_t>::create(tooManySymbols)),
+      std::nullopt);
+}
+
+TEST_F(HuffmanEncodingTest, estimateSizeIncludesCodesAndCheckpoints) {
+  std::vector<uint32_t> values;
+  values.insert(values.end(), 128, 0);
+  values.insert(values.end(), 64, 1);
+  values.insert(values.end(), 64, 2);
+
+  const auto estimate = HuffmanEncoding<uint32_t>::estimateSize(
+      values, Statistics<uint32_t>::create(values));
+  const uint64_t bitstreamBytes = 48 + 4;
+  const uint64_t expected =
+      EncodingPrefix::serializedSize(256, /*useVarint=*/false) +
+      varint::varintSize(3) + 1 + 3 * sizeof(uint32_t) + 3 +
+      varint::varintSize(1) + 2 + varint::varintSize(bitstreamBytes) +
+      bitstreamBytes;
+  EXPECT_EQ(estimate, expected);
+
+  values.push_back(0);
+  const auto estimateAcrossCheckpoint = HuffmanEncoding<uint32_t>::estimateSize(
+      values, Statistics<uint32_t>::create(values));
+  const uint64_t bitstreamBytesAcrossCheckpoint = 65 + 4;
+  const uint64_t expectedAcrossCheckpoint =
+      EncodingPrefix::serializedSize(257, /*useVarint=*/false) +
+      varint::varintSize(3) + 1 + 3 * sizeof(uint32_t) + 3 +
+      varint::varintSize(2) + 4 +
+      varint::varintSize(bitstreamBytesAcrossCheckpoint) +
+      bitstreamBytesAcrossCheckpoint;
+  EXPECT_EQ(estimateAcrossCheckpoint, expectedAcrossCheckpoint);
+}
+
+} // namespace
+} // namespace facebook::nimble::test

--- a/dwio/nimble/encodings/tests/HuffmanEncodingViewTest.cpp
+++ b/dwio/nimble/encodings/tests/HuffmanEncodingViewTest.cpp
@@ -1,0 +1,89 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <gtest/gtest.h>
+
+#include "dwio/nimble/encodings/HuffmanEncoding.h"
+#include "dwio/nimble/encodings/tests/EncodingViewTestUtils.h"
+#include "velox/buffer/BufferPool.h"
+
+using namespace facebook;
+
+using HuffmanEncodingViewTest = nimble::test::EncodingViewTest;
+
+TEST_F(HuffmanEncodingViewTest, readsAcrossCheckpoints) {
+  nimble::Vector<int32_t> values{pool_.get()};
+  values.reserve(1025);
+  for (uint32_t row = 0; row < 1025; ++row) {
+    values.push_back(row % 13 == 0 ? -7 : static_cast<int32_t>(row % 5));
+  }
+  expectReads<nimble::HuffmanEncoding<int32_t>>(
+      values, {1024, 0, 255, 256, 257, 511, 512, 768});
+}
+
+TEST_F(HuffmanEncodingViewTest, readsAllIntegralTypes) {
+  expectReads<nimble::HuffmanEncoding<int8_t>>(
+      makeVector<int8_t>({-2, -1, 0, 1, 2}), {4, 0, 2});
+  expectReads<nimble::HuffmanEncoding<uint8_t>>(
+      makeVector<uint8_t>({0, 1, 2, 3, 4}), {3, 1, 4});
+  expectReads<nimble::HuffmanEncoding<int16_t>>(
+      makeVector<int16_t>({-100, 0, 100, -100}), {3, 2, 0});
+  expectReads<nimble::HuffmanEncoding<uint16_t>>(
+      makeVector<uint16_t>({0, 100, 1000, 100}), {2, 0, 3});
+  expectReads<nimble::HuffmanEncoding<int32_t>>(
+      makeVector<int32_t>({-1000, 0, 1000, -1000}), {1, 3, 2});
+  expectReads<nimble::HuffmanEncoding<uint32_t>>(
+      makeVector<uint32_t>({0, 1000, 100000, 1000}), {2, 1, 0});
+  expectReads<nimble::HuffmanEncoding<int64_t>>(
+      makeVector<int64_t>({-100000, 0, 100000, -100000}), {3, 0, 2});
+  expectReads<nimble::HuffmanEncoding<uint64_t>>(
+      makeVector<uint64_t>({0, 100000, 1000000, 100000}), {2, 0, 3});
+}
+
+TEST_F(HuffmanEncodingViewTest, concurrent) {
+  expectConcurrentReads<nimble::HuffmanEncoding<uint32_t>>(
+      randomNarrowUnsigned<uint32_t>(/*seed=*/41),
+      randomizedPositions(/*seed=*/42));
+}
+
+TEST_F(HuffmanEncodingViewTest, reusesMetadataBuffers) {
+  auto values = randomNarrowUnsigned<uint32_t>(/*seed=*/43);
+  const auto encoded =
+      nimble::test::Encoder<nimble::HuffmanEncoding<uint32_t>>::encode(
+          *buffer_, values);
+  const std::vector<char> encodedStorage{encoded.begin(), encoded.end()};
+
+  auto decodePool = velox::memory::deprecatedAddDefaultLeafMemoryPool();
+  velox::BufferPool bufferPool{velox::BufferPool::kDefaultCapacity};
+  const nimble::Encoding::Options options{.bufferPool = &bufferPool};
+
+  auto readAndRelease = [&]() {
+    auto view = nimble::createEncodingView(
+        {encodedStorage.data(), encodedStorage.size()},
+        decodePool.get(),
+        options);
+    uint32_t value;
+    view->readAt(768, &value);
+    EXPECT_EQ(value, values[768]);
+  };
+
+  readAndRelease();
+  const auto numAllocsAfterFirstView = decodePool->stats().numAllocs;
+  EXPECT_GT(bufferPool.size(), 0);
+
+  readAndRelease();
+  EXPECT_EQ(decodePool->stats().numAllocs, numAllocsAfterFirstView);
+}

--- a/dwio/nimble/encodings/tests/TestUtils.h
+++ b/dwio/nimble/encodings/tests/TestUtils.h
@@ -23,6 +23,7 @@
 #include "dwio/nimble/encodings/FixedBitWidthEncoding.h"
 #include "dwio/nimble/encodings/ForEncoding.h"
 #include "dwio/nimble/encodings/FrequencyPartitionEncoding.h"
+#include "dwio/nimble/encodings/HuffmanEncoding.h"
 #include "dwio/nimble/encodings/MainlyConstantEncoding.h"
 #include "dwio/nimble/encodings/NullableEncoding.h"
 #include "dwio/nimble/encodings/PFOREncoding.h"
@@ -89,6 +90,12 @@ template <typename T>
 struct EncodingTypeTraits<nimble::ForEncoding<T>> {
   static constexpr inline nimble::EncodingType encodingType =
       nimble::EncodingType::FOR;
+};
+
+template <typename T>
+struct EncodingTypeTraits<nimble::HuffmanEncoding<T>> {
+  static constexpr inline nimble::EncodingType encodingType =
+      nimble::EncodingType::Huffman;
 };
 
 template <typename T>

--- a/dwio/nimble/encodings/views/EncodingViewFactory.cpp
+++ b/dwio/nimble/encodings/views/EncodingViewFactory.cpp
@@ -21,6 +21,7 @@
 #include "dwio/nimble/encodings/views/DictionaryEncodingView.h"
 #include "dwio/nimble/encodings/views/FOREncodingView.h"
 #include "dwio/nimble/encodings/views/FixedBitWidthEncodingView.h"
+#include "dwio/nimble/encodings/views/HuffmanEncodingView.h"
 #include "dwio/nimble/encodings/views/MainlyConstantEncodingView.h"
 #include "dwio/nimble/encodings/views/PFOREncodingView.h"
 #include "dwio/nimble/encodings/views/RLEEncodingView.h"
@@ -86,6 +87,15 @@ std::unique_ptr<TypedEncodingView<T>> createTypedEncodingView(
       }
       NIMBLE_INCOMPATIBLE_ENCODING(
           "FOR encoding should not be selected for non-integral data type: {}.",
+          TypeTraits<T>::dataType);
+    case EncodingType::Huffman:
+      if constexpr (
+          isIntegralType<physicalType>() &&
+          !std::is_same_v<physicalType, bool>) {
+        return std::make_unique<HuffmanEncodingView<T>>(data, pool, options);
+      }
+      NIMBLE_INCOMPATIBLE_ENCODING(
+          "Huffman encoding should not be selected for non-integral data type: {}.",
           TypeTraits<T>::dataType);
     case EncodingType::PFOR:
       if constexpr (isIntegralType<physicalType>()) {

--- a/dwio/nimble/encodings/views/HuffmanEncodingView.h
+++ b/dwio/nimble/encodings/views/HuffmanEncodingView.h
@@ -1,0 +1,154 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <algorithm>
+#include <array>
+#include <cstdint>
+#include <cstring>
+
+#include "dwio/nimble/common/Varint.h"
+#include "dwio/nimble/common/Vector.h"
+#include "dwio/nimble/encodings/HuffmanEncoding.h"
+#include "dwio/nimble/encodings/common/EncodingPrimitives.h"
+#include "dwio/nimble/encodings/views/EncodingView.h"
+
+namespace facebook::nimble {
+
+template <typename T>
+class HuffmanEncodingView final : public TypedEncodingView<T> {
+ public:
+  using physicalType = typename TypedEncodingView<T>::physicalType;
+
+  HuffmanEncodingView(
+      std::string_view data,
+      velox::memory::MemoryPool* pool,
+      const Encoding::Options& options)
+      : TypedEncodingView<T>{data, pool, options},
+        alphabet_{this->template getVectorBuffer<physicalType>()},
+        decodeTable_{this->template getVectorBuffer<DecodeEntry>()},
+        checkpoints_{this->template getVectorBuffer<uint32_t>()} {
+    static_assert(
+        std::is_integral_v<physicalType> &&
+        !std::is_same_v<physicalType, bool>);
+    NIMBLE_CHECK_EQ(this->encodingType_, EncodingType::Huffman);
+
+    const char* pos = data.data() + this->dataOffset_;
+    const uint32_t symbolCount = varint::readVarint32(&pos);
+    tableLog_ = static_cast<uint8_t>(encoding::readChar(pos));
+    NIMBLE_CHECK_GE(symbolCount, 2);
+    NIMBLE_CHECK_LE(symbolCount, HuffmanEncoding<T>::kMaxSymbols);
+    NIMBLE_CHECK_LE(tableLog_, HuffmanEncoding<T>::kMaxCodeBits);
+
+    alphabet_.resize(symbolCount);
+    std::memcpy(alphabet_.data(), pos, symbolCount * sizeof(physicalType));
+    pos += symbolCount * sizeof(physicalType);
+
+    const auto* lengths = reinterpret_cast<const uint8_t*>(pos);
+    pos += symbolCount;
+    decodeTable_.resize(1u << tableLog_);
+    std::fill(decodeTable_.begin(), decodeTable_.end(), DecodeEntry{});
+
+    std::array<uint16_t, HuffmanEncoding<T>::kMaxCodeBits + 1> counts{};
+    for (uint32_t symbol = 0; symbol < symbolCount; ++symbol) {
+      NIMBLE_CHECK_GT(lengths[symbol], 0);
+      NIMBLE_CHECK_LE(lengths[symbol], tableLog_);
+      ++counts[lengths[symbol]];
+    }
+    std::array<uint16_t, HuffmanEncoding<T>::kMaxCodeBits + 1> nextCode{};
+    uint16_t code = 0;
+    for (uint8_t bits = 1; bits <= tableLog_; ++bits) {
+      code = static_cast<uint16_t>((code + counts[bits - 1]) << 1);
+      nextCode[bits] = code;
+    }
+    for (uint32_t symbol = 0; symbol < symbolCount; ++symbol) {
+      const uint8_t bits = lengths[symbol];
+      const uint16_t reversed = reverseBits(nextCode[bits]++, bits);
+      for (uint32_t slot = reversed; slot < decodeTable_.size();
+           slot += 1u << bits) {
+        decodeTable_[slot] = DecodeEntry{static_cast<uint16_t>(symbol), bits};
+      }
+    }
+
+    const uint32_t checkpointCount = varint::readVarint32(&pos);
+    NIMBLE_CHECK_EQ(
+        checkpointCount,
+        velox::bits::divRoundUp(
+            this->rowCount_, HuffmanEncoding<T>::kCheckpointStride));
+    checkpoints_.resize(checkpointCount);
+    uint32_t bitOffset = 0;
+    for (uint32_t checkpoint = 0; checkpoint < checkpointCount; ++checkpoint) {
+      bitOffset += varint::readVarint32(&pos);
+      checkpoints_[checkpoint] = bitOffset;
+    }
+    bitstreamBytes_ = varint::readVarint32(&pos);
+    bitstream_ = reinterpret_cast<const uint8_t*>(pos);
+    NIMBLE_CHECK_EQ(pos + bitstreamBytes_, data.end());
+  }
+
+  ~HuffmanEncodingView() override {
+    this->releaseVectorBuffer(checkpoints_);
+    this->releaseVectorBuffer(decodeTable_);
+    this->releaseVectorBuffer(alphabet_);
+  }
+
+ private:
+  struct DecodeEntry {
+    uint16_t symbol{0};
+    uint8_t bits{0};
+  };
+
+  static uint16_t reverseBits(uint16_t value, uint8_t bits) {
+    uint16_t reversed = 0;
+    for (uint8_t i = 0; i < bits; ++i) {
+      reversed = static_cast<uint16_t>((reversed << 1) | (value & 1));
+      value >>= 1;
+    }
+    return reversed;
+  }
+
+  T readTypedAt(uint32_t index) const final {
+    NIMBLE_CHECK_LT(index, this->rowCount_);
+    const uint32_t checkpoint = index / HuffmanEncoding<T>::kCheckpointStride;
+    uint32_t bitOffset = checkpoints_[checkpoint];
+    uint32_t current = checkpoint * HuffmanEncoding<T>::kCheckpointStride;
+    while (current <= index) {
+      uint32_t lookahead = 0;
+      const uint32_t byteOffset = bitOffset >> 3;
+      NIMBLE_CHECK_LT(byteOffset, bitstreamBytes_);
+      const uint32_t available =
+          std::min<uint32_t>(4, bitstreamBytes_ - byteOffset);
+      std::memcpy(&lookahead, bitstream_ + byteOffset, available);
+      lookahead >>= bitOffset & 7;
+      const auto entry = decodeTable_[lookahead & ((1u << tableLog_) - 1)];
+      NIMBLE_CHECK_GT(entry.bits, 0);
+      bitOffset += entry.bits;
+      if (current++ == index) {
+        return detail::castFromPhysicalType<T>(alphabet_[entry.symbol]);
+      }
+    }
+    NIMBLE_UNREACHABLE("Invalid Huffman row {}", index);
+  }
+
+  Vector<physicalType> alphabet_;
+  Vector<DecodeEntry> decodeTable_;
+  Vector<uint32_t> checkpoints_;
+  const uint8_t* bitstream_{nullptr};
+  uint32_t bitstreamBytes_{0};
+  uint8_t tableLog_{0};
+};
+
+} // namespace facebook::nimble

--- a/dwio/nimble/fuzzer/encoding/EncodingFuzzer.h
+++ b/dwio/nimble/fuzzer/encoding/EncodingFuzzer.h
@@ -21,6 +21,7 @@
 #include <limits>
 #include <random>
 #include <string_view>
+#include <unordered_set>
 #include <vector>
 
 #include <glog/logging.h>
@@ -251,12 +252,16 @@ class EncodingFuzzer {
       uint32_t maxRows,
       uint32_t seed,
       bool testCompression,
-      const Encoding::Options& options = {})
+      const Encoding::Options& options = {},
+      uint32_t minDistinctValues = 1,
+      uint32_t maxDistinctValues = std::numeric_limits<uint32_t>::max())
       : iterations_{iterations},
         maxRows_{maxRows},
         seed_{seed},
         testCompression_{testCompression},
-        options_{options} {
+        options_{options},
+        minDistinctValues_{minDistinctValues},
+        maxDistinctValues_{maxDistinctValues} {
     pool_ = velox::memory::deprecatedAddDefaultLeafMemoryPool();
     buffer_ = std::make_unique<Buffer>(*pool_);
   }
@@ -277,7 +282,7 @@ class EncodingFuzzer {
       auto datasets = generateDatasets(rng);
 
       for (auto& data : datasets) {
-        if (data.empty()) {
+        if (data.empty() || !hasSupportedCardinality(data)) {
           continue;
         }
         auto compressionModes = testCompression_
@@ -292,6 +297,21 @@ class EncodingFuzzer {
   }
 
  private:
+  bool hasSupportedCardinality(const Vector<T>& data) const {
+    if (minDistinctValues_ == 1 &&
+        maxDistinctValues_ == std::numeric_limits<uint32_t>::max()) {
+      return true;
+    }
+    std::unordered_set<T> distinctValues;
+    for (const auto& value : data) {
+      distinctValues.insert(value);
+      if (distinctValues.size() > maxDistinctValues_) {
+        return false;
+      }
+    }
+    return distinctValues.size() >= minDistinctValues_;
+  }
+
   std::vector<Vector<T>> generateDatasets(std::mt19937& rng) {
     std::vector<Vector<T>> datasets;
     uint32_t rowCount = 1 + folly::Random::rand32(rng) % maxRows_;
@@ -549,6 +569,8 @@ class EncodingFuzzer {
   uint32_t seed_;
   bool testCompression_;
   Encoding::Options options_;
+  uint32_t minDistinctValues_;
+  uint32_t maxDistinctValues_;
   std::shared_ptr<velox::memory::MemoryPool> pool_;
   std::unique_ptr<Buffer> buffer_;
 };

--- a/dwio/nimble/fuzzer/encoding/EncodingFuzzerTest.cpp
+++ b/dwio/nimble/fuzzer/encoding/EncodingFuzzerTest.cpp
@@ -35,6 +35,7 @@
 #include "dwio/nimble/encodings/FixedBitWidthEncoding.h"
 #include "dwio/nimble/encodings/ForEncoding.h"
 #include "dwio/nimble/encodings/FrequencyPartitionEncoding.h"
+#include "dwio/nimble/encodings/HuffmanEncoding.h"
 #include "dwio/nimble/encodings/MainlyConstantEncoding.h"
 #include "dwio/nimble/encodings/RLEEncoding.h"
 #include "dwio/nimble/encodings/SimdForBitpackEncoding.h"
@@ -333,6 +334,33 @@ TYPED_TEST(ALPFuzzerTest, correctness) {
       FLAGS_fuzzer_max_rows,
       FLAGS_fuzzer_seed,
       FLAGS_fuzzer_compression);
+  fuzzer.run();
+}
+
+// Huffman: all integral types.
+using HuffmanTypes = ::testing::Types<
+    HuffmanEncoding<int8_t>,
+    HuffmanEncoding<uint8_t>,
+    HuffmanEncoding<int16_t>,
+    HuffmanEncoding<uint16_t>,
+    HuffmanEncoding<int32_t>,
+    HuffmanEncoding<uint32_t>,
+    HuffmanEncoding<int64_t>,
+    HuffmanEncoding<uint64_t>>;
+
+template <typename E>
+class HuffmanFuzzerTest : public ::testing::Test {};
+TYPED_TEST_SUITE(HuffmanFuzzerTest, HuffmanTypes);
+
+TYPED_TEST(HuffmanFuzzerTest, correctness) {
+  EncodingFuzzer<TypeParam> fuzzer(
+      FLAGS_fuzzer_iterations,
+      FLAGS_fuzzer_max_rows,
+      FLAGS_fuzzer_seed,
+      FLAGS_fuzzer_compression,
+      {},
+      /*minDistinctValues=*/2,
+      /*maxDistinctValues=*/HuffmanEncoding<int8_t>::kMaxSymbols);
   fuzzer.run();
 }
 

--- a/dwio/nimble/fuzzer/encoding/EncodingViewFuzzerTest.cpp
+++ b/dwio/nimble/fuzzer/encoding/EncodingViewFuzzerTest.cpp
@@ -28,6 +28,7 @@
 #include "dwio/nimble/encodings/ConstantEncoding.h"
 #include "dwio/nimble/encodings/DictionaryEncoding.h"
 #include "dwio/nimble/encodings/FixedBitWidthEncoding.h"
+#include "dwio/nimble/encodings/HuffmanEncoding.h"
 #include "dwio/nimble/encodings/PFOREncoding.h"
 #include "dwio/nimble/encodings/RLEEncoding.h"
 #include "dwio/nimble/encodings/SimdForBitpackEncoding.h"
@@ -362,6 +363,27 @@ class PforEncodingViewFuzzerTest : public ::testing::Test {};
 TYPED_TEST_SUITE(PforEncodingViewFuzzerTest, PforViewTypes);
 
 TYPED_TEST(PforEncodingViewFuzzerTest, readAtMatchesMaterialize) {
+  runEncodingViewFuzzer<TypeParam>(
+      FLAGS_view_fuzzer_iterations,
+      FLAGS_view_fuzzer_max_rows,
+      FLAGS_view_fuzzer_seed);
+}
+
+using HuffmanViewTypes = ::testing::Types<
+    HuffmanEncoding<int8_t>,
+    HuffmanEncoding<uint8_t>,
+    HuffmanEncoding<int16_t>,
+    HuffmanEncoding<uint16_t>,
+    HuffmanEncoding<int32_t>,
+    HuffmanEncoding<uint32_t>,
+    HuffmanEncoding<int64_t>,
+    HuffmanEncoding<uint64_t>>;
+
+template <typename E>
+class HuffmanEncodingViewFuzzerTest : public ::testing::Test {};
+TYPED_TEST_SUITE(HuffmanEncodingViewFuzzerTest, HuffmanViewTypes);
+
+TYPED_TEST(HuffmanEncodingViewFuzzerTest, readAtMatchesMaterialize) {
   runEncodingViewFuzzer<TypeParam>(
       FLAGS_view_fuzzer_iterations,
       FLAGS_view_fuzzer_max_rows,

--- a/dwio/nimble/tools/EncodingUtilities.cpp
+++ b/dwio/nimble/tools/EncodingUtilities.cpp
@@ -62,6 +62,7 @@ void extractCompressionType(
     case EncodingType::SubIntSplit:
     case EncodingType::FrequencyPartition:
     case EncodingType::FOR:
+    case EncodingType::Huffman:
       break;
   }
 }
@@ -294,6 +295,7 @@ void traverseEncodings(
     }
     case EncodingType::FrequencyPartition:
     case EncodingType::FOR:
+    case EncodingType::Huffman:
       break;
   }
 }

--- a/dwio/nimble/velox/selective/tests/E2EFilterTest.cpp
+++ b/dwio/nimble/velox/selective/tests/E2EFilterTest.cpp
@@ -1232,6 +1232,27 @@ TEST_P(E2EFilterTest, integerBiasedDelta) {
   verifyColumnEncodingsOnDisk(EncodingType::Delta);
 }
 
+TEST_P(E2EFilterTest, integerForcedHuffman) {
+  forcedEncodingType_ = EncodingType::Huffman;
+  testWithTypes(
+      "tiny_val:tinyint,"
+      "short_val:smallint,"
+      "int_val:int,"
+      "long_val:bigint",
+      [&]() {
+        makeIntDistribution<int8_t>("tiny_val", -8, 7, 20, 0, 0, 0, false);
+        makeIntDistribution<int16_t>("short_val", -32, 31, 20, 0, 0, 0, false);
+        makeIntDistribution<int32_t>("int_val", -128, 127, 20, 0, 0, 0, false);
+        makeIntDistribution<int64_t>("long_val", -512, 511, 20, 0, 0, 0, false);
+      },
+      /*wrapInStruct=*/false,
+      {"tiny_val", "short_val", "int_val", "long_val"},
+      /*numCombinations=*/20,
+      /*withRecursiveNulls=*/true);
+  forcedEncodingType_.reset();
+  verifyColumnEncodingsOnDisk(EncodingType::Huffman);
+}
+
 #ifdef NIMBLE_ENABLE_EXPERIMENTAL_ENCODINGS
 // Biased variant that forces SubIntSplit encoding selection.
 // SubIntSplit only applies to 32- and 64-bit types; smallint is excluded.

--- a/dwio/nimble/velox/selective/tests/SelectiveNimbleReaderTest.cpp
+++ b/dwio/nimble/velox/selective/tests/SelectiveNimbleReaderTest.cpp
@@ -3149,7 +3149,42 @@ TEST_P(SelectiveNimbleReaderTest, delta) {
 }
 
 // ---------------------------------------------------------------------------
-// DeltaEncoding: forced via ManualEncodingSelectionPolicyFactory
+// HuffmanEncoding: filtered reads across random-access checkpoints
+// ---------------------------------------------------------------------------
+TEST_P(SelectiveNimbleReaderTest, huffmanFilteredAcrossCheckpoints) {
+  const bool stringDecoderZeroCopy = this->stringDecoderZeroCopy();
+  auto c0 = makeFlatVector<int64_t>(1025, [](auto i) {
+    return i % 10 == 0 ? static_cast<int64_t>(100 + i % 7)
+                       : static_cast<int64_t>(i % 4);
+  });
+  auto input = makeRowVector({c0});
+  auto scanSpec = std::make_shared<common::ScanSpec>("root");
+  scanSpec->addAllChildFields(*input->type());
+  scanSpec->childByName("c0")->setFilter(
+      std::make_unique<common::BigintRange>(102, 104, false));
+
+  auto file = test::createNimbleFile(
+      *rootPool(),
+      input,
+      {.encodingLayoutTree = EncodingLayoutTree{
+           Kind::Row,
+           {},
+           "",
+           {{Kind::Scalar,
+             {{0,
+               EncodingLayout{
+                   EncodingType::Huffman, {}, CompressionType::Uncompressed}}},
+             ""}}}});
+  verifyEncodingOnDisk(file, EncodingType::Huffman, /*isNullable=*/false);
+
+  auto readers = makeReaders(input, file, scanSpec, stringDecoderZeroCopy);
+  validate(*input, *readers.rowReader, 73, [&](auto i) {
+    return c0->valueAt(i) >= 102 && c0->valueAt(i) <= 104;
+  });
+}
+
+// ---------------------------------------------------------------------------
+// DeltaEncoding: forced via encoding layout
 // ---------------------------------------------------------------------------
 TEST_P(SelectiveNimbleReaderTest, deltaForcedEncoding) {
   const bool stringDecoderZeroCopy = this->stringDecoderZeroCopy();


### PR DESCRIPTION
Summary:
Add a canonical Huffman encoding for integral Nimble streams. Preserve row order and store bit offsets every 256 rows for bounded random access. Use the canonical code-weight and table-driven decode design established by Zstrong/OpenZL while keeping a Nimble-native wire format.

Integrate `EncodingType::Huffman` with encoding factories, visitor dispatch, size estimation, encoding inspection, Buck, and CMake. Keep it out of default selection while allowing explicit read-factor configuration. Support both modern and legacy selective-reader decoder traits, and cover filtered reads across checkpoint boundaries.

Add random-access `EncodingView` support with pool-backed alphabet, checkpoint, and decoder-table buffers. Cover view reads, concurrent access, buffer reuse, all integral types, fuzzing, and skewed and uniform benchmark inputs.

Reviewed By: HuamengJiang

Differential Revision: D112700536


