### PR TITLE
feat(fuzzer): Add a random encoding selection policy for TableEvolutionFuzzer (#1009)

### DIFF
--- a/dwio/nimble/encodings/selection/EncodingSelectionPolicy.h
+++ b/dwio/nimble/encodings/selection/EncodingSelectionPolicy.h
@@ -17,8 +17,11 @@
 
 #include <glog/logging.h>
 #include <algorithm>
+#include <cstdint>
+#include <memory>
 #include <optional>
 #include <string>
+#include <string_view>
 #include <utility>
 #include <vector>
 #include "dwio/nimble/common/Constants.h"
@@ -48,49 +51,49 @@ using EncodingSelectionPolicyCreator =
 #endif
 
 #define COMMA ,
-#define UNIQUE_PTR_FACTORY_EXTRA(data_type, class, extra_types, ...)        \
-  switch (data_type) {                                                      \
-    case facebook::nimble::DataType::Uint8: {                               \
-      return std::make_unique<class<uint8_t extra_types>>(__VA_ARGS__);     \
-    }                                                                       \
-    case facebook::nimble::DataType::Int8: {                                \
-      return std::make_unique<class<int8_t extra_types>>(__VA_ARGS__);      \
-    }                                                                       \
-    case facebook::nimble::DataType::Uint16: {                              \
-      return std::make_unique<class<uint16_t extra_types>>(__VA_ARGS__);    \
-    }                                                                       \
-    case facebook::nimble::DataType::Int16: {                               \
-      return std::make_unique<class<int16_t extra_types>>(__VA_ARGS__);     \
-    }                                                                       \
-    case facebook::nimble::DataType::Uint32: {                              \
-      return std::make_unique<class<uint32_t extra_types>>(__VA_ARGS__);    \
-    }                                                                       \
-    case facebook::nimble::DataType::Int32: {                               \
-      return std::make_unique<class<int32_t extra_types>>(__VA_ARGS__);     \
-    }                                                                       \
-    case facebook::nimble::DataType::Uint64: {                              \
-      return std::make_unique<class<uint64_t extra_types>>(__VA_ARGS__);    \
-    }                                                                       \
-    case facebook::nimble::DataType::Int64: {                               \
-      return std::make_unique<class<int64_t extra_types>>(__VA_ARGS__);     \
-    }                                                                       \
-    case facebook::nimble::DataType::Float: {                               \
-      return std::make_unique<class<float extra_types>>(__VA_ARGS__);       \
-    }                                                                       \
-    case facebook::nimble::DataType::Double: {                              \
-      return std::make_unique<class<double extra_types>>(__VA_ARGS__);      \
-    }                                                                       \
-    case facebook::nimble::DataType::Bool: {                                \
-      return std::make_unique<class<bool extra_types>>(__VA_ARGS__);        \
-    }                                                                       \
-    case facebook::nimble::DataType::String: {                              \
-      return std::make_unique<class<std::string_view extra_types>>(         \
-          __VA_ARGS__);                                                     \
-    }                                                                       \
-    default: {                                                              \
-      NIMBLE_UNREACHABLE("Unsupported data type {}.", toString(data_type)); \
-    }                                                                       \
-  }
+#define UNIQUE_PTR_FACTORY_EXTRA(data_type, class, extra_types, ...)     \
+  switch (data_type) {                                                   \
+    case facebook::nimble::DataType::Uint8: {                            \
+      return std::make_unique<class<uint8_t extra_types>>(__VA_ARGS__);  \
+    }                                                                    \
+    case facebook::nimble::DataType::Int8: {                             \
+      return std::make_unique<class<int8_t extra_types>>(__VA_ARGS__);   \
+    }                                                                    \
+    case facebook::nimble::DataType::Uint16: {                           \
+      return std::make_unique<class<uint16_t extra_types>>(__VA_ARGS__); \
+    }                                                                    \
+    case facebook::nimble::DataType::Int16: {                            \
+      return std::make_unique<class<int16_t extra_types>>(__VA_ARGS__);  \
+    }                                                                    \
+    case facebook::nimble::DataType::Uint32: {                           \
+      return std::make_unique<class<uint32_t extra_types>>(__VA_ARGS__); \
+    }                                                                    \
+    case facebook::nimble::DataType::Int32: {                            \
+      return std::make_unique<class<int32_t extra_types>>(__VA_ARGS__);  \
+    }                                                                    \
+    case facebook::nimble::DataType::Uint64: {                           \
+      return std::make_unique<class<uint64_t extra_types>>(__VA_ARGS__); \
+    }                                                                    \
+    case facebook::nimble::DataType::Int64: {                            \
+      return std::make_unique<class<int64_t extra_types>>(__VA_ARGS__);  \
+    }                                                                    \
+    case facebook::nimble::DataType::Float: {                            \
+      return std::make_unique<class<float extra_types>>(__VA_ARGS__);    \
+    }                                                                    \
+    case facebook::nimble::DataType::Double: {                           \
+      return std::make_unique<class<double extra_types>>(__VA_ARGS__);   \
+    }                                                                    \
+    case facebook::nimble::DataType::Bool: {                             \
+      return std::make_unique<class<bool extra_types>>(__VA_ARGS__);     \
+    }                                                                    \
+    case facebook::nimble::DataType::String: {                           \
+      return std::make_unique<class<std::string_view extra_types>>(      \
+          __VA_ARGS__);                                                  \
+    }                                                                    \
+    case facebook::nimble::DataType::Undefined:                          \
+      break;                                                             \
+  }                                                                      \
+  NIMBLE_UNREACHABLE("Unsupported data type {}.", toString(data_type))
 
 #define UNIQUE_PTR_FACTORY(data_type, class, ...) \
   UNIQUE_PTR_FACTORY_EXTRA(data_type, class, , __VA_ARGS__)
@@ -288,9 +291,11 @@ class ManualEncodingSelectionPolicyFactory {
   std::unique_ptr<EncodingSelectionPolicyBase> createPolicy(
       DataType dataType) const;
 
- private:
+  /// All encodings the string-config parsers accept (production +
+  /// experimental). Also used to resolve encoding names to EncodingType.
   static std::vector<EncodingType> possibleEncodings();
 
+ private:
   const std::vector<std::pair<EncodingType, float>> encodingReadFactors_;
   const std::optional<CompressionOptions> compressionOptions_;
 };

--- a/dwio/nimble/encodings/selection/tests/RandomEncodingSelectionPolicy.cpp
+++ b/dwio/nimble/encodings/selection/tests/RandomEncodingSelectionPolicy.cpp
@@ -1,0 +1,144 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "dwio/nimble/encodings/selection/tests/RandomEncodingSelectionPolicy.h"
+
+#include <folly/Conv.h>
+#include <folly/String.h>
+#include <algorithm>
+
+namespace facebook::nimble::testing {
+
+namespace {
+
+// Resolves a ';'-separated list of encoding names to EncodingTypes, matching
+// against the full parseable set. Surfaces a NimbleUserError on an empty list,
+// an unknown name, or a duplicate.
+std::vector<EncodingType> parseEncodings(std::string_view value) {
+  const auto candidates =
+      ManualEncodingSelectionPolicyFactory::possibleEncodings();
+  std::vector<EncodingType> choices;
+  std::vector<std::string_view> names;
+  folly::split(';', value, names);
+  for (const auto name : names) {
+    NIMBLE_USER_CHECK(
+        !name.empty(),
+        "Empty encoding name in nimble.encoding_selection_config.");
+    bool found = false;
+    for (const auto candidate : candidates) {
+      if (name == toString(candidate)) {
+        NIMBLE_USER_CHECK(
+            std::find(choices.begin(), choices.end(), candidate) ==
+                choices.end(),
+            "Duplicate encoding '{}' in nimble.encoding_selection_config.",
+            name);
+        choices.push_back(candidate);
+        found = true;
+        break;
+      }
+    }
+    NIMBLE_USER_CHECK(
+        found,
+        "Unknown encoding '{}' in nimble.encoding_selection_config.",
+        name);
+  }
+  NIMBLE_USER_CHECK(
+      !choices.empty(),
+      "nimble.encoding_selection_config 'encodings' must list at least one encoding.");
+  return choices;
+}
+
+} // namespace
+
+/* static */ std::vector<EncodingType>
+RandomEncodingSelectionPolicyFactory::defaultEncodingChoices() {
+  return {
+      EncodingType::Constant,
+      EncodingType::Trivial,
+      EncodingType::FixedBitWidth,
+      EncodingType::MainlyConstant,
+      EncodingType::SparseBool,
+      EncodingType::Dictionary,
+      EncodingType::RLE,
+      EncodingType::Varint,
+  };
+}
+
+/* static */ RandomEncodingSelectionPolicyFactory
+RandomEncodingSelectionPolicyFactory::create(
+    std::string_view configStr,
+    std::optional<CompressionOptions> compressionOptions) {
+  std::optional<uint64_t> seed;
+  std::vector<EncodingType> candidateEncodingTypes = defaultEncodingChoices();
+  std::vector<std::string_view> entries;
+  folly::split(',', configStr, entries);
+  for (const auto entry : entries) {
+    const auto colonPos = entry.find(':');
+    NIMBLE_USER_CHECK(
+        colonPos != std::string_view::npos,
+        "Malformed nimble.encoding_selection_config entry '{}'; want key:value.",
+        entry);
+    const auto key = entry.substr(0, colonPos);
+    const auto value = entry.substr(colonPos + 1);
+    if (key == "type") {
+      // Selected by createEncodingSelectionPolicyFactory; ignore it here.
+      continue;
+    } else if (key == "seed") {
+      const auto parsed = folly::tryTo<uint64_t>(folly::StringPiece(value));
+      NIMBLE_USER_CHECK(
+          parsed.hasValue(),
+          "Invalid seed '{}' in nimble.encoding_selection_config.",
+          value);
+      seed = parsed.value();
+    } else if (key == "encodings") {
+      candidateEncodingTypes = parseEncodings(value);
+    } else {
+      NIMBLE_USER_FAIL(
+          "Unknown nimble.encoding_selection_config key '{}' for type 'random'.",
+          key);
+    }
+  }
+  NIMBLE_USER_CHECK(
+      seed.has_value(),
+      "nimble.encoding_selection_config type 'random' requires a 'seed'.");
+  return RandomEncodingSelectionPolicyFactory{
+      seed.value(),
+      std::move(candidateEncodingTypes),
+      std::move(compressionOptions)};
+}
+
+RandomEncodingSelectionPolicyFactory::RandomEncodingSelectionPolicyFactory(
+    uint64_t seed,
+    std::vector<EncodingType> candidateEncodingTypes,
+    std::optional<CompressionOptions> compressionOptions)
+    : seed_{seed},
+      candidateEncodingTypes_{std::move(candidateEncodingTypes)},
+      compressionOptions_{std::move(compressionOptions)} {}
+
+std::unique_ptr<EncodingSelectionPolicyBase>
+RandomEncodingSelectionPolicyFactory::createPolicy(DataType dataType) const {
+  // Derive the root policy's seed from the base seed and the column's data type
+  // so top-level columns of different types diverge; createImpl then folds in
+  // each nested slot. Deterministic and independent of encode thread order.
+  const uint64_t rootSeed = folly::hash::hash_combine(
+      seed_, static_cast<std::underlying_type_t<DataType>>(dataType));
+  UNIQUE_PTR_FACTORY(
+      dataType,
+      RandomEncodingSelectionPolicy,
+      rootSeed,
+      candidateEncodingTypes_,
+      compressionOptions_);
+}
+} // namespace facebook::nimble::testing

--- a/dwio/nimble/encodings/selection/tests/RandomEncodingSelectionPolicy.h
+++ b/dwio/nimble/encodings/selection/tests/RandomEncodingSelectionPolicy.h
@@ -1,0 +1,198 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <folly/hash/Hash.h>
+#include <cstdint>
+#include <memory>
+#include <optional>
+#include <random>
+#include <span>
+#include <string_view>
+#include <type_traits>
+#include <utility>
+#include <vector>
+
+#include "dwio/nimble/encodings/selection/EncodingSelectionPolicy.h"
+
+// Random encoding selection lives in the nimble::testing namespace and its own
+// target to keep it out of the core encoding-selection library: it is meant for
+// fuzz/stress testing and validation tooling, never for production table
+// ingestion.
+namespace facebook::nimble::testing {
+
+/// Randomized encoding selection for fuzz/stress testing. For each stream it
+/// picks uniformly at random among the encodings that are compatible with the
+/// data. Compatibility is defined exactly as encoding-size estimability:
+/// EncodingSizeEstimation returns nullopt for any encoding that cannot encode
+/// the given physical type or data statistics (e.g. Dictionary/FixedBitWidth/
+/// Varint on bool, Varint on non-integers, Constant on non-constant data), so
+/// reusing that signal keeps the random pick compatible without a
+/// hand-maintained rule table, and the writer's one-shot IncompatibleEncoding
+/// fallback is never relied upon.
+template <typename T>
+class RandomEncodingSelectionPolicy : public EncodingSelectionPolicy<T> {
+  using physicalType = typename TypeTraits<T>::physicalType;
+
+ public:
+  RandomEncodingSelectionPolicy(
+      uint64_t seed,
+      std::vector<EncodingType> candidateEncodingTypes,
+      std::optional<CompressionOptions> compressionOptions =
+          CompressionOptions{})
+      : seed_{seed},
+        candidateEncodingTypes_{std::move(candidateEncodingTypes)},
+        compressionOptions_{std::move(compressionOptions)} {}
+
+  EncodingSelectionResult select(
+      std::span<const physicalType> values,
+      const Statistics<physicalType>& statistics,
+      const Encoding::Options& options) override {
+    // Empty streams (e.g. the values of an all-null column, or an empty nested
+    // stream) can only be encoded trivially; several encodings hard-fail on
+    // zero rows. Matches Manual/Learned selection.
+    if (values.empty()) {
+      return {
+          .encodingType = EncodingType::Trivial,
+      };
+    }
+
+    // Keep only encodings that can estimate a size for this data. An absent
+    // estimate means the encoding is incompatible with the physical type or the
+    // data's statistics, so excluding it here is what keeps the random pick
+    // compatible.
+    std::vector<EncodingType> compatibleEncodings;
+    compatibleEncodings.reserve(candidateEncodingTypes_.size());
+    for (const auto& encodingType : candidateEncodingTypes_) {
+      if (detail::EncodingSizeEstimation<T>::estimateSize(
+              encodingType, values, statistics, options)
+              .has_value()) {
+        compatibleEncodings.push_back(encodingType);
+      }
+    }
+
+    if (compatibleEncodings.empty()) {
+      return {
+          .encodingType = EncodingType::Trivial,
+      };
+    }
+
+    // Seed a fresh generator from this policy's derived seed so the single pick
+    // is deterministic and independent of encode thread order.
+    std::mt19937_64 generator{seed_};
+    std::uniform_int_distribution<size_t> distribution(
+        0, compatibleEncodings.size() - 1);
+    const auto selectedEncoding = compatibleEncodings[distribution(generator)];
+
+    if (!compressionOptions_.has_value()) {
+      return {.encodingType = selectedEncoding};
+    }
+    // Encoding selection optimizes the in-memory layout. Compression is still
+    // attempted for leaf data streams to reduce persistent storage size.
+    return {
+        .encodingType = selectedEncoding,
+        .compressionPolicyFactory = [compressionOptions =
+                                         compressionOptions_.value(),
+                                     selectedEncoding]() {
+          return std::make_unique<ConfiguredCompressionPolicy>(
+              compressionOptions, selectedEncoding);
+        }};
+  }
+
+  EncodingSelectionResult selectNullable(
+      std::span<const physicalType> /* values */,
+      std::span<const bool> /* nulls */,
+      const Statistics<physicalType>& /* statistics */,
+      const Encoding::Options& /* options */) override {
+    return {
+        .encodingType = EncodingType::Nullable,
+    };
+  }
+
+ protected:
+  std::unique_ptr<EncodingSelectionPolicyBase> createImpl(
+      EncodingType parentEncodingType,
+      NestedEncodingIdentifier nestedEncodingIdentifier,
+      DataType nestedDataType) override {
+    // Exclude the parent encoding from nested choices so the recursive
+    // selection always converges (mirrors Manual/Learned).
+    std::vector<EncodingType> nestedCandidateEncodingTypes;
+    nestedCandidateEncodingTypes.reserve(candidateEncodingTypes_.size());
+    for (const auto& encodingType : candidateEncodingTypes_) {
+      if (encodingType != parentEncodingType) {
+        nestedCandidateEncodingTypes.push_back(encodingType);
+      }
+    }
+    // Fold this policy's seed with the parent encoding and the child slot so
+    // every node in the tree gets a distinct seed that depends only on its
+    // structural path, never on encode timing. This keeps the whole random
+    // layout reproducible from the single base seed even when streams are
+    // encoded concurrently.
+    const uint64_t nestedSeed = folly::hash::hash_combine(
+        seed_,
+        static_cast<std::underlying_type_t<EncodingType>>(parentEncodingType),
+        nestedEncodingIdentifier);
+    UNIQUE_PTR_FACTORY(
+        nestedDataType,
+        RandomEncodingSelectionPolicy,
+        nestedSeed,
+        std::move(nestedCandidateEncodingTypes),
+        compressionOptions_);
+  }
+
+ private:
+  const uint64_t seed_;
+  const std::vector<EncodingType> candidateEncodingTypes_;
+  const std::optional<CompressionOptions> compressionOptions_;
+};
+
+/// Produces RandomEncodingSelectionPolicy instances seeded deterministically
+/// from a single base seed, so an entire file's random encoding tree is
+/// reproducible from that seed. Intended for fuzz/stress testing only.
+class RandomEncodingSelectionPolicyFactory {
+ public:
+  /// The candidate encodings the random policy draws from (the production
+  /// Learned/Manual default set). EncodingSizeEstimation filters this per
+  /// stream down to the encodings compatible with the actual data.
+  static std::vector<EncodingType> defaultEncodingChoices();
+
+  /// Builds a factory from a nimble.encoding_selection_config string of the
+  /// form "type:random,seed:<n>[,encodings:<E1>;<E2>;...]". 'seed' is required;
+  /// 'encodings' (optional) restricts the candidate set. Ignores the 'type' key
+  /// (already used by createEncodingSelectionPolicyFactory). Reports bad input
+  /// as a NimbleUserError.
+  static RandomEncodingSelectionPolicyFactory create(
+      std::string_view configStr,
+      std::optional<CompressionOptions> compressionOptions =
+          CompressionOptions{});
+
+  explicit RandomEncodingSelectionPolicyFactory(
+      uint64_t seed,
+      std::vector<EncodingType> candidateEncodingTypes =
+          defaultEncodingChoices(),
+      std::optional<CompressionOptions> compressionOptions =
+          CompressionOptions{});
+
+  std::unique_ptr<EncodingSelectionPolicyBase> createPolicy(
+      DataType dataType) const;
+
+ private:
+  const uint64_t seed_;
+  const std::vector<EncodingType> candidateEncodingTypes_;
+  const std::optional<CompressionOptions> compressionOptions_;
+};
+
+} // namespace facebook::nimble::testing

--- a/dwio/nimble/velox/NimbleConfig.cpp
+++ b/dwio/nimble/velox/NimbleConfig.cpp
@@ -318,6 +318,10 @@ std::map<uint64_t, float> parseGrowthConfigMap(const std::string& str) {
     "nimble.flush_policy_config",
     "");
 
+/* static */ Config::Entry<std::string> Config::ENCODING_SELECTION_CONFIG(
+    "nimble.encoding_selection_config",
+    "");
+
 // EXPERIMENTAL: Cluster index is not production-ready. Do not enable for
 // production tables without consulting the Nimble team (oncall: dwios).
 /* static */ Config::Entry<const std::vector<std::string>>

--- a/dwio/nimble/velox/NimbleConfig.h
+++ b/dwio/nimble/velox/NimbleConfig.h
@@ -82,6 +82,20 @@ class Config : public velox::config::ConfigBase {
   // @lint-ignore CLANGTIDY facebook-hte-NonPodStaticDeclaration
   static Entry<std::string> FLUSH_POLICY_CONFIG;
 
+  /// Configures encoding selection. A comma-separated "type:<t>,key:value,..."
+  /// config whose leading "type" selects the policy (mirrors
+  /// nimble.flush_policy_config). Currently supported:
+  ///   type:random,seed:<n>[,encodings:<E1>;<E2>;...]
+  ///       Random-but-compatible encoding selection, reproducible from 'seed'
+  ///       (required). 'encodings' (optional, ';'-separated) restricts the
+  ///       candidate set; streams with no compatible encoding in the set (e.g.
+  ///       empty streams) still fall back to Trivial. Test/fuzz only; not for
+  ///       production.
+  /// An empty/unset config keeps the default (manual) policy. See
+  /// RandomEncodingSelectionPolicy. E.g. "type:random,seed:42".
+  // @lint-ignore CLANGTIDY facebook-hte-NonPodStaticDeclaration
+  static Entry<std::string> ENCODING_SELECTION_CONFIG;
+
   // EXPERIMENTAL: Cluster index is not production-ready. Do not enable for
   // production tables without consulting the Nimble team (oncall: dwios).
 

--- a/dwio/nimble/velox/tests/VeloxWriterTest.cpp
+++ b/dwio/nimble/velox/tests/VeloxWriterTest.cpp
@@ -31,6 +31,7 @@
 #include "dwio/nimble/encodings/common/EncodingFactory.h"
 #include "dwio/nimble/encodings/common/EncodingLayout.h"
 #include "dwio/nimble/encodings/common/EncodingUtils.h"
+#include "dwio/nimble/encodings/selection/tests/RandomEncodingSelectionPolicy.h"
 #include "dwio/nimble/encodings/tests/TestUtils.h"
 #include "dwio/nimble/index/ChunkStatsGroup.h"
 #include "dwio/nimble/index/KeyEncoding.h"
@@ -346,6 +347,50 @@ nimble::EncodingSelectionPolicyCreator makeEncodingSelectionPolicyCreator(
              -> std::unique_ptr<nimble::EncodingSelectionPolicyBase> {
     return factory.createPolicy(dataType);
   };
+}
+
+nimble::EncodingSelectionPolicyCreator createRandomEncodingSelectionFactory(
+    uint64_t seed) {
+  nimble::testing::RandomEncodingSelectionPolicyFactory factory{seed};
+  return [factory = std::move(factory)](nimble::DataType dataType)
+             -> std::unique_ptr<nimble::EncodingSelectionPolicyBase> {
+    return factory.createPolicy(dataType);
+  };
+}
+
+// Writes |vector| to an in-memory Nimble file using |creator| for encoding
+// selection.
+std::string writeWithEncodingSelectionCreator(
+    velox::memory::MemoryPool& rootPool,
+    const velox::RowVectorPtr& vector,
+    nimble::EncodingSelectionPolicyCreator creator) {
+  nimble::VeloxWriterOptions options;
+  options.encodingSelectionPolicyCreator = std::move(creator);
+  std::string file;
+  auto writeFile = std::make_unique<velox::InMemoryWriteFile>(&file);
+  nimble::VeloxWriter writer(
+      vector->type(), std::move(writeFile), rootPool, std::move(options));
+  writer.write(vector);
+  writer.close();
+  return file;
+}
+
+// A schema spanning the scalar physical types plus array/map/row nesting, so
+// the random policy is exercised across every per-type compatible encoding set.
+velox::RowTypePtr randomEncodingSelectionTestType() {
+  return velox::ROW({
+      {"i8", velox::TINYINT()},
+      {"i32", velox::INTEGER()},
+      {"i64", velox::BIGINT()},
+      {"f32", velox::REAL()},
+      {"f64", velox::DOUBLE()},
+      {"b", velox::BOOLEAN()},
+      {"s", velox::VARCHAR()},
+      {"arr", velox::ARRAY(velox::INTEGER())},
+      {"map", velox::MAP(velox::VARCHAR(), velox::BIGINT())},
+      {"nested",
+       velox::ROW({{"n1", velox::INTEGER()}, {"n2", velox::VARCHAR()}})},
+  });
 }
 
 nimble::EncodingLayout captureFirstColumnEncoding(
@@ -8136,4 +8181,89 @@ DEBUG_ONLY_TEST_F(VeloxWriterTest, parallelEncodeFlatMapTaskCount) {
   EXPECT_EQ(result->size(), numBatches * 100);
 }
 
+// Fuzzer data written with the random encoding selection policy round-trips for
+// every seed: the policy only ever picks encodings compatible with the data
+// (via EncodingSizeEstimation), so no stream needs the writer's one-shot
+// IncompatibleEncoding fallback. Regression seeds are pinned first; drive
+// breadth with --stress-runs.
+TEST_F(VeloxWriterTest, randomEncodingSelectionRoundTrip) {
+  const auto rowType = randomEncodingSelectionTestType();
+  std::vector<uint32_t> seeds = {1u, 7u, 42u};
+  seeds.push_back(
+      FLAGS_writer_tests_seed > 0 ? FLAGS_writer_tests_seed
+                                  : folly::Random::rand32());
+
+  for (const uint32_t seed : seeds) {
+    LOG(INFO) << "randomEncodingSelectionRoundTrip seed: " << seed;
+    velox::VectorFuzzer::Options fuzzerOptions;
+    fuzzerOptions.vectorSize = 500;
+    fuzzerOptions.nullRatio = 0.2;
+    fuzzerOptions.stringLength = 16;
+    fuzzerOptions.containerLength = 6;
+    fuzzerOptions.containerVariableLength = true;
+    velox::VectorFuzzer fuzzer(fuzzerOptions, leafPool_.get(), seed);
+    auto vector = fuzzer.fuzzInputFlatRow(rowType);
+
+    const auto file = writeWithEncodingSelectionCreator(
+        *rootPool_, vector, createRandomEncodingSelectionFactory(seed));
+
+    auto readFile = std::make_shared<velox::InMemoryReadFile>(file);
+    nimble::VeloxReader reader(readFile.get(), *leafPool_);
+    velox::VectorPtr result;
+    ASSERT_TRUE(reader.next(vector->size(), result));
+    ASSERT_EQ(result->size(), vector->size());
+    for (velox::vector_size_t i = 0; i < vector->size(); ++i) {
+      ASSERT_TRUE(vector->equalValueAt(result.get(), i, i))
+          << "mismatch at row " << i << " (seed " << seed << ")";
+    }
+    ASSERT_FALSE(reader.next(1, result));
+  }
+}
+
+// The random layout is reproducible from its seed: identical input + seed
+// yields byte-identical files (Nimble writer output is deterministic for
+// identical input). Concurrency-independence is guaranteed by construction --
+// each policy derives its seed from its structural path, never from encode
+// thread order, and shares no state across the encode executor's threads -- so
+// it is not exercised here (it would depend on the coroutine encode path). A
+// different seed selects a different layout.
+TEST_F(VeloxWriterTest, randomEncodingSelectionDeterministic) {
+  const uint32_t seed = FLAGS_writer_tests_seed > 0 ? FLAGS_writer_tests_seed
+                                                    : folly::Random::rand32();
+  LOG(INFO) << "randomEncodingSelectionDeterministic seed: " << seed;
+
+  const auto rowType = randomEncodingSelectionTestType();
+  velox::VectorFuzzer::Options fuzzerOptions;
+  fuzzerOptions.vectorSize = 500;
+  fuzzerOptions.nullRatio = 0.2;
+  fuzzerOptions.stringLength = 16;
+  fuzzerOptions.containerLength = 6;
+  fuzzerOptions.containerVariableLength = true;
+  velox::VectorFuzzer fuzzer(fuzzerOptions, leafPool_.get(), seed);
+  auto vector = fuzzer.fuzzInputFlatRow(rowType);
+
+  const auto file = writeWithEncodingSelectionCreator(
+      *rootPool_, vector, createRandomEncodingSelectionFactory(seed));
+  // Same seed reproduces the exact file.
+  EXPECT_EQ(
+      file,
+      writeWithEncodingSelectionCreator(
+          *rootPool_, vector, createRandomEncodingSelectionFactory(seed)));
+  // A different seed should be able to select a different layout. For a given
+  // fuzzed input some nodes may have a singleton compatible-encoding set, so an
+  // individual alternate seed can legitimately reproduce the same file; only
+  // require that at least one of several distinct alternate seeds diverges,
+  // which proves the seed drives the layout without flaking on such inputs. XOR
+  // a nonzero delta so every alternate seed stays distinct with no wraparound.
+  bool anyDifferent = false;
+  for (uint32_t delta = 1; delta <= 8 && !anyDifferent; ++delta) {
+    anyDifferent =
+        writeWithEncodingSelectionCreator(
+            *rootPool_,
+            vector,
+            createRandomEncodingSelectionFactory(seed ^ delta)) != file;
+  }
+  EXPECT_TRUE(anyDifferent)
+      << "no alternate seed produced a different layout for seed " << seed;
+}
 } // namespace facebook

--- a/dwio/nimble/velox/writer/EncodingSelectionPolicyFactory.cpp
+++ b/dwio/nimble/velox/writer/EncodingSelectionPolicyFactory.cpp
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "dwio/nimble/velox/writer/EncodingSelectionPolicyFactory.h"
+
+#include <folly/String.h>
+#include <vector>
+
+#include "dwio/nimble/encodings/selection/tests/RandomEncodingSelectionPolicy.h"
+
+namespace facebook::nimble {
+
+namespace {
+
+// Reads the "type" from a "type:...,key:value,..." config without consuming it;
+// the selected factory re-reads the whole config itself. Returns an empty view
+// when there is no "type" entry.
+std::string_view peekEncodingSelectionType(std::string_view configStr) {
+  std::vector<std::string_view> entries;
+  folly::split(',', configStr, entries);
+  for (const auto entry : entries) {
+    const auto colonPos = entry.find(':');
+    if (colonPos != std::string_view::npos &&
+        entry.substr(0, colonPos) == "type") {
+      return entry.substr(colonPos + 1);
+    }
+  }
+  return {};
+}
+
+} // namespace
+
+std::optional<EncodingSelectionPolicyCreator>
+createEncodingSelectionPolicyFactory(
+    std::string_view configStr,
+    std::optional<CompressionOptions> compressionOptions) {
+  if (configStr.empty()) {
+    return std::nullopt;
+  }
+  // Peek (do not consume) "type" to pick the factory; the factory parses the
+  // whole config itself. A non-empty config with no "type" is malformed (an
+  // empty config was handled above).
+  const auto type = peekEncodingSelectionType(configStr);
+  NIMBLE_USER_CHECK(
+      !type.empty(),
+      "nimble.encoding_selection_config '{}' is missing a 'type'.",
+      configStr);
+  if (type == "random") {
+    return
+        [factory = testing::RandomEncodingSelectionPolicyFactory::create(
+             configStr, std::move(compressionOptions))](
+            DataType dataType) -> std::unique_ptr<EncodingSelectionPolicyBase> {
+          return factory.createPolicy(dataType);
+        };
+  }
+  NIMBLE_USER_FAIL(
+      "Invalid nimble.encoding_selection_config type '{}'. Valid: 'random'.",
+      type);
+}
+
+} // namespace facebook::nimble

--- a/dwio/nimble/velox/writer/EncodingSelectionPolicyFactory.h
+++ b/dwio/nimble/velox/writer/EncodingSelectionPolicyFactory.h
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <optional>
+#include <string_view>
+
+#include "dwio/nimble/encodings/selection/EncodingSelectionPolicy.h"
+
+namespace facebook::nimble {
+
+/// Builds an EncodingSelectionPolicyCreator from a
+/// nimble.encoding_selection_config string of the form
+/// "type:<t>,key:value,...". The "type" selects which encoding-selection
+/// factory to build; that factory then parses the whole config itself.
+/// Currently supported:
+///   type:random,seed:<n>[,encodings:<E1>;<E2>;...] ->
+///       RandomEncodingSelectionPolicy (test/fuzz only).
+/// An absent config or absent type returns nullopt, so the caller keeps the
+/// default (manual) encoding selection. A malformed entry, unknown key,
+/// unparseable value, or unknown type is a NimbleUserError.
+std::optional<EncodingSelectionPolicyCreator>
+createEncodingSelectionPolicyFactory(
+    std::string_view configStr,
+    std::optional<CompressionOptions> compressionOptions =
+        CompressionOptions{});
+
+} // namespace facebook::nimble


### PR DESCRIPTION
Summary:

Replaces the config-string `EncodingLayoutTree`-replay hack with a proper `RandomEncodingSelectionPolicy<T>` that the table-evolution fuzzer uses to exercise diverse, valid encoding layouts.

- `RandomEncodingSelectionPolicy<T>` / `RandomEncodingSelectionPolicyFactory` (`dwio/nimble/encodings/selection/EncodingSelectionPolicy.{h,cpp}`): for each stream, pick uniformly at random among the encodings `EncodingSizeEstimation` deems compatible with the data. estimateSize already encodes every type/statistic constraint (no `Dictionary`/`FixedBitWidth`/`Varint` on bool, `Varint` only on integers, `Constant` only for a single unique value) and empty streams fall back to `Trivial`, so the writer's one-shot `IncompatibleEncoding` retry is never relied on.
- Per-node deterministic seeding: each policy derives its seed from `hash_combine(baseSeed, parentEncoding, childSlot)`, so the whole layout is reproducible from a single seed regardless of encode thread order (selection runs concurrently on the encoding executor). `createImpl` excludes ancestor encodings, guaranteeing convergence.
- Serializable config `nimble.encoding_selection_config` (mirrors `nimble.flush_policy_config`): `"seed:<n>[,encodings:<E1>;<E2>;...]"`. `RandomEncodingSelectionPolicyFactory::create()` parses it (empty -> keep the default manual policy; `NimbleUserError` on malformed input); `NimbleWriterOptionBuilder` installs the random creator when configured, else the manual default.
- `TableEvolutionFuzzer` emits the config for ~1/2 of files, reproducible from `FLAGS_seed`.

Removes the `buildRandomEncodingLayoutTree` / `randomScalarEncodingLayout` helpers and the `TEST_ONLY_ENCODING_LAYOUT_SEED` knob.

Reviewed By: xiaoxmeng

Differential Revision: D110052628


