### PR TITLE
refactor: Add format-specific runtime stats API

### DIFF
--- a/dwio/nimble/encodings/tests/ReadWithVisitorTest.cpp
+++ b/dwio/nimble/encodings/tests/ReadWithVisitorTest.cpp
@@ -281,7 +281,7 @@ class ReadWithVisitorTest : public ::testing::TestWithParam<bool>,
     std::string fileData;
     std::shared_ptr<ReaderBase> readerBase;
     std::unique_ptr<StripeStreams> streams;
-    dwio::common::ColumnReaderStatistics stats;
+    dwio::common::SplitStats stats{dwio::common::FileFormat::NIMBLE};
     std::unique_ptr<RowSizeTracker> rowSizeTracker;
     EncodingFactory encodingFactory;
   };

--- a/dwio/nimble/tools/encoding_bench/EncodingBench.cpp
+++ b/dwio/nimble/tools/encoding_bench/EncodingBench.cpp
@@ -290,7 +290,7 @@ struct ReaderContext {
   std::string fileData;
   std::shared_ptr<nimble::ReaderBase> readerBase;
   std::unique_ptr<nimble::StripeStreams> streams;
-  dwio::common::ColumnReaderStatistics stats;
+  dwio::common::SplitStats stats{dwio::common::FileFormat::NIMBLE};
   std::unique_ptr<nimble::RowSizeTracker> rowSizeTracker;
   nimble::EncodingFactory encodingFactory;
   std::shared_ptr<common::ScanSpec> scanSpec;

--- a/dwio/nimble/velox/selective/NimbleData.cpp
+++ b/dwio/nimble/velox/selective/NimbleData.cpp
@@ -238,11 +238,8 @@ std::unique_ptr<ChunkedDecoder> NimbleData::makeDecoder(
 std::unique_ptr<velox::dwio::common::FormatData> NimbleParams::toFormatData(
     const std::shared_ptr<const velox::dwio::common::TypeWithId>& type,
     const velox::common::ScanSpec& /*scanSpec*/) {
-  velox::dwio::common::DecodingStats* decodingStats = nullptr;
-  if (runtimeStatistics().decodingStatsSet.has_value()) {
-    decodingStats = runtimeStatistics().decodingStatsSet->getOrCreate(
-        type->id(), type->type()->kind());
-  }
+  velox::dwio::common::DecodingStats* const decodingStats =
+      splitStats().decodingStats(type->id());
   return std::make_unique<NimbleData>(
       nimbleType_,
       *streams_,

--- a/dwio/nimble/velox/selective/NimbleData.h
+++ b/dwio/nimble/velox/selective/NimbleData.h
@@ -129,7 +129,7 @@ class NimbleParams : public velox::dwio::common::FormatParams {
  public:
   NimbleParams(
       velox::memory::MemoryPool& pool,
-      velox::dwio::common::ColumnReaderStatistics& stats,
+      velox::dwio::common::SplitStats& stats,
       const std::shared_ptr<const Type>& nimbleType,
       StripeStreams& streams,
       RowSizeTracker* rowSizeTracker,
@@ -157,7 +157,7 @@ class NimbleParams : public velox::dwio::common::FormatParams {
   NimbleParams makeChildParams(const std::shared_ptr<const Type>& type) {
     return NimbleParams(
         pool(),
-        runtimeStatistics(),
+        splitStats(),
         type,
         *streams_,
         rowSizeTracker_,

--- a/dwio/nimble/velox/selective/SelectiveNimbleIndexReader.cpp
+++ b/dwio/nimble/velox/selective/SelectiveNimbleIndexReader.cpp
@@ -499,7 +499,7 @@ void SelectiveNimbleIndexReader::initStripeColumnReader(uint32_t stripeIndex) {
     streams_.setStripe(stripeIndex);
     NimbleParams params(
         *readerBase_->pool(),
-        columnReaderStatistics_,
+        splitStats_,
         readerBase_->nimbleSchema(),
         streams_,
         options_.trackRowSize() ? rowSizeTracker_.get() : nullptr,

--- a/dwio/nimble/velox/selective/SelectiveNimbleIndexReader.h
+++ b/dwio/nimble/velox/selective/SelectiveNimbleIndexReader.h
@@ -289,7 +289,8 @@ class SelectiveNimbleIndexReader : public velox::dwio::common::IndexReader {
   std::unique_ptr<velox::serializer::KeyEncoder> keyEncoder_;
 
   std::unique_ptr<velox::dwio::common::SelectiveColumnReader> columnReader_;
-  velox::dwio::common::ColumnReaderStatistics columnReaderStatistics_;
+  velox::dwio::common::SplitStats splitStats_{
+      velox::dwio::common::FileFormat::NIMBLE};
 
   // Current lookup state.
   size_t numRequests_{0};

--- a/dwio/nimble/velox/selective/SelectiveNimbleReader.cpp
+++ b/dwio/nimble/velox/selective/SelectiveNimbleReader.cpp
@@ -137,7 +137,7 @@ class SelectiveNimbleRowReader : public dwio::common::RowReader {
         streams_(readerBase_),
         rowSizeTracker_{
             std::make_unique<RowSizeTracker>(readerBase->fileSchemaWithId())} {
-    columnReaderStatistics_.initColumnStatsCollection(
+    splitStats_.initColumnStatsCollection(
         *readerBase_->fileSchemaWithId(), options);
     initReadRange();
     initIndexBounds();
@@ -159,8 +159,7 @@ class SelectiveNimbleRowReader : public dwio::common::RowReader {
       VectorPtr& result,
       const dwio::common::Mutation* mutation) override;
 
-  void updateRuntimeStats(
-      dwio::common::RuntimeStatistics& stats) const override;
+  void updateRuntimeStats(dwio::common::RuntimeStats& stats) const override;
 
   void resetFilterCaches() override;
 
@@ -255,7 +254,7 @@ class SelectiveNimbleRowReader : public dwio::common::RowReader {
   int64_t trailingSkippedRows_{0};
 
   std::unique_ptr<dwio::common::SelectiveColumnReader> columnReader_;
-  dwio::common::ColumnReaderStatistics columnReaderStatistics_;
+  dwio::common::SplitStats splitStats_{dwio::common::FileFormat::NIMBLE};
   std::unique_ptr<RowSizeTracker> rowSizeTracker_;
 
   // Cached row size estimate derived from file-level statistics.
@@ -352,13 +351,13 @@ uint64_t SelectiveNimbleRowReader::next(
 }
 
 void SelectiveNimbleRowReader::updateRuntimeStats(
-    dwio::common::RuntimeStatistics& stats) const {
+    dwio::common::RuntimeStats& stats) const {
   stats.skippedStrides += skippedStripes_;
   const auto& tabletStats = readerBase_->tablet().stats();
   stats.footerBufferOverread += tabletStats.footerBufferOverread;
   stats.footerBufferUnderread += tabletStats.footerBufferUnderread;
   stats.footerCacheHit += tabletStats.footerCacheHit ? 1 : 0;
-  stats.columnReaderStats.mergeFrom(columnReaderStatistics_);
+  stats.mergeFrom(splitStats_);
 }
 
 void SelectiveNimbleRowReader::resetFilterCaches() {
@@ -468,7 +467,7 @@ void SelectiveNimbleRowReader::loadCurrentStripe() {
   streams_.setStripe(currentStripe_);
   NimbleParams params(
       *readerBase_->pool(),
-      columnReaderStatistics_,
+      splitStats_,
       readerBase_->nimbleSchema(),
       streams_,
       options_.trackRowSize() ? rowSizeTracker_.get() : nullptr,

--- a/dwio/nimble/velox/selective/tests/IntEncodingBenchmark.cpp
+++ b/dwio/nimble/velox/selective/tests/IntEncodingBenchmark.cpp
@@ -242,18 +242,27 @@ struct BenchmarkState : public velox::test::VectorTestBase {
 
     // Extract per-column decode and decompression stats (CPU time).
     // nodeId: root=0, c0=1, c1=2.
-    dwio::common::RuntimeStatistics stats;
+    dwio::common::RuntimeStats stats;
     readers.rowReader->updateRuntimeStats(stats);
-    ColumnStats c0Stats{};
-    ColumnStats c1Stats{};
-    if (stats.columnReaderStats.decodingStatsSet.has_value()) {
-      auto* c0m = stats.columnReaderStats.decodingStatsSet->getOrCreate(1);
-      c0Stats = {
-          c0m->decodeCPUTimeNanos.sum(), c0m->decompressCPUTimeNanos.sum()};
-      auto* c1m = stats.columnReaderStats.decodingStatsSet->getOrCreate(2);
-      c1Stats = {
-          c1m->decodeCPUTimeNanos.sum(), c1m->decompressCPUTimeNanos.sum()};
-    }
+    const auto columnDecodingStats = [&](uint32_t nodeId) -> ColumnStats {
+      const auto nodeIt = stats.columnStats.find(nodeId);
+      if (nodeIt == stats.columnStats.end()) {
+        return {};
+      }
+      const auto formatIt =
+          nodeIt->second.find(dwio::common::FileFormat::NIMBLE);
+      if (formatIt == nodeIt->second.end() ||
+          !formatIt->second.decodingStats.has_value()) {
+        return {};
+      }
+      const auto& decoding = *formatIt->second.decodingStats;
+      return {
+          decoding.decodeCPUTimeNanos.sum(),
+          decoding.decompressCPUTimeNanos.sum()};
+    };
+    // nodeId: root=0, c0=1, c1=2.
+    const ColumnStats c0Stats = columnDecodingStats(1);
+    const ColumnStats c1Stats = columnDecodingStats(2);
 
     return {
         us(t1 - t0),

--- a/dwio/nimble/velox/selective/tests/SelectiveNimbleReaderTest.cpp
+++ b/dwio/nimble/velox/selective/tests/SelectiveNimbleReaderTest.cpp
@@ -2800,11 +2800,25 @@ TEST_P(SelectiveNimbleReaderTest, columnDecodeMetrics) {
   }
   EXPECT_EQ(totalRows, numRows) << "should read all rows";
 
-  dwio::common::RuntimeStatistics stats;
+  dwio::common::RuntimeStats stats;
   rowReader->updateRuntimeStats(stats);
-  ASSERT_TRUE(stats.columnReaderStats.decodingStatsSet.has_value());
 
-  auto* col1 = stats.columnReaderStats.decodingStatsSet->getOrCreate(1);
+  const auto columnDecodingStats =
+      [&](uint32_t nodeId) -> const dwio::common::DecodingStats* {
+    const auto nodeIt = stats.columnStats.find(nodeId);
+    if (nodeIt == stats.columnStats.end()) {
+      return nullptr;
+    }
+    const auto formatIt = nodeIt->second.find(dwio::common::FileFormat::NIMBLE);
+    if (formatIt == nodeIt->second.end() ||
+        !formatIt->second.decodingStats.has_value()) {
+      return nullptr;
+    }
+    return &formatIt->second.decodingStats.value();
+  };
+
+  const auto* col1 = columnDecodingStats(1);
+  ASSERT_NE(col1, nullptr);
   EXPECT_GT(col1->decodeCPUTimeNanos.count(), 0)
       << "column 1 decode count should be > 0";
   EXPECT_GT(col1->decompressCPUTimeNanos.count(), 0)
@@ -2813,7 +2827,8 @@ TEST_P(SelectiveNimbleReaderTest, columnDecodeMetrics) {
   // (withDecompressStats / NanosecondCPUTimer), so the comparison is safe.
   EXPECT_LE(col1->decompressCPUTimeNanos.sum(), col1->decodeCPUTimeNanos.sum())
       << "decompress time should be <= decode time (it is a subset)";
-  auto* col2 = stats.columnReaderStats.decodingStatsSet->getOrCreate(2);
+  const auto* col2 = columnDecodingStats(2);
+  ASSERT_NE(col2, nullptr);
   EXPECT_GT(col2->decodeCPUTimeNanos.count(), 0)
       << "column 2 decode count should be > 0";
   EXPECT_GT(col2->decompressCPUTimeNanos.count(), 0)


### PR DESCRIPTION
Summary:
The PR introduces code refactors to allow different file formats (e.g., dwrf / parquet) to add and update their own runtime stats with their units.

Previous hard-coded format-specific stats, e.g., `flattenStringDictionaryValues` for dwrf and `pageLoadTimeNs` for parquet, are moved to the new register files `ParquetRuntimeStats.h` and `DwrfRuntimeStats.h`.

The PR also adds the infrastructure to uniformly produce format-keyed and column-keyed runtime stats. For example, users now have access to:

- `dwrf.flattenStringDictionaryValues`
   The aggregated `dwrf.flattenStringDictionaryValues` for the whole operator
- `dwrf.column_<nodeId>.<type>.flattenStringDictionaryValues`
   The column-keyed `dwrf.flattenStringDictionaryValues`

## Breaking changes:
  - `pageLoadTimeNanos` is renamed to `parquet.pageLoadTimeNanos`
  - `parqetFooterEstimatedBytes` is renamed to `parquet.footerEstimatedBytes`
  - `flattenStringDictionaryValues` is renamed to `dwrf.flattenStringDictionaryValues`
  - `column_<nodeId>.<type>.decompressCPUTimeNanos` is renamed to `dwrf.column_<nodeId>.<type>.decompressCPUTimeNanos`
  - `column_<nodeId>.<type>.decodeCPUTimeNanos` is renamed to `dwrf.column_<nodeId>.<type>.decodeCPUTimeNanos`
------
Related: https://github.com/facebookincubator/velox/pull/18063

X-link: https://github.com/facebookincubator/velox/pull/18075

Reviewed By: Yuhta

Differential Revision: D112929824

Pulled By: kKPulla


