### PR TITLE
feat: Add encoded slice support

### DIFF
--- a/dwio/nimble/common/CMakeLists.txt
+++ b/dwio/nimble/common/CMakeLists.txt
@@ -17,6 +17,7 @@ add_library(
   nimble_common
   Buffer.cpp
   Checksum.cpp
+  DataTypeDispatch.h
   Exceptions.cpp
   FixedBitArray.cpp
   MetricsLogger.cpp

--- a/dwio/nimble/common/DataTypeDispatch.h
+++ b/dwio/nimble/common/DataTypeDispatch.h
@@ -1,0 +1,300 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <cstdint>
+#include <string_view>
+
+#include "dwio/nimble/common/Exceptions.h"
+#include "dwio/nimble/common/Types.h"
+
+namespace facebook::nimble {
+
+#define NIMBLE_RETURN_BY_DATA_TYPE_OR(dataType, Type, expression, ...) \
+  switch (dataType) {                                                  \
+    case ::facebook::nimble::DataType::Int8: {                         \
+      using Type = int8_t;                                             \
+      return (expression);                                             \
+    }                                                                  \
+    case ::facebook::nimble::DataType::Uint8: {                        \
+      using Type = uint8_t;                                            \
+      return (expression);                                             \
+    }                                                                  \
+    case ::facebook::nimble::DataType::Int16: {                        \
+      using Type = int16_t;                                            \
+      return (expression);                                             \
+    }                                                                  \
+    case ::facebook::nimble::DataType::Uint16: {                       \
+      using Type = uint16_t;                                           \
+      return (expression);                                             \
+    }                                                                  \
+    case ::facebook::nimble::DataType::Int32: {                        \
+      using Type = int32_t;                                            \
+      return (expression);                                             \
+    }                                                                  \
+    case ::facebook::nimble::DataType::Uint32: {                       \
+      using Type = uint32_t;                                           \
+      return (expression);                                             \
+    }                                                                  \
+    case ::facebook::nimble::DataType::Int64: {                        \
+      using Type = int64_t;                                            \
+      return (expression);                                             \
+    }                                                                  \
+    case ::facebook::nimble::DataType::Uint64: {                       \
+      using Type = uint64_t;                                           \
+      return (expression);                                             \
+    }                                                                  \
+    case ::facebook::nimble::DataType::Float: {                        \
+      using Type = float;                                              \
+      return (expression);                                             \
+    }                                                                  \
+    case ::facebook::nimble::DataType::Double: {                       \
+      using Type = double;                                             \
+      return (expression);                                             \
+    }                                                                  \
+    case ::facebook::nimble::DataType::Bool: {                         \
+      using Type = bool;                                               \
+      return (expression);                                             \
+    }                                                                  \
+    case ::facebook::nimble::DataType::String: {                       \
+      using Type = std::string_view;                                   \
+      return (expression);                                             \
+    }                                                                  \
+    default: {                                                         \
+      __VA_ARGS__;                                                     \
+    }                                                                  \
+  }
+
+#define NIMBLE_RETURN_BY_DATA_TYPE(dataType, Type, expression) \
+  NIMBLE_RETURN_BY_DATA_TYPE_OR(                               \
+      dataType,                                                \
+      Type,                                                    \
+      expression,                                              \
+      NIMBLE_UNREACHABLE("Unsupported data type {}.", dataType))
+
+#define NIMBLE_TRY_RETURN_BY_DATA_TYPE(dataType, Type, expression) \
+  NIMBLE_RETURN_BY_DATA_TYPE_OR(dataType, Type, expression, return {})
+
+#define NIMBLE_RETURN_BY_VARINT_DATA_TYPE_OR(dataType, Type, expression, ...) \
+  switch (dataType) {                                                         \
+    case ::facebook::nimble::DataType::Int32: {                               \
+      using Type = int32_t;                                                   \
+      return (expression);                                                    \
+    }                                                                         \
+    case ::facebook::nimble::DataType::Uint32: {                              \
+      using Type = uint32_t;                                                  \
+      return (expression);                                                    \
+    }                                                                         \
+    case ::facebook::nimble::DataType::Int64: {                               \
+      using Type = int64_t;                                                   \
+      return (expression);                                                    \
+    }                                                                         \
+    case ::facebook::nimble::DataType::Uint64: {                              \
+      using Type = uint64_t;                                                  \
+      return (expression);                                                    \
+    }                                                                         \
+    case ::facebook::nimble::DataType::Float: {                               \
+      using Type = float;                                                     \
+      return (expression);                                                    \
+    }                                                                         \
+    case ::facebook::nimble::DataType::Double: {                              \
+      using Type = double;                                                    \
+      return (expression);                                                    \
+    }                                                                         \
+    default: {                                                                \
+      __VA_ARGS__;                                                            \
+    }                                                                         \
+  }
+
+#define NIMBLE_RETURN_BY_VARINT_DATA_TYPE(dataType, Type, expression) \
+  NIMBLE_RETURN_BY_VARINT_DATA_TYPE_OR(                               \
+      dataType,                                                       \
+      Type,                                                           \
+      expression,                                                     \
+      NIMBLE_UNREACHABLE("Unsupported varint data type {}.", dataType))
+
+#define NIMBLE_TRY_RETURN_BY_VARINT_DATA_TYPE(dataType, Type, expression) \
+  NIMBLE_RETURN_BY_VARINT_DATA_TYPE_OR(dataType, Type, expression, return {})
+
+#define NIMBLE_RETURN_BY_NON_BOOL_DATA_TYPE_OR(  \
+    dataType, Type, expression, ...)             \
+  switch (dataType) {                            \
+    case ::facebook::nimble::DataType::Int8: {   \
+      using Type = int8_t;                       \
+      return (expression);                       \
+    }                                            \
+    case ::facebook::nimble::DataType::Uint8: {  \
+      using Type = uint8_t;                      \
+      return (expression);                       \
+    }                                            \
+    case ::facebook::nimble::DataType::Int16: {  \
+      using Type = int16_t;                      \
+      return (expression);                       \
+    }                                            \
+    case ::facebook::nimble::DataType::Uint16: { \
+      using Type = uint16_t;                     \
+      return (expression);                       \
+    }                                            \
+    case ::facebook::nimble::DataType::Int32: {  \
+      using Type = int32_t;                      \
+      return (expression);                       \
+    }                                            \
+    case ::facebook::nimble::DataType::Uint32: { \
+      using Type = uint32_t;                     \
+      return (expression);                       \
+    }                                            \
+    case ::facebook::nimble::DataType::Int64: {  \
+      using Type = int64_t;                      \
+      return (expression);                       \
+    }                                            \
+    case ::facebook::nimble::DataType::Uint64: { \
+      using Type = uint64_t;                     \
+      return (expression);                       \
+    }                                            \
+    case ::facebook::nimble::DataType::Float: {  \
+      using Type = float;                        \
+      return (expression);                       \
+    }                                            \
+    case ::facebook::nimble::DataType::Double: { \
+      using Type = double;                       \
+      return (expression);                       \
+    }                                            \
+    case ::facebook::nimble::DataType::String: { \
+      using Type = std::string_view;             \
+      return (expression);                       \
+    }                                            \
+    default: {                                   \
+      __VA_ARGS__;                               \
+    }                                            \
+  }
+
+#define NIMBLE_RETURN_BY_NON_BOOL_DATA_TYPE(dataType, Type, expression) \
+  NIMBLE_RETURN_BY_NON_BOOL_DATA_TYPE_OR(                               \
+      dataType,                                                         \
+      Type,                                                             \
+      expression,                                                       \
+      NIMBLE_UNREACHABLE("Unsupported non-bool data type {}.", dataType))
+
+#define NIMBLE_TRY_RETURN_BY_NON_BOOL_DATA_TYPE(dataType, Type, expression) \
+  NIMBLE_RETURN_BY_NON_BOOL_DATA_TYPE_OR(dataType, Type, expression, return {})
+
+#define NIMBLE_RETURN_BY_NUMERIC_DATA_TYPE_OR(dataType, Type, expression, ...) \
+  switch (dataType) {                                                          \
+    case ::facebook::nimble::DataType::Int8: {                                 \
+      using Type = int8_t;                                                     \
+      return (expression);                                                     \
+    }                                                                          \
+    case ::facebook::nimble::DataType::Uint8: {                                \
+      using Type = uint8_t;                                                    \
+      return (expression);                                                     \
+    }                                                                          \
+    case ::facebook::nimble::DataType::Int16: {                                \
+      using Type = int16_t;                                                    \
+      return (expression);                                                     \
+    }                                                                          \
+    case ::facebook::nimble::DataType::Uint16: {                               \
+      using Type = uint16_t;                                                   \
+      return (expression);                                                     \
+    }                                                                          \
+    case ::facebook::nimble::DataType::Int32: {                                \
+      using Type = int32_t;                                                    \
+      return (expression);                                                     \
+    }                                                                          \
+    case ::facebook::nimble::DataType::Uint32: {                               \
+      using Type = uint32_t;                                                   \
+      return (expression);                                                     \
+    }                                                                          \
+    case ::facebook::nimble::DataType::Int64: {                                \
+      using Type = int64_t;                                                    \
+      return (expression);                                                     \
+    }                                                                          \
+    case ::facebook::nimble::DataType::Uint64: {                               \
+      using Type = uint64_t;                                                   \
+      return (expression);                                                     \
+    }                                                                          \
+    case ::facebook::nimble::DataType::Float: {                                \
+      using Type = float;                                                      \
+      return (expression);                                                     \
+    }                                                                          \
+    case ::facebook::nimble::DataType::Double: {                               \
+      using Type = double;                                                     \
+      return (expression);                                                     \
+    }                                                                          \
+    default: {                                                                 \
+      __VA_ARGS__;                                                             \
+    }                                                                          \
+  }
+
+#define NIMBLE_RETURN_BY_NUMERIC_DATA_TYPE(dataType, Type, expression) \
+  NIMBLE_RETURN_BY_NUMERIC_DATA_TYPE_OR(                               \
+      dataType,                                                        \
+      Type,                                                            \
+      expression,                                                      \
+      NIMBLE_UNREACHABLE("Unsupported numeric data type {}.", dataType))
+
+#define NIMBLE_TRY_RETURN_BY_NUMERIC_DATA_TYPE(dataType, Type, expression) \
+  NIMBLE_RETURN_BY_NUMERIC_DATA_TYPE_OR(dataType, Type, expression, return {})
+
+#define NIMBLE_RETURN_BY_INTEGER_DATA_TYPE_OR(dataType, Type, expression, ...) \
+  switch (dataType) {                                                          \
+    case ::facebook::nimble::DataType::Int8: {                                 \
+      using Type = int8_t;                                                     \
+      return (expression);                                                     \
+    }                                                                          \
+    case ::facebook::nimble::DataType::Uint8: {                                \
+      using Type = uint8_t;                                                    \
+      return (expression);                                                     \
+    }                                                                          \
+    case ::facebook::nimble::DataType::Int16: {                                \
+      using Type = int16_t;                                                    \
+      return (expression);                                                     \
+    }                                                                          \
+    case ::facebook::nimble::DataType::Uint16: {                               \
+      using Type = uint16_t;                                                   \
+      return (expression);                                                     \
+    }                                                                          \
+    case ::facebook::nimble::DataType::Int32: {                                \
+      using Type = int32_t;                                                    \
+      return (expression);                                                     \
+    }                                                                          \
+    case ::facebook::nimble::DataType::Uint32: {                               \
+      using Type = uint32_t;                                                   \
+      return (expression);                                                     \
+    }                                                                          \
+    case ::facebook::nimble::DataType::Int64: {                                \
+      using Type = int64_t;                                                    \
+      return (expression);                                                     \
+    }                                                                          \
+    case ::facebook::nimble::DataType::Uint64: {                               \
+      using Type = uint64_t;                                                   \
+      return (expression);                                                     \
+    }                                                                          \
+    default: {                                                                 \
+      __VA_ARGS__;                                                             \
+    }                                                                          \
+  }
+
+#define NIMBLE_RETURN_BY_INTEGER_DATA_TYPE(dataType, Type, expression) \
+  NIMBLE_RETURN_BY_INTEGER_DATA_TYPE_OR(                               \
+      dataType,                                                        \
+      Type,                                                            \
+      expression,                                                      \
+      NIMBLE_UNREACHABLE("Unsupported integer data type {}.", dataType))
+
+#define NIMBLE_TRY_RETURN_BY_INTEGER_DATA_TYPE(dataType, Type, expression) \
+  NIMBLE_RETURN_BY_INTEGER_DATA_TYPE_OR(dataType, Type, expression, return {})
+
+} // namespace facebook::nimble

--- a/dwio/nimble/common/tests/CMakeLists.txt
+++ b/dwio/nimble/common/tests/CMakeLists.txt
@@ -26,6 +26,7 @@ add_executable(
   BitsTests.cpp
   ChunkHeaderTest.cpp
   ConstantsTest.cpp
+  DataTypeDispatchTest.cpp
   ExceptionHelperTest.cpp
   ExceptionTests.cpp
   FixedBitArrayTests.cpp

--- a/dwio/nimble/common/tests/DataTypeDispatchTest.cpp
+++ b/dwio/nimble/common/tests/DataTypeDispatchTest.cpp
@@ -1,0 +1,161 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "dwio/nimble/common/DataTypeDispatch.h"
+
+#include <string>
+#include <string_view>
+#include <type_traits>
+
+#include <gtest/gtest.h>
+
+#include "dwio/nimble/common/tests/GTestUtils.h"
+
+using namespace facebook;
+
+namespace {
+
+struct TypeName {
+  template <typename T>
+  std::string operator()() const {
+    if constexpr (std::is_same_v<T, int8_t>) {
+      return "int8";
+    } else if constexpr (std::is_same_v<T, uint8_t>) {
+      return "uint8";
+    } else if constexpr (std::is_same_v<T, int16_t>) {
+      return "int16";
+    } else if constexpr (std::is_same_v<T, uint16_t>) {
+      return "uint16";
+    } else if constexpr (std::is_same_v<T, int32_t>) {
+      return "int32";
+    } else if constexpr (std::is_same_v<T, uint32_t>) {
+      return "uint32";
+    } else if constexpr (std::is_same_v<T, int64_t>) {
+      return "int64";
+    } else if constexpr (std::is_same_v<T, uint64_t>) {
+      return "uint64";
+    } else if constexpr (std::is_same_v<T, float>) {
+      return "float";
+    } else if constexpr (std::is_same_v<T, double>) {
+      return "double";
+    } else if constexpr (std::is_same_v<T, bool>) {
+      return "bool";
+    } else if constexpr (std::is_same_v<T, std::string_view>) {
+      return "string_view";
+    }
+  }
+};
+
+std::string dispatchDataType(nimble::DataType dataType) {
+  NIMBLE_RETURN_BY_DATA_TYPE(dataType, T, TypeName{}.operator()<T>());
+}
+
+std::string tryDispatchDataType(nimble::DataType dataType) {
+  NIMBLE_TRY_RETURN_BY_DATA_TYPE(dataType, T, TypeName{}.operator()<T>());
+}
+
+std::string dispatchVarintDataType(nimble::DataType dataType) {
+  NIMBLE_RETURN_BY_VARINT_DATA_TYPE(dataType, T, TypeName{}.operator()<T>());
+}
+
+std::string dispatchNonBoolDataType(nimble::DataType dataType) {
+  NIMBLE_RETURN_BY_NON_BOOL_DATA_TYPE(dataType, T, TypeName{}.operator()<T>());
+}
+
+std::string dispatchNumericDataType(nimble::DataType dataType) {
+  NIMBLE_RETURN_BY_NUMERIC_DATA_TYPE(dataType, T, TypeName{}.operator()<T>());
+}
+
+std::string dispatchIntegerDataType(nimble::DataType dataType) {
+  NIMBLE_RETURN_BY_INTEGER_DATA_TYPE(dataType, T, TypeName{}.operator()<T>());
+}
+
+} // namespace
+
+TEST(DataTypeDispatchTest, dispatchesAllDataTypes) {
+  EXPECT_EQ(dispatchDataType(nimble::DataType::Int8), "int8");
+  EXPECT_EQ(dispatchDataType(nimble::DataType::Uint8), "uint8");
+  EXPECT_EQ(dispatchDataType(nimble::DataType::Int16), "int16");
+  EXPECT_EQ(dispatchDataType(nimble::DataType::Uint16), "uint16");
+  EXPECT_EQ(dispatchDataType(nimble::DataType::Int32), "int32");
+  EXPECT_EQ(dispatchDataType(nimble::DataType::Uint32), "uint32");
+  EXPECT_EQ(dispatchDataType(nimble::DataType::Int64), "int64");
+  EXPECT_EQ(dispatchDataType(nimble::DataType::Uint64), "uint64");
+  EXPECT_EQ(dispatchDataType(nimble::DataType::Float), "float");
+  EXPECT_EQ(dispatchDataType(nimble::DataType::Double), "double");
+  EXPECT_EQ(dispatchDataType(nimble::DataType::Bool), "bool");
+  EXPECT_EQ(dispatchDataType(nimble::DataType::String), "string_view");
+}
+
+TEST(DataTypeDispatchTest, tryDispatchReturnsDefaultForUndefined) {
+  EXPECT_EQ(tryDispatchDataType(nimble::DataType::Undefined), "");
+}
+
+TEST(DataTypeDispatchTest, dispatchRejectsUndefined) {
+  NIMBLE_ASSERT_THROW(
+      dispatchDataType(nimble::DataType::Undefined), "Unsupported data type");
+}
+
+TEST(DataTypeDispatchTest, dispatchesVarintDataTypes) {
+  EXPECT_EQ(dispatchVarintDataType(nimble::DataType::Int32), "int32");
+  EXPECT_EQ(dispatchVarintDataType(nimble::DataType::Uint32), "uint32");
+  EXPECT_EQ(dispatchVarintDataType(nimble::DataType::Int64), "int64");
+  EXPECT_EQ(dispatchVarintDataType(nimble::DataType::Uint64), "uint64");
+  EXPECT_EQ(dispatchVarintDataType(nimble::DataType::Float), "float");
+  EXPECT_EQ(dispatchVarintDataType(nimble::DataType::Double), "double");
+
+  NIMBLE_ASSERT_THROW(
+      dispatchVarintDataType(nimble::DataType::Int16),
+      "Unsupported varint data type");
+  NIMBLE_ASSERT_THROW(
+      dispatchVarintDataType(nimble::DataType::String),
+      "Unsupported varint data type");
+}
+
+TEST(DataTypeDispatchTest, dispatchesNonBoolDataTypes) {
+  EXPECT_EQ(dispatchNonBoolDataType(nimble::DataType::Int8), "int8");
+  EXPECT_EQ(dispatchNonBoolDataType(nimble::DataType::String), "string_view");
+
+  NIMBLE_ASSERT_THROW(
+      dispatchNonBoolDataType(nimble::DataType::Bool),
+      "Unsupported non-bool data type");
+  NIMBLE_ASSERT_THROW(
+      dispatchNonBoolDataType(nimble::DataType::Undefined),
+      "Unsupported non-bool data type");
+}
+
+TEST(DataTypeDispatchTest, dispatchesNumericDataTypes) {
+  EXPECT_EQ(dispatchNumericDataType(nimble::DataType::Int8), "int8");
+  EXPECT_EQ(dispatchNumericDataType(nimble::DataType::Double), "double");
+
+  NIMBLE_ASSERT_THROW(
+      dispatchNumericDataType(nimble::DataType::Bool),
+      "Unsupported numeric data type");
+  NIMBLE_ASSERT_THROW(
+      dispatchNumericDataType(nimble::DataType::String),
+      "Unsupported numeric data type");
+}
+
+TEST(DataTypeDispatchTest, dispatchesIntegerDataTypes) {
+  EXPECT_EQ(dispatchIntegerDataType(nimble::DataType::Int8), "int8");
+  EXPECT_EQ(dispatchIntegerDataType(nimble::DataType::Uint64), "uint64");
+
+  NIMBLE_ASSERT_THROW(
+      dispatchIntegerDataType(nimble::DataType::Float),
+      "Unsupported integer data type");
+  NIMBLE_ASSERT_THROW(
+      dispatchIntegerDataType(nimble::DataType::Bool),
+      "Unsupported integer data type");
+}

--- a/dwio/nimble/encodings/CMakeLists.txt
+++ b/dwio/nimble/encodings/CMakeLists.txt
@@ -18,6 +18,7 @@ add_subdirectory(legacy)
 add_library(
   nimble_encodings
   ConstantEncoding.cpp
+  EncodingSliceFactory.cpp
   FsstEncoding.cpp
   HuffmanEncoding.h
   MainlyConstantEncoding.cpp
@@ -28,6 +29,7 @@ add_library(
   common/Encoding.cpp
   common/EncodingFactory.cpp
   common/EncodingLayout.cpp
+  common/EncodingTypeDispatch.h
   selection/EncodingSelectionPolicy.cpp
   selection/Statistics.cpp
   views/DeltaBlockEncodingView.h

--- a/dwio/nimble/encodings/ConstantEncoding.h
+++ b/dwio/nimble/encodings/ConstantEncoding.h
@@ -21,6 +21,7 @@
 #include "dwio/nimble/common/Buffer.h"
 #include "dwio/nimble/common/Exceptions.h"
 #include "dwio/nimble/encodings/common/Encoding.h"
+#include "dwio/nimble/encodings/common/EncodingPrefix.h"
 #include "dwio/nimble/encodings/common/EncodingPrimitives.h"
 #include "dwio/nimble/encodings/common/EncodingType.h"
 #include "dwio/nimble/encodings/selection/EncodingSelection.h"
@@ -194,6 +195,36 @@ class ConstantEncodingBase
         options.allowNestedAlpSelection ? canonicalValue(values.front())
                                         : values.front(),
         pos);
+    NIMBLE_CHECK_EQ(pos - reserved, encodingSize, "Encoding size mismatch.");
+    return {reserved, encodingSize};
+  }
+
+  static std::string_view slice(
+      std::string_view encoded,
+      uint32_t offset,
+      uint32_t length,
+      Buffer& buffer,
+      const Encoding::Options& options = {}) {
+    const auto sourceRowCount =
+        EncodingPrefix::readRowCount(encoded, options.useVarintRowCount);
+    NIMBLE_CHECK_LE(offset, sourceRowCount);
+    NIMBLE_CHECK_LE(length, sourceRowCount - offset);
+
+    const auto sourcePrefixSize =
+        EncodingPrefix::prefixSize(encoded, options.useVarintRowCount);
+    const std::string_view valueData = encoded.substr(sourcePrefixSize);
+    const auto prefixSize =
+        EncodingPrefix::serializedSize(length, options.useVarintRowCount);
+    const auto encodingSize = prefixSize + valueData.size();
+    char* reserved = buffer.reserve(encodingSize);
+    char* pos = reserved;
+    EncodingPrefix::serialize(
+        EncodingType::Constant,
+        TypeTraits<T>::dataType,
+        length,
+        options.useVarintRowCount,
+        pos);
+    encoding::writeBytes(valueData, pos);
     NIMBLE_CHECK_EQ(pos - reserved, encodingSize, "Encoding size mismatch.");
     return {reserved, encodingSize};
   }

--- a/dwio/nimble/encodings/EncodingSliceFactory.cpp
+++ b/dwio/nimble/encodings/EncodingSliceFactory.cpp
@@ -1,0 +1,209 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "dwio/nimble/encodings/EncodingSliceFactory.h"
+
+#include <algorithm>
+#include <span>
+#include <vector>
+
+#include "dwio/nimble/common/NimbleException.h"
+#include "dwio/nimble/common/Vector.h"
+#include "dwio/nimble/encodings/ConstantEncoding.h"
+#include "dwio/nimble/encodings/MainlyConstantEncoding.h"
+#include "dwio/nimble/encodings/NullableEncoding.h"
+#include "dwio/nimble/encodings/RLEEncoding.h"
+#include "dwio/nimble/encodings/SparseBoolEncoding.h"
+#include "dwio/nimble/encodings/TrivialEncoding.h"
+#include "dwio/nimble/encodings/common/EncodingFactory.h"
+#include "dwio/nimble/encodings/common/EncodingLayout.h"
+#include "dwio/nimble/encodings/common/EncodingPrefix.h"
+#include "dwio/nimble/encodings/common/EncodingPrimitives.h"
+#include "dwio/nimble/encodings/common/EncodingType.h"
+#include "dwio/nimble/encodings/common/EncodingTypeDispatch.h"
+#include "dwio/nimble/encodings/selection/EncodingSelectionPolicy.h"
+
+namespace facebook::nimble {
+namespace {
+
+template <typename T>
+std::string_view encodeValuesWithLayout(
+    EncodingLayout encodingLayout,
+    std::span<const T> values,
+    Buffer& buffer,
+    const Encoding::Options& options) {
+  auto policy = std::make_unique<ReplayedEncodingSelectionPolicy<T>>(
+      std::move(encodingLayout),
+      CompressionOptions{},
+      [](DataType dataType) -> std::unique_ptr<EncodingSelectionPolicyBase> {
+        NIMBLE_FAIL(
+            "Captured encoding layout is missing nested child for {}.",
+            dataType);
+      });
+  return EncodingFactory::encode<T>(std::move(policy), values, buffer, options);
+}
+
+template <typename T>
+std::string_view sliceByMaterializing(
+    std::string_view encoded,
+    uint32_t offset,
+    uint32_t length,
+    Buffer& buffer,
+    const Encoding::Options& options) {
+  using physicalType = typename TypeTraits<T>::physicalType;
+  auto* pool = &buffer.getMemoryPool();
+  ScopedEncodingBuffer scopedBuffer{pool, options.encodingBufferPool};
+  Vector<physicalType> physicalValues{pool, length};
+
+  auto encoding = EncodingFactory{options}.create(
+      *pool, encoded, [&scopedBuffer](uint32_t size) -> void* {
+        return scopedBuffer.get().reserve(size);
+      });
+  encoding->skip(offset);
+  encoding->materialize(length, physicalValues.data());
+
+  return encodeValuesWithLayout<T>(
+      EncodingLayoutCapture::capture(encoded),
+      {reinterpret_cast<const T*>(physicalValues.data()),
+       physicalValues.size()},
+      buffer,
+      options);
+}
+
+std::string_view sliceByMaterializing(
+    std::string_view encoded,
+    EncodingType encodingType,
+    DataType dataType,
+    uint32_t offset,
+    uint32_t length,
+    Buffer& buffer,
+    const Encoding::Options& options) {
+  NIMBLE_CHECK_NE(
+      encodingType,
+      EncodingType::Nullable,
+      "Slicing nullable {} encoding by materializing is not supported.",
+      encodingType);
+  NIMBLE_RETURN_BY_DATA_TYPE(
+      dataType,
+      T,
+      sliceByMaterializing<T>(encoded, offset, length, buffer, options));
+}
+
+std::string_view sliceNullable(
+    std::string_view encoded,
+    DataType dataType,
+    uint32_t offset,
+    uint32_t length,
+    Buffer& buffer,
+    const Encoding::Options& options) {
+  NIMBLE_RETURN_BY_DATA_TYPE(
+      dataType,
+      T,
+      NullableEncoding<T>::slice(encoded, offset, length, buffer, options));
+}
+
+std::string_view sliceMainlyConstant(
+    std::string_view encoded,
+    DataType dataType,
+    uint32_t offset,
+    uint32_t length,
+    Buffer& buffer,
+    const Encoding::Options& options) {
+  NIMBLE_RETURN_BY_NON_BOOL_DATA_TYPE(
+      dataType,
+      T,
+      MainlyConstantEncoding<T>::slice(
+          encoded, offset, length, buffer, options));
+}
+
+std::string_view sliceTrivial(
+    std::string_view encoded,
+    DataType dataType,
+    uint32_t offset,
+    uint32_t length,
+    Buffer& buffer,
+    const Encoding::Options& options) {
+  NIMBLE_RETURN_BY_DATA_TYPE(
+      dataType,
+      T,
+      TrivialEncoding<T>::slice(encoded, offset, length, buffer, options));
+}
+
+std::string_view sliceRLE(
+    std::string_view encoded,
+    DataType dataType,
+    uint32_t offset,
+    uint32_t length,
+    Buffer& buffer,
+    const Encoding::Options& options) {
+  NIMBLE_RETURN_BY_DATA_TYPE(
+      dataType,
+      T,
+      RLEEncoding<T>::slice(encoded, offset, length, buffer, options));
+}
+
+std::string_view sliceConstant(
+    std::string_view encoded,
+    DataType dataType,
+    uint32_t offset,
+    uint32_t length,
+    Buffer& buffer,
+    const Encoding::Options& options) {
+  NIMBLE_RETURN_BY_DATA_TYPE(
+      dataType,
+      T,
+      ConstantEncoding<T>::slice(encoded, offset, length, buffer, options));
+}
+
+} // namespace
+
+std::string_view EncodingSliceFactory::slice(
+    std::string_view encoded,
+    uint32_t offset,
+    uint32_t length,
+    Buffer& buffer,
+    const Encoding::Options& options) {
+  const auto rowCount =
+      EncodingPrefix::readRowCount(encoded, options.useVarintRowCount);
+  NIMBLE_CHECK_LE(offset, rowCount);
+  NIMBLE_CHECK_LE(length, rowCount - offset);
+  if (offset == 0 && length == rowCount) {
+    return encoded;
+  }
+
+  const auto encodingType = EncodingPrefix::encodingType(encoded);
+  const auto dataType = EncodingPrefix::dataType(encoded);
+  switch (encodingType) {
+    case EncodingType::Constant:
+      return sliceConstant(encoded, dataType, offset, length, buffer, options);
+    case EncodingType::Trivial:
+      return sliceTrivial(encoded, dataType, offset, length, buffer, options);
+    case EncodingType::RLE:
+      return sliceRLE(encoded, dataType, offset, length, buffer, options);
+    case EncodingType::Nullable:
+      return sliceNullable(encoded, dataType, offset, length, buffer, options);
+    case EncodingType::SparseBool:
+      return SparseBoolEncoding::slice(
+          encoded, offset, length, buffer, options);
+    case EncodingType::MainlyConstant:
+      return sliceMainlyConstant(
+          encoded, dataType, offset, length, buffer, options);
+    default:
+      return sliceByMaterializing(
+          encoded, encodingType, dataType, offset, length, buffer, options);
+  }
+}
+
+} // namespace facebook::nimble

--- a/dwio/nimble/encodings/EncodingSliceFactory.h
+++ b/dwio/nimble/encodings/EncodingSliceFactory.h
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <string_view>
+
+#include "dwio/nimble/common/Buffer.h"
+#include "dwio/nimble/encodings/common/Encoding.h"
+
+namespace facebook::nimble {
+
+/// Creates encoded streams for row ranges from existing encoded streams.
+///
+/// Uses native slicing for supported encodings and falls back to materializing
+/// and re-encoding the requested range when metadata-only slicing is not
+/// available.
+class EncodingSliceFactory {
+ public:
+  /// Returns an encoded stream containing rows [offset, offset + length).
+  static std::string_view slice(
+      std::string_view encoded,
+      uint32_t offset,
+      uint32_t length,
+      Buffer& buffer,
+      const Encoding::Options& options = {});
+};
+
+} // namespace facebook::nimble

--- a/dwio/nimble/encodings/FsstEncoding.cpp
+++ b/dwio/nimble/encodings/FsstEncoding.cpp
@@ -267,7 +267,8 @@ std::string_view FsstEncoding::lengthsEncoding(
       EncodingType::Fsst,
       "Expected FSST encoding.");
 
-  const auto prefixSize = readPrefixSize(encoding, options.useVarintRowCount);
+  const auto prefixSize =
+      EncodingPrefix::prefixSize(encoding, options.useVarintRowCount);
   NIMBLE_CHECK_GE(encoding.size(), prefixSize, "FSST encoding too small.");
   const auto header = parseHeader(encoding.data() + prefixSize);
   return {header.lengths, header.lengthsSize};

--- a/dwio/nimble/encodings/MainlyConstantEncoding.h
+++ b/dwio/nimble/encodings/MainlyConstantEncoding.h
@@ -32,6 +32,7 @@
 #include "dwio/nimble/encodings/TrivialEncoding.h"
 #include "dwio/nimble/encodings/common/Encoding.h"
 #include "dwio/nimble/encodings/common/EncodingFactory.h"
+#include "dwio/nimble/encodings/common/EncodingPrefix.h"
 #include "dwio/nimble/encodings/common/EncodingPrimitives.h"
 #include "dwio/nimble/encodings/common/EncodingType.h"
 #include "dwio/nimble/encodings/selection/EncodingIdentifier.h"
@@ -696,6 +697,84 @@ class MainlyConstantEncodingBase
     }
   }
 
+  static std::pair<uint32_t, uint32_t> countCommonForSlice(
+      std::string_view encoded,
+      uint32_t offset,
+      uint32_t length,
+      Buffer& buffer,
+      const Encoding::Options& options) {
+    const auto rowEnd = offset + length;
+    if (rowEnd == 0) {
+      return {0, 0};
+    }
+
+    auto* pool = &buffer.getMemoryPool();
+    auto encoding = EncodingFactory{options}.create(
+        *pool, encoded, [](uint32_t /*size*/) -> void* { return nullptr; });
+
+    Vector<bool> values{pool, rowEnd};
+    encoding->materialize(rowEnd, values.data());
+    const auto sliceBegin = values.begin() + offset;
+    return {
+        std::count(values.begin(), sliceBegin, true),
+        std::count(sliceBegin, values.end(), true)};
+  }
+
+  static std::string_view slice(
+      std::string_view encoded,
+      uint32_t offset,
+      uint32_t length,
+      Buffer& buffer,
+      const Encoding::Options& options = {}) {
+    const auto sourceRowCount =
+        EncodingPrefix::readRowCount(encoded, options.useVarintRowCount);
+    NIMBLE_CHECK_LE(offset, sourceRowCount);
+    NIMBLE_CHECK_LE(length, sourceRowCount - offset);
+
+    const char* pos = encoded.data() +
+        EncodingPrefix::prefixSize(encoded, options.useVarintRowCount);
+    const uint32_t isCommonSize = encoding::readUint32(pos);
+    const std::string_view isCommon{pos, isCommonSize};
+    pos += isCommonSize;
+    const uint32_t otherValuesSize = encoding::readUint32(pos);
+    const std::string_view otherValues{pos, otherValuesSize};
+    pos += otherValuesSize;
+    const std::string_view commonValue{
+        pos, static_cast<size_t>(encoded.end() - pos)};
+
+    const auto [commonBefore, commonInSlice] =
+        countCommonForSlice(isCommon, offset, length, buffer, options);
+    const auto otherOffset = offset - commonBefore;
+    const auto otherCount = length - commonInSlice;
+
+    auto* pool = &buffer.getMemoryPool();
+    ScopedEncodingBuffer scopedBuffer{pool, options.encodingBufferPool};
+    const auto slicedIsCommon = EncodingFactory::slice(
+        isCommon, offset, length, scopedBuffer.get(), options);
+    const auto slicedOtherValues = EncodingFactory::slice(
+        otherValues, otherOffset, otherCount, scopedBuffer.get(), options);
+
+    const auto prefixSize =
+        EncodingPrefix::serializedSize(length, options.useVarintRowCount);
+    const auto encodingSize = prefixSize + sizeof(uint32_t) +
+        slicedIsCommon.size() + sizeof(uint32_t) + slicedOtherValues.size() +
+        commonValue.size();
+    char* reserved = buffer.reserve(encodingSize);
+    char* writePos = reserved;
+    EncodingPrefix::serialize(
+        EncodingType::MainlyConstant,
+        TypeTraits<T>::dataType,
+        length,
+        options.useVarintRowCount,
+        writePos);
+    encoding::writeString(slicedIsCommon, writePos);
+    encoding::writeString(slicedOtherValues, writePos);
+    encoding::writeBytes(commonValue, writePos);
+    NIMBLE_CHECK_EQ(
+        writePos - reserved, encodingSize, "Encoding size mismatch.");
+    return {reserved, encodingSize};
+  }
+
   // Counts unset bits across all words. Caller must mask tail bits
   // before calling (set garbage tail bits to 1 in the last word).
   FOLLY_ALWAYS_INLINE static uint32_t countNonCommon(
@@ -775,6 +854,16 @@ class MainlyConstantEncoding final : public MainlyConstantEncodingBase<T> {
       std::span<const physicalType> values,
       Buffer& buffer,
       const Encoding::Options& options = {});
+
+  static std::string_view slice(
+      std::string_view encoded,
+      uint32_t offset,
+      uint32_t length,
+      Buffer& buffer,
+      const Encoding::Options& options = {}) {
+    return MainlyConstantEncodingBase<T>::slice(
+        encoded, offset, length, buffer, options);
+  }
 };
 
 //
@@ -875,5 +964,15 @@ class MainlyConstantEncoding<std::string_view> final
       std::span<const physicalType> values,
       Buffer& buffer,
       const Encoding::Options& options = {});
+
+  static std::string_view slice(
+      std::string_view encoded,
+      uint32_t offset,
+      uint32_t length,
+      Buffer& buffer,
+      const Encoding::Options& options = {}) {
+    return MainlyConstantEncodingBase<std::string_view>::slice(
+        encoded, offset, length, buffer, options);
+  }
 };
 } // namespace facebook::nimble

--- a/dwio/nimble/encodings/NullableEncoding.h
+++ b/dwio/nimble/encodings/NullableEncoding.h
@@ -15,14 +15,18 @@
  */
 #pragma once
 
+#include <algorithm>
 #include <span>
+#include <utility>
 #include "dwio/nimble/common/Buffer.h"
 #include "dwio/nimble/common/Types.h"
 #include "dwio/nimble/common/Vector.h"
 #include "dwio/nimble/encodings/DictionaryEncoding.h"
 #include "dwio/nimble/encodings/common/Encoding.h"
 #include "dwio/nimble/encodings/common/EncodingFactory.h"
+#include "dwio/nimble/encodings/common/EncodingPrefix.h"
 #include "dwio/nimble/encodings/common/EncodingPrimitives.h"
+#include "dwio/nimble/encodings/common/EncodingType.h"
 #include "dwio/nimble/encodings/selection/EncodingIdentifier.h"
 #include "dwio/nimble/encodings/selection/EncodingSelection.h"
 
@@ -91,6 +95,13 @@ class NullableEncoding final
       Buffer& buffer,
       const Encoding::Options& options = {});
 
+  static std::string_view slice(
+      std::string_view encoded,
+      uint32_t offset,
+      uint32_t length,
+      Buffer& buffer,
+      const Encoding::Options& options = {});
+
   std::string debugString(int offset) const final;
 
   // Dictionary API — delegates to the inner (non-null) encoding.
@@ -115,6 +126,13 @@ class NullableEncoding final
   /// Shared by readWithVisitor and readIndicesWithVisitor.
   template <typename V>
   void materializeNullsForVisitor(V& visitor, ReadWithVisitorParams& params);
+
+  static std::pair<uint32_t, uint32_t> countNonNullsForSlice(
+      std::string_view encoded,
+      uint32_t offset,
+      uint32_t length,
+      Buffer& buffer,
+      const Encoding::Options& options);
 
   // One bit for each row. A true bit represents a row with a non-null value.
   const char* bitmap_;
@@ -383,6 +401,75 @@ std::string_view NullableEncoding<T>::encodeNullable(
   encoding::writeString(serializedValues, pos);
   encoding::writeBytes(serializedNulls, pos);
   NIMBLE_DCHECK_EQ(pos - reserved, encodingSize, "Encoding size mismatch.");
+  return {reserved, encodingSize};
+}
+
+template <typename T>
+std::pair<uint32_t, uint32_t> NullableEncoding<T>::countNonNullsForSlice(
+    std::string_view encoded,
+    uint32_t offset,
+    uint32_t length,
+    Buffer& buffer,
+    const Encoding::Options& options) {
+  const auto rowEnd = offset + length;
+  NIMBLE_CHECK_GT(rowEnd, 0, "Nullable slice requires a non-empty row range.");
+
+  auto* pool = &buffer.getMemoryPool();
+  auto encoding = EncodingFactory{options}.create(
+      *pool, encoded, [](uint32_t /*size*/) -> void* { return nullptr; });
+
+  Vector<bool> values{pool, rowEnd};
+  encoding->materialize(rowEnd, values.data());
+  const auto sliceBegin = values.begin() + offset;
+  return {
+      std::count(values.begin(), sliceBegin, true),
+      std::count(sliceBegin, values.end(), true)};
+}
+
+template <typename T>
+std::string_view NullableEncoding<T>::slice(
+    std::string_view encoded,
+    uint32_t offset,
+    uint32_t length,
+    Buffer& buffer,
+    const Encoding::Options& options) {
+  const auto sourceRowCount =
+      EncodingPrefix::readRowCount(encoded, options.useVarintRowCount);
+  NIMBLE_CHECK_LE(offset, sourceRowCount);
+  NIMBLE_CHECK_LE(length, sourceRowCount - offset);
+
+  const char* pos = encoded.data() +
+      EncodingPrefix::prefixSize(encoded, options.useVarintRowCount);
+  const uint32_t valuesSize = encoding::readUint32(pos);
+  const std::string_view values{pos, valuesSize};
+  pos += valuesSize;
+  const std::string_view nulls{pos, encoded.end()};
+
+  const auto [nonNullOffset, nonNullCount] =
+      countNonNullsForSlice(nulls, offset, length, buffer, options);
+
+  auto* pool = &buffer.getMemoryPool();
+  ScopedEncodingBuffer scopedBuffer{pool, options.encodingBufferPool};
+  const auto slicedValues = EncodingFactory::slice(
+      values, nonNullOffset, nonNullCount, scopedBuffer.get(), options);
+  const auto slicedNulls = EncodingFactory::slice(
+      nulls, offset, length, scopedBuffer.get(), options);
+
+  const auto prefixSize =
+      EncodingPrefix::serializedSize(length, options.useVarintRowCount);
+  const auto encodingSize =
+      prefixSize + sizeof(uint32_t) + slicedValues.size() + slicedNulls.size();
+  char* reserved = buffer.reserve(encodingSize);
+  char* writePos = reserved;
+  EncodingPrefix::serialize(
+      EncodingType::Nullable,
+      TypeTraits<T>::dataType,
+      length,
+      options.useVarintRowCount,
+      writePos);
+  encoding::writeString(slicedValues, writePos);
+  encoding::writeBytes(slicedNulls, writePos);
+  NIMBLE_CHECK_EQ(writePos - reserved, encodingSize, "Encoding size mismatch.");
   return {reserved, encodingSize};
 }
 

--- a/dwio/nimble/encodings/RLEEncoding.h
+++ b/dwio/nimble/encodings/RLEEncoding.h
@@ -16,6 +16,7 @@
 #pragma once
 
 #include <algorithm>
+#include <optional>
 #include <span>
 #include <vector>
 
@@ -224,6 +225,53 @@ class RLEEncodingBase
     return {reserved, encodingSize};
   }
 
+  static std::string_view slice(
+      std::string_view encoded,
+      uint32_t offset,
+      uint32_t length,
+      Buffer& buffer,
+      const Encoding::Options& options = {}) {
+    const auto sourceRowCount =
+        EncodingPrefix::readRowCount(encoded, options.useVarintRowCount);
+    NIMBLE_CHECK_LE(offset, sourceRowCount);
+    NIMBLE_CHECK_LE(length, sourceRowCount - offset);
+
+    const auto sourcePrefixSize =
+        EncodingPrefix::prefixSize(encoded, options.useVarintRowCount);
+    const char* pos = encoded.data() + sourcePrefixSize;
+    const auto runLengthsSize = encoding::readUint32(pos);
+    const std::string_view runLengthsData{pos, runLengthsSize};
+    pos += runLengthsSize;
+    const std::string_view runValuesData{
+        pos, static_cast<size_t>(encoded.end() - pos)};
+
+    auto slicedRuns =
+        sliceRuns(runLengthsData, offset, length, buffer, options);
+    const auto slicedRunValues = RLEEncoding::sliceRunValues(
+        runValuesData,
+        slicedRuns.runValueOffset,
+        slicedRuns.runValueCount,
+        buffer,
+        options);
+
+    const auto prefixSize =
+        EncodingPrefix::serializedSize(length, options.useVarintRowCount);
+    const auto encodingSize = prefixSize + sizeof(uint32_t) +
+        slicedRuns.encodedLengths.size() + slicedRunValues.size();
+    char* reserved = buffer.reserve(encodingSize);
+    char* output = reserved;
+    EncodingPrefix::serialize(
+        EncodingType::RLE,
+        TypeTraits<T>::dataType,
+        length,
+        options.useVarintRowCount,
+        output);
+    encoding::writeString(slicedRuns.encodedLengths, output);
+    encoding::writeBytes(slicedRunValues, output);
+    NIMBLE_CHECK_EQ(output - reserved, encodingSize, "Encoding size mismatch.");
+    return std::string_view{reserved, encodingSize};
+  }
+
   const char* getValuesStart() const {
     return this->data_.data() + this->dataOffset() + 4 +
         *reinterpret_cast<const uint32_t*>(
@@ -263,6 +311,114 @@ class RLEEncodingBase
   uint32_t copiesRemaining_ = 0;
   physicalType currentValue_;
   detail::BufferedEncoding<uint32_t, 32> materializedRunLengths_;
+
+ private:
+  struct RLESliceRuns {
+    // Run-length child encoding for the returned RLE slice. This view points
+    // into the caller-owned output buffer.
+    std::string_view encodedLengths;
+    // Run-value child range matching encodedLengths.
+    uint32_t runValueOffset{0};
+    uint32_t runValueCount{0};
+  };
+
+  static RLESliceRuns sliceRuns(
+      std::string_view encodedRunLengths,
+      uint32_t offset,
+      uint32_t length,
+      Buffer& buffer,
+      const Encoding::Options& options) {
+    const auto runCount = EncodingPrefix::readRowCount(
+        encodedRunLengths, options.useVarintRowCount);
+    NIMBLE_CHECK_GT(
+        length, 0, "RLE run slicing requires a non-empty row range.");
+    NIMBLE_CHECK_GT(
+        runCount, 0, "Cannot slice a non-empty range from empty RLE runs.");
+    auto* pool = &buffer.getMemoryPool();
+    RLESliceRuns result;
+
+    EncodingFactory encodingFactory{options};
+    auto runLengthsEncoding = encodingFactory.create(
+        *pool, encodedRunLengths, [](uint32_t /* totalLength */) -> void* {
+          return nullptr;
+        });
+
+    const auto end = offset + length;
+    uint32_t firstRunStart{0};
+    uint32_t lastRunEnd{0};
+    constexpr uint32_t kRunLengthChunkSize{256};
+    const auto maxRunLengthChunkSize =
+        std::min({runCount, length, kRunLengthChunkSize});
+    Vector<uint32_t> runLengths{pool, maxRunLengthChunkSize};
+    Vector<uint32_t> slicedRunLengths{pool};
+    slicedRunLengths.reserve(length);
+    uint32_t row{0};
+    for (uint32_t run = 0; run < runCount;) {
+      const auto chunkSize =
+          std::min<uint32_t>(maxRunLengthChunkSize, runCount - run);
+      runLengthsEncoding->materialize(chunkSize, runLengths.data());
+      for (uint32_t i = 0; i < chunkSize; ++i, ++run) {
+        const auto runStart = row;
+        const auto runEnd = row + runLengths[i];
+        row = runEnd;
+        if (runEnd <= offset) {
+          continue;
+        }
+        if (runStart >= end) {
+          break;
+        }
+        if (result.runValueCount == 0) {
+          result.runValueOffset = run;
+          firstRunStart = runStart;
+        }
+        lastRunEnd = runEnd;
+        ++result.runValueCount;
+        slicedRunLengths.push_back(runLengths[i]);
+      }
+      if (row >= end) {
+        break;
+      }
+    }
+
+    NIMBLE_CHECK_GT(
+        result.runValueCount,
+        0,
+        "Could not find RLE runs for a non-empty row range.");
+    NIMBLE_CHECK_EQ(
+        slicedRunLengths.size(),
+        result.runValueCount,
+        "Sliced RLE run length count mismatch.");
+
+    if (firstRunStart < offset || lastRunEnd > end) {
+      slicedRunLengths[0] -= offset - firstRunStart;
+      slicedRunLengths[result.runValueCount - 1] -= lastRunEnd - end;
+      result.encodedLengths = encodeRunLengthsSlice(
+          encodedRunLengths, slicedRunLengths, buffer, options);
+    } else {
+      result.encodedLengths = EncodingFactory::slice(
+          encodedRunLengths,
+          result.runValueOffset,
+          result.runValueCount,
+          buffer,
+          options);
+    }
+    return result;
+  }
+
+  static std::string_view encodeRunLengthsSlice(
+      std::string_view encodedRunLengths,
+      std::span<const uint32_t> runLengths,
+      Buffer& buffer,
+      const Encoding::Options& options) {
+    NIMBLE_CHECK_GT(
+        runLengths.size(), 0, "Cannot encode empty RLE run-length slice.");
+    return EncodingFactory::encodeWithCapturedLayout<uint32_t>(
+        encodedRunLengths,
+        runLengths,
+        buffer,
+        options,
+        "Captured RLE run-length layout");
+  }
 };
 
 } // namespace internal
@@ -454,6 +610,18 @@ class RLEEncoding final : public internal::RLEEncodingBase<T, RLEEncoding<T>> {
   }
 
  private:
+  friend class internal::RLEEncodingBase<T, RLEEncoding<T>>;
+
+  static std::string_view sliceRunValues(
+      std::string_view encodedRunValues,
+      uint32_t offset,
+      uint32_t length,
+      Buffer& buffer,
+      const Encoding::Options& options) {
+    return EncodingFactory::slice(
+        encodedRunValues, offset, length, buffer, options);
+  }
+
   static uint64_t estimateRunValuesSize(
       uint64_t runCount,
       const Statistics<physicalType>& statistics,
@@ -567,6 +735,23 @@ class RLEEncoding<bool> final
   }
 
  private:
+  friend class internal::RLEEncodingBase<bool, RLEEncoding<bool>>;
+
+  static std::string_view sliceRunValues(
+      std::string_view encodedRunValues,
+      uint32_t offset,
+      uint32_t /* length */,
+      Buffer& buffer,
+      const Encoding::Options& /* options */) {
+    const auto initialValue =
+        *reinterpret_cast<const bool*>(encodedRunValues.data());
+    const auto slicedInitialValue =
+        offset % 2 == 0 ? initialValue : !initialValue;
+    char* reserved = buffer.reserve(sizeof(bool));
+    *reserved = slicedInitialValue;
+    return {reserved, sizeof(bool)};
+  }
+
   bool initialValue_;
   bool value_;
 };

--- a/dwio/nimble/encodings/SparseBoolEncoding.cpp
+++ b/dwio/nimble/encodings/SparseBoolEncoding.cpp
@@ -20,8 +20,52 @@
 #include "dwio/nimble/common/Types.h"
 #include "dwio/nimble/encodings/common/EncodingFactory.h"
 #include "dwio/nimble/encodings/common/EncodingPrimitives.h"
+#include "dwio/nimble/encodings/selection/EncodingSelectionPolicy.h"
 
 namespace facebook::nimble {
+
+namespace {
+
+std::string_view sliceSparseIndices(
+    std::string_view encodedIndices,
+    uint32_t offset,
+    uint32_t length,
+    Buffer& buffer,
+    const Encoding::Options& options) {
+  auto* pool = &buffer.getMemoryPool();
+  const auto indexCount =
+      EncodingPrefix::readRowCount(encodedIndices, options.useVarintRowCount);
+  Vector<uint32_t> sparseIndices{pool, indexCount};
+  EncodingFactory{options}
+      .create(
+          *pool,
+          encodedIndices,
+          [](uint32_t /* totalLength */) -> void* { return nullptr; })
+      ->materialize(indexCount, sparseIndices.data());
+
+  const auto end = offset + length;
+  Vector<uint32_t> sliceIndices{pool};
+  sliceIndices.reserve(std::min<uint32_t>(length, indexCount));
+  for (uint32_t i = 0; i + 1 < indexCount; ++i) {
+    const auto index = sparseIndices[i];
+    if (index >= end) {
+      break;
+    }
+    if (index >= offset) {
+      sliceIndices.push_back(index - offset);
+    }
+  }
+  sliceIndices.push_back(length);
+
+  return EncodingFactory::encodeWithCapturedLayout<uint32_t>(
+      encodedIndices,
+      std::span<const uint32_t>{sliceIndices.data(), sliceIndices.size()},
+      buffer,
+      options,
+      "Captured SparseBool index layout");
+}
+
+} // namespace
 
 SparseBoolEncoding::SparseBoolEncoding(
     velox::memory::MemoryPool& pool,
@@ -191,6 +235,44 @@ std::string_view SparseBoolEncoding::encode(
   encoding::writeBytes(serializedIndices, pos);
 
   NIMBLE_DCHECK_EQ(pos - reserved, encodingSize, "Encoding size mismatch.");
+  return {reserved, encodingSize};
+}
+
+std::string_view SparseBoolEncoding::slice(
+    std::string_view encoded,
+    uint32_t offset,
+    uint32_t length,
+    Buffer& buffer,
+    const Encoding::Options& options) {
+  const auto sourceRowCount =
+      EncodingPrefix::readRowCount(encoded, options.useVarintRowCount);
+  NIMBLE_CHECK_LE(offset, sourceRowCount);
+  NIMBLE_CHECK_LE(length, sourceRowCount - offset);
+
+  const char* readPos = encoded.data() +
+      EncodingPrefix::prefixSize(encoded, options.useVarintRowCount);
+  const auto sparseValue = encoding::readChar(readPos);
+  const std::string_view encodedIndices{
+      readPos, static_cast<size_t>(encoded.end() - readPos)};
+
+  const auto serializedIndices =
+      sliceSparseIndices(encodedIndices, offset, length, buffer, options);
+
+  const auto prefixSize =
+      EncodingPrefix::serializedSize(length, options.useVarintRowCount);
+  const auto encodingSize =
+      prefixSize + SparseBoolEncoding::kPrefixSize + serializedIndices.size();
+  char* reserved = buffer.reserve(encodingSize);
+  char* pos = reserved;
+  EncodingPrefix::serialize(
+      EncodingType::SparseBool,
+      DataType::Bool,
+      length,
+      options.useVarintRowCount,
+      pos);
+  encoding::writeChar(sparseValue, pos);
+  encoding::writeBytes(serializedIndices, pos);
+  NIMBLE_CHECK_EQ(pos - reserved, encodingSize, "Encoding size mismatch.");
   return {reserved, encodingSize};
 }
 

--- a/dwio/nimble/encodings/SparseBoolEncoding.h
+++ b/dwio/nimble/encodings/SparseBoolEncoding.h
@@ -85,6 +85,13 @@ class SparseBoolEncoding final : public TypedEncoding<bool, bool> {
       Buffer& buffer,
       const Encoding::Options& options = {});
 
+  static std::string_view slice(
+      std::string_view encoded,
+      uint32_t offset,
+      uint32_t length,
+      Buffer& buffer,
+      const Encoding::Options& options = {});
+
   static uint64_t estimateSize(
       uint64_t rowCount,
       const Statistics<bool>& statistics,

--- a/dwio/nimble/encodings/TrivialEncoding.cpp
+++ b/dwio/nimble/encodings/TrivialEncoding.cpp
@@ -17,6 +17,54 @@
 #include "dwio/nimble/encodings/common/EncodingFactory.h"
 
 namespace facebook::nimble {
+namespace {
+
+struct UncompressedData {
+  const char* data;
+  velox::BufferPtr buffer;
+};
+
+UncompressedData uncompressIfNeeded(
+    velox::memory::MemoryPool& pool,
+    CompressionType compressionType,
+    DataType dataType,
+    std::string_view data,
+    const Encoding::Options& options) {
+  if (compressionType == CompressionType::Uncompressed) {
+    return {.data = data.data()};
+  }
+
+  auto buffer = Compression::uncompress(
+      pool,
+      compressionType,
+      dataType,
+      data,
+      options.decompressCounter(),
+      options.bufferPool);
+  return {.data = buffer->as<char>(), .buffer = std::move(buffer)};
+}
+
+template <typename T>
+Vector<T> makeScratchVector(
+    velox::memory::MemoryPool& pool,
+    const Encoding::Options& options,
+    uint64_t capacity) {
+  if (auto* bufferPool = options.bufferPool) {
+    if (auto buffer = bufferPool->get(capacity * sizeof(T))) {
+      return Vector<T>{std::move(buffer)};
+    }
+  }
+  return Vector<T>{&pool};
+}
+
+template <typename T>
+void releaseScratchVector(Vector<T>& vector, const Encoding::Options& options) {
+  if (auto* bufferPool = options.bufferPool) {
+    bufferPool->release(vector.releaseBuffer());
+  }
+}
+
+} // namespace
 
 TrivialEncoding<std::string_view>::TrivialEncoding(
     velox::memory::MemoryPool& pool,
@@ -151,6 +199,67 @@ std::string_view TrivialEncoding<std::string_view>::encode(
 
   NIMBLE_CHECK_EQ(pos - reserved, encodingSize, "Encoding size mismatch.");
   return {reserved, encodingSize};
+}
+
+std::string_view TrivialEncoding<std::string_view>::slice(
+    std::string_view encoded,
+    uint32_t offset,
+    uint32_t length,
+    Buffer& buffer,
+    const Encoding::Options& options) {
+  const auto sourcePrefixSize =
+      EncodingPrefix::prefixSize(encoded, options.useVarintRowCount);
+  const char* sourcePos = encoded.data() + sourcePrefixSize;
+  const auto compressionType =
+      static_cast<CompressionType>(encoding::readChar(sourcePos));
+
+  const uint32_t lengthsSize = encoding::readUint32(sourcePos);
+  const std::string_view lengthsData{sourcePos, lengthsSize};
+  sourcePos += lengthsSize;
+  const auto blob = uncompressIfNeeded(
+      buffer.getMemoryPool(),
+      compressionType,
+      DataType::String,
+      {sourcePos, static_cast<size_t>(encoded.end() - sourcePos)},
+      options);
+  const char* blobData = blob.data;
+
+  const auto slicedLengths =
+      EncodingFactory::slice(lengthsData, offset, length, buffer, options);
+  const auto rowEnd = offset + length;
+  auto materializedLengths =
+      makeScratchVector<uint32_t>(buffer.getMemoryPool(), options, rowEnd);
+  materializedLengths.resize(rowEnd);
+  auto lengthsEncoding = EncodingFactory{options}.create(
+      buffer.getMemoryPool(),
+      lengthsData,
+      [](uint32_t /*totalLength*/) -> void* { return nullptr; });
+  lengthsEncoding->materialize(rowEnd, materializedLengths.data());
+  const auto sliceBegin = materializedLengths.begin() + offset;
+  const auto blobOffset =
+      std::accumulate(materializedLengths.begin(), sliceBegin, uint32_t{0});
+  const auto blobBytes =
+      std::accumulate(sliceBegin, materializedLengths.end(), uint32_t{0});
+
+  const auto prefixSize =
+      EncodingPrefix::serializedSize(length, options.useVarintRowCount);
+  const auto encodingSize =
+      prefixSize + kPrefixSize + slicedLengths.size() + blobBytes;
+  char* reserved = buffer.reserve(encodingSize);
+  char* pos = reserved;
+  EncodingPrefix::serialize(
+      EncodingType::Trivial,
+      DataType::String,
+      length,
+      options.useVarintRowCount,
+      pos);
+  encoding::writeChar(static_cast<char>(CompressionType::Uncompressed), pos);
+  encoding::writeUint32(slicedLengths.size(), pos);
+  encoding::writeBytes(slicedLengths, pos);
+  encoding::writeBytes({blobData + blobOffset, blobBytes}, pos);
+  NIMBLE_CHECK_EQ(pos - reserved, encodingSize, "Encoding size mismatch.");
+  releaseScratchVector(materializedLengths, options);
+  return std::string_view{reserved, encodingSize};
 }
 
 TrivialEncoding<bool>::TrivialEncoding(
@@ -289,6 +398,50 @@ std::string_view TrivialEncoding<bool>::encode(
 
   NIMBLE_CHECK_EQ(pos - reserved, encodingSize, "Encoding size mismatch.");
   return {reserved, encodingSize};
+}
+
+std::string_view TrivialEncoding<bool>::slice(
+    std::string_view encoded,
+    uint32_t offset,
+    uint32_t length,
+    Buffer& buffer,
+    const Encoding::Options& options) {
+  const auto sourcePrefixSize =
+      EncodingPrefix::prefixSize(encoded, options.useVarintRowCount);
+  const char* sourcePos = encoded.data() + sourcePrefixSize;
+  const auto compressionType =
+      static_cast<CompressionType>(encoding::readChar(sourcePos));
+  const auto sourceData = uncompressIfNeeded(
+      buffer.getMemoryPool(),
+      compressionType,
+      DataType::Undefined,
+      {sourcePos, static_cast<size_t>(encoded.end() - sourcePos)},
+      options);
+  sourcePos = sourceData.data;
+
+  const auto prefixSize =
+      EncodingPrefix::serializedSize(length, options.useVarintRowCount);
+  const auto bitmapBytes = FixedBitArray::bufferSize(length, 1);
+  const auto encodingSize = prefixSize + kPrefixSize + bitmapBytes;
+  char* reserved = buffer.reserve(encodingSize);
+  char* pos = reserved;
+  EncodingPrefix::serialize(
+      EncodingType::Trivial,
+      DataType::Bool,
+      length,
+      options.useVarintRowCount,
+      pos);
+  encoding::writeChar(static_cast<char>(CompressionType::Uncompressed), pos);
+  std::memset(pos, 0, bitmapBytes);
+  velox::bits::copyBits(
+      reinterpret_cast<const uint64_t*>(sourcePos),
+      offset,
+      reinterpret_cast<uint64_t*>(pos),
+      0,
+      length);
+  pos += bitmapBytes;
+  NIMBLE_CHECK_EQ(pos - reserved, encodingSize, "Encoding size mismatch.");
+  return std::string_view{reserved, encodingSize};
 }
 
 } // namespace facebook::nimble

--- a/dwio/nimble/encodings/TrivialEncoding.h
+++ b/dwio/nimble/encodings/TrivialEncoding.h
@@ -16,6 +16,7 @@
 #pragma once
 
 #include <numeric>
+#include <optional>
 #include <span>
 
 #include "dwio/nimble/common/Buffer.h"
@@ -79,6 +80,13 @@ class TrivialEncoding final
       Buffer& buffer,
       const Encoding::Options& options = {});
 
+  static std::string_view slice(
+      std::string_view encoded,
+      uint32_t offset,
+      uint32_t length,
+      Buffer& buffer,
+      const Encoding::Options& options = {});
+
   static uint64_t estimateSize(uint64_t rowCount) {
     return EncodingPrefix::kFixedPrefixSize + kPrefixSize +
         rowCount * sizeof(physicalType);
@@ -129,6 +137,13 @@ class TrivialEncoding<std::string_view> final
   static std::string_view encode(
       EncodingSelection<std::string_view>& selection,
       std::span<const std::string_view> values,
+      Buffer& buffer,
+      const Encoding::Options& options = {});
+
+  static std::string_view slice(
+      std::string_view encoded,
+      uint32_t offset,
+      uint32_t length,
       Buffer& buffer,
       const Encoding::Options& options = {});
 
@@ -205,6 +220,13 @@ class TrivialEncoding<bool> final : public TypedEncoding<bool, bool> {
   static std::string_view encode(
       EncodingSelection<bool>& selection,
       std::span<const bool> values,
+      Buffer& buffer,
+      const Encoding::Options& options = {});
+
+  static std::string_view slice(
+      std::string_view encoded,
+      uint32_t offset,
+      uint32_t length,
       Buffer& buffer,
       const Encoding::Options& options = {});
 
@@ -305,6 +327,50 @@ std::string_view TrivialEncoding<T>::encode(
       static_cast<char>(compressionEncoder.compressionType()), pos);
   compressionEncoder.write(pos);
   return {reserved, encodingSize};
+}
+
+template <typename T>
+std::string_view TrivialEncoding<T>::slice(
+    std::string_view encoded,
+    uint32_t offset,
+    uint32_t length,
+    Buffer& buffer,
+    const Encoding::Options& options) {
+  const auto sourcePrefixSize =
+      EncodingPrefix::prefixSize(encoded, options.useVarintRowCount);
+  const char* sourcePos = encoded.data() + sourcePrefixSize;
+  const auto compressionType =
+      static_cast<CompressionType>(encoding::readChar(sourcePos));
+  velox::BufferPtr uncompressed;
+  if (compressionType != CompressionType::Uncompressed) {
+    uncompressed = Compression::uncompress(
+        buffer.getMemoryPool(),
+        compressionType,
+        TypeTraits<physicalType>::dataType,
+        {sourcePos, static_cast<size_t>(encoded.end() - sourcePos)},
+        options.decompressCounter(),
+        options.bufferPool);
+    sourcePos = uncompressed->template as<char>();
+  }
+
+  const char* sourceValues = sourcePos;
+  const auto valueBytes = length * sizeof(physicalType);
+  const auto prefixSize =
+      EncodingPrefix::serializedSize(length, options.useVarintRowCount);
+  const auto encodingSize = prefixSize + kPrefixSize + valueBytes;
+  char* reserved = buffer.reserve(encodingSize);
+  char* pos = reserved;
+  EncodingPrefix::serialize(
+      EncodingType::Trivial,
+      TypeTraits<T>::dataType,
+      length,
+      options.useVarintRowCount,
+      pos);
+  encoding::writeChar(static_cast<char>(CompressionType::Uncompressed), pos);
+  encoding::writeBytes(
+      {sourceValues + offset * sizeof(physicalType), valueBytes}, pos);
+  NIMBLE_DCHECK_EQ(pos - reserved, encodingSize, "Encoding size mismatch.");
+  return std::string_view{reserved, encodingSize};
 }
 
 template <typename T>

--- a/dwio/nimble/encodings/benchmarks/EncodingViewBenchmark.cpp
+++ b/dwio/nimble/encodings/benchmarks/EncodingViewBenchmark.cpp
@@ -196,7 +196,7 @@ class ReadAtOffsetsStringTrivialView {
       const Encoding::Options& options) {
     rowCount_ = EncodingPrefix::readRowCount(data, options.useVarintRowCount);
     const auto dataOffset =
-        EncodingPrefix::readPrefixSize(data, options.useVarintRowCount);
+        EncodingPrefix::prefixSize(data, options.useVarintRowCount);
     const char* pos = data.data() + dataOffset;
     const auto compressionType =
         static_cast<CompressionType>(encoding::readChar(pos));
@@ -234,7 +234,7 @@ class MaterializedOffsetsStringTrivialView {
       const Encoding::Options& options) {
     rowCount_ = EncodingPrefix::readRowCount(data, options.useVarintRowCount);
     const auto dataOffset =
-        EncodingPrefix::readPrefixSize(data, options.useVarintRowCount);
+        EncodingPrefix::prefixSize(data, options.useVarintRowCount);
     const char* pos = data.data() + dataOffset;
     const auto compressionType =
         static_cast<CompressionType>(encoding::readChar(pos));
@@ -273,7 +273,7 @@ class ReadAtRunEndsRLEView {
       : runEnds_{pool} {
     rowCount_ = EncodingPrefix::readRowCount(data, options.useVarintRowCount);
     const auto dataOffset =
-        EncodingPrefix::readPrefixSize(data, options.useVarintRowCount);
+        EncodingPrefix::prefixSize(data, options.useVarintRowCount);
     const char* pos = data.data() + dataOffset;
     const auto runLengthsSize = encoding::readUint32(pos);
     auto runLengths = detail::createTypedEncodingView<uint32_t>(
@@ -307,7 +307,7 @@ class MaterializedRunEndsRLEView {
       : runEnds_{pool} {
     rowCount_ = EncodingPrefix::readRowCount(data, options.useVarintRowCount);
     const auto dataOffset =
-        EncodingPrefix::readPrefixSize(data, options.useVarintRowCount);
+        EncodingPrefix::prefixSize(data, options.useVarintRowCount);
     const char* pos = data.data() + dataOffset;
     const auto runLengthsSize = encoding::readUint32(pos);
     auto noStringBufferFactory = [](uint32_t) -> void* { return nullptr; };

--- a/dwio/nimble/encodings/benchmarks/SliceEncodingBenchmark.cpp
+++ b/dwio/nimble/encodings/benchmarks/SliceEncodingBenchmark.cpp
@@ -1,0 +1,157 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "dwio/nimble/encodings/ConstantEncoding.h"
+#include "dwio/nimble/encodings/FixedBitWidthEncoding.h"
+#include "dwio/nimble/encodings/RLEEncoding.h"
+#include "dwio/nimble/encodings/TrivialEncoding.h"
+#include "dwio/nimble/encodings/benchmarks/BenchmarkUtils.h"
+#include "folly/Benchmark.h"
+#include "folly/init/Init.h"
+
+using namespace facebook::nimble;
+using namespace facebook::nimble::benchmarks;
+
+namespace {
+
+constexpr uint32_t kSliceOffset = 12345;
+constexpr uint32_t kSliceLength = 4096;
+
+void sliceBenchmark(const std::string& encoded, uint32_t iters) {
+  Buffer buffer{*benchmarkPool()};
+  while (iters--) {
+    buffer.reset();
+    const auto sliced =
+        EncodingFactory::slice(encoded, kSliceOffset, kSliceLength, buffer);
+    folly::doNotOptimizeAway(sliced.data());
+    folly::doNotOptimizeAway(sliced.size());
+  }
+}
+
+template <typename EncodingT, typename T>
+void materializeEncodeBenchmark(
+    const std::string& encoded,
+    EncodingType encodingType,
+    uint32_t iters) {
+  while (iters--) {
+    auto encoding =
+        EncodingFactory{}.create(*benchmarkPool(), encoded, nullFactory());
+    encoding->skip(kSliceOffset);
+
+    Vector<T> values{benchmarkPool().get(), kSliceLength};
+    encoding->materialize(kSliceLength, values.data());
+
+    const auto materialized =
+        encodeData<EncodingT>(encodingType, values, Encoding::Options{});
+    folly::doNotOptimizeAway(materialized.data());
+    folly::doNotOptimizeAway(materialized.size());
+  }
+}
+
+template <typename T>
+void materializeBenchmark(const std::string& encoded, uint32_t iters) {
+  Vector<T> values{benchmarkPool().get(), kSliceLength};
+  while (iters--) {
+    auto encoding =
+        EncodingFactory{}.create(*benchmarkPool(), encoded, nullFactory());
+    encoding->skip(kSliceOffset);
+    encoding->materialize(kSliceLength, values.data());
+    folly::doNotOptimizeAway(values.data());
+  }
+}
+
+} // namespace
+
+#define SLICE_BENCHMARKS(Name, EncodingT, EncodingTypeValue, DataExpr) \
+  BENCHMARK(Slice_##Name, iters) {                                     \
+    std::string encoded;                                               \
+    BENCHMARK_SUSPEND {                                                \
+      const auto data = DataExpr;                                      \
+      encoded = encodeData<EncodingT>(EncodingTypeValue, data);        \
+    }                                                                  \
+    sliceBenchmark(encoded, iters);                                    \
+  }                                                                    \
+  BENCHMARK_RELATIVE(MaterializeEncode_##Name, iters) {                \
+    std::string encoded;                                               \
+    BENCHMARK_SUSPEND {                                                \
+      const auto data = DataExpr;                                      \
+      encoded = encodeData<EncodingT>(EncodingTypeValue, data);        \
+    }                                                                  \
+    materializeEncodeBenchmark<EncodingT, uint32_t>(                   \
+        encoded, EncodingTypeValue, iters);                            \
+  }                                                                    \
+  BENCHMARK_DRAW_LINE()
+
+#define SLICE_MATERIALIZE_BENCHMARKS(                           \
+    Name, EncodingT, EncodingTypeValue, DataExpr)               \
+  BENCHMARK(SliceCreate_##Name, iters) {                        \
+    std::string encoded;                                        \
+    BENCHMARK_SUSPEND {                                         \
+      const auto data = DataExpr;                               \
+      encoded = encodeData<EncodingT>(EncodingTypeValue, data); \
+    }                                                           \
+    sliceBenchmark(encoded, iters);                             \
+  }                                                             \
+  BENCHMARK_RELATIVE(MaterializeRange_##Name, iters) {          \
+    std::string encoded;                                        \
+    BENCHMARK_SUSPEND {                                         \
+      const auto data = DataExpr;                               \
+      encoded = encodeData<EncodingT>(EncodingTypeValue, data); \
+    }                                                           \
+    materializeBenchmark<uint32_t>(encoded, iters);             \
+  }                                                             \
+  BENCHMARK_DRAW_LINE()
+
+SLICE_BENCHMARKS(
+    ConstantUint32,
+    ConstantEncoding<uint32_t>,
+    EncodingType::Constant,
+    makeConstant<uint32_t>(42));
+SLICE_BENCHMARKS(
+    TrivialUint32,
+    TrivialEncoding<uint32_t>,
+    EncodingType::Trivial,
+    makeRandom<uint32_t>());
+SLICE_BENCHMARKS(
+    RLEUint32,
+    RLEEncoding<uint32_t>,
+    EncodingType::RLE,
+    makeRunLength<uint32_t>());
+SLICE_BENCHMARKS(
+    FixedBitWidthUint32,
+    FixedBitWidthEncoding<uint32_t>,
+    EncodingType::FixedBitWidth,
+    makeNarrow<uint32_t>(12));
+
+SLICE_MATERIALIZE_BENCHMARKS(
+    TrivialUint32,
+    TrivialEncoding<uint32_t>,
+    EncodingType::Trivial,
+    makeRandom<uint32_t>());
+SLICE_MATERIALIZE_BENCHMARKS(
+    RLEUint32,
+    RLEEncoding<uint32_t>,
+    EncodingType::RLE,
+    makeRunLength<uint32_t>());
+
+#undef SLICE_MATERIALIZE_BENCHMARKS
+#undef SLICE_BENCHMARKS
+
+int main(int argc, char** argv) {
+  folly::Init init(&argc, &argv);
+  facebook::velox::memory::MemoryManager::initialize({});
+  folly::runBenchmarks();
+}

--- a/dwio/nimble/encodings/common/Encoding.cpp
+++ b/dwio/nimble/encodings/common/Encoding.cpp
@@ -28,7 +28,7 @@ Encoding::Encoding(
       dataType_{EncodingPrefix::readDataType(data)},
       rowCount_{EncodingPrefix::readRowCount(data, options_.useVarintRowCount)},
       prefixSize_{
-          EncodingPrefix::readPrefixSize(data, options_.useVarintRowCount)} {}
+          EncodingPrefix::prefixSize(data, options_.useVarintRowCount)} {}
 
 /* static */ void Encoding::copyIOBuf(char* pos, const folly::IOBuf& buf) {
   [[maybe_unused]] size_t length = buf.computeChainDataLength();

--- a/dwio/nimble/encodings/common/Encoding.h
+++ b/dwio/nimble/encodings/common/Encoding.h
@@ -336,8 +336,8 @@ class Encoding {
     return EncodingPrefix::readRowCount(data, useVarint);
   }
 
-  static uint32_t readPrefixSize(std::string_view data, bool useVarint) {
-    return EncodingPrefix::readPrefixSize(data, useVarint);
+  static uint32_t prefixSize(std::string_view data, bool useVarint) {
+    return EncodingPrefix::prefixSize(data, useVarint);
   }
 
   void releaseBuffer(velox::BufferPtr& buffer) {

--- a/dwio/nimble/encodings/common/EncodingFactory.cpp
+++ b/dwio/nimble/encodings/common/EncodingFactory.cpp
@@ -14,12 +14,14 @@
  * limitations under the License.
  */
 #include "dwio/nimble/encodings/common/EncodingFactory.h"
+
 #include "dwio/nimble/encodings/ALPEncoding.h"
 #include "dwio/nimble/encodings/BlockBitPackingEncoding.h"
 #include "dwio/nimble/encodings/ConstantEncoding.h"
 #include "dwio/nimble/encodings/DeltaBlockEncoding.h"
 #include "dwio/nimble/encodings/DeltaEncoding.h"
 #include "dwio/nimble/encodings/DictionaryEncoding.h"
+#include "dwio/nimble/encodings/EncodingSliceFactory.h"
 #include "dwio/nimble/encodings/FixedBitWidthEncoding.h"
 #include "dwio/nimble/encodings/FsstEncoding.h"
 #include "dwio/nimble/encodings/HuffmanEncoding.h"
@@ -32,229 +34,42 @@
 #include "dwio/nimble/encodings/SparseBoolEncoding.h"
 #include "dwio/nimble/encodings/TrivialEncoding.h"
 #include "dwio/nimble/encodings/VarintEncoding.h"
+#include "dwio/nimble/encodings/common/EncodingLayout.h"
+#include "dwio/nimble/encodings/common/EncodingPrefix.h"
+#include "dwio/nimble/encodings/common/EncodingTypeDispatch.h"
 #include "dwio/nimble/encodings/selection/EncodingSelection.h"
+#include "dwio/nimble/encodings/selection/EncodingSelectionPolicy.h"
 
 namespace facebook::nimble {
 
 namespace {
 
 template <typename T>
-static std::span<const typename TypeTraits<T>::physicalType> toPhysicalSpan(
+std::span<const typename TypeTraits<T>::physicalType> toPhysicalSpan(
     std::span<const T> values) {
   return std::span<const typename TypeTraits<T>::physicalType>(
       reinterpret_cast<const typename TypeTraits<T>::physicalType*>(
           values.data()),
       values.size());
 }
+
 } // namespace
 
 std::unique_ptr<Encoding> EncodingFactory::create(
     velox::memory::MemoryPool& pool,
     std::string_view data,
     std::function<void*(uint32_t)> stringBufferFactory) const {
-  return create(pool, data, std::move(stringBufferFactory), options_);
-}
-
-std::unique_ptr<Encoding> EncodingFactory::create(
-    velox::memory::MemoryPool& pool,
-    std::string_view data,
-    std::function<void*(uint32_t)> stringBufferFactory,
-    const Encoding::Options& options) const {
   // Maybe we should have a magic number of encodings too? Hrm.
-  const EncodingType encodingType = static_cast<EncodingType>(data[0]);
-  const DataType dataType = static_cast<DataType>(data[1]);
-#define RETURN_ENCODING_BY_LEAF_TYPE(Encoding, dataType)                  \
-  switch (dataType) {                                                     \
-    case DataType::Int8:                                                  \
-      return std::make_unique<Encoding<int8_t>>(                          \
-          pool, data, stringBufferFactory, options);                      \
-    case DataType::Uint8:                                                 \
-      return std::make_unique<Encoding<uint8_t>>(                         \
-          pool, data, stringBufferFactory, options);                      \
-    case DataType::Int16:                                                 \
-      return std::make_unique<Encoding<int16_t>>(                         \
-          pool, data, stringBufferFactory, options);                      \
-    case DataType::Uint16:                                                \
-      return std::make_unique<Encoding<uint16_t>>(                        \
-          pool, data, stringBufferFactory, options);                      \
-    case DataType::Int32:                                                 \
-      return std::make_unique<Encoding<int32_t>>(                         \
-          pool, data, stringBufferFactory, options);                      \
-    case DataType::Uint32:                                                \
-      return std::make_unique<Encoding<uint32_t>>(                        \
-          pool, data, stringBufferFactory, options);                      \
-    case DataType::Int64:                                                 \
-      return std::make_unique<Encoding<int64_t>>(                         \
-          pool, data, stringBufferFactory, options);                      \
-    case DataType::Uint64:                                                \
-      return std::make_unique<Encoding<uint64_t>>(                        \
-          pool, data, stringBufferFactory, options);                      \
-    case DataType::Float:                                                 \
-      return std::make_unique<Encoding<float>>(                           \
-          pool, data, stringBufferFactory, options);                      \
-    case DataType::Double:                                                \
-      return std::make_unique<Encoding<double>>(                          \
-          pool, data, stringBufferFactory, options);                      \
-    case DataType::Bool:                                                  \
-      return std::make_unique<Encoding<bool>>(                            \
-          pool, data, stringBufferFactory, options);                      \
-    case DataType::String:                                                \
-      return std::make_unique<Encoding<std::string_view>>(                \
-          pool, data, stringBufferFactory, options);                      \
-    default:                                                              \
-      NIMBLE_UNREACHABLE("Unknown encoding type {}.", toString(dataType)) \
-  }
-
-#define RETURN_ENCODING_BY_VARINT_TYPE(Encoding, dataType) \
-  switch (dataType) {                                      \
-    case DataType::Int32:                                  \
-      return std::make_unique<Encoding<int32_t>>(          \
-          pool, data, stringBufferFactory, options);       \
-    case DataType::Uint32:                                 \
-      return std::make_unique<Encoding<uint32_t>>(         \
-          pool, data, stringBufferFactory, options);       \
-    case DataType::Int64:                                  \
-      return std::make_unique<Encoding<int64_t>>(          \
-          pool, data, stringBufferFactory, options);       \
-    case DataType::Uint64:                                 \
-      return std::make_unique<Encoding<uint64_t>>(         \
-          pool, data, stringBufferFactory, options);       \
-    case DataType::Float:                                  \
-      return std::make_unique<Encoding<float>>(            \
-          pool, data, stringBufferFactory, options);       \
-    case DataType::Double:                                 \
-      return std::make_unique<Encoding<double>>(           \
-          pool, data, stringBufferFactory, options);       \
-    default:                                               \
-      NIMBLE_UNREACHABLE(                                  \
-          "Trying to deserialize a varint stream for "     \
-          "an incompatible data type {}.",                 \
-          toString(dataType));                             \
-  }
-
-#define RETURN_ENCODING_BY_NON_BOOL_TYPE(Encoding, dataType) \
-  switch (dataType) {                                        \
-    case DataType::Int8:                                     \
-      return std::make_unique<Encoding<int8_t>>(             \
-          pool, data, stringBufferFactory, options);         \
-    case DataType::Uint8:                                    \
-      return std::make_unique<Encoding<uint8_t>>(            \
-          pool, data, stringBufferFactory, options);         \
-    case DataType::Int16:                                    \
-      return std::make_unique<Encoding<int16_t>>(            \
-          pool, data, stringBufferFactory, options);         \
-    case DataType::Uint16:                                   \
-      return std::make_unique<Encoding<uint16_t>>(           \
-          pool, data, stringBufferFactory, options);         \
-    case DataType::Int32:                                    \
-      return std::make_unique<Encoding<int32_t>>(            \
-          pool, data, stringBufferFactory, options);         \
-    case DataType::Uint32:                                   \
-      return std::make_unique<Encoding<uint32_t>>(           \
-          pool, data, stringBufferFactory, options);         \
-    case DataType::Int64:                                    \
-      return std::make_unique<Encoding<int64_t>>(            \
-          pool, data, stringBufferFactory, options);         \
-    case DataType::Uint64:                                   \
-      return std::make_unique<Encoding<uint64_t>>(           \
-          pool, data, stringBufferFactory, options);         \
-    case DataType::Float:                                    \
-      return std::make_unique<Encoding<float>>(              \
-          pool, data, stringBufferFactory, options);         \
-    case DataType::Double:                                   \
-      return std::make_unique<Encoding<double>>(             \
-          pool, data, stringBufferFactory, options);         \
-    case DataType::String:                                   \
-      return std::make_unique<Encoding<std::string_view>>(   \
-          pool, data, stringBufferFactory, options);         \
-    default:                                                 \
-      NIMBLE_UNREACHABLE(                                    \
-          "Trying to deserialize a non-bool stream for "     \
-          "the bool data type {}.",                          \
-          toString(dataType));                               \
-  }
-
-#define RETURN_ENCODING_BY_NUMERIC_TYPE(Encoding, dataType) \
-  switch (dataType) {                                       \
-    case DataType::Int8:                                    \
-      return std::make_unique<Encoding<int8_t>>(            \
-          pool, data, stringBufferFactory, options);        \
-    case DataType::Uint8:                                   \
-      return std::make_unique<Encoding<uint8_t>>(           \
-          pool, data, stringBufferFactory, options);        \
-    case DataType::Int16:                                   \
-      return std::make_unique<Encoding<int16_t>>(           \
-          pool, data, stringBufferFactory, options);        \
-    case DataType::Uint16:                                  \
-      return std::make_unique<Encoding<uint16_t>>(          \
-          pool, data, stringBufferFactory, options);        \
-    case DataType::Int32:                                   \
-      return std::make_unique<Encoding<int32_t>>(           \
-          pool, data, stringBufferFactory, options);        \
-    case DataType::Uint32:                                  \
-      return std::make_unique<Encoding<uint32_t>>(          \
-          pool, data, stringBufferFactory, options);        \
-    case DataType::Int64:                                   \
-      return std::make_unique<Encoding<int64_t>>(           \
-          pool, data, stringBufferFactory, options);        \
-    case DataType::Uint64:                                  \
-      return std::make_unique<Encoding<uint64_t>>(          \
-          pool, data, stringBufferFactory, options);        \
-    case DataType::Float:                                   \
-      return std::make_unique<Encoding<float>>(             \
-          pool, data, stringBufferFactory, options);        \
-    case DataType::Double:                                  \
-      return std::make_unique<Encoding<double>>(            \
-          pool, data, stringBufferFactory, options);        \
-    default:                                                \
-      NIMBLE_UNREACHABLE(                                   \
-          "Trying to deserialize a non-numeric stream for " \
-          "a numeric data type {}.",                        \
-          toString(dataType));                              \
-  }
-
-#define RETURN_ENCODING_BY_INTEGER_TYPE(Encoding, dataType)                \
-  switch (dataType) {                                                      \
-    case DataType::Int8:                                                   \
-      return std::make_unique<Encoding<int8_t>>(                           \
-          pool, data, stringBufferFactory, options);                       \
-    case DataType::Uint8:                                                  \
-      return std::make_unique<Encoding<uint8_t>>(                          \
-          pool, data, stringBufferFactory, options);                       \
-    case DataType::Int16:                                                  \
-      return std::make_unique<Encoding<int16_t>>(                          \
-          pool, data, stringBufferFactory, options);                       \
-    case DataType::Uint16:                                                 \
-      return std::make_unique<Encoding<uint16_t>>(                         \
-          pool, data, stringBufferFactory, options);                       \
-    case DataType::Int32:                                                  \
-      return std::make_unique<Encoding<int32_t>>(                          \
-          pool, data, stringBufferFactory, options);                       \
-    case DataType::Uint32:                                                 \
-      return std::make_unique<Encoding<uint32_t>>(                         \
-          pool, data, stringBufferFactory, options);                       \
-    case DataType::Int64:                                                  \
-      return std::make_unique<Encoding<int64_t>>(                          \
-          pool, data, stringBufferFactory, options);                       \
-    case DataType::Uint64:                                                 \
-      return std::make_unique<Encoding<uint64_t>>(                         \
-          pool, data, stringBufferFactory, options);                       \
-    case DataType::Undefined:                                              \
-    case DataType::Float:                                                  \
-    case DataType::Double:                                                 \
-    case DataType::Bool:                                                   \
-    case DataType::String:                                                 \
-    default:                                                               \
-      NIMBLE_INCOMPATIBLE_ENCODING(                                        \
-          "{} only supports integer types, got {}.", #Encoding, dataType); \
-  }
+  const EncodingType encodingType = EncodingPrefix::encodingType(data);
+  const DataType dataType = EncodingPrefix::dataType(data);
+  const auto& options = options_;
 
   switch (encodingType) {
     case EncodingType::Trivial: {
-      RETURN_ENCODING_BY_LEAF_TYPE(TrivialEncoding, dataType);
+      RETURN_ENCODING_BY_DATA_TYPE(TrivialEncoding, dataType);
     }
     case EncodingType::RLE: {
-      RETURN_ENCODING_BY_LEAF_TYPE(RLEEncoding, dataType);
+      RETURN_ENCODING_BY_DATA_TYPE(RLEEncoding, dataType);
     }
     case EncodingType::Dictionary: {
       RETURN_ENCODING_BY_NON_BOOL_TYPE(DictionaryEncoding, dataType);
@@ -263,7 +78,7 @@ std::unique_ptr<Encoding> EncodingFactory::create(
       RETURN_ENCODING_BY_NUMERIC_TYPE(FixedBitWidthEncoding, dataType);
     }
     case EncodingType::Nullable: {
-      RETURN_ENCODING_BY_LEAF_TYPE(NullableEncoding, dataType);
+      RETURN_ENCODING_BY_DATA_TYPE(NullableEncoding, dataType);
     }
     case EncodingType::SparseBool: {
       NIMBLE_CHECK_EQ(
@@ -277,7 +92,7 @@ std::unique_ptr<Encoding> EncodingFactory::create(
       RETURN_ENCODING_BY_VARINT_TYPE(VarintEncoding, dataType);
     }
     case EncodingType::Constant: {
-      RETURN_ENCODING_BY_LEAF_TYPE(ConstantEncoding, dataType);
+      RETURN_ENCODING_BY_DATA_TYPE(ConstantEncoding, dataType);
     }
     case EncodingType::MainlyConstant: {
       RETURN_ENCODING_BY_NON_BOOL_TYPE(MainlyConstantEncoding, dataType);
@@ -338,6 +153,23 @@ std::unique_ptr<Encoding> EncodingFactory::create(
   }
 }
 
+std::unique_ptr<Encoding> EncodingFactory::create(
+    velox::memory::MemoryPool& pool,
+    std::string_view data,
+    std::function<void*(uint32_t)> stringBufferFactory,
+    const Encoding::Options& options) const {
+  return EncodingFactory{options}.create(pool, data, stringBufferFactory);
+}
+
+std::string_view EncodingFactory::slice(
+    std::string_view encoded,
+    uint32_t offset,
+    uint32_t length,
+    Buffer& buffer,
+    const Encoding::Options& options) {
+  return EncodingSliceFactory::slice(encoded, offset, length, buffer, options);
+}
+
 template <typename T>
 std::string_view EncodingFactory::encode(
     std::unique_ptr<EncodingSelectionPolicy<T>>&& selectorPolicy,
@@ -355,6 +187,26 @@ std::string_view EncodingFactory::encode(
       std::move(selectorPolicy)};
   return EncodingFactory::encode<T>(
       std::move(selection), physicalValues, buffer, options);
+}
+
+template <typename T>
+std::string_view EncodingFactory::encodeWithCapturedLayout(
+    std::string_view encodedLayoutSource,
+    std::span<const T> values,
+    Buffer& buffer,
+    const Encoding::Options& options,
+    std::string_view missingChildContext) {
+  auto policy = std::make_unique<ReplayedEncodingSelectionPolicy<T>>(
+      EncodingLayoutCapture::capture(encodedLayoutSource),
+      CompressionOptions{},
+      [missingChildContext](
+          DataType dataType) -> std::unique_ptr<EncodingSelectionPolicyBase> {
+        NIMBLE_FAIL(
+            "{} is missing nested child for {}.",
+            missingChildContext,
+            dataType);
+      });
+  return EncodingFactory::encode<T>(std::move(policy), values, buffer, options);
 }
 
 template <typename T>
@@ -561,6 +413,12 @@ std::string_view EncodingFactory::encodeNullable(
       std::span<const type> values,                                            \
       Buffer & buffer,                                                         \
       const Encoding::Options& options);                                       \
+  template std::string_view EncodingFactory::encodeWithCapturedLayout<type>(   \
+      std::string_view encodedLayoutSource,                                    \
+      std::span<const type> values,                                            \
+      Buffer & buffer,                                                         \
+      const Encoding::Options& options,                                        \
+      std::string_view missingChildContext);                                   \
   template std::string_view EncodingFactory::encodeNullable<type>(             \
       std::unique_ptr<EncodingSelectionPolicy<type>> && selectorPolicy,        \
       std::span<const type> values,                                            \

--- a/dwio/nimble/encodings/common/EncodingFactory.h
+++ b/dwio/nimble/encodings/common/EncodingFactory.h
@@ -42,7 +42,8 @@ class EncodingFactory {
       std::string_view data,
       std::function<void*(uint32_t)> stringBufferFactory) const;
 
-  /// Same as above but uses the provided options instead of stored options_.
+  /// Creates an Encoding from serialized data using the provided options while
+  /// preserving this factory's concrete implementation.
   virtual std::unique_ptr<Encoding> create(
       velox::memory::MemoryPool& pool,
       std::string_view data,
@@ -61,10 +62,28 @@ class EncodingFactory {
       const Encoding::Options& options = {});
 
   template <typename T>
+  static std::string_view encodeWithCapturedLayout(
+      std::string_view encodedLayoutSource,
+      std::span<const T> values,
+      Buffer& buffer,
+      const Encoding::Options& options = {},
+      std::string_view missingChildContext = "Captured encoding layout");
+
+  template <typename T>
   static std::string_view encodeNullable(
       std::unique_ptr<EncodingSelectionPolicy<T>>&& selectorPolicy,
       std::span<const T> values,
       std::span<const bool> nulls,
+      Buffer& buffer,
+      const Encoding::Options& options = {});
+
+  /// Creates a serialized encoding over the row range [offset, offset + length)
+  /// of an existing encoded buffer. Native slices are used when possible;
+  /// otherwise the range is materialized and re-encoded.
+  static std::string_view slice(
+      std::string_view encoded,
+      uint32_t offset,
+      uint32_t length,
       Buffer& buffer,
       const Encoding::Options& options = {});
 

--- a/dwio/nimble/encodings/common/EncodingPrefix.h
+++ b/dwio/nimble/encodings/common/EncodingPrefix.h
@@ -62,8 +62,16 @@ struct EncodingPrefix {
     return kRowCountOffset + varint::varintSize(rowCount);
   }
 
-  static DataType readDataType(std::string_view data) {
+  static EncodingType encodingType(std::string_view data) {
+    return static_cast<EncodingType>(data[kEncodingTypeOffset]);
+  }
+
+  static DataType dataType(std::string_view data) {
     return static_cast<DataType>(data[kDataTypeOffset]);
+  }
+
+  static DataType readDataType(std::string_view data) {
+    return dataType(data);
   }
 
   static uint32_t readRowCount(std::string_view data, bool useVarint) {
@@ -74,7 +82,7 @@ struct EncodingPrefix {
     return *reinterpret_cast<const uint32_t*>(data.data() + kRowCountOffset);
   }
 
-  static uint32_t readPrefixSize(std::string_view data, bool useVarint) {
+  static uint32_t prefixSize(std::string_view data, bool useVarint) {
     if (useVarint) {
       const char* pos = data.data() + kRowCountOffset;
       varint::readVarint32(&pos);

--- a/dwio/nimble/encodings/common/EncodingTypeDispatch.h
+++ b/dwio/nimble/encodings/common/EncodingTypeDispatch.h
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <memory>
+
+#include "dwio/nimble/common/DataTypeDispatch.h"
+
+namespace facebook::nimble {
+
+#define RETURN_ENCODING_BY_DATA_TYPE(Encoding, dataType)                       \
+  NIMBLE_RETURN_BY_DATA_TYPE_OR(                                               \
+      dataType,                                                                \
+      T,                                                                       \
+      std::make_unique<Encoding<T>>(pool, data, stringBufferFactory, options), \
+      NIMBLE_UNREACHABLE("Unknown encoding type {}.", dataType))
+
+#define RETURN_ENCODING_BY_VARINT_TYPE(Encoding, dataType)                     \
+  NIMBLE_RETURN_BY_VARINT_DATA_TYPE_OR(                                        \
+      dataType,                                                                \
+      T,                                                                       \
+      std::make_unique<Encoding<T>>(pool, data, stringBufferFactory, options), \
+      NIMBLE_UNREACHABLE(                                                      \
+          "Trying to deserialize a varint stream for "                         \
+          "an incompatible data type {}.",                                     \
+          toString(dataType)))
+
+#define RETURN_ENCODING_BY_NON_BOOL_TYPE(Encoding, dataType)                   \
+  NIMBLE_RETURN_BY_NON_BOOL_DATA_TYPE_OR(                                      \
+      dataType,                                                                \
+      T,                                                                       \
+      std::make_unique<Encoding<T>>(pool, data, stringBufferFactory, options), \
+      NIMBLE_UNREACHABLE(                                                      \
+          "Trying to deserialize a non-bool stream for "                       \
+          "the bool data type {}.",                                            \
+          toString(dataType)))
+
+#define RETURN_ENCODING_BY_NUMERIC_TYPE(Encoding, dataType)                    \
+  NIMBLE_RETURN_BY_NUMERIC_DATA_TYPE_OR(                                       \
+      dataType,                                                                \
+      T,                                                                       \
+      std::make_unique<Encoding<T>>(pool, data, stringBufferFactory, options), \
+      NIMBLE_UNREACHABLE(                                                      \
+          "Trying to deserialize a non-numeric stream for "                    \
+          "a numeric data type {}.",                                           \
+          toString(dataType)))
+
+#define RETURN_ENCODING_BY_INTEGER_TYPE(Encoding, dataType)                    \
+  NIMBLE_RETURN_BY_INTEGER_DATA_TYPE_OR(                                       \
+      dataType,                                                                \
+      T,                                                                       \
+      std::make_unique<Encoding<T>>(pool, data, stringBufferFactory, options), \
+      NIMBLE_UNREACHABLE(                                                      \
+          "Trying to deserialize an integer stream for "                       \
+          "an incompatible data type {}.",                                     \
+          toString(dataType)))
+
+} // namespace facebook::nimble

--- a/dwio/nimble/encodings/legacy/EncodingFactory.cpp
+++ b/dwio/nimble/encodings/legacy/EncodingFactory.cpp
@@ -333,8 +333,8 @@ std::unique_ptr<Encoding> EncodingFactory::create(
     velox::memory::MemoryPool& memoryPool,
     std::string_view data,
     std::function<void*(uint32_t)> stringBufferFactory,
-    const Encoding::Options& /*options*/) const {
-  return create(memoryPool, data, std::move(stringBufferFactory));
+    const Encoding::Options& options) const {
+  return EncodingFactory{options}.create(memoryPool, data, stringBufferFactory);
 }
 
 template <typename T>

--- a/dwio/nimble/encodings/tests/ALPEncodingTest.cpp
+++ b/dwio/nimble/encodings/tests/ALPEncodingTest.cpp
@@ -313,8 +313,7 @@ TYPED_TEST(ALPEncodingTest, headerMetadataUsesVarints) {
       *this->buffer_, values, alpWithFixedBitWidthPayloadLayout(), options);
 
   const char* pos = serialized.data() +
-      nimble::EncodingPrefix::readPrefixSize(
-                        serialized, options.useVarintRowCount);
+      nimble::EncodingPrefix::prefixSize(serialized, options.useVarintRowCount);
   const auto header = nimble::detail::alp::readHeader(pos);
   EXPECT_TRUE(header.hasExceptions);
 

--- a/dwio/nimble/encodings/tests/CMakeLists.txt
+++ b/dwio/nimble/encodings/tests/CMakeLists.txt
@@ -31,6 +31,8 @@ add_executable(
   CompressionTest.cpp
   EncodingTest.cpp
   EncodingLegacyTest.cpp
+  EncodingPrefixTest.cpp
+  EncodingTypeDispatchTest.cpp
   FixedBitWidthEncodingViewTest.cpp
   FsstEncodingTest.cpp
   HuffmanEncodingTest.cpp
@@ -50,6 +52,7 @@ add_executable(
   RLEEncodingTest.cpp
   SentinelEncodingTest.cpp
   SimdForBitpackEncodingViewTest.cpp
+  SliceEncodingTest.cpp
   SparseBoolEncodingViewTest.cpp
   StatisticsTest.cpp
   TrivialEncodingViewTest.cpp

--- a/dwio/nimble/encodings/tests/ConstantEncodingTest.cpp
+++ b/dwio/nimble/encodings/tests/ConstantEncodingTest.cpp
@@ -18,9 +18,11 @@
 #include <gtest/gtest.h>
 #include "dwio/nimble/common/Buffer.h"
 #include "dwio/nimble/common/Types.h"
+#include "dwio/nimble/common/tests/GTestUtils.h"
 #include "dwio/nimble/common/tests/NimbleCompare.h"
 #include "dwio/nimble/encodings/common/EncodingType.h"
 #include "dwio/nimble/encodings/tests/TestUtils.h"
+#include "velox/common/memory/Memory.h"
 
 #include <limits>
 #include <type_traits>
@@ -203,12 +205,12 @@ using TestTypes = ::testing::Types<NUM_TYPES>;
 
 TYPED_TEST_CASE(ConstantEncodingTest, TestTypes);
 
-TYPED_TEST(ConstantEncodingTest, SerializeThenDeserialize) {
-  using D = typename TypeParam::data_type;
+TYPED_TEST(ConstantEncodingTest, serializeThenDeserialize) {
+  using DataType = typename TypeParam::data_type;
   const nimble::Encoding::Options options{
       .useVarintRowCount = TypeParam::useVarint};
 
-  auto valueGroups = this->template prepareValues<D>();
+  auto valueGroups = this->template prepareValues<DataType>();
   std::vector<velox::BufferPtr> newStringBuffers;
   const auto stringBufferFactory = [&](uint32_t totalLength) {
     auto& buffer = newStringBuffers.emplace_back(
@@ -216,8 +218,8 @@ TYPED_TEST(ConstantEncodingTest, SerializeThenDeserialize) {
     return buffer->template asMutable<void>();
   };
   for (const auto& values : valueGroups) {
-    auto encoding =
-        nimble::test::Encoder<nimble::ConstantEncoding<D>>::createEncoding(
+    auto encoding = nimble::test::Encoder<nimble::ConstantEncoding<DataType>>::
+        createEncoding(
             *this->buffer_,
             values,
             stringBufferFactory,
@@ -225,24 +227,25 @@ TYPED_TEST(ConstantEncodingTest, SerializeThenDeserialize) {
             options);
 
     uint32_t rowCount = values.size();
-    nimble::Vector<D> result(this->pool_.get(), rowCount);
+    nimble::Vector<DataType> result(this->pool_.get(), rowCount);
     encoding->materialize(rowCount, result.data());
 
     EXPECT_EQ(encoding->encodingType(), nimble::EncodingType::Constant);
-    EXPECT_EQ(encoding->dataType(), nimble::TypeTraits<D>::dataType);
+    EXPECT_EQ(encoding->dataType(), nimble::TypeTraits<DataType>::dataType);
     EXPECT_EQ(encoding->rowCount(), rowCount);
     for (uint32_t i = 0; i < rowCount; ++i) {
-      EXPECT_TRUE(nimble::NimbleCompare<D>::equals(result[i], values[i]));
+      EXPECT_TRUE(
+          nimble::NimbleCompare<DataType>::equals(result[i], values[i]));
     }
   }
 }
 
-TYPED_TEST(ConstantEncodingTest, NonConstantFailure) {
-  using D = typename TypeParam::data_type;
+TYPED_TEST(ConstantEncodingTest, nonConstantFailure) {
+  using DataType = typename TypeParam::data_type;
   const nimble::Encoding::Options options{
       .useVarintRowCount = TypeParam::useVarint};
 
-  auto valueGroups = this->template prepareFailureValues<D>();
+  auto valueGroups = this->template prepareFailureValues<DataType>();
   std::vector<velox::BufferPtr> newStringBuffers;
   const auto stringBufferFactory = [&](uint32_t totalLength) {
     auto& buffer = newStringBuffers.emplace_back(
@@ -251,7 +254,7 @@ TYPED_TEST(ConstantEncodingTest, NonConstantFailure) {
   };
   for (const auto& values : valueGroups) {
     try {
-      nimble::test::Encoder<nimble::ConstantEncoding<D>>::createEncoding(
+      nimble::test::Encoder<nimble::ConstantEncoding<DataType>>::createEncoding(
           *this->buffer_,
           values,
           stringBufferFactory,
@@ -261,6 +264,163 @@ TYPED_TEST(ConstantEncodingTest, NonConstantFailure) {
     } catch (const nimble::NimbleUserError& e) {
       EXPECT_EQ(nimble::error_code::IncompatibleEncoding, e.errorCode());
       EXPECT_EQ("ConstantEncoding requires constant data.", e.errorMessage());
+    }
+  }
+}
+
+TYPED_TEST(ConstantEncodingTest, slice) {
+  using DataType = typename TypeParam::data_type;
+  const nimble::Encoding::Options options{
+      .useVarintRowCount = TypeParam::useVarint};
+
+  struct Range {
+    uint32_t offset;
+    uint32_t length;
+  };
+
+  const auto values = this->template toVector<DataType>(
+      {static_cast<DataType>(7),
+       static_cast<DataType>(7),
+       static_cast<DataType>(7),
+       static_cast<DataType>(7)});
+  const auto encoded =
+      nimble::test::Encoder<nimble::ConstantEncoding<DataType>>::encode(
+          *this->buffer_,
+          values,
+          nimble::CompressionType::Uncompressed,
+          options);
+
+  for (const auto range :
+       {Range{/*offset=*/0, /*length=*/0},
+        Range{/*offset=*/0, /*length=*/1},
+        Range{/*offset=*/1, /*length=*/2},
+        Range{/*offset=*/0, /*length=*/3},
+        Range{/*offset=*/3, /*length=*/1}}) {
+    SCOPED_TRACE(
+        testing::Message() << "offset=" << range.offset
+                           << ", length=" << range.length);
+    nimble::Buffer sliceBuffer{*this->pool_};
+    const auto sliced = nimble::ConstantEncoding<DataType>::slice(
+        encoded, range.offset, range.length, sliceBuffer, options);
+    nimble::ConstantEncoding<DataType> encoding{
+        *this->pool_,
+        sliced,
+        [](uint32_t /*totalLength*/) -> void* { return nullptr; },
+        options};
+
+    EXPECT_EQ(encoding.encodingType(), nimble::EncodingType::Constant);
+    EXPECT_EQ(encoding.dataType(), nimble::TypeTraits<DataType>::dataType);
+    EXPECT_EQ(encoding.rowCount(), range.length);
+    nimble::Vector<DataType> result(this->pool_.get(), range.length);
+    encoding.materialize(range.length, result.data());
+    for (uint32_t i = 0; i < range.length; ++i) {
+      EXPECT_TRUE(
+          nimble::NimbleCompare<DataType>::equals(
+              result[i], values[range.offset + i]));
+    }
+  }
+}
+
+TYPED_TEST(ConstantEncodingTest, invalidSliceRange) {
+  using DataType = typename TypeParam::data_type;
+  const nimble::Encoding::Options options{
+      .useVarintRowCount = TypeParam::useVarint};
+  const auto values = this->template toVector<DataType>(
+      {static_cast<DataType>(7),
+       static_cast<DataType>(7),
+       static_cast<DataType>(7),
+       static_cast<DataType>(7)});
+  const auto encoded =
+      nimble::test::Encoder<nimble::ConstantEncoding<DataType>>::encode(
+          *this->buffer_,
+          values,
+          nimble::CompressionType::Uncompressed,
+          options);
+
+  nimble::Buffer invalidSliceBuffer{*this->pool_};
+  NIMBLE_ASSERT_THROW(
+      nimble::ConstantEncoding<DataType>::slice(
+          encoded,
+          /*offset=*/5,
+          /*length=*/0,
+          invalidSliceBuffer,
+          options),
+      "");
+  NIMBLE_ASSERT_THROW(
+      nimble::ConstantEncoding<DataType>::slice(
+          encoded,
+          /*offset=*/3,
+          /*length=*/2,
+          invalidSliceBuffer,
+          options),
+      "");
+}
+
+class ConstantEncodingStringTest : public ::testing::Test {
+ protected:
+  static void SetUpTestCase() {
+    velox::memory::MemoryManager::testingSetInstance({});
+  }
+
+  void SetUp() override {
+    rootPool_ =
+        velox::memory::memoryManager()->addRootPool("ConstantEncodingTest");
+    pool_ = rootPool_->addLeafChild("ConstantEncodingTestLeaf");
+    buffer_ = std::make_unique<nimble::Buffer>(*pool_);
+  }
+
+  std::shared_ptr<velox::memory::MemoryPool> rootPool_;
+  std::shared_ptr<velox::memory::MemoryPool> pool_;
+  std::unique_ptr<nimble::Buffer> buffer_;
+};
+
+TEST_F(ConstantEncodingStringTest, slice) {
+  struct Range {
+    uint32_t offset;
+    uint32_t length;
+  };
+
+  for (const bool useVarint : {false, true}) {
+    SCOPED_TRACE(testing::Message() << "useVarint=" << useVarint);
+    const nimble::Encoding::Options options{.useVarintRowCount = useVarint};
+    const std::string value{"constant-value"};
+    nimble::Vector<std::string_view> values{pool_.get()};
+    for (uint32_t i = 0; i < 4; ++i) {
+      values.push_back(value);
+    }
+
+    const auto encoded = nimble::test::
+        Encoder<nimble::ConstantEncoding<std::string_view>>::encode(
+            *buffer_, values, nimble::CompressionType::Uncompressed, options);
+
+    for (const auto range :
+         {Range{/*offset=*/0, /*length=*/0},
+          Range{/*offset=*/1, /*length=*/2},
+          Range{/*offset=*/0, /*length=*/3}}) {
+      SCOPED_TRACE(
+          testing::Message()
+          << "offset=" << range.offset << ", length=" << range.length);
+      nimble::Buffer sliceBuffer{*pool_};
+      const auto sliced = nimble::ConstantEncoding<std::string_view>::slice(
+          encoded, range.offset, range.length, sliceBuffer, options);
+
+      std::vector<velox::BufferPtr> stringBuffers;
+      const auto stringBufferFactory = [&](uint32_t totalLength) -> void* {
+        auto& stringBuffer = stringBuffers.emplace_back(
+            velox::AlignedBuffer::allocate<char>(totalLength, pool_.get()));
+        return stringBuffer->asMutable<void>();
+      };
+      nimble::ConstantEncoding<std::string_view> encoding{
+          *pool_, sliced, stringBufferFactory, options};
+
+      EXPECT_EQ(encoding.encodingType(), nimble::EncodingType::Constant);
+      EXPECT_EQ(encoding.dataType(), nimble::DataType::String);
+      EXPECT_EQ(encoding.rowCount(), range.length);
+      nimble::Vector<std::string_view> result(pool_.get(), range.length);
+      encoding.materialize(range.length, result.data());
+      for (uint32_t i = 0; i < range.length; ++i) {
+        EXPECT_EQ(result[i], values[range.offset + i]);
+      }
     }
   }
 }

--- a/dwio/nimble/encodings/tests/EncodingPrefixTest.cpp
+++ b/dwio/nimble/encodings/tests/EncodingPrefixTest.cpp
@@ -1,0 +1,83 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "dwio/nimble/encodings/common/EncodingPrefix.h"
+
+#include <string>
+
+#include <gtest/gtest.h>
+
+using namespace facebook;
+
+namespace {
+
+std::string serializePrefix(
+    nimble::EncodingType encodingType,
+    nimble::DataType dataType,
+    uint32_t rowCount,
+    bool useVarint) {
+  std::string data(
+      nimble::EncodingPrefix::serializedSize(rowCount, useVarint), '\0');
+  char* pos = data.data();
+  nimble::EncodingPrefix::serialize(
+      encodingType, dataType, rowCount, useVarint, pos);
+  EXPECT_EQ(pos, data.data() + data.size());
+  return data;
+}
+
+} // namespace
+
+TEST(EncodingPrefixTest, readsEncodingTypeAndDataType) {
+  const auto data = serializePrefix(
+      nimble::EncodingType::Delta,
+      nimble::DataType::Int64,
+      /*rowCount=*/123,
+      /*useVarint=*/false);
+
+  EXPECT_EQ(
+      nimble::EncodingPrefix::encodingType(data), nimble::EncodingType::Delta);
+  EXPECT_EQ(nimble::EncodingPrefix::dataType(data), nimble::DataType::Int64);
+  EXPECT_EQ(
+      nimble::EncodingPrefix::readDataType(data), nimble::DataType::Int64);
+}
+
+TEST(EncodingPrefixTest, readsFixedRowCountPrefix) {
+  const auto data = serializePrefix(
+      nimble::EncodingType::Trivial,
+      nimble::DataType::Uint32,
+      /*rowCount=*/123,
+      /*useVarint=*/false);
+
+  EXPECT_EQ(
+      nimble::EncodingPrefix::readRowCount(data, /*useVarint=*/false), 123);
+  EXPECT_EQ(
+      nimble::EncodingPrefix::prefixSize(data, /*useVarint=*/false),
+      nimble::EncodingPrefix::kFixedPrefixSize);
+}
+
+TEST(EncodingPrefixTest, readsVarintRowCountPrefix) {
+  constexpr uint32_t rowCount = 1'000'000;
+  const auto data = serializePrefix(
+      nimble::EncodingType::RLE,
+      nimble::DataType::String,
+      rowCount,
+      /*useVarint=*/true);
+
+  EXPECT_EQ(
+      nimble::EncodingPrefix::readRowCount(data, /*useVarint=*/true), rowCount);
+  EXPECT_EQ(
+      nimble::EncodingPrefix::prefixSize(data, /*useVarint=*/true),
+      data.size());
+}

--- a/dwio/nimble/encodings/tests/EncodingTypeDispatchTest.cpp
+++ b/dwio/nimble/encodings/tests/EncodingTypeDispatchTest.cpp
@@ -1,0 +1,164 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "dwio/nimble/encodings/common/EncodingTypeDispatch.h"
+
+#include <memory>
+#include <string>
+#include <string_view>
+#include <type_traits>
+
+#include <gtest/gtest.h>
+
+#include "dwio/nimble/common/tests/GTestUtils.h"
+
+using namespace facebook;
+
+namespace {
+
+struct TypeName {
+  template <typename T>
+  std::string operator()() const {
+    if constexpr (std::is_same_v<T, int8_t>) {
+      return "int8";
+    } else if constexpr (std::is_same_v<T, uint8_t>) {
+      return "uint8";
+    } else if constexpr (std::is_same_v<T, int16_t>) {
+      return "int16";
+    } else if constexpr (std::is_same_v<T, uint16_t>) {
+      return "uint16";
+    } else if constexpr (std::is_same_v<T, int32_t>) {
+      return "int32";
+    } else if constexpr (std::is_same_v<T, uint32_t>) {
+      return "uint32";
+    } else if constexpr (std::is_same_v<T, int64_t>) {
+      return "int64";
+    } else if constexpr (std::is_same_v<T, uint64_t>) {
+      return "uint64";
+    } else if constexpr (std::is_same_v<T, float>) {
+      return "float";
+    } else if constexpr (std::is_same_v<T, double>) {
+      return "double";
+    } else if constexpr (std::is_same_v<T, bool>) {
+      return "bool";
+    } else if constexpr (std::is_same_v<T, std::string_view>) {
+      return "string_view";
+    }
+  }
+};
+
+struct ConstructedEncodingBase {
+  virtual ~ConstructedEncodingBase() = default;
+  virtual std::string typeName() const = 0;
+};
+
+template <typename T>
+struct ConstructedEncoding : ConstructedEncodingBase {
+  ConstructedEncoding(
+      int& /*pool*/,
+      std::string_view /*data*/,
+      int /*stringBufferFactory*/,
+      int /*options*/) {}
+
+  std::string typeName() const override {
+    return TypeName{}.operator()<T>();
+  }
+};
+
+std::unique_ptr<ConstructedEncodingBase> makeEncodingByDataType(
+    nimble::DataType dataType) {
+  int pool{0};
+  std::string_view data;
+  int stringBufferFactory{0};
+  int options{0};
+  RETURN_ENCODING_BY_DATA_TYPE(ConstructedEncoding, dataType);
+}
+
+std::unique_ptr<ConstructedEncodingBase> makeEncodingByVarintType(
+    nimble::DataType dataType) {
+  int pool{0};
+  std::string_view data;
+  int stringBufferFactory{0};
+  int options{0};
+  RETURN_ENCODING_BY_VARINT_TYPE(ConstructedEncoding, dataType);
+}
+
+std::unique_ptr<ConstructedEncodingBase> makeEncodingByNonBoolType(
+    nimble::DataType dataType) {
+  int pool{0};
+  std::string_view data;
+  int stringBufferFactory{0};
+  int options{0};
+  RETURN_ENCODING_BY_NON_BOOL_TYPE(ConstructedEncoding, dataType);
+}
+
+std::unique_ptr<ConstructedEncodingBase> makeEncodingByNumericType(
+    nimble::DataType dataType) {
+  int pool{0};
+  std::string_view data;
+  int stringBufferFactory{0};
+  int options{0};
+  RETURN_ENCODING_BY_NUMERIC_TYPE(ConstructedEncoding, dataType);
+}
+
+std::unique_ptr<ConstructedEncodingBase> makeEncodingByIntegerType(
+    nimble::DataType dataType) {
+  int pool{0};
+  std::string_view data;
+  int stringBufferFactory{0};
+  int options{0};
+  RETURN_ENCODING_BY_INTEGER_TYPE(ConstructedEncoding, dataType);
+}
+
+} // namespace
+
+TEST(EncodingTypeDispatchTest, encodingConstructionMacrosDispatchDataTypes) {
+  EXPECT_EQ(makeEncodingByDataType(nimble::DataType::Bool)->typeName(), "bool");
+  EXPECT_EQ(
+      makeEncodingByDataType(nimble::DataType::String)->typeName(),
+      "string_view");
+
+  NIMBLE_ASSERT_THROW(
+      makeEncodingByDataType(nimble::DataType::Undefined),
+      "Unknown encoding type");
+}
+
+TEST(
+    EncodingTypeDispatchTest,
+    encodingConstructionMacrosDispatchSupportedSubsets) {
+  EXPECT_EQ(
+      makeEncodingByVarintType(nimble::DataType::Uint32)->typeName(), "uint32");
+  EXPECT_EQ(
+      makeEncodingByNonBoolType(nimble::DataType::String)->typeName(),
+      "string_view");
+  EXPECT_EQ(
+      makeEncodingByNumericType(nimble::DataType::Double)->typeName(),
+      "double");
+  EXPECT_EQ(
+      makeEncodingByIntegerType(nimble::DataType::Int16)->typeName(), "int16");
+
+  NIMBLE_ASSERT_THROW(
+      makeEncodingByVarintType(nimble::DataType::Int16),
+      "Trying to deserialize a varint stream");
+  NIMBLE_ASSERT_THROW(
+      makeEncodingByNonBoolType(nimble::DataType::Bool),
+      "Trying to deserialize a non-bool stream");
+  NIMBLE_ASSERT_THROW(
+      makeEncodingByNumericType(nimble::DataType::String),
+      "Trying to deserialize a non-numeric stream");
+  NIMBLE_ASSERT_THROW(
+      makeEncodingByIntegerType(nimble::DataType::Double),
+      "Trying to deserialize an integer stream");
+}

--- a/dwio/nimble/encodings/tests/FixedBitWidthEncodingTest.cpp
+++ b/dwio/nimble/encodings/tests/FixedBitWidthEncodingTest.cpp
@@ -157,7 +157,7 @@ TYPED_TEST(
           nimble::CompressionType::Uncompressed,
           defaultOptions);
 
-  const auto defaultPrefixSize = nimble::EncodingPrefix::readPrefixSize(
+  const auto defaultPrefixSize = nimble::EncodingPrefix::prefixSize(
       defaultSerialized, TypeParam::useVarint);
   EXPECT_EQ(
       static_cast<uint8_t>(
@@ -172,18 +172,15 @@ TYPED_TEST(
           nimble::CompressionType::Uncompressed,
           exactOptions);
 
-  const auto exactPrefixSize = nimble::EncodingPrefix::readPrefixSize(
-      exactSerialized, TypeParam::useVarint);
+  const auto exactPrefixSize =
+      nimble::EncodingPrefix::prefixSize(exactSerialized, TypeParam::useVarint);
   EXPECT_EQ(
       static_cast<uint8_t>(
           exactSerialized[exactPrefixSize + sizeof(uint8_t) + 4]),
       6);
 
-  auto encoding = nimble::EncodingFactory().create(
-      *this->pool_,
-      defaultSerialized,
-      this->stringBufferFactory(),
-      defaultOptions);
+  auto encoding = nimble::EncodingFactory{defaultOptions}.create(
+      *this->pool_, defaultSerialized, this->stringBufferFactory());
   std::vector<uint32_t> result(values.size());
   encoding->materialize(values.size(), result.data());
   EXPECT_EQ(result, std::vector<uint32_t>(values.begin(), values.end()));
@@ -200,12 +197,12 @@ TYPED_TEST(FixedBitWidthEncodingTest, decodesByteRoundedPayload) {
   const auto serialized = this->encodeByteRounded(values, options);
 
   const auto prefixSize =
-      nimble::EncodingPrefix::readPrefixSize(serialized, TypeParam::useVarint);
+      nimble::EncodingPrefix::prefixSize(serialized, TypeParam::useVarint);
   EXPECT_EQ(
       static_cast<uint8_t>(serialized[prefixSize + sizeof(uint8_t) + 4]), 8);
 
-  auto encoding = nimble::EncodingFactory().create(
-      *this->pool_, serialized, this->stringBufferFactory(), options);
+  auto encoding = nimble::EncodingFactory{options}.create(
+      *this->pool_, serialized, this->stringBufferFactory());
   std::vector<uint32_t> result(values.size());
   encoding->materialize(values.size(), result.data());
   EXPECT_EQ(result, std::vector<uint32_t>(values.begin(), values.end()));

--- a/dwio/nimble/encodings/tests/MainlyConstantEncodingTest.cpp
+++ b/dwio/nimble/encodings/tests/MainlyConstantEncodingTest.cpp
@@ -18,6 +18,7 @@
 #include <gtest/gtest.h>
 #include "dwio/nimble/common/Buffer.h"
 #include "dwio/nimble/common/Types.h"
+#include "dwio/nimble/common/tests/GTestUtils.h"
 #include "dwio/nimble/common/tests/NimbleCompare.h"
 #include "dwio/nimble/encodings/common/EncodingPrefix.h"
 #include "dwio/nimble/encodings/common/EncodingPrimitives.h"
@@ -97,6 +98,13 @@ class MainlyConstantEncodingTest : public ::testing::Test {
   }
 
   template <typename T>
+  nimble::Vector<T> toVector(std::initializer_list<T> values) {
+    nimble::Vector<T> vector{pool_.get()};
+    vector.insert(vector.end(), values.begin(), values.end());
+    return vector;
+  }
+
+  template <typename T>
   std::vector<nimble::Vector<T>> prepareValues() {
     auto toVector =
         [this]<typename ValueType>(std::initializer_list<ValueType> values) {
@@ -148,12 +156,12 @@ using TestTypes = ::testing::Types<NUM_TYPES>;
 
 TYPED_TEST_CASE(MainlyConstantEncodingTest, TestTypes);
 
-TYPED_TEST(MainlyConstantEncodingTest, SerializeThenDeserialize) {
-  using D = typename TypeParam::data_type;
+TYPED_TEST(MainlyConstantEncodingTest, serializeThenDeserialize) {
+  using DataType = typename TypeParam::data_type;
   const nimble::Encoding::Options options{
       .useVarintRowCount = TypeParam::useVarint};
 
-  auto valueGroups = this->template prepareValues<D>();
+  auto valueGroups = this->template prepareValues<DataType>();
   std::vector<velox::BufferPtr> newStringBuffers;
   const auto stringBufferFactory = [&](uint32_t totalLength) {
     auto& buffer = newStringBuffers.emplace_back(
@@ -161,8 +169,8 @@ TYPED_TEST(MainlyConstantEncodingTest, SerializeThenDeserialize) {
     return buffer->template asMutable<void>();
   };
   for (const auto& values : valueGroups) {
-    auto encoding = nimble::test::Encoder<nimble::MainlyConstantEncoding<D>>::
-        createEncoding(
+    auto encoding = nimble::test::
+        Encoder<nimble::MainlyConstantEncoding<DataType>>::createEncoding(
             *this->buffer_,
             values,
             stringBufferFactory,
@@ -170,20 +178,112 @@ TYPED_TEST(MainlyConstantEncodingTest, SerializeThenDeserialize) {
             options);
 
     uint32_t rowCount = values.size();
-    nimble::Vector<D> result(this->pool_.get(), rowCount);
+    nimble::Vector<DataType> result(this->pool_.get(), rowCount);
     encoding->materialize(rowCount, result.data());
 
     EXPECT_EQ(encoding->encodingType(), nimble::EncodingType::MainlyConstant);
-    EXPECT_EQ(encoding->dataType(), nimble::TypeTraits<D>::dataType);
+    EXPECT_EQ(encoding->dataType(), nimble::TypeTraits<DataType>::dataType);
     EXPECT_EQ(encoding->rowCount(), rowCount);
     for (uint32_t i = 0; i < rowCount; ++i) {
-      EXPECT_TRUE(nimble::NimbleCompare<D>::equals(result[i], values[i]));
+      EXPECT_TRUE(
+          nimble::NimbleCompare<DataType>::equals(result[i], values[i]));
     }
   }
 }
 
+TYPED_TEST(MainlyConstantEncodingTest, slice) {
+  using DataType = typename TypeParam::data_type;
+  const nimble::Encoding::Options options{
+      .useVarintRowCount = TypeParam::useVarint};
+  const auto values = this->template toVector<DataType>(
+      {static_cast<DataType>(7),
+       static_cast<DataType>(7),
+       static_cast<DataType>(20),
+       static_cast<DataType>(7),
+       static_cast<DataType>(40),
+       static_cast<DataType>(7),
+       static_cast<DataType>(7),
+       static_cast<DataType>(70),
+       static_cast<DataType>(7),
+       static_cast<DataType>(7)});
+  const auto encoded =
+      nimble::test::Encoder<nimble::MainlyConstantEncoding<DataType>>::encode(
+          *this->buffer_,
+          values,
+          nimble::CompressionType::Uncompressed,
+          options);
+
+  struct Range {
+    uint32_t offset;
+    uint32_t length;
+  };
+  for (const auto range :
+       {Range{/*offset=*/0, /*length=*/0},
+        Range{/*offset=*/0, /*length=*/4},
+        Range{/*offset=*/2, /*length=*/6},
+        Range{/*offset=*/6, /*length=*/4}}) {
+    SCOPED_TRACE(
+        testing::Message() << "offset=" << range.offset
+                           << ", length=" << range.length);
+    nimble::Buffer sliceBuffer{*this->pool_};
+    const auto sliced = nimble::MainlyConstantEncoding<DataType>::slice(
+        encoded, range.offset, range.length, sliceBuffer, options);
+    nimble::MainlyConstantEncoding<DataType> encoding{
+        *this->pool_,
+        sliced,
+        [](uint32_t /*totalLength*/) -> void* { return nullptr; },
+        options};
+
+    EXPECT_EQ(encoding.encodingType(), nimble::EncodingType::MainlyConstant);
+    EXPECT_EQ(encoding.dataType(), nimble::TypeTraits<DataType>::dataType);
+    EXPECT_EQ(encoding.rowCount(), range.length);
+    nimble::Vector<DataType> result(this->pool_.get(), range.length);
+    encoding.materialize(range.length, result.data());
+    for (uint32_t i = 0; i < range.length; ++i) {
+      EXPECT_TRUE(
+          nimble::NimbleCompare<DataType>::equals(
+              result[i], values[range.offset + i]));
+    }
+  }
+}
+
+TYPED_TEST(MainlyConstantEncodingTest, invalidSliceRange) {
+  using DataType = typename TypeParam::data_type;
+  const nimble::Encoding::Options options{
+      .useVarintRowCount = TypeParam::useVarint};
+  const auto values = this->template toVector<DataType>(
+      {static_cast<DataType>(7),
+       static_cast<DataType>(7),
+       static_cast<DataType>(20),
+       static_cast<DataType>(7)});
+  const auto encoded =
+      nimble::test::Encoder<nimble::MainlyConstantEncoding<DataType>>::encode(
+          *this->buffer_,
+          values,
+          nimble::CompressionType::Uncompressed,
+          options);
+
+  nimble::Buffer invalidSliceBuffer{*this->pool_};
+  NIMBLE_ASSERT_THROW(
+      nimble::MainlyConstantEncoding<DataType>::slice(
+          encoded,
+          /*offset=*/5,
+          /*length=*/0,
+          invalidSliceBuffer,
+          options),
+      "");
+  NIMBLE_ASSERT_THROW(
+      nimble::MainlyConstantEncoding<DataType>::slice(
+          encoded,
+          /*offset=*/3,
+          /*length=*/2,
+          invalidSliceBuffer,
+          options),
+      "");
+}
+
 TYPED_TEST(MainlyConstantEncodingTest, deterministicSerializationOnTie) {
-  using D = typename TypeParam::data_type;
+  using DataType = typename TypeParam::data_type;
   const nimble::Encoding::Options options{
       .useVarintRowCount = TypeParam::useVarint};
 
@@ -192,9 +292,9 @@ TYPED_TEST(MainlyConstantEncodingTest, deterministicSerializationOnTie) {
   // order is seeded per table, so each encode() below sees a differently-seeded
   // map. The tie must be broken by value (deterministically) so that identical
   // input always produces identical serialized bytes.
-  nimble::Vector<D> values{this->pool_.get()};
+  nimble::Vector<DataType> values{this->pool_.get()};
   for (const auto value : {7, 7, 7, 5, 5, 5, 1}) {
-    values.push_back(static_cast<D>(value));
+    values.push_back(static_cast<DataType>(value));
   }
   const uint32_t rowCount = values.size();
 
@@ -208,17 +308,17 @@ TYPED_TEST(MainlyConstantEncodingTest, deterministicSerializationOnTie) {
   };
 
   // The tie-data must still round-trip to the original values.
-  auto encoding =
-      nimble::test::Encoder<nimble::MainlyConstantEncoding<D>>::createEncoding(
+  auto encoding = nimble::test::
+      Encoder<nimble::MainlyConstantEncoding<DataType>>::createEncoding(
           *this->buffer_,
           values,
           stringBufferFactory,
           nimble::CompressionType::Uncompressed,
           options);
-  nimble::Vector<D> result(this->pool_.get(), rowCount);
+  nimble::Vector<DataType> result(this->pool_.get(), rowCount);
   encoding->materialize(rowCount, result.data());
   for (uint32_t i = 0; i < rowCount; ++i) {
-    EXPECT_TRUE(nimble::NimbleCompare<D>::equals(result[i], values[i]));
+    EXPECT_TRUE(nimble::NimbleCompare<DataType>::equals(result[i], values[i]));
   }
 
   // Re-encoding the same input must yield byte-identical output regardless of
@@ -228,7 +328,7 @@ TYPED_TEST(MainlyConstantEncodingTest, deterministicSerializationOnTie) {
   for (int i = 0; i < kIterations; ++i) {
     nimble::Buffer buffer{*this->pool_};
     const std::string encoded{
-        nimble::test::Encoder<nimble::MainlyConstantEncoding<D>>::encode(
+        nimble::test::Encoder<nimble::MainlyConstantEncoding<DataType>>::encode(
             buffer, values, nimble::CompressionType::Uncompressed, options)};
     if (i == 0) {
       expected = encoded;

--- a/dwio/nimble/encodings/tests/NullableEncodingTest.cpp
+++ b/dwio/nimble/encodings/tests/NullableEncodingTest.cpp
@@ -20,6 +20,7 @@
 #include "dwio/nimble/common/Buffer.h"
 #include "dwio/nimble/common/Types.h"
 #include "dwio/nimble/common/Vector.h"
+#include "dwio/nimble/common/tests/GTestUtils.h"
 #include "dwio/nimble/common/tests/TestUtils.h"
 #include "dwio/nimble/encodings/SentinelEncoding.h"
 #include "dwio/nimble/encodings/TrivialEncoding.h"
@@ -141,7 +142,7 @@ nimble::Vector<E> spreadNullsIntoData(
   return result;
 }
 
-TYPED_TEST(NullableEncodingTest, Materialize) {
+TYPED_TEST(NullableEncodingTest, materialize) {
   using E = typename TypeParam::encoding_type::cppDataType;
   const nimble::Encoding::Options options{
       .useVarintRowCount = TypeParam::useVarint};
@@ -236,6 +237,119 @@ TYPED_TEST(NullableEncodingTest, Materialize) {
   }
 }
 
+class NullableEncodingSliceTest : public ::testing::Test {
+ protected:
+  static void SetUpTestCase() {
+    velox::memory::MemoryManager::testingSetInstance({});
+  }
+
+  void SetUp() override {
+    rootPool_ =
+        velox::memory::memoryManager()->addRootPool("NullableEncodingTest");
+    pool_ = rootPool_->addLeafChild("NullableEncodingTestLeaf");
+  }
+
+  nimble::Vector<int32_t> toInt32Vector(std::initializer_list<int32_t> values) {
+    nimble::Vector<int32_t> vector{pool_.get()};
+    vector.insert(vector.end(), values.begin(), values.end());
+    return vector;
+  }
+
+  nimble::Vector<bool> toBoolVector(std::initializer_list<bool> values) {
+    nimble::Vector<bool> vector{pool_.get()};
+    vector.insert(vector.end(), values.begin(), values.end());
+    return vector;
+  }
+
+  std::shared_ptr<velox::memory::MemoryPool> rootPool_;
+  std::shared_ptr<velox::memory::MemoryPool> pool_;
+};
+
+TEST_F(NullableEncodingSliceTest, slice) {
+  for (const bool useVarint : {false, true}) {
+    SCOPED_TRACE(testing::Message() << "useVarint=" << useVarint);
+    const nimble::Encoding::Options options{.useVarintRowCount = useVarint};
+    nimble::Buffer sourceBuffer{*pool_};
+    const auto values = toInt32Vector({10, 20, 30, 40, 50});
+    const auto nulls =
+        toBoolVector({true, false, true, true, false, true, true});
+    const auto expected = spreadNullsIntoData<int32_t>(*pool_, values, nulls);
+    const auto encoded = nimble::test::
+        Encoder<nimble::NullableEncoding<int32_t>>::encodeNullable(
+            sourceBuffer,
+            values,
+            nulls,
+            nimble::CompressionType::Uncompressed,
+            options);
+
+    struct Range {
+      uint32_t offset;
+      uint32_t length;
+    };
+    for (const auto range :
+         {Range{/*offset=*/0, /*length=*/3},
+          Range{/*offset=*/1, /*length=*/5},
+          Range{/*offset=*/4, /*length=*/3}}) {
+      SCOPED_TRACE(
+          testing::Message()
+          << "offset=" << range.offset << ", length=" << range.length);
+      nimble::Buffer sliceBuffer{*pool_};
+      const auto sliced = nimble::NullableEncoding<int32_t>::slice(
+          encoded, range.offset, range.length, sliceBuffer, options);
+      nimble::NullableEncoding<int32_t> encoding{
+          *pool_,
+          sliced,
+          [](uint32_t /*totalLength*/) -> void* { return nullptr; },
+          options};
+
+      EXPECT_EQ(encoding.encodingType(), nimble::EncodingType::Nullable);
+      EXPECT_EQ(encoding.dataType(), nimble::DataType::Int32);
+      EXPECT_EQ(encoding.rowCount(), range.length);
+      nimble::Vector<int32_t> result(pool_.get(), range.length);
+      encoding.materialize(range.length, result.data());
+      for (uint32_t i = 0; i < range.length; ++i) {
+        EXPECT_EQ(result[i], expected[range.offset + i]);
+      }
+    }
+  }
+}
+
+TEST_F(NullableEncodingSliceTest, invalidSliceRange) {
+  for (const bool useVarint : {false, true}) {
+    SCOPED_TRACE(testing::Message() << "useVarint=" << useVarint);
+    const nimble::Encoding::Options options{.useVarintRowCount = useVarint};
+    nimble::Buffer sourceBuffer{*pool_};
+    const auto values = toInt32Vector({10, 20, 30, 40, 50});
+    const auto nulls =
+        toBoolVector({true, false, true, true, false, true, true});
+    const auto encoded = nimble::test::
+        Encoder<nimble::NullableEncoding<int32_t>>::encodeNullable(
+            sourceBuffer,
+            values,
+            nulls,
+            nimble::CompressionType::Uncompressed,
+            options);
+
+    nimble::Buffer invalidSliceBuffer{*pool_};
+    NIMBLE_ASSERT_THROW(
+        nimble::NullableEncoding<int32_t>::slice(
+            encoded,
+            /*offset=*/8,
+            /*length=*/0,
+            invalidSliceBuffer,
+            options),
+        "");
+    NIMBLE_ASSERT_THROW(
+        nimble::NullableEncoding<int32_t>::slice(
+            encoded,
+            /*offset=*/6,
+            /*length=*/2,
+            invalidSliceBuffer,
+            options),
+        "");
+  }
+}
+
 template <typename T>
 void checkOutput(
     size_t index,
@@ -256,7 +370,7 @@ void checkOutput(
   }
 }
 
-TYPED_TEST(NullableEncodingTest, ScatteredMaterialize) {
+TYPED_TEST(NullableEncodingTest, scatteredMaterialize) {
   using E = typename TypeParam::encoding_type::cppDataType;
   const nimble::Encoding::Options options{
       .useVarintRowCount = TypeParam::useVarint};
@@ -447,7 +561,7 @@ TYPED_TEST(NullableEncodingTest, ScatteredMaterialize) {
   }
 }
 
-TYPED_TEST(NullableEncodingTest, MaterializeNullable) {
+TYPED_TEST(NullableEncodingTest, materializeNullable) {
   using E = typename TypeParam::encoding_type::cppDataType;
   const nimble::Encoding::Options options{
       .useVarintRowCount = TypeParam::useVarint};

--- a/dwio/nimble/encodings/tests/PFOREncodingTest.cpp
+++ b/dwio/nimble/encodings/tests/PFOREncodingTest.cpp
@@ -46,7 +46,7 @@ PforWireInfo readPforWireInfo(
     std::string_view encoded,
     bool useVarintRowCount) {
   const auto prefixSize =
-      EncodingPrefix::readPrefixSize(encoded, useVarintRowCount);
+      EncodingPrefix::prefixSize(encoded, useVarintRowCount);
   const char* pos = encoded.data() + prefixSize;
   pos += sizeof(uint32_t);
   const auto baseBitWidth = static_cast<uint8_t>(encoding::readChar(pos));

--- a/dwio/nimble/encodings/tests/RLEEncodingTest.cpp
+++ b/dwio/nimble/encodings/tests/RLEEncodingTest.cpp
@@ -18,6 +18,7 @@
 #include <gtest/gtest.h>
 #include "dwio/nimble/common/Buffer.h"
 #include "dwio/nimble/common/Types.h"
+#include "dwio/nimble/common/tests/GTestUtils.h"
 #include "dwio/nimble/common/tests/NimbleCompare.h"
 #include "dwio/nimble/encodings/common/EncodingType.h"
 #include "dwio/nimble/encodings/tests/TestUtils.h"
@@ -270,12 +271,12 @@ using TestTypes = ::testing::Types<NUM_TYPES>;
 
 TYPED_TEST_CASE(RleEncodingTest, TestTypes);
 
-TYPED_TEST(RleEncodingTest, SerializeThenDeserialize) {
-  using D = typename TypeParam::data_type;
+TYPED_TEST(RleEncodingTest, serializeThenDeserialize) {
+  using DataType = typename TypeParam::data_type;
   const nimble::Encoding::Options options{
       .useVarintRowCount = TypeParam::useVarint};
 
-  auto valueGroups = this->template prepareValues<D>();
+  auto valueGroups = this->template prepareValues<DataType>();
   std::vector<velox::BufferPtr> newStringBuffers;
   const auto stringBufferFactory = [&](uint32_t totalLength) {
     auto& buffer = newStringBuffers.emplace_back(
@@ -284,21 +285,130 @@ TYPED_TEST(RleEncodingTest, SerializeThenDeserialize) {
   };
   for (const auto& values : valueGroups) {
     auto encoding =
-        nimble::test::Encoder<nimble::RLEEncoding<D>>::createEncoding(
+        nimble::test::Encoder<nimble::RLEEncoding<DataType>>::createEncoding(
             *this->buffer_,
             values,
             stringBufferFactory,
             nimble::CompressionType::Uncompressed,
             options);
     uint32_t rowCount = values.size();
-    nimble::Vector<D> result(this->pool_.get(), rowCount);
+    nimble::Vector<DataType> result(this->pool_.get(), rowCount);
     encoding->materialize(rowCount, result.data());
 
     EXPECT_EQ(encoding->encodingType(), nimble::EncodingType::RLE);
-    EXPECT_EQ(encoding->dataType(), nimble::TypeTraits<D>::dataType);
+    EXPECT_EQ(encoding->dataType(), nimble::TypeTraits<DataType>::dataType);
     EXPECT_EQ(encoding->rowCount(), rowCount);
     for (uint32_t i = 0; i < rowCount; ++i) {
-      EXPECT_TRUE(nimble::NimbleCompare<D>::equals(result[i], values[i]));
+      EXPECT_TRUE(
+          nimble::NimbleCompare<DataType>::equals(result[i], values[i]));
     }
   }
+}
+
+TYPED_TEST(RleEncodingTest, slice) {
+  using DataType = typename TypeParam::data_type;
+  const nimble::Encoding::Options options{
+      .useVarintRowCount = TypeParam::useVarint};
+  const auto values = this->template toVector<DataType>(
+      {static_cast<DataType>(1),
+       static_cast<DataType>(1),
+       static_cast<DataType>(1),
+       static_cast<DataType>(2),
+       static_cast<DataType>(2),
+       static_cast<DataType>(3),
+       static_cast<DataType>(3),
+       static_cast<DataType>(3),
+       static_cast<DataType>(4),
+       static_cast<DataType>(4)});
+  const auto encoded =
+      nimble::test::Encoder<nimble::RLEEncoding<DataType>>::encode(
+          *this->buffer_,
+          values,
+          nimble::CompressionType::Uncompressed,
+          options);
+
+  struct Range {
+    const char* name;
+    uint32_t offset;
+    uint32_t length;
+  };
+  for (const auto range :
+       {Range{/*name=*/"allRunsNoPartial",
+              /*offset=*/0,
+              /*length=*/10},
+        Range{/*name=*/"singleRunNoPartial",
+              /*offset=*/0,
+              /*length=*/3},
+        Range{/*name=*/"middleRunsNoPartial",
+              /*offset=*/3,
+              /*length=*/5},
+        Range{/*name=*/"lastRunNoPartial", /*offset=*/8, /*length=*/2},
+        Range{/*name=*/"firstRunPartialLastExact",
+              /*offset=*/1,
+              /*length=*/7},
+        Range{/*name=*/"firstExactLastRunPartial",
+              /*offset=*/3,
+              /*length=*/4},
+        Range{/*name=*/"bothPartialSameRun", /*offset=*/1, /*length=*/1},
+        Range{/*name=*/"bothPartialWithInteriorRun",
+              /*offset=*/1,
+              /*length=*/5}}) {
+    SCOPED_TRACE(
+        testing::Message() << "case=" << range.name << ", offset="
+                           << range.offset << ", length=" << range.length);
+    nimble::Buffer sliceBuffer{*this->pool_};
+    const auto sliced = nimble::RLEEncoding<DataType>::slice(
+        encoded, range.offset, range.length, sliceBuffer, options);
+    nimble::RLEEncoding<DataType> encoding{
+        *this->pool_,
+        sliced,
+        [](uint32_t /*totalLength*/) -> void* { return nullptr; },
+        options};
+
+    EXPECT_EQ(encoding.encodingType(), nimble::EncodingType::RLE);
+    EXPECT_EQ(encoding.dataType(), nimble::TypeTraits<DataType>::dataType);
+    EXPECT_EQ(encoding.rowCount(), range.length);
+    nimble::Vector<DataType> result(this->pool_.get(), range.length);
+    encoding.materialize(range.length, result.data());
+    for (uint32_t i = 0; i < range.length; ++i) {
+      EXPECT_TRUE(
+          nimble::NimbleCompare<DataType>::equals(
+              result[i], values[range.offset + i]));
+    }
+  }
+}
+
+TYPED_TEST(RleEncodingTest, invalidSliceRange) {
+  using DataType = typename TypeParam::data_type;
+  const nimble::Encoding::Options options{
+      .useVarintRowCount = TypeParam::useVarint};
+  const auto values = this->template toVector<DataType>(
+      {static_cast<DataType>(1),
+       static_cast<DataType>(1),
+       static_cast<DataType>(2),
+       static_cast<DataType>(2)});
+  const auto encoded =
+      nimble::test::Encoder<nimble::RLEEncoding<DataType>>::encode(
+          *this->buffer_,
+          values,
+          nimble::CompressionType::Uncompressed,
+          options);
+
+  nimble::Buffer invalidSliceBuffer{*this->pool_};
+  NIMBLE_ASSERT_THROW(
+      nimble::RLEEncoding<DataType>::slice(
+          encoded,
+          /*offset=*/5,
+          /*length=*/0,
+          invalidSliceBuffer,
+          options),
+      "");
+  NIMBLE_ASSERT_THROW(
+      nimble::RLEEncoding<DataType>::slice(
+          encoded,
+          /*offset=*/3,
+          /*length=*/2,
+          invalidSliceBuffer,
+          options),
+      "");
 }

--- a/dwio/nimble/encodings/tests/SliceEncodingTest.cpp
+++ b/dwio/nimble/encodings/tests/SliceEncodingTest.cpp
@@ -1,0 +1,628 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "dwio/nimble/encodings/EncodingSliceFactory.h"
+
+#include <algorithm>
+#include <random>
+#include <string_view>
+#include <type_traits>
+#include <vector>
+
+#include <gtest/gtest.h>
+
+#include "dwio/nimble/common/Buffer.h"
+#include "dwio/nimble/common/Vector.h"
+#include "dwio/nimble/common/tests/GTestUtils.h"
+#include "dwio/nimble/encodings/ALPEncoding.h"
+#include "dwio/nimble/encodings/BlockBitPackingEncoding.h"
+#include "dwio/nimble/encodings/ConstantEncoding.h"
+#include "dwio/nimble/encodings/DeltaEncoding.h"
+#include "dwio/nimble/encodings/DictionaryEncoding.h"
+#include "dwio/nimble/encodings/FixedBitWidthEncoding.h"
+#include "dwio/nimble/encodings/HuffmanEncoding.h"
+#include "dwio/nimble/encodings/MainlyConstantEncoding.h"
+#include "dwio/nimble/encodings/NullableEncoding.h"
+#include "dwio/nimble/encodings/PFOREncoding.h"
+#include "dwio/nimble/encodings/RLEEncoding.h"
+#include "dwio/nimble/encodings/SimdForBitpackEncoding.h"
+#include "dwio/nimble/encodings/SparseBoolEncoding.h"
+#include "dwio/nimble/encodings/TrivialEncoding.h"
+#include "dwio/nimble/encodings/VarintEncoding.h"
+#include "dwio/nimble/encodings/common/EncodingFactory.h"
+#include "dwio/nimble/encodings/tests/TestUtils.h"
+#include "velox/common/base/BitUtil.h"
+#include "velox/common/memory/Memory.h"
+
+using namespace facebook;
+
+class SliceEncodingTest : public ::testing::Test {
+ protected:
+  static void SetUpTestCase() {
+    velox::memory::MemoryManager::testingSetInstance({});
+  }
+
+  void SetUp() override {
+    rootPool_ =
+        velox::memory::memoryManager()->addRootPool("SliceEncodingTest");
+    pool_ = rootPool_->addLeafChild("SliceEncodingTestLeaf");
+    buffer_ = std::make_unique<nimble::Buffer>(*pool_);
+  }
+
+  template <typename T>
+  nimble::Vector<T> makeVector(std::initializer_list<T> values) {
+    nimble::Vector<T> result{pool_.get()};
+    result.insert(result.end(), values.begin(), values.end());
+    return result;
+  }
+
+  template <typename EncodingType>
+  nimble::Vector<typename EncodingType::cppDataType> makeValuesForEncoding() {
+    using DataType = typename EncodingType::cppDataType;
+    if constexpr (std::is_same_v<
+                      EncodingType,
+                      nimble::ConstantEncoding<DataType>>) {
+      return makeVector<DataType>(
+          {static_cast<DataType>(7),
+           static_cast<DataType>(7),
+           static_cast<DataType>(7),
+           static_cast<DataType>(7),
+           static_cast<DataType>(7),
+           static_cast<DataType>(7)});
+    } else if constexpr (std::is_same_v<
+                             EncodingType,
+                             nimble::MainlyConstantEncoding<DataType>>) {
+      return makeVector<DataType>(
+          {static_cast<DataType>(10),
+           static_cast<DataType>(10),
+           static_cast<DataType>(12),
+           static_cast<DataType>(10),
+           static_cast<DataType>(14),
+           static_cast<DataType>(10)});
+    } else if constexpr (std::is_same_v<
+                             EncodingType,
+                             nimble::HuffmanEncoding<DataType>>) {
+      return makeVector<DataType>(
+          {static_cast<DataType>(10),
+           static_cast<DataType>(11),
+           static_cast<DataType>(10),
+           static_cast<DataType>(12),
+           static_cast<DataType>(10),
+           static_cast<DataType>(13)});
+    } else if constexpr (std::is_same_v<
+                             EncodingType,
+                             nimble::ALPEncoding<DataType>>) {
+      return makeVector<DataType>(
+          {static_cast<DataType>(1.25),
+           static_cast<DataType>(2.5),
+           static_cast<DataType>(3.75),
+           static_cast<DataType>(4.0),
+           static_cast<DataType>(5.125),
+           static_cast<DataType>(6.25)});
+    } else {
+      return makeVector<DataType>(
+          {static_cast<DataType>(10),
+           static_cast<DataType>(11),
+           static_cast<DataType>(12),
+           static_cast<DataType>(13),
+           static_cast<DataType>(14),
+           static_cast<DataType>(15)});
+    }
+  }
+
+  template <typename EncodingType>
+  nimble::Vector<typename EncodingType::cppDataType>
+  makeRandomValuesForEncoding(std::mt19937& rng, uint32_t rowCount) {
+    using DataType = typename EncodingType::cppDataType;
+    nimble::Vector<DataType> values{pool_.get()};
+    values.reserve(rowCount);
+
+    const auto nextIntegerValue = [&] {
+      return static_cast<DataType>(
+          std::uniform_int_distribution<uint32_t>{0, 1024}(rng));
+    };
+
+    if constexpr (std::is_same_v<
+                      EncodingType,
+                      nimble::ConstantEncoding<DataType>>) {
+      const auto value = nextIntegerValue();
+      for (uint32_t i = 0; i < rowCount; ++i) {
+        values.push_back(value);
+      }
+    } else if constexpr (std::is_same_v<
+                             EncodingType,
+                             nimble::MainlyConstantEncoding<DataType>>) {
+      const auto commonValue = nextIntegerValue();
+      for (uint32_t i = 0; i < rowCount; ++i) {
+        values.push_back(i % 5 == 2 ? nextIntegerValue() : commonValue);
+      }
+    } else if constexpr (std::is_same_v<
+                             EncodingType,
+                             nimble::HuffmanEncoding<DataType>>) {
+      for (uint32_t i = 0; i < rowCount; ++i) {
+        values.push_back(
+            static_cast<DataType>(
+                std::uniform_int_distribution<uint32_t>{0, 7}(rng)));
+      }
+    } else if constexpr (std::is_same_v<
+                             EncodingType,
+                             nimble::PFOREncoding<DataType>>) {
+      for (uint32_t i = 0; i < rowCount; ++i) {
+        values.push_back(
+            static_cast<DataType>(
+                std::uniform_int_distribution<uint32_t>{0, 15}(rng)));
+      }
+    } else if constexpr (std::is_same_v<
+                             EncodingType,
+                             nimble::ALPEncoding<DataType>>) {
+      for (uint32_t i = 0; i < rowCount; ++i) {
+        values.push_back(
+            static_cast<DataType>(
+                std::uniform_int_distribution<uint32_t>{0, 4096}(rng) / 4.0));
+      }
+    } else if constexpr (std::is_same_v<
+                             EncodingType,
+                             nimble::RLEEncoding<DataType>>) {
+      while (values.size() < rowCount) {
+        const auto value = nextIntegerValue();
+        const auto runLength =
+            std::uniform_int_distribution<uint32_t>{1, 8}(rng);
+        for (uint32_t i = 0; i < runLength && values.size() < rowCount; ++i) {
+          values.push_back(value);
+        }
+      }
+    } else {
+      for (uint32_t i = 0; i < rowCount; ++i) {
+        values.push_back(nextIntegerValue());
+      }
+    }
+
+    return values;
+  }
+
+  std::unique_ptr<nimble::Encoding> createEncoding(std::string_view encoded) {
+    return nimble::EncodingFactory{}.create(
+        *pool_, encoded, [&](uint32_t totalLength) {
+          auto& buffer = stringBuffers_.emplace_back(
+              velox::AlignedBuffer::allocate<char>(totalLength, pool_.get()));
+          return buffer->asMutable<void>();
+        });
+  }
+
+  std::string_view
+  slice(std::string_view encoded, uint32_t offset, uint32_t length) {
+    return nimble::EncodingFactory::slice(
+        encoded, offset, length, *buffer_, nimble::Encoding::Options{});
+  }
+
+  template <typename T>
+  std::vector<T>
+  stdVector(const nimble::Vector<T>& values, uint32_t offset, uint32_t length) {
+    return std::vector<T>(
+        values.begin() + offset, values.begin() + offset + length);
+  }
+
+  template <typename EncodingType, typename T>
+  void expectSliceMaterializes(
+      std::string_view name,
+      nimble::EncodingType expectedEncodingType,
+      const nimble::Vector<T>& values,
+      uint32_t offset,
+      uint32_t length) {
+    SCOPED_TRACE(name);
+    const auto encoded =
+        nimble::test::Encoder<EncodingType>::encode(*buffer_, values);
+
+    const auto sliced = slice(encoded, offset, length);
+    EXPECT_NE(sliced.data(), encoded.data());
+
+    auto encoding = createEncoding(sliced);
+
+    EXPECT_EQ(encoding->encodingType(), expectedEncodingType);
+    EXPECT_EQ(encoding->dataType(), nimble::TypeTraits<T>::dataType);
+    EXPECT_EQ(encoding->rowCount(), length);
+
+    nimble::Vector<T> output{pool_.get(), length};
+    encoding->materialize(length, output.data());
+
+    EXPECT_EQ(
+        std::vector<T>(output.begin(), output.end()),
+        stdVector(values, offset, length));
+  }
+
+  template <typename EncodingType, typename T>
+  void expectFactorySliceMaterializes(
+      const nimble::Vector<T>& values,
+      uint32_t offset,
+      uint32_t length) {
+    const auto encoded =
+        nimble::test::Encoder<EncodingType>::encode(*buffer_, values);
+    const auto sliced = slice(encoded, offset, length);
+    auto encoding = createEncoding(sliced);
+
+    EXPECT_EQ(
+        encoding->encodingType(),
+        nimble::test::Encoder<EncodingType>::encodingType());
+    EXPECT_EQ(encoding->dataType(), nimble::TypeTraits<T>::dataType);
+    EXPECT_EQ(encoding->rowCount(), length);
+
+    nimble::Vector<T> output{pool_.get(), length};
+    encoding->materialize(length, output.data());
+
+    EXPECT_EQ(
+        std::vector<T>(output.begin(), output.end()),
+        stdVector(values, offset, length));
+  }
+
+  template <typename EncodingType>
+  void expectBoolSliceMaterializes(
+      std::string_view name,
+      nimble::EncodingType expectedEncodingType,
+      const nimble::Vector<bool>& values,
+      uint32_t offset,
+      uint32_t length) {
+    SCOPED_TRACE(name);
+    const auto encoded =
+        nimble::test::Encoder<EncodingType>::encode(*buffer_, values);
+
+    const auto sliced = slice(encoded, offset, length);
+    EXPECT_NE(sliced.data(), encoded.data());
+
+    auto encoding = createEncoding(sliced);
+
+    EXPECT_EQ(encoding->encodingType(), expectedEncodingType);
+    EXPECT_EQ(encoding->dataType(), nimble::DataType::Bool);
+    EXPECT_EQ(encoding->rowCount(), length);
+
+    nimble::Vector<bool> output{pool_.get(), length};
+    encoding->materialize(length, output.data());
+
+    EXPECT_EQ(
+        std::vector<bool>(output.begin(), output.end()),
+        stdVector(values, offset, length));
+  }
+
+  std::shared_ptr<velox::memory::MemoryPool> rootPool_;
+  std::shared_ptr<velox::memory::MemoryPool> pool_;
+  std::unique_ptr<nimble::Buffer> buffer_;
+  std::vector<velox::BufferPtr> stringBuffers_;
+};
+
+template <typename Encoding>
+struct SliceEncodingConfig {
+  using EncodingType = Encoding;
+};
+
+using SliceEncodingTypes = ::testing::Types<
+    SliceEncodingConfig<nimble::TrivialEncoding<uint32_t>>,
+    SliceEncodingConfig<nimble::DictionaryEncoding<uint32_t>>,
+    SliceEncodingConfig<nimble::FixedBitWidthEncoding<uint32_t>>,
+    SliceEncodingConfig<nimble::VarintEncoding<uint32_t>>,
+    SliceEncodingConfig<nimble::RLEEncoding<uint32_t>>,
+    SliceEncodingConfig<nimble::ConstantEncoding<uint32_t>>,
+    SliceEncodingConfig<nimble::MainlyConstantEncoding<uint32_t>>,
+    SliceEncodingConfig<nimble::DeltaEncoding<uint32_t>>,
+    SliceEncodingConfig<nimble::BlockBitPackingEncoding<uint32_t>>,
+    SliceEncodingConfig<nimble::PFOREncoding<uint32_t>>,
+    SliceEncodingConfig<nimble::SimdForBitpackEncoding<uint32_t>>,
+    SliceEncodingConfig<nimble::HuffmanEncoding<uint32_t>>,
+    SliceEncodingConfig<nimble::ALPEncoding<double>>>;
+
+template <typename Config>
+class SliceEncodingTypedTest : public SliceEncodingTest {};
+
+TYPED_TEST_CASE(SliceEncodingTypedTest, SliceEncodingTypes);
+
+TYPED_TEST(SliceEncodingTypedTest, materializesRange) {
+  using EncodingType = typename TypeParam::EncodingType;
+  const auto values = this->template makeValuesForEncoding<EncodingType>();
+  constexpr uint32_t offset{1};
+  constexpr uint32_t length{3};
+
+  this->template expectSliceMaterializes<EncodingType>(
+      nimble::toString(nimble::test::Encoder<EncodingType>::encodingType()),
+      nimble::test::Encoder<EncodingType>::encodingType(),
+      values,
+      offset,
+      length);
+}
+
+TYPED_TEST(SliceEncodingTypedTest, materializesRandomRanges) {
+  using EncodingType = typename TypeParam::EncodingType;
+  constexpr uint32_t kIterations{64};
+  std::mt19937 rng{
+      0x5eed0000u +
+      static_cast<uint32_t>(
+          nimble::test::Encoder<EncodingType>::encodingType())};
+
+  for (uint32_t iteration = 0; iteration < kIterations; ++iteration) {
+    SCOPED_TRACE(testing::Message() << "iteration=" << iteration);
+    constexpr bool kRequiresAtLeastTwoRows = std::is_same_v<
+        EncodingType,
+        nimble::HuffmanEncoding<typename EncodingType::cppDataType>>;
+    const auto rowCount = std::uniform_int_distribution<uint32_t>{
+        kRequiresAtLeastTwoRows ? 2U : 1U, 128}(rng);
+    const auto values =
+        this->template makeRandomValuesForEncoding<EncodingType>(rng, rowCount);
+    const auto offset = std::uniform_int_distribution<uint32_t>{
+        0, rowCount - (kRequiresAtLeastTwoRows ? 2U : 1U)}(rng);
+    const auto length = std::uniform_int_distribution<uint32_t>{
+        kRequiresAtLeastTwoRows ? 2U : 1U, rowCount - offset}(rng);
+
+    SCOPED_TRACE(
+        testing::Message() << "rowCount=" << rowCount << ", offset=" << offset
+                           << ", length=" << length);
+    this->template expectFactorySliceMaterializes<EncodingType>(
+        values, offset, length);
+  }
+}
+
+TEST_F(SliceEncodingTest, materializesNumericRange) {
+  const auto values = makeVector<int32_t>({10, 11, 12, 13, 14, 15});
+  const auto encoded =
+      nimble::test::Encoder<nimble::TrivialEncoding<int32_t>>::encode(
+          *buffer_, values);
+
+  const auto sliced = slice(encoded, /*offset=*/2, /*length=*/3);
+  EXPECT_NE(sliced.data(), encoded.data());
+  auto encoding = createEncoding(sliced);
+
+  EXPECT_EQ(encoding->encodingType(), nimble::EncodingType::Trivial);
+  EXPECT_EQ(encoding->dataType(), nimble::DataType::Int32);
+  EXPECT_EQ(encoding->rowCount(), 3);
+
+  nimble::Vector<int32_t> output{pool_.get(), 3};
+  encoding->materialize(3, output.data());
+
+  const std::vector<int32_t> expected{12, 13, 14};
+  EXPECT_EQ(std::vector<int32_t>(output.begin(), output.end()), expected);
+}
+
+TEST_F(SliceEncodingTest, fullRangeReturnsOriginalEncoding) {
+  const auto values = makeVector<int32_t>({10, 11, 12, 13});
+  const auto encoded =
+      nimble::test::Encoder<nimble::TrivialEncoding<int32_t>>::encode(
+          *buffer_, values);
+
+  const auto sliced = slice(encoded, /*offset=*/0, /*length=*/4);
+
+  EXPECT_EQ(sliced.data(), encoded.data());
+  EXPECT_EQ(sliced.size(), encoded.size());
+}
+
+TEST_F(SliceEncodingTest, materializesAfterSkip) {
+  const auto values = makeVector<int32_t>({10, 11, 12, 13, 14, 15});
+  const auto encoded =
+      nimble::test::Encoder<nimble::TrivialEncoding<int32_t>>::encode(
+          *buffer_, values);
+
+  const auto sliced = slice(encoded, /*offset=*/1, /*length=*/4);
+  EXPECT_NE(sliced.data(), encoded.data());
+
+  auto encoding = createEncoding(sliced);
+  encoding->skip(2);
+
+  nimble::Vector<int32_t> output{pool_.get(), 2};
+  encoding->materialize(2, output.data());
+
+  const std::vector<int32_t> expected{13, 14};
+  EXPECT_EQ(std::vector<int32_t>(output.begin(), output.end()), expected);
+}
+
+TEST_F(SliceEncodingTest, materializesStringRange) {
+  const auto values =
+      makeVector<std::string_view>({"alpha", "beta", "gamma", "delta"});
+  const auto encoded =
+      nimble::test::Encoder<nimble::TrivialEncoding<std::string_view>>::encode(
+          *buffer_, values);
+
+  const auto sliced = slice(encoded, /*offset=*/1, /*length=*/2);
+  EXPECT_NE(sliced.data(), encoded.data());
+
+  EXPECT_NE(sliced.find("beta"), std::string_view::npos);
+  EXPECT_NE(sliced.find("gamma"), std::string_view::npos);
+  EXPECT_EQ(sliced.find("alpha"), std::string_view::npos);
+  EXPECT_EQ(sliced.find("delta"), std::string_view::npos);
+
+  auto encoding = createEncoding(sliced);
+
+  EXPECT_EQ(encoding->encodingType(), nimble::EncodingType::Trivial);
+  EXPECT_EQ(encoding->dataType(), nimble::DataType::String);
+  EXPECT_EQ(encoding->rowCount(), 2);
+
+  nimble::Vector<std::string_view> output{pool_.get(), 2};
+  encoding->materialize(2, output.data());
+
+  const std::vector<std::string_view> expected{"beta", "gamma"};
+  EXPECT_EQ(
+      std::vector<std::string_view>(output.begin(), output.end()), expected);
+}
+
+TEST_F(SliceEncodingTest, materializesBoolBits) {
+  const auto values = makeVector<bool>({true, false, true, true, false});
+  const auto encoded =
+      nimble::test::Encoder<nimble::TrivialEncoding<bool>>::encode(
+          *buffer_, values);
+
+  const auto sliced = slice(encoded, /*offset=*/1, /*length=*/3);
+  EXPECT_NE(sliced.data(), encoded.data());
+
+  auto encoding = createEncoding(sliced);
+
+  EXPECT_EQ(encoding->encodingType(), nimble::EncodingType::Trivial);
+  EXPECT_EQ(encoding->dataType(), nimble::DataType::Bool);
+  EXPECT_EQ(encoding->rowCount(), 3);
+
+  uint64_t bits{0};
+  encoding->materializeBoolsAsBits(/*rowCount=*/3, &bits, /*begin=*/0);
+
+  EXPECT_FALSE(velox::bits::isBitSet(&bits, 0));
+  EXPECT_TRUE(velox::bits::isBitSet(&bits, 1));
+  EXPECT_TRUE(velox::bits::isBitSet(&bits, 2));
+}
+
+TEST_F(SliceEncodingTest, materializesConstantRangeWithoutWrapper) {
+  const auto values = makeVector<int32_t>({7, 7, 7, 7, 7});
+  const auto encoded =
+      nimble::test::Encoder<nimble::ConstantEncoding<int32_t>>::encode(
+          *buffer_, values);
+
+  const auto sliced = slice(encoded, /*offset=*/2, /*length=*/2);
+  EXPECT_NE(sliced.data(), encoded.data());
+
+  auto encoding = createEncoding(sliced);
+
+  EXPECT_EQ(encoding->encodingType(), nimble::EncodingType::Constant);
+  EXPECT_EQ(encoding->dataType(), nimble::DataType::Int32);
+  EXPECT_EQ(encoding->rowCount(), 2);
+
+  nimble::Vector<int32_t> output{pool_.get(), 2};
+  encoding->materialize(2, output.data());
+
+  const std::vector<int32_t> expected{7, 7};
+  EXPECT_EQ(std::vector<int32_t>(output.begin(), output.end()), expected);
+}
+
+TEST_F(SliceEncodingTest, materializesRleRangeWithoutWrapper) {
+  const auto values = makeVector<int32_t>({10, 10, 11, 11, 11, 12, 12});
+  const auto encoded =
+      nimble::test::Encoder<nimble::RLEEncoding<int32_t>>::encode(
+          *buffer_, values);
+
+  const auto sliced = slice(encoded, /*offset=*/1, /*length=*/5);
+  EXPECT_NE(sliced.data(), encoded.data());
+
+  auto encoding = createEncoding(sliced);
+
+  EXPECT_EQ(encoding->encodingType(), nimble::EncodingType::RLE);
+  EXPECT_EQ(encoding->dataType(), nimble::DataType::Int32);
+  EXPECT_EQ(encoding->rowCount(), 5);
+
+  nimble::Vector<int32_t> output{pool_.get(), 5};
+  encoding->materialize(5, output.data());
+
+  const std::vector<int32_t> expected{10, 11, 11, 11, 12};
+  EXPECT_EQ(std::vector<int32_t>(output.begin(), output.end()), expected);
+}
+
+TEST_F(SliceEncodingTest, materializesRleBoolRangeWithoutWrapper) {
+  const auto values = makeVector<bool>({false, false, true, true, true, false});
+  const auto encoded = nimble::test::Encoder<nimble::RLEEncoding<bool>>::encode(
+      *buffer_, values);
+
+  const auto sliced = slice(encoded, /*offset=*/2, /*length=*/3);
+  EXPECT_NE(sliced.data(), encoded.data());
+
+  auto encoding = createEncoding(sliced);
+
+  EXPECT_EQ(encoding->encodingType(), nimble::EncodingType::RLE);
+  EXPECT_EQ(encoding->dataType(), nimble::DataType::Bool);
+  EXPECT_EQ(encoding->rowCount(), 3);
+
+  uint64_t bits{0};
+  encoding->materializeBoolsAsBits(/*rowCount=*/3, &bits, /*begin=*/0);
+
+  EXPECT_TRUE(velox::bits::isBitSet(&bits, 0));
+  EXPECT_TRUE(velox::bits::isBitSet(&bits, 1));
+  EXPECT_TRUE(velox::bits::isBitSet(&bits, 2));
+}
+
+TEST_F(SliceEncodingTest, materializesFixedBitWidthRangeWithoutWrapper) {
+  const auto values = makeVector<int32_t>({10, 11, 12, 13, 14});
+  const auto encoded =
+      nimble::test::Encoder<nimble::FixedBitWidthEncoding<int32_t>>::encode(
+          *buffer_, values);
+
+  const auto sliced = slice(encoded, /*offset=*/1, /*length=*/3);
+  EXPECT_NE(sliced.data(), encoded.data());
+
+  auto encoding = createEncoding(sliced);
+
+  EXPECT_EQ(encoding->encodingType(), nimble::EncodingType::FixedBitWidth);
+  EXPECT_EQ(encoding->dataType(), nimble::DataType::Int32);
+  EXPECT_EQ(encoding->rowCount(), 3);
+
+  nimble::Vector<int32_t> output{pool_.get(), 3};
+  encoding->materialize(3, output.data());
+
+  const std::vector<int32_t> expected{11, 12, 13};
+  EXPECT_EQ(std::vector<int32_t>(output.begin(), output.end()), expected);
+}
+
+TEST_F(SliceEncodingTest, materializesCompressedTrivialRangeWithoutWrapper) {
+  nimble::Vector<uint32_t> values{pool_.get()};
+  values.resize(1024);
+  std::fill(values.begin(), values.end(), 42);
+  const auto encoded =
+      nimble::test::Encoder<nimble::TrivialEncoding<uint32_t>>::encode(
+          *buffer_, values, nimble::CompressionType::Zstd);
+
+  const auto sliced = slice(encoded, /*offset=*/128, /*length=*/3);
+  EXPECT_NE(sliced.data(), encoded.data());
+
+  auto encoding = createEncoding(sliced);
+
+  EXPECT_EQ(encoding->encodingType(), nimble::EncodingType::Trivial);
+  EXPECT_EQ(encoding->dataType(), nimble::DataType::Uint32);
+  EXPECT_EQ(encoding->rowCount(), 3);
+
+  nimble::Vector<uint32_t> output{pool_.get(), 3};
+  encoding->materialize(3, output.data());
+
+  const std::vector<uint32_t> expected{42, 42, 42};
+  EXPECT_EQ(std::vector<uint32_t>(output.begin(), output.end()), expected);
+}
+
+TEST_F(SliceEncodingTest, materializesNativeSliceForBoolEncoding) {
+  expectBoolSliceMaterializes<nimble::SparseBoolEncoding>(
+      "SparseBool",
+      nimble::EncodingType::SparseBool,
+      makeVector<bool>({false, true, false, false, true, false}),
+      /*offset=*/1,
+      /*length=*/3);
+}
+
+TEST_F(SliceEncodingTest, materializesNativeSliceForNullableEncoding) {
+  const auto values = makeVector<uint32_t>({10, 11, 12, 13, 14, 15});
+  const auto nulls = makeVector<bool>({true, true, true, true, true, true});
+  const auto encoded =
+      nimble::test::Encoder<nimble::NullableEncoding<uint32_t>>::encodeNullable(
+          *buffer_, values, nulls);
+
+  const auto sliced = slice(encoded, /*offset=*/2, /*length=*/3);
+  EXPECT_NE(sliced.data(), encoded.data());
+
+  auto encoding = createEncoding(sliced);
+
+  EXPECT_EQ(encoding->encodingType(), nimble::EncodingType::Nullable);
+  EXPECT_EQ(encoding->dataType(), nimble::DataType::Uint32);
+  EXPECT_EQ(encoding->rowCount(), 3);
+
+  nimble::Vector<uint32_t> output{pool_.get(), 3};
+  encoding->materialize(3, output.data());
+
+  const std::vector<uint32_t> expected{12, 13, 14};
+  EXPECT_EQ(std::vector<uint32_t>(output.begin(), output.end()), expected);
+}
+
+TEST_F(SliceEncodingTest, rejectsOutOfRangeSlice) {
+  const auto values = makeVector<int32_t>({10, 11, 12});
+  const auto encoded =
+      nimble::test::Encoder<nimble::TrivialEncoding<int32_t>>::encode(
+          *buffer_, values);
+
+  NIMBLE_ASSERT_THROW(slice(encoded, /*offset=*/2, /*length=*/2), "");
+}

--- a/dwio/nimble/encodings/tests/SparseBoolEncodingTest.cpp
+++ b/dwio/nimble/encodings/tests/SparseBoolEncodingTest.cpp
@@ -19,6 +19,7 @@
 #include "dwio/nimble/common/Buffer.h"
 #include "dwio/nimble/common/Types.h"
 #include "dwio/nimble/common/Vector.h"
+#include "dwio/nimble/common/tests/GTestUtils.h"
 #include "dwio/nimble/encodings/common/EncodingType.h"
 #include "dwio/nimble/encodings/tests/TestUtils.h"
 #include "folly/Random.h"
@@ -244,6 +245,93 @@ TYPED_TEST(SparseBoolEncodingTest, skipThenMaterialize) {
   for (uint32_t i = 0; i < 4; ++i) {
     EXPECT_EQ(result[i], values[i + 3]) << "index " << i;
   }
+}
+
+TYPED_TEST(SparseBoolEncodingTest, slice) {
+  const nimble::Encoding::Options options{
+      .useVarintRowCount = TypeParam::useVarint};
+  for (const auto values :
+       {this->toVector(
+            {false,
+             false,
+             true,
+             false,
+             true,
+             false,
+             false,
+             true,
+             false,
+             false}),
+        this->toVector(
+            {true, true, false, true, false, true, true, false, true, true})}) {
+    const auto encoded =
+        nimble::test::Encoder<nimble::SparseBoolEncoding>::encode(
+            *this->buffer_,
+            values,
+            nimble::CompressionType::Uncompressed,
+            options);
+
+    struct Range {
+      uint32_t offset;
+      uint32_t length;
+    };
+    for (const auto range :
+         {Range{/*offset=*/0, /*length=*/4},
+          Range{/*offset=*/2, /*length=*/6},
+          Range{/*offset=*/7, /*length=*/3}}) {
+      SCOPED_TRACE(
+          testing::Message()
+          << "offset=" << range.offset << ", length=" << range.length);
+      nimble::Buffer sliceBuffer{*this->pool_};
+      const auto sliced = nimble::SparseBoolEncoding::slice(
+          encoded, range.offset, range.length, sliceBuffer, options);
+      nimble::SparseBoolEncoding encoding{
+          *this->pool_,
+          sliced,
+          [](uint32_t /*totalLength*/) -> void* { return nullptr; },
+          options};
+
+      EXPECT_EQ(encoding.encodingType(), nimble::EncodingType::SparseBool);
+      EXPECT_EQ(encoding.dataType(), nimble::DataType::Bool);
+      EXPECT_EQ(encoding.rowCount(), range.length);
+      nimble::Vector<bool> result(this->pool_.get(), range.length);
+      encoding.materialize(range.length, result.data());
+      for (uint32_t i = 0; i < range.length; ++i) {
+        EXPECT_EQ(result[i], values[range.offset + i]) << "index " << i;
+      }
+    }
+  }
+}
+
+TYPED_TEST(SparseBoolEncodingTest, invalidSliceRange) {
+  const nimble::Encoding::Options options{
+      .useVarintRowCount = TypeParam::useVarint};
+  auto values = this->toVector(
+      {false, false, true, false, true, false, false, true, false, false});
+  const auto encoded =
+      nimble::test::Encoder<nimble::SparseBoolEncoding>::encode(
+          *this->buffer_,
+          values,
+          nimble::CompressionType::Uncompressed,
+          options);
+
+  nimble::Buffer invalidSliceBuffer{*this->pool_};
+  NIMBLE_ASSERT_THROW(
+      nimble::SparseBoolEncoding::slice(
+          encoded,
+          /*offset=*/11,
+          /*length=*/0,
+          invalidSliceBuffer,
+          options),
+      "");
+  NIMBLE_ASSERT_THROW(
+      nimble::SparseBoolEncoding::slice(
+          encoded,
+          /*offset=*/9,
+          /*length=*/2,
+          invalidSliceBuffer,
+          options),
+      "");
 }
 
 TYPED_TEST(SparseBoolEncodingTest, resetAndRematerialize) {

--- a/dwio/nimble/encodings/tests/TrivialEncodingTest.cpp
+++ b/dwio/nimble/encodings/tests/TrivialEncodingTest.cpp
@@ -14,11 +14,20 @@
  * limitations under the License.
  */
 #include "dwio/nimble/encodings/TrivialEncoding.h"
+#include <string>
+#include <type_traits>
+#include <vector>
+
 #include <glog/logging.h>
 #include <gtest/gtest.h>
+
 #include "dwio/nimble/common/Buffer.h"
 #include "dwio/nimble/common/Exceptions.h"
 #include "dwio/nimble/common/Vector.h"
+#include "dwio/nimble/common/tests/GTestUtils.h"
+#include "dwio/nimble/encodings/common/EncodingFactory.h"
+#include "dwio/nimble/encodings/common/EncodingPrefix.h"
+#include "dwio/nimble/encodings/common/EncodingPrimitives.h"
 #include "dwio/nimble/encodings/tests/TestUtils.h"
 #include "velox/common/memory/Memory.h"
 
@@ -26,6 +35,12 @@ using namespace facebook;
 
 class TrivialEncodingTest : public ::testing::Test {
  protected:
+  struct Range {
+    const char* name;
+    uint32_t offset;
+    uint32_t length;
+  };
+
   static void SetUpTestCase() {
     velox::memory::MemoryManager::testingSetInstance({});
   }
@@ -42,6 +57,22 @@ class TrivialEncodingTest : public ::testing::Test {
     nimble::Vector<std::string_view> result{pool_.get()};
     result.insert(result.end(), values.begin(), values.end());
     return result;
+  }
+
+  template <typename T>
+  nimble::Vector<T> makeVector(std::initializer_list<T> values) {
+    nimble::Vector<T> result{pool_.get()};
+    result.insert(result.end(), values.begin(), values.end());
+    return result;
+  }
+
+  nimble::CompressionType compressionType(
+      std::string_view encoded,
+      const nimble::Encoding::Options& options = {}) {
+    const char* pos = encoded.data() +
+        nimble::EncodingPrefix::prefixSize(encoded, options.useVarintRowCount);
+    return static_cast<nimble::CompressionType>(
+        nimble::encoding::readChar(pos));
   }
 
   std::unique_ptr<nimble::Encoding> createEncoding(
@@ -62,8 +93,138 @@ class TrivialEncodingTest : public ::testing::Test {
             options);
   }
 
+  std::function<void*(uint32_t)> stringBufferFactory() {
+    return [&](uint32_t totalLength) -> void* {
+      auto& buffer = stringBuffers_.emplace_back(
+          velox::AlignedBuffer::allocate<char>(totalLength, pool_.get()));
+      return buffer->asMutable<void>();
+    };
+  }
+
+  static std::vector<Range> ranges(uint32_t valueCount) {
+    return {
+        Range{/*name=*/"full", /*offset=*/0, /*length=*/valueCount},
+        Range{/*name=*/"prefix", /*offset=*/0, /*length=*/128},
+        Range{/*name=*/"middle", /*offset=*/2047, /*length=*/257},
+        Range{/*name=*/"suffix",
+              /*offset=*/valueCount - 128,
+              /*length=*/128},
+        Range{/*name=*/"singleStart", /*offset=*/0, /*length=*/1},
+        Range{/*name=*/"singleMiddle", /*offset=*/2048, /*length=*/1},
+        Range{/*name=*/"singleEnd",
+              /*offset=*/valueCount - 1,
+              /*length=*/1},
+        Range{/*name=*/"emptyStart", /*offset=*/0, /*length=*/0},
+        Range{/*name=*/"emptyMiddle", /*offset=*/2048, /*length=*/0},
+        Range{/*name=*/"emptyEnd", /*offset=*/valueCount, /*length=*/0},
+    };
+  }
+
+  template <typename T>
+  nimble::Vector<T> makeRepeatedValues(uint32_t valueCount) {
+    nimble::Vector<T> values{pool_.get(), valueCount};
+    for (uint32_t i = 0; i < valueCount; ++i) {
+      values[i] = static_cast<T>(10 + (i % 4));
+    }
+    return values;
+  }
+
+  nimble::Vector<bool> makeBoolValues(uint32_t valueCount) {
+    nimble::Vector<bool> values{pool_.get(), valueCount};
+    for (uint32_t i = 0; i < valueCount; ++i) {
+      values[i] = (i % 4) == 0;
+    }
+    return values;
+  }
+
+  nimble::Vector<std::string_view> makeStringValues(
+      std::vector<std::string>& storage,
+      uint32_t valueCount) {
+    storage.reserve(valueCount);
+    nimble::Vector<std::string_view> values{pool_.get(), valueCount};
+    for (uint32_t i = 0; i < valueCount; ++i) {
+      storage.push_back(std::string{"value-"} + std::to_string(i % 4));
+      values[i] = storage.back();
+    }
+    return values;
+  }
+
+  template <typename T>
+  void expectSliceRanges(
+      const nimble::Vector<T>& values,
+      nimble::DataType dataType) {
+    const auto valueCount = static_cast<uint32_t>(values.size());
+    for (const auto sourceCompression :
+         {nimble::CompressionType::Uncompressed,
+          nimble::CompressionType::Zstd}) {
+      SCOPED_TRACE(
+          ::testing::Message()
+          << "sourceCompression=" << static_cast<int>(sourceCompression));
+      const auto encoded =
+          nimble::test::Encoder<nimble::TrivialEncoding<T>>::encode(
+              *buffer_, values, sourceCompression);
+      EXPECT_EQ(compressionType(encoded), sourceCompression);
+
+      for (const auto range : ranges(valueCount)) {
+        SCOPED_TRACE(
+            ::testing::Message()
+            << "range=" << range.name << ", offset=" << range.offset
+            << ", length=" << range.length);
+        const auto sliced = nimble::TrivialEncoding<T>::slice(
+            encoded,
+            range.offset,
+            range.length,
+            *buffer_,
+            nimble::Encoding::Options{});
+        EXPECT_NE(sliced.data(), encoded.data());
+        EXPECT_EQ(
+            compressionType(sliced), nimble::CompressionType::Uncompressed);
+
+        stringBuffers_.clear();
+        auto encoding = nimble::EncodingFactory{}.create(
+            *pool_, sliced, stringBufferFactory());
+        EXPECT_EQ(encoding->encodingType(), nimble::EncodingType::Trivial);
+        EXPECT_EQ(encoding->dataType(), dataType);
+        EXPECT_EQ(encoding->rowCount(), range.length);
+
+        nimble::Vector<T> output{pool_.get(), range.length};
+        encoding->materialize(range.length, output.data());
+
+        const std::vector<T> expected(
+            values.begin() + range.offset,
+            values.begin() + range.offset + range.length);
+        EXPECT_EQ(std::vector<T>(output.begin(), output.end()), expected);
+      }
+    }
+  }
+
   std::shared_ptr<velox::memory::MemoryPool> rootPool_;
   std::shared_ptr<velox::memory::MemoryPool> pool_;
   std::unique_ptr<nimble::Buffer> buffer_;
   std::vector<velox::BufferPtr> stringBuffers_;
 };
+
+TEST_F(TrivialEncodingTest, sliceRangesForSupportedTypes) {
+  constexpr uint32_t valueCount{4096};
+  expectSliceRanges<int8_t>(
+      makeRepeatedValues<int8_t>(valueCount), nimble::DataType::Int8);
+  expectSliceRanges<uint8_t>(
+      makeRepeatedValues<uint8_t>(valueCount), nimble::DataType::Uint8);
+  expectSliceRanges<int16_t>(
+      makeRepeatedValues<int16_t>(valueCount), nimble::DataType::Int16);
+  expectSliceRanges<uint16_t>(
+      makeRepeatedValues<uint16_t>(valueCount), nimble::DataType::Uint16);
+  expectSliceRanges<int32_t>(
+      makeRepeatedValues<int32_t>(valueCount), nimble::DataType::Int32);
+  expectSliceRanges<uint32_t>(
+      makeRepeatedValues<uint32_t>(valueCount), nimble::DataType::Uint32);
+  expectSliceRanges<int64_t>(
+      makeRepeatedValues<int64_t>(valueCount), nimble::DataType::Int64);
+  expectSliceRanges<uint64_t>(
+      makeRepeatedValues<uint64_t>(valueCount), nimble::DataType::Uint64);
+  expectSliceRanges<bool>(makeBoolValues(valueCount), nimble::DataType::Bool);
+
+  std::vector<std::string> stringStorage;
+  expectSliceRanges<std::string_view>(
+      makeStringValues(stringStorage, valueCount), nimble::DataType::String);
+}

--- a/dwio/nimble/encodings/views/EncodingView.h
+++ b/dwio/nimble/encodings/views/EncodingView.h
@@ -69,7 +69,7 @@ class EncodingView {
         rowCount_{
             EncodingPrefix::readRowCount(data, options.useVarintRowCount)},
         dataOffset_{
-            EncodingPrefix::readPrefixSize(data, options.useVarintRowCount)} {
+            EncodingPrefix::prefixSize(data, options.useVarintRowCount)} {
     NIMBLE_CHECK_NOT_NULL(pool_);
   }
 

--- a/dwio/nimble/encodings/views/EncodingViewFactory.cpp
+++ b/dwio/nimble/encodings/views/EncodingViewFactory.cpp
@@ -159,7 +159,7 @@ std::unique_ptr<EncodingView> createEncodingView(
     std::string_view data,
     velox::memory::MemoryPool* pool,
     const Encoding::Options& options) {
-  const auto dataType = EncodingPrefix::readDataType(data);
+  const auto dataType = EncodingPrefix::dataType(data);
   switch (dataType) {
     case DataType::Int8:
       return detail::createTypedEncodingView<int8_t>(data, pool, options);

--- a/dwio/nimble/encodings/views/MainlyConstantEncodingView.h
+++ b/dwio/nimble/encodings/views/MainlyConstantEncodingView.h
@@ -40,8 +40,8 @@ class MainlyConstantEncodingView final : public TypedEncodingView<T> {
     const char* pos = data.data() + this->dataOffset_;
     const auto isCommonSize = encoding::readUint32(pos);
     auto noStringBufferFactory = [](uint32_t) -> void* { return nullptr; };
-    auto isCommon = EncodingFactory{}.create(
-        *this->pool_, {pos, isCommonSize}, noStringBufferFactory, options);
+    auto isCommon = EncodingFactory{options}.create(
+        *this->pool_, {pos, isCommonSize}, noStringBufferFactory);
     NIMBLE_CHECK_NOT_NULL(isCommon);
     isCommon_.resize(this->rowCount_);
     isCommon->materialize(this->rowCount_, isCommon_.data());


### PR DESCRIPTION
Summary: Add `EncodingFactory::slice` to produce an encoded buffer for a row range. It writes native subset buffers for `Constant` and uncompressed fixed-width/bool `Trivial` encodings, and falls back to `SliceEncoding` for unsupported layouts without decoding or re-encoding row values.

Differential Revision: D113206722
