### PR TITLE
feat(flatmap): Raise default flat-map key cap to 200k

### DIFF
--- a/dwio/nimble/velox/NimbleConfig.h
+++ b/dwio/nimble/velox/NimbleConfig.h
@@ -24,7 +24,7 @@ namespace facebook::nimble {
 // Default cap on the number of distinct flat-map keys per file; 0 means
 // unlimited. Shared default for Config::MAP_FLAT_MAX_KEYS,
 // VeloxWriterOptions::maxFlatMapKeys, and FieldWriterContext::maxFlatMapKeys_.
-inline constexpr uint32_t kDefaultMaxFlatMapKeys = 30000;
+inline constexpr uint32_t kDefaultMaxFlatMapKeys = 200000;
 
 class Config : public velox::config::ConfigBase {
  public:


### PR DESCRIPTION
Summary: Raise the default cap on distinct flat-map keys per file (`kDefaultMaxFlatMapKeys`, `dwio/nimble/velox/NimbleConfig.h`) from 30,000 to 200,000. It is the shared default for `Config::MAP_FLAT_MAX_KEYS` (serde `orc.map.flat.max.keys`), `VeloxWriterOptions::maxFlatMapKeys`, and `FieldWriterContext::maxFlatMapKeys_`, so the higher cap applies wherever no explicit override is set. Tables can still set `orc.map.flat.max.keys` in their serde to pick a different cap (0 = unlimited).

Differential Revision: D113424311


