### PR TITLE
misc(encoding): Add SubIntSplit micro-benchmark for comparison with black-box compression (#1001)

### DIFF
--- a/dwio/nimble/encodings/benchmarks/SubIntSplitVsOpenZLBenchmark.cpp
+++ b/dwio/nimble/encodings/benchmarks/SubIntSplitVsOpenZLBenchmark.cpp
@@ -1,0 +1,692 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Comparison driver: the structural SubIntSplit encoding (with tuned section
+// candidates + entropy) vs the OpenZL general-purpose compressor, Zstd, and
+// FixedBitWidth, across many integer data characteristics.
+//
+// Two modes:
+//   (default)  folly microbenchmarks -- encode + decode wall-clock, one size.
+//   --csv      robust sweep: for every (pattern, size, method) it averages
+//              compression ratio and encode/decode throughput over --trials
+//              independent fixed seeds and reports mean and standard deviation.
+//              This feeds the evaluation tables/plots.
+//
+// All generators are seeded deterministically, so every run is reproducible and
+// trials differ only by an explicit per-trial seed.
+
+#include <algorithm>
+#include <bit>
+#include <chrono>
+#include <cmath>
+#include <cstdint>
+#include <functional>
+#include <iostream>
+#include <random>
+#include <string>
+#include <vector>
+
+#include "dwio/nimble/common/Buffer.h"
+#include "dwio/nimble/common/Vector.h"
+#include "dwio/nimble/compression/Compression.h"
+#include "dwio/nimble/compression/CompressionPolicy.h"
+#include "dwio/nimble/encodings/FixedBitWidthEncoding.h"
+#include "dwio/nimble/encodings/SubIntSplitEncoding.h"
+#include "dwio/nimble/encodings/benchmarks/BenchmarkUtils.h"
+#include "dwio/nimble/encodings/common/EncodingFactory.h"
+#include "dwio/nimble/encodings/selection/EncodingSelection.h"
+#include "dwio/nimble/encodings/selection/EncodingSelectionPolicy.h"
+#include "dwio/nimble/encodings/selection/Statistics.h"
+#include "folly/Benchmark.h"
+#include "folly/init/Init.h"
+#include "velox/common/memory/Memory.h"
+
+using namespace facebook::nimble;
+using namespace facebook::nimble::benchmarks;
+
+DEFINE_bool(
+    csv,
+    false,
+    "Emit the robust CSV sweep instead of microbenchmarks.");
+DEFINE_int32(
+    trials,
+    5,
+    "Independent seeds averaged per (pattern, size, method).");
+DEFINE_int64(
+    only_size,
+    0,
+    "If >0, run the CSV sweep for only this element count (e.g. 100000000).");
+DEFINE_bool(
+    layout,
+    false,
+    "Print the SubIntSplit section layout (bit ranges + chosen encoding) "
+    "for each pattern instead of running microbenchmarks.");
+
+namespace {
+
+using T = uint64_t;
+constexpr DataType kDataType = DataType::Uint64;
+constexpr int kBitWidth = 64;
+
+// ---------------------------------------------------------------------------
+// Seeded data generators, parameterized by element count and trial seed.
+// ---------------------------------------------------------------------------
+
+// Uniformly random full-width values (incompressible worst case).
+Vector<T> genRandom(uint32_t n, uint64_t seed) {
+  std::mt19937_64 rng{seed};
+  Vector<T> d{benchmarkPool().get()};
+  d.resize(n);
+  for (uint32_t i = 0; i < n; ++i) {
+    d[i] = rng();
+  }
+  return d;
+}
+
+// Values that fit in `bitWidth` bits, uniformly random.
+Vector<T> genNarrow(int bitWidth, uint32_t n, uint64_t seed) {
+  std::mt19937_64 rng{seed};
+  Vector<T> d{benchmarkPool().get()};
+  d.resize(n);
+  const T mask = bitWidth >= 64 ? ~T{0} : ((T{1} << bitWidth) - 1);
+  for (uint32_t i = 0; i < n; ++i) {
+    d[i] = rng() & mask;
+  }
+  return d;
+}
+
+// Constant high prefix, uniformly random low `lowBits`.
+Vector<T> genBitStruct(int lowBits, uint32_t n, uint64_t seed) {
+  std::mt19937_64 rng{seed};
+  Vector<T> d{benchmarkPool().get()};
+  d.resize(n);
+  const T prefix = 0x1234567800000000ULL;
+  const T lowMask = (T{1} << lowBits) - 1;
+  for (uint32_t i = 0; i < n; ++i) {
+    d[i] = prefix | (rng() & lowMask);
+  }
+  return d;
+}
+
+// Snowflake-style IDs: 41-bit ms timestamp (slowly increasing), 10-bit machine
+// id (constant), 12-bit per-ms sequence counter.
+Vector<T> genSnowflake(uint32_t n, uint64_t seed) {
+  std::mt19937_64 rng{seed};
+  Vector<T> d{benchmarkPool().get()};
+  d.resize(n);
+  const T machineId = 501;
+  T ts = 1700000000000ULL & ((T{1} << 41) - 1);
+  T seq = 0;
+  for (uint32_t i = 0; i < n; ++i) {
+    if ((rng() % 8) == 0) {
+      ++ts;
+      seq = 0;
+    } else {
+      seq = (seq + 1) & 0xFFF;
+    }
+    d[i] = (ts << 22) | (machineId << 12) | seq;
+  }
+  return d;
+}
+
+// Snowflake variant with a handful of distinct machine ids (low-cardinality
+// middle field) -- a harder multi-field case.
+Vector<T> genSnowflakeMultiDc(uint32_t n, uint64_t seed) {
+  std::mt19937_64 rng{seed};
+  Vector<T> d{benchmarkPool().get()};
+  d.resize(n);
+  T ts = 1700000000000ULL & ((T{1} << 41) - 1);
+  T seq = 0;
+  for (uint32_t i = 0; i < n; ++i) {
+    if ((rng() % 8) == 0) {
+      ++ts;
+      seq = 0;
+    } else {
+      seq = (seq + 1) & 0xFFF;
+    }
+    const T machineId = 500 + (rng() % 8);
+    d[i] = (ts << 22) | (machineId << 12) | seq;
+  }
+  return d;
+}
+
+// Monotonically increasing millisecond timestamps with small jitter.
+Vector<T> genTimestampMs(uint32_t n, uint64_t seed) {
+  std::mt19937_64 rng{seed};
+  Vector<T> d{benchmarkPool().get()};
+  d.resize(n);
+  T now = 1700000000000ULL;
+  for (uint32_t i = 0; i < n; ++i) {
+    now += rng() % 5;
+    d[i] = now;
+  }
+  return d;
+}
+
+// Sorted random values (monotone, non-uniform gaps).
+Vector<T> genSorted(uint32_t n, uint64_t seed) {
+  std::mt19937_64 rng{seed};
+  Vector<T> d{benchmarkPool().get()};
+  d.resize(n);
+  T cur = 0;
+  for (uint32_t i = 0; i < n; ++i) {
+    cur += rng() % 1024;
+    d[i] = cur;
+  }
+  return d;
+}
+
+// Dense sequential ids starting at an offset (0,1,2,...).
+Vector<T> genSequential(uint32_t n, uint64_t seed) {
+  std::mt19937_64 rng{seed};
+  const T base = rng();
+  Vector<T> d{benchmarkPool().get()};
+  d.resize(n);
+  for (uint32_t i = 0; i < n; ++i) {
+    d[i] = base + i;
+  }
+  return d;
+}
+
+// Low cardinality: values drawn uniformly from [0, cardinality).
+Vector<T> genLowCard(uint32_t cardinality, uint32_t n, uint64_t seed) {
+  std::mt19937_64 rng{seed};
+  Vector<T> d{benchmarkPool().get()};
+  d.resize(n);
+  for (uint32_t i = 0; i < n; ++i) {
+    d[i] = rng() % cardinality;
+  }
+  return d;
+}
+
+// 95% one dominant value, 5% random outliers.
+Vector<T> genMainlyConstant(uint32_t n, uint64_t seed) {
+  std::mt19937_64 rng{seed};
+  Vector<T> d{benchmarkPool().get()};
+  d.resize(n);
+  for (uint32_t i = 0; i < n; ++i) {
+    d[i] = (rng() % 100 < 95) ? T{42} : rng();
+  }
+  return d;
+}
+
+// ~99% zero, 1% random (very sparse).
+Vector<T> genMostlyZero(uint32_t n, uint64_t seed) {
+  std::mt19937_64 rng{seed};
+  Vector<T> d{benchmarkPool().get()};
+  d.resize(n);
+  for (uint32_t i = 0; i < n; ++i) {
+    d[i] = (rng() % 100 == 0) ? rng() : T{0};
+  }
+  return d;
+}
+
+// Skewed (Zipfian-ish) over `cardinality` values: frequent values get small
+// codes. Approximates a power-law by exponentiating a uniform.
+Vector<T> genZipfian(uint32_t cardinality, uint32_t n, uint64_t seed) {
+  std::mt19937_64 rng{seed};
+  std::uniform_real_distribution<double> unif{0.0, 1.0};
+  Vector<T> d{benchmarkPool().get()};
+  d.resize(n);
+  for (uint32_t i = 0; i < n; ++i) {
+    const double u = unif(rng);
+    d[i] = static_cast<T>(cardinality * std::pow(u, 3.0)) % cardinality;
+  }
+  return d;
+}
+
+// Packed multi-entropy field: 8-bit constant, 16-bit low-card, 20-bit counter,
+// 20-bit random -- exercises several sections at once.
+Vector<T> genMultiField(uint32_t n, uint64_t seed) {
+  std::mt19937_64 rng{seed};
+  Vector<T> d{benchmarkPool().get()};
+  d.resize(n);
+  const T constField = 0xAB;
+  T counter = 0;
+  for (uint32_t i = 0; i < n; ++i) {
+    const T lowCard = rng() % 64;
+    const T rnd = rng() & 0xFFFFF; // 20 bits
+    counter = (counter + 1) & 0xFFFFF; // 20-bit wrapping counter
+    d[i] = (constField << 56) | (lowCard << 40) | (counter << 20) | rnd;
+  }
+  return d;
+}
+
+struct Pattern {
+  std::string name;
+  std::function<Vector<T>(uint32_t, uint64_t)> gen;
+};
+
+std::vector<Pattern> patterns() {
+  return {
+      {"Random", [](uint32_t n, uint64_t s) { return genRandom(n, s); }},
+      {"Narrow8", [](uint32_t n, uint64_t s) { return genNarrow(8, n, s); }},
+      {"Narrow16", [](uint32_t n, uint64_t s) { return genNarrow(16, n, s); }},
+      {"Narrow32", [](uint32_t n, uint64_t s) { return genNarrow(32, n, s); }},
+      {"Narrow48", [](uint32_t n, uint64_t s) { return genNarrow(48, n, s); }},
+      {"BitStruct16",
+       [](uint32_t n, uint64_t s) { return genBitStruct(16, n, s); }},
+      {"BitStruct32",
+       [](uint32_t n, uint64_t s) { return genBitStruct(32, n, s); }},
+      {"Snowflake", [](uint32_t n, uint64_t s) { return genSnowflake(n, s); }},
+      {"SnowflakeMultiDc",
+       [](uint32_t n, uint64_t s) { return genSnowflakeMultiDc(n, s); }},
+      {"TimestampMs",
+       [](uint32_t n, uint64_t s) { return genTimestampMs(n, s); }},
+      {"Sorted", [](uint32_t n, uint64_t s) { return genSorted(n, s); }},
+      {"Sequential",
+       [](uint32_t n, uint64_t s) { return genSequential(n, s); }},
+      {"LowCard16",
+       [](uint32_t n, uint64_t s) { return genLowCard(16, n, s); }},
+      {"LowCard256",
+       [](uint32_t n, uint64_t s) { return genLowCard(256, n, s); }},
+      {"LowCard1024",
+       [](uint32_t n, uint64_t s) { return genLowCard(1024, n, s); }},
+      {"LowCard64K",
+       [](uint32_t n, uint64_t s) { return genLowCard(65536, n, s); }},
+      {"MainlyConstant",
+       [](uint32_t n, uint64_t s) { return genMainlyConstant(n, s); }},
+      {"MostlyZero",
+       [](uint32_t n, uint64_t s) { return genMostlyZero(n, s); }},
+      {"Zipfian4096",
+       [](uint32_t n, uint64_t s) { return genZipfian(4096, n, s); }},
+      {"MultiField",
+       [](uint32_t n, uint64_t s) { return genMultiField(n, s); }},
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Methods.
+// ---------------------------------------------------------------------------
+
+struct Encoded {
+  std::string bytes;
+  bool decodable;
+};
+
+class ForcePolicy : public CompressionPolicy {
+ public:
+  explicit ForcePolicy(CompressionType type) : type_{type} {}
+  CompressionConfig config() const override {
+    CompressionConfig config;
+    config.compressionType = type_;
+    config.minCompressionSize = 0;
+    config.parameters.zstd.compressionLevel = 3;
+    config.parameters.openzl.compressionLevel = 6;
+    config.parameters.openzl.decompressionLevel = 3;
+    config.parameters.openzl.formatVersion = 25;
+    return config;
+  }
+  bool shouldAccept(CompressionType, uint64_t, uint64_t) const override {
+    return true;
+  }
+
+ private:
+  const CompressionType type_;
+};
+
+struct Method {
+  std::string name;
+  std::function<Encoded(const Vector<T>&)> encode;
+  std::function<void(const std::string&, uint32_t n)> decode;
+};
+
+Encoded compressWith(CompressionType type, const Vector<T>& data) {
+  auto& pool = benchmarkPool();
+  ForcePolicy policy{type};
+  std::string_view raw{
+      reinterpret_cast<const char*>(data.data()), data.size() * sizeof(T)};
+  auto result = Compression::compress(*pool, raw, kDataType, kBitWidth, policy);
+  if (result.buffer.has_value() &&
+      result.compressionType != CompressionType::Uncompressed) {
+    return {std::string{result.buffer->data(), result.buffer->size()}, true};
+  }
+  return {std::string{raw}, false};
+}
+
+void decompressWith(CompressionType type, const std::string& compressed) {
+  auto& pool = benchmarkPool();
+  auto buffer = Compression::uncompress(
+      *pool, type, kDataType, compressed, nullptr, nullptr);
+  folly::doNotOptimizeAway(buffer);
+}
+
+std::vector<std::pair<EncodingType, float>> tunedReadFactors() {
+  auto factors =
+      ManualEncodingSelectionPolicyFactory::defaultEncodingReadFactors();
+  factors.emplace_back(EncodingType::Delta, 1.0f);
+  factors.emplace_back(EncodingType::FOR, 1.0f);
+  factors.emplace_back(EncodingType::BlockBitPacking, 1.0f);
+  return factors;
+}
+
+Encoded encodeSubIntSplitWith(
+    const Vector<T>& data,
+    std::vector<std::pair<EncodingType, float>> readFactors,
+    CompressionType compressionType) {
+  auto& pool = benchmarkPool();
+  Buffer buffer{*pool};
+  std::span<const uint64_t> values{data.data(), data.size()};
+  std::optional<CompressionOptions> compressionOptions;
+  if (compressionType != CompressionType::Uncompressed) {
+    CompressionOptions options;
+    options.compressionType = compressionType;
+    options.compressionAcceptRatio = 1.0f;
+    options.zstdMinCompressionSize = 0;
+    options.openzlMinCompressionSize = 0;
+    compressionOptions = options;
+  }
+  ManualEncodingSelectionPolicyFactory factory{
+      std::move(readFactors), compressionOptions};
+  EncodingSelectionResult result{.encodingType = EncodingType::SubIntSplit};
+  // SubIntSplit::encode never reads the parent selection's statistics (it draws
+  // its own sample and each section computes fresh statistics inside
+  // encodeNested), so we skip the expensive full-stream Statistics pass here.
+  // This matches the production replay path, where SubIntSplit is applied from
+  // a captured layout without recomputing outer statistics.
+  EncodingSelection<uint64_t> selection{
+      std::move(result),
+      Statistics<uint64_t>::create(values.subspan(0, 1)),
+      factory.createPolicy(DataType::Uint64)};
+  auto encoded =
+      SubIntSplitEncoding<uint64_t>::encode(selection, values, buffer, {});
+  return {std::string{encoded.data(), encoded.size()}, true};
+}
+
+void decodeNimble(const std::string& encoded, uint32_t n) {
+  auto& pool = benchmarkPool();
+  std::vector<T> out(n);
+  auto enc = EncodingFactory{}.create(*pool, encoded, nullFactory());
+  enc->materialize(n, out.data());
+  folly::doNotOptimizeAway(out);
+}
+
+std::vector<Method> makeMethods() {
+  std::vector<Method> methods;
+  methods.push_back(
+      {"SubIntSplit",
+       [](const Vector<T>& d) {
+         return encodeSubIntSplitWith(
+             d,
+             ManualEncodingSelectionPolicyFactory::defaultEncodingReadFactors(),
+             CompressionType::Uncompressed);
+       },
+       decodeNimble});
+  methods.push_back(
+      {"SubIntSplitTuned",
+       [](const Vector<T>& d) {
+         return encodeSubIntSplitWith(
+             d, tunedReadFactors(), CompressionType::Zstd);
+       },
+       decodeNimble});
+  methods.push_back(
+      {"SubIntSplitOpenZL",
+       [](const Vector<T>& d) {
+         return encodeSubIntSplitWith(
+             d, tunedReadFactors(), CompressionType::OpenZL);
+       },
+       decodeNimble});
+  methods.push_back(
+      {"OpenZL",
+       [](const Vector<T>& d) {
+         return compressWith(CompressionType::OpenZL, d);
+       },
+       [](const std::string& c, uint32_t) {
+         decompressWith(CompressionType::OpenZL, c);
+       }});
+  methods.push_back(
+      {"Zstd",
+       [](const Vector<T>& d) {
+         return compressWith(CompressionType::Zstd, d);
+       },
+       [](const std::string& c, uint32_t) {
+         decompressWith(CompressionType::Zstd, c);
+       }});
+  methods.push_back(
+      {"FixedBitWidth",
+       [](const Vector<T>& d) {
+         return Encoded{
+             encodeData<FixedBitWidthEncoding<T>>(
+                 EncodingType::FixedBitWidth, d),
+             true};
+       },
+       decodeNimble});
+  return methods;
+}
+
+// ---------------------------------------------------------------------------
+// Robust CSV sweep.
+// ---------------------------------------------------------------------------
+
+double timedThroughputMbPerSec(
+    const std::function<void()>& fn,
+    uint64_t rawBytes,
+    int iters) {
+  fn(); // warmup
+  auto start = std::chrono::steady_clock::now();
+  for (int i = 0; i < iters; ++i) {
+    fn();
+  }
+  auto end = std::chrono::steady_clock::now();
+  const double seconds =
+      std::chrono::duration<double>(end - start).count() / iters;
+  return (static_cast<double>(rawBytes) / (1024.0 * 1024.0)) / seconds;
+}
+
+struct Stat {
+  double mean{0.0};
+  double stddev{0.0};
+};
+
+Stat summarize(const std::vector<double>& xs) {
+  if (xs.empty()) {
+    return {};
+  }
+  double sum = 0.0;
+  for (const double x : xs) {
+    sum += x;
+  }
+  const double mean = sum / xs.size();
+  double var = 0.0;
+  for (const double x : xs) {
+    var += (x - mean) * (x - mean);
+  }
+  return {mean, std::sqrt(var / xs.size())};
+}
+
+// Per-element-count run configuration. Very large sizes use a representative
+// pattern subset with fewer trials/iterations so the sweep stays tractable
+// (100M elements is 800 MB raw per dataset; the full matrix would run for
+// hours). The subset spans the win/tie/loss spectrum seen at smaller sizes.
+struct SizeSpec {
+  uint64_t size;
+  int trials;
+  int encodeIters;
+  int decodeIters;
+  bool subset;
+};
+
+bool inBigSubset(const std::string& name) {
+  static const std::vector<std::string> kSubset = {
+      "Random",
+      "BitStruct16",
+      "Snowflake",
+      "TimestampMs",
+      "Sequential",
+      "LowCard1024",
+      "MainlyConstant",
+      "MultiField"};
+  return std::find(kSubset.begin(), kSubset.end(), name) != kSubset.end();
+}
+
+void emitCsv(int trials, int64_t onlySize) {
+  std::vector<SizeSpec> specs = {
+      {1'000'000ULL, trials, 8, 80, false},
+      {10'000'000ULL, std::min(trials, 3), 3, 20, false},
+      {100'000'000ULL, std::min(trials, 2), 1, 3, true},
+  };
+  if (onlySize > 0) {
+    std::vector<SizeSpec> filtered;
+    for (const auto& s : specs) {
+      if (static_cast<int64_t>(s.size) == onlySize) {
+        filtered.push_back(s);
+      }
+    }
+    specs = filtered;
+  }
+
+  const auto pats = patterns();
+  const auto methods = makeMethods();
+
+  std::cout << "pattern,size,method,trials,ratio_mean,ratio_stddev,"
+               "encode_mb_s_mean,decode_mb_s_mean\n";
+  for (const auto& spec : specs) {
+    const uint64_t rawBytes = spec.size * sizeof(T);
+    for (const auto& pat : pats) {
+      if (spec.subset && !inBigSubset(pat.name)) {
+        continue;
+      }
+      // Per-method accumulators across trials.
+      std::vector<std::vector<double>> ratios(methods.size());
+      std::vector<std::vector<double>> encMbs(methods.size());
+      std::vector<std::vector<double>> decMbs(methods.size());
+      for (int t = 0; t < spec.trials; ++t) {
+        const uint64_t seed = 0x9e3779b97f4a7c15ULL * (t + 1) + spec.size;
+        // Generate the dataset once per trial and reuse across all methods.
+        const Vector<T> data = pat.gen(static_cast<uint32_t>(spec.size), seed);
+        for (size_t m = 0; m < methods.size(); ++m) {
+          const auto& method = methods[m];
+          const Encoded encoded = method.encode(data);
+          ratios[m].push_back(
+              static_cast<double>(rawBytes) /
+              static_cast<double>(encoded.bytes.size()));
+          encMbs[m].push_back(timedThroughputMbPerSec(
+              [&] { folly::doNotOptimizeAway(method.encode(data)); },
+              rawBytes,
+              spec.encodeIters));
+          if (encoded.decodable) {
+            decMbs[m].push_back(timedThroughputMbPerSec(
+                [&] { method.decode(encoded.bytes, data.size()); },
+                rawBytes,
+                spec.decodeIters));
+          }
+        }
+      }
+      for (size_t m = 0; m < methods.size(); ++m) {
+        const Stat ratio = summarize(ratios[m]);
+        const Stat enc = summarize(encMbs[m]);
+        const Stat dec = summarize(decMbs[m]);
+        std::cout << pat.name << "," << spec.size << "," << methods[m].name
+                  << "," << spec.trials << "," << ratio.mean << ","
+                  << ratio.stddev << "," << enc.mean << ",";
+        if (!decMbs[m].empty()) {
+          std::cout << dec.mean;
+        }
+        std::cout << "\n";
+      }
+    }
+  }
+}
+
+// Print, for each pattern, the section layout the tuned SubIntSplit encoder
+// chose: the bit range of each section and the encoding selected for it (via
+// the encoding's own debugString, which recurses into each section).
+void emitLayout() {
+  auto& pool = benchmarkPool();
+  for (const auto& pat : patterns()) {
+    const uint64_t seed = 0x9e3779b97f4a7c15ULL + 1'000'000ULL;
+    const Vector<T> data = pat.gen(1'000'000u, seed);
+    const Encoded encoded =
+        encodeSubIntSplitWith(data, tunedReadFactors(), CompressionType::Zstd);
+    const double ratio = static_cast<double>(data.size() * sizeof(T)) /
+        static_cast<double>(encoded.bytes.size());
+    auto enc = EncodingFactory{}.create(*pool, encoded.bytes, nullFactory());
+    std::cout << "===== " << pat.name << " (SubIntSplitTuned ratio " << ratio
+              << ") =====\n"
+              << enc->debugString(0) << "\n";
+  }
+}
+
+// ---------------------------------------------------------------------------
+// folly microbenchmark mode (single size/seed, subset of methods).
+// ---------------------------------------------------------------------------
+
+std::vector<std::pair<std::string, Vector<T>>>& defaultDatasets() {
+  static std::vector<std::pair<std::string, Vector<T>>> ds = [] {
+    std::vector<std::pair<std::string, Vector<T>>> v;
+    for (const auto& p : patterns()) {
+      v.emplace_back(p.name, p.gen(kNumElements, 0x1234u));
+    }
+    return v;
+  }();
+  return ds;
+}
+
+std::vector<Method>& methodsSingleton() {
+  static std::vector<Method> m = makeMethods();
+  return m;
+}
+
+void registerBenchmarks() {
+  for (auto& [name, data] : defaultDatasets()) {
+    for (auto& method : methodsSingleton()) {
+      folly::addBenchmark(
+          __FILE__,
+          method.name + "_Encode_" + name,
+          [&method, &data](unsigned iters) {
+            while (iters--) {
+              folly::doNotOptimizeAway(method.encode(data));
+            }
+            return 1;
+          });
+      auto encoded = std::make_shared<Encoded>(method.encode(data));
+      if (!encoded->decodable) {
+        continue;
+      }
+      const uint32_t n = data.size();
+      folly::addBenchmark(
+          __FILE__,
+          method.name + "_Decode_" + name,
+          [&method, encoded, n](unsigned iters) {
+            while (iters--) {
+              method.decode(encoded->bytes, n);
+            }
+            return 1;
+          });
+    }
+  }
+}
+
+} // namespace
+
+int main(int argc, char** argv) {
+  folly::Init init(&argc, &argv);
+  facebook::velox::memory::MemoryManager::initialize({});
+
+  if (FLAGS_layout) {
+    emitLayout();
+    return 0;
+  }
+
+  if (FLAGS_csv) {
+    emitCsv(FLAGS_trials, FLAGS_only_size);
+    return 0;
+  }
+
+  registerBenchmarks();
+  folly::runBenchmarks();
+  return 0;
+}


### PR DESCRIPTION
Summary:


 Add SubIntSplit micro-benchmark for comparison with OpenZL

Each cell is **ratio / encode MB/s / decode MB/s** (higher is better on all three). **Bold rows** mark the (pattern, size) points where a SubIntSplit variant compresses better than OpenZL — a ratio more than 1% higher.

| Pattern | Size | SubIntSplit | SubIntSplit + Zstd | SubIntSplit + OpenZL | OpenZL | Chosen section layout |
|---|---|---|---|---|---|---|
| Random | 1M | 1.00 / 147 / 10113 | 1.00 / 137 / 9966 | 1.00 / 85 / 10102 | 1.00 / 213 / 10999 | [0-63] Trivial |
|  | 10M | 1.00 / 94 / 7652 | 1.00 / 89 / 7650 | 1.00 / 62 / 7755 | 1.00 / 175 / 8895 |  |
|  | 100M | 1.00 / 86 / 7847 | 1.00 / 79 / 7907 | 1.00 / 56 / 7777 | 1.00 / 158 / 9126 |  |
| Narrow8 | 1M | 8.00 / 1307 / 13615 | 8.00 / 707 / 13792 | 8.00 / 654 / 13724 | 8.00 / 4217 / 8905 | [0-63] FixedBitWidth 8b |
|  | 10M | 8.00 / 1794 / 9422 | 8.00 / 812 / 9392 | 8.00 / 791 / 9404 | 8.00 / 3608 / 7725 |  |
| Narrow16 | 1M | 4.00 / 447 / 12835 | 4.00 / 345 / 12905 | 4.00 / 333 / 12993 | 4.00 / 279 / 7034 | [0-63] FixedBitWidth 16b |
|  | 10M | 4.00 / 459 / 8788 | 4.00 / 345 / 8778 | 4.00 / 335 / 8745 | 4.00 / 209 / 6317 |  |
| Narrow32 | 1M | 2.00 / 147 / 13959 | 2.00 / 133 / 14265 | 2.00 / 128 / 14104 | 2.00 / 249 / 5568 | [0-63] FixedBitWidth 32b |
|  | 10M | 2.00 / 96 / 8425 | 2.00 / 88 / 8484 | 2.00 / 90 / 8495 | 2.00 / 198 / 4931 |  |
| Narrow48 | 1M | 1.33 / 142 / 10614 | 1.33 / 125 / 10669 | 1.33 / 120 / 10682 | 1.33 / 214 / 4783 | [0-63] FixedBitWidth 48b |
|  | 10M | 1.33 / 97 / 7134 | 1.33 / 92 / 7168 | 1.33 / 90 / 7232 | 1.33 / 175 / 4108 |  |
| BitStruct16 | 1M | 4.00 / 438 / 12571 | 4.00 / 342 / 12806 | 4.00 / 333 / 12762 | 4.00 / 279 / 7156 | [0-63] FixedBitWidth 16b |
|  | 10M | 4.00 / 480 / 8778 | 4.00 / 356 / 8819 | 4.00 / 341 / 8853 | 4.00 / 209 / 6456 |  |
|  | 100M | 4.00 / 303 / 8974 | 4.00 / 248 / 8921 | 4.00 / 242 / 8923 | 4.00 / 199 / 6515 |  |
| BitStruct32 | 1M | 2.00 / 143 / 13827 | 2.00 / 131 / 13846 | 2.00 / 125 / 13917 | 2.00 / 245 / 5493 | [0-63] FixedBitWidth 32b |
|  | 10M | 2.00 / 108 / 8379 | 2.00 / 91 / 8342 | 2.00 / 86 / 8458 | 2.00 / 197 / 4873 |  |
| **Snowflake** | **1M** | **6.95 / 461 / 3420** | **31.46 / 242 / 2241** | **36.18 / 185 / 2273** | **23.60 / 63 / 1570** | **[0-23] Dictionary; [24-31] RLE; [32-39] RLE; [40-63] Constant** |
|  | **10M** | **6.71 / 467 / 2884** | **30.38 / 246 / 1933** | **34.11 / 193 / 1978** | **23.62 / 60 / 1483** |  |
|  | 100M | 6.88 / 403 / 3181 | 18.81 / 230 / 2584 | 20.97 / 204 / 2534 | 23.62 / 60 / 1484 |  |
| SnowflakeMultiDc | 1M | 3.54 / 465 / 2876 | 9.17 / 170 / 1196 | 10.39 / 96 / 1264 | 11.20 / 53 / 1550 | [0-15] Trivial; [16-19] Constant; [20-27] RLE; [28-39] RLE; [40-63] Constant |
|  | 10M | 3.65 / 364 / 2710 | 9.35 / 155 / 1457 | 10.57 / 83 / 1470 | 11.20 / 50 / 1451 |  |
| TimestampMs | 1M | 7.82 / 517 / 6945 | 12.35 / 229 / 2626 | 15.37 / 180 / 2487 | 26.17 / 132 / 1549 | [0-7] Trivial; [8-23] RLE; [24-31] RLE; [32-63] Constant |
|  | 10M | 7.82 / 596 / 5468 | 12.77 / 236 / 2290 | 16.45 / 184 / 2261 | 26.20 / 109 / 1462 |  |
|  | 100M | 7.88 / 950 / 5652 | 12.81 / 258 / 2233 | 16.51 / 199 / 2315 | 26.20 / 107 / 1466 |  |
| Sorted | 1M | 3.95 / 395 / 7745 | 3.99 / 296 / 7346 | 6.08 / 104 / 3288 | 6.17 / 125 / 3355 | [0-15] Trivial; [16-31] RLE; [32-63] Constant |
|  | 10M | 3.95 / 453 / 5828 | 3.99 / 326 / 5546 | 5.91 / 87 / 2528 | 6.17 / 110 / 2961 |  |
| Sequential | 1M | 7.94 / 945 / 8728 | 3584 / 582 / 8558 | 3509 / 548 / 7866 | 20672 / 241 / 4822 | [0-7] Trivial; [8-23] RLE; [24-63] Constant |
|  | 10M | 7.94 / 711 / 6650 | 23302 / 469 / 6663 | 22858 / 450 / 6258 | 27276 / 187 / 4047 |  |
|  | **100M** | **7.94 / 734 / 6193** | **54650 / 400 / 6078** | **48638 / 401 / 5579** | **27763 / 184 / 4089** |  |
| **LowCard16** | **1M** | **8.00 / 1157 / 13676** | **15.70 / 509 / 13727** | **15.70 / 414 / 13742** | **15.09 / 434 / 2787** | **[0-63] BlockBitPacking** |
|  | **10M** | **8.00 / 1535 / 9484** | **15.69 / 548 / 9500** | **15.69 / 437 / 9571** | **14.99 / 413 / 2579** |  |
| LowCard256 | 1M | 8.00 / 1298 / 13783 | 8.00 / 703 / 13660 | 8.00 / 657 / 13874 | 8.00 / 4145 / 8978 | [0-63] FixedBitWidth 8b |
|  | 10M | 8.00 / 1794 / 9556 | 8.00 / 820 / 9524 | 8.00 / 791 / 9572 | 8.00 / 3625 / 7755 |  |
| **LowCard1024** | **1M** | **4.00 / 1344 / 12847** | **6.35 / 486 / 10592** | **6.35 / 343 / 10464** | **6.13 / 113 / 2304** | **[0-63] BlockBitPacking** |
|  | **10M** | **4.00 / 1742 / 8735** | **6.35 / 509 / 7967** | **6.35 / 363 / 7982** | **6.02 / 81 / 1712** |  |
|  | 100M | 4.00 / 1797 / 8833 | 5.38 / 547 / 2821 | 5.41 / 186 / 2250 | 6.01 / 80 / 1684 |  |
| LowCard64K | 1M | 4.00 / 406 / 12652 | 4.00 / 332 / 12748 | 4.00 / 329 / 12754 | 4.00 / 274 / 6958 | [0-63] FixedBitWidth 16b |
|  | 10M | 4.00 / 431 / 8673 | 4.00 / 345 / 8650 | 4.00 / 344 / 8769 | 4.00 / 206 / 6197 |  |
| **MainlyConstant** | **1M** | **15.24 / 346 / 15285** | **17.90 / 312 / 11188** | **17.89 / 275 / 10656** | **16.80 / 480 / 3381** | **[0-63] MainlyConstant** |
|  | **10M** | **15.24 / 338 / 8471** | **17.89 / 301 / 7071** | **17.94 / 270 / 7033** | **16.78 / 419 / 3154** |  |
|  | **100M** | **15.24 / 271 / 8682** | **17.88 / 245 / 7215** | **17.93 / 203 / 7117** | **16.79 / 423 / 3137** |  |
| MostlyZero | 1M | 72.96 / 549 / 16210 | 79.15 / 489 / 14683 | 79.15 / 473 / 14733 | 80.93 / 1049 / 5258 | [0-63] MainlyConstant |
|  | 10M | 72.82 / 578 / 10288 | 79.01 / 514 / 9610 | 79.01 / 495 / 9361 | 80.41 / 939 / 4788 |  |
| Zipfian4096 | 1M | 4.75 / 849 / 5385 | 5.30 / 508 / 11090 | 5.30 / 492 / 11057 | 5.59 / 121 / 2372 | [0-63] BlockBitPacking |
|  | 10M | 4.75 / 967 / 4571 | 5.30 / 502 / 8003 | 5.30 / 394 / 8114 | 5.55 / 91 / 1881 |  |
| MultiField | 1M | 1.97 / 131 / 2943 | 2.13 / 100 / 3087 | 2.13 / 92 / 3035 | 2.39 / 143 / 2612 | [0-23] FixedBitWidth 24b; [24-31] RLE; [32-39] RLE; [40-63] BlockBitPacking |
|  | 10M | 1.97 / 101 / 2729 | 2.13 / 76 / 2835 | 2.13 / 71 / 2863 | 2.39 / 121 / 2327 |  |
|  | 100M | 1.97 / 138 / 2758 | 2.13 / 103 / 2107 | 2.13 / 105 / 2048 | 2.39 / 117 / 2341 |  |

Reviewed By: xiaoxmeng

Differential Revision: D113054951


