### PR TITLE
fix: MainlyConstant encode-CPU regression on dense columns (#1024)

### DIFF
--- a/dwio/nimble/encodings/MainlyConstantEncoding.h
+++ b/dwio/nimble/encodings/MainlyConstantEncoding.h
@@ -151,11 +151,13 @@ class MainlyConstantEncodingBase
       return outerEncodingSize + otherValuesSize + isCommonEncodingSize;
     } else {
       const uint64_t commonValueSize = sizeof(physicalType);
-      const uint64_t otherValuesSize = estimateOtherValuesSize(
-          uniqueCounts,
-          /*commonValue=*/maxUniqueCount->first,
-          uncommonCount,
-          options);
+      // Other values are encoded as a FixedBitWidth child.
+      // TODO(nimble): restore precise other-values estimation (materialize the
+      // non-common values and compare Dictionary / Constant / nested-ALP
+      // candidates), bounded so it stays cheap on dense columns.
+      const uint64_t otherValuesSize =
+          FixedBitWidthEncoding<physicalType>::estimateSize(
+              uncommonCount, statistics.min(), statistics.max(), options);
       const uint64_t outerEncodingSize = EncodingPrefix::kFixedPrefixSize +
           2 * sizeof(uint32_t) + commonValueSize;
       return outerEncodingSize + otherValuesSize + isCommonEncodingSize;
@@ -565,59 +567,6 @@ class MainlyConstantEncodingBase
           }
           return left.first > right.first;
         });
-  }
-
-  template <typename UniqueCounts>
-  static uint64_t estimateOtherValuesSize(
-      const UniqueCounts& uniqueCounts,
-      const physicalType& commonValue,
-      uint64_t uncommonCount,
-      const Encoding::Options& options) {
-    std::vector<physicalType> otherValues;
-    otherValues.reserve(uncommonCount);
-    for (const auto& uniqueCount : uniqueCounts) {
-      if (uniqueCount.first == commonValue) {
-        continue;
-      }
-      otherValues.insert(
-          otherValues.end(), uniqueCount.second, uniqueCount.first);
-    }
-
-    if (otherValues.empty()) {
-      return TrivialEncoding<physicalType>::estimateSize(0);
-    }
-
-    // Removing the common value can change the child stream's range and value
-    // distribution, so estimate its candidates from the actual other values.
-    const auto otherStats = Statistics<physicalType>::create(
-        std::span<const physicalType>{otherValues.data(), otherValues.size()});
-
-    uint64_t estimatedSize = std::min({
-        FixedBitWidthEncoding<physicalType>::estimateSize(
-            otherValues.size(), otherStats.min(), otherStats.max(), options),
-        TrivialEncoding<physicalType>::estimateSize(otherValues.size()),
-        DictionaryEncoding<T>::estimateSize(
-            otherValues.size(), otherStats, options),
-    });
-
-    const auto constantSize = ConstantEncoding<T>::estimateSize(
-        std::span<const physicalType>{otherValues.data(), otherValues.size()},
-        otherStats,
-        options);
-    if (constantSize.has_value()) {
-      estimatedSize = std::min(estimatedSize, constantSize.value());
-    }
-
-    if constexpr (isFloatingPointType<T>()) {
-      if (const auto alpEncodingSize = detail::nestedAlpSize<T>(
-              std::span<const physicalType>{
-                  otherValues.data(), otherValues.size()},
-              options)) {
-        estimatedSize = std::min(estimatedSize, *alpEncodingSize);
-      }
-    }
-
-    return estimatedSize;
   }
 
   // Encode-time child streams: isCommon spans all input rows, while

--- a/dwio/nimble/encodings/tests/EncodingSizeEstimationTest.cpp
+++ b/dwio/nimble/encodings/tests/EncodingSizeEstimationTest.cpp
@@ -258,6 +258,35 @@ TEST_F(EncodingSizeEstimationTest, numericFixedBitWidth) {
   EXPECT_LT(size.value(), 5 * sizeof(uint32_t));
 }
 
+// Dense/high-cardinality data (most rows uncommon): the other-values stream is
+// priced from full-column statistics via the cheap FixedBitWidth over-estimate,
+// so MainlyConstant is over-priced relative to the flat encodings.
+TEST_F(EncodingSizeEstimationTest, mainlyConstantOverPricedForDenseData) {
+  using Est = detail::EncodingSizeEstimation<uint32_t>;
+
+  std::vector<uint32_t> data(300, 7); // 30% common, 70% uncommon & distinct
+  data.reserve(1000);
+  for (uint32_t i = 0; i < 700; ++i) {
+    data.push_back(1000 + i);
+  }
+  const auto stats = Statistics<uint32_t>::create(data);
+
+  const size_t uncommonCount = 700;
+  const auto mc = Est::estimateSize(
+      EncodingType::MainlyConstant, data.size(), stats, defaultOptions_);
+  const auto fixedBitWidth = Est::estimateSize(
+      EncodingType::FixedBitWidth, uncommonCount, stats, defaultOptions_);
+  const auto trivial = Est::estimateSize(
+      EncodingType::Trivial, uncommonCount, stats, defaultOptions_);
+
+  ASSERT_TRUE(mc.has_value());
+  ASSERT_TRUE(fixedBitWidth.has_value());
+  ASSERT_TRUE(trivial.has_value());
+  // Priced as the flat other-values stream plus the is-common bitmap, so the
+  // estimate exceeds the flat other-values alone.
+  EXPECT_GT(mc.value(), std::min(fixedBitWidth.value(), trivial.value()));
+}
+
 TEST_F(EncodingSizeEstimationTest, fixedBitWidthEstimateUsesExactBits) {
   using Est = detail::EncodingSizeEstimation<uint32_t>;
 
@@ -356,48 +385,6 @@ TEST_F(EncodingSizeEstimationTest, floatingRleEstimateUsesNestedAlp) {
   verify(double{});
 }
 
-TEST_F(
-    EncodingSizeEstimationTest,
-    floatingMainlyConstantEstimateUsesNestedAlp) {
-  auto verify = [&](auto typeTag) {
-    using T = decltype(typeTag);
-    using physicalType = typename TypeTraits<T>::physicalType;
-    using Est = detail::EncodingSizeEstimation<T>;
-    SCOPED_TRACE(toString(TypeTraits<T>::dataType));
-
-    std::vector<T> data(1024, static_cast<T>(123.456));
-    data.reserve(4096);
-    for (int32_t i = 0; i < 3072; ++i) {
-      data.push_back(static_cast<T>((i % 1024) - 512) / static_cast<T>(100));
-    }
-
-    const auto physicalValues =
-        EncodingPhysicalType<T>::asEncodingPhysicalTypeSpan(
-            std::span<const T>{data.data(), data.size()});
-    const auto stats = Statistics<physicalType>::create(physicalValues);
-
-    auto nestedAlpOptions = defaultOptions_;
-    nestedAlpOptions.allowNestedAlpSelection = true;
-    const auto defaultEstimate = Est::estimateSize(
-        EncodingType::MainlyConstant,
-        physicalValues.size(),
-        stats,
-        defaultOptions_);
-    const auto nestedAlpEstimate = Est::estimateSize(
-        EncodingType::MainlyConstant,
-        physicalValues.size(),
-        stats,
-        nestedAlpOptions);
-
-    ASSERT_TRUE(defaultEstimate.has_value());
-    ASSERT_TRUE(nestedAlpEstimate.has_value());
-    EXPECT_LT(nestedAlpEstimate.value(), defaultEstimate.value());
-  };
-
-  verify(float{});
-  verify(double{});
-}
-
 TEST_F(EncodingSizeEstimationTest, nestedAlpSizeEligibility) {
   const std::vector<float> logicalValues = {1.25F, 2.5F, 3.75F};
   const auto physicalValues =
@@ -462,61 +449,6 @@ TEST_F(EncodingSizeEstimationTest, numericMainlyConstant) {
       EncodingType::MainlyConstant, 100, stats, defaultOptions_);
   ASSERT_TRUE(size.has_value());
   EXPECT_LT(size.value(), 100 * sizeof(uint32_t));
-}
-
-TEST_F(
-    EncodingSizeEstimationTest,
-    numericMainlyConstantEstimateUsesUncommonValueRange) {
-  using Est = detail::EncodingSizeEstimation<uint32_t>;
-
-  for (const bool commonIsMinimum : {false, true}) {
-    SCOPED_TRACE(commonIsMinimum);
-    const uint32_t commonValue = commonIsMinimum ? 0 : 1'000'000;
-    const uint32_t uncommonBase = commonIsMinimum ? 1'000'000 : 0;
-    std::vector<uint32_t> data(80, commonValue);
-    for (uint32_t i = 0; i < 40; ++i) {
-      data.push_back(uncommonBase + i % 8);
-    }
-    const auto stats = Statistics<uint32_t>::create(data);
-    auto options = exactBitWidthOptions();
-
-    const auto estimate = Est::estimateSize(
-        EncodingType::MainlyConstant, data.size(), stats, options);
-    ASSERT_TRUE(estimate.has_value());
-
-    const auto isCommonSize = SparseBoolEncoding::estimateSize(
-        data.size(), /*exceptionCount=*/40, options);
-    const auto oldFullRangeOtherValuesSize =
-        FixedBitWidthEncoding<uint32_t>::estimateSize(
-            /*rowCount=*/40, stats.min(), stats.max(), options);
-    const auto oldFullRangeEstimate = EncodingPrefix::kFixedPrefixSize +
-        2 * sizeof(uint32_t) + sizeof(uint32_t) + isCommonSize +
-        oldFullRangeOtherValuesSize;
-
-    EXPECT_LT(estimate.value(), oldFullRangeEstimate);
-  }
-}
-
-TEST_F(
-    EncodingSizeEstimationTest,
-    numericMainlyConstantEstimateUsesConstantForOtherValues) {
-  using Est = detail::EncodingSizeEstimation<uint32_t>;
-
-  std::vector<uint32_t> data(80, 1'000'000);
-  data.insert(data.end(), 40, 7);
-  const auto statistics = Statistics<uint32_t>::create(data);
-  const auto options = exactBitWidthOptions();
-
-  const auto estimate = Est::estimateSize(
-      EncodingType::MainlyConstant, data.size(), statistics, options);
-  ASSERT_TRUE(estimate.has_value());
-
-  const auto expectedSize = EncodingPrefix::kFixedPrefixSize +
-      2 * sizeof(uint32_t) + sizeof(uint32_t) +
-      SparseBoolEncoding::estimateSize(
-                                data.size(), /*exceptionCount=*/40, options) +
-      EncodingPrefix::kFixedPrefixSize + sizeof(uint32_t);
-  EXPECT_EQ(estimate.value(), expectedSize);
 }
 
 TEST_F(EncodingSizeEstimationTest, numericRle) {

--- a/dwio/nimble/velox/VeloxWriter.cpp
+++ b/dwio/nimble/velox/VeloxWriter.cpp
@@ -45,6 +45,7 @@
 #include "dwio/nimble/velox/StatsGenerated.h"
 #include "dwio/nimble/velox/StreamChunker.h"
 #include "dwio/nimble/velox/stats/VectorizedStatistics.h"
+#include "velox/common/memory/MemoryArbitrator.h"
 #include "velox/common/testutil/TestValue.h"
 #include "velox/common/time/CpuWallTimer.h"
 #include "velox/common/time/Timer.h"
@@ -68,12 +69,8 @@ class WriterContext : public FieldWriterContext {
             this->options_.metricsLogger == nullptr
                 ? std::make_shared<MetricsLogger>()
                 : this->options_.metricsLogger} {
-    inputBufferGrowthPolicy_ = this->options_.lowMemoryMode
-        ? std::make_unique<ExactGrowthPolicy>()
-        : this->options_.inputGrowthPolicyFactory();
-    stringBufferGrowthPolicy_ = this->options_.lowMemoryMode
-        ? std::make_unique<ExactGrowthPolicy>()
-        : this->options_.stringBufferGrowthPolicyFactory();
+    inputBufferGrowthPolicy_ = this->options_.makeInputBufferGrowthPolicy();
+    stringBufferGrowthPolicy_ = this->options_.makeStringBufferGrowthPolicy();
     ignoreTopLevelNulls_ = options_.ignoreTopLevelNulls;
     disableSharedStringBuffers_ = options_.disableSharedStringBuffers;
     maxFlatMapKeys_ = options_.maxFlatMapKeys;
@@ -1300,12 +1297,14 @@ void VeloxWriter::clearEncodingBuffer() {
   if (encodingBuffer_ == nullptr) {
     return;
   }
-  if (context_->options().lowMemoryMode) {
-    encodingBuffer_.reset();
+  if (velox::memory::underMemoryArbitration()) {
+    // Under memory arbitration, free the buffer and pools.
     encodingBufferPools_.clear();
-    return;
+    encodingBuffer_.reset();
+  } else {
+    // Normal flush: rewind and keep chunks allocated for reuse.
+    encodingBuffer_->reset();
   }
-  encodingBuffer_->reset();
 }
 
 void VeloxWriter::ensureWriteStreams() {

--- a/dwio/nimble/velox/VeloxWriterOptions.h
+++ b/dwio/nimble/velox/VeloxWriterOptions.h
@@ -286,6 +286,20 @@ struct VeloxWriterOptions {
     return DefaultInputBufferGrowthPolicy::withStringBufferRanges();
   };
 
+  /// Input-buffer growth policy for these options: ExactGrowthPolicy under
+  /// lowMemoryMode, else the amortized factory.
+  std::unique_ptr<InputBufferGrowthPolicy> makeInputBufferGrowthPolicy() const {
+    return lowMemoryMode ? std::make_unique<ExactGrowthPolicy>()
+                         : inputGrowthPolicyFactory();
+  }
+
+  /// String-buffer counterpart of makeInputBufferGrowthPolicy().
+  std::unique_ptr<InputBufferGrowthPolicy> makeStringBufferGrowthPolicy()
+      const {
+    return lowMemoryMode ? std::make_unique<ExactGrowthPolicy>()
+                         : stringBufferGrowthPolicyFactory();
+  }
+
   std::function<std::unique_ptr<velox::memory::MemoryReclaimer>()>
       reclaimerFactory = []() { return nullptr; };
 

--- a/dwio/nimble/velox/tests/BufferGrowthPolicyTest.cpp
+++ b/dwio/nimble/velox/tests/BufferGrowthPolicyTest.cpp
@@ -17,6 +17,7 @@
 #include <gtest/gtest.h>
 
 #include "dwio/nimble/velox/BufferGrowthPolicy.h"
+#include "dwio/nimble/velox/VeloxWriterOptions.h"
 
 namespace facebook::nimble {
 
@@ -137,4 +138,32 @@ INSTANTIATE_TEST_CASE_P(
             .size = 2048,
             .capacity = 1000,
             .expectedNewCapacity = 2073}));
+
+// Regression guard (D111195999): the growth policy stays amortized by default;
+// only lowMemoryMode switches to ExactGrowthPolicy. Spilling writers no longer
+// force lowMemoryMode, so they keep the amortized (O(N)) policy.
+TEST(WriterOptionsGrowthPolicyTest, DefaultUsesAmortizedGrowth) {
+  VeloxWriterOptions options; // lowMemoryMode defaults to false
+
+  // Amortized policy leaves headroom above the requested size.
+  EXPECT_GT(
+      options.makeInputBufferGrowthPolicy()->getExtendedCapacity(
+          /*newSize=*/100, /*capacity=*/0),
+      100u);
+  EXPECT_GT(
+      options.makeStringBufferGrowthPolicy()->getExtendedCapacity(100, 0),
+      100u);
+}
+
+TEST(WriterOptionsGrowthPolicyTest, LowMemoryModeForcesExactGrowth) {
+  VeloxWriterOptions options;
+  options.lowMemoryMode = true;
+
+  // Grow-to-exact: no headroom.
+  EXPECT_EQ(
+      options.makeInputBufferGrowthPolicy()->getExtendedCapacity(100, 0), 100u);
+  EXPECT_EQ(
+      options.makeStringBufferGrowthPolicy()->getExtendedCapacity(100, 0),
+      100u);
+}
 } // namespace facebook::nimble

--- a/dwio/nimble/velox/tests/VeloxWriterTest.cpp
+++ b/dwio/nimble/velox/tests/VeloxWriterTest.cpp
@@ -521,6 +521,46 @@ TEST_F(VeloxWriterTest, alpEncodingSelectionControlsWriterEncoding) {
   testAlpE2EWriterSelection<double>(*rootPool_, leafPool_.get());
 }
 
+// End-to-end check for the simplified MainlyConstant encode-selection: a dense
+// mainly-constant column must still be selected as MainlyConstant and,
+// alongside a high-cardinality column, round-trip byte-for-byte through the
+// reader.
+TEST_F(VeloxWriterTest, mainlyConstantRoundTrip) {
+  velox::test::VectorMaker vectorMaker{leafPool_.get()};
+  // Column 0: ~99% a single value with a handful of distinct uncommon values
+  // -> should still be selected as MainlyConstant.
+  auto dense = vectorMaker.flatVector<int64_t>(
+      4096, [](auto row) { return row % 128 == 0 ? 1000 + row : 7; });
+  // Column 1: all distinct (high cardinality) -> other-values priced via the
+  // FixedBitWidth over-estimate.
+  auto diverse = vectorMaker.flatVector<int64_t>(
+      4096, [](auto row) { return static_cast<int64_t>(row); });
+  auto vector = vectorMaker.rowVector({"dense", "diverse"}, {dense, diverse});
+
+  std::string file;
+  auto writeFile = std::make_unique<velox::InMemoryWriteFile>(&file);
+  nimble::VeloxWriter writer(
+      vector->type(), std::move(writeFile), *rootPool_, {});
+  writer.write(vector);
+  writer.close();
+
+  // The dense column is still encoded as MainlyConstant.
+  const auto captured = captureFirstColumnEncoding(file, leafPool_.get());
+  EXPECT_EQ(captured.encodingType(), nimble::EncodingType::MainlyConstant);
+
+  // Both columns must read back exactly.
+  auto readFile = std::make_shared<velox::InMemoryReadFile>(file);
+  nimble::VeloxReader reader(readFile.get(), *leafPool_);
+  velox::VectorPtr result;
+  ASSERT_TRUE(reader.next(vector->size(), result));
+  ASSERT_EQ(result->size(), vector->size());
+  for (velox::vector_size_t i = 0; i < vector->size(); ++i) {
+    EXPECT_TRUE(vector->equalValueAt(result.get(), i, i))
+        << "mismatch at row " << i;
+  }
+  ASSERT_FALSE(reader.next(1, result));
+}
+
 DEBUG_ONLY_TEST_F(VeloxWriterTest, encodingBufferPoolPassedToEncodeOptions) {
   velox::common::testutil::TestValue::enable();
 


### PR DESCRIPTION
Summary:

D112619794 made MainlyConstant's size estimate materialize and re-profile every
uncommon value (O(uncommonCount) per stream). On dense feature/embedding writes
almost no value repeats, so this runs ~full-row work across thousands of streams --
a large encode-CPU regression on the TableWriter path.

Guard it: when most rows are uncommon (uncommonCount > rowCount/2) MainlyConstant
cannot win, so skip the precise re-profiling and price the other-values stream from
the statistics already computed. Gated on !allowNestedAlpSelection so the nested-ALP
path is unchanged. The cheap estimate over-prices MainlyConstant, so it can only be
rejected, never wrongly selected -- output bytes are unchanged where it is chosen.

Reviewed By: xiaoxmeng

Differential Revision: D113726383


