### PR TITLE
fix(nimble): Decouple encode-scratch reclaim from lowMemoryMode growth policy (#1018)

### DIFF
--- a/dwio/nimble/velox/VeloxWriter.cpp
+++ b/dwio/nimble/velox/VeloxWriter.cpp
@@ -45,6 +45,7 @@
 #include "dwio/nimble/velox/StatsGenerated.h"
 #include "dwio/nimble/velox/StreamChunker.h"
 #include "dwio/nimble/velox/stats/VectorizedStatistics.h"
+#include "velox/common/memory/MemoryArbitrator.h"
 #include "velox/common/testutil/TestValue.h"
 #include "velox/common/time/CpuWallTimer.h"
 #include "velox/common/time/Timer.h"
@@ -68,12 +69,8 @@ class WriterContext : public FieldWriterContext {
             this->options_.metricsLogger == nullptr
                 ? std::make_shared<MetricsLogger>()
                 : this->options_.metricsLogger} {
-    inputBufferGrowthPolicy_ = this->options_.lowMemoryMode
-        ? std::make_unique<ExactGrowthPolicy>()
-        : this->options_.inputGrowthPolicyFactory();
-    stringBufferGrowthPolicy_ = this->options_.lowMemoryMode
-        ? std::make_unique<ExactGrowthPolicy>()
-        : this->options_.stringBufferGrowthPolicyFactory();
+    inputBufferGrowthPolicy_ = this->options_.makeInputBufferGrowthPolicy();
+    stringBufferGrowthPolicy_ = this->options_.makeStringBufferGrowthPolicy();
     ignoreTopLevelNulls_ = options_.ignoreTopLevelNulls;
     disableSharedStringBuffers_ = options_.disableSharedStringBuffers;
     maxFlatMapKeys_ = options_.maxFlatMapKeys;
@@ -1300,12 +1297,14 @@ void VeloxWriter::clearEncodingBuffer() {
   if (encodingBuffer_ == nullptr) {
     return;
   }
-  if (context_->options().lowMemoryMode) {
-    encodingBuffer_.reset();
+  if (velox::memory::underMemoryArbitration()) {
+    // Under memory arbitration, free the buffer and pools.
     encodingBufferPools_.clear();
-    return;
+    encodingBuffer_.reset();
+  } else {
+    // Normal flush: rewind and keep chunks allocated for reuse.
+    encodingBuffer_->reset();
   }
-  encodingBuffer_->reset();
 }
 
 void VeloxWriter::ensureWriteStreams() {

--- a/dwio/nimble/velox/VeloxWriterOptions.h
+++ b/dwio/nimble/velox/VeloxWriterOptions.h
@@ -286,6 +286,20 @@ struct VeloxWriterOptions {
     return DefaultInputBufferGrowthPolicy::withStringBufferRanges();
   };
 
+  /// Input-buffer growth policy for these options: ExactGrowthPolicy under
+  /// lowMemoryMode, else the amortized factory.
+  std::unique_ptr<InputBufferGrowthPolicy> makeInputBufferGrowthPolicy() const {
+    return lowMemoryMode ? std::make_unique<ExactGrowthPolicy>()
+                         : inputGrowthPolicyFactory();
+  }
+
+  /// String-buffer counterpart of makeInputBufferGrowthPolicy().
+  std::unique_ptr<InputBufferGrowthPolicy> makeStringBufferGrowthPolicy()
+      const {
+    return lowMemoryMode ? std::make_unique<ExactGrowthPolicy>()
+                         : stringBufferGrowthPolicyFactory();
+  }
+
   std::function<std::unique_ptr<velox::memory::MemoryReclaimer>()>
       reclaimerFactory = []() { return nullptr; };
 

--- a/dwio/nimble/velox/tests/BufferGrowthPolicyTest.cpp
+++ b/dwio/nimble/velox/tests/BufferGrowthPolicyTest.cpp
@@ -17,6 +17,7 @@
 #include <gtest/gtest.h>
 
 #include "dwio/nimble/velox/BufferGrowthPolicy.h"
+#include "dwio/nimble/velox/VeloxWriterOptions.h"
 
 namespace facebook::nimble {
 
@@ -137,4 +138,32 @@ INSTANTIATE_TEST_CASE_P(
             .size = 2048,
             .capacity = 1000,
             .expectedNewCapacity = 2073}));
+
+// Regression guard (D111195999): the growth policy stays amortized by default;
+// only lowMemoryMode switches to ExactGrowthPolicy. Spilling writers no longer
+// force lowMemoryMode, so they keep the amortized (O(N)) policy.
+TEST(WriterOptionsGrowthPolicyTest, DefaultUsesAmortizedGrowth) {
+  VeloxWriterOptions options; // lowMemoryMode defaults to false
+
+  // Amortized policy leaves headroom above the requested size.
+  EXPECT_GT(
+      options.makeInputBufferGrowthPolicy()->getExtendedCapacity(
+          /*newSize=*/100, /*capacity=*/0),
+      100u);
+  EXPECT_GT(
+      options.makeStringBufferGrowthPolicy()->getExtendedCapacity(100, 0),
+      100u);
+}
+
+TEST(WriterOptionsGrowthPolicyTest, LowMemoryModeForcesExactGrowth) {
+  VeloxWriterOptions options;
+  options.lowMemoryMode = true;
+
+  // Grow-to-exact: no headroom.
+  EXPECT_EQ(
+      options.makeInputBufferGrowthPolicy()->getExtendedCapacity(100, 0), 100u);
+  EXPECT_EQ(
+      options.makeStringBufferGrowthPolicy()->getExtendedCapacity(100, 0),
+      100u);
+}
 } // namespace facebook::nimble


### PR DESCRIPTION
Summary:

**Issue:** D111195999 set lowMemoryMode=true on any writer that has a spillConfig, to
release encoding scratch buffers on flush. The problem is that lowMemoryMode
also switches the ingest buffer growth policy from Default to Exact (in the
WriterContext ctor). Default grows capacity geometrically and leaves headroom,
so most appends reuse the existing allocation; Exact grows to exactly the
requested size, so every append reallocates and copies the whole accumulated
Vector<T>. On wide embedding columns (2048 doubles/row, millions of rows/file)
that is an O(N^2) copy on the write path, and it runs under the ingestion timer
so it all lands in nimble.ingestionCpuNanos. Only spill-enabled writes hit it,
which is why it looked intermittent.

On a 5M-row file, TableWrite.92.nimble.ingestionCpuNanos went from ~1.3 us/row
to ~490 us/row (~380x).

**Fix**: reclaimEncodingScratchOnFlush now controls the scratch release on its own,
independent of the growth policy. NimbleWriter sets it (instead of lowMemoryMode)
for spillable writers, so they still free scratch on flush but keep the
amortized growth policy. lowMemoryMode is unchanged for callers that set it
directly.

Reviewed By: xiaoxmeng, shrinidhijoshi

Differential Revision: D113617153


