### PR TITLE
misc: Disable missing field filter tests temporarily

### DIFF
--- a/dwio/nimble/velox/selective/tests/NullColumnReaderTest.cpp
+++ b/dwio/nimble/velox/selective/tests/NullColumnReaderTest.cpp
@@ -182,7 +182,7 @@ TEST_F(NullColumnReaderTest, filterIsNullOnMissing) {
 // Note: top-level missing field filter rejection is handled by
 // SplitReader::filterOnStats, not by the file reader. The reader materializes
 // all rows with the missing column as null constants regardless of filters.
-TEST_F(NullColumnReaderTest, filterIsNotNullOnMissing) {
+TEST_F(NullColumnReaderTest, DISABLED_filterIsNotNullOnMissing) {
   constexpr int kSize = 50;
   auto input = makeRowVector({
       makeFlatVector<int64_t>(kSize, folly::identity),
@@ -204,7 +204,7 @@ TEST_F(NullColumnReaderTest, filterIsNotNullOnMissing) {
 // BigintRange filter on a missing column.
 // Same as above: top-level missing field filter evaluation is handled by
 // SplitReader, not by the file reader.
-TEST_F(NullColumnReaderTest, filterValueOnMissing) {
+TEST_F(NullColumnReaderTest, DISABLED_filterValueOnMissing) {
   constexpr int kSize = 50;
   auto input = makeRowVector({
       makeFlatVector<int64_t>(kSize, folly::identity),


### PR DESCRIPTION
This PR temporarily disables the incompatible Nimble tests introduced by https://github.com/facebookincubator/velox/pull/17554 to unblock its landing process. A follow-up PR (https://github.com/facebookincubator/nimble/pull/944) will update Nimble to the new Velox version and re-enable these tests after https://github.com/facebookincubator/velox/pull/17554 is merged.
