### PR TITLE
test(encoding): Comprehensive test coverage for SubIntSplit (#1006)

### DIFF
--- a/dwio/nimble/encodings/tests/TestUtils.h
+++ b/dwio/nimble/encodings/tests/TestUtils.h
@@ -15,6 +15,9 @@
  */
 #pragma once
 
+#include <algorithm>
+#include <optional>
+
 #include "dwio/nimble/encodings/ALPEncoding.h"
 #include "dwio/nimble/encodings/BlockBitPackingEncoding.h"
 #include "dwio/nimble/encodings/ConstantEncoding.h"
@@ -207,8 +210,11 @@ class Encoder {
     using physicalType = typename nimble::TypeTraits<TInner>::physicalType;
 
    public:
-    explicit TestTrivialEncodingSelectionPolicy(CompressionType compressionType)
-        : compressionType_{compressionType} {}
+    explicit TestTrivialEncodingSelectionPolicy(
+        CompressionType compressionType,
+        bool realNestedSelection = false)
+        : compressionType_{compressionType},
+          realNestedSelection_{realNestedSelection} {}
 
     nimble::EncodingSelectionResult select(
         std::span<const physicalType> /* values */,
@@ -235,12 +241,36 @@ class Encoder {
         nimble::EncodingType /* encodingType */,
         nimble::NestedEncodingIdentifier /* identifier */,
         nimble::DataType type) override {
+      // When realNestedSelection_ is set, nested (sub-stream) encodings are
+      // chosen by the normal cost-based factory instead of being forced to
+      // Trivial -- e.g. so SubIntSplit exercises its diverse per-section
+      // encoders. SubIntSplit is removed from the candidates to avoid infinite
+      // recursion (it is also not registered in EncodingFactory dispatch).
+      if (realNestedSelection_) {
+        auto readFactors = nimble::ManualEncodingSelectionPolicyFactory::
+            defaultEncodingReadFactors();
+        readFactors.erase(
+            std::remove_if(
+                readFactors.begin(),
+                readFactors.end(),
+                [](const auto& factor) {
+                  return factor.first == nimble::EncodingType::SubIntSplit;
+                }),
+            readFactors.end());
+        return nimble::ManualEncodingSelectionPolicyFactory{
+            std::move(readFactors), std::nullopt}
+            .createPolicy(type);
+      }
       UNIQUE_PTR_FACTORY(
-          type, TestTrivialEncodingSelectionPolicy, compressionType_);
+          type,
+          TestTrivialEncodingSelectionPolicy,
+          compressionType_,
+          realNestedSelection_);
     }
 
    private:
     CompressionType compressionType_;
+    bool realNestedSelection_;
   };
 
  public:
@@ -252,7 +282,8 @@ class Encoder {
       nimble::Buffer& buffer,
       const nimble::Vector<T>& values,
       CompressionType compressionType = CompressionType::Uncompressed,
-      const nimble::Encoding::Options& options = {}) {
+      const nimble::Encoding::Options& options = {},
+      bool realNestedSelection = false) {
     using physicalType = typename nimble::TypeTraits<T>::physicalType;
 
     auto physicalValues = std::span<const physicalType>(
@@ -265,7 +296,7 @@ class Encoder {
              }},
         nimble::Statistics<physicalType>::create(physicalValues),
         std::make_unique<TestTrivialEncodingSelectionPolicy<T>>(
-            compressionType)};
+            compressionType, realNestedSelection)};
 
     return E::encode(selection, physicalValues, buffer, options);
   }

--- a/dwio/nimble/fuzzer/encoding/EncodingFuzzer.h
+++ b/dwio/nimble/fuzzer/encoding/EncodingFuzzer.h
@@ -15,6 +15,7 @@
  */
 #pragma once
 
+#include <algorithm>
 #include <bit>
 #include <cmath>
 #include <iterator>
@@ -255,6 +256,192 @@ Vector<T> makeFloatingPointMixedExceptionData(
   return data;
 }
 
+// A sorted (non-decreasing by bit pattern) run built by accumulating small
+// random steps, including 0 so values repeat and can wrap. Complements
+// makeMonotonicData (strictly increasing) and, for float/double, sorts on the
+// physical bit pattern so the roundtrip stays bit-exact.
+template <typename T, typename RNG>
+Vector<T> makeSortedData(
+    velox::memory::MemoryPool& pool,
+    RNG& rng,
+    uint32_t rowCount,
+    [[maybe_unused]] Buffer* buffer) {
+  Vector<T> data(&pool);
+  data.reserve(rowCount);
+  if constexpr (std::is_arithmetic_v<T> && !std::is_same_v<T, bool>) {
+    using UintType = std::conditional_t<
+        sizeof(T) == 1,
+        uint8_t,
+        std::conditional_t<
+            sizeof(T) == 2,
+            uint16_t,
+            std::conditional_t<sizeof(T) == 4, uint32_t, uint64_t>>>;
+    UintType accumulator = 0;
+    for (uint32_t i = 0; i < rowCount; ++i) {
+      accumulator = static_cast<UintType>(
+          accumulator + (folly::Random::rand32(rng) % 256));
+      data.push_back(std::bit_cast<T>(accumulator));
+    }
+  }
+  return data;
+}
+
+// A handful of distinct values repeated throughout, exercising low-cardinality
+// encoders (Dictionary/RLE). Works for every type.
+template <typename T, typename RNG>
+Vector<T> makeLowCardinalityData(
+    velox::memory::MemoryPool& pool,
+    RNG& rng,
+    uint32_t rowCount,
+    Buffer* buffer) {
+  Vector<T> data(&pool);
+  data.reserve(rowCount);
+  constexpr uint32_t kPoolSize = 4;
+  Vector<T> valuePool(&pool);
+  valuePool.reserve(kPoolSize);
+  nimble::testing::addRandomData<T>(rng, kPoolSize, &valuePool, buffer);
+  for (uint32_t i = 0; i < rowCount; ++i) {
+    data.push_back(valuePool[folly::Random::rand32(rng) % kPoolSize]);
+  }
+  return data;
+}
+
+// One dominant value (~90%) with a high-cardinality random exception tail
+// (~10%). Unlike makeMainlyConstantData (which uses a single other value), the
+// exceptions here are all distinct, stressing MainlyConstant's exception path.
+template <typename T, typename RNG>
+Vector<T> makeDominantValueData(
+    velox::memory::MemoryPool& pool,
+    RNG& rng,
+    uint32_t rowCount,
+    Buffer* buffer) {
+  Vector<T> data(&pool);
+  data.reserve(rowCount);
+  Vector<T> dominant(&pool);
+  dominant.reserve(1);
+  nimble::testing::addRandomData<T>(rng, 1, &dominant, buffer);
+  Vector<T> exceptions(&pool);
+  exceptions.reserve(rowCount);
+  nimble::testing::addRandomData<T>(rng, rowCount, &exceptions, buffer);
+  for (uint32_t i = 0; i < rowCount; ++i) {
+    data.push_back(
+        folly::Random::rand32(rng) % 10 == 0 ? exceptions[i] : dominant[0]);
+  }
+  return data;
+}
+
+// Realistic composite (snowflake) IDs, LSB-first [sequence | worker |
+// timestamp] with the top bit left 0: a near-constant high timestamp prefix, a
+// few worker ids in the middle bits, and a cyclic low sequence counter. This is
+// SubIntSplitEncoding's flagship target -- distinct structure in disjoint bit
+// ranges -- but also stresses other encoders on composite integer data. Only
+// meaningful for 32-/64-bit numeric types.
+template <typename T, typename RNG>
+Vector<T> makeSnowflakeData(
+    velox::memory::MemoryPool& pool,
+    RNG& rng,
+    uint32_t rowCount,
+    [[maybe_unused]] Buffer* buffer) {
+  Vector<T> data(&pool);
+  data.reserve(rowCount);
+  if constexpr (
+      std::is_arithmetic_v<T> && !std::is_same_v<T, bool> && sizeof(T) >= 4) {
+    using UintType = std::conditional_t<sizeof(T) == 4, uint32_t, uint64_t>;
+    // 32-bit uses a scaled analog (6/5/20) of the classic 64-bit snowflake
+    // (12/10/41) so both widths get a valid composite id.
+    constexpr int kSequenceBits = sizeof(T) == 4 ? 6 : 12;
+    constexpr int kWorkerBits = sizeof(T) == 4 ? 5 : 10;
+    constexpr int kTimestampBits = sizeof(T) == 4 ? 20 : 41;
+    const UintType sequenceMask =
+        static_cast<UintType>((UintType{1} << kSequenceBits) - 1);
+    const UintType workerMask =
+        static_cast<UintType>((UintType{1} << kWorkerBits) - 1);
+    const UintType timestampMask =
+        static_cast<UintType>((UintType{1} << kTimestampBits) - 1);
+    const int workerShift = kSequenceBits;
+    const int timestampShift = kSequenceBits + kWorkerBits;
+
+    UintType workers[4];
+    for (auto& worker : workers) {
+      worker = static_cast<UintType>(folly::Random::rand64(rng)) & workerMask;
+    }
+    UintType timestamp =
+        static_cast<UintType>(folly::Random::rand64(rng)) & timestampMask;
+    UintType sequence = 0;
+    for (uint32_t i = 0; i < rowCount; ++i) {
+      const UintType worker = workers[folly::Random::rand32(rng) % 4];
+      const UintType bits = static_cast<UintType>(
+          (static_cast<UintType>(timestamp & timestampMask) << timestampShift) |
+          (static_cast<UintType>(worker) << workerShift) |
+          static_cast<UintType>(sequence & sequenceMask));
+      data.push_back(std::bit_cast<T>(bits));
+
+      if (sequence == sequenceMask) {
+        sequence = 0;
+        timestamp = static_cast<UintType>((timestamp + 1) & timestampMask);
+      } else {
+        ++sequence;
+      }
+      // Occasionally jump the timestamp forward (an idle gap) to vary the
+      // high-bit run lengths.
+      if (folly::Random::rand32(rng) % 16 == 0) {
+        timestamp = static_cast<UintType>(
+            (timestamp + (folly::Random::rand32(rng) % 16) + 1) &
+            timestampMask);
+        sequence = 0;
+      }
+    }
+  }
+  return data;
+}
+
+// A stream stitched from contiguous runs of several base patterns, so its
+// statistics shift across the row range (regime shifts). Stresses samplers and
+// selectors on non-homogeneous data. Uses only the all-type generators so it
+// stays valid for every T.
+template <typename T, typename RNG>
+Vector<T> makeMixedRegimeData(
+    velox::memory::MemoryPool& pool,
+    RNG& rng,
+    uint32_t rowCount,
+    Buffer* buffer) {
+  Vector<T> data(&pool);
+  data.reserve(rowCount);
+  const uint32_t segmentCount =
+      std::min<uint32_t>(2 + folly::Random::rand32(rng) % 4, rowCount);
+  uint32_t remaining = rowCount;
+  for (uint32_t segment = 0; segment < segmentCount; ++segment) {
+    const uint32_t segmentsLeft = segmentCount - segment;
+    const uint32_t segmentLength = (segmentsLeft == 1)
+        ? remaining
+        : std::max<uint32_t>(1, remaining / segmentsLeft);
+    Vector<T> run(&pool);
+    switch (folly::Random::rand32(rng) % 5) {
+      case 0:
+        run = makeSingleValueData<T>(pool, rng, segmentLength, buffer);
+        break;
+      case 1:
+        run = makeLowCardinalityData<T>(pool, rng, segmentLength, buffer);
+        break;
+      case 2:
+        run = makeMainlyConstantData<T>(pool, rng, segmentLength, buffer);
+        break;
+      case 3:
+        run = makeDominantValueData<T>(pool, rng, segmentLength, buffer);
+        break;
+      default:
+        run.reserve(segmentLength);
+        nimble::testing::addRandomData<T>(rng, segmentLength, &run, buffer);
+        break;
+    }
+    for (const auto& value : run) {
+      data.push_back(value);
+    }
+    remaining -= segmentLength;
+  }
+  return data;
+}
+
 // ============================================================================
 // Fuzzer operations
 // ============================================================================
@@ -286,14 +473,18 @@ class EncodingFuzzer {
       bool testCompression,
       const Encoding::Options& options = {},
       uint32_t minDistinctValues = 1,
-      uint32_t maxDistinctValues = std::numeric_limits<uint32_t>::max())
+      uint32_t maxDistinctValues = std::numeric_limits<uint32_t>::max(),
+      uint32_t largeInputRows = 0,
+      bool realNestedSelection = false)
       : iterations_{iterations},
         maxRows_{maxRows},
         seed_{seed},
         testCompression_{testCompression},
         options_{options},
         minDistinctValues_{minDistinctValues},
-        maxDistinctValues_{maxDistinctValues} {
+        maxDistinctValues_{maxDistinctValues},
+        largeInputRows_{largeInputRows},
+        realNestedSelection_{realNestedSelection} {
     pool_ = velox::memory::deprecatedAddDefaultLeafMemoryPool();
     buffer_ = std::make_unique<Buffer>(*pool_);
   }
@@ -326,9 +517,72 @@ class EncodingFuzzer {
         }
       }
     }
+
+    if (largeInputRows_ > 0) {
+      runLargeInput(rng);
+    }
   }
 
  private:
+  // Generic large-input coverage: encode a few big datasets (crossing the
+  // 4096-value decode-chunk boundary many times) and verify chunked, variable-
+  // block, and skip traversals. Enabled via the largeInputRows constructor arg.
+  void runLargeInput(std::mt19937& rng) {
+    std::vector<Vector<T>> datasets;
+    {
+      Vector<T> data(pool_.get());
+      data.reserve(largeInputRows_);
+      nimble::testing::addRandomData<T>(
+          rng, largeInputRows_, &data, buffer_.get());
+      datasets.push_back(std::move(data));
+    }
+    datasets.push_back(
+        makeMixedRegimeData<T>(*pool_, rng, largeInputRows_, buffer_.get()));
+    if constexpr (
+        std::is_arithmetic_v<T> && !std::is_same_v<T, bool> && sizeof(T) >= 4) {
+      datasets.push_back(
+          makeSnowflakeData<T>(*pool_, rng, largeInputRows_, buffer_.get()));
+    }
+
+    for (auto& data : datasets) {
+      if (data.empty()) {
+        continue;
+      }
+      Buffer encodeBuffer(*pool_);
+      std::vector<velox::BufferPtr> stringBuffers;
+      auto stringBufferFactory = [&](uint32_t totalLength) {
+        auto& buf = stringBuffers.emplace_back(
+            velox::AlignedBuffer::allocate<char>(totalLength, pool_.get()));
+        return buf->template asMutable<void>();
+      };
+      std::string_view encoded;
+      try {
+        encoded = Encoder<EncodingClass>::encode(
+            encodeBuffer,
+            data,
+            CompressionType::Uncompressed,
+            options_,
+            realNestedSelection_);
+      } catch (const NimbleUserError& e) {
+        if (e.errorCode() == error_code::IncompatibleEncoding) {
+          continue;
+        }
+        throw;
+      }
+
+      auto encoding =
+          std::make_unique<EncodingClass>(*pool_, encoded, stringBufferFactory);
+      EXPECT_EQ(encoding->rowCount(), data.size());
+
+      encoding->reset();
+      verifyMaterializeVariableBlocks(*encoding, data);
+      encoding->reset();
+      verifyMaterializeChunked(rng, *encoding, data);
+      encoding->reset();
+      verifySkipAndMaterialize(rng, *encoding, data);
+    }
+  }
+
   bool hasSupportedCardinality(const Vector<T>& data) const {
     if (minDistinctValues_ == 1 &&
         maxDistinctValues_ == std::numeric_limits<uint32_t>::max()) {
@@ -385,6 +639,12 @@ class EncodingFuzzer {
           makeMonotonicData<T>(*pool_, rng, rowCount, buffer_.get()));
     }
 
+    // Sorted-by-bit-pattern data (non-decreasing, with repeats and wrap).
+    if constexpr (std::is_arithmetic_v<T> && !std::is_same_v<T, bool>) {
+      datasets.push_back(
+          makeSortedData<T>(*pool_, rng, rowCount, buffer_.get()));
+    }
+
     // Mainly constant data (good for MainlyConstant encoding).
     datasets.push_back(
         makeMainlyConstantData<T>(*pool_, rng, rowCount, buffer_.get()));
@@ -393,6 +653,25 @@ class EncodingFuzzer {
     if constexpr (std::is_arithmetic_v<T> && !std::is_same_v<T, bool>) {
       datasets.push_back(
           makeBitStructuredData<T>(*pool_, rng, rowCount, buffer_.get()));
+    }
+
+    // Low-cardinality data (good for Dictionary/RLE).
+    datasets.push_back(
+        makeLowCardinalityData<T>(*pool_, rng, rowCount, buffer_.get()));
+
+    // Dominant value with a high-cardinality random exception tail.
+    datasets.push_back(
+        makeDominantValueData<T>(*pool_, rng, rowCount, buffer_.get()));
+
+    // Regime-shifting mixed stream (non-homogeneous statistics).
+    datasets.push_back(
+        makeMixedRegimeData<T>(*pool_, rng, rowCount, buffer_.get()));
+
+    // Composite (snowflake) IDs: distinct structure in disjoint bit ranges.
+    if constexpr (
+        std::is_arithmetic_v<T> && !std::is_same_v<T, bool> && sizeof(T) >= 4) {
+      datasets.push_back(
+          makeSnowflakeData<T>(*pool_, rng, rowCount, buffer_.get()));
     }
 
     if constexpr (std::is_floating_point_v<T>) {
@@ -434,7 +713,7 @@ class EncodingFuzzer {
     std::string_view encoded;
     try {
       encoded = Encoder<EncodingClass>::encode(
-          encodeBuffer, data, compressionType, options_);
+          encodeBuffer, data, compressionType, options_, realNestedSelection_);
     } catch (const NimbleUserError& e) {
       if (e.errorCode() == error_code::IncompatibleEncoding) {
         return;
@@ -616,6 +895,8 @@ class EncodingFuzzer {
   Encoding::Options options_;
   uint32_t minDistinctValues_;
   uint32_t maxDistinctValues_;
+  uint32_t largeInputRows_;
+  bool realNestedSelection_;
   std::shared_ptr<velox::memory::MemoryPool> pool_;
   std::unique_ptr<Buffer> buffer_;
 };

--- a/dwio/nimble/fuzzer/encoding/EncodingFuzzerTest.cpp
+++ b/dwio/nimble/fuzzer/encoding/EncodingFuzzerTest.cpp
@@ -26,6 +26,14 @@
 #include <gtest/gtest.h>
 
 #include <algorithm>
+#include <limits>
+#include <memory>
+#include <optional>
+#include <random>
+#include <set>
+#include <span>
+#include <string>
+#include <vector>
 
 #include "dwio/nimble/encodings/ALPEncoding.h"
 #include "dwio/nimble/encodings/BlockBitPackingEncoding.h"
@@ -42,7 +50,14 @@
 #include "dwio/nimble/encodings/SimdForBitpackEncoding.h"
 #include "dwio/nimble/encodings/SparseBoolEncoding.h"
 #ifdef NIMBLE_ENABLE_EXPERIMENTAL_ENCODINGS
+#include "dwio/nimble/encodings/SubIntSplitConfig.h"
 #include "dwio/nimble/encodings/SubIntSplitEncoding.h"
+#include "dwio/nimble/encodings/SubIntSplitSelector.h"
+#include "dwio/nimble/encodings/common/EncodingLayout.h"
+#include "dwio/nimble/encodings/common/EncodingType.h"
+#include "dwio/nimble/encodings/selection/EncodingSelection.h"
+#include "dwio/nimble/encodings/selection/EncodingSelectionPolicy.h"
+#include "dwio/nimble/encodings/selection/Statistics.h"
 #endif
 #include "dwio/nimble/encodings/TrivialEncoding.h"
 #include "dwio/nimble/encodings/VarintEncoding.h"
@@ -53,6 +68,7 @@ DEFINE_uint32(fuzzer_max_rows, 5000, "Maximum rows per fuzzer iteration");
 DEFINE_uint32(fuzzer_seed, 42, "Fuzzer seed (0 = random each run)");
 DEFINE_bool(fuzzer_compression, true, "Test with compression enabled");
 
+using namespace facebook;
 using namespace facebook::nimble;
 using namespace facebook::nimble::test;
 
@@ -404,99 +420,259 @@ class SubIntSplitFuzzerTest : public ::testing::Test {};
 TYPED_TEST_SUITE(SubIntSplitFuzzerTest, SubIntSplitTypes);
 
 TYPED_TEST(SubIntSplitFuzzerTest, correctness) {
-  const uint32_t iterations = std::min<uint32_t>(FLAGS_fuzzer_iterations, 20);
-  const uint32_t maxRows = std::min<uint32_t>(FLAGS_fuzzer_max_rows, 500);
+  // SubIntSplit's recompute encode runs an expensive DP split selector on every
+  // dataset, so keep the per-type budget small -- the dataset generators
+  // already cover all data patterns on each iteration. Compression roughly
+  // doubles encode cost (and Trivial-section compression is already covered by
+  // the other fuzzers), so it is left off here to keep the run within the test
+  // time limit. realNestedSelection exercises the diverse per-section encoders;
+  // largeInputRows adds a chunk-crossing large-input pass.
+  const uint32_t iterations = std::min<uint32_t>(FLAGS_fuzzer_iterations, 5);
+  const uint32_t maxRows = std::min<uint32_t>(FLAGS_fuzzer_max_rows, 300);
   EncodingFuzzer<TypeParam> fuzzer(
-      iterations, maxRows, FLAGS_fuzzer_seed, FLAGS_fuzzer_compression);
+      iterations,
+      maxRows,
+      FLAGS_fuzzer_seed,
+      /*testCompression=*/false,
+      /*options=*/{},
+      /*minDistinctValues=*/1,
+      /*maxDistinctValues=*/std::numeric_limits<uint32_t>::max(),
+      /*largeInputRows=*/65537u,
+      /*realNestedSelection=*/true);
   fuzzer.run();
+}
+
+namespace {
+
+template <typename T>
+std::span<const T> toSpan(const Vector<T>& values) {
+  return {values.data(), values.size()};
+}
+
+EncodingSelectionPolicyCreator makeLeafPolicyCreator() {
+  return [](DataType type) -> std::unique_ptr<EncodingSelectionPolicyBase> {
+    auto readFactors =
+        ManualEncodingSelectionPolicyFactory::defaultEncodingReadFactors();
+    readFactors.erase(
+        std::remove_if(
+            readFactors.begin(),
+            readFactors.end(),
+            [](const auto& factor) {
+              return factor.first == EncodingType::SubIntSplit;
+            }),
+        readFactors.end());
+    ManualEncodingSelectionPolicyFactory factory{
+        std::move(readFactors), std::nullopt};
+    return factory.createPolicy(type);
+  };
+}
+
+// Builds an EncodingSelection from the policy and calls SubIntSplitEncoding
+// directly, mirroring EncodingFactory::encode (which has no SubIntSplit case).
+template <typename T>
+std::string_view encodeWithPolicy(
+    std::unique_ptr<EncodingSelectionPolicy<T>> policy,
+    std::span<const T> values,
+    Buffer& buffer) {
+  using physicalType = typename TypeTraits<T>::physicalType;
+  const std::span<const physicalType> physicalValues(
+      reinterpret_cast<const physicalType*>(values.data()), values.size());
+  auto statistics = Statistics<physicalType>::create(physicalValues);
+  auto selectionResult =
+      policy->select(physicalValues, statistics, /*options=*/{});
+  EncodingSelection<physicalType> selection{
+      std::move(selectionResult), std::move(statistics), std::move(policy)};
+  return SubIntSplitEncoding<T>::encode(
+      selection, physicalValues, buffer, /*options=*/{});
+}
+
+template <typename T>
+std::unique_ptr<Encoding> decodeSubIntSplit(
+    std::string_view encoded,
+    velox::memory::MemoryPool& pool) {
+  return std::make_unique<SubIntSplitEncoding<T>>(
+      pool, encoded, [](uint32_t) { return nullptr; });
+}
+
+// Bit-exact comparison (float/double checked on their bit pattern, NaN-safe).
+template <typename T>
+void expectBitwiseEqual(
+    std::span<const T> expected,
+    std::span<const T> actual,
+    std::string_view context) {
+  ASSERT_EQ(expected.size(), actual.size()) << context;
+  for (size_t i = 0; i < expected.size(); ++i) {
+    EXPECT_EQ(
+        EncodingPhysicalType<T>::asEncodingPhysicalType(expected[i]),
+        EncodingPhysicalType<T>::asEncodingPhysicalType(actual[i]))
+        << context << " @ row " << i;
+  }
+}
+
+// Snowflake field widths (matches makeSnowflakeData): 12/10/41 for 64-bit,
+// 6/5/20 for 32-bit.
+struct SnowflakeLayout {
+  int sequenceBits;
+  int workerBits;
+  int timestampBits;
+};
+
+template <typename T>
+constexpr SnowflakeLayout snowflakeLayout() {
+  if constexpr (sizeof(typename TypeTraits<T>::physicalType) == 8) {
+    return {.sequenceBits = 12, .workerBits = 10, .timestampBits = 41};
+  } else {
+    return {.sequenceBits = 6, .workerBits = 5, .timestampBits = 20};
+  }
+}
+
+// A random contiguous partition of [0, kBits) into 1..6 sections -- a valid
+// preserve-mode boundary set (covers all bits, no gaps/overlaps).
+template <typename T>
+std::vector<detail::subintsplit::SegmentPlan> makeRandomSegments(
+    std::mt19937& rng) {
+  constexpr int kBits =
+      static_cast<int>(sizeof(typename TypeTraits<T>::physicalType) * 8);
+  std::uniform_int_distribution<int> internalCutCount(
+      0, std::min(5, kBits - 1));
+  const int cuts = internalCutCount(rng);
+  std::set<int> boundaries;
+  std::uniform_int_distribution<int> cutPos(1, kBits - 1);
+  while (static_cast<int>(boundaries.size()) < cuts) {
+    boundaries.insert(cutPos(rng));
+  }
+  std::vector<detail::subintsplit::SegmentPlan> segments;
+  int start = 0;
+  for (const int boundary : boundaries) {
+    segments.push_back({.bitStart = start, .bitEnd = boundary - 1});
+    start = boundary;
+  }
+  segments.push_back({.bitStart = start, .bitEnd = kBits - 1});
+  return segments;
+}
+
+template <typename T>
+EncodingLayout makePreserveLayout(
+    const std::vector<detail::subintsplit::SegmentPlan>& segments) {
+  std::vector<std::optional<const EncodingLayout>> children(segments.size());
+  return EncodingLayout{
+      EncodingType::SubIntSplit,
+      EncodingLayout::Config{
+          detail::subintsplit::makePreserveSplitConfig(segments)},
+      CompressionType::Uncompressed,
+      std::move(children)};
+}
+
+template <typename T>
+std::string_view encodePreserve(
+    const std::vector<detail::subintsplit::SegmentPlan>& segments,
+    std::span<const T> values,
+    Buffer& buffer) {
+  const auto layout = makePreserveLayout<T>(segments);
+  return encodeWithPolicy<T>(
+      std::make_unique<ReplayedEncodingSelectionPolicy<T>>(
+          layout, std::nullopt, makeLeafPolicyCreator()),
+      values,
+      buffer);
+}
+
+// One dataset per shared data pattern (empties, for type-gated patterns, are
+// dropped -- all SubIntSplit types are >= 4-byte numerics, so none are empty).
+template <typename T>
+std::vector<Vector<T>> makeSubIntSplitDatasets(
+    velox::memory::MemoryPool& pool,
+    std::mt19937& rng,
+    uint32_t rowCount,
+    Buffer* buffer) {
+  std::vector<Vector<T>> datasets;
+  {
+    Vector<T> random(&pool);
+    random.reserve(rowCount);
+    nimble::testing::addRandomData<T>(rng, rowCount, &random, buffer);
+    datasets.push_back(std::move(random));
+  }
+  datasets.push_back(makeSingleValueData<T>(pool, rng, rowCount, buffer));
+  datasets.push_back(makeLowCardinalityData<T>(pool, rng, rowCount, buffer));
+  datasets.push_back(makeSortedData<T>(pool, rng, rowCount, buffer));
+  datasets.push_back(makeBoundaryMixedData<T>(pool, rng, rowCount, buffer));
+  datasets.push_back(makeDominantValueData<T>(pool, rng, rowCount, buffer));
+  datasets.push_back(makeBitStructuredData<T>(pool, rng, rowCount, buffer));
+  datasets.push_back(makeSnowflakeData<T>(pool, rng, rowCount, buffer));
+  datasets.push_back(makeMixedRegimeData<T>(pool, rng, rowCount, buffer));
+  std::erase_if(datasets, [](const Vector<T>& d) { return d.empty(); });
+  return datasets;
+}
+
+uint32_t subIntSplitSeed() {
+  return FLAGS_fuzzer_seed == 0 ? 0x1234u : FLAGS_fuzzer_seed;
+}
+
+} // namespace
+
+// Preserve-mode encode with randomly generated valid boundary partitions must
+// honor those boundaries and roundtrip bit-exactly.
+TYPED_TEST(SubIntSplitFuzzerTest, preserveModeRandomBoundaries) {
+  using T = typename TypeParam::cppDataType;
+  auto pool = velox::memory::deprecatedAddDefaultLeafMemoryPool();
+  std::mt19937 rng(subIntSplitSeed());
+  Buffer buffer{*pool};
+  const auto datasets =
+      makeSubIntSplitDatasets<T>(*pool, rng, /*rowCount=*/300, &buffer);
+  for (size_t d = 0; d < datasets.size(); ++d) {
+    const auto& values = datasets[d];
+    const auto segments = makeRandomSegments<T>(rng);
+    Buffer encodeBuffer{*pool};
+    const auto encoded =
+        encodePreserve<T>(segments, toSpan(values), encodeBuffer);
+    auto encoding = decodeSubIntSplit<T>(encoded, *pool);
+    Vector<T> decoded(pool.get(), values.size());
+    encoding->materialize(static_cast<uint32_t>(values.size()), decoded.data());
+    expectBitwiseEqual<T>(
+        toSpan(values),
+        toSpan(decoded),
+        "preserve dataset " + std::to_string(d));
+  }
+}
+
+// Preserve-mode split aligned exactly to the snowflake field boundaries
+// (sequence | worker | timestamp) -- SubIntSplit's intended use case -- must
+// roundtrip bit-exactly, including at a chunk-crossing size.
+TYPED_TEST(SubIntSplitFuzzerTest, snowflakeFieldAlignedSplit) {
+  using T = typename TypeParam::cppDataType;
+  auto pool = velox::memory::deprecatedAddDefaultLeafMemoryPool();
+  const auto layout = snowflakeLayout<T>();
+  constexpr int kBits =
+      static_cast<int>(sizeof(typename TypeTraits<T>::physicalType) * 8);
+  const std::vector<detail::subintsplit::SegmentPlan> segments = {
+      {.bitStart = 0, .bitEnd = layout.sequenceBits - 1},
+      {.bitStart = layout.sequenceBits,
+       .bitEnd = layout.sequenceBits + layout.workerBits - 1},
+      {.bitStart = layout.sequenceBits + layout.workerBits,
+       .bitEnd = kBits - 1}};
+
+  std::mt19937 rng(subIntSplitSeed());
+  for (const uint32_t count : {300u, 4097u}) {
+    Buffer buffer{*pool};
+    const auto values = makeSnowflakeData<T>(*pool, rng, count, &buffer);
+    Buffer encodeBuffer{*pool};
+    const auto encoded =
+        encodePreserve<T>(segments, toSpan(values), encodeBuffer);
+    auto encoding = decodeSubIntSplit<T>(encoded, *pool);
+    Vector<T> decoded(pool.get(), count);
+    encoding->materialize(count, decoded.data());
+    expectBitwiseEqual<T>(
+        toSpan(values),
+        toSpan(decoded),
+        "snowflake field-aligned count=" + std::to_string(count));
+  }
+}
+
+// SubIntSplit rejects empty input rather than producing an undecodable stream.
+TYPED_TEST(SubIntSplitFuzzerTest, emptyInputRejected) {
+  using T = typename TypeParam::cppDataType;
+  auto pool = velox::memory::deprecatedAddDefaultLeafMemoryPool();
+  Buffer buffer{*pool};
+  const Vector<T> empty(pool.get());
+  EXPECT_THROW(Encoder<TypeParam>::encode(buffer, empty), NimbleUserError);
 }
 #endif // NIMBLE_ENABLE_EXPERIMENTAL_ENCODINGS
-
-// FOR: integral types only (float/string are excluded by static_assert)
-/*
-using ForTypes = ::testing::Types<
-    ForEncoding<int8_t>,
-    ForEncoding<int16_t>,
-    ForEncoding<int32_t>,
-    ForEncoding<int64_t>,
-    ForEncoding<uint8_t>,
-    ForEncoding<uint16_t>,
-    ForEncoding<uint32_t>,
-    ForEncoding<uint64_t>>;
-
-template <typename E>
-class ForFuzzerTest : public ::testing::Test {};
-TYPED_TEST_SUITE(ForFuzzerTest, ForTypes);
-
-TYPED_TEST(ForFuzzerTest, correctness) {
-  EncodingFuzzer<TypeParam> fuzzer(
-      FLAGS_fuzzer_iterations,
-      FLAGS_fuzzer_max_rows,
-      FLAGS_fuzzer_seed,
-      FLAGS_fuzzer_compression);
-  fuzzer.run();
-}
-
-// FrequencyPartitionEncoding: indexed modes that preserve original row order.
-// NoIndex mode (tier-order output) is omitted here; its correctness is covered
-// by the deterministic tests in FrequencyPartitionEncodingTest.cpp.
-using FPETypes = ::testing::Types<
-    FrequencyPartitionEncoding<int32_t>,
-    FrequencyPartitionEncoding<uint32_t>,
-    FrequencyPartitionEncoding<int64_t>,
-    FrequencyPartitionEncoding<uint64_t>,
-    FrequencyPartitionEncoding<float>,
-    FrequencyPartitionEncoding<double>,
-    FrequencyPartitionEncoding<std::string_view>>;
-
-template <typename E>
-class FPEPerTierBitmapsFuzzerTest : public ::testing::Test {};
-TYPED_TEST_SUITE(FPEPerTierBitmapsFuzzerTest, FPETypes);
-
-TYPED_TEST(FPEPerTierBitmapsFuzzerTest, correctness) {
-  Encoding::Options opts{};
-  opts.frequencyPartitionIndex =
-      static_cast<uint8_t>(FreqPartIndexType::PerTierBitmaps);
-  EncodingFuzzer<TypeParam> fuzzer(
-      FLAGS_fuzzer_iterations,
-      FLAGS_fuzzer_max_rows,
-      FLAGS_fuzzer_seed,
-      FLAGS_fuzzer_compression,
-      opts);
-  fuzzer.run();
-}
-
-template <typename E>
-class FPETierTagArrayFuzzerTest : public ::testing::Test {};
-TYPED_TEST_SUITE(FPETierTagArrayFuzzerTest, FPETypes);
-
-TYPED_TEST(FPETierTagArrayFuzzerTest, correctness) {
-  Encoding::Options opts{};
-  opts.frequencyPartitionIndex =
-      static_cast<uint8_t>(FreqPartIndexType::TierTagArray);
-  EncodingFuzzer<TypeParam> fuzzer(
-      FLAGS_fuzzer_iterations,
-      FLAGS_fuzzer_max_rows,
-      FLAGS_fuzzer_seed,
-      FLAGS_fuzzer_compression,
-      opts);
-  fuzzer.run();
-}
-
-template <typename E>
-class FPEEliasFanoFuzzerTest : public ::testing::Test {};
-TYPED_TEST_SUITE(FPEEliasFanoFuzzerTest, FPETypes);
-
-TYPED_TEST(FPEEliasFanoFuzzerTest, correctness) {
-  Encoding::Options opts{};
-  opts.frequencyPartitionIndex =
-      static_cast<uint8_t>(FreqPartIndexType::EliasFano);
-  EncodingFuzzer<TypeParam> fuzzer(
-      FLAGS_fuzzer_iterations,
-      FLAGS_fuzzer_max_rows,
-      FLAGS_fuzzer_seed,
-      FLAGS_fuzzer_compression,
-      opts);
-  fuzzer.run();
-}
-*/


### PR DESCRIPTION
Summary:

Adds a randomized correctness test suite for SubIntSplitEncoding.

  ┌─────────────────────────────────────┬────────────────┬────────────────────────┬────────┬────────────────────┬────────────────────────────────────────┬──────────────────────────────────────────────────────────┬───────┬────────────┐
  │                Test                 │     Types      │        Patterns        │ Mixed? │     Row counts     │               Split mode               │                  Operation(s) verified                   │ Seeds │ Iters/type │
  ├─────────────────────────────────────┼────────────────┼────────────────────────┼────────┼────────────────────┼────────────────────────────────────────┼──────────────────────────────────────────────────────────┼───────┼────────────┤
  │ RecomputeRoundTripFuzz              │ all 6          │ C R L S P B D SF M (9) │   Y    │ 1, 2, 7, 100, 300  │ recompute (DP)                         │ encode → full materialize; rowCount()                    │ 2     │ 90         │
  ├─────────────────────────────────────┼────────────────┼────────────────────────┼────────┼────────────────────┼────────────────────────────────────────┼──────────────────────────────────────────────────────────┼───────┼────────────┤
  │ ChunkedMaterializeFuzz              │ all 6          │ R P SF M (4)           │   Y    │ 4096, 4097         │ recompute                              │ partial materialize (random 1–500) across chunk boundary │ 1     │ 8          │
  ├─────────────────────────────────────┼────────────────┼────────────────────────┼────────┼────────────────────┼────────────────────────────────────────┼──────────────────────────────────────────────────────────┼───────┼────────────┤
  │ SkipThenMaterializeFuzz             │ all 6          │ 9 100; P 5000        │   Y    │ 100, 5000          │ recompute                              │ skip (random & cross-chunk) → materialize                │ 1     │ 10         │
  ├─────────────────────────────────────┼────────────────┼────────────────────────┼────────┼────────────────────┼────────────────────────────────────────┼──────────────────────────────────────────────────────────┼───────┼────────────┤
  │ ResetReMaterializeFuzz              │ all 6          │ C R L S P B D SF M (9) │   Y    │ 7, 300             │ recompute                              │ materialize → reset → re-materialize                     │ 1     │ 18         │
  ├─────────────────────────────────────┼────────────────┼────────────────────────┼────────┼────────────────────┼────────────────────────────────────────┼──────────────────────────────────────────────────────────┼───────┼────────────┤
  │ PreserveModeRandomBoundariesFuzz    │ all 6          │ C R L S P B D SF M (9) │   Y    │ 300                │ preserve (random 1–6 sections)         │ encode → full materialize                                │ 2     │ 18         │
  ├─────────────────────────────────────┼────────────────┼────────────────────────┼────────┼────────────────────┼────────────────────────────────────────┼──────────────────────────────────────────────────────────┼───────┼────────────┤
  │ SnowflakeFieldAlignedSplitRoundTrip │ all 6          │ SF                     │   —    │ 300, 4097          │ preserve (field-aligned seq|worker|ts) │ encode → full materialize                                │ 2     │ 4          │
  ├─────────────────────────────────────┼────────────────┼────────────────────────┼────────┼────────────────────┼────────────────────────────────────────┼──────────────────────────────────────────────────────────┼───────┼────────────┤
  │ LargeInputFuzz                      │ all 6          │ SF R M (3)             │   Y    │ 65537 (16 chunks)  │ recompute                              │ partial materialize (1–4096) + skip-across-chunks        │ 1     │ 3          │
  ├─────────────────────────────────────┼────────────────┼────────────────────────┼────────┼────────────────────┼────────────────────────────────────────┼──────────────────────────────────────────────────────────┼───────┼────────────┤
  │ VeryLargeInputTest (Uint64, Uint32) │ uint64, uint32 │ R M (2)                │   Y    │ 262144 (64 chunks) │ recompute                              │ partial materialize (1–8192)                             │ 1     │ 2 each     │
  ├─────────────────────────────────────┼────────────────┼────────────────────────┼────────┼────────────────────┼────────────────────────────────────────┼──────────────────────────────────────────────────────────┼───────┼────────────┤
  │ EmptyInputRejected                  │ all 6          │ — (empty)              │   —    │ 0                  │ recompute                              │ encode throws NimbleUserError                            │ —     │ 1          │
  ├─────────────────────────────────────┼────────────────┼────────────────────────┼────────┼────────────────────┼────────────────────────────────────────┼──────────────────────────────────────────────────────────┼───────┼────────────┤
  │ FloatSpecials (Float, Double)       │ float, double  │ specials + R padding   │   —    │ 212                │ recompute                              │ full materialize, bit-exact (NaN/±inf/−0.0/denorm)       │ 1     │ 1 each     │
  └─────────────────────────────────────┴────────────────┴────────────────────────┴────────┴────────────────────┴────────────────────────────────────────┴──────────────────────────────────────────────────────────┴───────┴────────────┘

Reviewed By: apurva-meta

Differential Revision: D113282421
