### PR TITLE
feat: return vectors with projected type from deserializer (#998)

### DIFF
--- a/dwio/nimble/serializer/Deserializer.cpp
+++ b/dwio/nimble/serializer/Deserializer.cpp
@@ -20,6 +20,7 @@
 #include "dwio/nimble/velox/SchemaReader.h"
 #include "dwio/nimble/velox/SchemaUtils.h"
 #include "folly/Likely.h"
+#include "folly/container/F14Set.h"
 #include "velox/buffer/Buffer.h"
 #include "velox/dwio/common/ColumnSelector.h"
 #include "velox/dwio/common/TypeWithId.h"
@@ -651,7 +652,7 @@ const StreamDescriptor& getMainDescriptor(const Type& type) {
   }
 }
 
-void checkColumnProjectionSubfield(
+bool checkColumnProjectionSubfield(
     const RowType& row,
     const Deserializer::Subfield& subfield) {
   const auto& path = subfield.path();
@@ -666,10 +667,19 @@ void checkColumnProjectionSubfield(
       subfield);
   const auto* nestedType = row.childAt(childIndex.value()).get();
   for (size_t i = 1; i < path.size(); ++i) {
-    NIMBLE_USER_CHECK(
-        !nestedType->isFlatMap(),
-        "Column projection deserialize does not support FlatMap feature projection: {}",
-        subfield);
+    if (nestedType->isFlatMap()) {
+      NIMBLE_USER_CHECK(
+          path[i]->is(velox::common::SubfieldKind::kStringSubscript) ||
+              path[i]->is(velox::common::SubfieldKind::kLongSubscript),
+          "FlatMap projection requires a string or integer key: {}",
+          subfield);
+      NIMBLE_USER_CHECK_EQ(
+          i + 1,
+          path.size(),
+          "Nested projection inside a FlatMap value is not supported: {}",
+          subfield);
+      return true;
+    }
     NIMBLE_USER_CHECK(
         path[i]->is(velox::common::SubfieldKind::kNestedField),
         "Column projection deserialize only supports named fields. Path: {}, element: {}",
@@ -689,12 +699,87 @@ void checkColumnProjectionSubfield(
         subfield);
     nestedType = nestedType->asRow().childAt(childIndex.value()).get();
   }
+  return false;
 }
 
 } // namespace
 
+Deserializer::ProjectedField* Deserializer::ProjectedField::ensureChild(
+    const std::string& name) {
+  auto& selectedChild = children[name];
+  if (selectedChild == nullptr) {
+    selectedChild = std::make_unique<ProjectedField>();
+  }
+  return selectedChild.get();
+}
+
+velox::TypePtr Deserializer::buildProjectedType(
+    const velox::TypePtr& source,
+    const ProjectedField& selected,
+    Deserializer::OutputProjection& projection) {
+  if (selected.selectWholeField) {
+    return source;
+  }
+  const auto& sourceRow = source->asRow();
+  std::vector<std::string> names;
+  std::vector<velox::TypePtr> types;
+  names.reserve(selected.children.size());
+  types.reserve(selected.children.size());
+  std::vector<std::string> selectedNames;
+  selectedNames.reserve(selected.children.size());
+  for (const auto& [name, _] : selected.children) {
+    selectedNames.emplace_back(name);
+  }
+  std::sort(selectedNames.begin(), selectedNames.end());
+  for (const auto& name : selectedNames) {
+    const auto sourceChannel = sourceRow.getChildIdx(name);
+    const auto& selectedChild = *selected.children.at(name);
+    projection.identityProjections.emplace_back(sourceChannel, names.size());
+    names.emplace_back(name);
+    auto& childProjection = projection.childProjections.emplace_back();
+    if (selectedChild.selectWholeField) {
+      types.emplace_back(sourceRow.childAt(sourceChannel));
+    } else {
+      types.emplace_back(buildProjectedType(
+          sourceRow.childAt(sourceChannel), selectedChild, childProjection));
+    }
+  }
+  return velox::ROW(std::move(names), std::move(types));
+}
+
+velox::RowTypePtr Deserializer::buildProjectedType(
+    const velox::RowTypePtr& sourceType,
+    const std::vector<Deserializer::Subfield>& selectedSubfields,
+    Deserializer::OutputProjection& outputProjection) {
+  ProjectedField root;
+  for (const auto& subfield : selectedSubfields) {
+    auto* selected = root.ensureChild(subfield.baseName());
+    const auto& path = subfield.path();
+    for (size_t i = 1; i < path.size(); ++i) {
+      if (path[i]->is(velox::common::SubfieldKind::kStringSubscript) ||
+          path[i]->is(velox::common::SubfieldKind::kLongSubscript)) {
+        NIMBLE_CHECK_EQ(
+            i,
+            1,
+            "FlatMap key projection is only supported for top-level fields: {}",
+            subfield);
+        selected->selectWholeField = true;
+        break;
+      }
+      const auto& name =
+          path[i]->asChecked<velox::common::Subfield::NestedField>()->name();
+      selected = selected->ensureChild(name);
+    }
+    selected->selectWholeField = true;
+  }
+
+  return velox::checkedPointerCast<const velox::RowType>(
+      buildProjectedType(sourceType, root, outputProjection));
+}
+
 FieldReaderParams Deserializer::createFieldReaderParams() const {
   FieldReaderParams params;
+  params.flatMapFeatureSelector = flatMapFeatureSelector_;
   params.decodeExecutor = options_.decodeExecutor;
   params.maxDecodeParallelism = options_.maxDecodeParallelism;
   params.minStreamsPerDecodeUnit = options_.minStreamsPerDecodeUnit;
@@ -762,27 +847,74 @@ Deserializer::Deserializer(
     : schema_{std::move(schema)},
       pool_{pool},
       options_{std::move(options)},
-      columnProjectionEnabled_{!selectedSubfields.empty()} {
+      hasColumnProjection_{!selectedSubfields.empty()} {
   auto veloxType = convertToVeloxType(*schema_);
-  if (selectedSubfields.empty()) {
-    initialize(velox::dwio::common::TypeWithId::create(veloxType), [](auto) {
-      return true;
-    });
+  if (!hasColumnProjection_) {
+    initialize(
+        velox::dwio::common::TypeWithId::create(veloxType),
+        [](uint32_t) { return true; });
     return;
   }
 
-  auto rowType = velox::checkedPointerCast<const velox::RowType>(veloxType);
+  initializeColumnProjection(veloxType, selectedSubfields);
+}
+
+void Deserializer::initializeColumnProjection(
+    const velox::TypePtr& veloxType,
+    const std::vector<Deserializer::Subfield>& selectedSubfields) {
+  NIMBLE_CHECK(hasColumnProjection_, "Column projection is not enabled");
+  const auto rowType =
+      velox::checkedPointerCast<const velox::RowType>(veloxType);
   std::vector<std::string> projectedColumnPaths;
+  folly::F14FastSet<std::string> selectedSubfieldSet;
+  folly::F14FastSet<std::string> projectedColumnPathSet;
+  folly::F14FastMap<std::string, folly::F14FastSet<std::string>>
+      flatMapFeatureSets;
   projectedColumnPaths.reserve(selectedSubfields.size());
+  selectedSubfieldSet.reserve(selectedSubfields.size());
+  projectedColumnPathSet.reserve(selectedSubfields.size());
+  flatMapFeatureSets.reserve(selectedSubfields.size());
   for (const auto& subfield : selectedSubfields) {
-    checkColumnProjectionSubfield(schema_->asRow(), subfield);
-    projectedColumnPaths.emplace_back(subfield.toString());
+    const bool selectsFlatMapKey =
+        checkColumnProjectionSubfield(schema_->asRow(), subfield);
+    const auto& path = subfield.path();
+    const auto selectedPath = subfield.toString();
+    NIMBLE_USER_CHECK(
+        selectedSubfieldSet.insert(selectedPath).second,
+        "Duplicate column projection subfield: {}",
+        subfield);
+    std::string columnPath;
+    if (selectsFlatMapKey) {
+      columnPath = subfield.baseName();
+      auto feature = path[1]->is(velox::common::SubfieldKind::kStringSubscript)
+          ? path[1]
+                ->asChecked<velox::common::Subfield::StringSubscript>()
+                ->index()
+          : std::to_string(
+                path[1]
+                    ->asChecked<velox::common::Subfield::LongSubscript>()
+                    ->index());
+      const bool newFlatMapFeature =
+          flatMapFeatureSets[columnPath].insert(feature).second;
+      NIMBLE_USER_CHECK(
+          newFlatMapFeature, "Duplicate FlatMap projection key: {}", subfield);
+      flatMapFeatureSelector_[columnPath].features.emplace_back(
+          std::move(feature));
+    } else {
+      columnPath = subfield.toString();
+    }
+    const bool newColumnPath = projectedColumnPathSet.insert(columnPath).second;
+    if (newColumnPath) {
+      projectedColumnPaths.emplace_back(columnPath);
+    }
   }
 
+  outputProjection_ = std::make_unique<OutputProjection>();
+  outputType_ =
+      buildProjectedType(rowType, selectedSubfields, *outputProjection_);
   auto selector = std::make_shared<velox::dwio::common::ColumnSelector>(
       rowType, projectedColumnPaths);
-  auto schemaWithId = selector->getSchemaWithId();
-  initialize(schemaWithId, [selector](auto nodeId) {
+  initialize(selector->getSchemaWithId(), [selector](auto nodeId) {
     return selector->shouldReadNode(nodeId);
   });
 }
@@ -796,6 +928,16 @@ void Deserializer::initialize(
   std::vector<uint32_t> offsets;
   rootFactory_ = FieldReaderFactory::create(
       params, schema_, schemaWithId, offsets, isSelected, pool_);
+
+  if (hasColumnProjection_) {
+    const auto maxSelectedOffset =
+        *std::max_element(offsets.begin(), offsets.end());
+    selectedStreamOffsetFlags_.resize(maxSelectedOffset + 1, false);
+    for (const auto offset : offsets) {
+      selectedStreamOffsetFlags_[offset] = true;
+    }
+  }
+
   SchemaReader::traverseSchema(schema_, [this](auto depth, auto& type, auto&) {
     createDeserializersForType(type, depth);
   });
@@ -812,13 +954,6 @@ void Deserializer::initialize(
     deserializers_[offset] = decoder.get();
   }
 
-  if (columnProjectionEnabled_) {
-    selectedStreamOffsetFlags_.resize(maxOffset + 1, false);
-    for (const auto offset : offsets) {
-      NIMBLE_CHECK_LE(offset, maxOffset, "Unexpected selected stream offset");
-      selectedStreamOffsetFlags_[offset] = true;
-    }
-  }
   // Pre-size stream presence-tracking state once. Both vectors are bounded
   // by maxOffset because every value-stream anchor offset is a Type main
   // descriptor offset already in deserializerMap_. Sizing here (rather than
@@ -856,12 +991,14 @@ Deserializer::~Deserializer() = default;
 void Deserializer::createDeserializersForType(
     const Type& type,
     uint32_t depth) {
-  deserializerMap_[getMainDescriptor(type).offset()] =
-      std::make_unique<SegmentedStreamDecoder>(
-          &type,
-          /*isInMapStream=*/false,
-          options_.bufferPoolCapacity,
-          pool_);
+  const auto streamOffset = getMainDescriptor(type).offset();
+  if (shouldDecodeStream(streamOffset)) {
+    deserializerMap_[streamOffset] = std::make_unique<SegmentedStreamDecoder>(
+        &type,
+        /*isInMapStream=*/false,
+        options_.bufferPoolCapacity,
+        pool_);
+  }
   // FlatMap is only supported at depth 1 (top-level columns). Register each
   // child in-map stream so it is decoded like other physical streams.
   if (type.isFlatMap()) {
@@ -870,6 +1007,9 @@ void Deserializer::createDeserializersForType(
     auto& flatMap = type.asFlatMap();
     for (size_t i = 0; i < flatMap.childrenCount(); ++i) {
       const auto inMapOffset = flatMap.inMapDescriptorAt(i).offset();
+      if (!shouldDecodeStream(inMapOffset)) {
+        continue;
+      }
       deserializerMap_[inMapOffset] = std::make_unique<SegmentedStreamDecoder>(
           &type,
           /*isInMapStream=*/true,
@@ -902,6 +1042,54 @@ void Deserializer::appendToOutput(
   output->append(decoded.get());
 }
 
+velox::VectorPtr Deserializer::projectOutput(velox::VectorPtr&& decoded) const {
+  if (!hasColumnProjection_) {
+    return std::move(decoded);
+  }
+  NIMBLE_CHECK_NOT_NULL(
+      outputProjection_, "Output projection must be initialized");
+  NIMBLE_CHECK_NOT_NULL(outputType_, "Output type must be initialized");
+
+  return projectOutput(std::move(decoded), outputType_, *outputProjection_);
+}
+
+velox::VectorPtr Deserializer::projectOutput(
+    velox::VectorPtr&& source,
+    const velox::TypePtr& projectedType,
+    const OutputProjection& projection) const {
+  auto* decodedRow = source->asChecked<velox::RowVector>();
+  const auto& projectedRowType = projectedType->asRow();
+  NIMBLE_CHECK_EQ(
+      projection.identityProjections.size(), projectedRowType.size());
+  NIMBLE_CHECK_EQ(projection.childProjections.size(), projectedRowType.size());
+  std::vector<velox::VectorPtr> children(projectedRowType.size());
+  for (const auto& identity : projection.identityProjections) {
+    const auto inputChannel = identity.inputChannel;
+    const auto outputChannel = identity.outputChannel;
+    const auto& childProjection = projection.childProjections[outputChannel];
+    auto decodedChild = decodedRow->childAt(inputChannel);
+    NIMBLE_CHECK_NOT_NULL(
+        decodedChild,
+        "Projected field was not decoded: {}",
+        projectedRowType.nameOf(outputChannel));
+    if (childProjection.identityProjections.empty()) {
+      children[outputChannel] = std::move(decodedChild);
+    } else {
+      children[outputChannel] = projectOutput(
+          std::move(decodedChild),
+          projectedRowType.childAt(outputChannel),
+          childProjection);
+    }
+  }
+  return std::make_shared<velox::RowVector>(
+      pool_,
+      projectedType,
+      decodedRow->nulls(),
+      decodedRow->size(),
+      std::move(children),
+      std::nullopt);
+}
+
 void Deserializer::decodeRun(DecodeRun& run, velox::VectorPtr& output) const {
   if (FOLLY_UNLIKELY(run.batches == 0)) {
     return;
@@ -909,6 +1097,7 @@ void Deserializer::decodeRun(DecodeRun& run, velox::VectorPtr& output) const {
 
   velox::VectorPtr decoded;
   reader_->next(run.rows, decoded, nullptr);
+  decoded = projectOutput(std::move(decoded));
   run = {};
   appendToOutput(std::move(decoded), output);
   reader_->reset();
@@ -929,8 +1118,7 @@ void Deserializer::appendStreamSegments(
     if (FOLLY_UNLIKELY(offset > maxStreamOffset)) {
       return;
     }
-    if (FOLLY_UNLIKELY(
-            columnProjectionEnabled_ && !selectedStreamOffsetFlags_[offset])) {
+    if (FOLLY_UNLIKELY(!shouldDecodeStream(offset))) {
       return;
     }
     if (hasInMapChildren) {

--- a/dwio/nimble/serializer/Deserializer.h
+++ b/dwio/nimble/serializer/Deserializer.h
@@ -18,6 +18,8 @@
 #include <cstdint>
 #include <functional>
 #include <limits>
+#include <memory>
+#include <string>
 #include <vector>
 
 #include "dwio/nimble/serializer/Options.h"
@@ -59,9 +61,8 @@ class Deserializer {
 
   /// Builds a deserializer that reads selected subfields from a Row schema.
   /// Empty selectedSubfields reads all fields.
-  /// Output keeps the original Row type, but fields not reached by
-  /// selectedSubfields are left unset. This does not support FlatMap feature
-  /// projection, schema compaction, or stream offset remapping.
+  /// Output Row types contain only fields reached by selectedSubfields, ordered
+  /// lexicographically by field name at each projected Row level.
   Deserializer(
       std::shared_ptr<const Type> schema,
       const std::vector<Subfield>& selectedSubfields,
@@ -83,14 +84,28 @@ class Deserializer {
 
  private:
   // Invoked by constructors to build parser, reader factory, reader, and stream
-  // decoders. `isSelected` is keyed by schemaWithId node id.
+  // decoders from the requested schema and field selection.
   void initialize(
       const std::shared_ptr<const velox::dwio::common::TypeWithId>&
           schemaWithId,
       const std::function<bool(uint32_t)>& isSelected);
 
+  // Builds projected output type, selected column paths, FlatMap key filters,
+  // then initializes readers for the projected schema.
+  void initializeColumnProjection(
+      const velox::TypePtr& veloxType,
+      const std::vector<Subfield>& selectedSubfields);
+
   // Creates deserializers for a type and its FlatMap inMap streams.
   void createDeserializersForType(const Type& type, uint32_t depth);
+
+  // Projection keeps only stream offsets selected by the reader tree. When
+  // projection is disabled, every stream is selected.
+  bool shouldDecodeStream(offset_size streamOffset) const {
+    return !hasColumnProjection_ ||
+        (streamOffset < selectedStreamOffsetFlags_.size() &&
+         selectedStreamOffsetFlags_[streamOffset]);
+  }
 
   // Creates FieldReaderParams from DeserializerOptions, including decode
   // executor, parallel decode threshold, and flatmap-as-struct settings.
@@ -105,6 +120,48 @@ class Deserializer {
     uint32_t rows{0};
     uint32_t batches{0};
   };
+
+  // Channel mapping for one projected Row child. The reader decodes selected
+  // fields into their original source channels; projection wraps them into the
+  // compact output Row using outputChannel.
+  struct IdentityProjection {
+    IdentityProjection(
+        velox::column_index_t inputChannel,
+        velox::column_index_t outputChannel)
+        : inputChannel{inputChannel}, outputChannel{outputChannel} {}
+
+    velox::column_index_t inputChannel;
+    velox::column_index_t outputChannel;
+  };
+
+  // Maps projected Row children to decoded channels. Nested plans are present
+  // only for recursively projected Row children.
+  struct OutputProjection {
+    std::vector<IdentityProjection> identityProjections;
+    std::vector<OutputProjection> childProjections;
+  };
+
+  struct ProjectedField {
+    ProjectedField* ensureChild(const std::string& name);
+
+    // A path ending at this node selects its complete source type; otherwise,
+    // only the descendants in children are retained.
+    bool selectWholeField{false};
+    folly::F14FastMap<std::string, std::unique_ptr<ProjectedField>> children;
+  };
+
+  // Recursively builds a projected field type and decoded-input channel
+  // mapping.
+  static velox::TypePtr buildProjectedType(
+      const velox::TypePtr& source,
+      const ProjectedField& selected,
+      OutputProjection& projection);
+
+  // Builds the projected type and its decoded-input channel mapping.
+  static velox::RowTypePtr buildProjectedType(
+      const velox::RowTypePtr& sourceType,
+      const std::vector<Subfield>& selectedSubfields,
+      OutputProjection& outputProjection);
 
   // Adds one serialized batch to the current decode run, decoding before and
   // after batches that require a null barrier.
@@ -124,6 +181,16 @@ class Deserializer {
   void appendToOutput(velox::VectorPtr&& decoded, velox::VectorPtr& output)
       const;
 
+  // Wraps selected Row children in the projected Row type after physical
+  // decoding. Returns decoded unchanged when projection is disabled.
+  velox::VectorPtr projectOutput(velox::VectorPtr&& decoded) const;
+
+  // Applies the projected Row type and source-to-output channel mapping.
+  velox::VectorPtr projectOutput(
+      velox::VectorPtr&& source,
+      const velox::TypePtr& projectedType,
+      const OutputProjection& projection) const;
+
   // Decodes the pending non-barrier batch run and resets reader state for the
   // next run.
   void decodeRun(DecodeRun& run, velox::VectorPtr& output) const;
@@ -135,9 +202,14 @@ class Deserializer {
 
   // If column projection is enabled, only selected fields in the schema will be
   // deserialized.
-  const bool columnProjectionEnabled_;
+  const bool hasColumnProjection_;
 
   // --- Non-const members (assigned in constructor body) ---
+  // Output Row type used only by projected reads to wrap decoded children.
+  velox::RowTypePtr outputType_;
+  std::unique_ptr<OutputProjection> outputProjection_;
+  // Requested keys for projected top-level FlatMap fields.
+  folly::F14FastMap<std::string, FeatureSelection> flatMapFeatureSelector_;
   std::unique_ptr<FieldReaderFactory> rootFactory_;
   std::unique_ptr<FieldReader> reader_;
   mutable std::unique_ptr<serde::StreamDataParser> parser_;

--- a/dwio/nimble/serializer/benchmarks/DeserializerBenchmark.cpp
+++ b/dwio/nimble/serializer/benchmarks/DeserializerBenchmark.cpp
@@ -1,0 +1,131 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <folly/Benchmark.h>
+#include <folly/init/Init.h>
+
+#include "dwio/nimble/serializer/Deserializer.h"
+#include "dwio/nimble/serializer/Serializer.h"
+#include "dwio/nimble/velox/OrderedRanges.h"
+#include "dwio/nimble/velox/SchemaReader.h"
+#include "velox/common/memory/Memory.h"
+#include "velox/vector/ComplexVector.h"
+#include "velox/vector/FlatVector.h"
+
+namespace facebook::nimble {
+namespace {
+
+constexpr velox::vector_size_t kNumRows = 10'000;
+constexpr size_t kNumColumns = 100;
+constexpr size_t kProjectionStride = 20;
+
+struct BenchmarkState {
+  std::string serialized;
+  std::shared_ptr<const Type> schema;
+  std::vector<Deserializer::Subfield> selectedSubfields;
+};
+
+BenchmarkState prepareBenchmark() {
+  auto pool = velox::memory::memoryManager()->addLeafPool("prepare_projection");
+  std::vector<std::string> names;
+  std::vector<velox::TypePtr> types;
+  std::vector<velox::VectorPtr> children;
+  names.reserve(kNumColumns);
+  types.reserve(kNumColumns);
+  children.reserve(kNumColumns);
+
+  for (size_t column = 0; column < kNumColumns; ++column) {
+    names.emplace_back("column_" + std::to_string(column));
+    types.emplace_back(velox::BIGINT());
+    auto child = velox::BaseVector::create<velox::FlatVector<int64_t>>(
+        velox::BIGINT(), kNumRows, pool.get());
+    for (velox::vector_size_t row = 0; row < kNumRows; ++row) {
+      child->set(row, static_cast<int64_t>(column * kNumRows + row));
+    }
+    children.emplace_back(std::move(child));
+  }
+
+  auto input = std::make_shared<velox::RowVector>(
+      pool.get(),
+      velox::ROW(std::move(names), std::move(types)),
+      /*nulls=*/nullptr,
+      kNumRows,
+      std::move(children));
+  Serializer serializer{
+      SerializerOptions{.version = SerializationVersion::kSerialization},
+      input->type(),
+      pool.get()};
+  const auto serialized =
+      serializer.serialize(input, OrderedRanges::of(0, input->size()));
+
+  BenchmarkState state{
+      .serialized = std::string{serialized},
+      .schema =
+          SchemaReader::getSchema(serializer.schemaBuilder().schemaNodes())};
+  for (size_t column = 0; column < kNumColumns; column += kProjectionStride) {
+    state.selectedSubfields.emplace_back("column_" + std::to_string(column));
+  }
+  return state;
+}
+
+void constructProjectedDeserializer(uint32_t iters) {
+  static const auto state = prepareBenchmark();
+  auto pool =
+      velox::memory::memoryManager()->addLeafPool("construct_projection");
+  while (iters-- > 0) {
+    Deserializer deserializer{
+        state.schema,
+        state.selectedSubfields,
+        pool.get(),
+        DeserializerOptions{.hasHeader = true}};
+    folly::doNotOptimizeAway(deserializer);
+  }
+}
+
+void constructAndDeserialize(uint32_t iters) {
+  static const auto state = prepareBenchmark();
+  auto pool = velox::memory::memoryManager()->addLeafPool("decode_projection");
+  while (iters-- > 0) {
+    Deserializer deserializer{
+        state.schema,
+        state.selectedSubfields,
+        pool.get(),
+        DeserializerOptions{.hasHeader = true}};
+    velox::VectorPtr output;
+    deserializer.deserialize(state.serialized, output);
+    folly::doNotOptimizeAway(output);
+  }
+}
+
+BENCHMARK(ConstructDeserializerWithProjection, iters) {
+  constructProjectedDeserializer(iters);
+}
+
+BENCHMARK_DRAW_LINE();
+
+BENCHMARK(ConstructAndDeserializeWithProjection, iters) {
+  constructAndDeserialize(iters);
+}
+
+} // namespace
+} // namespace facebook::nimble
+
+int main(int argc, char** argv) {
+  folly::Init init{&argc, &argv};
+  facebook::velox::memory::MemoryManager::initialize({});
+  folly::runBenchmarks();
+  return 0;
+}

--- a/dwio/nimble/serializer/tests/ProjectorTest.cpp
+++ b/dwio/nimble/serializer/tests/ProjectorTest.cpp
@@ -649,7 +649,7 @@ INSTANTIATE_TEST_SUITE_P(
 // Non-parameterized tests for special cases.
 class ProjectorTest : public ProjectorTestBase {};
 
-TEST_F(ProjectorTest, columnProjectionDeserializerKeepsOriginalShape) {
+TEST_F(ProjectorTest, columnProjectionDeserializerBuildsProjectedType) {
   auto type = ROW({
       {"a", INTEGER()},
       {"b", BIGINT()},
@@ -677,17 +677,14 @@ TEST_F(ProjectorTest, columnProjectionDeserializerKeepsOriginalShape) {
   ASSERT_EQ(output->size(), 3);
   auto* row = output->as<RowVector>();
   ASSERT_NE(row, nullptr);
-  ASSERT_EQ(row->children().size(), 3);
+  EXPECT_TRUE(output->type()->equivalent(*ROW({{"b", BIGINT()}})));
+  ASSERT_EQ(row->children().size(), 1);
 
-  EXPECT_EQ(row->childAt(0), nullptr);
-
-  auto* b = row->childAt(1)->as<FlatVector<int64_t>>();
+  auto* b = row->childAt(0)->as<FlatVector<int64_t>>();
   ASSERT_NE(b, nullptr);
   EXPECT_EQ(b->valueAt(0), 100);
   EXPECT_EQ(b->valueAt(1), 200);
   EXPECT_EQ(b->valueAt(2), 300);
-
-  EXPECT_EQ(row->childAt(2), nullptr);
 }
 
 TEST_F(ProjectorTest, columnProjectionDeserializerCanBeReused) {
@@ -718,8 +715,8 @@ TEST_F(ProjectorTest, columnProjectionDeserializerCanBeReused) {
   deserializer.deserialize(makeInput({1, 2}, {100, 200}), firstOutput);
   auto* firstRow = firstOutput->as<RowVector>();
   ASSERT_NE(firstRow, nullptr);
-  EXPECT_EQ(firstRow->childAt(0), nullptr);
-  auto* firstB = firstRow->childAt(1)->as<FlatVector<int64_t>>();
+  EXPECT_TRUE(firstOutput->type()->equivalent(*ROW({{"b", BIGINT()}})));
+  auto* firstB = firstRow->childAt(0)->as<FlatVector<int64_t>>();
   ASSERT_NE(firstB, nullptr);
   EXPECT_EQ(firstB->valueAt(0), 100);
   EXPECT_EQ(firstB->valueAt(1), 200);
@@ -728,8 +725,8 @@ TEST_F(ProjectorTest, columnProjectionDeserializerCanBeReused) {
   deserializer.deserialize(makeInput({3, 4, 5}, {300, 400, 500}), secondOutput);
   auto* secondRow = secondOutput->as<RowVector>();
   ASSERT_NE(secondRow, nullptr);
-  EXPECT_EQ(secondRow->childAt(0), nullptr);
-  auto* secondB = secondRow->childAt(1)->as<FlatVector<int64_t>>();
+  EXPECT_TRUE(secondOutput->type()->equivalent(*ROW({{"b", BIGINT()}})));
+  auto* secondB = secondRow->childAt(0)->as<FlatVector<int64_t>>();
   ASSERT_NE(secondB, nullptr);
   EXPECT_EQ(secondB->valueAt(0), 300);
   EXPECT_EQ(secondB->valueAt(1), 400);
@@ -775,20 +772,18 @@ TEST_F(ProjectorTest, columnProjectionDeserializerProjectsNestedFields) {
   ASSERT_EQ(output->size(), 2);
   auto* row = output->as<RowVector>();
   ASSERT_NE(row, nullptr);
-  ASSERT_EQ(row->children().size(), 2);
+  EXPECT_TRUE(output->type()->equivalent(
+      *ROW({{"outer", ROW({{"inner1", INTEGER()}})}})));
+  ASSERT_EQ(row->children().size(), 1);
 
   auto* outerRow = row->childAt(0)->as<RowVector>();
   ASSERT_NE(outerRow, nullptr);
-  ASSERT_EQ(outerRow->children().size(), 2);
+  ASSERT_EQ(outerRow->children().size(), 1);
 
   auto* inner1 = outerRow->childAt(0)->as<FlatVector<int32_t>>();
   ASSERT_NE(inner1, nullptr);
   EXPECT_EQ(inner1->valueAt(0), 10);
   EXPECT_EQ(inner1->valueAt(1), 20);
-
-  EXPECT_EQ(outerRow->childAt(1), nullptr);
-
-  EXPECT_EQ(row->childAt(1), nullptr);
 }
 
 TEST_F(
@@ -831,6 +826,225 @@ TEST_F(
   EXPECT_EQ(b->valueAt(0), 100);
   EXPECT_EQ(b->valueAt(1), 200);
   EXPECT_EQ(b->valueAt(2), 300);
+}
+
+TEST_F(ProjectorTest, columnProjectionDeserializerSelectsAllFieldsExplicitly) {
+  auto type = ROW({
+      {"a", INTEGER()},
+      {"b", BIGINT()},
+  });
+  auto vec = makeSimpleRowVector(
+      {"a", "b"},
+      {
+          makeIntVector<int32_t>({1, 2, 3}),
+          makeIntVector<int64_t>({100, 200, 300}),
+      });
+  auto serialized =
+      serialize(vec, type, {.version = SerializationVersion::kSerialization});
+  auto inputSchema =
+      getNimbleSchema(type, {.version = SerializationVersion::kSerialization});
+
+  Deserializer deserializer{
+      inputSchema, makeSubfields({"a", "b"}), pool_.get(), {.hasHeader = true}};
+  VectorPtr output;
+  deserializer.deserialize(serialized, output);
+
+  ASSERT_NE(output, nullptr);
+  EXPECT_TRUE(output->type()->equivalent(*type));
+  EXPECT_TRUE(output->equalValueAt(vec.get(), 0, 0));
+  EXPECT_TRUE(output->equalValueAt(vec.get(), 1, 1));
+  EXPECT_TRUE(output->equalValueAt(vec.get(), 2, 2));
+}
+
+TEST_F(ProjectorTest, columnProjectionDeserializerOrdersFieldsByName) {
+  auto type = ROW({
+      {"c", VARCHAR()},
+      {"a", INTEGER()},
+      {"b", BIGINT()},
+  });
+  auto vec = makeSimpleRowVector(
+      {"c", "a", "b"},
+      {
+          makeStringVector({"x", "y"}),
+          makeIntVector<int32_t>({1, 2}),
+          makeIntVector<int64_t>({100, 200}),
+      });
+  auto serialized =
+      serialize(vec, type, {.version = SerializationVersion::kSerialization});
+  auto inputSchema =
+      getNimbleSchema(type, {.version = SerializationVersion::kSerialization});
+
+  Deserializer deserializer{
+      inputSchema, makeSubfields({"c", "a"}), pool_.get(), {.hasHeader = true}};
+  VectorPtr output;
+  deserializer.deserialize(serialized, output);
+
+  EXPECT_TRUE(
+      output->type()->equivalent(*ROW({{"a", INTEGER()}, {"c", VARCHAR()}})));
+  auto* row = output->asChecked<RowVector>();
+  EXPECT_EQ(row->childAt(0)->asChecked<FlatVector<int32_t>>()->valueAt(0), 1);
+  EXPECT_EQ(
+      row->childAt(1)->asChecked<FlatVector<StringView>>()->valueAt(0), "x");
+}
+
+TEST_F(ProjectorTest, columnProjectionDeserializerProjectsNestedScenarios) {
+  auto type = ROW({
+      {"z",
+       ROW({
+           {"value", VARCHAR()},
+           {"nested", ROW({{"right", BIGINT()}, {"left", INTEGER()}})},
+       })},
+      {"a", ROW({{"second", VARCHAR()}, {"first", INTEGER()}})},
+      {"ignored", BIGINT()},
+  });
+  auto nested = makeSimpleRowVector(
+      {"right", "left"},
+      {
+          makeIntVector<int64_t>({100, 200}),
+          makeIntVector<int32_t>({10, 20}),
+      });
+  auto z = makeSimpleRowVector(
+      {"value", "nested"}, {makeStringVector({"x", "y"}), nested});
+  auto a = makeSimpleRowVector(
+      {"second", "first"},
+      {makeStringVector({"p", "q"}), makeIntVector<int32_t>({1, 2})});
+  auto input = makeSimpleRowVector(
+      {"z", "a", "ignored"}, {z, a, makeIntVector<int64_t>({15, 25})});
+  auto serialized =
+      serialize(input, type, {.version = SerializationVersion::kSerialization});
+  auto inputSchema =
+      getNimbleSchema(type, {.version = SerializationVersion::kSerialization});
+
+  Deserializer deserializer{
+      inputSchema,
+      makeSubfields({"z.nested.right", "z.nested.left", "a.first"}),
+      pool_.get(),
+      {.hasHeader = true}};
+  VectorPtr output;
+  deserializer.deserialize(serialized, output);
+
+  auto expectedType = ROW({
+      {"a", ROW({{"first", INTEGER()}})},
+      {"z", ROW({{"nested", ROW({{"left", INTEGER()}, {"right", BIGINT()}})}})},
+  });
+  EXPECT_TRUE(output->type()->equivalent(*expectedType));
+  auto* outputRow = output->asChecked<RowVector>();
+  auto* outputA = outputRow->childAt(0)->asChecked<RowVector>();
+  EXPECT_EQ(
+      outputA->childAt(0)->asChecked<FlatVector<int32_t>>()->valueAt(1), 2);
+  auto* outputNested = outputRow->childAt(1)
+                           ->asChecked<RowVector>()
+                           ->childAt(0)
+                           ->asChecked<RowVector>();
+  EXPECT_EQ(
+      outputNested->childAt(0)->asChecked<FlatVector<int32_t>>()->valueAt(0),
+      10);
+  EXPECT_EQ(
+      outputNested->childAt(1)->asChecked<FlatVector<int64_t>>()->valueAt(1),
+      200);
+
+  Deserializer wholeFieldDeserializer{
+      inputSchema,
+      makeSubfields({"z.nested.left", "z"}),
+      pool_.get(),
+      {.hasHeader = true}};
+  wholeFieldDeserializer.deserialize(serialized, output);
+  EXPECT_TRUE(output->type()->equivalent(*ROW({{"z", type->childAt(0)}})));
+  for (vector_size_t row = 0; row < input->size(); ++row) {
+    EXPECT_TRUE(output->asChecked<RowVector>()->childAt(0)->equalValueAt(
+        input->asChecked<RowVector>()->childAt(0).get(), row, row));
+  }
+}
+
+TEST_F(ProjectorTest, columnProjectionDeserializerRejectsDuplicateSubfields) {
+  auto type = ROW({
+      {"a", INTEGER()},
+      {"b", BIGINT()},
+  });
+  auto inputSchema =
+      getNimbleSchema(type, {.version = SerializationVersion::kSerialization});
+
+  NIMBLE_ASSERT_THROW(
+      Deserializer(inputSchema, makeSubfields({"a", "a"}), pool_.get(), {}),
+      "Duplicate column projection subfield");
+}
+
+TEST_F(ProjectorTest, columnProjectionDeserializerNestedFuzzer) {
+  constexpr vector_size_t kBatchSize = 32;
+  constexpr int kIterations = 10;
+  auto type = ROW({
+      {"z",
+       ROW({
+           {"y", VARCHAR()},
+           {"x", ROW({{"b", BIGINT()}, {"a", INTEGER()}})},
+       })},
+      {"a", ROW({{"q", DOUBLE()}, {"p", BOOLEAN()}})},
+      {"m", BIGINT()},
+      {"unused", VARCHAR()},
+  });
+  auto inputSchema =
+      getNimbleSchema(type, {.version = SerializationVersion::kSerialization});
+  Deserializer deserializer{
+      inputSchema,
+      makeSubfields({"z.y", "z.x.b", "z.x.a", "a", "m"}),
+      pool_.get(),
+      {.hasHeader = true}};
+  auto expectedType = ROW({
+      {"a", type->childAt(1)},
+      {"m", BIGINT()},
+      {"z",
+       ROW({
+           {"x", ROW({{"a", INTEGER()}, {"b", BIGINT()}})},
+           {"y", VARCHAR()},
+       })},
+  });
+
+  const auto seed = folly::Random::rand32();
+  LOG(INFO) << "columnProjectionDeserializerNestedFuzzer seed: " << seed;
+  VectorFuzzer fuzzer(
+      {.vectorSize = kBatchSize, .nullRatio = 0.2}, pool_.get(), seed);
+  for (int iteration = 0; iteration < kIterations; ++iteration) {
+    SCOPED_TRACE(fmt::format("seed={} iteration={}", seed, iteration));
+    std::vector<VectorPtr> inputChildren;
+    inputChildren.reserve(type->size());
+    for (const auto& child : type->children()) {
+      inputChildren.push_back(fuzzer.fuzzFlat(child, kBatchSize));
+    }
+    auto input = std::make_shared<RowVector>(
+        pool_.get(), type, nullptr, kBatchSize, std::move(inputChildren));
+    auto serialized = serialize(
+        input, type, {.version = SerializationVersion::kSerialization});
+    VectorPtr output;
+    deserializer.deserialize(serialized, output);
+
+    EXPECT_TRUE(output->type()->equivalent(*expectedType));
+    auto* inputRow = input->asChecked<RowVector>();
+    auto* inputZ = inputRow->childAt(0)->asChecked<RowVector>();
+    auto* inputX = inputZ->childAt(1)->asChecked<RowVector>();
+    auto expectedX = std::make_shared<RowVector>(
+        pool_.get(),
+        expectedType->childAt(2)->asRow().childAt(0),
+        inputX->nulls(),
+        kBatchSize,
+        std::vector<VectorPtr>{inputX->childAt(1), inputX->childAt(0)});
+    auto expectedZ = std::make_shared<RowVector>(
+        pool_.get(),
+        expectedType->childAt(2),
+        inputZ->nulls(),
+        kBatchSize,
+        std::vector<VectorPtr>{expectedX, inputZ->childAt(0)});
+    auto expected = std::make_shared<RowVector>(
+        pool_.get(),
+        expectedType,
+        inputRow->nulls(),
+        kBatchSize,
+        std::vector<VectorPtr>{
+            inputRow->childAt(1), inputRow->childAt(2), expectedZ});
+    for (vector_size_t row = 0; row < kBatchSize; ++row) {
+      EXPECT_TRUE(output->equalValueAt(expected.get(), row, row))
+          << "row=" << row;
+    }
+  }
 }
 
 TEST_F(ProjectorTest, columnProjectionDeserializerReadsTopLevelFlatMap) {
@@ -883,10 +1097,11 @@ TEST_F(ProjectorTest, columnProjectionDeserializerReadsTopLevelFlatMap) {
   ASSERT_EQ(output->size(), numRows);
   auto* row = output->as<RowVector>();
   ASSERT_NE(row, nullptr);
-  ASSERT_EQ(row->children().size(), 2);
-  EXPECT_EQ(row->childAt(0), nullptr);
+  EXPECT_TRUE(output->type()->equivalent(
+      *ROW({{"features", MAP(INTEGER(), DOUBLE())}})));
+  ASSERT_EQ(row->children().size(), 1);
 
-  auto* features = row->childAt(1)->as<MapVector>();
+  auto* features = row->childAt(0)->as<MapVector>();
   ASSERT_NE(features, nullptr);
   ASSERT_EQ(features->sizeAt(0), 1);
   const auto offset = features->offsetAt(0);
@@ -898,7 +1113,7 @@ TEST_F(ProjectorTest, columnProjectionDeserializerReadsTopLevelFlatMap) {
   EXPECT_DOUBLE_EQ(values->valueAt(offset), 1.5);
 }
 
-TEST_F(ProjectorTest, columnProjectionDeserializerRejectsFlatMapFeature) {
+TEST_F(ProjectorTest, columnProjectionDeserializerReadsFlatMapKey) {
   auto type = ROW({
       {"features", MAP(INTEGER(), DOUBLE())},
   });
@@ -907,7 +1122,7 @@ TEST_F(ProjectorTest, columnProjectionDeserializerRejectsFlatMapFeature) {
   auto mapOffsets = allocateOffsets(numRows, pool_.get());
   auto mapSizes = allocateSizes(numRows, pool_.get());
   mapOffsets->asMutable<vector_size_t>()[0] = 0;
-  mapSizes->asMutable<vector_size_t>()[0] = 1;
+  mapSizes->asMutable<vector_size_t>()[0] = 2;
 
   auto mapVector = std::make_shared<MapVector>(
       pool_.get(),
@@ -916,14 +1131,15 @@ TEST_F(ProjectorTest, columnProjectionDeserializerRejectsFlatMapFeature) {
       numRows,
       mapOffsets,
       mapSizes,
-      makeIntVector<int32_t>({1}),
-      BaseVector::create<FlatVector<double>>(DOUBLE(), 1, pool_.get()));
+      makeIntVector<int32_t>({1, 2}),
+      BaseVector::create<FlatVector<double>>(DOUBLE(), 2, pool_.get()));
   mapVector->mapValues()->as<FlatVector<double>>()->set(0, 1.5);
+  mapVector->mapValues()->as<FlatVector<double>>()->set(1, 2.5);
 
   auto vec = std::make_shared<RowVector>(
       pool_.get(), type, nullptr, numRows, std::vector<VectorPtr>{mapVector});
 
-  auto [_, inputSchema] = serializeWithSchema(
+  auto [serialized, inputSchema] = serializeWithSchema(
       vec,
       type,
       {
@@ -931,13 +1147,26 @@ TEST_F(ProjectorTest, columnProjectionDeserializerRejectsFlatMapFeature) {
           .flatMapColumns = {{"features", {}}},
       });
 
-  NIMBLE_ASSERT_USER_THROW(
-      Deserializer(
-          inputSchema,
-          makeSubfields({"features[\"1\"]"}),
-          pool_.get(),
-          {.hasHeader = true}),
-      "Column projection deserialize does not support FlatMap feature projection");
+  Deserializer deserializer{
+      inputSchema,
+      makeSubfields({"features[1]"}),
+      pool_.get(),
+      {.hasHeader = true}};
+  auto expectedType = ROW({{"features", MAP(INTEGER(), DOUBLE())}});
+  VectorPtr output;
+  deserializer.deserialize(serialized, output);
+
+  EXPECT_TRUE(output->type()->equivalent(*expectedType));
+  auto* row = output->as<RowVector>();
+  ASSERT_NE(row, nullptr);
+  ASSERT_EQ(row->childrenSize(), 1);
+  auto* features = row->childAt(0)->as<MapVector>();
+  ASSERT_NE(features, nullptr);
+  ASSERT_EQ(features->sizeAt(0), 1);
+  const auto offset = features->offsetAt(0);
+  EXPECT_EQ(features->mapKeys()->as<FlatVector<int32_t>>()->valueAt(offset), 1);
+  EXPECT_DOUBLE_EQ(
+      features->mapValues()->as<FlatVector<double>>()->valueAt(offset), 1.5);
 }
 
 // Test that incompatible format combinations are rejected at projection time.


### PR DESCRIPTION
Summary:

Make the selected-subfield `Deserializer` return Row vectors whose types contain only projected fields, including recursively projected nested Rows and terminal top-level FlatMap key selections. Projected Row fields are ordered lexicographically at every projected level so clients can reconstruct the output type without knowing source field order; selecting a whole Row preserves its original type.

Keep `VeloxReader` and `FieldReader` unchanged: decode selected streams into the original sparse Row shape, then wrap selected children in the projected output type inside `Deserializer`. Precompute serializer-local identity projections so each batch uses direct input-channel access without field-name lookup. Create decoders only for selected physical stream offsets while preserving original Nimble stream mapping and FlatMap in-map reconstruction.

Top-level FlatMap key paths such as `features[1]` or `features["key"]` reuse `flatMapFeatureSelector` and return a Map containing only requested keys. Nested projection inside a FlatMap value remains unsupported.

Performance versus master (optimized build, 100 columns with 5 selected):
- Constructor: 32.05 us -> 25.45 us (20.6% faster)
- Constructor + deserialize: 62.72 us -> 54.72 us (12.8% faster)

Differential Revision: D112664792


