### PR TITLE
perf(encoding): Non-byte section packing for SubIntSplit compared to black-box compression

### DIFF
--- a/dwio/nimble/encodings/SubIntSplitCostModels.h
+++ b/dwio/nimble/encodings/SubIntSplitCostModels.h
@@ -88,11 +88,12 @@ inline double fixedBitWidthCostBits(
       m.range == 0 ? uint8_t{0} : static_cast<uint8_t>(std::bit_width(m.range));
   const uint8_t packedBits =
       std::min<uint8_t>(static_cast<uint8_t>(bitWidth), rangeWidth);
-  // Round up to byte boundary (matches nimble's current FixedBitWidth impl).
-  const uint8_t roundedBits = (packedBits + 7u) & ~7u;
+  // Sections are packed at their exact bit width (SubIntSplit encodes nested
+  // sections with fixedBitWidthUseExactBits), so there is no byte-boundary
+  // rounding: a 12-bit section costs 12 bits/value, not 16.
 
   return headerBits +
-      static_cast<double>(roundedBits) * static_cast<double>(numValues);
+      static_cast<double>(packedBits) * static_cast<double>(numValues);
 }
 
 // Constant: zero cost when all values are equal, infinity otherwise.

--- a/dwio/nimble/encodings/SubIntSplitEncoding.h
+++ b/dwio/nimble/encodings/SubIntSplitEncoding.h
@@ -773,6 +773,14 @@ std::string_view SubIntSplitEncoding<T>::encode(
   std::vector<std::string_view> sectionData;
   sectionData.reserve(splitCount);
 
+  // Pack each section at its exact bit width instead of rounding up to a byte,
+  // so e.g. a 12-bit section costs 12 bits/value rather than 16. Sections
+  // dominate the encoded size for multi-field values, where byte rounding
+  // wasted up to 7 bits/value per section. FixedBitWidth records its own bit
+  // width, so the decode path is unaffected.
+  Encoding::Options sectionOptions = options;
+  sectionOptions.fixedBitWidthUseExactBits = true;
+
   for (uint8_t s = 0; s < splitCount; ++s) {
     const auto& seg = segments[s];
     const int bitStart = seg.bitStart;
@@ -796,7 +804,7 @@ std::string_view SubIntSplitEncoding<T>::encode(
             std::span<const uint8_t>(
                 sectionValues.data(), sectionValues.size()),
             sectionBuffer,
-            options);
+            sectionOptions);
         break;
       }
       case 2: {
@@ -811,7 +819,7 @@ std::string_view SubIntSplitEncoding<T>::encode(
             std::span<const uint16_t>(
                 sectionValues.data(), sectionValues.size()),
             sectionBuffer,
-            options);
+            sectionOptions);
         break;
       }
       case 4: {
@@ -826,7 +834,7 @@ std::string_view SubIntSplitEncoding<T>::encode(
             std::span<const uint32_t>(
                 sectionValues.data(), sectionValues.size()),
             sectionBuffer,
-            options);
+            sectionOptions);
         break;
       }
       case 8: {
@@ -841,7 +849,7 @@ std::string_view SubIntSplitEncoding<T>::encode(
             std::span<const uint64_t>(
                 sectionValues.data(), sectionValues.size()),
             sectionBuffer,
-            options);
+            sectionOptions);
         break;
       }
       default: {


### PR DESCRIPTION
Summary:
### Summary
SubIntSplit splits each value into bit-range sections, each bit-packed by a nested FixedBitWidth. That packer previously rounded each section's width up to a byte. This diff makes sections pack at their exact width and updates the DP cost model to value exact widths so the selector picks accordingly.


### Evaluations on different data pattern on storage savings

Storage / Compression ratio: 

```
Pattern            OFF  ->  ON     delta
LowCard16          8.00 -> 16.00   +100%   (4-bit values wasted 4 bits/byte)
SnowflakeMultiDc   3.55 ->  6.94   +95%
Sequential         7.94 -> 14.21   +79%
LowCard1024        4.00 ->  6.40   +60%
Snowflake          6.96 -> 10.17   +46%
TimestampMs        7.82 -> 11.00   +41%
Zipfian4096        4.75 ->  5.33   +12%
MultiField         1.97 ->  2.10   +7%
MostlyZero        72.95 -> 76.62   +5%
Sorted             3.95 ->  3.81   -4%   (only regression)
Narrow*/BitStruct*/LowCard256/64K: unchanged (already byte-aligned widths)
```
This lever flips SnowflakeMultiDc, MostlyZero and Zipfian to beating OpenZL on
ratio. Correctness: bit-exact round-trip across all 6 physical types.

Differential Revision: D113380975


