### PR TITLE
refactor(nimble): Generalize index factory configuration (#1002)

### DIFF
--- a/dwio/nimble/index/CMakeLists.txt
+++ b/dwio/nimble/index/CMakeLists.txt
@@ -19,6 +19,7 @@ add_library(
   ClusterIndex.cpp
   ClusterIndexFactory.cpp
   ClusterIndexWriter.cpp
+  DenseIndexFactory.cpp
   DenseIndexRegistry.cpp
   HashIndex.cpp
   HashIndexWriter.cpp

--- a/dwio/nimble/index/ClusterIndexFactory.cpp
+++ b/dwio/nimble/index/ClusterIndexFactory.cpp
@@ -15,29 +15,20 @@
  */
 #include "dwio/nimble/index/ClusterIndexFactory.h"
 
-#include <mutex>
 #include <optional>
 
-#include "dwio/nimble/common/Exceptions.h"
 #include "dwio/nimble/index/ClusterIndex.h"
 #include "dwio/nimble/index/ClusterIndexWriter.h"
-#include "folly/container/F14Map.h"
+#include "dwio/nimble/index/IndexFactoryRegistry.h"
 
 namespace facebook::nimble::index {
 
 namespace {
 
-using FactoryMap =
-    folly::F14FastMap<std::string, std::shared_ptr<const ClusterIndexFactory>>;
-
-FactoryMap& factories() {
-  static auto* map = new FactoryMap();
-  return *map;
-}
-
-std::mutex& factoriesMutex() {
-  static auto* mutex = new std::mutex();
-  return *mutex;
+IndexFactoryRegistry<ClusterIndexFactory>& factoryRegistry() {
+  static auto* registry =
+      new IndexFactoryRegistry<ClusterIndexFactory>{IndexFamily::Cluster};
+  return *registry;
 }
 
 class NimbleClusterIndexFactory final : public ClusterIndexFactory {
@@ -72,7 +63,7 @@ class NimbleClusterIndexFactory final : public ClusterIndexFactory {
 
 void ensureBuiltInFactoriesRegistered() {
   static const bool registered = [] {
-    registerClusterIndexFactory(
+    factoryRegistry().registerFactory(
         std::make_shared<const NimbleClusterIndexFactory>());
     return true;
   }();
@@ -83,21 +74,13 @@ void ensureBuiltInFactoriesRegistered() {
 
 void registerClusterIndexFactory(
     std::shared_ptr<const ClusterIndexFactory> factory) {
-  NIMBLE_CHECK_NOT_NULL(factory);
-  const auto name = std::string{factory->name()};
-  NIMBLE_CHECK(!name.empty(), "Cluster index factory name cannot be empty");
-  std::lock_guard lock(factoriesMutex());
-  auto [_, inserted] = factories().emplace(name, std::move(factory));
-  NIMBLE_CHECK(inserted, "Cluster index factory already registered: {}", name);
+  ensureBuiltInFactoriesRegistered();
+  factoryRegistry().registerFactory(std::move(factory));
 }
 
 const ClusterIndexFactory& clusterIndexFactory(std::string_view name) {
   ensureBuiltInFactoriesRegistered();
-  std::lock_guard lock(factoriesMutex());
-  auto it = factories().find(name);
-  NIMBLE_CHECK(
-      it != factories().end(), "Unknown cluster index factory: {}", name);
-  return *it->second;
+  return factoryRegistry().get(name);
 }
 
 } // namespace facebook::nimble::index

--- a/dwio/nimble/index/ClusterIndexFactory.h
+++ b/dwio/nimble/index/ClusterIndexFactory.h
@@ -53,9 +53,13 @@ class ClusterIndexFactory {
       const IndexLookup::Options& options) const = 0;
 };
 
+/// Registers a process-wide factory. Call during process initialization,
+/// before concurrent factory lookups begin.
 void registerClusterIndexFactory(
     std::shared_ptr<const ClusterIndexFactory> factory);
 
+/// Returns a process-lifetime reference. Concurrent access after registration
+/// is supported.
 const ClusterIndexFactory& clusterIndexFactory(std::string_view name);
 
 } // namespace facebook::nimble::index

--- a/dwio/nimble/index/DenseIndexFactory.cpp
+++ b/dwio/nimble/index/DenseIndexFactory.cpp
@@ -1,0 +1,226 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "dwio/nimble/index/DenseIndexFactory.h"
+
+#include <fmt/ranges.h>
+
+#include "dwio/nimble/common/Exceptions.h"
+#include "dwio/nimble/index/HashIndex.h"
+#include "dwio/nimble/index/HashIndexWriter.h"
+#include "dwio/nimble/index/IndexFactoryRegistry.h"
+#include "dwio/nimble/index/SortedIndex.h"
+#include "dwio/nimble/index/SortedIndexWriter.h"
+#include "dwio/nimble/tablet/HashIndexGenerated.h"
+#include "dwio/nimble/tablet/MetadataCache.h"
+#include "dwio/nimble/tablet/MetadataInput.h"
+#include "dwio/nimble/tablet/SortedIndexGenerated.h"
+#include "velox/dwio/common/BufferedInput.h"
+
+namespace facebook::nimble::index {
+namespace {
+
+IndexFactoryRegistry<DenseIndexFactory>& factoryRegistry() {
+  static auto* registry =
+      new IndexFactoryRegistry<DenseIndexFactory>{IndexFamily::Dense};
+  return *registry;
+}
+
+// Reads one built-in dense index directory and lazily materializes its indices
+// behind the DenseIndexReader interface. 'Index' is the concrete index type
+// (HashIndex or SortedIndex), 'FbDirectory' its FlatBuffer directory, and
+// 'ValueInput' the input stream 'Index::create' reads its payload from.
+template <typename Index, typename FbDirectory, typename ValueInput>
+class BuiltInDenseIndexReader final : public DenseIndexReader {
+ public:
+  static std::unique_ptr<DenseIndexReader> create(
+      Section rootSection,
+      std::string_view indexTypeName,
+      std::shared_ptr<MetadataInput> metadataInput,
+      std::shared_ptr<ValueInput> valueInput,
+      velox::memory::MemoryPool* pool) {
+    auto reader =
+        std::unique_ptr<BuiltInDenseIndexReader>(new BuiltInDenseIndexReader());
+    reader->descriptors_ = parseDescriptors(rootSection, indexTypeName);
+
+    // Always pin: findIndex returns raw pointers, so entries must stay alive.
+    reader->cache_ = std::make_unique<MetadataCache<uint32_t, Index>>(
+        [self = reader.get(),
+         metadataInput = std::move(metadataInput),
+         valueInput = std::move(valueInput),
+         pool](uint32_t index) -> std::shared_ptr<Index> {
+          const auto& descriptor = self->descriptors_[index];
+          auto results = metadataInput->load({&descriptor.section, 1});
+          NIMBLE_CHECK_EQ(results.size(), 1);
+          auto metadata =
+              std::make_unique<MetadataBuffer>(std::move(*results.front()));
+          return Index::create(
+              descriptor.columns, std::move(metadata), valueInput, pool);
+        },
+        /*pinEntries=*/true);
+    return reader;
+  }
+
+  const IndexLookup* findIndex(
+      const std::vector<std::string>& queryColumns) const override {
+    for (uint32_t i = 0; i < descriptors_.size(); ++i) {
+      if (descriptors_[i].columns == queryColumns) {
+        return cache_->getOrCreate(i).get();
+      }
+    }
+    return nullptr;
+  }
+
+  std::vector<std::vector<std::string>> indexColumns() const override {
+    std::vector<std::vector<std::string>> columns;
+    columns.reserve(descriptors_.size());
+    for (const auto& descriptor : descriptors_) {
+      columns.emplace_back(descriptor.columns);
+    }
+    return columns;
+  }
+
+ private:
+  struct IndexDescriptor {
+    std::vector<std::string> columns;
+    MetadataSection section;
+  };
+
+  static std::vector<IndexDescriptor> parseDescriptors(
+      const Section& directorySection,
+      std::string_view indexTypeName) {
+    const auto* root =
+        flatbuffers::GetRoot<FbDirectory>(directorySection.content().data());
+    NIMBLE_CHECK_NOT_NULL(root);
+    const auto* indices = root->indices();
+    NIMBLE_CHECK_NOT_NULL(indices);
+
+    std::vector<IndexDescriptor> descriptors;
+    descriptors.reserve(indices->size());
+    for (const auto* indexSection : *indices) {
+      NIMBLE_CHECK_NOT_NULL(indexSection);
+      const auto* columns = indexSection->index_columns();
+      NIMBLE_CHECK_NOT_NULL(columns);
+      NIMBLE_CHECK_GT(
+          columns->size(), 0u, "{} must have columns", indexTypeName);
+
+      std::vector<std::string> columnNames;
+      columnNames.reserve(columns->size());
+      for (const auto* column : *columns) {
+        NIMBLE_CHECK_NOT_NULL(column);
+        columnNames.emplace_back(column->string_view());
+      }
+      for (const auto& descriptor : descriptors) {
+        NIMBLE_CHECK(
+            descriptor.columns != columnNames,
+            "Duplicate {} columns: [{}]",
+            indexTypeName,
+            fmt::join(columnNames, ", "));
+      }
+
+      const auto* section = indexSection->section();
+      NIMBLE_CHECK_NOT_NULL(section);
+      descriptors.emplace_back(
+          IndexDescriptor{
+              std::move(columnNames),
+              MetadataSection{
+                  section->offset(),
+                  section->size(),
+                  static_cast<CompressionType>(section->compression_type())}});
+    }
+    return descriptors;
+  }
+
+  std::vector<IndexDescriptor> descriptors_;
+  mutable std::unique_ptr<MetadataCache<uint32_t, Index>> cache_;
+};
+
+class HashIndexFactory final : public DenseIndexFactory {
+ public:
+  std::string_view name() const override {
+    return kDenseHashIndexName;
+  }
+
+  std::unique_ptr<DenseIndexReader> createReader(
+      Section rootSection,
+      const IndexLookup::Options& options,
+      velox::memory::MemoryPool* pool) const override {
+    options.validate();
+    auto metadataInput = createIndexMetadataInput(options);
+    auto valueInput = metadataInput;
+    return BuiltInDenseIndexReader<
+        HashIndex,
+        serialization::HashIndexDirectory,
+        MetadataInput>::
+        create(
+            std::move(rootSection),
+            "Hash index",
+            std::move(metadataInput),
+            std::move(valueInput),
+            pool);
+  }
+};
+
+class SortedIndexFactory final : public DenseIndexFactory {
+ public:
+  std::string_view name() const override {
+    return kDenseSortedIndexName;
+  }
+
+  std::unique_ptr<DenseIndexReader> createReader(
+      Section rootSection,
+      const IndexLookup::Options& options,
+      velox::memory::MemoryPool* pool) const override {
+    options.validate();
+    auto metadataInput = createIndexMetadataInput(options);
+    auto dataInput = createIndexDataInput(options);
+    return BuiltInDenseIndexReader<
+        SortedIndex,
+        serialization::SortedIndexDirectory,
+        velox::dwio::common::BufferedInput>::
+        create(
+            std::move(rootSection),
+            "Sorted index",
+            std::move(metadataInput),
+            std::move(dataInput),
+            pool);
+  }
+};
+
+void ensureBuiltInFactoriesRegistered() {
+  static const bool registered = [] {
+    factoryRegistry().registerFactory(
+        std::make_shared<const HashIndexFactory>());
+    factoryRegistry().registerFactory(
+        std::make_shared<const SortedIndexFactory>());
+    return true;
+  }();
+  (void)registered;
+}
+
+} // namespace
+
+void registerDenseIndexFactory(
+    std::shared_ptr<const DenseIndexFactory> factory) {
+  ensureBuiltInFactoriesRegistered();
+  factoryRegistry().registerFactory(std::move(factory));
+}
+
+const DenseIndexFactory* denseIndexFactory(std::string_view name) {
+  ensureBuiltInFactoriesRegistered();
+  return factoryRegistry().tryGet(name);
+}
+
+} // namespace facebook::nimble::index

--- a/dwio/nimble/index/DenseIndexFactory.h
+++ b/dwio/nimble/index/DenseIndexFactory.h
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include "dwio/nimble/index/IndexConfig.h"
+#include "dwio/nimble/index/IndexLookup.h"
+#include "dwio/nimble/tablet/MetadataBuffer.h"
+#include "velox/common/memory/Memory.h"
+
+namespace facebook::nimble::index {
+
+class DenseIndexReader {
+ public:
+  virtual ~DenseIndexReader() = default;
+
+  /// Returns a non-owning pointer valid while this reader remains alive.
+  /// Concurrent calls must be safe.
+  virtual const IndexLookup* findIndex(
+      const std::vector<std::string>& queryColumns) const = 0;
+
+  /// Returns the complete set of non-empty, unique, ordered column sets
+  /// accepted by findIndex(). The result must remain unchanged for the
+  /// lifetime of this reader.
+  virtual std::vector<std::vector<std::string>> indexColumns() const = 0;
+};
+
+/// Creates readers for one named dense index implementation.
+class DenseIndexFactory {
+ public:
+  virtual ~DenseIndexFactory() = default;
+
+  virtual std::string_view name() const = 0;
+
+  /// Creates a non-null reader. The reader's index column topology must remain
+  /// immutable for its lifetime.
+  virtual std::unique_ptr<DenseIndexReader> createReader(
+      Section rootSection,
+      const IndexLookup::Options& options,
+      velox::memory::MemoryPool* pool) const = 0;
+};
+
+/// Registers a process-wide factory. Call during process initialization,
+/// before concurrent factory lookups begin.
+void registerDenseIndexFactory(
+    std::shared_ptr<const DenseIndexFactory> factory);
+
+/// Returns a process-lifetime pointer, or nullptr for an unknown
+/// implementation. Concurrent access after registration is supported.
+const DenseIndexFactory* denseIndexFactory(std::string_view name);
+
+} // namespace facebook::nimble::index

--- a/dwio/nimble/index/DenseIndexRegistry.cpp
+++ b/dwio/nimble/index/DenseIndexRegistry.cpp
@@ -15,190 +15,83 @@
  */
 #include "dwio/nimble/index/DenseIndexRegistry.h"
 
-#include <fmt/ranges.h>
+#include <set>
 
 #include "dwio/nimble/common/Exceptions.h"
-#include "dwio/nimble/index/HashIndex.h"
-#include "dwio/nimble/index/SortedIndex.h"
-#include "dwio/nimble/tablet/HashIndexGenerated.h"
-#include "dwio/nimble/tablet/MetadataInput.h"
-#include "dwio/nimble/tablet/SortedIndexGenerated.h"
-#include "velox/dwio/common/BufferedInput.h"
-#include "velox/dwio/common/SeekableInputStream.h"
 
 namespace facebook::nimble::index {
-
 namespace {
 
-bool columnsMatch(
-    const std::vector<std::string>& indexColumns,
-    const std::vector<std::string>& queryColumns) {
-  if (indexColumns.size() != queryColumns.size()) {
-    return false;
+void validateIndexColumns(
+    const std::vector<std::vector<std::string>>& columns) {
+  NIMBLE_CHECK(!columns.empty(), "Dense index must contain columns");
+  for (const auto& columnSet : columns) {
+    NIMBLE_CHECK(!columnSet.empty(), "Dense index columns cannot be empty");
   }
-  for (size_t i = 0; i < indexColumns.size(); ++i) {
-    if (indexColumns[i] != queryColumns[i]) {
-      return false;
-    }
-  }
-  return true;
+  const std::set<std::vector<std::string>> uniqueColumns{
+      columns.begin(), columns.end()};
+  NIMBLE_CHECK_EQ(
+      uniqueColumns.size(),
+      columns.size(),
+      "Dense index contains duplicate column sets");
 }
 
 } // namespace
 
-template <typename FbDirectory>
-std::vector<DenseIndexRegistry::IndexDescriptor>
-DenseIndexRegistry::parseDescriptors(
-    const Section& directorySection,
-    const std::string& indexTypeName) {
-  const auto* root =
-      flatbuffers::GetRoot<FbDirectory>(directorySection.content().data());
-  NIMBLE_CHECK_NOT_NULL(root);
-  const auto* indices = root->indices();
-  NIMBLE_CHECK_NOT_NULL(indices);
-
-  std::vector<DenseIndexRegistry::IndexDescriptor> descriptors;
-  descriptors.reserve(indices->size());
-  for (const auto* indexSection : *indices) {
-    NIMBLE_CHECK_NOT_NULL(indexSection);
-    const auto* columns = indexSection->index_columns();
-    NIMBLE_CHECK_NOT_NULL(columns);
-    NIMBLE_CHECK_GT(columns->size(), 0u, "{} must have columns", indexTypeName);
-
-    std::vector<std::string> columnNames;
-    columnNames.reserve(columns->size());
-    for (const auto* col : *columns) {
-      columnNames.emplace_back(col->string_view());
-    }
-
-    for (const auto& descriptor : descriptors) {
-      NIMBLE_CHECK(
-          !columnsMatch(descriptor.columns, columnNames),
-          "Duplicate {} columns: [{}]",
-          indexTypeName,
-          fmt::join(columnNames, ", "));
-    }
-
-    const auto* sectionRef = indexSection->section();
-    NIMBLE_CHECK_NOT_NULL(sectionRef);
-    descriptors.emplace_back(
-        DenseIndexRegistry::IndexDescriptor{
-            std::move(columnNames),
-            MetadataSection{
-                sectionRef->offset(),
-                sectionRef->size(),
-                static_cast<CompressionType>(sectionRef->compression_type())}});
-  }
-  return descriptors;
-}
-
 std::unique_ptr<DenseIndexRegistry> DenseIndexRegistry::create(
-    std::optional<Section> hashSection,
-    std::optional<Section> sortedSection,
+    std::vector<Entry> entries,
     const IndexLookup::Options& options,
     velox::memory::MemoryPool* pool) {
   options.validate();
-  if (!hashSection.has_value() && !sortedSection.has_value()) {
+  if (entries.empty()) {
     return nullptr;
   }
-  auto metadataInput = createIndexMetadataInput(options);
-  auto dataInput = createIndexDataInput(options);
   auto registry = std::unique_ptr<DenseIndexRegistry>(new DenseIndexRegistry());
-  if (hashSection.has_value()) {
-    registry->registerHashIndices(
-        std::move(hashSection.value()), metadataInput, pool);
+  registry->denseIndices_.reserve(entries.size());
+  std::set<std::pair<std::string, std::vector<std::string>>> indexKeys;
+  for (auto& entry : entries) {
+    const auto* factory = denseIndexFactory(entry.name);
+    NIMBLE_CHECK_NOT_NULL(
+        factory, "Unknown dense index factory: {}", entry.name);
+    auto reader =
+        factory->createReader(std::move(entry.section), options, pool);
+    NIMBLE_CHECK_NOT_NULL(
+        reader, "Dense index factory returned a null reader: {}", entry.name);
+    auto columns = reader->indexColumns();
+    validateIndexColumns(columns);
+    for (const auto& columnSet : columns) {
+      NIMBLE_CHECK(
+          indexKeys.emplace(entry.name, columnSet).second,
+          "Duplicate dense index '{}' columns",
+          entry.name);
+    }
+    registry->denseIndices_.emplace_back(
+        DenseIndex{std::move(entry.name), std::move(reader)});
   }
-  if (sortedSection.has_value()) {
-    registry->registerSortedIndices(
-        std::move(sortedSection.value()), metadataInput, dataInput, pool);
-  }
-  registry->validate();
   return registry;
 }
 
-void DenseIndexRegistry::validate() const {
-  for (const auto& hashDescriptor : hashDescriptors_) {
-    for (const auto& sortedDescriptor : sortedDescriptors_) {
-      NIMBLE_CHECK(
-          !columnsMatch(hashDescriptor.columns, sortedDescriptor.columns),
-          "Duplicate dense index columns across hash and sorted: [{}]",
-          fmt::join(hashDescriptor.columns, ", "));
-    }
-  }
-}
-
-void DenseIndexRegistry::registerHashIndices(
-    Section directorySection,
-    std::shared_ptr<MetadataInput> metadataInput,
-    velox::memory::MemoryPool* pool) {
-  hashDescriptors_ = parseDescriptors<serialization::HashIndexDirectory>(
-      directorySection, "Hash index");
-
-  // Always pin: findHashIndex returns raw pointers, so entries must stay alive.
-  hashIndexCache_ = std::make_unique<MetadataCache<uint32_t, HashIndex>>(
-      [this, metadataInput, pool](
-          uint32_t index) -> std::shared_ptr<HashIndex> {
-        const auto& descriptor = hashDescriptors_[index];
-        auto results = metadataInput->load({&descriptor.section, 1});
-        NIMBLE_CHECK_EQ(results.size(), 1);
-        auto indexMetadata =
-            std::make_unique<MetadataBuffer>(std::move(*results.front()));
-        return HashIndex::create(
-            descriptor.columns, std::move(indexMetadata), metadataInput, pool);
-      },
-      /*pinEntries=*/true);
-}
-
-void DenseIndexRegistry::registerSortedIndices(
-    Section directorySection,
-    std::shared_ptr<MetadataInput> metadataInput,
-    std::shared_ptr<velox::dwio::common::BufferedInput> dataInput,
-    velox::memory::MemoryPool* pool) {
-  sortedDescriptors_ = parseDescriptors<serialization::SortedIndexDirectory>(
-      directorySection, "Sorted index");
-
-  // Always pin: findSortedIndex returns raw pointers, so entries must stay
-  // alive.
-  sortedIndexCache_ = std::make_unique<MetadataCache<uint32_t, SortedIndex>>(
-      [this, metadataInput, dataInput, pool](
-          uint32_t index) -> std::shared_ptr<SortedIndex> {
-        const auto& descriptor = sortedDescriptors_[index];
-        auto results = metadataInput->load({&descriptor.section, 1});
-        NIMBLE_CHECK_EQ(results.size(), 1);
-        auto indexMetadata =
-            std::make_unique<MetadataBuffer>(std::move(*results.front()));
-        return SortedIndex::create(
-            descriptor.columns, std::move(indexMetadata), dataInput, pool);
-      },
-      /*pinEntries=*/true);
-}
-
-const HashIndex* DenseIndexRegistry::findHashIndex(
+const IndexLookup* DenseIndexRegistry::findIndex(
     const std::vector<std::string>& queryColumns) const {
-  for (uint32_t i = 0; i < hashDescriptors_.size(); ++i) {
-    if (columnsMatch(hashDescriptors_[i].columns, queryColumns)) {
-      return hashIndexCache_->getOrCreate(i).get();
-    }
-  }
-  return nullptr;
-}
-
-const SortedIndex* DenseIndexRegistry::findSortedIndex(
-    const std::vector<std::string>& queryColumns) const {
-  for (uint32_t i = 0; i < sortedDescriptors_.size(); ++i) {
-    if (columnsMatch(sortedDescriptors_[i].columns, queryColumns)) {
-      return sortedIndexCache_->getOrCreate(i).get();
+  for (const auto& denseIndex : denseIndices_) {
+    if (const auto* index = denseIndex.reader->findIndex(queryColumns)) {
+      return index;
     }
   }
   return nullptr;
 }
 
 const IndexLookup* DenseIndexRegistry::findIndex(
+    std::string_view name,
     const std::vector<std::string>& queryColumns) const {
-  if (auto* hashIdx = findHashIndex(queryColumns)) {
-    return hashIdx;
+  for (const auto& denseIndex : denseIndices_) {
+    if (denseIndex.name == name) {
+      if (const auto* index = denseIndex.reader->findIndex(queryColumns)) {
+        return index;
+      }
+    }
   }
-  return findSortedIndex(queryColumns);
+  return nullptr;
 }
 
 } // namespace facebook::nimble::index

--- a/dwio/nimble/index/DenseIndexRegistry.h
+++ b/dwio/nimble/index/DenseIndexRegistry.h
@@ -16,32 +16,29 @@
 #pragma once
 
 #include <memory>
-#include <optional>
 #include <string>
 #include <vector>
 
+#include "dwio/nimble/index/DenseIndexFactory.h"
 #include "dwio/nimble/index/IndexLookup.h"
 #include "dwio/nimble/tablet/MetadataBuffer.h"
-#include "dwio/nimble/tablet/MetadataCache.h"
 
 namespace facebook::nimble::index {
 
-class HashIndex;
-class SortedIndex;
-
-/// Unified registry for dense indices (hash and sorted) on a Nimble file.
+/// Unified registry for built-in and registered dense indices on a Nimble file.
 ///
-/// Loads dense index payloads referenced by the common index manifest and
-/// validates no duplicate column sets across index types.
+/// Loads index payloads referenced by the common index manifest.
 class DenseIndexRegistry {
  public:
-  /// Creates a registry from optional hash and sorted index sections.
-  /// Returns nullptr if both sections are empty.
-  /// Creates with Options — indexes create their own MetadataInput
-  /// internally with index-specific IO stats.
+  struct Entry {
+    std::string name;
+    Section section;
+  };
+
+  /// Creates readers by dispatching each named root section to its registered
+  /// factory. Returns nullptr if entries is empty.
   static std::unique_ptr<DenseIndexRegistry> create(
-      std::optional<Section> hashSection,
-      std::optional<Section> sortedSection,
+      std::vector<Entry> entries,
       const IndexLookup::Options& options,
       velox::memory::MemoryPool* pool);
 
@@ -49,46 +46,19 @@ class DenseIndexRegistry {
   const IndexLookup* findIndex(
       const std::vector<std::string>& queryColumns) const;
 
+  /// Finds the dense index with the given implementation name and columns.
+  const IndexLookup* findIndex(
+      std::string_view name,
+      const std::vector<std::string>& queryColumns) const;
+
  private:
   DenseIndexRegistry() = default;
 
-  void registerHashIndices(
-      Section directorySection,
-      std::shared_ptr<MetadataInput> metadataInput,
-      velox::memory::MemoryPool* pool);
-
-  void registerSortedIndices(
-      Section directorySection,
-      std::shared_ptr<MetadataInput> metadataInput,
-      std::shared_ptr<velox::dwio::common::BufferedInput> dataInput,
-      velox::memory::MemoryPool* pool);
-
-  struct IndexDescriptor {
-    std::vector<std::string> columns;
-    MetadataSection section;
+  struct DenseIndex {
+    std::string name;
+    std::unique_ptr<DenseIndexReader> reader;
   };
-
-  const HashIndex* findHashIndex(
-      const std::vector<std::string>& queryColumns) const;
-
-  const SortedIndex* findSortedIndex(
-      const std::vector<std::string>& queryColumns) const;
-
-  void validate() const;
-
-  template <typename FbDirectory>
-  static std::vector<IndexDescriptor> parseDescriptors(
-      const Section& directorySection,
-      const std::string& indexTypeName);
-
-  // Hash index state.
-  std::vector<IndexDescriptor> hashDescriptors_;
-  mutable std::unique_ptr<MetadataCache<uint32_t, HashIndex>> hashIndexCache_;
-
-  // Sorted index state.
-  std::vector<IndexDescriptor> sortedDescriptors_;
-  mutable std::unique_ptr<MetadataCache<uint32_t, SortedIndex>>
-      sortedIndexCache_;
+  std::vector<DenseIndex> denseIndices_;
 };
 
 } // namespace facebook::nimble::index

--- a/dwio/nimble/index/IndexFactoryRegistry.h
+++ b/dwio/nimble/index/IndexFactoryRegistry.h
@@ -1,0 +1,83 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <memory>
+#include <string>
+#include <string_view>
+
+#include "dwio/nimble/common/Exceptions.h"
+#include "dwio/nimble/index/IndexConfig.h"
+#include "folly/Synchronized.h"
+#include "folly/container/F14Map.h"
+
+namespace facebook::nimble::index {
+
+template <typename Factory>
+class IndexFactoryRegistry {
+ public:
+  explicit IndexFactoryRegistry(IndexFamily family) : family_{family} {}
+
+  void registerFactory(std::shared_ptr<const Factory> factory) {
+    NIMBLE_CHECK_NOT_NULL(factory);
+    const auto name = std::string{factory->name()};
+    NIMBLE_CHECK(
+        !name.empty(),
+        "Index factory name cannot be empty for family '{}'",
+        familyName(family_));
+    auto factories = factories_.wlock();
+    auto [_, inserted] = factories->emplace(name, std::move(factory));
+    NIMBLE_CHECK(
+        inserted,
+        "Index factory '{}' is already registered for family '{}'",
+        name,
+        familyName(family_));
+  }
+
+  const Factory& get(std::string_view name) const {
+    const auto* factory = tryGet(name);
+    NIMBLE_CHECK_NOT_NULL(
+        factory,
+        "Unknown index factory '{}' for family '{}'",
+        name,
+        familyName(family_));
+    return *factory;
+  }
+
+  const Factory* tryGet(std::string_view name) const {
+    auto factories = factories_.rlock();
+    auto it = factories->find(name);
+    return it == factories->end() ? nullptr : it->second.get();
+  }
+
+ private:
+  static std::string_view familyName(IndexFamily family) {
+    switch (family) {
+      case IndexFamily::Cluster:
+        return "cluster";
+      case IndexFamily::Dense:
+        return "dense";
+    }
+    NIMBLE_UNREACHABLE("Unsupported index family");
+  }
+
+  const IndexFamily family_;
+  folly::Synchronized<
+      folly::F14FastMap<std::string, std::shared_ptr<const Factory>>>
+      factories_;
+};
+
+} // namespace facebook::nimble::index

--- a/dwio/nimble/index/IndexWriter.h
+++ b/dwio/nimble/index/IndexWriter.h
@@ -35,6 +35,8 @@ namespace facebook::nimble::index {
 ///   2. For each batch: write(batch)
 ///   3. At stripe group boundaries: flush() to write index data
 ///   4. At file close: close() to finalize, serialize, and release resources
+/// Calls are serialized by the owning VeloxWriter; implementations do not need
+/// to support concurrent lifecycle calls.
 class IndexWriter {
  public:
   virtual ~IndexWriter() = default;

--- a/dwio/nimble/index/tests/DenseIndexRegistryTest.cpp
+++ b/dwio/nimble/index/tests/DenseIndexRegistryTest.cpp
@@ -17,7 +17,6 @@
 #include <gtest/gtest.h>
 #include <deque>
 
-#include "dwio/nimble/common/tests/GTestUtils.h"
 #include "dwio/nimble/index/DenseIndexRegistry.h"
 #include "dwio/nimble/index/HashIndex.h"
 #include "dwio/nimble/index/IndexConfig.h"
@@ -128,8 +127,7 @@ TEST_F(DenseIndexRegistryTest, emptyRegistry) {
   ioOptions.setMetadataIoStats(ioStats);
   ioOptions.setIndexIoStats(std::make_shared<velox::io::IoStatistics>());
   IndexLookup::Options options{.file = file, .ioOptions = &ioOptions};
-  auto registry = DenseIndexRegistry::create(
-      std::nullopt, std::nullopt, options, leafPool_.get());
+  auto registry = DenseIndexRegistry::create({}, options, leafPool_.get());
   EXPECT_EQ(registry, nullptr);
 }
 
@@ -225,7 +223,7 @@ TEST_F(DenseIndexRegistryTest, indexCacheRetention) {
   EXPECT_EQ(tablet->denseIndex({"nonexistent"}), nullptr);
 }
 
-TEST_F(DenseIndexRegistryTest, crossTypeDuplicateColumns) {
+TEST_F(DenseIndexRegistryTest, firstIndexWinsForDuplicateColumns) {
   std::vector<velox::VectorPtr> batches;
   batches.push_back(makeBatch(0, 50));
 
@@ -234,14 +232,16 @@ TEST_F(DenseIndexRegistryTest, crossTypeDuplicateColumns) {
   options.hashIndexConfigs.push_back(HashIndexConfig{.columns = {"id"}});
   options.sortedIndexConfigs.push_back(SortedIndexConfig{.columns = {"id"}});
 
-  // The writer does not validate across index types, so writing succeeds.
   writeFile(filePath, rowType(), batches, std::move(options));
 
-  // Opening the file should throw because the registry detects duplicate
-  // column sets across hash and sorted index types.
-  NIMBLE_ASSERT_THROW(
-      openTablet(filePath),
-      "Duplicate dense index columns across hash and sorted");
+  auto tablet = openTablet(filePath);
+  const auto* index = tablet->denseIndex({"id"});
+  ASSERT_NE(index, nullptr);
+  EXPECT_EQ(index->type(), IndexType::Hash);
+
+  const auto* sortedIndex = tablet->denseIndex(kDenseSortedIndexName, {"id"});
+  ASSERT_NE(sortedIndex, nullptr);
+  EXPECT_EQ(sortedIndex->type(), IndexType::Sorted);
 }
 
 } // namespace

--- a/dwio/nimble/index/tests/IndexFactoryTest.cpp
+++ b/dwio/nimble/index/tests/IndexFactoryTest.cpp
@@ -16,11 +16,18 @@
 
 #include <gtest/gtest.h>
 
+#include <atomic>
+#include <thread>
+
 #include "dwio/nimble/common/Buffer.h"
 #include "dwio/nimble/common/Exceptions.h"
 #include "dwio/nimble/common/tests/GTestUtils.h"
 #include "dwio/nimble/index/ClusterIndexFactory.h"
+#include "dwio/nimble/index/DenseIndexFactory.h"
+#include "dwio/nimble/index/DenseIndexRegistry.h"
 #include "dwio/nimble/index/IndexKeyEncoder.h"
+#include "dwio/nimble/tablet/Constants.h"
+#include "dwio/nimble/tablet/IndexGenerated.h"
 #include "dwio/nimble/tablet/TabletReader.h"
 #include "dwio/nimble/velox/VeloxWriter.h"
 #include "velox/common/file/FileSystems.h"
@@ -34,6 +41,7 @@ namespace facebook::nimble::index::test {
 namespace {
 
 constexpr std::string_view kCustomClusterIndexName{"test.cluster.v1"};
+constexpr std::string_view kCustomDenseIndexName{"test.dense.v1"};
 
 class RenamedIndexWriter final : public IndexWriter {
  public:
@@ -101,6 +109,38 @@ class TestClusterIndexFactory final : public ClusterIndexFactory {
   }
 };
 
+class TestDenseIndexReader final : public DenseIndexReader {
+ public:
+  const IndexLookup* findIndex(const std::vector<std::string>&) const override {
+    return nullptr;
+  }
+
+  std::vector<std::vector<std::string>> indexColumns() const override {
+    return {{"id"}};
+  }
+};
+
+class TestDenseIndexFactory final : public DenseIndexFactory {
+ public:
+  explicit TestDenseIndexFactory(
+      std::string name = std::string{kCustomDenseIndexName})
+      : name_{std::move(name)} {}
+
+  std::string_view name() const override {
+    return name_;
+  }
+
+  std::unique_ptr<DenseIndexReader> createReader(
+      Section,
+      const IndexLookup::Options&,
+      velox::memory::MemoryPool*) const override {
+    return std::make_unique<TestDenseIndexReader>();
+  }
+
+ private:
+  const std::string name_;
+};
+
 class IndexFactoryTest : public testing::Test {
  protected:
   static void SetUpTestSuite() {
@@ -108,6 +148,7 @@ class IndexFactoryTest : public testing::Test {
     velox::memory::MemoryManager::testingSetInstance({});
     registerClusterIndexFactory(
         std::make_shared<const TestClusterIndexFactory>());
+    registerDenseIndexFactory(std::make_shared<const TestDenseIndexFactory>());
   }
 
   void SetUp() override {
@@ -136,6 +177,19 @@ class IndexFactoryTest : public testing::Test {
         std::vector<velox::VectorPtr>{ids});
   }
 
+  std::unique_ptr<VeloxWriter> makeWriter(
+      std::string_view pathSuffix,
+      VeloxWriterOptions options) {
+    const auto path = tempDirectory_->getPath() + "/" + std::string{pathSuffix};
+    auto fileSystem = velox::filesystems::getFileSystem(path, {});
+    auto file = fileSystem->openFileForWrite(
+        path,
+        {.shouldCreateParentDirectories = true,
+         .shouldThrowOnFileAlreadyExists = false});
+    return std::make_unique<VeloxWriter>(
+        rowType(), std::move(file), *rootPool_, std::move(options));
+  }
+
   std::string writeFile() {
     const auto path = tempDirectory_->getPath() + "/custom_indexes";
     auto fileSystem = velox::filesystems::getFileSystem(path, {});
@@ -161,6 +215,7 @@ class IndexFactoryTest : public testing::Test {
     auto fileSystem = velox::filesystems::getFileSystem(path, {});
     TabletReader::Options options;
     options.loadClusterIndex = true;
+    options.loadDenseIndexes = true;
     options.clusterIndexName = std::move(clusterIndexName);
     options.ioOptions.emplace(leafPool_.get())
         .setMetadataIoStats(std::make_shared<velox::io::IoStatistics>())
@@ -215,17 +270,132 @@ TEST_F(IndexFactoryTest, builtInClusterFactoryIsRegistered) {
   EXPECT_EQ(clusterIndexFactory(kClusterIndexName).name(), kClusterIndexName);
 }
 
+TEST_F(IndexFactoryTest, builtInDenseFactoriesAreRegistered) {
+  EXPECT_EQ(
+      denseIndexFactory(kDenseHashIndexName)->name(), kDenseHashIndexName);
+  EXPECT_EQ(
+      denseIndexFactory(kDenseSortedIndexName)->name(), kDenseSortedIndexName);
+}
+
 TEST_F(IndexFactoryTest, rejectDuplicateClusterFactoryRegistration) {
   NIMBLE_ASSERT_THROW(
       registerClusterIndexFactory(
           std::make_shared<const TestClusterIndexFactory>()),
-      "Cluster index factory already registered: test.cluster.v1");
+      "Index factory 'test.cluster.v1' is already registered for family 'cluster'");
+}
+
+TEST_F(IndexFactoryTest, rejectDuplicateDenseFactoryRegistration) {
+  NIMBLE_ASSERT_THROW(
+      registerDenseIndexFactory(
+          std::make_shared<const TestDenseIndexFactory>()),
+      "Index factory 'test.dense.v1' is already registered for family 'dense'");
 }
 
 TEST_F(IndexFactoryTest, rejectUnknownClusterFactory) {
   NIMBLE_ASSERT_THROW(
       clusterIndexFactory("test.missing.cluster.v1"),
-      "Unknown cluster index factory: test.missing.cluster.v1");
+      "Unknown index factory 'test.missing.cluster.v1' for family 'cluster'");
+}
+
+TEST_F(IndexFactoryTest, rejectUnknownDenseFactory) {
+  EXPECT_EQ(denseIndexFactory("test.missing.dense.v1"), nullptr);
+}
+
+TEST_F(IndexFactoryTest, rejectDuplicateDenseIndex) {
+  auto file = std::make_shared<velox::InMemoryReadFile>(std::string{});
+  auto ioStats = std::make_shared<velox::io::IoStatistics>();
+  velox::io::ReaderOptions ioOptions{leafPool_.get()};
+  ioOptions.setMetadataIoStats(ioStats);
+  ioOptions.setIndexIoStats(ioStats);
+  IndexLookup::Options options{.file = file, .ioOptions = &ioOptions};
+
+  auto makeSection = [&] {
+    return Section{MetadataBuffer{
+        velox::AlignedBuffer::allocate<char>(1, leafPool_.get())}};
+  };
+  std::vector<DenseIndexRegistry::Entry> entries;
+  entries.emplace_back(
+      DenseIndexRegistry::Entry{
+          std::string{kCustomDenseIndexName}, makeSection()});
+  entries.emplace_back(
+      DenseIndexRegistry::Entry{
+          std::string{kCustomDenseIndexName}, makeSection()});
+
+  NIMBLE_ASSERT_THROW(
+      DenseIndexRegistry::create(std::move(entries), options, leafPool_.get()),
+      "Duplicate dense index 'test.dense.v1' columns");
+}
+
+TEST_F(IndexFactoryTest, concurrentFactoryAccess) {
+  constexpr size_t kFactoryCount = 32;
+  constexpr size_t kReaderCount = 8;
+  std::vector<std::shared_ptr<const TestDenseIndexFactory>> factories;
+  factories.reserve(kFactoryCount);
+  for (size_t i = 0; i < kFactoryCount; ++i) {
+    factories.emplace_back(
+        std::make_shared<const TestDenseIndexFactory>(
+            "test.concurrent.dense." + std::to_string(i)));
+  }
+
+  std::vector<std::thread> threads;
+  threads.reserve(kFactoryCount);
+  for (const auto& factory : factories) {
+    threads.emplace_back([factory] { registerDenseIndexFactory(factory); });
+  }
+  for (auto& thread : threads) {
+    thread.join();
+  }
+
+  std::atomic_bool lookupFailed{false};
+  threads.clear();
+  threads.reserve(kReaderCount);
+  for (size_t i = 0; i < kReaderCount; ++i) {
+    threads.emplace_back([&factories, &lookupFailed] {
+      for (const auto& factory : factories) {
+        if (denseIndexFactory(factory->name()) != factory.get()) {
+          lookupFailed = true;
+        }
+      }
+    });
+  }
+  for (auto& thread : threads) {
+    thread.join();
+  }
+  EXPECT_FALSE(lookupFailed);
+}
+
+TEST_F(IndexFactoryTest, preserveTypedIndexDescriptorOrder) {
+  VeloxWriterOptions options;
+  options.hashIndexConfigs.emplace_back(HashIndexConfig{.columns = {"id"}});
+  options.sortedIndexConfigs.emplace_back(SortedIndexConfig{.columns = {"id"}});
+  options.clusterIndexConfig =
+      ClusterIndexConfig{.columns = {"id"}, .enforceKeyOrder = true};
+  auto writer = makeWriter("typed_descriptor_order", std::move(options));
+  writer->write(makeBatch());
+  writer->close();
+
+  const auto path = tempDirectory_->getPath() + "/typed_descriptor_order";
+  auto fileSystem = velox::filesystems::getFileSystem(path, {});
+  TabletReader::Options readerOptions;
+  readerOptions.ioOptions.emplace(leafPool_.get())
+      .setMetadataIoStats(std::make_shared<velox::io::IoStatistics>());
+  auto tablet = TabletReader::create(
+      fileSystem->openFileForRead(path), leafPool_.get(), readerOptions);
+  auto section = tablet->loadOptionalSection(std::string{kIndexSection});
+  ASSERT_TRUE(section.has_value());
+  const auto* root =
+      flatbuffers::GetRoot<serialization::IndexRoot>(section->content().data());
+  ASSERT_NE(root->indexes(), nullptr);
+  std::vector<std::string> names;
+  for (const auto* descriptor : *root->indexes()) {
+    names.emplace_back(descriptor->name()->str());
+  }
+  EXPECT_EQ(
+      names,
+      (std::vector<std::string>{
+          std::string{kDenseHashIndexName},
+          std::string{kDenseSortedIndexName},
+          std::string{kClusterIndexName}}));
 }
 
 } // namespace

--- a/dwio/nimble/tablet/TabletReader.cpp
+++ b/dwio/nimble/tablet/TabletReader.cpp
@@ -24,6 +24,7 @@
 #include "dwio/nimble/tablet/FooterGenerated.h"
 #include "dwio/nimble/tablet/IndexGenerated.h"
 #include "dwio/nimble/tablet/StripeGroup.h"
+#include "folly/container/F14Map.h"
 #include "velox/dwio/common/SeekableInputStream.h"
 
 #include "flatbuffers/flatbuffers.h"
@@ -279,7 +280,7 @@ void TabletReader::init(const Options& options) {
   loadSections(sections);
 
   initStripes(footerView, footerOffset);
-  initIndexes();
+  initIndexDescriptors();
   initClusterIndex();
   initChunkIndex(footerView, footerOffset);
   initDenseIndexes();
@@ -404,7 +405,7 @@ bool TabletReader::initFromCache(const Options& options) {
   loadSections(sections);
 
   initStripes();
-  initIndexes();
+  initIndexDescriptors();
   initClusterIndex();
   initChunkIndex();
   initDenseIndexes();
@@ -1073,22 +1074,15 @@ const index::IndexDescriptor* TabletReader::findIndexDescriptor(
     index::IndexFamily family,
     std::string_view indexName) const {
   NIMBLE_CHECK(!indexName.empty(), "Index name cannot be empty");
-  const index::IndexDescriptor* result = nullptr;
   for (const auto& descriptor : indexDescriptors_) {
-    if (descriptor.family != family || descriptor.name != indexName) {
-      continue;
+    if (descriptor.family == family && descriptor.name == indexName) {
+      return &descriptor;
     }
-    NIMBLE_CHECK(
-        result == nullptr,
-        "Nimble file contains multiple indexes for family {} and name '{}'",
-        static_cast<int>(family),
-        indexName);
-    result = &descriptor;
   }
-  return result;
+  return nullptr;
 }
 
-void TabletReader::initIndexes() {
+void TabletReader::initIndexDescriptors() {
   if (!loadClusterIndex_ && !loadDenseIndexes_) {
     return;
   }
@@ -1105,6 +1099,7 @@ void TabletReader::initIndexes() {
   NIMBLE_CHECK_NOT_NULL(root);
   const auto* indexes = root->indexes();
   NIMBLE_CHECK_NOT_NULL(indexes);
+  NIMBLE_CHECK_GT(indexes->size(), 0u, "Index section contains no descriptors");
 
   for (const auto* descriptor : *indexes) {
     NIMBLE_CHECK_NOT_NULL(descriptor);
@@ -1112,11 +1107,20 @@ void TabletReader::initIndexes() {
     NIMBLE_CHECK_NOT_NULL(name, "Index descriptor name is missing");
     const auto* indexRoot = descriptor->root();
     NIMBLE_CHECK_NOT_NULL(indexRoot, "Index descriptor root is missing");
-    indexDescriptors_.emplace_back(
-        index::IndexDescriptor{
-            .family = index::toIndexFamily(descriptor->family()),
-            .name = name->str(),
-            .root = toMetadataSection(indexRoot)});
+    auto indexDescriptor = index::IndexDescriptor{
+        .family = index::toIndexFamily(descriptor->family()),
+        .name = name->str(),
+        .root = toMetadataSection(indexRoot)};
+    if (indexDescriptor.family == index::IndexFamily::Cluster) {
+      for (const auto& existing : indexDescriptors_) {
+        NIMBLE_CHECK(
+            existing.family != index::IndexFamily::Cluster ||
+                existing.name != indexDescriptor.name,
+            "Nimble file contains multiple cluster indexes named '{}'",
+            indexDescriptor.name);
+      }
+    }
+    indexDescriptors_.emplace_back(std::move(indexDescriptor));
   }
 }
 
@@ -1151,23 +1155,31 @@ const index::IndexLookup* TabletReader::denseIndex(
   return denseIndexRegistry_->findIndex(columns);
 }
 
+const index::IndexLookup* TabletReader::denseIndex(
+    std::string_view name,
+    const std::vector<std::string>& columns) const {
+  if (denseIndexRegistry_ == nullptr) {
+    return nullptr;
+  }
+  return denseIndexRegistry_->findIndex(name, columns);
+}
+
 void TabletReader::initDenseIndexes() {
   if (!loadDenseIndexes_) {
     return;
   }
-  const auto* hashIndex = findIndexDescriptor(
-      index::IndexFamily::Dense, index::kDenseHashIndexName);
-  const auto* sortedIndex = findIndexDescriptor(
-      index::IndexFamily::Dense, index::kDenseSortedIndexName);
+  std::vector<index::DenseIndexRegistry::Entry> entries;
+  for (const auto& descriptor : indexDescriptors_) {
+    if (descriptor.family != index::IndexFamily::Dense) {
+      continue;
+    }
+    entries.emplace_back(
+        index::DenseIndexRegistry::Entry{
+            descriptor.name,
+            Section{std::move(*readMetadata(descriptor.root))}});
+  }
   denseIndexRegistry_ = index::DenseIndexRegistry::create(
-      hashIndex == nullptr ? std::nullopt
-                           : std::optional<Section>{Section{
-                                 std::move(*readMetadata(hashIndex->root))}},
-      sortedIndex == nullptr ? std::nullopt
-                             : std::optional<Section>{Section{std::move(
-                                   *readMetadata(sortedIndex->root))}},
-      indexOptions_,
-      pool_);
+      std::move(entries), indexOptions_, pool_);
 }
 
 void TabletReader::initChunkIndex(

--- a/dwio/nimble/tablet/TabletReader.h
+++ b/dwio/nimble/tablet/TabletReader.h
@@ -261,6 +261,11 @@ class TabletReader {
   const index::IndexLookup* denseIndex(
       const std::vector<std::string>& columns) const;
 
+  /// Finds the dense index with the given implementation name and columns.
+  const index::IndexLookup* denseIndex(
+      std::string_view name,
+      const std::vector<std::string>& columns) const;
+
   uint64_t fileSize() const {
     return fileSize_;
   }
@@ -456,7 +461,7 @@ class TabletReader {
   std::shared_ptr<StripeGroup> loadStripeGroup(uint32_t stripeGroupIndex) const;
 
   // Parses the shared index section and caches its runtime descriptors.
-  void initIndexes();
+  void initIndexDescriptors();
 
   // Finds the unique descriptor matching the family and name.
   // Returns nullptr when no descriptor matches.

--- a/dwio/nimble/velox/VeloxWriter.cpp
+++ b/dwio/nimble/velox/VeloxWriter.cpp
@@ -24,7 +24,9 @@
 #include "dwio/nimble/common/Types.h"
 #include "dwio/nimble/encodings/selection/EncodingSelectionPolicy.h"
 #include "dwio/nimble/index/ClusterIndexFactory.h"
+#include "dwio/nimble/index/HashIndexWriter.h"
 #include "dwio/nimble/index/IndexSerialization.h"
+#include "dwio/nimble/index/SortedIndexWriter.h"
 #include "dwio/nimble/tablet/Constants.h"
 #include "dwio/nimble/tablet/IndexGenerated.h"
 #include "dwio/nimble/velox/BufferGrowthPolicy.h"
@@ -44,6 +46,7 @@
 #include "velox/common/testutil/TestValue.h"
 #include "velox/common/time/CpuWallTimer.h"
 #include "velox/common/time/Timer.h"
+#include "velox/dwio/common/ExecutorBarrier.h"
 #include "velox/type/Type.h"
 
 namespace facebook::nimble {
@@ -228,17 +231,6 @@ class WriterContext : public FieldWriterContext {
 } // namespace detail
 
 namespace {
-
-std::unique_ptr<index::IndexWriter> createClusterIndexWriter(
-    const std::optional<index::ClusterIndexConfig>& config,
-    const velox::TypePtr& type,
-    velox::memory::MemoryPool* pool) {
-  if (!config.has_value()) {
-    return nullptr;
-  }
-  return index::clusterIndexFactory(config->indexName)
-      .createWriter(config.value(), type, pool);
-}
 
 std::string_view asView(const flatbuffers::FlatBufferBuilder& builder) {
   return {
@@ -816,6 +808,53 @@ void initializeEncodingLayouts(
 }
 } // namespace
 
+std::optional<VeloxWriter::IndexWriterEntry>
+VeloxWriter::createClusterIndexWriter(
+    const VeloxWriterOptions& options,
+    const velox::TypePtr& type,
+    velox::memory::MemoryPool* pool) {
+  std::optional<IndexWriterEntry> result;
+  if (options.clusterIndexConfig.has_value()) {
+    const auto& config = options.clusterIndexConfig.value();
+    auto writer = index::clusterIndexFactory(config.indexName)
+                      .createWriter(config, type, pool);
+    NIMBLE_CHECK_NOT_NULL(
+        writer,
+        "Cluster index factory returned a null writer: {}",
+        config.indexName);
+    result.emplace(
+        IndexWriterEntry{
+            index::IndexFamily::Cluster, config.indexName, std::move(writer)});
+  }
+  return result;
+}
+
+std::vector<VeloxWriter::IndexWriterEntry> VeloxWriter::createDenseIndexWriters(
+    const VeloxWriterOptions& options,
+    const velox::TypePtr& type,
+    velox::memory::MemoryPool* pool) {
+  std::vector<IndexWriterEntry> writers;
+  writers.reserve(
+      !options.hashIndexConfigs.empty() + !options.sortedIndexConfigs.empty());
+  if (!options.hashIndexConfigs.empty()) {
+    writers.emplace_back(
+        IndexWriterEntry{
+            index::IndexFamily::Dense,
+            std::string{index::kDenseHashIndexName},
+            index::HashIndexWriter::create(
+                options.hashIndexConfigs, type, pool)});
+  }
+  if (!options.sortedIndexConfigs.empty()) {
+    writers.emplace_back(
+        IndexWriterEntry{
+            index::IndexFamily::Dense,
+            std::string{index::kDenseSortedIndexName},
+            index::SortedIndexWriter::create(
+                options.sortedIndexConfigs, type, pool)});
+  }
+  return writers;
+}
+
 VeloxWriter::VeloxWriter(
     const velox::TypePtr& type,
     std::unique_ptr<velox::WriteFile> file,
@@ -840,15 +879,11 @@ VeloxWriter::VeloxWriter(
           std::move(options))},
       file_{std::move(file)},
       clusterIndexWriter_{createClusterIndexWriter(
-          context_->options().clusterIndexConfig,
+          context_->options(),
           type,
           &(*context_->bufferMemoryPool()))},
-      hashIndexWriter_{index::HashIndexWriter::create(
-          context_->options().hashIndexConfigs,
-          type,
-          &(*context_->bufferMemoryPool()))},
-      sortedIndexWriter_{index::SortedIndexWriter::create(
-          context_->options().sortedIndexConfigs,
+      denseIndexWriters_{createDenseIndexWriters(
+          context_->options(),
           type,
           &(*context_->bufferMemoryPool()))},
       tabletWriter_{TabletWriter::create(
@@ -871,13 +906,19 @@ VeloxWriter::VeloxWriter(
            .stripeGroupEncodingLayoutReadFactors =
                context_->options()
                    .experimentalStripeGroupEncodingLayoutReadFactors,
-           .stripeGroupFlushCallback = clusterIndexWriter_ != nullptr
+           .stripeGroupFlushCallback =
+               (clusterIndexWriter_.has_value() || !denseIndexWriters_.empty())
                ? TabletWriter::StripeGroupFlushCallback(
                      [this](
                          const WriteDataFn& writeDataFn,
                          const CreateMetadataSectionFn& createMetadataFn) {
-                       clusterIndexWriter_->flush(
-                           writeDataFn, createMetadataFn);
+                       if (clusterIndexWriter_.has_value()) {
+                         clusterIndexWriter_->writer->flush(
+                             writeDataFn, createMetadataFn);
+                       }
+                       for (const auto& entry : denseIndexWriters_) {
+                         entry.writer->flush(writeDataFn, createMetadataFn);
+                       }
                      })
                : nullptr,
            .closeCallback = [this](
@@ -1042,62 +1083,12 @@ void VeloxWriter::writeSchema() {
       serializer.serialize(context_->schemaBuilder()));
 }
 
-bool VeloxWriter::hasClusterIndex() const {
-  return clusterIndexWriter_ != nullptr;
-}
-
-bool VeloxWriter::hasHashIndex() const {
-  return hashIndexWriter_ != nullptr;
-}
-
-bool VeloxWriter::hasSortedIndex() const {
-  return sortedIndexWriter_ != nullptr;
-}
-
-void VeloxWriter::addIndexKey(
-    const velox::VectorPtr& input,
-    velox::dwio::common::ExecutorBarrier* barrier) {
-  addClusterIndexKey(input, barrier);
-  addHashIndexKey(input, barrier);
-  addSortedIndexKey(input, barrier);
-}
-
-void VeloxWriter::addClusterIndexKey(
-    const velox::VectorPtr& input,
-    velox::dwio::common::ExecutorBarrier* barrier) {
-  if (!hasClusterIndex()) {
-    return;
+void VeloxWriter::addIndexKey(const velox::VectorPtr& input) {
+  if (clusterIndexWriter_.has_value()) {
+    clusterIndexWriter_->writer->write(input);
   }
-  if (barrier != nullptr) {
-    barrier->add([&]() { clusterIndexWriter_->write(input); });
-  } else {
-    clusterIndexWriter_->write(input);
-  }
-}
-
-void VeloxWriter::addHashIndexKey(
-    const velox::VectorPtr& input,
-    velox::dwio::common::ExecutorBarrier* barrier) {
-  if (!hasHashIndex()) {
-    return;
-  }
-  if (barrier != nullptr) {
-    barrier->add([&]() { hashIndexWriter_->write(input); });
-  } else {
-    hashIndexWriter_->write(input);
-  }
-}
-
-void VeloxWriter::addSortedIndexKey(
-    const velox::VectorPtr& input,
-    velox::dwio::common::ExecutorBarrier* barrier) {
-  if (!hasSortedIndex()) {
-    return;
-  }
-  if (barrier != nullptr) {
-    barrier->add([&]() { sortedIndexWriter_->write(input); });
-  } else {
-    sortedIndexWriter_->write(input);
+  for (const auto& entry : denseIndexWriters_) {
+    entry.writer->write(input);
   }
 }
 
@@ -1106,21 +1097,34 @@ void VeloxWriter::writeIndexes(
     const CreateMetadataSectionFn& createMetadataFn,
     const WriteOptionalSectionFn& writeMetadataFn) {
   std::vector<index::IndexDescriptor> descriptors;
-  if (hasHashIndex()) {
-    if (auto descriptor =
-            hashIndexWriter_->close(writeDataFn, createMetadataFn)) {
+  for (const auto& entry : denseIndexWriters_) {
+    if (auto descriptor = entry.writer->close(writeDataFn, createMetadataFn)) {
+      NIMBLE_CHECK_EQ(
+          descriptor->family,
+          entry.family,
+          "Index writer returned an unexpected family for {}",
+          entry.name);
+      NIMBLE_CHECK_EQ(
+          descriptor->name,
+          entry.name,
+          "Index writer returned an unexpected name for {}",
+          entry.name);
       descriptors.emplace_back(std::move(descriptor.value()));
     }
   }
-  if (hasSortedIndex()) {
-    if (auto descriptor =
-            sortedIndexWriter_->close(writeDataFn, createMetadataFn)) {
-      descriptors.emplace_back(std::move(descriptor.value()));
-    }
-  }
-  if (hasClusterIndex()) {
-    if (auto descriptor =
-            clusterIndexWriter_->close(writeDataFn, createMetadataFn)) {
+  if (clusterIndexWriter_.has_value()) {
+    const auto& entry = clusterIndexWriter_.value();
+    if (auto descriptor = entry.writer->close(writeDataFn, createMetadataFn)) {
+      NIMBLE_CHECK_EQ(
+          descriptor->family,
+          entry.family,
+          "Index writer returned an unexpected family for {}",
+          entry.name);
+      NIMBLE_CHECK_EQ(
+          descriptor->name,
+          entry.name,
+          "Index writer returned an unexpected name for {}",
+          entry.name);
       descriptors.emplace_back(std::move(descriptor.value()));
     }
   }

--- a/dwio/nimble/velox/VeloxWriter.h
+++ b/dwio/nimble/velox/VeloxWriter.h
@@ -16,15 +16,12 @@
 #pragma once
 
 #include "dwio/nimble/common/Buffer.h"
-#include "dwio/nimble/index/ClusterIndexWriter.h"
-#include "dwio/nimble/index/HashIndexWriter.h"
-#include "dwio/nimble/index/SortedIndexWriter.h"
+#include "dwio/nimble/index/IndexWriter.h"
 #include "dwio/nimble/tablet/TabletWriter.h"
 #include "dwio/nimble/velox/FieldWriter.h"
 #include "dwio/nimble/velox/VeloxWriterOptions.h"
 #include "velox/common/base/RuntimeMetrics.h"
 #include "velox/common/file/File.h"
-#include "velox/dwio/common/ExecutorBarrier.h"
 #include "velox/dwio/common/TypeWithId.h"
 #include "velox/vector/BaseVector.h"
 #include "velox/vector/DecodedVector.h"
@@ -99,27 +96,24 @@ class VeloxWriter {
   Stats stats() const;
 
  private:
-  inline bool hasClusterIndex() const;
-  inline bool hasHashIndex() const;
-  inline bool hasSortedIndex() const;
+  struct IndexWriterEntry {
+    index::IndexFamily family;
+    std::string name;
+    std::unique_ptr<index::IndexWriter> writer;
+  };
 
-  // Adds index keys to all configured index writers. If barrier is provided,
-  // the processing will be added to the barrier for parallel execution.
-  void addIndexKey(
-      const velox::VectorPtr& input,
-      velox::dwio::common::ExecutorBarrier* barrier = nullptr);
+  static std::optional<IndexWriterEntry> createClusterIndexWriter(
+      const VeloxWriterOptions& options,
+      const velox::TypePtr& type,
+      velox::memory::MemoryPool* pool);
 
-  void addClusterIndexKey(
-      const velox::VectorPtr& input,
-      velox::dwio::common::ExecutorBarrier* barrier = nullptr);
+  static std::vector<IndexWriterEntry> createDenseIndexWriters(
+      const VeloxWriterOptions& options,
+      const velox::TypePtr& type,
+      velox::memory::MemoryPool* pool);
 
-  void addHashIndexKey(
-      const velox::VectorPtr& input,
-      velox::dwio::common::ExecutorBarrier* barrier = nullptr);
-
-  void addSortedIndexKey(
-      const velox::VectorPtr& input,
-      velox::dwio::common::ExecutorBarrier* barrier = nullptr);
+  // Adds index keys to all configured index writers.
+  void addIndexKey(const velox::VectorPtr& input);
 
   bool shouldFlush(FlushPolicy* policy) const;
 
@@ -212,9 +206,8 @@ class VeloxWriter {
   MemoryPoolHolder encodingMemoryPool_;
   const std::unique_ptr<detail::WriterContext> context_;
   std::unique_ptr<velox::WriteFile> file_;
-  const std::unique_ptr<index::IndexWriter> clusterIndexWriter_;
-  const std::unique_ptr<index::IndexWriter> hashIndexWriter_;
-  const std::unique_ptr<index::IndexWriter> sortedIndexWriter_;
+  const std::optional<IndexWriterEntry> clusterIndexWriter_;
+  const std::vector<IndexWriterEntry> denseIndexWriters_;
   const std::unique_ptr<TabletWriter> tabletWriter_;
 
   std::unique_ptr<FieldWriter> rootWriter_;

--- a/dwio/nimble/velox/VeloxWriterOptions.h
+++ b/dwio/nimble/velox/VeloxWriterOptions.h
@@ -32,17 +32,15 @@
 #include "velox/common/base/SpillConfig.h"
 #include "velox/type/Type.h"
 
-// Options used by Velox writer that affect the output file format
-
 namespace facebook::nimble {
 
 namespace detail {
 std::unordered_map<std::string, std::string> defaultMetadata();
 } // namespace detail
 
-// NOTE: the object could be large when encodingOverrides are
-// supplied. It's strongly advised to move instead of copying
-// it.
+/// Options used by Velox writer that affect the output file format.
+/// NOTE: The object could be large when encodingOverrides are supplied. It's
+/// strongly advised to move instead of copying it.
 struct VeloxWriterOptions {
   /// Builds Encoding::Options from VeloxWriterOptions fields.
   Encoding::Options buildEncodingOptions() const {
@@ -53,28 +51,28 @@ struct VeloxWriterOptions {
         .fsstCompressionTargetRatio = fsstCompressionTargetRatio};
   }
 
-  // Property bag for storing user metadata in the file.
+  /// Property bag for storing user metadata in the file.
   std::unordered_map<std::string, std::string> metadata =
       detail::defaultMetadata();
 
-  // Enable column statistics collection. When false, the writer skips
-  // collecting per-column statistics, reducing write CPU cost.
+  /// Enable column statistics collection. When false, the writer skips
+  /// collecting per-column statistics, reducing write CPU cost.
   bool enableStatsCollection{true};
 
-  // Enable vectorized stats for applicable schema shapes.
+  /// Enable vectorized stats for applicable schema shapes.
   bool enableVectorizedStats{true};
 
-  // When true, chunk-level position index is built for all streams,
-  // enabling O(1) chunk-level seeking within stripes. Independent of
-  // the cluster index (clusterIndexConfig). When clusterIndexConfig is set,
-  // chunk index is always enabled regardless of this flag.
-  // EXPERIMENTAL: Not production-ready. Do not enable for production tables
-  // without consulting the Nimble team (oncall: dwios).
+  /// When true, chunk-level position index is built for all streams,
+  /// enabling O(1) chunk-level seeking within stripes. Independent of
+  /// the cluster index (clusterIndexConfig). When clusterIndexConfig is set,
+  /// chunk index is always enabled regardless of this flag.
+  /// EXPERIMENTAL: Not production-ready. Do not enable for production tables
+  /// without consulting the Nimble team (oncall: dwios).
   bool enableChunkIndex{false};
 
-  // Skip writing chunk index for a stripe group if the average number
-  // of chunks per stream is below this threshold. 0 disables chunk index
-  // skipping.
+  /// Skip writing chunk index for a stripe group if the average number
+  /// of chunks per stream is below this threshold. 0 disables chunk index
+  /// skipping.
   float chunkIndexMinAvgChunks{2};
 
   /// NOTE: !!! This is under experimentation and please do not turn on in
@@ -94,26 +92,28 @@ struct VeloxWriterOptions {
       experimentalStripeGroupEncodingLayoutReadFactors{};
 
   /// If set, the cluster index on the specified columns will be built during
-  /// writing. The index stores the per-chunk min and max key for each stripe.
-  // EXPERIMENTAL: Cluster index is not production-ready. Do not enable for
-  // production tables without consulting the Nimble team (oncall: dwios).
+  /// writing. It is the primary index over key-ordered data and stores
+  /// per-chunk boundary keys per stripe-group partition for binary-search
+  /// pruning.
+  /// EXPERIMENTAL: Cluster index is not production-ready. Do not enable for
+  /// production tables without consulting the Nimble team (oncall: dwios).
   std::optional<index::ClusterIndexConfig> clusterIndexConfig;
 
   /// Hash index configurations. Each config builds an independent hash-based
   /// point lookup index on the specified columns. Unlike cluster index, hash
   /// index does not require sorted data.
-  // EXPERIMENTAL: Hash index is not production-ready. Do not enable for
-  // production tables without consulting the Nimble team (oncall: dwios).
+  /// EXPERIMENTAL: Hash index is not production-ready. Do not enable for
+  /// production tables without consulting the Nimble team (oncall: dwios).
   std::vector<index::HashIndexConfig> hashIndexConfigs;
 
   /// Sorted index configurations. Each config builds an independent sorted
   /// key stream index supporting both point lookups and range scans on
   /// unsorted data.
-  // EXPERIMENTAL: Sorted index is not production-ready. Do not enable for
-  // production tables without consulting the Nimble team (oncall: dwios).
+  /// EXPERIMENTAL: Sorted index is not production-ready. Do not enable for
+  /// production tables without consulting the Nimble team (oncall: dwios).
   std::vector<index::SortedIndexConfig> sortedIndexConfigs;
 
-  // Columns that should be encoded as flat maps. Maps column name to a set
+  /// Columns that should be encoded as flat maps. Maps column name to a set
   /// of predefined key strings. When the set is empty, the column is
   /// treated as a flat map with dynamic key discovery. When non-empty, keys
   /// are predefined in sorted order to ensure all writers produce
@@ -121,36 +121,36 @@ struct VeloxWriterOptions {
   /// the set will cause an error during writing.
   folly::F14FastMap<std::string, std::set<std::string>> flatMapColumns;
 
-  // Maximum number of distinct flat-map keys allowed per file; 0 means
-  // unlimited. Writing fails when exceeded, bounding the per-key native memory
-  // the flat-map writer holds.
+  /// Maximum number of distinct flat-map keys allowed per file; 0 means
+  /// unlimited. Writing fails when exceeded, bounding the per-key native memory
+  /// the flat-map writer holds.
   uint32_t maxFlatMapKeys{kDefaultMaxFlatMapKeys};
 
   /// Per-column string-keyed attributes to stamp onto the NIMBLE schema.
-  // Keyed by a dotted path of `RowType` child names that resolves to a node
-  // in the input `RowType`. The empty key (`""`) targets the root.
-  // Examples:
-  //   "id"              -> top-level column `id`
-  //   "user.name"       -> field `name` inside top-level struct column
-  //                        `user`
-  // Each value is the attribute bag forwarded verbatim to
-  // `TypeBuilder::setAttributes(...)` on the matching node and preserves
-  // insertion order end-to-end through schema serialization.
-  //
-  // Paths that do not resolve to a node in the input `RowType` are silently
-  // ignored so that callers can submit a superset of attributes and let
-  // schema evolution drop entries that no longer apply. Paths walking
-  // through non-`RowType` parents are not supported in this diff; callers
-  // currently emit flat top-level / nested-struct keys only, and richer
-  // addressing can be added in a follow-up if needed.
-  //
-  // Empty map (default) is a no-op: every existing NIMBLE writer produces
-  // byte-identical files.
+  /// Keyed by a dotted path of `RowType` child names that resolves to a node
+  /// in the input `RowType`. The empty key (`""`) targets the root.
+  /// Examples:
+  ///   "id"              -> top-level column `id`
+  ///   "user.name"       -> field `name` inside top-level struct column
+  ///                        `user`
+  /// Each value is the attribute bag forwarded verbatim to
+  /// `TypeBuilder::setAttributes(...)` on the matching node and preserves
+  /// insertion order end-to-end through schema serialization.
+  ///
+  /// Paths that do not resolve to a node in the input `RowType` are silently
+  /// ignored so that callers can submit a superset of attributes and let
+  /// schema evolution drop entries that no longer apply. Paths walking
+  /// through non-`RowType` parents are not supported in this diff; callers
+  /// currently emit flat top-level / nested-struct keys only, and richer
+  /// addressing can be added in a follow-up if needed.
+  ///
+  /// Empty map (default) is a no-op: every existing NIMBLE writer produces
+  /// byte-identical files.
   folly::
       F14FastMap<std::string, std::vector<std::pair<std::string, std::string>>>
           attributesByColumn;
 
-  // When true, the writer skips encoding flat map in-map boolean streams that
+  /// When true, the writer skips encoding flat map in-map boolean streams that
   /// are all-true (every row has the key) or all-false (no row has the key).
   /// The reader infers the in-map state from value stream presence: all-true
   /// keys have value streams, all-false keys do not.
@@ -256,37 +256,37 @@ struct VeloxWriterOptions {
   /// wideSchemaMaxStreamChunkRawSize in place of maxStreamChunkRawSize.
   size_t largeSchemaThreshold{500};
 
-  // Number of streams to try chunking between memory pressure evaluations.
-  // Note: this is ignored when it is time to flush a stripe.
+  /// Number of streams to try chunking between memory pressure evaluations.
+  /// Note: this is ignored when it is time to flush a stripe.
   size_t chunkedStreamBatchSize{1024};
 
-  // The factory function that produces the root encoding selection policy.
-  // Encoding selection policy is the way to balance the tradeoffs of
-  // different performance factors (at both read and write times). Heuristics
-  // based, ML based or specialized policies can be specified.
+  /// The factory function that produces the root encoding selection policy.
+  /// Encoding selection policy is the way to balance the tradeoffs of
+  /// different performance factors (at both read and write times). Heuristics
+  /// based, ML based or specialized policies can be specified.
   EncodingSelectionPolicyCreator encodingSelectionPolicyCreator =
       [encodingFactory = ManualEncodingSelectionPolicyFactory{}](
           DataType dataType) -> std::unique_ptr<EncodingSelectionPolicyBase> {
     return encodingFactory.createPolicy(dataType);
   };
 
-  // Provides policy that controls stripe sizes and memory footprint.
+  /// Provides policy that controls stripe sizes and memory footprint.
   std::function<std::unique_ptr<FlushPolicy>()> flushPolicyFactory = []() {
     // Buffering 256MB data before encoding stripes.
     return std::make_unique<StripeRawSizeFlushPolicy>(256 << 20);
   };
 
-  // When the writer needs to buffer data, and internal buffers don't have
-  // enough capacity, the writer is using this policy to claculate the the new
-  // capacity for the vuffers.
+  /// When the writer needs to buffer data, and internal buffers don't have
+  /// enough capacity, the writer is using this policy to claculate the the new
+  /// capacity for the vuffers.
   std::function<std::unique_ptr<InputBufferGrowthPolicy>()>
       inputGrowthPolicyFactory =
           []() -> std::unique_ptr<InputBufferGrowthPolicy> {
     return DefaultInputBufferGrowthPolicy::withDefaultRanges();
   };
 
-  // When per-stream string buffers are enabled (disableSharedStringBuffers),
-  // this policy controls how the string buffer vectors grow.
+  /// When per-stream string buffers are enabled (disableSharedStringBuffers),
+  /// this policy controls how the string buffer vectors grow.
   std::function<std::unique_ptr<InputBufferGrowthPolicy>()>
       stringBufferGrowthPolicyFactory =
           []() -> std::unique_ptr<InputBufferGrowthPolicy> {
@@ -298,33 +298,33 @@ struct VeloxWriterOptions {
 
   const velox::common::SpillConfig* spillConfig{nullptr};
 
-  // If provided, internal encoding operations will happen in parallel using
-  // the specified executor.
-  //
-  // The KeepAlive wrapper ensures that the executor object will be kept alive
-  // (allocated), and that the pool will be open for receiving new tasks. A
-  // shared_ptr would only guarantee that the object is still allocated, but not
-  // necessarily open for new task (e.g. it could have been .join()'ed through a
-  // different reference). Because of that, many libraries only provide
-  // KeepAlive references to executors, not shared_ptr, so taking a KeepAlive
-  // also makes it more convenient to clients.
-  //
-  // As a result, if a KeepAlive is still being held, clients trying to destruct
-  // the last reference of a shared_ptr to that executor will block until all
-  // KeepAlive references are destructed.
+  /// If provided, internal encoding operations will happen in parallel using
+  /// the specified executor.
+  ///
+  /// The KeepAlive wrapper ensures that the executor object will be kept alive
+  /// (allocated), and that the pool will be open for receiving new tasks. A
+  /// shared_ptr would only guarantee that the object is still allocated, but
+  /// not necessarily open for new task (e.g. it could have been .join()'ed
+  /// through a different reference). Because of that, many libraries only
+  /// provide KeepAlive references to executors, not shared_ptr, so taking a
+  /// KeepAlive also makes it more convenient to clients.
+  ///
+  /// As a result, if a KeepAlive is still being held, clients trying to
+  /// destruct the last reference of a shared_ptr to that executor will block
+  /// until all KeepAlive references are destructed.
   folly::Executor::KeepAlive<> encodingExecutor;
 
-  // When maxEncodeParallelism > 0 and encodingExecutor is set,
-  // FieldWriter::write() operations will be parallelized using coroutines
-  // scheduled on encodingExecutor.
+  /// When maxEncodeParallelism > 0 and encodingExecutor is set,
+  /// FieldWriter::write() operations will be parallelized using coroutines
+  /// scheduled on encodingExecutor.
   uint32_t maxEncodeParallelism{0};
   uint32_t minStreamsPerEncodeUnit{1};
 
   bool enableChunking{true};
 
-  // This callback will be visited on access to getDecodedVector in order to
-  // monitor usage of decoded vectors vs. data that is passed-through in the
-  // writer. Default function is no-op since its used for tests only.
+  /// This callback will be visited on access to getDecodedVector in order to
+  /// monitor usage of decoded vectors vs. data that is passed-through in the
+  /// writer. Default function is no-op since its used for tests only.
   std::function<void(void)> vectorDecoderVisitor{[]() {}};
 
   /// Whether writer should ignore the top level nulls in the input.
@@ -332,15 +332,15 @@ struct VeloxWriterOptions {
 
   bool enableStreamDeduplication{true};
 
-  // When true, string fields use per-field buffers instead of a shared buffer.
-  // This enables incremental memory reclamation during chunking.
+  /// When true, string fields use per-field buffers instead of a shared buffer.
+  /// This enables incremental memory reclamation during chunking.
   bool disableSharedStringBuffers{false};
 
-  // When true, enables consistency check between fileRawSize (accumulated via
-  // RawSizeUtils) and the root column statistics during file close.
-  // This is used to validate that column statistics accurately track raw sizes,
-  // with the goal of eventually replacing RawSizeUtils accumulation with column
-  // statistics for non-deduplicated columns.
+  /// When true, enables consistency check between fileRawSize (accumulated via
+  /// RawSizeUtils) and the root column statistics during file close.
+  /// This is used to validate that column statistics accurately track raw
+  /// sizes, with the goal of eventually replacing RawSizeUtils accumulation
+  /// with column statistics for non-deduplicated columns.
   bool enableStatsConsistencyCheck{true};
 };
 


### PR DESCRIPTION
Summary:

Refactor cluster and dense index creation behind named writer factories. Add type-erased `IndexConfig` values with factory-bound type validation, and let `VeloxWriterOptions` accept a generic vector of index configurations while preserving the legacy fields.

Dispatch dense index readers through registered factories, validate descriptors, and skip unknown implementations before metadata I/O for forward compatibility.

As D101407345 removed the Remove unused writeExecutor from Nimble FieldWriter. The ExecutorBarrier is unnecessary

Reviewed By: xiaoxmeng

Differential Revision: D112705365


