### PR TITLE
fix(encoding): Preserve float bit patterns in ConstantEncoding when ALP is off

### DIFF
--- a/dwio/nimble/encodings/ConstantEncoding.h
+++ b/dwio/nimble/encodings/ConstantEncoding.h
@@ -50,7 +50,7 @@ class ConstantEncodingBase
       std::span<const physicalType> values,
       const Statistics<physicalType>& statistics,
       const Encoding::Options& options) {
-    if (!isConstant(values, statistics)) {
+    if (!isConstant(values, statistics, options)) {
       return std::nullopt;
     }
     const uint64_t outerEncodingSize =
@@ -169,7 +169,7 @@ class ConstantEncodingBase
       NIMBLE_INCOMPATIBLE_ENCODING("ConstantEncoding cannot be empty.");
     }
 
-    if (!isConstant(values, selection.statistics())) {
+    if (!isConstant(values, selection.statistics(), options)) {
       NIMBLE_INCOMPATIBLE_ENCODING("ConstantEncoding requires constant data.");
     }
 
@@ -188,21 +188,35 @@ class ConstantEncodingBase
         rowCount,
         useVarint,
         pos);
-    encoding::write<physicalType>(canonicalValue(values.front()), pos);
-    NIMBLE_DCHECK_EQ(pos - reserved, encodingSize, "Encoding size mismatch.");
+    // Canonicalizing logically-equal floats is only valid under ALP (which
+    // encodes floats by logical value); otherwise store the exact bits.
+    encoding::write<physicalType>(
+        options.allowNestedAlpSelection ? canonicalValue(values.front())
+                                        : values.front(),
+        pos);
+    NIMBLE_CHECK_EQ(pos - reserved, encodingSize, "Encoding size mismatch.");
     return {reserved, encodingSize};
   }
 
  protected:
   static bool isConstant(
       std::span<const physicalType> values,
-      const Statistics<physicalType>& statistics) {
+      const Statistics<physicalType>& statistics,
+      const Encoding::Options& options) {
     NIMBLE_CHECK(
         !values.empty(), "ConstantEncoding requires non-empty values.");
     if (values.size() == 1 || statistics.uniqueCounts().value().size() == 1) {
       return true;
     }
     if constexpr (!isFloatingPointType<T>()) {
+      return false;
+    }
+    // Logical-equality constancy collapses physically-distinct but logically
+    // equal floats (only -0.0/+0.0; NaN is excluded since NaN != NaN) to a
+    // single canonical value. That is only sound when ALP is enabled, since ALP
+    // encodes floats by logical value. Without ALP, encodings must preserve the
+    // exact bits, so require physical (bit-exact) constancy.
+    if (!options.allowNestedAlpSelection) {
       return false;
     }
     const auto logicalValue =

--- a/dwio/nimble/encodings/tests/EncodingSelectionTest.cpp
+++ b/dwio/nimble/encodings/tests/EncodingSelectionTest.cpp
@@ -1807,3 +1807,71 @@ TEST(
       /*uncompressedSize=*/100,
       /*compressedSize=*/50));
 }
+
+// Regression: a float stream of all-zeros with mixed sign bits (-0.0f/+0.0f) is
+// logically constant (float ==) but physically distinct. Without ALP,
+// ConstantEncoding must not treat it as constant, since doing so silently drops
+// per-row ±0.0 sign bits. Verifies bit-exact (not float-==) round-trip.
+TEST(EncodingSelectionFloatSignTest, mixedSignedZeroPreservesBitsWithoutAlp) {
+  using T = float;
+  auto pool = facebook::velox::memory::deprecatedAddDefaultLeafMemoryPool();
+  nimble::Buffer buffer{*pool};
+
+  std::vector<T> values(1000);
+  for (auto i = 0; i < values.size(); ++i) {
+    values[i] = (i % 2 == 0) ? -0.0f : 0.0f;
+  }
+
+  // Default options: allowNestedAlpSelection is false (prod/default).
+  const nimble::Encoding::Options options;
+  auto policy = getRootManualSelectionPolicy<T>();
+  auto serialized = nimble::EncodingFactory::encode<T>(
+      std::move(policy), values, buffer, options);
+
+  auto encoding = nimble::EncodingFactory(options).create(
+      *pool, serialized, [](uint32_t) -> void* { return nullptr; });
+  // Distinct sign bits must not collapse into a single Constant value.
+  EXPECT_NE(encoding->encodingType(), nimble::EncodingType::Constant);
+
+  nimble::Vector<T> result{pool.get()};
+  result.resize(values.size());
+  encoding->materialize(static_cast<uint32_t>(values.size()), result.data());
+  for (auto i = 0; i < values.size(); ++i) {
+    EXPECT_EQ(asPhysicalType(values[i]), asPhysicalType(result[i]))
+        << "row " << i;
+  }
+}
+
+// Companion: with allowNestedAlpSelection=true, floats are encoded by logical
+// value, so logically-equal ±0.0 are legitimately collapsed into a single
+// canonical ConstantEncoding value. Covers the ALP gate in the on state.
+TEST(EncodingSelectionFloatSignTest, mixedSignedZeroCollapsesWithAlp) {
+  using T = float;
+  auto pool = facebook::velox::memory::deprecatedAddDefaultLeafMemoryPool();
+  nimble::Buffer buffer{*pool};
+
+  std::vector<T> values(1000);
+  for (auto i = 0; i < values.size(); ++i) {
+    values[i] = (i % 2 == 0) ? -0.0f : 0.0f;
+  }
+
+  nimble::Encoding::Options options;
+  options.allowNestedAlpSelection = true;
+  auto policy = getRootManualSelectionPolicy<T>();
+  auto serialized = nimble::EncodingFactory::encode<T>(
+      std::move(policy), values, buffer, options);
+
+  auto encoding = nimble::EncodingFactory(options).create(
+      *pool, serialized, [](uint32_t) -> void* { return nullptr; });
+  EXPECT_EQ(encoding->encodingType(), nimble::EncodingType::Constant);
+
+  nimble::Vector<T> result{pool.get()};
+  result.resize(values.size());
+  encoding->materialize(static_cast<uint32_t>(values.size()), result.data());
+  const auto canonicalBits = asPhysicalType(result[0]);
+  for (auto i = 0; i < values.size(); ++i) {
+    EXPECT_FLOAT_EQ(result[i], 0.0f) << "row " << i;
+    // All values collapse to a single canonical bit pattern under ALP.
+    EXPECT_EQ(asPhysicalType(result[i]), canonicalBits) << "row " << i;
+  }
+}

--- a/dwio/nimble/velox/selective/tests/FlatMapColumnReaderTest.cpp
+++ b/dwio/nimble/velox/selective/tests/FlatMapColumnReaderTest.cpp
@@ -23,6 +23,8 @@
 #include "velox/dwio/common/TypeUtils.h"
 #include "velox/vector/tests/utils/VectorTestBase.h"
 
+#include <bit>
+
 #include <fmt/format.h>
 #include <gtest/gtest.h>
 
@@ -30,6 +32,12 @@ namespace facebook::nimble {
 namespace {
 
 using namespace facebook::velox;
+
+// Reinterprets a float as its raw bits so that -0.0f and +0.0f (which compare
+// equal under float ==) can be distinguished in assertions.
+uint32_t floatBits(float value) {
+  return std::bit_cast<uint32_t>(value);
+}
 
 // Tests for FlatMapAsStructColumnReader, FlatMapAsMapColumnReader, and
 // FlatMapColumnReader (native).
@@ -534,6 +542,63 @@ TEST_P(FlatMapColumnReaderTest, nativeWithNulls) {
       makeReaders(input, file, scanSpec, /*preserveFlatMapsInMemory=*/true);
   auto expected = makeRowVector({flatMap->toMapVector(), flatMap});
   validate(*expected, *readers.rowReader, 3);
+}
+
+// Regression: float flat-map value streams with mixed sign bits (-0.0f/+0.0f)
+// must round-trip bit-exactly through the native FlatMapVector path. The value
+// stream is logically constant (all zeros) but physically distinct; without ALP
+// the writer must not collapse it into a single ConstantEncoding value.
+// Existing native FlatMapVector tests only cover int64, so this closes the
+// float coverage gap.
+TEST_P(FlatMapColumnReaderTest, nativeFloatMixedSignedZeroPreservesBits) {
+  constexpr int kNumRows = 200;
+  std::vector<std::vector<std::pair<int32_t, std::optional<float>>>> data;
+  data.reserve(kNumRows);
+  for (int i = 0; i < kNumRows; ++i) {
+    // Single key per row; the key's value stream alternates -0.0f/+0.0f.
+    data.push_back({{1, (i % 2 == 0) ? -0.0f : 0.0f}});
+  }
+
+  auto flatMap = makeFlatMapVector<int32_t, float>(data);
+  auto input = makeRowVector({flatMap});
+  VeloxWriterOptions writerOptions;
+  writerOptions.flatMapColumns = {{"c0", {}}};
+  writerOptions.skipConstantFlatMapInMapStreams = GetParam();
+  auto file = test::createNimbleFile(*rootPool(), input, writerOptions);
+
+  // Read c0 back as a native FlatMapVector (preserveFlatMapsInMemory).
+  auto scanSpec = std::make_shared<common::ScanSpec>("root");
+  scanSpec->addAllChildFields(*input->type());
+  auto firstReaders =
+      makeReaders(input, file, scanSpec, /*preserveFlatMapsInMemory=*/true);
+  auto roundTripped = BaseVector::create(asRowType(input->type()), 0, pool());
+  ASSERT_EQ(firstReaders.rowReader->next(kNumRows, roundTripped), kNumRows);
+  roundTripped->validate();
+
+  // Write the read-back FlatMapVector out again and re-read it as a MapVector.
+  auto file2 = test::createNimbleFile(*rootPool(), roundTripped, writerOptions);
+  auto secondScanSpec = std::make_shared<common::ScanSpec>("root");
+  secondScanSpec->addAllChildFields(*input->type());
+  auto secondReaders = makeReaders(input, file2, secondScanSpec);
+  auto result = BaseVector::create(asRowType(input->type()), 0, pool());
+  ASSERT_EQ(secondReaders.rowReader->next(kNumRows, result), kNumRows);
+  result->validate();
+
+  // Bit-compare each value against the original input; -0.0f != +0.0f.
+  auto* resultRow = result->asUnchecked<RowVector>();
+  auto* mapVec =
+      resultRow->childAt(0)->loadedVector()->asUnchecked<MapVector>();
+  auto* values = mapVec->mapValues()->loadedVector()->as<SimpleVector<float>>();
+  ASSERT_NE(values, nullptr);
+  const auto* rawOffsets = mapVec->rawOffsets();
+  const auto* rawSizes = mapVec->rawSizes();
+  for (int i = 0; i < kNumRows; ++i) {
+    ASSERT_EQ(rawSizes[i], 1) << "row " << i;
+    EXPECT_EQ(
+        floatBits(values->valueAt(rawOffsets[i])),
+        floatBits(*data[i][0].second))
+        << "row " << i;
+  }
 }
 
 // ----- Lazy I/O tests -----


### PR DESCRIPTION
Summary:
D112619794 made `ConstantEncoding` value-aware for floating point, treating
physically-distinct but logically-equal values as constant (float `==`, so
`-0.0f == +0.0f`) and storing a single canonical value. This collapses a float
stream of all zeros with mixed signs down to one sign, dropping the per-row sign
bits. The behavior is ungated, so it applies even when ALP is disabled (the
production default), where encodings are expected to preserve the exact bit
pattern (see `EncodingPhysicalType`, `dwio/nimble/encodings/common/EncodingType.h`).

This surfaced as `CHECKSUM_MISMATCH` in the `alpha_flatmap_vector_validation`
Vader stage (`dwrf_reader_checksum`) on REAL `float_features` columns of the
`ig_muddler_generic_training_data_*` tables starting 2026-07-21: the FlatMapVector
round trip re-encodes each per-key float value stream and collapses mixed
`+/-0.0`, so the bit-sensitive checksum diverges from the baseline. A regular
`MapVector` read of the same file collapses identically, so this is a
write/encoding-level effect that hits all read paths. It is numerically lossless
(`-0.0 == +0.0`), so there is no query-result impact, but it is a bit-level
fidelity regression that the checksum validator (correctly) flags.

Fix: the logical-equality / `canonicalValue` behavior is only sound under ALP,
which encodes floats by logical value. Gate it on
`options.allowNestedAlpSelection` (default false). With ALP off,
`ConstantEncoding` again requires physical (bit-exact) constancy, so mixed
`+/-0.0` streams fall back to a bit-preserving encoding. ALP-enabled behavior is
unchanged. This also covers the nested `ConstantEncoding` used by MainlyConstant
and RLE, whose run/common-value grouping is already physical.

Reviewed By: xiaoxmeng

Differential Revision: D113080138


