### PR TITLE
feat: Add native range reads to `EncodingView` (#1004)

### DIFF
--- a/dwio/nimble/encodings/BlockBitPackingEncoding.h
+++ b/dwio/nimble/encodings/BlockBitPackingEncoding.h
@@ -16,6 +16,7 @@
 #pragma once
 
 #include <algorithm>
+#include <cstring>
 #include <limits>
 #include <optional>
 #include <span>
@@ -43,6 +44,9 @@
 // approach for better compression when value ranges vary across the stream.
 
 namespace facebook::nimble {
+
+template <typename T>
+class BlockBitPackingEncodingView;
 
 template <typename T>
 class BlockBitPackingEncoding final
@@ -143,6 +147,8 @@ class BlockBitPackingEncoding final
   std::string debugString(int offset) const final;
 
  private:
+  friend class BlockBitPackingEncodingView<T>;
+
   // Fixed metadata header written before the three nested sub-streams:
   // compressionType + blockSize + numBlocks + three 4-byte sub-stream size
   // prefixes. Shared by encode() and estimateSize() so the two stay in sync.

--- a/dwio/nimble/encodings/benchmarks/EncodingViewBenchmark.cpp
+++ b/dwio/nimble/encodings/benchmarks/EncodingViewBenchmark.cpp
@@ -59,6 +59,7 @@ namespace {
 
 constexpr uint32_t kRows = 4096;
 constexpr uint32_t kPositions = 130;
+constexpr uint32_t kRangeSize = 1024;
 
 template <typename T>
 std::span<const typename TypeTraits<T>::physicalType> physicalSpan(
@@ -123,12 +124,38 @@ void readPositionsWithView(
     const EncodingView& view,
     const std::vector<uint32_t>& positions,
     uint32_t iters) {
-  T value;
+  typename TypeTraits<T>::physicalType value;
   while (iters--) {
     for (const auto position : positions) {
       view.readAt(position, &value);
       folly::doNotOptimizeAway(value);
     }
+  }
+}
+
+template <typename T>
+void readRangesWithView(const EncodingView& view, uint32_t iters) {
+  auto output =
+      std::make_unique<typename TypeTraits<T>::physicalType[]>(kRangeSize);
+  while (iters--) {
+    for (uint32_t offset = 0; offset < kRows; offset += kRangeSize) {
+      view.read(
+          offset, std::min<uint32_t>(kRangeSize, kRows - offset), output.get());
+    }
+    folly::doNotOptimizeAway(output[0]);
+  }
+}
+
+template <typename T>
+void readUnalignedRangesWithView(const EncodingView& view, uint32_t iters) {
+  auto output =
+      std::make_unique<typename TypeTraits<T>::physicalType[]>(kRangeSize);
+  while (iters--) {
+    for (uint32_t offset = 17; offset < kRows; offset += kRangeSize) {
+      view.read(
+          offset, std::min<uint32_t>(kRangeSize, kRows - offset), output.get());
+    }
+    folly::doNotOptimizeAway(output[0]);
   }
 }
 
@@ -431,6 +458,28 @@ Vector<std::string_view> dictionaryStringData(
     readPositionsWithView<Type>(*view, positions, iters);        \
   }
 
+#define RANGE_VIEW_BENCHMARK(Name, Type, EncodedExpr)            \
+  BENCHMARK(Name, iters) {                                       \
+    std::string encoded;                                         \
+    std::unique_ptr<EncodingView> view;                          \
+    BENCHMARK_SUSPEND {                                          \
+      encoded = EncodedExpr;                                     \
+      view = createEncodingView(encoded, benchmarkPool().get()); \
+    }                                                            \
+    readRangesWithView<Type>(*view, iters);                      \
+  }
+
+#define UNALIGNED_RANGE_VIEW_BENCHMARK(Name, Type, EncodedExpr)  \
+  BENCHMARK(Name, iters) {                                       \
+    std::string encoded;                                         \
+    std::unique_ptr<EncodingView> view;                          \
+    BENCHMARK_SUSPEND {                                          \
+      encoded = EncodedExpr;                                     \
+      view = createEncodingView(encoded, benchmarkPool().get()); \
+    }                                                            \
+    readUnalignedRangesWithView<Type>(*view, iters);             \
+  }
+
 #define MATERIALIZE_BENCHMARK(Name, Type, EncodedExpr, PositionsExpr)    \
   BENCHMARK(Name, iters) {                                               \
     std::string encoded;                                                 \
@@ -452,6 +501,12 @@ VIEW_BENCHMARK(
         EncodingType::Trivial,
         makeRandom<uint32_t>(kRows)),
     randomPositions(kRows))
+RANGE_VIEW_BENCHMARK(
+    RangeView_TrivialUint32_Range1024,
+    uint32_t,
+    encodeWithSelection<TrivialEncoding<uint32_t>>(
+        EncodingType::Trivial,
+        makeRandom<uint32_t>(kRows)))
 VIEW_BENCHMARK(
     View_TrivialBool_Random130,
     bool,
@@ -459,6 +514,12 @@ VIEW_BENCHMARK(
         EncodingType::Trivial,
         boolData()),
     randomPositions(kRows))
+RANGE_VIEW_BENCHMARK(
+    RangeView_TrivialBool_Range1024,
+    bool,
+    encodeWithSelection<TrivialEncoding<bool>>(
+        EncodingType::Trivial,
+        boolData()))
 MATERIALIZE_BENCHMARK(
     Materialize_TrivialUint32_Random130,
     uint32_t,
@@ -480,6 +541,12 @@ VIEW_BENCHMARK(
         EncodingType::SparseBool,
         boolData()),
     randomPositions(kRows))
+RANGE_VIEW_BENCHMARK(
+    RangeView_SparseBool_Range1024,
+    bool,
+    encodeWithSelection<SparseBoolEncoding>(
+        EncodingType::SparseBool,
+        boolData()))
 MATERIALIZE_BENCHMARK(
     Materialize_SparseBool_Random130,
     bool,
@@ -499,6 +566,17 @@ BENCHMARK(View_TrivialStringEager_Random130, iters) {
     view = createEncodingView(encoded, benchmarkPool().get());
   }
   readPositionsWithView<std::string_view>(*view, positions, iters);
+}
+
+BENCHMARK(RangeView_TrivialStringEager_Range1024, iters) {
+  std::vector<std::string> backing;
+  std::string encoded;
+  std::unique_ptr<EncodingView> view;
+  BENCHMARK_SUSPEND {
+    encoded = encodeTrivialString(stringData(backing));
+    view = createEncodingView(encoded, benchmarkPool().get());
+  }
+  readRangesWithView<std::string_view>(*view, iters);
 }
 
 BENCHMARK(Construct_TrivialStringOffsets_ReadAt, iters) {
@@ -575,6 +653,12 @@ VIEW_BENCHMARK(
         EncodingType::Constant,
         makeConstant<uint32_t>(42, kRows)),
     randomPositions(kRows))
+RANGE_VIEW_BENCHMARK(
+    RangeView_ConstantUint32_Range1024,
+    uint32_t,
+    encodeWithSelection<ConstantEncoding<uint32_t>>(
+        EncodingType::Constant,
+        makeConstant<uint32_t>(42, kRows)))
 MATERIALIZE_BENCHMARK(
     Materialize_ConstantUint32_Random130,
     uint32_t,
@@ -589,6 +673,12 @@ VIEW_BENCHMARK(
         EncodingType::FixedBitWidth,
         makeNarrow<uint32_t>(10, kRows)),
     randomPositions(kRows))
+RANGE_VIEW_BENCHMARK(
+    RangeView_FixedBitWidthUint32_Range1024,
+    uint32_t,
+    encodeWithSelection<FixedBitWidthEncoding<uint32_t>>(
+        EncodingType::FixedBitWidth,
+        makeNarrow<uint32_t>(10, kRows)))
 MATERIALIZE_BENCHMARK(
     Materialize_FixedBitWidthUint32_Random130,
     uint32_t,
@@ -603,6 +693,12 @@ VIEW_BENCHMARK(
         EncodingType::MainlyConstant,
         mainlyConstantData()),
     randomPositions(kRows))
+RANGE_VIEW_BENCHMARK(
+    RangeView_MainlyConstantUint32_Range1024,
+    uint32_t,
+    encodeWithSelection<MainlyConstantEncoding<uint32_t>>(
+        EncodingType::MainlyConstant,
+        mainlyConstantData()))
 MATERIALIZE_BENCHMARK(
     Materialize_MainlyConstantUint32_Random130,
     uint32_t,
@@ -617,6 +713,12 @@ VIEW_BENCHMARK(
         EncodingType::Dictionary,
         dictionaryData()),
     randomPositions(kRows))
+RANGE_VIEW_BENCHMARK(
+    RangeView_DictionaryUint32_Range1024,
+    uint32_t,
+    encodeWithSelection<DictionaryEncoding<uint32_t>>(
+        EncodingType::Dictionary,
+        dictionaryData()))
 VIEW_BENCHMARK(
     View_DictionaryFloat_Random130,
     float,
@@ -624,6 +726,12 @@ VIEW_BENCHMARK(
         EncodingType::Dictionary,
         floatingDictionaryData<float>()),
     randomPositions(kRows))
+RANGE_VIEW_BENCHMARK(
+    RangeView_DictionaryFloat_Range1024,
+    float,
+    encodeWithSelection<DictionaryEncoding<float>>(
+        EncodingType::Dictionary,
+        floatingDictionaryData<float>()))
 VIEW_BENCHMARK(
     View_DictionaryDouble_Random130,
     double,
@@ -631,6 +739,12 @@ VIEW_BENCHMARK(
         EncodingType::Dictionary,
         floatingDictionaryData<double>()),
     randomPositions(kRows))
+RANGE_VIEW_BENCHMARK(
+    RangeView_DictionaryDouble_Range1024,
+    double,
+    encodeWithSelection<DictionaryEncoding<double>>(
+        EncodingType::Dictionary,
+        floatingDictionaryData<double>()))
 BENCHMARK(View_DictionaryString_Random130, iters) {
   std::vector<std::string> backing;
   std::string encoded;
@@ -643,6 +757,17 @@ BENCHMARK(View_DictionaryString_Random130, iters) {
     view = createEncodingView(encoded, benchmarkPool().get());
   }
   readPositionsWithView<std::string_view>(*view, positions, iters);
+}
+BENCHMARK(RangeView_DictionaryString_Range1024, iters) {
+  std::vector<std::string> backing;
+  std::string encoded;
+  std::unique_ptr<EncodingView> view;
+  BENCHMARK_SUSPEND {
+    encoded = encodeWithSelection<DictionaryEncoding<std::string_view>>(
+        EncodingType::Dictionary, dictionaryStringData(backing));
+    view = createEncodingView(encoded, benchmarkPool().get());
+  }
+  readRangesWithView<std::string_view>(*view, iters);
 }
 MATERIALIZE_BENCHMARK(
     Materialize_DictionaryUint32_Random130,
@@ -685,6 +810,10 @@ VIEW_BENCHMARK(
     uint32_t,
     encodeWithSelection<RLEEncoding<uint32_t>>(EncodingType::RLE, rleData()),
     randomPositions(kRows))
+RANGE_VIEW_BENCHMARK(
+    RangeView_RLEUint32_Range1024,
+    uint32_t,
+    encodeWithSelection<RLEEncoding<uint32_t>>(EncodingType::RLE, rleData()))
 MATERIALIZE_BENCHMARK(
     Materialize_RLEUint32_Random130,
     uint32_t,
@@ -721,6 +850,12 @@ VIEW_BENCHMARK(
         EncodingType::ALP,
         alpData<float>()),
     randomPositions(kRows))
+RANGE_VIEW_BENCHMARK(
+    RangeView_ALPFloat_Range1024,
+    float,
+    encodeWithSelection<ALPEncoding<float>>(
+        EncodingType::ALP,
+        alpData<float>()))
 VIEW_BENCHMARK(
     View_ALPDouble_Random130,
     double,
@@ -728,6 +863,12 @@ VIEW_BENCHMARK(
         EncodingType::ALP,
         alpData<double>()),
     randomPositions(kRows))
+RANGE_VIEW_BENCHMARK(
+    RangeView_ALPDouble_Range1024,
+    double,
+    encodeWithSelection<ALPEncoding<double>>(
+        EncodingType::ALP,
+        alpData<double>()))
 MATERIALIZE_BENCHMARK(
     Materialize_ALPFloat_Random130,
     float,
@@ -747,6 +888,10 @@ VIEW_BENCHMARK(
     uint32_t,
     encodeWithSelection<ForEncoding<uint32_t>>(EncodingType::FOR, pforData()),
     randomPositions(kRows))
+RANGE_VIEW_BENCHMARK(
+    RangeView_FORUint32_Range1024,
+    uint32_t,
+    encodeWithSelection<ForEncoding<uint32_t>>(EncodingType::FOR, pforData()))
 BENCHMARK(Materialize_FORUint32_Random130, iters) {
   std::string encoded;
   std::vector<uint32_t> positions;
@@ -765,6 +910,10 @@ VIEW_BENCHMARK(
     uint32_t,
     encodeWithSelection<PFOREncoding<uint32_t>>(EncodingType::PFOR, pforData()),
     randomPositions(kRows))
+RANGE_VIEW_BENCHMARK(
+    RangeView_PFORUint32_Range1024,
+    uint32_t,
+    encodeWithSelection<PFOREncoding<uint32_t>>(EncodingType::PFOR, pforData()))
 MATERIALIZE_BENCHMARK(
     Materialize_PFORUint32_Random130,
     uint32_t,
@@ -777,6 +926,12 @@ VIEW_BENCHMARK(
         EncodingType::Huffman,
         huffmanSkewedData()),
     randomPositions(kRows))
+RANGE_VIEW_BENCHMARK(
+    RangeView_HuffmanUint32_SkewedRange1024,
+    uint32_t,
+    encodeWithSelection<HuffmanEncoding<uint32_t>>(
+        EncodingType::Huffman,
+        huffmanSkewedData()))
 MATERIALIZE_BENCHMARK(
     Materialize_HuffmanUint32_SkewedRandom130,
     uint32_t,
@@ -791,6 +946,12 @@ VIEW_BENCHMARK(
         EncodingType::Huffman,
         huffmanUniformData()),
     randomPositions(kRows))
+RANGE_VIEW_BENCHMARK(
+    RangeView_HuffmanUint32_UniformRange1024,
+    uint32_t,
+    encodeWithSelection<HuffmanEncoding<uint32_t>>(
+        EncodingType::Huffman,
+        huffmanUniformData()))
 MATERIALIZE_BENCHMARK(
     Materialize_HuffmanUint32_UniformRandom130,
     uint32_t,
@@ -805,6 +966,12 @@ VIEW_BENCHMARK(
         EncodingType::SimdForBitpack,
         makeNarrow<uint32_t>(10, kRows)),
     randomPositions(kRows))
+RANGE_VIEW_BENCHMARK(
+    RangeView_SimdForBitpackUint32_Range1024,
+    uint32_t,
+    encodeWithSelection<SimdForBitpackEncoding<uint32_t>>(
+        EncodingType::SimdForBitpack,
+        makeNarrow<uint32_t>(10, kRows)))
 MATERIALIZE_BENCHMARK(
     Materialize_SimdForBitpackUint32_Random130,
     uint32_t,
@@ -819,6 +986,12 @@ VIEW_BENCHMARK(
         EncodingType::SimdForBitpack,
         makeNarrow<uint16_t>(10, kRows)),
     randomPositions(kRows))
+RANGE_VIEW_BENCHMARK(
+    RangeView_SimdForBitpackUint16_Range1024,
+    uint16_t,
+    encodeWithSelection<SimdForBitpackEncoding<uint16_t>>(
+        EncodingType::SimdForBitpack,
+        makeNarrow<uint16_t>(10, kRows)))
 MATERIALIZE_BENCHMARK(
     Materialize_SimdForBitpackUint16_Random130,
     uint16_t,
@@ -833,6 +1006,12 @@ VIEW_BENCHMARK(
         EncodingType::SimdForBitpack,
         makeNarrow<uint8_t>(10, kRows)),
     randomPositions(kRows))
+RANGE_VIEW_BENCHMARK(
+    RangeView_SimdForBitpackUint8_Range1024,
+    uint8_t,
+    encodeWithSelection<SimdForBitpackEncoding<uint8_t>>(
+        EncodingType::SimdForBitpack,
+        makeNarrow<uint8_t>(10, kRows)))
 MATERIALIZE_BENCHMARK(
     Materialize_SimdForBitpackUint8_Random130,
     uint8_t,
@@ -847,6 +1026,24 @@ VIEW_BENCHMARK(
         EncodingType::BlockBitPacking,
         pforData()),
     randomPositions(kRows))
+RANGE_VIEW_BENCHMARK(
+    RangeView_BlockBitPackingUint32_Range1024,
+    uint32_t,
+    encodeWithSelection<BlockBitPackingEncoding<uint32_t>>(
+        EncodingType::BlockBitPacking,
+        pforData()))
+UNALIGNED_RANGE_VIEW_BENCHMARK(
+    RangeView_BlockBitPackingUint32_UnalignedRange1024,
+    uint32_t,
+    encodeWithSelection<BlockBitPackingEncoding<uint32_t>>(
+        EncodingType::BlockBitPacking,
+        pforData()))
+UNALIGNED_RANGE_VIEW_BENCHMARK(
+    RangeView_BlockBitPackingUint16_UnalignedRange1024,
+    uint16_t,
+    encodeWithSelection<BlockBitPackingEncoding<uint16_t>>(
+        EncodingType::BlockBitPacking,
+        makeNarrow<uint16_t>(10, kRows)))
 MATERIALIZE_BENCHMARK(
     Materialize_BlockBitPackingUint32_Random130,
     uint32_t,
@@ -856,6 +1053,8 @@ MATERIALIZE_BENCHMARK(
     randomPositions(kRows))
 
 #undef VIEW_BENCHMARK
+#undef RANGE_VIEW_BENCHMARK
+#undef UNALIGNED_RANGE_VIEW_BENCHMARK
 #undef MATERIALIZE_BENCHMARK
 
 } // namespace

--- a/dwio/nimble/encodings/tests/EncodingViewTestUtils.h
+++ b/dwio/nimble/encodings/tests/EncodingViewTestUtils.h
@@ -73,6 +73,15 @@ class EncodingViewTest : public ::testing::Test {
         view->readAt(position, &value);
         EXPECT_EQ(value, values[position]);
       }
+      const auto rowCount = static_cast<uint32_t>(values.size());
+      expectRangeRead(*view, values, /*offset=*/0, /*length=*/0);
+      expectRangeRead(*view, values, rowCount, /*length=*/0);
+      expectRangeRead(
+          *view, values, /*offset=*/0, std::min<uint32_t>(rowCount, 3));
+      if (rowCount > 0) {
+        const auto tailLength = std::min<uint32_t>(rowCount, 3);
+        expectRangeRead(*view, values, rowCount - tailLength, tailLength);
+      }
     }
   }
 
@@ -139,6 +148,23 @@ class EncodingViewTest : public ::testing::Test {
     nimble::Vector<int32_t> values{pool_.get()};
     values.resize(kConcurrentRows, value);
     return values;
+  }
+
+  template <typename T>
+  void expectRangeRead(
+      const nimble::EncodingView& view,
+      const nimble::Vector<T>& values,
+      uint32_t offset,
+      uint32_t length) {
+    SCOPED_TRACE(fmt::format("offset={}, length={}", offset, length));
+    using PhysicalType = typename nimble::TypeTraits<T>::physicalType;
+    nimble::Vector<PhysicalType> actual{pool_.get(), length};
+    view.read(offset, length, actual.data());
+    const auto* expected =
+        reinterpret_cast<const PhysicalType*>(values.data()) + offset;
+    EXPECT_EQ(
+        std::vector<PhysicalType>(actual.begin(), actual.end()),
+        std::vector<PhysicalType>(expected, expected + length));
   }
 
   nimble::Vector<int32_t> randomInt32(uint32_t seed) {

--- a/dwio/nimble/encodings/views/ALPEncodingView.h
+++ b/dwio/nimble/encodings/views/ALPEncodingView.h
@@ -67,6 +67,24 @@ class ALPEncodingView final : public TypedEncodingView<T> {
     return decodeValue(encoded);
   }
 
+  void readPhysical(uint32_t offset, uint32_t length, physicalType* output)
+      const final {
+    this->checkReadRange(offset, length);
+    const auto* exceptionPosition = std::lower_bound(
+        exceptionPositions_, exceptionPositions_ + exceptionCount_, offset);
+    for (uint32_t i = 0; i < length; ++i) {
+      const auto row = offset + i;
+      if (exceptionPosition != exceptionPositions_ + exceptionCount_ &&
+          *exceptionPosition == row) {
+        output[i] = exceptionValues_[exceptionPosition - exceptionPositions_];
+        ++exceptionPosition;
+      } else {
+        output[i] = detail::alp::toPhysical<T>(
+            decodeValue(velox::ZigZag::decode(encodedValues_->readAt(row))));
+      }
+    }
+  }
+
   const physicalType* findException(uint32_t index) const {
     const auto* begin = exceptionPositions_;
     const auto* end = begin + exceptionCount_;

--- a/dwio/nimble/encodings/views/BlockBitPackingEncodingView.h
+++ b/dwio/nimble/encodings/views/BlockBitPackingEncodingView.h
@@ -16,6 +16,9 @@
 #pragma once
 
 #include <algorithm>
+#include <array>
+#include <cstring>
+#include <type_traits>
 #include <vector>
 
 #include "dwio/nimble/common/FixedBitArray.h"
@@ -124,9 +127,144 @@ class BlockBitPackingEncodingView final : public TypedEncodingView<T> {
         static_cast<physicalType>(fba.get(blockOffset) + block.baseline));
   }
 
+  void readPhysical(uint32_t offset, uint32_t length, physicalType* output)
+      const final {
+    this->checkReadRange(offset, length);
+    uint32_t outputOffset{0};
+    while (outputOffset < length) {
+      const auto blockIndex = offset / blockSize_;
+      const auto blockOffset = offset % blockSize_;
+      const auto count =
+          std::min<uint32_t>(length - outputOffset, blockSize_ - blockOffset);
+      readBlockRange(blockIndex, blockOffset, count, output + outputOffset);
+      outputOffset += count;
+      offset += count;
+    }
+  }
+
   uint32_t blockRowCount(uint32_t blockIndex) const {
     const auto start = blockIndex * blockSize_;
     return std::min<uint32_t>(blockSize_, this->rowCount_ - start);
+  }
+
+  void readBlockRange(
+      uint32_t blockIndex,
+      uint32_t blockOffset,
+      uint32_t length,
+      physicalType* output) const {
+    const auto& block = blocks_[blockIndex];
+    const auto bitWidth = block.bitWidth;
+    const auto baseline = block.baseline;
+    const auto* blockData = packedData_ + block.offset;
+
+    if (bitWidth == BlockBitPackingEncoding<T>::kRawBlockBitWidth) {
+      const auto* rawValues = reinterpret_cast<const physicalType*>(blockData);
+      std::memcpy(
+          output, rawValues + blockOffset, length * sizeof(physicalType));
+      return;
+    }
+
+    if (bitWidth == 0) {
+      std::fill(output, output + length, baseline);
+      return;
+    }
+
+    const auto* inputBytes = reinterpret_cast<const uint8_t*>(blockData);
+    if (blockOffset == 0) {
+      BlockBitPackingEncoding<T>::fullUnpack(
+          inputBytes, output, length, bitWidth, baseline);
+      return;
+    }
+
+    readPartialBlockRange(
+        inputBytes,
+        blockIndex,
+        blockOffset,
+        length,
+        bitWidth,
+        baseline,
+        output);
+  }
+
+  void readPartialBlockRange(
+      const uint8_t* input,
+      uint32_t blockIndex,
+      uint32_t blockOffset,
+      uint32_t length,
+      uint8_t bitWidth,
+      physicalType baseline,
+      physicalType* output) const {
+    constexpr uint32_t kGroupSize = packingGroupSize();
+    const auto numRows = blockRowCount(blockIndex);
+    const auto numFullGroupRows = numRows - (numRows % kGroupSize);
+    const auto groupBytes = bitWidth * kGroupSize / 8;
+    const auto* remainderInput = reinterpret_cast<const char*>(input) +
+        (numFullGroupRows / kGroupSize) * groupBytes;
+
+    // Rows after the full fastpack groups are stored as a FixedBitArray tail.
+    if (blockOffset >= numFullGroupRows) {
+      FixedBitArray fba{
+          {remainderInput,
+           FixedBitArray::bufferSize(numRows - numFullGroupRows, bitWidth)},
+          bitWidth};
+      const auto remainderOffset = blockOffset - numFullGroupRows;
+      fba.bulkGetWithBaseline(remainderOffset, length, output, baseline);
+      return;
+    }
+
+    uint32_t outputOffset{0};
+    if (const auto groupOffset = blockOffset % kGroupSize; groupOffset != 0) {
+      std::array<physicalType, kGroupSize> values;
+      const auto group = blockOffset / kGroupSize;
+      BlockBitPackingEncoding<T>::fullUnpack(
+          input + group * groupBytes,
+          values.data(),
+          kGroupSize,
+          bitWidth,
+          baseline);
+      const auto count = std::min<uint32_t>(length, kGroupSize - groupOffset);
+      std::copy(
+          values.data() + groupOffset,
+          values.data() + groupOffset + count,
+          output);
+      outputOffset += count;
+      blockOffset += count;
+    }
+
+    const auto packedLength = std::min<uint32_t>(
+        length - outputOffset, numFullGroupRows - blockOffset);
+    if (packedLength != 0) {
+      BlockBitPackingEncoding<T>::fullUnpack(
+          input + (blockOffset / kGroupSize) * groupBytes,
+          output + outputOffset,
+          packedLength,
+          bitWidth,
+          baseline);
+      outputOffset += packedLength;
+      blockOffset += packedLength;
+    }
+
+    if (outputOffset < length) {
+      FixedBitArray fba{
+          {remainderInput,
+           FixedBitArray::bufferSize(numRows - numFullGroupRows, bitWidth)},
+          bitWidth};
+      fba.bulkGetWithBaseline(
+          blockOffset - numFullGroupRows,
+          length - outputOffset,
+          output + outputOffset,
+          baseline);
+    }
+  }
+
+  static constexpr uint32_t packingGroupSize() {
+    if constexpr (sizeof(physicalType) == 1) {
+      return 8u;
+    } else if constexpr (sizeof(physicalType) == 2) {
+      return 16u;
+    } else {
+      return 32u;
+    }
   }
 
   struct BlockMeta {

--- a/dwio/nimble/encodings/views/ConstantEncodingView.h
+++ b/dwio/nimble/encodings/views/ConstantEncodingView.h
@@ -15,6 +15,8 @@
  */
 #pragma once
 
+#include <algorithm>
+
 #include "dwio/nimble/encodings/common/EncodingPrimitives.h"
 #include "dwio/nimble/encodings/views/EncodingView.h"
 
@@ -39,6 +41,12 @@ class ConstantEncodingView final : public TypedEncodingView<T> {
   T readTypedAt(uint32_t index) const final {
     NIMBLE_CHECK_LT(index, this->rowCount_);
     return detail::castFromPhysicalType<T>(value_);
+  }
+
+  void readPhysical(uint32_t offset, uint32_t length, physicalType* output)
+      const final {
+    this->checkReadRange(offset, length);
+    std::fill(output, output + length, value_);
   }
 
   physicalType value_;

--- a/dwio/nimble/encodings/views/DictionaryEncodingView.h
+++ b/dwio/nimble/encodings/views/DictionaryEncodingView.h
@@ -17,6 +17,7 @@
 
 #include "dwio/nimble/encodings/common/EncodingPrimitives.h"
 #include "dwio/nimble/encodings/views/EncodingViewFactory.h"
+#include "folly/ScopeGuard.h"
 
 namespace facebook::nimble {
 
@@ -46,6 +47,20 @@ class DictionaryEncodingView final : public TypedEncodingView<T> {
   T readTypedAt(uint32_t index) const final {
     NIMBLE_CHECK_LT(index, this->rowCount_);
     return alphabet_->readAt(indices_->readAt(index));
+  }
+
+  void readPhysical(uint32_t offset, uint32_t length, physicalType* output)
+      const final {
+    this->checkReadRange(offset, length);
+    auto indices = this->template getVectorBuffer<uint32_t>();
+    SCOPE_EXIT {
+      this->releaseVectorBuffer(indices);
+    };
+    indices.resize(length);
+    indices_->read(offset, length, indices.data());
+    for (uint32_t i = 0; i < length; ++i) {
+      alphabet_->readAt(indices[i], output + i);
+    }
   }
 
   std::unique_ptr<TypedEncodingView<T>> alphabet_;

--- a/dwio/nimble/encodings/views/EncodingView.h
+++ b/dwio/nimble/encodings/views/EncodingView.h
@@ -33,8 +33,12 @@ class EncodingView {
  public:
   virtual ~EncodingView() = default;
 
-  /// Reads the decoded value at the given row index into a typed output buffer.
+  /// Reads the physical value at the given row index into a typed output
+  /// buffer.
   virtual void readAt(uint32_t index, void* output) const = 0;
+
+  /// Reads physical values in the given row range into a typed output buffer.
+  virtual void read(uint32_t offset, uint32_t length, void* output) const = 0;
 
   /// Returns the number of rows in the encoded stream.
   uint32_t rowCount() const {
@@ -70,7 +74,7 @@ class EncodingView {
   }
 
   template <typename V>
-  Vector<V> getVectorBuffer() {
+  Vector<V> getVectorBuffer() const {
     if (auto* bufferPool = options_.bufferPool) {
       if (auto buffer = bufferPool->get()) {
         return Vector<V>{std::move(buffer)};
@@ -79,10 +83,15 @@ class EncodingView {
     return Vector<V>{pool_};
   }
 
-  void releaseVectorBuffer(auto& vector) {
+  void releaseVectorBuffer(auto& vector) const {
     if (auto* bufferPool = options_.bufferPool) {
       bufferPool->release(vector.releaseBuffer());
     }
+  }
+
+  void checkReadRange(uint32_t offset, uint32_t length) const {
+    NIMBLE_CHECK_LE(offset, rowCount_);
+    NIMBLE_CHECK_LE(length, rowCount_ - offset);
   }
 
   std::string_view data_;
@@ -100,13 +109,20 @@ class TypedEncodingView : public EncodingView {
   using physicalType = typename TypeTraits<T>::physicalType;
 
   T readAt(uint32_t index) const {
-    T value;
-    readAt(index, &value);
-    return value;
+    return readTypedAt(index);
+  }
+
+  void read(uint32_t offset, uint32_t length, physicalType* output) const {
+    read(offset, length, static_cast<void*>(output));
   }
 
   void readAt(uint32_t index, void* output) const final {
-    *static_cast<T*>(output) = readTypedAt(index);
+    *static_cast<physicalType*>(output) =
+        castToPhysicalType(readTypedAt(index));
+  }
+
+  void read(uint32_t offset, uint32_t length, void* output) const final {
+    readPhysical(offset, length, static_cast<physicalType*>(output));
   }
 
  protected:
@@ -116,7 +132,21 @@ class TypedEncodingView : public EncodingView {
       const Encoding::Options& options)
       : EncodingView{data, pool, options} {}
 
+  virtual void readPhysical(
+      uint32_t offset,
+      uint32_t length,
+      physicalType* output) const = 0;
+
   virtual T readTypedAt(uint32_t index) const = 0;
+
+  static physicalType castToPhysicalType(T value) {
+    if constexpr (isFloatingPointType<T>()) {
+      static_assert(sizeof(T) == sizeof(physicalType));
+      return reinterpret_cast<const physicalType&>(value);
+    } else {
+      return value;
+    }
+  }
 };
 
 } // namespace facebook::nimble

--- a/dwio/nimble/encodings/views/FOREncodingView.h
+++ b/dwio/nimble/encodings/views/FOREncodingView.h
@@ -193,6 +193,36 @@ class FOREncodingView final : public TypedEncodingView<T> {
     return detail::castFromPhysicalType<T>(addResidual(reference, residual));
   }
 
+  void readPhysical(uint32_t offset, uint32_t length, physicalType* output)
+      const final {
+    this->checkReadRange(offset, length);
+    uint32_t outputOffset{0};
+    while (outputOffset < length) {
+      const auto frame = offset / frameSize_;
+      const auto positionInFrame = offset % frameSize_;
+      const auto count = std::min<uint32_t>(
+          length - outputOffset, frameSize_ - positionInFrame);
+      readFrameRange(frame, positionInFrame, count, output + outputOffset);
+      outputOffset += count;
+      offset += count;
+    }
+  }
+
+  void readFrameRange(
+      uint32_t frame,
+      uint32_t positionInFrame,
+      uint32_t length,
+      physicalType* output) const {
+    const auto bitWidth = bitWidths_[frame];
+    NIMBLE_CHECK_LE(bitWidth, sizeof(physicalType) * 8);
+    const auto reference = references_[frame];
+    auto rowBitOffset = bitOffset(frame) + positionInFrame * bitWidth;
+    for (uint32_t i = 0; i < length; ++i) {
+      output[i] = addResidual(reference, residualAt(rowBitOffset, bitWidth));
+      rowBitOffset += bitWidth;
+    }
+  }
+
   uint32_t frameSize_{0};
   uint32_t numFrames_{0};
   bool enableBitOffsets_{false};

--- a/dwio/nimble/encodings/views/FixedBitWidthEncodingView.h
+++ b/dwio/nimble/encodings/views/FixedBitWidthEncodingView.h
@@ -15,6 +15,8 @@
  */
 #pragma once
 
+#include <algorithm>
+
 #include "dwio/nimble/common/FixedBitArray.h"
 #include "dwio/nimble/encodings/common/EncodingPrimitives.h"
 #include "dwio/nimble/encodings/views/EncodingView.h"
@@ -52,6 +54,16 @@ class FixedBitWidthEncodingView final : public TypedEncodingView<T> {
     const auto value =
         static_cast<physicalType>(fixedBitArray_.get(index) + baseline_);
     return detail::castFromPhysicalType<T>(value);
+  }
+
+  void readPhysical(uint32_t offset, uint32_t length, physicalType* output)
+      const final {
+    this->checkReadRange(offset, length);
+    if (bitWidth_ == 0) {
+      std::fill(output, output + length, baseline_);
+      return;
+    }
+    fixedBitArray_.bulkGetWithBaseline(offset, length, output, baseline_);
   }
 
   physicalType baseline_;

--- a/dwio/nimble/encodings/views/HuffmanEncodingView.h
+++ b/dwio/nimble/encodings/views/HuffmanEncodingView.h
@@ -143,6 +143,35 @@ class HuffmanEncodingView final : public TypedEncodingView<T> {
     NIMBLE_UNREACHABLE("Invalid Huffman row {}", index);
   }
 
+  void readPhysical(uint32_t offset, uint32_t length, physicalType* output)
+      const final {
+    this->checkReadRange(offset, length);
+    if (length == 0) {
+      return;
+    }
+
+    const uint32_t checkpoint = offset / HuffmanEncoding<T>::kCheckpointStride;
+    uint32_t bitOffset = checkpoints_[checkpoint];
+    uint32_t current = checkpoint * HuffmanEncoding<T>::kCheckpointStride;
+    const auto end = offset + length;
+    while (current < end) {
+      uint32_t lookahead = 0;
+      const uint32_t byteOffset = bitOffset >> 3;
+      NIMBLE_CHECK_LT(byteOffset, bitstreamBytes_);
+      const uint32_t available =
+          std::min<uint32_t>(4, bitstreamBytes_ - byteOffset);
+      std::memcpy(&lookahead, bitstream_ + byteOffset, available);
+      lookahead >>= bitOffset & 7;
+      const auto entry = decodeTable_[lookahead & ((1u << tableLog_) - 1)];
+      NIMBLE_CHECK_GT(entry.bits, 0);
+      bitOffset += entry.bits;
+      if (current >= offset) {
+        output[current - offset] = alphabet_[entry.symbol];
+      }
+      ++current;
+    }
+  }
+
   Vector<physicalType> alphabet_;
   Vector<DecodeEntry> decodeTable_;
   Vector<uint32_t> checkpoints_;

--- a/dwio/nimble/encodings/views/MainlyConstantEncodingView.h
+++ b/dwio/nimble/encodings/views/MainlyConstantEncodingView.h
@@ -15,6 +15,8 @@
  */
 #pragma once
 
+#include <algorithm>
+
 #include "dwio/nimble/common/Vector.h"
 #include "dwio/nimble/encodings/common/EncodingFactory.h"
 #include "dwio/nimble/encodings/common/EncodingPrimitives.h"
@@ -81,6 +83,28 @@ class MainlyConstantEncodingView final : public TypedEncodingView<T> {
       return detail::castFromPhysicalType<T>(commonValue_);
     }
     return otherValues_->readAt(otherValueIndex(index));
+  }
+
+  void readPhysical(uint32_t offset, uint32_t length, physicalType* output)
+      const final {
+    this->checkReadRange(offset, length);
+    uint32_t outputOffset{0};
+    while (outputOffset < length) {
+      const auto row = offset + outputOffset;
+      const bool isCommon = isCommon_[row];
+      uint32_t count{1};
+      while (outputOffset + count < length &&
+             isCommon_[row + count] == isCommon) {
+        ++count;
+      }
+      if (isCommon) {
+        std::fill(
+            output + outputOffset, output + outputOffset + count, commonValue_);
+      } else {
+        otherValues_->read(otherValueIndex(row), count, output + outputOffset);
+      }
+      outputOffset += count;
+    }
   }
 
   Vector<bool> isCommon_;

--- a/dwio/nimble/encodings/views/PFOREncodingView.h
+++ b/dwio/nimble/encodings/views/PFOREncodingView.h
@@ -99,6 +99,26 @@ class PFOREncodingView final : public TypedEncodingView<T> {
         static_cast<physicalType>(baseline_ + residual));
   }
 
+  void readPhysical(uint32_t offset, uint32_t length, physicalType* output)
+      const final {
+    this->checkReadRange(offset, length);
+    if (baseBitWidth_ == 0) {
+      std::fill(output, output + length, baseline_);
+    } else {
+      fixedBitArray_.bulkGetWithBaseline(offset, length, output, baseline_);
+    }
+
+    auto exceptionIt = std::lower_bound(
+        exceptionPositions_.begin(), exceptionPositions_.end(), offset);
+    const auto end = offset + length;
+    while (exceptionIt != exceptionPositions_.end() && *exceptionIt < end) {
+      output[*exceptionIt - offset] = static_cast<physicalType>(
+          baseline_ +
+          exceptionValues_[exceptionIt - exceptionPositions_.begin()]);
+      ++exceptionIt;
+    }
+  }
+
   physicalType baseline_{};
   uint8_t baseBitWidth_{0};
   uint32_t numExceptions_{0};

--- a/dwio/nimble/encodings/views/RLEEncodingView.h
+++ b/dwio/nimble/encodings/views/RLEEncodingView.h
@@ -69,6 +69,28 @@ class RLEEncodingView final : public TypedEncodingView<T> {
     return values_->readAt(static_cast<uint32_t>(it - runEnds_.begin()));
   }
 
+  void readPhysical(uint32_t offset, uint32_t length, physicalType* output)
+      const final {
+    this->checkReadRange(offset, length);
+    if (length == 0) {
+      return;
+    }
+    auto it = std::upper_bound(runEnds_.begin(), runEnds_.end(), offset);
+    NIMBLE_CHECK(it != runEnds_.end());
+    uint32_t outputOffset{0};
+    while (outputOffset < length) {
+      const auto runIndex = static_cast<uint32_t>(it - runEnds_.begin());
+      const auto runEnd = *it;
+      const auto count = std::min(length - outputOffset, runEnd - offset);
+      physicalType value;
+      values_->readAt(runIndex, &value);
+      std::fill(output + outputOffset, output + outputOffset + count, value);
+      outputOffset += count;
+      offset += count;
+      ++it;
+    }
+  }
+
   Vector<uint32_t> runEnds_;
   std::unique_ptr<TypedEncodingView<T>> values_;
 };
@@ -114,6 +136,29 @@ class RLEEncodingView<bool> final : public TypedEncodingView<bool> {
     NIMBLE_CHECK(it != runEnds_.end());
     const auto runIndex = static_cast<uint32_t>(it - runEnds_.begin());
     return runIndex % 2 == 0 ? initialValue_ : !initialValue_;
+  }
+
+  void readPhysical(uint32_t offset, uint32_t length, bool* output)
+      const final {
+    this->checkReadRange(offset, length);
+    if (length == 0) {
+      return;
+    }
+    auto it = std::upper_bound(runEnds_.begin(), runEnds_.end(), offset);
+    NIMBLE_CHECK(it != runEnds_.end());
+    uint32_t outputOffset{0};
+    while (outputOffset < length) {
+      const auto runIndex = static_cast<uint32_t>(it - runEnds_.begin());
+      const auto runEnd = *it;
+      const auto count = std::min(length - outputOffset, runEnd - offset);
+      std::fill(
+          output + outputOffset,
+          output + outputOffset + count,
+          runIndex % 2 == 0 ? initialValue_ : !initialValue_);
+      outputOffset += count;
+      offset += count;
+      ++it;
+    }
   }
 
   Vector<uint32_t> runEnds_;

--- a/dwio/nimble/encodings/views/SimdForBitpackEncodingView.h
+++ b/dwio/nimble/encodings/views/SimdForBitpackEncodingView.h
@@ -15,6 +15,7 @@
  */
 #pragma once
 
+#include <algorithm>
 #include <array>
 
 #include "dwio/nimble/encodings/SimdForBitpackEncoding.h"
@@ -53,6 +54,31 @@ class SimdForBitpackEncodingView final : public TypedEncodingView<T> {
     unpackGroup(groupIndex, group.data());
     return detail::castFromPhysicalType<T>(
         static_cast<physicalType>(group[index % kGroupSize] + baseline_));
+  }
+
+  void readPhysical(uint32_t offset, uint32_t length, physicalType* output)
+      const final {
+    this->checkReadRange(offset, length);
+    if (bitWidth_ == 0) {
+      std::fill(output, output + length, baseline_);
+      return;
+    }
+
+    uint32_t outputOffset{0};
+    while (outputOffset < length) {
+      const auto groupIndex = offset / kGroupSize;
+      const auto groupOffset = offset % kGroupSize;
+      const auto count =
+          std::min<uint32_t>(length - outputOffset, kGroupSize - groupOffset);
+      std::array<physicalType, kGroupSize> group{};
+      unpackGroup(groupIndex, group.data());
+      for (uint32_t i = 0; i < count; ++i) {
+        output[outputOffset + i] =
+            static_cast<physicalType>(group[groupOffset + i] + baseline_);
+      }
+      outputOffset += count;
+      offset += count;
+    }
   }
 
   static constexpr uint32_t kGroupSize = SimdForBitpackEncoding<T>::kGroupSize;

--- a/dwio/nimble/encodings/views/SparseBoolEncodingView.h
+++ b/dwio/nimble/encodings/views/SparseBoolEncodingView.h
@@ -15,6 +15,8 @@
  */
 #pragma once
 
+#include <algorithm>
+
 #include "dwio/nimble/encodings/common/EncodingPrimitives.h"
 #include "dwio/nimble/encodings/views/EncodingViewFactory.h"
 
@@ -39,7 +41,7 @@ class SparseBoolEncodingView final : public TypedEncodingView<bool> {
   }
 
  private:
-  bool containsSparseIndex(uint32_t index) const {
+  inline uint32_t lowerBoundSparseIndex(uint32_t index) const {
     uint32_t begin{0};
     uint32_t end{indices_->rowCount()};
     while (begin < end) {
@@ -50,12 +52,34 @@ class SparseBoolEncodingView final : public TypedEncodingView<bool> {
         end = mid;
       }
     }
-    return begin < indices_->rowCount() && indices_->readAt(begin) == index;
+    return begin;
+  }
+
+  inline bool containsSparseIndex(uint32_t index) const {
+    const auto position = lowerBoundSparseIndex(index);
+    return position < indices_->rowCount() &&
+        indices_->readAt(position) == index;
   }
 
   bool readTypedAt(uint32_t index) const final {
     NIMBLE_CHECK_LT(index, this->rowCount_);
     return containsSparseIndex(index) ? sparseValue_ : !sparseValue_;
+  }
+
+  void readPhysical(uint32_t offset, uint32_t length, bool* output)
+      const final {
+    this->checkReadRange(offset, length);
+    std::fill(output, output + length, !sparseValue_);
+    auto sparseIndex = lowerBoundSparseIndex(offset);
+    const auto end = offset + length;
+    while (sparseIndex < indices_->rowCount()) {
+      const auto row = indices_->readAt(sparseIndex);
+      if (row >= end) {
+        break;
+      }
+      output[row - offset] = sparseValue_;
+      ++sparseIndex;
+    }
   }
 
   bool sparseValue_{false};

--- a/dwio/nimble/encodings/views/TrivialEncodingView.h
+++ b/dwio/nimble/encodings/views/TrivialEncodingView.h
@@ -15,6 +15,9 @@
  */
 #pragma once
 
+#include <algorithm>
+#include <type_traits>
+
 #include "dwio/nimble/common/Vector.h"
 #include "dwio/nimble/compression/Compression.h"
 #include "dwio/nimble/encodings/common/EncodingFactory.h"
@@ -51,6 +54,12 @@ class TrivialEncodingView final : public TypedEncodingView<T> {
     return detail::castFromPhysicalType<T>(values_[index]);
   }
 
+  void readPhysical(uint32_t offset, uint32_t length, physicalType* output)
+      const final {
+    this->checkReadRange(offset, length);
+    std::copy(values_ + offset, values_ + offset + length, output);
+  }
+
   const physicalType* values_;
 };
 
@@ -78,6 +87,15 @@ class TrivialEncodingView<bool> final : public TypedEncodingView<bool> {
     NIMBLE_CHECK_LT(index, this->rowCount_);
     return velox::bits::isBitSet(
         reinterpret_cast<const uint8_t*>(bitmap_), index);
+  }
+
+  void readPhysical(uint32_t offset, uint32_t length, bool* output)
+      const final {
+    this->checkReadRange(offset, length);
+    const auto* bitmap = reinterpret_cast<const uint8_t*>(bitmap_);
+    for (uint32_t i = 0; i < length; ++i) {
+      output[i] = velox::bits::isBitSet(bitmap, offset + i);
+    }
   }
 
   const char* bitmap_{nullptr};
@@ -124,6 +142,16 @@ class TrivialEncodingView<std::string_view> final
   std::string_view readTypedAt(uint32_t index) const final {
     NIMBLE_CHECK_LT(index, this->rowCount_);
     return {blob_ + offsets_[index], offsets_[index + 1] - offsets_[index]};
+  }
+
+  void readPhysical(uint32_t offset, uint32_t length, std::string_view* output)
+      const final {
+    this->checkReadRange(offset, length);
+    for (uint32_t i = 0; i < length; ++i) {
+      output[i] = {
+          blob_ + offsets_[offset + i],
+          offsets_[offset + i + 1] - offsets_[offset + i]};
+    }
   }
 
   const char* blob_{nullptr};


### PR DESCRIPTION
Summary:

Add a range `readAt(offset, length, output)` API to `EncodingView` and `TypedEncodingView`.

`TypedEncodingView` requires concrete encoding views to implement the range hook, so new view implementations must make an explicit range-read choice. Existing concrete views provide native range implementations: direct copy/fill for simple encodings, per-run/per-frame/per-group decode for packed encodings, and single-pass exception/sparse scans for encodings with side tables.

Also add shared range-read test coverage for empty, prefix, and tail ranges across existing encoding-view tests. The existing `dwio/nimble/encodings/benchmarks:encoding_view_benchmark` target now includes range-read cases alongside its point-read and materialization cases.

Reviewed By: HuamengJiang

Differential Revision: D113107910


