### PR TITLE
fix(encoding): Explicit ctors for Huffman `TreeNode`/`QueueEntry` (OSS build) (#997)

### DIFF
--- a/dwio/nimble/encodings/HuffmanEncoding.h
+++ b/dwio/nimble/encodings/HuffmanEncoding.h
@@ -119,6 +119,18 @@ class HuffmanEncoding final
     int32_t left;
     int32_t right;
     int32_t symbol;
+
+    // Declaring the explicit constructor below removes the implicit default
+    // constructor; keep TreeNode default-constructible because
+    // Vector<TreeNode>'s debug-only placeholder_ member (see Vector.h) odr-uses
+    // it under mode/dev.
+    TreeNode() = default;
+
+    // Explicit constructor so emplace_back() works under compilers that do not
+    // apply parenthesized aggregate initialization (P0960) inside construct_at
+    // / placement-new (e.g. the OSS GCC build).
+    TreeNode(uint64_t frequency, int32_t left, int32_t right, int32_t symbol)
+        : frequency(frequency), left(left), right(right), symbol(symbol) {}
   };
 
   // Maps tableLog_ lookahead bits to an alphabet index and the number of bits
@@ -334,6 +346,13 @@ std::string_view HuffmanEncoding<T>::encode(
   struct QueueEntry {
     uint64_t frequency;
     int32_t node;
+
+    // Explicit constructor so priority_queue::emplace() works under compilers
+    // that do not apply parenthesized aggregate initialization (P0960) inside
+    // construct_at (e.g. the OSS GCC build).
+    QueueEntry(uint64_t frequency, int32_t node)
+        : frequency(frequency), node(node) {}
+
     bool operator>(const QueueEntry& other) const {
       // Node order makes equal-frequency trees deterministic.
       return frequency != other.frequency ? frequency > other.frequency


### PR DESCRIPTION
Summary:

The OSS GCC build fails compiling `HuffmanEncoding<T>::encode`: `TreeNode` and
`QueueEntry` are aggregates with no constructor, and `Vector::emplace_back` /
`std::priority_queue::emplace` construct them with parenthesized args inside
placement-new / `std::construct_at`. The OSS toolchain does not apply
parenthesized aggregate initialization (P0960) there, so no matching
constructor is found. Add explicit constructors so all four emplace call
sites compile under every toolchain. Internal build + Huffman tests (13/0)
pass; behavior unchanged.

Reviewed By: xiaoxmeng

Differential Revision: D112967794


