### PR TITLE
feat(nimble): Add top-level column index projection to Deserializer (#1017)

### DIFF
--- a/dwio/nimble/serializer/Deserializer.cpp
+++ b/dwio/nimble/serializer/Deserializer.cpp
@@ -702,6 +702,16 @@ bool checkColumnProjectionSubfield(
   return false;
 }
 
+std::vector<Deserializer::Subfield> makeSelectedColumnSubfields(
+    const std::vector<std::string>& selectedColumns) {
+  std::vector<Deserializer::Subfield> selectedSubfields;
+  selectedSubfields.reserve(selectedColumns.size());
+  for (const auto& column : selectedColumns) {
+    selectedSubfields.emplace_back(column);
+  }
+  return selectedSubfields;
+}
+
 } // namespace
 
 Deserializer::ProjectedField* Deserializer::ProjectedField::ensureChild(
@@ -857,6 +867,18 @@ Deserializer::Deserializer(
   }
 
   initializeColumnProjection(veloxType, selectedSubfields);
+}
+
+std::unique_ptr<Deserializer> Deserializer::createForSelectedColumns(
+    std::shared_ptr<const Type> schema,
+    const std::vector<std::string>& selectedColumns,
+    velox::memory::MemoryPool* pool,
+    DeserializerOptions options) {
+  return std::make_unique<Deserializer>(
+      std::move(schema),
+      makeSelectedColumnSubfields(selectedColumns),
+      pool,
+      std::move(options));
 }
 
 void Deserializer::initializeColumnProjection(

--- a/dwio/nimble/serializer/Deserializer.h
+++ b/dwio/nimble/serializer/Deserializer.h
@@ -69,6 +69,17 @@ class Deserializer {
       velox::memory::MemoryPool* pool,
       DeserializerOptions options);
 
+  /// Builds a deserializer that reads columns identified by Subfield
+  /// expressions, such as "weight" or "outer.inner".
+  /// Empty selectedColumns reads all fields.
+  /// Output ordering follows Subfield projection semantics and is
+  /// lexicographical by field name, not the order of selectedColumns.
+  static std::unique_ptr<Deserializer> createForSelectedColumns(
+      std::shared_ptr<const Type> schema,
+      const std::vector<std::string>& selectedColumns,
+      velox::memory::MemoryPool* pool,
+      DeserializerOptions options);
+
   ~Deserializer();
 
   Deserializer(Deserializer&&) = delete;

--- a/dwio/nimble/serializer/tests/ProjectorTest.cpp
+++ b/dwio/nimble/serializer/tests/ProjectorTest.cpp
@@ -687,6 +687,115 @@ TEST_F(ProjectorTest, columnProjectionDeserializerBuildsProjectedType) {
   EXPECT_EQ(b->valueAt(2), 300);
 }
 
+TEST_F(ProjectorTest, columnProjectionDeserializerSelectsColumnsByPath) {
+  auto type = ROW({
+      {"z", VARCHAR()},
+      {"a", INTEGER()},
+      {"weight", BIGINT()},
+      {"outer", ROW({{"inner", BIGINT()}, {"ignored", VARCHAR()}})},
+  });
+  auto outer = makeSimpleRowVector(
+      {"inner", "ignored"},
+      {
+          makeIntVector<int64_t>({300, 400}),
+          makeStringVector({"unused", "unused"}),
+      });
+  auto vec = makeSimpleRowVector(
+      {"z", "a", "weight", "outer"},
+      {
+          makeStringVector({"x", "y"}),
+          makeIntVector<int32_t>({1, 2}),
+          makeIntVector<int64_t>({100, 200}),
+          outer,
+      });
+  auto serialized =
+      serialize(vec, type, {.version = SerializationVersion::kSerialization});
+  auto inputSchema =
+      getNimbleSchema(type, {.version = SerializationVersion::kSerialization});
+
+  {
+    auto deserializer = Deserializer::createForSelectedColumns(
+        inputSchema,
+        /*selectedColumns=*/{"weight"},
+        pool_.get(),
+        {.hasHeader = true});
+    VectorPtr output;
+    deserializer->deserialize(serialized, output);
+
+    EXPECT_TRUE(output->type()->equivalent(*ROW({{"weight", BIGINT()}})));
+    auto* weight = output->asChecked<RowVector>()
+                       ->childAt(0)
+                       ->asChecked<FlatVector<int64_t>>();
+    EXPECT_EQ(weight->valueAt(0), 100);
+    EXPECT_EQ(weight->valueAt(1), 200);
+  }
+
+  {
+    auto deserializer = Deserializer::createForSelectedColumns(
+        inputSchema,
+        /*selectedColumns=*/{"z", "a", "weight"},
+        pool_.get(),
+        {.hasHeader = true});
+    VectorPtr output;
+    deserializer->deserialize(serialized, output);
+
+    EXPECT_TRUE(output->type()->equivalent(
+        *ROW({{"a", INTEGER()}, {"weight", BIGINT()}, {"z", VARCHAR()}})));
+  }
+
+  {
+    auto deserializer = Deserializer::createForSelectedColumns(
+        inputSchema,
+        /*selectedColumns=*/{"outer.inner"},
+        pool_.get(),
+        {.hasHeader = true});
+    VectorPtr output;
+    deserializer->deserialize(serialized, output);
+
+    EXPECT_TRUE(output->type()->equivalent(
+        *ROW({{"outer", ROW({{"inner", BIGINT()}})}})));
+    auto* inner = output->asChecked<RowVector>()
+                      ->childAt(0)
+                      ->asChecked<RowVector>()
+                      ->childAt(0)
+                      ->asChecked<FlatVector<int64_t>>();
+    EXPECT_EQ(inner->valueAt(0), 300);
+    EXPECT_EQ(inner->valueAt(1), 400);
+  }
+
+  {
+    auto deserializer = Deserializer::createForSelectedColumns(
+        inputSchema, {}, pool_.get(), {.hasHeader = true});
+    VectorPtr output;
+    deserializer->deserialize(serialized, output);
+
+    EXPECT_TRUE(output->type()->equivalent(*type));
+    EXPECT_TRUE(output->equalValueAt(vec.get(), 0, 0));
+    EXPECT_TRUE(output->equalValueAt(vec.get(), 1, 1));
+  }
+}
+
+TEST_F(ProjectorTest, columnProjectionDeserializerRejectsInvalidColumns) {
+  auto type = ROW({
+      {"data", BIGINT()},
+      {"weight", INTEGER()},
+  });
+  auto inputSchema =
+      getNimbleSchema(type, {.version = SerializationVersion::kSerialization});
+
+  NIMBLE_ASSERT_THROW(
+      Deserializer::createForSelectedColumns(
+          inputSchema, {"weight", "weight"}, pool_.get(), {}),
+      "Duplicate column projection subfield: weight");
+  NIMBLE_ASSERT_USER_THROW(
+      Deserializer::createForSelectedColumns(
+          inputSchema,
+          /*selectedColumns=*/{"missing"},
+          pool_.get(),
+          {.hasHeader = true}),
+      "Column projection subfield does not exist in schema: missing");
+}
+
 TEST_F(ProjectorTest, columnProjectionDeserializerCanBeReused) {
   auto type = ROW({
       {"a", INTEGER()},


### PR DESCRIPTION
Summary:

Added the named factory createForTopLevelColumns to support Nimble deserialization using numeric top-level column indices instead of field names.

`Deserializer::createForSelectedColumns`, which accepts zero-based Velox top-level column indices. Output ordering therefore remains unchanged and follows the existing lexicographical-by-field- name contract.

Reviewed By: xiaoxmeng

Differential Revision: D113589956


