### PR TITLE
feat(nimble_dump): Print schema-node attributes

### DIFF
--- a/dwio/nimble/tools/NimbleDumpLib.cpp
+++ b/dwio/nimble/tools/NimbleDumpLib.cpp
@@ -603,6 +603,20 @@ void NimbleDumpLib::emitSchema(bool collapseFlatMap) {
             ostream_ << "<" << toString(type.asFlatMap().keyScalarKind())
                      << ">";
           }
+
+          // Surface per-node schema attributes (e.g. Iceberg `iceberg.id`
+          // field-ids) so they are visible when inspecting a dumped schema.
+          const auto& attributes = type.attributes();
+          if (!attributes.empty()) {
+            ostream_ << " {";
+            for (size_t i = 0; i < attributes.size(); ++i) {
+              if (i > 0) {
+                ostream_ << ", ";
+              }
+              ostream_ << attributes[i].first << "=" << attributes[i].second;
+            }
+            ostream_ << "}";
+          }
           ostream_ << std::endl;
         }
       });

--- a/dwio/nimble/tools/tests/NimbleDumpLibTest.cpp
+++ b/dwio/nimble/tools/tests/NimbleDumpLibTest.cpp
@@ -189,3 +189,39 @@ TEST_F(NimbleDumpLibTest, EmitStats_NoStats) {
   auto result = output.str();
   EXPECT_NE(result.find("No stats section found"), std::string::npos);
 }
+
+TEST_F(NimbleDumpLibTest, EmitSchema_PrintsColumnAttributes) {
+  auto type = velox::ROW({"id", "name"}, {velox::BIGINT(), velox::VARCHAR()});
+
+  auto idVector =
+      velox::BaseVector::create(velox::BIGINT(), 1, leafPool_.get());
+  idVector->asFlatVector<int64_t>()->set(0, 42);
+  auto nameVector =
+      velox::BaseVector::create(velox::VARCHAR(), 1, leafPool_.get());
+  nameVector->asFlatVector<velox::StringView>()->set(0, velox::StringView("a"));
+
+  auto rowVector = std::make_shared<velox::RowVector>(
+      leafPool_.get(),
+      type,
+      nullptr,
+      1,
+      std::vector<velox::VectorPtr>{idVector, nameVector});
+
+  // Stamp Iceberg field-ids onto the top-level columns (as the write path does)
+  // and confirm the dumped schema round-trips and surfaces them.
+  VeloxWriterOptions writerOptions;
+  writerOptions.attributesByColumn = {
+      {"id", {{"iceberg.id", "1"}}}, {"name", {{"iceberg.id", "2"}}}};
+
+  auto fileContent =
+      test::createNimbleFile(*leafPool_, rowVector, writerOptions);
+  auto readFile = makeReadFile(fileContent);
+
+  std::ostringstream output;
+  tools::NimbleDumpLib dumpLib{readFile, false, output};
+  dumpLib.emitSchema(/*collapseFlatMap=*/false);
+
+  auto result = output.str();
+  EXPECT_NE(result.find("iceberg.id=1"), std::string::npos);
+  EXPECT_NE(result.find("iceberg.id=2"), std::string::npos);
+}


### PR DESCRIPTION
Summary:
`nimble_dump`'s `schema` subcommand now prints each `SchemaNode`'s string
attributes (e.g. `iceberg.id`) as a trailing `{key=value, ...}`. They were
previously dropped, so Iceberg field-ids stamped into a Nimble file were
invisible when inspecting the schema -- which is the primary way to verify a
field-id write.

The attributes were already reachable via `Type::attributes()` (populated from
the FlatBuffer `attributes` section); this only adds them to the printed node
line and is a no-op for files that carry no attributes.

Differential Revision: D113364395


