### PR TITLE
fix: Fix encoded slice review followups

### DIFF
--- a/dwio/nimble/encodings/EncodingSliceFactory.cpp
+++ b/dwio/nimble/encodings/EncodingSliceFactory.cpp
@@ -31,7 +31,6 @@
 #include "dwio/nimble/encodings/common/EncodingLayout.h"
 #include "dwio/nimble/encodings/common/EncodingPrefix.h"
 #include "dwio/nimble/encodings/common/EncodingPrimitives.h"
-#include "dwio/nimble/encodings/common/EncodingType.h"
 #include "dwio/nimble/encodings/common/EncodingTypeDispatch.h"
 #include "dwio/nimble/encodings/selection/EncodingSelectionPolicy.h"
 

--- a/dwio/nimble/encodings/NullableEncoding.h
+++ b/dwio/nimble/encodings/NullableEncoding.h
@@ -412,7 +412,9 @@ std::pair<uint32_t, uint32_t> NullableEncoding<T>::countNonNullsForSlice(
     Buffer& buffer,
     const Encoding::Options& options) {
   const auto rowEnd = offset + length;
-  NIMBLE_CHECK_GT(rowEnd, 0, "Nullable slice requires a non-empty row range.");
+  if (rowEnd == 0) {
+    return {0, 0};
+  }
 
   auto* pool = &buffer.getMemoryPool();
   auto encoding = EncodingFactory{options}.create(

--- a/dwio/nimble/encodings/TrivialEncoding.cpp
+++ b/dwio/nimble/encodings/TrivialEncoding.cpp
@@ -24,6 +24,38 @@ struct UncompressedData {
   velox::BufferPtr buffer;
 };
 
+struct StringPayload {
+  CompressionType compressionType;
+  std::string_view lengths;
+  std::string_view blob;
+};
+
+StringPayload readStringPayload(std::string_view encoded, uint32_t dataOffset) {
+  const char* pos = encoded.data() + dataOffset;
+  const auto compressionType =
+      static_cast<CompressionType>(encoding::readChar(pos));
+  const uint32_t lengthsSize = encoding::readUint32(pos);
+  const std::string_view lengths{pos, lengthsSize};
+  pos += lengthsSize;
+  return {
+      .compressionType = compressionType,
+      .lengths = lengths,
+      .blob = {pos, static_cast<size_t>(encoded.end() - pos)}};
+}
+
+void writeStringHeader(
+    uint32_t rowCount,
+    bool useVarint,
+    CompressionType compressionType,
+    std::string_view serializedLengths,
+    char*& pos) {
+  EncodingPrefix::serialize(
+      EncodingType::Trivial, DataType::String, rowCount, useVarint, pos);
+  encoding::writeChar(static_cast<char>(compressionType), pos);
+  encoding::writeUint32(serializedLengths.size(), pos);
+  encoding::writeBytes(serializedLengths, pos);
+}
+
 UncompressedData uncompressIfNeeded(
     velox::memory::MemoryPool& pool,
     CompressionType compressionType,
@@ -74,26 +106,23 @@ TrivialEncoding<std::string_view>::TrivialEncoding(
     : TypedEncoding<std::string_view, std::string_view>{pool, data, options},
       row_{0},
       buffer_{&pool} {
-  auto pos = data.data() + this->dataOffset();
-  const auto dataCompressionType =
-      static_cast<CompressionType>(encoding::readChar(pos));
-  const auto lengthsSize = encoding::readUint32(pos);
+  const auto payload = readStringPayload(data, this->dataOffset());
   lengths_ = EncodingFactory(options).create(
-      pool, {pos, lengthsSize}, stringBufferFactory);
-  blob_ = pos + lengthsSize;
+      pool, payload.lengths, stringBufferFactory);
+  blob_ = payload.blob.data();
 
-  if (dataCompressionType != CompressionType::Uncompressed) {
+  if (payload.compressionType != CompressionType::Uncompressed) {
     dataUncompressed_ = Compression::uncompress(
         pool,
-        dataCompressionType,
+        payload.compressionType,
         DataType::String,
-        {blob_, static_cast<size_t>(data.end() - blob_)},
+        payload.blob,
         options.decompressCounter(),
         options.bufferPool);
     blob_ = dataUncompressed_->as<char>();
     uncompressedDataBytes_ = dataUncompressed_->size();
   } else {
-    uncompressedDataBytes_ = data.size() - std::distance(data.data(), blob_);
+    uncompressedDataBytes_ = payload.blob.size();
   }
   // TODO(huamengjiang): if we want to reduce the temporary memory peak, we can
   // pass the string buffer factory into the compression api.
@@ -189,12 +218,12 @@ std::string_view TrivialEncoding<std::string_view>::encode(
 
   char* reserved = buffer.reserve(encodingSize);
   char* pos = reserved;
-  Encoding::serializePrefix(
-      EncodingType::Trivial, DataType::String, valueCount, useVarint, pos);
-  encoding::writeChar(
-      static_cast<char>(compressionEncoder.compressionType()), pos);
-  encoding::writeUint32(serializedLengths.size(), pos);
-  encoding::writeBytes(serializedLengths, pos);
+  writeStringHeader(
+      valueCount,
+      useVarint,
+      compressionEncoder.compressionType(),
+      serializedLengths,
+      pos);
   compressionEncoder.write(pos);
 
   NIMBLE_CHECK_EQ(pos - reserved, encodingSize, "Encoding size mismatch.");
@@ -207,32 +236,31 @@ std::string_view TrivialEncoding<std::string_view>::slice(
     uint32_t length,
     Buffer& buffer,
     const Encoding::Options& options) {
+  const auto sourceRowCount =
+      EncodingPrefix::readRowCount(encoded, options.useVarintRowCount);
+  NIMBLE_CHECK_LE(offset, sourceRowCount);
+  NIMBLE_CHECK_LE(length, sourceRowCount - offset);
+
   const auto sourcePrefixSize =
       EncodingPrefix::prefixSize(encoded, options.useVarintRowCount);
-  const char* sourcePos = encoded.data() + sourcePrefixSize;
-  const auto compressionType =
-      static_cast<CompressionType>(encoding::readChar(sourcePos));
-
-  const uint32_t lengthsSize = encoding::readUint32(sourcePos);
-  const std::string_view lengthsData{sourcePos, lengthsSize};
-  sourcePos += lengthsSize;
+  const auto payload = readStringPayload(encoded, sourcePrefixSize);
   const auto blob = uncompressIfNeeded(
       buffer.getMemoryPool(),
-      compressionType,
+      payload.compressionType,
       DataType::String,
-      {sourcePos, static_cast<size_t>(encoded.end() - sourcePos)},
+      payload.blob,
       options);
   const char* blobData = blob.data;
 
   const auto slicedLengths =
-      EncodingFactory::slice(lengthsData, offset, length, buffer, options);
+      EncodingFactory::slice(payload.lengths, offset, length, buffer, options);
   const auto rowEnd = offset + length;
   auto materializedLengths =
       makeScratchVector<uint32_t>(buffer.getMemoryPool(), options, rowEnd);
   materializedLengths.resize(rowEnd);
   auto lengthsEncoding = EncodingFactory{options}.create(
       buffer.getMemoryPool(),
-      lengthsData,
+      payload.lengths,
       [](uint32_t /*totalLength*/) -> void* { return nullptr; });
   lengthsEncoding->materialize(rowEnd, materializedLengths.data());
   const auto sliceBegin = materializedLengths.begin() + offset;
@@ -247,15 +275,12 @@ std::string_view TrivialEncoding<std::string_view>::slice(
       prefixSize + kPrefixSize + slicedLengths.size() + blobBytes;
   char* reserved = buffer.reserve(encodingSize);
   char* pos = reserved;
-  EncodingPrefix::serialize(
-      EncodingType::Trivial,
-      DataType::String,
+  writeStringHeader(
       length,
       options.useVarintRowCount,
+      CompressionType::Uncompressed,
+      slicedLengths,
       pos);
-  encoding::writeChar(static_cast<char>(CompressionType::Uncompressed), pos);
-  encoding::writeUint32(slicedLengths.size(), pos);
-  encoding::writeBytes(slicedLengths, pos);
   encoding::writeBytes({blobData + blobOffset, blobBytes}, pos);
   NIMBLE_CHECK_EQ(pos - reserved, encodingSize, "Encoding size mismatch.");
   releaseScratchVector(materializedLengths, options);
@@ -406,6 +431,11 @@ std::string_view TrivialEncoding<bool>::slice(
     uint32_t length,
     Buffer& buffer,
     const Encoding::Options& options) {
+  const auto sourceRowCount =
+      EncodingPrefix::readRowCount(encoded, options.useVarintRowCount);
+  NIMBLE_CHECK_LE(offset, sourceRowCount);
+  NIMBLE_CHECK_LE(length, sourceRowCount - offset);
+
   const auto sourcePrefixSize =
       EncodingPrefix::prefixSize(encoded, options.useVarintRowCount);
   const char* sourcePos = encoded.data() + sourcePrefixSize;

--- a/dwio/nimble/encodings/TrivialEncoding.h
+++ b/dwio/nimble/encodings/TrivialEncoding.h
@@ -336,6 +336,11 @@ std::string_view TrivialEncoding<T>::slice(
     uint32_t length,
     Buffer& buffer,
     const Encoding::Options& options) {
+  const auto sourceRowCount =
+      EncodingPrefix::readRowCount(encoded, options.useVarintRowCount);
+  NIMBLE_CHECK_LE(offset, sourceRowCount);
+  NIMBLE_CHECK_LE(length, sourceRowCount - offset);
+
   const auto sourcePrefixSize =
       EncodingPrefix::prefixSize(encoded, options.useVarintRowCount);
   const char* sourcePos = encoded.data() + sourcePrefixSize;

--- a/dwio/nimble/encodings/common/EncodingFactory.cpp
+++ b/dwio/nimble/encodings/common/EncodingFactory.cpp
@@ -15,6 +15,8 @@
  */
 #include "dwio/nimble/encodings/common/EncodingFactory.h"
 
+#include <utility>
+
 #include "dwio/nimble/encodings/ALPEncoding.h"
 #include "dwio/nimble/encodings/BlockBitPackingEncoding.h"
 #include "dwio/nimble/encodings/ConstantEncoding.h"
@@ -158,7 +160,8 @@ std::unique_ptr<Encoding> EncodingFactory::create(
     std::string_view data,
     std::function<void*(uint32_t)> stringBufferFactory,
     const Encoding::Options& options) const {
-  return EncodingFactory{options}.create(pool, data, stringBufferFactory);
+  return EncodingFactory{options}.create(
+      pool, data, std::move(stringBufferFactory));
 }
 
 std::string_view EncodingFactory::slice(
@@ -189,6 +192,8 @@ std::string_view EncodingFactory::encode(
       std::move(selection), physicalValues, buffer, options);
 }
 
+// The encoding layout is honored, except for nullable encodings, which are
+// replaced with the appropriate nullable encoding.
 template <typename T>
 std::string_view EncodingFactory::encodeWithCapturedLayout(
     std::string_view encodedLayoutSource,

--- a/dwio/nimble/encodings/tests/SparseBoolEncodingTest.cpp
+++ b/dwio/nimble/encodings/tests/SparseBoolEncodingTest.cpp
@@ -250,7 +250,7 @@ TYPED_TEST(SparseBoolEncodingTest, skipThenMaterialize) {
 TYPED_TEST(SparseBoolEncodingTest, slice) {
   const nimble::Encoding::Options options{
       .useVarintRowCount = TypeParam::useVarint};
-  for (const auto values :
+  for (const auto& values :
        {this->toVector(
             {false,
              false,

--- a/dwio/nimble/encodings/tests/TrivialEncodingTest.cpp
+++ b/dwio/nimble/encodings/tests/TrivialEncodingTest.cpp
@@ -228,3 +228,86 @@ TEST_F(TrivialEncodingTest, sliceRangesForSupportedTypes) {
   expectSliceRanges<std::string_view>(
       makeStringValues(stringStorage, valueCount), nimble::DataType::String);
 }
+
+TEST_F(TrivialEncodingTest, invalidSliceRange) {
+  for (const bool useVarint : {false, true}) {
+    SCOPED_TRACE(testing::Message() << "useVarint=" << useVarint);
+    const nimble::Encoding::Options options{.useVarintRowCount = useVarint};
+
+    const auto uint32Values = makeVector<uint32_t>({10, 20, 30});
+    const auto uint32Encoded =
+        nimble::test::Encoder<nimble::TrivialEncoding<uint32_t>>::encode(
+            *buffer_,
+            uint32Values,
+            nimble::CompressionType::Uncompressed,
+            options);
+    nimble::Buffer uint32SliceBuffer{*pool_};
+    NIMBLE_ASSERT_THROW(
+        nimble::TrivialEncoding<uint32_t>::slice(
+            uint32Encoded,
+            /*offset=*/4,
+            /*length=*/0,
+            uint32SliceBuffer,
+            options),
+        "");
+    NIMBLE_ASSERT_THROW(
+        nimble::TrivialEncoding<uint32_t>::slice(
+            uint32Encoded,
+            /*offset=*/2,
+            /*length=*/2,
+            uint32SliceBuffer,
+            options),
+        "");
+
+    const auto boolValues = makeBoolValues(/*valueCount=*/3);
+    const auto boolEncoded =
+        nimble::test::Encoder<nimble::TrivialEncoding<bool>>::encode(
+            *buffer_,
+            boolValues,
+            nimble::CompressionType::Uncompressed,
+            options);
+    nimble::Buffer boolSliceBuffer{*pool_};
+    NIMBLE_ASSERT_THROW(
+        nimble::TrivialEncoding<bool>::slice(
+            boolEncoded,
+            /*offset=*/4,
+            /*length=*/0,
+            boolSliceBuffer,
+            options),
+        "");
+    NIMBLE_ASSERT_THROW(
+        nimble::TrivialEncoding<bool>::slice(
+            boolEncoded,
+            /*offset=*/2,
+            /*length=*/2,
+            boolSliceBuffer,
+            options),
+        "");
+
+    std::vector<std::string> stringStorage;
+    const auto stringValues = makeStringValues(stringStorage, /*valueCount=*/3);
+    const auto stringEncoded = nimble::test::
+        Encoder<nimble::TrivialEncoding<std::string_view>>::encode(
+            *buffer_,
+            stringValues,
+            nimble::CompressionType::Uncompressed,
+            options);
+    nimble::Buffer stringSliceBuffer{*pool_};
+    NIMBLE_ASSERT_THROW(
+        nimble::TrivialEncoding<std::string_view>::slice(
+            stringEncoded,
+            /*offset=*/4,
+            /*length=*/0,
+            stringSliceBuffer,
+            options),
+        "");
+    NIMBLE_ASSERT_THROW(
+        nimble::TrivialEncoding<std::string_view>::slice(
+            stringEncoded,
+            /*offset=*/2,
+            /*length=*/2,
+            stringSliceBuffer,
+            options),
+        "");
+  }
+}


### PR DESCRIPTION
Summary: Fix review comments from the initial encoded slice support diff.\n\nThis adds source row-count bounds checks to all TrivialEncoding::slice overloads, matching sibling slice implementations. It also allows Nullable empty [0, 0) slices to return zero counts without materializing or throwing.

Reviewed By: duxiao1212

Differential Revision: D113784314


