### PR TITLE
fix(selective): Correctly handle long null gaps (#1003)

### DIFF
--- a/dwio/nimble/velox/selective/ChunkedDecoder.h
+++ b/dwio/nimble/velox/selective/ChunkedDecoder.h
@@ -444,35 +444,79 @@ class ChunkedDecoder {
       }
     };
 
-    while (visitor.rowIndex() < numRows) {
-      // Check for chunk exhaustion before computing the next row range.
-      // This is done unconditionally (for both kHasNulls and !kHasNulls)
-      // to avoid the testNulls path in computeNextRowIndex loading a new
-      // chunk mid-count, which would produce numNonNulls spanning two
-      // chunks and incorrect index reads.
-      if (FOLLY_UNLIKELY(remainingValues_ == 0)) {
-        loadNextChunk(/*preserveDictionaryEncoding=*/true);
-        if (!onChunkBoundary()) {
-          // The new chunk is not dictionary-compatible. readOffset_ has not
-          // moved during this read, so it still holds the read's start offset;
-          // adding params.numScanned (the rows consumed up to this chunk
-          // boundary) advances it to the boundary, where the flat encoding
-          // fallback resumes the decode.
-          //
-          // TODO: Make the decoder the single owner of readOffset_ — also
-          // advance it on the full-read path here instead of readWithDictionary
-          // doing readOffset_ += endReadRow, so the update is not split across
-          // the reader and the decoder.
-          visitor.reader().setReadOffset(
-              visitor.reader().readOffset() + params.numScanned);
-          return false;
-        }
+    // For kHasNulls, count the value-stream rows this read will consume, once
+    // up front, so the per-chunk-exhaustion guard below is an O(1) decrement
+    // rather than a bitmap re-scan each time a chunk runs out.
+    //
+    // The nulls bitmap here carries only structural nulls (incoming struct
+    // nulls plus flatmap in-map), populated whole-range by
+    // prepareRead()/readNulls() before this read. NullableEncoding merges
+    // value-level nulls only into the already-decoded prefix
+    // (materializeNullsForVisitor), never the remaining range, so over
+    // [numScanned, endRow) every structural non-null is exactly one
+    // value-stream row to consume; countNonNulls is thus an exact total.
+    //
+    // The !kHasNulls path has no null bitmap: every remaining row is a value,
+    // so it always loads (like the flat !kHasNulls path) and does not use this
+    // counter.
+    int64_t remainingValues = 0;
+    if constexpr (kHasNulls) {
+      const auto endRow = V::dense
+          ? params.numScanned + (numRows - visitor.rowIndex())
+          : visitor.rowAt(numRows - 1) + 1;
+      remainingValues = static_cast<int64_t>(
+          velox::bits::countNonNulls(nulls, params.numScanned, endRow));
+    }
 
-        // onChunkBoundary() rebuilt the per-chunk filter dictionary in the
-        // reader's scan state. Re-snapshot it into the visitor so the next
-        // chunk's filter evaluation uses this chunk's dictionary, not the
-        // stale copy captured when the visitor was constructed.
-        visitor.refreshScanState();
+    while (visitor.rowIndex() < numRows) {
+      // Load the next chunk only when a value-stream row still remains in this
+      // read range, mirroring the flat path's testNulls guard
+      // (c > 0 && remainingValues_ == 0). An all-null run leaves
+      // remainingValues == 0: skip the load; computeNextRowIndex then
+      // emits the null rows with numNonNulls == 0. If a value is expected but
+      // no chunk remains, loadNextChunk throws on the metadata/bitmap mismatch
+      // (corruption).
+      //
+      // The load is driven from this loop (computeNextRowIndex runs with
+      // kReadAllChunks=false) rather than reused from the flat testNulls path.
+      // Both paths read one chunk per pass and stop at its boundary; the
+      // difference is where the boundary load lives. In the flat path it lives
+      // inside the testNulls bit-scan and is bare: no
+      // preserveDictionaryEncoding, and no seam at which to run onChunkBoundary
+      // (merge the per-chunk alphabet
+      // + refresh scan state) or to abandon to the flat fallback when the next
+      // chunk is not dictionary-compatible. Hoisting the load here gives those
+      // a clean seam.
+      if (FOLLY_UNLIKELY(remainingValues_ == 0)) {
+        // With nulls, load only if a value-stream row still remains; without a
+        // null bitmap every remaining row is a value, so always load (as the
+        // flat !kHasNulls path does).
+        const bool needMoreValues = kHasNulls ? (remainingValues > 0) : true;
+        if (needMoreValues) {
+          loadNextChunk(/*preserveDictionaryEncoding=*/true);
+          if (!onChunkBoundary()) {
+            // The new chunk is not dictionary-compatible. readOffset_ has not
+            // moved during this read, so it still holds the read's start
+            // offset; adding params.numScanned (the rows consumed up to this
+            // chunk boundary) advances it to the boundary, where the flat
+            // encoding fallback resumes the decode.
+            //
+            // TODO: Make the decoder the single owner of readOffset_ — also
+            // advance it on the full-read path here instead of
+            // readWithDictionary doing readOffset_ += endReadRow, so the update
+            // is not split across the reader and the decoder.
+            visitor.reader().setReadOffset(
+                visitor.reader().readOffset() + params.numScanned);
+            return false;
+          }
+
+          // onChunkBoundary() rebuilt the per-chunk filter dictionary in the
+          // reader's scan state. Re-snapshot it into the visitor so the next
+          // chunk's filter evaluation uses this chunk's dictionary, not the
+          // stale copy captured when the visitor was constructed.
+          visitor.refreshScanState();
+        }
+        // Otherwise all remaining rows are null; no chunk is needed.
       }
 
       velox::vector_size_t numNulls{0};
@@ -509,6 +553,9 @@ class ChunkedDecoder {
       }
       advancePosition(numNonNulls);
       params.numScanned += numNulls + numNonNulls;
+      if constexpr (kHasNulls) {
+        remainingValues -= numNonNulls;
+      }
 
       if (stringDecoderZeroCopy_) {
         stringBuffers.reserve(

--- a/dwio/nimble/velox/selective/tests/E2EFilterTest.cpp
+++ b/dwio/nimble/velox/selective/tests/E2EFilterTest.cpp
@@ -4330,6 +4330,436 @@ TEST_P(E2EFilterTest, filterOnlyDictAbandonDropsFilter) {
       << "Dict abandon path dropped filter on dict portion";
 }
 
+// Regression: when all non-null values in a dictionary-encoded string field
+// inside a mostly-null struct are consumed in earlier batches, later batches
+// contain only null rows. readDictionaryIndicesImpl unconditionally calls
+// loadNextChunk when remainingValues_==0, even when no more chunks exist,
+// crashing with "Failed to read chunk header". The fix checks the null bitmap
+// to verify all remaining rows are null before skipping the chunk load.
+TEST_P(E2EFilterTest, dictionaryChunkExhaustedAllNullTail) {
+  if (!param().stringDecoderZeroCopy ||
+      !param().nimblePreserveDictionaryEncoding) {
+    GTEST_SKIP()
+        << "Dictionary path requires stringDecoderZeroCopy and nimblePreserveDict";
+  }
+
+  // 20,000 rows with only 20 struct-non-null. All non-null values are the
+  // same string → ConstantEncoding with rowCount=20. The non-null positions
+  // cluster in the first quarter so later batches are entirely null.
+  constexpr size_t kTotalRows = 20000;
+  constexpr size_t kNonNullCount = 20;
+
+  auto type =
+      ROW({"select_col", "info"}, {BIGINT(), ROW({{"val"}}, {VARCHAR()})});
+  rowType_ = asRowType(type);
+
+  velox::test::VectorMaker maker(leafPool_.get());
+
+  auto selectVector = maker.flatVector<int64_t>(
+      kTotalRows, [](auto row) { return static_cast<int64_t>(row); });
+
+  auto valVector = maker.flatVector<velox::StringView>(
+      kNonNullCount,
+      [](auto /*row*/) { return velox::StringView("constant-val"); });
+
+  auto innerType = ROW({{"val"}}, {VARCHAR()});
+  auto innerStruct = std::make_shared<RowVector>(
+      leafPool_.get(),
+      innerType,
+      nullptr,
+      kNonNullCount,
+      std::vector<VectorPtr>{valVector});
+
+  auto structNulls =
+      velox::AlignedBuffer::allocate<bool>(kTotalRows, leafPool_.get());
+  auto* rawStructNulls = structNulls->asMutable<uint64_t>();
+  velox::bits::fillBits(rawStructNulls, 0, kTotalRows, velox::bits::kNull);
+  for (size_t i = 0; i < kNonNullCount; ++i) {
+    velox::bits::setBit(rawStructNulls, i * 250, true);
+  }
+
+  auto indices = velox::AlignedBuffer::allocate<vector_size_t>(
+      kTotalRows, leafPool_.get());
+  auto* rawIndices = indices->asMutable<vector_size_t>();
+  vector_size_t innerIdx = 0;
+  for (size_t i = 0; i < kTotalRows; ++i) {
+    rawIndices[i] = velox::bits::isBitSet(rawStructNulls, i) ? innerIdx++ : 0;
+  }
+
+  auto infoVector = BaseVector::wrapInDictionary(
+      structNulls, indices, kTotalRows, innerStruct);
+
+  auto batch = std::make_shared<RowVector>(
+      leafPool_.get(),
+      type,
+      nullptr,
+      kTotalRows,
+      std::vector<VectorPtr>{selectVector, infoVector});
+
+  {
+    auto writeFile = std::make_unique<InMemoryWriteFile>(&sinkData_);
+    VeloxWriterOptions writerOptions;
+    VeloxWriter writer(
+        type, std::move(writeFile), *rootPool_, std::move(writerOptions));
+    writer.write(batch);
+    writer.close();
+  }
+
+  auto input = std::make_unique<velox::dwio::common::BufferedInput>(
+      std::make_shared<velox::InMemoryReadFile>(sinkData_),
+      *leafPool_,
+      velox::dwio::common::MetricsLog::voidLog());
+  velox::dwio::common::ReaderOptions readerOpts{leafPool_.get()};
+  readerOpts.setMetadataIoStats(metadataIoStats_);
+  auto reader = makeReader(readerOpts, std::move(input));
+
+  auto scanSpec = std::make_shared<velox::common::ScanSpec>("root");
+  scanSpec->addAllChildFields(*type);
+
+  velox::dwio::common::RowReaderOptions rowReaderOptions;
+  rowReaderOptions.setScanSpec(scanSpec);
+  rowReaderOptions.setStringDecoderZeroCopy(true);
+  rowReaderOptions.setNimblePreserveDictionaryEncoding(true);
+  auto rowReader = reader->createRowReader(rowReaderOptions);
+
+  VectorPtr result = velox::BaseVector::create(type, 0, leafPool_.get());
+  size_t totalRows = 0;
+  size_t totalNonNull = 0;
+  constexpr size_t kBatchSize = 1000;
+  while (rowReader->next(kBatchSize, result)) {
+    auto* rowVector = result->as<RowVector>();
+    totalRows += rowVector->size();
+    auto info = rowVector->childAt(1);
+    info->loadedVector();
+    for (vector_size_t i = 0; i < info->size(); ++i) {
+      if (!info->isNullAt(i)) {
+        ++totalNonNull;
+        auto innerRow = info->wrappedVector()->as<RowVector>();
+        auto wrappedIdx = info->wrappedIndex(i);
+        auto val = innerRow->childAt(0)->as<SimpleVector<velox::StringView>>();
+        ASSERT_FALSE(val->isNullAt(wrappedIdx));
+        EXPECT_EQ(val->valueAt(wrappedIdx), velox::StringView("constant-val"));
+      }
+    }
+  }
+
+  EXPECT_EQ(totalRows, kTotalRows);
+  EXPECT_EQ(totalNonNull, kNonNullCount);
+}
+
+namespace {
+// Builds a {select_col, info:{val}} batch of `totalRows` rows with the `info`
+// struct non-null only at `nonNullRows` (values from `values`), else null. Each
+// batch, written as its own chunk, forms one value-stream chunk.
+RowVectorPtr makeSparseDictStructBatch(
+    velox::memory::MemoryPool* pool,
+    const RowTypePtr& type,
+    const RowTypePtr& innerType,
+    int64_t globalRowBase,
+    size_t totalRows,
+    const std::vector<size_t>& nonNullRows,
+    const std::vector<std::string>& values) {
+  VELOX_CHECK_EQ(nonNullRows.size(), values.size());
+  velox::test::VectorMaker maker(pool);
+  auto selectVector = maker.flatVector<int64_t>(
+      static_cast<vector_size_t>(totalRows),
+      [&](auto row) { return globalRowBase + static_cast<int64_t>(row); });
+
+  auto valVector = maker.flatVector<velox::StringView>(
+      static_cast<vector_size_t>(values.size()),
+      [&](auto row) { return velox::StringView(values[row]); });
+  auto innerStruct = std::make_shared<RowVector>(
+      pool,
+      innerType,
+      nullptr,
+      values.size(),
+      std::vector<VectorPtr>{valVector});
+
+  auto structNulls = velox::AlignedBuffer::allocate<bool>(totalRows, pool);
+  auto* rawStructNulls = structNulls->asMutable<uint64_t>();
+  velox::bits::fillBits(
+      rawStructNulls,
+      0,
+      static_cast<vector_size_t>(totalRows),
+      velox::bits::kNull);
+  auto indices = velox::AlignedBuffer::allocate<vector_size_t>(totalRows, pool);
+  auto* rawIndices = indices->asMutable<vector_size_t>();
+  std::fill(rawIndices, rawIndices + totalRows, 0);
+  for (size_t i = 0; i < nonNullRows.size(); ++i) {
+    velox::bits::setBit(rawStructNulls, nonNullRows[i], true);
+    rawIndices[nonNullRows[i]] = static_cast<vector_size_t>(i);
+  }
+  auto infoVector = BaseVector::wrapInDictionary(
+      structNulls, indices, static_cast<vector_size_t>(totalRows), innerStruct);
+  return std::make_shared<RowVector>(
+      pool,
+      type,
+      nullptr,
+      totalRows,
+      std::vector<VectorPtr>{selectVector, infoVector});
+}
+} // namespace
+
+// Two dictionary-compatible value chunks (each a single repeated string ->
+// ConstantEncoding) separated by a large all-null gap, plus an all-null tail
+// after the last chunk. The struct null stream (20,000 rows) and the child
+// value stream (20 values in two chunks) are separate ChunkedDecoders, so once
+// a chunk's values are consumed the reader must decide whether to load the next
+// chunk from the null bitmap, not from remaining values alone. This is the
+// non-tail-specific counterpart to dictionaryChunkExhaustedAllNullTail: the gap
+// sits *between* two chunks, and non-nulls are spread across read batches.
+TEST_P(E2EFilterTest, dictionaryChunkGapBetweenChunks) {
+  if (!param().stringDecoderZeroCopy ||
+      !param().nimblePreserveDictionaryEncoding) {
+    GTEST_SKIP()
+        << "Dictionary path requires stringDecoderZeroCopy and nimblePreserveDict";
+  }
+
+  constexpr size_t kRowsPerWrite = 10000;
+  constexpr size_t kValsPerChunk = 10;
+  constexpr size_t kSpacing = 300; // spread non-nulls across read batches
+  constexpr size_t kBatchSize = 1000;
+
+  auto type =
+      ROW({"select_col", "info"}, {BIGINT(), ROW({{"val"}}, {VARCHAR()})});
+  rowType_ = asRowType(type);
+  auto innerType = ROW({{"val"}}, {VARCHAR()});
+
+  std::vector<size_t> chunkRows;
+  chunkRows.reserve(kValsPerChunk);
+  for (size_t i = 0; i < kValsPerChunk; ++i) {
+    chunkRows.push_back(i * kSpacing);
+  }
+  std::vector<std::string> chunkAVals(kValsPerChunk, "chunk-a-val");
+  std::vector<std::string> chunkBVals(kValsPerChunk, "chunk-b-val");
+
+  auto batchA = makeSparseDictStructBatch(
+      leafPool_.get(),
+      type,
+      innerType,
+      /*globalRowBase=*/0,
+      kRowsPerWrite,
+      chunkRows,
+      chunkAVals);
+  auto batchB = makeSparseDictStructBatch(
+      leafPool_.get(),
+      type,
+      innerType,
+      /*globalRowBase=*/kRowsPerWrite,
+      kRowsPerWrite,
+      chunkRows,
+      chunkBVals);
+
+  {
+    auto writeFile = std::make_unique<InMemoryWriteFile>(&sinkData_);
+    VeloxWriterOptions writerOptions;
+    writerOptions.enableChunking = true;
+    writerOptions.minStreamChunkRawSize = 0;
+    writerOptions.flushPolicyFactory = [] {
+      return std::make_unique<LambdaFlushPolicy>(
+          /*flushLambda=*/[](const StripeProgress&) { return false; },
+          /*chunkLambda=*/[](const StripeProgress&) { return true; });
+    };
+    VeloxWriter writer(
+        type, std::move(writeFile), *rootPool_, std::move(writerOptions));
+    writer.write(batchA);
+    writer.write(batchB);
+    writer.close();
+  }
+
+  auto input = std::make_unique<velox::dwio::common::BufferedInput>(
+      std::make_shared<velox::InMemoryReadFile>(sinkData_),
+      *leafPool_,
+      velox::dwio::common::MetricsLog::voidLog());
+  velox::dwio::common::ReaderOptions readerOpts{leafPool_.get()};
+  readerOpts.setMetadataIoStats(metadataIoStats_);
+  auto reader = makeReader(readerOpts, std::move(input));
+
+  auto scanSpec = std::make_shared<velox::common::ScanSpec>("root");
+  scanSpec->addAllChildFields(*type);
+  velox::dwio::common::RowReaderOptions rowReaderOptions;
+  rowReaderOptions.setScanSpec(scanSpec);
+  rowReaderOptions.setStringDecoderZeroCopy(true);
+  rowReaderOptions.setNimblePreserveDictionaryEncoding(true);
+  auto rowReader = reader->createRowReader(rowReaderOptions);
+
+  // Non-null iff the global row falls on a chunk's spacing grid; value depends
+  // on which write (chunk) the row belongs to.
+  auto expectedValue = [&](int64_t globalRow) -> std::optional<std::string> {
+    const int64_t local = globalRow < static_cast<int64_t>(kRowsPerWrite)
+        ? globalRow
+        : globalRow - static_cast<int64_t>(kRowsPerWrite);
+    if (local % static_cast<int64_t>(kSpacing) == 0 &&
+        local / static_cast<int64_t>(kSpacing) <
+            static_cast<int64_t>(kValsPerChunk)) {
+      return globalRow < static_cast<int64_t>(kRowsPerWrite) ? "chunk-a-val"
+                                                             : "chunk-b-val";
+    }
+    return std::nullopt;
+  };
+
+  VectorPtr result = velox::BaseVector::create(type, 0, leafPool_.get());
+  size_t rowsSeen = 0;
+  size_t totalNonNull = 0;
+  while (rowReader->next(kBatchSize, result)) {
+    auto* rowVector = result->as<RowVector>();
+    auto info = rowVector->childAt(1);
+    info->loadedVector();
+    for (vector_size_t i = 0; i < info->size(); ++i) {
+      const auto globalRow = static_cast<int64_t>(rowsSeen + i);
+      const auto expected = expectedValue(globalRow);
+      if (expected.has_value()) {
+        ASSERT_FALSE(info->isNullAt(i)) << "row " << globalRow;
+        ++totalNonNull;
+        auto innerRow = info->wrappedVector()->as<RowVector>();
+        auto wrappedIdx = info->wrappedIndex(i);
+        auto val = innerRow->childAt(0)->as<SimpleVector<velox::StringView>>();
+        ASSERT_FALSE(val->isNullAt(wrappedIdx)) << "row " << globalRow;
+        EXPECT_EQ(val->valueAt(wrappedIdx).str(), *expected)
+            << "row " << globalRow;
+      } else {
+        ASSERT_TRUE(info->isNullAt(i)) << "row " << globalRow;
+      }
+    }
+    rowsSeen += rowVector->size();
+  }
+
+  EXPECT_EQ(rowsSeen, 2 * kRowsPerWrite);
+  EXPECT_EQ(totalNonNull, 2 * kValsPerChunk);
+}
+
+// Gap-between-chunks layout where the second chunk is non-dictionary (distinct
+// padded values -> Trivial), forcing the reactive dictionary->flat abandon on
+// crossing into it. Covers the all-null gap/tail load decision under abandon.
+TEST_P(E2EFilterTest, dictionaryChunkGapWithAbandon) {
+  if (!param().stringDecoderZeroCopy ||
+      !param().nimblePreserveDictionaryEncoding) {
+    GTEST_SKIP()
+        << "Dictionary path requires stringDecoderZeroCopy and nimblePreserveDict";
+  }
+
+  constexpr size_t kRowsPerWrite = 10000;
+  constexpr size_t kValsPerChunk = 10;
+  constexpr size_t kSpacing = 300;
+  constexpr size_t kBatchSize = 1000;
+
+  auto type =
+      ROW({"select_col", "info"}, {BIGINT(), ROW({{"val"}}, {VARCHAR()})});
+  rowType_ = asRowType(type);
+  auto innerType = ROW({{"val"}}, {VARCHAR()});
+
+  std::vector<size_t> chunkRows;
+  chunkRows.reserve(kValsPerChunk);
+  for (size_t i = 0; i < kValsPerChunk; ++i) {
+    chunkRows.push_back(i * kSpacing);
+  }
+  // Chunk A: dictionary-compatible constant. Chunk B: all distinct padded
+  // strings -> Trivial (non-dictionary) -> abandon on cross into it.
+  std::vector<std::string> chunkAVals(kValsPerChunk, "chunk-a-val");
+  std::vector<std::string> chunkBVals;
+  chunkBVals.reserve(kValsPerChunk);
+  for (size_t i = 0; i < kValsPerChunk; ++i) {
+    chunkBVals.push_back(fmt::format("chunk-b-unique-value-{:03d}-padding", i));
+  }
+
+  auto batchA = makeSparseDictStructBatch(
+      leafPool_.get(),
+      type,
+      innerType,
+      /*globalRowBase=*/0,
+      kRowsPerWrite,
+      chunkRows,
+      chunkAVals);
+  auto batchB = makeSparseDictStructBatch(
+      leafPool_.get(),
+      type,
+      innerType,
+      /*globalRowBase=*/kRowsPerWrite,
+      kRowsPerWrite,
+      chunkRows,
+      chunkBVals);
+
+  {
+    auto writeFile = std::make_unique<InMemoryWriteFile>(&sinkData_);
+    VeloxWriterOptions writerOptions;
+    writerOptions.enableChunking = true;
+    writerOptions.minStreamChunkRawSize = 0;
+    writerOptions.flushPolicyFactory = [] {
+      return std::make_unique<LambdaFlushPolicy>(
+          /*flushLambda=*/[](const StripeProgress&) { return false; },
+          /*chunkLambda=*/[](const StripeProgress&) { return true; });
+    };
+    VeloxWriter writer(
+        type, std::move(writeFile), *rootPool_, std::move(writerOptions));
+    writer.write(batchA);
+    writer.write(batchB);
+    writer.close();
+  }
+
+  auto input = std::make_unique<velox::dwio::common::BufferedInput>(
+      std::make_shared<velox::InMemoryReadFile>(sinkData_),
+      *leafPool_,
+      velox::dwio::common::MetricsLog::voidLog());
+  velox::dwio::common::ReaderOptions readerOpts{leafPool_.get()};
+  readerOpts.setMetadataIoStats(metadataIoStats_);
+  auto reader = makeReader(readerOpts, std::move(input));
+
+  auto scanSpec = std::make_shared<velox::common::ScanSpec>("root");
+  scanSpec->addAllChildFields(*type);
+  velox::dwio::common::RowReaderOptions rowReaderOptions;
+  rowReaderOptions.setScanSpec(scanSpec);
+  rowReaderOptions.setStringDecoderZeroCopy(true);
+  rowReaderOptions.setNimblePreserveDictionaryEncoding(true);
+  auto rowReader = reader->createRowReader(rowReaderOptions);
+
+  auto expectedValue = [&](int64_t globalRow) -> std::optional<std::string> {
+    if (globalRow < static_cast<int64_t>(kRowsPerWrite)) {
+      if (globalRow % static_cast<int64_t>(kSpacing) == 0 &&
+          globalRow / static_cast<int64_t>(kSpacing) <
+              static_cast<int64_t>(kValsPerChunk)) {
+        return std::string("chunk-a-val");
+      }
+      return std::nullopt;
+    }
+    const int64_t local = globalRow - static_cast<int64_t>(kRowsPerWrite);
+    if (local % static_cast<int64_t>(kSpacing) == 0 &&
+        local / static_cast<int64_t>(kSpacing) <
+            static_cast<int64_t>(kValsPerChunk)) {
+      return chunkBVals[local / static_cast<int64_t>(kSpacing)];
+    }
+    return std::nullopt;
+  };
+
+  VectorPtr result = velox::BaseVector::create(type, 0, leafPool_.get());
+  size_t rowsSeen = 0;
+  size_t totalNonNull = 0;
+  while (rowReader->next(kBatchSize, result)) {
+    auto* rowVector = result->as<RowVector>();
+    auto info = rowVector->childAt(1);
+    info->loadedVector();
+    for (vector_size_t i = 0; i < info->size(); ++i) {
+      const auto globalRow = static_cast<int64_t>(rowsSeen + i);
+      const auto expected = expectedValue(globalRow);
+      if (expected.has_value()) {
+        ASSERT_FALSE(info->isNullAt(i)) << "row " << globalRow;
+        ++totalNonNull;
+        auto innerRow = info->wrappedVector()->as<RowVector>();
+        auto wrappedIdx = info->wrappedIndex(i);
+        auto val = innerRow->childAt(0)->as<SimpleVector<velox::StringView>>();
+        ASSERT_FALSE(val->isNullAt(wrappedIdx)) << "row " << globalRow;
+        EXPECT_EQ(val->valueAt(wrappedIdx).str(), *expected)
+            << "row " << globalRow;
+      } else {
+        ASSERT_TRUE(info->isNullAt(i)) << "row " << globalRow;
+      }
+    }
+    rowsSeen += rowVector->size();
+  }
+
+  EXPECT_EQ(rowsSeen, 2 * kRowsPerWrite);
+  EXPECT_EQ(totalNonNull, 2 * kValsPerChunk);
+}
+
 // Exercises the reactive fallback path (dictionary → flat mid-batch) with an
 // active filter on the string column. The test creates alternating dictionary
 // and trivial chunks. When the reader encounters a trivial chunk mid-read, it


### PR DESCRIPTION
Summary:

A dictionary-encoded string column inside a high-null struct crashed with `NimbleInternalError: Failed to read chunk header` when a read range's values were exhausted but null rows remained. The struct null stream and the child value stream are separate `ChunkedDecoder`s: the read loop is driven by the struct row count while `remainingValues_` tracks only the child value count, so once the values were consumed `readDictionaryIndicesImpl` called `loadNextChunk()` for the trailing null rows and failed when no chunk remained. Found via the Presto verifier on `prism.instagram.ig_data_apps_events_v2` (`page_info.report_id`, a `ConstantEncoding` string in a 99.9%-null struct).

The flat path already guards this in `testNulls` (it loads only when non-null bits remain: `c > 0 && remainingValues_ == 0`); the dictionary path dropped that guard when it opted out of `testNulls` (`kReadAllChunks=false`). This change restores the null-aware decision: at chunk exhaustion, load the next chunk only when the read-range null bitmap shows a non-null value still remains (`countNonNulls(nulls, numScanned, endRow) > 0`). An all-null run loads nothing; a genuine metadata/bitmap mismatch surfaces naturally via `loadNextChunk`. This also handles long all-null gaps between chunks, not only an all-null tail.

Reviewed By: xiaoxmeng

Differential Revision: D112934134


