### PR TITLE
feat: Stamp Iceberg field-ids on NIMBLE schema nodes by pre-order node id

### DIFF
--- a/dwio/nimble/tools/tests/NimbleDumpLibTest.cpp
+++ b/dwio/nimble/tools/tests/NimbleDumpLibTest.cpp
@@ -208,10 +208,11 @@ TEST_F(NimbleDumpLibTest, EmitSchema_PrintsColumnAttributes) {
       std::vector<velox::VectorPtr>{idVector, nameVector});
 
   // Stamp Iceberg field-ids onto the top-level columns (as the write path does)
-  // and confirm the dumped schema round-trips and surfaces them.
+  // and confirm the dumped schema round-trips and surfaces them. Node ids are
+  // pre-order: id=1, name=2 (root row = 0).
   VeloxWriterOptions writerOptions;
-  writerOptions.attributesByColumn = {
-      {"id", {{"iceberg.id", "1"}}}, {"name", {{"iceberg.id", "2"}}}};
+  writerOptions.schemaAttributes = {
+      {1, {{"iceberg.id", "1"}}}, {2, {{"iceberg.id", "2"}}}};
 
   auto fileContent =
       test::createNimbleFile(*leafPool_, rowVector, writerOptions);

--- a/dwio/nimble/velox/VeloxWriter.cpp
+++ b/dwio/nimble/velox/VeloxWriter.cpp
@@ -510,57 +510,6 @@ WriterStreamContext& getStreamContext(
   return *descriptor.context<WriterStreamContext>();
 }
 
-// NOTE: This is a temporary method. We currently use TypeWithId to assing
-// node ids to each node in the schema tree. Using TypeWithId is not ideal, as
-// it is not very intuitive to users to figure out node ids. In the future,
-// we'll design a new way to identify nodes in the tree (probably based on
-// multi-level ordinals). But until then, we keep using a "simple" (yet
-// restrictive) external configuration and perform internal conversion to node
-// ids. Once the new language is ready, we'll switch to using it instead and
-// this translation logic will be removed.
-
-// Resolves a dotted-path key (e.g. "user.name") against a TypeWithId tree by
-// walking RowType children. Returns nullptr if any segment fails to match a
-// row child. The empty path resolves to `root`. Paths that traverse a
-// non-Row parent return nullptr; callers currently emit flat top-level /
-// nested-struct keys only. Returning nullptr is the intentional "unresolved
-// path" result; folly is avoided per the velox coding guideline, so the
-// nullable-return check is suppressed instead of using FOLLY_NULLABLE.
-//
-// NOLINTNEXTLINE(facebook-hte-NullableReturn)
-const velox::dwio::common::TypeWithId* resolveDottedPath(
-    const velox::dwio::common::TypeWithId& root,
-    std::string_view path) {
-  if (path.empty()) {
-    return &root;
-  }
-  const velox::dwio::common::TypeWithId* current = &root;
-  size_t start = 0;
-  while (start <= path.size()) {
-    auto dot = path.find('.', start);
-    auto end = (dot == std::string_view::npos) ? path.size() : dot;
-    auto segment = path.substr(start, end - start);
-    if (current->type()->kind() != velox::TypeKind::ROW) {
-      return nullptr;
-    }
-    std::shared_ptr<const velox::dwio::common::TypeWithId> child;
-    try {
-      child = current->childByName(std::string(segment));
-    } catch (const velox::VeloxUserError&) {
-      return nullptr;
-    }
-    if (child == nullptr) {
-      return nullptr;
-    }
-    current = child.get();
-    if (dot == std::string_view::npos) {
-      break;
-    }
-    start = dot + 1;
-  }
-  return current;
-}
-
 std::unique_ptr<FieldWriter> createRootFieldWriter(
     const std::shared_ptr<const velox::dwio::common::TypeWithId>& type,
     detail::WriterContext& context) {
@@ -602,28 +551,12 @@ std::unique_ptr<FieldWriter> createRootFieldWriter(
     context.initStatsCollectors(type);
   }
 
-  // Translate dotted-path column-name keys to TypeWithId::id keys so the
-  // typeAddedHandler can look them up in O(1) as each TypeBuilder is
-  // constructed. Paths that fail to resolve are silently dropped (see
-  // VeloxWriterOptions::attributesByColumn doc).
-  std::unordered_map<uint32_t, std::vector<std::pair<std::string, std::string>>>
-      attributesByNodeId;
-  if (!context.options().attributesByColumn.empty()) {
-    attributesByNodeId.reserve(context.options().attributesByColumn.size());
-    for (const auto& [path, attributes] :
-         context.options().attributesByColumn) {
-      const auto* resolved = resolveDottedPath(*type, path);
-      if (resolved != nullptr) {
-        attributesByNodeId.emplace(resolved->id(), attributes);
-      }
-    }
-  }
-
+  // Stamp per-node attributes (e.g. Iceberg field-ids) keyed by pre-order node
+  // id. schemaAttributes uses the same TypeWithId::id() numbering the handler
+  // receives, so the lookup is a direct O(1) hit as each TypeBuilder is
+  // constructed. Ids with no matching node are simply never looked up.
   return FieldWriter::create(
-      context,
-      type,
-      [&, nodeAttributes = std::move(attributesByNodeId)](
-          TypeBuilder& type, uint32_t nodeId) {
+      context, type, [&context](TypeBuilder& type, uint32_t nodeId) {
         if (type.kind() == Kind::Row) {
           getStreamContext(type.asRow().nullsDescriptor())
               .setIsNullStream(true);
@@ -631,8 +564,9 @@ std::unique_ptr<FieldWriter> createRootFieldWriter(
           getStreamContext(type.asFlatMap().nullsDescriptor())
               .setIsNullStream(true);
         }
-        auto it = nodeAttributes.find(nodeId);
-        if (it != nodeAttributes.end()) {
+        const auto& schemaAttributes = context.options().schemaAttributes;
+        auto it = schemaAttributes.find(nodeId);
+        if (it != schemaAttributes.end()) {
           type.setAttributes(it->second);
         }
       });

--- a/dwio/nimble/velox/VeloxWriterOptions.h
+++ b/dwio/nimble/velox/VeloxWriterOptions.h
@@ -118,29 +118,21 @@ struct VeloxWriterOptions {
   /// the flat-map writer holds.
   uint32_t maxFlatMapKeys{kDefaultMaxFlatMapKeys};
 
-  /// Per-column string-keyed attributes to stamp onto the NIMBLE schema.
-  /// Keyed by a dotted path of `RowType` child names that resolves to a node
-  /// in the input `RowType`. The empty key (`""`) targets the root.
-  /// Examples:
-  ///   "id"              -> top-level column `id`
-  ///   "user.name"       -> field `name` inside top-level struct column
-  ///                        `user`
-  /// Each value is the attribute bag forwarded verbatim to
+  /// Per-type string attributes (e.g. Iceberg "iceberg.id") keyed by pre-order
+  /// schema node id (matching `TypeWithId::id()`: root = 0, then depth-first --
+  /// ROW children in field order, ARRAY element, MAP key then value). Each
+  /// value is the attribute bag forwarded verbatim to
   /// `TypeBuilder::setAttributes(...)` on the matching node and preserves
   /// insertion order end-to-end through schema serialization.
   ///
-  /// Paths that do not resolve to a node in the input `RowType` are silently
-  /// ignored so that callers can submit a superset of attributes and let
-  /// schema evolution drop entries that no longer apply. Paths walking
-  /// through non-`RowType` parents are not supported in this diff; callers
-  /// currently emit flat top-level / nested-struct keys only, and richer
-  /// addressing can be added in a follow-up if needed.
+  /// Node ids that do not correspond to a node in the input schema are ignored,
+  /// so callers may submit a superset and let schema evolution drop entries
+  /// that no longer apply.
   ///
   /// Empty map (default) is a no-op: every existing NIMBLE writer produces
   /// byte-identical files.
-  folly::
-      F14FastMap<std::string, std::vector<std::pair<std::string, std::string>>>
-          attributesByColumn;
+  folly::F14FastMap<uint32_t, std::vector<std::pair<std::string, std::string>>>
+      schemaAttributes;
 
   /// When true, the writer skips encoding flat map in-map boolean streams that
   /// are all-true (every row has the key) or all-false (no row has the key).

--- a/dwio/nimble/velox/tests/VeloxReaderTest.cpp
+++ b/dwio/nimble/velox/tests/VeloxReaderTest.cpp
@@ -7533,11 +7533,10 @@ TEST_P(VeloxReaderTest, openZLCompressionRoundTrip) {
 // ---------------------------------------------------------------------------
 // End-to-end attributes propagation through the writer/reader pipeline.
 //
-// Validates VeloxWriterOptions::attributesByColumn round-trips through the
+// Validates VeloxWriterOptions::schemaAttributes round-trips through the
 // writer pipeline, the schema flatbuffer, and back through VeloxReader to
-// the deserialized Type tree exposed by reader.schema(). Top-level and
-// nested-struct dotted-path keys are covered; unresolved paths must be
-// silently dropped per the documented contract.
+// the deserialized Type tree exposed by reader.schema(). Node ids are pre-order
+// (TypeWithId::id()); ids with no matching node must be ignored.
 // ---------------------------------------------------------------------------
 TEST_P(VeloxReaderTest, attributesByColumnRoundTrip) {
   facebook::velox::test::VectorMaker vectorMaker(leafPool_.get());
@@ -7548,22 +7547,22 @@ TEST_P(VeloxReaderTest, attributesByColumnRoundTrip) {
   auto type = velox::ROW({"id", "user"}, {velox::BIGINT(), userType});
 
   facebook::nimble::VeloxWriterOptions writerOptions;
-  // Top-level leaf and a nested-struct leaf via dotted path. The bogus path
-  // "user.does_not_exist" must be silently dropped.
-  writerOptions.attributesByColumn["id"] = {
+  // Pre-order node ids: id=1, user=2, user.name=3, user.age=4. Node 99 has no
+  // matching schema node and must be ignored.
+  writerOptions.schemaAttributes[1] = {
       {"key.a", "1"},
       {"key.b", "true"},
       {"key.c", "LONG"},
   };
-  writerOptions.attributesByColumn["user"] = {
+  writerOptions.schemaAttributes[2] = {
       {"key.a", "2"},
       {"key.b", "false"},
   };
-  writerOptions.attributesByColumn["user.name"] = {
+  writerOptions.schemaAttributes[3] = {
       {"key.a", "3"},
       {"key.b", "true"},
   };
-  writerOptions.attributesByColumn["user.does_not_exist"] = {
+  writerOptions.schemaAttributes[99] = {
       {"key.a", "999"},
   };
 
@@ -7632,7 +7631,81 @@ TEST_P(VeloxReaderTest, attributesByColumnRoundTrip) {
   EXPECT_TRUE(ageType->attributes().empty());
 }
 
-// Backward-compat: a writer that does NOT set attributesByColumn must
+// ---------------------------------------------------------------------------
+// Node-id addressing of ARRAY / MAP children through schemaAttributes.
+//
+// Validates that the list element and map key/value nodes (pre-order ids)
+// round-trip their attributes. Ids with no matching node must be ignored.
+// ---------------------------------------------------------------------------
+TEST_P(VeloxReaderTest, attributesByColumnRoundTripCollections) {
+  facebook::velox::test::VectorMaker vectorMaker(leafPool_.get());
+
+  // ROW{tags ARRAY<INTEGER>, props MAP<INTEGER, BIGINT>}
+  auto type = velox::ROW(
+      {"tags", "props"},
+      {velox::ARRAY(velox::INTEGER()),
+       velox::MAP(velox::INTEGER(), velox::BIGINT())});
+
+  facebook::nimble::VeloxWriterOptions writerOptions;
+  // Pre-order node ids: tags=1, element=2, props=3, key=4, value=5.
+  writerOptions.schemaAttributes[1] = {{"iceberg.id", "1"}};
+  writerOptions.schemaAttributes[2] = {{"iceberg.id", "2"}};
+  writerOptions.schemaAttributes[3] = {{"iceberg.id", "3"}};
+  writerOptions.schemaAttributes[4] = {{"iceberg.id", "4"}};
+  writerOptions.schemaAttributes[5] = {{"iceberg.id", "5"}};
+  // A node id past the end of the schema must be ignored.
+  writerOptions.schemaAttributes[99] = {{"iceberg.id", "999"}};
+
+  std::string file;
+  auto writeFile = std::make_unique<velox::InMemoryWriteFile>(&file);
+  nimble::VeloxWriter writer(
+      type, std::move(writeFile), *rootPool_, std::move(writerOptions));
+  auto tags = vectorMaker.arrayVector<int32_t>({{1, 2}, {3}});
+  auto props = vectorMaker.mapVector<int32_t, int64_t>(
+      /*size*/
+      2,
+      /*sizeAt*/ [](auto /*row*/) { return 1; },
+      /*keyAt*/ [](auto row) { return row; },
+      /*valueAt*/ [](auto row) { return row; });
+  auto vector = vectorMaker.rowVector({"tags", "props"}, {tags, props});
+  writer.write(vector);
+  writer.close();
+
+  velox::InMemoryReadFile readFile(file);
+  auto selector = std::make_shared<velox::dwio::common::ColumnSelector>(type);
+  nimble::VeloxReader reader(
+      &readFile, *leafPool_, std::move(selector), createReadParams());
+  const auto& root = reader.schema();
+  const auto& rowSchema = root->asRow();
+  ASSERT_EQ(2, rowSchema.childrenCount());
+
+  // List: attributes on the array node and on its element.
+  const auto& tagsType = rowSchema.childAt(0);
+  ASSERT_EQ(nimble::Kind::Array, tagsType->kind());
+  const std::vector<std::pair<std::string, std::string>> kTagsAttrs = {
+      {"iceberg.id", "1"}};
+  EXPECT_EQ(kTagsAttrs, tagsType->attributes());
+  const auto& elementType = tagsType->asArray().elements();
+  const std::vector<std::pair<std::string, std::string>> kElementAttrs = {
+      {"iceberg.id", "2"}};
+  EXPECT_EQ(kElementAttrs, elementType->attributes());
+
+  // Map: attributes on the map node and on its key / value.
+  const auto& propsType = rowSchema.childAt(1);
+  ASSERT_EQ(nimble::Kind::Map, propsType->kind());
+  const std::vector<std::pair<std::string, std::string>> kPropsAttrs = {
+      {"iceberg.id", "3"}};
+  EXPECT_EQ(kPropsAttrs, propsType->attributes());
+  const auto& mapType = propsType->asMap();
+  const std::vector<std::pair<std::string, std::string>> kKeyAttrs = {
+      {"iceberg.id", "4"}};
+  EXPECT_EQ(kKeyAttrs, mapType.keys()->attributes());
+  const std::vector<std::pair<std::string, std::string>> kValueAttrs = {
+      {"iceberg.id", "5"}};
+  EXPECT_EQ(kValueAttrs, mapType.values()->attributes());
+}
+
+// Backward-compat: a writer that does NOT set schemaAttributes must
 // produce a NIMBLE file whose deserialized Type tree exposes empty
 // attributes on every node. Pins the no-op upgrade path for every
 // existing NIMBLE writer.


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebookincubator/velox/pull/18269

Enables Iceberg field-id-based schema evolution for NIMBLE (Alpha) Iceberg
tables by stamping `iceberg.id` (and Iceberg V3 type) attributes on every schema
node -- top-level columns, nested struct fields, and list element / map
key/value at any depth -- matching DWRF's schemaAttributes.

Following review of the initial dotted-path approach (D113527853/D113527854),
per-node attributes are keyed by pre-order schema node id (matching the writer's
TypeWithId::id()), exactly like DWRF's Writer::schemaAttributes. Node-id
addressing is unambiguous (no field-name collisions or dot-in-name hazard),
needs no field-name alignment between the Iceberg and engine schemas, and is the
representation the writer already used internally.

- Native (nimble): VeloxWriterOptions::attributesByColumn -> schemaAttributes
  keyed by uint32 pre-order node id; the writer stamps directly by nodeId in the
  typeAddedHandler (deleted resolveDottedPath). NimbleWriterOptions bridge and
  NimbleWriterOptionBuilder::withSchemaAttributes retyped to match.
- alpha_jni transport: proto column_attributes -> map<uint32, ColumnAttributes>;
  AlphaWriterJNI and the Java JniAlphaWriter / JniAlphaWriterOptions /
  AlphaPageWriterOptions retyped to integer keys.
- Producers: NimbleWriterOptionsAdapter (native Presto) and
  NimbleFormats.buildColumnAttributes (Flink/Spark) emit pre-order node-id keys,
  walking the Iceberg field-id tree in lockstep with the schema. Dropped the
  now-unneeded validateColumnAttributeAlignment and engine-path collectors --
  positional addressing needs no name alignment.

Reviewed By: xiaoxmeng

Differential Revision: D113527853


