### PR TITLE
Add experimental DeltaBlock integer encoding (#1005)

### DIFF
--- a/dwio/nimble/common/Types.cpp
+++ b/dwio/nimble/common/Types.cpp
@@ -67,6 +67,8 @@ std::string toString(EncodingType encodingType) {
       return "SubIntSplit";
     case EncodingType::BlockBitPacking:
       return "BlockBitPacking";
+    case EncodingType::DeltaBlock:
+      return "DeltaBlock";
   }
   return fmt::format(
       "Unknown encoding type: {}", static_cast<int32_t>(encodingType));

--- a/dwio/nimble/common/Types.h
+++ b/dwio/nimble/common/Types.h
@@ -132,9 +132,13 @@ enum class EncodingType {
   // Partitions data by value frequency. Also, frequent values get shorter
   // bit-width
   // codes. Rows are reordered to group values with same code length.
+  // EXPERIMENTAL: Not production-ready. Do not enable for production tables
+  // without consulting the Nimble team (oncall: dwios).
   FrequencyPartition = 17,
   // Frame of Reference: stores offsets from per-frame minimum values.
   // Supports O(1) random access. Preserves row order.
+  // EXPERIMENTAL: Not production-ready. Do not enable for production tables
+  // without consulting the Nimble team (oncall: dwios).
   FOR = 18,
   // Stores string data compressed with FSST (Fast Static Symbol Table).
   // Trains a per-stripe symbol table and compresses each string independently,
@@ -147,6 +151,10 @@ enum class EncodingType {
   // EXPERIMENTAL: Not production-ready. Do not enable for production tables
   // without consulting the Nimble team (oncall: dwios).
   Huffman = 20,
+  // Stores sorted integer streams as block checkpoints plus bit-packed deltas.
+  // EXPERIMENTAL: Not production-ready. Do not enable for production tables
+  // without consulting the Nimble team (oncall: dwios).
+  DeltaBlock = 21,
 };
 std::string toString(EncodingType encodingType);
 std::ostream& operator<<(std::ostream& out, EncodingType encodingType);

--- a/dwio/nimble/encodings/CMakeLists.txt
+++ b/dwio/nimble/encodings/CMakeLists.txt
@@ -30,6 +30,7 @@ add_library(
   common/EncodingLayout.cpp
   selection/EncodingSelectionPolicy.cpp
   selection/Statistics.cpp
+  views/DeltaBlockEncodingView.h
   views/EncodingViewFactory.cpp
   views/HuffmanEncodingView.h
 )

--- a/dwio/nimble/encodings/DeltaBlockEncoding.h
+++ b/dwio/nimble/encodings/DeltaBlockEncoding.h
@@ -1,0 +1,561 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <algorithm>
+#include <cstdint>
+#include <cstring>
+#include <limits>
+#include <optional>
+#include <span>
+#include <type_traits>
+
+#include <fmt/format.h>
+
+#include "dwio/nimble/common/Buffer.h"
+#include "dwio/nimble/common/Exceptions.h"
+#include "dwio/nimble/common/FixedBitArray.h"
+#include "dwio/nimble/common/Varint.h"
+#include "dwio/nimble/common/Vector.h"
+#include "dwio/nimble/encodings/common/Encoding.h"
+#include "dwio/nimble/encodings/common/EncodingPrimitives.h"
+#include "dwio/nimble/encodings/selection/EncodingSelection.h"
+#include "velox/common/base/BitUtil.h"
+
+namespace facebook::nimble {
+
+template <typename T>
+class DeltaBlockEncodingView;
+
+/// Stores sorted integer streams as block checkpoints plus fixed-width deltas
+/// inside each block. This is intended for sorted dictionary alphabets, where
+/// values are monotonic and per-block gaps are substantially narrower than the
+/// original integer width.
+///
+/// DeltaEncoding handles arbitrary integer streams by writing decreasing values
+/// as restatements in a child stream. DeltaBlock has no restatement stream; it
+/// requires non-decreasing values and stores one base value per block plus
+/// deltas to subsequent rows in that block.
+template <typename T>
+class DeltaBlockEncoding final
+    : public TypedEncoding<T, typename TypeTraits<T>::physicalType> {
+ public:
+  using cppDataType = T;
+  using physicalType = typename TypeTraits<T>::physicalType;
+
+  DeltaBlockEncoding(
+      velox::memory::MemoryPool& pool,
+      std::string_view data,
+      const std::function<void*(uint32_t)>& stringBufferFactory,
+      const Encoding::Options& options = {});
+
+  ~DeltaBlockEncoding() override {
+    this->releaseVectorBuffer(deltaChunk_);
+    this->releaseVectorBuffer(blockBases_);
+    this->releaseVectorBuffer(bitWidths_);
+    this->releaseVectorBuffer(blockOffsets_);
+  }
+
+  DeltaBlockEncoding(const DeltaBlockEncoding&) = delete;
+  DeltaBlockEncoding& operator=(const DeltaBlockEncoding&) = delete;
+  DeltaBlockEncoding(DeltaBlockEncoding&&) = delete;
+  DeltaBlockEncoding& operator=(DeltaBlockEncoding&&) = delete;
+
+  void reset() final;
+  void skip(uint32_t rowCount) final;
+  void materialize(uint32_t rowCount, void* buffer) final;
+
+  template <typename DecoderVisitor>
+  void readWithVisitor(DecoderVisitor& visitor, ReadWithVisitorParams& params);
+
+  static std::string_view encode(
+      EncodingSelection<physicalType>& selection,
+      std::span<const physicalType> values,
+      Buffer& buffer,
+      const Encoding::Options& options = {});
+
+  static std::optional<uint64_t> estimateSize(
+      std::span<const physicalType> values,
+      const Encoding::Options& options);
+
+  std::string debugString(int offset) const final;
+
+ private:
+  static_assert(
+      std::is_integral_v<T> && !std::is_same_v<T, bool>,
+      "DeltaBlockEncoding only supports non-bool integer types.");
+
+  friend class DeltaBlockEncodingView<T>;
+
+  static constexpr uint64_t kSignMask{
+      uint64_t{1} << (sizeof(physicalType) * 8 - 1)};
+  static constexpr uint32_t kDeltaChunkSize{1024};
+
+  static uint64_t toOrdered(physicalType value) {
+    if constexpr (std::is_signed_v<T>) {
+      return static_cast<uint64_t>(value) ^ kSignMask;
+    } else {
+      return static_cast<uint64_t>(value);
+    }
+  }
+
+  static physicalType fromOrdered(uint64_t value) {
+    if constexpr (std::is_signed_v<T>) {
+      return static_cast<physicalType>(value ^ kSignMask);
+    } else {
+      return static_cast<physicalType>(value);
+    }
+  }
+
+  static uint32_t
+  blockRowCount(uint32_t rowCount, uint16_t blockSize, uint32_t blockIndex) {
+    const auto start = blockIndex * blockSize;
+    return std::min<uint32_t>(blockSize, rowCount - start);
+  }
+
+  static Encoding::Options prefixOptions(Encoding::Options options) {
+    // DeltaBlock is written with the varint row-count prefix.
+    options.useVarintRowCount = true;
+    return options;
+  }
+
+  static uint8_t bitsRequired(uint64_t value) {
+    return value == 0 ? 0
+                      : static_cast<uint8_t>(velox::bits::bitsRequired(value));
+  }
+
+  struct ReadWithVisitorState {
+    std::optional<uint32_t> cachedBlockIndex;
+    uint32_t cachedPosition{0};
+    uint8_t cachedBitWidth{0};
+    uint64_t cachedOrdered{0};
+    FixedBitArray cachedDeltas{};
+  };
+
+  // Returns the number of rows in the given block, handling the final partial
+  // block.
+  uint32_t blockRowCount(uint32_t blockIndex) const;
+
+  // Decodes a slice within a single block by reconstructing values from its
+  // base and deltas.
+  void materializeBlock(
+      uint32_t blockIndex,
+      uint32_t position,
+      uint32_t rowCount,
+      physicalType* output,
+      uint64_t* deltaChunk);
+
+  // Decodes a contiguous range that may span multiple blocks.
+  void materializeContiguous(
+      uint32_t startRow,
+      uint32_t rowCount,
+      physicalType* output);
+
+  void seekReadWithVisitorState(ReadWithVisitorState& state, uint32_t row)
+      const;
+
+  physicalType decodeWithVisitorState(ReadWithVisitorState& state);
+
+  // Number of rows per block, except possibly the last partial block.
+  uint16_t blockSize_{0};
+  // Total number of blocks in the encoding.
+  uint32_t numBlocks_{0};
+  // Per-block base values that anchor ordered delta reconstruction.
+  Vector<physicalType> blockBases_;
+  // Per-block bit width for delta storage. Zero indicates a constant block.
+  Vector<uint8_t> bitWidths_;
+  // Per-block byte offsets into packedData_ for the delta bit streams.
+  Vector<uint32_t> blockOffsets_;
+  Vector<uint64_t> deltaChunk_;
+  // Pointer into the encoded payload that holds the packed delta bits.
+  const char* packedData_{nullptr};
+  // Current read cursor used by materialize() and skip().
+  uint32_t row_{0};
+};
+
+template <typename T>
+DeltaBlockEncoding<T>::DeltaBlockEncoding(
+    velox::memory::MemoryPool& pool,
+    std::string_view data,
+    const std::function<void*(uint32_t)>& /*stringBufferFactory*/,
+    const Encoding::Options& options)
+    : TypedEncoding<T, physicalType>{pool, data, prefixOptions(options)},
+      blockBases_{this->template getVectorBuffer<physicalType>()},
+      bitWidths_{this->template getVectorBuffer<uint8_t>()},
+      blockOffsets_{this->template getVectorBuffer<uint32_t>()},
+      deltaChunk_{this->template getVectorBuffer<uint64_t>()} {
+  const char* pos = data.data() + this->dataOffset();
+  blockSize_ = static_cast<uint16_t>(varint::readVarint32(&pos));
+  numBlocks_ = varint::readVarint32(&pos);
+  NIMBLE_CHECK_GT(blockSize_, 0);
+  NIMBLE_CHECK_EQ(
+      numBlocks_,
+      velox::bits::divRoundUp(this->rowCount(), blockSize_),
+      "Invalid DeltaBlock block count.");
+
+  blockBases_.resize(numBlocks_);
+  for (uint32_t i = 0; i < numBlocks_; ++i) {
+    blockBases_[i] =
+        DeltaBlockEncoding<T>::fromOrdered(varint::readVarint64(&pos));
+  }
+
+  bitWidths_.resize(numBlocks_);
+  std::memcpy(bitWidths_.data(), pos, numBlocks_ * sizeof(uint8_t));
+  pos += numBlocks_ * sizeof(uint8_t);
+
+  blockOffsets_.resize(numBlocks_);
+  for (uint32_t i = 0; i < numBlocks_; ++i) {
+    blockOffsets_[i] = varint::readVarint32(&pos);
+  }
+  packedData_ = pos;
+}
+
+template <typename T>
+void DeltaBlockEncoding<T>::reset() {
+  row_ = 0;
+}
+
+template <typename T>
+void DeltaBlockEncoding<T>::skip(uint32_t rowCount) {
+  NIMBLE_CHECK_LE(row_, this->rowCount(), "Invalid encoding position.");
+  NIMBLE_CHECK_LE(
+      rowCount, this->rowCount() - row_, "Skipping past end of encoding.");
+  row_ += rowCount;
+}
+
+template <typename T>
+uint32_t DeltaBlockEncoding<T>::blockRowCount(uint32_t blockIndex) const {
+  return DeltaBlockEncoding<T>::blockRowCount(
+      this->rowCount(), blockSize_, blockIndex);
+}
+
+template <typename T>
+void DeltaBlockEncoding<T>::materializeBlock(
+    uint32_t blockIndex,
+    uint32_t position,
+    uint32_t rowCount,
+    physicalType* output,
+    uint64_t* deltaChunk) {
+  NIMBLE_CHECK_LE(position + rowCount, blockRowCount(blockIndex));
+  if (rowCount == 0) {
+    return;
+  }
+
+  uint64_t ordered = DeltaBlockEncoding<T>::toOrdered(blockBases_[blockIndex]);
+  const auto bitWidth = bitWidths_[blockIndex];
+  if (bitWidth == 0) {
+    std::fill_n(output, rowCount, DeltaBlockEncoding<T>::fromOrdered(ordered));
+    return;
+  }
+
+  FixedBitArray deltas{
+      {packedData_ + blockOffsets_[blockIndex],
+       FixedBitArray::bufferSize(blockRowCount(blockIndex) - 1, bitWidth)},
+      bitWidth};
+  // Apply deltas before `position` so `ordered` is the first requested value.
+  for (uint32_t offset = 0; offset < position; offset += kDeltaChunkSize) {
+    const auto chunkSize =
+        std::min<uint32_t>(kDeltaChunkSize, position - offset);
+    deltas.bulkGetWithBaseline(
+        offset, chunkSize, deltaChunk, /*baseline=*/uint64_t{0});
+    for (uint32_t i = 0; i < chunkSize; ++i) {
+      ordered += deltaChunk[i];
+    }
+  }
+
+  // Deltas are stored between adjacent rows. After reconstructing the value at
+  // `position`, delta `position + offset` advances to the next output row.
+  output[0] = DeltaBlockEncoding<T>::fromOrdered(ordered);
+  for (uint32_t offset = 0; offset + 1 < rowCount;) {
+    const auto chunkSize =
+        std::min<uint32_t>(kDeltaChunkSize, rowCount - offset - 1);
+    deltas.bulkGetWithBaseline(
+        position + offset, chunkSize, deltaChunk, /*baseline=*/uint64_t{0});
+    for (uint32_t i = 0; i < chunkSize; ++i) {
+      ordered += deltaChunk[i];
+      output[offset + i + 1] = DeltaBlockEncoding<T>::fromOrdered(ordered);
+    }
+    offset += chunkSize;
+  }
+}
+
+template <typename T>
+void DeltaBlockEncoding<T>::materializeContiguous(
+    uint32_t startRow,
+    uint32_t rowCount,
+    physicalType* output) {
+  deltaChunk_.resize(kDeltaChunkSize);
+  uint32_t written{0};
+  while (written < rowCount) {
+    const auto row = startRow + written;
+    const auto blockIndex = row / blockSize_;
+    const auto position = row % blockSize_;
+    const auto rowsInBlock = std::min<uint32_t>(
+        rowCount - written, blockRowCount(blockIndex) - position);
+    materializeBlock(
+        blockIndex,
+        position,
+        rowsInBlock,
+        output + written,
+        deltaChunk_.data());
+    written += rowsInBlock;
+  }
+}
+
+template <typename T>
+void DeltaBlockEncoding<T>::materialize(uint32_t rowCount, void* buffer) {
+  NIMBLE_CHECK_LE(row_, this->rowCount(), "Invalid encoding position.");
+  NIMBLE_CHECK_LE(
+      rowCount, this->rowCount() - row_, "Reading past end of encoding.");
+  auto* output = static_cast<physicalType*>(buffer);
+  materializeContiguous(row_, rowCount, output);
+  row_ += rowCount;
+}
+
+template <typename T>
+void DeltaBlockEncoding<T>::seekReadWithVisitorState(
+    ReadWithVisitorState& state,
+    uint32_t row) const {
+  const auto blockIndex = row / blockSize_;
+  const auto position = row % blockSize_;
+  state.cachedBlockIndex = blockIndex;
+  state.cachedPosition = 0;
+  state.cachedBitWidth = bitWidths_[blockIndex];
+  state.cachedOrdered =
+      DeltaBlockEncoding<T>::toOrdered(blockBases_[blockIndex]);
+  if (state.cachedBitWidth != 0) {
+    state.cachedDeltas = FixedBitArray{
+        {packedData_ + blockOffsets_[blockIndex],
+         FixedBitArray::bufferSize(
+             blockRowCount(blockIndex) - 1, state.cachedBitWidth)},
+        state.cachedBitWidth};
+    for (uint32_t i = 0; i < position; ++i) {
+      state.cachedOrdered += state.cachedDeltas.get(i);
+    }
+  }
+  state.cachedPosition = position;
+}
+
+template <typename T>
+typename DeltaBlockEncoding<T>::physicalType
+DeltaBlockEncoding<T>::decodeWithVisitorState(ReadWithVisitorState& state) {
+  const auto blockIndex = row_ / blockSize_;
+  const auto position = row_ % blockSize_;
+  if (!state.cachedBlockIndex.has_value() ||
+      blockIndex != state.cachedBlockIndex.value() ||
+      position < state.cachedPosition) {
+    seekReadWithVisitorState(state, row_);
+  } else if (position > state.cachedPosition) {
+    if (state.cachedBitWidth != 0) {
+      for (uint32_t i = state.cachedPosition; i < position; ++i) {
+        state.cachedOrdered += state.cachedDeltas.get(i);
+      }
+    }
+    state.cachedPosition = position;
+  }
+  ++row_;
+  return DeltaBlockEncoding<T>::fromOrdered(state.cachedOrdered);
+}
+
+template <typename T>
+template <typename DecoderVisitor>
+void DeltaBlockEncoding<T>::readWithVisitor(
+    DecoderVisitor& visitor,
+    ReadWithVisitorParams& params) {
+  ReadWithVisitorState state;
+
+  detail::readWithVisitorSlow(
+      visitor,
+      params,
+      [&](auto toSkip) { skip(toSkip); },
+      [&] { return decodeWithVisitorState(state); });
+}
+
+template <typename T>
+std::optional<uint64_t> DeltaBlockEncoding<T>::estimateSize(
+    std::span<const physicalType> values,
+    const Encoding::Options& options) {
+  const auto blockSize = options.deltaBlockSize;
+  if (values.empty() || blockSize == 0) {
+    return std::nullopt;
+  }
+
+  const auto rowCount = static_cast<uint32_t>(values.size());
+  const auto numBlocks = velox::bits::divRoundUp(rowCount, blockSize);
+  uint64_t packedSize{0};
+  uint64_t blockBasesSize{0};
+  uint64_t blockOffsetsSize{0};
+  for (uint32_t blockIndex = 0; blockIndex < numBlocks; ++blockIndex) {
+    const uint32_t start = blockIndex * blockSize;
+    const uint32_t end = std::min<uint32_t>(start + blockSize, rowCount);
+    blockBasesSize +=
+        varint::varintSize(DeltaBlockEncoding<T>::toOrdered(values[start]));
+    uint64_t prev = DeltaBlockEncoding<T>::toOrdered(values[start]);
+    uint64_t maxDelta{0};
+    for (uint32_t i = start + 1; i < end; ++i) {
+      const auto curr = DeltaBlockEncoding<T>::toOrdered(values[i]);
+      if (curr < prev) {
+        return std::nullopt;
+      }
+      maxDelta = std::max(maxDelta, curr - prev);
+      prev = curr;
+    }
+    // Each block stores the first row as a base, then one delta per remaining
+    // row.
+    const auto deltaCount = end - start - 1;
+    blockOffsetsSize += varint::varintSize(packedSize);
+    if (deltaCount != 0 && maxDelta != 0) {
+      packedSize +=
+          FixedBitArray::bufferSize(deltaCount, bitsRequired(maxDelta));
+    }
+  }
+
+  return Encoding::serializePrefixSize(rowCount, /*useVarint=*/true) +
+      varint::varintSize(blockSize) + varint::varintSize(numBlocks) +
+      blockBasesSize + /*bitWidths=*/numBlocks * sizeof(uint8_t) +
+      blockOffsetsSize + packedSize;
+}
+
+template <typename T>
+std::string_view DeltaBlockEncoding<T>::encode(
+    EncodingSelection<physicalType>& /*selection*/,
+    std::span<const physicalType> values,
+    Buffer& buffer,
+    const Encoding::Options& options) {
+  NIMBLE_CHECK(!values.empty(), "DeltaBlock cannot encode empty streams.");
+
+  const auto blockSize = options.deltaBlockSize;
+  NIMBLE_CHECK_GT(blockSize, 0);
+  const auto rowCount = static_cast<uint32_t>(values.size());
+  const auto numBlocks = velox::bits::divRoundUp(rowCount, blockSize);
+  auto* pool = &buffer.getMemoryPool();
+  Vector<physicalType> blockBases{pool, numBlocks};
+  Vector<uint8_t> bitWidths{pool, numBlocks};
+  Vector<uint32_t> blockOffsets{pool, numBlocks};
+  uint64_t packedSize{0};
+  uint64_t blockBasesSize{0};
+  uint64_t blockOffsetsSize{0};
+
+  for (uint32_t blockIndex = 0; blockIndex < numBlocks; ++blockIndex) {
+    const uint32_t start = blockIndex * blockSize;
+    const uint32_t end = std::min<uint32_t>(start + blockSize, rowCount);
+    const uint32_t count = end - start;
+
+    blockBases[blockIndex] = values[start];
+    blockBasesSize +=
+        varint::varintSize(DeltaBlockEncoding<T>::toOrdered(values[start]));
+    uint64_t prev = DeltaBlockEncoding<T>::toOrdered(values[start]);
+    uint64_t maxDelta{0};
+    for (uint32_t i = start + 1; i < end; ++i) {
+      const auto curr = DeltaBlockEncoding<T>::toOrdered(values[i]);
+      NIMBLE_CHECK_GE(curr, prev, "DeltaBlock requires non-decreasing values.");
+      maxDelta = std::max(maxDelta, curr - prev);
+      prev = curr;
+    }
+
+    const auto bitWidth = bitsRequired(maxDelta);
+    bitWidths[blockIndex] = bitWidth;
+    blockOffsets[blockIndex] = static_cast<uint32_t>(packedSize);
+    blockOffsetsSize += varint::varintSize(packedSize);
+    if (count <= 1 || bitWidth == 0) {
+      continue;
+    }
+
+    const auto deltaCount = count - 1;
+    const auto bytes = FixedBitArray::bufferSize(deltaCount, bitWidth);
+    NIMBLE_CHECK_LE(
+        packedSize + bytes,
+        std::numeric_limits<uint32_t>::max(),
+        "DeltaBlock payload exceeds uint32 offsets.");
+    packedSize += bytes;
+  }
+
+  ScopedEncodingBuffer scopedBuffer{pool, options.encodingBufferPool};
+  char* packedData{nullptr};
+  if (packedSize != 0) {
+    packedData = scopedBuffer.get().reserve(packedSize);
+    std::memset(packedData, 0, packedSize);
+  }
+
+  for (uint32_t blockIndex = 0; blockIndex < numBlocks; ++blockIndex) {
+    const auto bitWidth = bitWidths[blockIndex];
+    if (bitWidth == 0) {
+      continue;
+    }
+
+    const uint32_t start = blockIndex * blockSize;
+    const uint32_t end = std::min<uint32_t>(start + blockSize, rowCount);
+    if (end - start <= 1) {
+      continue;
+    }
+
+    FixedBitArray deltas{packedData + blockOffsets[blockIndex], bitWidth};
+    uint64_t prev = DeltaBlockEncoding<T>::toOrdered(values[start]);
+    for (uint32_t i = start + 1; i < end; ++i) {
+      const auto curr = DeltaBlockEncoding<T>::toOrdered(values[i]);
+      deltas.set(i - start - 1, curr - prev);
+      prev = curr;
+    }
+  }
+
+  const uint64_t encodingSize =
+      Encoding::serializePrefixSize(rowCount, /*useVarint=*/true) +
+      varint::varintSize(blockSize) + varint::varintSize(numBlocks) +
+      /*blockBases=*/blockBasesSize +
+      /*bitWidths=*/numBlocks * sizeof(uint8_t) +
+      /*blockOffsets=*/blockOffsetsSize + /*packedData=*/packedSize;
+  NIMBLE_CHECK_LE(
+      encodingSize,
+      std::numeric_limits<uint32_t>::max(),
+      "DeltaBlock encoding exceeds uint32 size.");
+
+  char* reserved = buffer.reserve(encodingSize);
+  char* pos = reserved;
+  Encoding::serializePrefix(
+      EncodingType::DeltaBlock,
+      TypeTraits<T>::dataType,
+      rowCount,
+      /*useVarint=*/true,
+      pos);
+  varint::writeVarint(blockSize, &pos);
+  varint::writeVarint(numBlocks, &pos);
+  for (uint32_t i = 0; i < numBlocks; ++i) {
+    varint::writeVarint(DeltaBlockEncoding<T>::toOrdered(blockBases[i]), &pos);
+  }
+  std::memcpy(pos, bitWidths.data(), numBlocks * sizeof(uint8_t));
+  pos += numBlocks * sizeof(uint8_t);
+  for (uint32_t i = 0; i < numBlocks; ++i) {
+    varint::writeVarint(blockOffsets[i], &pos);
+  }
+  if (packedSize != 0) {
+    std::memcpy(pos, packedData, packedSize);
+    pos += packedSize;
+  }
+  NIMBLE_CHECK_EQ(pos - reserved, encodingSize, "Encoding size mismatch.");
+  return {reserved, static_cast<size_t>(encodingSize)};
+}
+
+template <typename T>
+std::string DeltaBlockEncoding<T>::debugString(int offset) const {
+  return Encoding::debugString(offset) +
+      fmt::format(
+             "\n{}blockSize={}, numBlocks={}",
+             std::string(offset, ' '),
+             blockSize_,
+             numBlocks_);
+}
+
+} // namespace facebook::nimble

--- a/dwio/nimble/encodings/common/Encoding.h
+++ b/dwio/nimble/encodings/common/Encoding.h
@@ -141,6 +141,16 @@ class Encoding {
     /// reads it back from the stream (self-describing).
     uint16_t blockBitPackingBlockSize = kBlockBitPackingBlockSize;
 
+    /// Number of rows per independently encoded DeltaBlock block.
+    ///
+    /// Each block stores one base value plus fixed-width deltas between
+    /// adjacent sorted values inside that block. Smaller blocks adapt better
+    /// when local gap widths change, but pay more per-block metadata. Larger
+    /// blocks reduce metadata, but one large gap can widen every delta in the
+    /// block. The value is serialized in the stream header, so readers are
+    /// self-describing.
+    uint16_t deltaBlockSize{256};
+
     /// When true, FOR-family payloads use the exact required bit width. When
     /// false, FixedBitWidth and PFOR round to byte or bucket boundaries.
     bool fixedBitWidthUseExactBits{false};

--- a/dwio/nimble/encodings/common/EncodingFactory.cpp
+++ b/dwio/nimble/encodings/common/EncodingFactory.cpp
@@ -17,6 +17,7 @@
 #include "dwio/nimble/encodings/ALPEncoding.h"
 #include "dwio/nimble/encodings/BlockBitPackingEncoding.h"
 #include "dwio/nimble/encodings/ConstantEncoding.h"
+#include "dwio/nimble/encodings/DeltaBlockEncoding.h"
 #include "dwio/nimble/encodings/DeltaEncoding.h"
 #include "dwio/nimble/encodings/DictionaryEncoding.h"
 #include "dwio/nimble/encodings/FixedBitWidthEncoding.h"
@@ -212,40 +213,40 @@ std::unique_ptr<Encoding> EncodingFactory::create(
           toString(dataType));                              \
   }
 
-#define RETURN_ENCODING_BY_INTEGER_TYPE(Encoding, dataType)                  \
-  switch (dataType) {                                                        \
-    case DataType::Int8:                                                     \
-      return std::make_unique<Encoding<int8_t>>(                             \
-          pool, data, stringBufferFactory, options);                         \
-    case DataType::Uint8:                                                    \
-      return std::make_unique<Encoding<uint8_t>>(                            \
-          pool, data, stringBufferFactory, options);                         \
-    case DataType::Int16:                                                    \
-      return std::make_unique<Encoding<int16_t>>(                            \
-          pool, data, stringBufferFactory, options);                         \
-    case DataType::Uint16:                                                   \
-      return std::make_unique<Encoding<uint16_t>>(                           \
-          pool, data, stringBufferFactory, options);                         \
-    case DataType::Int32:                                                    \
-      return std::make_unique<Encoding<int32_t>>(                            \
-          pool, data, stringBufferFactory, options);                         \
-    case DataType::Uint32:                                                   \
-      return std::make_unique<Encoding<uint32_t>>(                           \
-          pool, data, stringBufferFactory, options);                         \
-    case DataType::Int64:                                                    \
-      return std::make_unique<Encoding<int64_t>>(                            \
-          pool, data, stringBufferFactory, options);                         \
-    case DataType::Uint64:                                                   \
-      return std::make_unique<Encoding<uint64_t>>(                           \
-          pool, data, stringBufferFactory, options);                         \
-    case DataType::Undefined:                                                \
-    case DataType::Float:                                                    \
-    case DataType::Double:                                                   \
-    case DataType::Bool:                                                     \
-    case DataType::String:                                                   \
-    default:                                                                 \
-      NIMBLE_UNREACHABLE(                                                    \
-          "HuffmanEncoding only supports integer types, got {}.", dataType); \
+#define RETURN_ENCODING_BY_INTEGER_TYPE(Encoding, dataType)                \
+  switch (dataType) {                                                      \
+    case DataType::Int8:                                                   \
+      return std::make_unique<Encoding<int8_t>>(                           \
+          pool, data, stringBufferFactory, options);                       \
+    case DataType::Uint8:                                                  \
+      return std::make_unique<Encoding<uint8_t>>(                          \
+          pool, data, stringBufferFactory, options);                       \
+    case DataType::Int16:                                                  \
+      return std::make_unique<Encoding<int16_t>>(                          \
+          pool, data, stringBufferFactory, options);                       \
+    case DataType::Uint16:                                                 \
+      return std::make_unique<Encoding<uint16_t>>(                         \
+          pool, data, stringBufferFactory, options);                       \
+    case DataType::Int32:                                                  \
+      return std::make_unique<Encoding<int32_t>>(                          \
+          pool, data, stringBufferFactory, options);                       \
+    case DataType::Uint32:                                                 \
+      return std::make_unique<Encoding<uint32_t>>(                         \
+          pool, data, stringBufferFactory, options);                       \
+    case DataType::Int64:                                                  \
+      return std::make_unique<Encoding<int64_t>>(                          \
+          pool, data, stringBufferFactory, options);                       \
+    case DataType::Uint64:                                                 \
+      return std::make_unique<Encoding<uint64_t>>(                         \
+          pool, data, stringBufferFactory, options);                       \
+    case DataType::Undefined:                                              \
+    case DataType::Float:                                                  \
+    case DataType::Double:                                                 \
+    case DataType::Bool:                                                   \
+    case DataType::String:                                                 \
+    default:                                                               \
+      NIMBLE_INCOMPATIBLE_ENCODING(                                        \
+          "{} only supports integer types, got {}.", #Encoding, dataType); \
   }
 
   switch (encodingType) {
@@ -299,6 +300,9 @@ std::unique_ptr<Encoding> EncodingFactory::create(
     }
     case EncodingType::Delta: {
       RETURN_ENCODING_BY_NUMERIC_TYPE(DeltaEncoding, dataType);
+    }
+    case EncodingType::DeltaBlock: {
+      RETURN_ENCODING_BY_INTEGER_TYPE(DeltaBlockEncoding, dataType);
     }
     case EncodingType::ALP: {
       switch (dataType) {
@@ -469,6 +473,15 @@ std::string_view EncodingFactory::encode(
       }
       NIMBLE_INCOMPATIBLE_ENCODING(
           "Delta encoding should not be selected for non-numeric data type: {}.",
+          TypeTraits<T>::dataType);
+    }
+    case EncodingType::DeltaBlock: {
+      if constexpr (isIntegralType<T>()) {
+        return DeltaBlockEncoding<T>::encode(
+            selection, castedValues, buffer, options);
+      }
+      NIMBLE_INCOMPATIBLE_ENCODING(
+          "DeltaBlock encoding only supports integral data types, got {}.",
           TypeTraits<T>::dataType);
     }
     case EncodingType::ALP: {

--- a/dwio/nimble/encodings/common/EncodingLayout.cpp
+++ b/dwio/nimble/encodings/common/EncodingLayout.cpp
@@ -191,6 +191,7 @@ EncodingLayout EncodingLayoutCapture::capture(std::string_view encoding) {
     case EncodingType::Varint:
     case EncodingType::Constant:
     case EncodingType::Prefix:
+    case EncodingType::DeltaBlock:
     case EncodingType::SimdForBitpack:
     case EncodingType::SubIntSplit:
     case EncodingType::FOR:

--- a/dwio/nimble/encodings/common/EncodingUtils.h
+++ b/dwio/nimble/encodings/common/EncodingUtils.h
@@ -18,6 +18,7 @@
 #include "dwio/nimble/encodings/ALPEncoding.h"
 #include "dwio/nimble/encodings/BlockBitPackingEncoding.h"
 #include "dwio/nimble/encodings/ConstantEncoding.h"
+#include "dwio/nimble/encodings/DeltaBlockEncoding.h"
 #include "dwio/nimble/encodings/DeltaEncoding.h"
 #include "dwio/nimble/encodings/DictionaryEncoding.h"
 #include "dwio/nimble/encodings/FixedBitWidthEncoding.h"
@@ -134,6 +135,13 @@ auto encodingTypeDispatchNonString(Encoding& encoding, F&& f) {
       return f(static_cast<MainlyConstantEncoding<T>&>(encoding));
     case EncodingType::Delta:
       return f(static_cast<DeltaEncoding<T>&>(encoding));
+    case EncodingType::DeltaBlock:
+      if constexpr (isIntegralType<T>()) {
+        return f(static_cast<DeltaBlockEncoding<T>&>(encoding));
+      }
+      NIMBLE_UNREACHABLE(
+          "DeltaBlock encoding only supports integral data types, got {}.",
+          encoding.dataType());
     case EncodingType::ALP:
       if constexpr (isFloatingPointType<T>()) {
         return f(static_cast<ALPEncoding<T>&>(encoding));

--- a/dwio/nimble/encodings/legacy/EncodingFactory.cpp
+++ b/dwio/nimble/encodings/legacy/EncodingFactory.cpp
@@ -15,6 +15,7 @@
  */
 #include "dwio/nimble/encodings/legacy/EncodingFactory.h"
 #include "dwio/nimble/encodings/BlockBitPackingEncoding.h"
+#include "dwio/nimble/encodings/DeltaBlockEncoding.h"
 #include "dwio/nimble/encodings/HuffmanEncoding.h"
 #include "dwio/nimble/encodings/PFOREncoding.h"
 #include "dwio/nimble/encodings/SimdForBitpackEncoding.h"
@@ -214,40 +215,40 @@ std::unique_ptr<Encoding> EncodingFactory::create(
           toString(dataType));                              \
   }
 
-#define RETURN_ENCODING_BY_INTEGRAL_TYPE(Encoding, dataType)                  \
-  switch (dataType) {                                                         \
-    case DataType::Int8:                                                      \
-      return std::make_unique<Encoding<int8_t>>(                              \
-          memoryPool, data, stringBufferFactory);                             \
-    case DataType::Uint8:                                                     \
-      return std::make_unique<Encoding<uint8_t>>(                             \
-          memoryPool, data, stringBufferFactory);                             \
-    case DataType::Int16:                                                     \
-      return std::make_unique<Encoding<int16_t>>(                             \
-          memoryPool, data, stringBufferFactory);                             \
-    case DataType::Uint16:                                                    \
-      return std::make_unique<Encoding<uint16_t>>(                            \
-          memoryPool, data, stringBufferFactory);                             \
-    case DataType::Int32:                                                     \
-      return std::make_unique<Encoding<int32_t>>(                             \
-          memoryPool, data, stringBufferFactory);                             \
-    case DataType::Uint32:                                                    \
-      return std::make_unique<Encoding<uint32_t>>(                            \
-          memoryPool, data, stringBufferFactory);                             \
-    case DataType::Int64:                                                     \
-      return std::make_unique<Encoding<int64_t>>(                             \
-          memoryPool, data, stringBufferFactory);                             \
-    case DataType::Uint64:                                                    \
-      return std::make_unique<Encoding<uint64_t>>(                            \
-          memoryPool, data, stringBufferFactory);                             \
-    case DataType::Undefined:                                                 \
-    case DataType::Float:                                                     \
-    case DataType::Double:                                                    \
-    case DataType::Bool:                                                      \
-    case DataType::String:                                                    \
-    default:                                                                  \
-      NIMBLE_UNREACHABLE(                                                     \
-          "HuffmanEncoding only supports integral types, got {}.", dataType); \
+#define RETURN_ENCODING_BY_INTEGRAL_TYPE(Encoding, dataType)               \
+  switch (dataType) {                                                      \
+    case DataType::Int8:                                                   \
+      return std::make_unique<Encoding<int8_t>>(                           \
+          memoryPool, data, stringBufferFactory);                          \
+    case DataType::Uint8:                                                  \
+      return std::make_unique<Encoding<uint8_t>>(                          \
+          memoryPool, data, stringBufferFactory);                          \
+    case DataType::Int16:                                                  \
+      return std::make_unique<Encoding<int16_t>>(                          \
+          memoryPool, data, stringBufferFactory);                          \
+    case DataType::Uint16:                                                 \
+      return std::make_unique<Encoding<uint16_t>>(                         \
+          memoryPool, data, stringBufferFactory);                          \
+    case DataType::Int32:                                                  \
+      return std::make_unique<Encoding<int32_t>>(                          \
+          memoryPool, data, stringBufferFactory);                          \
+    case DataType::Uint32:                                                 \
+      return std::make_unique<Encoding<uint32_t>>(                         \
+          memoryPool, data, stringBufferFactory);                          \
+    case DataType::Int64:                                                  \
+      return std::make_unique<Encoding<int64_t>>(                          \
+          memoryPool, data, stringBufferFactory);                          \
+    case DataType::Uint64:                                                 \
+      return std::make_unique<Encoding<uint64_t>>(                         \
+          memoryPool, data, stringBufferFactory);                          \
+    case DataType::Undefined:                                              \
+    case DataType::Float:                                                  \
+    case DataType::Double:                                                 \
+    case DataType::Bool:                                                   \
+    case DataType::String:                                                 \
+    default:                                                               \
+      NIMBLE_INCOMPATIBLE_ENCODING(                                        \
+          "{} only supports integer types, got {}.", #Encoding, dataType); \
   }
 
   switch (encodingType) {
@@ -285,6 +286,10 @@ std::unique_ptr<Encoding> EncodingFactory::create(
     }
     case EncodingType::Delta: {
       RETURN_ENCODING_BY_NUMERIC_TYPE(DeltaEncoding, dataType);
+    }
+    case EncodingType::DeltaBlock: {
+      RETURN_ENCODING_BY_INTEGRAL_TYPE(
+          ::facebook::nimble::DeltaBlockEncoding, dataType);
     }
     // SubIntSplit integration commented out (disabled):
     /*

--- a/dwio/nimble/encodings/legacy/EncodingUtils.h
+++ b/dwio/nimble/encodings/legacy/EncodingUtils.h
@@ -15,6 +15,7 @@
  */
 #pragma once
 
+#include "dwio/nimble/encodings/DeltaBlockEncoding.h"
 #include "dwio/nimble/encodings/HuffmanEncoding.h"
 #include "dwio/nimble/encodings/PFOREncoding.h"
 #include "dwio/nimble/encodings/SimdForBitpackEncoding.h"
@@ -120,6 +121,15 @@ auto encodingTypeDispatchNonString(Encoding& encoding, F&& f) {
           static_cast<facebook::nimble::BlockBitPackingEncoding<T>&>(encoding));
     // New Encoding has no legacy-specialised class; legacy reads dispatch into
     // the modern Encoding classes
+    case EncodingType::DeltaBlock:
+      if constexpr (isIntegralType<T>()) {
+        return f(
+            static_cast<::facebook::nimble::DeltaBlockEncoding<T>&>(encoding));
+      } else {
+        NIMBLE_UNREACHABLE(
+            "DeltaBlock encoding only supports integral data types, got {}.",
+            encoding.dataType());
+      }
     case EncodingType::PFOR:
       if constexpr (isIntegralType<T>()) {
         return f(static_cast<::facebook::nimble::PFOREncoding<T>&>(encoding));

--- a/dwio/nimble/encodings/selection/EncodingSelectionPolicy.cpp
+++ b/dwio/nimble/encodings/selection/EncodingSelectionPolicy.cpp
@@ -119,6 +119,7 @@ ManualEncodingSelectionPolicyFactory::possibleEncodings() {
       EncodingType::SimdForBitpack,
       EncodingType::SubIntSplit,
       EncodingType::BlockBitPacking,
+      EncodingType::DeltaBlock,
       EncodingType::Fsst,
       EncodingType::Huffman,
   };

--- a/dwio/nimble/encodings/selection/EncodingSizeEstimation.h
+++ b/dwio/nimble/encodings/selection/EncodingSizeEstimation.h
@@ -23,6 +23,7 @@
 #include "dwio/nimble/encodings/ALPEncoding.h"
 #include "dwio/nimble/encodings/BlockBitPackingEncoding.h"
 #include "dwio/nimble/encodings/ConstantEncoding.h"
+#include "dwio/nimble/encodings/DeltaBlockEncoding.h"
 #include "dwio/nimble/encodings/DictionaryEncoding.h"
 #include "dwio/nimble/encodings/FixedBitWidthEncoding.h"
 #include "dwio/nimble/encodings/FsstEncoding.h"
@@ -146,9 +147,6 @@ struct EncodingSizeEstimation {
         return BlockBitPackingEncoding<physicalType>::estimateSize(
             statistics, options.blockBitPackingBlockSize);
       }
-      case EncodingType::ALP: {
-        return std::nullopt;
-      }
       default: {
         return std::nullopt;
       }
@@ -174,6 +172,13 @@ struct EncodingSizeEstimation {
       case EncodingType::ALP: {
         if constexpr (isFloatingPointType<T>()) {
           return ALPEncoding<T>::estimateSize(values, options);
+        } else {
+          return std::nullopt;
+        }
+      }
+      case EncodingType::DeltaBlock: {
+        if constexpr (isIntegralType<T>()) {
+          return DeltaBlockEncoding<T>::estimateSize(values, options);
         } else {
           return std::nullopt;
         }

--- a/dwio/nimble/encodings/tests/DeltaBlockBenchmarks.cpp
+++ b/dwio/nimble/encodings/tests/DeltaBlockBenchmarks.cpp
@@ -1,0 +1,353 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Benchmarks for DeltaBlock materialize performance on sorted integer streams.
+//
+// Usage:
+//   buck2 run @mode/opt //dwio/nimble/encodings/tests:delta_block_benchmark
+
+#include <algorithm>
+#include <cstdint>
+#include <memory>
+#include <span>
+#include <vector>
+
+#include "common/init/light.h"
+#include "dwio/nimble/common/Buffer.h"
+#include "dwio/nimble/encodings/DeltaBlockEncoding.h"
+#include "dwio/nimble/encodings/common/EncodingFactory.h"
+#include "dwio/nimble/encodings/selection/EncodingSelectionPolicy.h"
+#include "dwio/nimble/encodings/views/EncodingViewFactory.h"
+#include "folly/Benchmark.h"
+#include "velox/common/memory/Memory.h"
+
+using namespace facebook::nimble;
+
+namespace {
+
+constexpr uint32_t kRowCount{1'000'000};
+constexpr uint32_t kRowCountSmall{100'000};
+constexpr uint16_t kDefaultBlockSize{256};
+
+std::shared_ptr<facebook::velox::memory::MemoryPool> pool;
+
+template <typename T>
+std::vector<T> generateUnitStep(uint32_t rowCount) {
+  std::vector<T> data(rowCount);
+  for (uint32_t i = 0; i < rowCount; ++i) {
+    data[i] = static_cast<T>(i);
+  }
+  return data;
+}
+
+template <typename T>
+std::vector<T> generateSmallGaps(uint32_t rowCount) {
+  std::vector<T> data(rowCount);
+  uint64_t value{1000};
+  for (uint32_t i = 0; i < rowCount; ++i) {
+    value += 1 + (i % 7);
+    data[i] = static_cast<T>(value);
+  }
+  return data;
+}
+
+template <typename T>
+std::vector<T> generatePeriodicLargeGaps(uint32_t rowCount) {
+  std::vector<T> data(rowCount);
+  uint64_t value{0};
+  for (uint32_t i = 0; i < rowCount; ++i) {
+    value += (i % 1024 == 0) ? 65'536 : 1;
+    data[i] = static_cast<T>(value);
+  }
+  return data;
+}
+
+template <typename T>
+std::vector<T> generateConstant(uint32_t rowCount) {
+  return std::vector<T>(rowCount, static_cast<T>(42));
+}
+
+struct EncodedData {
+  std::string_view encoded;
+  std::unique_ptr<Buffer> buffer;
+  uint32_t rowCount{0};
+};
+
+template <typename T>
+EncodedData encodeDeltaBlock(
+    const std::vector<T>& data,
+    uint16_t blockSize = kDefaultBlockSize) {
+  auto buffer = std::make_unique<Buffer>(*pool);
+  ManualEncodingSelectionPolicyFactory factory{
+      {{EncodingType::DeltaBlock, 1.0}},
+      /*compressionOptions=*/std::nullopt};
+  auto policy = std::unique_ptr<EncodingSelectionPolicy<T>>(
+      static_cast<EncodingSelectionPolicy<T>*>(
+          factory.createPolicy(TypeTraits<T>::dataType).release()));
+
+  Encoding::Options options;
+  options.deltaBlockSize = blockSize;
+  auto encoded = EncodingFactory::encode<T>(
+      std::move(policy),
+      std::span<const T>{data.data(), data.size()},
+      *buffer,
+      options);
+
+  return {
+      .encoded = encoded,
+      .buffer = std::move(buffer),
+      .rowCount = static_cast<uint32_t>(data.size())};
+}
+
+template <typename T>
+struct BenchmarkData {
+  EncodedData unitStep;
+  EncodedData smallGaps;
+  EncodedData periodicLargeGaps;
+  EncodedData constant;
+
+  void init(uint32_t rowCount) {
+    unitStep = encodeDeltaBlock(generateUnitStep<T>(rowCount));
+    smallGaps = encodeDeltaBlock(generateSmallGaps<T>(rowCount));
+    periodicLargeGaps =
+        encodeDeltaBlock(generatePeriodicLargeGaps<T>(rowCount));
+    constant = encodeDeltaBlock(generateConstant<T>(rowCount));
+  }
+};
+
+template <typename T>
+struct BlockSizeBenchmarkData {
+  EncodedData block64;
+  EncodedData block256;
+  EncodedData block1024;
+  EncodedData block4096;
+
+  void init(uint32_t rowCount) {
+    const auto data = generateSmallGaps<T>(rowCount);
+    block64 = encodeDeltaBlock(data, 64);
+    block256 = encodeDeltaBlock(data, 256);
+    block1024 = encodeDeltaBlock(data, 1024);
+    block4096 = encodeDeltaBlock(data, 4096);
+  }
+};
+
+template <typename T>
+void benchMaterialize(unsigned iters, const EncodedData& data) {
+  std::vector<T> output(data.rowCount);
+  for (unsigned i = 0; i < iters; ++i) {
+    auto encoding = EncodingFactory().create(*pool, data.encoded, {});
+    encoding->materialize(data.rowCount, output.data());
+    folly::doNotOptimizeAway(output.back());
+  }
+}
+
+template <typename T>
+void benchMaterializeBatched(
+    unsigned iters,
+    const EncodedData& data,
+    uint32_t batchSize) {
+  std::vector<T> output(batchSize);
+  for (unsigned i = 0; i < iters; ++i) {
+    auto encoding = EncodingFactory().create(*pool, data.encoded, {});
+    uint32_t remaining = data.rowCount;
+    while (remaining > 0) {
+      const auto count = std::min<uint32_t>(remaining, batchSize);
+      encoding->materialize(count, output.data());
+      remaining -= count;
+    }
+    folly::doNotOptimizeAway(output[0]);
+  }
+}
+
+template <typename T>
+void benchSkipAndMaterialize(
+    unsigned iters,
+    const EncodedData& data,
+    uint32_t skipCount,
+    uint32_t readCount) {
+  std::vector<T> output(readCount);
+  for (unsigned i = 0; i < iters; ++i) {
+    auto encoding = EncodingFactory().create(*pool, data.encoded, {});
+    uint32_t position{0};
+    while (position < data.rowCount) {
+      const auto toSkip =
+          std::min<uint32_t>(skipCount, data.rowCount - position);
+      encoding->skip(toSkip);
+      position += toSkip;
+      if (position >= data.rowCount) {
+        break;
+      }
+
+      const auto toRead =
+          std::min<uint32_t>(readCount, data.rowCount - position);
+      encoding->materialize(toRead, output.data());
+      position += toRead;
+    }
+    folly::doNotOptimizeAway(output[0]);
+  }
+}
+
+template <typename T>
+void benchViewReadAtSequential(unsigned iters, const EncodedData& data) {
+  T output{};
+  for (unsigned i = 0; i < iters; ++i) {
+    auto view = createEncodingView(data.encoded, pool.get());
+    for (uint32_t row = 0; row < data.rowCount; ++row) {
+      view->readAt(row, &output);
+    }
+    folly::doNotOptimizeAway(output);
+  }
+}
+
+template <typename T>
+void benchViewReadAtScattered(
+    unsigned iters,
+    const EncodedData& data,
+    const std::vector<uint32_t>& positions) {
+  T output{};
+  for (unsigned i = 0; i < iters; ++i) {
+    auto view = createEncodingView(data.encoded, pool.get());
+    for (const auto position : positions) {
+      view->readAt(position, &output);
+    }
+    folly::doNotOptimizeAway(output);
+  }
+}
+
+std::vector<uint32_t> generateScatteredPositions(
+    uint32_t rowCount,
+    uint32_t count) {
+  std::vector<uint32_t> positions;
+  positions.reserve(count);
+  uint64_t value{17};
+  for (uint32_t i = 0; i < count; ++i) {
+    value = (value * 48'271 + 1) % rowCount;
+    positions.push_back(static_cast<uint32_t>(value));
+  }
+  return positions;
+}
+
+std::unique_ptr<BenchmarkData<int32_t>> int32Data;
+std::unique_ptr<BenchmarkData<int64_t>> int64Data;
+std::unique_ptr<BenchmarkData<int64_t>> int64DataSmall;
+std::unique_ptr<BlockSizeBenchmarkData<int64_t>> int64BlockSizeData;
+std::vector<uint32_t> scatteredPositions;
+
+} // namespace
+
+BENCHMARK(Int32_Materialize_UnitStep, n) {
+  benchMaterialize<int32_t>(n, int32Data->unitStep);
+}
+BENCHMARK_RELATIVE(Int32_Materialize_SmallGaps, n) {
+  benchMaterialize<int32_t>(n, int32Data->smallGaps);
+}
+BENCHMARK_RELATIVE(Int32_Materialize_PeriodicLargeGaps, n) {
+  benchMaterialize<int32_t>(n, int32Data->periodicLargeGaps);
+}
+BENCHMARK_RELATIVE(Int32_Materialize_Constant, n) {
+  benchMaterialize<int32_t>(n, int32Data->constant);
+}
+
+BENCHMARK_DRAW_LINE();
+
+BENCHMARK(Int64_Materialize_UnitStep, n) {
+  benchMaterialize<int64_t>(n, int64Data->unitStep);
+}
+BENCHMARK_RELATIVE(Int64_Materialize_SmallGaps, n) {
+  benchMaterialize<int64_t>(n, int64Data->smallGaps);
+}
+BENCHMARK_RELATIVE(Int64_Materialize_PeriodicLargeGaps, n) {
+  benchMaterialize<int64_t>(n, int64Data->periodicLargeGaps);
+}
+BENCHMARK_RELATIVE(Int64_Materialize_Constant, n) {
+  benchMaterialize<int64_t>(n, int64Data->constant);
+}
+
+BENCHMARK_DRAW_LINE();
+
+BENCHMARK(Int64_Block64_SmallGaps, n) {
+  benchMaterialize<int64_t>(n, int64BlockSizeData->block64);
+}
+BENCHMARK_RELATIVE(Int64_Block256_SmallGaps, n) {
+  benchMaterialize<int64_t>(n, int64BlockSizeData->block256);
+}
+BENCHMARK_RELATIVE(Int64_Block1024_SmallGaps, n) {
+  benchMaterialize<int64_t>(n, int64BlockSizeData->block1024);
+}
+BENCHMARK_RELATIVE(Int64_Block4096_SmallGaps, n) {
+  benchMaterialize<int64_t>(n, int64BlockSizeData->block4096);
+}
+
+BENCHMARK_DRAW_LINE();
+
+BENCHMARK(Int64_Batched1024_SmallGaps, n) {
+  benchMaterializeBatched<int64_t>(n, int64DataSmall->smallGaps, 1024);
+}
+BENCHMARK_RELATIVE(Int64_Batched1024_PeriodicLargeGaps, n) {
+  benchMaterializeBatched<int64_t>(n, int64DataSmall->periodicLargeGaps, 1024);
+}
+BENCHMARK_RELATIVE(Int64_SkipRead512_SmallGaps, n) {
+  benchSkipAndMaterialize<int64_t>(n, int64DataSmall->smallGaps, 512, 512);
+}
+BENCHMARK_RELATIVE(Int64_SkipRead512_PeriodicLargeGaps, n) {
+  benchSkipAndMaterialize<int64_t>(
+      n, int64DataSmall->periodicLargeGaps, 512, 512);
+}
+
+BENCHMARK_DRAW_LINE();
+
+BENCHMARK(Int64_ViewReadAtSequential_SmallGaps, n) {
+  benchViewReadAtSequential<int64_t>(n, int64DataSmall->smallGaps);
+}
+BENCHMARK_RELATIVE(Int64_ViewReadAtScattered_SmallGaps, n) {
+  benchViewReadAtScattered<int64_t>(
+      n, int64DataSmall->smallGaps, scatteredPositions);
+}
+BENCHMARK_RELATIVE(Int64_ViewReadAtScattered_PeriodicLargeGaps, n) {
+  benchViewReadAtScattered<int64_t>(
+      n, int64DataSmall->periodicLargeGaps, scatteredPositions);
+}
+
+int main(int argc, char** argv) {
+  facebook::init::initFacebookLight(&argc, &argv);
+  facebook::velox::memory::MemoryManager::initialize({});
+  pool = facebook::velox::memory::memoryManager()->addLeafPool(
+      "delta_block_benchmark");
+
+  int32Data = std::make_unique<BenchmarkData<int32_t>>();
+  int32Data->init(kRowCount);
+
+  int64Data = std::make_unique<BenchmarkData<int64_t>>();
+  int64Data->init(kRowCount);
+
+  int64DataSmall = std::make_unique<BenchmarkData<int64_t>>();
+  int64DataSmall->init(kRowCountSmall);
+
+  int64BlockSizeData = std::make_unique<BlockSizeBenchmarkData<int64_t>>();
+  int64BlockSizeData->init(kRowCount);
+  scatteredPositions =
+      generateScatteredPositions(kRowCountSmall, /*count=*/kRowCountSmall);
+
+  folly::runBenchmarks();
+
+  scatteredPositions.clear();
+  int64BlockSizeData.reset();
+  int64DataSmall.reset();
+  int64Data.reset();
+  int32Data.reset();
+  pool.reset();
+  return 0;
+}

--- a/dwio/nimble/encodings/tests/DeltaBlockEncodingTest.cpp
+++ b/dwio/nimble/encodings/tests/DeltaBlockEncodingTest.cpp
@@ -1,0 +1,314 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "dwio/nimble/encodings/DeltaBlockEncoding.h"
+
+#include <gtest/gtest.h>
+#include <cstdint>
+#include <limits>
+#include <optional>
+#include <random>
+#include <span>
+#include <vector>
+
+#include <fmt/format.h>
+
+#include "dwio/nimble/common/Buffer.h"
+#include "dwio/nimble/common/Exceptions.h"
+#include "dwio/nimble/common/Types.h"
+#include "dwio/nimble/encodings/tests/TestUtils.h"
+
+using namespace facebook;
+
+class DeltaBlockEncodingTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    pool_ = velox::memory::deprecatedAddDefaultLeafMemoryPool();
+    buffer_ = std::make_unique<nimble::Buffer>(*pool_);
+  }
+
+  template <typename T>
+  nimble::Vector<T> toVector(const std::vector<T>& input) {
+    nimble::Vector<T> values{pool_.get()};
+    values.insert(values.end(), input.data(), input.data() + input.size());
+    return values;
+  }
+
+  template <typename T>
+  std::unique_ptr<nimble::Encoding> createEncoding(
+      const std::vector<T>& input,
+      const nimble::Encoding::Options& options = {.deltaBlockSize = 3}) {
+    auto values = toVector(input);
+    return nimble::test::Encoder<nimble::DeltaBlockEncoding<T>>::createEncoding(
+        *buffer_,
+        values,
+        nullptr,
+        nimble::CompressionType::Uncompressed,
+        options);
+  }
+
+  template <typename T>
+  void roundTrip(const std::vector<T>& input) {
+    auto encoding = createEncoding(input);
+    std::vector<T> output(input.size());
+    encoding->materialize(static_cast<uint32_t>(input.size()), output.data());
+
+    EXPECT_EQ(encoding->encodingType(), nimble::EncodingType::DeltaBlock);
+    EXPECT_EQ(encoding->dataType(), nimble::TypeTraits<T>::dataType);
+    EXPECT_EQ(encoding->rowCount(), static_cast<uint32_t>(input.size()));
+    EXPECT_EQ(output, input);
+  }
+
+  std::shared_ptr<velox::memory::MemoryPool> pool_;
+  std::unique_ptr<nimble::Buffer> buffer_;
+};
+
+class TestReader {
+ public:
+  velox::BufferPtr& nullsInReadRange() {
+    return nullsInReadRange_;
+  }
+
+  const uint64_t* rawNullsInReadRange() const {
+    return nullsInReadRange_ ? nullsInReadRange_->as<uint64_t>() : nullptr;
+  }
+
+  bool returnReaderNulls() const {
+    return false;
+  }
+
+ private:
+  velox::BufferPtr nullsInReadRange_;
+};
+
+template <typename T>
+class IntegralReadWithVisitor {
+ public:
+  using DataType = T;
+  using Extract = std::nullptr_t;
+
+  explicit IntegralReadWithVisitor(std::vector<velox::vector_size_t> rows)
+      : rows_{std::move(rows)} {}
+
+  TestReader& reader() {
+    return reader_;
+  }
+
+  velox::vector_size_t numRows() const {
+    return rows_.size();
+  }
+
+  velox::vector_size_t rowAt(velox::vector_size_t index) const {
+    return rows_[index];
+  }
+
+  velox::vector_size_t currentRow() const {
+    return rowAt(rowIndex_);
+  }
+
+  void process(T value, bool& atEnd) {
+    values_.push_back(value);
+    addRowIndex(1);
+    atEnd = this->atEnd();
+  }
+
+  void processNull(bool& atEnd) {
+    addRowIndex(1);
+    atEnd = this->atEnd();
+  }
+
+  bool allowNulls() const {
+    return false;
+  }
+
+  void addRowIndex(velox::vector_size_t count) {
+    rowIndex_ += count;
+  }
+
+  void addNumValues(velox::vector_size_t /*count*/) {}
+
+  bool atEnd() const {
+    return rowIndex_ >= rows_.size();
+  }
+
+  const std::vector<T>& values() const {
+    return values_;
+  }
+
+ private:
+  TestReader reader_;
+  std::vector<velox::vector_size_t> rows_;
+  velox::vector_size_t rowIndex_{0};
+  std::vector<T> values_;
+};
+
+TEST_F(DeltaBlockEncodingTest, roundTripUnsignedValues) {
+  roundTrip<uint32_t>({1, 2, 3, 7, 9, 12, 13, 15, 20, 100});
+  roundTrip<uint64_t>({0, 0, 0, 5, 5, 9, 1000, 2000, 2000, 4000});
+  roundTrip<uint16_t>({2, 4, 4, 4, 9, 12, 30});
+  roundTrip<uint8_t>({0, 1, 1, 2, 3, 8});
+}
+
+TEST_F(DeltaBlockEncodingTest, roundTripSignedValues) {
+  roundTrip<int32_t>({-5, -3, -3, -1, 0, 2, 9, 10});
+  roundTrip<int64_t>({-100, -100, -7, -1, 0, 1, 1000000});
+  roundTrip<int16_t>({-10, -5, -5, 0, 2, 4});
+  roundTrip<int8_t>({-8, -2, -2, 0, 5, 9});
+}
+
+TEST_F(DeltaBlockEncodingTest, resetSkipAndMaterialize) {
+  const std::vector<uint32_t> input{0, 1, 2, 10, 11, 12, 100, 101, 102};
+  auto encoding = createEncoding(input);
+
+  encoding->skip(4);
+  std::vector<uint32_t> output(3);
+  encoding->materialize(static_cast<uint32_t>(output.size()), output.data());
+  EXPECT_EQ(output, (std::vector<uint32_t>{11, 12, 100}));
+
+  encoding->reset();
+  output.resize(input.size());
+  encoding->materialize(static_cast<uint32_t>(output.size()), output.data());
+  EXPECT_EQ(output, input);
+}
+
+TEST_F(DeltaBlockEncodingTest, readWithVisitorDenseAndSparseAcrossBlocks) {
+  std::vector<int64_t> input;
+  input.reserve(257);
+  int64_t value{-1000};
+  for (uint32_t i = 0; i < 257; ++i) {
+    value += i % 11;
+    input.push_back(value);
+  }
+
+  auto encoding = createEncoding<int64_t>(input, {.deltaBlockSize = 32});
+
+  struct TestCase {
+    std::string name;
+    std::vector<velox::vector_size_t> rows;
+  };
+
+  const std::vector<TestCase> testCases{
+      {.name = "dense", .rows = {0, 1, 2, 3, 4, 5, 6, 7}},
+      {.name = "sparse across blocks", .rows = {0, 31, 32, 33, 127, 256}},
+  };
+
+  for (const auto& testCase : testCases) {
+    SCOPED_TRACE(testCase.name);
+    encoding->reset();
+    IntegralReadWithVisitor<int64_t> visitor{testCase.rows};
+    nimble::ReadWithVisitorParams params;
+    params.numScanned = 0;
+
+    dynamic_cast<nimble::DeltaBlockEncoding<int64_t>&>(*encoding)
+        .readWithVisitor(visitor, params);
+
+    ASSERT_EQ(visitor.values().size(), testCase.rows.size());
+    for (size_t i = 0; i < testCase.rows.size(); ++i) {
+      EXPECT_EQ(visitor.values()[i], input[testCase.rows[i]]);
+    }
+  }
+}
+
+TEST_F(DeltaBlockEncodingTest, randomizedRoundTrip) {
+  struct TestCase {
+    uint32_t seed;
+    uint32_t rowCount;
+    uint16_t blockSize;
+    int64_t start;
+    int64_t maxStep;
+  };
+
+  const std::vector<TestCase> testCases{
+      {.seed = 1, .rowCount = 1, .blockSize = 1, .start = -100, .maxStep = 0},
+      {.seed = 2, .rowCount = 37, .blockSize = 3, .start = -1000, .maxStep = 5},
+      {.seed = 3, .rowCount = 257, .blockSize = 64, .start = 0, .maxStep = 19},
+      {.seed = 4,
+       .rowCount = 1025,
+       .blockSize = 256,
+       .start = 1'000'000,
+       .maxStep = 1024},
+      {.seed = 5,
+       .rowCount = 4097,
+       .blockSize = 1024,
+       .start = std::numeric_limits<int32_t>::max(),
+       .maxStep = 4096},
+  };
+
+  for (const auto& testCase : testCases) {
+    SCOPED_TRACE(
+        fmt::format(
+            "seed={}, rowCount={}, blockSize={}",
+            testCase.seed,
+            testCase.rowCount,
+            testCase.blockSize));
+    std::mt19937 rng{testCase.seed};
+    std::uniform_int_distribution<int64_t> stepDist{0, testCase.maxStep};
+
+    std::vector<int64_t> input;
+    input.reserve(testCase.rowCount);
+    int64_t value{testCase.start};
+    for (uint32_t i = 0; i < testCase.rowCount; ++i) {
+      value += stepDist(rng);
+      input.push_back(value);
+    }
+
+    auto encoding =
+        createEncoding<int64_t>(input, {.deltaBlockSize = testCase.blockSize});
+    std::vector<int64_t> output(input.size());
+    uint32_t offset{0};
+    while (offset < input.size()) {
+      const auto batchSize =
+          std::min<uint32_t>(1 + (rng() % 97), input.size() - offset);
+      encoding->materialize(batchSize, output.data() + offset);
+      offset += batchSize;
+    }
+    EXPECT_EQ(output, input);
+  }
+}
+
+TEST_F(DeltaBlockEncodingTest, estimateRejectsUnsortedValues) {
+  const std::vector<uint32_t> input{1, 5, 4, 8};
+  const auto values = toVector(input);
+  const auto physicalValues = std::span<const uint32_t>{
+      reinterpret_cast<const uint32_t*>(values.data()), values.size()};
+
+  EXPECT_EQ(
+      nimble::DeltaBlockEncoding<uint32_t>::estimateSize(
+          physicalValues, {.deltaBlockSize = 3}),
+      std::nullopt);
+}
+
+TEST_F(DeltaBlockEncodingTest, estimateUsesVarintPrefixSize) {
+  const std::vector<uint32_t> input{1, 2, 5, 9, 10};
+  const auto values = toVector(input);
+  const auto physicalValues = std::span<const uint32_t>{
+      reinterpret_cast<const uint32_t*>(values.data()), values.size()};
+
+  const auto fixedPrefixSize =
+      nimble::DeltaBlockEncoding<uint32_t>::estimateSize(
+          physicalValues, {.useVarintRowCount = false, .deltaBlockSize = 3});
+  const auto varintPrefixSize =
+      nimble::DeltaBlockEncoding<uint32_t>::estimateSize(
+          physicalValues, {.useVarintRowCount = true, .deltaBlockSize = 3});
+
+  ASSERT_TRUE(fixedPrefixSize.has_value());
+  ASSERT_TRUE(varintPrefixSize.has_value());
+  EXPECT_EQ(fixedPrefixSize.value(), varintPrefixSize.value());
+}
+
+TEST_F(DeltaBlockEncodingTest, encodeRejectsUnsortedValues) {
+  const std::vector<int32_t> input{-1, -2};
+  EXPECT_THROW(createEncoding(input), nimble::NimbleException);
+}

--- a/dwio/nimble/encodings/tests/DeltaBlockEncodingViewTest.cpp
+++ b/dwio/nimble/encodings/tests/DeltaBlockEncodingViewTest.cpp
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "dwio/nimble/encodings/tests/EncodingViewTestUtils.h"
+
+#include <cstdint>
+
+#include <gtest/gtest.h>
+
+#include "dwio/nimble/encodings/DeltaBlockEncoding.h"
+
+using namespace facebook;
+
+using DeltaBlockEncodingViewTest = nimble::test::EncodingViewTest;
+using EncodingViewTest = nimble::test::EncodingViewTest;
+
+TEST_F(EncodingViewTest, readsDeltaBlockEncoding) {
+  nimble::Encoding::Options options;
+  options.deltaBlockSize = 4;
+
+  expectReads<nimble::DeltaBlockEncoding<int32_t>>(
+      makeVector<int32_t>({-10, -9, -9, -1, 0, 2, 2, 17, 18, 40, 41}),
+      {10, 0, 3, 4, 7, 8},
+      options);
+  expectReads<nimble::DeltaBlockEncoding<uint64_t>>(
+      makeVector<uint64_t>({0, 0, 1, 5, 9, 9, 100, 150, 151, 1000}),
+      {9, 0, 1, 4, 6, 8},
+      options);
+}
+
+TEST_F(DeltaBlockEncodingViewTest, concurrent) {
+  nimble::Encoding::Options options;
+  options.deltaBlockSize = 64;
+
+  nimble::Vector<uint64_t> values{pool_.get()};
+  values.reserve(kConcurrentRows);
+  uint64_t value{1000};
+  for (uint32_t i = 0; i < kConcurrentRows; ++i) {
+    value += 1 + (i % 7);
+    values.push_back(value);
+  }
+
+  expectConcurrentReads<nimble::DeltaBlockEncoding<uint64_t>>(
+      values, randomizedPositions(/*seed=*/41), options);
+}

--- a/dwio/nimble/encodings/tests/TestUtils.h
+++ b/dwio/nimble/encodings/tests/TestUtils.h
@@ -18,6 +18,7 @@
 #include "dwio/nimble/encodings/ALPEncoding.h"
 #include "dwio/nimble/encodings/BlockBitPackingEncoding.h"
 #include "dwio/nimble/encodings/ConstantEncoding.h"
+#include "dwio/nimble/encodings/DeltaBlockEncoding.h"
 #include "dwio/nimble/encodings/DeltaEncoding.h"
 #include "dwio/nimble/encodings/DictionaryEncoding.h"
 #include "dwio/nimble/encodings/FixedBitWidthEncoding.h"
@@ -66,6 +67,12 @@ template <typename T>
 struct EncodingTypeTraits<nimble::DeltaEncoding<T>> {
   static constexpr inline nimble::EncodingType encodingType =
       nimble::EncodingType::Delta;
+};
+
+template <typename T>
+struct EncodingTypeTraits<nimble::DeltaBlockEncoding<T>> {
+  static constexpr inline nimble::EncodingType encodingType =
+      nimble::EncodingType::DeltaBlock;
 };
 
 template <typename T>

--- a/dwio/nimble/encodings/views/DeltaBlockEncodingView.h
+++ b/dwio/nimble/encodings/views/DeltaBlockEncodingView.h
@@ -1,0 +1,175 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <algorithm>
+#include <cstdint>
+#include <cstring>
+#include <optional>
+#include <type_traits>
+
+#include "dwio/nimble/common/FixedBitArray.h"
+#include "dwio/nimble/common/Varint.h"
+#include "dwio/nimble/common/Vector.h"
+#include "dwio/nimble/encodings/DeltaBlockEncoding.h"
+#include "dwio/nimble/encodings/common/EncodingPrimitives.h"
+#include "dwio/nimble/encodings/views/EncodingView.h"
+#include "velox/common/base/BitUtil.h"
+
+namespace facebook::nimble {
+
+template <typename T>
+class DeltaBlockEncodingView final : public TypedEncodingView<T> {
+ public:
+  using physicalType = typename TypedEncodingView<T>::physicalType;
+
+  DeltaBlockEncodingView(
+      std::string_view data,
+      velox::memory::MemoryPool* pool,
+      const Encoding::Options& options)
+      : TypedEncodingView<
+            T>{data, pool, DeltaBlockEncoding<T>::prefixOptions(options)},
+        blockBases_{this->template getVectorBuffer<physicalType>()},
+        bitWidths_{this->template getVectorBuffer<uint8_t>()},
+        blockOffsets_{this->template getVectorBuffer<uint32_t>()} {
+    static_assert(
+        std::is_integral_v<T> && !std::is_same_v<T, bool>,
+        "DeltaBlockEncodingView only supports non-bool integral types.");
+
+    NIMBLE_CHECK_EQ(this->encodingType_, EncodingType::DeltaBlock);
+    const char* pos = data.data() + this->dataOffset_;
+    blockSize_ = static_cast<uint16_t>(varint::readVarint32(&pos));
+    numBlocks_ = varint::readVarint32(&pos);
+    NIMBLE_CHECK_GT(blockSize_, 0);
+    NIMBLE_CHECK_EQ(
+        numBlocks_, velox::bits::divRoundUp(this->rowCount_, blockSize_));
+
+    blockBases_.resize(numBlocks_);
+    for (uint32_t i = 0; i < numBlocks_; ++i) {
+      blockBases_[i] =
+          DeltaBlockEncoding<T>::fromOrdered(varint::readVarint64(&pos));
+    }
+
+    bitWidths_.resize(numBlocks_);
+    std::memcpy(bitWidths_.data(), pos, numBlocks_ * sizeof(uint8_t));
+    pos += numBlocks_ * sizeof(uint8_t);
+
+    blockOffsets_.resize(numBlocks_);
+    for (uint32_t i = 0; i < numBlocks_; ++i) {
+      blockOffsets_[i] = varint::readVarint32(&pos);
+    }
+    packedData_ = pos;
+  }
+
+  ~DeltaBlockEncodingView() override {
+    this->releaseVectorBuffer(blockOffsets_);
+    this->releaseVectorBuffer(bitWidths_);
+    this->releaseVectorBuffer(blockBases_);
+  }
+
+ private:
+  struct ReadCache {
+    const DeltaBlockEncodingView<T>* owner{nullptr};
+    const char* packedData{nullptr};
+    uint32_t rowCount{0};
+    uint16_t blockSize{0};
+    std::optional<uint32_t> blockIndex;
+    uint32_t position{0};
+    uint8_t bitWidth{0};
+    uint64_t ordered{0};
+    FixedBitArray deltas{};
+  };
+
+  uint32_t blockRowCount(uint32_t blockIndex) const {
+    return DeltaBlockEncoding<T>::blockRowCount(
+        this->rowCount_, blockSize_, blockIndex);
+  }
+
+  void resetCacheIfNeeded(ReadCache& cache) const {
+    if (cache.owner == this && cache.packedData == packedData_ &&
+        cache.rowCount == this->rowCount_ && cache.blockSize == blockSize_) {
+      return;
+    }
+
+    cache = ReadCache{};
+    cache.owner = this;
+    cache.packedData = packedData_;
+    cache.rowCount = this->rowCount_;
+    cache.blockSize = blockSize_;
+  }
+
+  void seekCache(ReadCache& cache, uint32_t blockIndex, uint32_t position)
+      const {
+    cache.blockIndex = blockIndex;
+    cache.position = 0;
+    cache.bitWidth = bitWidths_[blockIndex];
+    cache.ordered = DeltaBlockEncoding<T>::toOrdered(blockBases_[blockIndex]);
+    if (cache.bitWidth != 0) {
+      cache.deltas = FixedBitArray{
+          {packedData_ + blockOffsets_[blockIndex],
+           FixedBitArray::bufferSize(
+               blockRowCount(blockIndex) - 1, cache.bitWidth)},
+          cache.bitWidth};
+      for (uint32_t i = 0; i < position; ++i) {
+        cache.ordered += cache.deltas.get(i);
+      }
+    }
+    cache.position = position;
+  }
+
+  physicalType readWithCache(ReadCache& cache, uint32_t index) const {
+    const auto blockIndex = index / blockSize_;
+    const auto position = index % blockSize_;
+    if (!cache.blockIndex.has_value() ||
+        cache.blockIndex.value() != blockIndex || position < cache.position) {
+      seekCache(cache, blockIndex, position);
+    } else if (position > cache.position) {
+      if (cache.bitWidth != 0) {
+        for (uint32_t i = cache.position; i < position; ++i) {
+          cache.ordered += cache.deltas.get(i);
+        }
+      }
+      cache.position = position;
+    }
+    return DeltaBlockEncoding<T>::fromOrdered(cache.ordered);
+  }
+
+  T readTypedAt(uint32_t index) const final {
+    NIMBLE_CHECK_LT(index, this->rowCount_);
+    static thread_local ReadCache cache;
+    resetCacheIfNeeded(cache);
+    return readWithCache(cache, index);
+  }
+
+  void readPhysical(uint32_t offset, uint32_t length, physicalType* output)
+      const final {
+    this->checkReadRange(offset, length);
+    ReadCache cache;
+    resetCacheIfNeeded(cache);
+    for (uint32_t i = 0; i < length; ++i) {
+      output[i] = readWithCache(cache, offset + i);
+    }
+  }
+
+  uint16_t blockSize_{0};
+  uint32_t numBlocks_{0};
+  Vector<physicalType> blockBases_;
+  Vector<uint8_t> bitWidths_;
+  Vector<uint32_t> blockOffsets_;
+  const char* packedData_{nullptr};
+};
+
+} // namespace facebook::nimble

--- a/dwio/nimble/encodings/views/EncodingViewFactory.cpp
+++ b/dwio/nimble/encodings/views/EncodingViewFactory.cpp
@@ -18,6 +18,7 @@
 #include "dwio/nimble/encodings/views/ALPEncodingView.h"
 #include "dwio/nimble/encodings/views/BlockBitPackingEncodingView.h"
 #include "dwio/nimble/encodings/views/ConstantEncodingView.h"
+#include "dwio/nimble/encodings/views/DeltaBlockEncodingView.h"
 #include "dwio/nimble/encodings/views/DictionaryEncodingView.h"
 #include "dwio/nimble/encodings/views/FOREncodingView.h"
 #include "dwio/nimble/encodings/views/FixedBitWidthEncodingView.h"
@@ -87,6 +88,13 @@ std::unique_ptr<TypedEncodingView<T>> createTypedEncodingView(
       }
       NIMBLE_INCOMPATIBLE_ENCODING(
           "FOR encoding should not be selected for non-integral data type: {}.",
+          TypeTraits<T>::dataType);
+    case EncodingType::DeltaBlock:
+      if constexpr (isIntegralType<T>()) {
+        return std::make_unique<DeltaBlockEncodingView<T>>(data, pool, options);
+      }
+      NIMBLE_INCOMPATIBLE_ENCODING(
+          "DeltaBlock encoding only supports integral data types, got {}.",
           TypeTraits<T>::dataType);
     case EncodingType::Huffman:
       if constexpr (

--- a/dwio/nimble/fuzzer/encoding/EncodingFuzzer.h
+++ b/dwio/nimble/fuzzer/encoding/EncodingFuzzer.h
@@ -78,6 +78,38 @@ Vector<T> makeSingleValueData(
 }
 
 template <typename T, typename RNG>
+Vector<T> makeDeltaBlockSortedData(
+    velox::memory::MemoryPool& pool,
+    RNG& rng,
+    uint32_t rowCount,
+    [[maybe_unused]] Buffer* buffer) {
+  Vector<T> data(&pool);
+  data.reserve(rowCount);
+  if constexpr (std::is_integral_v<T> && !std::is_same_v<T, bool>) {
+    if constexpr (std::is_signed_v<T>) {
+      int64_t current{0};
+      constexpr int64_t kMaxValue{
+          static_cast<int64_t>(std::numeric_limits<T>::max())};
+      for (uint32_t i = 0; i < rowCount; ++i) {
+        data.push_back(static_cast<T>(current));
+        const auto step = static_cast<int64_t>(folly::Random::rand32(rng) % 4);
+        current = std::min<int64_t>(current + step, kMaxValue);
+      }
+    } else {
+      uint64_t current{0};
+      constexpr uint64_t kMaxValue{
+          static_cast<uint64_t>(std::numeric_limits<T>::max())};
+      for (uint32_t i = 0; i < rowCount; ++i) {
+        data.push_back(static_cast<T>(current));
+        const auto step = static_cast<uint64_t>(folly::Random::rand32(rng) % 4);
+        current = kMaxValue - current < step ? kMaxValue : current + step;
+      }
+    }
+  }
+  return data;
+}
+
+template <typename T, typename RNG>
 Vector<T> makeBoundaryMixedData(
     velox::memory::MemoryPool& pool,
     RNG& rng,
@@ -315,6 +347,19 @@ class EncodingFuzzer {
   std::vector<Vector<T>> generateDatasets(std::mt19937& rng) {
     std::vector<Vector<T>> datasets;
     uint32_t rowCount = 1 + folly::Random::rand32(rng) % maxRows_;
+
+    if constexpr (
+        Encoder<EncodingClass>::encodingType() == EncodingType::DeltaBlock) {
+      datasets.push_back(
+          makeDeltaBlockSortedData<T>(*pool_, rng, rowCount, buffer_.get()));
+      datasets.push_back(
+          makeSingleValueData<T>(*pool_, rng, rowCount, buffer_.get()));
+      for (uint32_t sz : {1u, 2u, 3u}) {
+        datasets.push_back(
+            makeDeltaBlockSortedData<T>(*pool_, rng, sz, buffer_.get()));
+      }
+      return datasets;
+    }
 
     // Random data.
     {

--- a/dwio/nimble/fuzzer/encoding/EncodingFuzzerTest.cpp
+++ b/dwio/nimble/fuzzer/encoding/EncodingFuzzerTest.cpp
@@ -30,6 +30,7 @@
 #include "dwio/nimble/encodings/ALPEncoding.h"
 #include "dwio/nimble/encodings/BlockBitPackingEncoding.h"
 #include "dwio/nimble/encodings/ConstantEncoding.h"
+#include "dwio/nimble/encodings/DeltaBlockEncoding.h"
 #include "dwio/nimble/encodings/DeltaEncoding.h"
 #include "dwio/nimble/encodings/DictionaryEncoding.h"
 #include "dwio/nimble/encodings/FixedBitWidthEncoding.h"
@@ -180,6 +181,30 @@ class DeltaFuzzerTest : public ::testing::Test {};
 TYPED_TEST_SUITE(DeltaFuzzerTest, DeltaTypes);
 
 TYPED_TEST(DeltaFuzzerTest, correctness) {
+  EncodingFuzzer<TypeParam> fuzzer(
+      FLAGS_fuzzer_iterations,
+      FLAGS_fuzzer_max_rows,
+      FLAGS_fuzzer_seed,
+      FLAGS_fuzzer_compression);
+  fuzzer.run();
+}
+
+// DeltaBlock: integer types
+using DeltaBlockTypes = ::testing::Types<
+    DeltaBlockEncoding<int8_t>,
+    DeltaBlockEncoding<uint8_t>,
+    DeltaBlockEncoding<int16_t>,
+    DeltaBlockEncoding<uint16_t>,
+    DeltaBlockEncoding<int32_t>,
+    DeltaBlockEncoding<uint32_t>,
+    DeltaBlockEncoding<int64_t>,
+    DeltaBlockEncoding<uint64_t>>;
+
+template <typename E>
+class DeltaBlockFuzzerTest : public ::testing::Test {};
+TYPED_TEST_SUITE(DeltaBlockFuzzerTest, DeltaBlockTypes);
+
+TYPED_TEST(DeltaBlockFuzzerTest, correctness) {
   EncodingFuzzer<TypeParam> fuzzer(
       FLAGS_fuzzer_iterations,
       FLAGS_fuzzer_max_rows,

--- a/dwio/nimble/fuzzer/encoding/EncodingViewFuzzerTest.cpp
+++ b/dwio/nimble/fuzzer/encoding/EncodingViewFuzzerTest.cpp
@@ -26,6 +26,7 @@
 #include "dwio/nimble/encodings/ALPEncoding.h"
 #include "dwio/nimble/encodings/BlockBitPackingEncoding.h"
 #include "dwio/nimble/encodings/ConstantEncoding.h"
+#include "dwio/nimble/encodings/DeltaBlockEncoding.h"
 #include "dwio/nimble/encodings/DictionaryEncoding.h"
 #include "dwio/nimble/encodings/FixedBitWidthEncoding.h"
 #include "dwio/nimble/encodings/HuffmanEncoding.h"
@@ -133,6 +134,16 @@ std::vector<Vector<typename EncodingClass::cppDataType>> makeDatasets(
   if constexpr (
       Encoder<EncodingClass>::encodingType() == EncodingType::Constant) {
     return makeConstantViewDatasets<T>(pool, rng, rowCount, buffer);
+  } else if constexpr (
+      Encoder<EncodingClass>::encodingType() == EncodingType::DeltaBlock) {
+    std::vector<Vector<T>> datasets;
+    datasets.push_back(
+        makeDeltaBlockSortedData<T>(pool, rng, rowCount, buffer));
+    datasets.push_back(makeSingleValueData<T>(pool, rng, rowCount, buffer));
+    for (uint32_t size : {1u, 2u, 3u}) {
+      datasets.push_back(makeDeltaBlockSortedData<T>(pool, rng, size, buffer));
+    }
+    return datasets;
   } else {
     return makeViewDatasets<T>(pool, rng, rowCount, buffer);
   }
@@ -363,6 +374,27 @@ class PforEncodingViewFuzzerTest : public ::testing::Test {};
 TYPED_TEST_SUITE(PforEncodingViewFuzzerTest, PforViewTypes);
 
 TYPED_TEST(PforEncodingViewFuzzerTest, readAtMatchesMaterialize) {
+  runEncodingViewFuzzer<TypeParam>(
+      FLAGS_view_fuzzer_iterations,
+      FLAGS_view_fuzzer_max_rows,
+      FLAGS_view_fuzzer_seed);
+}
+
+using DeltaBlockViewTypes = ::testing::Types<
+    DeltaBlockEncoding<int8_t>,
+    DeltaBlockEncoding<uint8_t>,
+    DeltaBlockEncoding<int16_t>,
+    DeltaBlockEncoding<uint16_t>,
+    DeltaBlockEncoding<int32_t>,
+    DeltaBlockEncoding<uint32_t>,
+    DeltaBlockEncoding<int64_t>,
+    DeltaBlockEncoding<uint64_t>>;
+
+template <typename E>
+class DeltaBlockEncodingViewFuzzerTest : public ::testing::Test {};
+TYPED_TEST_SUITE(DeltaBlockEncodingViewFuzzerTest, DeltaBlockViewTypes);
+
+TYPED_TEST(DeltaBlockEncodingViewFuzzerTest, readAtMatchesMaterialize) {
   runEncodingViewFuzzer<TypeParam>(
       FLAGS_view_fuzzer_iterations,
       FLAGS_view_fuzzer_max_rows,

--- a/dwio/nimble/tools/EncodingUtilities.cpp
+++ b/dwio/nimble/tools/EncodingUtilities.cpp
@@ -50,6 +50,7 @@ void extractCompressionType(
     case EncodingType::SparseBool:
     case EncodingType::Varint:
     case EncodingType::Delta:
+    case EncodingType::DeltaBlock:
     case EncodingType::Constant:
     case EncodingType::MainlyConstant:
     case EncodingType::Prefix:
@@ -116,6 +117,7 @@ void traverseEncodings(
     case EncodingType::Varint:
     case EncodingType::Constant:
     case EncodingType::Prefix:
+    case EncodingType::DeltaBlock:
     case EncodingType::SimdForBitpack:
     // SubIntSplit integration is disabled; treat it as having no nested
     // encoding to traverse.

--- a/dwio/nimble/velox/selective/tests/ScalarColumnReaderTest.cpp
+++ b/dwio/nimble/velox/selective/tests/ScalarColumnReaderTest.cpp
@@ -17,6 +17,7 @@
 #include "dwio/nimble/velox/selective/SelectiveNimbleReader.h"
 
 #include "dwio/nimble/common/tests/NimbleFileWriter.h"
+#include "dwio/nimble/encodings/selection/EncodingSelectionPolicy.h"
 #include "velox/common/base/tests/GTestUtils.h"
 #include "velox/common/io/IoStatistics.h"
 #include "velox/dwio/common/TypeUtils.h"
@@ -29,6 +30,17 @@ namespace facebook::nimble {
 namespace {
 
 using namespace facebook::velox;
+
+VeloxWriterOptions makeForcedEncodingWriterOptions(EncodingType encodingType) {
+  VeloxWriterOptions writerOptions;
+  writerOptions.encodingSelectionPolicyCreator =
+      [encodingType](DataType dataType) {
+        ManualEncodingSelectionPolicyFactory factory{
+            {{encodingType, 1.0}}, std::nullopt};
+        return factory.createPolicy(dataType);
+      };
+  return writerOptions;
+}
 
 // Tests for ByteColumnReader, IntegerColumnReader, and
 // FloatingPointColumnReader.
@@ -170,6 +182,36 @@ class ScalarColumnReaderTest : public ::testing::Test,
     ASSERT_EQ(0, rowReader.next(1, result));
   }
 
+  static int64_t deltaBlockFilterValue(int row) {
+    return int64_t{10} + row / 8;
+  }
+
+  template <typename T>
+  void testDeltaBlockWithFilter(bool stringDecoderZeroCopy) {
+    auto input = makeRowVector({
+        makeFlatVector<T>(
+            513,
+            [](auto row) {
+              return static_cast<T>(deltaBlockFilterValue(row));
+            }),
+    });
+
+    auto scanSpec = std::make_shared<common::ScanSpec>("root");
+    scanSpec->addAllChildFields(*input->type());
+    scanSpec->childByName("c0")->setFilter(
+        std::make_unique<common::BigintRange>(30, 60, false));
+
+    auto file = test::createNimbleFile(
+        *rootPool(),
+        input,
+        makeForcedEncodingWriterOptions(EncodingType::DeltaBlock));
+    auto readers = makeReaders(input, file, scanSpec, stringDecoderZeroCopy);
+    validateWithFilter(*input, *readers.rowReader, 29, [](auto row) {
+      const auto value = deltaBlockFilterValue(row);
+      return value >= 30 && value <= 60;
+    });
+  }
+
   const std::shared_ptr<io::IoStatistics> dataIoStats_{
       std::make_shared<io::IoStatistics>()};
   const std::shared_ptr<io::IoStatistics> metadataIoStats_{
@@ -271,6 +313,42 @@ TEST_P(ScalarColumnReaderTest, integerWithFilter) {
   validateWithFilter(*input, *readers.rowReader, 31, [](auto i) {
     return i * 7 >= 100 && i * 7 <= 500;
   });
+}
+
+TEST_P(ScalarColumnReaderTest, integerDeltaBlockWithFilter) {
+  const bool stringDecoderZeroCopy = GetParam();
+  {
+    SCOPED_TRACE("int8_t");
+    testDeltaBlockWithFilter<int8_t>(stringDecoderZeroCopy);
+  }
+  {
+    SCOPED_TRACE("uint8_t");
+    testDeltaBlockWithFilter<uint8_t>(stringDecoderZeroCopy);
+  }
+  {
+    SCOPED_TRACE("int16_t");
+    testDeltaBlockWithFilter<int16_t>(stringDecoderZeroCopy);
+  }
+  {
+    SCOPED_TRACE("uint16_t");
+    testDeltaBlockWithFilter<uint16_t>(stringDecoderZeroCopy);
+  }
+  {
+    SCOPED_TRACE("int32_t");
+    testDeltaBlockWithFilter<int32_t>(stringDecoderZeroCopy);
+  }
+  {
+    SCOPED_TRACE("uint32_t");
+    testDeltaBlockWithFilter<uint32_t>(stringDecoderZeroCopy);
+  }
+  {
+    SCOPED_TRACE("int64_t");
+    testDeltaBlockWithFilter<int64_t>(stringDecoderZeroCopy);
+  }
+  {
+    SCOPED_TRACE("uint64_t");
+    testDeltaBlockWithFilter<uint64_t>(stringDecoderZeroCopy);
+  }
 }
 
 TEST_P(ScalarColumnReaderTest, bigintWithNulls) {


### PR DESCRIPTION
Summary:

Adds `DeltaBlockEncoding`, a leaf integer encoding for non-decreasing streams.
The format stores per-block checkpoints and bit-packed deltas, and wires the
encoding into factory dispatch, layout traversal, encoding utilities, and size
selection when full stream values are available.

Reviewed By: HuamengJiang, sachin10101998

Differential Revision: D113142087


