### PR TITLE
perf: Add opt-in per-stream encoded StripeGroup metadata

### DIFF
--- a/dwio/nimble/tablet/FileLayout.cpp
+++ b/dwio/nimble/tablet/FileLayout.cpp
@@ -71,10 +71,13 @@ FileLayout FileLayout::create(
   // Per-stripe info
   const auto stripeCount = tablet->stripeCount();
   layout.stripesInfo.reserve(stripeCount);
+  std::vector<uint32_t> sizesScratch;
   for (uint32_t i = 0; i < stripeCount; ++i) {
     auto stripeIdentifier = tablet->stripeIdentifier(i);
-    auto sizes = tablet->streamSizes(stripeIdentifier);
-    auto stripeSize = std::accumulate(sizes.begin(), sizes.end(), 0UL);
+    sizesScratch.resize(tablet->streamCount(stripeIdentifier));
+    tablet->streamSizes(stripeIdentifier, sizesScratch);
+    auto stripeSize =
+        std::accumulate(sizesScratch.begin(), sizesScratch.end(), 0UL);
     layout.stripesInfo.push_back({
         .offset = tablet->stripeOffset(i),
         .size = stripeSize,

--- a/dwio/nimble/tablet/Footer.fbs
+++ b/dwio/nimble/tablet/Footer.fbs
@@ -30,10 +30,34 @@ table Stripes {
   group_indices:[uint32];
 }
 
+/// Raw (default) StripeGroup: flattened stripeCount x streamCount arrays
+/// (stripe-major) of per-stream byte offsets (relative to the owning stripe's
+/// start) and byte sizes. The original, universally-readable layout; short
+/// stripes are padded to streamCount with 0. Field slots 0..2 are FROZEN for
+/// backward compatibility with pre-existing files.
 table StripeGroup {
   stripe_count:uint32;
   stream_offsets:[uint32];
   stream_sizes:[uint32];
+}
+
+/// One independently encoded array. Wraps the raw encoded bytes in a sub-table
+/// so flatbuffers can express a vector of them (`[EncodedStream]`); it cannot
+/// express a bare vector-of-vectors (`[[ubyte]]`).
+table EncodedStream {
+  data:[ubyte];
+}
+
+/// kStreamMajor: one Nimble-encoded uint32 array per leaf stream, each of length
+/// stripe_count holding that stream's offsets / sizes across every stripe in the
+/// group. Per-stream bit width is tight to that stream's value range.
+table StreamMajorStripeGroup {
+  stripe_count:uint32;
+  /// Total number of leaf streams in the group (length of stream_offsets /
+  /// stream_sizes), not a per-stripe count.
+  stream_count:uint32;
+  stream_offsets:[EncodedStream];
+  stream_sizes:[EncodedStream];
 }
 
 table MetadataSection {

--- a/dwio/nimble/tablet/StripeGroup.cpp
+++ b/dwio/nimble/tablet/StripeGroup.cpp
@@ -1,0 +1,284 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "dwio/nimble/tablet/StripeGroup.h"
+
+#include <algorithm>
+
+#include "dwio/nimble/common/Exceptions.h"
+#include "dwio/nimble/encodings/views/EncodingViewFactory.h"
+#include "dwio/nimble/tablet/FooterGenerated.h"
+
+#include "flatbuffers/flatbuffers.h"
+
+namespace facebook::nimble {
+
+namespace {
+
+template <typename T>
+const T* asFlatBuffersRoot(std::string_view content) {
+  return flatbuffers::GetRoot<T>(content.data());
+}
+
+const serialization::Stripes* stripesRoot(const MetadataBuffer& stripes) {
+  return asFlatBuffersRoot<serialization::Stripes>(stripes.content());
+}
+
+// Detects the StripeGroup encoding layout from the blob's FlatBuffers file
+// identifier. Each non-kRaw layout carries its own identifier; kRaw blobs are
+// bare, so an absent/unknown identifier (including pre-existing files) is kRaw.
+StripeGroup::EncodingLayout stripeGroupEncodingLayout(
+    std::string_view content) {
+  if (flatbuffers::BufferHasIdentifier(
+          content.data(), StripeGroup::kStreamMajorLayoutIdentifier.data())) {
+    return StripeGroup::EncodingLayout::kStreamMajor;
+  }
+  return StripeGroup::EncodingLayout::kRaw;
+}
+
+// Creates a random-access view over one encoded uint32 array and validates its
+// length against `expectedRowCount` (the number of values the array must hold —
+// stripeCount for a per-stream array).
+std::unique_ptr<EncodingView> makeStripeGroupView(
+    const flatbuffers::Vector<uint8_t>* fbVec,
+    uint32_t expectedRowCount,
+    velox::memory::MemoryPool* pool) {
+  NIMBLE_CHECK_NOT_NULL(fbVec, "Missing encoded payload in stripe group.");
+  const std::string_view encoded(
+      reinterpret_cast<const char*>(fbVec->data()), fbVec->size());
+  auto view = createEncodingView(encoded, pool);
+  NIMBLE_CHECK_EQ(
+      view->rowCount(),
+      expectedRowCount,
+      "Encoded stripe-group row count mismatch.");
+  return view;
+}
+
+} // namespace
+
+StripeGroup::StripeGroup(
+    uint32_t stripeGroupIndex,
+    const MetadataBuffer& stripes,
+    std::unique_ptr<MetadataBuffer> stripeGroup,
+    velox::memory::MemoryPool* pool)
+    : metadata_{std::move(stripeGroup)},
+      index_{stripeGroupIndex},
+      // The blob self-identifies its layout via a FlatBuffers file identifier;
+      // a kRaw blob carries none (see stripeGroupEncodingLayout).
+      encodingLayout_{stripeGroupEncodingLayout(metadata_->content())} {
+  NIMBLE_CHECK_NOT_NULL(pool);
+
+  // The group's first stripe is the first stripe assigned to this group in the
+  // tablet's per-stripe group_indices.
+  const auto* groupIndices = stripesRoot(stripes)->group_indices();
+  NIMBLE_CHECK_NOT_NULL(groupIndices, "Missing group_indices in stripes.");
+  firstStripe_ = 0;
+  bool found = false;
+  for (uint32_t stripe = 0; stripe < groupIndices->size(); ++stripe) {
+    if (groupIndices->Get(stripe) == stripeGroupIndex) {
+      firstStripe_ = stripe;
+      found = true;
+      break;
+    }
+  }
+  NIMBLE_CHECK(found, "No stripes found for stripe group.");
+
+  switch (encodingLayout_) {
+    case EncodingLayout::kRaw: {
+      const auto* root =
+          asFlatBuffersRoot<serialization::StripeGroup>(metadata_->content());
+      stripeCount_ = root->stripe_count();
+      NIMBLE_CHECK_GT(stripeCount_, 0, "Unexpected stripe count");
+      // Flattened stripe-major arrays. streamCount is derived from the array
+      // length; an all-null group (e.g. every selected column null) has
+      // zero-length arrays and streamCount 0.
+      const auto* offsets = root->stream_offsets();
+      const auto* sizes = root->stream_sizes();
+      const auto offsetsLen = offsets != nullptr ? offsets->size() : 0;
+      const auto sizesLen = sizes != nullptr ? sizes->size() : 0;
+      NIMBLE_CHECK_EQ(
+          offsetsLen, sizesLen, "stream_offsets/stream_sizes length mismatch.");
+      if (offsetsLen == 0) {
+        streamCount_ = 0;
+        return;
+      }
+      NIMBLE_CHECK_EQ(
+          offsetsLen % stripeCount_,
+          0,
+          "stream_offsets length must be a multiple of stripe_count.");
+      streamCount_ = offsetsLen / stripeCount_;
+      raw_.offsets = offsets->data();
+      raw_.sizes = sizes->data();
+      return;
+    }
+
+    case EncodingLayout::kStreamMajor: {
+      const auto* root =
+          asFlatBuffersRoot<serialization::StreamMajorStripeGroup>(
+              metadata_->content());
+      stripeCount_ = root->stripe_count();
+      NIMBLE_CHECK_GT(stripeCount_, 0, "Unexpected stripe count");
+      streamCount_ = root->stream_count();
+      // streamCount_ may legitimately be 0 (every column all-null); leave the
+      // encoding lists empty.
+      if (streamCount_ == 0) {
+        return;
+      }
+      const auto* offsetsVec = root->stream_offsets();
+      const auto* sizesVec = root->stream_sizes();
+      NIMBLE_CHECK_NOT_NULL(
+          offsetsVec, "Missing stream_offsets in StreamMajorStripeGroup.");
+      NIMBLE_CHECK_NOT_NULL(
+          sizesVec, "Missing stream_sizes in StreamMajorStripeGroup.");
+      NIMBLE_CHECK_EQ(
+          offsetsVec->size(),
+          streamCount_,
+          "stream_offsets length must equal stream_count.");
+      NIMBLE_CHECK_EQ(
+          sizesVec->size(),
+          streamCount_,
+          "stream_sizes length must equal stream_count.");
+      streamMajor_.offsets.reserve(streamCount_);
+      streamMajor_.sizes.reserve(streamCount_);
+      for (uint32_t i = 0; i < streamCount_; ++i) {
+        const auto* offsetsEntry = offsetsVec->Get(i);
+        const auto* sizesEntry = sizesVec->Get(i);
+        NIMBLE_CHECK_NOT_NULL(
+            offsetsEntry,
+            "Null stream_offsets entry in StreamMajorStripeGroup.");
+        NIMBLE_CHECK_NOT_NULL(
+            sizesEntry, "Null stream_sizes entry in StreamMajorStripeGroup.");
+        streamMajor_.offsets.emplace_back(
+            makeStripeGroupView(offsetsEntry->data(), stripeCount_, pool));
+        streamMajor_.sizes.emplace_back(
+            makeStripeGroupView(sizesEntry->data(), stripeCount_, pool));
+      }
+      return;
+    }
+  }
+  NIMBLE_UNREACHABLE(
+      fmt::format("Unknown StripeGroup encoding layout: {}", encodingLayout_));
+}
+
+StripeGroup::~StripeGroup() = default;
+
+uint32_t StripeGroup::stripeOffset(uint32_t stripeIndex) const {
+  NIMBLE_DCHECK_GE(
+      stripeIndex, firstStripe_, "stripeIndex precedes this stripe group.");
+  const uint32_t localIndex = stripeIndex - firstStripe_;
+  NIMBLE_DCHECK_LT(
+      localIndex, stripeCount_, "stripeIndex is beyond this stripe group.");
+  return localIndex;
+}
+
+uint32_t StripeGroup::streamOffset(uint32_t stripeIndex, uint32_t streamId)
+    const {
+  NIMBLE_CHECK_LT(streamId, streamCount_, "streamId is out of range.");
+  const auto stripeOffset = this->stripeOffset(stripeIndex);
+  switch (encodingLayout_) {
+    case EncodingLayout::kRaw:
+      return raw_
+          .offsets[static_cast<size_t>(stripeOffset) * streamCount_ + streamId];
+    case EncodingLayout::kStreamMajor: {
+      uint32_t offset;
+      streamMajor_.offsets[streamId]->readAt(stripeOffset, &offset);
+      return offset;
+    }
+  }
+  NIMBLE_UNREACHABLE(
+      fmt::format("Unknown StripeGroup encoding layout: {}", encodingLayout_));
+}
+
+uint32_t StripeGroup::streamSize(uint32_t stripeIndex, uint32_t streamId)
+    const {
+  NIMBLE_CHECK_LT(streamId, streamCount_, "streamId is out of range.");
+  const auto stripeOffset = this->stripeOffset(stripeIndex);
+  switch (encodingLayout_) {
+    case EncodingLayout::kRaw:
+      return raw_
+          .sizes[static_cast<size_t>(stripeOffset) * streamCount_ + streamId];
+    case EncodingLayout::kStreamMajor: {
+      uint32_t size;
+      streamMajor_.sizes[streamId]->readAt(stripeOffset, &size);
+      return size;
+    }
+  }
+  NIMBLE_UNREACHABLE(
+      fmt::format("Unknown StripeGroup encoding layout: {}", encodingLayout_));
+}
+
+void StripeGroup::streamOffsets(uint32_t stripeIndex, std::span<uint32_t> out)
+    const {
+  NIMBLE_CHECK_EQ(
+      out.size(), streamCount_, "output size must equal streamCount.");
+  const uint32_t stripeOffset = this->stripeOffset(stripeIndex);
+  switch (encodingLayout_) {
+    case EncodingLayout::kRaw: {
+      const auto* base =
+          raw_.offsets + static_cast<size_t>(stripeOffset) * streamCount_;
+      std::copy(base, base + streamCount_, out.begin());
+      return;
+    }
+    case EncodingLayout::kStreamMajor:
+      // TODO: add a range-read API to EncodingView and decode the stripe's full
+      // offsets array in one call instead of per-stream readAt.
+      for (uint32_t i = 0; i < streamCount_; ++i) {
+        streamMajor_.offsets[i]->readAt(stripeOffset, &out[i]);
+      }
+      return;
+  }
+  NIMBLE_UNREACHABLE(
+      fmt::format("Unknown StripeGroup encoding layout: {}", encodingLayout_));
+}
+
+void StripeGroup::streamSizes(uint32_t stripeIndex, std::span<uint32_t> out)
+    const {
+  NIMBLE_CHECK_EQ(
+      out.size(), streamCount_, "output size must equal streamCount.");
+  const uint32_t stripeOffset = this->stripeOffset(stripeIndex);
+  switch (encodingLayout_) {
+    case EncodingLayout::kRaw: {
+      const auto* base =
+          raw_.sizes + static_cast<size_t>(stripeOffset) * streamCount_;
+      std::copy(base, base + streamCount_, out.begin());
+      return;
+    }
+    case EncodingLayout::kStreamMajor:
+      // TODO: add a range-read API to EncodingView and decode the stripe's full
+      // sizes array in one call instead of per-stream readAt.
+      for (uint32_t i = 0; i < streamCount_; ++i) {
+        streamMajor_.sizes[i]->readAt(stripeOffset, &out[i]);
+      }
+      return;
+  }
+  NIMBLE_UNREACHABLE(
+      fmt::format("Unknown StripeGroup encoding layout: {}", encodingLayout_));
+}
+
+std::string_view toString(StripeGroup::EncodingLayout layout) {
+  switch (layout) {
+    case StripeGroup::EncodingLayout::kRaw:
+      return "kRaw";
+    case StripeGroup::EncodingLayout::kStreamMajor:
+      return "kStreamMajor";
+  }
+  return "Unknown";
+}
+
+std::ostream& operator<<(std::ostream& os, StripeGroup::EncodingLayout layout) {
+  return os << toString(layout);
+}
+
+} // namespace facebook::nimble

--- a/dwio/nimble/tablet/StripeGroup.h
+++ b/dwio/nimble/tablet/StripeGroup.h
@@ -1,0 +1,181 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <array>
+#include <cstdint>
+#include <memory>
+#include <ostream>
+#include <span>
+#include <string_view>
+#include <vector>
+
+#include <fmt/format.h>
+
+#include "dwio/nimble/encodings/views/EncodingView.h"
+#include "dwio/nimble/tablet/MetadataBuffer.h"
+#include "velox/common/memory/MemoryPool.h"
+
+namespace facebook::nimble {
+
+/// Reads a single stripe group's per-stream metadata: the byte offset and size
+/// of every stream within each stripe of the group. The metadata's on-disk
+/// layout is one of EncodingLayout, self-identified by the blob's FlatBuffers
+/// file identifier.
+class StripeGroup {
+ public:
+  /// Selects how a stripe group's per-stream offsets/sizes are serialized (see
+  /// Footer.fbs). kRaw is the default, universally-readable layout;
+  /// kStreamMajor (per-stream encoded) is experimental. Each non-kRaw blob
+  /// self-identifies via a FlatBuffers file identifier, so no separate on-disk
+  /// flag is needed; a kRaw blob carries no identifier, hence an unrecognized
+  /// one decodes as kRaw and pre-existing files keep reading as kRaw. The
+  /// values are a frozen on-disk contract (encoded in the identifier):
+  /// append-only, never renumber/reorder.
+  enum class EncodingLayout : uint8_t {
+    kRaw = 0,
+    kStreamMajor = 1,
+  };
+
+  /// Composes an EncodingLayout's 4-byte FlatBuffers file identifier from a
+  /// fixed "SGL" (Stripe Group Layout) prefix + the EncodingLayout value as an
+  /// ASCII digit. Returns a null-terminated 5-char array so the same storage
+  /// serves both FlatBufferBuilder::Finish (which strlen's the id and requires
+  /// exactly 4 bytes) and flatbuffers::BufferHasIdentifier (see stripeGroup's
+  /// layout detection). The digit is derived from the enum, so the enum values
+  /// are a frozen on-disk contract: append-only, never renumber/reorder.
+  static constexpr std::array<char, 5> makeLayoutIdentifier(
+      EncodingLayout layout) {
+    return {
+        'S', 'G', 'L', static_cast<char>('0' + static_cast<int>(layout)), '\0'};
+  }
+
+  /// kStreamMajor blob identifier ("SGL1"). kRaw blobs are written bare, so an
+  /// absent or unrecognized identifier (including pre-existing files) decodes
+  /// as kRaw. Spelled out here (rather than makeLayoutIdentifier(kStreamMajor))
+  /// because a static constexpr member cannot be initialized by a same-class
+  /// static method; the static_assert below keeps the two in sync.
+  static constexpr std::array<char, 5> kStreamMajorLayoutIdentifier{
+      'S',
+      'G',
+      'L',
+      static_cast<char>('0' + static_cast<int>(EncodingLayout::kStreamMajor)),
+      '\0'};
+
+  StripeGroup(
+      uint32_t stripeGroupIndex,
+      const MetadataBuffer& stripes,
+      std::unique_ptr<MetadataBuffer> metadata,
+      velox::memory::MemoryPool* pool);
+
+  ~StripeGroup();
+
+  uint32_t index() const {
+    return index_;
+  }
+
+  uint32_t streamCount() const {
+    return streamCount_;
+  }
+
+  uint32_t firstStripe() const {
+    return firstStripe_;
+  }
+
+  uint32_t stripeCount() const {
+    return stripeCount_;
+  }
+
+  /// O(1) random-access read of the byte offset of `streamId` within
+  /// `stripeIndex` (relative to the stripe's start). Backed by the per-stream
+  /// EncodingView for `streamId` — stateless and safe to call concurrently.
+  /// `streamId` must be less than streamCount().
+  uint32_t streamOffset(uint32_t stripeIndex, uint32_t streamId) const;
+
+  /// O(1) random-access read of the byte length of `streamId` within
+  /// `stripeIndex`. Stateless. `streamId` must be less than streamCount().
+  uint32_t streamSize(uint32_t stripeIndex, uint32_t streamId) const;
+
+  /// Bulk decode of all `streamCount` byte offsets for `stripeIndex` into the
+  /// caller-provided output buffer. `out.size()` must equal `streamCount`.
+  /// Intended for callers that scan the whole array (file-layout dump tools).
+  void streamOffsets(uint32_t stripeIndex, std::span<uint32_t> out) const;
+
+  /// Bulk decode of all `streamCount` byte sizes for `stripeIndex`.
+  void streamSizes(uint32_t stripeIndex, std::span<uint32_t> out) const;
+
+ private:
+  // Maps an absolute stripe index to this group's local [0, stripeCount_)
+  // index. Debug-checks that the stripe belongs to this group.
+  uint32_t stripeOffset(uint32_t stripeIndex) const;
+
+  // kRaw: raw pointers into the flatbuffer blob, laid out stripe-major
+  // (stripeCount x streamCount). The blob is owned by metadata_ and outlives
+  // the StripeGroup.
+  struct RawMetadata {
+    const uint32_t* offsets{nullptr};
+    const uint32_t* sizes{nullptr};
+  };
+
+  // kStreamMajor: streamCount entries, one EncodingView per leaf stream, each
+  // over that stream's stripeCount-length array.
+  struct StreamMajorMetadata {
+    std::vector<std::unique_ptr<EncodingView>> offsets;
+    std::vector<std::unique_ptr<EncodingView>> sizes;
+  };
+
+  const std::unique_ptr<MetadataBuffer> metadata_;
+  const uint32_t index_;
+  // How this group's per-stream offsets/sizes are laid out; detected once at
+  // construction from the blob's FlatBuffers file identifier. Determines which
+  // metadata member below is populated. All encoded forms are written
+  // uncompressed (which EncodingView requires); every EncodingView-supported
+  // encoding provides a stateless O(1) const readAt, so point access needs no
+  // auxiliary state and is safe for concurrent reads.
+  const EncodingLayout encodingLayout_;
+  uint32_t streamCount_{0};
+  uint32_t stripeCount_{0};
+  uint32_t firstStripe_{0};
+  RawMetadata raw_;
+  StreamMajorMetadata streamMajor_;
+};
+
+static_assert(
+    StripeGroup::kStreamMajorLayoutIdentifier ==
+        StripeGroup::makeLayoutIdentifier(
+            StripeGroup::EncodingLayout::kStreamMajor),
+    "kStreamMajorLayoutIdentifier must match makeLayoutIdentifier(kStreamMajor).");
+static_assert(
+    static_cast<int>(StripeGroup::EncodingLayout::kStreamMajor) == 1,
+    "On-disk identifier contract: kStreamMajor must stay 1.");
+
+/// Returns the enumerator name (e.g. "kStreamMajor") for logging/formatting.
+std::string_view toString(StripeGroup::EncodingLayout layout);
+
+std::ostream& operator<<(std::ostream& os, StripeGroup::EncodingLayout layout);
+
+} // namespace facebook::nimble
+
+template <>
+struct fmt::formatter<facebook::nimble::StripeGroup::EncodingLayout>
+    : fmt::formatter<std::string_view> {
+  auto format(
+      facebook::nimble::StripeGroup::EncodingLayout layout,
+      format_context& ctx) const {
+    return fmt::formatter<std::string_view>::format(
+        facebook::nimble::toString(layout), ctx);
+  }
+};

--- a/dwio/nimble/tablet/TabletReader.cpp
+++ b/dwio/nimble/tablet/TabletReader.cpp
@@ -23,8 +23,10 @@
 #include "dwio/nimble/tablet/Constants.h"
 #include "dwio/nimble/tablet/FooterGenerated.h"
 #include "dwio/nimble/tablet/IndexGenerated.h"
+#include "dwio/nimble/tablet/StripeGroup.h"
 #include "velox/dwio/common/SeekableInputStream.h"
 
+#include "flatbuffers/flatbuffers.h"
 #include "folly/io/Cursor.h"
 
 #include <algorithm>
@@ -174,51 +176,6 @@ size_t copyTo(const folly::IOBuf& source, void* target, size_t size) {
 }
 
 } // namespace
-
-StripeGroup::StripeGroup(
-    uint32_t stripeGroupIndex,
-    const MetadataBuffer& stripes,
-    std::unique_ptr<MetadataBuffer> stripeGroup)
-    : metadata_{std::move(stripeGroup)}, index_{stripeGroupIndex} {
-  const auto* metadataRoot =
-      asFlatBuffersRoot<serialization::StripeGroup>(metadata_->content());
-  const auto* stripesParsed = stripesRoot(stripes);
-
-  const auto streamCount = metadataRoot->stream_offsets()->size();
-  NIMBLE_CHECK_EQ(
-      streamCount,
-      metadataRoot->stream_sizes()->size(),
-      "Unexpected stream metadata");
-
-  stripeCount_ = metadataRoot->stripe_count();
-  NIMBLE_CHECK_GT(stripeCount_, 0, "Unexpected stripe count");
-  streamCount_ = streamCount / stripeCount_;
-
-  streamOffsets_ = metadataRoot->stream_offsets()->data();
-  streamSizes_ = metadataRoot->stream_sizes()->data();
-
-  // Find the first stripe that use this stripe group
-  auto* groupIndices = stripesParsed->group_indices()->data();
-  for (uint32_t stripeIndex = 0,
-                groupIndicesSize = stripesParsed->group_indices()->size();
-       stripeIndex < groupIndicesSize;
-       ++stripeIndex) {
-    if (groupIndices[stripeIndex] == stripeGroupIndex) {
-      firstStripe_ = stripeIndex;
-      return;
-    }
-  }
-  NIMBLE_UNREACHABLE("No stripe found for stripe group");
-}
-
-std::span<const uint32_t> StripeGroup::streamOffsets(uint32_t stripe) const {
-  return {
-      streamOffsets_ + (stripe - firstStripe_) * streamCount_, streamCount_};
-}
-
-std::span<const uint32_t> StripeGroup::streamSizes(uint32_t stripe) const {
-  return {streamSizes_ + (stripe - firstStripe_) * streamCount_, streamCount_};
-}
 
 TabletReader::TabletReader(
     std::shared_ptr<velox::ReadFile> readFile,
@@ -686,7 +643,7 @@ void TabletReader::initStripes(
       stripeGroupCache_.pin(
           0,
           std::make_shared<StripeGroup>(
-              0, *stripes_, std::move(metadataBuffer)));
+              0, *stripes_, std::move(metadataBuffer), pool_));
     }
   }
 }
@@ -843,7 +800,7 @@ std::shared_ptr<StripeGroup> TabletReader::loadStripeGroup(
 
   const auto section = toMetadataSection(stripeGroupInfo);
   return std::make_shared<StripeGroup>(
-      stripeGroupIndex, *stripes_, readMetadata(section));
+      stripeGroupIndex, *stripes_, readMetadata(section), pool_);
 }
 
 std::shared_ptr<StripeGroup> TabletReader::stripeGroup(
@@ -871,7 +828,7 @@ TabletReader::StripeGroupMetadata TabletReader::loadStripeGroupMetadata(
 
   StripeGroupMetadata result;
   result.stripeGroup = std::make_shared<StripeGroup>(
-      stripeGroupIndex, *stripes_, std::move(groupMetadata));
+      stripeGroupIndex, *stripes_, std::move(groupMetadata), pool_);
   if (hasChunkIndex) {
     auto chunkIndexMetadata =
         std::make_unique<MetadataBuffer>(std::move(*results[1]));
@@ -883,23 +840,34 @@ TabletReader::StripeGroupMetadata TabletReader::loadStripeGroupMetadata(
   return result;
 }
 
-std::span<const uint32_t> TabletReader::streamOffsets(
-    const StripeIdentifier& stripe) const {
+uint32_t TabletReader::streamOffset(
+    const StripeIdentifier& stripe,
+    uint32_t streamId) const {
   NIMBLE_DCHECK_LT(stripe.stripeId(), stripeCount_, "Stripe is out of range.");
-  return stripe.stripeGroup()->streamOffsets(stripe.stripeId());
-}
-
-std::span<const uint32_t> TabletReader::streamSizes(
-    const StripeIdentifier& stripe) const {
-  NIMBLE_DCHECK_LT(stripe.stripeId(), stripeCount_, "Stripe is out of range.");
-  return stripe.stripeGroup()->streamSizes(stripe.stripeId());
+  return stripe.stripeGroup()->streamOffset(stripe.stripeId(), streamId);
 }
 
 uint32_t TabletReader::streamSize(
     const StripeIdentifier& stripe,
     uint32_t streamId) const {
-  const auto sizes = streamSizes(stripe);
-  return streamId < sizes.size() ? sizes[streamId] : 0;
+  NIMBLE_DCHECK_LT(stripe.stripeId(), stripeCount_, "Stripe is out of range.");
+  // Mirrors streamOffset: StripeGroup::streamSize already returns 0 for an
+  // out-of-range streamId, so delegate without a redundant guard here.
+  return stripe.stripeGroup()->streamSize(stripe.stripeId(), streamId);
+}
+
+void TabletReader::streamOffsets(
+    const StripeIdentifier& stripe,
+    std::span<uint32_t> out) const {
+  NIMBLE_DCHECK_LT(stripe.stripeId(), stripeCount_, "Stripe is out of range.");
+  stripe.stripeGroup()->streamOffsets(stripe.stripeId(), out);
+}
+
+void TabletReader::streamSizes(
+    const StripeIdentifier& stripe,
+    std::span<uint32_t> out) const {
+  NIMBLE_DCHECK_LT(stripe.stripeId(), stripeCount_, "Stripe is out of range.");
+  stripe.stripeGroup()->streamSizes(stripe.stripeId(), out);
 }
 
 uint32_t TabletReader::streamCount(const StripeIdentifier& stripe) const {
@@ -957,9 +925,7 @@ std::vector<std::unique_ptr<StreamLoader>> TabletReader::load(
 
   const uint64_t stripeOffset = this->stripeOffset(stripe.stripeId());
   const auto& stripeGroup = stripe.stripeGroup();
-  const auto stripeStreamOffsets =
-      stripeGroup->streamOffsets(stripe.stripeId());
-  const auto stripeStreamSizes = stripeGroup->streamSizes(stripe.stripeId());
+  const uint32_t stripeId = stripe.stripeId();
   const uint32_t streamsToLoad = streamIdentifiers.size();
 
   std::vector<std::unique_ptr<StreamLoader>> streams(streamsToLoad);
@@ -980,14 +946,15 @@ std::vector<std::unique_ptr<StreamLoader>> TabletReader::load(
       continue;
     }
 
-    const uint32_t streamSize = stripeStreamSizes[streamIdentifier];
+    const uint32_t streamSize =
+        stripeGroup->streamSize(stripeId, streamIdentifier);
     if (streamSize == 0) {
       streams[i] = nullptr;
       continue;
     }
 
     const auto streamStart =
-        stripeOffset + stripeStreamOffsets[streamIdentifier];
+        stripeOffset + stripeGroup->streamOffset(stripeId, streamIdentifier);
 
     auto it = regionToStreamIndices.emplace(
         velox::common::Region{streamStart, streamSize},
@@ -1024,14 +991,13 @@ uint64_t TabletReader::totalStreamSize(
     std::span<const uint32_t> streamIdentifiers) const {
   NIMBLE_CHECK_LT(stripe.stripeId(), stripeCount_, "Stripe is out of range.");
   const auto& stripeGroup = stripe.stripeGroup();
-
+  const uint32_t stripeId = stripe.stripeId();
   uint64_t streamSizeSum{0};
-  const auto stripeStreamSizes = stripeGroup->streamSizes(stripe.stripeId());
   for (const auto streamId : streamIdentifiers) {
     if (streamId >= stripeGroup->streamCount()) {
       continue;
     }
-    streamSizeSum += stripeStreamSizes[streamId];
+    streamSizeSum += stripeGroup->streamSize(stripeId, streamId);
   }
   return streamSizeSum;
 }

--- a/dwio/nimble/tablet/TabletReader.h
+++ b/dwio/nimble/tablet/TabletReader.h
@@ -21,7 +21,9 @@
 #include <span>
 #include <vector>
 
+#include "dwio/nimble/common/Types.h"
 #include "dwio/nimble/common/Vector.h"
+#include "dwio/nimble/encodings/views/EncodingView.h"
 #include "dwio/nimble/index/ChunkIndex.h"
 #include "dwio/nimble/index/ChunkIndexGroup.h"
 #include "dwio/nimble/index/ClusterIndex.h"
@@ -33,6 +35,7 @@
 #include "dwio/nimble/tablet/MetadataBuffer.h"
 #include "dwio/nimble/tablet/MetadataCache.h"
 #include "dwio/nimble/tablet/MetadataInput.h"
+#include "dwio/nimble/tablet/StripeGroup.h"
 #include "folly/Synchronized.h"
 #include "velox/common/caching/FileHandle.h"
 #include "velox/common/file/File.h"
@@ -69,42 +72,6 @@ class StreamLoader {
  public:
   virtual ~StreamLoader() = default;
   virtual const std::string_view getStream() const = 0;
-};
-
-class StripeGroup {
- public:
-  StripeGroup(
-      uint32_t stripeGroupIndex,
-      const MetadataBuffer& stripes,
-      std::unique_ptr<MetadataBuffer> metadata);
-
-  uint32_t index() const {
-    return index_;
-  }
-
-  uint32_t streamCount() const {
-    return streamCount_;
-  }
-
-  uint32_t firstStripe() const {
-    return firstStripe_;
-  }
-
-  uint32_t stripeCount() const {
-    return stripeCount_;
-  }
-
-  std::span<const uint32_t> streamOffsets(uint32_t stripe) const;
-  std::span<const uint32_t> streamSizes(uint32_t stripe) const;
-
- private:
-  const std::unique_ptr<MetadataBuffer> metadata_;
-  const uint32_t index_;
-  uint32_t streamCount_;
-  uint32_t stripeCount_;
-  uint32_t firstStripe_;
-  const uint32_t* streamOffsets_;
-  const uint32_t* streamSizes_;
 };
 
 using index::ChunkIndex;
@@ -374,21 +341,29 @@ class TabletReader {
     return stripeOffsets_[stripe];
   }
 
-  /// Returns stream offsets for the specified stripe. Number of streams is
-  /// determined by schema node count at the time when stripe is written, so
-  /// it may have fewer number of items than the final schema node count
-  std::span<const uint32_t> streamOffsets(const StripeIdentifier& stripe) const;
+  /// Returns the byte offset of `streamId` within `stripe` (relative to the
+  /// stripe's start). O(1) point read into the per-stream FBW-encoded blob
+  /// held by the StripeGroup. Callers must ensure
+  /// `streamId < streamCount(stripe)`.
+  uint32_t streamOffset(const StripeIdentifier& stripe, uint32_t streamId)
+      const;
 
-  /// Returns stream sizes for the specified stripe. Has same constraint as
-  /// `streamOffsets()`.
-  std::span<const uint32_t> streamSizes(const StripeIdentifier& stripe) const;
-
-  /// Returns the byte size of a single stream in the specified stripe.
-  /// Returns 0 if the stream does not exist in this stripe.
+  /// Returns the byte size of `streamId` within `stripe`. Returns 0 if the
+  /// stream does not exist in this stripe. O(1) point read.
   uint32_t streamSize(const StripeIdentifier& stripe, uint32_t streamId) const;
 
-  /// Returns stream count for the specified stripe. Has same constraint as
-  /// `streamOffsets()`.
+  /// Bulk decode of all `streamCount(stripe)` byte offsets for `stripe` into
+  /// the caller-provided buffer. Intended for cold-path callers (file layout
+  /// dump tools) that need to scan every stream.
+  void streamOffsets(const StripeIdentifier& stripe, std::span<uint32_t> out)
+      const;
+
+  /// Bulk decode of all `streamCount(stripe)` byte sizes for `stripe`.
+  void streamSizes(const StripeIdentifier& stripe, std::span<uint32_t> out)
+      const;
+
+  /// Returns the schema's leaf-stream count at the time `stripe`'s stripe
+  /// group was written. May be less than the final schema's node count.
   uint32_t streamCount(const StripeIdentifier& stripe) const;
 
   StripeIdentifier stripeIdentifier(uint32_t stripeIndex) const;

--- a/dwio/nimble/tablet/TabletWriter.cpp
+++ b/dwio/nimble/tablet/TabletWriter.cpp
@@ -16,9 +16,13 @@
 
 #include "dwio/nimble/tablet/TabletWriter.h"
 
+#include "dwio/nimble/common/Buffer.h"
+#include "dwio/nimble/encodings/common/EncodingFactory.h"
+#include "dwio/nimble/encodings/selection/EncodingSelectionPolicy.h"
 #include "dwio/nimble/tablet/Compression.h"
 #include "dwio/nimble/tablet/Constants.h"
 #include "dwio/nimble/tablet/FileLayout.h"
+#include "dwio/nimble/tablet/StripeGroup.h"
 
 namespace facebook::nimble {
 
@@ -497,16 +501,130 @@ bool TabletWriter::shouldWriteStripeGroup(bool force) const {
   return true;
 }
 
-void TabletWriter::writeStripeGroup(size_t streamCount, size_t stripeCount) {
-  flatbuffers::FlatBufferBuilder builder(kInitialFooterSize);
+namespace {
+// Build an encoding policy restricted to the given read factors. Read factors
+// must list only encodings with O(1) stateless point access (the EncodingView
+// requirement); the selector picks the smallest predicted size among them,
+// biased by each candidate's read weight. When `readFactors` is empty the
+// writer falls back to `kDefaultReadFactors` below.
+template <typename T>
+std::unique_ptr<EncodingSelectionPolicy<T>> makeMetadataEncodingPolicy(
+    const std::vector<std::pair<EncodingType, float>>& readFactors) {
+  static const std::vector<std::pair<EncodingType, float>> kDefaultReadFactors{
+      {EncodingType::Constant, 1.0},
+      {EncodingType::Trivial, 1.0},
+      {EncodingType::FixedBitWidth, 1.0},
+  };
+  ManualEncodingSelectionPolicyFactory factory{
+      readFactors.empty() ? kDefaultReadFactors : readFactors,
+      /*compressionOptions=*/std::nullopt};
+  auto base = factory.createPolicy(TypeTraits<T>::dataType);
+  return std::unique_ptr<EncodingSelectionPolicy<T>>(
+      static_cast<EncodingSelectionPolicy<T>*>(base.release()));
+}
+
+// Transposes the per-stripe vectors `source` into a single per-stream vector
+// of length `stripeCount`, gathering `source[stripe][streamId]` for one fixed
+// streamId across every stripe. Stripes whose recorded streamCount is less
+// than `streamId + 1` contribute 0 (the writer's default for absent streams).
+std::vector<uint32_t> transposeStreamMetadata(
+    uint32_t streamId,
+    size_t stripeCount,
+    const std::vector<std::vector<uint32_t>>& source) {
+  std::vector<uint32_t> streamValues(stripeCount, 0);
+  for (size_t stripe = 0; stripe < stripeCount; ++stripe) {
+    if (streamId < source[stripe].size()) {
+      streamValues[stripe] = source[stripe][streamId];
+    }
+  }
+  return streamValues;
+}
+} // namespace
+
+void TabletWriter::writeStripeGroupWithRawLayout(
+    flatbuffers::FlatBufferBuilder& builder,
+    size_t streamCount,
+    size_t stripeCount) {
+  // Flattened stripe-major arrays — the original wire layout every reader
+  // understands. Short stripes are padded to streamCount with 0; the reader
+  // derives streamCount from the array length.
   auto streamOffsets = createFlattenedVector<uint32_t, uint32_t>(
       builder, streamCount, streamOffsets_, 0);
   auto streamSizes = createFlattenedVector<uint32_t, uint32_t>(
       builder, streamCount, streamSizes_, 0);
-
   builder.Finish(
       serialization::CreateStripeGroup(
-          builder, stripeCount, streamOffsets, streamSizes));
+          builder,
+          static_cast<uint32_t>(stripeCount),
+          streamOffsets,
+          streamSizes));
+}
+
+void TabletWriter::writeStripeGroupWithStreamMajorLayout(
+    flatbuffers::FlatBufferBuilder& builder,
+    size_t streamCount,
+    size_t stripeCount) {
+  // For each leaf streamId, gather that stream's values across every stripe and
+  // encode the resulting stripeCount-length array independently. The per-stream
+  // bit width is tight to that stream's value range.
+  std::vector<flatbuffers::Offset<serialization::EncodedStream>> encodedOffsets;
+  std::vector<flatbuffers::Offset<serialization::EncodedStream>> encodedSizes;
+  encodedOffsets.reserve(streamCount);
+  encodedSizes.reserve(streamCount);
+
+  // Encodes one array, copies it into the flatbuffer, then rewinds the scratch
+  // buffer so peak memory stays bounded to a single stream.
+  Buffer encodingBuffer{*pool_};
+  auto encodeStream = [&](const std::vector<uint32_t>& values) {
+    const auto encoded = EncodingFactory::encode<uint32_t>(
+        makeMetadataEncodingPolicy<uint32_t>(
+            options_.stripeGroupEncodingLayoutReadFactors),
+        std::span<const uint32_t>(values),
+        encodingBuffer);
+    auto encodedStream = serialization::CreateEncodedStream(
+        builder,
+        builder.CreateVector(
+            reinterpret_cast<const uint8_t*>(encoded.data()), encoded.size()));
+    encodingBuffer.reset();
+    return encodedStream;
+  };
+
+  for (uint32_t streamId = 0; streamId < streamCount; ++streamId) {
+    encodedOffsets.push_back(encodeStream(
+        transposeStreamMetadata(streamId, stripeCount, streamOffsets_)));
+    encodedSizes.push_back(encodeStream(
+        transposeStreamMetadata(streamId, stripeCount, streamSizes_)));
+  }
+
+  // Tag the blob with the kStreamMajor file identifier so the reader detects
+  // the layout from the buffer itself (kRaw blobs are written bare).
+  builder.Finish(
+      serialization::CreateStreamMajorStripeGroup(
+          builder,
+          static_cast<uint32_t>(stripeCount),
+          static_cast<uint32_t>(streamCount),
+          builder.CreateVector(encodedOffsets),
+          builder.CreateVector(encodedSizes)),
+      StripeGroup::kStreamMajorLayoutIdentifier.data());
+}
+
+void TabletWriter::writeStripeGroup(size_t streamCount, size_t stripeCount) {
+  flatbuffers::FlatBufferBuilder builder(kInitialFooterSize);
+
+  switch (options_.stripeGroupEncodingLayout) {
+    case StripeGroup::EncodingLayout::kRaw:
+      writeStripeGroupWithRawLayout(builder, streamCount, stripeCount);
+      break;
+    case StripeGroup::EncodingLayout::kStreamMajor:
+      writeStripeGroupWithStreamMajorLayout(builder, streamCount, stripeCount);
+      break;
+    default:
+      NIMBLE_UNREACHABLE(
+          fmt::format(
+              "Unknown StripeGroup encoding layout: {}",
+              static_cast<int>(options_.stripeGroupEncodingLayout)));
+  }
+
   stripeGroups_.emplace_back(createMetadataSection(asView(builder)));
 }
 
@@ -576,8 +694,8 @@ void TabletWriter::tryWriteStripeGroup(bool force) {
   const auto streamCount = maxStreamCountIt->size();
 
   // Each stripe may have different stream count recorded.
-  // We need to pad shorter stripes to the full length of stream count. All
-  // these is handled by the |createFlattenedVector| function.
+  // We need to pad shorter stripes to the full length of stream count.
+  // Handled by the |transposeStreamMetadata| helper inside writeStripeGroup.
   writeStripeGroup(streamCount, stripeCount);
 
   writeChunkIndexGroup(streamCount, stripeCount);

--- a/dwio/nimble/tablet/TabletWriter.h
+++ b/dwio/nimble/tablet/TabletWriter.h
@@ -18,12 +18,14 @@
 
 #include "dwio/nimble/common/Buffer.h"
 #include "dwio/nimble/common/Checksum.h"
+#include "dwio/nimble/common/Types.h"
 #include "dwio/nimble/common/Vector.h"
 #include "dwio/nimble/tablet/Chunk.h"
 #include "dwio/nimble/tablet/ChunkIndexWriter.h"
 #include "dwio/nimble/tablet/FileLayout.h"
 #include "dwio/nimble/tablet/FooterGenerated.h"
 #include "dwio/nimble/tablet/MetadataBuffer.h"
+#include "dwio/nimble/tablet/StripeGroup.h"
 #include "velox/common/file/File.h"
 #include "velox/vector/TypeAliases.h"
 
@@ -75,6 +77,16 @@ class TabletWriter {
     // of chunks per stream is below this threshold. 0 disables chunk index
     // skipping.
     float chunkIndexMinAvgChunks{2};
+    // Selects how per-stripe-group stream offsets/sizes are serialized (default
+    // kRaw); see StripeGroup::EncodingLayout.
+    StripeGroup::EncodingLayout stripeGroupEncodingLayout{
+        StripeGroup::EncodingLayout::kRaw};
+    // Candidate encodings (with read-cost weights) considered when encoding
+    // per-stripe-group offsets/sizes in the encoded layouts. Only O(1)
+    // point-access encodings are valid. Empty (default) lets the writer pick
+    // its own candidate set (Constant, Trivial, FixedBitWidth).
+    std::vector<std::pair<EncodingType, float>>
+        stripeGroupEncodingLayoutReadFactors{};
     // Callback invoked at stripe group flush boundaries. Used by index
     // writers (e.g., ClusterIndexWriter) to write partition data aligned
     // with stripe groups.
@@ -162,7 +174,19 @@ class TabletWriter {
   // exceeds metadata flush size.
   void tryWriteStripeGroup(bool force = false);
   bool shouldWriteStripeGroup(bool force) const;
+  // Serialize the current stripe group's metadata, dispatching to the
+  // layout-specific helper below per options_.stripeGroupEncodingLayout.
   void writeStripeGroup(size_t streamCount, size_t stripeCount);
+  // Serialize the current stripe group's per-stream offsets/sizes into
+  // `builder` using the kRaw / kStreamMajor layout respectively.
+  void writeStripeGroupWithRawLayout(
+      flatbuffers::FlatBufferBuilder& builder,
+      size_t streamCount,
+      size_t stripeCount);
+  void writeStripeGroupWithStreamMajorLayout(
+      flatbuffers::FlatBufferBuilder& builder,
+      size_t streamCount,
+      size_t stripeCount);
   void finishStripeGroup();
 
   // Write stripes metadata section

--- a/dwio/nimble/tablet/tests/TabletTest.cpp
+++ b/dwio/nimble/tablet/tests/TabletTest.cpp
@@ -1348,13 +1348,10 @@ TEST_P(TabletTest, streamSize) {
       {0, 0, 10},
       {0, 1, 20},
       {0, 2, 8},
-      // Out of range returns 0.
-      {0, 3, 0},
-      {0, 100, 0},
       // Stripe 1: 2 streams with sizes 15, 25.
       {1, 0, 15},
       {1, 1, 25},
-      // Stream 2 doesn't exist in stripe 1.
+      // Stream 2 is absent in stripe 1 but within the group's stream count.
       {1, 2, 0},
   };
 
@@ -1363,6 +1360,360 @@ TEST_P(TabletTest, streamSize) {
     auto stripe = tablet->stripeIdentifier(testCase.stripeIndex);
     EXPECT_EQ(
         tablet->streamSize(stripe, testCase.streamId), testCase.expectedSize);
+  }
+
+  // An out-of-range streamId is a programming error: point access check-fails
+  // rather than silently returning 0.
+  auto stripe0 = tablet->stripeIdentifier(0);
+  const auto streamCount = tablet->streamCount(stripe0);
+  EXPECT_ANY_THROW(tablet->streamSize(stripe0, streamCount));
+  EXPECT_ANY_THROW(tablet->streamOffset(stripe0, streamCount));
+}
+
+TEST_P(TabletTest, stripeGroupEncodingLayouts) {
+  // Write the same 2-stripe layout in each StripeGroup metadata format, then
+  // verify: (1) each round-trips its stream offsets/sizes, and (2) all formats
+  // produce identical reads, via both point access and bulk materialize.
+  auto writeTablet = [&](nimble::StripeGroup::EncodingLayout format) {
+    std::string file;
+    velox::InMemoryWriteFile writeFile(&file);
+    auto tabletWriter = nimble::TabletWriter::create(
+        &writeFile,
+        *pool_,
+        {.streamDeduplicationEnabled = false,
+         .stripeGroupEncodingLayout = format});
+
+    nimble::Buffer buffer{*pool_};
+    // Stripe 0: 3 streams with sizes 10, 20, 8.
+    {
+      std::vector<nimble::Stream> streams;
+      streams.push_back(
+          nimble::index::test::createStream(
+              buffer, {.offset = 0, .chunks = {{.rowCount = 50, .size = 10}}}));
+      streams.push_back(
+          nimble::index::test::createStream(
+              buffer, {.offset = 1, .chunks = {{.rowCount = 50, .size = 20}}}));
+      streams.push_back(
+          nimble::index::test::createStream(
+              buffer, {.offset = 2, .chunks = {{.rowCount = 50, .size = 8}}}));
+      tabletWriter->writeStripe(50, std::move(streams));
+    }
+    // Stripe 1: 2 streams with sizes 15, 25.
+    {
+      std::vector<nimble::Stream> streams;
+      streams.push_back(
+          nimble::index::test::createStream(
+              buffer, {.offset = 0, .chunks = {{.rowCount = 30, .size = 15}}}));
+      streams.push_back(
+          nimble::index::test::createStream(
+              buffer, {.offset = 1, .chunks = {{.rowCount = 30, .size = 25}}}));
+      tabletWriter->writeStripe(30, std::move(streams));
+    }
+    tabletWriter->close();
+    writeFile.close();
+    return file;
+  };
+
+  auto readTablet = [&](const std::string& file) {
+    auto readFile =
+        std::make_shared<nimble::testing::InMemoryTrackableReadFile>(
+            file, false);
+    return createTabletReader(readFile, nimble::TabletReader::Options{});
+  };
+
+  // kRaw is also the default write path; kStreamMajor is the opt-in format.
+  auto rawTablet =
+      readTablet(writeTablet(nimble::StripeGroup::EncodingLayout::kRaw));
+  auto streamMajorTablet = readTablet(
+      writeTablet(nimble::StripeGroup::EncodingLayout::kStreamMajor));
+
+  // Per-stream sizes are the same regardless of representation.
+  struct SizeCase {
+    uint32_t stripe;
+    uint32_t streamId;
+    uint32_t expectedSize;
+  };
+  const std::vector<SizeCase> sizeCases = {
+      {0, 0, 10},
+      {0, 1, 20},
+      {0, 2, 8},
+      {1, 0, 15},
+      {1, 1, 25},
+      {1, 2, 0}}; // absent in stripe 1 (padded within the group's stream count)
+  for (const auto& tablet : {rawTablet, streamMajorTablet}) {
+    for (const auto& c : sizeCases) {
+      SCOPED_TRACE(
+          fmt::format(
+              "stripe={} stream={} expected={}",
+              c.stripe,
+              c.streamId,
+              c.expectedSize));
+      auto stripe = tablet->stripeIdentifier(c.stripe);
+      EXPECT_EQ(tablet->streamSize(stripe, c.streamId), c.expectedSize);
+    }
+  }
+
+  // An out-of-range streamId is a programming error: point access check-fails
+  // rather than silently returning 0.
+  for (const auto& tablet : {rawTablet, streamMajorTablet}) {
+    auto stripe = tablet->stripeIdentifier(0);
+    const auto streamCount = tablet->streamCount(stripe);
+    EXPECT_ANY_THROW(tablet->streamOffset(stripe, streamCount));
+    EXPECT_ANY_THROW(tablet->streamSize(stripe, streamCount));
+  }
+
+  // The encoded representation must agree with raw on every stripe/stream,
+  // via point access and bulk materialize.
+  for (const auto& encodedTablet : {streamMajorTablet}) {
+    ASSERT_EQ(rawTablet->stripeCount(), encodedTablet->stripeCount());
+    for (uint32_t stripe = 0; stripe < rawTablet->stripeCount(); ++stripe) {
+      SCOPED_TRACE(fmt::format("stripe={}", stripe));
+      auto rawStripe = rawTablet->stripeIdentifier(stripe);
+      auto encStripe = encodedTablet->stripeIdentifier(stripe);
+      const auto streamCount = rawTablet->streamCount(rawStripe);
+      ASSERT_EQ(streamCount, encodedTablet->streamCount(encStripe));
+
+      for (uint32_t streamId = 0; streamId < streamCount; ++streamId) {
+        EXPECT_EQ(
+            rawTablet->streamOffset(rawStripe, streamId),
+            encodedTablet->streamOffset(encStripe, streamId));
+        EXPECT_EQ(
+            rawTablet->streamSize(rawStripe, streamId),
+            encodedTablet->streamSize(encStripe, streamId));
+      }
+
+      std::vector<uint32_t> rawOffsets(streamCount);
+      std::vector<uint32_t> encOffsets(streamCount);
+      std::vector<uint32_t> rawSizes(streamCount);
+      std::vector<uint32_t> encSizes(streamCount);
+      rawTablet->streamOffsets(rawStripe, rawOffsets);
+      encodedTablet->streamOffsets(encStripe, encOffsets);
+      rawTablet->streamSizes(rawStripe, rawSizes);
+      encodedTablet->streamSizes(encStripe, encSizes);
+      EXPECT_EQ(rawOffsets, encOffsets);
+      EXPECT_EQ(rawSizes, encSizes);
+    }
+  }
+}
+
+TEST_P(TabletTest, writeStripeGroupUnknownLayoutThrows) {
+  // An unrecognized StripeGroup encoding layout must hit the writer switch's
+  // default and check-fail rather than silently writing malformed metadata.
+  std::string file;
+  velox::InMemoryWriteFile writeFile(&file);
+  auto tabletWriter = nimble::TabletWriter::create(
+      &writeFile,
+      *pool_,
+      {.streamDeduplicationEnabled = false,
+       .stripeGroupEncodingLayout =
+           static_cast<nimble::StripeGroup::EncodingLayout>(99)});
+
+  nimble::Buffer buffer{*pool_};
+  std::vector<nimble::Stream> streams;
+  streams.push_back(
+      nimble::index::test::createStream(
+          buffer, {.offset = 0, .chunks = {{.rowCount = 10, .size = 10}}}));
+  tabletWriter->writeStripe(10, std::move(streams));
+  // close() force-flushes the final stripe group, dispatching on the layout.
+  EXPECT_ANY_THROW(tabletWriter->close());
+}
+
+TEST_P(TabletTest, stripeGroupEncodingLayoutsMultipleGroups) {
+  // A tiny metadataFlushThreshold forces the writer to flush many stripe
+  // groups, so groups after the first have firstStripeIndex_ != 0. This
+  // exercises the encoded formats' per-group encode/reset and the reader's
+  // global->local stripe-index mapping across group boundaries, which the
+  // single-group tests above cannot reach.
+  constexpr uint32_t kStripeCount = 12;
+  constexpr uint32_t kStreamCount = 3;
+
+  auto writeTablet = [&](nimble::StripeGroup::EncodingLayout format) {
+    std::string file;
+    velox::InMemoryWriteFile writeFile(&file);
+    auto tabletWriter = nimble::TabletWriter::create(
+        &writeFile,
+        *pool_,
+        {// Small enough to flush a stripe group every few stripes.
+         .metadataFlushThreshold = 100,
+         .streamDeduplicationEnabled = false,
+         .stripeGroupEncodingLayout = format});
+
+    nimble::Buffer buffer{*pool_};
+    for (uint32_t stripe = 0; stripe < kStripeCount; ++stripe) {
+      std::vector<nimble::Stream> streams;
+      for (uint32_t s = 0; s < kStreamCount; ++s) {
+        // Vary sizes per (stripe, stream) so the encoded per-group arrays are
+        // not trivially constant.
+        const uint32_t size = 10 + stripe * kStreamCount + s;
+        streams.push_back(
+            nimble::index::test::createStream(
+                buffer,
+                {.offset = s, .chunks = {{.rowCount = 10, .size = size}}}));
+      }
+      tabletWriter->writeStripe(10, std::move(streams));
+    }
+    tabletWriter->close();
+    writeFile.close();
+    return file;
+  };
+
+  auto readTablet = [&](const std::string& file) {
+    auto readFile =
+        std::make_shared<nimble::testing::InMemoryTrackableReadFile>(
+            file, false);
+    return createTabletReader(readFile, nimble::TabletReader::Options{});
+  };
+
+  // Keep the file buffers alive for the whole test: the reader references the
+  // InMemoryReadFile's backing string and loads later stripe groups lazily, so
+  // a temporary would dangle once the first group is read.
+  const std::string rawFile =
+      writeTablet(nimble::StripeGroup::EncodingLayout::kRaw);
+  const std::string streamMajorFile =
+      writeTablet(nimble::StripeGroup::EncodingLayout::kStreamMajor);
+  auto rawTablet = readTablet(rawFile);
+  auto streamMajorTablet = readTablet(streamMajorFile);
+
+  // The test is only meaningful if writing produced several stripe groups (so
+  // later groups have firstStripeIndex_ != 0) and at least one group spans
+  // multiple stripes (so encoded arrays are not length-1). Assert both, so the
+  // test fails loudly rather than silently degrading if the flush heuristic
+  // changes.
+  for (const auto& tablet : {rawTablet, streamMajorTablet}) {
+    nimble::test::TabletReaderTestHelper helper(tablet.get());
+    ASSERT_GE(helper.numStripeGroups(), 2u);
+    ASSERT_LT(helper.numStripeGroups(), size_t{kStripeCount});
+    ASSERT_GT(helper.stripeGroupIndex(kStripeCount - 1), 0u);
+  }
+
+  // Every stripe/stream must agree between Raw and each encoded format, across
+  // all group boundaries, via point access and bulk materialize.
+  ASSERT_EQ(rawTablet->stripeCount(), kStripeCount);
+  for (const auto& encodedTablet : {streamMajorTablet}) {
+    ASSERT_EQ(rawTablet->stripeCount(), encodedTablet->stripeCount());
+    for (uint32_t stripe = 0; stripe < kStripeCount; ++stripe) {
+      SCOPED_TRACE(fmt::format("stripe={}", stripe));
+      auto rawStripe = rawTablet->stripeIdentifier(stripe);
+      auto encStripe = encodedTablet->stripeIdentifier(stripe);
+      const auto streamCount = rawTablet->streamCount(rawStripe);
+      ASSERT_EQ(streamCount, encodedTablet->streamCount(encStripe));
+
+      for (uint32_t streamId = 0; streamId < streamCount; ++streamId) {
+        EXPECT_EQ(
+            rawTablet->streamOffset(rawStripe, streamId),
+            encodedTablet->streamOffset(encStripe, streamId));
+        EXPECT_EQ(
+            rawTablet->streamSize(rawStripe, streamId),
+            encodedTablet->streamSize(encStripe, streamId));
+      }
+
+      std::vector<uint32_t> rawOffsets(streamCount);
+      std::vector<uint32_t> encOffsets(streamCount);
+      std::vector<uint32_t> rawSizes(streamCount);
+      std::vector<uint32_t> encSizes(streamCount);
+      rawTablet->streamOffsets(rawStripe, rawOffsets);
+      encodedTablet->streamOffsets(encStripe, encOffsets);
+      rawTablet->streamSizes(rawStripe, rawSizes);
+      encodedTablet->streamSizes(encStripe, encSizes);
+      EXPECT_EQ(rawOffsets, encOffsets);
+      EXPECT_EQ(rawSizes, encSizes);
+    }
+  }
+}
+
+TEST_P(TabletTest, stripeGroupMetadataConfigurableReadFactors) {
+  // The StripeGroup metadata encoding candidates are configurable via
+  // TabletWriter::Options::stripeGroupEncodingLayoutReadFactors. For
+  // kStreamMajor, write the same many-stripe layout twice: once with the
+  // default candidate set (includes Constant) and once restricted to Trivial.
+  // Verify (1) both round-trip every stream offset/size, and (2) restricting to
+  // Trivial produces strictly larger stripe-group metadata than the default —
+  // proving the option actually drives selection (the default collapses the
+  // constant arrays, Trivial stores them raw).
+  constexpr uint32_t kStripeCount = 64;
+  constexpr uint32_t kStreamCount = 3;
+  const std::vector<uint32_t> sizes = {10, 20, 8};
+
+  auto writeTablet =
+      [&](nimble::StripeGroup::EncodingLayout format,
+          const std::vector<std::pair<nimble::EncodingType, float>>&
+              readFactors) {
+        std::string file;
+        velox::InMemoryWriteFile writeFile(&file);
+        nimble::TabletWriter::Options options{
+            .streamDeduplicationEnabled = false,
+            .stripeGroupEncodingLayout = format};
+        if (!readFactors.empty()) {
+          options.stripeGroupEncodingLayoutReadFactors = readFactors;
+        }
+        auto tabletWriter = nimble::TabletWriter::create(
+            &writeFile, *pool_, std::move(options));
+
+        nimble::Buffer buffer{*pool_};
+        // Identical stripes, so every stream's offset/size array is constant
+        // across stripes and the default selector can collapse it.
+        for (uint32_t s = 0; s < kStripeCount; ++s) {
+          std::vector<nimble::Stream> streams;
+          streams.reserve(kStreamCount);
+          for (uint32_t id = 0; id < kStreamCount; ++id) {
+            streams.push_back(
+                nimble::index::test::createStream(
+                    buffer,
+                    {.offset = id,
+                     .chunks = {{.rowCount = 10, .size = sizes[id]}}}));
+          }
+          tabletWriter->writeStripe(10, std::move(streams));
+        }
+        tabletWriter->close();
+        writeFile.close();
+        return file;
+      };
+
+  auto readTablet = [&](const std::string& file) {
+    auto readFile =
+        std::make_shared<nimble::testing::InMemoryTrackableReadFile>(
+            file, false);
+    return createTabletReader(readFile, nimble::TabletReader::Options{});
+  };
+
+  auto metadataSize = [](const std::shared_ptr<nimble::TabletReader>& tablet) {
+    uint64_t total = 0;
+    for (const auto& section : tablet->stripeGroupsMetadata()) {
+      total += section.size();
+    }
+    return total;
+  };
+
+  for (const auto format :
+       {nimble::StripeGroup::EncodingLayout::kStreamMajor}) {
+    SCOPED_TRACE(fmt::format("format={}", static_cast<int>(format)));
+    auto defaultTablet = readTablet(writeTablet(format, /*readFactors=*/{}));
+    auto trivialTablet =
+        readTablet(writeTablet(format, {{nimble::EncodingType::Trivial, 1.0}}));
+
+    ASSERT_EQ(defaultTablet->stripeCount(), kStripeCount);
+    ASSERT_EQ(trivialTablet->stripeCount(), kStripeCount);
+    for (uint32_t s = 0; s < kStripeCount; ++s) {
+      auto defStripe = defaultTablet->stripeIdentifier(s);
+      auto trivStripe = trivialTablet->stripeIdentifier(s);
+      ASSERT_EQ(defaultTablet->streamCount(defStripe), kStreamCount);
+      ASSERT_EQ(trivialTablet->streamCount(trivStripe), kStreamCount);
+      for (uint32_t id = 0; id < kStreamCount; ++id) {
+        SCOPED_TRACE(fmt::format("stripe={} stream={}", s, id));
+        EXPECT_EQ(defaultTablet->streamSize(defStripe, id), sizes[id]);
+        EXPECT_EQ(
+            trivialTablet->streamSize(trivStripe, id),
+            defaultTablet->streamSize(defStripe, id));
+        EXPECT_EQ(
+            trivialTablet->streamOffset(trivStripe, id),
+            defaultTablet->streamOffset(defStripe, id));
+      }
+    }
+
+    // Restricting to Trivial drops Constant/FBW/Dictionary from the candidate
+    // set, so the constant arrays can no longer collapse — the encoded metadata
+    // must be strictly larger than the default.
+    EXPECT_GT(metadataSize(trivialTablet), metadataSize(defaultTablet));
   }
 }
 
@@ -1459,12 +1810,11 @@ class TabletWithIndexTest : public TabletTest {
     ASSERT_NE(stripeIdentifier.stripeGroup(), nullptr)
         << "Stripe group should be available for stripe " << stripeIdx;
 
-    // Get stream sizes from stripe group metadata
-    auto streamSizes = tablet.streamSizes(stripeIdentifier);
-    ASSERT_GT(streamSizes.size(), streamId)
+    // Get stream size from stripe group metadata
+    ASSERT_GT(tablet.streamCount(stripeIdentifier), streamId)
         << "Stream " << streamId << " not found in stripe " << stripeIdx;
 
-    const uint32_t streamSize = streamSizes[streamId];
+    const uint32_t streamSize = tablet.streamSize(stripeIdentifier, streamId);
 
     // Calculate stripe offset within the chunk index group.
     // Use the ChunkIndexTestHelper to get the first stripe of the group.

--- a/dwio/nimble/tools/NimbleDumpLib.cpp
+++ b/dwio/nimble/tools/NimbleDumpLib.cpp
@@ -625,10 +625,13 @@ void NimbleDumpLib::emitStripes(bool noHeader) {
   // stripe groups. We must hold on to it across loop iterations in order to
   // maintain the items in the cache.
   std::optional<StripeIdentifier> stripeIdentifier;
+  std::vector<uint32_t> sizesScratch;
   for (auto i = 0; i < tabletReader->stripeCount(); ++i) {
     stripeIdentifier = tabletReader->stripeIdentifier(i);
-    auto sizes = tabletReader->streamSizes(stripeIdentifier.value());
-    auto stripeSize = std::accumulate(sizes.begin(), sizes.end(), 0UL);
+    sizesScratch.resize(tabletReader->streamCount(stripeIdentifier.value()));
+    tabletReader->streamSizes(stripeIdentifier.value(), sizesScratch);
+    auto stripeSize =
+        std::accumulate(sizesScratch.begin(), sizesScratch.end(), 0UL);
     formatter.writeRow({
         folly::to<std::string>(i),
         commaSeparated(tabletReader->stripeOffset(i)),
@@ -714,10 +717,10 @@ void NimbleDumpLib::emitStreams(
         values.push_back(folly::to<std::string>(streamId));
         values.push_back(
             folly::to<std::string>(
-                tabletReader->streamOffsets(stripeIdentifier)[streamId]));
+                tabletReader->streamOffset(stripeIdentifier, streamId)));
         values.push_back(
             folly::to<std::string>(
-                tabletReader->streamSizes(stripeIdentifier)[streamId]));
+                tabletReader->streamSize(stripeIdentifier, streamId)));
         if (showStreamRawSize) {
           values.push_back(folly::to<std::string>(rawStreamSize));
         }

--- a/dwio/nimble/velox/VeloxWriter.cpp
+++ b/dwio/nimble/velox/VeloxWriter.cpp
@@ -866,6 +866,11 @@ VeloxWriter::VeloxWriter(
                context_->options().enableStreamDeduplication,
            .enableChunkIndex = context_->options().enableChunkIndex,
            .chunkIndexMinAvgChunks = context_->options().chunkIndexMinAvgChunks,
+           .stripeGroupEncodingLayout =
+               context_->options().experimentalStripeGroupEncodingLayout,
+           .stripeGroupEncodingLayoutReadFactors =
+               context_->options()
+                   .experimentalStripeGroupEncodingLayoutReadFactors,
            .stripeGroupFlushCallback = clusterIndexWriter_ != nullptr
                ? TabletWriter::StripeGroupFlushCallback(
                      [this](

--- a/dwio/nimble/velox/VeloxWriterOptions.h
+++ b/dwio/nimble/velox/VeloxWriterOptions.h
@@ -20,6 +20,7 @@
 #include "dwio/nimble/common/Types.h"
 #include "dwio/nimble/encodings/selection/EncodingSelectionPolicy.h"
 #include "dwio/nimble/index/IndexConfig.h"
+#include "dwio/nimble/tablet/StripeGroup.h"
 #include "dwio/nimble/velox/BufferGrowthPolicy.h"
 #include "dwio/nimble/velox/EncodingLayoutTree.h"
 #include "dwio/nimble/velox/FlushPolicy.h"
@@ -75,6 +76,22 @@ struct VeloxWriterOptions {
   // of chunks per stream is below this threshold. 0 disables chunk index
   // skipping.
   float chunkIndexMinAvgChunks{2};
+
+  /// NOTE: !!! This is under experimentation and please do not turn on in
+  /// production use case !!!
+  /// Selects how per-stripe-group stream offsets/sizes are serialized:
+  /// - kRaw: flat stripe-major uint32 arrays (default; all readers).
+  /// - kStreamMajor: one encoding per stream.
+  StripeGroup::EncodingLayout experimentalStripeGroupEncodingLayout{
+      StripeGroup::EncodingLayout::kRaw};
+
+  /// Candidate encodings (with read-cost weights) the writer considers when
+  /// encoding per-stripe-group stream offsets/sizes (kStreamMajor). Only
+  /// encodings with O(1) stateless point access (via EncodingView) are valid.
+  /// Empty (default) lets the writer pick its own candidate set (Constant,
+  /// Trivial, FixedBitWidth).
+  std::vector<std::pair<EncodingType, float>>
+      experimentalStripeGroupEncodingLayoutReadFactors{};
 
   /// If set, the cluster index on the specified columns will be built during
   /// writing. The index stores the per-chunk min and max key for each stripe.

--- a/dwio/nimble/velox/index/NimbleIndexProjector.cpp
+++ b/dwio/nimble/velox/index/NimbleIndexProjector.cpp
@@ -496,19 +496,22 @@ void NimbleIndexProjector::locateStripeStreams(StripePlan& stripePlan) {
   const auto stripeId = tablet_->stripeIdentifier(stripePlan.stripeIndex);
   const auto streamCount = tablet_->streamCount(stripeId);
   const auto stripeOffset = tablet_->stripeOffset(stripePlan.stripeIndex);
-  const auto& streamOffsets = tablet_->streamOffsets(stripeId);
-  const auto& streamSizes = tablet_->streamSizes(stripeId);
 
   stripePlan.projectedStreams.resize(projection_->streamOffsets.size());
   for (size_t i = 0; i < projection_->streamOffsets.size(); ++i) {
     const auto streamId = projection_->streamOffsets[i];
-    if (streamId >= streamCount || streamSizes[streamId] == 0) {
+    if (streamId >= streamCount) {
       continue;
     }
-    stripePlan.projectedStreams[i] = velox::common::Region{
-        stripeOffset + streamOffsets[streamId], streamSizes[streamId]};
+    const auto streamSize = tablet_->streamSize(stripeId, streamId);
+    if (streamSize == 0) {
+      continue;
+    }
+    const auto streamOffset = tablet_->streamOffset(stripeId, streamId);
+    stripePlan.projectedStreams[i] =
+        velox::common::Region{stripeOffset + streamOffset, streamSize};
     ++stripePlan.numStreams;
-    stripePlan.projectedBytes += streamSizes[streamId];
+    stripePlan.projectedBytes += streamSize;
     if (projection_->rowOrFlatMapNullStreams[i]) {
       // A present Row/FlatMap null stream means the slice may carry nulls.
       stripePlan.requiresNullBarrier = true;

--- a/dwio/nimble/velox/index/tests/NimbleIndexProjectorTest.cpp
+++ b/dwio/nimble/velox/index/tests/NimbleIndexProjectorTest.cpp
@@ -2920,13 +2920,16 @@ TEST_P(NimbleIndexProjectorTest, featureReorderingStorageReads) {
   };
 
   // Write data with optional feature reordering.
-  auto writeFile = [&](bool enableReordering) {
+  auto writeFile = [&](bool enableReordering,
+                       StripeGroup::EncodingLayout metadataFormat =
+                           StripeGroup::EncodingLayout::kRaw) {
     sinkData_.clear();
     auto file = std::make_unique<InMemoryWriteFile>(&sinkData_);
 
     VeloxWriterOptions options;
     options.enableChunking = true;
     options.flatMapColumns = {{"features", {}}};
+    options.experimentalStripeGroupEncodingLayout = metadataFormat;
 
     ClusterIndexConfig clusterIndexConfig;
     clusterIndexConfig.columns = {"key"};
@@ -2978,9 +2981,14 @@ TEST_P(NimbleIndexProjectorTest, featureReorderingStorageReads) {
         *tabletReaderCache_, fileHandle, subfields, readerOptions);
   };
 
-  // Part 1: Verify stream adjacency on disk with feature reordering.
-  {
-    writeFile(/*enableReordering=*/true);
+  // Part 1: Verify stream adjacency on disk with feature reordering, for each
+  // stripe-group metadata format.
+  for (auto metadataFormat :
+       {StripeGroup::EncodingLayout::kRaw,
+        StripeGroup::EncodingLayout::kStreamMajor}) {
+    SCOPED_TRACE(
+        fmt::format("metadataFormat={}", static_cast<int>(metadataFormat)));
+    writeFile(/*enableReordering=*/true, metadataFormat);
     auto readFile =
         std::make_shared<InMemoryReadFile>(std::string_view(sinkData_));
     auto tablet = TabletReader::create(
@@ -2988,8 +2996,11 @@ TEST_P(NimbleIndexProjectorTest, featureReorderingStorageReads) {
     ASSERT_GE(tablet->stripeCount(), 1);
 
     auto stripeId = tablet->stripeIdentifier(0);
-    auto offsets = tablet->streamOffsets(stripeId);
-    auto sizes = tablet->streamSizes(stripeId);
+    const auto streamCount = tablet->streamCount(stripeId);
+    std::vector<uint32_t> offsets(streamCount);
+    std::vector<uint32_t> sizes(streamCount);
+    tablet->streamOffsets(stripeId, offsets);
+    tablet->streamSizes(stripeId, sizes);
 
     VeloxReader reader(readFile.get(), *leafPool_);
     const auto& flatMap = reader.schema()->asRow().childAt(1)->asFlatMap();

--- a/dwio/nimble/velox/selective/ReaderBase.cpp
+++ b/dwio/nimble/velox/selective/ReaderBase.cpp
@@ -174,13 +174,13 @@ std::optional<common::Region> StripeStreams::streamRegion(int streamId) const {
   if (streamId >= tablet.streamCount(*stripeIdentifier_)) {
     return std::nullopt;
   }
-  const auto size = tablet.streamSizes(*stripeIdentifier_)[streamId];
+  const auto size = tablet.streamSize(*stripeIdentifier_, streamId);
   if (size == 0) {
     return std::nullopt;
   }
   common::Region region;
   region.offset = tablet.stripeOffset(stripe_) +
-      tablet.streamOffsets(*stripeIdentifier_)[streamId];
+      tablet.streamOffset(*stripeIdentifier_, streamId);
   region.length = size;
   return region;
 }
@@ -206,19 +206,20 @@ std::vector<std::optional<StreamLocation>> StripeStreams::locateStreams(
   const auto streamCount = tablet.streamCount(*stripeIdentifier_);
   // File offset where this stripe's data begins.
   const auto stripeOffset = tablet.stripeOffset(stripe_);
-  const auto& streamOffsets = tablet.streamOffsets(*stripeIdentifier_);
-  const auto& streamSizes = tablet.streamSizes(*stripeIdentifier_);
 
   std::vector<std::optional<StreamLocation>> locations(streamIds.size());
   for (size_t i = 0; i < streamIds.size(); ++i) {
     const auto streamId = streamIds[i];
-    if (streamId >= streamCount || streamSizes[streamId] == 0) {
+    if (streamId >= streamCount) {
       continue;
     }
+    const auto streamSize = tablet.streamSize(*stripeIdentifier_, streamId);
+    if (streamSize == 0) {
+      continue;
+    }
+    const auto streamOffset = tablet.streamOffset(*stripeIdentifier_, streamId);
     locations[i] = StreamLocation{
-        streamId,
-        common::Region{
-            stripeOffset + streamOffsets[streamId], streamSizes[streamId]}};
+        streamId, common::Region{stripeOffset + streamOffset, streamSize}};
   }
   return locations;
 }
@@ -229,6 +230,14 @@ std::shared_ptr<index::StreamIndex> StripeStreams::streamIndex(
 
   const auto& chunkIndex = stripeIdentifier_->chunkIndex();
   if (chunkIndex == nullptr) {
+    return nullptr;
+  }
+  // A stream absent from this stripe group (e.g. added by later schema
+  // evolution or a flat-map feature not present in this group) has no chunk
+  // index. Gate on streamCount as streamRegion()/locateStreams() do, so an
+  // out-of-range stream id does not reach streamSize() (which check-fails on
+  // out-of-range).
+  if (streamId >= readerBase_->tablet().streamCount(*stripeIdentifier_)) {
     return nullptr;
   }
   const uint32_t streamSize =

--- a/dwio/nimble/velox/selective/tests/ReaderBaseTest.cpp
+++ b/dwio/nimble/velox/selective/tests/ReaderBaseTest.cpp
@@ -224,7 +224,8 @@ INSTANTIATE_TEST_CASE_P(
       return info.param == CreationMode::kDirect ? "direct" : "cached";
     });
 
-class StripeStreamsMultiStripeTest : public ::testing::Test {
+class StripeStreamsMultiStripeTest
+    : public ::testing::TestWithParam<StripeGroup::EncodingLayout> {
  protected:
   static void SetUpTestSuite() {
     velox::memory::MemoryManager::testingSetInstance({});
@@ -240,6 +241,7 @@ class StripeStreamsMultiStripeTest : public ::testing::Test {
     velox::test::VectorMaker vectorMaker(pool_.get());
 
     VeloxWriterOptions writerOptions;
+    writerOptions.experimentalStripeGroupEncodingLayout = GetParam();
     writerOptions.flushPolicyFactory = []() {
       return std::make_unique<LambdaFlushPolicy>(
           [](const StripeProgress&) { return true; });
@@ -288,7 +290,7 @@ class StripeStreamsMultiStripeTest : public ::testing::Test {
       std::make_shared<velox::io::IoStatistics>()};
 };
 
-TEST_F(StripeStreamsMultiStripeTest, locateStreams) {
+TEST_P(StripeStreamsMultiStripeTest, locateStreams) {
   auto readFile = std::make_shared<velox::InMemoryReadFile>(fileData_);
   auto opts = makeReaderOptions();
 
@@ -312,8 +314,6 @@ TEST_F(StripeStreamsMultiStripeTest, locateStreams) {
 
     const auto stripeId = tablet.stripeIdentifier(stripe);
     const auto stripeOffset = tablet.stripeOffset(stripe);
-    const auto& streamOffsets = tablet.streamOffsets(stripeId);
-    const auto& streamSizes = tablet.streamSizes(stripeId);
     const auto& stripeInfo = layout.stripesInfo[stripe];
 
     for (size_t i = 0; i < locations.size(); ++i) {
@@ -322,8 +322,10 @@ TEST_F(StripeStreamsMultiStripeTest, locateStreams) {
       EXPECT_EQ(locations[i]->streamId, streamIds[i]);
       EXPECT_EQ(
           locations[i]->region.offset,
-          stripeOffset + streamOffsets[streamIds[i]]);
-      EXPECT_EQ(locations[i]->region.length, streamSizes[streamIds[i]]);
+          stripeOffset + tablet.streamOffset(stripeId, streamIds[i]));
+      EXPECT_EQ(
+          locations[i]->region.length,
+          tablet.streamSize(stripeId, streamIds[i]));
       EXPECT_GE(locations[i]->region.offset, stripeInfo.offset);
       EXPECT_LE(
           locations[i]->region.offset + locations[i]->region.length,
@@ -332,7 +334,7 @@ TEST_F(StripeStreamsMultiStripeTest, locateStreams) {
   }
 }
 
-TEST_F(StripeStreamsMultiStripeTest, preloadCollapsesStripeReads) {
+TEST_P(StripeStreamsMultiStripeTest, preloadCollapsesStripeReads) {
   constexpr uint32_t kStripeCount = 3;
 
   auto preadsReadingAllStripes = [&](uint64_t preloadThreshold) {
@@ -364,3 +366,14 @@ TEST_F(StripeStreamsMultiStripeTest, preloadCollapsesStripeReads) {
   EXPECT_EQ(preadsReadingAllStripes(fileData_.size() + 1), 1);
   EXPECT_GE(preadsReadingAllStripes(0), kStripeCount);
 }
+
+INSTANTIATE_TEST_CASE_P(
+    MetadataFormats,
+    StripeStreamsMultiStripeTest,
+    ::testing::Values(
+        StripeGroup::EncodingLayout::kRaw,
+        StripeGroup::EncodingLayout::kStreamMajor),
+    [](const ::testing::TestParamInfo<StripeGroup::EncodingLayout>& info) {
+      return info.param == StripeGroup::EncodingLayout::kRaw ? "raw"
+                                                             : "streamMajor";
+    });

--- a/dwio/nimble/velox/tests/VeloxReaderTest.cpp
+++ b/dwio/nimble/velox/tests/VeloxReaderTest.cpp
@@ -394,7 +394,8 @@ size_t streamsReadCount(
       makeTestTabletOptions(&pool));
   NIMBLE_CHECK_GE(tablet->stripeCount(), 1);
   auto stripeIdentifier = tablet->stripeIdentifier(0);
-  auto offsets = tablet->streamOffsets(stripeIdentifier);
+  std::vector<uint32_t> offsets(tablet->streamCount(stripeIdentifier));
+  tablet->streamOffsets(stripeIdentifier, offsets);
   std::unordered_set<uint32_t> streamOffsets;
   LOG(INFO) << "Number of streams: " << offsets.size();
   for (auto offset : offsets) {
@@ -427,9 +428,11 @@ std::unordered_set<nimble::offset_size> existingStreamOffsets(
       makeTestTabletOptions(&pool));
   NIMBLE_CHECK_LT(stripeIndex, tablet->stripeCount(), "Stripe out of range");
   auto stripeId = tablet->stripeIdentifier(stripeIndex);
-  auto streamSizes = tablet->streamSizes(stripeId);
+  const auto streamCount = tablet->streamCount(stripeId);
+  std::vector<uint32_t> streamSizes(streamCount);
+  tablet->streamSizes(stripeId, streamSizes);
   std::unordered_set<nimble::offset_size> result;
-  for (nimble::offset_size i = 0; i < streamSizes.size(); ++i) {
+  for (nimble::offset_size i = 0; i < streamCount; ++i) {
     if (streamSizes[i] > 0) {
       result.insert(i);
     }
@@ -1386,7 +1389,27 @@ nimble::EncodingLayout makeFsstEncodingLayout() {
           nimble::CompressionType::Uncompressed}}};
 }
 
-TEST_P(VeloxReaderTest, dontReadUnselectedColumnsFromFile) {
+// Exercises read-path stream-selection across every StripeGroup metadata
+// format. Parameterized on the format alone (independent of VeloxReaderTest's
+// cache/pin matrix) because these tests only assert which streams are read.
+class VeloxReaderStripeGroupFormatTest
+    : public ::testing::TestWithParam<nimble::StripeGroup::EncodingLayout> {
+ protected:
+  static void SetUpTestCase() {
+    velox::memory::MemoryManager::testingSetInstance(
+        velox::memory::MemoryManager::Options{});
+  }
+
+  void SetUp() override {
+    rootPool_ = velox::memory::memoryManager()->addRootPool("default_root");
+    leafPool_ = rootPool_->addLeafChild("default_leaf");
+  }
+
+  std::shared_ptr<velox::memory::MemoryPool> rootPool_;
+  std::shared_ptr<velox::memory::MemoryPool> leafPool_;
+};
+
+TEST_P(VeloxReaderStripeGroupFormatTest, dontReadUnselectedColumnsFromFile) {
   auto type = velox::ROW({
       {"tinyint_val", velox::TINYINT()},
       {"smallint_val", velox::SMALLINT()},
@@ -1406,9 +1429,10 @@ TEST_P(VeloxReaderTest, dontReadUnselectedColumnsFromFile) {
   velox::VectorFuzzer fuzzer({.vectorSize = batchSize}, leafPool_.get());
   auto vector = fuzzer.fuzzInputFlatRow(type);
 
-  auto file = nimble::test::createNimbleFile(*rootPool_, vector);
-
   uint32_t readSize = 1;
+  nimble::VeloxWriterOptions writerOptions;
+  writerOptions.experimentalStripeGroupEncodingLayout = GetParam();
+  auto file = nimble::test::createNimbleFile(*rootPool_, vector, writerOptions);
   for (auto useChainedBuffers : {false, true}) {
     nimble::testing::InMemoryTrackableReadFile readFile(
         file, useChainedBuffers);
@@ -1419,7 +1443,7 @@ TEST_P(VeloxReaderTest, dontReadUnselectedColumnsFromFile) {
         std::dynamic_pointer_cast<const velox::RowType>(vector->type()),
         selectedColumnNames);
     nimble::VeloxReader reader(
-        &readFile, *leafPool_, std::move(selector), createReadParams());
+        &readFile, *leafPool_, std::move(selector), nimble::VeloxReadParams{});
 
     velox::VectorPtr result;
     reader.next(readSize, result);
@@ -1436,7 +1460,7 @@ TEST_P(VeloxReaderTest, dontReadUnselectedColumnsFromFile) {
   }
 }
 
-TEST_P(VeloxReaderTest, dontReadUnprojectedFeaturesFromFile) {
+TEST_P(VeloxReaderStripeGroupFormatTest, dontReadUnprojectedFeaturesFromFile) {
   auto type = velox::ROW({
       {"float_features", velox::MAP(velox::INTEGER(), velox::REAL())},
   });
@@ -1459,6 +1483,7 @@ TEST_P(VeloxReaderTest, dontReadUnprojectedFeaturesFromFile) {
 
   nimble::VeloxWriterOptions writerOptions;
   writerOptions.flatMapColumns["float_features"];
+  writerOptions.experimentalStripeGroupEncodingLayout = GetParam();
 
   auto file = nimble::test::createNimbleFile(
       *rootPool_, vector, std::move(writerOptions));
@@ -1472,7 +1497,7 @@ TEST_P(VeloxReaderTest, dontReadUnprojectedFeaturesFromFile) {
     auto selector = std::make_shared<velox::dwio::common::ColumnSelector>(
         std::dynamic_pointer_cast<const velox::RowType>(vector->type()));
 
-    nimble::VeloxReadParams params = createReadParams();
+    nimble::VeloxReadParams params;
     params.readFlatMapFieldAsStruct.insert("float_features");
     auto& selectedFeatures =
         params.flatMapFeatureSelector["float_features"].features;
@@ -1546,6 +1571,23 @@ TEST_P(VeloxReaderTest, dontReadUnprojectedFeaturesFromFile) {
         expectedNonEmptyStreamsCount);
   }
 }
+
+INSTANTIATE_TEST_SUITE_P(
+    VeloxReaderStripeGroupFormatTestSuite,
+    VeloxReaderStripeGroupFormatTest,
+    ::testing::Values(
+        nimble::StripeGroup::EncodingLayout::kRaw,
+        nimble::StripeGroup::EncodingLayout::kStreamMajor),
+    [](const ::testing::TestParamInfo<nimble::StripeGroup::EncodingLayout>&
+           info) {
+      switch (info.param) {
+        case nimble::StripeGroup::EncodingLayout::kRaw:
+          return "Raw";
+        case nimble::StripeGroup::EncodingLayout::kStreamMajor:
+          return "StreamMajor";
+      }
+      return "Unknown";
+    });
 
 TEST_P(VeloxReaderTest, readComplexData) {
   auto type = velox::ROW({

--- a/dwio/nimble/velox/tests/VeloxWriterTest.cpp
+++ b/dwio/nimble/velox/tests/VeloxWriterTest.cpp
@@ -898,8 +898,11 @@ TEST_F(VeloxWriterTest, featureReorderingStreamCollocation) {
     }
 
     auto stripeId = tablet->stripeIdentifier(0);
-    auto offsets = tablet->streamOffsets(stripeId);
-    auto sizes = tablet->streamSizes(stripeId);
+    const auto streamCount = tablet->streamCount(stripeId);
+    std::vector<uint32_t> offsets(streamCount);
+    std::vector<uint32_t> sizes(streamCount);
+    tablet->streamOffsets(stripeId, offsets);
+    tablet->streamSizes(stripeId, sizes);
 
     nimble::VeloxReader reader(readFile.get(), *leafPool_);
     const auto& flatMap =
@@ -2074,9 +2077,9 @@ TEST_F(VeloxWriterTest, omitsAllNonNullRowNullStreams) {
     const auto rootNullOffset = root.nullsDescriptor().offset();
     const auto nestedNullOffset = nested.nullsDescriptor().offset();
     const auto stripeIdentifier = tablet->stripeIdentifier(0);
-    const auto streamSizes = tablet->streamSizes(stripeIdentifier);
-    ASSERT_GT(streamSizes.size(), static_cast<size_t>(rootNullOffset));
-    ASSERT_GT(streamSizes.size(), static_cast<size_t>(nestedNullOffset));
+    const auto streamCount = tablet->streamCount(stripeIdentifier);
+    ASSERT_GT(streamCount, static_cast<uint32_t>(rootNullOffset));
+    ASSERT_GT(streamCount, static_cast<uint32_t>(nestedNullOffset));
 
     std::array<uint32_t, 2> nullStreamOffsets{rootNullOffset, nestedNullOffset};
     auto streamLoaders = tablet->load(stripeIdentifier, nullStreamOffsets);
@@ -2087,13 +2090,13 @@ TEST_F(VeloxWriterTest, omitsAllNonNullRowNullStreams) {
     // or top-level nulls ignored); otherwise it is written and round-trips the
     // top-level nulls. The always-non-null nested row null stream is omitted.
     if (testCase.expectRootNullStreamOmitted) {
-      EXPECT_EQ(0, streamSizes[rootNullOffset]);
+      EXPECT_EQ(0, tablet->streamSize(stripeIdentifier, rootNullOffset));
       EXPECT_EQ(nullptr, streamLoaders[0]);
     } else {
-      EXPECT_GT(streamSizes[rootNullOffset], 0);
+      EXPECT_GT(tablet->streamSize(stripeIdentifier, rootNullOffset), 0);
       EXPECT_NE(nullptr, streamLoaders[0]);
     }
-    EXPECT_EQ(0, streamSizes[nestedNullOffset]);
+    EXPECT_EQ(0, tablet->streamSize(stripeIdentifier, nestedNullOffset));
     EXPECT_EQ(nullptr, streamLoaders[1]);
 
     velox::VectorPtr result;
@@ -2128,7 +2131,7 @@ TEST_F(VeloxWriterTest, chunkedStreamsRowAllNullsNoChunks) {
         // However, when writing stripes, we do not write empty streams.
         // In this case, the integer column is empty, and therefore, omitted.
         ASSERT_EQ(1, tablet.streamCount(stripeIdentifier));
-        EXPECT_LT(0, tablet.streamSizes(stripeIdentifier)[0]);
+        EXPECT_LT(0, tablet.streamSize(stripeIdentifier, 0));
 
         auto streamLoaders =
             tablet.load(stripeIdentifier, std::array<uint32_t, 1>{0});
@@ -2164,7 +2167,7 @@ TEST_F(VeloxWriterTest, chunkedStreamsRowAllNullsWithChunksMinSizeBig) {
         // However, when writing stripes, we do not write empty streams.
         // In this case, the integer column is empty, and therefore, omitted.
         ASSERT_EQ(1, tablet.streamCount(stripeIdentifier));
-        EXPECT_LT(0, tablet.streamSizes(stripeIdentifier)[0]);
+        EXPECT_LT(0, tablet.streamSize(stripeIdentifier, 0));
 
         auto streamLoaders =
             tablet.load(stripeIdentifier, std::array<uint32_t, 1>{0});
@@ -2201,7 +2204,7 @@ TEST_F(VeloxWriterTest, chunkedStreamsRowAllNullsWithChunksMinSizeZero) {
         // However, when writing stripes, we do not write empty streams.
         // In this case, the integer column is empty, and therefore, omitted.
         ASSERT_EQ(1, tablet.streamCount(stripeIdentifier));
-        EXPECT_LT(0, tablet.streamSizes(stripeIdentifier)[0]);
+        EXPECT_LT(0, tablet.streamSize(stripeIdentifier, 0));
 
         auto streamLoaders =
             tablet.load(stripeIdentifier, std::array<uint32_t, 1>{0});
@@ -2243,8 +2246,8 @@ TEST_F(VeloxWriterTest, chunkedStreamsRowSomeNullsNoChunks) {
 
         // We have values in stream 2, so it is not optimized away.
         ASSERT_EQ(2, tablet.streamCount(stripeIdentifier));
-        EXPECT_LT(0, tablet.streamSizes(stripeIdentifier)[0]);
-        EXPECT_LT(0, tablet.streamSizes(stripeIdentifier)[1]);
+        EXPECT_LT(0, tablet.streamSize(stripeIdentifier, 0));
+        EXPECT_LT(0, tablet.streamSize(stripeIdentifier, 1));
 
         auto streamLoaders =
             tablet.load(stripeIdentifier, std::array<uint32_t, 2>{0, 1});
@@ -2291,8 +2294,8 @@ TEST_F(VeloxWriterTest, chunkedStreamsRowSomeNullsWithChunksMinSizeBig) {
         ASSERT_EQ(1, tablet.stripeCount());
 
         ASSERT_EQ(2, tablet.streamCount(stripeIdentifier));
-        EXPECT_LT(0, tablet.streamSizes(stripeIdentifier)[0]);
-        EXPECT_LT(0, tablet.streamSizes(stripeIdentifier)[1]);
+        EXPECT_LT(0, tablet.streamSize(stripeIdentifier, 0));
+        EXPECT_LT(0, tablet.streamSize(stripeIdentifier, 1));
 
         auto streamLoaders =
             tablet.load(stripeIdentifier, std::array<uint32_t, 2>{0, 1});
@@ -2341,8 +2344,8 @@ TEST_F(VeloxWriterTest, chunkedStreamsRowSomeNullsWithChunksMinSizeZero) {
         ASSERT_EQ(1, tablet.stripeCount());
 
         ASSERT_EQ(2, tablet.streamCount(stripeIdentifier));
-        EXPECT_LT(0, tablet.streamSizes(stripeIdentifier)[0]);
-        EXPECT_LT(0, tablet.streamSizes(stripeIdentifier)[1]);
+        EXPECT_LT(0, tablet.streamSize(stripeIdentifier, 0));
+        EXPECT_LT(0, tablet.streamSize(stripeIdentifier, 1));
 
         auto streamLoaders =
             tablet.load(stripeIdentifier, std::array<uint32_t, 2>{0, 1});
@@ -2385,8 +2388,8 @@ TEST_F(VeloxWriterTest, chunkedStreamsRowNoNullsNoChunks) {
         ASSERT_EQ(2, tablet.streamCount(stripeIdentifier));
 
         // When there are no nulls, the nulls stream is omitted.
-        EXPECT_EQ(0, tablet.streamSizes(stripeIdentifier)[0]);
-        EXPECT_LT(0, tablet.streamSizes(stripeIdentifier)[1]);
+        EXPECT_EQ(0, tablet.streamSize(stripeIdentifier, 0));
+        EXPECT_LT(0, tablet.streamSize(stripeIdentifier, 1));
 
         auto streamLoaders =
             tablet.load(stripeIdentifier, std::array<uint32_t, 2>{0, 1});
@@ -2425,8 +2428,8 @@ TEST_F(VeloxWriterTest, chunkedStreamsRowNoNullsWithChunksMinSizeBig) {
         ASSERT_EQ(2, tablet.streamCount(stripeIdentifier));
 
         // When there are no nulls, the nulls stream is omitted.
-        EXPECT_EQ(0, tablet.streamSizes(stripeIdentifier)[0]);
-        EXPECT_LT(0, tablet.streamSizes(stripeIdentifier)[1]);
+        EXPECT_EQ(0, tablet.streamSize(stripeIdentifier, 0));
+        EXPECT_LT(0, tablet.streamSize(stripeIdentifier, 1));
 
         auto streamLoaders =
             tablet.load(stripeIdentifier, std::array<uint32_t, 2>{0, 1});
@@ -2466,8 +2469,8 @@ TEST_F(VeloxWriterTest, chunkedStreamsRowNoNullsWithChunksMinSizeZero) {
         ASSERT_EQ(2, tablet.streamCount(stripeIdentifier));
 
         // When there are no nulls, the nulls stream is omitted.
-        EXPECT_EQ(0, tablet.streamSizes(stripeIdentifier)[0]);
-        EXPECT_LT(0, tablet.streamSizes(stripeIdentifier)[1]);
+        EXPECT_EQ(0, tablet.streamSize(stripeIdentifier, 0));
+        EXPECT_LT(0, tablet.streamSize(stripeIdentifier, 1));
 
         auto streamLoaders =
             tablet.load(stripeIdentifier, std::array<uint32_t, 2>{0, 1});
@@ -2594,8 +2597,8 @@ TEST_F(VeloxWriterTest, chunkedStreamsFlatmapAllNullsNoChunks) {
         // 0: Row nulls stream (expected empty, as all values are not null)
         // 1: Flatmap nulls stream
         ASSERT_EQ(2, tablet.streamCount(stripeIdentifier));
-        EXPECT_EQ(0, tablet.streamSizes(stripeIdentifier)[0]);
-        EXPECT_LT(0, tablet.streamSizes(stripeIdentifier)[1]);
+        EXPECT_EQ(0, tablet.streamSize(stripeIdentifier, 0));
+        EXPECT_LT(0, tablet.streamSize(stripeIdentifier, 1));
 
         auto streamLoaders =
             tablet.load(stripeIdentifier, std::array<uint32_t, 2>{0, 1});
@@ -2638,8 +2641,8 @@ TEST_F(VeloxWriterTest, chunkedStreamsFlatmapAllNullsWithChunksMinSizeBig) {
         // 0: Row nulls stream (expected empty, as all values are not null)
         // 1: Flatmap nulls stream
         ASSERT_EQ(2, tablet.streamCount(stripeIdentifier));
-        EXPECT_EQ(0, tablet.streamSizes(stripeIdentifier)[0]);
-        EXPECT_LT(0, tablet.streamSizes(stripeIdentifier)[1]);
+        EXPECT_EQ(0, tablet.streamSize(stripeIdentifier, 0));
+        EXPECT_LT(0, tablet.streamSize(stripeIdentifier, 1));
 
         auto streamLoaders =
             tablet.load(stripeIdentifier, std::array<uint32_t, 2>{0, 1});
@@ -2683,8 +2686,8 @@ TEST_F(VeloxWriterTest, chunkedStreamsFlatmapAllNullsWithChunksMinSizeZero) {
         // 0: Row nulls stream (expected empty, as all values are not null)
         // 1: Flatmap nulls stream
         ASSERT_EQ(2, tablet.streamCount(stripeIdentifier));
-        EXPECT_EQ(0, tablet.streamSizes(stripeIdentifier)[0]);
-        EXPECT_LT(0, tablet.streamSizes(stripeIdentifier)[1]);
+        EXPECT_EQ(0, tablet.streamSize(stripeIdentifier, 0));
+        EXPECT_LT(0, tablet.streamSize(stripeIdentifier, 1));
 
         auto streamLoaders =
             tablet.load(stripeIdentifier, std::array<uint32_t, 2>{0, 1});
@@ -2741,10 +2744,10 @@ TEST_F(VeloxWriterTest, chunkedStreamsFlatmapSomeNullsNoChunks) {
         // 2: Scalar stream (flatmap value for key 5)
         // 3: Scalar stream (flatmap in-map for key 5)
         ASSERT_EQ(4, tablet.streamCount(stripeIdentifier));
-        EXPECT_EQ(0, tablet.streamSizes(stripeIdentifier)[0]);
-        EXPECT_LT(0, tablet.streamSizes(stripeIdentifier)[1]);
-        EXPECT_LT(0, tablet.streamSizes(stripeIdentifier)[2]);
-        EXPECT_LT(0, tablet.streamSizes(stripeIdentifier)[3]);
+        EXPECT_EQ(0, tablet.streamSize(stripeIdentifier, 0));
+        EXPECT_LT(0, tablet.streamSize(stripeIdentifier, 1));
+        EXPECT_LT(0, tablet.streamSize(stripeIdentifier, 2));
+        EXPECT_LT(0, tablet.streamSize(stripeIdentifier, 3));
 
         auto streamLoaders =
             tablet.load(stripeIdentifier, std::array<uint32_t, 4>{0, 1, 2, 3});
@@ -2820,10 +2823,10 @@ TEST_F(VeloxWriterTest, chunkedStreamsFlatmapSomeNullsWithChunksMinSizeBig) {
         // 2: Scalar stream (flatmap value for key 5)
         // 3: Scalar stream (flatmap in-map for key 5)
         ASSERT_EQ(4, tablet.streamCount(stripeIdentifier));
-        EXPECT_EQ(0, tablet.streamSizes(stripeIdentifier)[0]);
-        EXPECT_LT(0, tablet.streamSizes(stripeIdentifier)[1]);
-        EXPECT_LT(0, tablet.streamSizes(stripeIdentifier)[2]);
-        EXPECT_LT(0, tablet.streamSizes(stripeIdentifier)[3]);
+        EXPECT_EQ(0, tablet.streamSize(stripeIdentifier, 0));
+        EXPECT_LT(0, tablet.streamSize(stripeIdentifier, 1));
+        EXPECT_LT(0, tablet.streamSize(stripeIdentifier, 2));
+        EXPECT_LT(0, tablet.streamSize(stripeIdentifier, 3));
 
         auto streamLoaders =
             tablet.load(stripeIdentifier, std::array<uint32_t, 4>{0, 1, 2, 3});
@@ -2902,10 +2905,10 @@ TEST_F(VeloxWriterTest, chunkedStreamsFlatmapSomeNullsWithChunksMinSizeZero) {
         // 2: Scalar stream (flatmap value for key 5)
         // 3: Scalar stream (flatmap in-map for key 5)
         ASSERT_EQ(4, tablet.streamCount(stripeIdentifier));
-        EXPECT_EQ(0, tablet.streamSizes(stripeIdentifier)[0]);
-        EXPECT_LT(0, tablet.streamSizes(stripeIdentifier)[1]);
-        EXPECT_LT(0, tablet.streamSizes(stripeIdentifier)[2]);
-        EXPECT_LT(0, tablet.streamSizes(stripeIdentifier)[3]);
+        EXPECT_EQ(0, tablet.streamSize(stripeIdentifier, 0));
+        EXPECT_LT(0, tablet.streamSize(stripeIdentifier, 1));
+        EXPECT_LT(0, tablet.streamSize(stripeIdentifier, 2));
+        EXPECT_LT(0, tablet.streamSize(stripeIdentifier, 3));
 
         auto streamLoaders =
             tablet.load(stripeIdentifier, std::array<uint32_t, 4>{0, 1, 2, 3});
@@ -3952,8 +3955,11 @@ class VeloxWriterIndexTest
     for (uint32_t stripeIndex = 0; stripeIndex < tablet.stripeCount();
          ++stripeIndex) {
       const auto stripeIdentifier = tablet.stripeIdentifier(stripeIndex);
-      const auto offsets = tablet.streamOffsets(stripeIdentifier);
-      const auto sizes = tablet.streamSizes(stripeIdentifier);
+      const auto streamCount = tablet.streamCount(stripeIdentifier);
+      std::vector<uint32_t> offsets(streamCount);
+      std::vector<uint32_t> sizes(streamCount);
+      tablet.streamOffsets(stripeIdentifier, offsets);
+      tablet.streamSizes(stripeIdentifier, sizes);
 
       std::map<std::pair<uint32_t, uint32_t>, uint64_t> duplicateGroups;
       for (size_t streamIndex = 0; streamIndex < sizes.size(); ++streamIndex) {


### PR DESCRIPTION
Summary:

Adds an opt-in, backward-compatible StripeGroup metadata layout that encodes per-stream offsets/sizes independently instead of one raw flat `uint32` array per group.

**Backward compatibility.** The layout is recorded in a file-level `columnar.stripe_group_format` optional section as a decimal-text enum value (`StripeGroupMetadataFormat`: `Raw = 0` default, `Encoded2D = 1`). The section is written only for non-Raw files, so an absent section means Raw. Raw stays byte-identical to the existing layout and remains the default, so old and new readers keep reading all existing and default files. Opt in via `VeloxWriterOptions::experimentalStripeGroupMetadataFormat`; the encoded layout is self-describing and read only by new readers.

**Per-stream encoding (Encoded2D).** When enabled, each leaf stream's `stripeCount`-length offset/size array is encoded on its own, so every stream picks the encoding best fit to its distribution (absent stream -> `Constant`, bounded range -> `FixedBitWidth`) instead of one global bit width driven by the worst stream/stripe combo. The candidate set and read-cost weights are configurable via `VeloxWriterOptions::experimentalStripeGroupMetadataReadFactors` (default `{Constant, Trivial, FixedBitWidth}` @ 1.0). Only encodings with O(1) stateless point access via `EncodingView::readAt()` are valid, so the reader does every point access as a direct read with zero per-stream auxiliary state.

**Encoding distribution (measured with the original candidate set, incl. `Dictionary`).** Regenerated fb_public 5-rows cluster-index file: 209,070 rows, 59,832 stripes, 24 stripe groups (~250 streams/group), StripeGroup metadata 27.5 MB.
- Offsets: 63.2% `Constant`, 36.8% `FixedBitWidth`, 0% `Dictionary`.
- Sizes: 51.5% `FixedBitWidth`, 33.6% `Constant`, 14.9% `Dictionary`.
- No `Trivial` (raw) fallback on either side -- every array got a compact encoding.

**`Dictionary` excluded from the default set (per review).** An A/B via the read-factors option showed `Dictionary` shrinks StripeGroup metadata from 29.5 MB to 27.5 MB (-7.4%) on this file -- it only helps the size arrays (the 14.9% above; few distinct values over a wide numeric range). Despite the win, `Dictionary` is excluded from the shipped default candidate set for simplicity; the shipped default therefore produces ~29.5 MB here, with those size arrays falling back to `FixedBitWidth`. `Dictionary` remains `EncodingView`-supported, so callers can re-enable it explicitly via `experimentalStripeGroupMetadataReadFactors`.

Reviewed By: xiaoxmeng

Differential Revision: D106748611
