### PR TITLE
feat(nimble): Unify Velox writer index configuration through IndexConfig (#1015)

### DIFF
--- a/dwio/nimble/common/Types.cpp
+++ b/dwio/nimble/common/Types.cpp
@@ -15,63 +15,71 @@
  */
 #include "dwio/nimble/common/Types.h"
 
+#include <array>
+
 #include "dwio/nimble/common/Exceptions.h"
 
 namespace facebook::nimble {
+namespace {
+
+constexpr auto kEncodingTypes =
+    std::to_array<std::pair<EncodingType, std::string_view>>({
+        {EncodingType::Trivial, "Trivial"},
+        {EncodingType::RLE, "RLE"},
+        {EncodingType::Dictionary, "Dictionary"},
+        {EncodingType::FixedBitWidth, "FixedBitWidth"},
+        {EncodingType::Sentinel, "Sentinel"},
+        {EncodingType::Nullable, "Nullable"},
+        {EncodingType::SparseBool, "SparseBool"},
+        {EncodingType::Varint, "Varint"},
+        {EncodingType::Delta, "Delta"},
+        {EncodingType::Constant, "Constant"},
+        {EncodingType::MainlyConstant, "MainlyConstant"},
+        {EncodingType::Prefix, "Prefix"},
+        {EncodingType::ALP, "ALP"},
+        {EncodingType::PFOR, "PFOR"},
+        {EncodingType::SimdForBitpack, "SimdForBitpack"},
+        {EncodingType::BlockBitPacking, "BlockBitPacking"},
+        {EncodingType::SubIntSplit, "SubIntSplit"},
+        {EncodingType::FrequencyPartition, "FrequencyPartition"},
+        {EncodingType::FOR, "FOR"},
+        {EncodingType::Fsst, "Fsst"},
+        {EncodingType::Huffman, "Huffman"},
+        {EncodingType::DeltaBlock, "DeltaBlock"},
+    });
+
+constexpr auto kCompressionTypes =
+    std::to_array<std::pair<CompressionType, std::string_view>>({
+        {CompressionType::Uncompressed, "Uncompressed"},
+        {CompressionType::Zstd, "Zstd"},
+        {CompressionType::MetaInternal, "MetaInternal"},
+        {CompressionType::Lz4, "Lz4"},
+        {CompressionType::OpenZL, "OpenZL"},
+    });
+
+} // namespace
 
 std::ostream& operator<<(std::ostream& out, EncodingType encodingType) {
   return out << toString(encodingType);
 }
 
 std::string toString(EncodingType encodingType) {
-  switch (encodingType) {
-    case EncodingType::Trivial:
-      return "Trivial";
-    case EncodingType::RLE:
-      return "RLE";
-    case EncodingType::Dictionary:
-      return "Dictionary";
-    case EncodingType::FixedBitWidth:
-      return "FixedBitWidth";
-    case EncodingType::Nullable:
-      return "Nullable";
-    case EncodingType::SparseBool:
-      return "SparseBool";
-    case EncodingType::Varint:
-      return "Varint";
-    case EncodingType::Delta:
-      return "Delta";
-    case EncodingType::Constant:
-      return "Constant";
-    case EncodingType::MainlyConstant:
-      return "MainlyConstant";
-    case EncodingType::FrequencyPartition:
-      return "FrequencyPartition";
-    case EncodingType::FOR:
-      return "FOR";
-    case EncodingType::Sentinel:
-      return "Sentinel";
-    case EncodingType::Prefix:
-      return "Prefix";
-    case EncodingType::ALP:
-      return "ALP";
-    case EncodingType::Fsst:
-      return "Fsst";
-    case EncodingType::Huffman:
-      return "Huffman";
-    case EncodingType::PFOR:
-      return "PFOR";
-    case EncodingType::SimdForBitpack:
-      return "SimdForBitpack";
-    case EncodingType::SubIntSplit:
-      return "SubIntSplit";
-    case EncodingType::BlockBitPacking:
-      return "BlockBitPacking";
-    case EncodingType::DeltaBlock:
-      return "DeltaBlock";
+  for (const auto& [type, name] : kEncodingTypes) {
+    if (encodingType == type) {
+      return std::string{name};
+    }
   }
   return fmt::format(
       "Unknown encoding type: {}", static_cast<int32_t>(encodingType));
+}
+
+EncodingType toEncodingType(std::string_view name) {
+  for (const auto& [type, candidate] : kEncodingTypes) {
+    if (name == candidate) {
+      return type;
+    }
+  }
+  NIMBLE_USER_FAIL("Unknown encoding type: {}", name);
 }
 
 std::ostream& operator<<(std::ostream& out, DataType dataType) {
@@ -111,22 +119,22 @@ std::string toString(DataType dataType) {
 }
 
 std::string toString(CompressionType compressionType) {
-  switch (compressionType) {
-    case CompressionType::Uncompressed:
-      return "Uncompressed";
-    case CompressionType::Zstd:
-      return "Zstd";
-    case CompressionType::MetaInternal:
-      return "MetaInternal";
-    case CompressionType::Lz4:
-      return "Lz4";
-    case CompressionType::OpenZL:
-      return "OpenZL";
-    default:
-      return fmt::format(
-          "Unknown compression type: {}",
-          static_cast<int32_t>(compressionType));
+  for (const auto& [type, name] : kCompressionTypes) {
+    if (compressionType == type) {
+      return std::string{name};
+    }
   }
+  return fmt::format(
+      "Unknown compression type: {}", static_cast<int32_t>(compressionType));
+}
+
+CompressionType toCompressionType(std::string_view name) {
+  for (const auto& [type, candidate] : kCompressionTypes) {
+    if (name == candidate) {
+      return type;
+    }
+  }
+  NIMBLE_USER_FAIL("Unknown compression type: {}", name);
 }
 
 std::ostream& operator<<(std::ostream& out, CompressionType compressionType) {

--- a/dwio/nimble/common/Types.h
+++ b/dwio/nimble/common/Types.h
@@ -16,6 +16,7 @@
 #pragma once
 
 #include <memory>
+#include <optional>
 #include <string>
 #include <string_view>
 #include <variant>
@@ -157,6 +158,8 @@ enum class EncodingType {
   DeltaBlock = 21,
 };
 std::string toString(EncodingType encodingType);
+/// Returns the encoding type for 'name'. Throws if 'name' is unknown.
+EncodingType toEncodingType(std::string_view name);
 std::ostream& operator<<(std::ostream& out, EncodingType encodingType);
 
 enum class DataType : uint8_t {
@@ -190,6 +193,8 @@ enum class CompressionType : uint8_t {
 };
 
 std::string toString(CompressionType compressionType);
+/// Returns the compression type for 'name'. Throws if 'name' is unknown.
+CompressionType toCompressionType(std::string_view name);
 std::ostream& operator<<(std::ostream& out, CompressionType compressionType);
 
 enum class ChecksumType : uint8_t { XXH3_64 = 0 };

--- a/dwio/nimble/common/tests/TypesTest.cpp
+++ b/dwio/nimble/common/tests/TypesTest.cpp
@@ -25,26 +25,45 @@ namespace facebook::nimble::test {
 
 // --- toString for EncodingType ---
 
-TEST(TypesTest, EncodingTypeToString) {
-  EXPECT_EQ(toString(EncodingType::Trivial), "Trivial");
-  EXPECT_EQ(toString(EncodingType::RLE), "RLE");
-  EXPECT_EQ(toString(EncodingType::Dictionary), "Dictionary");
-  EXPECT_EQ(toString(EncodingType::FixedBitWidth), "FixedBitWidth");
-  EXPECT_EQ(toString(EncodingType::Sentinel), "Sentinel");
-  EXPECT_EQ(toString(EncodingType::Nullable), "Nullable");
-  EXPECT_EQ(toString(EncodingType::SparseBool), "SparseBool");
-  EXPECT_EQ(toString(EncodingType::Varint), "Varint");
-  EXPECT_EQ(toString(EncodingType::Delta), "Delta");
-  EXPECT_EQ(toString(EncodingType::Constant), "Constant");
-  EXPECT_EQ(toString(EncodingType::MainlyConstant), "MainlyConstant");
-  EXPECT_EQ(toString(EncodingType::Prefix), "Prefix");
-  EXPECT_EQ(toString(EncodingType::ALP), "ALP");
-  EXPECT_EQ(toString(EncodingType::BlockBitPacking), "BlockBitPacking");
+TEST(TypesTest, EncodingTypeStringConversion) {
+  const std::vector<std::pair<EncodingType, std::string_view>> testCases{
+      {EncodingType::Trivial, "Trivial"},
+      {EncodingType::RLE, "RLE"},
+      {EncodingType::Dictionary, "Dictionary"},
+      {EncodingType::FixedBitWidth, "FixedBitWidth"},
+      {EncodingType::Sentinel, "Sentinel"},
+      {EncodingType::Nullable, "Nullable"},
+      {EncodingType::SparseBool, "SparseBool"},
+      {EncodingType::Varint, "Varint"},
+      {EncodingType::Delta, "Delta"},
+      {EncodingType::Constant, "Constant"},
+      {EncodingType::MainlyConstant, "MainlyConstant"},
+      {EncodingType::Prefix, "Prefix"},
+      {EncodingType::ALP, "ALP"},
+      {EncodingType::PFOR, "PFOR"},
+      {EncodingType::SimdForBitpack, "SimdForBitpack"},
+      {EncodingType::BlockBitPacking, "BlockBitPacking"},
+      {EncodingType::SubIntSplit, "SubIntSplit"},
+      {EncodingType::FrequencyPartition, "FrequencyPartition"},
+      {EncodingType::FOR, "FOR"},
+      {EncodingType::Fsst, "Fsst"},
+      {EncodingType::Huffman, "Huffman"},
+      {EncodingType::DeltaBlock, "DeltaBlock"},
+  };
+  for (const auto& [type, name] : testCases) {
+    SCOPED_TRACE(name);
+    EXPECT_EQ(toString(type), name);
+    EXPECT_EQ(toEncodingType(name), type);
+  }
 }
 
 TEST(TypesTest, EncodingTypeToStringUnknown) {
   auto result = toString(static_cast<EncodingType>(255));
   EXPECT_NE(result.find("Unknown"), std::string::npos);
+}
+
+TEST(TypesTest, ToEncodingTypeUnknown) {
+  EXPECT_ANY_THROW(toEncodingType("unknown"));
 }
 
 TEST(TypesTest, EncodingTypeStreamOperator) {
@@ -88,16 +107,28 @@ TEST(TypesTest, DataTypeFmtFormat) {
 
 // --- toString for CompressionType ---
 
-TEST(TypesTest, CompressionTypeToString) {
-  EXPECT_EQ(toString(CompressionType::Uncompressed), "Uncompressed");
-  EXPECT_EQ(toString(CompressionType::Zstd), "Zstd");
-  EXPECT_EQ(toString(CompressionType::MetaInternal), "MetaInternal");
-  EXPECT_EQ(toString(CompressionType::Lz4), "Lz4");
+TEST(TypesTest, CompressionTypeStringConversion) {
+  const std::vector<std::pair<CompressionType, std::string_view>> testCases{
+      {CompressionType::Uncompressed, "Uncompressed"},
+      {CompressionType::Zstd, "Zstd"},
+      {CompressionType::MetaInternal, "MetaInternal"},
+      {CompressionType::Lz4, "Lz4"},
+      {CompressionType::OpenZL, "OpenZL"},
+  };
+  for (const auto& [type, name] : testCases) {
+    SCOPED_TRACE(name);
+    EXPECT_EQ(toString(type), name);
+    EXPECT_EQ(toCompressionType(name), type);
+  }
 }
 
 TEST(TypesTest, CompressionTypeToStringUnknown) {
   auto result = toString(static_cast<CompressionType>(200));
   EXPECT_NE(result.find("Unknown"), std::string::npos);
+}
+
+TEST(TypesTest, ToCompressionTypeUnknown) {
+  EXPECT_ANY_THROW(toCompressionType("unknown"));
 }
 
 TEST(TypesTest, CompressionTypeStreamOperator) {

--- a/dwio/nimble/index/ClusterIndexFactory.cpp
+++ b/dwio/nimble/index/ClusterIndexFactory.cpp
@@ -17,6 +17,7 @@
 
 #include <optional>
 
+#include "dwio/nimble/common/Exceptions.h"
 #include "dwio/nimble/index/ClusterIndex.h"
 #include "dwio/nimble/index/ClusterIndexWriter.h"
 #include "dwio/nimble/index/IndexFactoryRegistry.h"
@@ -38,11 +39,15 @@ class NimbleClusterIndexFactory final : public ClusterIndexFactory {
   }
 
   std::unique_ptr<IndexWriter> createWriter(
-      const ClusterIndexConfig& config,
+      const IndexConfig& config,
       const velox::TypePtr& inputType,
       velox::memory::MemoryPool* pool) const override {
+    NIMBLE_USER_CHECK_EQ(config.family, IndexFamily::Cluster);
+    NIMBLE_USER_CHECK_EQ(config.name, name());
     return ClusterIndexWriter::create(
-        std::optional<ClusterIndexConfig>{config}, inputType, pool);
+        std::optional<ClusterIndexConfig>{toClusterIndexConfig(config)},
+        inputType,
+        pool);
   }
 
   std::unique_ptr<IndexKeyEncoder> createKeyEncoder(

--- a/dwio/nimble/index/ClusterIndexFactory.h
+++ b/dwio/nimble/index/ClusterIndexFactory.h
@@ -37,7 +37,7 @@ class ClusterIndexFactory {
   virtual std::string_view name() const = 0;
 
   virtual std::unique_ptr<IndexWriter> createWriter(
-      const ClusterIndexConfig& config,
+      const IndexConfig& config,
       const velox::TypePtr& inputType,
       velox::memory::MemoryPool* pool) const = 0;
 

--- a/dwio/nimble/index/DenseIndexFactory.cpp
+++ b/dwio/nimble/index/DenseIndexFactory.cpp
@@ -153,6 +153,16 @@ class HashIndexFactory final : public DenseIndexFactory {
     return kDenseHashIndexName;
   }
 
+  std::unique_ptr<IndexWriter> createWriter(
+      const IndexConfig& config,
+      const velox::TypePtr& inputType,
+      velox::memory::MemoryPool* pool) const override {
+    NIMBLE_USER_CHECK_EQ(config.family, IndexFamily::Dense);
+    NIMBLE_USER_CHECK_EQ(config.name, name());
+    return HashIndexWriter::create(
+        {toHashIndexConfig(config)}, inputType, pool);
+  }
+
   std::unique_ptr<DenseIndexReader> createReader(
       Section rootSection,
       const IndexLookup::Options& options,
@@ -177,6 +187,16 @@ class SortedIndexFactory final : public DenseIndexFactory {
  public:
   std::string_view name() const override {
     return kDenseSortedIndexName;
+  }
+
+  std::unique_ptr<IndexWriter> createWriter(
+      const IndexConfig& config,
+      const velox::TypePtr& inputType,
+      velox::memory::MemoryPool* pool) const override {
+    NIMBLE_USER_CHECK_EQ(config.family, IndexFamily::Dense);
+    NIMBLE_USER_CHECK_EQ(config.name, name());
+    return SortedIndexWriter::create(
+        {toSortedIndexConfig(config)}, inputType, pool);
   }
 
   std::unique_ptr<DenseIndexReader> createReader(

--- a/dwio/nimble/index/DenseIndexFactory.h
+++ b/dwio/nimble/index/DenseIndexFactory.h
@@ -17,8 +17,10 @@
 
 #include "dwio/nimble/index/IndexConfig.h"
 #include "dwio/nimble/index/IndexLookup.h"
+#include "dwio/nimble/index/IndexWriter.h"
 #include "dwio/nimble/tablet/MetadataBuffer.h"
 #include "velox/common/memory/Memory.h"
+#include "velox/type/Type.h"
 
 namespace facebook::nimble::index {
 
@@ -43,6 +45,12 @@ class DenseIndexFactory {
   virtual ~DenseIndexFactory() = default;
 
   virtual std::string_view name() const = 0;
+
+  /// Creates a non-null writer for one index configuration.
+  virtual std::unique_ptr<IndexWriter> createWriter(
+      const IndexConfig& config,
+      const velox::TypePtr& inputType,
+      velox::memory::MemoryPool* pool) const = 0;
 
   /// Creates a non-null reader. The reader's index column topology must remain
   /// immutable for its lifetime.

--- a/dwio/nimble/index/IndexConfig.cpp
+++ b/dwio/nimble/index/IndexConfig.cpp
@@ -13,11 +13,262 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#include "dwio/nimble/index/IndexSerialization.h"
+#include "dwio/nimble/index/IndexConfig.h"
+
+#include <exception>
+
+#include <folly/json.h>
 
 #include "dwio/nimble/common/Exceptions.h"
+#include "dwio/nimble/index/IndexSerialization.h"
+#include "velox/common/config/Config.h"
 
 namespace facebook::nimble::index {
+namespace {
+
+using ConfigBase = velox::config::ConfigBase;
+
+constexpr std::string_view kKeyColumns{"columns"};
+constexpr std::string_view kSortOrders{"sortOrders"};
+constexpr std::string_view kEnforceKeyOrder{"enforceKeyOrder"};
+constexpr std::string_view kNoDuplicateKey{"noDuplicateKey"};
+constexpr std::string_view kEncodingLayout{"encodingLayout"};
+constexpr std::string_view kMaxRowsPerKeyChunk{"maxRowsPerKeyChunk"};
+constexpr std::string_view kKeyChunkCompressionType{"keyChunkCompressionType"};
+constexpr std::string_view kLoadFactor{"loadFactor"};
+constexpr std::string_view kBloomFilterBitsPerKey{"bloomFilter.bitsPerKey"};
+constexpr std::string_view kMaxPartitionSizeBytes{"maxPartitionSizeBytes"};
+
+// ConfigBase stores values as strings. These helpers provide JSON codecs for
+// structured built-in index options.
+folly::dynamic parseJson(const std::string& key, const std::string& value) {
+  try {
+    return folly::parseJson(value);
+  } catch (const std::exception& error) {
+    NIMBLE_USER_FAIL(
+        "Invalid JSON for index configuration '{}': {}", key, error.what());
+  }
+}
+
+std::vector<std::string> parseStrings(
+    const std::string& key,
+    const std::string& value) {
+  auto json = parseJson(key, value);
+  NIMBLE_USER_CHECK(
+      json.isArray(), "Index configuration must be a JSON array: {}", key);
+  std::vector<std::string> result;
+  result.reserve(json.size());
+  for (const auto& element : json) {
+    NIMBLE_USER_CHECK(
+        element.isString(),
+        "Index configuration array must contain strings: {}",
+        key);
+    result.emplace_back(element.asString());
+  }
+  return result;
+}
+
+std::string serializeStrings(const std::vector<std::string>& values) {
+  return folly::toJson(folly::dynamic::array(values.begin(), values.end()));
+}
+
+std::vector<SortOrder> parseSortOrders(
+    const std::string& key,
+    const std::string& value) {
+  auto json = parseJson(key, value);
+  NIMBLE_USER_CHECK(
+      json.isArray(), "Index configuration must be a JSON array: {}", key);
+  std::vector<SortOrder> result;
+  result.reserve(json.size());
+  for (const auto& element : json) {
+    NIMBLE_USER_CHECK(
+        element.isBool(),
+        "Index sort orders must be represented as booleans: {}",
+        key);
+    result.emplace_back(SortOrder{element.asBool()});
+  }
+  return result;
+}
+
+std::string serializeSortOrders(const std::vector<SortOrder>& sortOrders) {
+  auto json = folly::dynamic::array();
+  for (const auto& sortOrder : sortOrders) {
+    json.push_back(sortOrder.ascending);
+  }
+  return folly::toJson(json);
+}
+
+const ConfigBase::Entry<const std::vector<std::string>> columnsEntry{
+    std::string{kKeyColumns},
+    {},
+    serializeStrings,
+    parseStrings};
+const ConfigBase::Entry<const std::vector<SortOrder>> sortOrdersEntry{
+    std::string{kSortOrders},
+    {},
+    serializeSortOrders,
+    parseSortOrders};
+const ConfigBase::Entry<bool> enforceKeyOrderEntry{
+    std::string{kEnforceKeyOrder},
+    false};
+const ConfigBase::Entry<bool> noDuplicateKeyEntry{
+    std::string{kNoDuplicateKey},
+    false};
+const ConfigBase::Entry<uint64_t> clusterMaxRowsPerKeyChunkEntry{
+    std::string{kMaxRowsPerKeyChunk},
+    10'000};
+const ConfigBase::Entry<CompressionType> keyChunkCompressionTypeEntry{
+    std::string{kKeyChunkCompressionType},
+    CompressionType::Uncompressed,
+    [](CompressionType type) { return toString(type); },
+    [](const std::string&, const std::string& value) {
+      return toCompressionType(value);
+    }};
+const ConfigBase::Entry<uint64_t> sortedMaxRowsPerKeyChunkEntry{
+    std::string{kMaxRowsPerKeyChunk},
+    0};
+const ConfigBase::Entry<float> loadFactorEntry{std::string{kLoadFactor}, 0.7f};
+const ConfigBase::Entry<float> bloomFilterBitsPerKeyEntry{
+    std::string{kBloomFilterBitsPerKey},
+    10.0f};
+const ConfigBase::Entry<uint64_t> maxPartitionSizeBytesEntry{
+    std::string{kMaxPartitionSizeBytes},
+    0};
+
+const ConfigBase& options(const IndexConfig& config) {
+  NIMBLE_USER_CHECK_NOT_NULL(
+      config.options,
+      "Index configuration options cannot be null: {}",
+      config.name);
+  return *config.options;
+}
+
+// Preserve the complete recursive layout, including encoding-specific config
+// and absent child slots.
+folly::dynamic encodingLayoutToJson(const EncodingLayout& layout) {
+  folly::dynamic config = folly::dynamic::object();
+  for (const auto& [key, value] : layout.config().values()) {
+    config[key] = value;
+  }
+
+  auto children = folly::dynamic::array();
+  for (NestedEncodingIdentifier i = 0; i < layout.childrenCount(); ++i) {
+    const auto& child = layout.child(i);
+    children.push_back(
+        child.has_value() ? encodingLayoutToJson(child.value())
+                          : folly::dynamic(nullptr));
+  }
+
+  return folly::dynamic::object("type", toString(layout.encodingType()))(
+      "compression", toString(layout.compressionType()))(
+      "config", std::move(config))("children", std::move(children));
+}
+
+const folly::dynamic& requiredField(
+    const folly::dynamic& object,
+    const char* field,
+    const std::string& key) {
+  NIMBLE_USER_CHECK(
+      object.isObject() && object.get_ptr(field) != nullptr,
+      "Index configuration '{}' must contain field '{}'",
+      key,
+      field);
+  return object[field];
+}
+
+EncodingLayout encodingLayoutFromJson(
+    const folly::dynamic& json,
+    const std::string& key) {
+  const auto& type = requiredField(json, "type", key);
+  const auto& compression = requiredField(json, "compression", key);
+  const auto& config = requiredField(json, "config", key);
+  const auto& childrenJson = requiredField(json, "children", key);
+  NIMBLE_USER_CHECK(
+      type.isString(),
+      "Encoding type in index configuration '{}' must be a string",
+      key);
+  NIMBLE_USER_CHECK(
+      compression.isString(),
+      "Compression type in index configuration '{}' must be a string",
+      key);
+  NIMBLE_USER_CHECK(
+      config.isObject(),
+      "Encoding config in index configuration '{}' must be an object",
+      key);
+  NIMBLE_USER_CHECK(
+      childrenJson.isArray(),
+      "Encoding children in index configuration '{}' must be an array",
+      key);
+
+  std::unordered_map<std::string, std::string> configValues;
+  for (const auto& [configKey, value] : config.items()) {
+    NIMBLE_USER_CHECK(
+        configKey.isString() && value.isString(),
+        "Encoding config in index configuration '{}' must contain string values",
+        key);
+    configValues.emplace(configKey.asString(), value.asString());
+  }
+
+  std::vector<std::optional<const EncodingLayout>> children;
+  children.reserve(childrenJson.size());
+  for (const auto& child : childrenJson) {
+    children.emplace_back(
+        child.isNull() ? std::nullopt
+                       : std::optional<const EncodingLayout>{
+                             encodingLayoutFromJson(child, key)});
+  }
+
+  return EncodingLayout{
+      toEncodingType(type.asString()),
+      EncodingLayout::Config{std::move(configValues)},
+      toCompressionType(compression.asString()),
+      std::move(children)};
+}
+
+std::string serializeEncodingLayout(const EncodingLayout& layout) {
+  folly::json::serialization_opts options;
+  options.sort_keys = true;
+  return folly::json::serialize(encodingLayoutToJson(layout), options);
+}
+
+EncodingLayout parseEncodingLayout(
+    const std::string& key,
+    const std::string& value) {
+  return encodingLayoutFromJson(parseJson(key, value), key);
+}
+
+const ConfigBase::Entry<const EncodingLayout> encodingLayoutEntry{
+    std::string{kEncodingLayout},
+    EncodingLayout{EncodingType::Prefix, {}, CompressionType::Uncompressed},
+    serializeEncodingLayout,
+    parseEncodingLayout};
+
+std::unordered_map<std::string, std::string> makeKeyStreamOptions(
+    const std::vector<std::string>& columns,
+    const EncodingLayout& layout) {
+  std::unordered_map<std::string, std::string> options{
+      {columnsEntry.key, columnsEntry.toStr(columns)},
+      {encodingLayoutEntry.key, encodingLayoutEntry.toStr(layout)},
+  };
+  return options;
+}
+
+std::shared_ptr<const ConfigBase> makeOptions(
+    std::unordered_map<std::string, std::string> options) {
+  return std::make_shared<const ConfigBase>(std::move(options));
+}
+
+} // namespace
+
+std::string_view toString(IndexFamily family) {
+  switch (family) {
+    case IndexFamily::Cluster:
+      return "Cluster";
+    case IndexFamily::Dense:
+      return "Dense";
+  }
+  NIMBLE_UNREACHABLE("Unsupported index family: {}", static_cast<int>(family));
+}
 
 IndexFamily toIndexFamily(serialization::IndexFamily family) {
   switch (family) {
@@ -38,6 +289,94 @@ serialization::IndexFamily toIndexFamily(IndexFamily family) {
       return serialization::IndexFamily_Dense;
   }
   NIMBLE_UNREACHABLE("Unsupported index family: {}", static_cast<int>(family));
+}
+
+IndexConfig toIndexConfig(ClusterIndexConfig config) {
+  auto values = makeKeyStreamOptions(config.columns, config.encodingLayout);
+  values.emplace(sortOrdersEntry.key, sortOrdersEntry.toStr(config.sortOrders));
+  values.emplace(
+      enforceKeyOrderEntry.key,
+      enforceKeyOrderEntry.toStr(config.enforceKeyOrder));
+  values.emplace(
+      noDuplicateKeyEntry.key,
+      noDuplicateKeyEntry.toStr(config.noDuplicateKey));
+  values.emplace(
+      clusterMaxRowsPerKeyChunkEntry.key,
+      clusterMaxRowsPerKeyChunkEntry.toStr(config.maxRowsPerKeyChunk));
+  values.emplace(
+      keyChunkCompressionTypeEntry.key,
+      keyChunkCompressionTypeEntry.toStr(config.keyChunkCompressionType));
+  return IndexConfig{
+      IndexFamily::Cluster,
+      std::move(config.indexName),
+      makeOptions(std::move(values))};
+}
+
+IndexConfig toIndexConfig(HashIndexConfig config) {
+  std::unordered_map<std::string, std::string> values{
+      {columnsEntry.key, columnsEntry.toStr(config.columns)},
+      {loadFactorEntry.key, loadFactorEntry.toStr(config.loadFactor)},
+      {maxPartitionSizeBytesEntry.key,
+       maxPartitionSizeBytesEntry.toStr(config.maxPartitionSizeBytes)},
+  };
+  if (config.bloomFilter.has_value()) {
+    values.emplace(
+        bloomFilterBitsPerKeyEntry.key,
+        bloomFilterBitsPerKeyEntry.toStr(config.bloomFilter->bitsPerKey));
+  }
+  return IndexConfig{
+      IndexFamily::Dense,
+      std::move(config.indexName),
+      makeOptions(std::move(values))};
+}
+
+IndexConfig toIndexConfig(SortedIndexConfig config) {
+  auto values = makeKeyStreamOptions(config.columns, config.encodingLayout);
+  values.emplace(
+      sortedMaxRowsPerKeyChunkEntry.key,
+      sortedMaxRowsPerKeyChunkEntry.toStr(config.maxRowsPerKeyChunk));
+  return IndexConfig{
+      IndexFamily::Dense,
+      std::move(config.indexName),
+      makeOptions(std::move(values))};
+}
+
+ClusterIndexConfig toClusterIndexConfig(const IndexConfig& config) {
+  const auto& values = options(config);
+  return ClusterIndexConfig{
+      .indexName = config.name,
+      .columns = values.get(columnsEntry),
+      .sortOrders = values.get(sortOrdersEntry),
+      .enforceKeyOrder = values.get(enforceKeyOrderEntry),
+      .noDuplicateKey = values.get(noDuplicateKeyEntry),
+      .encodingLayout = values.get(encodingLayoutEntry),
+      .maxRowsPerKeyChunk = values.get(clusterMaxRowsPerKeyChunkEntry),
+      .keyChunkCompressionType = values.get(keyChunkCompressionTypeEntry),
+  };
+}
+
+HashIndexConfig toHashIndexConfig(const IndexConfig& config) {
+  const auto& values = options(config);
+  return HashIndexConfig{
+      .indexName = config.name,
+      .columns = values.get(columnsEntry),
+      .loadFactor = values.get(loadFactorEntry),
+      .bloomFilter = values.valueExists(bloomFilterBitsPerKeyEntry.key)
+          ? std::optional<BloomFilterConfig>{BloomFilterConfig{
+                values.get(bloomFilterBitsPerKeyEntry)}}
+          : std::nullopt,
+      .maxPartitionSizeBytes = values.get(maxPartitionSizeBytesEntry),
+  };
+}
+
+SortedIndexConfig toSortedIndexConfig(const IndexConfig& config) {
+  const auto& values = options(config);
+  return SortedIndexConfig{
+      .indexName = config.name,
+      .columns = values.get(columnsEntry),
+      .encodingLayout = values.get(encodingLayoutEntry),
+      .maxRowsPerKeyChunk = values.get(sortedMaxRowsPerKeyChunkEntry),
+  };
 }
 
 } // namespace facebook::nimble::index

--- a/dwio/nimble/index/IndexConfig.h
+++ b/dwio/nimble/index/IndexConfig.h
@@ -38,6 +38,8 @@ enum class IndexFamily : uint8_t {
   Dense,
 };
 
+std::string_view toString(IndexFamily family);
+
 struct IndexDescriptor {
   IndexFamily family;
   std::string name;
@@ -95,8 +97,6 @@ struct ClusterIndexConfig {
   /// not compress its own output, so this is the only way to block-compress a
   /// Prefix key index. Only Uncompressed, Zstd, and Lz4 are supported.
   CompressionType keyChunkCompressionType{CompressionType::Uncompressed};
-  /// Configuration options for a custom cluster index implementation.
-  std::shared_ptr<const velox::config::ConfigBase> customOptions;
 };
 
 /// Configuration for bloom filter.
@@ -159,4 +159,45 @@ struct SortedIndexConfig {
   uint64_t maxRowsPerKeyChunk{0};
 };
 
+/// Configures one named index implementation.
+struct IndexConfig {
+  /// Selects the index factory registry.
+  IndexFamily family;
+  /// Names the registered index factory.
+  std::string name;
+  /// Provides implementation-specific configuration options.
+  std::shared_ptr<const velox::config::ConfigBase> options;
+};
+
+/// Converts built-in cluster index options to the generic factory
+/// configuration.
+IndexConfig toIndexConfig(ClusterIndexConfig config);
+
+/// Converts built-in hash index options to the generic factory configuration.
+IndexConfig toIndexConfig(HashIndexConfig config);
+
+/// Converts built-in sorted index options to the generic factory
+/// configuration.
+IndexConfig toIndexConfig(SortedIndexConfig config);
+
+/// Parses generic options for the built-in cluster index implementation.
+ClusterIndexConfig toClusterIndexConfig(const IndexConfig& config);
+
+/// Parses generic options for the built-in hash index implementation.
+HashIndexConfig toHashIndexConfig(const IndexConfig& config);
+
+/// Parses generic options for the built-in sorted index implementation.
+SortedIndexConfig toSortedIndexConfig(const IndexConfig& config);
+
 } // namespace facebook::nimble::index
+
+template <>
+struct fmt::formatter<facebook::nimble::index::IndexFamily>
+    : formatter<std::string_view> {
+  auto format(
+      facebook::nimble::index::IndexFamily family,
+      format_context& context) const {
+    return formatter<std::string_view>::format(
+        facebook::nimble::index::toString(family), context);
+  }
+};

--- a/dwio/nimble/index/tests/ClusterIndexTestUtils.cpp
+++ b/dwio/nimble/index/tests/ClusterIndexTestUtils.cpp
@@ -76,7 +76,8 @@ void writeFile(
 
   VeloxWriterOptions options;
   options.enableChunking = true;
-  options.clusterIndexConfig = std::move(clusterIndexConfig);
+  options.clusterIndexConfig =
+      facebook::nimble::index::toIndexConfig(std::move(clusterIndexConfig));
   if (flushPolicyFactory) {
     options.flushPolicyFactory = std::move(flushPolicyFactory);
   }

--- a/dwio/nimble/index/tests/ClusterIndexWriterTest.cpp
+++ b/dwio/nimble/index/tests/ClusterIndexWriterTest.cpp
@@ -151,6 +151,16 @@ TEST_F(ClusterIndexWriterTest, createWithInvalidConfig) {
         ClusterIndexWriter::create(config, type, pool_.get()),
         "Key stream encoding only supports Prefix or Trivial encoding");
   }
+
+  {
+    SCOPED_TRACE("non-supported key chunk compression");
+    ClusterIndexConfig config{
+        .columns = {"col0"},
+        .keyChunkCompressionType = CompressionType::MetaInternal};
+    NIMBLE_ASSERT_THROW(
+        ClusterIndexWriter::create(config, type, pool_.get()),
+        "Key chunk compression only supports Uncompressed, Zstd, or Lz4");
+  }
 }
 
 TEST_F(ClusterIndexWriterTest, keyChunkCompressionProducesRequestedChunkCodec) {

--- a/dwio/nimble/index/tests/DenseIndexRegistryTest.cpp
+++ b/dwio/nimble/index/tests/DenseIndexRegistryTest.cpp
@@ -137,7 +137,8 @@ TEST_F(DenseIndexRegistryTest, hashOnlyRegistry) {
 
   const auto filePath = tempFilePath("hash_only");
   VeloxWriterOptions options;
-  options.hashIndexConfigs.push_back(HashIndexConfig{.columns = {"id"}});
+  options.denseIndexConfigs.push_back(
+      toIndexConfig(HashIndexConfig{.columns = {"id"}}));
   writeFile(filePath, rowType(), batches, std::move(options));
 
   auto tablet = openTablet(filePath);
@@ -158,7 +159,8 @@ TEST_F(DenseIndexRegistryTest, sortedOnlyRegistry) {
 
   const auto filePath = tempFilePath("sorted_only");
   VeloxWriterOptions options;
-  options.sortedIndexConfigs.push_back(SortedIndexConfig{.columns = {"value"}});
+  options.denseIndexConfigs.push_back(
+      toIndexConfig(SortedIndexConfig{.columns = {"value"}}));
   writeFile(filePath, rowType(), batches, std::move(options));
 
   auto tablet = openTablet(filePath);
@@ -179,8 +181,10 @@ TEST_F(DenseIndexRegistryTest, hashAndSortedLookup) {
 
   const auto filePath = tempFilePath("hash_and_sorted");
   VeloxWriterOptions options;
-  options.hashIndexConfigs.push_back(HashIndexConfig{.columns = {"id"}});
-  options.sortedIndexConfigs.push_back(SortedIndexConfig{.columns = {"value"}});
+  options.denseIndexConfigs.push_back(
+      toIndexConfig(HashIndexConfig{.columns = {"id"}}));
+  options.denseIndexConfigs.push_back(
+      toIndexConfig(SortedIndexConfig{.columns = {"value"}}));
   writeFile(filePath, rowType(), batches, std::move(options));
 
   auto tablet = openTablet(filePath);
@@ -205,7 +209,8 @@ TEST_F(DenseIndexRegistryTest, indexCacheRetention) {
 
   const auto filePath = tempFilePath("cache_retention");
   VeloxWriterOptions options;
-  options.hashIndexConfigs.push_back(HashIndexConfig{.columns = {"id"}});
+  options.denseIndexConfigs.push_back(
+      toIndexConfig(HashIndexConfig{.columns = {"id"}}));
   writeFile(filePath, rowType(), batches, std::move(options));
 
   auto tablet = openTablet(filePath);
@@ -229,8 +234,10 @@ TEST_F(DenseIndexRegistryTest, firstIndexWinsForDuplicateColumns) {
 
   const auto filePath = tempFilePath("cross_type_duplicate");
   VeloxWriterOptions options;
-  options.hashIndexConfigs.push_back(HashIndexConfig{.columns = {"id"}});
-  options.sortedIndexConfigs.push_back(SortedIndexConfig{.columns = {"id"}});
+  options.denseIndexConfigs.push_back(
+      toIndexConfig(HashIndexConfig{.columns = {"id"}}));
+  options.denseIndexConfigs.push_back(
+      toIndexConfig(SortedIndexConfig{.columns = {"id"}}));
 
   writeFile(filePath, rowType(), batches, std::move(options));
 

--- a/dwio/nimble/index/tests/HashIndexTest.cpp
+++ b/dwio/nimble/index/tests/HashIndexTest.cpp
@@ -97,7 +97,7 @@ class HashIndexTestBase {
       HashIndexConfig indexConfig,
       std::optional<uint64_t> flushSize = std::nullopt) {
     VeloxWriterOptions options;
-    options.hashIndexConfigs.push_back(std::move(indexConfig));
+    options.denseIndexConfigs.push_back(toIndexConfig(std::move(indexConfig)));
     if (flushSize.has_value()) {
       options.flushPolicyFactory = [size = flushSize.value()]() {
         return std::make_unique<StripeRawSizeFlushPolicy>(size);
@@ -469,9 +469,10 @@ TEST_F(HashIndexTest, multipleIndices) {
   const auto filePath = tempFilePath("multi_indices");
   {
     VeloxWriterOptions options;
-    options.hashIndexConfigs.push_back(HashIndexConfig{.columns = {"col_a"}});
-    options.hashIndexConfigs.push_back(
-        HashIndexConfig{.columns = {"col_b", "col_c"}});
+    options.denseIndexConfigs.push_back(
+        toIndexConfig(HashIndexConfig{.columns = {"col_a"}}));
+    options.denseIndexConfigs.push_back(
+        toIndexConfig(HashIndexConfig{.columns = {"col_b", "col_c"}}));
     writeFile(filePath, colAType, {batch}, std::move(options));
   }
 

--- a/dwio/nimble/index/tests/IndexConfigTest.cpp
+++ b/dwio/nimble/index/tests/IndexConfigTest.cpp
@@ -16,11 +16,36 @@
 
 #include <gtest/gtest.h>
 
+#include <fmt/format.h>
+
+#include "dwio/nimble/common/NimbleException.h"
+#include "dwio/nimble/encodings/PrefixEncoding.h"
 #include "dwio/nimble/index/IndexConfig.h"
 #include "dwio/nimble/index/IndexSerialization.h"
 #include "dwio/nimble/tablet/IndexGenerated.h"
+#include "velox/common/config/Config.h"
 
 namespace facebook::nimble::index::test {
+namespace {
+
+void expectEncodingLayoutEqual(
+    const EncodingLayout& expected,
+    const EncodingLayout& actual) {
+  EXPECT_EQ(actual.encodingType(), expected.encodingType());
+  EXPECT_EQ(actual.compressionType(), expected.compressionType());
+  EXPECT_EQ(actual.config().values(), expected.config().values());
+  ASSERT_EQ(actual.childrenCount(), expected.childrenCount());
+  for (NestedEncodingIdentifier i = 0; i < expected.childrenCount(); ++i) {
+    const auto& expectedChild = expected.child(i);
+    const auto& actualChild = actual.child(i);
+    ASSERT_EQ(actualChild.has_value(), expectedChild.has_value());
+    if (expectedChild.has_value()) {
+      expectEncodingLayoutEqual(expectedChild.value(), actualChild.value());
+    }
+  }
+}
+
+} // namespace
 
 TEST(IndexConfigTest, defaultValues) {
   ClusterIndexConfig config;
@@ -58,6 +83,153 @@ TEST(IndexConfigTest, customEncodingLayout) {
   EXPECT_EQ(config.encodingLayout.compressionType(), CompressionType::Zstd);
 }
 
+TEST(IndexConfigTest, clusterConfigRoundTrip) {
+  ClusterIndexConfig expected{
+      .indexName = "test.cluster.v1",
+      .columns = {"key", "timestamp"},
+      .sortOrders = {{.ascending = true}, {.ascending = false}},
+      .enforceKeyOrder = true,
+      .noDuplicateKey = true,
+      .encodingLayout =
+          EncodingLayout{
+              EncodingType::Prefix,
+              EncodingLayout::Config{{
+                  {std::string(PrefixEncoding::kRestartIntervalConfigKey),
+                   "32"},
+              }},
+              CompressionType::Zstd},
+      .maxRowsPerKeyChunk = 123,
+      .keyChunkCompressionType = CompressionType::Lz4,
+  };
+
+  const auto actual = toClusterIndexConfig(toIndexConfig(expected));
+  EXPECT_EQ(actual.indexName, expected.indexName);
+  EXPECT_EQ(actual.columns, expected.columns);
+  ASSERT_EQ(actual.sortOrders.size(), expected.sortOrders.size());
+  EXPECT_TRUE(actual.sortOrders[0].ascending);
+  EXPECT_FALSE(actual.sortOrders[1].ascending);
+  EXPECT_EQ(actual.enforceKeyOrder, expected.enforceKeyOrder);
+  EXPECT_EQ(actual.noDuplicateKey, expected.noDuplicateKey);
+  expectEncodingLayoutEqual(expected.encodingLayout, actual.encodingLayout);
+  EXPECT_EQ(actual.maxRowsPerKeyChunk, expected.maxRowsPerKeyChunk);
+  EXPECT_EQ(actual.keyChunkCompressionType, expected.keyChunkCompressionType);
+}
+
+TEST(IndexConfigTest, hashConfigRoundTrip) {
+  HashIndexConfig expected{
+      .columns = {"key"},
+      .loadFactor = 0.5,
+      .bloomFilter = BloomFilterConfig{.bitsPerKey = 7},
+      .maxPartitionSizeBytes = 123,
+  };
+
+  const auto actual = toHashIndexConfig(toIndexConfig(expected));
+  EXPECT_EQ(actual.indexName, expected.indexName);
+  EXPECT_EQ(actual.columns, expected.columns);
+  EXPECT_EQ(actual.loadFactor, expected.loadFactor);
+  ASSERT_TRUE(actual.bloomFilter.has_value());
+  EXPECT_EQ(actual.bloomFilter->bitsPerKey, expected.bloomFilter->bitsPerKey);
+  EXPECT_EQ(actual.maxPartitionSizeBytes, expected.maxPartitionSizeBytes);
+}
+
+TEST(IndexConfigTest, sortedConfigRoundTrip) {
+  SortedIndexConfig expected{
+      .columns = {"key"},
+      .maxRowsPerKeyChunk = 123,
+  };
+
+  const auto actual = toSortedIndexConfig(toIndexConfig(expected));
+  EXPECT_EQ(actual.indexName, expected.indexName);
+  EXPECT_EQ(actual.columns, expected.columns);
+  expectEncodingLayoutEqual(expected.encodingLayout, actual.encodingLayout);
+  EXPECT_EQ(actual.maxRowsPerKeyChunk, expected.maxRowsPerKeyChunk);
+}
+
+TEST(IndexConfigTest, encodingLayoutRoundTrip) {
+  struct TestCase {
+    std::string_view name;
+    EncodingLayout layout;
+  };
+  const std::vector<TestCase> testCases{
+      {
+          "prefix_config",
+          EncodingLayout{
+              EncodingType::Prefix,
+              EncodingLayout::Config{
+                  {{std::string(PrefixEncoding::kRestartIntervalConfigKey),
+                    "32"}}},
+              CompressionType::Zstd},
+      },
+      {
+          "nested_trivial",
+          EncodingLayout{
+              EncodingType::Trivial,
+              {},
+              CompressionType::Zstd,
+              {EncodingLayout{
+                  EncodingType::Trivial,
+                  EncodingLayout::Config{{{"child.key", "value"}}},
+                  CompressionType::Lz4,
+                  {std::nullopt}}}},
+      },
+  };
+
+  for (const auto& testCase : testCases) {
+    SCOPED_TRACE(testCase.name);
+    const auto actual = toSortedIndexConfig(toIndexConfig(
+        SortedIndexConfig{
+            .columns = {"key"}, .encodingLayout = testCase.layout}));
+    expectEncodingLayoutEqual(testCase.layout, actual.encodingLayout);
+  }
+}
+
+TEST(IndexConfigTest, builtInDefaults) {
+  const auto cluster = toClusterIndexConfig(
+      IndexConfig{
+          .family = IndexFamily::Cluster,
+          .name = std::string{kClusterIndexName},
+          .options = std::make_shared<const velox::config::ConfigBase>(
+              std::unordered_map<std::string, std::string>{}),
+      });
+  EXPECT_EQ(cluster.maxRowsPerKeyChunk, 10'000);
+  EXPECT_EQ(cluster.encodingLayout.encodingType(), EncodingType::Prefix);
+
+  const auto sorted = toSortedIndexConfig(
+      IndexConfig{
+          .family = IndexFamily::Dense,
+          .name = std::string{kDenseSortedIndexName},
+          .options = std::make_shared<const velox::config::ConfigBase>(
+              std::unordered_map<std::string, std::string>{}),
+      });
+  EXPECT_EQ(sorted.maxRowsPerKeyChunk, 0);
+}
+
+TEST(IndexConfigTest, malformedJsonIsUserError) {
+  auto makeConfig = [](std::string key) {
+    return IndexConfig{
+        .family = IndexFamily::Cluster,
+        .name = std::string{kClusterIndexName},
+        .options = std::make_shared<const velox::config::ConfigBase>(
+            std::unordered_map<std::string, std::string>{
+                {std::move(key), "{"}}),
+    };
+  };
+
+  for (const auto* key : {"columns", "encodingLayout"}) {
+    SCOPED_TRACE(key);
+    EXPECT_THROW(toClusterIndexConfig(makeConfig(key)), NimbleUserError);
+  }
+}
+
+TEST(IndexConfigTest, keyChunkCompressionRoundTrip) {
+  ClusterIndexConfig config{
+      .keyChunkCompressionType = CompressionType::MetaInternal};
+  EXPECT_EQ(
+      toClusterIndexConfig(toIndexConfig(std::move(config)))
+          .keyChunkCompressionType,
+      CompressionType::MetaInternal);
+}
+
 TEST(IndexConfigTest, indexFamilySerializationRoundTrip) {
   for (const auto [family, serializedFamily] :
        {std::pair{IndexFamily::Cluster, serialization::IndexFamily_Cluster},
@@ -66,6 +238,11 @@ TEST(IndexConfigTest, indexFamilySerializationRoundTrip) {
     EXPECT_EQ(toIndexFamily(family), serializedFamily);
     EXPECT_EQ(toIndexFamily(serializedFamily), family);
   }
+}
+
+TEST(IndexConfigTest, indexFamilyFormatting) {
+  EXPECT_EQ(fmt::format("{}", IndexFamily::Cluster), "Cluster");
+  EXPECT_EQ(fmt::format("{}", IndexFamily::Dense), "Dense");
 }
 
 } // namespace facebook::nimble::index::test

--- a/dwio/nimble/index/tests/IndexFactoryTest.cpp
+++ b/dwio/nimble/index/tests/IndexFactoryTest.cpp
@@ -25,11 +25,14 @@
 #include "dwio/nimble/index/ClusterIndexFactory.h"
 #include "dwio/nimble/index/DenseIndexFactory.h"
 #include "dwio/nimble/index/DenseIndexRegistry.h"
+#include "dwio/nimble/index/HashIndexWriter.h"
 #include "dwio/nimble/index/IndexKeyEncoder.h"
 #include "dwio/nimble/tablet/Constants.h"
 #include "dwio/nimble/tablet/IndexGenerated.h"
 #include "dwio/nimble/tablet/TabletReader.h"
 #include "dwio/nimble/velox/VeloxWriter.h"
+#include "folly/Synchronized.h"
+#include "velox/common/config/Config.h"
 #include "velox/common/file/FileSystems.h"
 #include "velox/common/io/IoStatistics.h"
 #include "velox/common/io/Options.h"
@@ -42,6 +45,21 @@ namespace {
 
 constexpr std::string_view kCustomClusterIndexName{"test.cluster.v1"};
 constexpr std::string_view kCustomDenseIndexName{"test.dense.v1"};
+constexpr std::string_view kValidationDenseIndexName{
+    "test.dense.validation.v1"};
+constexpr std::string_view kFailingDenseIndexName{"test.dense.failing.v1"};
+constexpr std::string_view kInvalidDescriptorIndexName{
+    "test.dense.invalid_descriptor.v1"};
+constexpr std::string_view kLifecycleDenseIndexName{"test.dense.lifecycle.v1"};
+
+enum class FailureStage { kNone, kFlush, kClose };
+
+folly::Synchronized<std::vector<std::string>> lifecycleEvents;
+
+std::shared_ptr<const velox::config::ConfigBase> makeOptions(
+    std::unordered_map<std::string, std::string> options = {}) {
+  return std::make_shared<const velox::config::ConfigBase>(std::move(options));
+}
 
 class RenamedIndexWriter final : public IndexWriter {
  public:
@@ -80,11 +98,15 @@ class TestClusterIndexFactory final : public ClusterIndexFactory {
   }
 
   std::unique_ptr<IndexWriter> createWriter(
-      const ClusterIndexConfig& config,
+      const IndexConfig& config,
       const velox::TypePtr& inputType,
       velox::memory::MemoryPool* pool) const override {
-    auto builtInConfig = config;
-    builtInConfig.indexName = kClusterIndexName;
+    NIMBLE_CHECK_NOT_NULL(config.options);
+    const auto column = config.options->get<std::string>("column");
+    NIMBLE_CHECK(column.has_value(), "Cluster index column is missing");
+    auto builtInConfig = toIndexConfig(
+        ClusterIndexConfig{
+            .columns = {column.value()}, .enforceKeyOrder = true});
     return std::make_unique<RenamedIndexWriter>(
         clusterIndexFactory(kClusterIndexName)
             .createWriter(builtInConfig, inputType, pool),
@@ -109,7 +131,42 @@ class TestClusterIndexFactory final : public ClusterIndexFactory {
   }
 };
 
-class TestDenseIndexReader final : public DenseIndexReader {
+class HashDelegatingDenseIndexFactory final : public DenseIndexFactory {
+ public:
+  explicit HashDelegatingDenseIndexFactory(
+      std::string name = std::string{kCustomDenseIndexName})
+      : name_{std::move(name)} {}
+
+  std::string_view name() const override {
+    return name_;
+  }
+
+  std::unique_ptr<IndexWriter> createWriter(
+      const IndexConfig& config,
+      const velox::TypePtr& inputType,
+      velox::memory::MemoryPool* pool) const override {
+    NIMBLE_CHECK_NOT_NULL(config.options);
+    const auto column = config.options->get<std::string>("column");
+    NIMBLE_CHECK(column.has_value(), "Dense index column is missing");
+    return std::make_unique<RenamedIndexWriter>(
+        HashIndexWriter::create(
+            {HashIndexConfig{.columns = {column.value()}}}, inputType, pool),
+        std::string{name()});
+  }
+
+  std::unique_ptr<DenseIndexReader> createReader(
+      Section rootSection,
+      const IndexLookup::Options& options,
+      velox::memory::MemoryPool* pool) const override {
+    return denseIndexFactory(kDenseHashIndexName)
+        ->createReader(std::move(rootSection), options, pool);
+  }
+
+ private:
+  const std::string name_;
+};
+
+class ValidationDenseIndexReader final : public DenseIndexReader {
  public:
   const IndexLookup* findIndex(const std::vector<std::string>&) const override {
     return nullptr;
@@ -120,21 +177,135 @@ class TestDenseIndexReader final : public DenseIndexReader {
   }
 };
 
-class TestDenseIndexFactory final : public DenseIndexFactory {
+class ValidationDenseIndexFactory final : public DenseIndexFactory {
  public:
-  explicit TestDenseIndexFactory(
-      std::string name = std::string{kCustomDenseIndexName})
-      : name_{std::move(name)} {}
-
   std::string_view name() const override {
-    return name_;
+    return kValidationDenseIndexName;
+  }
+
+  std::unique_ptr<IndexWriter> createWriter(
+      const IndexConfig&,
+      const velox::TypePtr&,
+      velox::memory::MemoryPool*) const override {
+    NIMBLE_UNREACHABLE("Validation factory does not create writers");
   }
 
   std::unique_ptr<DenseIndexReader> createReader(
       Section,
       const IndexLookup::Options&,
       velox::memory::MemoryPool*) const override {
-    return std::make_unique<TestDenseIndexReader>();
+    return std::make_unique<ValidationDenseIndexReader>();
+  }
+};
+
+class FailingIndexWriter final : public IndexWriter {
+ public:
+  void write(const velox::VectorPtr&) override {
+    NIMBLE_FAIL("Injected index write failure");
+  }
+
+  void flush(const WriteDataFn&, const CreateMetadataSectionFn&) override {}
+
+  std::optional<IndexDescriptor> close(
+      const WriteDataFn&,
+      const CreateMetadataSectionFn&) override {
+    return std::nullopt;
+  }
+};
+
+class InvalidDescriptorIndexWriter final : public IndexWriter {
+ public:
+  void write(const velox::VectorPtr&) override {}
+
+  void flush(const WriteDataFn&, const CreateMetadataSectionFn&) override {}
+
+  std::optional<IndexDescriptor> close(
+      const WriteDataFn&,
+      const CreateMetadataSectionFn&) override {
+    return IndexDescriptor{
+        IndexFamily::Dense,
+        "test.dense.wrong.v1",
+        MetadataSection{0, 0, CompressionType::Uncompressed}};
+  }
+};
+
+class LifecycleIndexWriter final : public IndexWriter {
+ public:
+  explicit LifecycleIndexWriter(FailureStage failureStage)
+      : failureStage_{failureStage} {}
+
+  void write(const velox::VectorPtr&) override {
+    lifecycleEvents.wlock()->emplace_back("write");
+  }
+
+  void flush(const WriteDataFn&, const CreateMetadataSectionFn&) override {
+    lifecycleEvents.wlock()->emplace_back("flush");
+    if (failureStage_ == FailureStage::kFlush) {
+      NIMBLE_FAIL("Injected index flush failure");
+    }
+  }
+
+  std::optional<IndexDescriptor> close(
+      const WriteDataFn&,
+      const CreateMetadataSectionFn&) override {
+    lifecycleEvents.wlock()->emplace_back("close");
+    if (failureStage_ == FailureStage::kClose) {
+      NIMBLE_FAIL("Injected index close failure");
+    }
+    return std::nullopt;
+  }
+
+ private:
+  const FailureStage failureStage_;
+};
+
+class LifecycleIndexFactory final : public DenseIndexFactory {
+ public:
+  std::string_view name() const override {
+    return kLifecycleDenseIndexName;
+  }
+
+  std::unique_ptr<IndexWriter> createWriter(
+      const IndexConfig& config,
+      const velox::TypePtr&,
+      velox::memory::MemoryPool*) const override {
+    NIMBLE_CHECK_NOT_NULL(config.options);
+    const auto failureStage = config.options->get<std::string>("failureStage");
+    return std::make_unique<LifecycleIndexWriter>(
+        failureStage == "flush"       ? FailureStage::kFlush
+            : failureStage == "close" ? FailureStage::kClose
+                                      : FailureStage::kNone);
+  }
+
+  std::unique_ptr<DenseIndexReader> createReader(
+      Section,
+      const IndexLookup::Options&,
+      velox::memory::MemoryPool*) const override {
+    NIMBLE_UNREACHABLE("Test factory does not create readers");
+  }
+};
+
+template <typename Writer>
+class StubDenseIndexFactory final : public DenseIndexFactory {
+ public:
+  explicit StubDenseIndexFactory(std::string name) : name_{std::move(name)} {}
+
+  std::string_view name() const override {
+    return name_;
+  }
+
+  std::unique_ptr<IndexWriter> createWriter(
+      const IndexConfig&,
+      const velox::TypePtr&,
+      velox::memory::MemoryPool*) const override {
+    return std::make_unique<Writer>();
+  }
+
+  std::unique_ptr<DenseIndexReader> createReader(
+      Section,
+      const IndexLookup::Options&,
+      velox::memory::MemoryPool*) const override {
+    NIMBLE_UNREACHABLE("Test factory does not create readers");
   }
 
  private:
@@ -148,7 +319,18 @@ class IndexFactoryTest : public testing::Test {
     velox::memory::MemoryManager::testingSetInstance({});
     registerClusterIndexFactory(
         std::make_shared<const TestClusterIndexFactory>());
-    registerDenseIndexFactory(std::make_shared<const TestDenseIndexFactory>());
+    registerDenseIndexFactory(
+        std::make_shared<const HashDelegatingDenseIndexFactory>());
+    registerDenseIndexFactory(
+        std::make_shared<const ValidationDenseIndexFactory>());
+    registerDenseIndexFactory(
+        std::make_shared<const StubDenseIndexFactory<FailingIndexWriter>>(
+            std::string{kFailingDenseIndexName}));
+    registerDenseIndexFactory(
+        std::make_shared<
+            const StubDenseIndexFactory<InvalidDescriptorIndexWriter>>(
+            std::string{kInvalidDescriptorIndexName}));
+    registerDenseIndexFactory(std::make_shared<const LifecycleIndexFactory>());
   }
 
   void SetUp() override {
@@ -198,11 +380,17 @@ class IndexFactoryTest : public testing::Test {
         {.shouldCreateParentDirectories = true,
          .shouldThrowOnFileAlreadyExists = false});
     VeloxWriterOptions options;
-    options.clusterIndexConfig = ClusterIndexConfig{
-        .indexName = std::string{kCustomClusterIndexName},
-        .columns = {"id"},
-        .enforceKeyOrder = true,
+    options.clusterIndexConfig = IndexConfig{
+        .family = IndexFamily::Cluster,
+        .name = std::string{kCustomClusterIndexName},
+        .options = makeOptions({{"column", "id"}}),
     };
+    options.denseIndexConfigs.emplace_back(
+        IndexConfig{
+            .family = IndexFamily::Dense,
+            .name = std::string{kCustomDenseIndexName},
+            .options = makeOptions({{"column", "id"}}),
+        });
     VeloxWriter writer(rowType(), std::move(file), *rootPool_, options);
     writer.write(makeBatch());
     writer.close();
@@ -252,7 +440,7 @@ class IndexFactoryTest : public testing::Test {
   std::shared_ptr<velox::common::testutil::TempDirectoryPath> tempDirectory_;
 };
 
-TEST_F(IndexFactoryTest, customClusterFactoryEndToEnd) {
+TEST_F(IndexFactoryTest, customFactoriesEndToEnd) {
   const auto path = writeFile();
   auto tablet = openFile(path, std::string{kCustomClusterIndexName});
   ASSERT_NE(tablet->clusterIndex(), nullptr);
@@ -261,6 +449,14 @@ TEST_F(IndexFactoryTest, customClusterFactoryEndToEnd) {
       IndexLookup::LookupRequest::pointLookup({key}));
   ASSERT_EQ(clusterResult.size(), 1);
   EXPECT_FALSE(clusterResult[0].empty());
+
+  const auto* denseIndex = tablet->denseIndex({"id"});
+  ASSERT_NE(denseIndex, nullptr);
+  auto denseResult =
+      denseIndex->lookup(IndexLookup::LookupRequest::pointLookup({key}));
+  ASSERT_EQ(denseResult.size(), 1);
+  ASSERT_EQ(denseResult[0].size(), 1);
+  EXPECT_EQ(denseResult[0][0], RowRange(7, 8));
 
   auto wrongClusterName = openFile(path, std::string{kClusterIndexName});
   EXPECT_EQ(wrongClusterName->clusterIndex(), nullptr);
@@ -287,7 +483,7 @@ TEST_F(IndexFactoryTest, rejectDuplicateClusterFactoryRegistration) {
 TEST_F(IndexFactoryTest, rejectDuplicateDenseFactoryRegistration) {
   NIMBLE_ASSERT_THROW(
       registerDenseIndexFactory(
-          std::make_shared<const TestDenseIndexFactory>()),
+          std::make_shared<const HashDelegatingDenseIndexFactory>()),
       "Index factory 'test.dense.v1' is already registered for family 'dense'");
 }
 
@@ -316,24 +512,24 @@ TEST_F(IndexFactoryTest, rejectDuplicateDenseIndex) {
   std::vector<DenseIndexRegistry::Entry> entries;
   entries.emplace_back(
       DenseIndexRegistry::Entry{
-          std::string{kCustomDenseIndexName}, makeSection()});
+          std::string{kValidationDenseIndexName}, makeSection()});
   entries.emplace_back(
       DenseIndexRegistry::Entry{
-          std::string{kCustomDenseIndexName}, makeSection()});
+          std::string{kValidationDenseIndexName}, makeSection()});
 
   NIMBLE_ASSERT_THROW(
       DenseIndexRegistry::create(std::move(entries), options, leafPool_.get()),
-      "Duplicate dense index 'test.dense.v1' columns");
+      "Duplicate dense index 'test.dense.validation.v1' columns");
 }
 
 TEST_F(IndexFactoryTest, concurrentFactoryAccess) {
   constexpr size_t kFactoryCount = 32;
   constexpr size_t kReaderCount = 8;
-  std::vector<std::shared_ptr<const TestDenseIndexFactory>> factories;
+  std::vector<std::shared_ptr<const HashDelegatingDenseIndexFactory>> factories;
   factories.reserve(kFactoryCount);
   for (size_t i = 0; i < kFactoryCount; ++i) {
     factories.emplace_back(
-        std::make_shared<const TestDenseIndexFactory>(
+        std::make_shared<const HashDelegatingDenseIndexFactory>(
             "test.concurrent.dense." + std::to_string(i)));
   }
 
@@ -364,12 +560,44 @@ TEST_F(IndexFactoryTest, concurrentFactoryAccess) {
   EXPECT_FALSE(lookupFailed);
 }
 
-TEST_F(IndexFactoryTest, preserveTypedIndexDescriptorOrder) {
+TEST_F(IndexFactoryTest, indexWriteFailurePoisonsWriter) {
   VeloxWriterOptions options;
-  options.hashIndexConfigs.emplace_back(HashIndexConfig{.columns = {"id"}});
-  options.sortedIndexConfigs.emplace_back(SortedIndexConfig{.columns = {"id"}});
-  options.clusterIndexConfig =
-      ClusterIndexConfig{.columns = {"id"}, .enforceKeyOrder = true};
+  options.denseIndexConfigs.emplace_back(
+      IndexConfig{
+          .family = IndexFamily::Dense,
+          .name = std::string{kFailingDenseIndexName},
+      });
+  auto writer = makeWriter("failing_writer", std::move(options));
+
+  NIMBLE_ASSERT_THROW(
+      writer->write(makeBatch()), "Injected index write failure");
+  NIMBLE_ASSERT_THROW(writer->flush(), "Injected index write failure");
+  NIMBLE_ASSERT_THROW(writer->close(), "Injected index write failure");
+}
+
+TEST_F(IndexFactoryTest, rejectInvalidWriterDescriptor) {
+  VeloxWriterOptions options;
+  options.denseIndexConfigs.emplace_back(
+      IndexConfig{
+          .family = IndexFamily::Dense,
+          .name = std::string{kInvalidDescriptorIndexName},
+      });
+  auto writer = makeWriter("invalid_descriptor", std::move(options));
+  writer->write(makeBatch());
+
+  NIMBLE_ASSERT_THROW(
+      writer->close(),
+      "Index writer returned an unexpected name for test.dense.invalid_descriptor.v1");
+}
+
+TEST_F(IndexFactoryTest, preserveIndexDescriptorOrder) {
+  VeloxWriterOptions options;
+  options.denseIndexConfigs.emplace_back(
+      toIndexConfig(HashIndexConfig{.columns = {"id"}}));
+  options.denseIndexConfigs.emplace_back(
+      toIndexConfig(SortedIndexConfig{.columns = {"id"}}));
+  options.clusterIndexConfig = toIndexConfig(
+      ClusterIndexConfig{.columns = {"id"}, .enforceKeyOrder = true});
   auto writer = makeWriter("typed_descriptor_order", std::move(options));
   writer->write(makeBatch());
   writer->close();
@@ -396,6 +624,47 @@ TEST_F(IndexFactoryTest, preserveTypedIndexDescriptorOrder) {
           std::string{kDenseHashIndexName},
           std::string{kDenseSortedIndexName},
           std::string{kClusterIndexName}}));
+}
+
+TEST_F(IndexFactoryTest, indexWriterLifecycle) {
+  struct TestCase {
+    std::string name;
+    std::string failureStage;
+    std::vector<std::string> expectedEvents;
+  };
+  const std::vector<TestCase> testCases{
+      {"success", "", {"write", "flush", "close"}},
+      {"flush_failure", "flush", {"write", "flush"}},
+      {"close_failure", "close", {"write", "flush", "close"}},
+  };
+
+  for (const auto& testCase : testCases) {
+    SCOPED_TRACE(testCase.name);
+    lifecycleEvents.wlock()->clear();
+    VeloxWriterOptions options;
+    options.denseIndexConfigs.emplace_back(
+        IndexConfig{
+            .family = IndexFamily::Dense,
+            .name = std::string{kLifecycleDenseIndexName},
+            .options = testCase.failureStage.empty()
+                ? makeOptions()
+                : makeOptions({{"failureStage", testCase.failureStage}}),
+        });
+    auto writer = makeWriter(testCase.name, std::move(options));
+    writer->write(makeBatch());
+
+    if (testCase.failureStage == "flush") {
+      NIMBLE_ASSERT_THROW(writer->close(), "Injected index flush failure");
+      NIMBLE_ASSERT_THROW(writer->flush(), "Injected index flush failure");
+      NIMBLE_ASSERT_THROW(writer->close(), "Injected index flush failure");
+    } else if (testCase.failureStage == "close") {
+      NIMBLE_ASSERT_THROW(writer->close(), "Injected index close failure");
+      NIMBLE_ASSERT_THROW(writer->close(), "Injected index close failure");
+    } else {
+      writer->close();
+    }
+    EXPECT_EQ(lifecycleEvents.copy(), testCase.expectedEvents);
+  }
 }
 
 } // namespace

--- a/dwio/nimble/index/tests/SortedIndexTest.cpp
+++ b/dwio/nimble/index/tests/SortedIndexTest.cpp
@@ -95,7 +95,7 @@ class SortedIndexTestBase {
       SortedIndexConfig indexConfig,
       std::optional<uint64_t> flushSize = std::nullopt) {
     VeloxWriterOptions options;
-    options.sortedIndexConfigs.push_back(std::move(indexConfig));
+    options.denseIndexConfigs.push_back(toIndexConfig(std::move(indexConfig)));
     if (flushSize.has_value()) {
       options.flushPolicyFactory = [size = flushSize.value()]() {
         return std::make_unique<StripeRawSizeFlushPolicy>(size);
@@ -425,9 +425,10 @@ TEST_F(SortedIndexTest, multipleIndices) {
   const auto filePath = tempFilePath("multi_indices");
   {
     VeloxWriterOptions options;
-    options.sortedIndexConfigs.push_back(SortedIndexConfig{.columns = {"id"}});
-    options.sortedIndexConfigs.push_back(
-        SortedIndexConfig{.columns = {"id", "value"}});
+    options.denseIndexConfigs.push_back(
+        toIndexConfig(SortedIndexConfig{.columns = {"id"}}));
+    options.denseIndexConfigs.push_back(
+        toIndexConfig(SortedIndexConfig{.columns = {"id", "value"}}));
     writeFile(filePath, rowType(), batches, std::move(options));
   }
 
@@ -468,7 +469,7 @@ TEST_P(SortedIndexParamTest, duplicateKeys) {
 
   const auto filePath = tempFilePath("duplicate_keys");
   VeloxWriterOptions options;
-  options.sortedIndexConfigs.push_back(indexConfig());
+  options.denseIndexConfigs.push_back(toIndexConfig(indexConfig()));
   writeFile(filePath, rowType(), {batch}, std::move(options));
 
   auto tablet = openTablet(filePath);
@@ -560,7 +561,7 @@ TEST_F(SortedIndexTest, duplicateKeysAcrossChunks) {
   const auto filePath = tempFilePath("dup_across_chunks");
   VeloxWriterOptions options;
   SortedIndexConfig config{.columns = {"id"}, .maxRowsPerKeyChunk = 3};
-  options.sortedIndexConfigs.push_back(std::move(config));
+  options.denseIndexConfigs.push_back(toIndexConfig(std::move(config)));
   writeFile(filePath, rowType(), {batch}, std::move(options));
 
   auto tablet = openTablet(filePath);

--- a/dwio/nimble/tablet/tests/TabletTest.cpp
+++ b/dwio/nimble/tablet/tests/TabletTest.cpp
@@ -4171,10 +4171,12 @@ TEST_P(TabletWithIndexTest, loadDenseIndexes) {
   std::string file;
   auto writeFile = std::make_unique<velox::InMemoryWriteFile>(&file);
   nimble::VeloxWriterOptions writerOptions;
-  writerOptions.hashIndexConfigs.push_back(
-      nimble::index::HashIndexConfig{.columns = {"id"}});
-  writerOptions.sortedIndexConfigs.push_back(
-      nimble::index::SortedIndexConfig{.columns = {"value"}});
+  writerOptions.denseIndexConfigs.push_back(
+      nimble::index::toIndexConfig(
+          nimble::index::HashIndexConfig{.columns = {"id"}}));
+  writerOptions.denseIndexConfigs.push_back(
+      nimble::index::toIndexConfig(
+          nimble::index::SortedIndexConfig{.columns = {"value"}}));
   nimble::VeloxWriter writer(
       type, std::move(writeFile), *pool_, std::move(writerOptions));
   writer.write(batch);
@@ -4219,8 +4221,9 @@ TEST_P(TabletWithIndexTest, loadDenseIndexesMissingIoStats) {
   std::string file;
   auto writeFile = std::make_unique<velox::InMemoryWriteFile>(&file);
   nimble::VeloxWriterOptions writerOptions;
-  writerOptions.hashIndexConfigs.push_back(
-      nimble::index::HashIndexConfig{.columns = {"id"}});
+  writerOptions.denseIndexConfigs.push_back(
+      nimble::index::toIndexConfig(
+          nimble::index::HashIndexConfig{.columns = {"id"}}));
   nimble::VeloxWriter writer(
       type, std::move(writeFile), *pool_, std::move(writerOptions));
   writer.write(batch);

--- a/dwio/nimble/velox/VeloxWriter.cpp
+++ b/dwio/nimble/velox/VeloxWriter.cpp
@@ -24,6 +24,7 @@
 #include "dwio/nimble/common/Types.h"
 #include "dwio/nimble/encodings/selection/EncodingSelectionPolicy.h"
 #include "dwio/nimble/index/ClusterIndexFactory.h"
+#include "dwio/nimble/index/DenseIndexFactory.h"
 #include "dwio/nimble/index/HashIndexWriter.h"
 #include "dwio/nimble/index/IndexSerialization.h"
 #include "dwio/nimble/index/SortedIndexWriter.h"
@@ -808,49 +809,46 @@ void initializeEncodingLayouts(
 }
 } // namespace
 
-std::optional<VeloxWriter::IndexWriterEntry>
-VeloxWriter::createClusterIndexWriter(
+std::unique_ptr<index::IndexWriter> VeloxWriter::createClusterIndexWriter(
     const VeloxWriterOptions& options,
     const velox::TypePtr& type,
     velox::memory::MemoryPool* pool) {
-  std::optional<IndexWriterEntry> result;
-  if (options.clusterIndexConfig.has_value()) {
-    const auto& config = options.clusterIndexConfig.value();
-    auto writer = index::clusterIndexFactory(config.indexName)
-                      .createWriter(config, type, pool);
-    NIMBLE_CHECK_NOT_NULL(
-        writer,
-        "Cluster index factory returned a null writer: {}",
-        config.indexName);
-    result.emplace(
-        IndexWriterEntry{
-            index::IndexFamily::Cluster, config.indexName, std::move(writer)});
+  if (!options.clusterIndexConfig.has_value()) {
+    return nullptr;
   }
-  return result;
+  const auto& config = options.clusterIndexConfig.value();
+  NIMBLE_USER_CHECK_EQ(
+      config.family,
+      index::IndexFamily::Cluster,
+      "Cluster index configuration must use the cluster family: {}",
+      config.name);
+  auto writer =
+      index::clusterIndexFactory(config.name).createWriter(config, type, pool);
+  NIMBLE_CHECK_NOT_NULL(
+      writer, "Cluster index factory returned a null writer: {}", config.name);
+  return writer;
 }
 
-std::vector<VeloxWriter::IndexWriterEntry> VeloxWriter::createDenseIndexWriters(
+std::vector<std::unique_ptr<index::IndexWriter>>
+VeloxWriter::createDenseIndexWriters(
     const VeloxWriterOptions& options,
     const velox::TypePtr& type,
     velox::memory::MemoryPool* pool) {
-  std::vector<IndexWriterEntry> writers;
-  writers.reserve(
-      !options.hashIndexConfigs.empty() + !options.sortedIndexConfigs.empty());
-  if (!options.hashIndexConfigs.empty()) {
-    writers.emplace_back(
-        IndexWriterEntry{
-            index::IndexFamily::Dense,
-            std::string{index::kDenseHashIndexName},
-            index::HashIndexWriter::create(
-                options.hashIndexConfigs, type, pool)});
-  }
-  if (!options.sortedIndexConfigs.empty()) {
-    writers.emplace_back(
-        IndexWriterEntry{
-            index::IndexFamily::Dense,
-            std::string{index::kDenseSortedIndexName},
-            index::SortedIndexWriter::create(
-                options.sortedIndexConfigs, type, pool)});
+  std::vector<std::unique_ptr<index::IndexWriter>> writers;
+  writers.reserve(options.denseIndexConfigs.size());
+  for (const auto& config : options.denseIndexConfigs) {
+    NIMBLE_USER_CHECK_EQ(
+        config.family,
+        index::IndexFamily::Dense,
+        "Dense index configuration must use the dense family: {}",
+        config.name);
+    const auto* factory = index::denseIndexFactory(config.name);
+    NIMBLE_USER_CHECK_NOT_NULL(
+        factory, "Unknown dense index factory: {}", config.name);
+    auto writer = factory->createWriter(config, type, pool);
+    NIMBLE_USER_CHECK_NOT_NULL(
+        writer, "Dense index factory returned a null writer: {}", config.name);
+    writers.emplace_back(std::move(writer));
   }
   return writers;
 }
@@ -907,17 +905,17 @@ VeloxWriter::VeloxWriter(
                context_->options()
                    .experimentalStripeGroupEncodingLayoutReadFactors,
            .stripeGroupFlushCallback =
-               (clusterIndexWriter_.has_value() || !denseIndexWriters_.empty())
+               (clusterIndexWriter_ != nullptr || !denseIndexWriters_.empty())
                ? TabletWriter::StripeGroupFlushCallback(
                      [this](
                          const WriteDataFn& writeDataFn,
                          const CreateMetadataSectionFn& createMetadataFn) {
-                       if (clusterIndexWriter_.has_value()) {
-                         clusterIndexWriter_->writer->flush(
+                       if (clusterIndexWriter_ != nullptr) {
+                         clusterIndexWriter_->flush(
                              writeDataFn, createMetadataFn);
                        }
-                       for (const auto& entry : denseIndexWriters_) {
-                         entry.writer->flush(writeDataFn, createMetadataFn);
+                       for (const auto& writer : denseIndexWriters_) {
+                         writer->flush(writeDataFn, createMetadataFn);
                        }
                      })
                : nullptr,
@@ -1084,11 +1082,11 @@ void VeloxWriter::writeSchema() {
 }
 
 void VeloxWriter::addIndexKey(const velox::VectorPtr& input) {
-  if (clusterIndexWriter_.has_value()) {
-    clusterIndexWriter_->writer->write(input);
+  if (clusterIndexWriter_ != nullptr) {
+    clusterIndexWriter_->write(input);
   }
-  for (const auto& entry : denseIndexWriters_) {
-    entry.writer->write(input);
+  for (const auto& writer : denseIndexWriters_) {
+    writer->write(input);
   }
 }
 
@@ -1097,34 +1095,37 @@ void VeloxWriter::writeIndexes(
     const CreateMetadataSectionFn& createMetadataFn,
     const WriteOptionalSectionFn& writeMetadataFn) {
   std::vector<index::IndexDescriptor> descriptors;
-  for (const auto& entry : denseIndexWriters_) {
-    if (auto descriptor = entry.writer->close(writeDataFn, createMetadataFn)) {
+  for (size_t i = 0; i < denseIndexWriters_.size(); ++i) {
+    if (auto descriptor =
+            denseIndexWriters_[i]->close(writeDataFn, createMetadataFn)) {
+      const auto& config = context_->options().denseIndexConfigs[i];
       NIMBLE_CHECK_EQ(
           descriptor->family,
-          entry.family,
+          index::IndexFamily::Dense,
           "Index writer returned an unexpected family for {}",
-          entry.name);
+          config.name);
       NIMBLE_CHECK_EQ(
           descriptor->name,
-          entry.name,
+          config.name,
           "Index writer returned an unexpected name for {}",
-          entry.name);
+          config.name);
       descriptors.emplace_back(std::move(descriptor.value()));
     }
   }
-  if (clusterIndexWriter_.has_value()) {
-    const auto& entry = clusterIndexWriter_.value();
-    if (auto descriptor = entry.writer->close(writeDataFn, createMetadataFn)) {
+  if (clusterIndexWriter_ != nullptr) {
+    if (auto descriptor =
+            clusterIndexWriter_->close(writeDataFn, createMetadataFn)) {
+      const auto& config = context_->options().clusterIndexConfig.value();
       NIMBLE_CHECK_EQ(
           descriptor->family,
-          entry.family,
+          index::IndexFamily::Cluster,
           "Index writer returned an unexpected family for {}",
-          entry.name);
+          config.name);
       NIMBLE_CHECK_EQ(
           descriptor->name,
-          entry.name,
+          config.name,
           "Index writer returned an unexpected name for {}",
-          entry.name);
+          config.name);
       descriptors.emplace_back(std::move(descriptor.value()));
     }
   }

--- a/dwio/nimble/velox/VeloxWriter.h
+++ b/dwio/nimble/velox/VeloxWriter.h
@@ -96,18 +96,13 @@ class VeloxWriter {
   Stats stats() const;
 
  private:
-  struct IndexWriterEntry {
-    index::IndexFamily family;
-    std::string name;
-    std::unique_ptr<index::IndexWriter> writer;
-  };
-
-  static std::optional<IndexWriterEntry> createClusterIndexWriter(
+  static std::unique_ptr<index::IndexWriter> createClusterIndexWriter(
       const VeloxWriterOptions& options,
       const velox::TypePtr& type,
       velox::memory::MemoryPool* pool);
 
-  static std::vector<IndexWriterEntry> createDenseIndexWriters(
+  static std::vector<std::unique_ptr<index::IndexWriter>>
+  createDenseIndexWriters(
       const VeloxWriterOptions& options,
       const velox::TypePtr& type,
       velox::memory::MemoryPool* pool);
@@ -206,8 +201,8 @@ class VeloxWriter {
   MemoryPoolHolder encodingMemoryPool_;
   const std::unique_ptr<detail::WriterContext> context_;
   std::unique_ptr<velox::WriteFile> file_;
-  const std::optional<IndexWriterEntry> clusterIndexWriter_;
-  const std::vector<IndexWriterEntry> denseIndexWriters_;
+  const std::unique_ptr<index::IndexWriter> clusterIndexWriter_;
+  const std::vector<std::unique_ptr<index::IndexWriter>> denseIndexWriters_;
   const std::unique_ptr<TabletWriter> tabletWriter_;
 
   std::unique_ptr<FieldWriter> rootWriter_;

--- a/dwio/nimble/velox/VeloxWriterOptions.h
+++ b/dwio/nimble/velox/VeloxWriterOptions.h
@@ -97,21 +97,13 @@ struct VeloxWriterOptions {
   /// pruning.
   /// EXPERIMENTAL: Cluster index is not production-ready. Do not enable for
   /// production tables without consulting the Nimble team (oncall: dwios).
-  std::optional<index::ClusterIndexConfig> clusterIndexConfig;
+  std::optional<index::IndexConfig> clusterIndexConfig;
 
-  /// Hash index configurations. Each config builds an independent hash-based
-  /// point lookup index on the specified columns. Unlike cluster index, hash
-  /// index does not require sorted data.
-  /// EXPERIMENTAL: Hash index is not production-ready. Do not enable for
+  /// Dense index configurations. Each configuration creates one independent
+  /// index through its named factory.
+  /// EXPERIMENTAL: Dense indexes are not production-ready. Do not enable for
   /// production tables without consulting the Nimble team (oncall: dwios).
-  std::vector<index::HashIndexConfig> hashIndexConfigs;
-
-  /// Sorted index configurations. Each config builds an independent sorted
-  /// key stream index supporting both point lookups and range scans on
-  /// unsorted data.
-  /// EXPERIMENTAL: Sorted index is not production-ready. Do not enable for
-  /// production tables without consulting the Nimble team (oncall: dwios).
-  std::vector<index::SortedIndexConfig> sortedIndexConfigs;
+  std::vector<index::IndexConfig> denseIndexConfigs;
 
   /// Columns that should be encoded as flat maps. Maps column name to a set
   /// of predefined key strings. When the set is empty, the column is

--- a/dwio/nimble/velox/index/tests/NimbleIndexProjectorTest.cpp
+++ b/dwio/nimble/velox/index/tests/NimbleIndexProjectorTest.cpp
@@ -217,7 +217,8 @@ class NimbleIndexProjectorTest : public ::testing::TestWithParam<TestParam> {
         indexColumns.size(), SortOrder{.ascending = true});
     clusterIndexConfig.enforceKeyOrder = true;
     clusterIndexConfig.noDuplicateKey = true;
-    options.clusterIndexConfig = std::move(clusterIndexConfig);
+    options.clusterIndexConfig =
+        facebook::nimble::index::toIndexConfig(std::move(clusterIndexConfig));
 
     options.flushPolicyFactory = [stripeSize]() {
       return std::make_unique<LambdaFlushPolicy>(
@@ -2936,7 +2937,8 @@ TEST_P(NimbleIndexProjectorTest, featureReorderingStorageReads) {
     clusterIndexConfig.sortOrders = {SortOrder{.ascending = true}};
     clusterIndexConfig.enforceKeyOrder = true;
     clusterIndexConfig.noDuplicateKey = true;
-    options.clusterIndexConfig = std::move(clusterIndexConfig);
+    options.clusterIndexConfig =
+        facebook::nimble::index::toIndexConfig(std::move(clusterIndexConfig));
 
     if (enableReordering) {
       // Ordinal 1 = "features" column (after "key").

--- a/dwio/nimble/velox/selective/tests/E2EFilterTest.cpp
+++ b/dwio/nimble/velox/selective/tests/E2EFilterTest.cpp
@@ -385,7 +385,8 @@ class E2EFilterTest
       ClusterIndexConfig clusterIndexConfig;
       clusterIndexConfig.columns = indexColumns;
       clusterIndexConfig.enforceKeyOrder = true;
-      options.clusterIndexConfig = std::move(clusterIndexConfig);
+      options.clusterIndexConfig =
+          facebook::nimble::index::toIndexConfig(std::move(clusterIndexConfig));
     }
     auto writeFile = std::make_unique<InMemoryWriteFile>(&sinkData_);
     // Branch on whether we need forced dictionary encoding, since

--- a/dwio/nimble/velox/selective/tests/E2EIndexTest.cpp
+++ b/dwio/nimble/velox/selective/tests/E2EIndexTest.cpp
@@ -303,7 +303,8 @@ class E2EIndexTestBase : public ::testing::Test {
     if (encodingLayout.has_value()) {
       clusterIndexConfig.encodingLayout = std::move(encodingLayout).value();
     }
-    options.clusterIndexConfig = std::move(clusterIndexConfig);
+    options.clusterIndexConfig =
+        facebook::nimble::index::toIndexConfig(std::move(clusterIndexConfig));
 
     // Use small stripe and chunk sizes to generate multiple stripes and write
     // groups for better index test coverage.

--- a/dwio/nimble/velox/tests/VeloxWriterTest.cpp
+++ b/dwio/nimble/velox/tests/VeloxWriterTest.cpp
@@ -445,7 +445,7 @@ TEST_F(VeloxWriterTest, emptyFileWithIndexEnabled) {
       type,
       std::move(writeFile),
       *rootPool_,
-      {.clusterIndexConfig = clusterIndexConfig});
+      {.clusterIndexConfig = nimble::index::toIndexConfig(clusterIndexConfig)});
   writer.close();
 
   // Verify FileLayout for empty file with index enabled using
@@ -880,7 +880,8 @@ TEST_F(VeloxWriterTest, featureReorderingStreamCollocation) {
             nimble::EncodingType::Prefix,
             {},
             nimble::CompressionType::Uncompressed};
-        options.clusterIndexConfig = std::move(clusterIndexConfig);
+        options.clusterIndexConfig = facebook::nimble::index::toIndexConfig(
+            std::move(clusterIndexConfig));
       }
 
       nimble::VeloxWriter writer(
@@ -3777,7 +3778,8 @@ class VeloxWriterIndexTest
       const std::function<std::unique_ptr<nimble::FlushPolicy>()>&
           flushPolicyFactory = nullptr) {
     nimble::VeloxWriterOptions options{
-        .clusterIndexConfig = std::move(clusterIndexConfig),
+        .clusterIndexConfig =
+            nimble::index::toIndexConfig(std::move(clusterIndexConfig)),
     };
     if (enableChunking()) {
       options.minStreamChunkRawSize = 1 << 10; // 1KB
@@ -4494,7 +4496,8 @@ TEST_F(VeloxWriterTest, indexEnforceKeyOrder) {
           type,
           std::move(writeFile),
           *rootPool_,
-          {.clusterIndexConfig = clusterIndexConfig});
+          {.clusterIndexConfig =
+               nimble::index::toIndexConfig(clusterIndexConfig)});
 
       velox::test::VectorMaker vectorMaker{leafPool_.get()};
 
@@ -4985,7 +4988,8 @@ TEST_F(VeloxWriterTest, customPrefixRestartInterval) {
         type,
         std::move(writeFile),
         *rootPool_,
-        {.clusterIndexConfig = clusterIndexConfig});
+        {.clusterIndexConfig =
+             nimble::index::toIndexConfig(clusterIndexConfig)});
 
     velox::test::VectorMaker vectorMaker{leafPool_.get()};
 


### PR DESCRIPTION
Summary:

Unify Velox writer index configuration through IndexConfig

Replace dedicated cluster/hash/sorted writer options with clusterIndexConfig and denseIndexConfigs. 
Route index creation through registered cluster/dense factories.

Reviewed By: xiaoxmeng

Differential Revision: D113444785


